### PR TITLE
fix(boot-self-test): pre-resolve auth codes so severity demotes correctly

### DIFF
--- a/bin/boot-self-test.sh
+++ b/bin/boot-self-test.sh
@@ -106,16 +106,22 @@ if [ -z "$DIAG_JSON" ]; then
   exit 0
 fi
 
-# Resolve cli_unauthenticated unconditionally — it's no longer
-# produced by this script, and any leftover entries from older
-# versions should clean up on the next reconcile + restart.
-resolve_one cli_unauthenticated
+# Resolve every known auth code FIRST so the new record below reflects
+# the *current* heal diagnosis, not a coalesced max severity from
+# stale prior boots. The issue store promotes severity on coalesce
+# (never demotes) — so without this pre-resolve, an agent that was
+# critical yesterday and is only warn today would still show as
+# critical. Each boot is a fresh empirical observation; the resolved
+# audit trail is preserved under --include-resolved for history.
+for code in "${ALL_CODES[@]}"; do
+  resolve_one "$code"
+done
 
-# Walk findings; record each present, resolve each absent code.
+# Walk findings; record each present at heal's actual severity.
 PRESENT_CODES=$(printf '%s' "$DIAG_JSON" | jq -r '.findings[]?.code' 2>/dev/null)
 
 for code in "${ALL_CODES[@]}"; do
-  [ "$code" = "cli_unauthenticated" ] && continue # already resolved above
+  [ "$code" = "cli_unauthenticated" ] && continue # legacy code — never re-record
   if printf '%s\n' "$PRESENT_CODES" | grep -qx "$code"; then
     severity=$(printf '%s' "$DIAG_JSON" | jq -r --arg c "$code" '.findings[] | select(.code == $c) | .severity' | head -1)
     summary=$(printf '%s' "$DIAG_JSON" | jq -r --arg c "$code" '.findings[] | select(.code == $c) | .summary' | head -1)
@@ -128,8 +134,6 @@ for code in "${ALL_CODES[@]}"; do
 $recommendation"
     fi
     record "$code" "$severity" "$AGENT_NAME $summary" "$detail"
-  else
-    resolve_one "$code"
   fi
 done
 


### PR DESCRIPTION
Followup to #462. After running #462 in production I noticed the issue cards still showed critical-severity entries from previous boots — because the issue store promotes severity on coalesce (never demotes), and boot-self-test's records were merging into older max-severity entries instead of replacing them.

## Symptom

```
$ switchroom issues list --state-dir .../finn/telegram
[error] credentials_missing  finn .credentials.json absent... (×5)
```

The agent's actual current state per heal is **warn** (only .oauth-token present, handoff hook works fine via Phase 1.2). But the entry stayed at error because boot N's error severity from before #462 had been coalesced.

## Fix

Resolve every known auth code at the start of each boot self-test run, then re-record only what heal currently reports. Resolved entries remain in the audit log via \`--include-resolved\`.

```
before: finn  → credentials_missing:error (×5, stale max)
after:  finn  → credentials_missing:warn  (current heal output)
```

## Trade-off

Loses multi-boot occurrence accumulation for these specific codes. The auth findings get \`occurrences=1\` on every boot now. The right call for the visibility surface — users want to know "what's broken NOW," not "what was the worst this has ever been." History stays in the audit trail.

## Test plan

- [x] All 9 boot-self-test tests pass.
- [x] Pre-stale repro: pre-recorded a stale error entry, ran boot-self-test, verified the active entry now shows warn.
- [x] Live verification on klanker / finn / gymbro / clerk after restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)