### PR TITLE
feat(telegram): /status returns full config audit on demand (closes #142)

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -137,6 +137,8 @@ import {
 } from '../auto-fallback.js'
 import { markSlotQuotaExhausted } from '../../src/auth/accounts.js'
 import { fallbackToNextSlot, currentActiveSlot, type AuthCodeOutcome } from '../../src/auth/manager.js'
+import { loadConfig as loadSwitchroomConfig } from '../../src/config/loader.js'
+import type { AgentAudit } from '../welcome-text.js'
 import { shouldSweepChatAtBoot } from './boot-sweep-filter.js'
 
 import { createIpcServer, type IpcClient, type IpcServer } from './ipc-server.js'
@@ -3629,6 +3631,72 @@ bot.use(async (ctx, next) => {
 
 // ─── Bot commands ─────────────────────────────────────────────────────────
 
+/**
+ * Build the optional audit details surfaced on `/status` (Profile, Tools,
+ * Skills, Limits, Channel, Memory, Version). Populated from switchroom.yaml
+ * at request time so the values reflect the live config.
+ *
+ * Pre-#142 this content was baked into a SessionStart curl script and
+ * pushed on every restart. Now it's pulled on demand via /status (#142
+ * PR 3) — server-side render of the same row shape.
+ *
+ * Best-effort: any failure (yaml unreadable, agent missing, etc.) returns
+ * undefined so /status falls back to its previous (auth + uptime + agent
+ * name) shape rather than blocking the reply.
+ */
+function buildAgentAudit(agentName: string): AgentAudit | undefined {
+  try {
+    const config = loadSwitchroomConfig()
+    const agentConfig = config.agents?.[agentName]
+    if (!agentConfig) return undefined
+
+    // Tools allowlist — same shape as the deleted greeting:
+    //   "all" / first 5 names + "+N more" / "none (default)".
+    const allow = agentConfig.tools?.allow
+    const tools = allow?.includes('all')
+      ? 'all'
+      : (allow?.slice(0, 5).join(', ') ?? 'none (default)')
+        + ((allow?.length ?? 0) > 5 ? ` +${(allow?.length ?? 0) - 5} more` : '')
+
+    const denyList = agentConfig.tools?.deny
+    const toolsDeny = denyList?.length ? denyList.join(', ') : null
+
+    // Skills cap at 6 names + "…+N more" so the row never wraps 4+
+    // mobile lines (matches the deleted greeting's behavior).
+    const skillsList = agentConfig.skills
+    let skills: string | null = null
+    if (skillsList?.length) {
+      const max = 6
+      skills = skillsList.length <= max
+        ? skillsList.join(', ')
+        : `${skillsList.slice(0, max).join(', ')}, …+${skillsList.length - max} more`
+    }
+
+    // Session limits — concatenated idle + max-turns, or "unlimited".
+    const session: string[] = []
+    if (agentConfig.session?.max_idle) session.push(`idle ${agentConfig.session.max_idle}`)
+    if (agentConfig.session?.max_turns) session.push(`${agentConfig.session.max_turns} turns`)
+    const limits = session.length ? session.join(', ') : 'unlimited (default)'
+
+    const channel = agentConfig.channels?.telegram?.plugin ?? 'switchroom (default)'
+    const memoryBank = agentConfig.memory?.collection ?? `${agentName} (default)`
+
+    return {
+      version: formatBootVersion(),
+      tools,
+      toolsDeny,
+      skills,
+      limits,
+      channel,
+      memoryBank,
+    }
+  } catch {
+    // Silent failure — gateway runs in agent dirs without switchroom.yaml
+    // path resolution always succeeding. /status falls back gracefully.
+    return undefined
+  }
+}
+
 // Build an AgentMetadata snapshot for the current agent by shelling out
 // to `switchroom agent list --json` and `switchroom auth status --json`.
 // Best-effort — any missing piece renders as a placeholder in the text
@@ -3669,6 +3737,7 @@ function buildAgentMetadata(agentName: string): AgentMetadata {
     uptime: a?.uptime ?? null,
     status: a?.status ?? null,
     auth: authSummary,
+    audit: buildAgentAudit(agentName),
   }
 }
 

--- a/telegram-plugin/tests/welcome-text.test.ts
+++ b/telegram-plugin/tests/welcome-text.test.ts
@@ -161,7 +161,94 @@ describe("statusPairedText", () => {
     const out = statusPairedText({ user: "@ken", meta: withStatus });
     expect(out).toContain("Status: <code>running</code> · up 3h 12m");
   });
+
+  // Issue #142 PR 3 — audit details surfaced on /status when the gateway
+  // successfully loads switchroom.yaml. Pre-#142 this content lived in
+  // the SessionStart greeting card; now it's pulled on demand.
+  describe("audit block (#142 PR 3)", () => {
+    const audit = {
+      version: "v0.3.0+44 · 2h ago",
+      tools: "Read, Write, Bash, Edit, Grep +12 more",
+      toolsDeny: "WebFetch",
+      skills: "git, telegram, vault, +3 more",
+      limits: "idle 30m, 50 turns",
+      channel: "switchroom (default)",
+      memoryBank: "assistant",
+    };
+
+    it("does NOT render audit rows when meta.audit is undefined (yaml load failed)", () => {
+      const out = statusPairedText({ user: "@ken", meta });
+      expect(out).not.toContain("Version");
+      expect(out).not.toContain("Tools");
+      expect(out).not.toContain("Channel");
+    });
+
+    it("renders all audit rows when meta.audit is fully populated", () => {
+      const withAudit: AgentMetadata = { ...meta, extendsProfile: "klanker", audit };
+      const out = statusPairedText({ user: "@ken", meta: withAudit });
+      expect(out).toContain("<b>Version</b> v0.3.0+44 · 2h ago");
+      expect(out).toContain("<b>Profile</b> klanker");
+      expect(out).toContain("<b>Tools</b> Read, Write, Bash, Edit, Grep +12 more");
+      expect(out).toContain("<b>Deny</b> WebFetch");
+      expect(out).toContain("<b>Skills</b> git, telegram, vault, +3 more");
+      expect(out).toContain("<b>Limits</b> idle 30m, 50 turns");
+      expect(out).toContain("<b>Channel</b> switchroom (default)");
+      expect(out).toContain("<b>Memory</b> assistant");
+    });
+
+    it("omits Deny row when toolsDeny is null", () => {
+      const partial: AgentMetadata = { ...meta, audit: { ...audit, toolsDeny: null } };
+      const out = statusPairedText({ user: "@ken", meta: partial });
+      expect(out).not.toContain("Deny");
+      expect(out).toContain("<b>Tools</b>");
+    });
+
+    it("omits Skills row when skills is null (agent has no bundled skills)", () => {
+      const partial: AgentMetadata = { ...meta, audit: { ...audit, skills: null } };
+      const out = statusPairedText({ user: "@ken", meta: partial });
+      expect(out).not.toContain("Skills");
+    });
+
+    it("renders the audit block AFTER the live state (Agent/Auth/Status)", () => {
+      const withAudit: AgentMetadata = { ...meta, status: "running", uptime: "1h", audit };
+      const out = statusPairedText({ user: "@ken", meta: withAudit });
+      const statusIdx = out.indexOf("Status:");
+      const versionIdx = out.indexOf("Version");
+      expect(statusIdx).toBeGreaterThan(0);
+      expect(versionIdx).toBeGreaterThan(statusIdx);
+    });
+
+    it("escapes HTML in audit values", () => {
+      const hostile: AgentAuditLike = {
+        version: "<script>alert(1)</script>",
+        tools: "Read & <Write>",
+        toolsDeny: null,
+        skills: null,
+        limits: "idle 30m",
+        channel: "switchroom",
+        memoryBank: "bank<>name",
+      };
+      const out = statusPairedText({ user: "@ken", meta: { ...meta, audit: hostile } });
+      expect(out).not.toContain("<script>alert");
+      expect(out).toContain("&lt;script&gt;");
+      expect(out).toContain("Read &amp; &lt;Write&gt;");
+      expect(out).toContain("bank&lt;&gt;name");
+    });
+
+    it("handles empty extendsProfile (no Profile row when meta.extendsProfile is null)", () => {
+      const withAudit: AgentMetadata = { ...meta, extendsProfile: null, audit };
+      const out = statusPairedText({ user: "@ken", meta: withAudit });
+      expect(out).not.toContain("<b>Profile</b>");
+      // But other audit rows still render.
+      expect(out).toContain("<b>Version</b>");
+    });
+  });
 });
+
+// Local alias for the audit shape — duplicates the AgentMetadata.audit
+// type so the test file doesn't have to re-import it just for one
+// hostile-input fixture.
+type AgentAuditLike = NonNullable<AgentMetadata["audit"]>;
 
 describe("statusPendingText / statusUnpairedText", () => {
   it("pending includes the code verbatim", () => {

--- a/telegram-plugin/welcome-text.ts
+++ b/telegram-plugin/welcome-text.ts
@@ -18,6 +18,36 @@ export type AuthSummary = {
   auth_source: string | null;
 };
 
+/**
+ * Optional audit details surfaced on `/status` for a paired user. Populated
+ * from switchroom.yaml at request time so the values reflect the live
+ * config, not what was baked at scaffold time. Pre-#142 this content
+ * lived in the SessionStart greeting card written by `scaffold.ts`; that
+ * surface was deleted in #142 PR 1, and the content is reincarnated here
+ * as on-demand server-side rendering instead of pushed-on-every-restart
+ * client-side curl.
+ *
+ * All fields are optional — gateway only populates them when the yaml
+ * load succeeds. A failure to read the config produces the previous
+ * (auth + uptime + agent name) shape.
+ */
+export type AgentAudit = {
+  /** Pre-formatted version string from build-info, e.g. "v0.3.0+44 · 2h ago". */
+  version?: string;
+  /** Tools allowlist preview — `["all"]` or up to 5 names plus `"+N more"`. */
+  tools?: string;
+  /** Tools denylist as a comma-joined string, or null. */
+  toolsDeny?: string | null;
+  /** Skills bundle preview — up to 6 names + `"…+N more"`, or null. */
+  skills?: string | null;
+  /** Session limits — `"idle 30m, 50 turns"` or `"unlimited (default)"`. */
+  limits?: string;
+  /** Channel plugin name, e.g. `"switchroom (default)"`. */
+  channel?: string;
+  /** Hindsight bank id for memory recall, defaults to agent name. */
+  memoryBank?: string;
+};
+
 export type AgentMetadata = {
   agentName: string;
   model: string | null;
@@ -27,6 +57,8 @@ export type AgentMetadata = {
   uptime: string | null;
   status: string | null;
   auth: AuthSummary | null;
+  /** Live audit details — present only when switchroom.yaml loaded cleanly. */
+  audit?: AgentAudit;
 };
 
 // Tiny escaper — duplicates the one in gateway.ts / server.ts so this
@@ -112,6 +144,12 @@ export function helpText(agentName: string): string {
 /**
  * Rich `/status` output for a paired user. Includes agent, model,
  * auth state, and optional uptime / topic info.
+ *
+ * When `meta.audit` is populated (gateway successfully loaded
+ * switchroom.yaml at request time), the reply also surfaces the full
+ * config audit — Profile, Tools, Skills, Limits, Channel, Memory bank,
+ * Version. This is the on-demand reincarnation of the SessionStart
+ * greeting card deleted in #142 PR 1.
  */
 export function statusPairedText(params: {
   user: string;
@@ -125,6 +163,22 @@ export function statusPairedText(params: {
     `Auth: ${formatAuthLine(meta.auth)}`,
   ];
   if (meta.status) lines.push(`Status: <code>${escapeHtml(meta.status)}</code>${meta.uptime ? ` · up ${escapeHtml(meta.uptime)}` : ""}`);
+
+  const audit = meta.audit;
+  if (audit) {
+    // Blank separator before the audit block so the reply reads as two
+    // sections: live state up top, config audit below.
+    lines.push("");
+    if (audit.version) lines.push(`<b>Version</b> ${escapeHtml(audit.version)}`);
+    if (meta.extendsProfile) lines.push(`<b>Profile</b> ${escapeHtml(meta.extendsProfile)}`);
+    if (audit.tools) lines.push(`<b>Tools</b> ${escapeHtml(audit.tools)}`);
+    if (audit.toolsDeny) lines.push(`<b>Deny</b> ${escapeHtml(audit.toolsDeny)}`);
+    if (audit.skills) lines.push(`<b>Skills</b> ${escapeHtml(audit.skills)}`);
+    if (audit.limits) lines.push(`<b>Limits</b> ${escapeHtml(audit.limits)}`);
+    if (audit.channel) lines.push(`<b>Channel</b> ${escapeHtml(audit.channel)}`);
+    if (audit.memoryBank) lines.push(`<b>Memory</b> ${escapeHtml(audit.memoryBank)}`);
+  }
+
   return lines.join("\n");
 }
 


### PR DESCRIPTION
## Summary

PR 3 of 3 in [#142](https://github.com/switchroom/switchroom/issues/142)'s "telegram surfaces: quiet, contextual cards" workstream. Reincarnates the deleted SessionStart greeting card content (PR 1 [#150](https://github.com/switchroom/switchroom/pull/150)) as on-demand server-side render via the existing \`/status\` command — pulled when the user wants it, never pushed.

\`\`\`
Paired as @ken.

Agent: <b>klanker</b> · model: sonnet · topic: 🎛️ Klanker
Auth: ✓ Max · expires 29 days
Status: running · up 3h 12m

Version v0.3.0+44 · 2h ago
Profile klanker
Tools Read, Write, Bash, Edit, Grep +12 more
Deny WebFetch
Skills git, telegram, vault
Limits idle 30m, 50 turns
Channel switchroom (default)
Memory klanker
\`\`\`

## What changed

- [\`welcome-text.ts\`](telegram-plugin/welcome-text.ts) — \`AgentMetadata\` gains an optional \`audit?: AgentAudit\` field. When populated, \`statusPairedText\` appends 7 audit rows after the live state.
- [\`gateway.ts\`](telegram-plugin/gateway/gateway.ts) — new \`buildAgentAudit(agentName)\` loads \`switchroom.yaml\` via \`loadSwitchroomConfig()\` at request time. Best-effort: any failure returns undefined and \`/status\` falls back to the previous shape.

## Why /status instead of restoring the greeting

Per [#142](https://github.com/switchroom/switchroom/issues/142)'s JTBD framing, the audit content answers *"what's the full config of this agent?"* — a non-JTBD that doesn't change between restarts. Pushing it on every SessionStart was noise. Pulling it via \`/status\` puts the user in control.

## Out of scope (deliberately)

- **Live Memory stats from Hindsight** (count, last retain). The HTTP probe shape exists in \`boot-card.ts probeHindsight\`; could be folded in as a follow-up.
- **/status enrichment with operator-events history** — that's [#146](https://github.com/switchroom/switchroom/pull/146)'s PR 4 of 5 territory.

## Tests

7 new unit tests in [\`welcome-text.test.ts\`](telegram-plugin/tests/welcome-text.test.ts):
- Audit rows omitted when \`meta.audit\` is undefined (yaml load failed)
- All rows render when fully populated
- Conditional rows (Deny only when \`toolsDeny\` non-null; Skills omitted when null)
- Audit block ordering (after live state)
- HTML escaping on audit values
- Profile row omitted when \`extendsProfile\` is null

## Acceptance check (closes [#142](https://github.com/switchroom/switchroom/issues/142))

- [x] \`/status\` returns the full config audit on demand
- [x] Verified in \`node:20\` docker: tsc clean, 52/52 pass

## Closes

- **Closes [#142](https://github.com/switchroom/switchroom/issues/142)** — final slice of the 3-PR workstream. PR 1 ([#150](https://github.com/switchroom/switchroom/pull/150)) deleted the greeting + replaced the boot card with a quiet ack. PR 2 ([#144](https://github.com/switchroom/switchroom/pull/144)) unified the sub-agent surfaces into the in-card tracker. This PR moves the audit content to /status.

🤖 Generated with [Claude Code](https://claude.com/claude-code)