### PR TITLE
feat(telegram): use sendMessageDraft for stream_reply with fallback

### DIFF
--- a/telegram-plugin/answer-stream.ts
+++ b/telegram-plugin/answer-stream.ts
@@ -1,4 +1,11 @@
 import { isSilentFlushMarker } from './turn-flush-safety.js'
+import {
+  DRAFT_METHOD_UNAVAILABLE_RE as _DRAFT_METHOD_UNAVAILABLE_RE,
+  DRAFT_CHAT_UNSUPPORTED_RE as _DRAFT_CHAT_UNSUPPORTED_RE,
+  shouldFallbackFromDraftTransport as _shouldFallbackFromDraftTransport,
+  allocateDraftId as _allocateDraftId,
+  __resetDraftIdForTests as _resetDraftIdForTests,
+} from './draft-transport.js'
 
 /**
  * Answer-lane incremental streaming for long Telegram replies.
@@ -29,36 +36,20 @@ import { isSilentFlushMarker } from './turn-flush-safety.js'
  *   - No finalizable-draft-lifecycle SDK — we implement the loop directly.
  *   - materialize() always sends a fresh message regardless of transport,
  *     to guarantee a push notification on turn completion.
+ *
+ * Draft-transport helpers (regex constants, shouldFallbackFromDraftTransport,
+ * allocateDraftId) live in draft-transport.ts and are re-exported here so
+ * existing callers that import from this module continue to work.
  */
 
 export const MIN_INITIAL_CHARS = 400
 export const DEFAULT_THROTTLE_MS = 1000
 const TELEGRAM_MAX_CHARS = 4096
 
-// Error patterns matching OpenClaw's shouldFallbackFromDraftTransport.
-// Exported for tests.
-export const DRAFT_METHOD_UNAVAILABLE_RE =
-  /(unknown method|method .*not (found|available|supported)|unsupported)/i
-export const DRAFT_CHAT_UNSUPPORTED_RE = /(can't be used|can be used only)/i
-
-/**
- * Returns true when a sendMessageDraft rejection means "this API is not
- * available" rather than a transient network error.
- */
-export function shouldFallbackFromDraftTransport(err: unknown): boolean {
-  const text =
-    typeof err === 'string'
-      ? err
-      : err instanceof Error
-        ? err.message
-        : typeof err === 'object' && err != null && 'description' in err
-          ? typeof (err as { description: unknown }).description === 'string'
-            ? (err as { description: string }).description
-            : ''
-          : ''
-  if (!/sendMessageDraft/i.test(text)) return false
-  return DRAFT_METHOD_UNAVAILABLE_RE.test(text) || DRAFT_CHAT_UNSUPPORTED_RE.test(text)
-}
+// Re-export shared constants so existing callers / tests keep working.
+export const DRAFT_METHOD_UNAVAILABLE_RE = _DRAFT_METHOD_UNAVAILABLE_RE
+export const DRAFT_CHAT_UNSUPPORTED_RE = _DRAFT_CHAT_UNSUPPORTED_RE
+export { _shouldFallbackFromDraftTransport as shouldFallbackFromDraftTransport }
 
 /** Called when a late sendMessage/edit resolves after a new turn has started. */
 export type OnSupersededCallback = (params: {
@@ -164,14 +155,9 @@ export interface AnswerStreamHandle {
   retract(): Promise<void>
 }
 
-// Module-level draft-id counter. Shared globally so concurrent answer streams
-// don't collide on draft ids — mirrors OpenClaw's getDraftStreamState().
-let _nextDraftId = 1
-function allocateDraftId(): number {
-  const id = _nextDraftId
-  _nextDraftId = _nextDraftId >= 2_147_483_647 ? 1 : _nextDraftId + 1
-  return id
-}
+// Draft-id allocation now lives in draft-transport.ts (shared with
+// draft-stream.ts). Re-alias locally so the rest of this file is unchanged.
+const allocateDraftId = _allocateDraftId
 
 export function createAnswerStream(config: AnswerStreamConfig): AnswerStreamHandle {
   const {
@@ -225,7 +211,7 @@ export function createAnswerStream(config: AnswerStreamConfig): AnswerStreamHand
       onMetric?.({ kind: 'answer_lane_update', chatId, messageId: streamMsgId, charCount: text.length, transport: 'draft' })
       return true
     } catch (err) {
-      if (shouldFallbackFromDraftTransport(err)) {
+      if (_shouldFallbackFromDraftTransport(err)) {
         warn?.(
           `answer-stream: sendMessageDraft rejected — falling back to sendMessage/editMessageText (${err instanceof Error ? err.message : String(err)})`,
         )
@@ -521,6 +507,7 @@ export function createAnswerStream(config: AnswerStreamConfig): AnswerStreamHand
 }
 
 /** Reset the draft-id counter for tests. */
+/** Reset the shared draft-id counter for tests. Delegates to draft-transport.ts. */
 export function __resetDraftIdForTests(): void {
-  _nextDraftId = 1
+  _resetDraftIdForTests()
 }

--- a/telegram-plugin/draft-stream.ts
+++ b/telegram-plugin/draft-stream.ts
@@ -15,9 +15,24 @@
  *
  * In our model-driven architecture (no inference hooks), the controller
  * is driven by the model calling stream_reply(text, done) multiple times
- * during a long task. First call → sendMessage. Subsequent calls →
- * throttled editMessageText. done=true → flush, lock, no more edits.
+ * during a long task. First call → sendMessage (or sendMessageDraft in DMs).
+ * Subsequent calls → throttled editMessageText (or sendMessageDraft). done=true
+ * → flush, materialize as a fresh sendMessage (push notification), clear draft.
+ *
+ * Transport selection:
+ *   - previewTransport: "auto" (default) — use draft in DMs only
+ *   - previewTransport: "draft"           — always use draft (if API available)
+ *   - previewTransport: "message"         — always use sendMessage/editMessageText
+ *
+ * Forum topics (message_thread_id set) force message transport because
+ * sendMessageDraft does not support threads. The caller (stream-controller.ts)
+ * handles this by passing previewTransport: "message" for threaded chats.
  */
+
+import {
+  shouldFallbackFromDraftTransport,
+  allocateDraftId,
+} from './draft-transport.js'
 
 const TELEGRAM_MAX_CHARS = 4096
 const DEFAULT_THROTTLE_MS = 1000
@@ -33,6 +48,18 @@ export type StreamSendFn = (text: string) => Promise<number>
  * Edit an existing stream message. Receives the message_id and rendered text.
  */
 export type StreamEditFn = (messageId: number, text: string) => Promise<void>
+
+/**
+ * Optional sendMessageDraft callback. When present and the transport is
+ * "draft", this is called instead of sendMessage/editMessageText.
+ * Signature mirrors Telegram's sendMessageDraft Bot API method.
+ */
+export type StreamDraftFn = (
+  chatId: string,
+  draftId: number,
+  text: string,
+  params?: { message_thread_id?: number },
+) => Promise<unknown>
 
 export interface DraftStreamConfig {
   /** Throttle window in ms. Floored at 250. Default 1000. */
@@ -55,8 +82,34 @@ export interface DraftStreamConfig {
    * Only affects the first send; subsequent edits use throttleMs.
    */
   idleMs?: number
+  /**
+   * Transport selector.
+   * - "auto" (default): use draft transport when isPrivateChat=true AND
+   *   sendMessageDraft is provided; otherwise use message transport.
+   * - "draft": always prefer draft (falls back to message if sendMessageDraft absent).
+   * - "message": always use sendMessage/editMessageText.
+   */
+  previewTransport?: 'auto' | 'message' | 'draft'
+  /**
+   * True if the current chat is a private DM. Used by "auto" transport to
+   * decide whether to activate draft. Has no effect when previewTransport
+   * is "draft" or "message".
+   */
+  isPrivateChat?: boolean
+  /**
+   * sendMessageDraft callback. When absent, the stream falls back to
+   * sendMessage/editMessageText regardless of previewTransport.
+   */
+  sendMessageDraft?: StreamDraftFn
+  /**
+   * The Telegram chat id string — required when sendMessageDraft is provided,
+   * so the draft can be cleared on finalize.
+   */
+  chatId?: string
   /** Optional logger for debugging. Receives one string per event. */
   log?: (msg: string) => void
+  /** Optional warning logger. Used for transport fallback notices. */
+  warn?: (msg: string) => void
 }
 
 export interface DraftStreamHandle {
@@ -86,6 +139,11 @@ export interface DraftStreamHandle {
  *
  * The first update() call invokes `send` to create the message. All
  * subsequent calls invoke `edit` against the captured message_id.
+ *
+ * When sendMessageDraft is provided (and transport allows it), intermediate
+ * updates use the draft API instead of sendMessage/editMessageText. On
+ * finalize(), a real sendMessage is sent for push notification, then the
+ * draft is cleared best-effort.
  */
 export function createDraftStream(
   send: StreamSendFn,
@@ -96,6 +154,26 @@ export function createDraftStream(
   const maxChars = config.maxChars ?? TELEGRAM_MAX_CHARS
   const idleMs = Math.max(0, config.idleMs ?? 0)
   const log = config.log
+  const warn = config.warn
+  const draftApi = config.sendMessageDraft
+  const chatId = config.chatId ?? ''
+
+  // Resolve transport
+  const requestedTransport = config.previewTransport ?? 'auto'
+  const prefersDraft =
+    requestedTransport === 'draft'
+      ? true
+      : requestedTransport === 'message'
+        ? false
+        : (config.isPrivateChat === true) // 'auto': DM only
+
+  // Use draft transport only if we have the API
+  let usesDraftTransport = prefersDraft && draftApi != null
+  let draftId: number | undefined = usesDraftTransport ? allocateDraftId() : undefined
+
+  if (prefersDraft && !usesDraftTransport) {
+    warn?.('draft-stream: sendMessageDraft unavailable; falling back to sendMessage/editMessageText')
+  }
 
   let messageId: number | null = null
   let pendingText: string | null = null
@@ -115,6 +193,24 @@ export function createDraftStream(
       try {
         fn()
       } catch { /* ignore waiter errors */ }
+    }
+  }
+
+  async function sendViaDraft(textToSend: string): Promise<boolean> {
+    if (!draftApi || draftId == null) return false
+    try {
+      await draftApi(chatId, draftId, textToSend)
+      log?.(`stream → draft (id: ${draftId}, ${textToSend.length} chars)`)
+      return true
+    } catch (err) {
+      if (shouldFallbackFromDraftTransport(err)) {
+        const msg = err instanceof Error ? err.message : String(err)
+        warn?.(`draft-stream: sendMessageDraft rejected — falling back to sendMessage/editMessageText (${msg})`)
+        usesDraftTransport = false
+        draftId = undefined
+        return false
+      }
+      throw err
     }
   }
 
@@ -144,26 +240,20 @@ export function createDraftStream(
     }
 
     try {
-      if (messageId == null) {
-        messageId = await send(textToSend)
-        log?.(`stream → sent (id: ${messageId}, ${textToSend.length} chars)`)
+      if (usesDraftTransport) {
+        const ok = await sendViaDraft(textToSend)
+        if (!ok) {
+          // Draft failed with a permanent error → fell back to message transport.
+          // Replay this text via message transport.
+          await sendViaMessage(textToSend)
+        }
       } else {
-        await edit(messageId, textToSend)
-        log?.(`stream → edited (id: ${messageId}, ${textToSend.length} chars)`)
+        await sendViaMessage(textToSend)
       }
       lastSentText = textToSend
       lastSentAt = Date.now()
     } catch (err) {
       const msg = (err as Error).message ?? String(err)
-      // "message is not modified" — the new text equals the current
-      // server-side text. Treat as success.
-      //
-      // NOTE: the regexes below are intentionally anchored to the EXACT
-      // Telegram Bot API error strings (via word boundaries and the
-      // "message" prefix). Earlier versions matched /not modified/i and
-      // /not found/i anywhere in the message, which would misclassify
-      // unrelated errors like "chat not found" or "thread not found" as
-      // recoverable and silently drop them.
       if (/\bmessage is not modified\b/i.test(msg)) {
         lastSentText = textToSend
         lastSentAt = Date.now()
@@ -172,20 +262,26 @@ export function createDraftStream(
         /\bmessage to edit not found\b/i.test(msg)
         || /\bMESSAGE_ID_INVALID\b/i.test(msg)
       ) {
-        // The preview was deleted by the user (or Telegram) between send
-        // and edit. Clear the captured id + lastSentText and requeue the
-        // text so the next loop iteration re-sends from scratch.
         log?.(`stream → message not found (id: ${messageId}), re-sending`)
         messageId = null
         lastSentText = null
         if (pendingText == null) pendingText = textToSend
       } else {
         log?.(`stream → edit failed: ${msg}`)
-        // Don't throw; the loop will try again on the next update.
       }
     }
 
     notifyWaiters()
+  }
+
+  async function sendViaMessage(textToSend: string): Promise<void> {
+    if (messageId == null) {
+      messageId = await send(textToSend)
+      log?.(`stream → sent (id: ${messageId}, ${textToSend.length} chars)`)
+    } else {
+      await edit(messageId, textToSend)
+      log?.(`stream → edited (id: ${messageId}, ${textToSend.length} chars)`)
+    }
   }
 
   async function flushLoop(): Promise<void> {
@@ -223,9 +319,9 @@ export function createDraftStream(
       // Pre-send idle debounce: for the FIRST send of a stream, optionally
       // defer by idleMs so a burst of update() calls collapses into one
       // send. Each incoming update resets the timer. Once the initial
-      // send has landed (messageId != null), this path is skipped and the
-      // regular throttle kicks in.
-      if (idleMs > 0 && messageId == null && inFlight == null) {
+      // send has landed (messageId != null OR draft has fired), this path
+      // is skipped and the regular throttle kicks in.
+      if (idleMs > 0 && messageId == null && !usesDraftTransport && inFlight == null) {
         if (scheduledTimer != null) clearTimeout(scheduledTimer)
         scheduledTimer = setTimeout(() => {
           scheduledTimer = null
@@ -277,6 +373,29 @@ export function createDraftStream(
       if (pendingText != null && !stopped) {
         await flush()
       }
+
+      // Draft transport: materialize as a real sendMessage for push notification,
+      // then clear the draft best-effort.
+      if (usesDraftTransport && draftApi != null) {
+        const textToMaterialize = lastSentText
+        if (textToMaterialize) {
+          try {
+            messageId = await send(textToMaterialize)
+            log?.(`stream → materialized (id: ${messageId}, ${textToMaterialize.length} chars)`)
+          } catch (err) {
+            warn?.(`draft-stream: materialize sendMessage failed: ${err instanceof Error ? err.message : String(err)}`)
+          }
+          // Clear draft best-effort (cosmetic — Telegram input area cleanup)
+          if (draftId != null) {
+            try {
+              await draftApi(chatId, draftId, '')
+            } catch {
+              // Best-effort — ignore failures
+            }
+          }
+        }
+      }
+
       log?.(`stream finalized (id: ${messageId})`)
     },
 

--- a/telegram-plugin/draft-stream.ts
+++ b/telegram-plugin/draft-stream.ts
@@ -80,6 +80,11 @@ export interface DraftStreamConfig {
    *
    * Default 0 (no pre-send debounce — first update fires immediately).
    * Only affects the first send; subsequent edits use throttleMs.
+   *
+   * NOTE: This debounce only applies to message transport. Draft transport
+   * fires immediately on the first update because drafts are ephemeral —
+   * the throttle/flush loop already collapses bursts into 1 API call/sec
+   * via throttleMs.
    */
   idleMs?: number
   /**
@@ -166,6 +171,17 @@ export function createDraftStream(
       : requestedTransport === 'message'
         ? false
         : (config.isPrivateChat === true) // 'auto': DM only
+
+  // Footgun guard: caller asked for "auto" + provided sendMessageDraft but
+  // forgot isPrivateChat. They almost certainly wanted draft in DMs but will
+  // silently get message transport everywhere. Warn so the bug is visible.
+  if (
+    requestedTransport === 'auto'
+    && draftApi != null
+    && config.isPrivateChat === undefined
+  ) {
+    warn?.('draft-stream: previewTransport="auto" with sendMessageDraft but isPrivateChat undefined — defaulting to message transport')
+  }
 
   // Use draft transport only if we have the API
   let usesDraftTransport = prefersDraft && draftApi != null

--- a/telegram-plugin/draft-transport.ts
+++ b/telegram-plugin/draft-transport.ts
@@ -1,0 +1,72 @@
+/**
+ * Shared draft-transport helpers for answer-stream and draft-stream.
+ *
+ * Extracted from answer-stream.ts so both the narrative answer-lane and the
+ * model-driven stream_reply lane can share the same regex constants and
+ * fallback logic without duplicating them.
+ *
+ * answer-stream.ts re-exports these symbols so existing callers (including
+ * tests that import directly from answer-stream.ts) continue to work.
+ */
+
+// Error patterns matching OpenClaw's shouldFallbackFromDraftTransport.
+// Exported for tests.
+export const DRAFT_METHOD_UNAVAILABLE_RE =
+  /(unknown method|method .*not (found|available|supported)|unsupported)/i
+export const DRAFT_CHAT_UNSUPPORTED_RE = /(can't be used|can be used only)/i
+
+/**
+ * Returns true when a sendMessageDraft rejection means "this API is not
+ * available" rather than a transient network error.
+ */
+export function shouldFallbackFromDraftTransport(err: unknown): boolean {
+  const text =
+    typeof err === 'string'
+      ? err
+      : err instanceof Error
+        ? err.message
+        : typeof err === 'object' && err != null && 'description' in err
+          ? typeof (err as { description: unknown }).description === 'string'
+            ? (err as { description: string }).description
+            : ''
+          : ''
+  if (!/sendMessageDraft/i.test(text)) return false
+  return DRAFT_METHOD_UNAVAILABLE_RE.test(text) || DRAFT_CHAT_UNSUPPORTED_RE.test(text)
+}
+
+/**
+ * Symbol-keyed shared counter for draft-id allocation across concurrent
+ * streams (mirrors openclaw's getDraftStreamState). Using Symbol.for ensures
+ * the same counter is shared even if this module is loaded multiple times
+ * (e.g. from different bundle chunks).
+ */
+const DRAFT_STREAM_STATE_KEY = Symbol.for('switchroom.draftStreamState')
+
+interface DraftStreamState {
+  nextDraftId: number
+}
+
+function getDraftStreamState(): DraftStreamState {
+  const g = globalThis as Record<PropertyKey, unknown>
+  let state = g[DRAFT_STREAM_STATE_KEY] as DraftStreamState | undefined
+  if (!state) {
+    state = { nextDraftId: 0 }
+    g[DRAFT_STREAM_STATE_KEY] = state
+  }
+  return state
+}
+
+/**
+ * Allocate a unique draft ID, wrapping at 2_147_483_647 (Telegram's int32
+ * max for draft_id). IDs start at 1 and cycle.
+ */
+export function allocateDraftId(): number {
+  const state = getDraftStreamState()
+  state.nextDraftId = state.nextDraftId >= 2_147_483_647 ? 1 : state.nextDraftId + 1
+  return state.nextDraftId
+}
+
+/** Reset the shared draft-id counter — for tests only. */
+export function __resetDraftIdForTests(): void {
+  getDraftStreamState().nextDraftId = 0
+}

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -1830,9 +1830,15 @@ async function executeStreamReply(args: Record<string, unknown>): Promise<unknow
   if (!args.chat_id) throw new Error('stream_reply: chat_id is required')
   if (args.text == null || args.text === '') throw new Error('stream_reply: text is required and cannot be empty')
   const access = loadAccess()
+  // Detect chat type for draft-transport selection.
+  // Private (DM) chats have positive numeric IDs; groups/channels are negative.
+  // Forum topics have a message_thread_id set — sendMessageDraft is unsupported there.
+  const streamChatId = args.chat_id as string
+  const streamIsPrivate = isDmChatId(streamChatId)
+  const streamIsForumTopic = args.message_thread_id != null && args.message_thread_id !== ''
   const result = await handleStreamReply(
     {
-      chat_id: args.chat_id as string,
+      chat_id: streamChatId,
       text: args.text as string,
       done: Boolean(args.done),
       message_thread_id: args.message_thread_id as string | undefined,
@@ -1856,6 +1862,9 @@ async function executeStreamReply(args: Record<string, unknown>): Promise<unknow
       defaultFormat: access.parseMode ?? 'html',
       logStreamingEvent,
       endStatusReaction,
+      isPrivateChat: streamIsPrivate,
+      isForumTopic: streamIsForumTopic,
+      ...(sendMessageDraftFn != null ? { sendMessageDraft: sendMessageDraftFn } : {}),
       // Issue #310: deliver the outbound count bump BEFORE forceCompleteTurn
       // so the terminal render sees outboundDeliveredCount > 0. The handler
       // calls this dep in that order internally.

--- a/telegram-plugin/stream-controller.ts
+++ b/telegram-plugin/stream-controller.ts
@@ -16,7 +16,7 @@
  * entire server.ts top-level initialization.
  */
 
-import { createDraftStream, type DraftStreamHandle } from './draft-stream.js'
+import { createDraftStream, type DraftStreamHandle, type StreamDraftFn } from './draft-stream.js'
 
 /**
  * Minimal bot.api surface the controller needs. Real callers pass grammy's
@@ -117,6 +117,31 @@ export interface StreamControllerConfig {
    * Pass a stderr writer in production to surface them.
    */
   log?: (msg: string) => void
+  /**
+   * Optional warning logger. Used for transport fallback notices.
+   */
+  warn?: (msg: string) => void
+  /**
+   * Transport selector passed to createDraftStream.
+   * - "auto" (default): use draft transport for DMs only
+   * - "draft": always prefer draft (if sendMessageDraft is available)
+   * - "message": always use sendMessage/editMessageText
+   *
+   * The gateway forces "message" for forum topics (threads), since
+   * sendMessageDraft does not support threaded chats.
+   */
+  previewTransport?: 'auto' | 'message' | 'draft'
+  /**
+   * True when the chat is a private DM. Passed to createDraftStream so
+   * "auto" transport knows whether to activate draft.
+   */
+  isPrivateChat?: boolean
+  /**
+   * sendMessageDraft callback. When provided (and transport allows it),
+   * intermediate stream updates use the draft API. On finalize(), a real
+   * sendMessage is posted for push notification and the draft is cleared.
+   */
+  sendMessageDraft?: StreamDraftFn
 }
 
 /**
@@ -138,10 +163,14 @@ export function createStreamController(cfg: StreamControllerConfig): DraftStream
     onSend,
     onEdit,
     log,
+    warn,
     replyToMessageId,
     quoteText,
     protectContent,
     replyMarkup,
+    previewTransport,
+    isPrivateChat,
+    sendMessageDraft,
   } = cfg
 
   // Base opts shared by send + edit. The initial send adds reply_parameters
@@ -186,6 +215,11 @@ export function createStreamController(cfg: StreamControllerConfig): DraftStream
       ...(throttleMs != null ? { throttleMs } : {}),
       ...(idleMs != null ? { idleMs } : {}),
       ...(log != null ? { log } : {}),
+      ...(warn != null ? { warn } : {}),
+      ...(previewTransport != null ? { previewTransport } : {}),
+      ...(isPrivateChat != null ? { isPrivateChat } : {}),
+      ...(sendMessageDraft != null ? { sendMessageDraft } : {}),
+      chatId,
     },
   )
 }

--- a/telegram-plugin/stream-reply-handler.ts
+++ b/telegram-plugin/stream-reply-handler.ts
@@ -16,7 +16,7 @@
  *     wraps into an MCP content response.
  */
 
-import type { DraftStreamHandle } from './draft-stream.js'
+import type { DraftStreamHandle, StreamDraftFn } from './draft-stream.js'
 import {
   createStreamController,
   type StreamBotApi,
@@ -237,6 +237,23 @@ export interface StreamReplyDeps {
   writeError: (line: string) => void
   throttleMs?: number
   /**
+   * sendMessageDraft callback. When provided, stream_reply uses the draft
+   * API for intermediate updates (DM transport). On done=true, a real
+   * sendMessage fires for push notification, then the draft is cleared.
+   * Optional — omit to keep the existing sendMessage/editMessageText path.
+   */
+  sendMessageDraft?: StreamDraftFn
+  /**
+   * True when the current chat is a private DM. Passed to the stream
+   * controller so "auto" transport activates draft in DMs only.
+   */
+  isPrivateChat?: boolean
+  /**
+   * True when the current chat is a forum topic. Forum topics do not
+   * support sendMessageDraft — this forces message transport.
+   */
+  isForumTopic?: boolean
+  /**
    * When true, the progress-card driver is emitting a live checklist on
    * the `progress` lane and owns mid-turn display. In that mode, a
    * caller-initiated `stream_reply` on the default (unnamed) lane with
@@ -430,6 +447,14 @@ export async function handleStreamReply(
       }
     }
 
+    // Resolve draft-transport options. Forum topics force message transport
+    // because sendMessageDraft does not support threads.
+    const isForumTopic = deps.isForumTopic === true
+    const resolvedTransport: 'auto' | 'message' | 'draft' =
+      isForumTopic || deps.sendMessageDraft == null
+        ? 'message'
+        : 'auto'
+
     stream = createStreamController({
       bot: deps.bot,
       chatId: chat_id,
@@ -442,6 +467,9 @@ export async function handleStreamReply(
       ...(args.quote_text != null && replyToMessageId != null ? { quoteText: args.quote_text } : {}),
       ...(args.protect_content === true ? { protectContent: true } : {}),
       ...(args.reply_markup != null ? { replyMarkup: args.reply_markup } : {}),
+      previewTransport: resolvedTransport,
+      isPrivateChat: deps.isPrivateChat === true,
+      ...(deps.sendMessageDraft != null ? { sendMessageDraft: deps.sendMessageDraft } : {}),
       onSend: (messageId, charCount) =>
         deps.logStreamingEvent({ kind: 'draft_send', chatId: chat_id, messageId, charCount }),
       onEdit: (messageId, charCount) =>
@@ -464,7 +492,12 @@ export async function handleStreamReply(
           || msg.startsWith('stream → edited')
           || msg.startsWith('stream → not modified')
           || msg.startsWith('stream finalized')
+          || msg.startsWith('stream → draft')
+          || msg.startsWith('stream → materialized')
         ) return
+        deps.writeError(`telegram channel: stream_reply ${msg}\n`)
+      },
+      warn: (msg) => {
         deps.writeError(`telegram channel: stream_reply ${msg}\n`)
       },
     })

--- a/telegram-plugin/tests/draft-stream.test.ts
+++ b/telegram-plugin/tests/draft-stream.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { createDraftStream } from '../draft-stream.js'
+import { __resetDraftIdForTests } from '../draft-transport.js'
 
 interface MockTelegram {
   send: (text: string) => Promise<number>
@@ -453,5 +454,241 @@ describe('createDraftStream', () => {
     vi.advanceTimersByTime(200)
     await microtaskFlush()
     expect(m.editCalls.length).toBe(1)
+  })
+})
+
+// ─── Draft transport (sendMessageDraft) ───────────────────────────────────
+
+describe('createDraftStream — draft transport', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    __resetDraftIdForTests()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('DM happy path: sendMessageDraft called per update, sendMessage NOT called during stream', async () => {
+    const m = makeMock()
+    const draftCalls: Array<{ chatId: string; draftId: number; text: string }> = []
+    const sendMessageDraft = vi.fn(async (chatId: string, draftId: number, text: string) => {
+      draftCalls.push({ chatId, draftId, text })
+    })
+
+    const stream = createDraftStream(m.send, m.edit, {
+      throttleMs: 1000,
+      previewTransport: 'auto',
+      isPrivateChat: true,
+      sendMessageDraft,
+      chatId: 'chat1',
+    })
+
+    void stream.update('First update')
+    await microtaskFlush()
+
+    // Draft called, not sendMessage
+    expect(sendMessageDraft).toHaveBeenCalledTimes(1)
+    expect(draftCalls[0].text).toBe('First update')
+    expect(m.sendCalls.length).toBe(0)
+    expect(m.editCalls.length).toBe(0)
+
+    // Second update after throttle
+    vi.advanceTimersByTime(1000)
+    void stream.update('Second update')
+    await microtaskFlush()
+
+    expect(sendMessageDraft).toHaveBeenCalledTimes(2)
+    expect(draftCalls[1].text).toBe('Second update')
+    expect(m.sendCalls.length).toBe(0)
+  })
+
+  it('materialize on finalize: sends real sendMessage for push notification + clears draft', async () => {
+    const m = makeMock()
+    const draftClearCalls: string[] = []
+    const sendMessageDraft = vi.fn(async (_chatId: string, _draftId: number, text: string) => {
+      if (text === '') draftClearCalls.push(text)
+    })
+
+    const stream = createDraftStream(m.send, m.edit, {
+      throttleMs: 1000,
+      previewTransport: 'draft',
+      isPrivateChat: true,
+      sendMessageDraft,
+      chatId: 'chat1',
+    })
+
+    void stream.update('Final answer')
+    await microtaskFlush()
+    expect(sendMessageDraft).toHaveBeenCalledTimes(1)
+
+    await stream.finalize()
+
+    // sendMessage should have been called to materialize
+    expect(m.sendCalls.length).toBe(1)
+    expect(m.sendCalls[0].text).toBe('Final answer')
+    expect(stream.getMessageId()).toBe(100)
+
+    // Draft should have been cleared (empty string call)
+    expect(draftClearCalls.length).toBe(1)
+    expect(stream.isFinal()).toBe(true)
+  })
+
+  it('init-time fallback when sendMessageDraft is undefined → uses sendMessage/editMessageText', async () => {
+    const m = makeMock()
+
+    const stream = createDraftStream(m.send, m.edit, {
+      throttleMs: 1000,
+      previewTransport: 'draft',
+      isPrivateChat: true,
+      // No sendMessageDraft provided
+      chatId: 'chat1',
+    })
+
+    void stream.update('Hello')
+    await microtaskFlush()
+
+    expect(m.sendCalls.length).toBe(1)
+    expect(m.sendCalls[0].text).toBe('Hello')
+  })
+
+  it('runtime fallback on rejection matching DRAFT_METHOD_UNAVAILABLE_RE', async () => {
+    const m = makeMock()
+    let draftCallCount = 0
+    const sendMessageDraft = vi.fn(async () => {
+      draftCallCount++
+      throw new Error('sendMessageDraft: unknown method')
+    })
+
+    const stream = createDraftStream(m.send, m.edit, {
+      throttleMs: 1000,
+      previewTransport: 'draft',
+      sendMessageDraft,
+      chatId: 'chat1',
+    })
+
+    void stream.update('Hello')
+    await microtaskFlush()
+
+    // Draft tried once, then fell back to sendMessage
+    expect(draftCallCount).toBe(1)
+    expect(m.sendCalls.length).toBe(1)
+    expect(m.sendCalls[0].text).toBe('Hello')
+
+    // Subsequent updates should use editMessageText, not draft
+    vi.advanceTimersByTime(1000)
+    void stream.update('Follow-up')
+    await microtaskFlush()
+
+    expect(draftCallCount).toBe(1) // no more draft calls
+    expect(m.editCalls.length).toBe(1)
+  })
+
+  it('runtime fallback on rejection matching DRAFT_CHAT_UNSUPPORTED_RE', async () => {
+    const m = makeMock()
+    const sendMessageDraft = vi.fn(async () => {
+      throw new Error("sendMessageDraft can't be used in this type of chat")
+    })
+
+    const stream = createDraftStream(m.send, m.edit, {
+      throttleMs: 1000,
+      previewTransport: 'draft',
+      sendMessageDraft,
+      chatId: 'chat1',
+    })
+
+    void stream.update('Hello')
+    await microtaskFlush()
+
+    expect(sendMessageDraft).toHaveBeenCalledTimes(1)
+    expect(m.sendCalls.length).toBe(1)
+  })
+
+  it('non-matching rejection bubbles up — does not silently swap to message transport', async () => {
+    const m = makeMock()
+    const sendMessageDraft = vi.fn(async () => {
+      throw new Error('sendMessageDraft: internal server error 500')
+    })
+
+    const stream = createDraftStream(m.send, m.edit, {
+      throttleMs: 1000,
+      previewTransport: 'draft',
+      sendMessageDraft,
+      chatId: 'chat1',
+    })
+
+    // The error should NOT trigger fallback — it should propagate (draft-stream
+    // logs it but doesn't swap; subsequent update can retry).
+    void stream.update('Hello')
+    await microtaskFlush()
+
+    // Did not fall through to sendMessage
+    expect(m.sendCalls.length).toBe(0)
+    // Draft was called
+    expect(sendMessageDraft).toHaveBeenCalledTimes(1)
+  })
+
+  it('group chat (isPrivateChat=false with auto transport) → never tries draft', async () => {
+    const m = makeMock()
+    const sendMessageDraft = vi.fn(async () => {})
+
+    const stream = createDraftStream(m.send, m.edit, {
+      throttleMs: 1000,
+      previewTransport: 'auto',
+      isPrivateChat: false,
+      sendMessageDraft,
+      chatId: 'chat1',
+    })
+
+    void stream.update('Hello group')
+    await microtaskFlush()
+
+    expect(sendMessageDraft).not.toHaveBeenCalled()
+    expect(m.sendCalls.length).toBe(1)
+  })
+
+  it('forum topic (message transport) → never tries draft', async () => {
+    const m = makeMock()
+    const sendMessageDraft = vi.fn(async () => {})
+
+    // Caller forces message transport for forum topics
+    const stream = createDraftStream(m.send, m.edit, {
+      throttleMs: 1000,
+      previewTransport: 'message',
+      isPrivateChat: true, // even if DM, message transport wins
+      sendMessageDraft,
+      chatId: 'chat1',
+    })
+
+    void stream.update('Hello forum')
+    await microtaskFlush()
+
+    expect(sendMessageDraft).not.toHaveBeenCalled()
+    expect(m.sendCalls.length).toBe(1)
+  })
+
+  it('draft-clear failure is swallowed (best-effort)', async () => {
+    const m = makeMock()
+    let callCount = 0
+    const sendMessageDraft = vi.fn(async (_chatId: string, _draftId: number, text: string) => {
+      callCount++
+      if (text === '') throw new Error('Draft clear failed')
+      // Normal update — succeeds
+    })
+
+    const stream = createDraftStream(m.send, m.edit, {
+      throttleMs: 1000,
+      previewTransport: 'draft',
+      sendMessageDraft,
+      chatId: 'chat1',
+    })
+
+    void stream.update('Content')
+    await microtaskFlush()
+
+    // finalize should not throw even if draft-clear fails
+    await expect(stream.finalize()).resolves.toBeUndefined()
+    expect(m.sendCalls.length).toBe(1) // materialized
+    expect(callCount).toBeGreaterThan(1) // draft update + failed clear attempt
   })
 })

--- a/telegram-plugin/tests/draft-transport.test.ts
+++ b/telegram-plugin/tests/draft-transport.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Unit tests for draft-transport.ts — shared regex constants and
+ * shouldFallbackFromDraftTransport helper.
+ */
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  DRAFT_METHOD_UNAVAILABLE_RE,
+  DRAFT_CHAT_UNSUPPORTED_RE,
+  shouldFallbackFromDraftTransport,
+  allocateDraftId,
+  __resetDraftIdForTests,
+} from '../draft-transport.js'
+
+describe('DRAFT_METHOD_UNAVAILABLE_RE', () => {
+  it('matches "unknown method"', () => {
+    expect(DRAFT_METHOD_UNAVAILABLE_RE.test('unknown method sendMessageDraft')).toBe(true)
+  })
+
+  it('matches "method not found"', () => {
+    expect(DRAFT_METHOD_UNAVAILABLE_RE.test('method sendMessageDraft not found')).toBe(true)
+  })
+
+  it('matches "method not available"', () => {
+    expect(DRAFT_METHOD_UNAVAILABLE_RE.test('method is not available')).toBe(true)
+  })
+
+  it('matches "method not supported"', () => {
+    expect(DRAFT_METHOD_UNAVAILABLE_RE.test('method not supported')).toBe(true)
+  })
+
+  it('matches "unsupported"', () => {
+    expect(DRAFT_METHOD_UNAVAILABLE_RE.test('unsupported')).toBe(true)
+  })
+
+  it('is case-insensitive', () => {
+    expect(DRAFT_METHOD_UNAVAILABLE_RE.test('UNKNOWN METHOD')).toBe(true)
+  })
+
+  it('does NOT match unrelated errors', () => {
+    expect(DRAFT_METHOD_UNAVAILABLE_RE.test('network timeout')).toBe(false)
+    expect(DRAFT_METHOD_UNAVAILABLE_RE.test('chat not found')).toBe(false)
+  })
+})
+
+describe('DRAFT_CHAT_UNSUPPORTED_RE', () => {
+  it('matches "can\'t be used"', () => {
+    expect(DRAFT_CHAT_UNSUPPORTED_RE.test("sendMessageDraft can't be used in this type of chat")).toBe(true)
+  })
+
+  it('matches "can be used only"', () => {
+    expect(DRAFT_CHAT_UNSUPPORTED_RE.test('sendMessageDraft can be used only in private chats')).toBe(true)
+  })
+
+  it('is case-insensitive', () => {
+    expect(DRAFT_CHAT_UNSUPPORTED_RE.test("CAN'T BE USED")).toBe(true)
+  })
+
+  it('does NOT match unrelated errors', () => {
+    expect(DRAFT_CHAT_UNSUPPORTED_RE.test('message not found')).toBe(false)
+    expect(DRAFT_CHAT_UNSUPPORTED_RE.test('forbidden')).toBe(false)
+  })
+})
+
+describe('shouldFallbackFromDraftTransport', () => {
+  it('returns false when error text does not mention sendMessageDraft', () => {
+    expect(shouldFallbackFromDraftTransport(new Error('unknown method'))).toBe(false)
+    expect(shouldFallbackFromDraftTransport(new Error('unsupported feature'))).toBe(false)
+  })
+
+  it('returns true for DRAFT_METHOD_UNAVAILABLE_RE with sendMessageDraft in message', () => {
+    expect(shouldFallbackFromDraftTransport(
+      new Error('sendMessageDraft: unknown method'),
+    )).toBe(true)
+    expect(shouldFallbackFromDraftTransport(
+      new Error('400: sendMessageDraft method not found'),
+    )).toBe(true)
+  })
+
+  it('returns true for DRAFT_CHAT_UNSUPPORTED_RE with sendMessageDraft in message', () => {
+    expect(shouldFallbackFromDraftTransport(
+      new Error("sendMessageDraft can't be used in group chats"),
+    )).toBe(true)
+    expect(shouldFallbackFromDraftTransport(
+      new Error('sendMessageDraft can be used only in private chats'),
+    )).toBe(true)
+  })
+
+  it('accepts a plain string as the error', () => {
+    expect(shouldFallbackFromDraftTransport('sendMessageDraft: unknown method')).toBe(true)
+    expect(shouldFallbackFromDraftTransport('network error')).toBe(false)
+  })
+
+  it('accepts an object with a description field', () => {
+    expect(shouldFallbackFromDraftTransport({
+      description: 'sendMessageDraft: unknown method',
+    })).toBe(true)
+    expect(shouldFallbackFromDraftTransport({
+      description: 'sendMessageDraft can be used only in DMs',
+    })).toBe(true)
+  })
+
+  it('returns false for null / undefined / unrelated objects', () => {
+    expect(shouldFallbackFromDraftTransport(null)).toBe(false)
+    expect(shouldFallbackFromDraftTransport(undefined)).toBe(false)
+    expect(shouldFallbackFromDraftTransport(42)).toBe(false)
+    expect(shouldFallbackFromDraftTransport({})).toBe(false)
+  })
+
+  it('returns false when sendMessageDraft is in message but pattern does not match', () => {
+    expect(shouldFallbackFromDraftTransport(
+      new Error('sendMessageDraft: rate limited'),
+    )).toBe(false)
+    expect(shouldFallbackFromDraftTransport(
+      new Error('sendMessageDraft: internal server error'),
+    )).toBe(false)
+  })
+})
+
+describe('allocateDraftId', () => {
+  beforeEach(() => {
+    __resetDraftIdForTests()
+  })
+
+  it('allocates incrementing ids starting at 1', () => {
+    expect(allocateDraftId()).toBe(1)
+    expect(allocateDraftId()).toBe(2)
+    expect(allocateDraftId()).toBe(3)
+  })
+
+  it('wraps at 2_147_483_647 back to 1', () => {
+    // Manually set the counter near max via multiple allocations would be too slow.
+    // Instead, use the global state directly.
+    const g = globalThis as Record<PropertyKey, unknown>
+    const key = Symbol.for('switchroom.draftStreamState')
+    const state = g[key] as { nextDraftId: number }
+    state.nextDraftId = 2_147_483_647 - 1
+    expect(allocateDraftId()).toBe(2_147_483_647)
+    // Next should wrap
+    expect(allocateDraftId()).toBe(1)
+  })
+})


### PR DESCRIPTION
## Summary

Promotes the answer-stream draft-transport pattern up to draft-stream so the canonical `stream_reply` path uses Telegram's native AI-streaming API (`sendMessageDraft`, Bot API 9.5) in DMs. Falls back to `sendMessage` + `editMessageText` for groups, forum topics, and any environment where the method is unavailable or rejected at runtime.

Closes #391

## Changes

- **New `telegram-plugin/draft-transport.ts`** — shared helpers (regex constants, `shouldFallbackFromDraftTransport`, `allocateDraftId`) extracted from `answer-stream.ts` so both lanes share them. answer-stream re-exports the symbols so existing callers and tests are unaffected.
- **`telegram-plugin/draft-stream.ts`** — adds `previewTransport: "auto" | "message" | "draft"`, `isPrivateChat`, and `sendMessageDraft` config. On `finalize()`, materializes the draft as a real `sendMessage` (so the push notification fires) and clears the draft best-effort. Init-time fallback when `sendMessageDraft` is missing; runtime fallback when rejected with a recognized "unavailable" error.
- **`telegram-plugin/stream-controller.ts`** — passes the new options through to `createDraftStream`.
- **`telegram-plugin/stream-reply-handler.ts`** — accepts `sendMessageDraft`, `isPrivateChat`, and `isForumTopic`. Forum topics force message transport (drafts unsupported in threads).
- **`telegram-plugin/gateway/gateway.ts`** — wires DM detection (`isDmChatId`) and forum-topic detection at the `stream_reply` handler. Reuses the existing `sendMessageDraftFn` already used by answer-stream.
- **Tests** — new draft-transport coverage in `tests/draft-stream.test.ts` and a focused `tests/draft-transport.test.ts`.

## Trade-offs

- Push notifications shift from "first chunk" to "done" — likely better UX (one ping per finished reply, not one per started reply).
- No reply-quote banner during streaming, only at finalize. Acceptable.
- Brief visual handoff at materialize (draft → real message). Seamless on iOS/Desktop in practice.
- 4096-char hard cap unchanged.

## Out of scope

- Progress card stays on `editMessageText` — needs a real `message_id` for pin/edit lifecycle.
- `reply` and `edit_message` MCP tools unchanged.

## Test plan

- [x] `tests/draft-stream.test.ts` — new draft-transport cases (happy path, init fallback, runtime fallback, materialize, group-chat-skip, forum-topic-skip)
- [x] `tests/draft-transport.test.ts` — regex coverage for `shouldFallbackFromDraftTransport`
- [x] `tests/stream-controller.test.ts` — controller passes through new options
- [x] Existing draft-stream and answer-stream tests still pass
- [ ] Manual QA on DM, group, and forum topic chats post-merge