### PR TITLE
fix(ci): unblock main — bktec brace-expansion + advanceTimersByTimeAsync polyfill

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -115,7 +115,9 @@ steps:
         # the assigned file list in place of {{testExamples}}.
         export BUILDKITE_TEST_ENGINE_TEST_CMD="bunx vitest run {{testExamples}}"
         # Match all test files that vitest.config.ts would include.
-        export BUILDKITE_TEST_ENGINE_TEST_FILE_PATTERN="{tests,test,experimental,src}/**/*.test.ts,telegram-plugin/tests/*.test.ts"
+        # Brace expansion ({a,b,c}) is not honored by bktec's glob library —
+        # it produces "no files found" silently. List each root dir explicitly.
+        export BUILDKITE_TEST_ENGINE_TEST_FILE_PATTERN="tests/**/*.test.ts,test/**/*.test.ts,experimental/**/*.test.ts,src/**/*.test.ts,telegram-plugin/tests/*.test.ts"
         export BUILDKITE_TEST_ENGINE_TEST_FILE_EXCLUDE_PATTERN="telegram-plugin/tests/history.test.ts"
         bktec run
       else

--- a/telegram-plugin/tests/retry-api-call.test.ts
+++ b/telegram-plugin/tests/retry-api-call.test.ts
@@ -13,6 +13,20 @@ import { GrammyError } from 'grammy'
 import { createRetryApiCall, type RetryObserver } from '../retry-api-call.js'
 import { errors, makeGrammyError } from './fake-bot-api.js'
 
+// vitest's vi.advanceTimersByTimeAsync isn't implemented by Bun's test runner.
+// This polyfill keeps the same semantics (advance fake clock + flush microtasks)
+// and lets the file run cleanly under both vitest and `bun test`.
+async function advanceTimers(ms: number): Promise<void> {
+  const viAny = vi as { advanceTimersByTimeAsync?: (ms: number) => Promise<void> }
+  if (typeof viAny.advanceTimersByTimeAsync === 'function') {
+    await viAny.advanceTimersByTimeAsync(ms)
+    return
+  }
+  vi.advanceTimersByTime(ms)
+  // Flush a few microtask turns so awaits chained off the timer callback resolve.
+  for (let i = 0; i < 5; i++) await Promise.resolve()
+}
+
 describe('retryApiCall', () => {
   beforeEach(() => {
     vi.useFakeTimers()
@@ -35,7 +49,7 @@ describe('retryApiCall', () => {
       // Haven't advanced time yet — call is parked on the sleep.
       await Promise.resolve()
       expect(fn).toHaveBeenCalledTimes(1)
-      await vi.advanceTimersByTimeAsync(3000)
+      await advanceTimers(3000)
       const result = await pending
       expect(result).toBe('ok')
       expect(fn).toHaveBeenCalledTimes(2)
@@ -60,7 +74,7 @@ describe('retryApiCall', () => {
       const retry = createRetryApiCall()
       const pending = retry(fn)
       await Promise.resolve()
-      await vi.advanceTimersByTimeAsync(5000)
+      await advanceTimers(5000)
       await pending
       expect(fn).toHaveBeenCalledTimes(2)
     })
@@ -75,9 +89,9 @@ describe('retryApiCall', () => {
       const retry = createRetryApiCall()
       const pending = retry(fn)
       await Promise.resolve()
-      await vi.advanceTimersByTimeAsync(1000)
+      await advanceTimers(1000)
       await Promise.resolve()
-      await vi.advanceTimersByTimeAsync(2000)
+      await advanceTimers(2000)
       expect(await pending).toBe('ok')
       expect(fn).toHaveBeenCalledTimes(3)
     })
@@ -146,9 +160,9 @@ describe('retryApiCall', () => {
       const pending = retry(fn)
 
       await Promise.resolve()
-      await vi.advanceTimersByTimeAsync(1000) // 2^0 * 1000
+      await advanceTimers(1000) // 2^0 * 1000
       await Promise.resolve()
-      await vi.advanceTimersByTimeAsync(2000) // 2^1 * 1000
+      await advanceTimers(2000) // 2^1 * 1000
       expect(await pending).toBe('ok')
       expect(observer.onRetry).toHaveBeenCalledTimes(2)
       expect((observer.onRetry as ReturnType<typeof vi.fn>).mock.calls[0][0]).toMatchObject({
@@ -173,9 +187,9 @@ describe('retryApiCall', () => {
       const caught = pending.catch((e) => e)
 
       await Promise.resolve()
-      await vi.advanceTimersByTimeAsync(1000)
+      await advanceTimers(1000)
       await Promise.resolve()
-      await vi.advanceTimersByTimeAsync(2000)
+      await advanceTimers(2000)
       const err = await caught
       expect((err as Error).message).toBe('fetch failed')
       expect(fn).toHaveBeenCalledTimes(3)
@@ -221,9 +235,9 @@ describe('retryApiCall', () => {
       const retry = createRetryApiCall({ observer: { onRetry } })
       const pending = retry(fn)
       await Promise.resolve()
-      await vi.advanceTimersByTimeAsync(1000)
+      await advanceTimers(1000)
       await Promise.resolve()
-      await vi.advanceTimersByTimeAsync(1000)
+      await advanceTimers(1000)
       await pending
       expect(onRetry).toHaveBeenCalledTimes(2)
       expect(onRetry.mock.calls[0][0]).toMatchObject({ attempt: 0, reason: 'flood_wait' })
@@ -251,7 +265,7 @@ describe('retryApiCall', () => {
       const retry = createRetryApiCall({ log })
       const pending = retry(fn)
       await Promise.resolve()
-      await vi.advanceTimersByTimeAsync(2000)
+      await advanceTimers(2000)
       await pending
       expect(log).toHaveBeenCalledWith(expect.stringMatching(/429 rate limited.*2s/))
     })
@@ -265,7 +279,7 @@ describe('retryApiCall', () => {
       const retry = createRetryApiCall({ log })
       const pending = retry(fn)
       await Promise.resolve()
-      await vi.advanceTimersByTimeAsync(1000)
+      await advanceTimers(1000)
       await pending
       expect(log).toHaveBeenCalledWith(expect.stringMatching(/network error.*1s/))
     })

--- a/telegram-plugin/tests/stream-reply-error-paths.test.ts
+++ b/telegram-plugin/tests/stream-reply-error-paths.test.ts
@@ -59,10 +59,24 @@ function makeDeps(
  * Pump vi fake timers + microtasks until all pending work settles.
  * The draft-stream's `flushLoop` has setTimeout(0) schedules that need
  * explicit advancement even at throttleMs=0, plus intermediate awaits.
+ *
+ * vi.advanceTimersByTimeAsync isn't implemented under bun's test runner.
+ * Polyfill via the sync advance + explicit microtask flush so this file
+ * runs cleanly under both vitest and `bun test`.
  */
+async function advanceFakeClock(ms: number): Promise<void> {
+  const viAny = vi as { advanceTimersByTimeAsync?: (ms: number) => Promise<void> }
+  if (typeof viAny.advanceTimersByTimeAsync === 'function') {
+    await viAny.advanceTimersByTimeAsync(ms)
+    return
+  }
+  vi.advanceTimersByTime(ms)
+  for (let i = 0; i < 5; i++) await Promise.resolve()
+}
+
 async function settle(ms = 0): Promise<void> {
   for (let i = 0; i < 20; i++) {
-    await vi.advanceTimersByTimeAsync(ms)
+    await advanceFakeClock(ms)
     await Promise.resolve()
   }
 }


### PR DESCRIPTION
Build #26 on main failed twice in two unrelated steps. Both fixed in this PR.

## Fix 1: vitest core tests (`bktec run` brace expansion)

bktec emitted `no files found with pattern`. The pattern used shell-style brace expansion (`{tests,test,...}`) which bktec's underlying glob library does NOT honour — silently matches zero files. Fix: list each root dir explicitly, comma-separated.

## Fix 2: plugin tests (`vi.advanceTimersByTimeAsync`)

`retry-api-call.test.ts` and `stream-reply-error-paths.test.ts` use `vi.advanceTimersByTimeAsync(ms)`. Vitest implements it; Bun's vitest-compat layer in `bun test` does not. Fix: tiny polyfill at the top of each file. Same observable behaviour under both runners.

## Local verification

- `bun test` (telegram-plugin): **865 pass, 0 fail**
- `bun run test:vitest`: **2858 pass, 1 fail** (pre-existing `auth.stale-token-fix.test.ts` flake on main, out of scope)

## Closes
- Closes #36 — note the test named there (`ipc-server-race.test.ts:150`) no longer reproduces the failure. The actual on-main CI failures are these two; #36 was stale.

## Risk
Low. YAML-only pipeline change + 2 small test polyfills. No production code paths touched.