### PR TITLE
feat(progress-card): sub-agent narrative on parent card (closes #305)

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -224,6 +224,7 @@ import {
 } from '../registry/turns-schema.js'
 import { applySubagentsSchema } from '../registry/subagents-schema.js'
 import { formatIdleFooter } from '../idle-footer.js'
+import { resolveCallingSubagent } from './resolve-calling-subagent.js'
 
 // ─── Stderr logging ───────────────────────────────────────────────────────
 installPluginLogger()
@@ -1920,61 +1921,6 @@ async function executeStreamReply(args: Record<string, unknown>): Promise<unknow
     } catch { /* best-effort signal */ }
   }
   return { content: [{ type: 'text', text: `${result.status} (id: ${result.messageId ?? 'pending'})` }] }
-}
-
-/**
- * Issue #305 Option A — resolve which sub-agent (by jsonl_agent_id) is
- * calling progress_update. Three resolution strategies, in priority order:
- *   1. agentIdHint — exact match on subagents.jsonl_agent_id
- *   2. toolUseIdHint — exact match on subagents.id (parent's Agent tool_use_id)
- *   3. Heuristic: most-recently-started running sub-agent in the active turn
- *      for this chat. Logs a stderr warning when multiple candidates exist.
- *
- * Returns null if no match (caller falls through to message-send).
- * Never throws; SQL errors return null.
- */
-function resolveCallingSubagent(opts: {
-  db: ReturnType<typeof openTurnsDb> | null
-  chatId: string
-  threadId?: number | string
-  agentIdHint: string | null
-  toolUseIdHint: string | null
-}): { agentId: string } | null {
-  if (opts.db == null) return null
-  try {
-    if (opts.agentIdHint != null) {
-      const row = opts.db.prepare(
-        "SELECT jsonl_agent_id FROM subagents WHERE jsonl_agent_id = ? AND status = 'running'"
-      ).get(opts.agentIdHint) as { jsonl_agent_id: string } | undefined
-      if (row?.jsonl_agent_id) return { agentId: row.jsonl_agent_id }
-    }
-    if (opts.toolUseIdHint != null) {
-      const row = opts.db.prepare(
-        "SELECT jsonl_agent_id FROM subagents WHERE id = ? AND status = 'running'"
-      ).get(opts.toolUseIdHint) as { jsonl_agent_id: string | null } | undefined
-      if (row?.jsonl_agent_id) return { agentId: row.jsonl_agent_id }
-    }
-    // Heuristic fallback.
-    const turnRow = opts.db.prepare(
-      "SELECT turn_key FROM turns WHERE chat_id = ? AND ended_at IS NULL ORDER BY started_at DESC LIMIT 1"
-    ).get(opts.chatId) as { turn_key: string } | undefined
-    if (turnRow?.turn_key == null) return null
-    const candidates = opts.db.prepare(
-      "SELECT jsonl_agent_id FROM subagents WHERE parent_turn_key = ? AND status = 'running' AND jsonl_agent_id IS NOT NULL ORDER BY started_at DESC"
-    ).all(turnRow.turn_key) as Array<{ jsonl_agent_id: string }>
-    if (candidates.length === 0) return null
-    if (candidates.length > 1) {
-      // eslint-disable-next-line no-console
-      console.warn(
-        `progress_update: heuristic resolution selected most-recent of ${candidates.length} running sub-agents (chat=${opts.chatId}); pass agent_id explicitly to avoid mis-attribution`
-      )
-    }
-    return { agentId: candidates[0].jsonl_agent_id }
-  } catch (err) {
-    // eslint-disable-next-line no-console
-    console.warn('progress_update: resolveCallingSubagent SQL error', err)
-    return null
-  }
 }
 
 async function executeProgressUpdate(args: Record<string, unknown>): Promise<unknown> {

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -1922,6 +1922,61 @@ async function executeStreamReply(args: Record<string, unknown>): Promise<unknow
   return { content: [{ type: 'text', text: `${result.status} (id: ${result.messageId ?? 'pending'})` }] }
 }
 
+/**
+ * Issue #305 Option A — resolve which sub-agent (by jsonl_agent_id) is
+ * calling progress_update. Three resolution strategies, in priority order:
+ *   1. agentIdHint — exact match on subagents.jsonl_agent_id
+ *   2. toolUseIdHint — exact match on subagents.id (parent's Agent tool_use_id)
+ *   3. Heuristic: most-recently-started running sub-agent in the active turn
+ *      for this chat. Logs a stderr warning when multiple candidates exist.
+ *
+ * Returns null if no match (caller falls through to message-send).
+ * Never throws; SQL errors return null.
+ */
+function resolveCallingSubagent(opts: {
+  db: ReturnType<typeof openTurnsDb> | null
+  chatId: string
+  threadId?: number | string
+  agentIdHint: string | null
+  toolUseIdHint: string | null
+}): { agentId: string } | null {
+  if (opts.db == null) return null
+  try {
+    if (opts.agentIdHint != null) {
+      const row = opts.db.prepare(
+        "SELECT jsonl_agent_id FROM subagents WHERE jsonl_agent_id = ? AND status = 'running'"
+      ).get(opts.agentIdHint) as { jsonl_agent_id: string } | undefined
+      if (row?.jsonl_agent_id) return { agentId: row.jsonl_agent_id }
+    }
+    if (opts.toolUseIdHint != null) {
+      const row = opts.db.prepare(
+        "SELECT jsonl_agent_id FROM subagents WHERE id = ? AND status = 'running'"
+      ).get(opts.toolUseIdHint) as { jsonl_agent_id: string | null } | undefined
+      if (row?.jsonl_agent_id) return { agentId: row.jsonl_agent_id }
+    }
+    // Heuristic fallback.
+    const turnRow = opts.db.prepare(
+      "SELECT turn_key FROM turns WHERE chat_id = ? AND ended_at IS NULL ORDER BY started_at DESC LIMIT 1"
+    ).get(opts.chatId) as { turn_key: string } | undefined
+    if (turnRow?.turn_key == null) return null
+    const candidates = opts.db.prepare(
+      "SELECT jsonl_agent_id FROM subagents WHERE parent_turn_key = ? AND status = 'running' AND jsonl_agent_id IS NOT NULL ORDER BY started_at DESC"
+    ).all(turnRow.turn_key) as Array<{ jsonl_agent_id: string }>
+    if (candidates.length === 0) return null
+    if (candidates.length > 1) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        `progress_update: heuristic resolution selected most-recent of ${candidates.length} running sub-agents (chat=${opts.chatId}); pass agent_id explicitly to avoid mis-attribution`
+      )
+    }
+    return { agentId: candidates[0].jsonl_agent_id }
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.warn('progress_update: resolveCallingSubagent SQL error', err)
+    return null
+  }
+}
+
 async function executeProgressUpdate(args: Record<string, unknown>): Promise<unknown> {
   if (!args.chat_id) throw new Error('progress_update: chat_id is required')
   if (!args.text) throw new Error('progress_update: text is required')
@@ -1971,6 +2026,45 @@ async function executeProgressUpdate(args: Record<string, unknown>): Promise<unk
       }
     }
     progressUpdateTurnCount.set(key, currentCount + 1)
+  }
+
+  // Issue #305 Option A — try the card-injection path first.
+  // If the call originates from a sub-agent and the parent has an active
+  // pinned card, narrative lands as the sub-agent's row body. Falls through
+  // to the message-send path on miss (parent-agent calls, no active card,
+  // race with watcher backfill, etc).
+  const agentIdHint = (typeof args.agent_id === 'string' && args.agent_id) || null
+  const toolUseIdHint = (typeof args.tool_use_id === 'string' && args.tool_use_id) || null
+  const subAgent = resolveCallingSubagent({
+    db: turnsDb,
+    chatId: chat_id,
+    threadId,
+    agentIdHint,
+    toolUseIdHint,
+  })
+  if (subAgent != null && progressDriver != null) {
+    const cardText = text.length > 200 ? text.slice(0, 199) + '…' : text
+    const result = progressDriver.recordSubAgentNarrative({
+      chatId: chat_id,
+      threadId: threadId != null ? String(threadId) : undefined,
+      agentId: subAgent.agentId,
+      text: cardText,
+    })
+    if (result.ok) {
+      progressUpdateLastSent.set(key, now)
+      try {
+        signalTracker.noteSignal(key, Date.now())
+      } catch { /* best-effort signal */ }
+      return {
+        content: [
+          {
+            type: 'text',
+            text: JSON.stringify({ ok: true, mode: 'card', agent_id: subAgent.agentId }),
+          },
+        ],
+      }
+    }
+    // Otherwise fall through to message-send below.
   }
 
   // Send plain message (no quote-reply)

--- a/telegram-plugin/gateway/resolve-calling-subagent.ts
+++ b/telegram-plugin/gateway/resolve-calling-subagent.ts
@@ -1,0 +1,78 @@
+/**
+ * Issue #305 Option A — resolve which sub-agent (by jsonl_agent_id) is
+ * calling progress_update.
+ *
+ * Three resolution strategies, in priority order:
+ *   1. agentIdHint — exact match on subagents.jsonl_agent_id
+ *   2. toolUseIdHint — exact match on subagents.id (parent's Agent tool_use_id)
+ *   3. Heuristic: most-recently-started running sub-agent in the active turn
+ *      for this chat. Logs a stderr warning when multiple candidates exist.
+ *
+ * Returns null if no match (caller falls through to message-send).
+ * Never throws; SQL errors return null.
+ *
+ * Extracted from gateway.ts so the resolver can be unit-tested against an
+ * in-memory SQLite DB without spinning up the full grammY bot harness.
+ */
+
+/**
+ * Minimal duck-typed interface that matches both bun:sqlite's `Database`
+ * and the `SqliteDatabase` shape returned by `openTurnsDb`. We accept the
+ * narrowed shape so the resolver can run against any equivalent handle.
+ */
+export interface ResolverDb {
+  prepare(sql: string): {
+    get(...params: unknown[]): unknown
+    all(...params: unknown[]): unknown[]
+  }
+}
+
+export interface ResolveCallingSubagentOpts {
+  db: ResolverDb | null
+  chatId: string
+  threadId?: number | string
+  agentIdHint: string | null
+  toolUseIdHint: string | null
+}
+
+export type ResolveCallingSubagentResult = { agentId: string } | null
+
+export function resolveCallingSubagent(
+  opts: ResolveCallingSubagentOpts,
+): ResolveCallingSubagentResult {
+  if (opts.db == null) return null
+  try {
+    if (opts.agentIdHint != null) {
+      const row = opts.db.prepare(
+        "SELECT jsonl_agent_id FROM subagents WHERE jsonl_agent_id = ? AND status = 'running'",
+      ).get(opts.agentIdHint) as { jsonl_agent_id: string } | undefined
+      if (row?.jsonl_agent_id) return { agentId: row.jsonl_agent_id }
+    }
+    if (opts.toolUseIdHint != null) {
+      const row = opts.db.prepare(
+        "SELECT jsonl_agent_id FROM subagents WHERE id = ? AND status = 'running'",
+      ).get(opts.toolUseIdHint) as { jsonl_agent_id: string | null } | undefined
+      if (row?.jsonl_agent_id) return { agentId: row.jsonl_agent_id }
+    }
+    // Heuristic fallback.
+    const turnRow = opts.db.prepare(
+      "SELECT turn_key FROM turns WHERE chat_id = ? AND ended_at IS NULL ORDER BY started_at DESC LIMIT 1",
+    ).get(opts.chatId) as { turn_key: string } | undefined
+    if (turnRow?.turn_key == null) return null
+    const candidates = opts.db.prepare(
+      "SELECT jsonl_agent_id FROM subagents WHERE parent_turn_key = ? AND status = 'running' AND jsonl_agent_id IS NOT NULL ORDER BY started_at DESC",
+    ).all(turnRow.turn_key) as Array<{ jsonl_agent_id: string }>
+    if (candidates.length === 0) return null
+    if (candidates.length > 1) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        `progress_update: heuristic resolution selected most-recent of ${candidates.length} running sub-agents (chat=${opts.chatId}); pass agent_id explicitly to avoid mis-attribution`,
+      )
+    }
+    return { agentId: candidates[0].jsonl_agent_id }
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.warn('progress_update: resolveCallingSubagent SQL error', err)
+    return null
+  }
+}

--- a/telegram-plugin/progress-card-driver.ts
+++ b/telegram-plugin/progress-card-driver.ts
@@ -531,6 +531,29 @@ export interface ProgressDriver {
    */
   hasActiveCard(chatId: string, threadId?: string): boolean
   /**
+   * Issue #305 Option A — push a sub-agent narrative line into the
+   * pinned progress card's row body for `agentId` (jsonl_agent_id).
+   * Replace-on-each-call. Caller (gateway) is responsible for truncating
+   * `text` to the 200-char card cap before invocation.
+   *
+   * Returns:
+   *   - `{ ok: true }` when the narrative was applied + flush triggered.
+   *   - `{ ok: false, reason: 'no_active_card' }` if no card is tracked
+   *     for (chatId, threadId) or its turn already completionFired.
+   *   - `{ ok: false, reason: 'unknown_agent' }` if the card is active
+   *     but does not yet contain a sub-agent for `agentId` (likely a
+   *     race with sub-agent watcher's jsonl_agent_id backfill — caller
+   *     should fall through to the message-send path).
+   *
+   * Never throws.
+   */
+  recordSubAgentNarrative(args: {
+    chatId: string
+    threadId?: string
+    agentId: string
+    text: string
+  }): { ok: true } | { ok: false; reason: 'no_active_card' | 'unknown_agent' }
+  /**
    * Report a Telegram API failure back to the driver after an async emit
    * fails. The outer layer (server.ts catch handler) classifies the raw
    * error and calls this so the driver can track consecutive 4xx failures
@@ -1307,6 +1330,7 @@ export function createProgressDriver(config: ProgressDriverConfig): ProgressDriv
       if (sa.parentToolUseId !== sb.parentToolUseId) return true
       if (sa.nestedSpawnCount !== sb.nestedSpawnCount) return true
       if ((sa.currentTool?.toolUseId ?? null) !== (sb.currentTool?.toolUseId ?? null)) return true
+      if (sa.currentNarrative !== sb.currentNarrative) return true
     }
     return false
   }
@@ -1775,6 +1799,38 @@ export function createProgressDriver(config: ProgressDriverConfig): ProgressDriv
         }
       }
       return false
+    },
+
+    recordSubAgentNarrative({ chatId, threadId, agentId, text }) {
+      // Locate the active card for (chatId, threadId). Mirrors
+      // hasActiveCard's iteration since `chats` is keyed by turnKey.
+      let cs: PerChatState | null = null
+      for (const candidate of chats.values()) {
+        if (
+          candidate.chatId === chatId
+          && candidate.threadId === threadId
+          && !candidate.completionFired
+        ) {
+          cs = candidate
+          break
+        }
+      }
+      if (cs == null) {
+        return { ok: false, reason: 'no_active_card' }
+      }
+      // Sub-agents are keyed by jsonl_agent_id in the reducer state.
+      if (!cs.state.subAgents.has(agentId)) {
+        return { ok: false, reason: 'unknown_agent' }
+      }
+      // Dispatch through the same reduce path used by ingest().
+      cs.state = reduce(
+        cs.state,
+        { kind: 'sub_agent_narrative', agentId, text },
+        now(),
+      )
+      // Force re-render even though milestoneVersion didn't bump.
+      flush(cs, false)
+      return { ok: true }
     },
 
     reportApiFailure(turnKey, failure) {

--- a/telegram-plugin/progress-card.ts
+++ b/telegram-plugin/progress-card.ts
@@ -134,6 +134,15 @@ export interface SubAgentState {
    */
   readonly firstNarrativeText?: string
   /**
+   * Most-recent narrative line pushed via the gateway's `progress_update`
+   * MCP tool (issue #305 Option A). Distinct from:
+   *   - `firstNarrativeText` — one-shot, used as description fallback
+   *   - `pendingPreamble`    — one-shot pre-tool narration from session-tail
+   * `currentNarrative` is replace-on-each-call (last write wins). Cleared
+   * naturally on terminal-state render via the existing branch.
+   */
+  readonly currentNarrative?: string | null
+  /**
    * The tool most recently completed by this sub-agent. Captured on
    * `sub_agent_tool_result` (before the toolUseId match clears
    * `currentTool`). Used by the render fallback chain when the sub-agent
@@ -694,6 +703,22 @@ export function reduce(
         // chain. Once set, never overwrite — we want the sub-agent's
         // initial framing, not its latest chatter.
         firstNarrativeText: sa.firstNarrativeText ?? event.text,
+        lastEventAt: now,
+      })
+      return { ...state, subAgents: next }
+    }
+
+    case 'sub_agent_narrative': {
+      // Issue #305 Option A: most-recent-wins narrative line pushed by the
+      // sub-agent via the gateway's `progress_update` MCP tool. Replace-only
+      // (last write wins); no milestoneVersion bump (per-tick update, not a
+      // structural transition). No-op if the sub-agent isn't known yet.
+      const sa = state.subAgents.get(event.agentId)
+      if (!sa) return state
+      const next = new Map(state.subAgents)
+      next.set(event.agentId, {
+        ...sa,
+        currentNarrative: event.text,
         lastEventAt: now,
       })
       return { ...state, subAgents: next }
@@ -1497,6 +1522,10 @@ function renderSubAgentExpandable(
     if (sa.currentTool) {
       const cur = sa.currentTool
       innerLines.push(`↳ ${renderItemCore(cur.tool, cur.label, false, cur.humanAuthored)}`)
+    } else if (sa.currentNarrative && sa.currentNarrative.length > 0) {
+      // Issue #305 Option A: MCP-pushed narrative wins over pendingPreamble
+      // when both are set — it's an explicit "tell the user this now" call.
+      innerLines.push(`↳ <i>${escapeHtml(truncate(sa.currentNarrative, 200))}</i>`)
     } else if (sa.pendingPreamble && sa.pendingPreamble.length > 0) {
       const preambleLine = sa.pendingPreamble.split('\n')[0].trim()
       if (preambleLine.length > 0) {

--- a/telegram-plugin/server.ts
+++ b/telegram-plugin/server.ts
@@ -1372,7 +1372,7 @@ mcp.setRequestHandler(ListToolsRequestSchema, async () => ({
     {
       name: 'progress_update',
       description:
-        'Send a mid-turn check-in message to the user. Use this at inflection points where a colleague would naturally want to know what\'s happening: plan formed, pivot or blocker encountered, chunk of work finished. Does NOT quote-reply, does NOT affect status reactions or progress card. Rate-limited: minimum 20s between calls per chat+thread, max 5 calls per turn. Text capped at 300 chars.',
+        "Post a one-line narrative status update. When called from a sub-agent and the parent has a pinned progress card, the text lands as that sub-agent's row body in the card (no new Telegram message). Otherwise sends a standalone message in the chat (rate-limited, ≥20s between calls, max 5/turn). Use at: start of work, on blocker/pivot, on completion. Text auto-truncated (200 chars on card, 300 chars on message).",
       inputSchema: {
         type: 'object',
         properties: {
@@ -1381,6 +1381,14 @@ mcp.setRequestHandler(ListToolsRequestSchema, async () => ({
           message_thread_id: {
             type: 'string',
             description: 'Forum topic thread ID. Auto-applied from the last inbound message if not specified.',
+          },
+          agent_id: {
+            type: 'string',
+            description: 'Optional sub-agent JSONL stem; gateway resolves automatically when omitted.',
+          },
+          tool_use_id: {
+            type: 'string',
+            description: 'Optional parent Agent tool_use_id; gateway resolves automatically when omitted.',
           },
         },
         required: ['chat_id', 'text'],

--- a/telegram-plugin/session-tail.ts
+++ b/telegram-plugin/session-tail.ts
@@ -96,6 +96,7 @@ export type SessionEvent =
   | { kind: 'sub_agent_started'; agentId: string; firstPromptText: string; subagentType?: string }
   | { kind: 'sub_agent_tool_use'; agentId: string; toolUseId: string | null; toolName: string; input?: Record<string, unknown> }
   | { kind: 'sub_agent_text'; agentId: string; text: string }
+  | { kind: 'sub_agent_narrative'; agentId: string; text: string }
   | { kind: 'sub_agent_tool_result'; agentId: string; toolUseId: string; isError?: boolean; errorText?: string }
   | { kind: 'sub_agent_turn_end'; agentId: string }
   | { kind: 'sub_agent_nested_spawn'; agentId: string }

--- a/telegram-plugin/tests/progress-card-driver.test.ts
+++ b/telegram-plugin/tests/progress-card-driver.test.ts
@@ -3626,3 +3626,118 @@ describe('progress-card driver — promote-on-sub-agent', () => {
     expect(emits.filter((e) => e.isFirstEmit)).toHaveLength(1)
   })
 })
+
+describe('recordSubAgentNarrative — Issue #305 Option A', () => {
+  it('happy path: applies narrative + flushes', () => {
+    // initialDelayMs=0 so the card emits eagerly and flush() actually
+    // produces a visible emit (not deferred).
+    const { driver, emits } = harness(0, 0, { initialDelayMs: 0 })
+
+    driver.startTurn({ chatId: 'c1', userText: 'investigate' })
+    driver.ingest({ kind: 'sub_agent_started', agentId: 'A1', firstPromptText: 'P' }, 'c1')
+
+    const emitsBefore = emits.length
+    const result = driver.recordSubAgentNarrative({
+      chatId: 'c1',
+      agentId: 'A1',
+      text: 'Analyzing 12 files',
+    })
+
+    expect(result).toEqual({ ok: true })
+
+    const peeked = driver.peek('c1')
+    expect(peeked).toBeDefined()
+    const sub = peeked!.subAgents.get('A1')
+    expect(sub).toBeDefined()
+    expect(sub!.currentNarrative).toBe('Analyzing 12 files')
+
+    // Flush actually fired (visibleDiff caught the narrative change).
+    expect(emits.length).toBeGreaterThan(emitsBefore)
+  })
+
+  it('replace, not append: second narrative wins', () => {
+    const { driver } = harness(0, 0, { initialDelayMs: 0 })
+
+    driver.startTurn({ chatId: 'c1', userText: 'investigate' })
+    driver.ingest({ kind: 'sub_agent_started', agentId: 'A1', firstPromptText: 'P' }, 'c1')
+
+    driver.recordSubAgentNarrative({ chatId: 'c1', agentId: 'A1', text: 'first' })
+    driver.recordSubAgentNarrative({ chatId: 'c1', agentId: 'A1', text: 'second' })
+
+    const sub = driver.peek('c1')!.subAgents.get('A1')!
+    expect(sub.currentNarrative).toBe('second')
+  })
+
+  it('unknown agentId: returns unknown_agent and does not flush', () => {
+    const { driver, emits } = harness(0, 0, { initialDelayMs: 0 })
+
+    driver.startTurn({ chatId: 'c1', userText: 'q' })
+    // NOTE: no sub_agent_started for 'A1'.
+
+    const emitsBefore = emits.length
+    const result = driver.recordSubAgentNarrative({
+      chatId: 'c1',
+      agentId: 'A1',
+      text: 'never lands',
+    })
+
+    expect(result).toEqual({ ok: false, reason: 'unknown_agent' })
+    // No additional flush.
+    expect(emits.length).toBe(emitsBefore)
+  })
+
+  it('no active card: returns no_active_card without throwing', () => {
+    const { driver, emits } = harness(0, 0, { initialDelayMs: 0 })
+
+    // No startTurn, no enqueue — nothing is active for 'c1'.
+    const emitsBefore = emits.length
+    const result = driver.recordSubAgentNarrative({
+      chatId: 'c1',
+      agentId: 'A1',
+      text: 'orphaned',
+    })
+
+    expect(result).toEqual({ ok: false, reason: 'no_active_card' })
+    expect(emits.length).toBe(emitsBefore)
+  })
+
+  it('card already completion-fired: returns no_active_card', () => {
+    const { driver, emits, advance } = harness(0, 0, { initialDelayMs: 0 })
+
+    driver.startTurn({ chatId: 'c1', userText: 'q' })
+    // No sub-agent — so forceCompleteTurn fully completes (no defer path).
+    // The point is that after completionFired flips, the card is no longer
+    // active for narrative purposes even if peek() can still find the state.
+    driver.forceCompleteTurn({ chatId: 'c1' })
+    advance(0)
+
+    const emitsBefore = emits.length
+    const result = driver.recordSubAgentNarrative({
+      chatId: 'c1',
+      agentId: 'A1',
+      text: 'after the fact',
+    })
+
+    expect(result).toEqual({ ok: false, reason: 'no_active_card' })
+    expect(emits.length).toBe(emitsBefore)
+  })
+
+  it('visibleDiff entry: back-to-back narratives each trigger a flush', () => {
+    // Without the visibleDiff entry, only the first narrative would
+    // re-render — the second would be filtered out because no other
+    // user-visible field changed. This test guards against that.
+    const { driver, emits } = harness(0, 0, { initialDelayMs: 0 })
+
+    driver.startTurn({ chatId: 'c1', userText: 'q' })
+    driver.ingest({ kind: 'sub_agent_started', agentId: 'A1', firstPromptText: 'P' }, 'c1')
+
+    const beforeFirst = emits.length
+    driver.recordSubAgentNarrative({ chatId: 'c1', agentId: 'A1', text: 'one' })
+    const afterFirst = emits.length
+    expect(afterFirst).toBeGreaterThan(beforeFirst)
+
+    driver.recordSubAgentNarrative({ chatId: 'c1', agentId: 'A1', text: 'two' })
+    const afterSecond = emits.length
+    expect(afterSecond).toBeGreaterThan(afterFirst)
+  })
+})

--- a/telegram-plugin/tests/progress-card.test.ts
+++ b/telegram-plugin/tests/progress-card.test.ts
@@ -1004,6 +1004,89 @@ describe('progress-card reducer — multi-agent correlation', () => {
     expect(st.subAgents.has('ghost')).toBe(false)
   })
 
+  // ── Issue #305 Option A: sub_agent_narrative reducer + render ─────────────
+
+  it('sub_agent_narrative sets currentNarrative and bumps lastEventAt', () => {
+    let st = fold([
+      enqueue('go'),
+      { kind: 'tool_use', toolName: 'Agent', toolUseId: 'toolu_p1', input: { description: 'd', prompt: 'P' } },
+      { kind: 'sub_agent_started', agentId: 'X', firstPromptText: 'P' },
+    ])
+    const before = st.subAgents.get('X')!
+    const beforeMilestone = before.milestoneVersion
+    st = reduce(st, { kind: 'sub_agent_narrative', agentId: 'X', text: 'Analyzing 12 files in /src/auth' }, 7000)
+    const sa = st.subAgents.get('X')!
+    expect(sa.currentNarrative).toBe('Analyzing 12 files in /src/auth')
+    expect(sa.lastEventAt).toBe(7000)
+    // Per-tick update — milestoneVersion must NOT bump.
+    expect(sa.milestoneVersion).toBe(beforeMilestone)
+  })
+
+  it('sub_agent_narrative for an unknown agent is a no-op', () => {
+    const before = fold([enqueue('go')])
+    const after = reduce(before, { kind: 'sub_agent_narrative', agentId: 'ghost', text: 'nobody home' }, 5000)
+    // State must be untouched (same reference is fine; subAgents must not have ghost).
+    expect(after.subAgents.has('ghost')).toBe(false)
+    expect(after).toBe(before)
+  })
+
+  it('subsequent sub_agent_narrative replaces prior narrative (last write wins)', () => {
+    let st = fold([
+      enqueue('go'),
+      { kind: 'tool_use', toolName: 'Agent', toolUseId: 'toolu_p1', input: { description: 'd', prompt: 'P' } },
+      { kind: 'sub_agent_started', agentId: 'X', firstPromptText: 'P' },
+    ])
+    st = reduce(st, { kind: 'sub_agent_narrative', agentId: 'X', text: 'first line' }, 7000)
+    expect(st.subAgents.get('X')!.currentNarrative).toBe('first line')
+    st = reduce(st, { kind: 'sub_agent_narrative', agentId: 'X', text: 'second line' }, 7100)
+    expect(st.subAgents.get('X')!.currentNarrative).toBe('second line')
+  })
+
+  it('renders currentNarrative ↳ <i>...</i> above pendingPreamble in running fallback chain', () => {
+    process.env.PROGRESS_CARD_MULTI_AGENT = '1'
+    try {
+      let st = fold([
+        enqueue('go'),
+        { kind: 'tool_use', toolName: 'Agent', toolUseId: 'toolu_p1', input: { description: 'work', prompt: 'P' } },
+        { kind: 'sub_agent_started', agentId: 'X', firstPromptText: 'P' },
+        // Both pendingPreamble and currentNarrative present — narrative must win.
+        { kind: 'sub_agent_text', agentId: 'X', text: 'preamble line that should lose' },
+        { kind: 'sub_agent_narrative', agentId: 'X', text: 'Analyzing 12 files in /src/auth' },
+      ])
+      const html = render(st, 7000)
+      expect(html).toContain('↳ <i>Analyzing 12 files in /src/auth</i>')
+      // pendingPreamble must NOT appear in the inner-body fallback line —
+      // the narrative branch ran first.
+      expect(html).not.toContain('preamble line that should lose')
+    } finally {
+      delete process.env.PROGRESS_CARD_MULTI_AGENT
+    }
+  })
+
+  it('terminal-state render does not surface currentNarrative (terminal branch only renders lastCompletedTool / count)', () => {
+    process.env.PROGRESS_CARD_MULTI_AGENT = '1'
+    try {
+      let st = fold([
+        enqueue('go'),
+        { kind: 'tool_use', toolName: 'Agent', toolUseId: 'toolu_p1', input: { description: 'work', prompt: 'P' } },
+        { kind: 'sub_agent_started', agentId: 'X', firstPromptText: 'P' },
+        { kind: 'sub_agent_narrative', agentId: 'X', text: 'narrative-that-should-not-render-in-done' },
+        // Move sub-agent into terminal 'done' state via the parent tool_result path.
+        { kind: 'tool_result', toolUseId: 'toolu_p1', toolName: 'Agent', isError: false },
+      ])
+      const sa = st.subAgents.get('X')!
+      // Sanity: state must be terminal and the narrative must still be on the slot.
+      expect(sa.state).toBe('done')
+      expect(sa.currentNarrative).toBe('narrative-that-should-not-render-in-done')
+      const html = render(st, 7000)
+      // Terminal branch falls through to lastCompletedTool / "N tools completed".
+      // The narrative text must not appear in the rendered output.
+      expect(html).not.toContain('narrative-that-should-not-render-in-done')
+    } finally {
+      delete process.env.PROGRESS_CARD_MULTI_AGENT
+    }
+  })
+
   it("parent's tool_result is authoritative: overrides early sub_agent_turn_end on isError", () => {
     let st = fold([
       enqueue('go'),

--- a/telegram-plugin/tests/resolve-calling-subagent.test.ts
+++ b/telegram-plugin/tests/resolve-calling-subagent.test.ts
@@ -1,0 +1,269 @@
+/**
+ * Unit tests for resolveCallingSubagent (issue #305 Option A).
+ *
+ * The resolver picks which sub-agent's row body should host the
+ * progress_update narrative when called from a sub-agent context.
+ * Resolution priority:
+ *   1. agentIdHint  → exact match on subagents.jsonl_agent_id
+ *   2. toolUseIdHint → exact match on subagents.id
+ *   3. Heuristic   → most-recently-started running sub-agent in the active turn
+ *
+ * Tests run against an in-memory bun:sqlite DB with the same schema that
+ * production uses (turns + subagents tables). Run via:
+ *   bun test telegram-plugin/tests/resolve-calling-subagent.test.ts
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test'
+import {
+  openSubagentsDbInMemory,
+  recordSubagentStart,
+} from '../registry/subagents-schema.js'
+import { resolveCallingSubagent } from '../gateway/resolve-calling-subagent.js'
+
+type Db = ReturnType<typeof openSubagentsDbInMemory>
+
+function insertOpenTurn(db: Db, turnKey: string, chatId: string, startedAt: number): void {
+  db.prepare(`
+    INSERT INTO turns
+      (turn_key, chat_id, thread_id, started_at, last_user_msg_id, created_at, updated_at)
+    VALUES (?, ?, ?, ?, ?, ?, ?)
+  `).run(turnKey, chatId, null, startedAt, 'msg-1', startedAt, startedAt)
+}
+
+describe('resolveCallingSubagent', () => {
+  let db: Db
+
+  beforeEach(() => {
+    db = openSubagentsDbInMemory()
+  })
+
+  afterEach(() => {
+    db.close()
+  })
+
+  it('returns null when db is null', () => {
+    const result = resolveCallingSubagent({
+      db: null,
+      chatId: 'c1',
+      agentIdHint: 'jsonl-1',
+      toolUseIdHint: null,
+    })
+    expect(result).toBeNull()
+  })
+
+  it('matches by agentIdHint (jsonl_agent_id)', () => {
+    insertOpenTurn(db, 'c1:1', 'c1', 1000)
+    recordSubagentStart(db, {
+      id: 'toolu_alpha',
+      parentTurnKey: 'c1:1',
+      jsonlAgentId: 'jsonl-alpha',
+      background: false,
+      startedAt: 1100,
+    })
+    recordSubagentStart(db, {
+      id: 'toolu_beta',
+      parentTurnKey: 'c1:1',
+      jsonlAgentId: 'jsonl-beta',
+      background: false,
+      startedAt: 1200,
+    })
+
+    const result = resolveCallingSubagent({
+      db,
+      chatId: 'c1',
+      agentIdHint: 'jsonl-alpha',
+      toolUseIdHint: null,
+    })
+    expect(result).toEqual({ agentId: 'jsonl-alpha' })
+  })
+
+  it('agentIdHint miss on completed sub-agent does NOT match (only running rows)', () => {
+    insertOpenTurn(db, 'c1:1', 'c1', 1000)
+    recordSubagentStart(db, {
+      id: 'toolu_done',
+      parentTurnKey: 'c1:1',
+      jsonlAgentId: 'jsonl-done',
+      background: false,
+      startedAt: 1100,
+    })
+    // Mark as completed via direct SQL.
+    db.prepare("UPDATE subagents SET status = 'completed', ended_at = 2000 WHERE id = ?")
+      .run('toolu_done')
+
+    const result = resolveCallingSubagent({
+      db,
+      chatId: 'c1',
+      agentIdHint: 'jsonl-done',
+      toolUseIdHint: null,
+    })
+    expect(result).toBeNull()
+  })
+
+  it('matches by toolUseIdHint (subagents.id) when agentIdHint absent', () => {
+    insertOpenTurn(db, 'c1:1', 'c1', 1000)
+    recordSubagentStart(db, {
+      id: 'toolu_via_id',
+      parentTurnKey: 'c1:1',
+      jsonlAgentId: 'jsonl-via-id',
+      background: false,
+      startedAt: 1100,
+    })
+
+    const result = resolveCallingSubagent({
+      db,
+      chatId: 'c1',
+      agentIdHint: null,
+      toolUseIdHint: 'toolu_via_id',
+    })
+    expect(result).toEqual({ agentId: 'jsonl-via-id' })
+  })
+
+  it('heuristic fallback: returns most-recently-started running sub-agent in active turn', () => {
+    insertOpenTurn(db, 'c1:1', 'c1', 1000)
+    recordSubagentStart(db, {
+      id: 'toolu_old',
+      parentTurnKey: 'c1:1',
+      jsonlAgentId: 'jsonl-old',
+      background: false,
+      startedAt: 1100,
+    })
+    recordSubagentStart(db, {
+      id: 'toolu_new',
+      parentTurnKey: 'c1:1',
+      jsonlAgentId: 'jsonl-new',
+      background: false,
+      startedAt: 1500, // strictly newer
+    })
+
+    const result = resolveCallingSubagent({
+      db,
+      chatId: 'c1',
+      agentIdHint: null,
+      toolUseIdHint: null,
+    })
+    expect(result).toEqual({ agentId: 'jsonl-new' })
+  })
+
+  it('heuristic skips sub-agents without jsonl_agent_id', () => {
+    insertOpenTurn(db, 'c1:1', 'c1', 1000)
+    recordSubagentStart(db, {
+      id: 'toolu_nojson',
+      parentTurnKey: 'c1:1',
+      jsonlAgentId: null,
+      background: false,
+      startedAt: 1500,
+    })
+    recordSubagentStart(db, {
+      id: 'toolu_withjson',
+      parentTurnKey: 'c1:1',
+      jsonlAgentId: 'jsonl-resolved',
+      background: false,
+      startedAt: 1100,
+    })
+
+    const result = resolveCallingSubagent({
+      db,
+      chatId: 'c1',
+      agentIdHint: null,
+      toolUseIdHint: null,
+    })
+    expect(result).toEqual({ agentId: 'jsonl-resolved' })
+  })
+
+  it('heuristic returns null when no active turn exists', () => {
+    // Insert an ENDED turn.
+    db.prepare(`
+      INSERT INTO turns
+        (turn_key, chat_id, thread_id, started_at, ended_at, last_user_msg_id, created_at, updated_at)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+    `).run('c1:1', 'c1', null, 1000, 2000, 'msg-1', 1000, 2000)
+    recordSubagentStart(db, {
+      id: 'toolu_orphan',
+      parentTurnKey: 'c1:1',
+      jsonlAgentId: 'jsonl-orphan',
+      background: false,
+      startedAt: 1100,
+    })
+
+    const result = resolveCallingSubagent({
+      db,
+      chatId: 'c1',
+      agentIdHint: null,
+      toolUseIdHint: null,
+    })
+    expect(result).toBeNull()
+  })
+
+  it('heuristic returns null when no running sub-agents in active turn', () => {
+    insertOpenTurn(db, 'c1:1', 'c1', 1000)
+    // No sub-agents inserted.
+    const result = resolveCallingSubagent({
+      db,
+      chatId: 'c1',
+      agentIdHint: null,
+      toolUseIdHint: null,
+    })
+    expect(result).toBeNull()
+  })
+
+  it('heuristic ignores sub-agents from a different chat', () => {
+    insertOpenTurn(db, 'c1:1', 'c1', 1000)
+    insertOpenTurn(db, 'c2:1', 'c2', 1000)
+    recordSubagentStart(db, {
+      id: 'toolu_other',
+      parentTurnKey: 'c2:1',
+      jsonlAgentId: 'jsonl-other-chat',
+      background: false,
+      startedAt: 1100,
+    })
+
+    const result = resolveCallingSubagent({
+      db,
+      chatId: 'c1',
+      agentIdHint: null,
+      toolUseIdHint: null,
+    })
+    expect(result).toBeNull()
+  })
+
+  it('agentIdHint takes priority over toolUseIdHint and heuristic', () => {
+    insertOpenTurn(db, 'c1:1', 'c1', 1000)
+    recordSubagentStart(db, {
+      id: 'toolu_priority',
+      parentTurnKey: 'c1:1',
+      jsonlAgentId: 'jsonl-priority',
+      background: false,
+      startedAt: 1100,
+    })
+    recordSubagentStart(db, {
+      id: 'toolu_other',
+      parentTurnKey: 'c1:1',
+      jsonlAgentId: 'jsonl-other',
+      background: false,
+      startedAt: 1500, // newer; would win heuristic
+    })
+
+    const result = resolveCallingSubagent({
+      db,
+      chatId: 'c1',
+      agentIdHint: 'jsonl-priority',
+      toolUseIdHint: 'toolu_other',
+    })
+    expect(result).toEqual({ agentId: 'jsonl-priority' })
+  })
+
+  it('returns null on SQL error (broken db.prepare)', () => {
+    const brokenDb = {
+      prepare: (): never => {
+        throw new Error('boom')
+      },
+    }
+    const result = resolveCallingSubagent({
+      db: brokenDb as unknown as Parameters<typeof resolveCallingSubagent>[0]['db'],
+      chatId: 'c1',
+      agentIdHint: 'whatever',
+      toolUseIdHint: null,
+    })
+    expect(result).toBeNull()
+  })
+})


### PR DESCRIPTION
## Summary

Implements Option A from #305 — sub-agents that call `progress_update` now have their narrative line rendered as the sub-agent row body in the parent's pinned progress card, instead of producing a separate Telegram message. No new pins; respects the single-card design from #142.

## What changed

- **`progress-card.ts`**: new `currentNarrative` slot on `SubAgentState` + render branch (above `pendingPreamble` in the running-state fallback chain).
- **`session-tail.ts`**: new `sub_agent_narrative` event in `SessionEvent` union + reducer case.
- **`progress-card-driver.ts`**: new `recordSubAgentNarrative` method on the driver interface for direct gateway → card injection. `visibleDiff` now compares `currentNarrative` so narrative-only updates trigger re-render.
- **`gateway.ts` + `gateway/resolve-calling-subagent.ts`**: `executeProgressUpdate` now routes via `resolveCallingSubagent` (agent_id hint → tool_use_id hint → heuristic via parent_turn_key). Card injection bypasses message-send when sub-agent is identified and the parent's card is active. Resolver extracted to its own module for unit testability. All rate-limits + truncation preserved.
- **`server.ts`**: tool schema reflects card-injection semantics + new optional `agent_id` / `tool_use_id` args.

## Acceptance

- ✅ Sub-agent calls `progress_update` while parent card active → renders as `↳ <i>{text}</i>` in row body. No new message.
- ✅ Repeated calls replace, not append.
- ✅ Sub-agent completes → terminal-state branch clears narrative naturally.
- ✅ Parent agent calls → unchanged message-send behavior.
- ✅ No active card / registry race → falls through to message-send.
- ✅ Multiple parallel sub-agents without hint → most-recent wins, stderr warning.
- ✅ All new tests green: 5 reducer/render + 6 driver method + 11 resolver = 22 new cases.

Note: one pre-existing test failure on `main` (`subagent-tracker-posttool > updates the row to completed with result_summary after pretool + posttool`) is unrelated to this PR.

## Out of scope (follow-ups)

- True session-id plumbing through MCP `_meta` (#305-B).
- `phase: 'start'|'progress'|'blocker'|'done'` enum for icon styling.
- CLAUDE.md profile addendum directing sub-agents to call `progress_update`.
- Hooks-based granular per-tool tracking (#305 Option B).

Closes #305.

🤖 Generated with [Claude Code](https://claude.com/claude-code)