### PR TITLE
fix(boot-card): live-watch agent service status after boot

### DIFF
--- a/telegram-plugin/gateway/boot-card.ts
+++ b/telegram-plugin/gateway/boot-card.ts
@@ -40,6 +40,9 @@ import {
   probeQuota,
   probeHindsight,
   probeCronTimers,
+  watchAgentProcess,
+  AGENT_LIVE_WINDOW_MS,
+  AGENT_LIVE_POLL_INTERVAL_MS,
 } from './boot-probes.js'
 import { escapeHtml } from '../card-format.js'
 import { join } from 'path'
@@ -273,6 +276,20 @@ export interface RunProbesOpts {
   settleWindowMs?: number
   /** Override setTimeout for tests. */
   setTimeoutImpl?: typeof setTimeout
+  /**
+   * How long the live-agent-status loop keeps editing the card after the
+   * initial probe run. Defaults to AGENT_LIVE_WINDOW_MS (45s). Set to 0
+   * to disable the live loop entirely (e.g. in tests that only need the
+   * one-shot settle-window behaviour).
+   */
+  agentLiveWindowMs?: number
+  /** How often the live loop re-polls systemd. Defaults to
+   *  AGENT_LIVE_POLL_INTERVAL_MS (2s). Override in tests for speed. */
+  agentLivePollIntervalMs?: number
+  /** Override for tests — replaces real execFile calls in the live loop. */
+  agentLiveExecFileImpl?: (cmd: string, args: string[]) => Promise<{ stdout: string; stderr: string }>
+  /** Override for tests — replaces real delays in the live loop. */
+  agentLiveSleepImpl?: (ms: number) => Promise<void>
 }
 
 /** Run all six probes concurrently with their own per-probe timeouts.
@@ -337,32 +354,93 @@ export async function startBootCard(
     return { messageId: -1, complete: () => {} }
   }
 
-  // Schedule the post-settle probe run + edit. Wrapped in setTimeout so
-  // the boot path returns the handle immediately — the gateway can
-  // continue setup without waiting on probes.
+  // Determine the live window for agent-service status updates. Callers
+  // can pass 0 to disable the live loop (e.g. in tests that only need
+  // the one-shot settle-window behaviour). Defaults to AGENT_LIVE_WINDOW_MS.
+  const liveWindowMs = opts.agentLiveWindowMs ?? AGENT_LIVE_WINDOW_MS
+
+  // Schedule the post-settle probe run + live agent-status loop. Wrapped
+  // in setTimeout so the boot path returns the handle immediately — the
+  // gateway can continue setup without waiting on probes.
   setTimeoutFn(() => {
     void (async () => {
       try {
+        // ── Phase 1: one-shot probe run after the settle window ───────────
+        // Run all probes concurrently. If the agent probe comes back ok at
+        // this point, no live loop is needed. If it's degraded/fail we
+        // start the live watch (Phase 2) to keep updating the card.
         const probes = await runAllProbes(opts)
-        const updatedText = renderBootCard({
+
+        // Render with current probe state and edit if anything changed.
+        let currentText = renderBootCard({
           agentName: opts.agentName,
           version: opts.version,
           probes,
           restartReason: opts.restartReason,
           restartAgeMs: opts.restartAgeMs,
         })
-        // Skip the edit when nothing degraded — saves the API call and
-        // avoids Telegram's "message is not modified" error.
-        if (updatedText === ackText) {
+
+        if (currentText !== ackText) {
+          try {
+            await bot.editMessageText(chatId, messageId, currentText, {
+              parse_mode: 'HTML',
+              link_preview_options: { is_disabled: true },
+              ...(threadId != null ? { message_thread_id: threadId } : {}),
+            })
+            logger(`telegram gateway: boot-card: probes settled with degraded rows msgId=${messageId}\n`)
+          } catch (editErr: unknown) {
+            logger(`telegram gateway: boot-card: probe-edit error msgId=${messageId}: ${(editErr as Error)?.message ?? String(editErr)}\n`)
+          }
+        } else {
           logger(`telegram gateway: boot-card: probes settled all-green msgId=${messageId}\n`)
+        }
+
+        // ── Phase 2: live agent-status watch loop ─────────────────────────
+        // If the agent probe is already ok, no need to keep watching.
+        if (probes.agent?.status === 'ok' || liveWindowMs <= 0) {
           return
         }
-        await bot.editMessageText(chatId, messageId, updatedText, {
-          parse_mode: 'HTML',
-          link_preview_options: { is_disabled: true },
-          ...(threadId != null ? { message_thread_id: threadId } : {}),
+
+        // Iterate watchAgentProcess — it yields on each meaningful state
+        // change and exits when active, failed, or the window expires.
+        const watcher = watchAgentProcess(opts.agentName, {
+          liveWindowMs,
+          pollIntervalMs: opts.agentLivePollIntervalMs,
+          sleepImpl: opts.agentLiveSleepImpl,
+          execFileImpl: opts.agentLiveExecFileImpl,
         })
-        logger(`telegram gateway: boot-card: probes settled with degraded rows msgId=${messageId}\n`)
+
+        for await (const agentResult of watcher) {
+          // Merge the new agent result into the probes snapshot so all
+          // probe rows are re-rendered consistently.
+          const updatedProbes: ProbeMap = { ...probes, agent: agentResult }
+          const updatedText = renderBootCard({
+            agentName: opts.agentName,
+            version: opts.version,
+            probes: updatedProbes,
+            restartReason: opts.restartReason,
+            restartAgeMs: opts.restartAgeMs,
+          })
+
+          if (updatedText === currentText) continue
+
+          try {
+            await bot.editMessageText(chatId, messageId, updatedText, {
+              parse_mode: 'HTML',
+              link_preview_options: { is_disabled: true },
+              ...(threadId != null ? { message_thread_id: threadId } : {}),
+            })
+            logger(`telegram gateway: boot-card: live agent update msgId=${messageId} state=${agentResult.status} "${agentResult.detail}"\n`)
+            currentText = updatedText
+          } catch (editErr: unknown) {
+            // Swallow edit errors — the card may have been deleted or the
+            // user dismissed it. Don't let this crash the whole loop.
+            logger(`telegram gateway: boot-card: live edit error msgId=${messageId}: ${(editErr as Error)?.message ?? String(editErr)}\n`)
+          }
+
+          // Once agent is active (ok), we're done — no more edits needed.
+          if (agentResult.status === 'ok') break
+        }
       } catch (err: unknown) {
         logger(`telegram gateway: boot-card: probe-edit error msgId=${messageId}: ${(err as Error)?.message ?? String(err)}\n`)
       }

--- a/telegram-plugin/gateway/boot-probes.ts
+++ b/telegram-plugin/gateway/boot-probes.ts
@@ -209,6 +209,25 @@ export const AGENT_RETRY_INTERVAL_MS = 1500
  */
 export const AGENT_RETRY_MAX_MS = 12_000
 
+/**
+ * How long the boot-card live-agent-status loop keeps polling and editing
+ * the card in-place after the initial probe run. The loop exits early as
+ * soon as the agent reaches `active`. If the window expires without the
+ * agent becoming active, the card commits to whatever state is current.
+ *
+ * 45 s covers the typical systemd restart cycle (deactivating → inactive →
+ * activating → active) even under load, while staying short enough that a
+ * genuinely stuck unit (still `inactive` at 45 s) is a real problem.
+ * Exported for test injection.
+ */
+export const AGENT_LIVE_WINDOW_MS = 45_000
+
+/**
+ * How often the live-watch loop re-polls systemd while waiting for the
+ * agent to become active. Exported for test injection.
+ */
+export const AGENT_LIVE_POLL_INTERVAL_MS = 2_000
+
 type ExecFileResult = { stdout: string; stderr: string }
 type ExecFileFnType = (
   cmd: string,
@@ -299,6 +318,114 @@ export async function probeAgentProcess(
       await sleep(retryIntervalMs)
     }
   })(), PROBE_TIMEOUT_MS + retryMaxMs)  // extend outer timeout to cover full retry budget
+}
+
+/**
+ * Async generator that watches the agent systemd unit and yields a
+ * ProbeResult each time the meaningful state changes, for up to
+ * `liveWindowMs` total. Exits early as soon as the unit reaches `active`.
+ *
+ * Designed for the boot-card live-update loop in `boot-card.ts`: the
+ * caller iterates, edits the card on each yielded result, and breaks once
+ * it sees `status === 'ok'` or the generator exhausts.
+ *
+ * Key contract:
+ *   - First yield is immediate (no initial delay) so the card can show
+ *     the current state right away.
+ *   - Subsequent yields happen every `pollIntervalMs`.
+ *   - `inactive` and `activating` within the window → status `degraded`
+ *     (🟡 "starting"), not `fail`. Only `failed` or window-expired-`inactive`
+ *     commits to `fail`.
+ *   - When the window expires without `active` the generator yields a
+ *     final committed result and then ends.
+ */
+export async function* watchAgentProcess(
+  agentName: string,
+  opts: {
+    liveWindowMs?: number
+    pollIntervalMs?: number
+    /** Override for tests — replaces real delays */
+    sleepImpl?: (ms: number) => Promise<void>
+    /** Override for tests — replaces real execFile calls */
+    execFileImpl?: ExecFileFnType
+  } = {},
+): AsyncGenerator<ProbeResult> {
+  const liveWindowMs = opts.liveWindowMs ?? AGENT_LIVE_WINDOW_MS
+  const pollIntervalMs = opts.pollIntervalMs ?? AGENT_LIVE_POLL_INTERVAL_MS
+  const sleep = opts.sleepImpl ?? ((ms: number) => new Promise<void>(resolve => setTimeout(resolve, ms)))
+  const execFileFn: ExecFileFnType = opts.execFileImpl ?? execFile
+
+  const startMs = Date.now()
+  let lastYieldedDetail: string | null = null
+
+  /**
+   * Convert a raw systemd state into a ProbeResult suitable for the boot card.
+   * Within the live window: inactive, activating, auto-restart, and
+   * deactivating are all 🟡 "starting" — we don't know they're stuck yet.
+   * Only `failed` is immediately 🔴. Everything else (unknown) is also 🔴.
+   */
+  function toProbeResult(
+    state: string,
+    kv: Record<string, string>,
+    withinWindow: boolean,
+  ): ProbeResult {
+    if (state === 'active') {
+      const pid = kv['MainPID'] ?? '?'
+      const uptime = formatUptime(kv['ActiveEnterTimestamp'] ?? '')
+      const mem = formatMemory(kv['MemoryCurrent'] ?? '')
+      const parts = [`PID ${pid}`, uptime, mem].filter(Boolean)
+      return { status: 'ok', label: 'Agent', detail: parts.join(' · ') }
+    }
+    if (withinWindow) {
+      // Treat all non-active states as transient while still within the
+      // window. `failed` is the only exception — hard fail even in-window.
+      if (state === 'failed') {
+        return { status: 'fail', label: 'Agent', detail: 'service failed' }
+      }
+      return { status: 'degraded', label: 'Agent', detail: 'service starting' }
+    }
+    // Window expired — commit to the actual state.
+    const isTransient =
+      state === 'deactivating' ||
+      state === 'activating' ||
+      state === 'auto-restart' ||
+      state === 'inactive'
+    const status = isTransient ? 'degraded' : 'fail'
+    return { status, label: 'Agent', detail: `service ${state}` }
+  }
+
+  while (true) {
+    const elapsedMs = Date.now() - startMs
+    const withinWindow = elapsedMs < liveWindowMs
+
+    const snapshot = await queryAgentState(agentName, execFileFn)
+
+    if ('error' in snapshot) {
+      yield { status: 'fail', label: 'Agent', detail: snapshot.error }
+      return
+    }
+
+    const result = toProbeResult(snapshot.state, snapshot.kv, withinWindow)
+
+    // Only yield when the result detail actually changed — avoids
+    // redundant card edits ("service starting" → "service starting").
+    if (result.detail !== lastYieldedDetail) {
+      lastYieldedDetail = result.detail
+      yield result
+    }
+
+    // Terminal states: active (ok) or genuinely failed.
+    if (result.status === 'ok' || (result.status === 'fail' && snapshot.state === 'failed')) {
+      return
+    }
+
+    // If window expired, we already yielded the final committed result.
+    if (!withinWindow) {
+      return
+    }
+
+    await sleep(pollIntervalMs)
+  }
 }
 
 // ─── Probe: Gateway ──────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Closes the user-visible "🔴 Agent service inactive" bug on boot cards whose process is actually running. The original boot-card showed a one-shot probe snapshot; if systemd was mid-restart at probe time, the card committed to "inactive" and never updated even when the agent came alive seconds later.

## Fix

After the initial probe settle window, if the agent probe is degraded a new async generator `watchAgentProcess` (in `boot-probes.ts`) polls systemd every 2 s for up to 45 s and yields on each meaningful state change. `startBootCard` iterates that generator and edits the card in-place until the unit reaches `active` or the window expires.

- 45 s covers the typical systemd restart cycle (`deactivating → inactive → activating → active`) under load.
- 2 s poll keeps the card responsive without hammering systemd.
- Loop exits early once `active` is observed.
- `agentLiveExecFileImpl` and `agentLiveSleepImpl` opts on `RunProbesOpts` make the loop test-injectable.

## Tests

Existing tests pass. **No new tests added for `watchAgentProcess` itself** — the injection points are present but unused. Worth a follow-up to add deterministic tests that drive the generator through state transitions.

Refs #211, #248.

🤖 Generated with [Claude Code](https://claude.com/claude-code)