### PR TITLE
feat(card-format): unify formatters + align worker card + suppress pin noise (#94)

### DIFF
--- a/telegram-plugin/card-format.ts
+++ b/telegram-plugin/card-format.ts
@@ -1,0 +1,62 @@
+/**
+ * Shared formatters for Telegram status cards.
+ *
+ * Both the main progress card (`progress-card.ts`) and the pinned worker
+ * card (`subagent-watcher.ts`) emit HTML to Telegram; before issue #94
+ * each module had its own private copies of these helpers with subtly
+ * different conventions:
+ *
+ *   - `formatDuration(500)` → progress-card returned `500ms`, watcher
+ *     returned `<1s` (which crashed Telegram's HTML parser when not
+ *     escaped — see #86 / #89 / #101). The numeric form is HTML-safe at
+ *     every call site without per-call escaping, so we standardise on
+ *     it here.
+ *
+ *   - `escapeHtml` / `truncate` were identical character-for-character
+ *     in both modules. Centralising removes one more piece of drift the
+ *     reviewer has to verify.
+ *
+ * Keep this module dependency-free. It's imported by every card-render
+ * surface and must not pull in plugin or gateway state.
+ */
+
+/**
+ * Render a millisecond duration as `<n>ms` for sub-second values, or
+ * `MM:SS` thereafter. Output is always HTML-safe (no `<` / `>` / `&`),
+ * so callers can interpolate it into HTML without `escapeHtml`.
+ *
+ *   formatDuration(0)      → "0ms"
+ *   formatDuration(500)    → "500ms"
+ *   formatDuration(999)    → "999ms"
+ *   formatDuration(1000)   → "00:01"
+ *   formatDuration(59_000) → "00:59"
+ *   formatDuration(60_000) → "01:00"
+ *
+ * Cap at 99:59 — turns and worker tasks both finish well inside that
+ * window in practice. Longer-running surfaces should use a different
+ * formatter rather than expect `100:00` to be sensible here.
+ */
+export function formatDuration(ms: number): string {
+  if (ms < 1000) return `${ms}ms`;
+  const s = Math.floor(ms / 1000);
+  if (s < 60) return `00:${s.toString().padStart(2, '0')}`;
+  const m = Math.floor(s / 60);
+  const r = s % 60;
+  return `${m.toString().padStart(2, '0')}:${r.toString().padStart(2, '0')}`;
+}
+
+/**
+ * Escape `&`, `<`, `>` for safe interpolation into Telegram HTML
+ * messages. Telegram's HTML parser is strict — an unescaped `<` is
+ * read as a tag opener and rejects the message with
+ * "can't parse entities" (see #101 for the cascade that crashed the
+ * gateway into a restart loop).
+ */
+export function escapeHtml(s: string): string {
+  return s.replace(/[&<>]/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;' })[c]!);
+}
+
+/** Truncate to at most `n` characters, replacing the last char with `…`. */
+export function truncate(s: string, n: number): string {
+  return s.length > n ? s.slice(0, n - 1) + '…' : s;
+}

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -5217,6 +5217,10 @@ void (async () => {
                   if (workerCardMsgId != null) {
                     const msgId = workerCardMsgId
                     workerCardMsgId = null
+                    // Drop external-pin tracking before issuing the unpin so
+                    // a race with a concurrent service-message capture can't
+                    // re-resurrect the entry. Issue #94.
+                    pinMgr.untrackExternalPin(String(ownerChatId), msgId)
                     void lockedBot.api.unpinChatMessage(ownerChatId, msgId).catch(() => {})
                     void lockedBot.api.deleteMessage(ownerChatId, msgId).catch(() => {})
                   }
@@ -5230,6 +5234,12 @@ void (async () => {
                     ...(TOPIC_ID != null ? { message_thread_id: TOPIC_ID } : {}),
                   }).then((sent) => {
                     workerCardMsgId = sent.message_id
+                    // Register the worker card with pinMgr BEFORE pinning so
+                    // its `captureServiceMessage` callback recognises the
+                    // service message Telegram emits in response and deletes
+                    // it (matching the existing main-card behaviour).
+                    // Issue #94.
+                    pinMgr.trackExternalPin(String(ownerChatId), sent.message_id)
                     void lockedBot.api.pinChatMessage(ownerChatId, sent.message_id, {
                       disable_notification: true,
                     }).catch(() => {})

--- a/telegram-plugin/progress-card-pin-manager.ts
+++ b/telegram-plugin/progress-card-pin-manager.ts
@@ -111,6 +111,21 @@ export interface PinManager {
     pinnedMessageId: number
     serviceMessageId: number
   }): void
+  /**
+   * Register a pin made outside the per-turn `considerPin()` path so
+   * `captureServiceMessage()` will recognise its service message and
+   * delete it. Used by the worker / sub-agent card (issue #94), which
+   * pins through the gateway directly rather than the progress-card
+   * pin candidate flow. Idempotent — calling twice with the same
+   * (chatId, messageId) is a no-op.
+   */
+  trackExternalPin(chatId: string, messageId: number): void
+  /**
+   * Drop an external pin from tracking. Call when the corresponding
+   * pinned message is unpinned/deleted by its owner so the manager
+   * doesn't keep a stale reference. Idempotent.
+   */
+  untrackExternalPin(chatId: string, messageId: number): void
   /** Test-only: snapshot the currently-pinned turnKeys. */
   pinnedTurnKeys(): ReadonlyArray<string>
   /** Test-only: look up the pinned message id for a turnKey. */
@@ -157,6 +172,13 @@ export function createPinManager(deps: PinManagerDeps): PinManager {
   // unpin path can also scrub the service message if the capture-delete
   // somehow failed.
   const serviceMessages = new Map<string, number>()
+  // Pins that the manager DIDN'T make through `considerPin()` but should
+  // still recognise so their "Clerk pinned …" service message gets
+  // deleted. Issue #94: the worker / sub-agent card pins via the gateway
+  // directly; without this set, captureServiceMessage would skip its
+  // service message and the user sees the system-message noise that the
+  // main card already suppresses. Keyed by `${chatId}:${messageId}`.
+  const externalPins = new Set<string>()
   // Fire-and-forget promises we want tests to be able to drain.
   const inFlight = new Set<Promise<unknown>>()
 
@@ -315,9 +337,17 @@ export function createPinManager(deps: PinManagerDeps): PinManager {
       // Only act on service messages that wrap one of our tracked pins —
       // otherwise we'd be deleting arbitrary pin-service messages in the
       // chat, which could include user-initiated pins.
+      //
+      // We match against two sets: per-turn progress-card pins (managed
+      // through `considerPin`) AND externally-registered pins (the
+      // worker / sub-agent card, registered via `trackExternalPin` —
+      // see issue #94).
       let matched = false
       for (const [, msgId] of pinned) {
         if (msgId === pinnedMessageId) { matched = true; break }
+      }
+      if (!matched && externalPins.has(serviceKey(chatId, pinnedMessageId))) {
+        matched = true
       }
       if (!matched) return
       const key = serviceKey(chatId, pinnedMessageId)
@@ -328,6 +358,14 @@ export function createPinManager(deps: PinManagerDeps): PinManager {
       // and a retry on unpin wouldn't help (Telegram pin-service messages
       // don't age back into existence).
       serviceMessages.delete(key)
+    },
+
+    trackExternalPin(chatId, messageId) {
+      externalPins.add(serviceKey(chatId, messageId))
+    },
+
+    untrackExternalPin(chatId, messageId) {
+      externalPins.delete(serviceKey(chatId, messageId))
     },
 
     pinnedTurnKeys() {

--- a/telegram-plugin/progress-card.ts
+++ b/telegram-plugin/progress-card.ts
@@ -16,6 +16,11 @@
 
 import type { SessionEvent } from './session-tail.js'
 import { toolLabel, isHumanDescription } from './tool-labels.js'
+import {
+  formatDuration as sharedFormatDuration,
+  escapeHtml as sharedEscapeHtml,
+  truncate as sharedTruncate,
+} from './card-format.js'
 
 // ─── Types ──────────────────────────────────────────────────────────────────
 
@@ -700,23 +705,12 @@ const TOOL_SYMBOL: Record<ItemState, string> = {
  */
 const MAX_VISIBLE_ITEMS = 5
 
-/** @internal exported for unit testing */
-export function formatDuration(ms: number): string {
-  if (ms < 1000) return `${ms}ms`
-  const s = Math.floor(ms / 1000)
-  if (s < 60) return `00:${s.toString().padStart(2, '0')}`
-  const m = Math.floor(s / 60)
-  const r = s % 60
-  return `${m.toString().padStart(2, '0')}:${r.toString().padStart(2, '0')}`
-}
-
-function escapeHtml(s: string): string {
-  return s.replace(/[&<>]/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;' })[c]!)
-}
-
-function truncate(s: string, n: number): string {
-  return s.length > n ? s.slice(0, n - 1) + '…' : s
-}
+// Re-export the shared formatters so existing callers (and the test
+// file `tests/progress-card.test.ts`) keep working. The implementation
+// lives in `./card-format.js` — see issue #94.
+export const formatDuration = sharedFormatDuration
+const escapeHtml = sharedEscapeHtml
+const truncate = sharedTruncate
 
 /**
  * Strip the `<channel …>` XML wrapper (if present) from the enqueue raw

--- a/telegram-plugin/subagent-watcher.ts
+++ b/telegram-plugin/subagent-watcher.ts
@@ -33,6 +33,7 @@ import {
 import { basename, join } from 'path'
 import { homedir } from 'os'
 import { projectSubagentLine } from './session-tail.js'
+import { formatDuration, escapeHtml, truncate } from './card-format.js'
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -136,29 +137,26 @@ const DEFAULT_CARD_UPDATE_INTERVAL_MS = 3000
 
 // ─── Card rendering ──────────────────────────────────────────────────────────
 
-function escapeHtml(s: string): string {
-  return s.replace(/[&<>]/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;' })[c]!)
-}
-
-function truncate(s: string, n: number): string {
-  return s.length > n ? s.slice(0, n - 1) + '…' : s
-}
-
-function formatDuration(ms: number): string {
-  if (ms < 1000) return '<1s'
-  const s = Math.floor(ms / 1000)
-  if (s < 60) return `${s}s`
-  const m = Math.floor(s / 60)
-  const r = s % 60
-  return `${m}m${r > 0 ? `${r}s` : ''}`
-}
+// formatDuration / escapeHtml / truncate now come from `./card-format.js`
+// — see issue #94. The previous local copy of `formatDuration` returned
+// the literal string `<1s` for sub-second values, which had to be
+// escaped at every call site or it crashed Telegram's HTML parser
+// (issue #86 / #89 / #101). The shared formatter returns `<n>ms`
+// instead, so the worker card no longer needs the per-call escapeHtml
+// dance for the elapsed-time component.
 
 /**
  * Render the pinned worker card from the current registry.
  * Returns null when no active workers are present.
  *
- * Format (one line per worker):
- *   🛠 <description> · <state> · last activity Xs ago · <tool count> tools
+ * Format (issue #94 — aligned with the main progress card):
+ *   🔧 <b>Background workers (N)</b> · ⏱ <elapsed-since-oldest>
+ *     🤖 <description> · ⏱ <last-activity-age> · <toolCount> tools
+ *
+ * The header mirrors the main card's `⚙️ Working… · ⏱ MM:SS` layout
+ * with a different icon (🔧 vs ⚙️) for visual distinction. Worker rows
+ * use the same `⏱` glyph + duration format as sub-agent rows in the
+ * main card.
  */
 export function renderWorkerCard(
   registry: ReadonlyMap<string, WorkerEntry>,
@@ -169,11 +167,20 @@ export function renderWorkerCard(
   )
   if (active.length === 0) return null
 
-  const lines: string[] = [`\u{1F6E0} <b>Background workers (${active.length})</b>`]
+  // Header elapsed = age of the oldest still-running worker. This gives
+  // the user a single "how long has the background fleet been busy"
+  // signal at a glance, matching the main card's "this turn has been
+  // running for X" framing.
+  const oldestDispatchedAt = Math.min(...active.map((w) => w.dispatchedAt))
+  const headerElapsed = formatDuration(now - oldestDispatchedAt)
+
+  const lines: string[] = [
+    `🔧 <b>Background workers (${active.length})</b> · ⏱ ${headerElapsed}`,
+  ]
   for (const w of active) {
-    const ago = escapeHtml(formatDuration(now - w.lastActivityAt))
+    const ago = formatDuration(now - w.lastActivityAt)
     const desc = escapeHtml(truncate(w.description || 'sub-agent', 60))
-    lines.push(`\u{1F527} ${desc} · running · last activity ${ago} ago · ${w.toolCount} tools`)
+    lines.push(`  🤖 ${desc} · ⏱ ${ago} · ${w.toolCount} tools`)
   }
   return lines.join('\n')
 }

--- a/telegram-plugin/tests/progress-card-pin-manager.test.ts
+++ b/telegram-plugin/tests/progress-card-pin-manager.test.ts
@@ -427,6 +427,36 @@ describe('createPinManager', () => {
       expect(h.deps.deleteMessage).not.toHaveBeenCalled()
     })
 
+    it('issue #94: deletes service messages for externally-tracked pins (worker card)', async () => {
+      // Worker / sub-agent cards are pinned via the gateway directly,
+      // not through `considerPin`. They register with `trackExternalPin`
+      // so `captureServiceMessage` recognises their service messages and
+      // suppresses the "Clerk pinned …" system noise (matching the main
+      // card's behaviour). Without this branch the worker card's pin
+      // event would slip through unmatched.
+      const h = mkHarness()
+      h.mgr.trackExternalPin('c', 777)
+
+      h.mgr.captureServiceMessage({ chatId: 'c', pinnedMessageId: 777, serviceMessageId: 9002 })
+      await h.mgr.drainInFlight()
+
+      expect(h.deps.deleteMessage).toHaveBeenCalledWith('c', 9002)
+    })
+
+    it('issue #94: untrackExternalPin stops further captures', async () => {
+      const h = mkHarness()
+      h.mgr.trackExternalPin('c', 777)
+      h.mgr.untrackExternalPin('c', 777)
+
+      h.mgr.captureServiceMessage({ chatId: 'c', pinnedMessageId: 777, serviceMessageId: 9002 })
+      await h.mgr.drainInFlight()
+
+      // Once untracked, the manager treats the pin as unknown again and
+      // declines to delete — same shape as the "ignores untracked pins"
+      // test above.
+      expect(h.deps.deleteMessage).not.toHaveBeenCalled()
+    })
+
     it('no-op when deleteMessage is not wired', async () => {
       const h = mkHarness({ deleteMessage: undefined })
       h.mgr.considerPin({ chatId: 'c', turnKey: 'c:1', messageId: 500, isFirstEmit: true })

--- a/telegram-plugin/tests/subagent-watcher.test.ts
+++ b/telegram-plugin/tests/subagent-watcher.test.ts
@@ -62,7 +62,12 @@ describe('renderWorkerCard', () => {
     expect(html).toContain('Background workers (1)')
     expect(html).toContain('Fix the tests')
     expect(html).toContain('3 tools')
-    expect(html).toContain('running')
+    // Issue #94: rows now use the same `🤖` glyph + `⏱ MM:SS` format as
+    // sub-agent rows in the main progress card. The literal word
+    // "running" no longer appears — the active state is implied by the
+    // worker showing up in the card at all (done/failed are filtered).
+    expect(html).toContain('🤖')
+    expect(html).toContain('⏱')
   })
 
   it('renders multiple running workers', () => {
@@ -106,27 +111,33 @@ describe('renderWorkerCard', () => {
     expect(html).toContain('…')
   })
 
-  it('formats last-activity age', () => {
+  it('formats last-activity age (issue #94: shared MM:SS format)', () => {
     const registry = new Map<string, WorkerEntry>([
       ['a', makeEntry({ lastActivityAt: 1000 })],
     ])
-    // 30s ago
+    // 30s ago — shared formatter emits "00:30", not the legacy "30s".
     const html = renderWorkerCard(registry, 31_000)
-    expect(html).toContain('30s ago')
+    expect(html).toContain('00:30')
+    expect(html).not.toContain('30s ago')
   })
 
-  it('escapes HTML in sub-second age (<1s)', () => {
-    // formatDuration returns the literal string "<1s" when ms < 1000.
-    // If left unescaped, Telegram parses the leading "<" as the start
-    // of an HTML tag and rejects the message with
-    // "can't parse entities: Unsupported start tag '1s'". Ensure the
-    // rendered card escapes the angle bracket so the card actually sends.
+  it('issue #94: sub-second age renders HTML-safe (no `<1s` literal)', () => {
+    // Pre-#94 the watcher's own formatDuration returned the literal
+    // string "<1s" when ms < 1000. That broke Telegram's HTML parser
+    // unless escaped at every call site (see #86 / #89 / #101). The
+    // shared formatter (`./card-format.ts`) returns "<n>ms" instead,
+    // so no `<` ever appears in the rendered output and no per-call
+    // escapeHtml is required.
     const registry = new Map<string, WorkerEntry>([
       ['a', makeEntry({ description: 'sub-agent', lastActivityAt: 999 })],
     ])
-    const html = renderWorkerCard(registry, 1000) // 1ms idle → "<1s"
+    const html = renderWorkerCard(registry, 1000) // 1ms idle
     expect(html).not.toContain('<1s')
-    expect(html).toContain('&lt;1s')
+    expect(html).not.toContain('&lt;1s')
+    // The HTML-safe form: "1ms" — a literal sub-second duration as
+    // numeric ms. No HTML special chars; ready to interpolate without
+    // escaping.
+    expect(html).toContain('1ms')
   })
 
   it('excludes historical entries from the active-workers card', () => {


### PR DESCRIPTION
Closes #94.

## Three small wins in one PR

### 1. Shared formatters — \`telegram-plugin/card-format.ts\`

Exports \`formatDuration\`, \`escapeHtml\`, \`truncate\` so the main progress card and the worker card share a single source of truth. Standardised on the post-#138 numeric-ms format (\`500ms\`, \`00:30\`, \`01:30\`) which is HTML-safe at every call site without per-call escaping. Eliminates a class of bugs where one renderer's \`formatDuration\` returned the literal \`<1s\` and broke Telegram's HTML parser if any caller forgot to wrap it in \`escapeHtml\` (#86 / #89 / #101).

- \`progress-card.ts\` re-exports \`formatDuration\` for the existing unit-test surface; uses shared escapeHtml/truncate as private bindings.
- \`subagent-watcher.ts\` drops its private copies entirely.

### 2. Worker card visual alignment

\`renderWorkerCard()\` now mirrors the main card's header layout:

\`\`\`
🔧 <b>Background workers (N)</b> · ⏱ <oldest-elapsed>
  🤖 <description> · ⏱ <last-activity-age> · <toolCount> tools
\`\`\`

The header \`⏱\` shows time since the oldest still-running worker was dispatched (matches the main card's "this turn has been running for X" framing). Row format aligns with sub-agent rows in the main card (same 🤖 glyph, same \`⏱ MM:SS\`, same \`· N tools\` suffix). Different header icon (🔧 vs ⚙️) keeps the two card types distinguishable at a glance — intentional, minimal visual diff per the spec.

### 3. Worker pin service-message suppression

Added \`pinMgr.trackExternalPin(chatId, messageId)\` and \`pinMgr.untrackExternalPin(chatId, messageId)\`. When the gateway pins the worker card it registers the message id with pinMgr; pinMgr's existing \`captureServiceMessage\` handler now also matches externally-tracked pins and deletes the "Clerk pinned …" service message — same UX as the main card. The worker card was the lone holdout still emitting the system-message noise.

The external-pin set is keyed \`\${chatId}:\${messageId}\` and is independent of the per-turn \`pinned\` map, so it doesn't interfere with \`completeTurn\` / \`unpinForChat\` paths. \`untrackExternalPin\` fires before the unpin in \`updatePinnedCard\` so a concurrent service capture can't race-resurrect a stale entry.

## Test plan

- [x] New pin-manager tests for \`trackExternalPin\` (happy path + untrack negative).
- [x] Updated subagent-watcher tests for the new card format (rows use 🤖/⏱/MM:SS; the literal "running" word and "Xs ago" suffix are gone). Sub-second test now asserts HTML-safe \`<n>ms\` instead of legacy \`&lt;1s\` escape.
- [x] All 252 affected vitest cases pass on Linux WSL.
- [x] \`npm run lint\` clean.
- [ ] CI green on Buildkite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)