### PR TITLE
test(progress-card,tool-labels): tighten coverage on PR #49 fixes (closes #50)

### DIFF
--- a/telegram-plugin/tests/progress-card.test.ts
+++ b/telegram-plugin/tests/progress-card.test.ts
@@ -12,6 +12,7 @@ import {
   render,
   compactItems,
   formatDuration,
+  hasInFlightSubAgents,
   type ProgressCardState,
   type ChecklistItem,
 } from '../progress-card.js'
@@ -1155,6 +1156,101 @@ describe('progress-card reducer — multi-agent correlation', () => {
   })
 })
 
+describe('hasInFlightSubAgents (PR #49 orphan-exclusion contract)', () => {
+  // Issue #50.2 — pin the contract directly so a regression flips this red
+  // before any integration test reproduces the ghost-pin bug end-to-end.
+  // The defer gate must:
+  //   1. return TRUE for any running sub-agent with a parentToolUseId
+  //   2. return FALSE when every running sub-agent is an orphan
+  //      (parentToolUseId == null) — orphans don't gate parent turn_end
+  //   3. return FALSE when no sub-agents are running
+  it('returns false on a fresh state with no sub-agents', () => {
+    expect(hasInFlightSubAgents(initialState())).toBe(false)
+  })
+
+  it('returns true when a correlated sub-agent is running', () => {
+    const st = fold([
+      enqueue('go'),
+      {
+        kind: 'tool_use',
+        toolName: 'Agent',
+        toolUseId: 'toolu_p1',
+        input: { description: 'd', prompt: 'P' },
+      },
+      { kind: 'sub_agent_started', agentId: 'A', firstPromptText: 'P' },
+    ])
+    // Sanity: the sub-agent really is correlated + running.
+    expect(st.subAgents.get('A')?.parentToolUseId).toBe('toolu_p1')
+    expect(st.subAgents.get('A')?.state).toBe('running')
+    expect(hasInFlightSubAgents(st)).toBe(true)
+  })
+
+  it('returns false when the only running sub-agent is an orphan', () => {
+    // Orphan = sub_agent_started without a matching parent tool_use.
+    const st = fold([
+      enqueue('go'),
+      { kind: 'sub_agent_started', agentId: 'orphan', firstPromptText: 'unmatched' },
+    ])
+    expect(st.subAgents.get('orphan')?.parentToolUseId).toBeNull()
+    expect(st.subAgents.get('orphan')?.state).toBe('running')
+    // …yet the defer gate stays open: orphan turn_ends may never arrive.
+    expect(hasInFlightSubAgents(st)).toBe(false)
+  })
+
+  it('returns false when a correlated sub-agent has finished', () => {
+    const st = fold([
+      enqueue('go'),
+      {
+        kind: 'tool_use',
+        toolName: 'Agent',
+        toolUseId: 'toolu_p1',
+        input: { description: 'd', prompt: 'P' },
+      },
+      { kind: 'sub_agent_started', agentId: 'A', firstPromptText: 'P' },
+      { kind: 'sub_agent_turn_end', agentId: 'A', durationMs: 5 },
+    ])
+    expect(st.subAgents.get('A')?.state).toBe('done')
+    expect(hasInFlightSubAgents(st)).toBe(false)
+  })
+
+  it('returns true when at least one correlated sub-agent runs alongside orphans', () => {
+    // Mixed fleet: one correlated runner + one orphan. Defer should hold.
+    const st = fold([
+      enqueue('go'),
+      {
+        kind: 'tool_use',
+        toolName: 'Agent',
+        toolUseId: 'toolu_p1',
+        input: { description: 'd', prompt: 'P' },
+      },
+      { kind: 'sub_agent_started', agentId: 'correlated', firstPromptText: 'P' },
+      { kind: 'sub_agent_started', agentId: 'orphan', firstPromptText: 'unmatched' },
+    ])
+    expect(st.subAgents.get('correlated')?.parentToolUseId).toBe('toolu_p1')
+    expect(st.subAgents.get('orphan')?.parentToolUseId).toBeNull()
+    expect(hasInFlightSubAgents(st)).toBe(true)
+  })
+
+  it('returns false when every correlated sub-agent finishes, leaving only running orphans', () => {
+    const st = fold([
+      enqueue('go'),
+      {
+        kind: 'tool_use',
+        toolName: 'Agent',
+        toolUseId: 'toolu_p1',
+        input: { description: 'd', prompt: 'P' },
+      },
+      { kind: 'sub_agent_started', agentId: 'correlated', firstPromptText: 'P' },
+      { kind: 'sub_agent_started', agentId: 'orphan', firstPromptText: 'unmatched' },
+      { kind: 'sub_agent_turn_end', agentId: 'correlated', durationMs: 5 },
+    ])
+    expect(st.subAgents.get('correlated')?.state).toBe('done')
+    expect(st.subAgents.get('orphan')?.state).toBe('running')
+    // Only orphan is alive → defer gate releases.
+    expect(hasInFlightSubAgents(st)).toBe(false)
+  })
+})
+
 describe('sub-agent description fallback chain', () => {
   it('correlated sub-agent: uses description', () => {
     const st = fold([
@@ -1405,6 +1501,60 @@ describe('compactItems', () => {
 
   it('empty input returns empty output', () => {
     expect(compactItems([])).toEqual([])
+  })
+
+  // Issue #50.3 — pin the humanAuthored carve-out (#41 fix). When the agent
+  // attached a human-readable description to each Bash, those descriptions
+  // are valuable signal — collapsing into "Bash ×3" would discard them.
+  describe('humanAuthored items are never collapsed (#41)', () => {
+    it('three same-label humanAuthored Bash items render as three singles, not Bash ×3', () => {
+      const items = [
+        makeItem(0, 'Bash', 'Run the migration', 'done', true),
+        makeItem(1, 'Bash', 'Run the migration', 'done', true),
+        makeItem(2, 'Bash', 'Run the migration', 'done', true),
+      ]
+      const out = compactItems(items)
+      expect(out).toHaveLength(3)
+      expect(out.every((x) => x.kind === 'single')).toBe(true)
+      expect(out.every((x) => x.humanAuthored === true)).toBe(true)
+    })
+
+    it('two same-label humanAuthored Bash items render as two singles', () => {
+      const items = [
+        makeItem(0, 'Bash', 'Check commit state', 'done', true),
+        makeItem(1, 'Bash', 'Check commit state', 'done', true),
+      ]
+      const out = compactItems(items)
+      expect(out).toHaveLength(2)
+      expect(out.every((x) => x.kind === 'single')).toBe(true)
+    })
+
+    it('a single humanAuthored item in a same-label run blocks the rollup of the whole run', () => {
+      // Two non-humanAuthored items would normally rollup at ROLLUP_THRESHOLD=2.
+      // Adding one humanAuthored sibling in the same run must keep all three
+      // as singles, otherwise the agent's description gets discarded.
+      const items = [
+        makeItem(0, 'Bash', 'git status', 'done', false),
+        makeItem(1, 'Bash', 'git status', 'done', true),
+        makeItem(2, 'Bash', 'git status', 'done', false),
+      ]
+      const out = compactItems(items)
+      expect(out).toHaveLength(3)
+      expect(out.every((x) => x.kind === 'single')).toBe(true)
+    })
+
+    it('a humanAuthored sibling blocks even the mixed-label rollup', () => {
+      // 3 same-tool, mixed-label, all done normally collapses (C1).
+      // One humanAuthored item in the run prevents that collapse too.
+      const items = [
+        makeItem(0, 'Bash', 'git status', 'done', false),
+        makeItem(1, 'Bash', 'Run the migration', 'done', true),
+        makeItem(2, 'Bash', 'npm test', 'done', false),
+      ]
+      const out = compactItems(items)
+      expect(out).toHaveLength(3)
+      expect(out.every((x) => x.kind === 'single')).toBe(true)
+    })
   })
 })
 

--- a/telegram-plugin/tests/tool-labels.test.ts
+++ b/telegram-plugin/tests/tool-labels.test.ts
@@ -153,7 +153,7 @@ describe('toolLabel', () => {
       ).toBe('Listing all TypeScript sources')
     })
 
-    it('Bash / Task / Agent ignore preamble (they already use input.description)', () => {
+    it('Bash: description wins over preamble when both are present', () => {
       expect(
         toolLabel(
           'Bash',
@@ -161,6 +161,38 @@ describe('toolLabel', () => {
           'Running git status real quick',
         ),
       ).toBe('Check git status')
+    })
+
+    it('Bash: falls back to preamble when description is absent', () => {
+      // Issue #50.1 — post-#41 Bash no longer ignores preamble. When the
+      // agent didn't supply a `description`, the preamble (model's preceding
+      // text narration) wins over the raw command string.
+      expect(
+        toolLabel(
+          'Bash',
+          { command: 'find /home -name "*.tmp" -mtime +30 -exec rm {} \\;' },
+          'Sweep stale temp files',
+        ),
+      ).toBe('Sweep stale temp files')
+    })
+
+    it('Bash: raw command fallback when both description and preamble are absent', () => {
+      expect(toolLabel('Bash', { command: 'git status' })).toBe('git status')
+      expect(toolLabel('Bash', { command: 'git status' }, undefined)).toBe('git status')
+      expect(toolLabel('Bash', { command: 'git status' }, '')).toBe('git status')
+    })
+
+    it('Bash: multi-line preamble is narrative, not a label → command fallback', () => {
+      expect(
+        toolLabel(
+          'Bash',
+          { command: 'git status' },
+          "Here's my plan:\n1. check status\n2. commit",
+        ),
+      ).toBe('git status')
+    })
+
+    it('Task / Agent ignore preamble (description / subagent_type is always set)', () => {
       expect(
         toolLabel('Task', { description: 'Research bug' }, 'Kicking off the research agent'),
       ).toBe('Research bug')

--- a/telegram-plugin/tool-labels.ts
+++ b/telegram-plugin/tool-labels.ts
@@ -146,8 +146,10 @@ export function isHumanDescription(
  * that prose over the filename/pattern fallback when it's short enough
  * to fit on one mobile line (single-line, ≤160 chars). Multi-line or
  * longer text is treated as a narrative step, not a per-tool preamble,
- * and the fallback label wins. Bash/BashOutput/Task/Agent already carry
- * `input.description` and intentionally ignore preamble.
+ * and the fallback label wins. Bash/BashOutput prefer their own
+ * `input.description` first but fall back to preamble when it's absent
+ * (then the raw command). Task/Agent ignore preamble entirely — their
+ * `input.description` / `subagent_type` is always set by the harness.
  */
 export function toolLabel(
   tool: string,


### PR DESCRIPTION
## Summary

Closes the three coverage gaps the PR #49 reviewer flagged in #50. Each new test pins a contract previously only exercised end-to-end, so a regression flips the unit suite red before any integration test reproduces the original bug.

- **#50.1 — tool-labels**: rename stale `'Bash / Task / Agent ignore preamble'` test (post-#41, Bash *does* fall back to preamble when `description` is absent — the title was lying). Split into five honest cases and corrected the matching JSDoc on `toolLabel()`.
- **#50.2 — progress-card**: new `describe('hasInFlightSubAgents')` block — six cases pin the orphan-exclusion contract from #49. Returns `true` only for correlated runners; `false` when the only running sub-agents are orphans. This was the central fix in #49 with no prior unit lock.
- **#50.3 — progress-card**: new sub-block under `compactItems` pinning the humanAuthored carve-out from #41. Three same-label Bash items with descriptions never collapse to `Bash ×3`; one humanAuthored sibling blocks rollup of the entire run, including the mixed-label C1 path.

The optional #50 item 4 (consolidate the two orphan-scan loops in `progress-card-driver.ts`) is left for whoever next touches that file — it's a micro-perf cleanup, not correctness.

## Test plan

- [x] `tsc --noEmit` clean
- [x] All 182 tests across the touched files pass (`tool-labels.test.ts` 55, `progress-card.test.ts` 115, `systemd-sha.test.ts` 12 — last one to confirm imports unchanged)
- [ ] CI green on Linux

🤖 Generated with [Claude Code](https://claude.com/claude-code)