### PR TITLE
fix(auth-status): lazy sync + restart settle for meta race (#171, #176)

### DIFF
--- a/src/auth/manager.ts
+++ b/src/auth/manager.ts
@@ -21,6 +21,7 @@ import {
   pickFallbackSlot,
   readActiveSlot,
   removeSlot,
+  slotTokenPath,
   suggestSlotName,
   syncLegacyFromActive,
   useSlot,
@@ -473,6 +474,23 @@ function readCredentials(agentDir: string): CredentialsFile["claudeAiOauth"] | n
 export function getAuthStatus(name: string, agentDir: string): AuthStatus {
   const pendingAuth = hasPendingAuthSession(name, agentDir);
   const creds = readCredentials(agentDir);
+
+  // Lazy-sync fix (#171): if the legacy .oauth-token mirror is absent but an
+  // active slot token exists, mirror it now.  This closes the race where the
+  // accounts/ slot was written (e.g. during scaffold) but syncLegacyFromActive
+  // hadn't run yet — legacy path was empty → status read "✗" until the next
+  // restart actually mirrored the file.
+  if (!existsSync(oauthTokenPath(agentDir))) {
+    const activeSlot = readActiveSlot(agentDir);
+    if (activeSlot && existsSync(slotTokenPath(agentDir, activeSlot))) {
+      try {
+        syncLegacyFromActive(agentDir);
+      } catch {
+        // best-effort — if sync fails, fall through to credential check below
+      }
+    }
+  }
+
   const oauthToken = readOAuthToken(agentDir);
 
   if (oauthToken) {

--- a/src/cli/restart.ts
+++ b/src/cli/restart.ts
@@ -1,10 +1,39 @@
 import type { Command } from "commander";
 import chalk from "chalk";
+import { resolve } from "node:path";
 import { withConfigError, getConfig, getConfigPath } from "./helpers.js";
 import { resolveAgentsDir } from "../config/loader.js";
 import { restartAgent, writeRestartReasonMarker, getAgentStatus } from "../agents/lifecycle.js";
 import { reconcileAndRestartAgent } from "./agent.js";
 import { printHealthSummary } from "./version.js";
+import { getAuthStatus } from "../auth/manager.js";
+
+/**
+ * Poll auth status for `name` until it reads authenticated=true, up to
+ * `timeoutMs` (default 30 s).  Returns true if auth converged within the
+ * window, false if it timed out.  Fixes #176: restart now blocks until auth
+ * status reflects reality so `switchroom restart && switchroom auth status`
+ * shows ✓ without a second manual run.
+ */
+function waitForAuthConverge(
+  name: string,
+  agentDir: string,
+  timeoutMs = 30_000,
+  intervalMs = 1_000,
+): boolean {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      const s = getAuthStatus(name, agentDir);
+      if (s.authenticated) return true;
+    } catch {
+      // ignore transient errors during settle window
+    }
+    // Synchronous sleep — restart command is already blocking on systemctl.
+    Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, intervalMs);
+  }
+  return false;
+}
 
 /**
  * `switchroom restart [agent]`
@@ -79,6 +108,24 @@ export function registerRestartCommand(program: Command): void {
               }
             } else {
               console.log(chalk.green(`  ${name}: restarted`));
+            }
+
+            // Auth-settling wait (#176): after a synchronous restart, poll
+            // until auth status converges so the very next `auth status` run
+            // shows the correct value without a manual retry.  Only applies
+            // when the restart actually completed (not "waiting for turn") —
+            // for scheduled restarts auth settles asynchronously.
+            const didRestart = res.restarted || !graceful;
+            if (didRestart) {
+              const agentDir = resolve(agentsDir, name);
+              const converged = waitForAuthConverge(name, agentDir);
+              if (!converged) {
+                console.log(
+                  chalk.yellow(
+                    `  ${name}: agent is up but auth status didn't converge in 30s — check logs`,
+                  ),
+                );
+              }
             }
           } catch (err) {
             console.error(chalk.red(`  ${name}: restart failed: ${(err as Error).message}`));

--- a/tests/auth.status-settling.test.ts
+++ b/tests/auth.status-settling.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Tests for the bounded-poll auth-settling behaviour introduced by #171 / #176.
+ *
+ * The two issues describe the same underlying race from different angles:
+ *   #171 — meta file absent right after scaffold → status shows ✗
+ *   #176 — after `switchroom restart`, status shows stale values for ~10-30 s
+ *
+ * The primary fix lives in two places:
+ *   1. getAuthStatus()  — lazy-sync of the legacy .oauth-token mirror when the
+ *      accounts/ slot token exists but the legacy path doesn't (tested here).
+ *   2. registerRestartCommand() — waitForAuthConverge() blocks the restart CLI
+ *      until getAuthStatus() returns authenticated=true (tested here via the
+ *      getAuthStatus primitive, since waitForAuthConverge() is internal).
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import {
+  mkdirSync,
+  writeFileSync,
+  rmSync,
+  existsSync,
+} from "node:fs";
+import { resolve } from "node:path";
+import { tmpdir } from "node:os";
+import { getAuthStatus } from "../src/auth/manager.js";
+
+describe("auth status settling (#171 / #176)", () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = resolve(tmpdir(), `switchroom-auth-settle-test-${Date.now()}`);
+    mkdirSync(resolve(tempDir, ".claude"), { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("converges to authenticated=true within one call when slot token exists but legacy mirror is absent", () => {
+    // Reproduce the #171 race:
+    //   - accounts/default/.oauth-token written by submitAuthCode
+    //   - .claude/.oauth-token (legacy mirror) NOT yet created
+    //   - getAuthStatus() must lazy-sync and return authenticated=true
+    const accountsDir = resolve(tempDir, ".claude", "accounts", "default");
+    mkdirSync(accountsDir, { recursive: true });
+
+    const expiresAt = Date.now() + 365 * 24 * 60 * 60_000;
+    writeFileSync(
+      resolve(accountsDir, ".oauth-token"),
+      "sk-ant-oat01-settle-test\n",
+      { mode: 0o600 },
+    );
+    writeFileSync(
+      resolve(accountsDir, ".oauth-token.meta.json"),
+      JSON.stringify({ createdAt: Date.now(), expiresAt, source: "claude-setup-token" }),
+      { mode: 0o600 },
+    );
+    writeFileSync(resolve(tempDir, ".claude", "active"), "default\n", { mode: 0o600 });
+
+    // Legacy mirror absent — this is the "first call before restart mirrored it"
+    expect(existsSync(resolve(tempDir, ".claude", ".oauth-token"))).toBe(false);
+
+    const status = getAuthStatus("settle-agent", tempDir);
+
+    // Must report authenticated on the FIRST call — no manual retry needed.
+    expect(status.authenticated).toBe(true);
+    expect(status.source).toBe("oauth-token");
+  });
+
+  it("returns authenticated=false when no token exists at all (not a false-positive)", () => {
+    // Guard: no slot, no legacy file — must NOT return authenticated.
+    const status = getAuthStatus("empty-agent", tempDir);
+    expect(status.authenticated).toBe(false);
+  });
+
+  it("returns authenticated=false when slot token exists but active marker is absent", () => {
+    // Without the active marker, lazy-sync can't know which slot to mirror.
+    // Must fall through gracefully rather than crash.
+    const accountsDir = resolve(tempDir, ".claude", "accounts", "default");
+    mkdirSync(accountsDir, { recursive: true });
+    writeFileSync(
+      resolve(accountsDir, ".oauth-token"),
+      "sk-ant-oat01-no-active\n",
+      { mode: 0o600 },
+    );
+    // No active marker file.
+
+    const status = getAuthStatus("no-active-agent", tempDir);
+    // Without knowing the active slot, legacy sync can't run → no oauth token.
+    expect(status.authenticated).toBe(false);
+  });
+
+  it("simulates #176 polling loop: repeated getAuthStatus calls converge once token is mirrored", () => {
+    // Simulate the window where restart has completed but the legacy mirror
+    // hasn't been written yet.  A tight waitForAuthConverge() loop calls
+    // getAuthStatus() repeatedly.  On the first call with the fix the lazy-sync
+    // mirrors the slot token → converged immediately.
+    //
+    // This test verifies idempotence: calling getAuthStatus() multiple times
+    // in quick succession all return the same settled result.
+    const accountsDir = resolve(tempDir, ".claude", "accounts", "default");
+    mkdirSync(accountsDir, { recursive: true });
+
+    const expiresAt = Date.now() + 365 * 24 * 60 * 60_000;
+    writeFileSync(
+      resolve(accountsDir, ".oauth-token"),
+      "sk-ant-oat01-poll-test\n",
+      { mode: 0o600 },
+    );
+    writeFileSync(
+      resolve(accountsDir, ".oauth-token.meta.json"),
+      JSON.stringify({ createdAt: Date.now(), expiresAt, source: "claude-setup-token" }),
+      { mode: 0o600 },
+    );
+    writeFileSync(resolve(tempDir, ".claude", "active"), "default\n", { mode: 0o600 });
+
+    // Three back-to-back calls (like the poll loop in waitForAuthConverge).
+    for (let i = 0; i < 3; i++) {
+      const s = getAuthStatus("poll-agent", tempDir);
+      expect(s.authenticated).toBe(true);
+      expect(s.source).toBe("oauth-token");
+    }
+  });
+});

--- a/tests/auth.test.ts
+++ b/tests/auth.test.ts
@@ -572,4 +572,59 @@ describe("submitAuthCode log-file polling integration", () => {
     expect(status.authenticated).toBe(false);
     expect(status.timeUntilExpiry).toBe("expired");
   });
+
+  // ── #171 / #176 regression tests ─────────────────────────────────────────
+
+  it("lazy-sync: getAuthStatus returns authenticated when slot token exists but legacy mirror is absent (#171)", () => {
+    // Simulates the scaffold race: accounts/default/.oauth-token was written
+    // by submitAuthCode but syncLegacyFromActive hadn't mirrored it to
+    // .claude/.oauth-token yet.  getAuthStatus should detect the active slot,
+    // mirror it on-demand, and return authenticated=true in the same call.
+    const accountsDir = resolve(tempDir, ".claude", "accounts", "default");
+    mkdirSync(accountsDir, { recursive: true });
+
+    const expiresAt = Date.now() + 365 * 24 * 60 * 60_000;
+    writeFileSync(
+      resolve(accountsDir, ".oauth-token"),
+      "sk-ant-oat01-slot-token\n",
+      { mode: 0o600 },
+    );
+    writeFileSync(
+      resolve(accountsDir, ".oauth-token.meta.json"),
+      JSON.stringify({ createdAt: Date.now(), expiresAt, source: "claude-setup-token" }),
+      { mode: 0o600 },
+    );
+    // Write the active marker so getAuthStatus knows which slot is active.
+    writeFileSync(resolve(tempDir, ".claude", "active"), "default\n", { mode: 0o600 });
+
+    // Legacy mirror does NOT exist yet — this is the pre-race state.
+    expect(existsSync(resolve(tempDir, ".claude", ".oauth-token"))).toBe(false);
+
+    const status = getAuthStatus("test-agent", tempDir);
+
+    // After the lazy-sync, the status must be authenticated.
+    expect(status.authenticated).toBe(true);
+    expect(status.source).toBe("oauth-token");
+
+    // And the legacy file should now exist (was mirrored as a side-effect).
+    expect(existsSync(resolve(tempDir, ".claude", ".oauth-token"))).toBe(true);
+  });
+
+  it("lazy-sync: getAuthStatus is a no-op when legacy mirror already exists (#171 regression guard)", () => {
+    // When the legacy mirror is already in place, the lazy-sync branch must
+    // NOT overwrite it (idempotent guard — avoids clobbering a valid token).
+    const expiresAt = Date.now() + 365 * 24 * 60 * 60_000;
+    writeFileSync(
+      resolve(tempDir, ".claude", ".oauth-token"),
+      "sk-ant-oat01-legacy-token\n",
+    );
+    writeFileSync(
+      resolve(tempDir, ".claude", ".oauth-token.meta.json"),
+      JSON.stringify({ createdAt: Date.now(), expiresAt, source: "claude-setup-token" }),
+    );
+
+    const status = getAuthStatus("test-agent", tempDir);
+    expect(status.authenticated).toBe(true);
+    expect(status.source).toBe("oauth-token");
+  });
 });


### PR DESCRIPTION
## Summary

- **`getAuthStatus` lazy-sync (#171):** When the legacy `.claude/.oauth-token` mirror is absent but the active slot token exists in `accounts/<slot>/.oauth-token`, `getAuthStatus` now calls `syncLegacyFromActive()` before reading — closing the race where scaffold wrote the accounts slot but the legacy path hadn't been mirrored yet. Previously this caused `auth status` to show `✗` until a manual second restart.

- **`restart` auth-settling wait (#176):** After a synchronous restart completes, `registerRestartCommand` now calls `waitForAuthConverge()` — a bounded poll of `getAuthStatus()` for up to 30 s. If auth converges, restart exits cleanly. If it times out, a clear warning is printed. Ensures `switchroom restart <agent> && switchroom auth status` returns settled values without a manual second invocation.

## Test plan

- [ ] `tests/auth.status-settling.test.ts` (4 new tests): lazy-sync race, no-active-marker guard, false-positive guard, polling idempotence
- [ ] `tests/auth.test.ts` (2 new cases): lazy-sync happy path + idempotent guard when legacy mirror already present
- [ ] `tests/restart-reconciles.test.ts` — existing 7 tests still pass

Closes #171
Closes #176

🤖 Generated with [Claude Code](https://claude.com/claude-code)