### PR TITLE
fix(progress-card): add diagnostic logs at narrative capture, render decision, and prose recovery

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -1798,11 +1798,27 @@ function handleSessionEvent(ev: SessionEvent): void {
           threadId != null ? String(threadId) : undefined,
         )
         const recovered = recoverProseFromProgressCard(peek)
+        // Issue #81 diagnostic: record both the success and the empty-recover
+        // path so we can correlate "card showed tool-count" with "recovery
+        // had nothing to give either". The narrative count tells us whether
+        // the issue is at capture time (no narratives ever made it into the
+        // state) or at parse time (narratives existed but produced empty
+        // text after trim).
+        const narrativeCount = peek?.narratives.length ?? 0
         if (recovered.length > 0) {
           process.stderr.write(
             `telegram gateway: turn-flush prose-recovery — recovered ${recovered.length} chars from progress-card narratives chat=${chatId} turnKey=${currentTurnStartedAt}\n`,
           )
+          process.stderr.write(
+            `progress-card.diag: prose-recovery hit chatId=${chatId} turnKey=${currentTurnStartedAt} ` +
+            `narrative_count=${narrativeCount} recovered_len=${recovered.length}\n`,
+          )
           currentTurnCapturedText.push(recovered)
+        } else {
+          process.stderr.write(
+            `progress-card.diag: prose-recovery miss chatId=${chatId} turnKey=${currentTurnStartedAt} ` +
+            `narrative_count=${narrativeCount} peek_state=${peek == null ? 'null' : 'present'}\n`,
+          )
         }
       }
 

--- a/telegram-plugin/progress-card-driver.ts
+++ b/telegram-plugin/progress-card-driver.ts
@@ -671,6 +671,23 @@ export function createProgressDriver(config: ProgressDriverConfig): ProgressDriv
       taskNum.total > 1 ? taskNum : undefined,
       { stuckMs },
     )
+    // Issue #81 diagnostic: which checklist branch is the renderer taking?
+    // The card prefers `narratives` (human preambles) over `items` (raw
+    // tool counts). When prose lands without narratives we want to know
+    // why — log the available state at the decision boundary.
+    if (forceDone || chatState.lastEmittedHtml == null /* first emit */) {
+      const s = chatState.state
+      const branch = s.narratives.length > 0
+        ? 'narratives'
+        : s.items.length > 0
+          ? 'tool-count-fallback'
+          : 'empty'
+      process.stderr.write(
+        `progress-card.diag: render branch=${branch} chatId=${chatState.chatId} turnKey=${chatState.turnKey} ` +
+        `narratives=${s.narratives.length} items=${s.items.length} latestText_len=${s.latestText?.length ?? 0} ` +
+        `subagents=${s.subAgents.size} pendingPreamble=${s.pendingPreamble ? 'yes' : 'no'} forceDone=${forceDone}\n`,
+      )
+    }
     if (html === chatState.lastEmittedHtml && !forceDone) return
     chatState.lastEmittedHtml = html
     chatState.lastEmittedAt = now()
@@ -886,6 +903,23 @@ export function createProgressDriver(config: ProgressDriverConfig): ProgressDriv
       chatState.lastEventAt = now()
       const stageChanged = chatState.state.stage !== prev.stage
       const visibleChanged = visibleDiff(prev, chatState.state)
+
+      // Issue #81 diagnostic: when a 'text' event lands, did the reducer
+      // recognize it as a narrative step? If narratives.length didn't grow,
+      // the card's "human-readable preamble" path can't render and the
+      // tool-count fallback wins. The log lets us correlate "user typed
+      // status?" telemetry with the missing narrative path.
+      if (event.kind === 'text') {
+        const before = prev.narratives.length
+        const after = chatState.state.narratives.length
+        const last = chatState.state.narratives[after - 1]
+        const preview = last?.text ? last.text.slice(0, 60).replace(/\n/g, ' ') : ''
+        const took = before === after ? 'discarded' : 'captured'
+        process.stderr.write(
+          `progress-card.diag: text-event ${took} chatId=${chatState.chatId} turnKey=${chatState.turnKey} ` +
+          `narratives_before=${before} narratives_after=${after} text_len=${event.text.length} preview=${JSON.stringify(preview)}\n`,
+        )
+      }
 
       // Cancel any pending coalesce timer — we'll either fire now or
       // reschedule.

--- a/telegram-plugin/progress-card-driver.ts
+++ b/telegram-plugin/progress-card-driver.ts
@@ -675,7 +675,12 @@ export function createProgressDriver(config: ProgressDriverConfig): ProgressDriv
     // The card prefers `narratives` (human preambles) over `items` (raw
     // tool counts). When prose lands without narratives we want to know
     // why — log the available state at the decision boundary.
-    if (forceDone || chatState.lastEmittedHtml == null /* first emit */) {
+    //
+    // Fires on the first emit AND on any forced-done flush (terminal
+    // state via completeTurnFully / closeZombie / maybeCompleteDeferredTurn)
+    // — both are useful inflection points for understanding what the card
+    // looked like when it transitioned.
+    if (forceDone || chatState.lastEmittedHtml == null /* first emit or terminal flush */) {
       const s = chatState.state
       const branch = s.narratives.length > 0
         ? 'narratives'
@@ -909,7 +914,13 @@ export function createProgressDriver(config: ProgressDriverConfig): ProgressDriv
       // the card's "human-readable preamble" path can't render and the
       // tool-count fallback wins. The log lets us correlate "user typed
       // status?" telemetry with the missing narrative path.
-      if (event.kind === 'text') {
+      //
+      // Gated behind PROGRESS_CARD_DIAG=1 because this fires on every
+      // assistant text event — a long verbose turn could produce dozens
+      // of lines per minute. The render-branch and prose-recovery diags
+      // (~2x and ~1x per turn respectively) stay always-on. Flip the env
+      // var on a one-off agent restart to capture data, then turn it off.
+      if (event.kind === 'text' && process.env.PROGRESS_CARD_DIAG === '1') {
         const before = prev.narratives.length
         const after = chatState.state.narratives.length
         const last = chatState.state.narratives[after - 1]


### PR DESCRIPTION
## Summary

Refs [switchroom#81](https://github.com/switchroom/switchroom/issues/81).

The progress card sometimes renders raw tool counts (\`3× Bash\`) instead of the human-readable preamble path, even when the agent did emit a preamble line. Issue #81 asks for diagnostic logging at the three decision points so we can capture which path is taken and why, then file a follow-up with the data.

This PR adds three log lines, all prefixed with \`progress-card.diag:\` for easy grep:

1. **text-event** — in [progress-card-driver.ts](telegram-plugin/progress-card-driver.ts) after \`reduce()\` runs on a \`text\` event. Reports \`captured\` vs \`discarded\` (the \`extractNarrativeLabel\` filter), narrative count before/after, and a 60-char preview.
2. **render branch=** — in \`flush()\` on first emit and on \`forceDone\`. Reports which checklist branch the renderer chose (\`narratives\` / \`tool-count-fallback\` / \`empty\`) plus the input counts.
3. **prose-recovery hit/miss** — in [gateway.ts](telegram-plugin/gateway/gateway.ts) turn-flush recovery path. Reports both the success and the empty-recover path with narrative count.

No behavior changes — pure logging. After a few real turns exhibit the bug, the logs should pinpoint which decision fails and a follow-up PR can land the fix.

## Test plan
- [x] \`npm run lint\` passes
- [ ] Manual smoke: run a tool-heavy turn and confirm three flavors of \`progress-card.diag:\` appear in journalctl
- [ ] After data is in hand, file a follow-up bug with the actual root cause + fix
- [ ] CI green