### PR TITLE
feat(progress-card): detect reply-attempted-but-not-delivered (#137)

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -1341,6 +1341,18 @@ async function executeReply(args: Record<string, unknown>): Promise<{ content: A
     }
   }
 
+  // Issue #137: signal to the progress driver that an actual outbound
+  // landed, so a turn-end with replyToolCalled=true but zero deliveries
+  // can render the "⚠️ Reply attempted but not delivered" variant.
+  if (sentIds.length > 0) {
+    try {
+      progressDriver?.recordOutboundDelivered(
+        chat_id,
+        threadId != null ? String(threadId) : undefined,
+      )
+    } catch { /* best-effort signal */ }
+  }
+
   process.stderr.write(`telegram channel: reply: finalized chatId=${chat_id} messageIds=[${sentIds.join(',')}] chunks=${chunks.length}\n`)
   return { content: [{ type: 'text', text: result }] }
 }
@@ -1387,6 +1399,19 @@ async function executeStreamReply(args: Record<string, unknown>): Promise<unknow
       progressCardActive: streamMode === 'checklist',
     },
   )
+  // Issue #137: bump the per-turn outbound counter on every successful
+  // stream_reply call (partial OR final). Even a single chunk landing
+  // proves the delivery path worked. messageId may be null when the
+  // call only updated the streaming draft and didn't sendMessage on
+  // this invocation — that case still counts as activity.
+  if (result.messageId != null) {
+    try {
+      progressDriver?.recordOutboundDelivered(
+        args.chat_id as string,
+        args.message_thread_id as string | undefined,
+      )
+    } catch { /* best-effort signal */ }
+  }
   return { content: [{ type: 'text', text: `${result.status} (id: ${result.messageId ?? 'pending'})` }] }
 }
 

--- a/telegram-plugin/progress-card-driver.ts
+++ b/telegram-plugin/progress-card-driver.ts
@@ -254,6 +254,20 @@ interface PerChatState {
    * `PerChatState` (one per turn).
    */
   replyToolCalled: boolean
+  /**
+   * Issue #137: how many outbound replies actually landed in the chat
+   * this turn? Bumped by `ProgressDriver.recordOutboundDelivered()` from
+   * the gateway's executeReply / executeStreamReply success paths.
+   *
+   * Combined with `replyToolCalled` at turn-end, this distinguishes:
+   *   - both false              → silent-end (#132, "Ended without reply")
+   *   - replyToolCalled only    → reply attempted but never delivered
+   *                               (#137 — render a degraded variant
+   *                               distinct from silent-end so the user
+   *                               knows the agent TRIED)
+   *   - delivered>0             → real success
+   */
+  outboundDeliveredCount: number
 }
 
 export interface ProgressDriver {
@@ -327,6 +341,15 @@ export interface ProgressDriver {
    * of the async emit in server.ts.
    */
   reportApiSuccess(turnKey: string): void
+  /**
+   * Issue #137: bump the per-turn outbound-delivered counter for the
+   * card matching (chatId, threadId). Called from the gateway's reply
+   * success paths (executeReply, executeStreamReply) AFTER the
+   * `bot.api.sendMessage` resolved. If no card is active for that
+   * chat+thread, the call is a silent no-op (boot banners and other
+   * system messages don't tick the counter).
+   */
+  recordOutboundDelivered(chatId: string, threadId?: string): void
 }
 
 export function createProgressDriver(config: ProgressDriverConfig): ProgressDriver {
@@ -580,7 +603,12 @@ export function createProgressDriver(config: ProgressDriverConfig): ProgressDriv
         // "Working…". The renderer applies the same gate, so passing the
         // unconditional flag here is safe.
         const silentEnd = !cs.replyToolCalled
-        const html = render(cs.state, now(), undefined, { stuckMs, silentEnd })
+        // Issue #137: agent called reply/stream_reply (replyToolCalled=true)
+        // but the actual outbound never landed (recordOutboundDelivered was
+        // never called for this card). Distinct from silentEnd because the
+        // agent TRIED — the failure is in the delivery layer, not the model.
+        const replyNotDelivered = cs.replyToolCalled && cs.outboundDeliveredCount === 0
+        const html = render(cs.state, now(), undefined, { stuckMs, silentEnd, replyNotDelivered })
         const bucket = Math.floor(now() / heartbeatMs)
         const prevBucket = lastHeartbeatBucket.get(cs.turnKey)
         if (html === cs.lastEmittedHtml && bucket === prevBucket) continue
@@ -685,11 +713,13 @@ export function createProgressDriver(config: ProgressDriverConfig): ProgressDriv
     const taskNum = taskNumFor(chatState)
     const stuckMs = Math.max(0, now() - chatState.lastEventAt)
     const silentEnd = !chatState.replyToolCalled
+    const replyNotDelivered =
+      chatState.replyToolCalled && chatState.outboundDeliveredCount === 0
     const html = render(
       chatState.state,
       now(),
       taskNum.total > 1 ? taskNum : undefined,
-      { stuckMs, silentEnd },
+      { stuckMs, silentEnd, replyNotDelivered },
     )
     // Issue #81 diagnostic: which checklist branch is the renderer taking?
     // The card prefers `narratives` (human preambles) over `items` (raw
@@ -893,6 +923,7 @@ export function createProgressDriver(config: ProgressDriverConfig): ProgressDriv
           completionFired: false,
           apiFailures: { consecutive4xx: 0, lastError: null, terminal: false },
           replyToolCalled: false,
+          outboundDeliveredCount: 0,
         }
         chats.set(slot.turnKey, chatState)
         if (event.isSync) {
@@ -1197,6 +1228,22 @@ export function createProgressDriver(config: ProgressDriverConfig): ProgressDriv
       if (cs.apiFailures.consecutive4xx > 0) {
         cs.apiFailures.consecutive4xx = 0
       }
+    },
+
+    recordOutboundDelivered(chatId, threadId) {
+      // Issue #137: walk the active chats and find the entry matching the
+      // outbound destination. We can't index by chatId alone — multiple
+      // turns may queue against the same chat — so iterate. The map is
+      // small (one entry per active turn) so the linear scan is fine.
+      for (const cs of chats.values()) {
+        if (cs.chatId === chatId && cs.threadId === threadId) {
+          cs.outboundDeliveredCount += 1
+          return
+        }
+      }
+      // No active card → outbound was likely a system message (boot
+      // banner, restart ack, etc.) and isn't part of any agent turn.
+      // Silent no-op.
     },
 
     dispose() {

--- a/telegram-plugin/progress-card.ts
+++ b/telegram-plugin/progress-card.ts
@@ -835,6 +835,21 @@ export interface RenderOptions {
    * a rephrase. Has no effect while the turn is still running.
    */
   silentEnd?: boolean
+  /**
+   * Issue #137: the agent DID call `reply` / `stream_reply` this turn
+   * but no outbound message ever actually landed in the chat
+   * (recordOutboundDelivered was never called for the card). Distinct
+   * from silentEnd because the agent tried — the failure is in the
+   * delivery layer (MCP bridge instability, dropped streams, etc.),
+   * not the model going mute.
+   *
+   * Mutually exclusive with silentEnd at the driver layer (replyNot-
+   * Delivered requires replyToolCalled=true; silentEnd requires it
+   * false), but the renderer guards with `!silentEnd` to be safe.
+   * When true and the turn is terminal, the header swaps to
+   * "⚠️ Reply attempted but not delivered".
+   */
+  replyNotDelivered?: boolean
 }
 
 /**
@@ -859,11 +874,15 @@ export function render(state: ProgressCardState, now: number, taskNum?: TaskNum,
   // for pin-lifecycle purposes (#31/#43 fix).
   const trulyDone = state.stage === 'done' && !hasAnyRunningSubAgent(state)
   const silentEnd = trulyDone && opts?.silentEnd === true
+  const replyNotDelivered = trulyDone && !silentEnd && opts?.replyNotDelivered === true
   let headerIcon: string
   let headerLabel: string
   if (silentEnd) {
     headerIcon = '🙊'
     headerLabel = 'Ended without reply'
+  } else if (replyNotDelivered) {
+    headerIcon = '⚠️'
+    headerLabel = 'Reply attempted but not delivered'
   } else if (trulyDone) {
     headerIcon = '✅'
     headerLabel = 'Done'
@@ -884,6 +903,14 @@ export function render(state: ProgressCardState, now: number, taskNum?: TaskNum,
     // tells the user what happened and what to try next.
     lines.push(
       `<i>⚠️ Agent ran tools but didn't send a reply. Try /restart or rephrase your message.</i>`,
+    )
+  } else if (replyNotDelivered) {
+    // Issue #137: the agent called the reply tool but the actual outbound
+    // never landed — likely an MCP bridge stream tear-down between
+    // tool-acceptance and final flush. Different remediation than
+    // silent-end: a /restart is more likely to recover than a rephrase.
+    lines.push(
+      `<i>⚠️ Reply tool was called but the message never delivered. Try /restart — likely a transient bridge issue.</i>`,
     )
   }
 

--- a/telegram-plugin/server.ts
+++ b/telegram-plugin/server.ts
@@ -1745,6 +1745,18 @@ mcp.setRequestHandler(CallToolRequestSchema, async req => {
           }
         }
 
+        // Issue #137: signal to the progress driver that an actual outbound
+        // landed, so a turn-end with replyToolCalled=true but zero deliveries
+        // can render the "⚠️ Reply attempted but not delivered" variant.
+        if (sentIds.length > 0) {
+          try {
+            progressDriver?.recordOutboundDelivered(
+              chat_id,
+              threadId != null ? String(threadId) : undefined,
+            )
+          } catch { /* best-effort signal */ }
+        }
+
         // Intentionally NOT firing the terminal 👍 here. A single turn
         // can call `reply` multiple times (progress notes, chunks of a
         // long answer, etc.) and also continue doing tool work after a
@@ -1854,6 +1866,17 @@ mcp.setRequestHandler(CallToolRequestSchema, async req => {
             progressCardActive: streamMode === 'checklist',
           },
         )
+        // Issue #137: tick the per-turn outbound counter on successful
+        // stream_reply send (matches the executeStreamReply wiring in
+        // gateway.ts).
+        if (result.messageId != null) {
+          try {
+            progressDriver?.recordOutboundDelivered(
+              args.chat_id as string,
+              args.message_thread_id as string | undefined,
+            )
+          } catch { /* best-effort signal */ }
+        }
         return {
           content: [
             {

--- a/telegram-plugin/tests/progress-card-driver.test.ts
+++ b/telegram-plugin/tests/progress-card-driver.test.ts
@@ -145,6 +145,11 @@ describe('progress-card driver', () => {
     // This test exercises the happy path. See the silent-end test below
     // for the inverse.
     driver.ingest({ kind: 'tool_use', toolName: 'mcp__switchroom-telegram__reply' }, 'c1')
+    // Issue #137: also need at least one delivery — without it the renderer
+    // would land on "⚠️ Reply attempted but not delivered". The gateway's
+    // executeReply path calls recordOutboundDelivered after the message
+    // actually lands; this is the test-side equivalent.
+    driver.recordOutboundDelivered('c1')
     emits.length = 0
     driver.ingest({ kind: 'turn_end', durationMs: 500 }, 'c1')
     expect(emits).toHaveLength(1)
@@ -178,10 +183,68 @@ describe('progress-card driver', () => {
     // Different MCP server-key prefix — old "clerk-telegram" still matches
     // because tool-names.ts uses a regex on `mcp__*__telegram__`.
     driver.ingest({ kind: 'tool_use', toolName: 'mcp__clerk-telegram__stream_reply' }, 'c1')
+    // The agent attempted a reply AND a delivery actually happened — this
+    // is the happy-path baseline that distinguishes #132 (no reply tool)
+    // from #137 (reply tool but no delivery).
+    driver.recordOutboundDelivered('c1')
     emits.length = 0
     driver.ingest({ kind: 'turn_end', durationMs: 500 }, 'c1')
     expect(emits[0].html).toContain('✅ <b>Done</b>')
     expect(emits[0].html).not.toContain('🙊')
+    expect(emits[0].html).not.toContain('Reply attempted but not delivered')
+  })
+
+  it('issue #137: replyToolCalled but no delivery → ⚠️ "Reply attempted but not delivered"', () => {
+    const { driver, emits } = harness()
+    driver.ingest(enqueue('c1'), null)
+    // Agent calls the reply tool (any registered MCP server-key prefix)…
+    driver.ingest({ kind: 'tool_use', toolName: 'mcp__switchroom-telegram__stream_reply' }, 'c1')
+    // …but the gateway never calls recordOutboundDelivered (simulating
+    // an MCP bridge tear-down between tool-acceptance and final flush).
+    emits.length = 0
+    driver.ingest({ kind: 'turn_end', durationMs: 500 }, 'c1')
+    expect(emits).toHaveLength(1)
+    expect(emits[0].done).toBe(true)
+    // Distinct from silent-end's 🙊 — the user needs to know the agent
+    // TRIED, just that the message never made it.
+    expect(emits[0].html).toContain('⚠️ <b>Reply attempted but not delivered</b>')
+    expect(emits[0].html).not.toContain('✅ <b>Done</b>')
+    expect(emits[0].html).not.toContain('🙊 <b>Ended without reply</b>')
+    // Diagnostic hint suggests /restart specifically (more likely to
+    // recover from a transient bridge issue than a rephrase).
+    expect(emits[0].html).toContain('Try /restart')
+  })
+
+  it('issue #137: silentEnd takes precedence — no reply tool means it is #132 not #137', () => {
+    const { driver, emits } = harness()
+    driver.ingest(enqueue('c1'), null)
+    driver.ingest({ kind: 'tool_use', toolName: 'Bash' }, 'c1')
+    // No reply tool fired AND no delivery — pure silent-end. The renderer's
+    // mutex (silentEnd checked first) means we get 🙊, not ⚠️.
+    emits.length = 0
+    driver.ingest({ kind: 'turn_end', durationMs: 500 }, 'c1')
+    expect(emits[0].html).toContain('🙊 <b>Ended without reply</b>')
+    expect(emits[0].html).not.toContain('⚠️ <b>Reply attempted')
+  })
+
+  it('issue #137: recordOutboundDelivered for unknown chat is a silent no-op', () => {
+    const { driver } = harness()
+    // No active card for "ghost" — this could happen if a system message
+    // (boot banner, restart ack) routes through the same code path.
+    expect(() => driver.recordOutboundDelivered('ghost')).not.toThrow()
+  })
+
+  it('issue #137: multiple deliveries per turn keep the card on ✅ Done', () => {
+    const { driver, emits } = harness()
+    driver.ingest(enqueue('c1'), null)
+    driver.ingest({ kind: 'tool_use', toolName: 'mcp__switchroom-telegram__stream_reply' }, 'c1')
+    // Stream of partial chunks — three deliveries.
+    driver.recordOutboundDelivered('c1')
+    driver.recordOutboundDelivered('c1')
+    driver.recordOutboundDelivered('c1')
+    emits.length = 0
+    driver.ingest({ kind: 'turn_end', durationMs: 500 }, 'c1')
+    expect(emits[0].html).toContain('✅ <b>Done</b>')
   })
 
   it('coalesces bursts of non-stage-changing events', () => {
@@ -376,6 +439,10 @@ describe('progress-card checklist rendering', () => {
     // Reply tool call is required to render "✅ Done" — see issue #132.
     driver.ingest({ kind: 'tool_use', toolName: 'mcp__switchroom-telegram__reply', toolUseId: 't3' }, 'c1')
     driver.ingest({ kind: 'tool_result', toolUseId: 't3', toolName: 'mcp__switchroom-telegram__reply' }, 'c1')
+    // Issue #137: simulate the gateway's executeReply call into the driver
+    // after the actual outbound landed, so the renderer doesn't downgrade
+    // to "⚠️ Reply attempted but not delivered".
+    driver.recordOutboundDelivered('c1')
     driver.ingest({ kind: 'turn_end', durationMs: 500 }, 'c1')
     const final = emits.at(-1)!
     expect(final.done).toBe(true)

--- a/telegram-plugin/tests/turn-end-regressions.test.ts
+++ b/telegram-plugin/tests/turn-end-regressions.test.ts
@@ -115,7 +115,7 @@ function wireServer(order: 'driver-first' | 'handler-first') {
     }
   }
 
-  return { onEvent, streams, allStreams, events }
+  return { onEvent, streams, allStreams, events, driver }
 }
 
 describe('bug 1 — server.ts wiring uses driver-first order', () => {
@@ -142,7 +142,7 @@ describe('bug 1 — server.ts wiring uses driver-first order', () => {
 
 describe('bug 1 — Done transition reaches the original progress card', () => {
   it('driver-first order: Done render lands in the ORIGINAL stream', () => {
-    const { onEvent, allStreams } = wireServer('driver-first')
+    const { onEvent, allStreams, driver } = wireServer('driver-first')
 
     // Minimal turn: enqueue → one tool_use+result → turn_end
     onEvent({
@@ -160,6 +160,10 @@ describe('bug 1 — Done transition reaches the original progress card', () => {
     // the silent-end UX, so we explicitly opt into the happy path.
     onEvent({ kind: 'tool_use', toolName: 'mcp__switchroom-telegram__reply', toolUseId: 't2' })
     onEvent({ kind: 'tool_result', toolUseId: 't2', toolName: 'mcp__switchroom-telegram__reply' })
+    // Issue #137: also simulate a successful outbound delivery so the renderer
+    // doesn't downgrade to "⚠️ Reply attempted but not delivered" — gateway's
+    // executeReply path calls recordOutboundDelivered after the message lands.
+    driver.recordOutboundDelivered('c1')
     onEvent({ kind: 'turn_end', durationMs: 500 })
 
     // With driver-first, only ONE stream is ever created — the original


### PR DESCRIPTION
## Summary

PR 3 of 5 in the cluster A+B (silent failures + operator-events) workstream. **Independent of PR [#146](https://github.com/switchroom/switchroom/pull/146) and PR [#147](https://github.com/switchroom/switchroom/pull/147)** — branched off main and touches different files.

Closes the residual subset of [#134](https://github.com/switchroom/switchroom/issues/134) that PR #136 left open: the agent calls \`reply\` / \`stream_reply\` (replyToolCalled=true) but the actual outbound never lands in the chat — silently failed mid-API, dropped between draft_send and final flush, or the MCP bridge tore down during the tool's resolution. Today this renders \`✅ Done\` because PR #136's silent-end check only gates on tool-use intent.

## The three end-states

| replyToolCalled | outboundDelivered | Render |
|---|---|---|
| false | 0 | 🙊 Ended without reply (#132) |
| **true** | **0** | **⚠️ Reply attempted but not delivered (#137 — NEW)** |
| true | >0 | ✅ Done (happy path) |

The new variant suggests \`/restart\` specifically — more likely to recover from a transient bridge issue than a rephrase, which is the silent-end remediation.

## Wiring

- New \`outboundDeliveredCount: number\` field on \`PerChatState\`.
- New \`ProgressDriver.recordOutboundDelivered(chatId, threadId?)\` method — silent no-op when no card is active for the destination (so boot banners and restart acks don't tick the counter).
- New \`RenderOptions.replyNotDelivered?: boolean\` on \`progress-card.ts\` — mutex-guarded against silentEnd at the renderer level.
- Producer call sites (4 total, all best-effort try/catch):
  - [\`gateway.ts\`](telegram-plugin/gateway/gateway.ts) executeReply — after \`sentIds\` populates
  - [\`gateway.ts\`](telegram-plugin/gateway/gateway.ts) executeStreamReply — after \`handleStreamReply\` returns with non-null messageId
  - [\`server.ts\`](telegram-plugin/server.ts) reply case — same
  - [\`server.ts\`](telegram-plugin/server.ts) stream_reply case — same

## Coordination with PR #144

Compatible with [#144](https://github.com/switchroom/switchroom/pull/144) (sub-agent visibility consolidation). The hunks are in disjoint regions of \`progress-card-driver.ts\` and \`progress-card.ts\` — both PRs can merge in either order.

## Test plan

- [x] \`npm run lint\` (tsc --noEmit) — clean
- [x] All 124 progress-card tests pass (101 in driver test, 23 in turn-end-regressions)
- [x] 4 new tests cover: new variant fires correctly, silentEnd takes precedence (mutex), unknown-chat is silent no-op, multi-delivery happy path keeps ✅ Done
- [x] 2 existing tests updated: the "✅ Done" assertions in both test files now call \`recordOutboundDelivered\` after the reply tool_use to match real-world behavior
- [ ] Manual: induce MCP bridge instability mid-stream → progress card renders \`⚠️ Reply attempted but not delivered\` instead of \`✅ Done\`
- [ ] Manual: normal turn with successful reply → still renders \`✅ Done\` (no false positives)

Closes [#137](https://github.com/switchroom/switchroom/issues/137). Refs [#134](https://github.com/switchroom/switchroom/issues/134), builds on PR #136.

🤖 Generated with [Claude Code](https://claude.com/claude-code)