### PR TITLE
feat(scaffold): seed default retainMission for new agents

### DIFF
--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -37,7 +37,7 @@ import {
 import { getHindsightSettingsEntry, getSwitchroomMcpSettingsEntry, getBuiltinDefaultMcpEntries } from "../memory/scaffold-integration.js";
 import { applyTelegramProgressGuidance, applyCronTelegramGuidance } from "./sub-agent-telegram-prompt.js";
 import type { McpServerConfig } from "../memory/hindsight.js";
-import { createBank, updateBankMissions, ensureUserProfileMentalModel } from "../memory/hindsight.js";
+import { createBank, updateBankMissions, ensureUserProfileMentalModel, DEFAULT_RETAIN_MISSION } from "../memory/hindsight.js";
 import { loadTopicState } from "../telegram/state.js";
 import { resolveDualPath } from "../config/paths.js";
 import { resolvePath } from "../config/loader.js";
@@ -1867,30 +1867,39 @@ export function scaffoldAgent(
 
     // Update bank missions and ensure user-profile MM — both gated on the
     // bank actually existing.
+    //
+    // Mission selection: explicit user yaml wins. When the operator hasn't
+    // set a `retain_mission`, scaffold (NOT reconcile) seeds the upstream-
+    // recommended default — this lifts retained memory quality on fresh
+    // agents without touching agents that already have a customized
+    // mission. `reconcileAgent` deliberately does not push the default,
+    // so existing agents' Hindsight-side missions stay untouched.
     bankOpsChain.then((bankReady) => {
       if (!bankReady) return;
 
-      if (agentConfig.memory?.bank_mission || agentConfig.memory?.retain_mission) {
-        const missions: { bank_mission?: string; retain_mission?: string } = {};
-        if (agentConfig.memory?.bank_mission) {
-          missions.bank_mission = agentConfig.memory.bank_mission;
-        }
-        if (agentConfig.memory?.retain_mission) {
-          missions.retain_mission = agentConfig.memory.retain_mission;
-        }
+      const userBankMission = agentConfig.memory?.bank_mission;
+      const userRetainMission = agentConfig.memory?.retain_mission;
+      const seededRetainMission = userRetainMission ?? DEFAULT_RETAIN_MISSION;
 
-        updateBankMissions(apiUrl, hindsightBankId, missions, { timeoutMs: 5000 })
-          .then((result) => {
-            if (result.ok) {
-              console.log(`  ${chalk.green("✓")} Bank missions updated for ${formatAgentBankLabel(name, hindsightBankId)}`);
-            } else {
-              console.warn(`  ${chalk.yellow("⚠")} Failed to update bank missions for ${formatAgentBankLabel(name, hindsightBankId)}: ${result.reason}`);
-            }
-          })
-          .catch((err) => {
-            console.warn(`  ${chalk.yellow("⚠")} Bank mission update error for ${formatAgentBankLabel(name, hindsightBankId)}: ${err}`);
-          });
+      const missions: { bank_mission?: string; retain_mission?: string } = {
+        retain_mission: seededRetainMission,
+      };
+      if (userBankMission) {
+        missions.bank_mission = userBankMission;
       }
+
+      updateBankMissions(apiUrl, hindsightBankId, missions, { timeoutMs: 5000 })
+        .then((result) => {
+          if (result.ok) {
+            const note = userRetainMission ? "(custom retain_mission)" : "(default retain_mission)";
+            console.log(`  ${chalk.green("✓")} Bank missions updated for ${formatAgentBankLabel(name, hindsightBankId)} ${chalk.dim(note)}`);
+          } else {
+            console.warn(`  ${chalk.yellow("⚠")} Failed to update bank missions for ${formatAgentBankLabel(name, hindsightBankId)}: ${result.reason}`);
+          }
+        })
+        .catch((err) => {
+          console.warn(`  ${chalk.yellow("⚠")} Bank mission update error for ${formatAgentBankLabel(name, hindsightBankId)}: ${err}`);
+        });
 
       ensureUserProfileMentalModel(apiUrl, hindsightBankId, { timeoutMs: 5000 })
         .then((result) => {

--- a/src/memory/hindsight.ts
+++ b/src/memory/hindsight.ts
@@ -89,6 +89,30 @@ export function isStrictIsolation(
 }
 
 /**
+ * Recommended default `retain_mission` for new agents.
+ *
+ * Sourced verbatim from upstream Hindsight's per-user-memory guide:
+ *   https://github.com/vectorize-io/hindsight/blob/main/hindsight-docs/guides/2026-04-15-guide-openclaw-per-user-memory-across-channels-setup.md
+ *   (lines 188–193)
+ *
+ * The mission shapes the LLM extraction step that fires inside
+ * Hindsight's auto-retain. Tighter wording here directly lifts retained
+ * memory quality (less conversational filler stored, fewer marginal hits
+ * surfacing in subsequent recalls).
+ *
+ * Switchroom seeds this for newly scaffolded agents only (see
+ * `scaffoldAgent` in `src/agents/scaffold.ts`). Existing agents'
+ * missions are left alone — operators may have customized them, and
+ * `reconcileAgent` does not push a default. Operators can always
+ * override per-agent via `agents.<name>.memory.retain_mission` in
+ * `switchroom.yaml`.
+ */
+export const DEFAULT_RETAIN_MISSION =
+  "Extract user preferences, ongoing projects, recurring commitments, " +
+  "important context, and durable facts that should help across future " +
+  "conversations. Skip one-off chatter and temporary task noise.";
+
+/**
  * Parse a Hindsight MCP response body.
  *
  * Hindsight's MCP server returns text/event-stream responses of the form:

--- a/tests/memory.bank-missions.test.ts
+++ b/tests/memory.bank-missions.test.ts
@@ -1,5 +1,47 @@
 import { describe, it, expect, vi } from "vitest";
-import { updateBankMissions } from "../src/memory/hindsight.js";
+import { updateBankMissions, DEFAULT_RETAIN_MISSION } from "../src/memory/hindsight.js";
+
+describe("DEFAULT_RETAIN_MISSION", () => {
+  it("matches upstream Hindsight per-user-memory guide wording", () => {
+    // Sourced verbatim from
+    // hindsight-docs/guides/2026-04-15-guide-openclaw-per-user-memory-across-channels-setup.md
+    // lines 188-193.
+    expect(DEFAULT_RETAIN_MISSION).toBe(
+      "Extract user preferences, ongoing projects, recurring commitments, " +
+        "important context, and durable facts that should help across future " +
+        "conversations. Skip one-off chatter and temporary task noise.",
+    );
+  });
+
+  it("explicitly tells extraction to skip conversational filler", () => {
+    expect(DEFAULT_RETAIN_MISSION).toContain("Skip one-off chatter");
+    expect(DEFAULT_RETAIN_MISSION).toContain("temporary task noise");
+  });
+
+  it("focuses on durable, cross-conversation signal", () => {
+    expect(DEFAULT_RETAIN_MISSION).toContain("durable facts");
+    expect(DEFAULT_RETAIN_MISSION).toContain("across future");
+  });
+});
+
+describe("scaffold seed wiring", () => {
+  // Source-structure assertion: scaffold imports the constant and uses
+  // it as the retain_mission default, while reconcile does NOT (existing
+  // agents' missions stay untouched).
+  it("scaffold imports DEFAULT_RETAIN_MISSION but reconcile path does not seed it", () => {
+    const fs = require("fs");
+    const scaffoldSource = fs.readFileSync("src/agents/scaffold.ts", "utf-8");
+    expect(scaffoldSource).toContain("DEFAULT_RETAIN_MISSION");
+    expect(scaffoldSource).toContain("seededRetainMission = userRetainMission ?? DEFAULT_RETAIN_MISSION");
+    // The reconcile-side bank-mission update block must remain
+    // explicit-only (the original `if user yaml has missions` gate).
+    // Asserting both forms exist guards against an accidental copy of
+    // the seed-default behaviour into reconcile.
+    expect(scaffoldSource).toContain(
+      "if (agentConfig.memory?.bank_mission || agentConfig.memory?.retain_mission)",
+    );
+  });
+});
 
 describe("updateBankMissions", () => {
   it("calls update_bank with both missions when provided", async () => {


### PR DESCRIPTION
Closes #452. Part of #438.

## Summary

- New constant `DEFAULT_RETAIN_MISSION` in `src/memory/hindsight.ts`, sourced verbatim from upstream Hindsight's per-user-memory guide:

  > Extract user preferences, ongoing projects, recurring commitments, important context, and durable facts that should help across future conversations. Skip one-off chatter and temporary task noise.

- `scaffoldAgent` seeds this for new agents whose operator hasn't set `agents.<name>.memory.retain_mission` in `switchroom.yaml`. Explicit user yaml always wins.
- `reconcileAgent` is unchanged: still only pushes a mission when user yaml has one. Existing agents' Hindsight-side missions are never overwritten.

## Why

Tighter `retainMission` shapes the LLM extraction step inside auto-retain. The upstream wording explicitly excludes "one-off chatter and temporary task noise" — which is the right default for switchroom's 24/7 personal-assistant pattern. Net effect: less filler stored in the bank → fewer marginal hits surfacing on subsequent auto-recalls. Directly addresses the over-injection symptom that motivated the parent epic.

## Migration

Operators who want to upgrade an existing agent's mission have two paths (this PR documents but does not automate either):
1. Add `retain_mission: "..."` under `agents.<name>.memory` in `switchroom.yaml` and run `switchroom agent reconcile <name>`.
2. Call `mcp__hindsight__update_bank` directly.

## Verification

- `npm run lint` clean.
- `tests/memory.bank-missions.test.ts`: 10/10 pass (was 6, added 4 — one asserts verbatim wording, one structural assertion that scaffold seeds the default while reconcile does not).
- Full vitest sweep: 4025 pass, 26 pre-existing failures (verified identical on bare upstream/main with my change stashed — all in `cli.issues` / `boot-self-test` / `run-hook` / `resolve-calling-subagent`, none touched by this PR).

## Test plan

- [ ] `switchroom agent create <new>` against a Hindsight on a fresh bank pushes the default `retain_mission` (verify via `mcp__hindsight__get_bank`).
- [ ] `switchroom agent reconcile <existing>` does NOT push the default to an agent whose yaml has no `retain_mission`.
- [ ] Operator-set `agents.<name>.memory.retain_mission` still wins on both code paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)