### PR TITLE
feat(gateway): wire idle/active footer into render path

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -219,7 +219,9 @@ import {
   recordTurnStart,
   recordTurnEnd,
   findMostRecentInterruptedTurn,
+  findRecentTurnsForChat,
 } from '../registry/turns-schema.js'
+import { formatIdleFooter } from '../idle-footer.js'
 
 // ─── Stderr logging ───────────────────────────────────────────────────────
 installPluginLogger()
@@ -6768,6 +6770,28 @@ if (streamMode === 'checklist') {
         lockedBot.api.sendMessage(chatId, `✅ Done — ${summary}`).catch((err: Error) => {
           process.stderr.write(`telegram gateway: completion message failed: ${err.message}\n`)
         })
+      }
+      // Phase 3 of #332: update the progress-card pin with the idle footer so
+      // the user can see at a glance when the agent last replied.
+      if (turnsDb != null) {
+        try {
+          const rows = findRecentTurnsForChat(turnsDb, chatId, 1)
+          const turnRows = rows.map(r => ({
+            turnKey: r.turn_key,
+            chatId: r.chat_id,
+            startedAt: r.started_at,
+            endedAt: r.ended_at,
+          }))
+          const footer = formatIdleFooter(turnRows, Date.now())
+          const pinnedMsgId = pinMgr.pinnedMessageId(turnKey)
+          if (pinnedMsgId != null) {
+            lockedBot.api.editMessageText(chatId, pinnedMsgId, footer, { parse_mode: 'HTML' }).catch((err: Error) => {
+              process.stderr.write(`telegram gateway: idle-footer edit failed chatId=${chatId} msgId=${pinnedMsgId}: ${err.message}\n`)
+            })
+          }
+        } catch (err) {
+          process.stderr.write(`telegram gateway: idle-footer render failed chatId=${chatId}: ${(err as Error).message}\n`)
+        }
       }
     },
     onSilentEnd: ({ chatId, turnKey }) => {

--- a/telegram-plugin/registry/turns-schema.test.ts
+++ b/telegram-plugin/registry/turns-schema.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Unit tests for telegram-plugin/registry/turns-schema.ts
+ *
+ * These tests use bun:sqlite directly and must run under Bun, not vitest/Node.
+ * They are excluded from vitest.config.ts and run via:
+ *   bun test telegram-plugin/registry/turns-schema.test.ts
+ * or as part of the `test:bun` script in the root package.json.
+ *
+ * Test plan:
+ *   1. findRecentTurnsForChat — empty DB returns empty array.
+ *   2. findRecentTurnsForChat — returns only rows for the requested chatId.
+ *   3. findRecentTurnsForChat — orders by started_at DESC.
+ *   4. findRecentTurnsForChat — limit param is respected.
+ *   5. findRecentTurnsForChat — ended_at is preserved correctly (null vs number).
+ */
+
+import { describe, it, expect } from 'bun:test'
+import {
+  openTurnsDbInMemory,
+  recordTurnStart,
+  recordTurnEnd,
+  findRecentTurnsForChat,
+} from './turns-schema.js'
+
+// ---------------------------------------------------------------------------
+// Test 1 — empty DB
+// ---------------------------------------------------------------------------
+
+describe('findRecentTurnsForChat', () => {
+  it('returns empty array when no turns exist for chat', () => {
+    const db = openTurnsDbInMemory()
+    const rows = findRecentTurnsForChat(db, 'chat_999')
+    expect(rows).toEqual([])
+    db.close()
+  })
+
+  // -------------------------------------------------------------------------
+  // Test 2 — cross-chat isolation
+  // -------------------------------------------------------------------------
+
+  it('returns only rows for the requested chatId', () => {
+    const db = openTurnsDbInMemory()
+    recordTurnStart(db, { turnKey: 'turn_a', chatId: 'chat_1' })
+    recordTurnStart(db, { turnKey: 'turn_b', chatId: 'chat_2' })
+    const rows = findRecentTurnsForChat(db, 'chat_1')
+    expect(rows.length).toBe(1)
+    expect(rows[0].turn_key).toBe('turn_a')
+    db.close()
+  })
+
+  // -------------------------------------------------------------------------
+  // Test 3 — DESC ordering
+  // -------------------------------------------------------------------------
+
+  it('orders rows by started_at DESC so newest is first', () => {
+    const db = openTurnsDbInMemory()
+    // Insert two turns; recordTurnStart uses Date.now() so they get distinct
+    // started_at values in insertion order. We insert turn_old first.
+    recordTurnStart(db, { turnKey: 'turn_old', chatId: 'chat_1' })
+    // Force a slightly later timestamp by patching the row directly.
+    recordTurnStart(db, { turnKey: 'turn_new', chatId: 'chat_1' })
+    db.prepare(`UPDATE turns SET started_at = started_at + 1000 WHERE turn_key = 'turn_new'`).run()
+
+    const rows = findRecentTurnsForChat(db, 'chat_1', 2)
+    expect(rows[0].turn_key).toBe('turn_new')
+    expect(rows[1].turn_key).toBe('turn_old')
+    db.close()
+  })
+
+  // -------------------------------------------------------------------------
+  // Test 4 — limit is respected
+  // -------------------------------------------------------------------------
+
+  it('respects the limit parameter', () => {
+    const db = openTurnsDbInMemory()
+    recordTurnStart(db, { turnKey: 'turn_1', chatId: 'chat_x' })
+    recordTurnStart(db, { turnKey: 'turn_2', chatId: 'chat_x' })
+    recordTurnStart(db, { turnKey: 'turn_3', chatId: 'chat_x' })
+    const rows = findRecentTurnsForChat(db, 'chat_x', 2)
+    expect(rows.length).toBe(2)
+    db.close()
+  })
+
+  // -------------------------------------------------------------------------
+  // Test 5 — ended_at preservation
+  // -------------------------------------------------------------------------
+
+  it('returns ended_at as null for running turns and a number for completed turns', () => {
+    const db = openTurnsDbInMemory()
+    recordTurnStart(db, { turnKey: 'turn_running', chatId: 'chat_1' })
+    recordTurnStart(db, { turnKey: 'turn_done', chatId: 'chat_1' })
+    recordTurnEnd(db, { turnKey: 'turn_done', endedVia: 'stop' })
+
+    const rows = findRecentTurnsForChat(db, 'chat_1', 2)
+    const running = rows.find(r => r.turn_key === 'turn_running')
+    const done = rows.find(r => r.turn_key === 'turn_done')
+    expect(running?.ended_at).toBeNull()
+    expect(typeof done?.ended_at).toBe('number')
+    db.close()
+  })
+})

--- a/telegram-plugin/registry/turns-schema.ts
+++ b/telegram-plugin/registry/turns-schema.ts
@@ -351,6 +351,28 @@ export function markOrphanedAsRestarted(db: SqliteDatabase): number {
 }
 
 /**
+ * Return the most recent N turns for `chatId` (any state — running or ended),
+ * ordered by started_at DESC. Used by the idle-footer renderer to decide
+ * whether to render "working since" vs "idle · last reply".
+ *
+ * `limit` defaults to 1 because the renderer only inspects the top row, but
+ * callers can pass more if they need backfill.
+ */
+export function findRecentTurnsForChat(
+  db: SqliteDatabase,
+  chatId: string,
+  limit = 1,
+): Turn[] {
+  const rows = db.prepare(`
+    SELECT * FROM turns
+    WHERE chat_id = ?
+    ORDER BY started_at DESC
+    LIMIT ?
+  `).all(chatId, limit) as RawTurnRow[]
+  return rows.map(mapRow)
+}
+
+/**
  * Find the single most-recently-started turn that ended via an interrupt
  * (`'restart'` | `'sigterm'` | `'timeout'`) OR is still open
  * (`ended_at IS NULL`). Used by Stage 4 to surface "you had pending work"

--- a/telegram-plugin/tests/idle-footer-wiring.test.ts
+++ b/telegram-plugin/tests/idle-footer-wiring.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Integration test for the idle-footer wiring layer.
+ *
+ * Tests the composed pipeline:
+ *   findRecentTurnsForChat → TurnRow mapping → formatIdleFooter
+ *
+ * These must run under Bun (bun:sqlite). Run via:
+ *   bun test telegram-plugin/tests/idle-footer-wiring.test.ts
+ */
+
+import { describe, it, expect } from 'bun:test'
+import {
+  openTurnsDbInMemory,
+  recordTurnStart,
+  recordTurnEnd,
+  findRecentTurnsForChat,
+} from '../registry/turns-schema.js'
+import { formatIdleFooter, type TurnRow } from '../idle-footer.js'
+
+/** Map Turn rows (from findRecentTurnsForChat) into the TurnRow shape that formatIdleFooter expects. */
+function toFooterRows(rows: ReturnType<typeof findRecentTurnsForChat>): TurnRow[] {
+  return rows.map(r => ({
+    turnKey: r.turn_key,
+    chatId: r.chat_id,
+    startedAt: r.started_at,
+    endedAt: r.ended_at,
+  }))
+}
+
+describe('idle-footer wiring pipeline', () => {
+  it('renders "quiet · no turns yet" when the DB has no turns for the chat', () => {
+    const db = openTurnsDbInMemory()
+    const rows = findRecentTurnsForChat(db, 'chat_empty')
+    const footer = formatIdleFooter(toFooterRows(rows), Date.now())
+    expect(footer).toBe('🟡 quiet · no turns yet')
+    db.close()
+  })
+
+  it('renders "working since" when the most recent turn is still running', () => {
+    const db = openTurnsDbInMemory()
+    const startedAt = Date.now() - 3 * 60_000 // 3 minutes ago
+    recordTurnStart(db, { turnKey: 'turn_live', chatId: 'chat_1' })
+    // Backdate started_at so the "ago" formatting is predictable.
+    db.prepare(`UPDATE turns SET started_at = ? WHERE turn_key = 'turn_live'`).run(startedAt)
+
+    const rows = findRecentTurnsForChat(db, 'chat_1', 1)
+    const footer = formatIdleFooter(toFooterRows(rows), Date.now())
+    expect(footer).toContain('⚙️ working since')
+    expect(footer).toContain('3m ago')
+    db.close()
+  })
+
+  it('renders "idle · last reply" when the most recent turn has ended', () => {
+    const db = openTurnsDbInMemory()
+    const endedAt = Date.now() - 12 * 60_000 // 12 minutes ago
+    recordTurnStart(db, { turnKey: 'turn_past', chatId: 'chat_2' })
+    recordTurnEnd(db, { turnKey: 'turn_past', endedVia: 'stop' })
+    // Backdate ended_at so the "ago" formatting is predictable.
+    db.prepare(`UPDATE turns SET ended_at = ? WHERE turn_key = 'turn_past'`).run(endedAt)
+
+    const rows = findRecentTurnsForChat(db, 'chat_2', 1)
+    const footer = formatIdleFooter(toFooterRows(rows), Date.now())
+    expect(footer).toContain('🟢 idle · last reply')
+    expect(footer).toContain('12m ago')
+    db.close()
+  })
+
+  it('uses the most recently STARTED turn (not most recently ended)', () => {
+    const db = openTurnsDbInMemory()
+    const now = Date.now()
+
+    // turn_a: started earlier, ended later
+    recordTurnStart(db, { turnKey: 'turn_a', chatId: 'chat_3' })
+    db.prepare(`UPDATE turns SET started_at = ? WHERE turn_key = 'turn_a'`).run(now - 20 * 60_000)
+    recordTurnEnd(db, { turnKey: 'turn_a', endedVia: 'stop' })
+    db.prepare(`UPDATE turns SET ended_at = ? WHERE turn_key = 'turn_a'`).run(now - 1 * 60_000)
+
+    // turn_b: started more recently, still running
+    recordTurnStart(db, { turnKey: 'turn_b', chatId: 'chat_3' })
+    db.prepare(`UPDATE turns SET started_at = ? WHERE turn_key = 'turn_b'`).run(now - 5 * 60_000)
+
+    const rows = findRecentTurnsForChat(db, 'chat_3', 2)
+    const footer = formatIdleFooter(toFooterRows(rows), now)
+    // turn_b has the larger started_at; its ended_at is null → "working since"
+    expect(footer).toContain('⚙️ working since')
+    db.close()
+  })
+})


### PR DESCRIPTION
## Summary

- Adds `findRecentTurnsForChat(db, chatId, limit)` helper to `turns-schema.ts` — mirrors style of `findOrphanedTurns`, returns rows ordered `started_at DESC`
- Imports `formatIdleFooter` and `findRecentTurnsForChat` in `gateway.ts`
- Wires idle-footer render into `onTurnComplete` callback: after every clean turn-end, queries the most recent turn row and edits the pinned progress-card message to show `🟢 idle · last reply Nm ago` (or `⚙️ working since` if somehow still running)
- Adds 5 unit tests for `findRecentTurnsForChat` in `telegram-plugin/registry/turns-schema.test.ts`
- Adds 4 integration tests for the full `findRecentTurnsForChat → TurnRow mapping → formatIdleFooter` pipeline in `telegram-plugin/tests/idle-footer-wiring.test.ts`

## Test plan

- [ ] `bun test telegram-plugin/registry/turns-schema.test.ts` — 5 tests pass
- [ ] `bun test telegram-plugin/tests/idle-footer-wiring.test.ts` — 4 tests pass
- [ ] Full `bun test` — no regressions vs baseline (78 pre-existing failures, same as before this PR)

Note: gateway integration is not directly unit-tested (the driver's `onTurnComplete` callback wires into a live Grammy bot); covered instead via the helper-layer integration tests above.

Closes #332.

🤖 Generated with [Claude Code](https://claude.com/claude-code)