### PR TITLE
vault(#209): docs + vault doctor + vault audit CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,6 +374,7 @@ Overlay entries win on collision with built-in defaults. Unknown files that appe
 | Guide | Description |
 |-------|-------------|
 | **[Configuration](docs/configuration.md)** | Full field reference, cascade semantics, profiles |
+| **[Vault](docs/vault.md)** | Architecture, per-cron secrets, ACL, audit log, threat model |
 | **[Telegram Plugin](docs/telegram-plugin.md)** | Progress cards, 10 MCP tools, emoji reactions |
 | **[Sub-Agents](docs/sub-agents.md)** | Model routing, delegation patterns, frontmatter spec |
 | **[Scheduling](docs/scheduling.md)** | Cron tasks, systemd timers, model selection |

--- a/docs/vault.md
+++ b/docs/vault.md
@@ -1,0 +1,239 @@
+# Vault — Operator Guide
+
+Switchroom's vault is an AES-256-GCM encrypted file (`vault.enc`) that stores
+secrets used by agents and scheduled cron tasks.  This guide covers the
+architecture, how to declare and scope secrets, Telegram commands for runtime
+management, the audit log, and the threat model.
+
+---
+
+## Architecture
+
+```
+vault.enc (AES-256-GCM, passphrase-derived)
+    │
+    └── vault broker daemon  (Unix socket: ~/.switchroom/vault-broker.sock)
+            │  mode 0600 — only the owner UID may connect
+            │  identity via peercred + cgroup — not spoofable from userspace
+            │
+            ├── switchroom-<agent>-cron-0.service   (allowed, if key in secrets[])
+            ├── switchroom-<agent>-cron-1.service   (allowed, if key in secrets[])
+            └── (all other callers)                 → DENIED
+```
+
+The broker is a long-running user-level systemd unit
+(`~/.config/systemd/user/switchroom-vault-broker.service`).  It holds the
+decrypted vault in memory after a one-time passphrase unlock.  When a cron
+unit makes a `get` request the broker:
+
+1. Identifies the caller via Linux cgroup membership (cgroups are written by
+   systemd as root — processes cannot move themselves between cgroups).
+2. Checks the per-schedule `secrets[]` allowlist.
+3. Checks the per-key scope ACL (if set via `--allow` / `--deny`).
+4. Returns the value or denies with a logged reason.
+
+Interactive calls (`switchroom vault get`) go directly to the vault file with
+the user's passphrase — the broker is for cron-only access.
+
+---
+
+## Commands
+
+### Initialise and populate the vault
+
+```sh
+switchroom vault init                          # create vault.enc (prompts for passphrase)
+switchroom vault set <key>                     # set a secret interactively
+switchroom vault set <key> --file /path/to     # read value from file (PEM, JSON, etc.)
+switchroom vault get <key>                     # decrypt and print (direct, not via broker)
+switchroom vault list                          # list key names (never values)
+switchroom vault remove <key>                  # delete a key
+```
+
+### Broker lifecycle
+
+```sh
+switchroom vault broker unlock                 # push passphrase to broker, start serving
+switchroom vault broker lock                   # wipe in-memory vault, stop serving
+switchroom vault broker status                 # print JSON status (locked/unlocked, uptime)
+switchroom vault broker enable-auto-unlock     # store passphrase in system credential store
+```
+
+---
+
+## Declaring per-cron secrets
+
+Cron tasks declare the vault keys they need in `switchroom.yaml` under
+`schedule[i].secrets`.  Only listed keys are accessible to that specific cron
+task — the broker denies any request for an unlisted key.
+
+```yaml
+agents:
+  my-agent:
+    schedule:
+      - cron: "0 8 * * *"
+        prompt: "Run the morning report"
+        secrets:
+          - reports/api-key           # only this key is accessible to cron task 0
+
+      - cron: "0 20 * * *"
+        prompt: "Send the evening digest"
+        secrets:
+          - digest/smtp-password      # cron task 1 can only read this key
+          - digest/sender-address
+```
+
+The cron script reads the secret via the broker:
+
+```sh
+API_KEY=$(switchroom vault get reports/api-key)
+```
+
+`secrets: []` (the default) means the cron has no vault access at all.  Any
+broker request from that cron task is denied.
+
+---
+
+## Per-key access control (ACL)
+
+Beyond the per-cron `secrets[]` allowlist you can apply an additional per-key
+scope to restrict which agents may read a key.  Set it when storing the secret:
+
+```sh
+# Only the 'reports' agent may read this key
+switchroom vault set stripe/live-key --allow reports
+
+# Everyone except the 'experiment' agent
+switchroom vault set openai/api-key --deny experiment
+
+# Combine: allow exactly two agents, deny is checked first
+switchroom vault set infra/deploy-token --allow deploy --allow infra --deny sandbox
+```
+
+ACL rules (evaluated in order, fail-closed):
+
+1. The caller must be a recognised switchroom cron unit.
+2. If the key's `deny` list contains the caller's agent slug → **denied**.
+3. If the key's `allow` list is non-empty and the caller is not in it → **denied**.
+4. Otherwise → **allowed** (and only if the key also appears in the cron's `secrets[]`).
+
+Both checks must pass.  The `secrets[]` allowlist is evaluated by the broker
+before the per-key scope is consulted.
+
+---
+
+## Telegram `/vault` commands
+
+Agents with the switchroom Telegram plugin expose these commands at runtime:
+
+| Command | Description |
+|---|---|
+| `/vault status` | Show whether the broker is running and unlocked |
+| `/vault unlock` | Prompt for the passphrase and push it to the broker |
+| `/vault lock` | Wipe the in-memory vault (broker continues running, locked) |
+| `/vault list` | List vault key names (never values) |
+| `/vault get <key>` | Retrieve a key directly from the vault file (interactive only) |
+| `/vault set <key>` | Set or update a key interactively |
+| `/vault delete <key>` | Remove a key from the vault |
+
+These commands run as the user who owns the agent process.  The broker's
+peercred ACL does not apply to interactive Telegram commands — they talk
+directly to the vault file with the user's passphrase, the same way
+`switchroom vault get --no-broker` does.
+
+---
+
+## Audit log
+
+Every broker request — successful or denied — is appended to:
+
+```
+~/.switchroom/vault-audit.log
+```
+
+The file is mode `0600` (user-only).  Each line is a JSON object:
+
+```json
+{
+  "ts": "2026-04-28T14:33:00.123Z",
+  "op": "get",
+  "key": "stripe/live-key",
+  "caller": "switchroom-my-agent-cron-0.service",
+  "pid": 12345,
+  "cgroup": "switchroom-my-agent-cron-0.service",
+  "result": "allowed"
+}
+```
+
+Fields:
+
+| Field | Type | Description |
+|---|---|---|
+| `ts` | ISO-8601 | Timestamp of the request |
+| `op` | string | Operation: `get`, `set`, `delete`, `list`, `unlock`, `lock` |
+| `key` | string? | Vault key name — **never the secret value** |
+| `caller` | string | Cgroup unit name, or `pid:<n>` if unavailable |
+| `pid` | number | PID of the calling process |
+| `cgroup` | string? | Raw cgroup unit name if resolved |
+| `result` | string | `"allowed"`, `"denied:<reason>"`, or `"error:<detail>"` |
+
+### Grep examples
+
+```sh
+# All denied requests
+grep '"result":"denied' ~/.switchroom/vault-audit.log
+
+# All requests for a specific key
+grep '"key":"stripe/live-key"' ~/.switchroom/vault-audit.log
+
+# Requests from a specific cron unit
+grep '"caller":"switchroom-my-agent-cron-0.service"' ~/.switchroom/vault-audit.log
+
+# Use switchroom vault audit for formatted output
+switchroom vault audit --denied
+switchroom vault audit --key stripe/live-key
+switchroom vault audit --who my-agent-cron-0
+```
+
+---
+
+## Threat model
+
+### What the ACL protects against
+
+- **Misconfiguration**: a typo in one cron's `secrets[]` does not grant it
+  access to another cron's keys.  Each cron task only sees keys explicitly
+  listed for it.
+- **Hijacked agent on this UID**: a compromised agent Claude session cannot
+  read vault keys via the broker — the broker only serves systemd cron units,
+  not interactive Claude processes.  The cgroup identity is set by systemd as
+  root and cannot be spoofed from userspace.
+- **Per-key scoping**: `--allow` / `--deny` narrows access further, so even a
+  legitimate cron unit cannot read keys it is not explicitly permitted to read.
+
+### What the ACL does not protect against
+
+- **Root compromise**: a process running as root can impersonate any cgroup or
+  read the vault file directly.
+- **Host-level compromise**: kernel-level access, full-disk access, or access
+  to the user's home directory bypasses all vault protections.
+- **Multi-tenant**: Switchroom is a single-user system.  Multiple users on the
+  same host each have separate vault files and broker sockets, but there is no
+  isolation between processes running as the same UID.
+- **Config edits**: anyone who can edit `switchroom.yaml` can add a key to a
+  cron's `secrets[]` list, granting it broker access to any vault key.
+  Anyone who knows the vault passphrase can read the vault file directly.
+
+The vault ACL is **misconfiguration protection**, not a security boundary.
+The real security boundary is the vault passphrase and the filesystem
+permissions on `vault.enc` (`0600`).
+
+---
+
+## See also
+
+- [`docs/vault-broker.md`](vault-broker.md) — broker ACL model deep-dive
+- [`docs/scheduling.md`](scheduling.md) — full `schedule[]` configuration reference
+- [`docs/configuration.md`](configuration.md) — `vault:` config block reference
+- `switchroom vault doctor` — health check for common vault misconfigurations
+- `switchroom vault audit` — tail and filter the audit log

--- a/src/cli/vault-audit.ts
+++ b/src/cli/vault-audit.ts
@@ -1,0 +1,120 @@
+/**
+ * CLI: `switchroom vault audit`
+ *
+ * Tail and filter the vault audit log (~/.switchroom/vault-audit.log).
+ *
+ * Usage:
+ *   switchroom vault audit                    # last 50 lines, formatted
+ *   switchroom vault audit --who <caller>     # filter by caller substring
+ *   switchroom vault audit --key <pattern>    # filter by key name (regex/glob)
+ *   switchroom vault audit --denied           # only denied attempts
+ *   switchroom vault audit --tail 100         # last N lines (default 50)
+ *
+ * Flags are combinable.
+ *
+ * NEVER logs secret values — the audit log itself never contains them, and
+ * this formatter does not reintroduce them.
+ */
+
+import type { Command } from "commander";
+import chalk from "chalk";
+import { existsSync, readFileSync } from "node:fs";
+import { defaultAuditLogPath } from "../vault/broker/audit-log.js";
+import { formatAuditLines } from "../vault/audit-reader.js";
+
+export function registerVaultAuditCommand(vault: Command, _program: Command): void {
+  vault
+    .command("audit")
+    .description(
+      "Tail and filter the vault audit log (~/.switchroom/vault-audit.log)"
+    )
+    .option("--who <caller>", "Filter by caller substring (unit name or pid)")
+    .option("--key <pattern>", "Filter by key name (regex or substring)")
+    .option("--denied", "Show only denied access attempts")
+    .option(
+      "--tail <n>",
+      "Number of matching entries to show (default: 50)",
+      "50"
+    )
+    .option("--path <file>", "Override audit log path (for debugging)")
+    .action(
+      (opts: {
+        who?: string;
+        key?: string;
+        denied?: boolean;
+        tail?: string;
+        path?: string;
+      }) => {
+        const logPath = opts.path ?? defaultAuditLogPath();
+
+        if (!existsSync(logPath)) {
+          console.error(
+            chalk.yellow(`Audit log not found at ${logPath}.`) +
+            chalk.gray(
+              "\nThe log is created when the vault broker handles its first request."
+            )
+          );
+          process.exit(0);
+        }
+
+        const raw = readFileSync(logPath, "utf-8");
+        const rawLines = raw.split("\n");
+
+        const limit = Math.max(1, parseInt(opts.tail ?? "50", 10) || 50);
+
+        const filters = {
+          who: opts.who,
+          key: opts.key,
+          denied: opts.denied,
+        };
+
+        const formatted = formatAuditLines(rawLines, filters, limit);
+
+        if (formatted.length === 0) {
+          const parts: string[] = [];
+          if (opts.who) parts.push(`caller containing '${opts.who}'`);
+          if (opts.key) parts.push(`key matching '${opts.key}'`);
+          if (opts.denied) parts.push("denied results");
+          const filterDesc =
+            parts.length > 0 ? ` matching ${parts.join(", ")}` : "";
+          console.log(chalk.dim(`No audit entries${filterDesc}.`));
+          process.exit(0);
+        }
+
+        // Print header
+        const headerTs = "Timestamp (UTC)    ".padEnd(21);
+        const headerOp = "Op      ".padEnd(10);
+        const headerKey = "Key                         ".padEnd(30);
+        const headerCaller = "Caller                                              ".padEnd(54);
+        const headerResult = "Result";
+        console.log(
+          chalk.dim(`  ${headerTs} ${headerOp} ${headerKey} ${headerCaller} ${headerResult}`)
+        );
+        console.log(chalk.dim("  " + "─".repeat(130)));
+
+        for (const line of formatted) {
+          // Colour-code based on result
+          if (line.includes("  allowed")) {
+            console.log(chalk.green("  " + line));
+          } else if (line.includes("  denied")) {
+            console.log(chalk.red("  " + line));
+          } else if (line.includes("  error:")) {
+            console.log(chalk.yellow("  " + line));
+          } else {
+            console.log("  " + line);
+          }
+        }
+
+        console.log();
+        console.log(
+          chalk.dim(
+            `  ${formatted.length} entr${formatted.length === 1 ? "y" : "ies"} shown` +
+              (formatted.length === limit && limit > 0
+                ? ` (limit ${limit} — use --tail N to see more)`
+                : "") +
+              `  ·  log: ${logPath}`
+          )
+        );
+      }
+    );
+}

--- a/src/cli/vault-doctor.ts
+++ b/src/cli/vault-doctor.ts
@@ -155,6 +155,22 @@ export function registerVaultDoctorCommand(vault: Command, program: Command): vo
         brokerRunning,
       });
 
+      // Reviewer-fix: when SWITCHROOM_VAULT_PASSPHRASE is unset, key-level
+      // checks (missing-keys, sensitive-without-scope, unreferenced) all
+      // skip. In --json mode the previous output was a clean
+      // `{ diagnostics: [] }` (or just broker-state), which a CI runner
+      // would interpret as "all good" — falsely. Surface the skipped-checks
+      // as an explicit info-level diagnostic so callers can detect it.
+      if (vaultKeys === undefined) {
+        diagnostics.unshift({
+          check: "passphrase-not-available",
+          level: "info",
+          message:
+            "Per-key checks skipped: SWITCHROOM_VAULT_PASSPHRASE not set or vault could not be opened.",
+          fix: "Set SWITCHROOM_VAULT_PASSPHRASE to enable missing-key, sensitive-key, and unreferenced-key analysis.",
+        });
+      }
+
       // ── Output ────────────────────────────────────────────────────
       if (opts.json) {
         console.log(JSON.stringify({ diagnostics }, null, 2));

--- a/src/cli/vault-doctor.ts
+++ b/src/cli/vault-doctor.ts
@@ -1,0 +1,192 @@
+/**
+ * CLI: `switchroom vault doctor`
+ *
+ * Health check for the vault security model.  Reports:
+ *   - fail: broker configured but not running
+ *   - fail: crons referencing vault keys that don't exist
+ *   - warn: sensitive-looking keys without a per-key ACL scope
+ *   - info: vault keys not referenced in any cron's secrets[]
+ *
+ * Exit codes:
+ *   0 = ok (no fails, no warns)
+ *   1 = fail (at least one fail-level diagnostic)
+ *   2 = warn (no fails, but at least one warn)
+ *
+ * Implements the pure-functional shape from src/vault/doctor.ts, with I/O
+ * loading done here so the core logic is testable without mocking.
+ */
+
+import type { Command } from "commander";
+import chalk from "chalk";
+import { existsSync } from "node:fs";
+import { analyseVaultHealth, type Diagnostic, type DiagnosticLevel } from "../vault/doctor.js";
+import { openVault, VaultError } from "../vault/vault.js";
+import { loadConfig, resolvePath } from "../config/loader.js";
+import { statusViaBroker } from "../vault/broker/client.js";
+
+function levelGlyph(level: DiagnosticLevel): string {
+  switch (level) {
+    case "ok":
+      return chalk.green("✓");
+    case "warn":
+      return chalk.yellow("!");
+    case "fail":
+      return chalk.red("✗");
+    case "info":
+      return chalk.cyan("i");
+  }
+}
+
+function levelLabel(level: DiagnosticLevel): string {
+  switch (level) {
+    case "ok":
+      return chalk.green("ok  ");
+    case "warn":
+      return chalk.yellow("warn");
+    case "fail":
+      return chalk.red("fail");
+    case "info":
+      return chalk.cyan("info");
+  }
+}
+
+function printDiagnostic(d: Diagnostic): void {
+  const glyph = levelGlyph(d.level);
+  const label = levelLabel(d.level);
+  const firstLine = d.message.split("\n")[0];
+  const rest = d.message.split("\n").slice(1);
+
+  console.log(`  ${glyph} [${label}] ${firstLine}`);
+  for (const line of rest) {
+    console.log(`          ${chalk.gray(line)}`);
+  }
+  if (d.fix && d.level !== "ok") {
+    console.log(chalk.gray(`          → ${d.fix}`));
+  }
+}
+
+export function registerVaultDoctorCommand(vault: Command, program: Command): void {
+  vault
+    .command("doctor")
+    .description(
+      "Health check for vault security: missing keys, unscoped secrets, broker status"
+    )
+    .option("--json", "Output diagnostics as JSON")
+    .action(async (opts: { json?: boolean }) => {
+      const parentOpts = program.opts();
+
+      // ── Load config ────────────────────────────────────────────────
+      let config: ReturnType<typeof loadConfig>;
+      try {
+        config = loadConfig(parentOpts.config);
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        console.error(chalk.red(`Error loading config: ${msg}`));
+        process.exit(1);
+      }
+
+      // ── Resolve vault path ─────────────────────────────────────────
+      const vaultPath = resolvePath(config.vault?.path ?? "~/.switchroom/vault.enc");
+
+      // ── Open vault (if passphrase available) ───────────────────────
+      const passphrase = process.env.SWITCHROOM_VAULT_PASSPHRASE;
+      let vaultKeys:
+        | Record<string, { scope?: { allow?: string[]; deny?: string[] } }>
+        | undefined = undefined;
+
+      if (passphrase && existsSync(vaultPath)) {
+        try {
+          const entries = openVault(passphrase, vaultPath);
+          vaultKeys = {};
+          for (const [name, entry] of Object.entries(entries)) {
+            vaultKeys[name] = {
+              scope:
+                "scope" in entry && entry.scope
+                  ? (entry.scope as { allow?: string[]; deny?: string[] })
+                  : undefined,
+            };
+          }
+        } catch (err) {
+          if (err instanceof VaultError) {
+            console.error(
+              chalk.yellow(
+                `Warning: could not open vault (${err.message}). ` +
+                  "Skipping key-level checks. Verify SWITCHROOM_VAULT_PASSPHRASE."
+              )
+            );
+          } else {
+            throw err;
+          }
+        }
+      } else if (!passphrase) {
+        console.error(
+          chalk.dim(
+            "Note: SWITCHROOM_VAULT_PASSPHRASE not set — skipping per-key checks. " +
+              "Set it to enable missing-key and scope analysis."
+          )
+        );
+      }
+
+      // ── Build agentSchedules from config ───────────────────────────
+      const agentSchedules: Record<string, Array<{ secrets?: string[] }>> = {};
+      for (const [agentName, agentConfig] of Object.entries(config.agents ?? {})) {
+        agentSchedules[agentName] = (agentConfig.schedule ?? []).map((s) => ({
+          secrets: s.secrets,
+        }));
+      }
+
+      // ── Probe broker ───────────────────────────────────────────────
+      const brokerConfigured = config.vault?.broker?.enabled !== false;
+      let brokerRunning: boolean | undefined = undefined;
+
+      if (brokerConfigured) {
+        const socketPath = resolvePath(
+          config.vault?.broker?.socket ?? "~/.switchroom/vault-broker.sock"
+        );
+        const status = await statusViaBroker({ socket: socketPath, timeoutMs: 1500 });
+        brokerRunning = status !== null;
+      }
+
+      // ── Analyse ───────────────────────────────────────────────────
+      const diagnostics = analyseVaultHealth({
+        vaultKeys,
+        agentSchedules,
+        brokerConfigured,
+        brokerRunning,
+      });
+
+      // ── Output ────────────────────────────────────────────────────
+      if (opts.json) {
+        console.log(JSON.stringify({ diagnostics }, null, 2));
+        const hasFail = diagnostics.some((d) => d.level === "fail");
+        const hasWarn = diagnostics.some((d) => d.level === "warn");
+        if (hasFail) process.exit(1);
+        if (hasWarn) process.exit(2);
+        process.exit(0);
+      }
+
+      console.log(chalk.bold("\nVault Doctor"));
+      console.log();
+
+      for (const d of diagnostics) {
+        printDiagnostic(d);
+      }
+
+      const fails = diagnostics.filter((d) => d.level === "fail").length;
+      const warns = diagnostics.filter((d) => d.level === "warn").length;
+      const infos = diagnostics.filter((d) => d.level === "info").length;
+
+      console.log();
+      const summary = [
+        chalk.red(`${fails} fail`),
+        chalk.yellow(`${warns} warn`),
+        chalk.cyan(`${infos} info`),
+      ].join(" · ");
+      console.log(`  ${summary}`);
+      console.log();
+
+      if (fails > 0) process.exit(1);
+      if (warns > 0) process.exit(2);
+      process.exit(0);
+    });
+}

--- a/src/cli/vault.ts
+++ b/src/cli/vault.ts
@@ -25,6 +25,8 @@ import {
   resolveBrokerSocketPath,
 } from "../vault/broker/client.js";
 import { registerVaultBrokerCommand } from "./vault-broker.js";
+import { registerVaultDoctorCommand } from "./vault-doctor.js";
+import { registerVaultAuditCommand } from "./vault-audit.js";
 
 function getVaultPath(configPath?: string): string {
   try {
@@ -617,4 +619,10 @@ export function registerVaultCommand(program: Command): void {
 
   // `vault broker` — manage the vault-broker daemon.
   registerVaultBrokerCommand(vault, program);
+
+  // `vault doctor` — health check for vault security model.
+  registerVaultDoctorCommand(vault, program);
+
+  // `vault audit` — tail/filter the vault audit log.
+  registerVaultAuditCommand(vault, program);
 }

--- a/src/vault/audit-reader.ts
+++ b/src/vault/audit-reader.ts
@@ -1,0 +1,151 @@
+/**
+ * audit-reader — pure-functional helpers for reading and filtering the vault
+ * audit log.
+ *
+ * The audit log is newline-delimited JSON written by audit-log.ts.
+ * This module parses, filters, and formats entries for the CLI.
+ *
+ * No I/O here — accepts raw lines and returns formatted strings.
+ * The CLI in src/cli/vault-audit.ts handles file reading.
+ */
+
+import type { AuditEntry, AuditOp } from "./broker/audit-log.js";
+
+export interface AuditFilters {
+  /**
+   * Filter by caller substring match (e.g. "my-agent-cron-0").
+   * Compared case-insensitively against the `caller` field.
+   */
+  who?: string;
+
+  /**
+   * Filter by key name.  Treated as a regex; falls back to substring match
+   * when the string is not a valid regex.
+   */
+  key?: string;
+
+  /**
+   * When true, only include entries where result starts with "denied".
+   */
+  denied?: boolean;
+}
+
+/**
+ * Parse a raw JSON line from the audit log.
+ * Returns null when the line is not valid JSON or missing required fields.
+ */
+export function parseAuditLine(line: string): AuditEntry | null {
+  const trimmed = line.trim();
+  if (!trimmed) return null;
+  try {
+    const obj = JSON.parse(trimmed) as Record<string, unknown>;
+    // Require at minimum ts, op, caller, pid, result
+    if (
+      typeof obj.ts !== "string" ||
+      typeof obj.op !== "string" ||
+      typeof obj.caller !== "string" ||
+      typeof obj.pid !== "number" ||
+      typeof obj.result !== "string"
+    ) {
+      return null;
+    }
+    return {
+      ts: obj.ts,
+      op: obj.op as AuditOp,
+      key: typeof obj.key === "string" ? obj.key : undefined,
+      caller: obj.caller,
+      pid: obj.pid,
+      cgroup: typeof obj.cgroup === "string" ? obj.cgroup : undefined,
+      result: obj.result,
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Apply filters to a list of parsed AuditEntry objects.
+ * Returns only entries that pass all specified filters.
+ */
+export function filterAuditEntries(
+  entries: AuditEntry[],
+  filters: AuditFilters
+): AuditEntry[] {
+  let result = entries;
+
+  if (filters.who !== undefined) {
+    const needle = filters.who.toLowerCase();
+    result = result.filter((e) => e.caller.toLowerCase().includes(needle));
+  }
+
+  if (filters.key !== undefined) {
+    let keyRe: RegExp | null = null;
+    try {
+      keyRe = new RegExp(filters.key, "i");
+    } catch {
+      // Not a valid regex — use substring match
+      keyRe = null;
+    }
+    const keyNeedle = filters.key.toLowerCase();
+    result = result.filter((e) => {
+      if (!e.key) return false;
+      if (keyRe) return keyRe.test(e.key);
+      return e.key.toLowerCase().includes(keyNeedle);
+    });
+  }
+
+  if (filters.denied) {
+    result = result.filter((e) => e.result.startsWith("denied"));
+  }
+
+  return result;
+}
+
+/**
+ * Format a single AuditEntry as a human-readable line.
+ *
+ * Format: timestamp · op · key · caller · result
+ * Example:
+ *   2026-04-28 14:33:00  get    stripe/live-key       switchroom-my-agent-cron-0.service  allowed
+ */
+export function formatAuditEntry(entry: AuditEntry): string {
+  // Shorten ISO timestamp to local-ish display: "2026-04-28 14:33:00"
+  const ts = entry.ts.replace("T", " ").replace(/\.\d+Z$/, "Z").replace("Z", "");
+
+  const op = entry.op.padEnd(8);
+  const key = (entry.key ?? "(no key)").padEnd(28);
+  // Truncate long caller names for readability
+  const caller =
+    entry.caller.length > 50
+      ? entry.caller.slice(0, 47) + "..."
+      : entry.caller;
+  const callerPadded = caller.padEnd(52);
+  const result = entry.result;
+
+  return `${ts}  ${op}  ${key}  ${callerPadded}  ${result}`;
+}
+
+/**
+ * Parse, filter, and format audit log lines.
+ *
+ * @param rawLines - Raw lines from the audit log file (may include blanks/garbage)
+ * @param filters  - Filters to apply
+ * @param limit    - Maximum number of entries to return (applied after filtering)
+ * @returns Array of formatted human-readable lines
+ */
+export function formatAuditLines(
+  rawLines: string[],
+  filters: AuditFilters,
+  limit = 50
+): string[] {
+  const parsed = rawLines
+    .map(parseAuditLine)
+    .filter((e): e is AuditEntry => e !== null);
+
+  const filtered = filterAuditEntries(parsed, filters);
+
+  // Take the last `limit` entries (most recent).
+  const limited = filtered.slice(-limit);
+
+  return limited.map(formatAuditEntry);
+}

--- a/src/vault/doctor.ts
+++ b/src/vault/doctor.ts
@@ -16,8 +16,18 @@ export interface Diagnostic {
 }
 
 // Regex for sensitive-looking key names.
+//
+// Each keyword requires `(?![a-zA-Z])` after it — the next character
+// must NOT be an ASCII letter. This permits snake_case / kebab-case
+// suffixes (`db_password`, `auth_token`, `secret-key`) while excluding
+// false positives where the keyword is a prefix of a benign word
+// (`tokenizer-config` → `token` followed by `i` → no match).
+//
+// Plural forms (`passwords`, `secrets`) miss this filter but are rare
+// in practice for vault key names — operators typically store one
+// secret per key, not collections.
 const SENSITIVE_KEY_RE =
-  /oauth|token|secret|api[-_]?key|password/i;
+  /oauth(?![a-zA-Z])|token(?![a-zA-Z])|secret(?![a-zA-Z])|api[-_]?key(?![a-zA-Z])|password(?![a-zA-Z])/i;
 
 /**
  * Input shape for analyseVaultHealth.

--- a/src/vault/doctor.ts
+++ b/src/vault/doctor.ts
@@ -1,0 +1,165 @@
+/**
+ * vault-doctor — pure-functional health checks for the vault security model.
+ *
+ * All checks accept injected inputs so they are testable without I/O.
+ * The CLI in src/cli/vault-doctor.ts handles loading + calling these.
+ */
+
+export type DiagnosticLevel = "ok" | "warn" | "fail" | "info";
+
+export interface Diagnostic {
+  level: DiagnosticLevel;
+  check: string;
+  message: string;
+  /** Actionable hint shown below the message. */
+  fix?: string;
+}
+
+// Regex for sensitive-looking key names.
+const SENSITIVE_KEY_RE =
+  /oauth|token|secret|api[-_]?key|password/i;
+
+/**
+ * Input shape for analyseVaultHealth.
+ *
+ * All fields are optional so callers can provide only what they have
+ * (e.g. vault passphrase unavailable → vaultKeys undefined).
+ */
+export interface VaultHealthInput {
+  /**
+   * Keys currently in the vault, keyed by name.
+   * undefined means the vault could not be opened (passphrase not set, etc.).
+   */
+  vaultKeys?: Record<
+    string,
+    {
+      /** Per-entry scope, if set. */
+      scope?: { allow?: string[]; deny?: string[] };
+    }
+  >;
+
+  /**
+   * Agent/schedule configuration, keyed by agent name.
+   * Each agent has a schedule array; each schedule entry has a secrets array.
+   */
+  agentSchedules: Record<
+    string,
+    Array<{ secrets?: string[] }>
+  >;
+
+  /**
+   * Whether the broker is configured to be enabled in switchroom.yaml.
+   */
+  brokerConfigured: boolean;
+
+  /**
+   * Whether the broker is currently reachable on its Unix socket.
+   * true = reachable (running), false = not reachable, undefined = unknown.
+   */
+  brokerRunning: boolean | undefined;
+}
+
+/**
+ * Analyse vault health and return a list of diagnostics.
+ *
+ * No I/O — accepts pre-loaded inputs and returns Diagnostic records.
+ * Ordering: fails first, then warns, then info.
+ */
+export function analyseVaultHealth(input: VaultHealthInput): Diagnostic[] {
+  const diagnostics: Diagnostic[] = [];
+
+  // ── Broker configured but not running ─────────────────────────────────
+  if (input.brokerConfigured && input.brokerRunning === false) {
+    diagnostics.push({
+      level: "fail",
+      check: "broker-running",
+      message: "Vault broker is configured but not running.",
+      fix: "Run `switchroom vault broker unlock` or check `systemctl --user status switchroom-vault-broker.service`",
+    });
+  }
+
+  if (input.vaultKeys !== undefined) {
+    // ── Collect all keys referenced in schedule secrets[] ─────────────
+    const referencedKeys = new Set<string>();
+    const missingKeys: Array<{ agent: string; index: number; key: string }> = [];
+
+    for (const [agentName, schedule] of Object.entries(input.agentSchedules)) {
+      for (let i = 0; i < schedule.length; i++) {
+        const secrets = schedule[i].secrets ?? [];
+        for (const key of secrets) {
+          referencedKeys.add(key);
+          if (!(key in input.vaultKeys)) {
+            missingKeys.push({ agent: agentName, index: i, key });
+          }
+        }
+      }
+    }
+
+    // ── Crons referencing keys that don't exist in the vault ──────────
+    if (missingKeys.length > 0) {
+      const details = missingKeys
+        .map((m) => `  ${m.agent}/schedule[${m.index}]: '${m.key}'`)
+        .join("\n");
+      diagnostics.push({
+        level: "fail",
+        check: "missing-vault-keys",
+        message:
+          `${missingKeys.length} key(s) referenced in schedule secrets[] do not exist in the vault:\n${details}`,
+        fix: "Run `switchroom vault set <key>` for each missing key, or remove it from secrets[]",
+      });
+    }
+
+    // ── Sensitive keys without a scope ───────────────────────────────
+    const unscopedSensitive: string[] = [];
+    for (const [keyName, entry] of Object.entries(input.vaultKeys)) {
+      if (!SENSITIVE_KEY_RE.test(keyName)) continue;
+      const hasScope =
+        (entry.scope?.allow?.length ?? 0) > 0 ||
+        (entry.scope?.deny?.length ?? 0) > 0;
+      if (!hasScope) {
+        unscopedSensitive.push(keyName);
+      }
+    }
+
+    if (unscopedSensitive.length > 0) {
+      const keyList = unscopedSensitive.map((k) => `  ${k}`).join("\n");
+      diagnostics.push({
+        level: "warn",
+        check: "sensitive-keys-unscoped",
+        message:
+          `${unscopedSensitive.length} sensitive-looking key(s) have no per-key ACL:\n${keyList}`,
+        fix: "Consider `switchroom vault set <key> --allow <agent>` to restrict access",
+      });
+    }
+
+    // ── Vault keys not referenced anywhere ───────────────────────────
+    const unreferencedKeys: string[] = [];
+    for (const keyName of Object.keys(input.vaultKeys)) {
+      if (!referencedKeys.has(keyName)) {
+        unreferencedKeys.push(keyName);
+      }
+    }
+
+    if (unreferencedKeys.length > 0) {
+      const keyList = unreferencedKeys.map((k) => `  ${k}`).join("\n");
+      diagnostics.push({
+        level: "info",
+        check: "unreferenced-vault-keys",
+        message:
+          `${unreferencedKeys.length} vault key(s) are not referenced in any schedule secrets[]:\n${keyList}`,
+        fix: "These keys are candidates for cleanup (`switchroom vault remove <key>`) if no longer needed",
+      });
+    }
+  }
+
+  // If no issues found, emit a single ok diagnostic.
+  if (diagnostics.length === 0) {
+    diagnostics.push({
+      level: "ok",
+      check: "vault-health",
+      message: "Vault health looks good.",
+    });
+  }
+
+  return diagnostics;
+}

--- a/tests/vault-audit.test.ts
+++ b/tests/vault-audit.test.ts
@@ -141,9 +141,17 @@ describe("filterAuditEntries", () => {
   });
 
   it("handles invalid regex in --key gracefully (falls back to substring)", () => {
-    // "[invalid" is not a valid regex; should fall back to substring
-    const result = filterAuditEntries(entries, { key: "stripe" });
-    expect(result.length).toBeGreaterThan(0);
+    // The previous fixture (`"stripe"`) was a valid regex, so the
+    // fallback branch was untested. Use `"[unclosed"` — genuinely
+    // invalid — and a fixture whose literal key contains that substring,
+    // so the substring-fallback returns it.
+    const withBracketKey = [
+      ...entries,
+      makeEntry({ key: "broken[unclosed/key", result: "allowed" }),
+    ];
+    const result = filterAuditEntries(withBracketKey, { key: "[unclosed" });
+    expect(result.length).toBe(1);
+    expect(result[0].key).toBe("broken[unclosed/key");
   });
 });
 

--- a/tests/vault-audit.test.ts
+++ b/tests/vault-audit.test.ts
@@ -1,0 +1,228 @@
+import { describe, it, expect } from "vitest";
+import {
+  parseAuditLine,
+  filterAuditEntries,
+  formatAuditEntry,
+  formatAuditLines,
+} from "../src/vault/audit-reader.js";
+import type { AuditEntry } from "../src/vault/broker/audit-log.js";
+
+// Fixture factory
+function makeEntry(overrides: Partial<AuditEntry> = {}): AuditEntry {
+  return {
+    ts: "2026-04-28T14:33:00.123Z",
+    op: "get",
+    key: "stripe/live-key",
+    caller: "switchroom-my-agent-cron-0.service",
+    pid: 12345,
+    result: "allowed",
+    ...overrides,
+  };
+}
+
+function makeJsonLine(overrides: Partial<AuditEntry> = {}): string {
+  return JSON.stringify(makeEntry(overrides));
+}
+
+// ── parseAuditLine ─────────────────────────────────────────────────────────
+
+describe("parseAuditLine", () => {
+  it("parses a valid JSON audit line", () => {
+    const line = makeJsonLine();
+    const entry = parseAuditLine(line);
+    expect(entry).not.toBeNull();
+    expect(entry!.op).toBe("get");
+    expect(entry!.key).toBe("stripe/live-key");
+    expect(entry!.caller).toBe("switchroom-my-agent-cron-0.service");
+    expect(entry!.result).toBe("allowed");
+    expect(entry!.pid).toBe(12345);
+  });
+
+  it("returns null for blank lines", () => {
+    expect(parseAuditLine("")).toBeNull();
+    expect(parseAuditLine("   ")).toBeNull();
+  });
+
+  it("returns null for non-JSON lines", () => {
+    expect(parseAuditLine("not json at all")).toBeNull();
+  });
+
+  it("returns null when required fields are missing", () => {
+    const partial = JSON.stringify({ ts: "2026-01-01T00:00:00Z", op: "get" });
+    expect(parseAuditLine(partial)).toBeNull();
+  });
+
+  it("handles entry without a key field (e.g. unlock op)", () => {
+    const line = JSON.stringify({
+      ts: "2026-04-28T14:33:00.123Z",
+      op: "unlock",
+      caller: "pid:999",
+      pid: 999,
+      result: "allowed",
+    });
+    const entry = parseAuditLine(line);
+    expect(entry).not.toBeNull();
+    expect(entry!.op).toBe("unlock");
+    expect(entry!.key).toBeUndefined();
+  });
+
+  it("handles entry with cgroup field", () => {
+    const line = makeJsonLine({ cgroup: "switchroom-my-agent-cron-0.service" });
+    const entry = parseAuditLine(line);
+    expect(entry!.cgroup).toBe("switchroom-my-agent-cron-0.service");
+  });
+});
+
+// ── filterAuditEntries ─────────────────────────────────────────────────────
+
+describe("filterAuditEntries", () => {
+  const entries: AuditEntry[] = [
+    makeEntry({ caller: "switchroom-my-agent-cron-0.service", key: "stripe/key", result: "allowed" }),
+    makeEntry({ caller: "switchroom-other-cron-1.service", key: "google/key", result: "denied:scope-allow" }),
+    makeEntry({ caller: "switchroom-my-agent-cron-1.service", key: "stripe/secret", result: "denied:missing" }),
+    makeEntry({ op: "unlock", caller: "pid:9999", result: "allowed", key: undefined }),
+  ];
+
+  it("returns all entries when no filters set", () => {
+    const result = filterAuditEntries(entries, {});
+    expect(result).toHaveLength(entries.length);
+  });
+
+  it("filters by --who substring (case-insensitive)", () => {
+    const result = filterAuditEntries(entries, { who: "my-agent" });
+    expect(result).toHaveLength(2);
+    for (const e of result) {
+      expect(e.caller.toLowerCase()).toContain("my-agent");
+    }
+  });
+
+  it("filters by --who with pid fallback format", () => {
+    const result = filterAuditEntries(entries, { who: "pid:9999" });
+    expect(result).toHaveLength(1);
+    expect(result[0].caller).toBe("pid:9999");
+  });
+
+  it("filters by --key substring", () => {
+    const result = filterAuditEntries(entries, { key: "stripe" });
+    expect(result).toHaveLength(2);
+    for (const e of result) {
+      expect(e.key).toMatch(/stripe/);
+    }
+  });
+
+  it("filters by --key regex", () => {
+    const result = filterAuditEntries(entries, { key: "stripe/(key|secret)" });
+    expect(result).toHaveLength(2);
+  });
+
+  it("filters by --denied", () => {
+    const result = filterAuditEntries(entries, { denied: true });
+    expect(result).toHaveLength(2);
+    for (const e of result) {
+      expect(e.result).toMatch(/^denied/);
+    }
+  });
+
+  it("filters by --who and --denied combined", () => {
+    const result = filterAuditEntries(entries, { who: "my-agent", denied: true });
+    expect(result).toHaveLength(1);
+    expect(result[0].key).toBe("stripe/secret");
+  });
+
+  it("filters by --key and --denied combined", () => {
+    const result = filterAuditEntries(entries, { key: "google", denied: true });
+    expect(result).toHaveLength(1);
+    expect(result[0].key).toBe("google/key");
+  });
+
+  it("returns empty when entry has no key and --key filter set", () => {
+    const result = filterAuditEntries(entries, { key: "stripe", who: "pid:9999" });
+    expect(result).toHaveLength(0);
+  });
+
+  it("handles invalid regex in --key gracefully (falls back to substring)", () => {
+    // "[invalid" is not a valid regex; should fall back to substring
+    const result = filterAuditEntries(entries, { key: "stripe" });
+    expect(result.length).toBeGreaterThan(0);
+  });
+});
+
+// ── formatAuditEntry ───────────────────────────────────────────────────────
+
+describe("formatAuditEntry", () => {
+  it("formats an entry with all fields", () => {
+    const entry = makeEntry();
+    const line = formatAuditEntry(entry);
+    expect(line).toContain("2026-04-28");
+    expect(line).toContain("get");
+    expect(line).toContain("stripe/live-key");
+    expect(line).toContain("switchroom-my-agent-cron-0.service");
+    expect(line).toContain("allowed");
+  });
+
+  it("formats an entry without a key field", () => {
+    const entry = makeEntry({ op: "unlock", key: undefined });
+    const line = formatAuditEntry(entry);
+    expect(line).toContain("(no key)");
+    expect(line).toContain("unlock");
+  });
+
+  it("truncates very long caller names", () => {
+    const longCaller = "switchroom-" + "a".repeat(60) + "-cron-0.service";
+    const entry = makeEntry({ caller: longCaller });
+    const line = formatAuditEntry(entry);
+    expect(line).toContain("...");
+    // Should not blow up the line
+    expect(line.length).toBeLessThan(300);
+  });
+
+  it("formats denied result", () => {
+    const entry = makeEntry({ result: "denied:scope-allow" });
+    const line = formatAuditEntry(entry);
+    expect(line).toContain("denied:scope-allow");
+  });
+});
+
+// ── formatAuditLines ───────────────────────────────────────────────────────
+
+describe("formatAuditLines", () => {
+  const lines = [
+    makeJsonLine({ result: "allowed", key: "a/key" }),
+    makeJsonLine({ result: "denied:scope-allow", key: "b/key" }),
+    makeJsonLine({ result: "allowed", key: "c/key" }),
+    "not-json-garbage",
+    "",
+  ];
+
+  it("returns formatted lines, skipping garbage", () => {
+    const result = formatAuditLines(lines, {});
+    expect(result).toHaveLength(3); // 3 valid JSON lines, 2 skipped
+  });
+
+  it("applies --denied filter", () => {
+    const result = formatAuditLines(lines, { denied: true });
+    expect(result).toHaveLength(1);
+    expect(result[0]).toContain("denied:scope-allow");
+  });
+
+  it("applies limit (takes last N)", () => {
+    const manyLines = Array.from({ length: 100 }, (_, i) =>
+      makeJsonLine({ key: `key/${i}` })
+    );
+    const result = formatAuditLines(manyLines, {}, 10);
+    expect(result).toHaveLength(10);
+    // Last entry should be key/99
+    expect(result[9]).toContain("key/99");
+  });
+
+  it("returns empty array when no lines match filters", () => {
+    const result = formatAuditLines(lines, { who: "nonexistent-caller" });
+    expect(result).toHaveLength(0);
+  });
+
+  it("defaults limit to 50", () => {
+    const manyLines = Array.from({ length: 60 }, () => makeJsonLine());
+    const result = formatAuditLines(manyLines, {});
+    expect(result).toHaveLength(50);
+  });
+});

--- a/tests/vault-doctor.test.ts
+++ b/tests/vault-doctor.test.ts
@@ -1,0 +1,234 @@
+import { describe, it, expect } from "vitest";
+import { analyseVaultHealth, type VaultHealthInput } from "../src/vault/doctor.js";
+
+// Minimal helper — all schedule entries can have empty secrets by default.
+function makeInput(overrides: Partial<VaultHealthInput> = {}): VaultHealthInput {
+  return {
+    vaultKeys: undefined,
+    agentSchedules: {},
+    brokerConfigured: false,
+    brokerRunning: undefined,
+    ...overrides,
+  };
+}
+
+describe("analyseVaultHealth", () => {
+  // ── Broker checks ──────────────────────────────────────────────────────
+
+  it("returns ok when broker not configured", () => {
+    const result = analyseVaultHealth(makeInput({ brokerConfigured: false }));
+    expect(result).toHaveLength(1);
+    expect(result[0].level).toBe("ok");
+  });
+
+  it("returns ok when broker configured and running", () => {
+    const result = analyseVaultHealth(
+      makeInput({ brokerConfigured: true, brokerRunning: true })
+    );
+    expect(result).toHaveLength(1);
+    expect(result[0].level).toBe("ok");
+  });
+
+  it("returns fail when broker configured but not running", () => {
+    const result = analyseVaultHealth(
+      makeInput({ brokerConfigured: true, brokerRunning: false })
+    );
+    const fail = result.find((d) => d.check === "broker-running");
+    expect(fail).toBeDefined();
+    expect(fail!.level).toBe("fail");
+    expect(fail!.fix).toContain("vault broker unlock");
+  });
+
+  it("does not emit broker-running fail when brokerRunning is undefined", () => {
+    const result = analyseVaultHealth(
+      makeInput({ brokerConfigured: true, brokerRunning: undefined })
+    );
+    const fail = result.find((d) => d.check === "broker-running");
+    expect(fail).toBeUndefined();
+  });
+
+  // ── Missing vault keys ─────────────────────────────────────────────────
+
+  it("returns fail for cron secrets referencing missing vault keys", () => {
+    const result = analyseVaultHealth(
+      makeInput({
+        vaultKeys: {
+          "stripe/live-key": {},
+        },
+        agentSchedules: {
+          "my-agent": [
+            { secrets: ["stripe/live-key", "missing/key"] },
+          ],
+        },
+      })
+    );
+    const fail = result.find((d) => d.check === "missing-vault-keys");
+    expect(fail).toBeDefined();
+    expect(fail!.level).toBe("fail");
+    expect(fail!.message).toContain("missing/key");
+    expect(fail!.message).toContain("my-agent/schedule[0]");
+  });
+
+  it("does not emit missing-key fail when vault keys undefined", () => {
+    const result = analyseVaultHealth(
+      makeInput({
+        vaultKeys: undefined,
+        agentSchedules: {
+          "my-agent": [{ secrets: ["any/key"] }],
+        },
+      })
+    );
+    const fail = result.find((d) => d.check === "missing-vault-keys");
+    expect(fail).toBeUndefined();
+  });
+
+  it("passes when all cron secrets exist in vault", () => {
+    const result = analyseVaultHealth(
+      makeInput({
+        vaultKeys: {
+          "api/key": {},
+        },
+        agentSchedules: {
+          "my-agent": [{ secrets: ["api/key"] }],
+        },
+      })
+    );
+    const fail = result.find((d) => d.check === "missing-vault-keys");
+    expect(fail).toBeUndefined();
+  });
+
+  // ── Sensitive keys without scope ───────────────────────────────────────
+
+  it("warns on sensitive key names without scope", () => {
+    const sensitiveKeys = [
+      "my-oauth-token",
+      "stripe-api-key",
+      "db_password",
+      "some-secret",
+      "service-token",
+    ];
+    const vaultKeys: Record<string, { scope?: { allow?: string[]; deny?: string[] } }> = {};
+    for (const k of sensitiveKeys) vaultKeys[k] = {};
+
+    const result = analyseVaultHealth(makeInput({ vaultKeys }));
+    const warn = result.find((d) => d.check === "sensitive-keys-unscoped");
+    expect(warn).toBeDefined();
+    expect(warn!.level).toBe("warn");
+    for (const k of sensitiveKeys) {
+      expect(warn!.message).toContain(k);
+    }
+  });
+
+  it("does not warn on sensitive key that has an allow scope", () => {
+    const result = analyseVaultHealth(
+      makeInput({
+        vaultKeys: {
+          "my-oauth-token": { scope: { allow: ["agent-a"] } },
+        },
+      })
+    );
+    const warn = result.find((d) => d.check === "sensitive-keys-unscoped");
+    expect(warn).toBeUndefined();
+  });
+
+  it("does not warn on sensitive key that has a deny scope", () => {
+    const result = analyseVaultHealth(
+      makeInput({
+        vaultKeys: {
+          "stripe-api-key": { scope: { deny: ["agent-b"] } },
+        },
+      })
+    );
+    const warn = result.find((d) => d.check === "sensitive-keys-unscoped");
+    expect(warn).toBeUndefined();
+  });
+
+  it("does not warn on non-sensitive key names", () => {
+    const result = analyseVaultHealth(
+      makeInput({
+        vaultKeys: {
+          "telegram/bot-id": {},
+          "mff/endpoint": {},
+        },
+      })
+    );
+    const warn = result.find((d) => d.check === "sensitive-keys-unscoped");
+    expect(warn).toBeUndefined();
+  });
+
+  // ── Unreferenced vault keys ────────────────────────────────────────────
+
+  it("emits info for vault keys not referenced in any schedule", () => {
+    // Fixture key names must NOT be substrings of each other —
+    // `expect.not.toContain("used/key")` would otherwise fail on
+    // a message that legitimately includes "unused/key".
+    const result = analyseVaultHealth(
+      makeInput({
+        vaultKeys: {
+          "active/key": {},
+          "stale/key": {},
+        },
+        agentSchedules: {
+          "my-agent": [{ secrets: ["active/key"] }],
+        },
+      })
+    );
+    const info = result.find((d) => d.check === "unreferenced-vault-keys");
+    expect(info).toBeDefined();
+    expect(info!.level).toBe("info");
+    expect(info!.message).toContain("stale/key");
+    expect(info!.message).not.toContain("active/key");
+  });
+
+  it("does not emit unreferenced info when all keys are referenced", () => {
+    const result = analyseVaultHealth(
+      makeInput({
+        vaultKeys: { "api/key": {} },
+        agentSchedules: {
+          "my-agent": [{ secrets: ["api/key"] }],
+        },
+      })
+    );
+    const info = result.find((d) => d.check === "unreferenced-vault-keys");
+    expect(info).toBeUndefined();
+  });
+
+  // ── Multi-issue combinations ───────────────────────────────────────────
+
+  it("returns multiple diagnostics when multiple issues exist", () => {
+    const result = analyseVaultHealth(
+      makeInput({
+        vaultKeys: {
+          "my-oauth-token": {},   // sensitive, unscoped
+          "orphan/key": {},       // unreferenced
+        },
+        agentSchedules: {
+          "my-agent": [{ secrets: ["nonexistent/key"] }], // missing key
+        },
+        brokerConfigured: true,
+        brokerRunning: false,     // broker not running
+      })
+    );
+
+    const checks = result.map((d) => d.check);
+    expect(checks).toContain("broker-running");
+    expect(checks).toContain("missing-vault-keys");
+    expect(checks).toContain("sensitive-keys-unscoped");
+    expect(checks).toContain("unreferenced-vault-keys");
+  });
+
+  it("returns single ok diagnostic when everything is healthy", () => {
+    const result = analyseVaultHealth(
+      makeInput({
+        vaultKeys: { "reports/api-key": { scope: { allow: ["reports"] } } },
+        agentSchedules: {
+          "reports": [{ secrets: ["reports/api-key"] }],
+        },
+        brokerConfigured: true,
+        brokerRunning: true,
+      })
+    );
+    expect(result).toHaveLength(1);
+    expect(result[0].level).toBe("ok");
+  });
+});


### PR DESCRIPTION
Closes #209. Phase 4 of vault security epic #205. Three deliverables across four commits.

## Files & deliverables

1. **\`docs/vault.md\`** — operator guide: architecture (vault.enc → broker → callers), how to declare per-cron secrets, per-key ACL via \`--allow\`/\`--deny\`, Telegram /vault commands, threat model, audit log format. Cross-linked from README.

2. **\`switchroom vault doctor\`** — health check CLI:
   - Sensitive-named keys (oauth/token/secret/api_key/password) without scope → warn
   - Crons declaring \`secrets:\` for keys not in vault → fail
   - Vault keys unreferenced in any schedule → info
   - Broker configured but not running → fail
   Pure \`analyseVaultHealth\` function for testability.

3. **\`switchroom vault audit\`** — tail/filter the audit log:
   - Default: last 50 lines, formatted (ts · op · key · caller · result)
   - \`--who <caller>\`, \`--key <pattern>\`, \`--denied\` (combinable)
   Pure \`formatAuditLines\` function for testability.

## Tests
40 / 40 cases across vault-doctor.test.ts (~24) and vault-audit.test.ts (~16). Typecheck clean.

## Followup
None — all three deliverables shipped. The vault security epic is now functionally complete except for #161 (design proposal in #223).

Co-authored-by: Claude <noreply@anthropic.com>