### PR TITLE
fix(#215): restart --force bypasses bot token validator

### DIFF
--- a/src/cli/agent.ts
+++ b/src/cli/agent.ts
@@ -384,6 +384,13 @@ export interface ReconcileAndRestartOpts {
   graceful?: boolean;
   /** Suppress stdout logging (tests). */
   silent?: boolean;
+  /**
+   * Skip the bot-token / Telegram getMe validation that would otherwise
+   * abort the restart on a transient network error. Wired from the CLI's
+   * `--force` flag — if the operator says force, they mean it, including
+   * for checks that go to the network.
+   */
+  force?: boolean;
 }
 
 /**
@@ -499,7 +506,14 @@ export async function reconcileAndRestartAgent(
   // bot username contains the agent slug. This catches copy-paste mistakes
   // (e.g. clerk's token in finn's .env) before the agent restarts and starts
   // spamming 409 conflicts. Fails loudly — refuse to restart on mismatch.
-  {
+  //
+  // --force bypasses this. The validator hits api.telegram.org and so can
+  // fail for reasons unrelated to a token mismatch (transient network blip,
+  // Telegram rate-limit, DNS hiccup). When the operator passes --force they
+  // are asserting they know what they want; making `--force` honest about
+  // skipping all preflight (including network-dependent ones) matches the
+  // behaviour of the other preflight gates in the restart command.
+  if (!opts.force) {
     const envPath = resolve(agentsDir, name, "telegram", ".env");
     if (existsSync(envPath)) {
       const envContent = readFileSync(envPath, "utf-8");
@@ -513,7 +527,8 @@ export async function reconcileAndRestartAgent(
           // Fail loudly — do not restart with a wrong token.
           throw new Error(
             `Bot token mismatch for agent "${name}": ${msg}\n` +
-              `Fix telegram/.env or the vault entry, then re-run the command.`,
+              `Fix telegram/.env or the vault entry, then re-run the command.\n` +
+              `Or pass --force to skip this and other preflight checks.`,
           );
         }
       }
@@ -1094,7 +1109,7 @@ export function registerAgentCommand(program: Command): void {
                 config,
                 agentsDir,
                 getConfigPath(program),
-                { graceful: opts.gracefulRestart },
+                { graceful: opts.gracefulRestart, force: opts.force },
               );
 
               if (opts.gracefulRestart) {

--- a/tests/scaffold.test.ts
+++ b/tests/scaffold.test.ts
@@ -1576,9 +1576,10 @@ describe("scaffoldAgent with global defaults cascade", () => {
         ],
       },
     ]);
-    // User's Stop hook + switchroom-owned Stop hooks (handoff + secret-scrub).
-    // secret-scrub is added when the switchroom telegram plugin is used
-    // (the default in this test's telegramConfig).
+    // User's Stop hook + switchroom-owned Stop hooks (handoff + secret-scrub
+    // + silent-end-interrupt). secret-scrub and silent-end-interrupt are added
+    // when the switchroom telegram plugin is used (the default in this test's
+    // telegramConfig).
     expect(settings.hooks.Stop).toEqual([
       {
         hooks: [
@@ -1598,6 +1599,12 @@ describe("scaffoldAgent with global defaults cascade", () => {
             command: expect.stringContaining("secret-scrub-stop.mjs"),
             timeout: 15,
             async: true,
+          },
+          {
+            type: "command",
+            command: expect.stringContaining("silent-end-interrupt-stop.mjs"),
+            timeout: 5,
+            async: false,
           },
         ],
       },


### PR DESCRIPTION
## Why

`switchroom agent restart <name> --force` is documented as "Skip preflight + in-flight checks", but in practice the bot-token getMe validation in `reconcileAndRestartAgent` runs anyway. That validator hits `api.telegram.org` so a transient network blip aborts the restart with "Bot token mismatch", leaving operators to fall back to `systemctl --user restart switchroom-<name>.service` directly. Defeats the wrapper.

Reproduced by Ken on 2026-04-28 — four agents all blocked at once on a single transient blip; direct `curl` to api.telegram.org from the same shell returned 302 in 800ms.

## What

- New `force?: boolean` on `ReconcileAndRestartOpts` (in `src/cli/agent.ts`).
- The bot-token validation block now gated on `!opts.force`. Existing structure preserved otherwise.
- Restart CLI handler at line 1097 now passes `force: opts.force` into `reconcileAndRestartAgent`.
- Error message extended to mention `--force` as the bypass.

The other preflight gates (`preflightCheck`, in-flight `detectInFlight`) were already gated on `!opts.force`; the bot-token validator was the lone holdout.

## Drive-by

Same `tests/scaffold.test.ts` fix as PRs #291 and #292 since upstream #288 left it broken.

## Test plan

- [x] `npm run lint` — passes
- [x] `npm run test:vitest` — 3661 pass / 6 skipped
- [ ] Live verification: simulate transient network failure during restart, confirm `--force` proceeds while default mode still aborts with the helpful message.

Closes #215.

🤖 Generated with [Claude Code](https://claude.com/claude-code)