### PR TITLE
feat(scaffold): expose interrupted-turn signal to agent on cold start (stage 4)

### DIFF
--- a/profiles/_base/start.sh.hbs
+++ b/profiles/_base/start.sh.hbs
@@ -166,6 +166,32 @@ if [ -n "$_RESUME_LATEST_JSONL" ]; then
 fi
 export SWITCHROOM_PRIOR_SESSION_EPOCH
 
+# --- Pending-turn signal (Stage 4 of simplify-restart, see #250) ---
+#
+# The gateway writes <agentDir>/.pending-turn.env on boot if the previous
+# shutdown left an interrupted turn (ended_via='restart' / 'sigterm' /
+# 'timeout' or never closed at all). Source it here so the agent process
+# inherits SWITCHROOM_PENDING_TURN=true plus chat/thread/last-user-msg
+# context. The agent's resume protocol (per-agent CLAUDE.md) reads these
+# and decides whether to ack the interruption + ask for direction or
+# silently continue.
+#
+# Consume the file (rm) so it only applies to ONE boot — multi-restart
+# scenarios shouldn't re-fire the resume prompt repeatedly.
+SWITCHROOM_PENDING_TURN_ENV="{{agentDir}}/.pending-turn.env"
+if [ -f "$SWITCHROOM_PENDING_TURN_ENV" ]; then
+  # shellcheck disable=SC1090
+  . "$SWITCHROOM_PENDING_TURN_ENV"
+  rm -f "$SWITCHROOM_PENDING_TURN_ENV"
+  export SWITCHROOM_PENDING_TURN \
+         SWITCHROOM_PENDING_TURN_KEY \
+         SWITCHROOM_PENDING_CHAT_ID \
+         SWITCHROOM_PENDING_THREAD_ID \
+         SWITCHROOM_PENDING_USER_MSG_ID \
+         SWITCHROOM_PENDING_ENDED_VIA \
+         SWITCHROOM_PENDING_STARTED_AT
+fi
+
 {{#if handoffEnabled}}
 # --- Session handoff briefing ---
 # On a normal shutdown the Stop hook writes .handoff.md (compact

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -218,6 +218,7 @@ import {
   markOrphanedAsRestarted,
   recordTurnStart,
   recordTurnEnd,
+  findMostRecentInterruptedTurn,
 } from '../registry/turns-schema.js'
 
 // ─── Stderr logging ───────────────────────────────────────────────────────
@@ -603,6 +604,36 @@ try {
     process.stderr.write(`telegram gateway: turn-registry boot-reaper stamped ${reaped} orphaned turn(s) as ended_via='restart'\n`)
   } else {
     process.stderr.write(`telegram gateway: turn-registry initialized at ${join(agentDir, 'telegram', 'registry.db')}\n`)
+  }
+
+  // Stage 4: surface the most-recently-interrupted turn to start.sh as a
+  // shell-sourceable env file. The agent's start.sh reads this on next
+  // boot, exports the env vars to the spawned `claude` process, and
+  // deletes the file (one-shot — only ever applies to the immediately
+  // following session). If there's no interrupted turn (clean previous
+  // shutdown), we delete any stale file so the resume protocol doesn't
+  // mis-fire.
+  const pendingEnvPath = join(agentDir, '.pending-turn.env')
+  try {
+    const pending = findMostRecentInterruptedTurn(turnsDb)
+    if (pending != null) {
+      const lines = [
+        `SWITCHROOM_PENDING_TURN=true`,
+        `SWITCHROOM_PENDING_TURN_KEY=${pending.turn_key}`,
+        `SWITCHROOM_PENDING_CHAT_ID=${pending.chat_id}`,
+        pending.thread_id != null ? `SWITCHROOM_PENDING_THREAD_ID=${pending.thread_id}` : `SWITCHROOM_PENDING_THREAD_ID=`,
+        pending.last_user_msg_id != null ? `SWITCHROOM_PENDING_USER_MSG_ID=${pending.last_user_msg_id}` : `SWITCHROOM_PENDING_USER_MSG_ID=`,
+        `SWITCHROOM_PENDING_ENDED_VIA=${pending.ended_via ?? 'unknown'}`,
+        `SWITCHROOM_PENDING_STARTED_AT=${pending.started_at}`,
+      ]
+      writeFileSync(pendingEnvPath, lines.join('\n') + '\n', { mode: 0o600 })
+      process.stderr.write(`telegram gateway: pending-turn env written to ${pendingEnvPath} turnKey=${pending.turn_key} endedVia=${pending.ended_via ?? 'open'}\n`)
+    } else if (existsSync(pendingEnvPath)) {
+      rmSync(pendingEnvPath, { force: true })
+      process.stderr.write(`telegram gateway: pending-turn env cleared (clean previous shutdown)\n`)
+    }
+  } catch (err) {
+    process.stderr.write(`telegram gateway: pending-turn env write failed (${(err as Error).message}) — resume protocol may not fire\n`)
   }
 } catch (err) {
   process.stderr.write(`telegram gateway: turn-registry init failed (${(err as Error).message}) — turn tracking disabled\n`)

--- a/telegram-plugin/registry/turns-schema.ts
+++ b/telegram-plugin/registry/turns-schema.ts
@@ -306,3 +306,27 @@ export function markOrphanedAsRestarted(db: SqliteDatabase): number {
   `).run(now, now) as { changes: number }
   return result.changes
 }
+
+/**
+ * Find the single most-recently-started turn that ended via an interrupt
+ * (`'restart'` | `'sigterm'` | `'timeout'`) OR is still open
+ * (`ended_at IS NULL`). Used by Stage 4 to surface "you had pending work"
+ * to the agent on cold start.
+ *
+ * Returns null if no such turn exists (clean boot — last turn ended 'stop').
+ *
+ * Note on ordering: we use `started_at DESC` (not `updated_at`) so the
+ * boot-time reaper (which mass-stamps orphans with the SAME `ended_at` /
+ * `updated_at`) doesn't reorder them; the temporal "last turn" is what
+ * the user remembers, and that's `started_at`.
+ */
+export function findMostRecentInterruptedTurn(db: SqliteDatabase): Turn | null {
+  const row = db.prepare(`
+    SELECT * FROM turns
+    WHERE ended_at IS NULL
+       OR ended_via IN ('restart', 'sigterm', 'timeout')
+    ORDER BY started_at DESC
+    LIMIT 1
+  `).get() as RawTurnRow | undefined
+  return row ? mapRow(row) : null
+}

--- a/telegram-plugin/tests/registry-turns.test.ts
+++ b/telegram-plugin/tests/registry-turns.test.ts
@@ -18,6 +18,7 @@ import {
   recordTurnEnd,
   findOrphanedTurns,
   markOrphanedAsRestarted,
+  findMostRecentInterruptedTurn,
 } from '../registry/turns-schema.js'
 
 // ---------------------------------------------------------------------------
@@ -345,6 +346,87 @@ describe('markOrphanedAsRestarted', () => {
   it('is safe to call on an empty DB (returns 0, no error)', () => {
     const db = openTurnsDbInMemory()
     expect(markOrphanedAsRestarted(db)).toBe(0)
+    db.close()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// findMostRecentInterruptedTurn
+// ---------------------------------------------------------------------------
+
+describe('findMostRecentInterruptedTurn', () => {
+  it('returns null when no turns exist', () => {
+    const db = openTurnsDbInMemory()
+    expect(findMostRecentInterruptedTurn(db)).toBeNull()
+    db.close()
+  })
+
+  it('returns null when the only turn ended cleanly via stop', () => {
+    const db = openTurnsDbInMemory()
+    recordTurnStart(db, { turnKey: '888:1', chatId: '888' })
+    recordTurnEnd(db, { turnKey: '888:1', endedVia: 'stop' })
+    expect(findMostRecentInterruptedTurn(db)).toBeNull()
+    db.close()
+  })
+
+  it('returns an open turn (ended_at IS NULL) as interrupted', () => {
+    const db = openTurnsDbInMemory()
+    recordTurnStart(db, { turnKey: '999:1', chatId: '999', lastUserMsgId: 'msg-1' })
+    const t = findMostRecentInterruptedTurn(db)
+    expect(t).not.toBeNull()
+    expect(t!.turn_key).toBe('999:1')
+    expect(t!.last_user_msg_id).toBe('msg-1')
+    db.close()
+  })
+
+  it('returns a sigterm-stamped turn as interrupted', () => {
+    const db = openTurnsDbInMemory()
+    recordTurnStart(db, { turnKey: 'aaa:1', chatId: 'aaa' })
+    recordTurnEnd(db, { turnKey: 'aaa:1', endedVia: 'sigterm' })
+    const t = findMostRecentInterruptedTurn(db)
+    expect(t).not.toBeNull()
+    expect(t!.ended_via).toBe('sigterm')
+    db.close()
+  })
+
+  it('returns a restart-stamped turn as interrupted', () => {
+    const db = openTurnsDbInMemory()
+    recordTurnStart(db, { turnKey: 'bbb:1', chatId: 'bbb' })
+    recordTurnEnd(db, { turnKey: 'bbb:1', endedVia: 'restart' })
+    const t = findMostRecentInterruptedTurn(db)
+    expect(t).not.toBeNull()
+    expect(t!.ended_via).toBe('restart')
+    db.close()
+  })
+
+  it('picks the most-recently-started across multiple interrupted turns', () => {
+    const db = openTurnsDbInMemory()
+    recordTurnStart(db, { turnKey: 'ccc:1', chatId: 'ccc' })
+    // Different started_at by waiting one ms; bun:sqlite stores the
+    // recordTurnStart call's Date.now() so we use raw insert below to be
+    // deterministic.
+    db.exec(`UPDATE turns SET started_at = 1000 WHERE turn_key = 'ccc:1'`)
+    recordTurnStart(db, { turnKey: 'ccc:2', chatId: 'ccc' })
+    db.exec(`UPDATE turns SET started_at = 2000 WHERE turn_key = 'ccc:2'`)
+    recordTurnEnd(db, { turnKey: 'ccc:1', endedVia: 'restart' })
+    recordTurnEnd(db, { turnKey: 'ccc:2', endedVia: 'sigterm' })
+    const t = findMostRecentInterruptedTurn(db)
+    expect(t).not.toBeNull()
+    expect(t!.turn_key).toBe('ccc:2')
+    db.close()
+  })
+
+  it('skips a clean stop and picks an older interrupted turn', () => {
+    const db = openTurnsDbInMemory()
+    recordTurnStart(db, { turnKey: 'ddd:1', chatId: 'ddd' })
+    db.exec(`UPDATE turns SET started_at = 1000 WHERE turn_key = 'ddd:1'`)
+    recordTurnStart(db, { turnKey: 'ddd:2', chatId: 'ddd' })
+    db.exec(`UPDATE turns SET started_at = 2000 WHERE turn_key = 'ddd:2'`)
+    recordTurnEnd(db, { turnKey: 'ddd:1', endedVia: 'sigterm' })
+    recordTurnEnd(db, { turnKey: 'ddd:2', endedVia: 'stop' })
+    const t = findMostRecentInterruptedTurn(db)
+    expect(t).not.toBeNull()
+    expect(t!.turn_key).toBe('ddd:1')
     db.close()
   })
 })


### PR DESCRIPTION
## Summary
- New \`findMostRecentInterruptedTurn(db)\` helper in turns-schema.ts.
- Gateway writes \`<agentDir>/.pending-turn.env\` after boot reaper if an interrupted turn exists. KEY=value shell-sourceable format.
- start.sh.hbs sources the env file, exports the vars, removes the file (one-shot).
- 7 new helper tests (29 total registry tests, was 22).

## Why
Producer→consumer plumbing for the resume protocol. Stage 5 (per-agent CLAUDE.md) is the last piece — it reads SWITCHROOM_PENDING_TURN and decides what to do.

## Env vars exposed to the agent
- \`SWITCHROOM_PENDING_TURN=true\`
- \`SWITCHROOM_PENDING_TURN_KEY\`
- \`SWITCHROOM_PENDING_CHAT_ID\`
- \`SWITCHROOM_PENDING_THREAD_ID\` (or empty)
- \`SWITCHROOM_PENDING_USER_MSG_ID\` (or empty)
- \`SWITCHROOM_PENDING_ENDED_VIA\` (restart / sigterm / timeout / unknown)
- \`SWITCHROOM_PENDING_STARTED_AT\` (unix ms)

## Test plan
- [x] 7 new tests for findMostRecentInterruptedTurn
- [x] 29 registry tests pass total
- [x] build + tsc clean
- [ ] manual: kill clerk mid-turn via SIGKILL → next boot, agent sees env vars

## Related
- #325 (schema, merged)
- #329 / #330 / #331 (Stage 3, merged)