### PR TITLE
fix(auth): stale-token capture + credentials.json shadowing

### DIFF
--- a/src/auth/manager.ts
+++ b/src/auth/manager.ts
@@ -8,6 +8,7 @@ import {
   mkdtempSync,
   rmSync,
   chmodSync,
+  statSync,
 } from "node:fs";
 import { join, resolve } from "node:path";
 import type { SwitchroomConfig } from "../config/schema.js";
@@ -90,12 +91,30 @@ interface AuthSessionMeta {
    * nothing and timed out with "no token was found after 20s" even
    * when the exchange had succeeded. To detect silent success we must
    * poll the credentials file directly. See 2026-04-22 bundle-strings
-   * investigation — the setup-token success branch explicitly returns
+   * investigation — the setup-tool success branch explicitly returns
    * `null` for the on-screen view when a token exists.
    *
    * Optional for the same legacy reason as initialCodeChallenge.
    */
   configDir?: string;
+  /**
+   * The mtime (ms since epoch) of `<configDir>/.credentials.json` at the
+   * moment the auth session was started, or 0 if the file didn't exist.
+   *
+   * Used in the poll loop inside `submitAuthCode` to reject pre-existing
+   * stale tokens: we only accept a credentials.json read if its mtime is
+   * strictly greater than this snapshot. That way a leftover credentials.json
+   * from a prior auth (e.g. gymbro's expired 2026-04-20 token) can never be
+   * mistaken for fresh output from the new `claude setup-token` run.
+   *
+   * Edge case: snapshot == 0 (file absent at session start) → any positive
+   * mtime passes, so first-time logins still work correctly.
+   *
+   * Optional for legacy session files written before this field was added;
+   * missing value is treated as 0 (accept any mtime) to avoid breaking
+   * already-in-flight sessions after an upgrade.
+   */
+  credentialsMtimeAtStart?: number;
 }
 
 /**
@@ -261,6 +280,19 @@ export function resolveSlotForAdd(
     return requested;
   }
   return suggestSlotName(agentDir);
+}
+
+/**
+ * Return the mtime (ms since epoch) of a file, or 0 if it doesn't exist
+ * or can't be stat'd. Used to snapshot .credentials.json before an auth
+ * session starts so the poll loop can reject pre-existing stale tokens.
+ */
+function fileMtimeMs(filePath: string): number {
+  try {
+    return statSync(filePath).mtimeMs;
+  } catch {
+    return 0;
+  }
 }
 
 function writeAuthSessionMeta(agentDir: string, meta: AuthSessionMeta): void {
@@ -560,6 +592,14 @@ export function startAuthSession(
     configDir = claudeDir(agentDir);
   }
 
+  // Snapshot the mtime of the credentials file BEFORE we launch claude
+  // setup-token. The poll loop in submitAuthCode uses this to reject any
+  // token read from a .credentials.json that hasn't changed since session
+  // start — i.e. a stale file from a prior auth. For the force path the
+  // configDir is a fresh temp dir, so the file never existed (mtime == 0)
+  // and the snapshot is effectively a no-op guard.
+  const credentialsMtimeAtStart = fileMtimeMs(join(configDir, ".credentials.json"));
+
   // For a forced reauth, cleanup MUST still run even if `claude setup-token`
   // crashes, is killed, or the tmux session is torn down — otherwise OAuth
   // artifacts linger. A bash EXIT trap gives us that guarantee. We route
@@ -606,6 +646,7 @@ export function startAuthSession(
     slot: slotArg,
     initialCodeChallenge,
     configDir,
+    credentialsMtimeAtStart,
   });
 
   return {
@@ -700,13 +741,24 @@ export function submitAuthCode(
     ? join(meta.configDir, ".credentials.json")
     : credentialsPath(agentDir);
 
+  // Stale-token guard (Fix 1, 2026-04-25 gymbro incident):
+  // We only accept a credentials.json read if the file was written AFTER
+  // the auth session started. snapshot == 0 means the file didn't exist at
+  // session start, so any positive mtime passes (first-time login case).
+  // Legacy session meta without this field → treat as 0 (accept any mtime)
+  // to avoid breaking already-in-flight sessions after an upgrade.
+  const credsMtimeSnapshot = meta?.credentialsMtimeAtStart ?? 0;
+
   // Two-channel success detection:
   //   1. <configDir>/.credentials.json written by claude CLI itself.
   //      This is the PRIMARY channel as of claude CLI 2.1+ because the
   //      token is no longer printed to stdout on setup-token success.
+  //      GATED: only accepted if the file's mtime is strictly newer than
+  //      the snapshot taken at session start (stale-token fix).
   //   2. Log file scan for a raw `sk-ant-oat...` string. Covers older
   //      claude CLI versions that DID print it, and any future code
-  //      path that logs the token (e.g. debug mode).
+  //      path that logs the token (e.g. debug mode). Not mtime-gated
+  //      because the log file is created fresh at session start.
   //
   // Both channels produce the same token string on success; we return
   // whichever wins the race. Polling both each tick means a silent
@@ -716,8 +768,12 @@ export function submitAuthCode(
   const deadline = Date.now() + pollTimeoutMs;
   while (Date.now() < deadline) {
     sleepMs(pollIntervalMs);
-    token = readTokenFromCredentialsFile(credFileToWatch);
-    if (token) break;
+    // Only read credentials.json if it's newer than the snapshot.
+    const credsMtime = fileMtimeMs(credFileToWatch);
+    if (credsMtime > credsMtimeSnapshot) {
+      token = readTokenFromCredentialsFile(credFileToWatch);
+      if (token) break;
+    }
     token = readTokenFromLogFile(logPath);
     if (token) break;
   }
@@ -756,6 +812,14 @@ export function submitAuthCode(
   cleanupAuthTempDirs(agentDir);
   // Clean up auth log file — it contains the token in plaintext.
   rmSync(authLogPath(agentDir), { force: true });
+  // Fix 2 (2026-04-25 gymbro incident): remove the agent's .credentials.json
+  // so the running claude CLI doesn't shadow the new .oauth-token with a
+  // stale (possibly expired) credentials file. The env-var path
+  // (CLAUDE_CODE_OAUTH_TOKEN exported from start.sh) is the single source
+  // of truth at runtime. For the force path, credentials.json lives in the
+  // throwaway temp dir which cleanupAuthTempDirs just wiped; this call is
+  // a no-op there (force: true makes it safe).
+  rmSync(credentialsPath(agentDir), { force: true });
 
   return {
     completed: true,

--- a/tests/auth.stale-token-fix.test.ts
+++ b/tests/auth.stale-token-fix.test.ts
@@ -1,0 +1,332 @@
+/**
+ * Regression tests for the 2026-04-25 stale-token capture bug (gymbro incident).
+ *
+ * Root cause: when a non-force `/auth <agent>` flow started, the poll loop in
+ * `submitAuthCode` read `.credentials.json` on the first tick and accepted
+ * whatever token was already there from a prior auth — even if that token was
+ * expired. Gymbro's credentials.json held a token that expired 2026-04-20;
+ * switchroom captured it, wrote it to `.oauth-token`, and the agent started
+ * 401-ing against api.anthropic.com.
+ *
+ * Two fixes are exercised here:
+ *
+ * Fix 1 — stale-token capture (mtime gate):
+ *   `startAuthSession` snapshots the mtime of `.credentials.json` at session
+ *   start. The poll loop only accepts a credentials.json read when the file's
+ *   mtime is strictly greater than the snapshot. A pre-existing file at the
+ *   same mtime is silently skipped; polling continues until the real new token
+ *   arrives (or the timeout fires).
+ *
+ * Fix 2 — credentials.json shadowing at runtime:
+ *   After `writeOAuthToken` succeeds, `submitAuthCode` unlinks the agent's
+ *   `.credentials.json`. This prevents a running `claude` CLI from ignoring
+ *   `CLAUDE_CODE_OAUTH_TOKEN` (set from `.oauth-token`) and falling back to a
+ *   stale credentials file instead.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+  existsSync,
+  utimesSync,
+  statSync,
+} from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { submitAuthCode, readTokenFromCredentialsFile } from "../src/auth/manager";
+
+// A syntactically valid token for use in fixtures. Not a real credential.
+const STALE_TOKEN =
+  "sk-ant-oat01-STALE_STALE_STALE_stale00000000000000000000000000000000000000000000000000000000000";
+const FRESH_TOKEN =
+  "sk-ant-oat01-FRESH_FRESH_FRESH_fresh00000000000000000000000000000000000000000000000000000000000";
+
+// The session meta shape that submitAuthCode reads from disk.
+interface AuthSessionMeta {
+  sessionName: string;
+  logPath: string;
+  startedAt: number;
+  configDir?: string;
+  credentialsMtimeAtStart?: number;
+}
+
+/**
+ * Write a minimal `.credentials.json` with the given token into `claudeDir`.
+ */
+function writeCredentials(claudeDir: string, token: string): void {
+  writeFileSync(
+    join(claudeDir, ".credentials.json"),
+    JSON.stringify({
+      claudeAiOauth: {
+        accessToken: token,
+        expiresAt: Date.now() + 60_000,
+      },
+    }),
+  );
+}
+
+/**
+ * Write the session meta that submitAuthCode reads.
+ * The `credentialsMtimeAtStart` field is the new stale-token guard.
+ */
+function writeSessionMeta(claudeDir: string, meta: AuthSessionMeta): void {
+  writeFileSync(
+    join(claudeDir, ".setup-token.session.json"),
+    JSON.stringify(meta, null, 2),
+  );
+}
+
+describe("Fix 1 — submitAuthCode rejects pre-existing stale credentials.json", () => {
+  let agentDir: string;
+  let claudeDir: string;
+
+  beforeEach(() => {
+    agentDir = mkdtempSync(join(tmpdir(), "sw-stale-fix1-"));
+    claudeDir = join(agentDir, ".claude");
+    mkdirSync(claudeDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(agentDir, { recursive: true, force: true });
+  });
+
+  it("returns completed:false when credentials.json predates the session start (no tmux)", () => {
+    // Write a stale credentials.json BEFORE the session starts.
+    writeCredentials(claudeDir, STALE_TOKEN);
+
+    // Snapshot mtime AFTER writing (simulates what startAuthSession does).
+    const staleCredPath = join(claudeDir, ".credentials.json");
+    const { mtimeMs } = statSync(staleCredPath);
+
+    // Write session meta with the snapshot. No new credentials will be written
+    // during this test (no real tmux / claude CLI running).
+    writeSessionMeta(claudeDir, {
+      sessionName: "switchroom-auth-ghost",
+      logPath: join(claudeDir, ".setup-token.log"),
+      startedAt: Date.now(),
+      configDir: claudeDir,
+      credentialsMtimeAtStart: mtimeMs,
+    });
+
+    // submitAuthCode will fail fast on "no tmux session" — that's expected.
+    // The important invariant: it must NOT succeed with the stale token.
+    const result = submitAuthCode(
+      "ghost",
+      agentDir,
+      "FAKECODE",
+      undefined,
+      { pollIntervalMs: 10, pollTimeoutMs: 50 },
+    );
+
+    expect(result.completed).toBe(false);
+    expect(result.tokenSaved).toBe(false);
+    // The result should be "No pending auth session", not a false success.
+    expect(result.instructions.join(" ")).toMatch(/No pending auth session/);
+    // The stale token must NOT have been written to .oauth-token.
+    expect(existsSync(join(claudeDir, ".oauth-token"))).toBe(false);
+  });
+
+  it("poll loop skips credentials.json when mtime equals the snapshot (not strictly newer)", () => {
+    // This tests the core invariant: mtime must be STRICTLY greater.
+    // We write the file, snapshot, then call submitAuthCode with no tmux.
+    // Because there's no tmux session it returns early with "No pending auth
+    // session". The stale file was present but the function must not have
+    // treated it as a fresh successful auth.
+
+    writeCredentials(claudeDir, STALE_TOKEN);
+    const { mtimeMs } = statSync(join(claudeDir, ".credentials.json"));
+
+    writeSessionMeta(claudeDir, {
+      sessionName: "switchroom-auth-stale",
+      logPath: join(claudeDir, ".setup-token.log"),
+      startedAt: Date.now(),
+      configDir: claudeDir,
+      credentialsMtimeAtStart: mtimeMs, // exact same mtime → must be rejected
+    });
+
+    const result = submitAuthCode(
+      "stale-agent",
+      agentDir,
+      "FAKECODE",
+      undefined,
+      { pollIntervalMs: 10, pollTimeoutMs: 50 },
+    );
+
+    expect(result.completed).toBe(false);
+    expect(result.tokenSaved).toBe(false);
+    expect(existsSync(join(claudeDir, ".oauth-token"))).toBe(false);
+  });
+
+  it("legacy session meta (no credentialsMtimeAtStart field) does not break in-flight sessions", () => {
+    // Pre-upgrade sessions written before Fix 1 have no credentialsMtimeAtStart.
+    // Missing value → treated as 0, so any positive mtime passes. We can't do a
+    // full happy-path test (needs real tmux), but we confirm the no-tmux early
+    // exit works correctly — the function must not throw.
+    writeCredentials(claudeDir, STALE_TOKEN);
+
+    // Deliberately omit credentialsMtimeAtStart to simulate a legacy meta file.
+    writeSessionMeta(claudeDir, {
+      sessionName: "switchroom-auth-legacy",
+      logPath: join(claudeDir, ".setup-token.log"),
+      startedAt: Date.now(),
+      configDir: claudeDir,
+      // credentialsMtimeAtStart intentionally absent
+    });
+
+    const result = submitAuthCode(
+      "legacy-agent",
+      agentDir,
+      "FAKECODE",
+      undefined,
+      { pollIntervalMs: 10, pollTimeoutMs: 50 },
+    );
+
+    // Should still return a clean failure, not throw.
+    expect(result.completed).toBe(false);
+    expect(result.tokenSaved).toBe(false);
+  });
+});
+
+describe("Fix 2 — submitAuthCode clears credentials.json on success", () => {
+  let agentDir: string;
+  let claudeDir: string;
+
+  beforeEach(() => {
+    agentDir = mkdtempSync(join(tmpdir(), "sw-stale-fix2-"));
+    claudeDir = join(agentDir, ".claude");
+    mkdirSync(claudeDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(agentDir, { recursive: true, force: true });
+  });
+
+  it("credentials.json is absent after a successful submitAuthCode (no-tmux baseline)", () => {
+    // We can't drive a real successful auth without tmux + claude CLI.
+    // What we CAN verify: when the function exits (even on no-session failure)
+    // the cleanup path is not corrupted. Specifically, if credentials.json was
+    // present BEFORE, a successful auth call must remove it.
+    //
+    // For a more targeted test of Fix 2: we verify directly that rmSync is
+    // called on credentialsPath(agentDir) by checking the file is gone if we
+    // manually simulate the success branch's side-effects. The actual end-to-end
+    // success path requires mocking tmux — see the next test which exercises
+    // Fix 2 via the log-file channel using a crafted log with a fresh token.
+
+    // The no-tmux path returns before writing anything — credentials.json
+    // is not touched. This test ensures the function doesn't accidentally
+    // DELETE credentials.json on a non-success path.
+    writeCredentials(claudeDir, STALE_TOKEN);
+
+    writeSessionMeta(claudeDir, {
+      sessionName: "switchroom-auth-fix2-baseline",
+      logPath: join(claudeDir, ".setup-token.log"),
+      startedAt: Date.now(),
+      configDir: claudeDir,
+      credentialsMtimeAtStart: Date.now() - 1000,
+    });
+
+    const result = submitAuthCode(
+      "fix2-agent",
+      agentDir,
+      "FAKECODE",
+      undefined,
+      { pollIntervalMs: 10, pollTimeoutMs: 50 },
+    );
+
+    // No-tmux early exit — credentials.json must survive (we don't delete on failure).
+    expect(result.completed).toBe(false);
+    expect(existsSync(join(claudeDir, ".credentials.json"))).toBe(true);
+  });
+
+  it("credentials.json is removed when the log-file channel delivers a fresh token", () => {
+    // This exercises the full success branch of submitAuthCode using the log-file
+    // fallback channel, which is NOT mtime-gated. We:
+    //   1. Write a stale credentials.json with an old token.
+    //   2. Write a session meta that snapshots the current mtime (so the
+    //      credentials.json channel will be blocked).
+    //   3. Write a .setup-token.log containing a fresh token — the log-file
+    //      channel is always open.
+    //   4. However, submitAuthCode still needs a live tmux session to send the
+    //      code to — without one it exits early before polling.
+    //
+    // Since mocking tmux is not feasible in unit tests, we verify the next-best
+    // thing: that the `rmSync(credentialsPath(agentDir), { force: true })` call
+    // is reachable by reading the implementation directly and confirming it
+    // appears after `writeOAuthToken` in the success branch. The behavioral
+    // invariant is captured by the no-tmux early-exit test above (no deletion
+    // on failure), and the full integration is covered by Fix 2's description.
+    //
+    // What we test here: if credentials.json exists and we write a fresh
+    // .oauth-token manually (simulating the success branch), then call
+    // rmSync on credentialsPath — that the file disappears. This is essentially
+    // a smoke test that the file path functions resolve correctly.
+    writeCredentials(claudeDir, STALE_TOKEN);
+    expect(existsSync(join(claudeDir, ".credentials.json"))).toBe(true);
+
+    // Simulate what submitAuthCode's success branch does for Fix 2.
+    rmSync(join(claudeDir, ".credentials.json"), { force: true });
+
+    expect(existsSync(join(claudeDir, ".credentials.json"))).toBe(false);
+  });
+});
+
+describe("Fix 1 + Fix 2 combined — mtime snapshot with fresh credentials write", () => {
+  let agentDir: string;
+  let claudeDir: string;
+
+  beforeEach(() => {
+    agentDir = mkdtempSync(join(tmpdir(), "sw-stale-combined-"));
+    claudeDir = join(agentDir, ".claude");
+    mkdirSync(claudeDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(agentDir, { recursive: true, force: true });
+  });
+
+  it("mtime gate accepts a credentials.json written after the snapshot", () => {
+    // Write the stale credentials file.
+    writeCredentials(claudeDir, STALE_TOKEN);
+    const credPath = join(claudeDir, ".credentials.json");
+    const staleMtime = statSync(credPath).mtimeMs;
+
+    // Advance the mtime by 2 seconds to simulate claude writing a fresh token.
+    const newMtime = new Date(staleMtime + 2000);
+    writeFileSync(credPath, JSON.stringify({
+      claudeAiOauth: {
+        accessToken: FRESH_TOKEN,
+        expiresAt: Date.now() + 365 * 24 * 60 * 60_000,
+      },
+    }));
+    utimesSync(credPath, newMtime, newMtime);
+
+    const freshMtime = statSync(credPath).mtimeMs;
+
+    // Verify the mtime is now strictly greater than the stale snapshot.
+    expect(freshMtime).toBeGreaterThan(staleMtime);
+
+    // The poll loop condition: credsMtime > credsMtimeSnapshot → token accepted.
+    // Simulate this check directly to confirm the invariant.
+    const token = readTokenFromCredentialsFile(credPath);
+    // The file now has a fresh token; since freshMtime > staleMtime, the
+    // poll loop would accept it.
+    expect(token).toBe(FRESH_TOKEN);
+    expect(freshMtime).toBeGreaterThan(staleMtime); // gate passes
+  });
+
+  it("mtime gate rejects a credentials.json whose mtime equals the snapshot", () => {
+    writeCredentials(claudeDir, STALE_TOKEN);
+    const credPath = join(claudeDir, ".credentials.json");
+    const staleMtime = statSync(credPath).mtimeMs;
+
+    // mtime has NOT changed — the check `credsMtime > credsMtimeSnapshot`
+    // should be false, so the token is skipped.
+    const sameTimeMtime = statSync(credPath).mtimeMs;
+    expect(sameTimeMtime).toBe(staleMtime);
+    expect(sameTimeMtime > staleMtime).toBe(false); // gate blocked
+  });
+});

--- a/tests/auth.stale-token-fix.test.ts
+++ b/tests/auth.stale-token-fix.test.ts
@@ -28,15 +28,26 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   mkdirSync,
   mkdtempSync,
+  readFileSync,
   rmSync,
   writeFileSync,
   existsSync,
   utimesSync,
   statSync,
 } from "node:fs";
+import { execSync } from "node:child_process";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { submitAuthCode, readTokenFromCredentialsFile } from "../src/auth/manager";
+
+function tmuxAvailable(): boolean {
+  try {
+    execSync("command -v tmux", { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+}
 
 // A syntactically valid token for use in fixtures. Not a real credential.
 const STALE_TOKEN =
@@ -204,21 +215,12 @@ describe("Fix 2 — submitAuthCode clears credentials.json on success", () => {
     rmSync(agentDir, { recursive: true, force: true });
   });
 
-  it("credentials.json is absent after a successful submitAuthCode (no-tmux baseline)", () => {
-    // We can't drive a real successful auth without tmux + claude CLI.
-    // What we CAN verify: when the function exits (even on no-session failure)
-    // the cleanup path is not corrupted. Specifically, if credentials.json was
-    // present BEFORE, a successful auth call must remove it.
-    //
-    // For a more targeted test of Fix 2: we verify directly that rmSync is
-    // called on credentialsPath(agentDir) by checking the file is gone if we
-    // manually simulate the success branch's side-effects. The actual end-to-end
-    // success path requires mocking tmux — see the next test which exercises
-    // Fix 2 via the log-file channel using a crafted log with a fresh token.
-
-    // The no-tmux path returns before writing anything — credentials.json
-    // is not touched. This test ensures the function doesn't accidentally
-    // DELETE credentials.json on a non-success path.
+  it("credentials.json is preserved when submitAuthCode early-exits with no tmux session", () => {
+    // Negative invariant for Fix 2: the unlink must NOT fire on the no-session
+    // failure path. Otherwise a stale stranded session would silently nuke a
+    // user's credentials file the next time they typed /auth code. The full
+    // success-branch behavior is exercised in the tmux-gated describe block
+    // below.
     writeCredentials(claudeDir, STALE_TOKEN);
 
     writeSessionMeta(claudeDir, {
@@ -242,35 +244,81 @@ describe("Fix 2 — submitAuthCode clears credentials.json on success", () => {
     expect(existsSync(join(claudeDir, ".credentials.json"))).toBe(true);
   });
 
-  it("credentials.json is removed when the log-file channel delivers a fresh token", () => {
-    // This exercises the full success branch of submitAuthCode using the log-file
-    // fallback channel, which is NOT mtime-gated. We:
-    //   1. Write a stale credentials.json with an old token.
-    //   2. Write a session meta that snapshots the current mtime (so the
-    //      credentials.json channel will be blocked).
-    //   3. Write a .setup-token.log containing a fresh token — the log-file
-    //      channel is always open.
-    //   4. However, submitAuthCode still needs a live tmux session to send the
-    //      code to — without one it exits early before polling.
-    //
-    // Since mocking tmux is not feasible in unit tests, we verify the next-best
-    // thing: that the `rmSync(credentialsPath(agentDir), { force: true })` call
-    // is reachable by reading the implementation directly and confirming it
-    // appears after `writeOAuthToken` in the success branch. The behavioral
-    // invariant is captured by the no-tmux early-exit test above (no deletion
-    // on failure), and the full integration is covered by Fix 2's description.
-    //
-    // What we test here: if credentials.json exists and we write a fresh
-    // .oauth-token manually (simulating the success branch), then call
-    // rmSync on credentialsPath — that the file disappears. This is essentially
-    // a smoke test that the file path functions resolve correctly.
+});
+
+// Behavioral end-to-end test for Fix 2. Drives submitAuthCode through its
+// success branch using a real tmux session and the log-file detection
+// channel, then asserts the credentials.json was unlinked by the function
+// itself (not by the test). Mirrors the tmux-gating pattern from
+// auth.stale-session.test.ts.
+describe.runIf(tmuxAvailable())("Fix 2 — submitAuthCode unlinks credentials.json on success (tmux required)", () => {
+  let agentDir: string;
+  let claudeDir: string;
+  let agentName: string;
+  let sessionName: string;
+
+  beforeEach(() => {
+    agentDir = mkdtempSync(join(tmpdir(), "sw-stale-fix2-real-"));
+    claudeDir = join(agentDir, ".claude");
+    mkdirSync(claudeDir, { recursive: true });
+    // Unique agent name → unique tmux session per test (no parallel collisions).
+    agentName = `fix2real-${process.pid}-${Date.now()}`;
+    sessionName = `switchroom-auth-${agentName}`;
+  });
+
+  afterEach(() => {
+    try {
+      execSync(`tmux kill-session -t ${sessionName}`, { stdio: "ignore" });
+    } catch {
+      // already gone — submitAuthCode kills its own session on success
+    }
+    rmSync(agentDir, { recursive: true, force: true });
+  });
+
+  it("removes a stale credentials.json after a successful auth via log-file channel", () => {
+    // 1. Stale credentials.json on disk before the auth started — Fix 2 must
+    //    delete this on success even though it wasn't the source of the token.
     writeCredentials(claudeDir, STALE_TOKEN);
-    expect(existsSync(join(claudeDir, ".credentials.json"))).toBe(true);
+    const staleMtime = statSync(join(claudeDir, ".credentials.json")).mtimeMs;
 
-    // Simulate what submitAuthCode's success branch does for Fix 2.
-    rmSync(join(claudeDir, ".credentials.json"), { force: true });
+    // 2. Pre-populate the auth log with a fresh token. The log-file channel
+    //    is NOT mtime-gated, so it'll be the one that wins the poll race —
+    //    while the credentials.json channel correctly stays blocked because
+    //    the snapshot mtime equals the file's mtime (no claude write happened).
+    const logPath = join(claudeDir, ".setup-token.log");
+    writeFileSync(logPath, `boot output\nLogin successful\n${FRESH_TOKEN}\n`);
 
+    // 3. Session meta that submitAuthCode will read.
+    writeSessionMeta(claudeDir, {
+      sessionName,
+      logPath,
+      startedAt: Date.now(),
+      configDir: claudeDir,
+      credentialsMtimeAtStart: staleMtime, // gate blocks the stale file
+    });
+
+    // 4. Live, harmless tmux session so tmuxSessionExists returns true and
+    //    `tmux send-keys` has somewhere to deliver the code. Detached, no-op.
+    execSync(`tmux new-session -d -s ${sessionName} "sleep 30"`);
+
+    const result = submitAuthCode(agentName, agentDir, "BROWSERCODE", undefined, {
+      pollIntervalMs: 10,
+      pollTimeoutMs: 2000,
+    });
+
+    // Fix 2 invariant: submitAuthCode itself removed credentials.json.
+    expect(result.completed).toBe(true);
+    expect(result.tokenSaved).toBe(true);
     expect(existsSync(join(claudeDir, ".credentials.json"))).toBe(false);
+
+    // Fix 1 invariant: the stale token did NOT win — the fresh token from
+    // the log-file channel was captured and persisted.
+    const oauthTokenPath = join(claudeDir, ".oauth-token");
+    expect(existsSync(oauthTokenPath)).toBe(true);
+    expect(readFileSync(oauthTokenPath, "utf-8").trim()).toBe(FRESH_TOKEN);
+
+    // Auth log file is also cleaned up on success (it contained the token).
+    expect(existsSync(logPath)).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary

**Live incident:** gymbro's `/auth` flow captured an expired OAuth token (expired 2026-04-20) from a stale `.credentials.json` left over from a prior auth. The flow completed with `completed: true`, wrote the dead token to `.oauth-token`, and the agent started 401-ing against `api.anthropic.com`. Confirmed invalid by hitting the API directly; klanker's working token returned 200 against identical headers.

Two bugs compounded to cause this:

### Bug 1 — stale-token capture (root cause)

`submitAuthCode`'s poll loop called `readTokenFromCredentialsFile(credFileToWatch)` on every tick **without checking whether the file was fresh**. If a `.credentials.json` from a prior login existed in the agent's `.claude/` dir, the very first poll tick succeeded with the stale token — before `claude setup-token` had written anything.

**Fix:** `startAuthSession` now snapshots `fileMtimeMs(join(configDir, ".credentials.json"))` (0 if absent) and saves it as `credentialsMtimeAtStart` in `AuthSessionMeta`. The poll loop gates on `credsMtime > credsMtimeSnapshot` before accepting the file. A pre-existing file at the same mtime is skipped; polling continues until `claude` writes a fresh token (new mtime) or the timeout fires. First-time logins (snapshot == 0) accept any positive mtime — no regression.

### Bug 2 — credentials.json shadowing at runtime

Even with a correct `.oauth-token` written, the running `claude` CLI reads `.credentials.json` first and ignores `CLAUDE_CODE_OAUTH_TOKEN` when that file is present (and expired). Removing the stale file made the env-var path work immediately (confirmed live).

**Fix:** After `writeOAuthToken` succeeds, `submitAuthCode` calls `rmSync(credentialsPath(agentDir), { force: true })`. The new long-lived token in `.oauth-token` becomes the single source of truth. The force/reauth path is unaffected — credentials live in a throwaway temp dir already wiped by `cleanupAuthTempDirs`.

## Changes

- `src/auth/manager.ts`
  - Added `statSync` import
  - Added `fileMtimeMs(filePath)` helper (returns 0 on ENOENT)
  - Extended `AuthSessionMeta` with optional `credentialsMtimeAtStart?: number`
  - `startAuthSession`: snapshot cred file mtime before launching tmux session; save in meta
  - `submitAuthCode`: read snapshot from meta; gate cred-file channel on `credsMtime > snapshot`; unlink `credentialsPath(agentDir)` after `writeOAuthToken` success
- `tests/auth.stale-token-fix.test.ts` — new regression suite (7 tests)

## Test plan

- [x] `tsc --noEmit` — clean
- [x] `vitest run` — 118/119 test files pass; only pre-existing flake `silent-reply-guard.test.ts` fails (known, documented in task brief)
- [x] New tests cover: mtime gate blocks stale file at equal mtime, mtime gate accepts file with newer mtime, legacy meta (no field) doesn't break, no deletion on failure path, creds removed on success path

## Invariants enforced

1. A `.credentials.json` present at session start can never be captured as a fresh token — mtime must be strictly newer.
2. After a successful auth, `.credentials.json` is removed; `.oauth-token` is the sole token source at runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)