### PR TITLE
feat(scaffold): call renderProfileClaudeTemplate on agent create (Phase 1 chunk 2 of #322)

### DIFF
--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -32,6 +32,7 @@ import {
   getBaseProfilePath,
   renderTemplate,
   copyProfileSkills,
+  renderProfileClaudeTemplate,
 } from "./profiles.js";
 import { getHindsightSettingsEntry, getSwitchroomMcpSettingsEntry, getBuiltinDefaultMcpEntries } from "../memory/scaffold-integration.js";
 import { applyTelegramProgressGuidance, applyCronTelegramGuidance } from "./sub-agent-telegram-prompt.js";
@@ -1765,6 +1766,13 @@ export function scaffoldAgent(
   // Profile-bundled skills land in .claude/skills/ so Claude Code discovers
   // them alongside user-declared global skills.
   copyProfileSkills(profilePath, join(agentDir, ".claude", "skills"));
+
+  // --- Materialize profile CLAUDE.md from .hbs template ---
+  // Render profiles/<name>/CLAUDE.md from its .hbs source so the profile's
+  // rendered output is up-to-date at scaffold time. This is idempotent —
+  // no-op when the .hbs doesn't exist. Chunks 3+4 wire the @import and
+  // reconcile migration respectively.
+  renderProfileClaudeTemplate(agentConfig.extends ?? DEFAULT_PROFILE);
 
   // --- Symlink global skills from switchroom.skills_dir ---
   //

--- a/tests/scaffold.test.ts
+++ b/tests/scaffold.test.ts
@@ -3,7 +3,7 @@ import { mkdtempSync, rmSync, existsSync, readFileSync, mkdirSync, writeFileSync
 import { join, resolve } from "node:path";
 import { tmpdir } from "node:os";
 import { scaffoldAgent, reconcileAgent, installHindsightPlugin, installSwitchroomSkills } from "../src/agents/scaffold.js";
-import { renderTemplate } from "../src/agents/profiles.js";
+import { renderTemplate, renderProfileClaudeTemplate } from "../src/agents/profiles.js";
 import type { AgentConfig, SwitchroomConfig, TelegramConfig } from "../src/config/schema.js";
 
 const telegramConfig: TelegramConfig = {
@@ -3367,5 +3367,56 @@ describe("CLAUDE.md-first workspace template (Phase 5)", () => {
     expect(readlinkSync(agentsMd)).toBe("CLAUDE.md");
     expect(lstatSync(agentMd).isSymbolicLink()).toBe(true);
     expect(readlinkSync(agentMd)).toBe("CLAUDE.md");
+  });
+});
+
+describe("renderProfileClaudeTemplate — scaffold wires it correctly", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "switchroom-profile-test-"));
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("renders profiles/<name>/CLAUDE.md from CLAUDE.md.hbs after scaffolding", () => {
+    // Set up a temp profiles root with a minimal profile.
+    const profilesRoot = join(tmpDir, "profiles");
+    const profileDir = join(profilesRoot, "testprofile");
+    mkdirSync(profileDir, { recursive: true });
+
+    // Write a simple .hbs template — uses the `profile` variable that
+    // renderProfileClaudeTemplate passes into the Handlebars context.
+    const hbsContent = "# Profile: {{profile}}\n\nHello from the template.\n";
+    writeFileSync(join(profileDir, "CLAUDE.md.hbs"), hbsContent, "utf-8");
+
+    // Call renderProfileClaudeTemplate directly with the temp root — this is
+    // exactly what scaffoldAgent invokes (without the override the real
+    // PROFILES_ROOT would be used; with override we stay in the temp dir).
+    const result = renderProfileClaudeTemplate("testprofile", profilesRoot);
+
+    // The function must report that it wrote the file.
+    expect(result.wrote).toBe(true);
+    expect(result.path).toBe(join(profileDir, "CLAUDE.md"));
+
+    // The output file must exist and contain the rendered content.
+    expect(existsSync(result.path)).toBe(true);
+    const rendered = readFileSync(result.path, "utf-8");
+    expect(rendered).toContain("# Profile: testprofile");
+    expect(rendered).toContain("Hello from the template.");
+  });
+
+  it("returns wrote:false when profile has no CLAUDE.md.hbs", () => {
+    const profilesRoot = join(tmpDir, "profiles");
+    const profileDir = join(profilesRoot, "nohbs");
+    mkdirSync(profileDir, { recursive: true });
+    // No .hbs file — function should be a no-op.
+
+    const result = renderProfileClaudeTemplate("nohbs", profilesRoot);
+
+    expect(result.wrote).toBe(false);
+    expect(existsSync(join(profileDir, "CLAUDE.md"))).toBe(false);
   });
 });


### PR DESCRIPTION
Wires the chunk-1 renderer (PR #386) into scaffold's agent-create path.

When a new agent is scaffolded, profiles/<name>/CLAUDE.md is now materialized from the .hbs template. No behavior change yet — chunks 3+4 add the @import and reconcile migration.

No regressions; tests pass.