### PR TITLE
feat(gateway): kill-path turn stamping (stage 3c)

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -6414,6 +6414,27 @@ async function shutdown(signal: string): Promise<void> {
     process.stderr.write(`telegram gateway: shutdown.clean_marker_skipped signal=${signal} (crash path — banner will fire on next boot)\n`)
   }
 
+  // Stage 3c: stamp any in-flight turn as endedVia='sigterm' (or 'restart'
+  // for the schedule_restart-initiated case where pendingRestarts is set).
+  // Best-effort — SIGKILL / OOM skip this path entirely and the next-boot
+  // reaper catches them as endedVia='restart'.
+  if (turnsDb != null && currentTurnRegistryKey != null) {
+    const wasScheduledRestart = pendingRestarts.size > 0
+    const endedVia = wasScheduledRestart ? 'restart' : 'sigterm'
+    try {
+      recordTurnEnd(turnsDb, {
+        turnKey: currentTurnRegistryKey,
+        endedVia,
+        lastAssistantMsgId: currentTurnLastAssistantMsgId,
+        lastAssistantDone: currentTurnLastAssistantDone,
+      })
+      process.stderr.write(`telegram gateway: shutdown.turn_stamped turnKey=${currentTurnRegistryKey} endedVia=${endedVia}\n`)
+    } catch (err) {
+      process.stderr.write(`telegram gateway: shutdown.turn_stamp_failed turnKey=${currentTurnRegistryKey} err=${(err as Error).message}\n`)
+    }
+    currentTurnRegistryKey = null
+  }
+
   // Stop the long-poll health check before draining so it doesn't trigger
   // a stall-recovery restart while we're already in shutdown.
   pollHealthCheck?.stop()

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -216,6 +216,8 @@ import {
 import {
   openTurnsDb,
   markOrphanedAsRestarted,
+  recordTurnStart,
+  recordTurnEnd,
 } from '../registry/turns-schema.js'
 
 // ─── Stderr logging ───────────────────────────────────────────────────────
@@ -643,6 +645,18 @@ let currentSessionThreadId: number | undefined = undefined
 let currentTurnReplyCalled = false
 let currentTurnCapturedText: string[] = []
 let orphanedReplyTimeoutId: ReturnType<typeof setTimeout> | null = null
+// Stage 3b: per-turn registry-key (chat:thread:startTs). Set on enqueue,
+// cleared after recordTurnEnd. Used by turn_end / SIGTERM / schedule_restart
+// paths to stamp the right row.
+let currentTurnRegistryKey: string | null = null
+// Last assistant outbound message id for the current turn — populated on
+// reply / stream_reply emit, captured into recordTurnEnd. Stage 4 reads
+// this on resume to thread-jump back to the in-flight conversation.
+let currentTurnLastAssistantMsgId: string | null = null
+// Whether the current turn produced a stream_reply with done=true. The
+// resume protocol uses this to decide "did the previous turn actually
+// finish a reply, or was it interrupted before commit?".
+let currentTurnLastAssistantDone = false
 
 // Issue #195 — answer-lane streaming.
 // Lazily created on the first text event of a turn (once enough text has
@@ -2201,6 +2215,26 @@ function handleSessionEvent(ev: SessionEvent): void {
         currentTurnReplyCalled = false
         currentTurnCapturedText = []
         currentTurnStartedAt = Date.now()
+        currentTurnLastAssistantMsgId = null
+        currentTurnLastAssistantDone = false
+        // Stage 3b: stamp turn-start in the registry. turn_key is
+        // chat:thread:startTs — unique per turn, distinct from the
+        // progress-card-driver's per-chat sequence number (these are two
+        // independent identifier schemes and don't need to align).
+        if (turnsDb != null) {
+          const turnKey = `${ev.chatId}:${ev.threadId ?? '_'}:${currentTurnStartedAt}`
+          currentTurnRegistryKey = turnKey
+          try {
+            recordTurnStart(turnsDb, {
+              turnKey,
+              chatId: String(ev.chatId),
+              threadId: ev.threadId != null ? String(ev.threadId) : null,
+              lastUserMsgId: ev.messageId != null ? String(ev.messageId) : null,
+            })
+          } catch (err) {
+            process.stderr.write(`telegram gateway: recordTurnStart failed turnKey=${turnKey}: ${(err as Error).message}\n`)
+          }
+        }
         // Issue #195: capture transport selection + time-to-ack baseline
         // up-front so the per-turn answer-stream config is determined before
         // the first text event arrives.
@@ -2619,10 +2653,28 @@ function handleSessionEvent(ev: SessionEvent): void {
       pendingPtyPartial = null
       closeActivityLane(chatId, threadId)
       closeProgressLane(chatId, threadId)
+      // Stage 3b: stamp turn-end in the registry as endedVia='stop' (clean
+      // turn_end emit). The kill paths (schedule_restart / SIGTERM) handle
+      // the 'restart' / 'sigterm' cases separately in 3c.
+      if (turnsDb != null && currentTurnRegistryKey != null) {
+        try {
+          recordTurnEnd(turnsDb, {
+            turnKey: currentTurnRegistryKey,
+            endedVia: 'stop',
+            lastAssistantMsgId: currentTurnLastAssistantMsgId,
+            lastAssistantDone: currentTurnLastAssistantDone,
+          })
+        } catch (err) {
+          process.stderr.write(`telegram gateway: recordTurnEnd(stop) failed turnKey=${currentTurnRegistryKey}: ${(err as Error).message}\n`)
+        }
+      }
+      currentTurnRegistryKey = null
       currentSessionChatId = null
       currentSessionThreadId = undefined
       currentTurnReplyCalled = false
       currentTurnCapturedText = []
+      currentTurnLastAssistantMsgId = null
+      currentTurnLastAssistantDone = false
       return
     }
   }


### PR DESCRIPTION
## Summary
- Gateway shutdown handler stamps any in-flight turn with \`endedVia='sigterm'\` (or \`'restart'\` when a schedule_restart had set \`pendingRestarts\`).
- Best-effort — SIGKILL / OOM / hard reboot skip this; Stage 3a's boot reaper catches those as \`'restart'\`.

## Why
Closes Stage 3 of the simplify-restart plan. With 3a/3b/3c, every turn either:
1. ends cleanly via turn_end → \`'stop'\`, or
2. is stamped at SIGTERM → \`'sigterm'\` / \`'restart'\`, or
3. left as orphan and stamped on next boot → \`'restart'\`

Stage 4 reads this on cold start. Stage 5 wires the agent-side resume protocol.

## Stack
- #329 (3a, base)
- #330 (3b, depends on 3a)
- this PR (3c, depends on 3b)

Diff currently includes 3a + 3b commits. Will auto-shrink as the stack lands on main.

## Test plan
- [x] build + tsc clean
- [x] registry-layer regression (22 tests pass)
- [ ] integration test deferred to Stage 4 where we'll have an end-to-end resume flow to assert against

## Related
- #325 (schema, merged)
- #329, #330 (Stage 3a, 3b)