### PR TITLE
feat(api): /api/agents/:name/{turns,subagents} routes

### DIFF
--- a/src/web/api.ts
+++ b/src/web/api.ts
@@ -1,4 +1,5 @@
 import { execFileSync } from "node:child_process";
+import { resolve } from "node:path";
 import type { SwitchroomConfig } from "../config/schema.js";
 import {
   getAllAgentStatuses,
@@ -9,6 +10,9 @@ import {
 import { getAllAuthStatuses } from "../auth/manager.js";
 import { getCollectionForAgent } from "../memory/hindsight.js";
 import { captureEvent, captureException } from "../analytics/posthog.js";
+import { resolveAgentsDir } from "../config/loader.js";
+import { openTurnsDb, listTurnsForAgent, type Turn } from "../../telegram-plugin/registry/turns-schema.js";
+import { applySubagentsSchema, listSubagents, type Subagent } from "../../telegram-plugin/registry/subagents-schema.js";
 
 export interface AgentInfo {
   name: string;
@@ -102,6 +106,53 @@ export function handleGetLogs(
       { encoding: "utf-8", timeout: 5000 }
     );
     return { ok: true, logs: output };
+  } catch (err) {
+    return {
+      ok: false,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+export function handleGetTurns(
+  config: SwitchroomConfig,
+  agentName: string,
+  limit: number,
+): { ok: boolean; turns?: Turn[]; error?: string } {
+  try {
+    const agentsDir = resolveAgentsDir(config);
+    const agentDir = resolve(agentsDir, agentName);
+    const db = openTurnsDb(agentDir);
+    try {
+      const turns = listTurnsForAgent(db, { limit });
+      return { ok: true, turns };
+    } finally {
+      db.close();
+    }
+  } catch (err) {
+    return {
+      ok: false,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+export function handleGetSubagents(
+  config: SwitchroomConfig,
+  agentName: string,
+  status: string | undefined,
+): { ok: boolean; subagents?: Subagent[]; error?: string } {
+  try {
+    const agentsDir = resolveAgentsDir(config);
+    const agentDir = resolve(agentsDir, agentName);
+    const db = openTurnsDb(agentDir);
+    try {
+      applySubagentsSchema(db);
+      const subagents = listSubagents(db, { status });
+      return { ok: true, subagents };
+    } finally {
+      db.close();
+    }
   } catch (err) {
     return {
       ok: false,

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -19,6 +19,8 @@ import {
   handleStopAgent,
   handleRestartAgent,
   handleGetLogs,
+  handleGetTurns,
+  handleGetSubagents,
 } from "./api.js";
 
 const MIME_TYPES: Record<string, string> = {
@@ -238,6 +240,18 @@ function parseRoute(
     return { handler: "restartAgent", params: { name: restartMatch[1] } };
   }
 
+  // GET /api/agents/:name/turns
+  const turnsMatch = pathname.match(/^\/api\/agents\/([^/]+)\/turns$/);
+  if (method === "GET" && turnsMatch) {
+    return { handler: "getTurns", params: { name: turnsMatch[1] } };
+  }
+
+  // GET /api/agents/:name/subagents
+  const subagentsMatch = pathname.match(/^\/api\/agents\/([^/]+)\/subagents$/);
+  if (method === "GET" && subagentsMatch) {
+    return { handler: "getSubagents", params: { name: subagentsMatch[1] } };
+  }
+
   return null;
 }
 
@@ -341,6 +355,36 @@ export function startWebServer(
               return jsonResponse({ ok: false, error: `Unknown agent: ${agentName}` }, 404);
             }
             return jsonResponse(handleRestartAgent(agentName));
+          }
+
+          case "getTurns": {
+            const agentName = route.params.name;
+            if (!config.agents[agentName]) {
+              return jsonResponse({ ok: false, error: `Unknown agent: ${agentName}` }, 404);
+            }
+            const rawLimit = Number(url.searchParams.get("limit") ?? "20");
+            const limit =
+              Number.isInteger(rawLimit) && rawLimit >= 1 && rawLimit <= 200
+                ? rawLimit
+                : 20;
+            const result = handleGetTurns(config, agentName, limit);
+            if (!result.ok) {
+              return jsonResponse({ ok: false, error: result.error }, 500);
+            }
+            return jsonResponse(result.turns);
+          }
+
+          case "getSubagents": {
+            const agentName = route.params.name;
+            if (!config.agents[agentName]) {
+              return jsonResponse({ ok: false, error: `Unknown agent: ${agentName}` }, 404);
+            }
+            const status = url.searchParams.get("status") ?? undefined;
+            const result = handleGetSubagents(config, agentName, status);
+            if (!result.ok) {
+              return jsonResponse({ ok: false, error: result.error }, 500);
+            }
+            return jsonResponse(result.subagents);
           }
         }
       }

--- a/telegram-plugin/registry/api-registry.test.ts
+++ b/telegram-plugin/registry/api-registry.test.ts
@@ -1,0 +1,201 @@
+/**
+ * Tests for listTurnsForAgent and listSubagents helpers.
+ *
+ * These tests use bun:sqlite directly and must run under Bun, not vitest/Node.
+ * Run via:
+ *   bun test telegram-plugin/registry/api-registry.test.ts
+ *
+ * Route-level testing is omitted here because the web server requires a full
+ * Bun.serve context and a SwitchroomConfig fixture that resolves to real
+ * filesystem paths. The helpers tested here are the core logic; the route
+ * wiring is thin and covered by the pattern match in server.ts.
+ */
+
+import { describe, it, expect } from 'bun:test'
+import {
+  openTurnsDbInMemory,
+  recordTurnStart,
+  recordTurnEnd,
+  listTurnsForAgent,
+} from './turns-schema.js'
+import {
+  openFreshSubagentsDbInMemory,
+  recordSubagentStart,
+  listSubagents,
+} from './subagents-schema.js'
+
+// ---------------------------------------------------------------------------
+// listTurnsForAgent
+// ---------------------------------------------------------------------------
+
+describe('listTurnsForAgent', () => {
+  it('returns empty array when no turns exist', () => {
+    const db = openTurnsDbInMemory()
+    const rows = listTurnsForAgent(db)
+    expect(rows).toEqual([])
+    db.close()
+  })
+
+  it('returns rows in JSON shape matching the Turn interface', () => {
+    const db = openTurnsDbInMemory()
+    recordTurnStart(db, {
+      turnKey: 'chat1:1',
+      chatId: 'chat1',
+      lastUserMsgId: 'msg_1',
+      userPromptPreview: 'hello',
+    })
+    const rows = listTurnsForAgent(db, { limit: 20 })
+    expect(rows.length).toBe(1)
+    const row = rows[0]
+    // Verify key fields of the Turn interface are present
+    expect(row.turn_key).toBe('chat1:1')
+    expect(row.chat_id).toBe('chat1')
+    expect(row.last_user_msg_id).toBe('msg_1')
+    expect(row.user_prompt_preview).toBe('hello')
+    expect(typeof row.started_at).toBe('number')
+    expect(row.ended_at).toBeNull()
+    db.close()
+  })
+
+  it('orders results by started_at DESC (newest first)', () => {
+    const db = openTurnsDbInMemory()
+    recordTurnStart(db, { turnKey: 'turn_old', chatId: 'chat1' })
+    recordTurnStart(db, { turnKey: 'turn_new', chatId: 'chat1' })
+    db.prepare(`UPDATE turns SET started_at = started_at + 1000 WHERE turn_key = 'turn_new'`).run()
+
+    const rows = listTurnsForAgent(db, { limit: 20 })
+    expect(rows[0].turn_key).toBe('turn_new')
+    expect(rows[1].turn_key).toBe('turn_old')
+    db.close()
+  })
+
+  it('respects the limit parameter', () => {
+    const db = openTurnsDbInMemory()
+    for (let i = 0; i < 5; i++) {
+      recordTurnStart(db, { turnKey: `turn_${i}`, chatId: 'chat1' })
+    }
+    const rows = listTurnsForAgent(db, { limit: 3 })
+    expect(rows.length).toBe(3)
+    db.close()
+  })
+
+  it('defaults limit to 20', () => {
+    const db = openTurnsDbInMemory()
+    for (let i = 0; i < 25; i++) {
+      recordTurnStart(db, { turnKey: `turn_${i}`, chatId: 'chat1' })
+    }
+    const rows = listTurnsForAgent(db)
+    expect(rows.length).toBe(20)
+    db.close()
+  })
+
+  it('caps limit at 200', () => {
+    const db = openTurnsDbInMemory()
+    for (let i = 0; i < 10; i++) {
+      recordTurnStart(db, { turnKey: `turn_${i}`, chatId: 'chat1' })
+    }
+    // Passing 9999 should be silently capped — only 10 rows exist so result is 10
+    const rows = listTurnsForAgent(db, { limit: 9999 })
+    expect(rows.length).toBe(10)
+    db.close()
+  })
+
+  it('returns turns across multiple chats', () => {
+    const db = openTurnsDbInMemory()
+    recordTurnStart(db, { turnKey: 'chatA:1', chatId: 'chatA' })
+    recordTurnStart(db, { turnKey: 'chatB:1', chatId: 'chatB' })
+    const rows = listTurnsForAgent(db, { limit: 20 })
+    expect(rows.length).toBe(2)
+    db.close()
+  })
+
+  it('returns ended_at as null for open turns and number for closed', () => {
+    const db = openTurnsDbInMemory()
+    recordTurnStart(db, { turnKey: 'open', chatId: 'chat1' })
+    recordTurnStart(db, { turnKey: 'closed', chatId: 'chat1' })
+    recordTurnEnd(db, { turnKey: 'closed', endedVia: 'stop' })
+    const rows = listTurnsForAgent(db, { limit: 20 })
+    const open = rows.find(r => r.turn_key === 'open')
+    const closed = rows.find(r => r.turn_key === 'closed')
+    expect(open?.ended_at).toBeNull()
+    expect(typeof closed?.ended_at).toBe('number')
+    db.close()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// listSubagents
+// ---------------------------------------------------------------------------
+
+describe('listSubagents', () => {
+  it('returns empty array when no subagents exist', () => {
+    const db = openFreshSubagentsDbInMemory()
+    const rows = listSubagents(db)
+    expect(rows).toEqual([])
+    db.close()
+  })
+
+  it('returns all subagents when no status filter is given', () => {
+    const db = openFreshSubagentsDbInMemory()
+    recordSubagentStart(db, { id: 'sa-1', background: false, startedAt: 1000 })
+    recordSubagentStart(db, { id: 'sa-2', background: false, startedAt: 2000 })
+    const rows = listSubagents(db)
+    expect(rows.length).toBe(2)
+    db.close()
+  })
+
+  it('filters by status=running', () => {
+    const db = openFreshSubagentsDbInMemory()
+    recordSubagentStart(db, { id: 'sa-running', background: false, startedAt: 1000 })
+    recordSubagentStart(db, { id: 'sa-done', background: false, startedAt: 2000 })
+    db.prepare(`UPDATE subagents SET status = 'completed', ended_at = 3000 WHERE id = 'sa-done'`).run()
+
+    const rows = listSubagents(db, { status: 'running' })
+    expect(rows.length).toBe(1)
+    expect(rows[0].id).toBe('sa-running')
+    expect(rows[0].status).toBe('running')
+    db.close()
+  })
+
+  it('returns rows in JSON shape matching the Subagent interface', () => {
+    const db = openFreshSubagentsDbInMemory()
+    recordSubagentStart(db, {
+      id: 'sa-shape',
+      parentTurnKey: 'chat1:1',
+      agentType: 'worker',
+      description: 'do work',
+      background: true,
+      startedAt: 5000,
+    })
+    const rows = listSubagents(db)
+    expect(rows.length).toBe(1)
+    const row = rows[0]
+    expect(row.id).toBe('sa-shape')
+    expect(row.parent_turn_key).toBe('chat1:1')
+    expect(row.agent_type).toBe('worker')
+    expect(row.description).toBe('do work')
+    expect(row.background).toBe(true)
+    expect(row.started_at).toBe(5000)
+    expect(row.status).toBe('running')
+    expect(row.ended_at).toBeNull()
+    db.close()
+  })
+
+  it('orders results by started_at DESC', () => {
+    const db = openFreshSubagentsDbInMemory()
+    recordSubagentStart(db, { id: 'old', background: false, startedAt: 1000 })
+    recordSubagentStart(db, { id: 'new', background: false, startedAt: 2000 })
+    const rows = listSubagents(db)
+    expect(rows[0].id).toBe('new')
+    expect(rows[1].id).toBe('old')
+    db.close()
+  })
+
+  it('status filter with no matches returns empty array', () => {
+    const db = openFreshSubagentsDbInMemory()
+    recordSubagentStart(db, { id: 'sa-1', background: false, startedAt: 1000 })
+    const rows = listSubagents(db, { status: 'failed' })
+    expect(rows).toEqual([])
+    db.close()
+  })
+})

--- a/telegram-plugin/registry/subagents-schema.ts
+++ b/telegram-plugin/registry/subagents-schema.ts
@@ -334,6 +334,30 @@ export function bumpSubagentActivity(db: SqliteDatabase, args: BumpSubagentActiv
 }
 
 /**
+ * Return all subagents, optionally filtered by status, ordered by
+ * started_at DESC. Intended for the REST API endpoint
+ * `GET /api/agents/:name/subagents?status=running`.
+ */
+export function listSubagents(
+  db: SqliteDatabase,
+  opts: { status?: string } = {},
+): Subagent[] {
+  if (opts.status !== undefined) {
+    const rows = db.prepare(`
+      SELECT * FROM subagents
+      WHERE status = ?
+      ORDER BY started_at DESC
+    `).all(opts.status) as RawSubagentRow[]
+    return rows.map(mapSubagentRow)
+  }
+  const rows = db.prepare(`
+    SELECT * FROM subagents
+    ORDER BY started_at DESC
+  `).all() as RawSubagentRow[]
+  return rows.map(mapSubagentRow)
+}
+
+/**
  * Retrieve a single subagent row by id. Returns null if not found.
  * Useful in tests and for callers that need to inspect current state.
  */

--- a/telegram-plugin/registry/turns-schema.ts
+++ b/telegram-plugin/registry/turns-schema.ts
@@ -373,6 +373,26 @@ export function findRecentTurnsForChat(
 }
 
 /**
+ * Return the most recent N turns across all chats for an agent, ordered by
+ * started_at DESC. Intended for the REST API endpoint
+ * `GET /api/agents/:name/turns?limit=20`.
+ *
+ * `limit` defaults to 20, max 200.
+ */
+export function listTurnsForAgent(
+  db: SqliteDatabase,
+  opts: { limit?: number } = {},
+): Turn[] {
+  const limit = Math.min(Math.max(1, opts.limit ?? 20), 200)
+  const rows = db.prepare(`
+    SELECT * FROM turns
+    ORDER BY started_at DESC
+    LIMIT ?
+  `).all(limit) as RawTurnRow[]
+  return rows.map(mapRow)
+}
+
+/**
  * Find the single most-recently-started turn that ended via an interrupt
  * (`'restart'` | `'sigterm'` | `'timeout'`) OR is still open
  * (`ended_at IS NULL`). Used by Stage 4 to surface "you had pending work"


### PR DESCRIPTION
## Summary

Part A of #335. Pairs with the threshold docs (Part B) shipping in parallel.

- Adds `GET /api/agents/:name/turns?limit=20` — returns the most recent N turns for the agent's registry DB (default 20, max 200). JSON array of `Turn` objects.
- Adds `GET /api/agents/:name/subagents?status=running` — returns all subagents with optional `status` filter. JSON array of `Subagent` objects.
- Both routes return 404 for unknown agents and reuse the existing `checkAuth` bearer-token gating.

## Files modified

- `telegram-plugin/registry/turns-schema.ts` — added `listTurnsForAgent(db, { limit })`
- `telegram-plugin/registry/subagents-schema.ts` — added `listSubagents(db, { status? })`
- `src/web/api.ts` — added `handleGetTurns` and `handleGetSubagents` handlers
- `src/web/server.ts` — added route patterns and case handlers for both routes
- `telegram-plugin/registry/api-registry.test.ts` (new) — 14 helper-level tests

## Test plan

- [x] `bun test telegram-plugin/registry/api-registry.test.ts` — 14 tests pass (covers listTurnsForAgent and listSubagents: empty DB, shape, ordering, limit, status filter)
- [x] Existing registry tests (`turns-schema.test.ts`, `subagents.test.ts`) — 30 tests, no regressions
- Note: Route-level tests are omitted. The web server requires a full `Bun.serve` context and a real `SwitchroomConfig` pointing to live filesystem paths; testing the thin route wiring in isolation adds more scaffolding than value. The core query logic is fully covered by the helper tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)