### PR TITLE
fix(vault-broker): SO_PEERCRED via bun:ffi + concurrency-safe ss fallback (#129 item 6)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -105,6 +105,25 @@ Materialized `kind="files"` dirs land under `$XDG_RUNTIME_DIR/switchroom/vault/<
 
 Manage entries with `switchroom vault set <key>`, `switchroom vault get <key>`, and `switchroom vault list`. Multi-line string values are preserved verbatim via piped stdin or `--file <path>`; file-kind entries are set programmatically via `setFilesSecret` (a CLI surface for multi-file set is tracked separately).
 
+### Vault broker (Linux only)
+
+For scheduled tasks that need vault access, switchroom can run a long-lived **vault broker** daemon that holds the decrypted vault in memory after a one-time passphrase entry. Cron scripts then ask the broker for keys instead of prompting for the passphrase on every run. The broker is **Linux-only by design** — its access control relies on cgroup-based systemd unit identification, which doesn't exist on macOS / WSL. On non-Linux platforms `switchroom vault get` always reads the vault file directly with the user's passphrase.
+
+```yaml
+agents:
+  myagent:
+    schedule:
+      - cron: "0 8 * * *"
+        prompt: "morning briefing"
+        secrets: [google_calendar_token, weather_api_key]   # NEW
+```
+
+The `secrets:` array is **misconfiguration protection, not a security boundary**: it prevents a typo in cron-A from accidentally reading cron-B's keys, and it makes the per-cron secret surface area explicit at config-review time. It does not prevent attack — anyone who can edit cron scripts on the host can also edit `switchroom.yaml` to declare any keys, and anyone who has the vault passphrase can read the vault file directly. Frame it as: "the cron-A script that asks for `weather_api_key` was clearly meant to ask for it" — not "the cron-A script can't reach `bank_token` even if compromised."
+
+The broker is started/stopped via `switchroom vault broker {start,stop,status,unlock,lock}`. When `installAllUnits()` runs (called by `switchroom agent create` and similar), a `switchroom-vault-broker.service` user unit is installed with `Restart=on-failure`, so the broker auto-restarts if it crashes and auto-starts at user login.
+
+For interactive use — `switchroom vault get key`, `switchroom vault set key`, etc. — the CLI does **not** go through the broker. It reads the vault file directly with your passphrase. The broker's ACL would deny an interactive caller anyway (no cron systemd unit), and the user already has the passphrase.
+
 ### Per-skill dependency caches
 
 Skills that need a Python venv or a Node `node_modules` tree get a lazy, hash-stamped cache per skill — no system-level installs, no per-agent duplication.

--- a/src/agents/systemd.ts
+++ b/src/agents/systemd.ts
@@ -337,13 +337,21 @@ export function installAllUnits(config: SwitchroomConfig): void {
 
   // Install the vault-broker unit when any agent uses secrets or
   // vault.broker.enabled is set.
+  //
+  // Bug fix (issue #129): the previous call passed `"switchroom-vault-broker"`
+  // as the unit name, but `installUnit` wraps that with another `switchroom-`
+  // prefix, producing `switchroom-switchroom-vault-broker.service` on disk —
+  // which never matched the `switchroom-vault-broker.service` reference used
+  // by cron timers' After/Wants. Pass the bare `vault-broker` so the file
+  // ends up correctly named.
   if (shouldInstallBrokerUnit(config)) {
     const homeDir = process.env.HOME ?? "/root";
     const bunBinDir = resolve(homeDir, ".bun", "bin");
     const brokerContent = generateBrokerUnit({ homeDir, bunBinDir });
-    const brokerUnitName = "switchroom-vault-broker";
-    installUnit(brokerUnitName, brokerContent);
-    installedAgents.push(brokerUnitName);
+    installUnit("vault-broker", brokerContent);
+    // installedAgents holds the OS unit name (with the `switchroom-` prefix
+    // that systemctl needs).
+    installedAgents.push("switchroom-vault-broker");
   }
 
   // Every telegram-using agent gets its OWN gateway unit. The gateway
@@ -382,6 +390,14 @@ export function installAllUnits(config: SwitchroomConfig): void {
   daemonReload();
   enableUnits(installedAgents);
   ensureLinger();
+
+  // Auto-start the broker if it was just installed (issue #129). Agent and
+  // gateway units stay in the enabled-but-not-running state until the user
+  // runs `switchroom agent start <name>` — that's deliberate. The broker is
+  // a passive infrastructure daemon, so there's no reason not to start it.
+  if (installedAgents.includes("switchroom-vault-broker")) {
+    startBrokerUnit();
+  }
 }
 
 export function daemonReload(): void {
@@ -401,6 +417,42 @@ function enableUnits(unitNames: string[]): void {
     execFileSync("systemctl", ["--user", "enable", ...services], { stdio: "pipe" });
   } catch {
     // non-fatal — units are installed but won't auto-start on boot
+  }
+}
+
+/**
+ * Start (or restart) the vault-broker user unit.
+ *
+ * The broker is the only switchroom unit that should auto-start at install
+ * time: agent and gateway units are intentionally left in the
+ * enabled-but-not-running state until the user runs `switchroom agent start`.
+ * The broker, by contrast, is a stateless infrastructure daemon — there is
+ * no UX reason to delay starting it. Issue #129 added this so a fresh
+ * install ends up with `switchroom-vault-broker.service` actually running,
+ * rather than enabled-but-still-needs-manual-start.
+ *
+ * Best-effort: failure is logged but not fatal (broker can still be started
+ * on demand by `switchroom vault broker start`). Skipped on non-Linux where
+ * the broker is unsupported anyway.
+ */
+function startBrokerUnit(): void {
+  if (process.platform !== "linux") return;
+  try {
+    // `restart` instead of `start` so reconciling an already-running broker
+    // picks up any unit-file changes (PATH, RestartSec, etc.) on the spot.
+    execFileSync(
+      "systemctl",
+      ["--user", "restart", "switchroom-vault-broker.service"],
+      { stdio: "pipe" },
+    );
+  } catch (err) {
+    // Don't surface as an error — the daemon may simply not have a vault to
+    // unlock yet (it'll keep crashing until passphrase is pushed). Log on
+    // stderr so operators have a breadcrumb.
+    process.stderr.write(
+      `[switchroom] note: failed to (re)start switchroom-vault-broker.service: ` +
+      `${err instanceof Error ? err.message : String(err)}\n`,
+    );
   }
 }
 

--- a/src/cli/vault-get-broker.test.ts
+++ b/src/cli/vault-get-broker.test.ts
@@ -1,26 +1,18 @@
 /**
- * Integration test: `vault get` routes through the broker.
+ * Integration test: broker client round-trip.
  *
- * Starts a real broker with seeded in-memory secrets on a tmp socket,
- * sets SWITCHROOM_VAULT_BROKER_SOCK, then invokes the CLI via child_process
- * and asserts stdout matches the secret value without a passphrase prompt.
+ * Starts a real broker with seeded in-memory secrets on a tmp socket and
+ * exercises the client's status / get / lock paths.
  *
- * Note: On Linux, peercred ACL kicks in and the CLI process (not a recognized
- * cron script) will be denied. This test is platform-scoped accordingly:
- *   - non-Linux: tests broker get round-trip
- *   - Linux:     tests that the broker is reachable and status works;
- *                get round-trip is covered by allowing allow_interactive=true
- *
- * TODO (PR 3): Add a gated systemd e2e test that:
- *   - Installs switchroom-vault-broker.service and starts it
- *   - Unlocks via the unlock socket
- *   - Runs a real cron script and asserts the secret is returned
- *   - Verifies that a cron script for a different agent cannot read the key
- *   This requires a real systemd user session and a properly scaffolded agent.
+ * Note: On Linux, peercred ACL kicks in and the test process (not a
+ * recognized cron unit) will be denied for `get`. That is the broker's
+ * intended behavior — interactive callers don't go through the broker;
+ * they use `switchroom vault get --no-broker` (or auto-fallback).
+ * See issue #129. On non-Linux, the broker has no peercred and serves
+ * any same-user caller, so the round-trip succeeds.
  */
 
 import { describe, expect, it, beforeAll, afterAll } from "vitest";
-import * as cp from "node:child_process";
 import * as os from "node:os";
 import * as path from "node:path";
 import * as fs from "node:fs";
@@ -31,7 +23,7 @@ const TEST_SECRETS: Record<string, VaultEntry> = {
   my_token: { kind: "string", value: "super-secret-value" },
 };
 
-function makeInteractiveConfig(socketPath: string) {
+function makeBrokerConfig(socketPath: string) {
   return {
     switchroom: { version: 1 },
     telegram: { bot_token: "test", forum_chat_id: "123" },
@@ -40,7 +32,6 @@ function makeInteractiveConfig(socketPath: string) {
       broker: {
         socket: socketPath,
         enabled: true,
-        allow_interactive: true, // Permit the switchroom CLI binary in tests
       },
     },
     agents: {},
@@ -51,14 +42,21 @@ describe("vault get → broker integration", () => {
   let broker: VaultBroker;
   let tmpDir: string;
   let socketPath: string;
+  let prevNonLinuxFlag: string | undefined;
 
   beforeAll(async () => {
+    // The broker is Linux-only by design (issue #129); opt into the
+    // non-Linux dev escape hatch so this test can boot a broker on
+    // whatever the runner happens to be. No-op on Linux.
+    prevNonLinuxFlag = process.env.SWITCHROOM_BROKER_ALLOW_NON_LINUX;
+    process.env.SWITCHROOM_BROKER_ALLOW_NON_LINUX = "1";
+
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "broker-int-test-"));
     socketPath = path.join(tmpDir, "test-data.sock");
 
     broker = new VaultBroker({
       _testSecrets: { ...TEST_SECRETS },
-      _testConfig: makeInteractiveConfig(socketPath),
+      _testConfig: makeBrokerConfig(socketPath),
     });
     await broker.start(socketPath, undefined, undefined);
   });
@@ -68,6 +66,11 @@ describe("vault get → broker integration", () => {
     try {
       fs.rmSync(tmpDir, { recursive: true, force: true });
     } catch { /* ignore */ }
+    if (prevNonLinuxFlag === undefined) {
+      delete process.env.SWITCHROOM_BROKER_ALLOW_NON_LINUX;
+    } else {
+      process.env.SWITCHROOM_BROKER_ALLOW_NON_LINUX = prevNonLinuxFlag;
+    }
   });
 
   it("broker is reachable and reports unlocked status", async () => {
@@ -78,22 +81,21 @@ describe("vault get → broker integration", () => {
     expect(status?.keyCount).toBe(1);
   });
 
-  it("getViaBroker returns the secret value", async () => {
+  it("getViaBroker returns the secret value (or null on Linux ACL deny)", async () => {
     const { getViaBroker } = await import("../vault/broker/client.js");
     const entry = await getViaBroker("my_token", { socket: socketPath });
-    // On Linux without allow_interactive effective (peercred denies non-cron),
-    // this returns null. On other platforms, it returns the value.
     if (process.platform !== "linux") {
+      // No peercred on non-Linux: the broker serves any same-user caller,
+      // so the round-trip succeeds and we get the seeded value back.
       expect(entry).not.toBeNull();
       expect(entry?.kind).toBe("string");
       if (entry?.kind === "string") {
         expect(entry.value).toBe("super-secret-value");
       }
     } else {
-      // Linux: peercred will deny the test process since it's not a cron script
-      // This is correct behavior — ACL is working as intended.
-      // allow_interactive=true requires the exe to match bunBinDir/switchroom
-      // which won't match bun/node in test context.
+      // Linux: peercred identifies us as not-a-cron-unit, ACL denies.
+      // Correct behavior — interactive callers are expected to use
+      // `switchroom vault get --no-broker`. See issue #129.
       expect(entry).toBeNull();
     }
   });
@@ -141,4 +143,45 @@ describe("vault-broker client: unreachable broker", () => {
     });
     expect(result).toBe(false);
   });
+
+  // Issue #129: structured result distinguishes unreachable from denied.
+  it("getViaBrokerStructured returns kind=unreachable with msg for ENOENT socket", async () => {
+    const { getViaBrokerStructured } = await import("../vault/broker/client.js");
+    const result = await getViaBrokerStructured("key", {
+      socket: "/tmp/definitely-does-not-exist-broker.sock",
+      timeoutMs: 100,
+    });
+    expect(result.kind).toBe("unreachable");
+    if (result.kind === "unreachable") {
+      // The legacy null-on-anything API loses this signal; the structured
+      // version surfaces enough detail for callers to log a useful reason.
+      expect(result.msg).toMatch(/socket not found|connection failed|did not respond/);
+    }
+  });
+});
+
+// Issue #129: the broker is Linux-only by design. On non-Linux, start()
+// throws unless SWITCHROOM_BROKER_ALLOW_NON_LINUX=1 was explicitly set.
+describe("VaultBroker.start non-Linux refusal", () => {
+  it.skipIf(process.platform === "linux")(
+    "throws a clear Linux-only error when SWITCHROOM_BROKER_ALLOW_NON_LINUX is unset",
+    async () => {
+      const prev = process.env.SWITCHROOM_BROKER_ALLOW_NON_LINUX;
+      delete process.env.SWITCHROOM_BROKER_ALLOW_NON_LINUX;
+      try {
+        const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "broker-refusal-"));
+        const sock = path.join(tmp, "x.sock");
+        const broker = new VaultBroker({
+          _testSecrets: {},
+          _testConfig: makeBrokerConfig(sock),
+        });
+        await expect(broker.start(sock, undefined, undefined)).rejects.toThrow(
+          /Linux-only|SWITCHROOM_BROKER_ALLOW_NON_LINUX/,
+        );
+        try { fs.rmSync(tmp, { recursive: true, force: true }); } catch { /* ignore */ }
+      } finally {
+        if (prev !== undefined) process.env.SWITCHROOM_BROKER_ALLOW_NON_LINUX = prev;
+      }
+    },
+  );
 });

--- a/src/cli/vault.ts
+++ b/src/cli/vault.ts
@@ -14,7 +14,7 @@ import {
 } from "../vault/vault.js";
 import { registerVaultSweep } from "./vault-sweep.js";
 import {
-  getViaBroker,
+  getViaBrokerStructured,
   statusViaBroker,
   unlockViaBroker,
   resolveBrokerSocketPath,
@@ -267,29 +267,57 @@ export function registerVaultCommand(program: Command): void {
           }
 
           // Broker is unlocked — request the key
-          const entry = await getViaBroker(key, brokerOpts);
-          if (entry === null) {
-            // Null from broker = DENIED or UNKNOWN_KEY
-            // Re-check with a status+error response by trying again and looking at response
-            if (process.stdin.isTTY) {
-              console.error(
-                chalk.yellow(
-                  `Key '${key}' not in ACL or not found. Use --no-broker to read directly.`,
-                ),
-              );
-              process.exit(2);
-            } else {
-              console.error(`key '${key}' not in ACL`);
-              process.exit(2);
+          const result = await getViaBrokerStructured(key, brokerOpts);
+
+          if (result.kind === "ok") {
+            const entry = result.entry;
+            if (entry.kind === "string" || entry.kind === "binary") {
+              console.log(entry.value);
+              return;
             }
-          }
-          if (entry.kind === "string" || entry.kind === "binary") {
-            console.log(entry.value);
-          } else {
             console.error(chalk.yellow(`Secret '${key}' is kind="${entry.kind}"`));
             process.exit(1);
           }
-          return;
+
+          if (result.kind === "not_found") {
+            // Broker is healthy and we're allowed; the key just doesn't
+            // exist. Direct vault decrypt won't help — exit straight away.
+            console.error(chalk.yellow(`Secret '${key}' not found in vault`));
+            process.exit(1);
+          }
+
+          if (result.kind === "denied") {
+            // ACL rejection or vault locked. For interactive callers, fall
+            // through to direct vault decrypt with the user's passphrase
+            // (--no-broker semantics). For non-interactive callers, fail
+            // with the broker's reason so cron logs explain it.
+            if (process.stdin.isTTY) {
+              console.error(
+                chalk.yellow(
+                  `broker denied request (${result.code}): ${result.msg}. ` +
+                  `Falling back to direct vault access.`,
+                ),
+              );
+              // fall through to direct-decrypt block below
+            } else {
+              console.error(
+                `broker denied request for '${key}' (${result.code}): ${result.msg}`,
+              );
+              process.exit(2);
+            }
+          } else {
+            // result.kind === "unreachable" — fall through to direct decrypt.
+            // The status check above already returned non-null, so this is a
+            // weird mid-request failure (broker died between status and get?).
+            if (process.stdin.isTTY) {
+              console.error(
+                chalk.yellow(`broker became unreachable mid-request: ${result.msg}`),
+              );
+            } else {
+              console.error(`broker unreachable: ${result.msg}`);
+              process.exit(1);
+            }
+          }
         }
 
         // Broker not reachable

--- a/src/config/schema.test.ts
+++ b/src/config/schema.test.ts
@@ -82,7 +82,6 @@ describe("VaultConfigSchema.broker", () => {
     expect(result.broker).toEqual({
       socket: "~/.switchroom/vault-broker.sock",
       enabled: true,
-      allow_interactive: false,
     });
   });
 

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -32,9 +32,13 @@ export const ScheduleEntrySchema = z.object({
     .array(z.string().regex(/^[a-zA-Z0-9_-]+$/, "Secret key names must contain only alphanumeric characters, underscores, and hyphens"))
     .default([])
     .describe(
-      "Vault key names this cron task is allowed to access via the vault-broker daemon. " +
-      "Declared keys are injected as env vars at runtime (PR 2). " +
-      "Empty by default — no vault access unless explicitly listed.",
+      "Vault key names this cron task may read via the vault-broker daemon. " +
+      "Empty by default — broker requests for unlisted keys are denied. " +
+      "Note: this is misconfiguration protection (a typo in cron-A doesn't " +
+      "accidentally read cron-B's keys) rather than a security boundary — " +
+      "anyone who can edit cron scripts can also edit switchroom.yaml, and " +
+      "anyone with the vault passphrase can read the vault file directly. " +
+      "See docs/configuration.md for the full framing.",
     ),
 });
 
@@ -736,15 +740,6 @@ export const VaultConfigSchema = z.object({
         .boolean()
         .default(true)
         .describe("Whether to start the vault-broker daemon on agent launch"),
-      allow_interactive: z
-        .boolean()
-        .default(false)
-        .describe(
-          "If true, the installed switchroom CLI binary may read any vault key " +
-          "via the broker without being declared in a cron ACL. Off by default — " +
-          "enable only for interactive developer workflows where the operator " +
-          "understands the trust model.",
-        ),
     })
     .default({})
     .describe(

--- a/src/vault/broker/acl.test.ts
+++ b/src/vault/broker/acl.test.ts
@@ -1,16 +1,19 @@
 /**
  * Tests for vault-broker ACL enforcement.
  *
- * Identity is established via cgroup-based systemdUnit (not exe path).
- * Covers:
+ * Identity is established via cgroup-based systemdUnit. Covers:
  *   - Valid cron unit + key in schedule secrets → allowed
  *   - Valid cron unit + key NOT in secrets → denied
  *   - Cross-agent: unit for agentA can't read agentB's secrets → denied
- *   - systemdUnit=null + allow_interactive=true + exe is switchroom CLI → allowed
- *   - systemdUnit=null + allow_interactive=false (default) → denied
+ *   - systemdUnit=null (interactive caller, broker not for them) → denied
  *   - Malformed/unrecognized unit name → denied
  *   - Unknown agent name in unit → denied
  *   - Out-of-range schedule index → denied
+ *
+ * Note: there is no "interactive fallback" path. The broker is for cron-driven
+ * access only. Interactive `switchroom vault get` reads the vault file directly
+ * with the user's passphrase via --no-broker (or auto-fallback when broker
+ * denies / is unreachable). See issue #129.
  */
 
 import { describe, expect, it } from "vitest";
@@ -18,16 +21,12 @@ import { checkAcl } from "./acl.js";
 import type { SwitchroomConfig } from "../../config/schema.js";
 import type { PeerInfo } from "./peercred.js";
 
-const HOME_DIR = "/home/testuser";
-const BUN_BIN_DIR = `${HOME_DIR}/.bun/bin`;
-
 /** Minimal valid SwitchroomConfig stub */
 function makeConfig(
   agentSchedules: Record<
     string,
     Array<{ cron: string; prompt: string; secrets?: string[] }>
   >,
-  allowInteractive = false,
 ): SwitchroomConfig {
   const agents: SwitchroomConfig["agents"] = {};
   for (const [name, schedule] of Object.entries(agentSchedules)) {
@@ -37,6 +36,7 @@ function makeConfig(
         cron: s.cron,
         prompt: s.prompt,
         secrets: s.secrets ?? [],
+        suppress_stdout: false,
       })),
     };
   }
@@ -48,7 +48,6 @@ function makeConfig(
       broker: {
         socket: "~/.switchroom/vault-broker.sock",
         enabled: true,
-        allow_interactive: allowInteractive,
       },
     },
     agents,
@@ -64,8 +63,6 @@ function peer(
   return { uid, pid, exe, systemdUnit };
 }
 
-const OPTS = { homeDir: HOME_DIR, bunBinDir: BUN_BIN_DIR };
-
 describe("ACL: cgroup-based cron identity", () => {
   it("allows a key that is in the declared secrets", () => {
     const config = makeConfig({
@@ -75,7 +72,6 @@ describe("ACL: cgroup-based cron identity", () => {
       peer("switchroom-myagent-cron-0.service"),
       config,
       "api_key",
-      OPTS,
     );
     expect(result.allow).toBe(true);
   });
@@ -88,7 +84,6 @@ describe("ACL: cgroup-based cron identity", () => {
       peer("switchroom-myagent-cron-0.service"),
       config,
       "other_secret",
-      OPTS,
     );
     expect(result.allow).toBe(false);
     if (!result.allow) {
@@ -104,9 +99,30 @@ describe("ACL: cgroup-based cron identity", () => {
       peer("switchroom-myagent-cron-0.service"),
       config,
       "any_key",
-      OPTS,
     );
     expect(result.allow).toBe(false);
+  });
+
+  it("does not leak the allowed-keys list in the deny reason", () => {
+    // Defense-in-depth: the per-cron deny message should not enumerate the
+    // allowed key set — same-UID callers can already read the config file,
+    // but the protocol should not echo the allowlist back.
+    const config = makeConfig({
+      myagent: [
+        { cron: "0 8 * * *", prompt: "hi", secrets: ["secret_a", "secret_b", "secret_c"] },
+      ],
+    });
+    const result = checkAcl(
+      peer("switchroom-myagent-cron-0.service"),
+      config,
+      "not_in_acl",
+    );
+    expect(result.allow).toBe(false);
+    if (!result.allow) {
+      expect(result.reason).not.toContain("secret_a");
+      expect(result.reason).not.toContain("secret_b");
+      expect(result.reason).not.toContain("secret_c");
+    }
   });
 
   it("prevents cross-agent key leakage (unit for otheragent can't read myagent secrets)", () => {
@@ -119,7 +135,6 @@ describe("ACL: cgroup-based cron identity", () => {
       peer("switchroom-otheragent-cron-0.service"),
       config,
       "api_key",
-      OPTS,
     );
     expect(result.allow).toBe(false);
   });
@@ -132,12 +147,12 @@ describe("ACL: cgroup-based cron identity", () => {
       ],
     });
     // cron-0 may read key_a but not key_b
-    expect(checkAcl(peer("switchroom-myagent-cron-0.service"), config, "key_a", OPTS).allow).toBe(true);
-    expect(checkAcl(peer("switchroom-myagent-cron-0.service"), config, "key_b", OPTS).allow).toBe(false);
+    expect(checkAcl(peer("switchroom-myagent-cron-0.service"), config, "key_a").allow).toBe(true);
+    expect(checkAcl(peer("switchroom-myagent-cron-0.service"), config, "key_b").allow).toBe(false);
 
     // cron-1 may read key_b but not key_a
-    expect(checkAcl(peer("switchroom-myagent-cron-1.service"), config, "key_b", OPTS).allow).toBe(true);
-    expect(checkAcl(peer("switchroom-myagent-cron-1.service"), config, "key_a", OPTS).allow).toBe(false);
+    expect(checkAcl(peer("switchroom-myagent-cron-1.service"), config, "key_b").allow).toBe(true);
+    expect(checkAcl(peer("switchroom-myagent-cron-1.service"), config, "key_a").allow).toBe(false);
   });
 });
 
@@ -150,7 +165,6 @@ describe("ACL: unknown agent → denied", () => {
       peer("switchroom-unknownagent-cron-0.service"),
       config,
       "key",
-      OPTS,
     );
     expect(result.allow).toBe(false);
     if (!result.allow) {
@@ -169,7 +183,6 @@ describe("ACL: out-of-range schedule index → denied", () => {
       peer("switchroom-myagent-cron-5.service"),
       config,
       "key",
-      OPTS,
     );
     expect(result.allow).toBe(false);
     if (!result.allow) {
@@ -188,9 +201,7 @@ describe("ACL: malformed unit name → denied", () => {
       peer("switchroom-myagent-cron-.service"),
       config,
       "key",
-      OPTS,
     );
-    // systemdUnit is not null, but parseCronUnit will reject it
     expect(result.allow).toBe(false);
   });
 
@@ -202,57 +213,21 @@ describe("ACL: malformed unit name → denied", () => {
       peer("some-random.service"),
       config,
       "key",
-      OPTS,
     );
     expect(result.allow).toBe(false);
   });
 });
 
-describe("ACL: allow_interactive", () => {
-  it("grants access when allow_interactive=true and exe is switchroom CLI (systemdUnit=null)", () => {
-    const config = makeConfig({}, true);
-    const switchroomExe = `${BUN_BIN_DIR}/switchroom`;
-    const result = checkAcl(
-      peer(null, switchroomExe),
-      config,
-      "any_key",
-      OPTS,
-    );
-    expect(result.allow).toBe(true);
-  });
-
-  it("denies when allow_interactive=false (default) even for switchroom CLI", () => {
-    const config = makeConfig({}, false);
-    const switchroomExe = `${BUN_BIN_DIR}/switchroom`;
-    const result = checkAcl(
-      peer(null, switchroomExe),
-      config,
-      "any_key",
-      OPTS,
-    );
-    expect(result.allow).toBe(false);
-  });
-
-  it("denies when allow_interactive absent (defaults to false)", () => {
+describe("ACL: non-cron callers (systemdUnit=null) → denied", () => {
+  it("denies any key for a caller without a switchroom cron systemd unit", () => {
+    // Replaces the prior "allow_interactive" tests. The broker no longer
+    // serves interactive callers — they read the vault file directly with
+    // the user's passphrase via `switchroom vault get --no-broker`.
     const config = makeConfig({});
-    const switchroomExe = `${BUN_BIN_DIR}/switchroom`;
-    const result = checkAcl(
-      peer(null, switchroomExe),
-      config,
-      "any_key",
-      OPTS,
-    );
+    const result = checkAcl(peer(null, "/some/path/switchroom"), config, "any_key");
     expect(result.allow).toBe(false);
-  });
-
-  it("denies interactive even with allow_interactive=true when exe is not switchroom CLI", () => {
-    const config = makeConfig({}, true);
-    const result = checkAcl(
-      peer(null, "/usr/bin/bash"),
-      config,
-      "any_key",
-      OPTS,
-    );
-    expect(result.allow).toBe(false);
+    if (!result.allow) {
+      expect(result.reason).toContain("not a switchroom cron unit");
+    }
   });
 });

--- a/src/vault/broker/acl.ts
+++ b/src/vault/broker/acl.ts
@@ -1,10 +1,18 @@
 /**
  * vault-broker ACL — per-cron access control for vault key requests.
  *
- * Identity is established via cgroup membership, not the exe path. When
- * systemd starts a cron unit (`switchroom-<agent>-cron-<i>.service`), it
- * places the process in a dedicated cgroup that it writes as root. Processes
- * cannot move themselves between cgroups from userspace, making the unit name
+ * The broker is for cron-driven access. Interactive `switchroom vault get`
+ * runs against the vault file directly with the user's passphrase — it
+ * does not need (and never had a real reason to use) the broker. Issue #129
+ * dropped the broker's interactive fallback for this reason: the symlink-
+ * fragile `peer.exe == bunBinDir/switchroom` check it relied on was both
+ * easy to bypass (npx, wrappers, $PATH) and easy to break (rename, move,
+ * different package manager).
+ *
+ * Identity is established via cgroup membership. When systemd starts a
+ * cron unit (`switchroom-<agent>-cron-<i>.service`), it places the process
+ * in a dedicated cgroup that it writes as root. Processes cannot move
+ * themselves between cgroups from userspace, making the unit name
  * unspoofable.
  *
  * Logic (fail-closed on any error):
@@ -14,23 +22,20 @@
  *
  *   2. If `peer.systemdUnit` matches `switchroom-<agent>-cron-<i>.service`:
  *      `<agent>` and `<i>` are parsed from the unit name. Then
- *      `config.agents[<agent>].schedule[<i>].secrets` (added by PR 1) is
- *      looked up. If the requested key appears in that array, access is
- *      granted. Otherwise: deny.
+ *      `config.agents[<agent>].schedule[<i>].secrets` is looked up.
+ *      If the requested key appears in that array, access is granted.
+ *      Otherwise: deny.
  *
- *   3. Interactive fallback: if `config.vault.broker.allow_interactive` is
- *      true AND `peer.exe` matches the installed `switchroom` CLI binary
- *      (<bunBinDir>/switchroom), access is granted. Default: false.
+ *   3. Otherwise: deny. Use `switchroom vault get --no-broker` to read
+ *      directly from the vault file with your passphrase.
  *
- *   4. Otherwise: deny.
- *
- * allow_interactive is gated off by default so ordinary users can't use
- * `switchroom vault get <key>` to read any key without being in an explicit
- * ACL. Operators who want an interactive shell workflow enable it explicitly.
+ * Note on threat model: the per-cron `secrets[]` allowlist is
+ * misconfiguration protection (a typo lets cron-A read cron-B's keys),
+ * not a security boundary. Anyone who can edit cron scripts can also edit
+ * the config to grant any key. See [docs/architecture.md] for the full
+ * framing.
  */
 
-import { resolve, join } from "node:path";
-import { homedir } from "node:os";
 import type { SwitchroomConfig } from "../../config/schema.js";
 import type { PeerInfo } from "./peercred.js";
 
@@ -44,16 +49,6 @@ export interface AclDeny {
 }
 
 export type AclResult = AclAllow | AclDeny;
-
-/**
- * Options for ACL checking, injectable for tests.
- */
-export interface AclOpts {
-  /** Override for the home directory (default: os.homedir()) */
-  homeDir?: string;
-  /** Override for the bun bin directory (default: ~/.bun/bin) */
-  bunBinDir?: string;
-}
 
 /**
  * Parse a systemd unit name as a switchroom cron unit.
@@ -93,17 +88,12 @@ export function parseCronUnit(
  * @param peer    Caller identity from peercred.identify()
  * @param config  The loaded SwitchroomConfig
  * @param key     The vault key being requested
- * @param opts    Overrides for home/bunBinDir (for tests)
  */
 export function checkAcl(
   peer: PeerInfo,
   config: SwitchroomConfig,
   key: string,
-  opts: AclOpts = {},
 ): AclResult {
-  const homeDir = opts.homeDir ?? homedir();
-  const bunBinDir = opts.bunBinDir ?? join(homeDir, ".bun", "bin");
-
   // ── Cgroup-based cron identity ─────────────────────────────────────────
   if (peer.systemdUnit !== null) {
     const parsed = parseCronUnit(peer.systemdUnit);
@@ -136,26 +126,17 @@ export function checkAcl(
     if (!allowedKeys.includes(key)) {
       return {
         allow: false,
-        reason: `key '${key}' not in ACL for ${agentName}/schedule[${index}] (allowed: [${allowedKeys.join(", ")}])`,
+        reason: `key '${key}' not in ACL for ${agentName}/schedule[${index}]`,
       };
     }
 
     return { allow: true };
   }
 
-  // ── Allow interactive: the installed switchroom CLI ────────────────────
-  // Only reached when systemdUnit is null (caller is not a cron unit).
-  // /proc/<pid>/exe always resolves to a bare binary path with no args.
-  const allowInteractive = config.vault?.broker?.allow_interactive ?? false;
-  if (allowInteractive) {
-    const switchroomCli = join(bunBinDir, "switchroom");
-    if (peer.exe === switchroomCli) {
-      return { allow: true };
-    }
-  }
-
+  // ── Non-cron callers are not served by the broker ──────────────────────
+  // Use `switchroom vault get --no-broker` for interactive access.
   return {
     allow: false,
-    reason: `caller is not a switchroom cron unit (no cgroup match) and allow_interactive is disabled`,
+    reason: "caller is not a switchroom cron unit; use 'switchroom vault get --no-broker' for interactive access",
   };
 }

--- a/src/vault/broker/client.ts
+++ b/src/vault/broker/client.ts
@@ -22,6 +22,7 @@ import {
   decodeResponse,
   type BrokerResponse,
   type BrokerStatus,
+  type ErrorCode,
 } from "./protocol.js";
 import type { VaultEntry } from "../vault.js";
 
@@ -43,6 +44,33 @@ export interface UnlockResult {
 }
 
 /**
+ * Structured result from a broker `get` request.
+ *
+ * `kind` discriminator surfaces the four cases callers actually need to
+ * distinguish, instead of collapsing all failures into `null` (issue #129).
+ *
+ *   - `ok`           — entry was returned; use `.entry`.
+ *   - `unreachable`  — broker is not running, timed out, or refused the
+ *                     connection. Caller may want to fall back to direct
+ *                     vault decrypt with the user's passphrase.
+ *   - `denied`       — broker rejected the caller (cron unit not in ACL,
+ *                     allow_interactive disabled, vault locked, etc).
+ *                     Falling back to direct decrypt is the right move
+ *                     for the CLI; for cron scripts it's a config bug.
+ *   - `not_found`    — broker is running and the caller is allowed, but
+ *                     the key doesn't exist in the vault. Don't fall back.
+ *
+ * `code` is the wire error code from `protocol.ts` (LOCKED, DENIED,
+ * UNKNOWN_KEY, BAD_REQUEST, INTERNAL) for `denied` and `not_found` cases.
+ * `msg` is the broker's human-readable reason.
+ */
+export type GetResult =
+  | { kind: "ok"; entry: VaultEntry }
+  | { kind: "unreachable"; msg: string }
+  | { kind: "denied"; code: ErrorCode; msg: string }
+  | { kind: "not_found"; code: ErrorCode; msg: string };
+
+/**
  * Resolve the data socket path from options.
  */
 export function resolveBrokerSocketPath(opts?: BrokerClientOpts): string {
@@ -54,20 +82,28 @@ export function resolveBrokerSocketPath(opts?: BrokerClientOpts): string {
 }
 
 /**
+ * Result of a single RPC: either a parsed broker response, or an
+ * "unreachable" status with a human-readable reason. Internal helper
+ * — public API on top distinguishes denied vs not-found vs unreachable.
+ */
+type RpcResult =
+  | { kind: "response"; resp: BrokerResponse }
+  | { kind: "unreachable"; msg: string };
+
+/**
  * Send a single request to the broker and get a response.
- * Returns null on connection failure (unreachable broker).
- * Throws on protocol errors (bad response).
+ * Returns { kind: "unreachable", msg } on any connection / protocol failure.
  */
 async function rpc(
   req: Parameters<typeof encodeRequest>[0],
   opts?: BrokerClientOpts,
-): Promise<BrokerResponse | null> {
+): Promise<RpcResult> {
   const socketPath = resolveBrokerSocketPath(opts);
   const timeoutMs = opts?.timeoutMs ?? DEFAULT_TIMEOUT_MS;
 
-  return new Promise<BrokerResponse | null>((resolve) => {
+  return new Promise<RpcResult>((resolve) => {
     let settled = false;
-    const settle = (val: BrokerResponse | null): void => {
+    const settle = (val: RpcResult): void => {
       if (settled) return;
       settled = true;
       resolve(val);
@@ -75,23 +111,20 @@ async function rpc(
 
     const timer = setTimeout(() => {
       client.destroy();
-      settle(null);
+      settle({ kind: "unreachable", msg: `broker did not respond within ${timeoutMs}ms` });
     }, timeoutMs);
 
     const client = net.createConnection({ path: socketPath });
 
     client.on("error", (err: NodeJS.ErrnoException) => {
       clearTimeout(timer);
-      // Unreachable broker — return null (not an error for the caller)
-      if (
-        err.code === "ENOENT" ||
-        err.code === "ECONNREFUSED" ||
-        err.code === "EACCES"
-      ) {
-        settle(null);
-      } else {
-        settle(null); // treat all connection errors as unreachable
-      }
+      const code = err.code ?? "ERR";
+      let msg: string;
+      if (code === "ENOENT") msg = "broker socket not found (is the daemon running?)";
+      else if (code === "ECONNREFUSED") msg = "broker socket exists but refused connection";
+      else if (code === "EACCES") msg = "broker socket access denied (wrong UID?)";
+      else msg = `broker connection failed: ${err.message}`;
+      settle({ kind: "unreachable", msg });
     });
 
     let buffer = "";
@@ -104,9 +137,12 @@ async function rpc(
         client.destroy();
         try {
           const resp = decodeResponse(line);
-          settle(resp);
-        } catch {
-          settle(null);
+          settle({ kind: "response", resp });
+        } catch (err) {
+          settle({
+            kind: "unreachable",
+            msg: `unparseable broker response: ${err instanceof Error ? err.message : String(err)}`,
+          });
         }
       }
     });
@@ -114,10 +150,13 @@ async function rpc(
     client.on("connect", () => {
       try {
         client.write(encodeRequest(req));
-      } catch {
+      } catch (err) {
         clearTimeout(timer);
         client.destroy();
-        settle(null);
+        settle({
+          kind: "unreachable",
+          msg: `failed to send request: ${err instanceof Error ? err.message : String(err)}`,
+        });
       }
     });
   });
@@ -125,16 +164,49 @@ async function rpc(
 
 /**
  * Get a vault entry via the broker.
- * Returns null if broker is unreachable or key is not found.
+ *
+ * Returns a structured `GetResult` distinguishing the four cases callers
+ * actually need to act on. See the `GetResult` type for semantics.
+ *
+ * For ergonomic callers that only care about success vs anything-else,
+ * use `getEntryOrNull()` below — it preserves the old null-on-failure shape.
+ */
+export async function getViaBrokerStructured(
+  key: string,
+  opts?: BrokerClientOpts,
+): Promise<GetResult> {
+  const result = await rpc({ v: 1, op: "get", key }, opts);
+  if (result.kind === "unreachable") {
+    return { kind: "unreachable", msg: result.msg };
+  }
+  const resp = result.resp;
+  if (resp.ok && "entry" in resp) {
+    return { kind: "ok", entry: resp.entry as VaultEntry };
+  }
+  if (!resp.ok) {
+    // UNKNOWN_KEY is "broker is healthy and willing, but the key isn't there"
+    // — meaningfully different from DENIED for the CLI's UX. LOCKED, DENIED,
+    // BAD_REQUEST, INTERNAL all roll up into "denied" from the caller's
+    // perspective: the broker said no and it isn't a missing-key issue.
+    if (resp.code === "UNKNOWN_KEY") {
+      return { kind: "not_found", code: resp.code, msg: resp.msg };
+    }
+    return { kind: "denied", code: resp.code, msg: resp.msg };
+  }
+  return { kind: "unreachable", msg: "unexpected broker response shape" };
+}
+
+/**
+ * Get a vault entry via the broker. Legacy shape: returns the entry on
+ * success or `null` on any failure. Prefer `getViaBrokerStructured()` in
+ * new code so the caller can tell unreachable from denied from not-found.
  */
 export async function getViaBroker(
   key: string,
   opts?: BrokerClientOpts,
 ): Promise<VaultEntry | null> {
-  const resp = await rpc({ v: 1, op: "get", key }, opts);
-  if (resp === null) return null;
-  if (resp.ok && "entry" in resp) return resp.entry as VaultEntry;
-  return null;
+  const result = await getViaBrokerStructured(key, opts);
+  return result.kind === "ok" ? result.entry : null;
 }
 
 /**
@@ -144,9 +216,11 @@ export async function getViaBroker(
 export async function listViaBroker(
   opts?: BrokerClientOpts,
 ): Promise<string[] | null> {
-  const resp = await rpc({ v: 1, op: "list" }, opts);
-  if (resp === null) return null;
-  if (resp.ok && "keys" in resp) return resp.keys as string[];
+  const result = await rpc({ v: 1, op: "list" }, opts);
+  if (result.kind === "unreachable") return null;
+  if (result.resp.ok && "keys" in result.resp) {
+    return result.resp.keys as string[];
+  }
   return null;
 }
 
@@ -157,9 +231,11 @@ export async function listViaBroker(
 export async function statusViaBroker(
   opts?: BrokerClientOpts,
 ): Promise<BrokerStatus | null> {
-  const resp = await rpc({ v: 1, op: "status" }, opts);
-  if (resp === null) return null;
-  if (resp.ok && "status" in resp) return resp.status as BrokerStatus;
+  const result = await rpc({ v: 1, op: "status" }, opts);
+  if (result.kind === "unreachable") return null;
+  if (result.resp.ok && "status" in result.resp) {
+    return result.resp.status as BrokerStatus;
+  }
   return null;
 }
 
@@ -168,9 +244,9 @@ export async function statusViaBroker(
  * Returns true on success, false if broker is unreachable.
  */
 export async function lockViaBroker(opts?: BrokerClientOpts): Promise<boolean> {
-  const resp = await rpc({ v: 1, op: "lock" }, opts);
-  if (resp === null) return false;
-  return resp.ok;
+  const result = await rpc({ v: 1, op: "lock" }, opts);
+  if (result.kind === "unreachable") return false;
+  return result.resp.ok;
 }
 
 /**

--- a/src/vault/broker/peercred-ffi.test.ts
+++ b/src/vault/broker/peercred-ffi.test.ts
@@ -1,0 +1,35 @@
+/**
+ * Tests for the peercred FFI helper.
+ *
+ * The function returns null whenever bun:ffi isn't available (running
+ * under node) or whenever we're not on Linux. Vitest runs under node, so
+ * exercising the fallback path is the most we can do here without spawning
+ * a real bun child. The goal is to lock in the contract: "no crash, no
+ * throw, just null" — so the calling site can rely on falling back to
+ * ss-parsing without defensive try/catch around getPeerCred itself.
+ */
+
+import { describe, expect, it } from "vitest";
+import { getPeerCred } from "./peercred-ffi.js";
+
+describe("peercred-ffi.getPeerCred", () => {
+  it("returns null on non-Linux without throwing", () => {
+    if (process.platform === "linux") return;
+    expect(() => getPeerCred(0)).not.toThrow();
+    expect(getPeerCred(0)).toBeNull();
+  });
+
+  it("returns null under node (no bun:ffi) without throwing", () => {
+    // Vitest runs under node. If bun:ffi were available the real syscall
+    // on fd=42 would EBADF and still return null, so the assertion holds
+    // regardless of runtime — but the import-time fallback is what we
+    // care about here.
+    expect(() => getPeerCred(42)).not.toThrow();
+    expect(getPeerCred(42)).toBeNull();
+  });
+
+  it("returns null for an obviously invalid fd", () => {
+    // -1 is not a valid fd. getsockopt on it errors and we return null.
+    expect(getPeerCred(-1)).toBeNull();
+  });
+});

--- a/src/vault/broker/peercred-ffi.ts
+++ b/src/vault/broker/peercred-ffi.ts
@@ -63,26 +63,49 @@ export function getPeerCred(fd: number): PeerCred | null {
     // (where require("bun:ffi") throws ERR_MODULE_NOT_FOUND).
     // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-explicit-any
     const ffi: any = (require as unknown as (m: string) => unknown)("bun:ffi");
-    const { dlopen, FFIType, ptr, suffix } = ffi;
+    const { dlopen, FFIType, ptr } = ffi;
 
     const SOL_SOCKET = 1;
     const SO_PEERCRED = 17;
     const UCRED_SIZE = 12;
 
-    // Open libc once and cache. Failure on first call is permanent —
-    // the symbols are part of glibc/musl and don't disappear at runtime.
+    // Open libc once and cache. We probe the SONAME variants we plausibly
+    // meet on a Linux host — glibc's `libc.so.6` and musl's unversioned
+    // `libc.so` (Alpine and similar). We deliberately do NOT use bun:ffi's
+    // `suffix` template (`so` / `dylib` / `dll`): the broker is Linux-only
+    // and `libc.dylib.6` is meaningless on macOS where it doesn't run
+    // anyway. The probe-and-log shape also gives operators a breadcrumb
+    // when a future glibc bumps to `libc.so.7` or some exotic libc isn't
+    // covered — without the warning we'd silently degrade to ss.
     type LibHandle = { symbols: { getsockopt: (...args: unknown[]) => number } };
     type WithCache = ((fd: number) => PeerCred | null) & { _lib?: LibHandle };
     const cache = getPeerCred as WithCache;
     const lib: LibHandle = cache._lib ?? (() => {
-      const opened = dlopen(`libc.${suffix}.6`, {
+      const candidates = ["libc.so.6", "libc.so"];
+      const symbolSpec = {
         getsockopt: {
           args: [FFIType.i32, FFIType.i32, FFIType.i32, FFIType.ptr, FFIType.ptr],
           returns: FFIType.i32,
         },
-      });
-      cache._lib = opened;
-      return opened;
+      };
+      const errors: string[] = [];
+      for (const name of candidates) {
+        try {
+          const opened = dlopen(name, symbolSpec);
+          cache._lib = opened;
+          return opened;
+        } catch (e) {
+          errors.push(`${name}: ${e instanceof Error ? e.message : String(e)}`);
+        }
+      }
+      // Surface the failure once so an operator on an exotic libc sees
+      // why the FFI fast-path degraded. The outer catch returns null and
+      // identify() falls through to the ss-parsing path.
+      process.stderr.write(
+        `[vault-broker] peercred-ffi: dlopen failed for all libc candidates ` +
+        `(${errors.join("; ")}); falling back to ss-parsing.\n`,
+      );
+      throw new Error("no libc candidate could be opened");
     })();
 
     const credBuf = new ArrayBuffer(UCRED_SIZE);

--- a/src/vault/broker/peercred-ffi.ts
+++ b/src/vault/broker/peercred-ffi.ts
@@ -1,0 +1,112 @@
+/**
+ * Direct SO_PEERCRED via bun:ffi — connection-bound peer credentials with
+ * zero ambiguity under concurrent accepts.
+ *
+ * Replaces the `ss -xpn` parsing path (issue #129) when running under bun.
+ * The kernel attaches credentials to a unix-domain socket at connect()/accept()
+ * time, before any user-space code runs, so getsockopt(SO_PEERCRED) returns
+ * the unique caller for *this* socket — no race, no inode-pair join, no shell-
+ * out. About 40 lines of FFI replace 150 lines of ss-output regex parsing.
+ *
+ * # When this path is active
+ *
+ * - bun runtime, Linux: `bun:ffi` is built in, `getsockopt` is in libc.
+ *   This is the production path (install.sh bootstraps bun) and the dev path.
+ * - node runtime, Linux: bun:ffi import throws → caller falls back to
+ *   `peercred.ts`'s ss-based identify(). The ss path was hardened in the
+ *   same PR to match by server-socket inode rather than first-row-wins,
+ *   so both paths are concurrency-safe; this one is just leaner.
+ * - non-Linux: SO_PEERCRED is Linux-specific. The broker refuses to start
+ *   on non-Linux at all (see VaultBroker.start), so this module is never
+ *   imported there.
+ *
+ * # The struct ucred wire format
+ *
+ *   struct ucred {
+ *     pid_t pid;   // 4 bytes, little-endian on x86_64/aarch64
+ *     uid_t uid;   // 4 bytes
+ *     gid_t gid;   // 4 bytes
+ *   };
+ *
+ * Total 12 bytes. Linux pid_t/uid_t/gid_t are all 32-bit on glibc and musl.
+ *
+ * # Why FFI instead of a native addon
+ *
+ * A node-gyp/N-API addon would mean a C compile step, a binding.gyp,
+ * platform-specific binaries, and a postinstall hook. For a single
+ * 4-byte syscall on a single platform, bun:ffi is dramatically simpler.
+ * Cost: "broker FFI path requires bun runtime, not node" — fine because
+ * install.sh bootstraps bun. npm-only consumers get the ss fallback.
+ */
+
+export interface PeerCred {
+  pid: number;
+  uid: number;
+  gid: number;
+}
+
+/**
+ * Look up SO_PEERCRED for the given socket fd. Returns null on any failure
+ * (FFI not available, getsockopt errored, non-Linux). Caller is expected
+ * to fall back to the ss-parsing path on null.
+ *
+ * NOTE: bun:ffi is type-checked under node where the types may not be
+ * installed. The require() is wrapped in a runtime try/catch and the
+ * `any` cast is intentional — the static type system can't see across
+ * runtimes. The runtime guard is what actually matters.
+ */
+export function getPeerCred(fd: number): PeerCred | null {
+  if (process.platform !== "linux") return null;
+  try {
+    // Lazy-load bun:ffi so the node static type checker doesn't need to
+    // resolve bun-only types. The catch below covers "running under node"
+    // (where require("bun:ffi") throws ERR_MODULE_NOT_FOUND).
+    // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-explicit-any
+    const ffi: any = (require as unknown as (m: string) => unknown)("bun:ffi");
+    const { dlopen, FFIType, ptr, suffix } = ffi;
+
+    const SOL_SOCKET = 1;
+    const SO_PEERCRED = 17;
+    const UCRED_SIZE = 12;
+
+    // Open libc once and cache. Failure on first call is permanent —
+    // the symbols are part of glibc/musl and don't disappear at runtime.
+    type LibHandle = { symbols: { getsockopt: (...args: unknown[]) => number } };
+    type WithCache = ((fd: number) => PeerCred | null) & { _lib?: LibHandle };
+    const cache = getPeerCred as WithCache;
+    const lib: LibHandle = cache._lib ?? (() => {
+      const opened = dlopen(`libc.${suffix}.6`, {
+        getsockopt: {
+          args: [FFIType.i32, FFIType.i32, FFIType.i32, FFIType.ptr, FFIType.ptr],
+          returns: FFIType.i32,
+        },
+      });
+      cache._lib = opened;
+      return opened;
+    })();
+
+    const credBuf = new ArrayBuffer(UCRED_SIZE);
+    const lenBuf = new Uint32Array(1);
+    lenBuf[0] = UCRED_SIZE;
+
+    const rc = lib.symbols.getsockopt(
+      fd,
+      SOL_SOCKET,
+      SO_PEERCRED,
+      ptr(credBuf),
+      ptr(lenBuf.buffer as ArrayBuffer),
+    );
+    if (rc !== 0) return null;
+    if (lenBuf[0] !== UCRED_SIZE) return null;
+
+    const view = new DataView(credBuf);
+    return {
+      pid: view.getInt32(0, true),
+      uid: view.getInt32(4, true),
+      gid: view.getInt32(8, true),
+    };
+  } catch {
+    // bun:ffi unavailable (running under node) or any other failure.
+    return null;
+  }
+}

--- a/src/vault/broker/peercred.test.ts
+++ b/src/vault/broker/peercred.test.ts
@@ -352,17 +352,21 @@ describe("peercred.identify", () => {
       throw new Error(`unexpected fd: ${fd}`);
     });
 
-    const fakeSocket = { _handle: { fd: SYNTH_FD } } as unknown as import("node:net").Socket;
-    const mockExec = mkMockExec(ssOutput);
-    const result = identify(SOCKET_PATH, fakeSocket, mockExec as any);
+    // try/finally so an assertion failure still restores the spy and
+    // doesn't leak fstat-mocked state into subsequent tests in the file.
+    try {
+      const fakeSocket = { _handle: { fd: SYNTH_FD } } as unknown as import("node:net").Socket;
+      const mockExec = mkMockExec(ssOutput);
+      const result = identify(SOCKET_PATH, fakeSocket, mockExec as any);
 
-    expect(result).not.toBeNull();
-    // Critical: the target client PID, not the OTHER client PID.
-    expect(result?.pid).toBe(TARGET_CLIENT_PID);
-    expect(result?.uid).toBe(brokerUid);
-    expect(result?.systemdUnit).toBe("switchroom-myagent-cron-3.service");
-
-    fstatSpy.mockRestore();
+      expect(result).not.toBeNull();
+      // Critical: the target client PID, not the OTHER client PID.
+      expect(result?.pid).toBe(TARGET_CLIENT_PID);
+      expect(result?.uid).toBe(brokerUid);
+      expect(result?.systemdUnit).toBe("switchroom-myagent-cron-3.service");
+    } finally {
+      fstatSpy.mockRestore();
+    }
   });
 });
 

--- a/src/vault/broker/peercred.test.ts
+++ b/src/vault/broker/peercred.test.ts
@@ -100,7 +100,7 @@ describe("peercred.identify", () => {
     setupProcMocks(brokerUid, exe, clientPid, cgroupContent);
 
     const mockExec = mkMockExec(ssOutput);
-    const result = identify(SOCKET_PATH, mockExec as any);
+    const result = identify(SOCKET_PATH, undefined, mockExec as any);
 
     expect(result).not.toBeNull();
     expect(result?.pid).toBe(clientPid);
@@ -150,7 +150,7 @@ describe("peercred.identify", () => {
       ssOutput,
       "LoadState=not-found\nActiveState=inactive\n",
     );
-    const result = identify(SOCKET_PATH, mockExec as any);
+    const result = identify(SOCKET_PATH, undefined, mockExec as any);
 
     // Caller is still identified (uid/pid/exe), but systemdUnit is null
     // because we couldn't verify the cgroup claim.
@@ -177,7 +177,7 @@ describe("peercred.identify", () => {
     setupProcMocks(brokerUid, "/bin/bash", clientPid, cgroupContent);
 
     const mockExec = mkMockExec(ssOutput, null); // systemctl throws
-    const result = identify(SOCKET_PATH, mockExec as any);
+    const result = identify(SOCKET_PATH, undefined, mockExec as any);
 
     expect(result).not.toBeNull();
     expect(result?.systemdUnit).toBeNull();
@@ -204,7 +204,7 @@ describe("peercred.identify", () => {
       ssOutput,
       "LoadState=loaded\nActiveState=failed\n",
     );
-    const result = identify(SOCKET_PATH, mockExec as any);
+    const result = identify(SOCKET_PATH, undefined, mockExec as any);
 
     expect(result).not.toBeNull();
     expect(result?.systemdUnit).toBeNull();
@@ -230,7 +230,7 @@ describe("peercred.identify", () => {
     // No systemctl call expected because cgroup name doesn't match the
     // switchroom-cron pattern; readSystemdUnit returns null upstream.
     const mockExec = vi.fn().mockReturnValue(ssOutput);
-    const result = identify(SOCKET_PATH, mockExec as any);
+    const result = identify(SOCKET_PATH, undefined, mockExec as any);
 
     expect(result).not.toBeNull();
     expect(result?.systemdUnit).toBeNull();
@@ -242,7 +242,7 @@ describe("peercred.identify", () => {
     const ssOutput = `Netid State Recv-Q Send-Q\nu_str ESTAB 0 0 ${SOCKET_PATH} 12345\n`;
     const mockExec = vi.fn().mockReturnValue(ssOutput);
 
-    const result = identify(SOCKET_PATH, mockExec as any);
+    const result = identify(SOCKET_PATH, undefined, mockExec as any);
     expect(result).toBeNull();
   });
 
@@ -253,7 +253,7 @@ describe("peercred.identify", () => {
       throw new Error("ss: command not found");
     });
 
-    const result = identify(SOCKET_PATH, mockExec as any);
+    const result = identify(SOCKET_PATH, undefined, mockExec as any);
     expect(result).toBeNull();
   });
 
@@ -270,7 +270,7 @@ describe("peercred.identify", () => {
       throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
     });
 
-    const result = identify(SOCKET_PATH, mockExec as any);
+    const result = identify(SOCKET_PATH, undefined, mockExec as any);
     expect(result).toBeNull();
   });
 
@@ -294,7 +294,7 @@ describe("peercred.identify", () => {
       throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
     });
 
-    const result = identify(SOCKET_PATH, mockExec as any);
+    const result = identify(SOCKET_PATH, undefined, mockExec as any);
     expect(result).toBeNull();
   });
 
@@ -302,9 +302,67 @@ describe("peercred.identify", () => {
     if (process.platform === "linux") return; // only run on non-Linux
 
     const mockExec = vi.fn();
-    const result = identify(SOCKET_PATH, mockExec as any);
+    const result = identify(SOCKET_PATH, undefined, mockExec as any);
     expect(result).toBeNull();
     expect(mockExec).not.toHaveBeenCalled();
+  });
+
+  // Issue #129: concurrency safety. With multiple clients connected, the
+  // legacy "first row wins" picked an arbitrary PID. Passing the socket
+  // (whose fd inode pinpoints the right ss row) returns the correct one.
+  it("picks the row matching the accepted server fd's inode under multi-client load", () => {
+    if (process.platform !== "linux") return;
+
+    const brokerPid = 1234;
+    const brokerUid = process.getuid?.() ?? 1000;
+    const exe = "/bin/bash";
+    const cgroupContent =
+      `0::/user.slice/user-${brokerUid}.slice/user@${brokerUid}.service/app.slice/switchroom-myagent-cron-3.service\n`;
+
+    // Two simultaneous connections to the same listening socket. The
+    // legacy lookup would return whichever client appears first in the
+    // ss output. Our fd-pinned lookup must select the correct one.
+    const TARGET_SERVER_INODE = 200;
+    const TARGET_CLIENT_INODE = "201";
+    const TARGET_CLIENT_PID = 9999;
+    const OTHER_SERVER_INODE = "300";
+    const OTHER_CLIENT_INODE = "301";
+    const OTHER_CLIENT_PID = 8888;
+
+    const ssOutput =
+      `Netid State Recv-Q Send-Q Local Address:Port Peer Address:Port Process\n` +
+      // OTHER connection (listed first in ss output, and would win under legacy)
+      `u_str ESTAB 0 0 ${SOCKET_PATH} ${OTHER_SERVER_INODE} * ${OTHER_CLIENT_INODE} users:(("broker",pid=${brokerPid},fd=5))\n` +
+      `u_str ESTAB 0 0 * ${OTHER_CLIENT_INODE} * ${OTHER_SERVER_INODE} users:(("bash",pid=${OTHER_CLIENT_PID},fd=4))\n` +
+      // TARGET connection — what our fd actually points to
+      `u_str ESTAB 0 0 ${SOCKET_PATH} ${TARGET_SERVER_INODE} * ${TARGET_CLIENT_INODE} users:(("broker",pid=${brokerPid},fd=6))\n` +
+      `u_str ESTAB 0 0 * ${TARGET_CLIENT_INODE} * ${TARGET_SERVER_INODE} users:(("bash",pid=${TARGET_CLIENT_PID},fd=4))\n`;
+
+    setupProcMocks(brokerUid, exe, TARGET_CLIENT_PID, cgroupContent);
+
+    // Build a fake `Socket` exposing a synthetic _handle.fd. peercred reads
+    // its inode via fstatSync, which we can't easily mock here without
+    // pulling in more vi.mock plumbing — so we mock fstat too.
+    const SYNTH_FD = 42;
+    const fstatSpy = vi.spyOn(fs, "fstatSync");
+    fstatSpy.mockImplementation((fd: number) => {
+      if (fd === SYNTH_FD) {
+        return { ino: TARGET_SERVER_INODE } as unknown as fs.Stats;
+      }
+      throw new Error(`unexpected fd: ${fd}`);
+    });
+
+    const fakeSocket = { _handle: { fd: SYNTH_FD } } as unknown as import("node:net").Socket;
+    const mockExec = mkMockExec(ssOutput);
+    const result = identify(SOCKET_PATH, fakeSocket, mockExec as any);
+
+    expect(result).not.toBeNull();
+    // Critical: the target client PID, not the OTHER client PID.
+    expect(result?.pid).toBe(TARGET_CLIENT_PID);
+    expect(result?.uid).toBe(brokerUid);
+    expect(result?.systemdUnit).toBe("switchroom-myagent-cron-3.service");
+
+    fstatSpy.mockRestore();
   });
 });
 

--- a/src/vault/broker/peercred.test.ts
+++ b/src/vault/broker/peercred.test.ts
@@ -20,7 +20,21 @@ import * as fs from "node:fs";
 
 vi.mock("node:fs", async () => {
   const actual = await vi.importActual<typeof import("node:fs")>("node:fs");
-  return { ...actual, readFileSync: vi.fn(), readlinkSync: vi.fn() };
+  return {
+    ...actual,
+    readFileSync: vi.fn(),
+    readlinkSync: vi.fn(),
+    // fstatSync is destructured at import time in peercred.ts
+    // (`import { fstatSync } from "node:fs"`), so the mock must replace it
+    // here at the module boundary. A later `vi.spyOn(fs, "fstatSync")`
+    // would only patch the namespace object, not peercred's bound copy.
+    // Default behavior: throw EBADF for any fd. Tests that exercise the
+    // socket-fd → inode path call vi.mocked(fs.fstatSync).mockImplementation
+    // to return a synthetic inode for their specific fd.
+    fstatSync: vi.fn().mockImplementation(() => {
+      throw Object.assign(new Error("EBADF: bad file descriptor"), { code: "EBADF" });
+    }),
+  };
 });
 
 // We cannot easily mock process.platform, so we mock the identify function
@@ -341,32 +355,33 @@ describe("peercred.identify", () => {
     setupProcMocks(brokerUid, exe, TARGET_CLIENT_PID, cgroupContent);
 
     // Build a fake `Socket` exposing a synthetic _handle.fd. peercred reads
-    // its inode via fstatSync, which we can't easily mock here without
-    // pulling in more vi.mock plumbing — so we mock fstat too.
+    // its inode via fstatSync (mocked at the module boundary above) — we
+    // override the default EBADF stub with a per-fd mapping for this test.
     const SYNTH_FD = 42;
-    const fstatSpy = vi.spyOn(fs, "fstatSync");
-    fstatSpy.mockImplementation((fd: number) => {
-      if (fd === SYNTH_FD) {
-        return { ino: TARGET_SERVER_INODE } as unknown as fs.Stats;
-      }
-      throw new Error(`unexpected fd: ${fd}`);
-    });
+    vi.mocked(fs.fstatSync).mockImplementation(
+      // The Stats object is huge; we only need .ino, so cast.
+      ((fd: number) => {
+        if (fd === SYNTH_FD) {
+          return { ino: TARGET_SERVER_INODE } as unknown as fs.Stats;
+        }
+        throw Object.assign(new Error(`unexpected fd: ${fd}`), { code: "EBADF" });
+      }) as unknown as typeof fs.fstatSync,
+    );
 
-    // try/finally so an assertion failure still restores the spy and
-    // doesn't leak fstat-mocked state into subsequent tests in the file.
-    try {
-      const fakeSocket = { _handle: { fd: SYNTH_FD } } as unknown as import("node:net").Socket;
-      const mockExec = mkMockExec(ssOutput);
-      const result = identify(SOCKET_PATH, fakeSocket, mockExec as any);
+    const fakeSocket = { _handle: { fd: SYNTH_FD } } as unknown as import("node:net").Socket;
+    const mockExec = mkMockExec(ssOutput);
+    const result = identify(SOCKET_PATH, fakeSocket, mockExec as any);
 
-      expect(result).not.toBeNull();
-      // Critical: the target client PID, not the OTHER client PID.
-      expect(result?.pid).toBe(TARGET_CLIENT_PID);
-      expect(result?.uid).toBe(brokerUid);
-      expect(result?.systemdUnit).toBe("switchroom-myagent-cron-3.service");
-    } finally {
-      fstatSpy.mockRestore();
-    }
+    expect(result).not.toBeNull();
+    // Critical: the target client PID, not the OTHER client PID.
+    expect(result?.pid).toBe(TARGET_CLIENT_PID);
+    expect(result?.uid).toBe(brokerUid);
+    expect(result?.systemdUnit).toBe("switchroom-myagent-cron-3.service");
+    // beforeEach() above runs vi.resetAllMocks() before the next test, which
+    // restores fstatSync to its module-level default (EBADF for any fd) —
+    // no manual mockRestore() needed. That was the prior pattern; the
+    // try/finally here is unnecessary because the module-mock provides the
+    // safety net automatically.
   });
 });
 

--- a/src/vault/broker/peercred.ts
+++ b/src/vault/broker/peercred.ts
@@ -1,39 +1,41 @@
 /**
  * peercred — Linux peer-credential identification for Unix socket connections.
  *
- * On Linux, identifies the calling process by:
- *   1. Running `ss -xpn state connected src <socket-path>` to enumerate
- *      connected peers and parse the `users:(("name",pid=NNN,fd=NN))` column.
- *   2. Reading `/proc/<pid>/status` to get the caller's real UID.
- *   3. Reading `/proc/<pid>/exe` (symlink) to get the caller's executable path.
- *   4. Reading `/proc/<pid>/cgroup` to find the systemd unit name, which is
- *      used as the primary identity signal for ACL decisions.
+ * Two paths, picked at runtime:
  *
- * The cgroup identity (`systemdUnit`) is the authoritative identity for cron
- * scripts. systemd writes the cgroup as root when it starts the unit, and
- * processes cannot change their own cgroup from userspace — making it
- * unspoofable. The exe path is retained for the interactive-CLI fallback only.
+ *   1. Bun runtime — `bun:ffi` getsockopt(SO_PEERCRED) on the accepted
+ *      socket fd. The kernel binds peer credentials to the connection
+ *      itself, so this returns the unique caller for *this* socket — no
+ *      shell-out, no inode join, no concurrency ambiguity. ~30 LOC.
+ *      See `peercred-ffi.ts`.
  *
- * Limitation: when multiple clients are simultaneously connected to the same
- * socket, `ss` returns all of them. This implementation picks the first
- * connected entry — the server calls `identify()` immediately on accept,
- * before the next connection can appear, which makes the single-client
- * assumption hold in practice for cron scripts (each is a short-lived
- * one-shot process). If more than one entry appears, a WARN is emitted to
- * stderr.
+ *   2. Node fallback — `ss -xpn` parsing. Same approach as before, but
+ *      issue #129 fixed the concurrency hazard: instead of "first row
+ *      that matches the listening socket path wins", we now match by
+ *      `serverFdInode` — the inode of the accepted server-side socket
+ *      fd, obtained via `fs.fstatSync(socket._handle.fd).ino`. That
+ *      gives us the unique row for this connection regardless of how
+ *      many clients are connected simultaneously.
+ *
+ * Both paths cross-check the resolved PID's UID against the broker's UID
+ * and look up its cgroup-derived systemd unit (validated against
+ * systemctl-user). The cgroup identity is what the ACL gates on.
  *
  * Security model:
  *   - Fail-closed: any parse error, missing /proc entry, or UID mismatch
- *     returns null (the caller should treat null as "unidentified" and deny).
- *   - On non-Linux platforms this module returns null immediately — the
- *     Unix socket's file mode 0600 is the sole access control in that case.
+ *     returns null (caller treats null as "unidentified" and denies).
+ *   - On non-Linux this module returns null immediately. The broker
+ *     refuses to start on non-Linux unless SWITCHROOM_BROKER_ALLOW_NON_LINUX
+ *     is set (see VaultBroker.start), so production never reaches that path.
  *
  * This module is the single seam for OS-specific process identification.
  * Keep it small, pure, and independently testable.
  */
 
 import { execFileSync, type ExecFileSyncOptions } from "node:child_process";
-import { readFileSync, readlinkSync } from "node:fs";
+import { readFileSync, readlinkSync, fstatSync } from "node:fs";
+import type { Socket } from "node:net";
+import { getPeerCred } from "./peercred-ffi.js";
 
 export interface PeerInfo {
   uid: number;
@@ -113,6 +115,44 @@ function findClientPids(rows: SsRow[], socketPath: string): number[] {
     }
   }
   return pids;
+}
+
+/**
+ * Like `findClientPids`, but pinpoints the row corresponding to the
+ * specific accepted server-side fd whose inode the caller already knows.
+ * Eliminates the "first connected entry wins" concurrency hazard that the
+ * original code documented — when N clients are connected, this returns
+ * the PID of the *Nth* one corresponding to *our* fd, not whichever ss
+ * happened to list first.
+ *
+ * Returns null when:
+ *   - no server row's localInode matches `serverInode` (we may have raced
+ *     with the kernel's socket bookkeeping)
+ *   - the matching server row has a peerInode but no client row has that
+ *     localInode (client may have already disconnected)
+ *
+ * Issue #129.
+ */
+function findClientPidByServerInode(
+  rows: SsRow[],
+  socketPath: string,
+  serverInode: number,
+): number | null {
+  // SsRow.localInode is a string (parsed from ss output as-is). Stringify
+  // the numeric inode from fstat once so the comparison is type-correct.
+  const serverInodeStr = String(serverInode);
+  for (const serverRow of rows) {
+    if (serverRow.localAddr !== socketPath) continue;
+    if (serverRow.localInode !== serverInodeStr) continue;
+    for (const clientRow of rows) {
+      if (clientRow.localAddr !== "*") continue;
+      if (clientRow.localInode !== serverRow.peerInode) continue;
+      if (clientRow.pid === null) continue;
+      return clientRow.pid;
+    }
+    return null;
+  }
+  return null;
 }
 
 /**
@@ -257,14 +297,66 @@ export function verifySystemdUnit(
 }
 
 /**
+ * Read the inode of an open file descriptor. Used to disambiguate ss rows
+ * for our specific accepted connection (issue #129). Returns null on any
+ * error so the caller can fall through to less-precise matching.
+ */
+function readFdInode(fd: number): number | null {
+  try {
+    const stat = fstatSync(fd);
+    // Node's Stats.ino is `number` on 32-bit inodes and falls back to
+    // `bigint` only when bigint:true is requested. We never request bigint,
+    // so this is safely numeric on Linux.
+    return stat.ino as number;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Extract the file descriptor from a connected `net.Socket`. Uses the
+ * undocumented `_handle.fd` because Node has no public fd accessor (only
+ * a setter via the constructor). The cast is intentional and isolated to
+ * this one helper so the rest of peercred treats fd as a plain number.
+ *
+ * Returns null when the handle is missing (socket already destroyed) or
+ * the fd is unset (Windows / non-fd-backed handle).
+ */
+function fdFromSocket(socket: Socket): number | null {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const handle = (socket as unknown as { _handle?: { fd?: number } })._handle;
+  if (!handle || typeof handle.fd !== "number" || handle.fd < 0) return null;
+  return handle.fd;
+}
+
+/**
  * Identify the peer on the other end of a Unix domain socket connection.
  *
+ * Two-path implementation:
+ *
+ *   1. **Bun fast path** — when `socket` is provided AND we're on Linux
+ *      AND `bun:ffi` is available, call `getsockopt(fd, SOL_SOCKET,
+ *      SO_PEERCRED)` directly. The kernel binds peer creds to the
+ *      connection at accept(2) time, so this gives the unique caller for
+ *      this exact socket. Cleanest, fastest, no shell-out.
+ *
+ *   2. **Node fallback** — `ss -xpn` parsing. When `socket` is provided
+ *      we now also pull the server-side fd's inode via `fstatSync` and
+ *      pass it to `findClientPidByServerInode`, which selects the
+ *      *exactly correct* row instead of "first row that matches
+ *      socketPath". That fixes the concurrency hazard the original code
+ *      documented as a "known limitation" (issue #129).
+ *
  * @param socketPath - Absolute path to the listening socket.
- * @param execFileSync_ - Injectable for testing (default: Node's execFileSync).
+ * @param socket - Optional connected socket from the accept() callback.
+ *                 Strongly preferred — without it we fall back to the
+ *                 first-row-wins lookup, which has the historical race.
+ * @param execFileSyncOverride - Injectable for testing (default: Node's execFileSync).
  * @returns PeerInfo or null (unidentified / non-Linux / error).
  */
 export function identify(
   socketPath: string,
+  socket?: Socket,
   execFileSyncOverride?: (
     file: string,
     args: readonly string[],
@@ -272,43 +364,81 @@ export function identify(
   ) => Buffer | string,
 ): PeerInfo | null {
   if (process.platform !== "linux") {
-    // macOS / other: degrade to UID-only (socket file mode 0600 is the guard)
+    // macOS / other: degrade to UID-only (socket file mode 0600 is the guard).
+    // The broker also refuses to start on non-Linux unless explicitly
+    // overridden, so this branch is reachable only via the dev escape hatch.
     return null;
   }
 
   const runner = execFileSyncOverride ?? execFileSync;
 
-  let ssOutput: string;
-  try {
-    // We need every unix endpoint to do the inode-pair lookup that maps the
-    // server-side row to the client-side row. `ss` only stamps the path on
-    // the server side; the connecting client appears under `Local *
-    // <inode>`. A `src` or `dst` filter narrows the result before we can
-    // match the pair, so we list everything and filter in user space.
-    const raw = runner("ss", ["-xpn"], {
-      timeout: 200,
-      encoding: "utf8",
-    });
-    ssOutput = typeof raw === "string" ? raw : raw.toString("utf8");
-  } catch {
-    // ss not available or timed out — fail closed
-    return null;
+  // ── Path 1: bun:ffi SO_PEERCRED ──────────────────────────────────────────
+  // Returns null under node (bun:ffi unavailable) or if getsockopt errors.
+  // We then fall through to the ss-parsing path below.
+  let pid: number | null = null;
+  if (socket !== undefined) {
+    const fd = fdFromSocket(socket);
+    if (fd !== null) {
+      const cred = getPeerCred(fd);
+      if (cred !== null) {
+        pid = cred.pid;
+        // The UID from SO_PEERCRED is authoritative; record it now so we can
+        // skip the /proc/<pid>/status read below if it agrees with the broker.
+        // (We re-validate below for robustness.)
+      }
+    }
   }
 
-  const rows = parseSsRows(ssOutput);
-  const clientPids = findClientPids(rows, socketPath);
-  if (clientPids.length === 0) return null;
+  // ── Path 2: ss -xpn fallback (concurrency-safe via inode match) ──────────
+  if (pid === null) {
+    let ssOutput: string;
+    try {
+      // We need every unix endpoint to do the inode-pair lookup that maps the
+      // server-side row to the client-side row. `ss` only stamps the path on
+      // the server side; the connecting client appears under `Local *
+      // <inode>`. A `src` or `dst` filter narrows the result before we can
+      // match the pair, so we list everything and filter in user space.
+      const raw = runner("ss", ["-xpn"], {
+        timeout: 200,
+        encoding: "utf8",
+      });
+      ssOutput = typeof raw === "string" ? raw : raw.toString("utf8");
+    } catch {
+      // ss not available or timed out — fail closed
+      return null;
+    }
 
-  if (clientPids.length > 1) {
-    // Multiple simultaneous connections — warn but use the first.
-    // This is documented as a known limitation.
-    process.stderr.write(
-      `[vault-broker] peercred: ${clientPids.length} connected peers found for ${socketPath}; ` +
-        `using pid=${clientPids[0]}. Multiple simultaneous connections reduce identification accuracy.\n`,
-    );
+    const rows = parseSsRows(ssOutput);
+
+    // When we have a connected socket, pin the lookup to its server-side
+    // inode. That eliminates the "first connected client wins" race the
+    // original code warned about (issue #129).
+    let serverInode: number | null = null;
+    if (socket !== undefined) {
+      const fd = fdFromSocket(socket);
+      if (fd !== null) serverInode = readFdInode(fd);
+    }
+
+    if (serverInode !== null) {
+      pid = findClientPidByServerInode(rows, socketPath, serverInode);
+    } else {
+      // Caller didn't pass the socket. Use the legacy "first row wins"
+      // lookup with the same warning the original code emitted.
+      const clientPids = findClientPids(rows, socketPath);
+      if (clientPids.length === 0) return null;
+      if (clientPids.length > 1) {
+        process.stderr.write(
+          `[vault-broker] peercred: ${clientPids.length} connected peers found for ${socketPath}; ` +
+            `using pid=${clientPids[0]}. ` +
+            `Multiple simultaneous connections reduce identification accuracy. ` +
+            `(This warning means identify() was called without a socket arg — likely a stale call site.)\n`,
+        );
+      }
+      pid = clientPids[0];
+    }
   }
 
-  const pid = clientPids[0];
+  if (pid === null) return null;
 
   const uid = readUid(pid);
   if (uid === null) {

--- a/src/vault/broker/peercred.ts
+++ b/src/vault/broker/peercred.ts
@@ -374,18 +374,20 @@ export function identify(
 
   // ── Path 1: bun:ffi SO_PEERCRED ──────────────────────────────────────────
   // Returns null under node (bun:ffi unavailable) or if getsockopt errors.
-  // We then fall through to the ss-parsing path below.
+  // We then fall through to the ss-parsing path below. We extract only the
+  // PID — the rest of the pipeline (UID via /proc/<pid>/status, exe via
+  // /proc/<pid>/exe, systemd-unit via /proc/<pid>/cgroup) is shared with
+  // the ss path. We do NOT short-circuit using SO_PEERCRED's `uid` even
+  // though it would be authoritative: the cost is one /proc read and the
+  // benefit is a single code path for both runtimes (no "did the FFI path
+  // do the UID check?" branching downstream). The cgroup-derived
+  // systemdUnit is still the load-bearing identity check.
   let pid: number | null = null;
   if (socket !== undefined) {
     const fd = fdFromSocket(socket);
     if (fd !== null) {
       const cred = getPeerCred(fd);
-      if (cred !== null) {
-        pid = cred.pid;
-        // The UID from SO_PEERCRED is authoritative; record it now so we can
-        // skip the /proc/<pid>/status read below if it agrees with the broker.
-        // (We re-validate below for robustness.)
-      }
+      if (cred !== null) pid = cred.pid;
     }
   }
 

--- a/src/vault/broker/server.test.ts
+++ b/src/vault/broker/server.test.ts
@@ -38,15 +38,11 @@ const TEST_SECRETS: Record<string, VaultEntry> = {
   },
 };
 
-// Minimal SwitchroomConfig for broker tests — ACL checks are skipped in
-// test because identify() returns null (no real ss / /proc in tests),
-// and on Linux the broker falls back to peercred=null → denies get requests.
-// We use a non-Linux-compatible config or mock platform behavior.
-// Instead of fighting Linux peercred in unit tests, we test ACL separately
-// and disable Linux-only denial by providing a testConfig that allows
-// interactive access via allow_interactive=true AND running under a fake exe.
-// The simplest approach: on Linux, skip get tests that require peercred
-// (those are covered by integration tests). On non-Linux, get tests work.
+// Minimal SwitchroomConfig for broker tests. On Linux the broker uses
+// peercred + ACL to identify cron units; the test process isn't one, so
+// `get` requests are denied. ACL behavior is covered by acl.test.ts; here
+// we test the protocol/socket layer. On non-Linux there's no peercred, so
+// the broker serves any same-user caller and `get` round-trips work end-to-end.
 
 function makeMinimalConfig() {
   return {
@@ -57,7 +53,6 @@ function makeMinimalConfig() {
       broker: {
         socket: "~/.switchroom/vault-broker.sock",
         enabled: true,
-        allow_interactive: false,
       },
     },
     agents: {},
@@ -96,8 +91,15 @@ describe("VaultBroker server", () => {
   let broker: VaultBroker;
   let socketPath: string;
   let tmpDir: string;
+  let prevNonLinuxFlag: string | undefined;
 
   beforeEach(async () => {
+    // The broker is Linux-only by design (see issue #129). Tests start the
+    // broker on whatever the CI runner / dev box happens to be, so opt in
+    // to the non-Linux escape hatch here. On Linux this env var is a no-op.
+    prevNonLinuxFlag = process.env.SWITCHROOM_BROKER_ALLOW_NON_LINUX;
+    process.env.SWITCHROOM_BROKER_ALLOW_NON_LINUX = "1";
+
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "broker-test-"));
     socketPath = path.join(tmpDir, "test.sock");
 
@@ -113,6 +115,11 @@ describe("VaultBroker server", () => {
     try {
       fs.rmSync(tmpDir, { recursive: true, force: true });
     } catch { /* ignore */ }
+    if (prevNonLinuxFlag === undefined) {
+      delete process.env.SWITCHROOM_BROKER_ALLOW_NON_LINUX;
+    } else {
+      process.env.SWITCHROOM_BROKER_ALLOW_NON_LINUX = prevNonLinuxFlag;
+    }
   });
 
   // ── status ──────────────────────────────────────────────────────────────

--- a/src/vault/broker/server.test.ts
+++ b/src/vault/broker/server.test.ts
@@ -134,9 +134,15 @@ describe("VaultBroker server", () => {
     }
   });
 
-  // ── list ───────────────────────────────────────────────────────────────
+  // ── list (non-Linux only — peercred skipped) ──────────────────────────
 
-  it("list: returns all key names", async () => {
+  it("list: returns all key names (non-Linux or ACL skip)", async () => {
+    if (process.platform === "linux") {
+      // On Linux, `list` requires peercred (PR #130 review fix). The test
+      // process isn't a recognized cron unit, so identify() returns null
+      // and the broker denies. Integration tests cover the cron path.
+      return;
+    }
     const resp = await rpc(socketPath, { v: 1, op: "list" });
     expect(resp.ok).toBe(true);
     if (resp.ok && "keys" in resp) {

--- a/src/vault/broker/server.ts
+++ b/src/vault/broker/server.ts
@@ -81,6 +81,29 @@ export class VaultBroker {
     configPath: string | undefined,
     vaultPath?: string,
   ): Promise<void> {
+    // Linux-only by design (issue #129). The broker's ACL is a cgroup-based
+    // identity check on the calling cron systemd unit; that primitive only
+    // exists on Linux. On macOS / WSL the only access control would be the
+    // socket's file mode (0600), which we don't consider sufficient for
+    // multi-cron secret routing. Fail-fast with an actionable message
+    // instead of silently degrading.
+    //
+    // Opt-out for dev / tests: SWITCHROOM_BROKER_ALLOW_NON_LINUX=1.
+    if (
+      process.platform !== "linux" &&
+      process.env.SWITCHROOM_BROKER_ALLOW_NON_LINUX !== "1"
+    ) {
+      throw new Error(
+        `vault-broker is Linux-only (running on ${process.platform}). ` +
+        `The broker's ACL relies on cgroup-based systemd unit identification, ` +
+        `which is not available on this platform. ` +
+        `Use 'switchroom vault get --no-broker' for direct vault access. ` +
+        `If you need to run the broker for development on this platform, ` +
+        `set SWITCHROOM_BROKER_ALLOW_NON_LINUX=1 — but understand that the ` +
+        `broker will accept any same-user caller without per-cron ACL enforcement.`,
+      );
+    }
+
     this.socketPath = resolve(socketPath);
     this.unlockSocketPath = this.socketPath.replace(/\.sock$/, ".unlock.sock");
     this.startedAt = Date.now();
@@ -134,9 +157,14 @@ export class VaultBroker {
     this._sdNotify("READY=1\n");
 
     if (process.platform !== "linux") {
+      // Reachable only when SWITCHROOM_BROKER_ALLOW_NON_LINUX=1 was set
+      // (the start() guard above would have thrown otherwise). Log a loud
+      // warning so dev runs can't be confused with production semantics.
       process.stderr.write(
-        `[vault-broker] WARNING: running on ${process.platform} — peercred ACL is disabled. ` +
-        `Access control relies solely on socket file mode 0600.\n`,
+        `[vault-broker] WARNING: running on ${process.platform} with ` +
+        `SWITCHROOM_BROKER_ALLOW_NON_LINUX=1 — peercred ACL is disabled. ` +
+        `Access control is socket file mode 0600 ONLY. Do not use this ` +
+        `configuration for production secrets.\n`,
       );
     }
   }

--- a/src/vault/broker/server.ts
+++ b/src/vault/broker/server.ts
@@ -289,10 +289,14 @@ export class VaultBroker {
   }
 
   private _handleDataConnection(socket: net.Socket): void {
-    // Identify peer immediately on accept (Linux only)
+    // Identify peer immediately on accept (Linux only). Pass the accepted
+    // socket so identify() can use SO_PEERCRED via bun:ffi (bun runtime) or
+    // pin its ss-output lookup to the server-side fd's inode (node runtime).
+    // Without the socket, identify() falls back to the legacy first-row-wins
+    // ss lookup which has a documented concurrency hazard. See issue #129.
     let peer: import("./peercred.js").PeerInfo | null = null;
     if (process.platform === "linux") {
-      peer = identify(this.socketPath);
+      peer = identify(this.socketPath, socket);
     }
 
     let buffer = "";
@@ -438,10 +442,11 @@ export class VaultBroker {
   }
 
   private _handleUnlockConnection(socket: net.Socket): void {
-    // Same UID check for unlock socket. On Linux: verify via peercred.
+    // Same UID check for unlock socket. On Linux: verify via peercred,
+    // pinned to this connection's fd (issue #129).
     // On other OSes: rely on socket file mode 0600.
     if (process.platform === "linux") {
-      const peer = identify(this.unlockSocketPath);
+      const peer = identify(this.unlockSocketPath, socket);
       if (peer === null) {
         socket.write("ERR unable to verify caller identity\n");
         socket.destroy();

--- a/src/vault/broker/server.ts
+++ b/src/vault/broker/server.ts
@@ -365,6 +365,23 @@ export class VaultBroker {
         socket.write(encodeResponse(errorResponse("LOCKED", "Vault is locked")));
         return;
       }
+      // Issue #129 review: `list` previously skipped peercred entirely, so
+      // any same-UID caller could enumerate vault key names without proving
+      // identity. Inconsistent with `get`, which requires peer != null on
+      // Linux. Apply the same Linux peercred gate here so cron units can
+      // still list (for diagnostics) but a non-cron same-UID caller can't.
+      // On non-Linux the socket-file mode 0600 remains the only gate.
+      if (process.platform === "linux" && peer === null) {
+        socket.write(
+          encodeResponse(
+            errorResponse(
+              "DENIED",
+              "Unable to identify caller (peercred unavailable); denying on Linux",
+            ),
+          ),
+        );
+        return;
+      }
       socket.write(encodeResponse({ ok: true, keys: Object.keys(this.secrets) }));
       return;
     }

--- a/src/vault/resolver.ts
+++ b/src/vault/resolver.ts
@@ -15,7 +15,7 @@ import type { SwitchroomConfig } from "../config/schema.js";
 import { openVault, type VaultEntry } from "./vault.js";
 import { resolvePath } from "../config/loader.js";
 import {
-  getViaBroker,
+  getViaBrokerStructured,
   resolveBrokerSocketPath,
   type BrokerClientOpts,
 } from "./broker/client.js";
@@ -280,27 +280,63 @@ export async function resolveVaultReferencesViaBroker(
     return config;
   }
 
-  // Try broker first
+  // Try broker first. Use the structured result so we can distinguish:
+  //   - ok          → use the entry
+  //   - unreachable → fall back to passphrase decrypt (broker is dead /
+  //                   not started yet; passphrase is the right answer)
+  //   - denied      → fall back to passphrase decrypt (the config caller
+  //                   has the passphrase, so this is a CLI/scaffold path
+  //                   running without a cron unit identity; opening the
+  //                   vault directly is correct — same UX as the CLI's
+  //                   `vault get` flow)
+  //   - not_found   → return config unchanged (key truly missing — falling
+  //                   back to passphrase would just re-confirm the absence)
+  //
+  // Issue #129 review: previously this loop used the legacy null-shape
+  // getViaBroker, which collapsed unreachable / denied / not_found into
+  // a single null. denied + not_found both look like "fall back" cases,
+  // but the right behavior for a missing key is to NOT fall back, since
+  // a passphrase decrypt won't conjure it from nothing.
   const brokerSecrets: Record<string, VaultEntry> = {};
-  let brokerReachable = false;
+  let allResolved = true;
+  let sawDenied = false;
+  let sawUnreachable = false;
+  let sawNotFound = false;
 
   for (const key of refs) {
-    const entry = await getViaBroker(key, opts);
-    if (entry !== null) {
-      brokerSecrets[key] = entry;
-      brokerReachable = true;
-    } else if (!brokerReachable) {
-      // First key attempt failed — broker unreachable
-      break;
+    const result = await getViaBrokerStructured(key, opts);
+    if (result.kind === "ok") {
+      brokerSecrets[key] = result.entry;
+    } else {
+      allResolved = false;
+      if (result.kind === "unreachable") sawUnreachable = true;
+      if (result.kind === "denied") sawDenied = true;
+      if (result.kind === "not_found") sawNotFound = true;
+      // Don't break — collect all keys so we can compute fallback need
+      // accurately. A short-circuit on first unreachable would be wrong if
+      // the same broker later denies a different key (mixed schedule).
+      if (sawUnreachable && !sawDenied && !sawNotFound) {
+        // Pure unreachable: bail early, every other call will time out
+        // for the same reason.
+        break;
+      }
     }
   }
 
-  if (brokerReachable && Object.keys(brokerSecrets).length === refs.size) {
-    // All refs resolved via broker
+  if (allResolved) {
     return resolveValue(config, brokerSecrets) as SwitchroomConfig;
   }
 
-  // Broker unreachable or partial — fall back to direct decrypt
+  // Mixed outcomes. If we saw `not_found`, the key is genuinely absent
+  // and a passphrase decrypt won't help — log and return unchanged so
+  // the caller surfaces the missing reference.
+  if (sawNotFound && !sawUnreachable && !sawDenied) {
+    return config;
+  }
+
+  // Broker said denied OR unreachable: fall back to direct decrypt with
+  // the user's passphrase if we have one. Same fallback policy as before;
+  // the difference is we no longer treat not_found as a fallback trigger.
   if (passphrase) {
     return resolveVaultReferences(config, passphrase);
   }

--- a/tests/integration/vault-broker-e2e.test.ts
+++ b/tests/integration/vault-broker-e2e.test.ts
@@ -76,7 +76,6 @@ function makeConfig(
       broker: {
         socket: join(tmpDir, "vault-broker.sock"),
         enabled: true,
-        allow_interactive: false,
       },
     },
     agents: {


### PR DESCRIPTION
Closes the last item of [switchroom#129](https://github.com/switchroom/switchroom/issues/129). Stacks on top of [#130](https://github.com/switchroom/switchroom/pull/130) (items 1-5) — please merge that one first.

## What this fixes

The vault-broker's peercred lookup uses \`ss -xpn\` parsing to map an accepted Unix-socket connection to a calling PID. The original code picked the *first row that matches the listening socket path*, which is wrong under concurrent accepts: ss returns all connected clients, in arbitrary order, and you can end up identifying the wrong one. The source even documented the issue:

> Limitation: when multiple clients are simultaneously connected to the same socket, \`ss\` returns all of them. This implementation picks the first connected entry [...] If more than one entry appears, a WARN is emitted to stderr.

Item 6 of #129 was \"replace this with SO_PEERCRED\". Two complementary paths, both correct:

### Path 1 — \`bun:ffi\` SO_PEERCRED (production)

New [src/vault/broker/peercred-ffi.ts](src/vault/broker/peercred-ffi.ts) uses bun's built-in FFI to call libc's \`getsockopt(fd, SOL_SOCKET, SO_PEERCRED)\` on the accepted socket fd. The kernel binds peer credentials to the connection at accept(2) time, so this returns the unique caller for *this* socket — no shell-out, no inode-pair join, no race. ~70 LOC.

This is the production path: install.sh bootstraps bun and PR #130 made the broker Linux-only.

**Why not a native addon (node-gyp / N-API)?** 30 lines of FFI vs. a binding.gyp + C file + platform-specific compiled binaries + postinstall hook for one 4-byte syscall on one platform. bun:ffi is dramatically simpler and ships with the runtime.

### Path 2 — ss-parsing fallback, hazard fixed

When running under node (npm-only consumers, no bun), \`require('bun:ffi')\` throws and \`getPeerCred()\` returns null. \`peercred.ts\` falls through to the existing ss-output approach, but with the concurrency hazard fixed: instead of \"first row whose Local Address matches\", we match by \`serverFdInode\` — the inode of the specific accepted server-side fd, read via \`fs.fstatSync(socket._handle.fd)\`.

That selects the unique row for *this* connection no matter how many clients are connected at the same time.

## Surface

- \`identify(path, execFileSyncOverride?)\` → \`identify(path, socket?, execFileSyncOverride?)\`
- All 10 in-tree call sites of the 2-arg form updated to pass \`undefined\` for the new socket arg (those tests exercise the legacy lookup path on purpose).
- \`VaultBroker._handleDataConnection\` and \`_handleUnlockConnection\` pass the accepted \`net.Socket\` so identify() can use the fast path.

## Tests
- [x] \`npm run lint\`
- [x] New [src/vault/broker/peercred-ffi.test.ts](src/vault/broker/peercred-ffi.test.ts) — locks in the no-throw null-return contract under node.
- [x] New regression case in [src/vault/broker/peercred.test.ts](src/vault/broker/peercred.test.ts) — simulates two simultaneous connections and asserts the inode-pinned lookup picks the correct PID. Would fail under the old \"first row wins\" code.
- [x] All 17 existing peercred tests still pass.
- [ ] CI green
- [ ] Manual on a Linux box: enable broker, fire two concurrent \`switchroom vault get\` calls from different cron units in a tight loop, confirm each returns the right secret without ACL crosstalk.

## Notes for review
- The \`socket._handle.fd\` access in \`fdFromSocket()\` uses Node's private API (no public getter exists — confirmed against the [Node net docs](https://nodejs.org/api/net.html)). The cast is isolated to one helper and gated by a runtime null check.
- The bun:ffi import is wrapped in try/catch + lazy require so static type-checking under node doesn't need bun's types installed. Deliberately permissive on the FFI types — they're only exercised when bun is the runtime.