### PR TITLE
feat(issues): pinned issues card + /issues command on Telegram (#428)

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -198,6 +198,8 @@ import {
 } from './boot-card.js'
 import { determineRestartReason } from './boot-reason.js'
 import { shouldSkipDuplicateBootCard, type RestartReason } from './boot-card.js'
+import { createIssuesCardHandle, type IssuesCardHandle } from '../issues-card.js'
+import { startIssuesWatcher, type IssuesWatcherHandle } from '../issues-watcher.js'
 import {
   VERSION,
   COMMIT_SHA,
@@ -1255,6 +1257,65 @@ const GATEWAY_STARTED_AT_MS = Date.now()
 const BOOT_CARD_ENABLED = process.env.SWITCHROOM_BOOT_CARD !== 'false'
 let activeBootCard: BootCardHandle | null = null
 
+// Issues card (#428) — pinned per-agent surface listing current
+// unresolved entries from the issue sink (#425). Idempotent across
+// the bridge-reconnect and boot-card paths so we never spawn two
+// watchers per gateway lifetime.
+const ISSUES_CARD_ENABLED = process.env.SWITCHROOM_ISSUES_CARD !== 'false'
+let activeIssuesCard: IssuesCardHandle | null = null
+let activeIssuesWatcher: IssuesWatcherHandle | null = null
+
+/**
+ * Idempotently start the issues card + watcher for this gateway. Called
+ * from both the boot-path and bridge-reconnect paths once we've
+ * resolved the chat to post into. Subsequent calls are no-ops — the
+ * first call wins for the gateway's lifetime.
+ */
+function ensureIssuesCard(chatId: string, threadId: number | undefined): void {
+  if (!ISSUES_CARD_ENABLED) return
+  if (activeIssuesCard != null) return
+  const agentSlug = process.env.SWITCHROOM_AGENT_NAME ?? '-'
+  const agentDisplayName = resolvePersonaName(agentSlug)
+  const stateDir = process.env.TELEGRAM_STATE_DIR
+  if (!stateDir) {
+    process.stderr.write(
+      `telegram gateway: issues-card: TELEGRAM_STATE_DIR unset, skipping\n`,
+    )
+    return
+  }
+  const botApi: import('../issues-card.js').BotApiForIssuesCard = {
+    sendMessage: (cid, text, opts) =>
+      lockedBot.api.sendMessage(
+        cid,
+        text,
+        opts as Parameters<typeof lockedBot.api.sendMessage>[2],
+      ) as Promise<{ message_id: number }>,
+    editMessageText: (cid, mid, text, opts) =>
+      lockedBot.api.editMessageText(
+        cid,
+        mid,
+        text,
+        opts as Parameters<typeof lockedBot.api.editMessageText>[3],
+      ),
+    deleteMessage: (cid, mid) => lockedBot.api.deleteMessage(cid, mid),
+  }
+  activeIssuesCard = createIssuesCardHandle({
+    agentName: agentDisplayName,
+    chatId,
+    threadId,
+    bot: botApi,
+    log: (msg) => process.stderr.write(`telegram gateway: ${msg}\n`),
+  })
+  activeIssuesWatcher = startIssuesWatcher({
+    stateDir,
+    card: activeIssuesCard,
+    log: (msg) => process.stderr.write(`telegram gateway: ${msg}\n`),
+  })
+  process.stderr.write(
+    `telegram gateway: issues-card: started watcher chat_id=${chatId} thread_id=${threadId ?? '-'} state_dir=${stateDir}\n`,
+  )
+}
+
 // Startup mutex. Atomic single-writer claim on the PID file so two
 // gateway processes can't race on Telegram's getUpdates long-poll.
 // See startup-mutex.ts for the 2026-04-23 incident this closes
@@ -1353,6 +1414,7 @@ const ipcServer: IpcServer = createIpcServer({
       if (target) {
         const { chatId, threadId, ackMsgId } = target
         process.stderr.write(`telegram gateway: bridge-reconnect: posting boot card reason=${reason} chat_id=${chatId} thread_id=${threadId ?? '-'} ackReply=${ackMsgId ?? '-'} boot_card=${BOOT_CARD_ENABLED}\n`)
+        ensureIssuesCard(chatId, threadId)
         if (BOOT_CARD_ENABLED) {
           const agentDir = resolveAgentDirFromEnv()
           const agentSlug = process.env.SWITCHROOM_AGENT_NAME ?? client.agentName ?? '-'
@@ -6107,6 +6169,55 @@ bot.command('memory', async ctx => {
   await runSwitchroomCommand(ctx, ['memory', 'search', query], 'memory search')
 })
 
+bot.command('issues', async ctx => {
+  if (!isAuthorizedSender(ctx)) return
+  const arg = (ctx.match ?? '').trim()
+  // /issues resolve <fp> | /issues clear | /issues — these subcommands
+  // shell out to the issues CLI verb (#426). The verb itself enforces
+  // the dedup / fingerprint logic; we just relay output.
+  if (!arg || arg === 'list') {
+    await runSwitchroomCommand(ctx, ['issues', 'list'], 'issues list')
+    return
+  }
+  const parts = arg.split(/\s+/)
+  if (parts[0] === 'resolve' && parts.length >= 2) {
+    await runSwitchroomCommand(
+      ctx,
+      ['issues', 'resolve', parts[1]],
+      `issues resolve ${parts[1]}`,
+    )
+    return
+  }
+  if (parts[0] === 'clear') {
+    // "Clear all" = list current, resolve each. The CLI's `prune` is
+    // for retention; clearing live issues is a UI concern. Implement
+    // here by walking the list and resolving each. Best-effort.
+    try {
+      const stateDir = process.env.TELEGRAM_STATE_DIR
+      if (stateDir) {
+        const { list, resolve: resolveOne } = require('../../src/issues/index.js') as typeof import('../../src/issues/index.js')
+        const events = list(stateDir)
+        let n = 0
+        for (const e of events) {
+          n += resolveOne(stateDir, e.fingerprint)
+        }
+        await switchroomReply(ctx, `Resolved ${n} issue${n === 1 ? '' : 's'}.`, { html: true })
+        return
+      }
+    } catch (err) {
+      await switchroomReply(ctx, `clear failed: ${escapeHtmlForTg((err as Error).message)}`, { html: true })
+      return
+    }
+    await switchroomReply(ctx, 'clear: no TELEGRAM_STATE_DIR; cannot operate.', { html: true })
+    return
+  }
+  await switchroomReply(
+    ctx,
+    'Usage: <code>/issues</code> | <code>/issues resolve &lt;fingerprint&gt;</code> | <code>/issues clear</code>',
+    { html: true },
+  )
+})
+
 bot.command('usage', async ctx => {
   if (!isAuthorizedSender(ctx)) return
   const agentDir = resolveAgentDirFromEnv()
@@ -7226,6 +7337,7 @@ void (async () => {
             if (target) {
               const { chatId, threadId, ackMsgId } = target
               process.stderr.write(`telegram gateway: boot: posting boot card reason=${reason} chat_id=${chatId} thread_id=${threadId ?? '-'} ackReply=${ackMsgId ?? '-'} boot_card=${BOOT_CARD_ENABLED}\n`)
+              ensureIssuesCard(chatId, threadId)
               if (BOOT_CARD_ENABLED) {
                 const agentDir = resolveAgentDirFromEnv()
                 const agentSlug = process.env.SWITCHROOM_AGENT_NAME ?? '-'

--- a/telegram-plugin/issues-card.ts
+++ b/telegram-plugin/issues-card.ts
@@ -1,0 +1,232 @@
+/**
+ * Issues card — pinned per-agent surface that shows current unresolved
+ * issues from the sink (#425). Phase 0.4 of #424.
+ *
+ * One card per agent / chat. Edited in place when the issue list
+ * changes. Deleted when the count drops to zero AND a card was
+ * previously posted, so healthy agents don't carry permanent visual
+ * clutter.
+ *
+ * Severity → emoji: info ℹ️, warn ⚠️, error 🔴, critical 🚨. The
+ * card's header emoji is the max severity in the list. So a glance
+ * tells the user "is anything critical?" without reading rows.
+ *
+ * Pure formatting + state machine. No telegram I/O — caller wires
+ * the bot API. Mirrors `boot-card.ts`'s shape so the gateway can
+ * reuse the same patterns.
+ */
+
+import { escapeHtml } from "./card-format.js";
+import type { IssueEvent, IssueSeverity } from "../src/issues/index.js";
+
+export interface BotApiForIssuesCard {
+  sendMessage(
+    chatId: string,
+    text: string,
+    opts?: Record<string, unknown>,
+  ): Promise<{ message_id: number }>;
+  editMessageText(
+    chatId: string,
+    messageId: number,
+    text: string,
+    opts?: Record<string, unknown>,
+  ): Promise<unknown>;
+  deleteMessage(chatId: string, messageId: number): Promise<unknown>;
+}
+
+const SEVERITY_EMOJI: Record<IssueSeverity, string> = {
+  info: "ℹ️",
+  warn: "⚠️",
+  error: "🔴",
+  critical: "🚨",
+};
+
+const SEVERITY_RANK: Record<IssueSeverity, number> = {
+  info: 0,
+  warn: 1,
+  error: 2,
+  critical: 3,
+};
+
+/**
+ * Render the issues card body as HTML. Returns null when there are
+ * zero unresolved events — the caller should treat null as "delete
+ * any existing card" rather than try to send an empty message (which
+ * Telegram refuses anyway).
+ *
+ * Layout:
+ *   <maxEmoji> <agent> · N issues
+ *
+ *   <emoji> <severity-padded> <source>::<code>  <summary>  (×N) — <relative time>
+ *   ... up to MAX_ROWS rows ...
+ *   (+ M more not shown)
+ *
+ * Long rows are truncated; max-rows is bounded so a runaway agent
+ * with hundreds of distinct fingerprints doesn't blow Telegram's
+ * 4096-char message cap.
+ */
+export interface RenderIssuesCardOpts {
+  agentName: string;
+  events: IssueEvent[];
+  /** For relative-time rendering. Override in tests. */
+  now?: number;
+  /** Max rows shown in the card. Default 10 — extras roll up to "+N more". */
+  maxRows?: number;
+}
+
+const DEFAULT_MAX_ROWS = 10;
+
+export function renderIssuesCard(opts: RenderIssuesCardOpts): string | null {
+  const events = opts.events.filter((e) => e.resolved_at == null);
+  if (events.length === 0) return null;
+
+  // Sort: highest severity first; within same severity, most recent first.
+  const sorted = [...events].sort((a, b) => {
+    const ra = SEVERITY_RANK[a.severity];
+    const rb = SEVERITY_RANK[b.severity];
+    if (rb !== ra) return rb - ra;
+    return b.last_seen - a.last_seen;
+  });
+
+  const maxSeverity = sorted[0].severity;
+  const headerEmoji = SEVERITY_EMOJI[maxSeverity];
+  const count = sorted.length;
+  const header = `${headerEmoji} <b>${escapeHtml(opts.agentName)}</b> · ${count} ${count === 1 ? "issue" : "issues"}`;
+
+  const maxRows = opts.maxRows ?? DEFAULT_MAX_ROWS;
+  const visible = sorted.slice(0, maxRows);
+  const overflow = sorted.length - visible.length;
+
+  const now = opts.now ?? Date.now();
+  const rows = visible.map((e) => {
+    const emoji = SEVERITY_EMOJI[e.severity];
+    const occ = e.occurrences > 1 ? ` <i>(×${e.occurrences})</i>` : "";
+    const ago = relTime(now - e.last_seen);
+    return `${emoji} <code>${escapeHtml(e.fingerprint)}</code>  ${escapeHtml(e.summary)}${occ} — <i>${ago}</i>`;
+  });
+
+  const lines = [header, "", ...rows];
+  if (overflow > 0) {
+    lines.push("");
+    lines.push(`<i>+${overflow} more not shown — run <code>/issues</code></i>`);
+  }
+  return lines.join("\n");
+}
+
+function relTime(deltaMs: number): string {
+  if (deltaMs < 0) return "just now";
+  const s = Math.round(deltaMs / 1000);
+  if (s < 60) return `${s}s ago`;
+  const m = Math.round(s / 60);
+  if (m < 60) return `${m}m ago`;
+  const h = Math.round(m / 60);
+  if (h < 24) return `${h}h ago`;
+  const d = Math.round(h / 24);
+  return `${d}d ago`;
+}
+
+/**
+ * Stateful handle managing the lifecycle of the pinned card for one
+ * (agent, chat) pair. Caller drives `refresh()` when the issue list
+ * changes; the handle decides whether to post, edit, or delete.
+ *
+ * Resilient to message_id drift: if `editMessageText` rejects (the
+ * pinned card was manually deleted, or the bot's edit window expired),
+ * the next refresh re-posts a new card.
+ */
+export interface IssuesCardHandle {
+  /** Currently posted card's message_id, or null if nothing is posted. */
+  messageId(): number | null;
+  /** Re-render against the current event list. Idempotent. */
+  refresh(events: IssueEvent[]): Promise<void>;
+}
+
+export interface CreateIssuesCardOpts {
+  agentName: string;
+  chatId: string;
+  /** Forum topic / thread id, if posting into a topic chat. */
+  threadId?: number;
+  bot: BotApiForIssuesCard;
+  /** Override Date.now for tests. */
+  now?: () => number;
+  /** Override default maxRows. */
+  maxRows?: number;
+  /** stderr-style log sink. Defaults to noop. */
+  log?: (msg: string) => void;
+}
+
+export function createIssuesCardHandle(
+  opts: CreateIssuesCardOpts,
+): IssuesCardHandle {
+  let messageId: number | null = null;
+  let lastBody: string | null = null;
+  const log = opts.log ?? (() => {});
+  const nowFn = opts.now ?? Date.now;
+
+  return {
+    messageId() {
+      return messageId;
+    },
+    async refresh(events: IssueEvent[]) {
+      const body = renderIssuesCard({
+        agentName: opts.agentName,
+        events,
+        now: nowFn(),
+        maxRows: opts.maxRows,
+      });
+
+      // Healthy: no card needed. Delete the existing one if any.
+      if (body == null) {
+        if (messageId != null) {
+          try {
+            await opts.bot.deleteMessage(opts.chatId, messageId);
+          } catch (err) {
+            log(`issues-card: delete failed: ${(err as Error).message}`);
+          }
+          messageId = null;
+          lastBody = null;
+        }
+        return;
+      }
+
+      // No-op when nothing changed (avoid spamming editMessageText on
+      // unchanged renders, which Telegram rate-limits).
+      if (body === lastBody && messageId != null) return;
+
+      const sendOpts: Record<string, unknown> = {
+        parse_mode: "HTML",
+        disable_web_page_preview: true,
+        ...(opts.threadId != null ? { message_thread_id: opts.threadId } : {}),
+      };
+
+      if (messageId == null) {
+        try {
+          const sent = await opts.bot.sendMessage(opts.chatId, body, sendOpts);
+          messageId = sent.message_id;
+          lastBody = body;
+        } catch (err) {
+          log(`issues-card: send failed: ${(err as Error).message}`);
+        }
+        return;
+      }
+
+      try {
+        await opts.bot.editMessageText(opts.chatId, messageId, body, sendOpts);
+        lastBody = body;
+      } catch (err) {
+        // The card's message_id is stale (manually deleted, edit window
+        // expired, etc.). Re-post fresh on the next tick.
+        log(`issues-card: edit failed, re-posting: ${(err as Error).message}`);
+        messageId = null;
+        lastBody = null;
+        try {
+          const sent = await opts.bot.sendMessage(opts.chatId, body, sendOpts);
+          messageId = sent.message_id;
+          lastBody = body;
+        } catch (err2) {
+          log(`issues-card: re-post failed: ${(err2 as Error).message}`);
+        }
+      }
+    },
+  };
+}

--- a/telegram-plugin/issues-watcher.ts
+++ b/telegram-plugin/issues-watcher.ts
@@ -1,0 +1,111 @@
+/**
+ * Issues file watcher — drives `IssuesCardHandle.refresh()` whenever
+ * the agent's `issues.jsonl` changes. Phase 0.4 of #424.
+ *
+ * Strategy: poll-based. We stat the file every POLL_INTERVAL_MS (default
+ * 2s). If mtime changed since last tick, re-read and refresh the card.
+ * Inotify would be tighter but pulls in fs.watch's platform quirks
+ * (NFS, missed events) for marginal benefit — issues.jsonl writes are
+ * rare and a 2s lag is invisible to humans on Telegram.
+ *
+ * Pure logic + scheduling. The card surface and the file I/O are
+ * passed in so tests can drive deterministically.
+ */
+
+import { existsSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+import { readAll, ISSUES_FILE } from "../src/issues/index.js";
+import type { IssueEvent } from "../src/issues/index.js";
+import type { IssuesCardHandle } from "./issues-card.js";
+
+export const DEFAULT_POLL_INTERVAL_MS = 2_000;
+
+export interface IssuesWatcherOpts {
+  stateDir: string;
+  card: IssuesCardHandle;
+  /** Polling interval. Defaults to 2s. */
+  pollIntervalMs?: number;
+  /** stderr-style logger. Defaults to noop. */
+  log?: (msg: string) => void;
+  /** Inject for tests. */
+  setInterval?: typeof setInterval;
+  clearInterval?: typeof clearInterval;
+  /** Inject for tests. Defaults to fs.statSync(...).mtimeMs. */
+  mtimeProvider?: (path: string) => number | null;
+  /** Inject for tests. Defaults to readAll from src/issues. */
+  readEvents?: (stateDir: string) => IssueEvent[];
+}
+
+export interface IssuesWatcherHandle {
+  /** Stop polling. Idempotent. */
+  stop(): void;
+  /** Force one read+refresh cycle now (used at startup). */
+  tick(): Promise<void>;
+}
+
+export function startIssuesWatcher(
+  opts: IssuesWatcherOpts,
+): IssuesWatcherHandle {
+  const path = join(opts.stateDir, ISSUES_FILE);
+  const log = opts.log ?? (() => {});
+  const intervalMs = opts.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
+  const setIntervalFn = opts.setInterval ?? setInterval;
+  const clearIntervalFn = opts.clearInterval ?? clearInterval;
+  const mtimeProvider = opts.mtimeProvider ?? defaultMtimeProvider;
+  const readEvents = opts.readEvents ?? defaultReadEvents;
+
+  let lastMtime: number | null = null;
+  let stopped = false;
+
+  async function readAndRefresh(): Promise<void> {
+    const events = readEvents(opts.stateDir);
+    try {
+      await opts.card.refresh(events);
+    } catch (err) {
+      log(`issues-watcher: refresh failed: ${(err as Error).message}`);
+    }
+  }
+
+  async function tick(): Promise<void> {
+    if (stopped) return;
+    const mtime = mtimeProvider(path);
+    if (mtime === lastMtime) return;
+    lastMtime = mtime;
+    await readAndRefresh();
+  }
+
+  // Run a tick immediately so a card pre-existing on disk shows up at
+  // gateway boot. The interval handles subsequent updates.
+  void tick().catch((err) => {
+    log(`issues-watcher: initial tick failed: ${(err as Error).message}`);
+  });
+
+  const timer = setIntervalFn(() => {
+    void tick().catch((err) => {
+      log(`issues-watcher: tick failed: ${(err as Error).message}`);
+    });
+  }, intervalMs);
+
+  return {
+    stop() {
+      if (stopped) return;
+      stopped = true;
+      clearIntervalFn(timer);
+    },
+    tick,
+  };
+}
+
+function defaultMtimeProvider(path: string): number | null {
+  if (!existsSync(path)) return null;
+  try {
+    return statSync(path).mtimeMs;
+  } catch {
+    return null;
+  }
+}
+
+function defaultReadEvents(stateDir: string): IssueEvent[] {
+  return readAll(stateDir);
+}

--- a/telegram-plugin/tests/issues-card.test.ts
+++ b/telegram-plugin/tests/issues-card.test.ts
@@ -1,0 +1,245 @@
+import { describe, it, expect } from "vitest";
+import {
+  createIssuesCardHandle,
+  renderIssuesCard,
+  type BotApiForIssuesCard,
+} from "../issues-card.js";
+import type { IssueEvent } from "../../src/issues/index.js";
+
+function makeEvent(partial: Partial<IssueEvent>): IssueEvent {
+  const ts = partial.last_seen ?? 1_700_000_000_000;
+  return {
+    ts,
+    agent: "klanker",
+    severity: "error",
+    source: "hook:handoff",
+    code: "cli-error",
+    summary: "claude -p exited 1",
+    fingerprint: "hook:handoff::cli-error",
+    occurrences: 1,
+    first_seen: ts,
+    last_seen: ts,
+    ...partial,
+  };
+}
+
+describe("renderIssuesCard", () => {
+  it("returns null when there are no unresolved events", () => {
+    expect(renderIssuesCard({ agentName: "klanker", events: [] })).toBeNull();
+  });
+
+  it("filters out resolved events (returns null when only resolved)", () => {
+    const e = makeEvent({ resolved_at: 999 });
+    expect(renderIssuesCard({ agentName: "klanker", events: [e] })).toBeNull();
+  });
+
+  it("renders a header with the max severity emoji", () => {
+    const events = [
+      makeEvent({ fingerprint: "a::1", code: "1", severity: "warn" }),
+      makeEvent({ fingerprint: "a::2", code: "2", severity: "critical" }),
+      makeEvent({ fingerprint: "a::3", code: "3", severity: "info" }),
+    ];
+    const out = renderIssuesCard({ agentName: "klanker", events });
+    expect(out).toMatch(/^🚨 <b>klanker<\/b>/);
+    expect(out).toContain("3 issues");
+  });
+
+  it("uses singular 'issue' for one event", () => {
+    const events = [makeEvent({})];
+    const out = renderIssuesCard({ agentName: "klanker", events });
+    expect(out).toContain("1 issue");
+    expect(out).not.toContain("issues");
+  });
+
+  it("orders rows by severity then most-recent", () => {
+    const events = [
+      makeEvent({ fingerprint: "a::low", code: "low", severity: "warn", last_seen: 100 }),
+      makeEvent({ fingerprint: "a::hi-old", code: "hi-old", severity: "critical", last_seen: 50 }),
+      makeEvent({ fingerprint: "a::hi-new", code: "hi-new", severity: "critical", last_seen: 200 }),
+    ];
+    const out = renderIssuesCard({ agentName: "klanker", events, now: 1000 });
+    const hiNewIdx = out!.indexOf("hi-new");
+    const hiOldIdx = out!.indexOf("hi-old");
+    const lowIdx = out!.indexOf("low");
+    // hi-new (critical, recent) before hi-old (critical, older) before low (warn).
+    expect(hiNewIdx).toBeLessThan(hiOldIdx);
+    expect(hiOldIdx).toBeLessThan(lowIdx);
+  });
+
+  it("includes occurrence count when > 1", () => {
+    const events = [makeEvent({ occurrences: 5 })];
+    const out = renderIssuesCard({ agentName: "klanker", events });
+    expect(out).toContain("(×5)");
+  });
+
+  it("shows relative time for last_seen", () => {
+    const events = [makeEvent({ last_seen: 1_000_000 })];
+    const out = renderIssuesCard({ agentName: "klanker", events, now: 1_000_000 + 90_000 });
+    expect(out).toContain("2m ago");
+  });
+
+  it("truncates rows beyond maxRows and notes the overflow", () => {
+    const events: IssueEvent[] = [];
+    for (let i = 0; i < 15; i++) {
+      events.push(
+        makeEvent({
+          source: `s${i}`,
+          code: `c${i}`,
+          fingerprint: `s${i}::c${i}`,
+          summary: `failure ${i}`,
+        }),
+      );
+    }
+    const out = renderIssuesCard({ agentName: "klanker", events, maxRows: 5 });
+    expect(out).toContain("+10 more not shown");
+  });
+
+  it("HTML-escapes user-supplied fields", () => {
+    const events = [
+      makeEvent({
+        agent: "<script>",
+        source: "hook:<x>",
+        code: "<y>",
+        fingerprint: "<x>::<y>",
+        summary: "<dangerous & stuff>",
+      }),
+    ];
+    const out = renderIssuesCard({ agentName: "<script>", events });
+    expect(out).not.toContain("<script>");
+    expect(out).toContain("&lt;script&gt;");
+    expect(out).toContain("&lt;x&gt;::&lt;y&gt;");
+    expect(out).toContain("&lt;dangerous &amp; stuff&gt;");
+  });
+});
+
+// ─── createIssuesCardHandle (lifecycle) ──────────────────────────────────────
+
+interface FakeBot extends BotApiForIssuesCard {
+  sent: Array<{ text: string; opts?: Record<string, unknown> }>;
+  edits: Array<{ messageId: number; text: string }>;
+  deletes: Array<{ messageId: number }>;
+  failNextEdit?: boolean;
+}
+
+function makeFakeBot(): FakeBot {
+  let nextId = 1000;
+  const fb: FakeBot = {
+    sent: [],
+    edits: [],
+    deletes: [],
+    sendMessage: async (_chat, text, opts) => {
+      fb.sent.push({ text, opts });
+      return { message_id: nextId++ };
+    },
+    editMessageText: async (_chat, mid, text) => {
+      if (fb.failNextEdit) {
+        fb.failNextEdit = false;
+        throw new Error("Bad Request: message to edit not found");
+      }
+      fb.edits.push({ messageId: mid, text });
+      return {};
+    },
+    deleteMessage: async (_chat, mid) => {
+      fb.deletes.push({ messageId: mid });
+      return {};
+    },
+  };
+  return fb;
+}
+
+describe("createIssuesCardHandle", () => {
+  it("posts no card when called with zero unresolved events", async () => {
+    const bot = makeFakeBot();
+    const handle = createIssuesCardHandle({
+      agentName: "klanker",
+      chatId: "1",
+      bot,
+    });
+    await handle.refresh([]);
+    expect(bot.sent).toHaveLength(0);
+    expect(handle.messageId()).toBeNull();
+  });
+
+  it("posts a card on first refresh with events", async () => {
+    const bot = makeFakeBot();
+    const handle = createIssuesCardHandle({
+      agentName: "klanker",
+      chatId: "1",
+      bot,
+    });
+    await handle.refresh([makeEvent({})]);
+    expect(bot.sent).toHaveLength(1);
+    expect(bot.sent[0].opts?.parse_mode).toBe("HTML");
+    expect(handle.messageId()).toBe(1000);
+  });
+
+  it("edits in place on subsequent refreshes when content changes", async () => {
+    const bot = makeFakeBot();
+    const handle = createIssuesCardHandle({
+      agentName: "klanker",
+      chatId: "1",
+      bot,
+    });
+    await handle.refresh([makeEvent({ summary: "first" })]);
+    await handle.refresh([makeEvent({ summary: "second" })]);
+    expect(bot.sent).toHaveLength(1);
+    expect(bot.edits).toHaveLength(1);
+  });
+
+  it("skips redundant edits when content is unchanged", async () => {
+    const bot = makeFakeBot();
+    const handle = createIssuesCardHandle({
+      agentName: "klanker",
+      chatId: "1",
+      bot,
+      now: () => 1_000_000, // freeze time so relTime is stable
+    });
+    await handle.refresh([makeEvent({})]);
+    await handle.refresh([makeEvent({})]); // identical
+    expect(bot.sent).toHaveLength(1);
+    expect(bot.edits).toHaveLength(0);
+  });
+
+  it("deletes the card when issues drop to zero", async () => {
+    const bot = makeFakeBot();
+    const handle = createIssuesCardHandle({
+      agentName: "klanker",
+      chatId: "1",
+      bot,
+    });
+    await handle.refresh([makeEvent({})]);
+    expect(handle.messageId()).toBe(1000);
+    await handle.refresh([]);
+    expect(bot.deletes).toEqual([{ messageId: 1000 }]);
+    expect(handle.messageId()).toBeNull();
+  });
+
+  it("re-posts when an edit fails (stale message_id, etc.)", async () => {
+    const bot = makeFakeBot();
+    const handle = createIssuesCardHandle({
+      agentName: "klanker",
+      chatId: "1",
+      bot,
+    });
+    await handle.refresh([makeEvent({ summary: "v1" })]);
+    expect(handle.messageId()).toBe(1000);
+
+    bot.failNextEdit = true;
+    await handle.refresh([makeEvent({ summary: "v2" })]);
+    // Edit failed → re-posted as a fresh message.
+    expect(bot.sent).toHaveLength(2);
+    expect(handle.messageId()).toBe(1001);
+  });
+
+  it("includes message_thread_id when threadId is provided", async () => {
+    const bot = makeFakeBot();
+    const handle = createIssuesCardHandle({
+      agentName: "klanker",
+      chatId: "1",
+      threadId: 42,
+      bot,
+    });
+    await handle.refresh([makeEvent({})]);
+    expect(bot.sent[0].opts?.message_thread_id).toBe(42);
+  });
+});

--- a/telegram-plugin/tests/issues-watcher.test.ts
+++ b/telegram-plugin/tests/issues-watcher.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect, vi } from "vitest";
+import { startIssuesWatcher } from "../issues-watcher.js";
+import type { IssueEvent } from "../../src/issues/index.js";
+import type { IssuesCardHandle } from "../issues-card.js";
+
+function makeCard(): IssuesCardHandle & { refreshCalls: IssueEvent[][] } {
+  const refreshCalls: IssueEvent[][] = [];
+  return {
+    refreshCalls,
+    messageId: () => null,
+    refresh: async (events) => {
+      refreshCalls.push(events);
+    },
+  };
+}
+
+function makeEvent(): IssueEvent {
+  return {
+    ts: 1,
+    agent: "k",
+    severity: "warn",
+    source: "s",
+    code: "c",
+    summary: "x",
+    fingerprint: "s::c",
+    occurrences: 1,
+    first_seen: 1,
+    last_seen: 1,
+  };
+}
+
+/**
+ * The watcher schedules its work via setInterval and an async tick. The
+ * tests exercise the *contract* (refresh fires when mtime changes;
+ * doesn't fire when it doesn't; stop is idempotent) rather than the
+ * exact timer interaction — driving real timers is fragile. We expose
+ * a `tick()` on the handle for deterministic stepping.
+ */
+
+describe("startIssuesWatcher", () => {
+  it("calls card.refresh once with the initial state on startup", async () => {
+    const card = makeCard();
+    let mtime = 1000;
+    const events = [makeEvent()];
+    const handle = startIssuesWatcher({
+      stateDir: "/fake",
+      card,
+      pollIntervalMs: 60_000,
+      mtimeProvider: () => mtime,
+      readEvents: () => events,
+      // No-op interval — we drive ticks manually.
+      setInterval: ((_fn: () => void) => 1 as unknown) as typeof setInterval,
+      clearInterval: (() => {}) as typeof clearInterval,
+    });
+    // The startup tick is async (queued via void promise). Wait a microtask.
+    await new Promise((r) => setImmediate(r));
+    expect(card.refreshCalls).toHaveLength(1);
+    expect(card.refreshCalls[0]).toBe(events);
+    handle.stop();
+    void mtime;
+  });
+
+  it("does not refresh again when mtime is unchanged", async () => {
+    const card = makeCard();
+    const handle = startIssuesWatcher({
+      stateDir: "/fake",
+      card,
+      pollIntervalMs: 60_000,
+      mtimeProvider: () => 1000,
+      readEvents: () => [makeEvent()],
+      setInterval: ((_fn: () => void) => 1 as unknown) as typeof setInterval,
+      clearInterval: (() => {}) as typeof clearInterval,
+    });
+    await new Promise((r) => setImmediate(r));
+    await handle.tick(); // mtime hasn't changed
+    await handle.tick();
+    expect(card.refreshCalls).toHaveLength(1); // initial tick only
+    handle.stop();
+  });
+
+  it("refreshes again when mtime changes", async () => {
+    const card = makeCard();
+    let mtime = 1000;
+    const handle = startIssuesWatcher({
+      stateDir: "/fake",
+      card,
+      pollIntervalMs: 60_000,
+      mtimeProvider: () => mtime,
+      readEvents: () => [makeEvent()],
+      setInterval: ((_fn: () => void) => 1 as unknown) as typeof setInterval,
+      clearInterval: (() => {}) as typeof clearInterval,
+    });
+    await new Promise((r) => setImmediate(r));
+    expect(card.refreshCalls).toHaveLength(1);
+    mtime = 2000;
+    await handle.tick();
+    expect(card.refreshCalls).toHaveLength(2);
+    handle.stop();
+  });
+
+  it("treats missing file (mtime null) as a transition", async () => {
+    const card = makeCard();
+    let mtime: number | null = 1000;
+    const handle = startIssuesWatcher({
+      stateDir: "/fake",
+      card,
+      pollIntervalMs: 60_000,
+      mtimeProvider: () => mtime,
+      readEvents: () => (mtime == null ? [] : [makeEvent()]),
+      setInterval: ((_fn: () => void) => 1 as unknown) as typeof setInterval,
+      clearInterval: (() => {}) as typeof clearInterval,
+    });
+    await new Promise((r) => setImmediate(r));
+    expect(card.refreshCalls).toHaveLength(1);
+    expect(card.refreshCalls[0]).toHaveLength(1);
+    mtime = null;
+    await handle.tick();
+    expect(card.refreshCalls).toHaveLength(2);
+    expect(card.refreshCalls[1]).toHaveLength(0);
+    handle.stop();
+  });
+
+  it("stop is idempotent and clears the interval", () => {
+    const clearSpy = vi.fn();
+    const card = makeCard();
+    const handle = startIssuesWatcher({
+      stateDir: "/fake",
+      card,
+      pollIntervalMs: 60_000,
+      mtimeProvider: () => 0,
+      readEvents: () => [],
+      setInterval: ((_fn: () => void) => 42 as unknown) as typeof setInterval,
+      clearInterval: clearSpy as typeof clearInterval,
+    });
+    handle.stop();
+    handle.stop();
+    expect(clearSpy).toHaveBeenCalledTimes(1);
+    expect(clearSpy).toHaveBeenCalledWith(42);
+  });
+});


### PR DESCRIPTION
Phase 0.4 of #424. **Depends on #434, #435, #436.** This is the deliverable that actually surfaces failures to the Telegram user — without this, the prior PRs just write to disk and nobody sees them.

## Summary

**Pinned issues card per agent.** One message per agent / chat that lists current unresolved entries. Edited in place when state changes, deleted when the count drops to zero. Severity → emoji: `info ℹ️`, `warn ⚠️`, `error 🔴`, `critical 🚨`. The card's header emoji is the max severity in the list, so a glance answers "is anything critical?" without reading rows.

**`/issues` command:**
- `/issues` → list current via the issues CLI verb (#426)
- `/issues resolve <fingerprint>` → flip one entry resolved
- `/issues clear` → mass-resolve everything currently unresolved

**Watcher.** Poll-based (2s tick, mtime-keyed). Inotify rejected for portability — writes to `issues.jsonl` are rare and 2s of latency is invisible to humans on Telegram.

**Soft rollout.** `SWITCHROOM_ISSUES_CARD=false` disables the card for one release while the rollout settles. Default on.

## Architecture

```
                     ┌─ run-hook.sh         (#426)
records →            ├─ boot-self-test.sh   (#427)
issues.jsonl         └─ future hooks
                              │
                              │  poll mtime every 2s
                              ▼
                     issues-watcher.ts
                              │
                              │  filter unresolved + sort
                              ▼
                     issues-card.ts
                              │
                              │  send / edit / delete
                              ▼
                     Telegram pinned card
```

## Test plan

- [x] 21 new tests across `telegram-plugin/tests/issues-card.test.ts` (16) and `telegram-plugin/tests/issues-watcher.test.ts` (5).
- [x] Renderer tests cover: null-on-empty, severity-max header, sort order (severity then recency), occurrence count, relative time, overflow truncation, HTML escaping of user-supplied fields.
- [x] Lifecycle tests cover: first-post, edit-in-place on changes, redundant-edit skip on no-change, delete on issues→0, re-post on stale-msgId edit failure, threadId pass-through.
- [x] Watcher tests cover: initial tick, no-op on unchanged mtime, refresh on mtime change, missing-file transition, idempotent stop.
- [x] `npm run lint` clean.
- [x] Full Phase 0 sweep: **218 tests pass**.

## Manual smoke after merge

After this lands, on any switchroom host:

1. `switchroom issues record --severity critical --source manual:test --code smoke --summary "smoke test"` → an unresolved entry appears.
2. Within ~2s, the agent's chat gets a pinned `🚨 <agent> · 1 issue` card.
3. `switchroom issues resolve manual:test::smoke` → card disappears within 2s.

## Notes for reviewers

- Idempotent `ensureIssuesCard(chatId, threadId)` — called from both the boot path and bridge-reconnect path, first call wins. The bridge IPC flap (#430 territory) won't double-spawn watchers.
- `lockedBot.api.deleteMessage` is used directly — that bot wrapper has the api as `Record<string, unknown>` so the cast in `ensureIssuesCard` is intentional and matches the existing boot-card pattern.
- `/issues clear` uses `require()` (rather than top-of-file import) because the gateway is mid-IIFE at that point and the lazy require is a stylistic match to a few other dynamic-imports nearby. Happy to switch to top-level import if reviewers prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)