### PR TITLE
fix(cron): always inject OAuth, never inherit ANTHROPIC_API_KEY

### DIFF
--- a/src/agents/cron-auth.test.ts
+++ b/src/agents/cron-auth.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Tests for cron-script authentication. Switchroom's whole thesis is OAuth
+ * subscription quota, NOT API-key billing. Every generated cron script must:
+ *   1. unset ANTHROPIC_API_KEY (defense against ambient env pollution),
+ *   2. point claude CLI at the agent's own .claude/ via CLAUDE_CONFIG_DIR,
+ *   3. inject CLAUDE_CODE_OAUTH_TOKEN from the agent's .oauth-token,
+ *   4. never contain a literal API-key pattern (sk-ant-...).
+ *
+ * Regression: a prior build emitted Environment=ANTHROPIC_API_KEY=... into
+ * agent cron systemd units (resolved from a vault: ref in switchroom.yaml),
+ * silently shifting cron auth from OAuth to the API. The fix moved auth
+ * setup into the .sh template so it's deterministic and inspectable.
+ */
+
+import { describe, expect, it } from "vitest";
+import { buildCronScript } from "./scaffold.js";
+
+const SAMPLE_AGENT_DIR = "/home/test/.switchroom/agents/sample";
+const SAMPLE_PROMPT = "Send a brief.";
+const SAMPLE_MODEL = "claude-sonnet-4-6";
+const SAMPLE_CHAT = "1234567";
+
+describe("buildCronScript: OAuth-only auth", () => {
+  it("unsets ANTHROPIC_API_KEY before invoking claude", () => {
+    const script = buildCronScript(
+      SAMPLE_AGENT_DIR, SAMPLE_PROMPT, SAMPLE_MODEL, SAMPLE_CHAT, undefined,
+    );
+    const unsetIdx = script.indexOf("unset ANTHROPIC_API_KEY");
+    const claudeIdx = script.indexOf("OUTPUT=$(claude -p");
+    expect(unsetIdx).toBeGreaterThan(-1);
+    expect(claudeIdx).toBeGreaterThan(-1);
+    expect(unsetIdx).toBeLessThan(claudeIdx);
+  });
+
+  it("points CLAUDE_CONFIG_DIR at the agent's own .claude directory", () => {
+    const script = buildCronScript(
+      SAMPLE_AGENT_DIR, SAMPLE_PROMPT, SAMPLE_MODEL, SAMPLE_CHAT, undefined,
+    );
+    expect(script).toContain(`export CLAUDE_CONFIG_DIR='${SAMPLE_AGENT_DIR}/.claude'`);
+  });
+
+  it("injects CLAUDE_CODE_OAUTH_TOKEN from .oauth-token when present", () => {
+    const script = buildCronScript(
+      SAMPLE_AGENT_DIR, SAMPLE_PROMPT, SAMPLE_MODEL, SAMPLE_CHAT, undefined,
+    );
+    expect(script).toMatch(/unset CLAUDE_CODE_OAUTH_TOKEN/);
+    expect(script).toMatch(/if \[ -f "\$CLAUDE_CONFIG_DIR\/\.oauth-token" \]/);
+    expect(script).toMatch(/export CLAUDE_CODE_OAUTH_TOKEN="\$\(/);
+  });
+
+  it("never embeds a literal API-key pattern", () => {
+    const script = buildCronScript(
+      SAMPLE_AGENT_DIR, "Prompt that mentions sk-ant-api03-foo as text.",
+      SAMPLE_MODEL, SAMPLE_CHAT, undefined,
+    );
+    // The prompt is single-quoted shell, so even if user text contains
+    // sk-ant-* it must be inside the prompt body, not as bare env. We assert
+    // that no `Environment=ANTHROPIC_API_KEY=...` or `export ANTHROPIC_API_KEY=`
+    // line is present anywhere in the generated script.
+    expect(script).not.toMatch(/^export ANTHROPIC_API_KEY=/m);
+    expect(script).not.toMatch(/^Environment=ANTHROPIC_API_KEY=/m);
+  });
+
+  it("uses --no-session-persistence and the configured model", () => {
+    const script = buildCronScript(
+      SAMPLE_AGENT_DIR, SAMPLE_PROMPT, "claude-haiku-4-5-20251001", SAMPLE_CHAT, undefined,
+    );
+    expect(script).toContain("--no-session-persistence");
+    expect(script).toContain("--model 'claude-haiku-4-5-20251001'");
+  });
+
+  it("auth setup happens after cd into agent dir, before claude invocation", () => {
+    const script = buildCronScript(
+      SAMPLE_AGENT_DIR, SAMPLE_PROMPT, SAMPLE_MODEL, SAMPLE_CHAT, undefined,
+    );
+    const cdIdx = script.indexOf(`cd '${SAMPLE_AGENT_DIR}'`);
+    const oauthIdx = script.indexOf("export CLAUDE_CODE_OAUTH_TOKEN");
+    const claudeIdx = script.indexOf("OUTPUT=$(claude -p");
+    expect(cdIdx).toBeGreaterThan(-1);
+    expect(cdIdx).toBeLessThan(oauthIdx);
+    expect(oauthIdx).toBeLessThan(claudeIdx);
+  });
+});

--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -1129,7 +1129,7 @@ function parseDurationToSeconds(d: string | undefined): number | undefined {
  * The script is self-contained — sources nvm, reads bot token from
  * .env at runtime, and uses POSIX quoting for the prompt.
  */
-function buildCronScript(
+export function buildCronScript(
   agentDir: string,
   prompt: string,
   model: string,
@@ -1146,6 +1146,19 @@ export NVM_DIR="$HOME/.nvm"
 export PATH="$HOME/.bun/bin:$PATH"
 
 cd ${shellSingleQuote(agentDir)}
+
+# Auth: always OAuth, never API key.
+# Defensively unset ANTHROPIC_API_KEY so any ambient env or systemd
+# Environment= mapping cannot silently shift cron auth from OAuth
+# subscription quota to API billing.
+unset ANTHROPIC_API_KEY
+export CLAUDE_CONFIG_DIR=${shellSingleQuote(agentDir + "/.claude")}
+
+# Inject OAuth token from the agent's own .oauth-token file.
+unset CLAUDE_CODE_OAUTH_TOKEN
+if [ -f "$CLAUDE_CONFIG_DIR/.oauth-token" ]; then
+  export CLAUDE_CODE_OAUTH_TOKEN="$(cat "$CLAUDE_CONFIG_DIR/.oauth-token" | tr -d '[:space:]')"
+fi
 
 # Run Claude one-shot (no persistent session, cheap model)
 OUTPUT=$(claude -p ${shellSingleQuote(prompt)} \\


### PR DESCRIPTION
## Summary
- Patches `buildCronScript` template so every generated cron script unsets `ANTHROPIC_API_KEY`, sets `CLAUDE_CONFIG_DIR` to the agent's own `.claude/`, and injects `CLAUDE_CODE_OAUTH_TOKEN` from `.oauth-token`.
- Adds `cron-auth.test.ts` (6 tests, all green) asserting no generated cron embeds an API key and that OAuth injection is always present — permanent regression guard.

## Why
A per-agent `env: { ANTHROPIC_API_KEY: "vault:..." }` mapping in `switchroom.yaml` was silently baking the API key into cron systemd units, shifting auth from OAuth subscription quota to API billing. That defeats switchroom's whole thesis. Removing the API key exposed a second issue: the cron template never injected OAuth — it relied on default credential discovery, which is flaky across cwd / global-`.claude/` / stale `.credentials.json` shadowing.

## Test plan
- [x] `bun run test src/agents/cron-auth.test.ts` — 6 green
- [x] `bun run build` — clean
- [x] Manual verification on real agent (gymbro): regenerated 6 cron scripts, fired cron-0 via systemctl, exit 0, OAuth handshake confirmed
- [ ] CI green on canonical