### PR TITLE
fix(agent): journal-silence watchdog + memory ceiling (closes #116)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,19 @@
   - disallowed-key path is denied with `ACL DENIED`, no value leaks
   - broker-stopped path fails loud (no silent fallback to interactive
     passphrase prompt in headless mode)
+- **Agent watchdog now detects journal-silent hangs.** Three classes of
+  agent hang were observed in production with the unit reporting
+  `active (running)` to systemd while internally frozen — no journal
+  output for many minutes, manual restart was the only recovery.
+  `bin/bridge-watchdog.sh` now also checks journal-output freshness
+  per-agent and restarts via `switchroom agent restart <agent>` when an
+  agent has been silent for `JOURNAL_SILENCE_SECS` (default 600s) and
+  has cleared the existing `UPTIME_GRACE_SECS`. Closes #116.
+
+### Changed
+- Agent service units now declare `MemoryMax=2G` and `MemoryHigh=1536M`,
+  so unbounded memory growth (observed up to 1 GB before hang) hits a
+  ceiling and gets OOM-killed. `Restart=on-failure` then recovers.
 
 ## v0.3.0 — 2026-04-25
 

--- a/bin/bridge-watchdog.sh
+++ b/bin/bridge-watchdog.sh
@@ -1,10 +1,24 @@
 #!/usr/bin/env bash
 # Watchdog: restarts switchroom agent services whose Telegram bridge has
-# disconnected from the gateway. Designed to run on a systemd timer.
+# disconnected from the gateway, OR whose journal output has been silent
+# for too long (indicating an internally-frozen agent that systemd still
+# reports as "active (running)"). Designed to run on a systemd timer.
 #
 # For each agent, checks whether the gateway is up and has an active bridge.
 # If the gateway is healthy but the bridge is disconnected (or never connected),
 # restarts the agent service so Claude Code gets a fresh MCP server.
+#
+# Journal-silence check (2026-04-26, issue #116): Three klanker hangs in
+# 10 hours exposed a class of failure where the agent process is
+# "active (running)" to systemd but internally frozen — no journal output
+# for many minutes, manual restart the only recovery. Two hangs were on the
+# Stop-hook ladder ("running stop hooks 0/N"); one was mid-task at 1.0 GB
+# RSS. The watchdog now also checks journal-output freshness per-agent and
+# restarts via `switchroom agent restart <agent>` when an agent has been
+# silent for JOURNAL_SILENCE_SECS (default 600s) and has cleared the uptime
+# grace. Sustained suspicion via a state file under
+# /run/user/<uid>/switchroom-watchdog/ prevents transient quiet from
+# triggering.
 #
 # Agent discovery: enumerates ALL active switchroom-*-gateway.service units
 # and derives the agent name + gateway-log path from each. This replaces the
@@ -27,9 +41,19 @@ set -euo pipefail
 
 # Tunables. Expressed as env-overridable so the test harness can drive
 # edge cases without mutating the script.
-: "${UPTIME_GRACE_SECS:=90}"       # skip the bridge check for this long after agent (re)start
-: "${DISCONNECT_GRACE_SECS:=600}"  # require disconnection to persist this long before restarting
-: "${LIVENESS_GRACE_SECS:=30}"     # liveness file mtime must be older than this before we treat bridge as dead
+: "${UPTIME_GRACE_SECS:=90}"              # skip checks for this long after agent (re)start
+: "${DISCONNECT_GRACE_SECS:=600}"         # require disconnection to persist this long before restarting
+: "${LIVENESS_GRACE_SECS:=30}"            # liveness file mtime must be recent before we treat bridge as dead
+: "${JOURNAL_SILENCE_SECS:=600}"          # seconds of journal silence before suspecting a hang
+: "${JOURNAL_SILENCE_HARD_SECS:=600}"     # seconds the silence_since marker must predate before restarting
+
+# Per-agent watchdog state lives under /run/user/$UID/switchroom-watchdog/
+# (tmpfs, cleared on logout — correct: we don't want stale silence markers
+# surviving restarts). mkdir -p is idempotent.
+# WATCHDOG_STATE_DIR is env-overridable for the test harness.
+UID_VAL="${UID:-$(id -u)}"
+: "${WATCHDOG_STATE_DIR:=/run/user/${UID_VAL}/switchroom-watchdog}"
+mkdir -p "$WATCHDOG_STATE_DIR" 2>/dev/null || true
 
 now_epoch() { date +%s; }
 
@@ -236,4 +260,134 @@ for gateway_svc in "${gateway_services[@]}"; do
   systemctl --user restart "$agent_svc" || {
     echo "$(date -Iseconds) watchdog: ${agent_svc} restart failed"
   }
+done
+
+# ─── Journal-silence check ───────────────────────────────────────────────────
+#
+# Independent of the bridge-disconnect check above. For each active
+# switchroom-<agent>.service unit (NOT the gateway), verify that it has
+# emitted at least one journal entry within JOURNAL_SILENCE_SECS. If an
+# agent has been silent longer than that AND uptime has cleared
+# UPTIME_GRACE_SECS, record a silence_since marker in the watchdog state
+# dir. Once the marker is older than JOURNAL_SILENCE_HARD_SECS, restart
+# via `switchroom agent restart <agent>` (the contracted reconcile+restart
+# path; NOT raw systemctl restart, which would bypass switchroom's
+# config reconciliation).
+#
+# Why `switchroom agent restart` rather than `systemctl --user restart`:
+# the project contract is that all lifecycle transitions go through the
+# switchroom CLI so that config reconciliation always runs. Raw systemctl
+# calls skip that step and can leave units with stale unit files.
+
+mapfile -t agent_services < <(
+  systemctl --user list-units --type=service --state=active --no-legend --plain 2>/dev/null \
+    | awk '{print $1}' \
+    | grep -E '^switchroom-.+\.service$' \
+    | grep -v -E '^switchroom-(gateway|vault-broker|foreman)\.service$' \
+    | grep -v -E '^switchroom-.+-gateway\.service$' \
+    | grep -v -E '^switchroom-.+-cron-[0-9]+\.service$' || true
+)
+
+for agent_svc in "${agent_services[@]}"; do
+  # Extract agent name: switchroom-<agent>.service → <agent>
+  agent="${agent_svc#switchroom-}"
+  agent="${agent%.service}"
+
+  silence_marker="${WATCHDOG_STATE_DIR}/${agent}.silence_since"
+
+  # Uptime grace: same logic as the bridge check. Fresh agents haven't
+  # had time to settle into a normal logging cadence.
+  active_enter_ts="$(
+    systemctl --user show "$agent_svc" -p ActiveEnterTimestamp --value 2>/dev/null
+  )"
+  if [[ -n "$active_enter_ts" ]]; then
+    active_enter_epoch="$(date -d "$active_enter_ts" +%s 2>/dev/null || echo 0)"
+    if [[ "$active_enter_epoch" -gt 0 ]]; then
+      uptime_secs=$(( $(now_epoch) - active_enter_epoch ))
+      if [[ "$uptime_secs" -lt "$UPTIME_GRACE_SECS" ]]; then
+        # Clear stale silence marker on fresh start so the grace window
+        # is a clean slate.
+        rm -f "$silence_marker" 2>/dev/null || true
+        continue
+      fi
+    fi
+  fi
+
+  # Read the timestamp of the most recent journal entry from this unit.
+  # --output=short-unix gives "EPOCH.USEC MESSAGE" format; we grab the
+  # leading integer epoch seconds.
+  latest_journal_line="$(
+    journalctl --user -u "$agent_svc" -n 1 --output=short-unix --no-pager 2>/dev/null || true
+  )"
+  latest_journal_epoch=0
+  if [[ -n "$latest_journal_line" ]]; then
+    # short-unix format: "1745632800.123456 hostname unit[pid]: message"
+    # Extract the leading epoch (integer part before the dot or space).
+    candidate="$(echo "$latest_journal_line" | awk '{print $1}' | cut -d. -f1)"
+    if [[ "$candidate" =~ ^[0-9]+$ ]]; then
+      latest_journal_epoch="$candidate"
+    fi
+  fi
+
+  now="$(now_epoch)"
+  if [[ "$latest_journal_epoch" -eq 0 ]]; then
+    # No journal entries at all — possibly a very new unit that hasn't
+    # logged yet. Treat conservatively: skip this tick (uptime grace
+    # should have caught a genuine fresh start above, so this branch
+    # mostly hits units that truly haven't logged due to a bug — still
+    # give them one tick of benefit of the doubt).
+    continue
+  fi
+
+  journal_age=$(( now - latest_journal_epoch ))
+
+  if [[ "$journal_age" -lt "$JOURNAL_SILENCE_SECS" ]]; then
+    # Journal is fresh — clear any stale silence marker and move on.
+    rm -f "$silence_marker" 2>/dev/null || true
+    continue
+  fi
+
+  # Journal has been silent for >= JOURNAL_SILENCE_SECS. Record the
+  # first observation so we can require sustained silence.
+  if [[ -f "$silence_marker" ]]; then
+    silence_since="$(cat "$silence_marker" 2>/dev/null || echo "$now")"
+    if ! [[ "$silence_since" =~ ^[0-9]+$ ]]; then
+      silence_since="$now"
+      echo "$now" > "$silence_marker"
+    fi
+  else
+    echo "$now" > "$silence_marker"
+    silence_since="$now"
+    logger -t switchroom-watchdog "agent ${agent}: journal silent for ${journal_age}s; recording silence marker (will restart after ${JOURNAL_SILENCE_HARD_SECS}s of sustained silence)"
+    continue
+  fi
+
+  silence_duration=$(( now - silence_since ))
+  if [[ "$silence_duration" -lt "$JOURNAL_SILENCE_HARD_SECS" ]]; then
+    # Silence not yet sustained long enough to act.
+    continue
+  fi
+
+  # The agent has been journal-silent for >= JOURNAL_SILENCE_HARD_SECS
+  # AND has cleared the uptime grace. This matches the production hang
+  # pattern (issue #116). Restart via the switchroom CLI.
+  logger -t switchroom-watchdog "agent ${agent}: journal silent for ${journal_age}s (marker age ${silence_duration}s >= ${JOURNAL_SILENCE_HARD_SECS}s); restarting via switchroom agent restart"
+  echo "$(date -Iseconds) watchdog: ${agent} journal silent for ${journal_age}s, restarting"
+  rm -f "$silence_marker" 2>/dev/null || true
+
+  # Use `switchroom agent restart` (not raw systemctl) — the project
+  # contract is that all agent lifecycle transitions go through the CLI
+  # so config reconciliation always runs. The CLI is on PATH when the
+  # watchdog is invoked via its systemd timer unit.
+  if command -v switchroom >/dev/null 2>&1; then
+    switchroom agent restart "$agent" || {
+      logger -t switchroom-watchdog "agent ${agent}: switchroom agent restart failed; falling back to systemctl"
+      systemctl --user restart "$agent_svc" || true
+    }
+  else
+    # Fallback: if the switchroom CLI isn't on PATH (unusual), use systemctl
+    # directly and log the degraded path.
+    logger -t switchroom-watchdog "agent ${agent}: switchroom CLI not on PATH; using systemctl restart as fallback"
+    systemctl --user restart "$agent_svc" || true
+  fi
 done

--- a/src/agents/systemd.ts
+++ b/src/agents/systemd.ts
@@ -77,6 +77,17 @@ StandardOutput=journal
 StandardError=journal
 Restart=on-failure
 RestartSec=5
+# Memory ceiling: MemoryHigh triggers kernel reclaim at 1.5G so the
+# process is throttled before hitting the hard ceiling. MemoryMax=2G is
+# the hard limit — once hit, the kernel OOM-kills the unit. Combined
+# with Restart=on-failure (already set above), this gives automatic
+# recovery from memory-growth hangs observed in production (issue #116):
+# three klanker hangs in 10h where RSS climbed past 1 GB before the
+# process froze — systemd still reported active (running) with no way to
+# detect or auto-recover. 2G gives ample headroom above the observed
+# 1 GB peak while providing a reliable ceiling.
+MemoryHigh=1536M
+MemoryMax=2G
 WorkingDirectory=${agentDir}
 # Optional vault-decrypted env. The "-" prefix makes systemd silently
 # skip the file when absent (e.g. pre-"switchroom vault init" or

--- a/tests/integration/watchdog-journal-silence.test.sh
+++ b/tests/integration/watchdog-journal-silence.test.sh
@@ -1,0 +1,224 @@
+#!/usr/bin/env bash
+# Integration test: watchdog journal-silence detection (issue #116).
+#
+# Verifies that bridge-watchdog.sh detects a journal-silent agent and
+# restarts it via `switchroom agent restart <agent>` when:
+#   1. The agent unit is active (mocked systemctl reports it so).
+#   2. The agent has been running longer than UPTIME_GRACE_SECS.
+#   3. The most recent journal entry is older than JOURNAL_SILENCE_SECS.
+#   4. The silence_since marker is older than JOURNAL_SILENCE_HARD_SECS.
+#
+# All system calls are mocked via PATH overrides — no real systemd or
+# switchroom needed.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WATCHDOG="${SCRIPT_DIR}/../../bin/bridge-watchdog.sh"
+
+if [[ ! -f "$WATCHDOG" ]]; then
+  echo "FAIL: watchdog script not found at $WATCHDOG" >&2
+  exit 1
+fi
+
+# ─── Temp workspace ──────────────────────────────────────────────────────────
+
+TMPDIR_TEST="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR_TEST"' EXIT
+
+MOCK_BIN="${TMPDIR_TEST}/mock-bin"
+mkdir -p "$MOCK_BIN"
+
+# Restart capture file — the mock `switchroom` writes here when called.
+RESTART_LOG="${TMPDIR_TEST}/restart.log"
+
+# ─── Epoch arithmetic ────────────────────────────────────────────────────────
+
+NOW="$(date +%s)"
+# Agent started 200s ago — well past the 90s UPTIME_GRACE_SECS.
+ACTIVE_ENTER_EPOCH=$(( NOW - 200 ))
+ACTIVE_ENTER_TS="$(date -d "@${ACTIVE_ENTER_EPOCH}" '+%a %Y-%m-%d %H:%M:%S %Z' 2>/dev/null \
+  || date -r "$ACTIVE_ENTER_EPOCH" '+%a %Y-%m-%d %H:%M:%S %Z' 2>/dev/null \
+  || echo "Mon 2026-01-01 00:00:00 UTC")"
+
+# Journal entry is 700s old — past the 10s test threshold we'll set.
+JOURNAL_ENTRY_EPOCH=$(( NOW - 700 ))
+
+# silence_since marker is 30s old — past the 10s hard threshold we'll set.
+SILENCE_SINCE_EPOCH=$(( NOW - 30 ))
+
+# ─── Mock: systemctl ─────────────────────────────────────────────────────────
+
+cat > "${MOCK_BIN}/systemctl" << MOCK_SYSTEMCTL
+#!/usr/bin/env bash
+# Minimal systemctl mock for watchdog tests.
+
+# list-units: return one gateway (for the bridge-check loop) and one agent unit.
+if [[ "\$*" == *"list-units"*"--type=service"* ]]; then
+  if [[ "\$*" == *"active"* ]]; then
+    echo "switchroom-testagent-gateway.service"
+    echo "switchroom-testagent.service"
+  fi
+  exit 0
+fi
+
+# show: return properties for the units we care about.
+if [[ "\$*" == *"show"* ]]; then
+  # Gateway WorkingDirectory (for the bridge-check loop).
+  if [[ "\$*" == *"gateway"* ]] && [[ "\$*" == *"WorkingDirectory"* ]]; then
+    echo "${TMPDIR_TEST}/gateway-state"
+    exit 0
+  fi
+  # Agent ActiveEnterTimestamp.
+  if [[ "\$*" == *"testagent.service"* ]] && [[ "\$*" == *"ActiveEnterTimestamp"* ]]; then
+    echo "${ACTIVE_ENTER_TS}"
+    exit 0
+  fi
+  # Agent ActiveState.
+  if [[ "\$*" == *"testagent.service"* ]] && [[ "\$*" == *"ActiveState"* ]]; then
+    echo "active"
+    exit 0
+  fi
+  exit 0
+fi
+
+# is-active: the agent is active.
+if [[ "\$*" == *"is-active"* ]]; then
+  exit 0
+fi
+
+# start / restart — no-op for mocked units.
+if [[ "\$*" == *"start"* ]] || [[ "\$*" == *"restart"* ]]; then
+  exit 0
+fi
+
+exit 0
+MOCK_SYSTEMCTL
+chmod +x "${MOCK_BIN}/systemctl"
+
+# ─── Mock: journalctl ────────────────────────────────────────────────────────
+
+cat > "${MOCK_BIN}/journalctl" << MOCK_JOURNALCTL
+#!/usr/bin/env bash
+# Returns a journal entry JOURNAL_ENTRY_EPOCH seconds old.
+echo "${JOURNAL_ENTRY_EPOCH}.000000 $(hostname) switchroom-testagent[1234]: last log line"
+exit 0
+MOCK_JOURNALCTL
+chmod +x "${MOCK_BIN}/journalctl"
+
+# ─── Mock: switchroom ────────────────────────────────────────────────────────
+
+cat > "${MOCK_BIN}/switchroom" << MOCK_SWITCHROOM
+#!/usr/bin/env bash
+# Capture the invocation so the test can assert on it.
+echo "switchroom \$*" >> "${RESTART_LOG}"
+exit 0
+MOCK_SWITCHROOM
+chmod +x "${MOCK_BIN}/switchroom"
+
+# ─── Mock: ss (no gateway socket — bridge loop skips cleanly) ────────────────
+
+cat > "${MOCK_BIN}/ss" << MOCK_SS
+#!/usr/bin/env bash
+# No ESTAB connections — makes the bridge-check see a disconnected bridge.
+# We give it a fresh disconnect marker so the bridge check won't trigger.
+exit 0
+MOCK_SS
+chmod +x "${MOCK_BIN}/ss"
+
+# ─── Mock: logger ────────────────────────────────────────────────────────────
+
+cat > "${MOCK_BIN}/logger" << MOCK_LOGGER
+#!/usr/bin/env bash
+# Suppress logger output in tests.
+exit 0
+MOCK_LOGGER
+chmod +x "${MOCK_BIN}/logger"
+
+# ─── Gateway state dir (so the bridge-check loop doesn't bail early) ─────────
+
+GATEWAY_STATE="${TMPDIR_TEST}/gateway-state"
+mkdir -p "$GATEWAY_STATE"
+# Create gateway.log and gateway.sock stubs so the bridge check doesn't skip.
+touch "${GATEWAY_STATE}/gateway.log"
+# No real socket — the ss mock returns nothing, which means ESTAB==0.
+# We set a fresh disconnect marker so the disconnect grace window isn't hit.
+DISC_MARKER="${GATEWAY_STATE}/.watchdog-disconnect-since"
+echo "$(( NOW - 5 ))" > "$DISC_MARKER"  # 5s disconnect — below grace threshold
+
+# Also create the liveness file to indicate the bridge process is alive
+# (so bridge-check won't trigger a restart — we want ONLY the journal check
+# to fire in this test).
+touch "${GATEWAY_STATE}/.bridge-alive"
+
+# ─── Watchdog state dir with pre-seeded silence marker ───────────────────────
+
+# The watchdog writes silence markers to /run/user/$UID/switchroom-watchdog/.
+# We override the UID to point at our tmp dir by setting UID_VAL and
+# WATCHDOG_STATE_DIR through env vars... except UID_VAL is not exported.
+# Instead, we write the silence_since file at the path the script would use
+# after it constructs WATCHDOG_STATE_DIR from UID_VAL. We pass WATCHDOG_STATE_DIR
+# directly as an env override — the script uses it if set.
+WATCHDOG_STATE_DIR="${TMPDIR_TEST}/watchdog-state"
+mkdir -p "$WATCHDOG_STATE_DIR"
+echo "$SILENCE_SINCE_EPOCH" > "${WATCHDOG_STATE_DIR}/testagent.silence_since"
+
+# ─── Run the watchdog ────────────────────────────────────────────────────────
+
+# Use tight tunables so the test thresholds are met by our fixture data:
+#   UPTIME_GRACE_SECS=90       agent started 200s ago → cleared
+#   JOURNAL_SILENCE_SECS=10    journal is 700s old → cleared
+#   JOURNAL_SILENCE_HARD_SECS=10  marker is 30s old → cleared
+#   DISCONNECT_GRACE_SECS=9999 bridge check won't fire
+
+export PATH="${MOCK_BIN}:${PATH}"
+WATCHDOG_STATE_DIR="$WATCHDOG_STATE_DIR" \
+UPTIME_GRACE_SECS=90 \
+JOURNAL_SILENCE_SECS=10 \
+JOURNAL_SILENCE_HARD_SECS=10 \
+DISCONNECT_GRACE_SECS=9999 \
+LIVENESS_GRACE_SECS=60 \
+bash "$WATCHDOG" 2>/dev/null || true
+
+# ─── Assertions ──────────────────────────────────────────────────────────────
+
+PASS=0
+FAIL=0
+
+check() {
+  local desc="$1"
+  local result="$2"
+  if [[ "$result" == "true" ]]; then
+    echo "PASS: $desc"
+    PASS=$(( PASS + 1 ))
+  else
+    echo "FAIL: $desc" >&2
+    FAIL=$(( FAIL + 1 ))
+  fi
+}
+
+# Assert: switchroom agent restart was called for testagent.
+if [[ -f "$RESTART_LOG" ]] && grep -q "switchroom agent restart testagent" "$RESTART_LOG"; then
+  check "watchdog called 'switchroom agent restart testagent'" "true"
+else
+  check "watchdog called 'switchroom agent restart testagent'" "false"
+  echo "  restart.log contents:" >&2
+  cat "$RESTART_LOG" 2>/dev/null || echo "  (empty)" >&2
+fi
+
+# Assert: silence_since marker was cleared after restart.
+if [[ ! -f "${WATCHDOG_STATE_DIR}/testagent.silence_since" ]]; then
+  check "silence_since marker cleared after restart" "true"
+else
+  check "silence_since marker cleared after restart" "false"
+fi
+
+# ─── Summary ─────────────────────────────────────────────────────────────────
+
+echo ""
+echo "Results: ${PASS} passed, ${FAIL} failed"
+
+if [[ "$FAIL" -gt 0 ]]; then
+  exit 1
+fi
+exit 0

--- a/tests/systemd.test.ts
+++ b/tests/systemd.test.ts
@@ -70,6 +70,24 @@ describe("generateUnit", () => {
     expect(unit).toContain("StartLimitIntervalSec=120");
   });
 
+  // Regression test for issue #116: three klanker hangs in 10h where the
+  // agent climbed past 1 GB RSS and froze — systemd still reported
+  // active (running) with no auto-recovery. MemoryMax=2G gives a hard
+  // ceiling; MemoryHigh=1536M triggers kernel reclaim first; both together
+  // with Restart=on-failure guarantee the agent self-heals after OOM.
+  it("declares MemoryMax=2G and MemoryHigh=1536M for memory ceiling (issue #116)", () => {
+    const unit = generateUnit("test", "/tmp/test");
+    expect(unit).toContain("MemoryMax=2G");
+    expect(unit).toContain("MemoryHigh=1536M");
+  });
+
+  it("places MemoryMax and MemoryHigh in the [Service] section", () => {
+    const unit = generateUnit("test", "/tmp/test");
+    const serviceSection = unit.split("[Service]")[1].split("[Install]")[0];
+    expect(serviceSection).toContain("MemoryMax=2G");
+    expect(serviceSection).toContain("MemoryHigh=1536M");
+  });
+
   it("places StartLimitBurst and StartLimitIntervalSec in [Unit] section, not [Service]", () => {
     const unit = generateUnit("test", "/tmp/test");
     const unitSection = unit.split("[Service]")[0];


### PR DESCRIPTION
## Problem

Three klanker hangs in 10 hours exposed a class of failure where the agent process is `active (running)` to systemd but internally frozen — no journal output for many minutes, no automated recovery. Failure modes observed:

- Twice frozen on "running stop hooks 0/N" status line (Stop-hook orchestration bug)
- Once frozen mid-task with RSS climbing to 1.0 GB
- All three: `systemctl --user is-active` reports `active (running)`, journal silent for many minutes, only `switchroom agent restart` rescued it

## Solution

**1. Journal-silence watchdog** (`bin/bridge-watchdog.sh`)

Added an independent per-agent journal-freshness check to the existing watchdog loop. For each active `switchroom-<agent>.service`:

- Reads uptime via `systemctl --user show ... --property=ActiveEnterTimestamp`. Skips if within `UPTIME_GRACE_SECS` (90s, shared with bridge check).
- Reads the latest journal entry timestamp via `journalctl --user -u <unit> -n 1 --output=short-unix`. If silent for more than `JOURNAL_SILENCE_SECS` (default 600s), records a `silence_since` state file under `/run/user/$UID/switchroom-watchdog/`.
- If the silence marker is older than `JOURNAL_SILENCE_HARD_SECS` (default 600s) AND the unit is still active, restarts via **`switchroom agent restart <agent>`** (not raw `systemctl restart` — the CLI verb runs config reconciliation per project contract).
- Logs all actions via `logger -t switchroom-watchdog` for journal traceability.

Both tunables are env-overridable for test harness use:
```bash
JOURNAL_SILENCE_SECS=600
JOURNAL_SILENCE_HARD_SECS=600
WATCHDOG_STATE_DIR=/run/user/$UID/switchroom-watchdog  # also overridable
```

The existing bridge-disconnect check is completely unaffected — both checks run independently per tick.

**2. Memory ceiling** (`src/agents/systemd.ts`)

Added `MemoryMax=2G` and `MemoryHigh=1536M` to the agent unit template `[Service]` section. `MemoryHigh` triggers kernel reclaim at 1.5 GB; `MemoryMax` hard-kills at 2 GB. The existing `Restart=on-failure` then recovers automatically. This covers the third failure mode (1 GB peak hang) and prevents memory-growth hangs from going undetected indefinitely.

**3. Tests**

- `tests/systemd.test.ts`: two new assertions that `generateUnit()` emits `MemoryMax=2G` and `MemoryHigh=1536M` in the `[Service]` section (52 tests total, all pass).
- `tests/integration/watchdog-journal-silence.test.sh`: bash integration test that mocks `systemctl`, `journalctl`, `switchroom`, and `ss` via PATH overrides, pre-seeds a silence_since marker, and asserts the watchdog calls `switchroom agent restart testagent` and clears the marker.

## Verification

```
bun run lint    ✓ (tsc --noEmit clean)
bun run test:vitest  ✓ (3130 passed, 1 pre-existing tmux-gated failure unrelated to this PR)
bun run build   ✓ (1.39 MB)
grep -c "/home/" dist/cli/switchroom.js  → 4 (at baseline)
bash tests/integration/watchdog-journal-silence.test.sh  → 2 passed, 0 failed
```

Closes #116.