### PR TITLE
feat(issues): boot self-test surfaces auth state at agent start (#427)

### DIFF
--- a/bin/boot-self-test.sh
+++ b/bin/boot-self-test.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+# boot-self-test.sh — pre-flight an agent's auth state at boot. Phase
+# 0.3 of #424. Records issues via `switchroom issues` so a Telegram
+# user sees the moment something breaks, instead of silently watching
+# their handoff hook fail for weeks.
+#
+# Invoked by start.sh after env is set up, before `claude` launches.
+# Best-effort throughout: every check that can fail does so cleanly,
+# and the script always exits 0 — boot must not be blocked by visibility
+# tooling.
+#
+# What it checks (each maps to a stable fingerprint):
+#
+#   auth.credentials_missing  — `.credentials.json` is absent. claude
+#     code can't shell `claude -p` without it (or without a live
+#     CLAUDE_CODE_OAUTH_TOKEN env, which child processes don't get —
+#     see #424). Hooks that spawn `claude -p` will fail.
+#
+#   auth.token_expired         — `.credentials.json` parses but the
+#     accessToken's expiresAt has passed.
+#
+#   auth.refresh_token_missing — refreshToken is empty or absent.
+#     Without it, claude can't self-refresh; the agent will work today
+#     but break later. Severity warn (not error) since immediate boot
+#     still works.
+#
+#   auth.cli_unauthenticated   — `claude -p hello` actually fails
+#     with the env stripped (which is what hook context looks like).
+#     This is the empirical, definitive check: if it passes, hooks
+#     can shell out. If it fails, they can't.
+#
+# On every check passing: resolve all four fingerprints. So the issue
+# card auto-clears once the user fixes the underlying problem.
+
+set -u
+
+AGENT_NAME="${SWITCHROOM_AGENT_NAME:-}"
+STATE_DIR="${TELEGRAM_STATE_DIR:-}"
+CLAUDE_CONFIG_DIR_LOCAL="${CLAUDE_CONFIG_DIR:-}"
+
+if [ -z "$AGENT_NAME" ] || [ -z "$STATE_DIR" ] || [ -z "$CLAUDE_CONFIG_DIR_LOCAL" ]; then
+  echo "boot-self-test: missing required env (SWITCHROOM_AGENT_NAME, TELEGRAM_STATE_DIR, CLAUDE_CONFIG_DIR); skipping" >&2
+  exit 0
+fi
+
+# Locate the switchroom CLI.
+if [ -n "${SWITCHROOM_CLI_PATH:-}" ] && [ -x "$SWITCHROOM_CLI_PATH" ]; then
+  SWITCHROOM_CLI="$SWITCHROOM_CLI_PATH"
+elif command -v switchroom >/dev/null 2>&1; then
+  SWITCHROOM_CLI="$(command -v switchroom)"
+else
+  echo "boot-self-test: switchroom CLI not found; cannot record issues" >&2
+  exit 0
+fi
+
+CREDS="$CLAUDE_CONFIG_DIR_LOCAL/.credentials.json"
+
+# Fingerprints we may toggle. Listed up-front so the resolve-all path
+# at the bottom doesn't drift if we add new checks.
+ALL_CODES=(credentials_missing token_expired refresh_token_missing cli_unauthenticated)
+
+record() {
+  # record <code> <severity> <summary> [<detail>]
+  local code="$1" severity="$2" summary="$3" detail="${4:-}"
+  if [ -n "$detail" ]; then
+    printf '%s' "$detail" | "$SWITCHROOM_CLI" issues record \
+      --severity "$severity" \
+      --source "boot:auth-check" \
+      --code "$code" \
+      --summary "$summary" \
+      --detail-stdin --quiet \
+      --state-dir "$STATE_DIR" --agent "$AGENT_NAME" \
+      >/dev/null 2>&1 || true
+  else
+    "$SWITCHROOM_CLI" issues record \
+      --severity "$severity" \
+      --source "boot:auth-check" \
+      --code "$code" \
+      --summary "$summary" \
+      --quiet \
+      --state-dir "$STATE_DIR" --agent "$AGENT_NAME" \
+      >/dev/null 2>&1 || true
+  fi
+}
+
+resolve_one() {
+  "$SWITCHROOM_CLI" issues resolve \
+    --source "boot:auth-check" --code "$1" \
+    --state-dir "$STATE_DIR" \
+    >/dev/null 2>&1 || true
+}
+
+# ─── Check 1: .credentials.json present ──────────────────────────────────────
+if [ ! -f "$CREDS" ]; then
+  record credentials_missing error \
+    "$AGENT_NAME has no .credentials.json — claude -p from hooks will fail" \
+    "Path: $CREDS\nFix: run \`switchroom auth use $AGENT_NAME\` (or the heal command from #429 once it lands)."
+  # Skip subsequent token-shape checks; nothing to inspect.
+  CREDS_PRESENT=0
+else
+  resolve_one credentials_missing
+  CREDS_PRESENT=1
+fi
+
+# ─── Check 2: token not expired (only if creds present) ──────────────────────
+if [ "$CREDS_PRESENT" -eq 1 ]; then
+  # jq is preferred. If unavailable, skip these structural checks.
+  if command -v jq >/dev/null 2>&1; then
+    EXPIRES_AT=$(jq -r '.claudeAiOauth.expiresAt // empty' "$CREDS" 2>/dev/null)
+    REFRESH_TOKEN=$(jq -r '.claudeAiOauth.refreshToken // empty' "$CREDS" 2>/dev/null)
+    NOW_MS=$(($(date +%s) * 1000))
+    if [ -n "$EXPIRES_AT" ] && [ "$EXPIRES_AT" -lt "$NOW_MS" ] 2>/dev/null; then
+      DAYS=$(( (NOW_MS - EXPIRES_AT) / 86400000 ))
+      record token_expired error \
+        "$AGENT_NAME .credentials.json access token expired ${DAYS}d ago" \
+        "expiresAt: $EXPIRES_AT (unix ms)\nnow:        $NOW_MS\ndelta_days: $DAYS"
+    else
+      resolve_one token_expired
+    fi
+
+    if [ -z "$REFRESH_TOKEN" ]; then
+      record refresh_token_missing warn \
+        "$AGENT_NAME .credentials.json has no refreshToken; claude can't self-refresh" \
+        "Without a refreshToken, the access token will eventually expire and \`claude -p\` from hooks will start failing. Re-auth ($AGENT_NAME) to populate it."
+    else
+      resolve_one refresh_token_missing
+    fi
+  fi
+fi
+
+# ─── Check 3: claude -p actually works in hook-shaped env ────────────────────
+# Strip CLAUDE_CODE_OAUTH_TOKEN so this matches the env hooks see.
+# Wall-clock cap so a network hang can't block boot.
+if command -v claude >/dev/null 2>&1; then
+  CLI_OUT=$(env -u CLAUDE_CODE_OAUTH_TOKEN \
+    timeout 12 claude -p "ping" \
+      --model claude-haiku-4-5-20251001 \
+      --no-session-persistence </dev/null 2>&1)
+  CLI_STATUS=$?
+  if [ "$CLI_STATUS" -eq 124 ]; then
+    # Treat timeout as warn — slow network, not a clear-cut auth break.
+    record cli_unauthenticated warn \
+      "$AGENT_NAME boot self-test: \`claude -p\` timed out after 12s" \
+      "Network conditions or claude code subprocess startup; not necessarily an auth failure. Retry next boot."
+  elif [ "$CLI_STATUS" -ne 0 ]; then
+    # Tail the output to keep the issue detail readable.
+    DETAIL=$(printf '%s' "$CLI_OUT" | tail -n 20)
+    record cli_unauthenticated critical \
+      "$AGENT_NAME boot self-test: \`claude -p\` exited $CLI_STATUS — hooks that shell claude will fail" \
+      "$DETAIL"
+  else
+    resolve_one cli_unauthenticated
+  fi
+fi
+
+exit 0

--- a/profiles/_base/start.sh.hbs
+++ b/profiles/_base/start.sh.hbs
@@ -301,6 +301,17 @@ $APPEND_PROMPT"
 fi
 {{/unless}}
 
+# --- Boot self-test (#427) ---
+# Pre-flights .credentials.json + claude-p auth in a hook-shaped env so
+# any auth break shows up on the Telegram issues card (#428) the day
+# it starts, not three weeks later. Async + best-effort: never blocks
+# boot and never fails it.
+{{#if repoRoot}}
+if [ -x "{{repoRoot}}/bin/boot-self-test.sh" ]; then
+  ( "{{repoRoot}}/bin/boot-self-test.sh" >/dev/null 2>&1 ) &
+fi
+{{/if}}
+
 {{#if useSwitchroomPlugin}}
 if [ -n "$APPEND_PROMPT" ]; then
   exec claude $CONTINUE_FLAG --dangerously-load-development-channels server:switchroom-telegram{{#if hindsightEnabled}} --plugin-dir "{{agentDir}}/.claude/plugins/hindsight-memory"{{/if}}{{#if modelQ}} --model {{{modelQ}}}{{/if}}{{#if thinkingEffort}} --effort {{thinkingEffort}}{{/if}}{{#if permissionMode}} --permission-mode {{permissionMode}}{{/if}}{{#if fallbackModelQ}} --fallback-model {{{fallbackModelQ}}}{{/if}} --append-system-prompt "$APPEND_PROMPT"{{#if dangerousMode}} --dangerously-skip-permissions{{/if}}{{#if extraCliArgs}}{{{extraCliArgs}}}{{/if}}

--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -1148,6 +1148,7 @@ function buildWorkspaceContext(args: BuildWorkspaceContextArgs): Record<string, 
   return {
     name,
     agentDir,
+    repoRoot: REPO_ROOT,
     topicId,
     topicName: agentConfig.topic_name,
     topicEmoji: agentConfig.topic_emoji,
@@ -2451,6 +2452,7 @@ export function reconcileAgent(
     const startShContext: Record<string, unknown> = {
       name,
       agentDir,
+      repoRoot: REPO_ROOT,
       botToken: resolvedBotToken ?? rawBotToken,
       forumChatId: telegramConfig.forum_chat_id,
       dangerousMode: agentConfig.dangerous_mode === true,

--- a/tests/boot-self-test.test.ts
+++ b/tests/boot-self-test.test.ts
@@ -1,0 +1,278 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { execFileSync, spawnSync } from "node:child_process";
+import {
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+  chmodSync,
+  mkdirSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+/**
+ * Tests for bin/boot-self-test.sh.
+ *
+ * Strategy: a fake `claude` binary on PATH so the test controls the
+ * exit code of the `claude -p` step. The fake also lets us assert
+ * which env it was called with (specifically, that
+ * CLAUDE_CODE_OAUTH_TOKEN was unset — matching the hook context the
+ * self-test simulates).
+ *
+ * Tests assert on the issues.jsonl produced by the script after each
+ * scenario.
+ */
+
+const SCRIPT = resolve(__dirname, "..", "bin", "boot-self-test.sh");
+const CLI = resolve(__dirname, "..", "dist", "cli", "switchroom.js");
+
+// Resolve `bun` to its absolute path once. The tests run with a
+// minimal PATH (so the fake `claude` is discovered) and that PATH
+// doesn't necessarily contain bun's dir — the shim must resolve it
+// from the test host instead.
+const BUN: string = (() => {
+  if (process.env.BUN_PATH) return process.env.BUN_PATH;
+  try {
+    return execFileSync("which", ["bun"], { encoding: "utf-8" }).trim();
+  } catch {
+    return "bun";
+  }
+})();
+
+let stateDir: string;
+let configDir: string;
+let scratch: string;
+let cliShim: string;
+let fakeBinDir: string;
+
+function writeCreds(payload: object): void {
+  writeFileSync(join(configDir, ".credentials.json"), JSON.stringify(payload));
+}
+
+function makeFakeClaude(exitCode: number, stdout = "ok"): void {
+  const fake = join(fakeBinDir, "claude");
+  writeFileSync(
+    fake,
+    `#!/usr/bin/env bash
+# Capture env for inspection by tests.
+env > "${scratch}/claude-env.txt"
+echo "${stdout}"
+exit ${exitCode}
+`,
+  );
+  chmodSync(fake, 0o755);
+}
+
+function runSelfTest(envOverride: Record<string, string> = {}): {
+  status: number;
+  stdout: string;
+  stderr: string;
+} {
+  const env: Record<string, string> = {};
+  // Start from a minimal env so the fake `claude` is the one found.
+  for (const [k, v] of Object.entries({
+    PATH: `${fakeBinDir}:/usr/bin:/bin`,
+    HOME: process.env.HOME ?? "/tmp",
+    SWITCHROOM_AGENT_NAME: "testagent",
+    TELEGRAM_STATE_DIR: stateDir,
+    CLAUDE_CONFIG_DIR: configDir,
+    SWITCHROOM_CLI_PATH: cliShim,
+    CLAUDE_CODE_OAUTH_TOKEN: "should-be-stripped-by-script",
+    ...envOverride,
+  })) {
+    if (v !== undefined) env[k] = String(v);
+  }
+  const r = spawnSync("bash", [SCRIPT], {
+    env,
+    stdio: ["ignore", "pipe", "pipe"],
+    encoding: "utf-8",
+  });
+  return {
+    status: r.status ?? 1,
+    stdout: r.stdout ?? "",
+    stderr: r.stderr ?? "",
+  };
+}
+
+function listIssues(includeResolved = true): Array<{
+  fingerprint: string;
+  severity: string;
+  code: string;
+  summary: string;
+  detail?: string;
+  resolved_at?: number;
+}> {
+  const args = [
+    CLI,
+    "issues",
+    "list",
+    "--json",
+    "--state-dir",
+    stateDir,
+  ];
+  if (includeResolved) args.push("--include-resolved");
+  const out = execFileSync(BUN, args, { encoding: "utf-8" });
+  return JSON.parse(out);
+}
+
+beforeEach(() => {
+  stateDir = mkdtempSync(join(tmpdir(), "boot-self-state-"));
+  configDir = mkdtempSync(join(tmpdir(), "boot-self-config-"));
+  scratch = mkdtempSync(join(tmpdir(), "boot-self-scratch-"));
+  fakeBinDir = mkdtempSync(join(tmpdir(), "boot-self-bin-"));
+  mkdirSync(join(scratch, "shim"), { recursive: true });
+  cliShim = join(scratch, "shim", "switchroom-shim.sh");
+  writeFileSync(
+    cliShim,
+    `#!/usr/bin/env bash\nexec ${BUN} ${CLI} "$@"\n`,
+  );
+  chmodSync(cliShim, 0o755);
+});
+
+afterEach(() => {
+  rmSync(stateDir, { recursive: true, force: true });
+  rmSync(configDir, { recursive: true, force: true });
+  rmSync(scratch, { recursive: true, force: true });
+  rmSync(fakeBinDir, { recursive: true, force: true });
+});
+
+describe("boot-self-test.sh", () => {
+  it("records auth.credentials_missing when .credentials.json is absent", () => {
+    makeFakeClaude(0);
+    const { status } = runSelfTest();
+    expect(status).toBe(0);
+    const issues = listIssues();
+    const missing = issues.find((i) => i.code === "credentials_missing");
+    expect(missing).toBeDefined();
+    expect(missing!.severity).toBe("error");
+    expect(missing!.summary).toContain("no .credentials.json");
+  });
+
+  it("records auth.token_expired when expiresAt is in the past", () => {
+    writeCreds({
+      claudeAiOauth: {
+        accessToken: "tok",
+        refreshToken: "rt",
+        expiresAt: Date.now() - 86_400_000, // 1 day ago
+      },
+    });
+    makeFakeClaude(0);
+    runSelfTest();
+    const issues = listIssues();
+    const expired = issues.find((i) => i.code === "token_expired");
+    expect(expired).toBeDefined();
+    expect(expired!.severity).toBe("error");
+    expect(expired!.summary).toMatch(/expired \d+d ago/);
+  });
+
+  it("records auth.refresh_token_missing as warn when refreshToken is empty", () => {
+    writeCreds({
+      claudeAiOauth: {
+        accessToken: "tok",
+        refreshToken: "",
+        expiresAt: Date.now() + 3_600_000, // valid for 1h
+      },
+    });
+    makeFakeClaude(0);
+    runSelfTest();
+    const issues = listIssues();
+    const noRefresh = issues.find(
+      (i) => i.code === "refresh_token_missing",
+    );
+    expect(noRefresh).toBeDefined();
+    expect(noRefresh!.severity).toBe("warn");
+  });
+
+  it("records auth.cli_unauthenticated as critical when claude -p fails", () => {
+    writeCreds({
+      claudeAiOauth: {
+        accessToken: "tok",
+        refreshToken: "rt",
+        expiresAt: Date.now() + 3_600_000,
+      },
+    });
+    makeFakeClaude(1, "401 Unauthorized");
+    runSelfTest();
+    const issues = listIssues();
+    const cli = issues.find((i) => i.code === "cli_unauthenticated");
+    expect(cli).toBeDefined();
+    expect(cli!.severity).toBe("critical");
+    expect(cli!.detail).toContain("401");
+  });
+
+  it("strips CLAUDE_CODE_OAUTH_TOKEN before invoking claude (matches hook context)", () => {
+    writeCreds({
+      claudeAiOauth: {
+        accessToken: "tok",
+        refreshToken: "rt",
+        expiresAt: Date.now() + 3_600_000,
+      },
+    });
+    makeFakeClaude(0);
+    runSelfTest();
+    const envCapture = require("node:fs").readFileSync(
+      join(scratch, "claude-env.txt"),
+      "utf-8",
+    ) as string;
+    // The fake claude was invoked. Its env must NOT contain
+    // CLAUDE_CODE_OAUTH_TOKEN — that's the whole point of the check.
+    expect(envCapture).not.toMatch(/^CLAUDE_CODE_OAUTH_TOKEN=/m);
+  });
+
+  it("resolves prior issues when state goes healthy", { timeout: 15_000 }, () => {
+    // First run with a bad state.
+    makeFakeClaude(0);
+    runSelfTest();
+    let issues = listIssues();
+    expect(
+      issues.find((i) => i.code === "credentials_missing"),
+    ).toBeDefined();
+
+    // Now write a healthy creds file and re-run.
+    writeCreds({
+      claudeAiOauth: {
+        accessToken: "tok",
+        refreshToken: "rt",
+        expiresAt: Date.now() + 3_600_000,
+      },
+    });
+    runSelfTest();
+    issues = listIssues();
+    const missing = issues.find((i) => i.code === "credentials_missing");
+    // The issue is now resolved (stays in the file with --include-resolved
+    // until pruned).
+    expect(missing!.resolved_at).toBeDefined();
+    // The unresolved view filters it out:
+    const unresolved = listIssues(false);
+    expect(unresolved.find((i) => i.code === "credentials_missing")).toBeUndefined();
+  });
+
+  it("exits 0 on every code path (boot must not be blocked)", () => {
+    // Even with everything broken, exit should be 0.
+    makeFakeClaude(1);
+    const { status } = runSelfTest();
+    expect(status).toBe(0);
+  });
+
+  it("skips silently when required env is missing", () => {
+    makeFakeClaude(0);
+    const { status, stderr } = runSelfTest({
+      SWITCHROOM_AGENT_NAME: "",
+    });
+    expect(status).toBe(0);
+    expect(stderr).toContain("missing required env");
+  });
+
+  it("skips silently when switchroom CLI is unavailable", () => {
+    makeFakeClaude(0);
+    const { status, stderr } = runSelfTest({
+      SWITCHROOM_CLI_PATH: "",
+      // Strip /usr/local/bin too in case switchroom ended up there.
+      PATH: `${fakeBinDir}:/usr/bin:/bin`,
+    });
+    // We can't fully prevent /usr/bin/switchroom existence on the test
+    // host, but we can at least ensure we don't crash.
+    expect(status).toBe(0);
+    void stderr;
+  });
+});


### PR DESCRIPTION
Phase 0.3 of #424. **Depends on #434 + #435.**

## Summary

A short pre-flight that runs at agent start and writes findings to the issue sink so a Telegram user sees broken auth state the day it breaks, not three weeks later when something else fails.

## What it checks (each → a stable fingerprint under `source=boot:auth-check`)

| Code | Severity | Repro across fleet |
|---|---|---|
| `credentials_missing` | error | finn, gymbro (no `.credentials.json` at all) |
| `token_expired` | error | klanker (expired 9d ago), lawgpt (expired 8d ago) |
| `refresh_token_missing` | warn | klanker, lawgpt (works today, breaks later) |
| `cli_unauthenticated` | critical | klanker (`claude -p` actually returns 401) |

The last check is the empirical, definitive one: it runs `env -u CLAUDE_CODE_OAUTH_TOKEN claude -p hello` — the exact env shape every Stop hook sees. If this fails, hooks **will** fail. If it passes, hooks can shell out.

On every check passing, the corresponding fingerprint is resolved, so the issue card auto-clears once the user fixes the underlying problem (or runs the upcoming `switchroom auth heal` from #429).

## Wiring

In `profiles/_base/start.sh.hbs`, just before `exec claude`:

```bash
if [ -x "{{repoRoot}}/bin/boot-self-test.sh" ]; then
  ( "{{repoRoot}}/bin/boot-self-test.sh" >/dev/null 2>&1 ) &
fi
```

Backgrounded — the 12s `claude -p` step never delays boot. Issue card appears within ~12s of start.sh launching.

## Test plan

- [x] 9 new vitest cases in `tests/boot-self-test.test.ts`. A fake `claude` binary on PATH lets each test control the script's behaviour deterministically.
- [x] Each failure mode + the auto-resolve path covered.
- [x] Asserts that `CLAUDE_CODE_OAUTH_TOKEN` is actually stripped before claude is invoked (matches hook context).
- [x] Asserts the script always exits 0 (boot must not be blocked by visibility tooling).
- [x] `npm run lint` clean.
- [x] Full sweep across all my Phase 0 work: **197 tests pass**.

## What this gets us

Combined with #434 + #435, the moment a refreshToken goes missing or `.credentials.json` expires on any switchroom user's machine, they'll see it on Telegram instead of having to ask Claude to dig through `journalctl`. That's the point of the whole epic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)