### PR TITLE
security(tests): assemble token-shaped fixtures at runtime per CLAUDE.md

### DIFF
--- a/telegram-plugin/tests/secret-detect-secretlint.test.ts
+++ b/telegram-plugin/tests/secret-detect-secretlint.test.ts
@@ -4,10 +4,13 @@ import {
   detectSecretsAsync,
 } from '../secret-detect/index.js'
 
-// Assembled at runtime so the source file never contains a contiguous
-// xoxb- pattern. Matches secretlint's Slack regex when evaluated; evades
-// GitHub Push Protection's static-text scan.
+// All three fixtures are assembled at runtime so the source file never
+// contains a contiguous token pattern. Matches the corresponding
+// secretlint regex when evaluated; evades GitHub Push Protection's
+// static-text scan. See CLAUDE.md "Secrets in tests".
 const SLACK_FIXTURE = ['xoxb', '0000000000', '0000000000000', 'FIXTURE0NOTAREALTOKEN000'].join('-')
+const GITHUB_FIXTURE = 'ghp' + '_' + '16C7e42F292c6912E7710c838347Ae178B4a'
+const NPM_FIXTURE = 'npm' + '_' + 'AbCdEfGhIjKlMnOpQrStUvWxYz0123456789'
 
 describe('secretlint-source.detectViaSecretlint', () => {
   it('catches a realistic-looking Slack bot token', async () => {
@@ -28,7 +31,7 @@ describe('secretlint-source.detectViaSecretlint', () => {
   })
 
   it('catches a GitHub personal access token', async () => {
-    const text = 'token=ghp_16C7e42F292c6912E7710c838347Ae178B4a rest of message'
+    const text = 'token=' + GITHUB_FIXTURE + ' rest of message'
     const hits = await detectViaSecretlint(text)
     const gh = hits.find((h) => h.rule_id.includes('github'))
     expect(gh).toBeDefined()
@@ -38,7 +41,7 @@ describe('secretlint-source.detectViaSecretlint', () => {
   })
 
   it('catches an NPM access token', async () => {
-    const text = 'NPM_TOKEN=npm_AbCdEfGhIjKlMnOpQrStUvWxYz0123456789'
+    const text = 'NPM_TOKEN=' + NPM_FIXTURE
     const hits = await detectViaSecretlint(text)
     const npm = hits.find((h) => h.rule_id.includes('npm'))
     expect(npm).toBeDefined()
@@ -89,7 +92,7 @@ describe('detectSecretsAsync merge', () => {
 
   it('produces unique slugs across the merged detection list', async () => {
     const text =
-      'tok1=ghp_16C7e42F292c6912E7710c838347Ae178B4a' +
+      'tok1=' + GITHUB_FIXTURE +
       ' and tok2=' + SLACK_FIXTURE
     const hits = await detectSecretsAsync(text)
     const slugs = hits.map((h) => h.suggested_slug)

--- a/telegram-plugin/tests/secret-detect.test.ts
+++ b/telegram-plugin/tests/secret-detect.test.ts
@@ -169,7 +169,8 @@ describe('detectSecrets — end-to-end', () => {
     expect(d[0]!.suppressed).toBe(false)
   })
   it('finds a GitHub PAT', () => {
-    const text = 'token: ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789 expires tomorrow'
+    // Token assembled at runtime — see CLAUDE.md "Secrets in tests".
+    const text = 'token: ghp' + '_' + 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789 expires tomorrow'
     const d = detectSecrets(text)
     expect(d.some((h) => h.rule_id === 'github_pat_classic')).toBe(true)
   })

--- a/tests/auth.credentials-file-success.test.ts
+++ b/tests/auth.credentials-file-success.test.ts
@@ -32,8 +32,18 @@ import {
  *     recognises (no drift between the two channels)
  */
 
-const VALID_TOKEN =
-  "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";
+// Assembled at runtime so the source file never contains a contiguous
+// `sk-ant-oat\d+-...` pattern that GitHub Push Protection (or Anthropic's
+// secret-scanning peers) would treat as a leaked OAuth token. The shape
+// still passes the regex `parseSetupTokenValue` and `readTokenFromCreden-
+// tialsFile` use, so the test exercises the real success contract.
+// See CLAUDE.md "Secrets in tests" + telegram-plugin/tests/secret-detect-
+// secretlint.test.ts for the established pattern.
+const VALID_TOKEN = [
+  "sk-ant-oat01-",
+  "FIXTURE0NOTAREALTOKEN",
+  "_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+].join("");
 
 describe("readTokenFromCredentialsFile", () => {
   let tempDir: string;

--- a/tests/vault-sweep.hindsight.test.ts
+++ b/tests/vault-sweep.hindsight.test.ts
@@ -50,15 +50,17 @@ describe('sweepHindsightBank', () => {
   })
 
   it('matches on the context field as well as text', async () => {
+    // Token assembled at runtime — see CLAUDE.md "Secrets in tests".
+    const GH_FIXTURE = 'ghp' + '_' + '16C7e42F292c6912E7710c838347Ae178B4a'
     const memories: HindsightMemory[] = [
       {
         id: 'm1',
         text: 'fine',
-        context: 'ran with ghp_16C7e42F292c6912E7710c838347Ae178B4a',
+        context: 'ran with ' + GH_FIXTURE,
       },
     ]
     const vaultValues = [
-      { key: 'GH_TOKEN', value: 'ghp_16C7e42F292c6912E7710c838347Ae178B4a' },
+      { key: 'GH_TOKEN', value: GH_FIXTURE },
     ]
     const { client, deleted } = makeFakeClient(memories)
     const report = await sweepHindsightBank(client, 'bank-a', vaultValues, {


### PR DESCRIPTION
## Summary

Audit of the repo for PII / leaked secrets surfaced four test files with **contiguous token literals** in source. The repo has GitHub Push Protection enabled and a documented "Secrets in tests" convention (see CLAUDE.md) that says token-shaped fixtures must be assembled at runtime via string concatenation so the source file never contains a contiguous token pattern. The existing pattern is in [\`telegram-plugin/tests/secret-detect-secretlint.test.ts\`](telegram-plugin/tests/secret-detect-secretlint.test.ts) (\`SLACK_FIXTURE\`).

These four files didn't follow the convention — they contained literal token strings.

## 🔴 Highest-risk finding

[\`tests/auth.credentials-file-success.test.ts:36\`](tests/auth.credentials-file-success.test.ts#L36) had a 91-character \`sk-ant-oat01-...\` value that passes the real-token regex used by \`parseSetupTokenValue\` and \`readTokenFromCredentialsFile\`:

\`\`\`
"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"
\`\`\`

Whether the value is a real expired/scrubbed token, random characters that happen to look real, or output from a fixed-seed RNG, the contiguous shape risked being indexed by GitHub's secret-scanning, Anthropic's peers, or surfaced via a careless \`git grep\`. Replaced with a runtime-assembled fixture that produces the same regex match.

## Files changed

| File | Change |
|---|---|
| [\`tests/auth.credentials-file-success.test.ts\`](tests/auth.credentials-file-success.test.ts) | \`VALID_TOKEN\` → runtime-assembled \`sk-ant-oat01-\` + \`FIXTURE0NOTAREALTOKEN\` + padding |
| [\`telegram-plugin/tests/secret-detect-secretlint.test.ts\`](telegram-plugin/tests/secret-detect-secretlint.test.ts) | New module-level \`GITHUB_FIXTURE\` and \`NPM_FIXTURE\` constants assembled at runtime; replaces three inline literals |
| [\`telegram-plugin/tests/secret-detect.test.ts\`](telegram-plugin/tests/secret-detect.test.ts) | "finds a GitHub PAT" test splits \`ghp_<hex>\` literal across a runtime concat |
| [\`tests/vault-sweep.hindsight.test.ts\`](tests/vault-sweep.hindsight.test.ts) | Hoisted duplicate \`ghp_<hex>\` literal into a single \`GH_FIXTURE\` runtime constant |

## Test plan

- [x] \`tsc --noEmit\` clean
- [x] 61/61 tests pass across the four touched files (verified in node:20 docker)
- [ ] CI green on Linux

## ⚠️ Out of scope (maintainer follow-up)

**Git history retention.** If the \`sk-ant-oat01-HK_46Li...\` value was a real Anthropic OAuth token, it remains in the git log at commit [5dd9f30](https://github.com/switchroom/switchroom/commit/5dd9f30) (2026-04-22, "fix(auth): detect silent setup-token success via credentials.json (#31)"). Removing it from the working tree doesn't purge it from history.

If the value was real, the recommended steps are:
1. **Rotate the OAuth token immediately** — log into the Anthropic account, revoke the token, re-authenticate.
2. **Optionally** scrub git history via [BFG Repo-Cleaner](https://rtyley.github.io/bfg-repo-cleaner/) or \`git filter-repo\` if you want to reduce post-leak forensic exposure. (Force-pushing rewritten history to \`main\` has its own coordination cost; the rotation in step 1 is the security-relevant action.)

If the value was generated random or a fixed-seed test fixture, no further action needed beyond this PR.

## Audit summary (no other findings)

I checked the rest of the repo for PII / leaked confidential info. Clean across:
- ✅ No \`.env\` files committed; \`private/\`, \`clerk-export/\`, \`.vault/\` correctly gitignored
- ✅ No phone numbers; the only emails are \`me@kenthompson.com.au\` (intentional plugin metadata in [\`marketplace.json\`](.claude-plugin/marketplace.json)) and Anthropic's standard \`noreply@anthropic.com\` Co-Authored-By trailer
- ✅ Path examples in docs/tests are all generic placeholders (\`/home/user\`, \`/home/test\`, \`/home/testuser\`)
- ✅ Other Anthropic OAuth strings in tests/auth.test.ts and tests/auth.stale-token-fix.test.ts are obviously fake (literal \`-test-token\`, \`-env-token\`, \`STALE_STALE\`, \`FRESH_FRESH\` markers)
- ✅ Slack \`xoxb-\` fixture already correctly uses runtime concatenation
- ✅ \`telegram-plugin/operator-events.fixtures.json\` explicitly says "Real API keys/IDs have been scrubbed"
- ✅ Forum chat IDs are all \`-1001234567890\` (canonical Telegram example)
- ✅ AWS ARNs are documentation placeholders (\`123456789012\`)
- ✅ \`reference/PRD.md\` and JTBD docs are public design artifacts; no confidential business info

🤖 Generated with [Claude Code](https://claude.com/claude-code)