### PR TITLE
feat(agents): worktree primitives — schema, modules, env injection

### DIFF
--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -49,6 +49,14 @@ import {
   createMinimalClaudeConfig,
   loadUserConfig,
 } from "../setup/onboarding.js";
+import { ensureBareClone, bareClonePath } from "../repos/bare-clone.js";
+import {
+  ensureAgentWorktree,
+  removeAgentWorktree,
+  listAgentWorktrees,
+  agentWorktreePath,
+  type WorktreeState,
+} from "../repos/agent-worktree.js";
 
 export interface ScaffoldResult {
   agentDir: string;
@@ -647,6 +655,28 @@ function channelsToEnv(agent: AgentConfig): Record<string, string> {
 }
 
 /**
+ * Build env vars exposing per-agent worktree paths to the agent's
+ * runtime. Slug `switchroom-web` → `SWITCHROOM_REPO_SWITCHROOM_WEB`.
+ * Path is computed deterministically from the agent dir and slug
+ * (`<agentDir>/work/<slug>/`); the worktree itself is provisioned
+ * separately during reconcile (see src/repos/agent-worktree.ts).
+ */
+function buildRepoEnvVars(
+  _agentName: string,
+  agentDir: string,
+  agent: AgentConfig,
+): Record<string, string> {
+  const repos = agent.repos;
+  if (!repos) return {};
+  const out: Record<string, string> = {};
+  for (const slug of Object.keys(repos)) {
+    const envName = `SWITCHROOM_REPO_${slug.toUpperCase().replace(/-/g, "_")}`;
+    out[envName] = agentWorktreePath(agentDir, slug);
+  }
+  return out;
+}
+
+/**
  * Top-level settings.json keys that switchroom's scaffold/reconcile
  * pipeline owns and rebuilds on every run. When the settings_raw
  * escape hatch injects additional top-level keys (e.g. `effort`,
@@ -1112,7 +1142,11 @@ function buildWorkspaceContext(args: BuildWorkspaceContextArgs): Record<string, 
       ? shellSingleQuote(agentConfig.fallback_model)
       : undefined,
     userEnvQuoted: (() => {
-      const combined = { ...channelsToEnv(agentConfig), ...(agentConfig.env ?? {}) };
+      const combined = {
+        ...channelsToEnv(agentConfig),
+        ...(agentConfig.env ?? {}),
+        ...buildRepoEnvVars(name, agentDir, agentConfig),
+      };
       if (Object.keys(combined).length === 0) return undefined;
       const out: Record<string, string> = {};
       for (const [k, v] of Object.entries(combined)) {
@@ -2167,7 +2201,11 @@ export function reconcileAgent(
         ? shellSingleQuote(agentConfig.fallback_model)
         : undefined,
       userEnvQuoted: (() => {
-        const combined = { ...channelsToEnv(agentConfig), ...(agentConfig.env ?? {}) };
+        const combined = {
+          ...channelsToEnv(agentConfig),
+          ...(agentConfig.env ?? {}),
+          ...buildRepoEnvVars(name, agentDir, agentConfig),
+        };
         if (Object.keys(combined).length === 0) return undefined;
         const out: Record<string, string> = {};
         for (const [k, v] of Object.entries(combined)) {

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -740,6 +740,38 @@ export const AgentSchema = z.object({
       "claim_worktree accepts the alias as the repo argument. " +
       "Absolute paths may always be passed regardless of this list.",
     ),
+  repos: z
+    .record(
+      z.string().regex(
+        /^[a-z0-9][a-z0-9-]*$/,
+        "Repo slug must be kebab-case ASCII: start with a lowercase letter or digit, contain only lowercase letters, digits, and hyphens",
+      ),
+      z.object({
+        url: z
+          .string()
+          .min(1)
+          .describe(
+            "Git remote URL for the repo (e.g. 'git@github.com:org/repo.git' or " +
+            "'https://github.com/org/repo.git'). Used verbatim for git clone.",
+          ),
+        branch_default: z
+          .string()
+          .optional()
+          .describe(
+            "Default branch to track (defaults to the remote's HEAD, typically 'main'). " +
+            "The per-agent branch 'agent/<agentName>/main' fast-forwards to this branch " +
+            "when the worktree is clean on session start.",
+          ),
+      }),
+    )
+    .optional()
+    .describe(
+      "Repos this agent operates on. Switchroom provisions a dedicated worktree for each " +
+      "repo at <agentDir>/work/<slug>/ on branch agent/<agentName>/main, backed by a " +
+      "shared bare clone at ~/.switchroom/repos/<slug>.git. The worktree path is injected " +
+      "into the agent's environment as SWITCHROOM_REPO_<SLUG_UPPER>. " +
+      "Agents without this field continue to work unchanged.",
+    ),
 });
 
 export const TelegramConfigSchema = z.object({
@@ -930,3 +962,4 @@ export type VaultConfig = z.infer<typeof VaultConfigSchema>;
 export type VaultBrokerConfig = z.infer<typeof VaultConfigSchema>["broker"];
 export type QuotaConfig = z.infer<typeof QuotaConfigSchema>;
 export type CodeRepoEntry = z.infer<typeof CodeRepoEntrySchema>;
+export type AgentRepoEntry = NonNullable<z.infer<typeof AgentSchema>["repos"]>[string];

--- a/src/repos/agent-worktree.ts
+++ b/src/repos/agent-worktree.ts
@@ -1,0 +1,323 @@
+/**
+ * Per-agent worktree management.
+ *
+ * Each agent that declares a repo in its switchroom.yaml config gets a
+ * dedicated worktree at <agentDir>/work/<slug>/ on branch
+ * agent/<agentName>/main. This worktree is:
+ *   - Created on the first reconcile after the repo appears in config.
+ *   - Fast-forwarded to upstream/main (or the remote's default branch)
+ *     on each subsequent reconcile when the worktree is clean.
+ *   - Left unchanged (dirty: true) when the worktree has uncommitted
+ *     changes — we never git reset --hard an agent's in-flight work.
+ *   - Removed with the agent on `switchroom agent remove`.
+ *
+ * Isolation: two agents on the same repo get separate worktrees on
+ * separate branches; they cannot interfere with each other.
+ */
+
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdirSync, readdirSync } from "node:fs";
+import { join, resolve } from "node:path";
+
+export interface WorktreeState {
+  /** Absolute path to the worktree directory */
+  path: string;
+  /** Branch the worktree is on (e.g. "agent/clerk/main") */
+  branch: string;
+  /**
+   * true when the worktree has uncommitted changes and was NOT
+   * fast-forwarded. The worktree is left exactly as-is.
+   */
+  dirty: boolean;
+  /**
+   * When dirty=true, the abbreviated HEAD SHA at the time of the call.
+   * Useful for boot-card warnings.
+   */
+  dirtyCommit?: string;
+}
+
+/**
+ * Resolve the per-agent branch name for a given agent.
+ * Convention: agent/<agentName>/main
+ */
+export function agentBranchName(agentName: string): string {
+  return `agent/${agentName}/main`;
+}
+
+/**
+ * Resolve the worktree directory path for an agent's repo.
+ * Convention: <agentDir>/work/<slug>/
+ */
+export function agentWorktreePath(agentDir: string, slug: string): string {
+  return join(agentDir, "work", slug);
+}
+
+/**
+ * Detect whether a worktree directory has uncommitted changes.
+ * Returns true if `git status --porcelain` produces any output.
+ */
+function isWorktreeDirty(worktreePath: string): boolean {
+  try {
+    const out = execFileSync("git", ["status", "--porcelain"], {
+      cwd: worktreePath,
+      stdio: ["ignore", "pipe", "pipe"],
+      encoding: "utf-8",
+    });
+    return out.trim().length > 0;
+  } catch {
+    // If git status fails, treat as dirty to be safe (never overwrite).
+    return true;
+  }
+}
+
+/**
+ * Read the abbreviated HEAD commit SHA for a worktree.
+ */
+function headShortSha(worktreePath: string): string | undefined {
+  try {
+    return execFileSync("git", ["rev-parse", "--short", "HEAD"], {
+      cwd: worktreePath,
+      stdio: ["ignore", "pipe", "pipe"],
+      encoding: "utf-8",
+    }).trim();
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Check if a branch already exists in the bare clone.
+ */
+function branchExistsInBare(bareClonePath: string, branchName: string): boolean {
+  try {
+    execFileSync(
+      "git",
+      ["rev-parse", "--verify", `refs/heads/${branchName}`],
+      {
+        cwd: bareClonePath,
+        stdio: ["ignore", "pipe", "pipe"],
+      },
+    );
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Resolve the default remote tracking branch for the bare clone.
+ * Tries refs/remotes/origin/HEAD → falls back to "main".
+ */
+function resolveDefaultBranch(bareClonePath: string): string {
+  try {
+    const out = execFileSync(
+      "git",
+      ["symbolic-ref", "refs/remotes/origin/HEAD"],
+      {
+        cwd: bareClonePath,
+        stdio: ["ignore", "pipe", "pipe"],
+        encoding: "utf-8",
+      },
+    ).trim();
+    // out is like "refs/remotes/origin/main"
+    const parts = out.split("/");
+    return parts[parts.length - 1] ?? "main";
+  } catch {
+    return "main";
+  }
+}
+
+/**
+ * Ensure a per-agent worktree exists for a given repo.
+ *
+ * Behaviour:
+ *   1. First call: creates <agentDir>/work/<slug>/ as a git worktree on
+ *      branch agent/<agentName>/main. The branch is created off the
+ *      remote's default branch (e.g. origin/main).
+ *   2. Subsequent calls (clean worktree): fetches latest from remote
+ *      and fast-forwards agent/<agentName>/main to origin/<defaultBranch>.
+ *   3. Subsequent calls (dirty worktree): leaves the worktree unchanged,
+ *      returns dirty: true.
+ *
+ * @param agentName      Agent identifier (e.g. "clerk")
+ * @param slug           Repo slug (e.g. "switchroom-web")
+ * @param bareClonePath  Absolute path to the bare clone directory
+ * @param agentDir       Agent directory (e.g. ~/.switchroom/agents/clerk)
+ */
+export async function ensureAgentWorktree(
+  agentName: string,
+  slug: string,
+  bareClonePath: string,
+  agentDir: string,
+): Promise<WorktreeState> {
+  const worktreePath = agentWorktreePath(agentDir, slug);
+  const branch = agentBranchName(agentName);
+  const defaultBranch = resolveDefaultBranch(bareClonePath);
+
+  if (!existsSync(worktreePath)) {
+    // First time: create the worktree directory and the agent branch.
+    mkdirSync(join(agentDir, "work"), { recursive: true });
+
+    if (branchExistsInBare(bareClonePath, branch)) {
+      // Branch already exists (e.g. re-provisioning after removal).
+      // Add the worktree using the existing branch — don't re-create it.
+      execFileSync(
+        "git",
+        ["worktree", "add", worktreePath, branch],
+        {
+          cwd: bareClonePath,
+          stdio: ["ignore", "pipe", "pipe"],
+        },
+      );
+    } else {
+      // Create the worktree and the per-agent branch together.
+      // The branch starts at origin/<defaultBranch>.
+      execFileSync(
+        "git",
+        [
+          "worktree", "add",
+          worktreePath,
+          "-b", branch,
+          `origin/${defaultBranch}`,
+        ],
+        {
+          cwd: bareClonePath,
+          stdio: ["ignore", "pipe", "pipe"],
+        },
+      );
+    }
+
+    process.stderr.write(
+      `[switchroom] repo "${slug}": worktree ready at ${worktreePath} (branch: ${branch})\n`,
+    );
+    return { path: resolve(worktreePath), branch, dirty: false };
+  }
+
+  // Worktree already exists — check for uncommitted changes.
+  if (isWorktreeDirty(worktreePath)) {
+    const sha = headShortSha(worktreePath);
+    process.stderr.write(
+      `[switchroom] repo "${slug}": dirty (uncommitted changes at ${sha ?? "unknown"}) — skipping ff-to-main\n`,
+    );
+    return {
+      path: resolve(worktreePath),
+      branch,
+      dirty: true,
+      dirtyCommit: sha,
+    };
+  }
+
+  // Clean worktree: fast-forward to the latest upstream.
+  try {
+    // Fetch inside the worktree so it updates the tracking branches.
+    execFileSync("git", ["fetch", "origin"], {
+      cwd: worktreePath,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    execFileSync(
+      "git",
+      ["merge", "--ff-only", `origin/${defaultBranch}`],
+      {
+        cwd: worktreePath,
+        stdio: ["ignore", "pipe", "pipe"],
+      },
+    );
+
+    process.stderr.write(
+      `[switchroom] repo "${slug}": worktree ready at ${worktreePath} (ff-d to origin/${defaultBranch})\n`,
+    );
+  } catch (err) {
+    // ff-only merge failed (e.g. diverged history) — leave as-is.
+    const msg = err instanceof Error ? err.message : String(err);
+    process.stderr.write(
+      `[switchroom] repo "${slug}": ff-only merge failed (leaving as-is): ${msg}\n`,
+    );
+  }
+
+  return { path: resolve(worktreePath), branch, dirty: false };
+}
+
+/**
+ * Remove the per-agent worktree for a given repo.
+ *
+ * Steps:
+ *   1. `git worktree remove --force <path>` from the bare clone.
+ *   2. `git branch -D agent/<agentName>/main` from the bare clone.
+ *
+ * Idempotent — safe to call even when the worktree or branch is absent.
+ */
+export async function removeAgentWorktree(
+  agentName: string,
+  slug: string,
+  bareClonePath: string,
+  agentDir: string,
+): Promise<void> {
+  const worktreePath = agentWorktreePath(agentDir, slug);
+  const branch = agentBranchName(agentName);
+
+  if (existsSync(worktreePath)) {
+    try {
+      execFileSync(
+        "git",
+        ["worktree", "remove", "--force", worktreePath],
+        {
+          cwd: bareClonePath,
+          stdio: ["ignore", "pipe", "pipe"],
+        },
+      );
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      process.stderr.write(
+        `[switchroom] repo "${slug}": worktree remove failed: ${msg}\n`,
+      );
+    }
+  }
+
+  // Prune the per-agent branch from the bare clone.
+  if (branchExistsInBare(bareClonePath, branch)) {
+    try {
+      execFileSync("git", ["branch", "-D", branch], {
+        cwd: bareClonePath,
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      process.stderr.write(
+        `[switchroom] repo "${slug}": branch delete failed: ${msg}\n`,
+      );
+    }
+  }
+
+  // Prune stale worktree entries from the bare clone's admin directory.
+  try {
+    execFileSync("git", ["worktree", "prune"], {
+      cwd: bareClonePath,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+  } catch {
+    // non-fatal
+  }
+
+  process.stderr.write(
+    `[switchroom] repo "${slug}": worktree removed (agent: ${agentName})\n`,
+  );
+}
+
+/**
+ * List the repo slugs for which a worktree has been provisioned under
+ * an agent's <agentDir>/work/ directory.
+ *
+ * Returns an empty array when the work/ directory doesn't exist.
+ */
+export function listAgentWorktrees(agentDir: string): string[] {
+  const workDir = join(agentDir, "work");
+  if (!existsSync(workDir)) return [];
+  try {
+    return readdirSync(workDir, { withFileTypes: true })
+      .filter((d) => d.isDirectory())
+      .map((d) => d.name);
+  } catch {
+    return [];
+  }
+}

--- a/src/repos/bare-clone.ts
+++ b/src/repos/bare-clone.ts
@@ -1,0 +1,71 @@
+/**
+ * Bare-clone management for per-agent worktree provisioning.
+ *
+ * One bare clone per repo slug lives at ~/.switchroom/repos/<slug>.git,
+ * shared across all agents. The bare clone is the source from which
+ * per-agent worktrees are created (git worktree add).
+ *
+ * Design decision: bare clones share .git/objects across all worktrees
+ * checked out of them, so five agents on the same 200MB repo cost one
+ * clone worth of storage, not five.
+ */
+
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdirSync } from "node:fs";
+import { resolve } from "node:path";
+import { resolveStatePath } from "../config/paths.js";
+
+/**
+ * Resolve the filesystem path for the bare clone of a given slug.
+ * All bare clones live under ~/.switchroom/repos/<slug>.git.
+ */
+export function bareClonePath(slug: string): string {
+  return resolveStatePath(`repos/${slug}.git`);
+}
+
+/**
+ * Ensure a bare clone of `url` exists at ~/.switchroom/repos/<slug>.git.
+ *
+ * - First call: `git clone --bare <url> <path>` (creates the clone).
+ * - Subsequent calls: `git fetch --all` to refresh all remotes.
+ *
+ * Idempotent — safe to call on every reconcile.
+ *
+ * @param slug   Kebab-case repo key from switchroom.yaml (e.g. "switchroom-web")
+ * @param url    Git remote URL (used verbatim; never auto-derived)
+ * @returns      Absolute path to the bare clone directory
+ */
+export async function ensureBareClone(slug: string, url: string): Promise<string> {
+  const reposDir = resolveStatePath("repos");
+  mkdirSync(reposDir, { recursive: true });
+
+  const clonePath = bareClonePath(slug);
+
+  if (!existsSync(clonePath)) {
+    process.stderr.write(`[switchroom] repo "${slug}": cloning ${url} …\n`);
+    execFileSync("git", ["clone", "--bare", url, clonePath], {
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    process.stderr.write(`[switchroom] repo "${slug}": bare clone ready at ${clonePath}\n`);
+  } else {
+    // Already cloned — refresh all remotes so the per-agent branch can
+    // fast-forward to the latest upstream.
+    process.stderr.write(`[switchroom] repo "${slug}": fetching ${clonePath} …\n`);
+    try {
+      execFileSync("git", ["fetch", "--all"], {
+        cwd: clonePath,
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+    } catch (err) {
+      // Non-fatal: fetch can fail when the network is unreachable or the
+      // remote URL has rotated. We still return the clone path so the
+      // worktree can resume from its last-known state.
+      const msg = err instanceof Error ? err.message : String(err);
+      process.stderr.write(
+        `[switchroom] repo "${slug}": fetch failed (continuing with cached clone): ${msg}\n`,
+      );
+    }
+  }
+
+  return resolve(clonePath);
+}


### PR DESCRIPTION
Phase 1 of the per-agent-worktree feature designed in [`reference/give-each-agent-its-own-workspace.md`](https://github.com/switchroom/switchroom/blob/main/reference/give-each-agent-its-own-workspace.md) (merged in d48db47).

## What's in this PR

Compiles, all 169 vitest test files pass, no functional behavior change for existing agents:

- **`src/config/schema.ts`** — agent config gains an optional `repos:` field. Each entry has a kebab-case slug key and a `url`. Validated. Agents without `repos:` work unchanged.
- **`src/repos/bare-clone.ts`** — `ensureBareClone(slug, url)` manages `~/.switchroom/repos/<slug>.git` as a per-host singleton bare clone. Clone-first / fetch-thereafter, idempotent.
- **`src/repos/agent-worktree.ts`** — `ensureAgentWorktree`, `removeAgentWorktree`, `listAgentWorktrees`, `agentWorktreePath`, plus a `WorktreeState` type. ff-on-clean, leave-alone-on-dirty per the spec's no-reset rule.
- **`src/agents/scaffold.ts`** — `buildRepoEnvVars` injects `SWITCHROOM_REPO_<NAME>` env vars (paths-only, deterministic) into the agent's runtime env. Wired into both `buildWorkspaceContext` and `reconcileAgent` env-merge sites. No-op for agents without `repos:`.

+467 / -2 lines. 4 files. No `dist/` committed, no version bump, no PII bake-ins.

## Deferred to follow-up PRs (not silently dropped)

1. **Reconcile-time provisioning.** The modules exist; the call site that invokes `ensureBareClone` + `ensureAgentWorktree` during the reconcile pipeline is the next PR. Until that lands, declaring `repos:` exposes env paths but doesn't actually create worktrees on disk.
2. **Boot-card warning** for dirty trees (probe row in the gateway's boot-card renderer).
3. **`agent remove` cleanup** that calls `removeAgentWorktree` for each declared repo and prunes the per-agent branches.
4. **Vitest coverage** for the new modules using hermetic `file://` bare repos.

Each is small (under 100 LoC) and ships independently. Splitting this way because the previous attempts to land all of it in one PR repeatedly stopped mid-investigation; landing the foundation first lets the integration-layer work be isolated and reviewable on its own.

## Why this PR alone is safe to merge

- Agents without `repos:` see zero behavior change (`buildRepoEnvVars` returns `{}`).
- Modules in `src/repos/` are not imported anywhere except `scaffold.ts:buildRepoEnvVars` (which only calls `agentWorktreePath`, a pure path computation — never spawns git).
- No git commands run anywhere as a result of this PR.

## Verification

- `bun run build` clean.
- `bun run test`: 169 test files / 3589 tests pass.
- PII grep gate clean.