### PR TITLE
fix(secret-detect): redact Anthropic OAuth browser codes

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -631,6 +631,14 @@ function deferredKey(chat_id: string, message_id: number): string {
   return `${chat_id}:${message_id}`
 }
 
+// Channel B context rule — tracks when the gateway has emitted the
+// "Paste the browser code here" prompt so that the next inbound message
+// in the same chat is treated as auth-flow-sensitive regardless of whether
+// the pattern rule fires (belt-and-braces: pattern covers the known shape,
+// context rule covers future shape changes).
+const awaitingAuthCodeAt = new Map<string, number>()
+const AUTH_CODE_CONTEXT_TTL_MS = 5 * 60_000 // 5 min — OAuth code lifetime
+
 // ─── TTL reaper ───────────────────────────────────────────────────────────
 // Pending state maps above all grow whenever a flow starts and only shrink
 // when the flow completes. Users abandoning a flow (closing Telegram, losing
@@ -650,6 +658,9 @@ const pendingStateReaper = setInterval(() => {
   }
   for (const [k, v] of vaultPassphraseCache) {
     if (now > v.expiresAt) vaultPassphraseCache.delete(k)
+  }
+  for (const [k, v] of awaitingAuthCodeAt) {
+    if (now - v > AUTH_CODE_CONTEXT_TTL_MS) awaitingAuthCodeAt.delete(k)
   }
 }, 60_000)
 pendingStateReaper.unref()
@@ -2146,6 +2157,19 @@ async function handleInbound(
   // — never fall through to recordInbound/broadcast with raw bytes. See
   // gateway-secret-detect.test.ts and secret-detect-fail-closed.test.ts.
   try {
+    // Channel B context rule: if we emitted "Paste the browser code here"
+    // recently in this chat, treat the inbound as auth-flow-sensitive —
+    // high-confidence secret detection regardless of pattern match. This
+    // survives Anthropic changing their token format because it tracks the
+    // gateway's own prompt, not the token shape.
+    const authCodeSentAt = awaitingAuthCodeAt.get(chat_id)
+    const isAuthFlowContext =
+      authCodeSentAt !== undefined && Date.now() - authCodeSentAt < AUTH_CODE_CONTEXT_TTL_MS
+    if (isAuthFlowContext) {
+      awaitingAuthCodeAt.delete(chat_id) // consume: one message per prompt
+      process.stderr.write(`[secret-detect] auth-flow context rule active for chat ${chat_id}\n`)
+    }
+
     const cachedPp = vaultPassphraseCache.get(chat_id)
     const passphrase = cachedPp && cachedPp.expiresAt > Date.now() ? cachedPp.passphrase : null
     if (passphrase) {
@@ -2182,6 +2206,25 @@ async function handleInbound(
             staged_at: Date.now(),
           })
         }
+      } else if (isAuthFlowContext && pipeRes.stored.length === 0) {
+        // Channel B fallback: pattern didn't fire (Anthropic may have changed
+        // the token format) but we know this is an auth code paste because we
+        // prompted for it. Delete + stage + warn so no raw bytes leak.
+        if (msgId != null) {
+          try { await bot.api.deleteMessage(chat_id, msgId) } catch {}
+        }
+        await switchroomReply(
+          ctx,
+          '⚠️ auth-flow secret detected (context rule). the message was deleted for safety. run <code>/vault list</code> to unlock and re-paste if you need to store it.',
+          { html: true },
+        )
+        deferredSecrets.set(deferredKey(chat_id, msgId ?? 0), {
+          chat_id,
+          original_message_id: msgId ?? 0,
+          text: effectiveText,
+          staged_at: Date.now(),
+        })
+        return
       } else if (pipeRes.ambiguous.length > 0) {
         for (const d of pipeRes.ambiguous) {
           secretStaging.set({ chat_id, message_id: msgId ?? 0, detection: d, staged_at: Date.now() })
@@ -2199,7 +2242,7 @@ async function handleInbound(
       // No passphrase cached — detect, but defer. Tell the user once per
       // message so they can /vault unlock and re-paste.
       const detections = detectSecrets(effectiveText)
-      const hasHigh = detections.some((d) => d.confidence === 'high' && !d.suppressed)
+      const hasHigh = detections.some((d) => d.confidence === 'high' && !d.suppressed) || isAuthFlowContext
       if (hasHigh) {
         deferredSecrets.set(deferredKey(chat_id, msgId ?? 0), {
           chat_id,
@@ -2780,6 +2823,11 @@ async function runSwitchroomAuthCommand(ctx: Context, args: string[], label: str
         await switchroomReply(ctx, '📋 Paste the browser code here ↓', {
           reply_markup: { force_reply: true, input_field_placeholder: 'Paste browser code', selective: true },
         })
+        // Channel B context rule: record that this chat is awaiting an auth
+        // code paste so the inbound handler can treat the next message as
+        // auth-flow-sensitive even if the pattern rule misses it.
+        const authChatId = String(ctx.chat!.id)
+        awaitingAuthCodeAt.set(authChatId, Date.now())
       } catch {
         // ForceReply is UX garnish — if it fails the flow still works
         // via the pending-intercept. Don't escalate.

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -2054,6 +2054,7 @@ async function handleInbound(
         }
       }
       if (msgId != null) {
+        void bot.api.deleteMessage(chat_id, msgId).catch(() => {})
         void bot.api.setMessageReaction(chat_id, msgId, [
           { type: 'emoji', emoji: '🔑' as ReactionTypeEmoji['emoji'] },
         ]).catch(() => {})
@@ -2166,7 +2167,6 @@ async function handleInbound(
     const isAuthFlowContext =
       authCodeSentAt !== undefined && Date.now() - authCodeSentAt < AUTH_CODE_CONTEXT_TTL_MS
     if (isAuthFlowContext) {
-      awaitingAuthCodeAt.delete(chat_id) // consume: one message per prompt
       process.stderr.write(`[secret-detect] auth-flow context rule active for chat ${chat_id}\n`)
     }
 
@@ -2183,6 +2183,9 @@ async function handleInbound(
       })
       if (pipeRes.stored.length > 0) {
         effectiveText = pipeRes.rewritten_text
+        if (isAuthFlowContext) {
+          awaitingAuthCodeAt.delete(chat_id) // consume: one message per prompt
+        }
         if (msgId != null) {
           try {
             await bot.api.deleteMessage(chat_id, msgId)
@@ -2210,6 +2213,7 @@ async function handleInbound(
         // Channel B fallback: pattern didn't fire (Anthropic may have changed
         // the token format) but we know this is an auth code paste because we
         // prompted for it. Delete + stage + warn so no raw bytes leak.
+        awaitingAuthCodeAt.delete(chat_id) // consume: one message per prompt
         if (msgId != null) {
           try { await bot.api.deleteMessage(chat_id, msgId) } catch {}
         }
@@ -2244,6 +2248,9 @@ async function handleInbound(
       const detections = detectSecrets(effectiveText)
       const hasHigh = detections.some((d) => d.confidence === 'high' && !d.suppressed) || isAuthFlowContext
       if (hasHigh) {
+        if (isAuthFlowContext) {
+          awaitingAuthCodeAt.delete(chat_id) // consume: one message per prompt
+        }
         deferredSecrets.set(deferredKey(chat_id, msgId ?? 0), {
           chat_id,
           original_message_id: msgId ?? 0,
@@ -2819,15 +2826,17 @@ async function runSwitchroomAuthCommand(ctx: Context, args: string[], label: str
     // this explicitly or just type) is auto-captured by the existing
     // pendingReauthFlows intercept in the inbound-message handler.
     if (formatted.url) {
+      // Channel B context rule: arm unconditionally — record that this chat
+      // is awaiting an auth code paste so the inbound handler can treat the
+      // next message as auth-flow-sensitive even if the pattern rule misses
+      // it. Set BEFORE the ForceReply attempt so a switchroomReply throw
+      // doesn't leave Channel B unarmed.
+      const authChatId = String(ctx.chat!.id)
+      awaitingAuthCodeAt.set(authChatId, Date.now())
       try {
         await switchroomReply(ctx, '📋 Paste the browser code here ↓', {
           reply_markup: { force_reply: true, input_field_placeholder: 'Paste browser code', selective: true },
         })
-        // Channel B context rule: record that this chat is awaiting an auth
-        // code paste so the inbound handler can treat the next message as
-        // auth-flow-sensitive even if the pattern rule misses it.
-        const authChatId = String(ctx.chat!.id)
-        awaitingAuthCodeAt.set(authChatId, Date.now())
       } catch {
         // ForceReply is UX garnish — if it fails the flow still works
         // via the pending-intercept. Don't escalate.

--- a/telegram-plugin/secret-detect/patterns.ts
+++ b/telegram-plugin/secret-detect/patterns.ts
@@ -31,6 +31,15 @@ export interface PatternDef {
  */
 export const ANCHORED_PATTERNS: PatternDef[] = [
   { rule_id: 'anthropic_api_key', regex: /\b(sk-ant-[A-Za-z0-9_-]{8,})\b/g, captureIndex: 1, slugHint: 'anthropic_api_key' },
+  // Anthropic OAuth browser code — emitted by the claude.com/cai authorize
+  // flow as two URL-safe base64 segments joined by `#`. Listed before the
+  // generic anthropic_api_key rule so it wins on ties.
+  // Shape: <20+ url-safe-b64>#<20+ url-safe-b64>
+  // The 20-char minimum on each segment reliably excludes ordinary URL
+  // fragment anchors (which are always short identifiers like `#section`).
+  // The \b boundaries prevent matching inside a URL where the preceding
+  // path component would be part of a longer word.
+  { rule_id: 'anthropic_oauth_code', regex: /\b([A-Za-z0-9_-]{20,}#[A-Za-z0-9_-]{20,})\b/g, captureIndex: 1, slugHint: 'anthropic_oauth_code' },
   { rule_id: 'openai_api_key', regex: /\b(sk-[A-Za-z0-9_-]{20,})\b/g, captureIndex: 1, slugHint: 'openai_api_key' },
   { rule_id: 'github_pat_classic', regex: /\b(ghp_[A-Za-z0-9]{20,})\b/g, captureIndex: 1, slugHint: 'github_pat' },
   { rule_id: 'github_pat_fine_grained', regex: /\b(github_pat_[A-Za-z0-9_]{20,})\b/g, captureIndex: 1, slugHint: 'github_pat' },

--- a/telegram-plugin/secret-detect/patterns.ts
+++ b/telegram-plugin/secret-detect/patterns.ts
@@ -31,15 +31,17 @@ export interface PatternDef {
  */
 export const ANCHORED_PATTERNS: PatternDef[] = [
   { rule_id: 'anthropic_api_key', regex: /\b(sk-ant-[A-Za-z0-9_-]{8,})\b/g, captureIndex: 1, slugHint: 'anthropic_api_key' },
+  // anthropic_api_key precedes; the patterns don't overlap (the `#` separator
+  // isn't in api-key shape) so ordering is moot for correctness.
   // Anthropic OAuth browser code — emitted by the claude.com/cai authorize
-  // flow as two URL-safe base64 segments joined by `#`. Listed before the
-  // generic anthropic_api_key rule so it wins on ties.
+  // flow as two URL-safe base64 segments joined by `#`.
   // Shape: <20+ url-safe-b64>#<20+ url-safe-b64>
-  // The 20-char minimum on each segment reliably excludes ordinary URL
-  // fragment anchors (which are always short identifiers like `#section`).
-  // The \b boundaries prevent matching inside a URL where the preceding
-  // path component would be part of a longer word.
-  { rule_id: 'anthropic_oauth_code', regex: /\b([A-Za-z0-9_-]{20,}#[A-Za-z0-9_-]{20,})\b/g, captureIndex: 1, slugHint: 'anthropic_oauth_code' },
+  // Anchored to whitespace boundaries (^/\s before, \s/$ after) to avoid
+  // false-positives on real URLs whose path segment + fragment anchor both
+  // exceed 20 chars (e.g. GitHub headings, npm readme anchors). The bare-code
+  // paste case ("code#state" alone on a line or after prose) is the only
+  // intended match target.
+  { rule_id: 'anthropic_oauth_code', regex: /(?:^|\s)([A-Za-z0-9_-]{20,}#[A-Za-z0-9_-]{20,})(?=\s|$)/gm, captureIndex: 1, slugHint: 'anthropic_oauth_code' },
   { rule_id: 'openai_api_key', regex: /\b(sk-[A-Za-z0-9_-]{20,})\b/g, captureIndex: 1, slugHint: 'openai_api_key' },
   { rule_id: 'github_pat_classic', regex: /\b(ghp_[A-Za-z0-9]{20,})\b/g, captureIndex: 1, slugHint: 'github_pat' },
   { rule_id: 'github_pat_fine_grained', regex: /\b(github_pat_[A-Za-z0-9_]{20,})\b/g, captureIndex: 1, slugHint: 'github_pat' },

--- a/telegram-plugin/tests/secret-detect-oauth-code.test.ts
+++ b/telegram-plugin/tests/secret-detect-oauth-code.test.ts
@@ -108,12 +108,14 @@ describe('auth-flow context rule — Channel B (structural wiring in gateway.ts)
     expect(src).toMatch(/AUTH_CODE_CONTEXT_TTL_MS\s*=\s*5\s*\*\s*60_000/)
   })
 
-  it('sets awaitingAuthCodeAt when emitting the "Paste the browser code here" prompt', () => {
-    // Find the block that sends the ForceReply prompt and confirm the map.set is nearby
+  it('sets awaitingAuthCodeAt near the "Paste the browser code here" prompt (before or after)', () => {
+    // awaitingAuthCodeAt.set is armed before the ForceReply attempt so that a
+    // switchroomReply throw doesn't leave Channel B unarmed. Verify it lives
+    // within 500 chars of the prompt string in either direction.
     const promptIdx = src.indexOf("'📋 Paste the browser code here ↓'")
     expect(promptIdx).toBeGreaterThan(0)
-    // Within 500 chars after the prompt, awaitingAuthCodeAt.set must appear
-    const window = src.slice(promptIdx, promptIdx + 500)
+    const start = Math.max(0, promptIdx - 500)
+    const window = src.slice(start, promptIdx + 500)
     expect(window).toMatch(/awaitingAuthCodeAt\.set\(/)
   })
 
@@ -155,5 +157,136 @@ describe('auth-flow context rule — Channel B (structural wiring in gateway.ts)
     expect(contextIdx).toBeGreaterThan(0)
     expect(recordIdx).toBeGreaterThan(contextIdx)
     expect(broadcastIdx).toBeGreaterThan(contextIdx)
+  })
+})
+
+// ─── New tests for reviewer-requested coverage ────────────────────────────────
+
+// Test 1: Negative URL test — Channel A regex must NOT match real URLs with
+// long path segments + long fragment anchors (Blocker 2 regression test).
+describe('anthropic_oauth_code pattern — URL false-positive regression', () => {
+  it('does NOT match a URL with long path segment and long fragment (inline in sentence)', () => {
+    const text = 'see https://docs.com/getting-started-tutorial#installation-and-setup-guide for details'
+    const d = detectSecrets(text)
+    expect(d.some((h) => h.rule_id === 'anthropic_oauth_code')).toBe(false)
+  })
+
+  it('does NOT match a markdown link with long path + long anchor', () => {
+    const text = '[docs](https://docs.com/getting-started-tutorial#installation-and-setup-guide)'
+    const d = detectSecrets(text)
+    expect(d.some((h) => h.rule_id === 'anthropic_oauth_code')).toBe(false)
+  })
+
+  it('does NOT match a GitHub permalink URL (long path + long heading anchor)', () => {
+    const text = 'See https://github.com/owner/repo/blob/main/README.md#installation-and-setup-guide for info.'
+    const d = detectSecrets(text)
+    expect(d.some((h) => h.rule_id === 'anthropic_oauth_code')).toBe(false)
+  })
+})
+
+// Test 2: Blocker 1 sequencing — structural check that deleteMessage is called
+// inside the pendingReauthFlows intercept path, before setMessageReaction.
+describe('pendingReauthFlows intercept — deleteMessage sequencing (Blocker 1)', () => {
+  const src = readFileSync(
+    new URL('../gateway/gateway.ts', import.meta.url),
+    'utf8',
+  )
+
+  it('calls bot.api.deleteMessage inside the pendingReauthFlows intercept before setMessageReaction', () => {
+    // Locate the pendingReauthFlows intercept block
+    const interceptIdx = src.indexOf('// Auth-code intercept')
+    expect(interceptIdx).toBeGreaterThan(0)
+
+    // Find the reaction (🔑) that marks the end of a successful intercept
+    const reactionIdx = src.indexOf("emoji: '🔑'", interceptIdx)
+    expect(reactionIdx).toBeGreaterThan(0)
+
+    // deleteMessage must appear between the intercept start and the 🔑 reaction
+    const interceptBlock = src.slice(interceptIdx, reactionIdx)
+    expect(interceptBlock).toMatch(/bot\.api\.deleteMessage\(chat_id, msgId\)/)
+  })
+
+  it('deleteMessage appears BEFORE setMessageReaction in the pendingReauthFlows path', () => {
+    const interceptIdx = src.indexOf('// Auth-code intercept')
+    // Within a reasonable window of the intercept block, deleteMessage must precede the 🔑 reaction
+    const window = src.slice(interceptIdx, interceptIdx + 2000)
+    const deleteIdx = window.indexOf('bot.api.deleteMessage(chat_id, msgId)')
+    const reactionIdx = window.indexOf("emoji: '🔑'")
+    expect(deleteIdx).toBeGreaterThan(0)
+    expect(reactionIdx).toBeGreaterThan(0)
+    expect(deleteIdx).toBeLessThan(reactionIdx)
+  })
+})
+
+// Test 3: Flag consumption — awaitingAuthCodeAt is NOT cleared on a non-detection
+// inbound (a stray "ok" within the 5-min window should not disarm Channel B).
+describe('awaitingAuthCodeAt flag — consumption only on actual detection', () => {
+  const src = readFileSync(
+    new URL('../gateway/gateway.ts', import.meta.url),
+    'utf8',
+  )
+
+  it('delete(chat_id) does NOT appear at the top of the isAuthFlowContext block (no early consume)', () => {
+    // The old bug: delete fired unconditionally inside `if (isAuthFlowContext)`.
+    // After the fix, there must be no `awaitingAuthCodeAt.delete` within
+    // the isAuthFlowContext guard block itself — only in the downstream branches.
+    const contextIdx = src.indexOf('const isAuthFlowContext =')
+    expect(contextIdx).toBeGreaterThan(0)
+    // Grab the isAuthFlowContext if-block (ends at the next blank line after the log line)
+    const logLineEnd = src.indexOf('\n', src.indexOf('[secret-detect] auth-flow context rule active', contextIdx))
+    const guardBlock = src.slice(contextIdx, logLineEnd + 5)
+    // Must NOT contain a delete call in the guard itself
+    expect(guardBlock).not.toMatch(/awaitingAuthCodeAt\.delete/)
+  })
+
+  it('awaitingAuthCodeAt.delete appears inside the Channel B fallback branch (pipeRes.stored === 0)', () => {
+    // Verify the consume is co-located with the actual auth-flow handling
+    const fallbackIdx = src.indexOf('Channel B fallback: pattern didn\'t fire')
+    expect(fallbackIdx).toBeGreaterThan(0)
+    // Within 400 chars after the comment, delete must appear
+    const window = src.slice(fallbackIdx, fallbackIdx + 400)
+    expect(window).toMatch(/awaitingAuthCodeAt\.delete\(chat_id\)/)
+  })
+
+  it('awaitingAuthCodeAt.delete appears inside the no-passphrase hasHigh branch', () => {
+    const noPpIdx = src.indexOf('No passphrase cached — detect, but defer')
+    expect(noPpIdx).toBeGreaterThan(0)
+    const window = src.slice(noPpIdx, noPpIdx + 600)
+    // Conditional consume: only fires if isAuthFlowContext
+    expect(window).toMatch(/if \(isAuthFlowContext\)/)
+    expect(window).toMatch(/awaitingAuthCodeAt\.delete\(chat_id\)/)
+  })
+})
+
+// Test 4: Armer-outside-catch — awaitingAuthCodeAt.set is before the try block,
+// so if switchroomReply throws, Channel B is still armed.
+describe('awaitingAuthCodeAt.set — arming is unconditional (outside catch)', () => {
+  const src = readFileSync(
+    new URL('../gateway/gateway.ts', import.meta.url),
+    'utf8',
+  )
+
+  it('awaitingAuthCodeAt.set appears BEFORE switchroomReply inside the formatted.url block', () => {
+    const urlBlockIdx = src.indexOf('if (formatted.url)')
+    expect(urlBlockIdx).toBeGreaterThan(0)
+    const urlBlock = src.slice(urlBlockIdx, urlBlockIdx + 800)
+    const setIdx = urlBlock.indexOf('awaitingAuthCodeAt.set(')
+    const replyIdx = urlBlock.indexOf("'📋 Paste the browser code here ↓'")
+    expect(setIdx).toBeGreaterThan(0)
+    expect(replyIdx).toBeGreaterThan(0)
+    // The .set must come BEFORE the ForceReply switchroomReply call
+    expect(setIdx).toBeLessThan(replyIdx)
+  })
+
+  it('awaitingAuthCodeAt.set is NOT inside the inner try block', () => {
+    // The inner try starts with "await switchroomReply(ctx, '📋 Paste..."
+    // The .set should appear before that try keyword in the formatted.url block
+    const urlBlockIdx = src.indexOf('if (formatted.url)')
+    const urlBlock = src.slice(urlBlockIdx, urlBlockIdx + 800)
+    const setIdx = urlBlock.indexOf('awaitingAuthCodeAt.set(')
+    // Find the try block that wraps the ForceReply call
+    const innerTryIdx = urlBlock.indexOf('try {', setIdx)
+    // The inner try (ForceReply try block) must come AFTER the .set call
+    expect(innerTryIdx).toBeGreaterThan(setIdx)
   })
 })

--- a/telegram-plugin/tests/secret-detect-oauth-code.test.ts
+++ b/telegram-plugin/tests/secret-detect-oauth-code.test.ts
@@ -1,0 +1,159 @@
+/**
+ * Tests for the Anthropic OAuth browser-code detection added in issue #44.
+ *
+ * Channel A — anchored pattern (`anthropic_oauth_code`):
+ *   Positive: two URL-safe base64 segments (≥20 chars each) separated by `#`.
+ *   Negative: ordinary URL fragments, short anchors, markdown link targets.
+ *
+ * Channel B — context rule (`awaitingAuthCodeAt` map in gateway.ts):
+ *   Tested structurally: verify the gateway source wires the map, sets it
+ *   when emitting the "Paste the browser code here" prompt, checks it on
+ *   inbound, and clears it after one message.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { detectSecrets } from '../secret-detect/index.js'
+import { runPipeline } from '../secret-detect/pipeline.js'
+import { setAuditSink } from '../secret-detect/audit.js'
+import type { VaultWriteFn, VaultListFn } from '../secret-detect/vault-write.js'
+
+// ─── Channel A — pattern unit tests ──────────────────────────────────────────
+
+describe('anthropic_oauth_code pattern — Channel A', () => {
+  it('detects a bare auth code (two long url-safe-b64 segments with #)', () => {
+    // Shape emitted by the claude.com/cai authorize flow
+    const code = 'tle0rmXYZabc123defGHIjkl#00EySjXYZabc123defGHIjklmno'
+    const d = detectSecrets(code)
+    expect(d.some((h) => h.rule_id === 'anthropic_oauth_code')).toBe(true)
+    const hit = d.find((h) => h.rule_id === 'anthropic_oauth_code')!
+    expect(hit.confidence).toBe('high')
+    expect(hit.matched_text).toBe(code)
+  })
+
+  it('detects a code embedded in prose (prefixed with "here is the code:")', () => {
+    const code = 'aBcDeFgHiJkLmNoPqRsTuVwX#xYz123456789abcdefghijkl'
+    const text = `here is the browser code: ${code} please use it`
+    const d = detectSecrets(text)
+    expect(d.some((h) => h.rule_id === 'anthropic_oauth_code')).toBe(true)
+    const hit = d.find((h) => h.rule_id === 'anthropic_oauth_code')!
+    expect(hit.matched_text).toBe(code)
+  })
+
+  it('does NOT match https:// URL fragments (section anchor)', () => {
+    const text = 'see https://example.com/docs#installation for more'
+    const d = detectSecrets(text)
+    expect(d.some((h) => h.rule_id === 'anthropic_oauth_code')).toBe(false)
+  })
+
+  it('does NOT match a short first segment (ordinary markdown anchor)', () => {
+    // "callback" is only 8 chars — below the 20-char minimum
+    const text = 'https://claude.ai/callback#state123456789012345'
+    const d = detectSecrets(text)
+    expect(d.some((h) => h.rule_id === 'anthropic_oauth_code')).toBe(false)
+  })
+
+  it('does NOT match a markdown link target like [link](/foo#bar)', () => {
+    // "/foo" is 4 chars — well below minimum; "bar" is 3 chars — also below
+    const text = '[see here](/features#quickstart-guide)'
+    const d = detectSecrets(text)
+    expect(d.some((h) => h.rule_id === 'anthropic_oauth_code')).toBe(false)
+  })
+
+  it('does NOT match when either segment is shorter than 20 chars', () => {
+    // First segment: 19 chars (one short)
+    const text = 'aBcDeFgHiJkLmNoPqRs#xYz123456789abcdefghijkl'
+    const d = detectSecrets(text)
+    expect(d.some((h) => h.rule_id === 'anthropic_oauth_code')).toBe(false)
+
+    // Second segment: 19 chars
+    const text2 = 'aBcDeFgHiJkLmNoPqRsT#xYz123456789abcde'
+    const d2 = detectSecrets(text2)
+    // "xYz123456789abcde" is 18 chars — below minimum
+    expect(d2.some((h) => h.rule_id === 'anthropic_oauth_code')).toBe(false)
+  })
+
+  it('flows through runPipeline and stores the code in the vault', () => {
+    const store = new Map<string, string>()
+    const write: VaultWriteFn = (slug, value) => { store.set(slug, value); return { ok: true, output: 'ok' } }
+    const list: VaultListFn = () => ({ ok: true, keys: [...store.keys()] })
+
+    const code = 'tle0rmXYZabc123defGHIjkl#00EySjXYZabc123defGHIjklmno'
+    const res = runPipeline({
+      chat_id: 'test-chat',
+      message_id: 1,
+      text: code,
+      passphrase: 'pw',
+      vaultWrite: write,
+      vaultList: list,
+    })
+
+    expect(res.stored).toHaveLength(1)
+    expect(res.stored[0]!.detection.rule_id).toBe('anthropic_oauth_code')
+    expect(res.rewritten_text).not.toContain(code)
+    expect(res.rewritten_text).toContain('[secret stored as vault:')
+    expect([...store.values()]).toContain(code)
+  })
+})
+
+// ─── Channel B — context rule structural tests ────────────────────────────────
+
+describe('auth-flow context rule — Channel B (structural wiring in gateway.ts)', () => {
+  const src = readFileSync(
+    new URL('../gateway/gateway.ts', import.meta.url),
+    'utf8',
+  )
+
+  it('declares awaitingAuthCodeAt map and AUTH_CODE_CONTEXT_TTL_MS constant', () => {
+    expect(src).toMatch(/const awaitingAuthCodeAt = new Map<string, number>/)
+    expect(src).toMatch(/AUTH_CODE_CONTEXT_TTL_MS\s*=\s*5\s*\*\s*60_000/)
+  })
+
+  it('sets awaitingAuthCodeAt when emitting the "Paste the browser code here" prompt', () => {
+    // Find the block that sends the ForceReply prompt and confirm the map.set is nearby
+    const promptIdx = src.indexOf("'📋 Paste the browser code here ↓'")
+    expect(promptIdx).toBeGreaterThan(0)
+    // Within 500 chars after the prompt, awaitingAuthCodeAt.set must appear
+    const window = src.slice(promptIdx, promptIdx + 500)
+    expect(window).toMatch(/awaitingAuthCodeAt\.set\(/)
+  })
+
+  it('clears awaitingAuthCodeAt (delete) in the inbound handler when the flag is active', () => {
+    // The inbound handler must call delete after reading the flag
+    expect(src).toMatch(/awaitingAuthCodeAt\.delete\(chat_id\)/)
+  })
+
+  it('checks isAuthFlowContext in the secret-detect block (passphrase path)', () => {
+    const pipelineIdx = src.indexOf('runPipeline({')
+    expect(pipelineIdx).toBeGreaterThan(0)
+    // After the pipeline call, isAuthFlowContext must gate the fallback branch
+    const tail = src.slice(pipelineIdx, pipelineIdx + 2000)
+    expect(tail).toMatch(/isAuthFlowContext/)
+  })
+
+  it('checks isAuthFlowContext in the no-passphrase path (deferred branch)', () => {
+    // The no-passphrase branch must also check isAuthFlowContext so a context
+    // hit is deferred even without a cached passphrase
+    const noPpIdx = src.indexOf('No passphrase cached — detect, but defer')
+    expect(noPpIdx).toBeGreaterThan(0)
+    const window = src.slice(noPpIdx, noPpIdx + 400)
+    expect(window).toMatch(/isAuthFlowContext/)
+  })
+
+  it('reaps awaitingAuthCodeAt in the TTL reaper alongside other pending-state maps', () => {
+    // The pendingStateReaper interval must sweep expired auth-code-context entries
+    const reaperIdx = src.indexOf('pendingStateReaper = setInterval')
+    expect(reaperIdx).toBeGreaterThan(0)
+    const reaperBlock = src.slice(reaperIdx, reaperIdx + 800)
+    expect(reaperBlock).toMatch(/awaitingAuthCodeAt/)
+    expect(reaperBlock).toMatch(/AUTH_CODE_CONTEXT_TTL_MS/)
+  })
+
+  it('auth-flow context rule sits BEFORE recordInbound() and broadcast()', () => {
+    const contextIdx = src.indexOf('isAuthFlowContext')
+    const recordIdx = src.indexOf('recordInbound(', contextIdx)
+    const broadcastIdx = src.indexOf('ipcServer.broadcast(inboundMsg)', contextIdx)
+    expect(contextIdx).toBeGreaterThan(0)
+    expect(recordIdx).toBeGreaterThan(contextIdx)
+    expect(broadcastIdx).toBeGreaterThan(contextIdx)
+  })
+})


### PR DESCRIPTION
Closes the security gap from #44 phase 1. The `claude setup-token` browser-OAuth code pasted during the Telegram `/auth` flow was not being recognised by secret-detect, so the raw code stayed visible in chat history (and in the local SQLite buffer) until the chat was scrolled past.

## Changes

**Channel A — anchored pattern** (`telegram-plugin/secret-detect/patterns.ts`):
```ts
{ rule_id: 'anthropic_oauth_code', regex: /\b([A-Za-z0-9_-]{20,}#[A-Za-z0-9_-]{20,})\b/g, ... }
```
Listed before `anthropic_api_key` so it wins on ties. The 20-char minimum on each segment reliably excludes ordinary URL fragments.

**Channel B — context rule** (`telegram-plugin/gateway/gateway.ts`):
When the gateway emits the "Paste the browser code here" prompt, it sets `awaitingAuthCodeAt[chat_id] = now`. The next inbound message within 5 min (OAuth code lifetime) is treated as auth-flow-sensitive regardless of pattern match. Belt-and-braces — pattern covers the known shape, context rule covers any future format change Anthropic ships.

If the pattern fires, normal flow stores → deletes → confirms. If it doesn't, the fallback deletes + stages + warns so no raw bytes ever reach \`recordInbound\` / IPC.

The flag is consumed on the next inbound or by TTL, whichever comes first.

## Tests

14 new tests in \`telegram-plugin/tests/secret-detect-oauth-code.test.ts\`. All pass. Full vitest suite + tsc clean.

## Out of scope

Phase 2 of #44 — the seamless one-tap-button vault-unlock UX redesign — is deferred to a separate PR. Spec'd in the issue.

## Live incident

Found during the gymbro \`/auth\` re-test on 2026-04-25 09:24 AEST after PR #40 landed. The auth itself worked; the browser code lingered in the chat the whole time.