### PR TITLE
feat: switchroom-worktree MCP + CLI for parallel sub-agent code isolation (closes #74)

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -19,6 +19,7 @@ import { registerHandoffCommand } from "./handoff.js";
 import { registerDepsCommand } from "./deps.js";
 import { registerWorkspaceCommand } from "./workspace.js";
 import { registerDebugCommand } from "./debug.js";
+import { registerWorktreeCommand } from "./worktree.js";
 import { captureEvent, installGlobalErrorHandlers } from "../analytics/posthog.js";
 
 installGlobalErrorHandlers();
@@ -60,6 +61,7 @@ registerHandoffCommand(program);
 registerDepsCommand(program);
 registerWorkspaceCommand(program);
 registerDebugCommand(program);
+registerWorktreeCommand(program);
 
 // Deprecated aliases — kept for one release, will be removed after.
 // Invoking these prints a clear deprecation warning and delegates to `update`.

--- a/src/cli/worktree.ts
+++ b/src/cli/worktree.ts
@@ -1,0 +1,159 @@
+/**
+ * CLI surface for the worktree subsystem.
+ *
+ * Commands:
+ *   switchroom worktree claim <repo> [--task <name>] [--agent <name>]
+ *   switchroom worktree release <id>
+ *   switchroom worktree list [--json]
+ *   switchroom worktree reap [--dry-run]
+ */
+
+import type { Command } from "commander";
+import chalk from "chalk";
+import { claimWorktree } from "../worktree/claim.js";
+import { releaseWorktree } from "../worktree/release.js";
+import { listWorktrees } from "../worktree/list.js";
+import { runReaper } from "../worktree/reaper.js";
+
+export function registerWorktreeCommand(program: Command): void {
+  const worktree = program
+    .command("worktree")
+    .description("Manage git worktrees for parallel sub-agent isolation");
+
+  // ─── claim ────────────────────────────────────────────────────────────────
+
+  worktree
+    .command("claim <repo>")
+    .description(
+      "Claim a worktree for the given repo alias or absolute path.\n" +
+      "Outputs the worktree id, path, and branch.",
+    )
+    .option("-t, --task <name>", "Human-readable task name (used as branch suffix)")
+    .option("-a, --agent <name>", "Agent name to associate with this claim")
+    .option("--json", "Output raw JSON")
+    .action(async (repo: string, opts: { task?: string; agent?: string; json?: boolean }) => {
+      try {
+        const result = await claimWorktree({
+          repo,
+          taskName: opts.task,
+          ownerAgent: opts.agent,
+        });
+        if (opts.json) {
+          console.log(JSON.stringify(result));
+        } else {
+          console.log(chalk.green("Worktree claimed"));
+          console.log(`  id:     ${chalk.bold(result.id)}`);
+          console.log(`  branch: ${chalk.bold(result.branch)}`);
+          console.log(`  path:   ${chalk.bold(result.path)}`);
+        }
+      } catch (err) {
+        console.error(chalk.red("Error:"), (err as Error).message);
+        process.exit(1);
+      }
+    });
+
+  // ─── release ──────────────────────────────────────────────────────────────
+
+  worktree
+    .command("release <id>")
+    .description("Release a claimed worktree by ID")
+    .option("--json", "Output raw JSON")
+    .action((id: string, opts: { json?: boolean }) => {
+      try {
+        const result = releaseWorktree({ id });
+        if (opts.json) {
+          console.log(JSON.stringify(result));
+        } else {
+          if (result.released) {
+            console.log(chalk.green(`Worktree ${id} released.`));
+          } else {
+            console.log(
+              chalk.yellow(
+                `Worktree ${id} release was partial (git remove failed, registry cleaned up).`,
+              ),
+            );
+          }
+        }
+      } catch (err) {
+        console.error(chalk.red("Error:"), (err as Error).message);
+        process.exit(1);
+      }
+    });
+
+  // ─── list ─────────────────────────────────────────────────────────────────
+
+  worktree
+    .command("list")
+    .description("List all active worktree claims")
+    .option("--json", "Output raw JSON")
+    .action((opts: { json?: boolean }) => {
+      const { worktrees } = listWorktrees();
+      if (opts.json) {
+        console.log(JSON.stringify({ worktrees }));
+        return;
+      }
+      if (worktrees.length === 0) {
+        console.log("No active worktrees.");
+        return;
+      }
+      console.log(chalk.bold(`${worktrees.length} active worktree(s):\n`));
+      for (const wt of worktrees) {
+        const hbAge = Math.round(wt.heartbeatAgeSeconds / 60);
+        const fresh = wt.heartbeatAgeSeconds < 120
+          ? chalk.green("fresh")
+          : chalk.yellow(`${hbAge}m ago`);
+        console.log(`  ${chalk.bold(wt.id)}`);
+        console.log(`    repo:    ${wt.repoName} (${wt.repo})`);
+        console.log(`    branch:  ${wt.branch}`);
+        console.log(`    path:    ${wt.path}`);
+        console.log(`    agent:   ${wt.ownerAgent ?? "(none)"}`);
+        console.log(`    heartbeat: ${fresh}`);
+        console.log();
+      }
+    });
+
+  // ─── reap ─────────────────────────────────────────────────────────────────
+
+  worktree
+    .command("reap")
+    .description("Run the reaper — remove stale/orphaned worktrees")
+    .option("--dry-run", "Show what would be reaped without acting")
+    .option("--json", "Output raw JSON")
+    .action((opts: { dryRun?: boolean; json?: boolean }) => {
+      if (opts.dryRun) {
+        // Show stale records without acting
+        const { worktrees } = listWorktrees();
+        const STALE_MS = 10 * 60 * 1000;
+        const stale = worktrees.filter(
+          w => w.heartbeatAgeSeconds * 1000 > STALE_MS,
+        );
+        if (opts.json) {
+          console.log(JSON.stringify({ would_reap: stale.map(w => w.id) }));
+        } else {
+          if (stale.length === 0) {
+            console.log("No stale worktrees found.");
+          } else {
+            console.log(chalk.yellow(`Would reap ${stale.length} worktree(s):`));
+            for (const w of stale) {
+              console.log(`  ${w.id} — ${w.branch}`);
+            }
+          }
+        }
+        return;
+      }
+
+      const result = runReaper();
+      if (opts.json) {
+        console.log(JSON.stringify(result));
+      } else {
+        if (result.reaped.length === 0) {
+          console.log("No worktrees reaped.");
+        } else {
+          console.log(chalk.green(`Reaped ${result.reaped.length} worktree(s): ${result.reaped.join(", ")}`));
+        }
+        for (const w of result.warnings) {
+          console.warn(chalk.yellow(w));
+        }
+      }
+    });
+}

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -1,5 +1,23 @@
 import { z } from "zod";
 
+/**
+ * A single entry in an agent's code_repos list.
+ * Declares a git repo the agent is allowed to claim worktrees from,
+ * with an optional short alias and per-repo concurrency cap.
+ */
+export const CodeRepoEntrySchema = z.object({
+  name: z.string().describe("Short alias used when claiming (e.g. 'switchroom')"),
+  source: z
+    .string()
+    .describe("Absolute or home-relative path to the repo (e.g. ~/code/switchroom)"),
+  concurrency: z
+    .number()
+    .int()
+    .positive()
+    .optional()
+    .describe("Max simultaneous worktrees for this repo (default 5)"),
+});
+
 export const ScheduleEntrySchema = z.object({
   cron: z.string().describe("Cron expression (e.g., '0 8 * * *')"),
   prompt: z.string().describe("Prompt to send at the scheduled time"),
@@ -636,6 +654,16 @@ export const AgentSchema = z.object({
       "doesn't expose directly (e.g. --effort high, " +
       "--exclude-dynamic-system-prompt-sections)."
     ),
+  code_repos: z
+    .array(CodeRepoEntrySchema)
+    .optional()
+    .describe(
+      "Git repositories this agent is allowed to claim worktrees from. " +
+      "Each entry provides a short name alias, a source path, and an " +
+      "optional concurrency cap (default 5). When code_repos is set, " +
+      "claim_worktree accepts the alias as the repo argument. " +
+      "Absolute paths may always be passed regardless of this list.",
+    ),
 });
 
 export const TelegramConfigSchema = z.object({
@@ -796,3 +824,4 @@ export type TelegramConfig = z.infer<typeof TelegramConfigSchema>;
 export type MemoryBackendConfig = z.infer<typeof MemoryBackendConfigSchema>;
 export type VaultConfig = z.infer<typeof VaultConfigSchema>;
 export type QuotaConfig = z.infer<typeof QuotaConfigSchema>;
+export type CodeRepoEntry = z.infer<typeof CodeRepoEntrySchema>;

--- a/src/worktree/claim.ts
+++ b/src/worktree/claim.ts
@@ -1,0 +1,158 @@
+/**
+ * claim_worktree: atomically reserve a git worktree for a sub-agent.
+ *
+ * Protocol:
+ *   1. Resolve repo path from alias or absolute path.
+ *   2. Check concurrency cap.
+ *   3. Write registry record BEFORE running git (atomic claim).
+ *   4. Run git worktree add with the generated branch.
+ *   5. Return { id, path, branch }.
+ *
+ * If git fails after the registry write, we clean up the record so the
+ * claim doesn't ghost.
+ */
+
+import { execFileSync } from "node:child_process";
+import { mkdirSync, existsSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { homedir } from "node:os";
+import { randomBytes } from "node:crypto";
+import { writeRecord, countByRepo, deleteRecord } from "./registry.js";
+import type { ClaimInput, ClaimResult, CodeRepoEntry } from "./types.js";
+
+/** Default max simultaneous worktrees per repo. */
+export const DEFAULT_CONCURRENCY = 5;
+
+/** Base directory where worktrees are created. */
+export function worktreesBaseDir(): string {
+  return resolve(
+    process.env.SWITCHROOM_WORKTREE_BASE ?? join(homedir(), ".switchroom", "worktree-checkouts"),
+  );
+}
+
+/**
+ * Generate a short URL-safe ID (8 hex chars).
+ */
+function shortId(): string {
+  return randomBytes(4).toString("hex");
+}
+
+/**
+ * Sanitize a task name for use in a branch name.
+ * Allows alphanumeric, hyphens, underscores. Truncates at 40 chars.
+ */
+function sanitizeTaskName(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9_-]/g, "-")
+    .replace(/-{2,}/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 40);
+}
+
+/**
+ * Resolve a repo alias or absolute path to an absolute path.
+ * Expands ~ and env vars minimally (only ~/).
+ */
+export function resolveRepoPath(
+  repo: string,
+  codeRepos?: CodeRepoEntry[],
+): string {
+  // Try alias match first
+  if (codeRepos) {
+    const entry = codeRepos.find(r => r.name === repo);
+    if (entry) {
+      return expandHome(entry.source);
+    }
+  }
+  // Accept absolute path directly
+  if (repo.startsWith("/") || repo.startsWith("~")) {
+    return expandHome(repo);
+  }
+  throw new Error(
+    `Repository "${repo}" is not declared in code_repos and is not an absolute path. ` +
+    `Declare it in your agent's code_repos list or pass an absolute path.`,
+  );
+}
+
+function expandHome(p: string): string {
+  if (p.startsWith("~/")) return join(homedir(), p.slice(2));
+  return p;
+}
+
+/**
+ * Claim a worktree.
+ *
+ * @param input.repo    Alias from code_repos or absolute path.
+ * @param input.taskName Optional human-readable suffix.
+ * @param input.ownerAgent Optional agent name for the registry record.
+ * @param codeRepos  code_repos entries from switchroom.yaml (optional).
+ */
+export async function claimWorktree(
+  input: ClaimInput,
+  codeRepos?: CodeRepoEntry[],
+): Promise<ClaimResult> {
+  const repoPath = resolveRepoPath(input.repo, codeRepos);
+
+  // Check repo exists
+  if (!existsSync(repoPath)) {
+    throw new Error(`Repository path does not exist: ${repoPath}`);
+  }
+
+  // Determine concurrency cap
+  let concurrencyCap = DEFAULT_CONCURRENCY;
+  if (codeRepos) {
+    const entry = codeRepos.find(r => r.name === input.repo);
+    if (entry?.concurrency !== undefined) concurrencyCap = entry.concurrency;
+  }
+
+  // Check concurrency cap
+  const current = countByRepo(repoPath);
+  if (current >= concurrencyCap) {
+    throw new Error(
+      `Concurrency cap of ${concurrencyCap} reached for repo "${input.repo}". ` +
+      `Release existing worktrees before claiming more.`,
+    );
+  }
+
+  // Generate ID and branch
+  const id = shortId();
+  const taskSuffix = input.taskName ? sanitizeTaskName(input.taskName) : "task";
+  const branch = `task/${taskSuffix}-${id}`;
+
+  // Compute worktree path
+  const baseDir = worktreesBaseDir();
+  mkdirSync(baseDir, { recursive: true });
+  const worktreePath = join(baseDir, `${id}-${taskSuffix}`);
+
+  const now = new Date().toISOString();
+  const record = {
+    id,
+    repo: repoPath,
+    repoName: input.repo,
+    branch,
+    path: worktreePath,
+    createdAt: now,
+    heartbeatAt: now,
+    ownerAgent: input.ownerAgent,
+  };
+
+  // ATOMIC: write registry record BEFORE git operation.
+  // If git fails, we delete the record to prevent orphaning.
+  writeRecord(record);
+
+  try {
+    // git worktree add -b <branch> <path>
+    execFileSync("git", ["worktree", "add", "-b", branch, worktreePath], {
+      cwd: repoPath,
+      stdio: "pipe",
+    });
+  } catch (err) {
+    // Clean up the registry record since git failed
+    deleteRecord(id);
+    const msg = err instanceof Error ? err.message : String(err);
+    throw new Error(`git worktree add failed: ${msg}`);
+  }
+
+  return { id, path: worktreePath, branch };
+}

--- a/src/worktree/claim.ts
+++ b/src/worktree/claim.ts
@@ -13,12 +13,49 @@
  */
 
 import { execFileSync } from "node:child_process";
-import { mkdirSync, existsSync } from "node:fs";
+import { closeSync, mkdirSync, openSync, existsSync, unlinkSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { homedir } from "node:os";
 import { randomBytes } from "node:crypto";
-import { writeRecord, countByRepo, deleteRecord } from "./registry.js";
+import { writeRecord, countByRepo, deleteRecord, registryDir } from "./registry.js";
 import type { ClaimInput, ClaimResult, CodeRepoEntry } from "./types.js";
+
+/**
+ * Acquire a per-repo lockfile to serialize claim() across processes.
+ *
+ * The TOCTOU window between countByRepo() and writeRecord() lets two
+ * concurrent claims both pass the cap check. A lockfile with O_EXCL
+ * forces them to serialize. Returns a release function the caller MUST
+ * call (use try/finally).
+ */
+function acquireRepoLock(repoPath: string): () => void {
+  const lockDir = registryDir();
+  mkdirSync(lockDir, { recursive: true });
+  // Different repos shouldn't block each other — lockfile per repo path.
+  const lockName = repoPath.replace(/[^A-Za-z0-9]/g, "_");
+  const lockPath = join(lockDir, `.lock-${lockName}`);
+  const deadline = Date.now() + 5_000;
+  let fd: number | null = null;
+  while (fd === null) {
+    try {
+      fd = openSync(lockPath, "wx");
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== "EEXIST") throw err;
+      if (Date.now() > deadline) {
+        throw new Error(
+          `Failed to acquire claim lock for "${repoPath}" within 5s. ` +
+          `Another claim may be hung; check ${lockPath} and remove if stale.`,
+        );
+      }
+      const start = Date.now();
+      while (Date.now() - start < 50) { /* spin briefly */ }
+    }
+  }
+  return () => {
+    try { closeSync(fd as number); } catch { /* ignore */ }
+    try { unlinkSync(lockPath); } catch { /* race-tolerant */ }
+  };
+}
 
 /** Default max simultaneous worktrees per repo. */
 export const DEFAULT_CONCURRENCY = 5;
@@ -106,40 +143,54 @@ export async function claimWorktree(
     if (entry?.concurrency !== undefined) concurrencyCap = entry.concurrency;
   }
 
-  // Check concurrency cap
-  const current = countByRepo(repoPath);
-  if (current >= concurrencyCap) {
-    throw new Error(
-      `Concurrency cap of ${concurrencyCap} reached for repo "${input.repo}". ` +
-      `Release existing worktrees before claiming more.`,
-    );
+  // Acquire per-repo lock so concurrent claims serialize through the
+  // count-check + writeRecord critical section. Without the lock, two
+  // callers can both read count<cap and both write, violating the cap.
+  const releaseLock = acquireRepoLock(repoPath);
+
+  let id: string;
+  let branch: string;
+  let worktreePath: string;
+  try {
+    // Check concurrency cap (now race-free under the lock)
+    const current = countByRepo(repoPath);
+    if (current >= concurrencyCap) {
+      throw new Error(
+        `Concurrency cap of ${concurrencyCap} reached for repo "${input.repo}". ` +
+        `Release existing worktrees before claiming more.`,
+      );
+    }
+
+    // Generate ID and branch
+    id = shortId();
+    const taskSuffix = input.taskName ? sanitizeTaskName(input.taskName) : "task";
+    branch = `task/${taskSuffix}-${id}`;
+
+    // Compute worktree path
+    const baseDir = worktreesBaseDir();
+    mkdirSync(baseDir, { recursive: true });
+    worktreePath = join(baseDir, `${id}-${taskSuffix}`);
+
+    const now = new Date().toISOString();
+    const record = {
+      id,
+      repo: repoPath,
+      repoName: input.repo,
+      branch,
+      path: worktreePath,
+      createdAt: now,
+      heartbeatAt: now,
+      ownerAgent: input.ownerAgent,
+    };
+
+    // ATOMIC: write registry record BEFORE git operation.
+    // If git fails, we delete the record to prevent orphaning.
+    writeRecord(record);
+  } finally {
+    // Release lock before the (potentially slow) git operation. The cap
+    // check + record write are done; subsequent counts include this record.
+    releaseLock();
   }
-
-  // Generate ID and branch
-  const id = shortId();
-  const taskSuffix = input.taskName ? sanitizeTaskName(input.taskName) : "task";
-  const branch = `task/${taskSuffix}-${id}`;
-
-  // Compute worktree path
-  const baseDir = worktreesBaseDir();
-  mkdirSync(baseDir, { recursive: true });
-  const worktreePath = join(baseDir, `${id}-${taskSuffix}`);
-
-  const now = new Date().toISOString();
-  const record = {
-    id,
-    repo: repoPath,
-    repoName: input.repo,
-    branch,
-    path: worktreePath,
-    createdAt: now,
-    heartbeatAt: now,
-    ownerAgent: input.ownerAgent,
-  };
-
-  // ATOMIC: write registry record BEFORE git operation.
-  // If git fails, we delete the record to prevent orphaning.
-  writeRecord(record);
 
   try {
     // git worktree add -b <branch> <path>

--- a/src/worktree/index.ts
+++ b/src/worktree/index.ts
@@ -1,0 +1,26 @@
+/**
+ * Public API for the switchroom-worktree subsystem.
+ */
+
+export { claimWorktree, resolveRepoPath, worktreesBaseDir } from "./claim.js";
+export { releaseWorktree } from "./release.js";
+export { listWorktrees } from "./list.js";
+export { runReaper, STALE_THRESHOLD_MS } from "./reaper.js";
+export {
+  writeRecord,
+  readRecord,
+  deleteRecord,
+  listRecords,
+  touchHeartbeat,
+  countByRepo,
+  registryDir,
+  recordPath,
+} from "./registry.js";
+export type {
+  WorktreeRecord,
+  ClaimInput,
+  ClaimResult,
+  ReleaseInput,
+  ReleaseResult,
+  CodeRepoEntry,
+} from "./types.js";

--- a/src/worktree/list.ts
+++ b/src/worktree/list.ts
@@ -1,0 +1,52 @@
+/**
+ * list_worktrees: enumerate active worktree claims for operator visibility.
+ */
+
+import { listRecords } from "./registry.js";
+import type { WorktreeRecord } from "./types.js";
+
+export interface ListedWorktree {
+  id: string;
+  repo: string;
+  repoName: string;
+  branch: string;
+  path: string;
+  /** Age in seconds since claim was created */
+  ageSeconds: number;
+  /** Seconds since last heartbeat */
+  heartbeatAgeSeconds: number;
+  ownerAgent?: string;
+  createdAt: string;
+  heartbeatAt: string;
+}
+
+export interface ListResult {
+  worktrees: ListedWorktree[];
+}
+
+/**
+ * List all active worktree claims.
+ */
+export function listWorktrees(): ListResult {
+  const now = Date.now();
+  const records = listRecords();
+  const worktrees: ListedWorktree[] = records.map(r => {
+    const ageSeconds = Math.floor((now - new Date(r.createdAt).getTime()) / 1000);
+    const heartbeatAgeSeconds = Math.floor(
+      (now - new Date(r.heartbeatAt).getTime()) / 1000,
+    );
+    return {
+      id: r.id,
+      repo: r.repo,
+      repoName: r.repoName,
+      branch: r.branch,
+      path: r.path,
+      ageSeconds,
+      heartbeatAgeSeconds,
+      ownerAgent: r.ownerAgent,
+      createdAt: r.createdAt,
+      heartbeatAt: r.heartbeatAt,
+    };
+  });
+  return { worktrees };
+}

--- a/src/worktree/reaper.ts
+++ b/src/worktree/reaper.ts
@@ -1,0 +1,126 @@
+/**
+ * Reaper: clean up orphaned worktree claims.
+ *
+ * Reaper logic (liveness-based, NOT age-based):
+ *   - A claim is stale when heartbeatAt is older than STALE_THRESHOLD_MS
+ *     AND no process holds the worktree path open (fuser check).
+ *   - A claim is an orphan when the registry record exists but the
+ *     filesystem worktree doesn't, or vice versa.
+ *
+ * On reap:
+ *   1. Run git worktree remove --force.
+ *   2. Delete the registry record.
+ *   3. If the worktree had uncommitted changes, emit a warning to stderr
+ *      (callers can forward this to Telegram).
+ */
+
+import { execFileSync, execSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { listRecords, deleteRecord } from "./registry.js";
+import type { WorktreeRecord } from "./types.js";
+
+/** Heartbeat age threshold in ms. Claims older than this are stale. */
+export const STALE_THRESHOLD_MS = 10 * 60 * 1000; // 10 minutes
+
+export interface ReapResult {
+  reaped: string[];
+  warnings: string[];
+}
+
+/**
+ * Check whether any process holds the worktree path open (Linux).
+ * Uses `fuser` (procps); returns false if fuser is unavailable.
+ */
+function isPathInUse(path: string): boolean {
+  try {
+    execFileSync("fuser", [path], { stdio: "pipe" });
+    return true; // fuser exits 0 when it finds a process
+  } catch {
+    return false; // fuser exits 1 when no process holds it, or not available
+  }
+}
+
+/**
+ * Check if a worktree has uncommitted changes.
+ * Returns true if there are staged or unstaged changes.
+ */
+function hasUncommittedChanges(repoPath: string, worktreePath: string): boolean {
+  try {
+    const out = execFileSync(
+      "git",
+      ["-C", worktreePath, "status", "--porcelain"],
+      { stdio: "pipe" },
+    ).toString();
+    return out.trim().length > 0;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Reap a single stale/orphan record.
+ * Returns a warning string if there were uncommitted changes, otherwise null.
+ */
+function reapRecord(record: WorktreeRecord): string | null {
+  const { id, path, repo, branch, ownerAgent } = record;
+
+  let warning: string | null = null;
+
+  if (existsSync(path)) {
+    // Check for uncommitted changes before removing
+    if (hasUncommittedChanges(repo, path)) {
+      warning =
+        `[worktree-reaper] Reaped worktree with uncommitted changes: ` +
+        `id=${id} branch=${branch} agent=${ownerAgent ?? "unknown"} path=${path}`;
+    }
+
+    try {
+      execFileSync("git", ["worktree", "remove", "--force", path], {
+        cwd: repo,
+        stdio: "pipe",
+      });
+    } catch {
+      // If git remove fails, still clean up the record.
+      // The path may have been manually deleted.
+    }
+  }
+
+  deleteRecord(id);
+  return warning;
+}
+
+/**
+ * Run the reaper pass.
+ *
+ * @param nowMs Optional override for "now" (for testing).
+ */
+export function runReaper(nowMs?: number): ReapResult {
+  const now = nowMs ?? Date.now();
+  const records = listRecords();
+
+  const reaped: string[] = [];
+  const warnings: string[] = [];
+
+  for (const record of records) {
+    const heartbeatAge = now - new Date(record.heartbeatAt).getTime();
+    const worktreeExists = existsSync(record.path);
+
+    // Case 1: Orphan — registry record exists but filesystem worktree doesn't.
+    // Clean up the dangling record.
+    if (!worktreeExists) {
+      deleteRecord(record.id);
+      reaped.push(record.id);
+      continue;
+    }
+
+    // Case 2: Stale heartbeat AND path not in use → reap.
+    if (heartbeatAge > STALE_THRESHOLD_MS && !isPathInUse(record.path)) {
+      const warning = reapRecord(record);
+      if (warning) warnings.push(warning);
+      reaped.push(record.id);
+      continue;
+    }
+  }
+
+  return { reaped, warnings };
+}

--- a/src/worktree/reaper.ts
+++ b/src/worktree/reaper.ts
@@ -14,7 +14,7 @@
  *      (callers can forward this to Telegram).
  */
 
-import { execFileSync, execSync } from "node:child_process";
+import { execFileSync } from "node:child_process";
 import { existsSync } from "node:fs";
 import { listRecords, deleteRecord } from "./registry.js";
 import type { WorktreeRecord } from "./types.js";
@@ -28,16 +28,37 @@ export interface ReapResult {
 }
 
 /**
- * Check whether any process holds the worktree path open (Linux).
- * Uses `fuser` (procps); returns false if fuser is unavailable.
+ * Check whether any process holds the worktree path open.
+ *
+ * Tries `fuser` (Linux/procps) first, then `lsof` (macOS/BSD). Returns
+ * false if neither probe finds a holder OR if neither tool is installed.
+ *
+ * Note: a false negative (returns false but a process actually has files
+ * open) means the reaper can fall through to heartbeat-only stale logic.
+ * That's acceptable — the spec allows reaping on stale heartbeat alone
+ * for hosts where process-liveness can't be probed.
  */
 function isPathInUse(path: string): boolean {
+  // fuser: Linux. Exits 0 when the path is in use; non-zero (or ENOENT
+  // if not installed) otherwise.
   try {
     execFileSync("fuser", [path], { stdio: "pipe" });
-    return true; // fuser exits 0 when it finds a process
+    return true;
   } catch {
-    return false; // fuser exits 1 when no process holds it, or not available
+    /* fuser missing or path not in use — fall through to lsof */
   }
+  // lsof: macOS / BSD. Exits 0 with PID output when in use.
+  try {
+    const out = execFileSync("lsof", ["-t", path], {
+      stdio: ["ignore", "pipe", "ignore"],
+    })
+      .toString()
+      .trim();
+    if (out.length > 0) return true;
+  } catch {
+    /* lsof missing or path not in use */
+  }
+  return false;
 }
 
 /**

--- a/src/worktree/registry.ts
+++ b/src/worktree/registry.ts
@@ -1,0 +1,112 @@
+/**
+ * Registry: atomic read/write of ~/.switchroom/worktrees/<id>.json records.
+ *
+ * Each file is a single WorktreeRecord. One file per claim.
+ * We write to a temp file then rename (atomic on POSIX).
+ */
+
+import {
+  mkdirSync,
+  writeFileSync,
+  readFileSync,
+  readdirSync,
+  unlinkSync,
+  existsSync,
+  renameSync,
+} from "node:fs";
+import { join, resolve } from "node:path";
+import { homedir } from "node:os";
+import type { WorktreeRecord } from "./types.js";
+
+/** Base directory for all worktree registry records. */
+export function registryDir(): string {
+  return resolve(
+    process.env.SWITCHROOM_WORKTREE_DIR ?? join(homedir(), ".switchroom", "worktrees"),
+  );
+}
+
+/** Path to the registry record for a given claim id. */
+export function recordPath(id: string): string {
+  return join(registryDir(), `${id}.json`);
+}
+
+/** Ensure the registry directory exists. */
+function ensureDir(): void {
+  mkdirSync(registryDir(), { recursive: true });
+}
+
+/**
+ * Write a worktree record atomically.
+ * The record is written to a temp file and then renamed so that readers
+ * never see a half-written file.
+ */
+export function writeRecord(record: WorktreeRecord): void {
+  ensureDir();
+  const target = recordPath(record.id);
+  const tmp = `${target}.tmp${process.pid}`;
+  writeFileSync(tmp, JSON.stringify(record, null, 2) + "\n", { mode: 0o600 });
+  renameSync(tmp, target);
+}
+
+/**
+ * Read a single worktree record. Returns null if missing or unparseable.
+ */
+export function readRecord(id: string): WorktreeRecord | null {
+  const path = recordPath(id);
+  try {
+    const raw = readFileSync(path, "utf8");
+    return JSON.parse(raw) as WorktreeRecord;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Remove a worktree record file.
+ */
+export function deleteRecord(id: string): void {
+  const path = recordPath(id);
+  try {
+    unlinkSync(path);
+  } catch {
+    /* best-effort */
+  }
+}
+
+/**
+ * Enumerate all records in the registry.
+ */
+export function listRecords(): WorktreeRecord[] {
+  ensureDir();
+  const dir = registryDir();
+  const records: WorktreeRecord[] = [];
+  for (const entry of readdirSync(dir)) {
+    if (!entry.endsWith(".json")) continue;
+    const id = entry.slice(0, -5); // strip ".json"
+    const rec = readRecord(id);
+    if (rec) records.push(rec);
+  }
+  return records;
+}
+
+/**
+ * Update the heartbeat timestamp for a claim.
+ * No-op if the record doesn't exist.
+ */
+export function touchHeartbeat(id: string): void {
+  const rec = readRecord(id);
+  if (!rec) return;
+  writeRecord({ ...rec, heartbeatAt: new Date().toISOString() });
+}
+
+/**
+ * Count active records for a given repo path.
+ */
+export function countByRepo(repoPath: string): number {
+  return listRecords().filter(r => r.repo === repoPath).length;
+}
+
+/** Check if a record file exists */
+export function recordExists(id: string): boolean {
+  return existsSync(recordPath(id));
+}

--- a/src/worktree/release.ts
+++ b/src/worktree/release.ts
@@ -1,0 +1,48 @@
+/**
+ * release_worktree: tear down a claimed worktree.
+ *
+ * Best-effort cleanup:
+ *   1. Read the registry record.
+ *   2. Run `git worktree remove --force` on the path.
+ *   3. Delete the registry record.
+ *
+ * If any step fails, we continue and report `released: false`.
+ * The reaper will handle orphans on its next run.
+ */
+
+import { execFileSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { readRecord, deleteRecord } from "./registry.js";
+import type { ReleaseInput, ReleaseResult } from "./types.js";
+
+/**
+ * Release a claimed worktree by ID.
+ */
+export function releaseWorktree(input: ReleaseInput): ReleaseResult {
+  const { id } = input;
+  const record = readRecord(id);
+
+  if (!record) {
+    // Already gone — idempotent success
+    return { released: true };
+  }
+
+  let gitSuccess = true;
+  if (existsSync(record.path)) {
+    try {
+      execFileSync("git", ["worktree", "remove", "--force", record.path], {
+        cwd: record.repo,
+        stdio: "pipe",
+      });
+    } catch {
+      // git remove failed — path may have been deleted externally, or
+      // repo is gone. Don't block the record cleanup.
+      gitSuccess = false;
+    }
+  }
+
+  // Always delete the registry record
+  deleteRecord(id);
+
+  return { released: gitSuccess };
+}

--- a/src/worktree/types.ts
+++ b/src/worktree/types.ts
@@ -1,0 +1,64 @@
+/**
+ * Types for the switchroom-worktree subsystem.
+ *
+ * Registry records live at ~/.switchroom/worktrees/<id>.json.
+ * Each record describes a single active git worktree claim.
+ */
+
+export interface WorktreeRecord {
+  /** Unique claim ID (nanoid short) */
+  id: string;
+  /** Resolved absolute path to the source repo */
+  repo: string;
+  /** Logical name declared in code_repos (or the path itself if undeclared) */
+  repoName: string;
+  /** Auto-generated branch: task/<taskName>-<shortId> */
+  branch: string;
+  /** Absolute path of the worktree directory */
+  path: string;
+  /** ISO 8601 timestamp when the claim was created */
+  createdAt: string;
+  /** ISO 8601 timestamp of most recent heartbeat */
+  heartbeatAt: string;
+  /** Agent name that claimed this worktree (optional) */
+  ownerAgent?: string;
+}
+
+/** Input to claim_worktree */
+export interface ClaimInput {
+  /** Repo alias from code_repos, or an absolute path */
+  repo: string;
+  /** Human-readable suffix for the branch name */
+  taskName?: string;
+  /** Agent name requesting the claim */
+  ownerAgent?: string;
+}
+
+/** Output from claim_worktree */
+export interface ClaimResult {
+  id: string;
+  path: string;
+  branch: string;
+}
+
+/** Input to release_worktree */
+export interface ReleaseInput {
+  id: string;
+}
+
+/** Output from release_worktree */
+export interface ReleaseResult {
+  released: boolean;
+}
+
+/**
+ * A single code repo entry from switchroom.yaml agent config.
+ */
+export interface CodeRepoEntry {
+  /** Short alias used when claiming (e.g. "switchroom") */
+  name: string;
+  /** Absolute or home-relative path to the repo (e.g. ~/code/switchroom) */
+  source: string;
+  /** Max simultaneous worktrees for this repo (default 5) */
+  concurrency?: number;
+}

--- a/switchroom-worktree-mcp/package.json
+++ b/switchroom-worktree-mcp/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "switchroom-worktree-mcp",
+  "version": "0.1.0",
+  "description": "MCP server exposing git worktree isolation tools to Claude Code sub-agents",
+  "type": "module",
+  "bin": "./server.ts",
+  "scripts": {
+    "start": "bun install --no-summary && bun server.ts"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.0.0"
+  }
+}

--- a/switchroom-worktree-mcp/package.json
+++ b/switchroom-worktree-mcp/package.json
@@ -1,9 +1,9 @@
 {
   "name": "switchroom-worktree-mcp",
   "version": "0.1.0",
-  "description": "MCP server exposing git worktree isolation tools to Claude Code sub-agents",
+  "private": true,
+  "description": "MCP server exposing git worktree tools — IN-TREE ONLY: imports from ../src/worktree/ via the switchroom monorepo, not standalone-installable.",
   "type": "module",
-  "bin": "./server.ts",
   "scripts": {
     "start": "bun install --no-summary && bun server.ts"
   },

--- a/switchroom-worktree-mcp/server.ts
+++ b/switchroom-worktree-mcp/server.ts
@@ -1,0 +1,250 @@
+#!/usr/bin/env bun
+/**
+ * switchroom-worktree MCP Server
+ *
+ * Exposes three tools for parallel sub-agent code isolation via git worktrees:
+ *
+ *   claim_worktree  — reserve a fresh git worktree branch for a task
+ *   release_worktree — tear down a worktree when done
+ *   list_worktrees  — operator visibility into active claims
+ *
+ * Runs as a stdio MCP server. Add to an agent's settings.json mcpServers:
+ *
+ *   "switchroom-worktree": {
+ *     "command": "bun",
+ *     "args": ["<path>/switchroom-worktree-mcp/server.ts"],
+ *     "env": {
+ *       "SWITCHROOM_AGENT_NAME": "klanker",
+ *       "SWITCHROOM_CODE_REPOS": "[{\"name\":\"switchroom\",\"source\":\"~/code/switchroom\",\"concurrency\":5}]"
+ *     }
+ *   }
+ *
+ * The code_repos list is read from SWITCHROOM_CODE_REPOS (JSON-encoded array
+ * of { name, source, concurrency? } objects). When unset, any absolute path
+ * can be passed to claim_worktree directly.
+ *
+ * Registry lives at ~/.switchroom/worktrees/ (overridable via
+ * SWITCHROOM_WORKTREE_DIR). Worktree checkouts at
+ * ~/.switchroom/worktree-checkouts/ (overridable via SWITCHROOM_WORKTREE_BASE).
+ */
+
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import {
+  ListToolsRequestSchema,
+  CallToolRequestSchema,
+} from "@modelcontextprotocol/sdk/types.js";
+import { claimWorktree } from "../src/worktree/claim.js";
+import { releaseWorktree } from "../src/worktree/release.js";
+import { listWorktrees } from "../src/worktree/list.js";
+import { touchHeartbeat } from "../src/worktree/registry.js";
+import type { CodeRepoEntry } from "../src/worktree/types.js";
+
+// ─── Config ──────────────────────────────────────────────────────────────────
+
+const AGENT_NAME = process.env.SWITCHROOM_AGENT_NAME ?? undefined;
+
+function loadCodeRepos(): CodeRepoEntry[] | undefined {
+  const raw = process.env.SWITCHROOM_CODE_REPOS;
+  if (!raw) return undefined;
+  try {
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return undefined;
+    return parsed as CodeRepoEntry[];
+  } catch {
+    process.stderr.write(
+      `switchroom-worktree-mcp: failed to parse SWITCHROOM_CODE_REPOS: ${raw}\n`,
+    );
+    return undefined;
+  }
+}
+
+const CODE_REPOS = loadCodeRepos();
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function textResult(content: string) {
+  return { content: [{ type: "text" as const, text: content }] };
+}
+
+function jsonResult(data: unknown) {
+  return { content: [{ type: "text" as const, text: JSON.stringify(data, null, 2) }] };
+}
+
+// ─── Server ───────────────────────────────────────────────────────────────────
+
+const server = new Server(
+  { name: "switchroom-worktree", version: "0.1.0" },
+  { capabilities: { tools: {} } },
+);
+
+// ─── Tool definitions ─────────────────────────────────────────────────────────
+
+server.setRequestHandler(ListToolsRequestSchema, async () => ({
+  tools: [
+    {
+      name: "claim_worktree",
+      description:
+        "Reserve a fresh git worktree for a code task. Returns a unique id, " +
+        "the worktree path, and the auto-generated branch name. " +
+        "Pass the path to the sub-agent's working directory so it edits " +
+        "an isolated branch. Call release_worktree when the task is done, " +
+        "or let the reaper handle cleanup if you forget.",
+      inputSchema: {
+        type: "object" as const,
+        properties: {
+          repo: {
+            type: "string",
+            description:
+              "Repo alias from code_repos (e.g. 'switchroom') or an absolute path. " +
+              "Available aliases: " +
+              (CODE_REPOS?.map(r => r.name).join(", ") ?? "(none configured — use absolute path)"),
+          },
+          taskName: {
+            type: "string",
+            description:
+              "Human-readable suffix for the branch name (e.g. 'fix-login-bug'). " +
+              "Alphanumeric, hyphens, underscores only. The actual branch will be " +
+              "task/<taskName>-<shortId> to guarantee uniqueness.",
+          },
+        },
+        required: ["repo"],
+      },
+    },
+    {
+      name: "release_worktree",
+      description:
+        "Release a previously claimed worktree. Runs git worktree remove and " +
+        "cleans the registry record. Best-effort — if git fails, the record is " +
+        "still removed. The reaper will handle any remnants.",
+      inputSchema: {
+        type: "object" as const,
+        properties: {
+          id: {
+            type: "string",
+            description: "The worktree claim ID returned by claim_worktree.",
+          },
+        },
+        required: ["id"],
+      },
+    },
+    {
+      name: "list_worktrees",
+      description:
+        "List all active worktree claims. Useful for operator visibility and " +
+        "debugging. Shows id, repo, branch, path, age, and heartbeat recency " +
+        "for each active claim.",
+      inputSchema: {
+        type: "object" as const,
+        properties: {},
+      },
+    },
+    {
+      name: "heartbeat_worktree",
+      description:
+        "Update the heartbeat timestamp for a claimed worktree. Call every " +
+        "60 seconds while actively working in the worktree to prevent the " +
+        "reaper from reclaiming it. The reaper removes worktrees whose " +
+        "heartbeat is more than 10 minutes stale.",
+      inputSchema: {
+        type: "object" as const,
+        properties: {
+          id: {
+            type: "string",
+            description: "The worktree claim ID returned by claim_worktree.",
+          },
+        },
+        required: ["id"],
+      },
+    },
+  ],
+}));
+
+// ─── Tool handlers ────────────────────────────────────────────────────────────
+
+server.setRequestHandler(CallToolRequestSchema, async (request) => {
+  const { name, arguments: args } = request.params;
+
+  switch (name) {
+    case "claim_worktree": {
+      const { repo, taskName } = args as { repo: string; taskName?: string };
+      if (typeof repo !== "string" || repo.length === 0) {
+        return textResult("Error: 'repo' must be a non-empty string.");
+      }
+      try {
+        const result = await claimWorktree(
+          { repo, taskName, ownerAgent: AGENT_NAME },
+          CODE_REPOS,
+        );
+        return jsonResult({
+          id: result.id,
+          path: result.path,
+          branch: result.branch,
+          instructions:
+            `Worktree ready. Set this as the working directory for your sub-agent: ${result.path}. ` +
+            `Branch: ${result.branch}. ` +
+            `Call heartbeat_worktree({ id: "${result.id}" }) every 60s if the task is long-running. ` +
+            `Call release_worktree({ id: "${result.id}" }) when done.`,
+        });
+      } catch (err) {
+        return textResult(`Error: ${(err as Error).message}`);
+      }
+    }
+
+    case "release_worktree": {
+      const { id } = args as { id: string };
+      if (typeof id !== "string" || id.length === 0) {
+        return textResult("Error: 'id' must be a non-empty string.");
+      }
+      try {
+        const result = releaseWorktree({ id });
+        return jsonResult(result);
+      } catch (err) {
+        return textResult(`Error: ${(err as Error).message}`);
+      }
+    }
+
+    case "list_worktrees": {
+      try {
+        const result = listWorktrees();
+        return jsonResult(result);
+      } catch (err) {
+        return textResult(`Error: ${(err as Error).message}`);
+      }
+    }
+
+    case "heartbeat_worktree": {
+      const { id } = args as { id: string };
+      if (typeof id !== "string" || id.length === 0) {
+        return textResult("Error: 'id' must be a non-empty string.");
+      }
+      try {
+        touchHeartbeat(id);
+        return jsonResult({ id, updated: true, timestamp: new Date().toISOString() });
+      } catch (err) {
+        return textResult(`Error: ${(err as Error).message}`);
+      }
+    }
+
+    default:
+      return textResult(`Unknown tool: ${name}`);
+  }
+});
+
+// ─── Start ────────────────────────────────────────────────────────────────────
+
+async function main() {
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+  process.stderr.write("switchroom-worktree-mcp: server started\n");
+  if (CODE_REPOS) {
+    process.stderr.write(
+      `switchroom-worktree-mcp: code_repos loaded: ${CODE_REPOS.map(r => r.name).join(", ")}\n`,
+    );
+  }
+}
+
+main().catch((err) => {
+  process.stderr.write(`switchroom-worktree-mcp: fatal error: ${err}\n`);
+  process.exit(1);
+});

--- a/telegram-plugin/foreman/foreman.ts
+++ b/telegram-plugin/foreman/foreman.ts
@@ -26,6 +26,7 @@ import { Bot, InlineKeyboard, type Context } from 'grammy'
 import { readFileSync, chmodSync } from 'fs'
 import { homedir } from 'os'
 import { join } from 'path'
+import { listWorktrees } from '../../src/worktree/list.js'
 import { installPluginLogger } from '../plugin-logger.js'
 import {
   escapeHtmlForTg,
@@ -340,6 +341,29 @@ bot.command('version', async ctx => {
   }
 })
 
+// ─── /worktrees ───────────────────────────────────────────────────────────
+bot.command('worktrees', async ctx => {
+  try {
+    const { worktrees } = listWorktrees()
+    if (worktrees.length === 0) {
+      await switchroomReply(ctx, 'No active worktrees.', { html: false })
+      return
+    }
+    const lines = ['<b>Active worktrees</b>', '']
+    for (const w of worktrees) {
+      const ageMin = Math.floor(w.ageSeconds / 60)
+      const hbMin = Math.floor(w.heartbeatAgeSeconds / 60)
+      const owner = w.ownerAgent ? ` (${escapeHtmlForTg(w.ownerAgent)})` : ''
+      lines.push(
+        `• <code>${escapeHtmlForTg(w.repoName)}</code>${owner} — branch <code>${escapeHtmlForTg(w.branch)}</code>, age ${ageMin}m, hb ${hbMin}m`,
+      )
+    }
+    await switchroomReply(ctx, lines.join('\n'), { html: true })
+  } catch (err) {
+    await switchroomReply(ctx, `<b>worktrees failed:</b> ${escapeHtmlForTg((err as Error).message)}`, { html: true })
+  }
+})
+
 // ─── /create-agent ────────────────────────────────────────────────────────
 
 bot.command('create_agent', async ctx => {
@@ -621,6 +645,7 @@ void runPollingLoop(bot, {
         { command: 'delete', description: 'Delete agent (with confirm): /delete <agent>' },
         { command: 'update', description: 'Update switchroom' },
         { command: 'version', description: 'Show versions + running agent health' },
+        { command: 'worktrees', description: 'List active git worktrees claimed by sub-agents' },
         { command: 'create_agent', description: 'Create new agent: /create-agent [name]' },
       ])
     } catch (err) {

--- a/tests/worktree.claim-integration.test.ts
+++ b/tests/worktree.claim-integration.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Integration tests for claim/release/list.
+ *
+ * Uses a temp git repo fixture (git init in tmpdir) to avoid touching
+ * the actual switchroom repo. Tests 3 parallel claims, verify each
+ * gets a unique worktree + branch, no conflicts.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { execFileSync } from "node:child_process";
+import { claimWorktree } from "../src/worktree/claim.js";
+import { releaseWorktree } from "../src/worktree/release.js";
+import { listWorktrees } from "../src/worktree/list.js";
+import { listRecords } from "../src/worktree/registry.js";
+
+function initTempRepo(): string {
+  const dir = mkdtempSync(join(tmpdir(), "sw-repo-"));
+  execFileSync("git", ["init"], { cwd: dir, stdio: "pipe" });
+  execFileSync("git", ["config", "user.email", "test@test.com"], { cwd: dir, stdio: "pipe" });
+  execFileSync("git", ["config", "user.name", "Test"], { cwd: dir, stdio: "pipe" });
+  // Need at least one commit so worktrees can branch off HEAD
+  execFileSync("bash", ["-c", "echo 'init' > README.md"], { cwd: dir, stdio: "pipe" });
+  execFileSync("git", ["add", "."], { cwd: dir, stdio: "pipe" });
+  execFileSync("git", ["commit", "-m", "init"], { cwd: dir, stdio: "pipe" });
+  return dir;
+}
+
+describe("claim / release / list integration", () => {
+  let repoDir: string;
+  let regDir: string;
+  let checkoutsDir: string;
+  const origReg = process.env.SWITCHROOM_WORKTREE_DIR;
+  const origBase = process.env.SWITCHROOM_WORKTREE_BASE;
+
+  beforeEach(() => {
+    repoDir = initTempRepo();
+    const base = mkdtempSync(join(tmpdir(), "sw-int-test-"));
+    regDir = join(base, "registry");
+    checkoutsDir = join(base, "checkouts");
+    mkdirSync(regDir, { recursive: true });
+    mkdirSync(checkoutsDir, { recursive: true });
+    process.env.SWITCHROOM_WORKTREE_DIR = regDir;
+    process.env.SWITCHROOM_WORKTREE_BASE = checkoutsDir;
+  });
+
+  afterEach(() => {
+    // Release all remaining worktrees (if any) before deleting dirs
+    for (const rec of listRecords()) {
+      try { releaseWorktree({ id: rec.id }); } catch { /* best-effort */ }
+    }
+    rmSync(repoDir, { recursive: true, force: true });
+    // The checkouts parent
+    try { rmSync(join(checkoutsDir, ".."), { recursive: true, force: true }); } catch { /* */ }
+    if (origReg === undefined) delete process.env.SWITCHROOM_WORKTREE_DIR;
+    else process.env.SWITCHROOM_WORKTREE_DIR = origReg;
+    if (origBase === undefined) delete process.env.SWITCHROOM_WORKTREE_BASE;
+    else process.env.SWITCHROOM_WORKTREE_BASE = origBase;
+  });
+
+  it("claim returns id, path, and branch", async () => {
+    const result = await claimWorktree({ repo: repoDir, taskName: "my-feature" });
+    expect(result.id).toBeTruthy();
+    expect(result.path).toContain(checkoutsDir);
+    expect(result.branch).toMatch(/^task\/my-feature-/);
+  });
+
+  it("3 parallel claims get unique ids, paths, and branches", async () => {
+    const [r1, r2, r3] = await Promise.all([
+      claimWorktree({ repo: repoDir, taskName: "feat" }),
+      claimWorktree({ repo: repoDir, taskName: "feat" }),
+      claimWorktree({ repo: repoDir, taskName: "feat" }),
+    ]);
+
+    // All IDs must be unique
+    const ids = [r1.id, r2.id, r3.id];
+    expect(new Set(ids).size).toBe(3);
+
+    // All paths must be unique
+    const paths = [r1.path, r2.path, r3.path];
+    expect(new Set(paths).size).toBe(3);
+
+    // All branches must be unique
+    const branches = [r1.branch, r2.branch, r3.branch];
+    expect(new Set(branches).size).toBe(3);
+
+    // All branches follow the pattern
+    for (const b of branches) {
+      expect(b).toMatch(/^task\/feat-[a-f0-9]+$/);
+    }
+
+    // Registry should have 3 records
+    const recs = listRecords();
+    expect(recs).toHaveLength(3);
+  });
+
+  it("list_worktrees shows all active claims", async () => {
+    await claimWorktree({ repo: repoDir, taskName: "task-a", ownerAgent: "worker1" });
+    await claimWorktree({ repo: repoDir, taskName: "task-b", ownerAgent: "worker2" });
+
+    const { worktrees } = listWorktrees();
+    expect(worktrees).toHaveLength(2);
+    const owners = worktrees.map(w => w.ownerAgent);
+    expect(owners).toContain("worker1");
+    expect(owners).toContain("worker2");
+  });
+
+  it("release removes the worktree and registry record", async () => {
+    const claim = await claimWorktree({ repo: repoDir, taskName: "release-test" });
+    expect(listRecords()).toHaveLength(1);
+
+    const result = releaseWorktree({ id: claim.id });
+    expect(result.released).toBe(true);
+    expect(listRecords()).toHaveLength(0);
+  });
+
+  it("release is idempotent — releasing a missing id returns released:true", () => {
+    const result = releaseWorktree({ id: "nonexistent-id" });
+    expect(result.released).toBe(true);
+  });
+
+  it("respects concurrency cap", async () => {
+    // Use codeRepos with concurrency 2
+    const codeRepos = [{ name: "testrepo", source: repoDir, concurrency: 2 }];
+
+    await claimWorktree({ repo: "testrepo" }, codeRepos);
+    await claimWorktree({ repo: "testrepo" }, codeRepos);
+
+    await expect(
+      claimWorktree({ repo: "testrepo" }, codeRepos),
+    ).rejects.toThrow(/concurrency cap/i);
+  });
+
+  it("resolves repo from code_repos alias", async () => {
+    const codeRepos = [{ name: "myrepo", source: repoDir }];
+    const result = await claimWorktree({ repo: "myrepo" }, codeRepos);
+    expect(result.id).toBeTruthy();
+    // The stored record should have the resolved absolute path
+    const recs = listRecords();
+    expect(recs[0].repo).toBe(repoDir);
+    expect(recs[0].repoName).toBe("myrepo");
+  });
+
+  it("rejects unknown repo alias", async () => {
+    await expect(
+      claimWorktree({ repo: "unknown-alias" }),
+    ).rejects.toThrow(/not declared/i);
+  });
+});

--- a/tests/worktree.reaper.test.ts
+++ b/tests/worktree.reaper.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Tests for the worktree reaper.
+ *
+ * IMPORTANT: We do NOT use real git worktrees here. We simulate the
+ * filesystem state so that the reaper's existsSync checks do the right thing.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { writeRecord, readRecord, listRecords } from "../src/worktree/registry.js";
+import { runReaper, STALE_THRESHOLD_MS } from "../src/worktree/reaper.js";
+import type { WorktreeRecord } from "../src/worktree/types.js";
+
+describe("worktree reaper", () => {
+  let tmpDir: string;
+  let checkoutsDir: string;
+  const origEnv = process.env.SWITCHROOM_WORKTREE_DIR;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "sw-reaper-test-"));
+    checkoutsDir = join(tmpDir, "checkouts");
+    mkdirSync(checkoutsDir, { recursive: true });
+    process.env.SWITCHROOM_WORKTREE_DIR = tmpDir;
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+    if (origEnv === undefined) delete process.env.SWITCHROOM_WORKTREE_DIR;
+    else process.env.SWITCHROOM_WORKTREE_DIR = origEnv;
+  });
+
+  function makeRecord(
+    id: string,
+    heartbeatAgoMs: number,
+    worktreePathExists: boolean,
+  ): WorktreeRecord {
+    const now = Date.now();
+    const heartbeatAt = new Date(now - heartbeatAgoMs).toISOString();
+    const path = join(checkoutsDir, id);
+    if (worktreePathExists) {
+      mkdirSync(path, { recursive: true });
+    }
+    return {
+      id,
+      repo: "/fake/repo",
+      repoName: "fake",
+      branch: `task/test-${id}`,
+      path,
+      createdAt: new Date(now - heartbeatAgoMs).toISOString(),
+      heartbeatAt,
+    };
+  }
+
+  it("reaps a record whose path doesn't exist (orphan)", () => {
+    const rec = makeRecord("orphan01", 0, false);
+    writeRecord(rec);
+    expect(listRecords()).toHaveLength(1);
+
+    const result = runReaper();
+
+    expect(result.reaped).toContain("orphan01");
+    expect(listRecords()).toHaveLength(0);
+  });
+
+  it("does NOT reap a record with fresh heartbeat even if path exists", () => {
+    const rec = makeRecord("fresh01", 60_000, true); // 1 min ago — fresh
+    writeRecord(rec);
+
+    const result = runReaper();
+
+    expect(result.reaped).not.toContain("fresh01");
+    expect(listRecords()).toHaveLength(1);
+  });
+
+  it("reaps a record with stale heartbeat (path exists, no fuser)", () => {
+    // Heartbeat is 11 minutes ago — over the 10-min threshold
+    const staleAge = STALE_THRESHOLD_MS + 60_000;
+    const rec = makeRecord("stale01", staleAge, true);
+    writeRecord(rec);
+
+    // The reaper will try `git worktree remove --force` which will fail
+    // on a fake path, but it should still delete the registry record.
+    // It also tries `fuser` which will return false for our tmp dir.
+    const result = runReaper();
+
+    expect(result.reaped).toContain("stale01");
+    expect(listRecords()).toHaveLength(0);
+  });
+
+  it("leaves fresh records intact while reaping stale ones", () => {
+    const staleAge = STALE_THRESHOLD_MS + 60_000;
+    const fresh = makeRecord("keepme", 60_000, true);
+    const stale = makeRecord("reaped", staleAge, true);
+    writeRecord(fresh);
+    writeRecord(stale);
+
+    const result = runReaper();
+
+    expect(result.reaped).toContain("reaped");
+    expect(result.reaped).not.toContain("keepme");
+    const remaining = listRecords();
+    expect(remaining.map(r => r.id)).toContain("keepme");
+    expect(remaining.map(r => r.id)).not.toContain("reaped");
+  });
+
+  it("reaper is idempotent — double-run on empty registry is safe", () => {
+    const r1 = runReaper();
+    const r2 = runReaper();
+    expect(r1.reaped).toHaveLength(0);
+    expect(r2.reaped).toHaveLength(0);
+  });
+
+  it("reaper with multiple orphans reaps all of them", () => {
+    writeRecord(makeRecord("orphan-a", 0, false));
+    writeRecord(makeRecord("orphan-b", 0, false));
+    writeRecord(makeRecord("orphan-c", 0, false));
+
+    const result = runReaper();
+
+    expect(result.reaped.sort()).toEqual(["orphan-a", "orphan-b", "orphan-c"]);
+    expect(listRecords()).toHaveLength(0);
+  });
+});

--- a/tests/worktree.registry.test.ts
+++ b/tests/worktree.registry.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Unit tests for worktree registry (read/write/delete/list).
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  writeRecord,
+  readRecord,
+  deleteRecord,
+  listRecords,
+  touchHeartbeat,
+  countByRepo,
+  recordExists,
+} from "../src/worktree/registry.js";
+import type { WorktreeRecord } from "../src/worktree/types.js";
+
+function makeRecord(overrides: Partial<WorktreeRecord> = {}): WorktreeRecord {
+  return {
+    id: "abc12345",
+    repo: "/home/user/code/myrepo",
+    repoName: "myrepo",
+    branch: "task/feature-abc12345",
+    path: "/home/user/.switchroom/worktree-checkouts/abc12345-feature",
+    createdAt: new Date().toISOString(),
+    heartbeatAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+describe("worktree registry", () => {
+  let tmpDir: string;
+  const origEnv = process.env.SWITCHROOM_WORKTREE_DIR;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "sw-reg-test-"));
+    process.env.SWITCHROOM_WORKTREE_DIR = tmpDir;
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+    if (origEnv === undefined) delete process.env.SWITCHROOM_WORKTREE_DIR;
+    else process.env.SWITCHROOM_WORKTREE_DIR = origEnv;
+  });
+
+  it("writes and reads back a record", () => {
+    const rec = makeRecord();
+    writeRecord(rec);
+    const back = readRecord(rec.id);
+    expect(back).not.toBeNull();
+    expect(back?.id).toBe(rec.id);
+    expect(back?.branch).toBe(rec.branch);
+    expect(back?.repoName).toBe(rec.repoName);
+  });
+
+  it("returns null for a missing record", () => {
+    expect(readRecord("nonexistent")).toBeNull();
+  });
+
+  it("recordExists returns correct boolean", () => {
+    const rec = makeRecord({ id: "exist001" });
+    expect(recordExists(rec.id)).toBe(false);
+    writeRecord(rec);
+    expect(recordExists(rec.id)).toBe(true);
+  });
+
+  it("deletes a record", () => {
+    const rec = makeRecord({ id: "del001" });
+    writeRecord(rec);
+    expect(recordExists(rec.id)).toBe(true);
+    deleteRecord(rec.id);
+    expect(recordExists(rec.id)).toBe(false);
+    expect(readRecord(rec.id)).toBeNull();
+  });
+
+  it("lists all records", () => {
+    const r1 = makeRecord({ id: "list001" });
+    const r2 = makeRecord({ id: "list002" });
+    writeRecord(r1);
+    writeRecord(r2);
+    const all = listRecords();
+    const ids = all.map(r => r.id);
+    expect(ids).toContain("list001");
+    expect(ids).toContain("list002");
+  });
+
+  it("lists empty when no records", () => {
+    expect(listRecords()).toHaveLength(0);
+  });
+
+  it("touches heartbeat updates heartbeatAt", async () => {
+    const pastIso = new Date(Date.now() - 30_000).toISOString();
+    const rec = makeRecord({ id: "hb001", heartbeatAt: pastIso });
+    writeRecord(rec);
+    const before = new Date(readRecord("hb001")!.heartbeatAt).getTime();
+    // Brief delay to ensure time difference
+    await new Promise(r => setTimeout(r, 10));
+    touchHeartbeat("hb001");
+    const after = new Date(readRecord("hb001")!.heartbeatAt).getTime();
+    expect(after).toBeGreaterThan(before);
+  });
+
+  it("touchHeartbeat is no-op for missing id", () => {
+    expect(() => touchHeartbeat("missing999")).not.toThrow();
+  });
+
+  it("countByRepo counts correctly", () => {
+    writeRecord(makeRecord({ id: "c1", repo: "/repo/a" }));
+    writeRecord(makeRecord({ id: "c2", repo: "/repo/a" }));
+    writeRecord(makeRecord({ id: "c3", repo: "/repo/b" }));
+    expect(countByRepo("/repo/a")).toBe(2);
+    expect(countByRepo("/repo/b")).toBe(1);
+    expect(countByRepo("/repo/c")).toBe(0);
+  });
+});

--- a/tests/worktree.schema.test.ts
+++ b/tests/worktree.schema.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Tests for the code_repos schema extension in switchroom.yaml.
+ */
+
+import { describe, it, expect } from "vitest";
+import { SwitchroomConfigSchema, CodeRepoEntrySchema } from "../src/config/schema.js";
+
+describe("CodeRepoEntrySchema", () => {
+  it("accepts a minimal entry with name and source", () => {
+    const entry = CodeRepoEntrySchema.parse({
+      name: "switchroom",
+      source: "~/code/switchroom",
+    });
+    expect(entry.name).toBe("switchroom");
+    expect(entry.source).toBe("~/code/switchroom");
+    expect(entry.concurrency).toBeUndefined();
+  });
+
+  it("accepts entry with explicit concurrency", () => {
+    const entry = CodeRepoEntrySchema.parse({
+      name: "myrepo",
+      source: "/home/user/repos/myrepo",
+      concurrency: 3,
+    });
+    expect(entry.concurrency).toBe(3);
+  });
+
+  it("rejects concurrency of 0", () => {
+    expect(() =>
+      CodeRepoEntrySchema.parse({ name: "r", source: "/r", concurrency: 0 }),
+    ).toThrow();
+  });
+
+  it("rejects negative concurrency", () => {
+    expect(() =>
+      CodeRepoEntrySchema.parse({ name: "r", source: "/r", concurrency: -1 }),
+    ).toThrow();
+  });
+});
+
+describe("SwitchroomConfigSchema — code_repos", () => {
+  const baseConfig = {
+    switchroom: { version: 1 as const },
+    telegram: { bot_token: "123:ABC", forum_chat_id: "-100123" },
+    agents: {
+      klanker: {
+        topic_name: "Klanker",
+      },
+    },
+  };
+
+  it("parses agent with code_repos list", () => {
+    const config = SwitchroomConfigSchema.parse({
+      ...baseConfig,
+      agents: {
+        klanker: {
+          topic_name: "Klanker",
+          code_repos: [
+            { name: "switchroom", source: "~/code/switchroom", concurrency: 5 },
+          ],
+        },
+      },
+    });
+    const repos = config.agents["klanker"].code_repos;
+    expect(repos).toHaveLength(1);
+    expect(repos?.[0].name).toBe("switchroom");
+    expect(repos?.[0].concurrency).toBe(5);
+  });
+
+  it("parses agent without code_repos (omitted = undefined)", () => {
+    const config = SwitchroomConfigSchema.parse(baseConfig);
+    expect(config.agents["klanker"].code_repos).toBeUndefined();
+  });
+
+  it("accepts multiple repos for an agent", () => {
+    const config = SwitchroomConfigSchema.parse({
+      ...baseConfig,
+      agents: {
+        klanker: {
+          topic_name: "Klanker",
+          code_repos: [
+            { name: "switchroom", source: "~/code/switchroom" },
+            { name: "myapp", source: "/home/user/myapp", concurrency: 2 },
+          ],
+        },
+      },
+    });
+    expect(config.agents["klanker"].code_repos).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #74. Per-agent code-isolation primitive that lets switchroom sub-agents work on the same git repo in parallel without stomping on each other's working tree. The fix to a class of bug that bit the user twice in two days (overnight worker stomping; clerk going mute when restart paths overlap).

## Why

Claude Code's built-in \`isolation: \"worktree\"\` flag for sub-agents requires the parent's CWD to be in a git repo, which switchroom agent workspace dirs aren't. So \`isolation\` doesn't work for switchroom agents — and parallel sub-agents stomp each other when editing the same code repo.

After a council of 8 sub-agents (3 reviews of an initial proposal, 3 alternative designs, 2 prior-art studies — see #74), the consensus was: build the worktree primitive switchroom-side, with six specific hardenings. This PR delivers that.

## What's implemented

**One core, three surfaces:**
- \`src/worktree/\` — claim, release, list, reaper, registry, types
- \`src/cli/worktree.ts\` — \`switchroom worktree claim|release|list\` for humans/scripts/cron
- \`switchroom-worktree-mcp/\` — typed MCP tools for agents (\`claim_worktree\`, \`release_worktree\`, \`list_worktrees\`)
- \`telegram-plugin/foreman/foreman.ts\` — \`/worktrees\` command for operator visibility

**The six review-converged hardenings, all baked in:**

1. **Liveness-based reaper** — heartbeat file per worktree, reaper kills only when heartbeat is stale AND no process holds the path. Never reap based on age alone (long-running tasks would die otherwise).
2. **Atomic claim record** — registry record at \`~/.switchroom/worktrees/<id>.json\` written before \`git worktree add\`, so a crash mid-claim doesn't leave an orphaned worktree.
3. **Auto-unique branch per claim** — caller passes \`taskName\`, we generate \`task/<taskName>-<short-id>\`. No same-branch collisions.
4. **Per-repo concurrency cap** — default 5, configurable via \`code_repos[].concurrency\` in switchroom.yaml.
5. **\`list_worktrees\`** — admin tool exposing owner, branch, age, last-heartbeat for operator visibility.
6. **Foreman \`/worktrees\`** — Telegram surface for discoverability.

**switchroom.yaml schema (optional):**

\`\`\`yaml
agents:
  klanker:
    code_repos:
      - { name: switchroom, source: ~/code/switchroom, concurrency: 5 }
\`\`\`

Declared repos get short aliases. Undeclared paths can still be claimed by absolute path.

## Test plan

- [x] \`bunx vitest run tests/worktree\` — 30 new tests passing (claim integration, reaper, registry, schema)
- [x] \`bunx vitest run\` (full) — 2945 passed (gained 32 over baseline). 7 pre-existing failures unchanged (cron-auth + tmux-dependent auth test, both unrelated).
- [ ] **Manual** (deferred — would require live agents): dispatch 3 parallel workers in production, verify each gets a distinct worktree and all 3 PRs land cleanly.

## Deferred to follow-ups

- **\`switchroom-code-task\` skill** — the spec called for one for protocol/discoverability; the MCP tools' typed schemas already give discoverability via Claude's tool list, so a skill is ergonomic polish, not blocking.
- **Reaper systemd timer** — code is in place; the systemd unit installation can be a separate small PR (similar pattern to the existing scheduled-task timers).

## Files changed

- New core: \`src/worktree/{claim,release,list,reaper,registry,types,index}.ts\`
- New CLI: \`src/cli/worktree.ts\` + registration in \`src/cli/index.ts\`
- New MCP: \`switchroom-worktree-mcp/{server.ts,package.json}\`
- New tests: 4 files, 30 tests
- Schema: \`src/config/schema.ts\` adds \`code_repos\`
- Foreman: \`telegram-plugin/foreman/foreman.ts\` adds \`/worktrees\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)