### PR TITLE
test(vault-broker): _testIdentify seam for Linux gated-path coverage

### DIFF
--- a/src/vault/broker/server.test.ts
+++ b/src/vault/broker/server.test.ts
@@ -38,6 +38,19 @@ const TEST_SECRETS: Record<string, VaultEntry> = {
   },
 };
 
+/**
+ * Deep-clone TEST_SECRETS for each broker. `broker.lock()` mutates entry
+ * values in place (zeros them as a best-effort wipe before GC), so a shallow
+ * copy `{ ...TEST_SECRETS }` would leak that mutation across tests via the
+ * shared entry objects. Concretely: once the "lock wipes secrets" test runs,
+ * subsequent tests that read `foo` get `value: ""` instead of `bar-value`.
+ * The Linux-skipped get tests masked this for a long time; the new
+ * `_testIdentify` happy-path tests below run on Linux and surface the issue.
+ */
+function cloneSecrets(): Record<string, VaultEntry> {
+  return JSON.parse(JSON.stringify(TEST_SECRETS));
+}
+
 // Minimal SwitchroomConfig for broker tests. On Linux the broker uses
 // peercred + ACL to identify cron units; the test process isn't one, so
 // `get` requests are denied. ACL behavior is covered by acl.test.ts; here
@@ -104,7 +117,7 @@ describe("VaultBroker server", () => {
     socketPath = path.join(tmpDir, "test.sock");
 
     broker = new VaultBroker({
-      _testSecrets: { ...TEST_SECRETS },
+      _testSecrets: cloneSecrets(),
       _testConfig: makeMinimalConfig(),
     });
     await broker.start(socketPath, undefined, undefined);
@@ -345,7 +358,7 @@ describe("VaultBroker server: gated paths (allowed cron identity via _testIdenti
     socketPath = path.join(tmpDir, "test.sock");
 
     broker = new VaultBroker({
-      _testSecrets: { ...TEST_SECRETS },
+      _testSecrets: cloneSecrets(),
       _testConfig: makeAclConfig(),
       _testIdentify: () => FAKE_PEER,
     });
@@ -419,7 +432,7 @@ describe("VaultBroker server: gated paths (denied identity via _testIdentify)", 
     socketPath = path.join(tmpDir, "test.sock");
 
     broker = new VaultBroker({
-      _testSecrets: { ...TEST_SECRETS },
+      _testSecrets: cloneSecrets(),
       _testConfig: makeMinimalConfig(),
       // Simulate "unidentified caller" — same shape as production when
       // identify() can't resolve the peer (foreign UID, exited process, etc.)

--- a/src/vault/broker/server.test.ts
+++ b/src/vault/broker/server.test.ts
@@ -280,3 +280,166 @@ describe("VaultBroker server", () => {
     });
   });
 });
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Gated-paths coverage with a fake "I'm an allowed cron unit" identity.
+//
+// The broker's real `identify()` reads /proc and ss/SO_PEERCRED to resolve the
+// caller's systemd unit. Under `vitest`/`bun test` the test process is not a
+// switchroom cron unit, so on Linux the gated `list`/`get` ops correctly
+// return DENIED — that's why the suite above skips them on Linux.
+//
+// The `_testIdentify` test hook on VaultBroker (server.ts) lets us inject a
+// synthetic PeerInfo so the broker treats the test client as an allowed cron
+// unit. That gives us Linux-side happy-path coverage without spinning up
+// systemd-run (the realm of integration tests under tests/integration).
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("VaultBroker server: gated paths (allowed cron identity via _testIdentify)", () => {
+  let broker: VaultBroker;
+  let socketPath: string;
+  let tmpDir: string;
+  let prevNonLinuxFlag: string | undefined;
+
+  // Synthetic identity: caller is `switchroom-myagent-cron-0.service`.
+  // The matching ACL config grants access to all keys in TEST_SECRETS for
+  // that exact (agent, schedule index) pair.
+  const FAKE_PEER = {
+    uid: process.getuid?.() ?? 1000,
+    pid: 99999,
+    exe: "/usr/bin/bash",
+    systemdUnit: "switchroom-myagent-cron-0.service" as string | null,
+  };
+
+  function makeAclConfig() {
+    return {
+      switchroom: { version: 1 },
+      telegram: { bot_token: "test", forum_chat_id: "123" },
+      vault: {
+        path: "~/.switchroom/vault.enc",
+        broker: {
+          socket: "~/.switchroom/vault-broker.sock",
+          enabled: true,
+        },
+      },
+      agents: {
+        myagent: {
+          schedule: [
+            { secrets: Object.keys(TEST_SECRETS) },
+          ],
+        },
+      },
+    } as any;
+  }
+
+  beforeEach(async () => {
+    prevNonLinuxFlag = process.env.SWITCHROOM_BROKER_ALLOW_NON_LINUX;
+    process.env.SWITCHROOM_BROKER_ALLOW_NON_LINUX = "1";
+
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "broker-acl-test-"));
+    socketPath = path.join(tmpDir, "test.sock");
+
+    broker = new VaultBroker({
+      _testSecrets: { ...TEST_SECRETS },
+      _testConfig: makeAclConfig(),
+      _testIdentify: () => FAKE_PEER,
+    });
+    await broker.start(socketPath, undefined, undefined);
+  });
+
+  afterEach(() => {
+    broker.stop();
+    try {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    } catch { /* ignore */ }
+    if (prevNonLinuxFlag === undefined) {
+      delete process.env.SWITCHROOM_BROKER_ALLOW_NON_LINUX;
+    } else {
+      process.env.SWITCHROOM_BROKER_ALLOW_NON_LINUX = prevNonLinuxFlag;
+    }
+  });
+
+  it("list: returns all key names (allowed cron unit)", async () => {
+    const resp = await rpc(socketPath, { v: 1, op: "list" });
+    expect(resp.ok).toBe(true);
+    if (resp.ok && "keys" in resp) {
+      expect(resp.keys.sort()).toEqual(Object.keys(TEST_SECRETS).sort());
+    }
+  });
+
+  it("get: returns entry for ACL-allowed key", async () => {
+    const resp = await rpc(socketPath, { v: 1, op: "get", key: "foo" });
+    expect(resp.ok).toBe(true);
+    if (resp.ok && "entry" in resp) {
+      expect(resp.entry).toEqual({ kind: "string", value: "bar-value" });
+    }
+  });
+
+  it("get: returns UNKNOWN_KEY for non-existent key", async () => {
+    const resp = await rpc(socketPath, { v: 1, op: "get", key: "nonexistent" });
+    expect(resp.ok).toBe(false);
+    if (!resp.ok) {
+      expect(resp.code).toBe("UNKNOWN_KEY");
+    }
+  });
+});
+
+describe("VaultBroker server: gated paths (denied identity via _testIdentify)", () => {
+  let broker: VaultBroker;
+  let socketPath: string;
+  let tmpDir: string;
+  let prevNonLinuxFlag: string | undefined;
+
+  beforeEach(async () => {
+    prevNonLinuxFlag = process.env.SWITCHROOM_BROKER_ALLOW_NON_LINUX;
+    process.env.SWITCHROOM_BROKER_ALLOW_NON_LINUX = "1";
+
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "broker-deny-test-"));
+    socketPath = path.join(tmpDir, "test.sock");
+
+    broker = new VaultBroker({
+      _testSecrets: { ...TEST_SECRETS },
+      _testConfig: makeMinimalConfig(),
+      // Simulate "unidentified caller" — same shape as production when
+      // identify() can't resolve the peer (foreign UID, exited process, etc.)
+      _testIdentify: () => null,
+    });
+    await broker.start(socketPath, undefined, undefined);
+  });
+
+  afterEach(() => {
+    broker.stop();
+    try {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    } catch { /* ignore */ }
+    if (prevNonLinuxFlag === undefined) {
+      delete process.env.SWITCHROOM_BROKER_ALLOW_NON_LINUX;
+    } else {
+      process.env.SWITCHROOM_BROKER_ALLOW_NON_LINUX = prevNonLinuxFlag;
+    }
+  });
+
+  // The deny path is Linux-specific: on non-Linux the broker doesn't gate on
+  // peercred (socket-file mode is the only check), so list/get pass through.
+  it.skipIf(process.platform !== "linux")(
+    "list: DENIED when caller cannot be identified",
+    async () => {
+      const resp = await rpc(socketPath, { v: 1, op: "list" });
+      expect(resp.ok).toBe(false);
+      if (!resp.ok) {
+        expect(resp.code).toBe("DENIED");
+      }
+    },
+  );
+
+  it.skipIf(process.platform !== "linux")(
+    "get: DENIED when caller cannot be identified",
+    async () => {
+      const resp = await rpc(socketPath, { v: 1, op: "get", key: "foo" });
+      expect(resp.ok).toBe(false);
+      if (!resp.ok) {
+        expect(resp.code).toBe("DENIED");
+      }
+    },
+  );
+});

--- a/src/vault/broker/server.test.ts
+++ b/src/vault/broker/server.test.ts
@@ -312,6 +312,11 @@ describe("VaultBroker server: gated paths (allowed cron identity via _testIdenti
   };
 
   function makeAclConfig() {
+    // ACL-allowed keys = every test-secret key + "nonexistent" so the
+    // UNKNOWN_KEY test below actually reaches the key-lookup code path
+    // instead of being short-circuited by ACL deny. See the comment on
+    // that test for why this matters.
+    const allowedKeys = [...Object.keys(TEST_SECRETS), "nonexistent"];
     return {
       switchroom: { version: 1 },
       telegram: { bot_token: "test", forum_chat_id: "123" },
@@ -325,7 +330,7 @@ describe("VaultBroker server: gated paths (allowed cron identity via _testIdenti
       agents: {
         myagent: {
           schedule: [
-            { secrets: Object.keys(TEST_SECRETS) },
+            { secrets: allowedKeys },
           ],
         },
       },
@@ -376,10 +381,26 @@ describe("VaultBroker server: gated paths (allowed cron identity via _testIdenti
   });
 
   it("get: returns UNKNOWN_KEY for non-existent key", async () => {
+    // makeAclConfig() puts "nonexistent" in the ACL allowlist on purpose
+    // — without that, this request would short-circuit to DENIED at the
+    // ACL gate (key not in schedule.secrets) and never reach the
+    // key-lookup branch we want to assert here.
     const resp = await rpc(socketPath, { v: 1, op: "get", key: "nonexistent" });
     expect(resp.ok).toBe(false);
     if (!resp.ok) {
       expect(resp.code).toBe("UNKNOWN_KEY");
+    }
+  });
+
+  it("get: returns DENIED for ACL-disallowed key", async () => {
+    // "not-in-acl" is neither in TEST_SECRETS nor in the ACL allowlist,
+    // so the ACL gate denies before we ever look up the key. This is
+    // the security-relevant path: even when the caller is a real cron
+    // unit, they can only read keys their schedule entry was granted.
+    const resp = await rpc(socketPath, { v: 1, op: "get", key: "not-in-acl" });
+    expect(resp.ok).toBe(false);
+    if (!resp.ok) {
+      expect(resp.code).toBe("DENIED");
     }
   });
 });

--- a/src/vault/broker/server.ts
+++ b/src/vault/broker/server.ts
@@ -30,7 +30,7 @@ import { dirname, resolve, join } from "node:path";
 import type { SwitchroomConfig } from "../../config/schema.js";
 import { openVault, type VaultEntry } from "../vault.js";
 import { resolvePath } from "../../config/loader.js";
-import { identify } from "./peercred.js";
+import { identify, type PeerInfo } from "./peercred.js";
 import { checkAcl } from "./acl.js";
 import {
   decodeRequest,
@@ -55,6 +55,20 @@ export interface BrokerTestOpts {
    * If provided, use this config instead of loading from configPath.
    */
   _testConfig?: SwitchroomConfig;
+  /**
+   * If provided, replaces the real `identify()` call on every connection.
+   * Returns the PeerInfo the broker should treat as the caller's identity,
+   * or null to simulate "unidentified" (broker denies).
+   *
+   * Without this hook, Linux unit tests can only ever exercise the deny
+   * path — the test process isn't a switchroom-…-cron-… cgroup, so the
+   * real identify() correctly returns null. Stubbing here lets us cover
+   * the happy path (allowed cron unit) without spinning up systemd-run.
+   *
+   * Production codepath is unchanged: when this is undefined the broker
+   * calls the real `identify()`. DO NOT set outside tests.
+   */
+  _testIdentify?: (socketPath: string, socket: net.Socket) => PeerInfo | null;
 }
 
 export class VaultBroker {
@@ -294,9 +308,11 @@ export class VaultBroker {
     // pin its ss-output lookup to the server-side fd's inode (node runtime).
     // Without the socket, identify() falls back to the legacy first-row-wins
     // ss lookup which has a documented concurrency hazard. See issue #129.
-    let peer: import("./peercred.js").PeerInfo | null = null;
+    let peer: PeerInfo | null = null;
     if (process.platform === "linux") {
-      peer = identify(this.socketPath, socket);
+      peer = this.testOpts._testIdentify
+        ? this.testOpts._testIdentify(this.socketPath, socket)
+        : identify(this.socketPath, socket);
     }
 
     let buffer = "";
@@ -446,7 +462,9 @@ export class VaultBroker {
     // pinned to this connection's fd (issue #129).
     // On other OSes: rely on socket file mode 0600.
     if (process.platform === "linux") {
-      const peer = identify(this.unlockSocketPath, socket);
+      const peer = this.testOpts._testIdentify
+        ? this.testOpts._testIdentify(this.unlockSocketPath, socket)
+        : identify(this.unlockSocketPath, socket);
       if (peer === null) {
         socket.write("ERR unable to verify caller identity\n");
         socket.destroy();


### PR DESCRIPTION
## Summary

- Adds `_testIdentify` test hook on `VaultBroker` so unit tests can stub a synthetic `PeerInfo` and exercise the broker's gated `list`/`get` paths on **any** Linux runner — including hosted Buildkite Docker where systemd-user isn't available.
- Two new describe blocks in `server.test.ts`:
  - **allowed cron identity** — happy-path `list`/`get` with the broker treating the test client as `switchroom-myagent-cron-0.service` and matching ACL config.
  - **denied identity (peer=null)** — Linux deny path made explicit.

## Why

The broker's `list`/`get` ops are gated by peercred — on Linux, `identify()` reads `/proc` and `ss`/`SO_PEERCRED` to resolve the caller's systemd cron unit. Under `vitest` the test process isn't a switchroom cron unit, so unit tests can only ever exercise the **deny** path on Linux. Happy-path coverage was therefore non-Linux only (existing tests skip Linux), with real-cron coverage living in `tests/integration/vault-broker-e2e.test.ts` behind `INTEGRATION=1` + systemd-run.

This seam closes the gap: hosted Buildkite Docker now exercises both branches.

## Production codepath unchanged

`_testIdentify` defaults to undefined → broker calls the real `identify()`. The only production caller (`src/cli/vault-broker.ts:120`) constructs `new VaultBroker()` with no opts.

## Test plan

- [x] `npm run lint` passes
- [ ] CI green on Linux (the new `allowed cron identity` block runs there for the first time)
- [x] Existing `list LOCKED after lock` test still works (LOCKED is checked before peercred in `server.ts`)
- [x] Production caller in `src/cli/vault-broker.ts` is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)