### PR TITLE
feat(config): allow namespaced vault key names in cron secrets[]

### DIFF
--- a/src/config/schema.test.ts
+++ b/src/config/schema.test.ts
@@ -56,7 +56,7 @@ describe("ScheduleEntrySchema.secrets", () => {
   });
 
   it("rejects key names containing shell-special characters", () => {
-    const badNames = ["foo$bar", "foo;bar", "foo/bar", "foo.bar", "foo@bar"];
+    const badNames = ["foo$bar", "foo;bar", "foo.bar", "foo@bar"];
     for (const name of badNames) {
       expect(() =>
         ScheduleEntrySchema.parse({
@@ -67,6 +67,15 @@ describe("ScheduleEntrySchema.secrets", () => {
         `expected "${name}" to be rejected`,
       ).toThrow();
     }
+  });
+
+  it("accepts namespaced key names with forward slashes", () => {
+    const result = ScheduleEntrySchema.parse({
+      cron: "0 8 * * *",
+      prompt: "Send a brief.",
+      secrets: ["microsoft/ken-tokens", "openai/api-key"],
+    });
+    expect(result.secrets).toEqual(["microsoft/ken-tokens", "openai/api-key"]);
   });
 });
 

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -29,7 +29,7 @@ export const ScheduleEntrySchema = z.object({
       "Use claude-opus-4-6 for tasks needing complex reasoning.",
     ),
   secrets: z
-    .array(z.string().regex(/^[a-zA-Z0-9_-]+$/, "Secret key names must contain only alphanumeric characters, underscores, and hyphens"))
+    .array(z.string().regex(/^[a-zA-Z0-9_\-/]+$/, "Secret key names must contain only alphanumeric characters, underscores, hyphens, and forward slashes"))
     .default([])
     .describe(
       "Vault key names this cron task may read via the vault-broker daemon. " +


### PR DESCRIPTION
## Summary

Extend the `ScheduleEntrySchema.secrets` regex to accept forward slashes, matching the namespaced naming convention already in production use.

The vault holds keys like \`anthropic/claude-code-token\`, \`google/buildkite-tokens\`, \`microsoft/ken-tokens\`, \`compass/credentials\`, \`discord/pairing\`, etc. Storage and broker fetch already accept these names — only the cron config schema's `secrets[]` validation regex was rejecting them. Effect: declaring any of those keys in a cron's \`secrets: [...]\` would fail Zod validation.

This was found as an in-flight uncommitted diff in Ken's working tree. Verified additive (no functionality removed), not duplicated by any other PR or branch on canonical, and the upstream/main schema still has the old regex.

## Change

- \`src/config/schema.ts\`: regex \`[a-zA-Z0-9_-]\` → \`[a-zA-Z0-9_\\-/]\` and updated the error message.
- \`src/config/schema.test.ts\`: removed \`foo/bar\` from "rejects shell-special chars" (it's no longer rejected) and added a positive test that namespaced keys parse.

## Test plan

- [x] \`bun run lint\` clean
- [x] \`bunx vitest run src/config/schema.test.ts\` — 12/12 pass

## Out of scope

- Path-traversal validation (e.g. rejecting \`foo/../bar\`) — vault key resolution doesn't traverse a filesystem, the slash is a flat namespace separator. Adding a stricter regex like \`[a-zA-Z0-9_\\-]+(/[a-zA-Z0-9_\\-]+)*\` would be defense-in-depth, but unnecessary given the broker's lookup model.