### PR TITLE
fix(plugin): output sanitizer for invariants (closes part of #270)

### DIFF
--- a/telegram-plugin/format.ts
+++ b/telegram-plugin/format.ts
@@ -203,6 +203,108 @@ export function escapeHtml(text: string): string {
     .replace(/"/g, '&quot;')
 }
 
+// ---------------------------------------------------------------------------
+// Output sanitizer — enforces fleet-wide Telegram formatting invariants
+// ---------------------------------------------------------------------------
+
+/**
+ * Normalize outbound Telegram HTML text against well-known invariants.
+ *
+ * Runs AFTER markdownToHtml, just before the text is sent to the Bot API.
+ * Conservative by design: only rewrites things that are universally wrong;
+ * leaves semantic decisions (where to bold, link choice, list-vs-prose) to
+ * the agent.
+ *
+ * Rules applied (in order):
+ *  1. Strip markdown heading markers (`## Foo` → `<b>Foo</b>\n\n`).
+ *     Headings that survived the markdown→HTML pass (e.g. when the input
+ *     was already HTML and passed through isLikelyTelegramHtml) would render
+ *     as ugly `## Foo` plain text. Convert to bold + blank line.
+ *  2. Flatten nested bullet indentation: `\n  - sub` → `\n· sub`.
+ *  3. Collapse 3+ consecutive blank lines to exactly 2.
+ *  4. Strip trailing whitespace on each line.
+ *  5. Ensure `<` `>` `&` inside `<code>` and `<pre>` blocks are
+ *     HTML-escaped (idempotent: won't double-escape existing `&amp;` etc.).
+ *
+ * The function is idempotent: sanitize(sanitize(x)) === sanitize(x).
+ * Content inside `<code>` / `<pre>` blocks is excluded from rules 1–4.
+ */
+export function sanitizeForTelegram(text: string): string {
+  // ── Phase 1: extract <code> and <pre> blocks so rules 1-4 don't touch them.
+  //
+  // We capture the full tag with its content so we can round-trip correctly.
+  // Placeholders are non-printing control sequences that cannot appear in
+  // normal text.
+  const CODE_PH = '\x00SANCODE'
+  const PRE_PH = '\x00SANPRE'
+  const codeSegments: string[] = []
+  const preSegments: string[] = []
+
+  // Extract <pre>...</pre> blocks first (they may contain <code> inside).
+  let result = text.replace(/<pre>([\s\S]*?)<\/pre>/gi, (_m, inner: string) => {
+    const idx = preSegments.length
+    // Rule 5: escape unescaped < > & inside pre blocks.
+    preSegments.push(`<pre>${escapeUnescapedEntities(inner)}</pre>`)
+    return `${PRE_PH}${idx}\x00`
+  })
+
+  // Extract standalone <code>...</code> blocks (not nested inside <pre>).
+  result = result.replace(/<code([^>]*)>([\s\S]*?)<\/code>/gi, (_m, attrs: string, inner: string) => {
+    const idx = codeSegments.length
+    // Rule 5: escape unescaped < > & inside code spans.
+    codeSegments.push(`<code${attrs}>${escapeUnescapedEntities(inner)}</code>`)
+    return `${CODE_PH}${idx}\x00`
+  })
+
+  // ── Phase 2: apply text-level rules to the remaining (non-code) content.
+
+  // Rule 1: strip markdown heading markers that survived markdown→HTML pass.
+  // Matches lines starting with one or more `#` followed by a space.
+  // Preserves the heading text as bold + trailing blank line.
+  result = result.replace(/^(#{1,6}) +(.+?)\s*$/gm, (_m, _hashes, title: string) => {
+    return `<b>${title}</b>\n`
+  })
+
+  // Rule 2: flatten nested bullet indentation.
+  // Matches lines with 2+ spaces (or a tab) at the start followed by - or *.
+  // Converts to a middle-dot bullet so the sub-detail survives as readable text.
+  result = result.replace(/^[ \t]{2,}[*-] /gm, '· ')
+
+  // Rule 4: strip trailing whitespace on each line.
+  result = result.replace(/[ \t]+$/gm, '')
+
+  // Rule 3: collapse 3+ consecutive blank lines to exactly 2.
+  // A "blank line" is a line that contains only optional whitespace (already
+  // stripped above, but let's be safe).
+  result = result.replace(/(\n[ \t]*){3,}/g, '\n\n')
+
+  // ── Phase 3: restore placeholders.
+  result = result.replace(new RegExp(`${CODE_PH}(\\d+)\x00`, 'g'), (_m, idx) => codeSegments[Number(idx)])
+  result = result.replace(new RegExp(`${PRE_PH}(\\d+)\x00`, 'g'), (_m, idx) => preSegments[Number(idx)])
+
+  return result
+}
+
+/**
+ * Escape `<`, `>`, and `&` characters that are NOT already part of an HTML
+ * entity or tag. Used inside `<code>` and `<pre>` content to correct
+ * unescaped characters without double-escaping existing `&amp;`, `&lt;`, etc.
+ *
+ * Strategy: we walk the string and escape `&` only when it is not the start
+ * of a valid entity (`&name;` or `&#digits;` or `&#xhex;`). We always escape
+ * bare `<` and `>` because they cannot appear literally inside code content
+ * that is correct Telegram HTML.
+ */
+function escapeUnescapedEntities(inner: string): string {
+  // Escape bare & first: replace & that is NOT followed by a valid entity
+  // pattern. A valid entity is: &[a-zA-Z][a-zA-Z0-9]*; or &#[0-9]+; or &#x[0-9a-fA-F]+;
+  let out = inner.replace(/&(?!(?:[a-zA-Z][a-zA-Z0-9]*|#[0-9]+|#x[0-9a-fA-F]+);)/g, '&amp;')
+  // Escape bare < and > (they should never appear literally in code content)
+  out = out.replace(/</g, '&lt;')
+  out = out.replace(/>/g, '&gt;')
+  return out
+}
+
 /**
  * Repair LLM-side JSON escape bungles.
  *

--- a/telegram-plugin/format.ts
+++ b/telegram-plugin/format.ts
@@ -266,9 +266,10 @@ export function sanitizeForTelegram(text: string): string {
   })
 
   // Rule 2: flatten nested bullet indentation.
-  // Matches lines with 2+ spaces (or a tab) at the start followed by - or *.
+  // Matches lines with a tab OR 2+ spaces at the start followed by - or *.
+  // A single tab is treated as sufficient indentation (standard 4-space equiv).
   // Converts to a middle-dot bullet so the sub-detail survives as readable text.
-  result = result.replace(/^[ \t]{2,}[*-] /gm, '· ')
+  result = result.replace(/^(?:\t+[ \t]*|[ \t]{2,})[*-] /gm, '· ')
 
   // Rule 4: strip trailing whitespace on each line.
   result = result.replace(/[ \t]+$/gm, '')

--- a/telegram-plugin/server.ts
+++ b/telegram-plugin/server.ts
@@ -915,8 +915,9 @@ export {
   markdownToHtml,
   splitHtmlChunks,
   escapeHtml,
+  sanitizeForTelegram,
 } from './format.js'
-import { markdownToHtml, splitHtmlChunks, escapeHtml, repairEscapedWhitespace } from './format.js'
+import { markdownToHtml, splitHtmlChunks, escapeHtml, repairEscapedWhitespace, sanitizeForTelegram } from './format.js'
 
 type AttachmentMeta = {
   kind: string
@@ -1508,7 +1509,7 @@ mcp.setRequestHandler(CallToolRequestSchema, async req => {
         let effectiveText: string
         if (format === 'html') {
           parseMode = 'HTML' as const
-          effectiveText = markdownToHtml(text)
+          effectiveText = sanitizeForTelegram(markdownToHtml(text))
         } else if (format === 'markdownv2') {
           parseMode = 'MarkdownV2' as const
           effectiveText = escapeMarkdownV2(text)
@@ -1871,7 +1872,7 @@ mcp.setRequestHandler(CallToolRequestSchema, async req => {
           {
             bot: lockedBot,
             retry: robustApiCall,
-            markdownToHtml,
+            markdownToHtml: (t: string) => sanitizeForTelegram(markdownToHtml(t)),
             escapeMarkdownV2,
             repairEscapedWhitespace,
             takeHandoffPrefix,
@@ -1974,7 +1975,7 @@ mcp.setRequestHandler(CallToolRequestSchema, async req => {
         const access = loadAccess()
         const configParseMode = access.parseMode ?? 'html'
         const parseMode = configParseMode === 'html' ? 'HTML' : undefined
-        const effectiveText = configParseMode === 'html' ? markdownToHtml(text) : text
+        const effectiveText = configParseMode === 'html' ? sanitizeForTelegram(markdownToHtml(text)) : text
 
         const sendOpts = {
           ...(parseMode ? { parse_mode: parseMode } : {}),
@@ -2043,7 +2044,7 @@ mcp.setRequestHandler(CallToolRequestSchema, async req => {
         let editText: string
         if (editFormat === 'html') {
           editParseMode = 'HTML' as const
-          editText = markdownToHtml(editRawText)
+          editText = sanitizeForTelegram(markdownToHtml(editRawText))
         } else if (editFormat === 'markdownv2') {
           editParseMode = 'MarkdownV2' as const
           editText = escapeMarkdownV2(editRawText)
@@ -2544,7 +2545,7 @@ if (streamMode === 'checklist') {
       handleStreamReply(args, { activeDraftStreams, activeDraftParseModes, suppressPtyPreview }, {
         bot: lockedBot,
         retry: robustApiCall,
-        markdownToHtml,
+        markdownToHtml: (t: string) => sanitizeForTelegram(markdownToHtml(t)),
         escapeMarkdownV2,
         repairEscapedWhitespace,
         takeHandoffPrefix: () => '',
@@ -2819,7 +2820,7 @@ function handlePtyPartial(text: string): void {
   handlePtyPartialPure(text, state, {
     bot,
     retry: robustApiCall,
-    renderText: markdownToHtml,
+    renderText: (t: string) => sanitizeForTelegram(markdownToHtml(t)),
     logEvent: logStreamingEvent,
     onStreamSend: (chatId, messageId, charCount) => {
       logOutbound('pty_preview', chatId, messageId, charCount, 'initial_send')

--- a/telegram-plugin/tests/telegram-format.test.ts
+++ b/telegram-plugin/tests/telegram-format.test.ts
@@ -6,7 +6,7 @@ import { describe, test, expect } from 'vitest'
 
 // Import from the side-effect-free format module so tests don't trigger
 // server.ts's startup (env load, token check, grammy init).
-import { markdownToHtml, splitHtmlChunks, isLikelyTelegramHtml, repairEscapedWhitespace } from '../format.js'
+import { markdownToHtml, splitHtmlChunks, isLikelyTelegramHtml, repairEscapedWhitespace, sanitizeForTelegram } from '../format.js'
 
 // ---------------------------------------------------------------------------
 // markdownToHtml
@@ -708,5 +708,193 @@ describe('repairEscapedWhitespace', () => {
     expect(html).toContain('- bullet one')
     // Literal \n must not survive anywhere.
     expect(html).not.toContain('\\n')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// sanitizeForTelegram — output invariants enforced pre-send
+// ---------------------------------------------------------------------------
+
+describe('sanitizeForTelegram', () => {
+  // ── Rule 1: strip ## headings ────────────────────────────────────────────
+
+  test('strips ## heading and converts to bold', () => {
+    const result = sanitizeForTelegram('## My Heading\n\nbody text')
+    expect(result).toContain('<b>My Heading</b>')
+    expect(result).not.toContain('## ')
+  })
+
+  test('strips ### heading and converts to bold', () => {
+    const result = sanitizeForTelegram('### Section\n\nbody')
+    expect(result).toContain('<b>Section</b>')
+    expect(result).not.toContain('### ')
+  })
+
+  test('strips #### heading and converts to bold', () => {
+    const result = sanitizeForTelegram('#### Sub\n\nbody')
+    expect(result).toContain('<b>Sub</b>')
+    expect(result).not.toContain('#### ')
+  })
+
+  test('strips # (h1) heading and converts to bold', () => {
+    const result = sanitizeForTelegram('# Title\n\nbody')
+    expect(result).toContain('<b>Title</b>')
+    expect(result).not.toContain('# Title')
+  })
+
+  // ── Rule 2: flatten nested bullets ──────────────────────────────────────
+
+  test('flattens 2-space-indented bullets', () => {
+    const result = sanitizeForTelegram('- top\n  - sub')
+    expect(result).toContain('· sub')
+    expect(result).not.toContain('  - sub')
+  })
+
+  test('flattens 4-space-indented bullets', () => {
+    const result = sanitizeForTelegram('- top\n    - deeply nested')
+    expect(result).toContain('· deeply nested')
+    expect(result).not.toContain('    - deeply nested')
+  })
+
+  test('flattens tab-indented bullets', () => {
+    const result = sanitizeForTelegram('- top\n\t- tabbed sub')
+    expect(result).toContain('· tabbed sub')
+    expect(result).not.toContain('\t- tabbed sub')
+  })
+
+  test('preserves unindented bullets unchanged', () => {
+    const result = sanitizeForTelegram('- item one\n- item two')
+    expect(result).toContain('- item one')
+    expect(result).toContain('- item two')
+    // No middle-dot substitution on top-level bullets
+    expect(result).not.toContain('· item one')
+  })
+
+  // ── Rule 3: collapse blank lines ────────────────────────────────────────
+
+  test('collapses 4 blank lines to 2', () => {
+    const result = sanitizeForTelegram('before\n\n\n\nafter')
+    expect(result).toBe('before\n\nafter')
+  })
+
+  test('collapses 3 blank lines to 2', () => {
+    const result = sanitizeForTelegram('a\n\n\nb')
+    expect(result).toBe('a\n\nb')
+  })
+
+  test('leaves exactly 2 blank lines alone', () => {
+    const result = sanitizeForTelegram('a\n\nb')
+    expect(result).toBe('a\n\nb')
+  })
+
+  // ── Rule 4: trailing whitespace ──────────────────────────────────────────
+
+  test('strips trailing spaces from lines', () => {
+    const result = sanitizeForTelegram('hello   \nworld  ')
+    expect(result).toBe('hello\nworld')
+  })
+
+  test('strips trailing tabs from lines', () => {
+    const result = sanitizeForTelegram('hello\t\t\nworld')
+    expect(result).toBe('hello\nworld')
+  })
+
+  // ── Rule 5: HTML escape inside code/pre ─────────────────────────────────
+
+  test('HTML-escapes bare < and > inside <code> block', () => {
+    const result = sanitizeForTelegram('<code>a < b && c > d</code>')
+    expect(result).toContain('<code>a &lt; b')
+    expect(result).toContain('&gt; d</code>')
+  })
+
+  test('HTML-escapes bare & inside <code> block', () => {
+    const result = sanitizeForTelegram('<code>foo & bar</code>')
+    expect(result).toContain('<code>foo &amp; bar</code>')
+  })
+
+  test('HTML-escapes bare < and > inside <pre> block', () => {
+    const result = sanitizeForTelegram('<pre><code>if a < b</code></pre>')
+    expect(result).toContain('&lt; b')
+  })
+
+  test('does not double-escape already-escaped &amp; in <code>', () => {
+    const result = sanitizeForTelegram('<code>a &amp; b</code>')
+    // Must remain single-escaped, not become &amp;amp;
+    expect(result).toContain('<code>a &amp; b</code>')
+    expect(result).not.toContain('&amp;amp;')
+  })
+
+  test('does not double-escape &lt; in <code>', () => {
+    const result = sanitizeForTelegram('<code>&lt;div&gt;</code>')
+    expect(result).toContain('<code>&lt;div&gt;</code>')
+    expect(result).not.toContain('&amp;lt;')
+  })
+
+  test('does not double-escape &#123; numeric entity in <code>', () => {
+    const result = sanitizeForTelegram('<code>&#123; x &#125;</code>')
+    expect(result).toContain('&#123;')
+    expect(result).not.toContain('&amp;#123;')
+  })
+
+  // ── Code block exclusion from structural rules ───────────────────────────
+
+  test('does not strip ## heading inside <code> block', () => {
+    const result = sanitizeForTelegram('<code>## not a heading</code>')
+    // The ## stays; only < > & are touched inside code
+    expect(result).toContain('## not a heading')
+  })
+
+  test('does not flatten bullets inside <code> block', () => {
+    const result = sanitizeForTelegram('<code>  - not flattened</code>')
+    // The indented bullet stays verbatim inside code
+    expect(result).toContain('  - not flattened')
+  })
+
+  test('does not strip ## heading inside <pre> block', () => {
+    const result = sanitizeForTelegram('<pre><code class="language-bash"># comment\n## heading\n</code></pre>')
+    expect(result).toContain('## heading')
+  })
+
+  // ── Idempotency ──────────────────────────────────────────────────────────
+
+  test('is idempotent for heading conversion', () => {
+    const once = sanitizeForTelegram('## Heading\n\nbody')
+    const twice = sanitizeForTelegram(once)
+    expect(twice).toBe(once)
+  })
+
+  test('is idempotent for bullet flattening', () => {
+    const once = sanitizeForTelegram('- top\n  - sub\n    - deep')
+    const twice = sanitizeForTelegram(once)
+    expect(twice).toBe(once)
+  })
+
+  test('is idempotent for blank-line collapse', () => {
+    const once = sanitizeForTelegram('a\n\n\n\nb')
+    const twice = sanitizeForTelegram(once)
+    expect(twice).toBe(once)
+  })
+
+  test('is idempotent for code-block escaping', () => {
+    const once = sanitizeForTelegram('<code>a < b & c > d</code>')
+    const twice = sanitizeForTelegram(once)
+    expect(twice).toBe(once)
+  })
+
+  test('is idempotent for a combined realistic message', () => {
+    const input = [
+      '## Status Report',
+      '',
+      '- top item',
+      '  - sub item one',
+      '  - sub item two',
+      '',
+      '',
+      '',
+      'Here is some <code>a < b</code> inline code.',
+    ].join('\n')
+    const once = sanitizeForTelegram(input)
+    const twice = sanitizeForTelegram(once)
+    expect(twice).toBe(once)
   })
 })


### PR DESCRIPTION
## Summary

Implements the SANITIZER half of #270. The shared CLAUDE.md style fragment half is a follow-up PR.

Adds `sanitizeForTelegram(text)` in `telegram-plugin/format.ts` that runs after markdown→HTML conversion, before send. Normalizes outbound text against well-defined invariants without making semantic decisions.

## Rules implemented

1. **Strip `##` markdown heading markers** at line start. Replace with bold + blank line. Preserves emphasis, drops the broken pseudo-hierarchy.
2. **Flatten nested bullet indentation** — `\n  - sub` (and deeper) becomes `\n· sub`. Telegram doesn't render nested lists; this surfaces sub-detail without losing it.
3. **Collapse 3+ consecutive blank lines** → 2.
4. **Strip trailing whitespace** on each line.
5. **HTML-escape `<`/`>`/`&` inside `<code>` and `<pre>`** blocks. Doesn't double-escape existing entities.

The sanitizer is **idempotent**: `sanitize(sanitize(x)) === sanitize(x)`. Required because the same text can flow through multiple paths and we must never escape twice.

## Wiring

Applied to all four outbound HTML paths in `server.ts`:
- `reply` (line 1509)
- `stream_reply` (line 1872, threaded through the streaming engine via the `markdownToHtml` function param)
- `forward_message` (line 1975)
- `edit_message` (line 2044)

`markdownv2` and `text` formats are not sanitized (they have their own conventions).

## Tests

`tests/telegram-format.test.ts` extended with a `describe('sanitizeForTelegram')` block covering each rule + idempotency + protection of code blocks (sanitizer doesn't touch `## not a heading` inside backticks).

`bun test` in `telegram-plugin/` exits 0.

## Follow-up (not in this PR)

- Integration test that pipes a heading-laden message through the full reply send path. Unit tests cover the function; the wiring is mechanical (single function call) but a regression test on the integrated path would catch future breakage.
- Issue #270's other half — extract the shared CLAUDE.md "Telegram interaction style" fragment so all 5 agents reference one source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)