### PR TITLE
fix(#265): assertSafeAgentName before vault grant token-write in gateway.ts

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -4920,6 +4920,12 @@ async function grantWizardConfirm(ctx: Context, chatId: string, state: Extract<P
 /** Execute the grant: call broker mint_grant, write token, reply. */
 async function executeGrantWizard(ctx: Context, chatId: string, state: Extract<PendingVaultOp, { kind: 'grant-wizard' }>): Promise<void> {
   pendingVaultOps.delete(chatId)
+  // Defence-in-depth: state.agent flows from callback_data into a path
+  // join below. A crafted vg:agent:../../etc payload would produce a
+  // path traversal. Validate against the same regex the rest of the
+  // file uses; on failure, drop silently — the wizard message has
+  // already been finalized.
+  try { assertSafeAgentName(state.agent!) } catch { return }
   const result = await mintGrantViaBroker({
     agent: state.agent!,
     keys: state.selectedKeys!,

--- a/telegram-plugin/tests/vault-grant-wizard.test.ts
+++ b/telegram-plugin/tests/vault-grant-wizard.test.ts
@@ -11,10 +11,25 @@
  */
 import { describe, it, expect } from 'vitest'
 import { readFileSync } from 'node:fs'
-import { join } from 'node:path'
+import { join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+// Resolve paths relative to the repo root, derived from this test file's
+// own location, instead of process.cwd() — which is brittle across run
+// modes (vitest from repo root vs `bun test` from telegram-plugin/ vs
+// CI's `cd telegram-plugin && bun test`). The repo root is two levels
+// up from this file (telegram-plugin/tests/vault-grant-wizard.test.ts).
+const TEST_DIR = (() => {
+  try {
+    return resolve(fileURLToPath(import.meta.url), '..')
+  } catch {
+    return resolve('.')
+  }
+})()
+const REPO_ROOT = resolve(TEST_DIR, '..', '..')
 
 function readSrc(rel: string): string {
-  return readFileSync(join(process.cwd(), rel), 'utf8')
+  return readFileSync(join(REPO_ROOT, rel), 'utf8')
 }
 
 describe('/vault grant inline-keyboard wizard (#227)', () => {

--- a/tests/scaffold.test.ts
+++ b/tests/scaffold.test.ts
@@ -1576,9 +1576,10 @@ describe("scaffoldAgent with global defaults cascade", () => {
         ],
       },
     ]);
-    // User's Stop hook + switchroom-owned Stop hooks (handoff + secret-scrub).
-    // secret-scrub is added when the switchroom telegram plugin is used
-    // (the default in this test's telegramConfig).
+    // User's Stop hook + switchroom-owned Stop hooks (handoff + secret-scrub
+    // + silent-end-interrupt). secret-scrub and silent-end-interrupt are added
+    // when the switchroom telegram plugin is used (the default in this test's
+    // telegramConfig).
     expect(settings.hooks.Stop).toEqual([
       {
         hooks: [
@@ -1598,6 +1599,12 @@ describe("scaffoldAgent with global defaults cascade", () => {
             command: expect.stringContaining("secret-scrub-stop.mjs"),
             timeout: 15,
             async: true,
+          },
+          {
+            type: "command",
+            command: expect.stringContaining("silent-end-interrupt-stop.mjs"),
+            timeout: 5,
+            async: false,
           },
         ],
       },


### PR DESCRIPTION
## Why

PR #262 mirrored the /vault grant wizard from \`server.ts\` into \`gateway.ts\`. PR #266 fixed the path-traversal in \`server.ts\` by adding \`assertSafeAgentName\`. The gateway port was a faithful mirror of server.ts at the time and inherited the same gap.

\`state.agent\` is set from \`data.slice('vg:agent:'.length)\` in the callback handler and flows directly into a path join inside \`executeGrantWizard\`:

\`\`\`ts
const tokenPath = join(homedir(), '.switchroom', 'agents', state.agent!, '.vault-token')
\`\`\`

A crafted \`vg:agent:../../etc\` payload would produce a path traversal.

## What

One-line add at the top of \`executeGrantWizard\` in \`telegram-plugin/gateway/gateway.ts\`:

\`\`\`ts
try { assertSafeAgentName(state.agent!) } catch { return }
\`\`\`

Mirrors the server.ts fix from PR #266. \`assertSafeAgentName\` is already defined elsewhere in this file. On failure, drop silently — the wizard message has been finalized by the caller, and silent-on-malformed matches how the other early-return paths in the same function behave.

## Drive-by

Same \`tests/scaffold.test.ts\` fix as PRs #291/#292/#294 (upstream #288 left it broken).

## Test plan

- [x] \`npm run lint\` — passes
- [x] \`npm run test:vitest\` — 3661 pass / 6 skipped
- [x] \`npm run test:bun\` — exit 0
- [ ] Add a regression test for the gateway's executeGrantWizard with malformed agent — out of scope for this PR; the issue body groups this with sub-issue 3 (test parity), which can ship separately.

Closes part of #265 (sub-issues 2 + 3 still open).

🤖 Generated with [Claude Code](https://claude.com/claude-code)