### PR TITLE
fix(#265 part 1): assertSafeAgentName before vault grant token-write

### DIFF
--- a/telegram-plugin/server.ts
+++ b/telegram-plugin/server.ts
@@ -4271,6 +4271,16 @@ function parseGrantDuration(s: string): number | null {
   return m[2]!.toLowerCase() === 'd' ? n * 86400 : n * 3600
 }
 
+/** Validate that a string looks like a safe agent/resource name.
+ *  Agent names should be alphanumeric with hyphens/underscores only.
+ *  Prevents path traversal when joining agent name into a filesystem path.
+ *  Defense in depth — called before any path join using a user-supplied name. */
+function assertSafeAgentName(name: string): void {
+  if (!/^[a-zA-Z0-9_-]{1,64}$/.test(name) && name !== 'all') {
+    throw new Error(`invalid agent name: ${name}`)
+  }
+}
+
 /** Format seconds as a human-readable expiry label. */
 function formatGrantExpiry(ttlSeconds: number | null, now: Date = new Date()): string {
   if (ttlSeconds === null) return 'Never'
@@ -4419,6 +4429,9 @@ async function grantWizardConfirm(ctx: Context, chatId: string, state: Extract<P
 /** Execute the grant: call broker mint_grant, write token, reply. */
 async function executeGrantWizard(ctx: Context, chatId: string, state: Extract<PendingVaultOp, { kind: 'grant-wizard' }>): Promise<void> {
   pendingVaultOps.delete(chatId)
+  // Guard against path traversal before any I/O: state.agent flows from the
+  // vg:agent:<name> callback_data which is user-controlled input.
+  try { assertSafeAgentName(state.agent!) } catch { return }
   const result = await mintGrantViaBroker({
     agent: state.agent!,
     keys: state.selectedKeys!,


### PR DESCRIPTION
## Summary

Partial fix for #265 (vault grant wizard followups flagged during PR #262 review). Closes the path-traversal defense-in-depth gap in **server.ts** only.

## Change

`executeGrantWizard` (server.ts) now calls a new local helper `assertSafeAgentName(state.agent!)` before any path I/O. The helper uses the same regex (`/^[a-zA-Z0-9_-]{1,64}$/`) that `auth-slot-parser.ts` uses for its parallel \`assertSafeAgentNameForParser\` guard.

## Why partial

Issue #265 had 3 sub-items. This PR addresses 1a only:

| | Item | Status |
|--|--|--|
| 1a | server.ts \`assertSafeAgentName\` | ✅ this PR |
| 1b | gateway.ts \`assertSafeAgentName\` mirror | ⏳ blocked on PR #262 (which adds \`executeGrantWizard\` to gateway.ts) |
| 2 | Double \`answerCallbackQuery\` swallowing 'select at least one key' toast | ⏳ separate PR |
| 3 | Gateway test coverage parity in \`vault-grant-wizard.test.ts\` | ⏳ separate PR |

Splitting keeps the diffs reviewable. 1b will follow once #262 lands. 2 + 3 will batch in their own PR.

## Severity

Minor — \`callback_data\` is bot-set rather than user-controlled, so the path-traversal vector requires the bot itself to be subverted. But defense-in-depth is cheap, and this matches the pattern \`auth-slot-parser.ts\` already uses for arbitrary-string agent names.

## Test plan
- [ ] Buildkite green (no new tests; this is a defensive guard that throws on invalid input)
- [ ] After merge: existing /vault grant wizard E2E flow still works (the regex passes for all real agent names: clerk, lawgpt, gymbro, finn, klanker)