### PR TITLE
hotfix(gateway): make subagent-watcher opt-in via env var (re #64)

### DIFF
--- a/src/build-info.ts
+++ b/src/build-info.ts
@@ -2,8 +2,8 @@
 // Tracked in git so `tsc --noEmit` works on a fresh clone before `npm run build`.
 // Values are refreshed every time `npm run build` runs.
 
-export const VERSION: string = "0.2.5";
-export const COMMIT_SHA: string | null = "635e492";
-export const COMMIT_DATE: string | null = "2026-04-25T00:31:38+10:00";
-export const LATEST_PR: number | null = null;
-export const COMMITS_AHEAD_OF_TAG: number | null = 13;
+export const VERSION: string = "0.3.0";
+export const COMMIT_SHA: string | null = "8a4039f";
+export const COMMIT_DATE: string | null = "2026-04-26T07:58:40+10:00";
+export const LATEST_PR: number | null = 79;
+export const COMMITS_AHEAD_OF_TAG: number | null = 10;

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -5002,7 +5002,14 @@ void (async () => {
         // and surfaces live activity to Telegram via a pinned card +
         // inline notifications. Only started when a valid agentDir is known
         // (gate on streamMode=checklist for progress-card parity).
-        if (streamMode === 'checklist') {
+        //
+        // OPT-IN: gated on SWITCHROOM_SUBAGENT_WATCHER=1 because the
+        // current implementation re-fires "Worker dispatched" notifications
+        // for pre-existing JSONL files at startup (issue: watcher treats
+        // historical sessions as new dispatches). Default OFF until the
+        // skip-pre-existing-files fix lands. See switchroom#82.
+        const subagentWatcherEnabled = process.env.SWITCHROOM_SUBAGENT_WATCHER === '1'
+        if (subagentWatcherEnabled && streamMode === 'checklist') {
           const watcherAgentDir = resolveAgentDirFromEnv()
           if (watcherAgentDir != null) {
             // Pinned worker card: one message per watcher session,


### PR DESCRIPTION
Re-fires 'Worker dispatched' notifications for pre-existing JSONL files at startup. Tonight's clerk restart flooded the chat with 11+ messages. Hotfix: opt-in via SWITCHROOM_SUBAGENT_WATCHER=1. Default OFF until skip-pre-existing-files fix lands. Filing follow-up for the real fix.