### PR TITLE
fix(boot-card): remove session-start pin/unpin of boot card

### DIFF
--- a/telegram-plugin/gateway/boot-card.ts
+++ b/telegram-plugin/gateway/boot-card.ts
@@ -29,8 +29,7 @@
  *   - `BotApiForBootCard` / `BootCardHandle` / dedupe gate
  *     (`shouldSkipDuplicateBootCard`) — public API stable for the
  *     gateway's two call sites (boot path + bridge-reconnect).
- *   - The pin lifecycle: card gets pinned at post and unpinned by
- *     `complete()` (called from the first user-turn handler).
+ *   - `BootCardHandle` / `complete()` (called from the first user-turn handler).
  */
 
 import type { ProbeResult, GatewayRuntimeInfo } from './boot-probes.js'
@@ -65,17 +64,11 @@ export interface BotApiForBootCard {
     text: string,
     opts?: Record<string, unknown>,
   ): Promise<unknown>
-  pinChatMessage(
-    chatId: string,
-    messageId: number,
-    opts?: Record<string, unknown>,
-  ): Promise<unknown>
-  unpinChatMessage(chatId: string, messageId: number): Promise<unknown>
 }
 
 export interface BootCardHandle {
   messageId: number
-  /** Call when the first user turn starts — unpins the card. */
+  /** Call when the first user turn starts. */
   complete(): void
 }
 
@@ -269,7 +262,7 @@ export async function runAllProbes(opts: RunProbesOpts): Promise<ProbeMap> {
  *  the card in-place if any probe came back degraded/failed. Healthy
  *  boots stay as the bare ack line forever.
  *
- *  Returns a handle whose `complete()` unpins the card. The probe edit
+ *  Returns a handle. The probe edit
  *  is fire-and-forget — failures are swallowed so the ack line is never
  *  rolled back to a worse state. */
 export async function startBootCard(
@@ -307,10 +300,6 @@ export async function startBootCard(
     logger(`telegram gateway: boot-card: failed to post ack: ${(err as Error)?.message ?? String(err)}\n`)
     return { messageId: -1, complete: () => {} }
   }
-
-  // Pin the ack — fire-and-forget; pin failures aren't worth rolling
-  // back the post for.
-  bot.pinChatMessage(chatId, messageId, { disable_notification: true }).catch(() => {})
 
   // Schedule the post-settle probe run + edit. Wrapped in setTimeout so
   // the boot path returns the handle immediately — the gateway can
@@ -350,8 +339,7 @@ export async function startBootCard(
     complete() {
       if (completed) return
       completed = true
-      bot.unpinChatMessage(chatId, messageId).catch(() => {})
-      logger(`telegram gateway: boot-card: completed (unpinned) msgId=${messageId}\n`)
+      logger(`telegram gateway: boot-card: completed msgId=${messageId}\n`)
     },
   }
 }

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -1073,8 +1073,6 @@ const ipcServer: IpcServer = createIpcServer({
           const botApiForCard: import('./boot-card.js').BotApiForBootCard = {
             sendMessage: (cid, text, opts) => lockedBot.api.sendMessage(cid, text, opts as Parameters<typeof lockedBot.api.sendMessage>[2]) as Promise<{ message_id: number }>,
             editMessageText: (cid, mid, text, opts) => lockedBot.api.editMessageText(cid, mid, text, opts as Parameters<typeof lockedBot.api.editMessageText>[3]),
-            pinChatMessage: (cid, mid, opts) => lockedBot.api.pinChatMessage(cid, mid, opts as Parameters<typeof lockedBot.api.pinChatMessage>[2]),
-            unpinChatMessage: (cid, mid) => lockedBot.api.unpinChatMessage(cid, mid),
           }
           startBootCard(chatId, threadId, botApiForCard, {
             agentName,
@@ -5713,8 +5711,6 @@ void (async () => {
                 const botApiForCard: import('./boot-card.js').BotApiForBootCard = {
                   sendMessage: (cid, text, opts) => lockedBot.api.sendMessage(cid, text, opts as Parameters<typeof lockedBot.api.sendMessage>[2]) as Promise<{ message_id: number }>,
                   editMessageText: (cid, mid, text, opts) => lockedBot.api.editMessageText(cid, mid, text, opts as Parameters<typeof lockedBot.api.editMessageText>[3]),
-                  pinChatMessage: (cid, mid, opts) => lockedBot.api.pinChatMessage(cid, mid, opts as Parameters<typeof lockedBot.api.pinChatMessage>[2]),
-                  unpinChatMessage: (cid, mid) => lockedBot.api.unpinChatMessage(cid, mid),
                 }
                 try {
                   const handle = await startBootCard(chatId, threadId, botApiForCard, {


### PR DESCRIPTION
Boot cards were pinned immediately after the ack post and unpinned on the first user turn. This caused an unwanted pin notification followed by a quick silent unpin — noisy with no UX benefit.

- Drops `pinChatMessage` / `unpinChatMessage` from `BotApiForBootCard` interface
- Removes the post-ack `pinChatMessage` call in `startBootCard`
- Simplifies `complete()` to just log — handle and call sites unchanged
- Two gateway adapter lines removed from bridge-reconnect and boot paths

Tests pass (exit 0).