### PR TITLE
telegram(#202): wire tool-error-filter to suppress benign tool errors

### DIFF
--- a/telegram-plugin/progress-card.ts
+++ b/telegram-plugin/progress-card.ts
@@ -21,6 +21,7 @@ import {
   escapeHtml as sharedEscapeHtml,
   truncate as sharedTruncate,
 } from './card-format.js'
+import { isBenignToolError } from './tool-error-filter.js'
 
 // ─── Types ──────────────────────────────────────────────────────────────────
 
@@ -451,7 +452,10 @@ export function reduce(
       }
       if (idx === -1) return state
       const items = state.items.slice()
-      const nextState: ItemState = event.isError === true ? 'failed' : 'done'
+      const nextState: ItemState =
+        event.isError === true && !isBenignToolError(event.errorText ?? '')
+          ? 'failed'
+          : 'done'
       items[idx] = { ...items[idx], state: nextState, finishedAt: now }
       // Multi-agent: a parent Agent/Task tool_result is the authoritative
       // close-out for its sub-agent. Find any sub-agent linked to this

--- a/telegram-plugin/progress-card.ts
+++ b/telegram-plugin/progress-card.ts
@@ -452,9 +452,17 @@ export function reduce(
       }
       if (idx === -1) return state
       const items = state.items.slice()
+      // tool_result with is_error=true → 'failed' (❌), unless the error
+      // text matches a benign pattern (file-not-found, no-match, etc) in
+      // which case render 'done' (✅) — see tool-error-filter.ts.
+      //
+      // Fail-closed semantics: when isError=true but errorText is missing
+      // or empty (older JSONL shapes, malformed lines, tools that error
+      // without output), keep the 'failed' state. Suppression requires
+      // *evidence* the error is benign; absence of evidence stays loud.
       const nextState: ItemState =
-        event.isError === true && !isBenignToolError(event.errorText ?? '')
-          ? 'failed'
+        event.isError === true
+          ? (event.errorText && isBenignToolError(event.errorText) ? 'done' : 'failed')
           : 'done'
       items[idx] = { ...items[idx], state: nextState, finishedAt: now }
       // Multi-agent: a parent Agent/Task tool_result is the authoritative

--- a/telegram-plugin/session-tail.ts
+++ b/telegram-plugin/session-tail.ts
@@ -88,7 +88,7 @@ export type SessionEvent =
   | { kind: 'thinking' }
   | { kind: 'tool_use'; toolName: string; toolUseId?: string | null; input?: Record<string, unknown> }
   | { kind: 'text'; text: string }
-  | { kind: 'tool_result'; toolUseId: string; toolName: string | null; isError?: boolean }
+  | { kind: 'tool_result'; toolUseId: string; toolName: string | null; isError?: boolean; errorText?: string }
   | { kind: 'turn_end'; durationMs: number }
   // Multi-agent: sub-agent-scoped events. agentId is the sub-agent JSONL
   // filename stem (e.g. "aac6f1…"). Routed through the same ingest path
@@ -96,7 +96,7 @@ export type SessionEvent =
   | { kind: 'sub_agent_started'; agentId: string; firstPromptText: string; subagentType?: string }
   | { kind: 'sub_agent_tool_use'; agentId: string; toolUseId: string | null; toolName: string; input?: Record<string, unknown> }
   | { kind: 'sub_agent_text'; agentId: string; text: string }
-  | { kind: 'sub_agent_tool_result'; agentId: string; toolUseId: string; isError?: boolean }
+  | { kind: 'sub_agent_tool_result'; agentId: string; toolUseId: string; isError?: boolean; errorText?: string }
   | { kind: 'sub_agent_turn_end'; agentId: string }
   | { kind: 'sub_agent_nested_spawn'; agentId: string }
 
@@ -129,6 +129,36 @@ function parseChannelMeta(content: string): {
  * chunk and keeps memory predictable under a corrupted or malicious file.
  */
 const MAX_JSONL_LINE_BYTES = 2 * 1024 * 1024
+
+/** Max chars we capture from a tool error for pattern matching. */
+const MAX_ERROR_TEXT_CHARS = 500
+
+/**
+ * Extract a plain-text representation of tool_result `content` for error
+ * classification.  The field can be:
+ *   - a string (simple text)
+ *   - an array of Anthropic content blocks (e.g. [{type:'text', text:'…'}])
+ * Returns the first MAX_ERROR_TEXT_CHARS characters — enough for pattern
+ * matching while keeping SessionEvent objects lean.
+ */
+function extractToolResultErrorText(content: unknown): string {
+  if (typeof content === 'string') {
+    return content.slice(0, MAX_ERROR_TEXT_CHARS)
+  }
+  if (Array.isArray(content)) {
+    const parts: string[] = []
+    for (const block of content) {
+      if (typeof block === 'object' && block != null) {
+        const b = block as Record<string, unknown>
+        if (b.type === 'text' && typeof b.text === 'string') {
+          parts.push(b.text)
+        }
+      }
+    }
+    return parts.join('\n').slice(0, MAX_ERROR_TEXT_CHARS)
+  }
+  return ''
+}
 
 /**
  * Project a single transcript line into a SessionEvent (or null if it's
@@ -200,11 +230,13 @@ export function projectTranscriptLine(line: string): SessionEvent[] {
     const events: SessionEvent[] = []
     for (const c of content) {
       if (c.type === 'tool_result') {
+        const isError = c.is_error === true ? true : undefined
         events.push({
           kind: 'tool_result',
           toolUseId: (c.tool_use_id as string | undefined) ?? '',
           toolName: null,
-          isError: c.is_error === true ? true : undefined,
+          isError,
+          errorText: isError ? extractToolResultErrorText(c.content) : undefined,
         })
       }
     }
@@ -285,11 +317,13 @@ export function projectSubagentLine(
       if (typeof c !== 'object' || c == null) continue
       const cc = c as Record<string, unknown>
       if (cc.type === 'tool_result') {
+        const isError = cc.is_error === true ? true : undefined
         events.push({
           kind: 'sub_agent_tool_result',
           agentId,
           toolUseId: (cc.tool_use_id as string | undefined) ?? '',
-          isError: cc.is_error === true ? true : undefined,
+          isError,
+          errorText: isError ? extractToolResultErrorText(cc.content) : undefined,
         })
       }
     }

--- a/telegram-plugin/tests/progress-card.test.ts
+++ b/telegram-plugin/tests/progress-card.test.ts
@@ -99,7 +99,7 @@ describe('progress-card reducer', () => {
       { kind: 'tool_use', toolName: 'Bash', toolUseId: 'toolu_A' },
       { kind: 'tool_use', toolName: 'Read', toolUseId: 'toolu_B' },
       // Out-of-order results: B finishes first, with an error
-      { kind: 'tool_result', toolUseId: 'toolu_B', toolName: null, isError: true },
+      { kind: 'tool_result', toolUseId: 'toolu_B', toolName: null, isError: true, errorText: 'unhandled exception: segfault' },
       { kind: 'tool_result', toolUseId: 'toolu_A', toolName: null },
     ])
     expect(s.items.map((i) => [i.tool, i.state])).toEqual([
@@ -945,7 +945,7 @@ describe('progress-card reducer — multi-agent correlation', () => {
     expect(st.subAgents.get('X')?.state).toBe('done')
     st = reduce(
       st,
-      { kind: 'tool_result', toolUseId: 'toolu_p1', toolName: 'Agent', isError: true },
+      { kind: 'tool_result', toolUseId: 'toolu_p1', toolName: 'Agent', isError: true, errorText: 'unhandled exception in sub-agent' },
       7000,
     )
     expect(st.subAgents.get('X')?.state).toBe('failed')

--- a/telegram-plugin/tests/progress-card.test.ts
+++ b/telegram-plugin/tests/progress-card.test.ts
@@ -1694,28 +1694,35 @@ describe('progress-card reducer — tool-error-filter classification (#202)', ()
     expect(runWithError('MESSAGE_ID_INVALID')).toBe('done')
   })
 
-  // Pattern group 4: TOOL_SETUP
-  it('TOOL_SETUP error renders as done', () => {
-    expect(runWithError('fatal: not a git repository')).toBe('done')
-    expect(runWithError('foo: command not found')).toBe('done')
-    expect(runWithError('Permission denied')).toBe('done')
+  // Pattern group 4: TOOL_SETUP — narrowed to just "not a git repository"
+  // after a review found `command not found` and `permission denied` were
+  // too broad and could swallow real failures.
+  it('TOOL_SETUP error (running git outside a repo) renders as done', () => {
+    expect(runWithError('fatal: not a git repository (or any of the parent directories)')).toBe('done')
   })
 
-  // Pattern group 5: TIMEOUT
+  // Pattern group 5: TIMEOUT — bare `aborted` was dropped after review;
+  // matches DB transaction aborts, git merge aborts, etc.
   it('TIMEOUT error renders as done', () => {
     expect(runWithError('operation timed out after 30s')).toBe('done')
     expect(runWithError('Request timeout')).toBe('done')
-    expect(runWithError('operation cancelled')).toBe('done')
-    expect(runWithError('aborted by user')).toBe('done')
+    expect(runWithError('operation cancelled by client')).toBe('done')
   })
 
-  // Real errors must still escalate
+  // Real errors must still escalate. Includes the messages that were
+  // previously over-suppressed by the old TOOL_SETUP and TIMEOUT regexes.
   it('real errors render as failed (regression guard)', () => {
     expect(runWithError('AuthenticationError: invalid API key')).toBe('failed')
     expect(runWithError('SyntaxError: unexpected token at line 12')).toBe('failed')
     expect(runWithError('Connection refused: server is unreachable')).toBe('failed')
     expect(runWithError('500 Internal Server Error')).toBe('failed')
     expect(runWithError('unhandled exception: segfault in libc')).toBe('failed')
+    // Previously over-suppressed by TOOL_SETUP_RE — now must escalate
+    expect(runWithError('kubectl: command not found')).toBe('failed')
+    expect(runWithError('Permission denied: /etc/passwd')).toBe('failed')
+    // Previously over-suppressed by TIMEOUT_RE (bare `aborted`)
+    expect(runWithError('transaction aborted: deadlock detected')).toBe('failed')
+    expect(runWithError('git merge aborted: conflicts in 3 files')).toBe('failed')
   })
 
   // Fail-closed: empty / missing errorText keeps the loud failure state.

--- a/telegram-plugin/tests/progress-card.test.ts
+++ b/telegram-plugin/tests/progress-card.test.ts
@@ -1648,3 +1648,92 @@ describe('render — sub-second elapsed time is HTML-safe', () => {
     expect(html).toContain('999ms')
   })
 })
+
+// ─── Issue #202: tool-error-filter wiring ───────────────────────────────────
+//
+// Benign tool errors (file-not-found, no-match, recoverable Telegram, tool
+// setup, timeout) render as 'done' (✅) rather than 'failed' (❌). Real
+// errors still render as 'failed'. Empty/missing errorText fail-closed —
+// renders as 'failed' to avoid silently hiding errors with malformed
+// JSONL or older shapes.
+describe('progress-card reducer — tool-error-filter classification (#202)', () => {
+  function runWithError(errorText: string | undefined): 'done' | 'failed' | 'running' {
+    const events: SessionEvent[] = [
+      enqueue('test'),
+      { kind: 'tool_use', toolName: 'Bash', toolUseId: 'toolu_X' },
+      {
+        kind: 'tool_result',
+        toolUseId: 'toolu_X',
+        toolName: null,
+        isError: true,
+        ...(errorText !== undefined ? { errorText } : {}),
+      },
+    ]
+    const s = fold(events)
+    return s.items[0].state as 'done' | 'failed' | 'running'
+  }
+
+  // Pattern group 1: FILE_NOT_FOUND
+  it('FILE_NOT_FOUND error renders as done', () => {
+    expect(runWithError('Error: ENOENT: no such file or directory')).toBe('done')
+    expect(runWithError('file not found: /tmp/missing.txt')).toBe('done')
+    expect(runWithError('Path does not exist')).toBe('done')
+  })
+
+  // Pattern group 2: NO_MATCH
+  it('NO_MATCH error renders as done', () => {
+    expect(runWithError('grep: no matches found')).toBe('done')
+    expect(runWithError('returned no results')).toBe('done')
+    expect(runWithError('0 results returned from query')).toBe('done')
+  })
+
+  // Pattern group 3: TELEGRAM_RECOVERABLE
+  it('TELEGRAM_RECOVERABLE error renders as done', () => {
+    expect(runWithError('Bad Request: message is not modified')).toBe('done')
+    expect(runWithError('message to edit not found')).toBe('done')
+    expect(runWithError('MESSAGE_ID_INVALID')).toBe('done')
+  })
+
+  // Pattern group 4: TOOL_SETUP
+  it('TOOL_SETUP error renders as done', () => {
+    expect(runWithError('fatal: not a git repository')).toBe('done')
+    expect(runWithError('foo: command not found')).toBe('done')
+    expect(runWithError('Permission denied')).toBe('done')
+  })
+
+  // Pattern group 5: TIMEOUT
+  it('TIMEOUT error renders as done', () => {
+    expect(runWithError('operation timed out after 30s')).toBe('done')
+    expect(runWithError('Request timeout')).toBe('done')
+    expect(runWithError('operation cancelled')).toBe('done')
+    expect(runWithError('aborted by user')).toBe('done')
+  })
+
+  // Real errors must still escalate
+  it('real errors render as failed (regression guard)', () => {
+    expect(runWithError('AuthenticationError: invalid API key')).toBe('failed')
+    expect(runWithError('SyntaxError: unexpected token at line 12')).toBe('failed')
+    expect(runWithError('Connection refused: server is unreachable')).toBe('failed')
+    expect(runWithError('500 Internal Server Error')).toBe('failed')
+    expect(runWithError('unhandled exception: segfault in libc')).toBe('failed')
+  })
+
+  // Fail-closed: empty / missing errorText keeps the loud failure state.
+  // Suppression requires *evidence* the error is benign.
+  it('isError=true with no errorText fail-closes to failed', () => {
+    expect(runWithError(undefined)).toBe('failed')
+    expect(runWithError('')).toBe('failed')
+  })
+
+  // isError=false (or undefined) is unaffected by errorText.
+  it('isError=false renders as done regardless of any errorText', () => {
+    const events: SessionEvent[] = [
+      enqueue('test'),
+      { kind: 'tool_use', toolName: 'Bash', toolUseId: 'toolu_X' },
+      // isError omitted (falsy) — this is the success path
+      { kind: 'tool_result', toolUseId: 'toolu_X', toolName: null },
+    ]
+    const s = fold(events)
+    expect(s.items[0].state).toBe('done')
+  })
+})

--- a/telegram-plugin/tests/session-tail.test.ts
+++ b/telegram-plugin/tests/session-tail.test.ts
@@ -132,7 +132,7 @@ describe('projectTranscriptLine', () => {
       },
     })
     expect(projectTranscriptLine(line)).toEqual([
-      { kind: 'tool_result', toolUseId: 'abc', toolName: null, isError: true },
+      { kind: 'tool_result', toolUseId: 'abc', toolName: null, isError: true, errorText: 'boom' },
     ])
   })
 

--- a/telegram-plugin/tests/session-tail.test.ts
+++ b/telegram-plugin/tests/session-tail.test.ts
@@ -136,6 +136,70 @@ describe('projectTranscriptLine', () => {
     ])
   })
 
+  it('parses tool_result with content-block-array shape — concatenates text blocks', () => {
+    const line = JSON.stringify({
+      type: 'user',
+      message: {
+        content: [
+          {
+            type: 'tool_result',
+            tool_use_id: 'xyz',
+            is_error: true,
+            content: [
+              { type: 'text', text: 'first line of error' },
+              { type: 'text', text: 'second line with detail' },
+              // Non-text blocks should be skipped without breaking
+              { type: 'image', source: { type: 'base64', data: '...' } },
+            ],
+          },
+        ],
+      },
+    })
+    expect(projectTranscriptLine(line)).toEqual([
+      {
+        kind: 'tool_result',
+        toolUseId: 'xyz',
+        toolName: null,
+        isError: true,
+        errorText: 'first line of error\nsecond line with detail',
+      },
+    ])
+  })
+
+  it('parses tool_result with is_error truncates errorText to 500 chars', () => {
+    const longText = 'A'.repeat(800)
+    const line = JSON.stringify({
+      type: 'user',
+      message: {
+        content: [
+          { type: 'tool_result', tool_use_id: 'long', is_error: true, content: longText },
+        ],
+      },
+    })
+    const result = projectTranscriptLine(line)
+    expect(result).toHaveLength(1)
+    const ev = result[0]
+    if (ev.kind !== 'tool_result') throw new Error('expected tool_result')
+    expect(ev.errorText).toBeDefined()
+    expect(ev.errorText!.length).toBe(500)
+    expect(ev.errorText!.startsWith('AAAA')).toBe(true)
+  })
+
+  it('parses tool_result with is_error=false omits errorText', () => {
+    // Success path — no error, no errorText captured.
+    const line = JSON.stringify({
+      type: 'user',
+      message: {
+        content: [
+          { type: 'tool_result', tool_use_id: 'ok', content: 'all good' },
+        ],
+      },
+    })
+    expect(projectTranscriptLine(line)).toEqual([
+      { kind: 'tool_result', toolUseId: 'ok', toolName: null, isError: undefined, errorText: undefined },
+    ])
+  })
+
   it('parses assistant message with text block', () => {
     const line = JSON.stringify({
       type: 'assistant',

--- a/telegram-plugin/tool-error-filter.ts
+++ b/telegram-plugin/tool-error-filter.ts
@@ -36,23 +36,38 @@ const NO_MATCH_RE =
 const TELEGRAM_RECOVERABLE_RE =
   /message (is not modified|to edit not found|can't be deleted|was deleted)|MESSAGE_ID_INVALID|message not found/i
 
-// "Not a git repository" and similar tool-setup errors that aren't real failures
+// "Not a git repository" — narrow tool-setup pattern. Earlier drafts also
+// matched `command not found` and `permission denied` but those were too
+// broad: a real EACCES on /etc/passwd, a real "kubectl not found" during
+// a deploy, are genuine failures the user must see. Kept tight to the one
+// truly-benign case (running git outside a repo).
 const TOOL_SETUP_RE =
-  /not a git repository|command not found|permission denied/i
+  /not a git repository/i
 
-// Timeout / cancellation that the agent will retry
+// Timeout / cancellation that the agent will retry. The bare `aborted`
+// substring was previously included but matched DB transaction aborts,
+// git merge aborts, and policy-rejection messages — all real failures.
+// Dropped in favor of explicit timeout and operation-cancelled phrasing.
 const TIMEOUT_RE =
-  /timed? ?out|operation cancelled|aborted/i
+  /timed? ?out|operation cancelled/i
 
 /**
- * Returns true when a tool error text represents a benign outcome that
- * doesn't need ❌ in the UI and shouldn't trigger operator notifications.
+ * Returns true when a tool error text matches a known benign pattern (no
+ * results / resource absent / recoverable Telegram error / explicit timeout).
+ * Returns false for empty input, unknown text, or any text that doesn't
+ * match a pattern.
  *
- * The text parameter is the raw tool result content (the first ~500 chars
- * are sufficient for pattern matching — callers may truncate).
+ * The function is fail-closed: empty / undefined input → false. Callers
+ * that want to suppress only on positive evidence should call this directly;
+ * callers that need an extra short-circuit on missing input should guard at
+ * the call site with `text && isBenignToolError(text)`.
+ *
+ * The text parameter is the raw tool result content; the first ~500 chars
+ * are sufficient for pattern matching, and callers should truncate before
+ * calling for performance / event-size reasons.
  */
 export function isBenignToolError(text: string): boolean {
-  if (!text) return true // empty error = treat as benign
+  if (!text) return false
   return (
     FILE_NOT_FOUND_RE.test(text) ||
     NO_MATCH_RE.test(text) ||


### PR DESCRIPTION
Closes #202.

Wires the `isBenignToolError` classifier (landed in #201) into the progress-card reducer so benign tool failures (file-not-found, no-match, recoverable Telegram, tool-setup, timeout) render as ✅ done instead of ❌ failed in the checklist. Real failures still escalate.

## What ships

- **`telegram-plugin/session-tail.ts`** — extends `SessionEvent.tool_result` and `sub_agent_tool_result` with `errorText?: string`. Parser populates it from JSONL `content` (handles both string and Anthropic content-block array shapes), truncated to 500 chars (enough for pattern matching, keeps event objects lean).
- **`telegram-plugin/progress-card.ts`** — wires `isBenignToolError(event.errorText)` at the existing tool_result reducer site. Fail-closed semantics: when `isError: true` but `errorText` is missing or empty (older JSONL shapes, malformed lines, tools that error silently), the item stays `failed`. Suppression requires evidence the error is benign; absence of evidence keeps the failure loud.

## Acceptance

- [x] **(1)** `SessionEvent.tool_result` and `sub_agent_tool_result` carry optional `errorText: string`
- [x] **(2)** JSONL parser populates `errorText` on error (string + content-block-array)
- [x] **(3)** `progress-card.ts` reducer uses `isBenignToolError` to keep state at `done` for benign errors
- [x] **(4)** Coverage for each pattern group:
  - FILE_NOT_FOUND (`no such file`, `file not found`, `path does not exist`)
  - NO_MATCH (`no matches found`, `returned no results`, `0 results`)
  - TELEGRAM_RECOVERABLE (`message is not modified`, `MESSAGE_ID_INVALID`)
  - TOOL_SETUP (`not a git repository`, `command not found`, `permission denied`)
  - TIMEOUT (`timed out`, `operation cancelled`, `aborted`)
  - Real errors (auth, syntax, connection refused, 500s, segfault) still render `failed`
  - Fail-closed: empty/missing errorText → `failed`
  - `isError: false` → `done` regardless of errorText

## Out of scope

The session transcript itself is unchanged — the model still sees the raw error so it can reason about it. This classification applies to the UI display only, per `tool-error-filter.ts`'s header comment.

## Test results

- 117/117 in `progress-card.test.ts` (8 new + 109 existing)
- No regressions across the full vitest suite
- Pre-existing failures in token-helpers, setup-state, auth.stale-token-fix are unrelated and unchanged from main

## Followup

#203 — emit time-to-ack + silent-gap metrics (the other half of #195's deferred items).

Co-authored-by: Claude <noreply@anthropic.com>