### PR TITLE
telegram(#203): emit time-to-ack + silent-gap + answer-lane metrics

### DIFF
--- a/telegram-plugin/answer-stream.ts
+++ b/telegram-plugin/answer-stream.ts
@@ -115,6 +115,15 @@ export interface AnswerStreamConfig {
   onSuperseded?: OnSupersededCallback
   log?: (msg: string) => void
   warn?: (msg: string) => void
+  /**
+   * Optional metric callback. Fires after each successful send/edit and on
+   * materialize. Injected by the gateway so tests can mock it with vi.fn().
+   * Acceptance #203: answer_lane_update / answer_lane_materialized events.
+   */
+  onMetric?: (ev:
+    | { kind: 'answer_lane_update'; chatId: string; messageId: number | undefined; charCount: number; transport: 'draft' | 'message' | 'edit' }
+    | { kind: 'answer_lane_materialized'; chatId: string; messageId: number | undefined }
+  ) => void
 }
 
 export interface AnswerStreamHandle {
@@ -164,6 +173,7 @@ export function createAnswerStream(config: AnswerStreamConfig): AnswerStreamHand
     onSuperseded,
     log,
     warn,
+    onMetric,
   } = config
 
   const effectiveThrottle = Math.max(250, throttleMs)
@@ -198,6 +208,7 @@ export function createAnswerStream(config: AnswerStreamConfig): AnswerStreamHand
       const params: { message_thread_id?: number } = {}
       if (threadId != null) params.message_thread_id = threadId
       await draftApi(chatId, draftId, text, Object.keys(params).length > 0 ? params : undefined)
+      onMetric?.({ kind: 'answer_lane_update', chatId, messageId: streamMsgId, charCount: text.length, transport: 'draft' })
       return true
     } catch (err) {
       if (shouldFallbackFromDraftTransport(err)) {
@@ -250,6 +261,7 @@ export function createAnswerStream(config: AnswerStreamConfig): AnswerStreamHand
       if (threadId != null) editParams.message_thread_id = threadId
       try {
         await editMessageText(chatId, streamMsgId, trimmed, editParams)
+        onMetric?.({ kind: 'answer_lane_update', chatId, messageId: streamMsgId, charCount: trimmed.length, transport: 'edit' })
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err)
         if (/message is not modified/i.test(msg)) {
@@ -287,6 +299,7 @@ export function createAnswerStream(config: AnswerStreamConfig): AnswerStreamHand
       }
       streamMsgId = sentId
       log?.(`answer-stream: sent (id=${sentId})`)
+      onMetric?.({ kind: 'answer_lane_update', chatId, messageId: streamMsgId, charCount: trimmed.length, transport: 'message' })
     }
   }
 

--- a/telegram-plugin/answer-stream.ts
+++ b/telegram-plugin/answer-stream.ts
@@ -431,6 +431,7 @@ export function createAnswerStream(config: AnswerStreamConfig): AnswerStreamHand
         if (typeof sentId === 'number' && Number.isFinite(sentId)) {
           streamMsgId = sentId
           log?.(`answer-stream: materialized (id=${sentId})`)
+          onMetric?.({ kind: 'answer_lane_materialized', chatId, messageId: streamMsgId })
           return sentId
         }
       } catch (err) {

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -1582,6 +1582,21 @@ async function executeStreamReply(args: Record<string, unknown>): Promise<unknow
         args.message_thread_id as string | undefined,
       )
     } catch { /* best-effort signal */ }
+    // Issue #203: stream_reply is the agent's primary reply path. Without
+    // ticking the silent-gap tracker here, turn_signal_gap reports the
+    // entire turn duration as silent for any turn that uses stream_reply
+    // — which per CLAUDE.md guidance is most of them. The metric would be
+    // worse than no metric. Tick on every successful delivery (partial or
+    // final) so the gap measurement reflects real silent intervals.
+    try {
+      const threadIdNum = args.message_thread_id != null
+        ? Number(args.message_thread_id)
+        : undefined
+      signalTracker.noteSignal(
+        statusKey(args.chat_id as string, threadIdNum),
+        Date.now(),
+      )
+    } catch { /* best-effort signal */ }
   }
   return { content: [{ type: 'text', text: `${result.status} (id: ${result.messageId ?? 'pending'})` }] }
 }
@@ -1664,6 +1679,12 @@ async function executeProgressUpdate(args: Record<string, unknown>): Promise<unk
   }
 
   progressUpdateLastSent.set(key, now)
+
+  // Issue #203: progress_update is a user-visible signal — tick the
+  // silent-gap tracker so it doesn't count as silent time.
+  try {
+    signalTracker.noteSignal(key, Date.now())
+  } catch { /* best-effort signal */ }
 
   return {
     content: [
@@ -2581,6 +2602,14 @@ async function handleInbound(
 
   // Capture wall-clock receive time for inbound_ack metric (#203).
   // Must be after gate() so early-exit paths (drop/pair) don't skew the delta.
+  //
+  // Measurement caveat: the `setMessageReaction` API call that posts the 👀
+  // is `void`-dispatched (fire-and-forget) before the metric is logged, so
+  // `ackDelayMs` measures gateway-receive → reaction-DISPATCH not
+  // gateway-receive → reaction-ACKNOWLEDGED-by-Telegram. The optimistic
+  // bias is one network RTT (~50–200ms typically). Acceptable for
+  // ambient-signal alerting (the dominant variance is reasoning time, not
+  // network RTT) but not a user-perceived end-to-end measurement.
   const inboundReceivedAt = Date.now()
 
   const access = result.access

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -35,6 +35,7 @@ import { buildAttachmentPath, assertInsideInbox } from '../attachment-path.js'
 import { createPinManager } from '../progress-card-pin-manager.js'
 import { createPinWatchdog } from '../progress-card-pin-watchdog.js'
 import { logStreamingEvent } from '../streaming-metrics.js'
+import * as signalTracker from '../turn-signal-tracker.js'
 import { createAnswerStream, type AnswerStreamHandle } from '../answer-stream.js'
 import { type SessionEvent } from '../session-tail.js'
 import {
@@ -1519,6 +1520,8 @@ async function executeReply(args: Record<string, unknown>): Promise<{ content: A
         threadId != null ? String(threadId) : undefined,
       )
     } catch { /* best-effort signal */ }
+    // #203: fresh sendMessage from reply tool is a user-visible signal.
+    signalTracker.noteSignal(statusKey(chat_id, threadId), Date.now())
   }
 
   process.stderr.write(`telegram channel: reply: finalized chatId=${chat_id} messageIds=[${sentIds.join(',')}] chunks=${chunks.length}\n`)
@@ -2217,12 +2220,18 @@ function handleSessionEvent(ev: SessionEvent): void {
         // still appear in turn-duration graphs.
         {
           const sKey = streamKey(chatId, threadId)
+          const turnDurationMs = currentTurnStartedAt > 0 ? Date.now() - currentTurnStartedAt : 0
           logStreamingEvent({
             kind: 'turn_end',
             chatId,
-            durationMs: currentTurnStartedAt > 0 ? Date.now() - currentTurnStartedAt : 0,
+            durationMs: turnDurationMs,
             suppressClearedCount: suppressPtyPreview.has(sKey) ? 1 : 0,
           })
+          // #203: compute trailing gap (last signal → turn_end) then emit.
+          const tKey = statusKey(chatId, threadId)
+          signalTracker.noteSignal(tKey, Date.now())
+          logStreamingEvent({ kind: 'turn_signal_gap', chatId, longestGapMs: signalTracker.getLongestGap(tKey), turnDurationMs })
+          signalTracker.clear(tKey)
         }
         lastPtyPreviewByChat.delete(statusKey(chatId, threadId))
         pendingPtyPartial = null
@@ -2304,12 +2313,18 @@ function handleSessionEvent(ev: SessionEvent): void {
       purgeReactionTracking(statusKey(chatId, threadId))
       {
         const sKey = streamKey(chatId, threadId)
+        const turnDurationMs = currentTurnStartedAt > 0 ? Date.now() - currentTurnStartedAt : 0
         logStreamingEvent({
           kind: 'turn_end',
           chatId,
-          durationMs: currentTurnStartedAt > 0 ? Date.now() - currentTurnStartedAt : 0,
+          durationMs: turnDurationMs,
           suppressClearedCount: suppressPtyPreview.has(sKey) ? 1 : 0,
         })
+        // #203: compute trailing gap (last signal → turn_end) then emit.
+        const tKey = statusKey(chatId, threadId)
+        signalTracker.noteSignal(tKey, Date.now())
+        logStreamingEvent({ kind: 'turn_signal_gap', chatId, longestGapMs: signalTracker.getLongestGap(tKey), turnDurationMs })
+        signalTracker.clear(tKey)
       }
       lastPtyPreviewByChat.delete(statusKey(chatId, threadId))
       pendingPtyPartial = null
@@ -2550,6 +2565,10 @@ async function handleInbound(
     await ctx.reply(`${lead} — run in Claude Code:\n\n/telegram:access pair ${result.code}`)
     return
   }
+
+  // Capture wall-clock receive time for inbound_ack metric (#203).
+  // Must be after gate() so early-exit paths (drop/pair) don't skew the delta.
+  const inboundReceivedAt = Date.now()
 
   const access = result.access
   const from = ctx.from!
@@ -2925,6 +2944,8 @@ async function handleInbound(
         // controller; just ack the inbound message with 👀 so the user
         // knows we received it, without disrupting the in-flight reaction.
         void bot.api.setMessageReaction(chat_id, msgId, [{ type: 'emoji', emoji: '👀' }]).catch(() => {})
+        // #203: time-to-ack metric — measure gateway-receive → ack-post delta.
+        logStreamingEvent({ kind: 'inbound_ack', chatId: chat_id, messageId: msgId, ackDelayMs: Date.now() - inboundReceivedAt })
       } else {
         // Fresh turn (no prior turn in flight): cancel any stale controller
         // and start a new one for this message.
@@ -2945,12 +2966,19 @@ async function handleInbound(
           await bot.api.setMessageReaction(chat_id, msgId, [
             { type: 'emoji', emoji: emoji as ReactionTypeEmoji['emoji'] },
           ])
+          // #203: every status-reaction transition is a user-visible signal.
+          signalTracker.noteSignal(key, Date.now())
         })
         activeStatusReactions.set(key, ctrl)
         activeReactionMsgIds.set(key, { chatId: chat_id, messageId: msgId })
         activeTurnStartedAt.set(key, Date.now())
         progressUpdateTurnCount.set(key, 0)  // Reset turn counter
         ctrl.setQueued()
+        // #203: time-to-ack metric — setQueued() triggers the initial 👀 reaction
+        // asynchronously through the controller chain.
+        logStreamingEvent({ kind: 'inbound_ack', chatId: chat_id, messageId: msgId, ackDelayMs: Date.now() - inboundReceivedAt })
+        // #203: signal tracker — start tracking silent gaps for this fresh turn.
+        signalTracker.reset(statusKey(chat_id, messageThreadId), Date.now())
         const agentDir = resolveAgentDirFromEnv()
         if (agentDir != null) {
           addActiveReaction(agentDir, { chatId: chat_id, messageId: msgId, threadId: messageThreadId ?? null, reactedAt: Date.now() })
@@ -2960,6 +2988,8 @@ async function handleInbound(
       void bot.api.setMessageReaction(chat_id, msgId, [
         { type: 'emoji', emoji: access.ackReaction as ReactionTypeEmoji['emoji'] },
       ]).catch(() => {})
+      // #203: time-to-ack metric for the custom-ack-reaction path.
+      logStreamingEvent({ kind: 'inbound_ack', chatId: chat_id, messageId: msgId, ackDelayMs: Date.now() - inboundReceivedAt })
     }
   }
 
@@ -5572,6 +5602,8 @@ if (streamMode === 'checklist') {
       }).then((result) => {
         // Successful API call — reset the consecutive-4xx counter.
         progressDriver?.reportApiSuccess(turnKey)
+        // #203: progress-card edit is a user-visible signal.
+        signalTracker.noteSignal(statusKey(chatId, threadId != null ? Number(threadId) : undefined), Date.now())
         if (!result?.messageId) return
         pinMgr.considerPin({
           chatId,

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -2018,6 +2018,19 @@ function handleSessionEvent(ev: SessionEvent): void {
               }),
             log: (msg) => process.stderr.write(`telegram gateway: ${msg}\n`),
             warn: (msg) => process.stderr.write(`telegram gateway: ${msg}\n`),
+            // Issue #203: route answer-lane events through the streaming
+            // metrics sink. Each successful update/edit/draft and the final
+            // materialize emit one event. Also tick the silent-gap tracker
+            // so answer-lane activity doesn't count as silent.
+            onMetric: (ev) => {
+              logStreamingEvent(ev)
+              if (currentSessionChatId != null) {
+                signalTracker.noteSignal(
+                  statusKey(currentSessionChatId, currentSessionThreadId),
+                  Date.now(),
+                )
+              }
+            },
           })
         }
         activeAnswerStream.update(currentTurnCapturedText.join(''))

--- a/telegram-plugin/tests/answer-stream.test.ts
+++ b/telegram-plugin/tests/answer-stream.test.ts
@@ -589,3 +589,140 @@ describe('answer-stream — materialize() max-chars guard', () => {
     expect(warn.mock.calls.some((c) => /4096|exceeds/i.test(String(c[0])))).toBe(true)
   })
 })
+
+// ─── Issue #203: onMetric callback ──────────────────────────────────────────
+describe('answer-stream — onMetric callback (#203)', () => {
+  it('fires answer_lane_update on first sendMessage (non-DM, message transport)', async () => {
+    const onMetric = vi.fn()
+    const sendMessage = makeSendMessage()
+    const editMessageText = makeEditMessageText()
+    const stream = createAnswerStream({
+      chatId: 'chatX',
+      isPrivateChat: false,
+      minInitialChars: 0,
+      throttleMs: 250,
+      sendMessage,
+      editMessageText,
+      onMetric,
+    })
+
+    stream.update('hello there friend, this is some answer text')
+    vi.advanceTimersByTime(500)
+    await flushMicrotasks()
+
+    expect(onMetric).toHaveBeenCalledTimes(1)
+    const ev = onMetric.mock.calls[0][0] as { kind: string; chatId: string; transport: string; charCount: number }
+    expect(ev.kind).toBe('answer_lane_update')
+    expect(ev.chatId).toBe('chatX')
+    expect(ev.transport).toBe('message')
+    expect(typeof ev.charCount).toBe('number')
+    expect(ev.charCount).toBeGreaterThan(0)
+  })
+
+  it('fires answer_lane_update on edit (transport: edit)', async () => {
+    const onMetric = vi.fn()
+    const sendMessage = makeSendMessage()
+    const editMessageText = makeEditMessageText()
+    const stream = createAnswerStream({
+      chatId: 'chatX',
+      isPrivateChat: false,
+      minInitialChars: 0,
+      throttleMs: 250,
+      sendMessage,
+      editMessageText,
+      onMetric,
+    })
+
+    stream.update('initial text')
+    vi.advanceTimersByTime(500)
+    await flushMicrotasks()
+
+    stream.update('initial text plus more')
+    vi.advanceTimersByTime(1500)
+    await flushMicrotasks()
+
+    const transports = onMetric.mock.calls.map((c) => (c[0] as { transport: string }).transport)
+    expect(transports).toContain('message')
+    expect(transports).toContain('edit')
+  })
+
+  it('fires answer_lane_update on draft transport for DMs', async () => {
+    const onMetric = vi.fn()
+    const sendMessage = makeSendMessage()
+    const editMessageText = makeEditMessageText()
+    const sendMessageDraft = makeSendMessageDraft()
+    const stream = createAnswerStream({
+      chatId: 'chatX',
+      isPrivateChat: true,
+      minInitialChars: 0,
+      throttleMs: 250,
+      sendMessage,
+      editMessageText,
+      sendMessageDraft,
+      onMetric,
+    })
+
+    stream.update('streaming via draft')
+    vi.advanceTimersByTime(500)
+    await flushMicrotasks()
+
+    const draftEvents = onMetric.mock.calls
+      .map((c) => c[0] as { kind: string; transport?: string })
+      .filter((ev) => ev.kind === 'answer_lane_update' && ev.transport === 'draft')
+    expect(draftEvents.length).toBeGreaterThan(0)
+  })
+
+  it('fires answer_lane_materialized on materialize success', async () => {
+    const onMetric = vi.fn()
+    const sendMessage = makeSendMessage()
+    const editMessageText = makeEditMessageText()
+    const stream = createAnswerStream({
+      chatId: 'chatX',
+      isPrivateChat: false,
+      minInitialChars: 0,
+      throttleMs: 250,
+      sendMessage,
+      editMessageText,
+      onMetric,
+    })
+
+    stream.update('full answer text')
+    vi.advanceTimersByTime(500)
+    await flushMicrotasks()
+
+    onMetric.mockClear()
+    const id = await stream.materialize()
+
+    expect(typeof id).toBe('number')
+    expect(onMetric).toHaveBeenCalledTimes(1)
+    const ev = onMetric.mock.calls[0][0] as { kind: string; chatId: string; messageId: number }
+    expect(ev.kind).toBe('answer_lane_materialized')
+    expect(ev.chatId).toBe('chatX')
+    expect(ev.messageId).toBe(id)
+  })
+
+  it('does not fire answer_lane_materialized when oversize guard rejects', async () => {
+    const onMetric = vi.fn()
+    const sendMessage = makeSendMessage()
+    const editMessageText = makeEditMessageText()
+    const stream = createAnswerStream({
+      chatId: 'chatX',
+      isPrivateChat: false,
+      minInitialChars: 0,
+      throttleMs: 250,
+      sendMessage,
+      editMessageText,
+      onMetric,
+    })
+
+    stream.update('x'.repeat(4097))
+    onMetric.mockClear()
+    const id = await stream.materialize()
+
+    expect(id).toBeUndefined()
+    const matEvents = onMetric.mock.calls
+      .map((c) => c[0] as { kind: string })
+      .filter((ev) => ev.kind === 'answer_lane_materialized')
+    expect(matEvents).toHaveLength(0)
+  })
+})

--- a/telegram-plugin/tests/turn-signal-tracker.test.ts
+++ b/telegram-plugin/tests/turn-signal-tracker.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  reset,
+  noteSignal,
+  getLongestGap,
+  getLastSignalAt,
+  clear,
+  __resetAllForTests,
+} from '../turn-signal-tracker.js'
+
+beforeEach(() => {
+  __resetAllForTests()
+})
+
+describe('turn-signal-tracker', () => {
+  it('reset() initialises a fresh turn with zero gap', () => {
+    reset('chat:thread', 1000)
+    expect(getLongestGap('chat:thread')).toBe(0)
+    expect(getLastSignalAt('chat:thread')).toBe(1000)
+  })
+
+  it('noteSignal() updates lastSignalAt and accumulates the longest gap', () => {
+    reset('k', 1000)
+    noteSignal('k', 1500) // gap=500
+    expect(getLongestGap('k')).toBe(500)
+    expect(getLastSignalAt('k')).toBe(1500)
+
+    noteSignal('k', 1700) // gap=200, smaller
+    expect(getLongestGap('k')).toBe(500)
+    expect(getLastSignalAt('k')).toBe(1700)
+
+    noteSignal('k', 4500) // gap=2800, new max
+    expect(getLongestGap('k')).toBe(2800)
+    expect(getLastSignalAt('k')).toBe(4500)
+
+    noteSignal('k', 5000) // gap=500, smaller
+    expect(getLongestGap('k')).toBe(2800)
+  })
+
+  it('noteSignal() on an unknown key is a no-op (no state created)', () => {
+    noteSignal('untracked', 1000)
+    expect(getLongestGap('untracked')).toBe(0)
+    expect(getLastSignalAt('untracked')).toBeUndefined()
+  })
+
+  it('separate keys track independently', () => {
+    reset('chatA', 1000)
+    reset('chatB', 1000)
+    noteSignal('chatA', 5000) // gap=4000
+    noteSignal('chatB', 1500) // gap=500
+    expect(getLongestGap('chatA')).toBe(4000)
+    expect(getLongestGap('chatB')).toBe(500)
+  })
+
+  it('reset() on an existing key starts a fresh window', () => {
+    reset('k', 1000)
+    noteSignal('k', 5000) // gap=4000
+    expect(getLongestGap('k')).toBe(4000)
+
+    // New turn — counter resets even though prior gap was huge
+    reset('k', 10000)
+    noteSignal('k', 10100)
+    expect(getLongestGap('k')).toBe(100)
+  })
+
+  it('clear() removes state for a key', () => {
+    reset('k', 1000)
+    noteSignal('k', 2000)
+    clear('k')
+    expect(getLongestGap('k')).toBe(0)
+    expect(getLastSignalAt('k')).toBeUndefined()
+  })
+
+  it('clear() on an unknown key is a no-op (no error)', () => {
+    expect(() => clear('never-tracked')).not.toThrow()
+  })
+
+  it('getLongestGap() never returns negative even with out-of-order timestamps', () => {
+    // Pathological case: clocks moving backwards (NTP slew, etc).
+    reset('k', 5000)
+    noteSignal('k', 4000) // negative-ish gap
+    // Whatever the implementation does, the returned gap should still be
+    // a sensible number for downstream histogram code.
+    const gap = getLongestGap('k')
+    expect(typeof gap).toBe('number')
+    expect(Number.isFinite(gap)).toBe(true)
+  })
+
+  it('typical full-turn flow — reset, multiple signals, clear', () => {
+    const k = 'flow-test'
+    reset(k, 0)
+
+    // Simulate a turn with periodic signals + one big silent stretch
+    noteSignal(k, 200)   // gap=200
+    noteSignal(k, 700)   // gap=500
+    noteSignal(k, 1100)  // gap=400
+    // ── 3.5s of silence (model thinking) ──
+    noteSignal(k, 4600)  // gap=3500 (longest)
+    noteSignal(k, 5000)  // gap=400
+
+    expect(getLongestGap(k)).toBe(3500)
+
+    // turn_end emits the metric, then clears
+    clear(k)
+    expect(getLongestGap(k)).toBe(0)
+  })
+})

--- a/telegram-plugin/turn-signal-tracker.ts
+++ b/telegram-plugin/turn-signal-tracker.ts
@@ -1,0 +1,79 @@
+/**
+ * Per-turn silent-gap tracker for streaming observability.
+ *
+ * Tracks the longest contiguous interval within a turn where no user-visible
+ * signal was sent. Signals include: progress-card edits, status-reaction
+ * transitions, answer-lane updates, and fresh sendMessage calls.
+ *
+ * Keyed by chatId+threadId so concurrent turns in different chats don't
+ * collide. Designed to be fully standalone (no grammy/bot dependency) so
+ * it's testable with deterministic time injection via vi.useFakeTimers().
+ *
+ * Usage:
+ *   signalTracker.reset(key, now)       // at turn start
+ *   signalTracker.noteSignal(key, now)  // on every user-visible signal
+ *   signalTracker.getLongestGap(key)    // at turn_end
+ *   signalTracker.clear(key)            // after emitting (cleanup)
+ */
+
+export interface TurnSignalState {
+  /** The time the current gap started (i.e., the last signal time). */
+  lastSignalAt: number
+  /** The longest gap observed so far (ms). */
+  longestGapMs: number
+}
+
+/**
+ * Module-scoped map: `"chatId:threadId"` → state. Using a module-level map
+ * keeps the tracker lightweight and avoids passing state through every
+ * call-site while remaining mockable in tests via the exported functions.
+ */
+const state = new Map<string, TurnSignalState>()
+
+/**
+ * Begin tracking a new turn. Records `now` as the initial signal time and
+ * resets the gap accumulator. Call at the start of each fresh turn.
+ */
+export function reset(key: string, now: number): void {
+  state.set(key, { lastSignalAt: now, longestGapMs: 0 })
+}
+
+/**
+ * Record a user-visible signal. Measures the gap since the last signal and
+ * updates `longestGapMs` if this gap is larger.
+ */
+export function noteSignal(key: string, now: number): void {
+  const entry = state.get(key)
+  if (entry == null) return
+  const gap = now - entry.lastSignalAt
+  if (gap > entry.longestGapMs) entry.longestGapMs = gap
+  entry.lastSignalAt = now
+}
+
+/**
+ * Returns the longest gap observed during the current turn (ms).
+ * Returns 0 if no tracking state exists for this key.
+ */
+export function getLongestGap(key: string): number {
+  return state.get(key)?.longestGapMs ?? 0
+}
+
+/**
+ * Returns the last signal time for this key, or undefined if not tracked.
+ * Useful for computing a trailing gap at turn_end before calling clear().
+ */
+export function getLastSignalAt(key: string): number | undefined {
+  return state.get(key)?.lastSignalAt
+}
+
+/**
+ * Remove state for this key. Call after emitting the turn_signal_gap metric.
+ */
+export function clear(key: string): void {
+  state.delete(key)
+}
+
+/** Exposed for tests — clears all tracked state. */
+export function __resetAllForTests(): void {
+  state.clear()
+}


### PR DESCRIPTION
Closes #203.

Completes the second of the two follow-ups deferred from #195. Wires emission for the four metric event types that landed in PR #201.

## What ships

- **`telegram-plugin/turn-signal-tracker.ts`** (new) — standalone module-scoped state map keyed by `chatId:threadId`. `reset()`, `noteSignal()`, `getLongestGap()`, `clear()`. No grammy/bot dependency, fully testable with deterministic time injection.

- **`telegram-plugin/gateway/gateway.ts`** —
  - `inboundReceivedAt = Date.now()` captured at the top of `handleInbound` (after `gate()` to avoid skewing on early-exit paths).
  - `inbound_ack` emitted on the steering and fresh-turn paths after the 👀-style status reaction post (`ackDelayMs = Date.now() - receivedAt`).
  - `signalTracker.reset()` on fresh-turn enqueue.
  - `signalTracker.noteSignal()` after reply finalization, status-reaction transitions, and answer-lane activity.
  - `turn_signal_gap` emitted at both `turn_end` sites with `longestGapMs` and `turnDurationMs`, then `clear()`.
  - `onMetric` callback wired on the answer-stream constructor — events flow through `logStreamingEvent` AND tick the silent-gap tracker.

- **`telegram-plugin/answer-stream.ts`** —
  - `AnswerStreamConfig.onMetric?` callback added.
  - Fires `answer_lane_update` on each successful send/edit/draft (with `transport: 'message' | 'edit' | 'draft'`, `charCount`).
  - Fires `answer_lane_materialized` on materialize success.
  - Does NOT fire on oversize-guard rejection (consistent with the silent-failure anti-pattern: the `warn` log surfaces the issue separately).

## Acceptance

- [x] **(1)** `inbound_ack` emitted with time-to-ack delta on both inbound paths
- [x] **(2)** `turn_signal_gap` tracker per-turn, ticking on every user-visible signal; emitted at `turn_end` with `longestGapMs` + `turnDurationMs`
- [x] **(3)** `answer_lane_update` and `answer_lane_materialized` emitted from `answer-stream.ts` via injected `onMetric` callback
- [x] **(4)** Tests with deterministic time injection (`vi.useFakeTimers`) cover tracker behaviour and answer-stream callbacks
- [x] **(5)** Tests pass (3430 / 3436 pass + 7 skipped — the 6 failures are pre-existing in token-helpers / setup-state / auth-stale-token-fix, unchanged from main); typecheck clean (only the pre-existing `rename-orchestrator.test.ts` errors that were red before this work).

## Surface convention

Metrics are emitted via the existing `logStreamingEvent` sink in `streaming-metrics.ts`, which respects the `STREAMING_METRICS_LOG` env-gate. No new infrastructure.

## Followup

Once #195 + #202 + #203 are all live, the JTBD's "ambient signals fire effectively instantly" claim becomes auditable — operators can correlate `inbound_ack.ackDelayMs` and `turn_signal_gap.longestGapMs` against real traffic.

Co-authored-by: Claude <noreply@anthropic.com>