### PR TITLE
feat(vault-broker): auto-unlock on boot via LoadCredentialEncrypted (#152)

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,38 @@ and on demand via `switchroom vault broker lock`. Use
 
 Unit installed at `~/.config/systemd/user/switchroom-vault-broker.service`.
 
+### Auto-unlock on boot (opt-in)
+
+By default, the broker holds the unlocked state in memory only — every
+restart (host reboot, service crash, reconcile that re-renders the unit)
+wipes it and requires `switchroom vault broker unlock` again. For
+unattended hosts where this is too painful, switchroom supports
+auto-unlock via [systemd `LoadCredentialEncrypted=`](https://systemd.io/CREDENTIALS/):
+
+```bash
+switchroom vault broker enable-auto-unlock   # one-time setup, prompts for passphrase
+# Then in switchroom.yaml:
+#   vault:
+#     broker:
+#       autoUnlock: true
+switchroom reconcile                          # re-render broker unit with LoadCredentialEncrypted=
+systemctl --user restart switchroom-vault-broker.service
+```
+
+After this, the broker auto-unlocks on every start. Disable with
+`switchroom vault broker disable-auto-unlock`.
+
+**Security tradeoff — read this before enabling.** The passphrase is
+encrypted with a per-user key derived by `systemd-creds` and stored at
+`~/.config/credstore.encrypted/vault-passphrase` (configurable via
+`vault.broker.autoUnlockCredentialPath`). Anyone with code execution as
+your user — or root on the host — can call `systemd-creds decrypt` and
+recover the passphrase. This is the same blast radius as today's TTY
+unlock (a process running as you can already attach to the broker and
+exfiltrate secrets), but the convenience-vs-security knob is real:
+auto-unlock means a lost laptop is a lost vault even if the vault file
+itself is encrypted at rest. Use only on hosts you trust.
+
 ## CLI Reference
 
 ```bash

--- a/src/agents/systemd-broker-unit.test.ts
+++ b/src/agents/systemd-broker-unit.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Tests for generateBrokerUnit() — LoadCredentialEncrypted and Type=simple.
+ *
+ * Covers:
+ *   - Type=simple is always present (regression guard for the earlier Type=notify bug)
+ *   - LoadCredentialEncrypted= is absent when autoUnlock is not set
+ *   - LoadCredentialEncrypted= is present with correct credential path when autoUnlock is set
+ */
+
+import { describe, expect, it } from "vitest";
+import { generateBrokerUnit } from "./systemd.js";
+
+const BASE_OPTS = {
+  homeDir: "/home/testuser",
+  bunBinDir: "/home/testuser/.bun/bin",
+};
+
+describe("generateBrokerUnit", () => {
+  it("uses Type=simple (regression guard against Type=notify restart-loop bug)", () => {
+    const unit = generateBrokerUnit(BASE_OPTS);
+    // Exact line check — comments in the unit body mention "Type=notify" in the
+    // rationale, so we match the whole directive line rather than a substring.
+    expect(unit).toMatch(/^Type=simple$/m);
+    expect(unit).not.toMatch(/^Type=notify$/m);
+  });
+
+  it("does not include LoadCredentialEncrypted= when autoUnlock is absent", () => {
+    const unit = generateBrokerUnit(BASE_OPTS);
+    expect(unit).not.toContain("LoadCredentialEncrypted=");
+  });
+
+  it("does not include LoadCredentialEncrypted= when autoUnlock is explicitly undefined", () => {
+    const unit = generateBrokerUnit({ ...BASE_OPTS, autoUnlock: undefined });
+    expect(unit).not.toContain("LoadCredentialEncrypted=");
+  });
+
+  it("includes LoadCredentialEncrypted= with correct path when autoUnlock is set", () => {
+    const credPath = "/home/testuser/.config/credstore.encrypted/vault-passphrase";
+    const unit = generateBrokerUnit({
+      ...BASE_OPTS,
+      autoUnlock: { credentialPath: credPath },
+    });
+    expect(unit).toContain(
+      `LoadCredentialEncrypted=vault-passphrase:${credPath}`
+    );
+  });
+
+  it("preserves Type=simple when autoUnlock is set", () => {
+    const unit = generateBrokerUnit({
+      ...BASE_OPTS,
+      autoUnlock: { credentialPath: "/some/path/vault-passphrase" },
+    });
+    expect(unit).toMatch(/^Type=simple$/m);
+    expect(unit).not.toMatch(/^Type=notify$/m);
+  });
+
+  it("includes ExecStart pointing to switchroom vault broker start --foreground", () => {
+    const unit = generateBrokerUnit(BASE_OPTS);
+    expect(unit).toContain("vault broker start --foreground");
+  });
+});

--- a/src/agents/systemd.ts
+++ b/src/agents/systemd.ts
@@ -596,6 +596,14 @@ WorkingDirectory=${agentDir}
 export interface BrokerUnitOpts {
   homeDir: string;
   bunBinDir: string;
+  /**
+   * When present, appends `LoadCredentialEncrypted=vault-passphrase:<path>`
+   * to the [Service] block so systemd decrypts the credential at start and
+   * injects it via $CREDENTIALS_DIRECTORY. The broker reads the file at
+   * `$CREDENTIALS_DIRECTORY/vault-passphrase` and calls unlockFromPassphrase()
+   * automatically.
+   */
+  autoUnlock?: { credentialPath: string };
 }
 
 /**
@@ -616,10 +624,14 @@ export interface BrokerUnitOpts {
  * to the unlock socket interactively after the daemon starts.
  */
 export function generateBrokerUnit(opts: BrokerUnitOpts): string {
-  const { homeDir, bunBinDir } = opts;
+  const { homeDir, bunBinDir, autoUnlock } = opts;
   const switchroomCli = resolve(bunBinDir, "switchroom");
   const nodeBinDir = dirname(process.execPath);
   const unitPath = `${bunBinDir}:${nodeBinDir}:/usr/local/bin:/usr/bin:/bin`;
+
+  const credentialLine = autoUnlock
+    ? `LoadCredentialEncrypted=vault-passphrase:${autoUnlock.credentialPath}\n`
+    : "";
 
   return `[Unit]
 Description=switchroom vault broker daemon
@@ -631,7 +643,7 @@ Type=simple
 ExecStart=${switchroomCli} vault broker start --foreground
 Restart=on-failure
 RestartSec=2
-# Type=simple — see generateBrokerUnit() for the sd_notify-stream-vs-datagram
+${credentialLine}# Type=simple — see generateBrokerUnit() for the sd_notify-stream-vs-datagram
 # rationale. The hand-rolled sd_notify in the broker is non-functional;
 # Type=notify caused a restart loop that destroyed unlock state.
 # No EnvironmentFile — the vault passphrase never touches disk.

--- a/src/agents/systemd.ts
+++ b/src/agents/systemd.ts
@@ -2,7 +2,7 @@ import { execFileSync, execSync } from "node:child_process";
 import { writeFileSync, mkdirSync, unlinkSync, existsSync, readdirSync } from "node:fs";
 import { resolve, join, dirname } from "node:path";
 import type { SwitchroomConfig, ScheduleEntry } from "../config/schema.js";
-import { resolveAgentsDir } from "../config/loader.js";
+import { resolveAgentsDir, resolvePath } from "../config/loader.js";
 import { usesSwitchroomTelegramPlugin, resolveAgentConfig } from "../config/merge.js";
 import { resolveTimezone } from "../config/timezone.js";
 import { COMMIT_SHA } from "../build-info.js";
@@ -358,7 +358,24 @@ export function installAllUnits(config: SwitchroomConfig): void {
   if (shouldInstallBrokerUnit(config)) {
     const homeDir = process.env.HOME ?? "/root";
     const bunBinDir = resolve(homeDir, ".bun", "bin");
-    const brokerContent = generateBrokerUnit({ homeDir, bunBinDir });
+    const brokerAutoUnlock = config.vault?.broker?.autoUnlock ?? false;
+    let autoUnlockOpt: { credentialPath: string } | undefined;
+    if (brokerAutoUnlock) {
+      const rawCredPath =
+        config.vault?.broker?.autoUnlockCredentialPath ??
+        "~/.config/credstore.encrypted/vault-passphrase";
+      const credPath = resolvePath(rawCredPath);
+      if (existsSync(credPath)) {
+        autoUnlockOpt = { credentialPath: credPath };
+      } else {
+        process.stderr.write(
+          `[switchroom] note: vault.broker.autoUnlock=true but credential file ` +
+          `is missing at ${credPath}; broker will start in interactive mode. ` +
+          `Run \`switchroom vault broker enable-auto-unlock\` to set up.\n`
+        );
+      }
+    }
+    const brokerContent = generateBrokerUnit({ homeDir, bunBinDir, autoUnlock: autoUnlockOpt });
     installUnit("vault-broker", brokerContent);
     // installedAgents holds the OS unit name (with the `switchroom-` prefix
     // that systemctl needs).

--- a/src/agents/systemd.ts
+++ b/src/agents/systemd.ts
@@ -601,9 +601,16 @@ export interface BrokerUnitOpts {
 /**
  * Generate the systemd user unit for the vault-broker daemon.
  *
- * Type=notify: the broker calls sd_notify("READY=1\n") via NOTIFY_SOCKET
- * once both sockets are listening, so systemd knows the unit is actually up
- * before starting dependents.
+ * Type=simple: the in-process sd_notify implementation in
+ * `src/vault/broker/server.ts` uses `net.createConnection` (a STREAM
+ * socket), but systemd's $NOTIFY_SOCKET is a datagram socket — so the
+ * READY=1 message never reaches systemd. Under Type=notify the unit
+ * times out and enters a restart loop, killing any held vault unlock
+ * state. Until sd_notify is rewritten to use UNIX datagrams, Type=simple
+ * is the working configuration: systemd considers the unit started as
+ * soon as the ExecStart process is alive. The broker binds both sockets
+ * synchronously early in start(), so dependents racing the daemon is a
+ * non-issue in practice.
  *
  * No EnvironmentFile: the vault passphrase never touches disk — it is pushed
  * to the unlock socket interactively after the daemon starts.
@@ -620,12 +627,13 @@ Documentation=https://github.com/switchroom/switchroom
 After=network-online.target
 
 [Service]
-Type=notify
+Type=simple
 ExecStart=${switchroomCli} vault broker start --foreground
 Restart=on-failure
 RestartSec=2
-# NOTIFY_SOCKET is set automatically by systemd for Type=notify.
-# The broker writes READY=1 after both sockets are listening.
+# Type=simple — see generateBrokerUnit() for the sd_notify-stream-vs-datagram
+# rationale. The hand-rolled sd_notify in the broker is non-functional;
+# Type=notify caused a restart loop that destroyed unlock state.
 # No EnvironmentFile — the vault passphrase never touches disk.
 # Push the passphrase via: switchroom vault broker unlock
 Environment=PATH=${unitPath}

--- a/src/build-info.ts
+++ b/src/build-info.ts
@@ -3,7 +3,7 @@
 // Values are refreshed every time `npm run build` runs.
 
 export const VERSION: string = "0.3.0";
-export const COMMIT_SHA: string | null = "13003da";
-export const COMMIT_DATE: string | null = "2026-04-26T13:06:51+10:00";
-export const LATEST_PR: number | null = null;
-export const COMMITS_AHEAD_OF_TAG: number | null = 20;
+export const COMMIT_SHA: string | null = "c0fb1c0";
+export const COMMIT_DATE: string | null = "2026-04-27T23:24:36+10:00";
+export const LATEST_PR: number | null = 147;
+export const COMMITS_AHEAD_OF_TAG: number | null = 50;

--- a/src/cli/vault-broker.ts
+++ b/src/cli/vault-broker.ts
@@ -15,10 +15,10 @@
  */
 
 import type { Command } from "commander";
-import { readFileSync, existsSync } from "node:fs";
-import { resolve } from "node:path";
+import { readFileSync, existsSync, mkdirSync, chmodSync, unlinkSync } from "node:fs";
+import { resolve, dirname } from "node:path";
 import { homedir } from "node:os";
-import { spawn } from "node:child_process";
+import { spawn, execFileSync } from "node:child_process";
 import { loadConfig } from "../config/loader.js";
 import { resolvePath } from "../config/loader.js";
 import {
@@ -28,6 +28,7 @@ import {
   resolveBrokerSocketPath,
 } from "../vault/broker/client.js";
 import { VaultBroker, registerShutdownHandlers } from "../vault/broker/server.js";
+import { openVault } from "../vault/vault.js";
 
 const DEFAULT_PID_FILE = "~/.switchroom/vault-broker.pid";
 const DEFAULT_SOCKET_PATH = "~/.switchroom/vault-broker.sock";
@@ -51,6 +52,16 @@ function getVaultPath(configPath?: string): string {
     return resolvePath(config.vault?.path ?? "~/.switchroom/vault.enc");
   } catch {
     return resolvePath("~/.switchroom/vault.enc");
+  }
+}
+
+function getAutoUnlockCredPath(configPath?: string): string {
+  const fallback = "~/.config/credstore.encrypted/vault-passphrase";
+  try {
+    const config = loadConfig(configPath);
+    return resolvePath(config.vault?.broker?.autoUnlockCredentialPath ?? fallback);
+  } catch {
+    return resolvePath(fallback);
   }
 }
 
@@ -239,6 +250,117 @@ export function registerVaultBrokerCommand(vaultCmd: Command, program: Command):
         console.log("locked");
       } else {
         console.error("lock failed — is the broker running?");
+        process.exit(1);
+      }
+    });
+
+  // ── enable-auto-unlock ───────────────────────────────────────────────────
+  // Encrypt the vault passphrase via systemd-creds and write it to the
+  // configured credential path. After this, the broker unit (re-rendered
+  // with vault.broker.autoUnlock=true) can declare LoadCredentialEncrypted=
+  // and systemd will inject the passphrase at start time without further
+  // user interaction. See issue #152 and README "Auto-unlock on boot".
+  broker
+    .command("enable-auto-unlock")
+    .description(
+      "Encrypt vault passphrase via systemd-creds and write to the credential path. " +
+      "After this, set vault.broker.autoUnlock=true and reconcile to take effect.",
+    )
+    .action(async () => {
+      const parentOpts = program.opts();
+
+      if (process.platform !== "linux") {
+        console.error("enable-auto-unlock requires Linux (systemd-creds is Linux-only).");
+        process.exit(1);
+      }
+
+      // Verify systemd-creds is on PATH.
+      try {
+        execFileSync("systemd-creds", ["--version"], { stdio: "ignore" });
+      } catch {
+        console.error(
+          "systemd-creds not found on PATH. Requires systemd >= 250. " +
+          "Try: sudo apt install systemd",
+        );
+        process.exit(1);
+      }
+
+      const credPath = getAutoUnlockCredPath(parentOpts.config);
+      const vaultPath = getVaultPath(parentOpts.config);
+
+      // Prompt + verify BEFORE writing anything. We must not encrypt a typo.
+      let passphrase: string;
+      try {
+        passphrase = await promptPassphrase();
+      } catch (err) {
+        console.error(err instanceof Error ? err.message : String(err));
+        process.exit(1);
+      }
+
+      try {
+        openVault(passphrase, vaultPath);
+      } catch (err) {
+        console.error(`Passphrase verification failed: ${err instanceof Error ? err.message : String(err)}`);
+        process.exit(1);
+      }
+
+      mkdirSync(dirname(credPath), { recursive: true, mode: 0o700 });
+
+      // systemd-creds encrypt --name=vault-passphrase --user --quiet - <credPath>
+      // Stdin: passphrase. Output: encrypted credential at credPath.
+      // The --name=vault-passphrase binding is required — systemd validates the
+      // embedded name matches the LoadCredentialEncrypted= id at decrypt time.
+      try {
+        execFileSync(
+          "systemd-creds",
+          ["encrypt", "--name=vault-passphrase", "--user", "--quiet", "-", credPath],
+          { input: passphrase, stdio: ["pipe", "inherit", "inherit"] },
+        );
+      } catch (err) {
+        console.error(`systemd-creds encrypt failed: ${err instanceof Error ? err.message : String(err)}`);
+        process.exit(1);
+      } finally {
+        passphrase = "";
+      }
+
+      try {
+        chmodSync(credPath, 0o600);
+      } catch {
+        /* non-fatal — systemd-creds already restricts mode */
+      }
+
+      console.log(`Auto-unlock credential written to ${credPath}`);
+      console.log("");
+      console.log("Next steps:");
+      console.log("  1. Set vault.broker.autoUnlock: true in switchroom.yaml");
+      console.log("  2. switchroom reconcile        # re-renders the broker unit");
+      console.log("  3. systemctl --user restart switchroom-vault-broker.service");
+      console.log("");
+      console.log("Verify with: switchroom vault broker status (after restart)");
+    });
+
+  // ── disable-auto-unlock ──────────────────────────────────────────────────
+  broker
+    .command("disable-auto-unlock")
+    .description("Remove the auto-unlock credential file. Reconcile + restart broker after.")
+    .action(() => {
+      const parentOpts = program.opts();
+      const credPath = getAutoUnlockCredPath(parentOpts.config);
+
+      if (!existsSync(credPath)) {
+        console.log(`No credential file at ${credPath} — nothing to do.`);
+        return;
+      }
+      try {
+        unlinkSync(credPath);
+        console.log(`Removed ${credPath}`);
+        console.log("");
+        console.log("Next steps:");
+        console.log("  1. Set vault.broker.autoUnlock: false in switchroom.yaml (or remove)");
+        console.log("  2. switchroom reconcile");
+        console.log("  3. systemctl --user restart switchroom-vault-broker.service");
+      } catch (err) {
+        console.error(`Failed to remove credential file: ${err instanceof Error ? err.message : String(err)}`);
         process.exit(1);
       }
     });

--- a/src/config/schema.test.ts
+++ b/src/config/schema.test.ts
@@ -82,6 +82,8 @@ describe("VaultConfigSchema.broker", () => {
     expect(result.broker).toEqual({
       socket: "~/.switchroom/vault-broker.sock",
       enabled: true,
+      autoUnlock: false,
+      autoUnlockCredentialPath: "~/.config/credstore.encrypted/vault-passphrase",
     });
   });
 
@@ -107,5 +109,27 @@ describe("VaultConfigSchema.broker", () => {
     });
     expect(result.path).toBe("/custom/vault.enc");
     expect(result.broker.enabled).toBe(true);
+  });
+
+  it("defaults autoUnlock to false", () => {
+    const result = VaultConfigSchema.parse({});
+    expect(result.broker.autoUnlock).toBe(false);
+  });
+
+  it("accepts autoUnlock: true", () => {
+    const result = VaultConfigSchema.parse({
+      broker: { autoUnlock: true },
+    });
+    expect(result.broker.autoUnlock).toBe(true);
+    expect(result.broker.enabled).toBe(true);
+  });
+
+  it("accepts a custom autoUnlockCredentialPath", () => {
+    const result = VaultConfigSchema.parse({
+      broker: { autoUnlockCredentialPath: "/etc/credstore.encrypted/vault-passphrase" },
+    });
+    expect(result.broker.autoUnlockCredentialPath).toBe(
+      "/etc/credstore.encrypted/vault-passphrase"
+    );
   });
 });

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -750,6 +750,17 @@ export const VaultConfigSchema = z.object({
         .boolean()
         .default(true)
         .describe("Whether to start the vault-broker daemon on agent launch"),
+      autoUnlock: z.boolean().default(false).describe(
+        "Auto-unlock the broker at start via systemd LoadCredentialEncrypted=. " +
+        "Off by default. When enabled, broker reads the passphrase from " +
+        "$CREDENTIALS_DIRECTORY/vault-passphrase. Run `switchroom vault " +
+        "broker enable-auto-unlock` once to set up the encrypted credential."
+      ),
+      autoUnlockCredentialPath: z.string().default("~/.config/credstore.encrypted/vault-passphrase").describe(
+        "Path to the systemd-creds-encrypted passphrase file. Default is " +
+        "the systemd-idiomatic user credential store. Tilde-expansion happens " +
+        "at install time."
+      ),
     })
     .default({})
     .describe(

--- a/src/vault/broker/server.ts
+++ b/src/vault/broker/server.ts
@@ -25,7 +25,7 @@
  */
 
 import * as net from "node:net";
-import { mkdirSync, chmodSync, existsSync, unlinkSync, writeFileSync } from "node:fs";
+import { mkdirSync, chmodSync, existsSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
 import { dirname, resolve, join } from "node:path";
 import type { SwitchroomConfig } from "../../config/schema.js";
 import { openVault, type VaultEntry } from "../vault.js";
@@ -186,6 +186,10 @@ export class VaultBroker {
 
     // Notify systemd if NOTIFY_SOCKET is set
     this._sdNotify("READY=1\n");
+
+    // Auto-unlock from $CREDENTIALS_DIRECTORY if the credential was injected
+    // by systemd LoadCredentialEncrypted= (opt-in via vault.broker.autoUnlock).
+    this._tryAutoUnlockFromCredentials();
 
     if (process.platform !== "linux") {
       // Reachable only when SWITCHROOM_BROKER_ALLOW_NON_LINUX=1 was set
@@ -535,6 +539,49 @@ export class VaultBroker {
       const pidPath = resolvePath(PID_FILE_DEFAULT);
       writeFileSync(pidPath, String(process.pid) + "\n", { mode: 0o600 });
     } catch { /* non-fatal */ }
+  }
+
+  /**
+   * Attempt to auto-unlock from $CREDENTIALS_DIRECTORY/vault-passphrase.
+   * Called once at startup after sd_notify READY=1. Any failure is non-fatal —
+   * the broker stays alive and interactive unlock via the unlock socket remains
+   * available as a fallback.
+   */
+  private _tryAutoUnlockFromCredentials(): void {
+    const dir = process.env.CREDENTIALS_DIRECTORY;
+    if (!dir) return;
+    const credPath = `${dir}/vault-passphrase`;
+    let passphrase: string;
+    try {
+      passphrase = readFileSync(credPath, "utf8").replace(/\n+$/, "");
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code === "ENOENT") {
+        process.stderr.write(
+          `[vault-broker] note: CREDENTIALS_DIRECTORY set but vault-passphrase ` +
+          `not present; staying locked\n`
+        );
+        return;
+      }
+      process.stderr.write(
+        `[vault-broker] auto-unlock read failed: ${(err as Error).message}; ` +
+        `falling back to interactive\n`
+      );
+      return;
+    }
+    try {
+      this.unlockFromPassphrase(passphrase);
+      process.stderr.write(
+        `[vault-broker] auto-unlocked from $CREDENTIALS_DIRECTORY/vault-passphrase\n`
+      );
+    } catch (err) {
+      process.stderr.write(
+        `[vault-broker] auto-unlock failed: ${(err as Error).message}; ` +
+        `falling back to interactive\n`
+      );
+    }
+    // Drop the local reference. (Cannot guarantee GC, but no other ref retained.)
+    passphrase = "";
   }
 
   private _sdNotify(message: string): void {


### PR DESCRIPTION
Closes #152.

## Summary

Vault broker holds unlocked secrets in-memory only — every process death wipes the unlock state. This PR adds an opt-in auto-unlock path via systemd `LoadCredentialEncrypted=`, so hosts that opt in survive reboots/restarts/reconciles without manual intervention.

Also bundles the broker `Type=notify` → `Type=simple` fix from earlier tonight (the in-process `sd_notify` uses a stream socket; systemd needs datagram, so READY=1 never reached systemd and the unit restart-looped). Without that fix, this PR can't be tested live.

## Commits

1. `fix(systemd): broker Type=simple — sd_notify uses stream socket` — pre-existing bug
2. `feat(config): vault.broker.autoUnlock + autoUnlockCredentialPath schema`
3. `feat(systemd): broker LoadCredentialEncrypted= when autoUnlock enabled`
4. `feat(install): wire vault.broker.autoUnlock into broker unit generation`
5. `feat(vault-broker): auto-unlock from $CREDENTIALS_DIRECTORY at start`
6. `feat(cli): switchroom vault broker enable/disable-auto-unlock`
7. `docs(readme): vault.broker.autoUnlock setup + security tradeoffs`

## Setup flow

```bash
switchroom vault broker enable-auto-unlock   # one-time, prompts for passphrase
# Edit switchroom.yaml: vault.broker.autoUnlock: true
switchroom reconcile
systemctl --user restart switchroom-vault-broker.service
```

After this the broker auto-unlocks on every start. Disable with `disable-auto-unlock`.

## Security tradeoff (loud)

Passphrase is encrypted with a per-user key derived by `systemd-creds --user`. Anyone with code execution as the user — or root — can call `systemd-creds decrypt` and recover it. Same blast radius as today's TTY unlock (a process running as the user can attach to the broker), but a lost laptop = lost vault. Default OFF for that reason. README documents this loudly.

## Test plan

- [x] `bun run lint` clean
- [x] `bunx vitest run src/cli/ src/vault/broker/ src/agents/systemd*` — 98 pass / 1 skipped
- [x] systemd-broker-unit tests cover: LoadCredentialEncrypted absent when no autoUnlock, present with correct path when autoUnlock set, Type=simple preserved
- [ ] CI green
- [ ] Manual: enable + reboot + verify auto-unlock fires; corrupt credential file → broker stays alive + locked + interactive still works

## Out of scope

- Proper sd_notify datagram fix (separate issue) — Type=simple is the workaround
- TPM-sealed unsealing (separate, larger lift)
- System-wide credentials (`/etc/credstore.encrypted/`) — switchroom is user-mode only