### PR TITLE
feat(vault): format hints + clearer broker-denied (#172, #173)

### DIFF
--- a/docs/vault-broker.md
+++ b/docs/vault-broker.md
@@ -1,0 +1,120 @@
+# Vault Broker — ACL model and access guide
+
+## What is the vault broker?
+
+The vault broker is a per-user daemon that holds the decrypted vault in memory
+and serves secrets to authorised **switchroom cron units** over a Unix socket
+(`~/.switchroom/vault-broker.sock`).  It avoids re-prompting for the vault
+passphrase on every scheduled run.
+
+The broker is **not** a general-purpose secret server.  It only serves callers
+it can positively identify as a switchroom cron unit — it does not serve
+interactive shells, Claude Code sessions, or arbitrary scripts.
+
+## Who can read from the broker?
+
+| Caller context | Broker access |
+|---|---|
+| systemd unit `switchroom-<agent>-cron-<N>.service` | Allowed if the requested key is in `schedule[N].secrets` |
+| Interactive shell (`switchroom vault get`) | **Denied** — use `--no-broker` |
+| Claude Code / agent session | **Denied** — use `--no-broker` |
+| Any other caller | **Denied** |
+
+Identity is established via Linux cgroup membership (peercred + `/proc`).
+When systemd starts a cron unit it places the process in a dedicated cgroup
+that it writes as root — processes cannot move themselves between cgroups, so
+the unit name is unspoofable.
+
+## Why are agents denied?
+
+The broker's ACL is misconfiguration protection, not a security boundary
+(see `docs/architecture.md`).  Allowing arbitrary agent sessions to read the
+vault would mean any skill or sub-agent could exfiltrate any secret.  Cron
+units receive only the keys explicitly listed in their `schedule[N].secrets`
+allowlist.
+
+Agent sessions are expected to receive secrets as environment variables
+injected by the cron job itself, not by querying the broker at runtime.
+
+## The `--no-broker` escape hatch
+
+For one-off interactive reads — debugging, scripting, manual key inspection —
+pass `--no-broker` to bypass the broker entirely and decrypt the vault file
+directly with your passphrase:
+
+```sh
+switchroom vault get my-key --no-broker
+```
+
+This prompts for the vault passphrase (or reads `SWITCHROOM_VAULT_PASSPHRASE`
+from the environment) and reads the vault file directly.  It does not require
+the broker to be running.
+
+## Recognising a broker denial in script output
+
+When a script or sub-process calls `switchroom vault get` and the broker
+denies the request, the CLI writes a clearly-prefixed error to **stderr**:
+
+```
+VAULT-BROKER-DENIED [DENIED]: caller is not a switchroom cron unit; use 'switchroom vault get --no-broker' for interactive access
+Hint: run 'switchroom vault get --no-broker <key>' for interactive (non-cron) access.
+```
+
+Exit code is **2** for an ACL denial, **3** for a locked broker.
+
+Scripts that capture subprocess output should grep stderr for the
+`VAULT-BROKER-DENIED` prefix to detect and surface this error rather than
+swallowing it.
+
+## Format hints (`--format` / `--expect`)
+
+Vault entries can carry an optional format annotation set at write time:
+
+```sh
+# Store a PEM private key and annotate it
+switchroom vault set my-key --format pem < key.pem
+
+# Store a 32-byte raw seed (base64-encoded)
+switchroom vault set my-key --format base64-raw-seed < seed.b64
+```
+
+Allowed format values: `pem`, `base64-raw-seed`, `base64`, `json`, `string`
+(default).
+
+At read time, consumers can declare what they expect:
+
+```sh
+switchroom vault get my-key --expect pem
+```
+
+If the stored format does not match `--expect`, the CLI writes a
+`VAULT-FORMAT-MISMATCH` warning to stderr and continues (warn-and-proceed).
+Pass `--strict-format` to turn the mismatch into a hard exit-4 failure.
+
+## Configuring secrets for cron access
+
+In `switchroom.yaml`, list the vault keys each scheduled run is allowed to
+read:
+
+```yaml
+agents:
+  myagent:
+    schedule:
+      - cron: "0 8 * * *"
+        prompt: "Run the daily job"
+        secrets:
+          - my-api-key
+          - other-token
+```
+
+The broker enforces this list exactly: `switchroom-myagent-cron-0.service` may
+read `my-api-key` and `other-token` but nothing else.
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| `VAULT-BROKER-DENIED [DENIED]: caller is not a switchroom cron unit` | Running interactively or in an agent session | Add `--no-broker` |
+| `broker locked and stdin is not a TTY` | Broker running but not yet unlocked | Unlock with `switchroom vault broker unlock` or wait for the next passphrase prompt |
+| `broker socket not found` | Broker daemon not running | Start with `switchroom vault broker start` |
+| `VAULT-FORMAT-MISMATCH` | Stored format differs from `--expect` | Re-store with correct `--format`, or convert the value |

--- a/src/cli/vault.ts
+++ b/src/cli/vault.ts
@@ -10,7 +10,11 @@ import {
   getSecret,
   listSecrets,
   removeSecret,
+  validateFormatHint,
+  detectFormat,
+  VAULT_FORMAT_HINTS,
   VaultError,
+  type VaultFormatHint,
 } from "../vault/vault.js";
 import { registerVaultSweep } from "./vault-sweep.js";
 import {
@@ -117,6 +121,24 @@ async function getPassphrase(confirm = false): Promise<string> {
   return passphrase;
 }
 
+/**
+ * Return a human-readable conversion suggestion when a stored format does not
+ * match the expected format.  Returns an empty string when no known conversion
+ * path exists.
+ */
+function conversionHint(stored: VaultFormatHint, expected: VaultFormatHint): string {
+  if (stored === "base64-raw-seed" && expected === "pem") {
+    return (
+      "Convert with: openssl genpkey -algorithm ed25519 " +
+      "(or wrap the raw seed with your key type's PEM encoder)."
+    );
+  }
+  if (stored === "pem" && expected === "base64-raw-seed") {
+    return "Extract the raw seed from the PEM with: openssl pkey -in key.pem -outform DER | tail -c 32 | base64";
+  }
+  return "";
+}
+
 export function registerVaultCommand(program: Command): void {
   const vault = program
     .command("vault")
@@ -149,10 +171,29 @@ export function registerVaultCommand(program: Command): void {
       "-f, --file <path>",
       "Read the secret value from a file (preserves multi-line content)"
     )
-    .action(async (key: string, opts: { file?: string }) => {
+    .option(
+      "--format <kind>",
+      `Annotate the stored value with a format hint (${VAULT_FORMAT_HINTS.join(", ")}). The hint is validated against the value at set time and checked against --expect at get time.`
+    )
+    .action(async (key: string, opts: { file?: string; format?: string }) => {
       try {
         const parentOpts = program.opts();
         const vaultPath = getVaultPath(parentOpts.config);
+
+        // Validate --format value early so we fail before prompting for passphrase.
+        let formatHint: VaultFormatHint | undefined;
+        if (opts.format !== undefined) {
+          if (!(VAULT_FORMAT_HINTS as readonly string[]).includes(opts.format)) {
+            console.error(
+              chalk.red(
+                `Error: unknown format '${opts.format}'. Allowed values: ${VAULT_FORMAT_HINTS.join(", ")}`
+              )
+            );
+            process.exit(1);
+          }
+          formatHint = opts.format as VaultFormatHint;
+        }
+
         // When stdin is piped we need to consume it for the secret value,
         // so the passphrase must come from the env var rather than a prompt.
         if (!process.stdin.isTTY && !process.env.SWITCHROOM_VAULT_PASSPHRASE && !opts.file) {
@@ -190,8 +231,23 @@ export function registerVaultCommand(program: Command): void {
           process.exit(1);
         }
 
-        setStringSecret(passphrase, vaultPath, key, value);
-        console.log(chalk.green(`✓ Secret '${key}' saved`));
+        // Validate the value against the declared format hint.
+        if (formatHint) {
+          const validationError = validateFormatHint(value, formatHint);
+          if (validationError) {
+            console.error(
+              chalk.red(`Error: format validation failed for --format ${formatHint}: ${validationError}`)
+            );
+            process.exit(1);
+          }
+        }
+
+        setStringSecret(passphrase, vaultPath, key, value, formatHint);
+        if (formatHint) {
+          console.log(chalk.green(`✓ Secret '${key}' saved (format: ${formatHint})`));
+        } else {
+          console.log(chalk.green(`✓ Secret '${key}' saved`));
+        }
       } catch (err) {
         if (err instanceof VaultError || err instanceof Error) {
           console.error(chalk.red(`Error: ${err.message}`));
@@ -204,10 +260,75 @@ export function registerVaultCommand(program: Command): void {
   vault
     .command("get <key>")
     .description("Get a secret from the vault (tries broker first)")
-    .option("--no-broker", "Bypass the broker and read directly from the vault file")
-    .action(async (key: string, opts: { broker?: boolean }) => {
+    .option("--no-broker", "Bypass the broker and read directly from the vault file. Required for interactive (non-cron) access — the broker only serves switchroom cron units.")
+    .option(
+      "--expect <format>",
+      `Warn if the stored format hint does not match. Allowed values: ${VAULT_FORMAT_HINTS.join(", ")}. Exits with code 4 on mismatch (warn-and-proceed is the default; use --strict-format to fail-closed).`
+    )
+    .option(
+      "--strict-format",
+      "When combined with --expect, exit with code 4 instead of warning-and-proceeding on a format mismatch."
+    )
+    .action(async (key: string, opts: { broker?: boolean; expect?: string; strictFormat?: boolean }) => {
       const useBroker = opts.broker !== false;
       const parentOpts = program.opts();
+
+      // Validate --expect value early.
+      let expectFormat: VaultFormatHint | undefined;
+      if (opts.expect !== undefined) {
+        if (!(VAULT_FORMAT_HINTS as readonly string[]).includes(opts.expect)) {
+          console.error(
+            chalk.red(
+              `Error: unknown format '${opts.expect}' for --expect. Allowed values: ${VAULT_FORMAT_HINTS.join(", ")}`
+            )
+          );
+          process.exit(1);
+        }
+        expectFormat = opts.expect as VaultFormatHint;
+      }
+
+      /**
+       * Check format hint on a retrieved entry and warn (or fail) on mismatch.
+       * Returns false if the caller should exit (strict-format + mismatch).
+       */
+      function checkFormatExpectation(entry: { kind: string; value?: string; format?: VaultFormatHint }): boolean {
+        if (!expectFormat) return true;
+        if (entry.kind !== "string" && entry.kind !== "binary") return true;
+
+        const storedFormat = (entry as { format?: VaultFormatHint }).format;
+
+        // Primary check: stored format hint vs expected
+        if (storedFormat && storedFormat !== expectFormat) {
+          const hint = conversionHint(storedFormat, expectFormat);
+          const msg =
+            `VAULT-FORMAT-MISMATCH: secret '${key}' was stored as format '${storedFormat}' ` +
+            `but caller expects '${expectFormat}'.` +
+            (hint ? ` ${hint}` : "");
+          process.stderr.write(msg + "\n");
+          if (opts.strictFormat) {
+            process.exit(4);
+          }
+          return true; // warn-and-proceed
+        }
+
+        // Secondary check: no stored hint — detect from value content
+        if (!storedFormat && entry.value !== undefined) {
+          const detected = detectFormat(entry.value);
+          if (detected && detected !== expectFormat) {
+            const hint = conversionHint(detected, expectFormat);
+            const msg =
+              `VAULT-FORMAT-MISMATCH: secret '${key}' has no stored format hint but value ` +
+              `looks like '${detected}', not '${expectFormat}'.` +
+              (hint ? ` ${hint}` : "");
+            process.stderr.write(msg + "\n");
+            if (opts.strictFormat) {
+              process.exit(4);
+            }
+          }
+        }
+
+        return true;
+      }
 
       // ── Broker routing ──────────────────────────────────────────────────
       if (useBroker) {
@@ -237,6 +358,7 @@ export function registerVaultCommand(program: Command): void {
                   process.exit(1);
                 }
                 if (entry.kind === "string" || entry.kind === "binary") {
+                  checkFormatExpectation(entry);
                   console.log(entry.value);
                 } else {
                   console.error(chalk.yellow(`Secret '${key}' is kind="${entry.kind}"`));
@@ -261,7 +383,12 @@ export function registerVaultCommand(program: Command): void {
                 throw err;
               }
             } else {
-              console.error("broker locked and stdin is not a TTY");
+              // Non-TTY + broker locked: write a clearly-prefixed error to
+              // stderr so agents/scripts surfacing captured output can grep it.
+              process.stderr.write(
+                `VAULT-BROKER-DENIED: broker locked and stdin is not a TTY; ` +
+                `use 'switchroom vault get --no-broker' for interactive access\n`
+              );
               process.exit(3);
             }
           }
@@ -272,6 +399,7 @@ export function registerVaultCommand(program: Command): void {
           if (result.kind === "ok") {
             const entry = result.entry;
             if (entry.kind === "string" || entry.kind === "binary") {
+              checkFormatExpectation(entry);
               console.log(entry.value);
               return;
             }
@@ -290,7 +418,8 @@ export function registerVaultCommand(program: Command): void {
             // ACL rejection or vault locked. For interactive callers, fall
             // through to direct vault decrypt with the user's passphrase
             // (--no-broker semantics). For non-interactive callers, fail
-            // with the broker's reason so cron logs explain it.
+            // with a clearly-prefixed error so captured subprocess output
+            // is still actionable (issue #173).
             if (process.stdin.isTTY) {
               console.error(
                 chalk.yellow(
@@ -300,8 +429,12 @@ export function registerVaultCommand(program: Command): void {
               );
               // fall through to direct-decrypt block below
             } else {
-              console.error(
-                `broker denied request for '${key}' (${result.code}): ${result.msg}`,
+              // Write a VAULT-BROKER-DENIED prefix so scripts/agents that
+              // capture stdout/stderr can grep for it even when the full
+              // message isn't surfaced in their UI.
+              process.stderr.write(
+                `VAULT-BROKER-DENIED [${result.code}]: ${result.msg}\n` +
+                `Hint: run 'switchroom vault get --no-broker ${key}' for interactive (non-cron) access.\n`
               );
               process.exit(2);
             }
@@ -322,7 +455,10 @@ export function registerVaultCommand(program: Command): void {
 
         // Broker not reachable
         if (!process.stdin.isTTY && !process.env.SWITCHROOM_VAULT_PASSPHRASE) {
-          console.error("broker not running and stdin is not a TTY");
+          process.stderr.write(
+            `VAULT-BROKER-DENIED: broker not running and stdin is not a TTY; ` +
+            `use 'switchroom vault get --no-broker ${key}' for interactive access\n`
+          );
           process.exit(1);
         }
         // Fall through to direct vault access with passphrase prompt (or env var)
@@ -340,6 +476,7 @@ export function registerVaultCommand(program: Command): void {
         }
 
         if (entry.kind === "string" || entry.kind === "binary") {
+          checkFormatExpectation(entry);
           console.log(entry.value);
         } else {
           console.error(

--- a/src/vault/vault.ts
+++ b/src/vault/vault.ts
@@ -41,9 +41,39 @@ export class VaultError extends Error {
   }
 }
 
+/**
+ * Format hints for vault entries (issue #172).
+ *
+ * Stored alongside the value as an opt-in annotation set via
+ * `switchroom vault set --format <kind>`.  Consumers can pass
+ * `--expect <kind>` at get-time to get an early warning when the stored
+ * format does not match what they need.
+ *
+ * Allowed values:
+ *   pem            — PEM-encoded key or certificate (-----BEGIN …-----)
+ *   base64-raw-seed — 32-byte raw seed, base64-encoded (no PEM wrapper)
+ *   base64         — arbitrary base64-encoded binary (no structural meaning)
+ *   json           — UTF-8 JSON text
+ *   string         — plain text (the default; no structural meaning)
+ */
+export type VaultFormatHint =
+  | "pem"
+  | "base64-raw-seed"
+  | "base64"
+  | "json"
+  | "string";
+
+export const VAULT_FORMAT_HINTS: VaultFormatHint[] = [
+  "pem",
+  "base64-raw-seed",
+  "base64",
+  "json",
+  "string",
+];
+
 export type VaultEntry =
-  | { kind: "string"; value: string }
-  | { kind: "binary"; value: string }
+  | { kind: "string"; value: string; format?: VaultFormatHint }
+  | { kind: "binary"; value: string; format?: VaultFormatHint }
   | {
       kind: "files";
       files: Record<string, { encoding: "utf8" | "base64"; value: string }>;
@@ -115,6 +145,94 @@ function normalizeSecrets(raw: StoredSecrets): Record<string, VaultEntry> {
     out[k] = normalizeEntry(v);
   }
   return out;
+}
+
+/**
+ * Validate that a value's content matches the claimed format hint.
+ *
+ * Returns null on success or an error string describing the mismatch.
+ * Only called at `set` time when the caller passes `--format`.
+ */
+export function validateFormatHint(
+  value: string,
+  format: VaultFormatHint,
+): string | null {
+  switch (format) {
+    case "pem": {
+      const trimmed = value.trim();
+      if (
+        !trimmed.startsWith("-----BEGIN ") ||
+        !trimmed.includes("-----END ")
+      ) {
+        return `value does not look like PEM (expected -----BEGIN ...-----)`;
+      }
+      return null;
+    }
+    case "base64-raw-seed": {
+      // Must be valid base64, decoding to 32 bytes (256-bit seed)
+      const trimmed = value.trim();
+      try {
+        const decoded = Buffer.from(trimmed, "base64");
+        if (decoded.length !== 32) {
+          return `expected a 32-byte base64-raw-seed but decoded to ${decoded.length} bytes`;
+        }
+      } catch {
+        return `value is not valid base64`;
+      }
+      return null;
+    }
+    case "base64": {
+      const trimmed = value.trim();
+      try {
+        Buffer.from(trimmed, "base64");
+      } catch {
+        return `value is not valid base64`;
+      }
+      return null;
+    }
+    case "json": {
+      try {
+        JSON.parse(value);
+      } catch {
+        return `value is not valid JSON`;
+      }
+      return null;
+    }
+    case "string":
+      // No structural validation for plain strings
+      return null;
+    default:
+      return null;
+  }
+}
+
+/**
+ * Detect the most likely format of a stored value for mismatch-warning
+ * purposes.  This is a best-effort heuristic; it returns the detected
+ * VaultFormatHint or null when uncertain.
+ */
+export function detectFormat(value: string): VaultFormatHint | null {
+  const trimmed = value.trim();
+  if (trimmed.startsWith("-----BEGIN ") && trimmed.includes("-----END ")) {
+    return "pem";
+  }
+  // Try to detect a 32-byte base64 seed (43 or 44 chars with optional = padding)
+  if (/^[A-Za-z0-9+/]{43}={0,1}$/.test(trimmed)) {
+    try {
+      const decoded = Buffer.from(trimmed, "base64");
+      if (decoded.length === 32) return "base64-raw-seed";
+    } catch { /* ignore */ }
+  }
+  // Try generic base64
+  if (/^[A-Za-z0-9+/\n\r]+=*$/.test(trimmed) && trimmed.length > 0) {
+    return "base64";
+  }
+  // Try JSON
+  try {
+    JSON.parse(value);
+    return "json";
+  } catch { /* ignore */ }
+  return null;
 }
 
 export function createVault(passphrase: string, vaultPath: string): void {
@@ -235,9 +353,13 @@ export function setStringSecret(
   passphrase: string,
   vaultPath: string,
   key: string,
-  value: string
+  value: string,
+  format?: VaultFormatHint,
 ): void {
-  setSecret(passphrase, vaultPath, key, { kind: "string", value });
+  const entry: VaultEntry = format
+    ? { kind: "string", value, format }
+    : { kind: "string", value };
+  setSecret(passphrase, vaultPath, key, entry);
 }
 
 export function getStringSecret(

--- a/tests/vault.test.ts
+++ b/tests/vault.test.ts
@@ -15,8 +15,12 @@ import {
   getStringSecret,
   listSecrets,
   removeSecret,
+  validateFormatHint,
+  detectFormat,
+  VAULT_FORMAT_HINTS,
   VaultError,
   type VaultEntry,
+  type VaultFormatHint,
 } from "../src/vault/vault.js";
 import {
   isVaultReference,
@@ -579,5 +583,236 @@ describe("vault resolver", () => {
       expect(existsSync(join(dir2, "stale.txt"))).toBe(false);
       expect(existsSync(join(dir2, "oauth_token.json"))).toBe(true);
     });
+  });
+});
+
+// ─── Issue #172: format hints ────────────────────────────────────────────────
+
+describe("validateFormatHint", () => {
+  it("accepts a valid PEM string", () => {
+    const pem =
+      "-----BEGIN PRIVATE KEY-----\nMIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEA\n-----END PRIVATE KEY-----\n";
+    expect(validateFormatHint(pem, "pem")).toBeNull();
+  });
+
+  it("rejects a non-PEM value for --format pem", () => {
+    expect(validateFormatHint("not pem", "pem")).toMatch(/PEM/);
+  });
+
+  it("accepts a valid 32-byte base64-raw-seed", () => {
+    const seed = Buffer.alloc(32).toString("base64"); // 32 zero bytes
+    expect(validateFormatHint(seed, "base64-raw-seed")).toBeNull();
+  });
+
+  it("rejects a short base64 value for --format base64-raw-seed", () => {
+    const short = Buffer.alloc(16).toString("base64"); // only 16 bytes
+    const result = validateFormatHint(short, "base64-raw-seed");
+    expect(result).toMatch(/32-byte/);
+  });
+
+  it("accepts valid base64 for --format base64", () => {
+    expect(validateFormatHint(Buffer.alloc(20).toString("base64"), "base64")).toBeNull();
+  });
+
+  it("accepts valid JSON for --format json", () => {
+    expect(validateFormatHint('{"key":"value"}', "json")).toBeNull();
+  });
+
+  it("rejects invalid JSON for --format json", () => {
+    expect(validateFormatHint("not json", "json")).toMatch(/JSON/i);
+  });
+
+  it("accepts anything for --format string", () => {
+    expect(validateFormatHint("any text at all", "string")).toBeNull();
+  });
+});
+
+describe("detectFormat", () => {
+  it("detects PEM strings", () => {
+    const pem = "-----BEGIN PRIVATE KEY-----\nMIIEvQI=\n-----END PRIVATE KEY-----\n";
+    expect(detectFormat(pem)).toBe("pem");
+  });
+
+  it("detects a 32-byte base64-raw-seed", () => {
+    const seed = Buffer.alloc(32).toString("base64");
+    expect(detectFormat(seed)).toBe("base64-raw-seed");
+  });
+
+  it("returns null for plain text", () => {
+    expect(detectFormat("hello world")).toBeNull();
+  });
+});
+
+describe("format hint roundtrip via setStringSecret / getSecret", () => {
+  let tmpDir: string;
+  let vaultPath: string;
+  const passphrase = "fmt-test-pass";
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "switchroom-fmt-test-"));
+    vaultPath = join(tmpDir, "vault.enc");
+    createVault(passphrase, vaultPath);
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("stores and retrieves the format hint", () => {
+    const pem =
+      "-----BEGIN PRIVATE KEY-----\nMIIEvQI=\n-----END PRIVATE KEY-----\n";
+    setStringSecret(passphrase, vaultPath, "mykey", pem, "pem");
+
+    const entry = getSecret(passphrase, vaultPath, "mykey");
+    expect(entry).not.toBeNull();
+    expect(entry?.kind).toBe("string");
+    if (entry?.kind === "string") {
+      expect(entry.format).toBe("pem");
+      expect(entry.value).toBe(pem);
+    }
+  });
+
+  it("entries without a format hint have format=undefined", () => {
+    setStringSecret(passphrase, vaultPath, "plain", "hello");
+    const entry = getSecret(passphrase, vaultPath, "plain");
+    expect(entry?.kind).toBe("string");
+    if (entry?.kind === "string") {
+      expect(entry.format).toBeUndefined();
+    }
+  });
+
+  it("all VAULT_FORMAT_HINTS are listed and non-empty", () => {
+    expect(VAULT_FORMAT_HINTS.length).toBeGreaterThan(0);
+    for (const hint of VAULT_FORMAT_HINTS) {
+      expect(hint).toBeTruthy();
+    }
+  });
+});
+
+// ─── Issue #172: vault set CLI --format integration ──────────────────────────
+
+describe("vault set CLI --format integration", () => {
+  const binPath = fileURLToPath(new URL("../bin/switchroom.ts", import.meta.url));
+  const passphrase = "fmt-cli-test-passphrase";
+  let tmpDir: string;
+  let vaultPath: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "switchroom-fmt-cli-test-"));
+    vaultPath = join(tmpDir, "vault.enc");
+    createVault(passphrase, vaultPath);
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function runCli(args: string[], input?: string) {
+    const configPath = join(tmpDir, "switchroom.yaml");
+    writeFileSync(
+      configPath,
+      `switchroom:\n  version: 1\n  agents_dir: ${tmpDir}/agents\nvault:\n  path: ${vaultPath}\ntelegram:\n  bot_token: x\n  forum_chat_id: "-1"\nagents: {}\n`
+    );
+    return spawnSync(
+      "bun",
+      [binPath, "--config", configPath, "vault", ...args],
+      {
+        input,
+        env: { ...process.env, SWITCHROOM_VAULT_PASSPHRASE: passphrase },
+        encoding: "utf8",
+      }
+    );
+  }
+
+  it("stores format hint when --format pem is passed with a valid PEM", () => {
+    const pem =
+      "-----BEGIN PRIVATE KEY-----\nMIIEvQIBADANBgkqhkiG9w0BAQEFAAS\n-----END PRIVATE KEY-----\n";
+    const result = runCli(["set", "pem-key", "--format", "pem"], pem);
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("format: pem");
+
+    const entry = getSecret(passphrase, vaultPath, "pem-key");
+    expect(entry?.kind).toBe("string");
+    if (entry?.kind === "string") {
+      expect(entry.format).toBe("pem");
+    }
+  });
+
+  it("rejects a non-PEM value with --format pem and exits non-zero", () => {
+    const result = runCli(["set", "bad-key", "--format", "pem"], "not a pem value");
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toMatch(/format validation failed/);
+  });
+
+  it("rejects an unknown --format value", () => {
+    const result = runCli(["set", "x", "--format", "unknown-format"], "value");
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toMatch(/unknown format/);
+  });
+
+  it("vault get --expect warns to stderr when stored format mismatches", () => {
+    // Store a seed but tell the consumer it's a PEM
+    const seed = Buffer.alloc(32).toString("base64");
+    const setResult = runCli(["set", "seed-key", "--format", "base64-raw-seed"], seed);
+    expect(setResult.status).toBe(0);
+
+    // Get with --expect pem should warn but still print the value (warn-and-proceed)
+    const getResult = runCli(["get", "seed-key", "--expect", "pem", "--no-broker"]);
+    expect(getResult.status).toBe(0);
+    expect(getResult.stderr).toMatch(/VAULT-FORMAT-MISMATCH/);
+  });
+
+  it("vault get --expect --strict-format exits 4 on mismatch", () => {
+    const seed = Buffer.alloc(32).toString("base64");
+    runCli(["set", "seed-key2", "--format", "base64-raw-seed"], seed);
+
+    const getResult = runCli(["get", "seed-key2", "--expect", "pem", "--strict-format", "--no-broker"]);
+    expect(getResult.status).toBe(4);
+    expect(getResult.stderr).toMatch(/VAULT-FORMAT-MISMATCH/);
+  });
+
+  it("vault get --expect passes when formats match", () => {
+    const pem =
+      "-----BEGIN PRIVATE KEY-----\nMIIEvQIBADANBgkqhkiG9w0BAQEFAAS\n-----END PRIVATE KEY-----\n";
+    runCli(["set", "ok-pem", "--format", "pem"], pem);
+
+    const getResult = runCli(["get", "ok-pem", "--expect", "pem", "--no-broker"]);
+    expect(getResult.status).toBe(0);
+    expect(getResult.stderr).not.toMatch(/VAULT-FORMAT-MISMATCH/);
+  });
+}, 30_000);
+
+// ─── Issue #173: broker-denied error surface ──────────────────────────────────
+
+describe("broker-denied error message format", () => {
+  it("VAULT-BROKER-DENIED prefix is stable (grep-friendly)", () => {
+    // The prefix is a contract — scripts grep for it. Verify it appears in
+    // the ACL deny path by simulating a non-TTY caller against a running
+    // broker that will deny them.
+    //
+    // Rather than spinning up a real broker (covered by the integration
+    // test), we verify the prefix is used in the cli/vault.ts source via
+    // a string match — the prefix must not be changed without updating the
+    // docs and this test.
+    const src = require("node:fs").readFileSync(
+      require("node:path").join(
+        require("node:url").fileURLToPath(new URL("../src/cli/vault.ts", import.meta.url))
+      ),
+      "utf8"
+    ) as string;
+    expect(src).toContain("VAULT-BROKER-DENIED");
+    // The prefix should appear in both the "locked" and "denied" paths.
+    const count = (src.match(/VAULT-BROKER-DENIED/g) ?? []).length;
+    expect(count).toBeGreaterThanOrEqual(2);
+  });
+
+  it("VAULT-FORMAT-MISMATCH prefix appears in vault CLI source", () => {
+    const src = require("node:fs").readFileSync(
+      require("node:path").join(
+        require("node:url").fileURLToPath(new URL("../src/cli/vault.ts", import.meta.url))
+      ),
+      "utf8"
+    ) as string;
+    expect(src).toContain("VAULT-FORMAT-MISMATCH");
   });
 });


### PR DESCRIPTION
## Summary

- **#172 — vault format hints**: `vault set` gains `--format <kind>` (validates at write time, stores hint in entry metadata). `vault get` gains `--expect <format>` (warns on mismatch via `VAULT-FORMAT-MISMATCH` prefix to stderr; `--strict-format` exits 4). Supported values: `pem`, `base64-raw-seed`, `base64`, `json`, `string`.
- **#173 — broker-denied surfacing**: All broker-deny paths now write a `VAULT-BROKER-DENIED [CODE]:` prefixed line to stderr so agents/scripts that capture subprocess output can grep for it. Added `docs/vault-broker.md` documenting the ACL model, who gets denied and why, the `--no-broker` escape hatch, and format hints.

## Test plan

- [ ] `vault set --format pem` validates PEM structure; rejects non-PEM
- [ ] `vault set --format base64-raw-seed` validates 32-byte seed; rejects short values
- [ ] `vault set --format unknown-format` exits non-zero with "unknown format" error
- [ ] `vault get --expect pem` warns (`VAULT-FORMAT-MISMATCH`) when stored format differs
- [ ] `vault get --expect pem --strict-format` exits 4 on mismatch
- [ ] `vault get --expect pem` passes cleanly when stored format matches
- [ ] Format hint roundtrips: stored hint survives vault encrypt/decrypt cycle
- [ ] `VAULT-BROKER-DENIED` prefix appears in locked + denied paths in source
- [ ] All existing vault tests (60 tests) still pass
- [ ] ACL + broker integration tests still pass

Closes #172
Closes #173

🤖 Generated with [Claude Code](https://claude.com/claude-code)