### PR TITLE
feat(operator-events): Phase 4b — callback handler + IPC + history store

### DIFF
--- a/src/build-info.ts
+++ b/src/build-info.ts
@@ -3,7 +3,7 @@
 // Values are refreshed every time `npm run build` runs.
 
 export const VERSION: string = "0.2.5";
-export const COMMIT_SHA: string | null = "4d2e213";
-export const COMMIT_DATE: string | null = "2026-04-24T13:03:30+10:00";
+export const COMMIT_SHA: string | null = "635e492";
+export const COMMIT_DATE: string | null = "2026-04-25T00:31:38+10:00";
 export const LATEST_PR: number | null = null;
-export const COMMITS_AHEAD_OF_TAG: number | null = 0;
+export const COMMITS_AHEAD_OF_TAG: number | null = 13;

--- a/telegram-plugin/bridge/ipc-client.ts
+++ b/telegram-plugin/bridge/ipc-client.ts
@@ -250,6 +250,10 @@ export function createIpcClient(options: IpcClientOptions): Promise<IpcClientHan
       sendRaw(msg);
     },
 
+    sendOperatorEvent(msg: OperatorEventForward): void {
+      sendRaw(msg);
+    },
+
     isConnected(): boolean {
       return connected;
     },

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -3677,7 +3677,10 @@ async function handleOperatorEventCallback(ctx: Context, data: string): Promise<
           { parse_mode: 'HTML' },
         )
       } catch (err) {
-        await ctx.reply(`<b>logs failed:</b> ${(err as Error).message}`)
+        await ctx.reply(
+          `<b>logs failed:</b> ${escapeHtmlForTg((err as Error).message)}`,
+          { parse_mode: 'HTML' },
+        )
       }
       return
     }

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -3590,6 +3590,110 @@ function resolveAgentDirForName(agent: string): string | null {
  * callback_data, runs the matching action, acknowledges the tap with a
  * toast, and refreshes the dashboard in-place via editMessageText.
  */
+/**
+ * Handle op:<action>:<encoded-agent> callbacks from operator-events.ts
+ * renderOperatorEvent(). Phase 4b — closes the "buttons do nothing" gap.
+ *
+ * Actions:
+ *   dismiss   — clear keyboard + toast
+ *   restart   — systemctl --user restart switchroom-<agent>
+ *   reauth    — delegate to runSwitchroomAuthCommand (same flow as /auth reauth)
+ *   logs      — post last 30 lines of journalctl for the agent
+ *   swap-slot, add-slot — Phase 4c will wire these; for now toast with the
+ *                         equivalent CLI command for the user to run manually.
+ */
+async function handleOperatorEventCallback(ctx: Context, data: string): Promise<void> {
+  const senderId = String(ctx.from?.id ?? '')
+  const access = loadAccess()
+  if (!access.allowFrom.includes(senderId)) {
+    await ctx.answerCallbackQuery({ text: 'Not authorized.' }).catch(() => {})
+    return
+  }
+
+  // Parse op:<action>:<encoded-agent>
+  const parts = data.slice(3).split(':', 2)  // drop "op:", then split action:agent
+  if (parts.length !== 2) {
+    await ctx.answerCallbackQuery({ text: 'Malformed operator-event callback.' }).catch(() => {})
+    return
+  }
+  const [action, encodedAgent] = parts
+  let agent: string
+  try {
+    agent = decodeURIComponent(encodedAgent)
+  } catch {
+    await ctx.answerCallbackQuery({ text: 'Bad agent name encoding.' }).catch(() => {})
+    return
+  }
+  if (!/^[a-z0-9][a-z0-9_-]{0,50}$/.test(agent)) {
+    await ctx.answerCallbackQuery({ text: 'Invalid agent name.' }).catch(() => {})
+    return
+  }
+
+  switch (action) {
+    case 'dismiss': {
+      await ctx.answerCallbackQuery({ text: 'Dismissed' }).catch(() => {})
+      await ctx.editMessageReplyMarkup({ reply_markup: { inline_keyboard: [] } }).catch(() => {})
+      return
+    }
+    case 'restart': {
+      await ctx.answerCallbackQuery({ text: `Restarting ${agent}…` }).catch(() => {})
+      try {
+        execFileSync('systemctl', ['--user', 'restart', `switchroom-${agent}`], {
+          encoding: 'utf-8',
+          timeout: 15000,
+          stdio: ['ignore', 'pipe', 'pipe'],
+        })
+        await ctx.reply(`<b>${agent}</b> restart requested.`, { parse_mode: 'HTML' })
+        await ctx.editMessageReplyMarkup({ reply_markup: { inline_keyboard: [] } }).catch(() => {})
+      } catch (err) {
+        await ctx.reply(`<b>Restart failed for ${agent}:</b>\n<pre>${(err as Error).message}</pre>`, {
+          parse_mode: 'HTML',
+        })
+      }
+      return
+    }
+    case 'reauth': {
+      await ctx.answerCallbackQuery({ text: `Starting reauth for ${agent}…` }).catch(() => {})
+      await runSwitchroomAuthCommand(ctx, ['auth', 'reauth', agent], `auth reauth ${agent}`)
+      pendingReauthFlows.set(String(ctx.chat!.id), { agent, startedAt: Date.now() })
+      return
+    }
+    case 'logs': {
+      await ctx.answerCallbackQuery({ text: 'Fetching logs…' }).catch(() => {})
+      try {
+        const out = execFileSync(
+          'journalctl',
+          ['--user', '-u', `switchroom-${agent}`, '-n', '30', '--no-pager', '--output=short-monotonic'],
+          { encoding: 'utf-8', timeout: 10000, stdio: ['ignore', 'pipe', 'pipe'] },
+        ) as string
+        const trimmed = out.trim().slice(-3500)
+        await ctx.reply(
+          trimmed
+            ? `<pre>${trimmed.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')}</pre>`
+            : `<i>No logs for ${agent}.</i>`,
+          { parse_mode: 'HTML' },
+        )
+      } catch (err) {
+        await ctx.reply(`<b>logs failed:</b> ${(err as Error).message}`)
+      }
+      return
+    }
+    case 'swap-slot':
+    case 'add-slot': {
+      await ctx.answerCallbackQuery({ text: 'Phase 4c will wire this' }).catch(() => {})
+      const cmd = action === 'swap-slot' ? `auth use ${agent} <slot-name>` : `auth add ${agent}`
+      await ctx.reply(`Phase 4c will wire ${action} buttons. Until then, run in terminal: <code>switchroom ${cmd}</code>`, {
+        parse_mode: 'HTML',
+      })
+      return
+    }
+    default: {
+      await ctx.answerCallbackQuery({ text: `Unknown action: ${action}` }).catch(() => {})
+      return
+    }
+  }
+}
+
 async function handleAuthDashboardCallback(ctx: Context): Promise<void> {
   const data = ctx.callbackQuery?.data ?? ''
   const senderId = String(ctx.from?.id ?? '')
@@ -3944,10 +4048,13 @@ bot.on('callback_query:data', async ctx => {
     return
   }
 
-  // TODO(Phase 4b): `op:<action>:<agent>` callbacks from operator-events.ts
-  // renderOperatorEvent(). Agent name is URL-encoded at emit (issue #24) —
-  // handler MUST decodeURIComponent(agent) before using the value.
-  // See telegram-plugin/operator-events.ts for the emit contract.
+  // op:<action>:<encoded-agent> callbacks from operator-events.ts
+  // renderOperatorEvent(). Agent name is URL-encoded at emit (issue #24).
+  // Actions: dismiss, restart, reauth, swap-slot, add-slot, logs.
+  if (data.startsWith('op:')) {
+    await handleOperatorEventCallback(ctx, data)
+    return
+  }
 
   // Permission request buttons.
   const m = /^perm:(allow|deny|more):([a-km-z]{5})$/.exec(data)

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -3646,7 +3646,10 @@ async function handleOperatorEventCallback(ctx: Context, data: string): Promise<
         await ctx.reply(`<b>${agent}</b> restart requested.`, { parse_mode: 'HTML' })
         await ctx.editMessageReplyMarkup({ reply_markup: { inline_keyboard: [] } }).catch(() => {})
       } catch (err) {
-        await ctx.reply(`<b>Restart failed for ${agent}:</b>\n<pre>${(err as Error).message}</pre>`, {
+        // err.message includes concatenated stderr which can contain HTML
+        // metacharacters; escape before interpolating into a <pre> block.
+        const safeMsg = escapeHtmlForTg((err as Error).message)
+        await ctx.reply(`<b>Restart failed for ${agent}:</b>\n<pre>${safeMsg}</pre>`, {
           parse_mode: 'HTML',
         })
       }

--- a/telegram-plugin/gateway/ipc-protocol.ts
+++ b/telegram-plugin/gateway/ipc-protocol.ts
@@ -88,10 +88,24 @@ export interface ScheduleRestartMessage {
   agentName: string;
 }
 
+/**
+ * Forwarded from bridge → gateway when session-tail detects a Claude API
+ * error in the JSONL transcript (Phase 4b).
+ */
+export interface OperatorEventForward {
+  type: "operator_event";
+  /** OperatorEventKind — kept as string to avoid cross-package type dep. */
+  kind: string;
+  agent: string;
+  detail: string;
+  chatId: string;
+}
+
 export type ClientToGateway =
   | RegisterMessage
   | ToolCallMessage
   | SessionEventForward
   | PermissionRequestForward
   | HeartbeatMessage
-  | ScheduleRestartMessage;
+  | ScheduleRestartMessage
+  | OperatorEventForward;

--- a/telegram-plugin/gateway/ipc-server.ts
+++ b/telegram-plugin/gateway/ipc-server.ts
@@ -3,6 +3,7 @@ import type {
   ClientToGateway,
   GatewayToClient,
   HeartbeatMessage,
+  OperatorEventForward,
   PermissionRequestForward,
   RegisterMessage,
   ScheduleRestartMessage,
@@ -20,6 +21,7 @@ export interface IpcServerOptions {
   onPermissionRequest: (client: IpcClient, msg: PermissionRequestForward) => void;
   onHeartbeat: (client: IpcClient, msg: HeartbeatMessage) => void;
   onScheduleRestart: (client: IpcClient, msg: ScheduleRestartMessage) => void;
+  onOperatorEvent?: (client: IpcClient, msg: OperatorEventForward) => void;
   log?: (msg: string) => void;
 }
 
@@ -82,6 +84,11 @@ export function validateClientMessage(msg: unknown): msg is ClientToGateway {
       return typeof m.agentName === "string" && m.agentName.length > 0;
     case "schedule_restart":
       return typeof m.agentName === "string" && m.agentName.length > 0;
+    case "operator_event":
+      return typeof m.kind === "string" && m.kind.length > 0
+        && typeof m.agent === "string" && m.agent.length > 0
+        && typeof m.detail === "string"
+        && typeof m.chatId === "string";
     default:
       return false;
   }
@@ -97,6 +104,7 @@ export function createIpcServer(options: IpcServerOptions): IpcServer {
     onPermissionRequest,
     onHeartbeat,
     onScheduleRestart,
+    onOperatorEvent,
     log = () => {},
   } = options;
 
@@ -169,6 +177,9 @@ export function createIpcServer(options: IpcServerOptions): IpcServer {
         break;
       case "schedule_restart":
         onScheduleRestart(client, msg);
+        break;
+      case "operator_event":
+        if (onOperatorEvent) onOperatorEvent(client, msg as OperatorEventForward);
         break;
       default:
         log(`unknown IPC message type from client ${client.id}: ${(msg as any).type}`);

--- a/telegram-plugin/operator-events-history.ts
+++ b/telegram-plugin/operator-events-history.ts
@@ -1,0 +1,94 @@
+/**
+ * operator-events-history.ts — short-lived in-memory history of recent
+ * OperatorEvents per agent, used by /status enrichment (Phase 4b).
+ *
+ * Design:
+ *  - Keyed by agent name.
+ *  - Stores the most recent event per agent.
+ *  - Events expire after EVENT_TTL_MS (1 hour by default).
+ *  - Zero persistence — intentionally volatile; survives gateway restarts
+ *    only as long as the process lives. /status shows last event if fresh.
+ */
+
+import type { OperatorEvent } from './operator-events.js'
+
+export const EVENT_TTL_MS = 60 * 60 * 1000 // 1 hour
+
+interface StoredEvent {
+  event: OperatorEvent
+  storedAt: number
+}
+
+const store = new Map<string, StoredEvent>()
+
+/**
+ * Record the most recent OperatorEvent for an agent.
+ * Overwrites any previous event for the same agent.
+ */
+export function recordOperatorEvent(event: OperatorEvent, now: number = Date.now()): void {
+  store.set(event.agent, { event, storedAt: now })
+}
+
+/**
+ * Retrieve the most recent OperatorEvent for an agent, or null if
+ * none exists or the stored event has expired.
+ */
+export function getLastOperatorEvent(
+  agent: string,
+  now: number = Date.now(),
+  ttlMs: number = EVENT_TTL_MS,
+): OperatorEvent | null {
+  const stored = store.get(agent)
+  if (!stored) return null
+  if (now - stored.storedAt > ttlMs) {
+    store.delete(agent)
+    return null
+  }
+  return stored.event
+}
+
+/**
+ * Clear all stored events (for testing).
+ */
+export function clearOperatorEventHistory(): void {
+  store.clear()
+}
+
+/**
+ * Format a last-event line for /status display.
+ * Returns an HTML string like "  last: 🔑 credentials-expired (2m ago)"
+ * or null if no fresh event exists.
+ */
+export function formatLastEventLine(
+  agent: string,
+  now: number = Date.now(),
+  ttlMs: number = EVENT_TTL_MS,
+): string | null {
+  const ev = getLastOperatorEvent(agent, now, ttlMs)
+  if (!ev) return null
+
+  const ageSec = Math.floor((now - ev.firstSeenAt.getTime()) / 1000)
+  let age: string
+  if (ageSec < 60) {
+    age = `${ageSec}s ago`
+  } else if (ageSec < 3600) {
+    age = `${Math.floor(ageSec / 60)}m ago`
+  } else {
+    age = `${Math.floor(ageSec / 3600)}h ago`
+  }
+
+  const kindIcon = EVENT_KIND_ICON[ev.kind] ?? '⚪'
+  return `  <i>last: ${kindIcon} ${ev.kind} (${age})</i>`
+}
+
+const EVENT_KIND_ICON: Record<string, string> = {
+  'credentials-expired': '🔑',
+  'credentials-invalid': '🔑',
+  'credit-exhausted': '💳',
+  'quota-exhausted': '⚠️',
+  'rate-limited': '🚦',
+  'agent-crashed': '💥',
+  'agent-restarted-unexpectedly': '🔄',
+  'unknown-4xx': '⚠️',
+  'unknown-5xx': '🔥',
+}

--- a/telegram-plugin/tests/operator-events-history.test.ts
+++ b/telegram-plugin/tests/operator-events-history.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Tests for telegram-plugin/operator-events-history.ts — in-memory
+ * per-agent OperatorEvent TTL store used by /status enrichment.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  recordOperatorEvent,
+  getLastOperatorEvent,
+  clearOperatorEventHistory,
+  formatLastEventLine,
+  EVENT_TTL_MS,
+} from '../operator-events-history.js'
+import type { OperatorEvent } from '../operator-events.js'
+
+function makeEvent(agent: string, kind: OperatorEvent['kind'] = 'credentials-expired'): OperatorEvent {
+  return {
+    kind,
+    agent,
+    detail: `test detail for ${agent}`,
+    suggestedActions: [],
+    firstSeenAt: new Date('2026-04-24T12:00:00Z'),
+  }
+}
+
+describe('operator-events-history', () => {
+  beforeEach(() => {
+    clearOperatorEventHistory()
+  })
+
+  describe('recordOperatorEvent + getLastOperatorEvent', () => {
+    it('stores and retrieves the last event per agent', () => {
+      const ev = makeEvent('gymbro')
+      recordOperatorEvent(ev)
+      expect(getLastOperatorEvent('gymbro')).toEqual(ev)
+    })
+
+    it('returns null for unknown agents', () => {
+      expect(getLastOperatorEvent('unknown')).toBeNull()
+    })
+
+    it('overwrites a previous event for the same agent', () => {
+      recordOperatorEvent(makeEvent('gymbro', 'credentials-expired'))
+      const latest = makeEvent('gymbro', 'rate-limited')
+      recordOperatorEvent(latest)
+      expect(getLastOperatorEvent('gymbro')).toEqual(latest)
+    })
+
+    it('keeps separate slots per agent', () => {
+      const a = makeEvent('gymbro', 'credentials-expired')
+      const b = makeEvent('clerk', 'rate-limited')
+      recordOperatorEvent(a)
+      recordOperatorEvent(b)
+      expect(getLastOperatorEvent('gymbro')).toEqual(a)
+      expect(getLastOperatorEvent('clerk')).toEqual(b)
+    })
+  })
+
+  describe('TTL expiry', () => {
+    it('returns null when the stored event is older than TTL', () => {
+      const now = 1_000_000
+      recordOperatorEvent(makeEvent('gymbro'), now)
+      const future = now + EVENT_TTL_MS + 1
+      expect(getLastOperatorEvent('gymbro', future)).toBeNull()
+    })
+
+    it('returns the event when exactly at TTL boundary', () => {
+      const now = 1_000_000
+      recordOperatorEvent(makeEvent('gymbro'), now)
+      expect(getLastOperatorEvent('gymbro', now + EVENT_TTL_MS)).not.toBeNull()
+    })
+
+    it('evicts expired events from the map on read', () => {
+      const now = 1_000_000
+      recordOperatorEvent(makeEvent('gymbro'), now)
+      const future = now + EVENT_TTL_MS + 1
+      getLastOperatorEvent('gymbro', future) // triggers eviction
+      // Now a fresh read at `now` should still miss (row was evicted)
+      expect(getLastOperatorEvent('gymbro', now)).toBeNull()
+    })
+
+    it('honors a custom TTL', () => {
+      const now = 1_000_000
+      recordOperatorEvent(makeEvent('gymbro'), now)
+      const ttl = 60_000 // 1 min
+      expect(getLastOperatorEvent('gymbro', now + ttl - 1, ttl)).not.toBeNull()
+      expect(getLastOperatorEvent('gymbro', now + ttl + 1, ttl)).toBeNull()
+    })
+  })
+
+  describe('clearOperatorEventHistory', () => {
+    it('drops all stored events', () => {
+      recordOperatorEvent(makeEvent('gymbro'))
+      recordOperatorEvent(makeEvent('clerk'))
+      clearOperatorEventHistory()
+      expect(getLastOperatorEvent('gymbro')).toBeNull()
+      expect(getLastOperatorEvent('clerk')).toBeNull()
+    })
+  })
+
+  describe('formatLastEventLine', () => {
+    it('returns null for agents with no event', () => {
+      expect(formatLastEventLine('unknown')).toBeNull()
+    })
+
+    it('renders a single-line summary for fresh events', () => {
+      recordOperatorEvent(makeEvent('gymbro', 'credentials-expired'))
+      const line = formatLastEventLine('gymbro')
+      expect(line).toContain('credentials-expired')
+    })
+
+    it('includes an age string', () => {
+      recordOperatorEvent(makeEvent('gymbro', 'rate-limited'))
+      const line = formatLastEventLine('gymbro')
+      expect(line).toMatch(/\((\d+[smh]) ago\)/)
+    })
+
+    it('returns null for expired events', () => {
+      const now = 1_000_000
+      recordOperatorEvent(makeEvent('gymbro'), now)
+      const future = now + EVENT_TTL_MS + 1
+      expect(formatLastEventLine('gymbro', future)).toBeNull()
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Closes the "buttons do nothing" gap from Phase 4a and lays foundations for `/status` enrichment.

- **Gateway callback handler** for `op:<action>:<encoded-agent>` — dispatches the six actions that `renderOperatorEvent` produces. URL-decodes and validates agent name. Allowlist-gated.
  - `dismiss` / `restart` / `reauth` / `logs` — fully wired
  - `swap-slot` / `add-slot` — Phase 4c stubs (reply with the equivalent CLI command for now)
- **`operator-events-history.ts`** — in-memory per-agent TTL store (1 hour). Ready for Phase 4c `/status` enrichment.
- **IPC protocol extension** — `OperatorEventForward` message shape + server-side handler. Client-side sender (Claude bridge → gateway) is Phase 4c.

## Why the partial scope

The original Phase 4b brief covered callback + IPC wiring + systemd watchdog + `/status` enrichment in one PR. That was too wide; this PR ships the foundations + the most user-visible piece (callbacks actually doing something). Phase 4c wires the rest:
- `sendOperatorEvent` in `ipc-client.ts` + session-tail call site
- Systemd uptime watchdog for `agent-restarted-unexpectedly`
- `formatLastEventLine` integration into foreman's `buildFleetSummary`
- Full `swap-slot` / `add-slot` dispatch

## Test plan
- [x] `bun run test:vitest` — 2825 pass / 2 skip (+13 from main)
- [x] `bun run test:bun` — 121 pass / 0 fail
- [x] `bun run lint` — clean
- [x] New `operator-events-history.test.ts`: 13 tests covering record/recall, TTL boundary, eviction, per-agent isolation, custom TTL, `formatLastEventLine` rendering.
- [ ] Handler tests deferred — grammy Context mocking is heavy; will add as integration tests in Phase 4c alongside the client-side IPC sender.

## Notes

- Re-uses the existing `runSwitchroomAuthCommand` + `pendingReauthFlows` for `reauth`, so the Phase 1 reauth flow (URL + ForceReply + code) works unchanged.
- The `dismiss` action edits the message to strip the keyboard so users can't re-trigger after dismissal.

Part of #16. Does not close it — Phase 4c above remains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)