### PR TITLE
feat(telegram): flatten main progress card body, accent sub-agents header

### DIFF
--- a/telegram-plugin/progress-card.ts
+++ b/telegram-plugin/progress-card.ts
@@ -1198,10 +1198,10 @@ export function render(
     }
   }
 
-  // Build the main card: header + body wrapped in <blockquote>.
+  // Build the main card: header + body (no blockquote wrapper).
   const bodyText = bodyLines.join('\n').trimStart()
   const mainCard = bodyText
-    ? `${headerLines.join('\n')}\n<blockquote>${bodyText}</blockquote>`
+    ? `${headerLines.join('\n')}\n${bodyText}`
     : headerLines.join('\n')
 
   // Sub-agent expandable sections — one <blockquote expandable> per agent,
@@ -1216,6 +1216,7 @@ export function render(
   const expandableParts: string[] = []
   if (multiAgentActive && state.subAgents.size > 0) {
     const counts = countSubAgentStates(state.subAgents, now)
+    expandableParts.push('')
     expandableParts.push(renderSubAgentSummaryHeader(counts))
     for (const sa of sortSubAgentsChrono(state.subAgents)) {
       const cached = expandableCache?.get(sa.agentId)
@@ -1374,7 +1375,7 @@ function renderSubAgentSummaryHeader(c: SubAgentCounts): string {
   if (c.failed > 0) parts.push(`❌ ${c.failed}`)
   if (c.stalled > 0) parts.push(`⚠️ ${c.stalled}`)
   const counters = parts.length > 0 ? ` · ${parts.join(' · ')}` : ''
-  return `🤖 Sub-agents${counters}`
+  return `<b><u>🤖 Sub-agents</u></b>${counters}`
 }
 
 /**

--- a/telegram-plugin/tests/progress-card.test.ts
+++ b/telegram-plugin/tests/progress-card.test.ts
@@ -2119,8 +2119,8 @@ describe('progress-card multi-agent layout snapshots', () => {
       const doneCount = (html.match(/✅ done/g) ?? []).length
       expect(doneCount).toBe(3)
 
-      // Header summary line shows emoji counts ("🤖 Sub-agents · ✅ 3").
-      expect(html).toContain('🤖 Sub-agents · ✅ 3')
+      // Header summary line shows emoji counts ("<b><u>🤖 Sub-agents</u></b> · ✅ 3").
+      expect(html).toContain('<b><u>🤖 Sub-agents</u></b> · ✅ 3')
 
       // 3 expandable forensic blocks, one per sub-agent
       const expandableCount = (html.match(/<blockquote expandable>/g) ?? []).length
@@ -2166,7 +2166,7 @@ describe('progress-card multi-agent layout snapshots', () => {
       const html = render(st, 3000)
 
       // Header summary line lists each non-zero count.
-      expect(html).toContain('🤖 Sub-agents · ✅ 1 · 🔄 1 · ❌ 1')
+      expect(html).toContain('<b><u>🤖 Sub-agents</u></b> · ✅ 1 · 🔄 1 · ❌ 1')
 
       // Each per-agent header carries the right status emoji + label.
       expect(html).toContain('🤖 <b>finished work</b>')
@@ -2203,7 +2203,7 @@ describe('progress-card multi-agent layout snapshots', () => {
       const html = render(st, 3000)
 
       // Header summary line: only the failed count, no done/running/stalled.
-      expect(html).toContain('🤖 Sub-agents · ❌ 3')
+      expect(html).toContain('<b><u>🤖 Sub-agents</u></b> · ❌ 3')
       expect(html).not.toContain('✅')
       expect(html).not.toContain('🔄')
 
@@ -2227,7 +2227,7 @@ describe('progress-card multi-agent layout snapshots', () => {
       const html = render(st, 72_100)
 
       // Stalled state surfaces in both the header summary and per-agent header.
-      expect(html).toContain('🤖 Sub-agents · ⚠️ 1')
+      expect(html).toContain('<b><u>🤖 Sub-agents</u></b> · ⚠️ 1')
       expect(html).toContain('⚠️ stalled')
 
       // The sub-agent's underlying state stays 'running' — stalled is a


### PR DESCRIPTION
## Visual change

The main progress card body is no longer wrapped in a `<blockquote>`. Content renders inline (flat), which removes the indented/quoted styling from the working state card. Only sub-agent expandable sections continue to use `<blockquote expandable>`.

A blank line is now inserted before the sub-agents summary header, and the title is rendered as `<b><u>🤖 Sub-agents</u></b>` (bold + underline) so it visually anchors the expandable blocks below it.

## Code changes

1. **Drop main `<blockquote>` wrapper** (`progress-card.ts` ~line 1204): `<blockquote>${bodyText}</blockquote>` → bare `${bodyText}`.

2. **Blank line before sub-agents summary** (`progress-card.ts` ~line 1219): push an empty string into `expandableParts` before `renderSubAgentSummaryHeader(counts)` so `parts.join('\n')` produces a blank separator.

3. **Bold + underline sub-agents title** (`progress-card.ts` ~line 1377): change `return \`🤖 Sub-agents${counters}\`` to `return \`<b><u>🤖 Sub-agents</u></b>${counters}\``.

## Test updates

Four snapshot assertions in `tests/progress-card.test.ts` updated to expect `<b><u>🤖 Sub-agents</u></b> · ...` instead of the plain `🤖 Sub-agents · ...` string. No assertions were loosened beyond what the design change requires. All 130 progress-card tests pass; the one pre-existing failure in `subagent-tracker-hooks.test.ts` is unrelated to this change.