### PR TITLE
feat(hindsight-recall): inject active directives as separate top-of-prompt block

### DIFF
--- a/vendor/hindsight-memory/scripts/lib/client.py
+++ b/vendor/hindsight-memory/scripts/lib/client.py
@@ -129,6 +129,29 @@ class HindsightClient:
         }
         return self._request("POST", path, body, timeout=timeout)
 
+    def list_directives(
+        self,
+        bank_id: str,
+        active_only: bool = True,
+        timeout: int = 5,
+    ) -> dict:
+        """List directives for a bank.
+
+        Returns the raw API response dict with 'items' list. Each item has:
+        id, bank_id, name, content, priority, is_active, tags, created_at,
+        updated_at.
+
+        We intentionally do NOT pass tags or isolation_mode arguments — the
+        upstream `reflect` tool has a known bug (vectorize-io/hindsight#1269)
+        where tagged directives are dropped by isolation_mode filtering.
+        `list_directives` itself works correctly with no filters, so we keep
+        the call surface minimal.
+        """
+        path = f"/v1/default/banks/{urllib.parse.quote(bank_id, safe='')}/directives"
+        if active_only:
+            path = f"{path}?active_only=true"
+        return self._request("GET", path, body=None, timeout=timeout)
+
     def set_bank_mission(
         self, bank_id: str, mission: str, retain_mission: Optional[str] = None, timeout: int = 15
     ) -> dict:

--- a/vendor/hindsight-memory/scripts/lib/directives.py
+++ b/vendor/hindsight-memory/scripts/lib/directives.py
@@ -1,0 +1,119 @@
+"""Active directives fetching and formatting for the recall hook.
+
+Why this lives separately from `content.py`:
+  Hindsight's `reflect` MCP tool has an upstream bug
+  (vectorize-io/hindsight#1269) where tagged directives are silently dropped
+  from synthesis. Until that ships, we surface directives client-side as a
+  structurally distinct top-of-prompt block so the agent reads them every
+  turn — independent of whatever `reflect` does with them.
+
+  `list_directives` itself works correctly upstream — only `reflect` is
+  broken — so this is a pure client-side win.
+
+Failure mode: any error fetching directives (HTTP error, malformed
+response, timeout) returns an empty list and logs a single warn line to
+stderr. We never raise to the caller — directives are nice-to-have on the
+recall path; a directive-fetch failure must not kill the recall block.
+"""
+
+import sys
+from typing import Optional
+
+# Sanity cap on how many directives we ever inject into the prompt. Banks
+# with more active directives than this are pathological; truncate with a
+# footer so the agent knows there are more.
+MAX_DIRECTIVES = 15
+
+# Hard timeout for the list_directives call. The recall hook is on the
+# UserPromptSubmit critical path — we cannot block it for long.
+DIRECTIVES_TIMEOUT_SECONDS = 2
+
+
+def fetch_active_directives(client, bank_id: str, timeout: int = DIRECTIVES_TIMEOUT_SECONDS) -> list:
+    """Fetch active directives for a bank, sorted by priority (highest first).
+
+    Args:
+        client: A HindsightClient instance with a list_directives method.
+        bank_id: The bank to fetch directives from.
+        timeout: HTTP timeout in seconds.
+
+    Returns:
+        A list of directive dicts (each with id, name, content, priority,
+        tags, ...), sorted by priority descending. On any failure returns
+        an empty list and logs a single warn line to stderr — never raises.
+    """
+    try:
+        response = client.list_directives(bank_id=bank_id, active_only=True, timeout=timeout)
+    except Exception as e:
+        print(f"[Hindsight] list_directives failed for bank '{bank_id}': {e}", file=sys.stderr)
+        return []
+
+    if not isinstance(response, dict):
+        print(
+            f"[Hindsight] list_directives returned non-dict for bank '{bank_id}': "
+            f"{type(response).__name__}",
+            file=sys.stderr,
+        )
+        return []
+
+    items = response.get("items")
+    if not isinstance(items, list):
+        # Empty / malformed response — quiet success, no warn (banks with
+        # no directives are normal).
+        return []
+
+    # Filter to dicts only, then sort by priority descending. Treat missing
+    # priority as 0 so malformed entries sink to the bottom rather than
+    # crashing.
+    valid = [d for d in items if isinstance(d, dict)]
+    valid.sort(key=lambda d: d.get("priority", 0), reverse=True)
+    return valid
+
+
+def format_active_directives_block(directives: list, max_directives: int = MAX_DIRECTIVES) -> Optional[str]:
+    """Format directives into the <active_directives> block string.
+
+    Returns None if the list is empty — callers should omit the block
+    entirely rather than emitting an empty wrapper.
+
+    Format:
+        <active_directives>
+        The following are HARD RULES the agent must follow on this turn. ...
+
+        1. [P10] <name>: <content>
+        2. [P9] <name>: <content>
+        ...
+        (+N more, omitted)
+        </active_directives>
+    """
+    if not directives:
+        return None
+
+    total = len(directives)
+    truncated = directives[:max_directives]
+    omitted = total - len(truncated)
+
+    lines = [
+        "<active_directives>",
+        (
+            "The following are HARD RULES the agent must follow on this turn. "
+            "They are the bank's currently active directives, ordered by priority. "
+            "Apply them when formulating your response."
+        ),
+        "",
+    ]
+
+    for i, d in enumerate(truncated, start=1):
+        priority = d.get("priority", 0)
+        name = (d.get("name") or "").strip() or "(unnamed)"
+        content = (d.get("content") or "").strip()
+        # Content verbatim — directives are deliberately authored. Do not
+        # reformat or truncate.
+        lines.append(f"{i}. [P{priority}] {name}: {content}")
+
+    if omitted > 0:
+        lines.append("")
+        lines.append(f"(+{omitted} more, omitted)")
+
+    lines.append("</active_directives>")
+    return "\n".join(lines)

--- a/vendor/hindsight-memory/scripts/recall.py
+++ b/vendor/hindsight-memory/scripts/recall.py
@@ -37,6 +37,7 @@ from lib.content import (
     truncate_recall_query,
 )
 from lib.daemon import get_api_url
+from lib.directives import fetch_active_directives, format_active_directives_block
 from lib.state import write_state
 
 LAST_RECALL_STATE = "last_recall.json"
@@ -105,7 +106,18 @@ def main():
 
     debug_log(config, f"Recalling from bank '{bank_id}', query length: {len(query)}")
 
+    # Fetch active directives FIRST (independent of recall — even if recall
+    # finds no memories, an agent with active directives still needs them
+    # surfaced every turn). fetch_active_directives is failure-safe and
+    # returns [] on any error.
+    directives = fetch_active_directives(client, bank_id)
+    directives_block = format_active_directives_block(directives) if directives else None
+    if directives_block:
+        debug_log(config, f"Injecting {len(directives)} active directives")
+
     # Call Hindsight recall API
+    memories_block = None
+    result_count = 0
     try:
         response = client.recall(
             bank_id=bank_id,
@@ -115,29 +127,41 @@ def main():
             types=config.get("recallTypes"),
             timeout=10,
         )
+        results = response.get("results", [])
+        result_count = len(results)
+        if results:
+            debug_log(config, f"Injecting {result_count} memories")
+            memories_formatted = format_memories(results)
+            preamble = config.get("recallPromptPreamble", "")
+            current_time = format_current_time()
+            memories_block = (
+                f"<hindsight_memories>\n"
+                f"{preamble}\n"
+                f"Current time - {current_time}\n\n"
+                f"{memories_formatted}\n"
+                f"</hindsight_memories>"
+            )
+        else:
+            debug_log(config, "No memories found")
     except Exception as e:
         print(f"[Hindsight] Recall failed: {e}", file=sys.stderr)
+        # Fall through — we still want to emit the directives block if we
+        # have one, so a recall API failure doesn't blind the agent to
+        # its own active directives.
+
+    # If neither block has content, there's nothing to inject — exit
+    # silently to avoid emitting an empty hookSpecificOutput.
+    if not directives_block and not memories_block:
         return
 
-    results = response.get("results", [])
-    if not results:
-        debug_log(config, "No memories found")
-        return
-
-    debug_log(config, f"Injecting {len(results)} memories")
-
-    # Format context message — exact match of Openclaw's format
-    memories_formatted = format_memories(results)
-    preamble = config.get("recallPromptPreamble", "")
-    current_time = format_current_time()
-
-    context_message = (
-        f"<hindsight_memories>\n"
-        f"{preamble}\n"
-        f"Current time - {current_time}\n\n"
-        f"{memories_formatted}\n"
-        f"</hindsight_memories>"
-    )
+    # Compose final context. Directives block goes ABOVE memories so the
+    # agent reads HARD RULES before low-signal recall traces.
+    parts = []
+    if directives_block:
+        parts.append(directives_block)
+    if memories_block:
+        parts.append(memories_block)
+    context_message = "\n\n".join(parts)
 
     # Save last recall to state for diagnostics
     write_state(
@@ -146,7 +170,8 @@ def main():
             "context": context_message,
             "saved_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
             "bank_id": bank_id,
-            "result_count": len(results),
+            "result_count": result_count,
+            "directive_count": len(directives),
         },
     )
 

--- a/vendor/hindsight-memory/scripts/tests/test_directives.py
+++ b/vendor/hindsight-memory/scripts/tests/test_directives.py
@@ -1,0 +1,211 @@
+"""Tests for lib/directives.py (active-directives fetch + format).
+
+Stdlib-only (unittest) — matches the rest of the hindsight-memory scripts,
+which deliberately avoid third-party dependencies so the hooks run on a
+bare Python install.
+
+Run from the repo root:
+    python -m unittest discover -s vendor/hindsight-memory/scripts/tests -v
+"""
+
+import os
+import sys
+import unittest
+from io import StringIO
+from unittest.mock import patch
+
+# Ensure the scripts dir is importable so `lib.*` resolves.
+SCRIPTS_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if SCRIPTS_DIR not in sys.path:
+    sys.path.insert(0, SCRIPTS_DIR)
+
+from lib.directives import (  # noqa: E402
+    MAX_DIRECTIVES,
+    fetch_active_directives,
+    format_active_directives_block,
+)
+
+
+class _StubClient:
+    """Minimal HindsightClient stand-in for tests.
+
+    Captures the args list_directives was called with and returns either
+    a canned response or raises a configured exception.
+    """
+
+    def __init__(self, response=None, exc=None):
+        self._response = response
+        self._exc = exc
+        self.calls = []
+
+    def list_directives(self, bank_id, active_only=True, timeout=2):
+        self.calls.append({"bank_id": bank_id, "active_only": active_only, "timeout": timeout})
+        if self._exc is not None:
+            raise self._exc
+        return self._response
+
+
+def _directive(name, content, priority=5, tags=None):
+    """Build a synthetic directive dict matching the API shape."""
+    return {
+        "id": f"id-{name}",
+        "bank_id": "test-bank",
+        "name": name,
+        "content": content,
+        "priority": priority,
+        "is_active": True,
+        "tags": tags or [],
+        "created_at": "2026-01-01T00:00:00+00:00",
+        "updated_at": "2026-01-01T00:00:00+00:00",
+    }
+
+
+class FetchActiveDirectivesTests(unittest.TestCase):
+    def test_returns_priority_sorted_descending(self):
+        client = _StubClient(
+            response={
+                "items": [
+                    _directive("low", "low content", priority=1),
+                    _directive("high", "high content", priority=10),
+                    _directive("mid", "mid content", priority=5),
+                ]
+            }
+        )
+        result = fetch_active_directives(client, "test-bank")
+        self.assertEqual([d["name"] for d in result], ["high", "mid", "low"])
+
+    def test_passes_active_only_true(self):
+        client = _StubClient(response={"items": []})
+        fetch_active_directives(client, "test-bank")
+        self.assertEqual(len(client.calls), 1)
+        self.assertTrue(client.calls[0]["active_only"])
+        self.assertEqual(client.calls[0]["bank_id"], "test-bank")
+
+    def test_empty_items_returns_empty_list(self):
+        client = _StubClient(response={"items": []})
+        self.assertEqual(fetch_active_directives(client, "test-bank"), [])
+
+    def test_http_failure_returns_empty_and_warns(self):
+        client = _StubClient(exc=RuntimeError("HTTP 503 from /directives"))
+        with patch("sys.stderr", new=StringIO()) as fake_err:
+            result = fetch_active_directives(client, "test-bank")
+        self.assertEqual(result, [])
+        err_output = fake_err.getvalue()
+        self.assertIn("list_directives failed", err_output)
+        self.assertIn("test-bank", err_output)
+
+    def test_timeout_exception_returns_empty_no_raise(self):
+        client = _StubClient(exc=TimeoutError("timed out"))
+        with patch("sys.stderr", new=StringIO()):
+            # Must not raise.
+            result = fetch_active_directives(client, "test-bank")
+        self.assertEqual(result, [])
+
+    def test_non_dict_response_returns_empty_and_warns(self):
+        client = _StubClient(response=["not", "a", "dict"])
+        with patch("sys.stderr", new=StringIO()) as fake_err:
+            result = fetch_active_directives(client, "test-bank")
+        self.assertEqual(result, [])
+        self.assertIn("non-dict", fake_err.getvalue())
+
+    def test_missing_items_key_returns_empty_quietly(self):
+        # Banks-with-no-directives is a normal state, not a warn-worthy event.
+        client = _StubClient(response={"unrelated": "shape"})
+        with patch("sys.stderr", new=StringIO()) as fake_err:
+            result = fetch_active_directives(client, "test-bank")
+        self.assertEqual(result, [])
+        self.assertEqual(fake_err.getvalue(), "")
+
+    def test_malformed_directive_entries_filtered(self):
+        client = _StubClient(
+            response={
+                "items": [
+                    _directive("ok", "real content", priority=5),
+                    "not-a-dict",
+                    None,
+                ]
+            }
+        )
+        result = fetch_active_directives(client, "test-bank")
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["name"], "ok")
+
+    def test_missing_priority_treated_as_zero(self):
+        client = _StubClient(
+            response={
+                "items": [
+                    _directive("has-priority", "content", priority=3),
+                    {"name": "no-priority", "content": "content"},
+                ]
+            }
+        )
+        result = fetch_active_directives(client, "test-bank")
+        self.assertEqual([d["name"] for d in result], ["has-priority", "no-priority"])
+
+    def test_uses_short_timeout(self):
+        # The recall hook is on the UserPromptSubmit critical path —
+        # directive fetch must not block it.
+        client = _StubClient(response={"items": []})
+        fetch_active_directives(client, "test-bank")
+        self.assertLessEqual(client.calls[0]["timeout"], 5)
+
+
+class FormatActiveDirectivesBlockTests(unittest.TestCase):
+    def test_returns_none_for_empty_list(self):
+        self.assertIsNone(format_active_directives_block([]))
+
+    def test_formats_multiple_directives(self):
+        directives = [
+            _directive("trailer", "End every response with: [VERIFIED]", priority=10),
+            _directive("greeting", "Open with the user's first name.", priority=8),
+        ]
+        out = format_active_directives_block(directives)
+        self.assertIsNotNone(out)
+        self.assertTrue(out.startswith("<active_directives>"))
+        self.assertTrue(out.endswith("</active_directives>"))
+        self.assertIn("HARD RULES", out)
+        self.assertIn("1. [P10] trailer: End every response with: [VERIFIED]", out)
+        self.assertIn("2. [P8] greeting: Open with the user's first name.", out)
+
+    def test_content_is_verbatim(self):
+        directives = [_directive("verbatim", "Line one.\nLine two.\nLine three.", priority=5)]
+        out = format_active_directives_block(directives)
+        self.assertIn("Line one.\nLine two.\nLine three.", out)
+
+    def test_truncates_at_cap_with_footer(self):
+        # 20 synthetic directives — should truncate to MAX_DIRECTIVES with
+        # a "(+N more, omitted)" footer.
+        directives = [
+            _directive(f"d{i}", f"content {i}", priority=20 - i) for i in range(20)
+        ]
+        out = format_active_directives_block(directives)
+        # Cap should be 15 by default.
+        self.assertEqual(MAX_DIRECTIVES, 15)
+        self.assertIn("1. [P20] d0", out)
+        self.assertIn(f"{MAX_DIRECTIVES}. [P", out)
+        # 16th item should NOT appear.
+        self.assertNotIn(f"{MAX_DIRECTIVES + 1}. [P", out)
+        # Footer with the right omitted count.
+        self.assertIn(f"(+{20 - MAX_DIRECTIVES} more, omitted)", out)
+
+    def test_no_footer_when_under_cap(self):
+        directives = [_directive("only", "single", priority=5)]
+        out = format_active_directives_block(directives)
+        self.assertNotIn("more, omitted", out)
+
+    def test_handles_missing_name_and_content(self):
+        directives = [{"priority": 7}]
+        out = format_active_directives_block(directives)
+        self.assertIn("[P7] (unnamed):", out)
+
+    def test_custom_cap_respected(self):
+        directives = [_directive(f"d{i}", f"c{i}", priority=10) for i in range(5)]
+        out = format_active_directives_block(directives, max_directives=2)
+        self.assertIn("1. [P10] d0", out)
+        self.assertIn("2. [P10] d1", out)
+        self.assertNotIn("3. [P10] d2", out)
+        self.assertIn("(+3 more, omitted)", out)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/vendor/hindsight-memory/scripts/tests/test_recall_integration.py
+++ b/vendor/hindsight-memory/scripts/tests/test_recall_integration.py
@@ -1,0 +1,179 @@
+"""Integration tests for recall.py — block composition + ordering.
+
+Exercises the actual main() flow with stubbed dependencies so we can
+verify:
+  - The <active_directives> block is emitted ABOVE <hindsight_memories>
+  - Empty bank (no directives, no memories) → no output at all
+  - Active directives present but no memories → directives block alone
+  - Active memories present but no directives → unchanged legacy behavior
+  - Recall API failure with directives present → directives still emitted
+    (so a recall outage doesn't blind the agent to its own HARD RULES)
+
+Stdlib-only (unittest + mock).
+"""
+
+import io
+import json
+import os
+import sys
+import unittest
+from unittest.mock import patch
+
+SCRIPTS_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if SCRIPTS_DIR not in sys.path:
+    sys.path.insert(0, SCRIPTS_DIR)
+
+import recall  # noqa: E402
+
+
+def _directive(name, content, priority=5):
+    return {
+        "id": f"id-{name}",
+        "bank_id": "test-bank",
+        "name": name,
+        "content": content,
+        "priority": priority,
+        "is_active": True,
+        "tags": [],
+    }
+
+
+def _memory(text, mem_type="fact", mentioned_at="2026-01-01"):
+    return {"text": text, "type": mem_type, "mentioned_at": mentioned_at}
+
+
+class _FakeClient:
+    """Stand-in for HindsightClient with configurable responses."""
+
+    def __init__(self, directives=None, memories=None, recall_exc=None, list_exc=None):
+        self._directives = directives if directives is not None else []
+        self._memories = memories if memories is not None else []
+        self._recall_exc = recall_exc
+        self._list_exc = list_exc
+
+    def list_directives(self, bank_id, active_only=True, timeout=2):
+        if self._list_exc is not None:
+            raise self._list_exc
+        return {"items": list(self._directives)}
+
+    def recall(self, bank_id, query, max_tokens=1024, budget="mid", types=None, timeout=10):
+        if self._recall_exc is not None:
+            raise self._recall_exc
+        return {"results": list(self._memories)}
+
+
+def _run_main_with(client, prompt="What is the meaning of life?"):
+    """Invoke recall.main with a fake client and capture stdout JSON.
+
+    Returns (additional_context_string_or_None, raw_stdout).
+    """
+    hook_input = {
+        "prompt": prompt,
+        "session_id": "test-session",
+        "transcript_path": "",
+        "cwd": "/tmp",
+    }
+    config = {
+        "autoRecall": True,
+        "bankId": "test-bank",
+        "recallMaxTokens": 1024,
+        "recallBudget": "mid",
+        "recallContextTurns": 1,
+        "recallMaxQueryChars": 800,
+        "recallPromptPreamble": "",
+    }
+
+    stdout = io.StringIO()
+    stderr = io.StringIO()
+    with patch.object(recall, "load_config", return_value=config), patch.object(
+        recall, "get_api_url", return_value="http://localhost:18888"
+    ), patch.object(recall, "HindsightClient", return_value=client), patch.object(
+        recall, "ensure_bank_mission", return_value=None
+    ), patch.object(recall, "write_state", return_value=None), patch(
+        "sys.stdin", new=io.StringIO(json.dumps(hook_input))
+    ), patch("sys.stdout", new=stdout), patch("sys.stderr", new=stderr):
+        recall.main()
+
+    raw = stdout.getvalue()
+    if not raw.strip():
+        return None, raw
+    parsed = json.loads(raw)
+    return parsed["hookSpecificOutput"]["additionalContext"], raw
+
+
+class RecallIntegrationTests(unittest.TestCase):
+    def test_directives_block_appears_above_memories_block(self):
+        client = _FakeClient(
+            directives=[_directive("trailer", "End every response with: [VERIFIED]", priority=10)],
+            memories=[_memory("user prefers concise answers")],
+        )
+        ctx, _ = _run_main_with(client)
+        self.assertIsNotNone(ctx)
+        d_idx = ctx.find("<active_directives>")
+        m_idx = ctx.find("<hindsight_memories>")
+        self.assertGreaterEqual(d_idx, 0, "active_directives block missing")
+        self.assertGreaterEqual(m_idx, 0, "hindsight_memories block missing")
+        self.assertLess(d_idx, m_idx, "directives must come before memories")
+
+    def test_empty_bank_emits_no_output(self):
+        client = _FakeClient(directives=[], memories=[])
+        ctx, raw = _run_main_with(client)
+        self.assertIsNone(ctx)
+        self.assertEqual(raw.strip(), "")
+
+    def test_directives_only_emits_directives_block_alone(self):
+        client = _FakeClient(
+            directives=[_directive("trailer", "End every response with: [VERIFIED]", priority=10)],
+            memories=[],
+        )
+        ctx, _ = _run_main_with(client)
+        self.assertIsNotNone(ctx)
+        self.assertIn("<active_directives>", ctx)
+        self.assertNotIn("<hindsight_memories>", ctx)
+        self.assertIn("End every response with: [VERIFIED]", ctx)
+
+    def test_memories_only_unchanged_legacy_behavior(self):
+        # No directives → block omitted entirely (not an empty wrapper).
+        client = _FakeClient(directives=[], memories=[_memory("an old preference")])
+        ctx, _ = _run_main_with(client)
+        self.assertIsNotNone(ctx)
+        self.assertNotIn("<active_directives>", ctx)
+        self.assertIn("<hindsight_memories>", ctx)
+        self.assertIn("an old preference", ctx)
+
+    def test_recall_failure_with_directives_still_emits_directives(self):
+        # A recall API outage must NOT blind the agent to its HARD RULES.
+        client = _FakeClient(
+            directives=[_directive("trailer", "End every response with: [VERIFIED]", priority=10)],
+            memories=[],
+            recall_exc=RuntimeError("HTTP 503"),
+        )
+        ctx, _ = _run_main_with(client)
+        self.assertIsNotNone(ctx)
+        self.assertIn("<active_directives>", ctx)
+        self.assertNotIn("<hindsight_memories>", ctx)
+
+    def test_directives_failure_does_not_kill_recall(self):
+        # Symmetric: a list_directives failure must not block the recall
+        # block from being emitted.
+        client = _FakeClient(
+            directives=[],
+            memories=[_memory("legacy memory still useful")],
+            list_exc=RuntimeError("HTTP 500"),
+        )
+        ctx, _ = _run_main_with(client)
+        self.assertIsNotNone(ctx)
+        self.assertIn("<hindsight_memories>", ctx)
+        self.assertNotIn("<active_directives>", ctx)
+
+    def test_blocks_separated_by_blank_line(self):
+        client = _FakeClient(
+            directives=[_directive("rule", "do the thing", priority=5)],
+            memories=[_memory("a memory")],
+        )
+        ctx, _ = _run_main_with(client)
+        self.assertIn("</active_directives>\n\n<hindsight_memories>", ctx)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Why

Active directives in a Hindsight bank currently flow into the same `<hindsight_memories>` block as recall results. They get visually lost among low-signal recall traces, so an agent reading the per-turn context can easily miss a high-priority rule (e.g. "always cite sources", "always defer legal-strategy questions to <X>"). This is purely a presentation problem — the directives are stored correctly and `list_directives` returns them correctly — but the structural muddling shows up as inconsistent rule-following at agent runtime.

(Tangentially related: Hindsight's `reflect` tool has an upstream filter bug where tagged directives are silently dropped from synthesis. That's tracked separately. This PR is a pure client-side win that doesn't depend on the upstream fix landing.)

## What changes

- New `lib/directives.py`: `fetch_active_directives(client, bank_id)` calls `list_directives(active_only=True)` with failure-safe degradation (any error → return `[]`, log a single warn line, never raise).
- `format_active_directives_block(directives)` emits a structurally distinct `<active_directives>` block, priority-ordered, capped at top 15 with a `(+N more, omitted)` footer for pathological banks.
- `recall.py` calls both helpers and emits the directives block ABOVE the existing `<hindsight_memories>` block on every turn.
- A failed `recall` no longer blinds the agent to its own directives — directives still emit even if recall errors out.

## What does NOT change

- The `<hindsight_memories>` block format is untouched.
- Banks with no active directives produce no `<active_directives>` block (no empty wrapper).
- No new dependencies. No schema or API changes. No upstream Hindsight changes.

## Test plan

24 new tests across `tests/test_directives.py` and `tests/test_recall_integration.py`:

- `fetch_active_directives` returns priority-ordered list
- HTTP failure → returns `[]` with stderr warn, never raises
- Empty bank → no block emitted
- Cap at 15 with truncation footer
- Directive content rendered verbatim with `[P<priority>]` marker
- Block positioned ABOVE recall block in final hook output
- Recall failure still emits directives block (no regression)

```
$ python3 -m pytest vendor/hindsight-memory/scripts/tests/ -q
24 passed in 0.04s
```

## Risk

Monotonic behavior change — agents see MORE structured info, never less. Banks without directives are unaffected. Backward-compatible with any consumer of the existing `<hindsight_memories>` block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>