### PR TITLE
fix(#259): skip silent-end card on autonomous wakeup turns

### DIFF
--- a/telegram-plugin/progress-card-driver.ts
+++ b/telegram-plugin/progress-card-driver.ts
@@ -288,6 +288,14 @@ interface PerChatState {
    *   - delivered>0             → real success
    */
   outboundDeliveredCount: number
+  /**
+   * Issue #259: true when the turn was started by an autonomous wakeup
+   * sentinel (`<<autonomous-loop>>` or `<<autonomous-loop-dynamic>>`).
+   * When set, the "🙊 Ended without reply" silent-end warning is
+   * suppressed — autonomous turns intentionally produce no user-visible
+   * reply and ending without one is entirely expected.
+   */
+  wasAutonomous: boolean
 }
 
 export interface ProgressDriver {
@@ -627,7 +635,8 @@ export function createProgressDriver(config: ProgressDriverConfig): ProgressDriv
         // is in flight, "no reply yet" is normal; the card stays in
         // "Working…". The renderer applies the same gate, so passing the
         // unconditional flag here is safe.
-        const silentEnd = !cs.replyToolCalled
+        // Issue #259: suppress for autonomous wakeup turns (no reply is expected).
+        const silentEnd = !cs.replyToolCalled && !cs.wasAutonomous
         // Issue #137: agent called reply/stream_reply (replyToolCalled=true)
         // but the actual outbound never landed (recordOutboundDelivered was
         // never called for this card). Distinct from silentEnd because the
@@ -737,7 +746,10 @@ export function createProgressDriver(config: ProgressDriverConfig): ProgressDriv
     }
     const taskNum = taskNumFor(chatState)
     const stuckMs = Math.max(0, now() - chatState.lastEventAt)
-    const silentEnd = !chatState.replyToolCalled
+    // Issue #259: autonomous wakeup turns never produce a reply by design —
+    // suppress the silent-end warning so the card renders "✅ Done" instead
+    // of "🙊 Ended without reply" when ScheduleWakeup / CronCreate fires.
+    const silentEnd = !chatState.replyToolCalled && !chatState.wasAutonomous
     const replyNotDelivered =
       chatState.replyToolCalled && chatState.outboundDeliveredCount === 0
     const html = render(
@@ -954,6 +966,7 @@ export function createProgressDriver(config: ProgressDriverConfig): ProgressDriv
           apiFailures: { consecutive4xx: 0, lastError: null, terminal: false },
           replyToolCalled: false,
           outboundDeliveredCount: 0,
+          wasAutonomous: false,
         }
         chats.set(slot.turnKey, chatState)
         if (event.isSync) {
@@ -1127,13 +1140,21 @@ export function createProgressDriver(config: ProgressDriverConfig): ProgressDriv
         chatId,
         threadId,
       )
-      // Stash the source message_id on the newly-created PerChatState so
-      // flush() can pass it to the emit callback on the first send only.
-      // Do this AFTER ingest() so the new PerChatState entry is in chats.
-      if (replyToMessageId != null && currentTurnKey != null) {
+      // Stash the source message_id and autonomous flag on the newly-created
+      // PerChatState so flush() can use them. Do this AFTER ingest() so the
+      // new PerChatState entry is in chats.
+      if (currentTurnKey != null) {
         const cs = chats.get(currentTurnKey)
         if (cs != null && cs.chatId === chatId) {
-          cs.replyToMessageId = replyToMessageId
+          if (replyToMessageId != null) {
+            cs.replyToMessageId = replyToMessageId
+          }
+          // Issue #259: autonomous wakeup turns (ScheduleWakeup / CronCreate
+          // sentinel) never produce a user-visible reply by design. Suppress
+          // the "🙊 Ended without reply" warning for these turns.
+          if (userText.startsWith('<<autonomous-loop')) {
+            cs.wasAutonomous = true
+          }
         }
       }
     },

--- a/telegram-plugin/tests/progress-card-driver.test.ts
+++ b/telegram-plugin/tests/progress-card-driver.test.ts
@@ -2488,3 +2488,45 @@ describe('progress-card driver — API failure escalation', () => {
     expect(emits.length).toBeGreaterThan(emitsAfterTransient)
   })
 })
+
+describe('issue #259: autonomous wakeup turns skip silent-end warning', () => {
+  it('<<autonomous-loop-dynamic>> turn ending without reply renders ✅ Done, not 🙊', () => {
+    const { driver, emits } = harness()
+    // Simulate a ScheduleWakeup turn — the user-prompt body is the sentinel.
+    driver.startTurn({ chatId: 'c1', userText: '<<autonomous-loop-dynamic>>' })
+    // Agent runs some tools but never calls reply/stream_reply (normal for
+    // autonomous turns that just do background work and exit).
+    driver.ingest({ kind: 'tool_use', toolName: 'Bash' }, 'c1')
+    driver.ingest({ kind: 'tool_result', toolUseId: 'a', toolName: 'Bash' }, 'c1')
+    emits.length = 0
+    driver.ingest({ kind: 'turn_end', durationMs: 500 }, 'c1')
+    expect(emits).toHaveLength(1)
+    expect(emits[0].done).toBe(true)
+    // Must NOT show the silent-end warning for autonomous turns.
+    expect(emits[0].html).not.toContain('🙊')
+    expect(emits[0].html).not.toContain('Ended without reply')
+    expect(emits[0].html).not.toContain("Agent ran tools but didn't send a reply")
+    // Must render as normal completion.
+    expect(emits[0].html).toContain('✅ <b>Done</b>')
+  })
+
+  it('<<autonomous-loop>> (CronCreate variant) also suppresses silent-end', () => {
+    const { driver, emits } = harness()
+    driver.startTurn({ chatId: 'c1', userText: '<<autonomous-loop>>' })
+    emits.length = 0
+    driver.ingest({ kind: 'turn_end', durationMs: 100 }, 'c1')
+    expect(emits[0].html).not.toContain('🙊')
+    expect(emits[0].html).toContain('✅ <b>Done</b>')
+  })
+
+  it('non-autonomous turns (real Telegram messages) still show 🙊 when no reply fires', () => {
+    const { driver, emits } = harness()
+    driver.startTurn({ chatId: 'c1', userText: 'check the logs' })
+    driver.ingest({ kind: 'tool_use', toolName: 'Bash' }, 'c1')
+    driver.ingest({ kind: 'tool_result', toolUseId: 'a', toolName: 'Bash' }, 'c1')
+    emits.length = 0
+    driver.ingest({ kind: 'turn_end', durationMs: 500 }, 'c1')
+    expect(emits[0].html).toContain('🙊 <b>Ended without reply</b>')
+    expect(emits[0].html).not.toContain('✅ <b>Done</b>')
+  })
+})


### PR DESCRIPTION
## Summary

- Detection signal is the `<<autonomous-loop>>` / `<<autonomous-loop-dynamic>>` sentinel in the user-prompt body (set by `ScheduleWakeup` / `CronCreate`). No IPC plumbing or env vars needed — just a string prefix check.
- `startTurn()` sets `wasAutonomous = true` on the `PerChatState` when `userText.startsWith('<<autonomous-loop')`.
- `flush()` and the heartbeat set `silentEnd = false` when `wasAutonomous` is true, so the card renders `✅ Done` instead of `🙊 Ended without reply`.
- The warning still fires correctly for genuinely-stuck Telegram turns where a real user is waiting.
- Closes #259.

## Files changed

- `telegram-plugin/progress-card-driver.ts` (+35, -7): add `wasAutonomous: boolean` to `PerChatState`, set it in `startTurn()`, guard both `silentEnd` expressions in `flush()` and the heartbeat.
- `telegram-plugin/tests/progress-card-driver.test.ts` (+42): three new tests covering `<<autonomous-loop-dynamic>>`, `<<autonomous-loop>>` (CronCreate variant), and regression assertion that real user turns still show the warning when no reply fires.

## Test plan

- [x] `bun lint` — passes (tsc --noEmit, zero output)
- [x] `bunx vitest run telegram-plugin/tests/progress-card-driver.test.ts` — 107 tests pass
- [ ] Verify on a live agent: trigger a `ScheduleWakeup` autonomous turn, confirm the progress card shows `✅ Done` with no `🙊` warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)