### PR TITLE
feat(memory): lexical-overlap relevance gate for auto-recall (#475)

### DIFF
--- a/profiles/_base/start.sh.hbs
+++ b/profiles/_base/start.sh.hbs
@@ -48,6 +48,15 @@ export HINDSIGHT_RECALL_CACHE_TTL_SECS={{hindsightRecallCacheTtlSecs}}
 {{else}}
 export HINDSIGHT_RECALL_CACHE_TTL_SECS=600
 {{/if}}
+# Lexical-overlap relevance gate (#475). Drops memories whose Jaccard
+# overlap with the user's query is below this threshold (range 0.0–1.0).
+# Plugin default is 0.0 (gate disabled); export only when the operator
+# overrode it via memory.recall.min_overlap in switchroom.yaml. Try
+# 0.10–0.20 to start; observe `overlap_dropped` via
+# `switchroom memory recall-log <agent>`.
+{{#if (isNumber hindsightRecallMinOverlap)}}
+export HINDSIGHT_RECALL_MIN_OVERLAP={{hindsightRecallMinOverlap}}
+{{/if}}
 # Wait for Hindsight API to be reachable before launching Claude, otherwise
 # the MCP server connection fails at startup with "1 MCP server failed".
 HINDSIGHT_WAIT=0

--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -1151,6 +1151,7 @@ interface BuildWorkspaceContextArgs {
   hindsightApiBaseUrl: string;
   hindsightRecallMaxMemories: number | undefined;
   hindsightRecallCacheTtlSecs: number | undefined;
+  hindsightRecallMinOverlap: number | undefined;
 }
 
 /**
@@ -1177,6 +1178,7 @@ function buildWorkspaceContext(args: BuildWorkspaceContextArgs): Record<string, 
     hindsightApiBaseUrl,
     hindsightRecallMaxMemories,
     hindsightRecallCacheTtlSecs,
+    hindsightRecallMinOverlap,
   } = args;
   return {
     name,
@@ -1209,6 +1211,7 @@ function buildWorkspaceContext(args: BuildWorkspaceContextArgs): Record<string, 
     hindsightApiBaseUrlQ: shellSingleQuote(hindsightApiBaseUrl),
     hindsightRecallMaxMemories,
     hindsightRecallCacheTtlSecs,
+    hindsightRecallMinOverlap,
     switchroomConfigPathQ: switchroomConfigPath
       ? shellSingleQuote(resolve(switchroomConfigPath))
       : undefined,
@@ -1408,6 +1411,10 @@ export function scaffoldAgent(
   // switchroom-managed default of 600s baked into start.sh.hbs."
   // Set to 0 in switchroom.yaml to disable caching for an agent.
   const hindsightRecallCacheTtlSecs = agentConfig.memory?.recall?.cache_ttl_secs;
+  // Lexical-overlap relevance gate (#475). Same cascade. `undefined`
+  // means "use the plugin's settings.json default of 0.0" (i.e. gate
+  // disabled, current behaviour). Set 0.10–0.20 to start filtering.
+  const hindsightRecallMinOverlap = agentConfig.memory?.recall?.min_overlap;
 
   // Build the template rendering context via the shared helper so
   // scaffold and reconcile always produce the same shape for workspace
@@ -1430,6 +1437,7 @@ export function scaffoldAgent(
     hindsightApiBaseUrl,
     hindsightRecallMaxMemories,
     hindsightRecallCacheTtlSecs,
+    hindsightRecallMinOverlap,
   });
 
   // --- Create directory structure ---
@@ -2500,6 +2508,7 @@ export function reconcileAgent(
     : "http://127.0.0.1:8888";
   const hindsightRecallMaxMemories = agentConfig.memory?.recall?.max_memories;
   const hindsightRecallCacheTtlSecs = agentConfig.memory?.recall?.cache_ttl_secs;
+  const hindsightRecallMinOverlap = agentConfig.memory?.recall?.min_overlap;
 
   // --- Reconcile start.sh (purely template-driven, safe to overwrite) ---
   // No existsSync guard: start.sh is a pure function of config+template.
@@ -2526,6 +2535,7 @@ export function reconcileAgent(
       hindsightApiBaseUrlQ: shellSingleQuote(hindsightApiBaseUrl),
       hindsightRecallMaxMemories,
       hindsightRecallCacheTtlSecs,
+      hindsightRecallMinOverlap,
       modelQ: shellSingleQuote(agentConfig.model ?? SWITCHROOM_DEFAULT_MAIN_MODEL),
       thinkingEffort: agentConfig.thinking_effort ?? SWITCHROOM_DEFAULT_THINKING_EFFORT,
       permissionMode: agentConfig.permission_mode,
@@ -2992,6 +3002,7 @@ Don't wait for a slash command. Don't ask permission. Memory work is table stake
     hindsightApiBaseUrl,
     hindsightRecallMaxMemories,
     hindsightRecallCacheTtlSecs,
+    hindsightRecallMinOverlap,
   });
   // Phase 5 migration: preserve any agent-specific edits to the legacy
   // workspace/AGENTS.md (pre-rename) by renaming it to CLAUDE.md before

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -120,6 +120,19 @@ export const AgentMemorySchema = z
             "result instead of round-tripping to Hindsight. 0 disables. " +
             "Default is 600 (10 min) for switchroom-managed agents.",
           ),
+        min_overlap: z
+          .number()
+          .min(0)
+          .max(1)
+          .optional()
+          .describe(
+            "Minimum Jaccard token overlap [0.0–1.0] between the user " +
+            "prompt and a memory's text for the memory to be injected. " +
+            "Drops low-relevance matches before the count cap so weak hits " +
+            "don't fill the slot on real queries. 0.0 disables (default — " +
+            "current behaviour). Try 0.10–0.20 to start; observe the " +
+            "`overlap_dropped` field via `switchroom memory recall-log`.",
+          ),
       })
       .optional()
       .describe("Auto-recall tuning knobs"),
@@ -567,6 +580,8 @@ const profileFields = {
       recall: z
         .object({
           max_memories: z.number().int().min(0).optional(),
+          cache_ttl_secs: z.number().int().min(0).optional(),
+          min_overlap: z.number().min(0).max(1).optional(),
         })
         .optional(),
     })

--- a/vendor/hindsight-memory/scripts/lib/config.py
+++ b/vendor/hindsight-memory/scripts/lib/config.py
@@ -29,6 +29,13 @@ DEFAULTS = {
     # formatting. Set to 0 (or any non-positive value) to disable the cap
     # and inject everything Hindsight returns.
     "recallMaxMemories": 12,
+    # Switchroom-local: minimum lexical (Jaccard) overlap between the
+    # user's query terms and a memory's text terms. Memories below this
+    # threshold are dropped before formatting. 0.0 disables the gate
+    # (current behaviour: inject everything Hindsight returns up to the
+    # count cap). Hindsight's HTTP API does not expose similarity
+    # scores, so this is the switchroom-side quality filter — see #475.
+    "recallMinOverlap": 0.0,
     "recallTypes": ["world", "experience"],
     "recallContextTurns": 1,
     "recallMaxQueryChars": 800,
@@ -87,6 +94,10 @@ ENV_OVERRIDES = {
     # agents.<name>.memory.recall.max_memories (cascading through
     # defaults.memory.recall.max_memories) when present in switchroom.yaml.
     "HINDSIGHT_RECALL_MAX_MEMORIES": ("recallMaxMemories", int),
+    # Switchroom-local: lexical-overlap threshold (#475). Float in
+    # [0.0, 1.0]. Set by start.sh from agents.<name>.memory.recall.min_overlap
+    # (cascading through defaults). 0.0 = off (current behaviour).
+    "HINDSIGHT_RECALL_MIN_OVERLAP": ("recallMinOverlap", float),
     "HINDSIGHT_RECALL_MAX_QUERY_CHARS": ("recallMaxQueryChars", int),
     "HINDSIGHT_RECALL_CONTEXT_TURNS": ("recallContextTurns", int),
     "HINDSIGHT_API_PORT": ("apiPort", int),
@@ -108,6 +119,8 @@ def _cast_env(value: str, typ):
             return value.lower() in ("true", "1", "yes")
         if typ is int:
             return int(value)
+        if typ is float:
+            return float(value)
         return value
     except (ValueError, AttributeError):
         return None

--- a/vendor/hindsight-memory/scripts/recall.py
+++ b/vendor/hindsight-memory/scripts/recall.py
@@ -196,6 +196,104 @@ def _is_demoted_memory(memory) -> bool:
     return False
 
 
+# Switchroom #475 — lexical-overlap relevance gate.
+#
+# Hindsight's HTTP API does not return similarity scores. Without a
+# score the existing `recallMaxMemories` cap acts as a *floor* on
+# low-relevance prompts: weak matches still fill the slot up to N,
+# mis-steering the model. This gate computes Jaccard overlap between
+# the user's query terms and each memory's text terms, and drops
+# memories below a configurable threshold.
+#
+# Threshold default is 0.0 (disabled) so the gate is opt-in initially.
+# Operators tune via `memory.recall.min_overlap` in switchroom.yaml or
+# `HINDSIGHT_RECALL_MIN_OVERLAP=0.15` env. Telemetry surfaces the dropped
+# count via the existing recall_log.jsonl (#432 4.3) under
+# `overlap_dropped`, so the gate's effect is observable per turn from
+# `switchroom memory recall-log <agent>`.
+#
+# A small English stop-word set is removed from both sides before the
+# overlap is computed — common-word coincidence is not a real signal.
+# Token comparison is case-insensitive and strips punctuation. The set
+# is intentionally tight; we'd rather miss a borderline drop than
+# silently throw out a real match.
+_OVERLAP_STOPWORDS = frozenset({
+    "a", "an", "and", "any", "are", "as", "at",
+    "be", "been", "being", "but", "by",
+    "can", "could", "did", "do", "does", "doing",
+    "for", "from",
+    "had", "has", "have", "having", "how",
+    "i", "if", "in", "into", "is", "it", "its",
+    "me", "my",
+    "of", "on", "one", "or",
+    "should", "so",
+    "that", "the", "their", "them", "then", "there", "these", "they",
+    "this", "to",
+    "was", "we", "were", "what", "when", "where", "which", "who",
+    "why", "will", "with", "would", "you", "your",
+})
+
+
+def _overlap_tokens(text) -> set:
+    """Tokenize text into a stop-word-stripped, lowercased set of terms.
+
+    Punctuation, digits, and short fragments (<= 1 char) are dropped.
+    Returns an empty set on non-string / empty input.
+    """
+    if not isinstance(text, str) or not text:
+        return set()
+    out = set()
+    cur = []
+    for ch in text:
+        if ch.isalpha():
+            cur.append(ch.lower())
+        else:
+            if cur:
+                tok = "".join(cur)
+                if len(tok) > 1 and tok not in _OVERLAP_STOPWORDS:
+                    out.add(tok)
+                cur = []
+    if cur:
+        tok = "".join(cur)
+        if len(tok) > 1 and tok not in _OVERLAP_STOPWORDS:
+            out.add(tok)
+    return out
+
+
+def jaccard_overlap(query: str, memory_text: str) -> float:
+    """Jaccard similarity between two texts, after stop-word + punctuation
+    stripping. Returns a float in [0.0, 1.0]. Empty/degenerate inputs
+    return 0.0 — it's safer to drop than retain when we can't compute.
+    """
+    a = _overlap_tokens(query)
+    b = _overlap_tokens(memory_text)
+    if not a or not b:
+        return 0.0
+    inter = len(a & b)
+    union = len(a | b)
+    return inter / union if union else 0.0
+
+
+def _filter_by_overlap(results, query: str, threshold: float):
+    """Drop memories whose Jaccard overlap with the query is below the
+    threshold. Threshold <= 0 short-circuits to passthrough (no
+    iteration cost).
+
+    Returns (kept_results, dropped_count).
+    """
+    if threshold <= 0:
+        return results, 0
+    kept = []
+    dropped = 0
+    for m in results:
+        text = m.get("text", "") if isinstance(m, dict) else ""
+        if jaccard_overlap(query, text) >= threshold:
+            kept.append(m)
+        else:
+            dropped += 1
+    return kept, dropped
+
+
 def _write_recall_log(entry: dict) -> None:
     """Append a JSONL line to recall_log.jsonl. Bounded by line count.
 
@@ -479,6 +577,25 @@ def main():
     if demoted_count > 0:
         debug_log(config, f"Filtered {demoted_count} demote-from-recall memories")
 
+    # Switchroom #475 — lexical-overlap relevance gate. Drops memories
+    # whose Jaccard overlap with the query is below
+    # `recallMinOverlap` (default 0.0 = disabled). Runs after the
+    # demote filter so the threshold sees the operator-curated set.
+    overlap_threshold = config.get("recallMinOverlap", 0.0)
+    if isinstance(overlap_threshold, (int, float)) and overlap_threshold > 0:
+        pre_overlap_count = len(results)
+        results, overlap_dropped = _filter_by_overlap(
+            results, query, float(overlap_threshold)
+        )
+        if overlap_dropped > 0:
+            debug_log(
+                config,
+                f"Overlap gate dropped {overlap_dropped}/{pre_overlap_count} "
+                f"memories below threshold {overlap_threshold}",
+            )
+    else:
+        overlap_dropped = 0
+
     # Switchroom-local: client-side count cap. Plugin v0.4.0 has no
     # `recallTopK` in the Claude Code integration (Openclaw-only), and a
     # token budget alone doesn't bound count — a single long memory can
@@ -570,6 +687,7 @@ def main():
         "result_count": len(results),
         "directive_count": len(directives),
         "demoted_count": demoted_count,
+        "overlap_dropped": overlap_dropped,
         "capped": capped,
         "pre_cap_count": pre_cap_count,
         "memory_ids": [

--- a/vendor/hindsight-memory/scripts/tests/test_recall_integration.py
+++ b/vendor/hindsight-memory/scripts/tests/test_recall_integration.py
@@ -476,5 +476,146 @@ class AckShortCircuitTests(unittest.TestCase):
         self.assertIsNotNone(ctx)
 
 
+class JaccardOverlapUnitTests(unittest.TestCase):
+    """Switchroom #475: pure-function tests for the relevance helpers."""
+
+    def test_identical_text_is_full_overlap(self):
+        # Modulo stop-word stripping (`is`, `the`, `a`, `to` removed).
+        self.assertEqual(
+            recall.jaccard_overlap("deploy the staging server", "deploy the staging server"),
+            1.0,
+        )
+
+    def test_disjoint_text_is_zero(self):
+        self.assertEqual(
+            recall.jaccard_overlap("deploy staging server", "vegan dinner recipes"),
+            0.0,
+        )
+
+    def test_partial_overlap_is_between(self):
+        score = recall.jaccard_overlap(
+            "deploy staging server",
+            "deploy production server",
+        )
+        # {deploy, staging, server} vs {deploy, production, server}
+        # → intersection 2, union 4 → 0.5
+        self.assertAlmostEqual(score, 0.5, places=2)
+
+    def test_stopwords_dont_inflate_overlap(self):
+        # "the" / "is" / "a" present in both shouldn't count.
+        score = recall.jaccard_overlap("the cat is a pet", "the dog is a pet")
+        # Real tokens after stopword strip: {cat, pet} vs {dog, pet}
+        # → intersection 1, union 3 → 0.333…
+        self.assertAlmostEqual(score, 1 / 3, places=2)
+
+    def test_empty_text_yields_zero(self):
+        self.assertEqual(recall.jaccard_overlap("", "anything at all"), 0.0)
+        self.assertEqual(recall.jaccard_overlap("query", ""), 0.0)
+
+    def test_non_string_inputs_yield_zero(self):
+        self.assertEqual(recall.jaccard_overlap(None, "x"), 0.0)
+        self.assertEqual(recall.jaccard_overlap("x", None), 0.0)
+
+    def test_case_insensitive(self):
+        self.assertEqual(
+            recall.jaccard_overlap("DEPLOY Server", "deploy server"),
+            1.0,
+        )
+
+    def test_punctuation_stripped(self):
+        self.assertEqual(
+            recall.jaccard_overlap("deploy, server!", "deploy server"),
+            1.0,
+        )
+
+
+class OverlapFilterUnitTests(unittest.TestCase):
+    """Switchroom #475: _filter_by_overlap behaviour."""
+
+    def test_threshold_zero_passthrough(self):
+        results = [_memory("totally unrelated text")]
+        kept, dropped = recall._filter_by_overlap(results, "deploy server", 0.0)
+        self.assertEqual(kept, results)
+        self.assertEqual(dropped, 0)
+
+    def test_high_threshold_drops_weak_matches(self):
+        results = [
+            _memory("deploy server staging"),  # full overlap
+            _memory("vegan dinner recipes"),    # zero overlap
+        ]
+        kept, dropped = recall._filter_by_overlap(results, "deploy server staging", 0.5)
+        self.assertEqual(len(kept), 1)
+        self.assertEqual(dropped, 1)
+        self.assertEqual(kept[0]["text"], "deploy server staging")
+
+    def test_threshold_keeps_partial_match_at_or_above(self):
+        results = [_memory("deploy production server")]
+        kept, dropped = recall._filter_by_overlap(results, "deploy staging server", 0.5)
+        # 2/4 = 0.5 ≥ 0.5 → kept
+        self.assertEqual(len(kept), 1)
+        self.assertEqual(dropped, 0)
+
+    def test_threshold_drops_partial_match_below(self):
+        results = [_memory("deploy production server")]
+        kept, dropped = recall._filter_by_overlap(results, "deploy staging server", 0.51)
+        self.assertEqual(len(kept), 0)
+        self.assertEqual(dropped, 1)
+
+
+class OverlapGateIntegrationTests(unittest.TestCase):
+    """Switchroom #475: gate wired through main()."""
+
+    def test_default_off_passes_everything_through(self):
+        # No recallMinOverlap in config → behaves as before.
+        client = _FakeClient(
+            directives=[],
+            memories=[
+                _memory("deploy staging server"),
+                _memory("vegan dinner recipes"),
+            ],
+        )
+        ctx, _ = _run_main_with(client, prompt="how do we deploy staging?")
+        self.assertIsNotNone(ctx)
+        self.assertIn("deploy staging server", ctx)
+        self.assertIn("vegan dinner recipes", ctx)
+
+    def test_high_threshold_drops_irrelevant_memories(self):
+        client = _FakeClient(
+            directives=[],
+            memories=[
+                _memory("deploy staging server"),
+                _memory("vegan dinner recipes"),
+            ],
+        )
+        ctx, _ = _run_main_with(
+            client,
+            prompt="how do we deploy staging server",
+            config_extra={"recallMinOverlap": 0.5},
+        )
+        # Relevant survives, junk doesn't.
+        self.assertIsNotNone(ctx)
+        self.assertIn("deploy staging server", ctx)
+        self.assertNotIn("vegan", ctx)
+
+    def test_threshold_emits_no_block_when_all_dropped(self):
+        # All memories below threshold → no <hindsight_memories> block.
+        # Telemetry still records the dropped count.
+        client = _FakeClient(
+            directives=[],
+            memories=[
+                _memory("vegan dinner recipes"),
+                _memory("totally unrelated chatter"),
+            ],
+        )
+        ctx, _ = _run_main_with(
+            client,
+            prompt="how do we deploy staging server",
+            config_extra={"recallMinOverlap": 0.5},
+        )
+        # No memories survived; with no directives either, we expect no
+        # additionalContext at all.
+        self.assertIsNone(ctx)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Closes #475.

## Summary

Hindsight's HTTP API does not return similarity scores. So the existing `recallMaxMemories` cap (#432 4.2) acts as a *floor* on low-relevance prompts — weak matches still fill the slot up to N, mis-steering the model away from the user's actual request. This is the JTBD anti-pattern from `reference/remember-across-sessions.md`:

> *Regurgitating old facts unprompted, out of context, just to prove the agent remembered. That's noise.*

This PR adds a switchroom-local **Jaccard overlap gate** that runs in `recall.py` between the demote-tag filter (#432 4.4) and the count cap. Memories whose token overlap with the user's query is below `recallMinOverlap` are dropped. Off by default (`0.0`) so the gate is opt-in; operators tune via `memory.recall.min_overlap: 0.15` in switchroom.yaml or `HINDSIGHT_RECALL_MIN_OVERLAP=0.15` env. The recall_log.jsonl telemetry (#432 4.3) gains an `overlap_dropped` field so the gate's effect is observable per turn via `switchroom memory recall-log <agent>`.

## JTBD anchors

`reference/remember-across-sessions.md`:

> *What comes back is relevant, not a grab-bag. If the agent recalls five things, four of them should be useful.*

> *Treating every retained memory as equally weighted. The agent needs a sense of what matters and what was small talk.*

## Why this approach

- **Why not a min-score filter:** Hindsight's recall API doesn't expose scores in its response (verified in `lib/client.py` recall + `_memory(...)` test factory). Score-based filtering needs an upstream change to `vectorize-io/hindsight`.
- **Why Jaccard over cosine:** zero embedding dependency, runs in-process in <1ms, works on the data we actually have today.
- **Why off-by-default:** lexical overlap is a heuristic; we ship safely, observe via existing telemetry on real banks, then flip the default once we have a tuned threshold from real fleet data.
- **Why stop-word stripping:** common-word coincidence isn't real signal. The set is intentionally tight — better to miss a borderline drop than throw out a real match.

## What's gated, what isn't

| Layer | Mechanism | Status |
|---|---|---|
| Skip the API call entirely on social acks | recall.py:299–330 | Already shipped |
| Drop demote-tagged memories | #432 4.4 | Shipped |
| **Drop low-overlap memories before cap** | **This PR** | **New** |
| Cap count below configured max | #432 4.2 | Shipped |
| Per-session cache to skip dupes | #432 4.1 | Shipped |
| Telemetry per turn | #432 4.3 | Shipped (extended with `overlap_dropped`) |

## Files

- `vendor/hindsight-memory/scripts/recall.py` — `jaccard_overlap`, `_filter_by_overlap`, wiring + telemetry field. Tagged switchroom-local matching the existing #432 conventions in this file.
- `vendor/hindsight-memory/scripts/lib/config.py` — `recallMinOverlap` default + `HINDSIGHT_RECALL_MIN_OVERLAP` env override + `float` cast support in `_cast_env`.
- `src/config/schema.ts` — `memory.recall.min_overlap` (defaults shape + agent-override shape).
- `src/agents/scaffold.ts` — three plumbing sites mirroring the existing `hindsightRecallCacheTtlSecs` pattern.
- `profiles/_base/start.sh.hbs` — gated `export HINDSIGHT_RECALL_MIN_OVERLAP={{...}}`.

## Test plan

- [x] **12 new python tests** — `JaccardOverlapUnitTests` (8 cases), `OverlapFilterUnitTests` (4 cases), `OverlapGateIntegrationTests` (3 cases via main()). All green.
- [x] **All existing python tests still pass** — 43/43 in `test_recall_integration.py`.
- [x] **`npm run lint`** — clean.
- [x] **`npm run build`** — clean.
- [x] **`npm test`** — 4109 vitest passing, 0 fail. (3 pre-existing failures in `vendor/hindsight-memory/tests/test_config.py` exist on stock `upstream/main` — they assert `recallBudget == "mid"` but switchroom defaults this to `"low"` per #470 speed work; unrelated to this PR.)
- [ ] **Manual smoke**: enable `memory.recall.min_overlap: 0.15` on a fleet agent, send 10 mixed prompts, verify `recall-log.jsonl` shows non-zero `overlap_dropped` on the irrelevant ones and zero on the relevant ones.

## Out of scope (follow-ups)

- **Upstream Hindsight: expose scores in recall response.** Once available, replace this lexical heuristic with a real similarity floor.
- **Surface scores in `format_memories`.** Once upstream returns scores, render them so the model can weigh weak vs strong itself.
- **Per-memory-type weighting.** Existing `recallTypes` knob covers most of this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)