### PR TITLE
fix(bootstrap): widen rollback scope + env-var token + missing outcome tests

### DIFF
--- a/src/agents/create-orchestrator.test.ts
+++ b/src/agents/create-orchestrator.test.ts
@@ -4,11 +4,11 @@
  * All external side-effects are mocked:
  *   - validateBotToken (HTTP call)
  *   - scaffoldAgent (large file-system operation)
- *   - installUnit / generateUnit / generateGatewayUnit / resolveGatewayUnitName
+ *   - installUnit / uninstallUnit / generateUnit / generateGatewayUnit / resolveGatewayUnitName
  *   - installScheduleTimers / enableScheduleTimers / daemonReload
  *   - startAuthSession / submitAuthCode
  *   - startAgent
- *   - writeAgentEntryToConfig / updateAgentExtendsInConfig
+ *   - writeAgentEntryToConfig / updateAgentExtendsInConfig / removeAgentFromConfig
  *   - loadConfig / resolveAgentsDir (config)
  *   - listAvailableProfiles
  *   - writeAgentEnv
@@ -37,6 +37,7 @@ vi.mock("./systemd.js", () => ({
   generateUnit: vi.fn().mockReturnValue("[Unit]\nDescription=stub"),
   generateGatewayUnit: vi.fn().mockReturnValue("[Unit]\nDescription=stub-gw"),
   installUnit: vi.fn(),
+  uninstallUnit: vi.fn(),
   installScheduleTimers: vi.fn(),
   enableScheduleTimers: vi.fn(),
   daemonReload: vi.fn(),
@@ -55,6 +56,7 @@ vi.mock("./lifecycle.js", () => ({
 vi.mock("../cli/agent.js", () => ({
   writeAgentEntryToConfig: vi.fn(),
   updateAgentExtendsInConfig: vi.fn(),
+  removeAgentFromConfig: vi.fn(),
   synthesizeTopicName: vi.fn((n: string) => n),
 }));
 
@@ -79,6 +81,7 @@ import { scaffoldAgent } from "./scaffold.js";
 import {
   generateUnit,
   installUnit,
+  uninstallUnit,
   resolveGatewayUnitName,
 } from "./systemd.js";
 import { startAuthSession, submitAuthCode } from "../auth/manager.js";
@@ -86,6 +89,7 @@ import { startAgent } from "./lifecycle.js";
 import {
   writeAgentEntryToConfig,
   updateAgentExtendsInConfig,
+  removeAgentFromConfig,
 } from "../cli/agent.js";
 import { loadConfig, resolveAgentsDir } from "../config/loader.js";
 import { listAvailableProfiles } from "./profiles.js";
@@ -139,7 +143,7 @@ describe("createAgent", () => {
 
   afterEach(() => {
     rmSync(agentsDir, { recursive: true, force: true });
-    vi.clearAllMocks();
+    vi.resetAllMocks();
   });
 
   it("rejects an unknown profile before any disk writes", async () => {
@@ -309,6 +313,133 @@ describe("createAgent", () => {
     const { existsSync } = await import("node:fs");
     expect(existsSync(agentDir)).toBe(true);
   });
+
+  it("rolls back agentDir, systemd unit, and yaml entry on installUnit failure (rollbackOnFail=true)", async () => {
+    const agentDir = join(agentsDir, "gymbro");
+    mkdirSync(agentDir, { recursive: true });
+
+    // Override: agent NOT yet in yaml, so orchestrator writes the entry (and
+    // rollback must remove it).
+    vi.mocked(loadConfig).mockReturnValue({
+      agents: {},
+      telegram: { bot_token: "stub", forum_chat_id: "-100111111111" },
+    } as any);
+    vi.mocked(loadConfig).mockReturnValueOnce({
+      agents: {},
+      telegram: { bot_token: "stub", forum_chat_id: "-100111111111" },
+    } as any);
+    vi.mocked(loadConfig).mockReturnValueOnce({
+      agents: {
+        gymbro: {
+          extends: "health-coach",
+          topic_name: "Gymbro",
+          channels: { telegram: { plugin: "switchroom" } },
+          schedule: [],
+        },
+      },
+      telegram: { bot_token: "stub", forum_chat_id: "-100111111111" },
+    } as any);
+
+    vi.mocked(installUnit).mockImplementation(() => {
+      throw new Error("permission denied writing unit file");
+    });
+
+    await expect(
+      createAgent({
+        name: "gymbro",
+        profile: "health-coach",
+        telegramBotToken: "123:abc",
+        configPath: join(agentsDir, "switchroom.yaml"),
+        rollbackOnFail: true,
+      }),
+    ).rejects.toThrow("permission denied writing unit file");
+
+    // YAML entry should be rolled back
+    expect(removeAgentFromConfig).toHaveBeenCalledWith(
+      expect.stringContaining("switchroom.yaml"),
+      "gymbro",
+    );
+    // agentDir should have been removed
+    const { existsSync } = await import("node:fs");
+    expect(existsSync(agentDir)).toBe(false);
+  });
+
+  it("rolls back agentDir, systemd unit, and yaml entry on writeAgentEnv failure (rollbackOnFail=true)", async () => {
+    const agentDir = join(agentsDir, "gymbro");
+    mkdirSync(agentDir, { recursive: true });
+
+    // Override: agent NOT yet in yaml, so rollback has an entry to remove.
+    vi.mocked(loadConfig).mockReturnValueOnce({
+      agents: {},
+      telegram: { bot_token: "stub", forum_chat_id: "-100111111111" },
+    } as any);
+    vi.mocked(loadConfig).mockReturnValueOnce({
+      agents: {
+        gymbro: {
+          extends: "health-coach",
+          topic_name: "Gymbro",
+          channels: { telegram: { plugin: "switchroom" } },
+          schedule: [],
+        },
+      },
+      telegram: { bot_token: "stub", forum_chat_id: "-100111111111" },
+    } as any);
+
+    vi.mocked(writeAgentEnv).mockImplementation(() => {
+      throw new Error("ENOENT: telegram dir missing");
+    });
+
+    await expect(
+      createAgent({
+        name: "gymbro",
+        profile: "health-coach",
+        telegramBotToken: "123:abc",
+        configPath: join(agentsDir, "switchroom.yaml"),
+        rollbackOnFail: true,
+      }),
+    ).rejects.toThrow("ENOENT: telegram dir missing");
+
+    // systemd unit should be uninstalled
+    expect(uninstallUnit).toHaveBeenCalledWith("gymbro");
+    // YAML entry should be rolled back
+    expect(removeAgentFromConfig).toHaveBeenCalledWith(
+      expect.stringContaining("switchroom.yaml"),
+      "gymbro",
+    );
+    // agentDir should have been removed
+    const { existsSync } = await import("node:fs");
+    expect(existsSync(agentDir)).toBe(false);
+  });
+
+  it("rolls back agentDir and yaml entry on writeAgentEntryToConfig failure (rollbackOnFail=true)", async () => {
+    // Simulate: agent not yet in yaml, writeAgentEntryToConfig throws part way
+    // through (e.g. file system full after first read).
+    // We model this by having loadConfig return empty agents (so the branch
+    // tries to write) but writeAgentEntryToConfig throws synchronously.
+    vi.mocked(loadConfig).mockReturnValueOnce({
+      agents: {},
+      telegram: { bot_token: "stub", forum_chat_id: "-100111111111" },
+    } as any);
+    vi.mocked(writeAgentEntryToConfig).mockImplementation(() => {
+      throw new Error("ENOSPC: no space left on device");
+    });
+
+    await expect(
+      createAgent({
+        name: "gymbro",
+        profile: "health-coach",
+        telegramBotToken: "123:abc",
+        configPath: join(agentsDir, "switchroom.yaml"),
+        rollbackOnFail: true,
+      }),
+    ).rejects.toThrow("ENOSPC: no space left on device");
+
+    // writeAgentEntryToConfig threw before the rollback push — no partial
+    // agentDir or systemd state should exist. Crucially, scaffoldAgent and
+    // installUnit must NOT have been called at all.
+    expect(scaffoldAgent).not.toHaveBeenCalled();
+    expect(installUnit).not.toHaveBeenCalled();
+  });
 });
 
 // ─── completeCreation ─────────────────────────────────────────────────────────
@@ -325,7 +456,7 @@ describe("completeCreation", () => {
 
   afterEach(() => {
     rmSync(agentsDir, { recursive: true, force: true });
-    vi.clearAllMocks();
+    vi.resetAllMocks();
   });
 
   it("returns success outcome and starts agent on happy path", async () => {
@@ -431,6 +562,46 @@ describe("completeCreation", () => {
       { pollTimeoutMs: 5000 },
     );
   });
+
+  it("surfaces expired-code outcome with paneTailText correctly", async () => {
+    vi.mocked(submitAuthCode).mockReturnValue({
+      completed: false,
+      tokenSaved: false,
+      outcome: {
+        kind: "expired-code",
+        paneTailText: "Error: The provided code has expired. Please try again.",
+      },
+      instructions: ["Code expired. Request a new one."],
+    });
+
+    const result = await completeCreation("gymbro", "stale-code", {
+      configPath: join(agentsDir, "switchroom.yaml"),
+    });
+
+    expect(result.outcome.kind).toBe("expired-code");
+    expect(result.outcome.paneTailText).toContain("expired");
+    expect(result.started).toBe(false);
+    expect(startAgent).not.toHaveBeenCalled();
+    expect(result.instructions).toEqual(["Code expired. Request a new one."]);
+  });
+
+  it("surfaces timeout outcome when submitAuthCode returns undefined outcome (fallback path)", async () => {
+    // The ?. ?? { kind: "timeout" } fallback fires when outcome is absent.
+    vi.mocked(submitAuthCode).mockReturnValue({
+      completed: false,
+      tokenSaved: false,
+      outcome: undefined as any, // simulate missing outcome — triggers fallback
+      instructions: ["Auth timed out."],
+    });
+
+    const result = await completeCreation("gymbro", "any-code", {
+      configPath: join(agentsDir, "switchroom.yaml"),
+    });
+
+    expect(result.outcome.kind).toBe("timeout");
+    expect(result.started).toBe(false);
+    expect(startAgent).not.toHaveBeenCalled();
+  });
 });
 
 // ─── End-to-end happy path (createAgent + completeCreation) ──────────────────
@@ -464,7 +635,7 @@ describe("createAgent + completeCreation end-to-end", () => {
 
   afterEach(() => {
     rmSync(agentsDir, { recursive: true, force: true });
-    vi.clearAllMocks();
+    vi.resetAllMocks();
   });
 
   it("createAgent then completeCreation returns success and started=true", async () => {

--- a/src/agents/create-orchestrator.ts
+++ b/src/agents/create-orchestrator.ts
@@ -23,6 +23,7 @@ import {
   generateUnit,
   generateGatewayUnit,
   installUnit,
+  uninstallUnit,
   installScheduleTimers,
   enableScheduleTimers,
   daemonReload,
@@ -31,6 +32,7 @@ import {
 import {
   writeAgentEntryToConfig,
   updateAgentExtendsInConfig,
+  removeAgentFromConfig,
   synthesizeTopicName,
 } from "../cli/agent.js";
 import { validateBotToken } from "../setup/telegram-api.js";
@@ -96,7 +98,14 @@ export interface CompletionResult {
  *   6. Write telegram/.env with the bot token.
  *   7. startAuthSession() — returns loginUrl + sessionName.
  *
- * On failure at step 7 with rollbackOnFail=true, the scaffold dir is removed.
+ * Side-effects are tracked in a rollback stack. When rollbackOnFail=true and
+ * any step throws, all previously-applied side-effects are unwound in reverse
+ * order:
+ *   - agentDir removed (rmSync)
+ *   - systemd units uninstalled (uninstallUnit)
+ *   - switchroom.yaml entry removed (removeAgentFromConfig)
+ * This prevents a failed bootstrap from leaving the user in a "stuck" state
+ * where a second run hits the "already configured" guard.
  */
 export async function createAgent(
   opts: CreateAgentOpts,
@@ -143,12 +152,38 @@ export async function createAgent(
       );
     })();
 
+  // Rollback stack — each entry is a best-effort undo for one side-effect.
+  // Unwound in reverse order on failure when rollbackOnFail=true.
+  const rollbackStack: Array<() => void> = [];
+
+  /**
+   * Run `fn`. If it throws and rollbackOnFail=true, unwind the rollback stack
+   * in reverse order, then re-throw the original error.
+   */
+  async function withRollback<T>(fn: () => T | Promise<T>): Promise<T> {
+    try {
+      return await fn();
+    } catch (err) {
+      if (rollbackOnFail) {
+        for (let i = rollbackStack.length - 1; i >= 0; i--) {
+          try { rollbackStack[i](); } catch { /* best effort */ }
+        }
+      }
+      throw err;
+    }
+  }
+
   let config = loadConfig(configPath);
   const existingEntry = config.agents[name];
+
+  // Track whether we wrote the yaml entry (so rollback can remove it).
+  let wroteYamlEntry = false;
 
   if (!existingEntry) {
     // Fresh agent: write entry to yaml.
     writeAgentEntryToConfig(configPath, name, profile);
+    wroteYamlEntry = true;
+    rollbackStack.push(() => removeAgentFromConfig(configPath, name));
     config = loadConfig(configPath);
   } else {
     // Agent already in yaml — reconcile extends.
@@ -175,45 +210,48 @@ export async function createAgent(
   const agentDir = resolve(agentsDir, name);
 
   // ── Step 4: Scaffold ──────────────────────────────────────────────────────
-  scaffoldAgent(name, agentConfig, agentsDir, config.telegram, config, undefined, configPath);
+  await withRollback(() => {
+    scaffoldAgent(name, agentConfig, agentsDir, config.telegram, config, undefined, configPath);
+    // Push agentDir removal onto stack after scaffold succeeds.
+    rollbackStack.push(() => rmSync(agentDir, { recursive: true, force: true }));
+  });
 
   // ── Step 5: Install systemd units ─────────────────────────────────────────
   const useAutoaccept = agentConfig.channels?.telegram?.plugin === "switchroom";
   const gwName = resolveGatewayUnitName(config, name);
-  const unitContent = generateUnit(name, agentDir, useAutoaccept, gwName);
-  installUnit(name, unitContent);
 
-  if (useAutoaccept && gwName) {
-    const stateDir = resolve(agentDir, "telegram");
-    const gatewayContent = generateGatewayUnit(stateDir, name);
-    installUnit(gwName, gatewayContent);
-  }
+  await withRollback(() => {
+    const unitContent = generateUnit(name, agentDir, useAutoaccept, gwName);
+    installUnit(name, unitContent);
+    rollbackStack.push(() => uninstallUnit(name));
+
+    if (useAutoaccept && gwName) {
+      const stateDir = resolve(agentDir, "telegram");
+      const gatewayContent = generateGatewayUnit(stateDir, name);
+      installUnit(gwName, gatewayContent);
+      rollbackStack.push(() => uninstallUnit(gwName));
+    }
+  });
 
   // Install schedule timers if any.
   const schedule = agentConfig.schedule ?? [];
   if (schedule.length > 0) {
-    installScheduleTimers(name, agentDir, schedule);
-    daemonReload();
-    enableScheduleTimers(name, schedule.length);
+    await withRollback(() => {
+      installScheduleTimers(name, agentDir, schedule);
+      daemonReload();
+      enableScheduleTimers(name, schedule.length);
+    });
   }
 
   // ── Step 6: Write bot token to telegram/.env ──────────────────────────────
-  writeAgentEnv(agentDir, telegramBotToken);
+  await withRollback(() => {
+    writeAgentEnv(agentDir, telegramBotToken);
+  });
 
   // ── Step 7: Start OAuth session ───────────────────────────────────────────
-  let authResult: ReturnType<typeof startAuthSession>;
-  try {
-    authResult = startAuthSession(name, agentDir, { force: false });
-  } catch (err) {
-    if (rollbackOnFail) {
-      try {
-        rmSync(agentDir, { recursive: true, force: true });
-      } catch {
-        /* best effort */
-      }
-    }
-    throw err;
-  }
+  const authResult = await withRollback(() =>
+    startAuthSession(name, agentDir, { force: false }),
+  );
 
   return {
     loginUrl: authResult.loginUrl,

--- a/src/cli/agent.ts
+++ b/src/cli/agent.ts
@@ -324,6 +324,23 @@ export function updateAgentExtendsInConfig(
 }
 
 /**
+ * Remove an agent entry from switchroom.yaml. No-ops silently if the
+ * agent is not present (e.g. it was never written or already removed).
+ * Used by rollback in the creation orchestrator to undo a partial write.
+ *
+ * Exported for tests.
+ */
+export function removeAgentFromConfig(configPath: string, name: string): void {
+  if (!existsSync(configPath)) return;
+  const raw = readFileSync(configPath, "utf-8");
+  const doc = YAML.parseDocument(raw);
+  const agents = doc.get("agents") as YAML.YAMLMap | null;
+  if (!agents || !agents.has(name)) return;
+  agents.delete(name);
+  writeFileSync(configPath, doc.toString(), "utf-8");
+}
+
+/**
  * Reconcile the agent's scaffolded state against switchroom.yaml, then
  * restart it. This is the single codepath every `switchroom agent
  * restart` invocation goes through — the CLI entry point thin-wraps
@@ -1483,14 +1500,29 @@ export function registerAgentCommand(program: Command): void {
       "Prints the OAuth URL to stdout and reads the code from stdin."
     )
     .requiredOption("--profile <profile>", "Profile to extend (e.g. health-coach)")
-    .requiredOption("--bot-token <token>", "BotFather token for the agent's Telegram bot")
+    .option(
+      "--bot-token <token>",
+      "BotFather token for the agent's Telegram bot " +
+      "(alternative: set SWITCHROOM_BOT_TOKEN env var to avoid leaking token into shell history)"
+    )
     .option("--rollback-on-fail", "Remove scaffold dir if auth fails (default: keep for retry)")
     .action(
       withConfigError(async (
         name: string,
-        opts: { profile: string; botToken: string; rollbackOnFail?: boolean },
+        opts: { profile: string; botToken?: string; rollbackOnFail?: boolean },
       ) => {
         const configPath = getConfigPath(program);
+
+        // Resolve bot token: flag takes precedence, then env var.
+        const botToken = opts.botToken ?? process.env.SWITCHROOM_BOT_TOKEN;
+        if (!botToken) {
+          console.error(
+            chalk.red(
+              "Error: --bot-token is required (or set SWITCHROOM_BOT_TOKEN env var)."
+            )
+          );
+          process.exit(1);
+        }
 
         console.log(chalk.bold(`\nBootstrapping agent: ${name}\n`));
         console.log(chalk.gray(`  Profile:   ${opts.profile}`));
@@ -1503,7 +1535,7 @@ export function registerAgentCommand(program: Command): void {
           creationResult = await createAgent({
             name,
             profile: opts.profile,
-            telegramBotToken: opts.botToken,
+            telegramBotToken: botToken,
             configPath,
             rollbackOnFail: opts.rollbackOnFail ?? false,
           });


### PR DESCRIPTION
## Summary

Resolves [#19](https://github.com/switchroom/switchroom/issues/19) — the three follow-up concerns from PR #18's review. Unblocks Phase 3 by making the creation orchestrator safe to expose via the foreman bot instead of terminal-only.

- **Widen rollback scope.** Introduces a rollback stack inside `createAgent()`: each successful side-effect (yaml entry, scaffold dir, per-unit systemd files) pushes its own undo. On failure with `rollbackOnFail=true`, the stack unwinds in reverse. Before this PR only `startAuthSession` throws triggered rollback; partial failures during `installUnit` or `writeAgentEnv` left orphan state the user had to hand-edit out of `switchroom.yaml`.
- **`SWITCHROOM_BOT_TOKEN` env var.** Bootstrap verb now reads the BotFather token from `$SWITCHROOM_BOT_TOKEN` when `--bot-token` is omitted. Flag still wins when both are set. Missing-token error is clearer.
- **Missing outcome tests.** Adds coverage for `expired-code` and `timeout` outcomes from `completeCreation` (the `?? { kind: "timeout" }` fallback branch was untested).
- **Missing rollback tests.** Adds coverage for the three failure points added by the widened rollback: `installUnit`, `writeAgentEnv`, and `writeAgentEntryToConfig`.

## Test plan
- [x] `bun run test:vitest` — 2598 pass / 2 skip (up from 2593 on #18, +5)
- [x] `bun run test:bun` — 110 pass / 0 fail
- [x] `bun run lint` (tsc --noEmit) — clean
- [x] All orchestrator tests green in isolation (21/21).

## Design note — Option A vs B

Plan offered two approaches (reorder steps or track a rollback stack). Chose the stack approach — reordering would have required scaffold to run before the yaml entry, but scaffold's existing contract assumes the yaml entry is present. The stack is local to `createAgent` and doesn't leak to callers.

Closes #19.

🤖 Generated with [Claude Code](https://claude.com/claude-code)