### PR TITLE
fix(subagent-watcher): escape HTML in worker-card last-activity age (closes #86)

### DIFF
--- a/telegram-plugin/subagent-watcher.ts
+++ b/telegram-plugin/subagent-watcher.ts
@@ -164,7 +164,7 @@ export function renderWorkerCard(
 
   const lines: string[] = [`\u{1F6E0} <b>Background workers (${active.length})</b>`]
   for (const w of active) {
-    const ago = formatDuration(now - w.lastActivityAt)
+    const ago = escapeHtml(formatDuration(now - w.lastActivityAt))
     const desc = escapeHtml(truncate(w.description || 'sub-agent', 60))
     lines.push(`\u{1F527} ${desc} · running · last activity ${ago} ago · ${w.toolCount} tools`)
   }

--- a/telegram-plugin/tests/subagent-watcher.test.ts
+++ b/telegram-plugin/tests/subagent-watcher.test.ts
@@ -113,6 +113,20 @@ describe('renderWorkerCard', () => {
     const html = renderWorkerCard(registry, 31_000)
     expect(html).toContain('30s ago')
   })
+
+  it('escapes HTML in sub-second age (<1s)', () => {
+    // formatDuration returns the literal string "<1s" when ms < 1000.
+    // If left unescaped, Telegram parses the leading "<" as the start
+    // of an HTML tag and rejects the message with
+    // "can't parse entities: Unsupported start tag '1s'". Ensure the
+    // rendered card escapes the angle bracket so the card actually sends.
+    const registry = new Map<string, WorkerEntry>([
+      ['a', makeEntry({ description: 'sub-agent', lastActivityAt: 999 })],
+    ])
+    const html = renderWorkerCard(registry, 1000) // 1ms idle → "<1s"
+    expect(html).not.toContain('<1s')
+    expect(html).toContain('&lt;1s')
+  })
 })
 
 // ─── startSubagentWatcher harness ────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- `formatDuration` returns the literal string `<1s` when ms < 1000
- `renderWorkerCard` dropped that into the HTML template unescaped → Telegram rejects the message with `Unsupported start tag '1s'`
- On a busy gateway this loops every poll interval until idle ages past 1s, flooding stderr (and was a contributing cause of the 22:30 spam burst)

## Fix
One-liner: wrap `formatDuration(...)` in `escapeHtml(...)` at the call site. Defensive — any future formatter quirk gets caught too.

## Tests
- Added `escapes HTML in sub-second age (<1s)` regression test
- All 18/18 watcher tests pass (was 17/17)

## Test plan
- [x] `bun test telegram-plugin/tests/subagent-watcher` — 18 pass
- [ ] Once merged + watcher re-enabled (separate PR for #83), verify no `card send failed` lines in gateway log