### PR TITLE
fix(scaffold): validate bot token via getMe at init

### DIFF
--- a/src/agents/create-orchestrator.test.ts
+++ b/src/agents/create-orchestrator.test.ts
@@ -27,6 +27,7 @@ import { join } from "node:path";
 
 vi.mock("../setup/telegram-api.js", () => ({
   validateBotToken: vi.fn(),
+  validateBotTokenMatchesAgent: vi.fn(),
 }));
 
 vi.mock("./scaffold.js", () => ({
@@ -76,7 +77,7 @@ vi.mock("../setup/onboarding.js", () => ({
 // ─── Imports (after mocks) ───────────────────────────────────────────────────
 
 import { createAgent, completeCreation } from "./create-orchestrator.js";
-import { validateBotToken } from "../setup/telegram-api.js";
+import { validateBotTokenMatchesAgent } from "../setup/telegram-api.js";
 import { scaffoldAgent } from "./scaffold.js";
 import {
   generateUnit,
@@ -127,7 +128,7 @@ describe("createAgent", () => {
   beforeEach(() => {
     agentsDir = makeAgentDir();
     vi.mocked(listAvailableProfiles).mockReturnValue(["health-coach", "coding"]);
-    vi.mocked(validateBotToken).mockResolvedValue({
+    vi.mocked(validateBotTokenMatchesAgent).mockResolvedValue({
       id: 111111111,
       is_bot: true,
       first_name: "Gymbro",
@@ -156,12 +157,12 @@ describe("createAgent", () => {
         configPath: join(agentsDir, "switchroom.yaml"),
       }),
     ).rejects.toThrow(/Unknown profile/);
-    // validateBotToken must NOT have been called (no disk write, no network call)
-    expect(validateBotToken).not.toHaveBeenCalled();
+    // validateBotTokenMatchesAgent must NOT have been called (no disk write, no network call)
+    expect(validateBotTokenMatchesAgent).not.toHaveBeenCalled();
   });
 
   it("rejects a bad bot token before any disk writes", async () => {
-    vi.mocked(validateBotToken).mockRejectedValue(
+    vi.mocked(validateBotTokenMatchesAgent).mockRejectedValue(
       new Error("Invalid bot token: Unauthorized"),
     );
     await expect(
@@ -171,7 +172,7 @@ describe("createAgent", () => {
         telegramBotToken: "bad-token",
         configPath: join(agentsDir, "switchroom.yaml"),
       }),
-    ).rejects.toThrow(/Bot token rejected/);
+    ).rejects.toThrow(/Bot token validation failed/);
     // scaffold must NOT have been called
     expect(scaffoldAgent).not.toHaveBeenCalled();
   });
@@ -612,7 +613,7 @@ describe("createAgent + completeCreation end-to-end", () => {
   beforeEach(() => {
     agentsDir = makeAgentDir();
     vi.mocked(listAvailableProfiles).mockReturnValue(["health-coach"]);
-    vi.mocked(validateBotToken).mockResolvedValue({
+    vi.mocked(validateBotTokenMatchesAgent).mockResolvedValue({
       id: 111111111,
       is_bot: true,
       first_name: "Gymbro",

--- a/src/agents/create-orchestrator.ts
+++ b/src/agents/create-orchestrator.ts
@@ -35,7 +35,7 @@ import {
   removeAgentFromConfig,
   synthesizeTopicName,
 } from "../cli/agent.js";
-import { validateBotToken } from "../setup/telegram-api.js";
+import { validateBotToken, validateBotTokenMatchesAgent } from "../setup/telegram-api.js";
 import { writeAgentEnv } from "../setup/onboarding.js";
 
 // ─── Types ───────────────────────────────────────────────────────────────────
@@ -143,10 +143,13 @@ export async function createAgent(
     );
   }
 
-  // ── Step 2: Validate bot token (BEFORE any disk writes) ──────────────────
-  await validateBotToken(telegramBotToken).catch((err: Error) => {
+  // ── Step 2: Validate bot token and assert username matches agent slug ────
+  // Uses getMe to verify the token is valid AND that the returned username
+  // contains the agent slug — catches copy-paste mistakes like writing
+  // clerk's token into finn's .env before any disk writes occur.
+  await validateBotTokenMatchesAgent(telegramBotToken, name).catch((err: Error) => {
     throw new Error(
-      `Bot token rejected by Telegram — check the token and try again. ` +
+      `Bot token validation failed — check the token and try again. ` +
         `(${err.message})`,
     );
   });

--- a/src/cli/agent.ts
+++ b/src/cli/agent.ts
@@ -45,6 +45,7 @@ import {
   type StatusInputs,
 } from "../agents/status.js";
 import { createAgent, completeCreation } from "../agents/create-orchestrator.js";
+import { validateBotTokenMatchesAgent } from "../setup/telegram-api.js";
 import { registerAgentPerfCommand } from "./perf.js";
 
 /**
@@ -489,6 +490,32 @@ export async function reconcileAndRestartAgent(
     log(chalk.green(`  ${name}: reconciled (${allChanges.length} file${allChanges.length === 1 ? "" : "s"})`));
     for (const f of allChanges) {
       log(chalk.gray(`    - ${f}`));
+    }
+  }
+
+  // ── Bot-token username validation ─────────────────────────────────────────
+  // Read the resolved token from telegram/.env and verify via getMe that the
+  // bot username contains the agent slug. This catches copy-paste mistakes
+  // (e.g. clerk's token in finn's .env) before the agent restarts and starts
+  // spamming 409 conflicts. Fails loudly — refuse to restart on mismatch.
+  {
+    const envPath = resolve(agentsDir, name, "telegram", ".env");
+    if (existsSync(envPath)) {
+      const envContent = readFileSync(envPath, "utf-8");
+      const match = envContent.match(/^TELEGRAM_BOT_TOKEN=(.+)$/m);
+      if (match) {
+        const token = match[1].trim();
+        try {
+          await validateBotTokenMatchesAgent(token, name);
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          // Fail loudly — do not restart with a wrong token.
+          throw new Error(
+            `Bot token mismatch for agent "${name}": ${msg}\n` +
+              `Fix telegram/.env or the vault entry, then re-run the command.`,
+          );
+        }
+      }
     }
   }
 

--- a/src/setup/telegram-api.test.ts
+++ b/src/setup/telegram-api.test.ts
@@ -1,0 +1,178 @@
+/**
+ * Unit tests for bot-token validation helpers in telegram-api.ts.
+ *
+ * Covers:
+ *   - assertBotUsernameMatchesAgent: pure slug-in-username check
+ *   - validateBotTokenMatchesAgent: integration of getMe + slug check (fetch mocked)
+ */
+
+import { describe, it, expect, vi, afterEach } from "vitest";
+import {
+  assertBotUsernameMatchesAgent,
+  validateBotToken,
+  validateBotTokenMatchesAgent,
+} from "./telegram-api.js";
+
+// ---------------------------------------------------------------------------
+// assertBotUsernameMatchesAgent — pure unit tests, no network
+// ---------------------------------------------------------------------------
+
+describe("assertBotUsernameMatchesAgent", () => {
+  it("passes when slug is a substring of username (suffix pattern)", () => {
+    // e.g. @clerk_meken_bot → slug "clerk"
+    expect(() =>
+      assertBotUsernameMatchesAgent("clerk_meken_bot", "clerk"),
+    ).not.toThrow();
+  });
+
+  it("passes when slug is a substring of username (prefix pattern)", () => {
+    // e.g. @meken_gymbro_bot → slug "gymbro"
+    expect(() =>
+      assertBotUsernameMatchesAgent("meken_gymbro_bot", "gymbro"),
+    ).not.toThrow();
+  });
+
+  it("passes when slug is the entire username (exact match)", () => {
+    expect(() =>
+      assertBotUsernameMatchesAgent("finn_bot", "finn"),
+    ).not.toThrow();
+  });
+
+  it("is case-insensitive on both sides", () => {
+    expect(() =>
+      assertBotUsernameMatchesAgent("MEKEN_GYMBRO_BOT", "gymbro"),
+    ).not.toThrow();
+  });
+
+  it("throws when slug is absent from username — the finn/clerk mix-up scenario", () => {
+    // finn's .env got clerk's token → getMe returns @clerk_meken_bot
+    expect(() =>
+      assertBotUsernameMatchesAgent("clerk_meken_bot", "finn"),
+    ).toThrow(/agent "finn" bot_token resolves to @clerk_meken_bot/);
+  });
+
+  it("throws error message that names the actual username and expected slug", () => {
+    let caught: Error | null = null;
+    try {
+      assertBotUsernameMatchesAgent("other_bot", "myagent");
+    } catch (err) {
+      caught = err as Error;
+    }
+    expect(caught).not.toBeNull();
+    expect(caught!.message).toMatch(/@other_bot/);
+    expect(caught!.message).toMatch(/"myagent"/);
+    expect(caught!.message).toMatch(/vault/i);
+  });
+
+  it("throws for an empty username", () => {
+    expect(() =>
+      assertBotUsernameMatchesAgent("", "finn"),
+    ).toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validateBotTokenMatchesAgent — mocks fetch, tests combined flow
+// ---------------------------------------------------------------------------
+
+describe("validateBotTokenMatchesAgent", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function mockGetMe(username: string) {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      json: async () => ({
+        ok: true,
+        result: {
+          id: 123456,
+          is_bot: true,
+          first_name: "TestBot",
+          username,
+        },
+      }),
+    } as Response);
+  }
+
+  function mockGetMeNetworkError() {
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(
+      new Error("ECONNREFUSED"),
+    );
+  }
+
+  function mockGetMeInvalidToken() {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      json: async () => ({
+        ok: false,
+        description: "Unauthorized",
+      }),
+    } as Response);
+  }
+
+  it("resolves with BotInfo when token is valid and username matches slug", async () => {
+    mockGetMe("meken_finn_bot");
+    const info = await validateBotTokenMatchesAgent("valid-token", "finn");
+    expect(info.username).toBe("meken_finn_bot");
+  });
+
+  it("throws on username mismatch — the finn/clerk mix-up", async () => {
+    mockGetMe("clerk_meken_bot");
+    await expect(
+      validateBotTokenMatchesAgent("clerk-token", "finn"),
+    ).rejects.toThrow(/agent "finn" bot_token resolves to @clerk_meken_bot/);
+  });
+
+  it("throws on invalid token (Telegram returns ok:false)", async () => {
+    mockGetMeInvalidToken();
+    await expect(
+      validateBotTokenMatchesAgent("bad-token", "finn"),
+    ).rejects.toThrow(/Invalid bot token/);
+  });
+
+  it("throws on network error with a redacted message", async () => {
+    mockGetMeNetworkError();
+    await expect(
+      validateBotTokenMatchesAgent("my-secret-token", "finn"),
+    ).rejects.toThrow(/Network error/);
+  });
+
+  it("does not leak the token in a network-error message", async () => {
+    mockGetMeNetworkError();
+    let caught: Error | null = null;
+    try {
+      await validateBotTokenMatchesAgent("my-secret-token-value", "finn");
+    } catch (err) {
+      caught = err as Error;
+    }
+    expect(caught).not.toBeNull();
+    expect(caught!.message).not.toContain("my-secret-token-value");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validateBotToken — sanity check that existing function still works
+// ---------------------------------------------------------------------------
+
+describe("validateBotToken", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns BotInfo on success", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      json: async () => ({
+        ok: true,
+        result: { id: 1, is_bot: true, first_name: "Bot", username: "test_bot" },
+      }),
+    } as Response);
+    const info = await validateBotToken("token");
+    expect(info.username).toBe("test_bot");
+  });
+
+  it("throws on ok:false response", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      json: async () => ({ ok: false, description: "Not Found" }),
+    } as Response);
+    await expect(validateBotToken("bad")).rejects.toThrow(/Invalid bot token/);
+  });
+});

--- a/src/setup/telegram-api.ts
+++ b/src/setup/telegram-api.ts
@@ -66,6 +66,52 @@ export async function validateBotToken(token: string): Promise<BotInfo> {
 }
 
 /**
+ * Assert that a bot's username contains the expected agent slug.
+ *
+ * Telegram bot usernames follow no single naming convention — Switchroom
+ * agents use both `@<slug>_meken_bot` and `@meken_<slug>_bot` depending on
+ * BotFather history. The minimal convention we enforce is that the slug
+ * appears somewhere in the username (case-insensitive).
+ *
+ * Throws with a human-readable message when the username does not contain
+ * the slug, so the caller can surface it as a loud error.
+ *
+ * @param username - The bot username returned by getMe (without leading @).
+ * @param agentSlug - The agent name / slug (e.g. "finn", "gymbro").
+ */
+export function assertBotUsernameMatchesAgent(
+  username: string,
+  agentSlug: string,
+): void {
+  const lowerUsername = username.toLowerCase();
+  const lowerSlug = agentSlug.toLowerCase();
+  if (!lowerUsername.includes(lowerSlug)) {
+    throw new Error(
+      `agent "${agentSlug}" bot_token resolves to @${username} — expected username to contain "${agentSlug}". ` +
+        `Check switchroom.yaml or the vault entry (bot_token key may point to the wrong bot).`,
+    );
+  }
+}
+
+/**
+ * Validate a bot token by calling getMe, then assert the returned username
+ * matches the expected agent slug. Throws on network error, invalid token,
+ * or username mismatch.
+ *
+ * This is the combined validation that should be called at scaffold/reconcile
+ * time so mismatched tokens (e.g. clerk's token written to finn's .env) are
+ * caught immediately with a clear error.
+ */
+export async function validateBotTokenMatchesAgent(
+  token: string,
+  agentSlug: string,
+): Promise<BotInfo> {
+  const botInfo = await validateBotToken(token);
+  assertBotUsernameMatchesAgent(botInfo.username, agentSlug);
+  return botInfo;
+}
+
+/**
  * Poll getUpdates looking for a /start message from a private chat.
  * Returns the sender's info once found.
  */


### PR DESCRIPTION
## Summary

- Adds `validateBotTokenMatchesAgent`: calls Telegram's `getMe` and asserts the returned username contains the agent slug, catching copy-paste token mix-ups (e.g. clerk's token in finn's `.env`) before any disk writes
- Wires the check into `createAgent` (replaces bare `validateBotToken`) and `reconcileAndRestartAgent` (reads `telegram/.env` and validates before restart)
- Adds `assertBotUsernameMatchesAgent` as a pure helper for the slug-in-username check (case-insensitive substring)
- Full unit test coverage in `src/setup/telegram-api.test.ts` (14 tests); orchestrator mock updated to reflect new export

Closes #167

🤖 Generated with [Claude Code](https://claude.com/claude-code)