### PR TITLE
fix(vault-broker): hard-fail when BrokerTestOpts is set outside NODE_ENV=test

### DIFF
--- a/src/vault/broker/server.ts
+++ b/src/vault/broker/server.ts
@@ -81,7 +81,24 @@ export class VaultBroker {
   private unlockSocketPath: string = "";
   private vaultPath: string = "";
 
-  constructor(private readonly testOpts: BrokerTestOpts = {}) {}
+  constructor(private readonly testOpts: BrokerTestOpts = {}) {
+    // Defence-in-depth: BrokerTestOpts is exported (so vitest can construct
+    // brokers with seeded state and a stubbed identify()), but each field
+    // bypasses a security boundary — secrets pre-load, config injection,
+    // and forged peer identity. None of the production callers set these
+    // (see src/cli/vault-broker.ts), so we hard-fail outside test runners.
+    // vitest sets NODE_ENV=test by default; production builds do not.
+    const usingTestOpt =
+      testOpts._testSecrets !== undefined ||
+      testOpts._testConfig !== undefined ||
+      testOpts._testIdentify !== undefined;
+    if (usingTestOpt && process.env.NODE_ENV !== "test") {
+      throw new Error(
+        "VaultBroker: BrokerTestOpts (_testSecrets/_testConfig/_testIdentify) " +
+          "must not be set outside tests. Set NODE_ENV=test if you really mean it.",
+      );
+    }
+  }
 
   /**
    * Start the broker — bind both sockets, write PID file, notify systemd.


### PR DESCRIPTION
## Summary
Defence-in-depth follow-up to #133. `BrokerTestOpts` is exported so vitest can construct brokers with seeded state, an injected config, and a stubbed `identify()`. Each field bypasses a security boundary; the previous JSDoc-only "DO NOT set outside tests" comment was advisory. This PR adds a runtime guard.

## Why
- `_testSecrets` skips passphrase/KDF and pre-loads decrypted vault state into broker memory
- `_testConfig` injects an arbitrary `SwitchroomConfig` (so any ACL)
- `_testIdentify` forges peer identity (caller-controlled `PeerInfo`, including allow-all)

A future regression — accidental or otherwise — could pass any of these via the public type. Vitest sets `NODE_ENV=test` automatically; production builds do not. Constructor now throws if a test opt is present without that env.

## Test plan
- [x] 73 broker unit tests still pass (vitest sets `NODE_ENV=test`)
- [x] `bun run lint` clean
- [x] `bun run build` clean; PII grep at baseline (4 `/home/hindsight/.pg0`)
- [x] Production caller (`src/cli/vault-broker.ts:120` — `new VaultBroker()` with no opts) unaffected