### PR TITLE
telegram(#228): /vault grants list + revoke with inline buttons

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -207,6 +207,8 @@ import {
   statusViaBroker,
   lockViaBroker,
   unlockViaBroker,
+  listGrantsViaBroker,
+  revokeGrantViaBroker,
 } from '../../src/vault/broker/client.js'
 
 // ─── Stderr logging ───────────────────────────────────────────────────────
@@ -746,6 +748,8 @@ type PendingVaultOp =
   // Issue #158: passphrase collected for /vault unlock — sent directly to the
   // broker unlock socket, never logged or cached beyond the op itself.
   | { kind: 'unlock'; startedAt: number }
+  // Issue #228: waiting for confirmation before revoking a grant.
+  | { kind: 'revoke_confirm'; grantId: string; agent: string; keys: string[]; startedAt: number }
 const VAULT_INPUT_TTL_MS = 5 * 60 * 1000
 const pendingVaultOps = new Map<string, PendingVaultOp>()
 
@@ -4691,6 +4695,90 @@ async function handleVaultDeferCallback(ctx: Context, data: string): Promise<voi
 }
 
 /**
+ * Issue #228: handle vault grant management callbacks.
+ *
+ *   `vg:revoke:<grantId>`  — fetch grant details and show confirmation card.
+ *   `vg:confirm:<grantId>` — call broker revoke_grant, reply with success.
+ *   `vg:cancel:<grantId>`  — dismiss (clear keyboard, no broker call).
+ */
+async function handleVaultGrantCallback(ctx: Context, data: string): Promise<void> {
+  const senderId = String(ctx.from?.id ?? '')
+  const access = loadAccess()
+  if (!access.allowFrom.includes(senderId)) {
+    await ctx.answerCallbackQuery({ text: 'Not authorized.' }).catch(() => {})
+    return
+  }
+
+  const revokeMatch = /^vg:revoke:(.+)$/.exec(data)
+  if (revokeMatch) {
+    const grantId = revokeMatch[1]!
+    const result = await listGrantsViaBroker(undefined)
+    if (result.kind !== 'ok') {
+      await ctx.answerCallbackQuery({ text: 'Broker unreachable.' }).catch(() => {})
+      return
+    }
+    const grant = result.grants.find(g => g.id === grantId)
+    if (!grant) {
+      await ctx.answerCallbackQuery({ text: 'Grant not found (already revoked?).' }).catch(() => {})
+      await ctx.editMessageReplyMarkup({ reply_markup: { inline_keyboard: [] } }).catch(() => {})
+      return
+    }
+    const cardText =
+      `🗑 Revoke <code>${escapeHtmlForTg(grantId)}</code>?\n` +
+      `Agent: <b>${escapeHtmlForTg(grant.agent_slug)}</b>\n` +
+      `Keys: <code>${escapeHtmlForTg(grant.key_allow.join(', '))}</code>`
+    const confirmKeyboard = new InlineKeyboard()
+      .text('✅ Confirm Revoke', `vg:confirm:${grantId}`)
+      .text('❌ Cancel', `vg:cancel:${grantId}`)
+    await ctx.answerCallbackQuery().catch(() => {})
+    await ctx.editMessageText(cardText, {
+      parse_mode: 'HTML',
+      reply_markup: confirmKeyboard,
+    }).catch(async () => {
+      const chatId = String(ctx.chat?.id ?? ctx.from?.id ?? '')
+      const threadId = ctx.callbackQuery.message?.message_thread_id
+      if (chatId) {
+        await bot.api.sendMessage(chatId, cardText, {
+          parse_mode: 'HTML',
+          reply_markup: confirmKeyboard,
+          ...(threadId != null ? { message_thread_id: threadId } : {}),
+        }).catch(() => {})
+      }
+    })
+    return
+  }
+
+  const confirmMatch = /^vg:confirm:(.+)$/.exec(data)
+  if (confirmMatch) {
+    const grantId = confirmMatch[1]!
+    const revokeResult = await revokeGrantViaBroker(grantId)
+    if (revokeResult.kind === 'unreachable') {
+      await ctx.answerCallbackQuery({ text: 'Broker unreachable.' }).catch(() => {})
+      return
+    }
+    if (revokeResult.kind === 'error') {
+      await ctx.answerCallbackQuery({ text: `Revoke failed: ${revokeResult.msg}` }).catch(() => {})
+      return
+    }
+    await ctx.answerCallbackQuery({ text: '✅ Revoked' }).catch(() => {})
+    await ctx.editMessageText(
+      `✅ Grant <code>${escapeHtmlForTg(grantId)}</code> revoked. Token file removed.`,
+      { parse_mode: 'HTML', reply_markup: { inline_keyboard: [] } },
+    ).catch(() => {})
+    return
+  }
+
+  const cancelMatch = /^vg:cancel:(.+)$/.exec(data)
+  if (cancelMatch) {
+    await ctx.answerCallbackQuery({ text: 'Cancelled.' }).catch(() => {})
+    await ctx.editMessageReplyMarkup({ reply_markup: { inline_keyboard: [] } }).catch(() => {})
+    return
+  }
+
+  await ctx.answerCallbackQuery().catch(() => {})
+}
+
+/**
  * Issue #44: write a deferred secret to the vault using the now-cached
  * passphrase. Confirms with a masked ref + slug; matches the "captured
  * N secret" UX of the cached-passphrase happy path so the user
@@ -5055,7 +5143,60 @@ bot.command('vault', async ctx => {
       '/vault status — show broker state',
       '/vault unlock — unlock the broker (prompts for passphrase)',
       '/vault lock — lock the broker',
+      '/vault grants [agent] — list active capability grants (tap to revoke)',
     ].join('\n'), { html: true })
+    return
+  }
+
+  // Issue #228: /vault grants [agent] — list active grants grouped by agent
+  if (sub === 'grants') {
+    const agentFilter = args[1]  // optional agent name filter
+    const result = await listGrantsViaBroker(agentFilter)
+    if (result.kind === 'unreachable') {
+      await switchroomReply(ctx, '🔴 Broker is not running (or unreachable).', { html: true })
+      return
+    }
+    if (result.kind === 'error') {
+      await switchroomReply(ctx, `🔴 list_grants failed: ${escapeHtmlForTg(result.msg)}`, { html: true })
+      return
+    }
+    const { grants } = result
+    if (grants.length === 0) {
+      const filterNote = agentFilter ? ` for <code>${escapeHtmlForTg(agentFilter)}</code>` : ''
+      await switchroomReply(ctx, `📜 No active grants${filterNote}.`, { html: true })
+      return
+    }
+    // Group grants by agent_slug
+    const byAgent = new Map<string, typeof grants>()
+    for (const g of grants) {
+      const list = byAgent.get(g.agent_slug) ?? []
+      list.push(g)
+      byAgent.set(g.agent_slug, list)
+    }
+    // Build message text (grouped) + inline keyboard (one [Revoke] per grant per row)
+    const lines: string[] = ['<b>📜 Active grants</b>', '']
+    const keyboard = new InlineKeyboard()
+    for (const [agentName, agentGrants] of byAgent) {
+      lines.push(`<b>${escapeHtmlForTg(agentName)}:</b>`)
+      for (const g of agentGrants) {
+        const keys = g.key_allow.join(', ')
+        const expiry = g.expires_at
+          ? new Date(g.expires_at * 1000).toISOString().slice(0, 10)
+          : 'no expiry'
+        lines.push(`• <code>${escapeHtmlForTg(g.id)}</code> — ${escapeHtmlForTg(keys)}, expires ${expiry}`)
+        // callback_data: vg:revoke:<id> — max 64 bytes; grant IDs are "vg_" + 6 chars = 9 chars total → well within limit
+        keyboard.text(`🗑 Revoke ${g.id}`, `vg:revoke:${g.id}`).row()
+      }
+      lines.push('')
+    }
+    const chatId2 = String(ctx.chat!.id)
+    const threadId2 = resolveThreadId(chatId2, ctx.message?.message_thread_id)
+    await ctx.reply(lines.join('\n'), {
+      parse_mode: 'HTML',
+      link_preview_options: { is_disabled: true },
+      reply_markup: keyboard,
+      ...(threadId2 != null ? { message_thread_id: threadId2 } : {}),
+    })
     return
   }
 
@@ -5290,6 +5431,15 @@ bot.on('callback_query:data', async ctx => {
   // Issue #44.
   if (data.startsWith('vd:')) {
     await handleVaultDeferCallback(ctx, data)
+    return
+  }
+
+  // Issue #228: vault grant management callbacks.
+  // vg:revoke:<id> — show confirmation card
+  // vg:confirm:<id> — execute revoke
+  // vg:cancel:<id> — dismiss
+  if (data.startsWith('vg:')) {
+    await handleVaultGrantCallback(ctx, data)
     return
   }
 

--- a/telegram-plugin/server.ts
+++ b/telegram-plugin/server.ts
@@ -79,6 +79,8 @@ import {
   unlockViaBroker,
   mintGrantViaBroker,
   listViaBroker,
+  listGrantsViaBroker,
+  revokeGrantViaBroker,
 } from '../src/vault/broker/client.js'
 
 // Route all process.stderr.write calls (including downstream "telegram channel:",
@@ -1178,6 +1180,8 @@ type PendingVaultOp =
       awaitingCustomDuration?: boolean  // true while waiting for text reply
       startedAt: number
     }
+  // Issue #228: waiting for confirmation before revoking a grant.
+  | { kind: 'revoke_confirm'; grantId: string; agent: string; keys: string[]; startedAt: number }
 const VAULT_INPUT_TTL_MS = 5 * 60 * 1000  // 5 min before prompts expire
 const pendingVaultOps = new Map<string, PendingVaultOp>()
 
@@ -4476,9 +4480,62 @@ bot.command('vault', async ctx => {
       '/vault unlock — unlock the broker (prompts for passphrase)',
       '/vault lock — lock the broker',
       '/vault grant — mint a capability token (inline wizard)',
+      '/vault grants [agent] — list active capability grants (tap to revoke)',
       '',
       'Your passphrase is cached in memory for 30 min after first use.',
     ].join('\n'), { html: true })
+    return
+  }
+
+  // Issue #228: /vault grants [agent] — list active grants grouped by agent
+  if (sub === 'grants') {
+    const agentFilter = args[1]  // optional agent name filter
+    const result = await listGrantsViaBroker(agentFilter)
+    if (result.kind === 'unreachable') {
+      await switchroomReply(ctx, '🔴 Broker is not running (or unreachable).', { html: true })
+      return
+    }
+    if (result.kind === 'error') {
+      await switchroomReply(ctx, `🔴 list_grants failed: ${escapeHtmlForTg(result.msg)}`, { html: true })
+      return
+    }
+    const { grants } = result
+    if (grants.length === 0) {
+      const filterNote = agentFilter ? ` for <code>${escapeHtmlForTg(agentFilter)}</code>` : ''
+      await switchroomReply(ctx, `📜 No active grants${filterNote}.`, { html: true })
+      return
+    }
+    // Group grants by agent_slug
+    const byAgent = new Map<string, typeof grants>()
+    for (const g of grants) {
+      const list = byAgent.get(g.agent_slug) ?? []
+      list.push(g)
+      byAgent.set(g.agent_slug, list)
+    }
+    // Build message text (grouped) + inline keyboard (one [Revoke] per grant per row)
+    const lines: string[] = ['<b>📜 Active grants</b>', '']
+    const keyboard = new InlineKeyboard()
+    for (const [agent, agentGrants] of byAgent) {
+      lines.push(`<b>${escapeHtmlForTg(agent)}:</b>`)
+      for (const g of agentGrants) {
+        const keys = g.key_allow.join(', ')
+        const expiry = g.expires_at
+          ? new Date(g.expires_at * 1000).toISOString().slice(0, 10)
+          : 'no expiry'
+        lines.push(`• <code>${escapeHtmlForTg(g.id)}</code> — ${escapeHtmlForTg(keys)}, expires ${expiry}`)
+        // callback_data: vg:revoke:<id> — max 64 bytes; grant IDs are "vg_" + 6 chars = 9 chars total → well within limit
+        keyboard.text(`🗑 Revoke ${g.id}`, `vg:revoke:${g.id}`).row()
+      }
+      lines.push('')
+    }
+    const chatId2 = String(ctx.chat!.id)
+    const threadId2 = resolveThreadId(chatId2, ctx.message?.message_thread_id)
+    await ctx.reply(lines.join('\n'), {
+      parse_mode: 'HTML',
+      link_preview_options: { is_disabled: true },
+      reply_markup: keyboard,
+      ...(threadId2 != null ? { message_thread_id: threadId2 } : {}),
+    })
     return
   }
 
@@ -5146,14 +5203,17 @@ async function registerSwitchroomBotCommands(): Promise<void> {
   )
 }
 
-// Inline-button handler for permission requests. Callback data is
-// `perm:allow:<id>`, `perm:deny:<id>`, or `perm:more:<id>`.
-// Also handles `vg:*` callbacks for the /vault grant wizard (Issue #227).
+// Inline-button handler for permission requests, vault grant wizard
+// (#227), and vault grant management (#228).
+// Callback prefixes:
+//   - perm:allow|deny|more:<id> — permission requests (#158)
+//   - vg:* — /vault grant wizard (#227) AND grant revoke (#228)
 // Security mirrors the text-reply path: allowFrom must contain the sender.
 bot.on('callback_query:data', async ctx => {
   const data = ctx.callbackQuery.data
 
-  // Grant wizard callbacks: vg:<action>[:<payload>]
+  // Issues #227 + #228: vault grant wizard + grant management callbacks
+
   if (data.startsWith('vg:')) {
     const access = loadAccess()
     const senderId = String(ctx.from.id)
@@ -5161,6 +5221,77 @@ bot.on('callback_query:data', async ctx => {
       await ctx.answerCallbackQuery({ text: 'Not authorized.' }).catch(() => {})
       return
     }
+    // #228 grant management callbacks (vg:revoke / vg:confirm / vg:cancel:<id>)
+    // come BEFORE the #227 wizard handlers because they are pattern-matched
+    // with a trailing colon+grantId (the wizard uses bare `vg:cancel` and
+    // step-specific suffixes that don't collide).
+
+    // vg:revoke:<grantId> — tap on list card → show confirmation card
+    const revokeMatch = /^vg:revoke:(.+)$/.exec(data)
+    if (revokeMatch) {
+      const grantId = revokeMatch[1]!
+      const result = await listGrantsViaBroker(undefined)
+      if (result.kind !== 'ok') {
+        await ctx.answerCallbackQuery({ text: 'Broker unreachable.' }).catch(() => {})
+        return
+      }
+      const grant = result.grants.find(g => g.id === grantId)
+      if (!grant) {
+        await ctx.answerCallbackQuery({ text: 'Grant not found (already revoked?).' }).catch(() => {})
+        await ctx.editMessageReplyMarkup({ reply_markup: { inline_keyboard: [] } }).catch(() => {})
+        return
+      }
+      const cardText =
+        `🗑 Revoke <code>${escapeHtmlForTg(grantId)}</code>?\n` +
+        `Agent: <b>${escapeHtmlForTg(grant.agent_slug)}</b>\n` +
+        `Keys: <code>${escapeHtmlForTg(grant.key_allow.join(', '))}</code>`
+      const confirmKeyboard = new InlineKeyboard()
+        .text('✅ Confirm Revoke', `vg:confirm:${grantId}`)
+        .text('❌ Cancel', `vg:cancel:${grantId}`)
+      await ctx.answerCallbackQuery().catch(() => {})
+      await ctx.editMessageText(cardText, {
+        parse_mode: 'HTML',
+        reply_markup: confirmKeyboard,
+      }).catch(async () => {
+        const chatIdStr = String(ctx.chat?.id ?? ctx.from.id)
+        const threadId = ctx.callbackQuery.message?.message_thread_id
+        await bot.api.sendMessage(chatIdStr, cardText, {
+          parse_mode: 'HTML',
+          reply_markup: confirmKeyboard,
+          ...(threadId != null ? { message_thread_id: threadId } : {}),
+        }).catch(() => {})
+      })
+      return
+    }
+    // vg:confirm:<grantId> — confirmed revoke
+    const confirmMatch = /^vg:confirm:(.+)$/.exec(data)
+    if (confirmMatch) {
+      const grantId = confirmMatch[1]!
+      const revokeResult = await revokeGrantViaBroker(grantId)
+      if (revokeResult.kind === 'unreachable') {
+        await ctx.answerCallbackQuery({ text: 'Broker unreachable.' }).catch(() => {})
+        return
+      }
+      if (revokeResult.kind === 'error') {
+        await ctx.answerCallbackQuery({ text: `Revoke failed: ${revokeResult.msg}` }).catch(() => {})
+        return
+      }
+      await ctx.answerCallbackQuery({ text: '✅ Revoked' }).catch(() => {})
+      await ctx.editMessageText(
+        `✅ Grant <code>${escapeHtmlForTg(grantId)}</code> revoked. Token file removed.`,
+        { parse_mode: 'HTML', reply_markup: { inline_keyboard: [] } },
+      ).catch(() => {})
+      return
+    }
+    // vg:cancel:<grantId> — cancelled (revoke flow only — wizard cancel is bare `vg:cancel`)
+    const cancelMatch = /^vg:cancel:(.+)$/.exec(data)
+    if (cancelMatch) {
+      await ctx.answerCallbackQuery({ text: 'Cancelled.' }).catch(() => {})
+      await ctx.editMessageReplyMarkup({ reply_markup: { inline_keyboard: [] } }).catch(() => {})
+      return
+    }
+
+    // #227 grant wizard callbacks (vg:cancel bare, vg:agent:*, vg:keys:*, vg:dur:*, vg:gen)
     const chatId = String(ctx.chat!.id)
     await ctx.answerCallbackQuery().catch(() => {})
 
@@ -5261,6 +5392,8 @@ bot.on('callback_query:data', async ctx => {
       return
     }
 
+    // Unrecognised vg: sub-action
+    await ctx.answerCallbackQuery().catch(() => {})
     return
   }
 

--- a/telegram-plugin/tests/vault-grants-revoke.test.ts
+++ b/telegram-plugin/tests/vault-grants-revoke.test.ts
@@ -1,0 +1,266 @@
+/**
+ * Structural tests for the /vault grants list + revoke implementation
+ * added in issue #228.
+ *
+ * Why structural: gateway/gateway.ts and server.ts do not export the bot
+ * command handlers, so pure-functional invocation would require a full
+ * Grammy/Bot harness. The broker client functions (listGrantsViaBroker,
+ * revokeGrantViaBroker) are separately unit-tested in
+ * src/vault/broker/server-grants.test.ts. What we pin here is:
+ *
+ *   1. Both server.ts and gateway/gateway.ts import listGrantsViaBroker and
+ *      revokeGrantViaBroker from the broker client module.
+ *   2. The /vault command handler contains a `grants` branch that calls
+ *      listGrantsViaBroker.
+ *   3. The grants list renders an inline keyboard with vg:revoke:<id> buttons.
+ *   4. A callback_query handler intercepts vg: prefixed data in both files.
+ *   5. The revoke callback handler invokes revokeGrantViaBroker on vg:confirm.
+ *   6. The confirmation flow uses an intermediate vg:confirm/<vg:cancel> card
+ *      (not immediate revoke on first tap) — two-step confirmation.
+ *   7. /vault grants <agent> filter form parses the agent argument.
+ *   8. Help text in both files mentions /vault grants.
+ *   9. welcome-text.ts /vault section lists the grants subcommand.
+ *
+ * Each assertion covers BOTH server.ts (monolith polling mode) and
+ * gateway/gateway.ts (persistent gateway mode) so a regression in either
+ * file is caught.
+ */
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { join, dirname } from 'node:path'
+
+const __dir = dirname(fileURLToPath(import.meta.url))
+const pluginDir = join(__dir, '..')
+
+const serverSrc = readFileSync(join(pluginDir, 'server.ts'), 'utf8')
+const gatewaySrc = readFileSync(join(pluginDir, 'gateway', 'gateway.ts'), 'utf8')
+
+// ─── helpers ─────────────────────────────────────────────────────────────────
+
+/** Slice the source from the first occurrence of `marker` for `len` chars. */
+function sliceFrom(src: string, marker: string, len = 4000): string {
+  const idx = src.indexOf(marker)
+  if (idx === -1) return ''
+  return src.slice(idx, idx + len)
+}
+
+/** Returns the portion of `src` inside the `/vault` bot.command() handler. */
+function vaultHandlerBlock(src: string): string {
+  const start = src.indexOf("bot.command('vault'")
+  if (start === -1) return ''
+  const nextCmd = src.indexOf('\nbot.command(', start + 1)
+  const end = nextCmd === -1 ? start + 12000 : nextCmd
+  return src.slice(start, end)
+}
+
+// ─── broker client imports ────────────────────────────────────────────────────
+
+describe('/vault grants #228 — broker client imports', () => {
+  for (const [label, src] of [['server.ts', serverSrc], ['gateway.ts', gatewaySrc]] as const) {
+    it(`${label} imports listGrantsViaBroker`, () => {
+      expect(src).toMatch(/listGrantsViaBroker/)
+    })
+
+    it(`${label} imports revokeGrantViaBroker`, () => {
+      expect(src).toMatch(/revokeGrantViaBroker/)
+    })
+  }
+})
+
+// ─── /vault grants dispatcher ────────────────────────────────────────────────
+
+describe('/vault grants — dispatcher entry', () => {
+  for (const [label, src] of [['server.ts', serverSrc], ['gateway.ts', gatewaySrc]] as const) {
+    const block = vaultHandlerBlock(src)
+
+    it(`${label}: has a grants branch inside the vault handler`, () => {
+      expect(block).toMatch(/sub === ['"]grants['"]/)
+    })
+
+    it(`${label}: grants branch calls listGrantsViaBroker`, () => {
+      // Use a larger slice (2000) — the keyboard.text('vg:revoke') call comes ~1580 chars in
+      const grantsBranch = sliceFrom(block, "sub === 'grants'", 2000)
+      expect(grantsBranch).toMatch(/listGrantsViaBroker\(/)
+    })
+  }
+})
+
+// ─── /vault grants — list rendering ──────────────────────────────────────────
+
+describe('/vault grants — list rendering wires to list_grants', () => {
+  for (const [label, src] of [['server.ts', serverSrc], ['gateway.ts', gatewaySrc]] as const) {
+    const block = vaultHandlerBlock(src)
+
+    it(`${label}: renders grouped grants with agent names as headers`, () => {
+      const grantsBranch = sliceFrom(block, "sub === 'grants'", 2000)
+      // Groups grants by agent_slug and renders agent name as a bold header
+      expect(grantsBranch).toMatch(/agent_slug/)
+      expect(grantsBranch).toMatch(/byAgent/)
+    })
+
+    it(`${label}: attaches inline keyboard with vg:revoke buttons`, () => {
+      // keyboard.text('Revoke', 'vg:revoke:<id>') is ~1580 chars into the grants branch
+      const grantsBranch = sliceFrom(block, "sub === 'grants'", 2000)
+      expect(grantsBranch).toMatch(/vg:revoke:/)
+      expect(grantsBranch).toMatch(/InlineKeyboard/)
+    })
+
+    it(`${label}: handles empty grants list with friendly message`, () => {
+      const grantsBranch = sliceFrom(block, "sub === 'grants'", 2000)
+      expect(grantsBranch).toMatch(/No active grants/)
+    })
+
+    it(`${label}: handles broker unreachable with error message`, () => {
+      const grantsBranch = sliceFrom(block, "sub === 'grants'", 2000)
+      expect(grantsBranch).toMatch(/unreachable/i)
+    })
+  }
+})
+
+// ─── /vault grants <agent> — filter form ─────────────────────────────────────
+
+describe('/vault grants <agent> — agent filter argument', () => {
+  for (const [label, src] of [['server.ts', serverSrc], ['gateway.ts', gatewaySrc]] as const) {
+    const block = vaultHandlerBlock(src)
+
+    it(`${label}: parses optional agent argument from args`, () => {
+      const grantsBranch = sliceFrom(block, "sub === 'grants'", 2000)
+      // Agent filter is read from args[1]
+      expect(grantsBranch).toMatch(/args\[1\]/)
+    })
+
+    it(`${label}: passes agentFilter to listGrantsViaBroker`, () => {
+      const grantsBranch = sliceFrom(block, "sub === 'grants'", 2000)
+      expect(grantsBranch).toMatch(/listGrantsViaBroker\(agentFilter\)/)
+    })
+
+    it(`${label}: filter note appears in empty-grants message when agent filter is set`, () => {
+      const grantsBranch = sliceFrom(block, "sub === 'grants'", 2000)
+      expect(grantsBranch).toMatch(/filterNote/)
+    })
+  }
+})
+
+// ─── vg: callback dispatch ────────────────────────────────────────────────────
+
+describe('vg: callback query handler exists', () => {
+  for (const [label, src] of [['server.ts', serverSrc], ['gateway.ts', gatewaySrc]] as const) {
+    it(`${label}: has a handler block that checks data.startsWith('vg:')`, () => {
+      expect(src).toMatch(/data\.startsWith\(['"]vg:['"]\)/)
+    })
+
+    it(`${label}: has a revokeMatch handler for vg:revoke: prefix`, () => {
+      // Use 'const revokeMatch' as a specific code marker (not a comment)
+      expect(src).toMatch(/const revokeMatch = \/\^vg:revoke:/)
+    })
+
+    it(`${label}: has a confirmMatch handler for vg:confirm: prefix`, () => {
+      expect(src).toMatch(/const confirmMatch = \/\^vg:confirm:/)
+    })
+
+    it(`${label}: has a cancelMatch handler for vg:cancel: prefix`, () => {
+      expect(src).toMatch(/const cancelMatch = \/\^vg:cancel:/)
+    })
+  }
+})
+
+// ─── revoke callback — invokes revokeGrantViaBroker ──────────────────────────
+
+describe('vg:confirm callback invokes revokeGrantViaBroker', () => {
+  for (const [label, src] of [['server.ts', serverSrc], ['gateway.ts', gatewaySrc]] as const) {
+    it(`${label}: vg:confirm branch calls revokeGrantViaBroker with the grant ID`, () => {
+      // Use 'const confirmMatch =' as the unique code marker (avoids comment occurrences)
+      const confirmArea = sliceFrom(src, 'const confirmMatch = /^vg:confirm:', 800)
+      expect(confirmArea).toMatch(/revokeGrantViaBroker\(grantId\)/)
+    })
+
+    it(`${label}: vg:confirm success replies with revoked confirmation text`, () => {
+      const confirmArea = sliceFrom(src, 'const confirmMatch = /^vg:confirm:', 800)
+      expect(confirmArea).toMatch(/revoked|Revoked/i)
+    })
+
+    it(`${label}: vg:confirm handles broker unreachable`, () => {
+      const confirmArea = sliceFrom(src, 'const confirmMatch = /^vg:confirm:', 800)
+      expect(confirmArea).toMatch(/unreachable/i)
+    })
+
+    it(`${label}: vg:confirm handles error result from broker`, () => {
+      const confirmArea = sliceFrom(src, 'const confirmMatch = /^vg:confirm:', 800)
+      expect(confirmArea).toMatch(/Revoke failed/i)
+    })
+  }
+})
+
+// ─── two-step confirmation flow ───────────────────────────────────────────────
+
+describe('revoke flow uses two-step confirmation (no immediate revoke on first tap)', () => {
+  for (const [label, src] of [['server.ts', serverSrc], ['gateway.ts', gatewaySrc]] as const) {
+    it(`${label}: vg:revoke tap shows confirmation card, not immediate revoke`, () => {
+      // Use 'const revokeMatch =' as the unique code marker
+      const revokeArea = sliceFrom(src, 'const revokeMatch = /^vg:revoke:', 1500)
+      // Must show a confirmation card with confirm/cancel buttons
+      expect(revokeArea).toMatch(/Confirm Revoke|confirm.*revoke/i)
+      // Must NOT call revokeGrantViaBroker in the first-tap handler
+      // (revokeGrantViaBroker is only called from confirmMatch, which appears later)
+      const firstTapArea = sliceFrom(src, 'const revokeMatch = /^vg:revoke:', 900)
+      expect(firstTapArea).not.toMatch(/revokeGrantViaBroker/)
+    })
+
+    it(`${label}: confirmation card shows vg:confirm and vg:cancel options`, () => {
+      const revokeArea = sliceFrom(src, 'const revokeMatch = /^vg:revoke:', 1500)
+      expect(revokeArea).toMatch(/vg:confirm:/)
+      expect(revokeArea).toMatch(/vg:cancel:/)
+    })
+  }
+})
+
+// ─── vg:cancel — dismiss without revoke ──────────────────────────────────────
+
+describe('vg:cancel dismisses without revoking', () => {
+  for (const [label, src] of [['server.ts', serverSrc], ['gateway.ts', gatewaySrc]] as const) {
+    it(`${label}: vg:cancel does NOT call revokeGrantViaBroker`, () => {
+      const cancelArea = sliceFrom(src, 'const cancelMatch = /^vg:cancel:', 500)
+      expect(cancelArea).not.toMatch(/revokeGrantViaBroker/)
+    })
+
+    it(`${label}: vg:cancel clears the inline keyboard`, () => {
+      const cancelArea = sliceFrom(src, 'const cancelMatch = /^vg:cancel:', 500)
+      expect(cancelArea).toMatch(/editMessageReplyMarkup|inline_keyboard/)
+    })
+  }
+})
+
+// ─── help text ───────────────────────────────────────────────────────────────
+
+describe('/vault help text includes grants subcommand', () => {
+  for (const [label, src] of [['server.ts', serverSrc], ['gateway.ts', gatewaySrc]] as const) {
+    const block = vaultHandlerBlock(src)
+
+    it(`${label}: /vault help lists grants subcommand`, () => {
+      const helpBranch = sliceFrom(block, "sub === 'help'", 1200)
+      expect(helpBranch).toMatch(/grants/)
+    })
+
+    it(`${label}: grants help entry mentions agent filter or 'tap to revoke'`, () => {
+      const helpBranch = sliceFrom(block, "sub === 'help'", 1200)
+      expect(helpBranch).toMatch(/revoke|agent/i)
+    })
+  }
+})
+
+// ─── switchroomHelpText (welcome-text.ts) ────────────────────────────────────
+
+describe('switchroomHelpText — /vault grants entry', () => {
+  it('lists vault grants as a separate entry', async () => {
+    const { switchroomHelpText } = await import('../welcome-text.js')
+    const out = switchroomHelpText('assistant')
+    expect(out).toMatch(/vault.*grants/i)
+  })
+
+  it('grants entry mentions revoke capability', async () => {
+    const { switchroomHelpText } = await import('../welcome-text.js')
+    const out = switchroomHelpText('assistant')
+    expect(out).toMatch(/revoke/i)
+  })
+})

--- a/telegram-plugin/welcome-text.ts
+++ b/telegram-plugin/welcome-text.ts
@@ -316,6 +316,7 @@ export function switchroomHelpText(agentName: string): string {
     `<code>/vault status</code> — show broker state (locked/unlocked, uptime, key count)`,
     `<code>/vault unlock</code> — unlock the broker (prompts for passphrase via Telegram)`,
     `<code>/vault lock</code> — lock the broker`,
+    `<code>/vault grants [agent]</code> — list active capability grants (tap to revoke)`,
     `<code>/doctor</code> — health check (deps, services, MCP)`,
     `<code>/usage</code> — Pro/Max plan quota (5h + 7d windows)`,
     `<code>/switchroomhelp</code> — this help`,


### PR DESCRIPTION
Closes #228. Phase 4 of capability tokens (depends on #225, sibling to #161/#205).

## What ships

`/vault grants` (and `/vault grants <agent>` filter) lists active grants per agent with inline `[Revoke]` buttons. Tap → confirmation card with grant details → `[Confirm Revoke]` → broker `revoke_grant`, replies with `✅ Grant <id> revoked. Token file removed.` Audit-logs.

Wired in BOTH:
- `telegram-plugin/server.ts` (monolith polling mode)
- `telegram-plugin/gateway/gateway.ts` (persistent gateway mode)

Reuses the existing pending-op pattern (#158) for the revoke-confirmation step. Inline-keyboard `[Revoke]` buttons keyed by grant ID via `callback_data`.

## Tests

52 structural tests pinning behaviour at the file level across both deployment modes.

Co-authored-by: Claude <noreply@anthropic.com>