### PR TITLE
feat(profiles): add renderProfileClaudeTemplate (Phase 1 chunk 1 of #322)

### DIFF
--- a/src/agents/profiles.test.ts
+++ b/src/agents/profiles.test.ts
@@ -1,9 +1,9 @@
 import { describe, it, expect } from "vitest";
 import { sep as pathSep, resolve } from "node:path";
-import { mkdtempSync, mkdirSync, symlinkSync, writeFileSync, rmSync } from "node:fs";
+import { mkdtempSync, mkdirSync, symlinkSync, writeFileSync, rmSync, readFileSync, existsSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { getProfilePath, listAvailableProfiles } from "./profiles.js";
+import { getProfilePath, listAvailableProfiles, renderProfileClaudeTemplate } from "./profiles.js";
 
 describe("getProfilePath", () => {
   it("resolves a real profile that exists on disk", () => {
@@ -108,5 +108,60 @@ describe("listAvailableProfiles", () => {
     const profiles = listAvailableProfiles();
     expect(profiles).not.toContain("_base");
     expect(profiles.every((name) => !name.startsWith("_"))).toBe(true);
+  });
+});
+
+describe("renderProfileClaudeTemplate", () => {
+  it("renders CLAUDE.md.hbs to CLAUDE.md and returns { wrote: true, path }", () => {
+    const tmp = mkdtempSync(join(tmpdir(), "switchroom-profile-render-test-"));
+    try {
+      const profileName = "test-profile";
+      const profileDir = join(tmp, profileName);
+      mkdirSync(profileDir, { recursive: true });
+      writeFileSync(
+        join(profileDir, "CLAUDE.md.hbs"),
+        "# Profile: {{profile}}\nHello from the template.",
+      );
+
+      const result = renderProfileClaudeTemplate(profileName, tmp);
+
+      expect(result.wrote).toBe(true);
+      expect(result.path).toBe(join(profileDir, "CLAUDE.md"));
+      expect(existsSync(result.path)).toBe(true);
+      const content = readFileSync(result.path, "utf-8");
+      expect(content).toBe("# Profile: test-profile\nHello from the template.");
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("returns { wrote: false } when no .hbs template exists", () => {
+    const tmp = mkdtempSync(join(tmpdir(), "switchroom-profile-render-test-"));
+    try {
+      const result = renderProfileClaudeTemplate("no-such-profile", tmp);
+      expect(result.wrote).toBe(false);
+      expect(existsSync(result.path)).toBe(false);
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("overwrites an existing CLAUDE.md on re-render", () => {
+    const tmp = mkdtempSync(join(tmpdir(), "switchroom-profile-render-test-"));
+    try {
+      const profileName = "test-profile";
+      const profileDir = join(tmp, profileName);
+      mkdirSync(profileDir, { recursive: true });
+      writeFileSync(join(profileDir, "CLAUDE.md.hbs"), "v1 {{profile}}");
+      writeFileSync(join(profileDir, "CLAUDE.md"), "old content");
+
+      const result = renderProfileClaudeTemplate(profileName, tmp);
+
+      expect(result.wrote).toBe(true);
+      const content = readFileSync(result.path, "utf-8");
+      expect(content).toBe("v1 test-profile");
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
   });
 });

--- a/src/agents/profiles.ts
+++ b/src/agents/profiles.ts
@@ -1,4 +1,4 @@
-import { readFileSync, existsSync, readdirSync, statSync, copyFileSync, mkdirSync, realpathSync } from "node:fs";
+import { readFileSync, writeFileSync, existsSync, readdirSync, statSync, copyFileSync, mkdirSync, realpathSync } from "node:fs";
 import { resolve, join, sep as pathSep } from "node:path";
 import Handlebars from "handlebars";
 
@@ -168,4 +168,33 @@ for (const name of SHARED_FRAGMENTS) {
   if (existsSync(fragPath)) {
     Handlebars.registerPartial(name, readFileSync(fragPath, "utf-8"));
   }
+}
+
+/**
+ * Render `profiles/<profileName>/CLAUDE.md.hbs` into
+ * `profiles/<profileName>/CLAUDE.md` using the profile-level context
+ * (no agent-specific values — those belong in the per-agent layer).
+ *
+ * Returns `{ wrote: true, path }` when the template was found and the
+ * output file was written, or `{ wrote: false, path }` when the .hbs
+ * source doesn't exist (caller can skip gracefully).
+ */
+export function renderProfileClaudeTemplate(
+  profileName: string,
+  /** Override the profiles root; used by tests to avoid touching real profiles. */
+  profilesRoot: string = PROFILES_ROOT,
+): { wrote: boolean; path: string } {
+  const profileDir = resolve(profilesRoot, profileName);
+  const hbsPath = join(profileDir, "CLAUDE.md.hbs");
+  const outPath = join(profileDir, "CLAUDE.md");
+
+  if (!existsSync(hbsPath)) {
+    return { wrote: false, path: outPath };
+  }
+
+  const source = readFileSync(hbsPath, "utf-8");
+  const template = Handlebars.compile(source, { noEscape: true });
+  const rendered = template({ profile: profileName });
+  writeFileSync(outPath, rendered, "utf-8");
+  return { wrote: true, path: outPath };
 }


### PR DESCRIPTION
First of ~3 chunks toward render-pipeline rearchitecture in #322.

This chunk adds a pure function only — no scaffold/reconcile wiring yet.
Follow-up chunks will: (chunk 2) call the renderer from scaffold; (chunk 3) generate per-agent CLAUDE.md with @import.

Doesn't change behavior until later chunks land. Tests + suite pass.