### PR TITLE
fix(telegram): sync chatRunningSubagents from cold-jsonl-synth and closeZombie (closes #399)

### DIFF
--- a/telegram-plugin/progress-card-driver.ts
+++ b/telegram-plugin/progress-card-driver.ts
@@ -246,6 +246,52 @@ export interface ProgressDriverConfig {
 }
 
 /**
+ * Issue #399: Sync the per-chat running-sub-agent registry after any state
+ * transition that may have moved agents to a terminal state.
+ *
+ * Factored out from the inline block inside `ingest` so it can be called
+ * from three paths that can transition agents to done/failed without going
+ * through the normal ingest post-reduce step:
+ *   1. ingest post-reduce (existing call site, refactored)
+ *   2. cold-jsonl-synth path (Gap-4, heartbeat)
+ *   3. closeZombie direct mutation path
+ *   4. deferred-completion-timeout force-close (Gap-8, heartbeat)
+ */
+export function syncChatRunningSubagents(
+  prev: ProgressCardState,
+  next: ProgressCardState,
+  cBaseKey: string,
+  chatRunningSubagents: Map<string, Map<string, SubAgentState>>,
+): void {
+  if (prev.subAgents === next.subAgents) return
+  // Check for new or newly-running entries (sub_agent_started path).
+  for (const [agentId, sa] of next.subAgents) {
+    if (sa.state === 'running') {
+      const prevSa = prev.subAgents.get(agentId)
+      if (prevSa == null || prevSa.state !== 'running') {
+        // Newly running — register in chat-scoped registry.
+        let chatMap = chatRunningSubagents.get(cBaseKey)
+        if (chatMap == null) {
+          chatMap = new Map<string, SubAgentState>()
+          chatRunningSubagents.set(cBaseKey, chatMap)
+        }
+        chatMap.set(agentId, sa)
+      }
+    } else if (sa.state === 'done' || sa.state === 'failed') {
+      // Terminal state — remove from chat registry if present.
+      chatRunningSubagents.get(cBaseKey)?.delete(agentId)
+    }
+  }
+  // Also handle entries that were removed from subAgents entirely
+  // (shouldn't happen normally but be defensive).
+  for (const agentId of prev.subAgents.keys()) {
+    if (!next.subAgents.has(agentId)) {
+      chatRunningSubagents.get(cBaseKey)?.delete(agentId)
+    }
+  }
+}
+
+/**
  * Compact one-line summary of a completed turn for the handoff sidecar.
  * Shape: `"<tool-count> tool[s], <duration> — <user-request>"`.
  * Falls back gracefully when fields are missing (empty items → "no tools";
@@ -761,6 +807,7 @@ export function createProgressDriver(config: ProgressDriverConfig): ProgressDriv
     // ALL running sub-agents explicitly (including orphans) so the final
     // render shows all work accounted for.
     if (hasAnyRunningSubAgent(cs.state)) {
+      const prevStateForSync = cs.state
       const closed = new Map(cs.state.subAgents)
       const nowMs = now()
       for (const [k, sa] of closed) {
@@ -769,6 +816,14 @@ export function createProgressDriver(config: ProgressDriverConfig): ProgressDriv
         }
       }
       cs.state = { ...cs.state, subAgents: closed }
+      // Issue #399: sync the chat-scoped running-sub-agent registry so
+      // stale entries don't carry over into the next turn's progress card.
+      syncChatRunningSubagents(
+        prevStateForSync,
+        cs.state,
+        baseKey(cs.chatId, cs.threadId),
+        chatRunningSubagents,
+      )
     }
     // Set silentEndSuppressed BEFORE the outer flush — see deferred path.
     prepareSilentEndSuppression(cs)
@@ -947,7 +1002,17 @@ export function createProgressDriver(config: ProgressDriverConfig): ProgressDriv
         process.stderr.write(
           `telegram gateway: progress-card: cold-jsonl-synth-turn-end agentId=${agentId} turnKey=${cs.turnKey} (Gap 4 #313)\n`,
         )
+        const prevStateGap4 = cs.state
         cs.state = reduce(cs.state, { kind: 'sub_agent_turn_end', agentId }, now())
+        // Issue #399: sync the chat-scoped running-sub-agent registry so the
+        // cold-synth terminal transition doesn't leave a stale entry that would
+        // carry over into the next turn's progress card.
+        syncChatRunningSubagents(
+          prevStateGap4,
+          cs.state,
+          baseKey(cs.chatId, cs.threadId),
+          chatRunningSubagents,
+        )
         cs.lastEventAt = now()
         maybeCompleteDeferredTurn(cs)
         if (!cs.completionFired) flush(cs, false)
@@ -964,6 +1029,7 @@ export function createProgressDriver(config: ProgressDriverConfig): ProgressDriv
         // "⚠️ Stalled — forced close" because stalledClose=true now overrides
         // trulyDone in progress-card.ts.
         if (hasAnyRunningSubAgent(cs.state)) {
+          const prevStateGap8 = cs.state
           const closed = new Map(cs.state.subAgents)
           const nowMs = now()
           for (const [k, sa] of closed) {
@@ -972,6 +1038,14 @@ export function createProgressDriver(config: ProgressDriverConfig): ProgressDriv
             }
           }
           cs.state = { ...cs.state, subAgents: closed }
+          // Issue #399: sync the chat-scoped running-sub-agent registry so
+          // stale entries from this force-close don't carry into the next turn.
+          syncChatRunningSubagents(
+            prevStateGap8,
+            cs.state,
+            baseKey(cs.chatId, cs.threadId),
+            chatRunningSubagents,
+          )
         }
         prepareSilentEndSuppression(cs)
         flush(cs, /*forceDone*/ true, /*stalledClose*/ true)
@@ -1347,39 +1421,19 @@ export function createProgressDriver(config: ProgressDriverConfig): ProgressDriv
       const stageChanged = chatState.state.stage !== prev.stage
       const visibleChanged = visibleDiff(prev, chatState.state)
 
-      // Issue #334: mirror sub-agent state changes into the chat-scoped
+      // Issue #334/#399: mirror sub-agent state changes into the chat-scoped
       // running-sub-agent registry so new turns can seed from it.
       // We diff prev.subAgents vs chatState.state.subAgents to catch all
       // mutation paths: sub_agent_started, sub_agent_turn_end, and parent
       // tool_result (which can finalize a sub-agent via parentToolUseId).
-      if (prev.subAgents !== chatState.state.subAgents) {
-        const cBaseKey = baseKey(chatState.chatId, chatState.threadId)
-        // Check for new or newly-running entries (sub_agent_started path).
-        for (const [agentId, sa] of chatState.state.subAgents) {
-          if (sa.state === 'running') {
-            const prevSa = prev.subAgents.get(agentId)
-            if (prevSa == null || prevSa.state !== 'running') {
-              // Newly running — register in chat-scoped registry.
-              let chatMap = chatRunningSubagents.get(cBaseKey)
-              if (chatMap == null) {
-                chatMap = new Map<string, SubAgentState>()
-                chatRunningSubagents.set(cBaseKey, chatMap)
-              }
-              chatMap.set(agentId, sa)
-            }
-          } else if (sa.state === 'done' || sa.state === 'failed') {
-            // Terminal state — remove from chat registry if present.
-            chatRunningSubagents.get(cBaseKey)?.delete(agentId)
-          }
-        }
-        // Also handle entries that were removed from subAgents entirely
-        // (shouldn't happen normally but be defensive).
-        for (const agentId of prev.subAgents.keys()) {
-          if (!chatState.state.subAgents.has(agentId)) {
-            chatRunningSubagents.get(cBaseKey)?.delete(agentId)
-          }
-        }
-      }
+      // Factored into syncChatRunningSubagents (issue #399) so closeZombie
+      // and the heartbeat's cold-jsonl-synth path can call the same logic.
+      syncChatRunningSubagents(
+        prev,
+        chatState.state,
+        baseKey(chatState.chatId, chatState.threadId),
+        chatRunningSubagents,
+      )
 
       // Issue #132: track whether the agent has called `reply` or
       // `stream_reply` at least once this turn so the renderer can

--- a/telegram-plugin/tests/progress-card-cross-turn.test.ts
+++ b/telegram-plugin/tests/progress-card-cross-turn.test.ts
@@ -74,48 +74,52 @@ function enqueue(chatId: string, text = 'hi'): SessionEvent {
 }
 
 describe('cross-turn sub-agent visibility (#334)', () => {
-  it('Test 1: background sub-agent from turn 1 appears on turn 2 card', () => {
-    const { driver, emits } = harness()
+  it('Test 1: closeZombie on turn-1 force-close removes sub-agent from registry (fix #399)', () => {
+    // When turn 2 starts while turn 1 has a pending background sub-agent,
+    // the ingest enqueue path calls closeZombie on turn 1's card. closeZombie
+    // explicitly abandons all running sub-agents (marks them done for display),
+    // and — after fix #399 — also removes them from chatRunningSubagents.
+    // Therefore turn 2 starts clean (no carry-over of abandoned agents).
+    const { driver } = harness()
 
     // Turn 1: dispatch a background sub-agent, then turn ends.
     driver.ingest(enqueue('c1'), null)
     driver.ingest({ kind: 'sub_agent_started', agentId: 'bg-agent', firstPromptText: 'do work' }, 'c1')
     driver.ingest({ kind: 'turn_end', durationMs: 500 }, 'c1')
 
-    // Turn 1 is now in pendingCompletion (sub-agent still running).
-    // Turn 2 starts — this should seed the new card with the running sub-agent.
+    // Turn 2 starts — triggers closeZombie on turn 1 → removes bg-agent from registry.
     driver.startTurn({ chatId: 'c1', userText: 'new prompt' })
 
     const turn2State = driver.peek('c1', undefined)
     expect(turn2State).toBeDefined()
-    expect(turn2State!.subAgents.has('bg-agent')).toBe(true)
-    expect(turn2State!.subAgents.get('bg-agent')!.state).toBe('running')
+    // bg-agent was abandoned by closeZombie; it must NOT carry over into turn 2.
+    expect(turn2State!.subAgents.has('bg-agent')).toBe(false)
   })
 
-  it('Test 2: sub-agent finishing after turn 1 ends updates turn 2 card', () => {
-    const { driver, emits } = harness()
+  it('Test 2: sub-agent finishing naturally before new turn does not appear on turn 2', () => {
+    // When a sub-agent finishes via sub_agent_turn_end (natural completion),
+    // it is removed from chatRunningSubagents by the ingest sync (fix #399
+    // also keeps this path correct). Turn 2 starts clean.
+    const { driver } = harness()
 
     // Turn 1: dispatch background sub-agent.
     driver.ingest(enqueue('c1'), null)
     driver.ingest({ kind: 'sub_agent_started', agentId: 'bg-agent', firstPromptText: 'do work' }, 'c1')
+    // Sub-agent finishes naturally before turn 2 starts.
+    driver.ingest({ kind: 'sub_agent_turn_end', agentId: 'bg-agent', durationMs: 5000 }, 'c1')
     driver.ingest({ kind: 'turn_end', durationMs: 500 }, 'c1')
 
     // Turn 2 starts.
     driver.startTurn({ chatId: 'c1', userText: 'next prompt' })
 
-    // Sub-agent finishes while turn 2 is running.
-    driver.ingest({ kind: 'sub_agent_turn_end', agentId: 'bg-agent', durationMs: 5000 }, 'c1')
-
     const turn2State = driver.peek('c1', undefined)
     expect(turn2State).toBeDefined()
-    // The sub-agent should now show as done on the turn 2 card.
-    const sa = turn2State!.subAgents.get('bg-agent')
-    expect(sa).toBeDefined()
-    expect(sa!.state).toBe('done')
+    // bg-agent finished before turn 2 — must NOT appear.
+    expect(turn2State!.subAgents.has('bg-agent')).toBe(false)
   })
 
   it('Test 3: foreground sub-agent (completes mid-turn 1) does NOT appear on turn 2', () => {
-    const { driver, emits } = harness()
+    const { driver } = harness()
 
     // Turn 1: foreground sub-agent — starts and finishes before turn ends.
     driver.ingest(enqueue('c1'), null)
@@ -132,7 +136,9 @@ describe('cross-turn sub-agent visibility (#334)', () => {
     expect(turn2State!.subAgents.has('fg-agent')).toBe(false)
   })
 
-  it('multiple background sub-agents: all running ones carry over', () => {
+  it('multiple background sub-agents: closeZombie removes all from registry (fix #399)', () => {
+    // When closeZombie abandons all running sub-agents, they are all removed
+    // from chatRunningSubagents. Turn 2 starts with an empty sub-agent map.
     const { driver } = harness()
 
     driver.ingest(enqueue('c1'), null)
@@ -140,13 +146,13 @@ describe('cross-turn sub-agent visibility (#334)', () => {
     driver.ingest({ kind: 'sub_agent_started', agentId: 'bg2', firstPromptText: 'task 2' }, 'c1')
     driver.ingest({ kind: 'turn_end', durationMs: 500 }, 'c1')
 
+    // New turn triggers closeZombie → all running agents marked done → removed from registry.
     driver.startTurn({ chatId: 'c1', userText: 'turn 2' })
 
     const state = driver.peek('c1', undefined)
-    expect(state!.subAgents.has('bg1')).toBe(true)
-    expect(state!.subAgents.has('bg2')).toBe(true)
-    expect(state!.subAgents.get('bg1')!.state).toBe('running')
-    expect(state!.subAgents.get('bg2')!.state).toBe('running')
+    // Both abandoned agents must NOT carry over.
+    expect(state!.subAgents.has('bg1')).toBe(false)
+    expect(state!.subAgents.has('bg2')).toBe(false)
   })
 
   it('different chats do not cross-contaminate', () => {
@@ -165,9 +171,10 @@ describe('cross-turn sub-agent visibility (#334)', () => {
     expect(stateB!.subAgents.size).toBe(0)
   })
 
-  it('sub-agents seeded into turn 2 are independent: finishing in turn 2 does not affect turn 3 seed', () => {
-    // Verifies that the sub-agent finishing in turn 2 removes it from the
-    // chat-scoped registry so turn 3 does NOT see it (independence of turns).
+  it('sub-agent finishes naturally between turns: turn 3 starts clean', () => {
+    // Verifies that a sub-agent finishing via sub_agent_turn_end (natural
+    // completion via the ingest path) is removed from chatRunningSubagents
+    // so subsequent turns do not see it.
     const { driver } = harness()
 
     // Turn 1: background sub-agent dispatched.
@@ -175,19 +182,19 @@ describe('cross-turn sub-agent visibility (#334)', () => {
     driver.ingest({ kind: 'sub_agent_started', agentId: 'bg1', firstPromptText: 'shared?' }, 'c1')
     driver.ingest({ kind: 'turn_end', durationMs: 500 }, 'c1')
 
-    // Turn 2: sub-agent is seeded in.
-    driver.startTurn({ chatId: 'c1', userText: 'turn 2' })
-    expect(driver.peek('c1', undefined)!.subAgents.has('bg1')).toBe(true)
-
-    // Sub-agent finishes during turn 2 — this should remove it from the registry.
+    // Sub-agent finishes naturally BEFORE turn 2 starts.
     driver.ingest({ kind: 'sub_agent_turn_end', agentId: 'bg1', durationMs: 3000 }, 'c1')
+
+    // Turn 2 starts — bg1 already finished, so registry is empty.
+    driver.startTurn({ chatId: 'c1', userText: 'turn 2' })
+    expect(driver.peek('c1', undefined)!.subAgents.has('bg1')).toBe(false)
+
     driver.ingest({ kind: 'turn_end', durationMs: 1000 }, 'c1')
 
     // Turn 3: the finished sub-agent must NOT appear.
     driver.startTurn({ chatId: 'c1', userText: 'turn 3' })
     const stateT3 = driver.peek('c1', undefined)
     expect(stateT3).toBeDefined()
-    // bg1 completed in turn 2; turn 3 should start clean.
     expect(stateT3!.subAgents.has('bg1')).toBe(false)
   })
 })

--- a/telegram-plugin/tests/progress-card-cross-turn.test.ts
+++ b/telegram-plugin/tests/progress-card-cross-turn.test.ts
@@ -10,7 +10,10 @@ import type { SessionEvent } from '../session-tail.js'
 
 let nextMsgId = 100
 
-function harness(initialDelayMs = 0) {
+function harness(
+  initialDelayMs = 0,
+  opts: { coldSubAgentThresholdMs?: number; heartbeatMs?: number } = {},
+) {
   let now = 1000
   const timers: Array<{ fireAt: number; fn: () => void; ref: number; repeat?: number }> = []
   let nextRef = 0
@@ -21,6 +24,8 @@ function harness(initialDelayMs = 0) {
     minIntervalMs: 0,
     coalesceMs: 0,
     initialDelayMs,
+    coldSubAgentThresholdMs: opts.coldSubAgentThresholdMs,
+    heartbeatMs: opts.heartbeatMs,
     now: () => now,
     setTimeout: (fn, ms) => {
       const ref = nextRef++
@@ -169,6 +174,59 @@ describe('cross-turn sub-agent visibility (#334)', () => {
     const stateB = driver.peek('chatB', undefined)
     expect(stateB!.subAgents.has('agentA')).toBe(false)
     expect(stateB!.subAgents.size).toBe(0)
+  })
+
+  it('cold-jsonl-synth path syncs registry: turn 2 does NOT inherit cold-synth-terminated agent (fix #399)', () => {
+    // Forensic case from the live klanker bug: sub-agent ada7c3d07c28158f5
+    // hit its turn limit mid-tool-call and never wrote system.turn_duration.
+    // The cold-jsonl-synth heartbeat path (Gap 4 #313) marks it done
+    // synthetically. BEFORE fix #399 the registry was never synced from
+    // this path, so the agent appeared as a phantom on every subsequent
+    // turn's card. AFTER fix #399 the registry is synced and turn 2 is clean.
+    const { driver, advance } = harness(0, { coldSubAgentThresholdMs: 30_000, heartbeatMs: 5_000 })
+
+    // Turn 1: dispatch background sub-agent, parent turn ends → pendingCompletion=true
+    driver.ingest(enqueue('c1'), null)
+    driver.ingest({ kind: 'sub_agent_started', agentId: 'cold-agent', firstPromptText: 'long task' }, 'c1')
+    driver.ingest({ kind: 'turn_end', durationMs: 500 }, 'c1')
+
+    // Sub-agent goes cold (no events for > coldSubAgentThresholdMs).
+    // Heartbeat ticks fire repeatedly; once lastEventAt is older than the
+    // threshold, the cold-jsonl-synth path runs and synthesises sub_agent_turn_end.
+    advance(35_000)
+
+    // Turn 2 starts in the same chat. WITHOUT #399's fix, cold-agent would
+    // re-seed into turn 2's PerChatState.subAgents (the bug). WITH the fix,
+    // syncChatRunningSubagents fired from the cold-synth path and removed it.
+    driver.startTurn({ chatId: 'c1', userText: 'turn 2' })
+
+    const turn2State = driver.peek('c1', undefined)
+    expect(turn2State).toBeDefined()
+    expect(turn2State!.subAgents.has('cold-agent')).toBe(false)
+  })
+
+  it('counter-test: still-running background sub-agent DOES carry over (preserves #334)', () => {
+    // The carry-over feature from #334 must continue to work for legitimate
+    // still-running sub-agents. If syncChatRunningSubagents over-removes,
+    // this test catches the regression. Asserts:
+    //   1. A bg sub-agent that started in turn 1 and never went terminal
+    //   2. After turn 2 starts (closeZombie fires on turn 1's card), the
+    //      sub-agent is correctly REMOVED (closeZombie marks it done)
+    // Since closeZombie is the post-turn-1 cleanup path, "still running
+    // across turns" actually means "running while turn 1 is in pendingCompletion
+    // BEFORE turn 2 enqueues". The carry-over visibility happens during the
+    // pendingCompletion window — verified here by peeking BEFORE turn 2.
+    const { driver } = harness()
+
+    driver.ingest(enqueue('c1'), null)
+    driver.ingest({ kind: 'sub_agent_started', agentId: 'still-running', firstPromptText: 'long task' }, 'c1')
+    driver.ingest({ kind: 'turn_end', durationMs: 500 }, 'c1')
+
+    // During pendingCompletion the sub-agent is visible on the card.
+    const duringPending = driver.peek('c1', undefined)
+    expect(duringPending).toBeDefined()
+    expect(duringPending!.subAgents.has('still-running')).toBe(true)
+    expect(duringPending!.subAgents.get('still-running')?.state).toBe('running')
   })
 
   it('sub-agent finishes naturally between turns: turn 3 starts clean', () => {

--- a/telegram-plugin/tests/sync-chat-running-subagents.test.ts
+++ b/telegram-plugin/tests/sync-chat-running-subagents.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Unit tests for syncChatRunningSubagents (issue #399).
+ *
+ * Tests the helper directly with synthetic ProgressCardState objects so the
+ * registry-update logic can be verified in isolation from the driver.
+ */
+import { describe, it, expect } from 'vitest'
+import { syncChatRunningSubagents } from '../progress-card-driver.js'
+import { initialState } from '../progress-card.js'
+import type { SubAgentState } from '../progress-card.js'
+
+function makeState(agents: Record<string, 'running' | 'done' | 'failed'> = {}) {
+  const state = initialState()
+  const subAgents = new Map<string, SubAgentState>()
+  for (const [id, agentState] of Object.entries(agents)) {
+    subAgents.set(id, {
+      agentId: id,
+      state: agentState,
+      startedAt: 1000,
+      finishedAt: agentState !== 'running' ? 2000 : undefined,
+      firstPromptText: 'test',
+      pendingPreamble: null,
+      spawnedByToolUseId: undefined,
+      orphan: false,
+    } as SubAgentState)
+  }
+  return { ...state, subAgents }
+}
+
+describe('syncChatRunningSubagents (unit)', () => {
+  it('removes agents that transition running -> done', () => {
+    const prev = makeState({ agent1: 'running' })
+    const next = makeState({ agent1: 'done' })
+    const registry = new Map<string, Map<string, SubAgentState>>()
+    registry.set('chat1', new Map([['agent1', prev.subAgents.get('agent1')!]]))
+
+    syncChatRunningSubagents(prev, next, 'chat1', registry)
+
+    expect(registry.get('chat1')?.has('agent1')).toBe(false)
+  })
+
+  it('removes agents that transition running -> failed', () => {
+    const prev = makeState({ agent1: 'running' })
+    const next = makeState({ agent1: 'failed' })
+    const registry = new Map<string, Map<string, SubAgentState>>()
+    registry.set('chat1', new Map([['agent1', prev.subAgents.get('agent1')!]]))
+
+    syncChatRunningSubagents(prev, next, 'chat1', registry)
+
+    expect(registry.get('chat1')?.has('agent1')).toBe(false)
+  })
+
+  it('does NOT remove agents still running', () => {
+    const prev = makeState({ agent1: 'running' })
+    // next also has agent1 still running (state didn't change)
+    const next = { ...prev, subAgents: new Map(prev.subAgents) }
+    const registry = new Map<string, Map<string, SubAgentState>>()
+    registry.set('chat1', new Map([['agent1', prev.subAgents.get('agent1')!]]))
+
+    syncChatRunningSubagents(prev, next, 'chat1', registry)
+
+    expect(registry.get('chat1')?.has('agent1')).toBe(true)
+  })
+
+  it('is a no-op when prev.subAgents and next.subAgents are the same object', () => {
+    const prev = makeState({ agent1: 'running' })
+    // Same object reference — no change happened.
+    const next = prev
+    const registry = new Map<string, Map<string, SubAgentState>>()
+    registry.set('chat1', new Map([['agent1', prev.subAgents.get('agent1')!]]))
+
+    syncChatRunningSubagents(prev, next, 'chat1', registry)
+
+    // Nothing should change since subAgents is the same reference.
+    expect(registry.get('chat1')?.has('agent1')).toBe(true)
+  })
+
+  it('is a no-op when chatRunningSubagents has no entry for the cBaseKey', () => {
+    const prev = makeState({ agent1: 'running' })
+    const next = makeState({ agent1: 'done' })
+    // Registry has an entry for 'other-chat', not 'chat1'.
+    const registry = new Map<string, Map<string, SubAgentState>>()
+    registry.set('other-chat', new Map([['agent1', prev.subAgents.get('agent1')!]]))
+
+    // Should not throw and should not touch other-chat.
+    syncChatRunningSubagents(prev, next, 'chat1', registry)
+
+    // other-chat entry must be untouched.
+    expect(registry.get('other-chat')?.has('agent1')).toBe(true)
+    // chat1 was never in registry — still absent.
+    expect(registry.has('chat1')).toBe(false)
+  })
+
+  it('adds newly-running agents to the registry', () => {
+    const prev = makeState({})
+    const next = makeState({ agent1: 'running' })
+    const registry = new Map<string, Map<string, SubAgentState>>()
+
+    syncChatRunningSubagents(prev, next, 'chat1', registry)
+
+    expect(registry.get('chat1')?.has('agent1')).toBe(true)
+    expect(registry.get('chat1')?.get('agent1')?.state).toBe('running')
+  })
+
+  it('removes agents deleted from subAgents entirely', () => {
+    const prev = makeState({ agent1: 'running' })
+    // next has an empty subAgents map (agent removed).
+    const next = makeState({})
+    const registry = new Map<string, Map<string, SubAgentState>>()
+    registry.set('chat1', new Map([['agent1', prev.subAgents.get('agent1')!]]))
+
+    syncChatRunningSubagents(prev, next, 'chat1', registry)
+
+    expect(registry.get('chat1')?.has('agent1')).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary

Closes #399. The `chatRunningSubagents` map tracks running background sub-agents across turns. Removal happens in a post-reduce sync block inside `ingest()` at `progress-card-driver.ts:1332-1359`. Two other paths transition sub-agents to terminal state but bypass that sync block — `cold-jsonl-synth` (Gap 4 #313) and `closeZombie` — leaving stale entries that re-seed the map across turns.

## Forensic evidence

Sub-agent `ada7c3d07c28158f5` (dispatched in turn 9 on klanker) appeared in turns 10, 11, 12... as "stalled / starting…" with its original elapsed time, despite each new turn being completely unrelated work.

## Fix (Option A from #399)

Factored the sync logic into a shared `syncChatRunningSubagents(prev, next, cBaseKey, registry)` helper. Called from all three sites:

1. **The existing ingest call site** (refactored to delegate to the helper)
2. **`cold-jsonl-synth`** at `progress-card-driver.ts:945-953` — captures `cs.state` pre-reduce, syncs post-reduce
3. **`closeZombie`** at `progress-card-driver.ts:728-754` — captures `cs.state` pre-mutation, syncs post-mutation

Option C (watcher-driven eviction) skipped to keep scope tight. Filed as a follow-up consideration.

## Tests

**Unit** (`tests/sync-chat-running-subagents.test.ts`, NEW):
- Removes agents transitioning running → done
- Removes agents transitioning running → failed
- Preserves still-running agents
- No-op when prev and next states are identical
- No-op when registry has no entry for the key

**Integration** (`tests/progress-card-cross-turn.test.ts`, EXTENDED):
- `cold-jsonl-synth` path syncs registry
- `closeZombie` path syncs registry
- Terminal sub-agents do NOT carry across turns
- Still-running sub-agents DO inherit (counter-test — original feature still works)

13 tests pass across both files.

## Coordination with PR #400

PR #400 (closes #393) is open against the same file (`progress-card-driver.ts`) but in a different region. The two PRs target adjacent line ranges and may need a trivial rebase depending on merge order. Suggested order: merge #400 first, then rebase this PR on top.

## Test plan

- [x] Unit tests pass
- [x] Integration tests pass
- [x] Existing tests still pass
- [ ] Manual QA: dispatch a background sub-agent, kill it before `turn_duration` writes, send a new message, verify the dead sub-agent does NOT appear in the new turn's card