### PR TITLE
feat(vault): per-key scope field on vault entries (allow/deny ACL)

### DIFF
--- a/src/cli/vault.ts
+++ b/src/cli/vault.ts
@@ -267,6 +267,37 @@ export function registerVaultCommand(program: Command): void {
               .map((s) => s.trim())
               .filter((s) => s.length > 0);
           }
+
+          // #8 review-fix: warn (don't error) on agent names that don't match
+          // any agent in switchroom.yaml. Operator typos like `--allow clerks`
+          // (instead of `clerk`) would otherwise silently lock out the
+          // intended agent — discoverable only by reading the audit log
+          // looking for `denied:scope-allow` with the wrong slug. A warning
+          // here catches the common case at write time.
+          //
+          // Non-fatal: a future agent name that doesn't exist yet is a
+          // legitimate use case (you can scope an entry for an agent you're
+          // about to add). Don't reject; nudge.
+          try {
+            const config = loadConfig();
+            const knownAgents = new Set(Object.keys(config.agents ?? {}));
+            const unknown: string[] = [];
+            for (const name of [...(scope.allow ?? []), ...(scope.deny ?? [])]) {
+              if (!knownAgents.has(name)) unknown.push(name);
+            }
+            if (unknown.length > 0) {
+              console.error(
+                chalk.yellow(
+                  `⚠️  Unknown agent name(s) in scope: ${unknown.join(", ")}. ` +
+                  `Known agents: ${[...knownAgents].sort().join(", ") || "(none)"}. ` +
+                  `Continuing — but verify this isn't a typo.`,
+                ),
+              );
+            }
+          } catch {
+            // loadConfig may fail in test contexts or before setup. Don't
+            // block the secret-set on a config-load problem.
+          }
         }
 
         setStringSecret(passphrase, vaultPath, key, value, formatHint, scope);

--- a/src/cli/vault.ts
+++ b/src/cli/vault.ts
@@ -15,6 +15,7 @@ import {
   VAULT_FORMAT_HINTS,
   VaultError,
   type VaultFormatHint,
+  type VaultEntryScope,
 } from "../vault/vault.js";
 import { registerVaultSweep } from "./vault-sweep.js";
 import {
@@ -175,7 +176,15 @@ export function registerVaultCommand(program: Command): void {
       "--format <kind>",
       `Annotate the stored value with a format hint (${VAULT_FORMAT_HINTS.join(", ")}). The hint is validated against the value at set time and checked against --expect at get time.`
     )
-    .action(async (key: string, opts: { file?: string; format?: string }) => {
+    .option(
+      "--allow <agents>",
+      "Comma-separated list of agent names allowed to read this secret via the broker. When set, only listed agents may access this key. Deny takes precedence over allow."
+    )
+    .option(
+      "--deny <agents>",
+      "Comma-separated list of agent names explicitly denied access to this secret via the broker. Takes precedence over --allow."
+    )
+    .action(async (key: string, opts: { file?: string; format?: string; allow?: string; deny?: string }) => {
       try {
         const parentOpts = program.opts();
         const vaultPath = getVaultPath(parentOpts.config);
@@ -242,9 +251,39 @@ export function registerVaultCommand(program: Command): void {
           }
         }
 
-        setStringSecret(passphrase, vaultPath, key, value, formatHint);
-        if (formatHint) {
+        // Build per-entry scope from --allow / --deny flags.
+        let scope: VaultEntryScope | undefined;
+        if (opts.allow !== undefined || opts.deny !== undefined) {
+          scope = {};
+          if (opts.allow !== undefined) {
+            scope.allow = opts.allow
+              .split(",")
+              .map((s) => s.trim())
+              .filter((s) => s.length > 0);
+          }
+          if (opts.deny !== undefined) {
+            scope.deny = opts.deny
+              .split(",")
+              .map((s) => s.trim())
+              .filter((s) => s.length > 0);
+          }
+        }
+
+        setStringSecret(passphrase, vaultPath, key, value, formatHint, scope);
+        if (formatHint && scope) {
+          const scopeDesc = [
+            scope.allow?.length ? `allow: ${scope.allow.join(", ")}` : "",
+            scope.deny?.length ? `deny: ${scope.deny.join(", ")}` : "",
+          ].filter(Boolean).join("; ");
+          console.log(chalk.green(`✓ Secret '${key}' saved (format: ${formatHint}, scope: ${scopeDesc})`));
+        } else if (formatHint) {
           console.log(chalk.green(`✓ Secret '${key}' saved (format: ${formatHint})`));
+        } else if (scope) {
+          const scopeDesc = [
+            scope.allow?.length ? `allow: ${scope.allow.join(", ")}` : "",
+            scope.deny?.length ? `deny: ${scope.deny.join(", ")}` : "",
+          ].filter(Boolean).join("; ");
+          console.log(chalk.green(`✓ Secret '${key}' saved (scope: ${scopeDesc})`));
         } else {
           console.log(chalk.green(`✓ Secret '${key}' saved`));
         }

--- a/src/vault/broker/acl.ts
+++ b/src/vault/broker/acl.ts
@@ -38,6 +38,7 @@
 
 import type { SwitchroomConfig } from "../../config/schema.js";
 import type { PeerInfo } from "./peercred.js";
+import type { VaultEntryScope } from "../vault.js";
 
 export interface AclAllow {
   allow: true;
@@ -80,6 +81,72 @@ export function parseCronUnit(
   if (!agentName) return null;
 
   return { agentName, index };
+}
+
+/**
+ * Extract the agent slug from a PeerInfo's systemd unit name.
+ *
+ * For a cron unit "switchroom-clerk-cron-0.service", returns "clerk".
+ * Returns null when the peer is not a recognised cron unit (systemdUnit is
+ * null, or the name doesn't parse — same input as parseCronUnit).
+ *
+ * This is the canonical place to go from PeerInfo → agent slug; keep it
+ * pure so tests can call it without starting a broker.
+ */
+export function agentSlugFromPeer(peer: PeerInfo): string | null {
+  if (peer.systemdUnit === null) return null;
+  const parsed = parseCronUnit(peer.systemdUnit);
+  return parsed?.agentName ?? null;
+}
+
+/**
+ * Evaluate a VaultEntry's per-entry scope against the calling agent slug.
+ *
+ * Called AFTER the existing checkAcl() cron-unit ACL passes. Both checks
+ * must pass before a secret is returned.
+ *
+ * Rules (fail-closed):
+ *   - scope undefined/null                → allowed (back-compat, all callers)
+ *   - agentSlug in scope.deny            → denied:scope-deny
+ *   - scope.allow is non-empty AND
+ *     agentSlug NOT in scope.allow       → denied:scope-allow
+ *   - otherwise                          → allowed
+ *
+ * agentSlug may be null when the caller is a cron unit whose name parses
+ * correctly but agentSlugFromPeer returned null for another reason. In that
+ * edge case we treat the entry as scope-restricted and deny if any allow
+ * list is present — fail-closed.
+ */
+export function checkEntryScope(
+  scope: VaultEntryScope | undefined,
+  agentSlug: string | null,
+): AclResult {
+  if (scope === undefined || scope === null) {
+    return { allow: true };
+  }
+
+  const deny = scope.deny ?? [];
+  const allow = scope.allow ?? [];
+
+  if (agentSlug !== null && deny.includes(agentSlug)) {
+    return {
+      allow: false,
+      reason: `agent '${agentSlug}' is in the entry's deny list (scope-deny)`,
+    };
+  }
+
+  if (allow.length > 0) {
+    if (agentSlug === null || !allow.includes(agentSlug)) {
+      return {
+        allow: false,
+        reason: agentSlug === null
+          ? "caller agent slug could not be determined; entry has a non-empty allow list (scope-allow)"
+          : `agent '${agentSlug}' is not in the entry's allow list (scope-allow)`,
+      };
+    }
+  }
+
+  return { allow: true };
 }
 
 /**

--- a/src/vault/broker/protocol.ts
+++ b/src/vault/broker/protocol.ts
@@ -204,7 +204,40 @@ export function errorResponse(code: ErrorCode, msg: string): ErrorResponse {
 
 /**
  * Build a typed entry response object (not framed).
+ *
+ * #8 review-fix: strip the `scope` field before sending. The `scope`
+ * allow/deny lists describe the ENTRY'S TRUST TOPOLOGY (which other
+ * agents are permitted, which are denied). A successful `get` should
+ * deliver the value, not the topology — the recipient gaining knowledge
+ * of who else has access is an information disclosure.
+ *
+ * The Zod `VaultEntrySchema` strips `scope` on the client-side
+ * `decodeResponse` parse, so a typed caller's returned object never
+ * sees it. But the WIRE BYTES still contain it without this strip —
+ * any strace, socket tap, or future debug-log reader would see the
+ * full topology. Strip at the source.
  */
 export function entryResponse(entry: VaultEntry): OkEntryResponse {
-  return { ok: true, entry };
+  const stripped = stripWireFields(entry);
+  return { ok: true, entry: stripped };
+}
+
+/**
+ * Project a VaultEntry to the fields appropriate for the wire response.
+ * Drops `scope` (server-side ACL metadata, not for the recipient) and
+ * preserves the discriminated union over `kind`.
+ */
+function stripWireFields(entry: VaultEntry): VaultEntry {
+  if (entry.kind === "string" || entry.kind === "binary") {
+    return {
+      kind: entry.kind,
+      value: entry.value,
+      ...(entry.format !== undefined ? { format: entry.format } : {}),
+    };
+  }
+  // files
+  return {
+    kind: "files",
+    files: entry.files,
+  };
 }

--- a/src/vault/broker/scope.test.ts
+++ b/src/vault/broker/scope.test.ts
@@ -1,0 +1,509 @@
+/**
+ * Tests for per-entry scope ACL (issue #8).
+ *
+ * Covers:
+ *   - VaultEntryScope schema: round-trips through VaultEntry correctly
+ *   - agentSlugFromPeer: extracts slug from systemd unit name
+ *   - checkEntryScope: pure function behavior for all rule combinations
+ *   - Broker get: scope-allow and scope-deny enforcement via _testIdentify
+ *   - Broker get: no scope = backwards compatible (all callers allowed)
+ *   - Broker list: narrows visible keys by scope
+ *   - Audit log: scope-deny reason recorded correctly
+ */
+
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import * as net from "node:net";
+import * as os from "node:os";
+import * as path from "node:path";
+import * as fs from "node:fs";
+import { VaultBroker } from "./server.js";
+import { checkEntryScope, agentSlugFromPeer } from "./acl.js";
+import { encodeRequest, decodeResponse, type BrokerResponse } from "./protocol.js";
+import { createAuditLogger, type AuditEntry } from "./audit-log.js";
+import type { VaultEntry, VaultEntryScope } from "../vault.js";
+import type { PeerInfo } from "./peercred.js";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+function peer(
+  systemdUnit: string | null,
+  uid = 1000,
+  pid = 1234,
+): PeerInfo {
+  return { uid, pid, exe: "/usr/bin/bash", systemdUnit };
+}
+
+async function rpc(
+  socketPath: string,
+  req: Parameters<typeof encodeRequest>[0],
+): Promise<BrokerResponse> {
+  return new Promise((resolve, reject) => {
+    const client = net.createConnection({ path: socketPath });
+    let buffer = "";
+    client.on("error", reject);
+    client.on("data", (chunk: Buffer) => {
+      buffer += chunk.toString("utf8");
+      const idx = buffer.indexOf("\n");
+      if (idx !== -1) {
+        const line = buffer.slice(0, idx);
+        client.destroy();
+        try {
+          resolve(decodeResponse(line));
+        } catch (e) {
+          reject(e);
+        }
+      }
+    });
+    client.on("connect", () => {
+      client.write(encodeRequest(req));
+    });
+  });
+}
+
+function readAuditLines(logPath: string): AuditEntry[] {
+  try {
+    const raw = fs.readFileSync(logPath, "utf8");
+    return raw
+      .split("\n")
+      .filter((l) => l.trim().length > 0)
+      .map((l) => JSON.parse(l) as AuditEntry);
+  } catch {
+    return [];
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// VaultEntryScope schema — round-trip through JSON (simulates vault storage)
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("VaultEntryScope schema", () => {
+  it("VaultEntry with no scope round-trips cleanly", () => {
+    const entry: VaultEntry = { kind: "string", value: "hello" };
+    const json = JSON.stringify(entry);
+    const restored = JSON.parse(json) as VaultEntry;
+    expect(restored).toEqual({ kind: "string", value: "hello" });
+    expect((restored as { scope?: VaultEntryScope }).scope).toBeUndefined();
+  });
+
+  it("VaultEntry with allow scope round-trips", () => {
+    const entry: VaultEntry = {
+      kind: "string",
+      value: "secret",
+      scope: { allow: ["lawgpt", "clerk"] },
+    };
+    const json = JSON.stringify(entry);
+    const restored = JSON.parse(json) as VaultEntry;
+    expect((restored as { scope?: VaultEntryScope }).scope).toEqual({
+      allow: ["lawgpt", "clerk"],
+    });
+  });
+
+  it("VaultEntry with deny scope round-trips", () => {
+    const entry: VaultEntry = {
+      kind: "string",
+      value: "secret",
+      scope: { deny: ["untrusted-agent"] },
+    };
+    const json = JSON.stringify(entry);
+    const restored = JSON.parse(json) as VaultEntry;
+    expect((restored as { scope?: VaultEntryScope }).scope).toEqual({
+      deny: ["untrusted-agent"],
+    });
+  });
+
+  it("VaultEntry with both allow and deny scope round-trips", () => {
+    const entry: VaultEntry = {
+      kind: "string",
+      value: "secret",
+      scope: { allow: ["clerk"], deny: ["bad-agent"] },
+    };
+    const json = JSON.stringify(entry);
+    const restored = JSON.parse(json) as VaultEntry;
+    expect((restored as { scope?: VaultEntryScope }).scope).toEqual({
+      allow: ["clerk"],
+      deny: ["bad-agent"],
+    });
+  });
+
+  it("binary VaultEntry with scope round-trips", () => {
+    const entry: VaultEntry = {
+      kind: "binary",
+      value: "aGVsbG8=",
+      scope: { allow: ["myagent"] },
+    };
+    const json = JSON.stringify(entry);
+    const restored = JSON.parse(json) as VaultEntry;
+    expect((restored as { scope?: VaultEntryScope }).scope).toEqual({
+      allow: ["myagent"],
+    });
+  });
+
+  it("files VaultEntry with scope round-trips", () => {
+    const entry: VaultEntry = {
+      kind: "files",
+      files: { "key.pem": { encoding: "utf8", value: "PEM_DATA" } },
+      scope: { deny: ["low-trust"] },
+    };
+    const json = JSON.stringify(entry);
+    const restored = JSON.parse(json) as VaultEntry;
+    expect((restored as { scope?: VaultEntryScope }).scope).toEqual({
+      deny: ["low-trust"],
+    });
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// agentSlugFromPeer
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("agentSlugFromPeer", () => {
+  it("returns the agent slug from a valid cron unit", () => {
+    expect(agentSlugFromPeer(peer("switchroom-clerk-cron-0.service"))).toBe("clerk");
+  });
+
+  it("returns the agent slug from a multi-hyphen agent name", () => {
+    expect(agentSlugFromPeer(peer("switchroom-my-cool-agent-cron-2.service"))).toBe("my-cool-agent");
+  });
+
+  it("returns the agent slug from schedule index > 0", () => {
+    expect(agentSlugFromPeer(peer("switchroom-lawgpt-cron-3.service"))).toBe("lawgpt");
+  });
+
+  it("returns null when systemdUnit is null", () => {
+    expect(agentSlugFromPeer(peer(null))).toBeNull();
+  });
+
+  it("returns null for a non-switchroom unit", () => {
+    expect(agentSlugFromPeer(peer("some-other.service"))).toBeNull();
+  });
+
+  it("returns null for a malformed unit name", () => {
+    expect(agentSlugFromPeer(peer("switchroom-myagent-cron-.service"))).toBeNull();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// checkEntryScope — pure function unit tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("checkEntryScope", () => {
+  it("allows when scope is undefined (back-compat — all callers)", () => {
+    const result = checkEntryScope(undefined, "clerk");
+    expect(result.allow).toBe(true);
+  });
+
+  it("allows when scope is empty object (no allow, no deny)", () => {
+    const result = checkEntryScope({}, "clerk");
+    expect(result.allow).toBe(true);
+  });
+
+  it("allows when scope has empty allow and deny arrays", () => {
+    const result = checkEntryScope({ allow: [], deny: [] }, "clerk");
+    expect(result.allow).toBe(true);
+  });
+
+  it("allows when caller is in the allow list", () => {
+    const result = checkEntryScope({ allow: ["clerk", "lawgpt"] }, "clerk");
+    expect(result.allow).toBe(true);
+  });
+
+  it("denies when caller is NOT in the allow list (scope-allow)", () => {
+    const result = checkEntryScope({ allow: ["clerk"] }, "lawgpt");
+    expect(result.allow).toBe(false);
+    if (!result.allow) {
+      expect(result.reason).toContain("lawgpt");
+      expect(result.reason).toContain("scope-allow");
+    }
+  });
+
+  it("denies when caller is in the deny list (scope-deny)", () => {
+    const result = checkEntryScope({ deny: ["bad-agent"] }, "bad-agent");
+    expect(result.allow).toBe(false);
+    if (!result.allow) {
+      expect(result.reason).toContain("bad-agent");
+      expect(result.reason).toContain("scope-deny");
+    }
+  });
+
+  it("deny takes precedence over allow: caller in both lists is denied", () => {
+    const result = checkEntryScope(
+      { allow: ["clerk", "lawgpt"], deny: ["clerk"] },
+      "clerk",
+    );
+    expect(result.allow).toBe(false);
+    if (!result.allow) {
+      expect(result.reason).toContain("scope-deny");
+    }
+  });
+
+  it("allows a caller not in deny list, even when deny list is non-empty", () => {
+    const result = checkEntryScope({ deny: ["bad-agent"] }, "clerk");
+    expect(result.allow).toBe(true);
+  });
+
+  it("denies when agentSlug is null and allow list is non-empty", () => {
+    const result = checkEntryScope({ allow: ["clerk"] }, null);
+    expect(result.allow).toBe(false);
+    if (!result.allow) {
+      expect(result.reason).toContain("scope-allow");
+    }
+  });
+
+  it("allows when agentSlug is null and scope is undefined", () => {
+    const result = checkEntryScope(undefined, null);
+    expect(result.allow).toBe(true);
+  });
+
+  it("allows when agentSlug is null and deny list is non-empty but allow is empty", () => {
+    // deny list: null caller can't be in it so we skip it.
+    // allow list: empty = all callers allowed.
+    const result = checkEntryScope({ deny: ["bad-agent"] }, null);
+    expect(result.allow).toBe(true);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Broker integration tests for scope enforcement
+//
+// Uses _testIdentify + _testAuditLogger to avoid real peercred or audit log.
+// The fake peer is `switchroom-myagent-cron-0.service` → slug "myagent".
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Build a SwitchroomConfig that grants the fake peer access to the given keys. */
+function makeScopeConfig(allowedKeys: string[]) {
+  return {
+    switchroom: { version: 1 },
+    telegram: { bot_token: "test", forum_chat_id: "123" },
+    vault: {
+      path: "~/.switchroom/vault.enc",
+      broker: { socket: "~/.switchroom/vault-broker.sock", enabled: true },
+    },
+    agents: {
+      myagent: { schedule: [{ secrets: allowedKeys }] },
+    },
+  } as any;
+}
+
+describe("VaultBroker scope enforcement via _testIdentify", () => {
+  let tmpDir: string;
+  let socketPath: string;
+  let auditLogPath: string;
+  let prevNonLinuxFlag: string | undefined;
+
+  // Fake peer: switchroom-myagent-cron-0.service → slug "myagent"
+  const FAKE_PEER: PeerInfo = {
+    uid: process.getuid?.() ?? 1000,
+    pid: 77777,
+    exe: "/usr/bin/bash",
+    systemdUnit: "switchroom-myagent-cron-0.service",
+  };
+
+  beforeEach(() => {
+    prevNonLinuxFlag = process.env.SWITCHROOM_BROKER_ALLOW_NON_LINUX;
+    process.env.SWITCHROOM_BROKER_ALLOW_NON_LINUX = "1";
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "broker-scope-test-"));
+    socketPath = path.join(tmpDir, "test.sock");
+    auditLogPath = path.join(tmpDir, "vault-audit.log");
+  });
+
+  afterEach(() => {
+    try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch { /* ignore */ }
+    if (prevNonLinuxFlag === undefined) {
+      delete process.env.SWITCHROOM_BROKER_ALLOW_NON_LINUX;
+    } else {
+      process.env.SWITCHROOM_BROKER_ALLOW_NON_LINUX = prevNonLinuxFlag;
+    }
+  });
+
+  async function startBroker(
+    secrets: Record<string, VaultEntry>,
+  ): Promise<VaultBroker> {
+    const allKeys = Object.keys(secrets);
+    const broker = new VaultBroker({
+      _testSecrets: JSON.parse(JSON.stringify(secrets)),
+      _testConfig: makeScopeConfig(allKeys),
+      _testIdentify: () => FAKE_PEER,
+      _testAuditLogger: createAuditLogger({ path: auditLogPath }),
+    });
+    await broker.start(socketPath, undefined, undefined);
+    return broker;
+  }
+
+  // ── get: no scope → back-compat (allowed) ─────────────────────────────
+
+  it("get: entry without scope is accessible to all callers (back-compat)", async () => {
+    const secrets: Record<string, VaultEntry> = {
+      "unscoped-key": { kind: "string", value: "open-value" },
+    };
+    const broker = await startBroker(secrets);
+    try {
+      const resp = await rpc(socketPath, { v: 1, op: "get", key: "unscoped-key" });
+      expect(resp.ok).toBe(true);
+      if (resp.ok && "entry" in resp) {
+        expect((resp.entry as { value: string }).value).toBe("open-value");
+      }
+    } finally {
+      broker.stop();
+    }
+  });
+
+  // ── get: caller in allow list → allowed ───────────────────────────────
+
+  it("get: caller in allow list is allowed", async () => {
+    const secrets: Record<string, VaultEntry> = {
+      "scoped-key": {
+        kind: "string",
+        value: "restricted-value",
+        scope: { allow: ["myagent", "clerk"] },
+      },
+    };
+    const broker = await startBroker(secrets);
+    try {
+      const resp = await rpc(socketPath, { v: 1, op: "get", key: "scoped-key" });
+      expect(resp.ok).toBe(true);
+    } finally {
+      broker.stop();
+    }
+  });
+
+  // ── get: caller NOT in allow list → denied (scope-allow) ─────────────
+
+  it("get: caller not in allow list is denied (scope-allow)", async () => {
+    const secrets: Record<string, VaultEntry> = {
+      "clerk-only": {
+        kind: "string",
+        value: "clerk-secret",
+        scope: { allow: ["clerk"] },
+      },
+    };
+    const broker = await startBroker(secrets);
+    try {
+      // fake peer is "myagent" — not in allow list
+      const resp = await rpc(socketPath, { v: 1, op: "get", key: "clerk-only" });
+      expect(resp.ok).toBe(false);
+      if (!resp.ok) {
+        expect(resp.code).toBe("DENIED");
+        expect(resp.msg).toContain("scope-allow");
+      }
+    } finally {
+      broker.stop();
+    }
+  });
+
+  // ── get: caller in deny list → denied (scope-deny) ────────────────────
+
+  it("get: caller in deny list is denied even if also in allow (scope-deny precedence)", async () => {
+    const secrets: Record<string, VaultEntry> = {
+      "paranoid-key": {
+        kind: "string",
+        value: "super-secret",
+        scope: { allow: ["myagent", "clerk"], deny: ["myagent"] },
+      },
+    };
+    const broker = await startBroker(secrets);
+    try {
+      // myagent is both in allow and deny → deny wins
+      const resp = await rpc(socketPath, { v: 1, op: "get", key: "paranoid-key" });
+      expect(resp.ok).toBe(false);
+      if (!resp.ok) {
+        expect(resp.code).toBe("DENIED");
+        expect(resp.msg).toContain("scope-deny");
+      }
+    } finally {
+      broker.stop();
+    }
+  });
+
+  // ── list: only scope-accessible keys are returned ─────────────────────
+
+  it("list: returns only keys accessible to the calling agent", async () => {
+    const secrets: Record<string, VaultEntry> = {
+      "shared-key": { kind: "string", value: "shared" },
+      "myagent-key": {
+        kind: "string",
+        value: "for-myagent",
+        scope: { allow: ["myagent"] },
+      },
+      "clerk-only-key": {
+        kind: "string",
+        value: "for-clerk",
+        scope: { allow: ["clerk"] },
+      },
+      "denied-key": {
+        kind: "string",
+        value: "not-for-myagent",
+        scope: { deny: ["myagent"] },
+      },
+    };
+    const broker = await startBroker(secrets);
+    try {
+      const resp = await rpc(socketPath, { v: 1, op: "list" });
+      expect(resp.ok).toBe(true);
+      if (resp.ok && "keys" in resp) {
+        const keys = resp.keys.sort();
+        // shared-key (no scope) + myagent-key (allow includes myagent) are visible.
+        // clerk-only-key (allow=["clerk"], myagent not in it) is hidden.
+        // denied-key (deny=["myagent"]) is hidden.
+        expect(keys).toContain("shared-key");
+        expect(keys).toContain("myagent-key");
+        expect(keys).not.toContain("clerk-only-key");
+        expect(keys).not.toContain("denied-key");
+      }
+    } finally {
+      broker.stop();
+    }
+  });
+
+  // ── audit log: scope-deny reason recorded ─────────────────────────────
+
+  it("audit log records scope-deny reason on denied get", async () => {
+    const secrets: Record<string, VaultEntry> = {
+      "audit-test-key": {
+        kind: "string",
+        value: "audit-secret",
+        scope: { deny: ["myagent"] },
+      },
+    };
+    const broker = await startBroker(secrets);
+    try {
+      await rpc(socketPath, { v: 1, op: "get", key: "audit-test-key" });
+      const lines = readAuditLines(auditLogPath);
+      expect(lines).toHaveLength(1);
+      const entry = lines[0];
+      expect(entry.op).toBe("get");
+      expect(entry.key).toBe("audit-test-key");
+      expect(entry.result).toMatch(/^denied:/);
+      expect(entry.result).toContain("scope-deny");
+      // Secret value must not appear in the audit log
+      const rawLog = fs.readFileSync(auditLogPath, "utf8");
+      expect(rawLog).not.toContain("audit-secret");
+    } finally {
+      broker.stop();
+    }
+  });
+
+  it("audit log records scope-allow reason on denied get", async () => {
+    const secrets: Record<string, VaultEntry> = {
+      "allow-test-key": {
+        kind: "string",
+        value: "restricted-value",
+        scope: { allow: ["clerk"] }, // myagent not in list
+      },
+    };
+    const broker = await startBroker(secrets);
+    try {
+      await rpc(socketPath, { v: 1, op: "get", key: "allow-test-key" });
+      const lines = readAuditLines(auditLogPath);
+      expect(lines).toHaveLength(1);
+      const entry = lines[0];
+      expect(entry.result).toMatch(/^denied:/);
+      expect(entry.result).toContain("scope-allow");
+      const rawLog = fs.readFileSync(auditLogPath, "utf8");
+      expect(rawLog).not.toContain("restricted-value");
+    } finally {
+      broker.stop();
+    }
+  });
+});

--- a/src/vault/broker/server.ts
+++ b/src/vault/broker/server.ts
@@ -31,7 +31,7 @@ import type { SwitchroomConfig } from "../../config/schema.js";
 import { openVault, type VaultEntry } from "../vault.js";
 import { resolvePath } from "../../config/loader.js";
 import { identify, type PeerInfo } from "./peercred.js";
-import { checkAcl } from "./acl.js";
+import { checkAcl, checkEntryScope, agentSlugFromPeer } from "./acl.js";
 import {
   decodeRequest,
   encodeResponse,
@@ -461,24 +461,41 @@ export class VaultBroker {
         return;
       }
 
-      // Issue #207: apply ACL scope filter to `list` so crons see only the
-      // keys they are allowed to read. An identified peer (cron unit) has a
-      // per-schedule allowlist in config; we iterate every key and include
-      // it only when checkAcl() says allow. Interactive sessions (peer===null
-      // on non-Linux, or no config) continue to see all keys — their only
-      // gate is the socket file mode 0600.
+      // Two gates apply to `list`, BOTH must pass for a key to be visible:
+      //   1. Per-key ACL (#207): the caller's cron unit must be allowed to
+      //      read the key under its `schedule.secrets` allowlist.
+      //   2. Per-entry scope (#8): the entry's allow/deny lists must permit
+      //      the caller's agent slug.
+      //
+      // Reviewer-flagged bypass for #8: this PR's worker REPLACED gate 1
+      // with gate 2 (rather than adding gate 2 ON TOP of gate 1). That
+      // allowed an agent without an ACL claim on key X to still enumerate
+      // X's name as long as X had no scope set. Now both gates fire.
+      //
+      // Interactive sessions (peer===null on non-Linux, or no config) skip
+      // gate 1 (no identity to gate on) but still apply gate 2 with a null
+      // slug — a deny list with literal-null entries would still take
+      // effect; an allow list of named agents would block (null is not in
+      // any named list). The socket file mode 0600 is the outer gate for
+      // that case.
+      const listAgentSlug = peer !== null ? agentSlugFromPeer(peer) : null;
       let visibleKeys: string[];
       if (peer !== null && this.config !== null) {
-        visibleKeys = Object.keys(this.secrets).filter(
-          (key) => checkAcl(peer, this.config!, key).allow,
-        );
+        visibleKeys = Object.entries(this.secrets)
+          .filter(
+            ([key, entry]) =>
+              checkAcl(peer, this.config!, key).allow &&
+              checkEntryScope(entry.scope, listAgentSlug).allow,
+          )
+          .map(([k]) => k);
       } else {
-        // Non-Linux (no peercred) or no config: full list as before.
-        visibleKeys = Object.keys(this.secrets);
+        visibleKeys = Object.entries(this.secrets)
+          .filter(([, entry]) => checkEntryScope(entry.scope, listAgentSlug).allow)
+          .map(([k]) => k);
       }
 
-      // Audit the visible key count. A bare "allowed" hides the case where
-      // an identified cron unit's ACL filter narrows to zero keys — almost
+      // Audit the visible key count (#207). A bare "allowed" hides the case
+      // where an identified cron unit's filter narrows to zero keys — almost
       // certainly a misconfiguration, but invisible in the log without the
       // count. `allowed:N` lets an operator grep for `result: "allowed:0"`.
       this.auditLogger.write({
@@ -557,6 +574,27 @@ export class VaultBroker {
         });
         socket.write(
           encodeResponse(errorResponse("UNKNOWN_KEY", `Key not found: ${req.key}`)),
+        );
+        return;
+      }
+
+      // Per-entry scope check (issue #8) — runs AFTER cron-unit ACL passes.
+      const getAgentSlug = peer !== null ? agentSlugFromPeer(peer) : null;
+      const scopeResult = checkEntryScope(entry.scope, getAgentSlug);
+      if (!scopeResult.allow) {
+        this.auditLogger.write({
+          ts: new Date().toISOString(),
+          op: "get",
+          key: req.key,
+          caller: auditCaller,
+          pid: auditPid,
+          cgroup: auditCgroup,
+          result: `denied:${scopeResult.reason}`,
+        });
+        socket.write(
+          encodeResponse(
+            errorResponse("DENIED", scopeResult.reason),
+          ),
         );
         return;
       }

--- a/src/vault/vault.ts
+++ b/src/vault/vault.ts
@@ -71,12 +71,33 @@ export const VAULT_FORMAT_HINTS: VaultFormatHint[] = [
   "string",
 ];
 
+/**
+ * Per-entry agent scope ACL (issue #8).
+ *
+ * Controls which agents may read this vault entry via the broker.
+ * Evaluated AFTER the existing cron-unit ACL (checkAcl) passes.
+ *
+ * Semantics:
+ *   - Neither allow nor deny set  → all agents may read (current behaviour)
+ *   - allow set (non-empty)       → only listed agents may read
+ *   - deny set (non-empty)        → listed agents are blocked (checked first)
+ *   - deny takes precedence over allow: an agent in both lists is denied
+ *
+ * Agent names are the slug portion of the systemd unit, e.g. "clerk" from
+ * "switchroom-clerk-cron-0.service".
+ */
+export interface VaultEntryScope {
+  allow?: string[];
+  deny?: string[];
+}
+
 export type VaultEntry =
-  | { kind: "string"; value: string; format?: VaultFormatHint }
-  | { kind: "binary"; value: string; format?: VaultFormatHint }
+  | { kind: "string"; value: string; format?: VaultFormatHint; scope?: VaultEntryScope }
+  | { kind: "binary"; value: string; format?: VaultFormatHint; scope?: VaultEntryScope }
   | {
       kind: "files";
       files: Record<string, { encoding: "utf8" | "base64"; value: string }>;
+      scope?: VaultEntryScope;
     };
 
 interface VaultFile {
@@ -355,10 +376,14 @@ export function setStringSecret(
   key: string,
   value: string,
   format?: VaultFormatHint,
+  scope?: VaultEntryScope,
 ): void {
   const entry: VaultEntry = format
     ? { kind: "string", value, format }
     : { kind: "string", value };
+  if (scope !== undefined) {
+    (entry as { kind: "string"; value: string; format?: VaultFormatHint; scope?: VaultEntryScope }).scope = scope;
+  }
   setSecret(passphrase, vaultPath, key, entry);
 }
 


### PR DESCRIPTION
## Summary

Implements per-entry agent scope ACL on vault entries (Phase 1A of #205, blocks Phase 2 #161).

- **Schema**: `VaultEntry` gains an optional `scope?: { allow?: string[]; deny?: string[] }` field across all entry kinds (`string`, `binary`, `files`). Entries without scope continue to work for all callers — zero regression.
- **CLI**: `switchroom vault set` now accepts `--allow <agents>` and `--deny <agents>` flags (comma-separated agent slugs). Persisted into `VaultEntry.scope`.
- **Broker enforcement**: After the existing cron-unit ACL (`checkAcl`) passes, `get` and `list` both evaluate the entry's per-entry scope. Deny takes precedence over allow. Audit log records the `scope-deny` / `scope-allow` reason on denial.
- **Helpers**: `agentSlugFromPeer(peer): string | null` and `checkEntryScope(scope, agentSlug): AclResult` added as pure functions in `acl.ts` — independently testable.

Closes #8. Phase 1A of #205; blocks Phase 2 (#161).

## Commits

1. `feat(vault,#8)` — schema change: `VaultEntryScope` interface + `scope` on all `VaultEntry` variants
2. `feat(cli,#8)` — `vault set --allow / --deny` flags
3. `feat(broker,#8)` — per-entry scope enforced in broker `get` + `list`
4. `test(#8)` — 30 new tests: schema round-trips, pure function coverage, broker integration, audit log

## Test plan

- [x] `bun run test:vitest -- src/vault/broker/` — 127 tests pass (0 regressions)
- [x] `bun run test:vitest -- src/vault/broker/scope.test.ts` — 30 new tests pass
- [x] `node_modules/.bin/tsc --noEmit` — no new type errors (pre-existing rename-orchestrator errors untouched)
- [ ] Manual: `switchroom vault set mykey --allow clerk,lawgpt` then inspect vault shows scope
- [ ] Manual: `switchroom vault set mykey --deny low-trust` and confirm broker denies from that agent

Co-authored-by: Claude <noreply@anthropic.com>