### PR TITLE
feat(gateway): sub-second streaming updates via update_placeholder IPC

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -157,6 +157,7 @@ import type {
   HeartbeatMessage,
   ScheduleRestartMessage,
   OperatorEventForward,
+  UpdatePlaceholderMessage,
   InboundMessage,
 } from './ipc-protocol.js'
 import { writePidFile, clearPidFile } from './pid-file.js'
@@ -1581,6 +1582,32 @@ const ipcServer: IpcServer = createIpcServer({
       detail: msg.detail,
       suggestedActions: [],
       firstSeenAt: new Date(),
+    })
+  },
+
+  onUpdatePlaceholder(_client: IpcClient, msg: UpdatePlaceholderMessage) {
+    // Edit the pre-allocated draft for this DM to show a more specific
+    // status during the wait between inbound and the agent's first
+    // tool call. Sent by hooks (e.g. recall.py) so the user sees
+    // `📚 recalling…` and `💭 thinking…` instead of the static
+    // `🔵 thinking…` placeholder for the entire model TTFT.
+    //
+    // Best-effort, silent on three legitimate misses:
+    //   1. No pre-alloc draft (forum topic, sendMessageDraft API absent,
+    //      pre-alloc API call still in flight).
+    //   2. Telegram API rejects the edit (rate limit, invalid text).
+    //   3. The draft was already consumed by stream_reply.
+    if (sendMessageDraftFn == null) return
+    const preAllocated = preAllocatedDrafts.get(msg.chatId)
+    if (preAllocated == null) return
+    const text = String(msg.text ?? '').slice(0, 200)  // sanity cap
+    if (text.length === 0) return
+    void sendMessageDraftFn(msg.chatId, preAllocated.draftId, text).catch((err) => {
+      process.stderr.write(
+        `telegram gateway: update_placeholder edit failed chatId=${msg.chatId}: ${
+          err instanceof Error ? err.message : String(err)
+        }\n`,
+      )
     })
   },
 
@@ -3621,6 +3648,11 @@ async function handleInbound(
     // of allocating a new one, so the user sees a placeholder draft within
     // ~1 s. Only fires for fresh DM turns; if the agent finishes the turn
     // without calling stream_reply, turn_end clears the orphan.
+    //
+    // Placeholder content is meaningful ('🔵 thinking…') rather than '…'
+    // so the user sees a real "I'm working" signal, not three dots that
+    // could read as "still loading the message." Hooks can refine this
+    // mid-turn via the `update_placeholder` IPC message.
     if (
       sendMessageDraftFn != null
       && isDmChatId(chat_id)
@@ -3630,7 +3662,7 @@ async function handleInbound(
       const draftId = allocateDraftId()
       // Best-effort, non-blocking: any failure (transport down, API not
       // available) falls through to today's behavior.
-      void sendMessageDraftFn(chat_id, draftId, '…')
+      void sendMessageDraftFn(chat_id, draftId, '🔵 thinking…')
         .then(() => {
           preAllocatedDrafts.set(chat_id, { draftId, allocatedAt: Date.now() })
         })

--- a/telegram-plugin/gateway/ipc-protocol.ts
+++ b/telegram-plugin/gateway/ipc-protocol.ts
@@ -101,6 +101,26 @@ export interface OperatorEventForward {
   chatId: string;
 }
 
+/**
+ * Edit the pre-allocated DM draft to show a more specific status during
+ * the wait between inbound and the agent's first tool call.
+ *
+ * Sent by hooks (e.g. recall.py at hook-start and after a recall returns)
+ * so the user sees `🔵 thinking…` → `📚 recalling…` → `💭 thinking…` →
+ * final reply, instead of `🔵 thinking…` for the entire model TTFT.
+ *
+ * Best-effort: silently no-op when the chat has no pre-allocated draft
+ * (forum topic, sendMessageDraft API unavailable, race with pre-alloc
+ * round-trip).
+ */
+export interface UpdatePlaceholderMessage {
+  type: "update_placeholder";
+  /** DM chat id (positive numeric string). Forum topics are skipped. */
+  chatId: string;
+  /** New placeholder text. Plain text — no HTML/Markdown parsing. */
+  text: string;
+}
+
 export type ClientToGateway =
   | RegisterMessage
   | ToolCallMessage
@@ -108,4 +128,5 @@ export type ClientToGateway =
   | PermissionRequestForward
   | HeartbeatMessage
   | ScheduleRestartMessage
-  | OperatorEventForward;
+  | OperatorEventForward
+  | UpdatePlaceholderMessage;

--- a/telegram-plugin/gateway/ipc-server.ts
+++ b/telegram-plugin/gateway/ipc-server.ts
@@ -10,6 +10,7 @@ import type {
   SessionEventForward,
   ToolCallMessage,
   ToolCallResult,
+  UpdatePlaceholderMessage,
 } from "./ipc-protocol.js";
 
 export interface IpcServerOptions {
@@ -22,6 +23,7 @@ export interface IpcServerOptions {
   onHeartbeat: (client: IpcClient, msg: HeartbeatMessage) => void;
   onScheduleRestart: (client: IpcClient, msg: ScheduleRestartMessage) => void;
   onOperatorEvent?: (client: IpcClient, msg: OperatorEventForward) => void;
+  onUpdatePlaceholder?: (client: IpcClient, msg: UpdatePlaceholderMessage) => void;
   log?: (msg: string) => void;
   /**
    * How long (in ms) to wait without a heartbeat before force-closing the
@@ -137,6 +139,18 @@ export function validateClientMessage(msg: unknown): msg is ClientToGateway {
         && typeof m.detail === "string"
         && (m.detail as string).length <= OPERATOR_EVENT_DETAIL_MAX
         && typeof m.chatId === "string";
+    case "update_placeholder":
+      // chatId: non-empty string, restricted to safe characters so a
+      // rogue process can't inject arbitrary payloads via the chat id
+      // (Telegram chat ids are numeric, possibly leading minus).
+      // text: non-empty, capped — the gateway slices to 200 chars
+      // again on its side, but reject anything obviously oversized
+      // here to keep the buffer + log bounded.
+      return typeof m.chatId === "string"
+        && /^-?\d{1,32}$/.test(m.chatId as string)
+        && typeof m.text === "string"
+        && (m.text as string).length > 0
+        && (m.text as string).length <= 500;
     default:
       return false;
   }
@@ -153,6 +167,7 @@ export function createIpcServer(options: IpcServerOptions): IpcServer {
     onHeartbeat,
     onScheduleRestart,
     onOperatorEvent,
+    onUpdatePlaceholder,
     log = () => {},
     heartbeatTimeoutMs = 30_000,
   } = options;
@@ -229,6 +244,9 @@ export function createIpcServer(options: IpcServerOptions): IpcServer {
         break;
       case "operator_event":
         if (onOperatorEvent) onOperatorEvent(client, msg as OperatorEventForward);
+        break;
+      case "update_placeholder":
+        if (onUpdatePlaceholder) onUpdatePlaceholder(client, msg as UpdatePlaceholderMessage);
         break;
       default:
         log(`unknown IPC message type from client ${client.id}: ${(msg as any).type}`);

--- a/telegram-plugin/tests/ipc-server-validate-update-placeholder.test.ts
+++ b/telegram-plugin/tests/ipc-server-validate-update-placeholder.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Validation contract for `update_placeholder` IPC messages.
+ *
+ * The hook (recall.py / future others) sends a JSON line over the
+ * gateway socket; `validateClientMessage` is the gate before the
+ * gateway acts on it. Keeps the contract narrow so a rogue process on
+ * the same socket can't push arbitrary content into the user's
+ * Telegram draft.
+ *
+ * Companion to the operator_event validator tests
+ * (`ipc-server-validate-operator.test.ts`).
+ */
+
+import { describe, it, expect } from 'vitest'
+import { validateClientMessage } from '../gateway/ipc-server.js'
+
+function base() {
+  return {
+    type: 'update_placeholder' as const,
+    chatId: '8248703757',
+    text: '📚 recalling memories…',
+  }
+}
+
+describe('validateClientMessage — update_placeholder', () => {
+  it('accepts a well-formed DM message', () => {
+    expect(validateClientMessage(base())).toBe(true)
+  })
+
+  it('accepts negative chat ids (groups / channels)', () => {
+    expect(validateClientMessage({ ...base(), chatId: '-1001234567890' })).toBe(true)
+  })
+
+  it('rejects non-numeric chatIds', () => {
+    expect(validateClientMessage({ ...base(), chatId: 'not-a-number' })).toBe(false)
+    expect(validateClientMessage({ ...base(), chatId: '12abc' })).toBe(false)
+    expect(validateClientMessage({ ...base(), chatId: '12 34' })).toBe(false)
+    expect(validateClientMessage({ ...base(), chatId: '<script>' })).toBe(false)
+  })
+
+  it('rejects empty chatId', () => {
+    expect(validateClientMessage({ ...base(), chatId: '' })).toBe(false)
+  })
+
+  it('rejects oversized chatId (would imply a malformed sender)', () => {
+    expect(validateClientMessage({ ...base(), chatId: '1'.repeat(33) })).toBe(false)
+  })
+
+  it('requires chatId to be a string', () => {
+    expect(validateClientMessage({ ...base(), chatId: 123 })).toBe(false)
+    expect(validateClientMessage({ ...base(), chatId: null })).toBe(false)
+    const noChat = { ...base() } as Record<string, unknown>
+    delete noChat.chatId
+    expect(validateClientMessage(noChat)).toBe(false)
+  })
+
+  it('rejects empty text', () => {
+    expect(validateClientMessage({ ...base(), text: '' })).toBe(false)
+  })
+
+  it('caps text at 500 chars', () => {
+    expect(validateClientMessage({ ...base(), text: 'x'.repeat(500) })).toBe(true)
+    expect(validateClientMessage({ ...base(), text: 'x'.repeat(501) })).toBe(false)
+  })
+
+  it('requires text to be a string', () => {
+    expect(validateClientMessage({ ...base(), text: 42 })).toBe(false)
+    expect(validateClientMessage({ ...base(), text: null })).toBe(false)
+    const noText = { ...base() } as Record<string, unknown>
+    delete noText.text
+    expect(validateClientMessage(noText)).toBe(false)
+  })
+
+  it('rejects unknown type values', () => {
+    expect(validateClientMessage({ ...base(), type: 'something_else' })).toBe(false)
+  })
+})

--- a/vendor/hindsight-memory/scripts/lib/gateway_ipc.py
+++ b/vendor/hindsight-memory/scripts/lib/gateway_ipc.py
@@ -1,0 +1,126 @@
+"""Minimal client for the switchroom telegram gateway's unix-socket IPC.
+
+Used by the auto-recall hook to push status updates to the user's Telegram
+draft during the silent gap between inbound and the agent's first tool
+call. See `update_placeholder` in
+`telegram-plugin/gateway/ipc-protocol.ts` for the wire format.
+
+Why a separate, tiny client (instead of importing the existing bridge):
+the recall hook is an ephemeral python subprocess invoked by Claude Code
+on every UserPromptSubmit. The bridge (telegram-plugin/bridge/) is
+TypeScript and lives inside the long-running claude process. Hooks can't
+share the bridge connection. Each hook fire opens its own one-shot
+unix-socket connection, sends one JSON line, closes. ~5 ms total.
+
+Failure-tolerant by design: every error path returns silently. The
+recall hook MUST NOT block on a Telegram UX nice-to-have.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import socket
+from typing import Optional
+
+# Same regex `bin/auto-recall-hook.sh` (now removed) used; mirrors the
+# `<channel ...>` wrapper that telegram-plugin emits on inbound. Kept
+# permissive — attribute order varies, attributes can be quoted with " or
+# (rarely) ' depending on tooling.
+_CHANNEL_OPEN_RE = re.compile(
+    r"<channel\b[^>]*\bchat_id=[\"']([^\"']+)[\"'][^>]*>",
+    re.IGNORECASE,
+)
+
+
+def extract_chat_id_from_prompt(prompt: str) -> Optional[str]:
+    """Pull `chat_id` out of a `<channel ...>...</channel>` wrapper.
+
+    Returns None when the prompt isn't channel-wrapped (e.g. interactive
+    sessions, non-Telegram channels, or test fixtures). Caller should
+    silently skip the IPC update when None — there's no user-visible
+    draft to update.
+    """
+    if not prompt or not isinstance(prompt, str):
+        return None
+    # Inspect only the first 1 KB — the wrapper is always at the head;
+    # anchoring there caps the regex cost regardless of prompt size.
+    head = prompt[:1024]
+    match = _CHANNEL_OPEN_RE.search(head)
+    if not match:
+        return None
+    chat_id = match.group(1).strip()
+    return chat_id or None
+
+
+def gateway_socket_path() -> Optional[str]:
+    """Resolve the gateway socket path for the current agent.
+
+    Order of resolution:
+      1. SWITCHROOM_GATEWAY_SOCKET env var (explicit override).
+      2. <agent_dir>/telegram/gateway.sock — the conventional path
+         that gateway.ts uses by default.
+
+    Returns None when neither is available; callers no-op on None.
+    """
+    explicit = os.environ.get("SWITCHROOM_GATEWAY_SOCKET", "").strip()
+    if explicit:
+        return explicit
+    # CLAUDE_PLUGIN_DATA → <agent_dir>/.claude/plugins/data/<plugin>/.
+    # Step up four to land at <agent_dir>.
+    plugin_data = os.environ.get("CLAUDE_PLUGIN_DATA", "").strip()
+    if plugin_data:
+        agent_dir = os.path.normpath(os.path.join(plugin_data, "..", "..", "..", ".."))
+        candidate = os.path.join(agent_dir, "telegram", "gateway.sock")
+        if os.path.exists(candidate):
+            return candidate
+    return None
+
+
+def update_placeholder(
+    chat_id: str,
+    text: str,
+    *,
+    socket_path: Optional[str] = None,
+    timeout_secs: float = 0.25,
+) -> bool:
+    """Send an `update_placeholder` message to the gateway. Returns True
+    on success (message written), False on any failure.
+
+    Failure cases (all silent):
+      - No socket path resolvable.
+      - Socket connect refused / timeout.
+      - Socket write fails (rare).
+
+    Caller should never branch on the return value — it's purely for
+    test introspection.
+    """
+    if not chat_id or not isinstance(chat_id, str):
+        return False
+    if not text or not isinstance(text, str):
+        return False
+
+    path = socket_path or gateway_socket_path()
+    if path is None:
+        return False
+
+    payload = json.dumps({
+        "type": "update_placeholder",
+        "chatId": chat_id,
+        "text": text,
+    }) + "\n"
+
+    sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    sock.settimeout(timeout_secs)
+    try:
+        sock.connect(path)
+        sock.sendall(payload.encode("utf-8"))
+        return True
+    except (FileNotFoundError, ConnectionRefusedError, OSError, socket.timeout):
+        return False
+    finally:
+        try:
+            sock.close()
+        except OSError:
+            pass

--- a/vendor/hindsight-memory/scripts/recall.py
+++ b/vendor/hindsight-memory/scripts/recall.py
@@ -41,6 +41,7 @@ from lib.content import (
 )
 from lib.daemon import get_api_url
 from lib.directives import fetch_active_directives, format_active_directives_block
+from lib.gateway_ipc import extract_chat_id_from_prompt, update_placeholder
 from lib.state import read_state, write_state
 
 LAST_RECALL_STATE = "last_recall.json"
@@ -297,6 +298,16 @@ def main():
 
     session_id = hook_input.get("session_id") or ""
 
+    # Switchroom #303 — push a "📚 recalling…" status to the user's
+    # pre-allocated Telegram draft so the gap between inbound and the
+    # model's first content token isn't 25 s of dead air. Best-effort
+    # and silent on every failure path; the gateway no-ops the IPC
+    # message when there's no draft for this chat (forum topic, fresh
+    # session before pre-alloc lands, etc.).
+    placeholder_chat_id = extract_chat_id_from_prompt(prompt)
+    if placeholder_chat_id:
+        update_placeholder(placeholder_chat_id, "📚 recalling memories…")
+
     # Resolve API URL (handles all three connection modes)
     def _dbg(*a):
         debug_log(config, *a)
@@ -473,6 +484,12 @@ def main():
         )
     else:
         debug_log(config, "No memories found")
+
+    # Switchroom #303 — recall is done, model is about to start the long
+    # TTFT. Update the placeholder so the user doesn't keep staring at
+    # `📚 recalling…` for the next 15–20 s of opus thinking.
+    if placeholder_chat_id:
+        update_placeholder(placeholder_chat_id, "💭 thinking…")
 
     # If neither block has content, there's nothing to inject — exit
     # silently to avoid emitting an empty hookSpecificOutput.

--- a/vendor/hindsight-memory/scripts/tests/test_gateway_ipc.py
+++ b/vendor/hindsight-memory/scripts/tests/test_gateway_ipc.py
@@ -1,0 +1,205 @@
+"""Unit tests for lib/gateway_ipc.py.
+
+Covers:
+  - chat_id extraction from <channel ...> wrapper (various attribute orders,
+    quote styles, no-channel prompts).
+  - socket-path resolution (env override + CLAUDE_PLUGIN_DATA fallback).
+  - update_placeholder happy path (one JSON line written, valid shape).
+  - update_placeholder failure paths (no socket, refused, timeout) all
+    silent — return False but never raise.
+
+Stdlib-only.
+"""
+
+import json
+import os
+import socket
+import tempfile
+import threading
+import unittest
+
+import sys
+SCRIPTS_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if SCRIPTS_DIR not in sys.path:
+    sys.path.insert(0, SCRIPTS_DIR)
+
+from lib.gateway_ipc import (  # noqa: E402
+    extract_chat_id_from_prompt,
+    gateway_socket_path,
+    update_placeholder,
+)
+
+
+class ExtractChatIdTests(unittest.TestCase):
+    def test_double_quoted_attribute(self):
+        prompt = '<channel source="switchroom-telegram" chat_id="8248703757" thread_id="-">\nhi\n</channel>'
+        self.assertEqual(extract_chat_id_from_prompt(prompt), "8248703757")
+
+    def test_single_quoted_attribute(self):
+        prompt = "<channel source='switchroom-telegram' chat_id='12345' user_id='99'>\nhi\n</channel>"
+        self.assertEqual(extract_chat_id_from_prompt(prompt), "12345")
+
+    def test_negative_group_chat_id(self):
+        prompt = '<channel source="switchroom-telegram" chat_id="-1001234567890">\nhi\n</channel>'
+        self.assertEqual(extract_chat_id_from_prompt(prompt), "-1001234567890")
+
+    def test_attribute_order_doesnt_matter(self):
+        prompt = '<channel chat_id="999" source="switchroom-telegram" user="x">\nhi\n</channel>'
+        self.assertEqual(extract_chat_id_from_prompt(prompt), "999")
+
+    def test_no_channel_wrapper_returns_none(self):
+        self.assertIsNone(extract_chat_id_from_prompt("plain user prompt"))
+
+    def test_channel_without_chat_id_returns_none(self):
+        prompt = '<channel source="x" user_id="1">hi</channel>'
+        self.assertIsNone(extract_chat_id_from_prompt(prompt))
+
+    def test_empty_chat_id_returns_none(self):
+        prompt = '<channel chat_id="">hi</channel>'
+        self.assertIsNone(extract_chat_id_from_prompt(prompt))
+
+    def test_non_string_input(self):
+        self.assertIsNone(extract_chat_id_from_prompt(None))  # type: ignore[arg-type]
+        self.assertIsNone(extract_chat_id_from_prompt(""))
+        self.assertIsNone(extract_chat_id_from_prompt(12345))  # type: ignore[arg-type]
+
+    def test_only_inspects_first_kb(self):
+        # Pad with content BEFORE the channel wrapper; the regex shouldn't
+        # find it because we only inspect the first 1 KB.
+        prompt = ("x" * 2000) + '<channel chat_id="111">hi</channel>'
+        self.assertIsNone(extract_chat_id_from_prompt(prompt))
+
+
+class GatewaySocketPathTests(unittest.TestCase):
+    def setUp(self):
+        self._saved = {
+            "SWITCHROOM_GATEWAY_SOCKET": os.environ.get("SWITCHROOM_GATEWAY_SOCKET"),
+            "CLAUDE_PLUGIN_DATA": os.environ.get("CLAUDE_PLUGIN_DATA"),
+        }
+        # Always start clean.
+        os.environ.pop("SWITCHROOM_GATEWAY_SOCKET", None)
+        os.environ.pop("CLAUDE_PLUGIN_DATA", None)
+
+    def tearDown(self):
+        for k, v in self._saved.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+
+    def test_explicit_env_override_wins(self):
+        os.environ["SWITCHROOM_GATEWAY_SOCKET"] = "/tmp/explicit.sock"
+        self.assertEqual(gateway_socket_path(), "/tmp/explicit.sock")
+
+    def test_env_override_with_only_whitespace_falls_through(self):
+        os.environ["SWITCHROOM_GATEWAY_SOCKET"] = "   "
+        # No CLAUDE_PLUGIN_DATA set → returns None.
+        self.assertIsNone(gateway_socket_path())
+
+    def test_resolves_from_plugin_data_when_socket_exists(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            agent_dir = os.path.join(tmp, "myagent")
+            plugin_data = os.path.join(
+                agent_dir, ".claude", "plugins", "data", "hindsight-memory-inline"
+            )
+            os.makedirs(plugin_data, exist_ok=True)
+            tg_dir = os.path.join(agent_dir, "telegram")
+            os.makedirs(tg_dir, exist_ok=True)
+            sock_path = os.path.join(tg_dir, "gateway.sock")
+            # Create a sentinel file so existence check passes.
+            open(sock_path, "w").close()
+
+            os.environ["CLAUDE_PLUGIN_DATA"] = plugin_data
+            self.assertEqual(gateway_socket_path(), sock_path)
+
+    def test_returns_none_when_socket_does_not_exist(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            plugin_data = os.path.join(
+                tmp, "agent", ".claude", "plugins", "data", "hindsight-memory-inline"
+            )
+            os.makedirs(plugin_data, exist_ok=True)
+            os.environ["CLAUDE_PLUGIN_DATA"] = plugin_data
+            self.assertIsNone(gateway_socket_path())
+
+    def test_no_env_no_path(self):
+        self.assertIsNone(gateway_socket_path())
+
+
+class UpdatePlaceholderHappyPathTests(unittest.TestCase):
+    """Spin up a real unix socket server, send a placeholder update,
+    assert the message we sent matches the wire protocol contract."""
+
+    def test_writes_one_json_line_with_correct_shape(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            sock_path = os.path.join(tmp, "test.sock")
+            received: list[bytes] = []
+            ready = threading.Event()
+
+            def server():
+                srv = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+                srv.bind(sock_path)
+                srv.listen(1)
+                ready.set()
+                conn, _ = srv.accept()
+                conn.settimeout(1.0)
+                try:
+                    chunk = conn.recv(4096)
+                    if chunk:
+                        received.append(chunk)
+                finally:
+                    conn.close()
+                    srv.close()
+
+            t = threading.Thread(target=server, daemon=True)
+            t.start()
+            ready.wait(timeout=1.0)
+
+            ok = update_placeholder(
+                "8248703757",
+                "📚 recalling memories…",
+                socket_path=sock_path,
+            )
+            t.join(timeout=1.0)
+
+            self.assertTrue(ok)
+            self.assertEqual(len(received), 1)
+            line = received[0].decode("utf-8")
+            self.assertTrue(line.endswith("\n"))
+            payload = json.loads(line)
+            self.assertEqual(payload["type"], "update_placeholder")
+            self.assertEqual(payload["chatId"], "8248703757")
+            self.assertEqual(payload["text"], "📚 recalling memories…")
+
+
+class UpdatePlaceholderFailureTests(unittest.TestCase):
+    """Every failure path returns False — never raises."""
+
+    def test_no_socket_path_returns_false(self):
+        # No socket_path arg, no env override, no plugin data → resolves None.
+        prev = os.environ.pop("SWITCHROOM_GATEWAY_SOCKET", None)
+        prev_data = os.environ.pop("CLAUDE_PLUGIN_DATA", None)
+        try:
+            self.assertFalse(update_placeholder("123", "x"))
+        finally:
+            if prev is not None:
+                os.environ["SWITCHROOM_GATEWAY_SOCKET"] = prev
+            if prev_data is not None:
+                os.environ["CLAUDE_PLUGIN_DATA"] = prev_data
+
+    def test_socket_does_not_exist_returns_false(self):
+        # Path is provided but the socket file isn't there.
+        self.assertFalse(update_placeholder("123", "x", socket_path="/nonexistent/sock"))
+
+    def test_empty_chat_id_returns_false(self):
+        self.assertFalse(update_placeholder("", "x", socket_path="/tmp/whatever"))
+
+    def test_empty_text_returns_false(self):
+        self.assertFalse(update_placeholder("123", "", socket_path="/tmp/whatever"))
+
+    def test_non_string_inputs_return_false(self):
+        self.assertFalse(update_placeholder(None, "x", socket_path="/tmp/x"))  # type: ignore[arg-type]
+        self.assertFalse(update_placeholder("123", None, socket_path="/tmp/x"))  # type: ignore[arg-type]
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes the silent-gap UX problem flagged in #303 and the 25-second silent gap I forensically traced on a real klanker turn.

## The problem (forensically confirmed)

On a real DM turn (klanker, 11:59:30Z 2026-04-30), the timeline was:

| T+ | Event |
|----|-------|
| 0.5s | gateway pre-alloc draft fires with text `'…'` |
| 5s | recall.py finishes |
| 5–24s | Claude Opus 4.7 thinks (no signal to user) |
| 24s | reply tool call lands |
| 25s | final reply posted as new message |

User sees `'…'` for 23 seconds, then a separate message appears. The pre-alloc draft is technically streaming within 1s, but its content is useless and the silence afterwards is 23 seconds.

## The fix (3 layers)

**1. Better pre-alloc placeholder text** — `'…'` → `'🔵 thinking…'`. One-line gateway.ts change. Gives the existing 500ms pre-alloc a real signal.

**2. New IPC message `update_placeholder`** — hooks (recall.py first, room for more) refine the placeholder mid-turn:

```
T+0.5s   🔵 thinking…        (gateway pre-alloc, on inbound)
T+0.5s   📚 recalling…       (recall.py at hook start)
T+~5s    💭 thinking…        (recall.py after Hindsight returns)
T+~24s   <final reply>       (consumes / replaces placeholder)
```

**3. Strict server-side validation** — chatId regex `^-?\d{1,32}$`, text cap 500 chars. Stops a rogue process on the same socket from injecting arbitrary content into the user's draft.

## Files

| File | Change |
| --- | --- |
| `telegram-plugin/gateway/gateway.ts` | Placeholder text fix + `onUpdatePlaceholder` handler. |
| `telegram-plugin/gateway/ipc-protocol.ts` | New `UpdatePlaceholderMessage` type. |
| `telegram-plugin/gateway/ipc-server.ts` | Route + validator. |
| `telegram-plugin/tests/ipc-server-validate-update-placeholder.test.ts` | 10 new validator tests. |
| `vendor/hindsight-memory/scripts/lib/gateway_ipc.py` | Tiny IPC client (~120 LoC) + `extract_chat_id_from_prompt`. |
| `vendor/hindsight-memory/scripts/recall.py` | Wires updates at start of hook + after recall returns. |
| `vendor/hindsight-memory/scripts/tests/test_gateway_ipc.py` | 20 new tests covering extraction, socket resolution, happy path with real unix server, all silent-failure paths. |

## Architecture choices

- **One-shot socket connections per hook fire** — Python hooks are ephemeral subprocesses; can't share the bridge connection. ~5ms per round-trip is acceptable on a recall path that's already ~5s.
- **Silent failure in both directions** — hook side returns False; gateway no-ops on the three legitimate misses (no draft, forum topic, pre-alloc race). Loud only when the Telegram API rejects the edit (real signal).
- **No bridge changes** — hooks talk directly to the gateway unix socket.

## Verification

- `npm run lint` clean.
- 10 new TS validator tests pass.
- 7 existing operator_event validator tests still pass.
- 20 new Python tests pass (`test_gateway_ipc.py`).
- 21 existing Python `test_recall_integration.py` tests still pass (no regression on cap/demote/telemetry from #463/#465/#468).
- Full vitest sweep: **4096 pass**, 0 fail.
- **Live smoke-test against running clerk gateway** — confirmed the validator rejected the message before this change ("invalid IPC message shape") and (locally) accepts it after.

## What this does NOT solve

The 19s of Opus 4.7 thinking is still 19s. This makes the wait *informative*, not *shorter*. Pair with `thinking_effort: low` and/or Sonnet 4.6 if you want to actually shrink it.

## Test plan

- [ ] After deploy + reconcile + restart, send any agent a DM. User should see `🔵 thinking…` within ~1s, transition to `📚 recalling memories…`, then `💭 thinking…`, then the final reply.
- [ ] On forum topics (group chats), pre-alloc skips silently — no regression vs today.
- [ ] If Hindsight is unreachable, recall.py's update calls fail silently; the placeholder text just stays at `🔵 thinking…`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)