### PR TITLE
fix(bridge): refuse anonymous registration; gateway rejects 'default' (#430)

### DIFF
--- a/telegram-plugin/bridge/bridge.ts
+++ b/telegram-plugin/bridge/bridge.ts
@@ -36,7 +36,27 @@ installPluginLogger()
 const STATE_DIR = process.env.TELEGRAM_STATE_DIR ?? join(homedir(), '.claude', 'channels', 'telegram')
 const SOCKET_PATH = process.env.SWITCHROOM_GATEWAY_SOCKET ?? join(STATE_DIR, 'gateway.sock')
 const TOPIC_ID = process.env.TELEGRAM_TOPIC_ID ? Number(process.env.TELEGRAM_TOPIC_ID) : undefined
-const AGENT_NAME = process.env.SWITCHROOM_AGENT_NAME ?? 'default'
+
+// Refuse to start as an unidentified bridge. Without SWITCHROOM_AGENT_NAME
+// we'd previously default to 'default' and register against whichever
+// gateway socket happened to be reachable — which is not us! Other
+// claude-code sessions on the same host (e.g. an operator debugging in
+// ~/code/) load the telegram MCP plugin and would crosstalk into the
+// agent's chat. See #430. The fingerprint of this in the wild is
+// dozens of `registered agent=default` lines per gateway log per hour
+// (analysis: #424). Phase 2 of #424 closes this hole at the source —
+// the bridge — and adds a server-side guard in ipc-server.ts as
+// defence in depth.
+const AGENT_NAME = process.env.SWITCHROOM_AGENT_NAME
+if (!AGENT_NAME) {
+  process.stderr.write(
+    'telegram bridge: SWITCHROOM_AGENT_NAME is not set; refusing to register against ' +
+    `gateway at ${SOCKET_PATH} (would crosstalk into another agent's chat). ` +
+    'If this is a switchroom agent, ensure start.sh exports the agent name. ' +
+    'If this is a stray claude-code session, this exit is the correct outcome.\n',
+  )
+  process.exit(0)
+}
 
 // ─── MCP server ──────────────────────────────────────────────────────────
 

--- a/telegram-plugin/gateway/ipc-server.ts
+++ b/telegram-plugin/gateway/ipc-server.ts
@@ -98,8 +98,16 @@ export function validateClientMessage(msg: unknown): msg is ClientToGateway {
   const m = msg as Record<string, unknown>;
   switch (m.type) {
     case "register":
+      // Reject the literal "default" — that's the legacy fallback used
+      // by anonymous bridges (see #430). A correctly-configured bridge
+      // sets SWITCHROOM_AGENT_NAME to the real agent name; a bridge
+      // sending "default" is either an older binary or a stray
+      // claude-code session and would crosstalk into another agent's
+      // chat. Server-side rejection is defence in depth — the bridge
+      // refuses to register without a name first.
       return typeof m.agentName === "string"
         && m.agentName.length > 0
+        && m.agentName !== "default"
         && m.agentName.length <= 128
         && (m.topicId === undefined
           || (typeof m.topicId === "number"
@@ -228,6 +236,27 @@ export function createIpcServer(options: IpcServerOptions): IpcServer {
   }
 
   function handleRegister(client: IpcClientImpl, msg: RegisterMessage) {
+    // Defence in depth for #430. The bridge refuses to register
+    // without SWITCHROOM_AGENT_NAME (set in start.sh per agent), but
+    // an older bridge or a third-party caller could still send the
+    // string "default" — which crosstalks into whichever agent's
+    // gateway happens to accept the connection. Reject server-side
+    // so the gateway never confuses an anonymous client for the
+    // agent it was launched to serve. The expected switchroom
+    // contract is exactly one agent name per gateway socket; any
+    // mismatch is an outright bug, not a transient.
+    if (msg.agentName === "default") {
+      log(
+        `rejecting register: agentName="default" — anonymous bridges are not allowed (close+drop client=${client.id})`,
+      );
+      try {
+        client.close();
+      } catch {
+        /* nothing to do */
+      }
+      return;
+    }
+
     if (client.agentName) agentIndex.delete(client.agentName);
     if (client.topicId != null) topicIndex.delete(client.topicId);
 

--- a/telegram-plugin/tests/bridge-anonymous-refuse.test.ts
+++ b/telegram-plugin/tests/bridge-anonymous-refuse.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from "vitest";
+import { spawnSync } from "node:child_process";
+import { resolve } from "node:path";
+
+/**
+ * Bridge-side enforcement of #430. When SWITCHROOM_AGENT_NAME is
+ * unset, the bridge must exit cleanly without connecting to the
+ * gateway socket. The script logs a short stderr line explaining why
+ * so an operator running a stray claude-code session knows what
+ * happened.
+ *
+ * Test strategy: spawn `bun bridge.ts` with no agent name, assert
+ * exit 0 and stderr contains the refusal line. We deliberately don't
+ * test against a real gateway socket — the assertion is "exits before
+ * trying to connect."
+ */
+
+const BRIDGE = resolve(__dirname, "..", "bridge", "bridge.ts");
+const BUN = process.env.BUN_PATH ?? "bun";
+
+function findBun(): string {
+  if (process.env.BUN_PATH) return process.env.BUN_PATH;
+  try {
+    const r = spawnSync("which", ["bun"], { encoding: "utf-8" });
+    return r.stdout.trim() || "bun";
+  } catch {
+    return "bun";
+  }
+}
+
+describe("bridge.ts — refuses to start without SWITCHROOM_AGENT_NAME (#430)", () => {
+  it("exits 0 and logs a refusal when SWITCHROOM_AGENT_NAME is unset", () => {
+    const bun = findBun();
+    const r = spawnSync(bun, ["run", BRIDGE], {
+      env: {
+        // Strip every var that might let it limp along.
+        PATH: process.env.PATH ?? "/usr/bin:/bin",
+        HOME: process.env.HOME ?? "/tmp",
+        // Pointing TELEGRAM_STATE_DIR at a fresh tmpdir avoids any
+        // chance of probing a real gateway socket.
+        TELEGRAM_STATE_DIR: "/tmp/__nonexistent_dir_for_bridge_test__",
+        // Explicitly omit SWITCHROOM_AGENT_NAME.
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+      encoding: "utf-8",
+      timeout: 5_000,
+    });
+    expect(r.status).toBe(0);
+    expect(r.stderr).toMatch(/SWITCHROOM_AGENT_NAME is not set/);
+    expect(r.stderr).toMatch(/refusing to register/);
+  });
+
+  // Avoid a positive-path test here — actually starting the bridge
+  // would make it block on stdin and try to connect to a gateway.
+  // The validator unit tests cover what the gateway does with a
+  // real bridge's register message; this file just owns the
+  // "no name → no connect" assertion.
+
+  void BUN; // Silence unused-import lint when BUN_PATH is set
+});

--- a/telegram-plugin/tests/ipc-server-anonymous-refuse.test.ts
+++ b/telegram-plugin/tests/ipc-server-anonymous-refuse.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from "vitest";
+import { validateClientMessage } from "../gateway/ipc-server.js";
+
+/**
+ * #430 Phase 2 — bridge anonymous refuse.
+ *
+ * The bridge defaults to SWITCHROOM_AGENT_NAME="default" if the env
+ * var isn't set (legacy behaviour). That's how we got the
+ * `registered agent=default` lines in every gateway log: any
+ * non-switchroom claude session that loaded the telegram MCP plugin
+ * would probe each agent's gateway socket and register as "default",
+ * crosstalking into someone else's chat.
+ *
+ * The bridge now refuses to start without a real agent name. The
+ * gateway's validator is the server-side defence: if anyone sends a
+ * register message with agentName="default" — a stale older bridge,
+ * a third-party tool, an attacker — we drop it.
+ */
+
+describe("validateClientMessage — register agentName='default' refused (#430)", () => {
+  it("rejects register with agentName=default (legacy anonymous fallback)", () => {
+    expect(
+      validateClientMessage({
+        type: "register",
+        agentName: "default",
+      }),
+    ).toBe(false);
+  });
+
+  it("accepts register with a real agent name", () => {
+    expect(
+      validateClientMessage({
+        type: "register",
+        agentName: "klanker",
+      }),
+    ).toBe(true);
+  });
+
+  it("still rejects empty / missing agentName (existing contract)", () => {
+    expect(validateClientMessage({ type: "register", agentName: "" })).toBe(false);
+    expect(validateClientMessage({ type: "register" })).toBe(false);
+  });
+
+  it("rejects oversized agentName (existing contract preserved)", () => {
+    expect(
+      validateClientMessage({
+        type: "register",
+        agentName: "x".repeat(129),
+      }),
+    ).toBe(false);
+  });
+
+  it("accepts a real name even when 'default' appears as a substring", () => {
+    // Sanity: we reject the literal string, not anything containing it.
+    expect(
+      validateClientMessage({
+        type: "register",
+        agentName: "default-finance-agent",
+      }),
+    ).toBe(true);
+    expect(
+      validateClientMessage({
+        type: "register",
+        agentName: "my-default",
+      }),
+    ).toBe(true);
+  });
+
+  it("validator rejection happens before handleRegister side effects", () => {
+    // No state to inspect at this layer — the validator is pure. The
+    // contract this test guards: validate() returning false means the
+    // gateway's main loop logs "invalid IPC message shape from
+    // client" and continues without dispatching to handleRegister.
+    // See ipc-server.ts processBuffer for the early-return.
+    expect(
+      validateClientMessage({
+        type: "register",
+        agentName: "default",
+      }),
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
Phase 2 of #424. Closes the cross-claude-session crosstalk hole identified in the silent-failure investigation.

## Symptom (verified live)

Every agent's gateway log shows `registered agent=default` events firing repeatedly — klanker 7/hr, finn 4/hr, gymbro 2/hr, clerk 3/hr in the original analysis. These are bridge processes spawned by *other* claude-code sessions on the same host that load the telegram MCP plugin without setting `SWITCHROOM_AGENT_NAME`. They default to the literal string `"default"` and probe each agent's gateway socket — crosstalking into whichever agent's chat first accepts.

I observed this during the investigation: my own debugging session (PID 3625680, parent = my main claude) briefly spawned one. Any third-party claude-code session on this machine with the telegram plugin would do the same.

## Fix

Two-layer defence:

1. **Bridge refuses to start.** `telegram-plugin/bridge/bridge.ts` early-exits with status 0 and a one-line stderr explaining why, before any IPC connection attempt. Closes the source.

2. **Gateway validator rejects `"default"`.** `validateClientMessage` in `ipc-server.ts` returns false for register messages with `agentName="default"`. Server-side defence in depth so any future bridge that bypasses the env check (older binary, third-party tool, malformed caller) still can't crosstalk. `handleRegister` keeps a redundant rejection as a backstop.

## Test plan

- [x] 7 new tests across `ipc-server-anonymous-refuse.test.ts` (6) and `bridge-anonymous-refuse.test.ts` (1).
- [x] Validator: rejects "default", accepts real names, preserves existing checks (length / empty / missing). Sanity test that substring matches like "default-finance-agent" still pass.
- [x] Bridge: spawns `bun bridge.ts` with no agent name and asserts exit 0 + stderr contains the refusal line.
- [x] Existing `ipc-validator.test.ts` (36 tests) still passes — no regression.
- [x] `npm run lint` clean.
- [x] Full telegram-plugin sweep: 2292 tests pass; only the unrelated pre-existing `resolve-calling-subagent.test.ts` bun:test issue still fails.

## Operational impact

After `switchroom agent restart all`, the `bridge-reconnect: skipping boot card` noise from agent=default registers should drop to zero. Watchdog already tolerated the flap; this just removes the source. Existing switchroom agents are unaffected — start.sh already sets `SWITCHROOM_AGENT_NAME` correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)