### PR TITLE
feat(gateway): log structured status-query telemetry (#109)

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -610,6 +610,11 @@ function logOutbound(
   )
 }
 
+// Issue #109: when a user types just "status" or "status?" they're asking
+// because the live progress surface failed to communicate. Anchored regex,
+// case-insensitive, optional trailing "?" — must be the entire body.
+const STATUS_QUERY_RE = /^\s*status\??\s*$/i
+
 // ─── Permission handling ──────────────────────────────────────────────────
 const PERMISSION_REPLY_RE = /^\s*(y|yes|n|no)\s+([a-km-z]{5})\s*$/i
 const pendingPermissions = new Map<string, { tool_name: string; description: string; input_preview: string; startedAt: number }>()
@@ -2208,6 +2213,32 @@ async function handleInbound(
   const msgId = ctx.message?.message_id
 
   if (messageThreadId != null) chatThreadMap.set(chat_id, messageThreadId)
+
+  // Issue #109: when the user has to ask "status?" mid-turn, the live progress
+  // surface (pinned card + status reactions) has failed its job. Log the
+  // event with a snapshot of the card state so we can count + analyze
+  // frequency. We don't intercept the message — it still flows through to
+  // the agent, since the agent may have a useful answer the card hasn't
+  // surfaced yet.
+  if (STATUS_QUERY_RE.test(text)) {
+    try {
+      const threadKey = messageThreadId != null ? String(messageThreadId) : undefined
+      const cardState = progressDriver?.peek(chat_id, threadKey)
+      const turnAge = cardState?.turnStartedAt
+        ? Math.max(0, Math.floor((Date.now() - cardState.turnStartedAt) / 1000))
+        : null
+      const stage = cardState?.stage ?? 'idle'
+      const itemCount = cardState?.items.length ?? 0
+      const subAgentCount = cardState?.subAgents.size ?? 0
+      const agentName = process.env.SWITCHROOM_AGENT_NAME ?? '-'
+      process.stderr.write(
+        `telegram gateway: ux-failure status-query agent=${agentName} chat_id=${chat_id} thread=${threadKey ?? 'none'} ` +
+        `card_stage=${stage} card_turn_age_s=${turnAge ?? 'idle'} card_items=${itemCount} card_subagents=${subAgentCount}\n`,
+      )
+    } catch (err) {
+      process.stderr.write(`telegram gateway: status-query telemetry failed: ${(err as Error).message}\n`)
+    }
+  }
 
   // Permission-reply intercept
   const permMatch = PERMISSION_REPLY_RE.exec(text)

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -2220,20 +2220,30 @@ async function handleInbound(
   // frequency. We don't intercept the message — it still flows through to
   // the agent, since the agent may have a useful answer the card hasn't
   // surfaced yet.
+  //
+  // Log shape (grep anchor: "ux-failure: status-query"):
+  //   ux-failure: status-query agent=<n> chat_id=<n> thread=<n|none>
+  //                            card_stage=<stage> card_turn_age_s=<int>
+  //                            card_items=<n> card_subagents=<n>
+  //
+  // `card_turn_age_s` is always a non-negative integer; `-1` is the
+  // sentinel for "no active turn / driver idle" so structured-log parsers
+  // (Loki, Datadog, awk) can treat the field as numeric without
+  // string-comparison branches.
   if (STATUS_QUERY_RE.test(text)) {
     try {
       const threadKey = messageThreadId != null ? String(messageThreadId) : undefined
       const cardState = progressDriver?.peek(chat_id, threadKey)
-      const turnAge = cardState?.turnStartedAt
+      const turnAgeS = cardState?.turnStartedAt
         ? Math.max(0, Math.floor((Date.now() - cardState.turnStartedAt) / 1000))
-        : null
+        : -1
       const stage = cardState?.stage ?? 'idle'
       const itemCount = cardState?.items.length ?? 0
       const subAgentCount = cardState?.subAgents.size ?? 0
       const agentName = process.env.SWITCHROOM_AGENT_NAME ?? '-'
       process.stderr.write(
-        `telegram gateway: ux-failure status-query agent=${agentName} chat_id=${chat_id} thread=${threadKey ?? 'none'} ` +
-        `card_stage=${stage} card_turn_age_s=${turnAge ?? 'idle'} card_items=${itemCount} card_subagents=${subAgentCount}\n`,
+        `telegram gateway: ux-failure: status-query agent=${agentName} chat_id=${chat_id} thread=${threadKey ?? 'none'} ` +
+        `card_stage=${stage} card_turn_age_s=${turnAgeS} card_items=${itemCount} card_subagents=${subAgentCount}\n`,
       )
     } catch (err) {
       process.stderr.write(`telegram gateway: status-query telemetry failed: ${(err as Error).message}\n`)


### PR DESCRIPTION
## Summary

Closes step 1 of [switchroom#109](https://github.com/switchroom/switchroom/issues/109).

When a user types just \`status\` / \`status?\` mid-turn, the pinned progress card has failed its job — the user shouldn't need to ask. The issue's first ask is telemetry: count and analyze how often this happens before deciding on follow-on UX changes.

This PR adds an anchored regex match in [telegram-plugin/gateway/gateway.ts](telegram-plugin/gateway/gateway.ts) at the top of \`handleInbound\` (just after the access gate). On match, it emits a structured stderr line with a snapshot of the card state — agent name, chat/thread, card stage, turn age in seconds, item count, sub-agent count.

\`\`\`
telegram gateway: ux-failure status-query agent=klanker chat_id=-1001234 thread=42 card_stage=Run card_turn_age_s=187 card_items=3 card_subagents=1
\`\`\`

The message is **not** intercepted — it still flows through to the agent so the agent can answer the question if the card hadn't.

## Out of scope

The issue's stretch items (auto-flush the card on status query, proactive heartbeat beats) are deliberately **not** in this PR. They're invasive enough to deserve their own change after we have telemetry showing *where* the silent stretches actually happen. This PR just unlocks the measurement.

## Test plan
- [x] \`npm run lint\`
- [ ] Manual smoke: send \`status?\` in a Telegram chat, confirm the log line appears in journalctl with the expected fields
- [ ] Run a few weeks → \`grep 'ux-failure status-query' service.log | wc -l\` gives a frequency number
- [ ] CI green