### PR TITLE
fix(telegram): scope ADMIN_COMMAND_NAMES to fleet-management verbs only

### DIFF
--- a/telegram-plugin/admin-commands/dispatch.test.ts
+++ b/telegram-plugin/admin-commands/dispatch.test.ts
@@ -34,15 +34,44 @@ describe('parseCommandName', () => {
 // ─── ADMIN_COMMAND_NAMES ─────────────────────────────────────────────────────
 
 describe('ADMIN_COMMAND_NAMES', () => {
-  it('contains the core admin commands', () => {
-    const required = ['agents', 'logs', 'restart', 'update', 'version', 'auth', 'reconcile']
+  it('contains the fleet-management admin commands', () => {
+    const required = ['agents', 'logs', 'restart', 'update', 'reconcile', 'stop', 'switchroomstart', 'grant', 'dangerous', 'permissions', 'vault']
     for (const cmd of required) {
       expect(ADMIN_COMMAND_NAMES.has(cmd)).toBe(true)
     }
   })
 
-  it('contains version (fleet management verb)', () => {
-    expect(ADMIN_COMMAND_NAMES.has('version')).toBe(true)
+  it('does not contain per-agent auth ops (must work without model)', () => {
+    // /auth, /reauth, /authfallback are handled by the gateway directly so
+    // the user can re-authenticate even when the model is rate-limited or the
+    // token is expired. Routing them through Claude would defeat the point.
+    expect(ADMIN_COMMAND_NAMES.has('auth')).toBe(false)
+    expect(ADMIN_COMMAND_NAMES.has('reauth')).toBe(false)
+    expect(ADMIN_COMMAND_NAMES.has('authfallback')).toBe(false)
+  })
+
+  it('does not contain interrupt (cancellation must always work)', () => {
+    expect(ADMIN_COMMAND_NAMES.has('interrupt')).toBe(false)
+  })
+
+  it('does not contain the permission-response flow', () => {
+    // /approve, /deny, /pending are intercepted by the gateway before the
+    // model is invoked anyway — they have nothing to do with admin gating.
+    expect(ADMIN_COMMAND_NAMES.has('approve')).toBe(false)
+    expect(ADMIN_COMMAND_NAMES.has('deny')).toBe(false)
+    expect(ADMIN_COMMAND_NAMES.has('pending')).toBe(false)
+  })
+
+  it('does not contain info commands (must work when model is down)', () => {
+    expect(ADMIN_COMMAND_NAMES.has('version')).toBe(false)
+    expect(ADMIN_COMMAND_NAMES.has('doctor')).toBe(false)
+    expect(ADMIN_COMMAND_NAMES.has('usage')).toBe(false)
+    expect(ADMIN_COMMAND_NAMES.has('switchroomhelp')).toBe(false)
+  })
+
+  it('does not contain session-reset commands', () => {
+    expect(ADMIN_COMMAND_NAMES.has('new')).toBe(false)
+    expect(ADMIN_COMMAND_NAMES.has('reset')).toBe(false)
   })
 
   it('does not contain create-agent (out of scope for phase 1)', () => {
@@ -64,8 +93,22 @@ describe('dispatchAdminCommand', () => {
       expect(dispatchAdminCommand('/logs', true)).toEqual({ handled: true })
       expect(dispatchAdminCommand('/restart', true)).toEqual({ handled: true })
       expect(dispatchAdminCommand('/update', true)).toEqual({ handled: true })
-      expect(dispatchAdminCommand('/version', true)).toEqual({ handled: true })
-      expect(dispatchAdminCommand('/auth', true)).toEqual({ handled: true })
+      expect(dispatchAdminCommand('/vault', true)).toEqual({ handled: true })
+      expect(dispatchAdminCommand('/permissions', true)).toEqual({ handled: true })
+    })
+
+    it('does NOT handle per-agent ops (auth/interrupt/info/session)', () => {
+      // These are intentionally NOT admin-gated — they always run via the
+      // gateway, regardless of admin status, so the user can recover when
+      // the model is unreachable.
+      expect(dispatchAdminCommand('/auth', true)).toEqual({ handled: false })
+      expect(dispatchAdminCommand('/reauth', true)).toEqual({ handled: false })
+      expect(dispatchAdminCommand('/interrupt', true)).toEqual({ handled: false })
+      expect(dispatchAdminCommand('/version', true)).toEqual({ handled: false })
+      expect(dispatchAdminCommand('/doctor', true)).toEqual({ handled: false })
+      expect(dispatchAdminCommand('/usage', true)).toEqual({ handled: false })
+      expect(dispatchAdminCommand('/new', true)).toEqual({ handled: false })
+      expect(dispatchAdminCommand('/reset', true)).toEqual({ handled: false })
     })
 
     it('handles a known command with arguments', () => {

--- a/telegram-plugin/admin-commands/index.ts
+++ b/telegram-plugin/admin-commands/index.ts
@@ -32,35 +32,33 @@
  * The set of command names that are treated as "admin commands" — intercepted
  * by the gateway when SWITCHROOM_AGENT_ADMIN=true, forwarded to Claude otherwise.
  *
+ * Scope: ONLY fleet-management verbs (lifecycle, scaffolding, privileges,
+ * secrets). Per-agent / per-chat ops — auth, interrupt, permission flow,
+ * info commands (`/version`, `/doctor`, `/usage`), session reset (`/new`,
+ * `/reset`), and `/switchroomhelp` — must always be gateway-handled
+ * regardless of admin status, because they need to work even when the model
+ * is unreachable (rate-limited, expired token, network down). Routing those
+ * through Claude defeats the entire point of the slash-command UX.
+ *
  * Keep in sync with the bot.command() registrations in gateway.ts.
  */
 export const ADMIN_COMMAND_NAMES = new Set<string>([
+  // Fleet lifecycle
   'agents',
   'logs',
   'restart',
-  'update',
-  'version',
-  'auth',
-  'reauth',
-  'reconcile',
   'stop',
   'switchroomstart',
+  'update',
+  'reconcile',
+  // Privileges + secrets
   'grant',
   'dangerous',
   'permissions',
-  'switchroomhelp',
-  'doctor',
-  'memory',
-  'usage',
-  'topics',
   'vault',
-  'authfallback',
-  'new',
-  'reset',
-  'approve',
-  'deny',
-  'pending',
-  'interrupt',
+  // Per-agent ops that read shared fleet state via the switchroom CLI
+  'memory',
+  'topics',
 ])
 
 /**


### PR DESCRIPTION
## Summary

`/auth` and `/reauth` (and 11 other per-agent slash commands) were being redirected to Claude when `SWITCHROOM_AGENT_ADMIN=false` (the default for non-admin agents). When the model was rate-limited, the user got `You're out of extra usage · resets …` instead of the auth dashboard — exactly the wrong UX, since `/auth` is the recovery path *for* a model-down agent.

The admin gate exists to stop multiple agents from all answering fleet-management commands like `/agents` and `/logs`. Per-agent ops have nothing to do with that. Scope the gated set accordingly.

**Removed from `ADMIN_COMMAND_NAMES`** (now always gateway-handled):
- Auth ops: `auth`, `reauth`, `authfallback`
- Cancellation: `interrupt`
- Permission flow: `approve`, `deny`, `pending`
- Info: `version`, `doctor`, `usage`, `switchroomhelp`
- Session: `new`, `reset`

**Retained** (legit fleet-management):
- Lifecycle: `agents`, `logs`, `restart`, `stop`, `switchroomstart`, `update`, `reconcile`
- Privileges + secrets: `grant`, `dangerous`, `permissions`, `vault`
- Per-agent ops that read shared fleet state: `memory`, `topics`

All `bot.command()` handlers in `gateway.ts` already exist for the removed commands — they were just being intercepted by the middleware before reaching the handler.

## Test plan

- [x] `bun test telegram-plugin/admin-commands/` — 22 pass, 0 fail
- [x] `npm run lint` (tsc --noEmit) — clean
- [x] Hot-patched on `gymbro` agent (rate-limited slot, was the original repro). Restarted, gateway log shows no `admin-gate redirect cmd=/auth` after the patch
- [ ] User to confirm `/auth` and `/reauth` now reach the auth dashboard instead of the rate-limit message

## Follow-up

Fix 2 (graceful model-down UX for messages that *do* legitimately go to Claude) tracked separately — even with this fix, a chat message hitting a quota-exhausted model gives a useless raw error. To be addressed in a follow-up issue.