### PR TITLE
Fix boot-card false 🔴 agent + 🟡 quota probes (#208, #210)

### DIFF
--- a/telegram-plugin/gateway/boot-probes.ts
+++ b/telegram-plugin/gateway/boot-probes.ts
@@ -192,33 +192,103 @@ function formatMemory(memoryCurrent: string): string {
   return `${mb} MB`
 }
 
-export async function probeAgentProcess(agentName: string): Promise<ProbeResult> {
+/**
+ * How often to retry after a non-active state during the re-probe loop.
+ * Exported for test injection.
+ */
+export const AGENT_RETRY_INTERVAL_MS = 1500
+
+/**
+ * Maximum additional wait beyond the settle window before committing to
+ * whatever the final state is. Exported for test injection.
+ */
+export const AGENT_RETRY_MAX_MS = 12_000
+
+type ExecFileResult = { stdout: string; stderr: string }
+type ExecFileFnType = (
+  cmd: string,
+  args: string[],
+) => Promise<ExecFileResult>
+
+/**
+ * Query systemctl for the agent service and return a snapshot of its state.
+ * Extracted so the re-probe loop can call it multiple times.
+ */
+async function queryAgentState(
+  agentName: string,
+  execFileImpl: ExecFileFnType,
+): Promise<{
+  state: string
+  kv: Record<string, string>
+} | { error: string }> {
+  let stdout: string
+  try {
+    const result = await execFileImpl('systemctl', [
+      '--user', 'show',
+      `switchroom-${agentName}.service`,
+      '-p', 'MainPID,ActiveState,MemoryCurrent,ActiveEnterTimestamp',
+    ])
+    stdout = result.stdout
+  } catch (err: unknown) {
+    return { error: `systemctl failed: ${(err as Error).message ?? String(err)}` }
+  }
+  const kv = parseSystemctlKv(stdout)
+  return { state: kv['ActiveState'] ?? 'unknown', kv }
+}
+
+export async function probeAgentProcess(
+  agentName: string,
+  opts: {
+    retryIntervalMs?: number
+    retryMaxMs?: number
+    /** Override for tests — replaces real delays */
+    sleepImpl?: (ms: number) => Promise<void>
+    /** Override for tests — replaces real execFile calls */
+    execFileImpl?: ExecFileFnType
+  } = {},
+): Promise<ProbeResult> {
+  const retryIntervalMs = opts.retryIntervalMs ?? AGENT_RETRY_INTERVAL_MS
+  const retryMaxMs = opts.retryMaxMs ?? AGENT_RETRY_MAX_MS
+  const sleep = opts.sleepImpl ?? ((ms: number) => new Promise(resolve => setTimeout(resolve, ms)))
+  const execFileFn: ExecFileFnType = opts.execFileImpl ?? execFile
+
   return withTimeout('Agent', (async (): Promise<ProbeResult> => {
-    let stdout: string
-    try {
-      const result = await execFile('systemctl', [
-        '--user', 'show',
-        `switchroom-${agentName}.service`,
-        '-p', 'MainPID,ActiveState,MemoryCurrent,ActiveEnterTimestamp',
-      ])
-      stdout = result.stdout
-    } catch (err: unknown) {
-      return { status: 'fail', label: 'Agent', detail: `systemctl failed: ${(err as Error).message ?? String(err)}` }
+    const startMs = Date.now()
+
+    // Re-probe loop: if state is not yet `active`, retry every retryIntervalMs
+    // up to retryMaxMs total elapsed. Transients (deactivating, activating,
+    // auto-restart) typically resolve within one or two retries.
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+      const snapshot = await queryAgentState(agentName, execFileFn)
+
+      if ('error' in snapshot) {
+        return { status: 'fail', label: 'Agent', detail: snapshot.error }
+      }
+
+      const { state, kv } = snapshot
+
+      if (state === 'active') {
+        const pid = kv['MainPID'] ?? '?'
+        const uptime = formatUptime(kv['ActiveEnterTimestamp'] ?? '')
+        const mem = formatMemory(kv['MemoryCurrent'] ?? '')
+        const parts = [`PID ${pid}`, uptime, mem].filter(Boolean)
+        return { status: 'ok', label: 'Agent', detail: parts.join(' · ') }
+      }
+
+      const elapsedMs = Date.now() - startMs
+      if (elapsedMs >= retryMaxMs) {
+        // Committed to the current non-active state.
+        // `deactivating` is an unambiguous transient — honest severity is
+        // degraded (🟡), not fail (🔴). Any other non-active state is fail.
+        const status = state === 'deactivating' ? 'degraded' : 'fail'
+        return { status, label: 'Agent', detail: `service ${state}` }
+      }
+
+      // Still within retry budget — wait and try again.
+      await sleep(retryIntervalMs)
     }
-
-    const kv = parseSystemctlKv(stdout)
-    const state = kv['ActiveState'] ?? 'unknown'
-    if (state !== 'active') {
-      return { status: 'fail', label: 'Agent', detail: `service ${state}` }
-    }
-
-    const pid = kv['MainPID'] ?? '?'
-    const uptime = formatUptime(kv['ActiveEnterTimestamp'] ?? '')
-    const mem = formatMemory(kv['MemoryCurrent'] ?? '')
-    const parts = [`PID ${pid}`, uptime, mem].filter(Boolean)
-
-    return { status: 'ok', label: 'Agent', detail: parts.join(' · ') }
-  })())
+  })(), PROBE_TIMEOUT_MS + retryMaxMs)  // extend outer timeout to cover full retry budget
 }
 
 // ─── Probe: Gateway ──────────────────────────────────────────────────────────
@@ -306,7 +376,19 @@ export async function probeQuota(
     }
 
     if (resp.status === 429) {
-      return { status: 'degraded', label: 'Quota', detail: 'rate limited' }
+      // A 429 from /api/oauth/usage means the endpoint is rate-limiting our
+      // probe calls — it does NOT mean the user is out of quota. Conflating
+      // the two is the root cause of the false 🟡 "rate limited" alarm
+      // reported in #210. Return ok-with-note and cache it for 30 s so
+      // simultaneous fleet restarts read the cached result instead of piling
+      // up on the same endpoint (see quota-cache.ts: RATE_LIMIT_TTL_MS).
+      const rateLimitResult: ProbeResult = {
+        status: 'ok',
+        label: 'Quota',
+        detail: 'quota check skipped: rate limited',
+      }
+      writeQuotaCache(rateLimitResult)
+      return rateLimitResult
     }
     if (!resp.ok) {
       return { status: 'degraded', label: 'Quota', detail: `HTTP ${resp.status}` }

--- a/telegram-plugin/gateway/quota-cache.ts
+++ b/telegram-plugin/gateway/quota-cache.ts
@@ -10,7 +10,9 @@
  *
  * Cache the result for 5 min in a single file shared across all agents.
  * On a hit, the cached ProbeResult is returned instead of making the
- * HTTP call. 429 results are NOT cached so the next boot tries fresh.
+ * HTTP call. 429 (rate-limited) results are cached for a shorter 30 s
+ * window so fleet-restart bursts are absorbed without holding stale state
+ * for 5 min. Fail results are never cached.
  *
  * Cache location: `~/.switchroom/quota-cache.json` (mode 0600). Format:
  *   { capturedAt: string, ttlMs: number, result: ProbeResult }
@@ -27,6 +29,14 @@ export interface QuotaCacheEntry {
 }
 
 export const DEFAULT_TTL_MS = 5 * 60 * 1000  // 5 min
+
+/**
+ * Short TTL used when caching a 429 result. 30 s is long enough to absorb
+ * a simultaneous fleet restart (all N agents firing their quota probe within
+ * the same second) while clearing fast enough that any real retry or the
+ * next scheduled boot gets a live result.
+ */
+export const RATE_LIMIT_TTL_MS = 30 * 1000  // 30 s
 export const DEFAULT_CACHE_PATH =
   process.env.SWITCHROOM_QUOTA_CACHE_PATH
     ?? join(process.env.HOME ?? '/tmp', '.switchroom', 'quota-cache.json')
@@ -67,8 +77,16 @@ export function readQuotaCache(opts: {
 }
 
 /**
- * Write a probe result to the cache. Ignored on rate-limited or
- * fail-status results — we want the next boot to try fresh.
+ * Write a probe result to the cache.
+ *
+ * Normal results (ok / degraded non-rate-limit) use the standard 5-min TTL.
+ * A 429 "quota check skipped: rate limited" result uses the short
+ * RATE_LIMIT_TTL_MS (30 s) so back-to-back fleet restarts read the cached
+ * 'ok' row instead of piling up on the endpoint, while still clearing fast
+ * enough for any real next-boot probe to see a live result.
+ *
+ * Fail results are still not cached — they indicate a real error and the
+ * next boot should always retry.
  *
  * Writes are best-effort: any IO error is swallowed (cache is an
  * optimization, not a correctness requirement).
@@ -81,12 +99,14 @@ export function writeQuotaCache(
     now?: number
   } = {},
 ): void {
-  // Don't cache failure / rate-limit so next boot retries clean.
+  // Don't cache hard failures — let the next boot retry clean.
   if (result.status === 'fail') return
-  if (result.detail === 'rate limited') return
 
   const path = opts.path ?? DEFAULT_CACHE_PATH
-  const ttlMs = opts.ttlMs ?? DEFAULT_TTL_MS
+  // Rate-limit results use a shorter TTL: long enough to absorb a fleet
+  // restart burst, short enough that subsequent boots get a live probe.
+  const isRateLimit = result.detail === 'quota check skipped: rate limited'
+  const ttlMs = opts.ttlMs ?? (isRateLimit ? RATE_LIMIT_TTL_MS : DEFAULT_TTL_MS)
   const now = opts.now ?? Date.now()
 
   const entry: QuotaCacheEntry = {

--- a/telegram-plugin/tests/boot-probes.test.ts
+++ b/telegram-plugin/tests/boot-probes.test.ts
@@ -1,0 +1,252 @@
+/**
+ * Unit tests for boot-probes fixes.
+ *
+ * Covers:
+ *   - #208: probeAgentProcess — deactivating → 🟡 (not 🔴), re-probe loop
+ *   - #210: probeQuota — 429 → ok-with-note + 30 s cache
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test'
+import { mkdtempSync, rmSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+
+import {
+  probeAgentProcess,
+  probeQuota,
+} from '../gateway/boot-probes.js'
+import { readQuotaCache, RATE_LIMIT_TTL_MS } from '../gateway/quota-cache.js'
+
+// ── #208: probeAgentProcess ────────────────────────────────────────────────
+
+/**
+ * Build a mock queryAgentState sequence: each call to `execFile` returns the
+ * next state in `states`. We inject this by passing a custom `sleepImpl` (a
+ * no-op) and providing a series of fake systemctl responses through a mock
+ * `execFile`. Since `queryAgentState` is not exported we test
+ * `probeAgentProcess` end-to-end with a zero-delay sleep and a
+ * pre-configured call sequence of fake systemctl output.
+ *
+ * Strategy: monkey-patch `child_process.execFile` is fragile across module
+ * boundaries with Bun's module cache. Instead we test via the exported
+ * probeAgentProcess signature which accepts:
+ *   - sleepImpl: no-op so tests are instant
+ *   - retryIntervalMs / retryMaxMs: kept tiny so the budget math works
+ *
+ * We inject systemctl output through a sequence of `execFileImpl` calls
+ * ─ but `probeAgentProcess` does not expose that yet. Rather than widen
+ * the internal API surface, we use a lightweight approach: test the
+ * exported constants and state-machine logic through two probe shapes:
+ *   1. always-deactivating (max retries exhausted) → degraded
+ *   2. first call inactive, second call active → ok
+ *
+ * This requires `probeAgentProcess` to accept an `execFileImpl` override.
+ * We added `execFileImpl` to the opts parameter for this purpose.
+ *
+ * NOTE: If the implementation doesn't expose execFileImpl, the tests will
+ * document the expected shape and we adjust the implementation to match.
+ */
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+function makeSystemctlOutput(state: string, pid = '1234'): string {
+  return [
+    `MainPID=${pid}`,
+    `ActiveState=${state}`,
+    `MemoryCurrent=104857600`,
+    `ActiveEnterTimestamp=1700000000000000`,
+  ].join('\n') + '\n'
+}
+
+type ExecFileResult = { stdout: string; stderr: string }
+type ExecFileFn = (...args: unknown[]) => Promise<ExecFileResult>
+
+/** Build a promisified execFile mock that returns each output in sequence. */
+function makeSequence(outputs: Array<string | Error>): ExecFileFn {
+  let idx = 0
+  return async (): Promise<ExecFileResult> => {
+    const item = outputs[idx] ?? outputs[outputs.length - 1]
+    idx++
+    if (item instanceof Error) throw item
+    return { stdout: item, stderr: '' }
+  }
+}
+
+const noopSleep = async (_ms: number): Promise<void> => undefined
+
+// ── #208: deactivating → 🟡 ───────────────────────────────────────────────
+
+describe('probeAgentProcess — #208: deactivating → 🟡 (degraded)', () => {
+  it('returns degraded when state is deactivating after all retries', async () => {
+    const result = await probeAgentProcess('testbot', {
+      retryIntervalMs: 0,
+      retryMaxMs: 0,  // exhaust budget immediately on first non-active result
+      sleepImpl: noopSleep,
+      execFileImpl: makeSequence([makeSystemctlOutput('deactivating')]),
+    })
+    expect(result.status).toBe('degraded')
+    expect(result.label).toBe('Agent')
+    expect(result.detail).toBe('service deactivating')
+  })
+
+  it('returns fail (not degraded) for inactive when budget is exhausted', async () => {
+    const result = await probeAgentProcess('testbot', {
+      retryIntervalMs: 0,
+      retryMaxMs: 0,
+      sleepImpl: noopSleep,
+      execFileImpl: makeSequence([makeSystemctlOutput('inactive')]),
+    })
+    expect(result.status).toBe('fail')
+    expect(result.detail).toBe('service inactive')
+  })
+
+  it('returns fail (not degraded) for failed when budget is exhausted', async () => {
+    const result = await probeAgentProcess('testbot', {
+      retryIntervalMs: 0,
+      retryMaxMs: 0,
+      sleepImpl: noopSleep,
+      execFileImpl: makeSequence([makeSystemctlOutput('failed')]),
+    })
+    expect(result.status).toBe('fail')
+    expect(result.detail).toBe('service failed')
+  })
+})
+
+// ── #208: re-probe loop ────────────────────────────────────────────────────
+
+describe('probeAgentProcess — #208: re-probe loop resolves transient', () => {
+  it('returns ok when first call is inactive but second is active', async () => {
+    const result = await probeAgentProcess('testbot', {
+      retryIntervalMs: 0,
+      retryMaxMs: 5000,  // enough budget for one retry
+      sleepImpl: noopSleep,
+      execFileImpl: makeSequence([
+        makeSystemctlOutput('inactive'),  // first probe: transient
+        makeSystemctlOutput('active'),    // second probe: resolved
+      ]),
+    })
+    expect(result.status).toBe('ok')
+    expect(result.label).toBe('Agent')
+    expect(result.detail).toContain('PID 1234')
+  })
+
+  it('returns ok immediately when first call is active (no retry needed)', async () => {
+    let callCount = 0
+    const execFileImpl: ExecFileFn = async () => {
+      callCount++
+      return { stdout: makeSystemctlOutput('active'), stderr: '' }
+    }
+    const result = await probeAgentProcess('testbot', {
+      retryIntervalMs: 0,
+      retryMaxMs: 5000,
+      sleepImpl: noopSleep,
+      execFileImpl,
+    })
+    expect(result.status).toBe('ok')
+    expect(callCount).toBe(1)
+  })
+
+  it('returns degraded after budget exhausted if deactivating on every attempt', async () => {
+    // All three calls return deactivating — budget eventually runs out.
+    const result = await probeAgentProcess('testbot', {
+      retryIntervalMs: 0,
+      retryMaxMs: 0,  // zero budget: commit after first non-active result
+      sleepImpl: noopSleep,
+      execFileImpl: makeSequence([
+        makeSystemctlOutput('deactivating'),
+        makeSystemctlOutput('deactivating'),
+        makeSystemctlOutput('deactivating'),
+      ]),
+    })
+    expect(result.status).toBe('degraded')
+    expect(result.detail).toBe('service deactivating')
+  })
+
+  it('returns fail when systemctl errors after all retries', async () => {
+    const result = await probeAgentProcess('testbot', {
+      retryIntervalMs: 0,
+      retryMaxMs: 0,
+      sleepImpl: noopSleep,
+      execFileImpl: makeSequence([new Error('unit not found')]),
+    })
+    expect(result.status).toBe('fail')
+    expect(result.detail).toContain('systemctl failed')
+  })
+})
+
+// ── #210: probeQuota — 429 → ok-with-note + 30s cache ────────────────────
+
+import { writeFileSync, mkdirSync } from 'fs'
+import { writeQuotaCache } from '../gateway/quota-cache.js'
+
+let tmp: string
+let cachePath: string
+let claudeDir: string
+let agentDir: string
+
+beforeEach(() => {
+  tmp = mkdtempSync(join(tmpdir(), 'boot-probes-test-'))
+  cachePath = join(tmp, 'quota-cache.json')
+  // Point the cache to the temp dir so tests don't pollute ~/.switchroom
+  process.env.SWITCHROOM_QUOTA_CACHE_PATH = cachePath
+
+  // Create a fake Claude config dir with a stub OAuth token so probeQuota
+  // gets past the "no OAuth token" guard and reaches the fetch call.
+  claudeDir = join(tmp, 'claude')
+  agentDir = join(tmp, 'agent')
+  mkdirSync(claudeDir, { recursive: true })
+  mkdirSync(agentDir, { recursive: true })
+  writeFileSync(join(claudeDir, '.oauth-token'), 'fake-token-for-testing')
+})
+
+afterEach(() => {
+  delete process.env.SWITCHROOM_QUOTA_CACHE_PATH
+  rmSync(tmp, { recursive: true, force: true })
+})
+
+describe('probeQuota — #210: 429 returns ok-with-note', () => {
+  it('returns ok with "quota check skipped: rate limited" on 429', async () => {
+    const fakeFetch: typeof fetch = async () =>
+      new Response(null, { status: 429 }) as Response
+
+    const result = await probeQuota(claudeDir, agentDir, fakeFetch)
+    expect(result.status).toBe('ok')
+    expect(result.label).toBe('Quota')
+    expect(result.detail).toBe('quota check skipped: rate limited')
+  })
+
+  it('writing 429 ok-result to cache produces a readable 30 s entry', () => {
+    // Verify the cache contract: writeQuotaCache stores rate-limit results
+    // with RATE_LIMIT_TTL_MS, and readQuotaCache returns them within TTL.
+    const rateLimitResult = {
+      status: 'ok' as const,
+      label: 'Quota',
+      detail: 'quota check skipped: rate limited',
+    }
+    const now = Date.now()
+    writeQuotaCache(rateLimitResult, { path: cachePath, now })
+
+    // Within 30 s window: cache hit
+    const hit = readQuotaCache({ path: cachePath, now: now + 1000 })
+    expect(hit).not.toBeNull()
+    expect(hit?.status).toBe('ok')
+    expect(hit?.detail).toBe('quota check skipped: rate limited')
+
+    // After 30 s window: cache miss
+    const miss = readQuotaCache({ path: cachePath, now: now + RATE_LIMIT_TTL_MS + 1 })
+    expect(miss).toBeNull()
+  })
+
+  it('429 cache expires after RATE_LIMIT_TTL_MS (30 s)', () => {
+    // Seed the cache with a 429-ok entry that is past its 30s TTL
+    const staleNow = Date.now() - RATE_LIMIT_TTL_MS - 1000
+    writeQuotaCache(
+      { status: 'ok', label: 'Quota', detail: 'quota check skipped: rate limited' },
+      { path: cachePath, now: staleNow, ttlMs: RATE_LIMIT_TTL_MS },
+    )
+
+    // readQuotaCache should see it as expired
+    const cached = readQuotaCache({ path: cachePath })
+    expect(cached).toBeNull()
+  })
+})

--- a/telegram-plugin/tests/quota-cache.test.ts
+++ b/telegram-plugin/tests/quota-cache.test.ts
@@ -11,7 +11,7 @@ import { mkdtempSync, rmSync, writeFileSync, existsSync, readFileSync } from 'fs
 import { tmpdir } from 'os'
 import { join } from 'path'
 
-import { readQuotaCache, writeQuotaCache, DEFAULT_TTL_MS } from '../gateway/quota-cache.js'
+import { readQuotaCache, writeQuotaCache, DEFAULT_TTL_MS, RATE_LIMIT_TTL_MS } from '../gateway/quota-cache.js'
 import type { ProbeResult } from '../gateway/boot-probes.js'
 
 let tmp: string
@@ -38,10 +38,18 @@ const failResult: ProbeResult = {
   detail: 'request failed: ECONNREFUSED',
 }
 
+/**
+ * The 429 result shape changed in #210: previously the probe returned
+ * { status: 'degraded', detail: 'rate limited' }; now it returns
+ * { status: 'ok', detail: 'quota check skipped: rate limited' } and is
+ * cached for 30 s (RATE_LIMIT_TTL_MS) rather than skipped entirely.
+ *
+ * This fixture represents the new 429 result shape.
+ */
 const rateLimitedResult: ProbeResult = {
-  status: 'degraded',
+  status: 'ok',
   label: 'Quota',
-  detail: 'rate limited',
+  detail: 'quota check skipped: rate limited',
 }
 
 const degradedSchemaUnknown: ProbeResult = {
@@ -118,9 +126,15 @@ describe('writeQuotaCache', () => {
     expect(existsSync(cachePath)).toBe(false)
   })
 
-  it('does NOT cache a rate-limited result (so next boot retries)', () => {
+  it('caches a rate-limited (429) result with short RATE_LIMIT_TTL_MS (#210 fix)', () => {
+    // #210: 429 results are now returned as ok-with-note and cached for 30 s
+    // (RATE_LIMIT_TTL_MS) rather than skipped, so fleet restarts absorb the
+    // burst without piling up on the endpoint.
     writeQuotaCache(rateLimitedResult, { path: cachePath })
-    expect(existsSync(cachePath)).toBe(false)
+    expect(existsSync(cachePath)).toBe(true)
+    const parsed = JSON.parse(readFileSync(cachePath, 'utf8'))
+    expect(parsed.result).toEqual(rateLimitedResult)
+    expect(parsed.ttlMs).toBe(RATE_LIMIT_TTL_MS)
   })
 
   it('caches a degraded "schema unknown" result (it is informational, not transient)', () => {
@@ -161,8 +175,12 @@ describe('readQuotaCache + writeQuotaCache round-trip', () => {
     expect(readQuotaCache({ path: cachePath, now: now + 60_000 })).toEqual(okResult)
   })
 
-  it('a rate-limited result is not cached, so reads return null', () => {
-    writeQuotaCache(rateLimitedResult, { path: cachePath })
-    expect(readQuotaCache({ path: cachePath })).toBeNull()
+  it('a rate-limited (429) result is cached and readable within RATE_LIMIT_TTL_MS (#210 fix)', () => {
+    const now = 1_700_000_000_000
+    writeQuotaCache(rateLimitedResult, { path: cachePath, now })
+    // Within 30 s window: cache hit
+    expect(readQuotaCache({ path: cachePath, now: now + 1000 })).toEqual(rateLimitedResult)
+    // After 30 s: cache miss
+    expect(readQuotaCache({ path: cachePath, now: now + RATE_LIMIT_TTL_MS + 1 })).toBeNull()
   })
 })


### PR DESCRIPTION
## Summary

Two boot-card UX bugs that produced false alarms during ordinary restarts:

| issue | symptom | fix |
|---|---|---|
| #208 | 🔴 service inactive on healthy restart | re-probe loop + treat `deactivating` as 🟡 |
| #210 | 🟡 rate limited on simultaneous restarts | render 429 as 🟢 with note + 30s 429 cache |

## #208 — agent probe

Single point-in-time check at +6s was unreliable on loaded machines: clean restarts that take a hair longer than the settle window showed 🔴 service inactive even though the agent recovered seconds later.

**Approach chosen** (smallest fix that addresses the symptom):
- `deactivating` → 🟡 (degraded) instead of 🔴 (fail). Honest severity.
- Re-probe loop: every 1500ms up to +12s additional, then commit to whatever the final state is. Most transients resolve in one retry.

**Approaches skipped:**
- Lengthening `SETTLE_WINDOW_MS` — would slow every healthy boot, even fast ones.
- Edge-triggered subscription — overkill for the symptom.

## #210 — quota probe

429 from `/api/oauth/usage` is endpoint rate-limiting, not quota exhaustion. Conflating them produced false 🟡 'rate limited' rows when the fleet hit the endpoint simultaneously.

**Approach chosen:**
- 429 returns `{ status: 'ok', detail: 'quota check skipped (rate limited)' }` — row stays 🟢, the note is honest about why.
- 429 result cached for 30s in `quota-cache.ts` (was previously not cached at all). Absorbs fleet-restart bursts cleanly while still letting real retries happen quickly.

**Approaches skipped:**
- Per-agent stagger/jitter — adds complexity, doesn't help when systemd starts the whole target simultaneously, the cache approach already absorbs the burst.
- Shared mutex / file lock — bigger surface than warranted.

## Tests

- `telegram-plugin/tests/boot-probes.test.ts` (new): `deactivating` → degraded mapping, re-probe loop happy path (inactive → active on retry), max-wait timeout behaviour.
- `telegram-plugin/tests/quota-cache.test.ts` (extended): 429 caches for 30s, 200/403 still honour the 5min TTL.
- All `telegram-plugin/tests/` green: exit 0.
- Build clean.

## Test plan

- [x] Unit tests pass
- [x] Build clean
- [ ] Smoke: restart all agents simultaneously, observe boot card stays 🟢/🟡 honestly (no false 🔴/🟡)

## Closes

- Closes #208
- Closes #210

🤖 Generated with [Claude Code](https://claude.com/claude-code)