### PR TITLE
fix(watchdog): bump DISCONNECT_GRACE_SECS 120s -> 600s

### DIFF
--- a/bin/bridge-watchdog.sh
+++ b/bin/bridge-watchdog.sh
@@ -28,7 +28,7 @@ set -euo pipefail
 # Tunables. Expressed as env-overridable so the test harness can drive
 # edge cases without mutating the script.
 : "${UPTIME_GRACE_SECS:=90}"       # skip the bridge check for this long after agent (re)start
-: "${DISCONNECT_GRACE_SECS:=120}"  # require disconnection to persist this long before restarting
+: "${DISCONNECT_GRACE_SECS:=600}"  # require disconnection to persist this long before restarting
 
 now_epoch() { date +%s; }
 


### PR DESCRIPTION
## Summary

- Band-aid: raise `DISCONNECT_GRACE_SECS` default from 120s to 600s in `bin/bridge-watchdog.sh`.
- The 120s threshold is shorter than a normal long Claude turn, so the watchdog regularly mistakes a healthy-but-quiet bridge for a stuck one and restarts the agent — killing the very turn it was trying to protect.

## Why

The bridge IPC client cycles `connect → register → disconnect` on every Claude tool call (Claude Code's MCP host spawns fresh stdio sessions per call). Between calls — or during a long thinking turn with no MCP calls — the bridge legitimately appears "disconnected" to the gateway. 120s isn't enough headroom for normal traffic on the busier agents.

Last 24h on my fleet, all watchdog-triggered (NRestarts=0 on every unit, so no real systemd failures):

- clerk: 5
- lawgpt: 3
- klanker: 2
- gymbro: 2

Each one killed the in-flight turn.

## Why this is a band-aid (not the real fix)

The deeper bug is the per-call IPC reconnect pattern itself. A persistent IPC connection per agent lifetime would make "disconnected" actually mean "agent is gone". I'm scoping that as a follow-up. This PR just stops the bleeding.

## Test plan

- [x] Existing watchdog tests pass unchanged (25/25). They pin `DISCONNECT_GRACE_SECS=120` via env override, so changing the script default doesn't affect them.
- [ ] Watch fleet for 24h after merge — restart count should drop to ~0 (real bridge wedges only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)