### PR TITLE
fix(#309): boot card uses slug for systemd probes (not display name)

### DIFF
--- a/telegram-plugin/gateway/boot-card.ts
+++ b/telegram-plugin/gateway/boot-card.ts
@@ -259,7 +259,12 @@ export function renderBootCard(opts: RenderBootCardOpts): string {
 // ─── Probe orchestration ─────────────────────────────────────────────────────
 
 export interface RunProbesOpts {
+  /** Persona display name — used only for rendering (ack line, probe rows). */
   agentName: string
+  /** Lowercase systemd slug (e.g. "klanker") — used for systemctl unit targets.
+   *  Must differ from agentName when the soul.name differs in case from the slug.
+   *  Falls back to agentName when not provided (backwards-compat). */
+  agentSlug?: string
   /** Pre-formatted version string passed through to the renderer. */
   version: string
   agentDir: string
@@ -286,6 +291,10 @@ export interface RunProbesOpts {
   /** How often the live loop re-polls systemd. Defaults to
    *  AGENT_LIVE_POLL_INTERVAL_MS (2s). Override in tests for speed. */
   agentLivePollIntervalMs?: number
+  /** Override for tests — replaces real execFile calls in the initial probe run
+   *  (probeAgentProcess + probeCronTimers). Distinct from agentLiveExecFileImpl
+   *  which covers the post-settle live-watch loop. */
+  probeExecFileImpl?: (cmd: string, args: string[]) => Promise<{ stdout: string; stderr: string }>
   /** Override for tests — replaces real execFile calls in the live loop. */
   agentLiveExecFileImpl?: (cmd: string, args: string[]) => Promise<{ stdout: string; stderr: string }>
   /** Override for tests — replaces real delays in the live loop. */
@@ -298,14 +307,17 @@ export interface RunProbesOpts {
 export async function runAllProbes(opts: RunProbesOpts): Promise<ProbeMap> {
   const claudeDir = join(opts.agentDir, '.claude')
   const probes: ProbeMap = {}
+  // Use the explicit slug for systemd unit targets; fall back to agentName for
+  // callers that haven't been updated yet (backwards-compat).
+  const slug = opts.agentSlug ?? opts.agentName
 
   await Promise.allSettled([
     probeAccount(opts.agentDir).then(r => { probes.account = r }),
-    probeAgentProcess(opts.agentName).then(r => { probes.agent = r }),
+    probeAgentProcess(slug, { execFileImpl: opts.probeExecFileImpl }).then(r => { probes.agent = r }),
     probeGateway(opts.gatewayInfo).then(r => { probes.gateway = r }),
     probeQuota(claudeDir, opts.agentDir, opts.fetchImpl).then(r => { probes.quota = r }),
     probeHindsight(opts.bankName, opts.fetchImpl).then(r => { probes.hindsight = r }),
-    probeCronTimers(opts.agentName).then(r => { probes.crons = r }),
+    probeCronTimers(slug, { execFileImpl: opts.probeExecFileImpl }).then(r => { probes.crons = r }),
   ])
 
   return probes
@@ -403,7 +415,8 @@ export async function startBootCard(
 
         // Iterate watchAgentProcess — it yields on each meaningful state
         // change and exits when active, failed, or the window expires.
-        const watcher = watchAgentProcess(opts.agentName, {
+        // Use the slug for the systemd unit target, not the display name.
+        const watcher = watchAgentProcess(opts.agentSlug ?? opts.agentName, {
           liveWindowMs,
           pollIntervalMs: opts.agentLivePollIntervalMs,
           sleepImpl: opts.agentLiveSleepImpl,

--- a/telegram-plugin/gateway/boot-probes.ts
+++ b/telegram-plugin/gateway/boot-probes.ts
@@ -645,11 +645,15 @@ function parseTimerLeft(left: string | undefined): number | null {
   return ms > 0 ? ms : null
 }
 
-export async function probeCronTimers(agentName: string): Promise<ProbeResult> {
+export async function probeCronTimers(
+  agentName: string,
+  opts: { execFileImpl?: ExecFileFnType } = {},
+): Promise<ProbeResult> {
+  const execFileFn: ExecFileFnType = opts.execFileImpl ?? execFile
   return withTimeout('Crons', (async (): Promise<ProbeResult> => {
     let stdout: string
     try {
-      const result = await execFile('systemctl', [
+      const result = await execFileFn('systemctl', [
         '--user', 'list-timers',
         `switchroom-${agentName}-cron-*`,
         '--output=json',

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -1145,6 +1145,7 @@ const ipcServer: IpcServer = createIpcServer({
           }
           startBootCard(chatId, threadId, botApiForCard, {
             agentName: agentDisplayName,
+            agentSlug,
             version: formatBootVersion(),
             agentDir: agentDir ?? (process.env.TELEGRAM_STATE_DIR ? require('path').dirname(process.env.TELEGRAM_STATE_DIR) : '/tmp'),
             gatewayInfo: { pid: process.pid, startedAtMs: GATEWAY_STARTED_AT_MS },
@@ -6586,6 +6587,7 @@ void (async () => {
                 try {
                   const handle = await startBootCard(chatId, threadId, botApiForCard, {
                     agentName: agentDisplayName,
+                    agentSlug,
                     version: formatBootVersion(),
                     agentDir: agentDir ?? join(homedir(), '.switchroom', 'agents', agentSlug),
                     gatewayInfo: { pid: process.pid, startedAtMs: GATEWAY_STARTED_AT_MS },

--- a/telegram-plugin/tests/boot-card-probe-target.test.ts
+++ b/telegram-plugin/tests/boot-card-probe-target.test.ts
@@ -1,0 +1,194 @@
+/**
+ * Tests for #309: boot card uses the agent slug (not display name) for
+ * systemd unit probes.
+ *
+ * Root cause: probeAgentProcess and probeCronTimers were called with
+ * opts.agentName (the persona display name, e.g. "Klanker") instead of
+ * the lowercase slug ("klanker"). systemctl returns LoadState=not-found
+ * for the capitalised name because unit files are always lowercase.
+ *
+ * Fix: RunProbesOpts.agentSlug carries the slug separately; runAllProbes
+ * passes opts.agentSlug (falling back to opts.agentName for compat) to
+ * both probeAgentProcess and probeCronTimers.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { join } from 'path'
+import { mkdtempSync, rmSync } from 'fs'
+import { tmpdir } from 'os'
+
+import { runAllProbes } from '../gateway/boot-card.js'
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+type ExecFileResult = { stdout: string; stderr: string }
+type RecordedCall = { cmd: string; args: string[] }
+
+/**
+ * Build an execFile mock that records every (cmd, args) call and dispatches
+ * the response based on which systemctl sub-command is being called.
+ *
+ * `show`       → responds with a valid "active" systemctl kv blob so that
+ *               probeAgentProcess resolves immediately without retrying.
+ * `list-timers`→ responds with empty JSON array (0 timers).
+ * anything else→ responds with empty stdout.
+ */
+function makeDispatchingExecFile(slug: string): {
+  fn: (cmd: string, args: string[]) => Promise<ExecFileResult>
+  calls: RecordedCall[]
+} {
+  const calls: RecordedCall[] = []
+  return {
+    fn: async (cmd: string, args: string[]) => {
+      calls.push({ cmd, args })
+      if (cmd === 'systemctl') {
+        if (args.includes('show')) {
+          // Return a valid active systemd kv blob so probeAgentProcess exits
+          // immediately on the first call (no retry needed).
+          return {
+            stdout: [
+              'MainPID=9999',
+              'ActiveState=active',
+              'MemoryCurrent=52428800',
+              'ActiveEnterTimestamp=1700000000000000',
+            ].join('\n') + '\n',
+            stderr: '',
+          }
+        }
+        if (args.includes('list-timers')) {
+          return { stdout: '[]', stderr: '' }
+        }
+      }
+      return { stdout: '', stderr: '' }
+    },
+    calls,
+  }
+}
+
+// ── Core probe-target tests ───────────────────────────────────────────────────
+
+describe('#309: runAllProbes — slug vs display name for systemd calls', () => {
+  function makeTmpAgentDir(): string {
+    return mkdtempSync(join(tmpdir(), 'switchroom-test-'))
+  }
+
+  it('probeAgentProcess target is switchroom-<slug>.service, not switchroom-<displayName>.service', async () => {
+    const tmpDir = makeTmpAgentDir()
+    try {
+      const { fn: execFileMock, calls } = makeDispatchingExecFile('klanker')
+
+      await runAllProbes({
+        agentName: 'Klanker',   // persona display name — capitalised
+        agentSlug: 'klanker',   // systemd slug — lowercase
+        version: 'v0.3.0',
+        agentDir: tmpDir,
+        gatewayInfo: { pid: 12345, startedAtMs: Date.now() },
+        fetchImpl: async () => new Response('', { status: 200 }),
+        settleWindowMs: 0,
+        agentLiveWindowMs: 0,   // disable live loop
+        probeExecFileImpl: execFileMock,
+      })
+
+      // probeAgentProcess calls: systemctl --user show switchroom-<name>.service -p ...
+      const agentProbeCall = calls.find(c =>
+        c.cmd === 'systemctl' && c.args.includes('show'),
+      )
+      expect(agentProbeCall, 'probeAgentProcess must call systemctl show').toBeDefined()
+      const unitArg = agentProbeCall!.args.find(a => a.startsWith('switchroom-'))
+      // Must use the slug, not the capitalised display name.
+      expect(unitArg).toBe('switchroom-klanker.service')
+    } finally {
+      rmSync(tmpDir, { recursive: true })
+    }
+  })
+
+  it('probeCronTimers target is switchroom-<slug>-cron-*, not switchroom-<displayName>-cron-*', async () => {
+    const tmpDir = makeTmpAgentDir()
+    try {
+      const { fn: execFileMock, calls } = makeDispatchingExecFile('klanker')
+
+      await runAllProbes({
+        agentName: 'Klanker',
+        agentSlug: 'klanker',
+        version: 'v0.3.0',
+        agentDir: tmpDir,
+        gatewayInfo: { pid: 12345, startedAtMs: Date.now() },
+        fetchImpl: async () => new Response('', { status: 200 }),
+        settleWindowMs: 0,
+        agentLiveWindowMs: 0,
+        probeExecFileImpl: execFileMock,
+      })
+
+      // probeCronTimers calls: systemctl --user list-timers switchroom-<name>-cron-*
+      const cronProbeCall = calls.find(c =>
+        c.cmd === 'systemctl' && c.args.includes('list-timers'),
+      )
+      expect(cronProbeCall, 'probeCronTimers must call systemctl list-timers').toBeDefined()
+      const cronGlob = cronProbeCall!.args.find(a => a.includes('cron'))
+      expect(cronGlob).toBe('switchroom-klanker-cron-*')
+    } finally {
+      rmSync(tmpDir, { recursive: true })
+    }
+  })
+
+  it('no systemctl call uses the capitalised display name as the unit target', async () => {
+    const tmpDir = makeTmpAgentDir()
+    try {
+      const { fn: execFileMock, calls } = makeDispatchingExecFile('klanker')
+
+      await runAllProbes({
+        agentName: 'Klanker',
+        agentSlug: 'klanker',
+        version: 'v0.3.0',
+        agentDir: tmpDir,
+        gatewayInfo: { pid: 12345, startedAtMs: Date.now() },
+        fetchImpl: async () => new Response('', { status: 200 }),
+        settleWindowMs: 0,
+        agentLiveWindowMs: 0,
+        probeExecFileImpl: execFileMock,
+      })
+
+      const systemctlCalls = calls.filter(c => c.cmd === 'systemctl')
+      expect(systemctlCalls.length, 'execFileMock must be called at least once').toBeGreaterThan(0)
+
+      for (const call of systemctlCalls) {
+        for (const arg of call.args) {
+          expect(
+            arg,
+            `systemctl was invoked with arg "${arg}" which contains the display name "Klanker" — expected slug "klanker"`,
+          ).not.toContain('Klanker')
+        }
+      }
+    } finally {
+      rmSync(tmpDir, { recursive: true })
+    }
+  })
+
+  it('falls back to agentName when agentSlug is not provided (backwards compat)', async () => {
+    const tmpDir = makeTmpAgentDir()
+    try {
+      const { fn: execFileMock, calls } = makeDispatchingExecFile('myagent')
+
+      await runAllProbes({
+        agentName: 'myagent',
+        // no agentSlug — should fall back to agentName
+        version: 'v0.3.0',
+        agentDir: tmpDir,
+        gatewayInfo: { pid: 12345, startedAtMs: Date.now() },
+        fetchImpl: async () => new Response('', { status: 200 }),
+        settleWindowMs: 0,
+        agentLiveWindowMs: 0,
+        probeExecFileImpl: execFileMock,
+      })
+
+      const agentProbeCall = calls.find(c =>
+        c.cmd === 'systemctl' && c.args.includes('show'),
+      )
+      expect(agentProbeCall, 'probeAgentProcess must call systemctl show').toBeDefined()
+      const unitArg = agentProbeCall!.args.find(a => a.startsWith('switchroom-'))
+      expect(unitArg).toBe('switchroom-myagent.service')
+    } finally {
+      rmSync(tmpDir, { recursive: true })
+    }
+  })
+})


### PR DESCRIPTION
## Summary

- `RunProbesOpts` gains an explicit `agentSlug` field (optional; falls back to `agentName` for backwards compat) so systemd unit targets are decoupled from the user-facing display name.
- `runAllProbes` passes `opts.agentSlug` (not `opts.agentName`) to `probeAgentProcess` and `probeCronTimers`, keeping `agentName` for rendering only.
- Both `gateway.ts` call sites (`bridge-reconnect` ~line 1146, `boot` ~line 6587) now pass `agentSlug` alongside `agentName: agentDisplayName`.
- `probeCronTimers` gains an `execFileImpl` override (matching `probeAgentProcess`) so the initial probe calls can be intercepted in tests.
- `RunProbesOpts` gains `probeExecFileImpl` to wire that override through `runAllProbes`.

## Test plan

- [x] New `telegram-plugin/tests/boot-card-probe-target.test.ts` — asserts `systemctl show switchroom-klanker.service` (not `switchroom-Klanker.service`) and `list-timers switchroom-klanker-cron-*` when display name differs in case from slug
- [x] `bun run test:vitest` — 172 test files pass, 0 failures
- [x] `bun run lint` (tsc --noEmit) — clean

Closes #309

🤖 Generated with [Claude Code](https://claude.com/claude-code)