### PR TITLE
docs(claude): agent-side resume protocol for SWITCHROOM_PENDING_TURN (stage 5 — closes simplify-restart)

### DIFF
--- a/profiles/_shared/telegram-style.md.hbs
+++ b/profiles/_shared/telegram-style.md.hbs
@@ -44,3 +44,21 @@ If both `queued` and `steering` are somehow present, `queued` wins (explicit bea
 - `accent: 'issue'` — renders `⚠️ Issue` above the body. Use when surfacing blockers, errors, or unresolved questions that need the user's attention.
 
 Don't use `accent` on routine conversational replies — it's for status communication, not decoration. Omitting `accent` (the default) produces identical output to today's behavior.
+
+**Resume protocol — interrupted turns.** When you boot, the start-up env may include `SWITCHROOM_PENDING_TURN=true`. That means the previous gateway died mid-turn (SIGTERM, restart, or a crash that bypassed the SIGTERM handler) and the user's last message was likely never fully answered. The accompanying env vars tell you what was in flight:
+
+- `SWITCHROOM_PENDING_CHAT_ID` — the chat the interrupted turn belonged to
+- `SWITCHROOM_PENDING_THREAD_ID` — the forum topic id (empty if not a forum)
+- `SWITCHROOM_PENDING_USER_MSG_ID` — the inbound message_id that started the turn (you can quote-reply to it for context)
+- `SWITCHROOM_PENDING_ENDED_VIA` — `restart` (user ran `switchroom agent restart`), `sigterm` (systemd/manual kill), `timeout` (watchdog), or `unknown` (crash before stamp)
+- `SWITCHROOM_PENDING_STARTED_AT` — unix-ms when the turn started
+
+**Your first action on a `SWITCHROOM_PENDING_TURN=true` boot must be to acknowledge the gap and confirm direction.** Don't silently pick up where you left off — the user has no way to know whether you remember what you were doing. Use `reply` with `accent: 'issue'` to make it obvious. Quote-reply to `SWITCHROOM_PENDING_USER_MSG_ID` so the original message is in view. Sample wording (adapt to the situation):
+
+> ⚠️ Issue
+>
+> I was killed mid-turn — looks like my previous shutdown was via `<endedVia>`. Don't have full context on what I'd already done. Want me to: (a) start over from your last message, (b) summarize what I think was in flight and continue, or (c) drop it and move on?
+
+The env vars are one-shot — start.sh deletes the file after sourcing. So this prompt only fires on the immediately-following session, not every restart afterward. If you genuinely don't remember anything useful about the prior turn (Hindsight didn't catch it, no handoff briefing landed), say so explicitly rather than guessing.
+
+If `SWITCHROOM_PENDING_TURN` is unset or empty, do nothing special — the previous turn ended cleanly.


### PR DESCRIPTION
## Summary
Adds the "Resume protocol — interrupted turns" section to \`profiles/_shared/telegram-style.md.hbs\`. Tells the agent that when \`SWITCHROOM_PENDING_TURN=true\` on boot, its first action is to send a \`reply\` with \`accent: 'issue'\` quote-replying to the original user message and asking for direction.

## Why
Stage 5 — and the last piece — of the simplify-restart plan. The producer is complete; this gives the agent explicit guidance on what to DO with the signal.

## The full simplify-restart pipeline (now complete)
- **Stage 1** (#317 merged) — \`update --force\` flag, mirrors \`restart --force\`
- **Stage 2** (#325 merged) — turn-tracking schema (Phase 0 of #250)
- **Stage 3a** (#329 merged) — gateway opens registry + boot reaper
- **Stage 3b** (#330 merged) — \`recordTurnStart\` on enqueue + \`recordTurnEnd\` on turn_end
- **Stage 3c** (#331 merged) — SIGTERM kill-path stamping
- **Stage 4** (#336 in flight) — gateway writes \`.pending-turn.env\` + start.sh sources it
- **Stage 5** (this PR) — per-agent CLAUDE.md resume protocol

## Test plan
- [ ] manual: kill clerk mid-turn, restart, watch first inbound message trigger the resume prompt
- [ ] manual: clean restart shows nothing (no false-positive resume prompts)

## Related
- #336 (Stage 4)
- #250 (full registry, future)