### PR TITLE
feat(scaffold): re-enable telegram progress guidance for sub-agents (#305 follow-up)

### DIFF
--- a/src/agents/sub-agent-telegram-prompt.test.ts
+++ b/src/agents/sub-agent-telegram-prompt.test.ts
@@ -5,8 +5,6 @@ import {
   shouldAppendTelegramProgressGuidance,
 } from './sub-agent-telegram-prompt.js'
 
-// shouldAppendTelegramProgressGuidance is kept for call-site compatibility
-// but its result is no longer acted on by applyTelegramProgressGuidance (#256).
 describe('shouldAppendTelegramProgressGuidance', () => {
   it('is true when telegram is enabled and a chat id is known', () => {
     expect(
@@ -42,7 +40,6 @@ describe('shouldAppendTelegramProgressGuidance', () => {
   })
 })
 
-// buildTelegramProgressGuidance is deprecated but kept for compatibility.
 describe('buildTelegramProgressGuidance', () => {
   it('embeds the chat id verbatim', () => {
     const out = buildTelegramProgressGuidance({ defaultChatId: '12345' })
@@ -50,23 +47,22 @@ describe('buildTelegramProgressGuidance', () => {
     expect(out).toContain('mcp__switchroom-telegram__progress_update')
   })
 
-  it('mentions the inflection points (plan, pivot, chunk done)', () => {
+  it('mentions the inflection points (start, blocker, chunk done)', () => {
     const out = buildTelegramProgressGuidance({ defaultChatId: '1' })
-    expect(out).toContain('Plan formed')
-    expect(out).toContain('Pivot or blocker')
-    expect(out).toContain('Chunk finished')
+    expect(out).toContain('Start of work')
+    expect(out).toContain('Blocker')
+    expect(out).toContain('chunk done')
   })
 
-  it('warns that intermediate tool output is not visible to the user', () => {
+  it('explains that progress_update lands on the parent card, not as a separate message', () => {
     const out = buildTelegramProgressGuidance({ defaultChatId: '1' })
-    expect(out.toLowerCase()).toContain('telegram')
-    expect(out.toLowerCase()).toContain('do not reach the user')
+    expect(out.toLowerCase()).toContain('pinned')
+    expect(out.toLowerCase()).toContain('card')
+    expect(out.toLowerCase()).toContain('does not send a separate telegram message')
   })
 })
 
 describe('applyTelegramProgressGuidance', () => {
-  // --- Core contract: body is ALWAYS returned unchanged (#256) ---
-
   it('returns the body unchanged when telegram is disabled', () => {
     const body = 'You are the worker sub-agent.'
     expect(
@@ -87,43 +83,34 @@ describe('applyTelegramProgressGuidance', () => {
     ).toBe(body)
   })
 
-  it('returns the body unchanged even when telegram + chat id are both present (#256 regression)', () => {
-    // Previously this case appended the guidance block. After #256 it must NOT.
+  it('returns the body unchanged when chat id is the empty string', () => {
+    const body = 'You are the worker sub-agent.'
+    expect(
+      applyTelegramProgressGuidance(body, {
+        telegramEnabled: true,
+        defaultChatId: '',
+      }),
+    ).toBe(body)
+  })
+
+  it('appends the guidance block when telegram is enabled and chat id is known', () => {
     const body = 'You are the worker sub-agent.'
     const out = applyTelegramProgressGuidance(body, {
       telegramEnabled: true,
       defaultChatId: '8248703757',
     })
-    expect(out).toBe(body)
+    expect(out.startsWith(body)).toBe(true)
+    expect(out.length).toBeGreaterThan(body.length)
+    expect(out).toContain('mcp__switchroom-telegram__progress_update')
+    expect(out).toContain('8248703757')
   })
 
-  it('does not append any "Telegram visibility" content regardless of args (#256 regression)', () => {
-    // Regression guard: if a future change accidentally re-enables the feature
-    // this test will catch it.
-    const body = 'You are the worker sub-agent.'
-
-    const cases = [
-      { telegramEnabled: true, defaultChatId: '8248703757' },
-      { telegramEnabled: true, defaultChatId: '1' },
-      { telegramEnabled: false, defaultChatId: '8248703757' },
-      { telegramEnabled: false, defaultChatId: undefined },
-    ] as const
-
-    for (const args of cases) {
-      const out = applyTelegramProgressGuidance(body, args)
-      expect(out).toBe(body)
-      expect(out).not.toContain('Telegram visibility')
-      expect(out).not.toContain('mcp__switchroom-telegram__progress_update')
-    }
-  })
-
-  it('does not mutate trailing whitespace in the body', () => {
-    // Ensure the function is truly a no-op — no trimming or normalisation.
+  it('preserves the original body verbatim as a prefix of the appended output', () => {
     const body = 'You are the worker.\n\n\n  '
     const out = applyTelegramProgressGuidance(body, {
       telegramEnabled: true,
       defaultChatId: '1',
     })
-    expect(out).toBe(body)
+    expect(out.slice(0, body.length)).toBe(body)
   })
 })

--- a/src/agents/sub-agent-telegram-prompt.ts
+++ b/src/agents/sub-agent-telegram-prompt.ts
@@ -1,22 +1,13 @@
 /**
- * Telegram progress-update guidance for sub-agent prompts — DISABLED (#256).
+ * Telegram progress-update guidance for sub-agent prompts.
  *
- * This module previously appended a "## Telegram visibility" block to every
- * sub-agent prompt when the parent agent ran in a Telegram-rooted session
- * (originally introduced in #32). That block instructed sub-agents to call
- * `mcp__switchroom-telegram__progress_update` so the user could see live
- * progress from parallel workers.
- *
- * Removed in #256 because:
- *  - The parent's progress card already provides equivalent visibility:
- *    sub-agent tool counts and descriptions render there automatically.
- *  - With parallel workers each posting "Got it…" and "Done with X…" the
- *    Telegram thread became noisy and ate the user's attention budget.
- *  - The JTBD (user sees worker activity) is preserved through the progress
- *    card; the spam is gone.
- *
- * The exported function signatures are kept intact so callers in scaffold.ts
- * continue to compile without changes.
+ * Originally introduced in #32; disabled in #256 because each
+ * `progress_update` call posted a fresh Telegram message and parallel
+ * sub-agents spammed the chat. Re-enabled in #305 Option A (PR #413):
+ * the gateway now routes sub-agent `progress_update` calls onto the
+ * parent's pinned progress card row body instead of sending separate
+ * messages, so the spam concern is gone and the JTBD (user sees what
+ * the sub-agent is doing) is restored without attention cost.
  *
  * Cron guidance (issue #269): scheduled tasks run as isolated `claude -p`
  * invocations with no live session. They must deliver their Telegram message
@@ -30,11 +21,8 @@
 
 /**
  * Returns true when the agent is wired up with a Telegram channel and
- * we have at least one chat to address.
- *
- * @deprecated The result of this function is no longer acted on —
- *   `applyTelegramProgressGuidance` always returns the body unchanged (#256).
- *   Kept for call-site compatibility.
+ * we have at least one chat to address. Used as the precondition for
+ * appending Telegram progress guidance to a sub-agent prompt.
  */
 export function shouldAppendTelegramProgressGuidance(args: {
   telegramEnabled: boolean
@@ -44,49 +32,46 @@ export function shouldAppendTelegramProgressGuidance(args: {
 }
 
 /**
- * Markdown block that was previously appended to a sub-agent's prompt body.
- *
- * @deprecated No longer appended to any prompt (#256). Kept for call-site
- *   compatibility.
+ * Markdown block appended to a sub-agent's prompt body when the parent
+ * runs on Telegram. The sub-agent's `progress_update` calls land on the
+ * parent's pinned progress card (PR #413, issue #305 Option A) — they
+ * do NOT send separate Telegram messages, so this is cheap and safe to
+ * call at every meaningful inflection point.
  */
 export function buildTelegramProgressGuidance(args: {
   defaultChatId: string
 }): string {
   return `
 
-## Telegram visibility (parent runs on Telegram)
+## Progress visibility on the parent's pinned card
 
-Your parent agent's user is reading this conversation on Telegram, NOT in this terminal. Your tool calls and intermediate output do not reach the user — they only see what gets posted via the parent's reply tool, or what *you* explicitly post.
+Your parent agent runs in a Telegram chat. The user reads on a phone, not in this terminal. Tool calls and intermediate output do not reach them — only what is posted to the parent's pinned progress card.
 
-When you do non-trivial work, post brief check-ins via \`mcp__switchroom-telegram__progress_update\` so the user knows you're alive:
+When you call \`mcp__switchroom-telegram__progress_update\` from inside this sub-agent, the gateway routes the text onto your row in the parent's pinned card (replace-on-write, capped at ~200 chars). It does NOT send a separate Telegram message, so call it freely at meaningful inflection points:
 
-- **Plan formed** — "Got it. Going to do X first, then Y."
-- **Pivot or blocker** — "First approach didn't work because <reason>. Trying <alternative>."
-- **Chunk finished** — "Done with X. Starting Y now."
+- **Start of work** — "Analyzing 12 files in /src/auth"
+- **Blocker / pivot** — "First approach hit X, switching to Y"
+- **Major chunk done** — "Tests green, opening PR"
 
-One sentence each. Don't narrate every tool call. Skip updates for trivial one-shot tasks.
+One short line per call. Skip for trivial one-shot tasks. Don't narrate every tool call — the parent card already shows your tool ring buffer.
 
-The default chat is **${args.defaultChatId}** (the parent agent's primary user). If the parent is handling a forum topic or a different chat in this turn, prefer that chat by passing the same \`chat_id\` (and \`message_thread_id\` if any) the parent is using — check the recent inbound message context.
+Pass \`chat_id\` = \`${args.defaultChatId}\` unless the parent is handling a different chat in this turn, in which case use whatever chat_id the parent saw on its inbound message.
 `
 }
 
 /**
- * Returns the sub-agent prompt body unchanged.
- *
- * Previously appended Telegram progress guidance when the parent ran in a
- * Telegram-rooted session. Disabled in #256: visibility is already provided
- * by the parent's progress card, and the per-worker check-in messages were
- * producing noise that hurt the user's attention budget.
- *
- * The `args` parameter is accepted but ignored so call sites in scaffold.ts
- * continue to compile without modification.
+ * Append Telegram progress guidance to the sub-agent prompt body when
+ * the parent runs in a Telegram-rooted session. Idempotent on the gate:
+ * if `telegramEnabled` is false or no `defaultChatId` is known, the body
+ * is returned unchanged.
  */
 export function applyTelegramProgressGuidance(
   body: string,
   args: { telegramEnabled: boolean; defaultChatId: string | undefined },
 ): string {
-  // Feature disabled (#256): always return body unchanged.
-  return body
+  if (!shouldAppendTelegramProgressGuidance(args)) return body
+  // shouldAppend guarantees defaultChatId is a non-empty string.
+  return body + buildTelegramProgressGuidance({ defaultChatId: args.defaultChatId as string })
 }
 
 /**


### PR DESCRIPTION
## Summary

Re-enables `applyTelegramProgressGuidance` so sub-agents actually receive the directive to call `mcp__switchroom-telegram__progress_update`. This is the prompt-side wiring for #305 Option A (PR #413 shipped the gateway routing).

## Context

- #256 disabled the function because per-worker progress_update calls posted as separate Telegram messages → parallel sub-agents spammed the chat.
- PR #413 (issue #305 Option A) changed the gateway: sub-agent `progress_update` calls now route onto the parent's pinned progress card row body, not as separate messages.
- The spam concern that motivated #256 is gone. Re-enabling is safe.

## What changed

- **`sub-agent-telegram-prompt.ts`**: `applyTelegramProgressGuidance` now appends `buildTelegramProgressGuidance(...)` when both gates (`telegramEnabled`, non-empty `defaultChatId`) pass. Guidance text rewritten to reflect card-injection semantics — narrative replaces row body, ~200-char cap, no separate messages, so sub-agents can call freely at meaningful inflection points.
- **`sub-agent-telegram-prompt.test.ts`**: rewritten for the re-enabled behavior. 11 cases covering gate logic, guidance content (chat_id verbatim, inflection-point keywords, card-injection language), and append behavior.

## Acceptance

- ✅ With `telegramEnabled: true` + valid `defaultChatId` → guidance block is appended, contains chat_id literal + `mcp__switchroom-telegram__progress_update`.
- ✅ With either gate failing → body returned unchanged.
- ✅ All 11 tests pass; existing scaffold call sites (1735, 2745) compile unchanged.
- ✅ `bun run build` clean.

## Wiring path

`scaffold.ts:1735` and `scaffold.ts:2745` already call `applyTelegramProgressGuidance` on every sub-agent prompt write. After this merges, next `switchroom agent restart all` (which runs reconcile + restart) will re-render every sub-agent's CLAUDE-md frontmatter with the directive.

To deploy:
```
bun run build
switchroom agent restart all
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)