### PR TITLE
chore(vendor): bump hindsight-memory plugin 0.3.0 → 0.4.0

### DIFF
--- a/dependencies.json
+++ b/dependencies.json
@@ -1,6 +1,6 @@
 {
   "switchroom_version": "0.4.0",
-  "tested_at": "2026-04-29T20:30:00+10:00",
+  "tested_at": "2026-04-30T19:35:00+10:00",
   "runtime": {
     "bun": "1.3.11",
     "node": "22.22.2"
@@ -11,7 +11,7 @@
   "playwright_mcp": "0.0.71",
   "hindsight": {
     "backend": null,
-    "client": null
+    "client": "0.4.0"
   },
   "vault_broker": {
     "protocol": 1

--- a/vendor/hindsight-memory/.claude-plugin/plugin.json
+++ b/vendor/hindsight-memory/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hindsight-memory",
   "description": "Automatic long-term memory for Claude Code via Hindsight. Recalls relevant memories before each prompt and retains conversation transcripts after each response.",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "author": {"name": "Hindsight Team", "url": "https://vectorize.io/hindsight"},
   "license": "MIT",
   "keywords": ["memory", "hindsight", "recall", "retain"]

--- a/vendor/hindsight-memory/CHANGELOG.md
+++ b/vendor/hindsight-memory/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+
+- `{user_id}` template variable for `retainTags` and `retainMetadata`, resolved
+  from the `HINDSIGHT_USER_ID` env var (empty string if unset). Enables
+  machine-independent per-user memory scoping without hardcoding user ids in
+  `settings.json`.
+
+### Changed
+
+- Tags that resolve to an empty namespace content (e.g. `"user:"` when
+  `HINDSIGHT_USER_ID` is unset) are now dropped from retain requests. Previously
+  such tags were sent as-is. Tags without `:` are unaffected.
+
 ## [0.1.0] - 2025-03-23
 
 ### Added

--- a/vendor/hindsight-memory/README.md
+++ b/vendor/hindsight-memory/README.md
@@ -202,9 +202,34 @@ Auto-retain runs after Claude responds. It extracts the conversation transcript 
 | `retainOverlapTurns` | — | `2` | When chunked retention fires, this many extra turns from the previous chunk are included for continuity. Total window size = `retainEveryNTurns + retainOverlapTurns`. |
 | `retainRoles` | — | `["user", "assistant"]` | Which message roles to include in the retained transcript. |
 | `retainToolCalls` | — | `true` | Whether to include tool calls (function invocations and results) in the retained transcript. Captures structured actions like file reads, searches, and code edits. |
-| `retainTags` | — | `["{session_id}"]` | Tags attached to the retained document. Supports `{session_id}` placeholder which is replaced with the current session ID at runtime. |
-| `retainMetadata` | — | `{}` | Arbitrary key-value metadata attached to the retained document. |
+| `retainTags` | — | `["{session_id}"]` | Tags attached to the retained document. Supports template placeholders: `{session_id}`, `{bank_id}`, `{timestamp}`, and `{user_id}` (resolved from `HINDSIGHT_USER_ID` env var; empty string if unset). Tags whose resolved form ends in an empty namespace part (e.g. `"user:"` when `HINDSIGHT_USER_ID` is unset) are dropped from the outgoing request. See [Template variables](#template-variables-for-retaintags-and-retainmetadata) below. |
+| `retainMetadata` | — | `{}` | Arbitrary key-value metadata attached to the retained document. Same template placeholders as `retainTags`. |
 | `retainContext` | — | `"claude-code"` | A label attached to retained memories identifying their source. Useful when multiple integrations write to the same bank. |
+
+#### Template variables for `retainTags` and `retainMetadata`
+
+| Variable | Source |
+|----------|--------|
+| `{session_id}` | Current Claude Code session ID |
+| `{bank_id}` | Resolved bank ID (per `bankGranularity`) |
+| `{timestamp}` | ISO 8601 UTC at retain time |
+| `{user_id}` | Value of `HINDSIGHT_USER_ID` env var (empty string if unset) |
+
+##### Example: per-user memory scoping
+
+```json
+{
+  "retainTags": ["user:{user_id}", "session:{session_id}"]
+}
+```
+
+Set `HINDSIGHT_USER_ID=<opaque-user-id>` in your shell profile (`.zshrc`,
+`.bashrc`, etc.). If the env var is unset, the `user:` tag is dropped from the
+outgoing retain request and the rest of the tags are sent as-is — so the same
+`settings.json` works across machines whether you've set the env var or not.
+
+Downstream, `recall` can filter by `tags=["user:alice"]` to isolate memories
+authored by a specific user from a shared bank.
 
 ---
 

--- a/vendor/hindsight-memory/scripts/lib/bank.py
+++ b/vendor/hindsight-memory/scripts/lib/bank.py
@@ -19,7 +19,6 @@ their environment to achieve equivalent behavior.
 
 import os
 import sys
-import urllib.parse
 
 from .state import read_state, write_state
 
@@ -80,7 +79,8 @@ def derive_bank_id(hook_input: dict, config: dict) -> str:
         "user": user_id or "anonymous",
     }
 
-    segments = [urllib.parse.quote(field_map.get(f, "unknown"), safe="") for f in fields]
+    # bank_id is stored as-is server-side; HTTP path encoding is the client layer's job.
+    segments = [field_map.get(f, "unknown") for f in fields]
     base_bank_id = "::".join(segments)
 
     return f"{prefix}-{base_bank_id}" if prefix else base_bank_id

--- a/vendor/hindsight-memory/scripts/lib/client.py
+++ b/vendor/hindsight-memory/scripts/lib/client.py
@@ -5,15 +5,30 @@ Openclaw HindsightClient (client.js), adapted for Python stdlib.
 """
 
 import json
-import time
 import urllib.error
 import urllib.parse
 import urllib.request
+from pathlib import Path
 from typing import Optional
 
 DEFAULT_TIMEOUT = 15  # seconds
 HEALTH_CHECK_RETRIES = 3
 HEALTH_CHECK_DELAY = 2  # seconds
+
+
+def _plugin_version() -> str:
+    """Read the plugin version from plugin.json (single source of truth)."""
+    manifest = Path(__file__).resolve().parents[2] / ".claude-plugin" / "plugin.json"
+    try:
+        return json.loads(manifest.read_text()).get("version", "0.0.0")
+    except (OSError, ValueError):
+        return "0.0.0"
+
+
+# Sent on every request so self-hosted deployments behind Cloudflare (or any
+# reverse proxy with UA-based bot filtering) don't block the stdlib default
+# "Python-urllib/X.Y", which trips Cloudflare error 1010.
+USER_AGENT = f"hindsight-claude-code/{_plugin_version()}"
 
 
 def _validate_api_url(url: str) -> str:
@@ -34,7 +49,10 @@ class HindsightClient:
         self.api_token = api_token
 
     def _headers(self) -> dict:
-        headers = {"Content-Type": "application/json"}
+        headers = {
+            "Content-Type": "application/json",
+            "User-Agent": USER_AGENT,
+        }
         if self.api_token:
             headers["Authorization"] = f"Bearer {self.api_token}"
         return headers
@@ -60,6 +78,8 @@ class HindsightClient:
         Mirrors Openclaw's checkExternalApiHealth: retries up to 3 times
         with 2s delay between attempts.
         """
+        import time
+
         for attempt in range(1, HEALTH_CHECK_RETRIES + 1):
             try:
                 url = f"{self.api_url}/health"
@@ -128,29 +148,6 @@ class HindsightClient:
             "async": True,
         }
         return self._request("POST", path, body, timeout=timeout)
-
-    def list_directives(
-        self,
-        bank_id: str,
-        active_only: bool = True,
-        timeout: int = 5,
-    ) -> dict:
-        """List directives for a bank.
-
-        Returns the raw API response dict with 'items' list. Each item has:
-        id, bank_id, name, content, priority, is_active, tags, created_at,
-        updated_at.
-
-        We intentionally do NOT pass tags or isolation_mode arguments — the
-        upstream `reflect` tool has a known bug (vectorize-io/hindsight#1269)
-        where tagged directives are dropped by isolation_mode filtering.
-        `list_directives` itself works correctly with no filters, so we keep
-        the call surface minimal.
-        """
-        path = f"/v1/default/banks/{urllib.parse.quote(bank_id, safe='')}/directives"
-        if active_only:
-            path = f"{path}?active_only=true"
-        return self._request("GET", path, body=None, timeout=timeout)
 
     def set_bank_mission(
         self, bank_id: str, mission: str, retain_mission: Optional[str] = None, timeout: int = 15

--- a/vendor/hindsight-memory/scripts/lib/config.py
+++ b/vendor/hindsight-memory/scripts/lib/config.py
@@ -32,6 +32,7 @@ DEFAULTS = {
     "retainContext": "claude-code",
     "retainTags": [],
     "retainMetadata": {},
+    "recallAdditionalBanks": [],
     # Connection
     "hindsightApiUrl": None,
     "hindsightApiToken": None,

--- a/vendor/hindsight-memory/scripts/lib/content.py
+++ b/vendor/hindsight-memory/scripts/lib/content.py
@@ -8,47 +8,8 @@ truncateRecallQuery, sliceLastTurnsByUserBoundary, prepareRetentionTranscript,
 formatMemories.
 """
 
-import json
-import os
 import re
 from datetime import datetime, timezone
-
-# ---------------------------------------------------------------------------
-# Transcript reading (shared by recall and retain hooks)
-# ---------------------------------------------------------------------------
-
-
-def read_transcript_messages(transcript_path: str) -> list:
-    """Read messages from a JSONL transcript file.
-
-    Claude Code transcript format nests messages:
-      {type: "user", message: {role: "user", content: "..."}, uuid: "...", ...}
-    Also supports flat format for testing:
-      {role: "user", content: "..."}
-    """
-    if not transcript_path or not os.path.isfile(transcript_path):
-        return []
-    messages = []
-    try:
-        with open(transcript_path) as f:
-            for line in f:
-                line = line.strip()
-                if not line:
-                    continue
-                try:
-                    entry = json.loads(line)
-                    if entry.get("type") in ("user", "assistant"):
-                        msg = entry.get("message", {})
-                        if isinstance(msg, dict) and msg.get("role"):
-                            messages.append(msg)
-                    elif "role" in entry and "content" in entry:
-                        messages.append(entry)
-                except json.JSONDecodeError:
-                    continue
-    except OSError:
-        pass
-    return messages
-
 
 # ---------------------------------------------------------------------------
 # Memory tag stripping (anti-feedback-loop)
@@ -315,8 +276,19 @@ def _extract_message_blocks(content, role: str = "") -> list:
                 blocks.append({"type": "tool_use", "name": name, "input": inp})
 
         elif block_type == "tool_result":
-            # Include tool results for context
+            # Include tool results for context.
+            # content can be a plain string or a list of content blocks
+            # (e.g. [{"type": "text", "text": "..."}] for Agent results).
             result_content = block.get("content", "")
+            if isinstance(result_content, list):
+                # Extract text from content blocks
+                parts = []
+                for item in result_content:
+                    if isinstance(item, dict) and item.get("type") == "text":
+                        t = item.get("text", "").strip()
+                        if t:
+                            parts.append(t)
+                result_content = "\n".join(parts)
             if isinstance(result_content, str) and result_content.strip():
                 text = result_content.strip()
                 # Truncate very long results
@@ -436,9 +408,11 @@ _MESSAGE_TEXT_FIELDS = ("text", "body", "message", "content")
 
 # MCP tool name suffixes that are operational, not conversational.
 # Checked against the last segment of the tool name (after the last __).
-_OPERATIONAL_TOOL_PATTERN = re.compile(
+import re as _re
+
+_OPERATIONAL_TOOL_PATTERN = _re.compile(
     r"(?:recall|retain|reflect|search|extract|create_|delete_|update_|get_|list_)",
-    re.IGNORECASE,
+    _re.IGNORECASE,
 )
 
 

--- a/vendor/hindsight-memory/scripts/lib/daemon.py
+++ b/vendor/hindsight-memory/scripts/lib/daemon.py
@@ -20,12 +20,12 @@ import time
 import urllib.error
 import urllib.request
 
+from .client import USER_AGENT
 from .llm import detect_llm_config, get_llm_env_vars
 from .state import read_state, write_state
 
 DAEMON_STATE_FILE = "daemon.json"
 PROFILE_NAME = "claude-code"
-DEFAULT_DAEMON_IDLE_TIMEOUT = 300
 
 
 def _get_embed_command(config: dict) -> list:
@@ -75,7 +75,7 @@ def _check_health(base_url: str, timeout: int = 2) -> bool:
     """Quick health check against a Hindsight server."""
     try:
         url = f"{base_url.rstrip('/')}/health"
-        req = urllib.request.Request(url, method="GET")
+        req = urllib.request.Request(url, method="GET", headers={"User-Agent": USER_AGENT})
         with urllib.request.urlopen(req, timeout=timeout) as resp:
             return resp.status == 200
     except Exception:
@@ -161,7 +161,7 @@ def _ensure_daemon_running(config: dict, port: int, debug_fn=None):
 
     # Build daemon environment
     daemon_env = dict(llm_env)
-    idle_timeout = config.get("daemonIdleTimeout", DEFAULT_DAEMON_IDLE_TIMEOUT)
+    idle_timeout = config.get("daemonIdleTimeout", 300)
     daemon_env["HINDSIGHT_EMBED_DAEMON_IDLE_TIMEOUT"] = str(idle_timeout)
 
     # On macOS, force CPU for embeddings/reranker (mirrors Openclaw)
@@ -274,7 +274,7 @@ def prestart_daemon_background(config: dict, debug_fn=None):
     llm_env = get_llm_env_vars(llm_config)
     daemon_env = dict(os.environ)
     daemon_env.update(llm_env)
-    idle_timeout = config.get("daemonIdleTimeout", DEFAULT_DAEMON_IDLE_TIMEOUT)
+    idle_timeout = config.get("daemonIdleTimeout", 300)
     daemon_env["HINDSIGHT_EMBED_DAEMON_IDLE_TIMEOUT"] = str(idle_timeout)
     if platform.system() == "Darwin":
         daemon_env["HINDSIGHT_API_EMBEDDINGS_LOCAL_FORCE_CPU"] = "1"
@@ -287,24 +287,14 @@ def prestart_daemon_background(config: dict, debug_fn=None):
         if env_val:
             profile_args.extend(["--env", f"{env_name}={env_val}"])
 
-    # Run profile create synchronously (fast, ~1s) then detach the daemon start.
-    # Avoids shell=True and the &&-chain; profile must complete before daemon starts.
-    import subprocess as _sp
-    try:
-        _sp.run(
-            embed_cmd + profile_args,
-            env=daemon_env,
-            stdout=_sp.DEVNULL,
-            stderr=_sp.DEVNULL,
-            timeout=10,
-        )
-    except Exception as e:
-        if debug_fn:
-            debug_fn(f"Daemon pre-start: profile create failed: {e}")
-        return
+    import shlex
+    profile_str = shlex.join(embed_cmd + profile_args)
+    daemon_str = shlex.join(embed_cmd + ["daemon", "--profile", PROFILE_NAME, "start"])
 
+    import subprocess as _sp
     _sp.Popen(
-        embed_cmd + ["daemon", "--profile", PROFILE_NAME, "start"],
+        f"{profile_str} && {daemon_str}",
+        shell=True,
         env=daemon_env,
         stdout=_sp.DEVNULL,
         stderr=_sp.DEVNULL,

--- a/vendor/hindsight-memory/scripts/lib/state.py
+++ b/vendor/hindsight-memory/scripts/lib/state.py
@@ -126,3 +126,71 @@ def increment_turn_count(session_id: str) -> int:
             del turns[k]
     write_state("turns.json", turns)
     return turns[session_id]
+
+
+def _locked_read_modify_write(state_name: str, lock_name: str, modify_fn):
+    """Read-modify-write a state file under flock.
+
+    modify_fn receives the current state dict and returns (updated_dict, result).
+    Returns the result from modify_fn.
+    """
+    lock_path = _state_file(lock_name)
+    if fcntl is not None:
+        try:
+            lock_fd = open(lock_path, "w")
+            fcntl.flock(lock_fd, fcntl.LOCK_EX)
+            try:
+                data = read_state(state_name, {})
+                data, result = modify_fn(data)
+                write_state(state_name, data)
+                return result
+            finally:
+                fcntl.flock(lock_fd, fcntl.LOCK_UN)
+                lock_fd.close()
+        except OSError:
+            pass
+
+    # Fallback without lock
+    data = read_state(state_name, {})
+    data, result = modify_fn(data)
+    write_state(state_name, data)
+    return result
+
+
+def track_retention(session_id: str, message_count: int) -> tuple:
+    """Track retention state and detect compaction.
+
+    Compares the current message count against the last retained count for this
+    session.  When the transcript shrinks (compaction), increments a chunk counter
+    so the caller can use a distinct document_id, preserving the pre-compaction
+    document.
+
+    Returns:
+        (chunk_index, compacted) — chunk_index for building document_id,
+        compacted is True if compaction was detected this call.
+    """
+
+    def _update(data):
+        entry = data.get(session_id, {"message_count": 0, "chunk": 0})
+        last_count = entry["message_count"]
+        chunk = entry["chunk"]
+        compacted = False
+
+        if message_count < last_count:
+            # Transcript shrank — compaction happened
+            chunk += 1
+            compacted = True
+
+        entry["message_count"] = message_count
+        entry["chunk"] = chunk
+        data[session_id] = entry
+
+        # Cap tracked sessions
+        if len(data) > 10000:
+            sorted_keys = sorted(data.keys())
+            for k in sorted_keys[: len(sorted_keys) // 2]:
+                del data[k]
+
+        return data, (chunk, compacted)
+
+    return _locked_read_modify_write("retention_tracking.json", "retention_tracking.lock", _update)

--- a/vendor/hindsight-memory/scripts/recall.py
+++ b/vendor/hindsight-memory/scripts/recall.py
@@ -33,7 +33,6 @@ from lib.content import (
     compose_recall_query,
     format_current_time,
     format_memories,
-    read_transcript_messages,
     truncate_recall_query,
 )
 from lib.daemon import get_api_url
@@ -41,6 +40,40 @@ from lib.directives import fetch_active_directives, format_active_directives_blo
 from lib.state import write_state
 
 LAST_RECALL_STATE = "last_recall.json"
+
+
+def read_transcript_messages(transcript_path: str) -> list:
+    """Read messages from a JSONL transcript file for multi-turn context.
+
+    Claude Code transcript format nests messages:
+      {type: "user", message: {role: "user", content: "..."}, uuid: "...", ...}
+    Also supports flat format for testing:
+      {role: "user", content: "..."}
+    """
+    if not transcript_path or not os.path.isfile(transcript_path):
+        return []
+    messages = []
+    try:
+        with open(transcript_path, encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    entry = json.loads(line)
+                    # Claude Code nested format: {type: "user", message: {role, content}}
+                    if entry.get("type") in ("user", "assistant"):
+                        msg = entry.get("message", {})
+                        if isinstance(msg, dict) and msg.get("role"):
+                            messages.append(msg)
+                    # Flat format (testing / future compatibility)
+                    elif "role" in entry and "content" in entry:
+                        messages.append(entry)
+                except json.JSONDecodeError:
+                    continue
+    except OSError:
+        pass
+    return messages
 
 
 def main():
@@ -104,20 +137,26 @@ def main():
 
     query = truncate_recall_query(query, prompt, recall_max_query_chars)
 
+    # Final defensive cap (mirrors Openclaw)
+    if len(query) > recall_max_query_chars:
+        query = query[:recall_max_query_chars]
+
     debug_log(config, f"Recalling from bank '{bank_id}', query length: {len(query)}")
 
     # Fetch active directives FIRST (independent of recall — even if recall
     # finds no memories, an agent with active directives still needs them
-    # surfaced every turn). fetch_active_directives is failure-safe and
-    # returns [] on any error.
+    # surfaced every turn). Workaround for upstream bug
+    # vectorize-io/hindsight#1269 (tagged directives silently dropped from
+    # `reflect`); `list_directives` itself works correctly upstream, so this
+    # is a pure client-side surface. fetch_active_directives is failure-safe
+    # and returns [] on any error.
     directives = fetch_active_directives(client, bank_id)
     directives_block = format_active_directives_block(directives) if directives else None
     if directives_block:
         debug_log(config, f"Injecting {len(directives)} active directives")
 
     # Call Hindsight recall API
-    memories_block = None
-    result_count = 0
+    results = []
     try:
         response = client.recall(
             bank_id=bank_id,
@@ -128,26 +167,47 @@ def main():
             timeout=10,
         )
         results = response.get("results", [])
-        result_count = len(results)
-        if results:
-            debug_log(config, f"Injecting {result_count} memories")
-            memories_formatted = format_memories(results)
-            preamble = config.get("recallPromptPreamble", "")
-            current_time = format_current_time()
-            memories_block = (
-                f"<hindsight_memories>\n"
-                f"{preamble}\n"
-                f"Current time - {current_time}\n\n"
-                f"{memories_formatted}\n"
-                f"</hindsight_memories>"
-            )
-        else:
-            debug_log(config, "No memories found")
     except Exception as e:
         print(f"[Hindsight] Recall failed: {e}", file=sys.stderr)
         # Fall through — we still want to emit the directives block if we
         # have one, so a recall API failure doesn't blind the agent to
         # its own active directives.
+
+    # Also recall from any additional banks (e.g. shared user profile bank)
+    additional_banks = config.get("recallAdditionalBanks", [])
+    for extra_bank_id in additional_banks:
+        try:
+            extra_response = client.recall(
+                bank_id=extra_bank_id,
+                query=query,
+                max_tokens=config.get("recallMaxTokens", 1024),
+                budget=config.get("recallBudget", "mid"),
+                types=config.get("recallTypes"),
+                timeout=10,
+            )
+            extra_results = extra_response.get("results", [])
+            if extra_results:
+                debug_log(config, f"Got {len(extra_results)} memories from additional bank '{extra_bank_id}'")
+                results = results + extra_results
+        except Exception as e:
+            debug_log(config, f"Recall from additional bank '{extra_bank_id}' failed: {e}")
+
+    memories_block = None
+    if results:
+        debug_log(config, f"Injecting {len(results)} memories")
+        # Format context message — exact match of Openclaw's format
+        memories_formatted = format_memories(results)
+        preamble = config.get("recallPromptPreamble", "")
+        current_time = format_current_time()
+        memories_block = (
+            f"<hindsight_memories>\n"
+            f"{preamble}\n"
+            f"Current time - {current_time}\n\n"
+            f"{memories_formatted}\n"
+            f"</hindsight_memories>"
+        )
+    else:
+        debug_log(config, "No memories found")
 
     # If neither block has content, there's nothing to inject — exit
     # silently to avoid emitting an empty hookSpecificOutput.
@@ -170,7 +230,7 @@ def main():
             "context": context_message,
             "saved_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
             "bank_id": bank_id,
-            "result_count": result_count,
+            "result_count": len(results),
             "directive_count": len(directives),
         },
     )

--- a/vendor/hindsight-memory/scripts/retain.py
+++ b/vendor/hindsight-memory/scripts/retain.py
@@ -29,34 +29,60 @@ from lib.client import HindsightClient
 from lib.config import debug_log, load_config
 from lib.content import (
     prepare_retention_transcript,
-    read_transcript_messages,
     slice_last_turns_by_user_boundary,
 )
 from lib.daemon import get_api_url
-from lib.state import increment_turn_count
+from lib.state import increment_turn_count, track_retention
 
 
-def main():
+def read_transcript(transcript_path: str) -> list:
+    """Read a JSONL transcript file and return list of message dicts.
+
+    Claude Code transcript format nests messages:
+      {type: "user", message: {role: "user", content: "..."}, uuid: "...", ...}
+    Also supports flat format for testing:
+      {role: "user", content: "..."}
+    """
+    if not transcript_path or not os.path.isfile(transcript_path):
+        return []
+    messages = []
+    try:
+        with open(transcript_path, encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    entry = json.loads(line)
+                    # Claude Code nested format: {type: "user", message: {role, content}}
+                    if entry.get("type") in ("user", "assistant"):
+                        msg = entry.get("message", {})
+                        if isinstance(msg, dict) and msg.get("role"):
+                            messages.append(msg)
+                    # Flat format (testing / future compatibility)
+                    elif "role" in entry and "content" in entry:
+                        messages.append(entry)
+                except json.JSONDecodeError:
+                    continue
+    except OSError:
+        pass
+    return messages
+
+
+def run_retain(hook_input: dict, force: bool = False) -> None:
     config = load_config()
 
     if not config.get("autoRetain"):
         debug_log(config, "Auto-retain disabled, exiting")
         return
 
-    # Read hook input from stdin
-    try:
-        hook_input = json.load(sys.stdin)
-    except (json.JSONDecodeError, EOFError):
-        print("[Hindsight] Failed to read hook input", file=sys.stderr)
-        return
-
-    debug_log(config, f"Stop hook input keys: {list(hook_input.keys())}")
+    debug_log(config, f"Retain hook_input keys: {list(hook_input.keys())} force={force}")
 
     session_id = hook_input.get("session_id", "unknown")
     transcript_path = hook_input.get("transcript_path", "")
 
     # Read full transcript
-    all_messages = read_transcript_messages(transcript_path)
+    all_messages = read_transcript(transcript_path)
     if not all_messages:
         debug_log(config, "No messages in transcript, skipping retain")
         return
@@ -69,8 +95,8 @@ def main():
     retain_full_window = False
     messages_to_retain = all_messages
 
-    # Respect retainEveryNTurns in both modes
-    if retain_every_n > 1:
+    # Respect retainEveryNTurns in both modes, unless force=True (SessionEnd final retain)
+    if retain_every_n > 1 and not force:
         turn_count = increment_turn_count(session_id)
         if turn_count % retain_every_n != 0:
             next_at = ((turn_count // retain_every_n) + 1) * retain_every_n
@@ -124,19 +150,33 @@ def main():
     bank_id = derive_bank_id(hook_input, config)
     ensure_bank_mission(client, bank_id, config, debug_fn=_dbg)
 
-    # Document ID: use session_id so the same session always upserts the same document.
-    # In chunked mode, append timestamp to create distinct documents per chunk.
+    # Document ID strategy:
+    # - Chunked mode: each chunk gets a timestamped document_id.
+    # - Full-session mode: uses session_id as base, but tracks message count
+    #   to detect compaction.  When Claude Code compacts the conversation the
+    #   transcript shrinks — if we kept the same document_id we'd overwrite the
+    #   pre-compaction document with a shorter one, losing context.  Instead we
+    #   increment a chunk counter so the old document is preserved.
     if retain_mode == "chunked" and retain_every_n > 1:
         document_id = f"{session_id}-{int(time.time() * 1000)}"
     else:
-        document_id = session_id
+        chunk_index, compacted = track_retention(session_id, len(all_messages))
+        if compacted:
+            debug_log(
+                config,
+                f"Compaction detected for session {session_id}: transcript shrank, "
+                f"advancing to chunk {chunk_index} to preserve prior document",
+            )
+        # chunk 0 → plain session_id (backwards compatible with existing docs)
+        document_id = session_id if chunk_index == 0 else f"{session_id}-c{chunk_index}"
 
     # Resolve template variables in tags and metadata.
-    # Supported variables: {session_id}, {bank_id}, {timestamp}
+    # Supported variables: {session_id}, {bank_id}, {timestamp}, {user_id}
     template_vars = {
         "session_id": session_id,
         "bank_id": bank_id,
         "timestamp": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "user_id": os.environ.get("HINDSIGHT_USER_ID", ""),
     }
 
     def _resolve_template(value: str) -> str:
@@ -144,9 +184,22 @@ def main():
             value = value.replace(f"{{{k}}}", v)
         return value
 
-    # Tags from config with template resolution
+    # Tags from config with template resolution.
+    # Drop tags whose resolved form ends in an empty namespace part (e.g. "user:"
+    # when HINDSIGHT_USER_ID is unset). Tags without ':' are preserved as-is.
     raw_tags = config.get("retainTags", [])
-    tags = [_resolve_template(t) for t in raw_tags] if raw_tags else None
+    if raw_tags:
+        tags = []
+        for original in raw_tags:
+            resolved = _resolve_template(original)
+            if ":" in resolved and resolved.split(":", 1)[1] == "":
+                debug_log(config, f"Dropping tag '{original}' -> '{resolved}' (empty content after ':')")
+                continue
+            tags.append(resolved)
+        if not tags:
+            tags = None
+    else:
+        tags = None
 
     # Metadata: merge built-in defaults with user-configured extras
     metadata = {
@@ -177,6 +230,15 @@ def main():
         debug_log(config, f"Retain response: {json.dumps(response)[:200]}")
     except Exception as e:
         print(f"[Hindsight] Retain failed: {e}", file=sys.stderr)
+
+
+def main():
+    try:
+        hook_input = json.load(sys.stdin)
+    except (json.JSONDecodeError, EOFError):
+        print("[Hindsight] Failed to read hook input", file=sys.stderr)
+        return
+    run_retain(hook_input, force=False)
 
 
 if __name__ == "__main__":

--- a/vendor/hindsight-memory/scripts/session_end.py
+++ b/vendor/hindsight-memory/scripts/session_end.py
@@ -28,6 +28,15 @@ def main():
 
     debug_log(config, f"SessionEnd hook, reason: {hook_input.get('reason', 'unknown')}")
 
+    # Force a final retain before stopping the daemon — guarantees short sessions
+    # (fewer turns than retainEveryNTurns) still land on disk.
+    if config.get("autoRetain") and hook_input.get("transcript_path"):
+        try:
+            from retain import run_retain
+            run_retain(hook_input, force=True)
+        except Exception as e:
+            print(f"[Hindsight] SessionEnd final retain error: {e}", file=sys.stderr)
+
     # Stop daemon if we started it
     def _dbg(*a):
         debug_log(config, *a)

--- a/vendor/hindsight-memory/scripts/session_start.py
+++ b/vendor/hindsight-memory/scripts/session_start.py
@@ -15,6 +15,7 @@ import sys
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
+from lib.client import HindsightClient
 from lib.config import debug_log, load_config
 from lib.daemon import get_api_url, prestart_daemon_background
 
@@ -41,6 +42,7 @@ def main():
 
     try:
         api_url = get_api_url(config, debug_fn=_dbg, allow_daemon_start=False)
+        client = HindsightClient(api_url, config.get("hindsightApiToken"))
         debug_log(config, f"Hindsight server reachable at {api_url}")
     except (RuntimeError, ValueError) as e:
         # Server not running — kick off background pre-start so it's ready

--- a/vendor/hindsight-memory/tests/conftest.py
+++ b/vendor/hindsight-memory/tests/conftest.py
@@ -1,0 +1,94 @@
+"""Shared fixtures for Hindsight Claude Code plugin tests."""
+
+import io
+import json
+import os
+import sys
+import tempfile
+
+import pytest
+
+# Make scripts/ importable as the root — the hook scripts do:
+#   sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+# so lib.* imports resolve relative to scripts/
+SCRIPTS_DIR = os.path.join(os.path.dirname(__file__), "..", "scripts")
+if SCRIPTS_DIR not in sys.path:
+    sys.path.insert(0, os.path.abspath(SCRIPTS_DIR))
+
+
+@pytest.fixture()
+def state_dir(tmp_path, monkeypatch):
+    """Isolated state directory — prevents tests from touching real state files."""
+    d = tmp_path / "state"
+    d.mkdir()
+    monkeypatch.setenv("CLAUDE_PLUGIN_DATA", str(tmp_path))
+    return d
+
+
+@pytest.fixture()
+def plugin_root(tmp_path):
+    """Temp plugin root with a minimal settings.json."""
+    settings = tmp_path / "settings.json"
+    settings.write_text(json.dumps({}))
+    return tmp_path
+
+
+@pytest.fixture()
+def default_config(plugin_root, monkeypatch):
+    """Load config with no overrides, isolated from real settings.json."""
+    monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(plugin_root))
+    # Strip any real HINDSIGHT_* env vars that might bleed in
+    for key in list(os.environ):
+        if key.startswith("HINDSIGHT_"):
+            monkeypatch.delenv(key, raising=False)
+    from lib.config import load_config
+
+    return load_config()
+
+
+def make_hook_input(
+    prompt="What is the capital of France?",
+    session_id="sess-abc123",
+    cwd="/home/user/myproject",
+    transcript_path="",
+):
+    return {
+        "prompt": prompt,
+        "session_id": session_id,
+        "cwd": cwd,
+        "transcript_path": transcript_path,
+    }
+
+
+def make_transcript_file(tmp_path, messages):
+    """Write messages as a JSONL transcript file (flat test format)."""
+    f = tmp_path / "transcript.jsonl"
+    lines = [json.dumps(m) for m in messages]
+    f.write_text("\n".join(lines))
+    return str(f)
+
+
+def make_recall_response(memories):
+    """Build a fake /recall API response."""
+    return {"results": memories}
+
+
+def make_memory(text, mem_type="experience", mentioned_at="2024-01-15"):
+    return {"text": text, "type": mem_type, "mentioned_at": mentioned_at}
+
+
+class FakeHTTPResponse:
+    """Minimal urllib response mock."""
+
+    def __init__(self, data: dict, status: int = 200):
+        self.status = status
+        self._data = json.dumps(data).encode()
+
+    def read(self):
+        return self._data
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_):
+        pass

--- a/vendor/hindsight-memory/tests/test_bank.py
+++ b/vendor/hindsight-memory/tests/test_bank.py
@@ -1,0 +1,142 @@
+"""Tests for lib/bank.py — bank ID derivation and mission management."""
+
+import json
+from unittest.mock import MagicMock
+
+import pytest
+
+from lib.bank import derive_bank_id, ensure_bank_mission
+
+
+def _cfg(**overrides):
+    base = {
+        "dynamicBankId": False,
+        "bankId": "claude-code",
+        "bankIdPrefix": "",
+        "agentName": "claude-code",
+        "dynamicBankGranularity": ["agent", "project"],
+        "bankMission": "",
+        "retainMission": None,
+    }
+    base.update(overrides)
+    return base
+
+
+def _hook(session_id="sess-1", cwd="/home/user/myproject"):
+    return {"session_id": session_id, "cwd": cwd}
+
+
+class TestDeriveBankIdStatic:
+    def test_static_default_bank(self):
+        assert derive_bank_id(_hook(), _cfg()) == "claude-code"
+
+    def test_static_custom_bank_id(self):
+        cfg = _cfg(bankId="my-agent")
+        assert derive_bank_id(_hook(), cfg) == "my-agent"
+
+    def test_static_with_prefix(self):
+        cfg = _cfg(bankId="bot", bankIdPrefix="prod")
+        assert derive_bank_id(_hook(), cfg) == "prod-bot"
+
+    def test_static_prefix_without_bankid_uses_default(self):
+        cfg = _cfg(bankId=None, bankIdPrefix="dev")
+        assert derive_bank_id(_hook(), cfg) == "dev-claude-code"
+
+
+class TestDeriveBankIdDynamic:
+    def test_dynamic_agent_project(self):
+        cfg = _cfg(dynamicBankId=True, agentName="mybot", dynamicBankGranularity=["agent", "project"])
+        result = derive_bank_id(_hook(cwd="/home/user/hindsight"), cfg)
+        assert result == "mybot::hindsight"
+
+    def test_dynamic_preserves_raw_special_chars(self):
+        cfg = _cfg(dynamicBankId=True, dynamicBankGranularity=["project"])
+        result = derive_bank_id(_hook(cwd="/home/user/my project"), cfg)
+        assert "my project" in result
+        assert "%" not in result
+
+    def test_dynamic_preserves_raw_utf8(self):
+        cfg = _cfg(dynamicBankId=True, dynamicBankGranularity=["project"])
+        result = derive_bank_id(_hook(cwd="/home/user/мой проект"), cfg)
+        assert "мой проект" in result
+        assert "%" not in result
+
+    def test_dynamic_session_field(self):
+        cfg = _cfg(dynamicBankId=True, dynamicBankGranularity=["session"])
+        result = derive_bank_id(_hook(session_id="abc-123"), cfg)
+        assert "abc-123" in result
+
+    def test_dynamic_with_prefix(self):
+        cfg = _cfg(dynamicBankId=True, dynamicBankGranularity=["agent"], bankIdPrefix="v2")
+        result = derive_bank_id(_hook(), cfg)
+        assert result.startswith("v2-")
+
+    def test_dynamic_channel_from_env(self, monkeypatch):
+        monkeypatch.setenv("HINDSIGHT_CHANNEL_ID", "telegram-123")
+        cfg = _cfg(dynamicBankId=True, dynamicBankGranularity=["channel"])
+        result = derive_bank_id(_hook(), cfg)
+        assert "telegram-123" in result
+
+    def test_dynamic_user_from_env(self, monkeypatch):
+        monkeypatch.setenv("HINDSIGHT_USER_ID", "user-456")
+        cfg = _cfg(dynamicBankId=True, dynamicBankGranularity=["user"])
+        result = derive_bank_id(_hook(), cfg)
+        assert "user-456" in result
+
+    def test_dynamic_missing_env_uses_defaults(self, monkeypatch):
+        monkeypatch.delenv("HINDSIGHT_CHANNEL_ID", raising=False)
+        monkeypatch.delenv("HINDSIGHT_USER_ID", raising=False)
+        cfg = _cfg(dynamicBankId=True, dynamicBankGranularity=["channel", "user"])
+        result = derive_bank_id(_hook(), cfg)
+        assert "default" in result
+        assert "anonymous" in result
+
+    def test_dynamic_empty_cwd_uses_unknown(self):
+        cfg = _cfg(dynamicBankId=True, dynamicBankGranularity=["project"])
+        result = derive_bank_id({"session_id": "s", "cwd": ""}, cfg)
+        assert "unknown" in result
+
+
+class TestEnsureBankMission:
+    def test_sets_mission_on_first_call(self, state_dir):
+        client = MagicMock()
+        cfg = _cfg(bankMission="You are a helpful assistant.", bankId="test-bank")
+        ensure_bank_mission(client, "test-bank", cfg)
+        client.set_bank_mission.assert_called_once_with(
+            "test-bank", "You are a helpful assistant.", retain_mission=None, timeout=10
+        )
+
+    def test_skips_if_already_set(self, state_dir):
+        client = MagicMock()
+        cfg = _cfg(bankMission="mission text")
+        ensure_bank_mission(client, "bank-a", cfg)
+        ensure_bank_mission(client, "bank-a", cfg)  # second call
+        assert client.set_bank_mission.call_count == 1
+
+    def test_skips_if_mission_empty(self, state_dir):
+        client = MagicMock()
+        cfg = _cfg(bankMission="")
+        ensure_bank_mission(client, "bank-b", cfg)
+        client.set_bank_mission.assert_not_called()
+
+    def test_includes_retain_mission_if_set(self, state_dir):
+        client = MagicMock()
+        cfg = _cfg(bankMission="reflect mission", retainMission="retain mission")
+        ensure_bank_mission(client, "bank-c", cfg)
+        client.set_bank_mission.assert_called_once_with(
+            "bank-c", "reflect mission", retain_mission="retain mission", timeout=10
+        )
+
+    def test_graceful_on_api_error(self, state_dir):
+        client = MagicMock()
+        client.set_bank_mission.side_effect = RuntimeError("server down")
+        cfg = _cfg(bankMission="mission")
+        # Should not raise
+        ensure_bank_mission(client, "bank-d", cfg)
+
+    def test_different_banks_each_set_once(self, state_dir):
+        client = MagicMock()
+        cfg = _cfg(bankMission="mission")
+        ensure_bank_mission(client, "bank-x", cfg)
+        ensure_bank_mission(client, "bank-y", cfg)
+        assert client.set_bank_mission.call_count == 2

--- a/vendor/hindsight-memory/tests/test_client.py
+++ b/vendor/hindsight-memory/tests/test_client.py
@@ -1,0 +1,232 @@
+"""Tests for lib/client.py — Hindsight REST API client."""
+
+import json
+import urllib.error
+from io import BytesIO
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from lib.client import USER_AGENT, HindsightClient, _validate_api_url
+
+
+class TestValidateApiUrl:
+    def test_valid_http(self):
+        assert _validate_api_url("http://localhost:9077") == "http://localhost:9077"
+
+    def test_valid_https(self):
+        assert _validate_api_url("https://api.example.com/") == "https://api.example.com"
+
+    def test_trailing_slash_stripped(self):
+        assert _validate_api_url("http://host:8080/") == "http://host:8080"
+
+    def test_invalid_scheme_raises(self):
+        with pytest.raises(ValueError, match="http or https"):
+            _validate_api_url("ftp://host")
+
+    def test_no_hostname_raises(self):
+        with pytest.raises(ValueError):
+            _validate_api_url("http://")
+
+
+class FakeResp:
+    def __init__(self, data, status=200):
+        self.status = status
+        self._body = json.dumps(data).encode()
+
+    def read(self):
+        return self._body
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_):
+        pass
+
+
+class TestHindsightClientInit:
+    def test_rejects_non_http_url(self):
+        with pytest.raises(ValueError):
+            HindsightClient("ftp://bad")
+
+    def test_stores_token(self):
+        c = HindsightClient("http://localhost:9077", api_token="tok123")
+        assert c.api_token == "tok123"
+
+    def test_no_token(self):
+        c = HindsightClient("http://localhost:9077")
+        assert c.api_token is None
+
+
+class TestHindsightClientRecall:
+    def test_posts_to_correct_path(self):
+        c = HindsightClient("http://localhost:9077")
+        response_data = {"results": [{"text": "Paris", "type": "world"}]}
+        with patch("urllib.request.urlopen", return_value=FakeResp(response_data)):
+            resp = c.recall("my-bank", "capital of France")
+        assert resp["results"][0]["text"] == "Paris"
+
+    def test_bank_id_url_encoded(self):
+        c = HindsightClient("http://localhost:9077")
+        captured = {}
+
+        def fake_open(req, timeout=None):
+            captured["url"] = req.full_url
+            return FakeResp({"results": []})
+
+        with patch("urllib.request.urlopen", side_effect=fake_open):
+            c.recall("bank with spaces", "query")
+
+        assert "bank%20with%20spaces" in captured["url"]
+
+    def test_includes_auth_header_when_token_set(self):
+        c = HindsightClient("http://localhost:9077", api_token="mytoken")
+        captured = {}
+
+        def fake_open(req, timeout=None):
+            captured["headers"] = dict(req.headers)
+            return FakeResp({"results": []})
+
+        with patch("urllib.request.urlopen", side_effect=fake_open):
+            c.recall("bank", "query")
+
+        assert "Authorization" in captured["headers"]
+        assert "mytoken" in captured["headers"]["Authorization"]
+
+    def test_no_auth_header_without_token(self):
+        c = HindsightClient("http://localhost:9077")
+        captured = {}
+
+        def fake_open(req, timeout=None):
+            captured["headers"] = dict(req.headers)
+            return FakeResp({"results": []})
+
+        with patch("urllib.request.urlopen", side_effect=fake_open):
+            c.recall("bank", "query")
+
+        assert "Authorization" not in captured["headers"]
+
+    def test_sends_user_agent_header(self):
+        # Regression test for #1041: the stdlib default "Python-urllib/X.Y" UA
+        # is blocked by Cloudflare with error 1010, so we must always send our own.
+        c = HindsightClient("http://localhost:9077")
+        captured = {}
+
+        def fake_open(req, timeout=None):
+            captured["ua"] = req.get_header("User-agent")
+            return FakeResp({"results": []})
+
+        with patch("urllib.request.urlopen", side_effect=fake_open):
+            c.recall("bank", "query")
+
+        assert captured["ua"] == USER_AGENT
+        assert captured["ua"].startswith("hindsight-claude-code/")
+
+    def test_http_error_raises_runtime_error(self):
+        c = HindsightClient("http://localhost:9077")
+        err = urllib.error.HTTPError(
+            url="http://localhost:9077/v1/default/banks/b/memories/recall",
+            code=500,
+            msg="Internal Server Error",
+            hdrs={},
+            fp=BytesIO(b"server exploded"),
+        )
+        with patch("urllib.request.urlopen", side_effect=err):
+            with pytest.raises(RuntimeError, match="HTTP 500"):
+                c.recall("b", "query")
+
+    def test_sends_budget_and_types(self):
+        c = HindsightClient("http://localhost:9077")
+        captured = {}
+
+        def fake_open(req, timeout=None):
+            captured["body"] = json.loads(req.data.decode())
+            return FakeResp({"results": []})
+
+        with patch("urllib.request.urlopen", side_effect=fake_open):
+            c.recall("bank", "query", budget="high", types=["world", "experience"])
+
+        assert captured["body"]["budget"] == "high"
+        assert captured["body"]["types"] == ["world", "experience"]
+
+
+class TestHindsightClientRetain:
+    def test_posts_with_async_true(self):
+        c = HindsightClient("http://localhost:9077")
+        captured = {}
+
+        def fake_open(req, timeout=None):
+            captured["body"] = json.loads(req.data.decode())
+            return FakeResp({"status": "accepted"})
+
+        with patch("urllib.request.urlopen", side_effect=fake_open):
+            c.retain("bank", "transcript content", document_id="doc-1", context="claude-code")
+
+        assert captured["body"]["async"] is True
+        assert captured["body"]["items"][0]["content"] == "transcript content"
+        assert captured["body"]["items"][0]["context"] == "claude-code"
+
+    def test_bank_id_encoded_in_retain_path(self):
+        c = HindsightClient("http://localhost:9077")
+        captured = {}
+
+        def fake_open(req, timeout=None):
+            captured["url"] = req.full_url
+            return FakeResp({})
+
+        with patch("urllib.request.urlopen", side_effect=fake_open):
+            c.retain("my::bank", "content")
+
+        assert "my%3A%3Abank" in captured["url"]
+
+
+class TestHindsightClientHealthCheck:
+    def test_returns_true_on_200(self):
+        c = HindsightClient("http://localhost:9077")
+        with patch("urllib.request.urlopen", return_value=FakeResp({}, status=200)):
+            with patch("time.sleep"):  # don't actually sleep
+                assert c.health_check() is True
+
+    def test_returns_false_after_retries(self):
+        c = HindsightClient("http://localhost:9077")
+        with patch("urllib.request.urlopen", side_effect=OSError("refused")):
+            with patch("time.sleep"):
+                assert c.health_check() is False
+
+    def test_retries_on_failure(self):
+        c = HindsightClient("http://localhost:9077")
+        call_count = 0
+
+        def flaky(*_a, **_kw):
+            nonlocal call_count
+            call_count += 1
+            if call_count < 3:
+                raise OSError("not yet")
+            return FakeResp({}, status=200)
+
+        with patch("urllib.request.urlopen", side_effect=flaky):
+            with patch("time.sleep"):
+                result = c.health_check()
+
+        assert result is True
+        assert call_count == 3
+
+
+class TestHindsightClientSetBankMission:
+    def test_patches_config_endpoint(self):
+        c = HindsightClient("http://localhost:9077")
+        captured = {}
+
+        def fake_open(req, timeout=None):
+            captured["url"] = req.full_url
+            captured["method"] = req.method
+            captured["body"] = json.loads(req.data.decode())
+            return FakeResp({})
+
+        with patch("urllib.request.urlopen", side_effect=fake_open):
+            c.set_bank_mission("my-bank", "I am Claude", retain_mission="Extract facts")
+
+        assert captured["method"] == "PATCH"
+        assert "my-bank" in captured["url"]
+        assert captured["body"]["updates"]["reflect_mission"] == "I am Claude"
+        assert captured["body"]["updates"]["retain_mission"] == "Extract facts"

--- a/vendor/hindsight-memory/tests/test_config.py
+++ b/vendor/hindsight-memory/tests/test_config.py
@@ -1,0 +1,128 @@
+"""Tests for lib/config.py — configuration loading and env overrides."""
+
+import json
+import os
+
+import pytest
+
+from lib.config import _cast_env, load_config
+
+
+class TestCastEnv:
+    def test_bool_true_values(self):
+        for v in ("true", "True", "TRUE", "1", "yes", "YES"):
+            assert _cast_env(v, bool) is True
+
+    def test_bool_false_values(self):
+        for v in ("false", "False", "0", "no"):
+            assert _cast_env(v, bool) is False
+
+    def test_int_cast(self):
+        assert _cast_env("42", int) == 42
+
+    def test_int_invalid_returns_none(self):
+        assert _cast_env("notanint", int) is None
+
+    def test_str_passthrough(self):
+        assert _cast_env("hello", str) == "hello"
+
+
+class TestLoadConfig:
+    @pytest.fixture(autouse=True)
+    def _isolate_config(self, tmp_path, monkeypatch):
+        """Isolate from real user config and env vars."""
+        monkeypatch.setenv("HOME", str(tmp_path))
+        for k in list(os.environ):
+            if k.startswith("HINDSIGHT_"):
+                monkeypatch.delenv(k, raising=False)
+
+    def test_defaults_applied_when_no_settings_file(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(tmp_path))
+        # No settings.json in tmp_path
+        cfg = load_config()
+        assert cfg["autoRecall"] is True
+        assert cfg["autoRetain"] is True
+        assert cfg["recallBudget"] == "mid"
+        assert cfg["retainEveryNTurns"] == 10
+
+    def test_settings_json_overrides_defaults(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(tmp_path))
+        (tmp_path / "settings.json").write_text(json.dumps({"recallBudget": "high", "bankId": "my-bank"}))
+        cfg = load_config()
+        assert cfg["recallBudget"] == "high"
+        assert cfg["bankId"] == "my-bank"
+
+    def test_env_var_overrides_settings_json(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(tmp_path))
+        (tmp_path / "settings.json").write_text(json.dumps({"recallBudget": "low"}))
+        monkeypatch.setenv("HINDSIGHT_RECALL_BUDGET", "high")
+        cfg = load_config()
+        assert cfg["recallBudget"] == "high"
+
+    def test_bool_env_var_override(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(tmp_path))
+        monkeypatch.setenv("HINDSIGHT_AUTO_RECALL", "false")
+        cfg = load_config()
+        assert cfg["autoRecall"] is False
+
+    def test_int_env_var_override(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(tmp_path))
+        monkeypatch.setenv("HINDSIGHT_API_PORT", "9999")
+        cfg = load_config()
+        assert cfg["apiPort"] == 9999
+
+    def test_invalid_settings_json_falls_back_to_defaults(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(tmp_path))
+        (tmp_path / "settings.json").write_text("not valid json{{")
+        cfg = load_config()
+        assert cfg["recallBudget"] == "mid"  # default still applies
+
+    def test_null_values_in_settings_json_not_applied(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(tmp_path))
+        (tmp_path / "settings.json").write_text(json.dumps({"bankId": None, "recallBudget": "high"}))
+        cfg = load_config()
+        # None values in file should not override defaults
+        assert cfg["bankId"] is None  # default is None, so ok
+        assert cfg["recallBudget"] == "high"
+
+    def test_api_url_env_override(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(tmp_path))
+        monkeypatch.setenv("HINDSIGHT_API_URL", "http://myserver:8080")
+        cfg = load_config()
+        assert cfg["hindsightApiUrl"] == "http://myserver:8080"
+
+    def test_user_config_overrides_plugin_settings(self, tmp_path, monkeypatch):
+        plugin_root = tmp_path / "plugin"
+        plugin_root.mkdir()
+
+        # Plugin default ships with "low"
+        (plugin_root / "settings.json").write_text(json.dumps({"recallBudget": "low"}))
+        # User overrides to "high" via ~/.hindsight/claude-code.json
+        user_cfg = tmp_path / ".hindsight" / "claude-code.json"
+        user_cfg.parent.mkdir()
+        user_cfg.write_text(json.dumps({"recallBudget": "high"}))
+
+        monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(plugin_root))
+        monkeypatch.setenv("HOME", str(tmp_path))
+        cfg = load_config()
+        assert cfg["recallBudget"] == "high"
+
+    def test_user_config_missing_falls_back_gracefully(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(tmp_path))
+        # HOME points to tmp_path where no .hindsight/claude-code.json exists
+        monkeypatch.setenv("HOME", str(tmp_path))
+        cfg = load_config()
+        assert cfg["recallBudget"] == "mid"  # default
+
+    def test_env_var_wins_over_user_config(self, tmp_path, monkeypatch):
+        plugin_root = tmp_path / "plugin"
+        plugin_root.mkdir()
+        user_cfg_dir = tmp_path / ".hindsight"
+        user_cfg_dir.mkdir()
+        (user_cfg_dir / "claude-code.json").write_text(json.dumps({"recallBudget": "low"}))
+
+        monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(plugin_root))
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setenv("HINDSIGHT_RECALL_BUDGET", "high")
+        cfg = load_config()
+        assert cfg["recallBudget"] == "high"

--- a/vendor/hindsight-memory/tests/test_content.py
+++ b/vendor/hindsight-memory/tests/test_content.py
@@ -1,0 +1,471 @@
+"""Tests for lib/content.py — pure content-processing functions."""
+
+import pytest
+
+from lib.content import (
+    _extract_text_content,
+    _is_channel_message_tool,
+    compose_recall_query,
+    format_memories,
+    prepare_retention_transcript,
+    slice_last_turns_by_user_boundary,
+    strip_channel_envelope,
+    strip_memory_tags,
+    truncate_recall_query,
+)
+
+
+# ---------------------------------------------------------------------------
+# strip_channel_envelope
+# ---------------------------------------------------------------------------
+
+
+class TestStripChannelEnvelope:
+    def test_strips_channel_xml(self):
+        raw = '<channel source="plugin:telegram:telegram" chat_id="123">Hello world</channel>'
+        assert strip_channel_envelope(raw) == "Hello world"
+
+    def test_passthrough_plain_text(self):
+        assert strip_channel_envelope("just plain text") == "just plain text"
+
+    def test_strips_multiline_channel(self):
+        raw = "<channel source='s'>\nline1\nline2\n</channel>"
+        assert strip_channel_envelope(raw) == "line1\nline2"
+
+    def test_passthrough_when_no_channel_tag(self):
+        raw = "<other>stuff</other>"
+        assert strip_channel_envelope(raw) == raw
+
+
+# ---------------------------------------------------------------------------
+# strip_memory_tags
+# ---------------------------------------------------------------------------
+
+
+class TestStripMemoryTags:
+    def test_strips_hindsight_memories_block(self):
+        raw = "before\n<hindsight_memories>secret</hindsight_memories>\nafter"
+        assert "hindsight_memories" not in strip_memory_tags(raw)
+        assert "before" in strip_memory_tags(raw)
+        assert "after" in strip_memory_tags(raw)
+
+    def test_strips_relevant_memories_block(self):
+        raw = "text <relevant_memories>old stuff</relevant_memories> text"
+        result = strip_memory_tags(raw)
+        assert "relevant_memories" not in result
+        assert "old stuff" not in result
+
+    def test_passthrough_clean_text(self):
+        raw = "no memory tags here"
+        assert strip_memory_tags(raw) == raw
+
+    def test_strips_multiline_block(self):
+        raw = "<hindsight_memories>\n- mem1\n- mem2\n</hindsight_memories>"
+        assert strip_memory_tags(raw).strip() == ""
+
+
+# ---------------------------------------------------------------------------
+# slice_last_turns_by_user_boundary
+# ---------------------------------------------------------------------------
+
+
+def _msgs(*pairs):
+    """Build a message list from (role, content) pairs."""
+    return [{"role": r, "content": c} for r, c in pairs]
+
+
+class TestSliceLastTurnsByUserBoundary:
+    def test_returns_all_when_fewer_turns_than_requested(self):
+        msgs = _msgs(("user", "hi"), ("assistant", "hello"))
+        assert slice_last_turns_by_user_boundary(msgs, 5) == msgs
+
+    def test_slices_to_last_one_turn(self):
+        msgs = _msgs(
+            ("user", "first"),
+            ("assistant", "a1"),
+            ("user", "second"),
+            ("assistant", "a2"),
+        )
+        result = slice_last_turns_by_user_boundary(msgs, 1)
+        assert result[0]["content"] == "second"
+        assert len(result) == 2
+
+    def test_slices_to_last_two_turns(self):
+        msgs = _msgs(
+            ("user", "u1"),
+            ("assistant", "a1"),
+            ("user", "u2"),
+            ("assistant", "a2"),
+            ("user", "u3"),
+            ("assistant", "a3"),
+        )
+        result = slice_last_turns_by_user_boundary(msgs, 2)
+        assert result[0]["content"] == "u2"
+        assert len(result) == 4
+
+    def test_empty_list_returns_empty(self):
+        assert slice_last_turns_by_user_boundary([], 3) == []
+
+    def test_zero_turns_returns_empty(self):
+        msgs = _msgs(("user", "hi"))
+        assert slice_last_turns_by_user_boundary(msgs, 0) == []
+
+    def test_non_list_returns_empty(self):
+        assert slice_last_turns_by_user_boundary(None, 1) == []
+
+
+# ---------------------------------------------------------------------------
+# compose_recall_query
+# ---------------------------------------------------------------------------
+
+
+class TestComposeRecallQuery:
+    def test_single_turn_returns_latest_only(self):
+        msgs = _msgs(("user", "previous"), ("assistant", "reply"))
+        result = compose_recall_query("new query", msgs, recall_context_turns=1)
+        assert result == "new query"
+
+    def test_multi_turn_includes_prior_context(self):
+        msgs = _msgs(("user", "prior question"), ("assistant", "prior answer"))
+        result = compose_recall_query("current question", msgs, recall_context_turns=2)
+        assert "Prior context:" in result
+        assert "prior question" in result
+        assert "current question" in result
+
+    def test_skips_duplicate_of_latest_query(self):
+        msgs = _msgs(("user", "same question"), ("assistant", "answer"))
+        result = compose_recall_query("same question", msgs, recall_context_turns=2)
+        # duplicate user msg should be dropped from context
+        assert result.count("same question") == 1
+
+    def test_empty_messages_returns_latest(self):
+        result = compose_recall_query("query", [], recall_context_turns=3)
+        assert result == "query"
+
+    def test_strips_memory_tags_from_context(self):
+        msgs = _msgs(
+            ("user", "<hindsight_memories>secret</hindsight_memories> actual question"),
+        )
+        result = compose_recall_query("now", msgs, recall_context_turns=2)
+        assert "hindsight_memories" not in result
+        assert "secret" not in result
+
+    def test_filters_by_recall_roles(self):
+        msgs = _msgs(("user", "user msg"), ("assistant", "assistant msg"))
+        result = compose_recall_query("query", msgs, recall_context_turns=2, recall_roles=["user"])
+        assert "user msg" in result
+        assert "assistant msg" not in result
+
+
+# ---------------------------------------------------------------------------
+# truncate_recall_query
+# ---------------------------------------------------------------------------
+
+
+class TestTruncateRecallQuery:
+    def test_short_query_unchanged(self):
+        q = "short"
+        assert truncate_recall_query(q, q, max_chars=100) == q
+
+    def test_plain_query_truncated_to_max(self):
+        q = "x" * 50
+        result = truncate_recall_query(q, q, max_chars=20)
+        assert len(result) <= 20
+
+    def test_preserves_latest_when_context_dropped(self):
+        latest = "final question"
+        query = f"Prior context:\n\nuser: old stuff\nassistant: old reply\n\n{latest}"
+        result = truncate_recall_query(query, latest, max_chars=30)
+        assert latest in result
+
+    def test_drops_oldest_context_lines_first(self):
+        latest = "latest"
+        query = f"Prior context:\n\nuser: oldest\nassistant: old\nuser: newer\n\n{latest}"
+        # Allow only the newest context line + latest
+        result = truncate_recall_query(query, latest, max_chars=len(f"Prior context:\n\nnewer\n\n{latest}") + 5)
+        if "Prior context:" in result:
+            assert "oldest" not in result
+
+    def test_zero_max_returns_query_unchanged(self):
+        q = "anything"
+        assert truncate_recall_query(q, q, max_chars=0) == q
+
+
+# ---------------------------------------------------------------------------
+# format_memories
+# ---------------------------------------------------------------------------
+
+
+class TestFormatMemories:
+    def test_formats_single_memory(self):
+        mems = [{"text": "Paris is the capital", "type": "world", "mentioned_at": "2024-01-01"}]
+        result = format_memories(mems)
+        assert "Paris is the capital" in result
+        assert "[world]" in result
+        assert "(2024-01-01)" in result
+
+    def test_formats_multiple_memories_with_separator(self):
+        mems = [
+            {"text": "mem1", "type": "experience", "mentioned_at": "2024-01-01"},
+            {"text": "mem2", "type": "world", "mentioned_at": "2024-02-01"},
+        ]
+        result = format_memories(mems)
+        assert "mem1" in result
+        assert "mem2" in result
+
+    def test_empty_list_returns_empty_string(self):
+        assert format_memories([]) == ""
+
+    def test_missing_optional_fields_graceful(self):
+        mems = [{"text": "bare memory"}]
+        result = format_memories(mems)
+        assert "bare memory" in result
+
+
+# ---------------------------------------------------------------------------
+# _is_channel_message_tool
+# ---------------------------------------------------------------------------
+
+
+class TestIsChannelMessageTool:
+    def test_telegram_send_message(self):
+        block = {"type": "tool_use", "name": "mcp__telegram__sendMessage", "input": {"text": "hello"}}
+        assert _is_channel_message_tool(block) is True
+
+    def test_slack_reply_tool(self):
+        block = {"type": "tool_use", "name": "mcp__slack__reply", "input": {"body": "hi there"}}
+        assert _is_channel_message_tool(block) is True
+
+    def test_operational_recall_tool_excluded(self):
+        block = {"type": "tool_use", "name": "mcp__hindsight__recall", "input": {"query": "test"}}
+        assert _is_channel_message_tool(block) is False
+
+    def test_builtin_bash_tool_excluded(self):
+        block = {"type": "tool_use", "name": "Bash", "input": {"command": "ls"}}
+        assert _is_channel_message_tool(block) is False
+
+    def test_mcp_tool_without_text_field_excluded(self):
+        block = {"type": "tool_use", "name": "mcp__something__action", "input": {"id": 123}}
+        assert _is_channel_message_tool(block) is False
+
+    def test_mcp_tool_with_empty_text_excluded(self):
+        block = {"type": "tool_use", "name": "mcp__telegram__send", "input": {"text": "   "}}
+        assert _is_channel_message_tool(block) is False
+
+    def test_mcp_create_action_excluded(self):
+        block = {"type": "tool_use", "name": "mcp__notion__create_page", "input": {"content": "hello"}}
+        assert _is_channel_message_tool(block) is False
+
+
+# ---------------------------------------------------------------------------
+# _extract_text_content
+# ---------------------------------------------------------------------------
+
+
+class TestExtractTextContent:
+    def test_plain_string_returned_as_is(self):
+        assert _extract_text_content("hello", role="user") == "hello"
+
+    def test_text_block_extracted(self):
+        content = [{"type": "text", "text": "response text"}]
+        assert _extract_text_content(content, role="assistant") == "response text"
+
+    def test_thinking_block_excluded(self):
+        content = [{"type": "thinking", "thinking": "private"}, {"type": "text", "text": "public"}]
+        result = _extract_text_content(content, role="assistant")
+        assert "private" not in result
+        assert "public" in result
+
+    def test_channel_tool_use_extracted_for_assistant(self):
+        content = [{"type": "tool_use", "name": "mcp__telegram__send", "input": {"text": "hello user"}}]
+        result = _extract_text_content(content, role="assistant")
+        assert "hello user" in result
+
+    def test_tool_use_not_extracted_for_user(self):
+        content = [{"type": "tool_use", "name": "mcp__telegram__send", "input": {"text": "hello user"}}]
+        result = _extract_text_content(content, role="user")
+        assert "hello user" not in result
+
+    def test_empty_list_returns_empty_string(self):
+        assert _extract_text_content([], role="assistant") == ""
+
+    def test_non_string_non_list_returns_empty(self):
+        assert _extract_text_content(None, role="user") == ""
+        assert _extract_text_content(42, role="user") == ""
+
+
+# ---------------------------------------------------------------------------
+# prepare_retention_transcript
+# ---------------------------------------------------------------------------
+
+
+class TestPrepareRetentionTranscript:
+    def test_formats_last_turn_by_default(self):
+        msgs = _msgs(("user", "old"), ("assistant", "old reply"), ("user", "new"), ("assistant", "new reply"))
+        transcript, count = prepare_retention_transcript(msgs, retain_full_window=False)
+        assert "new" in transcript
+        assert "new reply" in transcript
+        assert count == 2
+
+    def test_full_window_retains_all(self):
+        msgs = _msgs(("user", "msg1"), ("assistant", "reply1"), ("user", "msg2"), ("assistant", "reply2"))
+        transcript, count = prepare_retention_transcript(msgs, retain_full_window=True)
+        assert "msg1" in transcript
+        assert "msg2" in transcript
+        assert count == 4
+
+    def test_strips_memory_tags(self):
+        msgs = _msgs(("user", "<hindsight_memories>leaked</hindsight_memories> actual question"))
+        transcript, _ = prepare_retention_transcript(msgs, retain_full_window=True)
+        assert "leaked" not in transcript
+        assert "actual question" in transcript
+
+    def test_filters_by_retain_roles(self):
+        msgs = _msgs(("user", "user msg"), ("assistant", "assistant msg"))
+        transcript, _ = prepare_retention_transcript(msgs, retain_roles=["user"], retain_full_window=True)
+        assert "user msg" in transcript
+        assert "assistant msg" not in transcript
+
+    def test_empty_messages_returns_none(self):
+        result, count = prepare_retention_transcript([])
+        assert result is None
+        assert count == 0
+
+    def test_role_markers_present(self):
+        msgs = _msgs(("user", "hello"))
+        transcript, _ = prepare_retention_transcript(msgs, retain_full_window=True)
+        assert "[role: user]" in transcript
+        assert "[user:end]" in transcript
+
+    def test_no_user_message_returns_none(self):
+        msgs = [{"role": "assistant", "content": "only assistant"}]
+        result, _ = prepare_retention_transcript(msgs, retain_full_window=False)
+        assert result is None
+
+    def test_json_format_with_tool_calls(self):
+        """When include_tool_calls=True, output should be JSON with tool_use blocks."""
+        import json
+
+        msgs = [
+            {"role": "user", "content": "edit the file"},
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "text", "text": "I'll edit that file."},
+                    {
+                        "type": "tool_use",
+                        "name": "Edit",
+                        "input": {"file_path": "/tmp/foo.py", "old_string": "old", "new_string": "new"},
+                    },
+                ],
+            },
+        ]
+        transcript, count = prepare_retention_transcript(
+            msgs, retain_full_window=True, include_tool_calls=True
+        )
+        assert transcript is not None
+        data = json.loads(transcript)
+        assert len(data) == 2
+        assert data[0]["role"] == "user"
+        assert data[1]["role"] == "assistant"
+        # Should have both text and tool_use blocks
+        block_types = [b["type"] for b in data[1]["content"]]
+        assert "text" in block_types
+        assert "tool_use" in block_types
+        # Tool input should be preserved
+        tool_block = next(b for b in data[1]["content"] if b["type"] == "tool_use")
+        assert tool_block["name"] == "Edit"
+        assert tool_block["input"]["file_path"] == "/tmp/foo.py"
+
+    def test_json_format_excludes_hindsight_mcp_tools(self):
+        """Hindsight MCP tools should be excluded even in JSON mode."""
+        import json
+
+        msgs = [
+            {"role": "user", "content": "recall something"},
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "text", "text": "Let me check."},
+                    {"type": "tool_use", "name": "mcp__hindsight__recall", "input": {"query": "test"}},
+                ],
+            },
+        ]
+        transcript, _ = prepare_retention_transcript(
+            msgs, retain_full_window=True, include_tool_calls=True
+        )
+        data = json.loads(transcript)
+        assistant_blocks = data[1]["content"]
+        assert len(assistant_blocks) == 1
+        assert assistant_blocks[0]["type"] == "text"
+
+    def test_json_format_includes_tool_results(self):
+        """Tool results should be included in JSON mode."""
+        import json
+
+        msgs = [
+            {"role": "user", "content": "run ls"},
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "text", "text": "Running ls."},
+                    {"type": "tool_use", "name": "Bash", "input": {"command": "ls"}},
+                ],
+            },
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "tool_result", "tool_use_id": "123", "content": "file1.py\nfile2.py"},
+                    {"type": "text", "text": "Here are the files."},
+                ],
+            },
+        ]
+        transcript, _ = prepare_retention_transcript(
+            msgs, retain_full_window=True, include_tool_calls=True
+        )
+        data = json.loads(transcript)
+        result_msg = next(m for m in data if any(b.get("type") == "tool_result" for b in m["content"]))
+        result_block = next(b for b in result_msg["content"] if b["type"] == "tool_result")
+        assert "file1.py" in result_block["content"]
+
+    def test_json_format_handles_list_content_tool_results(self):
+        """Tool results with list content (e.g. Agent subagent responses) should be extracted."""
+        import json
+
+        msgs = [
+            {"role": "user", "content": "analyze the code"},
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "tool_use", "name": "Agent", "input": {"prompt": "check code"}},
+                ],
+            },
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "toolu_abc",
+                        "content": [
+                            {"type": "text", "text": "Found 3 issues in the codebase."},
+                            {"type": "text", "text": "1. Missing error handling in auth module"},
+                        ],
+                    },
+                ],
+            },
+        ]
+        transcript, _ = prepare_retention_transcript(
+            msgs, retain_full_window=True, include_tool_calls=True
+        )
+        data = json.loads(transcript)
+        result_msg = next(m for m in data if any(b.get("type") == "tool_result" for b in m["content"]))
+        result_block = next(b for b in result_msg["content"] if b["type"] == "tool_result")
+        assert "Found 3 issues" in result_block["content"]
+        assert "Missing error handling" in result_block["content"]
+
+    def test_without_tool_calls_uses_text_format(self):
+        """Default (include_tool_calls=False) should use legacy text format."""
+        msgs = _msgs(("user", "hello"), ("assistant", "world"))
+        transcript, _ = prepare_retention_transcript(msgs, retain_full_window=True, include_tool_calls=False)
+        assert "[role: user]" in transcript
+        assert "[user:end]" in transcript

--- a/vendor/hindsight-memory/tests/test_hooks.py
+++ b/vendor/hindsight-memory/tests/test_hooks.py
@@ -1,0 +1,669 @@
+"""End-to-end tests for recall.py and retain.py hook scripts.
+
+Mocks the Claude Code hook runtime:
+  - stdin  → io.StringIO(json.dumps(hook_input))
+  - stdout → io.StringIO() captured for assertions
+  - urllib.request.urlopen → fake HTTP responses
+  - CLAUDE_PLUGIN_ROOT / CLAUDE_PLUGIN_DATA → temp dirs
+"""
+
+import importlib
+import io
+import json
+import os
+import sys
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from conftest import FakeHTTPResponse, make_hook_input, make_memory, make_transcript_file
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _run_hook(module_name, hook_input, monkeypatch, tmp_path, urlopen_side_effect=None, extra_env=None, extra_settings=None):
+    """Import and run a hook script's main() with mocked stdin/stdout/HTTP."""
+    # Isolated plugin dirs
+    monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(tmp_path / "plugin_root"))
+    monkeypatch.setenv("CLAUDE_PLUGIN_DATA", str(tmp_path / "plugin_data"))
+    (tmp_path / "plugin_root").mkdir(exist_ok=True)
+    (tmp_path / "plugin_data").mkdir(exist_ok=True)
+
+    # Strip real HINDSIGHT_* env vars and neutralize user config (~/.hindsight/claude-code.json)
+    for k in list(os.environ):
+        if k.startswith("HINDSIGHT_"):
+            monkeypatch.delenv(k, raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    for k, v in (extra_env or {}).items():
+        monkeypatch.setenv(k, v)
+
+    # Write a minimal settings.json enabling fast retains
+    settings = {"autoRecall": True, "autoRetain": True, "retainEveryNTurns": 1, "hindsightApiUrl": "http://fake:9077"}
+    if extra_settings:
+        settings.update(extra_settings)
+    (tmp_path / "plugin_root" / "settings.json").write_text(json.dumps(settings))
+
+    stdin_data = io.StringIO(json.dumps(hook_input))
+    stdout_capture = io.StringIO()
+
+    # Force reimport so the module picks up patched env / path
+    scripts_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "scripts"))
+    spec = importlib.util.spec_from_file_location(module_name, os.path.join(scripts_dir, f"{module_name}.py"))
+    mod = importlib.util.module_from_spec(spec)
+
+    default_response = FakeHTTPResponse({"results": []})
+    side_effect = urlopen_side_effect or (lambda *a, **kw: default_response)
+
+    with (
+        patch("sys.stdin", stdin_data),
+        patch("sys.stdout", stdout_capture),
+        patch("urllib.request.urlopen", side_effect=side_effect),
+    ):
+        spec.loader.exec_module(mod)
+        mod.main()
+
+    return stdout_capture.getvalue()
+
+
+# ---------------------------------------------------------------------------
+# recall hook
+# ---------------------------------------------------------------------------
+
+
+class TestRecallHook:
+    def test_outputs_additional_context_when_memories_found(self, monkeypatch, tmp_path):
+        memory = make_memory("Paris is the capital of France", "world")
+        response = FakeHTTPResponse({"results": [memory]})
+
+        hook_input = make_hook_input(prompt="What is the capital of France?")
+        output = _run_hook("recall", hook_input, monkeypatch, tmp_path, urlopen_side_effect=lambda *a, **kw: response)
+
+        data = json.loads(output)
+        context = data["hookSpecificOutput"]["additionalContext"]
+        assert "Paris is the capital of France" in context
+        assert "<hindsight_memories>" in context
+
+    def test_no_output_when_no_memories(self, monkeypatch, tmp_path):
+        hook_input = make_hook_input(prompt="hello there world")
+        output = _run_hook("recall", hook_input, monkeypatch, tmp_path)
+        # Empty stdout = no memories injected
+        assert output.strip() == ""
+
+    def test_no_output_for_short_prompt(self, monkeypatch, tmp_path):
+        hook_input = make_hook_input(prompt="hi")
+        output = _run_hook("recall", hook_input, monkeypatch, tmp_path)
+        assert output.strip() == ""
+
+    def test_graceful_on_api_error(self, monkeypatch, tmp_path):
+        def raise_error(*a, **kw):
+            raise OSError("connection refused")
+
+        hook_input = make_hook_input(prompt="What is my project about?")
+        # Should not raise — graceful degradation
+        output = _run_hook("recall", hook_input, monkeypatch, tmp_path, urlopen_side_effect=raise_error)
+        assert output.strip() == ""
+
+    def test_output_format_matches_claude_code_spec(self, monkeypatch, tmp_path):
+        memory = make_memory("User prefers Python")
+        response = FakeHTTPResponse({"results": [memory]})
+
+        hook_input = make_hook_input(prompt="What language should I use?")
+        output = _run_hook("recall", hook_input, monkeypatch, tmp_path, urlopen_side_effect=lambda *a, **kw: response)
+
+        data = json.loads(output)
+        assert data["hookSpecificOutput"]["hookEventName"] == "UserPromptSubmit"
+        assert "additionalContext" in data["hookSpecificOutput"]
+
+    def test_multi_turn_context_from_transcript(self, monkeypatch, tmp_path):
+        """When recallContextTurns > 1, prior transcript is included in query."""
+        messages = [
+            {"role": "user", "content": "I use Python for all my scripts"},
+            {"role": "assistant", "content": "Noted!"},
+        ]
+        transcript = make_transcript_file(tmp_path, messages)
+
+        # Override to use multi-turn recall
+        settings = {
+            "autoRecall": True,
+            "hindsightApiUrl": "http://fake:9077",
+            "recallContextTurns": 2,
+            "retainEveryNTurns": 1,
+            "autoRetain": True,
+        }
+        (tmp_path / "plugin_root").mkdir(exist_ok=True)
+        (tmp_path / "plugin_data").mkdir(exist_ok=True)
+
+        captured_body = {}
+
+        def capture_and_respond(req, timeout=None):
+            if "/recall" in req.full_url:
+                captured_body["body"] = json.loads(req.data.decode())
+            return FakeHTTPResponse({"results": []})
+
+        for k in list(os.environ):
+            if k.startswith("HINDSIGHT_"):
+                monkeypatch.delenv(k, raising=False)
+        monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(tmp_path / "plugin_root"))
+        monkeypatch.setenv("CLAUDE_PLUGIN_DATA", str(tmp_path / "plugin_data"))
+        (tmp_path / "plugin_root" / "settings.json").write_text(json.dumps(settings))
+
+        hook_input = make_hook_input(prompt="What language should I use?", transcript_path=transcript)
+        stdin_data = io.StringIO(json.dumps(hook_input))
+
+        scripts_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "scripts"))
+        spec = importlib.util.spec_from_file_location("recall", os.path.join(scripts_dir, "recall.py"))
+        mod = importlib.util.module_from_spec(spec)
+
+        with (
+            patch("sys.stdin", stdin_data),
+            patch("sys.stdout", io.StringIO()),
+            patch("urllib.request.urlopen", side_effect=capture_and_respond),
+        ):
+            spec.loader.exec_module(mod)
+            mod.main()
+
+        # The query should contain prior context from the transcript
+        if "body" in captured_body:
+            assert "Python" in captured_body["body"].get("query", "")
+
+    def test_disabled_auto_recall_produces_no_output(self, monkeypatch, tmp_path):
+        (tmp_path / "plugin_root").mkdir(exist_ok=True)
+        (tmp_path / "plugin_data").mkdir(exist_ok=True)
+        settings = {"autoRecall": False, "autoRetain": False, "hindsightApiUrl": "http://fake:9077"}
+        (tmp_path / "plugin_root" / "settings.json").write_text(json.dumps(settings))
+
+        for k in list(os.environ):
+            if k.startswith("HINDSIGHT_"):
+                monkeypatch.delenv(k, raising=False)
+        monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(tmp_path / "plugin_root"))
+        monkeypatch.setenv("CLAUDE_PLUGIN_DATA", str(tmp_path / "plugin_data"))
+
+        hook_input = make_hook_input(prompt="What is the capital of France?")
+        stdin_data = io.StringIO(json.dumps(hook_input))
+        stdout_capture = io.StringIO()
+
+        scripts_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "scripts"))
+        spec = importlib.util.spec_from_file_location("recall_disabled", os.path.join(scripts_dir, "recall.py"))
+        mod = importlib.util.module_from_spec(spec)
+
+        with patch("sys.stdin", stdin_data), patch("sys.stdout", stdout_capture):
+            spec.loader.exec_module(mod)
+            mod.main()
+
+        assert stdout_capture.getvalue().strip() == ""
+
+
+# ---------------------------------------------------------------------------
+# retain hook
+# ---------------------------------------------------------------------------
+
+
+class TestRetainHook:
+    def test_posts_transcript_to_hindsight(self, monkeypatch, tmp_path):
+        messages = [{"role": "user", "content": "hello"}, {"role": "assistant", "content": "world"}]
+        transcript = make_transcript_file(tmp_path, messages)
+
+        captured = {}
+
+        def capture(req, timeout=None):
+            if "/memories" in req.full_url and "/recall" not in req.full_url:
+                captured["body"] = json.loads(req.data.decode())
+            return FakeHTTPResponse({"status": "accepted"})
+
+        hook_input = make_hook_input(transcript_path=transcript)
+        _run_hook("retain", hook_input, monkeypatch, tmp_path, urlopen_side_effect=capture)
+
+        assert "body" in captured, "retain API was not called"
+        assert "hello" in captured["body"]["items"][0]["content"]
+
+    def test_no_retain_on_empty_transcript(self, monkeypatch, tmp_path):
+        hook_input = make_hook_input(transcript_path="/nonexistent/transcript.jsonl")
+        captured = {}
+
+        def capture(req, timeout=None):
+            if "/memories" in req.full_url:
+                captured["called"] = True
+            return FakeHTTPResponse({})
+
+        _run_hook("retain", hook_input, monkeypatch, tmp_path, urlopen_side_effect=capture)
+        assert "called" not in captured
+
+    def test_strips_memory_tags_before_retaining(self, monkeypatch, tmp_path):
+        messages = [
+            {"role": "user", "content": "<hindsight_memories>old memories</hindsight_memories> actual question"},
+            {"role": "assistant", "content": "sure!"},
+        ]
+        transcript = make_transcript_file(tmp_path, messages)
+        captured = {}
+
+        def capture(req, timeout=None):
+            if "/memories" in req.full_url and "/recall" not in req.full_url:
+                captured["body"] = json.loads(req.data.decode())
+            return FakeHTTPResponse({})
+
+        hook_input = make_hook_input(transcript_path=transcript)
+        _run_hook("retain", hook_input, monkeypatch, tmp_path, urlopen_side_effect=capture)
+
+        if "body" in captured:
+            content = captured["body"]["items"][0]["content"]
+            assert "old memories" not in content
+            assert "actual question" in content
+
+    def test_retain_tags_with_template_variables(self, monkeypatch, tmp_path):
+        """retainTags config should resolve template variables like {session_id}."""
+        messages = [{"role": "user", "content": "hello"}, {"role": "assistant", "content": "world"}]
+        transcript = make_transcript_file(tmp_path, messages)
+        hook_input = make_hook_input(transcript_path=transcript, session_id="sess-tag-test")
+        captured = {}
+
+        def capture(req, timeout=None):
+            if "/memories" in req.full_url and "/recall" not in req.full_url:
+                captured["body"] = json.loads(req.data.decode())
+            return FakeHTTPResponse({})
+
+        _run_hook(
+            "retain", hook_input, monkeypatch, tmp_path,
+            urlopen_side_effect=capture,
+            extra_settings={"retainTags": ["{session_id}", "claude-code", "custom-tag"]},
+        )
+
+        assert "body" in captured, "retain API was not called"
+        item = captured["body"]["items"][0]
+        assert item["tags"] == ["sess-tag-test", "claude-code", "custom-tag"]
+
+    def test_retain_tag_resolves_user_id_when_env_set(self, monkeypatch, tmp_path):
+        """retainTags with {user_id} resolves from HINDSIGHT_USER_ID env var."""
+        messages = [{"role": "user", "content": "hello"}, {"role": "assistant", "content": "world"}]
+        transcript = make_transcript_file(tmp_path, messages)
+        hook_input = make_hook_input(transcript_path=transcript, session_id="sess-user-test")
+        captured = {}
+
+        def capture(req, timeout=None):
+            if "/memories" in req.full_url and "/recall" not in req.full_url:
+                captured["body"] = json.loads(req.data.decode())
+            return FakeHTTPResponse({})
+
+        _run_hook(
+            "retain", hook_input, monkeypatch, tmp_path,
+            urlopen_side_effect=capture,
+            extra_env={"HINDSIGHT_USER_ID": "alice"},
+            extra_settings={"retainTags": ["user:{user_id}", "session:{session_id}"]},
+        )
+
+        assert "body" in captured, "retain API was not called"
+        item = captured["body"]["items"][0]
+        assert item["tags"] == ["user:alice", "session:sess-user-test"]
+
+    def test_retain_tag_dropped_when_user_id_env_unset(self, monkeypatch, tmp_path):
+        """user:{user_id} resolves to 'user:' and is dropped when env is unset; other tags survive."""
+        messages = [{"role": "user", "content": "hello"}, {"role": "assistant", "content": "world"}]
+        transcript = make_transcript_file(tmp_path, messages)
+        hook_input = make_hook_input(transcript_path=transcript, session_id="sess-drop-test")
+        captured = {}
+
+        def capture(req, timeout=None):
+            if "/memories" in req.full_url and "/recall" not in req.full_url:
+                captured["body"] = json.loads(req.data.decode())
+            return FakeHTTPResponse({})
+
+        _run_hook(
+            "retain", hook_input, monkeypatch, tmp_path,
+            urlopen_side_effect=capture,
+            extra_settings={"retainTags": ["user:{user_id}", "session:{session_id}"]},
+        )
+
+        assert "body" in captured, "retain API was not called"
+        item = captured["body"]["items"][0]
+        assert item["tags"] == ["session:sess-drop-test"]
+        assert not any(t.startswith("user:") for t in item["tags"])
+
+    def test_retain_tag_without_colon_preserved(self, monkeypatch, tmp_path):
+        """Tags without ':' are never dropped, regardless of env state."""
+        # _run_hook strips all HINDSIGHT_* env vars, so unset state is the default.
+        messages = [{"role": "user", "content": "hello"}, {"role": "assistant", "content": "world"}]
+        transcript = make_transcript_file(tmp_path, messages)
+        hook_input = make_hook_input(transcript_path=transcript, session_id="sess-plain")
+        captured = {}
+
+        def capture(req, timeout=None):
+            if "/memories" in req.full_url and "/recall" not in req.full_url:
+                captured["body"] = json.loads(req.data.decode())
+            return FakeHTTPResponse({})
+
+        _run_hook(
+            "retain", hook_input, monkeypatch, tmp_path,
+            urlopen_side_effect=capture,
+            extra_settings={"retainTags": ["plain-tag", "another"]},
+        )
+
+        assert "body" in captured, "retain API was not called"
+        item = captured["body"]["items"][0]
+        assert item["tags"] == ["plain-tag", "another"]
+
+    def test_retain_tag_all_dropped_yields_no_tags_field(self, monkeypatch, tmp_path):
+        """If all tags resolve to dangling, the outgoing request omits the tags field."""
+        # _run_hook strips all HINDSIGHT_* env vars, so unset state is the default.
+        messages = [{"role": "user", "content": "hello"}, {"role": "assistant", "content": "world"}]
+        transcript = make_transcript_file(tmp_path, messages)
+        hook_input = make_hook_input(transcript_path=transcript, session_id="sess-none")
+        captured = {}
+
+        def capture(req, timeout=None):
+            if "/memories" in req.full_url and "/recall" not in req.full_url:
+                captured["body"] = json.loads(req.data.decode())
+            return FakeHTTPResponse({})
+
+        _run_hook(
+            "retain", hook_input, monkeypatch, tmp_path,
+            urlopen_side_effect=capture,
+            extra_settings={"retainTags": ["user:{user_id}"]},
+        )
+
+        assert "body" in captured, "retain API was not called"
+        item = captured["body"]["items"][0]
+        # HindsightClient.retain only sets item["tags"] if tags is truthy (client.py:144).
+        # With all tags dropped, retain.py sets tags=None, so "tags" is absent from item.
+        assert "tags" not in item
+
+    def test_retain_custom_metadata(self, monkeypatch, tmp_path):
+        """retainMetadata config should be merged with built-in metadata."""
+        messages = [{"role": "user", "content": "hello"}, {"role": "assistant", "content": "world"}]
+        transcript = make_transcript_file(tmp_path, messages)
+        hook_input = make_hook_input(transcript_path=transcript, session_id="sess-meta-test")
+        captured = {}
+
+        def capture(req, timeout=None):
+            if "/memories" in req.full_url and "/recall" not in req.full_url:
+                captured["body"] = json.loads(req.data.decode())
+            return FakeHTTPResponse({})
+
+        _run_hook(
+            "retain", hook_input, monkeypatch, tmp_path,
+            urlopen_side_effect=capture,
+            extra_settings={"retainMetadata": {"project": "my-project", "session": "{session_id}"}},
+        )
+
+        assert "body" in captured, "retain API was not called"
+        meta = captured["body"]["items"][0]["metadata"]
+        # Built-in metadata
+        assert meta["session_id"] == "sess-meta-test"
+        assert "retained_at" in meta
+        # Custom metadata with template resolution
+        assert meta["project"] == "my-project"
+        assert meta["session"] == "sess-meta-test"
+
+    def test_full_session_uses_session_id_as_document_id(self, monkeypatch, tmp_path):
+        """In full-session mode, document_id should be the session_id (for upsert)."""
+        messages = [
+            {"role": "user", "content": "first question"},
+            {"role": "assistant", "content": "first answer"},
+            {"role": "user", "content": "second question"},
+            {"role": "assistant", "content": "second answer"},
+        ]
+        transcript = make_transcript_file(tmp_path, messages)
+        hook_input = make_hook_input(transcript_path=transcript, session_id="sess-full-123")
+        captured = {}
+
+        def capture(req, timeout=None):
+            if "/memories" in req.full_url and "/recall" not in req.full_url:
+                captured["body"] = json.loads(req.data.decode())
+            return FakeHTTPResponse({})
+
+        _run_hook("retain", hook_input, monkeypatch, tmp_path, urlopen_side_effect=capture)
+
+        assert "body" in captured, "retain API was not called"
+        item = captured["body"]["items"][0]
+        # document_id should be just the session_id, no timestamp suffix
+        assert item["document_id"] == "sess-full-123"
+        # Should contain ALL messages, not just the last turn
+        assert "first question" in item["content"]
+        assert "second question" in item["content"]
+
+    def test_full_session_new_document_after_compaction(self, monkeypatch, tmp_path):
+        """After compaction shrinks the transcript, retain should use a new document_id
+        to avoid overwriting the pre-compaction document."""
+        # First retain: 4 messages
+        messages_full = [
+            {"role": "user", "content": "first question"},
+            {"role": "assistant", "content": "first answer"},
+            {"role": "user", "content": "second question"},
+            {"role": "assistant", "content": "second answer"},
+        ]
+        transcript = make_transcript_file(tmp_path, messages_full)
+        hook_input = make_hook_input(transcript_path=transcript, session_id="sess-compact-test")
+        captured_calls = []
+
+        def capture(req, timeout=None):
+            if "/memories" in req.full_url and "/recall" not in req.full_url:
+                captured_calls.append(json.loads(req.data.decode()))
+            return FakeHTTPResponse({})
+
+        _run_hook("retain", hook_input, monkeypatch, tmp_path, urlopen_side_effect=capture)
+
+        assert len(captured_calls) == 1
+        assert captured_calls[0]["items"][0]["document_id"] == "sess-compact-test"
+        assert "first question" in captured_calls[0]["items"][0]["content"]
+
+        # Second retain: compaction happened — transcript now has only 2 messages
+        messages_compacted = [
+            {"role": "user", "content": "third question"},
+            {"role": "assistant", "content": "third answer"},
+        ]
+        transcript = make_transcript_file(tmp_path, messages_compacted)
+        hook_input = make_hook_input(transcript_path=transcript, session_id="sess-compact-test")
+
+        _run_hook("retain", hook_input, monkeypatch, tmp_path, urlopen_side_effect=capture)
+
+        assert len(captured_calls) == 2
+        # Should use a new document_id with chunk suffix
+        assert captured_calls[1]["items"][0]["document_id"] == "sess-compact-test-c1"
+        assert "third question" in captured_calls[1]["items"][0]["content"]
+
+    def test_full_session_same_document_when_growing(self, monkeypatch, tmp_path):
+        """When transcript grows (no compaction), retain should keep the same document_id."""
+        messages_2 = [
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "world"},
+        ]
+        transcript = make_transcript_file(tmp_path, messages_2)
+        hook_input = make_hook_input(transcript_path=transcript, session_id="sess-grow-test")
+        captured_calls = []
+
+        def capture(req, timeout=None):
+            if "/memories" in req.full_url and "/recall" not in req.full_url:
+                captured_calls.append(json.loads(req.data.decode()))
+            return FakeHTTPResponse({})
+
+        _run_hook("retain", hook_input, monkeypatch, tmp_path, urlopen_side_effect=capture)
+
+        # Second retain: transcript grew to 4 messages
+        messages_4 = messages_2 + [
+            {"role": "user", "content": "more stuff"},
+            {"role": "assistant", "content": "more response"},
+        ]
+        transcript = make_transcript_file(tmp_path, messages_4)
+        hook_input = make_hook_input(transcript_path=transcript, session_id="sess-grow-test")
+
+        _run_hook("retain", hook_input, monkeypatch, tmp_path, urlopen_side_effect=capture)
+
+        assert len(captured_calls) == 2
+        # Both should use the same plain session_id
+        assert captured_calls[0]["items"][0]["document_id"] == "sess-grow-test"
+        assert captured_calls[1]["items"][0]["document_id"] == "sess-grow-test"
+
+    def test_full_session_respects_retain_every_n_turns(self, monkeypatch, tmp_path):
+        """In full-session mode, retainEveryNTurns should still gate when retain fires."""
+        messages = [{"role": "user", "content": "hello"}, {"role": "assistant", "content": "world"}]
+        transcript = make_transcript_file(tmp_path, messages)
+        hook_input = make_hook_input(transcript_path=transcript, session_id="sess-throttle")
+        captured = {}
+
+        def capture(req, timeout=None):
+            if "/memories" in req.full_url and "/recall" not in req.full_url:
+                captured["called"] = True
+                captured["body"] = json.loads(req.data.decode())
+            return FakeHTTPResponse({})
+
+        # retainEveryNTurns=3 in full-session mode — first 2 calls should be skipped
+        _run_hook(
+            "retain", hook_input, monkeypatch, tmp_path,
+            urlopen_side_effect=capture,
+            extra_settings={"retainEveryNTurns": 3},
+        )
+        # Turn 1 of 3 — should NOT retain
+        assert "called" not in captured
+
+        # Turn 2 — still skip
+        captured.clear()
+        _run_hook(
+            "retain", hook_input, monkeypatch, tmp_path,
+            urlopen_side_effect=capture,
+            extra_settings={"retainEveryNTurns": 3},
+        )
+        assert "called" not in captured
+
+        # Turn 3 — should fire, with full session content and session_id as doc ID
+        captured.clear()
+        _run_hook(
+            "retain", hook_input, monkeypatch, tmp_path,
+            urlopen_side_effect=capture,
+            extra_settings={"retainEveryNTurns": 3},
+        )
+        assert "called" in captured, "retain should fire on turn 3"
+        item = captured["body"]["items"][0]
+        assert item["document_id"] == "sess-throttle"  # full-session uses session_id
+        assert "hello" in item["content"]
+
+    def test_chunked_retain_skips_below_threshold(self, monkeypatch, tmp_path):
+        """With retainEveryNTurns=5 and retainMode=chunked, first call should be skipped."""
+        (tmp_path / "plugin_root").mkdir(exist_ok=True)
+        (tmp_path / "plugin_data").mkdir(exist_ok=True)
+        settings = {
+            "autoRetain": True,
+            "autoRecall": True,
+            "retainMode": "chunked",
+            "retainEveryNTurns": 5,
+            "hindsightApiUrl": "http://fake:9077",
+        }
+        (tmp_path / "plugin_root" / "settings.json").write_text(json.dumps(settings))
+
+        messages = [{"role": "user", "content": "hello"}, {"role": "assistant", "content": "hi"}]
+        transcript = make_transcript_file(tmp_path, messages)
+        hook_input = make_hook_input(transcript_path=transcript)
+
+        captured = {}
+
+        def capture(req, timeout=None):
+            if "/memories" in req.full_url and "/recall" not in req.full_url:
+                captured["called"] = True
+            return FakeHTTPResponse({})
+
+        for k in list(os.environ):
+            if k.startswith("HINDSIGHT_"):
+                monkeypatch.delenv(k, raising=False)
+        monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(tmp_path / "plugin_root"))
+        monkeypatch.setenv("CLAUDE_PLUGIN_DATA", str(tmp_path / "plugin_data"))
+        monkeypatch.setenv("HINDSIGHT_RETAIN_MODE", "chunked")
+        monkeypatch.setenv("HOME", str(tmp_path))
+
+        stdin_data = io.StringIO(json.dumps(hook_input))
+        scripts_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "scripts"))
+        spec = importlib.util.spec_from_file_location("retain_chunked", os.path.join(scripts_dir, "retain.py"))
+        mod = importlib.util.module_from_spec(spec)
+
+        with (
+            patch("sys.stdin", stdin_data),
+            patch("sys.stdout", io.StringIO()),
+            patch("urllib.request.urlopen", side_effect=capture),
+        ):
+            spec.loader.exec_module(mod)
+            mod.main()
+
+        # Turn 1 of 5 — should NOT retain
+        assert "called" not in captured
+
+    def test_graceful_on_retain_api_error(self, monkeypatch, tmp_path):
+        messages = [{"role": "user", "content": "test message"}, {"role": "assistant", "content": "response"}]
+        transcript = make_transcript_file(tmp_path, messages)
+        hook_input = make_hook_input(transcript_path=transcript)
+
+        def raise_error(req, timeout=None):
+            if "/memories" in req.full_url:
+                raise OSError("connection refused")
+            return FakeHTTPResponse({})
+
+        # Should not raise
+        _run_hook("retain", hook_input, monkeypatch, tmp_path, urlopen_side_effect=raise_error)
+
+    def test_retain_posts_async_true(self, monkeypatch, tmp_path):
+        messages = [{"role": "user", "content": "hello"}, {"role": "assistant", "content": "world"}]
+        transcript = make_transcript_file(tmp_path, messages)
+        hook_input = make_hook_input(transcript_path=transcript)
+        captured = {}
+
+        def capture(req, timeout=None):
+            if "/memories" in req.full_url and "/recall" not in req.full_url:
+                captured["body"] = json.loads(req.data.decode())
+            return FakeHTTPResponse({})
+
+        _run_hook("retain", hook_input, monkeypatch, tmp_path, urlopen_side_effect=capture)
+
+        if "body" in captured:
+            assert captured["body"].get("async") is True
+
+    def test_retain_includes_context_label(self, monkeypatch, tmp_path):
+        messages = [{"role": "user", "content": "hello"}, {"role": "assistant", "content": "world"}]
+        transcript = make_transcript_file(tmp_path, messages)
+        hook_input = make_hook_input(transcript_path=transcript)
+        captured = {}
+
+        def capture(req, timeout=None):
+            if "/memories" in req.full_url and "/recall" not in req.full_url:
+                captured["body"] = json.loads(req.data.decode())
+            return FakeHTTPResponse({})
+
+        _run_hook("retain", hook_input, monkeypatch, tmp_path, urlopen_side_effect=capture)
+
+        if "body" in captured:
+            assert captured["body"]["items"][0]["context"] == "claude-code"
+
+    def test_disabled_auto_retain_does_not_call_api(self, monkeypatch, tmp_path):
+        (tmp_path / "plugin_root").mkdir(exist_ok=True)
+        (tmp_path / "plugin_data").mkdir(exist_ok=True)
+        settings = {"autoRetain": False, "autoRecall": False, "hindsightApiUrl": "http://fake:9077"}
+        (tmp_path / "plugin_root" / "settings.json").write_text(json.dumps(settings))
+
+        messages = [{"role": "user", "content": "hello"}]
+        transcript = make_transcript_file(tmp_path, messages)
+        hook_input = make_hook_input(transcript_path=transcript)
+        captured = {}
+
+        def capture(req, timeout=None):
+            captured["called"] = True
+            return FakeHTTPResponse({})
+
+        for k in list(os.environ):
+            if k.startswith("HINDSIGHT_"):
+                monkeypatch.delenv(k, raising=False)
+        monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(tmp_path / "plugin_root"))
+        monkeypatch.setenv("CLAUDE_PLUGIN_DATA", str(tmp_path / "plugin_data"))
+
+        stdin_data = io.StringIO(json.dumps(hook_input))
+        scripts_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "scripts"))
+        spec = importlib.util.spec_from_file_location("retain_disabled", os.path.join(scripts_dir, "retain.py"))
+        mod = importlib.util.module_from_spec(spec)
+
+        with (
+            patch("sys.stdin", stdin_data),
+            patch("sys.stdout", io.StringIO()),
+            patch("urllib.request.urlopen", side_effect=capture),
+        ):
+            spec.loader.exec_module(mod)
+            mod.main()
+
+        assert "called" not in captured

--- a/vendor/hindsight-memory/tests/test_manifest.py
+++ b/vendor/hindsight-memory/tests/test_manifest.py
@@ -1,0 +1,14 @@
+"""Validate that JSON manifests are strict-valid JSON (no trailing commas, etc.)."""
+
+import json
+from pathlib import Path
+
+INTEGRATION_ROOT = Path(__file__).resolve().parent.parent
+
+
+def test_hooks_json_is_valid():
+    path = INTEGRATION_ROOT / "hooks" / "hooks.json"
+    raw = path.read_text()
+    parsed = json.loads(raw)
+    assert "hooks" in parsed
+    assert isinstance(parsed["hooks"], dict)

--- a/vendor/hindsight-memory/tests/test_state.py
+++ b/vendor/hindsight-memory/tests/test_state.py
@@ -1,0 +1,125 @@
+"""Unit tests for lib/state.py — retention tracking and compaction detection."""
+
+import json
+
+import pytest
+
+from lib.state import read_state, track_retention, write_state
+
+
+@pytest.fixture(autouse=True)
+def _isolated_state(monkeypatch, tmp_path):
+    """Point all state operations at a temp directory."""
+    monkeypatch.setenv("CLAUDE_PLUGIN_DATA", str(tmp_path))
+
+
+# ---------------------------------------------------------------------------
+# track_retention — core compaction detection
+# ---------------------------------------------------------------------------
+
+
+class TestTrackRetention:
+    def test_first_call_returns_chunk_zero(self):
+        chunk, compacted = track_retention("sess-1", 10)
+        assert chunk == 0
+        assert compacted is False
+
+    def test_growing_transcript_keeps_same_chunk(self):
+        track_retention("sess-1", 4)
+        chunk, compacted = track_retention("sess-1", 8)
+        assert chunk == 0
+        assert compacted is False
+
+    def test_equal_count_keeps_same_chunk(self):
+        track_retention("sess-1", 5)
+        chunk, compacted = track_retention("sess-1", 5)
+        assert chunk == 0
+        assert compacted is False
+
+    def test_shrinking_transcript_triggers_compaction(self):
+        track_retention("sess-1", 10)
+        chunk, compacted = track_retention("sess-1", 3)
+        assert chunk == 1
+        assert compacted is True
+
+    def test_multiple_compactions_increment_chunk(self):
+        track_retention("sess-1", 10)
+
+        chunk, compacted = track_retention("sess-1", 3)
+        assert chunk == 1
+        assert compacted is True
+
+        # Grow again after compaction
+        track_retention("sess-1", 8)
+
+        # Second compaction
+        chunk, compacted = track_retention("sess-1", 2)
+        assert chunk == 2
+        assert compacted is True
+
+    def test_growth_after_compaction_stays_on_same_chunk(self):
+        track_retention("sess-1", 10)
+        track_retention("sess-1", 3)  # compaction → chunk 1
+
+        chunk, compacted = track_retention("sess-1", 6)
+        assert chunk == 1
+        assert compacted is False
+
+    def test_sessions_are_independent(self):
+        track_retention("sess-a", 10)
+        track_retention("sess-b", 20)
+
+        # Compaction on sess-a only
+        chunk_a, compacted_a = track_retention("sess-a", 3)
+        chunk_b, compacted_b = track_retention("sess-b", 25)
+
+        assert chunk_a == 1
+        assert compacted_a is True
+        assert chunk_b == 0
+        assert compacted_b is False
+
+    def test_persists_across_calls(self, tmp_path):
+        """State file is written to disk and survives between calls."""
+        track_retention("sess-1", 10)
+
+        # Verify the state file exists
+        state_file = tmp_path / "state" / "retention_tracking.json"
+        assert state_file.exists()
+
+        data = json.loads(state_file.read_text())
+        assert data["sess-1"]["message_count"] == 10
+        assert data["sess-1"]["chunk"] == 0
+
+    def test_compaction_from_one_message(self):
+        """Edge case: transcript shrinks to a single message."""
+        track_retention("sess-1", 50)
+        chunk, compacted = track_retention("sess-1", 1)
+        assert chunk == 1
+        assert compacted is True
+
+    def test_shrink_by_one_triggers_compaction(self):
+        """Even shrinking by a single message counts as compaction."""
+        track_retention("sess-1", 10)
+        chunk, compacted = track_retention("sess-1", 9)
+        assert chunk == 1
+        assert compacted is True
+
+
+# ---------------------------------------------------------------------------
+# read_state / write_state basics
+# ---------------------------------------------------------------------------
+
+
+class TestReadWriteState:
+    def test_read_nonexistent_returns_default(self):
+        assert read_state("does_not_exist.json") is None
+        assert read_state("does_not_exist.json", {"key": "val"}) == {"key": "val"}
+
+    def test_write_then_read_roundtrips(self):
+        write_state("test_roundtrip.json", {"foo": 42})
+        assert read_state("test_roundtrip.json") == {"foo": 42}
+
+    def test_write_overwrites_previous(self):
+        write_state("test_overwrite.json", {"v": 1})
+        write_state("test_overwrite.json", {"v": 2})
+        assert read_state("test_overwrite.json") == {"v": 2}


### PR DESCRIPTION
Closes #448. Part of #438.

## Summary

- Refresh `vendor/hindsight-memory/` from upstream `vectorize-io/hindsight` at `cdc26daa` (`release(claude-code): v0.4.0`).
- Bump `dependencies.json` `hindsight.client` to `"0.4.0"`.
- Preserve switchroom-local `lib/directives.py` patch + re-apply directive integration on the new `recall.py`.

## What this brings in from upstream

| PR | Fix |
| --- | --- |
| vectorize-io/hindsight#1222 | Prevent compaction from overwriting retained memories — directly relevant to switchroom's 24/7 `--continue` model. |
| vectorize-io/hindsight#1152 | Stop hook retains correctly when `retainEveryNTurns > 1`. |
| vectorize-io/hindsight#1153 | `recallAdditionalBanks` setting — foundation for the per-user + shared-knowledge bank pattern (Tier 2 of #438). |
| vectorize-io/hindsight#1161 | `{user_id}` template variable for `retainTags` / `retainMetadata`. |
| vectorize-io/hindsight#1226 | Robust handling of list-content tool_results in transcript parsing. |

## Switchroom-local patches preserved

- `scripts/lib/directives.py` — workaround for upstream vectorize-io/hindsight#1269 (tagged directives silently dropped from `reflect`); surfaces directives client-side as a structurally distinct top-of-prompt block.
- `scripts/recall.py` — re-applied directive integration on top of the new upstream recall body. Directives are fetched independently of recall, emitted ABOVE the memories block, and a recall API failure no longer blinds the agent to its own active directives.
- `scripts/tests/test_directives.py` + `scripts/tests/test_recall_integration.py` — switchroom-owned tests covering the directive integration. All 24 pass against the new recall.py.

## Verification

| Check | Result |
| --- | --- |
| `npm run lint` | clean |
| `python3 -m pytest vendor/hindsight-memory/scripts/tests` | 24/24 pass |
| `python3 -m pytest vendor/hindsight-memory/tests` (upstream's own suite) | 150/150 pass |
| `npm run test:vitest` | 3991 pass, 1 pre-existing failure |

The pre-existing vitest failure is `telegram-plugin/tests/resolve-calling-subagent.test.ts` (imports `bun:test` and is loaded by vitest) — confirmed present on bare `upstream/main` with `git stash` of my changes. Not introduced by this PR.

## Test plan

- [ ] Bump merges cleanly with no rebase pain on top of main.
- [ ] `switchroom agent restart all` on a host with the v0.3.0 plugin reloads with the v0.4.0 plugin and recall continues to fire.
- [ ] Existing agents' bank state survives the bump (no schema break — settings.json keys are backwards-compatible).
- [ ] An agent with at least one active directive still sees a directives block in its `additionalContext` after the upgrade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)