### PR TITLE
fix(watchdog): skip journal-silence restart for genuinely-idle agents (#116 follow-up)

### DIFF
--- a/bin/bridge-watchdog.sh
+++ b/bin/bridge-watchdog.sh
@@ -46,6 +46,13 @@ set -euo pipefail
 : "${LIVENESS_GRACE_SECS:=30}"            # liveness file mtime must be recent before we treat bridge as dead
 : "${JOURNAL_SILENCE_SECS:=600}"          # seconds of journal silence before suspecting a hang
 : "${JOURNAL_SILENCE_HARD_SECS:=600}"     # seconds the silence_since marker must predate before restarting
+# Recent-activity gate: only treat journal-silence as suspect-hang when the
+# agent had ANY log activity within this window. Distinguishes "hung mid-task"
+# (last log moments ago, then silence) from "genuinely idle" (no logs in
+# hours/days — agent waiting for the next user message). Default 1h: long
+# enough to span a normal session but short enough that a long overnight idle
+# doesn't get falsely flagged.
+: "${RECENT_ACTIVITY_WINDOW_SECS:=3600}"
 
 # Per-agent watchdog state lives under /run/user/$UID/switchroom-watchdog/
 # (tmpfs, cleared on logout — correct: we don't want stale silence markers
@@ -347,8 +354,24 @@ for agent_svc in "${agent_services[@]}"; do
     continue
   fi
 
-  # Journal has been silent for >= JOURNAL_SILENCE_SECS. Record the
-  # first observation so we can require sustained silence.
+  # Recent-activity gate: only suspect a hang if the agent had log activity
+  # within RECENT_ACTIVITY_WINDOW_SECS. A genuinely idle agent (e.g. a
+  # personal agent that hasn't received a message in hours/days) has its
+  # latest journal entry far in the past — restarting it would just churn
+  # state for no reason. A hung agent, by contrast, was active before
+  # freezing, so its most recent entry is recent (within the window).
+  #
+  # Implementation: if `journal_age >= RECENT_ACTIVITY_WINDOW_SECS`, the
+  # latest entry is older than the window, so by definition there's no
+  # activity inside it. Treat as idle — clear any stale marker and skip.
+  if [[ "$journal_age" -ge "$RECENT_ACTIVITY_WINDOW_SECS" ]]; then
+    rm -f "$silence_marker" 2>/dev/null || true
+    continue
+  fi
+
+  # Journal has been silent for >= JOURNAL_SILENCE_SECS but the agent had
+  # activity within RECENT_ACTIVITY_WINDOW_SECS. Record the first
+  # observation so we can require sustained silence.
   if [[ -f "$silence_marker" ]]; then
     silence_since="$(cat "$silence_marker" 2>/dev/null || echo "$now")"
     if ! [[ "$silence_since" =~ ^[0-9]+$ ]]; then

--- a/tests/integration/watchdog-idle-skip.test.sh
+++ b/tests/integration/watchdog-idle-skip.test.sh
@@ -1,0 +1,202 @@
+#!/usr/bin/env bash
+# Integration test: watchdog skips genuinely-idle agents (issue #116 follow-up).
+#
+# Verifies the recent-activity gate added to bridge-watchdog.sh: an agent
+# whose latest journal entry is older than RECENT_ACTIVITY_WINDOW_SECS is
+# treated as idle (not hung) and is NOT restarted, even if the silence
+# duration would otherwise trigger the hard threshold.
+#
+# Without this gate, the watchdog would false-positive any agent that
+# went a long time between user messages — overnight, weekends, agents
+# the user hasn't talked to in hours.
+#
+# Setup:
+#   - Agent unit is active (mocked systemctl reports it so).
+#   - Agent has been running 4 hours (well past UPTIME_GRACE_SECS).
+#   - Latest journal entry is 2 hours old (past RECENT_ACTIVITY_WINDOW_SECS).
+#   - Pre-seeded silence_since marker that WOULD trigger restart absent
+#     the new gate.
+#
+# Expected: watchdog observes the silence, applies the recent-activity
+# gate, finds NO recent activity, treats as idle, clears the marker,
+# does NOT call switchroom agent restart.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WATCHDOG="${SCRIPT_DIR}/../../bin/bridge-watchdog.sh"
+
+if [[ ! -f "$WATCHDOG" ]]; then
+  echo "FAIL: watchdog script not found at $WATCHDOG" >&2
+  exit 1
+fi
+
+# ─── Temp workspace ──────────────────────────────────────────────────────────
+
+TMPDIR_TEST="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR_TEST"' EXIT
+
+MOCK_BIN="${TMPDIR_TEST}/mock-bin"
+mkdir -p "$MOCK_BIN"
+
+# Restart capture file — the mock `switchroom` writes here when called.
+# In the idle-skip test, this file MUST stay empty.
+RESTART_LOG="${TMPDIR_TEST}/restart.log"
+
+# ─── Epoch arithmetic ────────────────────────────────────────────────────────
+
+NOW="$(date +%s)"
+# Agent started 4h ago — well past 90s UPTIME_GRACE_SECS.
+ACTIVE_ENTER_EPOCH=$(( NOW - 14400 ))
+ACTIVE_ENTER_TS="$(date -d "@${ACTIVE_ENTER_EPOCH}" '+%a %Y-%m-%d %H:%M:%S %Z' 2>/dev/null \
+  || date -r "$ACTIVE_ENTER_EPOCH" '+%a %Y-%m-%d %H:%M:%S %Z' 2>/dev/null \
+  || echo "Mon 2026-01-01 00:00:00 UTC")"
+
+# Latest journal entry is 2 hours old. With RECENT_ACTIVITY_WINDOW_SECS=3600
+# (1h), this is OUTSIDE the window — agent is treated as idle, not hung.
+JOURNAL_ENTRY_EPOCH=$(( NOW - 7200 ))
+
+# Pre-seeded silence_since marker that WOULD trigger restart in the
+# absence of the recent-activity gate (well past 600s hard threshold).
+SILENCE_SINCE_EPOCH=$(( NOW - 1800 ))
+
+# ─── Mock: systemctl ─────────────────────────────────────────────────────────
+
+cat > "${MOCK_BIN}/systemctl" << MOCK_SYSTEMCTL
+#!/usr/bin/env bash
+if [[ "\$*" == *"list-units"*"--type=service"* ]]; then
+  if [[ "\$*" == *"active"* ]]; then
+    echo "switchroom-idleagent-gateway.service"
+    echo "switchroom-idleagent.service"
+  fi
+  exit 0
+fi
+if [[ "\$*" == *"show"* ]]; then
+  if [[ "\$*" == *"gateway"* ]] && [[ "\$*" == *"WorkingDirectory"* ]]; then
+    echo "${TMPDIR_TEST}/gateway-state"
+    exit 0
+  fi
+  if [[ "\$*" == *"idleagent.service"* ]] && [[ "\$*" == *"ActiveEnterTimestamp"* ]]; then
+    echo "${ACTIVE_ENTER_TS}"
+    exit 0
+  fi
+  if [[ "\$*" == *"idleagent.service"* ]] && [[ "\$*" == *"ActiveState"* ]]; then
+    echo "active"
+    exit 0
+  fi
+  exit 0
+fi
+if [[ "\$*" == *"is-active"* ]]; then
+  exit 0
+fi
+if [[ "\$*" == *"start"* ]] || [[ "\$*" == *"restart"* ]]; then
+  exit 0
+fi
+exit 0
+MOCK_SYSTEMCTL
+chmod +x "${MOCK_BIN}/systemctl"
+
+# ─── Mock: journalctl ────────────────────────────────────────────────────────
+
+cat > "${MOCK_BIN}/journalctl" << MOCK_JOURNALCTL
+#!/usr/bin/env bash
+echo "${JOURNAL_ENTRY_EPOCH}.000000 \$(hostname) switchroom-idleagent[1234]: last log line"
+exit 0
+MOCK_JOURNALCTL
+chmod +x "${MOCK_BIN}/journalctl"
+
+# ─── Mock: switchroom ────────────────────────────────────────────────────────
+
+cat > "${MOCK_BIN}/switchroom" << MOCK_SWITCHROOM
+#!/usr/bin/env bash
+echo "switchroom \$*" >> "${RESTART_LOG}"
+exit 0
+MOCK_SWITCHROOM
+chmod +x "${MOCK_BIN}/switchroom"
+
+# ─── Mock: ss ───────────────────────────────────────────────────────────────
+
+cat > "${MOCK_BIN}/ss" << MOCK_SS
+#!/usr/bin/env bash
+exit 0
+MOCK_SS
+chmod +x "${MOCK_BIN}/ss"
+
+# ─── Mock: logger ────────────────────────────────────────────────────────────
+
+cat > "${MOCK_BIN}/logger" << MOCK_LOGGER
+#!/usr/bin/env bash
+exit 0
+MOCK_LOGGER
+chmod +x "${MOCK_BIN}/logger"
+
+# ─── Gateway state dir ───────────────────────────────────────────────────────
+
+GATEWAY_STATE="${TMPDIR_TEST}/gateway-state"
+mkdir -p "$GATEWAY_STATE"
+touch "${GATEWAY_STATE}/gateway.log"
+DISC_MARKER="${GATEWAY_STATE}/.watchdog-disconnect-since"
+echo "$(( NOW - 5 ))" > "$DISC_MARKER"
+touch "${GATEWAY_STATE}/.bridge-alive"
+
+# ─── Watchdog state dir with pre-seeded silence marker ───────────────────────
+
+WATCHDOG_STATE_DIR="${TMPDIR_TEST}/watchdog-state"
+mkdir -p "$WATCHDOG_STATE_DIR"
+echo "$SILENCE_SINCE_EPOCH" > "${WATCHDOG_STATE_DIR}/idleagent.silence_since"
+
+# ─── Run the watchdog ────────────────────────────────────────────────────────
+
+# Use the same tight thresholds as the hang-detection test, but keep the
+# default RECENT_ACTIVITY_WINDOW_SECS=3600 so the 2h-old entry is OUT of
+# the recent-activity window. The gate should kick in and skip restart.
+export PATH="${MOCK_BIN}:${PATH}"
+WATCHDOG_STATE_DIR="$WATCHDOG_STATE_DIR" \
+UPTIME_GRACE_SECS=90 \
+JOURNAL_SILENCE_SECS=10 \
+JOURNAL_SILENCE_HARD_SECS=10 \
+DISCONNECT_GRACE_SECS=9999 \
+LIVENESS_GRACE_SECS=60 \
+bash "$WATCHDOG" 2>/dev/null || true
+
+# ─── Assertions ──────────────────────────────────────────────────────────────
+
+PASS=0
+FAIL=0
+
+check() {
+  local desc="$1"
+  local result="$2"
+  if [[ "$result" == "true" ]]; then
+    echo "PASS: $desc"
+    PASS=$(( PASS + 1 ))
+  else
+    echo "FAIL: $desc" >&2
+    FAIL=$(( FAIL + 1 ))
+  fi
+}
+
+# Assert: switchroom agent restart was NOT called.
+if [[ ! -f "$RESTART_LOG" ]] || ! grep -q "switchroom agent restart" "$RESTART_LOG" 2>/dev/null; then
+  check "watchdog did NOT restart idle agent" "true"
+else
+  check "watchdog did NOT restart idle agent" "false"
+  echo "  restart.log contents:" >&2
+  cat "$RESTART_LOG" 2>/dev/null || true
+fi
+
+# Assert: stale silence_since marker was cleared (because the agent is
+# now classified as idle, not silent-and-suspect).
+if [[ ! -f "${WATCHDOG_STATE_DIR}/idleagent.silence_since" ]]; then
+  check "stale silence_since marker was cleared on idle classification" "true"
+else
+  check "stale silence_since marker was cleared on idle classification" "false"
+fi
+
+echo ""
+echo "Results: ${PASS} passed, ${FAIL} failed"
+
+if [[ "$FAIL" -gt 0 ]]; then
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
Follow-up to #116 / #139.

## Problem flagged by running agent

The journal-silence detection added in #139 assumed any agent silent past 20 minutes (\`JOURNAL_SILENCE_SECS + JOURNAL_SILENCE_HARD_SECS\`) was hung. But an idle personal agent — overnight, weekends, or just hours between user messages — has nothing to log to its unit's journal. The agent process is \`claude\`, which only emits when processing a turn or running hooks. So the original watchdog would restart agents that were perfectly healthy, just quiet.

Restart-on-idle is visible (boot card, lost partial state) and produces no useful signal.

## Fix

Add a **recent-activity gate** before the silence-marker logic: if the latest journal entry is older than \`RECENT_ACTIVITY_WINDOW_SECS\` (default **1 hour**), the agent has been silent the entire window and is classified as idle, not hung. Skip the restart and clear any stale marker.

The hang signature — last entry within the last hour, then silent for 10+ min — still triggers normally. Idle agents are left alone.

| Scenario | journal_age | recent activity | Action |
|---|---|---|---|
| Healthy active | 5s | yes | nothing (fresh) |
| Hung mid-session (#116) | 700s | yes (within 1h) | restart after marker hardens |
| Idle overnight | 7200s | no (>1h) | skip — clear stale marker |

## Why 1h?

- **Long enough** to span a normal session: turns take seconds-to-minutes; long sessions emit hooks/tools repeatedly, so an active agent always has something within the last 1h.
- **Short enough** that a genuine hang is still caught — a hung mid-session agent has its last log entry seconds-to-minutes ago, well inside the 1h window.
- **Configurable** via env override.

## What I'm NOT changing

- Memory ceiling (#116) — current peaks (240–330 MB) are well under 2G. If long-context heavy work hits the ceiling, the OOM-restart-loop is the worse outcome — but the alternative (silent hang at 1G+ RSS) is what #116 was tracking. Will revisit if real OOMs appear.
- BrokerTestOpts hard-fail (#135) — also flagged in the same warning, but on inspection it's a non-issue: \`_testSecrets/_testConfig/_testIdentify\` are JS object fields on the constructor argument, not env vars. No way to accidentally set them via systemd \`Environment\`. The production caller (\`src/cli/vault-broker.ts:120\`) passes no opts.

## Test plan

- [x] Existing integration test (\`watchdog-journal-silence.test.sh\`) still passes — hang scenario triggers restart.
- [x] New integration test (\`watchdog-idle-skip.test.sh\`) — idle scenario (2h silent, no activity in last 1h) does NOT restart, stale marker is cleared.
- [x] Both tests run cleanly on Linux WSL.
- [ ] CI green on Buildkite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)