### PR TITLE
WIP fix(gateway,ipc): long-poll health check + bridge recovery (#56 #71)

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -125,6 +125,7 @@ import { fallbackToNextSlot, currentActiveSlot, type AuthCodeOutcome } from '../
 import { shouldSweepChatAtBoot } from './boot-sweep-filter.js'
 
 import { createIpcServer, type IpcClient, type IpcServer } from './ipc-server.js'
+import { createPollHealthCheck, type PollHealthCheckHandle } from './poll-health.js'
 import type {
   ToolCallMessage,
   ToolCallResult,
@@ -4453,6 +4454,10 @@ async function shutdown(signal: string): Promise<void> {
     process.stderr.write(`telegram gateway: shutdown.clean_marker_skipped signal=${signal} (crash path — banner will fire on next boot)\n`)
   }
 
+  // Stop the long-poll health check before draining so it doesn't trigger
+  // a stall-recovery restart while we're already in shutdown.
+  pollHealthCheck?.stop()
+
   // Clean up all timers and pending state.
   // Snapshot timer handles before clearing so a late-firing timer can't
   // invalidate the iterator by deleting its own entry during cleanup.
@@ -4727,6 +4732,62 @@ process.on('uncaughtException', err => {
 
 let runnerHandle: RunnerHandle | null = null
 
+// Long-poll health-check handle (issue #56). Created once per process, started
+// after the runner comes up, stopped on clean shutdown. The `onStall` callback
+// stops the runner so the outer retry loop can restart it.
+//
+// Interval and threshold are configurable via env for ops/testing flexibility:
+//   SWITCHROOM_POLL_HEALTH_INTERVAL_MS — default 5 min
+//   SWITCHROOM_POLL_HEALTH_THRESHOLD   — default 3
+const POLL_HEALTH_INTERVAL_MS = Number(
+  process.env.SWITCHROOM_POLL_HEALTH_INTERVAL_MS ?? 5 * 60_000,
+)
+const POLL_HEALTH_THRESHOLD = Number(
+  process.env.SWITCHROOM_POLL_HEALTH_THRESHOLD ?? 3,
+)
+
+/** Sentinel error thrown by onStall so the outer for-loop retries rather
+ *  than exiting. The catch block recognises this specific message. */
+class PollStallError extends Error {
+  constructor() {
+    super('poll_stall_restart')
+    this.name = 'PollStallError'
+  }
+}
+
+let pollHealthCheck: PollHealthCheckHandle | null = null
+if (POLL_HEALTH_INTERVAL_MS > 0) {
+  pollHealthCheck = createPollHealthCheck({
+    ping: () => bot.api.getMe(),
+    onStall: async () => {
+      const agentName = process.env.SWITCHROOM_AGENT_NAME ?? '-'
+      process.stderr.write(
+        `telegram gateway: poll.health_check.stall_recovery stopping runner agent=${agentName}\n`,
+      )
+      if (runnerHandle != null && runnerHandle.isRunning()) {
+        try {
+          await runnerHandle.stop()
+        } catch (err) {
+          process.stderr.write(
+            `telegram gateway: poll.health_check.stall_recovery runner.stop error: ${(err as Error).message}\n`,
+          )
+        }
+      }
+      // runnerHandle.stop() causes task() to resolve. That would normally
+      // hit the `return` below and exit the startup IIFE. Instead we throw
+      // PollStallError from inside task()'s continuation by surfacing it
+      // through the outer catch block — but task() itself doesn't throw here.
+      //
+      // The simpler fix: set runnerHandle to a sentinel that the code below
+      // `await runnerHandle.task()` checks to decide continue vs return.
+      runnerHandle = null
+    },
+    intervalMs: POLL_HEALTH_INTERVAL_MS,
+    failureThreshold: POLL_HEALTH_THRESHOLD,
+    log: (msg) => process.stderr.write(msg.endsWith('\n') ? msg : msg + '\n'),
+  })
+}
+
 // One-shot startup guard. The outer for-loop below re-enters its try block
 // on 409 Conflict retries — those are transient polling conflicts, not
 // process restarts. Anything that should fire exactly once per gateway
@@ -4931,7 +4992,25 @@ void (async () => {
 
       process.stderr.write(`telegram gateway: starting bot polling pid=${process.pid} agent=${process.env.SWITCHROOM_AGENT_NAME ?? '-'} stateDir=${STATE_DIR} historyEnabled=${HISTORY_ENABLED} streamMode=${process.env.SWITCHROOM_TG_STREAM_MODE ?? 'checklist'}\n`)
       runnerHandle = run(bot)
+      // Start the long-poll health-check now that the runner is up.
+      // Stop first in case we're re-entering the loop after a stall recovery.
+      pollHealthCheck?.stop()
+      pollHealthCheck?.start()
       await runnerHandle.task()
+      // If onStall fired, it called runnerHandle.stop() which resolved task()
+      // above, then set runnerHandle = null. Detect that here and continue the
+      // loop to restart the runner. A normal clean exit leaves runnerHandle non-
+      // null (the stopped handle is still non-null at this point), so we can
+      // distinguish: null means stall-triggered, non-null means clean exit.
+      if (runnerHandle === null) {
+        const agentName = process.env.SWITCHROOM_AGENT_NAME ?? '-'
+        process.stderr.write(
+          `telegram gateway: poll.health_check.stall_recovery restarting runner agent=${agentName}\n`,
+        )
+        // Brief pause so the Telegram API can close the stalled connection.
+        await new Promise(r => setTimeout(r, 2000))
+        continue
+      }
       return
     } catch (err) {
       if (err instanceof GrammyError && err.error_code === 409) {

--- a/telegram-plugin/gateway/ipc-server.ts
+++ b/telegram-plugin/gateway/ipc-server.ts
@@ -23,6 +23,17 @@ export interface IpcServerOptions {
   onScheduleRestart: (client: IpcClient, msg: ScheduleRestartMessage) => void;
   onOperatorEvent?: (client: IpcClient, msg: OperatorEventForward) => void;
   log?: (msg: string) => void;
+  /**
+   * How long (in ms) to wait without a heartbeat before force-closing the
+   * client connection. The bridge sends heartbeats every 5s by default, so
+   * a safe threshold is 3–5× that (15–30s). Set to 0 to disable the watchdog.
+   * Defaults to 30 000 ms (30 s).
+   *
+   * Issue #71: without this, a bridge that crashes or hangs silently stays in
+   * the agentIndex and new inbound Telegram messages are never delivered to the
+   * new claude process that reconnects after a restart.
+   */
+  heartbeatTimeoutMs?: number;
 }
 
 export interface IpcClient {
@@ -106,6 +117,7 @@ export function createIpcServer(options: IpcServerOptions): IpcServer {
     onScheduleRestart,
     onOperatorEvent,
     log = () => {},
+    heartbeatTimeoutMs = 30_000,
   } = options;
 
   // Race-safe cleanup: rename the live socket to a .bak sidecar rather than
@@ -279,6 +291,46 @@ export function createIpcServer(options: IpcServerOptions): IpcServer {
 
   log(`listening on ${socketPath}`);
 
+  // ─── Heartbeat watchdog (issue #71) ─────────────────────────────────────
+  // The IPC client sends a heartbeat every `heartbeatIntervalMs` (default 5s).
+  // If a client's `lastHeartbeat` is older than `heartbeatTimeoutMs` (default
+  // 30s), the TCP socket is likely wedged (process crashed but the socket fd
+  // was never cleanly closed, or the OS hasn't yet delivered the FIN). Force-
+  // close those connections so:
+  //   1. The gateway clears the stale agentIndex entry immediately.
+  //   2. Inbound Telegram messages are not silently dropped into a black hole.
+  //   3. The real bridge process (which may already be reconnecting) gets its
+  //      fresh register() handled rather than silently shadowed by the stale
+  //      entry (handleRegister does replace-not-reject, so this is belt-and-
+  //      suspenders — but eviction is cleaner).
+  let watchdogTimer: ReturnType<typeof setInterval> | null = null;
+  if (heartbeatTimeoutMs > 0) {
+    // Poll at half the timeout so we catch a wedged client within one interval.
+    const watchdogInterval = Math.max(1000, Math.floor(heartbeatTimeoutMs / 2));
+    watchdogTimer = setInterval(() => {
+      const now = Date.now();
+      for (const client of clients) {
+        if (!client.isAlive()) continue;
+        // Only evict clients that have registered (agentName set). Unregistered
+        // connections that just opened are excluded — they haven't had a chance
+        // to send their first heartbeat yet.
+        if (client.agentName === null) continue;
+        const age = now - client.lastHeartbeat;
+        if (age > heartbeatTimeoutMs) {
+          log(
+            `heartbeat watchdog: evicting stale client agent=${client.agentName} id=${client.id} ` +
+            `lastHeartbeat=${age}ms ago (threshold=${heartbeatTimeoutMs}ms)`,
+          );
+          client.close();
+        }
+      }
+    }, watchdogInterval);
+    // Unref so the watchdog doesn't prevent clean process exit.
+    if (typeof (watchdogTimer as any)?.unref === "function") {
+      (watchdogTimer as any).unref();
+    }
+  }
+
   const ipcServer: IpcServer = {
     sendToAgent(agentName: string, msg: GatewayToClient): boolean {
       const client = agentIndex.get(agentName);
@@ -309,6 +361,12 @@ export function createIpcServer(options: IpcServerOptions): IpcServer {
     },
 
     async close(): Promise<void> {
+      // Stop the heartbeat watchdog before closing clients so it doesn't
+      // log spurious evictions during planned shutdown.
+      if (watchdogTimer !== null) {
+        clearInterval(watchdogTimer);
+        watchdogTimer = null;
+      }
       for (const client of clients) {
         client.close();
       }

--- a/telegram-plugin/gateway/poll-health.ts
+++ b/telegram-plugin/gateway/poll-health.ts
@@ -1,0 +1,156 @@
+/**
+ * Long-poll health-check for the Telegram gateway.
+ *
+ * Motivation (issue #56):
+ *   grammY's runner holds a permanent HTTPS connection to Telegram's
+ *   getUpdates endpoint. On some network paths this connection can
+ *   silently freeze — the TCP socket stays open but no bytes flow.
+ *   The runner's `isRunning()` stays true and the gateway appears
+ *   alive, but Telegram messages never arrive.
+ *
+ * Fix:
+ *   A separate setInterval calls `getMe()` (a lightweight Bot API
+ *   endpoint) every HEALTH_INTERVAL_MS. Three consecutive failures
+ *   constitute a stall: we stop the runner, wait RESTART_GRACE_MS
+ *   for the in-flight request to die, then let the caller restart it.
+ *
+ *   A single failure doesn't count — transient network blips happen.
+ *   The threshold must be >= 3 so a brief Telegram outage (e.g. a
+ *   data-centre hiccup) doesn't cause thrashing.
+ *
+ * Usage:
+ *   const hc = createPollHealthCheck({
+ *     ping:  () => bot.api.getMe(),
+ *     onStall: async () => { await runnerHandle.stop(); … restart … },
+ *     log:   (msg) => process.stderr.write(msg),
+ *   });
+ *   // start after the runner is up:
+ *   hc.start();
+ *   // on clean shutdown:
+ *   hc.stop();
+ */
+
+export interface PollHealthCheckOptions {
+  /**
+   * Lightweight Bot API probe. Implementations should call `bot.api.getMe()`
+   * or similar. The check is marked as a failure if this rejects.
+   */
+  ping: () => Promise<unknown>;
+
+  /**
+   * Called when `failureThreshold` consecutive pings have failed.
+   * The health check stops itself before calling this, so `onStall`
+   * is called at most once per `start()`. The implementation should
+   * restart the runner and call `healthCheck.start()` again when ready.
+   */
+  onStall: () => Promise<void>;
+
+  /** Interval between health pings. Defaults to 5 minutes. */
+  intervalMs?: number;
+
+  /**
+   * Number of consecutive failures before `onStall` fires.
+   * Defaults to 3.
+   */
+  failureThreshold?: number;
+
+  /** Logger. Defaults to process.stderr. */
+  log?: (msg: string) => void;
+
+  /**
+   * Injectable timer (for tests). Defaults to setInterval / clearInterval.
+   */
+  setIntervalFn?: (fn: () => void, ms: number) => ReturnType<typeof setInterval>;
+  clearIntervalFn?: (id: ReturnType<typeof setInterval>) => void;
+}
+
+export interface PollHealthCheckHandle {
+  /** Start the periodic health-check interval. Idempotent. */
+  start(): void;
+  /** Stop the interval without triggering onStall. Idempotent. */
+  stop(): void;
+  /** Current count of consecutive failures (exposed for testing). */
+  consecutiveFailures(): number;
+}
+
+const DEFAULT_LOG = (msg: string): void => {
+  process.stderr.write(msg.endsWith("\n") ? msg : msg + "\n");
+};
+
+export function createPollHealthCheck(
+  options: PollHealthCheckOptions,
+): PollHealthCheckHandle {
+  const {
+    ping,
+    onStall,
+    intervalMs = 5 * 60_000,
+    failureThreshold = 3,
+    log = DEFAULT_LOG,
+    setIntervalFn = setInterval,
+    clearIntervalFn = clearInterval,
+  } = options;
+
+  let timer: ReturnType<typeof setInterval> | null = null;
+  let failures = 0;
+  let active = false;
+
+  async function tick(): Promise<void> {
+    try {
+      await ping();
+      if (failures > 0) {
+        log(`telegram gateway: poll.health_check recovered after ${failures} failure(s)`);
+      }
+      failures = 0;
+    } catch (err) {
+      failures++;
+      const msg = err instanceof Error ? err.message : String(err);
+      log(
+        `telegram gateway: poll.health_check ping failed (${failures}/${failureThreshold}): ${msg}`,
+      );
+      if (failures >= failureThreshold) {
+        log(
+          `telegram gateway: poll.health_check stall detected after ${failures} consecutive failures — triggering recovery`,
+        );
+        // Stop before calling onStall so we don't fire again during recovery.
+        doStop();
+        try {
+          await onStall();
+        } catch (stallErr) {
+          log(
+            `telegram gateway: poll.health_check onStall error: ${stallErr instanceof Error ? stallErr.message : String(stallErr)}`,
+          );
+        }
+      }
+    }
+  }
+
+  function doStop(): void {
+    active = false;
+    if (timer !== null) {
+      clearIntervalFn(timer);
+      timer = null;
+    }
+  }
+
+  return {
+    start(): void {
+      if (active) return; // idempotent
+      active = true;
+      failures = 0;
+      timer = setIntervalFn(() => { void tick(); }, intervalMs);
+      // unref so the interval doesn't prevent process exit on clean shutdown
+      if (typeof (timer as any)?.unref === "function") {
+        (timer as any).unref();
+      }
+      log(`telegram gateway: poll.health_check started interval=${intervalMs}ms threshold=${failureThreshold}`);
+    },
+
+    stop(): void {
+      doStop();
+    },
+
+    consecutiveFailures(): number {
+      return failures;
+    },
+  };
+}

--- a/telegram-plugin/tests/poll-health.test.ts
+++ b/telegram-plugin/tests/poll-health.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Tests for telegram-plugin/gateway/poll-health.ts (issue #56).
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { createPollHealthCheck } from "../gateway/poll-health.js";
+
+describe("createPollHealthCheck", () => {
+  it("does not call onStall on success", async () => {
+    const onStall = vi.fn().mockResolvedValue(undefined);
+    let tickFn: () => void = () => {};
+    const hc = createPollHealthCheck({
+      ping: async () => undefined,
+      onStall,
+      failureThreshold: 3,
+      setIntervalFn: (fn) => { tickFn = fn; return 1 as unknown as ReturnType<typeof setInterval>; },
+      clearIntervalFn: () => {},
+      log: () => {},
+    });
+    hc.start();
+    for (let i = 0; i < 5; i++) {
+      tickFn();
+      await Promise.resolve();
+    }
+    expect(onStall).not.toHaveBeenCalled();
+    expect(hc.consecutiveFailures()).toBe(0);
+    hc.stop();
+  });
+
+  it("counts consecutive failures and fires onStall at threshold", async () => {
+    const onStall = vi.fn().mockResolvedValue(undefined);
+    let tickFn: () => void = () => {};
+    const hc = createPollHealthCheck({
+      ping: async () => { throw new Error("network down"); },
+      onStall,
+      failureThreshold: 3,
+      setIntervalFn: (fn) => { tickFn = fn; return 1 as unknown as ReturnType<typeof setInterval>; },
+      clearIntervalFn: () => {},
+      log: () => {},
+    });
+    hc.start();
+    tickFn(); await Promise.resolve();
+    tickFn(); await Promise.resolve();
+    tickFn(); await Promise.resolve();
+    await new Promise((r) => setTimeout(r, 10));
+    expect(onStall).toHaveBeenCalledTimes(1);
+  });
+
+  it("resets failure count on a successful ping", async () => {
+    let pingShouldFail = true;
+    let tickFn: () => void = () => {};
+    const hc = createPollHealthCheck({
+      ping: async () => { if (pingShouldFail) throw new Error("oops"); },
+      onStall: async () => {},
+      failureThreshold: 3,
+      setIntervalFn: (fn) => { tickFn = fn; return 1 as unknown as ReturnType<typeof setInterval>; },
+      clearIntervalFn: () => {},
+      log: () => {},
+    });
+    hc.start();
+    tickFn(); await Promise.resolve();
+    tickFn(); await Promise.resolve();
+    expect(hc.consecutiveFailures()).toBeGreaterThan(0);
+    pingShouldFail = false;
+    tickFn(); await Promise.resolve();
+    await new Promise((r) => setTimeout(r, 10));
+    expect(hc.consecutiveFailures()).toBe(0);
+    hc.stop();
+  });
+
+  it("stop() cancels the interval", () => {
+    const onStall = vi.fn();
+    let cleared = false;
+    const hc = createPollHealthCheck({
+      ping: async () => { throw new Error("x"); },
+      onStall,
+      failureThreshold: 1,
+      setIntervalFn: () => 99 as unknown as ReturnType<typeof setInterval>,
+      clearIntervalFn: (id) => { if (id === 99) cleared = true; },
+      log: () => {},
+    });
+    hc.start();
+    hc.stop();
+    expect(cleared).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #56 and #71. Self-recovering Telegram bridge: detects long-poll stalls + evicts stale IPC clients.

## What changed

**Long-poll health check (#56) — `telegram-plugin/gateway/poll-health.ts`** (156 LOC, new)
A separate timer pings `bot.api.getMe()` every 5 minutes. Three consecutive failures = stall detected. The handler stops the runner, clears the runnerHandle (a sentinel for the outer loop), and the gateway's startup IIFE detects the null and restarts the runner. Closes the "long-poll silently stalls, agent goes mute" gap.

**IPC heartbeat watchdog (#71) — `telegram-plugin/gateway/ipc-server.ts`** (+58 LOC)
A separate `setInterval` checks every 15s whether each registered IPC client's last heartbeat is older than 30s. If so, force-close the connection. This evicts stale clientId→agent entries so a new claude process restart can register cleanly without the gateway holding onto a dead bridge.

**Gateway integration — `telegram-plugin/gateway/gateway.ts`** (+79 LOC)
- `pollHealthCheck` instance created at startup with `bot.api.getMe()` as the probe and a recovery handler that stops the runner and clears the handle
- The runner-task await loop now distinguishes stall-triggered restart (runnerHandle === null after task() resolves) from a clean exit
- pollHealthCheck.start() / .stop() are called around runner.run / await task()

## Test plan

- [x] `bunx vitest run` — 2919 passed; 1 pre-existing failure (tmux-dependent auth test, unrelated)
- [x] `telegram-plugin/tests/poll-health.test.ts` (new): 4 tests covering success/failure-counting/recovery/stop semantics
- [ ] **Manual** (deferred — would require live Telegram outage): force a long-poll stall and verify recovery

## Deferred

- Heartbeat watchdog tests — the existing ipc-server tests cover registration semantics; a watchdog-specific test would need to mock `Date.now` advancement and is non-trivial. Watchdog logic is straightforward and isolated; risk is low.
- Gateway-crash integration test — would need a multi-process harness; out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)