### PR TITLE
feat(memory): cap observation growth on bundled Hindsight container

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -84,6 +84,14 @@ The cap applies to the *combined* result list across the primary bank and any `r
 
 Operationally: the cap is set via the `HINDSIGHT_RECALL_MAX_MEMORIES` env var that `start.sh` exports. The vendored plugin's `recall.py` slices results client-side before formatting (plugin v0.4.0 has no `recallTopK` setting on the Claude Code integration — only Openclaw exposes it).
 
+### Server-side caps on the Hindsight container
+
+`switchroom memory --start` launches the bundled Hindsight container with `HINDSIGHT_API_MAX_OBSERVATIONS_PER_SCOPE=1000` already set. This caps how many observation entries Hindsight will hold per consolidation scope (per bank, per memory type) — without it, a 24/7 agent's bank grows unboundedly (vectorize-io/hindsight#1284 is the upstream tracking issue). The same default is baked into the `--compose` snippet output.
+
+You don't need to do anything to opt in. Override by stopping the bundled container and re-running `docker run` with a different `-e HINDSIGHT_API_MAX_OBSERVATIONS_PER_SCOPE=N` value, or by editing the generated docker-compose snippet before applying it.
+
+If you run your own Hindsight container outside `switchroom memory --start` (e.g. you point `memory.config.url` at an external server), switchroom doesn't manage that container's env — set the cap on your own image.
+
 Any server from `defaults.mcp_servers` also flows to all agents via the normal cascade.
 
 To suppress the built-in `playwright` server for a specific agent:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -86,7 +86,11 @@ Operationally: the cap is set via the `HINDSIGHT_RECALL_MAX_MEMORIES` env var th
 
 ### Server-side caps on the Hindsight container
 
-`switchroom memory --start` launches the bundled Hindsight container with `HINDSIGHT_API_MAX_OBSERVATIONS_PER_SCOPE=1000` already set. This caps how many observation entries Hindsight will hold per consolidation scope (per bank, per memory type) — without it, a 24/7 agent's bank grows unboundedly (vectorize-io/hindsight#1284 is the upstream tracking issue). The same default is baked into the `--compose` snippet output.
+`switchroom memory --start` launches the bundled Hindsight container with `HINDSIGHT_API_MAX_OBSERVATIONS_PER_SCOPE=1000` already set. The same default is baked into the `--compose` snippet output.
+
+What this actually caps: per-*tag scope* observation count. Switchroom's vendored plugin retains with `retainTags: ["{session_id}"]`, so each session becomes its own scope and the cap bounds a single very-long session at 1000 observations. Most sessions stay well below 1000 — this is a safety rail for the worst case (a Telegram session running uninterrupted for weeks), not an active limit on most agents. Tagless observations are unaffected.
+
+This is **not** a fix for vectorize-io/hindsight#1284 (the upstream unbounded-growth bug for whole-bank consolidation) — that's their work to do. It's a companion guardrail.
 
 You don't need to do anything to opt in. Override by stopping the bundled container and re-running `docker run` with a different `-e HINDSIGHT_API_MAX_OBSERVATIONS_PER_SCOPE=N` value, or by editing the generated docker-compose snippet before applying it.
 

--- a/src/setup/hindsight.ts
+++ b/src/setup/hindsight.ts
@@ -8,6 +8,25 @@ export const HINDSIGHT_DEFAULT_API_PORT = 8888;
 export const HINDSIGHT_DEFAULT_UI_PORT = 9999;
 
 /**
+ * Default cap on observations per consolidation scope.
+ *
+ * Upstream Hindsight defaults this to "unbounded" — observation entries
+ * accumulate forever inside a bank. For a 24/7 conversational agent
+ * (switchroom's primary use case) that means experience entries grow
+ * indefinitely; vectorize-io/hindsight#1284 is the open upstream
+ * tracking issue. Setting `HINDSIGHT_API_MAX_OBSERVATIONS_PER_SCOPE` on
+ * the container caps the count and lets older observations be
+ * consolidated/aged out.
+ *
+ * 1000 is a reasonable starting cap for a personal assistant pattern:
+ * comfortably above any single user's likely-relevant memory window,
+ * comfortably below the point where consolidation costs balloon. Tunable
+ * by setting `HINDSIGHT_API_MAX_OBSERVATIONS_PER_SCOPE` directly on the
+ * `docker run` invocation if you want to override.
+ */
+export const HINDSIGHT_DEFAULT_MAX_OBSERVATIONS_PER_SCOPE = 1000;
+
+/**
  * Check if a TCP port is free for binding on 127.0.0.1.
  * Returns true if free, false if something is already listening.
  */
@@ -139,7 +158,12 @@ export function startHindsight(
 ): void {
   const apiPort = ports?.apiPort ?? HINDSIGHT_DEFAULT_API_PORT;
   const uiPort = ports?.uiPort ?? HINDSIGHT_DEFAULT_UI_PORT;
-  const envArgs: string[] = [];
+  const envArgs: string[] = [
+    // Cap unbounded observation growth (vectorize-io/hindsight#1284).
+    // Always set on switchroom-managed containers so 24/7 agent banks
+    // don't accumulate indefinitely.
+    "-e", `HINDSIGHT_API_MAX_OBSERVATIONS_PER_SCOPE=${HINDSIGHT_DEFAULT_MAX_OBSERVATIONS_PER_SCOPE}`,
+  ];
   if (provider) envArgs.push("-e", `HINDSIGHT_API_LLM_PROVIDER=${provider}`);
   if (apiKey) envArgs.push("-e", `HINDSIGHT_API_LLM_API_KEY=${apiKey}`);
   const args = [
@@ -202,9 +226,11 @@ export function getHindsightMcpUrl(): {
  * Generate a docker-compose snippet for Hindsight.
  */
 export function generateHindsightComposeSnippet(provider?: string): string {
-  const envLines = provider
-    ? [`      - LLM_PROVIDER=${provider}`]
-    : [];
+  const envLines = [
+    // Always-on cap — see startHindsight() for context.
+    `      - HINDSIGHT_API_MAX_OBSERVATIONS_PER_SCOPE=${HINDSIGHT_DEFAULT_MAX_OBSERVATIONS_PER_SCOPE}`,
+  ];
+  if (provider) envLines.push(`      - LLM_PROVIDER=${provider}`);
 
   return [
     "services:",
@@ -214,9 +240,8 @@ export function generateHindsightComposeSnippet(provider?: string): string {
     "    ports:",
     "      - \"8888:8888\"",
     "      - \"9999:9999\"",
-    ...(envLines.length > 0
-      ? ["    environment:", ...envLines]
-      : []),
+    "    environment:",
+    ...envLines,
     "    volumes:",
     "      - switchroom-hindsight-data:/home/hindsight/.pg0",
     "    restart: unless-stopped",

--- a/src/setup/hindsight.ts
+++ b/src/setup/hindsight.ts
@@ -8,21 +8,26 @@ export const HINDSIGHT_DEFAULT_API_PORT = 8888;
 export const HINDSIGHT_DEFAULT_UI_PORT = 9999;
 
 /**
- * Default cap on observations per consolidation scope.
+ * Default cap on observations per *tag scope*.
  *
- * Upstream Hindsight defaults this to "unbounded" — observation entries
- * accumulate forever inside a bank. For a 24/7 conversational agent
- * (switchroom's primary use case) that means experience entries grow
- * indefinitely; vectorize-io/hindsight#1284 is the open upstream
- * tracking issue. Setting `HINDSIGHT_API_MAX_OBSERVATIONS_PER_SCOPE` on
- * the container caps the count and lets older observations be
- * consolidated/aged out.
+ * Upstream Hindsight defaults `HINDSIGHT_API_MAX_OBSERVATIONS_PER_SCOPE`
+ * to `-1` (unlimited). Once a tag scope hits the cap, consolidation
+ * stops creating new observations and only updates/deletes existing
+ * ones — bounding the cost of consolidating a single long-running
+ * scope. Tagless observations are unaffected.
  *
- * 1000 is a reasonable starting cap for a personal assistant pattern:
- * comfortably above any single user's likely-relevant memory window,
- * comfortably below the point where consolidation costs balloon. Tunable
- * by setting `HINDSIGHT_API_MAX_OBSERVATIONS_PER_SCOPE` directly on the
- * `docker run` invocation if you want to override.
+ * Switchroom retains with `retainTags: ["{session_id}"]` (vendored
+ * plugin default), so a "tag scope" maps roughly to "one session." A
+ * very long Telegram session that runs for weeks can accumulate
+ * thousands of observations under one scope — that's the case 1000
+ * targets. Most sessions are far below the cap, so for typical
+ * agents this is defense-in-depth rather than an active limit.
+ *
+ * This is NOT a fix for vectorize-io/hindsight#1284 (the upstream
+ * unbounded-growth bug for consolidation across a whole bank); it's a
+ * companion safety rail until that lands. Operators who want a
+ * different value can stop the container and re-run `docker run`
+ * with `-e HINDSIGHT_API_MAX_OBSERVATIONS_PER_SCOPE=N`.
  */
 export const HINDSIGHT_DEFAULT_MAX_OBSERVATIONS_PER_SCOPE = 1000;
 
@@ -159,9 +164,10 @@ export function startHindsight(
   const apiPort = ports?.apiPort ?? HINDSIGHT_DEFAULT_API_PORT;
   const uiPort = ports?.uiPort ?? HINDSIGHT_DEFAULT_UI_PORT;
   const envArgs: string[] = [
-    // Cap unbounded observation growth (vectorize-io/hindsight#1284).
-    // Always set on switchroom-managed containers so 24/7 agent banks
-    // don't accumulate indefinitely.
+    // Per-tag-scope observation cap. Bounds the size of a single
+    // long-running session (switchroom retains tagged with
+    // `{session_id}`). See HINDSIGHT_DEFAULT_MAX_OBSERVATIONS_PER_SCOPE
+    // for the rationale and how it relates to vectorize-io/hindsight#1284.
     "-e", `HINDSIGHT_API_MAX_OBSERVATIONS_PER_SCOPE=${HINDSIGHT_DEFAULT_MAX_OBSERVATIONS_PER_SCOPE}`,
   ];
   if (provider) envArgs.push("-e", `HINDSIGHT_API_LLM_PROVIDER=${provider}`);

--- a/tests/memory.test.ts
+++ b/tests/memory.test.ts
@@ -245,4 +245,17 @@ describe("generateHindsightComposeSnippet", () => {
     expect(snippet).toContain("LLM_PROVIDER=openai");
     expect(snippet).toContain("environment:");
   });
+
+  it("always sets HINDSIGHT_API_MAX_OBSERVATIONS_PER_SCOPE (caps unbounded growth)", () => {
+    // Mitigation for vectorize-io/hindsight#1284. Must be present even
+    // when no LLM provider is configured (e.g. operator using an
+    // external Hindsight server but still wanting the cap on a self-
+    // managed container they generate the compose snippet for).
+    const noProvider = generateHindsightComposeSnippet();
+    expect(noProvider).toContain("HINDSIGHT_API_MAX_OBSERVATIONS_PER_SCOPE=1000");
+    expect(noProvider).toContain("environment:");
+
+    const withProvider = generateHindsightComposeSnippet("openai");
+    expect(withProvider).toContain("HINDSIGHT_API_MAX_OBSERVATIONS_PER_SCOPE=1000");
+  });
 });


### PR DESCRIPTION
Part of #438 Tier 2.

## What

Always set `HINDSIGHT_API_MAX_OBSERVATIONS_PER_SCOPE=1000` on the Hindsight container that switchroom manages. Applied to both:
- `switchroom memory --start` (docker run)
- `switchroom memory --compose` (compose snippet output)

## What this actually caps

Per *tag scope*, not per bank. Upstream Hindsight defaults the env to `-1` (unlimited). Once a tag scope hits the cap, consolidation stops creating new observations and only updates/deletes existing ones — bounding the cost of consolidating a single long-running scope. Tagless observations are unaffected.

Switchroom's vendored plugin retains with `retainTags: ["{session_id}"]`, so a "tag scope" maps roughly to **one session**. The cap bounds a single very-long session at 1000 observations. Most sessions stay well below — this is a safety rail for the worst case (a Telegram session running uninterrupted for weeks), not an active limit on most agents.

## What this is NOT

Not a fix for vectorize-io/hindsight#1284 (the upstream unbounded-growth bug for whole-bank consolidation). That's upstream's work to do. This is a companion guardrail.

## Files

| File | Change |
| --- | --- |
| `src/setup/hindsight.ts` | New `HINDSIGHT_DEFAULT_MAX_OBSERVATIONS_PER_SCOPE=1000` constant; pushed into `startHindsight()` docker args and `generateHindsightComposeSnippet()`. The compose snippet now always emits `environment:` (was conditionally omitted when no LLM provider was set). |
| `tests/memory.test.ts` | One new test asserting both no-provider and with-provider compose snippets contain the cap line. |
| `docs/configuration.md` | New "Server-side caps on the Hindsight container" subsection — honest about what the cap accomplishes vs. what it doesn't. |

## Out of scope (intentional)

- **External Hindsight containers** (e.g. user's own `~/.hindsight-docker/` or a remote server). Switchroom doesn't manage those — the operator owns the env there. Documented.
- **Per-workspace yaml knob** for the cap. Adding `memory.config.max_observations_per_scope` would require a container restart on change, and most users won't want to tune. Add when demand emerges.
- **Other Hindsight server tunables** like `HINDSIGHT_API_RERANKER_MAX_CANDIDATES` and `HINDSIGHT_API_CONSOLIDATION_SOURCE_FACTS_MAX_TOKENS`. Same logic.

## Verification

- `npm run lint` clean.
- `tests/memory.test.ts` 16/16 pass.
- Full vitest sweep (after `bun scripts/build.mjs`): **4087 pass, 0 fail**.

## Test plan

- [ ] `switchroom memory --start` on a fresh host shows the env in `docker inspect switchroom-hindsight | grep MAX_OBSERVATIONS`.
- [ ] `switchroom memory --compose` output includes the env line in the `environment:` block whether or not `--provider` was passed.
- [ ] Existing `switchroom-hindsight` containers keep running until the operator restarts; no auto-migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)