### PR TITLE
fix(test): four pre-existing CI flakes blocking #471

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,10 @@ dist/
 # Agent runtime data (generated, not committed)
 /agents/
 
+# Test-generated sibling profiles (cleanup in afterEach normally handles
+# these; this catches the case where vitest is killed mid-run).
+/profiles/__test_*/
+
 # Vault
 *.enc
 

--- a/src/vault/broker/client.ts
+++ b/src/vault/broker/client.ts
@@ -308,12 +308,18 @@ async function rpc(
       resolve(val);
     };
 
+    // Build the socket and wire listeners BEFORE initiating connect().
+    // Bun (1.3.x) can emit `error` synchronously from inside connect()
+    // when the socket path doesn't exist, so net.createConnection (which
+    // calls connect immediately) races against the next-line `.on('error')`
+    // attachment under bun. Splitting into `new Socket()` + `.connect()`
+    // guarantees listeners are attached first under both runtimes.
+    const client = new net.Socket();
+
     const timer = setTimeout(() => {
       client.destroy();
       settle({ kind: "unreachable", msg: `broker did not respond within ${timeoutMs}ms` });
     }, timeoutMs);
-
-    const client = net.createConnection({ path: socketPath });
 
     client.on("error", (err: NodeJS.ErrnoException) => {
       clearTimeout(timer);
@@ -358,6 +364,8 @@ async function rpc(
         });
       }
     });
+
+    client.connect({ path: socketPath });
   });
 }
 

--- a/telegram-plugin/server.ts
+++ b/telegram-plugin/server.ts
@@ -1088,52 +1088,12 @@ const mcp = new Server(
  * Exact-match only to avoid suppressing legitimate replies that happen to
  * mention the tokens.
  */
-const SILENT_REPLY_MARKERS = new Set(['NO_REPLY', 'HEARTBEAT_OK'])
-
-// Derive the char-length bound from the marker set so adding a new
-// marker doesn't silently desync with a hand-tuned constant.
-const SILENT_REPLY_MAX_LEN = Math.max(
-  ...Array.from(SILENT_REPLY_MARKERS, (m) => m.length),
-) + 2 // small buffer for trailing punctuation callers might add accidentally
-
-export function isSilentReplyMarker(text: string | undefined): boolean {
-  if (typeof text !== 'string') return false
-  const trimmed = text.trim()
-  if (trimmed.length === 0) return false
-  if (trimmed.length > SILENT_REPLY_MAX_LEN) return false
-  // Case-insensitive match: models occasionally emit `no_reply` or
-  // `NoReply`. Require letters/underscores/digits only so legitimate
-  // prose that happens to contain "NO_REPLY was suggested" still sends.
-  return SILENT_REPLY_MARKERS.has(trimmed.toUpperCase())
-}
-
-/**
- * Decide whether a `reply`/`stream_reply` invocation should be short-
- * circuited as a silent-reply ack, enforcing the allowlist FIRST.
- *
- * Sprint1 review finding #6: an earlier revision returned the silent ack
- * before calling `assertAllowedChat`, so unauthorised chats could bypass
- * the outbound allowlist by having the agent emit `NO_REPLY`. The ack
- * itself is a cross-chat signal (it confirms to the LLM that the chat
- * exists and is reachable) even though no Telegram message is sent, so
- * we must refuse disallowed chats *before* producing it.
- *
- * `assertAllowed` throws when `chat_id` is not on the allowlist; callers
- * let that propagate so the MCP tool call fails loudly.
- */
-export function guardSilentReply(params: {
-  chat_id: string
-  text: string | undefined
-  hasFiles: boolean
-  assertAllowed: (chat_id: string) => void
-}): { kind: 'silent'; markerText: string } | { kind: 'continue' } {
-  const { chat_id, text, hasFiles, assertAllowed } = params
-  if (hasFiles) return { kind: 'continue' }
-  if (!isSilentReplyMarker(text)) return { kind: 'continue' }
-  // Allowlist check BEFORE returning the ack — see docblock above.
-  assertAllowed(chat_id)
-  return { kind: 'silent', markerText: (text as string).trim() }
-}
+// Implementation moved to ./silent-reply.ts so unit tests can import
+// the helpers without booting the full MCP server (which has top-level
+// side effects like env-load, TELEGRAM_BOT_TOKEN check, and session-tail
+// spawn). Re-exported here for backwards-compatible internal call sites.
+export { isSilentReplyMarker, guardSilentReply } from './silent-reply.js'
+import { guardSilentReply } from './silent-reply.js'
 
 // Stores full permission details for "See more" expansion keyed by request_id.
 // Entries expire after PENDING_PERMISSION_TTL_MS to prevent stuck requests

--- a/telegram-plugin/silent-reply.ts
+++ b/telegram-plugin/silent-reply.ts
@@ -1,0 +1,58 @@
+/**
+ * Silent-reply markers + allowlist guard.
+ *
+ * Lives in its own module (separate from server.ts) so that tests and
+ * other importers can pull these helpers in without booting the
+ * full MCP server — server.ts has top-level side effects (env load,
+ * TELEGRAM_BOT_TOKEN check, history.db open, session-tail spawn) that
+ * are inappropriate for a unit-test import boundary.
+ *
+ * Sprint1 review finding #6: an earlier revision of the reply /
+ * stream_reply tool handlers returned the silent-reply ack BEFORE
+ * calling `assertAllowedChat`, so unauthorised chats could bypass the
+ * outbound allowlist by having the agent emit `NO_REPLY`. The ack
+ * itself is a cross-chat signal (it confirms to the LLM that the chat
+ * exists and is reachable) even though no Telegram message is sent, so
+ * we must refuse disallowed chats *before* producing it. The
+ * guardSilentReply helper locks that ordering in.
+ */
+
+const SILENT_REPLY_MARKERS = new Set(['NO_REPLY', 'HEARTBEAT_OK'])
+
+// Derive the char-length bound from the marker set so adding a new
+// marker doesn't silently desync with a hand-tuned constant.
+const SILENT_REPLY_MAX_LEN = Math.max(
+  ...Array.from(SILENT_REPLY_MARKERS, (m) => m.length),
+) + 2 // small buffer for trailing punctuation callers might add accidentally
+
+export function isSilentReplyMarker(text: string | undefined): boolean {
+  if (typeof text !== 'string') return false
+  const trimmed = text.trim()
+  if (trimmed.length === 0) return false
+  if (trimmed.length > SILENT_REPLY_MAX_LEN) return false
+  // Case-insensitive match: models occasionally emit `no_reply` or
+  // `NoReply`. Require letters/underscores/digits only so legitimate
+  // prose that happens to contain "NO_REPLY was suggested" still sends.
+  return SILENT_REPLY_MARKERS.has(trimmed.toUpperCase())
+}
+
+/**
+ * Decide whether a `reply`/`stream_reply` invocation should be short-
+ * circuited as a silent-reply ack, enforcing the allowlist FIRST.
+ *
+ * `assertAllowed` throws when `chat_id` is not on the allowlist; callers
+ * let that propagate so the MCP tool call fails loudly.
+ */
+export function guardSilentReply(params: {
+  chat_id: string
+  text: string | undefined
+  hasFiles: boolean
+  assertAllowed: (chat_id: string) => void
+}): { kind: 'silent'; markerText: string } | { kind: 'continue' } {
+  const { chat_id, text, hasFiles, assertAllowed } = params
+  if (hasFiles) return { kind: 'continue' }
+  if (!isSilentReplyMarker(text)) return { kind: 'continue' }
+  // Allowlist check BEFORE returning the ack — see docblock above.
+  assertAllowed(chat_id)
+  return { kind: 'silent', markerText: (text as string).trim() }
+}

--- a/telegram-plugin/tests/silent-reply-guard.test.ts
+++ b/telegram-plugin/tests/silent-reply-guard.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it, vi } from 'vitest'
 
-import { guardSilentReply, isSilentReplyMarker } from '../server.js'
+// Import directly from the helper module (not server.js), so this test
+// doesn't boot the full MCP server — server.ts has top-level side
+// effects (env load, TELEGRAM_BOT_TOKEN check, session-tail spawn) that
+// kill the test process when run under bun-test without a real env.
+import { guardSilentReply, isSilentReplyMarker } from '../silent-reply.js'
 
 /**
  * Regression coverage for sprint1 review finding #6: the reply /

--- a/telegram-plugin/tests/subagent-tracker-hooks.test.ts
+++ b/telegram-plugin/tests/subagent-tracker-hooks.test.ts
@@ -128,7 +128,14 @@ describe('subagent-tracker-pretool', () => {
 
 describe('subagent-tracker-posttool', () => {
   it('updates the row to completed with result_summary after pretool + posttool', () => {
-    // First run the pretool to create the row
+    // First run the pretool to create the row.
+    //
+    // Foreground (run_in_background: false) is intentional here:
+    // PostToolUse fires on actual completion for foreground agents, so
+    // it owns the status transition. For background agents, PostToolUse
+    // fires on the launch ACK and the watcher (driven by JSONL
+    // turn_end) is the authoritative end signal — see the
+    // background-only assertion further below.
     const preEvent = {
       session_id: 'sess-xyz789',
       tool_name: 'Agent',
@@ -136,7 +143,7 @@ describe('subagent-tracker-posttool', () => {
       tool_input: {
         subagent_type: 'researcher',
         description: 'Research the topic',
-        run_in_background: true,
+        run_in_background: false,
       },
     }
     const preResult = runHook(PRETOOL_SCRIPT, preEvent)

--- a/tests/scaffold.test.ts
+++ b/tests/scaffold.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { mkdtempSync, rmSync, existsSync, readFileSync, mkdirSync, writeFileSync, readlinkSync, lstatSync, readdirSync } from "node:fs";
+import { mkdtempSync, rmSync, existsSync, readFileSync, mkdirSync, writeFileSync, readlinkSync, lstatSync, readdirSync, cpSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { tmpdir } from "node:os";
 import { scaffoldAgent, reconcileAgent, installHindsightPlugin, installSwitchroomSkills } from "../src/agents/scaffold.js";
@@ -821,26 +821,33 @@ describe("reconcileAgent", () => {
 
   afterEach(() => {
     rmSync(tmpDir, { recursive: true, force: true });
-    // Safety net: A4a/A4b tests write ephemeral __A4*_TEST_* templates
-    // into profiles/default/workspace/ (the repo source tree) and clean
-    // them up in their own try/finally. If a test crashes between
-    // writeFileSync and the finally, the orphan would linger and get
-    // picked up by subsequent test runs. Sweep any leftovers here as
-    // belt-and-braces; no-op in the common case.
-    const profileWorkspaceDir = resolve(
-      import.meta.dirname,
-      "../profiles/default/workspace",
-    );
+    // Safety net: A4a/A4b tests create sibling temp profiles
+    // (profiles/__test_a4{a,b}_<pid>_<ts>) and clean up in their own
+    // try/finally. Sweep any orphans as belt-and-braces.
+    const profilesRoot = resolve(import.meta.dirname, "../profiles");
     try {
-      for (const entry of readdirSync(profileWorkspaceDir)) {
-        if (/^__A4[AB]_(TEST|CONTRACT)_\d+\.md\.hbs$/.test(entry)) {
-          rmSync(join(profileWorkspaceDir, entry), { force: true });
+      for (const entry of readdirSync(profilesRoot)) {
+        if (/^__test_a4[ab]_\d+_\d+$/.test(entry)) {
+          rmSync(join(profilesRoot, entry), { recursive: true, force: true });
         }
       }
     } catch {
-      // profile dir missing is fine — nothing to clean
+      // profiles root missing is fine — nothing to clean
     }
   });
+
+  // Build a unique sibling profile dir under profiles/ whose contents
+  // are a copy of profiles/default. Caller can mutate workspace/ inside
+  // it without polluting the shared default profile (which other vitest
+  // workers walk in parallel). Returns the profile name (suitable for
+  // `extends:` in the agent config) and its absolute path.
+  function makeTempDefaultProfile(label: string): { profileName: string; profileDir: string } {
+    const profilesRoot = resolve(import.meta.dirname, "../profiles");
+    const profileName = `__test_${label}_${process.pid}_${Date.now()}`;
+    const profileDir = join(profilesRoot, profileName);
+    cpSync(join(profilesRoot, "default"), profileDir, { recursive: true });
+    return { profileName, profileDir };
+  }
 
   function buildSwitchroomConfig(
     agentConfig: AgentConfig,
@@ -972,12 +979,15 @@ describe("reconcileAgent", () => {
     // workspace directories. The earlier smoke test only proved that a
     // DELETED file gets re-seeded, not that a NEW template in the
     // profile flows through.
-    const profileWorkspaceDir = resolve(
-      import.meta.dirname,
-      "../profiles/default/workspace",
-    );
-    const newTemplateName = `__A4A_TEST_${Date.now()}.md.hbs`;
-    const newTemplatePath = join(profileWorkspaceDir, newTemplateName);
+    //
+    // We work against a sibling temp profile (profiles/__test_a4a_<pid>_<ts>),
+    // not profiles/default — earlier the test wrote into the shared
+    // default workspace and another vitest worker walking that dir in
+    // parallel could ENOENT mid-statSync when the cleanup raced. The
+    // `__` prefix keeps the temp profile out of `listAvailableProfiles`.
+    const { profileName, profileDir } = makeTempDefaultProfile("a4a");
+    const newTemplateName = "__A4A_TEST.md.hbs";
+    const newTemplatePath = join(profileDir, "workspace", newTemplateName);
     const renderedName = newTemplateName.replace(/\.hbs$/, "");
     writeFileSync(
       newTemplatePath,
@@ -985,7 +995,7 @@ describe("reconcileAgent", () => {
       "utf-8",
     );
     try {
-      const agentConfig = makeAgentConfig();
+      const agentConfig = makeAgentConfig({ extends: profileName });
       const scaffolded = scaffoldAgent("a4a", agentConfig, tmpDir, telegramConfig);
       // Sanity: scaffold already seeded it too… delete so we can prove
       // reconcile alone puts it back when missing. (Simulates "agent
@@ -1007,7 +1017,7 @@ describe("reconcileAgent", () => {
       const contents = readFileSync(renderedPath, "utf-8");
       expect(contents).toBe("# Late-arriving template for a4a\n");
     } finally {
-      if (existsSync(newTemplatePath)) rmSync(newTemplatePath);
+      rmSync(profileDir, { recursive: true, force: true });
     }
   });
 
@@ -1017,12 +1027,12 @@ describe("reconcileAgent", () => {
     // rendering (scaffold ~60 keys, reconcile 7 keys). They now share
     // buildWorkspaceContext() — pin that contract with a template that
     // references a key from outside the old 7-key subset.
-    const profileWorkspaceDir = resolve(
-      import.meta.dirname,
-      "../profiles/default/workspace",
-    );
-    const templateName = `__A4B_CONTRACT_${Date.now()}.md.hbs`;
-    const templatePath = join(profileWorkspaceDir, templateName);
+    //
+    // Same isolation as the A4a regression test: write into a sibling
+    // temp profile, not profiles/default.
+    const { profileName, profileDir } = makeTempDefaultProfile("a4b");
+    const templateName = "__A4B_CONTRACT.md.hbs";
+    const templatePath = join(profileDir, "workspace", templateName);
     const renderedName = templateName.replace(/\.hbs$/, "");
     // Reference `{{model}}` — not in the old 7-key reconcile subset,
     // so this would render as "" on reconcile before the refactor.
@@ -1033,6 +1043,7 @@ describe("reconcileAgent", () => {
     );
     try {
       const agentConfig = makeAgentConfig({
+        extends: profileName,
         model: "sonnet",
         soul: { name: "TestSoul" } as unknown,
       } as Partial<AgentConfig>);
@@ -1065,7 +1076,7 @@ describe("reconcileAgent", () => {
       expect(reconcileRendered).toContain("model=sonnet");
       expect(reconcileRendered).toContain("soul=TestSoul");
     } finally {
-      if (existsSync(templatePath)) rmSync(templatePath);
+      rmSync(profileDir, { recursive: true, force: true });
     }
   });
 


### PR DESCRIPTION
## Summary

Four independent flakes have been making Buildkite red on `main` for a while. They aren't caused by #471 but they mask its CI status. Each is fixed with the smallest viable change and verified locally.

## What changed

| # | File | Fix |
|---|---|---|
| 1 | `src/vault/broker/client.ts` | bun emits `connect ENOENT` synchronously from inside `net.createConnection`; switch to `new net.Socket()` + listeners + `.connect()` so handlers are wired before the connect attempt. |
| 2 | `tests/scaffold.test.ts` + `.gitignore` | A4a/A4b tests wrote into the shared `profiles/default/workspace/`; another test file walking the same dir in parallel ENOENT'd mid-`statSync`. Now they build a sibling temp profile (`profiles/__test_a4{a,b}_<pid>_<ts>`) and clean it up. |
| 3 | `telegram-plugin/server.ts` + new `silent-reply.ts` + test import path | `silent-reply-guard.test.ts` imported from `../server.js`, which has top-level side effects (env load, `TELEGRAM_BOT_TOKEN` check, `process.exit(1)`, session-tail spawn) that killed the bun-test runner mid-batch. Extracted `guardSilentReply` + `isSilentReplyMarker` to their own module; server.ts re-exports for internal call sites; test imports the helper directly. |
| 4 | `telegram-plugin/tests/subagent-tracker-hooks.test.ts` | "completed with result_summary" test passed `run_in_background: true` but asserted foreground-completion semantics. The correct semantics for background agents is "PostToolUse bumps last_activity_at + result_summary only; watcher owns the status transition on turn_end". Flipped to `run_in_background: false` (matches the test name) and added a clarifying comment. |

## Verification

```
$ npm test
…
 Test Files  202 passed | 1 skipped (203)
      Tests  4109 passed | 7 skipped (4116)
…
 285 pass
 1 skip
 0 fail
 648 expect() calls
Ran 286 tests across 21 files. [5.02s]
exit=0
```

Two consecutive clean runs, no flakes. Each individual fix was also verified by running its specific test file in isolation.

## Test plan

- [x] `npm run lint` clean
- [x] `npm test` exits 0
- [x] `bun test src/vault/resolver-via-broker.test.ts` — 6 pass
- [x] `bun test telegram-plugin/tests/silent-reply-guard.test.ts` — 7 pass
- [x] `bun test telegram-plugin/tests/subagent-tracker-hooks.test.ts` — 4 pass
- [x] `npx vitest run tests/scaffold.test.ts tests/scaffold.hot-reload-stable.test.ts` — 154 pass

## Why this is a separate PR

Could have folded into #471 but these fixes are general-purpose (not part of the overnight-review-fixes scope), and landing them first means #471 rebases onto green CI cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)