### PR TITLE
fix(watchdog): close trap zone for chat-cadence agents (#405)

### DIFF
--- a/bin/bridge-watchdog.sh
+++ b/bin/bridge-watchdog.sh
@@ -44,8 +44,23 @@ set -euo pipefail
 : "${UPTIME_GRACE_SECS:=90}"              # skip checks for this long after agent (re)start
 : "${DISCONNECT_GRACE_SECS:=600}"         # require disconnection to persist this long before restarting
 : "${LIVENESS_GRACE_SECS:=30}"            # liveness file mtime must be recent before we treat bridge as dead
-: "${JOURNAL_SILENCE_SECS:=600}"          # seconds of journal silence before suspecting a hang
-: "${JOURNAL_SILENCE_HARD_SECS:=600}"     # seconds the silence_since marker must predate before restarting
+# Journal-silence thresholds. Defaults raised from 600s to 4000s on
+# 2026-04-30 (issue #405). The previous 600s default opened a trap zone
+# where any agent whose latest journal entry sat between
+# JOURNAL_SILENCE_SECS (600s) and RECENT_ACTIVITY_WINDOW_SECS (3600s)
+# was eligible for restart. Normal chat-cadence agents (10–60 min between
+# user messages) land in that zone every cycle, producing ~208 false
+# restarts/24h on a typical host. With both defaults at 4000s (> the
+# 3600s recent-activity window), the trap zone closes: by the time
+# silence reaches 4000s, the latest entry is already past the
+# recent-activity gate and gets treated as idle. The hang detector is
+# effectively inert under defaults — operators who want it active must
+# opt in by lowering these values via env, and `Restart=on-failure` in
+# the unit file still catches actual crashes. See issue #405 for the
+# worked example showing the 21.5-min restart cadence the trap zone
+# produced.
+: "${JOURNAL_SILENCE_SECS:=4000}"          # seconds of journal silence before suspecting a hang
+: "${JOURNAL_SILENCE_HARD_SECS:=4000}"     # seconds the silence_since marker must predate before restarting
 # Recent-activity gate: only treat journal-silence as suspect-hang when the
 # agent had ANY log activity within this window. Distinguishes "hung mid-task"
 # (last log moments ago, then silence) from "genuinely idle" (no logs in

--- a/tests/integration/watchdog-chat-cadence-skip.test.sh
+++ b/tests/integration/watchdog-chat-cadence-skip.test.sh
@@ -1,0 +1,203 @@
+#!/usr/bin/env bash
+# Integration test: watchdog skips chat-cadence agents (issue #405).
+#
+# Verifies the bug-fix from issue #405: with the new defaults
+# (JOURNAL_SILENCE_SECS=4000, JOURNAL_SILENCE_HARD_SECS=4000,
+# RECENT_ACTIVITY_WINDOW_SECS=3600), an agent whose latest journal entry
+# is 30 minutes old (well within the recent-activity window AND well past
+# the OLD 600s silence threshold) must NOT be restarted.
+#
+# Before the fix, this exact scenario landed in the trap zone:
+#   600s (old JOURNAL_SILENCE_SECS) <= 1800s journal_age < 3600s
+#                                                 (RECENT_ACTIVITY_WINDOW_SECS)
+# and the watchdog would record a silence marker, wait 600s, and restart.
+# That produced ~208 false-positive restarts/24h on a typical host with
+# 5 chat-cadence agents.
+#
+# Setup:
+#   - Agent unit is active (mocked).
+#   - Agent has been running 4h (well past UPTIME_GRACE_SECS).
+#   - Latest journal entry is 30 min old (1800s).
+#   - No pre-existing silence marker (this is the first observation).
+#
+# Expected: with the new 4000s default JOURNAL_SILENCE_SECS, the journal
+# is "fresh enough" (1800s < 4000s) and the silence branch is never
+# entered. The watchdog does NOT call switchroom agent restart, and no
+# silence marker is created.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WATCHDOG="${SCRIPT_DIR}/../../bin/bridge-watchdog.sh"
+
+if [[ ! -f "$WATCHDOG" ]]; then
+  echo "FAIL: watchdog script not found at $WATCHDOG" >&2
+  exit 1
+fi
+
+# ─── Temp workspace ──────────────────────────────────────────────────────────
+
+TMPDIR_TEST="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR_TEST"' EXIT
+
+MOCK_BIN="${TMPDIR_TEST}/mock-bin"
+mkdir -p "$MOCK_BIN"
+
+# Restart capture file — must stay empty for this test.
+RESTART_LOG="${TMPDIR_TEST}/restart.log"
+
+# ─── Epoch arithmetic ────────────────────────────────────────────────────────
+
+NOW="$(date +%s)"
+# Agent started 4h ago — well past 90s UPTIME_GRACE_SECS.
+ACTIVE_ENTER_EPOCH=$(( NOW - 14400 ))
+ACTIVE_ENTER_TS="$(date -d "@${ACTIVE_ENTER_EPOCH}" '+%a %Y-%m-%d %H:%M:%S %Z' 2>/dev/null \
+  || date -r "$ACTIVE_ENTER_EPOCH" '+%a %Y-%m-%d %H:%M:%S %Z' 2>/dev/null \
+  || echo "Mon 2026-01-01 00:00:00 UTC")"
+
+# Latest journal entry is 30 min (1800s) old. Under the OLD defaults
+# (JOURNAL_SILENCE_SECS=600), this would land in the trap zone (>600s
+# silence AND <3600s recent-activity-window). Under the NEW defaults
+# (JOURNAL_SILENCE_SECS=4000), it's well below the threshold — the
+# silence branch never even runs.
+JOURNAL_ENTRY_EPOCH=$(( NOW - 1800 ))
+
+# ─── Mock: systemctl ─────────────────────────────────────────────────────────
+
+cat > "${MOCK_BIN}/systemctl" << MOCK_SYSTEMCTL
+#!/usr/bin/env bash
+if [[ "\$*" == *"list-units"*"--type=service"* ]]; then
+  if [[ "\$*" == *"active"* ]]; then
+    echo "switchroom-chatagent-gateway.service"
+    echo "switchroom-chatagent.service"
+  fi
+  exit 0
+fi
+if [[ "\$*" == *"show"* ]]; then
+  if [[ "\$*" == *"gateway"* ]] && [[ "\$*" == *"WorkingDirectory"* ]]; then
+    echo "${TMPDIR_TEST}/gateway-state"
+    exit 0
+  fi
+  if [[ "\$*" == *"chatagent.service"* ]] && [[ "\$*" == *"ActiveEnterTimestamp"* ]]; then
+    echo "${ACTIVE_ENTER_TS}"
+    exit 0
+  fi
+  if [[ "\$*" == *"chatagent.service"* ]] && [[ "\$*" == *"ActiveState"* ]]; then
+    echo "active"
+    exit 0
+  fi
+  exit 0
+fi
+if [[ "\$*" == *"is-active"* ]]; then
+  exit 0
+fi
+if [[ "\$*" == *"start"* ]] || [[ "\$*" == *"restart"* ]]; then
+  exit 0
+fi
+exit 0
+MOCK_SYSTEMCTL
+chmod +x "${MOCK_BIN}/systemctl"
+
+# ─── Mock: journalctl ────────────────────────────────────────────────────────
+
+cat > "${MOCK_BIN}/journalctl" << MOCK_JOURNALCTL
+#!/usr/bin/env bash
+echo "${JOURNAL_ENTRY_EPOCH}.000000 \$(hostname) switchroom-chatagent[1234]: last log line"
+exit 0
+MOCK_JOURNALCTL
+chmod +x "${MOCK_BIN}/journalctl"
+
+# ─── Mock: switchroom ────────────────────────────────────────────────────────
+
+cat > "${MOCK_BIN}/switchroom" << MOCK_SWITCHROOM
+#!/usr/bin/env bash
+echo "switchroom \$*" >> "${RESTART_LOG}"
+exit 0
+MOCK_SWITCHROOM
+chmod +x "${MOCK_BIN}/switchroom"
+
+# ─── Mock: ss ───────────────────────────────────────────────────────────────
+
+cat > "${MOCK_BIN}/ss" << MOCK_SS
+#!/usr/bin/env bash
+exit 0
+MOCK_SS
+chmod +x "${MOCK_BIN}/ss"
+
+# ─── Mock: logger ────────────────────────────────────────────────────────────
+
+cat > "${MOCK_BIN}/logger" << MOCK_LOGGER
+#!/usr/bin/env bash
+exit 0
+MOCK_LOGGER
+chmod +x "${MOCK_BIN}/logger"
+
+# ─── Gateway state dir ───────────────────────────────────────────────────────
+
+GATEWAY_STATE="${TMPDIR_TEST}/gateway-state"
+mkdir -p "$GATEWAY_STATE"
+touch "${GATEWAY_STATE}/gateway.log"
+DISC_MARKER="${GATEWAY_STATE}/.watchdog-disconnect-since"
+echo "$(( NOW - 5 ))" > "$DISC_MARKER"
+touch "${GATEWAY_STATE}/.bridge-alive"
+
+# ─── Watchdog state dir (clean — no pre-seeded silence marker) ───────────────
+
+WATCHDOG_STATE_DIR="${TMPDIR_TEST}/watchdog-state"
+mkdir -p "$WATCHDOG_STATE_DIR"
+
+# ─── Run the watchdog with PRODUCTION defaults ───────────────────────────────
+
+# The whole point of this test is that the DEFAULT thresholds protect
+# chat-cadence agents. So we do NOT override JOURNAL_SILENCE_SECS or
+# JOURNAL_SILENCE_HARD_SECS — we rely on the script's defaults.
+export PATH="${MOCK_BIN}:${PATH}"
+WATCHDOG_STATE_DIR="$WATCHDOG_STATE_DIR" \
+UPTIME_GRACE_SECS=90 \
+DISCONNECT_GRACE_SECS=9999 \
+LIVENESS_GRACE_SECS=60 \
+bash "$WATCHDOG" 2>/dev/null || true
+
+# ─── Assertions ──────────────────────────────────────────────────────────────
+
+PASS=0
+FAIL=0
+
+check() {
+  local desc="$1"
+  local result="$2"
+  if [[ "$result" == "true" ]]; then
+    echo "PASS: $desc"
+    PASS=$(( PASS + 1 ))
+  else
+    echo "FAIL: $desc" >&2
+    FAIL=$(( FAIL + 1 ))
+  fi
+}
+
+# Assert: switchroom agent restart was NOT called.
+if [[ ! -f "$RESTART_LOG" ]] || ! grep -q "switchroom agent restart" "$RESTART_LOG" 2>/dev/null; then
+  check "watchdog did NOT restart chat-cadence agent (30 min idle)" "true"
+else
+  check "watchdog did NOT restart chat-cadence agent (30 min idle)" "false"
+  echo "  restart.log contents:" >&2
+  cat "$RESTART_LOG" 2>/dev/null || true
+fi
+
+# Assert: no silence_since marker was created (journal was fresh enough
+# under the new default that the silence branch never fired).
+if [[ ! -f "${WATCHDOG_STATE_DIR}/chatagent.silence_since" ]]; then
+  check "no silence_since marker created (journal fresh under new default)" "true"
+else
+  check "no silence_since marker created (journal fresh under new default)" "false"
+  echo "  marker contents:" >&2
+  cat "${WATCHDOG_STATE_DIR}/chatagent.silence_since" 2>/dev/null || true
+fi
+
+echo ""
+echo "Results: ${PASS} passed, ${FAIL} failed"
+
+if [[ "$FAIL" -gt 0 ]]; then
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
Closes #405.

## Summary

`bin/bridge-watchdog.sh` had a trap zone where `JOURNAL_SILENCE_SECS` (600s default) sat below `RECENT_ACTIVITY_WINDOW_SECS` (3600s default). Any agent whose `journal_age` fell in `[600s, 3600s)` was eligible for restart: silence detected, marker written, 600s wait, restart. Normal chat-cadence agents (10–60 min between user messages) land in this zone every cycle, producing ~208 false-positive restarts/24h on a typical host.

## Fix

Raise the silence-threshold defaults above the recent-activity window so the trap zone closes:

```
JOURNAL_SILENCE_SECS:      600s -> 4000s
JOURNAL_SILENCE_HARD_SECS: 600s -> 4000s
```

By the time silence reaches 4000s, the latest journal entry is past the 3600s recent-activity gate and gets classified as idle. The hang detector becomes inert under defaults — operators who want it active must opt in via env. `Restart=on-failure` in the unit file still catches real crashes; this only disables the watchdog's speculative restart path.

This matches the "simplest correct fix" proposed in the issue.

## Test plan

- [x] New `tests/integration/watchdog-chat-cadence-skip.test.sh` — agent with last log 30 min ago, production defaults: no restart, no silence marker created. Reproduces the false-positive scenario under the OLD defaults.
- [x] Existing `tests/integration/watchdog-journal-silence.test.sh` — hang case still triggers (test sets `JOURNAL_SILENCE_SECS=10` explicitly).
- [x] Existing `tests/integration/watchdog-idle-skip.test.sh` — long-idle skip still passes.
- [x] Full vitest suite (3945 tests) green.
- [x] `tsc --noEmit` clean.

## Hotfix path

For hosts running this code today, the issue documents a systemd drop-in that sets these env vars without redeploying. After this PR ships, that drop-in becomes unnecessary.

## Follow-up

The issue notes a richer fix: invert the trigger from journal silence to a `registry.db` query (find an open `turn` with `ended_at IS NULL` older than 10 min). Positive hang signature, but depends on registry being reliably populated (#61). Deferred to a follow-up.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>