### PR TITLE
chore: release v0.2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,15 @@
 # Changelog
 
+## v0.2.4 — 2026-04-24
+
+### Fixed
+- gateway IPC socket cleanup race on `systemctl restart`: old gateway's delayed `unlinkSync` could arrive after the new gateway had already bound, deleting the new socket's filesystem entry and leaving an orphaned listener. Cleanup now renames the live socket to a `.bak` sidecar at both startup and shutdown so a late old-gateway cleanup cannot destroy the current generation's file; stale `.bak` is unlinked on the next startup when no one is using it.
+- session-greeting hook no longer re-fires on every SessionStart when the gateway's socket path is unlinked (orphaned socket); idempotency guard now uses `ss` directly rather than a filesystem-existence check. Added structured logging to `session-greeting.log` for future diagnosability.
+
 ## v0.2.3 — 2026-04-24
 
 ### Fixed
 - gateway SIGTERM handler was clobbering stamped restart reasons, so greetings showed "clean shutdown" with no "why". Handler now preserves fresh reasons from any initiator and falls back to "systemctl: external restart" otherwise.
-- gateway IPC socket cleanup race on `systemctl restart`: old gateway's delayed `unlinkSync` could arrive after the new gateway had already bound, deleting the new socket's filesystem entry and leaving an orphaned listener. Cleanup now renames the live socket to a `.bak` sidecar at both startup and shutdown so a late old-gateway cleanup cannot destroy the current generation's file; stale `.bak` is unlinked on the next startup when no one is using it.
-- session-greeting hook no longer re-fires on every SessionStart when the gateway's socket path is unlinked (orphaned socket); idempotency guard now uses `ss` directly rather than a filesystem-existence check. Added structured logging to `session-greeting.log` for future diagnosability.
 
 ## v0.2.2 — 2026-04-24
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "switchroom-ai",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Run Claude Code 24/7 on your Claude Pro/Max subscription over Telegram. Open-source alternative to OpenClaw and NanoClaw — no API keys, no Docker.",
   "type": "module",
   "bin": {

--- a/src/build-info.ts
+++ b/src/build-info.ts
@@ -2,8 +2,8 @@
 // Tracked in git so `tsc --noEmit` works on a fresh clone before `npm run build`.
 // Values are refreshed every time `npm run build` runs.
 
-export const VERSION: string = "0.2.3";
-export const COMMIT_SHA: string | null = "42d331e";
-export const COMMIT_DATE: string | null = "2026-04-24T08:01:14+10:00";
+export const VERSION: string = "0.2.4";
+export const COMMIT_SHA: string | null = "2764866";
+export const COMMIT_DATE: string | null = "2026-04-24T10:37:37+10:00";
 export const LATEST_PR: number | null = 2;
 export const COMMITS_AHEAD_OF_TAG: number | null = 2;


### PR DESCRIPTION
Release v0.2.4 — bug-fix only, no user-visible API change.

Bundles two fork fixes that landed after v0.2.3 was cut to npm:

- **#5** socket-orphan rename-instead-of-unlink on gateway cleanup — prevents delayed `unlinkSync` from old gateway destroying new gateway's bound socket file on `systemctl restart`.
- **#6** greeting-fire scaffold fix — session-greeting hook no longer re-fires on every SessionStart when gateway socket path is unlinked; idempotency guard uses `ss` directly rather than a filesystem-existence check. Adds structured logging for diagnosis.

## Verification
- `bun install && bun run build` OK
- PII scan: 0 `/home/kenthompson` refs in `dist/cli/switchroom.js`; only `/home/hindsight/.pg0` (docker-internal, known acceptable) appears.
- Bundle size: 1.28 MB (unchanged shape from v0.2.3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)