### PR TITLE
fix(scaffold): scope subagent-tracker hooks to matcher='Agent'

### DIFF
--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -2104,6 +2104,7 @@ export function buildSettingsHooksBlock(p: HooksBlockParams): Record<string, unk
           ],
         },
         {
+          matcher: "Agent",
           hooks: [
             {
               type: "command",
@@ -2119,6 +2120,7 @@ export function buildSettingsHooksBlock(p: HooksBlockParams): Record<string, unk
   const switchroomPostToolUse = useSwitchroomPlugin
     ? [
         {
+          matcher: "Agent",
           hooks: [
             {
               type: "command",

--- a/tests/reconcile-hooks-drift.test.ts
+++ b/tests/reconcile-hooks-drift.test.ts
@@ -52,15 +52,30 @@ describe("buildSettingsHooksBlock", () => {
 
     expect(result.PreToolUse).toBeDefined();
     expect(Array.isArray(result.PreToolUse)).toBe(true);
-    const preHooks = result.PreToolUse as Array<{ hooks: Array<{ command: string }> }>;
+    const preHooks = result.PreToolUse as Array<{ matcher?: string; hooks: Array<{ command: string }> }>;
     const preCmds = preHooks.flatMap(e => e.hooks.map(h => h.command));
     expect(preCmds.some(c => c.includes("secret-guard-pretool.mjs"))).toBe(true);
     expect(preCmds.some(c => c.includes("subagent-tracker-pretool.mjs"))).toBe(true);
 
+    // secret-guard must run on every tool (no matcher); subagent-tracker must
+    // be scoped to the Agent tool so it doesn't fire ~120ms/turn for nothing.
+    const secretGuardEntry = preHooks.find(e =>
+      e.hooks.some(h => h.command.includes("secret-guard-pretool.mjs")),
+    );
+    expect(secretGuardEntry?.matcher).toBeUndefined();
+    const subagentPreEntry = preHooks.find(e =>
+      e.hooks.some(h => h.command.includes("subagent-tracker-pretool.mjs")),
+    );
+    expect(subagentPreEntry?.matcher).toBe("Agent");
+
     expect(result.PostToolUse).toBeDefined();
-    const postHooks = result.PostToolUse as Array<{ hooks: Array<{ command: string }> }>;
+    const postHooks = result.PostToolUse as Array<{ matcher?: string; hooks: Array<{ command: string }> }>;
     const postCmds = postHooks.flatMap(e => e.hooks.map(h => h.command));
     expect(postCmds.some(c => c.includes("subagent-tracker-posttool.mjs"))).toBe(true);
+    const subagentPostEntry = postHooks.find(e =>
+      e.hooks.some(h => h.command.includes("subagent-tracker-posttool.mjs")),
+    );
+    expect(subagentPostEntry?.matcher).toBe("Agent");
   });
 
   it("with user hooks declared merges them with switchroom-owned hooks", () => {


### PR DESCRIPTION
## Summary
- The `PreToolUse` and `PostToolUse` subagent-tracker entries in `src/agents/scaffold.ts` (`buildSettingsHooksBlock`) had no `matcher` field, so they were firing on every tool call (Read, Edit, Bash, Grep, etc.) and burning ~120ms/turn doing nothing.
- Added `matcher: "Agent"` to both entries. `secret-guard-pretool` is intentionally left without a matcher — it must run on every tool.
- Strengthened `tests/reconcile-hooks-drift.test.ts` with explicit assertions that `secret-guard-pretool` has no matcher and the two `subagent-tracker` entries are scoped to `Agent`. Acts as a regression guard so this can't silently come back.

Closes #407

## Test plan
- [x] `npx vitest run tests/reconcile-hooks-drift.test.ts` — 10/10 pass (including new matcher assertions)
- [x] `npx vitest run` (full vitest suite) — 3945 pass, 0 fail, 7 skipped
- [x] Sanity scan: no other `PreToolUse`/`PostToolUse` entries in `scaffold.ts` are missing matchers (only `secret-guard-pretool` is matcher-less, by design). `UserPromptSubmit` and `Stop` hooks don't take matchers, so the `workspace-dynamic`/`timezone`/etc. entries are correct as-is.
- [ ] (Out of scope) Pre-existing failure in `telegram-plugin/tests/subagent-tracker-hooks.test.ts` ("updates the row to completed with result_summary after pretool + posttool" expects `completed`, gets `running`). Reproduces on `origin/main` without these changes — unrelated to this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)