### PR TITLE
feat(telegram): conditional slot banner + soft-confirm /auth use (#421)

### DIFF
--- a/src/auth/accounts.ts
+++ b/src/auth/accounts.ts
@@ -30,7 +30,7 @@ import {
 } from "node:fs";
 import { join } from "node:path";
 
-const DEFAULT_SLOT = "default";
+export const DEFAULT_SLOT = "default";
 const SLOT_NAME_MAX = 64;
 const SLOT_NAME_RE = /^[A-Za-z0-9._-]+$/;
 const FIVE_HOURS_MS = 5 * 60 * 60_000;

--- a/telegram-plugin/auth-slot-parser.ts
+++ b/telegram-plugin/auth-slot-parser.ts
@@ -33,7 +33,7 @@ export type AuthIntent =
   | { kind: 'cancel'; agent: string; label: string; cliArgs: string[] }
   | { kind: 'status'; label: string; cliArgs: string[] }
   | { kind: 'add'; agent: string; slot?: string; label: string; cliArgs: string[] }
-  | { kind: 'use'; agent: string; slot: string; label: string; cliArgs: string[]; restartAgentAfter: true }
+  | { kind: 'use'; agent: string; slot: string; force: boolean; label: string; cliArgs: string[]; restartAgentAfter: true }
   | { kind: 'list'; agent: string; label: string; cliArgs: string[] }
   | { kind: 'rm'; agent: string; slot: string; force: boolean; label: string; cliArgs: string[] }
   | { kind: 'usage'; message: string }
@@ -57,7 +57,7 @@ export function usageText(): string {
     '/auth code [agent] <browser-code>',
     '/auth cancel [agent]',
     '/auth add [agent] [--slot <name>]',
-    '/auth use [agent] <slot>',
+    '/auth use [agent] <slot> [--force]',
     '/auth list [agent]',
     '/auth rm [agent] <slot> [--force]',
   ].join('\n');
@@ -133,20 +133,22 @@ export function parseAuthSubCommand(
   }
 
   if (sub === 'use') {
-    // /auth use [agent] <slot>
-    const rest = parts.slice(1).filter(p => !p.startsWith('--'));
-    if (rest.length === 0) {
-      return { kind: 'usage', message: 'Usage: /auth use [agent] <slot>' };
+    // /auth use [agent] <slot> [--force]
+    const rest = parts.slice(1);
+    const { flags, positional } = splitFlags(rest, []);
+    if (positional.length === 0) {
+      return { kind: 'usage', message: 'Usage: /auth use [agent] <slot> [--force]' };
     }
-    const [agent, slot] = rest.length === 1
-      ? [currentAgent, rest[0]]
-      : [rest[0], rest[1]];
+    const [agent, slot] = positional.length === 1
+      ? [currentAgent, positional[0]]
+      : [positional[0], positional[1]];
     try { assertSafeAgentNameForParser(agent); }
     catch { return { kind: 'error', message: 'Invalid agent name.' }; }
     try { assertSafeSlotName(slot); }
     catch { return { kind: 'error', message: 'Invalid slot name. Use [A-Za-z0-9_-], 1-32 chars.' }; }
     return {
       kind: 'use', agent, slot,
+      force: flags['--force'] === true,
       label: `auth use ${agent} ${slot}`,
       cliArgs: ['auth', 'use', agent, slot],
       restartAgentAfter: true,

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -141,8 +141,9 @@ import {
   nextLockout,
   type LockoutRecord,
 } from '../auto-fallback.js'
-import { markSlotQuotaExhausted } from '../../src/auth/accounts.js'
+import { markSlotQuotaExhausted, DEFAULT_SLOT } from '../../src/auth/accounts.js'
 import { fallbackToNextSlot, currentActiveSlot, type AuthCodeOutcome } from '../../src/auth/manager.js'
+import { decideBannerAction, type BannerState } from '../slot-banner.js'
 import { loadConfig as loadSwitchroomConfig } from '../../src/config/loader.js'
 import type { AgentAudit } from '../welcome-text.js'
 import { shouldSweepChatAtBoot } from './boot-sweep-filter.js'
@@ -4913,6 +4914,60 @@ bot.command('interrupt', async ctx => {
 // manual /authfallback trigger (see telegram-plugin/auto-fallback.ts).
 let autoFallbackLockout: LockoutRecord = emptyLockout()
 
+// Pinned slot-banner state (#421). One banner per gateway process,
+// in the owner chat (access.allowFrom[0]). Per-topic forum support
+// + multi-chat pinning are tracked as #421 follow-ups.
+let pinnedBannerState: BannerState | null = null
+
+async function refreshPinnedBanner(reason: string): Promise<void> {
+  try {
+    const ownerChatId = loadAccess().allowFrom[0]
+    if (!ownerChatId) return
+    const agentDir = resolveAgentDirFromEnv()
+    const agentName = getMyAgentName()
+    const slot = currentActiveSlot(agentDir)
+    const action = decideBannerAction(pinnedBannerState, slot, agentName, DEFAULT_SLOT)
+    if (action.kind === 'noop') return
+    if (action.kind === 'unpin') {
+      try {
+        await bot.api.unpinChatMessage(ownerChatId, action.messageId)
+      } catch (err) {
+        process.stderr.write(`telegram gateway: banner unpin failed (${reason}): ${err}\n`)
+      }
+      pinnedBannerState = null
+      return
+    }
+    if (action.kind === 'pin') {
+      const sent = await bot.api.sendMessage(ownerChatId, action.text, {
+        parse_mode: 'HTML',
+        link_preview_options: { is_disabled: true },
+      })
+      try {
+        await bot.api.pinChatMessage(ownerChatId, sent.message_id, { disable_notification: true })
+      } catch (err) {
+        process.stderr.write(`telegram gateway: banner pin failed (${reason}): ${err}\n`)
+        return
+      }
+      pinnedBannerState = { messageId: sent.message_id, slot: action.slot }
+      return
+    }
+    if (action.kind === 'edit') {
+      try {
+        await bot.api.editMessageText(ownerChatId, action.messageId, action.text, {
+          parse_mode: 'HTML',
+          link_preview_options: { is_disabled: true },
+        })
+        pinnedBannerState = { messageId: action.messageId, slot: action.slot }
+      } catch (err) {
+        process.stderr.write(`telegram gateway: banner edit failed (${reason}): ${err}\n`)
+      }
+      return
+    }
+  } catch (err) {
+    process.stderr.write(`telegram gateway: banner refresh error (${reason}): ${err}\n`)
+  }
+}
+
 type AutoFallbackCheckResult =
   | { kind: 'no-action'; reason: string; decision: 'noop' | 'fallback-skipped' }
   | { kind: 'executed'; previousSlot: string; newSlot: string }
@@ -4959,6 +5014,7 @@ async function runAutoFallbackCheck(opts: { trigger: 'scheduled' | 'manual' }): 
         process.stderr.write(`telegram gateway: auto-fallback restart failed: ${err}\n`)
       }
       autoFallbackLockout = nextLockout(plan.previousSlot, Date.now())
+      void refreshPinnedBanner('auto-fallback')
       return { kind: 'executed', previousSlot: plan.previousSlot, newSlot: plan.newSlot }
     }
     autoFallbackLockout = nextLockout(plan.activeSlot, Date.now())
@@ -5032,14 +5088,29 @@ bot.command('auth', async ctx => {
   if (intent.kind === 'add') {
     await runSwitchroomAuthCommand(ctx, intent.cliArgs, intent.label)
     pendingReauthFlows.set(String(ctx.chat!.id), { agent: intent.agent, startedAt: Date.now() })
+    void refreshPinnedBanner('auth-add')
     return
   }
 
   if (intent.kind === 'use') {
+    // Soft-confirm: a slot swap restarts the agent process, killing any
+    // in-flight turn. If a turn is currently running, refuse without
+    // --force so a fat-finger tap doesn't quietly destroy the user's
+    // work-in-progress. Idle-state swaps proceed with no friction. (#421B)
+    if (!intent.force && activeTurnStartedAt.size > 0) {
+      await switchroomReply(
+        ctx,
+        `⚠️ A turn is in flight. Swapping to <code>${escapeHtmlForTg(intent.slot)}</code> will abort it.\n` +
+          `Resend as <code>/auth use ${escapeHtmlForTg(intent.agent)} ${escapeHtmlForTg(intent.slot)} --force</code> to proceed.`,
+        { html: true },
+      )
+      return
+    }
     await runSwitchroomCommand(ctx, intent.cliArgs, intent.label)
     // Restart the agent so the new OAuth token is picked up.
     try { assertSafeAgentName(intent.agent) } catch { return }
     await runSwitchroomCommand(ctx, ['agent', 'restart', intent.agent], `restart ${intent.agent}`)
+    void refreshPinnedBanner('auth-use')
     return
   }
 

--- a/telegram-plugin/slot-banner.ts
+++ b/telegram-plugin/slot-banner.ts
@@ -1,0 +1,86 @@
+/**
+ * Pinned slot banner — pure decision logic.
+ *
+ * The gateway pins a banner in the owner chat when the agent is
+ * running on a non-default account slot (e.g. after auto-fallback
+ * swapped away from `default`). The banner unpins when the agent
+ * returns to `default`. This gives the user an always-visible answer
+ * to "what slot am I on right now?" exactly when it's not what they
+ * expect, and zero noise when everything is normal.
+ *
+ * This module is dependency-free so it's testable in isolation; the
+ * gateway translates `BannerAction` into actual Telegram API calls.
+ *
+ * v1 scope: one banner per gateway process, in the owner chat
+ * (access.allowFrom[0]). Per-topic forum support and multi-chat
+ * pinning are tracked as #421 follow-ups.
+ *
+ * See #421 (Switchroom).
+ */
+
+export type BannerState = {
+  /** Telegram message_id of the currently pinned banner. */
+  messageId: number;
+  /** The slot name shown by the pinned message — used to skip
+   *  redundant edits when the slot hasn't changed. */
+  slot: string;
+};
+
+export type BannerAction =
+  | { kind: 'noop'; reason: string }
+  /** Pin a fresh banner. Caller sends + pins, then records the
+   *  resulting message_id back into BannerState. */
+  | { kind: 'pin'; text: string; slot: string }
+  /** Edit the existing pinned banner's text. */
+  | { kind: 'edit'; messageId: number; text: string; slot: string }
+  /** Unpin + forget. Caller unpins (best-effort) and clears state. */
+  | { kind: 'unpin'; messageId: number };
+
+/**
+ * Decide what to do with the banner given the current active slot,
+ * the default slot, and the previously-pinned banner state.
+ */
+export function decideBannerAction(
+  prev: BannerState | null,
+  currentSlot: string | null,
+  agentName: string,
+  defaultSlot: string,
+): BannerAction {
+  // Default state (or no slot yet): no banner needed. If one is
+  // pinned from a prior failover, unpin so the chat is clean again.
+  if (currentSlot === null || currentSlot === defaultSlot) {
+    if (prev) return { kind: 'unpin', messageId: prev.messageId };
+    return { kind: 'noop', reason: 'on default slot, nothing pinned' };
+  }
+
+  // Non-default state. Either pin fresh or edit existing.
+  const text = formatBannerHtml(agentName, currentSlot, defaultSlot);
+  if (!prev) return { kind: 'pin', text, slot: currentSlot };
+  if (prev.slot === currentSlot) {
+    return { kind: 'noop', reason: 'banner already shows current slot' };
+  }
+  return { kind: 'edit', messageId: prev.messageId, text, slot: currentSlot };
+}
+
+/**
+ * The banner body. Kept short — the user reads this at a glance,
+ * and pinned messages eat vertical space at the top of the chat.
+ */
+export function formatBannerHtml(
+  agentName: string,
+  currentSlot: string,
+  defaultSlot: string,
+): string {
+  return [
+    `📌 <b>${escapeHtml(agentName)}</b> is running on slot <code>${escapeHtml(currentSlot)}</code>`,
+    `<i>(failover from <code>${escapeHtml(defaultSlot)}</code>)</i>`,
+  ].join(' ');
+}
+
+function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}

--- a/telegram-plugin/tests/auth-slot-commands.test.ts
+++ b/telegram-plugin/tests/auth-slot-commands.test.ts
@@ -125,6 +125,7 @@ describe("parseAuthSubCommand — /auth use", () => {
     if (intent.kind === "use") {
       expect(intent.agent).toBe("clerk");
       expect(intent.slot).toBe("personal");
+      expect(intent.force).toBe(false);
       expect(intent.cliArgs).toEqual(["auth", "use", "clerk", "personal"]);
       expect(intent.restartAgentAfter).toBe(true);
     }
@@ -136,6 +137,26 @@ describe("parseAuthSubCommand — /auth use", () => {
     if (intent.kind === "use") {
       expect(intent.agent).toBe("klanker");
       expect(intent.slot).toBe("personal");
+      expect(intent.force).toBe(false);
+    }
+  });
+
+  it("--force sets force=true (#421)", () => {
+    const intent = parseAuthSubCommand(["use", "personal", "--force"], "clerk");
+    expect(intent.kind).toBe("use");
+    if (intent.kind === "use") {
+      expect(intent.slot).toBe("personal");
+      expect(intent.force).toBe(true);
+    }
+  });
+
+  it("--force with explicit agent + slot", () => {
+    const intent = parseAuthSubCommand(["use", "klanker", "personal", "--force"], "clerk");
+    expect(intent.kind).toBe("use");
+    if (intent.kind === "use") {
+      expect(intent.agent).toBe("klanker");
+      expect(intent.slot).toBe("personal");
+      expect(intent.force).toBe(true);
     }
   });
 

--- a/telegram-plugin/tests/slot-banner.test.ts
+++ b/telegram-plugin/tests/slot-banner.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest';
+import { decideBannerAction, formatBannerHtml, type BannerState } from '../slot-banner';
+
+const DEFAULT = 'default';
+
+describe('decideBannerAction — default state', () => {
+  it('noop when on default and nothing pinned', () => {
+    const action = decideBannerAction(null, DEFAULT, 'clerk', DEFAULT);
+    expect(action.kind).toBe('noop');
+  });
+
+  it('noop when slot is null and nothing pinned', () => {
+    const action = decideBannerAction(null, null, 'clerk', DEFAULT);
+    expect(action.kind).toBe('noop');
+  });
+
+  it('unpins existing banner when slot returns to default', () => {
+    const prev: BannerState = { messageId: 42, slot: 'personal' };
+    const action = decideBannerAction(prev, DEFAULT, 'clerk', DEFAULT);
+    expect(action).toEqual({ kind: 'unpin', messageId: 42 });
+  });
+
+  it('unpins existing banner when active slot becomes null', () => {
+    const prev: BannerState = { messageId: 7, slot: 'work' };
+    const action = decideBannerAction(prev, null, 'clerk', DEFAULT);
+    expect(action).toEqual({ kind: 'unpin', messageId: 7 });
+  });
+});
+
+describe('decideBannerAction — non-default state', () => {
+  it('pins fresh banner when nothing currently pinned', () => {
+    const action = decideBannerAction(null, 'personal', 'clerk', DEFAULT);
+    expect(action.kind).toBe('pin');
+    if (action.kind === 'pin') {
+      expect(action.slot).toBe('personal');
+      expect(action.text).toContain('clerk');
+      expect(action.text).toContain('personal');
+      expect(action.text).toContain('default');
+    }
+  });
+
+  it('edits when banner exists for a different slot', () => {
+    const prev: BannerState = { messageId: 99, slot: 'personal' };
+    const action = decideBannerAction(prev, 'work', 'clerk', DEFAULT);
+    expect(action.kind).toBe('edit');
+    if (action.kind === 'edit') {
+      expect(action.messageId).toBe(99);
+      expect(action.slot).toBe('work');
+      expect(action.text).toContain('work');
+    }
+  });
+
+  it('noops when banner already reflects current slot', () => {
+    const prev: BannerState = { messageId: 12, slot: 'personal' };
+    const action = decideBannerAction(prev, 'personal', 'clerk', DEFAULT);
+    expect(action.kind).toBe('noop');
+  });
+});
+
+describe('formatBannerHtml', () => {
+  it('escapes HTML in agent and slot names', () => {
+    const text = formatBannerHtml('<bad>', '"hax"', '&def');
+    expect(text).not.toContain('<bad>');
+    expect(text).toContain('&lt;bad&gt;');
+    expect(text).toContain('&quot;hax&quot;');
+    expect(text).toContain('&amp;def');
+  });
+
+  it('mentions the failover-from default for context', () => {
+    const text = formatBannerHtml('clerk', 'personal', 'default');
+    expect(text).toMatch(/failover from/i);
+    expect(text).toContain('default');
+  });
+});


### PR DESCRIPTION
Closes #421.

## Summary

Two Telegram-native UX guards on the multi-account auth surface, both serving the **track-plan-quota-live** ("at a glance") and **survive-reboots-and-real-life** ("silent recovery is worse than visible failure") JTBDs.

### A. Pinned slot banner — only when active slot ≠ default
- A one-line banner pins to the owner chat whenever the agent is running on a non-default slot (e.g. after auto-fallback). Auto-unpins when the agent returns to the default slot, so the chat stays clean when nothing is wrong.
- Pure decision logic in `telegram-plugin/slot-banner.ts` (`BannerAction` state machine: `pin` / `edit` / `unpin` / `noop`), wired into the gateway at three trigger points: after `/auth use`, after `/auth add`, and after `runAutoFallbackCheck` executes a swap.
- Edits-in-place when the same banner already reflects the current slot — no churn from re-renders.

### B. Soft-confirm `/auth use` only during in-flight turn
- If a turn is in flight (`activeTurnStartedAt.size > 0`), `/auth use` refuses with a one-line warning and asks the user to resend with `--force`. Idle case proceeds with no friction.
- Parser gains `--force` on the `use` verb, mirroring the existing `rm` shape.

## Why this slice

The recent overnight-review pass (#472) is shipping the failover plumbing fixes (#417/#418/#420). This PR is the user-visible UX layer that sits on top: once auto-fallback lands you on a non-default slot, the user has an always-visible answer to "what slot am I on right now?", and a fat-finger `/auth use` while a turn is running can no longer silently destroy work-in-progress.

Both halves are independent of the overnight-review changes — they touch different code paths.

## v1 scope (follow-ups noted in slot-banner.ts header)

- One banner per gateway process, in `access.allowFrom[0]`.
- Per-topic forum support and multi-chat pinning are deferred — both are tracked as #421 follow-ups in the module header. The single-chat case is the dominant deployment shape today.
- Inline `/confirm` button (the alternative `--force` re-issue) is deferred — single round-trip with `--force` is the simpler ship.

## Test plan

- [x] `bun test telegram-plugin/tests/slot-banner.test.ts` — 9 cases for the pure state machine (default ↔ non-default, all transitions, HTML escaping)
- [x] `bun test telegram-plugin/tests/auth-slot-commands.test.ts` — 43 pass; new `--force` cases for `use`
- [x] `npm run lint` — clean
- [x] `npm run build` — clean
- [x] `npm test` — 4118 vitest pass + bun side. Two pre-existing flakes unrelated to this change: `tests/scaffold.hot-reload-stable.test.ts` (race when run in parallel; passes in isolation) and `src/vault/resolver-via-broker.test.ts` (broker socket ENOENT — also fails on stock `upstream/main`)
- [ ] Manual: trigger `/auth use` mid-turn → confirm warning + turn keeps running until `--force`
- [ ] Manual: trigger auto-fallback → confirm pinned banner appears in owner chat with current slot
- [ ] Manual: `/auth use default --force` → confirm banner unpins

🤖 Generated with [Claude Code](https://claude.com/claude-code)