### PR TITLE
fix(streaming): drop stream_reply(done=false) checklist-mode rejection (#481)

### DIFF
--- a/telegram-plugin/stream-reply-handler.ts
+++ b/telegram-plugin/stream-reply-handler.ts
@@ -310,41 +310,19 @@ export async function handleStreamReply(
     process.stderr.write(`telegram channel: stream_reply: invoked done=true chatId=${chat_id} lane=${args.lane ?? 'default'} charCount=${rawText.length}\n`)
   }
 
-  // Access check runs BEFORE the progress-card short-circuit: a denied
-  // chat id must throw regardless of streaming mode. Previously the
-  // suppression path silently "succeeded" for unauthorized chats.
+  // Access check runs BEFORE any other branch: a denied chat id must
+  // throw regardless of streaming mode. Previously the suppression path
+  // silently "succeeded" for unauthorized chats.
   deps.assertAllowedChat(chat_id)
   const threadId = deps.resolveThreadId(chat_id, args.message_thread_id)
 
-  // In checklist mode the progress card is the mid-turn surface. A
-  // caller-initiated default-lane stream_reply(done=false) creates a
-  // second surface that either duplicates the card's narrative or
-  // races it. We reject it with a clear error so the caller learns
-  // in-context rather than through silent suppression + a missing
-  // message later. Internal callers (the progress-card driver itself)
-  // pass lane:'progress' and are allowed through.
-  const isDefaultLane = args.lane == null || args.lane.length === 0
-  if (deps.progressCardActive === true && isDefaultLane && !done) {
-    // Claim the PTY-preview slot so any PTY partial that fires after
-    // this rejected call doesn't leak a raw-TUI draft. The claim is
-    // keyed lane-less because the PTY handler uses lane-less keys.
-    state.suppressPtyPreview?.add(streamKey(chat_id, threadId))
-    deps.logStreamingEvent({
-      kind: 'stream_reply_called',
-      chatId: chat_id,
-      charCount: rawText.length,
-      done: false,
-      streamExisted: state.activeDraftStreams.has(
-        streamKey(chat_id, threadId, args.lane, args.turnKey),
-      ),
-    })
-    throw new Error(
-      'stream_reply(done=false) is not supported in checklist mode. ' +
-        'The progress card already renders mid-turn status (Plan → Run → Done ' +
-        'with live tool bullets). Call stream_reply exactly once per turn ' +
-        'with done=true and your complete final answer.',
-    )
-  }
+  // Note: caller-initiated stream_reply(done=false) used to be rejected
+  // when the progress card was active. The card and the answer message
+  // live on different lanes (progress vs default) and render different
+  // content (tool structure vs model prose), so they don't actually
+  // collide — the rejection forced single-shot final replies and broke
+  // the progressive-streaming contract documented in
+  // profiles/default/CLAUDE.md. See #481.
 
   let parseMode: 'HTML' | 'MarkdownV2' | undefined
   let effectiveText: string

--- a/telegram-plugin/tests/stream-reply-handler.test.ts
+++ b/telegram-plugin/tests/stream-reply-handler.test.ts
@@ -777,27 +777,37 @@ describe('handleStreamReply', () => {
     expect(streamReplyCalledEvents[1].streamExisted).toBe(true)
   })
 
-  describe('progressCardActive enforcement', () => {
-    // In checklist mode the progress-card driver owns the mid-turn
-    // surface. A default-lane stream_reply(done=false) is rejected with
-    // an error so the caller (the model) learns in-context to only call
-    // stream_reply with done=true. Previously this was silently
-    // suppressed — the loud error makes the contract deterministic.
-    it('rejects default-lane done=false with a clear error when progress card is active', async () => {
+  describe('progressCardActive coexistence', () => {
+    // The progress card and the answer message live on different lanes
+    // (progress vs default) and render different content (tool structure
+    // vs model prose), so default-lane stream_reply(done=false) is
+    // accepted in checklist mode. The card is no longer treated as the
+    // sole mid-turn surface — it shows tool structure on its own lane
+    // while the model's progressive replies stream into the answer
+    // message. See #481.
+    it('accepts default-lane done=false when progress card is active (streams into answer)', async () => {
       const state: StreamReplyState = {
         ...makeState(),
         suppressPtyPreview: new Set<string>(),
       }
       const deps = makeDeps(bot, { progressCardActive: true })
 
-      await expect(
-        handleStreamReply({ chat_id: '1', text: 'working...' }, state, deps),
-      ).rejects.toThrow(/stream_reply\(done=false\) is not supported in checklist mode/)
+      const pending = handleStreamReply(
+        { chat_id: '1', text: 'working...' },
+        state,
+        deps,
+      )
+      await microtaskFlush()
+      const result = await pending
 
-      expect(bot.api.sendMessage).not.toHaveBeenCalled()
-      expect(state.activeDraftStreams.size).toBe(0)
-      // PTY-preview slot still claimed so a late PTY partial doesn't
-      // leak a raw-TUI draft_send after the rejection.
+      expect(bot.api.sendMessage).toHaveBeenCalledTimes(1)
+      expect(bot.api.sendMessage.mock.calls[0][1]).toBe('<html>working...</html>')
+      expect(result.status).toBe('updated')
+      // PTY-preview slot is claimed because the model is now the
+      // answer-lane surface owner — late PTY partials should defer to
+      // the model's stream rather than racing it with a parallel edit.
+      // (Same suppression pattern as before — no longer for cleanup
+      // after a rejection, but for ownership during normal streaming.)
       expect(state.suppressPtyPreview?.has('1:_')).toBe(true)
     })
 

--- a/telegram-plugin/tests/streaming-e2e.test.ts
+++ b/telegram-plugin/tests/streaming-e2e.test.ts
@@ -258,28 +258,34 @@ describe('streaming e2e smoke', () => {
 
   // --- checklist-mode contract ----------------------------------------
   //
-  // In checklist mode the progress-card driver owns the mid-turn surface.
-  // The model-facing stream_reply tool must:
-  //   - reject any call with done=false (throws, surfaces to the model as
-  //     an MCP tool error so it learns in-context not to call it)
-  //   - accept done=true and post the answer as a single message
+  // In checklist mode the progress-card driver renders tool structure on
+  // lane:'progress'; the model's stream_reply / reply lands on the
+  // default lane. They coexist — the rejection that used to force
+  // single-shot final replies is gone (#481). The model-facing
+  // stream_reply tool must:
+  //   - accept done=false (streams interim text into the answer message)
+  //   - accept done=true (finalizes the answer message)
   //
-  // Internal callers (the progress-card driver) pass lane:'progress' and
-  // bypass the rejection. End-to-end shape exercised here mirrors
-  // production when SWITCHROOM_TG_STREAM_MODE=checklist (the default).
+  // Internal callers (the progress-card driver) pass lane:'progress'
+  // and land on the card stream. End-to-end shape exercised here
+  // mirrors production when SWITCHROOM_TG_STREAM_MODE=checklist
+  // (the default).
 
-  it('checklist mode: done=false (default lane) throws a clear tool error', async () => {
+  it('checklist mode: done=false (default lane) streams interim text into the answer message', async () => {
     holder.current = setup({ progressCardActive: true })
     const f = holder.current
 
-    await expect(
-      f.fireStreamReply({ chat_id: '42', text: 'looking into this…' }),
-    ).rejects.toThrow(/stream_reply\(done=false\) is not supported in checklist mode/)
+    const pending = f.fireStreamReply({ chat_id: '42', text: 'looking into this…' })
+    await microtaskFlush()
+    const r = await pending
 
-    expect(f.bot.api.sendMessage).not.toHaveBeenCalled()
-    expect(f.bot.api.editMessageText).not.toHaveBeenCalled()
-    // PTY slot is still claimed — stops a late PTY partial from leaking
-    // a raw-TUI draft after the rejection.
+    expect(r.status).toBe('updated')
+    expect(f.bot.api.sendMessage).toHaveBeenCalledTimes(1)
+    expect(f.bot.api.sendMessage.mock.calls[0][1]).toBe('<b>looking into this…</b>')
+    // PTY slot is claimed because the model is now the answer-lane
+    // surface owner — late PTY partials defer to the model's stream
+    // rather than racing it. (Same suppression pattern as before;
+    // ownership reason now, not cleanup-after-rejection.)
     expect(f.suppress.has('42:_')).toBe(true)
   })
 
@@ -298,13 +304,16 @@ describe('streaming e2e smoke', () => {
     expect(f.map.has('1:_')).toBe(false)
   })
 
-  it('checklist mode: rejection does NOT block a subsequent done=true answer', async () => {
+  it('checklist mode: progressive done=false then done=true edits the same message', async () => {
     holder.current = setup({ progressCardActive: true })
     const f = holder.current
 
-    await expect(
-      f.fireStreamReply({ chat_id: '1', text: 'wrong call' }),
-    ).rejects.toThrow()
+    const p1 = f.fireStreamReply({ chat_id: '1', text: 'thinking…' })
+    await microtaskFlush()
+    await p1
+
+    expect(f.bot.api.sendMessage).toHaveBeenCalledTimes(1)
+    expect(f.bot.api.sendMessage.mock.calls[0][1]).toBe('<b>thinking…</b>')
 
     vi.advanceTimersByTime(1000)
     await microtaskFlush()
@@ -312,8 +321,9 @@ describe('streaming e2e smoke', () => {
     await microtaskFlush()
     await pdone
 
+    // First call sent the message; second call edits it (no second send).
     expect(f.bot.api.sendMessage).toHaveBeenCalledTimes(1)
-    expect(f.bot.api.sendMessage.mock.calls[0][1]).toBe('<b>right answer</b>')
+    expect(f.bot.api.editMessageText).toHaveBeenCalled()
   })
 
   it('checklist mode: internal lane=progress callers bypass the rejection', async () => {


### PR DESCRIPTION
## Summary

Closes #481. Removes the hard-error rejection of \`stream_reply(done=false)\` in default \`checklist\` mode at \`telegram-plugin/stream-reply-handler.ts:319-347\`.

The original rationale (\"creates a second surface that duplicates the card's narrative or races it\") doesn't hold:
- The card is on \`lane: 'progress'\`, the answer is on the default lane — different streams, different message ids, different throttles.
- The card renders tool *structure* (Plan→Run→Done with tool bullets); the answer renders model *prose*. Not duplicative.

The rejection directly contradicted \`profiles/default/CLAUDE.md:33-35\`, which instructs the model to call \`stream_reply\` progressively with \`done=false\`. With the rejection in place, the model's progressive calls threw, it fell back to a single final reply, and the user saw the long silent gap described in #303 / #478 / #480.

## Changes

- \`telegram-plugin/stream-reply-handler.ts\` — delete the rejection block (lines 319-347 in the old file). The \`suppressPtyPreview\` ownership claim further down at line 374 already handles PTY/model coordination during normal streams; nothing else needs changing.
- \`telegram-plugin/tests/stream-reply-handler.test.ts\` — flip the \"rejects default-lane done=false\" test to \"accepts default-lane done=false\". Asserts the send happens and ownership claim still fires.
- \`telegram-plugin/tests/streaming-e2e.test.ts\` — rewrite the two rejection tests as positive flows (interim text streams, then done=true edits same message). Internal \`lane:'progress'\` test (the card-driver path) is unchanged.

## Verification

\`\`\`
$ cd telegram-plugin && bun test
…
 2763 pass
 1 skip
 0 fail
 6039 expect() calls
Ran 2764 tests across 137 files. [17.52s]

$ npm test
…
 Test Files  202 passed | 1 skipped (203)
      Tests  4109 passed | 7 skipped (4116)
…
 285 pass
 1 skip
 0 fail
exit=0
\`\`\`

## Phase 2

Phase 2 (#482) re-enables PTY-tail's character-level extraction in checklist mode and wires pre-alloc draft consumption so the answer streams character-by-character (closes the rest of the gap described in #480). It builds on this PR and ships separately.

#479 (pre-alloc placeholder in groups + forum topics) is the third independent piece.

🤖 Generated with [Claude Code](https://claude.com/claude-code)