### PR TITLE
feat(streaming): wire PTY-tail extraction through bridge → gateway → draft (#482)

### DIFF
--- a/telegram-plugin/bridge/bridge.ts
+++ b/telegram-plugin/bridge/bridge.ts
@@ -485,17 +485,22 @@ if (ptyTailEnabled) {
     ptyTailHandle = startPtyTail({
       logFile: serviceLogPath,
       log: (msg) => process.stderr.write(`telegram bridge: ${msg}\n`),
-      onPartial: (_text) => {
-        // PTY partial draft previews (live text as the model types) are
-        // intentionally disabled in gateway mode. The progress card
-        // (driven by session-tail events forwarded over IPC) provides
-        // the primary "model is working" UX surface instead. Draft
-        // previews would require a high-frequency IPC channel for raw
-        // PTY output which isn't worth the complexity.
+      onPartial: (text) => {
+        // Forward to the gateway so it can drive a draft-stream edit.
+        // Best-effort: ipc.sendPtyPartial silently no-ops when not
+        // connected, mirroring how sendSessionEvent handles the gap.
+        // Disable forwarding entirely with SWITCHROOM_PTY_TAIL=off
+        // (handled by ptyTailEnabled above) — there's no per-side
+        // toggle because the bridge doesn't know whether the gateway
+        // wants the events. The gateway-side `onPtyPartial` handler
+        // is also optional, so a downgraded gateway gets silent drops.
+        ipc?.sendPtyPartial({ type: 'pty_partial', text })
       },
       activityExtractor: new V1ToolActivityExtractor(),
       onActivity: (_text) => {
-        // Activity is also handled gateway-side via session events.
+        // Activity (the "Running Read…" tool-use lane) is currently
+        // surfaced gateway-side via session_event tool_use → progress
+        // card. No separate IPC forward needed for that lane.
       },
     })
     process.stderr.write(`telegram bridge: pty tail watching ${serviceLogPath}\n`)

--- a/telegram-plugin/bridge/ipc-client.ts
+++ b/telegram-plugin/bridge/ipc-client.ts
@@ -6,6 +6,7 @@ import type {
   OperatorEventForward,
   PermissionEvent,
   PermissionRequestForward,
+  PtyPartialForward,
   SessionEventForward,
   StatusEvent,
   ToolCallResult,
@@ -58,6 +59,16 @@ export interface IpcClientHandle {
   sendSessionEvent(event: SessionEventForward): void;
   sendPermissionRequest(msg: PermissionRequestForward): void;
   sendOperatorEvent(msg: OperatorEventForward): void;
+  /**
+   * Forward a PTY-tail partial — the latest extracted reply text from
+   * Claude Code's TUI rendering of an in-flight `reply (MCP)` /
+   * `stream_reply (MCP)` tool call. The gateway routes the text into a
+   * draft stream so the user sees the model's reply assemble character-
+   * by-character (Claude.ai-style streaming). Wire-protocol only —
+   * silent no-op when not connected. See `PtyPartialForward` in
+   * `gateway/ipc-protocol.ts`.
+   */
+  sendPtyPartial(msg: PtyPartialForward): void;
   isConnected(): boolean;
   close(): void;
 }
@@ -275,6 +286,10 @@ export function createIpcClient(options: IpcClientOptions): Promise<IpcClientHan
     },
 
     sendOperatorEvent(msg: OperatorEventForward): void {
+      sendRaw(msg);
+    },
+
+    sendPtyPartial(msg: PtyPartialForward): void {
       sendRaw(msg);
     },
 

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -163,6 +163,7 @@ import type {
   ScheduleRestartMessage,
   OperatorEventForward,
   UpdatePlaceholderMessage,
+  PtyPartialForward,
   InboundMessage,
 } from './ipc-protocol.js'
 import { writePidFile, clearPidFile } from './pid-file.js'
@@ -1639,6 +1640,24 @@ const ipcServer: IpcServer = createIpcServer({
         }\n`,
       )
     })
+  },
+
+  /**
+   * Forwarded PTY-tail partial: the latest extracted assistant-reply
+   * text from Claude Code's TUI rendering. Routes through
+   * `handlePtyPartial` (declared further down) which writes the text
+   * into the active draft stream for `currentSessionChatId`. The chat
+   * id is resolved from the most recent enqueue session_event the
+   * bridge has forwarded — same pattern as the legacy monolith path
+   * in server.ts.
+   *
+   * Best-effort: silently no-op when the stream isn't ready (no chat
+   * resolved yet, suppressed by an in-flight reply, dedup match).
+   * `handlePtyPartial` does its own buffering for the
+   * partial-before-enqueue race.
+   */
+  onPtyPartial(_client: IpcClient, msg: PtyPartialForward) {
+    handlePtyPartial(msg.text)
   },
 
   log: (msg) => process.stderr.write(`telegram gateway: ipc — ${msg}\n`),

--- a/telegram-plugin/gateway/ipc-protocol.ts
+++ b/telegram-plugin/gateway/ipc-protocol.ts
@@ -121,6 +121,26 @@ export interface UpdatePlaceholderMessage {
   text: string;
 }
 
+/**
+ * Forwarded from bridge → gateway when PTY-tail extracts updated reply
+ * text from Claude Code's TUI rendering. The gateway routes the text
+ * through `handlePtyPartial` → draft-stream so the user sees the model's
+ * reply assemble character-by-character (Claude.ai-style streaming).
+ *
+ * Sent by bridge.ts's `startPtyTail({onPartial})` callback. The bridge
+ * doesn't know the chat id — the gateway resolves it from
+ * `currentSessionChatId`, which is set when the bridge forwards the
+ * matching `enqueue` session event.
+ *
+ * No throttle on the wire: PTY-tail's onPartial already coalesces at
+ * ~150 ms. Same pattern as session_event forwarding.
+ */
+export interface PtyPartialForward {
+  type: "pty_partial";
+  /** Extracted reply text snapshot. Up to ~4096 chars (Telegram limit). */
+  text: string;
+}
+
 export type ClientToGateway =
   | RegisterMessage
   | ToolCallMessage
@@ -129,4 +149,5 @@ export type ClientToGateway =
   | HeartbeatMessage
   | ScheduleRestartMessage
   | OperatorEventForward
-  | UpdatePlaceholderMessage;
+  | UpdatePlaceholderMessage
+  | PtyPartialForward;

--- a/telegram-plugin/gateway/ipc-server.ts
+++ b/telegram-plugin/gateway/ipc-server.ts
@@ -5,6 +5,7 @@ import type {
   HeartbeatMessage,
   OperatorEventForward,
   PermissionRequestForward,
+  PtyPartialForward,
   RegisterMessage,
   ScheduleRestartMessage,
   SessionEventForward,
@@ -24,6 +25,13 @@ export interface IpcServerOptions {
   onScheduleRestart: (client: IpcClient, msg: ScheduleRestartMessage) => void;
   onOperatorEvent?: (client: IpcClient, msg: OperatorEventForward) => void;
   onUpdatePlaceholder?: (client: IpcClient, msg: UpdatePlaceholderMessage) => void;
+  /**
+   * Forwarded PTY-tail partial — the latest extracted reply text from
+   * Claude Code's TUI rendering. Optional: gateways without streaming
+   * configured (or in test fixtures) can omit this and pty_partial
+   * messages will be silently dropped at dispatch.
+   */
+  onPtyPartial?: (client: IpcClient, msg: PtyPartialForward) => void;
   log?: (msg: string) => void;
   /**
    * How long (in ms) to wait without a heartbeat before force-closing the
@@ -151,6 +159,14 @@ export function validateClientMessage(msg: unknown): msg is ClientToGateway {
         && typeof m.text === "string"
         && (m.text as string).length > 0
         && (m.text as string).length <= 500;
+    case "pty_partial":
+      // Extracted reply text from PTY-tail. May be empty (the extractor
+      // returns empty strings for "no text yet" snapshots — gateway
+      // handler dedups on lastPtyPreviewByChat). Capped at 8192 to
+      // give some headroom over Telegram's 4096-char wire limit while
+      // still bounding buffer growth from a runaway extractor.
+      return typeof m.text === "string"
+        && (m.text as string).length <= 8192;
     default:
       return false;
   }
@@ -168,6 +184,7 @@ export function createIpcServer(options: IpcServerOptions): IpcServer {
     onScheduleRestart,
     onOperatorEvent,
     onUpdatePlaceholder,
+    onPtyPartial,
     log = () => {},
     heartbeatTimeoutMs = 30_000,
   } = options;
@@ -247,6 +264,9 @@ export function createIpcServer(options: IpcServerOptions): IpcServer {
         break;
       case "update_placeholder":
         if (onUpdatePlaceholder) onUpdatePlaceholder(client, msg as UpdatePlaceholderMessage);
+        break;
+      case "pty_partial":
+        if (onPtyPartial) onPtyPartial(client, msg as PtyPartialForward);
         break;
       default:
         log(`unknown IPC message type from client ${client.id}: ${(msg as any).type}`);

--- a/telegram-plugin/tests/ipc-server-validate-pty-partial.test.ts
+++ b/telegram-plugin/tests/ipc-server-validate-pty-partial.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Validation contract for `pty_partial` IPC messages.
+ *
+ * The bridge forwards extracted reply text from Claude Code's TUI
+ * rendering so the gateway can drive a draft-stream edit (Claude.ai-
+ * style per-character reply streaming, #482). `validateClientMessage`
+ * is the gate before the gateway acts on it. Keeps the contract narrow
+ * so a rogue process on the same Unix socket can't push arbitrary
+ * payloads into the user's chat.
+ *
+ * Companion to the operator_event and update_placeholder validator
+ * tests.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { validateClientMessage } from '../gateway/ipc-server.js'
+
+function base() {
+  return {
+    type: 'pty_partial' as const,
+    text: 'Yes — I can help with that.',
+  }
+}
+
+describe('validateClientMessage — pty_partial', () => {
+  it('accepts a well-formed partial', () => {
+    expect(validateClientMessage(base())).toBe(true)
+  })
+
+  it('accepts the empty string (the extractor emits empty snapshots while the model warms up)', () => {
+    // Empty isn't a malformed payload — it's the normal "no text yet"
+    // shape from the extractor. The handler dedups against the
+    // last-emitted text so an empty snapshot is a no-op downstream.
+    expect(validateClientMessage({ ...base(), text: '' })).toBe(true)
+  })
+
+  it('caps text at 8192 chars (headroom over Telegram 4096-char limit)', () => {
+    expect(validateClientMessage({ ...base(), text: 'x'.repeat(8192) })).toBe(true)
+    expect(validateClientMessage({ ...base(), text: 'x'.repeat(8193) })).toBe(false)
+  })
+
+  it('requires text to be a string', () => {
+    expect(validateClientMessage({ ...base(), text: 42 })).toBe(false)
+    expect(validateClientMessage({ ...base(), text: null })).toBe(false)
+    const noText = { ...base() } as Record<string, unknown>
+    delete noText.text
+    expect(validateClientMessage(noText)).toBe(false)
+  })
+
+  it('preserves Unicode + multi-line content (the model emits both)', () => {
+    expect(
+      validateClientMessage({ ...base(), text: 'Line 1\nLine 2 — with em-dash\n你好' }),
+    ).toBe(true)
+  })
+
+  it('rejects unknown type values', () => {
+    expect(validateClientMessage({ ...base(), type: 'pty_oops' })).toBe(false)
+  })
+
+  it('rejects messages without a type field', () => {
+    const noType = { text: 'hello' } as Record<string, unknown>
+    expect(validateClientMessage(noType)).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary

Phase 2 of the streaming UX overhaul (#480 umbrella). Phase 1 (#481, PR #483) dropped the \`stream_reply(done=false)\` checklist-mode rejection so the model could stream interim text. This phase wires the infrastructure that lets the model APPEAR to stream **even when it doesn't choose to** — by tailing Claude Code's TUI for the character-by-character \`reply (MCP)(text: "...")\` rendering and pumping each delta into a Telegram draft message.

Pre-this-PR, PTY-tail extraction worked in the legacy monolith (\`server.ts\`) but was explicitly stubbed off in the bridge (\`bridge/bridge.ts:488-495\` had \`onPartial: (_text) => {}\` with a "intentionally disabled in gateway mode" comment). The result: every agent on the modern gateway architecture got **zero per-character streaming** regardless of what \`stream_mode\` they configured.

## What ships

**New IPC message: \`pty_partial\`**
- \`gateway/ipc-protocol.ts\` — adds \`PtyPartialForward\` to the \`ClientToGateway\` union. Carries a single \`text\` field (capped at 8192 chars).
- \`gateway/ipc-server.ts\` — adds the validator case (text-only, ≤8192) and dispatch into \`onPtyPartial\`. The handler is optional; servers without streaming wired silently drop.
- \`bridge/ipc-client.ts\` — adds \`sendPtyPartial(msg)\` to the client handle.

**Bridge: forward the partials**
- \`bridge/bridge.ts:488-495\` — replaces the stubbed onPartial with \`ipc?.sendPtyPartial({ type: 'pty_partial', text })\`. Best-effort: silent no-op when not connected. Disable end-to-end with \`SWITCHROOM_PTY_TAIL=off\` (existing flag).
- onActivity stays no-op'd in gateway mode — the activity lane is already covered by session_event tool_use → progress card.

**Gateway: route into the existing draft-stream**
- \`gateway.ts\` — adds \`onPtyPartial(_client, msg)\` that forwards straight into the existing \`handlePtyPartial(text)\` function. PTY edits land on the default lane via the same \`activeDraftStreams\` map the model's own \`stream_reply\` uses.

## User-visible UX after merge

\`\`\`
T+~250ms     🔵 thinking…             (pre-alloc placeholder, DM only)
T+~500ms     📚 recalling memories…   (recall.py update_placeholder)
T+~5s        💭 thinking…             (recall.py post-recall)
T+1st token  Reply text appears       (NEW — PTY-tail forwards extraction)
T+last token Reply finalises          (model's reply consumes placeholder)
\`\`\`

**Two visible drafts briefly during streaming, collapsing to one at finalize.** Subjective UX win: text appears WHILE the model is generating, not after.

## What's NOT in this PR

- **Pre-alloc draft consumption from PTY.** Threading \`preAllocatedDraftId\` into the PTY-side \`createStreamController\` would be ideal — single visible draft, smooth handoff. The coordination with \`stream_reply\`/\`reply\`'s existing consume-and-clear logic is the load-bearing bit, not the IPC plumbing. Worth its own PR.
- **#479** (pre-alloc in groups + forum topics) — orthogonal.
- **\`server.ts:3018\` activity-lane guard removal** — that's the legacy-monolith path; gateway has no equivalent. Server.ts is end-of-life as more deployments move to the gateway architecture.

## Verification

\`\`\`
$ npm run lint        # clean
$ npm test            # exit 0 — 4109 vitest + 285 bun
$ cd telegram-plugin && bun test
…
 2784 pass
 1 skip
 0 fail
 6063 expect() calls
Ran 2785 tests across 139 files. [17.45s]
\`\`\`

7 new vitest tests in \`tests/ipc-server-validate-pty-partial.test.ts\` pin the IPC validator contract.

## Sequencing

Phase 1: PR #483 (merged, b132278) — drop stream_reply rejection.
**Phase 2: this PR** — wire PTY through bridge.
Phase 3: pre-alloc consume coordination (separate PR).
Phase 4: #479 (pre-alloc in groups + topics).

🤖 Generated with [Claude Code](https://claude.com/claude-code)