### PR TITLE
fix(#314): heartbeat keeps elapsed counter live while sub-agent runs

### DIFF
--- a/telegram-plugin/progress-card-driver.ts
+++ b/telegram-plugin/progress-card-driver.ts
@@ -223,6 +223,25 @@ export interface ProgressDriverConfig {
    * Default 180000 (3 minutes). Set to 0 to disable.
    */
   deferredCompletionTimeoutMs?: number
+  /**
+   * Fix #314 — elapsed-ticker interval for silent sub-agent gaps.
+   *
+   * While at least one sub-agent is in `state='running'`, the parent card
+   * only re-renders when an event changes the HTML (tool start/end, stage
+   * change). During silent stretches between tool calls the elapsed counter
+   * freezes — the diff guard suppresses edits when only the timestamp
+   * advances. This interval forces a render (bypassing that guard) every N ms
+   * so the elapsed counter visibly ticks even when the sub-agent is quietly
+   * thinking or waiting for I/O.
+   *
+   * 10 s was chosen as a balance: short enough that the counter advances
+   * at human-perceptible speed (users notice a 15+ second freeze), long
+   * enough to stay well under Telegram's ~20 edits/minute budget even when
+   * multiple cards are active in parallel.
+   *
+   * Default 10000. Set to 0 to disable the elapsed-ticker path entirely.
+   */
+  subAgentTickIntervalMs?: number
 }
 
 /**
@@ -498,6 +517,7 @@ export function createProgressDriver(config: ProgressDriverConfig): ProgressDriv
   const orphanPromotionMs = config.orphanPromotionMs ?? 5_000
   const coldSubAgentThresholdMs = config.coldSubAgentThresholdMs ?? 30_000
   const deferredCompletionTimeoutMs = config.deferredCompletionTimeoutMs ?? 3 * 60_000
+  const subAgentTickIntervalMs = config.subAgentTickIntervalMs ?? 10_000
   // Per-chat sliding 60s window of recent emit timestamps. When the
   // window holds more than `editBudgetThreshold` entries we're "hot"
   // and coalesce more aggressively.
@@ -558,6 +578,14 @@ export function createProgressDriver(config: ProgressDriverConfig): ProgressDriv
   // header elapsed counter (rounded to the heartbeat cadence) would
   // still render identically, skip the edit.
   const lastHeartbeatBucket = new Map<string, number>()
+  // Fix #314: tracks the last sub-agent elapsed-tick bucket per turn.
+  // Works exactly like `lastHeartbeatBucket` but uses `subAgentTickIntervalMs`
+  // as the bucket width. When the bucket advances AND at least one sub-agent
+  // is running, the heartbeat forces an emit even when the HTML hash is
+  // unchanged. Bucket-based (not timestamp-based) so the comparison is stable
+  // even when multiple heartbeat ticks fire at the same `now()` value during
+  // a fake-clock advance in tests.
+  const lastSubAgentTickBucket = new Map<string, number>()
 
   /**
    * Fire completion callbacks + delete chatState + tidy bookkeeping.
@@ -641,6 +669,7 @@ export function createProgressDriver(config: ProgressDriverConfig): ProgressDriv
     }
     chats.delete(cs.turnKey)
     lastHeartbeatBucket.delete(cs.turnKey)
+    lastSubAgentTickBucket.delete(cs.turnKey)
     editTimestamps.delete(cs.turnKey)
     if (currentTurnKey === cs.turnKey) {
       currentChatId = null
@@ -792,11 +821,28 @@ export function createProgressDriver(config: ProgressDriverConfig): ProgressDriv
           continue
         }
 
+        // Fix #314 — elapsed-ticker bucket: compute BEFORE the budget-hot
+        // skip so the ticker can override the skip when the elapsed counter
+        // would otherwise freeze. A bursty sub-agent (many tool calls) makes
+        // the chat hot, which suppresses the heartbeat — but the user still
+        // expects elapsed time to advance visibly. The ticker provides a hard
+        // floor every `subAgentTickIntervalMs` so the UI never looks dead for
+        // longer than that, even when a sub-agent is grinding through tools.
+        const subAgentRunning = subAgentTickIntervalMs > 0 && hasAnyRunningSubAgent(cs.state)
+        const subAgentBucket = subAgentTickIntervalMs > 0 ? Math.floor(now() / subAgentTickIntervalMs) : 0
+        const prevSubAgentBucket = lastSubAgentTickBucket.get(cs.turnKey)
+        const elapsedTickDue = subAgentRunning && subAgentBucket !== prevSubAgentBucket
+
         // Skip heartbeat while the chat is hot — sub-agent bursts are
         // already producing edits, the elapsed counter is ticking from
         // those, and an extra heartbeat edit just spends budget. (Design
-        // §4.4: "heartbeat respects budget too".)
-        if (isBudgetHot(cs.turnKey)) continue
+        // §4.4: "heartbeat respects budget too".) EXCEPTION: when the
+        // elapsed-ticker is due, push one render through to keep elapsed
+        // visibly advancing — this is the floor that fixes #314.
+        if (isBudgetHot(cs.turnKey) && !elapsedTickDue) continue
+        if (elapsedTickDue) {
+          lastSubAgentTickBucket.set(cs.turnKey, subAgentBucket)
+        }
         const stuckMs = Math.max(0, now() - cs.lastEventAt)
         // Issue #132: silentEnd only matters once the parent turn is in
         // `stage='done'` AND no sub-agents are still running. While work
@@ -817,7 +863,13 @@ export function createProgressDriver(config: ProgressDriverConfig): ProgressDriv
         const html = render(cs.state, now(), undefined, { stuckMs, silentEnd, replyNotDelivered, parentDone })
         const bucket = Math.floor(now() / heartbeatMs)
         const prevBucket = lastHeartbeatBucket.get(cs.turnKey)
-        if (html === cs.lastEmittedHtml && bucket === prevBucket) continue
+
+        // Fix #314 — elapsed-ticker bypass for the html-unchanged guard. When
+        // the elapsed-ticker is due, push the emit through even if html and
+        // heartbeat-bucket are both unchanged. Combined with the budget-hot
+        // bypass above, this guarantees the elapsed counter advances at most
+        // `subAgentTickIntervalMs` apart while a sub-agent is running.
+        if (html === cs.lastEmittedHtml && bucket === prevBucket && !elapsedTickDue) continue
         lastHeartbeatBucket.set(cs.turnKey, bucket)
         cs.lastEmittedHtml = html
         cs.lastEmittedAt = now()

--- a/telegram-plugin/tests/progress-card-driver.test.ts
+++ b/telegram-plugin/tests/progress-card-driver.test.ts
@@ -2782,3 +2782,269 @@ describe('issue #313: sub-agent visibility leaks — regression tests', () => {
     expect(stalledEmit?.done).toBe(true)
   })
 })
+
+describe('issue #314: elapsed-ticker keeps counter live during sub-agent silence', () => {
+  /**
+   * Helper that builds a standalone driver with injected clocks and the
+   * subAgentTickIntervalMs option, mirroring the pattern used by Gap 3/4/8.
+   */
+  function makeDriver314(subAgentTickIntervalMs: number, extraOpts: Record<string, unknown> = {}) {
+    let nowMs = 1000
+    const timers: Array<{ fireAt: number; fn: () => void; ref: number; repeat?: number }> = []
+    let nextRef = 0
+    const emits: Array<{ html: string; done: boolean }> = []
+
+    const driver = createProgressDriver({
+      emit: (a) => emits.push({ html: a.html, done: a.done }),
+      minIntervalMs: 0,
+      coalesceMs: 0,
+      heartbeatMs: 5000,
+      initialDelayMs: 0,
+      // Disable features that would auto-close the sub-agent before the test
+      // window ends — we want to keep it alive for the full 30s.
+      coldSubAgentThresholdMs: 0,
+      deferredCompletionTimeoutMs: 0,
+      maxIdleMs: 0,
+      subAgentTickIntervalMs,
+      now: () => nowMs,
+      setTimeout: (fn, ms) => {
+        const ref = nextRef++
+        timers.push({ fireAt: nowMs + ms, fn, ref })
+        return { ref }
+      },
+      clearTimeout: (handle) => {
+        const t = (handle as { ref: number }).ref
+        const i = timers.findIndex((x) => x.ref === t)
+        if (i !== -1) timers.splice(i, 1)
+      },
+      setInterval: (fn, ms) => {
+        const ref = nextRef++
+        timers.push({ fireAt: nowMs + ms, fn, ref, repeat: ms })
+        return { ref }
+      },
+      clearInterval: (handle) => {
+        const t = (handle as { ref: number }).ref
+        const i = timers.findIndex((x) => x.ref === t)
+        if (i !== -1) timers.splice(i, 1)
+      },
+      ...extraOpts,
+    })
+
+    const advanceMs = (ms: number) => {
+      const target = nowMs + ms
+      for (;;) {
+        timers.sort((a, b) => a.fireAt - b.fireAt)
+        const next = timers[0]
+        if (!next || next.fireAt > target) break
+        // Advance the fake clock to each fire time BEFORE calling fn so the
+        // driver's bucket comparisons (heartbeat & sub-agent ticker) see a
+        // monotonically advancing now(). Without this, every heartbeat fire
+        // within a single advanceMs() call sees the same nowMs and coalesces
+        // to one bucket — masking the elapsed-ticker behaviour entirely.
+        nowMs = next.fireAt
+        if (next.repeat != null) {
+          next.fireAt += next.repeat
+          next.fn()
+        } else {
+          timers.shift()
+          next.fn()
+        }
+      }
+      nowMs = target
+    }
+
+    return { driver, emits, advanceMs, get nowMs() { return nowMs } }
+  }
+
+  /**
+   * Positive test: sub-agent in state='running', no tool events for 30s.
+   * With subAgentTickIntervalMs=5000 the driver should emit ~6 renders in
+   * that window and each one must have a strictly non-decreasing elapsed
+   * string relative to the one before.
+   *
+   * "At least 3" is the stated acceptance criterion from #314; with a 5s
+   * tick over 30s we assert at least 5 to give a tight lower bound while
+   * allowing one missed tick at either boundary.
+   */
+  it('emits at least 5 renders in 30s while sub-agent is running with no tool events', () => {
+    const { driver, emits, advanceMs } = makeDriver314(5000)
+
+    driver.ingest(enqueue('c'), null)
+    driver.ingest({ kind: 'tool_use', toolName: 'Agent', toolUseId: 'p1', input: { description: 'bg', prompt: 'P' } }, 'c')
+    driver.ingest({ kind: 'sub_agent_started', agentId: 'sa1', firstPromptText: 'P' }, 'c')
+
+    // Record emit count after setup (before the silent window).
+    const emitsAfterSetup = emits.length
+
+    // Advance 30 seconds with ZERO further events — pure silence.
+    advanceMs(30_000)
+
+    const delta = emits.length - emitsAfterSetup
+    // Accept criterion from #314: at least 3; our interval gives ~6 so we
+    // assert ≥ 5 to catch if the ticker fires much less often than expected.
+    expect(delta).toBeGreaterThanOrEqual(5)
+  })
+
+  /**
+   * The actual #314 fix lives here: when the chat is "hot" (edit-budget
+   * threshold tripped by a bursty sub-agent), the heartbeat is normally
+   * skipped entirely (`isBudgetHot` continue at line ~828). The ticker
+   * bypass at the budget-hot check guarantees elapsed still advances every
+   * `subAgentTickIntervalMs` even during a burst — the actual symptom Ken
+   * screenshotted (47s elapsed, frozen UI while sub-agent grinding).
+   */
+  it('elapsed-ticker bypasses isBudgetHot suppression during sub-agent burst', () => {
+    // editBudgetThreshold=2 means chat goes hot after just 2 edits in 60s —
+    // tighter than production's 18, but exercises the same code path.
+    const { driver, emits, advanceMs } = makeDriver314(5000, { editBudgetThreshold: 2 })
+
+    driver.ingest(enqueue('c'), null)
+    driver.ingest({ kind: 'tool_use', toolName: 'Agent', toolUseId: 'p_burst', input: { description: 'bg', prompt: 'P' } }, 'c')
+    driver.ingest({ kind: 'sub_agent_started', agentId: 'sa_burst', firstPromptText: 'P' }, 'c')
+
+    // Burst: fire several sub-agent tool events to trip the edit budget.
+    // Each tool_use → a render → a recordEdit. Quickly the chat goes hot.
+    for (let i = 0; i < 5; i++) {
+      driver.ingest({ kind: 'sub_agent_tool_use', agentId: 'sa_burst', toolUseId: `t${i}`, toolName: 'Read', input: { file_path: `/f${i}` } }, 'c')
+      driver.ingest({ kind: 'sub_agent_tool_result', agentId: 'sa_burst', toolUseId: `t${i}` }, 'c')
+    }
+
+    const before = emits.length
+
+    // Now go silent for 30s. Without the budget-hot bypass the heartbeat
+    // would skip every tick (chat is hot) and the elapsed counter would
+    // freeze. With the bypass, the ticker forces ~6 emits at 5s intervals.
+    advanceMs(30_000)
+
+    const delta = emits.length - before
+    // The bypass should produce multiple ticker emits during the burst-hot
+    // window — not zero.
+    expect(delta).toBeGreaterThanOrEqual(3)
+  })
+
+  it('elapsed counter in rendered HTML increases monotonically during sub-agent silence', () => {
+    const { driver, emits, advanceMs } = makeDriver314(5000)
+
+    driver.ingest(enqueue('c'), null)
+    driver.ingest({ kind: 'tool_use', toolName: 'Agent', toolUseId: 'p2', input: { description: 'bg', prompt: 'P' } }, 'c')
+    driver.ingest({ kind: 'sub_agent_started', agentId: 'sa2', firstPromptText: 'P' }, 'c')
+
+    const snapshots: string[] = []
+    // Capture HTML at each 5s tick for 30s.
+    for (let i = 0; i < 6; i++) {
+      advanceMs(5000)
+      const last = emits[emits.length - 1]
+      if (last) snapshots.push(last.html)
+    }
+
+    // We need at least 2 snapshots to check monotonicity.
+    expect(snapshots.length).toBeGreaterThanOrEqual(2)
+
+    // Extract elapsed seconds from the HTML header. The renderer produces
+    // something like "00:12" or "1:05" for the parent elapsed time.
+    // We parse it generically: find the pattern mm:ss and convert to seconds.
+    function parseElapsedSecs(html: string): number {
+      const m = html.match(/(\d+):(\d{2})/)
+      if (!m) return -1
+      return parseInt(m[1], 10) * 60 + parseInt(m[2], 10)
+    }
+
+    const seconds = snapshots.map(parseElapsedSecs)
+    // Every snapshot must have a valid elapsed string.
+    expect(seconds.every((s) => s >= 0)).toBe(true)
+    // Each elapsed value must be >= the previous (strictly non-decreasing).
+    for (let i = 1; i < seconds.length; i++) {
+      expect(seconds[i]).toBeGreaterThanOrEqual(seconds[i - 1])
+    }
+    // The last snapshot must be strictly greater than the first (overall progress).
+    expect(seconds[seconds.length - 1]).toBeGreaterThan(seconds[0])
+  })
+
+  /**
+   * Sanity test: with no sub-agent running, the elapsed-ticker bypass must
+   * NOT fire (the `subAgentRunning` gate uses `hasAnyRunningSubAgent`). The
+   * existing heartbeat-bucket logic still produces emits as the parent's
+   * elapsed-time string ticks, which is correct behaviour. We just verify
+   * the ticker bypass itself is gated.
+   */
+  it('elapsed-ticker bypass is gated on running sub-agent (idle parent)', () => {
+    const { driver, emits, advanceMs } = makeDriver314(5000)
+
+    // A normal turn with no sub-agents at all — just a Bash tool that ended.
+    driver.ingest(enqueue('c'), null)
+    driver.ingest({ kind: 'tool_use', toolName: 'Bash', toolUseId: 'b1', input: { command: 'sleep 1' } }, 'c')
+    driver.ingest({ kind: 'tool_result', toolUseId: 'b1', toolName: 'Bash' }, 'c')
+
+    // Wait for any pending coalesce timers to drain.
+    advanceMs(1000)
+
+    // Compare emit counts with ticker enabled vs disabled — they should match
+    // when no sub-agent is running, proving the bypass is gated.
+    const countAfterDrain = emits.length
+    advanceMs(30_000)
+    const deltaWithTicker = emits.length - countAfterDrain
+
+    // Same scenario, ticker disabled.
+    const { driver: d2, emits: e2, advanceMs: a2 } = makeDriver314(0)
+    d2.ingest(enqueue('c'), null)
+    d2.ingest({ kind: 'tool_use', toolName: 'Bash', toolUseId: 'b1', input: { command: 'sleep 1' } }, 'c')
+    d2.ingest({ kind: 'tool_result', toolUseId: 'b1', toolName: 'Bash' }, 'c')
+    a2(1000)
+    const c2 = e2.length
+    a2(30_000)
+    const deltaWithoutTicker = e2.length - c2
+
+    // With no running sub-agent the ticker contributes nothing — both runs
+    // produce the same number of emits (heartbeat-bucket fires only).
+    expect(deltaWithTicker).toBe(deltaWithoutTicker)
+  })
+
+  /**
+   * Configurable interval test: explicitly set subAgentTickIntervalMs=5000
+   * and advance 30s — expect approximately 6 ticks (one every 5s).
+   * This exercises the option round-trip and confirms the tick count scales
+   * with the interval setting.
+   */
+  it('subAgentTickIntervalMs=5000 produces ~6 ticks over 30s', () => {
+    const { driver, emits, advanceMs } = makeDriver314(5000)
+
+    driver.ingest(enqueue('c'), null)
+    driver.ingest({ kind: 'tool_use', toolName: 'Agent', toolUseId: 'p3', input: { description: 'bg', prompt: 'P' } }, 'c')
+    driver.ingest({ kind: 'sub_agent_started', agentId: 'sa3', firstPromptText: 'P' }, 'c')
+
+    const before = emits.length
+    advanceMs(30_000)
+    const delta = emits.length - before
+
+    // With a 5s interval over 30s we expect ~6 ticks. Allow a tolerance of ±2
+    // for boundary/fence-post effects (the heartbeat itself fires at 5s
+    // intervals and may coalesce with the first elapsed tick).
+    expect(delta).toBeGreaterThanOrEqual(4)
+    expect(delta).toBeLessThanOrEqual(8)
+  })
+
+  /**
+   * Disabled ticker test: subAgentTickIntervalMs=0 should make the bypass a
+   * no-op. The heartbeat still fires its own bucket-change emits as elapsed
+   * advances — that's the existing behaviour and we expect ~6 over 30s.
+   * The key property is that the disabled path doesn't crash or produce
+   * runaway emits beyond what the heartbeat alone produces.
+   */
+  it('subAgentTickIntervalMs=0 disables the elapsed-ticker bypass', () => {
+    const { driver, emits, advanceMs } = makeDriver314(0)
+
+    driver.ingest(enqueue('c'), null)
+    driver.ingest({ kind: 'tool_use', toolName: 'Agent', toolUseId: 'p4', input: { description: 'bg', prompt: 'P' } }, 'c')
+    driver.ingest({ kind: 'sub_agent_started', agentId: 'sa4', firstPromptText: 'P' }, 'c')
+
+    const before = emits.length
+    advanceMs(30_000)
+    const delta = emits.length - before
+
+    // With the bypass off, heartbeat-bucket fires still produce ~6 emits
+    // (one per 5s bucket change). The ticker just stops adding any extra.
+    // This is the existing behaviour pre-#314; assert a bounded sanity range.
+    expect(delta).toBeGreaterThanOrEqual(3)
+    expect(delta).toBeLessThanOrEqual(10)
+  })
+})


### PR DESCRIPTION
## Summary

Bundle B from the #305 audit. The screenshot symptom (47s elapsed, last tool 1s ago, frozen UI while sub-agent grinding) was caused by `isBudgetHot` skipping the heartbeat during sub-agent bursts. Once the chat trips the 60s sliding edit budget, the heartbeat returns early — and the parent's elapsed counter stops advancing visibly even though the sub-agent is actively running.

## What changed

- New per-turn `lastSubAgentTickBucket` Map (mirrors the existing `lastHeartbeatBucket`).
- The elapsed-tick check is computed BEFORE the budget-hot skip, and the skip is bypassed when the ticker bucket has advanced.
- The same flag also bypasses the html-unchanged guard further down.
- Gated on `subAgentTickIntervalMs > 0 && hasAnyRunningSubAgent(cs.state)` so idle parents don't burn quota.
- New config `subAgentTickIntervalMs` (default 10s, set to `0` to disable).

The combined effect: every `subAgentTickIntervalMs` gets one render through to the chat, even when the burst-hot window would otherwise suppress all heartbeats.

## Test plan

- [x] `bun run test:vitest` — 3705 passed
- [x] `bun run lint` clean
- [x] **Bypass test:** with `editBudgetThreshold=2` (forces hot quickly via 5 sub-agent tool events), the ticker still fires ≥3 emits over 30s of silence — the actual #314 fix
- [x] Positive: 5+ renders in 30s while sub-agent running with no tool events
- [x] Configurability: `subAgentTickIntervalMs=5000` produces 4–8 ticks over 30s
- [x] Disabled ticker: `subAgentTickIntervalMs=0` is a clean no-op
- [x] Gated: with no running sub-agent, ticker contributes zero emits

Closes #314

🤖 Generated with [Claude Code](https://claude.com/claude-code)