### PR TITLE
feat(card): MCP label polish + deferred-completion visibility + preamble nudge

### DIFF
--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -1898,7 +1898,19 @@ progress card shows that for free. Don't send an update on a trivial one-shot
 task. Send them when a colleague would genuinely want to know what's happening.
 
 Final answers still go through \`stream_reply\` with done=true as usual,
-\`progress_update\` is only for mid-turn check-ins.`;
+\`progress_update\` is only for mid-turn check-ins.
+
+## Think out loud before tool calls
+
+When you're about to call a tool — especially on the second and later
+tool calls in a turn — lead the assistant message with one short
+sentence naming what you're doing: "Reading the config.", "Running the
+migration.", "Searching for X." The progress card pairs that sentence
+with the tool as a natural-language step, so the user can tell what's
+happening without decoding raw tool names. Without a preamble the card
+goes quiet during long tool chains and feels stuck. Keep it to one
+line; don't repeat the preamble before every call in a fast sequence,
+but do refresh it when you switch to a genuinely different step.`;
 
       const memoryGuidance = `## Memory — proactive, conversational
 
@@ -2939,7 +2951,19 @@ progress card shows that for free. Don't send an update on a trivial one-shot
 task. Send them when a colleague would genuinely want to know what's happening.
 
 Final answers still go through \`stream_reply\` with done=true as usual,
-\`progress_update\` is only for mid-turn check-ins.`;
+\`progress_update\` is only for mid-turn check-ins.
+
+## Think out loud before tool calls
+
+When you're about to call a tool — especially on the second and later
+tool calls in a turn — lead the assistant message with one short
+sentence naming what you're doing: "Reading the config.", "Running the
+migration.", "Searching for X." The progress card pairs that sentence
+with the tool as a natural-language step, so the user can tell what's
+happening without decoding raw tool names. Without a preamble the card
+goes quiet during long tool chains and feels stuck. Keep it to one
+line; don't repeat the preamble before every call in a fast sequence,
+but do refresh it when you switch to a genuinely different step.`;
         const memoryGuidance = `## Memory — proactive, conversational
 
 You have Hindsight tools: \`mcp__hindsight__sync_retain\`, \`mcp__hindsight__delete_memory\`, \`mcp__hindsight__recall\`, \`mcp__hindsight__reflect\`. Use them without being asked.

--- a/telegram-plugin/progress-card-driver.ts
+++ b/telegram-plugin/progress-card-driver.ts
@@ -466,7 +466,14 @@ export function createProgressDriver(config: ProgressDriverConfig): ProgressDriv
       // the cleanup.
       const zombies: PerChatState[] = []
       for (const [, cs] of chats) {
-        if (cs.state.stage === 'done') continue
+        // Skip only when TRULY done. During the deferred-completion
+        // window (parent turn_end fired but background sub-agents are
+        // still running), reducer stage is 'done' but the card is
+        // still alive and `hasInFlightSubAgents` is true. We want the
+        // heartbeat to keep ticking so elapsed time + sub-agent
+        // durations visibly advance — a frozen "✅ Done" card was the
+        // "card went dead" bug.
+        if (cs.state.stage === 'done' && !hasInFlightSubAgents(cs.state)) continue
         // Don't heartbeat a card that's still in the initial delay window.
         if (cs.isFirstEmit && cs.deferredFirstEmitTimer !== DELAY_ELAPSED) continue
         if (maxIdleMs > 0 && now() - cs.lastEventAt > maxIdleMs) {

--- a/telegram-plugin/progress-card.ts
+++ b/telegram-plugin/progress-card.ts
@@ -698,6 +698,15 @@ function extractUserText(raw: string): string {
  * currently in flight.
  */
 function renderItemCore(tool: string, label: string, bold = false): string {
+  // MCP tools: the label from toolLabel() already begins with a
+  // prettified "Server: action" form (from mcpBaseLabel), so echoing
+  // the raw `mcp__server__action` tool name as a prefix just duplicates
+  // the friendly name. Render the label alone. If label is empty
+  // (malformed mcp__ name, no input keys to preview), fall through so
+  // the raw tool name still appears rather than rendering nothing.
+  if (tool.startsWith('mcp__') && label) {
+    return bold ? `<b>${escapeHtml(label)}</b>` : escapeHtml(label)
+  }
   const toolHtml = bold ? `<b>${escapeHtml(tool)}</b>` : escapeHtml(tool)
   if (!label) return toolHtml
   const separator = tool === 'Agent' || tool === 'Task' ? ': ' : ' '
@@ -781,8 +790,15 @@ export function render(state: ProgressCardState, now: number, taskNum?: TaskNum,
   const lines: string[] = []
 
   const elapsed = formatDuration(now - state.turnStartedAt)
-  const headerIcon = state.stage === 'done' ? '✅' : '⚙️'
-  const headerLabel = state.stage === 'done' ? 'Done' : 'Working…'
+  // "Truly done" = parent turn_end fired AND no sub-agents still in
+  // flight. While the driver's `pendingCompletion` state is active
+  // (background Agent calls outliving parent turn_end), the reducer
+  // has already flipped `state.stage` to 'done' but the work isn't
+  // actually finished. Show "Working…" + ticking elapsed in that
+  // window so users aren't looking at a frozen ✅ card.
+  const trulyDone = state.stage === 'done' && !hasInFlightSubAgents(state)
+  const headerIcon = trulyDone ? '✅' : '⚙️'
+  const headerLabel = trulyDone ? 'Done' : 'Working…'
   const taskSuffix = taskNum && taskNum.total > 1 ? ` (${taskNum.index}/${taskNum.total})` : ''
   lines.push(`${headerIcon} <b>${headerLabel}${taskSuffix}</b> · ⏱ ${elapsed}`)
 
@@ -793,10 +809,11 @@ export function render(state: ProgressCardState, now: number, taskNum?: TaskNum,
   // Stuck-warning: after 2 min of no session events the card is likely
   // orphaned or the sub-agent is in a long-running silent tool call.
   // Surface the gap early so users aren't left guessing until the 5-min
-  // zombie ceiling force-closes. Suppressed on 'done' because the warning
-  // becomes misleading once the turn has ended.
+  // zombie ceiling force-closes. Suppressed only on TRUE done — during
+  // the deferred-completion window (parent done, sub-agents still
+  // running silently) the warning is still the correct signal.
   if (
-    state.stage !== 'done' &&
+    !trulyDone &&
     opts?.stuckMs != null &&
     opts.stuckMs >= STUCK_THRESHOLD_MS
   ) {
@@ -833,7 +850,13 @@ export function render(state: ProgressCardState, now: number, taskNum?: TaskNum,
     const counts = countSubAgentStates(state.subAgents)
     lines.push(`[Sub-agents · ${formatSubAgentCounts(counts)}]`)
     for (const sa of sortSubAgentsChrono(state.subAgents)) {
-      for (const l of renderSubAgent(sa, now, state.stage === 'done')) {
+      // forceCollapse only when TRULY done — during deferred-completion
+      // (parent ended but sub-agents still running), keep running
+      // sub-agents in the two-line running block so their ticking
+      // elapsed-time stays visible. When trulyDone is reached the
+      // reducer has already marked every sub-agent as done/failed, so
+      // this arg is effectively moot in that branch.
+      for (const l of renderSubAgent(sa, now, trulyDone)) {
         lines.push(l)
       }
     }
@@ -864,8 +887,20 @@ function renderNarrativeChecklist(
   const visible = narratives.slice(-MAX_VISIBLE_ITEMS)
   for (const step of visible) {
     if (step.state === 'active') {
-      const dur = formatDuration(now - step.startedAt)
-      lines.push(`${STEP_ACTIVE} <b>${escapeHtml(step.text)}</b> <i>(${dur})</i>`)
+      const age = now - step.startedAt
+      const dur = formatDuration(age)
+      // When an active narrative is older than the stuck threshold, the
+      // "No events for X" banner will already be rendered above. A
+      // confidently-bolded narrative with a ticking age next to it sends
+      // mixed signals ("stuck" vs "actively working on X"). De-emphasise
+      // the narrative to italic with a `stale` marker so the signals
+      // agree: the last announced step, not necessarily what's running
+      // right now.
+      if (age > STUCK_THRESHOLD_MS) {
+        lines.push(`${STEP_ACTIVE} <i>${escapeHtml(step.text)} · stale (${dur})</i>`)
+      } else {
+        lines.push(`${STEP_ACTIVE} <b>${escapeHtml(step.text)}</b> <i>(${dur})</i>`)
+      }
     } else {
       lines.push(`${STEP_DONE} ${escapeHtml(step.text)}`)
     }

--- a/telegram-plugin/tests/progress-card-stuck-warning.test.ts
+++ b/telegram-plugin/tests/progress-card-stuck-warning.test.ts
@@ -65,6 +65,44 @@ describe("render — stuck-warning", () => {
     const html = render(s, START + STUCK_THRESHOLD_MS + 10_000);
     expect(html).not.toContain("No events for");
   });
+
+  it("demotes active narrative to italic+stale when age > threshold", () => {
+    // When the stuck banner appears, a still-bolded narrative with a
+    // confidently ticking age sends mixed signals. The narrative should
+    // render in italics with a "· stale" marker so the two signals agree.
+    let s = reduce(initialState(), enqueue(), START);
+    s = reduce(s, { kind: "text", text: "Reading config" }, START + 100);
+    const html = render(s, START + STUCK_THRESHOLD_MS + 30_000, undefined, {
+      stuckMs: STUCK_THRESHOLD_MS + 30_000,
+    });
+    expect(html).toContain("stale");
+    expect(html).not.toContain("<b>Reading config</b>");
+  });
+
+  it("keeps active narrative bold while fresh (below threshold)", () => {
+    let s = reduce(initialState(), enqueue(), START);
+    s = reduce(s, { kind: "text", text: "Reading config" }, START + 100);
+    const html = render(s, START + 30_000, undefined, {
+      stuckMs: 30_000,
+    });
+    expect(html).toContain("<b>Reading config</b>");
+    expect(html).not.toContain("stale");
+  });
+
+  it("narrative at exact STUCK_THRESHOLD_MS stays bold (deliberate `>` asymmetry)", () => {
+    // Banner condition is `>=`; narrative demotion uses `>`. At the
+    // exact-equality tick the banner appears but the narrative is still
+    // bold. In production stuckMs ticks in ~5s increments so the window
+    // never reaches exact-equality — pin this as intentional so a
+    // future refactor doesn't accidentally change both to `>=`.
+    let s = reduce(initialState(), enqueue(), START);
+    s = reduce(s, { kind: "text", text: "Reading config" }, START);
+    const html = render(s, START + STUCK_THRESHOLD_MS, undefined, {
+      stuckMs: STUCK_THRESHOLD_MS,
+    });
+    expect(html).toContain("<b>Reading config</b>");
+    expect(html).toContain("No events for");
+  });
 });
 
 describe("progress-card driver — stuck warning propagation via heartbeat", () => {
@@ -163,6 +201,53 @@ describe("progress-card driver — stuck warning propagation via heartbeat", () 
     const post = emits.slice(beforeReset);
     const postHasWarning = post.some((e) => e.html.includes("No events for"));
     expect(postHasWarning).toBe(false);
+  });
+
+  it("heartbeat keeps ticking while sub-agent outlives parent turn_end", () => {
+    // Regression: pre-fix, the heartbeat skipped any card with
+    // `state.stage === 'done'` — which the reducer sets the moment
+    // turn_end fires, even when sub-agents are still running. Result:
+    // user saw a frozen "✅ Done" card with stopped elapsed time while
+    // a background Agent sub-agent ground away. Post-fix the heartbeat
+    // only skips when BOTH stage='done' AND !hasInFlightSubAgents.
+    const { driver, emits, advance } = harness({ heartbeatMs: 5_000 });
+    driver.ingest(enqueue("c1"), null);
+    // Start a background Agent sub-agent.
+    driver.ingest(
+      {
+        kind: "tool_use",
+        toolName: "Agent",
+        toolUseId: "toolu_agent",
+        input: { description: "run review", subagent_type: "reviewer" },
+      },
+      "c1",
+    );
+    driver.ingest(
+      {
+        kind: "sub_agent_started",
+        agentId: "agent-bg",
+        firstPromptText: "run review",
+        subagentType: "reviewer",
+      },
+      "c1",
+    );
+    // Parent turn ends while sub-agent still running.
+    driver.ingest({ kind: "turn_end", durationMs: 500 }, "c1");
+    const emitsAtTurnEnd = emits.length;
+    // Tick a few heartbeats forward. Since hasInFlightSubAgents is true,
+    // the heartbeat should keep re-rendering and emitting as the
+    // elapsed-time bucket advances.
+    advance(20_000);
+    const postHeartbeatEmits = emits.length;
+    expect(postHeartbeatEmits).toBeGreaterThan(emitsAtTurnEnd);
+    // None of those heartbeat emits should carry done=true — the card
+    // is still waiting on the sub-agent.
+    const heartbeatEmits = emits.slice(emitsAtTurnEnd);
+    expect(heartbeatEmits.every((e) => e.done === false)).toBe(true);
+    // And the header should still say "Working…" (⚙️), not "✅ Done".
+    const lastHeartbeat = heartbeatEmits[heartbeatEmits.length - 1];
+    expect(lastHeartbeat.html).toContain("⚙️");
+    expect(lastHeartbeat.html).not.toContain("✅");
   });
 
   it("zombie ceiling force-closes a card whose lastEventAt is older than maxIdleMs", () => {

--- a/telegram-plugin/tests/progress-card.test.ts
+++ b/telegram-plugin/tests/progress-card.test.ts
@@ -545,6 +545,108 @@ describe('progress-card render', () => {
     const out = render(st, 1500)
     expect(out).toContain('◉ <i>Thinking…</i>')
   })
+
+  it('suppresses raw mcp__ tool name prefix when label is present', () => {
+    // The checklist used to render:
+    //   "mcp__switchroom-telegram__stream_reply Telegram: stream_reply (…)"
+    // after the MCP polish it should render the friendly label alone.
+    let st = reduce(initialState(), enqueue('polish test'), 1000)
+    st = reduce(
+      st,
+      {
+        kind: 'tool_use',
+        toolName: 'mcp__switchroom-telegram__stream_reply',
+        toolUseId: 'toolu_x',
+        input: { text: 'Hello world' },
+      },
+      1100,
+    )
+    const out = render(st, 1500)
+    expect(out).not.toContain('mcp__switchroom-telegram__stream_reply')
+    expect(out).toContain('Telegram: stream_reply')
+  })
+
+  it('strips HTML tags from MCP preview so <b> does not leak as literal text', () => {
+    let st = reduce(initialState(), enqueue('html leak test'), 1000)
+    st = reduce(
+      st,
+      {
+        kind: 'tool_use',
+        toolName: 'mcp__switchroom-telegram__stream_reply',
+        toolUseId: 'toolu_y',
+        input: { text: '<b>Recommendation, priority-ordered:</b> 1a' },
+      },
+      1100,
+    )
+    const out = render(st, 1500)
+    // escapeHtml would turn a surviving '<b>' into '&lt;b&gt;' in the
+    // final string. Assert neither form appears.
+    expect(out).not.toContain('<b>Recommendation')
+    expect(out).not.toContain('&lt;b&gt;Recommendation')
+    expect(out).toContain('Recommendation')
+  })
+
+  // ─── Deferred-completion header: "Working…" while sub-agents outlive turn_end ───
+  //
+  // Root cause covered by these tests: after parent turn_end the reducer
+  // sets stage='done' unconditionally, but background Agent sub-agents
+  // can still be running. Pre-fix the header rendered "✅ Done" and the
+  // heartbeat stopped re-rendering — users saw a frozen ✅ card while
+  // the sub-agent ground away. Post-fix "truly done" means
+  // stage==='done' AND no in-flight sub-agents.
+
+  it('shows "Working…" header while sub-agent outlives parent turn_end', () => {
+    let st = reduce(initialState(), enqueue('deferred test'), 1000)
+    st = reduce(st, {
+      kind: 'tool_use',
+      toolName: 'Agent',
+      toolUseId: 'toolu_a',
+      input: { description: 'run review', subagent_type: 'reviewer' },
+    }, 1100)
+    st = reduce(st, {
+      kind: 'sub_agent_started',
+      agentId: 'agent-x',
+      firstPromptText: 'run review',
+      subagentType: 'reviewer',
+    }, 1200)
+    st = reduce(st, { kind: 'turn_end', durationMs: 500 }, 1500)
+
+    // Sanity: reducer still flips stage='done' internally, but the
+    // sub-agent is still running — so the header should reflect
+    // "still working" to the user.
+    expect(st.stage).toBe('done')
+    const out = render(st, 2000)
+    expect(out).toContain('⚙️')
+    expect(out).toContain('Working')
+    expect(out).not.toContain('✅')
+  })
+
+  it('flips header to "✅ Done" once last sub-agent finishes', () => {
+    let st = reduce(initialState(), enqueue('deferred completion'), 1000)
+    st = reduce(st, {
+      kind: 'tool_use',
+      toolName: 'Agent',
+      toolUseId: 'toolu_b',
+      input: { description: 'run review', subagent_type: 'reviewer' },
+    }, 1100)
+    st = reduce(st, {
+      kind: 'sub_agent_started',
+      agentId: 'agent-y',
+      firstPromptText: 'run review',
+      subagentType: 'reviewer',
+    }, 1200)
+    st = reduce(st, { kind: 'turn_end', durationMs: 500 }, 1500)
+    // Sub-agent finishes after parent turn_end.
+    st = reduce(st, {
+      kind: 'sub_agent_turn_end',
+      agentId: 'agent-y',
+      durationMs: 2000,
+    }, 3500)
+
+    const out = render(st, 3600)
+    expect(out).toContain('✅')
+    expect(out).toContain('Done')
+  })
 })
 
 // ─── Multi-agent correlation reducer tests ───────────────────────────────

--- a/telegram-plugin/tests/tool-labels.test.ts
+++ b/telegram-plugin/tests/tool-labels.test.ts
@@ -254,6 +254,34 @@ describe('toolLabel', () => {
       // Only one `__` segment after prefix — no action half.
       expect(toolLabel('mcp__broken', { query: 'foo' })).toBe('foo')
     })
+
+    it('strips HTML tags from preview text', () => {
+      // stream_reply accepts Telegram-HTML text; raw tags in the preview
+      // would survive escapeHtml() in the renderer and render as literal
+      // `<b>` on screen. The label must come back as plain prose.
+      const out = toolLabel('mcp__switchroom-telegram__stream_reply', {
+        text: '<b>Recommendation, priority-ordered:</b> 1a — scaffold',
+      })
+      expect(out).not.toContain('<b>')
+      expect(out).not.toContain('</b>')
+      expect(out).toContain('Recommendation')
+    })
+
+    it('strips HTML from description fallback', () => {
+      const out = toolLabel('mcp__hindsight__retain', {
+        description: 'Remember <i>Ken</i> prefers TypeScript',
+      })
+      expect(out).toBe('Remember Ken prefers TypeScript')
+    })
+
+    it('preserves comparison operators in non-HTML queries', () => {
+      // stripHtml's regex requires a letter/slash after `<` so plain-text
+      // comparisons like "x < 5 and y > 3" don't get their middle eaten.
+      const out = toolLabel('mcp__hindsight__recall', {
+        query: 'x < 5 and y > 3',
+      })
+      expect(out).toBe('Hindsight: recall (x < 5 and y > 3)')
+    })
   })
 
   describe('regression: existing cases still pass with new defaults', () => {

--- a/telegram-plugin/tool-labels.ts
+++ b/telegram-plugin/tool-labels.ts
@@ -79,6 +79,22 @@ function truncate(s: string, n = MAX_LABEL_CHARS): string {
   return s.slice(0, n - 1) + '…'
 }
 
+/**
+ * Strip HTML tags from a preview string. MCP tools like `stream_reply`
+ * accept Telegram-HTML text as input; when we use that text as a label
+ * preview, the raw `<b>`/`<i>`/etc. markers would pass through
+ * `escapeHtml` in the renderer and show up as visible `<b>` on screen.
+ * Dropping tags here keeps the preview human-readable.
+ *
+ * Requires an ASCII letter (or `/`) immediately after `<` so comparison
+ * operators in plain-text queries (`"find x < 5 and y > 3"`) survive
+ * unmolested. A naive `/<[^>]+>/g` would otherwise eat everything
+ * between the two brackets.
+ */
+function stripHtml(s: string): string {
+  return s.replace(/<\/?[a-zA-Z][^>]*>/g, '')
+}
+
 function firstLine(s: string): string {
   const idx = s.indexOf('\n')
   return idx === -1 ? s : s.slice(0, idx)
@@ -208,14 +224,14 @@ export function toolLabel(
       // key-sweep fallback, which would otherwise echo raw query strings.
       if (tool.startsWith('mcp__')) {
         const description = str('description')
-        if (description) return truncate(firstLine(description), MAX_DESCRIPTION_CHARS)
+        if (description) return truncate(firstLine(stripHtml(description)), MAX_DESCRIPTION_CHARS)
         const label = mcpBaseLabel(tool)
         const query = str('query') ?? str('text') ?? str('name')
         if (label && query) {
           // Reserve room for the " (…)" wrapping so the total label stays
           // under MAX_LABEL_CHARS. 4 chars of framing: " (" + "…" + ")".
           const budget = Math.max(8, MAX_LABEL_CHARS - label.length - 4)
-          const preview = truncate(firstLine(query), budget)
+          const preview = truncate(firstLine(stripHtml(query)), budget)
           return `${label} (${preview})`
         }
         if (label) return truncate(label)


### PR DESCRIPTION
## Summary

Five related progress-card improvements:

1. **MCP label polish** — suppress the raw `mcp__server__action` prefix on the checklist when the tool already has a friendly `Server: action` label (e.g. `Telegram: stream_reply (preview)` instead of `mcp__switchroom-telegram__stream_reply Telegram: stream_reply (preview)`). Also strip HTML tags from MCP input previews so Telegram-HTML text (like `stream_reply`'s `<b>…</b>` body) doesn't survive `escapeHtml()` and render as literal `<b>` on screen. The strip regex requires a letter/slash after `<` so comparison operators like `"x < 5 and y > 3"` in plain queries aren't eaten.

2. **Stale-narrative guard** — when an active narrative's age crosses `STUCK_THRESHOLD_MS`, demote from bold to italic with a `· stale (age)` marker so it doesn't contradict the "No events for X" stuck banner with a confidently ticking age.

3. **Deferred-completion visibility** — fixes the "card went dead" bug where a background `Agent` sub-agent outliving its parent `turn_end` left the card frozen at `✅ Done` with stopped elapsed time. The deferral machinery (`pendingCompletion` / `hasInFlightSubAgents` / flush terminal gate) was already wired up, but three render sites still treated `stage === 'done'` as fully done. Introduces a `trulyDone` check (`stage==='done' && !hasInFlightSubAgents`) at:
   - Renderer header icon/label — shows ⚙️ Working… during the deferred window, flips to ✅ only when the last sub-agent finishes
   - Stuck-banner gate — still surfaces "No events for X" during silent sub-agent waits
   - Heartbeat skip — keeps re-rendering while sub-agents in flight so elapsed time and sub-agent durations actually tick
   - `renderSubAgent` forceCollapse — running sub-agents stay in the two-line running block instead of collapsing at parent turn_end

4. **Preamble nudge** (scaffold) — adds a "Think out loud before tool calls" section to the telegram-plugin guidance in both `buildScaffoldContext` and the reconcile path. Agents are nudged to emit one short `text` block before tool calls so the card always has narrative to show during long tool chains. Takes effect on next agent session start.

5. **Worker subagent isolation** (local config) — not part of this PR, but paired in the same work session: removed `isolation: worktree` default from the worker subagent in my local `~/.switchroom/switchroom.yaml`. Dispatching a sub-agent from an agent whose cwd isn't a git repo was failing with `Cannot create agent worktree`. Upstream scaffold examples don't include this default anyway.

## Test plan
- [x] `bun test tests/tool-labels.test.ts tests/progress-card.test.ts tests/progress-card-stuck-warning.test.ts tests/progress-card-golden.test.ts tests/progress-card-harness.test.ts` — 152/152 pass
- [x] New coverage: MCP prefix suppression, HTML-strip regression, comparison-operator preservation, stale-narrative demotion, exact-equality asymmetry pin, "Working…" header during deferred completion, flip to "✅ Done" after last sub-agent, heartbeat keeps ticking while sub-agent outlives turn_end
- [x] Manually verified live on my local gateway: card correctly shows ⚙️ Working… with ticking timer when a background Agent is dispatched and `stream_reply(done=true)` is called
- [ ] (Reviewer) Eyeball the diff for any golden/harness snapshot drift — ran locally and none surfaced
- [ ] Intended as minor release 0.2.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)