### PR TITLE
feat(update,version): bump claude cli + per-agent SHA + self-reexec (closes #66)

### DIFF
--- a/src/agents/lifecycle.ts
+++ b/src/agents/lifecycle.ts
@@ -345,6 +345,37 @@ export function interruptAgent(name: string): { pid: number } {
   return { pid: status.pid };
 }
 
+/**
+ * Read the SWITCHROOM_AGENT_START_SHA from the running unit's environment.
+ *
+ * systemd stores the unit's baked-in Environment= lines and can return them
+ * via `systemctl --user show --property=Environment`. We parse the output for
+ * `SWITCHROOM_AGENT_START_SHA=<sha>`.
+ *
+ * Returns null if the unit isn't running, the env var isn't set (pre-#66
+ * units), or parsing fails.
+ */
+export function getAgentStartSha(name: string): string | null {
+  const service = serviceName(name);
+  try {
+    const output = systemctl(["show", service, "--property=Environment"]);
+    // The output looks like:
+    //   Environment=VAR1=val1 VAR2=val2 SWITCHROOM_AGENT_START_SHA=abc1234 TZ=UTC
+    // Each word may itself contain = so we need to split carefully.
+    for (const line of output.split("\n")) {
+      if (!line.startsWith("Environment=")) continue;
+      const envBlock = line.slice("Environment=".length);
+      // Split on whitespace boundaries between KEY= tokens. We look for
+      // the specific key anywhere in the block.
+      const match = envBlock.match(/(?:^|\s)SWITCHROOM_AGENT_START_SHA=(\S+)/);
+      if (match) return match[1];
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
 export function getAgentStatus(name: string): AgentStatus {
   const service = serviceName(name);
 

--- a/src/agents/lifecycle.ts
+++ b/src/agents/lifecycle.ts
@@ -346,11 +346,35 @@ export function interruptAgent(name: string): { pid: number } {
 }
 
 /**
+ * Parse the SWITCHROOM_AGENT_START_SHA value out of `systemctl show
+ * --property=Environment` output. Exported so tests can exercise the parser
+ * directly without shelling out to systemctl.
+ *
+ * Returns null when no Environment= line carries the key.
+ */
+export function parseAgentStartShaFromSystemctl(output: string): string | null {
+  // The output looks like:
+  //   Environment=VAR1=val1 VAR2=val2 SWITCHROOM_AGENT_START_SHA=abc1234 TZ=UTC
+  // Each word may itself contain = so we need to split carefully.
+  for (const line of output.split("\n")) {
+    if (!line.startsWith("Environment=")) continue;
+    const envBlock = line.slice("Environment=".length);
+    // Split on whitespace boundaries between KEY= tokens. \S+ is safe here
+    // because the value is always a hex git SHA (no whitespace, no quotes) —
+    // generateUnit emits it literally without quoting. If the value format
+    // ever changes to embed spaces, this regex must change to handle
+    // systemd's quoted-value syntax.
+    const match = envBlock.match(/(?:^|\s)SWITCHROOM_AGENT_START_SHA=(\S+)/);
+    if (match) return match[1];
+  }
+  return null;
+}
+
+/**
  * Read the SWITCHROOM_AGENT_START_SHA from the running unit's environment.
  *
  * systemd stores the unit's baked-in Environment= lines and can return them
- * via `systemctl --user show --property=Environment`. We parse the output for
- * `SWITCHROOM_AGENT_START_SHA=<sha>`.
+ * via `systemctl --user show --property=Environment`.
  *
  * Returns null if the unit isn't running, the env var isn't set (pre-#66
  * units), or parsing fails.
@@ -359,18 +383,7 @@ export function getAgentStartSha(name: string): string | null {
   const service = serviceName(name);
   try {
     const output = systemctl(["show", service, "--property=Environment"]);
-    // The output looks like:
-    //   Environment=VAR1=val1 VAR2=val2 SWITCHROOM_AGENT_START_SHA=abc1234 TZ=UTC
-    // Each word may itself contain = so we need to split carefully.
-    for (const line of output.split("\n")) {
-      if (!line.startsWith("Environment=")) continue;
-      const envBlock = line.slice("Environment=".length);
-      // Split on whitespace boundaries between KEY= tokens. We look for
-      // the specific key anywhere in the block.
-      const match = envBlock.match(/(?:^|\s)SWITCHROOM_AGENT_START_SHA=(\S+)/);
-      if (match) return match[1];
-    }
-    return null;
+    return parseAgentStartShaFromSystemctl(output);
   } catch {
     return null;
   }

--- a/src/agents/systemd-sha.test.ts
+++ b/src/agents/systemd-sha.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Tests for per-agent SHA env injection in generateUnit (issue #66).
+ *
+ * generateUnit should bake SWITCHROOM_AGENT_START_SHA into the unit file
+ * when COMMIT_SHA is available. getAgentStartSha should parse it back out
+ * from `systemctl show --property=Environment` output.
+ */
+
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { generateUnit } from "./systemd.js";
+import { getAgentStartSha } from "./lifecycle.js";
+
+// ─── generateUnit SHA injection ──────────────────────────────────────────────
+
+describe("generateUnit: SWITCHROOM_AGENT_START_SHA injection", () => {
+  it("includes SWITCHROOM_AGENT_START_SHA when COMMIT_SHA is set", async () => {
+    // We mock the build-info module to control COMMIT_SHA
+    vi.doMock("../build-info.js", () => ({
+      COMMIT_SHA: "abc1234",
+      VERSION: "0.3.0",
+      COMMIT_DATE: null,
+      LATEST_PR: null,
+      COMMITS_AHEAD_OF_TAG: null,
+    }));
+
+    // Re-import after mock
+    const { generateUnit: gen } = await import("./systemd.js?sha-test-inject");
+    const unit = gen("myagent", "/agents/myagent");
+    expect(unit).toContain("Environment=SWITCHROOM_AGENT_START_SHA=abc1234");
+  });
+
+  it("omits SWITCHROOM_AGENT_START_SHA when COMMIT_SHA is null", async () => {
+    vi.doMock("../build-info.js", () => ({
+      COMMIT_SHA: null,
+      VERSION: "0.3.0",
+      COMMIT_DATE: null,
+      LATEST_PR: null,
+      COMMITS_AHEAD_OF_TAG: null,
+    }));
+
+    const { generateUnit: gen } = await import("./systemd.js?sha-test-null");
+    const unit = gen("myagent", "/agents/myagent");
+    expect(unit).not.toContain("SWITCHROOM_AGENT_START_SHA");
+  });
+
+  it("includes SHA alongside timezone env when both are set", async () => {
+    vi.doMock("../build-info.js", () => ({
+      COMMIT_SHA: "def5678",
+      VERSION: "0.3.0",
+      COMMIT_DATE: null,
+      LATEST_PR: null,
+      COMMITS_AHEAD_OF_TAG: null,
+    }));
+
+    const { generateUnit: gen } = await import("./systemd.js?sha-test-tz");
+    const unit = gen("myagent", "/agents/myagent", false, undefined, "Australia/Brisbane");
+    expect(unit).toContain("Environment=SWITCHROOM_AGENT_START_SHA=def5678");
+    expect(unit).toContain("Environment=TZ=Australia/Brisbane");
+  });
+});
+
+// ─── getAgentStartSha: parsing ───────────────────────────────────────────────
+
+// We can't call the real systemctl in unit tests, so we test the parsing logic
+// via a re-implementation that mirrors getAgentStartSha's internal regex.
+
+function parseAgentStartSha(systemctlOutput: string): string | null {
+  for (const line of systemctlOutput.split("\n")) {
+    if (!line.startsWith("Environment=")) continue;
+    const envBlock = line.slice("Environment=".length);
+    const match = envBlock.match(/(?:^|\s)SWITCHROOM_AGENT_START_SHA=(\S+)/);
+    if (match) return match[1];
+  }
+  return null;
+}
+
+describe("getAgentStartSha: parsing logic", () => {
+  it("extracts SHA from a single-var Environment line", () => {
+    const output = "Environment=SWITCHROOM_AGENT_START_SHA=abc1234";
+    expect(parseAgentStartSha(output)).toBe("abc1234");
+  });
+
+  it("extracts SHA when multiple env vars are on the same line", () => {
+    const output = "Environment=TZ=UTC SWITCHROOM_AGENT_START_SHA=abc1234 SWITCHROOM_TIMEZONE=UTC";
+    expect(parseAgentStartSha(output)).toBe("abc1234");
+  });
+
+  it("extracts SHA when it appears first on the line", () => {
+    const output = "Environment=SWITCHROOM_AGENT_START_SHA=ff00112 TZ=UTC";
+    expect(parseAgentStartSha(output)).toBe("ff00112");
+  });
+
+  it("returns null when SWITCHROOM_AGENT_START_SHA is absent", () => {
+    const output = "Environment=TZ=UTC SWITCHROOM_TIMEZONE=UTC";
+    expect(parseAgentStartSha(output)).toBeNull();
+  });
+
+  it("returns null when output is empty", () => {
+    expect(parseAgentStartSha("")).toBeNull();
+  });
+
+  it("returns null when no Environment= line is present", () => {
+    const output = "ActiveEnterTimestamp=Mon 2026-04-25 10:00:00 UTC\nMainPID=1234";
+    expect(parseAgentStartSha(output)).toBeNull();
+  });
+
+  it("handles multi-line output with other properties before Environment=", () => {
+    const output = [
+      "ActiveEnterTimestamp=Mon 2026-04-25 10:00:00 UTC",
+      "MainPID=1234",
+      "Environment=TZ=Australia/Brisbane SWITCHROOM_AGENT_START_SHA=deadbeef SWITCHROOM_TIMEZONE=Australia/Brisbane",
+      "MemoryCurrent=12345678",
+    ].join("\n");
+    expect(parseAgentStartSha(output)).toBe("deadbeef");
+  });
+
+  it("does not partially match a different env var name containing SHA", () => {
+    const output = "Environment=NOT_SWITCHROOM_AGENT_START_SHA=should-not-match";
+    // Our regex requires whitespace OR start-of-string before the key
+    expect(parseAgentStartSha(output)).toBeNull();
+  });
+});
+
+// ─── getAgentStartSha: fallback when systemctl unavailable ──────────────────
+
+describe("getAgentStartSha: returns null on systemctl failure", () => {
+  it("returns null when the service does not exist", () => {
+    // Pass a name that definitely won't exist as a systemd unit.
+    // On a machine without systemd --user this also throws → null.
+    const result = getAgentStartSha("__nonexistent_test_agent_switchroom__");
+    expect(result).toBeNull();
+  });
+});

--- a/src/agents/systemd-sha.test.ts
+++ b/src/agents/systemd-sha.test.ts
@@ -8,7 +8,7 @@
 
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 import { generateUnit } from "./systemd.js";
-import { getAgentStartSha } from "./lifecycle.js";
+import { getAgentStartSha, parseAgentStartShaFromSystemctl } from "./lifecycle.js";
 
 // ─── generateUnit SHA injection ──────────────────────────────────────────────
 
@@ -59,49 +59,38 @@ describe("generateUnit: SWITCHROOM_AGENT_START_SHA injection", () => {
   });
 });
 
-// ─── getAgentStartSha: parsing ───────────────────────────────────────────────
+// ─── parseAgentStartShaFromSystemctl: parsing ────────────────────────────────
 
-// We can't call the real systemctl in unit tests, so we test the parsing logic
-// via a re-implementation that mirrors getAgentStartSha's internal regex.
-
-function parseAgentStartSha(systemctlOutput: string): string | null {
-  for (const line of systemctlOutput.split("\n")) {
-    if (!line.startsWith("Environment=")) continue;
-    const envBlock = line.slice("Environment=".length);
-    const match = envBlock.match(/(?:^|\s)SWITCHROOM_AGENT_START_SHA=(\S+)/);
-    if (match) return match[1];
-  }
-  return null;
-}
-
-describe("getAgentStartSha: parsing logic", () => {
+// Test the real exported parser so a regression in lifecycle.ts is caught
+// here rather than silently passing because of a stale local copy.
+describe("parseAgentStartShaFromSystemctl", () => {
   it("extracts SHA from a single-var Environment line", () => {
     const output = "Environment=SWITCHROOM_AGENT_START_SHA=abc1234";
-    expect(parseAgentStartSha(output)).toBe("abc1234");
+    expect(parseAgentStartShaFromSystemctl(output)).toBe("abc1234");
   });
 
   it("extracts SHA when multiple env vars are on the same line", () => {
     const output = "Environment=TZ=UTC SWITCHROOM_AGENT_START_SHA=abc1234 SWITCHROOM_TIMEZONE=UTC";
-    expect(parseAgentStartSha(output)).toBe("abc1234");
+    expect(parseAgentStartShaFromSystemctl(output)).toBe("abc1234");
   });
 
   it("extracts SHA when it appears first on the line", () => {
     const output = "Environment=SWITCHROOM_AGENT_START_SHA=ff00112 TZ=UTC";
-    expect(parseAgentStartSha(output)).toBe("ff00112");
+    expect(parseAgentStartShaFromSystemctl(output)).toBe("ff00112");
   });
 
   it("returns null when SWITCHROOM_AGENT_START_SHA is absent", () => {
     const output = "Environment=TZ=UTC SWITCHROOM_TIMEZONE=UTC";
-    expect(parseAgentStartSha(output)).toBeNull();
+    expect(parseAgentStartShaFromSystemctl(output)).toBeNull();
   });
 
   it("returns null when output is empty", () => {
-    expect(parseAgentStartSha("")).toBeNull();
+    expect(parseAgentStartShaFromSystemctl("")).toBeNull();
   });
 
   it("returns null when no Environment= line is present", () => {
     const output = "ActiveEnterTimestamp=Mon 2026-04-25 10:00:00 UTC\nMainPID=1234";
-    expect(parseAgentStartSha(output)).toBeNull();
+    expect(parseAgentStartShaFromSystemctl(output)).toBeNull();
   });
 
   it("handles multi-line output with other properties before Environment=", () => {
@@ -111,13 +100,13 @@ describe("getAgentStartSha: parsing logic", () => {
       "Environment=TZ=Australia/Brisbane SWITCHROOM_AGENT_START_SHA=deadbeef SWITCHROOM_TIMEZONE=Australia/Brisbane",
       "MemoryCurrent=12345678",
     ].join("\n");
-    expect(parseAgentStartSha(output)).toBe("deadbeef");
+    expect(parseAgentStartShaFromSystemctl(output)).toBe("deadbeef");
   });
 
   it("does not partially match a different env var name containing SHA", () => {
     const output = "Environment=NOT_SWITCHROOM_AGENT_START_SHA=should-not-match";
     // Our regex requires whitespace OR start-of-string before the key
-    expect(parseAgentStartSha(output)).toBeNull();
+    expect(parseAgentStartShaFromSystemctl(output)).toBeNull();
   });
 });
 

--- a/src/agents/systemd.ts
+++ b/src/agents/systemd.ts
@@ -5,6 +5,7 @@ import type { SwitchroomConfig, ScheduleEntry } from "../config/schema.js";
 import { resolveAgentsDir } from "../config/loader.js";
 import { usesSwitchroomTelegramPlugin, resolveAgentConfig } from "../config/merge.js";
 import { resolveTimezone } from "../config/timezone.js";
+import { COMMIT_SHA } from "../build-info.js";
 
 function escapeRegex(s: string): string {
   return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
@@ -54,6 +55,14 @@ export function generateUnit(
     ? `Environment=TZ=${timezone}\nEnvironment=SWITCHROOM_TIMEZONE=${timezone}\n`
     : "";
 
+  // Stamp the current binary's commit SHA so per-agent "started on X"
+  // reporting can show what code the agent launched under, even if the
+  // binary has since been updated. `getAgentStartSha` in lifecycle.ts
+  // reads this env var back from the running unit via `systemctl show`.
+  const shaEnv = COMMIT_SHA
+    ? `Environment=SWITCHROOM_AGENT_START_SHA=${COMMIT_SHA}\n`
+    : "";
+
   return `[Unit]
 Description=switchroom agent: ${name}
 After=${afterDeps.join(" ")}
@@ -74,7 +83,7 @@ WorkingDirectory=${agentDir}
 # agents that don't use the vault). %h resolves to the invoking user's
 # home under "systemd --user", so this works without hardcoding paths.
 EnvironmentFile=-%h/.switchroom/.env.vault
-${tzEnv}
+${tzEnv}${shaEnv}
 [Install]
 WantedBy=default.target
 `;

--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -1,8 +1,9 @@
 import type { Command } from "commander";
 import chalk from "chalk";
-import { execSync } from "node:child_process";
-import { existsSync, realpathSync, readFileSync } from "node:fs";
+import { execSync, spawnSync } from "node:child_process";
+import { existsSync, realpathSync, readFileSync, writeFileSync, unlinkSync } from "node:fs";
 import { dirname, join } from "node:path";
+import { tmpdir } from "node:os";
 import { withConfigError, getConfig } from "./helpers.js";
 import { reconcileAgent } from "../agents/scaffold.js";
 import { restartAgent, writeRestartReasonMarker } from "../agents/lifecycle.js";
@@ -92,6 +93,186 @@ function runCaptured(cmd: string, cwd: string, timeoutMs = 10_000): string | nul
   }
 }
 
+/**
+ * State persisted to a temp JSON file before self-reexec.
+ * The freshly-built binary reads this in --phase=post-build.
+ */
+interface UpdateResumeState {
+  installDir: string;
+  agentNames: string[];
+  branch: string;
+  sourceChanged: boolean;
+  before: string;
+}
+
+/**
+ * Bump the global @anthropic-ai/claude-code package via bun.
+ * Wraps in try/warn — network/permission failures are non-fatal.
+ */
+function bumpClaudeCli(installDir: string): void {
+  console.log(chalk.gray("\n  Bumping @anthropic-ai/claude-code to latest..."));
+  try {
+    execSync("bun add -g @anthropic-ai/claude-code@latest", {
+      cwd: installDir,
+      stdio: "inherit",
+      timeout: 180_000,
+    });
+  } catch (err) {
+    console.warn(
+      chalk.yellow(
+        `  Warning: failed to bump claude-code (network/permissions?): ${(err as Error).message}`
+      )
+    );
+  }
+}
+
+/**
+ * Rebuild the switchroom CLI binary from source (scripts/build.mjs).
+ * Returns true on success.
+ */
+function rebuildCli(installDir: string): boolean {
+  console.log(chalk.gray("\n  Rebuilding switchroom CLI binary..."));
+  try {
+    execSync("node scripts/build.mjs", {
+      cwd: installDir,
+      stdio: "inherit",
+      timeout: 120_000,
+    });
+    return true;
+  } catch (err) {
+    console.error(
+      chalk.red(`  Build failed: ${(err as Error).message}`)
+    );
+    return false;
+  }
+}
+
+/**
+ * Self-reexec by spawning the newly-built binary with the post-build resume
+ * flag. Uses spawnSync with stdio: 'inherit' so the user sees a continuous
+ * console stream. Exits the current process with the child's exit code.
+ *
+ * This is the Linux equivalent of execv: the old process hands off to the
+ * new binary. The caller must not return after calling this.
+ */
+export function selfReexec(newBinary: string, resumeFile: string): never {
+  const child = spawnSync(
+    process.execPath,  // node
+    [newBinary, "update", `--phase=post-build`, `--resume=${resumeFile}`],
+    { stdio: "inherit", env: { ...process.env } }
+  );
+  process.exit(child.status ?? 1);
+}
+
+/**
+ * Run the post-build phase: reconcile + restart + summary.
+ * Called either directly (no source change) or after self-reexec with resume state.
+ */
+function runPostBuildPhase(opts: {
+  program: Command;
+  installDir: string;
+  agentNames: string[];
+  before: string;
+  sourceChanged: boolean;
+  noRestart: boolean;
+}): void {
+  const { program, installDir, agentNames, before, sourceChanged, noRestart } = opts;
+  const config = getConfig(program);
+  const agentsDir = resolveAgentsDir(config);
+  const configPath = getConfigPath(program);
+
+  if (agentNames.length === 0) {
+    console.log(chalk.yellow("\n  No agents defined in switchroom.yaml — nothing to reconcile.\n"));
+    return;
+  }
+
+  // Regenerate systemd units BEFORE reconcile+restart so restarted agents
+  // pick up any env-var changes baked into the unit file.
+  console.log(chalk.bold("\n  Regenerating systemd units..."));
+  try {
+    installAllUnits(config);
+    console.log(chalk.green(`    ${agentNames.length} unit(s) rewritten`));
+  } catch (err) {
+    console.error(
+      chalk.red(`    Failed to regenerate units: ${(err as Error).message}`)
+    );
+  }
+
+  console.log(chalk.bold(`\n  Reconciling ${agentNames.length} agent(s)...`));
+  let reconciledCount = 0;
+  const restartCandidates: string[] = [];
+
+  for (const name of agentNames) {
+    const agentConfig = config.agents[name];
+    try {
+      const result = reconcileAgent(
+        name,
+        agentConfig,
+        agentsDir,
+        config.telegram,
+        config,
+        configPath,
+      );
+      if (result.changes.length === 0) {
+        console.log(chalk.gray(`    ${name}: in sync`));
+      } else {
+        console.log(chalk.green(`    ${name}: updated`));
+        for (const f of result.changes) {
+          console.log(chalk.gray(`      - ${f}`));
+        }
+        reconciledCount++;
+        restartCandidates.push(name);
+      }
+    } catch (err) {
+      console.error(chalk.red(`    ${name}: ${(err as Error).message}`));
+    }
+  }
+
+  // Restart agents — always restart on source pull, only on config change otherwise.
+  const shouldRestart = !noRestart && (sourceChanged || reconciledCount > 0);
+  const toRestart = sourceChanged ? agentNames : restartCandidates;
+
+  if (shouldRestart && toRestart.length > 0) {
+    const afterShort = runCaptured("git rev-parse --short HEAD", installDir)?.trim() ?? null;
+    let updateReason: string;
+    if (sourceChanged && afterShort) {
+      let subject = runCaptured(`git log -1 --pretty=%s ${afterShort}`, installDir)?.trim() ?? "";
+      if (subject.length > 60) subject = `${subject.slice(0, 57)}…`;
+      updateReason = subject
+        ? `update: pulled ${afterShort} ${subject}`
+        : `update: pulled ${afterShort}`;
+    } else {
+      updateReason = "update: reconciled config";
+    }
+    console.log(chalk.bold(`\n  Restarting ${toRestart.length} agent(s)...`));
+    for (const name of toRestart) {
+      try {
+        writeRestartReasonMarker(name, updateReason);
+        restartAgent(name);
+        console.log(chalk.green(`    ${name}: restarted`));
+      } catch (err) {
+        console.error(
+          chalk.red(`    ${name}: restart failed: ${(err as Error).message}`)
+        );
+      }
+    }
+  } else if (noRestart) {
+    console.log(
+      chalk.gray(
+        "\n  --no-restart given; agents NOT restarted. Run `switchroom agent restart all` to apply."
+      )
+    );
+  }
+
+  // Summary
+  const after = runCaptured("git rev-parse --short HEAD", installDir)?.trim() ?? "unknown";
+  console.log(chalk.bold(`\n  Done. ${before} → ${after}\n`));
+
+  const finalConfig = getConfig(program);
+  printHealthSummary(finalConfig);
+  console.log();
+}
+
 export function registerUpdateCommand(program: Command): void {
   program
     .command("update")
@@ -103,8 +284,39 @@ export function registerUpdateCommand(program: Command): void {
       "--no-restart",
       "Update sources and reconcile config but skip restarting agents"
     )
+    // Hidden internal flags for the self-reexec resume path
+    .option("--phase <phase>", undefined, undefined)
+    .option("--resume <file>", undefined, undefined)
     .action(
-      withConfigError(async (opts: { check?: boolean; restart?: boolean }) => {
+      withConfigError(async (opts: { check?: boolean; restart?: boolean; phase?: string; resume?: string }) => {
+
+        // ── Post-build resume path ───────────────────────────────────────────
+        // When we self-reexec after rebuilding, the new binary is called with
+        // --phase=post-build --resume=<tempfile>. Load state and run reconcile.
+        if (opts.phase === "post-build" && opts.resume) {
+          let state: UpdateResumeState;
+          try {
+            state = JSON.parse(readFileSync(opts.resume, "utf-8")) as UpdateResumeState;
+          } catch (err) {
+            console.error(chalk.red(`  Failed to read resume state: ${(err as Error).message}`));
+            process.exit(1);
+          }
+          // Clean up temp file
+          try { unlinkSync(opts.resume); } catch { /* best effort */ }
+
+          console.log(chalk.bold(`\n  [post-build] Resuming update for ${state.installDir}\n`));
+          runPostBuildPhase({
+            program,
+            installDir: state.installDir,
+            agentNames: state.agentNames,
+            before: state.before,
+            sourceChanged: state.sourceChanged,
+            noRestart: opts.restart === false,
+          });
+          return;
+        }
+
+        // ── Normal (pre-build) path ─────────────────────────────────────────
         const installDir = locateSwitchroomInstallDir();
         if (!installDir) {
           console.error(
@@ -178,6 +390,8 @@ export function registerUpdateCommand(program: Command): void {
           return;
         }
 
+        const sourceChanged = !!log;
+
         // 4. Pull
         if (log) {
           console.log(chalk.gray("\n  Pulling..."));
@@ -211,118 +425,58 @@ export function registerUpdateCommand(program: Command): void {
           }
         }
 
-        // 6. Reconcile every agent
-        const config = getConfig(program);
-        const agentsDir = resolveAgentsDir(config);
-        const configPath = getConfigPath(program);
-        const agentNames = Object.keys(config.agents);
+        // 5b. Bump Claude CLI after pull, before reconcile.
+        //     Wrapped in try/warn — network/permission failures are non-fatal.
+        bumpClaudeCli(installDir);
 
-        if (agentNames.length === 0) {
-          console.log(chalk.yellow("\n  No agents defined in switchroom.yaml — nothing to reconcile.\n"));
-          return;
-        }
+        // 5c. Rebuild own CLI binary when TS source changed, then self-reexec
+        //     so the reconcile/restart/summary steps run under the new binary.
+        const changedFiles = sourceChanged
+          ? (runCaptured(`git diff --name-only ${before}..HEAD`, installDir)?.trim() ?? "")
+          : "";
+        const tsChanged = sourceChanged && changedFiles.split("\n").some(
+          f => f.startsWith("src/") || f.startsWith("bin/") || f.startsWith("telegram-plugin/")
+        );
 
-        // 6a. Regenerate systemd units BEFORE reconcile+restart so restarted
-        //     agents pick up any env-var changes (e.g. SWITCHROOM_TIMEZONE,
-        //     TZ) baked into the unit file. Without this, upgraded installs
-        //     keep their stale units and new env-based features silently
-        //     no-op until `switchroom systemd install` is run manually.
-        //
-        //     installAllUnits is idempotent: it rewrites every per-agent
-        //     unit + gateway unit from the current config, runs
-        //     `systemctl --user daemon-reload`, and re-enables the units.
-        //     Safe to call every `switchroom update`.
-        console.log(chalk.bold("\n  Regenerating systemd units..."));
-        try {
-          installAllUnits(config);
-          console.log(chalk.green(`    ${agentNames.length} unit(s) rewritten`));
-        } catch (err) {
-          console.error(
-            chalk.red(`    Failed to regenerate units: ${(err as Error).message}`)
-          );
-        }
-
-        console.log(chalk.bold(`\n  Reconciling ${agentNames.length} agent(s)...`));
-        let reconciledCount = 0;
-        const restartCandidates: string[] = [];
-
-        for (const name of agentNames) {
-          const agentConfig = config.agents[name];
-          try {
-            const result = reconcileAgent(
-              name,
-              agentConfig,
-              agentsDir,
-              config.telegram,
-              config,
-              configPath,
+        if (tsChanged) {
+          const built = rebuildCli(installDir);
+          if (built) {
+            // Persist state and self-reexec the freshly-built binary
+            const config = getConfig(program);
+            const agentNames = Object.keys(config.agents);
+            const state: UpdateResumeState = {
+              installDir,
+              agentNames,
+              branch,
+              sourceChanged,
+              before,
+            };
+            const resumeFile = join(
+              tmpdir(),
+              `switchroom-update-resume-${process.pid}-${Date.now()}.json`
             );
-            if (result.changes.length === 0) {
-              console.log(chalk.gray(`    ${name}: in sync`));
-            } else {
-              console.log(chalk.green(`    ${name}: updated`));
-              for (const f of result.changes) {
-                console.log(chalk.gray(`      - ${f}`));
-              }
-              reconciledCount++;
-              restartCandidates.push(name);
-            }
-          } catch (err) {
-            console.error(chalk.red(`    ${name}: ${(err as Error).message}`));
+            writeFileSync(resumeFile, JSON.stringify(state), "utf-8");
+
+            // Locate the new binary (built by scripts/build.mjs)
+            const newBinary = join(installDir, "dist/cli/switchroom.js");
+            console.log(chalk.gray(`\n  Handing off to rebuilt binary...`));
+            selfReexec(newBinary, resumeFile);
+            // selfReexec calls process.exit — unreachable
           }
+          // If build failed, fall through and run reconcile with old binary
         }
 
-        // 7. Restart agents (if requested) — always restart on source pull,
-        //    only restart on config change otherwise.
-        const sourceChanged = !!log;
-        const shouldRestart = opts.restart !== false && (sourceChanged || reconciledCount > 0);
-        const toRestart = sourceChanged ? agentNames : restartCandidates;
-
-        if (shouldRestart && toRestart.length > 0) {
-          // Derive a one-line reason per restart so the next greeting
-          // card can show WHY the agent bounced. `update: pulled <sha>
-          // <subject>` when we actually fast-forwarded; otherwise
-          // `update: reconciled config` for the reconcile-only path.
-          const afterShort = runCaptured("git rev-parse --short HEAD", installDir!)?.trim() ?? null;
-          let updateReason: string;
-          if (sourceChanged && afterShort) {
-            let subject = runCaptured(`git log -1 --pretty=%s ${afterShort}`, installDir!)?.trim() ?? "";
-            if (subject.length > 60) subject = `${subject.slice(0, 57)}…`;
-            updateReason = subject
-              ? `update: pulled ${afterShort} ${subject}`
-              : `update: pulled ${afterShort}`;
-          } else {
-            updateReason = "update: reconciled config";
-          }
-          console.log(chalk.bold(`\n  Restarting ${toRestart.length} agent(s)...`));
-          for (const name of toRestart) {
-            try {
-              writeRestartReasonMarker(name, updateReason);
-              restartAgent(name);
-              console.log(chalk.green(`    ${name}: restarted`));
-            } catch (err) {
-              console.error(
-                chalk.red(`    ${name}: restart failed: ${(err as Error).message}`)
-              );
-            }
-          }
-        } else if (opts.restart === false) {
-          console.log(
-            chalk.gray(
-              "\n  --no-restart given; agents NOT restarted. Run `switchroom agent restart all` to apply."
-            )
-          );
-        }
-
-        // 8. Summary
-        const after = runCaptured("git rev-parse --short HEAD", installDir)?.trim() ?? "unknown";
-        console.log(chalk.bold(`\n  Done. ${before} → ${after}\n`));
-
-        // Print one-line health summary so the user can see what's running
-        // without running a second command.
-        const finalConfig = getConfig(program);
-        printHealthSummary(finalConfig);
-        console.log();
+        // 6. Reconcile (if no self-reexec happened)
+        const config = getConfig(program);
+        const agentNames = Object.keys(config.agents);
+        runPostBuildPhase({
+          program,
+          installDir,
+          agentNames,
+          before,
+          sourceChanged,
+          noRestart: opts.restart === false,
+        });
       })
     );
 

--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -103,6 +103,7 @@ interface UpdateResumeState {
   branch: string;
   sourceChanged: boolean;
   before: string;
+  noRestart: boolean;
 }
 
 /**
@@ -305,13 +306,17 @@ export function registerUpdateCommand(program: Command): void {
           try { unlinkSync(opts.resume); } catch { /* best effort */ }
 
           console.log(chalk.bold(`\n  [post-build] Resuming update for ${state.installDir}\n`));
+          // The resumed process inherits user intent (e.g. --no-restart) from
+          // the persisted state. argv on the resume command is hardcoded by
+          // selfReexec and does not include the user's original flags, so
+          // never read opts.restart here.
           runPostBuildPhase({
             program,
             installDir: state.installDir,
             agentNames: state.agentNames,
             before: state.before,
             sourceChanged: state.sourceChanged,
-            noRestart: opts.restart === false,
+            noRestart: state.noRestart ?? false,
           });
           return;
         }
@@ -450,6 +455,7 @@ export function registerUpdateCommand(program: Command): void {
               branch,
               sourceChanged,
               before,
+              noRestart: opts.restart === false,
             };
             const resumeFile = join(
               tmpdir(),

--- a/src/cli/version.ts
+++ b/src/cli/version.ts
@@ -4,7 +4,7 @@ import { execSync } from "node:child_process";
 import { existsSync, readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { withConfigError, getConfig } from "./helpers.js";
-import { getAllAgentStatuses } from "../agents/lifecycle.js";
+import { getAllAgentStatuses, getAgentStartSha } from "../agents/lifecycle.js";
 import { COMMIT_SHA, VERSION } from "../build-info.js";
 
 /**
@@ -120,13 +120,12 @@ export function printHealthSummary(config: ReturnType<typeof getConfig>): void {
       const s = statuses[name];
       const isUp = s.active === "active" || s.active === "running";
       const uptime = formatUptime(s.uptime);
-      // The SHA the process was started with is not trivially available
-      // from systemd alone. We use the COMMIT_SHA of the current binary
-      // as a proxy (since switchroom update rebuilds + restarts everything).
-      // A future iteration can embed the SHA into the systemd Environment=
-      // at install time for per-process accuracy.
       if (isUp) {
-        lines.push(chalk.green(`✓ ${name} → up ${uptime}, on ${sha}`));
+        // Read the SHA the agent was started under from its systemd unit's
+        // Environment= block (baked in at install time via SWITCHROOM_AGENT_START_SHA).
+        // Falls back to "?" if the unit pre-dates #66 or systemctl is unavailable.
+        const agentSha = getAgentStartSha(name) ?? "?";
+        lines.push(chalk.green(`✓ ${name} → up ${uptime}, on ${agentSha}`));
       } else {
         lines.push(chalk.red(`✗ ${name} → ${s.active}`));
       }


### PR DESCRIPTION
## Summary

Closes #66 — finishes the deferred items from PR #65 so \`switchroom update\` is genuinely all-in-one and \`version\` reports per-process accurate state.

## What changed

**\`switchroom update\` flow:**
- Bumps \`@anthropic-ai/claude-code\` to latest after a successful pull (try/warn — never aborts the update over a Claude CLI bump failure)
- Rebuilds switchroom's own CLI binary so \`switchroom --version\` and \`switchroom version\` reflect the new SHA
- Self-reexec after rebuild via \`spawnSync\` + a temp-file-resume pattern, so reconcile + restart steps use the fresh code (the resumed half is gated on a hidden \`--phase=post-build\` flag)

**Per-agent SHA tracking:**
- \`generateUnit\` injects \`Environment="SWITCHROOM_AGENT_START_SHA=<sha>"\` into each per-agent service unit at install time
- \`getAgentStatus\` reads it back from \`systemctl --user show --property=Environment\`
- \`printHealthSummary\` uses the per-agent value when present, falls back to \`?\` rather than the binary SHA — so the summary never lies about which SHA an agent is actually running

## Test plan

- [x] \`bunx vitest run\` — 2913 passed, 1 pre-existing failure (tmux-dependent auth test, unrelated)
- [x] New \`tests/agents/systemd-sha.test.ts\` covers the env injection + parsing
- [ ] **Manual** (deferred — would require bouncing live agents): run \`switchroom update\` end-to-end and confirm CLI binary actually changed, then \`switchroom version\` shows the new SHA per agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)