### PR TITLE
fix(auth): ASCII-only heal output (work around bun bundler bug)

### DIFF
--- a/src/cli/auth.ts
+++ b/src/cli/auth.ts
@@ -106,7 +106,7 @@ export function diagnoseAuthState(claudeConfigDir: string): AuthDiagnosis {
     findings.push({
       code: "credentials_missing",
       severity: "error",
-      summary: "no .credentials.json AND no .oauth-token — agent has never been authenticated",
+      summary: "no .credentials.json AND no .oauth-token - agent has never been authenticated",
     });
   } else if (!hasCreds) {
     // .oauth-token alone is the legacy state — works for in-process
@@ -127,7 +127,7 @@ export function diagnoseAuthState(claudeConfigDir: string): AuthDiagnosis {
       findings.push({
         code: "credentials_malformed",
         severity: "error",
-        summary: ".credentials.json is not valid JSON — file corrupted",
+        summary: ".credentials.json is not valid JSON - file corrupted",
       });
     }
     if (parsed) {
@@ -136,7 +136,7 @@ export function diagnoseAuthState(claudeConfigDir: string): AuthDiagnosis {
         findings.push({
           code: "credentials_malformed",
           severity: "error",
-          summary: ".credentials.json missing claudeAiOauth.accessToken — file corrupted",
+          summary: ".credentials.json missing claudeAiOauth.accessToken - file corrupted",
         });
       } else {
         // Token shape OK; check expiry.
@@ -154,7 +154,7 @@ export function diagnoseAuthState(claudeConfigDir: string): AuthDiagnosis {
           findings.push({
             code: "refresh_token_missing",
             severity: "warn",
-            summary: "no refreshToken — claude can't self-refresh; will break when access token expires",
+            summary: "no refreshToken - claude can't self-refresh; will break when access token expires",
           });
         }
       }
@@ -329,7 +329,7 @@ export function registerAuthCommand(program: Command): void {
         }
         console.log();
         if (diagnosis.severity === "ok") {
-          console.log(chalk.green("  ✓ Auth healthy — nothing to do."));
+          console.log(chalk.green("  ok: Auth healthy - nothing to do."));
           console.log();
           return;
         }


### PR DESCRIPTION
## What you saw

\`\`\`
🔴 boot:auth-check::refresh_token_missing  klanker no refreshToken â claude can't self-refresh; will break when access token expires
\`\`\`

The em-dash (\`—\`, U+2014) in heal's diagnose summary was arriving as \`â\` followed by control chars. Real bytes in the JSONL: \`c3 a2 c2 80 c2 94\` instead of the source's \`e2 80 94\`. That's classic double-UTF-8: the original bytes got read as Latin-1 codepoints and re-encoded as UTF-8.

## Root cause

**Bun bundler bug (v1.3.13).** Bun double-encodes UTF-8 string literals at runtime when the bundle starts with the \`// @bun\` directive. Minimal repro confirms:

\`\`\`bash
$ cat main.ts
console.log("before — after");
$ bun run main.ts                  # correct: e2 80 94
$ bun build main.ts --target node
$ bun run dist/main.js             # correct: e2 80 94
$ <prepend "// @bun" to dist/main.js>
$ bun run dist/main.js             # WRONG: c3 a2 c2 80 c2 94
\`\`\`

Stripping the directive fixes the encoding but breaks \`import.meta.dirname\` resolution. Out of scope to fix in bun here.

## Pragmatic fix

Replace em-dashes with ASCII \`-\` in heal's user-visible output strings. Loses zero meaning, eliminates the rendering glitch.

\`\`\`
"no refreshToken — claude can't self-refresh"  →  "no refreshToken - claude can't self-refresh"
\`\`\`

(and 4 similar replacements)

## Out of scope

The pre-existing em-dashes in \`auth status\` table rendering (\`—\` placeholders for empty cells, \`✓\` for status) have the same bug but are wider in scope. They'll need either a repo-wide ASCII pass or an upstream bun fix. Filed for follow-up.

## Test plan

- [x] All 39 affected tests pass (heal diagnoser, handoff summarizer, oauth token inject).
- [x] Verified live on klanker: heal summary now reads \`no refreshToken - claude can't self-refresh\` cleanly.
- [x] \`npm run lint\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)