### PR TITLE
fix(#310): stream_reply records delivery before terminal render

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -1603,6 +1603,15 @@ async function executeStreamReply(args: Record<string, unknown>): Promise<unknow
       defaultFormat: access.parseMode ?? 'html',
       logStreamingEvent,
       endStatusReaction,
+      // Issue #310: deliver the outbound count bump BEFORE forceCompleteTurn
+      // so the terminal render sees outboundDeliveredCount > 0. The handler
+      // calls this dep in that order internally.
+      recordOutboundDelivered: (chatId, threadId) => {
+        progressDriver?.recordOutboundDelivered(
+          chatId,
+          threadId != null ? String(threadId) : undefined,
+        )
+      },
       forceCompleteTurn: (chatId, threadId) => {
         progressDriver?.forceCompleteTurn({
           chatId,

--- a/telegram-plugin/stream-reply-handler.ts
+++ b/telegram-plugin/stream-reply-handler.ts
@@ -176,6 +176,18 @@ export interface StreamReplyDeps {
    * re-entry). Safe to leave unset for callers that don't use the driver.
    */
   forceCompleteTurn?: (chatId: string, threadId: number | undefined) => void
+  /**
+   * Optional: progress-card driver delivery counter hook. Wired by the
+   * gateway to `progressDriver.recordOutboundDelivered(...)`. Called
+   * BEFORE `forceCompleteTurn` so the driver's per-turn outbound counter
+   * is non-zero when the terminal render fires. Without this ordering
+   * guarantee, `forceCompleteTurn` flushes the card while
+   * `outboundDeliveredCount === 0` → ⚠️ false positive (issue #310).
+   * Only called on the default (unnamed) lane when `done=true` and the
+   * stream produced a non-null messageId. Safe to leave unset for callers
+   * that don't use the driver.
+   */
+  recordOutboundDelivered?: (chatId: string, threadId: number | undefined) => void
   /** Whether to persist outbound history. */
   historyEnabled: boolean
   /** History row writer. Only called when historyEnabled && done && messageId != null. */
@@ -458,13 +470,32 @@ export async function handleStreamReply(
   const finalMessageId = stream.getMessageId()
   if (done) {
     process.stderr.write(`telegram channel: stream_reply: finalized done=true chatId=${chat_id} lane=${args.lane ?? 'default'} messageId=${finalMessageId ?? 'null'}\n`)
+    const isDefaultLaneForCompletion = args.lane == null || args.lane.length === 0
+    // Issue #310: record delivery BEFORE forceCompleteTurn so the
+    // progress-card driver's outboundDeliveredCount is non-zero when the
+    // terminal render fires. forceCompleteTurn synchronously flushes the
+    // card; if we recorded after that flush, outboundDeliveredCount would
+    // still be 0 at render time → ⚠️ false positive even though the
+    // message landed. Only record when a messageId is confirmed — a null
+    // id means the send never succeeded and the ⚠️ branch is correct.
+    if (
+      deps.recordOutboundDelivered != null
+      && finalMessageId != null
+      && isDefaultLaneForCompletion
+    ) {
+      try {
+        deps.recordOutboundDelivered(chat_id, threadId)
+      } catch (err) {
+        deps.writeError(`telegram channel: stream_reply: recordOutboundDelivered hook threw: ${err}\n`)
+      }
+    }
     // Fire the authoritative turn-complete signal to the progress-card
     // driver so any in-flight card for this chat is closed out alongside
     // the final answer landing. Only for the default (unnamed) lane —
     // the progress lane is the driver's own emit path and routing
     // completion through it would re-enter the driver from within its
     // own flush. Idempotent on the driver side: first caller wins.
-    if (deps.forceCompleteTurn != null && (args.lane == null || args.lane.length === 0)) {
+    if (deps.forceCompleteTurn != null && isDefaultLaneForCompletion) {
       try {
         deps.forceCompleteTurn(chat_id, threadId)
       } catch (err) {

--- a/telegram-plugin/tests/progress-card-driver.test.ts
+++ b/telegram-plugin/tests/progress-card-driver.test.ts
@@ -248,6 +248,51 @@ describe('progress-card driver', () => {
     expect(emits[0].html).toContain('✅ <b>Done</b>')
   })
 
+  it('issue #310: recordOutboundDelivered BEFORE forceCompleteTurn → ✅ Done, not ⚠️', () => {
+    // Regression for the delivery-record race: when stream_reply(done=true)
+    // fires forceCompleteTurn from inside the handler, the terminal render
+    // must see outboundDeliveredCount > 0. The fix records delivery first,
+    // then invokes forceCompleteTurn. This test simulates that ordering
+    // directly against the driver so the render outcome can be asserted.
+    const { driver, emits } = harness()
+    driver.ingest(enqueue('c1'), null)
+    driver.ingest({ kind: 'tool_use', toolName: 'mcp__switchroom-telegram__stream_reply' }, 'c1')
+    emits.length = 0
+
+    // Simulate the fixed ordering: delivery recorded first, then the
+    // turn-complete signal fires. Before the fix this order was reversed
+    // (recordOutboundDelivered happened AFTER handleStreamReply resolved)
+    // so the render saw outboundDeliveredCount=0 → ⚠️ false positive.
+    driver.recordOutboundDelivered('c1')          // step 1: delivery confirmed
+    driver.forceCompleteTurn({ chatId: 'c1' })    // step 2: terminal flush
+
+    // Terminal emit must be ✅ Done, never ⚠️.
+    expect(emits).toHaveLength(1)
+    expect(emits[0].done).toBe(true)
+    expect(emits[0].html).toContain('✅ <b>Done</b>')
+    expect(emits[0].html).not.toContain('⚠️')
+    expect(emits[0].html).not.toContain('Reply attempted but not delivered')
+  })
+
+  it('issue #310 (negative): wrong order — forceCompleteTurn before recordOutboundDelivered → ⚠️', () => {
+    // Documents the race that the fix eliminates: if forceCompleteTurn fires
+    // before recordOutboundDelivered the card renders ⚠️. This test proves
+    // the ordering matters, giving confidence that the positive test above
+    // actually validates the fix rather than passing trivially.
+    const { driver, emits } = harness()
+    driver.ingest(enqueue('c1'), null)
+    driver.ingest({ kind: 'tool_use', toolName: 'mcp__switchroom-telegram__stream_reply' }, 'c1')
+    emits.length = 0
+
+    // Wrong (pre-fix) order: forceCompleteTurn fires while count is still 0.
+    driver.forceCompleteTurn({ chatId: 'c1' })    // step 1: terminal flush (count=0)
+    driver.recordOutboundDelivered('c1')          // step 2: too late — card already committed
+
+    expect(emits[0].done).toBe(true)
+    expect(emits[0].html).toContain('⚠️ <b>Reply attempted but not delivered</b>')
+    expect(emits[0].html).not.toContain('✅ <b>Done</b>')
+  })
+
   it('coalesces bursts of non-stage-changing events', () => {
     const { driver, emits, advance } = harness(500, 400)
     driver.ingest(enqueue('c1'), null) // emit #1


### PR DESCRIPTION
## Summary

- Added `recordOutboundDelivered` dep callback to `StreamReplyDeps` in `stream-reply-handler.ts`
- Inside `handleStreamReply`, call it (when `done=true` and `messageId != null`) **before** `forceCompleteTurn` so the progress-card driver's `outboundDeliveredCount` is non-zero when the terminal render fires
- Wired the new dep in `gateway.ts` alongside the existing `forceCompleteTurn` dep

The pre-fix race: `forceCompleteTurn` synchronously flushed the card while `outboundDeliveredCount === 0` → ⚠️ false positive. `gateway.ts` only called `recordOutboundDelivered` after `await handleStreamReply` resolved — one tick too late.

## Test plan

- [x] New test: `issue #310: recordOutboundDelivered BEFORE forceCompleteTurn → ✅ Done, not ⚠️` — asserts correct ordering produces `✅ Done`
- [x] New test: `issue #310 (negative): wrong order → ⚠️` — proves the ordering matters (documents the pre-fix race)
- [x] Existing `issue #137` test unchanged and passing — genuine no-delivery case still renders ⚠️
- [x] Full vitest suite: 171 files, 3663 tests — all pass
- [x] `bun run lint` (tsc --noEmit) — clean

Closes #310