### PR TITLE
feat(operator-events): wire bridge → IPC → gateway end-to-end (#30)

### DIFF
--- a/telegram-plugin/bridge/bridge.ts
+++ b/telegram-plugin/bridge/bridge.ts
@@ -353,6 +353,27 @@ if (sessionTailEnabled) {
       cwd: sessionCwd,
       log: (msg) => process.stderr.write(`telegram bridge: ${msg}\n`),
       onEvent: forwardSessionEvent,
+      onOperatorEvent: (ev) => {
+        // Phase 4c: forward Anthropic API errors to the gateway so it can
+        // post the operator card + record into the /status history. The
+        // gateway resolves the destination chat from its access allowlist
+        // (operator events are agent-level, not tied to a specific user
+        // message), so chatId is left empty here.
+        if (!ipc || !ipc.isConnected()) return
+        try {
+          ipc.sendOperatorEvent({
+            type: 'operator_event',
+            kind: ev.kind,
+            agent: AGENT_NAME,
+            detail: ev.detail.slice(0, 1000),
+            chatId: '',
+          })
+        } catch (err) {
+          process.stderr.write(
+            `telegram bridge: sendOperatorEvent failed kind=${ev.kind}: ${(err as Error).message}\n`,
+          )
+        }
+      },
     })
     process.stderr.write(
       `telegram bridge: session tail watching ${sessionTailHandle.getActiveFile() ?? '(no active file yet)'}\n`,

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -66,6 +66,13 @@ import {
   deleteFromHistory, query as queryHistory, getLatestInboundMessageId,
 } from '../history.js'
 import { parseQueuePrefix, parseSteerPrefix, formatPriorAssistantPreview, formatReplyToText } from '../steering.js'
+import {
+  renderOperatorEvent,
+  shouldEmitOperatorEvent,
+  type OperatorEvent,
+  type OperatorEventKind,
+} from '../operator-events.js'
+import { recordOperatorEvent } from '../operator-events-history.js'
 
 /**
  * Truncation cap for the `reply_to_text` channel-meta attribute (issue #119).
@@ -139,6 +146,8 @@ import type {
   SessionEventForward,
   PermissionRequestForward,
   HeartbeatMessage,
+  ScheduleRestartMessage,
+  OperatorEventForward,
   InboundMessage,
 } from './ipc-protocol.js'
 import { writePidFile, clearPidFile } from './pid-file.js'
@@ -1093,6 +1102,75 @@ const ipcServer: IpcServer = createIpcServer({
         success: true,
         waitingForTurn: true,
       });
+    }
+  },
+
+  onOperatorEvent(_client: IpcClient, msg: OperatorEventForward) {
+    // Phase 4c: bridge has detected an Anthropic API error (or synthetic
+    // gateway-side event). Render the operator card + post to every chat
+    // on the access allowlist, deduped by per-agent per-kind cooldown.
+    //
+    // chatId on the wire is currently always empty — the bridge doesn't
+    // know which user-chat the error should attribute to (errors aren't
+    // tied to a specific inbound message). We broadcast to the same set
+    // of chats that receive permission requests so the right operator
+    // sees it.
+    const kind = msg.kind as OperatorEventKind
+    const agent = msg.agent
+
+    if (!shouldEmitOperatorEvent(agent, kind)) {
+      process.stderr.write(
+        `telegram gateway: operator-event suppressed (cooldown) agent=${agent} kind=${kind}\n`,
+      )
+      return
+    }
+
+    const event: OperatorEvent = {
+      kind,
+      agent,
+      detail: msg.detail,
+      suggestedActions: [],
+      firstSeenAt: new Date(),
+    }
+
+    try {
+      recordOperatorEvent(event)
+    } catch (err) {
+      process.stderr.write(
+        `telegram gateway: recordOperatorEvent failed agent=${agent} kind=${kind}: ${(err as Error).message}\n`,
+      )
+    }
+
+    let rendered: ReturnType<typeof renderOperatorEvent>
+    try {
+      rendered = renderOperatorEvent(event)
+    } catch (err) {
+      process.stderr.write(
+        `telegram gateway: renderOperatorEvent failed agent=${agent} kind=${kind}: ${(err as Error).message}\n`,
+      )
+      return
+    }
+
+    const access = loadAccess()
+    if (access.allowFrom.length === 0) {
+      process.stderr.write(
+        `telegram gateway: operator-event no-allowlist agent=${agent} kind=${kind} (recorded only)\n`,
+      )
+      return
+    }
+
+    process.stderr.write(
+      `telegram gateway: operator-event posting agent=${agent} kind=${kind} to ${access.allowFrom.length} chat(s)\n`,
+    )
+    for (const chat_id of access.allowFrom) {
+      void bot.api.sendMessage(chat_id, rendered.text, {
+        parse_mode: 'HTML',
+        reply_markup: rendered.keyboard,
+      }).catch(e => {
+        process.stderr.write(
+          `telegram gateway: operator-event send to ${chat_id} failed agent=${agent} kind=${kind}: ${e}\n`,
+        )
+      })
     }
   },
 

--- a/telegram-plugin/gateway/ipc-server.ts
+++ b/telegram-plugin/gateway/ipc-server.ts
@@ -61,6 +61,32 @@ type SocketData = { clientId: string; buffer: string };
  *  data without newline delimiters, which would cause unbounded memory growth. */
 const MAX_BUFFER_SIZE = 1024 * 1024;
 
+/** Allowlist of OperatorEventKind values that can arrive over IPC. Mirrors
+ *  the union in `telegram-plugin/operator-events.ts` — kept as a literal Set
+ *  here so the validator has zero cross-package type dependencies. If the
+ *  taxonomy grows, update both places. */
+const VALID_OPERATOR_KINDS = new Set([
+  "credentials-expired",
+  "credentials-invalid",
+  "credit-exhausted",
+  "quota-exhausted",
+  "rate-limited",
+  "agent-crashed",
+  "agent-restarted-unexpectedly",
+  "unknown-4xx",
+  "unknown-5xx",
+]);
+
+/** Same regex as `assertSafeAgentName` and the op:* callback handler in
+ *  gateway.ts — keeps every entry-point that touches an agent name on the
+ *  same shape. */
+const AGENT_NAME_RE = /^[a-z0-9][a-z0-9_-]{0,50}$/;
+
+/** Cap for the `detail` field on an operator_event message. Long enough to
+ *  carry a typical Anthropic error body, short enough that a misbehaving
+ *  bridge can't fill the gateway log. */
+const OPERATOR_EVENT_DETAIL_MAX = 1000;
+
 /** Validate that a parsed JSON object looks like a legitimate ClientToGateway
  *  message. Returns false for malformed or unexpected shapes. This prevents
  *  a rogue process on the same Unix socket from injecting arbitrary payloads.
@@ -96,9 +122,12 @@ export function validateClientMessage(msg: unknown): msg is ClientToGateway {
     case "schedule_restart":
       return typeof m.agentName === "string" && m.agentName.length > 0;
     case "operator_event":
-      return typeof m.kind === "string" && m.kind.length > 0
-        && typeof m.agent === "string" && m.agent.length > 0
+      return typeof m.kind === "string"
+        && VALID_OPERATOR_KINDS.has(m.kind as string)
+        && typeof m.agent === "string"
+        && AGENT_NAME_RE.test(m.agent as string)
         && typeof m.detail === "string"
+        && (m.detail as string).length <= OPERATOR_EVENT_DETAIL_MAX
         && typeof m.chatId === "string";
     default:
       return false;

--- a/telegram-plugin/tests/ipc-server-validate-operator.test.ts
+++ b/telegram-plugin/tests/ipc-server-validate-operator.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Tightened operator_event validation in `validateClientMessage`
+ * (Phase 4c wiring — issue #30 task 2).
+ *
+ * The Phase 4b shape check accepted any non-empty kind/agent string. With
+ * the producer side now actually wired (bridge → IPC), the gateway needs
+ * a stricter gate so a misbehaving or compromised bridge can't:
+ *   - inject an unknown `kind` that crashes the renderer at switch-default
+ *   - send an agent name that bypasses systemctl-arg sanity (the same
+ *     regex as `assertSafeAgentName`)
+ *   - flood the gateway journal with a giant `detail` payload
+ */
+
+import { describe, it, expect } from 'vitest'
+import { validateClientMessage } from '../gateway/ipc-server.js'
+
+const VALID_KINDS = [
+  'credentials-expired',
+  'credentials-invalid',
+  'credit-exhausted',
+  'quota-exhausted',
+  'rate-limited',
+  'agent-crashed',
+  'agent-restarted-unexpectedly',
+  'unknown-4xx',
+  'unknown-5xx',
+]
+
+function base() {
+  return {
+    type: 'operator_event' as const,
+    kind: 'credentials-expired',
+    agent: 'gymbro',
+    detail: 'token expired at 2026-04-27',
+    chatId: '',
+  }
+}
+
+describe('validateClientMessage — operator_event', () => {
+  it('accepts every taxonomy kind', () => {
+    for (const kind of VALID_KINDS) {
+      expect(validateClientMessage({ ...base(), kind })).toBe(true)
+    }
+  })
+
+  it('rejects unknown kinds', () => {
+    expect(validateClientMessage({ ...base(), kind: 'something-else' })).toBe(false)
+    expect(validateClientMessage({ ...base(), kind: '' })).toBe(false)
+    expect(validateClientMessage({ ...base(), kind: 'CREDENTIALS-EXPIRED' })).toBe(false)
+  })
+
+  it('accepts well-formed agent names', () => {
+    for (const agent of ['gymbro', 'a', 'a1', 'agent-1', 'a_b', '0xff']) {
+      expect(validateClientMessage({ ...base(), agent })).toBe(true)
+    }
+  })
+
+  it('rejects malformed agent names', () => {
+    // leading hyphen would let `switchroom-${agent}` look like a flag
+    expect(validateClientMessage({ ...base(), agent: '-bad' })).toBe(false)
+    // uppercase, spaces, slashes, semicolons all rejected — the regex
+    // is the same one `assertSafeAgentName` uses for systemctl arg safety
+    expect(validateClientMessage({ ...base(), agent: 'BadName' })).toBe(false)
+    expect(validateClientMessage({ ...base(), agent: 'a b' })).toBe(false)
+    expect(validateClientMessage({ ...base(), agent: '../etc' })).toBe(false)
+    expect(validateClientMessage({ ...base(), agent: 'a;rm' })).toBe(false)
+    expect(validateClientMessage({ ...base(), agent: '' })).toBe(false)
+    // Over the 51-char cap (1 leading + 50 trailing)
+    expect(validateClientMessage({ ...base(), agent: 'a' + 'b'.repeat(51) })).toBe(false)
+  })
+
+  it('caps detail at 1000 chars', () => {
+    expect(validateClientMessage({ ...base(), detail: 'x'.repeat(1000) })).toBe(true)
+    expect(validateClientMessage({ ...base(), detail: 'x'.repeat(1001) })).toBe(false)
+  })
+
+  it('requires chatId to be a string (may be empty)', () => {
+    expect(validateClientMessage({ ...base(), chatId: '' })).toBe(true)
+    expect(validateClientMessage({ ...base(), chatId: '12345' })).toBe(true)
+    const noChat = { ...base() } as Record<string, unknown>
+    delete noChat.chatId
+    expect(validateClientMessage(noChat)).toBe(false)
+    expect(validateClientMessage({ ...base(), chatId: 12345 })).toBe(false)
+  })
+
+  it('rejects wrong types on every field', () => {
+    expect(validateClientMessage({ ...base(), kind: 42 })).toBe(false)
+    expect(validateClientMessage({ ...base(), agent: null })).toBe(false)
+    expect(validateClientMessage({ ...base(), detail: null })).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary

Phase 4c — connects the operator-events spans that PR #29 left dangling. Anthropic API errors detected by `session-tail` now actually reach the gateway, get deduped + recorded, and post as actionable operator cards to Telegram.

This is **PR 1 of 5** in the cluster A+B (silent failures + operator-events) workstream. Pure foundation — no user-visible regression risk for agents that never error.

## What changed

- **`telegram-plugin/bridge/bridge.ts`** — `startSessionTail` now passes `onOperatorEvent` that forwards detected errors over IPC, with the agent name from `SWITCHROOM_AGENT_NAME` and `detail` truncated to 1000 chars.
- **`telegram-plugin/gateway/gateway.ts`** — `createIpcServer` now passes `onOperatorEvent` that:
  1. Dedupes via `shouldEmitOperatorEvent` (5-min per-agent per-kind cooldown)
  2. Records into `operator-events-history` (feeds `/status` enrichment in PR 4)
  3. Renders via `renderOperatorEvent`
  4. Broadcasts to every chat in `access.allowFrom`

  Each step is independently fault-tolerant — a record failure doesn't block the post; a failed send to one chat doesn't block siblings.
- **`telegram-plugin/gateway/ipc-server.ts`** — tightened `validateClientMessage` for `operator_event`:
  - `kind` must be in the 9-element OperatorEventKind allowlist (rejects unknown kinds that would crash the renderer at switch-default)
  - `agent` must match `^[a-z0-9][a-z0-9_-]{0,50}$` (same regex as `assertSafeAgentName` and the op:* callback handler)
  - `detail` capped at 1000 chars (matches bridge-side truncation)

  Defense-in-depth — the gateway's pre-dispatch validator catches malformed payloads before any consuming code runs.
- **`telegram-plugin/tests/ipc-server-validate-operator.test.ts`** — 7 new tests covering kind allowlist, agent-name regex, detail cap, chatId requirement, per-field type rejection.

## Why empty `chatId`

Operator events (auth-expired, credit-exhausted, rate-limited, etc.) are agent-level, not tied to a specific user message. The bridge has no way to know which chat the user was in when their next inference call hit a 401. The gateway resolves the destination from the same `access.allowFrom` allowlist that receives permission requests — the right operator gets paged.

## What this unblocks

- **PR 2** ([#92](https://github.com/switchroom/switchroom/issues/92), [#30](https://github.com/switchroom/switchroom/issues/30) task 4) — systemd `NRestarts` watchdog will emit `agent-restarted-unexpectedly` events through this pipe.
- **PR 4** ([#30](https://github.com/switchroom/switchroom/issues/30) task 3, [#109](https://github.com/switchroom/switchroom/issues/109)) — `/status` enrichment shows recent events recorded by this PR.
- **PR 5** ([#30](https://github.com/switchroom/switchroom/issues/30) task 5) — `op:swap-slot` / `op:add-slot` real dispatch replaces the current "Phase 4c will wire this" stub.

## Test plan

- [x] `npm run lint` (tsc --noEmit) — clean
- [x] `npx vitest run telegram-plugin/tests/ipc-server-validate-operator.test.ts` — 7/7 pass
- [x] All 100 operator-events-related tests pass (existing + new)
- [x] All 67 existing `validateClientMessage` tests pass
- [ ] Manual: induce a 401 on a test agent (rotate the OAuth token) → reauth banner posts to allowlisted chat within 5s of the API error, with working "Reauth now" / "Dismiss" buttons
- [ ] Manual: trigger same error twice within 5 min → second is suppressed (cooldown), logged as `operator-event suppressed (cooldown)` in gateway stderr

Refs [#30](https://github.com/switchroom/switchroom/issues/30). Completes Phase 4c task 1 + task 2 from [#16](https://github.com/switchroom/switchroom/issues/16).

🤖 Generated with [Claude Code](https://claude.com/claude-code)