### PR TITLE
feat(memory): recall telemetry log + demote-from-recall tag (#432 4.3 + 4.4)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -84,6 +84,41 @@ The cap applies to the *combined* result list across the primary bank and any `r
 
 Operationally: the cap is set via the `HINDSIGHT_RECALL_MAX_MEMORIES` env var that `start.sh` exports. The vendored plugin's `recall.py` slices results client-side before formatting (plugin v0.4.0 has no `recallTopK` setting on the Claude Code integration — only Openclaw exposes it).
 
+### Demoting individual memories from auto-recall
+
+If one specific memory keeps surfacing in the recall block and isn't useful (over-broad world fact, stale context, etc.), tag it with `[demote-from-recall]` — or `demote-from-recall` / `no-recall`, all three work. The memory stays in the bank, `mcp__hindsight__reflect` and manual recall can still find it, but auto-recall skips it.
+
+```
+# inside an agent, against its own bank
+mcp__hindsight__update_memory(memory_id="abc-123", tags=["[demote-from-recall]"])
+```
+
+The filter runs before the `max_memories` cap, so demoting a noisy memory doesn't waste a slot.
+
+### Inspecting auto-recall in production — `switchroom memory recall-log`
+
+Every auto-recall run (cache hit or miss) appends a JSONL record to the agent's plugin-state dir. View via:
+
+```
+switchroom memory recall-log [agent] [-n N] [--json]
+```
+
+Per-agent output looks like:
+
+```
+clerk:
+  last 20 turns: avg=11.4 max=12 cache_hits=2 capped=8
+  2026-04-30T07:53:45Z OK    n=12 ids=mem-a1,mem-c4,mem-9f…+9
+  2026-04-30T07:52:10Z CAP   n=12/18 ids=mem-a1,mem-c4,mem-7e…+9
+  2026-04-30T07:51:33Z CACHE n=—
+```
+
+`OK` = uncapped recall fired; `CAP` = recall returned more than `max_memories` and was sliced; `CACHE` = served from the per-session cache (#424 4.1).
+
+Use this to answer "is 12 the right cap?" — if `CAP` fires on most turns, the bank has more relevant content than 12 lets through; consider raising. If `CAP` rarely fires and `avg` stays well below the cap, the cap isn't the lever and other tuning (`recallBudget`, retain hygiene) probably matters more.
+
+The log is bounded to the last ~5000 events per agent.
+
 ### Server-side caps on the Hindsight container
 
 `switchroom memory --start` launches the bundled Hindsight container with `HINDSIGHT_API_MAX_OBSERVATIONS_PER_SCOPE=1000` already set. The same default is baked into the `--compose` snippet output.

--- a/src/cli/memory.ts
+++ b/src/cli/memory.ts
@@ -15,7 +15,66 @@ import {
   HINDSIGHT_DEFAULT_API_PORT,
 } from "../setup/hindsight.js";
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { resolveAgentsDir } from "../config/loader.js";
 import YAML from "yaml";
+
+interface RecallLogEntry {
+  ts: string;
+  session_id?: string;
+  bank_id?: string;
+  additional_banks?: string[];
+  query_chars?: number;
+  result_count?: number | null;
+  directive_count?: number | null;
+  demoted_count?: number;
+  capped?: boolean;
+  pre_cap_count?: number;
+  memory_ids?: string[];
+  cache_hit?: boolean;
+}
+
+/**
+ * Read the most recent N entries from an agent's recall_log.jsonl.
+ *
+ * Path: <agentsDir>/<agent>/.claude/plugins/data/hindsight-memory-inline/state/recall_log.jsonl
+ * Returns [] if the file is missing (e.g. agent hasn't fired a recall
+ * since #432 phase 4.3 was deployed) or unreadable.
+ *
+ * Exported for tests.
+ */
+export function readRecallLog(
+  agentDir: string,
+  limit: number,
+): RecallLogEntry[] {
+  const path = join(
+    agentDir,
+    ".claude",
+    "plugins",
+    "data",
+    "hindsight-memory-inline",
+    "state",
+    "recall_log.jsonl",
+  );
+  if (!existsSync(path)) return [];
+  let raw: string;
+  try {
+    raw = readFileSync(path, "utf-8");
+  } catch {
+    return [];
+  }
+  const lines = raw.split("\n").filter((l) => l.trim().length > 0);
+  const tail = lines.slice(-limit);
+  const out: RecallLogEntry[] = [];
+  for (const line of tail) {
+    try {
+      out.push(JSON.parse(line) as RecallLogEntry);
+    } catch {
+      // Skip malformed lines silently — telemetry is best-effort.
+    }
+  }
+  return out;
+}
 
 export function registerMemoryCommand(program: Command): void {
   const memory = program
@@ -292,4 +351,94 @@ export function registerMemoryCommand(program: Command): void {
       console.log(generateHindsightComposeSnippet(opts.provider));
       console.log();
     });
+
+  // switchroom memory recall-log [agent]
+  memory
+    .command("recall-log [agent]")
+    .description(
+      "Show recent auto-recall events (per-turn JSONL log) — see what was injected, when the cap fired, hit rate hints",
+    )
+    .option("-n, --limit <n>", "Tail the last N events per agent (default 20)", "20")
+    .option("--json", "Emit raw JSONL (one entry per line)")
+    .action(
+      withConfigError(async (
+        agent: string | undefined,
+        opts: { limit: string; json?: boolean },
+      ) => {
+        const config = getConfig(program);
+        const agentsDir = resolveAgentsDir(config);
+        const limit = Math.max(1, parseInt(opts.limit, 10) || 20);
+
+        const targets = agent
+          ? config.agents[agent]
+            ? [agent]
+            : (() => {
+              console.error(chalk.red(`Agent "${agent}" is not defined in switchroom.yaml`));
+              process.exit(1);
+            })()
+          : Object.keys(config.agents);
+
+        for (const name of targets as string[]) {
+          const agentDir = join(agentsDir, name);
+          const entries = readRecallLog(agentDir, limit);
+
+          if (opts.json) {
+            for (const e of entries) {
+              console.log(JSON.stringify({ agent: name, ...e }));
+            }
+            continue;
+          }
+
+          if (entries.length === 0) {
+            console.log(
+              chalk.gray(`${name}: no recall events recorded yet (agent hasn't fired UserPromptSubmit since #432.4.3 deployed)`),
+            );
+            continue;
+          }
+
+          console.log(chalk.bold(`\n${name}:`));
+          // Aggregate at the top — one-line summary so scanning is fast.
+          const total = entries.length;
+          const hits = entries.filter((e) => e.cache_hit).length;
+          const cappedTurns = entries.filter((e) => e.capped).length;
+          const memCounts = entries
+            .map((e) => e.result_count)
+            .filter((n): n is number => typeof n === "number");
+          const avg =
+            memCounts.length > 0
+              ? Math.round(
+                  (memCounts.reduce((s, n) => s + n, 0) / memCounts.length) * 10,
+                ) / 10
+              : null;
+          const max = memCounts.length > 0 ? Math.max(...memCounts) : null;
+          console.log(
+            chalk.gray(
+              `  last ${total} turn${total === 1 ? "" : "s"}: ` +
+              `avg=${avg ?? "—"} max=${max ?? "—"} ` +
+              `cache_hits=${hits} capped=${cappedTurns}`,
+            ),
+          );
+
+          for (const e of entries) {
+            const flag = e.cache_hit
+              ? chalk.cyan("CACHE")
+              : e.capped
+                ? chalk.yellow("CAP")
+                : chalk.green("OK");
+            const dem = e.demoted_count && e.demoted_count > 0
+              ? chalk.dim(` -${e.demoted_count}d`)
+              : "";
+            const ids = e.memory_ids && e.memory_ids.length > 0
+              ? chalk.dim(` ids=${e.memory_ids.slice(0, 3).join(",")}${e.memory_ids.length > 3 ? `…+${e.memory_ids.length - 3}` : ""}`)
+              : "";
+            console.log(
+              `  ${chalk.gray(e.ts)} ${flag} ` +
+              `n=${e.result_count ?? "—"}${e.pre_cap_count != null && e.pre_cap_count !== e.result_count ? `/${e.pre_cap_count}` : ""}` +
+              `${dem}${ids}`,
+            );
+          }
+        }
+        console.log();
+      }),
+    );
 }

--- a/tests/cli.memory.recall-log.test.ts
+++ b/tests/cli.memory.recall-log.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { readRecallLog } from "../src/cli/memory.js";
+
+describe("readRecallLog", () => {
+  let agentDir: string;
+  let logPath: string;
+
+  beforeEach(() => {
+    agentDir = mkdtempSync(join(tmpdir(), "recall-log-"));
+    const stateDir = join(
+      agentDir,
+      ".claude",
+      "plugins",
+      "data",
+      "hindsight-memory-inline",
+      "state",
+    );
+    mkdirSync(stateDir, { recursive: true });
+    logPath = join(stateDir, "recall_log.jsonl");
+  });
+
+  afterEach(() => {
+    rmSync(agentDir, { recursive: true, force: true });
+  });
+
+  it("returns empty array when the log file doesn't exist", () => {
+    expect(readRecallLog(agentDir, 10)).toEqual([]);
+  });
+
+  it("returns empty array for an unrelated agent path", () => {
+    expect(readRecallLog("/nonexistent/path", 10)).toEqual([]);
+  });
+
+  it("parses well-formed JSONL lines", () => {
+    const lines = [
+      { ts: "2026-04-30T10:00:00Z", bank_id: "coach", result_count: 12, capped: false },
+      { ts: "2026-04-30T10:01:00Z", bank_id: "coach", result_count: 12, capped: true, pre_cap_count: 18 },
+    ];
+    writeFileSync(logPath, lines.map((l) => JSON.stringify(l)).join("\n") + "\n");
+
+    const out = readRecallLog(agentDir, 10);
+    expect(out).toHaveLength(2);
+    expect(out[0].bank_id).toBe("coach");
+    expect(out[1].capped).toBe(true);
+    expect(out[1].pre_cap_count).toBe(18);
+  });
+
+  it("tails the last N entries when limit is below the line count", () => {
+    const lines: string[] = [];
+    for (let i = 0; i < 50; i++) {
+      lines.push(JSON.stringify({ ts: `2026-04-30T${String(i).padStart(2, "0")}:00:00Z`, result_count: i }));
+    }
+    writeFileSync(logPath, lines.join("\n") + "\n");
+
+    const out = readRecallLog(agentDir, 5);
+    expect(out).toHaveLength(5);
+    expect(out[0].result_count).toBe(45);
+    expect(out[4].result_count).toBe(49);
+  });
+
+  it("skips malformed lines silently (telemetry is best-effort)", () => {
+    writeFileSync(
+      logPath,
+      [
+        JSON.stringify({ ts: "ok", result_count: 1 }),
+        "{this is not json",
+        JSON.stringify({ ts: "ok2", result_count: 2 }),
+      ].join("\n") + "\n",
+    );
+
+    const out = readRecallLog(agentDir, 10);
+    expect(out).toHaveLength(2);
+    expect(out[0].ts).toBe("ok");
+    expect(out[1].ts).toBe("ok2");
+  });
+
+  it("ignores blank lines", () => {
+    writeFileSync(
+      logPath,
+      `\n${JSON.stringify({ ts: "x" })}\n\n\n${JSON.stringify({ ts: "y" })}\n`,
+    );
+
+    const out = readRecallLog(agentDir, 10);
+    expect(out).toHaveLength(2);
+  });
+});

--- a/vendor/hindsight-memory/scripts/recall.py
+++ b/vendor/hindsight-memory/scripts/recall.py
@@ -68,6 +68,29 @@ CACHE_ENV = "HINDSIGHT_RECALL_CACHE_TTL_SECS"
 # well below any concern about state-file size growth.
 CACHE_MAX_ENTRIES = 100
 
+# Switchroom #432 phase 4.4 — demote-from-recall tag.
+#
+# A memory tagged with any of these strings stays in the bank (it can
+# still surface via reflect, manual mcp__hindsight__recall, etc.) but is
+# excluded from the auto-recall block injected on every UserPromptSubmit.
+# Useful when an over-broad "world fact" memory keeps drowning out more
+# relevant recent memories.
+DEMOTE_TAG_VARIANTS = (
+    "[demote-from-recall]",
+    "demote-from-recall",
+    "no-recall",
+)
+
+# Switchroom #432 phase 4.3 — recall telemetry log.
+#
+# Every recall (cache hit or miss) appends a JSONL record to
+# state/recall_log.jsonl: timestamp, session_id, bank, count, capped flag,
+# memory IDs. The file is bounded by RECALL_LOG_MAX_LINES so it stays
+# under a few MB even on chatty 24/7 agents. View via
+# `switchroom memory recall-log <agent>`.
+RECALL_LOG_FILE = "recall_log.jsonl"
+RECALL_LOG_MAX_LINES = 5000
+
 
 def _cache_ttl_secs() -> int:
     """Read the recall-cache TTL from env. Returns 0 (disabled) on any
@@ -153,6 +176,66 @@ def _emit_cached_context(context: str) -> None:
         },
         sys.stdout,
     )
+
+
+def _is_demoted_memory(memory) -> bool:
+    """Return True if the memory has any demote-from-recall tag.
+
+    Switchroom #432 phase 4.4. Tags are case-sensitive and can be
+    written with or without surrounding brackets (`[demote-from-recall]`
+    or `demote-from-recall` or `no-recall`). Anything that's not a list
+    of strings is treated as untagged.
+    """
+    tags = memory.get("tags") if isinstance(memory, dict) else None
+    if not isinstance(tags, list):
+        return False
+    for tag in tags:
+        if isinstance(tag, str) and tag.strip() in DEMOTE_TAG_VARIANTS:
+            return True
+    return False
+
+
+def _write_recall_log(entry: dict) -> None:
+    """Append a JSONL line to recall_log.jsonl. Bounded by line count.
+
+    Switchroom #432 phase 4.3. Failure-tolerant — telemetry must never
+    block recall, so any write error is swallowed silently. Unbounded
+    growth is prevented by truncating to the last RECALL_LOG_MAX_LINES
+    when the file is rolled over (cheap because we read once per
+    append; the alternative — keeping a separate index — is more code
+    for a feature that runs at most once per turn).
+    """
+    try:
+        plugin_data = os.environ.get("CLAUDE_PLUGIN_DATA", "")
+        if not plugin_data:
+            return
+        log_dir = os.path.join(plugin_data, "state")
+        os.makedirs(log_dir, exist_ok=True)
+        log_path = os.path.join(log_dir, RECALL_LOG_FILE)
+        line = json.dumps(entry, separators=(",", ":")) + "\n"
+        # Append-then-trim. For typical operation the file is well
+        # under the cap and the trim path is a no-op.
+        with open(log_path, "a", encoding="utf-8") as f:
+            f.write(line)
+        # Cheap rolling trim every ~50 writes (estimated by file size
+        # vs. 200 bytes/line average) to amortize the read cost.
+        try:
+            size = os.path.getsize(log_path)
+        except OSError:
+            return
+        if size > RECALL_LOG_MAX_LINES * 250:
+            try:
+                with open(log_path, "r", encoding="utf-8") as f:
+                    lines = f.readlines()
+                if len(lines) > RECALL_LOG_MAX_LINES:
+                    keep = lines[-RECALL_LOG_MAX_LINES:]
+                    with open(log_path, "w", encoding="utf-8") as f:
+                        f.writelines(keep)
+            except OSError:
+                pass
+    except Exception:
+        # Silently swallow — telemetry is never load-bearing.
+        pass
 
 
 def read_transcript_messages(transcript_path: str) -> list:
@@ -252,6 +335,18 @@ def main():
         if cached_context is not None:
             debug_log(config, f"Recall cache HIT (key={cache_key[:12]}…) — skipping API call")
             _emit_cached_context(cached_context)
+            _write_recall_log({
+                "ts": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+                "session_id": (session_id or "")[:32],
+                "bank_id": bank_id,
+                "additional_banks": additional_banks,
+                "query_chars": len(prompt),
+                "result_count": None,  # not known on cache hit
+                "directive_count": None,
+                "demoted_count": 0,
+                "capped": False,
+                "cache_hit": True,
+            })
             return
         debug_log(config, f"Recall cache MISS (key={cache_key[:12]}…)")
 
@@ -330,6 +425,16 @@ def main():
         except Exception as e:
             debug_log(config, f"Recall from additional bank '{extra_bank_id}' failed: {e}")
 
+    # Switchroom #432 phase 4.4 — drop demote-tagged memories before
+    # the cap. Filtering early means the cap kicks in over the
+    # non-demoted set (i.e. the user gets up to N "real" hits,
+    # not N including ones they explicitly demoted).
+    pre_filter_count = len(results)
+    results = [m for m in results if not _is_demoted_memory(m)]
+    demoted_count = pre_filter_count - len(results)
+    if demoted_count > 0:
+        debug_log(config, f"Filtered {demoted_count} demote-from-recall memories")
+
     # Switchroom-local: client-side count cap. Plugin v0.4.0 has no
     # `recallTopK` in the Claude Code integration (Openclaw-only), and a
     # token budget alone doesn't bound count — a single long memory can
@@ -337,6 +442,8 @@ def main():
     # Slice the combined results from primary + additional banks before
     # formatting. <= 0 disables the cap.
     recall_max_memories = config.get("recallMaxMemories", 0)
+    pre_cap_count = len(results)
+    capped = False
     if (
         isinstance(recall_max_memories, int)
         and recall_max_memories > 0
@@ -348,6 +455,7 @@ def main():
             f"(set HINDSIGHT_RECALL_MAX_MEMORIES=0 to disable)",
         )
         results = results[:recall_max_memories]
+        capped = True
 
     memories_block = None
     if results:
@@ -399,6 +507,27 @@ def main():
             _cache_store(cache_key, context_message)
         except Exception as e:
             debug_log(config, f"Recall cache write failed (non-fatal): {e}")
+
+    # Switchroom #432 phase 4.3 — telemetry log. memory IDs (when
+    # available) let an operator confirm what was injected on a given
+    # turn. Failure-tolerant.
+    _write_recall_log({
+        "ts": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "session_id": (session_id or "")[:32],
+        "bank_id": bank_id,
+        "additional_banks": additional_banks,
+        "query_chars": len(query),
+        "result_count": len(results),
+        "directive_count": len(directives),
+        "demoted_count": demoted_count,
+        "capped": capped,
+        "pre_cap_count": pre_cap_count,
+        "memory_ids": [
+            m.get("id") for m in results
+            if isinstance(m, dict) and m.get("id")
+        ],
+        "cache_hit": False,
+    })
 
     # Output JSON for Claude Code hook system
     output = {

--- a/vendor/hindsight-memory/scripts/tests/test_recall_integration.py
+++ b/vendor/hindsight-memory/scripts/tests/test_recall_integration.py
@@ -38,8 +38,13 @@ def _directive(name, content, priority=5):
     }
 
 
-def _memory(text, mem_type="fact", mentioned_at="2026-01-01"):
-    return {"text": text, "type": mem_type, "mentioned_at": mentioned_at}
+def _memory(text, mem_type="fact", mentioned_at="2026-01-01", mem_id=None, tags=None):
+    out = {"text": text, "type": mem_type, "mentioned_at": mentioned_at}
+    if mem_id is not None:
+        out["id"] = mem_id
+    if tags is not None:
+        out["tags"] = tags
+    return out
 
 
 class _FakeClient:
@@ -261,6 +266,150 @@ class RecallMaxMemoriesCapTests(unittest.TestCase):
         self.assertIsNotNone(ctx)
         for i in range(15):
             self.assertIn(f"memory {i}", ctx)
+
+
+class DemoteFromRecallTagTests(unittest.TestCase):
+    """Switchroom #432 phase 4.4 — memories tagged demote-from-recall
+    are filtered out of the auto-recall block but otherwise stay in the
+    bank.
+    """
+
+    def test_bracketed_tag_is_filtered(self):
+        memories = [
+            _memory("keep this", tags=[]),
+            _memory("drop this", tags=["[demote-from-recall]"]),
+        ]
+        client = _FakeClient(directives=[], memories=memories)
+        ctx, _ = _run_main_with(client)
+        self.assertIsNotNone(ctx)
+        self.assertIn("keep this", ctx)
+        self.assertNotIn("drop this", ctx)
+
+    def test_unbracketed_tag_is_filtered(self):
+        memories = [
+            _memory("keep this"),
+            _memory("drop this", tags=["demote-from-recall"]),
+        ]
+        client = _FakeClient(directives=[], memories=memories)
+        ctx, _ = _run_main_with(client)
+        self.assertIn("keep this", ctx)
+        self.assertNotIn("drop this", ctx)
+
+    def test_no_recall_alias_is_filtered(self):
+        # `no-recall` is the third accepted variant — shorter to type when
+        # tagging via `mcp__hindsight__update_memory`.
+        memories = [
+            _memory("keep this"),
+            _memory("drop this", tags=["no-recall"]),
+        ]
+        client = _FakeClient(directives=[], memories=memories)
+        ctx, _ = _run_main_with(client)
+        self.assertIn("keep this", ctx)
+        self.assertNotIn("drop this", ctx)
+
+    def test_unrelated_tag_is_kept(self):
+        memories = [_memory("keep this", tags=["topic:fitness", "user:ken"])]
+        client = _FakeClient(directives=[], memories=memories)
+        ctx, _ = _run_main_with(client)
+        self.assertIn("keep this", ctx)
+
+    def test_filter_applies_before_cap(self):
+        # 8 memories total, 3 demoted, cap=4. Result: 4 non-demoted
+        # memories survive (proves the filter runs first; if the cap
+        # ran first we'd see 4 of the 8 including demoted ones).
+        memories = [_memory(f"keep {i}") for i in range(5)] + [
+            _memory(f"drop {i}", tags=["[demote-from-recall]"]) for i in range(3)
+        ]
+        client = _FakeClient(directives=[], memories=memories)
+        ctx, _ = _run_main_with(client, config_extra={"recallMaxMemories": 4})
+        self.assertIsNotNone(ctx)
+        # All 4 cap survivors come from the "keep" pool.
+        for i in range(4):
+            self.assertIn(f"keep {i}", ctx)
+        for i in range(3):
+            self.assertNotIn(f"drop {i}", ctx)
+
+
+class RecallTelemetryLogTests(unittest.TestCase):
+    """Switchroom #432 phase 4.3 — every recall (hit or miss) appends
+    a JSONL record to state/recall_log.jsonl when CLAUDE_PLUGIN_DATA is
+    set.
+    """
+
+    def setUp(self):
+        import tempfile
+        self._tmpdir = tempfile.mkdtemp(prefix="recall-log-test-")
+        # The log writer reads CLAUDE_PLUGIN_DATA at write time. Set it
+        # for the test and restore on tearDown.
+        self._prev = os.environ.get("CLAUDE_PLUGIN_DATA")
+        os.environ["CLAUDE_PLUGIN_DATA"] = self._tmpdir
+
+    def tearDown(self):
+        import shutil
+        shutil.rmtree(self._tmpdir, ignore_errors=True)
+        if self._prev is None:
+            os.environ.pop("CLAUDE_PLUGIN_DATA", None)
+        else:
+            os.environ["CLAUDE_PLUGIN_DATA"] = self._prev
+
+    def _read_log(self):
+        path = os.path.join(self._tmpdir, "state", "recall_log.jsonl")
+        if not os.path.isfile(path):
+            return []
+        with open(path, encoding="utf-8") as f:
+            return [json.loads(line) for line in f if line.strip()]
+
+    def test_logs_one_line_per_recall_with_memory_ids(self):
+        memories = [
+            _memory("first", mem_id="mem-1"),
+            _memory("second", mem_id="mem-2"),
+        ]
+        client = _FakeClient(directives=[], memories=memories)
+        _run_main_with(client)
+        entries = self._read_log()
+        self.assertEqual(len(entries), 1)
+        e = entries[0]
+        self.assertEqual(e["result_count"], 2)
+        self.assertEqual(e["memory_ids"], ["mem-1", "mem-2"])
+        self.assertFalse(e["cache_hit"])
+        self.assertFalse(e["capped"])
+        self.assertEqual(e["bank_id"], "test-bank")
+
+    def test_logs_capped_flag_when_cap_fires(self):
+        memories = [_memory(f"m {i}", mem_id=f"id-{i}") for i in range(8)]
+        client = _FakeClient(directives=[], memories=memories)
+        _run_main_with(client, config_extra={"recallMaxMemories": 3})
+        entries = self._read_log()
+        self.assertEqual(len(entries), 1)
+        e = entries[0]
+        self.assertTrue(e["capped"])
+        self.assertEqual(e["pre_cap_count"], 8)
+        self.assertEqual(e["result_count"], 3)
+        # Only the kept IDs are logged.
+        self.assertEqual(e["memory_ids"], ["id-0", "id-1", "id-2"])
+
+    def test_logs_demoted_count(self):
+        memories = [
+            _memory("keep", mem_id="k1"),
+            _memory("drop", mem_id="d1", tags=["[demote-from-recall]"]),
+        ]
+        client = _FakeClient(directives=[], memories=memories)
+        _run_main_with(client)
+        entries = self._read_log()
+        self.assertEqual(len(entries), 1)
+        self.assertEqual(entries[0]["demoted_count"], 1)
+        self.assertEqual(entries[0]["memory_ids"], ["k1"])
+
+    def test_no_log_when_plugin_data_unset(self):
+        # If CLAUDE_PLUGIN_DATA isn't set, the writer no-ops silently —
+        # we don't want a stray log file in the working directory.
+        del os.environ["CLAUDE_PLUGIN_DATA"]
+        client = _FakeClient(directives=[], memories=[_memory("x", mem_id="x1")])
+        _run_main_with(client)
+        # No file ever created.
+        self.assertEqual(self._read_log(), [])
+        # Restore so tearDown's pop doesn't error.
+        os.environ["CLAUDE_PLUGIN_DATA"] = self._tmpdir
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes the remaining two phases of #432. Part of #424.

## Phase 4.4 — `[demote-from-recall]` tag

A memory tagged with `[demote-from-recall]`, `demote-from-recall`, or `no-recall` stays in the bank but is filtered out of the auto-recall block on every UserPromptSubmit. The memory remains discoverable via `mcp__hindsight__reflect` and manual `mcp__hindsight__recall`.

Operator-side use:
```
mcp__hindsight__update_memory(memory_id="abc-123", tags=["[demote-from-recall]"])
```

The filter runs **before** the `max_memories` cap, so demoting a noisy memory doesn't waste a slot.

## Phase 4.3 — telemetry log + `switchroom memory recall-log`

`recall.py` appends a JSONL record per recall to `<plugin-data>/state/recall_log.jsonl`. Each record carries timestamp, session_id, bank, result_count, `pre_cap_count`, demoted_count, capped flag, directive_count, cache_hit flag, query_chars, and `memory_ids` of what got injected.

Bounded to 5000 lines per agent — auto-trims when the file grows past ~1.25 MB. Failure-tolerant: any write error is swallowed silently (telemetry must never block recall).

New CLI verb:
```
switchroom memory recall-log [agent] [-n N] [--json]
```

Output:
```
clerk:
  last 20 turns: avg=11.4 max=12 cache_hits=2 capped=8
  2026-04-30T07:53:45Z OK    n=12 ids=mem-a1,mem-c4,mem-9f…+9
  2026-04-30T07:52:10Z CAP   n=12/18 ids=mem-a1,mem-c4,mem-7e…+9
  2026-04-30T07:51:33Z CACHE n=—
```

`OK` = uncapped recall fired; `CAP` = was sliced; `CACHE` = served from per-session cache (#424 4.1).

## Why this matters now

Without telemetry, the cap of 12 (#463) is a guess. If `CAP` fires on most turns, the bank has more relevant content than 12 lets through and we should raise the cap. If `CAP` rarely fires and `avg` stays well below 12, the cap isn't the lever — `recallBudget` or retain hygiene matters more. **This PR is the load-bearing measurement layer for whether the cap fix worked.**

## Files

| File | Change |
| --- | --- |
| `vendor/hindsight-memory/scripts/recall.py` | Demote filter (before cap) + log writer (both miss + cache-hit paths). |
| `vendor/hindsight-memory/scripts/tests/test_recall_integration.py` | 9 new tests — 5 demote, 4 telemetry. |
| `src/cli/memory.ts` | Exported `readRecallLog`; new `recall-log` verb with text + `--json` output. |
| `tests/cli.memory.recall-log.test.ts` | 6 new tests on `readRecallLog`. |
| `docs/configuration.md` | New subsections on demoting + inspecting recall. |

## Verification

- `npm run lint` clean.
- Python: 38/38 pass (was 29; 9 new).
- Vitest: **4096 pass, 0 fail** (after `bun scripts/build.mjs`).
- Smoke-test on live fleet: `bun bin/switchroom.ts memory recall-log -n 5` reports "no recall events recorded yet" for all 5 agents — the expected state before this PR deploys.

## Test plan

- [ ] After `switchroom agent reconcile all && switchroom agent restart all`, send any agent a Telegram message — `switchroom memory recall-log <name>` should show one entry.
- [ ] Tag a memory with `[demote-from-recall]` via MCP, send the same prompt, observe the demoted memory absent from the next recall block (and `demoted_count: 1` in the log).
- [ ] After ~20 turns, look at the aggregate line — that's the empirical answer on whether 12 is the right cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)