### PR TITLE
feat(foreman): Phase 3b — /create-agent multi-turn + destructive commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,9 +17,9 @@
   "scripts": {
     "dev": "bun bin/switchroom.ts",
     "build": "node scripts/build.mjs",
-    "test": "vitest run && bun test telegram-plugin/tests/history.test.ts telegram-plugin/tests/ipc-server-client.test.ts telegram-plugin/tests/ipc-server-race.test.ts telegram-plugin/tests/gateway-bridge.test.ts telegram-plugin/tests/gateway-startup-mutex.test.ts telegram-plugin/tests/gateway-clean-shutdown-marker.test.ts",
+    "test": "vitest run && bun test telegram-plugin/tests/history.test.ts telegram-plugin/tests/ipc-server-client.test.ts telegram-plugin/tests/ipc-server-race.test.ts telegram-plugin/tests/gateway-bridge.test.ts telegram-plugin/tests/gateway-startup-mutex.test.ts telegram-plugin/tests/gateway-clean-shutdown-marker.test.ts telegram-plugin/tests/foreman-state.test.ts",
     "test:vitest": "vitest run",
-    "test:bun": "bun test telegram-plugin/tests/history.test.ts telegram-plugin/tests/ipc-server-client.test.ts telegram-plugin/tests/ipc-server-race.test.ts telegram-plugin/tests/gateway-bridge.test.ts telegram-plugin/tests/gateway-startup-mutex.test.ts telegram-plugin/tests/gateway-clean-shutdown-marker.test.ts",
+    "test:bun": "bun test telegram-plugin/tests/history.test.ts telegram-plugin/tests/ipc-server-client.test.ts telegram-plugin/tests/ipc-server-race.test.ts telegram-plugin/tests/gateway-bridge.test.ts telegram-plugin/tests/gateway-startup-mutex.test.ts telegram-plugin/tests/gateway-clean-shutdown-marker.test.ts telegram-plugin/tests/foreman-state.test.ts",
     "test:watch": "vitest",
     "lint": "tsc --noEmit",
     "prepublishOnly": "npm run build && npm run lint && npm test"

--- a/telegram-plugin/bridge/ipc-client.ts
+++ b/telegram-plugin/bridge/ipc-client.ts
@@ -2,6 +2,7 @@ import type {
   ClientToGateway,
   GatewayToClient,
   InboundMessage,
+  OperatorEventForward,
   PermissionEvent,
   PermissionRequestForward,
   SessionEventForward,
@@ -49,6 +50,7 @@ export interface IpcClientHandle {
   callTool(tool: string, args: Record<string, unknown>, timeoutMs?: number): Promise<ToolCallResult>;
   sendSessionEvent(event: SessionEventForward): void;
   sendPermissionRequest(msg: PermissionRequestForward): void;
+  sendOperatorEvent(msg: OperatorEventForward): void;
   isConnected(): boolean;
   close(): void;
 }

--- a/telegram-plugin/foreman/foreman-create-flow.ts
+++ b/telegram-plugin/foreman/foreman-create-flow.ts
@@ -1,0 +1,194 @@
+/**
+ * Pure create-agent flow state machine — extracted from foreman.ts for
+ * testability. No grammY imports, no SQLite imports, no side effects.
+ *
+ * Each function takes current state + input and returns an Action
+ * (what the foreman should do next). foreman.ts interprets actions
+ * by calling the actual SQLite / grammY / orchestrator APIs.
+ *
+ * Steps:
+ *   start                  → asked-name  (when no name given)
+ *                          → asked-profile (when name provided inline)
+ *   asked-name  + text     → asked-profile (if valid name)
+ *   asked-profile + text   → asked-bot-token (if valid profile)
+ *   asked-bot-token + text → asked-oauth-code (after createAgent())
+ *   asked-oauth-code + text → done (after completeCreation())
+ */
+
+import type { CreateFlowState, CreateFlowStep } from './state.js'
+
+// ─── Action types ────────────────────────────────────────────────────────
+
+export type CreateFlowAction =
+  | { kind: 'ask-name' }
+  | { kind: 'ask-profile'; profiles: string[] }
+  | { kind: 'ask-bot-token'; name: string; profile: string }
+  | { kind: 'call-create-agent'; name: string; profile: string; botToken: string }
+  | { kind: 'ask-oauth-code'; loginUrl: string; name: string }
+  | { kind: 'call-complete-creation'; name: string; code: string }
+  | { kind: 'done'; name: string; botUsername: string | null }
+  | { kind: 'error'; message: string; stayInStep: boolean }
+  | { kind: 'cancel'; reason: string }
+
+// ─── Name validation (mirrors assertSafeAgentName) ───────────────────────
+
+export function isValidAgentName(name: string): boolean {
+  return /^[a-z0-9][a-z0-9_-]{0,50}$/.test(name)
+}
+
+// ─── Flow entry point ────────────────────────────────────────────────────
+
+/**
+ * Start or resume a /create-agent flow.
+ *
+ * @param inlineName  Optional name from the command args (/create-agent gymbro)
+ * @param profiles    Available profile names (from listAvailableProfiles())
+ * @returns Action to perform
+ */
+export function startCreateFlow(
+  inlineName: string | null,
+  profiles: string[],
+): CreateFlowAction {
+  if (!inlineName) {
+    return { kind: 'ask-name' }
+  }
+
+  if (!isValidAgentName(inlineName)) {
+    return {
+      kind: 'error',
+      message: `"${inlineName}" is not a valid agent name. Names must be lowercase, alphanumeric, hyphens or underscores, max 51 chars.`,
+      stayInStep: false,
+    }
+  }
+
+  return { kind: 'ask-profile', profiles }
+}
+
+// ─── Step transition: handle inbound text for current step ───────────────
+
+export interface StepTransitionInput {
+  /** Current persisted state (or null if no state yet). */
+  state: CreateFlowState | null
+  /** The text the user sent. */
+  text: string
+  /** Available profiles (for profile validation). */
+  profiles: string[]
+}
+
+/**
+ * Given the current state and user text, compute the next action.
+ * The caller (foreman.ts) is responsible for persisting state changes
+ * and executing the returned action.
+ */
+export function handleFlowText(input: StepTransitionInput): CreateFlowAction {
+  const { state, text, profiles } = input
+  const trimmed = text.trim()
+
+  if (!state) {
+    // No active flow — ignore
+    return { kind: 'cancel', reason: 'no-active-flow' }
+  }
+
+  switch (state.step) {
+    case 'asked-name': {
+      if (!isValidAgentName(trimmed)) {
+        return {
+          kind: 'error',
+          message: `"${trimmed}" is not a valid agent name. Names must be lowercase, alphanumeric, hyphens or underscores, max 51 chars. Try again:`,
+          stayInStep: true,
+        }
+      }
+      return { kind: 'ask-profile', profiles }
+    }
+
+    case 'asked-profile': {
+      if (!profiles.includes(trimmed)) {
+        return {
+          kind: 'error',
+          message: `Unknown profile "${trimmed}". Choose one of: ${profiles.join(', ')}`,
+          stayInStep: true,
+        }
+      }
+      const name = state.name ?? trimmed // name was set when we transitioned here
+      return { kind: 'ask-bot-token', name, profile: trimmed }
+    }
+
+    case 'asked-bot-token': {
+      const name = state.name ?? ''
+      const profile = state.profile ?? ''
+      if (!name || !profile) {
+        return { kind: 'cancel', reason: 'missing-name-or-profile' }
+      }
+      // Basic bot token shape check (foreman.ts validates via Telegram API)
+      if (!trimmed.includes(':') || trimmed.length < 20) {
+        return {
+          kind: 'error',
+          message: "That doesn't look like a BotFather token. It should be in the form <code>1234567890:AAH...</code> — try again:",
+          stayInStep: true,
+        }
+      }
+      return { kind: 'call-create-agent', name, profile, botToken: trimmed }
+    }
+
+    case 'asked-oauth-code': {
+      const name = state.name ?? ''
+      if (!name) return { kind: 'cancel', reason: 'missing-name' }
+      // Codes are typically 8+ alphanumeric chars; pass through for server validation
+      if (trimmed.length < 4) {
+        return {
+          kind: 'error',
+          message: 'That code looks too short. Paste the full code from the browser:',
+          stayInStep: true,
+        }
+      }
+      return { kind: 'call-complete-creation', name, code: trimmed }
+    }
+
+    case 'done':
+      return { kind: 'cancel', reason: 'flow-already-done' }
+
+    default: {
+      const _exhaustive: never = state.step
+      return { kind: 'cancel', reason: `unknown-step:${_exhaustive}` }
+    }
+  }
+}
+
+// ─── State factory helpers (for foreman.ts to build new state objects) ───
+
+export function makeInitialState(chatId: string, name: string | null): CreateFlowState {
+  const now = Date.now()
+  return {
+    chatId,
+    step: name ? 'asked-profile' : 'asked-name',
+    name,
+    profile: null,
+    botToken: null,
+    authSessionName: null,
+    loginUrl: null,
+    startedAt: now,
+    updatedAt: now,
+  }
+}
+
+export function advanceState(
+  state: CreateFlowState,
+  updates: Partial<Omit<CreateFlowState, 'chatId' | 'startedAt'>>,
+): CreateFlowState {
+  return {
+    ...state,
+    ...updates,
+    updatedAt: Date.now(),
+  }
+}
+
+/** Compute the human-readable step label for recovery messages. */
+export function stepLabel(step: CreateFlowStep): string {
+  switch (step) {
+    case 'asked-name': return 'waiting for agent name'
+    case 'asked-profile': return 'waiting for profile selection'
+    case 'asked-bot-token': return 'waiting for BotFather token'
+    case 'asked-oauth-code': return 'waiting for OAuth code'
+    case 'done': return 'done'
+  }
+}

--- a/telegram-plugin/foreman/foreman-handlers.ts
+++ b/telegram-plugin/foreman/foreman-handlers.ts
@@ -9,6 +9,9 @@
  */
 
 import { execFileSync } from 'child_process'
+import { renameSync, existsSync } from 'fs'
+import { homedir } from 'os'
+import { join, resolve } from 'path'
 import {
   escapeHtmlForTg,
   preBlock,
@@ -183,6 +186,252 @@ export function handleLogsCommand(
         },
       ],
     }
+  }
+
+  if (Buffer.byteLength(trimmed, 'utf8') > LOG_PAGE_BYTES) {
+    const chunks = chunkText(trimmed, 3800)
+    return {
+      replies: chunks.map((chunk, i) => {
+        const label = chunks.length > 1 ? ` (${i + 1}/${chunks.length})` : ''
+        return {
+          text: preBlock(chunk) + (label ? `\n<i>${label}</i>` : ''),
+          html: true,
+        }
+      }),
+    }
+  }
+
+  return { replies: [{ text: preBlock(trimmed), html: true }] }
+}
+
+// ─── /restart handler impl ────────────────────────────────────────────────
+
+export interface RestartResult {
+  ok: boolean
+  text: string
+  html: boolean
+}
+
+/**
+ * Core /restart implementation.
+ *
+ * Shells out to `systemctl --user restart switchroom-<agent>` via execFileSync
+ * (no shell, so agent name is safely passed as an arg — no injection risk).
+ *
+ * @param match      Text after "/restart " from ctx.match
+ * @param execFile   Injected execFileSync for testability
+ */
+export function handleRestartCommand(
+  match: string,
+  execFile: typeof execFileSync = execFileSync,
+): RestartResult {
+  const agentName = match.trim().split(/\s+/)[0] ?? ''
+
+  if (!agentName) {
+    return {
+      ok: false,
+      text: 'Usage: /restart &lt;agent&gt;',
+      html: true,
+    }
+  }
+
+  try {
+    assertSafeAgentName(agentName)
+  } catch {
+    return { ok: false, text: 'Invalid agent name.', html: true }
+  }
+
+  try {
+    execFile(
+      'systemctl',
+      ['--user', 'restart', `switchroom-${agentName}`],
+      {
+        encoding: 'utf-8',
+        timeout: 15000,
+        stdio: ['ignore', 'pipe', 'pipe'],
+      },
+    )
+    return {
+      ok: true,
+      text: `Restarted <code>switchroom-${escapeHtmlForTg(agentName)}</code>.`,
+      html: true,
+    }
+  } catch (err) {
+    const msg = err as { stderr?: string; stdout?: string; message?: string }
+    const detail = stripAnsi(msg.stderr || msg.stdout || msg.message || 'unknown error').trim()
+    return {
+      ok: false,
+      text: `<b>restart failed for ${escapeHtmlForTg(agentName)}:</b>\n${preBlock(formatSwitchroomOutput(detail))}`,
+      html: true,
+    }
+  }
+}
+
+// ─── /delete (destroy) handler impl ──────────────────────────────────────
+
+export interface DeleteResult {
+  replies: Array<{ text: string; html: boolean }>
+  /** When true, foreman.ts should also send an inline keyboard for confirmation. */
+  needsConfirm?: boolean
+  /** Agent name (for the confirmation prompt). */
+  agentForConfirm?: string
+}
+
+/**
+ * Resolve the agents directory from environment or default location.
+ * Exposed for testability.
+ */
+export function resolveAgentsDirForDelete(): string {
+  const switchroomDir = process.env.SWITCHROOM_AGENTS_DIR
+    ?? join(homedir(), '.switchroom', 'agents')
+  return switchroomDir
+}
+
+/**
+ * Core /delete first-step implementation — returns a confirmation prompt.
+ *
+ * The actual deletion is performed by executeDeleteAgent() once the user
+ * confirms via callback_query or "YES" text.
+ */
+export function handleDeleteCommand(match: string): DeleteResult {
+  const agentName = match.trim().split(/\s+/)[0] ?? ''
+
+  if (!agentName) {
+    return {
+      replies: [{ text: 'Usage: /delete &lt;agent&gt;', html: true }],
+    }
+  }
+
+  try {
+    assertSafeAgentName(agentName)
+  } catch {
+    return { replies: [{ text: 'Invalid agent name.', html: true }] }
+  }
+
+  return {
+    replies: [
+      {
+        text: `Are you sure you want to delete agent <b>${escapeHtmlForTg(agentName)}</b>?\n\nThis will stop and remove the systemd unit and archive the agent directory. Reply <b>YES</b> to confirm.`,
+        html: true,
+      },
+    ],
+    needsConfirm: true,
+    agentForConfirm: agentName,
+  }
+}
+
+/**
+ * Execute agent deletion after confirmation.
+ *
+ * Archives the agent dir to `agents/_archived_<name>_<timestamp>/` before
+ * running `switchroom agent destroy --yes <name>` so data is recoverable.
+ *
+ * @param agentName   Validated agent name
+ * @param switchroomExec  Injected CLI exec for testability
+ * @param execFile    Injected execFileSync for testability (systemctl)
+ * @param agentsDir   Override agents dir (for tests)
+ */
+export function executeDeleteAgent(
+  agentName: string,
+  switchroomExec: SwitchroomExecFn,
+  execFile: typeof execFileSync = execFileSync,
+  agentsDir: string = resolveAgentsDirForDelete(),
+): DeleteResult {
+  try {
+    assertSafeAgentName(agentName)
+  } catch {
+    return { replies: [{ text: 'Invalid agent name.', html: true }] }
+  }
+
+  const agentDir = resolve(agentsDir, agentName)
+  let archivePath: string | null = null
+
+  // Step 1: Archive the dir if it exists
+  if (existsSync(agentDir)) {
+    const timestamp = Date.now()
+    archivePath = resolve(agentsDir, `_archived_${agentName}_${timestamp}`)
+    try {
+      renameSync(agentDir, archivePath)
+    } catch (err) {
+      return {
+        replies: [
+          {
+            text: `<b>Archive failed for ${escapeHtmlForTg(agentName)}:</b>\n${preBlock(formatSwitchroomOutput((err as Error).message))}`,
+            html: true,
+          },
+        ],
+      }
+    }
+  }
+
+  // Step 2: Stop + remove systemd unit via CLI (--yes skips the interactive prompt)
+  let cliOutput = ''
+  let cliOk = true
+  try {
+    cliOutput = switchroomExec(['agent', 'destroy', '--yes', agentName])
+  } catch (err) {
+    cliOk = false
+    const msg = err as { stderr?: string; stdout?: string; message?: string }
+    cliOutput = stripAnsi(msg.stderr || msg.stdout || msg.message || 'unknown error').trim()
+  }
+
+  const lines: string[] = []
+
+  if (archivePath) {
+    lines.push(`Archived <code>${escapeHtmlForTg(agentName)}</code> to:`)
+    lines.push(`<code>${escapeHtmlForTg(archivePath)}</code>`)
+    lines.push('')
+  }
+
+  if (cliOk) {
+    lines.push(`Agent <b>${escapeHtmlForTg(agentName)}</b> deleted.`)
+    if (cliOutput.trim()) {
+      lines.push(preBlock(formatSwitchroomOutput(stripAnsi(cliOutput))))
+    }
+  } else {
+    lines.push(`<b>CLI destroy failed</b> (agent dir was archived; systemd unit may still exist):`)
+    lines.push(preBlock(formatSwitchroomOutput(cliOutput)))
+  }
+
+  return { replies: [{ text: lines.join('\n'), html: true }] }
+}
+
+// ─── /update handler impl ─────────────────────────────────────────────────
+
+export interface UpdateResult {
+  replies: Array<{ text: string; html: boolean }>
+}
+
+/**
+ * Core /update implementation.
+ *
+ * Shells out to `switchroom update` via the CLI exec helper. Output is
+ * paginated when > 3 KB.
+ *
+ * @param switchroomExec  Injected CLI exec (combined stdout+stderr) for testability
+ */
+export function handleUpdateCommand(
+  switchroomExec: SwitchroomExecFn,
+): UpdateResult {
+  let output: string
+  try {
+    output = switchroomExec(['update'])
+  } catch (err) {
+    const msg = err as { stderr?: string; stdout?: string; message?: string }
+    const detail = stripAnsi(msg.stderr || msg.stdout || msg.message || 'unknown error').trim()
+    return {
+      replies: [
+        {
+          text: `<b>update failed:</b>\n${preBlock(formatSwitchroomOutput(detail))}`,
+          html: true,
+        },
+      ],
+    }
+  }
+
+  const trimmed = stripAnsi(output).trim()
+  if (!trimmed) {
+    return { replies: [{ text: 'Update complete (no output).', html: false }] }
   }
 
   if (Buffer.byteLength(trimmed, 'utf8') > LOG_PAGE_BYTES) {

--- a/telegram-plugin/foreman/foreman.ts
+++ b/telegram-plugin/foreman/foreman.ts
@@ -384,6 +384,16 @@ async function handleCreateAgentCommand(ctx: Context, match: string): Promise<vo
 // ─── Create-agent: callback_query for profile selection ───────────────────
 
 bot.on('callback_query:data', async ctx => {
+  // Defense-in-depth: the global bot.use middleware already fires a
+  // `ctx.chat?.type !== 'private'` check, but callback_query updates from
+  // inline messages can arrive without a ctx.chat (callback_query.message
+  // is populated but ctx.chat may be undefined in edge cases). The global
+  // guard does `undefined !== 'private'` = true = ALLOW, so re-check here
+  // explicitly. If this isn't a private chat, silently drop.
+  if (ctx.chat?.type !== 'private') {
+    await ctx.answerCallbackQuery().catch(() => {})
+    return
+  }
   const data = ctx.callbackQuery.data
   const chatId = String(ctx.chat?.id ?? ctx.callbackQuery.from.id)
 
@@ -502,7 +512,14 @@ async function handleCreateFlowText(
 
       await switchroomReply(ctx, `Token OK. Creating agent <b>${escapeHtmlForTg(name)}</b>…`, { html: true })
       try {
-        const result = await createAgent({ name, profile, telegramBotToken: botToken })
+        const result = await createAgent({
+          name,
+          profile,
+          telegramBotToken: botToken,
+          // Clean up scaffold/systemd/yaml on mid-flow failure so the user
+          // can retry /create-agent with the same name without conflicts.
+          rollbackOnFail: true,
+        })
         const newState = advanceState(flowState, {
           step: 'asked-oauth-code',
           name,

--- a/telegram-plugin/foreman/foreman.ts
+++ b/telegram-plugin/foreman/foreman.ts
@@ -3,8 +3,7 @@
  * Foreman — always-on admin bot for the switchroom fleet.
  *
  * Unlike per-agent gateways, the foreman is not bound to a single agent.
- * It provides fleet-wide read-only visibility (Phase 3a) with write ops
- * coming in Phase 3b.
+ * It provides fleet-wide read-only and write visibility (Phase 3a + 3b).
  *
  * Configuration:
  *   ~/.switchroom/foreman/.env          TELEGRAM_BOT_TOKEN=<token>
@@ -15,9 +14,15 @@
  *   /status, /list  — fleet summary via `switchroom agent list --json`
  *   /logs <agent> [--tail N]  — journalctl output, paginated > 3 KB
  *   /auth [agent]   — fleet auth dashboard (per-agent, agent-name-parametric)
+ *
+ * Phase 3b commands (write):
+ *   /restart <agent>        — systemctl --user restart switchroom-<agent>
+ *   /delete <agent>         — 2-step confirm → archive dir + destroy unit
+ *   /update                 — switchroom update (paginated output)
+ *   /create-agent [name]    — multi-turn flow: profile → bot token → OAuth
  */
 
-import { Bot } from 'grammy'
+import { Bot, InlineKeyboard, type Context } from 'grammy'
 import { readFileSync, chmodSync } from 'fs'
 import { homedir } from 'os'
 import { join } from 'path'
@@ -26,6 +31,7 @@ import {
   escapeHtmlForTg,
   isAllowedSender,
   makeSwitchroomExec,
+  makeSwitchroomExecCombined,
   makeSwitchroomExecJson,
   makeSwitchroomReply,
   runPollingLoop,
@@ -34,6 +40,10 @@ import {
   assertSafeAgentName,
   buildFleetSummary,
   handleLogsCommand,
+  handleRestartCommand,
+  handleDeleteCommand,
+  executeDeleteAgent,
+  handleUpdateCommand,
 } from './foreman-handlers.js'
 import {
   buildDashboard,
@@ -43,6 +53,22 @@ import {
   type SlotHealth,
 } from '../auth-dashboard.js'
 import { parseAuthSubCommand } from '../auth-slot-parser.js'
+import {
+  getState,
+  setState,
+  clearState,
+  listActiveFlows,
+} from './state.js'
+import {
+  startCreateFlow,
+  handleFlowText,
+  makeInitialState,
+  advanceState,
+  stepLabel,
+} from './foreman-create-flow.js'
+import { listAvailableProfiles } from '../../src/agents/profiles.js'
+import { createAgent, completeCreation } from '../../src/agents/create-orchestrator.js'
+import { validateBotToken } from '../../src/setup/telegram-api.js'
 
 // ─── Stderr logging ───────────────────────────────────────────────────────
 installPluginLogger()
@@ -95,6 +121,7 @@ function loadAllowFrom(): string[] {
 
 // ─── CLI exec helpers ─────────────────────────────────────────────────────
 const switchroomExec = makeSwitchroomExec()
+const switchroomExecCombined = makeSwitchroomExecCombined()
 const switchroomExecJson = makeSwitchroomExecJson()
 
 // ─── Bot ──────────────────────────────────────────────────────────────────
@@ -173,13 +200,16 @@ bot.command('start', async ctx => {
   await switchroomReply(ctx, [
     '<b>Foreman — switchroom fleet admin</b>',
     '',
-    'Read-only fleet commands:',
-    '  /status — fleet summary',
-    '  /list — same as /status',
+    'Read-only commands:',
+    '  /status, /list — fleet summary',
     '  /logs &lt;agent&gt; [--tail N] — last N log lines (default 50)',
-    '  /auth [agent] — auth dashboard for agent',
+    '  /auth [agent] — auth dashboard',
     '',
-    '<i>Write commands (create, restart, delete) coming in Phase 3b.</i>',
+    'Write commands:',
+    '  /restart &lt;agent&gt; — restart an agent',
+    '  /delete &lt;agent&gt; — delete an agent (2-step confirm)',
+    '  /update — update switchroom',
+    '  /create-agent [name] — create a new agent (multi-turn)',
   ].join('\n'), { html: true })
 })
 
@@ -188,13 +218,21 @@ bot.command('help', async ctx => {
   await switchroomReply(ctx, [
     '<b>Foreman commands</b>',
     '',
+    '<b>Fleet info:</b>',
     '/status, /list — show fleet status',
     '/logs &lt;agent&gt; [--tail N] — show agent journal logs',
     '/auth [agent] — auth slot dashboard for an agent',
     '',
+    '<b>Fleet management:</b>',
+    '/restart &lt;agent&gt; — restart an agent via systemctl',
+    '/delete &lt;agent&gt; — delete agent (confirms, then archives dir)',
+    '/update — pull latest switchroom + reconcile agents',
+    '/create-agent [name] — interactive new-agent wizard',
+    '',
     '<b>Examples:</b>',
     '<code>/logs gymbro --tail 100</code>',
-    '<code>/auth gymbro</code>',
+    '<code>/restart gymbro</code>',
+    '<code>/create-agent gymbro</code>',
   ].join('\n'), { html: true })
 })
 
@@ -257,11 +295,277 @@ bot.command('auth', async ctx => {
   }
 })
 
-// ─── Unrecognised text (DM only) ──────────────────────────────────────────
+// ─── /restart ─────────────────────────────────────────────────────────────
+bot.command('restart', async ctx => {
+  const result = handleRestartCommand((ctx.match ?? '') as string)
+  await switchroomReply(ctx, result.text, { html: result.html })
+})
+
+// ─── /delete ──────────────────────────────────────────────────────────────
+
+/**
+ * In-memory map of chatId → pending delete agent name.
+ * Cleared when the user confirms or the conversation moves on.
+ * For lightweight 2-step confirm — no SQLite needed since this is ephemeral.
+ */
+const pendingDeletes = new Map<string, string>()
+
+bot.command('delete', async ctx => {
+  const result = handleDeleteCommand((ctx.match ?? '') as string)
+  for (const reply of result.replies) {
+    await switchroomReply(ctx, reply.text, { html: reply.html })
+  }
+  if (result.needsConfirm && result.agentForConfirm) {
+    const chatId = String(ctx.chat!.id)
+    pendingDeletes.set(chatId, result.agentForConfirm)
+  }
+})
+
+// ─── /update ──────────────────────────────────────────────────────────────
+bot.command('update', async ctx => {
+  await switchroomReply(ctx, 'Running <code>switchroom update</code>…', { html: true })
+  const result = handleUpdateCommand(switchroomExecCombined)
+  for (const reply of result.replies) {
+    await switchroomReply(ctx, reply.text, { html: reply.html })
+  }
+})
+
+// ─── /create-agent ────────────────────────────────────────────────────────
+
+bot.command('create_agent', async ctx => {
+  await handleCreateAgentCommand(ctx, (ctx.match ?? '') as string)
+})
+// Also register with hyphen (Telegram normalises _ and - differently per client)
+bot.command('create-agent', async ctx => {
+  await handleCreateAgentCommand(ctx, (ctx.match ?? '') as string)
+})
+
+async function handleCreateAgentCommand(ctx: Context, match: string): Promise<void> {
+  const chatId = String(ctx.chat!.id)
+  const inlineName = match.trim().split(/\s+/)[0] || null
+
+  let profiles: string[]
+  try {
+    profiles = listAvailableProfiles()
+  } catch {
+    await switchroomReply(ctx, 'Could not load profiles. Is switchroom installed correctly?', { html: false })
+    return
+  }
+
+  const action = startCreateFlow(inlineName, profiles)
+
+  if (action.kind === 'error') {
+    await switchroomReply(ctx, action.message, { html: true })
+    return
+  }
+
+  if (action.kind === 'ask-name') {
+    const state = makeInitialState(chatId, null)
+    setState(state)
+    await switchroomReply(ctx, 'What should the new agent be named? (lowercase, hyphens/underscores OK)', { html: false })
+    return
+  }
+
+  if (action.kind === 'ask-profile') {
+    const state = makeInitialState(chatId, inlineName)
+    setState(state)
+    const kb = new InlineKeyboard()
+    for (const p of profiles) {
+      kb.text(p, `cf:profile:${p}`).row()
+    }
+    await ctx.reply(
+      `Choose a profile for <b>${escapeHtmlForTg(inlineName!)}</b>:`,
+      { parse_mode: 'HTML', reply_markup: kb },
+    )
+    return
+  }
+}
+
+// ─── Create-agent: callback_query for profile selection ───────────────────
+
+bot.on('callback_query:data', async ctx => {
+  const data = ctx.callbackQuery.data
+  const chatId = String(ctx.chat?.id ?? ctx.callbackQuery.from.id)
+
+  if (data.startsWith('cf:profile:')) {
+    const profile = data.slice('cf:profile:'.length)
+    await ctx.answerCallbackQuery()
+
+    const state = getState(chatId)
+    if (!state || (state.step !== 'asked-name' && state.step !== 'asked-profile')) {
+      await ctx.reply('No active create-agent flow. Use /create-agent to start.')
+      return
+    }
+
+    const profiles = listAvailableProfiles()
+    if (!profiles.includes(profile)) {
+      await ctx.reply('Unknown profile. Use /create-agent to restart.')
+      return
+    }
+
+    const updated = advanceState(state, { step: 'asked-bot-token', profile })
+    setState(updated)
+
+    await ctx.reply(
+      `Profile <b>${escapeHtmlForTg(profile)}</b> selected.\n\nPaste the BotFather token for the new agent's Telegram bot:\n<i>(Note: this token will be visible in this chat)</i>`,
+      { parse_mode: 'HTML' },
+    )
+    return
+  }
+
+  // Unknown callback — ignore
+  await ctx.answerCallbackQuery()
+})
+
+// ─── Inbound text router for multi-turn flows ─────────────────────────────
+
 bot.on('message:text', async ctx => {
   if (ctx.chat?.type !== 'private') return
+  const chatId = String(ctx.chat.id)
+  const text = ctx.message.text ?? ''
+
+  // 1. Check for pending delete confirmation
+  const pendingDelete = pendingDeletes.get(chatId)
+  if (pendingDelete && text.trim().toUpperCase() === 'YES') {
+    pendingDeletes.delete(chatId)
+    const result = executeDeleteAgent(pendingDelete, switchroomExec)
+    for (const reply of result.replies) {
+      await switchroomReply(ctx, reply.text, { html: reply.html })
+    }
+    return
+  }
+  if (pendingDelete) {
+    // Any non-YES text cancels the pending delete
+    pendingDeletes.delete(chatId)
+    await switchroomReply(ctx, 'Deletion cancelled.', { html: false })
+    return
+  }
+
+  // 2. Check for active create-agent flow
+  const flowState = getState(chatId)
+  if (flowState && flowState.step !== 'done') {
+    await handleCreateFlowText(ctx, chatId, text, flowState)
+    return
+  }
+
+  // 3. Unknown text
   await switchroomReply(ctx, 'Unknown command. Try /help.', { html: true })
 })
+
+async function handleCreateFlowText(
+  ctx: Context,
+  chatId: string,
+  text: string,
+  flowState: NonNullable<ReturnType<typeof getState>>,
+): Promise<void> {
+  const profiles = listAvailableProfiles()
+  const action = handleFlowText({ state: flowState, text, profiles })
+
+  switch (action.kind) {
+    case 'ask-name':
+      await switchroomReply(ctx, 'What should the new agent be named?', { html: false })
+      return
+
+    case 'ask-profile': {
+      // Update name in state if we just got it
+      const updatedName = text.trim()
+      const newState = advanceState(flowState, { step: 'asked-profile', name: updatedName })
+      setState(newState)
+      const kb = new InlineKeyboard()
+      for (const p of profiles) {
+        kb.text(p, `cf:profile:${p}`).row()
+      }
+      await ctx.reply(
+        `Choose a profile for <b>${escapeHtmlForTg(updatedName)}</b>:`,
+        { parse_mode: 'HTML', reply_markup: kb },
+      )
+      return
+    }
+
+    case 'ask-bot-token': {
+      const newState = advanceState(flowState, { step: 'asked-bot-token', profile: action.profile })
+      setState(newState)
+      await switchroomReply(ctx, `Profile <b>${escapeHtmlForTg(action.profile)}</b> selected.\n\nPaste the BotFather token for <b>${escapeHtmlForTg(action.name)}</b>'s Telegram bot:\n<i>(Note: this token will be visible in this chat)</i>`, { html: true })
+      return
+    }
+
+    case 'call-create-agent': {
+      const { name, profile, botToken } = action
+      // Validate token via Telegram API before scaffold
+      await switchroomReply(ctx, 'Validating token…', { html: false })
+      try {
+        await validateBotToken(botToken)
+      } catch (err) {
+        await switchroomReply(ctx, `Token rejected by Telegram — ${(err as Error).message}. Try again:`, { html: false })
+        return
+      }
+
+      await switchroomReply(ctx, `Token OK. Creating agent <b>${escapeHtmlForTg(name)}</b>…`, { html: true })
+      try {
+        const result = await createAgent({ name, profile, telegramBotToken: botToken })
+        const newState = advanceState(flowState, {
+          step: 'asked-oauth-code',
+          name,
+          profile,
+          botToken,
+          authSessionName: result.sessionName,
+          loginUrl: result.loginUrl ?? null,
+        })
+        setState(newState)
+
+        if (result.loginUrl) {
+          const kb = new InlineKeyboard().url('Open OAuth URL', result.loginUrl)
+          await ctx.reply(
+            'Open this URL to log in, then paste the code back here:',
+            { reply_markup: kb },
+          )
+        } else {
+          await switchroomReply(ctx, 'Auth session started. Paste the OAuth code back here:', { html: false })
+        }
+      } catch (err) {
+        await switchroomReply(ctx, `<b>createAgent failed:</b> ${escapeHtmlForTg((err as Error).message)}`, { html: true })
+        clearState(chatId)
+      }
+      return
+    }
+
+    case 'call-complete-creation': {
+      const { name, code } = action
+      await switchroomReply(ctx, 'Submitting OAuth code…', { html: false })
+      try {
+        const result = await completeCreation(name, code)
+        if (result.outcome.kind === 'success' && result.started) {
+          clearState(chatId)
+          await switchroomReply(ctx, `<b>${escapeHtmlForTg(name)}</b> is online! DM its bot to say hi.`, { html: true })
+        } else if (result.outcome.kind === 'success') {
+          clearState(chatId)
+          await switchroomReply(ctx, `Auth succeeded but agent start failed. Try: <code>switchroom agent start ${escapeHtmlForTg(name)}</code>`, { html: true })
+        } else {
+          // Bad code — stay in asked-oauth-code step
+          await switchroomReply(ctx, `Code rejected (${result.outcome.kind}). Paste the code again, or use /create-agent to restart:`, { html: false })
+        }
+      } catch (err) {
+        await switchroomReply(ctx, `<b>completeCreation failed:</b> ${escapeHtmlForTg((err as Error).message)}`, { html: true })
+        clearState(chatId)
+      }
+      return
+    }
+
+    case 'error': {
+      await switchroomReply(ctx, action.message, { html: true })
+      if (!action.stayInStep) {
+        clearState(chatId)
+      }
+      return
+    }
+
+    case 'cancel':
+    case 'done':
+      // No active flow — fall through to unknown command
+      await switchroomReply(ctx, 'Unknown command. Try /help.', { html: true })
+      return
+  }
+}
 
 // ─── Startup ──────────────────────────────────────────────────────────────
 process.on('unhandledRejection', err => {
@@ -286,9 +590,31 @@ void runPollingLoop(bot, {
         { command: 'list', description: 'Fleet status (alias)' },
         { command: 'logs', description: 'Agent logs: /logs <agent> [--tail N]' },
         { command: 'auth', description: 'Auth dashboard: /auth [agent]' },
+        { command: 'restart', description: 'Restart agent: /restart <agent>' },
+        { command: 'delete', description: 'Delete agent (with confirm): /delete <agent>' },
+        { command: 'update', description: 'Update switchroom' },
+        { command: 'create_agent', description: 'Create new agent: /create-agent [name]' },
       ])
     } catch (err) {
       process.stderr.write(`foreman: setMyCommands failed: ${err}\n`)
+    }
+
+    // Resume any in-progress create-agent flows that survived a restart
+    try {
+      const activeFlows = listActiveFlows(60 * 60 * 1000) // 1 hour
+      for (const flow of activeFlows) {
+        try {
+          await bot.api.sendMessage(
+            flow.chatId,
+            `Picking up create-agent flow for <b>${escapeHtmlForTg(flow.name ?? '?')}</b> (${stepLabel(flow.step)})…\n\nType your response to continue, or /create-agent to restart.`,
+            { parse_mode: 'HTML' },
+          )
+        } catch (err) {
+          process.stderr.write(`foreman: failed to resume flow for chat ${flow.chatId}: ${err}\n`)
+        }
+      }
+    } catch (err) {
+      process.stderr.write(`foreman: failed to list active flows: ${err}\n`)
     }
   },
   on409: (attempt, delayMs) => {

--- a/telegram-plugin/foreman/state.ts
+++ b/telegram-plugin/foreman/state.ts
@@ -21,7 +21,7 @@
  */
 
 import { Database } from 'bun:sqlite'
-import { mkdirSync } from 'fs'
+import { chmodSync, mkdirSync } from 'fs'
 import { homedir } from 'os'
 import { join } from 'path'
 
@@ -56,10 +56,18 @@ function getDb(): Database {
   const foremanDir =
     process.env.SWITCHROOM_FOREMAN_DIR ?? join(homedir(), '.switchroom', 'foreman')
 
-  mkdirSync(foremanDir, { recursive: true })
+  // 0o700 on the directory + 0o600 on the DB: this file stores in-flight
+  // BotFather tokens during /create-agent flows. On a multi-user host,
+  // default umask (0o022) would leave tokens world-readable otherwise.
+  mkdirSync(foremanDir, { recursive: true, mode: 0o700 })
 
   const dbPath = join(foremanDir, 'state.sqlite')
   _db = new Database(dbPath)
+  try {
+    chmodSync(dbPath, 0o600)
+  } catch {
+    // best-effort — fall through if chmod isn't supported
+  }
 
   _db.exec(`
     CREATE TABLE IF NOT EXISTS create_flow (

--- a/telegram-plugin/foreman/state.ts
+++ b/telegram-plugin/foreman/state.ts
@@ -1,0 +1,195 @@
+/**
+ * Foreman conversation state — SQLite-backed per-chat state for multi-turn
+ * flows. Survives foreman restarts so a create-agent flow started before a
+ * restart can resume cleanly.
+ *
+ * Location: ~/.switchroom/foreman/state.sqlite
+ * Override via SWITCHROOM_FOREMAN_DIR env var.
+ *
+ * Schema:
+ *   CREATE TABLE IF NOT EXISTS create_flow (
+ *     chat_id TEXT PRIMARY KEY,
+ *     step TEXT NOT NULL,   -- 'asked-name' | 'asked-profile' | 'asked-bot-token' | 'asked-oauth-code' | 'done'
+ *     name TEXT,
+ *     profile TEXT,
+ *     bot_token TEXT,
+ *     auth_session_name TEXT,
+ *     login_url TEXT,
+ *     started_at INTEGER NOT NULL,
+ *     updated_at INTEGER NOT NULL
+ *   );
+ */
+
+import { Database } from 'bun:sqlite'
+import { mkdirSync } from 'fs'
+import { homedir } from 'os'
+import { join } from 'path'
+
+// ─── Types ────────────────────────────────────────────────────────────────
+
+export type CreateFlowStep =
+  | 'asked-name'
+  | 'asked-profile'
+  | 'asked-bot-token'
+  | 'asked-oauth-code'
+  | 'done'
+
+export interface CreateFlowState {
+  chatId: string
+  step: CreateFlowStep
+  name: string | null
+  profile: string | null
+  botToken: string | null
+  authSessionName: string | null
+  loginUrl: string | null
+  startedAt: number
+  updatedAt: number
+}
+
+// ─── DB singleton ─────────────────────────────────────────────────────────
+
+let _db: Database | null = null
+
+function getDb(): Database {
+  if (_db) return _db
+
+  const foremanDir =
+    process.env.SWITCHROOM_FOREMAN_DIR ?? join(homedir(), '.switchroom', 'foreman')
+
+  mkdirSync(foremanDir, { recursive: true })
+
+  const dbPath = join(foremanDir, 'state.sqlite')
+  _db = new Database(dbPath)
+
+  _db.exec(`
+    CREATE TABLE IF NOT EXISTS create_flow (
+      chat_id TEXT PRIMARY KEY,
+      step TEXT NOT NULL,
+      name TEXT,
+      profile TEXT,
+      bot_token TEXT,
+      auth_session_name TEXT,
+      login_url TEXT,
+      started_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
+    );
+  `)
+
+  return _db
+}
+
+// ─── Public API ───────────────────────────────────────────────────────────
+
+/** Upsert the state for a given chat. */
+export function setState(state: CreateFlowState): void {
+  const db = getDb()
+  db.prepare(`
+    INSERT INTO create_flow
+      (chat_id, step, name, profile, bot_token, auth_session_name, login_url, started_at, updated_at)
+    VALUES
+      ($chatId, $step, $name, $profile, $botToken, $authSessionName, $loginUrl, $startedAt, $updatedAt)
+    ON CONFLICT(chat_id) DO UPDATE SET
+      step = excluded.step,
+      name = excluded.name,
+      profile = excluded.profile,
+      bot_token = excluded.bot_token,
+      auth_session_name = excluded.auth_session_name,
+      login_url = excluded.login_url,
+      updated_at = excluded.updated_at
+  `).run({
+    $chatId: state.chatId,
+    $step: state.step,
+    $name: state.name,
+    $profile: state.profile,
+    $botToken: state.botToken,
+    $authSessionName: state.authSessionName,
+    $loginUrl: state.loginUrl,
+    $startedAt: state.startedAt,
+    $updatedAt: state.updatedAt,
+  })
+}
+
+/** Retrieve the state for a given chat, or null if none exists. */
+export function getState(chatId: string): CreateFlowState | null {
+  const db = getDb()
+  const row = db.prepare<{
+    chat_id: string
+    step: string
+    name: string | null
+    profile: string | null
+    bot_token: string | null
+    auth_session_name: string | null
+    login_url: string | null
+    started_at: number
+    updated_at: number
+  }, [string]>(`
+    SELECT chat_id, step, name, profile, bot_token, auth_session_name, login_url, started_at, updated_at
+    FROM create_flow
+    WHERE chat_id = ?
+  `).get(chatId)
+
+  if (!row) return null
+
+  return {
+    chatId: row.chat_id,
+    step: row.step as CreateFlowStep,
+    name: row.name,
+    profile: row.profile,
+    botToken: row.bot_token,
+    authSessionName: row.auth_session_name,
+    loginUrl: row.login_url,
+    startedAt: row.started_at,
+    updatedAt: row.updated_at,
+  }
+}
+
+/** Remove the state for a given chat (flow completed or cancelled). */
+export function clearState(chatId: string): void {
+  const db = getDb()
+  db.prepare('DELETE FROM create_flow WHERE chat_id = ?').run(chatId)
+}
+
+/**
+ * List all in-progress flows updated within the last `maxAgeMs` ms.
+ * Used at foreman startup to resume flows that survived a restart.
+ */
+export function listActiveFlows(maxAgeMs = 60 * 60 * 1000): CreateFlowState[] {
+  const db = getDb()
+  const cutoff = Date.now() - maxAgeMs
+  const rows = db.prepare<{
+    chat_id: string
+    step: string
+    name: string | null
+    profile: string | null
+    bot_token: string | null
+    auth_session_name: string | null
+    login_url: string | null
+    started_at: number
+    updated_at: number
+  }, [number]>(`
+    SELECT chat_id, step, name, profile, bot_token, auth_session_name, login_url, started_at, updated_at
+    FROM create_flow
+    WHERE step != 'done' AND updated_at > ?
+    ORDER BY updated_at DESC
+  `).all(cutoff)
+
+  return rows.map(row => ({
+    chatId: row.chat_id,
+    step: row.step as CreateFlowStep,
+    name: row.name,
+    profile: row.profile,
+    botToken: row.bot_token,
+    authSessionName: row.auth_session_name,
+    loginUrl: row.login_url,
+    startedAt: row.started_at,
+    updatedAt: row.updated_at,
+  }))
+}
+
+/** Reset the DB singleton (useful in tests to avoid sharing state). */
+export function _resetDbForTest(): void {
+  if (_db) {
+    _db.close()
+    _db = null
+  }
+}

--- a/telegram-plugin/tests/foreman-create-flow.test.ts
+++ b/telegram-plugin/tests/foreman-create-flow.test.ts
@@ -1,0 +1,337 @@
+/**
+ * Tests for the create-agent flow state machine (foreman-create-flow.ts).
+ *
+ * Pure function tests — no grammY, no SQLite, no network.
+ *
+ * Covers:
+ *   - startCreateFlow: valid/invalid name, inline name, no name
+ *   - handleFlowText: step transitions (asked-name → asked-profile → asked-bot-token → ...)
+ *   - Error paths: invalid name, unknown profile, bad token shape, short code
+ *   - makeInitialState / advanceState / stepLabel helpers
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+  startCreateFlow,
+  handleFlowText,
+  makeInitialState,
+  advanceState,
+  stepLabel,
+  isValidAgentName,
+} from '../foreman/foreman-create-flow.js'
+import type { CreateFlowState } from '../foreman/state.js'
+
+const PROFILES = ['default', 'health-coach', 'coding-assistant']
+
+// ─── isValidAgentName ─────────────────────────────────────────────────────
+
+describe('foreman-create-flow: isValidAgentName', () => {
+  it('accepts lowercase simple name', () => expect(isValidAgentName('gymbro')).toBe(true))
+  it('accepts name with hyphens', () => expect(isValidAgentName('my-agent')).toBe(true))
+  it('accepts name with underscores', () => expect(isValidAgentName('my_agent')).toBe(true))
+  it('accepts name starting with digit', () => expect(isValidAgentName('1agent')).toBe(true))
+  it('rejects uppercase', () => expect(isValidAgentName('Gymbro')).toBe(false))
+  it('rejects empty string', () => expect(isValidAgentName('')).toBe(false))
+  it('rejects spaces', () => expect(isValidAgentName('my agent')).toBe(false))
+  it('rejects semicolon', () => expect(isValidAgentName('agent; evil')).toBe(false))
+  it('accepts 51-char name', () => expect(isValidAgentName('a'.repeat(51))).toBe(true))
+  it('rejects 52-char name', () => expect(isValidAgentName('a'.repeat(52))).toBe(false))
+})
+
+// ─── startCreateFlow ──────────────────────────────────────────────────────
+
+describe('foreman-create-flow: startCreateFlow', () => {
+  it('asks for name when no inline name given', () => {
+    const action = startCreateFlow(null, PROFILES)
+    expect(action.kind).toBe('ask-name')
+  })
+
+  it('asks for profile when valid inline name given', () => {
+    const action = startCreateFlow('gymbro', PROFILES)
+    expect(action.kind).toBe('ask-profile')
+    if (action.kind === 'ask-profile') {
+      expect(action.profiles).toEqual(PROFILES)
+    }
+  })
+
+  it('returns error when inline name is invalid', () => {
+    const action = startCreateFlow('Bad Name!', PROFILES)
+    expect(action.kind).toBe('error')
+    if (action.kind === 'error') {
+      expect(action.message).toContain('Bad Name!')
+      expect(action.stayInStep).toBe(false)
+    }
+  })
+
+  it('returns error for uppercase inline name', () => {
+    const action = startCreateFlow('MyAgent', PROFILES)
+    expect(action.kind).toBe('error')
+  })
+})
+
+// ─── handleFlowText — null state ─────────────────────────────────────────
+
+describe('foreman-create-flow: handleFlowText with null state', () => {
+  it('cancels when no active flow', () => {
+    const action = handleFlowText({ state: null, text: 'hello', profiles: PROFILES })
+    expect(action.kind).toBe('cancel')
+  })
+})
+
+// ─── handleFlowText — asked-name step ────────────────────────────────────
+
+describe('foreman-create-flow: handleFlowText step=asked-name', () => {
+  function makeState(): CreateFlowState {
+    return makeInitialState('chat-1', null) // step = 'asked-name'
+  }
+
+  it('transitions to ask-profile on valid name', () => {
+    const action = handleFlowText({ state: makeState(), text: 'gymbro', profiles: PROFILES })
+    expect(action.kind).toBe('ask-profile')
+    if (action.kind === 'ask-profile') {
+      expect(action.profiles).toEqual(PROFILES)
+    }
+  })
+
+  it('returns error on invalid name, stayInStep=true', () => {
+    const action = handleFlowText({ state: makeState(), text: 'Bad Name!', profiles: PROFILES })
+    expect(action.kind).toBe('error')
+    if (action.kind === 'error') {
+      expect(action.stayInStep).toBe(true)
+    }
+  })
+
+  it('error message mentions the bad input', () => {
+    const action = handleFlowText({ state: makeState(), text: 'MyBotIsGreat', profiles: PROFILES })
+    if (action.kind === 'error') {
+      expect(action.message).toContain('MyBotIsGreat')
+    }
+  })
+
+  it('accepts name with hyphens', () => {
+    const action = handleFlowText({ state: makeState(), text: 'my-agent', profiles: PROFILES })
+    expect(action.kind).toBe('ask-profile')
+  })
+})
+
+// ─── handleFlowText — asked-profile step ──────────────────────────────────
+
+describe('foreman-create-flow: handleFlowText step=asked-profile', () => {
+  function makeState(name = 'gymbro'): CreateFlowState {
+    return {
+      chatId: 'chat-1',
+      step: 'asked-profile',
+      name,
+      profile: null,
+      botToken: null,
+      authSessionName: null,
+      loginUrl: null,
+      startedAt: Date.now(),
+      updatedAt: Date.now(),
+    }
+  }
+
+  it('transitions to ask-bot-token on valid profile', () => {
+    const action = handleFlowText({ state: makeState(), text: 'health-coach', profiles: PROFILES })
+    expect(action.kind).toBe('ask-bot-token')
+    if (action.kind === 'ask-bot-token') {
+      expect(action.profile).toBe('health-coach')
+      expect(action.name).toBe('gymbro')
+    }
+  })
+
+  it('returns error on unknown profile, stayInStep=true', () => {
+    const action = handleFlowText({ state: makeState(), text: 'nonexistent-profile', profiles: PROFILES })
+    expect(action.kind).toBe('error')
+    if (action.kind === 'error') {
+      expect(action.stayInStep).toBe(true)
+      expect(action.message).toContain('nonexistent-profile')
+    }
+  })
+
+  it('lists valid profiles in error message', () => {
+    const action = handleFlowText({ state: makeState(), text: 'bad', profiles: PROFILES })
+    if (action.kind === 'error') {
+      for (const p of PROFILES) {
+        expect(action.message).toContain(p)
+      }
+    }
+  })
+})
+
+// ─── handleFlowText — asked-bot-token step ───────────────────────────────
+
+describe('foreman-create-flow: handleFlowText step=asked-bot-token', () => {
+  function makeState(): CreateFlowState {
+    return {
+      chatId: 'chat-1',
+      step: 'asked-bot-token',
+      name: 'gymbro',
+      profile: 'health-coach',
+      botToken: null,
+      authSessionName: null,
+      loginUrl: null,
+      startedAt: Date.now(),
+      updatedAt: Date.now(),
+    }
+  }
+
+  it('transitions to call-create-agent on token-shaped input', () => {
+    const token = '1234567890:AAHaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+    const action = handleFlowText({ state: makeState(), text: token, profiles: PROFILES })
+    expect(action.kind).toBe('call-create-agent')
+    if (action.kind === 'call-create-agent') {
+      expect(action.botToken).toBe(token)
+      expect(action.name).toBe('gymbro')
+      expect(action.profile).toBe('health-coach')
+    }
+  })
+
+  it('returns error on token with no colon, stayInStep=true', () => {
+    const action = handleFlowText({ state: makeState(), text: 'notavalidtoken', profiles: PROFILES })
+    expect(action.kind).toBe('error')
+    if (action.kind === 'error') {
+      expect(action.stayInStep).toBe(true)
+    }
+  })
+
+  it('returns error on token too short', () => {
+    const action = handleFlowText({ state: makeState(), text: 'a:b', profiles: PROFILES })
+    expect(action.kind).toBe('error')
+    if (action.kind === 'error') {
+      expect(action.stayInStep).toBe(true)
+    }
+  })
+
+  it('cancels if name or profile missing in state', () => {
+    const state: CreateFlowState = {
+      ...makeState(),
+      name: null,
+    }
+    const action = handleFlowText({ state, text: '1234567890:AAHsomething', profiles: PROFILES })
+    expect(action.kind).toBe('cancel')
+  })
+})
+
+// ─── handleFlowText — asked-oauth-code step ──────────────────────────────
+
+describe('foreman-create-flow: handleFlowText step=asked-oauth-code', () => {
+  function makeState(): CreateFlowState {
+    return {
+      chatId: 'chat-1',
+      step: 'asked-oauth-code',
+      name: 'gymbro',
+      profile: 'health-coach',
+      botToken: '1234567890:AAHsomething',
+      authSessionName: 'gymbro-auth-123',
+      loginUrl: 'https://claude.ai/oauth/authorize?...',
+      startedAt: Date.now(),
+      updatedAt: Date.now(),
+    }
+  }
+
+  it('transitions to call-complete-creation on plausible code', () => {
+    const action = handleFlowText({ state: makeState(), text: 'abc12345', profiles: PROFILES })
+    expect(action.kind).toBe('call-complete-creation')
+    if (action.kind === 'call-complete-creation') {
+      expect(action.name).toBe('gymbro')
+      expect(action.code).toBe('abc12345')
+    }
+  })
+
+  it('returns error on code that is too short, stayInStep=true', () => {
+    const action = handleFlowText({ state: makeState(), text: 'ab', profiles: PROFILES })
+    expect(action.kind).toBe('error')
+    if (action.kind === 'error') {
+      expect(action.stayInStep).toBe(true)
+    }
+  })
+
+  it('cancels if name missing in state', () => {
+    const state: CreateFlowState = { ...makeState(), name: null }
+    const action = handleFlowText({ state, text: 'abc12345', profiles: PROFILES })
+    expect(action.kind).toBe('cancel')
+  })
+})
+
+// ─── handleFlowText — done step ──────────────────────────────────────────
+
+describe('foreman-create-flow: handleFlowText step=done', () => {
+  it('returns cancel when flow is already done', () => {
+    const state: CreateFlowState = {
+      chatId: 'chat-1',
+      step: 'done',
+      name: 'gymbro',
+      profile: 'health-coach',
+      botToken: null,
+      authSessionName: null,
+      loginUrl: null,
+      startedAt: Date.now(),
+      updatedAt: Date.now(),
+    }
+    const action = handleFlowText({ state, text: 'hello', profiles: PROFILES })
+    expect(action.kind).toBe('cancel')
+  })
+})
+
+// ─── makeInitialState ─────────────────────────────────────────────────────
+
+describe('foreman-create-flow: makeInitialState', () => {
+  it('sets step to asked-name when name is null', () => {
+    const state = makeInitialState('chat-1', null)
+    expect(state.step).toBe('asked-name')
+    expect(state.name).toBeNull()
+  })
+
+  it('sets step to asked-profile when name provided', () => {
+    const state = makeInitialState('chat-1', 'gymbro')
+    expect(state.step).toBe('asked-profile')
+    expect(state.name).toBe('gymbro')
+  })
+
+  it('sets startedAt and updatedAt', () => {
+    const before = Date.now()
+    const state = makeInitialState('chat-1', null)
+    const after = Date.now()
+    expect(state.startedAt).toBeGreaterThanOrEqual(before)
+    expect(state.startedAt).toBeLessThanOrEqual(after)
+    expect(state.updatedAt).toBe(state.startedAt)
+  })
+})
+
+// ─── advanceState ─────────────────────────────────────────────────────────
+
+describe('foreman-create-flow: advanceState', () => {
+  it('merges updates into state', () => {
+    const state = makeInitialState('chat-1', 'gymbro')
+    const next = advanceState(state, { step: 'asked-bot-token', profile: 'health-coach' })
+    expect(next.step).toBe('asked-bot-token')
+    expect(next.profile).toBe('health-coach')
+    expect(next.name).toBe('gymbro')
+    expect(next.chatId).toBe('chat-1')
+  })
+
+  it('updates updatedAt', () => {
+    const state = makeInitialState('chat-1', null)
+    const before = Date.now()
+    const next = advanceState(state, { step: 'asked-profile', name: 'gymbro' })
+    expect(next.updatedAt).toBeGreaterThanOrEqual(before)
+  })
+
+  it('preserves startedAt', () => {
+    const state = makeInitialState('chat-1', null)
+    const next = advanceState(state, { step: 'asked-profile' })
+    expect(next.startedAt).toBe(state.startedAt)
+  })
+})
+
+// ─── stepLabel ────────────────────────────────────────────────────────────
+
+describe('foreman-create-flow: stepLabel', () => {
+  it('returns a non-empty string for each step', () => {
+    const steps = ['asked-name', 'asked-profile', 'asked-bot-token', 'asked-oauth-code', 'done'] as const
+    for (const step of steps) {
+      expect(stepLabel(step).length).toBeGreaterThan(0)
+    }
+  })
+})

--- a/telegram-plugin/tests/foreman-state.test.ts
+++ b/telegram-plugin/tests/foreman-state.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Tests for telegram-plugin/foreman/state.ts — SQLite-backed conversation state.
+ *
+ * Uses bun:test (not vitest) because it imports bun:sqlite.
+ * Run with: bun test telegram-plugin/tests/foreman-state.test.ts
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test'
+import { mkdtempSync, rmSync } from 'fs'
+import { tmpdir } from 'os'
+
+// We override SWITCHROOM_FOREMAN_DIR before importing state so each test
+// gets a fresh DB in a temp directory.
+
+let tmpDir: string
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(tmpdir() + '/foreman-state-test-')
+  process.env.SWITCHROOM_FOREMAN_DIR = tmpDir
+})
+
+afterEach(async () => {
+  // Must reset the DB singleton between tests so the next test gets a fresh one
+  const { _resetDbForTest } = await import('../foreman/state.js')
+  _resetDbForTest()
+  delete process.env.SWITCHROOM_FOREMAN_DIR
+  try { rmSync(tmpDir, { recursive: true, force: true }) } catch { /* ignore */ }
+})
+
+// ─── Round-trip: setState + getState ─────────────────────────────────────
+
+describe('foreman-state: setState + getState round-trip', () => {
+  it('returns null for unknown chat', async () => {
+    const { getState } = await import('../foreman/state.js')
+    const result = getState('unknown-chat')
+    expect(result).toBeNull()
+  })
+
+  it('persists and retrieves state', async () => {
+    const { setState, getState } = await import('../foreman/state.js')
+    const now = Date.now()
+    setState({
+      chatId: 'chat-1',
+      step: 'asked-name',
+      name: null,
+      profile: null,
+      botToken: null,
+      authSessionName: null,
+      loginUrl: null,
+      startedAt: now,
+      updatedAt: now,
+    })
+    const retrieved = getState('chat-1')
+    expect(retrieved).not.toBeNull()
+    expect(retrieved!.chatId).toBe('chat-1')
+    expect(retrieved!.step).toBe('asked-name')
+    expect(retrieved!.name).toBeNull()
+    expect(retrieved!.startedAt).toBe(now)
+  })
+
+  it('persists all fields', async () => {
+    const { setState, getState } = await import('../foreman/state.js')
+    const now = Date.now()
+    setState({
+      chatId: 'chat-2',
+      step: 'asked-oauth-code',
+      name: 'gymbro',
+      profile: 'health-coach',
+      botToken: '1234567890:AAH...',
+      authSessionName: 'gymbro-auth-session',
+      loginUrl: 'https://example.com/oauth',
+      startedAt: now - 5000,
+      updatedAt: now,
+    })
+    const retrieved = getState('chat-2')
+    expect(retrieved!.step).toBe('asked-oauth-code')
+    expect(retrieved!.name).toBe('gymbro')
+    expect(retrieved!.profile).toBe('health-coach')
+    expect(retrieved!.botToken).toBe('1234567890:AAH...')
+    expect(retrieved!.authSessionName).toBe('gymbro-auth-session')
+    expect(retrieved!.loginUrl).toBe('https://example.com/oauth')
+  })
+
+  it('upserts on conflict (same chat_id)', async () => {
+    const { setState, getState } = await import('../foreman/state.js')
+    const now = Date.now()
+    setState({ chatId: 'chat-3', step: 'asked-name', name: null, profile: null, botToken: null, authSessionName: null, loginUrl: null, startedAt: now, updatedAt: now })
+    setState({ chatId: 'chat-3', step: 'asked-profile', name: 'gymbro', profile: null, botToken: null, authSessionName: null, loginUrl: null, startedAt: now, updatedAt: now + 100 })
+
+    const retrieved = getState('chat-3')
+    expect(retrieved!.step).toBe('asked-profile')
+    expect(retrieved!.name).toBe('gymbro')
+  })
+})
+
+// ─── clearState ───────────────────────────────────────────────────────────
+
+describe('foreman-state: clearState', () => {
+  it('removes state so getState returns null', async () => {
+    const { setState, getState, clearState } = await import('../foreman/state.js')
+    const now = Date.now()
+    setState({ chatId: 'chat-4', step: 'asked-name', name: null, profile: null, botToken: null, authSessionName: null, loginUrl: null, startedAt: now, updatedAt: now })
+    clearState('chat-4')
+    expect(getState('chat-4')).toBeNull()
+  })
+
+  it('is idempotent on unknown chat', async () => {
+    const { clearState } = await import('../foreman/state.js')
+    expect(() => clearState('nonexistent-chat')).not.toThrow()
+  })
+})
+
+// ─── listActiveFlows ──────────────────────────────────────────────────────
+
+describe('foreman-state: listActiveFlows', () => {
+  it('returns empty when no flows', async () => {
+    const { listActiveFlows } = await import('../foreman/state.js')
+    expect(listActiveFlows()).toHaveLength(0)
+  })
+
+  it('returns in-progress flows updated within window', async () => {
+    const { setState, listActiveFlows } = await import('../foreman/state.js')
+    const now = Date.now()
+    setState({ chatId: 'chat-5', step: 'asked-bot-token', name: 'gymbro', profile: 'health-coach', botToken: null, authSessionName: null, loginUrl: null, startedAt: now - 1000, updatedAt: now - 500 })
+
+    const flows = listActiveFlows(60 * 60 * 1000)
+    expect(flows).toHaveLength(1)
+    expect(flows[0].chatId).toBe('chat-5')
+    expect(flows[0].step).toBe('asked-bot-token')
+  })
+
+  it('excludes flows with step=done', async () => {
+    const { setState, listActiveFlows } = await import('../foreman/state.js')
+    const now = Date.now()
+    setState({ chatId: 'chat-6', step: 'done', name: 'gymbro', profile: null, botToken: null, authSessionName: null, loginUrl: null, startedAt: now - 1000, updatedAt: now - 500 })
+
+    const flows = listActiveFlows(60 * 60 * 1000)
+    const match = flows.find(f => f.chatId === 'chat-6')
+    expect(match).toBeUndefined()
+  })
+
+  it('excludes flows older than maxAgeMs', async () => {
+    const { setState, listActiveFlows } = await import('../foreman/state.js')
+    const now = Date.now()
+    // updated_at is 2 hours ago
+    setState({ chatId: 'chat-7', step: 'asked-oauth-code', name: 'gymbro', profile: null, botToken: null, authSessionName: null, loginUrl: null, startedAt: now - 2 * 3600 * 1000, updatedAt: now - 2 * 3600 * 1000 })
+
+    const flows = listActiveFlows(60 * 60 * 1000) // 1 hour window
+    const match = flows.find(f => f.chatId === 'chat-7')
+    expect(match).toBeUndefined()
+  })
+
+  it('returns multiple in-progress flows', async () => {
+    const { setState, listActiveFlows } = await import('../foreman/state.js')
+    const now = Date.now()
+    setState({ chatId: 'chat-8', step: 'asked-name', name: null, profile: null, botToken: null, authSessionName: null, loginUrl: null, startedAt: now, updatedAt: now })
+    setState({ chatId: 'chat-9', step: 'asked-profile', name: 'agent2', profile: null, botToken: null, authSessionName: null, loginUrl: null, startedAt: now, updatedAt: now })
+
+    const flows = listActiveFlows()
+    const chatIds = flows.map(f => f.chatId)
+    expect(chatIds).toContain('chat-8')
+    expect(chatIds).toContain('chat-9')
+  })
+})

--- a/telegram-plugin/tests/foreman-write-ops.test.ts
+++ b/telegram-plugin/tests/foreman-write-ops.test.ts
@@ -1,0 +1,214 @@
+/**
+ * Tests for Phase 3b foreman write operations:
+ *   - handleRestartCommand (mocked execFileSync)
+ *   - handleDeleteCommand + executeDeleteAgent (mocked exec + FS)
+ *   - handleUpdateCommand (mocked combined exec)
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import {
+  handleRestartCommand,
+  handleDeleteCommand,
+  executeDeleteAgent,
+  handleUpdateCommand,
+  type SwitchroomExecFn,
+} from '../foreman/foreman-handlers.js'
+import type { execFileSync } from 'child_process'
+
+// ─── /restart ─────────────────────────────────────────────────────────────
+
+describe('foreman: handleRestartCommand — input validation', () => {
+  it('returns usage when no agent specified', () => {
+    const result = handleRestartCommand('')
+    expect(result.ok).toBe(false)
+    expect(result.text).toContain('Usage')
+  })
+
+  it('rejects invalid agent name', () => {
+    const execFile = vi.fn()
+    // 'BadName' has uppercase — first token is invalid
+    const result = handleRestartCommand('BadName', execFile as never)
+    expect(result.ok).toBe(false)
+    expect(result.text).toBe('Invalid agent name.')
+    expect(execFile).not.toHaveBeenCalled()
+  })
+
+  it('rejects path traversal', () => {
+    const execFile = vi.fn()
+    const result = handleRestartCommand('../etc/passwd', execFile as never)
+    expect(result.ok).toBe(false)
+    expect(execFile).not.toHaveBeenCalled()
+  })
+
+  it('rejects agent name with colon', () => {
+    const execFile = vi.fn()
+    const result = handleRestartCommand('bad:name', execFile as never)
+    expect(result.ok).toBe(false)
+    expect(execFile).not.toHaveBeenCalled()
+  })
+})
+
+describe('foreman: handleRestartCommand — execFileSync calls', () => {
+  it('calls systemctl --user restart with correct unit name', () => {
+    const execFile = vi.fn().mockReturnValue('')
+    const result = handleRestartCommand('gymbro', execFile as never)
+
+    expect(result.ok).toBe(true)
+    expect(execFile).toHaveBeenCalledOnce()
+    const [cmd, args] = execFile.mock.calls[0] as [string, string[]]
+    expect(cmd).toBe('systemctl')
+    expect(args).toContain('--user')
+    expect(args).toContain('restart')
+    expect(args).toContain('switchroom-gymbro')
+    // Must NOT be a shell string — second arg must be an array
+    expect(Array.isArray(args)).toBe(true)
+  })
+
+  it('uses execFileSync not execSync (no shell)', () => {
+    const execFile = vi.fn().mockReturnValue('')
+    handleRestartCommand('gymbro', execFile as never)
+    // The function is called with 3 args (cmd, args[], opts) not a shell string
+    const [, args] = execFile.mock.calls[0] as [string, string[], object]
+    expect(Array.isArray(args)).toBe(true)
+  })
+
+  it('includes agent name in success reply', () => {
+    const execFile = vi.fn().mockReturnValue('')
+    const result = handleRestartCommand('gymbro', execFile as never)
+    expect(result.ok).toBe(true)
+    expect(result.text).toContain('gymbro')
+  })
+
+  it('returns error text when systemctl fails', () => {
+    const execFile = vi.fn().mockImplementation(() => {
+      throw Object.assign(new Error('unit not found'), { stderr: 'Unit switchroom-gymbro.service not found.' })
+    })
+    const result = handleRestartCommand('gymbro', execFile as never)
+    expect(result.ok).toBe(false)
+    expect(result.text).toContain('restart failed')
+    expect(result.text).toContain('gymbro')
+  })
+
+  it('handles agent name with hyphen', () => {
+    const execFile = vi.fn().mockReturnValue('')
+    handleRestartCommand('my-agent', execFile as never)
+    const [, args] = execFile.mock.calls[0] as [string, string[]]
+    expect(args).toContain('switchroom-my-agent')
+  })
+
+  it('escapes HTML in error output', () => {
+    const execFile = vi.fn().mockImplementation(() => {
+      throw Object.assign(new Error('err'), { stderr: 'Error: <unit> not found' })
+    })
+    const result = handleRestartCommand('gymbro', execFile as never)
+    expect(result.text).not.toContain('<unit>')
+  })
+})
+
+// ─── /delete first step ───────────────────────────────────────────────────
+
+describe('foreman: handleDeleteCommand — prompt', () => {
+  it('returns usage when no agent specified', () => {
+    const result = handleDeleteCommand('')
+    expect(result.replies[0].text).toContain('Usage')
+    expect(result.needsConfirm).toBeFalsy()
+  })
+
+  it('rejects invalid agent name', () => {
+    // 'BadAgent' has uppercase — invalid
+    const result = handleDeleteCommand('BadAgent')
+    expect(result.replies[0].text).toBe('Invalid agent name.')
+    expect(result.needsConfirm).toBeFalsy()
+  })
+
+  it('returns confirmation prompt for valid agent', () => {
+    const result = handleDeleteCommand('gymbro')
+    expect(result.replies[0].text).toContain('gymbro')
+    expect(result.replies[0].text).toContain('YES')
+    expect(result.needsConfirm).toBe(true)
+    expect(result.agentForConfirm).toBe('gymbro')
+  })
+
+  it('escapes HTML in agent name in prompt', () => {
+    // valid name, but let's use one that could trip HTML — actually all valid names
+    // are alphanumeric so no HTML risk; just verify the name appears
+    const result = handleDeleteCommand('my-agent')
+    expect(result.replies[0].text).toContain('my-agent')
+    expect(result.replies[0].html).toBe(true)
+  })
+})
+
+// ─── executeDeleteAgent ───────────────────────────────────────────────────
+
+describe('foreman: executeDeleteAgent — execution', () => {
+  it('runs CLI destroy with --yes flag', () => {
+    const switchroomExec: SwitchroomExecFn = vi.fn().mockReturnValue('Removed unit.')
+    const execFile = vi.fn().mockReturnValue('')
+    const tmpDir = '/tmp/fake-agents-dir'
+
+    const result = executeDeleteAgent('gymbro', switchroomExec, execFile as never, tmpDir)
+    expect(switchroomExec).toHaveBeenCalledWith(['agent', 'destroy', '--yes', 'gymbro'])
+    expect(result.replies[0].text).toContain('gymbro')
+  })
+
+  it('reports success without archive when dir does not exist', () => {
+    const switchroomExec: SwitchroomExecFn = vi.fn().mockReturnValue('done')
+    const result = executeDeleteAgent('gymbro', switchroomExec, vi.fn() as never, '/nonexistent-agents-dir')
+    // No archive reported (dir didn't exist)
+    expect(result.replies[0].text).not.toContain('Archived')
+  })
+
+  it('rejects invalid agent name without calling CLI', () => {
+    const switchroomExec: SwitchroomExecFn = vi.fn()
+    const result = executeDeleteAgent('bad name!', switchroomExec, vi.fn() as never, '/tmp')
+    expect(result.replies[0].text).toBe('Invalid agent name.')
+    expect(switchroomExec).not.toHaveBeenCalled()
+  })
+
+  it('reports CLI error but notes archive succeeded', () => {
+    const switchroomExec: SwitchroomExecFn = vi.fn().mockImplementation(() => {
+      throw Object.assign(new Error('destroy failed'), { stderr: 'switchroom error' })
+    })
+    // Use a dir that definitely doesn't exist so no actual rename
+    const result = executeDeleteAgent('gymbro', switchroomExec, vi.fn() as never, '/nonexistent-agents-12345')
+    expect(result.replies[0].text).toContain('CLI destroy failed')
+  })
+})
+
+// ─── /update ──────────────────────────────────────────────────────────────
+
+describe('foreman: handleUpdateCommand', () => {
+  it('calls switchroomExec with ["update"]', () => {
+    const exec: SwitchroomExecFn = vi.fn().mockReturnValue('Updated successfully.')
+    handleUpdateCommand(exec)
+    expect(exec).toHaveBeenCalledWith(['update'])
+  })
+
+  it('returns output in a pre block', () => {
+    const exec: SwitchroomExecFn = vi.fn().mockReturnValue('Pulled abc123. Reconciled 2 agents.')
+    const result = handleUpdateCommand(exec)
+    expect(result.replies[0].text).toContain('Pulled abc123')
+    expect(result.replies[0].html).toBe(true)
+  })
+
+  it('returns error message when CLI throws', () => {
+    const exec: SwitchroomExecFn = vi.fn().mockImplementation(() => {
+      throw Object.assign(new Error('not a git repo'), { stderr: 'fatal: not a git repository' })
+    })
+    const result = handleUpdateCommand(exec)
+    expect(result.replies[0].text).toContain('update failed')
+  })
+
+  it('returns no-output message when CLI returns empty', () => {
+    const exec: SwitchroomExecFn = vi.fn().mockReturnValue('   \n')
+    const result = handleUpdateCommand(exec)
+    expect(result.replies[0].text).toContain('Update complete')
+  })
+
+  it('paginates output > 3 KB', () => {
+    const bigOutput = 'x'.repeat(4000)
+    const exec: SwitchroomExecFn = vi.fn().mockReturnValue(bigOutput)
+    const result = handleUpdateCommand(exec)
+    expect(result.replies.length).toBeGreaterThan(1)
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -30,6 +30,7 @@ export default defineConfig({
       "**/telegram-plugin/tests/gateway-bridge.test.ts",
       "**/telegram-plugin/tests/gateway-startup-mutex.test.ts",
       "**/telegram-plugin/tests/gateway-clean-shutdown-marker.test.ts",
+      "**/telegram-plugin/tests/foreman-state.test.ts",
     ],
     coverage: {
       provider: "v8",


### PR DESCRIPTION
## Summary

Completes Phase 3 of the Telegram-first rollout. Closes the bootstrap wall — a fresh install can now create agents end-to-end through Telegram, no terminal required.

**Destructive commands** — `/restart <agent>`, `/delete <agent>` (with 2-step inline confirm + reversible archive), `/update` (paginated installer refresh).

**Conversational `/create-agent`** — multi-turn flow with SQLite state:
- Step 1: name → validated via the Phase 3a hardened `assertSafeAgentName`
- Step 2: profile → inline keyboard selection from `switchroom profile list`
- Step 3: BotFather token → validated via `getMe()` before any disk writes
- Step 4: calls Phase 2's `createAgent()` → posts OAuth URL as inline button
- Step 5: user pastes code → `completeCreation()` → agent start → "online at @handle"
- Recovery on foreman boot: in-flight flows resume if `updated_at > now - 1hr`

**State persistence** — `~/.switchroom/foreman/state.sqlite` via `bun:sqlite`. Pure state-machine logic in `foreman-create-flow.ts` + SQLite layer in `state.ts` — both testable without grammy.

## Test plan
- [x] `bun run test:vitest` — 2812 pass / 2 skip (+60 from main)
- [x] `bun run test:bun` — 121 pass / 0 fail (+11; `foreman-state.test.ts` added to the bun-test carve-out since it uses `bun:sqlite`)
- [x] `bun run lint` — clean
- [x] New: `foreman-write-ops.test.ts` (23), `foreman-create-flow.test.ts` (37), `foreman-state.test.ts` (11)
- [ ] Manual smoke: DM `/create-agent test-agent` to a foreman bot → walk through name/profile/token/OAuth. Gated on Ken supplying a foreman bot token.

## Design notes

- `/delete` archives the agent directory (`agents/_archived_<name>_<ts>/`) before systemd disable, so deletions are reversible for ~forever until the user manually cleans up.
- SQLite chosen over in-memory Map so the flow survives foreman restarts. Without it, a restart mid-OAuth would strand the user with a scaffolded agent and no way to finish auth.
- State TTL is 1 hour — long enough for the OAuth dance, short enough that stale flows get garbage-collected.

## Deferred (deliberate)

- **Phase 4b:** callback_query handler for `op:<action>:<agent>` (the operator-events buttons shipped in Phase 4a with the decode TODO from #24). Separate PR.
- Systemd sandboxing hardening — worth doing before public rollout but not urgent for the internal fleet.
- `/update` richness (currently shells to the installer; could watch for a version changelog).

Closes Phase 3 (part of #15). Does not close #15 itself until Phase 4b lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)