### PR TITLE
fix(#313): sub-agent visibility leaks — orphan promotion, cold-JSONL detection, decoupled unpin

### DIFF
--- a/telegram-plugin/progress-card-driver.ts
+++ b/telegram-plugin/progress-card-driver.ts
@@ -194,6 +194,35 @@ export interface ProgressDriverConfig {
    * Default 3. Set to 0 to disable the escalation mechanism entirely.
    */
   maxConsecutive4xx?: number
+  /**
+   * Gap 3 (orphan promotion): how long a `PendingAgentSpawn` must be
+   * outstanding before the heartbeat promotes it to a synthesised
+   * sub-agent row (state='running'). Gives the sub-agent JSONL watcher a
+   * chance to deliver the real `sub_agent_started` event first.
+   *
+   * Default 5000 (5 seconds). Set to 0 to disable promotion entirely.
+   */
+  orphanPromotionMs?: number
+  /**
+   * Gap 4 (cold-JSONL detection): when a running sub-agent's last event
+   * is older than this threshold, the heartbeat synthesises a
+   * `sub_agent_turn_end` for it so the deferred-completion path can
+   * proceed (avoids the card staying pinned forever on a dead watcher).
+   *
+   * Default 30000 (30 seconds). Set to 0 to disable the synthetic close.
+   */
+  coldSubAgentThresholdMs?: number
+  /**
+   * Gap 8 (decoupled render and unpin): after `turn_end` arrives while
+   * sub-agents are still running, this is the maximum ms to wait before
+   * force-closing the card with a "stalled — forced close" header and
+   * calling `onTurnComplete`. This is separate from `maxIdleMs` (which
+   * watches for absence of ALL events) — this timeout starts specifically
+   * on parent `turn_end` and fires regardless of sub-agent activity.
+   *
+   * Default 180000 (3 minutes). Set to 0 to disable.
+   */
+  deferredCompletionTimeoutMs?: number
 }
 
 /**
@@ -328,6 +357,26 @@ interface PerChatState {
    * fires once per turn even if multiple sites call into the helper.
    */
   silentEndPrepared: boolean
+  /**
+   * Gap 8 (decoupled render and unpin): set to the timestamp when parent
+   * `turn_end` landed while sub-agents were still running. Used by the
+   * heartbeat to enforce `deferredCompletionTimeoutMs`. Null until
+   * parent turn_end with in-flight sub-agents is observed.
+   */
+  parentTurnEndAt: number | null
+  /**
+   * Gap 8: true once the parent-done render (✅ Done header with sub-agents
+   * still visible) has been emitted. Prevents re-rendering the ✅ Done
+   * frame on every sub-agent event while deferred.
+   */
+  parentDoneRendered: boolean
+  /**
+   * Gap 3 (orphan promotion): set of toolUseIds from `pendingAgentSpawns`
+   * that have already been promoted to synthetic sub-agent rows. Guards
+   * against re-promotion on successive heartbeat ticks and against
+   * double-registration if a real `sub_agent_started` arrives later.
+   */
+  promotedSpawnIds: Set<string>
 }
 
 export interface ProgressDriver {
@@ -446,6 +495,9 @@ export function createProgressDriver(config: ProgressDriverConfig): ProgressDriv
   const maxIdleMs = config.maxIdleMs ?? 30 * 60_000
   const initialDelayMs = config.initialDelayMs ?? 30_000
   const maxConsecutive4xx = config.maxConsecutive4xx ?? 3
+  const orphanPromotionMs = config.orphanPromotionMs ?? 5_000
+  const coldSubAgentThresholdMs = config.coldSubAgentThresholdMs ?? 30_000
+  const deferredCompletionTimeoutMs = config.deferredCompletionTimeoutMs ?? 3 * 60_000
   // Per-chat sliding 60s window of recent emit timestamps. When the
   // window holds more than `editBudgetThreshold` entries we're "hot"
   // and coalesce more aggressively.
@@ -679,6 +731,12 @@ export function createProgressDriver(config: ProgressDriverConfig): ProgressDriv
       // Deferring the close keeps Map iteration safe and lets us batch
       // the cleanup.
       const zombies: PerChatState[] = []
+      // Gap 3: pendingAgentSpawns that need orphan promotion this tick.
+      const orphanPromotions: PerChatState[] = []
+      // Gap 4: running sub-agents whose JSONL watcher appears cold.
+      const coldSubAgents: Array<{ cs: PerChatState; agentId: string }> = []
+      // Gap 8: cards where the deferred-completion timeout has expired.
+      const stalledCards: PerChatState[] = []
       for (const [, cs] of chats) {
         // Skip only when TRULY done. During the deferred-completion
         // window (parent turn_end fired but sub-agents — correlated or
@@ -697,6 +755,43 @@ export function createProgressDriver(config: ProgressDriverConfig): ProgressDriv
           zombies.push(cs)
           continue
         }
+
+        // Gap 3 — orphan promotion: if any PendingAgentSpawn has been
+        // waiting longer than orphanPromotionMs without a matching
+        // sub_agent_started, promote it to a synthesised sub-agent row so
+        // the work is at least visible on the card.
+        if (orphanPromotionMs > 0 && cs.state.pendingAgentSpawns.size > 0) {
+          for (const [toolUseId, pending] of cs.state.pendingAgentSpawns) {
+            if (!cs.promotedSpawnIds.has(toolUseId) && now() - pending.startedAt >= orphanPromotionMs) {
+              orphanPromotions.push(cs)
+              break
+            }
+          }
+        }
+
+        // Gap 4 — cold-JSONL detection: if a running sub-agent hasn't
+        // emitted an event for coldSubAgentThresholdMs, synthesise a
+        // sub_agent_turn_end so the deferred-completion path can proceed.
+        if (coldSubAgentThresholdMs > 0 && cs.pendingCompletion) {
+          for (const [agentId, sa] of cs.state.subAgents) {
+            if (sa.state === 'running' && sa.lastEventAt != null && now() - sa.lastEventAt >= coldSubAgentThresholdMs) {
+              coldSubAgents.push({ cs, agentId })
+            }
+          }
+        }
+
+        // Gap 8 — deferred-completion timeout: if the parent turn_end fired
+        // but sub-agents never finished within deferredCompletionTimeoutMs,
+        // force-close with a "stalled" header.
+        if (
+          deferredCompletionTimeoutMs > 0
+          && cs.parentTurnEndAt != null
+          && now() - cs.parentTurnEndAt >= deferredCompletionTimeoutMs
+        ) {
+          stalledCards.push(cs)
+          continue
+        }
+
         // Skip heartbeat while the chat is hot — sub-agent bursts are
         // already producing edits, the elapsed counter is ticking from
         // those, and an extra heartbeat edit just spends budget. (Design
@@ -717,7 +812,9 @@ export function createProgressDriver(config: ProgressDriverConfig): ProgressDriv
         // never called for this card). Distinct from silentEnd because the
         // agent TRIED — the failure is in the delivery layer, not the model.
         const replyNotDelivered = cs.replyToolCalled && cs.outboundDeliveredCount === 0
-        const html = render(cs.state, now(), undefined, { stuckMs, silentEnd, replyNotDelivered })
+        // Gap 8: pass parentDone to renderer during the deferred-unpin window.
+        const parentDone = cs.parentTurnEndAt != null && hasAnyRunningSubAgent(cs.state)
+        const html = render(cs.state, now(), undefined, { stuckMs, silentEnd, replyNotDelivered, parentDone })
         const bucket = Math.floor(now() / heartbeatMs)
         const prevBucket = lastHeartbeatBucket.get(cs.turnKey)
         if (html === cs.lastEmittedHtml && bucket === prevBucket) continue
@@ -735,6 +832,65 @@ export function createProgressDriver(config: ProgressDriverConfig): ProgressDriv
         })
       }
       for (const cs of zombies) closeZombie(cs)
+
+      // Gap 3: promote stale PendingAgentSpawns to synthetic sub-agent rows.
+      for (const cs of orphanPromotions) {
+        for (const [toolUseId, pending] of cs.state.pendingAgentSpawns) {
+          if (cs.promotedSpawnIds.has(toolUseId)) continue
+          if (now() - pending.startedAt < orphanPromotionMs) continue
+          cs.promotedSpawnIds.add(toolUseId)
+          const syntheticId = `orphan-${toolUseId}`
+          process.stderr.write(
+            `telegram gateway: progress-card: orphan-promotion toolUseId=${toolUseId} syntheticId=${syntheticId} description="${pending.description}" (Gap 3 #313)\n`,
+          )
+          // Synthesise a sub_agent_started event — drives the reducer's
+          // existing sub_agent_started path (adds to subAgents, removes
+          // from pendingAgentSpawns, links checklist item via spawnedAgentId).
+          cs.state = reduce(cs.state, {
+            kind: 'sub_agent_started',
+            agentId: syntheticId,
+            firstPromptText: pending.promptText,
+          }, now())
+          cs.lastEventAt = now()
+          flush(cs, false)
+        }
+      }
+
+      // Gap 4: synthesise sub_agent_turn_end for cold-JSONL sub-agents.
+      for (const { cs, agentId } of coldSubAgents) {
+        process.stderr.write(
+          `telegram gateway: progress-card: cold-jsonl-synth-turn-end agentId=${agentId} turnKey=${cs.turnKey} (Gap 4 #313)\n`,
+        )
+        cs.state = reduce(cs.state, { kind: 'sub_agent_turn_end', agentId }, now())
+        cs.lastEventAt = now()
+        maybeCompleteDeferredTurn(cs)
+        if (!cs.completionFired) flush(cs, false)
+      }
+
+      // Gap 8: force-close cards whose deferred-completion timeout has expired.
+      for (const cs of stalledCards) {
+        process.stderr.write(
+          `telegram gateway: progress-card: deferred-completion-timeout-expired turnKey=${cs.turnKey} deferredCompletionTimeoutMs=${deferredCompletionTimeoutMs} (Gap 8 #313)\n`,
+        )
+        // Mark all still-running sub-agents as done first so that the emit's
+        // `done` flag is true (the notification-spam guard suppresses done=true
+        // while sub-agents are running). The renderer still shows
+        // "⚠️ Stalled — forced close" because stalledClose=true now overrides
+        // trulyDone in progress-card.ts.
+        if (hasAnyRunningSubAgent(cs.state)) {
+          const closed = new Map(cs.state.subAgents)
+          const nowMs = now()
+          for (const [k, sa] of closed) {
+            if (sa.state === 'running') {
+              closed.set(k, { ...sa, state: 'done', finishedAt: nowMs, pendingPreamble: null })
+            }
+          }
+          cs.state = { ...cs.state, subAgents: closed }
+        }
+        prepareSilentEndSuppression(cs)
+        flush(cs, /*forceDone*/ true, /*stalledClose*/ true)
+        completeTurnFully(cs)
+      }
       // Evict stale dedup entries to prevent unbounded map growth.
       const t60 = now() - 60_000
       for (const [k, ts] of seenEnqueueMsgIds) {
@@ -787,7 +943,7 @@ export function createProgressDriver(config: ProgressDriverConfig): ProgressDriv
   }
 
   const DELAY_ELAPSED = 'elapsed'
-  function flush(chatState: PerChatState, forceDone: boolean): void {
+  function flush(chatState: PerChatState, forceDone: boolean, stalledClose = false): void {
     // If this card has hit the permanent-failure threshold, don't attempt
     // any more edits. Avoids log spam and pointless retries for deleted
     // messages / blocked bots.
@@ -831,11 +987,14 @@ export function createProgressDriver(config: ProgressDriverConfig): ProgressDriv
       !chatState.replyToolCalled && !chatState.wasAutonomous && !chatState.silentEndSuppressed
     const replyNotDelivered =
       chatState.replyToolCalled && chatState.outboundDeliveredCount === 0
+    // Gap 8: during the deferred-unpin window (parent turn_end fired but
+    // sub-agents still running), show ✅ Done in the parent header immediately.
+    const parentDone = chatState.parentTurnEndAt != null && hasAnyRunningSubAgent(chatState.state)
     const html = render(
       chatState.state,
       now(),
       taskNum.total > 1 ? taskNum : undefined,
-      { stuckMs, silentEnd, replyNotDelivered },
+      { stuckMs, silentEnd, replyNotDelivered, parentDone, stalledClose },
     )
     // Issue #81 diagnostic: which checklist branch is the renderer taking?
     // The card prefers `narratives` (human preambles) over `items` (raw
@@ -1048,6 +1207,9 @@ export function createProgressDriver(config: ProgressDriverConfig): ProgressDriv
           wasAutonomous: false,
           silentEndSuppressed: false,
           silentEndPrepared: false,
+          parentTurnEndAt: null,
+          parentDoneRendered: false,
+          promotedSpawnIds: new Set(),
         }
         chats.set(slot.turnKey, chatState)
         if (event.isSync) {
@@ -1142,6 +1304,13 @@ export function createProgressDriver(config: ProgressDriverConfig): ProgressDriv
           if (!hasAnyRunningSubAgent(chatState.state)) {
             prepareSilentEndSuppression(chatState)
           }
+        }
+        if (event.kind === 'turn_end' && hasAnyRunningSubAgent(chatState.state)) {
+          // Gap 8: parent turn_end with sub-agents still running — render
+          // done=true immediately (card shows ✅ Done) then defer unpin.
+          // Set parentTurnEndAt BEFORE flush so flush()'s parentDone
+          // computation picks it up on this very call.
+          chatState.parentTurnEndAt = now()
         }
         flush(chatState, /*forceDone*/ event.kind === 'turn_end')
         if (event.kind === 'turn_end') {

--- a/telegram-plugin/progress-card.ts
+++ b/telegram-plugin/progress-card.ts
@@ -148,6 +148,15 @@ export interface SubAgentState {
   }
   /** Sub-sub-agents observed (rendered as `(spawned N)` only, not as rows). */
   readonly nestedSpawnCount: number
+  /**
+   * Gap 4 (cold-JSONL detection): wall-clock ms of the most recent sub-agent
+   * event (sub_agent_tool_use, sub_agent_tool_result, sub_agent_text, etc.).
+   * Set on every event that updates this sub-agent's state. When the driver
+   * observes that a running sub-agent's `lastEventAt` is more than
+   * `coldSubAgentThresholdMs` (default 30s) in the past, it synthesises a
+   * `sub_agent_turn_end` so the deferred-completion path can proceed.
+   */
+  readonly lastEventAt?: number
 }
 
 /**
@@ -547,6 +556,7 @@ export function reduce(
         firstPromptText: event.firstPromptText,
         nestedSpawnCount: 0,
         milestoneVersion: 1,
+        lastEventAt: now,
       }
       const subAgents = new Map(state.subAgents)
       subAgents.set(event.agentId, sub)
@@ -581,6 +591,7 @@ export function reduce(
         // chain. Once set, never overwrite — we want the sub-agent's
         // initial framing, not its latest chatter.
         firstNarrativeText: sa.firstNarrativeText ?? event.text,
+        lastEventAt: now,
       })
       return { ...state, subAgents: next }
     }
@@ -609,6 +620,7 @@ export function reduce(
             }
           : sa.currentTool,
         pendingPreamble: null,
+        lastEventAt: now,
       })
       return { ...state, subAgents: next }
     }
@@ -637,6 +649,7 @@ export function reduce(
           currentTool: undefined,
           lastCompletedTool: justFinished,
           toolCount: sa.toolCount + 1,
+          lastEventAt: now,
         })
         return { ...state, subAgents: next }
       }
@@ -878,6 +891,22 @@ export interface RenderOptions {
    * "⚠️ Reply attempted but not delivered".
    */
   replyNotDelivered?: boolean
+  /**
+   * Gap 8 (decoupled render and unpin): when true, the parent turn has
+   * ended (turn_end received) but sub-agents are still running. The
+   * renderer shows "✅ Done" in the parent header immediately rather than
+   * "⚙️ Working…", while sub-agent rows still show their running state.
+   * Distinct from `silentEnd` / `replyNotDelivered` — those apply only
+   * on true terminal state. This flag applies during the deferred-unpin
+   * window.
+   */
+  parentDone?: boolean
+  /**
+   * Gap 8 (stalled forced close): when true, the deferred-completion
+   * timeout fired (sub-agents never reported done). Render a "stalled"
+   * header rather than "✅ Done" to signal forced closure.
+   */
+  stalledClose?: boolean
 }
 
 /**
@@ -930,15 +959,32 @@ export function render(
   const trulyDone = state.stage === 'done' && !hasAnyRunningSubAgent(state)
   const silentEnd = trulyDone && opts?.silentEnd === true
   const replyNotDelivered = trulyDone && !silentEnd && opts?.replyNotDelivered === true
+  // Gap 8: parentDone is set when parent turn_end fired but sub-agents are still
+  // running (deferred-unpin window). Show ✅ Done header immediately without
+  // waiting for sub-agents. stalledClose takes precedence — forced timeout close.
+  // stalledClose is allowed even when trulyDone=true (the stalled-close flush
+  // may run after sub-agents are explicitly marked done for cleanup purposes).
+  const parentDone = !trulyDone && opts?.parentDone === true
+  const stalledClose = opts?.stalledClose === true
   let headerIcon: string
   let headerLabel: string
-  if (silentEnd) {
+  if (stalledClose) {
+    // stalledClose takes priority over all other headers — it's an explicit
+    // forced-close signal that overrides silentEnd/replyNotDelivered/trulyDone.
+    // The driver marks sub-agents done before the final flush so trulyDone=true,
+    // but we still want the stalled header to show.
+    headerIcon = '⚠️'
+    headerLabel = 'Stalled — forced close'
+  } else if (silentEnd) {
     headerIcon = '🙊'
     headerLabel = 'Ended without reply'
   } else if (replyNotDelivered) {
     headerIcon = '⚠️'
     headerLabel = 'Reply attempted but not delivered'
   } else if (trulyDone) {
+    headerIcon = '✅'
+    headerLabel = 'Done'
+  } else if (parentDone) {
     headerIcon = '✅'
     headerLabel = 'Done'
   } else {
@@ -974,11 +1020,13 @@ export function render(
   // Stuck-warning: after 2 min of no session events the card is likely
   // orphaned or the sub-agent is in a long-running silent tool call.
   // Surface the gap early so users aren't left guessing until the 5-min
-  // zombie ceiling force-closes. Suppressed only on TRUE done — during
-  // the deferred-completion window (parent done, sub-agents still
-  // running silently) the warning is still the correct signal.
+  // zombie ceiling force-closes. Suppressed when the parent is done
+  // (trulyDone, parentDone, or stalledClose) — showing "stuck" after
+  // the parent has already acknowledged completion is confusing.
   if (
     !trulyDone &&
+    !parentDone &&
+    !stalledClose &&
     opts?.stuckMs != null &&
     opts.stuckMs >= STUCK_THRESHOLD_MS
   ) {

--- a/telegram-plugin/tests/progress-card-driver.test.ts
+++ b/telegram-plugin/tests/progress-card-driver.test.ts
@@ -2575,3 +2575,210 @@ describe('issue #259: autonomous wakeup turns skip silent-end warning', () => {
     expect(emits[0].html).not.toContain('✅ <b>Done</b>')
   })
 })
+
+describe('issue #313: sub-agent visibility leaks — regression tests', () => {
+  /**
+   * Gap 3 (orphan promotion): A PendingAgentSpawn sitting > 5s without a
+   * matching sub_agent_started must be promoted to a synthetic sub-agent
+   * row so the work is visible on the card.
+   */
+  it('Gap 3 — orphan promoted to sub-agent row after 5s heartbeat', () => {
+    const emitted: Array<unknown> = []
+    const { driver, emits, advance } = harness(0, 0, {
+      heartbeatMs: 1000,
+      initialDelayMs: 0,
+      onTurnComplete: (args) => emitted.push(args),
+    })
+    // Override defaults: use a short orphanPromotionMs so the test doesn't
+    // need a real 5s fake-clock advance. We do this by re-creating the
+    // driver with a custom config via the extended harness options below.
+    // Since harness() doesn't expose orphanPromotionMs, we use a separate
+    // driver instance here with a fast threshold.
+    let nowMs = 1000
+    const timers2: Array<{ fireAt: number; fn: () => void; ref: number; repeat?: number }> = []
+    let nextRef2 = 0
+    const emits2: Array<{ html: string; done: boolean }> = []
+    const driver2 = createProgressDriver({
+      emit: (a) => emits2.push(a),
+      minIntervalMs: 0,
+      coalesceMs: 0,
+      heartbeatMs: 1000,
+      initialDelayMs: 0,
+      orphanPromotionMs: 5000,
+      now: () => nowMs,
+      setTimeout: (fn, ms) => { const ref = nextRef2++; timers2.push({ fireAt: nowMs + ms, fn, ref }); return { ref } },
+      clearTimeout: (handle) => { const t = (handle as { ref: number }).ref; const i = timers2.findIndex(x => x.ref === t); if (i !== -1) timers2.splice(i, 1) },
+      setInterval: (fn, ms) => { const ref = nextRef2++; timers2.push({ fireAt: nowMs + ms, fn, ref, repeat: ms }); return { ref } },
+      clearInterval: (handle) => { const t = (handle as { ref: number }).ref; const i = timers2.findIndex(x => x.ref === t); if (i !== -1) timers2.splice(i, 1) },
+    })
+    const advanceMs = (ms: number) => {
+      nowMs += ms
+      for (;;) {
+        timers2.sort((a, b) => a.fireAt - b.fireAt)
+        const next = timers2[0]
+        if (!next || next.fireAt > nowMs) break
+        if (next.repeat != null) { next.fireAt += next.repeat; next.fn() }
+        else { timers2.shift(); next.fn() }
+      }
+    }
+
+    // Enqueue and dispatch an Agent tool_use — creates a PendingAgentSpawn.
+    driver2.ingest(enqueue('c'), null)
+    driver2.ingest({
+      kind: 'tool_use',
+      toolName: 'Agent',
+      toolUseId: 'spawn1',
+      input: { description: 'Analyse logs', prompt: 'Please analyse the logs' },
+    }, 'c')
+
+    // At t=0 no sub_agent_started arrives — simulating watcher race.
+    const htmlBefore = emits2[emits2.length - 1]?.html ?? ''
+    // The pending spawn should NOT yet be in subAgents (no sub_agent_started).
+    expect(htmlBefore).not.toContain('orphan-spawn1')
+
+    // Advance 4s — orphan threshold not yet reached.
+    advanceMs(4000)
+    const htmlAt4s = emits2[emits2.length - 1]?.html ?? ''
+    // Synthetic sub-agent must not exist yet (still pending, no sub_agent_started).
+    expect(htmlAt4s).not.toContain('orphan-spawn1')
+
+    // Advance 2 more seconds (6s total > 5s threshold) — heartbeat fires promotion.
+    advanceMs(2000)
+    const htmlAt6s = emits2[emits2.length - 1]?.html ?? ''
+    // After promotion the synthetic sub-agent row must be visible. Renderer
+    // produces a `<blockquote expandable>🤖 📂 #orphan-spawn1 …` block
+    // containing the description from the pending spawn ("Analyse logs").
+    expect(htmlAt6s).toContain('orphan-spawn1')
+    expect(htmlAt6s).toContain('Analyse logs')
+  })
+
+  /**
+   * Gap 4 (cold-JSONL detection): a running sub-agent whose lastEventAt is
+   * > 30s old must receive a synthetic sub_agent_turn_end so the deferred
+   * completion path can proceed.
+   */
+  it('Gap 4 — cold JSONL causes synthetic sub_agent_turn_end and deferred completion fires', () => {
+    const emitted: Array<unknown> = []
+    let nowMs = 1000
+    const timers3: Array<{ fireAt: number; fn: () => void; ref: number; repeat?: number }> = []
+    let nextRef3 = 0
+    const emits3: Array<{ html: string; done: boolean }> = []
+    const driver3 = createProgressDriver({
+      emit: (a) => emits3.push(a),
+      minIntervalMs: 0,
+      coalesceMs: 0,
+      heartbeatMs: 5000,
+      initialDelayMs: 0,
+      coldSubAgentThresholdMs: 30_000,
+      onTurnComplete: (args) => emitted.push(args),
+      now: () => nowMs,
+      setTimeout: (fn, ms) => { const ref = nextRef3++; timers3.push({ fireAt: nowMs + ms, fn, ref }); return { ref } },
+      clearTimeout: (handle) => { const t = (handle as { ref: number }).ref; const i = timers3.findIndex(x => x.ref === t); if (i !== -1) timers3.splice(i, 1) },
+      setInterval: (fn, ms) => { const ref = nextRef3++; timers3.push({ fireAt: nowMs + ms, fn, ref, repeat: ms }); return { ref } },
+      clearInterval: (handle) => { const t = (handle as { ref: number }).ref; const i = timers3.findIndex(x => x.ref === t); if (i !== -1) timers3.splice(i, 1) },
+    })
+    const advanceMs3 = (ms: number) => {
+      nowMs += ms
+      for (;;) {
+        timers3.sort((a, b) => a.fireAt - b.fireAt)
+        const next = timers3[0]
+        if (!next || next.fireAt > nowMs) break
+        if (next.repeat != null) { next.fireAt += next.repeat; next.fn() }
+        else { timers3.shift(); next.fn() }
+      }
+    }
+
+    driver3.ingest(enqueue('c'), null)
+    driver3.ingest({ kind: 'tool_use', toolName: 'Agent', toolUseId: 'p2', input: { description: 'bg', prompt: 'P' } }, 'c')
+    driver3.ingest({ kind: 'sub_agent_started', agentId: 'sa1', firstPromptText: 'P' }, 'c')
+    // Parent turn_end while sa1 is still running → pendingCompletion=true.
+    driver3.ingest({ kind: 'turn_end', durationMs: 1000 }, 'c')
+
+    expect(emitted).toHaveLength(0) // deferred — sa1 still running
+
+    // Simulate JSONL watcher silence: no events for 35s.
+    // The heartbeat (every 5s) fires 7 times → after 35s coldSubAgentThresholdMs (30s) triggers.
+    advanceMs3(35_000)
+
+    // Synthetic sub_agent_turn_end should have fired and unblocked completion.
+    expect(emitted).toHaveLength(1)
+    // Final emit must be done=true.
+    const last = emits3[emits3.length - 1]
+    expect(last?.done).toBe(true)
+  })
+
+  /**
+   * Gap 8 (decoupled render and unpin):
+   *   1. Parent turn_end fires while a sub-agent is still running.
+   *   2. The immediate flush must render done=true (✅ Done header) without
+   *      waiting for the sub-agent.
+   *   3. After deferredCompletionTimeoutMs the heartbeat force-closes with
+   *      the "Stalled — forced close" header and fires onTurnComplete.
+   */
+  it('Gap 8 — turn_end renders ✅ Done immediately; force-unpin fires after deferred timeout', () => {
+    const emitted: Array<unknown> = []
+    let nowMs = 1000
+    const timers4: Array<{ fireAt: number; fn: () => void; ref: number; repeat?: number }> = []
+    let nextRef4 = 0
+    const emits4: Array<{ html: string; done: boolean }> = []
+    const driver4 = createProgressDriver({
+      emit: (a) => emits4.push(a),
+      minIntervalMs: 0,
+      coalesceMs: 0,
+      heartbeatMs: 5000,
+      initialDelayMs: 0,
+      // Disable cold-JSONL so Gap 4 doesn't fire before Gap 8 timeout.
+      coldSubAgentThresholdMs: 0,
+      // Short deferred timeout for the test.
+      deferredCompletionTimeoutMs: 60_000,
+      onTurnComplete: (args) => emitted.push(args),
+      now: () => nowMs,
+      setTimeout: (fn, ms) => { const ref = nextRef4++; timers4.push({ fireAt: nowMs + ms, fn, ref }); return { ref } },
+      clearTimeout: (handle) => { const t = (handle as { ref: number }).ref; const i = timers4.findIndex(x => x.ref === t); if (i !== -1) timers4.splice(i, 1) },
+      setInterval: (fn, ms) => { const ref = nextRef4++; timers4.push({ fireAt: nowMs + ms, fn, ref, repeat: ms }); return { ref } },
+      clearInterval: (handle) => { const t = (handle as { ref: number }).ref; const i = timers4.findIndex(x => x.ref === t); if (i !== -1) timers4.splice(i, 1) },
+    })
+    const advanceMs4 = (ms: number) => {
+      nowMs += ms
+      for (;;) {
+        timers4.sort((a, b) => a.fireAt - b.fireAt)
+        const next = timers4[0]
+        if (!next || next.fireAt > nowMs) break
+        if (next.repeat != null) { next.fireAt += next.repeat; next.fn() }
+        else { timers4.shift(); next.fn() }
+      }
+    }
+
+    driver4.ingest(enqueue('c'), null)
+    driver4.ingest({ kind: 'tool_use', toolName: 'Agent', toolUseId: 'p3', input: { description: 'bg', prompt: 'Q' } }, 'c')
+    driver4.ingest({ kind: 'sub_agent_started', agentId: 'sa2', firstPromptText: 'Q' }, 'c')
+
+    const emitsBefore = emits4.length
+
+    // Parent turn_end while sa2 is still running.
+    driver4.ingest({ kind: 'turn_end', durationMs: 500 }, 'c')
+
+    // Gap 8 assertion 1: the immediate flush on turn_end must render ✅ Done.
+    const afterTurnEnd = emits4.slice(emitsBefore)
+    expect(afterTurnEnd.length).toBeGreaterThanOrEqual(1)
+    const turnEndEmit = afterTurnEnd[afterTurnEnd.length - 1]
+    // Gap 8: header must show ✅ Done immediately (parentDone renders it).
+    expect(turnEndEmit?.html).toContain('✅ <b>Done</b>')
+    // done flag remains false while sub-agents are still running — the
+    // notification-spam guard prevents premature unpin. The HTML header
+    // shows Done (parentDone) but the emit.done=false defers the actual unpin.
+    expect(turnEndEmit?.done).toBe(false)
+
+    // Sub-agent still running → onTurnComplete must NOT have fired yet.
+    expect(emitted).toHaveLength(0)
+
+    // Gap 8 assertion 2: after deferredCompletionTimeoutMs the heartbeat
+    // force-closes with "Stalled — forced close" and fires onTurnComplete.
+    advanceMs4(65_000) // > 60s timeout
+
+    expect(emitted).toHaveLength(1)
+    const stalledEmit = emits4[emits4.length - 1]
+    expect(stalledEmit?.html).toContain('Stalled')
+    expect(stalledEmit?.done).toBe(true)
+  })
+})

--- a/telegram-plugin/tests/progress-card-harness.test.ts
+++ b/telegram-plugin/tests/progress-card-harness.test.ts
@@ -348,9 +348,13 @@ describe('progress-card integration harness', () => {
       now = target
     }
 
-    // Start turn + issue one tool_use, then go idle (simulates Task running).
+    // Start turn + issue one tool_use, then go idle (simulates a long-running
+    // tool such as a slow Bash command). Use a non-dispatching tool (Bash, not
+    // Task/Agent) so the heartbeat scenario isn't perturbed by #313 Gap 3
+    // orphan promotion creating a synthetic sub-agent that would defer the
+    // turn_end terminal emit.
     driver.startTurn({ chatId: 'c1', userText: 'do thing' })
-    driver.ingest({ kind: 'tool_use', toolName: 'Task', toolUseId: 't_task', input: {} } as SessionEvent, 'c1')
+    driver.ingest({ kind: 'tool_use', toolName: 'Bash', toolUseId: 't_bash', input: { command: 'sleep 30' } } as SessionEvent, 'c1')
     advance(100) // let coalesce flush
 
     const countBeforeIdle = emits.length

--- a/telegram-plugin/tests/progress-card-stuck-warning.test.ts
+++ b/telegram-plugin/tests/progress-card-stuck-warning.test.ts
@@ -208,13 +208,12 @@ describe("progress-card driver — stuck warning propagation via heartbeat", () 
     expect(postHasWarning).toBe(false);
   });
 
-  it("heartbeat keeps ticking while sub-agent outlives parent turn_end", () => {
-    // Regression: pre-fix, the heartbeat skipped any card with
-    // `state.stage === 'done'` — which the reducer sets the moment
-    // turn_end fires, even when sub-agents are still running. Result:
-    // user saw a frozen "✅ Done" card with stopped elapsed time while
-    // a sub-agent ground away. Post-fix the heartbeat only skips when
-    // BOTH stage='done' AND !hasAnyRunningSubAgent (display gate).
+  it("heartbeat keeps card pinned while sub-agent outlives parent turn_end (#313 Gap 8)", () => {
+    // Post-#313: parent `turn_end` immediately renders the final card with
+    // ✅ Done in the header (decoupled from unpin). The card stays pinned —
+    // onTurnComplete fires only when the last running sub-agent finishes
+    // OR the deferred-completion timeout expires. Heartbeat still ticks so
+    // the sub-agent's per-row elapsed advances visibly.
     //
     // Note: this scenario exercises a CORRELATED sub-agent — the parent
     // tool_use's `prompt` matches sub_agent_started's `firstPromptText`
@@ -222,7 +221,11 @@ describe("progress-card driver — stuck warning propagation via heartbeat", () 
     // orphan sub-agents (parentToolUseId == null) no longer gate the
     // defer at turn_end — the card closes immediately for those.
     // Correlated sub-agents like this one DO keep the card alive.
-    const { driver, emits, advance } = harness({ heartbeatMs: 5_000 });
+    const completions: Array<{ chatId: string; turnKey: string }> = [];
+    const { driver, emits, advance } = harness({
+      heartbeatMs: 5_000,
+      onTurnComplete: ({ chatId, turnKey }) => completions.push({ chatId, turnKey }),
+    });
     driver.ingest(enqueue("c1"), null);
     // Start a background Agent sub-agent. `prompt` matches firstPromptText
     // below so correlation succeeds and parentToolUseId is set.
@@ -244,23 +247,30 @@ describe("progress-card driver — stuck warning propagation via heartbeat", () 
       },
       "c1",
     );
-    // Parent turn ends while sub-agent still running.
+    // Parent turn ends while sub-agent still running. Per Gap 8, this
+    // produces an immediate ✅ Done render but does NOT fire onTurnComplete.
     driver.ingest({ kind: "turn_end", durationMs: 500 }, "c1");
     const emitsAtTurnEnd = emits.length;
-    // Tick a few heartbeats forward. The sub-agent is still running, so
-    // hasAnyRunningSubAgent gates the defer and the card stays alive — the
-    // heartbeat re-renders as the elapsed-time bucket advances.
+    expect(completions.length).toBe(0); // unpin deferred
+    // The most recent emit at turn_end carries the ✅ Done header.
+    expect(emits[emits.length - 1].html).toContain("✅");
+    // Tick heartbeats forward. The sub-agent is still running, so the card
+    // stays alive and heartbeat re-renders as the sub-agent's elapsed advances.
     advance(20_000);
     const postHeartbeatEmits = emits.length;
     expect(postHeartbeatEmits).toBeGreaterThan(emitsAtTurnEnd);
-    // None of those heartbeat emits should carry done=true — the card
-    // is still waiting on the sub-agent.
     const heartbeatEmits = emits.slice(emitsAtTurnEnd);
+    // Heartbeat emits are non-terminal (not done=true) — terminal already fired
+    // at turn_end. The card stays pinned; unpin is the separate deferred path.
     expect(heartbeatEmits.every((e) => e.done === false)).toBe(true);
-    // And the header should still say "Working…" (⚙️), not "✅ Done".
+    // Heartbeat keeps ✅ Done in the header (parent committed at turn_end);
+    // sub-agent rows underneath still show 🤖 running.
     const lastHeartbeat = heartbeatEmits[heartbeatEmits.length - 1];
-    expect(lastHeartbeat.html).toContain("⚙️");
-    expect(lastHeartbeat.html).not.toContain("✅");
+    expect(lastHeartbeat.html).toContain("✅");
+    expect(lastHeartbeat.html).toContain("🤖");
+    // Still no unpin signal — onTurnComplete only fires when sub-agent finishes
+    // (natural) or the deferred-completion timeout expires.
+    expect(completions.length).toBe(0);
   });
 
   it("zombie ceiling force-closes a card whose lastEventAt is older than maxIdleMs", () => {


### PR DESCRIPTION
## Summary

Three related gaps in the single-card sub-agent tracker that left background work invisible or pinned forever. All under the #305 umbrella.

- **Gap 3 — Orphan promotion.** If a `PendingAgentSpawn` sits >5s without a matching `sub_agent_started` event, promote it to a synthetic sub-agent row. Idempotent against a late real `sub_agent_started`. The work is now at least visible on the card.
- **Gap 4 — Cold-JSONL detection.** If a running sub-agent's JSONL has no new event for >30s, synthesise a `sub_agent_turn_end` so the deferred-completion path can proceed. Closes the watcher-disconnect / dead-FS class of pin leaks.
- **Gap 8 — Decoupled render and unpin.** On parent `turn_end` with running sub-agents, render the parent header as ✅ Done immediately. The card stays pinned. Unpin fires on the last sub-agent's natural finish OR a deferred-completion timeout (default 3 min) with a "stalled — forced close" header.

New thresholds are tunable via config: `orphanPromotionMs`, `coldSubAgentThresholdMs`, `deferredCompletionTimeoutMs`. Pass `0` to any to disable.

## Test plan

- [x] `bun run test:vitest` — 3664 passed
- [x] `bun run lint` clean
- [x] 3 new regression tests in `progress-card-driver.test.ts` (orphan promotion, cold-JSONL synth, decoupled-unpin)
- [x] Existing `progress-card-stuck-warning.test.ts` "heartbeat keeps ticking" updated to reflect the new ✅-Done-on-turn-end contract
- [x] Existing `progress-card-harness.test.ts` heartbeat-idle test changed Task → Bash so the heartbeat scenario isn't perturbed by Gap 3 promotion

Closes #313
Closes #304
Closes #308

🤖 Generated with [Claude Code](https://claude.com/claude-code)