### PR TITLE
fix(#285): invoke bun explicitly in broker ExecStart

### DIFF
--- a/src/agents/cron-broker.test.ts
+++ b/src/agents/cron-broker.test.ts
@@ -107,6 +107,13 @@ describe("generateBrokerUnit", () => {
     expect(unit).toContain("vault broker start --foreground");
   });
 
+  it("ExecStart invokes bun explicitly (fix #285: bun-only installs where node is absent)", () => {
+    const unit = generateBrokerUnit(opts);
+    // The ExecStart must begin with the bun binary so systemd doesn't try to
+    // resolve #!/usr/bin/env node from the switchroom shebang (issue #285).
+    expect(unit).toMatch(/^ExecStart=.*\/bun .*\/switchroom vault broker start --foreground$/m);
+  });
+
   it("uses Restart=on-failure", () => {
     const unit = generateBrokerUnit(opts);
     expect(unit).toContain("Restart=on-failure");

--- a/src/agents/systemd-broker-unit.test.ts
+++ b/src/agents/systemd-broker-unit.test.ts
@@ -58,4 +58,9 @@ describe("generateBrokerUnit", () => {
     const unit = generateBrokerUnit(BASE_OPTS);
     expect(unit).toContain("vault broker start --foreground");
   });
+
+  it("ExecStart invokes bun explicitly before the switchroom CLI (fix #285)", () => {
+    const unit = generateBrokerUnit(BASE_OPTS);
+    expect(unit).toMatch(/^ExecStart=.*\/bun .*\/switchroom vault broker start --foreground$/m);
+  });
 });

--- a/src/agents/systemd.ts
+++ b/src/agents/systemd.ts
@@ -688,6 +688,7 @@ export interface BrokerUnitOpts {
  */
 export function generateBrokerUnit(opts: BrokerUnitOpts): string {
   const { homeDir, bunBinDir, autoUnlock } = opts;
+  const bunBin = resolve(bunBinDir, "bun");
   const switchroomCli = resolve(bunBinDir, "switchroom");
   const nodeBinDir = dirname(process.execPath);
   const unitPath = `${bunBinDir}:${nodeBinDir}:/usr/local/bin:/usr/bin:/bin`;
@@ -703,7 +704,7 @@ After=network-online.target
 
 [Service]
 Type=simple
-ExecStart=${switchroomCli} vault broker start --foreground
+ExecStart=${bunBin} ${switchroomCli} vault broker start --foreground
 Restart=on-failure
 RestartSec=2
 ${credentialLine}# Type=simple — see generateBrokerUnit() for the sd_notify-stream-vs-datagram
@@ -711,6 +712,8 @@ ${credentialLine}# Type=simple — see generateBrokerUnit() for the sd_notify-st
 # Type=notify caused a restart loop that destroyed unlock state.
 # No EnvironmentFile — the vault passphrase never touches disk.
 # Push the passphrase via: switchroom vault broker unlock
+# ExecStart invokes bun explicitly so the unit works on bun-only installs
+# where /usr/bin/env node is not resolvable (issue #285).
 Environment=PATH=${unitPath}
 Environment=HOME=${homeDir}
 


### PR DESCRIPTION
## Summary

- Fixes vault-broker systemd unit restart loop on bun-only installs (no `node` binary on PATH)
- Closes #285
- Changes `ExecStart=${switchroomCli} vault broker start --foreground` → `ExecStart=${bunBin} ${switchroomCli} vault broker start --foreground` in `generateBrokerUnit()`, matching the pattern already used by `generateGatewayUnit`

## Evidence

Ken's broker was at **6,264 restarts** at time of filing due to:

```
/usr/bin/env: 'node': No such file or directory
switchroom-vault-broker.service: Main process exited, code=exited, status=127/n/a
switchroom-vault-broker.service: Failed with result 'exit-code'.
```

The switchroom CLI shebang is `#!/usr/bin/env node`. On a bun-only install, `env` can't resolve `node`, so systemd exits 127 and immediately retries.

## Fix

`generateBrokerUnit()` now derives `bunBin = resolve(bunBinDir, "bun")` and uses it as the explicit interpreter in ExecStart — same approach as `generateGatewayUnit` (~line 241). Bun executes the CLI JS file directly, bypassing the shebang.

Verified locally: `bun ~/.bun/bin/switchroom --version` returns `0.3.0`.

## Test changes

Two new test assertions added — one in `src/agents/cron-broker.test.ts` and one in `src/agents/systemd-broker-unit.test.ts` — both asserting that ExecStart matches `bun … switchroom vault broker start --foreground`.

23 tests pass across the two broker test files (up from 21 before this PR).

## Backward compatibility

Switchroom already requires bun as its primary runtime. Node-only installs (no bun) would need bun installed, which is the documented requirement. This change aligns ExecStart with that requirement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)