### PR TITLE
fix(telegram): retract answer-stream preview when reply path wins

### DIFF
--- a/telegram-plugin/answer-stream.ts
+++ b/telegram-plugin/answer-stream.ts
@@ -148,6 +148,18 @@ export interface AnswerStreamHandle {
   messageId(): number | undefined
   /** Stop the stream — cancels pending throttled edits. */
   stop(): void
+  /**
+   * Stop the stream AND delete any preliminary message that was already sent.
+   * Used when the reply/stream_reply tool takes over as the authoritative
+   * answer surface: the answer-lane preview must be retracted so the user
+   * sees only one message (the canonical stream_reply output) rather than a
+   * raw-markdown duplicate followed by the properly-formatted reply.
+   *
+   * Best-effort: if deleteMessage is not wired or the API call fails, the
+   * preliminary message is left in place (same behaviour as before the fix).
+   * Resolves after the delete attempt (or immediately when no message exists).
+   */
+  retract(): Promise<void>
 }
 
 // Module-level draft-id counter. Shared globally so concurrent answer streams
@@ -462,6 +474,32 @@ export function createAnswerStream(config: AnswerStreamConfig): AnswerStreamHand
     stop(): void {
       stopped = true
       cancelScheduled()
+    },
+
+    async retract(): Promise<void> {
+      // Stop immediately so no further edits or sends go out.
+      stopped = true
+      cancelScheduled()
+      // Wait for any in-flight operation to settle so we don't race a
+      // concurrent sendMessage that would leave a dangling message.
+      if (inFlight) {
+        try { await inFlight } catch { /* ignore */ }
+      }
+      // Delete the preliminary message if one was sent and deleteMessage
+      // is wired. Best-effort: failures are logged but not re-thrown.
+      const msgId = streamMsgId
+      if (msgId != null && config.deleteMessage != null) {
+        try {
+          await config.deleteMessage(chatId, msgId)
+          log?.(`answer-stream: retracted preliminary message (id=${msgId})`)
+        } catch (err) {
+          warn?.(
+            `answer-stream: retract deleteMessage failed (id=${msgId}): ${
+              err instanceof Error ? err.message : String(err)
+            }`,
+          )
+        }
+      }
     },
   }
 }

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -704,13 +704,20 @@ const robustApiCall = createRetryApiCall({
 
 // ─── Structured outbound log ──────────────────────────────────────────────
 function logOutbound(
-  path: 'reply' | 'stream_reply' | 'backstop' | 'pty_preview' | 'edit' | 'forward',
+  path: 'reply' | 'stream_reply' | 'backstop' | 'pty_preview' | 'edit' | 'forward' | 'answer_lane',
   chatId: string, messageId: number | null, chars: number, extra?: string,
+  opts?: { turnKey?: string; formatHint?: 'html' | 'markdownv2' | 'text'; textPreview?: string },
 ): void {
   const ts = new Date().toISOString()
+  const turnKeyPart = opts?.turnKey ? ` turnKey=${opts.turnKey}` : ''
+  const formatPart = opts?.formatHint ? ` formatHint=${opts.formatHint}` : ''
+  const previewPart = opts?.textPreview
+    ? ` text_preview="${opts.textPreview.replace(/\n/g, '\\n').slice(0, 80)}"`
+    : ''
   process.stderr.write(
     `telegram gateway [outbound] ${ts} path=${path} chat=${chatId} ` +
     `msg_id=${messageId ?? 'pending'} chars=${chars}` +
+    turnKeyPart + formatPart + previewPart +
     (extra ? ` ${extra}` : '') + '\n',
   )
 }
@@ -2049,6 +2056,8 @@ function handleSessionEvent(ev: SessionEvent): void {
                   ? { link_preview_options: params.link_preview_options }
                   : {}),
               }),
+            deleteMessage: (chatId, messageId) =>
+              bot.api.deleteMessage(chatId, messageId),
             log: (msg) => process.stderr.write(`telegram gateway: ${msg}\n`),
             warn: (msg) => process.stderr.write(`telegram gateway: ${msg}\n`),
             // Issue #203: route answer-lane events through the streaming
@@ -2157,8 +2166,21 @@ function handleSessionEvent(ev: SessionEvent): void {
               stream.stop()
             })
         } else {
-          // Reply path won — discard the answer-lane silently.
-          stream.stop()
+          // Reply path won — retract any preliminary answer-lane message
+          // so the user sees only the canonical stream_reply output.
+          // Issue #251: without retraction the answer-stream's raw-markdown
+          // preview (sent when captured text hit the minInitialChars threshold)
+          // coexists with the properly-rendered stream_reply message, producing
+          // a duplicate ~26 s apart with different formatting.
+          // retract() is best-effort: if deleteMessage fails the preliminary
+          // message lingers but no exception escapes to break turn_end.
+          void stream.retract().catch((err) => {
+            process.stderr.write(
+              `telegram gateway: answer-stream retract failed: ${
+                err instanceof Error ? err.message : String(err)
+              }\n`,
+            )
+          })
         }
       }
       if (currentSessionChatId == null) return

--- a/telegram-plugin/tests/answer-stream.test.ts
+++ b/telegram-plugin/tests/answer-stream.test.ts
@@ -590,6 +590,156 @@ describe('answer-stream — materialize() max-chars guard', () => {
   })
 })
 
+// ─── Issue #251: retract() — delete preliminary message when reply path wins ──
+describe('answer-stream — retract() (#251)', () => {
+  it('calls deleteMessage with (chatId, messageId) after a preliminary message was sent', async () => {
+    const sendMessage = makeSendMessage()
+    const editMessageText = makeEditMessageText()
+    const deleteMessage = vi.fn(async () => {})
+    const stream = createAnswerStream({
+      chatId: 'chat251',
+      isPrivateChat: false,
+      minInitialChars: 0,
+      throttleMs: 250,
+      sendMessage,
+      editMessageText,
+      deleteMessage,
+    })
+
+    // Push enough text to exceed the threshold and actually send a message
+    stream.update('x'.repeat(500))
+    await flushMicrotasks()
+
+    // Verify a message was sent and we know its id
+    expect(sendMessage).toHaveBeenCalledTimes(1)
+    const sentMsgId = (sendMessage.mock.results[0].value as Promise<{ message_id: number }>)
+    const resolved = await sentMsgId
+    expect(typeof resolved.message_id).toBe('number')
+
+    const msgId = stream.messageId()
+    expect(typeof msgId).toBe('number')
+
+    // Now retract — simulates the reply path winning
+    await stream.retract()
+
+    expect(deleteMessage).toHaveBeenCalledTimes(1)
+    expect(deleteMessage).toHaveBeenCalledWith('chat251', msgId)
+  })
+
+  it('does not call deleteMessage when no preliminary message was sent', async () => {
+    const sendMessage = makeSendMessage()
+    const editMessageText = makeEditMessageText()
+    const deleteMessage = vi.fn(async () => {})
+    const stream = createAnswerStream({
+      chatId: 'chat251',
+      isPrivateChat: false,
+      // High threshold so the text below never triggers a send
+      minInitialChars: 5000,
+      throttleMs: 250,
+      sendMessage,
+      editMessageText,
+      deleteMessage,
+    })
+
+    // Short text — stays below minInitialChars, no message sent
+    stream.update('x'.repeat(100))
+    vi.advanceTimersByTime(1000)
+    await flushMicrotasks()
+
+    expect(sendMessage).not.toHaveBeenCalled()
+    expect(stream.messageId()).toBeUndefined()
+
+    // retract() should be a no-op — no delete attempt
+    await stream.retract()
+
+    expect(deleteMessage).not.toHaveBeenCalled()
+  })
+
+  it('retract() stops the stream — subsequent update() calls are no-ops', async () => {
+    const sendMessage = makeSendMessage()
+    const editMessageText = makeEditMessageText()
+    const deleteMessage = vi.fn(async () => {})
+    const stream = createAnswerStream({
+      chatId: 'chat251',
+      isPrivateChat: false,
+      minInitialChars: 0,
+      throttleMs: 250,
+      sendMessage,
+      editMessageText,
+      deleteMessage,
+    })
+
+    // Establish an initial message
+    stream.update('hello world')
+    await flushMicrotasks()
+    expect(sendMessage).toHaveBeenCalledTimes(1)
+
+    // Retract
+    await stream.retract()
+
+    // Any subsequent update should be silently dropped
+    sendMessage.mockClear()
+    editMessageText.mockClear()
+    stream.update('this should be ignored after retract')
+    vi.advanceTimersByTime(2000)
+    await flushMicrotasks()
+
+    expect(sendMessage).not.toHaveBeenCalled()
+    expect(editMessageText).not.toHaveBeenCalled()
+  })
+
+  it('retract() is best-effort — deleteMessage failure does not throw', async () => {
+    const sendMessage = makeSendMessage()
+    const editMessageText = makeEditMessageText()
+    const deleteMessage = vi.fn(async () => {
+      throw new Error('deleteMessage: message to delete not found')
+    })
+    const warn = vi.fn()
+    const stream = createAnswerStream({
+      chatId: 'chat251',
+      isPrivateChat: false,
+      minInitialChars: 0,
+      throttleMs: 250,
+      sendMessage,
+      editMessageText,
+      deleteMessage,
+      warn,
+    })
+
+    stream.update('x'.repeat(500))
+    await flushMicrotasks()
+    expect(sendMessage).toHaveBeenCalledTimes(1)
+
+    // retract() must not throw even when deleteMessage rejects
+    await expect(stream.retract()).resolves.toBeUndefined()
+
+    // The failure should have been logged via warn
+    expect(warn).toHaveBeenCalled()
+    expect(warn.mock.calls.some((c) => /retract.*failed|deleteMessage.*failed/i.test(String(c[0])))).toBe(true)
+  })
+
+  it('retract() without deleteMessage wired is a no-op (no error)', async () => {
+    const sendMessage = makeSendMessage()
+    const editMessageText = makeEditMessageText()
+    const stream = createAnswerStream({
+      chatId: 'chat251',
+      isPrivateChat: false,
+      minInitialChars: 0,
+      throttleMs: 250,
+      sendMessage,
+      editMessageText,
+      // deleteMessage intentionally omitted
+    })
+
+    stream.update('hello world')
+    await flushMicrotasks()
+    expect(sendMessage).toHaveBeenCalledTimes(1)
+
+    // retract() with no deleteMessage callback — should resolve without error
+    await expect(stream.retract()).resolves.toBeUndefined()
+  })
+})
+
 // ─── Issue #203: onMetric callback ──────────────────────────────────────────
 describe('answer-stream — onMetric callback (#203)', () => {
   it('fires answer_lane_update on first sendMessage (non-DM, message transport)', async () => {


### PR DESCRIPTION
## Summary

- **Root cause**: The gateway has two surfaces that publish an assistant reply — the answer-stream lane (PTY-scraped raw markdown, sent when accumulated text crosses the `minInitialChars` threshold) and the canonical `stream_reply`/`reply` MCP tool path (properly-formatted HTML). When both fired in the same turn, `turn_end` called `stream.stop()` which cancelled future edits but left the preliminary message in Telegram. The canonical reply landed ~26s later as a separate message, producing a duplicate with mismatched formatting — the exact symptom reported in msg_id 7981/7982 in #251.

- **Fix**: Added a `retract()` method to `AnswerStreamHandle` (`telegram-plugin/answer-stream.ts`) that stops the stream and then calls an injected `deleteMessage` callback to remove the preliminary message. Wired `deleteMessage: (chatId, msgId) => bot.api.deleteMessage(chatId, msgId)` into `createAnswerStream` in the gateway. In the `turn_end` handler, the `else` branch (reply path won) now calls `stream.retract()` instead of `stream.stop()`, cleanly removing the dangling preview.

- **Best-effort semantics**: If `deleteMessage` is not injected or the API call fails, the preliminary message lingers (same behaviour as before the fix) — the error is logged via `warn()` but never re-thrown, so `turn_end` is never disrupted.

- **Regression test**: 5 new unit tests added to `telegram-plugin/tests/answer-stream.test.ts` covering: `deleteMessage` called with correct `(chatId, messageId)`; no delete when no preliminary message was sent; `update()` is a no-op after `retract()`; failure of `deleteMessage` does not throw (best-effort); `retract()` without `deleteMessage` wired resolves cleanly.

- **Build & tests**: `bun run build` is clean; all 27 answer-stream tests pass (22 pre-existing + 5 new); full `bun test` suite passes with no regressions introduced by these changes (one pre-existing xterm `DisposableStore` error in `silent-reply-guard.test.ts` is unrelated and present on `main`).

- **PII gate**: `grep -c "/home/" dist/cli/switchroom.js` returns 4 in both the worktree and `main` baseline — no new absolute path bake-ins.

- **Evidence**: Duplicate messages visible in #251 (msg_id 7981 raw-markdown preview, msg_id 7982 stream_reply HTML, same turn) — `retract()` eliminates the first.

Closes #251

🤖 Generated with [Claude Code](https://claude.com/claude-code)