### PR TITLE
fix(plugin): align gateway get_recent_messages summary with server.ts

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -2068,8 +2068,15 @@ async function executeGetRecentMessages(args: Record<string, unknown>): Promise<
       const who = r.role === 'user' ? r.user ?? 'user' : 'assistant'
       const time = new Date(r.ts * 1000).toISOString()
       const attach = r.attachment_kind ? ` [${r.attachment_kind}]` : ''
-      const reaction = r.user_reaction ? ` [reaction:${r.user_reaction}]` : ''
-      return `[${time}] ${who}${attach}${reaction}: ${r.text}`
+      // Match server.ts get_recent_messages format exactly — both code paths
+      // serve the same MCP tool, so the agent's parsing must not depend on
+      // which entry point handled the call. See issue #119 for replyCtx;
+      // reaction tag added in #297 with the server.ts format as canonical.
+      const replyCtx = r.reply_to_message_id != null
+        ? ` ↪️#${r.reply_to_message_id}${r.reply_to_text ? `:"${r.reply_to_text.slice(0, 60)}${r.reply_to_text.length > 60 ? '…' : ''}"` : ''}`
+        : ''
+      const reactionTag = r.user_reaction ? ` [reaction: ${r.user_reaction}]` : ''
+      return `[${time}] ${who}${attach}${replyCtx}: ${r.text}${reactionTag}`
     })
     .join('\n')
   return {


### PR DESCRIPTION
Reviewer audit of overnight Telegram-plugin sprint (#277/#287/#261/#301/#302) caught two divergences between the **gateway's IPC-served `get_recent_messages`** and the **server.ts in-process variant**. Both serve the same MCP tool, so an agent parsing the summary must not see different shapes depending on which entry point handled the call.

## Defects

| Field | gateway.ts | server.ts | Source |
|---|---|---|---|
| Reaction tag | `[reaction:X]` (no space) | `[reaction: X]` (with space) | #297 / PR #302 added both |
| Reply context | (missing) | `↪️#N:"…"` | #119 / older PR added only to server |
| Reaction position | before colon | after text body | divergent since #302 |

## Fix

Pull gateway.ts into alignment with server.ts as canonical. Same `replyCtx` format, same reaction tag with space, reaction tag positioned after the text body.

## Tests

- `tsc --noEmit` clean
- `bun test` (plugin) exit 0
- `bunx vitest run` 3680 pass / 0 fail (no regression)

Future divergence guard: filed as #306.