### PR TITLE
fix(telegram): add /vault to slash-menu (PR #221 followup)

### DIFF
--- a/telegram-plugin/tests/welcome-text.test.ts
+++ b/telegram-plugin/tests/welcome-text.test.ts
@@ -312,7 +312,9 @@ describe("TELEGRAM_MENU_COMMANDS (slash-menu shape)", () => {
     // These used to be in the menu and are now handler-only (still
     // typable, but not in autocomplete). If they sneak back in, the
     // menu has regressed to pre-trim length.
-    for (const droppedFromMenu of ["vault", "grant", "dangerous", "permissions", "switchroomstart", "topics", "memory", "pins-status", "interrupt"]) {
+    // Note: /vault was re-added to the menu in PR #254 — users couldn't
+    // discover the vault subcommands without typing the verb manually.
+    for (const droppedFromMenu of ["grant", "dangerous", "permissions", "switchroomstart", "topics", "memory", "pins-status", "interrupt"]) {
       expect(names, `/${droppedFromMenu} should NOT be in the trimmed Telegram menu`).not.toContain(droppedFromMenu);
     }
   });

--- a/telegram-plugin/welcome-text.ts
+++ b/telegram-plugin/welcome-text.ts
@@ -254,6 +254,12 @@ export const TELEGRAM_MENU_COMMANDS = [
   { command: "logs", description: "Show recent agent logs" },
   { command: "doctor", description: "Health check (deps, services, MCP)" },
   { command: "usage", description: "Pro/Max plan quota (5h + 7d windows)" },
+  // Vault — secrets + capability grants. /vault is a top-level command
+  // dispatching subcommands (list, get, set, delete, status, unlock, lock,
+  // grant, grants). Surfaced in the menu so mobile users can tap-to-pick
+  // instead of needing to know the verb (PR #221 added the handlers but
+  // forgot the menu entry, so /vault was effectively invisible).
+  { command: "vault", description: "Manage vault secrets + capability grants" },
   // Auth / subscription management. These are deliberately in the menu
   // rather than only typable — the whole point of the auth surface is
   // that it has to work from mobile without any other tooling


### PR DESCRIPTION
## Summary

PR #221 added the `/vault` command handler (`server.ts:4464`) and 8 subcommands (list, get, set, delete, status, unlock, lock, grant, grants) but forgot to list `/vault` in `TELEGRAM_MENU_COMMANDS`. Result: users could type `/vault` manually, but the slash-menu picker didn't surface it — effectively invisible on mobile.

## Change

One-line addition to `telegram-plugin/welcome-text.ts`. Foreman re-registers via `setMyCommands` on next agent boot, so existing fleet picks it up after restart.

## Test plan
- [ ] Restart an agent, open Telegram chat, tap the slash menu — `/vault` should appear with description "Manage vault secrets + capability grants"
- [ ] Tap it → bot expands to subcommand help (existing `bot.command('vault', ...)` handler at `server.ts:4464`)