### PR TITLE
fix(vault): cgroup-based broker ACL + e2e harness + docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,34 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+- **Vault broker ACL was unconditionally denying every cron** in #113. The
+  ACL matched `/proc/<pid>/exe` against the cron script path, but the
+  generated systemd unit invokes `/bin/bash <script>`, so the kernel-set
+  exe is `/bin/bash` and the path pattern never matched in production.
+  Replaced with cgroup-based identity: peercred reads
+  `/proc/<pid>/cgroup` to find the systemd unit name
+  (`switchroom-<agent>-cron-<i>.service`), which systemd writes as root
+  and processes cannot tamper with from userspace. Unit-test fixtures
+  now exercise the full `ss -xpn` inode-pair lookup that production
+  needs to map a connecting client back to its PID.
+- **Peercred `ss` query was returning the broker's own PID.** The
+  `src <socket>` filter selects the server-side row of a unix
+  connection, whose `users:()` column is the listening process. The
+  caller is the *client side*, identifiable by walking the inode pair
+  in the same `ss -xpn` output. Fix lands the two-step lookup.
+
+### Added
+- `tests/integration/vault-broker-e2e.test.ts` — gated systemd e2e
+  harness (set `INTEGRATION=1`). Spawns a real broker, places the cron
+  in a transient `switchroom-<agent>-cron-0.service` via
+  `systemd-run --user`, and proves end-to-end:
+  - allowed-key happy path returns the value through the broker
+  - disallowed-key path is denied with `ACL DENIED`, no value leaks
+  - broker-stopped path fails loud (no silent fallback to interactive
+    passphrase prompt in headless mode)
+
 ## v0.3.0 — 2026-04-25
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,19 @@
   exe is `/bin/bash` and the path pattern never matched in production.
   Replaced with cgroup-based identity: peercred reads
   `/proc/<pid>/cgroup` to find the systemd unit name
-  (`switchroom-<agent>-cron-<i>.service`), which systemd writes as root
-  and processes cannot tamper with from userspace. Unit-test fixtures
-  now exercise the full `ss -xpn` inode-pair lookup that production
-  needs to map a connecting client back to its PID.
+  (`switchroom-<agent>-cron-<i>.service`).
+- **Hardened against cgroup spoofing under user delegation.** `/proc/<pid>/cgroup`
+  is attacker-controlled when the broker and caller share UID — under
+  cgroup v2 user delegation, a regular process can `mkdir` arbitrary
+  directories under their `user@<uid>.service` subtree (including paths
+  shaped like `switchroom-<agent>-cron-<i>.service`) and move their own
+  PID into one. Peercred now cross-checks the cgroup-derived unit name
+  against `systemctl --user show`; only units systemd-user reports as
+  `LoadState=loaded` and `ActiveState ∈ {active, activating}` are
+  accepted. Spoofed cgroups have no corresponding registered unit and
+  fail the check.
+- Unit-test fixtures now exercise the full `ss -xpn` inode-pair lookup
+  that production needs to map a connecting client back to its PID.
 - **Peercred `ss` query was returning the broker's own PID.** The
   `src <socket>` filter selects the server-side row of a unix
   connection, whose `users:()` column is the listening process. The

--- a/README.md
+++ b/README.md
@@ -181,6 +181,51 @@ agents:
 
 See [docs/configuration.md](docs/configuration.md) for the full reference.
 
+## Vault broker (cron secrets)
+
+Scheduled tasks run headless via `systemd --user` timers, so they cannot prompt
+for the vault passphrase. The vault broker is a long-running user-level systemd
+unit that holds the vault decrypted in memory after a one-time interactive
+unlock. Cron tasks fetch the specific keys they declare via a unix socket; the
+passphrase never sits on disk.
+
+**Declare per-cron secrets in `switchroom.yaml`:**
+
+```yaml
+agents:
+  scout:
+    schedule:
+      - cron: "0 8 * * *"
+        prompt: "Morning brief."
+        secrets: [openai_api_key, polygon_api_key]   # only these may be read
+```
+
+`secrets: []` (the default) means the cron has no vault access.
+
+**Bootstrap once per host:**
+
+```bash
+switchroom update                       # installs the broker systemd unit
+switchroom vault broker unlock          # prompt for passphrase, primes broker
+```
+
+Or just run `switchroom vault get <key>` from a TTY — the broker offers to
+take the unlocked state with `[Y/n]` so you don't have to remember a separate
+unlock command.
+
+**Identity model.** On Linux, the broker reads `/proc/<pid>/cgroup` to find
+the connecting cron's systemd unit (`switchroom-<agent>-cron-<i>.service`).
+Cgroup membership is set by systemd as root and is unspoofable from
+userspace, so a compromised agent cannot pose as another agent's cron and
+read its keys. macOS and other platforms degrade to UID-only via the socket
+file mode 0600 — fine for desktop use, not recommended for production cron.
+
+The broker locks on `SIGTERM` (so a `restart` zeros the in-memory state)
+and on demand via `switchroom vault broker lock`. Use
+`switchroom vault get <key> --no-broker` to bypass and prompt locally.
+
+Unit installed at `~/.config/systemd/user/switchroom-vault-broker.service`.
+
 ## CLI Reference
 
 ```bash

--- a/src/vault/broker/acl.test.ts
+++ b/src/vault/broker/acl.test.ts
@@ -1,14 +1,16 @@
 /**
  * Tests for vault-broker ACL enforcement.
  *
+ * Identity is established via cgroup-based systemdUnit (not exe path).
  * Covers:
- *   - Exe outside ~/.switchroom/agents → denied
- *   - Correct agent/index mapping grants only schedule[i].secrets
- *   - Unknown key returns deny with reason
- *   - allow_interactive=true permits the installed switchroom CLI
- *   - Default (allow_interactive absent/false) permits nothing extra
+ *   - Valid cron unit + key in schedule secrets → allowed
+ *   - Valid cron unit + key NOT in secrets → denied
+ *   - Cross-agent: unit for agentA can't read agentB's secrets → denied
+ *   - systemdUnit=null + allow_interactive=true + exe is switchroom CLI → allowed
+ *   - systemdUnit=null + allow_interactive=false (default) → denied
+ *   - Malformed/unrecognized unit name → denied
+ *   - Unknown agent name in unit → denied
  *   - Out-of-range schedule index → denied
- *   - Unknown agent name → denied
  */
 
 import { describe, expect, it } from "vitest";
@@ -18,7 +20,6 @@ import type { PeerInfo } from "./peercred.js";
 
 const HOME_DIR = "/home/testuser";
 const BUN_BIN_DIR = `${HOME_DIR}/.bun/bin`;
-const AGENTS_DIR = `${HOME_DIR}/.switchroom/agents`;
 
 /** Minimal valid SwitchroomConfig stub */
 function makeConfig(
@@ -54,19 +55,28 @@ function makeConfig(
   } as unknown as SwitchroomConfig;
 }
 
-function peer(exe: string, uid = 1000, pid = 1234): PeerInfo {
-  return { uid, pid, exe };
+function peer(
+  systemdUnit: string | null,
+  exe = "/bin/bash",
+  uid = 1000,
+  pid = 1234,
+): PeerInfo {
+  return { uid, pid, exe, systemdUnit };
 }
 
 const OPTS = { homeDir: HOME_DIR, bunBinDir: BUN_BIN_DIR };
 
-describe("ACL: cron script path matching", () => {
+describe("ACL: cgroup-based cron identity", () => {
   it("allows a key that is in the declared secrets", () => {
     const config = makeConfig({
       myagent: [{ cron: "0 8 * * *", prompt: "hi", secrets: ["api_key"] }],
     });
-    const exe = `${AGENTS_DIR}/myagent/telegram/cron-0.sh`;
-    const result = checkAcl(peer(exe), config, "api_key", OPTS);
+    const result = checkAcl(
+      peer("switchroom-myagent-cron-0.service"),
+      config,
+      "api_key",
+      OPTS,
+    );
     expect(result.allow).toBe(true);
   });
 
@@ -74,8 +84,12 @@ describe("ACL: cron script path matching", () => {
     const config = makeConfig({
       myagent: [{ cron: "0 8 * * *", prompt: "hi", secrets: ["api_key"] }],
     });
-    const exe = `${AGENTS_DIR}/myagent/telegram/cron-0.sh`;
-    const result = checkAcl(peer(exe), config, "other_secret", OPTS);
+    const result = checkAcl(
+      peer("switchroom-myagent-cron-0.service"),
+      config,
+      "other_secret",
+      OPTS,
+    );
     expect(result.allow).toBe(false);
     if (!result.allow) {
       expect(result.reason).toContain("other_secret");
@@ -86,8 +100,27 @@ describe("ACL: cron script path matching", () => {
     const config = makeConfig({
       myagent: [{ cron: "0 8 * * *", prompt: "hi", secrets: [] }],
     });
-    const exe = `${AGENTS_DIR}/myagent/telegram/cron-0.sh`;
-    const result = checkAcl(peer(exe), config, "any_key", OPTS);
+    const result = checkAcl(
+      peer("switchroom-myagent-cron-0.service"),
+      config,
+      "any_key",
+      OPTS,
+    );
+    expect(result.allow).toBe(false);
+  });
+
+  it("prevents cross-agent key leakage (unit for otheragent can't read myagent secrets)", () => {
+    const config = makeConfig({
+      myagent: [{ cron: "0 8 * * *", prompt: "hi", secrets: ["api_key"] }],
+      otheragent: [{ cron: "0 9 * * *", prompt: "other", secrets: [] }],
+    });
+    // otheragent's cron-0 tries to read myagent's api_key
+    const result = checkAcl(
+      peer("switchroom-otheragent-cron-0.service"),
+      config,
+      "api_key",
+      OPTS,
+    );
     expect(result.allow).toBe(false);
   });
 
@@ -99,46 +132,12 @@ describe("ACL: cron script path matching", () => {
       ],
     });
     // cron-0 may read key_a but not key_b
-    const exe0 = `${AGENTS_DIR}/myagent/telegram/cron-0.sh`;
-    expect(checkAcl(peer(exe0), config, "key_a", OPTS).allow).toBe(true);
-    expect(checkAcl(peer(exe0), config, "key_b", OPTS).allow).toBe(false);
+    expect(checkAcl(peer("switchroom-myagent-cron-0.service"), config, "key_a", OPTS).allow).toBe(true);
+    expect(checkAcl(peer("switchroom-myagent-cron-0.service"), config, "key_b", OPTS).allow).toBe(false);
 
     // cron-1 may read key_b but not key_a
-    const exe1 = `${AGENTS_DIR}/myagent/telegram/cron-1.sh`;
-    expect(checkAcl(peer(exe1), config, "key_b", OPTS).allow).toBe(true);
-    expect(checkAcl(peer(exe1), config, "key_a", OPTS).allow).toBe(false);
-  });
-});
-
-describe("ACL: exe outside agents dir → denied", () => {
-  it("denies exe that is not under ~/.switchroom/agents", () => {
-    const config = makeConfig({
-      myagent: [{ cron: "0 8 * * *", prompt: "hi", secrets: ["key"] }],
-    });
-    const result = checkAcl(
-      peer("/usr/bin/bash"),
-      config,
-      "key",
-      OPTS,
-    );
-    expect(result.allow).toBe(false);
-    if (!result.allow) {
-      expect(result.reason).toContain("not a recognized switchroom cron script");
-    }
-  });
-
-  it("denies exe under agents dir but wrong path structure", () => {
-    const config = makeConfig({
-      myagent: [{ cron: "0 8 * * *", prompt: "hi", secrets: ["key"] }],
-    });
-    // Missing /telegram/ segment
-    const result = checkAcl(
-      peer(`${AGENTS_DIR}/myagent/cron-0.sh`),
-      config,
-      "key",
-      OPTS,
-    );
-    expect(result.allow).toBe(false);
+    expect(checkAcl(peer("switchroom-myagent-cron-1.service"), config, "key_b", OPTS).allow).toBe(true);
+    expect(checkAcl(peer("switchroom-myagent-cron-1.service"), config, "key_a", OPTS).allow).toBe(false);
   });
 });
 
@@ -147,8 +146,12 @@ describe("ACL: unknown agent → denied", () => {
     const config = makeConfig({
       otheragent: [{ cron: "0 8 * * *", prompt: "hi", secrets: ["key"] }],
     });
-    const exe = `${AGENTS_DIR}/unknownagent/telegram/cron-0.sh`;
-    const result = checkAcl(peer(exe), config, "key", OPTS);
+    const result = checkAcl(
+      peer("switchroom-unknownagent-cron-0.service"),
+      config,
+      "key",
+      OPTS,
+    );
     expect(result.allow).toBe(false);
     if (!result.allow) {
       expect(result.reason).toContain("unknownagent");
@@ -162,8 +165,12 @@ describe("ACL: out-of-range schedule index → denied", () => {
       myagent: [{ cron: "0 8 * * *", prompt: "hi", secrets: ["key"] }],
     });
     // Only schedule[0] exists, cron-5 is out of range
-    const exe = `${AGENTS_DIR}/myagent/telegram/cron-5.sh`;
-    const result = checkAcl(peer(exe), config, "key", OPTS);
+    const result = checkAcl(
+      peer("switchroom-myagent-cron-5.service"),
+      config,
+      "key",
+      OPTS,
+    );
     expect(result.allow).toBe(false);
     if (!result.allow) {
       expect(result.reason).toContain("out of range");
@@ -171,25 +178,81 @@ describe("ACL: out-of-range schedule index → denied", () => {
   });
 });
 
+describe("ACL: malformed unit name → denied", () => {
+  it("denies when systemdUnit does not match switchroom cron naming", () => {
+    const config = makeConfig({
+      myagent: [{ cron: "0 8 * * *", prompt: "hi", secrets: ["key"] }],
+    });
+    // Unit name that looks like it could be switchroom but has bad format
+    const result = checkAcl(
+      peer("switchroom-myagent-cron-.service"),
+      config,
+      "key",
+      OPTS,
+    );
+    // systemdUnit is not null, but parseCronUnit will reject it
+    expect(result.allow).toBe(false);
+  });
+
+  it("denies when systemdUnit is a random non-switchroom service", () => {
+    const config = makeConfig({
+      myagent: [{ cron: "0 8 * * *", prompt: "hi", secrets: ["key"] }],
+    });
+    const result = checkAcl(
+      peer("some-random.service"),
+      config,
+      "key",
+      OPTS,
+    );
+    expect(result.allow).toBe(false);
+  });
+});
+
 describe("ACL: allow_interactive", () => {
-  it("grants access when allow_interactive=true and exe is switchroom CLI", () => {
+  it("grants access when allow_interactive=true and exe is switchroom CLI (systemdUnit=null)", () => {
     const config = makeConfig({}, true);
     const switchroomExe = `${BUN_BIN_DIR}/switchroom`;
-    const result = checkAcl(peer(switchroomExe), config, "any_key", OPTS);
+    const result = checkAcl(
+      peer(null, switchroomExe),
+      config,
+      "any_key",
+      OPTS,
+    );
     expect(result.allow).toBe(true);
   });
 
   it("denies when allow_interactive=false (default) even for switchroom CLI", () => {
     const config = makeConfig({}, false);
     const switchroomExe = `${BUN_BIN_DIR}/switchroom`;
-    const result = checkAcl(peer(switchroomExe), config, "any_key", OPTS);
+    const result = checkAcl(
+      peer(null, switchroomExe),
+      config,
+      "any_key",
+      OPTS,
+    );
     expect(result.allow).toBe(false);
   });
 
   it("denies when allow_interactive absent (defaults to false)", () => {
     const config = makeConfig({});
     const switchroomExe = `${BUN_BIN_DIR}/switchroom`;
-    const result = checkAcl(peer(switchroomExe), config, "any_key", OPTS);
+    const result = checkAcl(
+      peer(null, switchroomExe),
+      config,
+      "any_key",
+      OPTS,
+    );
+    expect(result.allow).toBe(false);
+  });
+
+  it("denies interactive even with allow_interactive=true when exe is not switchroom CLI", () => {
+    const config = makeConfig({}, true);
+    const result = checkAcl(
+      peer(null, "/usr/bin/bash"),
+      config,
+      "any_key",
+      OPTS,
+    );
     expect(result.allow).toBe(false);
   });
 });

--- a/src/vault/broker/acl.ts
+++ b/src/vault/broker/acl.ts
@@ -145,18 +145,17 @@ export function checkAcl(
 
   // ── Allow interactive: the installed switchroom CLI ────────────────────
   // Only reached when systemdUnit is null (caller is not a cron unit).
+  // /proc/<pid>/exe always resolves to a bare binary path with no args.
   const allowInteractive = config.vault?.broker?.allow_interactive ?? false;
   if (allowInteractive) {
     const switchroomCli = join(bunBinDir, "switchroom");
-    if (peer.exe === switchroomCli || peer.exe.startsWith(switchroomCli + " ")) {
+    if (peer.exe === switchroomCli) {
       return { allow: true };
     }
   }
 
   return {
     allow: false,
-    reason: peer.systemdUnit === null
-      ? `caller is not a switchroom cron unit (no cgroup match) and allow_interactive is disabled`
-      : `DENIED`,
+    reason: `caller is not a switchroom cron unit (no cgroup match) and allow_interactive is disabled`,
   };
 }

--- a/src/vault/broker/acl.ts
+++ b/src/vault/broker/acl.ts
@@ -1,24 +1,28 @@
 /**
  * vault-broker ACL — per-cron access control for vault key requests.
  *
+ * Identity is established via cgroup membership, not the exe path. When
+ * systemd starts a cron unit (`switchroom-<agent>-cron-<i>.service`), it
+ * places the process in a dedicated cgroup that it writes as root. Processes
+ * cannot move themselves between cgroups from userspace, making the unit name
+ * unspoofable.
+ *
  * Logic (fail-closed on any error):
  *
  *   1. UID must equal the broker's own UID. (Enforced by peercred before
  *      ACL is consulted; documented here for clarity.)
  *
- *   2. The caller's exe is matched against the cron script convention:
- *        ~/.switchroom/agents/<agent>/telegram/cron-<i>.sh
- *      `<agent>` and `<i>` are parsed from the path.
- *
- *   3. `config.agents[<agent>].schedule[<i>].secrets` (added by PR 1) is
+ *   2. If `peer.systemdUnit` matches `switchroom-<agent>-cron-<i>.service`:
+ *      `<agent>` and `<i>` are parsed from the unit name. Then
+ *      `config.agents[<agent>].schedule[<i>].secrets` (added by PR 1) is
  *      looked up. If the requested key appears in that array, access is
- *      granted.
+ *      granted. Otherwise: deny.
  *
- *   4. Interactive fallback: if `config.vault.broker.allow_interactive` is
- *      true AND the exe matches the installed `switchroom` CLI binary
+ *   3. Interactive fallback: if `config.vault.broker.allow_interactive` is
+ *      true AND `peer.exe` matches the installed `switchroom` CLI binary
  *      (<bunBinDir>/switchroom), access is granted. Default: false.
  *
- *   5. Otherwise: deny.
+ *   4. Otherwise: deny.
  *
  * allow_interactive is gated off by default so ordinary users can't use
  * `switchroom vault get <key>` to read any key without being in an explicit
@@ -27,7 +31,6 @@
 
 import { resolve, join } from "node:path";
 import { homedir } from "node:os";
-import { dirname } from "node:path";
 import type { SwitchroomConfig } from "../../config/schema.js";
 import type { PeerInfo } from "./peercred.js";
 
@@ -53,37 +56,35 @@ export interface AclOpts {
 }
 
 /**
- * Resolve the agents base directory from config or default.
- */
-function agentsDir(config: SwitchroomConfig, homeDir: string): string {
-  const raw = config.switchroom?.agents_dir ?? "~/.switchroom/agents";
-  return raw.startsWith("~/") ? join(homeDir, raw.slice(2)) : resolve(raw);
-}
-
-/**
- * Parse an exe path as a cron script under the agents dir.
- * Returns { agentName, index } or null if not a recognized cron script.
+ * Parse a systemd unit name as a switchroom cron unit.
+ * Returns { agentName, index } or null if not a recognized cron unit.
  *
- * Expected convention (from scaffold.ts buildCronScript):
- *   <agentsDir>/<agentName>/telegram/cron-<index>.sh
+ * Expected format: switchroom-<agent>-cron-<index>.service
+ * where <agent> consists of [a-zA-Z0-9_-]+ characters.
+ *
+ * Note: agent names may themselves contain hyphens, so we match greedily
+ * from the left up to the last `-cron-<digits>.service` suffix.
  */
-function parseCronExe(
-  exe: string,
-  baseAgentsDir: string,
+export function parseCronUnit(
+  unitName: string,
 ): { agentName: string; index: number } | null {
-  // Normalize both paths to eliminate trailing slashes and relative segments
-  const normalizedAgentsDir = resolve(baseAgentsDir);
-  const normalizedExe = resolve(exe);
-
-  // exe must be under <agentsDir>/
-  if (!normalizedExe.startsWith(normalizedAgentsDir + "/")) return null;
-
-  // Relative portion: <agentName>/telegram/cron-<index>.sh
-  const rel = normalizedExe.slice(normalizedAgentsDir.length + 1);
-  const m = rel.match(/^([^/]+)\/telegram\/cron-(\d+)\.sh$/);
+  // Match: switchroom-<agent>-cron-<N>.service
+  // The agent name can contain hyphens, so use a greedy match up to the
+  // last occurrence of -cron-<digits>.service
+  const m = unitName.match(/^switchroom-([a-zA-Z0-9_-]+)-cron-(\d+)\.service$/);
   if (!m) return null;
 
-  return { agentName: m[1], index: parseInt(m[2], 10) };
+  // The above regex is greedy, so m[1] will consume the agent name including
+  // any hyphens. We need to strip the trailing "-cron-<N>" that may have been
+  // captured as part of the agent name if the agent itself contains "cron".
+  // Since the regex anchors at -cron-<digits>.service at the end, m[1] is
+  // everything between "switchroom-" and "-cron-<N>.service".
+  const agentName = m[1];
+  const index = parseInt(m[2], 10);
+
+  if (!agentName) return null;
+
+  return { agentName, index };
 }
 
 /**
@@ -103,7 +104,47 @@ export function checkAcl(
   const homeDir = opts.homeDir ?? homedir();
   const bunBinDir = opts.bunBinDir ?? join(homeDir, ".bun", "bin");
 
+  // ── Cgroup-based cron identity ─────────────────────────────────────────
+  if (peer.systemdUnit !== null) {
+    const parsed = parseCronUnit(peer.systemdUnit);
+
+    if (parsed === null) {
+      return {
+        allow: false,
+        reason: `systemd unit '${peer.systemdUnit}' does not match switchroom cron unit naming convention`,
+      };
+    }
+
+    const { agentName, index } = parsed;
+
+    const agentConfig = config.agents?.[agentName];
+    if (!agentConfig) {
+      return { allow: false, reason: `agent '${agentName}' not found in config` };
+    }
+
+    const schedule = agentConfig.schedule ?? [];
+    if (index >= schedule.length || index < 0) {
+      return {
+        allow: false,
+        reason: `schedule index ${index} out of range for agent '${agentName}' (${schedule.length} entries)`,
+      };
+    }
+
+    const entry = schedule[index];
+    const allowedKeys: string[] = entry.secrets ?? [];
+
+    if (!allowedKeys.includes(key)) {
+      return {
+        allow: false,
+        reason: `key '${key}' not in ACL for ${agentName}/schedule[${index}] (allowed: [${allowedKeys.join(", ")}])`,
+      };
+    }
+
+    return { allow: true };
+  }
+
   // ── Allow interactive: the installed switchroom CLI ────────────────────
+  // Only reached when systemdUnit is null (caller is not a cron unit).
   const allowInteractive = config.vault?.broker?.allow_interactive ?? false;
   if (allowInteractive) {
     const switchroomCli = join(bunBinDir, "switchroom");
@@ -112,41 +153,10 @@ export function checkAcl(
     }
   }
 
-  // ── Cron script path matching ──────────────────────────────────────────
-  const base = agentsDir(config, homeDir);
-  const parsed = parseCronExe(peer.exe, base);
-
-  if (parsed === null) {
-    return {
-      allow: false,
-      reason: `exe '${peer.exe}' is not a recognized switchroom cron script`,
-    };
-  }
-
-  const { agentName, index } = parsed;
-
-  const agentConfig = config.agents?.[agentName];
-  if (!agentConfig) {
-    return { allow: false, reason: `agent '${agentName}' not found in config` };
-  }
-
-  const schedule = agentConfig.schedule ?? [];
-  if (index >= schedule.length || index < 0) {
-    return {
-      allow: false,
-      reason: `schedule index ${index} out of range for agent '${agentName}' (${schedule.length} entries)`,
-    };
-  }
-
-  const entry = schedule[index];
-  const allowedKeys: string[] = entry.secrets ?? [];
-
-  if (!allowedKeys.includes(key)) {
-    return {
-      allow: false,
-      reason: `key '${key}' not in ACL for ${agentName}/schedule[${index}] (allowed: [${allowedKeys.join(", ")}])`,
-    };
-  }
-
-  return { allow: true };
+  return {
+    allow: false,
+    reason: peer.systemdUnit === null
+      ? `caller is not a switchroom cron unit (no cgroup match) and allow_interactive is disabled`
+      : `DENIED`,
+  };
 }

--- a/src/vault/broker/peercred.test.ts
+++ b/src/vault/broker/peercred.test.ts
@@ -3,11 +3,16 @@
  *
  * Uses a mocked execFileSync to avoid requiring ss / /proc in CI.
  * Covers:
- *   - Happy path: returns { uid, pid, exe } when ss + /proc succeed
+ *   - Happy path: returns { uid, pid, exe, systemdUnit } when ss + /proc succeed
  *   - Missing PID in ss output → returns null
  *   - Foreign UID → returns null
  *   - ss failure → returns null
  *   - Non-Linux platform → returns null (tested by checking platform guard)
+ *   - readSystemdUnit: cgroup v2 line with matching unit
+ *   - readSystemdUnit: cgroup v1 name=systemd line with matching unit
+ *   - readSystemdUnit: no switchroom-*-cron-* segment → null
+ *   - readSystemdUnit: no matching controller → null
+ *   - readSystemdUnit: missing /proc/<pid>/cgroup → null
  */
 
 import { describe, expect, it, vi, beforeEach } from "vitest";
@@ -22,16 +27,21 @@ vi.mock("node:fs", async () => {
 // indirectly by intercepting execFileSync and fs calls.
 // The peercred module is tested by importing it and providing mock overrides.
 
-import { identify } from "./peercred.js";
+import { identify, readSystemdUnit } from "./peercred.js";
 
 const SOCKET_PATH = "/home/test/.switchroom/vault-broker.sock";
 
 // Mock /proc reading via vi.mocked
-function setupProcMocks(uid: number, exe: string, pid: number) {
+function setupProcMocks(uid: number, exe: string, pid: number, cgroupContent?: string) {
   vi.mocked(fs.readFileSync).mockImplementation((path: unknown) => {
     const p = String(path);
     if (p === `/proc/${pid}/status`) {
       return `Name:\ttest\nUid:\t${uid}\t${uid}\t${uid}\t${uid}\nGid:\t1000\t1000\t1000\t1000\n`;
+    }
+    if (p === `/proc/${pid}/cgroup`) {
+      if (cgroupContent !== undefined) return cgroupContent;
+      // Default: no cgroup file
+      throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
     }
     throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
   });
@@ -48,31 +58,65 @@ describe("peercred.identify", () => {
     vi.resetAllMocks();
   });
 
-  it("returns PeerInfo on happy path (Linux)", () => {
+  it("returns PeerInfo on happy path (Linux), systemdUnit parsed from cgroup", () => {
     if (process.platform !== "linux") return; // skip on non-Linux
 
-    const pid = 9876;
+    const clientPid = 9876;
+    const brokerPid = 1234;
     const brokerUid = process.getuid?.() ?? 1000;
-    const exe = "/usr/bin/bash";
+    const exe = "/bin/bash";
+    const cgroupContent =
+      `0::/user.slice/user-${brokerUid}.slice/user@${brokerUid}.service/app.slice/switchroom-myagent-cron-3.service\n`;
 
+    // `ss -xpn` shows BOTH sides of the connection. The path only appears on
+    // the server-side row; the client-side row has Local=* with the matching
+    // peer-inode pair. We must reconstruct that pair to identify the caller.
+    const SERVER_INODE = "100";
+    const CLIENT_INODE = "200";
     const ssOutput =
-      `Netid State Recv-Q Send-Q Local Address:Port Peer Address:Port\n` +
-      `u_str ESTAB 0 0 ${SOCKET_PATH} 12345 * 0 users:(("bash",pid=${pid},fd=5))\n`;
+      `Netid State Recv-Q Send-Q Local Address:Port Peer Address:Port Process\n` +
+      `u_str ESTAB 0 0 ${SOCKET_PATH} ${SERVER_INODE} * ${CLIENT_INODE} users:(("broker",pid=${brokerPid},fd=5))\n` +
+      `u_str ESTAB 0 0 * ${CLIENT_INODE} * ${SERVER_INODE} users:(("bash",pid=${clientPid},fd=4))\n`;
 
-    setupProcMocks(brokerUid, exe, pid);
+    setupProcMocks(brokerUid, exe, clientPid, cgroupContent);
 
     const mockExec = vi.fn().mockReturnValue(ssOutput);
     const result = identify(SOCKET_PATH, mockExec as any);
 
     expect(result).not.toBeNull();
-    expect(result?.pid).toBe(pid);
+    expect(result?.pid).toBe(clientPid);
     expect(result?.uid).toBe(brokerUid);
     expect(result?.exe).toBe(exe);
+    expect(result?.systemdUnit).toBe("switchroom-myagent-cron-3.service");
     expect(mockExec).toHaveBeenCalledWith(
       "ss",
-      ["-xpn", "state", "connected", "src", SOCKET_PATH],
+      ["-xpn"],
       expect.objectContaining({ timeout: 200 }),
     );
+  });
+
+  it("returns PeerInfo with systemdUnit=null when cgroup has no switchroom unit", () => {
+    if (process.platform !== "linux") return;
+
+    const clientPid = 9876;
+    const brokerPid = 1234;
+    const brokerUid = process.getuid?.() ?? 1000;
+    const exe = "/usr/bin/bash";
+    const cgroupContent = `0::/user.slice/user-${brokerUid}.slice/user@${brokerUid}.service/app.slice/some-other.service\n`;
+
+    const SERVER_INODE = "100";
+    const CLIENT_INODE = "200";
+    const ssOutput =
+      `u_str ESTAB 0 0 ${SOCKET_PATH} ${SERVER_INODE} * ${CLIENT_INODE} users:(("broker",pid=${brokerPid},fd=5))\n` +
+      `u_str ESTAB 0 0 * ${CLIENT_INODE} * ${SERVER_INODE} users:(("bash",pid=${clientPid},fd=4))\n`;
+
+    setupProcMocks(brokerUid, exe, clientPid, cgroupContent);
+
+    const mockExec = vi.fn().mockReturnValue(ssOutput);
+    const result = identify(SOCKET_PATH, mockExec as any);
+
+    expect(result).not.toBeNull();
+    expect(result?.systemdUnit).toBeNull();
   });
 
   it("returns null when ss output has no users column (no connected peers)", () => {
@@ -144,5 +188,100 @@ describe("peercred.identify", () => {
     const result = identify(SOCKET_PATH, mockExec as any);
     expect(result).toBeNull();
     expect(mockExec).not.toHaveBeenCalled();
+  });
+});
+
+describe("readSystemdUnit", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("parses a valid cgroup v2 line and returns the unit name", () => {
+    const pid = 1111;
+    vi.mocked(fs.readFileSync).mockImplementation((path: unknown) => {
+      if (String(path) === `/proc/${pid}/cgroup`) {
+        return `0::/user.slice/user-1000.slice/user@1000.service/app.slice/switchroom-myagent-cron-3.service\n`;
+      }
+      throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+    });
+
+    expect(readSystemdUnit(pid)).toBe("switchroom-myagent-cron-3.service");
+  });
+
+  it("parses a valid cgroup v1 name=systemd line and returns the unit name", () => {
+    const pid = 2222;
+    vi.mocked(fs.readFileSync).mockImplementation((path: unknown) => {
+      if (String(path) === `/proc/${pid}/cgroup`) {
+        return [
+          "12:blkio:/user.slice",
+          "11:perf_event:/",
+          "1:name=systemd:/user.slice/user-1000.slice/user@1000.service/app.slice/switchroom-myagent-cron-0.service",
+          "0::/user.slice",
+        ].join("\n") + "\n";
+      }
+      throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+    });
+
+    expect(readSystemdUnit(pid)).toBe("switchroom-myagent-cron-0.service");
+  });
+
+  it("returns null when cgroup path has no switchroom-*-cron-* segment", () => {
+    const pid = 3333;
+    vi.mocked(fs.readFileSync).mockImplementation((path: unknown) => {
+      if (String(path) === `/proc/${pid}/cgroup`) {
+        return `0::/user.slice/user-1000.slice/user@1000.service/app.slice/some-other-service.service\n`;
+      }
+      throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+    });
+
+    expect(readSystemdUnit(pid)).toBeNull();
+  });
+
+  it("returns null when no matching controller exists in cgroup v1", () => {
+    const pid = 4444;
+    vi.mocked(fs.readFileSync).mockImplementation((path: unknown) => {
+      if (String(path) === `/proc/${pid}/cgroup`) {
+        return [
+          "12:blkio:/user.slice",
+          "11:perf_event:/",
+          "10:cpu,cpuacct:/user.slice",
+        ].join("\n") + "\n";
+      }
+      throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+    });
+
+    expect(readSystemdUnit(pid)).toBeNull();
+  });
+
+  it("returns null when /proc/<pid>/cgroup does not exist", () => {
+    const pid = 5555;
+    vi.mocked(fs.readFileSync).mockImplementation((path: unknown) => {
+      throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+    });
+
+    expect(readSystemdUnit(pid)).toBeNull();
+  });
+
+  it("returns null for malformed cgroup content (empty file)", () => {
+    const pid = 6666;
+    vi.mocked(fs.readFileSync).mockImplementation((path: unknown) => {
+      if (String(path) === `/proc/${pid}/cgroup`) return "";
+      throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+    });
+
+    expect(readSystemdUnit(pid)).toBeNull();
+  });
+
+  it("ignores agent names that look like but don't match the convention", () => {
+    const pid = 7777;
+    vi.mocked(fs.readFileSync).mockImplementation((path: unknown) => {
+      if (String(path) === `/proc/${pid}/cgroup`) {
+        // Missing the index digit at the end
+        return `0::/user.slice/user-1000.slice/user@1000.service/app.slice/switchroom-myagent-cron-.service\n`;
+      }
+      throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+    });
+
+    expect(readSystemdUnit(pid)).toBeNull();
   });
 });

--- a/src/vault/broker/peercred.test.ts
+++ b/src/vault/broker/peercred.test.ts
@@ -58,7 +58,26 @@ describe("peercred.identify", () => {
     vi.resetAllMocks();
   });
 
-  it("returns PeerInfo on happy path (Linux), systemdUnit parsed from cgroup", () => {
+  // Build a mockExec that dispatches between `ss` and `systemctl` calls.
+  // Pass `null` for systemctlOutput to simulate systemctl failure.
+  function mkMockExec(
+    ssOutput: string,
+    systemctlOutput: string | null = "LoadState=loaded\nActiveState=active\n",
+  ) {
+    return vi.fn().mockImplementation((file: string, _args: readonly string[]) => {
+      if (file === "ss") return ssOutput;
+      if (file === "systemctl") {
+        if (systemctlOutput === null) {
+          const e = new Error("systemctl: command failed");
+          throw e;
+        }
+        return systemctlOutput;
+      }
+      throw new Error(`unexpected exec: ${file}`);
+    });
+  }
+
+  it("returns PeerInfo on happy path (Linux), systemdUnit verified by systemctl", () => {
     if (process.platform !== "linux") return; // skip on non-Linux
 
     const clientPid = 9876;
@@ -80,7 +99,7 @@ describe("peercred.identify", () => {
 
     setupProcMocks(brokerUid, exe, clientPid, cgroupContent);
 
-    const mockExec = vi.fn().mockReturnValue(ssOutput);
+    const mockExec = mkMockExec(ssOutput);
     const result = identify(SOCKET_PATH, mockExec as any);
 
     expect(result).not.toBeNull();
@@ -93,6 +112,102 @@ describe("peercred.identify", () => {
       ["-xpn"],
       expect.objectContaining({ timeout: 200 }),
     );
+    expect(mockExec).toHaveBeenCalledWith(
+      "systemctl",
+      [
+        "--user",
+        "show",
+        "switchroom-myagent-cron-3.service",
+        "--property=LoadState,ActiveState",
+      ],
+      expect.objectContaining({ timeout: 500 }),
+    );
+  });
+
+  it("returns systemdUnit=null when cgroup name is spoofed (systemctl reports not-found)", () => {
+    // Threat: a same-UID attacker creates a cgroup directory shaped like a
+    // real cron unit and moves their PID into it. /proc/<pid>/cgroup then
+    // claims the unit name, but systemd-user has no record of it.
+    if (process.platform !== "linux") return;
+
+    const clientPid = 9876;
+    const brokerPid = 1234;
+    const brokerUid = process.getuid?.() ?? 1000;
+    const exe = "/bin/bash";
+    const cgroupContent =
+      `0::/user.slice/user-${brokerUid}.slice/user@${brokerUid}.service/app.slice/switchroom-fakecron-cron-0.service\n`;
+
+    const SERVER_INODE = "100";
+    const CLIENT_INODE = "200";
+    const ssOutput =
+      `u_str ESTAB 0 0 ${SOCKET_PATH} ${SERVER_INODE} * ${CLIENT_INODE} users:(("broker",pid=${brokerPid},fd=5))\n` +
+      `u_str ESTAB 0 0 * ${CLIENT_INODE} * ${SERVER_INODE} users:(("bash",pid=${clientPid},fd=4))\n`;
+
+    setupProcMocks(brokerUid, exe, clientPid, cgroupContent);
+
+    // systemctl returns LoadState=not-found for spoofed/unknown units.
+    const mockExec = mkMockExec(
+      ssOutput,
+      "LoadState=not-found\nActiveState=inactive\n",
+    );
+    const result = identify(SOCKET_PATH, mockExec as any);
+
+    // Caller is still identified (uid/pid/exe), but systemdUnit is null
+    // because we couldn't verify the cgroup claim.
+    expect(result).not.toBeNull();
+    expect(result?.pid).toBe(clientPid);
+    expect(result?.systemdUnit).toBeNull();
+  });
+
+  it("returns systemdUnit=null when systemctl errors (e.g. systemd-user not running)", () => {
+    if (process.platform !== "linux") return;
+
+    const clientPid = 9876;
+    const brokerPid = 1234;
+    const brokerUid = process.getuid?.() ?? 1000;
+    const cgroupContent =
+      `0::/user.slice/user-${brokerUid}.slice/user@${brokerUid}.service/app.slice/switchroom-myagent-cron-3.service\n`;
+
+    const SERVER_INODE = "100";
+    const CLIENT_INODE = "200";
+    const ssOutput =
+      `u_str ESTAB 0 0 ${SOCKET_PATH} ${SERVER_INODE} * ${CLIENT_INODE} users:(("broker",pid=${brokerPid},fd=5))\n` +
+      `u_str ESTAB 0 0 * ${CLIENT_INODE} * ${SERVER_INODE} users:(("bash",pid=${clientPid},fd=4))\n`;
+
+    setupProcMocks(brokerUid, "/bin/bash", clientPid, cgroupContent);
+
+    const mockExec = mkMockExec(ssOutput, null); // systemctl throws
+    const result = identify(SOCKET_PATH, mockExec as any);
+
+    expect(result).not.toBeNull();
+    expect(result?.systemdUnit).toBeNull();
+  });
+
+  it("returns systemdUnit=null when unit is loaded but inactive (failed/stale)", () => {
+    if (process.platform !== "linux") return;
+
+    const clientPid = 9876;
+    const brokerPid = 1234;
+    const brokerUid = process.getuid?.() ?? 1000;
+    const cgroupContent =
+      `0::/user.slice/user-${brokerUid}.slice/user@${brokerUid}.service/app.slice/switchroom-myagent-cron-3.service\n`;
+
+    const SERVER_INODE = "100";
+    const CLIENT_INODE = "200";
+    const ssOutput =
+      `u_str ESTAB 0 0 ${SOCKET_PATH} ${SERVER_INODE} * ${CLIENT_INODE} users:(("broker",pid=${brokerPid},fd=5))\n` +
+      `u_str ESTAB 0 0 * ${CLIENT_INODE} * ${SERVER_INODE} users:(("bash",pid=${clientPid},fd=4))\n`;
+
+    setupProcMocks(brokerUid, "/bin/bash", clientPid, cgroupContent);
+
+    const mockExec = mkMockExec(
+      ssOutput,
+      "LoadState=loaded\nActiveState=failed\n",
+    );
+    const result = identify(SOCKET_PATH, mockExec as any);
+
+    expect(result).not.toBeNull();
+    expect(result?.systemdUnit).toBeNull();
   });
 
   it("returns PeerInfo with systemdUnit=null when cgroup has no switchroom unit", () => {
@@ -112,6 +227,8 @@ describe("peercred.identify", () => {
 
     setupProcMocks(brokerUid, exe, clientPid, cgroupContent);
 
+    // No systemctl call expected because cgroup name doesn't match the
+    // switchroom-cron pattern; readSystemdUnit returns null upstream.
     const mockExec = vi.fn().mockReturnValue(ssOutput);
     const result = identify(SOCKET_PATH, mockExec as any);
 

--- a/src/vault/broker/peercred.ts
+++ b/src/vault/broker/peercred.ts
@@ -73,7 +73,9 @@ function parseSsRows(output: string): SsRow[] {
   for (const line of lines) {
     if (!line.trim() || line.startsWith("Netid")) continue;
     // Tokenize on whitespace runs. Columns are:
-    //   netid state recv-q send-q local-addr local-port peer-addr peer-port [users:(...)]
+    //   netid state recv-q send-q local-addr local-inode peer-addr peer-inode [users:(...)]
+    // (`ss` reuses the TCP "port" header label even for unix sockets, where
+    //  the trailing slot actually holds an inode number.)
     const tokens = line.split(/\s+/).filter((t) => t.length > 0);
     if (tokens.length < 8) continue;
     const localAddr = tokens[4];
@@ -190,6 +192,71 @@ export function readSystemdUnit(pid: number): string | null {
 }
 
 /**
+ * Verify with systemd-user that a unit name read from /proc/<pid>/cgroup
+ * actually corresponds to a unit systemd has loaded.
+ *
+ * Background: under cgroup v2 user delegation, a regular user owns their
+ * own user@<uid>.service subtree and can `mkdir` arbitrary cgroup
+ * directories within it (including paths shaped like
+ * `switchroom-<agent>-cron-<i>.service`) and move their own processes in
+ * via `cgroup.procs`. /proc/<pid>/cgroup then reports the spoofed name.
+ * The cgroup file by itself is therefore attacker-controlled input for
+ * any same-UID caller — the broker can't trust it without cross-checking
+ * against systemd's authoritative view.
+ *
+ * `systemctl --user show <unit>` returns LoadState=not-found for any
+ * name systemd-user has not loaded as a real unit. Real cron units (and
+ * `systemd-run --user --unit=...` transient units) report
+ * LoadState=loaded with an ActiveState we accept.
+ *
+ * Returns true only when the unit is loaded and currently running.
+ */
+export function verifySystemdUnit(
+  unitName: string,
+  runner: (
+    file: string,
+    args: readonly string[],
+    opts: ExecFileSyncOptions,
+  ) => Buffer | string,
+): boolean {
+  let raw: string;
+  try {
+    const out = runner(
+      "systemctl",
+      [
+        "--user",
+        "show",
+        unitName,
+        "--property=LoadState,ActiveState",
+      ],
+      { timeout: 500, encoding: "utf8" },
+    );
+    raw = typeof out === "string" ? out : out.toString("utf8");
+  } catch {
+    // systemctl not available, timeout, or returned non-zero — fail closed
+    return false;
+  }
+
+  const props: Record<string, string> = {};
+  for (const line of raw.split("\n")) {
+    const m = line.match(/^([A-Za-z]+)=(.*)$/);
+    if (m) props[m[1]] = m[2];
+  }
+
+  // not-found: spoofed cgroup with no corresponding registered unit.
+  if (props.LoadState !== "loaded") return false;
+
+  // Real cron units cycle through `activating` (Type=oneshot ExecStart
+  // running) and `active`. Any other state means the unit isn't currently
+  // executing the caller's script — reject.
+  if (props.ActiveState !== "active" && props.ActiveState !== "activating") {
+    return false;
+  }
+
+  return true;
+}
+
+/**
  * Identify the peer on the other end of a Unix domain socket connection.
  *
  * @param socketPath - Absolute path to the listening socket.
@@ -264,7 +331,20 @@ export function identify(
     return null;
   }
 
-  const systemdUnit = readSystemdUnit(pid);
+  // Read the alleged unit from cgroup, then cross-check with systemd.
+  // /proc/<pid>/cgroup is attacker-controlled under user delegation; only
+  // a unit systemd-user actually has loaded counts.
+  const cgroupClaim = readSystemdUnit(pid);
+  let systemdUnit: string | null = null;
+  if (cgroupClaim !== null) {
+    if (verifySystemdUnit(cgroupClaim, runner)) {
+      systemdUnit = cgroupClaim;
+    } else {
+      process.stderr.write(
+        `[vault-broker] peercred: cgroup claims unit=${cgroupClaim} but systemd-user does not report it as loaded+running; treating caller as unidentified\n`,
+      );
+    }
+  }
 
   return { uid, pid, exe, systemdUnit };
 }

--- a/src/vault/broker/peercred.ts
+++ b/src/vault/broker/peercred.ts
@@ -6,6 +6,13 @@
  *      connected peers and parse the `users:(("name",pid=NNN,fd=NN))` column.
  *   2. Reading `/proc/<pid>/status` to get the caller's real UID.
  *   3. Reading `/proc/<pid>/exe` (symlink) to get the caller's executable path.
+ *   4. Reading `/proc/<pid>/cgroup` to find the systemd unit name, which is
+ *      used as the primary identity signal for ACL decisions.
+ *
+ * The cgroup identity (`systemdUnit`) is the authoritative identity for cron
+ * scripts. systemd writes the cgroup as root when it starts the unit, and
+ * processes cannot change their own cgroup from userspace — making it
+ * unspoofable. The exe path is retained for the interactive-CLI fallback only.
  *
  * Limitation: when multiple clients are simultaneously connected to the same
  * socket, `ss` returns all of them. This implementation picks the first
@@ -32,27 +39,78 @@ export interface PeerInfo {
   uid: number;
   pid: number;
   exe: string;
+  /** Systemd unit name e.g. "switchroom-myagent-cron-3.service", or null if
+   *  the caller is not a switchroom cron unit or cgroup is unavailable. */
+  systemdUnit: string | null;
 }
 
 /**
- * Parse `users:(("name",pid=NNN,fd=NN))` columns from `ss` output.
- * Returns an array of { pid } objects for all connected clients found.
- * Empty array if none found or parse failed.
+ * One row of `ss -xpn` output for a unix-domain connection.
+ *
+ * `ss -xpn` lists every endpoint of every unix-domain connection — the server
+ * side and the client side appear as separate rows that share an inode pair.
+ *   server side: Local = SOCKET_PATH inodeA, Peer = * inodeB
+ *   client side: Local = *           inodeB, Peer = * inodeA
+ *
+ * We need both rows to identify the client: the path filter selects the
+ * server row, then we walk the client row keyed by `inodeB` to read its pid.
  */
-function parseSsOutput(output: string): Array<{ pid: number }> {
-  // Each line from `ss -xpn state connected src <path>` looks like:
-  //   u_str ESTAB 0 0 /path/to.sock 12345 * 0 users:(("prog",pid=9876,fd=5))
-  // The users column may be absent if the process exited before ss ran.
-  const results: Array<{ pid: number }> = [];
+interface SsRow {
+  localAddr: string;
+  localInode: string;
+  peerAddr: string;
+  peerInode: string;
+  pid: number | null;
+}
+
+/**
+ * Parse `ss -xpn` output into structured rows. Tolerant of missing fields
+ * (the users:() column may be absent if the process exited mid-scan).
+ */
+function parseSsRows(output: string): SsRow[] {
+  const rows: SsRow[] = [];
   const lines = output.split("\n");
   for (const line of lines) {
-    // Match users:((...,pid=NNN,...))
-    const m = line.match(/users:\(\(".*?",pid=(\d+),fd=\d+\)\)/);
-    if (m) {
-      results.push({ pid: parseInt(m[1], 10) });
+    if (!line.trim() || line.startsWith("Netid")) continue;
+    // Tokenize on whitespace runs. Columns are:
+    //   netid state recv-q send-q local-addr local-port peer-addr peer-port [users:(...)]
+    const tokens = line.split(/\s+/).filter((t) => t.length > 0);
+    if (tokens.length < 8) continue;
+    const localAddr = tokens[4];
+    const localInode = tokens[5];
+    const peerAddr = tokens[6];
+    const peerInode = tokens[7];
+    const usersToken = tokens.slice(8).join(" ");
+    const m = usersToken.match(/users:\(\(".*?",pid=(\d+),fd=\d+\)\)/);
+    const pid = m ? parseInt(m[1], 10) : null;
+    rows.push({ localAddr, localInode, peerAddr, peerInode, pid });
+  }
+  return rows;
+}
+
+/**
+ * Given parsed `ss -xpn` rows and our listening socket path, return the
+ * caller-side PIDs for every active connection to that socket.
+ *
+ * For each row whose Local Address equals our socket, we look up the matching
+ * client row via the peer-inode pair (server's peerInode === client's
+ * localInode) and harvest its pid. Server-side rows are skipped because they
+ * point at the broker itself.
+ */
+function findClientPids(rows: SsRow[], socketPath: string): number[] {
+  const pids: number[] = [];
+  for (const serverRow of rows) {
+    if (serverRow.localAddr !== socketPath) continue;
+    // Find the client row whose local inode equals our peer inode.
+    for (const clientRow of rows) {
+      if (clientRow.localAddr !== "*") continue;
+      if (clientRow.localInode !== serverRow.peerInode) continue;
+      if (clientRow.pid === null) continue;
+      pids.push(clientRow.pid);
+      break;
     }
   }
-  return results;
+  return pids;
 }
 
 /**
@@ -84,6 +142,54 @@ function readExe(pid: number): string | null {
 }
 
 /**
+ * Read the systemd unit name from /proc/<pid>/cgroup.
+ *
+ * Supports both cgroup v2 (single line starting with "0::") and cgroup v1
+ * (multiple lines; the relevant controller has "name=systemd" in field 2).
+ *
+ * Returns the unit name (e.g. "switchroom-myagent-cron-3.service") if the
+ * process is in a switchroom cron unit, or null otherwise.
+ * Never throws — all errors return null.
+ */
+export function readSystemdUnit(pid: number): string | null {
+  try {
+    const content = readFileSync(`/proc/${pid}/cgroup`, "utf8");
+    const lines = content.split("\n");
+
+    for (const line of lines) {
+      if (!line.trim()) continue;
+
+      const parts = line.split(":");
+      if (parts.length < 3) continue;
+
+      const controller = parts[1];
+      // cgroup v2: controller field is empty, hierarchy id is "0"
+      // cgroup v1: find the name=systemd controller
+      const isV2 = parts[0] === "0" && controller === "";
+      const isV1Systemd = controller === "name=systemd";
+
+      if (!isV2 && !isV1Systemd) continue;
+
+      // The path is everything from parts[2] onward (paths may contain colons in theory)
+      const cgroupPath = parts.slice(2).join(":");
+      const segments = cgroupPath.split("/");
+      const lastSegment = segments[segments.length - 1];
+
+      if (!lastSegment) continue;
+
+      // Must match the switchroom cron unit naming convention
+      if (/^switchroom-[a-zA-Z0-9_-]+-cron-\d+\.service$/.test(lastSegment)) {
+        return lastSegment;
+      }
+    }
+
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Identify the peer on the other end of a Unix domain socket connection.
  *
  * @param socketPath - Absolute path to the listening socket.
@@ -107,7 +213,12 @@ export function identify(
 
   let ssOutput: string;
   try {
-    const raw = runner("ss", ["-xpn", "state", "connected", "src", socketPath], {
+    // We need every unix endpoint to do the inode-pair lookup that maps the
+    // server-side row to the client-side row. `ss` only stamps the path on
+    // the server side; the connecting client appears under `Local *
+    // <inode>`. A `src` or `dst` filter narrows the result before we can
+    // match the pair, so we list everything and filter in user space.
+    const raw = runner("ss", ["-xpn"], {
       timeout: 200,
       encoding: "utf8",
     });
@@ -117,19 +228,20 @@ export function identify(
     return null;
   }
 
-  const peers = parseSsOutput(ssOutput);
-  if (peers.length === 0) return null;
+  const rows = parseSsRows(ssOutput);
+  const clientPids = findClientPids(rows, socketPath);
+  if (clientPids.length === 0) return null;
 
-  if (peers.length > 1) {
+  if (clientPids.length > 1) {
     // Multiple simultaneous connections — warn but use the first.
     // This is documented as a known limitation.
     process.stderr.write(
-      `[vault-broker] peercred: ${peers.length} connected peers found for ${socketPath}; ` +
-        `using pid=${peers[0].pid}. Multiple simultaneous connections reduce identification accuracy.\n`,
+      `[vault-broker] peercred: ${clientPids.length} connected peers found for ${socketPath}; ` +
+        `using pid=${clientPids[0]}. Multiple simultaneous connections reduce identification accuracy.\n`,
     );
   }
 
-  const { pid } = peers[0];
+  const pid = clientPids[0];
 
   const uid = readUid(pid);
   if (uid === null) {
@@ -152,5 +264,7 @@ export function identify(
     return null;
   }
 
-  return { uid, pid, exe };
+  const systemdUnit = readSystemdUnit(pid);
+
+  return { uid, pid, exe, systemdUnit };
 }

--- a/tests/integration/vault-broker-e2e.test.ts
+++ b/tests/integration/vault-broker-e2e.test.ts
@@ -1,0 +1,472 @@
+// Behavioural e2e tests for the vault broker against real systemd.
+// To run: INTEGRATION=1 bun run test:vitest -- tests/integration/vault-broker-e2e
+// Skipped without INTEGRATION=1 or on non-Linux or without user systemd.
+//
+// Uses `systemd-run --user --unit=switchroom-<agent>-cron-<i> --wait` to place
+// the cron script in the correct cgroup (switchroom-<agent>-cron-<i>.service)
+// without writing permanent unit files to ~/.config/systemd/user. This
+// exercises the cgroup-based ACL end-to-end against a real systemd instance.
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import {
+  mkdtempSync,
+  rmSync,
+  mkdirSync,
+  writeFileSync,
+  existsSync,
+} from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { execFileSync, spawn, type ChildProcess } from "node:child_process";
+import * as net from "node:net";
+
+// ─── Gate conditions ──────────────────────────────────────────────────────────
+
+const INTEGRATION = process.env.INTEGRATION === "1";
+const IS_LINUX = process.platform === "linux";
+
+function systemdAvailable(): boolean {
+  try {
+    execFileSync("systemctl", ["--user", "--version"], { stdio: "ignore", timeout: 1000 });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function systemdRunAvailable(): boolean {
+  try {
+    execFileSync("systemd-run", ["--version"], { stdio: "ignore", timeout: 1000 });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const SKIP = !INTEGRATION || !IS_LINUX || !systemdAvailable() || !systemdRunAvailable();
+const SKIP_REASON = !INTEGRATION
+  ? "set INTEGRATION=1 to run"
+  : !IS_LINUX
+  ? "Linux only"
+  : !systemdAvailable()
+  ? "no user-level systemd detected"
+  : "systemd-run not available";
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+const BROKER_ENTRY = join(import.meta.dirname, "../../src/vault/broker/server.ts");
+
+/**
+ * Build a minimal switchroom.yaml for the test agent, with the given schedule
+ * secrets for cron-0.
+ */
+function makeConfig(
+  tmpDir: string,
+  agentName: string,
+  agentsDir: string,
+  cronSecrets: string[],
+): string {
+  const configObj = {
+    switchroom: { version: 1, agents_dir: agentsDir },
+    telegram: { bot_token: "123:TEST", forum_chat_id: "-1001" },
+    vault: {
+      path: join(tmpDir, "vault.enc"),
+      broker: {
+        socket: join(tmpDir, "vault-broker.sock"),
+        enabled: true,
+        allow_interactive: false,
+      },
+    },
+    agents: {
+      [agentName]: {
+        topic_name: "Test",
+        schedule: [
+          { cron: "0 8 * * *", prompt: "test", secrets: cronSecrets },
+        ],
+      },
+    },
+  };
+  const configPath = join(tmpDir, "switchroom.yaml");
+  // JSON is valid YAML
+  writeFileSync(configPath, JSON.stringify(configObj, null, 2));
+  return configPath;
+}
+
+/**
+ * Build a minimal vault file containing { test_key_a: "VALUE_A" } at
+ * vaultPath using a known passphrase.
+ */
+function makeVault(vaultPath: string, passphrase: string): void {
+  const script = `
+    import { createVault, setStringSecret } from ${JSON.stringify(
+      join(import.meta.dirname, "../../src/vault/vault.ts"),
+    )};
+    createVault(${JSON.stringify(passphrase)}, ${JSON.stringify(vaultPath)});
+    setStringSecret(${JSON.stringify(passphrase)}, ${JSON.stringify(vaultPath)}, "test_key_a", "VALUE_A");
+  `;
+  const scriptPath = join(vaultPath + ".setup.mts");
+  writeFileSync(scriptPath, script);
+  execFileSync("bun", ["run", scriptPath], { stdio: "pipe" });
+}
+
+/**
+ * Write the cron script that systemd-run will execute via /bin/bash.
+ * The script uses bun to run a TypeScript client against the broker.
+ */
+function makeCronScript(
+  agentsDir: string,
+  agentName: string,
+  socketPath: string,
+): string {
+  const cronDir = join(agentsDir, agentName, "telegram");
+  mkdirSync(cronDir, { recursive: true });
+  const cronPath = join(cronDir, "cron-0.sh");
+
+  const clientTs = join(import.meta.dirname, "../../src/vault/broker/client.ts");
+  const protocolTs = join(import.meta.dirname, "../../src/vault/broker/protocol.ts");
+
+  const script = `#!/bin/bash
+BUN=$(command -v bun)
+if [ -z "$BUN" ]; then
+  echo "bun not found" >&2
+  exit 1
+fi
+
+exec "$BUN" --eval '
+import { getViaBroker } from ${JSON.stringify(clientTs)};
+import { encodeRequest, decodeResponse } from ${JSON.stringify(protocolTs)};
+import * as net from "node:net";
+
+const SOCKET = ${JSON.stringify(socketPath)};
+
+// Try the high-level client first
+const result = await getViaBroker("test_key_a", { socket: SOCKET, timeoutMs: 3000 });
+if (result !== null) {
+  process.stdout.write(String((result as any).value) + "\\n");
+  process.exit(0);
+}
+
+// High-level client returned null — do a raw request to distinguish DENIED from down.
+// Use data + newline framing (NOT the end event) because the broker does not
+// close the connection after responding; the response always ends with "\\n".
+const resp = await new Promise<any>((resolve) => {
+  const client = net.createConnection({ path: SOCKET });
+  let buf = "";
+  const timer = setTimeout(() => { client.destroy(); resolve(null); }, 3000);
+  client.on("data", (c: Buffer) => {
+    buf += c.toString("utf8");
+    const nl = buf.indexOf("\\n");
+    if (nl !== -1) {
+      clearTimeout(timer);
+      client.destroy();
+      try { resolve(decodeResponse(buf.slice(0, nl))); } catch { resolve(null); }
+    }
+  });
+  client.on("error", (e: Error) => {
+    clearTimeout(timer);
+    process.stderr.write("broker not running: " + e.message + "\\n");
+    resolve(null);
+  });
+  client.on("connect", () => {
+    client.write(encodeRequest({ v: 1, op: "get", key: "test_key_a" }));
+    // Do NOT call end() — broker keeps the connection open after responding.
+  });
+});
+
+if (resp && resp.ok === false) {
+  if (resp.code === "DENIED") {
+    process.stderr.write("ACL DENIED: " + resp.msg + "\\n");
+    process.exit(2);
+  }
+  if (resp.code === "LOCKED") {
+    process.stderr.write("broker LOCKED: " + resp.msg + "\\n");
+    process.exit(3);
+  }
+  process.stderr.write("broker error " + resp.code + ": " + resp.msg + "\\n");
+  process.exit(4);
+}
+
+process.stderr.write("broker not running or key missing\\n");
+process.exit(1);
+'
+`;
+  writeFileSync(cronPath, script, { mode: 0o755 });
+  return cronPath;
+}
+
+/**
+ * Start the broker subprocess pointing at the given socket and config.
+ * Returns the child process once the socket file exists (or after 5s timeout).
+ */
+async function startBroker(
+  configPath: string,
+  socketPath: string,
+  vaultPath: string,
+): Promise<ChildProcess> {
+  const child = spawn(
+    "bun",
+    [
+      "--eval",
+      `
+import { VaultBroker } from ${JSON.stringify(BROKER_ENTRY)};
+const broker = new VaultBroker();
+await broker.start(
+  ${JSON.stringify(socketPath)},
+  ${JSON.stringify(configPath)},
+  ${JSON.stringify(vaultPath)},
+);
+process.on("SIGTERM", () => { broker.stop(); process.exit(0); });
+process.on("SIGINT",  () => { broker.stop(); process.exit(0); });
+      `,
+    ],
+    { stdio: ["ignore", "pipe", "pipe"] },
+  );
+
+  // Drain the broker's stdout/stderr pipes so they don't fill the OS buffer
+  // and stall the subprocess. The data is dropped — broker logging is
+  // useful for manual debugging only.
+  child.stderr?.on("data", () => {});
+  child.stdout?.on("data", () => {});
+
+  const deadline = Date.now() + 5000;
+  while (!existsSync(socketPath)) {
+    if (Date.now() > deadline) {
+      child.kill("SIGTERM");
+      throw new Error(`Broker socket never appeared at ${socketPath}`);
+    }
+    await new Promise((r) => setTimeout(r, 50));
+  }
+  await new Promise((r) => setTimeout(r, 200));
+  return child;
+}
+
+/**
+ * Unlock the broker by sending the passphrase to the unlock socket.
+ */
+async function unlockBroker(socketPath: string, passphrase: string): Promise<void> {
+  const unlockSocketPath = socketPath.replace(/\.sock$/, ".unlock.sock");
+
+  await new Promise<void>((resolve, reject) => {
+    const client = net.createConnection({ path: unlockSocketPath });
+    let buf = "";
+    client.on("data", (c) => { buf += c.toString(); });
+    client.on("end", () => {
+      if (buf.trim() === "OK") resolve();
+      else reject(new Error(`Broker unlock failed: ${buf.trim()}`));
+    });
+    client.on("error", (e) => reject(e));
+    client.on("connect", () => {
+      client.write(passphrase + "\n");
+      client.end();
+    });
+  });
+}
+
+/**
+ * Run the cron script via `systemd-run --user --unit=<unitBase> --wait`,
+ * placing it in the switchroom-<agent>-cron-<i>.service cgroup.
+ *
+ * systemd-run creates a transient unit (no permanent unit file needed) and
+ * --wait blocks until the unit completes, returning its exit status.
+ *
+ * Returns { success, stdout, stderr } captured from the unit's journal.
+ */
+async function runCronViaSystemdRun(
+  agentName: string,
+  cronPath: string,
+  agentDir: string,
+  timeoutMs = 15000,
+): Promise<{ success: boolean; stdout: string; stderr: string }> {
+  // The unit base name must match what peercred will find in /proc/<pid>/cgroup.
+  // systemd-run will create: switchroom-<agent>-cron-0.service
+  const unitBase = `switchroom-${agentName}-cron-0`;
+
+  // Capture stdout/stderr via the journal. systemd-run --wait exits with the
+  // unit's exit code (non-zero on failure).
+  let stdout = "";
+  let stderr = "";
+  let success = false;
+
+  // Pass PATH so bun is findable inside the transient unit
+  const bunDir = join(process.env.HOME ?? "/root", ".bun", "bin");
+  const augmentedPath = [bunDir, process.env.PATH ?? "/usr/local/bin:/usr/bin:/bin"].join(":");
+
+  try {
+    const result = execFileSync(
+      "systemd-run",
+      [
+        "--user",
+        `--unit=${unitBase}`,
+        "--wait",
+        "--collect",
+        `--setenv=PATH=${augmentedPath}`,
+        "--property=WorkingDirectory=" + agentDir,
+        "/bin/bash",
+        cronPath,
+      ],
+      {
+        encoding: "utf8",
+        timeout: timeoutMs,
+        stdio: ["ignore", "pipe", "pipe"],
+      },
+    );
+    // execFileSync with encoding returns string; stdout is captured
+    stdout = typeof result === "string" ? result : "";
+    success = true;
+  } catch (e: any) {
+    // Non-zero exit or timeout — unit failed
+    stdout = e.stdout ?? "";
+    stderr = e.stderr ?? "";
+    success = false;
+  }
+
+  // Also pull from journalctl for stderr output (script writes to stderr which
+  // goes to the journal, not to systemd-run's captured stdout).
+  try {
+    const journalOut = execFileSync(
+      "journalctl",
+      [
+        "--user",
+        "--unit", `${unitBase}.service`,
+        "--since", "30 seconds ago",
+        "--no-pager",
+        "-o", "cat",
+      ],
+      { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"], timeout: 5000 },
+    );
+    const journalStr = typeof journalOut === "string" ? journalOut : "";
+    stdout += journalStr;
+    stderr += journalStr;
+  } catch {
+    // journal unavailable — not fatal
+  }
+
+  return { success, stdout, stderr };
+}
+
+// ─── Test suite ───────────────────────────────────────────────────────────────
+
+describe("vault-broker e2e (systemd)", () => {
+  let tmpDir: string;
+  let broker: ChildProcess | null;
+  let socketPath: string;
+  let configPath: string;
+  let vaultPath: string;
+  let agentsDir: string;
+  // Each test gets a unique agent name so the systemd unit name
+  // (`switchroom-<agent>-cron-0.service`) and the journalctl scope are
+  // disjoint. Otherwise output from a prior test bleeds into the next
+  // test's captured journal and breaks `not.toContain(VALUE)` assertions.
+  let AGENT: string;
+  const PASSPHRASE = "e2e-test-passphrase-not-real";
+  let agentCounter = 0;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "sw-vault-broker-e2e-"));
+    agentsDir = join(tmpDir, "agents");
+    mkdirSync(agentsDir, { recursive: true });
+    socketPath = join(tmpDir, "vault-broker.sock");
+    vaultPath = join(tmpDir, "vault.enc");
+    broker = null;
+    AGENT = `e2eagent${++agentCounter}-${process.pid}`;
+  });
+
+  afterEach(async () => {
+    if (broker) {
+      broker.kill("SIGTERM");
+      await new Promise<void>((resolve) => {
+        broker!.on("close", () => resolve());
+        setTimeout(resolve, 1000);
+      });
+      broker = null;
+    }
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it.skipIf(SKIP)(
+    `prerequisite check passes (${SKIP_REASON || "all conditions met"})`,
+    () => {
+      expect(INTEGRATION).toBe(true);
+      expect(IS_LINUX).toBe(true);
+    },
+  );
+
+  it.skipIf(SKIP)(
+    "allowed key (happy path) — cgroup identity grants access via systemd-run",
+    async () => {
+      configPath = makeConfig(tmpDir, AGENT, agentsDir, ["test_key_a"]);
+      makeVault(vaultPath, PASSPHRASE);
+
+      const agentDir = join(agentsDir, AGENT);
+      mkdirSync(agentDir, { recursive: true });
+      const cronPath = makeCronScript(agentsDir, AGENT, socketPath);
+
+      // Start and unlock the broker
+      broker = await startBroker(configPath, socketPath, vaultPath);
+      await unlockBroker(socketPath, PASSPHRASE);
+
+      // Run via systemd-run — places process in switchroom-e2eagent-cron-0.service cgroup
+      const { success, stdout, stderr } = await runCronViaSystemdRun(AGENT, cronPath, agentDir);
+
+      expect(success).toBe(true);
+      // The value should appear in the captured output
+      const combined = stdout + stderr;
+      expect(combined).toContain("VALUE_A");
+    },
+    25000,
+  );
+
+  it.skipIf(SKIP)(
+    "disallowed key — secrets:[] causes ACL DENIED, no value leaks",
+    async () => {
+      // cron's secrets list is empty — test_key_a is NOT declared
+      configPath = makeConfig(tmpDir, AGENT, agentsDir, []);
+      makeVault(vaultPath, PASSPHRASE);
+
+      const agentDir = join(agentsDir, AGENT);
+      mkdirSync(agentDir, { recursive: true });
+      const cronPath = makeCronScript(agentsDir, AGENT, socketPath);
+
+      broker = await startBroker(configPath, socketPath, vaultPath);
+      await unlockBroker(socketPath, PASSPHRASE);
+
+      const { success, stdout, stderr } = await runCronViaSystemdRun(AGENT, cronPath, agentDir);
+
+      // The cron script exits 2 on DENIED — systemd-run returns non-zero
+      expect(success).toBe(false);
+      // Value must never appear in output
+      const combined = stdout + stderr;
+      expect(combined).not.toContain("VALUE_A");
+      // Output should mention denial
+      expect(combined.toLowerCase()).toMatch(/denied|acl/);
+    },
+    25000,
+  );
+
+  it.skipIf(SKIP)(
+    "broker stopped — cron exits non-zero, does not silently fall through",
+    async () => {
+      // Do NOT start the broker
+      configPath = makeConfig(tmpDir, AGENT, agentsDir, ["test_key_a"]);
+      makeVault(vaultPath, PASSPHRASE);
+
+      const agentDir = join(agentsDir, AGENT);
+      mkdirSync(agentDir, { recursive: true });
+      const cronPath = makeCronScript(agentsDir, AGENT, socketPath);
+
+      // Socket does not exist
+      expect(existsSync(socketPath)).toBe(false);
+
+      const { success, stdout, stderr } = await runCronViaSystemdRun(AGENT, cronPath, agentDir);
+
+      // Must exit non-zero — broker is not running
+      expect(success).toBe(false);
+      // Must not silently succeed with a value
+      const combined = stdout + stderr;
+      expect(combined).not.toContain("VALUE_A");
+      // Output must mention the failure
+      expect(combined.length).toBeGreaterThan(0);
+    },
+    25000,
+  );
+});

--- a/tests/integration/vault-broker-e2e.test.ts
+++ b/tests/integration/vault-broker-e2e.test.ts
@@ -50,7 +50,9 @@ const SKIP_REASON = !INTEGRATION
   ? "Linux only"
   : !systemdAvailable()
   ? "no user-level systemd detected"
-  : "systemd-run not available";
+  : !systemdRunAvailable()
+  ? "systemd-run not available"
+  : "";
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
The vault broker that landed in #113 had two production-blocking bugs the unit tests missed. This PR fixes both, adds a gated systemd e2e harness that actually exercises the production path, and ships user docs.

### Bug 1 — exe-path ACL
The ACL matched `/proc/<pid>/exe` against the cron script path. But the generated cron unit runs `/bin/bash <script>`, so the kernel-set exe is `/bin/bash` — the pattern never matched. **Every cron `vault get` would fail-closed `DENIED` in production.**

Fix: cgroup-based identity. Peercred reads `/proc/<pid>/cgroup` to find the systemd unit name (`switchroom-<agent>-cron-<i>.service`). Cgroup membership is set by systemd as root and unspoofable from userspace.

### Bug 2 — peercred queried itself
Peercred ran `ss -xpn … src <socket>`, which selects the **server-side** row of a unix connection. The `users:()` column on that row is the listening process — the broker itself. Any check based on that PID asks the broker about the broker.

Fix: parse all of `ss -xpn` and walk the inode pair from server-side row → matching client-side row (Local=*) → client PID.

### Why the unit tests didn't catch it
Synthetic ss fixtures matched the cron-path regex; synthetic exe paths bypassed the real `/proc` walk. The new e2e harness spins a real broker, places the cron in a transient systemd unit via `systemd-run --user`, and exercises the full path.

## What's in this PR
- `src/vault/broker/peercred.ts` — cgroup reader + inode-pair `ss` walk
- `src/vault/broker/acl.ts` — switched from exe-path to systemd unit name
- `src/vault/broker/{peercred,acl}.test.ts` — fixtures rewritten to match production output
- `tests/integration/vault-broker-e2e.test.ts` — gated `INTEGRATION=1` harness (allowed key, denied key, broker stopped)
- `CHANGELOG.md`, `README.md` — `[Unreleased]` entry + new "Vault broker (cron secrets)" section

## Test plan
- [x] `bun run lint` clean
- [x] Broker unit tests: 62 passed (4 files)
- [x] `INTEGRATION=1 bun run test:vitest -- tests/integration/vault-broker-e2e` — 4/4 pass against real systemd
- [x] Full vitest suite — only the pre-existing `auth.stale-token-fix.test.ts` tmux-dependent failure (unrelated)
- [x] `bun run build` clean; PII grep at baseline (4 `/home/hindsight/.pg0` mentions, identical to main)