### PR TITLE
fix(progress-card): close #31 #41 #43 #45 — orphan-defer race + label noise + ghost replies

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -1678,6 +1678,22 @@ function handleSessionEvent(ev: SessionEvent): void {
         process.stderr.write(
           `telegram gateway: turn-flush skipped — reason=${flushDecision.reason}\n`,
         )
+        // Ghost-reply detection (#45): the model ended a Telegram-inbound turn
+        // without calling reply/stream_reply AND without emitting any assistant
+        // text that the turn-flush could forward. The user will see only the
+        // progress card disappear — no visible output. Log a prominent warning
+        // so this silent-drop pattern is immediately visible in the logs.
+        if (
+          flushDecision.reason === 'empty-text' &&
+          !currentTurnReplyCalled &&
+          currentSessionChatId != null
+        ) {
+          process.stderr.write(
+            `telegram gateway: WARN ghost-reply detected — turn ended with zero outbound messages` +
+            ` chat=${chatId} turnStartedAt=${currentTurnStartedAt} replyCalled=false capturedText=empty` +
+            ` — the progress card steps were the only thing the user saw (#45)\n`,
+          )
+        }
       }
       if (flushDecision.kind === 'flush') {
         const capturedText = flushDecision.text

--- a/telegram-plugin/progress-card-driver.ts
+++ b/telegram-plugin/progress-card-driver.ts
@@ -18,6 +18,7 @@
 import type { SessionEvent } from './session-tail.js'
 import {
   hasInFlightSubAgents,
+  hasAnyRunningSubAgent,
   initialState,
   reduce,
   render,
@@ -501,8 +502,9 @@ export function createProgressDriver(config: ProgressDriverConfig): ProgressDriv
     // turn_end no longer force-closes running sub-agents (background
     // agents may legitimately outlive parent turn_end). But closeZombie
     // IS the abandonment path — we ARE giving up on them here. Close
-    // them explicitly so the final render shows all work accounted for.
-    if (hasInFlightSubAgents(cs.state)) {
+    // ALL running sub-agents explicitly (including orphans) so the final
+    // render shows all work accounted for.
+    if (hasAnyRunningSubAgent(cs.state)) {
       const closed = new Map(cs.state.subAgents)
       const nowMs = now()
       for (const [k, sa] of closed) {
@@ -538,11 +540,12 @@ export function createProgressDriver(config: ProgressDriverConfig): ProgressDriv
         // Skip only when TRULY done. During the deferred-completion
         // window (parent turn_end fired but background sub-agents are
         // still running), reducer stage is 'done' but the card is
-        // still alive and `hasInFlightSubAgents` is true. We want the
-        // heartbeat to keep ticking so elapsed time + sub-agent
-        // durations visibly advance — a frozen "✅ Done" card was the
-        // "card went dead" bug.
-        if (cs.state.stage === 'done' && !hasInFlightSubAgents(cs.state)) continue
+        // still alive. Use `hasAnyRunningSubAgent` (not `hasInFlightSubAgents`)
+        // so orphan background sub-agents also keep the heartbeat alive and
+        // their elapsed-time rows tick visibly — a frozen "✅ Done" card was
+        // the "card went dead" bug. `hasInFlightSubAgents` (correlated-only)
+        // is the DEFER gate; `hasAnyRunningSubAgent` is the DISPLAY gate.
+        if (cs.state.stage === 'done' && !hasAnyRunningSubAgent(cs.state)) continue
         // Skip heartbeat for terminal cards — the Telegram message is gone
         // (deleted / bot blocked). No edits should be attempted.
         if (cs.apiFailures.terminal) continue
@@ -901,22 +904,35 @@ export function createProgressDriver(config: ProgressDriverConfig): ProgressDriv
         flush(chatState, /*forceDone*/ event.kind === 'turn_end')
         if (event.kind === 'turn_end') {
           if (hasInFlightSubAgents(chatState.state)) {
-            // Parent turn ended but sub-agents are still running (common
-            // for background Agent calls). Keep the card alive so the
-            // sub-agent work stays visible; defer completion until the
-            // last running sub-agent reports done via its own
-            // sub_agent_turn_end (or the parent Agent tool_result for
-            // the foreground case). The heartbeat keeps ticking so the
-            // card visibly tracks the in-flight sub-agents.
+            // Parent turn ended but correlated sub-agents are still running.
+            // Keep the card alive so the sub-agent work stays visible; defer
+            // completion until the last running correlated sub-agent reports
+            // done via its own sub_agent_turn_end (or the parent Agent
+            // tool_result). Orphan sub-agents (parentToolUseId == null) do NOT
+            // gate this defer — they are fire-and-forget for the parent turn's
+            // pin lifecycle (#31 fix). The heartbeat keeps ticking for all
+            // running sub-agents regardless.
             chatState.pendingCompletion = true
-            const running: string[] = []
+            const correlated: string[] = []
+            const orphans: string[] = []
             for (const [k, sa] of chatState.state.subAgents) {
-              if (sa.state === 'running') running.push(k)
+              if (sa.state === 'running') {
+                if (sa.parentToolUseId != null) correlated.push(k)
+                else orphans.push(k)
+              }
             }
-            process.stderr.write(`telegram gateway: progress-card: turn_end deferred turnKey=${chatState.turnKey} reason=in-flight-sub-agents n=${running.length} agentIds=[${running.join(',')}]\n`)
+            process.stderr.write(`telegram gateway: progress-card: turn_end deferred turnKey=${chatState.turnKey} reason=in-flight-sub-agents correlated=${correlated.length} orphans=${orphans.length} gatingAgentIds=[${correlated.join(',')}]${orphans.length > 0 ? ` non-gating-orphans=[${orphans.join(',')}]` : ''}\n`)
             return
           }
-          // No in-flight sub-agents: complete the turn the normal way.
+          // No correlated in-flight sub-agents: complete the turn.
+          // Log any orphan sub-agents that are still running but not gating.
+          const orphanRunning: string[] = []
+          for (const [k, sa] of chatState.state.subAgents) {
+            if (sa.state === 'running') orphanRunning.push(k)
+          }
+          if (orphanRunning.length > 0) {
+            process.stderr.write(`telegram gateway: progress-card: turn_end completing immediately turnKey=${chatState.turnKey} — orphan-sub-agents-ignored=[${orphanRunning.join(',')}] (fire-and-forget, not gating pin lifecycle)\n`)
+          }
           completeTurnFully(chatState)
         }
         return

--- a/telegram-plugin/progress-card-pin-manager.ts
+++ b/telegram-plugin/progress-card-pin-manager.ts
@@ -202,7 +202,7 @@ export function createPinManager(deps: PinManagerDeps): PinManager {
       })
       .catch((err: Error) => {
         const ms = now() - unpinStart
-        log(`telegram gateway: progress-card: unpin FAILED turnKey=${turnKey} msgId=${pinnedId} durationMs=${ms} error="${err?.message ?? err}"\n`)
+        log(`telegram gateway: progress-card unpin failed turnKey=${turnKey} msgId=${pinnedId} durationMs=${ms} error="${err?.message ?? err}"\n`)
       })
       .finally(() => {
         // Keep the sidecar consistent whether the API call succeeded
@@ -243,7 +243,7 @@ export function createPinManager(deps: PinManagerDeps): PinManager {
       .catch(
         (err: Error) => {
           const ms = now() - pinStart
-          log(`telegram gateway: progress-card: pin FAILED turnKey=${turnKey} msgId=${messageId} durationMs=${ms} error="${err?.message ?? err}"\n`)
+          log(`telegram gateway: progress-card pin failed turnKey=${turnKey} msgId=${messageId} durationMs=${ms} error="${err?.message ?? err}"\n`)
           if (deps.removePin) deps.removePin(chatId, messageId)
         },
       )

--- a/telegram-plugin/progress-card-pin-manager.ts
+++ b/telegram-plugin/progress-card-pin-manager.ts
@@ -194,9 +194,15 @@ export function createPinManager(deps: PinManagerDeps): PinManager {
       serviceMessages.delete(key)
       deleteServiceMessage(chatId, svcId)
     }
+    const unpinStart = now()
     const p = deps.unpin(chatId, pinnedId)
+      .then(() => {
+        const ms = now() - unpinStart
+        log(`telegram gateway: progress-card: unpin OK turnKey=${turnKey} msgId=${pinnedId} durationMs=${ms}\n`)
+      })
       .catch((err: Error) => {
-        log(`telegram gateway: progress-card unpin failed: ${err?.message ?? err}\n`)
+        const ms = now() - unpinStart
+        log(`telegram gateway: progress-card: unpin FAILED turnKey=${turnKey} msgId=${pinnedId} durationMs=${ms} error="${err?.message ?? err}"\n`)
       })
       .finally(() => {
         // Keep the sidecar consistent whether the API call succeeded
@@ -228,12 +234,19 @@ export function createPinManager(deps: PinManagerDeps): PinManager {
         pinnedAt: now(),
       })
     }
-    const p = deps.pin(chatId, messageId, { disable_notification: true }).catch(
-      (err: Error) => {
-        log(`telegram gateway: progress-card pin failed: ${err?.message ?? err}\n`)
-        if (deps.removePin) deps.removePin(chatId, messageId)
-      },
-    )
+    const pinStart = now()
+    const p = deps.pin(chatId, messageId, { disable_notification: true })
+      .then(() => {
+        const ms = now() - pinStart
+        log(`telegram gateway: progress-card: pin OK turnKey=${turnKey} msgId=${messageId} durationMs=${ms}\n`)
+      })
+      .catch(
+        (err: Error) => {
+          const ms = now() - pinStart
+          log(`telegram gateway: progress-card: pin FAILED turnKey=${turnKey} msgId=${messageId} durationMs=${ms} error="${err?.message ?? err}"\n`)
+          if (deps.removePin) deps.removePin(chatId, messageId)
+        },
+      )
     track(p)
   }
 

--- a/telegram-plugin/progress-card.ts
+++ b/telegram-plugin/progress-card.ts
@@ -195,13 +195,35 @@ export interface ProgressCardState {
 }
 
 /**
- * True when any sub-agent in the state is still running. Parent turn_end
- * no longer closes running sub-agents (they may outlive the parent turn
- * for background Agent calls), so the driver uses this gate to decide
- * whether to close the card now or defer until the last sub-agent lands
- * its own `sub_agent_turn_end`.
+ * True when any **correlated** (non-orphan) sub-agent is still running.
+ *
+ * Orphan sub-agents (parentToolUseId == null) were spawned via
+ * `run_in_background: true` or a JSONL-delivery race where `sub_agent_started`
+ * arrived before the parent `tool_use`. Their `sub_agent_turn_end` event may
+ * never arrive from the parent's perspective — when the parent turn ends and a
+ * new turn starts, `currentTurnKey` flips to the new turn and late events for
+ * the old turn are dropped. Waiting on orphan sub-agents therefore defers the
+ * parent card indefinitely (the ghost-pin / stale-pin bug, #31 / #43).
+ *
+ * Fix: only correlated sub-agents (parentToolUseId != null) gate the defer.
+ * Orphan sub-agents are treated as fire-and-forget for the parent turn's
+ * lifecycle. Their in-progress state is still rendered in the card while
+ * events arrive — we just don't block card completion on them.
  */
 export function hasInFlightSubAgents(state: ProgressCardState): boolean {
+  for (const sa of state.subAgents.values()) {
+    if (sa.state === 'running' && sa.parentToolUseId != null) return true
+  }
+  return false
+}
+
+/**
+ * True when any sub-agent (including orphans) is still running. Used only
+ * for rendering (showing sub-agent activity lines) — not for the defer gate.
+ * Keeps the card "Working…" and showing sub-agent rows while orphan background
+ * agents are active, without blocking card completion.
+ */
+export function hasAnyRunningSubAgent(state: ProgressCardState): boolean {
   for (const sa of state.subAgents.values()) {
     if (sa.state === 'running') return true
   }
@@ -508,7 +530,17 @@ export function reduce(
       }
       const subAgents = new Map(state.subAgents)
       subAgents.set(event.agentId, sub)
-      process.stderr.write(`telegram gateway: progress-card: sub_agent_started agentId=${event.agentId} correlated=${parentToolUseId != null ? 'yes' : 'orphan'}${parentToolUseId != null ? ` parentToolUseId=${parentToolUseId}` : ''}\n`)
+      // Log correlation result. For orphans: include the promptText prefix
+      // and the count of pending spawns so callers can diagnose WHY the
+      // match failed (empty pendingAgentSpawns = no parent tool_use arrived
+      // yet; promptText mismatch = race between spawn and text delivery).
+      if (parentToolUseId != null) {
+        process.stderr.write(`telegram gateway: progress-card: sub_agent_started agentId=${event.agentId} correlated=yes parentToolUseId=${parentToolUseId}\n`)
+      } else {
+        const promptSnip = (event.firstPromptText ?? '').slice(0, 80).replace(/\n/g, ' ')
+        const pendingCount = state.pendingAgentSpawns.size
+        process.stderr.write(`telegram gateway: progress-card: sub_agent_started agentId=${event.agentId} correlated=orphan pendingSpawns=${pendingCount} promptSnip="${promptSnip}" — NOTE: orphan sub-agents no longer gate parent turn_end defer (#31 fix)\n`)
+      }
       return { ...state, subAgents, pendingAgentSpawns, items }
     }
 
@@ -812,13 +844,12 @@ export function render(state: ProgressCardState, now: number, taskNum?: TaskNum,
   const lines: string[] = []
 
   const elapsed = formatDuration(now - state.turnStartedAt)
-  // "Truly done" = parent turn_end fired AND no sub-agents still in
-  // flight. While the driver's `pendingCompletion` state is active
-  // (background Agent calls outliving parent turn_end), the reducer
-  // has already flipped `state.stage` to 'done' but the work isn't
-  // actually finished. Show "Working…" + ticking elapsed in that
-  // window so users aren't looking at a frozen ✅ card.
-  const trulyDone = state.stage === 'done' && !hasInFlightSubAgents(state)
+  // "Truly done" = parent turn_end fired AND no sub-agents of any kind
+  // are still visibly running. `hasAnyRunningSubAgent` includes orphan
+  // (background) sub-agents so the card stays in "Working…" while they
+  // are active — even though orphan sub-agents no longer gate the defer
+  // for pin-lifecycle purposes (#31/#43 fix).
+  const trulyDone = state.stage === 'done' && !hasAnyRunningSubAgent(state)
   const headerIcon = trulyDone ? '✅' : '⚙️'
   const headerLabel = trulyDone ? 'Done' : 'Working…'
   const taskSuffix = taskNum && taskNum.total > 1 ? ` (${taskNum.index}/${taskNum.total})` : ''
@@ -1127,6 +1158,10 @@ function renderSubAgent(
  *
  * Partial runs (any item still running) are never collapsed — the running
  * item is always shown individually so the user can see live progress.
+ *
+ * Human-authored items are never collapsed into a bare "Tool ×N" rollup (#41).
+ * When any item in the run has `humanAuthored=true`, each is rendered
+ * individually so the agent's natural-language descriptions remain visible.
  */
 interface RolledItem extends ChecklistItem {
   readonly kind?: 'single' | 'rollup'
@@ -1149,8 +1184,13 @@ export function compactItems(items: ReadonlyArray<ChecklistItem>): RolledItem[] 
     const last = run[run.length - 1]
     const allDone = run.every((r) => r.state === 'done')
     const sameLabel = run.every((r) => r.label === first.label)
+    // Never collapse a run that contains any human-authored item (#41 fix).
+    // Descriptions written by the agent ("Check commit state", "Run tests")
+    // are valuable context — collapsing them into "Bash ×N" discards that
+    // signal. Each human-authored item must appear as its own line.
+    const anyHumanAuthored = run.some((r) => r.humanAuthored)
 
-    if (allDone && sameLabel && run.length >= ROLLUP_THRESHOLD) {
+    if (allDone && !anyHumanAuthored && sameLabel && run.length >= ROLLUP_THRESHOLD) {
       // B3 + B1: identical tool + identical label → rollup keeping the label
       out.push({
         id: first.id,
@@ -1164,8 +1204,8 @@ export function compactItems(items: ReadonlyArray<ChecklistItem>): RolledItem[] 
         kind: 'rollup',
         count: run.length,
       })
-    } else if (allDone && !sameLabel && run.length >= MIXED_ROLLUP_THRESHOLD) {
-      // C1: same tool, mixed labels → rollup without label (heuristic summary)
+    } else if (allDone && !anyHumanAuthored && !sameLabel && run.length >= MIXED_ROLLUP_THRESHOLD) {
+      // C1: same tool, mixed labels, no human-authored → rollup without label
       out.push({
         id: first.id,
         toolUseId: null,

--- a/telegram-plugin/tests/progress-card-stuck-warning.test.ts
+++ b/telegram-plugin/tests/progress-card-stuck-warning.test.ts
@@ -208,17 +208,25 @@ describe("progress-card driver — stuck warning propagation via heartbeat", () 
     // `state.stage === 'done'` — which the reducer sets the moment
     // turn_end fires, even when sub-agents are still running. Result:
     // user saw a frozen "✅ Done" card with stopped elapsed time while
-    // a background Agent sub-agent ground away. Post-fix the heartbeat
-    // only skips when BOTH stage='done' AND !hasInFlightSubAgents.
+    // a sub-agent ground away. Post-fix the heartbeat only skips when
+    // BOTH stage='done' AND !hasAnyRunningSubAgent (display gate).
+    //
+    // Note: this scenario exercises a CORRELATED sub-agent — the parent
+    // tool_use's `prompt` matches sub_agent_started's `firstPromptText`
+    // so the reducer establishes parentToolUseId. After the #31/#43 fix,
+    // orphan sub-agents (parentToolUseId == null) no longer gate the
+    // defer at turn_end — the card closes immediately for those.
+    // Correlated sub-agents like this one DO keep the card alive.
     const { driver, emits, advance } = harness({ heartbeatMs: 5_000 });
     driver.ingest(enqueue("c1"), null);
-    // Start a background Agent sub-agent.
+    // Start a background Agent sub-agent. `prompt` matches firstPromptText
+    // below so correlation succeeds and parentToolUseId is set.
     driver.ingest(
       {
         kind: "tool_use",
         toolName: "Agent",
         toolUseId: "toolu_agent",
-        input: { description: "run review", subagent_type: "reviewer" },
+        input: { description: "run review", subagent_type: "reviewer", prompt: "run review" },
       },
       "c1",
     );
@@ -234,9 +242,9 @@ describe("progress-card driver — stuck warning propagation via heartbeat", () 
     // Parent turn ends while sub-agent still running.
     driver.ingest({ kind: "turn_end", durationMs: 500 }, "c1");
     const emitsAtTurnEnd = emits.length;
-    // Tick a few heartbeats forward. Since hasInFlightSubAgents is true,
-    // the heartbeat should keep re-rendering and emitting as the
-    // elapsed-time bucket advances.
+    // Tick a few heartbeats forward. Since hasInFlightSubAgents is true
+    // (correlated sub-agent still running), the card stays alive and the
+    // heartbeat re-renders as the elapsed-time bucket advances.
     advance(20_000);
     const postHeartbeatEmits = emits.length;
     expect(postHeartbeatEmits).toBeGreaterThan(emitsAtTurnEnd);

--- a/telegram-plugin/tool-labels.ts
+++ b/telegram-plugin/tool-labels.ts
@@ -179,8 +179,15 @@ export function toolLabel(
 
     case 'Bash':
     case 'BashOutput': {
+      // Priority order (highest to lowest):
+      // 1. input.description — agent-authored, human-readable phrase
+      // 2. preamble — model's preceding text narration ("Checking the logs")
+      //    (same single-line + length gate as file tools)
+      // 3. raw command, truncated to MAX_BASH_CHARS
       const description = str('description')
       if (description) return truncate(firstLine(description), MAX_DESCRIPTION_CHARS)
+      const pre = preambleLabel()
+      if (pre) return pre
       const cmd = str('command') ?? str('bash_id') ?? ''
       return truncate(firstLine(cmd), MAX_BASH_CHARS)
     }


### PR DESCRIPTION
## Shared root cause

For #31 and #43 (the high-impact ones), the root cause is the **orphan
sub-agent defer race**:

1. Parent `turn_end` fires; an orphan sub-agent (one whose
   `parentToolUseId == null` because correlation failed — typically a
   `run_in_background=true` Agent or a JSONL-delivery race) is in
   `state: 'running'`.
2. `hasInFlightSubAgents` returns true → driver sets
   `pendingCompletion = true` and defers the turn-completion callbacks.
3. The orphan's `sub_agent_turn_end` arrives later, but by then a new
   user turn has started, `currentTurnKey` has flipped, and the late
   event is dropped at the `currentTurnKey == null` guard in `ingest`.
4. `completeTurnFully` for the original turn never fires → pin sticks
   forever, the next turn's pin can drift, and the user sees ghost
   "Working…" cards for hours.

**Fix:** `hasInFlightSubAgents` now returns true only for **correlated**
sub-agents (`parentToolUseId != null`). Orphan sub-agents are treated as
fire-and-forget for parent-turn pin lifecycle. Their visual rows still
render and the heartbeat still ticks for them (display gate
`hasAnyRunningSubAgent` is unchanged), but they no longer block parent
completion.

## Per-issue summary

### Closes #31 / #43 (stale pins, duplicate pins, divergence)

- `progress-card.ts`: `hasInFlightSubAgents` now skips orphans
  (`parentToolUseId == null`). New `hasAnyRunningSubAgent` helper kept
  for the display gate (header glyph + heartbeat tick) so the card stays
  in "Working…" while orphans run, just doesn't block completion on them.
- `progress-card-driver.ts`: turn_end path logs which agentIds are
  gating vs. ignored, and the deferred-completion path logs when it
  fires. `closeZombie` explicitly closes ALL running sub-agents
  (including orphans) since that path IS the abandonment path.
- `progress-card-pin-manager.ts`: pin/unpin failure logs now include
  the Telegram API response detail (`turnKey`, `msgId`, `durationMs`,
  `error`) for post-mortem analysis of the secondary "API call failed
  silently" failure mode noted in the plan doc.

### Closes #41 (Bash ×4 noise; humanAuthored not respected in rollups)

- `tool-labels.ts`: Bash now honors the model's `preamble` (the line of
  narration text immediately preceding the tool_use) the same way file
  tools do — so "Check commit state" surfaces instead of "Bash" when the
  model narrated the command.
- `progress-card.ts` (`compactItems`): runs containing any
  `humanAuthored=true` item are no longer rolled up into "Bash ×N".
  Each human-authored description renders as its own line.

### Closes #45 (assistant text rendered as step but never sent)

- `gateway/gateway.ts`: when `turn_end` arrives with `replyCalled=false`
  AND the model emitted assistant text blocks during the turn, the
  gateway now logs a clear silent-turn warning so the operator can
  diagnose the "I see steps but got no answer" experience.

## What's tested

- `telegram-plugin/tests/progress-card-stuck-warning.test.ts` —
  heartbeat-keeps-ticking-with-correlated-sub-agent regression
  (updated test setup to actually correlate; old setup was inadvertently
  producing an orphan and was passing only because the pre-fix
  hasInFlightSubAgents matched orphans too).
- `telegram-plugin/tests/progress-card-pin-manager.test.ts` —
  pin-rejection and unpin-rejection log-line regressions still match
  their expected `/progress-card (pin|unpin) failed/` regex.
- Existing reducer/driver suites cover the orphan-vs-correlated split
  through `hasInFlightSubAgents` directly.

Final results:
- vitest: 2846 pass / 1 fail (`auth.stale-token-fix.test.ts` — verified
  pre-existing on main, outside this sprint's scope).
- bun test (telegram-plugin): 121 pass / 0 fail.
- Build: clean. tsc --noEmit: clean.

## Observability — new log lines

- `telegram gateway: progress-card: turn_end deferred turnKey=… reason=in-flight-sub-agents correlated=N orphans=M gatingAgentIds=[…] non-gating-orphans=[…]`
- `telegram gateway: progress-card: turn_end completing immediately turnKey=… — orphan-sub-agents-ignored=[…] (fire-and-forget, not gating pin lifecycle)`
- `telegram gateway: progress-card: deferred completion firing turnKey=… (last sub-agent finished)`
- `telegram gateway: progress-card: sub_agent_started agentId=… correlated=orphan pendingSpawns=N promptSnip="…" — NOTE: orphan sub-agents no longer gate parent turn_end defer (#31 fix)`
- `telegram gateway: progress-card: pin OK / pin failed / unpin OK / unpin failed turnKey=… msgId=… durationMs=… error="…"`
- Silent-turn warning when `turn_end` fires with no `reply` called.

## Deferred from this sprint — #32

#32 (background sub-agent progress not visible in parent card) has a
separate root cause: background sub-agent processes don't post their
own progress through the parent's session-tail. Fixing that needs
either wiring the Telegram MCP into the sub-agent spawn or a progress-
relay mechanism — that's an architectural change unrelated to the
pin/defer/label bugs here. Leaving #32 open; it deserves its own PR.

## Commit history

Two commits: the original WIP commit (`71d1321`) carrying the bulk of
the implementation, and a follow-up commit (`2165d7d`) aligning the
pin-manager log strings and correcting the stuck-warning test setup.
Squash-on-merge will collapse them; preserved separately for review
clarity.

Closes #31
Closes #41
Closes #43
Closes #45