### PR TITLE
ux(reactions): drop 🔥 from active-work states (part of #320)

### DIFF
--- a/telegram-plugin/status-reactions.ts
+++ b/telegram-plugin/status-reactions.ts
@@ -72,7 +72,7 @@ export const REACTION_VARIANTS: Record<ReactionState, string[]> = {
   thinking:  ['🤔', '🤓', '👀'],     // unchanged
   tool:      ['✍', '⚡', '👌'],      // WORKING: actively using a tool
   coding:    ['👨‍💻', '✍', '⚡'],     // WORKING: writing / running code
-  web:       ['⚡', '👀', '👌'],      // WORKING: lookup in motion
+  web:       ['⚡', '🤔', '👌'],      // WORKING: lookup in motion (👀 reserved for READ)
   compacting:['✍', '🤔', '👀'],      // unchanged
   done:      ['👍', '💯', '🎉'],      // FINISHED: reply landed
   // 🙊 — turn ended without producing a user-visible reply. Distinct from

--- a/telegram-plugin/status-reactions.ts
+++ b/telegram-plugin/status-reactions.ts
@@ -4,7 +4,7 @@
  * Ports the pattern from openclaw's src/channels/status-reactions.ts +
  * extensions/telegram/src/status-reaction-variants.ts. The goal is to give
  * the user a glanceable, non-spammy progress signal on their inbound
- * message: 👀 received → 🤔 thinking → 🔥/👨‍💻/⚡ working → 👍 done → 😱 error.
+ * message: 👀 received → 🤔 thinking → ✍/👨‍💻/⚡ working → 👍 done → 😱 error.
  *
  * Three load-bearing properties (all from openclaw research):
  *
@@ -58,22 +58,30 @@ export type ReactionState =
  * Per-state emoji preference, with fallbacks if the first isn't allowed
  * in this particular chat. Modeled on openclaw's
  * TELEGRAM_STATUS_REACTION_VARIANTS.
+ *
+ * Semantic split — do not conflate these three tiers:
+ *   READ     👀  = "I have seen your message" (acknowledgement only)
+ *   WORKING  ✍   = actively doing something (tools, coding, compacting)
+ *   FINISHED 👍/💯/🎉 = definitively done; a reply landed
+ *
+ * 🔥 is reserved for genuine 5xx server errors (operator-events.ts).
+ * It reads as "on fire / broken" — keep it out of normal active-work states.
  */
 export const REACTION_VARIANTS: Record<ReactionState, string[]> = {
-  queued:    ['👀', '👍', '🔥'],
-  thinking:  ['🤔', '🤓', '👀'],
-  tool:      ['🔥', '⚡', '👍'],
-  coding:    ['👨‍💻', '🔥', '⚡'],
-  web:       ['⚡', '🔥', '👍'],
-  compacting:['✍', '🤔', '👀'],
-  done:      ['👍', '🎉', '💯'],
+  queued:    ['👀', '🤔', '🤓'],     // READ: I see your message
+  thinking:  ['🤔', '🤓', '👀'],     // unchanged
+  tool:      ['✍', '⚡', '👌'],      // WORKING: actively using a tool
+  coding:    ['👨‍💻', '✍', '⚡'],     // WORKING: writing / running code
+  web:       ['⚡', '👀', '👌'],      // WORKING: lookup in motion
+  compacting:['✍', '🤔', '👀'],      // unchanged
+  done:      ['👍', '💯', '🎉'],      // FINISHED: reply landed
   // 🙊 — turn ended without producing a user-visible reply. Distinct from
   // 'done' (which means "reply landed") so the user doesn't read 👍 as
   // "agent acknowledged" when actually nothing was sent. See issue #132.
-  silent:    ['🙊', '🤔', '😐'],
-  error:     ['😱', '😨', '🤯'],
-  stallSoft: ['🥱', '😴', '🤔'],
-  stallHard: ['😨', '🤯', '😱'],
+  silent:    ['🙊', '🤔', '😐'],      // unchanged
+  error:     ['😱', '😨', '🤯'],      // unchanged (genuine alarm)
+  stallSoft: ['🥱', '😴', '🤔'],      // unchanged
+  stallHard: ['😨', '🤯', '😱'],      // unchanged
 }
 
 /**
@@ -264,7 +272,7 @@ export class StatusReactionController {
       }
     }
     // Last resort: any whitelisted-and-allowed emoji from the broad fallback set
-    for (const v of ['👍', '👀', '🔥']) {
+    for (const v of ['👍', '👀', '✍']) {
       if (this.allowedReactions == null || this.allowedReactions.has(v)) {
         return v
       }

--- a/telegram-plugin/tests/status-reactions.test.ts
+++ b/telegram-plugin/tests/status-reactions.test.ts
@@ -62,6 +62,19 @@ describe('REACTION_VARIANTS', () => {
       }
     }
   })
+
+  it('🔥 is not in active-work states (queued/tool/coding/web) — #320', () => {
+    const activeWorkStates = ['queued', 'tool', 'coding', 'web'] as const
+    for (const state of activeWorkStates) {
+      expect(REACTION_VARIANTS[state]).not.toContain('🔥')
+    }
+  })
+
+  it('done includes at least one positive completion emoji (👍 or 💯)', () => {
+    const done = REACTION_VARIANTS['done']
+    const hasPositive = done.includes('👍') || done.includes('💯')
+    expect(hasPositive).toBe(true)
+  })
 })
 
 describe('StatusReactionController', () => {
@@ -247,9 +260,9 @@ describe('StatusReactionController', () => {
     const allowed = new Set(['👍', '🔥'])
     const ctrl = new StatusReactionController(emit, allowed)
 
-    ctrl.setQueued() // wants 👀, falls back to 🔥 (3rd queued variant) ... actually 👀 → fallback chain
+    ctrl.setQueued() // wants 👀, then 🤔, then 🤓 — none allowed; broad fallback picks 👍
     await flush()
-    // 👀 is not allowed, 👍 is the second queued variant → 👍
+    // 👀, 🤔, 🤓 — none in allowed; broad fallback hits 👍 → 👍
     expect(calls).toEqual(['👍'])
 
     ctrl.setThinking() // wants 🤔, falls back through variants, then generic — none in allowed


### PR DESCRIPTION
## Summary
- Removes 🔥 (fire) from `queued`/`tool`/`coding`/`web` reaction ladders. Reads as alarm rather than active work.
- Replaces with neutral motion emoji: ✍ / ⚡ / 👀 / 👌 / 👨‍💻. All whitelist-allowed.
- Reserves 🔥 only for genuine 5xx errors in `operator-events.ts` (already the case; not touched).
- Documents the semantic split: 👀 = read, ✍ = working, 👍/💯/🎉 = definitively finished.

## Test plan
- [ ] 🔥 not in active-work ladders
- [ ] all new emojis are in TELEGRAM_REACTION_WHITELIST
- [ ] manual: trigger queued/working/done state changes; verify reactions feel calm

## Related
- #320 (color scheme — reads as alarming)