### PR TITLE
fix(systemd): force cgroup-wide kill on restart (closes #361)

### DIFF
--- a/src/agents/systemd.ts
+++ b/src/agents/systemd.ts
@@ -77,6 +77,18 @@ StandardOutput=journal
 StandardError=journal
 Restart=on-failure
 RestartSec=5
+# Cgroup-wide kill so restart actually kills claude (issue #361).
+# ExecStart wraps claude in \`script -qfc\` for PTY allocation (autoaccept
+# needs a TTY). The PTY layer detaches claude from the unit cgroup, so a
+# plain SIGTERM to the ExecStart PID only kills \`script\`; claude survives
+# and the Apr 17 incident showed the same PID running 12 days after the
+# service "restarted". KillMode=control-group sends SIGTERM to every
+# process in the cgroup (including detached descendants), waits
+# TimeoutStopSec, then SIGKILL if anything is still alive.
+KillMode=control-group
+KillSignal=SIGTERM
+SendSIGKILL=yes
+TimeoutStopSec=15
 # Memory ceiling: MemoryHigh triggers kernel reclaim at 1.5G so the
 # process is throttled before hitting the hard ceiling. MemoryMax=2G is
 # the hard limit — once hit, the kernel OOM-kills the unit. Combined
@@ -243,6 +255,11 @@ StandardOutput=journal
 StandardError=journal
 Restart=always
 RestartSec=3
+# Cgroup-wide kill so restart actually kills the gateway process (issue #361).
+# Same script PTY cgroup-escape issue as the agent unit — see generateUnit().
+KillMode=control-group
+KillSignal=SIGTERM
+SendSIGKILL=yes
 # Give the gateway 45s to drain its long-poll on SIGTERM. The drain
 # itself budgets 35s (SHUTDOWN_DRAIN_BUDGET_MS in gateway.ts) plus a
 # 5s force-exit safety; the extra 5s is systemd-side headroom before
@@ -300,6 +317,11 @@ StandardOutput=journal
 StandardError=journal
 Restart=always
 RestartSec=3
+# Cgroup-wide kill so restart actually kills the foreman process (issue #361).
+# Same script PTY cgroup-escape issue as the agent unit — see generateUnit().
+KillMode=control-group
+KillSignal=SIGTERM
+SendSIGKILL=yes
 TimeoutStopSec=30
 WorkingDirectory=${foremanDir}
 EnvironmentFile=-%h/.switchroom/.env.vault
@@ -707,6 +729,13 @@ Type=simple
 ExecStart=${bunBin} ${switchroomCli} vault broker start --foreground
 Restart=on-failure
 RestartSec=2
+# Cgroup-wide kill for consistency with agent/gateway units (issue #361).
+# The broker doesn't use the script PTY wrapper but may spawn subprocesses;
+# control-group kill ensures a clean slate on every restart.
+KillMode=control-group
+KillSignal=SIGTERM
+SendSIGKILL=yes
+TimeoutStopSec=15
 ${credentialLine}# Type=simple — see generateBrokerUnit() for the sd_notify-stream-vs-datagram
 # rationale. The hand-rolled sd_notify in the broker is non-functional;
 # Type=notify caused a restart loop that destroyed unlock state.

--- a/tests/systemd-restart.test.ts
+++ b/tests/systemd-restart.test.ts
@@ -1,0 +1,235 @@
+/**
+ * Regression tests for issue #361: cgroup-escape via `script -qfc` PTY.
+ *
+ * Problem: ExecStart wraps claude (and gateway/foreman) in `/usr/bin/script
+ * -qfc "..."`. The PTY layer detaches the child process from the systemd
+ * unit's cgroup. When systemd restarts the unit it kills `script` but the
+ * underlying process survives — confirmed 2026-04-29 when `ps` showed a
+ * claude PID with start time Apr 17 while the service ActiveEnterTimestamp
+ * was Apr 29 19:50. PR #358 merged, scaffold reconciled, agent restarted,
+ * but Playwright MCP never loaded because the Apr 17 claude was still live.
+ *
+ * Fix: add KillMode=control-group / SendSIGKILL=yes / TimeoutStopSec=15
+ * to every unit type. systemd then SIGTERMs every process in the cgroup
+ * (including script's spawned children), waits TimeoutStopSec, and
+ * SIGKILLs any survivors.
+ *
+ * These unit-level tests are the regression-catcher. They assert the
+ * directives are present in ALL unit types so a future template edit
+ * can't silently reintroduce the bug.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  generateUnit,
+  generateGatewayUnit,
+  generateTimerServiceUnit,
+  generateBrokerUnit,
+  generateForemanUnit,
+} from "../src/agents/systemd.js";
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+/** Extract the text between [Service] and the next section header. */
+function serviceSection(unit: string): string {
+  const after = unit.split("[Service]")[1];
+  if (!after) throw new Error("No [Service] section found in unit");
+  // Stop at the next `[…]` header (e.g. [Install])
+  return after.split(/^\[/m)[0];
+}
+
+// ─── Agent unit ───────────────────────────────────────────────────────────────
+
+describe("generateUnit — cgroup kill semantics (issue #361)", () => {
+  const unit = generateUnit("clerk", "/tmp/clerk");
+  const svc = serviceSection(unit);
+
+  it("sets KillMode=control-group in [Service]", () => {
+    expect(svc).toContain("KillMode=control-group");
+  });
+
+  it("sets KillSignal=SIGTERM in [Service]", () => {
+    expect(svc).toContain("KillSignal=SIGTERM");
+  });
+
+  it("sets SendSIGKILL=yes in [Service]", () => {
+    expect(svc).toContain("SendSIGKILL=yes");
+  });
+
+  it("sets TimeoutStopSec=15 in [Service]", () => {
+    expect(svc).toContain("TimeoutStopSec=15");
+  });
+
+  it("preserves ExecStart with script -qfc (PTY must not be removed)", () => {
+    expect(unit).toContain("ExecStart=/usr/bin/script -qfc");
+  });
+
+  it("preserves Restart=on-failure", () => {
+    expect(svc).toContain("Restart=on-failure");
+  });
+
+  it("same kill semantics apply with useAutoaccept=true", () => {
+    const autoUnit = generateUnit("clerk", "/tmp/clerk", true);
+    const autoSvc = serviceSection(autoUnit);
+    expect(autoSvc).toContain("KillMode=control-group");
+    expect(autoSvc).toContain("SendSIGKILL=yes");
+    expect(autoSvc).toContain("TimeoutStopSec=15");
+    // PTY wrapper still present
+    expect(autoUnit).toContain("autoaccept.exp");
+  });
+});
+
+// ─── Gateway unit ─────────────────────────────────────────────────────────────
+
+describe("generateGatewayUnit — cgroup kill semantics (issue #361)", () => {
+  const unit = generateGatewayUnit("/tmp/clerk/telegram", "clerk");
+  const svc = serviceSection(unit);
+
+  it("sets KillMode=control-group in [Service]", () => {
+    expect(svc).toContain("KillMode=control-group");
+  });
+
+  it("sets KillSignal=SIGTERM in [Service]", () => {
+    expect(svc).toContain("KillSignal=SIGTERM");
+  });
+
+  it("sets SendSIGKILL=yes in [Service]", () => {
+    expect(svc).toContain("SendSIGKILL=yes");
+  });
+
+  it("preserves TimeoutStopSec=45 for the 35s Telegram drain budget", () => {
+    // The gateway needs 45s (35s drain + headroom) — do NOT reduce to 15s.
+    expect(svc).toContain("TimeoutStopSec=45");
+    expect(svc).not.toContain("TimeoutStopSec=15");
+  });
+
+  it("preserves ExecStart with script -qfc (PTY must not be removed)", () => {
+    expect(unit).toContain("ExecStart=/usr/bin/script -qfc");
+  });
+
+  it("preserves Restart=always", () => {
+    expect(svc).toContain("Restart=always");
+  });
+});
+
+// ─── Foreman unit ─────────────────────────────────────────────────────────────
+
+describe("generateForemanUnit — cgroup kill semantics (issue #361)", () => {
+  const unit = generateForemanUnit();
+  const svc = serviceSection(unit);
+
+  it("sets KillMode=control-group in [Service]", () => {
+    expect(svc).toContain("KillMode=control-group");
+  });
+
+  it("sets KillSignal=SIGTERM in [Service]", () => {
+    expect(svc).toContain("KillSignal=SIGTERM");
+  });
+
+  it("sets SendSIGKILL=yes in [Service]", () => {
+    expect(svc).toContain("SendSIGKILL=yes");
+  });
+
+  it("sets TimeoutStopSec=30 in [Service]", () => {
+    expect(svc).toContain("TimeoutStopSec=30");
+  });
+
+  it("preserves ExecStart with script -qfc (PTY must not be removed)", () => {
+    expect(unit).toContain("ExecStart=/usr/bin/script -qfc");
+  });
+
+  it("preserves Restart=always", () => {
+    expect(svc).toContain("Restart=always");
+  });
+});
+
+// ─── Broker unit ──────────────────────────────────────────────────────────────
+
+describe("generateBrokerUnit — cgroup kill semantics (issue #361)", () => {
+  const unit = generateBrokerUnit({
+    homeDir: "/home/user",
+    bunBinDir: "/home/user/.bun/bin",
+  });
+  const svc = serviceSection(unit);
+
+  it("sets KillMode=control-group in [Service]", () => {
+    expect(svc).toContain("KillMode=control-group");
+  });
+
+  it("sets KillSignal=SIGTERM in [Service]", () => {
+    expect(svc).toContain("KillSignal=SIGTERM");
+  });
+
+  it("sets SendSIGKILL=yes in [Service]", () => {
+    expect(svc).toContain("SendSIGKILL=yes");
+  });
+
+  it("sets TimeoutStopSec=15 in [Service]", () => {
+    expect(svc).toContain("TimeoutStopSec=15");
+  });
+
+  it("preserves Restart=on-failure", () => {
+    expect(svc).toContain("Restart=on-failure");
+  });
+});
+
+// ─── Kill directives in [Service] not [Unit] ─────────────────────────────────
+
+describe("kill directives placement — must be in [Service] not [Unit]", () => {
+  it("agent unit: KillMode is in [Service], not [Unit]", () => {
+    const unit = generateUnit("test", "/tmp/test");
+    const unitSection = unit.split("[Service]")[0];
+    expect(unitSection).not.toContain("KillMode");
+    expect(serviceSection(unit)).toContain("KillMode=control-group");
+  });
+
+  it("gateway unit: KillMode is in [Service], not [Unit]", () => {
+    const unit = generateGatewayUnit("/tmp/telegram", "test");
+    const unitSection = unit.split("[Service]")[0];
+    expect(unitSection).not.toContain("KillMode");
+    expect(serviceSection(unit)).toContain("KillMode=control-group");
+  });
+});
+
+// ─── Integration test (skipped unless RUN_SYSTEMD_INTEGRATION_TESTS=1) ───────
+//
+// This test scaffolds a real agent service, starts it, captures the claude
+// PID, restarts the service via systemctl, and asserts the new claude PID
+// differs from the old one — proving the cgroup kill actually terminated
+// the old process rather than leaving it orphaned.
+//
+// It is SKIPPED by default because it requires:
+//   - A systemd user session (--user)
+//   - switchroom installed (switchroom agent scaffold …)
+//   - The test runner to have permission to start/stop user services
+//
+// Enable in CI by setting RUN_SYSTEMD_INTEGRATION_TESTS=1.
+
+const runIntegration = process.env.RUN_SYSTEMD_INTEGRATION_TESTS === "1";
+
+describe.skipIf(!runIntegration)(
+  "integration: restart actually changes claude PID (issue #361) [requires RUN_SYSTEMD_INTEGRATION_TESTS=1]",
+  () => {
+    it(
+      "claude PID after restart differs from claude PID before restart",
+      async () => {
+        // This test body intentionally left as a stub.
+        // Full implementation requires:
+        //   1. scaffoldAgent() + installUnit() for a test agent
+        //   2. systemctl --user start switchroom-<agent>.service
+        //   3. pgrep -f "claude.*<agent>" to capture PID
+        //   4. systemctl --user restart switchroom-<agent>.service
+        //   5. pgrep again — assert new PID !== old PID
+        //   6. systemctl --user stop + uninstall cleanup
+        //
+        // Until a full harness is wired up, skip with a descriptive error
+        // so anyone who sets the env var gets a clear signal to implement.
+        throw new Error(
+          "Integration test stub: implement the PID-change assertion described in the comment above. " +
+          "Set RUN_SYSTEMD_INTEGRATION_TESTS=1 to run."
+        );
+      },
+      60_000,
+    );
+  },
+);


### PR DESCRIPTION
## Summary

Fixes #361. `script -qfc` allocates a PTY so autoaccept can handle Claude Code's permission prompts. That PTY layer detaches claude from the unit's cgroup. When systemd restarts the unit it SIGTERMs `script` but the underlying claude process is in a different cgroup slice and survives.

**Evidence captured 2026-04-29 19:50:** `ActiveEnterTimestamp=Wed 19:50:55` but `pgrep claude` returned a PID with start time **Apr 17** — 12 days of ghost claude. PR #358 merged Playwright MCP as a default, scaffold reconciled, agent restarted — Playwright never loaded because the Apr 17 claude was still live.

## Directives added to all unit types

```
KillMode=control-group   # SIGTERM every process in the cgroup, not just ExecStart PID
KillSignal=SIGTERM       # explicit (was already default, now documented)
SendSIGKILL=yes          # SIGKILL survivors after TimeoutStopSec
TimeoutStopSec=<N>       # agent/broker: 15s  gateway: 45s (preserves drain budget)  foreman: 30s
```

Units fixed:
- `generateUnit` — agent service (the primary fix)
- `generateGatewayUnit` — gateway service (same script PTY escape path)
- `generateForemanUnit` — foreman service (same script PTY escape path)
- `generateBrokerUnit` — broker service (no PTY but consistent kill policy)

`ExecStart` and the `script -qfc` wrapper are **unchanged** — kill semantics are independent of PTY allocation. `Restart=on-failure` / `Restart=always` unchanged.

## Tests

New file `tests/systemd-restart.test.ts` — 26 unit-level assertions:
- Each unit type: `KillMode=control-group`, `KillSignal=SIGTERM`, `SendSIGKILL=yes`, correct `TimeoutStopSec`
- Kill directives land in `[Service]`, not `[Unit]`
- PTY (`script -qfc`) and restart directives are preserved
- One integration test stub (skipped by default; `RUN_SYSTEMD_INTEGRATION_TESTS=1` to enable)

All existing tests pass: `systemd.test.ts` (57), `scaffold.test.ts` (132).

## Apply path

Per the reconcile-then-restart contract (PR #59), running `switchroom agent restart <name>` triggers reconcile which regenerates the unit file from the updated template, then restarts — no manual unit editing needed.

## Reference

- JTBD: `reference/restart-and-know-what-im-running.md`
- Related: PR #359 (idempotent update/restart), PR #358 (Playwright MCP default, unblocked by this fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)