### PR TITLE
fix(#256): remove sub-agent Telegram visibility (prompt + tool denylist)

### DIFF
--- a/examples/switchroom.yaml
+++ b/examples/switchroom.yaml
@@ -61,6 +61,8 @@ defaults:
       isolation: worktree
       maxTurns: 50
       color: blue
+      disallowedTools:
+        - "mcp__switchroom-telegram__*"
       prompt: |
         You are a worker sub-agent. Implement the task described in your
         prompt precisely and completely. Commit your work when done.
@@ -71,6 +73,8 @@ defaults:
       model: haiku
       background: true
       color: green
+      disallowedTools:
+        - "mcp__switchroom-telegram__*"
       prompt: |
         You are a research sub-agent. Investigate the topic described
         in your prompt thoroughly. Return structured findings — not
@@ -80,6 +84,8 @@ defaults:
       description: "Reviews code, plans, documents for quality, correctness, and completeness. Use after a worker finishes or before shipping."
       model: sonnet
       color: purple
+      disallowedTools:
+        - "mcp__switchroom-telegram__*"
       prompt: |
         You are a review sub-agent. Examine the work described in
         your prompt for correctness, completeness, security, and

--- a/src/agents/sub-agent-telegram-prompt.test.ts
+++ b/src/agents/sub-agent-telegram-prompt.test.ts
@@ -5,6 +5,8 @@ import {
   shouldAppendTelegramProgressGuidance,
 } from './sub-agent-telegram-prompt.js'
 
+// shouldAppendTelegramProgressGuidance is kept for call-site compatibility
+// but its result is no longer acted on by applyTelegramProgressGuidance (#256).
 describe('shouldAppendTelegramProgressGuidance', () => {
   it('is true when telegram is enabled and a chat id is known', () => {
     expect(
@@ -40,6 +42,7 @@ describe('shouldAppendTelegramProgressGuidance', () => {
   })
 })
 
+// buildTelegramProgressGuidance is deprecated but kept for compatibility.
 describe('buildTelegramProgressGuidance', () => {
   it('embeds the chat id verbatim', () => {
     const out = buildTelegramProgressGuidance({ defaultChatId: '12345' })
@@ -62,6 +65,8 @@ describe('buildTelegramProgressGuidance', () => {
 })
 
 describe('applyTelegramProgressGuidance', () => {
+  // --- Core contract: body is ALWAYS returned unchanged (#256) ---
+
   it('returns the body unchanged when telegram is disabled', () => {
     const body = 'You are the worker sub-agent.'
     expect(
@@ -82,25 +87,43 @@ describe('applyTelegramProgressGuidance', () => {
     ).toBe(body)
   })
 
-  it('appends the guidance block when telegram + chat id are present', () => {
+  it('returns the body unchanged even when telegram + chat id are both present (#256 regression)', () => {
+    // Previously this case appended the guidance block. After #256 it must NOT.
     const body = 'You are the worker sub-agent.'
     const out = applyTelegramProgressGuidance(body, {
       telegramEnabled: true,
       defaultChatId: '8248703757',
     })
-    expect(out).toContain(body)
-    expect(out).toContain('Telegram visibility')
-    expect(out).toContain('8248703757')
+    expect(out).toBe(body)
   })
 
-  it('trims trailing whitespace before appending so the join is clean', () => {
+  it('does not append any "Telegram visibility" content regardless of args (#256 regression)', () => {
+    // Regression guard: if a future change accidentally re-enables the feature
+    // this test will catch it.
+    const body = 'You are the worker sub-agent.'
+
+    const cases = [
+      { telegramEnabled: true, defaultChatId: '8248703757' },
+      { telegramEnabled: true, defaultChatId: '1' },
+      { telegramEnabled: false, defaultChatId: '8248703757' },
+      { telegramEnabled: false, defaultChatId: undefined },
+    ] as const
+
+    for (const args of cases) {
+      const out = applyTelegramProgressGuidance(body, args)
+      expect(out).toBe(body)
+      expect(out).not.toContain('Telegram visibility')
+      expect(out).not.toContain('mcp__switchroom-telegram__progress_update')
+    }
+  })
+
+  it('does not mutate trailing whitespace in the body', () => {
+    // Ensure the function is truly a no-op — no trimming or normalisation.
     const body = 'You are the worker.\n\n\n  '
     const out = applyTelegramProgressGuidance(body, {
       telegramEnabled: true,
       defaultChatId: '1',
     })
-    // No triple-blank between body and the appended block.
-    expect(out).not.toMatch(/\n\n\n\n## Telegram/)
-    expect(out).toMatch(/You are the worker\.\n\n## Telegram/)
+    expect(out).toBe(body)
   })
 })

--- a/src/agents/sub-agent-telegram-prompt.ts
+++ b/src/agents/sub-agent-telegram-prompt.ts
@@ -1,24 +1,31 @@
 /**
- * Telegram progress-update guidance appended to sub-agent prompts (#32).
+ * Telegram progress-update guidance for sub-agent prompts — DISABLED (#256).
  *
- * When the parent agent runs in a Telegram-rooted session, sub-agents
- * spawned via the Claude Code Agent tool are separate processes. Their
- * tool calls and intermediate output don't flow back into the parent's
- * progress card, so from the Telegram user's perspective a long-running
- * sub-agent looks like a black box: "spawning worker" → silence → final
- * result.
+ * This module previously appended a "## Telegram visibility" block to every
+ * sub-agent prompt when the parent agent ran in a Telegram-rooted session
+ * (originally introduced in #32). That block instructed sub-agents to call
+ * `mcp__switchroom-telegram__progress_update` so the user could see live
+ * progress from parallel workers.
  *
- * Cheapest fix (issue #32 option 1): tell the sub-agent it can post its
- * own progress via the `mcp__switchroom-telegram__progress_update` tool
- * to the chat the parent is serving. The user's primary chat (DM) is
- * baked in as a default; sub-agents can also infer the live chat from
- * the parent's recent messages if they're handling forum topics.
+ * Removed in #256 because:
+ *  - The parent's progress card already provides equivalent visibility:
+ *    sub-agent tool counts and descriptions render there automatically.
+ *  - With parallel workers each posting "Got it…" and "Done with X…" the
+ *    Telegram thread became noisy and ate the user's attention budget.
+ *  - The JTBD (user sees worker activity) is preserved through the progress
+ *    card; the spam is gone.
+ *
+ * The exported function signatures are kept intact so callers in scaffold.ts
+ * continue to compile without changes.
  */
 
 /**
  * Returns true when the agent is wired up with a Telegram channel and
- * we have at least one chat to address. Anything else (no telegram, no
- * chats) means the addendum is meaningless and should be omitted.
+ * we have at least one chat to address.
+ *
+ * @deprecated The result of this function is no longer acted on —
+ *   `applyTelegramProgressGuidance` always returns the body unchanged (#256).
+ *   Kept for call-site compatibility.
  */
 export function shouldAppendTelegramProgressGuidance(args: {
   telegramEnabled: boolean
@@ -28,8 +35,10 @@ export function shouldAppendTelegramProgressGuidance(args: {
 }
 
 /**
- * Markdown block to append to a sub-agent's prompt body when the parent
- * runs in a Telegram-rooted session.
+ * Markdown block that was previously appended to a sub-agent's prompt body.
+ *
+ * @deprecated No longer appended to any prompt (#256). Kept for call-site
+ *   compatibility.
  */
 export function buildTelegramProgressGuidance(args: {
   defaultChatId: string
@@ -53,15 +62,20 @@ The default chat is **${args.defaultChatId}** (the parent agent's primary user).
 }
 
 /**
- * Combine an existing sub-agent prompt body with the Telegram progress
- * guidance when applicable. Pure: returns the body unchanged when
- * telegram isn't configured.
+ * Returns the sub-agent prompt body unchanged.
+ *
+ * Previously appended Telegram progress guidance when the parent ran in a
+ * Telegram-rooted session. Disabled in #256: visibility is already provided
+ * by the parent's progress card, and the per-worker check-in messages were
+ * producing noise that hurt the user's attention budget.
+ *
+ * The `args` parameter is accepted but ignored so call sites in scaffold.ts
+ * continue to compile without modification.
  */
 export function applyTelegramProgressGuidance(
   body: string,
   args: { telegramEnabled: boolean; defaultChatId: string | undefined },
 ): string {
-  if (!shouldAppendTelegramProgressGuidance(args)) return body
-  const trimmed = body.replace(/\s+$/, '')
-  return trimmed + buildTelegramProgressGuidance({ defaultChatId: args.defaultChatId! })
+  // Feature disabled (#256): always return body unchanged.
+  return body
 }


### PR DESCRIPTION
## Summary

Closes #256. Sub-agents inheriting the Telegram MCP and emitting "Got it..." progress messages was producing chat noise — especially with parallel workers. The user's JTBD ("see what workers are doing") is already satisfied by the parent's progress card (sub-agent tool counts + descriptions render automatically). The visibility prompt block was redundant; the spam was real.

## Changes

1. **Prompt-side neuter** — `src/agents/sub-agent-telegram-prompt.ts`: `applyTelegramProgressGuidance()` now returns the body unchanged regardless of input. Other exports kept with `@deprecated` notices so `scaffold.ts` continues compiling.

2. **Tool denylist defense-in-depth** — `examples/switchroom.yaml`: added `disallowedTools: ["mcp__switchroom-telegram__*"]` to each of `worker`, `researcher`, `reviewer` subagent blocks. Even if a future prompt tells a sub-agent to call the tool, the harness denies it.

3. **Test updates** — `src/agents/sub-agent-telegram-prompt.test.ts`: replaced the "appends guidance when enabled" assertion with a regression test that asserts no "Telegram visibility" content is appended for any combination of inputs.

## Operator action required after merge

Run `switchroom agent reconcile` to regenerate `.claude/agents/*.md` for all live agents. New behavior takes effect after agent restart.

## Test plan
- [x] `bunx vitest run src/agents/sub-agent-telegram-prompt.test.ts` — 11/11 green
- [x] `bun lint` — clean
- [ ] After merge + reconcile + restart, dispatch a parallel worker batch and confirm zero Telegram noise from sub-agents

## Related
- #259 (false 'Ended without reply' trigger on autonomous wakeup turns — adjacent UX hygiene)