### PR TITLE
telegram(#195): incremental answer-text streaming via sendMessageDraft

### DIFF
--- a/telegram-plugin/answer-stream.ts
+++ b/telegram-plugin/answer-stream.ts
@@ -377,10 +377,28 @@ export function createAnswerStream(config: AnswerStreamConfig): AnswerStreamHand
         }
       }
 
-      // The text we want to materialize
-      const textToSend = lastSentText || pendingText
-      if (!textToSend || !textToSend.trim()) {
+      // The text we want to materialize. Prefer pendingText (most recent
+      // snapshot from the model) over lastSentText (what last reached the
+      // wire). They usually match, but if a buffered update was scheduled
+      // and not yet sent when materialize() was called, pendingText holds
+      // the freshest content.
+      const textToSend = (pendingText || lastSentText).trimEnd()
+      if (!textToSend) {
         log?.('answer-stream: materialize — nothing to send')
+        return undefined
+      }
+
+      // Telegram caps a single message at 4096 chars. The streaming path
+      // already guards on this in sendOrEdit; materialize must too, or
+      // long answers silently drop the final push notification (Telegram
+      // returns 400, the catch swallows). Per the JTBD anti-pattern
+      // "silent failure of any kind", warn and bail explicitly so the
+      // operator can correlate.
+      if (textToSend.length > TELEGRAM_MAX_CHARS) {
+        warn?.(
+          `answer-stream: materialize — text exceeds ${TELEGRAM_MAX_CHARS} chars (got ${textToSend.length}); skipping. ` +
+          `The reply path should have already delivered chunked output; this is a defensive guard.`,
+        )
         return undefined
       }
 
@@ -395,7 +413,7 @@ export function createAnswerStream(config: AnswerStreamConfig): AnswerStreamHand
       // nested quote that looks wrong.
 
       try {
-        const sent = await sendMessage(chatId, textToSend.trimEnd(), sendParams)
+        const sent = await sendMessage(chatId, textToSend, sendParams)
         const sentId = sent?.message_id
         if (typeof sentId === 'number' && Number.isFinite(sentId)) {
           streamMsgId = sentId

--- a/telegram-plugin/answer-stream.ts
+++ b/telegram-plugin/answer-stream.ts
@@ -1,0 +1,440 @@
+/**
+ * Answer-lane incremental streaming for long Telegram replies.
+ *
+ * This module implements the "narrative" liveness layer described in
+ * `reference/know-what-my-agent-is-doing.md`:
+ *
+ *   ambient     → 👀 ack reaction
+ *   structured  → progress card (existing, via stream-reply-handler.ts lane:'progress')
+ *   narrative   → THIS — incremental answer text appearing below the card as it arrives
+ *
+ * Design constraints honored:
+ *   1. Separate message ID from the progress card — never overwritten.
+ *   2. sendMessageDraft for DMs (detected by chatType='private'); regular
+ *      sendMessage+editMessageText for groups/channels. Runtime fallback
+ *      when draft API rejects (DRAFT_METHOD_UNAVAILABLE_RE / DRAFT_CHAT_UNSUPPORTED_RE).
+ *   3. minInitialChars (~400) — don't open the answer lane until enough text
+ *      has arrived. Short replies bypass the lane entirely.
+ *   4. Turn-end materializes as a fresh sendMessage (push notification) NOT
+ *      an edit-finalize — mirrors OpenClaw's materialize() pattern.
+ *   5. Supersession protection — when a new turn starts while a prior
+ *      answer-lane edit is in flight, the late edit is identified as stale
+ *      and orphaned (via generation counter), not applied to the new message.
+ *
+ * Key differences from the OpenClaw draft-stream.ts:
+ *   - No grammy Bot dependency at this layer — callers inject typed send/edit
+ *     callbacks so this module is fully testable without a real bot.
+ *   - No finalizable-draft-lifecycle SDK — we implement the loop directly.
+ *   - materialize() always sends a fresh message regardless of transport,
+ *     to guarantee a push notification on turn completion.
+ */
+
+export const MIN_INITIAL_CHARS = 400
+export const DEFAULT_THROTTLE_MS = 1000
+const TELEGRAM_MAX_CHARS = 4096
+
+// Error patterns matching OpenClaw's shouldFallbackFromDraftTransport.
+// Exported for tests.
+export const DRAFT_METHOD_UNAVAILABLE_RE =
+  /(unknown method|method .*not (found|available|supported)|unsupported)/i
+export const DRAFT_CHAT_UNSUPPORTED_RE = /(can't be used|can be used only)/i
+
+/**
+ * Returns true when a sendMessageDraft rejection means "this API is not
+ * available" rather than a transient network error.
+ */
+export function shouldFallbackFromDraftTransport(err: unknown): boolean {
+  const text =
+    typeof err === 'string'
+      ? err
+      : err instanceof Error
+        ? err.message
+        : typeof err === 'object' && err != null && 'description' in err
+          ? typeof (err as { description: unknown }).description === 'string'
+            ? (err as { description: string }).description
+            : ''
+          : ''
+  if (!/sendMessageDraft/i.test(text)) return false
+  return DRAFT_METHOD_UNAVAILABLE_RE.test(text) || DRAFT_CHAT_UNSUPPORTED_RE.test(text)
+}
+
+/** Called when a late sendMessage/edit resolves after a new turn has started. */
+export type OnSupersededCallback = (params: {
+  messageId: number
+  textSnapshot: string
+}) => void
+
+export interface AnswerStreamConfig {
+  /** chatId for all API calls */
+  chatId: string
+  /** True if this is a DM — tries sendMessageDraft first */
+  isPrivateChat: boolean
+  /** Optional forum thread */
+  threadId?: number
+  /** Minimum chars before opening the answer lane. Default: MIN_INITIAL_CHARS */
+  minInitialChars?: number
+  /** Throttle window in ms. Default: DEFAULT_THROTTLE_MS */
+  throttleMs?: number
+  /** Optional quote-reply target for the initial sendMessage */
+  replyToMessageId?: number
+
+  // ── Transport callbacks ────────────────────────────────────────────────
+  /**
+   * sendMessageDraft(chatId, draftId, text, params?). Optional — when absent,
+   * the answer stream falls back immediately to sendMessage+editMessageText.
+   */
+  sendMessageDraft?: (
+    chatId: string,
+    draftId: number,
+    text: string,
+    params?: { message_thread_id?: number },
+  ) => Promise<unknown>
+  sendMessage: (
+    chatId: string,
+    text: string,
+    params?: {
+      parse_mode?: 'HTML'
+      message_thread_id?: number
+      link_preview_options?: { is_disabled: boolean }
+      reply_parameters?: { message_id: number }
+    },
+  ) => Promise<{ message_id: number }>
+  editMessageText: (
+    chatId: string,
+    messageId: number,
+    text: string,
+    params?: {
+      parse_mode?: 'HTML'
+      message_thread_id?: number
+      link_preview_options?: { is_disabled: boolean }
+    },
+  ) => Promise<unknown>
+  deleteMessage?: (chatId: string, messageId: number) => Promise<unknown>
+
+  /** Called when a late edit/send resolves but this stream has been superseded. */
+  onSuperseded?: OnSupersededCallback
+  log?: (msg: string) => void
+  warn?: (msg: string) => void
+}
+
+export interface AnswerStreamHandle {
+  /**
+   * Push a new full-text snapshot. Throttled to ~1 send/edit per throttleMs.
+   * No-op if minInitialChars hasn't been reached yet.
+   */
+  update(text: string): void
+  /**
+   * Finalize: send the accumulated text as a fresh sendMessage for push
+   * notification. Returns the final message_id, or undefined if nothing was
+   * buffered. Idempotent after first call.
+   */
+  materialize(): Promise<number | undefined>
+  /**
+   * Force-start a new generation: resets internal state so the next update
+   * creates a new message instead of editing. Use when a new turn starts
+   * while this stream is still in flight.
+   */
+  forceNewMessage(): void
+  /** Current message_id if one has been sent, else undefined. */
+  messageId(): number | undefined
+  /** Stop the stream — cancels pending throttled edits. */
+  stop(): void
+}
+
+// Module-level draft-id counter. Shared globally so concurrent answer streams
+// don't collide on draft ids — mirrors OpenClaw's getDraftStreamState().
+let _nextDraftId = 1
+function allocateDraftId(): number {
+  const id = _nextDraftId
+  _nextDraftId = _nextDraftId >= 2_147_483_647 ? 1 : _nextDraftId + 1
+  return id
+}
+
+export function createAnswerStream(config: AnswerStreamConfig): AnswerStreamHandle {
+  const {
+    chatId,
+    isPrivateChat,
+    threadId,
+    minInitialChars = MIN_INITIAL_CHARS,
+    throttleMs = DEFAULT_THROTTLE_MS,
+    replyToMessageId,
+    sendMessageDraft: draftApi,
+    sendMessage,
+    editMessageText,
+    onSuperseded,
+    log,
+    warn,
+  } = config
+
+  const effectiveThrottle = Math.max(250, throttleMs)
+
+  // Draft transport is only used in DMs and only when the API method is available.
+  const preferDraft = isPrivateChat && draftApi != null
+  let usesDraftTransport = preferDraft
+  let draftId = preferDraft ? allocateDraftId() : undefined
+
+  // Stream state
+  let streamMsgId: number | undefined
+  let pendingText: string | null = null
+  let lastSentText = ''
+  let lastSentAt = 0
+  let inFlight: Promise<void> | null = null
+  let scheduledTimer: ReturnType<typeof setTimeout> | null = null
+  let stopped = false
+  let materialized = false
+  /** Generation counter for supersession detection. */
+  let generation = 0
+
+  function cancelScheduled(): void {
+    if (scheduledTimer != null) {
+      clearTimeout(scheduledTimer)
+      scheduledTimer = null
+    }
+  }
+
+  async function sendDraft(text: string): Promise<boolean> {
+    if (!draftApi || draftId == null) return false
+    try {
+      const params: { message_thread_id?: number } = {}
+      if (threadId != null) params.message_thread_id = threadId
+      await draftApi(chatId, draftId, text, Object.keys(params).length > 0 ? params : undefined)
+      return true
+    } catch (err) {
+      if (shouldFallbackFromDraftTransport(err)) {
+        warn?.(
+          `answer-stream: sendMessageDraft rejected — falling back to sendMessage/editMessageText (${err instanceof Error ? err.message : String(err)})`,
+        )
+        usesDraftTransport = false
+        draftId = undefined
+        return false
+      }
+      throw err
+    }
+  }
+
+  async function sendOrEdit(text: string, gen: number): Promise<void> {
+    if (stopped) return
+    const trimmed = text.trimEnd()
+    if (!trimmed || trimmed.length > TELEGRAM_MAX_CHARS) return
+    if (trimmed === lastSentText) return
+
+    const prevText = lastSentText
+    lastSentText = trimmed
+
+    try {
+      if (usesDraftTransport) {
+        const ok = await sendDraft(trimmed)
+        if (!ok) {
+          // Draft failed with a permanent error → fell back to message transport
+          // Retry the same text via message transport
+          await sendOrEditViaMessage(trimmed, gen, prevText)
+        }
+        return
+      }
+      await sendOrEditViaMessage(trimmed, gen, prevText)
+    } catch (err) {
+      // Log but don't crash — transient errors are common
+      warn?.(`answer-stream: send/edit failed: ${err instanceof Error ? err.message : String(err)}`)
+      // Restore so next iteration retries
+      lastSentText = prevText
+    }
+  }
+
+  async function sendOrEditViaMessage(trimmed: string, gen: number, prevText: string): Promise<void> {
+    if (typeof streamMsgId === 'number') {
+      // Edit existing message
+      const editParams: Parameters<typeof editMessageText>[3] = {
+        parse_mode: 'HTML',
+        link_preview_options: { is_disabled: true },
+      }
+      if (threadId != null) editParams.message_thread_id = threadId
+      try {
+        await editMessageText(chatId, streamMsgId, trimmed, editParams)
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err)
+        if (/message is not modified/i.test(msg)) {
+          // Not an error — identical text
+          return
+        }
+        if (/message to edit not found|MESSAGE_ID_INVALID/i.test(msg)) {
+          // Message deleted — re-send from scratch next cycle
+          log?.(`answer-stream: message not found (id=${streamMsgId}), will re-send`)
+          streamMsgId = undefined
+          lastSentText = prevText
+          return
+        }
+        throw err
+      }
+    } else {
+      // First send — capture message_id; check generation for supersession
+      const sendParams: Parameters<typeof sendMessage>[2] = {
+        parse_mode: 'HTML',
+        link_preview_options: { is_disabled: true },
+      }
+      if (threadId != null) sendParams.message_thread_id = threadId
+      if (replyToMessageId != null) sendParams.reply_parameters = { message_id: replyToMessageId }
+      const sent = await sendMessage(chatId, trimmed, sendParams)
+      const sentId = sent?.message_id
+      if (typeof sentId !== 'number' || !Number.isFinite(sentId)) {
+        warn?.('answer-stream: sendMessage returned no message_id')
+        return
+      }
+      if (gen !== generation) {
+        // Superseded — this send resolved after forceNewMessage() was called
+        onSuperseded?.({ messageId: sentId, textSnapshot: trimmed })
+        log?.(`answer-stream: superseded send (messageId=${sentId}, gen=${gen} vs ${generation})`)
+        return
+      }
+      streamMsgId = sentId
+      log?.(`answer-stream: sent (id=${sentId})`)
+    }
+  }
+
+  async function flushLoop(): Promise<void> {
+    while (pendingText != null && !stopped) {
+      const text = pendingText
+      pendingText = null
+      const gen = generation
+      await sendOrEdit(text, gen)
+      lastSentAt = Date.now()
+    }
+  }
+
+  function schedule(): void {
+    if (scheduledTimer != null || stopped) return
+    const sinceLast = Date.now() - lastSentAt
+    const delay = Math.max(0, effectiveThrottle - sinceLast)
+    scheduledTimer = setTimeout(() => {
+      scheduledTimer = null
+      if (inFlight) return
+      inFlight = flushLoop().finally(() => {
+        inFlight = null
+      })
+    }, delay)
+  }
+
+  return {
+    update(text: string): void {
+      if (stopped || materialized) return
+      const trimmed = text.trimEnd()
+      if (!trimmed) return
+
+      // minInitialChars gate: don't open the lane yet
+      if (streamMsgId == null && !usesDraftTransport && trimmed.length < minInitialChars) return
+
+      pendingText = trimmed
+
+      if (inFlight == null) {
+        const sinceLast = Date.now() - lastSentAt
+        if (sinceLast >= effectiveThrottle) {
+          inFlight = flushLoop().finally(() => {
+            inFlight = null
+          })
+        } else {
+          schedule()
+        }
+      } else {
+        // Chain off current in-flight to drain the new pendingText
+        inFlight.then(() => {
+          if (stopped || pendingText == null) return
+          if (inFlight != null) return
+          const sinceLast = Date.now() - lastSentAt
+          if (sinceLast >= effectiveThrottle) {
+            inFlight = flushLoop().finally(() => {
+              inFlight = null
+            })
+          } else {
+            schedule()
+          }
+        }).catch(() => {})
+      }
+    },
+
+    async materialize(): Promise<number | undefined> {
+      if (materialized) return streamMsgId
+      materialized = true
+      stopped = true
+      cancelScheduled()
+
+      // Wait for any in-flight edit to settle
+      if (inFlight) {
+        try { await inFlight } catch { /* ignore */ }
+      }
+
+      // Clear draft so Telegram input area doesn't show stale text
+      if (usesDraftTransport && draftApi != null && draftId != null) {
+        try {
+          const clearParams: { message_thread_id?: number } = {}
+          if (threadId != null) clearParams.message_thread_id = threadId
+          await draftApi(
+            chatId,
+            draftId,
+            '',
+            Object.keys(clearParams).length > 0 ? clearParams : undefined,
+          )
+        } catch {
+          // Best-effort cleanup
+        }
+      }
+
+      // The text we want to materialize
+      const textToSend = lastSentText || pendingText
+      if (!textToSend || !textToSend.trim()) {
+        log?.('answer-stream: materialize — nothing to send')
+        return undefined
+      }
+
+      // Always send a fresh message for push notification
+      const sendParams: Parameters<typeof sendMessage>[2] = {
+        parse_mode: 'HTML',
+        link_preview_options: { is_disabled: true },
+      }
+      if (threadId != null) sendParams.message_thread_id = threadId
+      // Don't quote-reply on materialize — the draft stream already established
+      // the reply context visually. A second reply_parameters would create a
+      // nested quote that looks wrong.
+
+      try {
+        const sent = await sendMessage(chatId, textToSend.trimEnd(), sendParams)
+        const sentId = sent?.message_id
+        if (typeof sentId === 'number' && Number.isFinite(sentId)) {
+          streamMsgId = sentId
+          log?.(`answer-stream: materialized (id=${sentId})`)
+          return sentId
+        }
+      } catch (err) {
+        warn?.(`answer-stream: materialize send failed: ${err instanceof Error ? err.message : String(err)}`)
+      }
+      return undefined
+    },
+
+    forceNewMessage(): void {
+      cancelScheduled()
+      generation += 1
+      streamMsgId = undefined
+      lastSentText = ''
+      lastSentAt = 0
+      pendingText = null
+      stopped = false
+      materialized = false
+      if (usesDraftTransport) {
+        draftId = allocateDraftId()
+      }
+      log?.(`answer-stream: forceNewMessage (gen=${generation})`)
+    },
+
+    messageId(): number | undefined {
+      return streamMsgId
+    },
+
+    stop(): void {
+      stopped = true
+      cancelScheduled()
+    },
+  }
+}
+
+/** Reset the draft-id counter for tests. */
+export function __resetDraftIdForTests(): void {
+  _nextDraftId = 1
+}

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -35,6 +35,7 @@ import { buildAttachmentPath, assertInsideInbox } from '../attachment-path.js'
 import { createPinManager } from '../progress-card-pin-manager.js'
 import { createPinWatchdog } from '../progress-card-pin-watchdog.js'
 import { logStreamingEvent } from '../streaming-metrics.js'
+import { createAnswerStream, type AnswerStreamHandle } from '../answer-stream.js'
 import { type SessionEvent } from '../session-tail.js'
 import {
   createProgressDriver,
@@ -495,6 +496,27 @@ let currentSessionThreadId: number | undefined = undefined
 let currentTurnReplyCalled = false
 let currentTurnCapturedText: string[] = []
 let orphanedReplyTimeoutId: ReturnType<typeof setTimeout> | null = null
+
+// Issue #195 — answer-lane streaming.
+// Lazily created on the first text event of a turn (once enough text has
+// accumulated, the stream itself gates on minInitialChars). Materialized
+// and cleared at turn_end. One per active turn; supersession protection
+// on the answer-stream handle covers race with rapid steers/queues.
+let activeAnswerStream: AnswerStreamHandle | null = null
+let currentTurnIsDm = false
+let currentTurnGatewayReceiveAt = 0
+
+/**
+ * Telegram chat-id convention: positive ids are private chats (DM with a
+ * user; chat.id === user.id). Negative ids are groups, supergroups, or
+ * channels. Used to pick the answer-stream transport without an extra
+ * getChat round-trip.
+ */
+function isDmChatId(chatId: string | null | undefined): boolean {
+  if (!chatId) return false
+  const id = Number(chatId)
+  return Number.isFinite(id) && id > 0
+}
 
 const CONTEXT_EXHAUSTION_COOLDOWN_MS = 10 * 60 * 1000
 let lastContextExhaustionWarningAt = 0
@@ -1891,11 +1913,26 @@ function handleSessionEvent(ev: SessionEvent): void {
       // prior turn before resetting focus.
       typingWrapper.drainAll()
       if (ev.chatId) {
+        // Issue #195: if a previous turn left an answer-lane stream open
+        // (rapid steer/queue), force it to a new generation so its in-flight
+        // edits don't mutate the new turn's message. Materialize is best-effort
+        // — we don't await here because turn_end on the prior turn should
+        // have already done it; this is a defensive supersession guard.
+        if (activeAnswerStream != null) {
+          activeAnswerStream.forceNewMessage()
+          activeAnswerStream.stop()
+          activeAnswerStream = null
+        }
         currentSessionChatId = ev.chatId
         currentSessionThreadId = ev.threadId != null ? Number(ev.threadId) : undefined
         currentTurnReplyCalled = false
         currentTurnCapturedText = []
         currentTurnStartedAt = Date.now()
+        // Issue #195: capture transport selection + time-to-ack baseline
+        // up-front so the per-turn answer-stream config is determined before
+        // the first text event arrives.
+        currentTurnIsDm = isDmChatId(ev.chatId)
+        currentTurnGatewayReceiveAt = currentTurnStartedAt
         if (pendingPtyPartial != null) {
           const pending = pendingPtyPartial
           pendingPtyPartial = null
@@ -1933,6 +1970,54 @@ function handleSessionEvent(ev: SessionEvent): void {
     case 'text': {
       if (currentSessionChatId != null) {
         currentTurnCapturedText.push(ev.text)
+        // Issue #195: feed the answer-lane stream. The stream itself
+        // gates on minInitialChars and throttles edits — short replies
+        // stay below the threshold and never spawn a message.
+        if (activeAnswerStream == null) {
+          activeAnswerStream = createAnswerStream({
+            chatId: currentSessionChatId,
+            isPrivateChat: currentTurnIsDm,
+            threadId: currentSessionThreadId,
+            sendMessageDraft: (
+              bot.api as Bot['api'] & {
+                sendMessageDraft?: (
+                  chatId: string,
+                  draftId: number,
+                  text: string,
+                  params?: { message_thread_id?: number },
+                ) => Promise<unknown>
+              }
+            ).sendMessageDraft?.bind(bot.api),
+            sendMessage: async (chatId, text, params) => {
+              const msg = await bot.api.sendMessage(chatId, text, {
+                parse_mode: params?.parse_mode,
+                ...(params?.message_thread_id != null
+                  ? { message_thread_id: params.message_thread_id }
+                  : {}),
+                ...(params?.link_preview_options != null
+                  ? { link_preview_options: params.link_preview_options }
+                  : {}),
+                ...(params?.reply_parameters != null
+                  ? { reply_parameters: params.reply_parameters }
+                  : {}),
+              })
+              return { message_id: msg.message_id }
+            },
+            editMessageText: (chatId, messageId, text, params) =>
+              bot.api.editMessageText(chatId, messageId, text, {
+                parse_mode: params?.parse_mode,
+                ...(params?.message_thread_id != null
+                  ? { message_thread_id: params.message_thread_id }
+                  : {}),
+                ...(params?.link_preview_options != null
+                  ? { link_preview_options: params.link_preview_options }
+                  : {}),
+              }),
+            log: (msg) => process.stderr.write(`telegram gateway: ${msg}\n`),
+            warn: (msg) => process.stderr.write(`telegram gateway: ${msg}\n`),
+          })
+        }
+        activeAnswerStream.update(currentTurnCapturedText.join(''))
       }
       resetOrphanedReplyTimeout()
 
@@ -1955,6 +2040,13 @@ function handleSessionEvent(ev: SessionEvent): void {
         const ctrl = activeStatusReactions.get(statusKey(chatId, threadId))
         if (ctrl) ctrl.setError()
         purgeReactionTracking(statusKey(chatId, threadId))
+        // Issue #195: tear down the answer-lane stream on context-exhaustion
+        // bail-out. The user is being told the session needs /restart, so any
+        // partially-streamed answer would be misleading.
+        if (activeAnswerStream != null) {
+          activeAnswerStream.stop()
+          activeAnswerStream = null
+        }
         currentSessionChatId = null
         currentSessionThreadId = undefined
         currentTurnReplyCalled = false
@@ -1983,6 +2075,27 @@ function handleSessionEvent(ev: SessionEvent): void {
       if (orphanedReplyTimeoutId != null) {
         clearTimeout(orphanedReplyTimeoutId)
         orphanedReplyTimeoutId = null
+      }
+      // Issue #195: materialize the answer-lane stream as a fresh
+      // sendMessage so the user's device gets a push notification on
+      // turn completion (edits don't fire pushes). Best-effort — if
+      // materialize fails, log and proceed; the existing reply path
+      // is still authoritative.
+      if (activeAnswerStream != null) {
+        const stream = activeAnswerStream
+        activeAnswerStream = null
+        void stream
+          .materialize()
+          .catch((err) => {
+            process.stderr.write(
+              `telegram gateway: answer-stream materialize failed: ${
+                err instanceof Error ? err.message : String(err)
+              }\n`,
+            )
+          })
+          .finally(() => {
+            stream.stop()
+          })
       }
       if (currentSessionChatId == null) return
       const chatId = currentSessionChatId

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -2078,24 +2078,39 @@ function handleSessionEvent(ev: SessionEvent): void {
       }
       // Issue #195: materialize the answer-lane stream as a fresh
       // sendMessage so the user's device gets a push notification on
-      // turn completion (edits don't fire pushes). Best-effort — if
-      // materialize fails, log and proceed; the existing reply path
-      // is still authoritative.
+      // turn completion (edits don't fire pushes).
+      //
+      // Guard with !currentTurnReplyCalled: the existing reply path is
+      // authoritative for the user-visible answer text. The agent normally
+      // calls reply/stream_reply during the turn, which posts the canonical
+      // message. Materializing the answer-lane on top of that produces a
+      // duplicate. Only materialize when no reply tool was invoked — which
+      // covers the case where the model emitted text but the agent never
+      // committed it via a tool call (rare, but the JTBD wants the user to
+      // see SOMETHING in that case rather than nothing).
+      //
+      // Either way we stop+null the stream — even when the reply path won,
+      // we don't want a leaked stream lingering past turn_end.
       if (activeAnswerStream != null) {
         const stream = activeAnswerStream
         activeAnswerStream = null
-        void stream
-          .materialize()
-          .catch((err) => {
-            process.stderr.write(
-              `telegram gateway: answer-stream materialize failed: ${
-                err instanceof Error ? err.message : String(err)
-              }\n`,
-            )
-          })
-          .finally(() => {
-            stream.stop()
-          })
+        if (!currentTurnReplyCalled) {
+          void stream
+            .materialize()
+            .catch((err) => {
+              process.stderr.write(
+                `telegram gateway: answer-stream materialize failed: ${
+                  err instanceof Error ? err.message : String(err)
+                }\n`,
+              )
+            })
+            .finally(() => {
+              stream.stop()
+            })
+        } else {
+          // Reply path won — discard the answer-lane silently.
+          stream.stop()
+        }
       }
       if (currentSessionChatId == null) return
       const chatId = currentSessionChatId

--- a/telegram-plugin/streaming-metrics.ts
+++ b/telegram-plugin/streaming-metrics.ts
@@ -52,6 +52,47 @@ export type StreamingEvent =
       durationMs: number
       suppressClearedCount: number
     }
+  /**
+   * Emitted when the gateway receives an inbound message (from Telegram)
+   * and immediately sets the 👀 ack reaction. Delta = gateway-receive → ack.
+   * Acceptance item 7: time-to-ack instrumentation.
+   */
+  | {
+      kind: 'inbound_ack'
+      chatId: string
+      messageId: number
+      ackDelayMs: number
+    }
+  /**
+   * Emitted at turn_end. Records the longest contiguous interval during
+   * the turn where no signal (progress-card edit, text event, status
+   * reaction update, or answer-lane update) was sent to the user.
+   * Acceptance item 7: longest-silent-gap-during-turn instrumentation.
+   */
+  | {
+      kind: 'turn_signal_gap'
+      chatId: string
+      longestGapMs: number
+      turnDurationMs: number
+    }
+  /**
+   * Emitted when the answer-lane sends or edits a message.
+   */
+  | {
+      kind: 'answer_lane_update'
+      chatId: string
+      messageId: number | undefined
+      charCount: number
+      transport: 'draft' | 'message' | 'edit'
+    }
+  /**
+   * Emitted when the answer-lane is materialized at turn-end.
+   */
+  | {
+      kind: 'answer_lane_materialized'
+      chatId: string
+      messageId: number | undefined
+    }
 
 /**
  * True iff the env gate is on. Re-read on every call so tests can toggle

--- a/telegram-plugin/tests/answer-stream.test.ts
+++ b/telegram-plugin/tests/answer-stream.test.ts
@@ -1,0 +1,483 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import {
+  createAnswerStream,
+  __resetDraftIdForTests,
+  MIN_INITIAL_CHARS,
+  DRAFT_METHOD_UNAVAILABLE_RE,
+  DRAFT_CHAT_UNSUPPORTED_RE,
+} from '../answer-stream.js'
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+/** Flush microtask queue N times. */
+async function flushMicrotasks(times = 10): Promise<void> {
+  for (let i = 0; i < times; i++) {
+    await Promise.resolve()
+  }
+}
+
+type SendMessageFn = (
+  chatId: string,
+  text: string,
+  params?: {
+    parse_mode?: 'HTML'
+    message_thread_id?: number
+    link_preview_options?: { is_disabled: boolean }
+    reply_parameters?: { message_id: number }
+  },
+) => Promise<{ message_id: number }>
+
+type EditMessageTextFn = (
+  chatId: string,
+  messageId: number,
+  text: string,
+  params?: {
+    parse_mode?: 'HTML'
+    message_thread_id?: number
+    link_preview_options?: { is_disabled: boolean }
+  },
+) => Promise<unknown>
+
+type SendMessageDraftFn = (
+  chatId: string,
+  draftId: number,
+  text: string,
+  params?: { message_thread_id?: number },
+) => Promise<unknown>
+
+let nextMessageId = 1000
+
+function makeSendMessage(): ReturnType<typeof vi.fn> & SendMessageFn {
+  const fn = vi.fn(async (_chatId: string, _text: string) => {
+    return { message_id: nextMessageId++ }
+  })
+  return fn as unknown as ReturnType<typeof vi.fn> & SendMessageFn
+}
+
+function makeEditMessageText(): ReturnType<typeof vi.fn> & EditMessageTextFn {
+  return vi.fn(async () => {}) as unknown as ReturnType<typeof vi.fn> & EditMessageTextFn
+}
+
+function makeSendMessageDraft(): ReturnType<typeof vi.fn> & SendMessageDraftFn {
+  return vi.fn(async () => {}) as unknown as ReturnType<typeof vi.fn> & SendMessageDraftFn
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  __resetDraftIdForTests()
+  nextMessageId = 1000
+  vi.useFakeTimers()
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('answer-stream — minInitialChars threshold', () => {
+  it('does not call transport when text is below minInitialChars', async () => {
+    const sendMessage = makeSendMessage()
+    const editMessageText = makeEditMessageText()
+    const stream = createAnswerStream({
+      chatId: 'chat1',
+      isPrivateChat: false,
+      minInitialChars: 400,
+      throttleMs: 250,
+      sendMessage,
+      editMessageText,
+    })
+
+    // 200 chars < 400 threshold
+    stream.update('x'.repeat(200))
+    vi.advanceTimersByTime(1000)
+    await flushMicrotasks()
+
+    expect(sendMessage).not.toHaveBeenCalled()
+    expect(editMessageText).not.toHaveBeenCalled()
+  })
+
+  it('calls transport exactly once when text meets minInitialChars', async () => {
+    const sendMessage = makeSendMessage()
+    const editMessageText = makeEditMessageText()
+    const stream = createAnswerStream({
+      chatId: 'chat1',
+      isPrivateChat: false,
+      minInitialChars: 400,
+      throttleMs: 250,
+      sendMessage,
+      editMessageText,
+    })
+
+    // 500 chars >= 400 threshold
+    stream.update('y'.repeat(500))
+    // effectiveThrottle = max(250, 250) = 250; lastSentAt=0 so fires immediately
+    await flushMicrotasks()
+
+    expect(sendMessage).toHaveBeenCalledTimes(1)
+    expect(sendMessage).toHaveBeenCalledWith(
+      'chat1',
+      'y'.repeat(500),
+      expect.objectContaining({ parse_mode: 'HTML' }),
+    )
+    expect(editMessageText).not.toHaveBeenCalled()
+  })
+})
+
+describe('answer-stream — draft transport selection', () => {
+  it('uses sendMessageDraft for DMs (isPrivateChat: true)', async () => {
+    const sendMessage = makeSendMessage()
+    const editMessageText = makeEditMessageText()
+    const sendMessageDraft = makeSendMessageDraft()
+    const stream = createAnswerStream({
+      chatId: 'chat1',
+      isPrivateChat: true,
+      throttleMs: 250,
+      sendMessage,
+      editMessageText,
+      sendMessageDraft,
+    })
+
+    // Draft transport bypasses minInitialChars gate — any non-empty text goes
+    stream.update('Hello from DM!')
+    await flushMicrotasks()
+
+    expect(sendMessageDraft).toHaveBeenCalledTimes(1)
+    expect(sendMessageDraft).toHaveBeenCalledWith(
+      'chat1',
+      expect.any(Number),
+      'Hello from DM!',
+      undefined,
+    )
+    expect(sendMessage).not.toHaveBeenCalled()
+  })
+
+  it('uses sendMessage for non-DM chats even when sendMessageDraft is provided', async () => {
+    const sendMessage = makeSendMessage()
+    const editMessageText = makeEditMessageText()
+    const sendMessageDraft = makeSendMessageDraft()
+    const stream = createAnswerStream({
+      chatId: 'chat1',
+      isPrivateChat: false,
+      minInitialChars: 10,
+      throttleMs: 250,
+      sendMessage,
+      editMessageText,
+      sendMessageDraft,
+    })
+
+    stream.update('x'.repeat(50))
+    await flushMicrotasks()
+
+    expect(sendMessage).toHaveBeenCalledTimes(1)
+    expect(sendMessageDraft).not.toHaveBeenCalled()
+  })
+})
+
+describe('answer-stream — runtime fallback when sendMessageDraft rejects', () => {
+  it('falls back to sendMessage when sendMessageDraft throws DRAFT_METHOD_UNAVAILABLE_RE pattern', async () => {
+    const sendMessage = makeSendMessage()
+    const editMessageText = makeEditMessageText()
+    // The shouldFallbackFromDraftTransport helper checks for "sendMessageDraft" in the
+    // error message plus the regex pattern.
+    const sendMessageDraft = vi.fn(async () => {
+      throw new Error('sendMessageDraft: unknown method')
+    })
+
+    const stream = createAnswerStream({
+      chatId: 'chat1',
+      isPrivateChat: true,
+      throttleMs: 250,
+      sendMessage,
+      editMessageText,
+      sendMessageDraft,
+    })
+
+    // First update — draft throws, falls back
+    stream.update('Hello DM!')
+    await flushMicrotasks()
+
+    expect(sendMessageDraft).toHaveBeenCalledTimes(1)
+    // After fallback, sendMessage should have been called with the same text
+    expect(sendMessage).toHaveBeenCalledTimes(1)
+    expect(sendMessage).toHaveBeenCalledWith('chat1', 'Hello DM!', expect.any(Object))
+
+    // Subsequent update should use sendMessage+editMessageText, not draft
+    sendMessageDraft.mockClear()
+    sendMessage.mockClear()
+    vi.advanceTimersByTime(1000)
+    stream.update('Follow-up!')
+    await flushMicrotasks()
+
+    expect(sendMessageDraft).not.toHaveBeenCalled()
+    expect(editMessageText).toHaveBeenCalledTimes(1)
+  })
+
+  it('falls back when sendMessageDraft throws DRAFT_CHAT_UNSUPPORTED_RE pattern', async () => {
+    const sendMessage = makeSendMessage()
+    const editMessageText = makeEditMessageText()
+    const sendMessageDraft = vi.fn(async () => {
+      throw new Error("sendMessageDraft can't be used in this chat")
+    })
+
+    const stream = createAnswerStream({
+      chatId: 'chat1',
+      isPrivateChat: true,
+      throttleMs: 250,
+      sendMessage,
+      editMessageText,
+      sendMessageDraft,
+    })
+
+    stream.update('Hello!')
+    await flushMicrotasks()
+
+    expect(sendMessageDraft).toHaveBeenCalledTimes(1)
+    expect(sendMessage).toHaveBeenCalledTimes(1)
+    expect(sendMessage).toHaveBeenCalledWith('chat1', 'Hello!', expect.any(Object))
+  })
+})
+
+describe('answer-stream — throttling', () => {
+  it('three rapid updates within throttleMs result in at most two transport calls', async () => {
+    const sendMessage = makeSendMessage()
+    const editMessageText = makeEditMessageText()
+    const THROTTLE = 1000
+    const stream = createAnswerStream({
+      chatId: 'chat1',
+      isPrivateChat: false,
+      minInitialChars: 10,
+      throttleMs: THROTTLE,
+      sendMessage,
+      editMessageText,
+    })
+
+    // First update — fires immediately (lastSentAt=0)
+    stream.update('a'.repeat(50))
+    await flushMicrotasks()
+    expect(sendMessage).toHaveBeenCalledTimes(1)
+
+    // Three rapid updates within the throttle window
+    stream.update('b'.repeat(50))
+    stream.update('c'.repeat(50))
+    stream.update('d'.repeat(50))
+    await flushMicrotasks()
+    // Not yet — throttle window not elapsed
+    expect(editMessageText).toHaveBeenCalledTimes(0)
+
+    // Advance past the throttle window
+    vi.advanceTimersByTime(THROTTLE)
+    await flushMicrotasks()
+
+    // Only the latest (coalesced) text lands — at most one edit call
+    expect(editMessageText.mock.calls.length).toBeLessThanOrEqual(1)
+    if (editMessageText.mock.calls.length === 1) {
+      expect(editMessageText.mock.calls[0][2]).toBe('d'.repeat(50))
+    }
+
+    // Total transport calls: 1 initial send + at most 1 coalesced edit
+    const totalCalls = sendMessage.mock.calls.length + editMessageText.mock.calls.length
+    expect(totalCalls).toBeLessThanOrEqual(2)
+  })
+})
+
+describe('answer-stream — materialize()', () => {
+  it('sends a fresh sendMessage (not editMessageText) on materialize', async () => {
+    const sendMessage = makeSendMessage()
+    const editMessageText = makeEditMessageText()
+    const THROTTLE = 1000
+    const stream = createAnswerStream({
+      chatId: 'chat1',
+      isPrivateChat: false,
+      minInitialChars: 10,
+      throttleMs: THROTTLE,
+      sendMessage,
+      editMessageText,
+    })
+
+    // Stream some text
+    stream.update('x'.repeat(50))
+    await flushMicrotasks()
+    // Advance so the initial send lands
+    vi.advanceTimersByTime(THROTTLE)
+    await flushMicrotasks()
+
+    const sendCallsBefore = sendMessage.mock.calls.length
+    editMessageText.mockClear()
+
+    // materialize() should fire a fresh sendMessage
+    const msgId = await stream.materialize()
+
+    expect(typeof msgId).toBe('number')
+    expect(sendMessage.mock.calls.length).toBeGreaterThan(sendCallsBefore)
+    // materialize always uses sendMessage, never editMessageText
+    expect(editMessageText).not.toHaveBeenCalled()
+  })
+
+  it('materialize() is idempotent — second call returns same id, no extra sendMessage', async () => {
+    const sendMessage = makeSendMessage()
+    const editMessageText = makeEditMessageText()
+    const stream = createAnswerStream({
+      chatId: 'chat1',
+      isPrivateChat: false,
+      minInitialChars: 10,
+      throttleMs: 250,
+      sendMessage,
+      editMessageText,
+    })
+
+    stream.update('x'.repeat(50))
+    await flushMicrotasks()
+
+    const id1 = await stream.materialize()
+    const sendCallsAfterFirst = sendMessage.mock.calls.length
+
+    const id2 = await stream.materialize()
+
+    expect(id1).toBe(id2)
+    // No additional sendMessage calls on the second call
+    expect(sendMessage.mock.calls.length).toBe(sendCallsAfterFirst)
+  })
+})
+
+describe('answer-stream — forceNewMessage() supersession', () => {
+  it('after forceNewMessage(), next update sends a fresh message not an edit', async () => {
+    const sendMessage = makeSendMessage()
+    const editMessageText = makeEditMessageText()
+    const THROTTLE = 1000
+    const stream = createAnswerStream({
+      chatId: 'chat1',
+      isPrivateChat: false,
+      minInitialChars: 10,
+      throttleMs: THROTTLE,
+      sendMessage,
+      editMessageText,
+    })
+
+    // Stream initial text
+    stream.update('x'.repeat(50))
+    await flushMicrotasks()
+    expect(sendMessage).toHaveBeenCalledTimes(1)
+    const firstMsgId = sendMessage.mock.calls[0]
+
+    // Advance past throttle so a new update is ready to send
+    vi.advanceTimersByTime(THROTTLE)
+    await flushMicrotasks()
+
+    // Now force a new message
+    stream.forceNewMessage()
+    sendMessage.mockClear()
+    editMessageText.mockClear()
+
+    // Next update should NOT edit the old message — should send a fresh one
+    stream.update('y'.repeat(50))
+    await flushMicrotasks()
+
+    expect(sendMessage).toHaveBeenCalledTimes(1)
+    expect(editMessageText).not.toHaveBeenCalled()
+  })
+})
+
+describe('answer-stream — stop() cancels pending throttled edits', () => {
+  it('stop() before timer fires prevents any transport call', async () => {
+    const sendMessage = makeSendMessage()
+    const editMessageText = makeEditMessageText()
+    const THROTTLE = 1000
+    const stream = createAnswerStream({
+      chatId: 'chat1',
+      isPrivateChat: false,
+      minInitialChars: 10,
+      throttleMs: THROTTLE,
+      sendMessage,
+      editMessageText,
+    })
+
+    // Send initial to get msgId established
+    stream.update('x'.repeat(50))
+    await flushMicrotasks()
+    expect(sendMessage).toHaveBeenCalledTimes(1)
+
+    // Schedule a throttled edit
+    stream.update('y'.repeat(50))
+    await flushMicrotasks()
+    // Not yet sent (within throttle window)
+    expect(editMessageText).toHaveBeenCalledTimes(0)
+
+    // Stop before the timer fires
+    stream.stop()
+    sendMessage.mockClear()
+    editMessageText.mockClear()
+
+    // Advance well past the throttle window
+    vi.advanceTimersByTime(THROTTLE * 3)
+    await flushMicrotasks()
+
+    // The pending edit should NOT have fired
+    expect(editMessageText).not.toHaveBeenCalled()
+    expect(sendMessage).not.toHaveBeenCalled()
+  })
+})
+
+describe('answer-stream — empty / whitespace-only text is a no-op', () => {
+  it('update("") does not trigger any transport call', async () => {
+    const sendMessage = makeSendMessage()
+    const editMessageText = makeEditMessageText()
+    const stream = createAnswerStream({
+      chatId: 'chat1',
+      isPrivateChat: false,
+      minInitialChars: 0,
+      throttleMs: 250,
+      sendMessage,
+      editMessageText,
+    })
+
+    stream.update('')
+    vi.advanceTimersByTime(1000)
+    await flushMicrotasks()
+
+    expect(sendMessage).not.toHaveBeenCalled()
+    expect(editMessageText).not.toHaveBeenCalled()
+  })
+
+  it('update("   ") does not trigger any transport call', async () => {
+    const sendMessage = makeSendMessage()
+    const editMessageText = makeEditMessageText()
+    const stream = createAnswerStream({
+      chatId: 'chat1',
+      isPrivateChat: false,
+      minInitialChars: 0,
+      throttleMs: 250,
+      sendMessage,
+      editMessageText,
+    })
+
+    stream.update('   ')
+    vi.advanceTimersByTime(1000)
+    await flushMicrotasks()
+
+    expect(sendMessage).not.toHaveBeenCalled()
+    expect(editMessageText).not.toHaveBeenCalled()
+  })
+})
+
+describe('answer-stream — maxChars guard', () => {
+  it('does not send when text exceeds 4096 chars', async () => {
+    const sendMessage = makeSendMessage()
+    const editMessageText = makeEditMessageText()
+    const stream = createAnswerStream({
+      chatId: 'chat1',
+      isPrivateChat: false,
+      minInitialChars: 0,
+      throttleMs: 250,
+      sendMessage,
+      editMessageText,
+    })
+
+    // 4097 chars exceeds Telegram's 4096 limit
+    stream.update('z'.repeat(4097))
+    vi.advanceTimersByTime(1000)
+    await flushMicrotasks()
+
+    expect(sendMessage).not.toHaveBeenCalled()
+    expect(editMessageText).not.toHaveBeenCalled()
+  })
+})

--- a/telegram-plugin/tests/answer-stream.test.ts
+++ b/telegram-plugin/tests/answer-stream.test.ts
@@ -481,3 +481,111 @@ describe('answer-stream — maxChars guard', () => {
     expect(editMessageText).not.toHaveBeenCalled()
   })
 })
+
+describe('answer-stream — materialize() on draft transport', () => {
+  it('clears the draft and sends a fresh sendMessage on materialize', async () => {
+    const sendMessage = makeSendMessage()
+    const editMessageText = makeEditMessageText()
+    const sendMessageDraft = makeSendMessageDraft()
+    const stream = createAnswerStream({
+      chatId: 'chat1',
+      isPrivateChat: true,
+      minInitialChars: 0,
+      throttleMs: 250,
+      sendMessage,
+      editMessageText,
+      sendMessageDraft,
+    })
+
+    stream.update('hello world')
+    vi.advanceTimersByTime(500)
+    await flushMicrotasks()
+
+    expect(sendMessageDraft).toHaveBeenCalled()
+    const draftCallsBeforeMaterialize = sendMessageDraft.mock.calls.length
+
+    const finalId = await stream.materialize()
+
+    expect(sendMessage).toHaveBeenCalledTimes(1)
+    expect(sendMessage.mock.calls[0][1]).toBe('hello world')
+    expect(typeof finalId).toBe('number')
+
+    expect(sendMessageDraft.mock.calls.length).toBeGreaterThan(draftCallsBeforeMaterialize)
+    const lastDraftCall = sendMessageDraft.mock.calls[sendMessageDraft.mock.calls.length - 1]
+    expect(lastDraftCall[2]).toBe('')
+  })
+})
+
+describe('answer-stream — onSuperseded callback', () => {
+  it('invokes onSuperseded when a send resolves after forceNewMessage', async () => {
+    const onSuperseded = vi.fn()
+
+    let resolveSend: ((value: { message_id: number }) => void) | undefined
+    const sendMessage = vi.fn(
+      () =>
+        new Promise<{ message_id: number }>((resolve) => {
+          resolveSend = resolve
+        }),
+    ) as unknown as ReturnType<typeof vi.fn> & SendMessageFn
+
+    const editMessageText = makeEditMessageText()
+    const stream = createAnswerStream({
+      chatId: 'chat1',
+      isPrivateChat: false,
+      minInitialChars: 0,
+      throttleMs: 250,
+      sendMessage,
+      editMessageText,
+      onSuperseded,
+    })
+
+    stream.update('first message text')
+    vi.advanceTimersByTime(500)
+    await flushMicrotasks()
+
+    expect(sendMessage).toHaveBeenCalledTimes(1)
+    expect(resolveSend).toBeDefined()
+
+    stream.forceNewMessage()
+
+    resolveSend!({ message_id: 9999 })
+    await flushMicrotasks()
+
+    expect(onSuperseded).toHaveBeenCalledTimes(1)
+    expect(onSuperseded.mock.calls[0][0]).toEqual({
+      messageId: 9999,
+      textSnapshot: 'first message text',
+    })
+    expect(stream.messageId()).toBeUndefined()
+  })
+})
+
+describe('answer-stream — materialize() max-chars guard', () => {
+  it('does not send when buffered text exceeds 4096 chars', async () => {
+    const sendMessage = makeSendMessage()
+    const editMessageText = makeEditMessageText()
+    const warn = vi.fn()
+    const stream = createAnswerStream({
+      chatId: 'chat1',
+      isPrivateChat: false,
+      minInitialChars: 0,
+      throttleMs: 250,
+      sendMessage,
+      editMessageText,
+      warn,
+    })
+
+    stream.update('a'.repeat(4000))
+    vi.advanceTimersByTime(500)
+    await flushMicrotasks()
+    const sendsAfterStreaming = sendMessage.mock.calls.length
+
+    stream.update('b'.repeat(4097))
+    const result = await stream.materialize()
+
+    expect(result).toBeUndefined()
+    expect(sendMessage.mock.calls.length).toBe(sendsAfterStreaming)
+    expect(warn).toHaveBeenCalled()
+    expect(warn.mock.calls.some((c) => /4096|exceeds/i.test(String(c[0])))).toBe(true)
+  })
+})

--- a/telegram-plugin/tool-error-filter.ts
+++ b/telegram-plugin/tool-error-filter.ts
@@ -1,0 +1,74 @@
+/**
+ * tool-error-filter.ts — severity classifier for tool_result isError events.
+ *
+ * Acceptance item 5: benign tool failures (no-match, file-not-found,
+ * recoverable Telegram errors) don't surface as raw debug in the progress
+ * card checklist. Real failures (auth, crash, network) still escalate.
+ *
+ * Design: pure function, no side effects, no dependencies. The gateway
+ * calls isBenignToolError() on every tool_result with isError=true; when
+ * it returns true, the progress-card item is marked 'done' (✅) rather
+ * than 'failed' (❌) and no operator notification is raised.
+ *
+ * Important: this classification applies to the DISPLAY only. The agent
+ * session transcript is never mutated — the raw error text still reaches
+ * the model so it can reason about what happened.
+ */
+
+/**
+ * Pattern groups for benign tool errors.
+ *
+ * These are errors that represent "no results" or "resource absent" — the
+ * tool ran correctly but found nothing. Surfacing them as ❌ in the checklist
+ * is noise: the user can't act on "grep found nothing" and the agent will
+ * handle it in context.
+ */
+
+// File-not-found patterns (common across Bash, Read, Edit tools)
+const FILE_NOT_FOUND_RE =
+  /no such file or directory|file not found|path does not exist|enoent/i
+
+// No-match patterns (grep, find, search tools)
+const NO_MATCH_RE =
+  /no match(es)? found|returned no results?|not found in|0 result/i
+
+// Recoverable Telegram API patterns (message deleted, not modified, etc.)
+const TELEGRAM_RECOVERABLE_RE =
+  /message (is not modified|to edit not found|can't be deleted|was deleted)|MESSAGE_ID_INVALID|message not found/i
+
+// "Not a git repository" and similar tool-setup errors that aren't real failures
+const TOOL_SETUP_RE =
+  /not a git repository|command not found|permission denied/i
+
+// Timeout / cancellation that the agent will retry
+const TIMEOUT_RE =
+  /timed? ?out|operation cancelled|aborted/i
+
+/**
+ * Returns true when a tool error text represents a benign outcome that
+ * doesn't need ❌ in the UI and shouldn't trigger operator notifications.
+ *
+ * The text parameter is the raw tool result content (the first ~500 chars
+ * are sufficient for pattern matching — callers may truncate).
+ */
+export function isBenignToolError(text: string): boolean {
+  if (!text) return true // empty error = treat as benign
+  return (
+    FILE_NOT_FOUND_RE.test(text) ||
+    NO_MATCH_RE.test(text) ||
+    TELEGRAM_RECOVERABLE_RE.test(text) ||
+    TOOL_SETUP_RE.test(text) ||
+    TIMEOUT_RE.test(text)
+  )
+}
+
+/**
+ * Severity of a tool error for routing purposes.
+ * - `benign`: no-match / not-found / recoverable — suppress from UI
+ * - `real`: auth failure, crash, unexpected error — surface in UI
+ */
+export type ToolErrorSeverity = 'benign' | 'real'
+
+export function classifyToolError(text: string): ToolErrorSeverity {
+  return isBenignToolError(text) ? 'benign' : 'real'
+}


### PR DESCRIPTION
Closes #195 (partial — 5 of 7 acceptance items; remaining two filed as follow-ups, see below).

## What ships

The narrative liveness layer described in `reference/know-what-my-agent-is-doing.md`. Long replies now stream below the progress card as they arrive, instead of arriving as a wall after the checklist completes.

### Acceptance status

- [x] **(1)** New `lane: 'answer'` on a separate message ID below the progress card. Progress card never overwritten.
- [x] **(2)** `sendMessageDraft` preferred transport in DMs (detected from chat-id sign convention: positive ids are DMs). `sendMessage`+`editMessageText` fallback for groups/channels and on runtime draft rejection (mirrors OpenClaw's `DRAFT_METHOD_UNAVAILABLE_RE` / `DRAFT_CHAT_UNSUPPORTED_RE`).
- [x] **(3)** `minInitialChars` threshold (~400 chars). Short replies bypass the answer lane entirely.
- [x] **(4)** Final "done" arrives as a fresh `sendMessage` (push-firing) via `materialize()`, not an edit-finalize.
- [ ] **(5)** ~~Tool-error suppression~~ — *follow-up.* Classifier module is in place (`tool-error-filter.ts`) but wiring requires extending `SessionEvent.tool_result` to carry the error text (currently only carries `isError: boolean`). Filed as a separate issue to keep this PR focused.
- [x] **(6)** Stream-lane supersession protection via generation counter in `answer-stream.ts`; gateway `enqueue` handler does a defensive supersession of any leaked prior stream.
- [ ] **(7)** ~~Time-to-ack + silent-gap instrumentation~~ — *follow-up.* Event types are defined in `streaming-metrics.ts` (`inbound_ack`, `turn_signal_gap`, `answer_lane_update`, `answer_lane_materialized`); emission points need wiring at the 👀-reaction site and via a per-turn signal tracker. Filed as a separate issue.

## Files changed

- `telegram-plugin/answer-stream.ts` (new, 440 lines) — the answer-lane stream module modeled on OpenClaw's `draft-stream.ts` with sendMessageDraft + fallback transport, minInitialChars gating, supersession via generation counter, materialize() for fresh push-notify, throttling.
- `telegram-plugin/tool-error-filter.ts` (new, 74 lines) — pure severity classifier. Awaits a consumer (see follow-up issue).
- `telegram-plugin/streaming-metrics.ts` (+47 lines) — four new metric event types. Emission wiring is the follow-up issue.
- `telegram-plugin/gateway/gateway.ts` (+113 lines) — wires `createAnswerStream` into the session-event handler. Lazy-create on first text event; update on each subsequent text event; materialize+stop at turn_end; defensive supersession on enqueue; clean teardown on context-exhaustion.

## Status

Draft. Tests pending — being written by a follow-up worker. Will mark ready-for-review when those land.

## Implementation reference

OpenClaw's `extensions/telegram/src/draft-stream.ts` — design borrowed from there with two adaptations: (a) typed transport callbacks injected by caller for full testability without a real bot, (b) chatId sign convention for DM detection (positive = private) avoiding an extra getChat round-trip.

Co-authored-by: Claude <noreply@anthropic.com>