### PR TITLE
feat(memory): cap auto-recall memory count per turn (memory.recall.max_memories)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -58,6 +58,32 @@ The scaffold wires the following MCP servers automatically:
 - **playwright** — Microsoft's `@playwright/mcp` browser automation server, launched via `npx -y @playwright/mcp@<pinned-version> --snapshot`. Always wired by default; opt out with `mcp_servers: { playwright: false }`. Runs in accessibility-tree (snapshot) mode, which is token-cheap and reliable for most web automation tasks. Exposes `browser_navigate`, `browser_snapshot`, `browser_click`, `browser_type`, and related tools directly to the agent without requiring a local Playwright installation. The version is pinned in `src/memory/scaffold-integration.ts` — bump deliberately when validating against a newer release.
 - **hindsight** — semantic memory bank, wired only when `memory.backend` is `hindsight`. Agents using a different memory backend (or none) don't get this server.
 
+### Tuning auto-recall — `memory.recall.max_memories`
+
+Hindsight's auto-recall hook injects relevant memories into every inbound prompt. Without a cap, a busy bank can return 16–22 memories per turn (forensic on real fleets), bloating the prompt and risking irrelevant memories steering the response.
+
+```yaml
+defaults:
+  memory:
+    recall:
+      max_memories: 12   # workspace default (also the plugin default)
+
+agents:
+  coach:
+    memory:
+      recall:
+        max_memories: 8  # tighter for a chatty agent
+
+  research:
+    memory:
+      recall:
+        max_memories: 0  # 0 = uncapped; let the token budget alone bound the block
+```
+
+The cap applies to the *combined* result list across the primary bank and any `recallAdditionalBanks`, not per-bank. Lower values reduce noise; very low values (≤3) can starve the agent of useful long-term context. The plugin's own default is `12`; omit the field to inherit it. Setting `0` (or any non-positive value) disables the cap entirely.
+
+Operationally: the cap is set via the `HINDSIGHT_RECALL_MAX_MEMORIES` env var that `start.sh` exports. The vendored plugin's `recall.py` slices results client-side before formatting (plugin v0.4.0 has no `recallTopK` setting on the Claude Code integration — only Openclaw exposes it).
+
 Any server from `defaults.mcp_servers` also flows to all agents via the normal cascade.
 
 To suppress the built-in `playwright` server for a specific agent:

--- a/profiles/_base/start.sh.hbs
+++ b/profiles/_base/start.sh.hbs
@@ -32,6 +32,12 @@ export HINDSIGHT_BANK_ID={{{hindsightBankIdQ}}}
 export HINDSIGHT_AUTO_RECALL=true
 export HINDSIGHT_AUTO_RETAIN=true
 export HINDSIGHT_AGENT_NAME="{{name}}"
+{{#if (isNumber hindsightRecallMaxMemories)}}
+# Cap on memories injected per turn (memory.recall.max_memories cascade).
+# Plugin's settings.json default is 12; export only when the operator
+# overrode it via switchroom.yaml. 0 disables the cap entirely.
+export HINDSIGHT_RECALL_MAX_MEMORIES={{hindsightRecallMaxMemories}}
+{{/if}}
 # Wait for Hindsight API to be reachable before launching Claude, otherwise
 # the MCP server connection fails at startup with "1 MCP server failed".
 HINDSIGHT_WAIT=0

--- a/src/agents/profiles.ts
+++ b/src/agents/profiles.ts
@@ -157,6 +157,15 @@ Handlebars.registerHelper("json", (value: unknown) => {
   return new Handlebars.SafeString(JSON.stringify(value, null, 2));
 });
 
+// Register an "isNumber" helper. Plain `{{#if value}}` treats 0 as
+// falsy, but several config knobs (like memory.recall.max_memories)
+// use 0 as a meaningful "disable cap" sentinel — rendering must
+// distinguish "operator set 0" from "operator left it unset". This
+// helper returns true for any finite number, including 0.
+Handlebars.registerHelper("isNumber", (value: unknown) => {
+  return typeof value === "number" && Number.isFinite(value);
+});
+
 // Register shared profile fragments as Handlebars partials so any profile
 // template can use {{> fragment-name}} instead of copy-pasting the content.
 // The _shared/ directory is underscore-prefixed (like _base/) and is not

--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -1120,6 +1120,7 @@ interface BuildWorkspaceContextArgs {
   hindsightAutoRecallEnabled: boolean;
   hindsightBankId: string;
   hindsightApiBaseUrl: string;
+  hindsightRecallMaxMemories: number | undefined;
 }
 
 /**
@@ -1144,6 +1145,7 @@ function buildWorkspaceContext(args: BuildWorkspaceContextArgs): Record<string, 
     hindsightAutoRecallEnabled,
     hindsightBankId,
     hindsightApiBaseUrl,
+    hindsightRecallMaxMemories,
   } = args;
   return {
     name,
@@ -1174,6 +1176,7 @@ function buildWorkspaceContext(args: BuildWorkspaceContextArgs): Record<string, 
     hindsightEnabled: hindsightAutoRecallEnabled,
     hindsightBankIdQ: shellSingleQuote(hindsightBankId),
     hindsightApiBaseUrlQ: shellSingleQuote(hindsightApiBaseUrl),
+    hindsightRecallMaxMemories,
     switchroomConfigPathQ: switchroomConfigPath
       ? shellSingleQuote(resolve(switchroomConfigPath))
       : undefined,
@@ -1362,6 +1365,12 @@ export function scaffoldAgent(
   const hindsightApiBaseUrl = (switchroomConfig?.memory?.config?.url as string | undefined)
     ? (switchroomConfig!.memory!.config!.url as string).replace(/\/mcp\/?$/, "").replace(/\/$/, "")
     : "http://127.0.0.1:8888";
+  // Cascading recall cap. Per-agent value already merged from defaults
+  // by config/merge.ts (memory is shallow-merged), so reading
+  // agentConfig.memory.recall.max_memories here picks up the resolved
+  // value. `undefined` means "let the plugin's settings.json default
+  // apply" — start.sh.hbs gates the env var on this being defined.
+  const hindsightRecallMaxMemories = agentConfig.memory?.recall?.max_memories;
 
   // Build the template rendering context via the shared helper so
   // scaffold and reconcile always produce the same shape for workspace
@@ -1382,6 +1391,7 @@ export function scaffoldAgent(
     hindsightAutoRecallEnabled,
     hindsightBankId,
     hindsightApiBaseUrl,
+    hindsightRecallMaxMemories,
   });
 
   // --- Create directory structure ---
@@ -2449,6 +2459,7 @@ export function reconcileAgent(
   const hindsightApiBaseUrl = (switchroomConfig.memory?.config?.url as string | undefined)
     ? (switchroomConfig.memory!.config!.url as string).replace(/\/mcp\/?$/, "").replace(/\/$/, "")
     : "http://127.0.0.1:8888";
+  const hindsightRecallMaxMemories = agentConfig.memory?.recall?.max_memories;
 
   // --- Reconcile start.sh (purely template-driven, safe to overwrite) ---
   // No existsSync guard: start.sh is a pure function of config+template.
@@ -2473,6 +2484,7 @@ export function reconcileAgent(
       hindsightEnabled: hindsightAutoRecallEnabled,
       hindsightBankIdQ: shellSingleQuote(hindsightBankId),
       hindsightApiBaseUrlQ: shellSingleQuote(hindsightApiBaseUrl),
+      hindsightRecallMaxMemories,
       modelQ: agentConfig.model ? shellSingleQuote(agentConfig.model) : undefined,
       thinkingEffort: agentConfig.thinking_effort,
       permissionMode: agentConfig.permission_mode,
@@ -2937,6 +2949,7 @@ Don't wait for a slash command. Don't ask permission. Memory work is table stake
     hindsightAutoRecallEnabled,
     hindsightBankId,
     hindsightApiBaseUrl,
+    hindsightRecallMaxMemories,
   });
   // Phase 5 migration: preserve any agent-specific edits to the legacy
   // workspace/AGENTS.md (pre-rename) by renaming it to CLAUDE.md before

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -97,6 +97,21 @@ export const AgentMemorySchema = z
       .string()
       .optional()
       .describe("Instructions for the fact extraction LLM during retain"),
+    recall: z
+      .object({
+        max_memories: z
+          .number()
+          .int()
+          .min(0)
+          .optional()
+          .describe(
+            "Cap on the number of memories injected into the prompt by " +
+            "auto-recall, regardless of token budget. Plugin default is 12. " +
+            "0 disables the cap (all memories Hindsight returns are injected).",
+          ),
+      })
+      .optional()
+      .describe("Auto-recall tuning knobs"),
   })
   .optional();
 
@@ -538,6 +553,11 @@ const profileFields = {
       collection: z.string().optional(),
       auto_recall: z.boolean().optional(),
       isolation: z.enum(["default", "strict"]).optional(),
+      recall: z
+        .object({
+          max_memories: z.number().int().min(0).optional(),
+        })
+        .optional(),
     })
     .optional(),
   schedule: z.array(ScheduleEntrySchema).optional(),

--- a/tests/merge.test.ts
+++ b/tests/merge.test.ts
@@ -216,6 +216,29 @@ describe("mergeAgentConfig", () => {
     });
   });
 
+  it("cascades memory.recall.max_memories from defaults when agent omits it", () => {
+    const defaults: AgentDefaults = {
+      memory: { recall: { max_memories: 8 } },
+    };
+    const agent = baseAgent({
+      memory: { collection: "coach" },
+    });
+    const result = mergeAgentConfig(defaults, agent);
+    expect(result.memory?.recall?.max_memories).toBe(8);
+    expect(result.memory?.collection).toBe("coach");
+  });
+
+  it("agent memory.recall.max_memories overrides defaults", () => {
+    const defaults: AgentDefaults = {
+      memory: { recall: { max_memories: 8 } },
+    };
+    const agent = baseAgent({
+      memory: { recall: { max_memories: 3 } },
+    });
+    const result = mergeAgentConfig(defaults, agent);
+    expect(result.memory?.recall?.max_memories).toBe(3);
+  });
+
   it("prepends defaults.schedule to agent.schedule", () => {
     const defaults: AgentDefaults = {
       schedule: [{ cron: "0 8 * * *", prompt: "Morning check-in" }],

--- a/tests/scaffold.test.ts
+++ b/tests/scaffold.test.ts
@@ -1221,6 +1221,52 @@ describe("reconcileAgent", () => {
     expect(startSh).not.toContain("HINDSIGHT_WAIT");
   });
 
+  it("start.sh omits HINDSIGHT_RECALL_MAX_MEMORIES when no override is set (plugin default applies)", () => {
+    const agentConfig = makeAgentConfig();
+    const withMemory = buildSwitchroomConfig(agentConfig, {
+      backend: "hindsight",
+      shared_collection: "shared",
+      config: { provider: "openai", docker_service: true, url: "http://127.0.0.1:18888/mcp/" },
+    });
+    scaffoldAgent("test-agent", agentConfig, tmpDir, telegramConfig, withMemory);
+
+    const startSh = readFileSync(join(tmpDir, "test-agent", "start.sh"), "utf-8");
+    expect(startSh).not.toContain("HINDSIGHT_RECALL_MAX_MEMORIES");
+  });
+
+  it("start.sh exports HINDSIGHT_RECALL_MAX_MEMORIES when agent overrides the cap", () => {
+    const agentConfig = makeAgentConfig({
+      memory: { collection: "test-agent", recall: { max_memories: 5 } },
+    });
+    const withMemory = buildSwitchroomConfig(agentConfig, {
+      backend: "hindsight",
+      shared_collection: "shared",
+      config: { provider: "openai", docker_service: true, url: "http://127.0.0.1:18888/mcp/" },
+    });
+    scaffoldAgent("test-agent", agentConfig, tmpDir, telegramConfig, withMemory);
+
+    const startSh = readFileSync(join(tmpDir, "test-agent", "start.sh"), "utf-8");
+    expect(startSh).toContain("export HINDSIGHT_RECALL_MAX_MEMORIES=5");
+  });
+
+  it("start.sh exports HINDSIGHT_RECALL_MAX_MEMORIES=0 when operator explicitly disables the cap", () => {
+    // 0 is a meaningful sentinel ("uncapped"), not the same as unset.
+    // The template uses an isNumber helper specifically so 0 still
+    // emits the export (vs being treated as falsy by plain {{#if}}).
+    const agentConfig = makeAgentConfig({
+      memory: { collection: "test-agent", recall: { max_memories: 0 } },
+    });
+    const withMemory = buildSwitchroomConfig(agentConfig, {
+      backend: "hindsight",
+      shared_collection: "shared",
+      config: { provider: "openai", docker_service: true, url: "http://127.0.0.1:18888/mcp/" },
+    });
+    scaffoldAgent("test-agent", agentConfig, tmpDir, telegramConfig, withMemory);
+
+    const startSh = readFileSync(join(tmpDir, "test-agent", "start.sh"), "utf-8");
+    expect(startSh).toContain("export HINDSIGHT_RECALL_MAX_MEMORIES=0");
+  });
+
   it("returns no changes when settings already match", () => {
     const agentConfig = makeAgentConfig();
     const config = buildSwitchroomConfig(agentConfig);

--- a/vendor/hindsight-memory/scripts/lib/config.py
+++ b/vendor/hindsight-memory/scripts/lib/config.py
@@ -13,6 +13,13 @@ DEFAULTS = {
     "autoRecall": True,
     "recallBudget": "mid",
     "recallMaxTokens": 1024,
+    # Switchroom-local: cap on the number of memories injected into the
+    # `<hindsight_memories>` block, regardless of token budget. Plugin v0.4.0
+    # exposes `recallTopK` only in the Openclaw integration, not the
+    # Claude Code integration, so we slice client-side in recall.py before
+    # formatting. Set to 0 (or any non-positive value) to disable the cap
+    # and inject everything Hindsight returns.
+    "recallMaxMemories": 12,
     "recallTypes": ["world", "experience"],
     "recallContextTurns": 1,
     "recallMaxQueryChars": 800,
@@ -67,6 +74,10 @@ ENV_OVERRIDES = {
     "HINDSIGHT_RETAIN_MODE": ("retainMode", str),
     "HINDSIGHT_RECALL_BUDGET": ("recallBudget", str),
     "HINDSIGHT_RECALL_MAX_TOKENS": ("recallMaxTokens", int),
+    # Switchroom-local: count cap. Set by start.sh from
+    # agents.<name>.memory.recall.max_memories (cascading through
+    # defaults.memory.recall.max_memories) when present in switchroom.yaml.
+    "HINDSIGHT_RECALL_MAX_MEMORIES": ("recallMaxMemories", int),
     "HINDSIGHT_RECALL_MAX_QUERY_CHARS": ("recallMaxQueryChars", int),
     "HINDSIGHT_RECALL_CONTEXT_TURNS": ("recallContextTurns", int),
     "HINDSIGHT_API_PORT": ("apiPort", int),

--- a/vendor/hindsight-memory/scripts/recall.py
+++ b/vendor/hindsight-memory/scripts/recall.py
@@ -192,6 +192,25 @@ def main():
         except Exception as e:
             debug_log(config, f"Recall from additional bank '{extra_bank_id}' failed: {e}")
 
+    # Switchroom-local: client-side count cap. Plugin v0.4.0 has no
+    # `recallTopK` in the Claude Code integration (Openclaw-only), and a
+    # token budget alone doesn't bound count — a single long memory can
+    # blow past intended caps, while many short ones can flood the prompt.
+    # Slice the combined results from primary + additional banks before
+    # formatting. <= 0 disables the cap.
+    recall_max_memories = config.get("recallMaxMemories", 0)
+    if (
+        isinstance(recall_max_memories, int)
+        and recall_max_memories > 0
+        and len(results) > recall_max_memories
+    ):
+        debug_log(
+            config,
+            f"Capping {len(results)} memories to {recall_max_memories} "
+            f"(set HINDSIGHT_RECALL_MAX_MEMORIES=0 to disable)",
+        )
+        results = results[:recall_max_memories]
+
     memories_block = None
     if results:
         debug_log(config, f"Injecting {len(results)} memories")

--- a/vendor/hindsight-memory/scripts/tests/test_recall_integration.py
+++ b/vendor/hindsight-memory/scripts/tests/test_recall_integration.py
@@ -62,10 +62,15 @@ class _FakeClient:
         return {"results": list(self._memories)}
 
 
-def _run_main_with(client, prompt="What is the meaning of life?"):
+def _run_main_with(client, prompt="What is the meaning of life?", config_extra=None):
     """Invoke recall.main with a fake client and capture stdout JSON.
 
     Returns (additional_context_string_or_None, raw_stdout).
+
+    `config_extra` is merged on top of the baseline config so individual
+    tests can override knobs like `recallMaxMemories` or
+    `recallAdditionalBanks` without growing the helper signature for
+    every new field.
     """
     hook_input = {
         "prompt": prompt,
@@ -82,6 +87,8 @@ def _run_main_with(client, prompt="What is the meaning of life?"):
         "recallMaxQueryChars": 800,
         "recallPromptPreamble": "",
     }
+    if config_extra:
+        config.update(config_extra)
 
     stdout = io.StringIO()
     stderr = io.StringIO()
@@ -173,6 +180,87 @@ class RecallIntegrationTests(unittest.TestCase):
         )
         ctx, _ = _run_main_with(client)
         self.assertIn("</active_directives>\n\n<hindsight_memories>", ctx)
+
+
+class RecallMaxMemoriesCapTests(unittest.TestCase):
+    """Tests for the switchroom-local recallMaxMemories count cap.
+
+    The cap is applied client-side after the (primary + additional banks)
+    results are concatenated and BEFORE formatting, so it bounds the
+    final injected memory count regardless of token budget. <= 0
+    disables the cap.
+    """
+
+    def test_cap_truncates_over_limit(self):
+        memories = [_memory(f"memory {i}") for i in range(8)]
+        client = _FakeClient(directives=[], memories=memories)
+        ctx, _ = _run_main_with(client, config_extra={"recallMaxMemories": 3})
+        self.assertIsNotNone(ctx)
+        self.assertIn("memory 0", ctx)
+        self.assertIn("memory 2", ctx)
+        # memory 3 and beyond must be trimmed.
+        self.assertNotIn("memory 3", ctx)
+        self.assertNotIn("memory 7", ctx)
+
+    def test_cap_zero_disables_truncation(self):
+        memories = [_memory(f"memory {i}") for i in range(20)]
+        client = _FakeClient(directives=[], memories=memories)
+        ctx, _ = _run_main_with(client, config_extra={"recallMaxMemories": 0})
+        self.assertIsNotNone(ctx)
+        # All 20 should make it through.
+        for i in range(20):
+            self.assertIn(f"memory {i}", ctx)
+
+    def test_cap_below_count_no_op(self):
+        # Cap=12 but only 5 memories returned → no slicing.
+        memories = [_memory(f"memory {i}") for i in range(5)]
+        client = _FakeClient(directives=[], memories=memories)
+        ctx, _ = _run_main_with(client, config_extra={"recallMaxMemories": 12})
+        self.assertIsNotNone(ctx)
+        for i in range(5):
+            self.assertIn(f"memory {i}", ctx)
+
+    def test_cap_applies_after_additional_banks_concat(self):
+        # Primary bank returns 4 memories; additional bank returns 4
+        # more. Cap of 5 must apply to the total (slicing keeps primary
+        # 0..3 + first 1 from additional). This locks in the rule:
+        # "cap is total, not per-bank."
+        primary = [_memory(f"primary-{i}") for i in range(4)]
+
+        # Build a client whose `recall` returns different sets per bank.
+        class _MultiBankClient(_FakeClient):
+            def recall(self, bank_id, **kwargs):
+                if bank_id == "test-bank":
+                    return {"results": list(primary)}
+                if bank_id == "shared-bank":
+                    return {"results": [_memory(f"shared-{i}") for i in range(4)]}
+                return {"results": []}
+
+        client = _MultiBankClient(directives=[], memories=[])
+        ctx, _ = _run_main_with(
+            client,
+            config_extra={
+                "recallMaxMemories": 5,
+                "recallAdditionalBanks": ["shared-bank"],
+            },
+        )
+        self.assertIsNotNone(ctx)
+        # Primary 0..3 + the first shared (shared-0) survive the cap.
+        for i in range(4):
+            self.assertIn(f"primary-{i}", ctx)
+        self.assertIn("shared-0", ctx)
+        # shared-1..3 are sliced off.
+        self.assertNotIn("shared-1", ctx)
+        self.assertNotIn("shared-3", ctx)
+
+    def test_cap_negative_disables(self):
+        # Defensive: negative values are treated the same as 0 (uncapped).
+        memories = [_memory(f"memory {i}") for i in range(15)]
+        client = _FakeClient(directives=[], memories=memories)
+        ctx, _ = _run_main_with(client, config_extra={"recallMaxMemories": -1})
+        self.assertIsNotNone(ctx)
+        for i in range(15):
+            self.assertIn(f"memory {i}", ctx)
 
 
 if __name__ == "__main__":

--- a/vendor/hindsight-memory/settings.json
+++ b/vendor/hindsight-memory/settings.json
@@ -8,6 +8,7 @@
   "retainMode": "full-session",
   "recallBudget": "mid",
   "recallMaxTokens": 1024,
+  "recallMaxMemories": 12,
   "recallTypes": ["world", "experience"],
   "recallContextTurns": 1,
   "recallMaxQueryChars": 800,


### PR DESCRIPTION
Implements Phase 4.2 of #432. Part of #424.

## What

Adds a cascading `memory.recall.max_memories` config knob that caps how many memories Hindsight's auto-recall injects into the prompt per turn. Default 12 (set as the plugin's own settings.json default; the switchroom yaml field is purely an override).

```yaml
defaults:
  memory:
    recall:
      max_memories: 12

agents:
  coach:
    memory:
      recall:
        max_memories: 8       # tighter for a chatty agent

  research:
    memory:
      recall:
        max_memories: 0       # 0 = uncapped, token budget alone
```

Forensic measurement in #424 showed real fleets averaging 16–22 memories per inbound — direct latency cost and a meaningful steering risk for irrelevant context. Capping at 12 should noticeably tighten the noise floor.

## Why client-side

Plugin v0.4.0 exposes `recallTopK` only in the **Openclaw** integration, not the Claude Code integration. The CC plugin returns whatever Hindsight sends back, bounded only by token budget — which doesn't bound item count. So the cap lives in the vendored plugin's `recall.py`, applied after the primary + additional banks are concatenated and before formatting.

The `0` sentinel ("uncapped") needs special handling: plain `{{#if 0}}` is falsy in Handlebars and would silently drop the operator's intent. PR registers an `isNumber` helper so `0` still emits `export HINDSIGHT_RECALL_MAX_MEMORIES=0` and the plugin honors it.

## Files

| File | Change |
| --- | --- |
| `src/config/schema.ts` | New `recall.max_memories` field on both `AgentMemorySchema` and `defaults.memory`. |
| `src/agents/scaffold.ts` | Reads resolved value, threads it through `buildWorkspaceContext` so scaffold + reconcile stay in lockstep. |
| `src/agents/profiles.ts` | New `isNumber` Handlebars helper (0 must not be treated as falsy). |
| `profiles/_base/start.sh.hbs` | Conditional `export HINDSIGHT_RECALL_MAX_MEMORIES=<n>`. |
| `vendor/hindsight-memory/scripts/lib/config.py` | DEFAULTS + ENV_OVERRIDES entries. |
| `vendor/hindsight-memory/scripts/recall.py` | Slice combined results before formatting. |
| `vendor/hindsight-memory/settings.json` | Plugin default `12`. |
| `docs/configuration.md` | New "Tuning auto-recall" subsection. |

## Tests

- **Python (vendored plugin):** 5 new cap-behavior tests + 7 existing directives integration tests = 12/12 passing. 150/150 upstream tests still green.
- **TypeScript:** 2 new merge cascade tests (defaults flow through; agent override wins) = 59/59 pass. 3 new scaffold env-emission tests (omitted when unset, present when overridden, present as `=0` when explicitly disabled).
- `npm run lint` clean.
- Full vitest: 4060 pass, 26 pre-existing failures (all dist-dependent integration tests — #460 fixes those CI-side; identical state on bare `upstream/main`).

## Test plan

- [ ] `switchroom doctor` reports the per-agent cap once configured (separate doctor PR not required for this; existing doctor surface already shows config drift).
- [ ] On a live host, set `memory.recall.max_memories: 5` for a noisy agent, reconcile + restart, observe the recall payload size drop in logs.
- [ ] Setting `0` on an agent confirms unbounded behavior (debug log shows the cap is disabled).
- [ ] Agents without an override pick up the plugin default of 12.

## Out of scope (separate PRs)

- **#432 Phase 4.1** — per-session recall cache.
- **#432 Phase 4.3** — drift telemetry (logging which recalled memories the model actually referenced).
- **#432 Phase 4.4** — `[demote-from-recall]` memory tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)