### PR TITLE
fix(hooks): subagent-tracker hooks — bun:sqlite fallback

### DIFF
--- a/telegram-plugin/hooks/subagent-tracker-posttool.mjs
+++ b/telegram-plugin/hooks/subagent-tracker-posttool.mjs
@@ -51,6 +51,35 @@ function fillPlaceholders(sql, params) {
 }
 
 /**
+ * Resolve a synchronous SQLite binding compatible with the
+ * `DatabaseSync(path)` API. See subagent-tracker-pretool.mjs for the
+ * full doc — kept in lockstep across both hook scripts.
+ */
+function resolveSyncSqlite() {
+  const [major] = process.versions.node.split('.').map(Number)
+  if (major >= 22) {
+    try {
+      const { DatabaseSync } = require('node:sqlite')
+      if (DatabaseSync) return DatabaseSync
+    } catch { /* fall through to bun:sqlite */ }
+  }
+  if (typeof globalThis.Bun !== 'undefined') {
+    try {
+      const { Database } = require('bun:sqlite')
+      return function BunDatabaseSyncAdapter(p) {
+        const d = new Database(p)
+        return {
+          exec: (sql) => d.exec(sql),
+          prepare: (sql) => d.prepare(sql),
+          close: () => d.close(),
+        }
+      }
+    } catch { /* fall through to CLI */ }
+  }
+  return null
+}
+
+/**
  * Run SQL against the DB via the sqlite3 CLI (non-blocking).
  * Calls cb(error | null) when the process exits.
  */
@@ -166,17 +195,13 @@ function updateRow(dbPath, { id, status, resultSummary, now }, done) {
   const snapResultSummary = resultSummary
   const snapNow = now
 
-  const [major] = process.versions.node.split('.').map(Number)
-
-  // Resolve node:sqlite availability synchronously (before deferring), so the
-  // setImmediate closure knows which path to take without further try/catch.
-  let DatabaseSync = null
-  if (major >= 22) {
-    try { DatabaseSync = require('node:sqlite').DatabaseSync } catch { /* CLI fallback */ }
-  }
+  // Resolve a synchronous SQLite binding (node:sqlite under Node 22+,
+  // bun:sqlite under bun, else null → CLI fallback). See helper docs.
+  const DatabaseSync = resolveSyncSqlite()
 
   if (DatabaseSync != null) {
-    // Node 22+ with node:sqlite available — defer the write to the next tick.
+    // Sync SQLite binding available — defer the write to the next tick
+    // so the hook returns to Claude Code as fast as possible.
     const SnapDatabaseSync = DatabaseSync
     setImmediate(() => {
       try {

--- a/telegram-plugin/hooks/subagent-tracker-pretool.mjs
+++ b/telegram-plugin/hooks/subagent-tracker-pretool.mjs
@@ -84,6 +84,47 @@ function fillPlaceholders(sql, params) {
 }
 
 /**
+ * Resolve a synchronous SQLite binding compatible with the
+ * `DatabaseSync(path)` API (`db.exec(sql)`, `db.prepare(sql).run(...)`,
+ * `db.prepare(sql).get(...)`, `db.close()`).
+ *
+ * Production hooks are spawned via the `#!/usr/bin/env node` shebang, so
+ * Node 22+'s `node:sqlite` is the primary path. When the hook is invoked
+ * under bun (e.g. `bun test` calling spawnSync(process.execPath, ...) on
+ * CI), `node:sqlite` isn't available — fall back to `bun:sqlite` wrapped
+ * in a tiny adapter so the call-site code below stays identical.
+ *
+ * Returns null if neither is available; callers then drop to the
+ * `sqlite3` CLI fallback further down.
+ */
+function resolveSyncSqlite() {
+  const [major] = process.versions.node.split('.').map(Number)
+  if (major >= 22) {
+    try {
+      const { DatabaseSync } = require('node:sqlite')
+      if (DatabaseSync) return DatabaseSync
+    } catch { /* fall through to bun:sqlite */ }
+  }
+  if (typeof globalThis.Bun !== 'undefined') {
+    try {
+      const { Database } = require('bun:sqlite')
+      // Adapt bun:sqlite to the node:sqlite DatabaseSync surface used
+      // below. bun's Database.prepare/run/get/all and exec are
+      // sufficient — we only need the call-site shape.
+      return function BunDatabaseSyncAdapter(p) {
+        const d = new Database(p)
+        return {
+          exec: (sql) => d.exec(sql),
+          prepare: (sql) => d.prepare(sql),
+          close: () => d.close(),
+        }
+      }
+    } catch { /* fall through to CLI */ }
+  }
+  return null
+}
+
+/**
  * Run SQL against the DB via the sqlite3 CLI (non-blocking).
  * Calls cb(error | null) when the process exits.
  */
@@ -114,16 +155,14 @@ function writeRow(dbPath, { id, parentSessionId, parentTurnKey, agentType, descr
   `
   const params = [id, parentSessionId, parentTurnKey, agentType, description, background, now, now]
 
-  // Resolve node:sqlite availability synchronously (before deferring), so the
-  // setImmediate closure knows which path to take without further try/catch.
-  const [major] = process.versions.node.split('.').map(Number)
-  let DatabaseSync = null
-  if (major >= 22) {
-    try { DatabaseSync = require('node:sqlite').DatabaseSync } catch { /* CLI fallback */ }
-  }
+  // Resolve a synchronous SQLite binding. Try in order:
+  //   1. node:sqlite (Node 22+, production path) — exposes DatabaseSync
+  //   2. bun:sqlite (when invoked under bun, e.g. from `bun test`) — wrapped
+  //      in a tiny adapter so call sites stay unchanged
+  // Falls back to the sqlite3 CLI block below if neither is available.
+  const DatabaseSync = resolveSyncSqlite()
 
   if (DatabaseSync != null) {
-    // Node 22+ with node:sqlite available — defer the write to the next tick.
     // Snapshot all values used inside the closure now, before setImmediate fires.
     const SnapDatabaseSync = DatabaseSync
     const snapDbPath = dbPath

--- a/telegram-plugin/registry/subagents-bugs.test.ts
+++ b/telegram-plugin/registry/subagents-bugs.test.ts
@@ -236,7 +236,11 @@ afterEach(() => {
 })
 
 function runHook(scriptPath: string, event: object) {
-  return spawnSync('node', [scriptPath], {
+  // Invoke the hook with the current runtime (bun under `bun test`,
+  // node in production), not a hard-coded 'node'. CI's hosted Buildkite
+  // agent doesn't ship node:sqlite or sqlite3 CLI, so requiring node
+  // would fail; the hook detects bun and uses bun:sqlite instead.
+  return spawnSync(process.execPath, [scriptPath], {
     input: JSON.stringify(event),
     encoding: 'utf8',
     env: { ...process.env, SWITCHROOM_AGENT_DIR: agentDir },

--- a/telegram-plugin/tests/subagent-tracker-hooks.test.ts
+++ b/telegram-plugin/tests/subagent-tracker-hooks.test.ts
@@ -38,7 +38,11 @@ afterEach(() => {
 })
 
 function runHook(scriptPath: string, event: object, extraEnv: Record<string, string> = {}) {
-  const result = spawnSync('node', [scriptPath], {
+  // Invoke the hook with the current runtime (bun under `bun test`, node
+  // in production), not a hard-coded 'node'. The hook script detects bun
+  // and uses bun:sqlite, so it works on CI agents that lack node:sqlite
+  // and the sqlite3 CLI.
+  const result = spawnSync(process.execPath, [scriptPath], {
     input: JSON.stringify(event),
     encoding: 'utf8',
     env: {


### PR DESCRIPTION
## Summary

Follow-up to #474. Buildkite hosted Linux 2x4 agents don't ship Node 22+ with `node:sqlite` (and don't ship the `sqlite3` CLI either). The subagent-tracker pre/posttool hooks rely on one of those two paths, so the bug-regression suite (`telegram-plugin/registry/subagents-bugs.test.ts`, `telegram-plugin/tests/subagent-tracker-hooks.test.ts`) fails on every CI run with `expect(result.status).toBe(0) Received: 1`. Locally tests pass because Node 22.22 + node:sqlite is the default. This is what's keeping `main` red right now (build #555 deb2f8f failed in Plugin tests on these 10 tests).

## Two coordinated changes

1. **Hook scripts** (`subagent-tracker-pretool.mjs`, `subagent-tracker-posttool.mjs`): extract a `resolveSyncSqlite()` helper that tries `node:sqlite` first (production path under Node 22+), then falls back to a tiny `bun:sqlite` adapter when running under bun, then null. The adapter only mirrors the call sites we use (`exec`, `prepare`, `close`) — bun:sqlite's prepared statements already match `node:sqlite`'s `run/get/all`. The `sqlite3` CLI fallback at the bottom of `writeRow`/`updateRow` is kept as a last resort.

2. **Test runners** (`subagents-bugs.test.ts`, `subagent-tracker-hooks.test.ts`): swap `spawnSync('node', ...)` for `spawnSync(process.execPath, ...)`. Under `bun test`, `process.execPath` is the bun binary, so the hook runs under bun and uses bun:sqlite. In production the hook script is invoked by Claude Code via its `#!/usr/bin/env node` shebang — that path is unaffected.

## Verification

```
$ cd telegram-plugin && bun test
…
 2681 pass
 1 skip
 0 fail
 5874 expect() calls
Ran 2682 tests across 132 files. [17.90s]
```

Same totals as CI's "Plugin tests" step. `npm test` from root also clean (4109 vitest + 285 bun = exit 0).

## Why a separate PR

#474 already merged with the first four fixes; #471 was waiting on those. This is the last red light blocking #471's CI from going green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)