### PR TITLE
fix(ci): bypass bktec + soft_fail Eval summary so main goes green

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -97,6 +97,9 @@ steps:
       # to capture debug logs to diagnose. The bktec block below is wired
       # to capture those logs the next time someone flips the env flag —
       # see CHECKLIST in the comment block immediately below.
+      # bktec disabled by default (exit-16 on every Core-tests run since
+      # build #65; tracking issue #107). Re-enable with SWITCHROOM_USE_BKTEC=1
+      # in the cluster env once you're ready to capture --debug logs.
       if [[ "$$SWITCHROOM_USE_BKTEC" == "1" ]]; then
         # ─── bktec re-enable checklist (skills/buildkite-test-engine) ───
         # 1. SWITCHROOM_TEST_ENGINE_API_TOKEN cluster secret must exist with
@@ -118,6 +121,11 @@ steps:
         #    `custom` with a TEST_CMD that substitutes {{testExamples}}.
         #    The custom runner doesn't need RESULT_PATH (per bktec's
         #    config validation in internal/config/validate.go).
+        # 6. **Restore `parallelism: 2` on this step** when re-enabling.
+        #    bktec aborts with "BUILDKITE_PARALLEL_JOB_COUNT was 0" without
+        #    it. The directive was removed in this PR because plain vitest
+        #    runs the suite once, so duplicating jobs would just waste
+        #    compute.
         export BUILDKITE_TEST_ENGINE_API_ACCESS_TOKEN="$$(buildkite-agent secret get SWITCHROOM_TEST_ENGINE_API_TOKEN 2>/dev/null || true)"
         if [[ -n "$$BUILDKITE_TEST_ENGINE_API_ACCESS_TOKEN" ]]; then
           export BUILDKITE_TEST_ENGINE_DEBUG_ENABLED="true"
@@ -287,9 +295,13 @@ steps:
     # a public badge gist. Neither is load-bearing — every status that
     # matters (build, type-check, tests, evals) already shows on the build
     # page. A red Eval summary should never fail the build, so soft_fail
-    # any exit_status >= 1 (the publish-badges curl PATCH can 404 the gist
-    # on fork PRs that don't have access to the GIST_TOKEN cluster secret).
-    soft_fail: true
+    # the exit codes the scripts can plausibly produce (1 from a script
+    # failure, 2 from buildkite-agent secret/artifact errors). We
+    # deliberately do NOT mask agent loss (-1) or signal kills (143) so
+    # those infrastructure failures still bubble up.
+    soft_fail:
+      - exit_status: 1
+      - exit_status: 2
     command: |
       mkdir -p evals/results
       # Download to "." — buildkite-agent preserves the artifact's original

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -92,26 +92,47 @@ steps:
       export BUILDKITE_ANALYTICS_TOKEN="$$(buildkite-agent secret get ANALYTICS_TOKEN_VITEST 2>/dev/null || true)"
       # Run vitest directly. bktec parallel sharding is opt-in via
       # SWITCHROOM_USE_BKTEC=1 — see the bktec block below. Plain vitest is
-      # the default because every recent build of bktec v2.3.2 has exited 16
-      # ("no files found") on this repo's pattern, even after switching from
-      # comma-separated to brace alternation in PR #120. The pattern parses
-      # correctly per drjosh.dev/zzglob docs (brace + ** are both supported
-      # and combinable), so the failure is somewhere else in the pipeline:
-      # discoverTestFiles, the test-plan API call, or vitest argument
-      # construction. Until that's diagnosed with bktec --debug logs, the
-      # parallel-sharding gain isn't worth a red main. See issues #107, #111.
+      # the default because every Core-tests run since #65 has exited bktec
+      # with code 16 (any non-exec error) and the team hasn't had a chance
+      # to capture debug logs to diagnose. The bktec block below is wired
+      # to capture those logs the next time someone flips the env flag —
+      # see CHECKLIST in the comment block immediately below.
       if [[ "$$SWITCHROOM_USE_BKTEC" == "1" ]]; then
+        # ─── bktec re-enable checklist (skills/buildkite-test-engine) ───
+        # 1. SWITCHROOM_TEST_ENGINE_API_TOKEN cluster secret must exist with
+        #    the read_suites scope (Personal Settings > API Access Tokens).
+        # 2. Confirm the `switchroom-vitest` suite has historical timing
+        #    data — without it, bktec falls back to file-count splitting
+        #    instead of timing-balanced. The collector is wired in
+        #    vitest.config.ts via BUILDKITE_ANALYTICS_TOKEN; check the
+        #    Test Engine dashboard.
+        # 3. DEBUG_ENABLED=true is on so the build log will print
+        #    "Discovering test files with include pattern: ..." +
+        #    "Discovered N files" — that confirms the zzglob-based
+        #    discoverTestFiles is finding our suite.
+        # 4. We do NOT download the bktec binary ourselves: hosted
+        #    Buildkite agents have it pre-installed. Downloading v2.3.2
+        #    from GitHub Releases shadows whatever fixed version the
+        #    hosted image already ships.
+        # 5. vitest is not a natively-supported runner, so we use
+        #    `custom` with a TEST_CMD that substitutes {{testExamples}}.
+        #    The custom runner doesn't need RESULT_PATH (per bktec's
+        #    config validation in internal/config/validate.go).
         export BUILDKITE_TEST_ENGINE_API_ACCESS_TOKEN="$$(buildkite-agent secret get SWITCHROOM_TEST_ENGINE_API_TOKEN 2>/dev/null || true)"
         if [[ -n "$$BUILDKITE_TEST_ENGINE_API_ACCESS_TOKEN" ]]; then
-          BKTEC_VERSION="2.3.2"
-          curl -fsSL "https://github.com/buildkite/test-engine-client/releases/download/v$${BKTEC_VERSION}/bktec_$${BKTEC_VERSION}_linux_amd64" \
-            -o /usr/local/bin/bktec && chmod +x /usr/local/bin/bktec
+          export BUILDKITE_TEST_ENGINE_DEBUG_ENABLED="true"
           export BUILDKITE_TEST_ENGINE_SUITE_SLUG="switchroom-vitest"
           export BUILDKITE_TEST_ENGINE_TEST_RUNNER="custom"
           export BUILDKITE_TEST_ENGINE_TEST_CMD="bunx vitest run {{testExamples}}"
           export BUILDKITE_TEST_ENGINE_TEST_FILE_PATTERN="{tests,test,experimental,src,telegram-plugin}/**/*.test.ts"
           export BUILDKITE_TEST_ENGINE_TEST_FILE_EXCLUDE_PATTERN="telegram-plugin/tests/{history,ipc-server-client,ipc-server-race,gateway-bridge,gateway-startup-mutex,gateway-clean-shutdown-marker,foreman-state,boot-card-dedupe,boot-card-reason,progress-update,quota-cache,silent-reply-guard,unhandled-rejection-policy}.test.ts"
-          bktec run
+          if command -v bktec >/dev/null 2>&1; then
+            bktec --version
+            bktec run
+          else
+            echo "SWITCHROOM_USE_BKTEC=1 set but bktec is not pre-installed on this agent. Falling back to plain vitest."
+            bun run test:vitest
+          fi
         else
           echo "SWITCHROOM_USE_BKTEC=1 set but bktec token unavailable — falling back to plain vitest"
           bun run test:vitest

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -262,6 +262,13 @@ steps:
       - evals-trigger
       - evals-quality
     allow_dependency_failure: true
+    # Best-effort: this step only writes a Buildkite annotation and patches
+    # a public badge gist. Neither is load-bearing — every status that
+    # matters (build, type-check, tests, evals) already shows on the build
+    # page. A red Eval summary should never fail the build, so soft_fail
+    # any exit_status >= 1 (the publish-badges curl PATCH can 404 the gist
+    # on fork PRs that don't have access to the GIST_TOKEN cluster secret).
+    soft_fail: true
     command: |
       mkdir -p evals/results
       # Download to "." — buildkite-agent preserves the artifact's original
@@ -269,7 +276,9 @@ steps:
       # root, not `evals/results/`, otherwise files land at
       # `evals/results/evals/results/*.json` and the script can't find them.
       buildkite-agent artifact download "evals/results/*.json" . || true
-      bash .buildkite/annotate-evals.sh
-      # Publish dynamic shields.io badges (best-effort — never fails the build)
+      # Annotation + badge publish are independent best-effort steps —
+      # gate each one with `|| true` so a failure in one doesn't drop the
+      # next, and the step never aborts under buildkite's default `set -e`.
+      bash .buildkite/annotate-evals.sh || echo "annotate-evals.sh failed (continuing)"
       export GITHUB_GIST_TOKEN="$$(buildkite-agent secret get GITHUB_GIST_TOKEN 2>/dev/null || true)"
-      bash .buildkite/publish-badges.sh
+      bash .buildkite/publish-badges.sh || echo "publish-badges.sh failed (continuing)"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -61,12 +61,6 @@ steps:
 
   - label: ":vitest: Core tests"
     key: tests-core
-    # bktec splits test files across parallel jobs via BUILDKITE_PARALLEL_JOB /
-    # BUILDKITE_PARALLEL_JOB_COUNT. Those env vars are only populated when the
-    # step declares parallelism — without it, `bktec run` aborts with
-    # "BUILDKITE_PARALLEL_JOB_COUNT was 0". Two parallel jobs is a conservative
-    # start; bump when suite timing warrants it.
-    parallelism: 2
     # Stub token so importing server.ts (via cross-package coverage of
     # telegram-plugin/tests/*.test.ts) doesn't boot the legacy monolith path
     # and demand a live TELEGRAM_BOT_TOKEN. Tests never actually poll Telegram.
@@ -96,42 +90,33 @@ steps:
       # switchroom-vitest suite. When unset, vitest.config.ts falls back to
       # the default reporter and no upload is attempted.
       export BUILDKITE_ANALYTICS_TOKEN="$$(buildkite-agent secret get ANALYTICS_TOKEN_VITEST 2>/dev/null || true)"
-      # Buildkite Test Engine Client (bktec): splits test files across
-      # parallel nodes using historical timing from the suite above.
-      # bktec is installed from GitHub releases; graceful fallback to plain
-      # vitest if the binary or token is unavailable.
-      #
-      # Token key cannot start with BUILDKITE/BK (cluster secret restriction),
-      # so it is stored as SWITCHROOM_TEST_ENGINE_API_TOKEN and re-exported.
-      export BUILDKITE_TEST_ENGINE_API_ACCESS_TOKEN="$$(buildkite-agent secret get SWITCHROOM_TEST_ENGINE_API_TOKEN 2>/dev/null || true)"
-      if [[ -n "$$BUILDKITE_TEST_ENGINE_API_ACCESS_TOKEN" ]]; then
-        # Install bktec (linux amd64 — matches Buildkite hosted agent shape)
-        BKTEC_VERSION="2.3.2"
-        curl -fsSL "https://github.com/buildkite/test-engine-client/releases/download/v$${BKTEC_VERSION}/bktec_$${BKTEC_VERSION}_linux_amd64" \
-          -o /usr/local/bin/bktec && chmod +x /usr/local/bin/bktec
-        export BUILDKITE_TEST_ENGINE_SUITE_SLUG="switchroom-vitest"
-        export BUILDKITE_TEST_ENGINE_TEST_RUNNER="custom"
-        # vitest accepts test file paths as positional args — bktec substitutes
-        # the assigned file list in place of {{testExamples}}.
-        export BUILDKITE_TEST_ENGINE_TEST_CMD="bunx vitest run {{testExamples}}"
-        # Match all test files that vitest.config.ts would include.
-        #
-        # Root cause of issue #111: bktec v2.3.2 uses drjosh.dev/zzglob which
-        # does NOT treat commas as pattern separators at the top level — commas
-        # are only significant inside {a,b,c} alternation groups. A
-        # comma-separated list like "tests/**,src/**" is parsed as a single
-        # literal glob containing commas, which matches no real paths, so bktec
-        # exits with "no files found". Fix: use a single brace-alternation
-        # pattern instead.
-        #
-        # Exclude pattern mirrors vitest.config.ts excludes — these files use
-        # Bun-only APIs (bun:sqlite, bun:test timers, Bun.spawn) that vitest
-        # running under Node cannot resolve.
-        export BUILDKITE_TEST_ENGINE_TEST_FILE_PATTERN="{tests,test,experimental,src,telegram-plugin}/**/*.test.ts"
-        export BUILDKITE_TEST_ENGINE_TEST_FILE_EXCLUDE_PATTERN="telegram-plugin/tests/{history,ipc-server-client,ipc-server-race,gateway-bridge,gateway-startup-mutex,gateway-clean-shutdown-marker,foreman-state,boot-card-dedupe,boot-card-reason,progress-update,quota-cache,silent-reply-guard,unhandled-rejection-policy}.test.ts"
-        bktec run
+      # Run vitest directly. bktec parallel sharding is opt-in via
+      # SWITCHROOM_USE_BKTEC=1 — see the bktec block below. Plain vitest is
+      # the default because every recent build of bktec v2.3.2 has exited 16
+      # ("no files found") on this repo's pattern, even after switching from
+      # comma-separated to brace alternation in PR #120. The pattern parses
+      # correctly per drjosh.dev/zzglob docs (brace + ** are both supported
+      # and combinable), so the failure is somewhere else in the pipeline:
+      # discoverTestFiles, the test-plan API call, or vitest argument
+      # construction. Until that's diagnosed with bktec --debug logs, the
+      # parallel-sharding gain isn't worth a red main. See issues #107, #111.
+      if [[ "$$SWITCHROOM_USE_BKTEC" == "1" ]]; then
+        export BUILDKITE_TEST_ENGINE_API_ACCESS_TOKEN="$$(buildkite-agent secret get SWITCHROOM_TEST_ENGINE_API_TOKEN 2>/dev/null || true)"
+        if [[ -n "$$BUILDKITE_TEST_ENGINE_API_ACCESS_TOKEN" ]]; then
+          BKTEC_VERSION="2.3.2"
+          curl -fsSL "https://github.com/buildkite/test-engine-client/releases/download/v$${BKTEC_VERSION}/bktec_$${BKTEC_VERSION}_linux_amd64" \
+            -o /usr/local/bin/bktec && chmod +x /usr/local/bin/bktec
+          export BUILDKITE_TEST_ENGINE_SUITE_SLUG="switchroom-vitest"
+          export BUILDKITE_TEST_ENGINE_TEST_RUNNER="custom"
+          export BUILDKITE_TEST_ENGINE_TEST_CMD="bunx vitest run {{testExamples}}"
+          export BUILDKITE_TEST_ENGINE_TEST_FILE_PATTERN="{tests,test,experimental,src,telegram-plugin}/**/*.test.ts"
+          export BUILDKITE_TEST_ENGINE_TEST_FILE_EXCLUDE_PATTERN="telegram-plugin/tests/{history,ipc-server-client,ipc-server-race,gateway-bridge,gateway-startup-mutex,gateway-clean-shutdown-marker,foreman-state,boot-card-dedupe,boot-card-reason,progress-update,quota-cache,silent-reply-guard,unhandled-rejection-policy}.test.ts"
+          bktec run
+        else
+          echo "SWITCHROOM_USE_BKTEC=1 set but bktec token unavailable — falling back to plain vitest"
+          bun run test:vitest
+        fi
       else
-        echo "bktec token unavailable — falling back to plain vitest"
         bun run test:vitest
       fi
     cache:


### PR DESCRIPTION
## Summary

Two fixes — verified green on [build #86](https://buildkite.com/ken-thompson/switchroom/builds/86):

### 1. Bypass bktec (default to plain vitest)

[Build #77](https://buildkite.com/ken-thompson/switchroom/builds/77) and every \`:vitest: Core tests\` run since #65 fails with **bktec exit code 16**. PR #120 (comma → brace alternation) didn't unblock it — the brace pattern fails just as silently as the comma form did. bktec wraps every non-exec error as exit 16 ([main.go logErrorAndExit](https://github.com/buildkite/test-engine-client/blob/v2.3.2/main.go)), so the real cause could be the file glob, the test-plan API call, or vitest argument construction. Without \`bktec --debug\` we can't tell which. Per the [zzglob docs](https://pkg.go.dev/drjosh.dev/zzglob), our pattern syntax should work.

- Gate bktec on \`SWITCHROOM_USE_BKTEC=1\` (default off). Re-enable later by setting that in cluster env.
- Default path: plain \`bun run test:vitest\`.
- Drop \`parallelism: 2\` — only existed for bktec sharding.

### 2. soft_fail Eval summary + gate scripts with \`|| true\`

The bktec fix exposed a downstream issue. With Core tests now passing, the eval steps run, soft-fail (allowed), and then the **Eval summary** step hard-failed in 1 second. Both \`annotate-evals.sh\` and \`publish-badges.sh\` are documented best-effort with \`exit 0\` at the end, but they're invoked from a YAML \`command: |\` block where buildkite's default shell sets \`-e\`, so any non-zero exit aborts the step.

- \`soft_fail: true\` on the Eval summary step.
- \`|| echo "... (continuing)"\` on each script invocation so an annotate failure doesn't drop the publish-badges call.

## Build #86 final state (this PR)

| Step | Outcome |
|---|---|
| :pipeline: Upload | passed |
| :lock: Type check | passed |
| :vitest: Core tests | **passed** ← was the blocker |
| :telegram: Plugin tests (402) | passed |
| :compass: Skills evals — trigger routing | soft_failed (allowed) |
| :sparkles: Skills evals — quality | soft_failed (allowed) |
| :bar_chart: Eval summary | passed |

GitHub status check: **SUCCESS**

## Follow-ups

- Capture \`bktec --debug\` on a one-off branch with \`SWITCHROOM_USE_BKTEC=1\` to diagnose the original exit-16 cause.
- Investigate why \`Skills evals — quality\` is soft-failing — possibly real eval flakiness, possibly a credential issue on fork PRs.

Refs [#107](https://github.com/switchroom/switchroom/issues/107), [#111](https://github.com/switchroom/switchroom/issues/111)