### PR TITLE
debug(gateway): trace every Telegram API write to identify DM dup source

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -419,6 +419,33 @@ const chatLock = createChatLock()
 const lockedBot = chatLock.wrapBot({ api: bot.api as unknown as Record<string, unknown> }) as unknown as typeof bot
 let botUsername = ''
 
+// ─── DEBUG TRACER (issue #109 / dual-message investigation) ───────────────
+// Patches every Telegram API write op so we can grep journalctl and reconstruct
+// exactly what messages got sent for each turn. Remove before merging — this is
+// a live diagnostic for the DM-channel duplicate-message bug Ken hit on
+// 2026-04-29. See chat for context.
+;(() => {
+  const ops: Array<keyof typeof bot.api> = [
+    'sendMessage', 'editMessageText', 'editMessageReplyMarkup',
+    'pinChatMessage', 'unpinChatMessage', 'unpinAllChatMessages',
+    'deleteMessage', 'sendChatAction', 'sendPhoto', 'sendDocument',
+  ] as Array<keyof typeof bot.api>
+  for (const op of ops) {
+    const orig = (bot.api as unknown as Record<string, Function>)[op as string]
+    if (typeof orig !== 'function') continue
+    const bound = orig.bind(bot.api)
+    ;(bot.api as unknown as Record<string, Function>)[op as string] = function (...args: unknown[]) {
+      const stack = new Error().stack?.split('\n').slice(2, 5).map(l => l.trim()).join(' ← ') ?? 'unknown'
+      const chatId = args[0] != null ? String(args[0]) : 'none'
+      // Slice gateway-relative source paths so logs are grep-friendly
+      const cleanStack = stack.replace(/file:\/\/[^/]+\//g, '').replace(/\?[^)]+\)/g, ')')
+      process.stderr.write(`telegram gateway: TRACE op=${String(op)} chatId=${chatId} caller=${cleanStack}\n`)
+      return (bound as (...a: unknown[]) => unknown)(...args)
+    }
+  }
+})()
+
+
 // ─── Access control ───────────────────────────────────────────────────────
 
 type PendingEntry = {


### PR DESCRIPTION
## Summary

Wraps `bot.api` at module init with a small Proxy that logs every `sendMessage` / `editMessageText` / `pin` / `unpin` / etc. call along with its caller stack. One ~30-line block at the top of `gateway.ts`. Touches no other code.

## Why

Hunt for the duplicate-message bug Ken hit on 2026-04-29 in DM chats: every `stream_reply(done=true)` produces a phantom message_id gap of 2 (one suspected card, one suspected pin service event). The earlier guesses (forum-topic-only completion message, etc.) didn't fit the DM path. Need actual runtime evidence.

## Approach

Traditional approach would be inline `process.stderr.write(...)` before each of the ~30 API call sites. But:
- Three separate worker attempts on this file have stalled out trying that — the file is huge and inline edits don't scale.
- Inline traces miss any call sites in other files (pin-manager, server.ts wrapper, etc.).

Instead: patch `bot.api` once. The Proxy captures the op, the chat_id, and the caller's stack frame — gives us complete coverage from any source path.

## Deploy + repro

```bash
git checkout debug/gateway-api-write-tracer
bun run build
switchroom agent restart all
# send a few messages
journalctl --user -u switchroom-clerk-gateway -n 200 | grep 'TRACE op='
```

## NOT FOR MERGE

This is a debug branch — instrumentation only. Once we've identified the duplicate source from the trace, the actual fix will be a focused PR and this trace block gets reverted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)