### PR TITLE
feat(web): add --bind flag for LAN/Tailscale dashboard access

### DIFF
--- a/src/cli/web.ts
+++ b/src/cli/web.ts
@@ -9,31 +9,50 @@ export function registerWebCommand(program: Command): void {
     .command("web")
     .description("Start the web dashboard for monitoring agents")
     .option("-p, --port <port>", "Port to listen on", "8080")
+    .option("-b, --bind <host>", "Host/IP to bind to (default: 127.0.0.1, localhost-only)", "127.0.0.1")
     .action(
       withConfigError(async (opts) => {
         const config = getConfig(program);
         const port = parseInt(opts.port, 10);
+        const hostname = opts.bind as string;
 
         if (isNaN(port) || port < 1 || port > 65535) {
           console.error(chalk.red("Invalid port number"));
           process.exit(1);
         }
 
+        const isLanBind = hostname !== "127.0.0.1" && hostname !== "localhost" && hostname !== "::1";
+
         console.log(chalk.bold("\nStarting Switchroom dashboard...\n"));
         console.log(chalk.gray(`  Agents: ${Object.keys(config.agents).join(", ")}`));
-        console.log(chalk.gray(`  Port:   ${port}\n`));
+        console.log(chalk.gray(`  Port:   ${port}`));
+        if (isLanBind) {
+          console.log(chalk.gray(`  Bind:   ${hostname} (network-accessible)\n`));
+        } else {
+          console.log();
+        }
 
-        const { token } = startWebServer(config, port);
+        const { token } = startWebServer(config, port, hostname);
 
         void captureEvent("web_server_started", {
           port,
+          hostname,
           agent_count: Object.keys(config.agents).length,
           auth_configured: Boolean(process.env.SWITCHROOM_WEB_TOKEN),
         });
 
+        const displayHost = hostname === "0.0.0.0" ? "<host-ip>" : hostname;
         console.log(
-          chalk.green(`\n  Dashboard: http://localhost:${port}\n`)
+          chalk.green(`\n  Dashboard: http://${displayHost}:${port}\n`)
         );
+        if (isLanBind) {
+          console.log(
+            chalk.yellow(
+              "  Network-accessible bind — reachable from LAN/Tailscale.\n" +
+                "  The token below is required for all requests.\n"
+            )
+          );
+        }
         console.log(chalk.gray(`  Token: ${token}`));
         console.log(
           chalk.gray(

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -109,8 +109,21 @@ function resolveWebToken(): string {
  * on any ambient credentials a browser might attach. We accept requests
  * with NO Origin header (CLI / curl / same-origin) but block any Origin
  * that isn't http[s]://localhost[:port] or http[s]://127.0.0.1[:port].
+ *
+ * When the server is bound to a non-loopback address (e.g. 0.0.0.0 or a
+ * Tailscale IP) the user has explicitly opted in to network exposure. In that
+ * case the original CSRF concern — a malicious website reaching localhost —
+ * doesn't apply: the attacker would need to know the target IP and defeat
+ * same-origin browser protections for a remote host. The randomly-generated
+ * bearer token is the security boundary; origin filtering is skipped.
+ *
+ * Exported for unit-testing; not part of the public API.
  */
-function isOriginAllowed(req: Request, port: number): boolean {
+export function isOriginAllowed(req: Request, port: number, localhostOnly: boolean): boolean {
+  if (!localhostOnly) {
+    // Non-loopback bind: token is the sole auth boundary; skip origin check.
+    return true;
+  }
   const origin = req.headers.get("Origin");
   if (!origin) return true;
   const allowed = [
@@ -189,24 +202,34 @@ function parseRoute(
   return null;
 }
 
-export function startWebServer(config: SwitchroomConfig, port: number): { token: string } {
+export function startWebServer(
+  config: SwitchroomConfig,
+  port: number,
+  hostname = "127.0.0.1",
+): { token: string } {
   const uiDirRaw = resolve(import.meta.dirname, "ui");
   // Resolve symlinks once at startup so the traversal check compares real paths.
   const uiDir = existsSync(uiDirRaw) ? realpathSync(uiDirRaw) : uiDirRaw;
   const token = resolveWebToken();
 
+  // Loopback-only when binding to a localhost address; any other bind address
+  // (including 0.0.0.0) is considered a deliberate network-exposure opt-in.
+  const localhostOnly =
+    hostname === "127.0.0.1" || hostname === "localhost" || hostname === "::1";
+
   const server = Bun.serve({
     port,
-    hostname: "127.0.0.1",
+    hostname,
     fetch(req, server) {
       const url = new URL(req.url);
       const { pathname } = url;
 
       // Cross-origin requests from any page the user happens to load in a
-      // browser must not reach the privileged API. Reject anything whose
-      // Origin isn't our own loopback. Requests with no Origin (CLI, curl,
-      // same-origin fetches) are still allowed.
-      if (!isOriginAllowed(req, port)) {
+      // browser must not reach the privileged API. When bound to loopback,
+      // reject any Origin that isn't our own loopback address. When bound to
+      // a non-loopback address the user has opted in to network exposure and
+      // the bearer token is the sole security boundary (see isOriginAllowed).
+      if (!isOriginAllowed(req, port, localhostOnly)) {
         return new Response("Forbidden", { status: 403 });
       }
 
@@ -384,6 +407,10 @@ export function startWebServer(config: SwitchroomConfig, port: number): { token:
     },
   });
 
-  console.log(`Switchroom dashboard running at http://localhost:${server.port}`);
+  const displayHost = hostname === "0.0.0.0" ? "<host-ip>" : hostname;
+  console.log(`Switchroom dashboard running at http://${displayHost}:${server.port}`);
+  if (!localhostOnly) {
+    console.log("  Network-accessible — token required for all requests.");
+  }
   return { token };
 }

--- a/tests/web.test.ts
+++ b/tests/web.test.ts
@@ -33,6 +33,7 @@ import {
   handleGetLogs,
   type AgentInfo,
 } from "../src/web/api.js";
+import { isOriginAllowed } from "../src/web/server.js";
 import { getAllAgentStatuses, startAgent, stopAgent, restartAgent } from "../src/agents/lifecycle.js";
 import { getAllAuthStatuses } from "../src/auth/manager.js";
 import { execFileSync } from "node:child_process";
@@ -235,5 +236,64 @@ describe("handleGetLogs", () => {
     const result = handleGetLogs("missing", 10);
     expect(result.ok).toBe(false);
     expect(result.error).toContain("no journal data");
+  });
+});
+
+// Helper to build a minimal Request with an optional Origin header.
+function makeRequest(origin?: string): Request {
+  const headers: Record<string, string> = {};
+  if (origin !== undefined) headers["Origin"] = origin;
+  return new Request("http://127.0.0.1:8080/api/agents", { headers });
+}
+
+describe("isOriginAllowed — localhost-only bind (default)", () => {
+  const port = 8080;
+  const localhostOnly = true;
+
+  it("allows requests with no Origin header (CLI / curl)", () => {
+    expect(isOriginAllowed(makeRequest(), port, localhostOnly)).toBe(true);
+  });
+
+  it("allows same-origin requests from localhost", () => {
+    expect(isOriginAllowed(makeRequest(`http://localhost:${port}`), port, localhostOnly)).toBe(true);
+  });
+
+  it("allows same-origin requests from 127.0.0.1", () => {
+    expect(isOriginAllowed(makeRequest(`http://127.0.0.1:${port}`), port, localhostOnly)).toBe(true);
+  });
+
+  it("rejects a cross-origin request from a remote host", () => {
+    expect(isOriginAllowed(makeRequest("http://evil.example.com"), port, localhostOnly)).toBe(false);
+  });
+
+  it("rejects a cross-origin request from a LAN IP", () => {
+    expect(isOriginAllowed(makeRequest("http://192.168.1.100:8080"), port, localhostOnly)).toBe(false);
+  });
+
+  it("rejects when port in Origin doesn't match server port", () => {
+    expect(isOriginAllowed(makeRequest("http://localhost:9999"), port, localhostOnly)).toBe(false);
+  });
+});
+
+describe("isOriginAllowed — network bind (--bind 0.0.0.0 or Tailscale IP)", () => {
+  const port = 8080;
+  const localhostOnly = false;
+
+  it("allows requests with no Origin header", () => {
+    expect(isOriginAllowed(makeRequest(), port, localhostOnly)).toBe(true);
+  });
+
+  it("allows a request from a LAN origin with a valid token (origin check skipped)", () => {
+    // When bound to 0.0.0.0 / non-loopback, the origin check is bypassed.
+    // The bearer token is the sole auth boundary — tested by checkAuth in the server.
+    expect(isOriginAllowed(makeRequest("http://192.168.1.100:8080"), port, localhostOnly)).toBe(true);
+  });
+
+  it("allows a request from a Tailscale origin (origin check skipped)", () => {
+    expect(isOriginAllowed(makeRequest("http://100.64.0.1:8080"), port, localhostOnly)).toBe(true);
+  });
+
+  it("allows even a remote-looking origin (token is the boundary)", () => {
+    expect(isOriginAllowed(makeRequest("http://remote.example.com"), port, localhostOnly)).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

- Adds `-b, --bind <host>` option to `switchroom web` (default: `127.0.0.1`). No flag = no behaviour change.
- When bound to a non-loopback address (e.g. `0.0.0.0` or a Tailscale IP), the per-request Origin allowlist is bypassed. The randomly-generated bearer token — already constant-time checked on every request — becomes the sole security boundary. This is safe because the original CSRF concern (a malicious website reaching `localhost`) doesn't apply when the user has deliberately opted in to network exposure via `--bind`.
- Startup log and console output reflect the actual bind address; `0.0.0.0` prints `<host-ip>:<port>` with a note that the token is required.

## Trust model note

Localhost-only bind (default): strict origin check preserved (CSRF defence). Non-loopback bind: origin check skipped, bearer token is the sole boundary. The rationale is documented in a comment on `isOriginAllowed` in `src/web/server.ts`.

## Test plan

- `isOriginAllowed` exported for unit testing (no public API impact).
- New test suite `isOriginAllowed — localhost-only bind`: cross-origin requests from remote/LAN IPs are rejected; no-Origin and same-origin requests are allowed.
- New test suite `isOriginAllowed — network bind`: all origins permitted when `localhostOnly` is false, confirming the opt-in trust model.
- Full vitest run: no regressions (10 new tests passing, pre-existing failures unchanged).
- `bun run build` succeeds.
- PII grep gate: `/home/` count in `dist/cli/switchroom.js` unchanged vs main.

## Usage

```
# Expose on all interfaces (LAN + Tailscale)
switchroom web --bind 0.0.0.0

# Expose on a specific Tailscale IP
switchroom web --bind 100.64.0.1

# Default (unchanged) — localhost only
switchroom web
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)