### PR TITLE
fix(boot-card): render persona name not slug (#169)

### DIFF
--- a/telegram-plugin/gateway/boot-card.ts
+++ b/telegram-plugin/gateway/boot-card.ts
@@ -43,6 +43,42 @@ import {
 } from './boot-probes.js'
 import { escapeHtml } from '../card-format.js'
 import { join } from 'path'
+import { loadConfig as _loadSwitchroomConfig } from '../../src/config/loader.js'
+
+// ─── Persona name resolution ─────────────────────────────────────────────────
+
+/**
+ * Resolve the display name for an agent from its config's soul.name field.
+ *
+ * The slug (e.g. "finn") is an operator-facing identifier: agent directory,
+ * systemd unit name, vault key prefix. It should never appear in
+ * user-facing Telegram output. soul.name (e.g. "Finn") is the persona
+ * the user knows through the bot username, topic emoji, and conversation.
+ *
+ * Falls back to the slug when:
+ *   - soul is not set in the agent config
+ *   - the agent key is not found in switchroom.yaml
+ *   - the config cannot be loaded (gateway running outside a switchroom env)
+ *
+ * The optional `loadConfig` override exists purely for unit-test injection.
+ * Production callers pass no second argument and get the live config.
+ *
+ * Closes #169.
+ */
+export function resolvePersonaName(
+  slug: string,
+  loadConfig?: () => { agents?: Record<string, { soul?: { name?: string } | null }> } | null,
+): string {
+  try {
+    const config = loadConfig ? loadConfig() : _loadSwitchroomConfig()
+    const name = config?.agents?.[slug]?.soul?.name
+    return name && name.trim().length > 0 ? name : slug
+  } catch {
+    // Config unreadable (gateway running in a test env or outside a
+    // switchroom workspace). Degrade gracefully to the slug.
+    return slug
+  }
+}
 
 // ─── Types ──────────────────────────────────────────────────────────────────
 

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -187,6 +187,7 @@ import {
 } from '../subagent-watcher.js'
 import {
   startBootCard,
+  resolvePersonaName,
   type BootCardHandle,
 } from './boot-card.js'
 import { determineRestartReason } from './boot-reason.js'
@@ -1069,13 +1070,14 @@ const ipcServer: IpcServer = createIpcServer({
         process.stderr.write(`telegram gateway: bridge-reconnect: posting boot card reason=${reason} chat_id=${chatId} thread_id=${threadId ?? '-'} ackReply=${ackMsgId ?? '-'} boot_card=${BOOT_CARD_ENABLED}\n`)
         if (BOOT_CARD_ENABLED) {
           const agentDir = resolveAgentDirFromEnv()
-          const agentName = process.env.SWITCHROOM_AGENT_NAME ?? client.agentName ?? '-'
+          const agentSlug = process.env.SWITCHROOM_AGENT_NAME ?? client.agentName ?? '-'
+          const agentDisplayName = resolvePersonaName(agentSlug)
           const botApiForCard: import('./boot-card.js').BotApiForBootCard = {
             sendMessage: (cid, text, opts) => lockedBot.api.sendMessage(cid, text, opts as Parameters<typeof lockedBot.api.sendMessage>[2]) as Promise<{ message_id: number }>,
             editMessageText: (cid, mid, text, opts) => lockedBot.api.editMessageText(cid, mid, text, opts as Parameters<typeof lockedBot.api.editMessageText>[3]),
           }
           startBootCard(chatId, threadId, botApiForCard, {
-            agentName,
+            agentName: agentDisplayName,
             version: formatBootVersion(),
             agentDir: agentDir ?? (process.env.TELEGRAM_STATE_DIR ? require('path').dirname(process.env.TELEGRAM_STATE_DIR) : '/tmp'),
             gatewayInfo: { pid: process.pid, startedAtMs: GATEWAY_STARTED_AT_MS },
@@ -5707,16 +5709,17 @@ void (async () => {
               process.stderr.write(`telegram gateway: boot: posting boot card reason=${reason} chat_id=${chatId} thread_id=${threadId ?? '-'} ackReply=${ackMsgId ?? '-'} boot_card=${BOOT_CARD_ENABLED}\n`)
               if (BOOT_CARD_ENABLED) {
                 const agentDir = resolveAgentDirFromEnv()
-                const agentName = process.env.SWITCHROOM_AGENT_NAME ?? '-'
+                const agentSlug = process.env.SWITCHROOM_AGENT_NAME ?? '-'
+                const agentDisplayName = resolvePersonaName(agentSlug)
                 const botApiForCard: import('./boot-card.js').BotApiForBootCard = {
                   sendMessage: (cid, text, opts) => lockedBot.api.sendMessage(cid, text, opts as Parameters<typeof lockedBot.api.sendMessage>[2]) as Promise<{ message_id: number }>,
                   editMessageText: (cid, mid, text, opts) => lockedBot.api.editMessageText(cid, mid, text, opts as Parameters<typeof lockedBot.api.editMessageText>[3]),
                 }
                 try {
                   const handle = await startBootCard(chatId, threadId, botApiForCard, {
-                    agentName,
+                    agentName: agentDisplayName,
                     version: formatBootVersion(),
-                    agentDir: agentDir ?? join(homedir(), '.switchroom', 'agents', agentName),
+                    agentDir: agentDir ?? join(homedir(), '.switchroom', 'agents', agentSlug),
                     gatewayInfo: { pid: process.pid, startedAtMs: GATEWAY_STARTED_AT_MS },
                     restartReason: reason,
                     restartAgeMs: markerAgeMs,

--- a/telegram-plugin/tests/boot-card-render.test.ts
+++ b/telegram-plugin/tests/boot-card-render.test.ts
@@ -13,7 +13,7 @@
  */
 
 import { describe, it, expect } from 'vitest'
-import { renderBootCard } from '../gateway/boot-card.js'
+import { renderBootCard, resolvePersonaName } from '../gateway/boot-card.js'
 
 describe('renderBootCard — quiet by default', () => {
   it('returns one-line ack with default ✅ when no probes and no restart reason', () => {
@@ -170,5 +170,50 @@ describe('renderBootCard — HTML escaping', () => {
     })
     expect(out).toContain('rate &lt;limited&gt;')
     expect(out).not.toContain('rate <limited>')
+  })
+})
+
+describe('resolvePersonaName — persona name over slug (#169)', () => {
+  it('returns soul.name when set in config', () => {
+    const fakeCfg = () => ({
+      agents: { finn: { soul: { name: 'Finn', style: 'warm' } } },
+    })
+    expect(resolvePersonaName('finn', fakeCfg)).toBe('Finn')
+  })
+
+  it('falls back to slug when soul.name is absent', () => {
+    const fakeCfg = () => ({
+      agents: { finn: { soul: null } },
+    })
+    expect(resolvePersonaName('finn', fakeCfg)).toBe('finn')
+  })
+
+  it('falls back to slug when soul.name is empty string', () => {
+    const fakeCfg = () => ({
+      agents: { finn: { soul: { name: '', style: 'warm' } } },
+    })
+    expect(resolvePersonaName('finn', fakeCfg)).toBe('finn')
+  })
+
+  it('falls back to slug when agent key is not in config', () => {
+    const fakeCfg = () => ({ agents: {} })
+    expect(resolvePersonaName('finn', fakeCfg)).toBe('finn')
+  })
+
+  it('falls back to slug when config loader throws', () => {
+    const throwing = () => { throw new Error('no config file') }
+    expect(resolvePersonaName('finn', throwing)).toBe('finn')
+  })
+
+  it('boot card rendered with soul.name not slug — acceptance criterion for #169', () => {
+    // Simulate: slug is "finn", soul.name is "Finn"
+    const fakeCfg = () => ({
+      agents: { finn: { soul: { name: 'Finn', style: 'warm' } } },
+    })
+    const displayName = resolvePersonaName('finn', fakeCfg)
+    const out = renderBootCard({ agentName: displayName, version: 'v0.3.0+50' })
+    // User sees "Finn", not the slug "finn"
+    expect(out).toBe('✅ <b>Finn</b> back up · v0.3.0+50')
+    expect(out).not.toContain('<b>finn</b>')
   })
 })


### PR DESCRIPTION
## Summary

- Adds `resolvePersonaName(slug, loadConfig?)` to `boot-card.ts` that looks up `agents[slug].soul.name` from the switchroom config, falling back to the slug when unavailable
- Wires it into both boot-card call sites in `gateway.ts` so the headline reads "✅ **Finn** back up" instead of "✅ **fin** back up"
- Replaced the previous dynamic `require()` (broken in this ESM-only project) with a static `import { loadConfig } from '../../src/config/loader.js'`, matching the pattern already used in `gateway.ts`
- Adds 6 unit tests covering the happy path, all fallback branches, and the end-to-end acceptance criterion from the issue

## Test plan

- [ ] `bun test telegram-plugin/tests/boot-card-render.test.ts` — 19 pass including 6 new `resolvePersonaName` tests
- [ ] `npx vitest run` — same pass/fail count as clean `main` (pre-existing failures in `tests/auth.stale-token-fix.test.ts` and `tests/token-helpers.test.ts` are unrelated)
- [ ] `bun test telegram-plugin/tests/boot-card-dedupe.test.ts telegram-plugin/tests/boot-card-reason.test.ts telegram-plugin/tests/boot-card-render.test.ts` — 32 pass

Closes #169

🤖 Generated with [Claude Code](https://claude.com/claude-code)