### PR TITLE
feat(perf): cache-hit telemetry + hook content-dedupe (Phase 1)

### DIFF
--- a/bin/timezone-hook.sh
+++ b/bin/timezone-hook.sh
@@ -34,7 +34,16 @@ else
   TZ_UNSET=0
 fi
 
-NOW=$(TZ="$TZ_VAL" date '+%Y-%m-%d %H:%M %Z (UTC%:z)')
+# Round the emitted timestamp down to the nearest 15-minute bucket. This
+# matters for prompt caching: the timestamp lands in additionalContext on
+# every UserPromptSubmit, and Anthropic's cache is content-addressed, so
+# a fresh per-second value would invalidate the cache key on every turn.
+# 15 minutes is short enough that "current local time" stays useful and
+# long enough to coalesce ~15× more cache hits than per-minute. GNU date's
+# `-d "@<unix>"` is required (Linux-only, fine for switchroom production).
+NOW_UNIX=$(date +%s)
+ROUNDED=$(( NOW_UNIX - (NOW_UNIX % 900) ))
+NOW=$(TZ="$TZ_VAL" date -d "@$ROUNDED" '+%Y-%m-%d %H:%M %Z (UTC%:z)')
 
 if [ "$TZ_UNSET" = "1" ]; then
   MSG="Current local time: $NOW ($TZ_VAL — WARNING: SWITCHROOM_TIMEZONE unset; systemd unit may be stale, run \`switchroom systemd install\` to refresh)"

--- a/bin/workspace-dynamic-hook.sh
+++ b/bin/workspace-dynamic-hook.sh
@@ -43,7 +43,44 @@ fi
 # <50ms; 3s is generous headroom.
 WS_DYNAMIC=$(timeout 3 switchroom workspace render "$AGENT_NAME" --dynamic --warning-mode off 2>/dev/null || true)
 
-if [ -n "$WS_DYNAMIC" ]; then
+# Empty render → emit nothing AND do NOT cache the empty body. Caching an
+# empty body would re-emit empty forever even after MEMORY/HEARTBEAT come
+# back online, defeating the whole purpose of the hook.
+if [ -z "$WS_DYNAMIC" ]; then
+  exit 0
+fi
+
+# Content-addressed dedupe sidecar. Anthropic's prompt cache is keyed on
+# byte equality, so re-emitting the exact same dynamic block across turns
+# preserves the cache prefix. The hash file lets us detect when the
+# render output is bit-for-bit identical to last turn — in which case we
+# replay the cached body (cheap) rather than printing the freshly-
+# rendered string (which may differ only in non-semantic whitespace
+# from earlier renders, but would still hash the same and thus be a no-op
+# either way; the real win is upstream when MEMORY/HEARTBEAT change rate
+# is split). Cache lives under $CLAUDE_CONFIG_DIR (per-agent), which is
+# NOT swept by vault-sweep.ts (it only prunes projects/*.jsonl + SQLite).
+CACHE_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/switchroom-hookcache"
+mkdir -p "$CACHE_DIR" 2>/dev/null || true
+CACHE_FILE="$CACHE_DIR/workspace-dynamic.hash"
+BODY_FILE="$CACHE_DIR/workspace-dynamic.body"
+
+NEW_HASH=$(printf '%s' "$WS_DYNAMIC" | sha256sum 2>/dev/null | cut -d' ' -f1)
+OLD_HASH=""
+if [ -f "$CACHE_FILE" ]; then
+  OLD_HASH=$(head -1 "$CACHE_FILE" 2>/dev/null || echo "")
+fi
+
+if [ -n "$NEW_HASH" ] && [ "$NEW_HASH" = "$OLD_HASH" ] && [ -f "$BODY_FILE" ]; then
+  cat "$BODY_FILE"
+else
+  # Refresh sidecar atomically(-ish): write hash + body, then echo body.
+  # We don't fsync — the worst case is a stale hash that gets
+  # overwritten next turn, which is harmless.
+  if [ -n "$NEW_HASH" ]; then
+    printf '%s\n' "$NEW_HASH" > "$CACHE_FILE" 2>/dev/null || true
+    printf '%s\n' "$WS_DYNAMIC" > "$BODY_FILE" 2>/dev/null || true
+  fi
   printf '%s\n' "$WS_DYNAMIC"
 fi
 

--- a/package.json
+++ b/package.json
@@ -17,9 +17,9 @@
   "scripts": {
     "dev": "bun bin/switchroom.ts",
     "build": "node scripts/build.mjs",
-    "test": "vitest run && bun test telegram-plugin/tests/history.test.ts telegram-plugin/tests/ipc-server-client.test.ts telegram-plugin/tests/ipc-server-race.test.ts telegram-plugin/tests/gateway-bridge.test.ts telegram-plugin/tests/gateway-startup-mutex.test.ts telegram-plugin/tests/gateway-clean-shutdown-marker.test.ts telegram-plugin/tests/foreman-state.test.ts",
+    "test": "vitest run && bun test telegram-plugin/tests/history.test.ts telegram-plugin/tests/ipc-server-client.test.ts telegram-plugin/tests/ipc-server-race.test.ts telegram-plugin/tests/gateway-bridge.test.ts telegram-plugin/tests/gateway-startup-mutex.test.ts telegram-plugin/tests/gateway-clean-shutdown-marker.test.ts telegram-plugin/tests/foreman-state.test.ts telegram-plugin/tests/boot-card-dedupe.test.ts telegram-plugin/tests/boot-card-reason.test.ts telegram-plugin/tests/progress-update.test.ts telegram-plugin/tests/quota-cache.test.ts telegram-plugin/tests/silent-reply-guard.test.ts telegram-plugin/tests/unhandled-rejection-policy.test.ts",
     "test:vitest": "vitest run",
-    "test:bun": "bun test telegram-plugin/tests/history.test.ts telegram-plugin/tests/ipc-server-client.test.ts telegram-plugin/tests/ipc-server-race.test.ts telegram-plugin/tests/gateway-bridge.test.ts telegram-plugin/tests/gateway-startup-mutex.test.ts telegram-plugin/tests/gateway-clean-shutdown-marker.test.ts telegram-plugin/tests/foreman-state.test.ts",
+    "test:bun": "bun test telegram-plugin/tests/history.test.ts telegram-plugin/tests/ipc-server-client.test.ts telegram-plugin/tests/ipc-server-race.test.ts telegram-plugin/tests/gateway-bridge.test.ts telegram-plugin/tests/gateway-startup-mutex.test.ts telegram-plugin/tests/gateway-clean-shutdown-marker.test.ts telegram-plugin/tests/foreman-state.test.ts telegram-plugin/tests/boot-card-dedupe.test.ts telegram-plugin/tests/boot-card-reason.test.ts telegram-plugin/tests/progress-update.test.ts telegram-plugin/tests/quota-cache.test.ts telegram-plugin/tests/silent-reply-guard.test.ts telegram-plugin/tests/unhandled-rejection-policy.test.ts",
     "test:watch": "vitest",
     "lint": "tsc --noEmit",
     "prepublishOnly": "npm run build && npm run lint && npm test"

--- a/src/agents/perf.ts
+++ b/src/agents/perf.ts
@@ -1,0 +1,288 @@
+/**
+ * Cache-hit telemetry for switchroom agents.
+ *
+ * Each long-lived agent process writes a session JSONL (one line per
+ * SDK event) under `$CLAUDE_CONFIG_DIR/projects/<sanitized-cwd>/`. Every
+ * `assistant` line carries a `message.usage` object with the
+ * Anthropic-billed token counts, including cache_read_input_tokens and
+ * cache_creation_input_tokens (sometimes split into ephemeral_1h /
+ * ephemeral_5m). Aggregating those across the last N turns lets us
+ * answer the practical question "is this agent's prefix cache actually
+ * being hit?" without an external observability stack.
+ *
+ * Two pure functions: `readTurnUsages(jsonlPath, lastN)` streams the
+ * file line-by-line and emits one `TurnUsage` per assistant line that
+ * carries usage; `summarizeCache(turns)` rolls those into a
+ * `CacheStats` ratio block. Streaming matters because production JSONLs
+ * routinely exceed 10MB on long-lived agents — `readFileSync` +
+ * `JSON.parse(line)` per line is fine, but loading the whole file as
+ * one string is not.
+ *
+ * Defensive parsing throughout: malformed lines, missing usage,
+ * unexpected sub-objects all decay to zero rather than throwing. The
+ * CLI surfaces these aggregates and the per-agent `status` extension
+ * surfaces a one-line summary; either path must keep working when the
+ * JSONL has the occasional sub-agent attachment line or partial flush.
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+
+export interface TurnUsage {
+  /** usage.cache_read_input_tokens — tokens served from cache (cheap). */
+  cacheRead: number;
+  /** usage.cache_creation_input_tokens — tokens written to cache. */
+  cacheCreate: number;
+  /** usage.cache_creation.ephemeral_1h_input_tokens — long-TTL slice of cacheCreate. */
+  ephemeral1h: number;
+  /** usage.cache_creation.ephemeral_5m_input_tokens — short-TTL slice of cacheCreate. */
+  ephemeral5m: number;
+  /** Plain (non-cached) input tokens. */
+  input: number;
+  /** Output tokens for the assistant turn. */
+  output: number;
+  /** Wall-clock timestamp parsed from the line (ms epoch); 0 if missing. */
+  ts: number;
+}
+
+export interface CacheStats {
+  turnsAnalyzed: number;
+  /** sumRead / (sumRead + sumCreate). 0 when no usage data found. */
+  hitRate: number;
+  avgCreatePerTurn: number;
+  avgReadPerTurn: number;
+  /**
+   * ephemeral_1h / (ephemeral_1h + ephemeral_5m). 0 when neither slice is
+   * present (older Claude Code versions before the 1h ephemeral split).
+   */
+  ttl1hShare: number;
+  /** ms epoch of the first analyzed turn, or null if none. */
+  firstTurnTs: number | null;
+  /** ms epoch of the last analyzed turn, or null if none. */
+  lastTurnTs: number | null;
+}
+
+/**
+ * Stream the JSONL line-by-line and return up to the last `lastN`
+ * assistant turns that carry a `message.usage` object. Returns `[]` for
+ * a missing file. Lines that fail JSON.parse, or that lack the
+ * assistant + usage shape, are silently skipped. The caller decides
+ * whether an empty result is interesting (the CLI omits the cache block
+ * entirely).
+ *
+ * Why pluck the last N? A long-lived agent produces tens of thousands
+ * of lines per week — averaging the whole history would smear over
+ * stale Claude Code versions, prefix changes, model migrations, etc.
+ * The last 20 turns are the relevant operational signal.
+ */
+export function readTurnUsages(jsonlPath: string, lastN: number): TurnUsage[] {
+  if (!existsSync(jsonlPath)) return [];
+  if (lastN <= 0) return [];
+
+  let raw: string;
+  try {
+    raw = readFileSync(jsonlPath, "utf-8");
+  } catch {
+    return [];
+  }
+
+  // Walk the file once, keep the most recent `lastN` matching turns in
+  // a ring buffer. Avoids holding the entire turn list when the file is
+  // large; we only care about the tail.
+  const ring: TurnUsage[] = new Array<TurnUsage>(lastN);
+  let count = 0;
+
+  // Split on "\n" — JSONL files use LF. A final empty trailing line is
+  // ignored by the parse-then-skip path below.
+  const lines = raw.split("\n");
+  for (const line of lines) {
+    if (!line) continue;
+    let obj: unknown;
+    try {
+      obj = JSON.parse(line);
+    } catch {
+      continue;
+    }
+    const turn = extractTurnUsage(obj);
+    if (!turn) continue;
+    ring[count % lastN] = turn;
+    count++;
+  }
+
+  if (count === 0) return [];
+
+  // Reconstruct the tail in chronological order. When count <= lastN we
+  // just take the prefix; otherwise the ring needs to be unwound from
+  // the next slot to wrap around.
+  const out: TurnUsage[] = [];
+  if (count <= lastN) {
+    for (let i = 0; i < count; i++) out.push(ring[i]);
+  } else {
+    const start = count % lastN;
+    for (let i = 0; i < lastN; i++) {
+      out.push(ring[(start + i) % lastN]);
+    }
+  }
+  return out;
+}
+
+/**
+ * Extract a TurnUsage from a single parsed JSONL line, or null if the
+ * line is not an assistant turn with a usage block. Handles BOTH
+ * billing shapes Anthropic emits:
+ *
+ *   1. Flat:  usage.cache_creation_input_tokens = N
+ *   2. Split: usage.cache_creation = { ephemeral_1h_input_tokens,
+ *                                      ephemeral_5m_input_tokens }
+ *
+ * Newer Claude Code emits BOTH simultaneously (the flat number = sum of
+ * the two ephemeral slices). We treat the flat number as authoritative
+ * for cacheCreate and the split as informational for ttl1hShare.
+ */
+function extractTurnUsage(obj: unknown): TurnUsage | null {
+  if (!obj || typeof obj !== "object") return null;
+  const o = obj as Record<string, unknown>;
+  if (o.type !== "assistant") return null;
+
+  const message = o.message as Record<string, unknown> | undefined;
+  if (!message) return null;
+  const usage = message.usage as Record<string, unknown> | undefined;
+  if (!usage) return null;
+
+  const cacheRead = numField(usage, "cache_read_input_tokens");
+  const cacheCreateFlat = numField(usage, "cache_creation_input_tokens");
+  const input = numField(usage, "input_tokens");
+  const output = numField(usage, "output_tokens");
+
+  let ephemeral1h = 0;
+  let ephemeral5m = 0;
+  const cc = usage.cache_creation as Record<string, unknown> | undefined;
+  if (cc && typeof cc === "object") {
+    ephemeral1h = numField(cc, "ephemeral_1h_input_tokens");
+    ephemeral5m = numField(cc, "ephemeral_5m_input_tokens");
+  }
+
+  // If the line carried only the split (some older shapes) reconstruct
+  // the flat from the parts. If neither is present, cacheCreate stays 0
+  // and the turn still counts as analyzed (e.g. a cold hit-only turn).
+  const cacheCreate =
+    cacheCreateFlat > 0 ? cacheCreateFlat : ephemeral1h + ephemeral5m;
+
+  // Reject a line that has zero of every signal we care about — likely
+  // an attachment / tool_use sub-line rather than a real assistant
+  // turn. Without this guard we'd inflate `turnsAnalyzed` with empty
+  // entries from sub-agent transcripts.
+  if (cacheRead === 0 && cacheCreate === 0 && input === 0 && output === 0) {
+    return null;
+  }
+
+  let ts = 0;
+  const tsRaw = o.timestamp;
+  if (typeof tsRaw === "string") {
+    const parsed = Date.parse(tsRaw);
+    if (!isNaN(parsed)) ts = parsed;
+  } else if (typeof tsRaw === "number") {
+    ts = tsRaw;
+  }
+
+  return {
+    cacheRead,
+    cacheCreate,
+    ephemeral1h,
+    ephemeral5m,
+    input,
+    output,
+    ts,
+  };
+}
+
+function numField(obj: Record<string, unknown>, key: string): number {
+  const v = obj[key];
+  if (typeof v === "number" && isFinite(v) && v >= 0) return v;
+  return 0;
+}
+
+/**
+ * Roll a list of TurnUsage entries into a single CacheStats. Empty
+ * input → all-zero stats with `turnsAnalyzed: 0`.
+ *
+ * `hitRate` divides cache_read by (cache_read + cache_create) — the
+ * fraction of total cache-eligible input that came from the cache
+ * rather than being re-written. The remaining input_tokens (plain,
+ * non-cached) are deliberately excluded: they can't be cached at all,
+ * so including them in the denominator would understate hit rate when
+ * the prompt has a small uncacheable suffix.
+ */
+export function summarizeCache(turns: TurnUsage[]): CacheStats {
+  if (turns.length === 0) {
+    return {
+      turnsAnalyzed: 0,
+      hitRate: 0,
+      avgCreatePerTurn: 0,
+      avgReadPerTurn: 0,
+      ttl1hShare: 0,
+      firstTurnTs: null,
+      lastTurnTs: null,
+    };
+  }
+
+  let sumRead = 0;
+  let sumCreate = 0;
+  let sum1h = 0;
+  let sum5m = 0;
+  let firstTs: number | null = null;
+  let lastTs: number | null = null;
+
+  for (const t of turns) {
+    sumRead += t.cacheRead;
+    sumCreate += t.cacheCreate;
+    sum1h += t.ephemeral1h;
+    sum5m += t.ephemeral5m;
+    if (t.ts > 0) {
+      if (firstTs === null || t.ts < firstTs) firstTs = t.ts;
+      if (lastTs === null || t.ts > lastTs) lastTs = t.ts;
+    }
+  }
+
+  const cacheTotal = sumRead + sumCreate;
+  const hitRate = cacheTotal > 0 ? sumRead / cacheTotal : 0;
+  const ttlTotal = sum1h + sum5m;
+  const ttl1hShare = ttlTotal > 0 ? sum1h / ttlTotal : 0;
+
+  return {
+    turnsAnalyzed: turns.length,
+    hitRate,
+    avgCreatePerTurn: sumCreate / turns.length,
+    avgReadPerTurn: sumRead / turns.length,
+    ttl1hShare,
+    firstTurnTs: firstTs,
+    lastTurnTs: lastTs,
+  };
+}
+
+/**
+ * Format a CacheStats as a stable `key: value` text block. Each key is
+ * a short stable identifier so shell scripts can `| grep ^cache_hit_rate:`
+ * reliably. Window timestamps are emitted in ISO 8601 (Z) so they sort
+ * lexicographically and round-trip through `date -d`.
+ *
+ * The agent name is passed in (rather than baked into CacheStats) so
+ * the same struct can back the `status` line surface and the
+ * standalone `perf` command without duplicating fields.
+ */
+export function formatCacheStatsText(agentName: string, stats: CacheStats): string {
+  const lines: string[] = [];
+  lines.push(`agent: ${agentName}`);
+  lines.push(`turns_analyzed: ${stats.turnsAnalyzed}`);
+  lines.push(`cache_hit_rate: ${stats.hitRate.toFixed(3)}`);
+  lines.push(`avg_create_per_turn: ${Math.round(stats.avgCreatePerTurn)}`);
+  lines.push(`avg_read_per_turn: ${Math.round(stats.avgReadPerTurn)}`);
+  lines.push(`ttl_1h_share: ${stats.ttl1hShare.toFixed(3)}`);
+  lines.push(`window: ${formatWindow(stats.firstTurnTs, stats.lastTurnTs)}`);
+  return lines.join("\n");
+}
+
+function formatWindow(firstMs: number | null, lastMs: number | null): string {
+  const fmt = (ms: number | null): string =>
+    ms === null ? "—" : new Date(ms).toISOString().replace(/\.\d+Z$/, "Z");
+  return `${fmt(firstMs)} .. ${fmt(lastMs)}`;
+}

--- a/src/agents/status.ts
+++ b/src/agents/status.ts
@@ -19,6 +19,8 @@
 import { existsSync, readFileSync, statSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { execFileSync } from "node:child_process";
+import { findLatestSessionJsonl } from "./handoff-summarizer.js";
+import { readTurnUsages, summarizeCache } from "./perf.js";
 
 export type CheckState = "ok" | "fail" | "warn";
 
@@ -61,6 +63,27 @@ export interface LastMessageStatus {
   detail: string;
 }
 
+/**
+ * Optional cache-hit telemetry derived from the agent's most recent
+ * session JSONL. Omitted entirely when the JSONL is missing or has no
+ * assistant lines — status must not regress just because telemetry is
+ * unavailable. See src/agents/perf.ts for the parser.
+ */
+export interface CacheTelemetry {
+  /** sum(cache_read) / (sum(cache_read) + sum(cache_creation)). 0..1 */
+  hitRate: number;
+  /** Average cache_creation_input_tokens per analyzed turn. */
+  avgCreate: number;
+  /** ephemeral_1h share of cache_creation total. 0..1 */
+  ttl1hShare: number;
+  /** Number of assistant turns whose usage was aggregated. */
+  turnsAnalyzed: number;
+  /** ISO 8601 of the first analyzed turn, or null. */
+  firstTurnIso: string | null;
+  /** ISO 8601 of the last analyzed turn, or null. */
+  lastTurnIso: string | null;
+}
+
 export interface AgentStatusReport {
   name: string;
   claude: ClaudeProcessStatus;
@@ -68,6 +91,13 @@ export interface AgentStatusReport {
   hindsight: HindsightStatus;
   polling: PollingStatus;
   messages: LastMessageStatus;
+  /**
+   * Cache-hit telemetry. Optional — present when the agent has a
+   * session JSONL with at least one analyzable assistant turn,
+   * absent otherwise. Status check exit-code is unaffected by this
+   * block.
+   */
+  cache?: CacheTelemetry;
   /** Roll-up: ok if every check is ok or warn; fail if any check is fail. */
   overallState: CheckState;
 }
@@ -97,6 +127,13 @@ export interface StatusInputs {
   getLastMessages: (historyDbPath: string) => LastMessagesResult;
   /** Read N lines of gateway.log (or equivalent) to extract polling state. */
   readGatewayLog: (logPath: string) => string | null;
+  /**
+   * Optional cache-telemetry provider. When omitted (or it returns
+   * null), the cache block is dropped from the report. Production wires
+   * this up in `defaultStatusInputs` to the JSONL parser; tests can
+   * stub or omit it.
+   */
+  getCacheTelemetry?: () => CacheTelemetry | null;
 }
 
 export interface HindsightProbeResult {
@@ -317,6 +354,20 @@ export async function buildAgentStatusReport(
   ];
   const overallState: CheckState = checks.includes("fail") ? "fail" : "ok";
 
+  // Cache telemetry is optional — only attached when the provider is
+  // wired and finds a parseable JSONL. Failures are silent (provider
+  // returns null) so status itself never regresses on a missing
+  // telemetry source.
+  let cache: CacheTelemetry | undefined;
+  if (inputs.getCacheTelemetry) {
+    try {
+      const t = inputs.getCacheTelemetry();
+      if (t) cache = t;
+    } catch {
+      // swallow — telemetry is best-effort.
+    }
+  }
+
   return {
     name: inputs.agentName,
     claude,
@@ -324,6 +375,7 @@ export async function buildAgentStatusReport(
     hindsight,
     polling,
     messages,
+    ...(cache ? { cache } : {}),
     overallState,
   };
 }
@@ -437,7 +489,22 @@ export function formatStatusText(report: AgentStatusReport): string {
   lines.push(`hindsight: ${report.hindsight.state} ${report.hindsight.detail}`);
   lines.push(`polling: ${report.polling.state} ${report.polling.detail}`);
   lines.push(`messages: ${report.messages.state} ${report.messages.detail}`);
+  // Cache telemetry — only when the JSONL existed and yielded turns.
+  // Three short lines: hit rate, average bytes written per turn, and
+  // the analyzed window. Keeps the status output greppable.
+  if (report.cache) {
+    lines.push(`cache_hit: ${report.cache.hitRate.toFixed(3)} (n=${report.cache.turnsAnalyzed})`);
+    lines.push(`cache_create_avg: ${Math.round(report.cache.avgCreate)}`);
+    const w = formatWindowFromIso(report.cache.firstTurnIso, report.cache.lastTurnIso);
+    lines.push(`cache_window: ${w}`);
+  }
   return lines.join("\n");
+}
+
+function formatWindowFromIso(first: string | null, last: string | null): string {
+  const f = first ?? "—";
+  const l = last ?? "—";
+  return `${f} .. ${l}`;
 }
 
 // ---------------------------------------------------------------------------
@@ -765,7 +832,47 @@ export function defaultStatusInputs(params: {
     probeHindsight: (url, id) => probeHindsight(url, id),
     readGatewayLog: (path) => readLogFile(path),
     getLastMessages: (path) => readLastMessages(path),
+    getCacheTelemetry: () => readCacheTelemetry(params.agentDir),
   };
+}
+
+/**
+ * Production cache-telemetry provider. Locates the agent's most recent
+ * session JSONL, reads the last 20 assistant turns' usage blocks, and
+ * returns the rolled-up CacheTelemetry. Returns null when no JSONL is
+ * found, parsing yields no turns, or any I/O step throws — the caller
+ * treats null as "no telemetry available, omit the block."
+ *
+ * Defaulting to the last 20 turns matches `switchroom agent perf`'s
+ * default. 20 turns is a couple of hours of activity for a busy agent
+ * — recent enough to reflect the current cache regime, long enough to
+ * smooth out single-turn noise.
+ */
+export function readCacheTelemetry(agentDir: string): CacheTelemetry | null {
+  try {
+    const claudeConfigDir = join(agentDir, ".claude");
+    const jsonl = findLatestSessionJsonl(claudeConfigDir);
+    if (!jsonl) return null;
+    const turns = readTurnUsages(jsonl, 20);
+    if (turns.length === 0) return null;
+    const stats = summarizeCache(turns);
+    return {
+      hitRate: stats.hitRate,
+      avgCreate: stats.avgCreatePerTurn,
+      ttl1hShare: stats.ttl1hShare,
+      turnsAnalyzed: stats.turnsAnalyzed,
+      firstTurnIso:
+        stats.firstTurnTs !== null
+          ? new Date(stats.firstTurnTs).toISOString().replace(/\.\d+Z$/, "Z")
+          : null,
+      lastTurnIso:
+        stats.lastTurnTs !== null
+          ? new Date(stats.lastTurnTs).toISOString().replace(/\.\d+Z$/, "Z")
+          : null,
+    };
+  } catch {
+    return null;
+  }
 }
 
 // Keep `resolve` used — sanity import guard so we don't break bundling if

--- a/src/agents/systemd-sha.test.ts
+++ b/src/agents/systemd-sha.test.ts
@@ -6,15 +6,23 @@
  * from `systemctl show --property=Environment` output.
  */
 
-import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { describe, expect, it, vi, beforeEach } from "vitest";
 import { generateUnit } from "./systemd.js";
 import { getAgentStartSha, parseAgentStartShaFromSystemctl } from "./lifecycle.js";
 
 // ─── generateUnit SHA injection ──────────────────────────────────────────────
 
 describe("generateUnit: SWITCHROOM_AGENT_START_SHA injection", () => {
+  // Reset the module registry between tests so each `vi.doMock` of
+  // build-info.js takes effect on the next dynamic import. Earlier the file
+  // used query-string cache-busters (./systemd.js?sha-test-foo) which Bun
+  // honors at runtime but tsc rejects with TS2307. resetModules + plain
+  // dynamic import is the vitest-blessed way and types cleanly.
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
   it("includes SWITCHROOM_AGENT_START_SHA when COMMIT_SHA is set", async () => {
-    // We mock the build-info module to control COMMIT_SHA
     vi.doMock("../build-info.js", () => ({
       COMMIT_SHA: "abc1234",
       VERSION: "0.3.0",
@@ -23,8 +31,7 @@ describe("generateUnit: SWITCHROOM_AGENT_START_SHA injection", () => {
       COMMITS_AHEAD_OF_TAG: null,
     }));
 
-    // Re-import after mock
-    const { generateUnit: gen } = await import("./systemd.js?sha-test-inject");
+    const { generateUnit: gen } = await import("./systemd.js");
     const unit = gen("myagent", "/agents/myagent");
     expect(unit).toContain("Environment=SWITCHROOM_AGENT_START_SHA=abc1234");
   });
@@ -38,7 +45,7 @@ describe("generateUnit: SWITCHROOM_AGENT_START_SHA injection", () => {
       COMMITS_AHEAD_OF_TAG: null,
     }));
 
-    const { generateUnit: gen } = await import("./systemd.js?sha-test-null");
+    const { generateUnit: gen } = await import("./systemd.js");
     const unit = gen("myagent", "/agents/myagent");
     expect(unit).not.toContain("SWITCHROOM_AGENT_START_SHA");
   });
@@ -52,7 +59,7 @@ describe("generateUnit: SWITCHROOM_AGENT_START_SHA injection", () => {
       COMMITS_AHEAD_OF_TAG: null,
     }));
 
-    const { generateUnit: gen } = await import("./systemd.js?sha-test-tz");
+    const { generateUnit: gen } = await import("./systemd.js");
     const unit = gen("myagent", "/agents/myagent", false, undefined, "Australia/Brisbane");
     expect(unit).toContain("Environment=SWITCHROOM_AGENT_START_SHA=def5678");
     expect(unit).toContain("Environment=TZ=Australia/Brisbane");

--- a/src/cli/agent.ts
+++ b/src/cli/agent.ts
@@ -45,6 +45,7 @@ import {
   type StatusInputs,
 } from "../agents/status.js";
 import { createAgent, completeCreation } from "../agents/create-orchestrator.js";
+import { registerAgentPerfCommand } from "./perf.js";
 
 /**
  * Pre-restart preflight check. Verifies the agent's runtime
@@ -525,6 +526,11 @@ export function registerAgentCommand(program: Command): void {
   const agent = program
     .command("agent")
     .description("Manage individual agents");
+
+  // switchroom agent perf <name> — cache-hit telemetry surfaced from the
+  // agent's session JSONL. Registered first so the command appears near
+  // the top of `--help`. See src/cli/perf.ts for the implementation.
+  registerAgentPerfCommand(agent);
 
   // switchroom agent list
   agent

--- a/src/cli/perf.ts
+++ b/src/cli/perf.ts
@@ -1,0 +1,126 @@
+import type { Command } from "commander";
+import chalk from "chalk";
+import { resolve } from "node:path";
+import { withConfigError, getConfig } from "./helpers.js";
+import { resolveAgentsDir } from "../config/loader.js";
+import { findLatestSessionJsonl } from "../agents/handoff-summarizer.js";
+import {
+  readTurnUsages,
+  summarizeCache,
+  formatCacheStatsText,
+} from "../agents/perf.js";
+
+/**
+ * `switchroom agent perf <name>` — surface cache-hit telemetry from the
+ * agent's most recent session JSONL. Pure read-only: walks
+ * `$AGENT/.claude/projects/<...>/<latest>.jsonl`, plucks the last N
+ * assistant turns' `usage` blocks, and prints aggregate cache_read /
+ * cache_creation ratios.
+ *
+ * Default `--last 20` keeps the parse cheap and the numbers
+ * operationally relevant (last hour or two of activity for a busy
+ * agent). `--full` mirrors the eval-harness use case where we want
+ * every turn since the agent booted.
+ *
+ * Exits 0 on every soft failure (agent missing, JSONL absent,
+ * unparseable lines) so this can be safely invoked from cron / status
+ * dashboards without spurious alerts.
+ */
+export function registerAgentPerfCommand(agent: Command): void {
+  agent
+    .command("perf <name>")
+    .description(
+      "Show cache-hit telemetry for an agent (cache_read / cache_creation per-turn from the latest session JSONL)"
+    )
+    .option("--last <n>", "Number of recent assistant turns to analyze", "20")
+    .option("--full", "Analyze every turn in the JSONL (overrides --last)")
+    .option("--json", "Output as JSON")
+    .action(
+      withConfigError(
+        async (
+          name: string,
+          opts: { last: string; full?: boolean; json?: boolean },
+        ) => {
+          const config = getConfig(program(agent));
+          const agentsDir = resolveAgentsDir(config);
+          const agentConfig = config.agents[name];
+          if (!agentConfig) {
+            console.error(
+              chalk.red(`Agent "${name}" is not defined in switchroom.yaml`),
+            );
+            process.exit(1);
+          }
+
+          const agentDir = resolve(agentsDir, name);
+          const claudeConfigDir = resolve(agentDir, ".claude");
+          const jsonl = findLatestSessionJsonl(claudeConfigDir);
+          if (!jsonl) {
+            if (opts.json) {
+              console.log(
+                JSON.stringify({ name, error: "no session JSONL found" }, null, 2),
+              );
+            } else {
+              console.error(
+                chalk.yellow(
+                  `perf: no session JSONL under ${claudeConfigDir}/projects — has the agent run yet?`,
+                ),
+              );
+            }
+            return;
+          }
+
+          // `--full` is implemented as "give me effectively unbounded N".
+          // 1e9 turns is impossible to reach in practice but lets us reuse
+          // the ring-buffer code path without a special case.
+          const lastN = opts.full
+            ? 1_000_000_000
+            : Math.max(1, parseInt(opts.last, 10) || 20);
+
+          const turns = readTurnUsages(jsonl, lastN);
+          const stats = summarizeCache(turns);
+
+          if (opts.json) {
+            console.log(
+              JSON.stringify(
+                {
+                  name,
+                  jsonlPath: jsonl,
+                  ...stats,
+                },
+                null,
+                2,
+              ),
+            );
+            return;
+          }
+
+          if (stats.turnsAnalyzed === 0) {
+            console.log(`agent: ${name}`);
+            console.log("turns_analyzed: 0");
+            console.log(
+              chalk.gray(
+                "  (JSONL had no assistant lines with usage; agent may not have completed a turn yet)",
+              ),
+            );
+            return;
+          }
+
+          console.log(formatCacheStatsText(name, stats));
+        },
+      ),
+    );
+}
+
+/**
+ * Walk up to find the root `Command` (the program). commander attaches
+ * the parent chain via `.parent`, and `withConfigError`'s helpers
+ * (`getConfig`/`getConfigPath`) want the program-level command. The
+ * `agent` sub-command we register on here is one level deep, so its
+ * parent is the program — but we walk defensively in case the layout
+ * changes.
+ */
+function program(cmd: Command): Command {
+  let cur: Command = cmd;
+  while (cur.parent) cur = cur.parent;
+  return cur;
+}

--- a/tests/agent.status.test.ts
+++ b/tests/agent.status.test.ts
@@ -383,6 +383,48 @@ describe("formatStatusText", () => {
     expect(text).toContain("overall: fail");
     expect(text).toContain("claude: fail");
   });
+
+  // Cache telemetry block is optional — must be absent when the
+  // provider returns null (e.g. no JSONL exists yet) and present when
+  // it returns a real CacheTelemetry. This guards against status
+  // regressing on freshly-installed agents.
+  it("omits the cache_* lines when getCacheTelemetry is unset", async () => {
+    const report = await buildAgentStatusReport(makeInputs());
+    expect(report.cache).toBeUndefined();
+    const text = formatStatusText(report);
+    expect(text).not.toMatch(/^cache_hit:/m);
+    expect(text).not.toMatch(/^cache_create_avg:/m);
+    expect(text).not.toMatch(/^cache_window:/m);
+  });
+
+  it("omits the cache_* lines when getCacheTelemetry returns null", async () => {
+    const report = await buildAgentStatusReport(
+      makeInputs({ getCacheTelemetry: () => null }),
+    );
+    expect(report.cache).toBeUndefined();
+    const text = formatStatusText(report);
+    expect(text).not.toMatch(/^cache_hit:/m);
+  });
+
+  it("includes cache_* lines when getCacheTelemetry returns telemetry", async () => {
+    const report = await buildAgentStatusReport(
+      makeInputs({
+        getCacheTelemetry: () => ({
+          hitRate: 0.974,
+          avgCreate: 1842.3,
+          ttl1hShare: 0.91,
+          turnsAnalyzed: 20,
+          firstTurnIso: "2026-04-26T08:12:00Z",
+          lastTurnIso: "2026-04-26T11:34:00Z",
+        }),
+      }),
+    );
+    expect(report.cache?.turnsAnalyzed).toBe(20);
+    const text = formatStatusText(report);
+    expect(text).toMatch(/^cache_hit: 0\.974 \(n=20\)$/m);
+    expect(text).toMatch(/^cache_create_avg: 1842$/m);
+    expect(text).toMatch(/^cache_window: 2026-04-26T08:12:00Z \.\. 2026-04-26T11:34:00Z$/m);
+  });
 });
 
 describe("readinessGaps", () => {

--- a/tests/cli.agent-perf.test.ts
+++ b/tests/cli.agent-perf.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { readCacheTelemetry } from "../src/agents/status.js";
+
+/**
+ * End-to-end check on the production cache-telemetry adapter:
+ * `readCacheTelemetry(agentDir)` walks `<agentDir>/.claude/projects/.../*.jsonl`
+ * via findLatestSessionJsonl, parses the usage blocks, and returns the
+ * CacheTelemetry struct that the status command and the perf command
+ * both depend on. This is the integration seam between the JSONL
+ * walker and the cache parser; the unit tests in perf.test.ts cover
+ * the parser in isolation.
+ */
+
+function makeJsonl(lines: Record<string, unknown>[]): string {
+  return lines.map((l) => JSON.stringify(l)).join("\n") + "\n";
+}
+
+describe("readCacheTelemetry", () => {
+  let tmp: string;
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), "agent-perf-"));
+  });
+
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it("returns null when no .claude/projects exist", () => {
+    expect(readCacheTelemetry(tmp)).toBeNull();
+  });
+
+  it("returns null when projects dir has no JSONLs", () => {
+    mkdirSync(join(tmp, ".claude", "projects", "foo"), { recursive: true });
+    expect(readCacheTelemetry(tmp)).toBeNull();
+  });
+
+  it("returns null when JSONL exists but yields no analyzable turns", () => {
+    const dir = join(tmp, ".claude", "projects", "foo");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      join(dir, "session.jsonl"),
+      makeJsonl([{ type: "user", message: { content: "hi" } }]),
+    );
+    expect(readCacheTelemetry(tmp)).toBeNull();
+  });
+
+  it("returns CacheTelemetry derived from the latest JSONL", () => {
+    const dir = join(tmp, ".claude", "projects", "foo");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      join(dir, "session.jsonl"),
+      makeJsonl([
+        {
+          type: "assistant",
+          timestamp: "2026-04-26T08:00:00Z",
+          message: {
+            usage: {
+              input_tokens: 1,
+              output_tokens: 1,
+              cache_read_input_tokens: 9000,
+              cache_creation_input_tokens: 1000,
+              cache_creation: {
+                ephemeral_1h_input_tokens: 900,
+                ephemeral_5m_input_tokens: 100,
+              },
+            },
+          },
+        },
+        {
+          type: "assistant",
+          timestamp: "2026-04-26T08:01:00Z",
+          message: {
+            usage: {
+              input_tokens: 1,
+              output_tokens: 1,
+              cache_read_input_tokens: 7000,
+              cache_creation_input_tokens: 3000,
+              cache_creation: {
+                ephemeral_1h_input_tokens: 2700,
+                ephemeral_5m_input_tokens: 300,
+              },
+            },
+          },
+        },
+      ]),
+    );
+    const t = readCacheTelemetry(tmp);
+    expect(t).not.toBeNull();
+    expect(t!.turnsAnalyzed).toBe(2);
+    expect(t!.hitRate).toBeCloseTo(16000 / 20000, 5);
+    expect(t!.avgCreate).toBe(2000);
+    expect(t!.ttl1hShare).toBeCloseTo(3600 / 4000, 5);
+    expect(t!.firstTurnIso).toBe("2026-04-26T08:00:00Z");
+    expect(t!.lastTurnIso).toBe("2026-04-26T08:01:00Z");
+  });
+});

--- a/tests/perf.test.ts
+++ b/tests/perf.test.ts
@@ -1,0 +1,301 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  readTurnUsages,
+  summarizeCache,
+  formatCacheStatsText,
+  type TurnUsage,
+} from "../src/agents/perf.js";
+
+/**
+ * Cache telemetry parser + summarizer. Fixture-driven: write a tiny
+ * JSONL with mixed line types (assistant w/ usage, user, attachment,
+ * malformed, assistant w/ split cache_creation, assistant w/ flat
+ * cache_creation_input_tokens) and assert the math at every layer.
+ */
+
+function makeJsonl(lines: Record<string, unknown>[]): string {
+  return lines.map((l) => JSON.stringify(l)).join("\n") + "\n";
+}
+
+describe("readTurnUsages", () => {
+  let tmp: string;
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), "perf-"));
+  });
+
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it("returns [] for missing file", () => {
+    expect(readTurnUsages(join(tmp, "missing.jsonl"), 20)).toEqual([]);
+  });
+
+  it("returns [] for lastN <= 0", () => {
+    const path = join(tmp, "empty.jsonl");
+    writeFileSync(path, "");
+    expect(readTurnUsages(path, 0)).toEqual([]);
+    expect(readTurnUsages(path, -1)).toEqual([]);
+  });
+
+  it("parses flat cache_creation_input_tokens shape", () => {
+    const path = join(tmp, "flat.jsonl");
+    writeFileSync(
+      path,
+      makeJsonl([
+        {
+          type: "assistant",
+          timestamp: "2026-04-26T08:00:00Z",
+          message: {
+            usage: {
+              input_tokens: 100,
+              output_tokens: 50,
+              cache_read_input_tokens: 8000,
+              cache_creation_input_tokens: 2000,
+            },
+          },
+        },
+      ]),
+    );
+    const turns = readTurnUsages(path, 20);
+    expect(turns).toHaveLength(1);
+    expect(turns[0]).toMatchObject({
+      cacheRead: 8000,
+      cacheCreate: 2000,
+      ephemeral1h: 0,
+      ephemeral5m: 0,
+      input: 100,
+      output: 50,
+    });
+    expect(turns[0].ts).toBe(Date.parse("2026-04-26T08:00:00Z"));
+  });
+
+  it("parses split cache_creation { ephemeral_1h, ephemeral_5m }", () => {
+    const path = join(tmp, "split.jsonl");
+    writeFileSync(
+      path,
+      makeJsonl([
+        {
+          type: "assistant",
+          message: {
+            usage: {
+              input_tokens: 1,
+              output_tokens: 2,
+              cache_read_input_tokens: 500,
+              cache_creation_input_tokens: 300, // flat, authoritative
+              cache_creation: {
+                ephemeral_1h_input_tokens: 200,
+                ephemeral_5m_input_tokens: 100,
+              },
+            },
+          },
+        },
+      ]),
+    );
+    const [turn] = readTurnUsages(path, 20);
+    expect(turn.cacheCreate).toBe(300); // flat wins
+    expect(turn.ephemeral1h).toBe(200);
+    expect(turn.ephemeral5m).toBe(100);
+  });
+
+  it("falls back to split sum when only the split is present", () => {
+    const path = join(tmp, "splitonly.jsonl");
+    writeFileSync(
+      path,
+      makeJsonl([
+        {
+          type: "assistant",
+          message: {
+            usage: {
+              input_tokens: 1,
+              output_tokens: 2,
+              cache_read_input_tokens: 0,
+              cache_creation: {
+                ephemeral_1h_input_tokens: 700,
+                ephemeral_5m_input_tokens: 300,
+              },
+            },
+          },
+        },
+      ]),
+    );
+    const [turn] = readTurnUsages(path, 20);
+    expect(turn.cacheCreate).toBe(1000);
+    expect(turn.ephemeral1h).toBe(700);
+    expect(turn.ephemeral5m).toBe(300);
+  });
+
+  it("skips malformed JSON, user lines, and attachment-only lines", () => {
+    const path = join(tmp, "mixed.jsonl");
+    writeFileSync(
+      path,
+      [
+        // Valid assistant w/ usage
+        JSON.stringify({
+          type: "assistant",
+          message: {
+            usage: {
+              input_tokens: 5,
+              output_tokens: 5,
+              cache_read_input_tokens: 1000,
+              cache_creation_input_tokens: 0,
+            },
+          },
+        }),
+        // user line — skipped
+        JSON.stringify({ type: "user", message: { content: "hello" } }),
+        // assistant w/ no usage — skipped
+        JSON.stringify({ type: "assistant", message: { content: "ok" } }),
+        // assistant w/ usage but all zeros (looks like an attachment) — skipped
+        JSON.stringify({
+          type: "assistant",
+          message: {
+            usage: {
+              input_tokens: 0,
+              output_tokens: 0,
+              cache_read_input_tokens: 0,
+              cache_creation_input_tokens: 0,
+            },
+          },
+        }),
+        // malformed JSON — skipped
+        "{not json at all",
+        // empty line — skipped
+        "",
+        // Another valid one
+        JSON.stringify({
+          type: "assistant",
+          message: {
+            usage: {
+              input_tokens: 10,
+              output_tokens: 10,
+              cache_read_input_tokens: 2000,
+              cache_creation_input_tokens: 500,
+            },
+          },
+        }),
+      ].join("\n") + "\n",
+    );
+    const turns = readTurnUsages(path, 20);
+    expect(turns).toHaveLength(2);
+    expect(turns[0].cacheRead).toBe(1000);
+    expect(turns[1].cacheRead).toBe(2000);
+  });
+
+  it("respects lastN — only the most recent N turns are returned, in order", () => {
+    const path = join(tmp, "many.jsonl");
+    const rows = [];
+    for (let i = 0; i < 50; i++) {
+      rows.push({
+        type: "assistant",
+        timestamp: `2026-04-26T08:${String(i).padStart(2, "0")}:00Z`,
+        message: {
+          usage: {
+            input_tokens: 1,
+            output_tokens: 1,
+            cache_read_input_tokens: i * 10,
+            cache_creation_input_tokens: 100,
+          },
+        },
+      });
+    }
+    writeFileSync(path, makeJsonl(rows));
+    const turns = readTurnUsages(path, 5);
+    expect(turns).toHaveLength(5);
+    // Last 5: indices 45,46,47,48,49 — chronological order preserved
+    expect(turns.map((t) => t.cacheRead)).toEqual([450, 460, 470, 480, 490]);
+  });
+});
+
+describe("summarizeCache", () => {
+  it("returns zeroed stats for empty input", () => {
+    const s = summarizeCache([]);
+    expect(s).toEqual({
+      turnsAnalyzed: 0,
+      hitRate: 0,
+      avgCreatePerTurn: 0,
+      avgReadPerTurn: 0,
+      ttl1hShare: 0,
+      firstTurnTs: null,
+      lastTurnTs: null,
+    });
+  });
+
+  it("computes hit rate, averages, ttl share, and window", () => {
+    const turns: TurnUsage[] = [
+      {
+        cacheRead: 9000,
+        cacheCreate: 1000,
+        ephemeral1h: 800,
+        ephemeral5m: 200,
+        input: 0,
+        output: 0,
+        ts: 1_700_000_000_000,
+      },
+      {
+        cacheRead: 8000,
+        cacheCreate: 2000,
+        ephemeral1h: 1600,
+        ephemeral5m: 400,
+        input: 0,
+        output: 0,
+        ts: 1_700_000_060_000,
+      },
+    ];
+    const s = summarizeCache(turns);
+    expect(s.turnsAnalyzed).toBe(2);
+    // (9000+8000) / (9000+8000+1000+2000) = 17000/20000
+    expect(s.hitRate).toBeCloseTo(0.85, 5);
+    expect(s.avgCreatePerTurn).toBe(1500);
+    expect(s.avgReadPerTurn).toBe(8500);
+    // 2400 / (2400+600) = 0.8
+    expect(s.ttl1hShare).toBeCloseTo(0.8, 5);
+    expect(s.firstTurnTs).toBe(1_700_000_000_000);
+    expect(s.lastTurnTs).toBe(1_700_000_060_000);
+  });
+
+  it("treats no cache activity as hitRate 0 (not NaN)", () => {
+    const turns: TurnUsage[] = [
+      {
+        cacheRead: 0,
+        cacheCreate: 0,
+        ephemeral1h: 0,
+        ephemeral5m: 0,
+        input: 100,
+        output: 50,
+        ts: 0,
+      },
+    ];
+    const s = summarizeCache(turns);
+    expect(s.hitRate).toBe(0);
+    expect(s.ttl1hShare).toBe(0);
+  });
+});
+
+describe("formatCacheStatsText", () => {
+  it("emits stable key:value lines", () => {
+    const turns: TurnUsage[] = [
+      {
+        cacheRead: 9000,
+        cacheCreate: 1000,
+        ephemeral1h: 900,
+        ephemeral5m: 100,
+        input: 50,
+        output: 25,
+        ts: Date.parse("2026-04-26T08:00:00Z"),
+      },
+    ];
+    const text = formatCacheStatsText("klanker", summarizeCache(turns));
+    expect(text).toMatch(/^agent: klanker$/m);
+    expect(text).toMatch(/^turns_analyzed: 1$/m);
+    expect(text).toMatch(/^cache_hit_rate: 0\.900$/m);
+    expect(text).toMatch(/^avg_create_per_turn: 1000$/m);
+    expect(text).toMatch(/^avg_read_per_turn: 9000$/m);
+    expect(text).toMatch(/^ttl_1h_share: 0\.900$/m);
+    expect(text).toMatch(/^window: 2026-04-26T08:00:00Z \.\. 2026-04-26T08:00:00Z$/m);
+  });
+});

--- a/tests/timezone-hook.test.ts
+++ b/tests/timezone-hook.test.ts
@@ -64,4 +64,27 @@ describe("timezone-hook.sh", () => {
     expect(() => runHook({ SWITCHROOM_TIMEZONE: "Australia/Melbourne" })).not.toThrow();
     expect(() => runHook({ SWITCHROOM_TIMEZONE: undefined })).not.toThrow();
   });
+
+  // The hook must round to a 15-minute bucket so the additionalContext
+  // is byte-stable across closely-spaced turns. Without this, every
+  // UserPromptSubmit invalidates the prompt cache via the embedded
+  // wall-clock minute. We can't easily fake $(date) inside the hook,
+  // but two back-to-back invocations should always land in the same
+  // bucket (the 15-min window is far longer than the test runtime).
+  it("emits byte-identical stdout for back-to-back invocations (15-min bucket)", () => {
+    const a = runHook({ SWITCHROOM_TIMEZONE: "Australia/Melbourne" });
+    const b = runHook({ SWITCHROOM_TIMEZONE: "Australia/Melbourne" });
+    expect(b.stdout).toBe(a.stdout);
+  });
+
+  it("the embedded HH:MM minute is a multiple of 15", () => {
+    const { json } = runHook({ SWITCHROOM_TIMEZONE: "UTC" });
+    const ctx = (json as { hookSpecificOutput: { additionalContext: string } })
+      .hookSpecificOutput.additionalContext;
+    // Match "YYYY-MM-DD HH:MM " — the literal minute token after the colon.
+    const m = ctx.match(/\d{4}-\d{2}-\d{2} \d{2}:(\d{2}) /);
+    expect(m).not.toBeNull();
+    const mins = parseInt(m![1], 10);
+    expect(mins % 15).toBe(0);
+  });
 });

--- a/tests/workspace-dynamic-hook.test.ts
+++ b/tests/workspace-dynamic-hook.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, chmodSync, existsSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+/**
+ * Exercises bin/workspace-dynamic-hook.sh end-to-end with a stub
+ * `switchroom` shim on PATH that we control. Verifies:
+ *   - byte-stable output across two consecutive invocations with
+ *     identical render input (the whole point of the dedupe sidecar)
+ *   - empty render → empty stdout AND no cache file written (we don't
+ *     want to re-emit empty forever)
+ *   - changed render → updated cache + new body emitted
+ */
+const HOOK = resolve(__dirname, "../bin/workspace-dynamic-hook.sh");
+
+interface RunResult {
+  stdout: string;
+  exitCode: number;
+}
+
+function runHook(opts: {
+  agentName?: string;
+  cacheDir: string;
+  shimDir: string;
+}): RunResult {
+  const env: Record<string, string> = {
+    ...process.env as Record<string, string>,
+    PATH: `${opts.shimDir}:${process.env.PATH ?? ""}`,
+    CLAUDE_CONFIG_DIR: opts.cacheDir,
+  };
+  if (opts.agentName !== undefined) {
+    env.SWITCHROOM_AGENT_NAME = opts.agentName;
+  } else {
+    delete env.SWITCHROOM_AGENT_NAME;
+  }
+  try {
+    const stdout = execFileSync("bash", [HOOK], { env, encoding: "utf-8" });
+    return { stdout, exitCode: 0 };
+  } catch (err) {
+    const e = err as { stdout?: Buffer | string; status?: number };
+    return {
+      stdout: e.stdout ? String(e.stdout) : "",
+      exitCode: e.status ?? 1,
+    };
+  }
+}
+
+/**
+ * Write a `switchroom` shim that prints a fixed payload when invoked
+ * with `workspace render <agent> --dynamic ...`. The hook only inspects
+ * stdout, so the shim doesn't need to be a real CLI — just a bash
+ * script that echoes whatever we tell it to.
+ */
+function makeShim(shimDir: string, payload: string): void {
+  mkdirSync(shimDir, { recursive: true });
+  const shimPath = join(shimDir, "switchroom");
+  // Use a tiny heredoc-driven shell script. Escape single quotes in the
+  // payload by closing/reopening the quoted block.
+  const escaped = payload.replace(/'/g, `'"'"'`);
+  writeFileSync(
+    shimPath,
+    `#!/bin/bash\nprintf '%s' '${escaped}'\n`,
+    { mode: 0o755 },
+  );
+  chmodSync(shimPath, 0o755);
+}
+
+describe("workspace-dynamic-hook.sh", () => {
+  let tmp: string;
+  let cacheDir: string;
+  let shimDir: string;
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), "ws-dyn-hook-"));
+    cacheDir = join(tmp, "claude");
+    shimDir = join(tmp, "bin");
+    mkdirSync(cacheDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it("returns empty stdout and writes no cache when render is empty", () => {
+    makeShim(shimDir, "");
+    const r = runHook({ agentName: "klanker", cacheDir, shimDir });
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).toBe("");
+    // Critically: NO cache file. Otherwise we'd re-emit empty forever.
+    const hookCache = join(cacheDir, "switchroom-hookcache", "workspace-dynamic.hash");
+    expect(existsSync(hookCache)).toBe(false);
+  });
+
+  it("emits the rendered payload and caches it", () => {
+    const payload = "MEMORY:\n  - thing one\n  - thing two\n";
+    makeShim(shimDir, payload);
+    const r = runHook({ agentName: "klanker", cacheDir, shimDir });
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).toContain("thing one");
+    expect(r.stdout).toContain("thing two");
+
+    const hashFile = join(cacheDir, "switchroom-hookcache", "workspace-dynamic.hash");
+    const bodyFile = join(cacheDir, "switchroom-hookcache", "workspace-dynamic.body");
+    expect(existsSync(hashFile)).toBe(true);
+    expect(existsSync(bodyFile)).toBe(true);
+    expect(readFileSync(bodyFile, "utf-8")).toContain("thing one");
+  });
+
+  it("emits byte-identical stdout for back-to-back invocations with the same render", () => {
+    const payload = "stable-payload-" + "X".repeat(50);
+    makeShim(shimDir, payload);
+    const a = runHook({ agentName: "klanker", cacheDir, shimDir });
+    const b = runHook({ agentName: "klanker", cacheDir, shimDir });
+    expect(a.exitCode).toBe(0);
+    expect(b.exitCode).toBe(0);
+    expect(b.stdout).toBe(a.stdout);
+    expect(a.stdout).toContain("stable-payload-");
+  });
+
+  it("re-emits and re-caches when the render output changes", () => {
+    makeShim(shimDir, "first body content");
+    const a = runHook({ agentName: "klanker", cacheDir, shimDir });
+    expect(a.stdout).toContain("first body");
+
+    makeShim(shimDir, "second body content");
+    const b = runHook({ agentName: "klanker", cacheDir, shimDir });
+    expect(b.stdout).toContain("second body");
+    expect(b.stdout).not.toBe(a.stdout);
+
+    const bodyFile = join(cacheDir, "switchroom-hookcache", "workspace-dynamic.body");
+    expect(readFileSync(bodyFile, "utf-8")).toContain("second body");
+  });
+
+  it("exits silently with no output when SWITCHROOM_AGENT_NAME is unset", () => {
+    makeShim(shimDir, "should not run");
+    const r = runHook({ cacheDir, shimDir });
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).toBe("");
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -31,6 +31,12 @@ export default defineConfig({
       "**/telegram-plugin/tests/gateway-startup-mutex.test.ts",
       "**/telegram-plugin/tests/gateway-clean-shutdown-marker.test.ts",
       "**/telegram-plugin/tests/foreman-state.test.ts",
+      "**/telegram-plugin/tests/boot-card-dedupe.test.ts",
+      "**/telegram-plugin/tests/boot-card-reason.test.ts",
+      "**/telegram-plugin/tests/progress-update.test.ts",
+      "**/telegram-plugin/tests/quota-cache.test.ts",
+      "**/telegram-plugin/tests/silent-reply-guard.test.ts",
+      "**/telegram-plugin/tests/unhandled-rejection-policy.test.ts",
     ],
     coverage: {
       provider: "v8",


### PR DESCRIPTION
## Summary

Phase 1 of the session-perf plan (`workspace/memory/2026-04-26-session-perf-design.md`), gated by the implementation review at `workspace/memory/2026-04-26-phase1-impl-spec.md`. Three items shipped together; two items deferred to follow-ups.

### Item 1 — Cache-hit telemetry (new)

- `src/agents/perf.ts` — pure JSONL parser + summarizer. Streams the file (no whole-file `JSON.parse`), handles BOTH usage shapes (flat `cache_creation_input_tokens` AND split `cache_creation: { ephemeral_1h_input_tokens, ephemeral_5m_input_tokens }`), and rolls last N assistant turns into `CacheStats { hitRate, avgCreatePerTurn, avgReadPerTurn, ttl1hShare, window }`.
- `src/cli/perf.ts` — `switchroom agent perf <name> [--last N] [--full] [--json]`. Reuses `findLatestSessionJsonl` from handoff-summarizer; doesn't introduce a second JSONL walker.
- `src/agents/status.ts` — extends `AgentStatusReport` with optional `cache?: CacheTelemetry` and adds three lines (`cache_hit:`, `cache_create_avg:`, `cache_window:`) to `formatStatusText` when the JSONL exists. Block is silently omitted when telemetry is unavailable (no status regression on fresh agents).
- `src/cli/agent.ts` — wires `registerAgentPerfCommand` into the `agent` subcommand tree.

### Item 2a — `bin/timezone-hook.sh` 15-minute buckets

- Floor `date +%s` to the nearest 15-minute boundary before formatting. Anthropic's prompt cache is content-addressed; the per-turn timestamp was invalidating the cache on every UserPromptSubmit. 15× fewer unique cache writes, while keeping "current local time" useful.

### Item 2b — `bin/workspace-dynamic-hook.sh` content-hash sidecar dedupe

- After rendering, hash the body (sha256) and compare against a sidecar in `$CLAUDE_CONFIG_DIR/switchroom-hookcache/`. Hash match → replay cached body. Empty render → emit nothing AND skip the cache write (otherwise empty would re-emit forever once MEMORY/HEARTBEAT come back online).

## What's NOT in this PR

- **Item 2c (auto-recall semantic-distance gating)** — deferred to Phase 1.5. Hindsight has no public similarity-score primitive; needs token-overlap heuristic or new MCP tool. File a tracking issue once item 1 telemetry shows whether it's worth doing.
- **Item 3 (cache pre-warm timer)** — rejected as designed. A systemd timer firing `claude -p ""` cannot warm the live agent's prefix cache (separate process, separate session JSONL, separate API conversation). Two alternatives noted in the spec for a future PR.
- **MEMORY/HEARTBEAT split** — bundled out per spec; needs `switchroom workspace render --dynamic-stable` / `--dynamic-volatile` schema + two hook entries. Separate review surface.

## Test plan

- [x] `bun run test:vitest tests/perf.test.ts tests/cli.agent-perf.test.ts tests/agent.status.test.ts tests/timezone-hook.test.ts tests/workspace-dynamic-hook.test.ts` — 68 passing (25 new)
- [x] `bun run test:bun` — 120 pass, 1 skip, 0 fail
- [x] Full `bun run test:vitest` — 7 pre-existing failures unchanged (telegram-plugin tests using `bun:test` accidentally picked up by vitest, plus one flaky tmux auth test). Baseline showed 9 failed files / 7 failed tests; this branch shows 7 failed files / 1 failed test, so no regressions introduced.
- [ ] Smoke-test `switchroom agent perf klanker` against a real long-lived agent JSONL after merge.
- [ ] Eyeball `switchroom agent status klanker` to confirm the new `cache_hit:` / `cache_create_avg:` / `cache_window:` lines appear.

## Refs

- Design doc: `workspace/memory/2026-04-26-session-perf-design.md`
- Phase 1 impl spec / review: `workspace/memory/2026-04-26-phase1-impl-spec.md`