### PR TITLE
test(config): exclude .claude/worktrees from vitest discovery

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -24,6 +24,10 @@ export default defineConfig({
     exclude: [
       "**/node_modules/**",
       "**/dist/**",
+      // `.claude/worktrees/<slug>/` are checkout copies created by sub-agent
+      // sessions. Their tests duplicate the canonical ones and run against
+      // stale code — never discover them from the canonical repo.
+      "**/.claude/worktrees/**",
       "**/telegram-plugin/tests/history.test.ts",
       "**/telegram-plugin/tests/ipc-server-client.test.ts",
       "**/telegram-plugin/tests/ipc-server-race.test.ts",


### PR DESCRIPTION
## Summary

Sub-agent worktrees under `.claude/worktrees/<slug>/` (created by Claude Code's worktree-isolation feature) contain duplicate test files that vitest was discovering and running against stale code. Locally this added hundreds of phantom failures to `npm test`.

The fix adds `**/.claude/worktrees/**` to vitest's exclude list.

## Test plan
- [x] `npm run lint` passes
- [x] `npm run test:vitest` no longer reports test files inside `.claude/worktrees`
- [ ] CI green