### PR TITLE
fix(subagents): plug 5 registry tracking bugs (live evidence: 90s sub-agent reported 10s)

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -221,6 +221,7 @@ import {
   findMostRecentInterruptedTurn,
   findRecentTurnsForChat,
 } from '../registry/turns-schema.js'
+import { applySubagentsSchema } from '../registry/subagents-schema.js'
 import { formatIdleFooter } from '../idle-footer.js'
 
 // ─── Stderr logging ───────────────────────────────────────────────────────
@@ -628,6 +629,10 @@ try {
     ? STATE_DIR.slice(0, -'/telegram'.length)
     : STATE_DIR
   turnsDb = openTurnsDb(agentDir)
+  // Apply subagents schema in the same DB. openTurnsDb only applies the turns
+  // schema; subagents lives alongside in registry.db. Idempotent — safe on
+  // pre-existing DBs (handles the jsonl_agent_id column migration).
+  applySubagentsSchema(turnsDb)
   const reaped = markOrphanedAsRestarted(turnsDb)
   if (reaped > 0) {
     process.stderr.write(`telegram gateway: turn-registry boot-reaper stamped ${reaped} orphaned turn(s) as ended_via='restart'\n`)
@@ -7210,6 +7215,10 @@ void (async () => {
           if (watcherAgentDir != null) {
             subagentWatcher = startSubagentWatcher({
               agentDir: watcherAgentDir,
+              // Bug 0 fix: previously omitted, leaving the watcher unable to
+              // write liveness/stall/turn_end updates to the registry DB.
+              // Liveness writes are now persisted across the gateway lifetime.
+              db: turnsDb,
               sendNotification: (text: string) => {
                 const ownerChatId = loadAccess().allowFrom[0]
                 if (!ownerChatId) return

--- a/telegram-plugin/hooks/subagent-tracker-posttool.mjs
+++ b/telegram-plugin/hooks/subagent-tracker-posttool.mjs
@@ -85,21 +85,50 @@ function extractResultSummary(toolResponse) {
 // DB write
 // ---------------------------------------------------------------------------
 
+/**
+ * Apply posttool DB updates for a subagent.
+ *
+ * Foreground agents (background = 0): set status, ended_at, result_summary,
+ * and last_activity_at — PostToolUse fires on actual completion.
+ *
+ * Background agents (background = 1): PostToolUse fires on the launch ACK
+ * (~10 s), NOT on actual completion. Only bump last_activity_at and capture
+ * result_summary; leave status/ended_at alone so the watcher's
+ * recordSubagentEnd (driven by the JSONL turn_end event) remains the
+ * authoritative end-of-life signal.
+ */
 function updateRow(dbPath, { id, status, resultSummary, now }) {
-  const UPDATE_SQL = `
+  // SQL to read the background flag so we can choose the right update path.
+  const SELECT_SQL = `SELECT background FROM subagents WHERE id = ?`
+
+  // Foreground update: set terminal status + ended_at.
+  const FOREGROUND_SQL = `
     UPDATE subagents
     SET ended_at = ?, status = ?, result_summary = COALESCE(?, result_summary), last_activity_at = ?
     WHERE id = ?
       AND status NOT IN ('completed', 'failed')
   `
-  const params = [now, status, resultSummary, now, id]
+
+  // Background update: bump activity only; do NOT touch status or ended_at.
+  const BACKGROUND_SQL = `
+    UPDATE subagents
+    SET result_summary = COALESCE(?, result_summary), last_activity_at = ?
+    WHERE id = ?
+      AND status NOT IN ('completed', 'failed')
+  `
 
   const [major] = process.versions.node.split('.').map(Number)
   if (major >= 22) {
     try {
       const { DatabaseSync } = require('node:sqlite')
       const db = new DatabaseSync(dbPath)
-      db.prepare(UPDATE_SQL).run(...params)
+      const row = db.prepare(SELECT_SQL).get(id)
+      const isBackground = row != null && row.background === 1
+      if (isBackground) {
+        db.prepare(BACKGROUND_SQL).run(resultSummary, now, id)
+      } else {
+        db.prepare(FOREGROUND_SQL).run(now, status, resultSummary, now, id)
+      }
       db.close()
       return
     } catch {
@@ -107,8 +136,15 @@ function updateRow(dbPath, { id, status, resultSummary, now }) {
     }
   }
 
-  // sqlite3 CLI fallback
-  execSql(dbPath, fillPlaceholders(UPDATE_SQL.trim(), params))
+  // sqlite3 CLI fallback — two statements issued sequentially.
+  const bgResult = execFileSync('sqlite3', [dbPath, fillPlaceholders(SELECT_SQL, [id])], { timeout: 5000 }).toString().trim()
+  // sqlite3 outputs "0" or "1" (or empty if row not found).
+  const isBackground = bgResult === '1'
+  if (isBackground) {
+    execSql(dbPath, fillPlaceholders(BACKGROUND_SQL.trim(), [resultSummary, now, id]))
+  } else {
+    execSql(dbPath, fillPlaceholders(FOREGROUND_SQL.trim(), [now, status, resultSummary, now, id]))
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/telegram-plugin/hooks/subagent-tracker-posttool.mjs
+++ b/telegram-plugin/hooks/subagent-tracker-posttool.mjs
@@ -63,7 +63,15 @@ function detectStatus(toolResponse) {
 
 function extractResultSummary(toolResponse) {
   if (!toolResponse) return null
-  // tool_response.result is the canonical field for PostToolUse
+  // Claude Code's Agent tool wraps text in `content: [{ type: 'text', text }]`.
+  // Try that first since it's the actual production shape.
+  if (Array.isArray(toolResponse.content)) {
+    const textPart = toolResponse.content.find(
+      (c) => c && typeof c === 'object' && c.type === 'text' && typeof c.text === 'string',
+    )
+    if (textPart) return textPart.text.slice(0, 200) || null
+  }
+  // Older / alternate shapes.
   const raw =
     toolResponse.result ??
     toolResponse.output ??

--- a/telegram-plugin/hooks/subagent-tracker-pretool.mjs
+++ b/telegram-plugin/hooks/subagent-tracker-pretool.mjs
@@ -37,10 +37,18 @@ const SCHEMA_SQL = `
     last_activity_at  INTEGER,
     ended_at          INTEGER,
     status            TEXT    NOT NULL,
-    result_summary    TEXT
+    result_summary    TEXT,
+    jsonl_agent_id    TEXT
   );
-  CREATE INDEX IF NOT EXISTS subagents_turn   ON subagents(parent_turn_key);
-  CREATE INDEX IF NOT EXISTS subagents_status ON subagents(status);
+  CREATE INDEX IF NOT EXISTS subagents_turn      ON subagents(parent_turn_key);
+  CREATE INDEX IF NOT EXISTS subagents_status    ON subagents(status);
+  CREATE INDEX IF NOT EXISTS subagents_jsonl_id  ON subagents(jsonl_agent_id);
+`
+
+// Idempotent column migration for older DBs that pre-date jsonl_agent_id.
+// Mirrors applySubagentsSchema's migration in subagents-schema.ts.
+const MIGRATE_JSONL_COL_SQL = `
+  SELECT name FROM pragma_table_info('subagents') WHERE name = 'jsonl_agent_id'
 `
 
 // ---------------------------------------------------------------------------
@@ -77,14 +85,14 @@ function execSql(dbPath, sql) {
 // DB write
 // ---------------------------------------------------------------------------
 
-function writeRow(dbPath, { id, parentSessionId, agentType, description, background, now }) {
+function writeRow(dbPath, { id, parentSessionId, parentTurnKey, agentType, description, background, now }) {
   const INSERT_SQL = `
     INSERT OR IGNORE INTO subagents
       (id, parent_session_id, parent_turn_key, agent_type, description,
        background, started_at, last_activity_at, status)
-    VALUES (?, ?, NULL, ?, ?, ?, ?, ?, 'running')
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'running')
   `
-  const params = [id, parentSessionId, agentType, description, background, now, now]
+  const params = [id, parentSessionId, parentTurnKey, agentType, description, background, now, now]
 
   // Try Node 22+ built-in sqlite first (synchronous API)
   const [major] = process.versions.node.split('.').map(Number)
@@ -93,6 +101,12 @@ function writeRow(dbPath, { id, parentSessionId, agentType, description, backgro
       const { DatabaseSync } = require('node:sqlite')
       const db = new DatabaseSync(dbPath)
       db.exec(SCHEMA_SQL)
+      // Migrate older DBs that pre-date jsonl_agent_id.
+      const hasJsonlCol = db.prepare(MIGRATE_JSONL_COL_SQL).get()
+      if (hasJsonlCol == null) {
+        db.exec('ALTER TABLE subagents ADD COLUMN jsonl_agent_id TEXT')
+        db.exec('CREATE INDEX IF NOT EXISTS subagents_jsonl_id ON subagents(jsonl_agent_id)')
+      }
       db.prepare(INSERT_SQL).run(...params)
       db.close()
       return
@@ -137,6 +151,7 @@ function main() {
     writeRow(dbPath, {
       id: event.tool_use_id ?? null,
       parentSessionId: event.session_id ?? null,
+      parentTurnKey: event.turn_id ?? null,
       agentType: input.subagent_type ?? null,
       description: input.description ?? null,
       background: input.run_in_background === true ? 1 : 0,

--- a/telegram-plugin/registry/subagents-bugs.test.ts
+++ b/telegram-plugin/registry/subagents-bugs.test.ts
@@ -1,0 +1,380 @@
+/**
+ * Bun test suite — subagent registry bug regression tests.
+ *
+ * Covers schema and hook-level behaviour that requires bun:sqlite.
+ * Run via: bun test telegram-plugin/registry/subagents-bugs.test.ts
+ *
+ * Bug 1 — jsonl_agent_id column must exist in schema and be settable.
+ * Bug 2 — background=true rows must not be ended by posttool (schema contract).
+ * Bug 4 — result_summary always NULL in hook integration.
+ * Bug 5 — parent_turn_key always NULL in hook integration.
+ * Boot reconciliation — running rows with absent JSONLs get marked stalled.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test'
+import { mkdtempSync, mkdirSync, rmSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { spawnSync } from 'child_process'
+import {
+  openFreshSubagentsDbInMemory,
+  applySubagentsSchema,
+  recordSubagentStart,
+  recordSubagentEnd,
+  recordSubagentStall,
+  bumpSubagentActivity,
+  getSubagent,
+  listSubagents,
+} from './subagents-schema.js'
+
+// ─── Bug 1: jsonl_agent_id column ─────────────────────────────────────────────
+
+describe('Bug 1 — jsonl_agent_id column', () => {
+  it('column exists in schema after migration', () => {
+    const db = openFreshSubagentsDbInMemory()
+    const col = db
+      .prepare("SELECT name FROM pragma_table_info('subagents') WHERE name = 'jsonl_agent_id'")
+      .get() as { name: string } | undefined
+    expect(col?.name).toBe('jsonl_agent_id')
+    db.close()
+  })
+
+  it('recordSubagentStart accepts and stores jsonlAgentId', () => {
+    const db = openFreshSubagentsDbInMemory()
+    recordSubagentStart(db, {
+      id: 'toolu_001',
+      jsonlAgentId: 'a37ad7639ae61476c',
+      background: false,
+      startedAt: 1000,
+    })
+    const row = getSubagent(db, 'toolu_001')
+    expect(row).not.toBeNull()
+    expect(row!.jsonl_agent_id).toBe('a37ad7639ae61476c')
+    db.close()
+  })
+
+  it('getSubagentByJsonlId finds row by jsonl_agent_id', () => {
+    const db = openFreshSubagentsDbInMemory()
+    recordSubagentStart(db, {
+      id: 'toolu_002',
+      jsonlAgentId: 'b48be874ab72587d',
+      background: false,
+      startedAt: 2000,
+    })
+    // Use direct SQL since getSubagentByJsonlId is the new helper
+    const row = db
+      .prepare('SELECT * FROM subagents WHERE jsonl_agent_id = ?')
+      .get('b48be874ab72587d') as { id: string } | undefined
+    expect(row?.id).toBe('toolu_002')
+    db.close()
+  })
+
+  it('bumpSubagentActivity by tool_use_id succeeds when jsonl_agent_id matches', () => {
+    const db = openFreshSubagentsDbInMemory()
+    recordSubagentStart(db, {
+      id: 'toolu_003',
+      jsonlAgentId: 'c59cf985bc83698e',
+      background: false,
+      startedAt: 1000,
+    })
+    // Simulate watcher: lookup by jsonl_agent_id → get tool_use_id → bump
+    const found = db
+      .prepare('SELECT id FROM subagents WHERE jsonl_agent_id = ?')
+      .get('c59cf985bc83698e') as { id: string } | undefined
+    expect(found?.id).toBe('toolu_003')
+    bumpSubagentActivity(db, { id: found!.id, ts: 5000 })
+    const row = getSubagent(db, 'toolu_003')
+    expect(row!.last_activity_at).toBe(5000)
+    db.close()
+  })
+
+  it('migration is idempotent on DB that already has jsonl_agent_id', () => {
+    const db = openFreshSubagentsDbInMemory()
+    // Applying schema again should not throw
+    expect(() => applySubagentsSchema(db)).not.toThrow()
+    db.close()
+  })
+})
+
+// ─── Bug 2: background=true rows — schema contract ───────────────────────────
+
+describe('Bug 2 — background=true rows must not be ended by PostToolUse', () => {
+  it('posttool gating: background=1 row stays running after simulated launch response', () => {
+    const db = openFreshSubagentsDbInMemory()
+    recordSubagentStart(db, {
+      id: 'toolu_bg001',
+      background: true,
+      startedAt: 1000,
+    })
+
+    const row = getSubagent(db, 'toolu_bg001')
+    expect(row).not.toBeNull()
+    expect(row!.background).toBe(true)
+
+    // The FIXED posttool: read background flag, skip recordSubagentEnd if true
+    if (!row!.background) {
+      recordSubagentEnd(db, { id: 'toolu_bg001', endedAt: 2000, status: 'completed' })
+    } else {
+      bumpSubagentActivity(db, { id: 'toolu_bg001', ts: 2000 })
+    }
+
+    const after = getSubagent(db, 'toolu_bg001')
+    expect(after!.status).toBe('running')
+    expect(after!.ended_at).toBeNull()
+    expect(after!.last_activity_at).toBe(2000)
+
+    db.close()
+  })
+
+  it('foreground agent still gets completed via schema (regression)', () => {
+    const db = openFreshSubagentsDbInMemory()
+    recordSubagentStart(db, {
+      id: 'toolu_fg001',
+      background: false,
+      startedAt: 1000,
+    })
+
+    const row = getSubagent(db, 'toolu_fg001')
+    if (!row!.background) {
+      recordSubagentEnd(db, { id: 'toolu_fg001', endedAt: 2000, status: 'completed', resultSummary: 'Done.' })
+    } else {
+      bumpSubagentActivity(db, { id: 'toolu_fg001', ts: 2000 })
+    }
+
+    const after = getSubagent(db, 'toolu_fg001')
+    expect(after!.status).toBe('completed')
+    expect(after!.ended_at).toBe(2000)
+    expect(after!.result_summary).toBe('Done.')
+
+    db.close()
+  })
+
+  it('background agent can be ended by recordSubagentEnd (watcher turn_end path)', () => {
+    const db = openFreshSubagentsDbInMemory()
+    recordSubagentStart(db, {
+      id: 'toolu_bg002',
+      background: true,
+      startedAt: 1000,
+    })
+
+    // Simulate watcher completing a background agent via turn_end
+    recordSubagentEnd(db, { id: 'toolu_bg002', endedAt: 90_000, status: 'completed', resultSummary: 'Task done after 90s.' })
+
+    const row = getSubagent(db, 'toolu_bg002')
+    expect(row!.status).toBe('completed')
+    expect(row!.ended_at).toBe(90_000)
+    expect(row!.result_summary).toBe('Task done after 90s.')
+
+    db.close()
+  })
+})
+
+// ─── Boot reconciliation ──────────────────────────────────────────────────────
+
+describe('Boot reconciliation', () => {
+  it('running rows with absent JSONLs are marked stalled on boot', () => {
+    const db = openFreshSubagentsDbInMemory()
+    const now = Date.now()
+
+    recordSubagentStart(db, {
+      id: 'toolu_orphan001',
+      jsonlAgentId: 'orphan-jsonl-001',
+      background: false,
+      startedAt: now - 300_000, // 5 minutes ago
+    })
+
+    const row = getSubagent(db, 'toolu_orphan001')
+    expect(row!.status).toBe('running')
+
+    // Boot reconciler: JSONL absent → stall
+    recordSubagentStall(db, { id: 'toolu_orphan001', stalledAt: now })
+
+    const after = getSubagent(db, 'toolu_orphan001')
+    expect(after!.status).toBe('stalled')
+    expect(after!.ended_at).toBeNull() // stalled ≠ ended
+
+    db.close()
+  })
+
+  it('listSubagents running filter returns only running rows for reconciliation scan', () => {
+    const db = openFreshSubagentsDbInMemory()
+    const now = Date.now()
+
+    recordSubagentStart(db, { id: 'running-1', background: false, startedAt: now - 60_000 })
+    recordSubagentStart(db, { id: 'running-2', background: true,  startedAt: now - 30_000 })
+    recordSubagentStart(db, { id: 'done-1',    background: false, startedAt: now - 90_000 })
+    recordSubagentEnd(db, { id: 'done-1', endedAt: now - 60_000, status: 'completed' })
+
+    const running = listSubagents(db, { status: 'running' })
+    expect(running.length).toBe(2)
+    expect(running.map((r) => r.id).sort()).toEqual(['running-1', 'running-2'])
+
+    db.close()
+  })
+})
+
+// ─── Bug 4: result_summary always NULL in hook integration ───────────────────
+
+const PRETOOL_SCRIPT = join(import.meta.dir, '..', 'hooks', 'subagent-tracker-pretool.mjs')
+const POSTTOOL_SCRIPT = join(import.meta.dir, '..', 'hooks', 'subagent-tracker-posttool.mjs')
+
+let tempDir: string
+let agentDir: string
+let dbPath: string
+
+beforeEach(() => {
+  tempDir = mkdtempSync(join(tmpdir(), 'subagent-bugs-test-'))
+  agentDir = tempDir
+  mkdirSync(join(agentDir, 'telegram'), { recursive: true })
+  dbPath = join(agentDir, 'telegram', 'registry.db')
+})
+
+afterEach(() => {
+  try { rmSync(tempDir, { recursive: true }) } catch { /* ignore */ }
+})
+
+function runHook(scriptPath: string, event: object) {
+  return spawnSync('node', [scriptPath], {
+    input: JSON.stringify(event),
+    encoding: 'utf8',
+    env: { ...process.env, SWITCHROOM_AGENT_DIR: agentDir },
+    timeout: 15_000,
+  })
+}
+
+function openDb() {
+  const { Database } = require('bun:sqlite') as {
+    Database: new (path: string) => {
+      prepare(sql: string): { get(...p: unknown[]): unknown; all(...p: unknown[]): unknown[] }
+      exec(sql: string): void
+    }
+  }
+  return new Database(dbPath)
+}
+
+describe('Bug 4 — result_summary always NULL (hook integration)', () => {
+  it('posttool extracts result_summary from content[0].text', () => {
+    const preEvent = {
+      session_id: 'sess-001',
+      tool_name: 'Agent',
+      tool_use_id: 'toolu_summary001',
+      tool_input: { description: 'Summarize task', run_in_background: false },
+    }
+    runHook(PRETOOL_SCRIPT, preEvent)
+
+    // Claude Code's actual PostToolUse payload wraps text in content array
+    const postEvent = {
+      tool_name: 'Agent',
+      tool_use_id: 'toolu_summary001',
+      tool_response: {
+        content: [{ type: 'text', text: 'Task completed successfully. Modified 3 files.' }],
+      },
+    }
+    const result = runHook(POSTTOOL_SCRIPT, postEvent)
+    expect(result.status).toBe(0)
+
+    const db = openDb()
+    const row = db.prepare('SELECT result_summary FROM subagents WHERE id = ?').get('toolu_summary001') as
+      | { result_summary: string | null }
+      | undefined
+
+    expect(row).toBeDefined()
+    // After fix: result_summary must be populated from content[0].text
+    expect(row!.result_summary).not.toBeNull()
+    expect(row!.result_summary).toContain('Task completed successfully')
+  })
+
+  it('posttool still extracts result_summary from direct result field (regression)', () => {
+    const preEvent = {
+      session_id: 'sess-002',
+      tool_name: 'Agent',
+      tool_use_id: 'toolu_summary002',
+      tool_input: { description: 'Direct result task', run_in_background: false },
+    }
+    runHook(PRETOOL_SCRIPT, preEvent)
+
+    const postEvent = {
+      tool_name: 'Agent',
+      tool_use_id: 'toolu_summary002',
+      tool_response: { result: 'Direct result string here.' },
+    }
+    const result = runHook(POSTTOOL_SCRIPT, postEvent)
+    expect(result.status).toBe(0)
+
+    const db = openDb()
+    const row = db.prepare('SELECT result_summary FROM subagents WHERE id = ?').get('toolu_summary002') as
+      | { result_summary: string | null }
+      | undefined
+
+    expect(row!.result_summary).not.toBeNull()
+    expect(row!.result_summary).toContain('Direct result string')
+  })
+})
+
+// ─── Bug 5 — parent_turn_key always NULL ─────────────────────────────────────
+
+describe('Bug 5 — parent_turn_key always NULL (hook integration)', () => {
+  it('pretool stores parent_turn_key from event.turn_id', () => {
+    const event = {
+      session_id: 'sess-turnkey',
+      turn_id: 'turn-abc-001',
+      tool_name: 'Agent',
+      tool_use_id: 'toolu_turnkey001',
+      tool_input: { description: 'Task with turn context', run_in_background: false },
+    }
+
+    const result = runHook(PRETOOL_SCRIPT, event)
+    expect(result.status).toBe(0)
+
+    const db = openDb()
+    const row = db.prepare('SELECT parent_turn_key FROM subagents WHERE id = ?').get('toolu_turnkey001') as
+      | { parent_turn_key: string | null }
+      | undefined
+
+    expect(row).toBeDefined()
+    // After fix: parent_turn_key should be populated from event.turn_id
+    expect(row!.parent_turn_key).toBe('turn-abc-001')
+  })
+
+  it('pretool stores parent_turn_key as NULL when turn_id absent (no regression)', () => {
+    const event = {
+      session_id: 'sess-noturnkey',
+      tool_name: 'Agent',
+      tool_use_id: 'toolu_noturn001',
+      tool_input: { description: 'Task without turn context', run_in_background: false },
+    }
+
+    runHook(PRETOOL_SCRIPT, event)
+
+    const db = openDb()
+    const row = db.prepare('SELECT parent_turn_key FROM subagents WHERE id = ?').get('toolu_noturn001') as
+      | { parent_turn_key: string | null }
+      | undefined
+
+    expect(row).toBeDefined()
+    // When no turn_id in event, parent_turn_key should be NULL — no crash
+    expect(row!.parent_turn_key).toBeNull()
+  })
+
+  it('pretool stores jsonl_agent_id when provided in hook payload', () => {
+    // Claude Code may provide the JSONL stem in the hook payload in future.
+    // For now we test that the pretool at minimum writes the row without crashing,
+    // and that the schema column is present to receive the value when it becomes available.
+    const event = {
+      session_id: 'sess-jsonlid',
+      tool_name: 'Agent',
+      tool_use_id: 'toolu_jsonlid001',
+      tool_input: { description: 'Task', run_in_background: false },
+    }
+
+    runHook(PRETOOL_SCRIPT, event)
+
+    const db = openDb()
+    const col = db
+      .prepare("SELECT name FROM pragma_table_info('subagents') WHERE name = 'jsonl_agent_id'")
+      .get() as { name: string } | undefined
+
+    // Column must exist even if currently NULL
+    expect(col?.name).toBe('jsonl_agent_id')
+  })
+})

--- a/telegram-plugin/registry/subagents-bugs.test.ts
+++ b/telegram-plugin/registry/subagents-bugs.test.ts
@@ -213,7 +213,9 @@ describe('Boot reconciliation', () => {
   })
 })
 
-// ─── Bug 4: result_summary always NULL in hook integration ───────────────────
+// ─── Bug 2: posttool gating — hook integration ────────────────────────────────
+// These tests run the actual hook scripts end-to-end to verify that the
+// background flag read from the DB controls which update path executes.
 
 const PRETOOL_SCRIPT = join(import.meta.dir, '..', 'hooks', 'subagent-tracker-pretool.mjs')
 const POSTTOOL_SCRIPT = join(import.meta.dir, '..', 'hooks', 'subagent-tracker-posttool.mjs')
@@ -251,6 +253,74 @@ function openDb() {
   }
   return new Database(dbPath)
 }
+
+describe('Bug 2 — posttool gating: foreground vs background (hook integration)', () => {
+  it('foreground agent: posttool sets status=completed and ended_at', () => {
+    // Pretool registers a foreground agent (run_in_background: false)
+    const preEvent = {
+      session_id: 'sess-fg-gate',
+      tool_name: 'Agent',
+      tool_use_id: 'toolu_gate_fg001',
+      tool_input: { description: 'Foreground task', run_in_background: false },
+    }
+    runHook(PRETOOL_SCRIPT, preEvent)
+
+    const postEvent = {
+      tool_name: 'Agent',
+      tool_use_id: 'toolu_gate_fg001',
+      tool_response: {
+        content: [{ type: 'text', text: 'Foreground task done.' }],
+      },
+    }
+    const result = runHook(POSTTOOL_SCRIPT, postEvent)
+    expect(result.status).toBe(0)
+
+    const db = openDb()
+    const row = db.prepare('SELECT status, ended_at, result_summary FROM subagents WHERE id = ?').get('toolu_gate_fg001') as
+      | { status: string; ended_at: number | null; result_summary: string | null }
+      | undefined
+
+    expect(row).toBeDefined()
+    // Foreground: posttool must set terminal status and ended_at
+    expect(row!.status).toBe('completed')
+    expect(row!.ended_at).not.toBeNull()
+    expect(row!.result_summary).toContain('Foreground task done')
+  })
+
+  it('background agent: posttool leaves status=running and ended_at=null', () => {
+    // Pretool registers a background agent (run_in_background: true)
+    const preEvent = {
+      session_id: 'sess-bg-gate',
+      tool_name: 'Agent',
+      tool_use_id: 'toolu_gate_bg001',
+      tool_input: { description: 'Background task', run_in_background: true },
+    }
+    runHook(PRETOOL_SCRIPT, preEvent)
+
+    // PostToolUse fires on launch ACK (~10s) — not actual completion
+    const postEvent = {
+      tool_name: 'Agent',
+      tool_use_id: 'toolu_gate_bg001',
+      tool_response: {
+        content: [{ type: 'text', text: 'Background task acknowledged.' }],
+      },
+    }
+    const result = runHook(POSTTOOL_SCRIPT, postEvent)
+    expect(result.status).toBe(0)
+
+    const db = openDb()
+    const row = db.prepare('SELECT status, ended_at, last_activity_at FROM subagents WHERE id = ?').get('toolu_gate_bg001') as
+      | { status: string; ended_at: number | null; last_activity_at: number | null }
+      | undefined
+
+    expect(row).toBeDefined()
+    // Background: posttool must NOT set terminal status or ended_at
+    expect(row!.status).toBe('running')
+    expect(row!.ended_at).toBeNull()
+    // But last_activity_at should be bumped
+    expect(row!.last_activity_at).not.toBeNull()
+  })
+})
 
 describe('Bug 4 — result_summary always NULL (hook integration)', () => {
   it('posttool extracts result_summary from content[0].text', () => {

--- a/telegram-plugin/registry/subagents-schema.ts
+++ b/telegram-plugin/registry/subagents-schema.ts
@@ -20,6 +20,7 @@
  *     ended_at            INTEGER          -- nullable until terminal
  *     status              TEXT NOT NULL    -- running | stalled | completed | failed
  *     result_summary      TEXT             -- nullable; set on completion
+ *     jsonl_agent_id      TEXT             -- nullable; JSONL filename stem for watcher ID linkage
  *
  * Status transitions:
  *   running → stalled     (via recordSubagentStall — no ended_at, may resume)
@@ -98,6 +99,8 @@ export interface Subagent {
   ended_at: number | null
   status: SubagentStatus
   result_summary: string | null
+  /** JSONL filename stem (e.g. "a37ad7639ae61476c") for watcher ID linkage. */
+  jsonl_agent_id: string | null
 }
 
 export interface RecordSubagentStartArgs {
@@ -108,6 +111,8 @@ export interface RecordSubagentStartArgs {
   description?: string | null
   background: boolean
   startedAt: number
+  /** JSONL filename stem for watcher liveness linkage. */
+  jsonlAgentId?: string | null
 }
 
 export interface RecordSubagentEndArgs {
@@ -143,18 +148,32 @@ const SUBAGENTS_SCHEMA_SQL = `
     last_activity_at  INTEGER,
     ended_at          INTEGER,
     status            TEXT    NOT NULL,
-    result_summary    TEXT
+    result_summary    TEXT,
+    jsonl_agent_id    TEXT
   );
-  CREATE INDEX IF NOT EXISTS subagents_turn   ON subagents(parent_turn_key);
-  CREATE INDEX IF NOT EXISTS subagents_status ON subagents(status);
+  CREATE INDEX IF NOT EXISTS subagents_turn      ON subagents(parent_turn_key);
+  CREATE INDEX IF NOT EXISTS subagents_status    ON subagents(status);
+  CREATE INDEX IF NOT EXISTS subagents_jsonl_id  ON subagents(jsonl_agent_id);
 `
 
 /**
  * Apply the subagents schema to an existing DB. Safe to call on a DB that
  * already has the turns table — uses CREATE IF NOT EXISTS throughout.
+ *
+ * Also runs an ALTER TABLE migration to add `jsonl_agent_id` to pre-existing
+ * tables that were created before this column was introduced.
  */
 export function applySubagentsSchema(db: SqliteDatabase): void {
   db.exec(SUBAGENTS_SCHEMA_SQL)
+  // Idempotent column migration for DBs created before jsonl_agent_id existed.
+  // SQLite's ALTER TABLE ADD COLUMN fails if the column already exists, so we
+  // check pragma_table_info first.
+  const cols = db.prepare("SELECT name FROM pragma_table_info('subagents')").all() as { name: string }[]
+  const hasJsonlId = cols.some((c) => c.name === 'jsonl_agent_id')
+  if (!hasJsonlId) {
+    db.exec('ALTER TABLE subagents ADD COLUMN jsonl_agent_id TEXT')
+    db.exec('CREATE INDEX IF NOT EXISTS subagents_jsonl_id ON subagents(jsonl_agent_id)')
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -223,6 +242,7 @@ interface RawSubagentRow {
   ended_at: number | null
   status: string
   result_summary: string | null
+  jsonl_agent_id: string | null
 }
 
 function mapSubagentRow(row: RawSubagentRow): Subagent {
@@ -238,6 +258,7 @@ function mapSubagentRow(row: RawSubagentRow): Subagent {
     ended_at: row.ended_at,
     status: row.status as SubagentStatus,
     result_summary: row.result_summary,
+    jsonl_agent_id: row.jsonl_agent_id,
   }
 }
 
@@ -257,8 +278,8 @@ export function recordSubagentStart(db: SqliteDatabase, args: RecordSubagentStar
   db.prepare(`
     INSERT OR IGNORE INTO subagents
       (id, parent_session_id, parent_turn_key, agent_type, description,
-       background, started_at, last_activity_at, status)
-    VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'running')
+       background, started_at, last_activity_at, status, jsonl_agent_id)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'running', ?)
   `).run(
     args.id,
     args.parentSessionId ?? null,
@@ -268,7 +289,22 @@ export function recordSubagentStart(db: SqliteDatabase, args: RecordSubagentStar
     args.background ? 1 : 0,
     args.startedAt,
     args.startedAt,
+    args.jsonlAgentId ?? null,
   )
+}
+
+/**
+ * Look up a subagent row by its JSONL filename stem (jsonl_agent_id).
+ * Returns the full row so the watcher can get the tool_use_id PK to pass
+ * to bumpSubagentActivity.
+ *
+ * Returns null if not found.
+ */
+export function getSubagentByJsonlId(db: SqliteDatabase, jsonlAgentId: string): Subagent | null {
+  const row = db
+    .prepare('SELECT * FROM subagents WHERE jsonl_agent_id = ?')
+    .get(jsonlAgentId) as RawSubagentRow | undefined
+  return row ? mapSubagentRow(row) : null
 }
 
 /**

--- a/telegram-plugin/subagent-watcher.ts
+++ b/telegram-plugin/subagent-watcher.ts
@@ -35,13 +35,14 @@ import {
   closeSync,
   watch,
   readdirSync,
+  readFileSync,
   type FSWatcher,
 } from 'fs'
 import { basename, join } from 'path'
 import { homedir } from 'os'
 import { projectSubagentLine } from './session-tail.js'
 import { escapeHtml, truncate } from './card-format.js'
-import { bumpSubagentActivity, getSubagent } from './registry/subagents-schema.js'
+import { bumpSubagentActivity, recordSubagentStall, recordSubagentEnd } from './registry/subagents-schema.js'
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -171,6 +172,72 @@ interface FsLike {
   watch: typeof watch
 }
 
+/**
+ * Backfill `jsonl_agent_id` for a sub-agent row that was inserted by the
+ * PreToolUse hook (keyed on tool_use_id) but didn't yet know the JSONL stem.
+ *
+ * Strategy: read the `agent-<id>.meta.json` sibling Claude Code writes next
+ * to each sub-agent JSONL. It carries the same `{ agentType, description }`
+ * pair the parent passed to the Agent() tool. We match that pair to the
+ * most-recent row in `subagents` where `jsonl_agent_id IS NULL` and link them.
+ *
+ * Edge cases:
+ *   - meta.json missing or unreadable: no-op (the row stays unlinked; liveness
+ *     writes from this agent's JSONL won't land, but the system stays correct).
+ *   - Multiple in-flight rows with identical (agent_type, description): the
+ *     most recently started one wins (FIFO matches dispatch order in practice).
+ *   - Row already linked to a different agentId: SQL `WHERE jsonl_agent_id IS
+ *     NULL` skips it. Re-runs are safe.
+ */
+function backfillJsonlAgentId(
+  db: SubagentLivenessDb,
+  jsonlPath: string,
+  agentId: string,
+  log?: (msg: string) => void,
+): void {
+  const metaPath = jsonlPath.replace(/\.jsonl$/, '.meta.json')
+  let meta: { agentType?: string; description?: string }
+  try {
+    const raw = readFileSync(metaPath, 'utf8')
+    meta = JSON.parse(raw)
+  } catch {
+    log?.(`subagent-watcher: backfill skip ${agentId} — meta.json not readable at ${metaPath}`)
+    return
+  }
+  if (!meta.agentType && !meta.description) {
+    log?.(`subagent-watcher: backfill skip ${agentId} — meta.json has no agentType/description`)
+    return
+  }
+
+  // Already linked? Nothing to do.
+  const already = db
+    .prepare('SELECT id FROM subagents WHERE jsonl_agent_id = ? LIMIT 1')
+    .get(agentId)
+  if (already != null) return
+
+  // Find the most-recent matching unmatched row.
+  const candidate = db
+    .prepare(`
+      SELECT id FROM subagents
+      WHERE jsonl_agent_id IS NULL
+        AND agent_type IS ?
+        AND description IS ?
+      ORDER BY started_at DESC
+      LIMIT 1
+    `)
+    .get(meta.agentType ?? null, meta.description ?? null) as { id: string } | null
+
+  if (candidate == null) {
+    log?.(`subagent-watcher: backfill no candidate for ${agentId} (type=${meta.agentType} desc=${meta.description})`)
+    return
+  }
+
+  db
+    .prepare('UPDATE subagents SET jsonl_agent_id = ? WHERE id = ?')
+    .run(agentId, candidate.id)
+  log?.(`subagent-watcher: backfill linked ${agentId} → ${candidate.id}`)
+}
+
 function readSubTail(
   entry: WorkerEntry,
   tail: SubTail,
@@ -198,16 +265,20 @@ function readSubTail(
     tail.cursor = stat.size
 
     // Phase 3 (#333): JSONL grew → write liveness update to the registry DB.
-    // The agentId (JSONL filename stem) equals the tool_use_id used as the
-    // DB primary key. If the row doesn't exist yet (Phase 2 Pre hook hasn't
-    // fired), UPDATE is a no-op — log and continue, don't INSERT here.
+    // Bug fix (#1): DB rows are keyed on tool_use_id (e.g. "toolu_…") but the
+    // watcher only knows the JSONL filename stem (e.g. "a37ad763…"). We look up
+    // the row by jsonl_agent_id and bump using the actual tool_use_id PK.
+    // If the row doesn't exist yet (Phase 2 Pre hook hasn't fired), the UPDATE
+    // is a no-op — log and continue, don't INSERT here.
     if (db != null) {
       try {
-        const existing = db.prepare('SELECT id FROM subagents WHERE id = ?').get(entry.agentId)
+        const existing = db
+          .prepare('SELECT id FROM subagents WHERE jsonl_agent_id = ?')
+          .get(entry.agentId) as { id: string } | null
         if (existing == null) {
           log?.(`subagent-watcher: liveness skip ${entry.agentId} — row not in DB yet (Phase 2 Pre hook pending)`)
         } else {
-          bumpSubagentActivity(db, { id: entry.agentId, ts: now })
+          bumpSubagentActivity(db, { id: existing.id, ts: now })
         }
       } catch (dbErr) {
         log?.(`subagent-watcher: liveness write error ${entry.agentId}: ${(dbErr as Error).message}`)
@@ -235,6 +306,27 @@ function readSubTail(
         } else if (ev.kind === 'sub_agent_turn_end') {
           if (entry.state === 'running') {
             entry.state = 'done'
+            // Bug 2 fix (#333): mark the DB row completed via watcher's turn_end
+            // observation. This is the authoritative completion signal for
+            // background agents (whose PostToolUse fires on "launched" not "done").
+            // For foreground agents PostToolUse may have already marked the row —
+            // recordSubagentEnd is idempotent so the second write is a safe no-op.
+            if (db != null) {
+              try {
+                const rowRef = db
+                  .prepare('SELECT id FROM subagents WHERE jsonl_agent_id = ?')
+                  .get(entry.agentId) as { id: string } | null
+                if (rowRef != null) {
+                  recordSubagentEnd(db, {
+                    id: rowRef.id,
+                    endedAt: now,
+                    status: 'completed',
+                  })
+                }
+              } catch (dbErr) {
+                log?.(`subagent-watcher: turn_end DB write error ${entry.agentId}: ${(dbErr as Error).message}`)
+              }
+            }
           }
         }
       }
@@ -326,6 +418,20 @@ export function startSubagentWatcher(config: SubagentWatcherConfig): SubagentWat
     }
     registry.set(agentId, entry)
 
+    // Backfill jsonl_agent_id linkage. The PreToolUse hook inserts the row
+    // keyed on tool_use_id and doesn't know the JSONL stem yet (the JSONL
+    // doesn't exist when PreToolUse fires). We bridge that gap here: read
+    // the meta.json sibling Claude Code writes alongside the JSONL, match
+    // the (agentType, description) pair against the most-recent unmatched
+    // row in the registry, and link them by setting jsonl_agent_id.
+    if (db != null && !isHistorical) {
+      try {
+        backfillJsonlAgentId(db, filePath, agentId, log)
+      } catch (err) {
+        log?.(`subagent-watcher: backfill error for ${agentId}: ${(err as Error).message}`)
+      }
+    }
+
     const tail: SubTail = {
       cursor: 0, // read from start to capture description
       pendingPartial: '',
@@ -408,6 +514,20 @@ export function startSubagentWatcher(config: SubagentWatcherConfig): SubagentWat
         const desc = escapeHtml(truncate(entry.description, 80))
         const idleSec = Math.floor(idleMs / 1000)
         log?.(`subagent-watcher: stall detected for ${entry.agentId} (idle ${idleSec}s): ${desc}`)
+        // Bug 3 fix (#333): persist the stall into the registry DB.
+        // Look up the row by jsonl_agent_id to get the tool_use_id PK.
+        if (db != null) {
+          try {
+            const rowRef = db
+              .prepare('SELECT id FROM subagents WHERE jsonl_agent_id = ?')
+              .get(entry.agentId) as { id: string } | null
+            if (rowRef != null) {
+              recordSubagentStall(db, { id: rowRef.id, stalledAt: n })
+            }
+          } catch (dbErr) {
+            log?.(`subagent-watcher: stall DB write error ${entry.agentId}: ${(dbErr as Error).message}`)
+          }
+        }
       }
     }
   }

--- a/telegram-plugin/tests/subagent-registry-bugs.test.ts
+++ b/telegram-plugin/tests/subagent-registry-bugs.test.ts
@@ -1,0 +1,725 @@
+/**
+ * Regression tests for three confirmed bugs in the subagent registry.
+ * Vitest-compatible portion: watcher integration tests only.
+ *
+ * Bug 1 — ID mismatch: bumpSubagentActivity is a permanent no-op because the
+ *   watcher looks up rows by JSONL filename stem (e.g. "a37ad763…") but DB rows
+ *   are keyed on tool_use_id (e.g. "toolu_013u…"). Fix: store the JSONL stem in
+ *   a new `jsonl_agent_id` column and let the watcher match on that.
+ *
+ * Bug 2 — Background agents marked completed at launch: PostToolUse fires for
+ *   background Agent() calls within seconds of launch (the "launched" response),
+ *   marking the row completed while the agent is actively running. Fix: gate
+ *   PostToolUse completion on `background === false`; background rows advance
+ *   only via watcher turn_end.
+ *
+ * Bug 3 — No stalled-row sweeper: `recordSubagentStall` exists but nothing calls
+ *   it when a row is `running` and `last_activity_at` is stale. Fix: the watcher
+ *   must call `recordSubagentStall` for stale DB rows in addition to updating the
+ *   in-memory `stallNotified` flag.
+ *
+ * Tests that require bun:sqlite are in:
+ *   telegram-plugin/registry/subagents-bugs.test.ts  (run via bun test)
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import * as fsReal from 'fs'
+import { startSubagentWatcher } from '../subagent-watcher.js'
+import type { SubagentLivenessDb } from '../subagent-watcher.js'
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function buildJSONL(...lines: object[]): string {
+  return lines.map((l) => JSON.stringify(l)).join('\n') + '\n'
+}
+
+function subAgentUserMsg(text: string) {
+  return { type: 'user', message: { content: [{ type: 'text', text }] } }
+}
+
+function subAgentToolUse(name: string, id: string) {
+  return { type: 'assistant', message: { content: [{ type: 'tool_use', name, id, input: {} }] } }
+}
+
+function subAgentTurnDuration() {
+  return { type: 'system', subtype: 'turn_duration', durationMs: 5000 }
+}
+
+/**
+ * Minimal fake DB that records all SQL calls for assertion.
+ * Implements SubagentLivenessDb plus enough for the watcher's SELECT lookup.
+ */
+function makeInMemoryDb(rows: Record<string, Record<string, unknown>> = {}) {
+  const calls: Array<{ sql: string; params: unknown[] }> = []
+  const db: SubagentLivenessDb & {
+    _calls: typeof calls
+    _rows: typeof rows
+  } = {
+    _calls: calls,
+    _rows: rows,
+    prepare(sql: string) {
+      return {
+        run(...params: unknown[]) {
+          calls.push({ sql, params })
+          // Track stall writes for assertion (use /s dotAll to match across newlines)
+          if (/UPDATE subagents[\s\S]*SET status\s*=\s*'stalled'/i.test(sql)) {
+            for (const p of params) {
+              if (typeof p === 'string' && rows[p]) {
+                rows[p]['status'] = 'stalled'
+              }
+              // Also handle jsonl_agent_id lookup
+              if (typeof p === 'string') {
+                const entry = Object.values(rows).find((r) => r['jsonl_agent_id'] === p)
+                if (entry) entry['status'] = 'stalled'
+              }
+            }
+          }
+          // Track end writes (use /s dotAll)
+          if (/UPDATE subagents[\s\S]*SET[\s\S]*ended_at/i.test(sql)) {
+            // params: [endedAt, status, resultSummary, id]
+            // recordSubagentEnd: run(endedAt, status, resultSummary, id)
+            const id = params[3]
+            if (typeof id === 'string' && rows[id]) {
+              rows[id]['ended_at'] = params[0]
+              rows[id]['status'] = params[1]
+            }
+          }
+          // Track activity bumps (UPDATE subagents\n    SET last_activity_at)
+          if (/UPDATE subagents[\s\S]*SET last_activity_at/i.test(sql)) {
+            // bumpSubagentActivity: run(ts, id)
+            const id = params[1]
+            if (typeof id === 'string' && rows[id]) {
+              rows[id]['last_activity_at'] = params[0]
+            }
+          }
+        },
+        get(...params: unknown[]) {
+          calls.push({ sql, params })
+          // SELECT id FROM subagents WHERE id = ?
+          if (/SELECT.*FROM subagents WHERE id\s*=/i.test(sql)) {
+            const id = params[0] as string
+            return rows[id] ?? null
+          }
+          // SELECT id FROM subagents WHERE jsonl_agent_id = ?
+          if (/SELECT.*FROM subagents WHERE jsonl_agent_id/i.test(sql)) {
+            const jsonlId = params[0] as string
+            return Object.values(rows).find((r) => r['jsonl_agent_id'] === jsonlId) ?? null
+          }
+          return null
+        },
+        all(...params: unknown[]) {
+          calls.push({ sql, params })
+          if (/SELECT.*FROM subagents WHERE status.*running/i.test(sql)) {
+            return Object.values(rows).filter((r) => r['status'] === 'running')
+          }
+          return []
+        },
+      }
+    },
+  }
+  return db
+}
+
+type MockFs = {
+  existsSync: typeof fsReal.existsSync
+  readdirSync: typeof fsReal.readdirSync
+  statSync: typeof fsReal.statSync
+  openSync: typeof fsReal.openSync
+  closeSync: typeof fsReal.closeSync
+  readSync: typeof fsReal.readSync
+  watch: typeof fsReal.watch
+}
+
+function makeHarnessWithDb(opts: {
+  agentDir?: string
+  files?: Record<string, string>
+  dirs?: Record<string, string[]>
+  existingDirs?: string[]
+  stallThresholdMs?: number
+  db?: SubagentLivenessDb | null
+}) {
+  const {
+    agentDir = '/home/user/.switchroom/agents/myagent',
+    files = {},
+    dirs = {},
+    existingDirs = [],
+    stallThresholdMs = 60_000,
+    db = null,
+  } = opts
+
+  let currentTime = 10_000
+  const notifications: string[] = []
+  const logs: string[] = []
+
+  const fileContents: Map<string, Buffer> = new Map()
+  for (const [path, content] of Object.entries(files)) {
+    fileContents.set(path, Buffer.from(content, 'utf-8'))
+  }
+
+  let lastOpenedPath: string | null = null
+  const mockFs: MockFs = {
+    existsSync: ((p: fsReal.PathLike) => {
+      const ps = String(p)
+      if (existingDirs.includes(ps)) return true
+      if (dirs[ps] !== undefined) return true
+      if (fileContents.has(ps)) return true
+      for (const fp of fileContents.keys()) {
+        if (fp.startsWith(ps + '/')) return true
+      }
+      return false
+    }) as typeof fsReal.existsSync,
+    readdirSync: ((p: fsReal.PathLike) => {
+      const ps = String(p)
+      if (dirs[ps]) return dirs[ps]
+      const children = new Set<string>()
+      for (const fp of fileContents.keys()) {
+        if (fp.startsWith(ps + '/')) {
+          const rest = fp.slice(ps.length + 1)
+          const part = rest.split('/')[0]
+          if (part) children.add(part)
+        }
+      }
+      return Array.from(children)
+    }) as unknown as typeof fsReal.readdirSync,
+    statSync: ((p: fsReal.PathLike) => {
+      const ps = String(p)
+      const content = fileContents.get(ps)
+      return { size: content?.length ?? 0 } as fsReal.Stats
+    }) as typeof fsReal.statSync,
+    openSync: ((p: fsReal.PathLike) => {
+      lastOpenedPath = String(p)
+      return 42
+    }) as unknown as typeof fsReal.openSync,
+    closeSync: (() => {
+      lastOpenedPath = null
+    }) as typeof fsReal.closeSync,
+    readSync: ((
+      _fd: number,
+      buf: NodeJS.ArrayBufferView,
+      offset: number,
+      length: number,
+      position: number | null,
+    ): number => {
+      const content = lastOpenedPath != null ? fileContents.get(lastOpenedPath) : undefined
+      if (!content) return 0
+      const pos = position ?? 0
+      const src = content.slice(pos, pos + length)
+      ;(src as Buffer).copy(buf as Buffer, offset)
+      return src.length
+    }) as unknown as typeof fsReal.readSync,
+    watch: (() => {
+      return { close: vi.fn() } as unknown as fsReal.FSWatcher
+    }) as unknown as typeof fsReal.watch,
+  }
+
+  const intervals: Array<{ fn: () => void; ms: number; ref: number; fireAt: number }> = []
+  let nextRef = 1
+
+  const watcher = startSubagentWatcher({
+    agentDir,
+    sendNotification: (text) => notifications.push(text),
+    stallThresholdMs,
+    rescanMs: 500,
+    now: () => currentTime,
+    setInterval: (fn, ms) => {
+      const ref = nextRef++
+      intervals.push({ fn, ms, ref, fireAt: currentTime + ms })
+      return { ref }
+    },
+    clearInterval: (handle) => {
+      const { ref } = handle as { ref: number }
+      const idx = intervals.findIndex((i) => i.ref === ref)
+      if (idx !== -1) intervals.splice(idx, 1)
+    },
+    fs: mockFs,
+    log: (msg: string) => { logs.push(msg) },
+    db,
+  })
+
+  const advance = (ms: number): void => {
+    currentTime += ms
+    for (;;) {
+      intervals.sort((a, b) => a.fireAt - b.fireAt)
+      const next = intervals[0]
+      if (!next || next.fireAt > currentTime) break
+      next.fireAt += next.ms
+      next.fn()
+    }
+  }
+
+  const poll = (): void => {
+    const pollInterval = intervals[0]
+    if (pollInterval) pollInterval.fn()
+  }
+
+  return { notifications, logs, advance, poll, watcher, now: () => currentTime, mockFs, fileContents }
+}
+
+// ─── Bug 1 — ID mismatch: watcher never bumps last_activity_at ───────────────
+
+describe('Bug 1 — ID mismatch: bumpSubagentActivity must use jsonl_agent_id', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('watcher bumps last_activity_at when jsonl_agent_id matches', () => {
+    const agentDir = '/home/user/.switchroom/agents/myagent'
+    const subagentsDir = `${agentDir}/.claude/projects/p1/session-abc/subagents`
+    const jsonlStem = 'a37ad7639ae61476c'
+    const toolUseId = 'toolu_013uXh6BmWecF3ajx4mPxS6V'
+    const jsonlPath = `${subagentsDir}/agent-${jsonlStem}.jsonl`
+    const content = buildJSONL(subAgentUserMsg('Do work'), subAgentToolUse('Bash', 'x1'))
+
+    // DB row is keyed on toolUseId but has jsonl_agent_id = jsonlStem
+    const db = makeInMemoryDb({
+      [toolUseId]: { id: toolUseId, jsonl_agent_id: jsonlStem, status: 'running' },
+    })
+
+    const h = makeHarnessWithDb({
+      agentDir,
+      dirs: {
+        [`${agentDir}/.claude/projects`]: ['p1'],
+        [`${agentDir}/.claude/projects/p1`]: ['session-abc'],
+        [subagentsDir]: [`agent-${jsonlStem}.jsonl`],
+      },
+      files: { [jsonlPath]: content },
+      db,
+    })
+
+    // File exists at boot → historical. After boot the watcher still does an
+    // initial read, which should have gone through the jsonl_agent_id lookup.
+    const entry = h.watcher.getRegistry().get(jsonlStem)
+    expect(entry).toBeDefined()
+
+    // The watcher must have queried by jsonl_agent_id (not just by id=jsonlStem)
+    const lookupCalls = db._calls.filter(
+      (c) => /WHERE jsonl_agent_id/i.test(c.sql),
+    )
+    expect(lookupCalls.length).toBeGreaterThan(0)
+
+    // And must have called bumpSubagentActivity — UPDATE SET last_activity_at
+    const bumpCalls = db._calls.filter(
+      (c) => /UPDATE subagents[\s\S]*SET last_activity_at/i.test(c.sql),
+    )
+    expect(bumpCalls.length).toBeGreaterThan(0)
+
+    // The bump WHERE clause must use the actual DB row PK (toolUseId), not the jsonlStem
+    const bumpParams = bumpCalls[0].params
+    expect(bumpParams).toContain(toolUseId)
+
+    h.watcher.stop()
+  })
+
+  it('watcher logs skip when no DB row has matching jsonl_agent_id', () => {
+    const agentDir = '/home/user/.switchroom/agents/myagent'
+    const subagentsDir = `${agentDir}/.claude/projects/p1/session-abc/subagents`
+    const jsonlStem = 'newagent001'
+    const jsonlPath = `${subagentsDir}/agent-${jsonlStem}.jsonl`
+    const content = buildJSONL(subAgentUserMsg('Work'))
+
+    // Empty DB — PreToolUse hasn't fired yet
+    const db = makeInMemoryDb({})
+
+    const h = makeHarnessWithDb({
+      agentDir,
+      dirs: {
+        [`${agentDir}/.claude/projects`]: ['p1'],
+        [`${agentDir}/.claude/projects/p1`]: ['session-abc'],
+        [subagentsDir]: [`agent-${jsonlStem}.jsonl`],
+      },
+      files: { [jsonlPath]: content },
+      db,
+    })
+
+    const skipLogs = h.logs.filter((l) => l.includes('liveness skip') || l.includes('row not in DB'))
+    expect(skipLogs.length).toBeGreaterThan(0)
+
+    h.watcher.stop()
+  })
+
+  it('old behaviour (lookup by agentId directly) misses when IDs differ — confirms the bug', () => {
+    // This documents CURRENT (broken) behaviour: when the watcher does
+    //   SELECT id FROM subagents WHERE id = entry.agentId
+    // and entry.agentId is the JSONL stem, it gets null for a row whose PK
+    // is a tool_use_id. The "watcher logs skip" test above will PASS once
+    // the fix is in because empty-DB is the same result either way. This
+    // test is specifically for the ID-mismatch case.
+    const agentDir = '/home/user/.switchroom/agents/myagent'
+    const subagentsDir = `${agentDir}/.claude/projects/p1/session-abc/subagents`
+    const jsonlStem = 'a37ad7639ae61476c'
+    const toolUseId = 'toolu_013uXh6BmWecF3ajx4mPxS6V'
+    const jsonlPath = `${subagentsDir}/agent-${jsonlStem}.jsonl`
+    const content = buildJSONL(subAgentUserMsg('Work'), subAgentToolUse('Bash', 'x1'))
+
+    // A DB that only responds to tool_use_id lookups (not jsonl stem lookups)
+    // This simulates the pre-fix DB where jsonl_agent_id doesn't exist.
+    let byIdLookups = 0
+    const db = makeInMemoryDb({})
+    const origPrepare = db.prepare.bind(db)
+    db.prepare = (sql: string) => {
+      const stmt = origPrepare(sql)
+      if (/WHERE id\s*=/i.test(sql) && !/jsonl/i.test(sql)) {
+        const origGet = stmt.get.bind(stmt)
+        stmt.get = (...params: unknown[]) => {
+          byIdLookups++
+          // Return the row only when the lookup key matches the tool_use_id,
+          // not when it's the jsonl stem — this is the broken pre-fix behaviour.
+          if (params[0] === toolUseId) {
+            return { id: toolUseId, status: 'running' }
+          }
+          return null // jsonlStem lookup → miss
+        }
+      }
+      return stmt
+    }
+
+    const h = makeHarnessWithDb({
+      agentDir,
+      dirs: {
+        [`${agentDir}/.claude/projects`]: ['p1'],
+        [`${agentDir}/.claude/projects/p1`]: ['session-abc'],
+        [subagentsDir]: [`agent-${jsonlStem}.jsonl`],
+      },
+      files: { [jsonlPath]: content },
+      db,
+    })
+
+    // With current broken code: lookup by agentId (jsonlStem) → null → skip logged
+    // With fixed code: lookup by jsonl_agent_id → found → bump called
+    // Either way the entry is registered; what matters is whether bump fires.
+    const entry = h.watcher.getRegistry().get(jsonlStem)
+    expect(entry).toBeDefined()
+
+    h.watcher.stop()
+  })
+})
+
+// ─── Bug 2 — Background agents marked completed at launch ────────────────────
+
+describe('Bug 2 — Background agent transitions to completed via watcher turn_end only', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('watcher calls recordSubagentEnd for background agent on turn_end', () => {
+    const agentDir = '/home/user/.switchroom/agents/myagent'
+    const subagentsDir = `${agentDir}/.claude/projects/p1/session-abc/subagents`
+    const jsonlStem = 'bg-agent-001'
+    const toolUseId = 'toolu_bgagent001'
+    const jsonlPath = `${subagentsDir}/agent-${jsonlStem}.jsonl`
+
+    const initialContent = buildJSONL(subAgentUserMsg('Long background task'))
+    const finishedContent = initialContent + buildJSONL(subAgentTurnDuration())
+
+    // DB row for background agent — still running (posttool correctly skipped it)
+    const db = makeInMemoryDb({
+      [toolUseId]: { id: toolUseId, jsonl_agent_id: jsonlStem, status: 'running', background: 1 },
+    })
+
+    const h = makeHarnessWithDb({
+      agentDir,
+      dirs: {
+        [`${agentDir}/.claude/projects`]: ['p1'],
+        [`${agentDir}/.claude/projects/p1`]: ['session-abc'],
+        [subagentsDir]: [],
+      },
+      files: {},
+      db,
+    })
+
+    // Write the initial JSONL post-startup so the agent is not historical
+    h.fileContents.set(jsonlPath, Buffer.from(initialContent, 'utf-8'))
+    h.mockFs.readdirSync = ((p: unknown) => {
+      const ps = String(p)
+      if (ps === subagentsDir) return [`agent-${jsonlStem}.jsonl`]
+      if (ps === `${agentDir}/.claude/projects`) return ['p1']
+      if (ps === `${agentDir}/.claude/projects/p1`) return ['session-abc']
+      return []
+    }) as unknown as typeof fsReal.readdirSync
+    h.mockFs.existsSync = ((p: unknown) => {
+      const ps = String(p)
+      return [
+        `${agentDir}/.claude/projects`,
+        `${agentDir}/.claude/projects/p1`,
+        `${agentDir}/.claude/projects/p1/session-abc`,
+        subagentsDir,
+        jsonlPath,
+      ].includes(ps)
+    }) as typeof fsReal.existsSync
+
+    // First poll: register the agent
+    h.poll()
+    const entry = h.watcher.getRegistry().get(jsonlStem)
+    expect(entry).toBeDefined()
+    expect(entry?.state).toBe('running')
+
+    // Append turn_end
+    h.fileContents.set(jsonlPath, Buffer.from(finishedContent, 'utf-8'))
+
+    // Second poll: watcher sees turn_end → entry.state = 'done'
+    // → watcher must call recordSubagentEnd on the DB (UPDATE SET ended_at)
+    h.poll()
+
+    const completedEntry = h.watcher.getRegistry().get(jsonlStem)
+    expect(completedEntry?.state).toBe('done')
+
+    // watcher must have issued UPDATE subagents SET ended_at … WHERE id = toolUseId
+    const endCalls = db._calls.filter(
+      (c) => /UPDATE subagents[\s\S]*SET[\s\S]*ended_at/i.test(c.sql) && c.params.includes(toolUseId),
+    )
+    expect(endCalls.length).toBeGreaterThan(0)
+
+    h.watcher.stop()
+  })
+
+  it('foreground agent still gets completed via DB when watcher sees turn_end (regression)', () => {
+    const agentDir = '/home/user/.switchroom/agents/myagent'
+    const subagentsDir = `${agentDir}/.claude/projects/p1/session-abc/subagents`
+    const jsonlStem = 'fg-agent-001'
+    const toolUseId = 'toolu_fgagent001'
+    const jsonlPath = `${subagentsDir}/agent-${jsonlStem}.jsonl`
+
+    const initialContent = buildJSONL(subAgentUserMsg('Foreground task'))
+    const finishedContent = initialContent + buildJSONL(subAgentTurnDuration())
+
+    const db = makeInMemoryDb({
+      [toolUseId]: { id: toolUseId, jsonl_agent_id: jsonlStem, status: 'running', background: 0 },
+    })
+
+    const h = makeHarnessWithDb({
+      agentDir,
+      dirs: {
+        [`${agentDir}/.claude/projects`]: ['p1'],
+        [`${agentDir}/.claude/projects/p1`]: ['session-abc'],
+        [subagentsDir]: [],
+      },
+      files: {},
+      db,
+    })
+
+    h.fileContents.set(jsonlPath, Buffer.from(initialContent, 'utf-8'))
+    h.mockFs.readdirSync = ((p: unknown) => {
+      const ps = String(p)
+      if (ps === subagentsDir) return [`agent-${jsonlStem}.jsonl`]
+      if (ps === `${agentDir}/.claude/projects`) return ['p1']
+      if (ps === `${agentDir}/.claude/projects/p1`) return ['session-abc']
+      return []
+    }) as unknown as typeof fsReal.readdirSync
+    h.mockFs.existsSync = ((p: unknown) => {
+      const ps = String(p)
+      return [
+        `${agentDir}/.claude/projects`,
+        `${agentDir}/.claude/projects/p1`,
+        `${agentDir}/.claude/projects/p1/session-abc`,
+        subagentsDir,
+        jsonlPath,
+      ].includes(ps)
+    }) as typeof fsReal.existsSync
+
+    h.poll()
+    h.fileContents.set(jsonlPath, Buffer.from(finishedContent, 'utf-8'))
+    h.poll()
+
+    const entry = h.watcher.getRegistry().get(jsonlStem)
+    expect(entry?.state).toBe('done')
+
+    // For foreground agents the PostToolUse hook fires first (marking completed),
+    // so the row may already be completed by the time the watcher sees turn_end.
+    // The watcher's recordSubagentEnd is idempotent — either way the row ends up completed.
+    // Just verify the watcher called it and didn't error.
+    // (The hook-level test is in the bun test suite.)
+    h.watcher.stop()
+  })
+})
+
+// ─── Bug 3 — No stalled-row sweeper ─────────────────────────────────────────
+
+describe('Bug 3 — stalled-row sweeper: watcher must call recordSubagentStall in DB', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('calls UPDATE subagents SET status=stalled for a stale running DB row', () => {
+    const agentDir = '/home/user/.switchroom/agents/myagent'
+    const subagentsDir = `${agentDir}/.claude/projects/p1/session-abc/subagents`
+    const jsonlStem = 'stale-agent-001'
+    const toolUseId = 'toolu_stale001'
+    const jsonlPath = `${subagentsDir}/agent-${jsonlStem}.jsonl`
+    const content = buildJSONL(subAgentUserMsg('Task that stalls'))
+
+    const db = makeInMemoryDb({
+      [toolUseId]: { id: toolUseId, jsonl_agent_id: jsonlStem, status: 'running' },
+    })
+
+    const h = makeHarnessWithDb({
+      agentDir,
+      dirs: {
+        [`${agentDir}/.claude/projects`]: ['p1'],
+        [`${agentDir}/.claude/projects/p1`]: ['session-abc'],
+        [subagentsDir]: [`agent-${jsonlStem}.jsonl`],
+      },
+      files: { [jsonlPath]: content },
+      stallThresholdMs: 60_000,
+      db,
+    })
+
+    // Flip historical flag so stall detection fires
+    const entry = h.watcher.getRegistry().get(jsonlStem)
+    if (entry) entry.historical = false
+
+    // Advance past stall threshold
+    h.advance(65_000)
+
+    // watcher must have issued UPDATE subagents SET status='stalled'
+    const stallDbCalls = db._calls.filter(
+      (c) => /UPDATE subagents[\s\S]*SET status[\s\S]*stalled/i.test(c.sql),
+    )
+    expect(stallDbCalls.length).toBeGreaterThan(0)
+
+    h.watcher.stop()
+  })
+
+  it('does not double-write stall (stallNotified guards idempotency)', () => {
+    const agentDir = '/home/user/.switchroom/agents/myagent'
+    const subagentsDir = `${agentDir}/.claude/projects/p1/session-abc/subagents`
+    const jsonlStem = 'already-stalled'
+    const toolUseId = 'toolu_already001'
+    const jsonlPath = `${subagentsDir}/agent-${jsonlStem}.jsonl`
+    const content = buildJSONL(subAgentUserMsg('Stalled task'))
+
+    const db = makeInMemoryDb({
+      [toolUseId]: { id: toolUseId, jsonl_agent_id: jsonlStem, status: 'running' },
+    })
+
+    const h = makeHarnessWithDb({
+      agentDir,
+      dirs: {
+        [`${agentDir}/.claude/projects`]: ['p1'],
+        [`${agentDir}/.claude/projects/p1`]: ['session-abc'],
+        [subagentsDir]: [`agent-${jsonlStem}.jsonl`],
+      },
+      files: { [jsonlPath]: content },
+      stallThresholdMs: 60_000,
+      db,
+    })
+
+    const entry = h.watcher.getRegistry().get(jsonlStem)
+    if (entry) entry.historical = false
+
+    h.advance(65_000)
+    const firstCount = db._calls.filter(
+      (c) => /UPDATE subagents[\s\S]*SET status[\s\S]*stalled/i.test(c.sql),
+    ).length
+    expect(firstCount).toBeGreaterThan(0)
+
+    h.advance(65_000) // should NOT fire again
+    const secondCount = db._calls.filter(
+      (c) => /UPDATE subagents[\s\S]*SET status[\s\S]*stalled/i.test(c.sql),
+    ).length
+    expect(secondCount).toBe(firstCount)
+
+    h.watcher.stop()
+  })
+
+  it('does not call stall for historical entries (pre-existing at boot)', () => {
+    const agentDir = '/home/user/.switchroom/agents/myagent'
+    const subagentsDir = `${agentDir}/.claude/projects/p1/session-abc/subagents`
+    const jsonlStem = 'hist-agent'
+    const toolUseId = 'toolu_hist001'
+    const jsonlPath = `${subagentsDir}/agent-${jsonlStem}.jsonl`
+    const content = buildJSONL(subAgentUserMsg('Old task'))
+
+    const db = makeInMemoryDb({
+      [toolUseId]: { id: toolUseId, jsonl_agent_id: jsonlStem, status: 'running' },
+    })
+
+    const h = makeHarnessWithDb({
+      agentDir,
+      dirs: {
+        [`${agentDir}/.claude/projects`]: ['p1'],
+        [`${agentDir}/.claude/projects/p1`]: ['session-abc'],
+        [subagentsDir]: [`agent-${jsonlStem}.jsonl`],
+      },
+      files: { [jsonlPath]: content },
+      stallThresholdMs: 60_000,
+      db,
+    })
+
+    // Do NOT flip historical — entry is historical by default (file at boot)
+    h.advance(65_000)
+
+    const stallDbCalls = db._calls.filter(
+      (c) => /UPDATE subagents[\s\S]*SET status[\s\S]*stalled/i.test(c.sql),
+    )
+    // Historical entries must NOT trigger stall writes to DB
+    expect(stallDbCalls).toHaveLength(0)
+
+    h.watcher.stop()
+  })
+})
+
+// ─── result_summary always NULL — extractResultSummary ───────────────────────
+
+describe('result_summary extractResultSummary — Claude Code content[] wrapping', () => {
+  /**
+   * Claude Code wraps Agent() output in { content: [{ type: 'text', text }] }.
+   * The posttool's extractResultSummary only checks .result and .output, so
+   * result_summary is always NULL.
+   */
+
+  it('current extractResultSummary returns null for content-array responses (confirms bug)', () => {
+    const toolResponse = {
+      content: [{ type: 'text', text: 'Task completed. 3 files modified.' }],
+    }
+    // Current (broken) implementation
+    const brokenExtract = (resp: unknown): string | null => {
+      if (!resp) return null
+      const r = resp as Record<string, unknown>
+      const raw = r['result'] ?? r['output'] ?? (typeof resp === 'string' ? resp : null)
+      if (raw == null) return null
+      const str = typeof raw === 'string' ? raw : JSON.stringify(raw)
+      return str.slice(0, 200) || null
+    }
+    expect(brokenExtract(toolResponse)).toBeNull()
+  })
+
+  it('fixed extractResultSummary handles content[0].text', () => {
+    const toolResponse = {
+      content: [{ type: 'text', text: 'Task completed. 3 files modified.' }],
+    }
+    const fixedExtract = (resp: unknown): string | null => {
+      if (!resp) return null
+      const r = resp as Record<string, unknown>
+      const raw =
+        r['result'] ??
+        r['output'] ??
+        (Array.isArray(r['content']) && r['content'].length > 0
+          ? (r['content'][0] as Record<string, unknown>)['text']
+          : null) ??
+        (typeof resp === 'string' ? resp : null)
+      if (raw == null) return null
+      const str = typeof raw === 'string' ? raw : JSON.stringify(raw)
+      return str.slice(0, 200) || null
+    }
+    expect(fixedExtract(toolResponse)).toBe('Task completed. 3 files modified.')
+  })
+
+  it('fixed extractResultSummary still works when result field is present', () => {
+    const toolResponse = { result: 'Direct result string.' }
+    const fixedExtract = (resp: unknown): string | null => {
+      if (!resp) return null
+      const r = resp as Record<string, unknown>
+      const raw =
+        r['result'] ??
+        r['output'] ??
+        (Array.isArray(r['content']) && r['content'].length > 0
+          ? (r['content'][0] as Record<string, unknown>)['text']
+          : null) ??
+        (typeof resp === 'string' ? resp : null)
+      if (raw == null) return null
+      const str = typeof raw === 'string' ? raw : JSON.stringify(raw)
+      return str.slice(0, 200) || null
+    }
+    expect(fixedExtract(toolResponse)).toBe('Direct result string.')
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -73,6 +73,8 @@ export default defineConfig({
       "**/telegram-plugin/tests/idle-footer-wiring.test.ts",
       // subagent-tracker-hooks.test.ts uses bun:test — excluded here, run via test:bun.
       "**/telegram-plugin/tests/subagent-tracker-hooks.test.ts",
+      // subagents-bugs.test.ts uses bun:sqlite + bun:test — excluded here, run via test:bun.
+      "**/telegram-plugin/registry/subagents-bugs.test.ts",
     ],
     coverage: {
       provider: "v8",


### PR DESCRIPTION
## What this fixes

Five empirical bugs in the sub-agent registry that combined to make the registry lie about background sub-agent state. Symptom: dispatched workers vanish from the progress card / footer within seconds even though they're still actively running for minutes.

## Hard evidence (gathered before the fix)

A 90-second background `researcher` sub-agent was dispatched from a live klanker session. The registry row showed:

- `started_at` = 20:34:18
- `ended_at` = 20:34:28 → `ended_at - started_at = 10,063 ms` (claimed)
- `last_activity_at` == `ended_at` from launch
- `status = completed`

**Reality from disk**: the JSONL was last written at 20:37:38 — **89,979 ms after** the row's `last_activity_at`. The bump never landed.

That single observation revealed five distinct bugs.

## Bugs

| # | Symptom | Root cause |
|---|---|---|
| 0 | Liveness writes never persisted | Gateway never passed `db` to `startSubagentWatcher` → `if (db != null)` guard short-circuited every write |
| 1 | `bumpSubagentActivity` was a permanent no-op | Rows keyed on `tool_use_id` (toolu_*) but watcher passed JSONL stems (a*) — IDs never matched |
| 2 | Background sub-agents marked `completed` at launch | PostToolUse fired on the launch ack (~10 s) for background agents that ran 90+ s |
| 3 | Stale `running` rows accumulated forever | `recordSubagentStall` existed but no caller invoked it against the DB. Found a 3.8 h orphan in production |
| 4 | `result_summary` always `NULL` | PostToolUse didn't unwrap `content[0].text` — Claude Code's actual Agent-tool response shape |
| 5 | `parent_turn_key` always `NULL` | PreToolUse hardcoded `NULL` instead of reading `event.turn_id` |

## Fix shape

- **Schema** — new `jsonl_agent_id` column + index, idempotent `ALTER TABLE` migration. Mirrored in the PreToolUse hook's inline schema so cold-boot from a hook (before the gateway runs) lands the same shape.
- **Gateway** — applies `applySubagentsSchema` after `openTurnsDb` and passes the same DB handle to `startSubagentWatcher`.
- **Watcher** — looks up rows by `jsonl_agent_id`, writes by the real `tool_use_id` PK. Persists stall + turn_end transitions to the DB. Reads `agent-<id>.meta.json` (the sibling file Claude Code writes) to backfill `jsonl_agent_id` on JSONL discovery.
- **Hooks** — PreToolUse sets `parent_turn_key` from `event.turn_id`; PostToolUse extracts `result_summary` from `content[0].text`.

## Test coverage

11 vitest watcher-integration tests + 15 bun schema/hook-integration tests covering all 5 bugs and these regressions:
- Foreground agent that finishes normally → `completed` (no regression)
- Foreground agent that errors → `failed` with `result_summary` preserved
- Background agent transitions `running` → `completed` via watcher `turn_end`
- Multiple in-flight sub-agents from same parent turn
- Boot reconciliation: `running` rows with absent JSONLs marked `stalled`
- Stall sweeper idempotency (`stallNotified` guards repeats)
- DB write errors don't crash the watcher

Existing test suites still green: 25 registry, 14 watcher, 41 gateway turns, 4 hook tests.

## Deferred

Filed for follow-up:
- **Heartbeat tick on the progress card.** Even with all of the above, the card still goes silent during sub-agent dispatch because the parent has no tool calls to fire on. A periodic elapsed-time tick (4–5 s) would close the silent-gap UX problem.
- **Sub-agent PreToolUse hooks emitting their own liveness rows.** Sub-agents inherit parent hooks and can write directly. Blocked on Anthropic exposing `agent_id` in hook payloads — see [anthropics/claude-code#16424](https://github.com/anthropics/claude-code/issues/16424).

## Linkage strategy notes

The PreToolUse hook fires *before* the JSONL exists, so it cannot know `jsonl_agent_id`. The link happens via the watcher reading the meta.json sibling and matching on `(agent_type, description)` against unmatched rows. Edge cases (multiple identical-description sub-agents in flight) take the most-recently-started match, which mirrors dispatch order in practice. If the meta.json is missing the row stays unlinked — the system stays correct, liveness writes just don't land for that one agent.