### PR TITLE
feat(update): reconcile built-in default MCPs on switchroom update

### DIFF
--- a/src/agents/reconcile-default-mcps.test.ts
+++ b/src/agents/reconcile-default-mcps.test.ts
@@ -1,0 +1,261 @@
+/**
+ * Unit tests for src/agents/reconcile-default-mcps.ts
+ *
+ * Covers:
+ *   (a) adds a missing built-in default to settings.json
+ *   (b) leaves an existing entry alone (user may have customised it)
+ *   (c) honours per-agent opt-out (mcp_servers: { key: false })
+ *   (d) idempotent — running twice produces zero changes on the second run
+ *   (e) handles agents with no settings.json (non-standard layout)
+ *   (f) reconcileAllAgentDefaultMcps iterates over agent directories correctly
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  reconcileAgentDefaultMcps,
+  reconcileAllAgentDefaultMcps,
+} from "./reconcile-default-mcps.js";
+import type { BuiltinMcpEntry } from "../memory/scaffold-integration.js";
+
+// Minimal fixture defaults — tests don't need real npx commands
+const FIXTURE_DEFAULTS: BuiltinMcpEntry[] = [
+  {
+    key: "playwright",
+    value: { command: "npx", args: ["-y", "@playwright/mcp@0.0.71", "--snapshot"] },
+    optOutKey: "playwright",
+  },
+];
+
+function makeAgentDir(
+  tmpRoot: string,
+  name: string,
+  settings?: Record<string, unknown>,
+): string {
+  const agentDir = join(tmpRoot, name);
+  const claudeDir = join(agentDir, ".claude");
+  mkdirSync(claudeDir, { recursive: true });
+  if (settings !== undefined) {
+    writeFileSync(
+      join(claudeDir, "settings.json"),
+      JSON.stringify(settings, null, 2) + "\n",
+      "utf-8",
+    );
+  }
+  return agentDir;
+}
+
+function readSettings(agentDir: string): Record<string, unknown> {
+  return JSON.parse(
+    readFileSync(join(agentDir, ".claude", "settings.json"), "utf-8"),
+  ) as Record<string, unknown>;
+}
+
+describe("reconcileAgentDefaultMcps", () => {
+  let tmpRoot: string;
+
+  beforeEach(() => {
+    tmpRoot = mkdtempSync(join(tmpdir(), "sr-reconcile-"));
+  });
+
+  afterEach(() => {
+    rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  it("(a) adds a missing built-in default to settings.json", () => {
+    const agentDir = makeAgentDir(tmpRoot, "alpha", {
+      mcpServers: {
+        switchroom: { command: "bun", args: ["run", "server.ts"] },
+      },
+    });
+
+    const result = reconcileAgentDefaultMcps(agentDir, {}, FIXTURE_DEFAULTS);
+
+    expect(result.added).toEqual(["playwright"]);
+    expect(result.alreadyPresent).toEqual([]);
+    expect(result.optedOut).toEqual([]);
+    expect(result.changed).toBe(true);
+
+    const written = readSettings(agentDir);
+    const servers = written.mcpServers as Record<string, unknown>;
+    expect(servers["playwright"]).toEqual(FIXTURE_DEFAULTS[0]!.value);
+    // Existing entry untouched
+    expect(servers["switchroom"]).toEqual({ command: "bun", args: ["run", "server.ts"] });
+  });
+
+  it("(b) leaves an existing entry alone (customised command/args)", () => {
+    const customPlaywright = {
+      command: "npx",
+      args: ["-y", "@playwright/mcp@custom-fork", "--headed"],
+    };
+    const agentDir = makeAgentDir(tmpRoot, "beta", {
+      mcpServers: {
+        playwright: customPlaywright,
+      },
+    });
+    const before = readSettings(agentDir);
+
+    const result = reconcileAgentDefaultMcps(agentDir, {}, FIXTURE_DEFAULTS);
+
+    expect(result.added).toEqual([]);
+    expect(result.alreadyPresent).toEqual(["playwright"]);
+    expect(result.changed).toBe(false);
+
+    // File should NOT have been rewritten
+    const after = readSettings(agentDir);
+    expect(JSON.stringify(after)).toBe(JSON.stringify(before));
+    // The customised entry is untouched
+    const servers = after.mcpServers as Record<string, unknown>;
+    expect(servers["playwright"]).toEqual(customPlaywright);
+  });
+
+  it("(c) honours per-agent opt-out (mcp_servers: { playwright: false })", () => {
+    const agentDir = makeAgentDir(tmpRoot, "gamma", {
+      mcpServers: {
+        switchroom: { command: "bun", args: ["run", "server.ts"] },
+      },
+    });
+    const before = readSettings(agentDir);
+
+    const result = reconcileAgentDefaultMcps(
+      agentDir,
+      { playwright: false },
+      FIXTURE_DEFAULTS,
+    );
+
+    expect(result.added).toEqual([]);
+    expect(result.optedOut).toEqual(["playwright"]);
+    expect(result.changed).toBe(false);
+
+    // File must not be modified
+    const after = readSettings(agentDir);
+    expect(JSON.stringify(after)).toBe(JSON.stringify(before));
+    const servers = after.mcpServers as Record<string, unknown>;
+    expect(Object.prototype.hasOwnProperty.call(servers, "playwright")).toBe(false);
+  });
+
+  it("(d) idempotent — second run produces zero changes", () => {
+    const agentDir = makeAgentDir(tmpRoot, "delta", {
+      mcpServers: {
+        switchroom: { command: "bun", args: ["run", "server.ts"] },
+      },
+    });
+
+    // First run: should add playwright
+    const first = reconcileAgentDefaultMcps(agentDir, {}, FIXTURE_DEFAULTS);
+    expect(first.added).toEqual(["playwright"]);
+    expect(first.changed).toBe(true);
+
+    // Second run: nothing to add
+    const second = reconcileAgentDefaultMcps(agentDir, {}, FIXTURE_DEFAULTS);
+    expect(second.added).toEqual([]);
+    expect(second.alreadyPresent).toEqual(["playwright"]);
+    expect(second.changed).toBe(false);
+
+    // Third run for paranoia
+    const third = reconcileAgentDefaultMcps(agentDir, {}, FIXTURE_DEFAULTS);
+    expect(third.changed).toBe(false);
+  });
+
+  it("(e) silently skips agents with no settings.json", () => {
+    // Create a directory without .claude/settings.json
+    const agentDir = join(tmpRoot, "epsilon");
+    mkdirSync(join(agentDir, ".claude"), { recursive: true });
+
+    const result = reconcileAgentDefaultMcps(agentDir, {}, FIXTURE_DEFAULTS);
+
+    expect(result.added).toEqual([]);
+    expect(result.changed).toBe(false);
+  });
+
+  it("adds default when mcpServers key is absent entirely", () => {
+    const agentDir = makeAgentDir(tmpRoot, "zeta", {
+      permissions: { allow: ["Bash"], deny: [] },
+      // No mcpServers key at all
+    });
+
+    const result = reconcileAgentDefaultMcps(agentDir, {}, FIXTURE_DEFAULTS);
+
+    expect(result.added).toEqual(["playwright"]);
+    expect(result.changed).toBe(true);
+
+    const written = readSettings(agentDir);
+    const servers = written.mcpServers as Record<string, unknown>;
+    expect(servers["playwright"]).toEqual(FIXTURE_DEFAULTS[0]!.value);
+    // Other keys preserved
+    expect((written.permissions as Record<string, unknown>)["allow"]).toEqual(["Bash"]);
+  });
+});
+
+describe("reconcileAllAgentDefaultMcps", () => {
+  let tmpRoot: string;
+
+  beforeEach(() => {
+    tmpRoot = mkdtempSync(join(tmpdir(), "sr-reconcile-all-"));
+  });
+
+  afterEach(() => {
+    rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  it("(f) iterates over all agent directories and returns per-agent results", () => {
+    const agentsDir = join(tmpRoot, "agents");
+    mkdirSync(agentsDir);
+
+    // Agent 1: needs playwright added
+    makeAgentDir(agentsDir, "agent1", { mcpServers: { switchroom: {} } });
+
+    // Agent 2: already has playwright
+    makeAgentDir(agentsDir, "agent2", {
+      mcpServers: { playwright: { command: "npx", args: ["@playwright/mcp@0.0.71"] } },
+    });
+
+    // Agent 3: opted out
+    makeAgentDir(agentsDir, "agent3", { mcpServers: {} });
+
+    const results = reconcileAllAgentDefaultMcps(
+      agentsDir,
+      { agent3: { playwright: false } },
+      FIXTURE_DEFAULTS,
+    );
+
+    expect(results).toHaveLength(3);
+
+    const r1 = results.find(r => r.name === "agent1")!;
+    expect(r1.added).toEqual(["playwright"]);
+    expect(r1.changed).toBe(true);
+
+    const r2 = results.find(r => r.name === "agent2")!;
+    expect(r2.added).toEqual([]);
+    expect(r2.alreadyPresent).toEqual(["playwright"]);
+    expect(r2.changed).toBe(false);
+
+    const r3 = results.find(r => r.name === "agent3")!;
+    expect(r3.optedOut).toEqual(["playwright"]);
+    expect(r3.changed).toBe(false);
+  });
+
+  it("returns empty array when agentsDir does not exist", () => {
+    const results = reconcileAllAgentDefaultMcps(
+      join(tmpRoot, "nonexistent"),
+      {},
+      FIXTURE_DEFAULTS,
+    );
+    expect(results).toEqual([]);
+  });
+
+  it("skips non-directory entries in agentsDir", () => {
+    const agentsDir = join(tmpRoot, "agents");
+    mkdirSync(agentsDir);
+    // A file in the agents dir (not an agent)
+    writeFileSync(join(agentsDir, "README.md"), "# agents", "utf-8");
+    // A real agent
+    makeAgentDir(agentsDir, "realagent", { mcpServers: {} });
+
+    const results = reconcileAllAgentDefaultMcps(agentsDir, {}, FIXTURE_DEFAULTS);
+    expect(results).toHaveLength(1);
+    expect(results[0]!.name).toBe("realagent");
+  });
+});

--- a/src/agents/reconcile-default-mcps.ts
+++ b/src/agents/reconcile-default-mcps.ts
@@ -1,0 +1,139 @@
+/**
+ * reconcileDefaultMcps — additive MCP reconciler for `switchroom update`.
+ *
+ * Problem: built-in default MCP servers (e.g. @playwright/mcp, added in #358)
+ * are written into settings.json only at scaffold time. Agents created before a
+ * default was introduced never pick it up unless re-scaffolded.
+ *
+ * This module is the fix: iterate over every agent directory, check which
+ * built-in defaults are missing from settings.json, honour per-agent opt-outs,
+ * and add only what's absent. Idempotent — running twice produces no changes.
+ */
+
+import { existsSync, readFileSync, writeFileSync, readdirSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { getBuiltinDefaultMcpEntries, type BuiltinMcpEntry } from "../memory/scaffold-integration.js";
+
+/**
+ * Result for a single agent processed by reconcileDefaultMcps.
+ */
+export interface AgentMcpReconcileResult {
+  /** Agent name */
+  name: string;
+  /** Which built-in MCP keys were added */
+  added: string[];
+  /** Which built-in MCP keys were already present (no change) */
+  alreadyPresent: string[];
+  /** Which built-in MCP keys were skipped due to opt-out */
+  optedOut: string[];
+  /**
+   * True when settings.json was written (i.e. at least one entry was added).
+   * False means the file was untouched.
+   */
+  changed: boolean;
+}
+
+/**
+ * Reconcile built-in default MCP entries into a single agent's settings.json.
+ *
+ * Rules:
+ *   - If the agent's settings.json already has an entry for a default key,
+ *     leave it alone (user may have customised command/args/env).
+ *   - If the agent's effective config opts out (`mcp_servers: { key: false }`),
+ *     skip that entry.
+ *   - Otherwise, add the missing entry.
+ *   - If nothing changed, do NOT write the file (idempotent).
+ *
+ * @param agentDir      - Absolute path to the agent directory
+ * @param mcpOptOuts    - The agent's `mcp_servers` map from switchroom.yaml
+ *                        (only `false` values are meaningful here)
+ * @param defaults      - Built-in default entries to reconcile
+ *                        (defaults to getBuiltinDefaultMcpEntries())
+ */
+export function reconcileAgentDefaultMcps(
+  agentDir: string,
+  mcpOptOuts: Record<string, unknown> = {},
+  defaults: BuiltinMcpEntry[] = getBuiltinDefaultMcpEntries(),
+): AgentMcpReconcileResult {
+  const name = agentDir.split("/").pop() ?? agentDir;
+  const settingsPath = join(agentDir, ".claude", "settings.json");
+
+  const result: AgentMcpReconcileResult = {
+    name,
+    added: [],
+    alreadyPresent: [],
+    optedOut: [],
+    changed: false,
+  };
+
+  if (!existsSync(settingsPath)) {
+    // Agent not yet scaffolded or non-standard layout — skip silently.
+    return result;
+  }
+
+  let settings: Record<string, unknown>;
+  try {
+    settings = JSON.parse(readFileSync(settingsPath, "utf-8")) as Record<string, unknown>;
+  } catch {
+    // Corrupt settings.json — leave it alone, don't risk overwriting.
+    return result;
+  }
+
+  const mcpServers = (settings.mcpServers ?? {}) as Record<string, unknown>;
+
+  for (const entry of defaults) {
+    const isOptOut = mcpOptOuts[entry.optOutKey] === false;
+    if (isOptOut) {
+      result.optedOut.push(entry.key);
+      continue;
+    }
+
+    if (Object.prototype.hasOwnProperty.call(mcpServers, entry.key)) {
+      result.alreadyPresent.push(entry.key);
+      continue;
+    }
+
+    // Missing and not opted out — add it.
+    mcpServers[entry.key] = entry.value;
+    result.added.push(entry.key);
+  }
+
+  if (result.added.length > 0) {
+    settings.mcpServers = mcpServers;
+    writeFileSync(settingsPath, JSON.stringify(settings, null, 2) + "\n", "utf-8");
+    result.changed = true;
+  }
+
+  return result;
+}
+
+/**
+ * Iterate over every agent in `agentsDir` and call reconcileAgentDefaultMcps.
+ *
+ * @param agentsDir   - The resolved agents directory (e.g. ~/.switchroom/agents)
+ * @param agentOptOuts - Map of agent name → their `mcp_servers` config block.
+ *                       Agents absent from this map are treated as having no
+ *                       opt-outs.
+ * @param defaults    - Built-in default entries (override for testing)
+ */
+export function reconcileAllAgentDefaultMcps(
+  agentsDir: string,
+  agentOptOuts: Record<string, Record<string, unknown>> = {},
+  defaults: BuiltinMcpEntry[] = getBuiltinDefaultMcpEntries(),
+): AgentMcpReconcileResult[] {
+  if (!existsSync(agentsDir)) return [];
+
+  const entries = readdirSync(agentsDir, { withFileTypes: true });
+  const results: AgentMcpReconcileResult[] = [];
+
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    const name = entry.name;
+    const agentDir = resolve(agentsDir, name);
+    const optOuts = agentOptOuts[name] ?? {};
+    const result = reconcileAgentDefaultMcps(agentDir, optOuts, defaults);
+    results.push(result);
+  }
+
+  return results;
+}

--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -33,7 +33,7 @@ import {
   renderTemplate,
   copyProfileSkills,
 } from "./profiles.js";
-import { getHindsightSettingsEntry, getSwitchroomMcpSettingsEntry, getPlaywrightMcpSettingsEntry } from "../memory/scaffold-integration.js";
+import { getHindsightSettingsEntry, getSwitchroomMcpSettingsEntry, getBuiltinDefaultMcpEntries } from "../memory/scaffold-integration.js";
 import { applyTelegramProgressGuidance, applyCronTelegramGuidance } from "./sub-agent-telegram-prompt.js";
 import type { McpServerConfig } from "../memory/hindsight.js";
 import { createBank, updateBankMissions, ensureUserProfileMentalModel } from "../memory/hindsight.js";
@@ -1427,18 +1427,19 @@ export function scaffoldAgent(
         settings.mcpServers[switchroomMcpEntry.key] = switchroomMcpEntry.value;
       }
 
-      // Playwright browser automation MCP (built-in default).
-      // Agents can suppress this with `mcp_servers: { playwright: false }` in
-      // switchroom.yaml. Playwright is added as a built-in here AFTER the
-      // template renders user-declared mcp_servers — so this is the only
-      // place that decides whether to wire it in. The opt-out check below
-      // reads the user's mcp_servers map directly to honour `false` even
-      // though that sentinel never reaches the template (filterMcpServers
-      // strips it).
-      const playwrightMcpEntry = getPlaywrightMcpSettingsEntry();
-      const agentOptOut = (agentConfig.mcp_servers ?? {})[playwrightMcpEntry.key] === false;
-      if (!agentOptOut && !settings.mcpServers[playwrightMcpEntry.key]) {
-        settings.mcpServers[playwrightMcpEntry.key] = playwrightMcpEntry.value;
+      // Built-in default MCPs (e.g. playwright). Single source of truth lives
+      // in scaffold-integration.ts so scaffold + `switchroom update` reconcile
+      // stay in sync. Agents can suppress any default with
+      // `mcp_servers: { <key>: false }` in switchroom.yaml; defaults are added
+      // here AFTER the template renders user-declared mcp_servers, and the
+      // opt-out check reads the user's mcp_servers map directly to honour
+      // `false` even though filterMcpServers strips that sentinel before the
+      // template sees it.
+      for (const entry of getBuiltinDefaultMcpEntries()) {
+        const agentOptOut = (agentConfig.mcp_servers ?? {})[entry.optOutKey] === false;
+        if (!agentOptOut && !settings.mcpServers[entry.key]) {
+          settings.mcpServers[entry.key] = entry.value;
+        }
       }
 
       // Hindsight memory plugin install (replaces our old shell hook).
@@ -2532,12 +2533,15 @@ Don't wait for a slash command. Don't ask permission. Memory work is table stake
     const switchroomMcpEntry = getSwitchroomMcpSettingsEntry(switchroomConfigPath);
     mcpServers[switchroomMcpEntry.key] = switchroomMcpEntry.value;
 
-    // Playwright browser automation MCP (built-in default).
-    // Agents can suppress it with `mcp_servers: { playwright: false }`.
-    const playwrightEntry = getPlaywrightMcpSettingsEntry();
-    const playwrightOptOut = (agentConfig.mcp_servers ?? {})[playwrightEntry.key] === false;
-    if (!playwrightOptOut) {
-      mcpServers[playwrightEntry.key] = playwrightEntry.value;
+    // Built-in default MCPs (e.g. playwright). Single source of truth lives
+    // in scaffold-integration.ts; `switchroom update` reconciles the same
+    // list onto pre-existing agents. Agents opt out via
+    // `mcp_servers: { <key>: false }` in switchroom.yaml.
+    for (const entry of getBuiltinDefaultMcpEntries()) {
+      const optOut = (agentConfig.mcp_servers ?? {})[entry.optOutKey] === false;
+      if (!optOut) {
+        mcpServers[entry.key] = entry.value;
+      }
     }
 
     // User-defined extras from switchroom.yaml agents.<name>.mcp_servers.

--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -6,6 +6,7 @@ import { dirname, join, resolve } from "node:path";
 import { tmpdir, homedir } from "node:os";
 import { withConfigError, getConfig } from "./helpers.js";
 import { reconcileAgent } from "../agents/scaffold.js";
+import { reconcileAllAgentDefaultMcps } from "../agents/reconcile-default-mcps.js";
 import { restartAgent, writeRestartReasonMarker } from "../agents/lifecycle.js";
 import { installAllUnits } from "../agents/systemd.js";
 import { resolveAgentsDir } from "../config/loader.js";
@@ -458,6 +459,36 @@ async function runPostBuildPhase(opts: {
     );
     console.error(chalk.red("    Aborting update — fix unit generation and re-run."));
     process.exit(1);
+  }
+
+  // Reconcile built-in default MCPs into every agent on disk. Additive only —
+  // never removes existing entries, respects per-agent opt-outs. Runs before
+  // the full reconcileAgent loop so agents that exist on disk but aren't in
+  // switchroom.yaml (orphaned agents) also pick up new defaults. For agents
+  // that ARE in config, reconcileAgent will fully rebuild mcpServers anyway —
+  // this step is a belt-and-suspenders that also surfaces explicit per-agent
+  // logging so the operator can see exactly what was added.
+  {
+    console.log(chalk.bold(`\n  Reconciling built-in default MCPs...`));
+    const agentOptOuts: Record<string, Record<string, unknown>> = {};
+    for (const [name, agentCfg] of Object.entries(config.agents)) {
+      if (agentCfg?.mcp_servers) {
+        agentOptOuts[name] = agentCfg.mcp_servers as Record<string, unknown>;
+      }
+    }
+    const mcpResults = reconcileAllAgentDefaultMcps(agentsDir, agentOptOuts);
+    for (const r of mcpResults) {
+      if (r.added.length > 0) {
+        console.log(chalk.green(`    ${r.name}: added ${r.added.join(", ")}`));
+      } else if (r.optedOut.length > 0 && r.alreadyPresent.length === 0) {
+        console.log(chalk.gray(`    ${r.name}: opted out of ${r.optedOut.join(", ")}`));
+      } else {
+        console.log(chalk.gray(`    ${r.name}: already present`));
+      }
+    }
+    if (mcpResults.length === 0) {
+      console.log(chalk.gray("    no agent directories found"));
+    }
   }
 
   // Reconcile-all-first. Pre-flight every agent before touching any live

--- a/src/memory/scaffold-integration.ts
+++ b/src/memory/scaffold-integration.ts
@@ -52,6 +52,45 @@ export function getPlaywrightMcpSettingsEntry(): { key: string; value: McpServer
 }
 
 /**
+ * Describes a single built-in default MCP entry.
+ *
+ * - `key`: the mcpServers key in settings.json (e.g. "playwright")
+ * - `value`: the MCP server config object to write
+ * - `optOutKey`: the key in `mcp_servers` that an agent uses to opt out
+ *   (currently always the same as `key`, but kept explicit so the type is
+ *   self-documenting and future entries can differ)
+ */
+export interface BuiltinMcpEntry {
+  key: string;
+  value: McpServerConfig;
+  /** The key an agent sets to `false` in `mcp_servers` to suppress this default. */
+  optOutKey: string;
+}
+
+/**
+ * Return the complete list of built-in default MCP entries that every agent
+ * should receive unless explicitly opted out.
+ *
+ * This is the single source of truth consumed by both:
+ *   - `scaffoldAgent` / `reconcileAgent` (scaffold.ts) — at agent creation and
+ *     on every `switchroom agent reconcile` run
+ *   - `reconcileDefaultMcps` (update.ts) — at `switchroom update` time, so
+ *     agents created before a default was introduced pick it up automatically
+ *
+ * To add a new built-in default: add an entry here. Both scaffold and update
+ * paths will pick it up automatically.
+ *
+ * Agents can opt out of any entry by setting
+ * `mcp_servers: { <optOutKey>: false }` in their switchroom.yaml config.
+ */
+export function getBuiltinDefaultMcpEntries(): BuiltinMcpEntry[] {
+  const playwright = getPlaywrightMcpSettingsEntry();
+  return [
+    { key: playwright.key, value: playwright.value, optOutKey: playwright.key },
+  ];
+}
+
+/**
  * Return the MCP server entry for the Switchroom management server.
  *
  * The switchroom-mcp server is a thin wrapper around the `switchroom` CLI,


### PR DESCRIPTION
Closes #372

## Summary

- `getBuiltinDefaultMcpEntries()` in `src/memory/scaffold-integration.ts` is now the single source of truth for built-in default MCP entries (currently just `@playwright/mcp`). Both scaffold and update paths consume it.
- New module `src/agents/reconcile-default-mcps.ts` exposes `reconcileAgentDefaultMcps` (single agent) and `reconcileAllAgentDefaultMcps` (fleet-wide). Additive-only, never overwrites existing entries, honours `mcp_servers: { key: false }` opt-outs, idempotent.
- `runPostBuildPhase` in `src/cli/update.ts` now runs the default-MCP reconcile step before the existing `reconcileAgent` loop, iterating over every agent directory on disk (including orphaned agents not in `switchroom.yaml`).

## Behaviour

Adding a new built-in default MCP to `getBuiltinDefaultMcpEntries()` is now sufficient — both new agents (via scaffold) and existing agents (via update) pick it up automatically.

Logged output per agent:
```
  Reconciling built-in default MCPs...
    klanker: added playwright
    gymbro: already present
    clerk: opted out of playwright
```

## Test plan

**Manual repro recipe:**

- Agent X exists, `settings.json` lacks `playwright`. Run `switchroom update`. Confirm `playwright` is now in `settings.json`.
- Agent Y has `mcp_servers: { playwright: false }` in `switchroom.yaml`. Run `switchroom update`. Confirm `playwright` is NOT added to `settings.json`.
- Run `switchroom update` again on both agents. Confirm zero changes on the second run (idempotent — X says "already present", Y says "opted out").

**Unit tests (9 cases, all green):**
- [ ] adds missing built-in default to `settings.json`
- [ ] leaves an existing (possibly customised) entry alone
- [ ] honours per-agent opt-out (`mcp_servers: { playwright: false }`)
- [ ] idempotent — second run produces zero file writes
- [ ] silently skips agents with no `settings.json`
- [ ] adds default when `mcpServers` key is absent entirely
- [ ] fleet iterate: covers add / already-present / opted-out in one pass
- [ ] returns empty array when agentsDir doesn't exist
- [ ] skips non-directory entries in agentsDir

🤖 Generated with [Claude Code](https://claude.com/claude-code)