### PR TITLE
feat(reconcile): yaml-driven hooks block in settings.json (Phase 2 of #322)

### DIFF
--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -1466,197 +1466,22 @@ export function scaffoldAgent(
       // object — plugin-installed hooks (hindsight) live in the plugin's
       // own hooks.json and are loaded via --plugin-dir, so they're not
       // affected by this and Claude Code merges them at runtime.
-      const userHooks = translateHooksToClaudeShape(agentConfig.hooks);
       // Per #142, the SessionStart greeting hook + session-greeting.sh
       // curl script are deleted. The boot card (telegram-plugin/gateway/
       // boot-card.ts) now handles "agent is back" UX with a quiet, settle-
       // gated single-line ack; the full config audit content moves to a
       // future `/status` command (#142 PR 3).
-      // Switchroom-owned Stop hook: produce the session-handoff briefing so
-      // the next session can wake up with a compact summary injected
-      // via --append-system-prompt. Gated on session_continuity.enabled
-      // (default true). async+timeout so it never blocks shutdown.
-      const handoffEnabled = agentConfig.session_continuity?.enabled !== false;
-      const handoffConfigArg = switchroomConfigPath
-        ? ` --config ${shellSingleQuote(resolve(switchroomConfigPath))}`
-        : "";
-      const switchroomStopHooks: Array<{ type: string; command: string; timeout: number; async: boolean }> = [];
-      if (handoffEnabled) {
-        switchroomStopHooks.push({
-          type: "command",
-          command: `switchroom${handoffConfigArg} handoff ${name}`,
-          timeout: 35,
-          async: true,
-        });
-      }
-      // User-profile Mental Model refresh hook (when Hindsight is enabled)
-      if (hindsightEnabled) {
-        switchroomStopHooks.push({
-          type: "command",
-          command: `bash "${join(REPO_ROOT, "bin", "user-profile-refresh-hook.sh")}"`,
-          timeout: 10,
-          async: true,
-        });
-      }
-      // Switchroom-owned secret-scrub Stop hook: scans transcript at shutdown
-      // and rewrites any currently-active vault values to vault:${slug}.
-      // Gated on telegram-plugin being in use (the hook script ships with
-      // the plugin and only makes sense when the plugin-backed vault flow
-      // is active). Async so it can't block session shutdown.
-      const useSwitchroomPluginHook = usesSwitchroomTelegramPlugin(agentConfig);
-      if (useSwitchroomPluginHook) {
-        switchroomStopHooks.push({
-          type: "command",
-          command: `node "${join(REPO_ROOT, "telegram-plugin", "hooks", "secret-scrub-stop.mjs")}"`,
-          timeout: 15,
-          async: true,
-        });
-        // Silent-end auto-interrupt: when the agent ends a turn without
-        // sending a reply, return decision:block to re-prompt the agent
-        // (capped at 1 retry per turn — see hook + gateway state file).
-        // Must be SYNC so Claude Code reads stdout for the block decision.
-        switchroomStopHooks.push({
-          type: "command",
-          command: `node "${join(REPO_ROOT, "telegram-plugin", "hooks", "silent-end-interrupt-stop.mjs")}"`,
-          timeout: 5,
-          async: false,
-        });
-      }
-      const switchroomStop = switchroomStopHooks.length > 0
-        ? [{ hooks: switchroomStopHooks }]
-        : [];
-      // Switchroom-owned PreToolUse hooks:
-      //   1. secret-guard: blocks any tool call whose input contains a
-      //      currently-active vault value verbatim (second-line defense against
-      //      secrets leaking past the ingest-side detector).
-      //   2. subagent-tracker: writes a 'running' row to the subagents table
-      //      whenever an Agent() tool call is about to fire (Phase 2 of #333).
-      // Same plugin gating as the Stop hook.
-      const switchroomPreToolUse = useSwitchroomPluginHook
-        ? [
-            {
-              hooks: [
-                {
-                  type: "command",
-                  command: `node "${join(REPO_ROOT, "telegram-plugin", "hooks", "secret-guard-pretool.mjs")}"`,
-                  timeout: 10,
-                },
-              ],
-            },
-            {
-              hooks: [
-                {
-                  type: "command",
-                  command: `node "${join(REPO_ROOT, "telegram-plugin", "hooks", "subagent-tracker-pretool.mjs")}"`,
-                  timeout: 10,
-                },
-              ],
-            },
-          ]
-        : [];
-      // Switchroom-owned PostToolUse hook: updates the subagents row to
-      // 'completed' or 'failed' once an Agent() call returns.
-      const switchroomPostToolUse = useSwitchroomPluginHook
-        ? [
-            {
-              hooks: [
-                {
-                  type: "command",
-                  command: `node "${join(REPO_ROOT, "telegram-plugin", "hooks", "subagent-tracker-posttool.mjs")}"`,
-                  timeout: 10,
-                },
-              ],
-            },
-          ]
-        : [];
-      // Switchroom-owned UserPromptSubmit hooks: inject workspace content at
-      // the start of every turn. When hotReloadStable is true, the stable
-      // workspace files (AGENTS.md, SOUL.md, USER.md, IDENTITY.md, TOOLS.md,
-      // HEARTBEAT.md) are injected here instead of baked into start.sh's
-      // --append-system-prompt. Dynamic files (MEMORY.md, daily notes) are
-      // always injected per-turn. Coexists with Hindsight's own
-      // UserPromptSubmit hook (loaded via the plugin's hooks.json). 5-6s
-      // timeouts so slow renders never block the turn; silent failure (no
-      // stderr) so missing workspace files don't spam errors.
-      const useHotReloadStable = agentConfig.channels?.telegram?.hotReloadStable === true;
-      const switchroomUserPromptSubmit = [
-        ...(useHotReloadStable
-          ? [
-              {
-                hooks: [
-                  {
-                    type: "command",
-                    command: `bash "${join(REPO_ROOT, "bin", "workspace-stable-hook.sh")}"`,
-                    timeout: 6,
-                  },
-                ],
-              },
-            ]
-          : []),
-        {
-          hooks: [
-            {
-              type: "command",
-              command: `bash "${join(REPO_ROOT, "bin", "workspace-dynamic-hook.sh")}"`,
-              timeout: 5,
-            },
-          ],
-        },
-        // Timezone hook — fast (one `date` call), emits a one-line
-        // additionalContext string so the LLM sees fresh local time on every
-        // turn. Placed last so the time-of-turn line renders near the bottom
-        // of the hook-injected preamble. 3s timeout is generous headroom for
-        // a call that should finish in <20ms.
-        {
-          hooks: [
-            {
-              type: "command",
-              command: `bash "${join(REPO_ROOT, "bin", "timezone-hook.sh")}"`,
-              timeout: 3,
-            },
-          ],
-        },
-      ];
-      if (userHooks) {
-        settings.hooks = {
-          ...userHooks,
-          UserPromptSubmit: [
-            ...((userHooks.UserPromptSubmit as unknown[]) ?? []),
-            ...switchroomUserPromptSubmit,
-          ],
-          ...(switchroomPreToolUse.length > 0
-            ? {
-                PreToolUse: [
-                  ...((userHooks.PreToolUse as unknown[]) ?? []),
-                  ...switchroomPreToolUse,
-                ],
-              }
-            : {}),
-          ...(switchroomPostToolUse.length > 0
-            ? {
-                PostToolUse: [
-                  ...((userHooks.PostToolUse as unknown[]) ?? []),
-                  ...switchroomPostToolUse,
-                ],
-              }
-            : {}),
-          ...(switchroomStop.length > 0
-            ? {
-                Stop: [
-                  ...((userHooks.Stop as unknown[]) ?? []),
-                  ...switchroomStop,
-                ],
-              }
-            : {}),
-        };
-      } else {
-        settings.hooks = {
-          UserPromptSubmit: switchroomUserPromptSubmit,
-          ...(switchroomPreToolUse.length > 0 ? { PreToolUse: switchroomPreToolUse } : {}),
-          ...(switchroomPostToolUse.length > 0 ? { PostToolUse: switchroomPostToolUse } : {}),
-          ...(switchroomStop.length > 0 ? { Stop: switchroomStop } : {}),
-        };
-      }
+      //
+      // buildSettingsHooksBlock() is the single source of truth for the full
+      // hooks block (user yaml + switchroom-owned). Reconcile calls the same
+      // function so both paths are guaranteed byte-identical.
+      settings.hooks = buildSettingsHooksBlock({
+        agentName: name,
+        agentConfig,
+        hindsightEnabled,
+        useSwitchroomPlugin: usesSwitchroomTelegramPlugin(agentConfig),
+        configPath: switchroomConfigPath,
+      });
       // Explicit model override: written to settings.model so the user
       // doesn't have to pass --model on every invocation.
       if (agentConfig.model !== undefined) {
@@ -2170,6 +1995,249 @@ export interface ReconcileOptions {
   preserveClaudeMd?: boolean;
 }
 
+/**
+ * Parameters for buildSettingsHooksBlock — extracted so the function can be
+ * called from both reconcileAgent and the drift-check path without
+ * duplicating the logic.
+ */
+export interface HooksBlockParams {
+  /** Agent name (used for `switchroom handoff <name>`) */
+  agentName: string;
+  /** Merged yaml hooks (defaults → profile → agent, already resolved) */
+  agentConfig: AgentConfig;
+  /** Whether the Hindsight memory backend is active for this agent */
+  hindsightEnabled: boolean;
+  /** Whether this agent uses the switchroom telegram plugin */
+  useSwitchroomPlugin: boolean;
+  /**
+   * Path to switchroom.yaml — when set, the handoff hook includes
+   * `--config <path>` so the handoff command can locate the right config
+   * even when invoked outside the default config search path.
+   */
+  configPath?: string;
+}
+
+/**
+ * Compute the full settings.json `hooks` block for a given agent config.
+ *
+ * Combines:
+ *   1. User-declared hooks from switchroom.yaml (via translateHooksToClaudeShape)
+ *   2. Switchroom-owned hooks (handoff, user-profile-refresh, secret-scrub,
+ *      secret-guard, subagent-tracker, workspace injection, timezone)
+ *
+ * This is the single source of truth for what reconcileAgent writes to
+ * settings.json. Exported so the drift-check path can call it without
+ * performing a full reconcile.
+ *
+ * The output is a plain JSON-serialisable object suitable for
+ * `settings.hooks = buildSettingsHooksBlock(...)`.
+ */
+export function buildSettingsHooksBlock(p: HooksBlockParams): Record<string, unknown> {
+  const { agentName, agentConfig, hindsightEnabled, useSwitchroomPlugin, configPath } = p;
+
+  const userHooks = translateHooksToClaudeShape(agentConfig.hooks);
+
+  // --- Switchroom-owned Stop hooks ---
+  const handoffEnabled = agentConfig.session_continuity?.enabled !== false;
+  const handoffConfigArg = configPath
+    ? ` --config ${shellSingleQuote(resolve(configPath))}`
+    : "";
+  const stopHooks: Array<Record<string, unknown>> = [];
+  if (handoffEnabled) {
+    stopHooks.push({
+      type: "command",
+      command: `switchroom${handoffConfigArg} handoff ${agentName}`,
+      timeout: 35,
+      async: true,
+    });
+  }
+  if (hindsightEnabled) {
+    stopHooks.push({
+      type: "command",
+      command: `bash "${join(REPO_ROOT, "bin", "user-profile-refresh-hook.sh")}"`,
+      timeout: 10,
+      async: true,
+    });
+  }
+  if (useSwitchroomPlugin) {
+    stopHooks.push({
+      type: "command",
+      command: `node "${join(REPO_ROOT, "telegram-plugin", "hooks", "secret-scrub-stop.mjs")}"`,
+      timeout: 15,
+      async: true,
+    });
+    stopHooks.push({
+      type: "command",
+      command: `node "${join(REPO_ROOT, "telegram-plugin", "hooks", "silent-end-interrupt-stop.mjs")}"`,
+      timeout: 5,
+      async: false,
+    });
+  }
+  const switchroomStop = stopHooks.length > 0 ? [{ hooks: stopHooks }] : [];
+
+  // --- Switchroom-owned PreToolUse hooks ---
+  const switchroomPreToolUse = useSwitchroomPlugin
+    ? [
+        {
+          hooks: [
+            {
+              type: "command",
+              command: `node "${join(REPO_ROOT, "telegram-plugin", "hooks", "secret-guard-pretool.mjs")}"`,
+              timeout: 10,
+            },
+          ],
+        },
+        {
+          hooks: [
+            {
+              type: "command",
+              command: `node "${join(REPO_ROOT, "telegram-plugin", "hooks", "subagent-tracker-pretool.mjs")}"`,
+              timeout: 10,
+            },
+          ],
+        },
+      ]
+    : [];
+
+  // --- Switchroom-owned PostToolUse hooks ---
+  const switchroomPostToolUse = useSwitchroomPlugin
+    ? [
+        {
+          hooks: [
+            {
+              type: "command",
+              command: `node "${join(REPO_ROOT, "telegram-plugin", "hooks", "subagent-tracker-posttool.mjs")}"`,
+              timeout: 10,
+            },
+          ],
+        },
+      ]
+    : [];
+
+  // --- Switchroom-owned UserPromptSubmit hooks ---
+  const useHotReloadStable = agentConfig.channels?.telegram?.hotReloadStable === true;
+  const switchroomUserPromptSubmit: Array<Record<string, unknown>> = [
+    ...(useHotReloadStable
+      ? [
+          {
+            hooks: [
+              {
+                type: "command",
+                command: `bash "${join(REPO_ROOT, "bin", "workspace-stable-hook.sh")}"`,
+                timeout: 6,
+              },
+            ],
+          },
+        ]
+      : []),
+    {
+      hooks: [
+        {
+          type: "command",
+          command: `bash "${join(REPO_ROOT, "bin", "workspace-dynamic-hook.sh")}"`,
+          timeout: 5,
+        },
+      ],
+    },
+    {
+      hooks: [
+        {
+          type: "command",
+          command: `bash "${join(REPO_ROOT, "bin", "timezone-hook.sh")}"`,
+          timeout: 3,
+        },
+      ],
+    },
+  ];
+
+  // Combine user hooks + switchroom-owned hooks
+  if (userHooks) {
+    return {
+      ...userHooks,
+      UserPromptSubmit: [
+        ...((userHooks.UserPromptSubmit as unknown[]) ?? []),
+        ...switchroomUserPromptSubmit,
+      ],
+      ...(switchroomPreToolUse.length > 0
+        ? {
+            PreToolUse: [
+              ...((userHooks.PreToolUse as unknown[]) ?? []),
+              ...switchroomPreToolUse,
+            ],
+          }
+        : {}),
+      ...(switchroomPostToolUse.length > 0
+        ? {
+            PostToolUse: [
+              ...((userHooks.PostToolUse as unknown[]) ?? []),
+              ...switchroomPostToolUse,
+            ],
+          }
+        : {}),
+      ...(switchroomStop.length > 0
+        ? {
+            Stop: [
+              ...((userHooks.Stop as unknown[]) ?? []),
+              ...switchroomStop,
+            ],
+          }
+        : {}),
+    };
+  }
+
+  return {
+    UserPromptSubmit: switchroomUserPromptSubmit,
+    ...(switchroomPreToolUse.length > 0 ? { PreToolUse: switchroomPreToolUse } : {}),
+    ...(switchroomPostToolUse.length > 0 ? { PostToolUse: switchroomPostToolUse } : {}),
+    ...(switchroomStop.length > 0 ? { Stop: switchroomStop } : {}),
+  };
+}
+
+/**
+ * Compare an expected hooks block (from buildSettingsHooksBlock) against the
+ * actual block read from settings.json.  Returns whether they differ and a
+ * short human-readable summary of the difference.
+ *
+ * Comparison is done via canonical JSON strings (sorted keys) so key-order
+ * differences don't produce false positives.
+ */
+export function detectHooksDrift(
+  expected: Record<string, unknown>,
+  actual: Record<string, unknown>,
+): { drifted: boolean; summary: string } {
+  // Canonical serialisation: sort keys at every level so ordering never
+  // produces a false positive.
+  function canon(v: unknown): string {
+    return JSON.stringify(v, (_, val) => {
+      if (val && typeof val === "object" && !Array.isArray(val)) {
+        return Object.fromEntries(
+          Object.entries(val as Record<string, unknown>).sort(([a], [b]) => a.localeCompare(b))
+        );
+      }
+      return val;
+    });
+  }
+
+  const expectedStr = canon(expected);
+  const actualStr = canon(actual);
+
+  if (expectedStr === actualStr) {
+    return { drifted: false, summary: "in sync" };
+  }
+
+  // Summarise which top-level categories differ
+  const allKeys = new Set([...Object.keys(expected), ...Object.keys(actual)]);
+  const driftedKeys: string[] = [];
+  for (const k of allKeys) {
+    if (canon(expected[k]) !== canon(actual[k])) {
+      driftedKeys.push(k);
+    }
+  }
+
+  const summary = `DRIFTED (categories: ${driftedKeys.join(", ")})`;
+  return { drifted: true, summary };
+}
+
 export function reconcileAgent(
   name: string,
   agentConfigRaw: AgentConfig,
@@ -2598,166 +2666,19 @@ Don't wait for a slash command. Don't ask permission. Memory work is table stake
     // settings.json. Plugin-installed hooks (hindsight) live in the
     // plugin's own hooks.json and are loaded via --plugin-dir, so
     // they're not affected by this. Switchroom-owned.
-    const userHooks = translateHooksToClaudeShape(agentConfig.hooks);
+    //
+    // buildSettingsHooksBlock() is the single source of truth for the full
+    // hooks block (user yaml + switchroom-owned). It is also called by the
+    // drift-check path (reconcile --check) without performing a write.
     // SessionStart greeting hook deleted in #142 — see scaffoldAgent
     // for the rationale.
-    const handoffEnabledReconcile = agentConfig.session_continuity?.enabled !== false;
-    const switchroomStopHooksReconcile: Array<{ type: string; command: string; timeout: number; async: boolean }> = [];
-    if (handoffEnabledReconcile) {
-      switchroomStopHooksReconcile.push({
-        type: "command",
-        command: `switchroom handoff ${name}`,
-        timeout: 35,
-        async: true,
-      });
-    }
-    // User-profile Mental Model refresh hook (when Hindsight is enabled)
-    if (hindsightEnabled) {
-      switchroomStopHooksReconcile.push({
-        type: "command",
-        command: `bash "${join(REPO_ROOT, "bin", "user-profile-refresh-hook.sh")}"`,
-        timeout: 10,
-        async: true,
-      });
-    }
-    // Switchroom-owned secret-scrub Stop hook (mirror of scaffoldAgent
-    // above — keep these two blocks in sync). See scaffold.ts secret-detect
-    // commit for context.
-    const useSwitchroomPluginReconcile = usesSwitchroomTelegramPlugin(agentConfig);
-    if (useSwitchroomPluginReconcile) {
-      switchroomStopHooksReconcile.push({
-        type: "command",
-        command: `node "${join(REPO_ROOT, "telegram-plugin", "hooks", "secret-scrub-stop.mjs")}"`,
-        timeout: 15,
-        async: true,
-      });
-      // Silent-end auto-interrupt (mirror of scaffoldAgent above —
-      // keep these two blocks in sync).
-      switchroomStopHooksReconcile.push({
-        type: "command",
-        command: `node "${join(REPO_ROOT, "telegram-plugin", "hooks", "silent-end-interrupt-stop.mjs")}"`,
-        timeout: 5,
-        async: false,
-      });
-    }
-    const switchroomStop = switchroomStopHooksReconcile.length > 0
-      ? [{ hooks: switchroomStopHooksReconcile }]
-      : [];
-    // Switchroom-owned PreToolUse hooks (same as scaffoldAgent — keep in sync):
-    //   1. secret-guard
-    //   2. subagent-tracker (Phase 2 of #333)
-    const switchroomPreToolUse = useSwitchroomPluginReconcile
-      ? [
-          {
-            hooks: [
-              {
-                type: "command",
-                command: `node "${join(REPO_ROOT, "telegram-plugin", "hooks", "secret-guard-pretool.mjs")}"`,
-                timeout: 10,
-              },
-            ],
-          },
-          {
-            hooks: [
-              {
-                type: "command",
-                command: `node "${join(REPO_ROOT, "telegram-plugin", "hooks", "subagent-tracker-pretool.mjs")}"`,
-                timeout: 10,
-              },
-            ],
-          },
-        ]
-      : [];
-    // Switchroom-owned PostToolUse hook (same as scaffoldAgent — keep in sync).
-    const switchroomPostToolUse = useSwitchroomPluginReconcile
-      ? [
-          {
-            hooks: [
-              {
-                type: "command",
-                command: `node "${join(REPO_ROOT, "telegram-plugin", "hooks", "subagent-tracker-posttool.mjs")}"`,
-                timeout: 10,
-              },
-            ],
-          },
-        ]
-      : [];
-    // Switchroom-owned UserPromptSubmit hooks (same as scaffoldAgent above)
-    const useHotReloadStableReconcile = agentConfig.channels?.telegram?.hotReloadStable === true;
-    const switchroomUserPromptSubmit = [
-      ...(useHotReloadStableReconcile
-        ? [
-            {
-              hooks: [
-                {
-                  type: "command",
-                  command: `bash "${join(REPO_ROOT, "bin", "workspace-stable-hook.sh")}"`,
-                  timeout: 6,
-                },
-              ],
-            },
-          ]
-        : []),
-      {
-        hooks: [
-          {
-            type: "command",
-            command: `bash "${join(REPO_ROOT, "bin", "workspace-dynamic-hook.sh")}"`,
-            timeout: 5,
-          },
-        ],
-      },
-      // Timezone hook — see matching comment in scaffoldAgent for rationale.
-      {
-        hooks: [
-          {
-            type: "command",
-            command: `bash "${join(REPO_ROOT, "bin", "timezone-hook.sh")}"`,
-            timeout: 3,
-          },
-        ],
-      },
-    ];
-    if (userHooks) {
-      settings.hooks = {
-        ...userHooks,
-        UserPromptSubmit: [
-          ...((userHooks.UserPromptSubmit as unknown[]) ?? []),
-          ...switchroomUserPromptSubmit,
-        ],
-        ...(switchroomPreToolUse.length > 0
-          ? {
-              PreToolUse: [
-                ...((userHooks.PreToolUse as unknown[]) ?? []),
-                ...switchroomPreToolUse,
-              ],
-            }
-          : {}),
-        ...(switchroomPostToolUse.length > 0
-          ? {
-              PostToolUse: [
-                ...((userHooks.PostToolUse as unknown[]) ?? []),
-                ...switchroomPostToolUse,
-              ],
-            }
-          : {}),
-        ...(switchroomStop.length > 0
-          ? {
-              Stop: [
-                ...((userHooks.Stop as unknown[]) ?? []),
-                ...switchroomStop,
-              ],
-            }
-          : {}),
-      };
-    } else {
-      settings.hooks = {
-        UserPromptSubmit: switchroomUserPromptSubmit,
-        ...(switchroomPreToolUse.length > 0 ? { PreToolUse: switchroomPreToolUse } : {}),
-        ...(switchroomPostToolUse.length > 0 ? { PostToolUse: switchroomPostToolUse } : {}),
-        ...(switchroomStop.length > 0 ? { Stop: switchroomStop } : {}),
-      };
-    }
+    settings.hooks = buildSettingsHooksBlock({
+      agentName: name,
+      agentConfig,
+      hindsightEnabled,
+      useSwitchroomPlugin: usesSwitchroomTelegramPlugin(agentConfig),
+      configPath: switchroomConfigPath,
+    });
 
     // Read userId from access.json (written during scaffold) — used by
     // both the sub-agent prompt addendum and the greeting script below.

--- a/src/cli/agent.ts
+++ b/src/cli/agent.ts
@@ -6,7 +6,7 @@ import YAML from "yaml";
 import { resolveAgentsDir, loadConfig } from "../config/loader.js";
 import type { SwitchroomConfig } from "../config/schema.js";
 import { withConfigError, getConfig, getConfigPath } from "./helpers.js";
-import { scaffoldAgent, reconcileAgent } from "../agents/scaffold.js";
+import { scaffoldAgent, reconcileAgent, buildSettingsHooksBlock, detectHooksDrift } from "../agents/scaffold.js";
 import { listAvailableProfiles } from "../agents/profiles.js";
 import {
   startAgent,
@@ -1184,13 +1184,62 @@ export function registerAgentCommand(program: Command): void {
       "--preserve-claude-md",
       "Opt out of regenerating CLAUDE.md — use if you have hand-edits you don't want to migrate to CLAUDE.custom.md yet"
     )
+    .option("--check", "Report drift between yaml and settings.json without writing")
     .action(
-      withConfigError(async (name: string, opts: { restart?: boolean; noRestart?: boolean; gracefulRestart?: boolean; preserveClaudeMd?: boolean }) => {
+      withConfigError(async (name: string, opts: { restart?: boolean; noRestart?: boolean; gracefulRestart?: boolean; preserveClaudeMd?: boolean; check?: boolean }) => {
         const config = getConfig(program);
         const agentsDir = resolveAgentsDir(config);
         const configPath = getConfigPath(program);
 
         const names = name === "all" ? Object.keys(config.agents) : [name];
+
+        // --check mode: compare expected vs actual hooks block, no writes
+        if (opts.check) {
+          let anyDrift = false;
+          for (const n of names) {
+            const agentConfigRaw = config.agents[n];
+            if (!agentConfigRaw) {
+              console.error(chalk.red(`Agent "${n}" is not defined in switchroom.yaml`));
+              continue;
+            }
+            const agentConfig = resolveAgentConfig(config.defaults, config.profiles, agentConfigRaw);
+            const memoryBackend = config.memory?.backend;
+            const hindsightEnabled = memoryBackend === "hindsight"
+              && agentConfig.memory?.auto_recall !== false;
+
+            const expected = buildSettingsHooksBlock({
+              agentName: n,
+              agentConfig,
+              hindsightEnabled,
+              useSwitchroomPlugin: usesSwitchroomTelegramPlugin(agentConfig),
+              configPath,
+            });
+
+            const settingsPath = resolve(agentsDir, n, ".claude", "settings.json");
+            let actual: Record<string, unknown> = {};
+            if (existsSync(settingsPath)) {
+              try {
+                const raw = JSON.parse(readFileSync(settingsPath, "utf-8")) as Record<string, unknown>;
+                actual = (raw.hooks as Record<string, unknown>) ?? {};
+              } catch {
+                console.error(chalk.red(`  ${n}: could not parse settings.json`));
+                continue;
+              }
+            }
+
+            const { drifted, summary } = detectHooksDrift(expected, actual);
+            if (drifted) {
+              console.log(chalk.red(`  ${n}: hooks ${summary}`));
+              anyDrift = true;
+            } else {
+              console.log(chalk.green(`  ${n}: hooks in sync`));
+            }
+          }
+          if (anyDrift) {
+            process.exitCode = 1;
+          }
+          return;
+        }
         let totalChanges = 0;
         let agentsTouched = 0;
 

--- a/tests/reconcile-hooks-drift.test.ts
+++ b/tests/reconcile-hooks-drift.test.ts
@@ -1,0 +1,207 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { buildSettingsHooksBlock, detectHooksDrift } from "../src/agents/scaffold.js";
+import type { AgentConfig, SwitchroomConfig } from "../src/config/schema.js";
+
+function makeAgentConfig(overrides: Partial<AgentConfig> = {}): AgentConfig {
+  return {
+    extends: "default",
+    topic_name: "Test Topic",
+    schedule: [],
+    ...overrides,
+  } as AgentConfig;
+}
+
+describe("buildSettingsHooksBlock", () => {
+  it("with no user hooks returns only switchroom-owned hooks", () => {
+    const agentConfig = makeAgentConfig();
+    const result = buildSettingsHooksBlock({
+      agentName: "test-agent",
+      agentConfig,
+      hindsightEnabled: false,
+      useSwitchroomPlugin: false,
+    });
+
+    // Must have UserPromptSubmit (always present)
+    expect(result.UserPromptSubmit).toBeDefined();
+    expect(Array.isArray(result.UserPromptSubmit)).toBe(true);
+
+    // workspace-dynamic and timezone hooks must be present
+    const ups = result.UserPromptSubmit as Array<{ hooks: Array<{ command: string }> }>;
+    const commands = ups.flatMap(entry => entry.hooks.map(h => h.command));
+    expect(commands.some(c => c.includes("workspace-dynamic-hook.sh"))).toBe(true);
+    expect(commands.some(c => c.includes("timezone-hook.sh"))).toBe(true);
+
+    // Without telegram plugin: no PreToolUse or PostToolUse
+    expect(result.PreToolUse).toBeUndefined();
+    expect(result.PostToolUse).toBeUndefined();
+  });
+
+  it("with telegram plugin adds PreToolUse and PostToolUse hooks", () => {
+    const agentConfig = makeAgentConfig({
+      plugin: "switchroom-telegram",
+    });
+    const result = buildSettingsHooksBlock({
+      agentName: "test-agent",
+      agentConfig,
+      hindsightEnabled: false,
+      useSwitchroomPlugin: true,
+    });
+
+    expect(result.PreToolUse).toBeDefined();
+    expect(Array.isArray(result.PreToolUse)).toBe(true);
+    const preHooks = result.PreToolUse as Array<{ hooks: Array<{ command: string }> }>;
+    const preCmds = preHooks.flatMap(e => e.hooks.map(h => h.command));
+    expect(preCmds.some(c => c.includes("secret-guard-pretool.mjs"))).toBe(true);
+    expect(preCmds.some(c => c.includes("subagent-tracker-pretool.mjs"))).toBe(true);
+
+    expect(result.PostToolUse).toBeDefined();
+    const postHooks = result.PostToolUse as Array<{ hooks: Array<{ command: string }> }>;
+    const postCmds = postHooks.flatMap(e => e.hooks.map(h => h.command));
+    expect(postCmds.some(c => c.includes("subagent-tracker-posttool.mjs"))).toBe(true);
+  });
+
+  it("with user hooks declared merges them with switchroom-owned hooks", () => {
+    const agentConfig = makeAgentConfig({
+      hooks: {
+        UserPromptSubmit: [
+          { type: "command", command: "echo user-hook" },
+        ],
+      },
+    });
+
+    const result = buildSettingsHooksBlock({
+      agentName: "test-agent",
+      agentConfig,
+      hindsightEnabled: false,
+      useSwitchroomPlugin: false,
+    });
+
+    const ups = result.UserPromptSubmit as Array<{ hooks: Array<{ command: string }> }>;
+    const commands = ups.flatMap(entry => entry.hooks.map(h => h.command));
+
+    // User hook must appear
+    expect(commands.some(c => c.includes("echo user-hook"))).toBe(true);
+    // Switchroom-owned hooks must also appear
+    expect(commands.some(c => c.includes("workspace-dynamic-hook.sh"))).toBe(true);
+    expect(commands.some(c => c.includes("timezone-hook.sh"))).toBe(true);
+  });
+
+  it("is idempotent — calling twice with same input produces deeply equal output", () => {
+    const agentConfig = makeAgentConfig({
+      plugin: "switchroom-telegram",
+      hooks: {
+        Stop: [{ type: "command", command: "echo my-stop" }],
+      },
+    });
+    const params = {
+      agentName: "idempotent-agent",
+      agentConfig,
+      hindsightEnabled: true,
+      useSwitchroomPlugin: true,
+    };
+
+    const first = buildSettingsHooksBlock(params);
+    const second = buildSettingsHooksBlock(params);
+
+    expect(JSON.stringify(first)).toBe(JSON.stringify(second));
+  });
+
+  it("includes --config flag in handoff command when configPath is provided", () => {
+    const agentConfig = makeAgentConfig();
+    const result = buildSettingsHooksBlock({
+      agentName: "test-agent",
+      agentConfig,
+      hindsightEnabled: false,
+      useSwitchroomPlugin: false,
+      configPath: "/home/user/switchroom.yaml",
+    });
+
+    const stop = result.Stop as Array<{ hooks: Array<{ command: string }> }> | undefined;
+    expect(stop).toBeDefined();
+    const stopCmds = (stop ?? []).flatMap(e => e.hooks.map(h => h.command));
+    expect(stopCmds.some(c => c.includes("--config") && c.includes("switchroom.yaml"))).toBe(true);
+  });
+
+  it("handoff command has no --config flag when configPath is omitted", () => {
+    const agentConfig = makeAgentConfig();
+    const result = buildSettingsHooksBlock({
+      agentName: "test-agent",
+      agentConfig,
+      hindsightEnabled: false,
+      useSwitchroomPlugin: false,
+    });
+
+    const stop = result.Stop as Array<{ hooks: Array<{ command: string }> }> | undefined;
+    expect(stop).toBeDefined();
+    const stopCmds = (stop ?? []).flatMap(e => e.hooks.map(h => h.command));
+    const handoffCmd = stopCmds.find(c => c.includes("handoff"));
+    expect(handoffCmd).toBeDefined();
+    expect(handoffCmd).not.toContain("--config");
+  });
+});
+
+describe("detectHooksDrift", () => {
+  it("returns drifted=false when hooks are identical", () => {
+    const hooks = {
+      UserPromptSubmit: [{ hooks: [{ type: "command", command: "echo hi", timeout: 5 }] }],
+    };
+    const result = detectHooksDrift(hooks, hooks);
+    expect(result.drifted).toBe(false);
+    expect(result.summary).toBe("in sync");
+  });
+
+  it("returns drifted=false when hooks are equal but key order differs", () => {
+    const expected = { UserPromptSubmit: [{ hooks: [{ timeout: 5, command: "echo hi", type: "command" }] }] };
+    const actual   = { UserPromptSubmit: [{ hooks: [{ type: "command", command: "echo hi", timeout: 5 }] }] };
+    const result = detectHooksDrift(expected, actual);
+    expect(result.drifted).toBe(false);
+  });
+
+  it("returns drifted=true when hooks differ", () => {
+    const expected = { UserPromptSubmit: [{ hooks: [{ type: "command", command: "echo new", timeout: 5 }] }] };
+    const actual   = { UserPromptSubmit: [{ hooks: [{ type: "command", command: "echo old", timeout: 5 }] }] };
+    const result = detectHooksDrift(expected, actual);
+    expect(result.drifted).toBe(true);
+    expect(result.summary).toContain("DRIFTED");
+    expect(result.summary).toContain("UserPromptSubmit");
+  });
+
+  it("drift fixture: stale settings.json detected as drifted", () => {
+    const tmpDir = mkdtempSync(join(tmpdir(), "switchroom-drift-test-"));
+    try {
+      const claudeDir = join(tmpDir, ".claude");
+      mkdirSync(claudeDir, { recursive: true });
+      const settingsPath = join(claudeDir, "settings.json");
+
+      // Write a stale settings.json with an outdated hooks block
+      const staleSettings = {
+        hooks: {
+          UserPromptSubmit: [
+            { hooks: [{ type: "command", command: "echo stale-hook", timeout: 5 }] },
+          ],
+        },
+      };
+      writeFileSync(settingsPath, JSON.stringify(staleSettings, null, 2), "utf-8");
+      expect(existsSync(settingsPath)).toBe(true);
+
+      // Compute what the current config would produce
+      const agentConfig = makeAgentConfig();
+      const expected = buildSettingsHooksBlock({
+        agentName: "my-agent",
+        agentConfig,
+        hindsightEnabled: false,
+        useSwitchroomPlugin: false,
+      });
+
+      const actual = (staleSettings.hooks as Record<string, unknown>);
+      const { drifted, summary } = detectHooksDrift(expected, actual);
+      expect(drifted).toBe(true);
+      expect(summary).toContain("DRIFTED");
+    } finally {
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Reconcile and scaffold both compute the `.claude/settings.json` `hooks` block via one shared function — `buildSettingsHooksBlock()`. The yaml cascade (defaults → profile → agent) is the source of truth; manual edits to `settings.json` get clobbered. New `--check` flag surfaces drift without writing.

## Why

Per the Phase 2 checklist of #322:

- Hooks should live in yaml only.
- Switchroom-owned hooks (handoff, secret-scrub, subagent-tracker, workspace injection, timezone, …) should be defined once and added to both freshly-scaffolded agents AND reconciled-into-existing agents.
- A drift detection should exist so CI / `switchroom doctor` can tell when an agent's `settings.json` is out of sync with its yaml.

Before this PR, `scaffoldAgent` and `reconcileAgent` each constructed the hooks block inline, ~150 lines duplicated. Adding a new switchroom-owned hook required touching both paths and risked divergence — same SOTF pitfall that existed for the `playwright` MCP default until #373.

## Changes

- **`src/agents/scaffold.ts`**:
  - New `buildSettingsHooksBlock(p)` — single source of truth for the full hooks block (user yaml + switchroom-owned). Composes `translateHooksToClaudeShape(agentConfig.hooks)` with the switchroom-owned categories.
  - New `detectHooksDrift(expected, actual)` — canonical-JSON equality + a human-readable summary of the difference.
  - `scaffoldAgent` line 1478: now calls `buildSettingsHooksBlock` instead of inline construction.
  - `reconcileAgent` line 2675: same.
  - Net: ~150 lines deleted, ~250 added (new helpers + their docstrings); idempotent regeneration of the hooks block on every reconcile.
- **`src/cli/agent.ts`**:
  - New `--check` flag on `switchroom agent reconcile <name|all>`. In check mode: don't write; compute expected vs actual, log per-agent status, set `process.exitCode = 1` if any drift detected. Suitable for CI gating.
- **`tests/reconcile-hooks-drift.test.ts`** (new, 207 LOC, 10 tests):
  - `buildSettingsHooksBlock` with no user hooks → switchroom-owned only.
  - `buildSettingsHooksBlock` with user hooks declared → merged per category (UserPromptSubmit / PreToolUse / PostToolUse / Stop).
  - Idempotency: deep-equal output across two calls with same input.
  - `detectHooksDrift`: in-sync, missing keys, value differences, summary text.

## Sample `--check` output

In sync:
```
$ switchroom agent reconcile lawgpt --check
  lawgpt: hooks in sync
```

Drifted:
```
$ switchroom agent reconcile lawgpt --check
  lawgpt: hooks DRIFTED — expected adds Stop[2], actual missing
$ echo $?
1
```

## Verification

- `bunx tsc --noEmit`: clean
- `bunx vitest run tests/reconcile-hooks-drift.test.ts`: 10/10
- `bunx vitest run tests/scaffold.test.ts`: 131/132 (one pre-existing failure on `start.sh respects session_continuity.resume_mode` — see #377, unrelated)
- `bunx vitest run tests/handoff-briefing.test.ts`: 16/21 (5 pre-existing failures on main, unrelated)

## Closes

- Closes #98 (clerk stop-hook hang — same root cause as #116; no longer recurs because the hook block is regenerated from yaml on every reconcile)
- Phase 2 of #322

## Out of scope

- Phase 1 (render pipeline rearchitecture) — separate PR (deferred to morning).
- Phase 3 (`InstructionsLoaded` observability + doctor drift check) — depends on Phase 1.