### PR TITLE
feat(#332): idle footer renderer (Phase 2)

### DIFF
--- a/telegram-plugin/idle-footer.ts
+++ b/telegram-plugin/idle-footer.ts
@@ -1,0 +1,65 @@
+/**
+ * Pure renderer for the idle/active footer shown on each agent's Telegram topic.
+ *
+ * No DB, no IO, no time-source coupling. Both `rows` and `now` are
+ * caller-supplied so the function is trivially testable.
+ *
+ * ## "Most recent" definition
+ * We pick the row with the greatest `startedAt` value. Using `startedAt` (rather
+ * than `endedAt ?? startedAt`) keeps the semantics simple: the most recently
+ * *started* turn is the one that best reflects the agent's current engagement.
+ * A turn that finished long ago but whose `endedAt` happens to be later than a
+ * newer turn's `startedAt` would give a misleading "working since" signal; that
+ * edge case can't occur in practice (turns are sequential per chat), but the
+ * comment documents the deliberate choice.
+ */
+
+export interface TurnRow {
+  turnKey: string;
+  chatId: string;
+  startedAt: number;     // ms epoch
+  endedAt: number | null; // ms epoch, or null if the turn is still running
+}
+
+/**
+ * Format a past timestamp as a human-readable "ago" string.
+ *
+ *   <60 s  → "<1m ago"
+ *   60 s..59 min → "Nm ago"
+ *   60 min..23 h → "Nh ago"
+ *   >=24 h → "Nd ago"
+ */
+function formatAgo(ts: number, now: number): string {
+  const diffMs = now - ts;
+  const diffSec = diffMs / 1000;
+  if (diffSec < 60) return "<1m ago";
+  const diffMin = Math.floor(diffMs / 60_000);
+  if (diffMin < 60) return `${diffMin}m ago`;
+  const diffHr = Math.floor(diffMs / 3_600_000);
+  if (diffHr < 24) return `${diffHr}h ago`;
+  const diffDay = Math.floor(diffMs / 86_400_000);
+  return `${diffDay}d ago`;
+}
+
+/**
+ * Format an array of turn rows into a footer string for the agent's topic.
+ *
+ * States:
+ * - No rows            → "🟡 quiet · no turns yet"
+ * - Latest turn running → "⚙️ working since <Nm ago>"  (uses startedAt)
+ * - Latest turn ended  → "🟢 idle · last reply <Nm ago>" (uses endedAt)
+ */
+export function formatIdleFooter(rows: ReadonlyArray<TurnRow>, now: number): string {
+  if (rows.length === 0) {
+    return "🟡 quiet · no turns yet";
+  }
+
+  // Pick most recent by MAX(startedAt).
+  const latest = rows.reduce((best, row) => (row.startedAt > best.startedAt ? row : best));
+
+  if (latest.endedAt == null) {
+    return `⚙️ working since ${formatAgo(latest.startedAt, now)}`;
+  }
+
+  return `🟢 idle · last reply ${formatAgo(latest.endedAt, now)}`;
+}

--- a/telegram-plugin/tests/idle-footer.test.ts
+++ b/telegram-plugin/tests/idle-footer.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from "vitest";
+import { formatIdleFooter, type TurnRow } from "../idle-footer";
+
+// Fixed "now" anchor for all tests: 2026-01-01T00:00:00Z
+const NOW = 1_751_328_000_000;
+
+function row(overrides: Partial<TurnRow> & { startedAt: number }): TurnRow {
+  return {
+    turnKey: "t1",
+    chatId: "100",
+    endedAt: null,
+    ...overrides,
+  };
+}
+
+describe("formatIdleFooter", () => {
+  it("empty rows → quiet", () => {
+    expect(formatIdleFooter([], NOW)).toBe("🟡 quiet · no turns yet");
+  });
+
+  it("single old turn ended 1h ago → idle 1h ago", () => {
+    const r = row({ startedAt: NOW - 70 * 60_000, endedAt: NOW - 60 * 60_000 });
+    expect(formatIdleFooter([r], NOW)).toBe("🟢 idle · last reply 1h ago");
+  });
+
+  it("single turn ended 3m ago → idle 3m ago", () => {
+    const r = row({ startedAt: NOW - 5 * 60_000, endedAt: NOW - 3 * 60_000 });
+    expect(formatIdleFooter([r], NOW)).toBe("🟢 idle · last reply 3m ago");
+  });
+
+  it("single turn ended 10s ago → idle <1m ago", () => {
+    const r = row({ startedAt: NOW - 30_000, endedAt: NOW - 10_000 });
+    expect(formatIdleFooter([r], NOW)).toBe("🟢 idle · last reply <1m ago");
+  });
+
+  it("currently running turn started 2m ago → working since 2m ago", () => {
+    const r = row({ startedAt: NOW - 2 * 60_000 });
+    expect(formatIdleFooter([r], NOW)).toBe("⚙️ working since 2m ago");
+  });
+
+  it("multiple turns, most recent is running → working since recent", () => {
+    const old = row({ turnKey: "t1", startedAt: NOW - 10 * 60_000, endedAt: NOW - 8 * 60_000 });
+    const running = row({ turnKey: "t2", startedAt: NOW - 90_000 }); // 1m 30s ago
+    expect(formatIdleFooter([old, running], NOW)).toBe("⚙️ working since 1m ago");
+  });
+
+  it("multiple turns, most recent is ended → idle last reply", () => {
+    const old = row({ turnKey: "t1", startedAt: NOW - 30 * 60_000, endedAt: NOW - 28 * 60_000 });
+    const recent = row({ turnKey: "t2", startedAt: NOW - 6 * 60_000, endedAt: NOW - 4 * 60_000 });
+    expect(formatIdleFooter([old, recent], NOW)).toBe("🟢 idle · last reply 4m ago");
+  });
+
+  it("day-old turn → 1d ago", () => {
+    const r = row({ startedAt: NOW - 26 * 3_600_000, endedAt: NOW - 25 * 3_600_000 });
+    expect(formatIdleFooter([r], NOW)).toBe("🟢 idle · last reply 1d ago");
+  });
+
+  it("unsorted rows — picks max startedAt", () => {
+    // rows in reverse chronological order; function must not assume sorted
+    const r1 = row({ turnKey: "t1", startedAt: NOW - 20 * 60_000, endedAt: NOW - 18 * 60_000 });
+    const r2 = row({ turnKey: "t2", startedAt: NOW - 5 * 60_000, endedAt: NOW - 2 * 60_000 });
+    const r3 = row({ turnKey: "t3", startedAt: NOW - 40 * 60_000, endedAt: NOW - 38 * 60_000 });
+    // r2 has the largest startedAt, endedAt is 2m ago
+    expect(formatIdleFooter([r1, r2, r3], NOW)).toBe("🟢 idle · last reply 2m ago");
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `telegram-plugin/idle-footer.ts` — a pure `formatIdleFooter(rows, now)` function with no DB/IO/time-source coupling
- Implements all three footer states: `🟡 quiet · no turns yet`, `⚙️ working since Nm ago`, `🟢 idle · last reply Nm ago`
- Time-ago formatter handles sub-minute, minutes, hours, and days

Phase 2 of #332 — pure function, no surface wiring. Phase 3 (wire to topic message) ships after the turns writer (Phase 1) lands.

## Test plan

- [ ] `bun run test:vitest --run` passes (9 new assertions in `telegram-plugin/tests/idle-footer.test.ts`)
- [ ] `bun run lint` passes clean (tsc --noEmit)
- [ ] Empty rows → `🟡 quiet · no turns yet`
- [ ] Single old turn (1h ago, ended) → `🟢 idle · last reply 1h ago`
- [ ] Single recent turn (3m ago, ended) → `🟢 idle · last reply 3m ago`
- [ ] Single very recent turn (10s ago, ended) → `🟢 idle · last reply <1m ago`
- [ ] Currently running turn (started 2m ago, no endedAt) → `⚙️ working since 2m ago`
- [ ] Multiple turns, most recent is running → working state
- [ ] Multiple turns, most recent is ended → idle state
- [ ] Day-old turn → `1d ago`
- [ ] Unsorted input rows → picks correct MAX(startedAt)

🤖 Generated with [Claude Code](https://claude.com/claude-code)