### PR TITLE
fix(subagents): split jsonl_agent_id index out of base schema SQL

### DIFF
--- a/telegram-plugin/registry/subagents-schema.ts
+++ b/telegram-plugin/registry/subagents-schema.ts
@@ -136,6 +136,13 @@ export interface BumpSubagentActivityArgs {
 // Schema
 // ---------------------------------------------------------------------------
 
+// Base table + indexes that don't depend on the jsonl_agent_id column.
+// The jsonl_agent_id column is added (if missing) by the migration block in
+// applySubagentsSchema, and its index is created there too — putting the
+// index in this base SQL would fail on pre-existing tables that don't yet
+// have the column ("no such column: jsonl_agent_id"), because
+// `CREATE TABLE IF NOT EXISTS` is a no-op on those tables and the column
+// only appears after the ALTER below.
 const SUBAGENTS_SCHEMA_SQL = `
   CREATE TABLE IF NOT EXISTS subagents (
     id                TEXT    PRIMARY KEY,
@@ -153,7 +160,6 @@ const SUBAGENTS_SCHEMA_SQL = `
   );
   CREATE INDEX IF NOT EXISTS subagents_turn      ON subagents(parent_turn_key);
   CREATE INDEX IF NOT EXISTS subagents_status    ON subagents(status);
-  CREATE INDEX IF NOT EXISTS subagents_jsonl_id  ON subagents(jsonl_agent_id);
 `
 
 /**
@@ -161,7 +167,11 @@ const SUBAGENTS_SCHEMA_SQL = `
  * already has the turns table — uses CREATE IF NOT EXISTS throughout.
  *
  * Also runs an ALTER TABLE migration to add `jsonl_agent_id` to pre-existing
- * tables that were created before this column was introduced.
+ * tables that were created before this column was introduced. The migration
+ * runs BEFORE the jsonl_agent_id index is created — putting that index in
+ * the base SQL would throw "no such column: jsonl_agent_id" on pre-existing
+ * tables, because `CREATE TABLE IF NOT EXISTS` is a no-op there and the
+ * column only appears after the ALTER below.
  */
 export function applySubagentsSchema(db: SqliteDatabase): void {
   db.exec(SUBAGENTS_SCHEMA_SQL)
@@ -172,8 +182,13 @@ export function applySubagentsSchema(db: SqliteDatabase): void {
   const hasJsonlId = cols.some((c) => c.name === 'jsonl_agent_id')
   if (!hasJsonlId) {
     db.exec('ALTER TABLE subagents ADD COLUMN jsonl_agent_id TEXT')
-    db.exec('CREATE INDEX IF NOT EXISTS subagents_jsonl_id ON subagents(jsonl_agent_id)')
   }
+  // Always (re-)apply the index. `IF NOT EXISTS` makes this a no-op when it
+  // already exists. Splitting it from SUBAGENTS_SCHEMA_SQL is what fixes the
+  // pre-existing-table failure mode — by the time we reach this line, the
+  // column is guaranteed to exist (either created with the table or added by
+  // the migration above).
+  db.exec('CREATE INDEX IF NOT EXISTS subagents_jsonl_id ON subagents(jsonl_agent_id)')
 }
 
 // ---------------------------------------------------------------------------

--- a/telegram-plugin/tests/subagents-schema-init-order.test.ts
+++ b/telegram-plugin/tests/subagents-schema-init-order.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Regression test for the subagents-schema init-order bug.
+ *
+ * The bug: SUBAGENTS_SCHEMA_SQL contained
+ * `CREATE INDEX IF NOT EXISTS subagents_jsonl_id ON subagents(jsonl_agent_id)`
+ * — but on a pre-existing `subagents` table that was created before the
+ * `jsonl_agent_id` column was introduced, `CREATE TABLE IF NOT EXISTS` is a
+ * no-op, so the column doesn't exist when the index is created → SQLite
+ * throws "no such column: jsonl_agent_id" and the entire schema-apply
+ * aborts before the ALTER TABLE migration block can add the column.
+ *
+ * Symptom in production: gateways with pre-#341 DBs logged
+ * `turn-registry init failed (no such column: jsonl_agent_id) — turn
+ * tracking disabled` on every restart, even though they were running
+ * source that contained the migration.
+ *
+ * Fix: split the index creation OUT of SUBAGENTS_SCHEMA_SQL and into the
+ * migration function, AFTER the ALTER TABLE.
+ *
+ * Uses `bun:sqlite` directly so it must run under Bun, not vitest/Node.
+ * Excluded from vitest.config.ts; runs via `bun test` (CI :telegram: step).
+ */
+import { describe, it, expect } from 'bun:test'
+import { Database } from 'bun:sqlite'
+import { applySubagentsSchema } from '../registry/subagents-schema.js'
+
+describe('applySubagentsSchema init-order', () => {
+  it('migrates a pre-existing subagents table missing jsonl_agent_id', () => {
+    const db = new Database(':memory:')
+
+    // Simulate a DB created before #341 — the table exists but no
+    // jsonl_agent_id column. (Mirrors the live state of clerk/klanker/finn
+    // on 2026-04-30 before this fix.)
+    db.exec(`
+      CREATE TABLE subagents (
+        id                TEXT    PRIMARY KEY,
+        parent_session_id TEXT,
+        parent_turn_key   TEXT,
+        agent_type        TEXT,
+        description       TEXT,
+        background        INTEGER NOT NULL,
+        started_at        INTEGER NOT NULL,
+        last_activity_at  INTEGER,
+        ended_at          INTEGER,
+        status            TEXT    NOT NULL,
+        result_summary    TEXT
+      );
+    `)
+
+    // Pre-fix: this throws "no such column: jsonl_agent_id".
+    // Post-fix: schema apply runs to completion, ALTER adds the column,
+    // and the index is created.
+    expect(() => applySubagentsSchema(db)).not.toThrow()
+
+    const cols = db
+      .prepare("SELECT name FROM pragma_table_info('subagents')")
+      .all() as { name: string }[]
+    expect(cols.some((c) => c.name === 'jsonl_agent_id')).toBe(true)
+
+    // Index landed too — confirm via sqlite_master so future regressions
+    // (e.g. if the index is moved out of the migration path) are caught.
+    const indexes = db
+      .prepare("SELECT name FROM sqlite_master WHERE type = 'index' AND tbl_name = 'subagents'")
+      .all() as { name: string }[]
+    expect(indexes.map((r) => r.name)).toContain('subagents_jsonl_id')
+  })
+
+  it('is idempotent on a fresh DB (column was never missing)', () => {
+    const db = new Database(':memory:')
+    applySubagentsSchema(db)
+    // Second call must not throw — both ALTER (skipped) and CREATE INDEX
+    // (IF NOT EXISTS) are no-ops here.
+    expect(() => applySubagentsSchema(db)).not.toThrow()
+
+    const cols = db
+      .prepare("SELECT name FROM pragma_table_info('subagents')")
+      .all() as { name: string }[]
+    expect(cols.some((c) => c.name === 'jsonl_agent_id')).toBe(true)
+  })
+
+  it('is idempotent on a DB that already has the column (no-op migration)', () => {
+    const db = new Database(':memory:')
+    // Simulate a DB created AFTER #341 but BEFORE this fix — the table
+    // exists with the column, but the (broken) old schema-apply may or
+    // may not have created the index. Verify both paths converge.
+    db.exec(`
+      CREATE TABLE subagents (
+        id                TEXT    PRIMARY KEY,
+        parent_session_id TEXT,
+        parent_turn_key   TEXT,
+        agent_type        TEXT,
+        description       TEXT,
+        background        INTEGER NOT NULL,
+        started_at        INTEGER NOT NULL,
+        last_activity_at  INTEGER,
+        ended_at          INTEGER,
+        status            TEXT    NOT NULL,
+        result_summary    TEXT,
+        jsonl_agent_id    TEXT
+      );
+    `)
+    expect(() => applySubagentsSchema(db)).not.toThrow()
+
+    const indexes = db
+      .prepare("SELECT name FROM sqlite_master WHERE type = 'index' AND tbl_name = 'subagents'")
+      .all() as { name: string }[]
+    expect(indexes.map((r) => r.name)).toContain('subagents_jsonl_id')
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -75,6 +75,8 @@ export default defineConfig({
       "**/telegram-plugin/tests/subagent-tracker-hooks.test.ts",
       // subagents-bugs.test.ts uses bun:sqlite + bun:test — excluded here, run via test:bun.
       "**/telegram-plugin/registry/subagents-bugs.test.ts",
+      // subagents-schema-init-order.test.ts uses bun:sqlite + bun:test — excluded here, run via test:bun.
+      "**/telegram-plugin/tests/subagents-schema-init-order.test.ts",
     ],
     coverage: {
       provider: "v8",


### PR DESCRIPTION
## Bug

`applySubagentsSchema` had `CREATE INDEX subagents_jsonl_id ON subagents(jsonl_agent_id)` baked into the base schema SQL block. On pre-existing `subagents` tables (created before #341 added the `jsonl_agent_id` column), `CREATE TABLE IF NOT EXISTS` is a no-op — so the table still lacks the column when the `CREATE INDEX` immediately afterwards tries to reference it. SQLite throws `no such column: jsonl_agent_id` and the whole schema-apply aborts **before** the `ALTER TABLE` migration can add the column.

## Symptom

Gateways with pre-#341 DBs log on every restart:

```
turn-registry init failed (no such column: jsonl_agent_id) — turn tracking disabled
```

…even though the running source code contains the migration that would have added the column. The init order is just wrong.

## Fix

Move the `CREATE INDEX subagents_jsonl_id` statement out of `SUBAGENTS_SCHEMA_SQL` and into `applySubagentsSchema()`, executed after the `ALTER TABLE … ADD COLUMN jsonl_agent_id` migration has run. The column is now guaranteed to exist by the time the index is created, on both fresh and pre-existing tables.

## Test

Added `telegram-plugin/tests/subagents-schema-init-order.test.ts` — a regression test that:

1. Builds a pre-#341-shaped `subagents` table (no `jsonl_agent_id` column).
2. Calls `applySubagentsSchema` against it.
3. Asserts the column AND the index now exist, and no error was thrown.

The test uses `bun:sqlite` so it's bun-only. `vitest.config.ts` was updated to exclude it from vitest's run.

## Acceptance

- [ ] Restart a gateway with a pre-#341 DB and confirm the "no such column" error is gone.