### PR TITLE
fix(reconcile): auto-restart on soul changes (#170)

### DIFF
--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -1963,11 +1963,20 @@ function classifyChange(
   if (relPath.startsWith("workspace/memory/") && relPath.endsWith(".md")) return "hot";
   if (relPath === "workspace/HEARTBEAT.md") return "hot";
 
+  // Soul files — persona identity (name, vibe, creature) is baked into
+  // --append-system-prompt at session start. When hotReloadStable is true the
+  // per-turn hook re-injects SOUL.md so changes go live next turn (hot).
+  // When hotReloadStable is false (default), the file is frozen at launch and
+  // any edit is invisible until the agent restarts — so we promote it to
+  // restart-required so the reconciler auto-restarts immediately.
+  if (relPath === "workspace/SOUL.md" || relPath === "workspace/SOUL.custom.md") {
+    return useHotReloadStable ? "hot" : "restart-required";
+  }
+
   // Stable workspace files — classification depends on hotReloadStable flag
   // When hotReloadStable is true, these are re-injected on every turn via hook
   // When hotReloadStable is false (default), they're baked into --append-system-prompt at start
   const stableWorkspaceFiles = [
-    "workspace/SOUL.md",
     "workspace/CLAUDE.md",
     "workspace/AGENTS.md",
     "workspace/AGENT.md",
@@ -1982,7 +1991,6 @@ function classifyChange(
   // CLAUDE.md stays stale-till-restart regardless (Claude Code's own file-load convention)
   if (relPath === "CLAUDE.md") return "stale-till-restart";
   if (relPath === "workspace/CLAUDE.custom.md") return "stale-till-restart";
-  if (relPath === "workspace/SOUL.custom.md") return "stale-till-restart";
 
   // Restart required — claude-code / MCP / subsystem lifecycle
   if (relPath === ".mcp.json") return "restart-required";

--- a/src/cli/agent.ts
+++ b/src/cli/agent.ts
@@ -1161,14 +1161,15 @@ export function registerAgentCommand(program: Command): void {
     .description(
       "Re-apply switchroom.yaml to an existing agent (rewrites .mcp.json + settings.json + start.sh + CLAUDE.md)"
     )
-    .option("--restart", "Restart the agent after reconciling")
+    .option("--restart", "Restart the agent after reconciling (no-op when auto-restart fires)")
+    .option("--no-restart", "Suppress the automatic restart even when soul/config changes require it")
     .option("--graceful-restart", "Wait for active turn to complete before restarting")
     .option(
       "--preserve-claude-md",
       "Opt out of regenerating CLAUDE.md — use if you have hand-edits you don't want to migrate to CLAUDE.custom.md yet"
     )
     .action(
-      withConfigError(async (name: string, opts: { restart?: boolean; gracefulRestart?: boolean; preserveClaudeMd?: boolean }) => {
+      withConfigError(async (name: string, opts: { restart?: boolean; noRestart?: boolean; gracefulRestart?: boolean; preserveClaudeMd?: boolean }) => {
         const config = getConfig(program);
         const agentsDir = resolveAgentsDir(config);
         const configPath = getConfigPath(program);
@@ -1203,12 +1204,12 @@ export function registerAgentCommand(program: Command): void {
               console.log(chalk.green(`  ${n}: reconciled (${result.changes.length} file${result.changes.length === 1 ? "" : "s"})`));
 
               // Categorize and display changes by reload semantics
-              const { changesBySemantics } = result;
-              if (changesBySemantics) {
-                const { hot, staleTillRestart, restartRequired } = changesBySemantics;
+              const semantics = result.changesBySemantics;
+              if (semantics) {
+                const { hot, staleTillRestart, restartRequired } = semantics;
 
                 if (restartRequired.length > 0) {
-                  console.log(chalk.yellow("\n  Changed (restart REQUIRED, MCP/settings/launch):"));
+                  console.log(chalk.yellow("\n  Changed (restart required — soul/MCP/settings/launch):"));
                   for (const f of restartRequired) {
                     console.log(chalk.yellow(`    - ${f}`));
                   }
@@ -1230,11 +1231,17 @@ export function registerAgentCommand(program: Command): void {
 
                 // If only hot changes, suppress restart suggestion
                 const needsRestart = restartRequired.length > 0 || staleTillRestart.length > 0;
+                // Auto-restart when restart-required changes present (e.g. soul fields),
+                // unless the user explicitly opted out with --no-restart.
+                const autoRestart = restartRequired.length > 0 && !opts.noRestart;
                 if (!needsRestart && hot.length > 0) {
                   console.log(chalk.green("\n  (no restart needed, changes active next turn)"));
-                } else if (needsRestart && !opts.restart && !opts.gracefulRestart) {
+                } else if (needsRestart && !opts.restart && !opts.gracefulRestart && !autoRestart) {
                   console.log(chalk.gray(`\nRestart: switchroom agent restart ${n}`));
                   console.log(chalk.gray(`  (Or add --restart / --graceful-restart to this reconcile)`));
+                } else if (autoRestart) {
+                  console.log(chalk.cyan(`\n  Soul/config fields changed — restarting ${n} now.`));
+                  console.log(chalk.gray(`  (Pass --no-restart to skip.)`));
                 }
               } else {
                 // Fallback if changesBySemantics not available (shouldn't happen)
@@ -1244,7 +1251,16 @@ export function registerAgentCommand(program: Command): void {
               }
             }
 
-            if ((opts.restart || opts.gracefulRestart) && result.changes.length > 0) {
+            // Determine whether to restart: explicit flag, graceful flag, or auto-restart
+            // triggered by restart-required changes (soul fields, MCP, settings, etc.)
+            const changesBySemantics = result.changesBySemantics;
+            const autoRestartNeeded =
+              !opts.noRestart &&
+              changesBySemantics !== undefined &&
+              changesBySemantics.restartRequired.length > 0;
+            const shouldRestart = (opts.restart || opts.gracefulRestart || autoRestartNeeded) && result.changes.length > 0;
+
+            if (shouldRestart) {
               try {
                 // Summarise the files that changed (at most 3) so the
                 // greeting's Restarted row is meaningful rather than
@@ -1288,10 +1304,10 @@ export function registerAgentCommand(program: Command): void {
               `\nReconciled ${agentsTouched} agent(s), ${totalChanges} file(s) changed.`
             )
           );
-          if (!opts.restart) {
+          if (!opts.restart && !opts.gracefulRestart) {
             console.log(
               chalk.gray(
-                "  Tip: pass --restart to apply changes immediately, or run `switchroom agent restart <name>`."
+                "  Tip: soul/MCP/settings changes trigger an auto-restart. Pass --no-restart to defer, or --graceful-restart to wait for idle."
               )
             );
           }

--- a/tests/scaffold.hot-reload-stable.test.ts
+++ b/tests/scaffold.hot-reload-stable.test.ts
@@ -105,7 +105,7 @@ describe("hot-reload stable feature", () => {
       expect(hasDynamicHook).toBe(true);
     });
 
-    it("classifies stable workspace files as stale-till-restart", () => {
+    it("classifies SOUL.md as restart-required (soul changes need restart to take effect)", () => {
       const config = makeAgentConfig({
         soul: { name: "Bot", style: "helpful" },
         channels: {
@@ -126,8 +126,10 @@ describe("hot-reload stable feature", () => {
       // Reconcile
       const reconcileResult = reconcileAgent("test-agent", config, tmpDir, telegramConfig, switchroomConfig);
 
-      // SOUL.md should be in staleTillRestart, not hot
-      expect(reconcileResult.changesBySemantics?.staleTillRestart).toContain(soulMdPath);
+      // SOUL.md should be in restartRequired (not stale-till-restart, not hot) —
+      // soul fields are frozen at session launch and invisible until restart.
+      expect(reconcileResult.changesBySemantics?.restartRequired).toContain(soulMdPath);
+      expect(reconcileResult.changesBySemantics?.staleTillRestart).not.toContain(soulMdPath);
       expect(reconcileResult.changesBySemantics?.hot).not.toContain(soulMdPath);
     });
   });


### PR DESCRIPTION
## Summary

- Promotes `workspace/SOUL.md` and `workspace/SOUL.custom.md` from `stale-till-restart` to `restart-required` in `classifyChange()` (when `hotReloadStable` is false, the default). Soul fields are baked into `--append-system-prompt` at session launch and are invisible to the running agent until restart.
- When `hotReloadStable: true`, SOUL.md remains `hot` (the per-turn hook re-injects it anyway — no restart needed).
- The reconcile CLI action now auto-restarts when `changesBySemantics.restartRequired` is non-empty, so editing `soul.name` in `switchroom.yaml` and running `switchroom agent reconcile <agent>` picks up the change immediately.
- Adds `--no-restart` opt-out flag for users who want to defer the restart.
- Updates the existing `hotReloadStable: false` test that expected `stale-till-restart` for SOUL.md — it now correctly expects `restart-required`.

Closes #170

## Test plan

- [x] `npx vitest run tests/reconcile.persona.test.ts` — all 6 pass
- [x] `npx vitest run tests/restart-reconciles.test.ts` — all 7 pass
- [x] `npx vitest run tests/scaffold.test.ts` — all 123 pass
- [x] `npx vitest run tests/scaffold.hot-reload-stable.test.ts` — all 11 pass
- [x] Full suite: 2855 pass, 6 fail (pre-existing env failures in token-helpers + tmux tests)
- [x] `tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)