### PR TITLE
feat(schedule): suppress_stdout flag to skip stdout-to-Telegram forwarding

### DIFF
--- a/docs/scheduling.md
+++ b/docs/scheduling.md
@@ -36,6 +36,23 @@ For each schedule entry, switchroom generates:
 | `cron` | Yes | — | Standard 5-field cron expression |
 | `prompt` | Yes | — | The prompt sent to Claude |
 | `model` | No | `claude-sonnet-4-6` | Model for this task |
+| `secrets` | No | `[]` | Vault keys this task may read via the broker. See [configuration.md#vault-broker-linux-only](configuration.md#vault-broker-linux-only). |
+| `suppress_stdout` | No | `false` | When `true`, the cron script discards stdout instead of forwarding it to Telegram. Use for tasks that send their own message via MCP tools (`stream_reply` / `reply`) so the trailing model summary doesn't post as a duplicate. See [issue #118](https://github.com/switchroom/switchroom/issues/118). |
+
+### When to set `suppress_stdout: true`
+
+The default cron flow captures `claude -p`'s stdout and `curl`s it to Telegram, so the agent gets one message per cron run for free. That works for tasks that respond entirely via the model's final text — "morning briefing", "weekly summary", etc.
+
+It backfires for tasks that already post their own message via MCP tools (`mcp__switchroom-telegram__stream_reply`, `mcp__switchroom-telegram__reply`). The MCP tool call posts the formatted message; then the cron script forwards the model's trailing summary as a second message:
+
+```
+[MCP tool call]: 🌅 Morning briefing — 3 items on today's calendar...
+[stdout]:        Morning briefing sent. Key signals flagged: low sleep, gym in 2h.
+```
+
+The user sees both. The `HEARTBEAT_OK` / `NO_REPLY` sentinels can suppress the stdout but only if the model produces them as the exact final tokens — fragile.
+
+`suppress_stdout: true` is the deterministic switch. The cron script `exec`s `claude -p` with stdout routed to `/dev/null`, so only the MCP-tool-posted message reaches Telegram.
 
 ### Cron Expression Examples
 

--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -1182,11 +1182,14 @@ fi
 
 ${suppressStdout
     ? `# suppress_stdout: true (cron entry posts its own message via MCP tools — see issue #118)
-# Discard stdout so the trailing model summary doesn't arrive as a second message.
+# Discard stdout so the trailing model summary doesn't arrive as a second
+# Telegram message. Stderr is left open so systemd captures auth/network/
+# bad-prompt errors via journalctl — silently swallowing those would make
+# a broken cron job invisible to operators.
 exec claude -p ${shellSingleQuote(prompt)} \\
   --model ${shellSingleQuote(model)} \\
   --no-session-persistence \\
-  > /dev/null 2>&1
+  > /dev/null
 `
     : `# Run Claude one-shot (no persistent session, cheap model)
 OUTPUT=$(claude -p ${shellSingleQuote(prompt)} \\

--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -1128,6 +1128,12 @@ function parseDurationToSeconds(d: string | undefined): number | undefined {
  * with the configured model, sends output to Telegram via curl.
  * The script is self-contained — sources nvm, reads bot token from
  * .env at runtime, and uses POSIX quoting for the prompt.
+ *
+ * When `suppressStdout` is true (issue #118), the script discards stdout
+ * instead of forwarding it to Telegram. Use this for cron entries that
+ * post their own message via MCP tools (stream_reply / reply) — the
+ * trailing model summary that the cron prompt produces would otherwise
+ * arrive as a second, redundant Telegram message.
  */
 export function buildCronScript(
   agentDir: string,
@@ -1137,6 +1143,7 @@ export function buildCronScript(
   userId: string | undefined,
   secrets: string[] = [],
   brokerSocket?: string,
+  suppressStdout = false,
 ): string {
   const dest = userId ?? chatId;
   const secretsComment = secrets.length > 0
@@ -1173,7 +1180,15 @@ if [ -f "$CLAUDE_CONFIG_DIR/.oauth-token" ]; then
   export CLAUDE_CODE_OAUTH_TOKEN="$(cat "$CLAUDE_CONFIG_DIR/.oauth-token" | tr -d '[:space:]')"
 fi
 
-# Run Claude one-shot (no persistent session, cheap model)
+${suppressStdout
+    ? `# suppress_stdout: true (cron entry posts its own message via MCP tools — see issue #118)
+# Discard stdout so the trailing model summary doesn't arrive as a second message.
+exec claude -p ${shellSingleQuote(prompt)} \\
+  --model ${shellSingleQuote(model)} \\
+  --no-session-persistence \\
+  > /dev/null 2>&1
+`
+    : `# Run Claude one-shot (no persistent session, cheap model)
 OUTPUT=$(claude -p ${shellSingleQuote(prompt)} \\
   --model ${shellSingleQuote(model)} \\
   --no-session-persistence \\
@@ -1190,7 +1205,7 @@ curl -s "https://api.telegram.org/bot\${TELEGRAM_BOT_TOKEN}/sendMessage" \\
   -d parse_mode="HTML" \\
   -d disable_web_page_preview=true \\
   --data-urlencode text="$OUTPUT" > /dev/null 2>&1 || true
-`;
+`}`;
 }
 
 /**
@@ -2600,7 +2615,7 @@ export function scaffoldAgent(
     for (let i = 0; i < agentConfig.schedule!.length; i++) {
       const entry = agentConfig.schedule![i];
       const model = entry.model ?? "claude-sonnet-4-6";
-      const script = buildCronScript(agentDir, entry.prompt, model, telegramConfig.forum_chat_id, userId, entry.secrets ?? [], brokerSocket);
+      const script = buildCronScript(agentDir, entry.prompt, model, telegramConfig.forum_chat_id, userId, entry.secrets ?? [], brokerSocket, entry.suppress_stdout ?? false);
       const scriptPath = join(agentDir, "telegram", `cron-${i}.sh`);
       writeFileSync(scriptPath, script, { encoding: "utf-8", mode: 0o700 });
     }
@@ -3445,6 +3460,7 @@ Don't wait for a slash command. Don't ask permission. Memory work is table stake
       const script = buildCronScript(
         agentDir, entry.prompt, model,
         telegramConfig.forum_chat_id, cronUserId, entry.secrets ?? [], reconBrokerSocket,
+        entry.suppress_stdout ?? false,
       );
       const scriptPath = join(agentDir, "telegram", `cron-${i}.sh`);
       const before = existsSync(scriptPath) ? readFileSync(scriptPath, "utf-8") : "";

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -36,6 +36,16 @@ export const ScheduleEntrySchema = z.object({
       "Declared keys are injected as env vars at runtime (PR 2). " +
       "Empty by default — no vault access unless explicitly listed.",
     ),
+  suppress_stdout: z
+    .boolean()
+    .default(false)
+    .describe(
+      "When true, the cron script runs `claude -p` and discards stdout " +
+      "instead of forwarding it to Telegram. Use for tasks that send their " +
+      "own message via MCP tools (stream_reply / reply) so the trailing " +
+      "model summary doesn't post as a duplicate. Defaults to false to " +
+      "preserve the legacy stdout-forwarding behavior. See issue #118.",
+    ),
 });
 
 export const AgentSoulSchema = z

--- a/src/vault/broker/acl.test.ts
+++ b/src/vault/broker/acl.test.ts
@@ -37,6 +37,7 @@ function makeConfig(
         cron: s.cron,
         prompt: s.prompt,
         secrets: s.secrets ?? [],
+        suppress_stdout: false,
       })),
     };
   }

--- a/tests/scaffold.test.ts
+++ b/tests/scaffold.test.ts
@@ -2673,10 +2673,14 @@ describe("scheduled task cron script generation", () => {
       join(result.agentDir, "telegram", "cron-0.sh"),
       "utf-8",
     );
-    // Suppress path: exec claude directly, route output to /dev/null, no curl.
-    expect(content).toContain("suppress_stdout: true");
+    // Suppress path: `exec` replaces the shell with claude (no captured
+    // OUTPUT, no curl), and stdout goes to /dev/null. We assert on the
+    // structural shape — `exec claude -p ... > /dev/null` followed by the
+    // absence of the forwarding block — rather than the human-readable
+    // comment text, so the test doesn't break when the comment is reworded.
     expect(content).toContain("exec claude -p");
-    expect(content).toContain("> /dev/null 2>&1");
+    expect(content).toMatch(/> \/dev\/null(?!\s*2>&1)/); // stdout-only, stderr left for journal
+    expect(content).not.toContain("> /dev/null 2>&1"); // PR #125 review: don't swallow stderr
     expect(content).not.toContain("api.telegram.org");
     expect(content).not.toContain("OUTPUT=");
   });

--- a/tests/scaffold.test.ts
+++ b/tests/scaffold.test.ts
@@ -2644,6 +2644,70 @@ describe("scheduled task cron script generation", () => {
     expect(content).not.toContain("claude-sonnet-4-6");
   });
 
+  // Issue #118: cron entries that send their own message via MCP tools
+  // shouldn't also forward stdout to Telegram (would arrive as a duplicate).
+  it("default cron script forwards stdout to Telegram (legacy behavior)", () => {
+    const agentConfig = makeAgentConfig({
+      schedule: [{ cron: "0 8 * * *", prompt: "default-route" }],
+    });
+    const result = scaffoldAgent("default-cron", agentConfig, tmpDir, telegramConfig);
+    const content = readFileSync(
+      join(result.agentDir, "telegram", "cron-0.sh"),
+      "utf-8",
+    );
+    // Default path: capture stdout and curl it.
+    expect(content).toContain("OUTPUT=$(claude -p");
+    expect(content).toContain("api.telegram.org");
+    expect(content).toContain("sendMessage");
+    expect(content).not.toContain("suppress_stdout");
+  });
+
+  it("suppress_stdout=true skips the curl-to-Telegram block", () => {
+    const agentConfig = makeAgentConfig({
+      schedule: [
+        { cron: "0 7 * * *", prompt: "mcp-only", suppress_stdout: true },
+      ],
+    });
+    const result = scaffoldAgent("mcp-cron", agentConfig, tmpDir, telegramConfig);
+    const content = readFileSync(
+      join(result.agentDir, "telegram", "cron-0.sh"),
+      "utf-8",
+    );
+    // Suppress path: exec claude directly, route output to /dev/null, no curl.
+    expect(content).toContain("suppress_stdout: true");
+    expect(content).toContain("exec claude -p");
+    expect(content).toContain("> /dev/null 2>&1");
+    expect(content).not.toContain("api.telegram.org");
+    expect(content).not.toContain("OUTPUT=");
+  });
+
+  it("reconcile flips a cron from default to suppress_stdout", () => {
+    const baseAgent = makeAgentConfig({
+      schedule: [{ cron: "0 6 * * *", prompt: "test" }],
+    });
+    const switchroomConfig: SwitchroomConfig = {
+      switchroom: { version: 1, agents_dir: tmpDir },
+      telegram: telegramConfig,
+      agents: { "flip-cron": baseAgent },
+    } as SwitchroomConfig;
+    scaffoldAgent("flip-cron", baseAgent, tmpDir, telegramConfig, switchroomConfig);
+    const scriptPath = join(tmpDir, "flip-cron", "telegram", "cron-0.sh");
+    expect(readFileSync(scriptPath, "utf-8")).toContain("api.telegram.org");
+
+    const updated = makeAgentConfig({
+      schedule: [{ cron: "0 6 * * *", prompt: "test", suppress_stdout: true }],
+    });
+    const updatedConfig: SwitchroomConfig = {
+      ...switchroomConfig,
+      agents: { "flip-cron": updated },
+    } as SwitchroomConfig;
+    const result = reconcileAgent("flip-cron", updated, tmpDir, telegramConfig, updatedConfig);
+    expect(result.changes).toContain(scriptPath);
+    const updatedScript = readFileSync(scriptPath, "utf-8");
+    expect(updatedScript).toContain("exec claude -p");
+    expect(updatedScript).not.toContain("api.telegram.org");
+  });
+
   it("reconcile regenerates cron scripts when prompt changes", () => {
     const initial = makeAgentConfig({
       schedule: [{ cron: "0 8 * * *", prompt: "v1 prompt" }],


### PR DESCRIPTION
## Summary

Closes [switchroom#118](https://github.com/switchroom/switchroom/issues/118).

Cron sessions that post their own message via MCP tools (\`stream_reply\` / \`reply\`) currently arrive twice in Telegram: once from the MCP tool, then a second time when the cron script forwards the model's trailing summary via curl. The \`HEARTBEAT_OK\` / \`NO_REPLY\` sentinel approach is model-level and breaks the moment the model says one extra word.

This PR adds a deterministic config-level escape hatch:

\`\`\`yaml
schedule:
  - cron: "0 7 * * *"
    prompt: "Morning briefing"
    suppress_stdout: true   # NEW
\`\`\`

When set, the generated \`cron-N.sh\` switches from the capture-then-curl block to:

\`\`\`bash
exec claude -p '<prompt>' --model '<model>' --no-session-persistence > /dev/null 2>&1
\`\`\`

Default is \`false\` so behavior is unchanged for existing cron entries.

## Implementation
- [src/config/schema.ts](src/config/schema.ts) — new \`suppress_stdout\` boolean on \`ScheduleEntrySchema\` (default false)
- [src/agents/scaffold.ts](src/agents/scaffold.ts) — \`buildCronScript\` takes a new optional positional, both scaffold and reconcile call sites thread \`entry.suppress_stdout\` through
- [src/vault/broker/acl.test.ts](src/vault/broker/acl.test.ts) — builder updated for the now-required field on the parsed \`ScheduleEntry\` output type

## Test plan
- [x] \`npm run lint\`
- [x] New cases in [tests/scaffold.test.ts](tests/scaffold.test.ts):
  - default path forwards stdout to Telegram (legacy behavior)
  - \`suppress_stdout: true\` skips the curl-to-Telegram block
  - reconcile flips a cron from default → suppressed and reports the change
- [ ] CI green
- [ ] Manual smoke on the gymbro agent: set \`suppress_stdout: true\` on the morning briefing entry, confirm only one Telegram message arrives at trigger time