### PR TITLE
fix(gateway): break boot-card crash loop family — discriminate unhandledRejection, dedupe boot card, cache quota probe (closes #99)

### DIFF
--- a/src/build-info.ts
+++ b/src/build-info.ts
@@ -3,7 +3,7 @@
 // Values are refreshed every time `npm run build` runs.
 
 export const VERSION: string = "0.3.0";
-export const COMMIT_SHA: string | null = "b656351";
-export const COMMIT_DATE: string | null = "2026-04-26T09:23:32+10:00";
-export const LATEST_PR: number | null = 91;
-export const COMMITS_AHEAD_OF_TAG: number | null = 15;
+export const COMMIT_SHA: string | null = "0d62c1e";
+export const COMMIT_DATE: string | null = "2026-04-26T10:58:25+10:00";
+export const LATEST_PR: number | null = 97;
+export const COMMITS_AHEAD_OF_TAG: number | null = 18;

--- a/src/build-info.ts
+++ b/src/build-info.ts
@@ -3,7 +3,7 @@
 // Values are refreshed every time `npm run build` runs.
 
 export const VERSION: string = "0.3.0";
-export const COMMIT_SHA: string | null = "0d62c1e";
-export const COMMIT_DATE: string | null = "2026-04-26T10:58:25+10:00";
-export const LATEST_PR: number | null = 97;
-export const COMMITS_AHEAD_OF_TAG: number | null = 18;
+export const COMMIT_SHA: string | null = "8d8bb40";
+export const COMMIT_DATE: string | null = "2026-04-26T12:45:28+10:00";
+export const LATEST_PR: number | null = 99;
+export const COMMITS_AHEAD_OF_TAG: number | null = 19;

--- a/src/build-info.ts
+++ b/src/build-info.ts
@@ -3,7 +3,7 @@
 // Values are refreshed every time `npm run build` runs.
 
 export const VERSION: string = "0.3.0";
-export const COMMIT_SHA: string | null = "8d8bb40";
-export const COMMIT_DATE: string | null = "2026-04-26T12:45:28+10:00";
-export const LATEST_PR: number | null = 99;
-export const COMMITS_AHEAD_OF_TAG: number | null = 19;
+export const COMMIT_SHA: string | null = "13003da";
+export const COMMIT_DATE: string | null = "2026-04-26T13:06:51+10:00";
+export const LATEST_PR: number | null = null;
+export const COMMITS_AHEAD_OF_TAG: number | null = 20;

--- a/telegram-plugin/gateway/boot-card.ts
+++ b/telegram-plugin/gateway/boot-card.ts
@@ -59,6 +59,48 @@ export interface BootCardHandle {
   complete(): void
 }
 
+export type BootCardSite = 'boot' | 'bridge-reconnect'
+
+export interface BootCardGate {
+  /**
+   * Set after the boot path successfully posts a card. The bridge-reconnect
+   * path checks this to avoid posting a second card on the same gateway
+   * lifetime — observed in the wild as klanker msgId 2245 + 2248 within 5s
+   * (2026-04-26 11:19:47).
+   */
+  activeBootCard: { messageId: number } | null
+}
+
+export interface BootCardSkipDecision {
+  skip: boolean
+  /** Human-readable reason (only present when skip=true). */
+  reason?: string
+}
+
+/**
+ * Decide whether to skip posting the boot card based on gateway state.
+ *
+ * The boot path runs first (in the gateway IIFE) and sets activeBootCard
+ * on success. The bridge-reconnect path runs later when the agent
+ * registers; without this guard it posts a duplicate card.
+ *
+ * Boot path: never skip — it's the primary post site.
+ * Bridge-reconnect: skip if a card was already posted this lifetime.
+ */
+export function shouldSkipDuplicateBootCard(
+  gate: BootCardGate,
+  site: BootCardSite,
+): BootCardSkipDecision {
+  if (site === 'boot') return { skip: false }
+  if (gate.activeBootCard != null) {
+    return {
+      skip: true,
+      reason: `already-posted-msgId=${gate.activeBootCard.messageId}`,
+    }
+  }
+  return { skip: false }
+}
+
 // ─── Rendering ───────────────────────────────────────────────────────────────
 
 const REASON_EMOJI: Record<RestartReason, string> = {

--- a/telegram-plugin/gateway/boot-probes.ts
+++ b/telegram-plugin/gateway/boot-probes.ts
@@ -16,6 +16,8 @@ import { join } from 'path'
 import { execFile as execFileCb } from 'child_process'
 import { promisify } from 'util'
 
+import { readQuotaCache, writeQuotaCache } from './quota-cache.js'
+
 const execFile = promisify(execFileCb)
 
 // ─── Types ──────────────────────────────────────────────────────────────────
@@ -231,6 +233,13 @@ const QUOTA_DEBUG_FILE = 'quota-debug.json'
  * Attempt to read quota info via the /api/oauth/usage endpoint.
  * The response schema is undocumented — we probe defensively and
  * save the raw response to a debug file on first 2xx hit.
+ *
+ * Result is cached for 5 min in `~/.switchroom/quota-cache.json` and
+ * shared across all agents. Without the cache, every gateway boot +
+ * bridge-reconnect across 4 agents hits the endpoint, triggering 429s
+ * that surface as 🟡 "rate limited" in the boot card. See `quota-cache.ts`.
+ *
+ * Tests can override the cache path via SWITCHROOM_QUOTA_CACHE_PATH.
  */
 export async function probeQuota(
   claudeConfigDir: string,
@@ -238,6 +247,12 @@ export async function probeQuota(
   fetchImpl: typeof fetch = fetch,
 ): Promise<ProbeResult> {
   return withTimeout('Quota', (async (): Promise<ProbeResult> => {
+    // Cache hit → return early (avoids the rate-limit cascade)
+    const cached = readQuotaCache()
+    if (cached) {
+      return cached
+    }
+
     // Read token
     let token: string | null = null
     for (const candidate of [
@@ -332,7 +347,9 @@ export async function probeQuota(
     if (parts.length === 0) {
       return { status: 'degraded', label: 'Quota', detail: 'schema unknown — saving raw response' }
     }
-    return { status: 'ok', label: 'Quota', detail: parts.join(' · ') }
+    const result: ProbeResult = { status: 'ok', label: 'Quota', detail: parts.join(' · ') }
+    writeQuotaCache(result)
+    return result
   })())
 }
 

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -170,6 +170,7 @@ import {
 } from './boot-card.js'
 import { determineRestartReason } from './boot-reason.js'
 import type { RestartReason } from './boot-card.js'
+import { classifyRejection } from './unhandled-rejection-policy.js'
 
 // ─── Stderr logging ───────────────────────────────────────────────────────
 installPluginLogger()
@@ -4832,9 +4833,20 @@ initHandoffContinuity()
 // held until the next boot's stale-PID auto-recovery — workable, but noisy.
 // The `shuttingDown` guard inside shutdown() prevents double-invocation if
 // SIGTERM races with one of these handlers.
+//
+// `unhandledRejection` is discriminated through `classifyRejection` so that
+// benign Telegram 400s ("message is not modified", "message to edit not
+// found") are logged but NOT crashed-on. These leaked through restart loops
+// for klanker (#99) and lawgpt's mid-day crash family — see the unit tests
+// in `tests/unhandled-rejection-policy.test.ts`.
 process.on('unhandledRejection', err => {
-  process.stderr.write(`telegram gateway: unhandled rejection: ${err}\n`)
-  void shutdown('unhandledRejection')
+  const action = classifyRejection(err)
+  process.stderr.write(
+    `telegram gateway: unhandled rejection (${action}): ${err}\n`,
+  )
+  if (action === 'shutdown') {
+    void shutdown('unhandledRejection')
+  }
 })
 process.on('uncaughtException', err => {
   process.stderr.write(`telegram gateway: uncaught exception: ${err}\n`)

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -169,7 +169,7 @@ import {
   type BootCardHandle,
 } from './boot-card.js'
 import { determineRestartReason } from './boot-reason.js'
-import type { RestartReason } from './boot-card.js'
+import { shouldSkipDuplicateBootCard, type RestartReason } from './boot-card.js'
 import { classifyRejection } from './unhandled-rejection-policy.js'
 
 // ─── Stderr logging ───────────────────────────────────────────────────────
@@ -883,7 +883,16 @@ const ipcServer: IpcServer = createIpcServer({
     // If the agent reconnected after a /restart (or any restart), post a boot
     // card. The restart-marker carries the ack chat; if absent we fall back to
     // resolveBootChatId so crash-recovery reconnects also get a card.
-    {
+    //
+    // Skip if the boot path already posted a card this lifetime — the boot
+    // path runs first (in the IIFE at end of file) and `activeBootCard` is
+    // set as soon as it succeeds. Without this guard, both paths fire on a
+    // single gateway start (observed: msgId 2245 + 2248 within 5s for klanker
+    // at 11:19:47 on 2026-04-26). See `shouldSkipDuplicateBootCard`.
+    const dedupeDecision = shouldSkipDuplicateBootCard({ activeBootCard }, 'bridge-reconnect')
+    if (dedupeDecision.skip) {
+      process.stderr.write(`telegram gateway: bridge-reconnect: skipping boot card (${dedupeDecision.reason})\n`)
+    } else {
       const nowMs = Date.now()
       const marker = readRestartMarker()
       const cleanMarker = readCleanShutdownMarker(GATEWAY_CLEAN_SHUTDOWN_MARKER_PATH)

--- a/telegram-plugin/gateway/quota-cache.ts
+++ b/telegram-plugin/gateway/quota-cache.ts
@@ -1,0 +1,104 @@
+/**
+ * Shared quota probe cache.
+ *
+ * Background: every gateway boot AND every bridge-reconnect calls
+ * `probeQuota` which hits Anthropic's /api/oauth/usage endpoint. With
+ * four agents on one OAuth account and reconnects happening multiple
+ * times per minute (per the boot-card-on-every-start design), the
+ * endpoint returns 429 and the boot card shows 🟡 "rate limited" — a
+ * cosmetic alarm caused by the boot card itself.
+ *
+ * Cache the result for 5 min in a single file shared across all agents.
+ * On a hit, the cached ProbeResult is returned instead of making the
+ * HTTP call. 429 results are NOT cached so the next boot tries fresh.
+ *
+ * Cache location: `~/.switchroom/quota-cache.json` (mode 0600). Format:
+ *   { capturedAt: string, ttlMs: number, result: ProbeResult }
+ */
+
+import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'fs'
+import { join, dirname } from 'path'
+import type { ProbeResult } from './boot-probes.js'
+
+export interface QuotaCacheEntry {
+  capturedAt: string  // ISO 8601
+  ttlMs: number
+  result: ProbeResult
+}
+
+export const DEFAULT_TTL_MS = 5 * 60 * 1000  // 5 min
+export const DEFAULT_CACHE_PATH =
+  process.env.SWITCHROOM_QUOTA_CACHE_PATH
+    ?? join(process.env.HOME ?? '/tmp', '.switchroom', 'quota-cache.json')
+
+/**
+ * Read a cached probe result if one exists and is still within TTL.
+ * Returns null on:
+ *   - file missing
+ *   - JSON parse error
+ *   - cache entry past its TTL
+ *
+ * Pure helper — accepts a clock so tests can advance time.
+ */
+export function readQuotaCache(opts: {
+  path?: string
+  now?: number
+} = {}): ProbeResult | null {
+  const path = opts.path ?? DEFAULT_CACHE_PATH
+  const now = opts.now ?? Date.now()
+
+  if (!existsSync(path)) return null
+
+  let entry: QuotaCacheEntry
+  try {
+    entry = JSON.parse(readFileSync(path, 'utf8')) as QuotaCacheEntry
+  } catch {
+    return null
+  }
+
+  const capturedAtMs = Date.parse(entry.capturedAt)
+  if (!isFinite(capturedAtMs)) return null
+
+  const ageMs = now - capturedAtMs
+  if (ageMs < 0) return null  // clock went backwards; treat as miss
+  if (ageMs >= entry.ttlMs) return null  // expired
+
+  return entry.result
+}
+
+/**
+ * Write a probe result to the cache. Ignored on rate-limited or
+ * fail-status results — we want the next boot to try fresh.
+ *
+ * Writes are best-effort: any IO error is swallowed (cache is an
+ * optimization, not a correctness requirement).
+ */
+export function writeQuotaCache(
+  result: ProbeResult,
+  opts: {
+    path?: string
+    ttlMs?: number
+    now?: number
+  } = {},
+): void {
+  // Don't cache failure / rate-limit so next boot retries clean.
+  if (result.status === 'fail') return
+  if (result.detail === 'rate limited') return
+
+  const path = opts.path ?? DEFAULT_CACHE_PATH
+  const ttlMs = opts.ttlMs ?? DEFAULT_TTL_MS
+  const now = opts.now ?? Date.now()
+
+  const entry: QuotaCacheEntry = {
+    capturedAt: new Date(now).toISOString(),
+    ttlMs,
+    result,
+  }
+
+  try {
+    mkdirSync(dirname(path), { recursive: true })
+    writeFileSync(path, JSON.stringify(entry, null, 2), { mode: 0o600 })
+  } catch {
+    // Best-effort. Swallow.
+  }
+}

--- a/telegram-plugin/gateway/unhandled-rejection-policy.ts
+++ b/telegram-plugin/gateway/unhandled-rejection-policy.ts
@@ -1,0 +1,59 @@
+/**
+ * Discriminating policy for the gateway's `unhandledRejection` handler.
+ *
+ * Background: gateway.ts crashes the process on every unhandledRejection
+ * (it calls `shutdown()` from the handler). Some Telegram API errors
+ * surface here as benign 400s — "message is not modified", "message to
+ * edit not found" — and crashing the gateway over them creates restart
+ * loops (issue #99 + lawgpt's 11:36 crash family).
+ *
+ * Pure helper so it can be tested without spinning up the gateway.
+ */
+
+import { GrammyError } from 'grammy'
+
+export type RejectionAction = 'shutdown' | 'log_only'
+
+export interface RejectionPolicyOptions {
+  /** Allow tests to inject error type detection without depending on grammy. */
+  isGrammyError?: (err: unknown) => boolean
+}
+
+/**
+ * Decide whether an unhandledRejection should crash the gateway.
+ *
+ * Returns:
+ *   - `'log_only'` for benign Telegram 400s the bot already tolerates
+ *     elsewhere (see retry-api-call.ts). Logging surfaces the leak; not
+ *     crashing prevents restart loops.
+ *   - `'shutdown'` for everything else. Genuine bugs still crash, which
+ *     systemd will surface as a restart and we want that signal.
+ *
+ * The set of benign descriptions is intentionally narrow — only the
+ * specific 400s the wrapper already swallows. Any other 400 still
+ * triggers shutdown so we don't silently mask new bugs.
+ */
+export function classifyRejection(
+  err: unknown,
+  opts: RejectionPolicyOptions = {},
+): RejectionAction {
+  const isGrammy =
+    opts.isGrammyError != null
+      ? opts.isGrammyError(err)
+      : err instanceof GrammyError
+
+  if (!isGrammy) return 'shutdown'
+
+  const e = err as { error_code?: number; description?: string }
+  if (e.error_code !== 400) return 'shutdown'
+
+  const desc = (e.description ?? '').toLowerCase()
+  if (
+    desc.includes('message is not modified') ||
+    desc.includes('message to edit not found') ||
+    desc.includes('message to delete not found')
+  ) {
+    return 'log_only'
+  }
+  return 'shutdown'
+}

--- a/telegram-plugin/tests/boot-card-dedupe.test.ts
+++ b/telegram-plugin/tests/boot-card-dedupe.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Unit tests for `shouldSkipDuplicateBootCard` — the helper that prevents
+ * the boot path AND the bridge-reconnect path from BOTH posting a boot
+ * card on a single gateway lifetime.
+ *
+ * Regression for the duplicate-post observed in klanker's journal at
+ * 2026-04-26 11:19:47, where msgId 2245 was posted by the boot path and
+ * msgId 2248 by the bridge-reconnect path within 5 seconds.
+ */
+
+import { describe, it, expect } from 'bun:test'
+import { shouldSkipDuplicateBootCard } from '../gateway/boot-card.js'
+
+describe('shouldSkipDuplicateBootCard — boot path', () => {
+  it('never skips on the boot path, even when a card is already active', () => {
+    // Edge case: stale activeBootCard from a previous lifetime should not
+    // affect the boot path (it ran first; if anything's set, that's a bug).
+    const decision = shouldSkipDuplicateBootCard(
+      { activeBootCard: { messageId: 42 } },
+      'boot',
+    )
+    expect(decision.skip).toBe(false)
+  })
+
+  it('does not skip on the boot path with no active card', () => {
+    const decision = shouldSkipDuplicateBootCard({ activeBootCard: null }, 'boot')
+    expect(decision.skip).toBe(false)
+  })
+})
+
+describe('shouldSkipDuplicateBootCard — bridge-reconnect path', () => {
+  it('skips when the boot path already posted (active card present)', () => {
+    const decision = shouldSkipDuplicateBootCard(
+      { activeBootCard: { messageId: 2245 } },
+      'bridge-reconnect',
+    )
+    expect(decision.skip).toBe(true)
+    expect(decision.reason).toBeDefined()
+    expect(decision.reason).toContain('2245')
+  })
+
+  it('does not skip when the boot path produced no card', () => {
+    // Plausible scenario: boot path skipped due to no chat_id known yet,
+    // and bridge-reconnect arrives later with a chat_id from the IPC client.
+    const decision = shouldSkipDuplicateBootCard(
+      { activeBootCard: null },
+      'bridge-reconnect',
+    )
+    expect(decision.skip).toBe(false)
+  })
+})
+
+describe('shouldSkipDuplicateBootCard — reason format', () => {
+  it('includes the active messageId in the reason for observability', () => {
+    const decision = shouldSkipDuplicateBootCard(
+      { activeBootCard: { messageId: 9999 } },
+      'bridge-reconnect',
+    )
+    expect(decision.skip).toBe(true)
+    expect(decision.reason).toMatch(/msgId.*9999/)
+  })
+
+  it('omits reason when not skipping', () => {
+    const decision = shouldSkipDuplicateBootCard({ activeBootCard: null }, 'boot')
+    expect(decision.skip).toBe(false)
+    expect(decision.reason).toBeUndefined()
+  })
+})

--- a/telegram-plugin/tests/quota-cache.test.ts
+++ b/telegram-plugin/tests/quota-cache.test.ts
@@ -1,0 +1,168 @@
+/**
+ * Unit tests for the quota probe cache.
+ *
+ * The cache exists to break the rate-limit cascade caused by 4 agents
+ * × frequent boot card posts × Anthropic /api/oauth/usage rate limit
+ * (observed as 🟡 "rate limited" in production boot cards on 2026-04-26).
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test'
+import { mkdtempSync, rmSync, writeFileSync, existsSync, readFileSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+
+import { readQuotaCache, writeQuotaCache, DEFAULT_TTL_MS } from '../gateway/quota-cache.js'
+import type { ProbeResult } from '../gateway/boot-probes.js'
+
+let tmp: string
+let cachePath: string
+
+beforeEach(() => {
+  tmp = mkdtempSync(join(tmpdir(), 'quota-cache-test-'))
+  cachePath = join(tmp, 'quota-cache.json')
+})
+
+afterEach(() => {
+  rmSync(tmp, { recursive: true, force: true })
+})
+
+const okResult: ProbeResult = {
+  status: 'ok',
+  label: 'Quota',
+  detail: 'Sonnet 23% · resets in 2h 15m',
+}
+
+const failResult: ProbeResult = {
+  status: 'fail',
+  label: 'Quota',
+  detail: 'request failed: ECONNREFUSED',
+}
+
+const rateLimitedResult: ProbeResult = {
+  status: 'degraded',
+  label: 'Quota',
+  detail: 'rate limited',
+}
+
+const degradedSchemaUnknown: ProbeResult = {
+  status: 'degraded',
+  label: 'Quota',
+  detail: 'schema unknown — saving raw response',
+}
+
+// ── Read paths ─────────────────────────────────────────────────────────────
+
+describe('readQuotaCache', () => {
+  it('returns null when the cache file does not exist', () => {
+    expect(readQuotaCache({ path: cachePath })).toBeNull()
+  })
+
+  it('returns null when the cache file is invalid JSON', () => {
+    writeFileSync(cachePath, 'not valid json')
+    expect(readQuotaCache({ path: cachePath })).toBeNull()
+  })
+
+  it('returns the cached result when fresh', () => {
+    const now = 1_700_000_000_000
+    writeQuotaCache(okResult, { path: cachePath, now })
+    const result = readQuotaCache({ path: cachePath, now: now + 1000 })
+    expect(result).toEqual(okResult)
+  })
+
+  it('returns null when the cache is past its TTL', () => {
+    const now = 1_700_000_000_000
+    writeQuotaCache(okResult, { path: cachePath, now })
+    const result = readQuotaCache({ path: cachePath, now: now + DEFAULT_TTL_MS + 1 })
+    expect(result).toBeNull()
+  })
+
+  it('returns null when the clock went backwards', () => {
+    const now = 1_700_000_000_000
+    writeQuotaCache(okResult, { path: cachePath, now })
+    const result = readQuotaCache({ path: cachePath, now: now - 60_000 })
+    expect(result).toBeNull()
+  })
+
+  it('returns null when capturedAt is unparseable', () => {
+    writeFileSync(cachePath, JSON.stringify({
+      capturedAt: 'not-a-date',
+      ttlMs: 60_000,
+      result: okResult,
+    }))
+    expect(readQuotaCache({ path: cachePath })).toBeNull()
+  })
+
+  it('honors a custom ttlMs from the entry, not the global default', () => {
+    const now = 1_700_000_000_000
+    const shortTtl = 1000
+    writeQuotaCache(okResult, { path: cachePath, ttlMs: shortTtl, now })
+    expect(readQuotaCache({ path: cachePath, now: now + 500 })).toEqual(okResult)
+    expect(readQuotaCache({ path: cachePath, now: now + 1500 })).toBeNull()
+  })
+})
+
+// ── Write paths ─────────────────────────────────────────────────────────────
+
+describe('writeQuotaCache', () => {
+  it('writes a fresh entry to disk', () => {
+    writeQuotaCache(okResult, { path: cachePath })
+    expect(existsSync(cachePath)).toBe(true)
+    const parsed = JSON.parse(readFileSync(cachePath, 'utf8'))
+    expect(parsed.result).toEqual(okResult)
+    expect(parsed.ttlMs).toBe(DEFAULT_TTL_MS)
+    expect(parsed.capturedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/)
+  })
+
+  it('does NOT cache a fail result (so next boot retries)', () => {
+    writeQuotaCache(failResult, { path: cachePath })
+    expect(existsSync(cachePath)).toBe(false)
+  })
+
+  it('does NOT cache a rate-limited result (so next boot retries)', () => {
+    writeQuotaCache(rateLimitedResult, { path: cachePath })
+    expect(existsSync(cachePath)).toBe(false)
+  })
+
+  it('caches a degraded "schema unknown" result (it is informational, not transient)', () => {
+    writeQuotaCache(degradedSchemaUnknown, { path: cachePath })
+    expect(existsSync(cachePath)).toBe(true)
+    const parsed = JSON.parse(readFileSync(cachePath, 'utf8'))
+    expect(parsed.result).toEqual(degradedSchemaUnknown)
+  })
+
+  it('overwrites an existing entry', () => {
+    writeQuotaCache(okResult, { path: cachePath, now: 1_700_000_000_000 })
+    const newer: ProbeResult = { status: 'ok', label: 'Quota', detail: 'Sonnet 50%' }
+    writeQuotaCache(newer, { path: cachePath, now: 1_700_000_001_000 })
+    const parsed = JSON.parse(readFileSync(cachePath, 'utf8'))
+    expect(parsed.result).toEqual(newer)
+  })
+
+  it('writes mode 0600 (owner-only — file may contain quota detail)', () => {
+    writeQuotaCache(okResult, { path: cachePath })
+    const { statSync } = require('fs')
+    const mode = statSync(cachePath).mode & 0o777
+    expect(mode).toBe(0o600)
+  })
+
+  it('swallows IO errors (cache is best-effort)', () => {
+    // Try to write to a path whose parent doesn't exist AND can't be made
+    const bogusPath = '/proc/1/quota-cache.json'  // /proc/1 is read-only
+    expect(() => writeQuotaCache(okResult, { path: bogusPath })).not.toThrow()
+  })
+})
+
+// ── Round-trip ─────────────────────────────────────────────────────────────
+
+describe('readQuotaCache + writeQuotaCache round-trip', () => {
+  it('successfully roundtrips an ok result within TTL', () => {
+    const now = 1_700_000_000_000
+    writeQuotaCache(okResult, { path: cachePath, now })
+    expect(readQuotaCache({ path: cachePath, now: now + 60_000 })).toEqual(okResult)
+  })
+
+  it('a rate-limited result is not cached, so reads return null', () => {
+    writeQuotaCache(rateLimitedResult, { path: cachePath })
+    expect(readQuotaCache({ path: cachePath })).toBeNull()
+  })
+})

--- a/telegram-plugin/tests/unhandled-rejection-policy.test.ts
+++ b/telegram-plugin/tests/unhandled-rejection-policy.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Unit tests for `classifyRejection` — the policy that decides whether
+ * an unhandledRejection should crash the gateway or be logged-only.
+ *
+ * Regression for the klanker/lawgpt crash loops (issue #99 + sibling),
+ * where Telegram 400 "message is not modified" errors triggered
+ * `process.on('unhandledRejection')` → `shutdown()` → systemd restart →
+ * loop.
+ */
+
+import { describe, it, expect } from 'bun:test'
+import { GrammyError } from 'grammy'
+import { classifyRejection } from '../gateway/unhandled-rejection-policy.js'
+
+// ── Real GrammyError fixtures ──────────────────────────────────────────────
+
+function grammyError(error_code: number, description: string): GrammyError {
+  // GrammyError constructor signature: (message, payload, method, params)
+  // We only need error_code and description on the surface; the rest is fine
+  // as defaults.
+  const err = new GrammyError(
+    `Call to 'editMessageText' failed!`,
+    {
+      ok: false,
+      error_code,
+      description,
+    },
+    'editMessageText',
+    {} as never,
+  )
+  return err
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+describe('classifyRejection — benign Telegram 400s', () => {
+  it('returns "log_only" for "message is not modified" (klanker #99 + lawgpt)', () => {
+    const err = grammyError(
+      400,
+      'Bad Request: message is not modified: specified new message content and reply markup are exactly the same as a current content and reply markup of the message',
+    )
+    expect(classifyRejection(err)).toBe('log_only')
+  })
+
+  it('returns "log_only" for "message to edit not found"', () => {
+    const err = grammyError(400, 'Bad Request: message to edit not found')
+    expect(classifyRejection(err)).toBe('log_only')
+  })
+
+  it('returns "log_only" for "message to delete not found"', () => {
+    const err = grammyError(400, 'Bad Request: message to delete not found')
+    expect(classifyRejection(err)).toBe('log_only')
+  })
+
+  it('case-insensitive description match', () => {
+    const err = grammyError(400, 'Bad Request: MESSAGE IS NOT MODIFIED: blah')
+    expect(classifyRejection(err)).toBe('log_only')
+  })
+})
+
+describe('classifyRejection — genuine errors still crash', () => {
+  it('returns "shutdown" for plain Error', () => {
+    expect(classifyRejection(new Error('something blew up'))).toBe('shutdown')
+  })
+
+  it('returns "shutdown" for non-Error rejection', () => {
+    expect(classifyRejection('a string was thrown')).toBe('shutdown')
+    expect(classifyRejection(42)).toBe('shutdown')
+    expect(classifyRejection(null)).toBe('shutdown')
+    expect(classifyRejection(undefined)).toBe('shutdown')
+  })
+
+  it('returns "shutdown" for GrammyError 401 (auth) — must not be masked', () => {
+    const err = grammyError(401, 'Bad Request: unauthorized')
+    expect(classifyRejection(err)).toBe('shutdown')
+  })
+
+  it('returns "shutdown" for GrammyError 429 (rate limit) — should be retried not masked', () => {
+    const err = grammyError(429, 'Too Many Requests: retry after 5')
+    expect(classifyRejection(err)).toBe('shutdown')
+  })
+
+  it('returns "shutdown" for GrammyError 400 with NEW unknown description', () => {
+    const err = grammyError(400, 'Bad Request: chat not found')
+    expect(classifyRejection(err)).toBe('shutdown')
+  })
+
+  it('returns "shutdown" for GrammyError 500 server error', () => {
+    const err = grammyError(500, 'Internal Server Error')
+    expect(classifyRejection(err)).toBe('shutdown')
+  })
+})
+
+describe('classifyRejection — duck typing via injected detector', () => {
+  it('respects custom isGrammyError detector', () => {
+    const fakeGrammy = {
+      error_code: 400,
+      description: 'Bad Request: message is not modified',
+    }
+    const result = classifyRejection(fakeGrammy, {
+      isGrammyError: () => true,
+    })
+    expect(result).toBe('log_only')
+  })
+
+  it('treats unknown error type as shutdown when detector says false', () => {
+    const fake = {
+      error_code: 400,
+      description: 'message is not modified',
+    }
+    const result = classifyRejection(fake, {
+      isGrammyError: () => false,
+    })
+    expect(result).toBe('shutdown')
+  })
+})


### PR DESCRIPTION
## Summary

Three related fixes that together break the gateway crash loops observed today (klanker 54 restarts, lawgpt 14 restarts at minute scale across hours).

Closes #99 (klanker editMessageText "not modified" loop). Addresses the same crash family on lawgpt.

## Commits

1. **`fix(gateway): discriminate unhandledRejection`** — log benign Telegram 400s ("message is not modified", "message to edit not found", "message to delete not found") instead of shutting down. The set mirrors `retry-api-call.ts`. New module `unhandled-rejection-policy.ts` with pure `classifyRejection()` + 12 unit tests. **This commit alone breaks the loops** even if other unwrapped editMessageText sites still leak.

2. **`fix(boot-card): dedupe boot path + bridge-reconnect post`** — boot card was firing twice per gateway lifetime (boot path + bridge-reconnect path). Direct evidence: klanker msgId 2245 + 2248 within 5s at 11:19:47. New helper `shouldSkipDuplicateBootCard` with 6 unit tests.

3. **`fix(boot-card): cache quota probe`** — kill the 🟡 "rate limited" cascade caused by 4 agents × frequent boot-card posts × Anthropic /api/oauth/usage 429s. New `quota-cache.ts` (`~/.switchroom/quota-cache.json`, 5 min TTL, shared across agents, mode 0600). 429/fail results NOT cached so next boot retries fresh. 16 unit tests.

## Evidence

```
Apr 26 11:19:48 telegram gateway: boot-card: posted msgId=2245 chatId=...
Apr 26 11:19:48 telegram gateway: bridge-reconnect: posting boot card reason=graceful   ← duplicate
Apr 26 11:19:52 telegram gateway: boot-card: posted msgId=2248                          ← second card
Apr 26 11:19:56 telegram gateway: unhandled rejection: GrammyError: Call to 'editMessageText' failed!
                (400: Bad Request: message is not modified: ...)
Apr 26 11:19:56 telegram gateway: shutdown.clean_marker_skipped signal=unhandledRejection
Apr 26 11:19:59 systemd: Scheduled restart job, restart counter is at 1.
... 54 restart cycles ...
```

After this PR:
- The gateway logs the 400 and continues running (commit 1).
- Only one boot card is posted per gateway lifetime (commit 2).
- The probe doesn't hammer Anthropic's quota endpoint (commit 3).

## Test coverage

- `tests/unhandled-rejection-policy.test.ts` — 12 tests
- `tests/boot-card-dedupe.test.ts` — 6 tests
- `tests/quota-cache.test.ts` — 16 tests
- Full plugin suite: `bun test telegram-plugin` exit 0
- Build clean: `bun run build`

Buildkite pipeline will run the same tests on push; merge once green.

## Not in this PR

- Finding the actual unwrapped `editMessageText` source that leaked the "not modified" 400 in the first place. The unhandledRejection containment makes this defense-in-depth rather than urgent — log lines (`unhandled rejection (log_only)`) will tell us where it's coming from in production. Track-and-fix as a follow-up.
- Issue #101's broader `formatDuration` audit. Mostly already covered by #89 — the only `<1s` literal in the codebase is in `subagent-watcher.ts` and is escaped at use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)