### PR TITLE
fix(ci): replace comma-separated bktec pattern with brace alternation (closes #111)

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -115,10 +115,20 @@ steps:
         # the assigned file list in place of {{testExamples}}.
         export BUILDKITE_TEST_ENGINE_TEST_CMD="bunx vitest run {{testExamples}}"
         # Match all test files that vitest.config.ts would include.
-        # Brace expansion ({a,b,c}) is not honored by bktec's glob library —
-        # it produces "no files found" silently. List each root dir explicitly.
-        export BUILDKITE_TEST_ENGINE_TEST_FILE_PATTERN="tests/**/*.test.ts,test/**/*.test.ts,experimental/**/*.test.ts,src/**/*.test.ts,telegram-plugin/tests/*.test.ts"
-        export BUILDKITE_TEST_ENGINE_TEST_FILE_EXCLUDE_PATTERN="telegram-plugin/tests/history.test.ts"
+        #
+        # Root cause of issue #111: bktec v2.3.2 uses drjosh.dev/zzglob which
+        # does NOT treat commas as pattern separators at the top level — commas
+        # are only significant inside {a,b,c} alternation groups. A
+        # comma-separated list like "tests/**,src/**" is parsed as a single
+        # literal glob containing commas, which matches no real paths, so bktec
+        # exits with "no files found". Fix: use a single brace-alternation
+        # pattern instead.
+        #
+        # Exclude pattern mirrors vitest.config.ts excludes — these files use
+        # Bun-only APIs (bun:sqlite, bun:test timers, Bun.spawn) that vitest
+        # running under Node cannot resolve.
+        export BUILDKITE_TEST_ENGINE_TEST_FILE_PATTERN="{tests,test,experimental,src,telegram-plugin}/**/*.test.ts"
+        export BUILDKITE_TEST_ENGINE_TEST_FILE_EXCLUDE_PATTERN="telegram-plugin/tests/{history,ipc-server-client,ipc-server-race,gateway-bridge,gateway-startup-mutex,gateway-clean-shutdown-marker,foreman-state,boot-card-dedupe,boot-card-reason,progress-update,quota-cache,silent-reply-guard,unhandled-rejection-policy}.test.ts"
         bktec run
       else
         echo "bktec token unavailable — falling back to plain vitest"


### PR DESCRIPTION
## Summary
Standalone, scope-isolated CI fix extracted from #114. One file, ~10 line change.

bktec v2.3.2's `zzglob` library only treats commas as separators inside `{a,b,c}` alternation groups — top-level commas are literal. The previous pipeline passed a comma-list pattern, parsed as one literal containing commas, matching nothing → "no files found" → tests didn't run on CI.

Fix: single brace-alternation pattern `{tests,test,experimental,src,telegram-plugin}/**/*.test.ts` plus an expanded exclude list mirroring `vitest.config.ts` (13 Bun-only test files vitest can't run under Node).

Bonus: old `telegram-plugin/tests/*.test.ts` (single-star) silently missed nested suites like `telegram-plugin/admin-commands/dispatch.test.ts`; the new `telegram-plugin/**/*.test.ts` recovers that coverage.

## Why a new PR
#114 ballooned to 28 files mixing this CI fix with unrelated feature work (perf telemetry, BRIEF.md support, progress card overhaul, etc.). Mixed scope makes the CI failure on #114 hard to attribute and impossible to revert cleanly. This PR is the CI fix only — landing it first lets us see whether the rest of #114's tests pass once tests actually run on CI.

## Test plan
- [ ] Buildkite picks up the new pattern; `tests-core` step actually discovers and runs tests
- [ ] Local: `vitest.config.ts` and bktec brace-glob agree on the same 13 excludes