### PR TITLE
fix: switchroom update reliability — bun shebang + rolling restart with settle gate

### DIFF
--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -89,11 +89,15 @@ execSync(
   { stdio: "inherit", cwd: root }
 );
 
-// Rewrite shebang from `bun` to `node` so npm-installed users don't need bun.
-console.log("[build] rewriting shebang -> node");
+// Rewrite shebang from `node` to `bun` — bun:sqlite and other bun: imports
+// are not polyfillable in Node, and bun is already a hard runtime dependency
+// (broker uses it explicitly, gateway runs `bun gateway.ts`, build itself
+// requires `bun install`). Running the bundle under node produces an
+// immediate ERR_UNSUPPORTED_ESM_URL_SCHEME 'bun:' error.
+console.log("[build] rewriting shebang -> bun");
 let src = readFileSync(outFile, "utf8");
-if (src.startsWith("#!/usr/bin/env bun")) {
-  src = src.replace(/^#!\/usr\/bin\/env bun/, "#!/usr/bin/env node");
+if (src.startsWith("#!/usr/bin/env node")) {
+  src = src.replace(/^#!\/usr\/bin\/env node/, "#!/usr/bin/env bun");
   writeFileSync(outFile, src);
 }
 chmodSync(outFile, 0o755);

--- a/src/build-info.ts
+++ b/src/build-info.ts
@@ -3,7 +3,7 @@
 // Values are refreshed every time `npm run build` runs.
 
 export const VERSION: string = "0.3.0";
-export const COMMIT_SHA: string | null = "c0fb1c0";
-export const COMMIT_DATE: string | null = "2026-04-27T23:24:36+10:00";
-export const LATEST_PR: number | null = 147;
-export const COMMITS_AHEAD_OF_TAG: number | null = 50;
+export const COMMIT_SHA: string | null = "49fd0a4";
+export const COMMIT_DATE: string | null = "2026-04-28T23:30:14+10:00";
+export const LATEST_PR: number | null = 18;
+export const COMMITS_AHEAD_OF_TAG: number | null = 102;

--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -2,7 +2,7 @@ import type { Command } from "commander";
 import chalk from "chalk";
 import { execSync, spawnSync } from "node:child_process";
 import { existsSync, realpathSync, readFileSync, writeFileSync, unlinkSync, mkdirSync } from "node:fs";
-import { dirname, join } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import { tmpdir, homedir } from "node:os";
 import { withConfigError, getConfig } from "./helpers.js";
 import { reconcileAgent } from "../agents/scaffold.js";
@@ -11,6 +11,19 @@ import { installAllUnits } from "../agents/systemd.js";
 import { resolveAgentsDir } from "../config/loader.js";
 import { getConfigPath } from "./helpers.js";
 import { printHealthSummary } from "./version.js";
+import {
+  defaultStatusInputs,
+  waitForAgentReady,
+  type StatusInputs,
+} from "../agents/status.js";
+import type { SwitchroomConfig } from "../config/schema.js";
+
+/**
+ * Per-agent settling timeout for the rolling update gate. After each agent
+ * is restarted we poll waitForAgentReady up to this long; if the agent has
+ * not become ready by then we halt the rolling update.
+ */
+const RESTART_SETTLE_TIMEOUT_MS = 30_000;
 
 /**
  * Locate the directory where switchroom is installed (the git checkout root).
@@ -262,7 +275,8 @@ interface UpdateResumeState {
 
 /**
  * Bump the global @anthropic-ai/claude-code package via bun.
- * Wraps in try/warn — network/permission failures are non-fatal.
+ * A half-installed Claude CLI is a worse state than aborting the update —
+ * fail loud rather than continue with an inconsistent fleet.
  */
 function bumpClaudeCli(installDir: string): void {
   console.log(chalk.gray("\n  Bumping @anthropic-ai/claude-code to latest..."));
@@ -273,11 +287,13 @@ function bumpClaudeCli(installDir: string): void {
       timeout: 180_000,
     });
   } catch (err) {
-    console.warn(
-      chalk.yellow(
-        `  Warning: failed to bump claude-code (network/permissions?): ${(err as Error).message}`
+    console.error(
+      chalk.red(
+        `  Failed to bump claude-code (network/permissions?): ${(err as Error).message}`
       )
     );
+    console.error(chalk.red("  Aborting update — fix the dep install and re-run."));
+    process.exit(1);
   }
 }
 
@@ -320,10 +336,81 @@ export function selfReexec(newBinary: string, resumeFile: string): never {
 }
 
 /**
- * Run the post-build phase: reconcile + restart + summary.
- * Called either directly (no source change) or after self-reexec with resume state.
+ * Build the StatusInputs for an agent, mirroring the resolution that
+ * `switchroom agent restart` already uses. Kept here so the rolling
+ * update gate can poll readiness with the same signal the operator sees.
  */
-function runPostBuildPhase(opts: {
+function buildStatusInputsForAgent(
+  name: string,
+  config: SwitchroomConfig,
+  agentsDir: string,
+): StatusInputs {
+  const agentDir = resolve(agentsDir, name);
+  const agentConfig = config.agents[name];
+  let hindsightApiUrl: string | null = null;
+  let hindsightBankId = name;
+  if (config.memory?.backend === "hindsight") {
+    const baseUrl =
+      (config.memory.config?.url as string | undefined) ??
+      "http://localhost:8888/mcp/";
+    hindsightApiUrl = baseUrl.endsWith("/mcp/")
+      ? baseUrl
+      : baseUrl.replace(/\/$/, "") + "/mcp/";
+    hindsightBankId = agentConfig?.memory?.collection ?? name;
+  }
+  return defaultStatusInputs({
+    agentName: name,
+    agentDir,
+    hindsightApiUrl,
+    hindsightBankId,
+  });
+}
+
+/**
+ * Print the rolling-halt message when an agent fails to settle. Lists
+ * what's on the new build vs. still on the old build, plus retry +
+ * inspect commands. Anchored to the JTBDs `survive-reboots-and-real-life`
+ * and `restart-and-know-what-im-running` — honest reporting over silent
+ * recovery, never claim ready when ready isn't true.
+ */
+function printRollingHaltMessage(
+  failed: string,
+  reason: string,
+  restarted: string[],
+  remaining: string[],
+): void {
+  console.error(chalk.red(`\n  ❌ Halting rolling update — agent ${failed} ${reason}.`));
+  console.error(chalk.red(`     Settle timeout: ${RESTART_SETTLE_TIMEOUT_MS / 1000}s per agent`));
+  console.error(
+    chalk.red(
+      `     On new build:  ${restarted.length > 0 ? restarted.join(", ") : "(none)"}`
+    )
+  );
+  console.error(chalk.red(`     Still on old:  ${remaining.join(", ")}`));
+  console.error(chalk.red(`     Retry:         switchroom update`));
+  console.error(chalk.red(`     Inspect:       switchroom logs ${failed}`));
+  console.error(chalk.red(`\n  Deployed-SHA marker NOT advanced — operator-of-record state preserved.\n`));
+}
+
+/**
+ * Run the post-build phase: reconcile-all → rolling restart with settle
+ * gate → summary. Async because the settle gate awaits waitForAgentReady.
+ *
+ * Behavior:
+ *   1. Regenerate systemd units. Hard fail on any unit error.
+ *   2. Reconcile every agent up front. Hard fail if any reconcile throws —
+ *      old binary stays in place, no live restart was attempted.
+ *   3. Compute the restart set (everyone if sourceChanged, else just the
+ *      agents whose reconcile produced changes).
+ *   4. For each agent in the restart set: writeRestartReasonMarker →
+ *      restartAgent → waitForAgentReady (timeout RESTART_SETTLE_TIMEOUT_MS).
+ *      On any failure (restart command throws, or ready times out), HALT.
+ *      Print the rolling-halt message; do NOT advance the deployed-SHA
+ *      marker; exit non-zero.
+ *   5. Persist deployed SHA only when every restart succeeded.
+ *   6. Print summary + health.
+ */
+async function runPostBuildPhase(opts: {
   program: Command;
   installDir: string;
   agentNames: string[];
@@ -332,7 +419,7 @@ function runPostBuildPhase(opts: {
   noRestart: boolean;
   /** Fix 4: new COMMIT_SHA from the just-built binary. Written to state file after restart. */
   newSha?: string;
-}): void {
+}): Promise<void> {
   const { program, installDir, agentNames, before, sourceChanged, noRestart, newSha } = opts;
   const config = getConfig(program);
   const agentsDir = resolveAgentsDir(config);
@@ -344,7 +431,8 @@ function runPostBuildPhase(opts: {
   }
 
   // Regenerate systemd units BEFORE reconcile+restart so restarted agents
-  // pick up any env-var changes baked into the unit file.
+  // pick up any env-var changes baked into the unit file. Hard fail —
+  // bad units = bad restarts. JTBD: real failures need real messages.
   console.log(chalk.bold("\n  Regenerating systemd units..."));
   try {
     installAllUnits(config);
@@ -353,12 +441,16 @@ function runPostBuildPhase(opts: {
     console.error(
       chalk.red(`    Failed to regenerate units: ${(err as Error).message}`)
     );
+    console.error(chalk.red("    Aborting update — fix unit generation and re-run."));
+    process.exit(1);
   }
 
+  // Reconcile-all-first. Pre-flight every agent before touching any live
+  // process; a single bad config aborts before the first restart. JTBD:
+  // "Eating a crash to look stable" is the anti-pattern we're avoiding.
   console.log(chalk.bold(`\n  Reconciling ${agentNames.length} agent(s)...`));
-  let reconciledCount = 0;
   const restartCandidates: string[] = [];
-
+  let reconcileFailures = 0;
   for (const name of agentNames) {
     const agentConfig = config.agents[name];
     try {
@@ -377,65 +469,115 @@ function runPostBuildPhase(opts: {
         for (const f of result.changes) {
           console.log(chalk.gray(`      - ${f}`));
         }
-        reconciledCount++;
         restartCandidates.push(name);
       }
     } catch (err) {
       console.error(chalk.red(`    ${name}: ${(err as Error).message}`));
+      reconcileFailures++;
     }
   }
 
-  // Restart agents — always restart on source pull, only on config change otherwise.
-  const shouldRestart = !noRestart && (sourceChanged || reconciledCount > 0);
-  const toRestart = sourceChanged ? agentNames : restartCandidates;
-
-  if (shouldRestart && toRestart.length > 0) {
-    const afterShort = runCaptured("git rev-parse --short HEAD", installDir)?.trim() ?? null;
-    let updateReason: string;
-    if (sourceChanged && afterShort) {
-      let subject = runCaptured(`git log -1 --pretty=%s ${afterShort}`, installDir)?.trim() ?? "";
-      if (subject.length > 60) subject = `${subject.slice(0, 57)}…`;
-      updateReason = subject
-        ? `update: pulled ${afterShort} ${subject}`
-        : `update: pulled ${afterShort}`;
-    } else {
-      updateReason = "update: reconciled config";
-    }
-    console.log(chalk.bold(`\n  Restarting ${toRestart.length} agent(s)...`));
-    for (const name of toRestart) {
-      try {
-        writeRestartReasonMarker(name, updateReason);
-        restartAgent(name);
-        console.log(chalk.green(`    ${name}: restarted`));
-      } catch (err) {
-        console.error(
-          chalk.red(`    ${name}: restart failed: ${(err as Error).message}`)
-        );
-      }
-    }
-
-    // Fix 4: Persist the deployed SHA so the next `switchroom update` can
-    // detect whether the in-memory agents are already running this build.
-    if (newSha) {
-      try {
-        writeLastDeployedSha(newSha);
-        console.log(chalk.gray(`\n  Deployed SHA recorded: ${newSha}`));
-      } catch (err) {
-        console.warn(chalk.yellow(`  Warning: could not write deployed SHA: ${(err as Error).message}`));
-      }
-    }
-  } else if (noRestart) {
-    console.log(
-      chalk.gray(
-        "\n  --no-restart given; agents NOT restarted. Run `switchroom agent restart all` to apply."
+  if (reconcileFailures > 0) {
+    console.error(
+      chalk.red(
+        `\n  ${reconcileFailures} agent(s) failed to reconcile — aborting before any restart.`
       )
     );
+    console.error(chalk.red("  Old binary remains in place. Fix the config and re-run.\n"));
+    process.exit(1);
   }
 
-  // Summary
+  // Determine restart set.
+  const shouldRestart = !noRestart && (sourceChanged || restartCandidates.length > 0);
+  const toRestart = sourceChanged ? agentNames : restartCandidates;
+
+  if (!shouldRestart || toRestart.length === 0) {
+    if (noRestart) {
+      console.log(
+        chalk.gray(
+          "\n  --no-restart given; agents NOT restarted. Run `switchroom agent restart all` to apply."
+        )
+      );
+    }
+    const after = runCaptured("git rev-parse --short HEAD", installDir)?.trim() ?? "unknown";
+    console.log(chalk.bold(`\n  Done. ${before} → ${after}\n`));
+    const finalConfig = getConfig(program);
+    printHealthSummary(finalConfig);
+    console.log();
+    return;
+  }
+
+  // Compute restart reason once (used for the marker each agent gets).
+  const afterShort = runCaptured("git rev-parse --short HEAD", installDir)?.trim() ?? null;
+  let updateReason: string;
+  if (sourceChanged && afterShort) {
+    let subject = runCaptured(`git log -1 --pretty=%s ${afterShort}`, installDir)?.trim() ?? "";
+    if (subject.length > 60) subject = `${subject.slice(0, 57)}…`;
+    updateReason = subject
+      ? `update: pulled ${afterShort} ${subject}`
+      : `update: pulled ${afterShort}`;
+  } else {
+    updateReason = "update: reconciled config";
+  }
+
+  // Rolling restart with settle gate. One-at-a-time, halt on first failure.
+  console.log(
+    chalk.bold(
+      `\n  Rolling restart of ${toRestart.length} agent(s) (settle timeout ${RESTART_SETTLE_TIMEOUT_MS / 1000}s each)...`
+    )
+  );
+  const restarted: string[] = [];
+
+  for (let i = 0; i < toRestart.length; i++) {
+    const name = toRestart[i]!;
+    const remainingAfter = toRestart.slice(i + 1);
+
+    try {
+      writeRestartReasonMarker(name, updateReason);
+      restartAgent(name);
+      console.log(chalk.gray(`    ${name}: restart issued, waiting for settle...`));
+    } catch (err) {
+      console.error(
+        chalk.red(`    ${name}: restart failed: ${(err as Error).message}`)
+      );
+      printRollingHaltMessage(name, "restart command failed", restarted, [name, ...remainingAfter]);
+      process.exit(1);
+    }
+
+    const inputs = buildStatusInputsForAgent(name, config, agentsDir);
+    const result = await waitForAgentReady(inputs, { timeoutMs: RESTART_SETTLE_TIMEOUT_MS });
+    const secs = (result.elapsedMs / 1000).toFixed(1);
+    if (result.ready) {
+      console.log(chalk.green(`    ${name}: settled in ${secs}s`));
+      restarted.push(name);
+    } else {
+      console.error(
+        chalk.red(
+          `    ${name}: did not settle within ${secs}s — gaps: ${result.notReady.join(", ")}`
+        )
+      );
+      printRollingHaltMessage(
+        name,
+        `did not settle (${result.notReady.join(", ")})`,
+        restarted,
+        [name, ...remainingAfter],
+      );
+      process.exit(1);
+    }
+  }
+
+  // All agents settled. Persist the deployed-SHA marker.
+  if (newSha) {
+    try {
+      writeLastDeployedSha(newSha);
+      console.log(chalk.gray(`\n  Deployed SHA recorded: ${newSha}`));
+    } catch (err) {
+      console.warn(chalk.yellow(`  Warning: could not write deployed SHA: ${(err as Error).message}`));
+    }
+  }
+
   const after = runCaptured("git rev-parse --short HEAD", installDir)?.trim() ?? "unknown";
   console.log(chalk.bold(`\n  Done. ${before} → ${after}\n`));
-
   const finalConfig = getConfig(program);
   printHealthSummary(finalConfig);
   console.log();
@@ -477,7 +619,7 @@ export function registerUpdateCommand(program: Command): void {
           // the persisted state. argv on the resume command is hardcoded by
           // selfReexec and does not include the user's original flags, so
           // never read opts.restart here.
-          runPostBuildPhase({
+          await runPostBuildPhase({
             program,
             installDir: state.installDir,
             agentNames: state.agentNames,
@@ -624,7 +766,9 @@ export function registerUpdateCommand(program: Command): void {
           if (changed.includes("package.json") || changed.includes("bun.lock")) {
             console.log(chalk.gray("\n  Reinstalling dependencies (package.json changed)..."));
             if (!runStreamed("bun install --quiet", installDir, 120_000)) {
-              console.error(chalk.yellow("  bun install reported a non-zero exit"));
+              console.error(chalk.red("  bun install failed — aborting update."));
+              console.error(chalk.red("  Fix dependencies and re-run `switchroom update`."));
+              process.exit(1);
             }
           }
 
@@ -632,7 +776,10 @@ export function registerUpdateCommand(program: Command): void {
           const pluginPkg = join(installDir, "telegram-plugin", "package.json");
           if (existsSync(pluginPkg) && changed.includes("telegram-plugin/package.json")) {
             console.log(chalk.gray("  Reinstalling telegram-plugin dependencies..."));
-            runStreamed("bun install --quiet", join(installDir, "telegram-plugin"), 120_000);
+            if (!runStreamed("bun install --quiet", join(installDir, "telegram-plugin"), 120_000)) {
+              console.error(chalk.red("  bun install (telegram-plugin) failed — aborting update."));
+              process.exit(1);
+            }
           }
         }
 
@@ -675,7 +822,9 @@ export function registerUpdateCommand(program: Command): void {
           // Always reinstall deps before a rebuild so any lockfile changes are applied.
           console.log(chalk.gray("\n  Running bun install..."));
           if (!runStreamed("bun install --quiet", installDir, 120_000)) {
-            console.error(chalk.yellow("  bun install reported a non-zero exit"));
+            console.error(chalk.red("  bun install failed — aborting update before rebuild."));
+            console.error(chalk.red("  Fix dependencies and re-run `switchroom update`."));
+            process.exit(1);
           }
           const built = rebuildCli(installDir);
 
@@ -719,7 +868,7 @@ export function registerUpdateCommand(program: Command): void {
         // 6. Reconcile (if no self-reexec happened)
         const config = getConfig(program);
         const agentNames = Object.keys(config.agents);
-        runPostBuildPhase({
+        await runPostBuildPhase({
           program,
           installDir,
           agentNames,

--- a/tests/scaffold.test.ts
+++ b/tests/scaffold.test.ts
@@ -1576,9 +1576,10 @@ describe("scaffoldAgent with global defaults cascade", () => {
         ],
       },
     ]);
-    // User's Stop hook + switchroom-owned Stop hooks (handoff + secret-scrub).
-    // secret-scrub is added when the switchroom telegram plugin is used
-    // (the default in this test's telegramConfig).
+    // User's Stop hook + switchroom-owned Stop hooks (handoff + secret-scrub
+    // + silent-end-interrupt). secret-scrub and silent-end-interrupt are added
+    // when the switchroom telegram plugin is used (the default in this test's
+    // telegramConfig).
     expect(settings.hooks.Stop).toEqual([
       {
         hooks: [
@@ -1598,6 +1599,12 @@ describe("scaffoldAgent with global defaults cascade", () => {
             command: expect.stringContaining("secret-scrub-stop.mjs"),
             timeout: 15,
             async: true,
+          },
+          {
+            type: "command",
+            command: expect.stringContaining("silent-end-interrupt-stop.mjs"),
+            timeout: 5,
+            async: false,
           },
         ],
       },


### PR DESCRIPTION
## Why

`switchroom update` has been silently broken for operators for weeks. Two interlocking failures:

1. **CLI binary unrunnable via node.** The bundle's shebang is `#!/usr/bin/env node`, but the bundle imports `bun:` modules (`bun:sqlite` and friends) that node cannot load. Result: `switchroom <any-cmd>` from the shell errors immediately with `ERR_UNSUPPORTED_ESM_URL_SCHEME 'bun:'`. Workaround was `bun /path/switchroom`.

2. **No health gate between agent restarts.** `update` restarted every agent in a tight loop. If agent #3 failed to come back, the loop continued and the operator only found out later. Anti-pattern from the JTBDs `survive-reboots-and-real-life` and `restart-and-know-what-im-running`: silent recovery, green ticks that hide dead processes.

## What

Three commits (rebased onto upstream/main):

**`d395ff9 fix(build): use bun shebang in CLI bundle`**
- Change `scripts/build.mjs` to rewrite the shebang to `bun` instead of `node`. Bun is already a hard dep (telegram-plugin runs `bun gateway.ts`, broker uses bun explicitly per #285, build itself runs `bun install`). Polyfilling `bun:sqlite` and other bun-only APIs is impractical.

**`1a20cea fix(cli): rolling update with settle gate and fail-loud deps`**
- Restart agents one-at-a-time, gated on `waitForAgentReady` (same primitive `switchroom agent restart` uses post-#171/#176).
- On any agent failing to settle within 30s: halt, do NOT advance `last-deployed-sha.json`, print which agents are on the new build vs still on old, with retry + inspect commands.
- Pre-flight: reconcile every agent up-front; a single bad config aborts before touching any live process.
- Hard-fail on `bun install`, `bumpClaudeCli`, and unit-regen errors. Half-installed deps is a worse state than 'aborted, fix and retry'.
- No new flags. Default behaviour. `--check` still covers dry-run.

**`facbea9 test(scaffold): include silent-end-interrupt-stop.mjs in Stop hooks expectation`** (drive-by)
- Upstream PR #288 added a silent-end-interrupt Stop hook in scaffold.ts but didn't update the test expectation. CI has been failing on every PR since. Drive-by fix included so this PR can merge cleanly.

## Anchored to JTBDs

- `reference/survive-reboots-and-real-life.md`: "Eating a crash to look stable. Real failures need real messages."
- `reference/restart-and-know-what-im-running.md`: "Reporting success when auth is broken. A 'ready' message that hides a dead login is a trap."

## Test plan

- [x] `npm run lint` (tsc --noEmit) — passes
- [x] `npm run test:vitest` — 3661 pass / 6 skipped (was 3632 pre-rebase + 29 in upstream's recent PRs)
- [x] `npm run test:bun` — exit 0
- [x] `node scripts/build.mjs` — produces 1.49MB bundle with `bun` shebang
- [x] **Live deploy test** — copied built dist to canonical, ran `switchroom update --no-restart` end-to-end via new code. Result: vault-broker recovered (NRestarts 6264 → 0, listening on socket); finn manually restarted came back `overall: ok` with all components green; CLI now responds to `switchroom --version` (was throwing ESM error before).
- [ ] **Full fleet rolling restart test** — needs operator authorization. The settle-gate code path is untested in production until a real `switchroom update` (without `--no-restart`) runs against the live fleet.

## Test gap

Did not add a new integration test for the halt-on-fail behavior in this PR — the surface mocks (`waitForAgentReady`, `restartAgent`, `reconcileAgent`, `installAllUnits`, `getConfig`) are large. Existing `tests/update.helpers.test.ts` and `tests/update.unit-regen.test.ts` still pass. Flagged as follow-up.

## Notes

- After merge + fleet update, operators with `last-deployed-sha.json` missing will get one written on the first successful run.
- The vault-broker's NRestarts=6264 failure (caused by node executing the bun-required CLI to do its work) gets fixed transitively — units regenerate via `installAllUnits`, broker ExecStart now invokes bun explicitly per #285, and from this PR the CLI shebang is bun so any code path through the binary works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)