### PR TITLE
fix(restart): fall back to direct systemctl when graceful IPC fails (#71)

### DIFF
--- a/src/cli/agent.ts
+++ b/src/cli/agent.ts
@@ -492,13 +492,29 @@ export async function reconcileAndRestartAgent(
   }
 
   if (opts.graceful) {
-    const r = await deps.gracefulRestartAgent(name);
-    return {
-      reconciled: true,
-      restarted: r.restartedImmediately,
-      waitingForTurn: r.waitingForTurn,
-      changes: allChanges,
-    };
+    try {
+      const r = await deps.gracefulRestartAgent(name);
+      return {
+        reconciled: true,
+        restarted: r.restartedImmediately,
+        waitingForTurn: r.waitingForTurn,
+        changes: allChanges,
+      };
+    } catch (err) {
+      // Gateway IPC is the path graceful restart depends on. If the socket
+      // is missing or unresponsive, the gateway itself is wedged — exactly
+      // the case where the user most needs `restart` to work. Fall back to
+      // a direct systemctl bounce, which restartAgent does for both the
+      // gateway and the agent service together. See switchroom#71.
+      const msg = err instanceof Error ? err.message : String(err);
+      log(
+        chalk.yellow(
+          `  ${name}: graceful path unavailable (${msg}) — falling back to direct restart`,
+        ),
+      );
+      deps.restartAgent(name);
+      return { reconciled: true, restarted: true, changes: allChanges };
+    }
   }
 
   deps.restartAgent(name);


### PR DESCRIPTION
## Summary

When the gateway IPC socket is missing or unresponsive — the symptom of a wedged gateway, the very state where the user most wants \`switchroom restart\` to work — \`gracefulRestartAgent\` errors out and leaves the agent running on a broken bridge. The user has to know to manually bounce both services.

This PR catches the graceful-path failure, logs it, and falls back to \`restartAgent()\` which bounces both the gateway and the agent via systemctl. End result: one command always restores a working bridge, even when the gateway IPC is dead.

## Why

Twice in 24h, clerk has gone mute because the gateway got wedged. The agent's \`claude\` process kept running but the IPC bridge couldn't re-form. Bouncing only the agent didn't fix it — the gateway's wedged state survived. The fix today required:

\`\`\`
systemctl --user restart switchroom-clerk-gateway.service switchroom-clerk.service
\`\`\`

That's not a verb users should have to know. \`switchroom restart clerk\` should just work.

## What changed

\`reconcileAndRestartAgent\` (in \`src/cli/agent.ts\`) wraps \`gracefulRestartAgent\` in try/catch. On failure (socket missing, connect refused, timeout) it logs a yellow warning and calls \`restartAgent\` instead — which already bounces gateway + agent in the right order via systemctl.

## What this doesn't do (filed for follow-up)

This is the immediate UX fix. The deeper questions are tracked in:
- #56 — gateway long-poll silently stalls
- #71 — agent restart alone doesn't re-establish bridge (root-cause investigation pending)

## Test plan

- [x] \`bunx vitest run\` — 2915 passed; 7 pre-existing failures unrelated to this change (6 in cron-auth.test.ts, 1 tmux-dependent auth test) — verified by stashing this PR's diff and re-running
- [ ] **Manual** (deferred — would require deliberately wedging the gateway): run \`switchroom restart\` against an agent whose gateway IPC is dead, confirm fallback fires and bridge re-forms

🤖 Generated with [Claude Code](https://claude.com/claude-code)