### PR TITLE
feat(memory): per-session recall cache (#424 phase 4.1)

### DIFF
--- a/profiles/_base/start.sh.hbs
+++ b/profiles/_base/start.sh.hbs
@@ -38,6 +38,16 @@ export HINDSIGHT_AGENT_NAME="{{name}}"
 # overrode it via switchroom.yaml. 0 disables the cap entirely.
 export HINDSIGHT_RECALL_MAX_MEMORIES={{hindsightRecallMaxMemories}}
 {{/if}}
+# Per-session recall cache (#424 phase 4.1). Identical (prompt, bank)
+# within a session reuses the prior recall result instead of round-
+# tripping to Hindsight. Defaults to 600s (10 min); operators can
+# override via memory.recall.cache_ttl_secs in switchroom.yaml.
+# Setting it to 0 disables caching for that agent.
+{{#if (isNumber hindsightRecallCacheTtlSecs)}}
+export HINDSIGHT_RECALL_CACHE_TTL_SECS={{hindsightRecallCacheTtlSecs}}
+{{else}}
+export HINDSIGHT_RECALL_CACHE_TTL_SECS=600
+{{/if}}
 # Wait for Hindsight API to be reachable before launching Claude, otherwise
 # the MCP server connection fails at startup with "1 MCP server failed".
 HINDSIGHT_WAIT=0

--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -1121,6 +1121,7 @@ interface BuildWorkspaceContextArgs {
   hindsightBankId: string;
   hindsightApiBaseUrl: string;
   hindsightRecallMaxMemories: number | undefined;
+  hindsightRecallCacheTtlSecs: number | undefined;
 }
 
 /**
@@ -1146,6 +1147,7 @@ function buildWorkspaceContext(args: BuildWorkspaceContextArgs): Record<string, 
     hindsightBankId,
     hindsightApiBaseUrl,
     hindsightRecallMaxMemories,
+    hindsightRecallCacheTtlSecs,
   } = args;
   return {
     name,
@@ -1177,6 +1179,7 @@ function buildWorkspaceContext(args: BuildWorkspaceContextArgs): Record<string, 
     hindsightBankIdQ: shellSingleQuote(hindsightBankId),
     hindsightApiBaseUrlQ: shellSingleQuote(hindsightApiBaseUrl),
     hindsightRecallMaxMemories,
+    hindsightRecallCacheTtlSecs,
     switchroomConfigPathQ: switchroomConfigPath
       ? shellSingleQuote(resolve(switchroomConfigPath))
       : undefined,
@@ -1371,6 +1374,11 @@ export function scaffoldAgent(
   // value. `undefined` means "let the plugin's settings.json default
   // apply" — start.sh.hbs gates the env var on this being defined.
   const hindsightRecallMaxMemories = agentConfig.memory?.recall?.max_memories;
+  // Per-session recall cache TTL (#424 phase 4.1). Same cascade
+  // semantics as max_memories. `undefined` here means "use the
+  // switchroom-managed default of 600s baked into start.sh.hbs."
+  // Set to 0 in switchroom.yaml to disable caching for an agent.
+  const hindsightRecallCacheTtlSecs = agentConfig.memory?.recall?.cache_ttl_secs;
 
   // Build the template rendering context via the shared helper so
   // scaffold and reconcile always produce the same shape for workspace
@@ -1392,6 +1400,7 @@ export function scaffoldAgent(
     hindsightBankId,
     hindsightApiBaseUrl,
     hindsightRecallMaxMemories,
+    hindsightRecallCacheTtlSecs,
   });
 
   // --- Create directory structure ---
@@ -2460,6 +2469,7 @@ export function reconcileAgent(
     ? (switchroomConfig.memory!.config!.url as string).replace(/\/mcp\/?$/, "").replace(/\/$/, "")
     : "http://127.0.0.1:8888";
   const hindsightRecallMaxMemories = agentConfig.memory?.recall?.max_memories;
+  const hindsightRecallCacheTtlSecs = agentConfig.memory?.recall?.cache_ttl_secs;
 
   // --- Reconcile start.sh (purely template-driven, safe to overwrite) ---
   // No existsSync guard: start.sh is a pure function of config+template.
@@ -2485,6 +2495,7 @@ export function reconcileAgent(
       hindsightBankIdQ: shellSingleQuote(hindsightBankId),
       hindsightApiBaseUrlQ: shellSingleQuote(hindsightApiBaseUrl),
       hindsightRecallMaxMemories,
+      hindsightRecallCacheTtlSecs,
       modelQ: agentConfig.model ? shellSingleQuote(agentConfig.model) : undefined,
       thinkingEffort: agentConfig.thinking_effort,
       permissionMode: agentConfig.permission_mode,
@@ -2950,6 +2961,7 @@ Don't wait for a slash command. Don't ask permission. Memory work is table stake
     hindsightBankId,
     hindsightApiBaseUrl,
     hindsightRecallMaxMemories,
+    hindsightRecallCacheTtlSecs,
   });
   // Phase 5 migration: preserve any agent-specific edits to the legacy
   // workspace/AGENTS.md (pre-rename) by renaming it to CLAUDE.md before

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -109,6 +109,17 @@ export const AgentMemorySchema = z
             "auto-recall, regardless of token budget. Plugin default is 12. " +
             "0 disables the cap (all memories Hindsight returns are injected).",
           ),
+        cache_ttl_secs: z
+          .number()
+          .int()
+          .min(0)
+          .optional()
+          .describe(
+            "Per-session recall cache TTL in seconds. When > 0, identical " +
+            "(prompt, bank) within the same session reuse the cached recall " +
+            "result instead of round-tripping to Hindsight. 0 disables. " +
+            "Default is 600 (10 min) for switchroom-managed agents.",
+          ),
       })
       .optional()
       .describe("Auto-recall tuning knobs"),

--- a/tests/scaffold.test.ts
+++ b/tests/scaffold.test.ts
@@ -1267,6 +1267,54 @@ describe("reconcileAgent", () => {
     expect(startSh).toContain("export HINDSIGHT_RECALL_MAX_MEMORIES=0");
   });
 
+  it("start.sh exports HINDSIGHT_RECALL_CACHE_TTL_SECS=600 by default for hindsight agents", () => {
+    // Per-session recall cache (#424 phase 4.1) — the switchroom-managed
+    // default is 10 minutes. Operators can override or disable via
+    // memory.recall.cache_ttl_secs.
+    const agentConfig = makeAgentConfig();
+    const withMemory = buildSwitchroomConfig(agentConfig, {
+      backend: "hindsight",
+      shared_collection: "shared",
+      config: { provider: "openai", docker_service: true, url: "http://127.0.0.1:18888/mcp/" },
+    });
+    scaffoldAgent("test-agent", agentConfig, tmpDir, telegramConfig, withMemory);
+
+    const startSh = readFileSync(join(tmpDir, "test-agent", "start.sh"), "utf-8");
+    expect(startSh).toContain("export HINDSIGHT_RECALL_CACHE_TTL_SECS=600");
+  });
+
+  it("start.sh respects an operator override of memory.recall.cache_ttl_secs", () => {
+    const agentConfig = makeAgentConfig({
+      memory: { collection: "test-agent", recall: { cache_ttl_secs: 300 } },
+    });
+    const withMemory = buildSwitchroomConfig(agentConfig, {
+      backend: "hindsight",
+      shared_collection: "shared",
+      config: { provider: "openai", docker_service: true, url: "http://127.0.0.1:18888/mcp/" },
+    });
+    scaffoldAgent("test-agent", agentConfig, tmpDir, telegramConfig, withMemory);
+
+    const startSh = readFileSync(join(tmpDir, "test-agent", "start.sh"), "utf-8");
+    expect(startSh).toContain("export HINDSIGHT_RECALL_CACHE_TTL_SECS=300");
+    expect(startSh).not.toContain("export HINDSIGHT_RECALL_CACHE_TTL_SECS=600");
+  });
+
+  it("start.sh exports HINDSIGHT_RECALL_CACHE_TTL_SECS=0 to disable caching for an agent", () => {
+    // 0 is a meaningful sentinel ("disabled") — recall.py treats it as off.
+    const agentConfig = makeAgentConfig({
+      memory: { collection: "test-agent", recall: { cache_ttl_secs: 0 } },
+    });
+    const withMemory = buildSwitchroomConfig(agentConfig, {
+      backend: "hindsight",
+      shared_collection: "shared",
+      config: { provider: "openai", docker_service: true, url: "http://127.0.0.1:18888/mcp/" },
+    });
+    scaffoldAgent("test-agent", agentConfig, tmpDir, telegramConfig, withMemory);
+
+    const startSh = readFileSync(join(tmpDir, "test-agent", "start.sh"), "utf-8");
+    expect(startSh).toContain("export HINDSIGHT_RECALL_CACHE_TTL_SECS=0");
+  });
+
   it("returns no changes when settings already match", () => {
     const agentConfig = makeAgentConfig();
     const config = buildSwitchroomConfig(agentConfig);

--- a/vendor/hindsight-memory/scripts/recall.py
+++ b/vendor/hindsight-memory/scripts/recall.py
@@ -6,19 +6,23 @@ Adapted for Claude Code hooks (ephemeral process, JSON stdin/stdout).
 
 Flow:
   1. Read hook input from stdin (prompt, session_id, transcript_path, cwd)
-  2. Resolve API URL (external, existing local, or auto-start daemon)
-  3. Derive bank ID (static or dynamic from project context)
-  4. Ensure bank mission is set (first use only)
-  5. Compose multi-turn query if recallContextTurns > 1
-  6. Truncate to recallMaxQueryChars
-  7. Call Hindsight recall API
-  8. Format memories and output hookSpecificOutput.additionalContext
-  9. Save last recall to state (for PostCompact re-injection)
+  2. (switchroom #424 4.1) Check per-session recall cache; on hit, emit
+     cached output and skip the API round-trip.
+  3. Resolve API URL (external, existing local, or auto-start daemon)
+  4. Derive bank ID (static or dynamic from project context)
+  5. Ensure bank mission is set (first use only)
+  6. Compose multi-turn query if recallContextTurns > 1
+  7. Truncate to recallMaxQueryChars
+  8. Call Hindsight recall API
+  9. Format memories and output hookSpecificOutput.additionalContext
+ 10. Persist to per-session cache for the next prompt-equal invocation.
+ 11. Save last recall to state (for PostCompact re-injection)
 
 Exit codes:
   0 — always (graceful degradation on any error)
 """
 
+import hashlib
 import json
 import os
 import sys
@@ -37,9 +41,118 @@ from lib.content import (
 )
 from lib.daemon import get_api_url
 from lib.directives import fetch_active_directives, format_active_directives_block
-from lib.state import write_state
+from lib.state import read_state, write_state
 
 LAST_RECALL_STATE = "last_recall.json"
+RECALL_CACHE_STATE = "recall_cache.json"
+
+# Switchroom #424 phase 4.1 — per-session recall cache.
+#
+# Caching is opt-in via env var: HINDSIGHT_RECALL_CACHE_TTL_SECS=N. Set N
+# to 0 (or leave unset) to disable. On hit, the script emits the cached
+# `additionalContext` and skips the directive + recall API round-trips
+# entirely.
+#
+# Hits fire when (session_id, prompt, bank_id, extra_banks) match a
+# prior entry within the TTL. Cache entries are scoped to a single
+# session_id — a new session (e.g. agent restart, /reset, /new) starts
+# a fresh cache window even if the env-configured TTL hasn't elapsed.
+#
+# The expected hit rate in production is modest (real users don't
+# typically resubmit identical prompts), but this trims redundant
+# recall traffic on session-resume re-processing and any retry paths.
+CACHE_ENV = "HINDSIGHT_RECALL_CACHE_TTL_SECS"
+
+# Maximum number of cache entries kept per session before LRU eviction.
+# 100 is comfortably above the typical session size (~30 inbounds) and
+# well below any concern about state-file size growth.
+CACHE_MAX_ENTRIES = 100
+
+
+def _cache_ttl_secs() -> int:
+    """Read the recall-cache TTL from env. Returns 0 (disabled) on any
+    parse error or sub-zero value — caller treats 0 as "skip cache."""
+    raw = os.environ.get(CACHE_ENV, "").strip()
+    if not raw:
+        return 0
+    try:
+        n = int(raw)
+        return n if n > 0 else 0
+    except ValueError:
+        return 0
+
+
+def _cache_key(session_id: str, prompt: str, bank_id: str, extra_banks: list) -> str:
+    """Stable hash for cache keying. Session_id is included so a new
+    session always misses, regardless of the TTL setting. Extra banks
+    are sorted so list-order doesn't change the key."""
+    parts = [
+        session_id or "",
+        prompt or "",
+        bank_id or "",
+        ",".join(sorted(extra_banks or [])),
+    ]
+    payload = "\x1f".join(parts)
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def _cache_lookup(key: str, ttl_secs: int) -> str | None:
+    """Return the cached `additionalContext` for `key` if present and
+    within TTL, else None. Failure-tolerant — any read error returns
+    None and the caller falls through to a fresh recall."""
+    if ttl_secs <= 0:
+        return None
+    state = read_state(RECALL_CACHE_STATE, {}) or {}
+    entries = state.get("entries") or {}
+    entry = entries.get(key)
+    if not isinstance(entry, dict):
+        return None
+    saved_at = entry.get("saved_at")
+    context = entry.get("context")
+    if not isinstance(saved_at, (int, float)) or not isinstance(context, str):
+        return None
+    if time.time() - saved_at > ttl_secs:
+        return None
+    return context
+
+
+def _cache_store(key: str, context: str) -> None:
+    """Write a cache entry. LRU-evicts the oldest entry when exceeding
+    CACHE_MAX_ENTRIES so the file stays bounded. Failure-tolerant."""
+    state = read_state(RECALL_CACHE_STATE, {}) or {}
+    entries = state.get("entries") or {}
+    if not isinstance(entries, dict):
+        entries = {}
+    entries[key] = {
+        "context": context,
+        "saved_at": time.time(),
+    }
+    if len(entries) > CACHE_MAX_ENTRIES:
+        # LRU evict by saved_at ascending.
+        sorted_keys = sorted(
+            entries.keys(),
+            key=lambda k: entries[k].get("saved_at") if isinstance(entries[k], dict) else 0,
+        )
+        for k in sorted_keys[: len(entries) - CACHE_MAX_ENTRIES]:
+            entries.pop(k, None)
+    state["entries"] = entries
+    state["updated_at"] = time.time()
+    write_state(RECALL_CACHE_STATE, state)
+
+
+def _emit_cached_context(context: str) -> None:
+    """Emit the same hookSpecificOutput shape that the fresh-recall
+    path emits, so the cached path is byte-equivalent from claude
+    code's perspective."""
+    json.dump(
+        {
+            "hookSpecificOutput": {
+                "hookEventName": "UserPromptSubmit",
+                "additionalContext": context,
+            }
+        },
+        sys.stdout,
+    )
 
 
 def read_transcript_messages(transcript_path: str) -> list:
@@ -99,6 +212,8 @@ def main():
         debug_log(config, "Prompt too short for recall, skipping")
         return
 
+    session_id = hook_input.get("session_id") or ""
+
     # Resolve API URL (handles all three connection modes)
     def _dbg(*a):
         debug_log(config, *a)
@@ -118,6 +233,27 @@ def main():
 
     # Derive bank ID (static or dynamic from project context)
     bank_id = derive_bank_id(hook_input, config)
+    additional_banks = config.get("recallAdditionalBanks", []) or []
+
+    # Switchroom #424 phase 4.1 — cache check BEFORE any HTTP traffic.
+    # Whole-session-scoped, opt-in via HINDSIGHT_RECALL_CACHE_TTL_SECS.
+    cache_ttl = _cache_ttl_secs()
+    cache_key = (
+        _cache_key(session_id, prompt, bank_id, additional_banks)
+        if cache_ttl > 0
+        else ""
+    )
+    if cache_ttl > 0:
+        try:
+            cached_context = _cache_lookup(cache_key, cache_ttl)
+        except Exception as e:
+            debug_log(config, f"Recall cache read failed (non-fatal): {e}")
+            cached_context = None
+        if cached_context is not None:
+            debug_log(config, f"Recall cache HIT (key={cache_key[:12]}…) — skipping API call")
+            _emit_cached_context(cached_context)
+            return
+        debug_log(config, f"Recall cache MISS (key={cache_key[:12]}…)")
 
     # Set bank mission on first use
     ensure_bank_mission(client, bank_id, config, debug_fn=_dbg)
@@ -173,8 +309,10 @@ def main():
         # have one, so a recall API failure doesn't blind the agent to
         # its own active directives.
 
-    # Also recall from any additional banks (e.g. shared user profile bank)
-    additional_banks = config.get("recallAdditionalBanks", [])
+    # Also recall from any additional banks (e.g. shared user profile bank).
+    # `additional_banks` was already extracted above the cache check so the
+    # cache key reflects every bank queried; reuse that local instead of
+    # re-reading config.
     for extra_bank_id in additional_banks:
         try:
             extra_response = client.recall(
@@ -253,6 +391,14 @@ def main():
             "directive_count": len(directives),
         },
     )
+
+    # Switchroom #424 phase 4.1 — populate the cache for the next hit.
+    # Failure-tolerant: a write error here doesn't mask the recall result.
+    if cache_ttl > 0 and cache_key:
+        try:
+            _cache_store(cache_key, context_message)
+        except Exception as e:
+            debug_log(config, f"Recall cache write failed (non-fatal): {e}")
 
     # Output JSON for Claude Code hook system
     output = {

--- a/vendor/hindsight-memory/tests/test_hooks.py
+++ b/vendor/hindsight-memory/tests/test_hooks.py
@@ -171,6 +171,145 @@ class TestRecallHook:
         if "body" in captured_body:
             assert "Python" in captured_body["body"].get("query", "")
 
+    def test_cache_disabled_by_default_no_state_written(self, monkeypatch, tmp_path):
+        """Without HINDSIGHT_RECALL_CACHE_TTL_SECS the recall_cache.json
+        state file should never be created — backwards-compatible default."""
+        memory = make_memory("Some fact", "world")
+        response = FakeHTTPResponse({"results": [memory]})
+        hook_input = make_hook_input(prompt="A meaningful prompt that stays put")
+        _run_hook("recall", hook_input, monkeypatch, tmp_path,
+                  urlopen_side_effect=lambda *a, **kw: response)
+
+        cache_path = tmp_path / "plugin_data" / "state" / "recall_cache.json"
+        assert not cache_path.exists()
+
+    def test_cache_hit_skips_http_call(self, monkeypatch, tmp_path):
+        """Two identical recall calls with TTL>0 should hit HTTP exactly once."""
+        memory = make_memory("Paris is the capital of France", "world")
+        response = FakeHTTPResponse({"results": [memory]})
+
+        call_count = {"n": 0}
+
+        def counting_urlopen(*a, **kw):
+            call_count["n"] += 1
+            return FakeHTTPResponse({"results": [memory]})
+
+        hook_input = make_hook_input(prompt="What is the capital of France?")
+
+        # First call — must hit HTTP
+        out1 = _run_hook(
+            "recall", hook_input, monkeypatch, tmp_path,
+            urlopen_side_effect=counting_urlopen,
+            extra_env={"HINDSIGHT_RECALL_CACHE_TTL_SECS": "60"},
+        )
+        first_http = call_count["n"]
+        assert first_http >= 1
+        assert "Paris is the capital of France" in out1
+
+        # Second call — same prompt, same session → cache hit, no extra HTTP
+        out2 = _run_hook(
+            "recall", hook_input, monkeypatch, tmp_path,
+            urlopen_side_effect=counting_urlopen,
+            extra_env={"HINDSIGHT_RECALL_CACHE_TTL_SECS": "60"},
+        )
+        assert call_count["n"] == first_http  # unchanged
+        # Cached output is byte-equivalent context
+        data1 = json.loads(out1)
+        data2 = json.loads(out2)
+        assert data1["hookSpecificOutput"]["additionalContext"] == \
+            data2["hookSpecificOutput"]["additionalContext"]
+
+    def test_cache_miss_on_different_prompt(self, monkeypatch, tmp_path):
+        memory = make_memory("Some fact", "world")
+        call_count = {"n": 0}
+
+        def counting_urlopen(*a, **kw):
+            call_count["n"] += 1
+            return FakeHTTPResponse({"results": [memory]})
+
+        hook_a = make_hook_input(prompt="Question one about France?")
+        hook_b = make_hook_input(prompt="Question two about Spain?")
+
+        _run_hook("recall", hook_a, monkeypatch, tmp_path,
+                  urlopen_side_effect=counting_urlopen,
+                  extra_env={"HINDSIGHT_RECALL_CACHE_TTL_SECS": "60"})
+        before_b = call_count["n"]
+        _run_hook("recall", hook_b, monkeypatch, tmp_path,
+                  urlopen_side_effect=counting_urlopen,
+                  extra_env={"HINDSIGHT_RECALL_CACHE_TTL_SECS": "60"})
+        # Different prompts → both must hit HTTP independently
+        assert call_count["n"] > before_b
+
+    def test_cache_miss_on_session_change(self, monkeypatch, tmp_path):
+        """Same prompt but different session_id must MISS the cache —
+        sessions are isolated to prevent cross-contamination."""
+        memory = make_memory("Some fact", "world")
+        call_count = {"n": 0}
+
+        def counting_urlopen(*a, **kw):
+            call_count["n"] += 1
+            return FakeHTTPResponse({"results": [memory]})
+
+        hook_session_a = make_hook_input(prompt="The same prompt", session_id="session-a")
+        hook_session_b = make_hook_input(prompt="The same prompt", session_id="session-b")
+
+        _run_hook("recall", hook_session_a, monkeypatch, tmp_path,
+                  urlopen_side_effect=counting_urlopen,
+                  extra_env={"HINDSIGHT_RECALL_CACHE_TTL_SECS": "60"})
+        first = call_count["n"]
+        _run_hook("recall", hook_session_b, monkeypatch, tmp_path,
+                  urlopen_side_effect=counting_urlopen,
+                  extra_env={"HINDSIGHT_RECALL_CACHE_TTL_SECS": "60"})
+        assert call_count["n"] > first
+
+    def test_cache_miss_after_ttl_expiry(self, monkeypatch, tmp_path):
+        """An entry older than TTL should NOT serve a cache hit. We
+        backdate the cache file's saved_at to simulate TTL elapse."""
+        memory = make_memory("Some fact", "world")
+        call_count = {"n": 0}
+
+        def counting_urlopen(*a, **kw):
+            call_count["n"] += 1
+            return FakeHTTPResponse({"results": [memory]})
+
+        hook_input = make_hook_input(prompt="Same exact prompt twice")
+
+        # Populate cache with TTL=60.
+        _run_hook("recall", hook_input, monkeypatch, tmp_path,
+                  urlopen_side_effect=counting_urlopen,
+                  extra_env={"HINDSIGHT_RECALL_CACHE_TTL_SECS": "60"})
+        first = call_count["n"]
+
+        # Backdate every entry's saved_at to an hour ago.
+        cache_path = tmp_path / "plugin_data" / "state" / "recall_cache.json"
+        assert cache_path.exists()
+        state = json.loads(cache_path.read_text())
+        long_ago = time.time() - 3600
+        for k, entry in (state.get("entries") or {}).items():
+            entry["saved_at"] = long_ago
+        cache_path.write_text(json.dumps(state))
+
+        # Re-run with the same TTL — should MISS because of expiry.
+        _run_hook("recall", hook_input, monkeypatch, tmp_path,
+                  urlopen_side_effect=counting_urlopen,
+                  extra_env={"HINDSIGHT_RECALL_CACHE_TTL_SECS": "60"})
+        assert call_count["n"] > first
+
+    def test_cache_invalid_env_disables_caching(self, monkeypatch, tmp_path):
+        """Garbage TTL env vars are treated as 'disabled' — no cache file."""
+        memory = make_memory("Some fact", "world")
+        response = FakeHTTPResponse({"results": [memory]})
+        hook_input = make_hook_input(prompt="A normal prompt")
+
+        for bad in ("not-a-number", "-5", "0", " "):
+            _run_hook(
+                "recall", hook_input, monkeypatch, tmp_path,
+                urlopen_side_effect=lambda *a, **kw: response,
+                extra_env={"HINDSIGHT_RECALL_CACHE_TTL_SECS": bad},
+            )
+            cache_path = tmp_path / "plugin_data" / "state" / "recall_cache.json"
+            assert not cache_path.exists(), f"Cache should not be written for TTL={bad!r}"
+
     def test_disabled_auto_recall_produces_no_output(self, monkeypatch, tmp_path):
         (tmp_path / "plugin_root").mkdir(exist_ok=True)
         (tmp_path / "plugin_data").mkdir(exist_ok=True)


### PR DESCRIPTION
Phase 4.1 of #424.

## What it does

Identical (prompt, bank, session_id) recalls within a TTL window now reuse the cached \`additionalContext\` block and skip the Hindsight HTTP recall + directives fetch entirely.

Cache lives in \`\$CLAUDE_PLUGIN_DATA/state/recall_cache.json\`. Atomic writes via the plugin's existing state library. LRU-evicts the oldest entry beyond 100 entries.

## Honest ROI

Same-prompt-twice scenarios are rare in practice. Real cache hits come from:
- session resume re-processing the same inbound (the \`--continue\` path)
- manual user retry of identical message
- rapid-fire identical prompt within the TTL window

Expected savings per session: ~200-500ms across one or two skipped HTTP recalls. Not as impactful as the \`max_memories\` cap (which reduces *every*-turn prompt-token cost). But additive — failure-tolerant, falls through to fresh recall on cache miss.

## Switchroom integration

- New \`memory.recall.cache_ttl_secs\` field in \`switchroom.yaml\` schema (cascades like \`max_memories\`).
- \`profiles/_base/start.sh.hbs\` exports \`HINDSIGHT_RECALL_CACHE_TTL_SECS\` unconditionally, defaulting to 600 (10 min). Set to 0 in switchroom.yaml to disable per agent.

## Implementation

Patched \`vendor/hindsight-memory/scripts/recall.py\` directly. The vendor folder already carries switchroom-specific patches (workaround for vectorize-io/hindsight#1269), so the fork-maintenance burden is already accepted. Caching is gated by an env var so the upstream behavior is preserved when unset — diff stays minimal and easy to rebase against future upstream updates.

## Test plan

- [x] 6 new Python tests in \`vendor/hindsight-memory/tests/test_hooks.py\` covering cache disabled/hit/miss/session-change/TTL-expiry/invalid-env.
- [x] 3 new scaffold tests in \`tests/scaffold.test.ts\` verifying default-600s, operator override, and the 0-disabled sentinel.
- [x] All 156 Python tests + 160 vitest scaffold tests pass.
- [x] \`npm run lint\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)