### PR TITLE
fix(lint): import afterEach in rename-orchestrator.test.ts

### DIFF
--- a/src/agents/rename-orchestrator.test.ts
+++ b/src/agents/rename-orchestrator.test.ts
@@ -18,7 +18,7 @@
  *   - yaml rename logic (renameAgentInConfig helper)
  */
 
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { mkdtempSync, writeFileSync, rmSync, mkdirSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";


### PR DESCRIPTION
Unblocks the Type-check step in Buildkite. Two pre-existing TS2304 errors on main: `src/agents/rename-orchestrator.test.ts` uses `afterEach` at lines 193 and 314 but only imports it as a hook name — not as a value. One-line fix: add `afterEach` to the vitest import. Unblocks lint for all current open PRs.