### PR TITLE
fix(access): validate allowFrom is string[] at load (#165)

### DIFF
--- a/telegram-plugin/gateway/access-validator.test.ts
+++ b/telegram-plugin/gateway/access-validator.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Unit tests for access-validator.ts — validateStringArray.
+ *
+ * This function guards access.json fields at load time. The motivating bug:
+ * a hand-edit that drops quotes around IDs (`[8248703757]` instead of
+ * `["8248703757"]`) produces a valid JSON number array. Array.includes() uses
+ * strict equality, so number entries never match the string comparison in the
+ * gate — every DM is silently dropped.
+ *
+ * Run with: npx vitest run telegram-plugin/gateway/access-validator.test.ts
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { validateStringArray } from './access-validator.js'
+
+describe('validateStringArray', () => {
+  let stderrSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+  })
+
+  afterEach(() => {
+    stderrSpy.mockRestore()
+  })
+
+  // ─── Happy path ────────────────────────────────────────────────────────────
+
+  it('returns the array unchanged for a valid string array', () => {
+    expect(validateStringArray('allowFrom', ['8248703757', '9999'])).toEqual(['8248703757', '9999'])
+    expect(stderrSpy).not.toHaveBeenCalled()
+  })
+
+  it('returns [] for an empty array without warning', () => {
+    expect(validateStringArray('allowFrom', [])).toEqual([])
+    expect(stderrSpy).not.toHaveBeenCalled()
+  })
+
+  it('defaults to [] when value is undefined (missing field)', () => {
+    expect(validateStringArray('allowFrom', undefined)).toEqual([])
+    expect(stderrSpy).not.toHaveBeenCalled()
+  })
+
+  it('defaults to [] when value is null', () => {
+    expect(validateStringArray('allowFrom', null)).toEqual([])
+    expect(stderrSpy).not.toHaveBeenCalled()
+  })
+
+  // ─── Bug reproduction: number array ────────────────────────────────────────
+
+  it('rejects a number array (the hand-edit bug) and returns []', () => {
+    // This is the exact bug: [8248703757] parses as a number, not a string.
+    // Array.includes("8248703757") === false for a number entry — silently drops DMs.
+    const result = validateStringArray('allowFrom', [8248703757])
+    expect(result).toEqual([])
+    expect(stderrSpy).toHaveBeenCalled()
+    const msg = String(stderrSpy.mock.calls[0][0])
+    expect(msg).toContain('allowFrom')
+    expect(msg).toContain('non-string entries')
+    expect(msg).toContain('8248703757')
+  })
+
+  // ─── Mixed array ──────────────────────────────────────────────────────────
+
+  it('rejects a mixed array (some strings, some numbers) and returns []', () => {
+    const result = validateStringArray('allowFrom', ['8248703757', 9999])
+    expect(result).toEqual([])
+    expect(stderrSpy).toHaveBeenCalled()
+    const msg = String(stderrSpy.mock.calls[0][0])
+    expect(msg).toContain('non-string entries')
+  })
+
+  // ─── Tag in error message ─────────────────────────────────────────────────
+
+  it('includes the tag in the stderr message (gateway)', () => {
+    validateStringArray('allowFrom', [123], 'gateway')
+    const msg = String(stderrSpy.mock.calls[0][0])
+    expect(msg).toContain('telegram gateway')
+  })
+
+  it('includes the tag in the stderr message (channel)', () => {
+    validateStringArray('allowFrom', [123], 'channel')
+    const msg = String(stderrSpy.mock.calls[0][0])
+    expect(msg).toContain('telegram channel')
+  })
+
+  // ─── Non-array inputs ─────────────────────────────────────────────────────
+
+  it('returns [] without warning for non-array values (object, string, number)', () => {
+    expect(validateStringArray('allowFrom', {})).toEqual([])
+    expect(validateStringArray('allowFrom', 'oops')).toEqual([])
+    expect(validateStringArray('allowFrom', 42)).toEqual([])
+    expect(stderrSpy).not.toHaveBeenCalled()
+  })
+})

--- a/telegram-plugin/gateway/access-validator.ts
+++ b/telegram-plugin/gateway/access-validator.ts
@@ -1,0 +1,37 @@
+/**
+ * Validates fields loaded from access.json, failing loudly on type mismatches.
+ *
+ * JSON has no type system — a hand-edit that drops quotes around IDs
+ * (e.g. `[8248703757]` instead of `["8248703757"]`) parses without error
+ * but produces a number array. The gate compares with strict equality via
+ * Array.includes(), so number entries silently drop every matching DM.
+ *
+ * This module surfaces that mistake at load time rather than at runtime.
+ */
+
+/**
+ * Validates that `value` is an array of strings.
+ *
+ * - If `value` is not an array, returns [].
+ * - If any entry is not a string, logs a loud warning to stderr and returns []
+ *   so the field behaves as if no entries were present (fail-closed).
+ * - If all entries are strings, returns the array as-is.
+ *
+ * @param field  Human-readable field name for the error message (e.g. "allowFrom")
+ * @param value  The parsed JSON value to validate
+ * @param tag    Process tag for the error message ("gateway" or "channel")
+ */
+export function validateStringArray(field: string, value: unknown, tag = 'gateway'): string[] {
+  if (!Array.isArray(value)) return []
+  const hasNonString = value.some((v) => typeof v !== 'string')
+  if (hasNonString) {
+    const example = String(value[0])
+    process.stderr.write(
+      `telegram ${tag}: access.json: ${field} contains non-string entries — ` +
+        `all values must be quoted strings (e.g. ["${example}"]). ` +
+        `Fix and reload. Treating as empty.\n`,
+    )
+    return []
+  }
+  return value as string[]
+}

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -74,6 +74,7 @@ import {
 } from '../operator-events.js'
 import { recordOperatorEvent } from '../operator-events-history.js'
 import { startRestartWatchdog } from './restart-watchdog.js'
+import { validateStringArray } from './access-validator.js'
 
 /**
  * Truncation cap for the `reply_to_text` channel-meta attribute (issue #119).
@@ -370,10 +371,18 @@ function readAccessFile(): Access {
   try {
     const raw = readFileSync(ACCESS_FILE, 'utf8')
     const parsed = JSON.parse(raw) as Partial<Access>
+    const allowFrom = validateStringArray('allowFrom', parsed.allowFrom ?? [])
+    const groups: Record<string, GroupPolicy> = {}
+    for (const [chatId, policy] of Object.entries(parsed.groups ?? {})) {
+      groups[chatId] = {
+        ...policy,
+        allowFrom: validateStringArray(`groups.${chatId}.allowFrom`, policy.allowFrom ?? []),
+      }
+    }
     return {
       dmPolicy: parsed.dmPolicy ?? 'pairing',
-      allowFrom: parsed.allowFrom ?? [],
-      groups: parsed.groups ?? {},
+      allowFrom,
+      groups,
       pending: parsed.pending ?? {},
       mentionPatterns: parsed.mentionPatterns,
       ackReaction: parsed.ackReaction,

--- a/telegram-plugin/server.ts
+++ b/telegram-plugin/server.ts
@@ -369,6 +369,7 @@ import {
 } from './active-pins.js'
 import { sweepActivePins, sweepBotAuthoredPins } from './active-pins-sweep.js'
 import { logPinEvent, classifyPinError, errorMessage } from './pin-event-log.js'
+import { validateStringArray } from './gateway/access-validator.js'
 
 /**
  * One-shot carry-over from the session-end summarizer: a short topic
@@ -610,10 +611,18 @@ function readAccessFile(): Access {
   try {
     const raw = readFileSync(ACCESS_FILE, 'utf8')
     const parsed = JSON.parse(raw) as Partial<Access>
+    const allowFrom = validateStringArray('allowFrom', parsed.allowFrom ?? [], 'channel')
+    const groups: Record<string, GroupPolicy> = {}
+    for (const [chatId, policy] of Object.entries(parsed.groups ?? {})) {
+      groups[chatId] = {
+        ...policy,
+        allowFrom: validateStringArray(`groups.${chatId}.allowFrom`, policy.allowFrom ?? [], 'channel'),
+      }
+    }
     return {
       dmPolicy: parsed.dmPolicy ?? 'pairing',
-      allowFrom: parsed.allowFrom ?? [],
-      groups: parsed.groups ?? {},
+      allowFrom,
+      groups,
       pending: parsed.pending ?? {},
       mentionPatterns: parsed.mentionPatterns,
       ackReaction: parsed.ackReaction,


### PR DESCRIPTION
## Summary

- Hand-edits to `access.json` can produce a number array (e.g. `[8248703757]` vs `["8248703757"]`), which parses silently but causes `Array.includes()` to never match — every DM is silently dropped.
- New `validateStringArray` helper detects non-string entries at load time, writes a loud stderr diagnostic, and returns `[]` (fail-closed) so the behaviour is predictable rather than invisible.
- Wired into `readAccessFile()` in both `gateway.ts` and `server.ts`, covering top-level and per-group `allowFrom` fields.

Closes #165

🤖 Generated with [Claude Code](https://claude.com/claude-code)