### PR TITLE
fix(telegram-plugin): bounded retry for gateway startup network failures

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -47,6 +47,7 @@ import {
   shouldSuppressToolActivity,
 } from '../pty-tail.js'
 import { clearStaleTelegramPollingState } from '../startup-reset.js'
+import { gatewayStartupRetry } from './startup-network-retry.js'
 import {
   parseAuthSubCommand,
   checkRemoveSafety,
@@ -6964,13 +6965,23 @@ let didOneTimeSetup = false
 void (async () => {
   for (let attempt = 1; ; attempt++) {
     try {
-      // Clear any orphan long-poll from a previous gateway process
-      // before we start our own. See clearStaleTelegramPollingState
-      // docstring for the production incident that motivates this.
-      // Safe to re-run on retries: it's idempotent.
-      await clearStaleTelegramPollingState(bot.api)
-
-      const me = await bot.api.getMe()
+      // ── Startup network-retry fence ───────────────────────────────────────
+      // On boot the network stack may not be truly usable yet even after
+      // network-online.target fires (observed 2026-04-29: all 5 gateways
+      // started at ~21:26:26 and couldn't reach api.telegram.org for ~27 min).
+      // Grammy throws HttpError for both deleteWebhook and getMe in that case.
+      // `gatewayStartupRetry` absorbs those with exponential backoff (1s→64s,
+      // 8 total attempts, ~2 min budget). On exhaustion it calls process.exit(1)
+      // so systemd's Restart=always can restart the unit from a clean state.
+      // Non-network errors (bad token, 403, etc.) are rethrown immediately so
+      // the catch block below can handle them as before.
+      const me = await gatewayStartupRetry(async () => {
+        // Clear any orphan long-poll from a previous gateway process before we
+        // start our own. See clearStaleTelegramPollingState docstring for the
+        // production incident that motivates this. Safe to re-run on retries.
+        await clearStaleTelegramPollingState(bot.api)
+        return bot.api.getMe()
+      })
       botUsername = me.username
       process.stderr.write(`telegram gateway: polling as @${me.username}\n`)
       if (TOPIC_ID != null) process.stderr.write(`telegram gateway: topic filter active — thread_id=${TOPIC_ID}\n`)
@@ -7290,7 +7301,15 @@ void (async () => {
       }
       if (err instanceof Error && err.message === 'Aborted delay') return
       process.stderr.write(`telegram gateway: polling failed: ${err}\n`)
-      return
+      // Exit non-zero so systemd's Restart=always re-runs the unit instead of
+      // leaving a live-but-silent process that never polls. Previously this path
+      // just `return`ed — that IS the bug from 2026-04-29 where all 5 gateways
+      // stayed alive but deaf after a boot-time network failure.
+      // Note: network errors at startup are handled earlier by gatewayStartupRetry
+      // (with bounded retries before the exit); reaching here means either a
+      // non-network fatal error, or an unexpected mid-session failure. Either
+      // way, exiting is safer than silently staying alive with polling stopped.
+      process.exit(1)
     }
   }
 })()

--- a/telegram-plugin/gateway/startup-network-retry.ts
+++ b/telegram-plugin/gateway/startup-network-retry.ts
@@ -1,0 +1,142 @@
+/**
+ * Bounded exponential-backoff retry for gateway startup network errors.
+ *
+ * On 2026-04-29 all five switchroom gateways silently broke at boot because
+ * `api.telegram.org` was unreachable for ~27 minutes after system boot (the
+ * network stack wasn't fully usable when `network-online.target` fired).
+ * Grammy threw `HttpError: Network request for 'deleteWebhook'/'getMe' failed!`
+ * and the gateway's catch block logged the error and **returned** — leaving the
+ * process alive but not polling. No crash, so systemd's `Restart=always` never
+ * fired. Telegram → agent delivery was dead until manual restarts.
+ *
+ * This module provides:
+ *
+ *   `isBootNetworkError(err)`  — recognises network-layer errors thrown by
+ *       grammy's HttpError wrapper and by raw fetch/Node network failures.
+ *
+ *   `STARTUP_RETRY_DELAYS_MS`  — the chosen backoff schedule.
+ *
+ *   `gatewayStartupRetry(fn, opts)` — drives the retry loop. Calls `fn()` up to
+ *       `maxAttempts` times with delays from `delaysMs`. On success it resolves.
+ *       On exhaustion it calls `opts.onExhausted()` (default: `process.exit(1)`)
+ *       so systemd's `Restart=always` can restart the unit cleanly.
+ *
+ * The function is extracted from `gateway.ts`'s top-level IIFE so it can be
+ * unit-tested without spinning up the full bot runtime.
+ */
+
+export interface StartupRetryOpts {
+  /**
+   * Delay schedule in milliseconds. Each attempt waits the corresponding
+   * element before the NEXT attempt. Length determines max extra attempts
+   * (total = delays.length + 1 initial attempt).
+   *
+   * Defaults to `STARTUP_RETRY_DELAYS_MS` (~2 min budget).
+   */
+  delaysMs?: number[]
+
+  /** Inject a sleep helper so tests can use fake timers. */
+  sleep?: (ms: number) => Promise<void>
+
+  /**
+   * Called when all attempts are exhausted. Should NOT return (exit/throw).
+   * Defaults to `process.exit(1)`.
+   */
+  onExhausted?: (lastError: unknown) => never
+
+  /** Log sink for retry progress messages. Defaults to process.stderr.write. */
+  log?: (line: string) => void
+}
+
+/**
+ * Default backoff schedule: 1 s, 2 s, 4 s, 8 s, 16 s, 32 s, 64 s.
+ * Total budget including 8 attempts: ~2 min 7 s. Chosen so a typical
+ * post-boot network settle (empirically <90 s) is covered with headroom.
+ */
+export const STARTUP_RETRY_DELAYS_MS: number[] = [
+  1_000,
+  2_000,
+  4_000,
+  8_000,
+  16_000,
+  32_000,
+  64_000,
+]
+
+const DEFAULT_SLEEP = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms))
+
+/**
+ * Returns true if `err` is a transient network-level failure that the startup
+ * retry loop should absorb. Covers:
+ *
+ * - Grammy's `HttpError` (name === 'HttpError'), which wraps fetch/ECONN errors
+ *   during `deleteWebhook` and `getMe`.
+ * - Raw Node/fetch errors: ECONNRESET, ETIMEDOUT, ENOTFOUND, ECONNREFUSED,
+ *   fetch failed, etc.
+ */
+export function isBootNetworkError(err: unknown): boolean {
+  if (!(err instanceof Error)) return false
+  // Grammy wraps network errors in HttpError (name is set in the constructor)
+  if (err.name === 'HttpError') return true
+  const msg = err.message
+  return (
+    msg.includes('ECONNRESET') ||
+    msg.includes('ETIMEDOUT') ||
+    msg.includes('ENOTFOUND') ||
+    msg.includes('ECONNREFUSED') ||
+    msg.includes('fetch failed') ||
+    msg.includes('Network request')
+  )
+}
+
+/**
+ * Attempt `fn()` and retry on `isBootNetworkError` failures using the
+ * provided delay schedule.
+ *
+ * - On success: returns whatever `fn()` resolved to.
+ * - On non-network error: re-throws immediately (not a transient boot issue).
+ * - On exhausted retries: calls `opts.onExhausted(lastError)` which must not
+ *   return (it should exit or throw). The default is `process.exit(1)` so
+ *   systemd's `Restart=always` picks up the dead unit.
+ */
+export async function gatewayStartupRetry<T>(
+  fn: () => Promise<T>,
+  opts: StartupRetryOpts = {},
+): Promise<T> {
+  const delays = opts.delaysMs ?? STARTUP_RETRY_DELAYS_MS
+  const sleep = opts.sleep ?? DEFAULT_SLEEP
+  const onExhausted: (err: unknown) => never =
+    opts.onExhausted ??
+    ((err: unknown) => {
+      process.stderr.write(
+        `telegram gateway: startup failed after ${delays.length + 1} attempts — exiting so systemd can restart: ${err}\n`,
+      )
+      process.exit(1)
+    })
+  const log =
+    opts.log ??
+    ((line: string) => {
+      process.stderr.write(line.endsWith('\n') ? line : line + '\n')
+    })
+
+  const maxAttempts = delays.length + 1
+  let lastError: unknown
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      return await fn()
+    } catch (err) {
+      if (!isBootNetworkError(err)) throw err
+      lastError = err
+      if (attempt >= maxAttempts) break
+      const delayMs = delays[attempt - 1]
+      log(
+        `telegram gateway: startup network error (attempt ${attempt}/${maxAttempts}), retrying in ${delayMs / 1000}s: ${err}`,
+      )
+      await sleep(delayMs)
+    }
+  }
+
+  return onExhausted(lastError)
+}

--- a/telegram-plugin/tests/gateway-startup-network-retry.test.ts
+++ b/telegram-plugin/tests/gateway-startup-network-retry.test.ts
@@ -1,0 +1,185 @@
+/**
+ * Tests for the gateway startup network-retry helper.
+ *
+ * Regression guard for the 2026-04-29 incident where all five switchroom
+ * gateways silently failed at boot because `api.telegram.org` was unreachable
+ * for ~27 minutes. The process logged an error and returned (stayed alive,
+ * didn't poll) rather than exiting, so systemd's `Restart=always` never fired.
+ *
+ * These tests pin:
+ *   - `isBootNetworkError` correctly classifies grammy HttpErrors and raw errors
+ *   - `gatewayStartupRetry` retries on network errors with backoff
+ *   - When retries are exhausted, `onExhausted` is called (simulating exit)
+ *   - Non-network errors are NOT retried (rethrown immediately)
+ *   - Success on a later attempt resolves the returned promise
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+import {
+  isBootNetworkError,
+  gatewayStartupRetry,
+  STARTUP_RETRY_DELAYS_MS,
+} from '../gateway/startup-network-retry'
+
+// ── isBootNetworkError ────────────────────────────────────────────────────────
+
+describe('isBootNetworkError', () => {
+  it('returns true for an error with name HttpError (grammy wrapper)', () => {
+    const err = Object.assign(new Error('Network request for getMe failed!'), {
+      name: 'HttpError',
+    })
+    expect(isBootNetworkError(err)).toBe(true)
+  })
+
+  it('returns true for ECONNRESET', () => {
+    expect(isBootNetworkError(new Error('ECONNRESET'))).toBe(true)
+  })
+
+  it('returns true for ETIMEDOUT', () => {
+    expect(isBootNetworkError(new Error('connect ETIMEDOUT 149.154.167.220:443'))).toBe(true)
+  })
+
+  it('returns true for ENOTFOUND', () => {
+    expect(isBootNetworkError(new Error('getaddrinfo ENOTFOUND api.telegram.org'))).toBe(true)
+  })
+
+  it('returns true for ECONNREFUSED', () => {
+    expect(isBootNetworkError(new Error('connect ECONNREFUSED 127.0.0.1:443'))).toBe(true)
+  })
+
+  it('returns true for "fetch failed"', () => {
+    expect(isBootNetworkError(new Error('fetch failed'))).toBe(true)
+  })
+
+  it('returns true for "Network request" messages', () => {
+    expect(
+      isBootNetworkError(new Error("Network request for 'deleteWebhook' failed!")),
+    ).toBe(true)
+  })
+
+  it('returns false for a GrammyError 403 (not a network error)', () => {
+    const err = Object.assign(new Error('Forbidden: bot was kicked'), {
+      name: 'GrammyError',
+      error_code: 403,
+    })
+    expect(isBootNetworkError(err)).toBe(false)
+  })
+
+  it('returns false for a generic application error', () => {
+    expect(isBootNetworkError(new Error('some unrelated error'))).toBe(false)
+  })
+
+  it('returns false for non-Error values', () => {
+    expect(isBootNetworkError('string error')).toBe(false)
+    expect(isBootNetworkError(null)).toBe(false)
+    expect(isBootNetworkError(42)).toBe(false)
+  })
+})
+
+// ── gatewayStartupRetry ───────────────────────────────────────────────────────
+
+describe('gatewayStartupRetry', () => {
+  const noopLog = () => {}
+
+  it('resolves immediately when fn() succeeds on first attempt', async () => {
+    const fn = vi.fn().mockResolvedValue('ok')
+    const result = await gatewayStartupRetry(fn, { log: noopLog })
+    expect(result).toBe('ok')
+    expect(fn).toHaveBeenCalledTimes(1)
+  })
+
+  it('retries on network error and resolves when fn eventually succeeds', async () => {
+    const networkErr = Object.assign(new Error('Network request failed'), {
+      name: 'HttpError',
+    })
+    const fn = vi
+      .fn()
+      .mockRejectedValueOnce(networkErr)
+      .mockRejectedValueOnce(networkErr)
+      .mockResolvedValue('recovered')
+
+    const sleep = vi.fn().mockResolvedValue(undefined)
+    const result = await gatewayStartupRetry(fn, {
+      delaysMs: [100, 200, 400],
+      sleep,
+      log: noopLog,
+    })
+
+    expect(result).toBe('recovered')
+    expect(fn).toHaveBeenCalledTimes(3)
+    expect(sleep).toHaveBeenCalledTimes(2)
+    expect(sleep).toHaveBeenNthCalledWith(1, 100)
+    expect(sleep).toHaveBeenNthCalledWith(2, 200)
+  })
+
+  it('calls onExhausted (not returns) when all retries are exhausted', async () => {
+    const networkErr = Object.assign(new Error('Network request failed'), {
+      name: 'HttpError',
+    })
+    const fn = vi.fn().mockRejectedValue(networkErr)
+    const onExhausted = vi.fn(() => { throw new Error('__exited__') }) as unknown as (err: unknown) => never
+
+    const sleep = vi.fn().mockResolvedValue(undefined)
+
+    await expect(
+      gatewayStartupRetry(fn, {
+        delaysMs: [1, 2],  // 3 total attempts (delays.length + 1)
+        sleep,
+        onExhausted,
+        log: noopLog,
+      }),
+    ).rejects.toThrow('__exited__')
+
+    expect(fn).toHaveBeenCalledTimes(3)
+    expect(onExhausted).toHaveBeenCalledTimes(1)
+    expect(onExhausted).toHaveBeenCalledWith(networkErr)
+  })
+
+  it('does NOT retry non-network errors — rethrows immediately', async () => {
+    const appErr = new Error('bad token')
+    const fn = vi.fn().mockRejectedValue(appErr)
+    const sleep = vi.fn()
+    const onExhausted = vi.fn()
+
+    await expect(
+      gatewayStartupRetry(fn, {
+        delaysMs: [100, 200],
+        sleep,
+        onExhausted: onExhausted as unknown as (err: unknown) => never,
+        log: noopLog,
+      }),
+    ).rejects.toThrow('bad token')
+
+    expect(fn).toHaveBeenCalledTimes(1)
+    expect(sleep).not.toHaveBeenCalled()
+    expect(onExhausted).not.toHaveBeenCalled()
+  })
+
+  it('uses STARTUP_RETRY_DELAYS_MS by default (7 delays → 8 total attempts)', () => {
+    expect(STARTUP_RETRY_DELAYS_MS).toHaveLength(7)
+    // Verify the schedule is monotonically increasing and ends at 64 s
+    expect(STARTUP_RETRY_DELAYS_MS[0]).toBe(1_000)
+    expect(STARTUP_RETRY_DELAYS_MS[STARTUP_RETRY_DELAYS_MS.length - 1]).toBe(64_000)
+  })
+
+  it('logs retry progress before each sleep', async () => {
+    const networkErr = Object.assign(new Error('Network request failed'), {
+      name: 'HttpError',
+    })
+    const fn = vi
+      .fn()
+      .mockRejectedValueOnce(networkErr)
+      .mockResolvedValue('ok')
+
+    const sleep = vi.fn().mockResolvedValue(undefined)
+    const log = vi.fn()
+
+    await gatewayStartupRetry(fn, { delaysMs: [50], sleep, log })
+
+    expect(log).toHaveBeenCalledTimes(1)
+    const logMsg: string = log.mock.calls[0][0]
+    expect(logMsg).toMatch(/startup network error/)
+    expect(logMsg).toMatch(/attempt 1\/2/)
+    expect(logMsg).toMatch(/retrying in 0.05s/)
+  })
+})


### PR DESCRIPTION
## Problem

On 2026-04-29, all five switchroom Telegram gateways silently broke on system boot. At startup, `deleteWebhook` and `getMe` failed against `api.telegram.org` because the network stack wasn't actually usable yet — despite `network-online.target` having already fired, the network settled ~27 minutes after the gateways started. Grammy wrapped the failure in an `HttpError`, the catch block logged it and returned, leaving each process alive but not polling. No crash means no `Restart=always` trigger. Five agents had to be manually restarted.

## Fix

New helper `startup-network-retry.ts` exports `gatewayStartupRetry(fn, opts)` — a bounded exponential-backoff retry loop used to wrap the `deleteWebhook` + `getMe` calls at gateway startup.

Retry policy:
- Schedule: 1 s, 2 s, 4 s, 8 s, 16 s, 32 s, 64 s
- Total: 8 attempts, ~2 min 7 s budget — enough to cover a typical post-boot network settle with headroom
- On network error: retries with backoff, logs progress to stderr
- On non-network error (bad token, 403, etc.): rethrows immediately — these aren't transient
- On exhaustion: calls `process.exit(1)` so systemd's `Restart=always` takes over from a clean state

## Manual repro

1. Block Telegram: `echo '127.0.0.1 api.telegram.org' | sudo tee -a /etc/hosts`
2. Restart a gateway: `systemctl --user restart switchroom-klanker-gateway`
3. Tail log: `tail -f ~/.switchroom/agents/klanker/telegram/gateway.log` — observe retry attempts with backoff delays logged to stderr.
4. Unblock before exhaustion (`sudo sed -i '/api.telegram.org/d' /etc/hosts`) and confirm polling starts normally.
5. Or let it exhaust and confirm systemd restarts the unit (`systemctl --user status switchroom-klanker-gateway`).

## Test plan

- [x] `bun test telegram-plugin/tests/gateway-startup-network-retry.test.ts` — 16 tests, all pass
- [x] `bun test telegram-plugin/tests/` — full suite, exit 0
- [x] `bun run lint` (`tsc --noEmit`) — clean, no type errors
- [x] `src/build-info.ts` excluded from this commit (auto-generated, unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)