### PR TITLE
fix(progress-card): use reply_parameters for tap-to-jump quote (#156)

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -2835,6 +2835,7 @@ async function handleInbound(
         chatId: chat_id,
         threadId: messageThreadId != null ? String(messageThreadId) : undefined,
         userText: effectiveText,
+        replyToMessageId: msgId != null ? msgId : undefined,
       })
     } catch (err) {
       process.stderr.write(`telegram gateway: progress-card startTurn failed: ${(err as Error).message}\n`)
@@ -5407,10 +5408,23 @@ if (streamMode === 'checklist') {
   }
 
   progressDriver = createProgressDriver({
-    emit: ({ chatId, threadId, turnKey, html, done, isFirstEmit }) => {
+    emit: ({ chatId, threadId, turnKey, html, done, isFirstEmit, replyToMessageId }) => {
       const args = {
         chat_id: chatId, text: html, done, message_thread_id: threadId,
         lane: 'progress', format: 'html', turnKey,
+        // Pass the source message_id as reply_to on the initial send only
+        // (isFirstEmit=true). handleStreamReply only applies reply_to on
+        // stream creation (first call for a given sKey), so subsequent
+        // edits — which reuse the existing DraftStream — naturally ignore
+        // this. Passing it unconditionally would be harmless, but being
+        // explicit here documents the "first send only" contract.
+        // We also opt out of auto-quote (quote:false) so that if
+        // replyToMessageId is absent the progress card sends bare — it
+        // doesn't want a random "latest inbound" quote attached.
+        quote: false as const,
+        ...(isFirstEmit && replyToMessageId != null
+          ? { reply_to: String(replyToMessageId) }
+          : {}),
       }
       handleStreamReply(args, { activeDraftStreams, activeDraftParseModes, suppressPtyPreview }, {
         bot: lockedBot, retry: robustApiCall, markdownToHtml, escapeMarkdownV2, repairEscapedWhitespace,

--- a/telegram-plugin/progress-card-driver.ts
+++ b/telegram-plugin/progress-card-driver.ts
@@ -60,6 +60,14 @@ export interface ProgressDriverConfig {
    * that creates the Telegram message. The caller can use this signal to
    * pin the new message: after this call resolves, the message_id will be
    * available in the caller's draft-stream handle.
+   *
+   * `replyToMessageId` is set only on the first emit (when `isFirstEmit`
+   * is true) and only when the turn was started with a source message_id
+   * (via `startTurn({ replyToMessageId })`). The caller should pass this
+   * as `reply_parameters` on the initial `sendMessage` so the progress
+   * card is a tappable reply to the user's original message. Edits
+   * (subsequent emits) must NOT carry reply_parameters — Telegram rejects
+   * it on editMessageText.
    */
   emit: (args: {
     chatId: string
@@ -70,6 +78,12 @@ export interface ProgressDriverConfig {
     done: boolean
     /** True only on the first flush for this turn (message creation). */
     isFirstEmit: boolean
+    /**
+     * Set on the first emit only (isFirstEmit=true) when the turn was
+     * started via startTurn({ replyToMessageId }). Pass as
+     * reply_parameters.message_id on the initial sendMessage.
+     */
+    replyToMessageId?: number
   }) => void
   /**
    * Optional callback fired once per turn immediately after the final
@@ -200,6 +214,13 @@ interface PerChatState {
   /** Timer for the deferred first emit (initial-delay suppression). */
   deferredFirstEmitTimer: unknown
   /**
+   * The Telegram message_id of the user's original inbound message that
+   * triggered this turn. Set via startTurn({ replyToMessageId }). Passed
+   * as reply_parameters on the FIRST sendMessage only — edits must not
+   * carry it (Telegram rejects reply_parameters on editMessageText).
+   */
+  replyToMessageId?: number
+  /**
    * Wall-clock ms of the last real session event routed to this card.
    * Distinct from `lastEmittedAt`: the heartbeat ticks `lastEmittedAt`
    * every cycle, but `lastEventAt` only advances when an actual event
@@ -286,7 +307,7 @@ export interface ProgressDriver {
    * onTurnComplete fired) before the new card is created. Each call always
    * produces an independent card with its own pin lifecycle.
    */
-  startTurn(args: { chatId: string; threadId?: string; userText: string }): void
+  startTurn(args: { chatId: string; threadId?: string; userText: string; replyToMessageId?: number }): void
   /**
    * External completion hook — authoritative turn-finished signal from
    * outside the session-tail path. Intended for `stream_reply(done=true)`
@@ -779,6 +800,12 @@ export function createProgressDriver(config: ProgressDriverConfig): ProgressDriv
       html,
       done: terminal,
       isFirstEmit: isFirst,
+      // Thread the source message_id through on the first emit only so
+      // the caller can pass it as reply_parameters on the initial
+      // sendMessage. Edits (isFirstEmit=false) must NOT carry it.
+      ...(isFirst && chatState.replyToMessageId != null
+        ? { replyToMessageId: chatState.replyToMessageId }
+        : {}),
     })
   }
 
@@ -1080,7 +1107,7 @@ export function createProgressDriver(config: ProgressDriverConfig): ProgressDriv
       }, delay)
     },
 
-    startTurn({ chatId, threadId, userText }) {
+    startTurn({ chatId, threadId, userText, replyToMessageId }) {
       // Synthesize an enqueue event and run it through the normal ingest
       // path. This guarantees we share all the flush/cadence/teardown
       // semantics with session-tail-driven enqueues.
@@ -1100,6 +1127,15 @@ export function createProgressDriver(config: ProgressDriverConfig): ProgressDriv
         chatId,
         threadId,
       )
+      // Stash the source message_id on the newly-created PerChatState so
+      // flush() can pass it to the emit callback on the first send only.
+      // Do this AFTER ingest() so the new PerChatState entry is in chats.
+      if (replyToMessageId != null && currentTurnKey != null) {
+        const cs = chats.get(currentTurnKey)
+        if (cs != null && cs.chatId === chatId) {
+          cs.replyToMessageId = replyToMessageId
+        }
+      }
     },
 
     forceCompleteTurn({ chatId, threadId }) {

--- a/telegram-plugin/progress-card.ts
+++ b/telegram-plugin/progress-card.ts
@@ -880,9 +880,11 @@ export function render(state: ProgressCardState, now: number, taskNum?: TaskNum,
   const taskSuffix = taskNum && taskNum.total > 1 ? ` (${taskNum.index}/${taskNum.total})` : ''
   lines.push(`${headerIcon} <b>${headerLabel}${taskSuffix}</b> · ⏱ ${elapsed}`)
 
-  if (state.userRequest) {
-    lines.push(`<blockquote>${escapeHtml(truncate(state.userRequest, 120))}</blockquote>`)
-  }
+  // (#156) The user's request used to render here as an inline
+  // <blockquote>. That was a styled element only — Telegram clients
+  // don't deep-link inline HTML quotes. The progress card now sets
+  // reply_parameters.message_id on the initial sendMessage so Telegram
+  // shows its native, tappable reply banner above the card instead.
 
   if (silentEnd) {
     // Diagnostic hint shown only on silent-end turns. Distinct from the

--- a/telegram-plugin/server.ts
+++ b/telegram-plugin/server.ts
@@ -5383,6 +5383,7 @@ async function handleInbound(
         chatId: chat_id,
         threadId: messageThreadId != null ? String(messageThreadId) : undefined,
         userText: effectiveText,
+        replyToMessageId: msgId != null ? msgId : undefined,
       })
     } catch (err) {
       process.stderr.write(

--- a/telegram-plugin/tests/progress-card-driver.test.ts
+++ b/telegram-plugin/tests/progress-card-driver.test.ts
@@ -95,7 +95,8 @@ describe('progress-card driver', () => {
     expect(emits).toHaveLength(1)
     expect(emits[0].chatId).toBe('c1')
     expect(emits[0].done).toBe(false)
-    expect(emits[0].html).toContain('<blockquote>hi</blockquote>')
+    // User request is no longer in the HTML — shown via Telegram reply banner.
+    expect(emits[0].html).not.toContain('<blockquote>')
   })
 
   it('startTurn fires an initial "Working…" render BEFORE any tool_use event', () => {
@@ -112,9 +113,9 @@ describe('progress-card driver', () => {
     expect(emits[0].html).toContain('⚙️ <b>Working…</b>')
     // No tool_use has been fed in yet — there must be no checklist items.
     expect(emits[0].html).not.toContain('◉ <b>')
-    // And the echoed user request shows up so the card ties back to the
-    // user's message.
-    expect(emits[0].html).toContain('please investigate')
+    // The user request is no longer in the HTML — it is shown via Telegram's
+    // native reply banner (reply_parameters on the initial sendMessage).
+    expect(emits[0].html).not.toContain('<blockquote>')
   })
 
   it('startTurn passes threadId through for forum-topic chats', () => {
@@ -280,9 +281,11 @@ describe('progress-card driver', () => {
     const { driver, emits } = harness()
     driver.ingest(enqueue('c1', 'request-one'), null)
     driver.ingest(enqueue('c2', 'request-two'), null)
+    // Each chat produces its own emit; user request text is no longer
+    // rendered in the card body (#156 — shown via Telegram reply banner).
     expect(emits.map((e) => e.chatId)).toEqual(['c1', 'c2'])
-    expect(emits[0].html).toContain('request-one')
-    expect(emits[1].html).toContain('request-two')
+    expect(emits[0].html).not.toContain('<blockquote>')
+    expect(emits[1].html).not.toContain('<blockquote>')
   })
 
   it('turn_end drops state so next turn starts fresh', () => {
@@ -296,7 +299,8 @@ describe('progress-card driver', () => {
     // New turn
     driver.ingest(enqueue('c1', 'second'), null)
     expect(emits).toHaveLength(1)
-    expect(emits[0].html).toContain('<blockquote>second</blockquote>')
+    // User request is no longer in the HTML — shown via Telegram reply banner.
+    expect(emits[0].html).not.toContain('<blockquote>')
     // No leaked items from the prior turn
     expect(emits[0].html).not.toContain('Read')
   })

--- a/telegram-plugin/tests/progress-card-golden.test.ts
+++ b/telegram-plugin/tests/progress-card-golden.test.ts
@@ -103,7 +103,9 @@ describe('progress-card golden turn', () => {
 
     // Structural assertions — don't brittle-pin the whole string, but
     // lock in the key visual elements and their ordering.
-    expect(html).toContain('<blockquote>fix the failing tests and push</blockquote>')
+    // User request is no longer rendered as a blockquote — it is shown via
+    // Telegram's native reply banner (reply_parameters on sendMessage).
+    expect(html).not.toContain('<blockquote>')
     expect(html).toContain('✅ <b>Done</b>')
 
     // Text events create narrative steps; the final text block becomes a narrative

--- a/telegram-plugin/tests/progress-card.test.ts
+++ b/telegram-plugin/tests/progress-card.test.ts
@@ -266,7 +266,9 @@ describe('progress-card render', () => {
   it('renders plan stage with no items', () => {
     const s = fold([enqueue('fix tests')])
     const out = render(s, 5000)
-    expect(out).toContain('<blockquote>fix tests</blockquote>')
+    // User request is no longer rendered as a blockquote — it is shown via
+    // Telegram's native reply banner (reply_parameters on sendMessage).
+    expect(out).not.toContain('<blockquote>')
     expect(out).not.toContain('🤔 Plan')
   })
 
@@ -274,14 +276,10 @@ describe('progress-card render', () => {
     const s = fold([enqueue('fix tests')])
     const out = render(s, 5000)
     const lines = out.split('\n')
-    // Header should be FIRST, blockquote SECOND
     const headerLine = lines.find(l => l.includes('⚙️ <b>Working…</b>'))
-    const quoteLine = lines.find(l => l.includes('<blockquote>'))
     expect(headerLine).toBeDefined()
-    expect(quoteLine).toBeDefined()
-    const headerIdx = lines.indexOf(headerLine!)
-    const quoteIdx = lines.indexOf(quoteLine!)
-    expect(headerIdx).toBeLessThan(quoteIdx)
+    // No blockquote — user request shown via Telegram native reply banner.
+    expect(out).not.toContain('<blockquote>')
     expect(out).not.toContain('─ ─ ─')
     expect(out).not.toContain('✅ <b>Done</b> ·')
   })
@@ -444,24 +442,28 @@ describe('progress-card render', () => {
     expect(out).not.toContain('b.ts')
   })
 
-  it('truncates long user requests', () => {
+  it('does not render the user request as a blockquote (shown via Telegram reply banner)', () => {
     const long = 'a'.repeat(300)
     const s = fold([enqueue(long)])
     const out = render(s, 2000)
-    expect(out).toContain('aaa…')
-    const bqLine = out.split('\n').find(l => l.includes('<blockquote>'))!
-    expect(bqLine.length).toBeLessThan(160)
+    // The user request is no longer in the HTML — it appears as a Telegram
+    // native reply banner (reply_parameters) which is outside the HTML body.
+    expect(out).not.toContain('<blockquote>')
+    expect(out).not.toContain('aaa')
   })
 
-  it('escapes HTML in user text and latestText', () => {
+  it('escapes HTML in latestText', () => {
     const s = fold([
       enqueue('fix <script>alert(1)</script>'),
       { kind: 'text', text: 'my plan: <img>' },
     ])
     const out = render(s, 2000)
-    expect(out).toContain('&lt;script&gt;')
+    // User request is no longer in the HTML (shown via Telegram reply banner),
+    // so the script tag does not appear in the rendered card HTML at all.
+    expect(out).not.toContain('script')
+    // latestText IS still rendered, and its HTML must be escaped.
     expect(out).toContain('&lt;img&gt;')
-    expect(out).not.toContain('<script>')
+    expect(out).not.toContain('<img>')
   })
 
   it('header banner reflects the active stage', () => {


### PR DESCRIPTION
## Summary

- Closes #156
- Progress card's inline `<blockquote>` was pure HTML — tappable-looking, not actually tappable. Replaced with Telegram's native `reply_parameters` mechanism so the quote banner above the card is a real reply that jumps to the user's original message on tap.
- Threads `replyToMessageId` through `startTurn` → `PerChatState` → emit callback → gateway/server send; only attached on the first send (Telegram rejects `reply_parameters` on `editMessageText`).
- Removed the inline `<blockquote>` — user request now visible via Telegram's reply banner only.

## Files

- `telegram-plugin/progress-card.ts` — drop inline `<blockquote>`
- `telegram-plugin/progress-card-driver.ts` — `replyToMessageId` plumbed through `startTurn`, `PerChatState`, and emit
- `telegram-plugin/gateway/gateway.ts` — `handleInbound` passes `msgId`; emit handler sets `reply_to` on first send + `quote: false` to opt out of auto-quote
- `telegram-plugin/server.ts` — same pattern as gateway
- Test updates in 3 progress-card test files

## Test plan

- [x] `bun test telegram-plugin/tests/progress-card*` — 259/259 pass
- [x] Typecheck clean
- [ ] **Manual sanity check needed**: send a message in a real Telegram DM, watch the progress card render, tap the reply banner, confirm it scrolls back to your original message. The synthetic tests verify the wiring; real-world client behavior is the actual contract.
- [ ] Spot-check that subsequent edits to the SAME card don't error — Telegram rejects `reply_parameters` on edits and we explicitly only set it on `isFirstEmit=true`, but verify in production once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)