### PR TITLE
WIP feat(telegram): subagent visibility scaffold (#64)

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -159,6 +159,10 @@ import { maskToken } from '../secret-detect/mask.js'
 import { defaultVaultWrite, defaultVaultList } from '../secret-detect/vault-write.js'
 import { detectSecrets } from '../secret-detect/index.js'
 import { ADMIN_COMMAND_NAMES, parseCommandName } from '../admin-commands/index.js'
+import {
+  startSubagentWatcher,
+  type SubagentWatcherHandle,
+} from '../subagent-watcher.js'
 
 // ─── Stderr logging ───────────────────────────────────────────────────────
 installPluginLogger()
@@ -751,6 +755,7 @@ const streamMode = process.env.SWITCHROOM_TG_STREAM_MODE ?? 'checklist'
 const TURN_FLUSH_SAFETY_ENABLED = isTurnFlushSafetyEnabled()
 let progressDriver: ProgressDriver | null = null
 let unpinProgressCardForChat: ((chatId: string, threadId: number | undefined) => void) | null = null
+let subagentWatcher: SubagentWatcherHandle | null = null
 
 // ─── IPC server ───────────────────────────────────────────────────────────
 const SOCKET_PATH = process.env.SWITCHROOM_GATEWAY_SOCKET ?? join(STATE_DIR, 'gateway.sock')
@@ -4456,6 +4461,9 @@ async function shutdown(signal: string): Promise<void> {
   // Clean up all timers and pending state.
   // Snapshot timer handles before clearing so a late-firing timer can't
   // invalidate the iterator by deleting its own entry during cleanup.
+  subagentWatcher?.stop()
+  subagentWatcher = null
+
   for (const iv of [...typingIntervals.values()]) clearInterval(iv)
   typingIntervals.clear()
   for (const t of [...typingRetryTimers.values()]) clearTimeout(t)
@@ -4926,6 +4934,76 @@ void (async () => {
         const AUTO_FALLBACK_POLL_MS = Number(process.env.SWITCHROOM_AUTO_FALLBACK_POLL_MS ?? 60 * 60_000)
         if (AUTO_FALLBACK_POLL_MS > 0) {
           setInterval(() => { void runAutoFallbackCheck({ trigger: 'scheduled' }) }, AUTO_FALLBACK_POLL_MS).unref()
+        }
+
+        // Background sub-agent visibility watcher. Watches the subagents/
+        // directory under each session dir for new agent-<id>.jsonl files
+        // and surfaces live activity to Telegram via a pinned card +
+        // inline notifications. Only started when a valid agentDir is known
+        // (gate on streamMode=checklist for progress-card parity).
+        if (streamMode === 'checklist') {
+          const watcherAgentDir = resolveAgentDirFromEnv()
+          if (watcherAgentDir != null) {
+            // Pinned worker card: one message per watcher session,
+            // edited in-place. Managed entirely by the watcher.
+            let workerCardMsgId: number | null = null
+
+            subagentWatcher = startSubagentWatcher({
+              agentDir: watcherAgentDir,
+              sendNotification: (text: string) => {
+                const ownerChatId = loadAccess().allowFrom[0]
+                if (!ownerChatId) return
+                void lockedBot.api.sendMessage(ownerChatId, text, {
+                  parse_mode: 'HTML',
+                  link_preview_options: { is_disabled: true },
+                  ...(TOPIC_ID != null ? { message_thread_id: TOPIC_ID } : {}),
+                }).catch((err: Error) => {
+                  process.stderr.write(`telegram gateway: subagent-watcher notification failed: ${err.message}\n`)
+                })
+              },
+              updatePinnedCard: (html: string | null) => {
+                const ownerChatId = loadAccess().allowFrom[0]
+                if (!ownerChatId) return
+                if (html === null) {
+                  // No active workers — unpin and delete the card
+                  if (workerCardMsgId != null) {
+                    const msgId = workerCardMsgId
+                    workerCardMsgId = null
+                    void lockedBot.api.unpinChatMessage(ownerChatId, msgId).catch(() => {})
+                    void lockedBot.api.deleteMessage(ownerChatId, msgId).catch(() => {})
+                  }
+                  return
+                }
+                if (workerCardMsgId == null) {
+                  // Create a new pinned card
+                  void lockedBot.api.sendMessage(ownerChatId, html, {
+                    parse_mode: 'HTML',
+                    link_preview_options: { is_disabled: true },
+                    ...(TOPIC_ID != null ? { message_thread_id: TOPIC_ID } : {}),
+                  }).then((sent) => {
+                    workerCardMsgId = sent.message_id
+                    void lockedBot.api.pinChatMessage(ownerChatId, sent.message_id, {
+                      disable_notification: true,
+                    }).catch(() => {})
+                  }).catch((err: Error) => {
+                    process.stderr.write(`telegram gateway: subagent-watcher card send failed: ${err.message}\n`)
+                  })
+                } else {
+                  // Edit the existing card
+                  void lockedBot.api.editMessageText(ownerChatId, workerCardMsgId, html, {
+                    parse_mode: 'HTML',
+                    link_preview_options: { is_disabled: true },
+                  }).catch((err: Error) => {
+                    const msg = err instanceof GrammyError && err.error_code === 400 &&
+                      /message is not modified/i.test(err.description ?? '') ? '' : err.message
+                    if (msg) process.stderr.write(`telegram gateway: subagent-watcher card edit failed: ${msg}\n`)
+                  })
+                }
+              },
+              log: (msg) => process.stderr.write(`telegram gateway: ${msg}\n`),
+            })
+            process.stderr.write('telegram gateway: subagent-watcher active\n')
+          }
         }
       }
 

--- a/telegram-plugin/subagent-watcher.ts
+++ b/telegram-plugin/subagent-watcher.ts
@@ -347,6 +347,12 @@ export function startSubagentWatcher(config: SubagentWatcherConfig): SubagentWat
       maybeSendCardUpdate()
     }, fs, log)
 
+    // If the JSONL already contained a turn_end at registration time
+    // (file written-then-watched), fire the state-transition + completion
+    // notification now. Otherwise the FSWatcher callback handles it on
+    // subsequent writes.
+    maybySendStateTransition(agentId)
+
     // Set up FSWatcher
     try {
       tail.watcher = fs.watch(filePath, () => {

--- a/telegram-plugin/subagent-watcher.ts
+++ b/telegram-plugin/subagent-watcher.ts
@@ -99,6 +99,20 @@ export interface SubagentWatcherConfig {
   /** `setTimeout` override for tests. */
   setTimeout?: (fn: () => void, ms: number) => { ref: unknown }
   clearTimeout?: (ref: unknown) => void
+  /**
+   * `fs` overrides for tests. ESM namespace exports are not configurable so
+   * `vi.spyOn(fs, ...)` doesn't work — tests inject a mock object here
+   * instead. Defaults to the real `node:fs` functions.
+   */
+  fs?: {
+    existsSync: typeof existsSync
+    readdirSync: typeof readdirSync
+    statSync: typeof statSync
+    openSync: typeof openSync
+    closeSync: typeof closeSync
+    readSync: typeof readSync
+    watch: typeof watch
+  }
 }
 
 export interface SubagentWatcherHandle {
@@ -166,15 +180,26 @@ interface SubTail {
   watcher: FSWatcher | null
 }
 
+interface FsLike {
+  existsSync: typeof existsSync
+  readdirSync: typeof readdirSync
+  statSync: typeof statSync
+  openSync: typeof openSync
+  closeSync: typeof closeSync
+  readSync: typeof readSync
+  watch: typeof watch
+}
+
 function readSubTail(
   entry: WorkerEntry,
   tail: SubTail,
   now: number,
   onDescriptionUpdate: (desc: string) => void,
+  fs: FsLike,
   log?: (msg: string) => void,
 ): void {
   try {
-    const stat = statSync(entry.filePath)
+    const stat = fs.statSync(entry.filePath)
     if (stat.size < tail.cursor) {
       tail.cursor = 0
       tail.pendingPartial = ''
@@ -182,11 +207,11 @@ function readSubTail(
     if (stat.size === tail.cursor) return
 
     const buf = Buffer.alloc(stat.size - tail.cursor)
-    const fd = openSync(entry.filePath, 'r')
+    const fd = fs.openSync(entry.filePath, 'r')
     try {
-      readSync(fd, buf, 0, buf.length, tail.cursor)
+      fs.readSync(fd, buf, 0, buf.length, tail.cursor)
     } finally {
-      closeSync(fd)
+      fs.closeSync(fd)
     }
     tail.cursor = stat.size
 
@@ -242,6 +267,17 @@ export function startSubagentWatcher(config: SubagentWatcherConfig): SubagentWat
   const clearI = config.clearInterval ?? ((ref) => {
     clearInterval((ref as { ref: ReturnType<typeof setInterval> }).ref)
   })
+
+  // fs DI: tests pass a mock; production uses the real node:fs functions.
+  const fs = config.fs ?? {
+    existsSync,
+    readdirSync,
+    statSync,
+    openSync,
+    closeSync,
+    readSync,
+    watch,
+  }
 
   // Registry: agentId → WorkerEntry
   const registry = new Map<string, WorkerEntry>()
@@ -309,11 +345,11 @@ export function startSubagentWatcher(config: SubagentWatcherConfig): SubagentWat
     readSubTail(entry, tail, n, (desc) => {
       log?.(`subagent-watcher: description updated for ${agentId}: ${desc}`)
       maybeSendCardUpdate()
-    }, log)
+    }, fs, log)
 
     // Set up FSWatcher
     try {
-      tail.watcher = watch(filePath, () => {
+      tail.watcher = fs.watch(filePath, () => {
         if (stopped) return
         const entry = registry.get(agentId)
         const t = tails.get(agentId)
@@ -321,7 +357,7 @@ export function startSubagentWatcher(config: SubagentWatcherConfig): SubagentWat
         readSubTail(entry, t, nowFn(), (desc) => {
           log?.(`subagent-watcher: description updated for ${agentId}: ${desc}`)
           maybeSendCardUpdate()
-        }, log)
+        }, fs, log)
         maybySendStateTransition(agentId)
         maybeSendCardUpdate()
       })
@@ -396,32 +432,32 @@ export function startSubagentWatcher(config: SubagentWatcherConfig): SubagentWat
     if (stopped) return
     const claudeHome = join(agentDir, '.claude')
     const projectsRoot = join(claudeHome, 'projects')
-    if (!existsSync(projectsRoot)) return
+    if (!fs.existsSync(projectsRoot)) return
 
     let projectDirs: string[]
     try {
-      projectDirs = readdirSync(projectsRoot)
+      projectDirs = fs.readdirSync(projectsRoot) as string[]
     } catch { return }
 
     for (const pDir of projectDirs) {
       const projectPath = join(projectsRoot, pDir)
       let sessionDirs: string[]
       try {
-        sessionDirs = readdirSync(projectPath)
+        sessionDirs = fs.readdirSync(projectPath) as string[]
       } catch { continue }
 
       for (const sDir of sessionDirs) {
         // Session dirs are UUID-like; skip known non-session entries
         if (sDir.endsWith('.jsonl')) continue
         const subagentsPath = join(projectPath, sDir, 'subagents')
-        if (!existsSync(subagentsPath)) continue
+        if (!fs.existsSync(subagentsPath)) continue
 
         // Watch the subagents dir for new files if not already watching
         if (!dirWatchers.has(subagentsPath)) {
           try {
-            const w = watch(subagentsPath, (_event, filename) => {
-              if (!filename || !filename.startsWith('agent-') || !filename.endsWith('.jsonl')) return
-              const filePath = join(subagentsPath, filename)
+            const w = fs.watch(subagentsPath, (_event, filename) => {
+              if (!filename || !filename.toString().startsWith('agent-') || !filename.toString().endsWith('.jsonl')) return
+              const filePath = join(subagentsPath, filename.toString())
               if (!knownFiles.has(filePath)) {
                 scanSubagentsDir(subagentsPath)
               }
@@ -442,7 +478,7 @@ export function startSubagentWatcher(config: SubagentWatcherConfig): SubagentWat
   function scanSubagentsDir(subagentsPath: string): void {
     let entries: string[]
     try {
-      entries = readdirSync(subagentsPath)
+      entries = fs.readdirSync(subagentsPath) as string[]
     } catch { return }
 
     for (const e of entries) {

--- a/telegram-plugin/subagent-watcher.ts
+++ b/telegram-plugin/subagent-watcher.ts
@@ -507,7 +507,7 @@ export function startSubagentWatcher(config: SubagentWatcherConfig): SubagentWat
       if (!tail) continue
       readSubTail(entry, tail, n, (desc) => {
         log?.(`subagent-watcher: description updated for ${agentId}: ${desc}`)
-      }, log)
+      }, fs, log)
       maybySendStateTransition(agentId)
     }
 

--- a/telegram-plugin/subagent-watcher.ts
+++ b/telegram-plugin/subagent-watcher.ts
@@ -1,0 +1,515 @@
+/**
+ * Background sub-agent visibility — registry + directory watcher + pinned card.
+ *
+ * Watches the subagents/ directory under each active session dir for new
+ * agent-<id>.jsonl files. For each discovered sub-agent it:
+ *   1. Registers it in an in-memory registry.
+ *   2. Tails the JSONL to count tool calls and detect turn_end.
+ *   3. Maintains a pinned "worker card" in Telegram showing live state.
+ *   4. Emits inline notifications for dispatch / stall / completion events.
+ *
+ * Architecture notes:
+ *   - Option B from the spec: filesystem-driven, no IPC contract.
+ *   - The registry is independent of the progress-card driver — it watches
+ *     the subagents/ directories directly, not the parent session JSONL.
+ *   - The pinned card is a separate Telegram message managed here; it does
+ *     NOT interact with the progress-card pin lifecycle.
+ *   - Privacy: tool counts + descriptions only — no tool args or file content.
+ *
+ * Integration: call `startSubagentWatcher(config)` once at gateway startup
+ * (after the bot is ready). Call `.stop()` on shutdown.
+ */
+
+import {
+  existsSync,
+  openSync,
+  readSync,
+  statSync,
+  closeSync,
+  watch,
+  readdirSync,
+  type FSWatcher,
+} from 'fs'
+import { basename, join } from 'path'
+import { homedir } from 'os'
+import { projectSubagentLine } from './session-tail.js'
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+export type WorkerState = 'running' | 'done' | 'failed'
+
+export interface WorkerEntry {
+  /** Sub-agent JSONL file stem, e.g. "a75d4757a81e7b1f8". */
+  readonly agentId: string
+  /** File path of the JSONL. */
+  readonly filePath: string
+  /** Short description — from the sub-agent's first text/narrative line. */
+  description: string
+  /** Current lifecycle state. */
+  state: WorkerState
+  readonly dispatchedAt: number
+  lastActivityAt: number
+  /** Number of tool calls seen so far. */
+  toolCount: number
+  /** True once a stall notification has been sent (suppresses repeat). */
+  stallNotified: boolean
+  /** True once a completion notification has been sent. */
+  completionNotified: boolean
+  /** Short summary from last completed tool / narrative, for completion message. */
+  lastSummaryLine: string
+}
+
+export interface SubagentWatcherConfig {
+  /**
+   * Agent home directory (e.g. `/home/user/.switchroom/agents/klanker`).
+   * Used to derive `.claude/projects/<cwd>/` dirs to watch.
+   */
+  agentDir: string
+  /**
+   * Send a fresh (non-edit) Telegram message. For dispatch / completion / stall
+   * notifications.
+   */
+  sendNotification: (text: string) => void
+  /**
+   * Send + manage the pinned worker card. Called on every registry change
+   * (throttled internally). Receives null to delete/unpin the card when no
+   * workers are active.
+   */
+  updatePinnedCard: (html: string | null) => void
+  /**
+   * How often to re-scan for new subagent dirs (ms). Default 1000.
+   */
+  rescanMs?: number
+  /**
+   * How long without JSONL activity before a worker is considered stalled (ms).
+   * Default 60_000.
+   */
+  stallThresholdMs?: number
+  /**
+   * Throttle for pinned-card updates (ms). Default 3000.
+   */
+  cardUpdateIntervalMs?: number
+  /** Optional logger for debug output. */
+  log?: (msg: string) => void
+  /** `Date.now` override for tests. */
+  now?: () => number
+  /** `setInterval` override for tests. */
+  setInterval?: (fn: () => void, ms: number) => { ref: unknown }
+  clearInterval?: (ref: unknown) => void
+  /** `setTimeout` override for tests. */
+  setTimeout?: (fn: () => void, ms: number) => { ref: unknown }
+  clearTimeout?: (ref: unknown) => void
+}
+
+export interface SubagentWatcherHandle {
+  stop(): void
+  /** Snapshot of current registry for tests/inspection. */
+  getRegistry(): ReadonlyMap<string, WorkerEntry>
+}
+
+// ─── Constants ───────────────────────────────────────────────────────────────
+
+const DEFAULT_RESCAN_MS = 1000
+const DEFAULT_STALL_THRESHOLD_MS = 60_000
+const DEFAULT_CARD_UPDATE_INTERVAL_MS = 3000
+
+// ─── Card rendering ──────────────────────────────────────────────────────────
+
+function escapeHtml(s: string): string {
+  return s.replace(/[&<>]/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;' })[c]!)
+}
+
+function truncate(s: string, n: number): string {
+  return s.length > n ? s.slice(0, n - 1) + '…' : s
+}
+
+function formatDuration(ms: number): string {
+  if (ms < 1000) return '<1s'
+  const s = Math.floor(ms / 1000)
+  if (s < 60) return `${s}s`
+  const m = Math.floor(s / 60)
+  const r = s % 60
+  return `${m}m${r > 0 ? `${r}s` : ''}`
+}
+
+/**
+ * Render the pinned worker card from the current registry.
+ * Returns null when no active workers are present.
+ *
+ * Format (one line per worker):
+ *   🛠 <description> · <state> · last activity Xs ago · <tool count> tools
+ */
+export function renderWorkerCard(
+  registry: ReadonlyMap<string, WorkerEntry>,
+  now: number,
+): string | null {
+  const active = Array.from(registry.values()).filter(
+    (w) => w.state === 'running',
+  )
+  if (active.length === 0) return null
+
+  const lines: string[] = [`\u{1F6E0} <b>Background workers (${active.length})</b>`]
+  for (const w of active) {
+    const ago = formatDuration(now - w.lastActivityAt)
+    const desc = escapeHtml(truncate(w.description || 'sub-agent', 60))
+    lines.push(`\u{1F527} ${desc} · running · last activity ${ago} ago · ${w.toolCount} tools`)
+  }
+  return lines.join('\n')
+}
+
+// ─── JSONL tail per sub-agent ─────────────────────────────────────────────
+
+interface SubTail {
+  cursor: number
+  pendingPartial: string
+  hasEmittedStart: boolean
+  watcher: FSWatcher | null
+}
+
+function readSubTail(
+  entry: WorkerEntry,
+  tail: SubTail,
+  now: number,
+  onDescriptionUpdate: (desc: string) => void,
+  log?: (msg: string) => void,
+): void {
+  try {
+    const stat = statSync(entry.filePath)
+    if (stat.size < tail.cursor) {
+      tail.cursor = 0
+      tail.pendingPartial = ''
+    }
+    if (stat.size === tail.cursor) return
+
+    const buf = Buffer.alloc(stat.size - tail.cursor)
+    const fd = openSync(entry.filePath, 'r')
+    try {
+      readSync(fd, buf, 0, buf.length, tail.cursor)
+    } finally {
+      closeSync(fd)
+    }
+    tail.cursor = stat.size
+
+    const text = tail.pendingPartial + buf.toString('utf-8')
+    const lines = text.split('\n')
+    tail.pendingPartial = lines.pop() ?? ''
+
+    const startState = { hasEmittedStart: tail.hasEmittedStart }
+    for (const line of lines) {
+      if (!line) continue
+      const events = projectSubagentLine(line, entry.agentId, startState)
+      for (const ev of events) {
+        entry.lastActivityAt = now
+        if (ev.kind === 'sub_agent_tool_use') {
+          entry.toolCount++
+        } else if (ev.kind === 'sub_agent_text') {
+          // Use first narrative text as description if we haven't set one yet.
+          if (!entry.description || entry.description === 'sub-agent') {
+            const line1 = ev.text.split('\n')[0].trim()
+            if (line1) {
+              entry.description = line1.length > 80 ? line1.slice(0, 79) + '…' : line1
+              onDescriptionUpdate(entry.description)
+            }
+          }
+          entry.lastSummaryLine = ev.text.split('\n')[0].trim().slice(0, 120)
+        } else if (ev.kind === 'sub_agent_turn_end') {
+          if (entry.state === 'running') {
+            entry.state = 'done'
+          }
+        }
+      }
+    }
+    tail.hasEmittedStart = startState.hasEmittedStart
+  } catch (err) {
+    log?.(`subagent-watcher: read error ${entry.agentId}: ${(err as Error).message}`)
+  }
+}
+
+// ─── Main watcher factory ─────────────────────────────────────────────────
+
+export function startSubagentWatcher(config: SubagentWatcherConfig): SubagentWatcherHandle {
+  const agentDir = config.agentDir
+  const stallThresholdMs = config.stallThresholdMs ?? DEFAULT_STALL_THRESHOLD_MS
+  const cardUpdateIntervalMs = config.cardUpdateIntervalMs ?? DEFAULT_CARD_UPDATE_INTERVAL_MS
+  const rescanMs = config.rescanMs ?? DEFAULT_RESCAN_MS
+  const log = config.log
+  const nowFn = config.now ?? (() => Date.now())
+
+  const setI = config.setInterval ?? ((fn, ms) => {
+    const h = setInterval(fn, ms)
+    return { ref: h }
+  })
+  const clearI = config.clearInterval ?? ((ref) => {
+    clearInterval((ref as { ref: ReturnType<typeof setInterval> }).ref)
+  })
+
+  // Registry: agentId → WorkerEntry
+  const registry = new Map<string, WorkerEntry>()
+  // Per-agent tail state
+  const tails = new Map<string, SubTail>()
+  // Dir-level FSWatcher for the subagents/ directory
+  const dirWatchers = new Map<string, FSWatcher>()
+  // Known subagent files: filePath → true
+  const knownFiles = new Set<string>()
+
+  let stopped = false
+  let lastCardUpdate = 0
+  let pendingCardUpdate = false
+
+  // ─── Card management ────────────────────────────────────────────────────
+
+  function maybeSendCardUpdate(force = false): void {
+    const n = nowFn()
+    if (!force && n - lastCardUpdate < cardUpdateIntervalMs) {
+      if (!pendingCardUpdate) {
+        pendingCardUpdate = true
+      }
+      return
+    }
+    lastCardUpdate = n
+    pendingCardUpdate = false
+    const html = renderWorkerCard(registry, n)
+    try {
+      config.updatePinnedCard(html)
+    } catch (err) {
+      log?.(`subagent-watcher: updatePinnedCard error: ${(err as Error).message}`)
+    }
+  }
+
+  // ─── Per-agent registration ─────────────────────────────────────────────
+
+  function registerAgent(filePath: string, agentId: string): void {
+    if (registry.has(agentId)) return
+    const n = nowFn()
+    log?.(`subagent-watcher: registering agent ${agentId}`)
+
+    const entry: WorkerEntry = {
+      agentId,
+      filePath,
+      description: 'sub-agent',
+      state: 'running',
+      dispatchedAt: n,
+      lastActivityAt: n,
+      toolCount: 0,
+      stallNotified: false,
+      completionNotified: false,
+      lastSummaryLine: '',
+    }
+    registry.set(agentId, entry)
+
+    const tail: SubTail = {
+      cursor: 0, // read from start to capture description
+      pendingPartial: '',
+      hasEmittedStart: false,
+      watcher: null,
+    }
+    tails.set(agentId, tail)
+
+    // Initial read
+    readSubTail(entry, tail, n, (desc) => {
+      log?.(`subagent-watcher: description updated for ${agentId}: ${desc}`)
+      maybeSendCardUpdate()
+    }, log)
+
+    // Set up FSWatcher
+    try {
+      tail.watcher = watch(filePath, () => {
+        if (stopped) return
+        const entry = registry.get(agentId)
+        const t = tails.get(agentId)
+        if (!entry || !t) return
+        readSubTail(entry, t, nowFn(), (desc) => {
+          log?.(`subagent-watcher: description updated for ${agentId}: ${desc}`)
+          maybeSendCardUpdate()
+        }, log)
+        maybySendStateTransition(agentId)
+        maybeSendCardUpdate()
+      })
+    } catch (err) {
+      log?.(`subagent-watcher: fs.watch failed for ${agentId}: ${(err as Error).message}`)
+    }
+
+    // Dispatch notification
+    try {
+      const desc = escapeHtml(truncate(entry.description, 80))
+      config.sendNotification(`\u{1F6E0} Worker dispatched: ${desc}`)
+    } catch (err) {
+      log?.(`subagent-watcher: sendNotification error: ${(err as Error).message}`)
+    }
+
+    maybeSendCardUpdate(true)
+  }
+
+  // ─── State-transition notifications ─────────────────────────────────────
+
+  function maybySendStateTransition(agentId: string): void {
+    const entry = registry.get(agentId)
+    if (!entry) return
+
+    if (entry.state === 'done' && !entry.completionNotified) {
+      entry.completionNotified = true
+      const desc = escapeHtml(truncate(entry.description, 80))
+      const summary = entry.lastSummaryLine
+        ? ` — ${escapeHtml(truncate(entry.lastSummaryLine, 120))}`
+        : ''
+      const tools = entry.toolCount > 0 ? ` (${entry.toolCount} tools)` : ''
+      try {
+        config.sendNotification(`✓ Worker done: ${desc}${tools}${summary}`)
+      } catch (err) {
+        log?.(`subagent-watcher: completion notification error: ${(err as Error).message}`)
+      }
+      maybeSendCardUpdate(true)
+    }
+  }
+
+  // ─── Stall detection ────────────────────────────────────────────────────
+
+  function checkStalls(): void {
+    const n = nowFn()
+    for (const entry of registry.values()) {
+      if (entry.state !== 'running') continue
+      if (entry.stallNotified) continue
+      const idleMs = n - entry.lastActivityAt
+      if (idleMs >= stallThresholdMs) {
+        entry.stallNotified = true
+        const desc = escapeHtml(truncate(entry.description, 80))
+        const idleSec = Math.floor(idleMs / 1000)
+        try {
+          config.sendNotification(`⚠ Worker idle: ${desc} (no activity for ${idleSec}s)`)
+        } catch (err) {
+          log?.(`subagent-watcher: stall notification error: ${(err as Error).message}`)
+        }
+      }
+    }
+  }
+
+  // ─── Subagents dir scanner ───────────────────────────────────────────────
+
+  /**
+   * The subagents directory for a given session lives at:
+   *   <agentDir>/.claude/projects/<sanitized-cwd>/<sessionId>/subagents/
+   *
+   * We walk: <agentDir>/.claude/projects/ → each project dir → each session dir
+   * → subagents/ → agent-*.jsonl
+   */
+  function rescanSubagentDirs(): void {
+    if (stopped) return
+    const claudeHome = join(agentDir, '.claude')
+    const projectsRoot = join(claudeHome, 'projects')
+    if (!existsSync(projectsRoot)) return
+
+    let projectDirs: string[]
+    try {
+      projectDirs = readdirSync(projectsRoot)
+    } catch { return }
+
+    for (const pDir of projectDirs) {
+      const projectPath = join(projectsRoot, pDir)
+      let sessionDirs: string[]
+      try {
+        sessionDirs = readdirSync(projectPath)
+      } catch { continue }
+
+      for (const sDir of sessionDirs) {
+        // Session dirs are UUID-like; skip known non-session entries
+        if (sDir.endsWith('.jsonl')) continue
+        const subagentsPath = join(projectPath, sDir, 'subagents')
+        if (!existsSync(subagentsPath)) continue
+
+        // Watch the subagents dir for new files if not already watching
+        if (!dirWatchers.has(subagentsPath)) {
+          try {
+            const w = watch(subagentsPath, (_event, filename) => {
+              if (!filename || !filename.startsWith('agent-') || !filename.endsWith('.jsonl')) return
+              const filePath = join(subagentsPath, filename)
+              if (!knownFiles.has(filePath)) {
+                scanSubagentsDir(subagentsPath)
+              }
+            })
+            dirWatchers.set(subagentsPath, w)
+            log?.(`subagent-watcher: watching dir ${subagentsPath}`)
+          } catch (err) {
+            log?.(`subagent-watcher: dir watch failed ${subagentsPath}: ${(err as Error).message}`)
+          }
+        }
+
+        // Scan existing files
+        scanSubagentsDir(subagentsPath)
+      }
+    }
+  }
+
+  function scanSubagentsDir(subagentsPath: string): void {
+    let entries: string[]
+    try {
+      entries = readdirSync(subagentsPath)
+    } catch { return }
+
+    for (const e of entries) {
+      if (!e.startsWith('agent-') || !e.endsWith('.jsonl')) continue
+      const filePath = join(subagentsPath, e)
+      if (knownFiles.has(filePath)) continue
+      knownFiles.add(filePath)
+      const agentId = e.slice('agent-'.length, -'.jsonl'.length)
+      registerAgent(filePath, agentId)
+    }
+  }
+
+  // ─── Main poll loop ──────────────────────────────────────────────────────
+
+  function poll(): void {
+    if (stopped) return
+
+    // Rescan for new sub-agent dirs
+    rescanSubagentDirs()
+
+    // Defensive read for any running agents (in case fs.watch missed events)
+    const n = nowFn()
+    for (const [agentId, entry] of registry) {
+      if (entry.state !== 'running') continue
+      const tail = tails.get(agentId)
+      if (!tail) continue
+      readSubTail(entry, tail, n, (desc) => {
+        log?.(`subagent-watcher: description updated for ${agentId}: ${desc}`)
+      }, log)
+      maybySendStateTransition(agentId)
+    }
+
+    // Stall detection
+    checkStalls()
+
+    // Flush pending card update if needed
+    if (pendingCardUpdate) {
+      maybeSendCardUpdate(true)
+    }
+  }
+
+  // Initial scan
+  rescanSubagentDirs()
+
+  const pollHandle = setI(poll, rescanMs)
+
+  return {
+    stop(): void {
+      stopped = true
+      clearI(pollHandle)
+      for (const w of dirWatchers.values()) {
+        try { w.close() } catch { /* ignore */ }
+      }
+      dirWatchers.clear()
+      for (const tail of tails.values()) {
+        if (tail.watcher) {
+          try { tail.watcher.close() } catch { /* ignore */ }
+          tail.watcher = null
+        }
+      }
+      tails.clear()
+      registry.clear()
+      knownFiles.clear()
+    },
+
+    getRegistry(): ReadonlyMap<string, WorkerEntry> {
+      return registry
+    },
+  }
+}

--- a/telegram-plugin/tests/subagent-watcher.test.ts
+++ b/telegram-plugin/tests/subagent-watcher.test.ts
@@ -162,6 +162,18 @@ interface WatcherHarness {
   watcher: ReturnType<typeof startSubagentWatcher>
   // Current mocked time
   now: () => number
+  // Mutable fs object — tests can override .readSync, .statSync etc.
+  // for per-test customization (the watcher reads each method on every call,
+  // so reassigning is picked up immediately).
+  mockFs: {
+    existsSync: typeof fs.existsSync
+    readdirSync: typeof fs.readdirSync
+    statSync: typeof fs.statSync
+    openSync: typeof fs.openSync
+    closeSync: typeof fs.closeSync
+    readSync: typeof fs.readSync
+    watch: typeof fs.watch
+  }
 }
 
 function makeHarness(opts: {
@@ -193,73 +205,53 @@ function makeHarness(opts: {
     fileContents.set(path, Buffer.from(content, 'utf-8'))
   }
 
-  // Mock fs.existsSync
-  vi.spyOn(fs, 'existsSync').mockImplementation((p: fs.PathLike) => {
-    const ps = String(p)
-    // Check dirs
-    if (existingDirs.includes(ps)) return true
-    if (dirs[ps] !== undefined) return true
-    // Check files
-    if (fileContents.has(ps)) return true
-    // Check parent paths of files
-    for (const fp of fileContents.keys()) {
-      if (fp.startsWith(ps + '/')) return true
-    }
-    return false
-  })
-
-  // Mock fs.readdirSync
-  vi.spyOn(fs, 'readdirSync').mockImplementation((p: fs.PathLike) => {
-    const ps = String(p)
-    if (dirs[ps]) return dirs[ps] as unknown as fs.Dirent[]
-    // Derive from files
-    const children = new Set<string>()
-    for (const fp of fileContents.keys()) {
-      if (fp.startsWith(ps + '/')) {
-        const rest = fp.slice(ps.length + 1)
-        const part = rest.split('/')[0]
-        if (part) children.add(part)
-      }
-    }
-    return Array.from(children) as unknown as fs.Dirent[]
-  })
-
-  // Mock fs.statSync
-  vi.spyOn(fs, 'statSync').mockImplementation((p: fs.PathLike) => {
-    const ps = String(p)
-    const content = fileContents.get(ps)
-    if (content !== undefined) {
-      return { size: content.length } as fs.Stats
-    }
-    return { size: 0 } as fs.Stats
-  })
-
-  // Mock fs.openSync, readSync, closeSync
-  vi.spyOn(fs, 'openSync').mockReturnValue(42 as ReturnType<typeof fs.openSync>)
-  vi.spyOn(fs, 'closeSync').mockImplementation(() => {})
-  vi.spyOn(fs, 'readSync').mockImplementation((
-    _fd: number,
-    buf: NodeJS.ArrayBufferView,
-    offset: number,
-    length: number,
-    position: number | null,
-  ): number => {
-    // We don't know which file was opened in this mock, so we need a stateful
-    // approach. Since openSync is a no-op (returns 42), we track the last
-    // opened file via a side-channel. This requires us to intercept openSync.
-    // For simplicity: return zeros (the watcher will see 0-length reads and
-    // correctly no-op). The file content is delivered via explicit setContent.
-    void _fd; void buf; void offset; void length; void position
-    return 0
-  })
-
-  // Mock fs.watch
+  // Build a mock fs object — injected via watcher config (ESM namespace
+  // exports are not configurable so vi.spyOn(fs, ...) doesn't work).
   const fakeWatchers: Array<{ close: () => void }> = []
-  vi.spyOn(fs, 'watch').mockImplementation(() => {
-    const w = { close: vi.fn() }
-    fakeWatchers.push(w)
-    return w as unknown as fs.FSWatcher
-  })
+  const mockFs = {
+    existsSync: ((p: fs.PathLike) => {
+      const ps = String(p)
+      if (existingDirs.includes(ps)) return true
+      if (dirs[ps] !== undefined) return true
+      if (fileContents.has(ps)) return true
+      for (const fp of fileContents.keys()) {
+        if (fp.startsWith(ps + '/')) return true
+      }
+      return false
+    }) as typeof fs.existsSync,
+    readdirSync: ((p: fs.PathLike) => {
+      const ps = String(p)
+      if (dirs[ps]) return dirs[ps]
+      const children = new Set<string>()
+      for (const fp of fileContents.keys()) {
+        if (fp.startsWith(ps + '/')) {
+          const rest = fp.slice(ps.length + 1)
+          const part = rest.split('/')[0]
+          if (part) children.add(part)
+        }
+      }
+      return Array.from(children)
+    }) as unknown as typeof fs.readdirSync,
+    statSync: ((p: fs.PathLike) => {
+      const ps = String(p)
+      const content = fileContents.get(ps)
+      return { size: content?.length ?? 0 } as fs.Stats
+    }) as typeof fs.statSync,
+    openSync: (() => 42) as unknown as typeof fs.openSync,
+    closeSync: (() => {}) as typeof fs.closeSync,
+    readSync: ((
+      _fd: number,
+      _buf: NodeJS.ArrayBufferView,
+      _offset: number,
+      _length: number,
+      _position: number | null,
+    ): number => 0) as unknown as typeof fs.readSync,
+    watch: (() => {
+      const w = { close: vi.fn() }
+      fakeWatchers.push(w)
+      return w as unknown as fs.FSWatcher
+    }) as unknown as typeof fs.watch,
+  }
 
   // Injected timers
   const intervals: Array<{ fn: () => void; ms: number; ref: number; fireAt: number }> = []
@@ -283,6 +275,7 @@ function makeHarness(opts: {
       const idx = intervals.findIndex((i) => i.ref === ref)
       if (idx !== -1) intervals.splice(idx, 1)
     },
+    fs: mockFs,
     log: (_msg: string) => {}, // silence in tests
   })
 
@@ -310,6 +303,7 @@ function makeHarness(opts: {
     poll,
     watcher,
     now: () => currentTime,
+    mockFs,
   }
 }
 
@@ -383,7 +377,7 @@ describe('startSubagentWatcher', () => {
 
     // Override readSync to actually return file content
     let fileData = Buffer.from(content)
-    vi.spyOn(fs, 'readSync').mockImplementation((
+    h.mockFs.readSync = ((
       _fd, buf, offset, length, position,
     ) => {
       const pos = position ?? 0
@@ -392,7 +386,7 @@ describe('startSubagentWatcher', () => {
       fileData.copy(buf as Buffer, offset, pos, pos + available)
       return available
     })
-    vi.spyOn(fs, 'statSync').mockImplementation((p) => {
+    h.mockFs.statSync = ((p) => {
       const ps = String(p)
       if (ps === jsonlPath) return { size: fileData.length } as fs.Stats
       return { size: 0 } as fs.Stats
@@ -437,14 +431,14 @@ describe('startSubagentWatcher', () => {
     })
 
     const buf = Buffer.from(content)
-    vi.spyOn(fs, 'readSync').mockImplementation((_fd, b, offset, length, position) => {
+    h.mockFs.readSync = ((_fd, b, offset, length, position) => {
       const pos = position ?? 0
       const available = Math.min(length, buf.length - pos)
       if (available <= 0) return 0
       buf.copy(b as Buffer, offset, pos, pos + available)
       return available
     })
-    vi.spyOn(fs, 'statSync').mockImplementation((p) => {
+    h.mockFs.statSync = ((p) => {
       const ps = String(p)
       if (ps === jsonlPath) return { size: buf.length } as fs.Stats
       return { size: 0 } as fs.Stats
@@ -486,14 +480,14 @@ describe('startSubagentWatcher', () => {
     })
 
     const buf = Buffer.from(content)
-    vi.spyOn(fs, 'readSync').mockImplementation((_fd, b, offset, length, position) => {
+    h.mockFs.readSync = ((_fd, b, offset, length, position) => {
       const pos = position ?? 0
       const available = Math.min(length, buf.length - pos)
       if (available <= 0) return 0
       buf.copy(b as Buffer, offset, pos, pos + available)
       return available
     })
-    vi.spyOn(fs, 'statSync').mockImplementation((p) => {
+    h.mockFs.statSync = ((p) => {
       const ps = String(p)
       if (ps === jsonlPath) return { size: buf.length } as fs.Stats
       return { size: 0 } as fs.Stats

--- a/telegram-plugin/tests/subagent-watcher.test.ts
+++ b/telegram-plugin/tests/subagent-watcher.test.ts
@@ -11,8 +11,11 @@
  *   - Card lifecycle (created on first worker, updated on changes, removed when all done)
  */
 
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import * as fs from 'fs'
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
 import { renderWorkerCard, startSubagentWatcher, type WorkerEntry } from '../subagent-watcher.js'
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
@@ -351,160 +354,118 @@ describe('startSubagentWatcher', () => {
     h.watcher.stop()
   })
 
-  it('updates description from sub_agent_text event', () => {
-    const agentDir = '/home/user/.switchroom/agents/myagent'
-    const projectsRoot = `${agentDir}/.claude/projects`
-    const projectDir = `${projectsRoot}/myproject`
-    const sessionDir = `${projectDir}/session-abc123`
-    const subagentsDir = `${sessionDir}/subagents`
-    const jsonlPath = `${subagentsDir}/agent-deadbeef.jsonl`
+  // The next three tests use a real tmp dir + real files + real fs (no
+  // injection). The over-mocked harness can't reproduce the read-sequence
+  // statefully — real fs is simpler and more accurate.
+  describe('with real tmp filesystem', () => {
+    let tmpRoot = ''
+    const startedWatchers: Array<{ stop(): void }> = []
 
-    const content = buildJSONL(
-      subAgentUserMsg('Do the thing'),
-      subAgentAssistantText('I will implement the feature now'),
-    )
-
-    const h = makeHarness({
-      agentDir,
-      existingDirs: [projectsRoot, projectDir, sessionDir, subagentsDir],
-      dirs: {
-        [projectsRoot]: ['myproject'],
-        [projectDir]: ['session-abc123'],
-        [subagentsDir]: ['agent-deadbeef.jsonl'],
-      },
-      files: { [jsonlPath]: content },
+    beforeEach(() => {
+      tmpRoot = mkdtempSync(join(tmpdir(), 'switchroom-watcher-test-'))
     })
 
-    // Override readSync to actually return file content
-    let fileData = Buffer.from(content)
-    h.mockFs.readSync = ((
-      _fd, buf, offset, length, position,
-    ) => {
-      const pos = position ?? 0
-      const available = Math.min(length, fileData.length - pos)
-      if (available <= 0) return 0
-      fileData.copy(buf as Buffer, offset, pos, pos + available)
-      return available
-    })
-    h.mockFs.statSync = ((p) => {
-      const ps = String(p)
-      if (ps === jsonlPath) return { size: fileData.length } as fs.Stats
-      return { size: 0 } as fs.Stats
+    afterEach(() => {
+      while (startedWatchers.length) {
+        try { startedWatchers.pop()?.stop() } catch { /* ignore */ }
+      }
+      try { rmSync(tmpRoot, { recursive: true, force: true }) } catch { /* ignore */ }
     })
 
-    h.poll()
-
-    const registry = h.watcher.getRegistry()
-    const entry = registry.get('deadbeef')
-    // Description should be updated from first text line
-    if (entry) {
-      expect(entry.description).not.toBe('sub-agent')
+    function setupRealFs(jsonlContent: string, agentId: string): {
+      agentDir: string
+      jsonlPath: string
+    } {
+      const agentDir = join(tmpRoot, 'agent')
+      const subagentsDir = join(agentDir, '.claude', 'projects', 'p1', 'session-abc', 'subagents')
+      mkdirSync(subagentsDir, { recursive: true })
+      const jsonlPath = join(subagentsDir, `agent-${agentId}.jsonl`)
+      writeFileSync(jsonlPath, jsonlContent)
+      return { agentDir, jsonlPath }
     }
 
-    h.watcher.stop()
-  })
-
-  it('counts tools from sub_agent_tool_use events', () => {
-    const agentDir = '/home/user/.switchroom/agents/myagent'
-    const projectsRoot = `${agentDir}/.claude/projects`
-    const projectDir = `${projectsRoot}/myproject`
-    const sessionDir = `${projectDir}/session-abc123`
-    const subagentsDir = `${sessionDir}/subagents`
-    const jsonlPath = `${subagentsDir}/agent-deadbeef.jsonl`
-
-    const content = buildJSONL(
-      subAgentUserMsg('Fix things'),
-      subAgentToolUse('Read', 'id1'),
-      subAgentToolUse('Bash', 'id2'),
-      subAgentToolUse('Edit', 'id3'),
-    )
-
-    const h = makeHarness({
-      agentDir,
-      existingDirs: [projectsRoot, projectDir, sessionDir, subagentsDir],
-      dirs: {
-        [projectsRoot]: ['myproject'],
-        [projectDir]: ['session-abc123'],
-        [subagentsDir]: ['agent-deadbeef.jsonl'],
-      },
-      files: { [jsonlPath]: content },
-    })
-
-    const buf = Buffer.from(content)
-    h.mockFs.readSync = ((_fd, b, offset, length, position) => {
-      const pos = position ?? 0
-      const available = Math.min(length, buf.length - pos)
-      if (available <= 0) return 0
-      buf.copy(b as Buffer, offset, pos, pos + available)
-      return available
-    })
-    h.mockFs.statSync = ((p) => {
-      const ps = String(p)
-      if (ps === jsonlPath) return { size: buf.length } as fs.Stats
-      return { size: 0 } as fs.Stats
-    })
-
-    h.poll()
-
-    const registry = h.watcher.getRegistry()
-    const entry = registry.get('deadbeef')
-    if (entry) {
-      expect(entry.toolCount).toBe(3)
+    function startWatcherSync(opts: { agentDir: string }): {
+      notifications: string[]
+      cardUpdates: Array<string | null>
+      poll: () => void
+      watcher: ReturnType<typeof startSubagentWatcher>
+    } {
+      const notifications: string[] = []
+      const cardUpdates: Array<string | null> = []
+      const intervals: Array<{ fn: () => void; ref: number }> = []
+      let nextRef = 1
+      const watcher = startSubagentWatcher({
+        agentDir: opts.agentDir,
+        sendNotification: (text) => notifications.push(text),
+        updatePinnedCard: (html) => cardUpdates.push(html),
+        stallThresholdMs: 60_000,
+        cardUpdateIntervalMs: 100,
+        rescanMs: 500,
+        now: () => Date.now(),
+        setInterval: (fn) => {
+          const ref = nextRef++
+          intervals.push({ fn, ref })
+          return { ref }
+        },
+        clearInterval: (handle) => {
+          const { ref } = handle as { ref: number }
+          const idx = intervals.findIndex((i) => i.ref === ref)
+          if (idx !== -1) intervals.splice(idx, 1)
+        },
+        log: () => {},
+      })
+      startedWatchers.push(watcher)
+      return {
+        notifications,
+        cardUpdates,
+        poll: () => intervals[0]?.fn(),
+        watcher,
+      }
     }
 
-    h.watcher.stop()
-  })
-
-  it('emits completion notification when turn_end arrives', () => {
-    const agentDir = '/home/user/.switchroom/agents/myagent'
-    const projectsRoot = `${agentDir}/.claude/projects`
-    const projectDir = `${projectsRoot}/myproject`
-    const sessionDir = `${projectDir}/session-abc123`
-    const subagentsDir = `${sessionDir}/subagents`
-    const jsonlPath = `${subagentsDir}/agent-deadbeef.jsonl`
-
-    const content = buildJSONL(
-      subAgentUserMsg('Do the task'),
-      subAgentTurnDuration(),
-    )
-
-    const h = makeHarness({
-      agentDir,
-      existingDirs: [projectsRoot, projectDir, sessionDir, subagentsDir],
-      dirs: {
-        [projectsRoot]: ['myproject'],
-        [projectDir]: ['session-abc123'],
-        [subagentsDir]: ['agent-deadbeef.jsonl'],
-      },
-      files: { [jsonlPath]: content },
+    it('updates description from sub_agent_text event', () => {
+      const content = buildJSONL(
+        subAgentUserMsg('Do the thing'),
+        subAgentAssistantText('I will implement the feature now'),
+      )
+      const { agentDir } = setupRealFs(content, 'deadbeef')
+      const h = startWatcherSync({ agentDir })
+      h.poll()
+      const entry = h.watcher.getRegistry().get('deadbeef')
+      expect(entry).toBeDefined()
+      expect(entry?.description).not.toBe('sub-agent')
+      expect(entry?.description).toMatch(/I will implement/)
     })
 
-    const buf = Buffer.from(content)
-    h.mockFs.readSync = ((_fd, b, offset, length, position) => {
-      const pos = position ?? 0
-      const available = Math.min(length, buf.length - pos)
-      if (available <= 0) return 0
-      buf.copy(b as Buffer, offset, pos, pos + available)
-      return available
+    it('counts tools from sub_agent_tool_use events', () => {
+      const content = buildJSONL(
+        subAgentUserMsg('Fix things'),
+        subAgentToolUse('Read', 'id1'),
+        subAgentToolUse('Bash', 'id2'),
+        subAgentToolUse('Edit', 'id3'),
+      )
+      const { agentDir } = setupRealFs(content, 'deadbeef')
+      const h = startWatcherSync({ agentDir })
+      h.poll()
+      const entry = h.watcher.getRegistry().get('deadbeef')
+      expect(entry).toBeDefined()
+      expect(entry?.toolCount).toBe(3)
     })
-    h.mockFs.statSync = ((p) => {
-      const ps = String(p)
-      if (ps === jsonlPath) return { size: buf.length } as fs.Stats
-      return { size: 0 } as fs.Stats
+
+    it('emits completion notification when turn_end arrives', () => {
+      const content = buildJSONL(
+        subAgentUserMsg('Do the task'),
+        subAgentTurnDuration(),
+      )
+      const { agentDir } = setupRealFs(content, 'deadbeef')
+      const h = startWatcherSync({ agentDir })
+      h.poll()
+      const entry = h.watcher.getRegistry().get('deadbeef')
+      expect(entry).toBeDefined()
+      expect(entry?.state).toBe('done')
+      const completionNotifs = h.notifications.filter((n) => n.includes('Worker done'))
+      expect(completionNotifs.length).toBeGreaterThanOrEqual(1)
     })
-
-    h.poll()
-
-    const completionNotifs = h.notifications.filter((n) => n.includes('Worker done'))
-    expect(completionNotifs.length).toBeGreaterThanOrEqual(1)
-
-    const registry = h.watcher.getRegistry()
-    const entry = registry.get('deadbeef')
-    if (entry) {
-      expect(entry.state).toBe('done')
-    }
-
-    h.watcher.stop()
   })
 
   it('emits stall notification after stallThresholdMs idle', () => {

--- a/telegram-plugin/tests/subagent-watcher.test.ts
+++ b/telegram-plugin/tests/subagent-watcher.test.ts
@@ -1,0 +1,628 @@
+/**
+ * Unit tests for the subagent-watcher module.
+ *
+ * Covers:
+ *   - renderWorkerCard output format
+ *   - Registry transitions (register, tool_use, turn_end)
+ *   - JSONL tail parsing (description from sub_agent_text, toolCount from sub_agent_tool_use)
+ *   - Stall detection (stall notification after stallThresholdMs idle)
+ *   - Completion notification (sent once on state=done)
+ *   - Dispatch notification (sent on registration)
+ *   - Card lifecycle (created on first worker, updated on changes, removed when all done)
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import * as fs from 'fs'
+import { renderWorkerCard, startSubagentWatcher, type WorkerEntry } from '../subagent-watcher.js'
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function makeEntry(overrides: Partial<WorkerEntry> = {}): WorkerEntry {
+  return {
+    agentId: 'test-agent-01',
+    filePath: '/tmp/agent-test-agent-01.jsonl',
+    description: 'Build the feature',
+    state: 'running',
+    dispatchedAt: 1000,
+    lastActivityAt: 1000,
+    toolCount: 0,
+    stallNotified: false,
+    completionNotified: false,
+    lastSummaryLine: '',
+    ...overrides,
+  }
+}
+
+// ─── renderWorkerCard ────────────────────────────────────────────────────────
+
+describe('renderWorkerCard', () => {
+  it('returns null when registry is empty', () => {
+    const registry = new Map<string, WorkerEntry>()
+    expect(renderWorkerCard(registry, 2000)).toBeNull()
+  })
+
+  it('returns null when all workers are done', () => {
+    const registry = new Map<string, WorkerEntry>([
+      ['a', makeEntry({ state: 'done' })],
+      ['b', makeEntry({ agentId: 'b', state: 'failed' })],
+    ])
+    expect(renderWorkerCard(registry, 2000)).toBeNull()
+  })
+
+  it('renders a single running worker', () => {
+    const registry = new Map<string, WorkerEntry>([
+      ['a', makeEntry({ description: 'Fix the tests', toolCount: 3, lastActivityAt: 1000 })],
+    ])
+    const html = renderWorkerCard(registry, 61_000)
+    expect(html).not.toBeNull()
+    expect(html).toContain('Background workers (1)')
+    expect(html).toContain('Fix the tests')
+    expect(html).toContain('3 tools')
+    expect(html).toContain('running')
+  })
+
+  it('renders multiple running workers', () => {
+    const registry = new Map<string, WorkerEntry>([
+      ['a', makeEntry({ description: 'Worker A', toolCount: 2 })],
+      ['b', makeEntry({ agentId: 'b', description: 'Worker B', toolCount: 5 })],
+    ])
+    const html = renderWorkerCard(registry, 2000)
+    expect(html).toContain('Background workers (2)')
+    expect(html).toContain('Worker A')
+    expect(html).toContain('Worker B')
+  })
+
+  it('shows only running workers in the card', () => {
+    const registry = new Map<string, WorkerEntry>([
+      ['a', makeEntry({ description: 'Still running', state: 'running' })],
+      ['b', makeEntry({ agentId: 'b', description: 'Already done', state: 'done' })],
+    ])
+    const html = renderWorkerCard(registry, 2000)
+    expect(html).toContain('Background workers (1)')
+    expect(html).toContain('Still running')
+    expect(html).not.toContain('Already done')
+  })
+
+  it('escapes HTML special characters in description', () => {
+    const registry = new Map<string, WorkerEntry>([
+      ['a', makeEntry({ description: '<script>alert("xss")</script>' })],
+    ])
+    const html = renderWorkerCard(registry, 2000)
+    expect(html).not.toContain('<script>')
+    expect(html).toContain('&lt;script&gt;')
+  })
+
+  it('truncates long descriptions', () => {
+    const long = 'a'.repeat(100)
+    const registry = new Map<string, WorkerEntry>([
+      ['a', makeEntry({ description: long })],
+    ])
+    const html = renderWorkerCard(registry, 2000)
+    expect(html?.length).toBeLessThan(400)
+    expect(html).toContain('…')
+  })
+
+  it('formats last-activity age', () => {
+    const registry = new Map<string, WorkerEntry>([
+      ['a', makeEntry({ lastActivityAt: 1000 })],
+    ])
+    // 30s ago
+    const html = renderWorkerCard(registry, 31_000)
+    expect(html).toContain('30s ago')
+  })
+})
+
+// ─── startSubagentWatcher harness ────────────────────────────────────────────
+
+/**
+ * Minimal harness to drive the watcher without real filesystem or timers.
+ *
+ * We mock:
+ *  - fs.existsSync, fs.readdirSync → control which dirs/files are "on disk"
+ *  - fs.statSync → control file sizes (drives JSONL read)
+ *  - fs.openSync, fs.readSync, fs.closeSync → feed JSONL content
+ *  - fs.watch → stub (returns a fake watcher)
+ *  - Date.now → injected via config.now
+ *  - setInterval / clearInterval → injected via config
+ */
+
+function buildJSONL(...lines: object[]): string {
+  return lines.map((l) => JSON.stringify(l)).join('\n') + '\n'
+}
+
+function subAgentUserMsg(promptText: string) {
+  return { type: 'user', message: { content: [{ type: 'text', text: promptText }] } }
+}
+
+function subAgentAssistantText(text: string) {
+  return {
+    type: 'assistant',
+    message: { content: [{ type: 'text', text }] },
+  }
+}
+
+function subAgentToolUse(name: string, id: string) {
+  return {
+    type: 'assistant',
+    message: { content: [{ type: 'tool_use', name, id, input: {} }] },
+  }
+}
+
+function subAgentTurnDuration() {
+  return { type: 'system', subtype: 'turn_duration', durationMs: 5000 }
+}
+
+interface WatcherHarness {
+  notifications: string[]
+  cardUpdates: Array<string | null>
+  advance: (ms: number) => void
+  // Trigger the poll timer manually
+  poll: () => void
+  // Expose the watcher
+  watcher: ReturnType<typeof startSubagentWatcher>
+  // Current mocked time
+  now: () => number
+}
+
+function makeHarness(opts: {
+  agentDir?: string
+  files?: Record<string, string>  // filePath → JSONL content
+  dirs?: Record<string, string[]> // dirPath → list of filenames
+  existingDirs?: string[]
+  stallThresholdMs?: number
+  cardUpdateIntervalMs?: number
+  rescanMs?: number
+}): WatcherHarness {
+  const {
+    agentDir = '/home/user/.switchroom/agents/myagent',
+    files = {},
+    dirs = {},
+    existingDirs = [],
+    stallThresholdMs = 60_000,
+    cardUpdateIntervalMs = 100,
+    rescanMs = 500,
+  } = opts
+
+  let currentTime = 1000
+  const notifications: string[] = []
+  const cardUpdates: Array<string | null> = []
+
+  // Track all JSONL content per path for statSync + read simulation
+  const fileContents: Map<string, Buffer> = new Map()
+  for (const [path, content] of Object.entries(files)) {
+    fileContents.set(path, Buffer.from(content, 'utf-8'))
+  }
+
+  // Mock fs.existsSync
+  vi.spyOn(fs, 'existsSync').mockImplementation((p: fs.PathLike) => {
+    const ps = String(p)
+    // Check dirs
+    if (existingDirs.includes(ps)) return true
+    if (dirs[ps] !== undefined) return true
+    // Check files
+    if (fileContents.has(ps)) return true
+    // Check parent paths of files
+    for (const fp of fileContents.keys()) {
+      if (fp.startsWith(ps + '/')) return true
+    }
+    return false
+  })
+
+  // Mock fs.readdirSync
+  vi.spyOn(fs, 'readdirSync').mockImplementation((p: fs.PathLike) => {
+    const ps = String(p)
+    if (dirs[ps]) return dirs[ps] as unknown as fs.Dirent[]
+    // Derive from files
+    const children = new Set<string>()
+    for (const fp of fileContents.keys()) {
+      if (fp.startsWith(ps + '/')) {
+        const rest = fp.slice(ps.length + 1)
+        const part = rest.split('/')[0]
+        if (part) children.add(part)
+      }
+    }
+    return Array.from(children) as unknown as fs.Dirent[]
+  })
+
+  // Mock fs.statSync
+  vi.spyOn(fs, 'statSync').mockImplementation((p: fs.PathLike) => {
+    const ps = String(p)
+    const content = fileContents.get(ps)
+    if (content !== undefined) {
+      return { size: content.length } as fs.Stats
+    }
+    return { size: 0 } as fs.Stats
+  })
+
+  // Mock fs.openSync, readSync, closeSync
+  vi.spyOn(fs, 'openSync').mockReturnValue(42 as ReturnType<typeof fs.openSync>)
+  vi.spyOn(fs, 'closeSync').mockImplementation(() => {})
+  vi.spyOn(fs, 'readSync').mockImplementation((
+    _fd: number,
+    buf: NodeJS.ArrayBufferView,
+    offset: number,
+    length: number,
+    position: number | null,
+  ): number => {
+    // We don't know which file was opened in this mock, so we need a stateful
+    // approach. Since openSync is a no-op (returns 42), we track the last
+    // opened file via a side-channel. This requires us to intercept openSync.
+    // For simplicity: return zeros (the watcher will see 0-length reads and
+    // correctly no-op). The file content is delivered via explicit setContent.
+    void _fd; void buf; void offset; void length; void position
+    return 0
+  })
+
+  // Mock fs.watch
+  const fakeWatchers: Array<{ close: () => void }> = []
+  vi.spyOn(fs, 'watch').mockImplementation(() => {
+    const w = { close: vi.fn() }
+    fakeWatchers.push(w)
+    return w as unknown as fs.FSWatcher
+  })
+
+  // Injected timers
+  const intervals: Array<{ fn: () => void; ms: number; ref: number; fireAt: number }> = []
+  let nextRef = 1
+
+  const watcher = startSubagentWatcher({
+    agentDir,
+    sendNotification: (text) => notifications.push(text),
+    updatePinnedCard: (html) => cardUpdates.push(html),
+    stallThresholdMs,
+    cardUpdateIntervalMs,
+    rescanMs,
+    now: () => currentTime,
+    setInterval: (fn, ms) => {
+      const ref = nextRef++
+      intervals.push({ fn, ms, ref, fireAt: currentTime + ms })
+      return { ref }
+    },
+    clearInterval: (handle) => {
+      const { ref } = handle as { ref: number }
+      const idx = intervals.findIndex((i) => i.ref === ref)
+      if (idx !== -1) intervals.splice(idx, 1)
+    },
+    log: (_msg: string) => {}, // silence in tests
+  })
+
+  const advance = (ms: number): void => {
+    currentTime += ms
+    // Fire any intervals whose fireAt <= currentTime
+    for (;;) {
+      intervals.sort((a, b) => a.fireAt - b.fireAt)
+      const next = intervals[0]
+      if (!next || next.fireAt > currentTime) break
+      next.fireAt += next.ms
+      next.fn()
+    }
+  }
+
+  const poll = (): void => {
+    const pollInterval = intervals[0]
+    if (pollInterval) pollInterval.fn()
+  }
+
+  return {
+    notifications,
+    cardUpdates,
+    advance,
+    poll,
+    watcher,
+    now: () => currentTime,
+  }
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe('startSubagentWatcher', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('does nothing when the agent dir has no .claude/projects', () => {
+    const h = makeHarness({ agentDir: '/nonexistent', existingDirs: [] })
+    h.poll()
+    expect(h.notifications).toHaveLength(0)
+    expect(h.cardUpdates).toHaveLength(0)
+    h.watcher.stop()
+  })
+
+  it('detects a new subagent JSONL and emits dispatch notification', () => {
+    const agentDir = '/home/user/.switchroom/agents/myagent'
+    const projectsRoot = `${agentDir}/.claude/projects`
+    const projectDir = `${projectsRoot}/myproject`
+    const sessionDir = `${projectDir}/session-abc123`
+    const subagentsDir = `${sessionDir}/subagents`
+    const jsonlPath = `${subagentsDir}/agent-deadbeef.jsonl`
+
+    const h = makeHarness({
+      agentDir,
+      existingDirs: [projectsRoot, projectDir, sessionDir, subagentsDir],
+      dirs: {
+        [projectsRoot]: ['myproject'],
+        [projectDir]: ['session-abc123'],
+        [subagentsDir]: ['agent-deadbeef.jsonl'],
+      },
+      files: {
+        [jsonlPath]: buildJSONL(subAgentUserMsg('Fix the tests please')),
+      },
+    })
+
+    h.poll()
+
+    expect(h.notifications.length).toBeGreaterThanOrEqual(1)
+    expect(h.notifications[0]).toContain('Worker dispatched')
+
+    h.watcher.stop()
+  })
+
+  it('updates description from sub_agent_text event', () => {
+    const agentDir = '/home/user/.switchroom/agents/myagent'
+    const projectsRoot = `${agentDir}/.claude/projects`
+    const projectDir = `${projectsRoot}/myproject`
+    const sessionDir = `${projectDir}/session-abc123`
+    const subagentsDir = `${sessionDir}/subagents`
+    const jsonlPath = `${subagentsDir}/agent-deadbeef.jsonl`
+
+    const content = buildJSONL(
+      subAgentUserMsg('Do the thing'),
+      subAgentAssistantText('I will implement the feature now'),
+    )
+
+    const h = makeHarness({
+      agentDir,
+      existingDirs: [projectsRoot, projectDir, sessionDir, subagentsDir],
+      dirs: {
+        [projectsRoot]: ['myproject'],
+        [projectDir]: ['session-abc123'],
+        [subagentsDir]: ['agent-deadbeef.jsonl'],
+      },
+      files: { [jsonlPath]: content },
+    })
+
+    // Override readSync to actually return file content
+    let fileData = Buffer.from(content)
+    vi.spyOn(fs, 'readSync').mockImplementation((
+      _fd, buf, offset, length, position,
+    ) => {
+      const pos = position ?? 0
+      const available = Math.min(length, fileData.length - pos)
+      if (available <= 0) return 0
+      fileData.copy(buf as Buffer, offset, pos, pos + available)
+      return available
+    })
+    vi.spyOn(fs, 'statSync').mockImplementation((p) => {
+      const ps = String(p)
+      if (ps === jsonlPath) return { size: fileData.length } as fs.Stats
+      return { size: 0 } as fs.Stats
+    })
+
+    h.poll()
+
+    const registry = h.watcher.getRegistry()
+    const entry = registry.get('deadbeef')
+    // Description should be updated from first text line
+    if (entry) {
+      expect(entry.description).not.toBe('sub-agent')
+    }
+
+    h.watcher.stop()
+  })
+
+  it('counts tools from sub_agent_tool_use events', () => {
+    const agentDir = '/home/user/.switchroom/agents/myagent'
+    const projectsRoot = `${agentDir}/.claude/projects`
+    const projectDir = `${projectsRoot}/myproject`
+    const sessionDir = `${projectDir}/session-abc123`
+    const subagentsDir = `${sessionDir}/subagents`
+    const jsonlPath = `${subagentsDir}/agent-deadbeef.jsonl`
+
+    const content = buildJSONL(
+      subAgentUserMsg('Fix things'),
+      subAgentToolUse('Read', 'id1'),
+      subAgentToolUse('Bash', 'id2'),
+      subAgentToolUse('Edit', 'id3'),
+    )
+
+    const h = makeHarness({
+      agentDir,
+      existingDirs: [projectsRoot, projectDir, sessionDir, subagentsDir],
+      dirs: {
+        [projectsRoot]: ['myproject'],
+        [projectDir]: ['session-abc123'],
+        [subagentsDir]: ['agent-deadbeef.jsonl'],
+      },
+      files: { [jsonlPath]: content },
+    })
+
+    const buf = Buffer.from(content)
+    vi.spyOn(fs, 'readSync').mockImplementation((_fd, b, offset, length, position) => {
+      const pos = position ?? 0
+      const available = Math.min(length, buf.length - pos)
+      if (available <= 0) return 0
+      buf.copy(b as Buffer, offset, pos, pos + available)
+      return available
+    })
+    vi.spyOn(fs, 'statSync').mockImplementation((p) => {
+      const ps = String(p)
+      if (ps === jsonlPath) return { size: buf.length } as fs.Stats
+      return { size: 0 } as fs.Stats
+    })
+
+    h.poll()
+
+    const registry = h.watcher.getRegistry()
+    const entry = registry.get('deadbeef')
+    if (entry) {
+      expect(entry.toolCount).toBe(3)
+    }
+
+    h.watcher.stop()
+  })
+
+  it('emits completion notification when turn_end arrives', () => {
+    const agentDir = '/home/user/.switchroom/agents/myagent'
+    const projectsRoot = `${agentDir}/.claude/projects`
+    const projectDir = `${projectsRoot}/myproject`
+    const sessionDir = `${projectDir}/session-abc123`
+    const subagentsDir = `${sessionDir}/subagents`
+    const jsonlPath = `${subagentsDir}/agent-deadbeef.jsonl`
+
+    const content = buildJSONL(
+      subAgentUserMsg('Do the task'),
+      subAgentTurnDuration(),
+    )
+
+    const h = makeHarness({
+      agentDir,
+      existingDirs: [projectsRoot, projectDir, sessionDir, subagentsDir],
+      dirs: {
+        [projectsRoot]: ['myproject'],
+        [projectDir]: ['session-abc123'],
+        [subagentsDir]: ['agent-deadbeef.jsonl'],
+      },
+      files: { [jsonlPath]: content },
+    })
+
+    const buf = Buffer.from(content)
+    vi.spyOn(fs, 'readSync').mockImplementation((_fd, b, offset, length, position) => {
+      const pos = position ?? 0
+      const available = Math.min(length, buf.length - pos)
+      if (available <= 0) return 0
+      buf.copy(b as Buffer, offset, pos, pos + available)
+      return available
+    })
+    vi.spyOn(fs, 'statSync').mockImplementation((p) => {
+      const ps = String(p)
+      if (ps === jsonlPath) return { size: buf.length } as fs.Stats
+      return { size: 0 } as fs.Stats
+    })
+
+    h.poll()
+
+    const completionNotifs = h.notifications.filter((n) => n.includes('Worker done'))
+    expect(completionNotifs.length).toBeGreaterThanOrEqual(1)
+
+    const registry = h.watcher.getRegistry()
+    const entry = registry.get('deadbeef')
+    if (entry) {
+      expect(entry.state).toBe('done')
+    }
+
+    h.watcher.stop()
+  })
+
+  it('emits stall notification after stallThresholdMs idle', () => {
+    const agentDir = '/home/user/.switchroom/agents/myagent'
+    const projectsRoot = `${agentDir}/.claude/projects`
+    const projectDir = `${projectsRoot}/myproject`
+    const sessionDir = `${projectDir}/session-abc123`
+    const subagentsDir = `${sessionDir}/subagents`
+    const jsonlPath = `${subagentsDir}/agent-deadbeef.jsonl`
+
+    // Only the initial user message — no tool_use or turn_end
+    const content = buildJSONL(subAgentUserMsg('Run a long task'))
+
+    const h = makeHarness({
+      agentDir,
+      existingDirs: [projectsRoot, projectDir, sessionDir, subagentsDir],
+      dirs: {
+        [projectsRoot]: ['myproject'],
+        [projectDir]: ['session-abc123'],
+        [subagentsDir]: ['agent-deadbeef.jsonl'],
+      },
+      files: { [jsonlPath]: content },
+      stallThresholdMs: 60_000,
+      rescanMs: 500,
+    })
+
+    // Initial poll — registers the agent
+    h.poll()
+
+    // Advance past stall threshold without any new JSONL activity
+    h.advance(65_000)
+
+    const stallNotifs = h.notifications.filter((n) => n.includes('Worker idle'))
+    expect(stallNotifs.length).toBeGreaterThanOrEqual(1)
+    expect(stallNotifs[0]).toContain('Worker idle')
+
+    h.watcher.stop()
+  })
+
+  it('does not emit stall notification twice', () => {
+    const agentDir = '/home/user/.switchroom/agents/myagent'
+    const projectsRoot = `${agentDir}/.claude/projects`
+    const projectDir = `${projectsRoot}/myproject`
+    const sessionDir = `${projectDir}/session-abc123`
+    const subagentsDir = `${sessionDir}/subagents`
+    const jsonlPath = `${subagentsDir}/agent-deadbeef.jsonl`
+
+    const content = buildJSONL(subAgentUserMsg('Long task'))
+
+    const h = makeHarness({
+      agentDir,
+      existingDirs: [projectsRoot, projectDir, sessionDir, subagentsDir],
+      dirs: {
+        [projectsRoot]: ['myproject'],
+        [projectDir]: ['session-abc123'],
+        [subagentsDir]: ['agent-deadbeef.jsonl'],
+      },
+      files: { [jsonlPath]: content },
+      stallThresholdMs: 60_000,
+    })
+
+    h.poll()
+    h.advance(65_000)
+    h.advance(65_000) // advance past threshold AGAIN
+
+    const stallNotifs = h.notifications.filter((n) => n.includes('Worker idle'))
+    expect(stallNotifs.length).toBe(1)
+
+    h.watcher.stop()
+  })
+
+  it('does not duplicate workers registered from same file', () => {
+    const agentDir = '/home/user/.switchroom/agents/myagent'
+    const projectsRoot = `${agentDir}/.claude/projects`
+    const projectDir = `${projectsRoot}/myproject`
+    const sessionDir = `${projectDir}/session-abc123`
+    const subagentsDir = `${sessionDir}/subagents`
+    const jsonlPath = `${subagentsDir}/agent-deadbeef.jsonl`
+
+    const content = buildJSONL(subAgentUserMsg('Do it'))
+
+    const h = makeHarness({
+      agentDir,
+      existingDirs: [projectsRoot, projectDir, sessionDir, subagentsDir],
+      dirs: {
+        [projectsRoot]: ['myproject'],
+        [projectDir]: ['session-abc123'],
+        [subagentsDir]: ['agent-deadbeef.jsonl'],
+      },
+      files: { [jsonlPath]: content },
+    })
+
+    h.poll()
+    h.poll() // second poll — should not re-register
+    h.poll()
+
+    const registry = h.watcher.getRegistry()
+    expect(registry.size).toBe(1)
+
+    const dispatchNotifs = h.notifications.filter((n) => n.includes('Worker dispatched'))
+    expect(dispatchNotifs.length).toBe(1)
+
+    h.watcher.stop()
+  })
+
+  it('stop() cleans up and stops poll timers', () => {
+    const h = makeHarness({})
+    h.watcher.stop()
+
+    // After stop, advancing should not trigger anything new
+    const notifsBefore = h.notifications.length
+    h.advance(100_000)
+    expect(h.notifications.length).toBe(notifsBefore)
+  })
+})


### PR DESCRIPTION
## Status: DRAFT — needs test refactor before merge

Closes #64 once tests are fixed.

## Summary

Lands what an autonomous worker built before its turn budget ran out. Includes the watcher module + 10 unit tests + gateway integration. Worker was mid-refactor of the test mocking approach when it stopped.

## What's here
- \`telegram-plugin/subagent-watcher.ts\` (515 lines): registry of dispatched sub-agents, JSONL tail, pinned card maintenance, dispatch/stall/completion notifications
- \`telegram-plugin/gateway/gateway.ts\`: hooks the watcher into gateway startup when \`SUBAGENT_OWNER_CHAT_ID\` is set
- \`telegram-plugin/tests/subagent-watcher.test.ts\`: 10 unit tests covering registry transitions, dispatch/stall/completion events, pinned card lifecycle

## Known issue (blocks merge)

All 10 tests fail with:
\`\`\`
TypeError: Cannot spy on export "existsSync". Module namespace is not configurable in ESM.
\`\`\`

The watcher imports node:fs functions directly; tests use \`vi.spyOn\` to mock them, which doesn't work on ESM namespace exports.

## Fix-it path

Refactor \`startSubagentWatcher\` to accept an \`fs\` dependency (object with \`existsSync\`, \`readdirSync\`, \`createReadStream\`, \`statSync\`, \`watchFile\`). Tests pass a mock; production code passes \`require('node:fs')\` (or imports as default). Common DI pattern in this codebase already.

Should be a focused 30-60 minute fix.

## Why ship as draft

Other autonomous PRs from this batch already merged the high-value parts (#65, #67, #66). This one needs cleanup but the design + bulk of the code is here — preserving for the next session rather than throwing away.

🤖 Generated with [Claude Code](https://claude.com/claude-code)