### PR TITLE
feat(gateway): pre-allocate sendMessageDraft on inbound DM (closes #416)

### DIFF
--- a/telegram-plugin/draft-stream.ts
+++ b/telegram-plugin/draft-stream.ts
@@ -111,6 +111,17 @@ export interface DraftStreamConfig {
    * so the draft can be cleared on finalize.
    */
   chatId?: string
+  /**
+   * Optional pre-allocated draft id (issue #416). When set, the stream uses
+   * this id for its first send instead of calling `allocateDraftId()`. Used
+   * by the gateway to consume a placeholder draft created on inbound DM
+   * receipt, so the agent's first stream_reply edits the existing visual
+   * draft rather than spawning a new one.
+   *
+   * Ignored when draft transport is not active (no `sendMessageDraft`, or
+   * `previewTransport: 'message'`, or `auto` transport in a non-DM chat).
+   */
+  preAllocatedDraftId?: number
   /** Optional logger for debugging. Receives one string per event. */
   log?: (msg: string) => void
   /** Optional warning logger. Used for transport fallback notices. */
@@ -185,7 +196,13 @@ export function createDraftStream(
 
   // Use draft transport only if we have the API
   let usesDraftTransport = prefersDraft && draftApi != null
-  let draftId: number | undefined = usesDraftTransport ? allocateDraftId() : undefined
+  // Issue #416: prefer a pre-allocated draft id when provided. Skips the
+  // shared counter bump and reuses the placeholder draft the gateway already
+  // populated on inbound, so the user's input area doesn't briefly show two
+  // overlapping drafts.
+  let draftId: number | undefined = usesDraftTransport
+    ? (config.preAllocatedDraftId ?? allocateDraftId())
+    : undefined
 
   if (prefersDraft && !usesDraftTransport) {
     warn?.('draft-stream: sendMessageDraft unavailable; falling back to sendMessage/editMessageText')

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -27,6 +27,7 @@ import { StatusReactionController } from '../status-reactions.js'
 import { isTelegramReplyTool, isTelegramSurfaceTool } from '../tool-names.js'
 import { createTypingWrapper } from '../typing-wrap.js'
 import { type DraftStreamHandle } from '../draft-stream.js'
+import { allocateDraftId } from '../draft-transport.js'
 import { handlePtyPartialPure, type PtyHandlerState } from '../pty-partial-handler.js'
 import { handleStreamReply } from '../stream-reply-handler.js'
 import { createChatLock } from '../chat-lock.js'
@@ -678,6 +679,17 @@ const suppressPtyPreview = new Set<string>()
 const lastPtyPreviewByChat = new Map<string, string>()
 const progressUpdateLastSent = new Map<string, number>()
 const progressUpdateTurnCount = new Map<string, number>()
+
+// Issue #416 — pre-allocated stream_reply draft id, populated on inbound DM
+// receipt so the user sees a placeholder draft within ~1 s. Consumed by the
+// agent's first stream_reply call (which uses this draftId instead of
+// allocating a fresh one). Cleared on turn_end if the agent never called
+// stream_reply. DM-only: keyed by chatId since DMs don't have threads.
+interface PreAllocatedDraft {
+  draftId: number
+  allocatedAt: number
+}
+const preAllocatedDrafts = new Map<string, PreAllocatedDraft>()
 
 let currentSessionChatId: string | null = null
 let currentTurnStartedAt = 0

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -3530,6 +3530,33 @@ async function handleInbound(
     } catch (err) {
       process.stderr.write(`telegram gateway: progress-card startTurn failed: ${(err as Error).message}\n`)
     }
+
+    // Issue #416 — pre-allocate a sendMessageDraft for instant visual feedback
+    // in DMs. The agent's first stream_reply consumes this draft id instead
+    // of allocating a new one, so the user sees a placeholder draft within
+    // ~1 s. Only fires for fresh DM turns; if the agent finishes the turn
+    // without calling stream_reply, turn_end clears the orphan.
+    if (
+      sendMessageDraftFn != null
+      && isDmChatId(chat_id)
+      && messageThreadId == null
+      && !preAllocatedDrafts.has(chat_id)
+    ) {
+      const draftId = allocateDraftId()
+      // Best-effort, non-blocking: any failure (transport down, API not
+      // available) falls through to today's behavior.
+      void sendMessageDraftFn(chat_id, draftId, '…')
+        .then(() => {
+          preAllocatedDrafts.set(chat_id, { draftId, allocatedAt: Date.now() })
+        })
+        .catch((err) => {
+          process.stderr.write(
+            `telegram gateway: pre-allocate draft failed chatId=${chat_id}: ${
+              err instanceof Error ? err.message : String(err)
+            }\n`,
+          )
+        })
+    }
   }
 
   const imagePath = downloadImage ? await downloadImage() : undefined

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -1852,6 +1852,15 @@ async function executeStreamReply(args: Record<string, unknown>): Promise<unknow
   const streamChatId = args.chat_id as string
   const streamIsPrivate = isDmChatId(streamChatId)
   const streamIsForumTopic = args.message_thread_id != null && args.message_thread_id !== ''
+  // Issue #416: consume any pre-allocated draft for this DM. The gateway
+  // populates this map on inbound; the first stream_reply hands it off to
+  // the draft-stream so the existing placeholder is edited in place rather
+  // than a fresh draft being allocated and visibly flickering. Forum topics
+  // never have a pre-alloc entry (gateway skips them).
+  const preAllocated = streamIsPrivate ? preAllocatedDrafts.get(streamChatId) : undefined
+  if (preAllocated != null) {
+    preAllocatedDrafts.delete(streamChatId)
+  }
   const result = await handleStreamReply(
     {
       chat_id: streamChatId,
@@ -1881,6 +1890,7 @@ async function executeStreamReply(args: Record<string, unknown>): Promise<unknow
       isPrivateChat: streamIsPrivate,
       isForumTopic: streamIsForumTopic,
       ...(sendMessageDraftFn != null ? { sendMessageDraft: sendMessageDraftFn } : {}),
+      ...(preAllocated != null ? { preAllocatedDraftId: preAllocated.draftId } : {}),
       // Issue #310: deliver the outbound count bump BEFORE forceCompleteTurn
       // so the terminal render sees outboundDeliveredCount > 0. The handler
       // calls this dep in that order internally.

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -2792,6 +2792,19 @@ function handleSessionEvent(ev: SessionEvent): void {
       pendingPtyPartial = null
       closeActivityLane(chatId, threadId)
       closeProgressLane(chatId, threadId)
+      // Issue #416 — clean up an unconsumed pre-allocated draft. Telegram's
+      // current Bot API exposes no deleteMessageDraft, but sendMessageDraft
+      // with empty text effectively clears the placeholder (same trick the
+      // draft-stream uses on finalize). Best-effort: failures are silent.
+      const orphanDraft = preAllocatedDrafts.get(chatId)
+      if (orphanDraft != null) {
+        preAllocatedDrafts.delete(chatId)
+        if (sendMessageDraftFn != null) {
+          void sendMessageDraftFn(chatId, orphanDraft.draftId, '').catch(() => {
+            /* best-effort cleanup */
+          })
+        }
+      }
       // Stage 3b: stamp turn-end in the registry as endedVia='stop' (clean
       // turn_end emit). The kill paths (schedule_restart / SIGTERM) handle
       // the 'restart' / 'sigterm' cases separately in 3c.

--- a/telegram-plugin/stream-controller.ts
+++ b/telegram-plugin/stream-controller.ts
@@ -142,6 +142,12 @@ export interface StreamControllerConfig {
    * sendMessage is posted for push notification and the draft is cleared.
    */
   sendMessageDraft?: StreamDraftFn
+  /**
+   * Optional pre-allocated draft id (issue #416). Forwarded to
+   * createDraftStream so the first send reuses a placeholder draft already
+   * created by the gateway on inbound DM receipt.
+   */
+  preAllocatedDraftId?: number
 }
 
 /**
@@ -171,6 +177,7 @@ export function createStreamController(cfg: StreamControllerConfig): DraftStream
     previewTransport,
     isPrivateChat,
     sendMessageDraft,
+    preAllocatedDraftId,
   } = cfg
 
   // Base opts shared by send + edit. The initial send adds reply_parameters
@@ -219,6 +226,7 @@ export function createStreamController(cfg: StreamControllerConfig): DraftStream
       ...(previewTransport != null ? { previewTransport } : {}),
       ...(isPrivateChat != null ? { isPrivateChat } : {}),
       ...(sendMessageDraft != null ? { sendMessageDraft } : {}),
+      ...(preAllocatedDraftId != null ? { preAllocatedDraftId } : {}),
       chatId,
     },
   )

--- a/telegram-plugin/stream-reply-handler.ts
+++ b/telegram-plugin/stream-reply-handler.ts
@@ -267,6 +267,18 @@ export interface StreamReplyDeps {
    * to preserve legacy behavior.
    */
   progressCardActive?: boolean
+  /**
+   * Optional pre-allocated draft id (issue #416). When provided alongside
+   * `sendMessageDraft`, the new stream uses this id for its first send
+   * instead of allocating fresh. The gateway sets this when consuming a
+   * placeholder draft created on inbound DM receipt — the agent's first
+   * stream_reply edits the existing visual draft so the user sees a
+   * smooth update instead of a flash from one draft to another.
+   *
+   * Only consumed on the first stream_reply call for a chat+thread+lane.
+   * Subsequent calls reuse the existing stream and ignore this field.
+   */
+  preAllocatedDraftId?: number
 }
 
 export interface StreamReplyResult {
@@ -470,6 +482,7 @@ export async function handleStreamReply(
       previewTransport: resolvedTransport,
       isPrivateChat: deps.isPrivateChat === true,
       ...(deps.sendMessageDraft != null ? { sendMessageDraft: deps.sendMessageDraft } : {}),
+      ...(deps.preAllocatedDraftId != null ? { preAllocatedDraftId: deps.preAllocatedDraftId } : {}),
       onSend: (messageId, charCount) =>
         deps.logStreamingEvent({ kind: 'draft_send', chatId: chat_id, messageId, charCount }),
       onEdit: (messageId, charCount) =>

--- a/telegram-plugin/tests/draft-stream.test.ts
+++ b/telegram-plugin/tests/draft-stream.test.ts
@@ -691,4 +691,109 @@ describe('createDraftStream — draft transport', () => {
     expect(m.sendCalls.length).toBe(1) // materialized
     expect(callCount).toBeGreaterThan(1) // draft update + failed clear attempt
   })
+
+  // ─── Issue #416 — pre-allocated draft id ────────────────────────────────
+
+  it('preAllocatedDraftId: stream uses provided id instead of allocating fresh', async () => {
+    const m = makeMock()
+    const draftCalls: Array<{ chatId: string; draftId: number; text: string }> = []
+    const sendMessageDraft = vi.fn(async (chatId: string, draftId: number, text: string) => {
+      draftCalls.push({ chatId, draftId, text })
+    })
+
+    // Reset shared counter so we can detect whether allocateDraftId was called.
+    __resetDraftIdForTests()
+
+    const stream = createDraftStream(m.send, m.edit, {
+      throttleMs: 1000,
+      previewTransport: 'draft',
+      isPrivateChat: true,
+      sendMessageDraft,
+      chatId: 'chat1',
+      preAllocatedDraftId: 9999,
+    })
+
+    void stream.update('Hello from pre-alloc')
+    await microtaskFlush()
+
+    // The draft call must have used the pre-allocated id, NOT a freshly
+    // allocated counter value (which would start at 1 after reset).
+    expect(draftCalls.length).toBe(1)
+    expect(draftCalls[0].draftId).toBe(9999)
+  })
+
+  it('no preAllocatedDraftId: stream allocates a fresh draft id (existing behavior)', async () => {
+    const m = makeMock()
+    const draftCalls: Array<{ chatId: string; draftId: number; text: string }> = []
+    const sendMessageDraft = vi.fn(async (chatId: string, draftId: number, text: string) => {
+      draftCalls.push({ chatId, draftId, text })
+    })
+
+    __resetDraftIdForTests()
+
+    const stream = createDraftStream(m.send, m.edit, {
+      throttleMs: 1000,
+      previewTransport: 'draft',
+      isPrivateChat: true,
+      sendMessageDraft,
+      chatId: 'chat1',
+    })
+
+    void stream.update('Hello fresh')
+    await microtaskFlush()
+
+    expect(draftCalls.length).toBe(1)
+    // Fresh allocation starts at 1 after reset.
+    expect(draftCalls[0].draftId).toBe(1)
+  })
+
+  it('preAllocatedDraftId is ignored when draft transport is unavailable', async () => {
+    const m = makeMock()
+
+    const stream = createDraftStream(m.send, m.edit, {
+      throttleMs: 1000,
+      previewTransport: 'draft',
+      isPrivateChat: true,
+      // No sendMessageDraft — forces fallback to message transport
+      chatId: 'chat1',
+      preAllocatedDraftId: 12345,
+    })
+
+    void stream.update('Falls back')
+    await microtaskFlush()
+
+    // Without a draft API, the stream falls through to sendMessage. The
+    // pre-allocated id is irrelevant — there's nothing to consume.
+    expect(m.sendCalls.length).toBe(1)
+    expect(m.sendCalls[0].text).toBe('Falls back')
+  })
+
+  it('preAllocatedDraftId is reused across multiple updates (no fresh allocation mid-stream)', async () => {
+    const m = makeMock()
+    const draftCalls: Array<{ chatId: string; draftId: number; text: string }> = []
+    const sendMessageDraft = vi.fn(async (chatId: string, draftId: number, text: string) => {
+      draftCalls.push({ chatId, draftId, text })
+    })
+
+    __resetDraftIdForTests()
+
+    const stream = createDraftStream(m.send, m.edit, {
+      throttleMs: 1000,
+      previewTransport: 'draft',
+      isPrivateChat: true,
+      sendMessageDraft,
+      chatId: 'chat1',
+      preAllocatedDraftId: 7777,
+    })
+
+    void stream.update('First chunk')
+    await microtaskFlush()
+    vi.advanceTimersByTime(1000)
+    void stream.update('Second chunk')
+    await microtaskFlush()
+
+    expect(draftCalls.length).toBe(2)
+    expect(draftCalls[0].draftId).toBe(7777)
+    expect(draftCalls[1].draftId).toBe(7777) // same id, no reallocation
+  })
 })


### PR DESCRIPTION
## Summary

Implements #416. Gateway pre-allocates a sendMessageDraft the moment a DM inbound message is received, so the user sees a draft placeholder within ~1s. The agent's first stream_reply call consumes this pre-allocated draft instead of allocating a new one. If the turn ends without stream_reply, the orphan draft is cleared.

## What changed (6 commits)

1. \`78167a4\` add preAllocatedDrafts state map (gateway)
2. \`80956de\` pre-allocate sendMessageDraft on inbound DM (gateway)
3. \`e1e9da7\` wire preAllocatedDraftId through stream pipeline (draft-stream.ts, stream-reply-handler.ts, stream-controller.ts)
4. \`91b3314\` consume pre-allocated draft in executeStreamReply (gateway)
5. \`2271de6\` clear unconsumed pre-allocated draft on turn_end (gateway)
6. \`01d126d\` test(draft-stream): cover preAllocatedDraftId consumption — 4 new cases (uses provided id, falls back to fresh allocation, ignored when transport unavailable, reused across updates)

## Decoupling

- DMs only. Groups + forum topics: unchanged (drafts not supported in threads per #392).
- Independent of progress card lifecycle (PR #404). Card still suppressed 30s.
- Independent of #305 sub-agent narrative routing.
- Allocation failure is non-fatal — warn + falls through to today's behavior.

## Tests

- \`bun test telegram-plugin/tests/draft-stream.test.ts\` — 34 pass / 0 fail (4 new cases)
- \`bun run build\` — clean

Closes #416.

🤖 Generated with [Claude Code](https://claude.com/claude-code)