### PR TITLE
docs(profile): document progress-card tunable thresholds

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -41,9 +41,40 @@ Each field type has specific merge behavior when values exist at multiple layers
 | `channels.telegram.plugin` | override | `switchroom` (default, enhanced) or `official` |
 | `channels.telegram.format` | override | Reply format (`html`, `markdownv2`, `text`) |
 | `channels.telegram.rate_limit_ms` | override | Min delay between outgoing messages |
+| `channels.telegram.orphan_promotion_ms` | override | Progress-card: ms before an unmatched spawn is promoted to a running row (default 5000) |
+| `channels.telegram.cold_sub_agent_threshold_ms` | override | Progress-card: ms of JSONL silence before a sub-agent is synthesised as finished (default 30000) |
+| `channels.telegram.deferred_completion_timeout_ms` | override | Progress-card: force-close timeout (ms) after parent `turn_end` while sub-agents are still running (default 180000) |
+| `channels.telegram.sub_agent_tick_interval_ms` | override | Progress-card: elapsed-counter tick interval (ms) while a sub-agent is running (default 10000) |
+| `channels.telegram.edit_budget_threshold` | override | Progress-card: card-edit budget per minute before throttled mode (default 18) |
 | `settings_raw` | deep merge | Escape hatch: raw settings.json overrides |
 | `claude_md_raw` | concatenate | Escape hatch: append to CLAUDE.md on scaffold |
 | `cli_args` | concatenate | Escape hatch: extra `exec claude` flags |
+
+## Progress-Card Tunable Thresholds
+
+When `channels.telegram.stream_mode` is `checklist` (the default), the progress-card driver manages an edit-in-place Telegram message that tracks tool calls and sub-agent activity during a turn. The five knobs below control how it handles edge cases — timeouts, JSONL gaps, and Telegram API rate limits.
+
+All values are in milliseconds unless otherwise noted. Omit a field to keep the built-in default. These fields are only effective when `stream_mode` is `checklist`.
+
+| Field | Default | Description | When to tune |
+|---|---|---|---|
+| `orphan_promotion_ms` | 5000 (5 s) | How long a parent turn waits for a sub-agent JSONL watcher to deliver `sub_agent_started` before the heartbeat promotes the spawn to a synthesised "running" row. | Increase if fast sub-agents are appearing as orphan rows before their JSONL watcher can connect; decrease if you want orphan detection to fire sooner. Set to `0` to disable orphan promotion entirely. |
+| `cold_sub_agent_threshold_ms` | 30000 (30 s) | JSONL-cold threshold. When a running sub-agent emits no events for this long, the heartbeat synthesises a `turn_end` for it so the deferred-completion path can proceed — avoids cards pinned forever on a dead watcher. | Increase if legitimate long-running sub-agents (e.g. waiting on a slow external API) are being falsely closed; decrease to recover faster from a genuinely dead watcher. |
+| `deferred_completion_timeout_ms` | 180000 (3 min) | Force-close timeout after the parent `turn_end` arrives while sub-agents are still running. The card is force-closed after this many ms even if the sub-agents never finish. | Increase for agents that routinely spawn very long-running background sub-agents; decrease to shorten the worst-case delay before the card and pin are cleaned up. |
+| `sub_agent_tick_interval_ms` | 10000 (10 s) | Elapsed-counter tick interval while a sub-agent is running. Forces a re-render so the elapsed counter advances even during silent stretches between tool calls. | Decrease for a more real-time counter (costs extra edits); increase to reduce edit traffic when many parallel sub-agents are active. Set to `0` to disable. |
+| `edit_budget_threshold` | 18 | Card-edit budget per minute before the driver falls back to a slower coalesce window. When a chat exceeds this many edits in the trailing 60 s, the coalesce interval widens until the rate drops. | Increase if your gateway frequently hits the Telegram edit-rate ceiling with many parallel sub-agents; decrease for a more conservative buffer. |
+
+Example: an agent with many parallel sub-agents that hit the Telegram rate ceiling:
+
+```yaml
+agents:
+  worker:
+    channels:
+      telegram:
+        stream_mode: checklist
+        edit_budget_threshold: 12
+        sub_agent_tick_interval_ms: 15000
+```
 
 ## Profiles
 

--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -614,7 +614,7 @@ export function installSwitchroomSkills(agentDir: string): void {
 /**
  * Translate per-channel YAML fields into env vars the telegram-plugin
  * will read at startup. Today: SWITCHROOM_TG_FORMAT, SWITCHROOM_TG_RATE_LIMIT_MS,
- * SWITCHROOM_TG_STREAM_MODE.
+ * SWITCHROOM_TG_STREAM_MODE, and the progress-card threshold knobs.
  *
  * Returns an object that can be merged into the user env. User-declared
  * env vars with the same key take precedence (see the call site) since
@@ -631,6 +631,22 @@ function channelsToEnv(agent: AgentConfig): Record<string, string> {
   }
   if (tg.stream_mode !== undefined) {
     out.SWITCHROOM_TG_STREAM_MODE = tg.stream_mode;
+  }
+  // Progress-card driver thresholds — only effective when stream_mode=checklist.
+  if (tg.orphan_promotion_ms !== undefined) {
+    out.SWITCHROOM_TG_ORPHAN_PROMOTION_MS = String(tg.orphan_promotion_ms);
+  }
+  if (tg.cold_sub_agent_threshold_ms !== undefined) {
+    out.SWITCHROOM_TG_COLD_SUB_AGENT_THRESHOLD_MS = String(tg.cold_sub_agent_threshold_ms);
+  }
+  if (tg.deferred_completion_timeout_ms !== undefined) {
+    out.SWITCHROOM_TG_DEFERRED_COMPLETION_TIMEOUT_MS = String(tg.deferred_completion_timeout_ms);
+  }
+  if (tg.sub_agent_tick_interval_ms !== undefined) {
+    out.SWITCHROOM_TG_SUB_AGENT_TICK_INTERVAL_MS = String(tg.sub_agent_tick_interval_ms);
+  }
+  if (tg.edit_budget_threshold !== undefined) {
+    out.SWITCHROOM_TG_EDIT_BUDGET_THRESHOLD = String(tg.edit_budget_threshold);
   }
   return out;
 }

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -378,6 +378,68 @@ export const TelegramChannelSchema = z
         "Costs ~5-10% per-turn latency/spend since the stable prefix is no " +
         "longer prompt-cached."
       ),
+    /**
+     * Progress-card driver tuning. These knobs are only effective when
+     * stream_mode is 'checklist' (the default). All values are in
+     * milliseconds unless noted. Omit a field to keep the built-in default.
+     */
+    orphan_promotion_ms: z
+      .number()
+      .int()
+      .nonnegative()
+      .optional()
+      .describe(
+        "How long (ms) a parent turn waits for a sub-agent JSONL watcher " +
+        "to deliver sub_agent_started before the heartbeat promotes the spawn " +
+        "to a synthesised 'running' row. Default 5000. Set to 0 to disable " +
+        "orphan promotion entirely."
+      ),
+    cold_sub_agent_threshold_ms: z
+      .number()
+      .int()
+      .nonnegative()
+      .optional()
+      .describe(
+        "JSONL-cold threshold (ms). When a running sub-agent emits no events " +
+        "for this long, the heartbeat synthesises a turn_end for it so the " +
+        "deferred-completion path can proceed. Default 30000. Set to 0 to " +
+        "disable the synthetic close."
+      ),
+    deferred_completion_timeout_ms: z
+      .number()
+      .int()
+      .nonnegative()
+      .optional()
+      .describe(
+        "Force-close timeout (ms) for deferred sub-agent completion. After " +
+        "the parent turn_end arrives while sub-agents are still running, the " +
+        "card is force-closed after this many ms even if sub-agents never " +
+        "finish. Watcher-disconnect safety net. Default 180000 (3 min)."
+      ),
+    sub_agent_tick_interval_ms: z
+      .number()
+      .int()
+      .nonnegative()
+      .optional()
+      .describe(
+        "Heartbeat tick interval (ms) for sub-agent rendering. Forces a " +
+        "re-render of the elapsed-time counter while sub-agents are running, " +
+        "even during silent stretches between tool calls. Default 10000 (10 s). " +
+        "Set to 0 to disable the elapsed-ticker path."
+      ),
+    edit_budget_threshold: z
+      .number()
+      .int()
+      .nonnegative()
+      .optional()
+      .describe(
+        "Telegram API edit budget per minute before the progress-card driver " +
+        "falls back to a slower coalesce window. When a chat accumulates more " +
+        "than this many card edits in the trailing 60 s, the driver switches " +
+        "to a wider coalesce interval until the rate drops back. Default 18. " +
+        "Increase if your gateway frequently bumps the Telegram edit-rate ceiling " +
+        "with many parallel sub-agents; decrease for a more conservative buffer."
+      ),
   })
   .optional();
 

--- a/telegram-plugin/server.ts
+++ b/telegram-plugin/server.ts
@@ -2938,6 +2938,24 @@ if (streamMode === 'checklist') {
     // plenty for a genuine long-running turn to show activity, and it
     // cuts the worst-case orphan window from 30 min to 5 min.
     maxIdleMs: 5 * 60_000,
+    // Tunable thresholds — read from env vars set by channelsToEnv()
+    // when the user declares channels.telegram.<knob> in switchroom.yaml.
+    // Each falls back to the driver's built-in default when unset.
+    ...(process.env.SWITCHROOM_TG_ORPHAN_PROMOTION_MS !== undefined && {
+      orphanPromotionMs: Number(process.env.SWITCHROOM_TG_ORPHAN_PROMOTION_MS),
+    }),
+    ...(process.env.SWITCHROOM_TG_COLD_SUB_AGENT_THRESHOLD_MS !== undefined && {
+      coldSubAgentThresholdMs: Number(process.env.SWITCHROOM_TG_COLD_SUB_AGENT_THRESHOLD_MS),
+    }),
+    ...(process.env.SWITCHROOM_TG_DEFERRED_COMPLETION_TIMEOUT_MS !== undefined && {
+      deferredCompletionTimeoutMs: Number(process.env.SWITCHROOM_TG_DEFERRED_COMPLETION_TIMEOUT_MS),
+    }),
+    ...(process.env.SWITCHROOM_TG_SUB_AGENT_TICK_INTERVAL_MS !== undefined && {
+      subAgentTickIntervalMs: Number(process.env.SWITCHROOM_TG_SUB_AGENT_TICK_INTERVAL_MS),
+    }),
+    ...(process.env.SWITCHROOM_TG_EDIT_BUDGET_THRESHOLD !== undefined && {
+      editBudgetThreshold: Number(process.env.SWITCHROOM_TG_EDIT_BUDGET_THRESHOLD),
+    }),
   })
   process.stderr.write('telegram channel: progress-card driver active (stream_mode=checklist)\n')
 }


### PR DESCRIPTION
## Summary

- Documents five tunable progress-card thresholds (`orphan_promotion_ms`, `cold_sub_agent_threshold_ms`, `deferred_completion_timeout_ms`, `sub_agent_tick_interval_ms`, `edit_budget_threshold`) under `channels.telegram` in `docs/configuration.md`
- Adds all five as optional typed fields to `TelegramChannelSchema` in `src/config/schema.ts` with full JSDoc
- Wires them through `channelsToEnv()` in `src/agents/scaffold.ts` as `SWITCHROOM_TG_*` env vars
- Reads them at driver instantiation in `telegram-plugin/server.ts` so switchroom.yaml values take effect at runtime

Part B of #335. Closes #335 (paired with Part A /api routes).

## Test plan

- [x] `bun test src/config/schema.test.ts` — 26 pass, 0 fail
- [ ] Verify a `channels.telegram.edit_budget_threshold: 12` config is scaffolded with `SWITCHROOM_TG_EDIT_BUDGET_THRESHOLD=12` in the agent env

🤖 Generated with [Claude Code](https://claude.com/claude-code)