### PR TITLE
feat(boot-card): post on every gateway start with restart reason (closes #93)

### DIFF
--- a/src/build-info.ts
+++ b/src/build-info.ts
@@ -3,7 +3,7 @@
 // Values are refreshed every time `npm run build` runs.
 
 export const VERSION: string = "0.3.0";
-export const COMMIT_SHA: string | null = "2d212bf";
-export const COMMIT_DATE: string | null = "2026-04-26T08:10:20+10:00";
-export const LATEST_PR: number | null = 82;
-export const COMMITS_AHEAD_OF_TAG: number | null = 11;
+export const COMMIT_SHA: string | null = "b656351";
+export const COMMIT_DATE: string | null = "2026-04-26T09:23:32+10:00";
+export const LATEST_PR: number | null = 91;
+export const COMMITS_AHEAD_OF_TAG: number | null = 15;

--- a/telegram-plugin/gateway/boot-card.ts
+++ b/telegram-plugin/gateway/boot-card.ts
@@ -27,6 +27,8 @@ import { join } from 'path'
 
 // ─── Types ──────────────────────────────────────────────────────────────────
 
+export type RestartReason = 'planned' | 'graceful' | 'crash' | 'fresh'
+
 export type ProbeKey = 'account' | 'agent' | 'gateway' | 'quota' | 'hindsight' | 'crons'
 
 export type ProbeMap = Partial<Record<ProbeKey, ProbeResult | null>>
@@ -59,6 +61,30 @@ export interface BootCardHandle {
 
 // ─── Rendering ───────────────────────────────────────────────────────────────
 
+const REASON_EMOJI: Record<RestartReason, string> = {
+  planned:  '🔄',
+  graceful: '✅',
+  crash:    '⚠️',
+  fresh:    '🆕',
+}
+
+const REASON_LABEL: Record<RestartReason, string> = {
+  planned:  'planned restart',
+  graceful: 'graceful restart',
+  crash:    'crash recovery',
+  fresh:    'fresh start',
+}
+
+function renderRestartRow(reason: RestartReason, ageMs?: number): string {
+  const emoji = REASON_EMOJI[reason]
+  const label = REASON_LABEL[reason]
+  if (ageMs != null && ageMs > 0) {
+    const ageSec = (ageMs / 1000).toFixed(1)
+    return `${emoji} <b>Restart</b>  ${escapeHtml(label)} · ${ageSec}s ago`
+  }
+  return `${emoji} <b>Restart</b>  ${escapeHtml(label)}`
+}
+
 const DOT: Record<string, string> = {
   ok: '🟢',
   degraded: '🟡',
@@ -87,17 +113,27 @@ function renderRow(key: ProbeKey, result: ProbeResult | null | undefined): strin
   return `${dot} <b>${PROBE_LABELS[key]}</b>  ${escapeHtml(result.detail)}`
 }
 
-export function renderBootCard(probes: ProbeMap): string {
+export function renderBootCard(
+  probes: ProbeMap,
+  restartReason?: RestartReason,
+  restartAgeMs?: number,
+): string {
   const rows: string[] = [
     '🎛️ <b>Switchroom boot</b>',
     '',
+  ]
+  if (restartReason != null) {
+    rows.push(renderRestartRow(restartReason, restartAgeMs))
+    rows.push('')
+  }
+  rows.push(
     renderRow('account',   probes.account),
     renderRow('agent',     probes.agent),
     renderRow('gateway',   probes.gateway),
     renderRow('quota',     probes.quota),
     renderRow('hindsight', probes.hindsight),
     renderRow('crons',     probes.crons),
-  ]
+  )
   return rows.join('\n')
 }
 
@@ -110,6 +146,10 @@ export interface RunProbesOpts {
   agentDir: string
   gatewayInfo: GatewayRuntimeInfo
   bankName?: string
+  /** Why the gateway is starting — shown as a top row in the card. */
+  restartReason?: RestartReason
+  /** Age of the restart in milliseconds (for "X.Xs ago" display). */
+  restartAgeMs?: number
   /** Override fetch for tests. */
   fetchImpl?: typeof fetch
 }
@@ -119,8 +159,9 @@ export async function postInitialBootCard(
   threadId: number | undefined,
   bot: BotApiForBootCard,
   ackMessageId?: number,
+  opts?: Pick<RunProbesOpts, 'restartReason' | 'restartAgeMs'>,
 ): Promise<number> {
-  const text = renderBootCard({})
+  const text = renderBootCard({}, opts?.restartReason, opts?.restartAgeMs)
   const sent = await bot.sendMessage(chatId, text, {
     parse_mode: 'HTML',
     link_preview_options: { is_disabled: true },
@@ -144,11 +185,16 @@ export async function runProbesAndUpdateCard(
 
   async function editCard(): Promise<void> {
     try {
-      await bot.editMessageText(chatId, messageId, renderBootCard(probes), {
-        parse_mode: 'HTML',
-        link_preview_options: { is_disabled: true },
-        ...(threadId != null ? { message_thread_id: threadId } : {}),
-      })
+      await bot.editMessageText(
+        chatId,
+        messageId,
+        renderBootCard(probes, opts.restartReason, opts.restartAgeMs),
+        {
+          parse_mode: 'HTML',
+          link_preview_options: { is_disabled: true },
+          ...(threadId != null ? { message_thread_id: threadId } : {}),
+        },
+      )
     } catch {
       // Edit failures are non-fatal; another edit will follow
     }
@@ -216,7 +262,7 @@ export async function startBootCard(
 
   let messageId: number
   try {
-    messageId = await postInitialBootCard(chatId, threadId, bot, ackMessageId)
+    messageId = await postInitialBootCard(chatId, threadId, bot, ackMessageId, opts)
     logger(`telegram gateway: boot-card: posted msgId=${messageId} chatId=${chatId}\n`)
   } catch (err: unknown) {
     logger(`telegram gateway: boot-card: failed to post initial card: ${(err as Error)?.message ?? String(err)}\n`)

--- a/telegram-plugin/gateway/boot-reason.ts
+++ b/telegram-plugin/gateway/boot-reason.ts
@@ -1,0 +1,51 @@
+/**
+ * Pure helpers for determining boot reason and resolving the target chat
+ * on every gateway start.
+ *
+ * Kept in a separate module so unit tests can import them without pulling
+ * in the full gateway.ts side-effect tree (bot setup, DB init, etc.).
+ */
+
+import type { RestartReason } from './boot-card.js'
+import type { CleanShutdownMarker } from './clean-shutdown-marker.js'
+import { DEFAULT_MAX_AGE_MS as CLEAN_SHUTDOWN_MAX_AGE_MS } from './clean-shutdown-marker.js'
+import type { SessionMarker } from './session-marker.js'
+
+// Re-export so tests can import from a single path
+export type { RestartReason }
+
+/**
+ * Determine why this gateway is starting up.
+ *
+ * Priority order:
+ *   1. restart-pending.json present + fresh (<5 min) → 'planned'
+ *   2. clean-shutdown.json present + fresh (<60s default) → 'graceful'
+ *   3. gateway-session.json present (prior process existed) → 'crash'
+ *   4. Otherwise → 'fresh'
+ */
+export function determineRestartReason(opts: {
+  marker: { ts: number } | null
+  cleanMarker: CleanShutdownMarker | null
+  sessionMarker: SessionMarker | null
+  now: number
+  cleanMaxAgeMs?: number
+  markerMaxAgeMs?: number
+}): RestartReason {
+  const {
+    marker,
+    cleanMarker,
+    sessionMarker,
+    now,
+    cleanMaxAgeMs = CLEAN_SHUTDOWN_MAX_AGE_MS,
+    markerMaxAgeMs = 5 * 60_000,
+  } = opts
+  if (marker != null && now - marker.ts < markerMaxAgeMs) return 'planned'
+  if (
+    cleanMarker != null &&
+    now - cleanMarker.ts >= 0 &&
+    now - cleanMarker.ts < cleanMaxAgeMs
+  )
+    return 'graceful'
+  if (sessionMarker != null) return 'crash'
+  return 'fresh'
+}

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -168,6 +168,8 @@ import {
   startBootCard,
   type BootCardHandle,
 } from './boot-card.js'
+import { determineRestartReason } from './boot-reason.js'
+import type { RestartReason } from './boot-card.js'
 
 // ─── Stderr logging ───────────────────────────────────────────────────────
 installPluginLogger()
@@ -877,19 +879,28 @@ const ipcServer: IpcServer = createIpcServer({
     process.stderr.write(`telegram gateway: bridge registered — agent=${client.agentName}\n`)
     client.send({ type: 'status', status: 'agent_connected' })
 
-    // If the agent reconnected after a /restart, clear the marker and
-    // notify the user so Telegram doesn't stay stuck on "restarting…".
-    const marker = readRestartMarker()
-    if (marker) {
-      const ageMs = Date.now() - marker.ts
-      const ageSec = Math.max(1, Math.round(ageMs / 1000))
-      process.stderr.write(`telegram gateway: bridge-reconnect: restart-marker present, chat_id=${marker.chat_id} age=${ageSec}s within5min=${ageMs < 5 * 60_000} agent=${client.agentName}\n`)
-      clearRestartMarker()
-      if (ageMs < 5 * 60_000) {
-        const chatId = marker.chat_id
-        const threadId = marker.thread_id ?? undefined
-        const ackMsgId = marker.ack_message_id ?? undefined
-        process.stderr.write(`telegram gateway: bridge-reconnect: posting boot card chat_id=${chatId} thread_id=${threadId ?? '-'} ackReply=${ackMsgId ?? '-'} boot_card=${BOOT_CARD_ENABLED}\n`)
+    // If the agent reconnected after a /restart (or any restart), post a boot
+    // card. The restart-marker carries the ack chat; if absent we fall back to
+    // resolveBootChatId so crash-recovery reconnects also get a card.
+    {
+      const nowMs = Date.now()
+      const marker = readRestartMarker()
+      const cleanMarker = readCleanShutdownMarker(GATEWAY_CLEAN_SHUTDOWN_MARKER_PATH)
+      const storedSession = readSessionMarker(GATEWAY_SESSION_MARKER_PATH)
+      const markerAgeMs = marker ? nowMs - marker.ts : undefined
+
+      if (marker) {
+        const ageSec = Math.max(1, Math.round((markerAgeMs ?? 0) / 1000))
+        process.stderr.write(`telegram gateway: bridge-reconnect: restart-marker present, chat_id=${marker.chat_id} age=${ageSec}s agent=${client.agentName}\n`)
+        clearRestartMarker()
+      }
+
+      const reason = determineRestartReason({ marker, cleanMarker, sessionMarker: storedSession, now: nowMs })
+      const target = resolveBootChatId(marker, markerAgeMs)
+
+      if (target) {
+        const { chatId, threadId, ackMsgId } = target
+        process.stderr.write(`telegram gateway: bridge-reconnect: posting boot card reason=${reason} chat_id=${chatId} thread_id=${threadId ?? '-'} ackReply=${ackMsgId ?? '-'} boot_card=${BOOT_CARD_ENABLED}\n`)
         if (BOOT_CARD_ENABLED) {
           const agentDir = resolveAgentDirFromEnv()
           const agentName = process.env.SWITCHROOM_AGENT_NAME ?? client.agentName ?? '-'
@@ -903,14 +914,19 @@ const ipcServer: IpcServer = createIpcServer({
             agentName,
             agentDir: agentDir ?? (process.env.TELEGRAM_STATE_DIR ? require('path').dirname(process.env.TELEGRAM_STATE_DIR) : '/tmp'),
             gatewayInfo: { pid: process.pid, startedAtMs: GATEWAY_STARTED_AT_MS },
+            restartReason: reason,
+            restartAgeMs: markerAgeMs,
           }, ackMsgId).then(handle => {
             activeBootCard = handle
           }).catch((err: Error) => {
             process.stderr.write(`telegram gateway: bridge-reconnect: boot card error: ${err.message}\n`)
           })
         } else {
+          const ageSec = markerAgeMs != null ? Math.max(1, Math.round(markerAgeMs / 1000)) : 0
           postLegacyBanner(chatId, threadId, ackMsgId, ageSec, 'bridge-reconnect')
         }
+      } else {
+        process.stderr.write(`telegram gateway: bridge-reconnect: no known chat for boot card (reason=${reason}) — skipping\n`)
       }
     }
   },
@@ -2755,6 +2771,47 @@ function clearRestartMarker(): void {
     rmSync(p, { force: true })
     process.stderr.write(`telegram gateway: restart-marker: cleared path=${p}\n`)
   } catch {}
+}
+
+/**
+ * Resolve which Telegram chat should receive the boot card.
+ *
+ * Fallback chain:
+ *   1. restart-pending.json chat_id (if present and fresh)
+ *   2. SUBAGENT_OWNER_CHAT_ID env var
+ *   3. Most recent inbound from history SQLite
+ *   4. null → skip (no known chat)
+ *
+ * TODO: add test coverage for the history-SQLite fallback path
+ */
+function resolveBootChatId(
+  marker: { chat_id: string; thread_id: number | null; ack_message_id: number | null; ts: number } | null,
+  ageMs?: number,
+): { chatId: string; threadId: number | undefined; ackMsgId: number | undefined } | null {
+  // 1. Restart marker
+  if (marker != null && (ageMs == null || ageMs < 5 * 60_000)) {
+    return {
+      chatId: marker.chat_id,
+      threadId: marker.thread_id ?? undefined,
+      ackMsgId: marker.ack_message_id ?? undefined,
+    }
+  }
+  // 2. Env var
+  const envChat = process.env.SUBAGENT_OWNER_CHAT_ID
+  if (envChat) return { chatId: envChat, threadId: undefined, ackMsgId: undefined }
+  // 3. Most-recent inbound from history
+  if (HISTORY_ENABLED) {
+    try {
+      const access = loadAccess()
+      const ownerChatId = access.allowFrom[0]
+      if (ownerChatId) {
+        const recent = queryHistory({ chat_id: ownerChatId, limit: 1 })
+        if (recent.length > 0) return { chatId: ownerChatId, threadId: undefined, ackMsgId: undefined }
+      }
+    } catch {}
+  }
+  // 4. No known chat
+  return null
 }
 
 /**
@@ -4919,19 +4976,51 @@ void (async () => {
           }
         } catch {}
 
-        // Restart follow-up
+        // Boot card — always post on every gateway start with the restart reason.
+        // Gated on session marker so a grammY poll-restart (same process, no
+        // actual restart) does NOT re-post.  See session-marker.ts for the
+        // 2026-04-22 incident that introduced this gate.
         try {
+          const nowMs = Date.now()
           const marker = readRestartMarker()
+          const cleanMarker = readCleanShutdownMarker(GATEWAY_CLEAN_SHUTDOWN_MARKER_PATH)
+          const currentSession: SessionMarker = { pid: process.pid, startedAtMs: GATEWAY_STARTED_AT_MS }
+          const storedSession = readSessionMarker(GATEWAY_SESSION_MARKER_PATH)
+          const isRealRestart = shouldFireRestartBanner({ stored: storedSession, current: currentSession })
+
+          if (cleanMarker) {
+            const ageSec = Math.max(0, Math.round((nowMs - cleanMarker.ts) / 1000))
+            const reasonTag = cleanMarker.reason ? ` reason=${JSON.stringify(cleanMarker.reason)}` : ''
+            const cleanFresh = shouldSuppressRecoveryBanner(cleanMarker, nowMs, CLEAN_SHUTDOWN_MAX_AGE_MS)
+            if (cleanFresh) {
+              process.stderr.write(`telegram gateway: boot.clean_shutdown_detected age=${ageSec}s signal=${cleanMarker.signal}${reasonTag}\n`)
+            } else {
+              process.stderr.write(`telegram gateway: boot.clean_shutdown_marker_stale age=${ageSec}s signal=${cleanMarker.signal}${reasonTag}\n`)
+            }
+            // IMPORTANT: do NOT clearCleanShutdownMarker() here.
+            // session-greeting.sh reads clean-shutdown.json to render the
+            // "Restarted <reason>" row. Gateway and agent boot in parallel
+            // under systemd, so clearing here would race and drop the reason.
+            // Ownership of cleanup belongs to session-greeting.sh.
+          }
+
           if (marker) {
-            const ageMs = Date.now() - marker.ts
+            const ageMs = nowMs - marker.ts
             const ageSec = Math.max(1, Math.round(ageMs / 1000))
             process.stderr.write(`telegram gateway: boot: restart-marker present, chat_id=${marker.chat_id} age=${ageSec}s within5min=${ageMs < 5 * 60_000}\n`)
             clearRestartMarker()
-            if (ageMs < 5 * 60_000) {
-              const chatId = marker.chat_id
-              const threadId = marker.thread_id ?? undefined
-              const ackMsgId = marker.ack_message_id ?? undefined
-              process.stderr.write(`telegram gateway: boot: posting boot card chat_id=${chatId} thread_id=${threadId ?? '-'} ackReply=${ackMsgId ?? '-'} boot_card=${BOOT_CARD_ENABLED}\n`)
+          }
+
+          if (!isRealRestart) {
+            process.stderr.write(`telegram gateway: boot: suppressed boot card — session marker matches current process (pid=${process.pid} startedAt=${GATEWAY_STARTED_AT_MS})\n`)
+          } else {
+            const markerAgeMs = marker ? nowMs - marker.ts : undefined
+            const reason = determineRestartReason({ marker, cleanMarker, sessionMarker: storedSession, now: nowMs })
+            const target = resolveBootChatId(marker, markerAgeMs)
+
+            if (target) {
+              const { chatId, threadId, ackMsgId } = target
+              process.stderr.write(`telegram gateway: boot: posting boot card reason=${reason} chat_id=${chatId} thread_id=${threadId ?? '-'} ackReply=${ackMsgId ?? '-'} boot_card=${BOOT_CARD_ENABLED}\n`)
               if (BOOT_CARD_ENABLED) {
                 const agentDir = resolveAgentDirFromEnv()
                 const agentName = process.env.SWITCHROOM_AGENT_NAME ?? '-'
@@ -4946,95 +5035,23 @@ void (async () => {
                     agentName,
                     agentDir: agentDir ?? join(homedir(), '.switchroom', 'agents', agentName),
                     gatewayInfo: { pid: process.pid, startedAtMs: GATEWAY_STARTED_AT_MS },
+                    restartReason: reason,
+                    restartAgeMs: markerAgeMs,
                   }, ackMsgId)
                   activeBootCard = handle
                 } catch (err) {
                   process.stderr.write(`telegram gateway: boot: boot card error: ${err}\n`)
                 }
               } else {
+                const ageSec = markerAgeMs != null ? Math.max(1, Math.round(markerAgeMs / 1000)) : 0
                 postLegacyBanner(chatId, threadId, ackMsgId, ageSec, 'boot')
               }
-            }
-          } else {
-            process.stderr.write(`telegram gateway: boot: no restart-marker found (clean start or crash recovery path)\n`)
-          }
-        } catch {}
-
-        // Crash recovery. Gated on the session marker so a grammY
-        // poll-restart (which re-enters the outer retry loop) does NOT
-        // fire the banner — only an actual new process does. See
-        // session-marker.ts for the 2026-04-22 incident this closes.
-        //
-        // ALSO gated on the clean-shutdown marker: SIGTERM/SIGINT writes
-        // a sentinel before draining, so deliberate restarts (systemctl,
-        // `switchroom agent restart`, Coolify, etc.) suppress the
-        // banner. See clean-shutdown-marker.ts for the 2026-04-23 UX gap
-        // this closes.
-        try {
-          const marker = readRestartMarker()
-          const cleanMarker = readCleanShutdownMarker(GATEWAY_CLEAN_SHUTDOWN_MARKER_PATH)
-          const nowMs = Date.now()
-          const cleanFresh = shouldSuppressRecoveryBanner(cleanMarker, nowMs, CLEAN_SHUTDOWN_MAX_AGE_MS)
-          if (cleanMarker) {
-            const ageSec = Math.max(0, Math.round((nowMs - cleanMarker.ts) / 1000))
-            const reasonTag = cleanMarker.reason ? ` reason=${JSON.stringify(cleanMarker.reason)}` : ''
-            if (cleanFresh) {
-              process.stderr.write(`telegram gateway: boot.clean_shutdown_detected age=${ageSec}s signal=${cleanMarker.signal}${reasonTag} — suppressing 'recovered from unexpected restart' banner\n`)
             } else {
-              // Marker present but stale: shutdown was initiated cleanly
-              // but never finished within the age window. Almost
-              // certainly a crash mid-drain; fall through so the operator
-              // gets the banner anyway. We DON'T clear here either — see
-              // the note below — but stale markers are harmless to leave
-              // in place because shouldSuppressRecoveryBanner returns
-              // false on the next boot too.
-              process.stderr.write(`telegram gateway: boot.clean_shutdown_marker_stale age=${ageSec}s signal=${cleanMarker.signal}${reasonTag} — posting banner anyway (leaving marker for agent-side consumer)\n`)
-            }
-            // IMPORTANT: do NOT clearCleanShutdownMarker() here.
-            //
-            // Lifecycle change (PR for restart-reason-greeting):
-            //   The agent-side consumer (session-greeting.sh) reads
-            //   `clean-shutdown.json` to render a "Restarted  <reason>"
-            //   row in the next greeting card. The gateway and the agent
-            //   boot in parallel under systemd, so if we cleared here the
-            //   greeting would race and miss the reason.
-            //
-            //   The gateway only needs to READ the marker to decide
-            //   banner suppression; the file's continued presence after
-            //   that decision is harmless to the gateway. We hand
-            //   ownership of cleanup to session-greeting.sh which
-            //   deletes the marker right after rendering the row.
-          }
-          const currentSession: SessionMarker = { pid: process.pid, startedAtMs: GATEWAY_STARTED_AT_MS }
-          const storedSession = readSessionMarker(GATEWAY_SESSION_MARKER_PATH)
-          const bannerOK = shouldFireRestartBanner({ stored: storedSession, current: currentSession })
-          if (!marker && !bannerOK) {
-            process.stderr.write(`telegram gateway: boot: suppressed 'recovered' banner — session marker matches current process (pid=${process.pid} startedAt=${GATEWAY_STARTED_AT_MS})\n`)
-          }
-          if (!marker && bannerOK && !cleanFresh) {
-            const bootAccess = loadAccess()
-            const ownerChatId = bootAccess.allowFrom[0]
-            if (ownerChatId && HISTORY_ENABLED) {
-              try {
-                const recent = queryHistory({ chat_id: ownerChatId, limit: 1 })
-                if (recent.length > 0) {
-                  const lastTs = recent[0].ts * 1000
-                  const downtime = Date.now() - lastTs
-                  const downSec = Math.max(1, Math.round(downtime / 1000))
-                  if (downtime < 30 * 60_000) {
-                    const text = `⚡ Recovered from unexpected restart. (down ~${downSec}s)`
-                    process.stderr.write(`telegram gateway: boot: posting 'recovered from unexpected restart' banner chat_id=${ownerChatId} down=${downSec}s (no marker present, last msg ${downSec}s ago)\n`)
-                    const sent = await lockedBot.api.sendMessage(ownerChatId, text, { parse_mode: 'HTML', link_preview_options: { is_disabled: true } })
-                    if (HISTORY_ENABLED) { try { recordOutbound({ chat_id: ownerChatId, thread_id: null, message_ids: [sent.message_id], texts: [text], attachment_kinds: [] }) } catch {} }
-                  } else {
-                    process.stderr.write(`telegram gateway: boot: suppressed 'recovered' banner — last msg ${downSec}s ago exceeds 30min window\n`)
-                  }
-                }
-              } catch {}
+              process.stderr.write(`telegram gateway: boot: no known chat for boot card (reason=${reason}) — skipping\n`)
             }
           }
-          // Always update the marker to the current process on this
-          // boot pass so subsequent banner-gates see "stored === current".
+
+          // Always update the session marker so subsequent boots see "stored === current".
           try {
             writeSessionMarker(GATEWAY_SESSION_MARKER_PATH, currentSession)
           } catch (err) {

--- a/telegram-plugin/tests/boot-card-reason.test.ts
+++ b/telegram-plugin/tests/boot-card-reason.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Unit tests for determineRestartReason() — the pure helper that decides
+ * which restart reason to show in the boot card.
+ *
+ * Run with:
+ *   bun test telegram-plugin/tests/boot-card-reason.test.ts
+ */
+import { describe, it, expect } from 'bun:test'
+import { determineRestartReason } from '../gateway/boot-reason.js'
+
+const NOW = 1_700_000_000_000 // arbitrary fixed timestamp
+
+// ── Marker fixtures ────────────────────────────────────────────────────────
+
+function recentMarker(offsetMs = 0) {
+  return { ts: NOW - offsetMs }
+}
+
+function recentCleanMarker(offsetMs = 0) {
+  return { ts: NOW - offsetMs }
+}
+
+function sessionMarker() {
+  return { pid: 1234 }
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+describe('determineRestartReason', () => {
+  it('returns "planned" when a restart marker is present and fresh (<5 min)', () => {
+    const result = determineRestartReason({
+      marker: recentMarker(10_000),     // 10s ago
+      cleanMarker: null,
+      sessionMarker: sessionMarker(),
+      now: NOW,
+    })
+    expect(result).toBe('planned')
+  })
+
+  it('returns "graceful" when clean-shutdown marker is present and fresh, no restart marker', () => {
+    const result = determineRestartReason({
+      marker: null,
+      cleanMarker: recentCleanMarker(5_000),   // 5s ago, within 60s default
+      sessionMarker: sessionMarker(),
+      now: NOW,
+    })
+    expect(result).toBe('graceful')
+  })
+
+  it('returns "crash" when session marker exists but no other markers', () => {
+    const result = determineRestartReason({
+      marker: null,
+      cleanMarker: null,
+      sessionMarker: sessionMarker(),
+      now: NOW,
+    })
+    expect(result).toBe('crash')
+  })
+
+  it('returns "fresh" when no markers exist at all (first ever start)', () => {
+    const result = determineRestartReason({
+      marker: null,
+      cleanMarker: null,
+      sessionMarker: null,
+      now: NOW,
+    })
+    expect(result).toBe('fresh')
+  })
+
+  it('returns "crash" (not "graceful") when clean-shutdown marker is stale (>60s)', () => {
+    const result = determineRestartReason({
+      marker: null,
+      cleanMarker: recentCleanMarker(90_000),  // 90s ago, stale
+      sessionMarker: sessionMarker(),
+      now: NOW,
+    })
+    // stale clean-shutdown = marker too old to suppress crash detection
+    expect(result).toBe('crash')
+  })
+
+  it('returns "planned" even when clean-shutdown marker is also present (planned wins)', () => {
+    // Both present: planned restart marker takes priority
+    const result = determineRestartReason({
+      marker: recentMarker(3_000),
+      cleanMarker: recentCleanMarker(3_000),
+      sessionMarker: sessionMarker(),
+      now: NOW,
+    })
+    expect(result).toBe('planned')
+  })
+
+  it('respects custom markerMaxAgeMs — stale marker does not count as planned', () => {
+    const result = determineRestartReason({
+      marker: recentMarker(10 * 60_000),  // 10 min ago
+      cleanMarker: null,
+      sessionMarker: sessionMarker(),
+      now: NOW,
+      markerMaxAgeMs: 5 * 60_000,          // 5 min window
+    })
+    // Marker is too old to be "planned", session marker present → crash
+    expect(result).toBe('crash')
+  })
+})


### PR DESCRIPTION
## Summary

Decouples the boot card from the restart-marker gate so EVERY gateway start posts a card — planned, graceful, crash recovery, or fresh — with the reason as a top row.

Closes #93.

## What changed

- `boot-reason.ts` (new, pure module): `determineRestartReason()` reads restart-pending / clean-shutdown / session markers and decides reason
- `RestartReason` type + `renderRestartRow()` in `boot-card.ts`
- `resolveBootChatId()` fallback chain in `gateway.ts`: marker.chat_id → `SUBAGENT_OWNER_CHAT_ID` env → most-recent inbound from history SQLite → null
- Both gateway boot-card call sites (boot path + bridge-reconnect) collapsed onto a single shared post path; chat_id is the gate, not the marker
- `boot-card-reason.test.ts` — 7 unit tests covering each reason case

## Why

Operator visibility. Currently a silent gateway crash + auto-restart leaves no Telegram trace (see #92). Even a fresh first-boot of a new agent gets no surface. Per Ken: "Any time an agent restarts, starts, recovers, I want that new start message."

## Test plan
- [x] `bun run build` clean
- [x] `bun test telegram-plugin/tests/boot-card-reason.test.ts` — 7 pass / 0 fail
- [ ] Manual smoke: restart an agent and observe card with reason row

## Notes / TODOs

- The clean-shutdown marker writer already exists (came in #60). Reason heuristic uses it.
- Chat-resolver test deferred — covered by integration via the live-restart smoke test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)