### PR TITLE
feat(workspace): support per-agent extra_stable_files config

### DIFF
--- a/src/agents/bootstrap-types.ts
+++ b/src/agents/bootstrap-types.ts
@@ -32,12 +32,19 @@ export type WorkspaceBootstrapFileName =
   | typeof DEFAULT_MEMORY_FILENAME;
 
 /**
+ * A file name used in the workspace bootstrap pipeline. Well-known names are
+ * enumerated in `WorkspaceBootstrapFileName`; agent-declared extra files from
+ * `extra_stable_files` use arbitrary `string` filenames.
+ */
+export type WorkspaceFileName = WorkspaceBootstrapFileName | (string & {});
+
+/**
  * A file discovered in the workspace bootstrap pipeline. `content` is the raw
  * file contents (no trimming) when present. `missing` is true when the file
  * does not exist in the workspace.
  */
 export type WorkspaceBootstrapFile = {
-  name: WorkspaceBootstrapFileName;
+  name: WorkspaceFileName;
   path: string;
   content?: string;
   missing: boolean;

--- a/src/agents/workspace.ts
+++ b/src/agents/workspace.ts
@@ -81,6 +81,7 @@ import {
   type EmbeddedContextFile,
   type WorkspaceBootstrapFile,
   type WorkspaceBootstrapFileName,
+  type WorkspaceFileName,
 } from "./bootstrap-types.js";
 
 export const DEFAULT_WORKSPACE_DIR_NAME = "workspace";
@@ -171,7 +172,7 @@ function isErrnoException(value: unknown): value is NodeJS.ErrnoException {
 
 async function loadNamedFile(
   workspaceDir: string,
-  name: WorkspaceBootstrapFileName,
+  name: WorkspaceFileName,
   relativePath?: string,
 ): Promise<WorkspaceBootstrapFile> {
   const filePath = path.join(workspaceDir, relativePath ?? name);
@@ -186,14 +187,27 @@ async function loadNamedFile(
  * Load the stable workspace bootstrap files. Files that don't exist are
  * reported as `missing: true` rather than throwing, so callers can decide
  * whether absence is acceptable.
+ *
+ * `extraStableFiles` is an optional list of additional filenames (relative to
+ * `workspaceDir`) to append after the defaults. This corresponds to the
+ * per-agent `extra_stable_files` config field in `switchroom.yaml`. Missing
+ * files yield `missing: true` and are silently skipped during rendering.
  */
 export async function loadStableBootstrapFiles(
   workspaceDir: string,
+  options?: { extraStableFiles?: string[] },
 ): Promise<WorkspaceBootstrapFile[]> {
-  const loaded = await Promise.all(
+  const defaultFiles = await Promise.all(
     STABLE_BOOTSTRAP_FILENAMES.map((name) => loadNamedFile(workspaceDir, name)),
   );
-  return loaded;
+  const extras = options?.extraStableFiles ?? [];
+  if (extras.length === 0) {
+    return defaultFiles;
+  }
+  const extraFiles = await Promise.all(
+    extras.map((name) => loadNamedFile(workspaceDir, name)),
+  );
+  return [...defaultFiles, ...extraFiles];
 }
 
 /**
@@ -394,13 +408,20 @@ export function projectBootstrapFiles(params: {
 /**
  * Convenience: build the full `--append-system-prompt` block for stable
  * files. Returns empty string when no files exist.
+ *
+ * `extraStableFiles` is forwarded to `loadStableBootstrapFiles` and
+ * corresponds to the per-agent `extra_stable_files` config in
+ * `switchroom.yaml`. Pass an empty array or omit to get default behavior.
  */
 export async function buildStableBootstrapPrompt(params: {
   workspaceDir: string;
+  extraStableFiles?: string[];
   budget?: BootstrapBudgetConfig;
   seenSignatures?: string[];
 }): Promise<BootstrapInjectionResult> {
-  const files = await loadStableBootstrapFiles(params.workspaceDir);
+  const files = await loadStableBootstrapFiles(params.workspaceDir, {
+    extraStableFiles: params.extraStableFiles,
+  });
   const budget = {
     bootstrapMaxChars: params.budget?.bootstrapMaxChars ?? DEFAULT_BOOTSTRAP_MAX_CHARS,
     bootstrapTotalMaxChars:

--- a/src/cli/workspace.ts
+++ b/src/cli/workspace.ts
@@ -122,6 +122,11 @@ export function registerWorkspaceCommand(program: Command): void {
             ? safeParseInt(opts.maxTotal, defaultTotal)
             : defaultTotal;
 
+          // Resolve extra_stable_files from the agent's config for stable render.
+          const extraStableFiles = stable
+            ? resolveAgentExtraStableFiles(program, agentName)
+            : undefined;
+
           try {
             const result = dynamic
               ? await buildDynamicBootstrapPrompt({
@@ -134,6 +139,7 @@ export function registerWorkspaceCommand(program: Command): void {
                 })
               : await buildStableBootstrapPrompt({
                   workspaceDir: dir,
+                  extraStableFiles,
                   budget: {
                     bootstrapMaxChars: maxPerFile,
                     bootstrapTotalMaxChars: maxTotal,
@@ -399,6 +405,23 @@ function resolveAgentWorkspaceDirOrExit(
     return undefined;
   }
   return dir;
+}
+
+/**
+ * Return `extra_stable_files` from the named agent's raw config in
+ * switchroom.yaml. Returns an empty array when the agent is not defined or
+ * has no `extra_stable_files` entry — callers can pass this directly to
+ * `buildStableBootstrapPrompt` without any null-checks.
+ *
+ * NOTE: This reads the raw (unresolved) agent config. Profile / defaults
+ * cascade is intentionally skipped here because `extra_stable_files` is a
+ * workspace-level concern and callers that need the full resolved value
+ * (e.g. scaffold.ts) should call `resolveAgentConfig` themselves.
+ */
+function resolveAgentExtraStableFiles(program: Command, agentName: string): string[] {
+  const config = getConfig(program);
+  const agentConfig = config.agents[agentName];
+  return agentConfig?.extra_stable_files ?? [];
 }
 
 function normalizeWarningMode(value: string | undefined): BootstrapPromptWarningMode {

--- a/src/config/merge.ts
+++ b/src/config/merge.ts
@@ -429,5 +429,16 @@ export function mergeAgentConfig(
     ];
   }
 
+  // --- extra_stable_files: union, dedup-preserving-order (defaults first) ---
+  //
+  // Follows the same pattern as `skills`: defaults provide the base list,
+  // per-agent entries extend it. Duplicates are removed so the same file
+  // isn't loaded twice if both layers declare it.
+  if (defaults.extra_stable_files || merged.extra_stable_files) {
+    const d = defaults.extra_stable_files ?? [];
+    const a = merged.extra_stable_files ?? [];
+    merged.extra_stable_files = dedupe([...d, ...a]);
+  }
+
   return merged;
 }

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -591,6 +591,15 @@ const profileFields = {
   settings_raw: z.record(z.string(), z.unknown()).optional(),
   claude_md_raw: z.string().optional(),
   cli_args: z.array(z.string()).optional(),
+  extra_stable_files: z
+    .array(z.string())
+    .optional()
+    .describe(
+      "Extra filenames (relative to the agent's workspace directory) to append " +
+      "to the stable bootstrap render. Loaded once at session start via " +
+      "`--append-system-prompt`. Missing files are silently skipped. " +
+      "Example: ['BRIEF.md', 'CONTEXT.md'].",
+    ),
 };
 
 /**
@@ -804,6 +813,15 @@ export const AgentSchema = z.object({
       "invocation in start.sh. Use for Claude Code CLI flags switchroom " +
       "doesn't expose directly (e.g. --effort high, " +
       "--exclude-dynamic-system-prompt-sections)."
+    ),
+  extra_stable_files: z
+    .array(z.string())
+    .optional()
+    .describe(
+      "Extra filenames (relative to the agent's workspace directory) to append " +
+      "to the stable bootstrap render. Loaded once at session start via " +
+      "`--append-system-prompt`. Missing files are silently skipped. " +
+      "Example: ['BRIEF.md', 'CONTEXT.md'].",
     ),
   code_repos: z
     .array(CodeRepoEntrySchema)

--- a/tests/workspace.stable.test.ts
+++ b/tests/workspace.stable.test.ts
@@ -1,0 +1,276 @@
+/**
+ * Tests for the `extra_stable_files` feature — per-agent config option
+ * to include additional files in the stable workspace render.
+ *
+ * Replaces the earlier hardcoded BRIEF.md approach from feat/brief-md-stable-render.
+ * See feat/extra-stable-files for the design rationale.
+ */
+
+import { describe, it, expect, afterEach } from "vitest";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import {
+  buildStableBootstrapPrompt,
+  loadStableBootstrapFiles,
+  STABLE_BOOTSTRAP_FILENAMES,
+} from "../src/agents/workspace.js";
+
+async function makeWorkspace(files: Record<string, string>): Promise<string> {
+  const dir = await mkdtemp(path.join(tmpdir(), "sr-extra-stable-"));
+  for (const [relPath, content] of Object.entries(files)) {
+    const full = path.join(dir, relPath);
+    await mkdir(path.dirname(full), { recursive: true });
+    await writeFile(full, content, "utf8");
+  }
+  return dir;
+}
+
+// ---------------------------------------------------------------------------
+// loadStableBootstrapFiles — extra_stable_files option
+// ---------------------------------------------------------------------------
+
+describe("loadStableBootstrapFiles with no extra_stable_files", () => {
+  let dir: string;
+  afterEach(async () => {
+    if (dir) await rm(dir, { recursive: true, force: true });
+  });
+
+  it("returns only default files when no extraStableFiles provided", async () => {
+    dir = await makeWorkspace({
+      "AGENTS.md": "agents content",
+      "SOUL.md": "soul content",
+      "BRIEF.md": "brief content that should NOT appear in default render",
+    });
+    const files = await loadStableBootstrapFiles(dir);
+    const names = files.map((f) => f.name);
+    // Should match exactly the STABLE_BOOTSTRAP_FILENAMES defaults
+    expect(names).toEqual(STABLE_BOOTSTRAP_FILENAMES);
+    // BRIEF.md must not be present
+    expect(names).not.toContain("BRIEF.md");
+    expect(files).toHaveLength(STABLE_BOOTSTRAP_FILENAMES.length);
+  });
+
+  it("returns only default files when extraStableFiles is empty array", async () => {
+    dir = await makeWorkspace({ "AGENTS.md": "hi" });
+    const files = await loadStableBootstrapFiles(dir, { extraStableFiles: [] });
+    expect(files).toHaveLength(STABLE_BOOTSTRAP_FILENAMES.length);
+  });
+});
+
+describe("loadStableBootstrapFiles with extra_stable_files: ['BRIEF.md']", () => {
+  let dir: string;
+  afterEach(async () => {
+    if (dir) await rm(dir, { recursive: true, force: true });
+  });
+
+  it("loads BRIEF.md content when the file exists", async () => {
+    dir = await makeWorkspace({
+      "AGENTS.md": "agents",
+      "BRIEF.md": "# Case Brief\nThis is the brief.",
+    });
+    const files = await loadStableBootstrapFiles(dir, { extraStableFiles: ["BRIEF.md"] });
+    const brief = files.find((f) => f.name === "BRIEF.md");
+    expect(brief).toBeDefined();
+    expect(brief?.missing).toBe(false);
+    expect(brief?.content).toBe("# Case Brief\nThis is the brief.");
+  });
+
+  it("appends BRIEF.md after the default files, not before", async () => {
+    dir = await makeWorkspace({
+      "AGENTS.md": "a",
+      "BRIEF.md": "brief",
+    });
+    const files = await loadStableBootstrapFiles(dir, { extraStableFiles: ["BRIEF.md"] });
+    const names = files.map((f) => f.name);
+    const briefIdx = names.indexOf("BRIEF.md");
+    // BRIEF.md should come after all default stable filenames
+    for (const defaultName of STABLE_BOOTSTRAP_FILENAMES) {
+      const defaultIdx = names.indexOf(defaultName);
+      expect(briefIdx).toBeGreaterThan(defaultIdx);
+    }
+  });
+
+  it("marks BRIEF.md as missing: true when file does not exist", async () => {
+    dir = await makeWorkspace({ "AGENTS.md": "a" });
+    const files = await loadStableBootstrapFiles(dir, { extraStableFiles: ["BRIEF.md"] });
+    const brief = files.find((f) => f.name === "BRIEF.md");
+    expect(brief).toBeDefined();
+    expect(brief?.missing).toBe(true);
+  });
+});
+
+describe("loadStableBootstrapFiles with extra_stable_files: ['NONEXISTENT.md']", () => {
+  let dir: string;
+  afterEach(async () => {
+    if (dir) await rm(dir, { recursive: true, force: true });
+  });
+
+  it("does not throw when extra file is missing", async () => {
+    dir = await makeWorkspace({ "AGENTS.md": "a" });
+    await expect(
+      loadStableBootstrapFiles(dir, { extraStableFiles: ["NONEXISTENT.md"] }),
+    ).resolves.not.toThrow();
+  });
+
+  it("includes missing entry but gracefully skips in render", async () => {
+    dir = await makeWorkspace({ "AGENTS.md": "agents content" });
+    const result = await buildStableBootstrapPrompt({
+      workspaceDir: dir,
+      extraStableFiles: ["NONEXISTENT.md"],
+    });
+    // Should not error, NONEXISTENT.md should not appear in output
+    expect(result.concatenated).not.toContain("NONEXISTENT.md");
+    // agents content should still be present
+    expect(result.concatenated).toContain("agents content");
+  });
+});
+
+describe("loadStableBootstrapFiles with multiple extra_stable_files", () => {
+  let dir: string;
+  afterEach(async () => {
+    if (dir) await rm(dir, { recursive: true, force: true });
+  });
+
+  it("loads both FOO.md and BAR.md in declared order", async () => {
+    dir = await makeWorkspace({
+      "FOO.md": "foo content",
+      "BAR.md": "bar content",
+    });
+    const files = await loadStableBootstrapFiles(dir, {
+      extraStableFiles: ["FOO.md", "BAR.md"],
+    });
+    const names = files.map((f) => f.name);
+    const fooIdx = names.indexOf("FOO.md");
+    const barIdx = names.indexOf("BAR.md");
+    expect(fooIdx).toBeGreaterThan(-1);
+    expect(barIdx).toBeGreaterThan(-1);
+    // FOO before BAR (declared order preserved)
+    expect(fooIdx).toBeLessThan(barIdx);
+    // Both extra files come after all defaults
+    for (const defaultName of STABLE_BOOTSTRAP_FILENAMES) {
+      const defaultIdx = names.indexOf(defaultName);
+      expect(fooIdx).toBeGreaterThan(defaultIdx);
+      expect(barIdx).toBeGreaterThan(defaultIdx);
+    }
+  });
+
+  it("includes content from both extra files in the stable render", async () => {
+    dir = await makeWorkspace({
+      "AGENTS.md": "base agents",
+      "FOO.md": "foo body",
+      "BAR.md": "bar body",
+    });
+    const result = await buildStableBootstrapPrompt({
+      workspaceDir: dir,
+      extraStableFiles: ["FOO.md", "BAR.md"],
+    });
+    expect(result.concatenated).toContain("foo body");
+    expect(result.concatenated).toContain("bar body");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildStableBootstrapPrompt — end-to-end with extra_stable_files
+// ---------------------------------------------------------------------------
+
+describe("buildStableBootstrapPrompt with extra_stable_files: ['BRIEF.md']", () => {
+  let dir: string;
+  afterEach(async () => {
+    if (dir) await rm(dir, { recursive: true, force: true });
+  });
+
+  it("includes BRIEF.md content in the render output", async () => {
+    dir = await makeWorkspace({
+      "AGENTS.md": "agent rules",
+      "BRIEF.md": "case brief text",
+    });
+    const result = await buildStableBootstrapPrompt({
+      workspaceDir: dir,
+      extraStableFiles: ["BRIEF.md"],
+    });
+    expect(result.concatenated).toContain("case brief text");
+  });
+
+  it("does NOT include BRIEF.md when extraStableFiles is omitted", async () => {
+    dir = await makeWorkspace({
+      "AGENTS.md": "agent rules",
+      "BRIEF.md": "case brief text that should NOT appear",
+    });
+    const result = await buildStableBootstrapPrompt({ workspaceDir: dir });
+    expect(result.concatenated).not.toContain("case brief text that should NOT appear");
+  });
+
+  it("injectedFiles count includes the extra file when present", async () => {
+    dir = await makeWorkspace({
+      "AGENTS.md": "agent rules",
+      "BRIEF.md": "brief",
+    });
+    const withExtra = await buildStableBootstrapPrompt({
+      workspaceDir: dir,
+      extraStableFiles: ["BRIEF.md"],
+    });
+    const withoutExtra = await buildStableBootstrapPrompt({ workspaceDir: dir });
+    expect(withExtra.injectedFiles.length).toBe(withoutExtra.injectedFiles.length + 1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Schema validation — extra_stable_files rejects non-string entries
+// ---------------------------------------------------------------------------
+
+describe("AgentSchema — extra_stable_files validation", () => {
+  it("accepts a valid string array", async () => {
+    const { AgentSchema } = await import("../src/config/schema.js");
+    const result = AgentSchema.safeParse({
+      topic_name: "Test Agent",
+      extra_stable_files: ["BRIEF.md", "CONTEXT.md"],
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.extra_stable_files).toEqual(["BRIEF.md", "CONTEXT.md"]);
+    }
+  });
+
+  it("accepts omitted extra_stable_files (optional field)", async () => {
+    const { AgentSchema } = await import("../src/config/schema.js");
+    const result = AgentSchema.safeParse({ topic_name: "Test Agent" });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.extra_stable_files).toBeUndefined();
+    }
+  });
+
+  it("accepts an empty array", async () => {
+    const { AgentSchema } = await import("../src/config/schema.js");
+    const result = AgentSchema.safeParse({
+      topic_name: "Test Agent",
+      extra_stable_files: [],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects non-string entries (e.g. [123])", async () => {
+    const { AgentSchema } = await import("../src/config/schema.js");
+    const result = AgentSchema.safeParse({
+      topic_name: "Test Agent",
+      extra_stable_files: [123],
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const msg = result.error.issues[0]?.message ?? "";
+      // Zod reports "Expected string, received number" for z.string() violations
+      expect(msg).toMatch(/string/i);
+    }
+  });
+
+  it("rejects mixed array with non-string entries", async () => {
+    const { AgentSchema } = await import("../src/config/schema.js");
+    const result = AgentSchema.safeParse({
+      topic_name: "Test Agent",
+      extra_stable_files: ["BRIEF.md", null],
+    });
+    expect(result.success).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a per-agent `extra_stable_files` yaml field so agents can declare additional workspace files to include in the stable bootstrap render alongside the default set (`AGENTS.md`, `SOUL.md`, `IDENTITY.md`, `USER.md`, `TOOLS.md`, `BOOTSTRAP.md`).

## Why

Live regression: agents that declare `extra_stable_files: [...]` in `switchroom.yaml` silently lose those files because the schema strips unknown fields. `lawgpt` is one production agent currently running without its `BRIEF.md` for this reason.

Replaces the earlier hardcoded `BRIEF.md` approach with a generic shape — any agent can supply its own key markdown inputs.

## Changes

- `src/config/schema.ts` + `src/config/merge.ts` — schema accepts `extra_stable_files: string[]`
- `src/agents/workspace.ts` + `src/agents/bootstrap-types.ts` — render path loads each declared file and slots it into the stable section
- `src/cli/workspace.ts` — `switchroom workspace render` honours the new field
- `tests/workspace.stable.test.ts` — 276-line test suite covering present/missing/empty/multiple files

Missing files are silently skipped (matching the pattern for default files). Field is optional — agents without it render unchanged.

## Closes

Part of #322 (Phase 0).