### PR TITLE
feat(subagents): Agent tool hooks populate registry rows

### DIFF
--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -1475,9 +1475,12 @@ export function scaffoldAgent(
       const switchroomStop = switchroomStopHooks.length > 0
         ? [{ hooks: switchroomStopHooks }]
         : [];
-      // Switchroom-owned PreToolUse hook: blocks any tool call whose input
-      // contains a currently-active vault value verbatim (second-line
-      // defense against secrets leaking past the ingest-side detector).
+      // Switchroom-owned PreToolUse hooks:
+      //   1. secret-guard: blocks any tool call whose input contains a
+      //      currently-active vault value verbatim (second-line defense against
+      //      secrets leaking past the ingest-side detector).
+      //   2. subagent-tracker: writes a 'running' row to the subagents table
+      //      whenever an Agent() tool call is about to fire (Phase 2 of #333).
       // Same plugin gating as the Stop hook.
       const switchroomPreToolUse = useSwitchroomPluginHook
         ? [
@@ -1486,6 +1489,30 @@ export function scaffoldAgent(
                 {
                   type: "command",
                   command: `node "${join(REPO_ROOT, "telegram-plugin", "hooks", "secret-guard-pretool.mjs")}"`,
+                  timeout: 10,
+                },
+              ],
+            },
+            {
+              hooks: [
+                {
+                  type: "command",
+                  command: `node "${join(REPO_ROOT, "telegram-plugin", "hooks", "subagent-tracker-pretool.mjs")}"`,
+                  timeout: 10,
+                },
+              ],
+            },
+          ]
+        : [];
+      // Switchroom-owned PostToolUse hook: updates the subagents row to
+      // 'completed' or 'failed' once an Agent() call returns.
+      const switchroomPostToolUse = useSwitchroomPluginHook
+        ? [
+            {
+              hooks: [
+                {
+                  type: "command",
+                  command: `node "${join(REPO_ROOT, "telegram-plugin", "hooks", "subagent-tracker-posttool.mjs")}"`,
                   timeout: 10,
                 },
               ],
@@ -1555,6 +1582,14 @@ export function scaffoldAgent(
                 ],
               }
             : {}),
+          ...(switchroomPostToolUse.length > 0
+            ? {
+                PostToolUse: [
+                  ...((userHooks.PostToolUse as unknown[]) ?? []),
+                  ...switchroomPostToolUse,
+                ],
+              }
+            : {}),
           ...(switchroomStop.length > 0
             ? {
                 Stop: [
@@ -1568,6 +1603,7 @@ export function scaffoldAgent(
         settings.hooks = {
           UserPromptSubmit: switchroomUserPromptSubmit,
           ...(switchroomPreToolUse.length > 0 ? { PreToolUse: switchroomPreToolUse } : {}),
+          ...(switchroomPostToolUse.length > 0 ? { PostToolUse: switchroomPostToolUse } : {}),
           ...(switchroomStop.length > 0 ? { Stop: switchroomStop } : {}),
         };
       }
@@ -2500,7 +2536,9 @@ Don't wait for a slash command. Don't ask permission. Memory work is table stake
     const switchroomStop = switchroomStopHooksReconcile.length > 0
       ? [{ hooks: switchroomStopHooksReconcile }]
       : [];
-    // Switchroom-owned PreToolUse hook: secret-guard (same as scaffoldAgent).
+    // Switchroom-owned PreToolUse hooks (same as scaffoldAgent — keep in sync):
+    //   1. secret-guard
+    //   2. subagent-tracker (Phase 2 of #333)
     const switchroomPreToolUse = useSwitchroomPluginReconcile
       ? [
           {
@@ -2508,6 +2546,29 @@ Don't wait for a slash command. Don't ask permission. Memory work is table stake
               {
                 type: "command",
                 command: `node "${join(REPO_ROOT, "telegram-plugin", "hooks", "secret-guard-pretool.mjs")}"`,
+                timeout: 10,
+              },
+            ],
+          },
+          {
+            hooks: [
+              {
+                type: "command",
+                command: `node "${join(REPO_ROOT, "telegram-plugin", "hooks", "subagent-tracker-pretool.mjs")}"`,
+                timeout: 10,
+              },
+            ],
+          },
+        ]
+      : [];
+    // Switchroom-owned PostToolUse hook (same as scaffoldAgent — keep in sync).
+    const switchroomPostToolUse = useSwitchroomPluginReconcile
+      ? [
+          {
+            hooks: [
+              {
+                type: "command",
+                command: `node "${join(REPO_ROOT, "telegram-plugin", "hooks", "subagent-tracker-posttool.mjs")}"`,
                 timeout: 10,
               },
             ],
@@ -2565,6 +2626,14 @@ Don't wait for a slash command. Don't ask permission. Memory work is table stake
               ],
             }
           : {}),
+        ...(switchroomPostToolUse.length > 0
+          ? {
+              PostToolUse: [
+                ...((userHooks.PostToolUse as unknown[]) ?? []),
+                ...switchroomPostToolUse,
+              ],
+            }
+          : {}),
         ...(switchroomStop.length > 0
           ? {
               Stop: [
@@ -2578,6 +2647,7 @@ Don't wait for a slash command. Don't ask permission. Memory work is table stake
       settings.hooks = {
         UserPromptSubmit: switchroomUserPromptSubmit,
         ...(switchroomPreToolUse.length > 0 ? { PreToolUse: switchroomPreToolUse } : {}),
+        ...(switchroomPostToolUse.length > 0 ? { PostToolUse: switchroomPostToolUse } : {}),
         ...(switchroomStop.length > 0 ? { Stop: switchroomStop } : {}),
       };
     }

--- a/telegram-plugin/hooks/subagent-tracker-posttool.mjs
+++ b/telegram-plugin/hooks/subagent-tracker-posttool.mjs
@@ -1,0 +1,148 @@
+#!/usr/bin/env node
+/**
+ * PostToolUse hook — marks subagent rows completed or failed in the registry DB.
+ *
+ * Claude Code PostToolUse protocol (v1):
+ *   Input:  JSON on stdin — { tool_name, tool_use_id, tool_response, ... }
+ *   Output: exit 0 (we never block here).
+ *
+ * Gates to tool_name === 'Agent'; exits 0 immediately for everything else.
+ * DB writes are fire-and-forget: failures are logged to stderr but never
+ * block the tool response.
+ *
+ * DB location: <agentDir>/telegram/registry.db
+ *   agentDir = SWITCHROOM_AGENT_DIR env var, falling back to process.cwd()
+ */
+
+import { readFileSync, existsSync } from 'node:fs'
+import { join } from 'node:path'
+import { execFileSync } from 'node:child_process'
+import { createRequire } from 'node:module'
+
+const require = createRequire(import.meta.url)
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function readStdin() {
+  try {
+    return readFileSync(0, 'utf8')
+  } catch {
+    return ''
+  }
+}
+
+function sqlLiteral(v) {
+  if (v === null || v === undefined) return 'NULL'
+  if (typeof v === 'number') return String(v)
+  return "'" + String(v).replace(/'/g, "''") + "'"
+}
+
+function fillPlaceholders(sql, params) {
+  let i = 0
+  return sql.replace(/\?/g, () => sqlLiteral(params[i++]))
+}
+
+function execSql(dbPath, sql) {
+  execFileSync('sqlite3', [dbPath, sql], { timeout: 5000 })
+}
+
+// ---------------------------------------------------------------------------
+// Status detection
+// ---------------------------------------------------------------------------
+
+function detectStatus(toolResponse) {
+  if (!toolResponse) return 'completed'
+  if (toolResponse.is_error === true) return 'failed'
+  if (toolResponse.error != null) return 'failed'
+  // Claude Code wraps sub-agent output in { type: 'text', text: '...' } arrays;
+  // a top-level "error" key or is_error flag means the tool itself failed.
+  return 'completed'
+}
+
+function extractResultSummary(toolResponse) {
+  if (!toolResponse) return null
+  // tool_response.result is the canonical field for PostToolUse
+  const raw =
+    toolResponse.result ??
+    toolResponse.output ??
+    (typeof toolResponse === 'string' ? toolResponse : null)
+  if (raw == null) return null
+  const str = typeof raw === 'string' ? raw : JSON.stringify(raw)
+  return str.slice(0, 200) || null
+}
+
+// ---------------------------------------------------------------------------
+// DB write
+// ---------------------------------------------------------------------------
+
+function updateRow(dbPath, { id, status, resultSummary, now }) {
+  const UPDATE_SQL = `
+    UPDATE subagents
+    SET ended_at = ?, status = ?, result_summary = COALESCE(?, result_summary), last_activity_at = ?
+    WHERE id = ?
+      AND status NOT IN ('completed', 'failed')
+  `
+  const params = [now, status, resultSummary, now, id]
+
+  const [major] = process.versions.node.split('.').map(Number)
+  if (major >= 22) {
+    try {
+      const { DatabaseSync } = require('node:sqlite')
+      const db = new DatabaseSync(dbPath)
+      db.prepare(UPDATE_SQL).run(...params)
+      db.close()
+      return
+    } catch {
+      // Fall through to sqlite3 CLI
+    }
+  }
+
+  // sqlite3 CLI fallback
+  execSql(dbPath, fillPlaceholders(UPDATE_SQL.trim(), params))
+}
+
+// ---------------------------------------------------------------------------
+// main
+// ---------------------------------------------------------------------------
+
+function main() {
+  const raw = readStdin().trim()
+  if (!raw) process.exit(0)
+
+  let event
+  try {
+    event = JSON.parse(raw)
+  } catch {
+    process.exit(0)
+  }
+
+  // Only care about Agent tool calls
+  if (event.tool_name !== 'Agent') process.exit(0)
+
+  const id = event.tool_use_id ?? null
+  if (!id) process.exit(0)
+
+  const agentDir = process.env.SWITCHROOM_AGENT_DIR ?? process.cwd()
+  const dbPath = join(agentDir, 'telegram', 'registry.db')
+
+  // If DB doesn't exist yet, nothing to update
+  if (!existsSync(dbPath)) process.exit(0)
+
+  try {
+    const toolResponse = event.tool_response ?? null
+    updateRow(dbPath, {
+      id,
+      status: detectStatus(toolResponse),
+      resultSummary: extractResultSummary(toolResponse),
+      now: Date.now(),
+    })
+  } catch (err) {
+    process.stderr.write(`[subagent-tracker-posttool] DB error: ${err?.message ?? err}\n`)
+  }
+
+  process.exit(0)
+}
+
+main()

--- a/telegram-plugin/hooks/subagent-tracker-pretool.mjs
+++ b/telegram-plugin/hooks/subagent-tracker-pretool.mjs
@@ -1,0 +1,152 @@
+#!/usr/bin/env node
+/**
+ * PreToolUse hook — records subagent dispatches in the registry DB.
+ *
+ * Claude Code PreToolUse protocol (v1):
+ *   Input:  JSON on stdin — { session_id, tool_name, tool_input, tool_use_id, ... }
+ *   Output: exit 0 + empty stdout → allow (we never block here).
+ *
+ * Gates to tool_name === 'Agent'; exits 0 immediately for everything else.
+ * DB writes are fire-and-forget: failures are logged to stderr but never
+ * block the tool call.
+ *
+ * DB location: <agentDir>/telegram/registry.db
+ *   agentDir = SWITCHROOM_AGENT_DIR env var, falling back to process.cwd()
+ */
+
+import { readFileSync, mkdirSync, existsSync } from 'node:fs'
+import { join } from 'node:path'
+import { execFileSync } from 'node:child_process'
+import { createRequire } from 'node:module'
+
+const require = createRequire(import.meta.url)
+
+// ---------------------------------------------------------------------------
+// Schema SQL (mirrors subagents-schema.ts)
+// ---------------------------------------------------------------------------
+
+const SCHEMA_SQL = `
+  CREATE TABLE IF NOT EXISTS subagents (
+    id                TEXT    PRIMARY KEY,
+    parent_session_id TEXT,
+    parent_turn_key   TEXT,
+    agent_type        TEXT,
+    description       TEXT,
+    background        INTEGER NOT NULL,
+    started_at        INTEGER NOT NULL,
+    last_activity_at  INTEGER,
+    ended_at          INTEGER,
+    status            TEXT    NOT NULL,
+    result_summary    TEXT
+  );
+  CREATE INDEX IF NOT EXISTS subagents_turn   ON subagents(parent_turn_key);
+  CREATE INDEX IF NOT EXISTS subagents_status ON subagents(status);
+`
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function readStdin() {
+  try {
+    return readFileSync(0, 'utf8')
+  } catch {
+    return ''
+  }
+}
+
+/**
+ * Escape a value for inline SQLite SQL (used only in CLI fallback).
+ */
+function sqlLiteral(v) {
+  if (v === null || v === undefined) return 'NULL'
+  if (typeof v === 'number') return String(v)
+  return "'" + String(v).replace(/'/g, "''") + "'"
+}
+
+function fillPlaceholders(sql, params) {
+  let i = 0
+  return sql.replace(/\?/g, () => sqlLiteral(params[i++]))
+}
+
+function execSql(dbPath, sql) {
+  execFileSync('sqlite3', [dbPath, sql], { timeout: 5000 })
+}
+
+// ---------------------------------------------------------------------------
+// DB write
+// ---------------------------------------------------------------------------
+
+function writeRow(dbPath, { id, parentSessionId, agentType, description, background, now }) {
+  const INSERT_SQL = `
+    INSERT OR IGNORE INTO subagents
+      (id, parent_session_id, parent_turn_key, agent_type, description,
+       background, started_at, last_activity_at, status)
+    VALUES (?, ?, NULL, ?, ?, ?, ?, ?, 'running')
+  `
+  const params = [id, parentSessionId, agentType, description, background, now, now]
+
+  // Try Node 22+ built-in sqlite first (synchronous API)
+  const [major] = process.versions.node.split('.').map(Number)
+  if (major >= 22) {
+    try {
+      const { DatabaseSync } = require('node:sqlite')
+      const db = new DatabaseSync(dbPath)
+      db.exec(SCHEMA_SQL)
+      db.prepare(INSERT_SQL).run(...params)
+      db.close()
+      return
+    } catch {
+      // Fall through to sqlite3 CLI
+    }
+  }
+
+  // sqlite3 CLI fallback
+  execSql(dbPath, SCHEMA_SQL.replace(/\n\s+/g, ' '))
+  execSql(dbPath, fillPlaceholders(INSERT_SQL.trim(), params))
+}
+
+// ---------------------------------------------------------------------------
+// main
+// ---------------------------------------------------------------------------
+
+function main() {
+  const raw = readStdin().trim()
+  if (!raw) process.exit(0)
+
+  let event
+  try {
+    event = JSON.parse(raw)
+  } catch {
+    process.exit(0)
+  }
+
+  // Only care about Agent tool calls
+  if (event.tool_name !== 'Agent') process.exit(0)
+
+  const agentDir = process.env.SWITCHROOM_AGENT_DIR ?? process.cwd()
+  const telegramDir = join(agentDir, 'telegram')
+  const dbPath = join(telegramDir, 'registry.db')
+
+  try {
+    if (!existsSync(telegramDir)) {
+      mkdirSync(telegramDir, { recursive: true })
+    }
+
+    const input = event.tool_input ?? {}
+    writeRow(dbPath, {
+      id: event.tool_use_id ?? null,
+      parentSessionId: event.session_id ?? null,
+      agentType: input.subagent_type ?? null,
+      description: input.description ?? null,
+      background: input.run_in_background === true ? 1 : 0,
+      now: Date.now(),
+    })
+  } catch (err) {
+    process.stderr.write(`[subagent-tracker-pretool] DB error: ${err?.message ?? err}\n`)
+  }
+
+  process.exit(0)
+}
+
+main()

--- a/telegram-plugin/tests/subagent-tracker-hooks.test.ts
+++ b/telegram-plugin/tests/subagent-tracker-hooks.test.ts
@@ -1,0 +1,202 @@
+/**
+ * Integration tests for the subagent-tracker pretool and posttool hooks.
+ *
+ * Each test spawns the hook script as a subprocess (mirroring how Claude Code
+ * executes hooks), feeds a JSON event on stdin, then reads back the DB to
+ * verify the correct row was written / updated.
+ *
+ * These tests use bun:test + bun:sqlite and must run under Bun:
+ *   bun test telegram-plugin/tests/subagent-tracker-hooks.test.ts
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test'
+import { mkdtempSync, mkdirSync, rmSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { spawnSync } from 'child_process'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const PRETOOL_SCRIPT = join(import.meta.dir, '..', 'hooks', 'subagent-tracker-pretool.mjs')
+const POSTTOOL_SCRIPT = join(import.meta.dir, '..', 'hooks', 'subagent-tracker-posttool.mjs')
+
+let tempDir: string
+let agentDir: string
+let dbPath: string
+
+beforeEach(() => {
+  tempDir = mkdtempSync(join(tmpdir(), 'subagent-tracker-test-'))
+  agentDir = tempDir
+  mkdirSync(join(agentDir, 'telegram'), { recursive: true })
+  dbPath = join(agentDir, 'telegram', 'registry.db')
+})
+
+afterEach(() => {
+  try { rmSync(tempDir, { recursive: true }) } catch { /* ignore */ }
+})
+
+function runHook(scriptPath: string, event: object, extraEnv: Record<string, string> = {}) {
+  const result = spawnSync('node', [scriptPath], {
+    input: JSON.stringify(event),
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      SWITCHROOM_AGENT_DIR: agentDir,
+      ...extraEnv,
+    },
+    timeout: 15_000,
+  })
+  return result
+}
+
+function openDb() {
+  // bun:sqlite is available at runtime in Bun
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const { Database } = require('bun:sqlite') as { Database: new (path: string) => {
+    prepare(sql: string): { all(...params: unknown[]): unknown[]; get(...params: unknown[]): unknown }
+    exec(sql: string): void
+  } }
+  return new Database(dbPath)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('subagent-tracker-pretool', () => {
+  it('inserts a running row when tool_name is Agent', () => {
+    const event = {
+      session_id: 'sess-abc123',
+      tool_name: 'Agent',
+      tool_use_id: 'toolu_test001',
+      tool_input: {
+        subagent_type: 'worker',
+        description: 'Build the feature',
+        run_in_background: false,
+      },
+    }
+
+    const result = runHook(PRETOOL_SCRIPT, event)
+    expect(result.status).toBe(0)
+
+    const db = openDb()
+    const row = db.prepare('SELECT * FROM subagents WHERE id = ?').get('toolu_test001') as {
+      id: string
+      parent_session_id: string
+      agent_type: string
+      description: string
+      background: number
+      status: string
+      started_at: number
+      last_activity_at: number
+    } | undefined
+
+    expect(row).toBeDefined()
+    expect(row!.id).toBe('toolu_test001')
+    expect(row!.parent_session_id).toBe('sess-abc123')
+    expect(row!.agent_type).toBe('worker')
+    expect(row!.description).toBe('Build the feature')
+    expect(row!.background).toBe(0)
+    expect(row!.status).toBe('running')
+    expect(row!.started_at).toBeGreaterThan(0)
+    expect(row!.last_activity_at).toBe(row!.started_at)
+  })
+
+  it('does not write a row when tool_name is not Agent', () => {
+    const event = {
+      session_id: 'sess-abc123',
+      tool_name: 'Bash',
+      tool_use_id: 'toolu_bash001',
+      tool_input: { command: 'ls' },
+    }
+
+    const result = runHook(PRETOOL_SCRIPT, event)
+    expect(result.status).toBe(0)
+
+    // DB should not exist (or have no subagents table / rows)
+    const dbExists = Bun.file(dbPath).size > 0
+    if (dbExists) {
+      const db = openDb()
+      const rows = db.prepare('SELECT * FROM subagents').all()
+      expect(rows.length).toBe(0)
+    }
+    // If DB doesn't exist that's also fine — no row was written
+  })
+})
+
+describe('subagent-tracker-posttool', () => {
+  it('updates the row to completed with result_summary after pretool + posttool', () => {
+    // First run the pretool to create the row
+    const preEvent = {
+      session_id: 'sess-xyz789',
+      tool_name: 'Agent',
+      tool_use_id: 'toolu_test002',
+      tool_input: {
+        subagent_type: 'researcher',
+        description: 'Research the topic',
+        run_in_background: true,
+      },
+    }
+    const preResult = runHook(PRETOOL_SCRIPT, preEvent)
+    expect(preResult.status).toBe(0)
+
+    // Verify row exists with status=running
+    const db = openDb()
+    const beforeRow = db.prepare('SELECT status FROM subagents WHERE id = ?').get('toolu_test002') as
+      | { status: string }
+      | undefined
+    expect(beforeRow?.status).toBe('running')
+
+    // Now run the posttool
+    const postEvent = {
+      tool_name: 'Agent',
+      tool_use_id: 'toolu_test002',
+      tool_response: {
+        result: 'The research is complete. Found 3 relevant papers.',
+        is_error: false,
+      },
+    }
+    const postResult = runHook(POSTTOOL_SCRIPT, postEvent)
+    expect(postResult.status).toBe(0)
+
+    const afterRow = db.prepare('SELECT * FROM subagents WHERE id = ?').get('toolu_test002') as {
+      status: string
+      ended_at: number
+      result_summary: string
+    } | undefined
+    expect(afterRow).toBeDefined()
+    expect(afterRow!.status).toBe('completed')
+    expect(afterRow!.ended_at).toBeGreaterThan(0)
+    expect(afterRow!.result_summary).toContain('research is complete')
+  })
+
+  it('marks row as failed when is_error is true', () => {
+    // Create the row first
+    const preEvent = {
+      session_id: 'sess-err',
+      tool_name: 'Agent',
+      tool_use_id: 'toolu_fail001',
+      tool_input: { description: 'Failing task' },
+    }
+    runHook(PRETOOL_SCRIPT, preEvent)
+
+    const postEvent = {
+      tool_name: 'Agent',
+      tool_use_id: 'toolu_fail001',
+      tool_response: {
+        is_error: true,
+        result: 'Something went wrong',
+      },
+    }
+    const postResult = runHook(POSTTOOL_SCRIPT, postEvent)
+    expect(postResult.status).toBe(0)
+
+    const db = openDb()
+    const row = db.prepare('SELECT status FROM subagents WHERE id = ?').get('toolu_fail001') as
+      | { status: string }
+      | undefined
+    expect(row?.status).toBe('failed')
+  })
+})


### PR DESCRIPTION
## Summary

- Adds `subagent-tracker-pretool.mjs`: PreToolUse hook that inserts a `status='running'` row into `subagents` table on every `Agent()` tool call, using `INSERT OR IGNORE` for idempotency
- Adds `subagent-tracker-posttool.mjs`: PostToolUse hook that updates the row to `status='completed'` or `'failed'` (via `is_error` detection) and captures the first 200 chars of the result as `result_summary`
- Wires both hooks into `scaffold.ts` for both `scaffoldAgent` and `scaffoldFleet` (reconcile) paths alongside the existing `secret-guard-pretool.mjs`
- Both hooks use Node 22+ `node:sqlite` with `sqlite3` CLI fallback, always exit 0, and swallow DB errors to stderr to never block tool calls

Phase 2 of #333. Pairs with the Phase 3 watcher liveness writes already in main (#341).

## Test plan

- [x] `bun test telegram-plugin/tests/subagent-tracker-hooks.test.ts` — 4 integration tests pass (pretool inserts row, non-Agent tool writes nothing, posttool marks completed, posttool marks failed on is_error)
- [x] `bun test tests/scaffold.test.ts` — 132 existing scaffold tests pass unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)