### PR TITLE
fix(tests): unblock CI by fixing auth.stale-token-fix + token-helpers

### DIFF
--- a/tests/auth.stale-token-fix.test.ts
+++ b/tests/auth.stale-token-fix.test.ts
@@ -297,9 +297,11 @@ describe.runIf(tmuxAvailable())("Fix 2 — submitAuthCode unlinks credentials.js
       credentialsMtimeAtStart: staleMtime, // gate blocks the stale file
     });
 
-    // 4. Live, harmless tmux session so tmuxSessionExists returns true and
-    //    `tmux send-keys` has somewhere to deliver the code. Detached, no-op.
-    execSync(`tmux new-session -d -s ${sessionName} "sleep 30"`);
+    // 4. Live tmux session so tmuxSessionExists returns true and
+    //    `tmux send-keys` has somewhere to deliver the code.
+    //    The pane must show "Paste code here" so probeForCodePrompt passes;
+    //    otherwise submitAuthCode returns pane-not-ready before checking logs.
+    execSync(`tmux new-session -d -s ${sessionName} "printf 'Paste code here\\n'; sleep 30"`);
 
     const result = submitAuthCode(agentName, agentDir, "BROWSERCODE", undefined, {
       pollIntervalMs: 10,

--- a/tests/token-helpers.test.ts
+++ b/tests/token-helpers.test.ts
@@ -150,9 +150,14 @@ describe.skipIf(runSkipCondition)("token-helpers/google-cal-token.sh", () => {
     );
 
     configPath = join(tmpDir, "switchroom.yaml");
+    // Point vault.broker.socket to a non-existent path so the CLI bypasses
+    // the live system broker and falls through to direct vault access.
+    // Without this, `switchroom vault get` hits the real broker daemon running
+    // on ~/.switchroom/vault-broker.sock, which is locked and rejects non-TTY
+    // callers with VAULT-BROKER-DENIED.
     writeFileSync(
       configPath,
-      `switchroom:\n  version: 1\n  agents_dir: ${tmpDir}/agents\nvault:\n  path: ${vaultPath}\ntelegram:\n  bot_token: x\n  forum_chat_id: "-1"\nagents: {}\n`
+      `switchroom:\n  version: 1\n  agents_dir: ${tmpDir}/agents\nvault:\n  path: ${vaultPath}\n  broker:\n    socket: ${tmpDir}/no-broker.sock\ntelegram:\n  bot_token: x\n  forum_chat_id: "-1"\nagents: {}\n`
     );
 
     // Shim that substitutes `switchroom` on PATH with the repo's
@@ -319,9 +324,14 @@ describe.skipIf(runSkipCondition)("token-helpers/ms-graph-token.sh", () => {
     setStringSecret(passphrase, vaultPath, "ms-graph-client-id", "ms-cid");
 
     configPath = join(tmpDir, "switchroom.yaml");
+    // Point vault.broker.socket to a non-existent path so the CLI bypasses
+    // the live system broker and falls through to direct vault access.
+    // Without this, `switchroom vault get` hits the real broker daemon running
+    // on ~/.switchroom/vault-broker.sock, which is locked and rejects non-TTY
+    // callers with VAULT-BROKER-DENIED.
     writeFileSync(
       configPath,
-      `switchroom:\n  version: 1\n  agents_dir: ${tmpDir}/agents\nvault:\n  path: ${vaultPath}\ntelegram:\n  bot_token: x\n  forum_chat_id: "-1"\nagents: {}\n`
+      `switchroom:\n  version: 1\n  agents_dir: ${tmpDir}/agents\nvault:\n  path: ${vaultPath}\n  broker:\n    socket: ${tmpDir}/no-broker.sock\ntelegram:\n  bot_token: x\n  forum_chat_id: "-1"\nagents: {}\n`
     );
 
     shimDir = join(tmpDir, "bin");


### PR DESCRIPTION
## Summary

Buildkite has been red on `main` since at least PR #194's merge (2026-04-28) due to two test failures in vitest. PR #252 addressed the bun:sqlite-related failures; this PR addresses the remaining two.

### `tests/auth.stale-token-fix.test.ts` — stale test

The tmux-gated e2e test spun up `sleep 30` as its dummy session, but `probeForCodePrompt()` (added in a later commit) now requires "Paste code here" to be visible in the pane before injecting the auth code. Without it, the probe returns pane-not-ready and the test never reaches the log-file-channel token detection path it was exercising.

**Fix:** prepend `echo "Paste code here"` before the sleep so the probe passes.

### `tests/token-helpers.test.ts` — environment issue

The vault-broker daemon is running on the dev machine at `~/.switchroom/vault-broker.sock`. `switchroom vault get` tries the broker first by default; the broker is locked and stdin is not a TTY in the vitest subprocess, so it exits 3 with `VAULT-BROKER-DENIED` before ever reaching the `SWITCHROOM_VAULT_PASSPHRASE` env-var path.

**Fix:** set `vault.broker.socket` in each test's inline config to a non-existent path so the broker lookup returns "unreachable" and falls through to direct vault decrypt with the passphrase env var the tests already provide.

## Notes

- Neither change touches production code.
- The bun:sqlite/bun:test failures in vault-broker and telegram-plugin test files were addressed separately in PR #252 (orthogonal — merging in either order works).

## Test plan
- [ ] `bunx vitest run tests/auth.stale-token-fix.test.ts tests/token-helpers.test.ts` — both green
- [ ] Full vitest suite green (modulo the bun:sqlite excludes from #252)
- [ ] Buildkite green on this PR