### PR TITLE
fix(#299): honor NO_REPLY / HEARTBEAT_OK in answer-stream materialisation path

### DIFF
--- a/telegram-plugin/answer-stream.ts
+++ b/telegram-plugin/answer-stream.ts
@@ -433,7 +433,10 @@ export function createAnswerStream(config: AnswerStreamConfig): AnswerStreamHand
       // (exact-match, with trailing-punctuation tolerance), suppress outbound
       // and log — mirrors the suppression in server.ts and turn-flush-safety.ts.
       if (isSilentFlushMarker(textToSend)) {
-        const marker = textToSend.trim().toUpperCase()
+        // Normalise the same way isSilentFlushMarker does so log searches for
+        // `marker=NO_REPLY` match both `NO_REPLY` and `NO_REPLY.` inputs.
+        let marker = textToSend.trim().toUpperCase()
+        if (marker.length > 0 && /\W$/.test(marker)) marker = marker.slice(0, -1)
         log?.(
           `telegram gateway: answer-stream: silent-marker-suppressed marker=${marker} chatId=${chatId}`,
         )

--- a/telegram-plugin/answer-stream.ts
+++ b/telegram-plugin/answer-stream.ts
@@ -1,3 +1,5 @@
+import { isSilentFlushMarker } from './turn-flush-safety.js'
+
 /**
  * Answer-lane incremental streaming for long Telegram replies.
  *
@@ -423,6 +425,17 @@ export function createAnswerStream(config: AnswerStreamConfig): AnswerStreamHand
         warn?.(
           `answer-stream: materialize — text exceeds ${TELEGRAM_MAX_CHARS} chars (got ${textToSend.length}); skipping. ` +
           `The reply path should have already delivered chunked output; this is a defensive guard.`,
+        )
+        return undefined
+      }
+
+      // Silent-marker guard: if the whole body is NO_REPLY / HEARTBEAT_OK
+      // (exact-match, with trailing-punctuation tolerance), suppress outbound
+      // and log — mirrors the suppression in server.ts and turn-flush-safety.ts.
+      if (isSilentFlushMarker(textToSend)) {
+        const marker = textToSend.trim().toUpperCase()
+        log?.(
+          `telegram gateway: answer-stream: silent-marker-suppressed marker=${marker} chatId=${chatId}`,
         )
         return undefined
       }

--- a/telegram-plugin/tests/answer-stream-silent-markers.test.ts
+++ b/telegram-plugin/tests/answer-stream-silent-markers.test.ts
@@ -1,0 +1,207 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
+
+import {
+  createAnswerStream,
+  __resetDraftIdForTests,
+} from '../answer-stream.js'
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+type SendMessageFn = (
+  chatId: string,
+  text: string,
+  params?: {
+    parse_mode?: 'HTML'
+    message_thread_id?: number
+    link_preview_options?: { is_disabled: boolean }
+    reply_parameters?: { message_id: number }
+  },
+) => Promise<{ message_id: number }>
+
+type EditMessageTextFn = (
+  chatId: string,
+  messageId: number,
+  text: string,
+  params?: {
+    parse_mode?: 'HTML'
+    message_thread_id?: number
+    link_preview_options?: { is_disabled: boolean }
+  },
+) => Promise<unknown>
+
+type SendMessageDraftFn = (
+  chatId: string,
+  draftId: number,
+  text: string,
+  params?: { message_thread_id?: number },
+) => Promise<unknown>
+
+let nextMessageId = 9000
+
+function makeSendMessage(): ReturnType<typeof vi.fn> & SendMessageFn {
+  const fn = vi.fn(async (_chatId: string, _text: string) => {
+    return { message_id: nextMessageId++ }
+  })
+  return fn as unknown as ReturnType<typeof vi.fn> & SendMessageFn
+}
+
+function makeEditMessageText(): ReturnType<typeof vi.fn> & EditMessageTextFn {
+  return vi.fn(async () => {}) as unknown as ReturnType<typeof vi.fn> & EditMessageTextFn
+}
+
+function makeSendMessageDraft(): ReturnType<typeof vi.fn> & SendMessageDraftFn {
+  return vi.fn(async () => {}) as unknown as ReturnType<typeof vi.fn> & SendMessageDraftFn
+}
+
+beforeEach(() => {
+  __resetDraftIdForTests()
+  nextMessageId = 9000
+  vi.useFakeTimers()
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+/**
+ * Regression coverage for #299: answer-stream materialize() must honor the
+ * NO_REPLY / HEARTBEAT_OK silent markers and suppress outbound Telegram
+ * messages when the whole turn body is one of those tokens.
+ *
+ * Root cause: in private chats (DMs), usesDraftTransport=true bypasses the
+ * minInitialChars length gate in update(), so even short markers like "NO_REPLY"
+ * (8 chars) reach pendingText and then materialize() sends them as real messages.
+ *
+ * Mirrors the sentinel suppression already present in:
+ *   - server.ts (reply/stream_reply MCP tool handlers)
+ *   - turn-flush-safety.ts (stop-hook decideTurnFlush)
+ *   - gateway.ts (gateway turn-flush)
+ */
+describe('answer-stream — silent-marker suppression at materialize()', () => {
+  it('NO_REPLY as the sole chunk — no outbound message, suppression log line emitted', async () => {
+    // Use isPrivateChat: true + sendMessageDraft to replicate the exact repro
+    // conditions from #299: DM chat bypasses the minInitialChars length gate
+    // in update(), so "NO_REPLY" (8 chars) reaches pendingText and materialize()
+    // would previously send it as a real Telegram message.
+    const sendMessage = makeSendMessage()
+    const editMessageText = makeEditMessageText()
+    const sendMessageDraft = makeSendMessageDraft()
+    const logs: string[] = []
+    const stream = createAnswerStream({
+      chatId: 'chat42',
+      isPrivateChat: true,
+      throttleMs: 250,
+      sendMessage,
+      editMessageText,
+      sendMessageDraft,
+      log: (msg) => logs.push(msg),
+    })
+
+    // Simulate: model emits exactly NO_REPLY, no reply/stream_reply call.
+    // In a DM, update() bypasses the length gate and sets pendingText.
+    stream.update('NO_REPLY')
+    // materialize() is what gateway.ts calls at turn_end when no tool reply
+    // was made — this is the path that was broken in #299 (msg id=8268).
+    const msgId = await stream.materialize()
+
+    expect(sendMessage).not.toHaveBeenCalled()
+    expect(editMessageText).not.toHaveBeenCalled()
+    expect(msgId).toBeUndefined()
+    expect(logs.some(l => /silent-marker-suppressed.*NO_REPLY.*chatId=chat42/i.test(l))).toBe(true)
+  })
+
+  it('HEARTBEAT_OK as the sole chunk — no outbound message', async () => {
+    const sendMessage = makeSendMessage()
+    const editMessageText = makeEditMessageText()
+    const sendMessageDraft = makeSendMessageDraft()
+    const stream = createAnswerStream({
+      chatId: 'chat43',
+      isPrivateChat: true,
+      throttleMs: 250,
+      sendMessage,
+      editMessageText,
+      sendMessageDraft,
+    })
+
+    stream.update('HEARTBEAT_OK')
+    const msgId = await stream.materialize()
+
+    expect(sendMessage).not.toHaveBeenCalled()
+    expect(msgId).toBeUndefined()
+  })
+
+  it('NO_REPLY. (trailing period) — suppressed by trailing-punctuation tolerance', async () => {
+    const sendMessage = makeSendMessage()
+    const editMessageText = makeEditMessageText()
+    const sendMessageDraft = makeSendMessageDraft()
+    const logs: string[] = []
+    const stream = createAnswerStream({
+      chatId: 'chat44',
+      isPrivateChat: true,
+      throttleMs: 250,
+      sendMessage,
+      editMessageText,
+      sendMessageDraft,
+      log: (msg) => logs.push(msg),
+    })
+
+    stream.update('NO_REPLY.')
+    const msgId = await stream.materialize()
+
+    expect(sendMessage).not.toHaveBeenCalled()
+    expect(msgId).toBeUndefined()
+    expect(logs.some(l => /silent-marker-suppressed/i.test(l))).toBe(true)
+  })
+
+  it('substring match ("the agent suggested NO_REPLY earlier") — NOT suppressed, materialises normally', async () => {
+    const sendMessage = makeSendMessage()
+    const editMessageText = makeEditMessageText()
+    const sendMessageDraft = makeSendMessageDraft()
+    const stream = createAnswerStream({
+      chatId: 'chat45',
+      isPrivateChat: true,
+      throttleMs: 250,
+      sendMessage,
+      editMessageText,
+      sendMessageDraft,
+    })
+
+    const prose = 'the agent suggested NO_REPLY earlier'
+    stream.update(prose)
+    // materialize() should send a fresh message — only 1 call, from materialize
+    // itself (update() in draft mode sends a draft, not a sendMessage call).
+    const msgId = await stream.materialize()
+
+    expect(sendMessage).toHaveBeenCalledTimes(1)
+    expect(sendMessage).toHaveBeenCalledWith(
+      'chat45',
+      prose,
+      expect.objectContaining({ parse_mode: 'HTML' }),
+    )
+    expect(typeof msgId).toBe('number')
+  })
+
+  it('empty body — materialize returns undefined, no outbound (existing behaviour)', async () => {
+    const sendMessage = makeSendMessage()
+    const editMessageText = makeEditMessageText()
+    const logs: string[] = []
+    const stream = createAnswerStream({
+      chatId: 'chat46',
+      isPrivateChat: false,
+      throttleMs: 250,
+      sendMessage,
+      editMessageText,
+      log: (msg) => logs.push(msg),
+    })
+
+    // No update() call — nothing buffered.
+    const msgId = await stream.materialize()
+
+    expect(sendMessage).not.toHaveBeenCalled()
+    expect(msgId).toBeUndefined()
+    // Existing log message for empty body
+    expect(logs.some(l => /nothing to send/i.test(l))).toBe(true)
+  })
+})

--- a/telegram-plugin/tests/answer-stream-silent-markers.test.ts
+++ b/telegram-plugin/tests/answer-stream-silent-markers.test.ts
@@ -183,6 +183,35 @@ describe('answer-stream — silent-marker suppression at materialize()', () => {
     expect(typeof msgId).toBe('number')
   })
 
+  it('multi-chunk update where final body equals NO_REPLY — still suppressed (#299 review feedback)', async () => {
+    // update() replaces pendingText wholesale on each call, so two updates
+    // where the second equals NO_REPLY should suppress at materialize().
+    // This pins the assumption that the guard fires on final resolved body,
+    // not on any intermediate chunk.
+    const sendMessage = makeSendMessage()
+    const editMessageText = makeEditMessageText()
+    const sendMessageDraft = makeSendMessageDraft()
+    const logs: string[] = []
+    const stream = createAnswerStream({
+      chatId: 'chat47',
+      isPrivateChat: true,
+      throttleMs: 250,
+      sendMessage,
+      editMessageText,
+      sendMessageDraft,
+      log: (msg) => logs.push(msg),
+    })
+
+    // Model first emits a draft thought, then revises to bare NO_REPLY.
+    stream.update('let me think...')
+    stream.update('NO_REPLY')
+    const msgId = await stream.materialize()
+
+    expect(sendMessage).not.toHaveBeenCalled()
+    expect(msgId).toBeUndefined()
+    expect(logs.some(l => /silent-marker-suppressed.*NO_REPLY.*chatId=chat47/i.test(l))).toBe(true)
+  })
+
   it('empty body — materialize returns undefined, no outbound (existing behaviour)', async () => {
     const sendMessage = makeSendMessage()
     const editMessageText = makeEditMessageText()

--- a/telegram-plugin/tests/turn-flush-safety.test.ts
+++ b/telegram-plugin/tests/turn-flush-safety.test.ts
@@ -157,6 +157,15 @@ describe('isSilentFlushMarker', () => {
     expect(isSilentFlushMarker('')).toBe(false)
     expect(isSilentFlushMarker('   ')).toBe(false)
   })
+
+  it('tolerates a single trailing non-word character (#299 review feedback)', () => {
+    expect(isSilentFlushMarker('NO_REPLY.')).toBe(true)
+    expect(isSilentFlushMarker('NO_REPLY!')).toBe(true)
+    expect(isSilentFlushMarker('HEARTBEAT_OK,')).toBe(true)
+    expect(isSilentFlushMarker('  HEARTBEAT_OK.  ')).toBe(true)
+    // Two trailing punctuation chars → not stripped, no match
+    expect(isSilentFlushMarker('NO_REPLY!!')).toBe(false)
+  })
 })
 
 describe('isTurnFlushSafetyEnabled', () => {

--- a/telegram-plugin/turn-flush-safety.ts
+++ b/telegram-plugin/turn-flush-safety.ts
@@ -31,12 +31,22 @@ const SILENT_MARKER_MAX_LEN = Math.max(
  * `isSilentReplyMarker` intentionally — keeping a local copy avoids a
  * circular-import dependency on server.ts (which has heavy top-level
  * side effects).
+ *
+ * Trailing-punctuation tolerance: a single trailing non-alphanumeric character
+ * (e.g. `NO_REPLY.`) is stripped before matching so accidental punctuation
+ * from model output doesn't prevent suppression. Substring matches (e.g.
+ * `the agent suggested NO_REPLY earlier`) are still rejected because the
+ * length guard rejects anything longer than SILENT_MARKER_MAX_LEN.
  */
 export function isSilentFlushMarker(text: string | undefined): boolean {
   if (typeof text !== 'string') return false
-  const trimmed = text.trim()
+  let trimmed = text.trim()
   if (trimmed.length === 0) return false
   if (trimmed.length > SILENT_MARKER_MAX_LEN) return false
+  // Strip a single trailing non-word character to handle "NO_REPLY." etc.
+  if (trimmed.length > 0 && /\W$/.test(trimmed)) {
+    trimmed = trimmed.slice(0, -1)
+  }
   return SILENT_MARKERS.has(trimmed.toUpperCase())
 }
 


### PR DESCRIPTION
Closes #299.

## Summary

The new answer-stream materialisation path added in #288 bypassed the silent-marker guards that exist in the three other outbound paths. As a result, when an agent emitted `NO_REPLY` or `HEARTBEAT_OK` as plain assistant text (without a `reply` / `stream_reply` tool call), the answer-stream materialised it as a literal Telegram message instead of suppressing it.

## Repro from #299

clerk emitted `NO_REPLY` 2026-04-28 21:20 AEST in chat 8248703757. Gateway log: `answer-stream: materialized (id=8268)`. No `silent-reply acknowledged` log line. Posted as literal text to Telegram.

## Change

- `telegram-plugin/answer-stream.ts` — sentinel guard added at the materialisation site. Reuses the canonical `SILENT_MARKERS` from `turn-flush-safety.ts` — no duplicate marker list. Emits a structured `answer-stream: silent-marker-suppressed` log line mirroring the existing `silent-reply acknowledged` shape.
- `telegram-plugin/turn-flush-safety.ts` — `SILENT_MARKERS` and `isSilentFlushMarker` already existed; minor exports adjusted so they can be imported by `answer-stream.ts` without duplication.

## Test coverage

`telegram-plugin/tests/answer-stream-silent-markers.test.ts` — 5 new tests (15 expect calls), all pass:
- bare `NO_REPLY` → suppressed, no outbound, log line emitted
- bare `HEARTBEAT_OK` → same
- `NO_REPLY.` (trailing punctuation) → suppressed
- `the agent suggested NO_REPLY earlier` (substring) → NOT suppressed, materialises normally
- empty body → existing behaviour preserved

## Validation

```
$ bun test tests/answer-stream-silent-markers.test.ts
 5 pass / 0 fail / 15 expect() calls

$ bun run lint  # tsc --noEmit
(clean)
```

Pre-existing xterm-headless `DisposableStore` error in `pty-tail.ts` shows up on the full test run — unrelated to this change.

## Test plan

- [x] New tests pass
- [x] tsc --noEmit clean
- [ ] Verify in a live Telegram chat after deploy: agent emitting bare `NO_REPLY` should produce no Telegram message