### PR TITLE
feat(vault): append-only audit log for broker access (#206)

### DIFF
--- a/src/vault/broker/audit-log.test.ts
+++ b/src/vault/broker/audit-log.test.ts
@@ -197,7 +197,7 @@ describe("denied requests", () => {
     // Assert the secret value is not present anywhere in the raw log line
     expect(lines[0]).not.toContain(SECRET_VALUE);
     // The entry itself must not have a value field
-    expect((entry as Record<string, unknown>).value).toBeUndefined();
+    expect((entry as unknown as Record<string, unknown>).value).toBeUndefined();
   });
 });
 

--- a/src/vault/broker/audit-log.test.ts
+++ b/src/vault/broker/audit-log.test.ts
@@ -1,0 +1,287 @@
+/**
+ * Tests for the audit-log module (src/vault/broker/audit-log.ts).
+ *
+ * Covers:
+ *   - get / set / delete / list each emit exactly one line with expected fields
+ *   - Denied request logs result:"denied:..." and never leaks the value
+ *   - Concurrent writes don't interleave bytes (each parsed line is valid JSON)
+ *   - File created with mode 0600
+ *   - Path is configurable (uses a tmp file, not ~/.switchroom/vault-audit.log)
+ *   - callerFromPeer: prefers systemdUnit, falls back to pid:<n>
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import {
+  createAuditLogger,
+  callerFromPeer,
+  defaultAuditLogPath,
+  type AuditEntry,
+} from "./audit-log.js";
+
+// ─── helpers ──────────────────────────────────────────────────────────────────
+
+function readLines(filePath: string): string[] {
+  const raw = fs.readFileSync(filePath, "utf8");
+  return raw.split("\n").filter((l) => l.trim().length > 0);
+}
+
+function parseLines(filePath: string): AuditEntry[] {
+  return readLines(filePath).map((l) => JSON.parse(l) as AuditEntry);
+}
+
+// ─── fixtures ─────────────────────────────────────────────────────────────────
+
+let tmpDir: string;
+let logPath: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "audit-log-test-"));
+  logPath = path.join(tmpDir, "vault-audit.log");
+});
+
+afterEach(() => {
+  try {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  } catch { /* ignore */ }
+});
+
+// ─── basic emission ───────────────────────────────────────────────────────────
+
+describe("createAuditLogger", () => {
+  it("emits exactly one line for a get op", () => {
+    const audit = createAuditLogger({ path: logPath });
+    audit.write({
+      ts: "2026-04-28T14:33:00.000Z",
+      op: "get",
+      key: "my/secret-key",
+      caller: "switchroom-myagent-cron-0.service",
+      pid: 12345,
+      cgroup: "switchroom-myagent-cron-0.service",
+      result: "allowed",
+    });
+    const lines = readLines(logPath);
+    expect(lines).toHaveLength(1);
+    const entry = JSON.parse(lines[0]) as AuditEntry;
+    expect(entry.ts).toBe("2026-04-28T14:33:00.000Z");
+    expect(entry.op).toBe("get");
+    expect(entry.key).toBe("my/secret-key");
+    expect(entry.caller).toBe("switchroom-myagent-cron-0.service");
+    expect(entry.pid).toBe(12345);
+    expect(entry.cgroup).toBe("switchroom-myagent-cron-0.service");
+    expect(entry.result).toBe("allowed");
+  });
+
+  it("emits exactly one line for a set op", () => {
+    const audit = createAuditLogger({ path: logPath });
+    audit.write({
+      ts: new Date().toISOString(),
+      op: "set",
+      key: "calendar/admin-api-key",
+      caller: "switchroom-cron-morning-brief.service",
+      pid: 9999,
+      cgroup: "switchroom-cron-morning-brief.service",
+      result: "allowed",
+    });
+    const lines = readLines(logPath);
+    expect(lines).toHaveLength(1);
+    const entry = JSON.parse(lines[0]) as AuditEntry;
+    expect(entry.op).toBe("set");
+    expect(entry.key).toBe("calendar/admin-api-key");
+    expect(entry.result).toBe("allowed");
+  });
+
+  it("emits exactly one line for a delete op", () => {
+    const audit = createAuditLogger({ path: logPath });
+    audit.write({
+      ts: new Date().toISOString(),
+      op: "delete",
+      key: "old/key",
+      caller: "switchroom-cleaner-cron-0.service",
+      pid: 1111,
+      result: "allowed",
+    });
+    const lines = readLines(logPath);
+    expect(lines).toHaveLength(1);
+    const entry = JSON.parse(lines[0]) as AuditEntry;
+    expect(entry.op).toBe("delete");
+    expect(entry.key).toBe("old/key");
+  });
+
+  it("emits exactly one line for a list op (no key field)", () => {
+    const audit = createAuditLogger({ path: logPath });
+    audit.write({
+      ts: new Date().toISOString(),
+      op: "list",
+      caller: "switchroom-myagent-cron-0.service",
+      pid: 2222,
+      result: "allowed",
+    });
+    const lines = readLines(logPath);
+    expect(lines).toHaveLength(1);
+    const entry = JSON.parse(lines[0]) as AuditEntry;
+    expect(entry.op).toBe("list");
+    expect(entry.key).toBeUndefined();
+    expect(entry.result).toBe("allowed");
+  });
+
+  it("emits exactly one line for an unlock op (no key field)", () => {
+    const audit = createAuditLogger({ path: logPath });
+    audit.write({
+      ts: new Date().toISOString(),
+      op: "unlock",
+      caller: "pid:7777",
+      pid: 7777,
+      result: "allowed",
+    });
+    const lines = readLines(logPath);
+    expect(lines).toHaveLength(1);
+    const entry = JSON.parse(lines[0]) as AuditEntry;
+    expect(entry.op).toBe("unlock");
+    expect(entry.key).toBeUndefined();
+  });
+
+  it("emits exactly one line for a lock op (no key field)", () => {
+    const audit = createAuditLogger({ path: logPath });
+    audit.write({
+      ts: new Date().toISOString(),
+      op: "lock",
+      caller: "pid:8888",
+      pid: 8888,
+      result: "allowed",
+    });
+    const lines = readLines(logPath);
+    expect(lines).toHaveLength(1);
+    const entry = JSON.parse(lines[0]) as AuditEntry;
+    expect(entry.op).toBe("lock");
+    expect(entry.key).toBeUndefined();
+  });
+
+  it("accumulates multiple lines — one per write", () => {
+    const audit = createAuditLogger({ path: logPath });
+    const ops = ["get", "set", "delete", "list"] as const;
+    for (const op of ops) {
+      audit.write({
+        ts: new Date().toISOString(),
+        op,
+        key: op !== "list" ? "some/key" : undefined,
+        caller: "switchroom-myagent-cron-0.service",
+        pid: 42,
+        result: "allowed",
+      });
+    }
+    expect(readLines(logPath)).toHaveLength(ops.length);
+  });
+});
+
+// ─── denied path ──────────────────────────────────────────────────────────────
+
+describe("denied requests", () => {
+  it("logs result:denied:<reason> and does not include the value", () => {
+    const SECRET_VALUE = "s3cr3t-password-do-not-log";
+    const audit = createAuditLogger({ path: logPath });
+    audit.write({
+      ts: new Date().toISOString(),
+      op: "get",
+      key: "calendar/api-key",
+      caller: "pid:555",
+      pid: 555,
+      result: "denied:key 'calendar/api-key' not in ACL for myagent/schedule[0]",
+    });
+    const lines = readLines(logPath);
+    expect(lines).toHaveLength(1);
+    const entry = JSON.parse(lines[0]) as AuditEntry;
+    expect(entry.result).toMatch(/^denied:/);
+    // Assert the secret value is not present anywhere in the raw log line
+    expect(lines[0]).not.toContain(SECRET_VALUE);
+    // The entry itself must not have a value field
+    expect((entry as Record<string, unknown>).value).toBeUndefined();
+  });
+});
+
+// ─── file mode ────────────────────────────────────────────────────────────────
+
+describe("file mode", () => {
+  it("creates the log file with mode 0600", () => {
+    const audit = createAuditLogger({ path: logPath });
+    audit.write({
+      ts: new Date().toISOString(),
+      op: "get",
+      key: "k",
+      caller: "pid:1",
+      pid: 1,
+      result: "allowed",
+    });
+    const stat = fs.statSync(logPath);
+    // Compare the permission bits only (mask out file type bits)
+    const mode = stat.mode & 0o777;
+    expect(mode).toBe(0o600);
+  });
+});
+
+// ─── concurrent writes ────────────────────────────────────────────────────────
+
+describe("concurrent writes", () => {
+  it("does not interleave bytes — each line is valid JSON when concurrent writes complete", async () => {
+    const audit = createAuditLogger({ path: logPath });
+    const N = 50;
+
+    // Kick off N concurrent writes. Each write is sync inside but we schedule
+    // them via Promise.all to exercise any interleaving at the OS level.
+    await Promise.all(
+      Array.from({ length: N }, (_, i) =>
+        Promise.resolve().then(() => {
+          audit.write({
+            ts: new Date().toISOString(),
+            op: "get",
+            key: `key-${i}`,
+            caller: `switchroom-agent-cron-${i}.service`,
+            pid: 10000 + i,
+            cgroup: `switchroom-agent-cron-${i}.service`,
+            result: "allowed",
+          });
+        }),
+      ),
+    );
+
+    const lines = readLines(logPath);
+    // All N writes must produce exactly N lines
+    expect(lines).toHaveLength(N);
+
+    // Every line must parse cleanly as valid JSON
+    for (const line of lines) {
+      expect(() => JSON.parse(line)).not.toThrow();
+      const entry = JSON.parse(line) as AuditEntry;
+      expect(entry.op).toBe("get");
+      expect(entry.result).toBe("allowed");
+    }
+  });
+});
+
+// ─── callerFromPeer ───────────────────────────────────────────────────────────
+
+describe("callerFromPeer", () => {
+  it("returns systemdUnit when available", () => {
+    const caller = callerFromPeer({
+      pid: 12345,
+      systemdUnit: "switchroom-myagent-cron-0.service",
+    });
+    expect(caller).toBe("switchroom-myagent-cron-0.service");
+  });
+
+  it("falls back to pid:<n> when systemdUnit is null", () => {
+    const caller = callerFromPeer({ pid: 99999, systemdUnit: null });
+    expect(caller).toBe("pid:99999");
+  });
+});
+
+// ─── defaultAuditLogPath ──────────────────────────────────────────────────────
+
+describe("defaultAuditLogPath", () => {
+  it("returns a path under os.homedir()/.switchroom/", () => {
+    const p = defaultAuditLogPath();
+    expect(p).toBe(path.join(os.homedir(), ".switchroom", "vault-audit.log"));
+  });
+});

--- a/src/vault/broker/audit-log.test.ts
+++ b/src/vault/broker/audit-log.test.ts
@@ -275,6 +275,14 @@ describe("callerFromPeer", () => {
     const caller = callerFromPeer({ pid: 99999, systemdUnit: null });
     expect(caller).toBe("pid:99999");
   });
+
+  it("falls back to pid:<n> when systemdUnit is the empty string", () => {
+    // Defensive guard for malformed cgroup hierarchies that produce
+    // empty-string unit names. Prevents the audit log from recording
+    // a literal `caller: ""` entry.
+    const caller = callerFromPeer({ pid: 42, systemdUnit: "" });
+    expect(caller).toBe("pid:42");
+  });
 });
 
 // ─── defaultAuditLogPath ──────────────────────────────────────────────────────

--- a/src/vault/broker/audit-log.ts
+++ b/src/vault/broker/audit-log.ts
@@ -1,0 +1,139 @@
+/**
+ * audit-log — append-only audit log for vault broker access.
+ *
+ * Every vault key access — successful or denied — leaves a record in
+ * ~/.switchroom/vault-audit.log (mode 0600, newline-delimited JSON).
+ *
+ * Design constraints:
+ *   - Sync write (no buffering, no Promises) — audit must survive a broker
+ *     crash mid-request. The broker is request/response; write completes
+ *     before response is sent.
+ *   - O_APPEND flag — on Linux, write(2) calls with O_APPEND are atomic up
+ *     to PIPE_BUF (4 KiB) bytes, so concurrent writes of short JSON lines
+ *     don't interleave bytes within a line.
+ *   - Mode 0600 — user-owned, not world-readable.
+ *   - Path is injectable for tests (use a tmp file, not the real log).
+ *   - NEVER log secret values — only key names and results.
+ *   - Failures write to process.stderr — a broken audit volume must not be
+ *     silent (the operator needs to notice).
+ *
+ * Usage:
+ *   const audit = createAuditLogger();                  // default path
+ *   const audit = createAuditLogger({ path: tmpFile }); // test override
+ *   audit.write({ ts, op, key, caller, pid, cgroup, result });
+ */
+
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+/** Operations the broker can perform. */
+export type AuditOp = "get" | "set" | "delete" | "list" | "unlock" | "lock";
+
+/**
+ * One audit log entry.
+ * `key` is omitted for ops that don't target a specific key (e.g. unlock, lock, list).
+ * `cgroup` is undefined when peercred couldn't resolve the caller's systemd unit.
+ */
+export interface AuditEntry {
+  /** ISO-8601 timestamp, e.g. "2026-04-28T14:33:00.123Z" */
+  ts: string;
+  /** Operation name */
+  op: AuditOp;
+  /** Vault key name — NEVER the secret value */
+  key?: string;
+  /** Human-readable caller identity: cgroup unit name or "pid:<n>" */
+  caller: string;
+  /** PID of the calling process */
+  pid: number;
+  /** Raw cgroup unit name if available, e.g. "switchroom-myagent-cron-0.service" */
+  cgroup?: string;
+  /** Outcome: "allowed", "denied:<reason>", or "error:<detail>" */
+  result: string;
+}
+
+export interface AuditLogger {
+  write(entry: AuditEntry): void;
+}
+
+/** Options for createAuditLogger. */
+export interface AuditLoggerOptions {
+  /**
+   * Absolute path to the audit log file.
+   * Defaults to ~/.switchroom/vault-audit.log (resolved via os.homedir()).
+   */
+  path?: string;
+}
+
+/**
+ * Default log path: ~/.switchroom/vault-audit.log.
+ * Resolved at call time so tests can override os.homedir() if needed,
+ * but typically called once at broker startup.
+ */
+export function defaultAuditLogPath(): string {
+  return path.join(os.homedir(), ".switchroom", "vault-audit.log");
+}
+
+/**
+ * Derive a friendly caller string from a PeerInfo-like object.
+ * Prefers the cgroup unit name; falls back to "pid:<n>".
+ */
+export function callerFromPeer(peer: {
+  pid: number;
+  systemdUnit: string | null;
+}): string {
+  if (peer.systemdUnit !== null) {
+    return peer.systemdUnit;
+  }
+  return `pid:${peer.pid}`;
+}
+
+/**
+ * Factory — returns an AuditLogger that writes to the configured path.
+ *
+ * The logger opens + writes + closes on every call (O_APPEND mode).
+ * This is intentionally NOT a persistent open-fd design: keeping the fd open
+ * across requests would prevent log rotation (logrotate moves the file while
+ * the fd still points at the old inode). Re-opening per write is cheap on
+ * Linux for a low-volume audit channel.
+ */
+export function createAuditLogger(opts: AuditLoggerOptions = {}): AuditLogger {
+  const logPath = opts.path ?? defaultAuditLogPath();
+
+  return {
+    write(entry: AuditEntry): void {
+      // Build the JSON line. Control characters are not a concern for the
+      // fields we log (ISO timestamps, key names, unit names, pid numbers),
+      // but JSON.stringify handles them correctly anyway.
+      const line = JSON.stringify(entry) + "\n";
+
+      let fd: number;
+      try {
+        // 'a' = O_WRONLY | O_CREAT | O_APPEND — atomic appends on Linux.
+        // Mode 0o600: user-only read/write.
+        fd = fs.openSync(logPath, "a", 0o600);
+      } catch (err) {
+        process.stderr.write(
+          `[vault-audit] ERROR: could not open audit log ${logPath}: ${(err as Error).message}\n`,
+        );
+        return;
+      }
+
+      try {
+        fs.writeSync(fd, line);
+      } catch (err) {
+        process.stderr.write(
+          `[vault-audit] ERROR: could not write to audit log ${logPath}: ${(err as Error).message}\n`,
+        );
+      } finally {
+        try {
+          fs.closeSync(fd);
+        } catch (closeErr) {
+          process.stderr.write(
+            `[vault-audit] ERROR: could not close audit log fd: ${(closeErr as Error).message}\n`,
+          );
+        }
+      }
+    },
+  };
+}

--- a/src/vault/broker/audit-log.ts
+++ b/src/vault/broker/audit-log.ts
@@ -82,7 +82,10 @@ export function callerFromPeer(peer: {
   pid: number;
   systemdUnit: string | null;
 }): string {
-  if (peer.systemdUnit !== null) {
+  // Guard empty string in addition to null. A malformed cgroup hierarchy
+  // can produce systemdUnit === "" — without this check the audit log
+  // would record `caller: ""` instead of falling back to the pid.
+  if (peer.systemdUnit !== null && peer.systemdUnit.length > 0) {
     return peer.systemdUnit;
   }
   return `pid:${peer.pid}`;

--- a/src/vault/broker/server.test.ts
+++ b/src/vault/broker/server.test.ts
@@ -28,6 +28,7 @@ import {
   type BrokerResponse,
 } from "./protocol.js";
 import type { VaultEntry } from "../vault.js";
+import { createAuditLogger, type AuditEntry } from "./audit-log.js";
 
 const TEST_SECRETS: Record<string, VaultEntry> = {
   foo: { kind: "string", value: "bar-value" },
@@ -474,6 +475,230 @@ describe("VaultBroker server: gated paths (denied identity via _testIdentify)", 
       if (!resp.ok) {
         expect(resp.code).toBe("DENIED");
       }
+    },
+  );
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Audit log emission tests
+//
+// Verifies that each broker operation emits exactly one audit line with the
+// correct fields. Uses _testAuditLogger + _testIdentify to exercise the full
+// request path without hitting the real audit log or peercred.
+// ─────────────────────────────────────────────────────────────────────────────
+
+function readAuditLines(logPath: string): AuditEntry[] {
+  try {
+    const raw = fs.readFileSync(logPath, "utf8");
+    return raw
+      .split("\n")
+      .filter((l) => l.trim().length > 0)
+      .map((l) => JSON.parse(l) as AuditEntry);
+  } catch {
+    return [];
+  }
+}
+
+describe("VaultBroker server: audit log emission (allowed cron unit)", () => {
+  let broker: VaultBroker;
+  let socketPath: string;
+  let tmpDir: string;
+  let auditLogPath: string;
+  let prevNonLinuxFlag: string | undefined;
+
+  const FAKE_PEER = {
+    uid: process.getuid?.() ?? 1000,
+    pid: 55555,
+    exe: "/usr/bin/bash",
+    systemdUnit: "switchroom-myagent-cron-0.service" as string | null,
+  };
+
+  function makeAuditAclConfig() {
+    const allowedKeys = [...Object.keys(TEST_SECRETS), "nonexistent"];
+    return {
+      switchroom: { version: 1 },
+      telegram: { bot_token: "test", forum_chat_id: "123" },
+      vault: {
+        path: "~/.switchroom/vault.enc",
+        broker: { socket: "~/.switchroom/vault-broker.sock", enabled: true },
+      },
+      agents: {
+        myagent: { schedule: [{ secrets: allowedKeys }] },
+      },
+    } as any;
+  }
+
+  beforeEach(async () => {
+    prevNonLinuxFlag = process.env.SWITCHROOM_BROKER_ALLOW_NON_LINUX;
+    process.env.SWITCHROOM_BROKER_ALLOW_NON_LINUX = "1";
+
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "broker-audit-test-"));
+    socketPath = path.join(tmpDir, "test.sock");
+    auditLogPath = path.join(tmpDir, "vault-audit.log");
+
+    broker = new VaultBroker({
+      _testSecrets: cloneSecrets(),
+      _testConfig: makeAuditAclConfig(),
+      _testIdentify: () => FAKE_PEER,
+      _testAuditLogger: createAuditLogger({ path: auditLogPath }),
+    });
+    await broker.start(socketPath, undefined, undefined);
+  });
+
+  afterEach(() => {
+    broker.stop();
+    try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch { /* ignore */ }
+    if (prevNonLinuxFlag === undefined) {
+      delete process.env.SWITCHROOM_BROKER_ALLOW_NON_LINUX;
+    } else {
+      process.env.SWITCHROOM_BROKER_ALLOW_NON_LINUX = prevNonLinuxFlag;
+    }
+  });
+
+  it("get (allowed): emits exactly one audit line with correct fields", async () => {
+    await rpc(socketPath, { v: 1, op: "get", key: "foo" });
+    const lines = readAuditLines(auditLogPath);
+    expect(lines).toHaveLength(1);
+    const entry = lines[0];
+    expect(entry.op).toBe("get");
+    expect(entry.key).toBe("foo");
+    expect(entry.caller).toBe("switchroom-myagent-cron-0.service");
+    expect(entry.pid).toBe(55555);
+    expect(entry.cgroup).toBe("switchroom-myagent-cron-0.service");
+    expect(entry.result).toBe("allowed");
+    expect(entry.ts).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  it("get (allowed): does not log the secret value", async () => {
+    await rpc(socketPath, { v: 1, op: "get", key: "foo" });
+    const rawLog = fs.readFileSync(auditLogPath, "utf8");
+    // "bar-value" is the secret for key "foo" — must not appear in the log
+    expect(rawLog).not.toContain("bar-value");
+  });
+
+  it("list (allowed): emits exactly one audit line", async () => {
+    await rpc(socketPath, { v: 1, op: "list" });
+    const lines = readAuditLines(auditLogPath);
+    expect(lines).toHaveLength(1);
+    const entry = lines[0];
+    expect(entry.op).toBe("list");
+    expect(entry.key).toBeUndefined();
+    expect(entry.result).toBe("allowed");
+    expect(entry.caller).toBe("switchroom-myagent-cron-0.service");
+  });
+
+  it("lock: emits exactly one audit line", async () => {
+    await rpc(socketPath, { v: 1, op: "lock" });
+    const lines = readAuditLines(auditLogPath);
+    expect(lines).toHaveLength(1);
+    const entry = lines[0];
+    expect(entry.op).toBe("lock");
+    expect(entry.key).toBeUndefined();
+    expect(entry.result).toBe("allowed");
+  });
+
+  it("status: does NOT emit an audit line (informational only)", async () => {
+    await rpc(socketPath, { v: 1, op: "status" });
+    const lines = readAuditLines(auditLogPath);
+    expect(lines).toHaveLength(0);
+  });
+
+  it("get (denied by ACL): emits result:denied:<reason> and no value", async () => {
+    // "not-in-acl" is not in the allowlist — will be denied by ACL
+    await rpc(socketPath, { v: 1, op: "get", key: "not-in-acl" });
+    const lines = readAuditLines(auditLogPath);
+    expect(lines).toHaveLength(1);
+    const entry = lines[0];
+    expect(entry.op).toBe("get");
+    expect(entry.key).toBe("not-in-acl");
+    expect(entry.result).toMatch(/^denied:/);
+    // Assert no secret value leaks into the log line
+    const rawLog = fs.readFileSync(auditLogPath, "utf8");
+    expect(rawLog).not.toContain("bar-value");
+    expect(rawLog).not.toContain("aGVsbG8=");
+  });
+
+  it("get (UNKNOWN_KEY): emits result:error:UNKNOWN_KEY", async () => {
+    // "nonexistent" is in the ACL allowlist (makeAuditAclConfig) but not in secrets
+    await rpc(socketPath, { v: 1, op: "get", key: "nonexistent" });
+    const lines = readAuditLines(auditLogPath);
+    expect(lines).toHaveLength(1);
+    const entry = lines[0];
+    expect(entry.op).toBe("get");
+    expect(entry.key).toBe("nonexistent");
+    expect(entry.result).toBe("error:UNKNOWN_KEY");
+  });
+
+  it("multiple ops each emit one line each", async () => {
+    await rpc(socketPath, { v: 1, op: "get", key: "foo" });
+    await rpc(socketPath, { v: 1, op: "list" });
+    await rpc(socketPath, { v: 1, op: "lock" });
+    const lines = readAuditLines(auditLogPath);
+    expect(lines).toHaveLength(3);
+    expect(lines[0].op).toBe("get");
+    expect(lines[1].op).toBe("list");
+    expect(lines[2].op).toBe("lock");
+  });
+});
+
+describe("VaultBroker server: audit log emission (denied identity)", () => {
+  let broker: VaultBroker;
+  let socketPath: string;
+  let tmpDir: string;
+  let auditLogPath: string;
+  let prevNonLinuxFlag: string | undefined;
+
+  beforeEach(async () => {
+    prevNonLinuxFlag = process.env.SWITCHROOM_BROKER_ALLOW_NON_LINUX;
+    process.env.SWITCHROOM_BROKER_ALLOW_NON_LINUX = "1";
+
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "broker-audit-deny-test-"));
+    socketPath = path.join(tmpDir, "test.sock");
+    auditLogPath = path.join(tmpDir, "vault-audit.log");
+
+    broker = new VaultBroker({
+      _testSecrets: cloneSecrets(),
+      _testConfig: makeMinimalConfig(),
+      _testIdentify: () => null, // simulate unidentified caller
+      _testAuditLogger: createAuditLogger({ path: auditLogPath }),
+    });
+    await broker.start(socketPath, undefined, undefined);
+  });
+
+  afterEach(() => {
+    broker.stop();
+    try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch { /* ignore */ }
+    if (prevNonLinuxFlag === undefined) {
+      delete process.env.SWITCHROOM_BROKER_ALLOW_NON_LINUX;
+    } else {
+      process.env.SWITCHROOM_BROKER_ALLOW_NON_LINUX = prevNonLinuxFlag;
+    }
+  });
+
+  it.skipIf(process.platform !== "linux")(
+    "get (unidentified caller): emits result:denied: and no value",
+    async () => {
+      await rpc(socketPath, { v: 1, op: "get", key: "foo" });
+      const lines = readAuditLines(auditLogPath);
+      expect(lines).toHaveLength(1);
+      const entry = lines[0];
+      expect(entry.op).toBe("get");
+      expect(entry.key).toBe("foo");
+      expect(entry.result).toMatch(/^denied:/);
+      const rawLog = fs.readFileSync(auditLogPath, "utf8");
+      expect(rawLog).not.toContain("bar-value");
+    },
+  );
+
+  it.skipIf(process.platform !== "linux")(
+    "list (unidentified caller): emits result:denied:",
+    async () => {
+      await rpc(socketPath, { v: 1, op: "list" });
+      const lines = readAuditLines(auditLogPath);
+      expect(lines).toHaveLength(1);
+      const entry = lines[0];
+      expect(entry.op).toBe("list");
+      expect(entry.result).toMatch(/^denied:/);
     },
   );
 });

--- a/src/vault/broker/server.ts
+++ b/src/vault/broker/server.ts
@@ -40,6 +40,7 @@ import {
   MAX_FRAME_BYTES,
   type BrokerStatus,
 } from "./protocol.js";
+import { createAuditLogger, callerFromPeer, type AuditLogger } from "./audit-log.js";
 
 const PID_FILE_DEFAULT = "~/.switchroom/vault-broker.pid";
 
@@ -69,6 +70,12 @@ export interface BrokerTestOpts {
    * calls the real `identify()`. DO NOT set outside tests.
    */
   _testIdentify?: (socketPath: string, socket: net.Socket) => PeerInfo | null;
+  /**
+   * If provided, replaces the real audit logger. Use in tests to inject a
+   * logger that writes to a tmp file instead of ~/.switchroom/vault-audit.log.
+   * DO NOT set outside tests.
+   */
+  _testAuditLogger?: AuditLogger;
 }
 
 export class VaultBroker {
@@ -80,6 +87,7 @@ export class VaultBroker {
   private socketPath: string = "";
   private unlockSocketPath: string = "";
   private vaultPath: string = "";
+  private auditLogger: AuditLogger;
 
   constructor(private readonly testOpts: BrokerTestOpts = {}) {
     // Defence-in-depth: BrokerTestOpts is exported (so vitest can construct
@@ -91,13 +99,18 @@ export class VaultBroker {
     const usingTestOpt =
       testOpts._testSecrets !== undefined ||
       testOpts._testConfig !== undefined ||
-      testOpts._testIdentify !== undefined;
+      testOpts._testIdentify !== undefined ||
+      testOpts._testAuditLogger !== undefined;
     if (usingTestOpt && process.env.NODE_ENV !== "test") {
       throw new Error(
-        "VaultBroker: BrokerTestOpts (_testSecrets/_testConfig/_testIdentify) " +
+        "VaultBroker: BrokerTestOpts (_testSecrets/_testConfig/_testIdentify/_testAuditLogger) " +
           "must not be set outside tests. Set NODE_ENV=test if you really mean it.",
       );
     }
+
+    // Use the injected logger for tests; create the real one for production.
+    // The real logger's path defaults to ~/.switchroom/vault-audit.log.
+    this.auditLogger = testOpts._testAuditLogger ?? createAuditLogger();
   }
 
   /**
@@ -386,8 +399,15 @@ export class VaultBroker {
       return;
     }
 
+    // Derive audit identity fields from peer (already computed by peercred at
+    // connection accept time — do NOT re-derive here).
+    const auditPid = peer?.pid ?? process.pid;
+    const auditCaller = peer !== null ? callerFromPeer(peer) : `pid:${process.pid}`;
+    const auditCgroup = peer?.systemdUnit ?? undefined;
+
     // Handle each op
     if (req.op === "status") {
+      // status is an informational op — not audited (no secret access, no ACL decision)
       const status = this.getStatus();
       socket.write(
         encodeResponse({ ok: true, status }),
@@ -397,6 +417,14 @@ export class VaultBroker {
 
     if (req.op === "lock") {
       this.lock();
+      this.auditLogger.write({
+        ts: new Date().toISOString(),
+        op: "lock",
+        caller: auditCaller,
+        pid: auditPid,
+        cgroup: auditCgroup,
+        result: "allowed",
+      });
       socket.write(encodeResponse({ ok: true, locked: true }));
       return;
     }
@@ -413,16 +441,33 @@ export class VaultBroker {
       // still list (for diagnostics) but a non-cron same-UID caller can't.
       // On non-Linux the socket-file mode 0600 remains the only gate.
       if (process.platform === "linux" && peer === null) {
+        const reason = "Unable to identify caller (peercred unavailable); denying on Linux";
+        this.auditLogger.write({
+          ts: new Date().toISOString(),
+          op: "list",
+          caller: auditCaller,
+          pid: auditPid,
+          cgroup: auditCgroup,
+          result: `denied:${reason}`,
+        });
         socket.write(
           encodeResponse(
             errorResponse(
               "DENIED",
-              "Unable to identify caller (peercred unavailable); denying on Linux",
+              reason,
             ),
           ),
         );
         return;
       }
+      this.auditLogger.write({
+        ts: new Date().toISOString(),
+        op: "list",
+        caller: auditCaller,
+        pid: auditPid,
+        cgroup: auditCgroup,
+        result: "allowed",
+      });
       socket.write(encodeResponse({ ok: true, keys: Object.keys(this.secrets) }));
       return;
     }
@@ -437,6 +482,15 @@ export class VaultBroker {
       if (peer !== null && this.config !== null) {
         const aclResult = checkAcl(peer, this.config, req.key);
         if (!aclResult.allow) {
+          this.auditLogger.write({
+            ts: new Date().toISOString(),
+            op: "get",
+            key: req.key,
+            caller: auditCaller,
+            pid: auditPid,
+            cgroup: auditCgroup,
+            result: `denied:${aclResult.reason}`,
+          });
           socket.write(
             encodeResponse(
               errorResponse("DENIED", aclResult.reason),
@@ -446,11 +500,21 @@ export class VaultBroker {
         }
       } else if (process.platform === "linux" && peer === null) {
         // On Linux, peercred unavailable → fail-closed
+        const reason = "Unable to identify caller (peercred unavailable); denying on Linux";
+        this.auditLogger.write({
+          ts: new Date().toISOString(),
+          op: "get",
+          key: req.key,
+          caller: auditCaller,
+          pid: auditPid,
+          cgroup: auditCgroup,
+          result: `denied:${reason}`,
+        });
         socket.write(
           encodeResponse(
             errorResponse(
               "DENIED",
-              "Unable to identify caller (peercred unavailable); denying on Linux",
+              reason,
             ),
           ),
         );
@@ -460,12 +524,32 @@ export class VaultBroker {
 
       const entry = this.secrets[req.key];
       if (entry === undefined) {
+        // Key not found — still audited (caller was allowed but key doesn't exist)
+        this.auditLogger.write({
+          ts: new Date().toISOString(),
+          op: "get",
+          key: req.key,
+          caller: auditCaller,
+          pid: auditPid,
+          cgroup: auditCgroup,
+          result: "error:UNKNOWN_KEY",
+        });
         socket.write(
           encodeResponse(errorResponse("UNKNOWN_KEY", `Key not found: ${req.key}`)),
         );
         return;
       }
 
+      // Successful get — log only the key name, NEVER the value
+      this.auditLogger.write({
+        ts: new Date().toISOString(),
+        op: "get",
+        key: req.key,
+        caller: auditCaller,
+        pid: auditPid,
+        cgroup: auditCgroup,
+        result: "allowed",
+      });
       socket.write(encodeResponse(entryResponse(entry)));
       return;
     }
@@ -482,16 +566,28 @@ export class VaultBroker {
     // Same UID check for unlock socket. On Linux: verify via peercred,
     // pinned to this connection's fd (issue #129).
     // On other OSes: rely on socket file mode 0600.
+    let unlockPeer: PeerInfo | null = null;
     if (process.platform === "linux") {
-      const peer = this.testOpts._testIdentify
+      unlockPeer = this.testOpts._testIdentify
         ? this.testOpts._testIdentify(this.unlockSocketPath, socket)
         : identify(this.unlockSocketPath, socket);
-      if (peer === null) {
+      if (unlockPeer === null) {
+        this.auditLogger.write({
+          ts: new Date().toISOString(),
+          op: "unlock",
+          caller: `pid:${process.pid}`,
+          pid: process.pid,
+          result: "denied:unable to verify caller identity",
+        });
         socket.write("ERR unable to verify caller identity\n");
         socket.destroy();
         return;
       }
     }
+
+    const auditPid = unlockPeer?.pid ?? process.pid;
+    const auditCaller = unlockPeer !== null ? callerFromPeer(unlockPeer) : `pid:${process.pid}`;
+    const auditCgroup = unlockPeer?.systemdUnit ?? undefined;
 
     let buffer = "";
     socket.on("data", (chunk: Buffer) => {
@@ -513,6 +609,14 @@ export class VaultBroker {
       buffer = "";
 
       if (!passphrase) {
+        this.auditLogger.write({
+          ts: new Date().toISOString(),
+          op: "unlock",
+          caller: auditCaller,
+          pid: auditPid,
+          cgroup: auditCgroup,
+          result: "denied:passphrase cannot be empty",
+        });
         socket.write("ERR passphrase cannot be empty\n");
         socket.destroy();
         return;
@@ -520,9 +624,25 @@ export class VaultBroker {
 
       try {
         this.unlockFromPassphrase(passphrase);
+        this.auditLogger.write({
+          ts: new Date().toISOString(),
+          op: "unlock",
+          caller: auditCaller,
+          pid: auditPid,
+          cgroup: auditCgroup,
+          result: "allowed",
+        });
         socket.write("OK\n");
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
+        this.auditLogger.write({
+          ts: new Date().toISOString(),
+          op: "unlock",
+          caller: auditCaller,
+          pid: auditPid,
+          cgroup: auditCgroup,
+          result: `error:${msg}`,
+        });
         socket.write(`ERR ${msg}\n`);
       } finally {
         socket.destroy();

--- a/src/vault/broker/server.ts
+++ b/src/vault/broker/server.ts
@@ -635,13 +635,25 @@ export class VaultBroker {
         socket.write("OK\n");
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
+        // Audit-log secret-leak guard (#206 review):
+        // openVault() bubbles up errors from the underlying KDF/cipher
+        // library. If that library ever embeds ciphertext bytes, key
+        // material, or passphrase context in its error message, putting
+        // `msg` verbatim into the audit log would defeat the very thing
+        // the log exists to record (who pulled what — never the value).
+        //
+        // Audit gets a constant string. The raw msg still travels to
+        // stderr (operator diagnostics) and to the client (so the user
+        // can see WHY their unlock failed) — those surfaces are not the
+        // append-only public-record audit channel.
+        process.stderr.write(`vault broker: unlock error: ${msg}\n`);
         this.auditLogger.write({
           ts: new Date().toISOString(),
           op: "unlock",
           caller: auditCaller,
           pid: auditPid,
           cgroup: auditCgroup,
-          result: `error:${msg}`,
+          result: "error:decryption failed",
         });
         socket.write(`ERR ${msg}\n`);
       } finally {


### PR DESCRIPTION
## Summary

Closes #206. Part of Phase 1B of the vault security epic (#205). Blocks Phase 2 (#161) — the approval flow needs an audit channel, and this provides it.

- Adds `src/vault/broker/audit-log.ts` — a standalone `createAuditLogger({ path? })` factory that writes one JSON line per audit event. Sync write via `fs.openSync('a', 0o600)` + `fs.writeSync` + `fs.closeSync` for O_APPEND atomicity and crash durability. File mode 0600.
- Wires audit logging into `src/vault/broker/server.ts` for every brokered operation: `get` (allowed, denied, UNKNOWN_KEY), `list` (allowed, denied), `lock` (allowed), `unlock` (allowed, denied, error). `status` is not audited — it has no ACL decision and accesses no secrets.
- Caller identity reuses the existing `peer: PeerInfo` computed at connection accept time — not re-derived. `caller` field is the cgroup unit name when available, else `pid:<n>`.
- **Secret values are never logged.** Only key names and result strings.

## Operations now audited

| Op | Logged result values |
|---|---|
| `get` | `allowed`, `denied:<reason>`, `error:UNKNOWN_KEY` |
| `list` | `allowed`, `denied:<reason>` |
| `lock` | `allowed` |
| `unlock` | `allowed`, `denied:<reason>`, `error:<detail>` |
| `status` | not audited |

## Notes on `set` and `delete`

The broker protocol does not currently implement `set` or `delete` — it is a read-only secret server for cron scripts. The `AuditOp` type includes them for future use when those ops are added to the protocol.

## Test plan

- [ ] `src/vault/broker/audit-log.test.ts` — 13 unit tests: one-line emission for each op, denied result format, no-value-leak, concurrent writes produce valid JSON, 0600 mode, `callerFromPeer` helper, `defaultAuditLogPath` shape
- [ ] `src/vault/broker/server.test.ts` — 10 new audit-emission integration tests: `get`/`list`/`lock` allowed, `get`/`list` denied, `status` emits no line, no-value-leak on denied, sequential multi-op accumulation
- [ ] `bun run test:vitest` — 96 broker tests pass (all pre-existing tests continue to pass)
- [ ] `tsc --noEmit` — typecheck clean (pre-existing errors in `rename-orchestrator.test.ts` are not from this PR)

Co-authored-by: Claude <noreply@anthropic.com>