### PR TITLE
Surface thinking_effort, permission_mode, fallback_model in switchroom.yaml

### DIFF
--- a/profiles/_base/start.sh.hbs
+++ b/profiles/_base/start.sh.hbs
@@ -242,14 +242,14 @@ fi
 
 {{#if useSwitchroomPlugin}}
 if [ -n "$APPEND_PROMPT" ]; then
-  exec claude $CONTINUE_FLAG --dangerously-load-development-channels server:switchroom-telegram{{#if hindsightEnabled}} --plugin-dir "{{agentDir}}/.claude/plugins/hindsight-memory"{{/if}}{{#if modelQ}} --model {{{modelQ}}}{{/if}} --append-system-prompt "$APPEND_PROMPT"{{#if dangerousMode}} --dangerously-skip-permissions{{/if}}{{#if extraCliArgs}}{{{extraCliArgs}}}{{/if}}
+  exec claude $CONTINUE_FLAG --dangerously-load-development-channels server:switchroom-telegram{{#if hindsightEnabled}} --plugin-dir "{{agentDir}}/.claude/plugins/hindsight-memory"{{/if}}{{#if modelQ}} --model {{{modelQ}}}{{/if}}{{#if thinkingEffort}} --effort {{thinkingEffort}}{{/if}}{{#if permissionMode}} --permission-mode {{permissionMode}}{{/if}}{{#if fallbackModelQ}} --fallback-model {{{fallbackModelQ}}}{{/if}} --append-system-prompt "$APPEND_PROMPT"{{#if dangerousMode}} --dangerously-skip-permissions{{/if}}{{#if extraCliArgs}}{{{extraCliArgs}}}{{/if}}
 else
-  exec claude $CONTINUE_FLAG --dangerously-load-development-channels server:switchroom-telegram{{#if hindsightEnabled}} --plugin-dir "{{agentDir}}/.claude/plugins/hindsight-memory"{{/if}}{{#if modelQ}} --model {{{modelQ}}}{{/if}}{{#if dangerousMode}} --dangerously-skip-permissions{{/if}}{{#if extraCliArgs}}{{{extraCliArgs}}}{{/if}}
+  exec claude $CONTINUE_FLAG --dangerously-load-development-channels server:switchroom-telegram{{#if hindsightEnabled}} --plugin-dir "{{agentDir}}/.claude/plugins/hindsight-memory"{{/if}}{{#if modelQ}} --model {{{modelQ}}}{{/if}}{{#if thinkingEffort}} --effort {{thinkingEffort}}{{/if}}{{#if permissionMode}} --permission-mode {{permissionMode}}{{/if}}{{#if fallbackModelQ}} --fallback-model {{{fallbackModelQ}}}{{/if}}{{#if dangerousMode}} --dangerously-skip-permissions{{/if}}{{#if extraCliArgs}}{{{extraCliArgs}}}{{/if}}
 fi
 {{else}}
 if [ -n "$APPEND_PROMPT" ]; then
-  exec claude $CONTINUE_FLAG --channels plugin:telegram@claude-plugins-official{{#if hindsightEnabled}} --plugin-dir "{{agentDir}}/.claude/plugins/hindsight-memory"{{/if}}{{#if modelQ}} --model {{{modelQ}}}{{/if}} --append-system-prompt "$APPEND_PROMPT"{{#if dangerousMode}} --dangerously-skip-permissions{{/if}}{{#if extraCliArgs}}{{{extraCliArgs}}}{{/if}}
+  exec claude $CONTINUE_FLAG --channels plugin:telegram@claude-plugins-official{{#if hindsightEnabled}} --plugin-dir "{{agentDir}}/.claude/plugins/hindsight-memory"{{/if}}{{#if modelQ}} --model {{{modelQ}}}{{/if}}{{#if thinkingEffort}} --effort {{thinkingEffort}}{{/if}}{{#if permissionMode}} --permission-mode {{permissionMode}}{{/if}}{{#if fallbackModelQ}} --fallback-model {{{fallbackModelQ}}}{{/if}} --append-system-prompt "$APPEND_PROMPT"{{#if dangerousMode}} --dangerously-skip-permissions{{/if}}{{#if extraCliArgs}}{{{extraCliArgs}}}{{/if}}
 else
-  exec claude $CONTINUE_FLAG --channels plugin:telegram@claude-plugins-official{{#if hindsightEnabled}} --plugin-dir "{{agentDir}}/.claude/plugins/hindsight-memory"{{/if}}{{#if modelQ}} --model {{{modelQ}}}{{/if}}{{#if dangerousMode}} --dangerously-skip-permissions{{/if}}{{#if extraCliArgs}}{{{extraCliArgs}}}{{/if}}
+  exec claude $CONTINUE_FLAG --channels plugin:telegram@claude-plugins-official{{#if hindsightEnabled}} --plugin-dir "{{agentDir}}/.claude/plugins/hindsight-memory"{{/if}}{{#if modelQ}} --model {{{modelQ}}}{{/if}}{{#if thinkingEffort}} --effort {{thinkingEffort}}{{/if}}{{#if permissionMode}} --permission-mode {{permissionMode}}{{/if}}{{#if fallbackModelQ}} --fallback-model {{{fallbackModelQ}}}{{/if}}{{#if dangerousMode}} --dangerously-skip-permissions{{/if}}{{#if extraCliArgs}}{{{extraCliArgs}}}{{/if}}
 fi
 {{/if}}

--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -1106,6 +1106,11 @@ function buildWorkspaceContext(args: BuildWorkspaceContextArgs): Record<string, 
       ? shellSingleQuote(resolve(switchroomConfigPath))
       : undefined,
     modelQ: agentConfig.model ? shellSingleQuote(agentConfig.model) : undefined,
+    thinkingEffort: agentConfig.thinking_effort,
+    permissionMode: agentConfig.permission_mode,
+    fallbackModelQ: agentConfig.fallback_model
+      ? shellSingleQuote(agentConfig.fallback_model)
+      : undefined,
     userEnvQuoted: (() => {
       const combined = { ...channelsToEnv(agentConfig), ...(agentConfig.env ?? {}) };
       if (Object.keys(combined).length === 0) return undefined;
@@ -2156,6 +2161,11 @@ export function reconcileAgent(
       hindsightBankIdQ: shellSingleQuote(hindsightBankId),
       hindsightApiBaseUrlQ: shellSingleQuote(hindsightApiBaseUrl),
       modelQ: agentConfig.model ? shellSingleQuote(agentConfig.model) : undefined,
+      thinkingEffort: agentConfig.thinking_effort,
+      permissionMode: agentConfig.permission_mode,
+      fallbackModelQ: agentConfig.fallback_model
+        ? shellSingleQuote(agentConfig.fallback_model)
+        : undefined,
       userEnvQuoted: (() => {
         const combined = { ...channelsToEnv(agentConfig), ...(agentConfig.env ?? {}) };
         if (Object.keys(combined).length === 0) return undefined;

--- a/src/config/merge.ts
+++ b/src/config/merge.ts
@@ -221,6 +221,15 @@ export function mergeAgentConfig(
   ) {
     merged.skip_permission_prompt = defaults.skip_permission_prompt;
   }
+  if (defaults.thinking_effort !== undefined && merged.thinking_effort === undefined) {
+    merged.thinking_effort = defaults.thinking_effort;
+  }
+  if (defaults.permission_mode !== undefined && merged.permission_mode === undefined) {
+    merged.permission_mode = defaults.permission_mode;
+  }
+  if (defaults.fallback_model !== undefined && merged.fallback_model === undefined) {
+    merged.fallback_model = defaults.fallback_model;
+  }
   // --- tools: union (dedup-preserving-order, defaults first) ---
   if (defaults.tools || merged.tools) {
     const dAllow = defaults.tools?.allow ?? [];

--- a/src/config/schema.test.ts
+++ b/src/config/schema.test.ts
@@ -1,13 +1,16 @@
 /**
- * Tests for vault-broker schema additions (PR 1).
+ * Tests for vault-broker schema additions (PR 1) and CLI flag knobs (PR 196-198).
  *
  * Covers:
  *   - ScheduleEntrySchema.secrets: valid values, regex rejection, default []
  *   - VaultConfigSchema.broker: default population when omitted
+ *   - AgentSchema.thinking_effort: enum validation
+ *   - AgentSchema.permission_mode: enum validation
+ *   - AgentSchema.fallback_model: regex validation
  */
 
 import { describe, expect, it } from "vitest";
-import { ScheduleEntrySchema, VaultConfigSchema } from "./schema.js";
+import { AgentSchema, ScheduleEntrySchema, VaultConfigSchema } from "./schema.js";
 
 describe("ScheduleEntrySchema.secrets", () => {
   it("accepts a list of valid vault key names", () => {
@@ -140,5 +143,87 @@ describe("VaultConfigSchema.broker", () => {
     expect(result.broker.autoUnlockCredentialPath).toBe(
       "/etc/credstore.encrypted/vault-passphrase"
     );
+  });
+});
+
+function baseAgentInput(overrides: Record<string, unknown> = {}) {
+  return {
+    topic_name: "Test",
+    ...overrides,
+  };
+}
+
+describe("AgentSchema.thinking_effort", () => {
+  it("accepts all valid effort values", () => {
+    for (const effort of ["low", "medium", "high", "xhigh", "max"] as const) {
+      const result = AgentSchema.parse(baseAgentInput({ thinking_effort: effort }));
+      expect(result.thinking_effort).toBe(effort);
+    }
+  });
+
+  it("is optional — omitted means no flag", () => {
+    const result = AgentSchema.parse(baseAgentInput());
+    expect(result.thinking_effort).toBeUndefined();
+  });
+
+  it("rejects invalid effort values", () => {
+    expect(() =>
+      AgentSchema.parse(baseAgentInput({ thinking_effort: "ultra" })),
+    ).toThrow();
+  });
+
+  it("rejects empty string", () => {
+    expect(() =>
+      AgentSchema.parse(baseAgentInput({ thinking_effort: "" })),
+    ).toThrow();
+  });
+});
+
+describe("AgentSchema.permission_mode", () => {
+  it("accepts all valid permission_mode values", () => {
+    const modes = [
+      "acceptEdits", "auto", "bypassPermissions", "default", "dontAsk", "plan",
+    ] as const;
+    for (const mode of modes) {
+      const result = AgentSchema.parse(baseAgentInput({ permission_mode: mode }));
+      expect(result.permission_mode).toBe(mode);
+    }
+  });
+
+  it("is optional — omitted means no flag", () => {
+    const result = AgentSchema.parse(baseAgentInput());
+    expect(result.permission_mode).toBeUndefined();
+  });
+
+  it("rejects invalid permission_mode values", () => {
+    expect(() =>
+      AgentSchema.parse(baseAgentInput({ permission_mode: "skipAll" })),
+    ).toThrow();
+  });
+});
+
+describe("AgentSchema.fallback_model", () => {
+  it("accepts valid model names", () => {
+    for (const model of ["sonnet", "haiku", "claude-sonnet-4-6", "claude-haiku-4-5"]) {
+      const result = AgentSchema.parse(baseAgentInput({ fallback_model: model }));
+      expect(result.fallback_model).toBe(model);
+    }
+  });
+
+  it("is optional — omitted means no flag", () => {
+    const result = AgentSchema.parse(baseAgentInput());
+    expect(result.fallback_model).toBeUndefined();
+  });
+
+  it("rejects model names with spaces", () => {
+    expect(() =>
+      AgentSchema.parse(baseAgentInput({ fallback_model: "bad model" })),
+    ).toThrow();
+  });
+
+  it("rejects model names with shell-special characters", () => {
+    expect(() =>
+      AgentSchema.parse(baseAgentInput({ fallback_model: "model$foo" })),
+    ).toThrow();
   });
 });

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -190,7 +190,7 @@ export const SubagentSchema = z.object({
     .optional()
     .describe("Permission mode override for this sub-agent"),
   effort: z
-    .enum(["low", "medium", "high", "max"])
+    .enum(["low", "medium", "high", "xhigh", "max"])
     .optional()
     .describe("Effort level override"),
   color: z

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -484,6 +484,32 @@ const profileFields = {
       "Model name must be alphanumeric with ._-/[]: only",
     )
     .optional(),
+  thinking_effort: z
+    .enum(["low", "medium", "high", "xhigh", "max"])
+    .optional()
+    .describe(
+      "Adaptive-thinking effort level passed as --effort to the claude CLI. " +
+      "lower = faster/cheaper, higher = more reasoning. Omit to use Claude's default.",
+    ),
+  permission_mode: z
+    .enum(["acceptEdits", "auto", "bypassPermissions", "default", "dontAsk", "plan"])
+    .optional()
+    .describe(
+      "Permission mode passed as --permission-mode to the claude CLI. " +
+      "Omit to use Claude's default (acceptEdits for switchroom agents). " +
+      "Warning: bypassPermissions and dontAsk skip all safety checks — use only in trusted sandboxes.",
+    ),
+  fallback_model: z
+    .string()
+    .regex(
+      /^[a-zA-Z0-9][a-zA-Z0-9._\-/\[\]:]*$/,
+      "Fallback model name must be alphanumeric with ._-/[]: only",
+    )
+    .optional()
+    .describe(
+      "Fallback model passed as --fallback-model to the claude CLI. " +
+      "Used when the primary model is overloaded. Note: only functional in --print (non-interactive) mode per Claude CLI docs; silently no-ops in interactive sessions.",
+    ),
   mcp_servers: z.record(z.string(), z.unknown()).optional(),
   hooks: AgentHooksSchema,
   env: z.record(z.string(), z.string()).optional(),
@@ -583,6 +609,34 @@ export const AgentSchema = z.object({
     )
     .optional()
     .describe("Claude model override (e.g., 'claude-sonnet-4-6')"),
+  thinking_effort: z
+    .enum(["low", "medium", "high", "xhigh", "max"])
+    .optional()
+    .describe(
+      "Adaptive-thinking effort level passed as --effort to the claude CLI. " +
+      "Per-agent override wins over defaults.thinking_effort. " +
+      "lower = faster/cheaper, higher = more reasoning. Omit to use Claude's default.",
+    ),
+  permission_mode: z
+    .enum(["acceptEdits", "auto", "bypassPermissions", "default", "dontAsk", "plan"])
+    .optional()
+    .describe(
+      "Permission mode passed as --permission-mode to the claude CLI. " +
+      "Per-agent override wins over defaults.permission_mode. " +
+      "Warning: bypassPermissions and dontAsk skip all safety checks — use only in trusted sandboxes.",
+    ),
+  fallback_model: z
+    .string()
+    .regex(
+      /^[a-zA-Z0-9][a-zA-Z0-9._\-/\[\]:]*$/,
+      "Fallback model name must be alphanumeric with ._-/[]: only",
+    )
+    .optional()
+    .describe(
+      "Fallback model passed as --fallback-model to the claude CLI. " +
+      "Per-agent override wins over defaults.fallback_model. " +
+      "Used when the primary model is overloaded. Note: only functional in --print (non-interactive) mode per Claude CLI docs; silently no-ops in interactive sessions.",
+    ),
   mcp_servers: z
     .record(z.string(), z.unknown())
     .optional()

--- a/tests/merge.test.ts
+++ b/tests/merge.test.ts
@@ -53,6 +53,60 @@ describe("mergeAgentConfig", () => {
     expect(result.model).toBe("opus");
   });
 
+  it("fills in thinking_effort from defaults when agent omits it", () => {
+    const defaults: AgentDefaults = { thinking_effort: "high" };
+    const result = mergeAgentConfig(defaults, baseAgent());
+    expect(result.thinking_effort).toBe("high");
+  });
+
+  it("per-agent thinking_effort wins over defaults", () => {
+    const defaults: AgentDefaults = { thinking_effort: "high" };
+    const agent = baseAgent({ thinking_effort: "xhigh" });
+    const result = mergeAgentConfig(defaults, agent);
+    expect(result.thinking_effort).toBe("xhigh");
+  });
+
+  it("thinking_effort stays undefined when neither side sets it", () => {
+    const result = mergeAgentConfig({ model: "sonnet" }, baseAgent());
+    expect(result.thinking_effort).toBeUndefined();
+  });
+
+  it("fills in permission_mode from defaults when agent omits it", () => {
+    const defaults: AgentDefaults = { permission_mode: "acceptEdits" };
+    const result = mergeAgentConfig(defaults, baseAgent());
+    expect(result.permission_mode).toBe("acceptEdits");
+  });
+
+  it("per-agent permission_mode wins over defaults", () => {
+    const defaults: AgentDefaults = { permission_mode: "acceptEdits" };
+    const agent = baseAgent({ permission_mode: "plan" });
+    const result = mergeAgentConfig(defaults, agent);
+    expect(result.permission_mode).toBe("plan");
+  });
+
+  it("permission_mode stays undefined when neither side sets it", () => {
+    const result = mergeAgentConfig({ model: "sonnet" }, baseAgent());
+    expect(result.permission_mode).toBeUndefined();
+  });
+
+  it("fills in fallback_model from defaults when agent omits it", () => {
+    const defaults: AgentDefaults = { fallback_model: "sonnet" };
+    const result = mergeAgentConfig(defaults, baseAgent());
+    expect(result.fallback_model).toBe("sonnet");
+  });
+
+  it("per-agent fallback_model wins over defaults", () => {
+    const defaults: AgentDefaults = { fallback_model: "sonnet" };
+    const agent = baseAgent({ fallback_model: "haiku" });
+    const result = mergeAgentConfig(defaults, agent);
+    expect(result.fallback_model).toBe("haiku");
+  });
+
+  it("fallback_model stays undefined when neither side sets it", () => {
+    const result = mergeAgentConfig({ model: "sonnet" }, baseAgent());
+    expect(result.fallback_model).toBeUndefined();
+  });
+
   it("leaves agent.extends unchanged — the cascade resolves profiles separately", () => {
     // mergeAgentConfig() is the defaults → agent primitive; profile
     // resolution happens in resolveAgentConfig(). AgentDefaults does

--- a/tests/scaffold.test.ts
+++ b/tests/scaffold.test.ts
@@ -228,6 +228,19 @@ describe("scaffoldAgent", () => {
     expect(startSh).toContain("--permission-mode bypassPermissions");
   });
 
+  it("reconcile re-renders start.sh with fallback_model flag", () => {
+    const config = makeAgentConfig({ fallback_model: "sonnet" });
+    const switchroomConfig: SwitchroomConfig = {
+      switchroom: { version: 1, agents_dir: tmpDir },
+      telegram: telegramConfig,
+      agents: { "fallback-reconcile": config },
+    } as SwitchroomConfig;
+    scaffoldAgent("fallback-reconcile", config, tmpDir, telegramConfig, switchroomConfig);
+    reconcileAgent("fallback-reconcile", config, tmpDir, telegramConfig, switchroomConfig);
+    const startSh = readFileSync(join(tmpDir, "fallback-reconcile", "start.sh"), "utf-8");
+    expect(startSh).toContain("--fallback-model 'sonnet'");
+  });
+
   it("scaffold wiring: documented callers write the clean-shutdown marker with a reason before restarting", () => {
     // Source-grep regression for the five documented call sites so a
     // future refactor can't silently drop the reason-stamping step.

--- a/tests/scaffold.test.ts
+++ b/tests/scaffold.test.ts
@@ -160,6 +160,73 @@ describe("scaffoldAgent", () => {
     expect(startSh).not.toContain("export SWITCHROOM_CONFIG=");
   });
 
+  it("start.sh includes --effort flag when thinking_effort is set", () => {
+    const config = makeAgentConfig({ thinking_effort: "xhigh" });
+    const result = scaffoldAgent("effort-agent", config, tmpDir, telegramConfig);
+    const startSh = readFileSync(join(result.agentDir, "start.sh"), "utf-8");
+    expect(startSh).toContain("--effort xhigh");
+  });
+
+  it("start.sh omits --effort when thinking_effort is not set", () => {
+    const config = makeAgentConfig();
+    const result = scaffoldAgent("no-effort-agent", config, tmpDir, telegramConfig);
+    const startSh = readFileSync(join(result.agentDir, "start.sh"), "utf-8");
+    expect(startSh).not.toContain("--effort");
+  });
+
+  it("start.sh includes --permission-mode flag when permission_mode is set", () => {
+    const config = makeAgentConfig({ permission_mode: "plan" });
+    const result = scaffoldAgent("perm-agent", config, tmpDir, telegramConfig);
+    const startSh = readFileSync(join(result.agentDir, "start.sh"), "utf-8");
+    expect(startSh).toContain("--permission-mode plan");
+  });
+
+  it("start.sh omits --permission-mode when permission_mode is not set", () => {
+    const config = makeAgentConfig();
+    const result = scaffoldAgent("no-perm-agent", config, tmpDir, telegramConfig);
+    const startSh = readFileSync(join(result.agentDir, "start.sh"), "utf-8");
+    expect(startSh).not.toContain("--permission-mode");
+  });
+
+  it("start.sh includes --fallback-model flag when fallback_model is set", () => {
+    const config = makeAgentConfig({ fallback_model: "sonnet" });
+    const result = scaffoldAgent("fallback-agent", config, tmpDir, telegramConfig);
+    const startSh = readFileSync(join(result.agentDir, "start.sh"), "utf-8");
+    expect(startSh).toContain("--fallback-model 'sonnet'");
+  });
+
+  it("start.sh omits --fallback-model when fallback_model is not set", () => {
+    const config = makeAgentConfig();
+    const result = scaffoldAgent("no-fallback-agent", config, tmpDir, telegramConfig);
+    const startSh = readFileSync(join(result.agentDir, "start.sh"), "utf-8");
+    expect(startSh).not.toContain("--fallback-model");
+  });
+
+  it("reconcile re-renders start.sh with thinking_effort flag", () => {
+    const config = makeAgentConfig({ thinking_effort: "medium" });
+    const switchroomConfig: SwitchroomConfig = {
+      switchroom: { version: 1, agents_dir: tmpDir },
+      telegram: telegramConfig,
+      agents: { "effort-reconcile": config },
+    } as SwitchroomConfig;
+    scaffoldAgent("effort-reconcile", config, tmpDir, telegramConfig, switchroomConfig);
+    reconcileAgent("effort-reconcile", config, tmpDir, telegramConfig, switchroomConfig);
+    const startSh = readFileSync(join(tmpDir, "effort-reconcile", "start.sh"), "utf-8");
+    expect(startSh).toContain("--effort medium");
+  });
+
+  it("reconcile re-renders start.sh with permission_mode flag", () => {
+    const config = makeAgentConfig({ permission_mode: "bypassPermissions" });
+    const switchroomConfig: SwitchroomConfig = {
+      switchroom: { version: 1, agents_dir: tmpDir },
+      telegram: telegramConfig,
+      agents: { "perm-reconcile": config },
+    } as SwitchroomConfig;
+    scaffoldAgent("perm-reconcile", config, tmpDir, telegramConfig, switchroomConfig);
+    reconcileAgent("perm-reconcile", config, tmpDir, telegramConfig, switchroomConfig);
+    const startSh = readFileSync(join(tmpDir, "perm-reconcile", "start.sh"), "utf-8");
+    expect(startSh).toContain("--permission-mode bypassPermissions");
+  });
 
   it("scaffold wiring: documented callers write the clean-shutdown marker with a reason before restarting", () => {
     // Source-grep regression for the five documented call sites so a


### PR DESCRIPTION
## Summary

Three new yaml fields, two layers, one resolution rule. Each maps to a documented Claude Code CLI flag.

| field | maps to | values |
|---|---|---|
| `thinking_effort` | `claude --effort` | `low \| medium \| high \| xhigh \| max` |
| `permission_mode` | `claude --permission-mode` | `acceptEdits \| auto \| plan \| default \| dontAsk \| bypassPermissions` |
| `fallback_model` | `claude --fallback-model` | model alias or full id |

```yaml
defaults:
  thinking_effort: high
  permission_mode: acceptEdits
  fallback_model: sonnet

agents:
  clerk:
    thinking_effort: medium   # snappier chat replies
  worker:
    thinking_effort: xhigh    # deeper reasoning on code
```

Resolution: per-agent → defaults → omit (Claude's own default). Omitted = no flag passed, which keeps prompt-cache shape stable for default-config agents.

## Why per-agent

Different jtbd: chat-style agents benefit from `medium` for snappy replies; deep-work agents (worker, researcher) want `xhigh` for SWE-bench-tier reasoning. One knob doesn't fit the fleet.

## Plumbing

- **Schema** (`src/config/schema.ts`): new fields at both `defaults` and `agents.<name>` levels, with enum validation. Bad values fail loud at config-load.
- **Merge** (`src/config/merge.ts`): per-agent values override defaults.
- **Scaffold** (`src/agents/scaffold.ts`): forwards resolved values into the template context.
- **Profile template** (`profiles/_base/start.sh.hbs`): conditionally appends `--effort`, `--permission-mode`, `--fallback-model` to the `claude` invocation across all four code paths (dev/official channels × with/without append-prompt).
- **Reconcile**: existing `restart = reconcile + restart` contract re-renders start.sh whenever these fields change.

## Tests

213 passing (3 test files): schema validation, merge resolution order, scaffold output, profile rendering. New tests cover good values, bad values, defaults-only, per-agent-only, and per-agent-overrides-defaults.

```
$ bun test tests/merge.test.ts tests/scaffold.test.ts src/config/schema.test.ts
213 pass, 0 fail, 552 expect() calls
```

Build clean: `bun run build` produces a 1.40 MB bundle, no PII leaks.

## Test plan

- [x] `bun test` — 213/213 pass
- [x] `bun run build` — clean
- [ ] Smoke test on a real agent: set `thinking_effort: low` on clerk, restart, confirm `--effort low` in `ps aux` for the claude process
- [ ] Smoke test `permission_mode: plan` — should boot with planning gating
- [ ] Smoke test `fallback_model: sonnet` — verify it doesn't break interactive mode (CLI help says `--print` only, but worth confirming)

## Closes

- Closes #196 — `thinking_effort`
- Closes #197 — `permission_mode`
- Closes #198 — `fallback_model`

## Out of scope

Companion #199 (`add_dirs` + granular `allowed_tools`/`disallowed_tools`) deferred to a follow-up PR — bigger surface, deserves its own review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)