### PR TITLE
chore(telegram): backport upstream commits since fork (#894, #1397)

### DIFF
--- a/telegram-plugin/dm-command-gate.ts
+++ b/telegram-plugin/dm-command-gate.ts
@@ -1,0 +1,56 @@
+/**
+ * Pure decision logic for the bot-command access gate.
+ *
+ * Backport of upstream `5a71459` (claude-plugins-official #894). The
+ * /start, /help, /status command handlers used to reply to ANY private
+ * DM regardless of `dmPolicy`, leaking the bot's existence to
+ * non-allowlisted senders. That contradicted access.json's "drop
+ * silently" contract for allowlist mode and the bot-disabled state.
+ *
+ * Lives in its own module (separate from server.ts and gateway.ts) so
+ * the decision can be unit-tested without booting the MCP server or
+ * the gateway long-poll. The actual call sites in server.ts and
+ * gateway.ts wrap this with `ctx.chat?.type` / `ctx.from` /
+ * `loadAccess()` shims.
+ */
+
+export interface DmCommandGateInput {
+  /** Telegram chat type from `ctx.chat?.type`. Only "private" is allowed. */
+  chatType: string | undefined
+  /** Stringified sender id from `ctx.from?.id`. Required. */
+  senderId: string | undefined
+  /** Current access policy: pairing | allowlist | disabled. */
+  dmPolicy: "pairing" | "allowlist" | "disabled" | string
+  /** Sender ids on the outbound allowlist. */
+  allowFrom: readonly string[]
+}
+
+export type DmCommandGateDecision =
+  | { allow: true; senderId: string }
+  | { allow: false; reason: "not-private" | "no-sender" | "disabled" | "not-allowlisted" }
+
+/**
+ * Decide whether a bot command (/start, /help, /status) should be
+ * answered. Returns `{ allow: false, reason }` on every drop branch
+ * so callers and tests can introspect why a particular drop happened.
+ *
+ * The four drop branches:
+ * - `not-private` — non-DM chat (group/supergroup/channel)
+ * - `no-sender` — message without a `from` (rare; channel posts)
+ * - `disabled` — operator turned the bot off via dmPolicy=disabled
+ * - `not-allowlisted` — dmPolicy=allowlist and sender not on `allowFrom`
+ *
+ * Pairing-mode senders that aren't yet on `allowFrom` are explicitly
+ * ALLOWED through — that's how /status surfaces a user's pending code.
+ */
+export function decideDmCommandGate(input: DmCommandGateInput): DmCommandGateDecision {
+  if (input.chatType !== "private") return { allow: false, reason: "not-private" }
+  if (input.senderId == null || input.senderId.length === 0) {
+    return { allow: false, reason: "no-sender" }
+  }
+  if (input.dmPolicy === "disabled") return { allow: false, reason: "disabled" }
+  if (input.dmPolicy === "allowlist" && !input.allowFrom.includes(input.senderId)) {
+    return { allow: false, reason: "not-allowlisted" }
+  }
+  return { allow: true, senderId: input.senderId }
+}

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -23,6 +23,7 @@ import { homedir } from 'os'
 import { join, extname, sep, basename } from 'path'
 
 import { installPluginLogger } from '../plugin-logger.js'
+import { decideDmCommandGate } from '../dm-command-gate.js'
 import { StatusReactionController } from '../status-reactions.js'
 import { isTelegramReplyTool, isTelegramSurfaceTool } from '../tool-names.js'
 import { createTypingWrapper } from '../typing-wrap.js'
@@ -3084,6 +3085,26 @@ type GateResult =
   | { action: 'drop' }
   | { action: 'pair'; code: string; isResend: boolean }
 
+/**
+ * Wrap `decideDmCommandGate` (pure helper in
+ * `../dm-command-gate.ts`) with grammy ctx + access.json side effects.
+ * Returns null (silent drop) on every reject path. See
+ * dm-command-gate.ts for the upstream backport (#894) rationale.
+ */
+function dmCommandGate(ctx: Context): { access: Access; senderId: string } | null {
+  const access = loadAccess()
+  const pruned = pruneExpired(access)
+  if (pruned) saveAccess(access)
+  const decision = decideDmCommandGate({
+    chatType: ctx.chat?.type,
+    senderId: ctx.from?.id != null ? String(ctx.from.id) : undefined,
+    dmPolicy: access.dmPolicy,
+    allowFrom: access.allowFrom,
+  })
+  if (!decision.allow) return null
+  return { access, senderId: decision.senderId }
+}
+
 function gate(ctx: Context): GateResult {
   const access = loadAccess()
   const pruned = pruneExpired(access)
@@ -4687,22 +4708,27 @@ function buildAgentMetadata(agentName: string): AgentMetadata {
 }
 
 bot.command('start', async ctx => {
-  if (ctx.chat?.type !== 'private') return
-  const access = loadAccess()
-  const disabled = access.dmPolicy === 'disabled'
+  // dmCommandGate (#894 backport): silent drop on disabled or
+  // non-allowlisted senders so the bot doesn't leak its existence.
+  const gated = dmCommandGate(ctx)
+  if (!gated) return
+  const disabled = gated.access.dmPolicy === 'disabled'
   await ctx.reply(buildStartText(getMyAgentName(), disabled), { parse_mode: 'HTML' })
 })
 
 bot.command('help', async ctx => {
-  if (ctx.chat?.type !== 'private') return
+  if (!dmCommandGate(ctx)) return
   await ctx.reply(buildHelpText(getMyAgentName()), { parse_mode: 'HTML' })
 })
 
 bot.command('status', async ctx => {
-  if (ctx.chat?.type !== 'private') return
-  const from = ctx.from; if (!from) return
-  const senderId = String(from.id)
-  const access = loadAccess()
+  // dmCommandGate (#894 backport) drops disabled / non-allowlisted in
+  // allowlist mode. Pairing-mode users still fall through to either
+  // the pending-code branch or the unpaired branch.
+  const gated = dmCommandGate(ctx)
+  if (!gated) return
+  const { access, senderId } = gated
+  const from = ctx.from!
   if (access.allowFrom.includes(senderId)) {
     const userTag = from.username ? `@${from.username}` : senderId
     const meta = buildAgentMetadata(getMyAgentName())
@@ -7553,6 +7579,16 @@ void (async () => {
         await clearStaleTelegramPollingState(bot.api)
         return bot.api.getMe()
       })
+      // Backport of upstream `7e401ed` (claude-plugins-official #1397):
+      // reset the backoff counter on successful poll-loop start so a
+      // transient mid-session 409 doesn't compound with prior attempts
+      // and push the next retry past 15s. Note: the rest of #1397
+      // (retry on non-409 transient errors) is supplanted in the
+      // gateway by the deliberate process.exit(1) below — systemd's
+      // Restart=always recovers from non-409 failures with a clean
+      // reboot, which has been the chosen strategy since the 2026-04-29
+      // "live-but-silent gateway" incident.
+      attempt = 0
       botUsername = me.username
       process.stderr.write(`telegram gateway: polling as @${me.username}\n`)
       if (TOPIC_ID != null) process.stderr.write(`telegram gateway: topic filter active — thread_id=${TOPIC_ID}\n`)

--- a/telegram-plugin/server.ts
+++ b/telegram-plugin/server.ts
@@ -384,6 +384,7 @@ import {
 import { sweepActivePins, sweepBotAuthoredPins } from './active-pins-sweep.js'
 import { logPinEvent, classifyPinError, errorMessage } from './pin-event-log.js'
 import { validateStringArray } from './gateway/access-validator.js'
+import { decideDmCommandGate } from './dm-command-gate.js'
 
 /**
  * One-shot carry-over from the session-end summarizer: a short topic
@@ -794,6 +795,27 @@ function gate(ctx: Context): GateResult {
   }
 
   return { action: 'drop' }
+}
+
+/**
+ * Wrap `decideDmCommandGate` (pure helper in `./dm-command-gate.ts`) with
+ * the grammy ctx + access.json side effects. Returns the loaded access
+ * snapshot + senderId when the handler should proceed; returns null
+ * (silent drop) on every reject path. See dm-command-gate.ts for the
+ * upstream backport (#894) rationale.
+ */
+function dmCommandGate(ctx: Context): { access: Access; senderId: string } | null {
+  const access = loadAccess()
+  const pruned = pruneExpired(access)
+  if (pruned) saveAccess(access)
+  const decision = decideDmCommandGate({
+    chatType: ctx.chat?.type,
+    senderId: ctx.from?.id != null ? String(ctx.from.id) : undefined,
+    dmPolicy: access.dmPolicy,
+    allowFrom: access.allowFrom,
+  })
+  if (!decision.allow) return null
+  return { access, senderId: decision.senderId }
 }
 
 function isMentioned(ctx: Context, extraPatterns?: string[]): boolean {
@@ -3526,14 +3548,16 @@ process.on('SIGINT', shutdown)
 // the gate's behavior for unrecognized groups.
 
 bot.command('start', async ctx => {
-  if (ctx.chat?.type !== 'private') return
-  const access = loadAccess()
-  const disabled = access.dmPolicy === 'disabled'
+  // dmCommandGate (#894 backport): silent drop on disabled or
+  // non-allowlisted senders so the bot doesn't leak its existence.
+  const gated = dmCommandGate(ctx)
+  if (!gated) return
+  const disabled = gated.access.dmPolicy === 'disabled'
   await ctx.reply(buildStartText(getMyAgentName(), disabled), { parse_mode: 'HTML' })
 })
 
 bot.command('help', async ctx => {
-  if (ctx.chat?.type !== 'private') return
+  if (!dmCommandGate(ctx)) return
   await ctx.reply(buildHelpText(getMyAgentName()), { parse_mode: 'HTML' })
 })
 
@@ -3585,11 +3609,13 @@ function buildAgentMetadata(agentName: string): {
 }
 
 bot.command('status', async ctx => {
-  if (ctx.chat?.type !== 'private') return
-  const from = ctx.from
-  if (!from) return
-  const senderId = String(from.id)
-  const access = loadAccess()
+  // dmCommandGate (#894 backport) drops disabled / non-allowlisted in
+  // allowlist mode. Pairing-mode users still fall through to either
+  // the pending-code branch or the unpaired branch.
+  const gated = dmCommandGate(ctx)
+  if (!gated) return
+  const { access, senderId } = gated
+  const from = ctx.from!
 
   if (access.allowFrom.includes(senderId)) {
     const userTag = from.username ? `@${from.username}` : senderId
@@ -6386,6 +6412,10 @@ void (async () => {
       // Pre-fetch bot info (the runner doesn't expose an onStart callback
       // like bot.start does, so we have to call getMe ourselves).
       const me = await bot.api.getMe()
+      // Backport of upstream `7e401ed`: reset the backoff counter on
+      // successful poll-loop start so a transient mid-session failure
+      // doesn't combine with prior attempts to push delays past 15s.
+      attempt = 0
       botUsername = me.username
       process.stderr.write(`telegram channel: polling as @${me.username}\n`)
       if (TOPIC_ID != null) {
@@ -6619,20 +6649,28 @@ void (async () => {
       await runnerHandle.task()
       return // graceful stop
     } catch (err) {
-      if (err instanceof GrammyError && err.error_code === 409) {
-        const delay = Math.min(1000 * attempt, 15000)
-        const detail = attempt === 1
-          ? ' — another instance is polling (zombie session, or a second Claude Code running?)'
-          : ''
-        process.stderr.write(
-          `telegram channel: 409 Conflict${detail}, retrying in ${delay / 1000}s\n`,
-        )
-        await new Promise(r => setTimeout(r, delay))
-        continue
-      }
+      // Backport of upstream `7e401ed` (claude-plugins-official #1397):
+      // retry polling on ALL transient errors, not just 409. A single
+      // ETIMEDOUT / ECONNRESET / DNS failure used to fall through and
+      // `return`, ending the polling loop forever — the MCP process
+      // stayed alive (stdin keeps it running), outbound tools kept
+      // working, but the bot was deaf to inbound messages until a full
+      // restart. Now we retry with exponential-capped backoff like 409.
       if (err instanceof Error && err.message === 'Aborted delay') return
-      process.stderr.write(`telegram channel: polling failed: ${err}\n`)
-      return
+      const is409 = err instanceof GrammyError && err.error_code === 409
+      if (is409 && attempt >= 8) {
+        process.stderr.write(
+          `telegram channel: 409 Conflict persists after ${attempt} attempts — ` +
+          `another poller is holding the bot token (stray 'bun server.ts' process or a second session). Exiting.\n`,
+        )
+        return
+      }
+      const delay = Math.min(1000 * attempt, 15000)
+      const detail = is409
+        ? `409 Conflict${attempt === 1 ? ' — another instance is polling (zombie session, or a second Claude Code running?)' : ''}`
+        : `polling error: ${err}`
+      process.stderr.write(`telegram channel: ${detail}, retrying in ${delay / 1000}s\n`)
+      await new Promise(r => setTimeout(r, delay))
     }
   }
 })()

--- a/telegram-plugin/tests/dm-command-gate.test.ts
+++ b/telegram-plugin/tests/dm-command-gate.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it } from 'vitest'
+
+import { decideDmCommandGate } from '../dm-command-gate.js'
+
+/**
+ * Regression coverage for the upstream backport of
+ * claude-plugins-official `5a71459` (#894): /start, /help, /status
+ * must respect dmPolicy and the allowlist instead of replying to any
+ * private DM. The wrapper in server.ts and gateway.ts adds grammy ctx
+ * + access.json side effects — those are integration-tested via the
+ * production traffic the gateway sees. The decision logic is here.
+ */
+describe('decideDmCommandGate — bot command access', () => {
+  describe('drop branches', () => {
+    it('drops non-private chat (group)', () => {
+      const result = decideDmCommandGate({
+        chatType: 'group',
+        senderId: '12345',
+        dmPolicy: 'allowlist',
+        allowFrom: ['12345'],
+      })
+      expect(result).toEqual({ allow: false, reason: 'not-private' })
+    })
+
+    it('drops non-private chat (supergroup)', () => {
+      const result = decideDmCommandGate({
+        chatType: 'supergroup',
+        senderId: '12345',
+        dmPolicy: 'pairing',
+        allowFrom: [],
+      })
+      expect(result).toEqual({ allow: false, reason: 'not-private' })
+    })
+
+    it('drops non-private chat (channel)', () => {
+      const result = decideDmCommandGate({
+        chatType: 'channel',
+        senderId: '12345',
+        dmPolicy: 'pairing',
+        allowFrom: [],
+      })
+      expect(result).toEqual({ allow: false, reason: 'not-private' })
+    })
+
+    it('drops when chatType is undefined', () => {
+      const result = decideDmCommandGate({
+        chatType: undefined,
+        senderId: '12345',
+        dmPolicy: 'pairing',
+        allowFrom: [],
+      })
+      expect(result).toEqual({ allow: false, reason: 'not-private' })
+    })
+
+    it('drops when senderId is missing (anonymous channel post)', () => {
+      const result = decideDmCommandGate({
+        chatType: 'private',
+        senderId: undefined,
+        dmPolicy: 'pairing',
+        allowFrom: [],
+      })
+      expect(result).toEqual({ allow: false, reason: 'no-sender' })
+    })
+
+    it('drops when senderId is empty', () => {
+      const result = decideDmCommandGate({
+        chatType: 'private',
+        senderId: '',
+        dmPolicy: 'pairing',
+        allowFrom: [],
+      })
+      expect(result).toEqual({ allow: false, reason: 'no-sender' })
+    })
+
+    it('drops when dmPolicy is disabled — even for allowlisted senders', () => {
+      // The "disabled" branch wins over allowlist membership. Operator
+      // can turn the bot off for everyone with one knob.
+      const result = decideDmCommandGate({
+        chatType: 'private',
+        senderId: '12345',
+        dmPolicy: 'disabled',
+        allowFrom: ['12345'],
+      })
+      expect(result).toEqual({ allow: false, reason: 'disabled' })
+    })
+
+    it('drops when dmPolicy is allowlist and sender not on the list', () => {
+      // The exact bug the backport closes: pre-fix, /start replied here
+      // and leaked the bot's existence to a non-allowlisted user.
+      const result = decideDmCommandGate({
+        chatType: 'private',
+        senderId: '99999',
+        dmPolicy: 'allowlist',
+        allowFrom: ['12345', '67890'],
+      })
+      expect(result).toEqual({ allow: false, reason: 'not-allowlisted' })
+    })
+  })
+
+  describe('allow branches', () => {
+    it('allows allowlisted sender in allowlist mode', () => {
+      const result = decideDmCommandGate({
+        chatType: 'private',
+        senderId: '12345',
+        dmPolicy: 'allowlist',
+        allowFrom: ['12345'],
+      })
+      expect(result).toEqual({ allow: true, senderId: '12345' })
+    })
+
+    it('allows pairing-mode sender even when not on allowFrom', () => {
+      // /status surfacing a user's pending pairing code is the
+      // canonical example. The handler downstream of this decision
+      // checks `access.pending` and renders the right text. The gate
+      // itself must let pairing-mode senders through regardless of
+      // allowFrom membership.
+      const result = decideDmCommandGate({
+        chatType: 'private',
+        senderId: '99999',
+        dmPolicy: 'pairing',
+        allowFrom: [],
+      })
+      expect(result).toEqual({ allow: true, senderId: '99999' })
+    })
+
+    it('allows pairing-mode sender who happens to also be on allowFrom', () => {
+      const result = decideDmCommandGate({
+        chatType: 'private',
+        senderId: '12345',
+        dmPolicy: 'pairing',
+        allowFrom: ['12345'],
+      })
+      expect(result).toEqual({ allow: true, senderId: '12345' })
+    })
+  })
+
+  describe('reject ordering', () => {
+    // The drop reasons cascade in a specific order that matters for
+    // operator intent. Pin the order so refactors don't accidentally
+    // tell a non-allowlisted sender "the bot is disabled" when both
+    // conditions hold (or vice versa).
+
+    it('not-private wins over no-sender', () => {
+      const result = decideDmCommandGate({
+        chatType: 'group',
+        senderId: undefined,
+        dmPolicy: 'disabled',
+        allowFrom: [],
+      })
+      expect(result).toEqual({ allow: false, reason: 'not-private' })
+    })
+
+    it('no-sender wins over disabled', () => {
+      const result = decideDmCommandGate({
+        chatType: 'private',
+        senderId: undefined,
+        dmPolicy: 'disabled',
+        allowFrom: [],
+      })
+      expect(result).toEqual({ allow: false, reason: 'no-sender' })
+    })
+
+    it('disabled wins over not-allowlisted', () => {
+      // Operator turning the bot off is a stronger statement than the
+      // allowlist filter; both are silent drops at the wire, but
+      // observability is better when the right reason fires.
+      const result = decideDmCommandGate({
+        chatType: 'private',
+        senderId: '99999',
+        dmPolicy: 'disabled',
+        allowFrom: ['12345'],
+      })
+      expect(result).toEqual({ allow: false, reason: 'disabled' })
+    })
+  })
+})


### PR DESCRIPTION
## Summary

The telegram-plugin was forked from \`anthropics/claude-plugins-official:external_plugins/telegram\` on 2026-04-07 (commit \`41fe773\`). Three upstream commits have touched that directory since fork. This PR ships the two relevant backports.

## What's in the upstream window

| Upstream | What | Backport? |
|---|---|---|
| \`5a71459\` | gate /start /help /status behind dmPolicy (#894) | **yes** — info-leak fix |
| \`7e401ed\` | retry polling on all transient errors (#1397) | **yes** (server.ts) / **partial** (gateway.ts) |
| \`58578a4\` | PID-file zombie-poller detection (#1349) | **skip** — supplanted by gateway's startup-mutex stack |

## #894 — bot-command access gate

Pre-backport, \`/start /help /status\` replied to ANY private DM regardless of \`dmPolicy\`, leaking the bot's existence to non-allowlisted users and contradicting access.json's "drop silently" contract for allowlist mode.

Both \`telegram-plugin/server.ts\` and \`telegram-plugin/gateway/gateway.ts\` had the same bug — fixed in both. Decision logic extracted to a new \`dm-command-gate.ts\` module (pure helper) so the contract is unit-testable without booting the MCP server or the gateway long-poll.

14 vitest tests pin every drop reason and the cascade order so a later refactor can't silently flip which reason fires first.

## #1397 — retry on all transient errors

Pre-backport, both poll loops only retried on \`GrammyError 409\`. A single \`ETIMEDOUT\` / \`ECONNRESET\` / DNS failure fell through to \`return\` — the loop ended forever, MCP process stayed alive (stdin keeps it running), outbound tools kept working, but the bot was **deaf to inbound** until a full restart.

- \`server.ts\` now retries any non-\`Aborted delay\` error with the same exponential-capped backoff. \`attempt\` resets on successful start so a transient mid-session failure doesn't push the next retry past 15s.
- \`gateway.ts\` only takes the \`attempt = 0\` reset. The full retry-on-non-409 part is **intentionally NOT applied** — the gateway's \`process.exit(1)\` on non-409 errors (post-2026-04-29 incident) lets systemd's \`Restart=always\` recover from a clean reboot, which has been the chosen strategy since "live-but-silent gateway" was diagnosed.

## #1349 — skipped (architectural divergence)

Upstream's PID-file zombie-poller fix targets the same race the switchroom gateway already handles with:
- \`startup-mutex.ts\` — pid-file + lock acquisition with stale-recovery
- \`clearStaleTelegramPollingState\` — clears orphan long-polls before bind
- 35s SIGTERM drain budget — gives the kernel time to FIN the long-poll TCP socket
- \`gateway.pid.json\` — clean-shutdown vs crash markers

Adding the upstream PID file on top would create two competing pid files and zero new coverage.

## Verification

\`\`\`
$ npm run lint        # clean (tsc --noEmit)
$ npm test            # exit 0 — 4109 vitest + 285 bun
$ cd telegram-plugin && bun test
…
 2777 pass
 1 skip
 0 fail
 6053 expect() calls
Ran 2778 tests across 138 files. [17.44s]
\`\`\`

## Going forward

Recommend sweeping \`git log telegram-upstream/main -- external_plugins/telegram/\` periodically (e.g. weekly or after security advisories). To wire up the remote:

\`\`\`
git remote add telegram-upstream https://github.com/anthropics/claude-plugins-official.git
git fetch telegram-upstream main --depth=200
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)