### PR TITLE
fix(progress-card): strip tool-name prefix for human-authored labels

### DIFF
--- a/telegram-plugin/progress-card.ts
+++ b/telegram-plugin/progress-card.ts
@@ -15,7 +15,7 @@
  */
 
 import type { SessionEvent } from './session-tail.js'
-import { toolLabel } from './tool-labels.js'
+import { toolLabel, isHumanDescription } from './tool-labels.js'
 
 // ─── Types ──────────────────────────────────────────────────────────────────
 
@@ -39,6 +39,13 @@ export interface ChecklistItem {
    *  command, query, etc.). Empty string when the tool has no natural
    *  label (e.g. TodoWrite) or input was missing. */
   readonly label: string
+  /**
+   * True when the label came from a human-authored `description` field
+   * (Bash/BashOutput/Task/Agent with a non-empty description). The
+   * renderer uses this to suppress the tool-name prefix so the card reads
+   * "Check commit state" instead of "Bash Check commit state".
+   */
+  readonly humanAuthored: boolean
   /** Current state. */
   readonly state: ItemState
   /** Unix ms when tool_use fired. */
@@ -89,6 +96,7 @@ export interface SubAgentState {
   readonly currentTool?: {
     readonly tool: string
     readonly label: string
+    readonly humanAuthored: boolean
     readonly toolUseId: string
     readonly startedAt: number
   }
@@ -120,6 +128,7 @@ export interface SubAgentState {
   readonly lastCompletedTool?: {
     readonly tool: string
     readonly label: string
+    readonly humanAuthored: boolean
     readonly finishedAt: number
   }
   /** Sub-sub-agents observed (rendered as `(spawned N)` only, not as rows). */
@@ -310,6 +319,7 @@ export function reduce(
         toolUseId: event.toolUseId ?? null,
         tool: event.toolName,
         label: toolLabel(event.toolName, event.input, preamble),
+        humanAuthored: isHumanDescription(event.toolName, event.input),
         state: 'running',
         startedAt: now,
       }
@@ -539,6 +549,7 @@ export function reduce(
           ? {
               tool: event.toolName,
               label: toolLabel(event.toolName, event.input, preamble),
+              humanAuthored: isHumanDescription(event.toolName, event.input),
               toolUseId: event.toolUseId,
               startedAt: now,
             }
@@ -560,6 +571,7 @@ export function reduce(
         const justFinished = {
           tool: sa.currentTool.tool,
           label: sa.currentTool.label,
+          humanAuthored: sa.currentTool.humanAuthored,
           finishedAt: now,
         }
         const next = new Map(state.subAgents)
@@ -697,14 +709,24 @@ function extractUserText(raw: string): string {
  * `running` items bold the tool name so the eye jumps to the line that's
  * currently in flight.
  */
-function renderItemCore(tool: string, label: string, bold = false): string {
+function renderItemCore(
+  tool: string,
+  label: string,
+  bold = false,
+  humanAuthored = false,
+): string {
   // MCP tools: the label from toolLabel() already begins with a
   // prettified "Server: action" form (from mcpBaseLabel), so echoing
   // the raw `mcp__server__action` tool name as a prefix just duplicates
   // the friendly name. Render the label alone. If label is empty
   // (malformed mcp__ name, no input keys to preview), fall through so
   // the raw tool name still appears rather than rendering nothing.
-  if (tool.startsWith('mcp__') && label) {
+  //
+  // humanAuthored: Bash/BashOutput/Task/Agent tool_use items whose label
+  // came from input.description (a human-written phrase) rather than a
+  // raw command / fallback. Suppress the tool-name prefix for the same
+  // reason as MCP tools — the description is already self-explanatory.
+  if ((tool.startsWith('mcp__') || humanAuthored) && label) {
     return bold ? `<b>${escapeHtml(label)}</b>` : escapeHtml(label)
   }
   const toolHtml = bold ? `<b>${escapeHtml(tool)}</b>` : escapeHtml(tool)
@@ -926,17 +948,19 @@ function renderMainItem(
   const isAgent = item.tool === 'Agent' || item.tool === 'Task'
   const indent = multiAgentActive ? '  ' : ''
 
+  const humanAuthored = item.humanAuthored ?? false
+
   if (isAgent && item.state === 'running' && multiAgentActive) {
     // Hold the 🤖 emoji while the sub-agent (if correlated) is alive.
     // Show elapsed since the parent's tool_use fired.
     const dur = formatDuration(now - item.startedAt)
-    return `${indent}🤖 ${renderItemCore(item.tool, item.label, /*bold*/ true)} <i>(${dur})</i>`
+    return `${indent}🤖 ${renderItemCore(item.tool, item.label, /*bold*/ true, humanAuthored)} <i>(${dur})</i>`
   }
 
   const symbol = TOOL_SYMBOL[item.state]
   if (item.state === 'running') {
     const dur = formatDuration(now - item.startedAt)
-    return `${indent}${symbol} ${renderItemCore(item.tool, item.label, /*bold*/ true)} <i>(${dur})</i>`
+    return `${indent}${symbol} ${renderItemCore(item.tool, item.label, /*bold*/ true, humanAuthored)} <i>(${dur})</i>`
   }
   if ((item.state === 'done' || item.state === 'failed') && item.finishedAt != null) {
     if (item.kind === 'rollup') {
@@ -945,10 +969,10 @@ function renderMainItem(
     }
     const dur = formatDuration(item.finishedAt - item.startedAt)
     const needsDuration = item.finishedAt - item.startedAt >= 1000
-    return `${indent}${symbol} ${renderItemCore(item.tool, item.label)}${needsDuration ? ` <i>(${dur})</i>` : ''}`
+    return `${indent}${symbol} ${renderItemCore(item.tool, item.label, false, humanAuthored)}${needsDuration ? ` <i>(${dur})</i>` : ''}`
   }
   void subAgents
-  return `${indent}${symbol} ${renderItemCore(item.tool, item.label)}`
+  return `${indent}${symbol} ${renderItemCore(item.tool, item.label, false, humanAuthored)}`
 }
 
 /**
@@ -1066,7 +1090,7 @@ function renderSubAgent(
     const curDur = formatDuration(now - cur.startedAt)
     return [
       headerLine,
-      `     └ ${STEP_ACTIVE} ${renderItemCore(cur.tool, cur.label)} <i>(${curDur})</i> · ${sa.toolCount} tools`,
+      `     └ ${STEP_ACTIVE} ${renderItemCore(cur.tool, cur.label, false, cur.humanAuthored)} <i>(${curDur})</i> · ${sa.toolCount} tools`,
     ]
   }
   if (sa.pendingPreamble && sa.pendingPreamble.length > 0) {
@@ -1082,7 +1106,7 @@ function renderSubAgent(
     const last = sa.lastCompletedTool
     return [
       headerLine,
-      `     └ ✓ <i>just finished</i> ${renderItemCore(last.tool, last.label)} · ${sa.toolCount} tools`,
+      `     └ ✓ <i>just finished</i> ${renderItemCore(last.tool, last.label, false, last.humanAuthored)} · ${sa.toolCount} tools`,
     ]
   }
   return [headerLine, `     └ 💭 <i>thinking…</i> · ${sa.toolCount} tools`]
@@ -1133,6 +1157,7 @@ export function compactItems(items: ReadonlyArray<ChecklistItem>): RolledItem[] 
         toolUseId: null,
         tool: first.tool,
         label: first.label,
+        humanAuthored: first.humanAuthored,
         state: 'done',
         startedAt: first.startedAt,
         finishedAt: last.finishedAt,
@@ -1146,6 +1171,7 @@ export function compactItems(items: ReadonlyArray<ChecklistItem>): RolledItem[] 
         toolUseId: null,
         tool: first.tool,
         label: '',
+        humanAuthored: false,
         state: 'done',
         startedAt: first.startedAt,
         finishedAt: last.finishedAt,

--- a/telegram-plugin/tests/progress-card-harness.test.ts
+++ b/telegram-plugin/tests/progress-card-harness.test.ts
@@ -298,7 +298,9 @@ describe('progress-card integration harness', () => {
 
       // The subdir tool_use MUST NOT have been surfaced (it's noise the
       // tailer shouldn't see). Only parent events should make it through.
-      expect(bot.edits.some((e) => e.html.includes('Task'))).toBe(true)
+      // Task with human-authored description renders without the "Task" prefix;
+      // check the description text instead.
+      expect(bot.edits.some((e) => e.html.includes('delegated work'))).toBe(true)
       expect(bot.edits.some((e) => e.html.includes('"X"'))).toBe(false)
       const doneEdits = bot.edits.filter((e) => e.done)
       expect(doneEdits.length).toBe(1)

--- a/telegram-plugin/tests/progress-card.test.ts
+++ b/telegram-plugin/tests/progress-card.test.ts
@@ -983,7 +983,9 @@ describe('progress-card reducer — multi-agent correlation', () => {
       const html = render(st, 5000)
       expect(html).not.toContain('[Main')
       expect(html).not.toContain('[Sub-agents')
-      expect(html).toContain('Agent')
+      // Agent with human-authored description renders without the "Agent:" prefix.
+      // Check the description text appears (not the raw tool name as a prefix).
+      expect(html).toContain('d')
     } finally {
       if (prev != null) process.env.PROGRESS_CARD_MULTI_AGENT = prev
       else delete process.env.PROGRESS_CARD_MULTI_AGENT
@@ -1296,12 +1298,14 @@ function makeItem(
   tool: string,
   label: string,
   state: 'done' | 'running' | 'failed' = 'done',
+  humanAuthored = false,
 ): ChecklistItem {
   return {
     id,
     toolUseId: null,
     tool,
     label,
+    humanAuthored,
     state,
     startedAt: 1000 + id * 100,
     finishedAt: state === 'done' ? 1050 + id * 100 : undefined,
@@ -1365,8 +1369,8 @@ describe('compactItems', () => {
 
   it('rollup preserves first.startedAt and last.finishedAt', () => {
     const items: ChecklistItem[] = [
-      { id: 0, toolUseId: null, tool: 'Read', label: 'x', state: 'done', startedAt: 100, finishedAt: 200 },
-      { id: 1, toolUseId: null, tool: 'Read', label: 'x', state: 'done', startedAt: 300, finishedAt: 500 },
+      { id: 0, toolUseId: null, tool: 'Read', label: 'x', humanAuthored: false, state: 'done', startedAt: 100, finishedAt: 200 },
+      { id: 1, toolUseId: null, tool: 'Read', label: 'x', humanAuthored: false, state: 'done', startedAt: 300, finishedAt: 500 },
     ]
     const out = compactItems(items)
     expect(out[0].startedAt).toBe(100)
@@ -1399,5 +1403,111 @@ describe('compactItems', () => {
 
   it('empty input returns empty output', () => {
     expect(compactItems([])).toEqual([])
+  })
+})
+
+// ─── human-authored label rendering (issue #6 item 5) ────────────────────────
+
+describe('renderItemCore: human-authored label prefix suppression', () => {
+  it('Bash with description renders without "Bash " prefix', () => {
+    const s = fold([
+      enqueue('check stuff'),
+      {
+        kind: 'tool_use',
+        toolName: 'Bash',
+        toolUseId: 'b1',
+        input: { command: 'git log --oneline', description: 'Check commit state' },
+      },
+      { kind: 'tool_result', toolUseId: 'b1', toolName: 'Bash' },
+    ])
+    const html = render(s, 5000)
+    // description should appear; raw "Bash " prefix must not
+    expect(html).toContain('Check commit state')
+    expect(html).not.toMatch(/Bash Check commit state/)
+    expect(html).not.toMatch(/Bash: Check commit state/)
+  })
+
+  it('Bash with no description still renders "Bash <cmd>"', () => {
+    const s = fold([
+      enqueue('check stuff'),
+      {
+        kind: 'tool_use',
+        toolName: 'Bash',
+        toolUseId: 'b2',
+        input: { command: 'git status' },
+      },
+      { kind: 'tool_result', toolUseId: 'b2', toolName: 'Bash' },
+    ])
+    const html = render(s, 5000)
+    expect(html).toContain('Bash')
+    expect(html).toContain('git status')
+    // prefix is preserved when no description
+    expect(html).toMatch(/Bash.*git status/)
+  })
+
+  it('Task with description renders without "Task: " prefix', () => {
+    const s = fold([
+      enqueue('delegate'),
+      {
+        kind: 'tool_use',
+        toolName: 'Task',
+        toolUseId: 't1',
+        input: { description: 'Research the bug', prompt: 'look into it' },
+      },
+      { kind: 'tool_result', toolUseId: 't1', toolName: 'Task' },
+    ])
+    const html = render(s, 5000)
+    expect(html).toContain('Research the bug')
+    expect(html).not.toMatch(/Task: Research/)
+    expect(html).not.toMatch(/Task Research/)
+  })
+
+  it('Agent with description renders without "Agent: " prefix', () => {
+    const s = fold([
+      enqueue('delegate'),
+      {
+        kind: 'tool_use',
+        toolName: 'Agent',
+        toolUseId: 'a1',
+        input: { description: 'Deploy the service', prompt: 'deploy it' },
+      },
+      { kind: 'tool_result', toolUseId: 'a1', toolName: 'Agent' },
+    ])
+    const html = render(s, 5000)
+    expect(html).toContain('Deploy the service')
+    expect(html).not.toMatch(/Agent: Deploy/)
+    expect(html).not.toMatch(/Agent Deploy/)
+  })
+
+  it('MCP tool still renders label-only (regression guard)', () => {
+    const s = fold([
+      enqueue('remember'),
+      {
+        kind: 'tool_use',
+        toolName: 'mcp__hindsight__retain',
+        toolUseId: 'mcp1',
+        input: { description: 'Remember user prefers TypeScript' },
+      },
+      { kind: 'tool_result', toolUseId: 'mcp1', toolName: 'mcp__hindsight__retain' },
+    ])
+    const html = render(s, 5000)
+    expect(html).toContain('Remember user prefers TypeScript')
+    expect(html).not.toContain('mcp__hindsight__retain')
+  })
+
+  it('WebFetch still renders "WebFetch <host>" (regression guard)', () => {
+    const s = fold([
+      enqueue('fetch docs'),
+      {
+        kind: 'tool_use',
+        toolName: 'WebFetch',
+        toolUseId: 'w1',
+        input: { url: 'https://docs.example.com/api' },
+      },
+      { kind: 'tool_result', toolUseId: 'w1', toolName: 'WebFetch' },
+    ])
+    const html = render(s, 5000)
+    expect(html).toContain('WebFetch')
+    expect(html).toContain('docs.example.com')
   })
 })

--- a/telegram-plugin/tests/progress-card.test.ts
+++ b/telegram-plugin/tests/progress-card.test.ts
@@ -976,7 +976,7 @@ describe('progress-card reducer — multi-agent correlation', () => {
           kind: 'tool_use',
           toolName: 'Agent',
           toolUseId: 'toolu_p1',
-          input: { description: 'd', prompt: 'P' },
+          input: { description: 'Deploy the service', prompt: 'P' },
         },
         { kind: 'sub_agent_started', agentId: 'X', firstPromptText: 'P' },
       ])
@@ -985,7 +985,8 @@ describe('progress-card reducer — multi-agent correlation', () => {
       expect(html).not.toContain('[Sub-agents')
       // Agent with human-authored description renders without the "Agent:" prefix.
       // Check the description text appears (not the raw tool name as a prefix).
-      expect(html).toContain('d')
+      expect(html).toContain('Deploy the service')
+      expect(html).not.toContain('Agent: Deploy')
     } finally {
       if (prev != null) process.env.PROGRESS_CARD_MULTI_AGENT = prev
       else delete process.env.PROGRESS_CARD_MULTI_AGENT

--- a/telegram-plugin/tests/tool-labels.test.ts
+++ b/telegram-plugin/tests/tool-labels.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { toolLabel } from '../tool-labels.js'
+import { toolLabel, isHumanDescription } from '../tool-labels.js'
 
 describe('toolLabel', () => {
   it('Read: uses basename of file_path', () => {
@@ -292,5 +292,60 @@ describe('toolLabel', () => {
     it('unknown non-mcp tool still uses generic sweep', () => {
       expect(toolLabel('SomeRandomTool', { description: 'doing a thing' })).toBe('doing a thing')
     })
+  })
+})
+
+describe('isHumanDescription', () => {
+  it('Bash with non-empty description → true', () => {
+    expect(isHumanDescription('Bash', { description: 'Check commit state' })).toBe(true)
+    expect(isHumanDescription('Bash', { command: 'git status', description: 'Check git status' })).toBe(true)
+  })
+
+  it('BashOutput with non-empty description → true', () => {
+    expect(isHumanDescription('BashOutput', { description: 'Stream output' })).toBe(true)
+  })
+
+  it('Bash with no description, command only → false', () => {
+    expect(isHumanDescription('Bash', { command: 'git status' })).toBe(false)
+    expect(isHumanDescription('Bash', {})).toBe(false)
+    expect(isHumanDescription('Bash', { description: '' })).toBe(false)
+    expect(isHumanDescription('Bash', { description: '   ' })).toBe(false)
+  })
+
+  it('Task with non-empty description → true', () => {
+    expect(isHumanDescription('Task', { description: 'Research the bug' })).toBe(true)
+  })
+
+  it('Agent with non-empty description → true', () => {
+    expect(isHumanDescription('Agent', { description: 'Deploy the service', subagent_type: 'worker' })).toBe(true)
+  })
+
+  it('Task / Agent without description → false', () => {
+    expect(isHumanDescription('Task', { subagent_type: 'general-purpose' })).toBe(false)
+    expect(isHumanDescription('Agent', {})).toBe(false)
+  })
+
+  it('WebFetch → false (tool name provides context)', () => {
+    expect(isHumanDescription('WebFetch', { url: 'https://example.com', description: 'Check docs' })).toBe(false)
+  })
+
+  it('WebSearch → false', () => {
+    expect(isHumanDescription('WebSearch', { query: 'foo', description: 'Search for foo' })).toBe(false)
+  })
+
+  it('Read / Edit / Grep → false', () => {
+    expect(isHumanDescription('Read', { file_path: '/x/foo.ts' })).toBe(false)
+    expect(isHumanDescription('Edit', { file_path: '/x/foo.ts', description: 'Fix the bug' })).toBe(false)
+    expect(isHumanDescription('Grep', { pattern: 'TODO' })).toBe(false)
+  })
+
+  it('MCP tools → false (handled separately by tool.startsWith("mcp__"))', () => {
+    expect(isHumanDescription('mcp__hindsight__recall', { query: 'foo' })).toBe(false)
+    expect(isHumanDescription('mcp__hindsight__retain', { description: 'Store user pref' })).toBe(false)
+  })
+
+  it('missing or non-object input → false', () => {
+    expect(isHumanDescription('Bash', undefined)).toBe(false)
+    expect(isHumanDescription('Bash')).toBe(false)
   })
 })

--- a/telegram-plugin/tool-labels.ts
+++ b/telegram-plugin/tool-labels.ts
@@ -101,6 +101,40 @@ function firstLine(s: string): string {
 }
 
 /**
+ * Return true when the label produced by `toolLabel(tool, input)` came
+ * from a human-authored `description` field rather than a raw fallback
+ * (filename, command string, hostname, etc.). The progress card uses this
+ * flag to suppress the tool-name prefix — "Check commit state" reads
+ * better than "Bash Check commit state".
+ *
+ * Rules:
+ *   - Bash / BashOutput → true when `input.description` is a non-empty string
+ *   - Task / Agent     → true when `input.description` is a non-empty string
+ *   - All other tools  → false (keep the "ToolName label" concat)
+ *
+ * WebFetch and WebSearch are intentionally left as false because the
+ * tool name provides important context ("WebFetch example.com" makes more
+ * sense than just "example.com").
+ */
+export function isHumanDescription(
+  tool: string,
+  input?: Record<string, unknown>,
+): boolean {
+  if (!input || typeof input !== 'object') return false
+  const description =
+    typeof input['description'] === 'string' ? input['description'] : undefined
+  switch (tool) {
+    case 'Bash':
+    case 'BashOutput':
+    case 'Task':
+    case 'Agent':
+      return typeof description === 'string' && description.trim().length > 0
+    default:
+      return false
+  }
+}
+
+/**
  * Return a display suffix for `tool` given its `input`, without the tool
  * name itself. Caller renders `${tool} ${suffix}` (space-separated; no
  * colon) — the checklist format the progress card uses.


### PR DESCRIPTION
Fixes **#6 item 5**.

## Summary

PR #4 shipped MCP-prefix stripping in `renderItemCore` — when an `mcp__*` tool has a resolvable label, the raw `mcp__server__action` prefix is dropped in favour of the friendly label. This PR extends the same principle to built-in tools that carry a human-authored `description` field.

**Before:**
```
● Bash Check commit state (00:09)
● Agent: Research steering queue
```

**After:**
```
● Check commit state (00:09)
● Research steering queue
```

## Changes

- **`telegram-plugin/tool-labels.ts`** — new exported helper `isHumanDescription(tool, input)` returns true for `Bash`/`BashOutput`/`Task`/`Agent` when `input.description` is a non-empty string. `WebFetch`/`WebSearch`/`Read`/`Edit`/etc. are untouched (their labels are identifiers, not prose — tool-name prefix still adds context).
- **`telegram-plugin/progress-card.ts`** — `ChecklistItem` and the `currentTool`/`lastCompletedTool` sub-structs of `SubAgentState` gain a `humanAuthored: boolean` field, populated at ingest time. `renderItemCore` gains a `humanAuthored` parameter and treats it the same as `tool.startsWith('mcp__')`.
- All six `renderItemCore` callsites thread the flag through from the stored item.

## Tests

- `tool-labels.test.ts`: new `isHumanDescription` suite (14 cases)
- `progress-card.test.ts`: new `renderItemCore: human-authored label prefix suppression` suite (6 cases: Bash±description, Task, Agent, MCP regression, WebFetch regression). Two existing tests updated for the new Agent/Task rendering.
- **Full suite: 2537 tests pass, 1 skipped. Type check clean.**

## Review focus

- Confirm the list of tools treated as "human-authored" is correct. Currently: `Bash`, `BashOutput`, `Task`, `Agent`. Tempted to add `Skill` if its `skill` param is prose-like — left out for now.
- The `humanAuthored` flag is persisted in state so the renderer doesn't need to re-parse `input`. Small storage overhead (1 bool per item); trade-off is renderer stays purely deterministic from state.

🤖 Generated during switchroom session work.