### PR TITLE
fix(ux): streaming/UX bundle + /issues clear confirm + restart branch guard

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -18,6 +18,17 @@
       "keywords": ["switchroom", "agents", "telegram", "orchestration", "skills"],
       "category": "agents",
       "tags": ["switchroom", "multi-agent", "telegram", "ops"]
+    },
+    {
+      "name": "switchroom-telegram",
+      "source": "./telegram-plugin",
+      "description": "Switchroom's enhanced Telegram channel — HTML formatting, smart message chunking, message coalescing, attachment helpers, progress card with sub-agent visibility, vault-grant wizard, and slash-command admin surface (/restart, /usage, /auth, /vault, /issues).",
+      "homepage": "https://github.com/mekenthompson/switchroom",
+      "repository": "https://github.com/mekenthompson/switchroom",
+      "license": "MIT",
+      "keywords": ["telegram", "switchroom", "channel", "progress-card", "vault"],
+      "category": "messaging",
+      "tags": ["telegram", "channel", "switchroom", "multi-agent"]
     }
   ]
 }

--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,13 @@ Thumbs.db
 *.tsbuildinfo
 telegram-plugin/server.js
 
+# Rendered profile artifact — Handlebars source is profiles/<name>/CLAUDE.md.hbs;
+# renderProfileClaudeTemplate (src/agents/profiles.ts) writes profiles/<name>/CLAUDE.md
+# next to it. The rendered output is per-machine and per-render; only .hbs is tracked.
+# Without this entry the artifact appears as untracked and blocks `switchroom update`'s
+# clean-tree precondition. See #402.
+profiles/*/CLAUDE.md
+
 # Python bytecode (from vendored Hindsight plugin)
 __pycache__/
 *.pyc

--- a/bin/bridge-watchdog.sh
+++ b/bin/bridge-watchdog.sh
@@ -68,6 +68,15 @@ set -euo pipefail
 # enough to span a normal session but short enough that a long overnight idle
 # doesn't get falsely flagged.
 : "${RECENT_ACTIVITY_WINDOW_SECS:=3600}"
+# Turn-active marker check (issue #412): the gateway writes a per-agent
+# `turn-active.json` at turn-start, touches its mtime on every tool_use,
+# and removes it on turn_complete. If the file exists AND its mtime
+# hasn't advanced in TURN_HANG_SECS, the agent is wedged mid-turn —
+# distinguishable from "legitimately idle" because legitimate idle
+# leaves no marker file at all. Default 5 min: bigger than the slowest
+# legitimate single-tool turn (a long Bash compile maybe) but tight
+# enough to catch Stop-hook deadlocks before the user notices.
+: "${TURN_HANG_SECS:=300}"
 
 # Per-agent watchdog state lives under /run/user/$UID/switchroom-watchdog/
 # (tmpfs, cleared on logout — correct: we don't want stale silence markers
@@ -330,6 +339,47 @@ for agent_svc in "${agent_services[@]}"; do
         # Clear stale silence marker on fresh start so the grace window
         # is a clean slate.
         rm -f "$silence_marker" 2>/dev/null || true
+        continue
+      fi
+    fi
+  fi
+
+  # Issue #412: turn-active marker hang detector. The gateway writes
+  # `<agentDir>/telegram/turn-active.json` at turn-start, bumps its
+  # mtime on every tool_use, and removes it on turn_complete. If the
+  # file is older than TURN_HANG_SECS, the agent is wedged mid-turn —
+  # distinguishable from healthy idle because healthy idle leaves no
+  # marker file at all. This closes the gap left when JOURNAL_SILENCE_SECS
+  # was raised to 4000s (PR #410) to kill chat-cadence false positives.
+  agent_state_dir="${HOME}/.switchroom/agents/${agent}/telegram"
+  turn_active_file="${agent_state_dir}/turn-active.json"
+  if [[ -f "$turn_active_file" ]]; then
+    turn_mtime=$(stat -c %Y "$turn_active_file" 2>/dev/null || echo 0)
+    if [[ "$turn_mtime" -gt 0 ]]; then
+      turn_age=$(( $(now_epoch) - turn_mtime ))
+      if [[ "$turn_age" -ge "$TURN_HANG_SECS" ]]; then
+        logger -t switchroom-watchdog "agent ${agent}: turn-active marker stale (${turn_age}s >= ${TURN_HANG_SECS}s); restarting via switchroom agent restart (#412)"
+        echo "$(date -Iseconds) watchdog: ${agent} wedged mid-turn (${turn_age}s), restarting"
+        # Resolve the switchroom CLI (same belt-and-suspenders as below)
+        switchroom_cli=""
+        for candidate in "${HOME}/.bun/bin/switchroom" "${HOME}/.local/bin/switchroom"; do
+          if [[ -x "$candidate" ]]; then
+            switchroom_cli="$candidate"
+            break
+          fi
+        done
+        if [[ -z "$switchroom_cli" ]] && command -v switchroom >/dev/null 2>&1; then
+          switchroom_cli="$(command -v switchroom)"
+        fi
+        if [[ -n "$switchroom_cli" ]]; then
+          "$switchroom_cli" agent restart "$agent" || {
+            logger -t switchroom-watchdog "agent ${agent}: switchroom agent restart failed; falling back to systemctl"
+            systemctl --user restart "$agent_svc" || true
+          }
+        else
+          systemctl --user restart "$agent_svc" || true
+        fi
+        # Restarted — skip remaining checks for this agent this tick.
         continue
       fi
     fi

--- a/bin/run-hook.sh
+++ b/bin/run-hook.sh
@@ -96,6 +96,14 @@ emit_warn() {
   echo "run-hook.sh: $1" >&2
 }
 
+# When RUN_HOOK_DEBUG=1 is set, drop the stderr redirect on the
+# issues-CLI invocations so an operator debugging a broken record-path
+# sees the actual cause in journald instead of just the generic
+# "failed to record issue (non-fatal)" line. See #445.
+debug_mode() {
+  [ "${RUN_HOOK_DEBUG:-}" = "1" ]
+}
+
 record_failure() {
   local detail summary
   # Last ~60 lines of stderr; CLI will further cap to DETAIL_MAX_BYTES.
@@ -108,33 +116,62 @@ record_failure() {
 
   # Pipe detail via stdin so we don't have to shell-quote arbitrary
   # error text. CLI reads it when --detail-stdin is set.
-  if [ -n "$detail" ]; then
-    printf '%s' "$detail" | "$SWITCHROOM_CLI" issues record \
-      --severity error \
-      --source "$SOURCE" \
-      --code "$CODE" \
-      --summary "$summary" \
-      --detail-stdin \
-      --quiet \
-      ${STATE_DIR:+--state-dir "$STATE_DIR"} \
-      >/dev/null 2>&1 || emit_warn "failed to record issue (non-fatal)"
+  if debug_mode; then
+    if [ -n "$detail" ]; then
+      printf '%s' "$detail" | "$SWITCHROOM_CLI" issues record \
+        --severity error \
+        --source "$SOURCE" \
+        --code "$CODE" \
+        --summary "$summary" \
+        --detail-stdin \
+        --quiet \
+        ${STATE_DIR:+--state-dir "$STATE_DIR"} \
+        || emit_warn "failed to record issue (non-fatal)"
+    else
+      "$SWITCHROOM_CLI" issues record \
+        --severity error \
+        --source "$SOURCE" \
+        --code "$CODE" \
+        --summary "$summary" \
+        --quiet \
+        ${STATE_DIR:+--state-dir "$STATE_DIR"} \
+        || emit_warn "failed to record issue (non-fatal)"
+    fi
   else
-    "$SWITCHROOM_CLI" issues record \
-      --severity error \
-      --source "$SOURCE" \
-      --code "$CODE" \
-      --summary "$summary" \
-      --quiet \
-      ${STATE_DIR:+--state-dir "$STATE_DIR"} \
-      >/dev/null 2>&1 || emit_warn "failed to record issue (non-fatal)"
+    if [ -n "$detail" ]; then
+      printf '%s' "$detail" | "$SWITCHROOM_CLI" issues record \
+        --severity error \
+        --source "$SOURCE" \
+        --code "$CODE" \
+        --summary "$summary" \
+        --detail-stdin \
+        --quiet \
+        ${STATE_DIR:+--state-dir "$STATE_DIR"} \
+        >/dev/null 2>&1 || emit_warn "failed to record issue (non-fatal)"
+    else
+      "$SWITCHROOM_CLI" issues record \
+        --severity error \
+        --source "$SOURCE" \
+        --code "$CODE" \
+        --summary "$summary" \
+        --quiet \
+        ${STATE_DIR:+--state-dir "$STATE_DIR"} \
+        >/dev/null 2>&1 || emit_warn "failed to record issue (non-fatal)"
+    fi
   fi
 }
 
 resolve_success() {
   # Resolve by source+code; the CLI computes the fingerprint.
-  "$SWITCHROOM_CLI" issues resolve --source "$SOURCE" --code "$CODE" \
-    ${STATE_DIR:+--state-dir "$STATE_DIR"} \
-    >/dev/null 2>&1 || true
+  if debug_mode; then
+    "$SWITCHROOM_CLI" issues resolve --source "$SOURCE" --code "$CODE" \
+      ${STATE_DIR:+--state-dir "$STATE_DIR"} \
+      || true
+  else
+    "$SWITCHROOM_CLI" issues resolve --source "$SOURCE" --code "$CODE" \
+      ${STATE_DIR:+--state-dir "$STATE_DIR"} \
+      >/dev/null 2>&1 || true
+  fi
 }
 
 if [ -z "$SWITCHROOM_CLI" ]; then

--- a/bin/workspace-dynamic-hook.sh
+++ b/bin/workspace-dynamic-hook.sh
@@ -29,6 +29,69 @@ if ! command -v switchroom >/dev/null 2>&1; then
   exit 0
 fi
 
+# Cache directory shared with the post-render dedupe sidecar below. We
+# need it earlier than the original code so the mtime-based fast-skip
+# can read its body file before invoking the (~800ms) switchroom CLI.
+CACHE_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/switchroom-hookcache"
+mkdir -p "$CACHE_DIR" 2>/dev/null || true
+# Date-keyed cache filename: when the calendar day rolls over, the
+# `today's daily` file path the renderer reads changes (the template
+# embeds different filenames in its output), so we invalidate the cache
+# at midnight UTC by varying the filename. Yesterday's file lingers
+# harmlessly until the next sweep.
+CACHE_DATE="$(date -u +%Y-%m-%d)"
+CACHE_FILE="$CACHE_DIR/workspace-dynamic.${CACHE_DATE}.hash"
+BODY_FILE="$CACHE_DIR/workspace-dynamic.${CACHE_DATE}.body"
+
+# Mtime-fast-skip: if BODY_FILE exists AND is newer than every workspace
+# source the renderer reads, we can emit the cached body and skip the
+# ~800ms `switchroom workspace render` invocation entirely. The renderer
+# reads MEMORY.md, HEARTBEAT.md, today's daily, yesterday's daily — see
+# `loadDynamicBootstrapFiles` in src/agents/workspace.ts.
+#
+# Skip semantics: a source file that doesn't exist contributes a "very
+# old" mtime (epoch-0 via stat fallback), which never invalidates the
+# cache. A source file that's been updated since BODY_FILE's mtime
+# triggers a fresh render. Forensics measured this fast-path saving
+# ~825ms on the common case (chat turns where MEMORY/HEARTBEAT haven't
+# changed since the last turn).
+#
+# Resolve the agent's workspace dir. Switchroom uses
+# `~/.switchroom/agents/<name>/workspace/` by default. We avoid invoking
+# the switchroom CLI here (would defeat the whole point of the
+# fast-skip) — so derive directly from the conventional layout. If the
+# operator has overridden `agents_dir` in switchroom.yaml, the fast-skip
+# silently no-ops (cache miss; falls through to the renderer which
+# resolves correctly).
+AGENT_DIR="${SWITCHROOM_AGENT_DIR:-$HOME/.switchroom/agents/$AGENT_NAME}"
+WS_DIR="$AGENT_DIR/workspace"
+TODAY_FILE="$WS_DIR/memory/${CACHE_DATE}.md"
+YESTERDAY_DATE="$(date -u -d 'yesterday' +%Y-%m-%d 2>/dev/null || echo "")"
+YESTERDAY_FILE="$WS_DIR/memory/${YESTERDAY_DATE}.md"
+
+if [ -f "$BODY_FILE" ]; then
+  # Compare BODY_FILE mtime against every source. If any source is newer
+  # the cache is stale; fall through. If all sources are older (or
+  # missing), emit the cache and exit.
+  body_mtime=$(stat -c '%Y' "$BODY_FILE" 2>/dev/null || echo 0)
+  newest_src_mtime=0
+  for src in "$WS_DIR/MEMORY.md" "$WS_DIR/HEARTBEAT.md" "$TODAY_FILE" "$YESTERDAY_FILE"; do
+    if [ -f "$src" ]; then
+      src_mtime=$(stat -c '%Y' "$src" 2>/dev/null || echo 0)
+      if [ "$src_mtime" -gt "$newest_src_mtime" ]; then
+        newest_src_mtime="$src_mtime"
+      fi
+    fi
+  done
+  if [ "$body_mtime" -gt "$newest_src_mtime" ]; then
+    # Fast path: every source is older than the cached body. Emit and
+    # skip the renderer entirely. Saves ~800ms cold-start of the
+    # switchroom CLI plus the actual render work.
+    cat "$BODY_FILE"
+    exit 0
+  fi
+fi
+
 # Render the dynamic workspace files (MEMORY.md, today/yesterday daily,
 # HEARTBEAT.md). The render command exits 0 and returns empty string if the
 # workspace doesn't exist or all dynamic files are missing/empty, so no
@@ -53,18 +116,10 @@ fi
 # Content-addressed dedupe sidecar. Anthropic's prompt cache is keyed on
 # byte equality, so re-emitting the exact same dynamic block across turns
 # preserves the cache prefix. The hash file lets us detect when the
-# render output is bit-for-bit identical to last turn — in which case we
-# replay the cached body (cheap) rather than printing the freshly-
-# rendered string (which may differ only in non-semantic whitespace
-# from earlier renders, but would still hash the same and thus be a no-op
-# either way; the real win is upstream when MEMORY/HEARTBEAT change rate
-# is split). Cache lives under $CLAUDE_CONFIG_DIR (per-agent), which is
-# NOT swept by vault-sweep.ts (it only prunes projects/*.jsonl + SQLite).
-CACHE_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/switchroom-hookcache"
-mkdir -p "$CACHE_DIR" 2>/dev/null || true
-CACHE_FILE="$CACHE_DIR/workspace-dynamic.hash"
-BODY_FILE="$CACHE_DIR/workspace-dynamic.body"
-
+# render output is bit-for-bit identical to last turn — same body, no
+# need to rewrite the body file. Cache files (CACHE_FILE/BODY_FILE)
+# were declared at the top of the script for the mtime fast-skip;
+# reuse them here.
 NEW_HASH=$(printf '%s' "$WS_DYNAMIC" | sha256sum 2>/dev/null | cut -d' ' -f1)
 OLD_HASH=""
 if [ -f "$CACHE_FILE" ]; then
@@ -74,9 +129,9 @@ fi
 if [ -n "$NEW_HASH" ] && [ "$NEW_HASH" = "$OLD_HASH" ] && [ -f "$BODY_FILE" ]; then
   cat "$BODY_FILE"
 else
-  # Refresh sidecar atomically(-ish): write hash + body, then echo body.
-  # We don't fsync — the worst case is a stale hash that gets
-  # overwritten next turn, which is harmless.
+  # Refresh sidecar: write hash + body, then echo body. Touch the body
+  # file last so the mtime fast-skip path next turn sees a fresh
+  # mtime (newer than every source we just consumed).
   if [ -n "$NEW_HASH" ]; then
     printf '%s\n' "$NEW_HASH" > "$CACHE_FILE" 2>/dev/null || true
     printf '%s\n' "$WS_DYNAMIC" > "$BODY_FILE" 2>/dev/null || true

--- a/examples/switchroom.yaml
+++ b/examples/switchroom.yaml
@@ -68,7 +68,14 @@ defaults:
       model: sonnet
       background: true
       isolation: worktree
-      maxTurns: 50
+      # 100 turns is a comfortable budget for most worker tasks; if a
+      # worker exhausts this mid-flow, it'll be reported as #423-style
+      # ceiling. Bump to 200 for genuinely long PR-shipping flows or
+      # remove the line entirely to inherit Claude Code's default.
+      # Origin: this used to be 50 and was the literal cause of #423
+      # ("worker sub-agents hit ~50 tool-use ceiling mid-flow before
+      # finishing"). Don't shrink it without good reason.
+      maxTurns: 100
       color: blue
       disallowedTools:
         - "mcp__switchroom-telegram__*"

--- a/profiles/_base/start.sh.hbs
+++ b/profiles/_base/start.sh.hbs
@@ -116,7 +116,11 @@ _find_latest_jsonl() {
 # on each UserPromptSubmit so recent context isn't lost.
 SWITCHROOM_RESUME_MODE="{{#if resumeMode}}{{{resumeMode}}}{{else}}handoff{{/if}}"
 SWITCHROOM_RESUME_MAX_BYTES="{{#if resumeMaxBytes}}{{{resumeMaxBytes}}}{{else}}2000000{{/if}}"
-CONTINUE_FLAG=""
+{{#if sessionMaxIdleSecs}}# When session.max_idle is configured, auto-mode resume uses it as the
+# freshness window instead of the 7-day default. Lets chat-cadence
+# agents (e.g. health-coach) demand a fresher session — see #218.
+SWITCHROOM_SESSION_MAX_IDLE_SECS="{{{sessionMaxIdleSecs}}}"
+{{/if}}CONTINUE_FLAG=""
 
 {{#if resumeModeHasContinuePath}}_RESUME_LATEST_JSONL="$(_find_latest_jsonl "$CLAUDE_CONFIG_DIR/projects")"
 case "$SWITCHROOM_RESUME_MODE" in
@@ -130,7 +134,8 @@ case "$SWITCHROOM_RESUME_MODE" in
       _RESUME_SIZE="$(_stat_size "$_RESUME_LATEST_JSONL")"
       _RESUME_MTIME="$(_stat_mtime "$_RESUME_LATEST_JSONL")"
       _RESUME_AGE=$(( $(date +%s) - _RESUME_MTIME ))
-      if [ "$_RESUME_SIZE" -gt 0 ] && [ "$_RESUME_SIZE" -lt "$SWITCHROOM_RESUME_MAX_BYTES" ] && [ "$_RESUME_AGE" -lt 604800 ]; then
+      _RESUME_MAX_AGE="${SWITCHROOM_SESSION_MAX_IDLE_SECS:-604800}"
+      if [ "$_RESUME_SIZE" -gt 0 ] && [ "$_RESUME_SIZE" -lt "$SWITCHROOM_RESUME_MAX_BYTES" ] && [ "$_RESUME_AGE" -lt "$_RESUME_MAX_AGE" ]; then
         CONTINUE_FLAG="--continue"
       fi
     fi

--- a/profiles/_shared/telegram-style.md.hbs
+++ b/profiles/_shared/telegram-style.md.hbs
@@ -62,3 +62,14 @@ Don't use `accent` on routine conversational replies — it's for status communi
 The env vars are one-shot — start.sh deletes the file after sourcing. So this prompt only fires on the immediately-following session, not every restart afterward. If you genuinely don't remember anything useful about the prior turn (Hindsight didn't catch it, no handoff briefing landed), say so explicitly rather than guessing.
 
 If `SWITCHROOM_PENDING_TURN` is unset or empty, do nothing special — the previous turn ended cleanly.
+
+**"status?" / "still there?" / "any update?" is a UX-failure signal, not a feature request.** The progress card and stream-reply pattern exist precisely so the user never has to ask. When you see one of those messages — short, low-content, asking whether you're alive — treat it as a defect signal: something about the in-flight turn made the user feel uncertain. The product expectation (per `reference/know-what-my-agent-is-doing.md`) is that this rate trends to zero.
+
+Your response in this case should:
+
+1. Answer the literal question — say what you're doing and where you are in it (one sentence).
+2. **Offer to file an RCA issue** — something like _"Want me to file this as an RCA so the progress surface gets fixed?"_ — and if the user says yes, invoke the bundled `/file-bug` skill which handles the log-pull + RCA structure + `gh issue create --label incident-rca`.
+
+Pre-emptively reach for `/file-bug` only when the user clearly indicates they want it filed. Don't auto-file from a single "status?" — that creates noise. The offer-then-confirm shape is the right friction.
+
+The companion telemetry already in place (`gateway.ts` logs every `status?` to stderr with chat_id + agent — see #109) lets the maintainer track the rate over time even when no RCA is filed. Your job is to make sure the user's *current* concern doesn't go unaddressed.

--- a/skills/file-bug/SKILL.md
+++ b/skills/file-bug/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: file-bug
+version: 0.1.0
+description: |
+  File a high-quality bug report against switchroom (or another configured
+  repo). Pulls the right log files automatically, forces a root-cause
+  section with citations, flags logging gaps when RCA can't be pinned, and
+  files via `gh issue create`. Use when a user asks "file a bug",
+  "open an issue", or describes a symptom that needs a real ticket.
+license: MIT
+compatibility: claude-code
+allowed-tools:
+  - Bash
+  - Read
+  - Grep
+  - Glob
+  - WebFetch
+  - AskUserQuestion
+---
+
+# file-bug — File a real bug, not a one-line stub
+
+You are filing a bug. The point of this skill is to make low-effort bug filing harder than high-effort bug filing. Skipping any of the steps below produces a worse ticket than not filing at all — it fills the queue with noise the human has to chase later.
+
+## When to use this skill
+
+The user said "file a bug", "open an issue", "raise a ticket", "log this", or described a symptom that's clearly worth tracking. If the symptom is fuzzy, ask one question to pin it before filing — see "Phase 1" below.
+
+## Non-goals
+
+- Do not auto-file from a thin description. Push back if the symptom is too vague to RCA.
+- Do not invent log lines or paste paraphrased excerpts. If the log doesn't say what the bug needs, that's a logging-fidelity finding, not a fix-up.
+- Do not file when the user is in the middle of debugging — the bug is "what we couldn't fix in flow", not "what we just observed".
+
+## Phase 1 — Lock the symptom
+
+In one sentence: **What was supposed to happen, what actually happened, and the user-visible surface where it diverged.** If the user gave you any of these, restate them back. If anything is missing, ask one targeted question — e.g. "did this happen on the gymbro agent or on lawgpt?" — not a five-question form.
+
+Pin a time window. The default is the user's last 10 minutes of activity; ask if it should be wider or earlier.
+
+## Phase 2 — Pull the logs
+
+Switchroom's standard log map (resolve `<agent>` from the user or from `SWITCHROOM_AGENT_NAME`):
+
+| Source | Path | What's in it |
+|---|---|---|
+| Gateway events | `~/.switchroom/agents/<agent>/telegram/gateway.log` | Inbound/outbound messages, IPC, progress card, watcher, classifier output |
+| Claude stdout/stderr | `~/.switchroom/agents/<agent>/service.log` | The agent's own session output, tool calls, errors |
+| Systemd lifecycle | `journalctl --user -u switchroom-agent-<agent>` | Boot/restart/crash, exit codes |
+| Cron lifecycle | `journalctl --user -u switchroom-agent-<agent>-cron` | Scheduled-task firings |
+| Vault broker | `journalctl --user -u switchroom-vault-broker` | Audit log, ACL gates |
+
+For each relevant source: extract the slice that brackets the symptom window. Use `awk '/<start-ts>/,/<end-ts>/'` or `journalctl --since "10 min ago"`. Do **not** paste raw multi-MB dumps; cap each excerpt at the lines that actually matter and signpost what was clipped.
+
+If the gateway.log doesn't have what you need, check whether `progress-card.log`, `bridge.log`, or `subagent-watcher.log` are configured separately on this agent (some setups split).
+
+## Phase 3 — Build a timeline
+
+Order the relevant log lines by timestamp. Put them in a fenced block in the issue body. Annotate each line with one short prefix: what it tells us. The reader should be able to follow the timeline without opening a log file.
+
+## Phase 4 — RCA
+
+The bug body **must** have a `## Root cause` subsection. Fill it with:
+- The line(s) that prove the root cause, by file and line number.
+- One sentence stating what the proximate cause is and why those lines prove it.
+- One sentence stating what the underlying cause is, if different from proximate.
+
+If you can't pin RCA on the available log lines, **do not invent one**. Instead, write a `## Logging fidelity — what's missing` checklist:
+- `[ ] Add log: <component>::<event-name> — fields: <a, b, c> — gates: <when to log>`
+- `[ ] Capture: <signal we don't currently capture>` (e.g. timestamps on a ledger that doesn't have them, error_code on a catch site that swallows)
+
+Logging-gap items are first-class outputs. They turn an unfileable bug into "we need to instrument <thing> before we can RCA this class of failure" — that itself is a useful issue.
+
+## Phase 5 — Related issues
+
+Run `gh search issues --repo switchroom/switchroom <symptom keywords>` and `gh issue list --repo switchroom/switchroom --state all --search "<symptom keywords>"`. Pick up to 5 related issues by similarity. List them in a `## Related` section with one-line descriptions of how they relate (duplicate? blocked-by? same surface?). If you find an exact duplicate, **stop** and tell the user — they should comment on the existing issue, not file a new one.
+
+## Phase 6 — File
+
+Use the canonical body shape from #87:
+
+```
+## Symptom
+<one sentence — what diverged, on what surface>
+
+## Timeline
+\`\`\`
+HH:MM:SS [gateway.log]    <line>
+HH:MM:SS [service.log]    <line>
+HH:MM:SS [journalctl]     <line>
+\`\`\`
+<one-paragraph narration of what happened>
+
+## Root cause
+<one paragraph — proximate + underlying — with file:line citations>
+
+## Logging fidelity — what's missing
+- [ ] <gap 1>
+- [ ] <gap 2>
+(omit this section if the existing logs were sufficient for RCA)
+
+## Reproduction
+1. <steps if known; "intermittent" or "happened once" is acceptable>
+
+## Related
+- #<n> — <how it relates>
+
+## Environment
+- agent: <name>
+- branch: <branch> (run `cd ~/code/switchroom && git rev-parse --short HEAD`)
+- runtime versions: <bun/node/claude-cli versions>
+- triggered: <human-readable timestamp>
+```
+
+File the issue with `gh issue create --repo switchroom/switchroom --title "<short title>" --body "$(cat <<'EOF' ... EOF)"`. Write the body to a temp file first if it's longer than ~50 lines — bash heredocs in switchroom commits with embedded quotes are footguns.
+
+After the issue is filed, paste the URL back to the user and stop. Do **not** start working on the bug — filing it was the work.
+
+## Anti-patterns
+
+- ❌ "Card didn't render. See logs." — no log excerpts, no RCA, no related-issue check. The reader has to do all the work you were supposed to do.
+- ❌ "Probably a race in the IPC layer." — speculation without log proof. Either the log lines show the race or you have a logging-fidelity finding, not a bug.
+- ❌ Filing without `gh search issues` first — duplicate noise.
+- ❌ Pasting 500 lines of `journalctl` output. The reader's eye glazes over and the real signal gets buried.
+- ❌ Telling the user "I'll file this" and then never doing it. The skill is the file step. If you can't file, say so and stop.
+
+## Output
+
+A single line: `Filed: <issue URL>`. Or, if you couldn't file: a single sentence stating what blocked it (missing logs, dup of #N, can't reach the symptom from here, etc.).

--- a/src/agents/lifecycle.ts
+++ b/src/agents/lifecycle.ts
@@ -210,13 +210,25 @@ export function restartAgent(name: string, reason?: string): void {
   // if the dir is missing.
   if (reason) writeRestartReasonMarker(name, reason);
   try {
-    // Gateway owns the long-running Telegram connection and loads
-    // telegram-plugin code at process start. Restart it alongside the agent
-    // so code changes in telegram-plugin/*.ts always propagate on user
-    // action, not silently 6 hours later. Gateway first so the fresh gateway
-    // is ready when the agent wakes.
-    systemctlIfExists("restart", gatewayServiceName(name));
+    // ORDERING (#177): agent first, gateway second.
+    //
+    // When this function runs inside a child spawned from the gateway
+    // (e.g. /new from Telegram → spawnSwitchroomDetached → here), the
+    // child can be in the gateway's cgroup. If we restart the gateway
+    // FIRST (the previous order) and the cgroup escape (systemd-run
+    // --scope wrapper) is missing or fails, the child gets cgroup-
+    // killed mid-flight before reaching the second `systemctl` call,
+    // and the agent service is never actually restarted — the user
+    // says "/new" and sees the gateway bounce but their session
+    // doesn't actually rotate.
+    //
+    // With the agent service restarted first, even a worst-case
+    // cgroup kill on the second call still leaves the user's session
+    // rotated. Gateway restart is purely about picking up
+    // telegram-plugin code changes; missing it is annoying but not
+    // user-visible the way "session didn't rotate" is.
     systemctl(["restart", serviceName(name)]);
+    systemctlIfExists("restart", gatewayServiceName(name));
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     throw new Error(`Failed to restart agent "${name}": ${message}`);

--- a/src/agents/profiles.test.ts
+++ b/src/agents/profiles.test.ts
@@ -165,3 +165,40 @@ describe("renderProfileClaudeTemplate", () => {
     }
   });
 });
+
+describe("telegram-style partial — status? RCA-offer guidance (#162)", () => {
+  it("instructs the agent to treat 'status?' as a UX-failure signal", () => {
+    const REPO_ROOT = resolve(__dirname, "..", "..");
+    const partial = readFileSync(
+      join(REPO_ROOT, "profiles", "_shared", "telegram-style.md.hbs"),
+      "utf-8",
+    );
+    expect(partial).toContain("status?");
+    expect(partial).toContain("UX-failure signal");
+    // Must reference the JTBD source for context
+    expect(partial).toContain("know-what-my-agent-is-doing.md");
+  });
+
+  it("offers to file an RCA via the /file-bug skill", () => {
+    const REPO_ROOT = resolve(__dirname, "..", "..");
+    const partial = readFileSync(
+      join(REPO_ROOT, "profiles", "_shared", "telegram-style.md.hbs"),
+      "utf-8",
+    );
+    expect(partial).toContain("/file-bug");
+    expect(partial).toContain("incident-rca");
+  });
+
+  it("warns against auto-filing on every status? (offer-then-confirm pattern)", () => {
+    const REPO_ROOT = resolve(__dirname, "..", "..");
+    const partial = readFileSync(
+      join(REPO_ROOT, "profiles", "_shared", "telegram-style.md.hbs"),
+      "utf-8",
+    );
+    // The "auto-file from a single status?" anti-pattern is explicitly
+    // called out — without it the agent might invoke /file-bug
+    // immediately on every "status?".
+    expect(partial.toLowerCase()).toContain("auto-file");
+    expect(partial.toLowerCase()).toContain("offer-then-confirm");
+  });
+});

--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -1299,9 +1299,30 @@ Don't wait for a slash command. Don't ask permission. Memory work is table stake
       }
       return baseAppend.length > 0 ? shellSingleQuote(baseAppend) : undefined;
     })(),
-    extraCliArgs: agentConfig.cli_args && agentConfig.cli_args.length > 0
-      ? " " + agentConfig.cli_args.map(shellSingleQuote).join(" ")
-      : undefined,
+    extraCliArgs: (() => {
+      const parts: string[] = []
+      if (agentConfig.cli_args && agentConfig.cli_args.length > 0) {
+        parts.push(...agentConfig.cli_args.map(shellSingleQuote))
+      }
+      // #199: native Claude Code flag pass-through. add_dirs becomes
+      // repeated --add-dir <path>; allowed_tools / disallowed_tools become
+      // a single space-separated --allowedTools "..." / --disallowedTools "..."
+      // arg. Coexistence semantics with the coarse `tools.allow`: granular-
+      // only-when-present (Claude Code's own OR semantics), so existing
+      // operators on `tools.allow` are unaffected.
+      if (agentConfig.add_dirs && agentConfig.add_dirs.length > 0) {
+        for (const dir of agentConfig.add_dirs) {
+          parts.push("--add-dir", shellSingleQuote(dir))
+        }
+      }
+      if (agentConfig.allowed_tools && agentConfig.allowed_tools.length > 0) {
+        parts.push("--allowedTools", shellSingleQuote(agentConfig.allowed_tools.join(" ")))
+      }
+      if (agentConfig.disallowed_tools && agentConfig.disallowed_tools.length > 0) {
+        parts.push("--disallowedTools", shellSingleQuote(agentConfig.disallowed_tools.join(" ")))
+      }
+      return parts.length > 0 ? " " + parts.join(" ") : undefined
+    })(),
     sessionMaxIdleSecs: parseDurationToSeconds(agentConfig.session?.max_idle),
     sessionMaxTurns: agentConfig.session?.max_turns,
     handoffEnabled: agentConfig.session_continuity?.enabled !== false,
@@ -2623,9 +2644,26 @@ Don't wait for a slash command. Don't ask permission. Memory work is table stake
         }
         return baseAppend.length > 0 ? shellSingleQuote(baseAppend) : undefined;
       })(),
-      extraCliArgs: agentConfig.cli_args && agentConfig.cli_args.length > 0
-        ? " " + agentConfig.cli_args.map(shellSingleQuote).join(" ")
-        : undefined,
+      extraCliArgs: (() => {
+        const parts: string[] = []
+        if (agentConfig.cli_args && agentConfig.cli_args.length > 0) {
+          parts.push(...agentConfig.cli_args.map(shellSingleQuote))
+        }
+        // #199: native Claude Code flag pass-through (mirror of the
+        // initial-scaffold path above; reconcile must keep parity).
+        if (agentConfig.add_dirs && agentConfig.add_dirs.length > 0) {
+          for (const dir of agentConfig.add_dirs) {
+            parts.push("--add-dir", shellSingleQuote(dir))
+          }
+        }
+        if (agentConfig.allowed_tools && agentConfig.allowed_tools.length > 0) {
+          parts.push("--allowedTools", shellSingleQuote(agentConfig.allowed_tools.join(" ")))
+        }
+        if (agentConfig.disallowed_tools && agentConfig.disallowed_tools.length > 0) {
+          parts.push("--disallowedTools", shellSingleQuote(agentConfig.disallowed_tools.join(" ")))
+        }
+        return parts.length > 0 ? " " + parts.join(" ") : undefined
+      })(),
       sessionMaxIdleSecs: parseDurationToSeconds(agentConfig.session?.max_idle),
       sessionMaxTurns: agentConfig.session?.max_turns,
       handoffEnabled: agentConfig.session_continuity?.enabled !== false,

--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -2196,7 +2196,11 @@ export function buildSettingsHooksBlock(p: HooksBlockParams): Record<string, unk
           ],
         },
         {
-          matcher: "Agent",
+          // Claude Code's hook matcher is a regex. Cover both the legacy
+          // 'Agent' and newer 'Task' tool names — same dispatch
+          // semantics, only the name varies by Claude Code version. The
+          // tracker hooks themselves also gate on both.
+          matcher: "^(Agent|Task)$",
           hooks: [
             {
               type: "command",
@@ -2215,7 +2219,11 @@ export function buildSettingsHooksBlock(p: HooksBlockParams): Record<string, unk
   const switchroomPostToolUse = useSwitchroomPlugin
     ? [
         {
-          matcher: "Agent",
+          // Claude Code's hook matcher is a regex. Cover both the legacy
+          // 'Agent' and newer 'Task' tool names — same dispatch
+          // semantics, only the name varies by Claude Code version. The
+          // tracker hooks themselves also gate on both.
+          matcher: "^(Agent|Task)$",
           hooks: [
             {
               type: "command",

--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -12,7 +12,7 @@ import {
   lstatSync,
   readlinkSync,
 } from "node:fs";
-import { execSync } from "node:child_process";
+import { execSync, execFileSync } from "node:child_process";
 import { join, resolve } from "node:path";
 import chalk from "chalk";
 import type { AgentConfig, QuotaConfig, SwitchroomConfig, TelegramConfig } from "../config/schema.js";
@@ -1010,13 +1010,22 @@ Thumbs.db
     execSync("git init --quiet", { cwd: workspaceDir, stdio: "pipe" });
     execSync("git add -A", { cwd: workspaceDir, stdio: "pipe" });
 
-    // Use switchroom's git identity if available from env, else fall back to generic
+    // Use switchroom's git identity if available from env, else fall back to generic.
+    // execFileSync (argv array) — never interpolate env vars into a shell string.
+    // GIT_AUTHOR_NAME='";rm -rf $HOME;#' as an env var would have been a real
+    // injection vector through the previous execSync template literal.
     const userEmail = process.env.GIT_AUTHOR_EMAIL || "switchroom@localhost";
     const userName = process.env.GIT_AUTHOR_NAME || "Switchroom Agent";
 
-    execSync(
-      `git -c user.email="${userEmail}" -c user.name="${userName}" commit -m "chore: seed workspace from switchroom scaffold"`,
-      { cwd: workspaceDir, stdio: "pipe" }
+    execFileSync(
+      "git",
+      [
+        "-c", `user.email=${userEmail}`,
+        "-c", `user.name=${userName}`,
+        "commit",
+        "-m", "chore: seed workspace from switchroom scaffold",
+      ],
+      { cwd: workspaceDir, stdio: "pipe" },
     );
 
     console.log(chalk.green(`  initialized workspace git repo (${agentName})`));

--- a/src/auth/accounts.ts
+++ b/src/auth/accounts.ts
@@ -24,10 +24,12 @@ import {
   mkdirSync,
   readFileSync,
   readdirSync,
+  renameSync,
   rmSync,
   statSync,
   writeFileSync,
 } from "node:fs";
+import { randomBytes } from "node:crypto";
 import { join } from "node:path";
 
 const DEFAULT_SLOT = "default";
@@ -229,6 +231,13 @@ export function writeSlotToken(
 /**
  * Sync the legacy top-level .oauth-token (+ meta) path from the active slot
  * so that start.sh / Claude Code see no layout change.
+ *
+ * Atomic write: read source → write to a sibling tempfile in the same
+ * directory → renameSync onto the destination. Pre-fix this used
+ * copyFileSync, which is non-atomic on Linux — a concurrent cron reader
+ * doing `cat .oauth-token` mid-failover could observe a partial file
+ * (zero-bytes / truncated). The 401 that followed manifested as a
+ * silent OAuth failure with no monitoring. See #418.
  */
 export function syncLegacyFromActive(agentDir: string): void {
   const active = readActiveSlot(agentDir);
@@ -237,9 +246,33 @@ export function syncLegacyFromActive(agentDir: string): void {
   const srcMeta = slotMetaPath(agentDir, active);
   if (!existsSync(srcToken)) return;
   mkdirSync(claudeDir(agentDir), { recursive: true });
-  copyFileSync(srcToken, legacyTokenPath(agentDir));
+  atomicCopy(srcToken, legacyTokenPath(agentDir), 0o600);
   if (existsSync(srcMeta)) {
-    copyFileSync(srcMeta, legacyMetaPath(agentDir));
+    atomicCopy(srcMeta, legacyMetaPath(agentDir), 0o600);
+  }
+}
+
+/**
+ * Read `src`, write to a sibling tempfile in the same directory as
+ * `dest`, then renameSync onto `dest`. The same-directory invariant
+ * keeps the rename on a single filesystem (rename(2) is only atomic
+ * within one fs).
+ */
+function atomicCopy(src: string, dest: string, mode: number): void {
+  const contents = readFileSync(src);
+  const tmp = `${dest}.tmp-${process.pid}-${randomBytes(4).toString("hex")}`;
+  try {
+    writeFileSync(tmp, contents, { mode });
+    renameSync(tmp, dest);
+  } catch (err) {
+    // Best-effort cleanup of the tempfile on failure so a crash mid-copy
+    // doesn't leave a permanent half-written sibling.
+    try {
+      rmSync(tmp);
+    } catch {
+      /* already gone */
+    }
+    throw err;
   }
 }
 

--- a/src/cli/agent.ts
+++ b/src/cli/agent.ts
@@ -57,6 +57,59 @@ import { registerAgentPerfCommand } from "./perf.js";
  *
  * Returns an array of error strings. Empty = all checks passed.
  */
+/**
+ * Defense-in-depth (#61): detect when the switchroom checkout is on a
+ * non-main branch or has a dirty working tree. The gateway runs source
+ * directly via `bun gateway.ts` (no compile step), so whatever branch
+ * is checked out IS what the gateway picks up after restart. Restarting
+ * from a feature branch silently bypasses release tags + PR-merged fixes.
+ *
+ * Returns:
+ *   - null when on main with a clean tree (or git is unavailable —
+ *     swallow the error rather than break the restart path)
+ *   - a one-line warning string otherwise
+ *
+ * The check uses execFileSync against git in the cwd. Any git error
+ * (not a repo, no main ref, no remote, etc) returns null so this
+ * never blocks restart on hosts that aren't running from a git
+ * checkout (npm-global installs, prebuilt dist, etc).
+ */
+function checkSwitchroomBranch(): string | null {
+  // Locate the switchroom install directory. The CLI may be running
+  // from a global install (in which case there's no git checkout) or
+  // from `bun run dev` (in which case the cwd is the checkout).
+  // process.cwd() works for the dev path; the global path returns a
+  // non-git error which we swallow.
+  try {
+    // node-fetch-style execFileSync for predictable shell-free invocation.
+    const { execFileSync } = require("node:child_process") as typeof import("node:child_process");
+    const cwd = process.cwd();
+    const branch = execFileSync("git", ["-C", cwd, "rev-parse", "--abbrev-ref", "HEAD"], {
+      encoding: "utf-8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+    if (branch === "" || branch === "HEAD") return null; // detached or empty — punt
+    if (branch === "main" || branch === "master") {
+      // On main — check for uncommitted changes (which would also alter
+      // gateway behaviour).
+      const status = execFileSync("git", ["-C", cwd, "status", "--porcelain"], {
+        encoding: "utf-8",
+        stdio: ["ignore", "pipe", "ignore"],
+      });
+      if (status.trim().length > 0) {
+        return `switchroom checkout has uncommitted changes on ${branch}`;
+      }
+      return null;
+    }
+    return `switchroom checkout is on branch '${branch}', not main`;
+  } catch {
+    // Not a git repo, or git unavailable, or any other error — assume
+    // the host runs from a non-checkout install (npm-global, prebuilt
+    // dist, etc) and skip the warning.
+    return null;
+  }
+}
+
 function preflightCheck(
   name: string,
   agentDir: string,
@@ -986,6 +1039,30 @@ export function registerAgentCommand(program: Command): void {
           const agentsDir = resolveAgentsDir(config);
           const names =
             name === "all" ? Object.keys(config.agents) : [name];
+
+          // #61 defense #1: warn if the switchroom checkout is on a non-main
+          // branch. The gateway runs source directly via `bun gateway.ts`
+          // (no compile step), so whatever branch is checked out IS what the
+          // gateway will pick up after restart. Restarting from a feature
+          // branch silently bypasses release tags + PR-merged fixes — which
+          // is exactly the scenario most likely to surface bugs.
+          if (!opts.force) {
+            const branchWarning = checkSwitchroomBranch();
+            if (branchWarning != null) {
+              console.error(chalk.yellow(`\n  ⚠ ${branchWarning}`));
+              console.error(
+                chalk.gray(
+                  `\n  The gateway will run code from this branch after restart.`
+                )
+              );
+              console.error(
+                chalk.gray(
+                  `  Switch to main with \`git checkout main && git pull\`, or use --force to proceed anyway.\n`
+                )
+              );
+              process.exit(1);
+            }
+          }
 
           let sawAbort = false;
 

--- a/src/cli/auth.ts
+++ b/src/cli/auth.ts
@@ -141,12 +141,32 @@ export function diagnoseAuthState(claudeConfigDir: string): AuthDiagnosis {
       } else {
         // Token shape OK; check expiry.
         const expiresAt = oauth.expiresAt;
-        if (typeof expiresAt === "number" && expiresAt < Date.now()) {
-          const days = Math.floor((Date.now() - expiresAt) / 86_400_000);
+        if (typeof expiresAt === "number") {
+          if (!Number.isFinite(expiresAt)) {
+            // NaN / Infinity — same masking concern as #441: silently
+            // skipping non-numeric values lets a corrupt creds file
+            // appear healthy when it isn't.
+            findings.push({
+              code: "credentials_malformed",
+              severity: "warn",
+              summary: ".credentials.json claudeAiOauth.expiresAt is non-finite",
+            });
+          } else if (expiresAt < Date.now()) {
+            const days = Math.floor((Date.now() - expiresAt) / 86_400_000);
+            findings.push({
+              code: "token_expired",
+              severity: "error",
+              summary: `access token expired ${days}d ago`,
+            });
+          }
+        } else if (expiresAt !== undefined) {
+          // expiresAt present but the wrong type (string/null/object).
+          // Pre-fix this branch silently fell through, masking a corrupt
+          // creds file as healthy. See #441.
           findings.push({
-            code: "token_expired",
-            severity: "error",
-            summary: `access token expired ${days}d ago`,
+            code: "credentials_malformed",
+            severity: "warn",
+            summary: ".credentials.json claudeAiOauth.expiresAt is missing or non-numeric",
           });
         }
         // Refresh token: warn if missing.

--- a/src/cli/issues.ts
+++ b/src/cli/issues.ts
@@ -41,14 +41,46 @@ function resolveAgentName(opts: { agent?: string }): string {
   );
 }
 
+const STDIN_READ_CAP_BYTES = 64 * 1024;
+
 function readDetailFromStdin(): string | undefined {
-  // Synchronously read all of stdin. Used by `record --detail-stdin`
-  // so callers can pipe stderr through without shell-quoting hell.
-  // Cap at 64KB; the store will truncate further to DETAIL_MAX_BYTES.
+  // Synchronously read up to STDIN_READ_CAP_BYTES of stdin. Used by
+  // `record --detail-stdin` so callers can pipe stderr through without
+  // shell-quoting hell. The store will further truncate to
+  // DETAIL_MAX_BYTES; this cap protects against multi-MB blobs being
+  // slurped into memory before that truncation.
+  //
+  // TTY guard: refuse if stdin is a TTY. The previous behaviour blocked
+  // forever on `readFileSync(0)` waiting for EOF that would never come,
+  // and the parent hook then hung for the full 35s claude-hook timeout.
+  // See #439.
   const fs = require("node:fs") as typeof import("node:fs");
+  if (process.stdin.isTTY) {
+    process.stderr.write(
+      "issues record: refusing to read --detail-stdin from a TTY (would hang).\n",
+    );
+    return undefined;
+  }
   try {
-    const buf = fs.readFileSync(0, { encoding: "utf-8" });
-    return buf || undefined;
+    const buf = Buffer.alloc(STDIN_READ_CAP_BYTES);
+    const bytesRead = fs.readSync(0, buf, 0, STDIN_READ_CAP_BYTES, null);
+    if (bytesRead <= 0) return undefined;
+    let text = buf.subarray(0, bytesRead).toString("utf-8");
+    if (bytesRead === STDIN_READ_CAP_BYTES) {
+      // Probe one more byte to know if the input was longer; surface the
+      // truncation honestly rather than silently dropping content.
+      const probe = Buffer.alloc(1);
+      let extra = 0;
+      try {
+        extra = fs.readSync(0, probe, 0, 1, null);
+      } catch {
+        extra = 0;
+      }
+      if (extra > 0) {
+        text += "\n[truncated: stdin exceeded 64KB]";
+      }
+    }
+    return text || undefined;
   } catch {
     return undefined;
   }

--- a/src/cli/vault-grant.ts
+++ b/src/cli/vault-grant.ts
@@ -203,7 +203,22 @@ export function registerVaultGrantCommands(vault: Command, program: Command): vo
         );
 
         console.log(chalk.green(`✓ Grant minted`));
-        console.log(chalk.bold("Token: ") + result.token);
+        // Token: only print when stdout is a TTY. Possession of the
+        // token = full vault scope access, so non-TTY surfaces (CI logs,
+        // tmux scrollback shared by another user, asciinema recordings,
+        // ssh -T that captures stdout, support-share screen recordings)
+        // shouldn't get a copy. The token file at the path below is the
+        // canonical ergonomic source. Operators who genuinely need the
+        // token in a script can read the file directly.
+        if (process.stdout.isTTY) {
+          console.log(chalk.bold("Token: ") + result.token);
+        } else {
+          console.log(
+            chalk.dim(
+              "Token: <hidden, read it from the token file printed below>",
+            ),
+          );
+        }
         console.log(chalk.bold("Grant ID: ") + result.id);
         console.log(
           chalk.bold("Expires: ") +

--- a/src/cli/web.ts
+++ b/src/cli/web.ts
@@ -53,7 +53,17 @@ export function registerWebCommand(program: Command): void {
             )
           );
         }
-        console.log(chalk.gray(`  Token: ${token}`));
+        // Token only echoes to TTY. Possession = full dashboard
+        // access — non-TTY captures (CI logs, tmux scrollback, support
+        // screen-shares) shouldn't get a copy. Operators reading from
+        // a non-TTY context should fetch from ~/.switchroom/web-token.
+        if (process.stdout.isTTY) {
+          console.log(chalk.gray(`  Token: ${token}`));
+        } else {
+          console.log(
+            chalk.gray(`  Token: <hidden, read ~/.switchroom/web-token>`),
+          );
+        }
         console.log(
           chalk.gray(
             "  Open the dashboard in a browser that can pass the bearer via\n" +

--- a/src/config/merge.ts
+++ b/src/config/merge.ts
@@ -261,13 +261,28 @@ export function mergeAgentConfig(
     merged.soul = combined as AgentConfig["soul"];
   }
 
-  // --- memory: shallow field merge, agent wins ---
+  // --- memory: top-level field merge with one-level-deep merge of `recall` ---
+  //
+  // Pre-DOC2 fix this was a single shallow merge. That meant
+  //   defaults.memory.recall = { max_memories: 12 }
+  //   agents.foo.memory.recall = { cache_ttl_secs: 30 }
+  // produced agents.foo.memory.recall = { cache_ttl_secs: 30 } — silently
+  // dropping max_memories. The doc table at docs/configuration.md:32 says
+  // "per-field merge" implying deep behaviour; cascade users expected
+  // overriding one knob to leave the rest in place. Now `recall` deep-merges
+  // (one level — sufficient because recall has only scalar children) and
+  // every other top-level memory key keeps the existing override behaviour.
   if (defaults.memory || merged.memory) {
     const base = defaults.memory ?? {};
     const override = merged.memory ?? {};
     const combined: Record<string, unknown> = { ...base };
     for (const [k, v] of Object.entries(override)) {
-      if (v !== undefined) combined[k] = v;
+      if (v === undefined) continue;
+      if (k === "recall" && base.recall && typeof v === "object" && v !== null && !Array.isArray(v)) {
+        combined[k] = { ...base.recall, ...(v as Record<string, unknown>) };
+      } else {
+        combined[k] = v;
+      }
     }
     merged.memory = combined as AgentConfig["memory"];
   }

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -845,6 +845,33 @@ export const AgentSchema = z.object({
       "doesn't expose directly (e.g. --effort high, " +
       "--exclude-dynamic-system-prompt-sections)."
     ),
+  add_dirs: z
+    .array(z.string())
+    .optional()
+    .describe(
+      "Additional filesystem paths the agent's tools can access. Passed " +
+      "as repeated --add-dir <path> on the claude invocation. Use to grant " +
+      "an agent reach into shared dirs (e.g. '/share/collab') without " +
+      "scaffold hacks. Per-agent only — paths are persona-specific. See #199."
+    ),
+  allowed_tools: z
+    .array(z.string())
+    .optional()
+    .describe(
+      "Granular tool allowlist passed verbatim to Claude Code's --allowedTools " +
+      "flag. Supports patterns like 'Bash(git *)' or 'Edit(*.md)' that the " +
+      "coarse `tools.allow` field can't express. When set, Claude Code OR-merges " +
+      "with `tools.allow` (granular only when present, otherwise coarse — chosen " +
+      "via #199 to keep blast radius minimal for existing operators on tools.allow). " +
+      "See #199."
+    ),
+  disallowed_tools: z
+    .array(z.string())
+    .optional()
+    .describe(
+      "Granular tool denylist passed verbatim to Claude Code's --disallowedTools " +
+      "flag. Same pattern syntax as allowed_tools (e.g. 'Bash(rm *)'). See #199."
+    ),
   extra_stable_files: z
     .array(z.string())
     .optional()

--- a/src/issues/store.ts
+++ b/src/issues/store.ts
@@ -30,8 +30,10 @@ import {
   existsSync,
   mkdirSync,
   openSync,
+  readdirSync,
   readFileSync,
   renameSync,
+  statSync,
   unlinkSync,
   writeFileSync,
   writeSync,
@@ -250,6 +252,11 @@ function ensureDir(stateDir: string): void {
 
 function writeAll(stateDir: string, events: IssueEvent[]): void {
   const path = join(stateDir, ISSUES_FILE);
+  // Sweep orphan tempfiles from prior crashes before allocating a new
+  // one. Any `issues.jsonl.tmp-*` older than ORPHAN_TMP_TTL_MS is
+  // assumed crashed (writeAll completes in ms, so even a slow disk is
+  // way under the threshold). See #447.
+  sweepOrphanTmpFiles(stateDir);
   const tmp = `${path}.tmp-${process.pid}-${randomBytes(4).toString("hex")}`;
   const body =
     events.length === 0
@@ -257,6 +264,37 @@ function writeAll(stateDir: string, events: IssueEvent[]): void {
       : events.map((e) => JSON.stringify(e)).join("\n") + "\n";
   writeFileSync(tmp, body, "utf-8");
   renameSync(tmp, path);
+}
+
+const ORPHAN_TMP_TTL_MS = 60_000;
+const TMP_PREFIX = `${ISSUES_FILE}.tmp-`;
+
+/**
+ * Best-effort cleanup of tempfiles left behind by prior crashes. Any
+ * `<stateDir>/issues.jsonl.tmp-*` whose mtime is older than
+ * ORPHAN_TMP_TTL_MS is unlinked. Errors are ignored — this is a sweep,
+ * not a guarantee, and we never want it to fail an in-progress write.
+ */
+function sweepOrphanTmpFiles(stateDir: string): void {
+  let entries: string[];
+  try {
+    entries = readdirSync(stateDir);
+  } catch {
+    return;
+  }
+  const cutoff = Date.now() - ORPHAN_TMP_TTL_MS;
+  for (const entry of entries) {
+    if (!entry.startsWith(TMP_PREFIX)) continue;
+    const tmpPath = join(stateDir, entry);
+    try {
+      const stat = statSync(tmpPath);
+      if (stat.mtimeMs < cutoff) {
+        unlinkSync(tmpPath);
+      }
+    } catch {
+      // Vanished mid-sweep or unreadable — fine, skip.
+    }
+  }
 }
 
 /**

--- a/src/vault/broker/client.ts
+++ b/src/vault/broker/client.ts
@@ -80,6 +80,22 @@ export function vaultTokenFilePath(agentSlug: string): string {
 export function readVaultTokenFile(agentSlug: string): string | null {
   const filePath = vaultTokenFilePath(agentSlug);
   try {
+    // Defense-in-depth: token file MUST be 0600 (owner-only). The broker
+    // treats the token as full auth (peercred ACL is bypassed when a
+    // valid token is presented), so a widened mode = anyone in the same
+    // UID can exfiltrate the bearer. Real causes: backup tools restoring
+    // with default umask, an errant chmod, an rsync without -p. Fail
+    // closed and tell the operator how to fix.
+    const stat = fs.statSync(filePath);
+    const mode = stat.mode & 0o777;
+    if ((mode & 0o077) !== 0) {
+      process.stderr.write(
+        `[vault-broker] Refusing to read ${filePath} with mode ${mode.toString(8).padStart(3, "0")} ` +
+        `(must be 0600). Delete the file and re-mint with 'switchroom vault grant mint <agent>'. ` +
+        `Falling through to peercred ACL.\n`,
+      );
+      return null;
+    }
     const raw = fs.readFileSync(filePath, "utf8");
     const token = raw.split("\n")[0].trim();
     return token.length > 0 ? token : null;

--- a/telegram-plugin/.claude-plugin/plugin.json
+++ b/telegram-plugin/.claude-plugin/plugin.json
@@ -1,0 +1,20 @@
+{
+  "name": "switchroom-telegram",
+  "description": "Switchroom's enhanced Telegram channel: HTML formatting, smart message chunking, message coalescing, attachment helpers, progress card with sub-agent visibility, vault-grant wizard, and slash-command admin surface (/restart, /usage, /auth, /vault, /issues).",
+  "version": "0.1.0",
+  "author": {
+    "name": "Ken Thompson",
+    "email": "me@kenthompson.com.au"
+  },
+  "homepage": "https://github.com/mekenthompson/switchroom",
+  "repository": "https://github.com/mekenthompson/switchroom",
+  "license": "MIT",
+  "keywords": [
+    "telegram",
+    "switchroom",
+    "channel",
+    "multi-agent",
+    "progress-card",
+    "vault"
+  ]
+}

--- a/telegram-plugin/.mcp.json
+++ b/telegram-plugin/.mcp.json
@@ -1,0 +1,14 @@
+{
+  "mcpServers": {
+    "switchroom-telegram": {
+      "command": "bun",
+      "args": [
+        "run",
+        "--cwd",
+        "${CLAUDE_PLUGIN_ROOT}",
+        "--silent",
+        "start"
+      ]
+    }
+  }
+}

--- a/telegram-plugin/auto-fallback.ts
+++ b/telegram-plugin/auto-fallback.ts
@@ -224,6 +224,75 @@ export function emptyLockout(): LockoutRecord {
 }
 
 /**
+ * Disk-persistence helpers for the lockout record. The cooldown guard
+ * lives entirely in process memory pre-fix, so a gateway restart inside
+ * the cooldown window resets the timer to zero — and a quota-flap on
+ * the now-recovering slot can re-trigger fallback the moment the
+ * gateway comes back. See #417.
+ *
+ * Storage path: \`<agentDir>/.claude/auto-fallback-lockout.json\`. We
+ * tolerate any read/parse error by returning emptyLockout (the same
+ * outcome as a fresh process), since the cooldown is a noise filter,
+ * not a security boundary.
+ */
+const LOCKOUT_FILE = "auto-fallback-lockout.json";
+
+export interface LockoutPersistOps {
+  readFileSync: (path: string, encoding: BufferEncoding) => string;
+  writeFileSync: (path: string, data: string, opts: { mode?: number }) => void;
+  existsSync: (path: string) => boolean;
+  mkdirSync: (path: string, opts: { recursive: true }) => void;
+  joinPath: (...parts: string[]) => string;
+  now?: () => number;
+}
+
+export function lockoutPath(agentDir: string, joinPath: LockoutPersistOps['joinPath']): string {
+  return joinPath(agentDir, '.claude', LOCKOUT_FILE);
+}
+
+export function loadLockout(agentDir: string, ops: LockoutPersistOps): LockoutRecord {
+  const path = lockoutPath(agentDir, ops.joinPath);
+  if (!ops.existsSync(path)) return emptyLockout();
+  try {
+    const raw = ops.readFileSync(path, 'utf-8');
+    const parsed = JSON.parse(raw);
+    if (
+      parsed &&
+      typeof parsed === 'object' &&
+      (typeof parsed.lastTransitionedFrom === 'string' ||
+        parsed.lastTransitionedFrom === null) &&
+      typeof parsed.lastTransitionAt === 'number' &&
+      Number.isFinite(parsed.lastTransitionAt)
+    ) {
+      return {
+        lastTransitionedFrom: parsed.lastTransitionedFrom,
+        lastTransitionAt: parsed.lastTransitionAt,
+      };
+    }
+  } catch {
+    /* fall through to empty */
+  }
+  return emptyLockout();
+}
+
+export function saveLockout(
+  agentDir: string,
+  record: LockoutRecord,
+  ops: LockoutPersistOps,
+): void {
+  const path = lockoutPath(agentDir, ops.joinPath);
+  // Best-effort: ensure the .claude directory exists, then write. Any
+  // failure is swallowed by the caller's try/catch — losing the lockout
+  // file just degrades to in-memory-only behaviour, not a hard failure.
+  ops.mkdirSync(ops.joinPath(agentDir, '.claude'), { recursive: true });
+  ops.writeFileSync(
+    path,
+    JSON.stringify(record, null, 2) + '\n',
+    { mode: 0o600 },
+  );
+}
+
+/**
  * Build the notification HTML for a successful slot switch.
  * Delegates to renderOperatorEvent for quota-exhausted; appends
  * slot-transition detail as structured context.

--- a/telegram-plugin/auto-fallback.ts
+++ b/telegram-plugin/auto-fallback.ts
@@ -137,6 +137,13 @@ export type FallbackPlan =
       resetAtMs: number | null;
       notificationHtml: string;
       agentName: string;
+      /** Carried through from the FallbackDecision so the executor can
+       *  decide whether to do a hard or graceful restart. Reactive
+       *  (`429-response`) failover wants a hard restart — the request
+       *  the user just made already failed, so there's no in-flight
+       *  turn worth preserving. Preemptive (`utilization-over-threshold`
+       *  / `explicit`) failover wants a graceful one. See #420. */
+      triggerReason: 'utilization-over-threshold' | '429-response' | 'explicit';
     }
   | {
       kind: 'exhausted-all';
@@ -203,6 +210,7 @@ export function performAutoFallback(args: PerformArgs): FallbackPlan {
     resetAtMs: args.decision.resetAtMs,
     notificationHtml: buildSwitchedMessage(prev, newActive, args.agentName, args.decision.resetAtMs),
     agentName: args.agentName,
+    triggerReason: args.decision.triggerReason,
   };
 }
 

--- a/telegram-plugin/credits-watch.ts
+++ b/telegram-plugin/credits-watch.ts
@@ -1,0 +1,220 @@
+/**
+ * Claude-independent credit-exhaustion notify (#348).
+ *
+ * Background: Anthropic's API rate-limit headers (used by quota-check.ts)
+ * tell us 5h/7d utilization, but they don't surface plan-level credit
+ * exhaustion ("out of pre-paid usage", "billing disabled by org admin",
+ * etc). Claude Code itself caches that signal in `.claude.json` as
+ * `cachedExtraUsageDisabledReason`. When the agent runs into the wall —
+ * especially in a cron context where stdout is discarded — Switchroom
+ * has no way to tell the user without ALSO checking that file.
+ *
+ * Pre-#348: cron-issued requests against an out-of-credits account
+ * silently failed (stdout to /dev/null), and the user only noticed
+ * hours later when they wondered why their morning brief never came.
+ * Direct violation of the #1 product principle (silent failure is
+ * the worst case — see reference/know-what-my-agent-is-doing.md).
+ *
+ * This module is a pure decision layer. It reads the file, compares
+ * against the last-notified state on disk, and tells the caller
+ * whether to emit a Telegram message + what to say. The gateway
+ * wires the actual `bot.api.sendMessage` call.
+ */
+
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from "fs";
+import { join } from "path";
+
+const STATE_FILE = "credits-watch.json";
+
+/**
+ * Possible values of `cachedExtraUsageDisabledReason` in `.claude.json`
+ * that warrant a user-facing notification. Other values (null,
+ * undefined, transient unknowns) are treated as "no notification
+ * needed".
+ *
+ * Conservative list: only fatal-billing reasons. We don't want to fire
+ * on every transient API blip the cache happens to write.
+ */
+const FATAL_REASONS = new Set([
+  "out_of_credits",
+  "org_level_disabled",
+  "credits_exhausted",
+  "extra_usage_disabled",
+]);
+
+export interface CreditState {
+  /** Last reason we notified the user about. null when healthy / never notified. */
+  lastNotifiedReason: string | null;
+  /** Wall-clock ms when we last notified. */
+  lastNotifiedAt: number;
+}
+
+export function emptyCreditState(): CreditState {
+  return { lastNotifiedReason: null, lastNotifiedAt: 0 };
+}
+
+/**
+ * Read `.claude.json` and return the cached extra-usage-disabled reason.
+ * Returns null when:
+ *   - The file is missing (Claude Code hasn't booted yet on this machine)
+ *   - The file is unreadable / malformed
+ *   - The field is unset, null, or not a string
+ */
+export function readClaudeJsonOverage(claudeConfigDir: string): string | null {
+  const path = join(claudeConfigDir, ".claude.json");
+  if (!existsSync(path)) return null;
+  let raw: string;
+  try {
+    raw = readFileSync(path, "utf-8");
+  } catch {
+    return null;
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (!parsed || typeof parsed !== "object") return null;
+  const reason = (parsed as { cachedExtraUsageDisabledReason?: unknown })
+    .cachedExtraUsageDisabledReason;
+  if (typeof reason !== "string" || reason.length === 0) return null;
+  return reason;
+}
+
+/**
+ * Pure decision: given the current `.claude.json` reason and the last
+ * notified state, decide whether to notify and what state to write.
+ *
+ * Transition table (current → previous → action):
+ *   - fatal-X → no-prev or healthy → notify (new fatal state)
+ *   - fatal-X → fatal-X → skip (already notified for this exact reason)
+ *   - fatal-X → fatal-Y → notify (state changed; X != Y)
+ *   - healthy → fatal-X → notify (recovered — let user know it's working again)
+ *   - healthy → healthy → skip (steady-state)
+ *   - non-fatal-X → anything → skip (unknown/transient state, don't pollute)
+ */
+export type CreditDecision =
+  | { kind: "notify"; message: string; newState: CreditState; transition: "entered" | "exited" | "changed" }
+  | { kind: "skip"; reason: string };
+
+export function evaluateCreditState(args: {
+  agentName: string;
+  currentReason: string | null;
+  prev: CreditState;
+  now: number;
+}): CreditDecision {
+  const { agentName, currentReason, prev, now } = args;
+
+  // Non-fatal current state (null, or some unknown reason) — no
+  // notification regardless of prev (we already notified on entry to
+  // fatal; recovery from a known-fatal state below is the only path
+  // that fires when current is null).
+  const currentIsFatal = currentReason != null && FATAL_REASONS.has(currentReason);
+  const prevIsFatal = prev.lastNotifiedReason != null && FATAL_REASONS.has(prev.lastNotifiedReason);
+
+  // Recovery path: last-notified was fatal, current is null/non-fatal.
+  if (!currentIsFatal && prevIsFatal) {
+    return {
+      kind: "notify",
+      message: `✅ <b>${escapeHtml(agentName)}</b>: credits restored — agent should resume normal operation.`,
+      newState: { lastNotifiedReason: null, lastNotifiedAt: now },
+      transition: "exited",
+    };
+  }
+
+  // Entry path: current is fatal, prev was healthy.
+  if (currentIsFatal && !prevIsFatal) {
+    return {
+      kind: "notify",
+      message: buildEntryMessage(agentName, currentReason!),
+      newState: { lastNotifiedReason: currentReason, lastNotifiedAt: now },
+      transition: "entered",
+    };
+  }
+
+  // Reason-change path: both fatal but different value.
+  if (currentIsFatal && prevIsFatal && currentReason !== prev.lastNotifiedReason) {
+    return {
+      kind: "notify",
+      message: buildEntryMessage(agentName, currentReason!),
+      newState: { lastNotifiedReason: currentReason, lastNotifiedAt: now },
+      transition: "changed",
+    };
+  }
+
+  // Steady-state cases: no notification.
+  if (currentIsFatal && prevIsFatal) {
+    return { kind: "skip", reason: "already-notified-for-this-reason" };
+  }
+  return { kind: "skip", reason: "no-fatal-state" };
+}
+
+function buildEntryMessage(agentName: string, reason: string): string {
+  const desc = humanizeReason(reason);
+  return [
+    `⚠️ <b>${escapeHtml(agentName)}</b>: ${desc}`,
+    ``,
+    `Cron tasks and inbound replies will fail until this is resolved. Check`,
+    `your subscription or pre-paid usage at <a href="https://console.anthropic.com">console.anthropic.com</a>.`,
+    ``,
+    `<i>Source: Claude CLI cache (cachedExtraUsageDisabledReason=${escapeHtml(reason)})</i>`,
+  ].join("\n");
+}
+
+function humanizeReason(reason: string): string {
+  switch (reason) {
+    case "out_of_credits":
+      return "out of pre-paid credits";
+    case "org_level_disabled":
+      return "org admin has disabled extra usage";
+    case "credits_exhausted":
+      return "subscription credits exhausted";
+    case "extra_usage_disabled":
+      return "extra-usage billing is disabled";
+    default:
+      return `usage disabled (${reason})`;
+  }
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+// ─── State persistence ───────────────────────────────────────────────────────
+
+export function loadCreditState(stateDir: string): CreditState {
+  const path = join(stateDir, STATE_FILE);
+  if (!existsSync(path)) return emptyCreditState();
+  try {
+    const raw = readFileSync(path, "utf-8");
+    const parsed = JSON.parse(raw);
+    if (
+      parsed &&
+      typeof parsed === "object" &&
+      (parsed.lastNotifiedReason === null ||
+        typeof parsed.lastNotifiedReason === "string") &&
+      typeof parsed.lastNotifiedAt === "number" &&
+      Number.isFinite(parsed.lastNotifiedAt)
+    ) {
+      return {
+        lastNotifiedReason: parsed.lastNotifiedReason,
+        lastNotifiedAt: parsed.lastNotifiedAt,
+      };
+    }
+  } catch {
+    /* fall through */
+  }
+  return emptyCreditState();
+}
+
+export function saveCreditState(stateDir: string, state: CreditState): void {
+  mkdirSync(stateDir, { recursive: true });
+  const path = join(stateDir, STATE_FILE);
+  writeFileSync(path, JSON.stringify(state, null, 2) + "\n", { mode: 0o600 });
+}

--- a/telegram-plugin/foreman/foreman-create-flow.ts
+++ b/telegram-plugin/foreman/foreman-create-flow.ts
@@ -109,8 +109,16 @@ export function handleFlowText(input: StepTransitionInput): CreateFlowAction {
           stayInStep: true,
         }
       }
-      const name = state.name ?? trimmed // name was set when we transitioned here
-      return { kind: 'ask-bot-token', name, profile: trimmed }
+      // Pre-#28 fix this fell back to `trimmed` (the profile name)
+      // when state.name was missing — silently treating the profile
+      // as the agent name. Now we cancel with missing-name instead,
+      // matching the asked-bot-token step's behaviour on corrupt
+      // state. The fallback wasn't exploitable (assertSafeAgentName
+      // catches it downstream), but it's semantically wrong.
+      if (!state.name) {
+        return { kind: 'cancel', reason: 'missing-name' }
+      }
+      return { kind: 'ask-bot-token', name: state.name, profile: trimmed }
     }
 
     case 'asked-bot-token': {

--- a/telegram-plugin/foreman/foreman.ts
+++ b/telegram-plugin/foreman/foreman.ts
@@ -71,7 +71,7 @@ import {
 } from './foreman-create-flow.js'
 import { listAvailableProfiles } from '../../src/agents/profiles.js'
 import { createAgent, completeCreation } from '../../src/agents/create-orchestrator.js'
-import { validateBotToken, validateBotTokenMatchesAgent } from '../../src/setup/telegram-api.js'
+import { validateBotToken } from '../../src/setup/telegram-api.js'
 import { resolveAgentsDir, loadConfig } from '../../src/config/loader.js'
 import {
   getSetupState,
@@ -580,6 +580,20 @@ bot.on('message:text', async ctx => {
     await switchroomReply(ctx, 'Deletion cancelled.', { html: false })
     return
   }
+  // No pendingDelete on this chat. If the user's text is `YES` or `YES.`,
+  // they probably typed it expecting to confirm a delete that was queued
+  // before a foreman restart (pendingDeletes is in-memory; #28 item 7).
+  // Pre-fix this fell through and eventually rendered "Unknown command",
+  // which left the user wondering whether the delete went through. Surface
+  // a clear "no pending delete" message instead.
+  if (/^yes\.?$/i.test(text.trim())) {
+    await switchroomReply(
+      ctx,
+      'There is no pending delete to confirm — the foreman may have restarted since you ran <code>/delete</code>. Re-run <code>/delete &lt;agent&gt;</code> if you still want to delete.',
+      { html: true },
+    )
+    return
+  }
 
   // 2. Check for active /setup wizard flow
   const setupState = getSetupState(chatId)
@@ -859,16 +873,13 @@ async function handleCreateFlowText(
 
     case 'call-create-agent': {
       const { name, profile, botToken } = action
-      // Validate token via Telegram API before scaffold
-      await switchroomReply(ctx, 'Validating token…', { html: false })
-      try {
-        await validateBotToken(botToken)
-      } catch (err) {
-        await switchroomReply(ctx, `Token rejected by Telegram — ${(err as Error).message}. Try again:`, { html: false })
-        return
-      }
-
-      await switchroomReply(ctx, `Token OK. Creating agent <b>${escapeHtmlForTg(name)}</b>…`, { html: true })
+      // Pre-#28 fix this called validateBotToken here AND createAgent
+      // (via validateBotTokenMatchesAgent at create-orchestrator.ts:150)
+      // would call it again — two sequential Telegram getMe() requests in
+      // the happy path. We now trust the orchestrator's check and surface
+      // its error if it fails. The /setup flow at line 723 keeps its own
+      // pre-check because it uses the returned botInfo.username for UX.
+      await switchroomReply(ctx, `Creating agent <b>${escapeHtmlForTg(name)}</b>…`, { html: true })
       try {
         const result = await createAgent({
           name,

--- a/telegram-plugin/format.ts
+++ b/telegram-plugin/format.ts
@@ -309,11 +309,6 @@ export function markdownToHtml(text: string): string {
   // Escape HTML entities in remaining plain text
   result = escapeHtml(result)
 
-  // Restore code-block and table-block placeholders (entity-escaped, fix them)
-  result = result.replace(new RegExp(`${escapeHtml(BLOCK_PH)}(\\d+)${escapeHtml('\x00')}`, 'g'), (_m, idx) => codeBlocks[Number(idx)])
-  result = result.replace(new RegExp(`${escapeHtml(TABLE_PH)}(\\d+)${escapeHtml('\x00')}`, 'g'), (_m, idx) => codeBlocks[Number(idx)])
-  result = result.replace(new RegExp(`${escapeHtml(INLINE_PH)}(\\d+)${escapeHtml('\x00')}`, 'g'), (_m, idx) => inlineCodes[Number(idx)])
-
   // Bold: **text** (must come before italic)
   result = result.replace(/\*\*(.+?)\*\*/g, '<b>$1</b>')
 
@@ -327,6 +322,18 @@ export function markdownToHtml(text: string): string {
 
   // Strikethrough: ~~text~~
   result = result.replace(/~~(.+?)~~/g, '<s>$1</s>')
+
+  // Restore inline-code, code-block, and table-block placeholders ONLY
+  // AFTER bold/italic/strike have run. If the inline-code placeholder
+  // is restored before italic, an inline-code span containing asterisks
+  // (e.g. `\`size_t *p\``) gets matched by the italic regex on the
+  // restored `<code>...*p</code>` buffer and produces invalid HTML
+  // that Telegram rejects with 400 Bad Request — sending the caller
+  // into a `format: text` fallback for the rest of the chunk. Same
+  // fault class for code blocks containing `**` literals. See #415.
+  result = result.replace(new RegExp(`${escapeHtml(BLOCK_PH)}(\\d+)${escapeHtml('\x00')}`, 'g'), (_m, idx) => codeBlocks[Number(idx)])
+  result = result.replace(new RegExp(`${escapeHtml(TABLE_PH)}(\\d+)${escapeHtml('\x00')}`, 'g'), (_m, idx) => codeBlocks[Number(idx)])
+  result = result.replace(new RegExp(`${escapeHtml(INLINE_PH)}(\\d+)${escapeHtml('\x00')}`, 'g'), (_m, idx) => inlineCodes[Number(idx)])
 
   // Links: [text](url). Two safety requirements here:
   //

--- a/telegram-plugin/gateway/boot-probes.ts
+++ b/telegram-plugin/gateway/boot-probes.ts
@@ -228,6 +228,23 @@ export const AGENT_LIVE_WINDOW_MS = 45_000
  */
 export const AGENT_LIVE_POLL_INTERVAL_MS = 2_000
 
+/**
+ * After the live window expires with the agent still not `active`, the
+ * generator schedules ONE follow-up re-poll this many ms later. If the
+ * agent has reached `active` by then, an updated ✅ ProbeResult is
+ * yielded and the boot card edits in place. Otherwise no further yield.
+ *
+ * Pre-#296 fix the generator returned immediately at window-expiry, so
+ * an agent that became active 1-30s after the window stayed visibly
+ * 🟡 "service inactive" forever (until the user noticed and asked).
+ *
+ * 30 s is the recommended-by-issue-author value: long enough to catch
+ * the common late-boot scenario (slow disk, claude-cli npm install
+ * ticking down), short enough that genuinely stuck units still surface
+ * as a real problem within ~75 s total.
+ */
+export const AGENT_LIVE_FOLLOWUP_REPOLL_MS = 30_000
+
 type ExecFileResult = { stdout: string; stderr: string }
 type ExecFileFnType = (
   cmd: string,
@@ -344,18 +361,33 @@ export async function* watchAgentProcess(
   opts: {
     liveWindowMs?: number
     pollIntervalMs?: number
+    /**
+     * Wait this many ms after the live window expires before doing one
+     * follow-up state check. If the agent reached `active` in that
+     * window, yield an updated ✅ ProbeResult so the boot card flips
+     * from 🟡 "service inactive" to ✅. See #296. Set to 0 to disable.
+     */
+    followupRepollMs?: number
     /** Override for tests — replaces real delays */
     sleepImpl?: (ms: number) => Promise<void>
     /** Override for tests — replaces real execFile calls */
     execFileImpl?: ExecFileFnType
+    /**
+     * Override for tests. Defaults to Date.now. The within-window
+     * check uses this; injecting lets tests advance "time" without
+     * real sleeps.
+     */
+    nowImpl?: () => number
   } = {},
 ): AsyncGenerator<ProbeResult> {
   const liveWindowMs = opts.liveWindowMs ?? AGENT_LIVE_WINDOW_MS
   const pollIntervalMs = opts.pollIntervalMs ?? AGENT_LIVE_POLL_INTERVAL_MS
+  const followupRepollMs = opts.followupRepollMs ?? AGENT_LIVE_FOLLOWUP_REPOLL_MS
   const sleep = opts.sleepImpl ?? ((ms: number) => new Promise<void>(resolve => setTimeout(resolve, ms)))
   const execFileFn: ExecFileFnType = opts.execFileImpl ?? execFile
+  const now = opts.nowImpl ?? (() => Date.now())
 
-  const startMs = Date.now()
+  const startMs = now()
   let lastYieldedDetail: string | null = null
 
   /**
@@ -395,7 +427,7 @@ export async function* watchAgentProcess(
   }
 
   while (true) {
-    const elapsedMs = Date.now() - startMs
+    const elapsedMs = now() - startMs
     const withinWindow = elapsedMs < liveWindowMs
 
     const snapshot = await queryAgentState(agentName, execFileFn)
@@ -421,6 +453,25 @@ export async function* watchAgentProcess(
 
     // If window expired, we already yielded the final committed result.
     if (!withinWindow) {
+      // #296 follow-up: schedule ONE re-poll after the live window so a
+      // late-boot transition (active arriving 1-30s after the window) flips
+      // the card from 🟡 "service inactive" to ✅ instead of staying stale
+      // until the next user-driven event. Skipped when:
+      //   - followupRepollMs <= 0 (test override / explicit disable)
+      //   - the final result was already 'ok' (handled by the early-return above)
+      //   - the final result was 'fail' due to systemd reporting `failed`
+      //     (also handled above) — anything reaching here is degraded
+      if (followupRepollMs <= 0) return
+      await sleep(followupRepollMs)
+      const followup = await queryAgentState(agentName, execFileFn)
+      if ('error' in followup) return
+      // Only yield on a state we DIDN'T see before — silently no-op if the
+      // agent is still inactive/activating/etc., to avoid card flapping.
+      if (followup.state !== 'active') return
+      const okResult = toProbeResult(followup.state, followup.kv, false)
+      if (okResult.detail !== lastYieldedDetail) {
+        yield okResult
+      }
       return
     }
 

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -213,6 +213,11 @@ import {
   saveCreditState,
 } from '../credits-watch.js'
 import {
+  writeTurnActiveMarker,
+  touchTurnActiveMarker,
+  removeTurnActiveMarker,
+} from './turn-active-marker.js'
+import {
   VERSION,
   COMMIT_SHA,
   COMMIT_DATE,
@@ -2510,6 +2515,17 @@ function handleSessionEvent(ev: SessionEvent): void {
               process.stderr.write(`telegram gateway: recordTurnStart failed turnKey=${turnKey}: ${(err as Error).message}\n`)
             }
           })
+          // #412: turn-active marker for the bridge-watchdog. File exists
+          // for the duration of the in-flight turn; mtime advances on
+          // every tool_use; deleted on turn_complete. The watchdog
+          // distinguishes wedged-mid-turn from healthy-idle by checking
+          // for this file's presence + mtime staleness.
+          writeTurnActiveMarker(STATE_DIR, {
+            turnKey,
+            chatId: String(ev.chatId),
+            threadId: ev.threadId != null ? String(ev.threadId) : null,
+            startedAt: currentTurnStartedAt,
+          })
         }
         // Issue #195: capture transport selection + time-to-ack baseline
         // up-front so the per-turn answer-stream config is determined before
@@ -2535,6 +2551,11 @@ function handleSessionEvent(ev: SessionEvent): void {
       if (currentSessionChatId == null) return
       // Phase 1 of #332: count every tool_use in the current turn.
       currentTurnToolCallCount++
+      // #412: bump turn-active marker mtime so the watchdog sees this
+      // turn is making forward progress. Stop-hook deadlocks (the
+      // failure mode #116 originally tracked) emit no more tool_use
+      // events, so the marker mtime stops advancing → watchdog acts.
+      touchTurnActiveMarker(STATE_DIR)
       const ctrl = activeStatusReactions.get(statusKey(currentSessionChatId, currentSessionThreadId))
       const name = ev.toolName
       if (isTelegramReplyTool(name)) {
@@ -7254,6 +7275,10 @@ if (streamMode === 'checklist') {
       process.stderr.write(`telegram gateway: progress-card: onTurnComplete callback turnKey=${turnKey}\n`)
       pinMgr.completeTurn({ chatId, threadId, turnKey })
       pinWatchdog.clear(turnKey)
+      // #412: drop the turn-active marker so the watchdog stops tracking
+      // this turn. Absent file = no in-flight turn = legitimate idle (no
+      // hang to detect).
+      removeTurnActiveMarker(STATE_DIR)
       // Clean up silent-end-pending.json once the turn delivered for real.
       // Without this, the file lingers between sessions and the Stop hook
       // can read a stale `retryCount` from a long-resolved turn. See #289.

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -6452,27 +6452,53 @@ bot.command('issues', async ctx => {
     // "Clear all" = list current, resolve each. The CLI's `prune` is
     // for retention; clearing live issues is a UI concern. Implement
     // here by walking the list and resolving each. Best-effort.
+    //
+    // #443: require an explicit `--confirm` flag. A fat-finger
+    // `/issues clear` used to mass-resolve every unresolved entry in
+    // one shot — destructive verbs deserve a guard. Bare `/issues
+    // clear` now counts and prints the prompt; `--confirm` actually
+    // executes.
     try {
       const stateDir = process.env.TELEGRAM_STATE_DIR
-      if (stateDir) {
-        const events = listIssues(stateDir)
-        let n = 0
-        for (const e of events) {
-          n += resolveIssue(stateDir, e.fingerprint)
-        }
-        await switchroomReply(ctx, `Resolved ${n} issue${n === 1 ? '' : 's'}.`, { html: true })
+      if (!stateDir) {
+        await switchroomReply(ctx, 'clear: no TELEGRAM_STATE_DIR; cannot operate.', { html: true })
         return
       }
+      const confirmed = parts.slice(1).includes('--confirm')
+      if (!confirmed) {
+        const events = listIssues(stateDir)
+        const n = events.length
+        if (n === 0) {
+          await switchroomReply(ctx, 'No unresolved issues to clear.', { html: true })
+          return
+        }
+        const noun = n === 1 ? 'issue' : 'issues'
+        await switchroomReply(
+          ctx,
+          [
+            `This will resolve <b>${n} ${noun}</b>. To confirm, run:`,
+            '',
+            '<code>/issues clear --confirm</code>',
+          ].join('\n'),
+          { html: true },
+        )
+        return
+      }
+      const events = listIssues(stateDir)
+      let n = 0
+      for (const e of events) {
+        n += resolveIssue(stateDir, e.fingerprint)
+      }
+      await switchroomReply(ctx, `Resolved ${n} issue${n === 1 ? '' : 's'}.`, { html: true })
+      return
     } catch (err) {
       await switchroomReply(ctx, `clear failed: ${escapeHtmlForTg((err as Error).message)}`, { html: true })
       return
     }
-    await switchroomReply(ctx, 'clear: no TELEGRAM_STATE_DIR; cannot operate.', { html: true })
-    return
   }
   await switchroomReply(
     ctx,
-    'Usage: <code>/issues</code> | <code>/issues resolve &lt;fingerprint&gt;</code> | <code>/issues clear</code>',
+    'Usage: <code>/issues</code> | <code>/issues resolve &lt;fingerprint&gt;</code> | <code>/issues clear [--confirm]</code>',
     { html: true },
   )
 })

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -5674,8 +5674,15 @@ async function handleVaultGrantCallback(ctx: Context, data: string): Promise<voi
   // vg:dur:*, vg:back:*, vg:generate). These come after the management callbacks above
   // because management uses vg:cancel:<id> (with trailing id) while the wizard uses
   // bare vg:cancel — the cancelMatch above only matches the id-suffixed form.
+  //
+  // Note: pre-#265 fix this function did `await ctx.answerCallbackQuery().catch(() => {})`
+  // unconditionally up front. That meant the `vg:keys-continue` branch's
+  // toast call (`Select at least one key.`) hit a Telegram error
+  // ("query is too old or query ID is invalid") because the query was
+  // already answered, and the toast never reached the user. Each branch
+  // now owns its own ack.
   const chatId = String(ctx.chat?.id ?? ctx.from?.id ?? '')
-  await ctx.answerCallbackQuery().catch(() => {})
+  const ackSilently = () => ctx.answerCallbackQuery().catch(() => {})
 
   // Cancel at any wizard step
   if (data === 'vg:cancel') {
@@ -5684,12 +5691,14 @@ async function handleVaultGrantCallback(ctx: Context, data: string): Promise<voi
     if (msg && 'text' in msg) {
       await ctx.editMessageText('❌ Grant wizard cancelled.').catch(() => {})
     }
+    await ackSilently()
     return
   }
 
   const state = pendingVaultOps.get(chatId)
   if (!state || state.kind !== 'grant-wizard') {
     await ctx.editMessageText('⚠️ Wizard session expired. Run /vault grant to start again.').catch(() => {})
+    await ackSilently()
     return
   }
 
@@ -5698,13 +5707,14 @@ async function handleVaultGrantCallback(ctx: Context, data: string): Promise<voi
     const agent = data.slice('vg:agent:'.length)
     const msgId = (ctx.callbackQuery.message as { message_id?: number })?.message_id ?? state.wizardMsgId
     await grantWizardStep2(ctx, chatId, agent, msgId)
+    await ackSilently()
     return
   }
 
   // vg:key:<name> — step 2 toggle
   if (data.startsWith('vg:key:')) {
     const key = data.slice('vg:key:'.length)
-    if (state.step !== 'keys') return
+    if (state.step !== 'keys') { await ackSilently(); return }
     const selectedSet = new Set(state.selectedKeys ?? [])
     if (selectedSet.has(key)) {
       selectedSet.delete(key)
@@ -5715,23 +5725,27 @@ async function handleVaultGrantCallback(ctx: Context, data: string): Promise<voi
     pendingVaultOps.set(chatId, updatedState)
     const kb = buildGrantKeysKeyboard(state.availableKeys ?? [], selectedSet)
     await ctx.editMessageReplyMarkup({ reply_markup: kb }).catch(() => {})
+    await ackSilently()
     return
   }
 
   // vg:keys-continue — step 2 → 3
   if (data === 'vg:keys-continue') {
-    if (state.step !== 'keys') return
+    if (state.step !== 'keys') { await ackSilently(); return }
     if (!state.selectedKeys || state.selectedKeys.length === 0) {
+      // Toast-only ack: this is the branch the unconditional pre-ack
+      // used to silently swallow. See #265.
       await ctx.answerCallbackQuery({ text: 'Select at least one key.' }).catch(() => {})
       return
     }
     await grantWizardStep3(ctx, chatId, state)
+    await ackSilently()
     return
   }
 
   // vg:dur:<value> — step 3 duration selection
   if (data.startsWith('vg:dur:')) {
-    if (state.step !== 'duration') return
+    if (state.step !== 'duration') { await ackSilently(); return }
     const dur = data.slice('vg:dur:'.length)
     if (dur === 'custom') {
       // Ask for text reply with n d|h format
@@ -5743,6 +5757,7 @@ async function handleVaultGrantCallback(ctx: Context, data: string): Promise<voi
           { parse_mode: 'HTML', reply_markup: buildGrantDurationKeyboard() },
         ).catch(() => {})
       }
+      await ackSilently()
       return
     }
     let ttlSeconds: number | null
@@ -5752,29 +5767,33 @@ async function handleVaultGrantCallback(ctx: Context, data: string): Promise<voi
       ttlSeconds = 365 * 86400
     } else {
       ttlSeconds = parseGrantDuration(dur)
-      if (ttlSeconds === null) return
+      if (ttlSeconds === null) { await ackSilently(); return }
     }
     const newState = { ...state, ttlSeconds, awaitingCustomDuration: false }
     await grantWizardConfirm(ctx, chatId, newState)
+    await ackSilently()
     return
   }
 
   // vg:back:duration — go back to step 2 (keys selection) from step 3
   if (data === 'vg:back:duration') {
-    if (state.step !== 'duration') return
+    if (state.step !== 'duration') { await ackSilently(); return }
     const msgId = state.wizardMsgId
     await grantWizardStep2(ctx, chatId, state.agent!, msgId)
+    await ackSilently()
     return
   }
 
   // vg:generate — final step
   if (data === 'vg:generate') {
-    if (state.step !== 'confirm') return
+    if (state.step !== 'confirm') { await ackSilently(); return }
     await executeGrantWizard(ctx, chatId, state)
+    await ackSilently()
     return
   }
 
-  // Unrecognised vg: sub-action — already answered callbackQuery above
+  // Unrecognised vg: sub-action
+  await ackSilently()
 }
 
 /**

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -4970,7 +4970,15 @@ async function runAutoFallbackCheck(opts: { trigger: 'scheduled' | 'manual' }): 
         return { kind: 'error', message: `invalid agent name: ${plan.agentName}` }
       }
       try {
-        switchroomExec(['agent', 'restart', plan.agentName])
+        // Preemptive failover (utilization-over-threshold / explicit) waits
+        // for the active turn to drain. Reactive failover (429-response)
+        // hard-restarts because the request that triggered it has already
+        // failed — there's no in-flight turn worth preserving. See #420.
+        const restartArgs = ['agent', 'restart', plan.agentName]
+        if (plan.triggerReason !== '429-response') {
+          restartArgs.push('--graceful-restart')
+        }
+        switchroomExec(restartArgs)
       } catch (err) {
         process.stderr.write(`telegram gateway: auto-fallback restart failed: ${err}\n`)
       }

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -138,8 +138,11 @@ import {
   evaluateFallbackTrigger,
   performAutoFallback,
   emptyLockout,
+  loadLockout,
   nextLockout,
+  saveLockout,
   type LockoutRecord,
+  type LockoutPersistOps,
 } from '../auto-fallback.js'
 import { markSlotQuotaExhausted } from '../../src/auth/accounts.js'
 import { fallbackToNextSlot, currentActiveSlot, type AuthCodeOutcome } from '../../src/auth/manager.js'
@@ -4927,7 +4930,38 @@ bot.command('interrupt', async ctx => {
 // Shared auto-fallback state. `lockout` is a per-process in-memory
 // guard against rapid re-fire between the scheduled poll and a
 // manual /authfallback trigger (see telegram-plugin/auto-fallback.ts).
+//
+// Pre-#417 fix this was always emptyLockout() at process start, so a
+// gateway restart inside the cooldown window reset the timer and a
+// quota-flap on the recovering slot could re-trigger fallback the
+// moment the gateway came back. We now seed from disk on first use
+// and persist on every transition. Errors are swallowed: losing the
+// lockout file just degrades to in-memory-only behaviour.
+const lockoutOps: LockoutPersistOps = {
+  readFileSync: (p, enc) => readFileSync(p, enc),
+  writeFileSync: (p, data, opts) => writeFileSync(p, data, opts),
+  existsSync: (p) => existsSync(p),
+  mkdirSync: (p, opts) => mkdirSync(p, opts),
+  joinPath: (...parts) => join(...parts),
+}
 let autoFallbackLockout: LockoutRecord = emptyLockout()
+let autoFallbackLockoutSeeded = false
+function seedAutoFallbackLockoutIfNeeded(agentDir: string): void {
+  if (autoFallbackLockoutSeeded) return
+  autoFallbackLockoutSeeded = true
+  try {
+    autoFallbackLockout = loadLockout(agentDir, lockoutOps)
+  } catch (err) {
+    process.stderr.write(`telegram gateway: auto-fallback lockout seed failed (using empty): ${(err as Error).message}\n`)
+  }
+}
+function persistLockout(agentDir: string): void {
+  try {
+    saveLockout(agentDir, autoFallbackLockout, lockoutOps)
+  } catch (err) {
+    process.stderr.write(`telegram gateway: auto-fallback lockout persist failed: ${(err as Error).message}\n`)
+  }
+}
 
 type AutoFallbackCheckResult =
   | { kind: 'no-action'; reason: string; decision: 'noop' | 'fallback-skipped' }
@@ -4939,6 +4973,7 @@ async function runAutoFallbackCheck(opts: { trigger: 'scheduled' | 'manual' }): 
   try {
     const agentDir = resolveAgentDirFromEnv()
     const agentName = getMyAgentName()
+    seedAutoFallbackLockoutIfNeeded(agentDir)
     const active = currentActiveSlot(agentDir)
     const quota = await fetchQuota({ claudeConfigDir: join(agentDir, '.claude') })
     const decision = evaluateFallbackTrigger({
@@ -4983,9 +5018,11 @@ async function runAutoFallbackCheck(opts: { trigger: 'scheduled' | 'manual' }): 
         process.stderr.write(`telegram gateway: auto-fallback restart failed: ${err}\n`)
       }
       autoFallbackLockout = nextLockout(plan.previousSlot, Date.now())
+      persistLockout(agentDir)
       return { kind: 'executed', previousSlot: plan.previousSlot, newSlot: plan.newSlot }
     }
     autoFallbackLockout = nextLockout(plan.activeSlot, Date.now())
+    persistLockout(agentDir)
     return { kind: 'exhausted-all', activeSlot: plan.activeSlot }
   } catch (err) {
     process.stderr.write(`telegram gateway: auto-fallback ${opts.trigger} poll error: ${err}\n`)

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -4077,6 +4077,35 @@ function stampUserRestartReason(reason: string): void {
  * fail-fast CLI errors to the Telegram user instead of silently
  * swallowing them into detached-spawn.log.
  */
+/**
+ * Detect whether `systemd-run --user` is callable. Cached for the
+ * process lifetime — the answer is essentially fixed by the host OS.
+ *
+ * When available, `spawnSwitchroomDetached` wraps every spawn through
+ * `systemd-run --user --scope --collect` so the spawned child escapes
+ * the gateway's cgroup. Without this escape, restarting the gateway
+ * cgroup-kills the in-flight child mid-restart, and the agent service
+ * never actually restarts (#177).
+ *
+ * `--scope` makes a transient scope unit (lives in its own cgroup,
+ * doesn't trigger the spawn-supervised semantics of `--service`).
+ * `--collect` auto-removes the unit when it exits so we don't
+ * accumulate transient units.
+ */
+let _systemdRunPath: string | null | undefined
+function resolveSystemdRunPath(): string | null {
+  if (_systemdRunPath !== undefined) return _systemdRunPath
+  // Try `command -v systemd-run` via execSync; on missing-binary or
+  // a non-systemd box we set null and fall back to direct spawn.
+  try {
+    const out = execSync('command -v systemd-run 2>/dev/null', { encoding: 'utf-8' }).trim()
+    _systemdRunPath = out.length > 0 ? out : null
+  } catch {
+    _systemdRunPath = null
+  }
+  return _systemdRunPath
+}
+
 function spawnSwitchroomDetached(
   args: string[],
   onFailure?: (info: { code: number; tail: string }) => void,
@@ -4089,7 +4118,16 @@ function spawnSwitchroomDetached(
     outFd = openSync(logPath, 'a')
     writeFileSync(logPath, `\n[${new Date().toISOString()}] spawn ${SWITCHROOM_CLI} ${fullArgs.join(' ')}\n`, { flag: 'a' })
   } catch {}
-  const child = spawn(SWITCHROOM_CLI, fullArgs, {
+  // Escape the gateway's cgroup via systemd-run --scope when available.
+  // Without this, a gateway service restart (e.g. triggered as part of
+  // the detached child's own work) cgroup-kills the child mid-flight.
+  // See #177.
+  const systemdRun = resolveSystemdRunPath()
+  const spawnBin = systemdRun ?? SWITCHROOM_CLI
+  const spawnArgs = systemdRun
+    ? ['--user', '--scope', '--collect', '--quiet', '--', SWITCHROOM_CLI, ...fullArgs]
+    : fullArgs
+  const child = spawn(spawnBin, spawnArgs, {
     detached: true,
     stdio: outFd != null ? ['ignore', outFd, outFd] : 'ignore',
     env: { ...process.env, FORCE_COLOR: '0', NO_COLOR: '1' },

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -6810,6 +6810,15 @@ async function shutdown(signal: string): Promise<void> {
   subagentWatcher?.stop()
   subagentWatcher = null
 
+  // Issues watcher polls issues.jsonl on a setInterval (default 2s) and
+  // edits the issues card on every tick. Without an explicit stop() the
+  // poll keeps firing for the lifetime of the process and accumulates
+  // editMessageText calls during shutdown drain — log noise plus a
+  // genuine resource leak if the gateway runs long after the bridge
+  // disconnected. Mirrors the subagentWatcher pattern above.
+  activeIssuesWatcher?.stop()
+  activeIssuesWatcher = null
+
   for (const iv of [...typingIntervals.values()]) clearInterval(iv)
   typingIntervals.clear()
   for (const t of [...typingRetryTimers.values()]) clearTimeout(t)

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -202,6 +202,7 @@ import { shouldSkipDuplicateBootCard, type RestartReason } from './boot-card.js'
 import { createIssuesCardHandle, type IssuesCardHandle } from '../issues-card.js'
 import { startIssuesWatcher, type IssuesWatcherHandle } from '../issues-watcher.js'
 import { list as listIssues, resolve as resolveIssue } from '../../src/issues/index.js'
+import { summarizeToolForTitle } from '../permission-title.js'
 import {
   VERSION,
   COMMIT_SHA,
@@ -1514,7 +1515,10 @@ const ipcServer: IpcServer = createIpcServer({
     const { requestId, toolName, description, inputPreview } = msg
     pendingPermissions.set(requestId, { tool_name: toolName, description, input_preview: inputPreview, startedAt: Date.now() })
     const access = loadAccess()
-    const text = `🔐 Permission: ${toolName}`
+    // Lift the most-identifying field into the title so the user can
+    // approve at a glance — e.g. `Skill (mail)` instead of bare `Skill`.
+    // See #186.
+    const text = `🔐 Permission: ${summarizeToolForTitle(toolName, inputPreview)}`
     const keyboard = new InlineKeyboard()
       .text('See more', `perm:more:${requestId}`)
       .text('✅ Allow', `perm:allow:${requestId}`)
@@ -7092,6 +7096,21 @@ if (streamMode === 'checklist') {
       process.stderr.write(`telegram gateway: progress-card: onTurnComplete callback turnKey=${turnKey}\n`)
       pinMgr.completeTurn({ chatId, threadId, turnKey })
       pinWatchdog.clear(turnKey)
+      // Clean up silent-end-pending.json once the turn delivered for real.
+      // Without this, the file lingers between sessions and the Stop hook
+      // can read a stale `retryCount` from a long-resolved turn. See #289.
+      try {
+        const statePath = join(STATE_DIR, 'silent-end-pending.json')
+        if (existsSync(statePath)) {
+          const prev = JSON.parse(readFileSync(statePath, 'utf8'))
+          if (prev.turnKey === turnKey) {
+            unlinkSync(statePath)
+          }
+        }
+      } catch {
+        // Best-effort: a stale file or vanished mid-read is fine — the
+        // hook will re-create it on the next silent-end if needed.
+      }
       if (threadId != null) {
         lockedBot.api.sendMessage(chatId, `✅ Done — ${summary}`).catch((err: Error) => {
           process.stderr.write(`telegram gateway: completion message failed: ${err.message}\n`)

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -207,6 +207,12 @@ import { startIssuesWatcher, type IssuesWatcherHandle } from '../issues-watcher.
 import { list as listIssues, resolve as resolveIssue } from '../../src/issues/index.js'
 import { summarizeToolForTitle } from '../permission-title.js'
 import {
+  readClaudeJsonOverage,
+  evaluateCreditState,
+  loadCreditState,
+  saveCreditState,
+} from '../credits-watch.js'
+import {
   VERSION,
   COMMIT_SHA,
   COMMIT_DATE,
@@ -5068,6 +5074,56 @@ async function runAutoFallbackCheck(opts: { trigger: 'scheduled' | 'manual' }): 
   }
 }
 
+/**
+ * Credit-exhaustion watcher loop body (#348). Reads the agent's
+ * `.claude.json` for `cachedExtraUsageDisabledReason`, evaluates the
+ * transition against the last-notified state, and emits a Telegram
+ * message via the existing access.allowFrom path when the state
+ * crosses a fatal-billing boundary.
+ *
+ * Idempotent: if the state hasn't changed since the last check, no
+ * message is sent. State persists across gateway restarts via
+ * `<stateDir>/credits-watch.json` so a restart inside an out-of-credits
+ * window doesn't re-spam the user.
+ */
+async function runCreditWatch(): Promise<void> {
+  const agentDir = resolveAgentDirFromEnv()
+  const agentName = getMyAgentName()
+  const claudeConfigDir = join(agentDir, '.claude')
+  const stateDir = STATE_DIR
+  const reason = readClaudeJsonOverage(claudeConfigDir)
+  const prev = loadCreditState(stateDir)
+  const decision = evaluateCreditState({
+    agentName,
+    currentReason: reason,
+    prev,
+    now: Date.now(),
+  })
+  if (decision.kind === 'skip') {
+    return
+  }
+  // Notify path. Send to all configured allowFrom chats — the
+  // assumption mirrors auto-fallback's notification routing.
+  const access = loadAccess()
+  for (const chat_id of access.allowFrom) {
+    try {
+      await bot.api.sendMessage(chat_id, decision.message, {
+        parse_mode: 'HTML',
+        link_preview_options: { is_disabled: true },
+      })
+    } catch (err) {
+      process.stderr.write(`telegram gateway: credit-watch notify chat=${chat_id} failed: ${err}\n`)
+    }
+  }
+  // Persist state regardless of whether send succeeded — losing a
+  // notify is bad, but re-spamming on every poll tick is worse.
+  try {
+    saveCreditState(stateDir, decision.newState)
+  } catch (err) {
+    process.stderr.write(`telegram gateway: credit-watch state persist failed: ${err}\n`)
+  }
+}
+
 bot.command('authfallback', async ctx => {
   if (!isAuthorizedSender(ctx)) return
   const result = await runAutoFallbackCheck({ trigger: 'manual' })
@@ -7594,6 +7650,31 @@ void (async () => {
         const AUTO_FALLBACK_POLL_MS = Number(process.env.SWITCHROOM_AUTO_FALLBACK_POLL_MS ?? 60 * 60_000)
         if (AUTO_FALLBACK_POLL_MS > 0) {
           setInterval(() => { void runAutoFallbackCheck({ trigger: 'scheduled' }) }, AUTO_FALLBACK_POLL_MS).unref()
+        }
+
+        // Credit-exhaustion watcher (#348). Reads `<agentDir>/.claude/.claude.json`
+        // for `cachedExtraUsageDisabledReason`. Fires a Telegram notification
+        // on transition into / out of fatal billing states (out_of_credits,
+        // org_level_disabled, credits_exhausted, extra_usage_disabled).
+        // Pre-#348, cron tasks against an exhausted account silently failed
+        // because stdout was discarded — direct violation of P1 JTBD (silent
+        // failure is the worst case).
+        //
+        // Cadence: 15 min by default; tuned to be cheaper than the API
+        // quota poll because this is a local file read (no network).
+        // SWITCHROOM_CREDIT_WATCH_POLL_MS=0 disables.
+        const CREDIT_WATCH_POLL_MS = Number(process.env.SWITCHROOM_CREDIT_WATCH_POLL_MS ?? 15 * 60_000)
+        if (CREDIT_WATCH_POLL_MS > 0) {
+          // Run an immediate check at boot so a recent fatal transition
+          // doesn't have to wait 15 min to surface.
+          void runCreditWatch().catch((err) => {
+            process.stderr.write(`telegram gateway: credit-watch initial run failed: ${err}\n`)
+          })
+          setInterval(() => {
+            void runCreditWatch().catch((err) => {
+              process.stderr.write(`telegram gateway: credit-watch scheduled run failed: ${err}\n`)
+            })
+          }, CREDIT_WATCH_POLL_MS).unref()
         }
 
         // Restart-watchdog: poll systemd's NRestarts for the agent unit.

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -201,6 +201,7 @@ import { determineRestartReason } from './boot-reason.js'
 import { shouldSkipDuplicateBootCard, type RestartReason } from './boot-card.js'
 import { createIssuesCardHandle, type IssuesCardHandle } from '../issues-card.js'
 import { startIssuesWatcher, type IssuesWatcherHandle } from '../issues-watcher.js'
+import { list as listIssues, resolve as resolveIssue } from '../../src/issues/index.js'
 import {
   VERSION,
   COMMIT_SHA,
@@ -6263,11 +6264,10 @@ bot.command('issues', async ctx => {
     try {
       const stateDir = process.env.TELEGRAM_STATE_DIR
       if (stateDir) {
-        const { list, resolve: resolveOne } = require('../../src/issues/index.js') as typeof import('../../src/issues/index.js')
-        const events = list(stateDir)
+        const events = listIssues(stateDir)
         let n = 0
         for (const e of events) {
-          n += resolveOne(stateDir, e.fingerprint)
+          n += resolveIssue(stateDir, e.fingerprint)
         }
         await switchroomReply(ctx, `Resolved ${n} issue${n === 1 ? '' : 's'}.`, { html: true })
         return

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -3724,15 +3724,23 @@ async function handleInbound(
     // so the user sees a real "I'm working" signal, not three dots that
     // could read as "still loading the message." Hooks can refine this
     // mid-turn via the `update_placeholder` IPC message.
+    // #479 fix: drop the DM-only gate so non-forum group chats also get
+    // the 🔵 thinking… placeholder within ~1s. Pre-fix the placeholder UX
+    // was locked to DMs even though sendMessageDraft works in groups —
+    // exactly the population (groups, including the standard switchroom
+    // forum-topic layout) that reported "feels dead until the status
+    // card appears." Forum topics still excluded via the messageThreadId
+    // guard because sendMessageDraft doesn't accept message_thread_id;
+    // forum-topic placeholder needs a separate path (out of scope here).
     if (
       sendMessageDraftFn != null
-      && isDmChatId(chat_id)
       && messageThreadId == null
       && !preAllocatedDrafts.has(chat_id)
     ) {
       const draftId = allocateDraftId()
       // Best-effort, non-blocking: any failure (transport down, API not
-      // available) falls through to today's behavior.
+      // available, group rejects sendMessageDraft) falls through to
+      // today's behavior — the existing .catch already silently logs.
       void sendMessageDraftFn(chat_id, draftId, '🔵 thinking…')
         .then(() => {
           preAllocatedDrafts.set(chat_id, { draftId, allocatedAt: Date.now() })

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -639,7 +639,16 @@ try {
         `SWITCHROOM_PENDING_ENDED_VIA=${pending.ended_via ?? 'unknown'}`,
         `SWITCHROOM_PENDING_STARTED_AT=${pending.started_at}`,
       ]
-      writeFileSync(pendingEnvPath, lines.join('\n') + '\n', { mode: 0o600 })
+      // Atomic write: tmp + rename. Without this, a crash mid-write
+      // (power loss, OOM, panic) leaves a truncated `.pending-turn.env`
+      // that start.sh `source`s — partial SWITCHROOM_PENDING_* vars
+      // half-trigger the resume protocol with incomplete context, or
+      // a malformed line breaks shell parsing inside the source.
+      // Same pattern used by the access-file write a few hundred lines
+      // above and by src/issues/store.ts.
+      const pendingEnvTmp = `${pendingEnvPath}.tmp-${process.pid}`
+      writeFileSync(pendingEnvTmp, lines.join('\n') + '\n', { mode: 0o600 })
+      renameSync(pendingEnvTmp, pendingEnvPath)
       process.stderr.write(`telegram gateway: pending-turn env written to ${pendingEnvPath} turnKey=${pending.turn_key} endedVia=${pending.ended_via ?? 'open'}\n`)
     } else if (existsSync(pendingEnvPath)) {
       rmSync(pendingEnvPath, { force: true })
@@ -2213,11 +2222,13 @@ async function executeDownloadAttachment(args: Record<string, unknown>): Promise
   }
   const file = await bot.api.getFile(file_id)
   if (!file.file_path) throw new Error('Telegram returned no file_path — file may have expired')
-  // Build download URL — token is embedded but NEVER included in error messages
+  // Build download URL — token is embedded but NEVER included in error messages.
+  // Bounded fetch (30s) — without a timeout, the agent's tool_call hangs
+  // indefinitely on a stalled CDN connection.
   const downloadUrl = `https://api.telegram.org/file/bot${TOKEN}/${file.file_path}`
   let res: Response
   try {
-    res = await fetch(downloadUrl)
+    res = await fetch(downloadUrl, { signal: AbortSignal.timeout(30_000) })
   } catch (err) {
     // Sanitize: never leak the token in network error messages
     throw new Error(`download failed: network error`)
@@ -6487,9 +6498,15 @@ bot.on('message:photo', async ctx => {
       const file = await ctx.api.getFile(best.file_id)
       if (!file.file_path) return undefined
       // Build download URL — token is embedded in the URL but never exposed
-      // in error messages or logs (caught and sanitized below)
+      // in error messages or logs (caught and sanitized below).
+      //
+      // Bounded fetch: a stalled Telegram CDN connection without a
+      // timeout would hang the entire inbound handler, blocking the
+      // user's photo from ever being acked or seen by the agent.
+      // 15s is generous for normal photos (typical 100ms-2s) and
+      // tight enough to surface a real outage.
       const downloadUrl = `https://api.telegram.org/file/bot${TOKEN}/${file.file_path}`
-      const res = await fetch(downloadUrl)
+      const res = await fetch(downloadUrl, { signal: AbortSignal.timeout(15_000) })
       if (!res.ok) {
         process.stderr.write(`telegram gateway: photo download failed: HTTP ${res.status}\n`)
         return undefined

--- a/telegram-plugin/gateway/turn-active-marker.ts
+++ b/telegram-plugin/gateway/turn-active-marker.ts
@@ -1,0 +1,101 @@
+/**
+ * Turn-active liveness marker (#412).
+ *
+ * Writes `<STATE_DIR>/turn-active.json` on turn_start, touches its mtime
+ * on every tool_use, removes it on turn_complete. The watchdog
+ * (bin/bridge-watchdog.sh) reads the mtime: if the file exists AND its
+ * mtime is older than TURN_HANG_SECS (default 300s = 5min), the agent
+ * is wedged mid-turn and the watchdog restarts.
+ *
+ * Why this exists: PR #410 raised the journal-silence detector to 4000s
+ * to kill false positives on chat-cadence agents that legitimately
+ * idle for hours between turns. That left a gap — Stop-hook deadlocks
+ * (the original failure mode #116 tracked) are no longer caught under
+ * default thresholds.
+ *
+ * The distinguisher is "in-turn-and-silent" vs "between-turns-and-silent":
+ * the former is a wedge, the latter is healthy idle. This marker exists
+ * exactly during in-turn windows, so its staleness uniquely indicates
+ * the wedge.
+ *
+ * Pure file I/O. The actual hang-detection-and-restart loop lives in the
+ * bash watchdog, where it composes with the existing
+ * Restart=on-failure / journal-silence / bridge-disconnect detectors.
+ */
+
+import {
+  closeSync,
+  existsSync,
+  mkdirSync,
+  openSync,
+  unlinkSync,
+  utimesSync,
+  writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
+
+export const TURN_ACTIVE_MARKER_FILE = "turn-active.json";
+
+export interface TurnActiveMarker {
+  turnKey: string;
+  chatId: string;
+  threadId?: string | null;
+  startedAt: number;
+}
+
+/**
+ * Write the marker file at turn-start. Idempotent — if the file
+ * already exists from a stale prior turn (unlikely; turn_complete
+ * removes it), the new write wins.
+ */
+export function writeTurnActiveMarker(stateDir: string, marker: TurnActiveMarker): void {
+  try {
+    mkdirSync(stateDir, { recursive: true });
+    writeFileSync(
+      join(stateDir, TURN_ACTIVE_MARKER_FILE),
+      JSON.stringify(marker, null, 2) + "\n",
+      { mode: 0o600 },
+    );
+  } catch {
+    // Best-effort: marker file is a watchdog optimisation, not a
+    // correctness requirement. Don't break the turn-start path on
+    // disk-full, ENOSPC, etc.
+  }
+}
+
+/**
+ * Touch the marker file's mtime. Called on every tool_use event so an
+ * agent doing real work continually advances the mtime. The watchdog's
+ * threshold compares against this mtime.
+ */
+export function touchTurnActiveMarker(stateDir: string): void {
+  const path = join(stateDir, TURN_ACTIVE_MARKER_FILE);
+  if (!existsSync(path)) return;
+  const now = new Date();
+  try {
+    utimesSync(path, now, now);
+  } catch {
+    // utimesSync can fail on some filesystems; fall back to a tiny
+    // open-close cycle to bump the mtime via writes from the kernel side.
+    try {
+      const fd = openSync(path, "r+");
+      closeSync(fd);
+    } catch {
+      /* swallow — best-effort */
+    }
+  }
+}
+
+/**
+ * Remove the marker file at turn_complete. Absence of the file is the
+ * watchdog's signal that no turn is in flight (legitimate idle, no
+ * reason to suspect a hang).
+ */
+export function removeTurnActiveMarker(stateDir: string): void {
+  try {
+    unlinkSync(join(stateDir, TURN_ACTIVE_MARKER_FILE));
+  } catch {
+    // ENOENT is fine (already removed); other errors don't justify
+    // breaking the turn-end path.
+  }
+}

--- a/telegram-plugin/hooks/hooks.json
+++ b/telegram-plugin/hooks/hooks.json
@@ -1,0 +1,58 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/secret-guard-pretool.mjs\"",
+            "timeout": 10
+          }
+        ]
+      },
+      {
+        "matcher": "^(Agent|Task)$",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/subagent-tracker-pretool.mjs\"",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "^(Agent|Task)$",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/subagent-tracker-posttool.mjs\"",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/secret-scrub-stop.mjs\"",
+            "timeout": 15,
+            "async": true
+          }
+        ]
+      },
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/silent-end-interrupt-stop.mjs\"",
+            "timeout": 5
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/telegram-plugin/hooks/subagent-tracker-posttool.mjs
+++ b/telegram-plugin/hooks/subagent-tracker-posttool.mjs
@@ -233,8 +233,12 @@ function main() {
     process.exit(0)
   }
 
-  // Only care about Agent tool calls
-  if (event.tool_name !== 'Agent') process.exit(0)
+  // Only care about sub-agent dispatches. Claude Code emits the dispatch
+  // tool under either the legacy name 'Agent' or the newer 'Task'
+  // depending on version. The matching session-tail / progress-card /
+  // tool-label code paths already recognize both. See pretool hook for
+  // detail.
+  if (event.tool_name !== 'Agent' && event.tool_name !== 'Task') process.exit(0)
 
   const id = event.tool_use_id ?? null
   if (!id) process.exit(0)

--- a/telegram-plugin/hooks/subagent-tracker-pretool.mjs
+++ b/telegram-plugin/hooks/subagent-tracker-pretool.mjs
@@ -174,8 +174,15 @@ function main() {
     process.exit(0)
   }
 
-  // Only care about Agent tool calls
-  if (event.tool_name !== 'Agent') process.exit(0)
+  // Only care about sub-agent dispatches. Claude Code emits the dispatch
+  // tool under either the legacy name 'Agent' or the newer 'Task'
+  // depending on version. Other call sites in this codebase (session-tail.ts,
+  // progress-card.ts, pty-tail.ts, tool-labels.ts) already recognize both —
+  // these tracker hooks were the lone gate accepting only 'Agent', which
+  // would silently drop every dispatch on any Claude Code version emitting
+  // 'Task' (rows never inserted → progress card heuristic + watcher both
+  // misroute).
+  if (event.tool_name !== 'Agent' && event.tool_name !== 'Task') process.exit(0)
 
   const agentDir = process.env.SWITCHROOM_AGENT_DIR ?? process.cwd()
   const telegramDir = join(agentDir, 'telegram')

--- a/telegram-plugin/issues-card.ts
+++ b/telegram-plugin/issues-card.ts
@@ -155,19 +155,57 @@ export interface CreateIssuesCardOpts {
   log?: (msg: string) => void;
 }
 
+/**
+ * Inspect an error thrown by a grammY API call and, if it's a 429
+ * flood-wait, return the retry_after value in seconds. Returns null
+ * for any non-429 error (or non-grammY shape). We avoid importing
+ * `GrammyError` directly to keep this module test-friendly — duck-typing
+ * on the documented public field shape suffices for our needs.
+ *
+ * See #442.
+ */
+function extractRetryAfterSecs(err: unknown): number | null {
+  if (err == null || typeof err !== "object") return null;
+  const e = err as { error_code?: unknown; parameters?: { retry_after?: unknown } };
+  if (e.error_code !== 429) return null;
+  const ra = e.parameters?.retry_after;
+  if (typeof ra === "number" && Number.isFinite(ra) && ra > 0) return ra;
+  return null;
+}
+
+const COOLDOWN_JITTER_MS = 500;
+
 export function createIssuesCardHandle(
   opts: CreateIssuesCardOpts,
 ): IssuesCardHandle {
   let messageId: number | null = null;
   let lastBody: string | null = null;
+  // Cooldown gate: when we hit a 429, suspend further refreshes until
+  // retry_after elapses. The watcher polls every 2s; without this gate
+  // we'd burn through grammY's auto-retry budget and risk a bot-wide
+  // 24h ban under sustained issue-flapping. See #442.
+  let cooldownUntil = 0;
   const log = opts.log ?? (() => {});
   const nowFn = opts.now ?? Date.now;
+
+  function noteRateLimited(err: unknown, label: string): void {
+    const retryAfter = extractRetryAfterSecs(err);
+    if (retryAfter == null) return;
+    cooldownUntil = nowFn() + retryAfter * 1000 + COOLDOWN_JITTER_MS;
+    log(
+      `issues-card: ${label} 429 — backing off ${retryAfter}s (cooldown until ${cooldownUntil})`,
+    );
+  }
 
   return {
     messageId() {
       return messageId;
     },
     async refresh(events: IssueEvent[]) {
+      // Honour Telegram's flood-wait. Skipping a refresh is cheap;
+      // burning through the wait is what gets bots banned.
+      if (nowFn() < cooldownUntil) return;
+
       const body = renderIssuesCard({
         agentName: opts.agentName,
         events,
@@ -181,6 +219,7 @@ export function createIssuesCardHandle(
           try {
             await opts.bot.deleteMessage(opts.chatId, messageId);
           } catch (err) {
+            noteRateLimited(err, "delete");
             log(`issues-card: delete failed: ${(err as Error).message}`);
           }
           messageId = null;
@@ -205,6 +244,7 @@ export function createIssuesCardHandle(
           messageId = sent.message_id;
           lastBody = body;
         } catch (err) {
+          noteRateLimited(err, "send");
           log(`issues-card: send failed: ${(err as Error).message}`);
         }
         return;
@@ -214,16 +254,22 @@ export function createIssuesCardHandle(
         await opts.bot.editMessageText(opts.chatId, messageId, body, sendOpts);
         lastBody = body;
       } catch (err) {
+        noteRateLimited(err, "edit");
         // The card's message_id is stale (manually deleted, edit window
         // expired, etc.). Re-post fresh on the next tick.
         log(`issues-card: edit failed, re-posting: ${(err as Error).message}`);
         messageId = null;
         lastBody = null;
+        // If we've just been told to back off, don't double-down by
+        // immediately re-posting — let the cooldown gate above pick
+        // up the next call.
+        if (nowFn() < cooldownUntil) return;
         try {
           const sent = await opts.bot.sendMessage(opts.chatId, body, sendOpts);
           messageId = sent.message_id;
           lastBody = body;
         } catch (err2) {
+          noteRateLimited(err2, "re-post");
           log(`issues-card: re-post failed: ${(err2 as Error).message}`);
         }
       }

--- a/telegram-plugin/issues-watcher.ts
+++ b/telegram-plugin/issues-watcher.ts
@@ -86,6 +86,15 @@ export function startIssuesWatcher(
       log(`issues-watcher: tick failed: ${(err as Error).message}`);
     });
   }, intervalMs);
+  // Defense in depth: don't let the watcher itself keep the process
+  // alive. The gateway has other ref'd resources (bot polling, IPC
+  // socket listener) that own the process lifecycle. If those go
+  // away, this watcher should NOT block exit.
+  // `unref()` is a no-op in test runners that pass a fake setInterval
+  // returning a non-Timer value; guard with optional chaining.
+  if (typeof (timer as { unref?: () => void }).unref === "function") {
+    (timer as { unref: () => void }).unref();
+  }
 
   return {
     stop() {

--- a/telegram-plugin/issues-watcher.ts
+++ b/telegram-plugin/issues-watcher.ts
@@ -31,8 +31,10 @@ export interface IssuesWatcherOpts {
   /** Inject for tests. */
   setInterval?: typeof setInterval;
   clearInterval?: typeof clearInterval;
-  /** Inject for tests. Defaults to fs.statSync(...).mtimeMs. */
-  mtimeProvider?: (path: string) => number | null;
+  /** Inject for tests. Defaults to a "<mtimeMs>:<size>" signature from
+   * fs.statSync. Combining mtime + size makes the watcher robust to two
+   * writes inside the same millisecond — the bug from #446. */
+  signatureProvider?: (path: string) => string | null;
   /** Inject for tests. Defaults to readAll from src/issues. */
   readEvents?: (stateDir: string) => IssueEvent[];
 }
@@ -52,10 +54,10 @@ export function startIssuesWatcher(
   const intervalMs = opts.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
   const setIntervalFn = opts.setInterval ?? setInterval;
   const clearIntervalFn = opts.clearInterval ?? clearInterval;
-  const mtimeProvider = opts.mtimeProvider ?? defaultMtimeProvider;
+  const signatureProvider = opts.signatureProvider ?? defaultSignatureProvider;
   const readEvents = opts.readEvents ?? defaultReadEvents;
 
-  let lastMtime: number | null = null;
+  let lastSignature: string | null = null;
   let stopped = false;
 
   async function readAndRefresh(): Promise<void> {
@@ -69,9 +71,9 @@ export function startIssuesWatcher(
 
   async function tick(): Promise<void> {
     if (stopped) return;
-    const mtime = mtimeProvider(path);
-    if (mtime === lastMtime) return;
-    lastMtime = mtime;
+    const signature = signatureProvider(path);
+    if (signature === lastSignature) return;
+    lastSignature = signature;
     await readAndRefresh();
   }
 
@@ -106,10 +108,13 @@ export function startIssuesWatcher(
   };
 }
 
-function defaultMtimeProvider(path: string): number | null {
+function defaultSignatureProvider(path: string): string | null {
   if (!existsSync(path)) return null;
   try {
-    return statSync(path).mtimeMs;
+    const stat = statSync(path);
+    // Combine mtime + size so two writes within the same ms (which would
+    // share an mtimeMs value) still register as a change. See #446.
+    return `${stat.mtimeMs}:${stat.size}`;
   } catch {
     return null;
   }

--- a/telegram-plugin/permission-title.ts
+++ b/telegram-plugin/permission-title.ts
@@ -1,0 +1,89 @@
+/**
+ * Build a human-readable title for the inline-keyboard permission
+ * approval message. Pre-fix the title was always `🔐 Permission:
+ * ${toolName}` — for a `Skill` or `Bash` call the user couldn't tell
+ * which skill / command was being approved without tapping "See more".
+ *
+ * The detail surfaces (the expanded view at server.ts/gateway.ts) still
+ * render the full description + input_preview block; this helper just
+ * lifts the most identifying field into the title so the user can
+ * approve at a glance.
+ *
+ * See #186.
+ */
+
+import { basename } from "node:path";
+
+const COMMAND_TITLE_MAX = 40;
+const PATH_TITLE_MAX = 40;
+
+/**
+ * Build a title fragment for a permission prompt. Returns the toolName
+ * for any tool we don't recognise — the helper is intentionally
+ * conservative: better to keep the bare name than render gibberish from
+ * a malformed input_preview.
+ */
+export function summarizeToolForTitle(
+  toolName: string,
+  inputPreview: string | undefined,
+): string {
+  const input = parseInput(inputPreview);
+  if (!input) return toolName;
+
+  switch (toolName) {
+    case "Skill": {
+      const skill = readString(input, "skill");
+      return skill ? `${toolName} (${skill})` : toolName;
+    }
+    case "Bash": {
+      const command = readString(input, "command");
+      return command ? `${toolName}: ${truncate(command, COMMAND_TITLE_MAX)}` : toolName;
+    }
+    case "Read":
+    case "Edit":
+    case "Write":
+    case "MultiEdit":
+    case "NotebookEdit": {
+      const filePath = readString(input, "file_path") ?? readString(input, "notebook_path");
+      return filePath ? `${toolName}: ${truncate(basename(filePath), PATH_TITLE_MAX)}` : toolName;
+    }
+    case "Glob":
+    case "Grep": {
+      const pattern = readString(input, "pattern");
+      return pattern ? `${toolName}: ${truncate(pattern, COMMAND_TITLE_MAX)}` : toolName;
+    }
+    case "WebFetch":
+    case "WebSearch": {
+      const query = readString(input, "url") ?? readString(input, "query");
+      return query ? `${toolName}: ${truncate(query, COMMAND_TITLE_MAX)}` : toolName;
+    }
+    default:
+      return toolName;
+  }
+}
+
+function parseInput(raw: string | undefined): Record<string, unknown> | null {
+  if (!raw || typeof raw !== "string") return null;
+  const trimmed = raw.trim();
+  if (!trimmed.startsWith("{")) return null;
+  try {
+    const parsed = JSON.parse(trimmed);
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      return parsed as Record<string, unknown>;
+    }
+  } catch {
+    /* fall through */
+  }
+  return null;
+}
+
+function readString(input: Record<string, unknown>, key: string): string | null {
+  const value = input[key];
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+function truncate(text: string, max: number): string {
+  const collapsed = text.replace(/\s+/g, " ").trim();
+  if (collapsed.length <= max) return collapsed;
+  return collapsed.slice(0, max - 1) + "…";
+}

--- a/telegram-plugin/progress-card-driver.ts
+++ b/telegram-plugin/progress-card-driver.ts
@@ -206,6 +206,22 @@ export interface ProgressDriverConfig {
    */
   promoteOnSubAgent?: boolean
   /**
+   * Promote the card out of initial-delay suppression once the agent has
+   * issued this many parent-side tool calls in the suppression window.
+   * Closes #478 — the user sees no progress card for the first 30s of a
+   * substantial turn that does parent-side work (Read/Grep/Bash/Edit)
+   * but never dispatches a sub-agent.
+   *
+   * Symmetric to `promoteOnSubAgent`. Default 3: a turn with ≥3 tool
+   * calls is not "short" by any reasonable definition, so the
+   * fast-turn suppression goal (no clutter on quick replies) still
+   * holds. Set to a large value (e.g. 999) to effectively disable.
+   *
+   * Fast-turn suppression in `flush()` is unchanged — if the turn
+   * ends before promotion, the card still skips the emit.
+   */
+  promoteOnParentToolCount?: number
+  /**
    * Number of consecutive 4xx Telegram API failures on card edits before
    * the card is marked terminal and all further edits are suppressed for
    * this turn. Transient (5xx/network) errors and "message is not modified"
@@ -629,6 +645,7 @@ export function createProgressDriver(config: ProgressDriverConfig): ProgressDriv
   const maxIdleMs = config.maxIdleMs ?? 30 * 60_000
   const initialDelayMs = config.initialDelayMs ?? 30_000
   const promoteOnSubAgent = config.promoteOnSubAgent ?? true
+  const promoteOnParentToolCount = config.promoteOnParentToolCount ?? 3
   const maxConsecutive4xx = config.maxConsecutive4xx ?? 3
   const orphanPromotionMs = config.orphanPromotionMs ?? 5_000
   const coldSubAgentThresholdMs = config.coldSubAgentThresholdMs ?? 30_000
@@ -1564,6 +1581,23 @@ export function createProgressDriver(config: ProgressDriverConfig): ProgressDriv
         && !chatState.apiFailures.terminal
       ) {
         promoteFirstEmit(chatState, 'sub_agent_started')
+      }
+
+      // #478: promote the card when the agent has issued enough parent-
+      // side tool calls during the suppression window. The previous
+      // logic only promoted on sub-agent dispatch, so a turn that did
+      // 5 Read/Grep/Bash calls in 30s never showed a card — user saw
+      // typing-indicator-only and described it as "feels dead." A turn
+      // with ≥3 parent tools is not "short" by any reasonable
+      // definition, so this doesn't regress the fast-turn-suppression
+      // goal (which continues to fire in flush() for sub-3-tool turns).
+      if (
+        chatState.isFirstEmit
+        && chatState.deferredFirstEmitTimer !== DELAY_ELAPSED
+        && !chatState.apiFailures.terminal
+        && chatState.state.items.length >= promoteOnParentToolCount
+      ) {
+        promoteFirstEmit(chatState, `parent_tool_count_${chatState.state.items.length}`)
       }
 
       // Issue #132: track whether the agent has called `reply` or

--- a/telegram-plugin/progress-card-driver.ts
+++ b/telegram-plugin/progress-card-driver.ts
@@ -741,7 +741,20 @@ export function createProgressDriver(config: ProgressDriverConfig): ProgressDriv
   function prepareSilentEndSuppression(cs: PerChatState): void {
     if (cs.silentEndPrepared) return
     cs.silentEndPrepared = true
-    const isSilentEnd = !cs.replyToolCalled && !cs.wasAutonomous
+    // #371 fix: when stream_reply(done=true) lands as the final tool call,
+    // the Stop hook can fire before session-tail observes the matching
+    // tool_use event. Pre-fix replyToolCalled stayed false long enough for
+    // isSilentEnd to read true → the silent-end retry kicks in → the user
+    // sees a duplicate reply.
+    //
+    // outboundDeliveredCount is bumped synchronously by
+    // recordOutboundDelivered() inside the stream_reply MCP handler when
+    // the API call returns successfully — it doesn't depend on the
+    // session-tail event landing. Consulting it here closes the race.
+    const isSilentEnd =
+      !cs.replyToolCalled
+      && cs.outboundDeliveredCount === 0
+      && !cs.wasAutonomous
     if (!isSilentEnd || !config.onSilentEnd) return
     try {
       const result = config.onSilentEnd({ chatId: cs.chatId, threadId: cs.threadId, turnKey: cs.turnKey })

--- a/telegram-plugin/progress-card.ts
+++ b/telegram-plugin/progress-card.ts
@@ -1294,7 +1294,13 @@ function renderNarrativeChecklist(
         lines.push(`${STEP_ACTIVE} <b>${escapeHtml(step.text)}</b> <i>(${dur})</i>`)
       }
     } else {
-      lines.push(`${STEP_DONE} <s>${escapeHtml(step.text)}</s>`)
+      // #320: drop the <s>...</s> wrap on done items. Telegram desktop
+      // renders strikethrough with a salmon/red strike-line in both
+      // light and dark themes — users read it as "deleted/failed/error",
+      // not "done". The leading STEP_DONE bullet (●) + the symbol
+      // distinction (vs ◉ for active) + bold-vs-plain weight already
+      // signal completion without the alarm. See #320 Option A.
+      lines.push(`${STEP_DONE} ${escapeHtml(step.text)}`)
     }
   }
 }
@@ -1339,6 +1345,13 @@ function renderMainItem(
     }
     const dur = formatDuration(item.finishedAt - item.startedAt)
     const needsDuration = item.finishedAt - item.startedAt >= 1000
+    // #320: no <s> wrap on done items here either. The symbol
+    // distinction (● vs ◉) + the bold-vs-plain treatment already
+    // differentiate done from active; strikethrough renders red in
+    // Telegram desktop and reads as "deleted/failed". See #320
+    // Option A — this aligns the rolled-card path with the
+    // narrative-checklist + sub-agent-expandable paths now that all
+    // three drop strikethrough.
     return `${indent}${symbol} ${renderItemCore(item.tool, item.label, false, humanAuthored)}${needsDuration ? ` <i>(${dur})</i>` : ''}`
   }
   void subAgents
@@ -1508,15 +1521,20 @@ function renderSubAgentExpandable(
       innerLines.push(`↳ ${sa.toolCount} tool${sa.toolCount !== 1 ? 's' : ''} completed`)
     }
   } else {
-    // Running state: show recent completed actions (strikethrough) + current (↳).
+    // Running state: show recent completed actions + current (↳).
     //
     // `recentCompletedTools` holds up to 2 previously completed tools.
-    // `currentTool` is the in-flight tool (shown with ↳, no strikethrough).
+    // `currentTool` is the in-flight tool (shown with ↳).
     // Together they give up to 3 action lines per the spec.
+    //
+    // #320: no <s> wrap on completed actions here. The active line is
+    // distinguished by its `↳` prefix; the recent-completed lines have
+    // no prefix. Strikethrough adds a salmon/red line that reads as
+    // "deleted/failed" rather than "done" — drop it for visual calm.
     const recent = sa.recentCompletedTools ?? []
     for (const t of recent) {
       // renderItemCore returns HTML (with <code> tags) — do NOT re-escape it.
-      innerLines.push(`<s>${renderItemCore(t.tool, t.label, false, t.humanAuthored)}</s>`)
+      innerLines.push(renderItemCore(t.tool, t.label, false, t.humanAuthored))
     }
 
     if (sa.currentTool) {

--- a/telegram-plugin/server.ts
+++ b/telegram-plugin/server.ts
@@ -1207,7 +1207,7 @@ mcp.setRequestHandler(ListToolsRequestSchema, async () => ({
     {
       name: 'reply',
       description:
-        'Reply on Telegram. Pass chat_id from the inbound message. By default the reply is a quote-reply to the latest inbound user message in this chat+thread — pass quote:false to opt out, or pass an explicit reply_to to thread under a specific earlier message. message_thread_id routes to a forum topic; files (absolute paths) attach images or documents.',
+        '**Terminal — sends a final message and ends the turn.** Use for one-shot answers requiring zero further tool calls (factual answers, confirmations, simple replies). For any response that involves dispatching work (Agent calls, Bash commands, multi-step tool chains), use `stream_reply` and keep doing work — calling `reply` to announce in-flight work will leave the work undone, because the turn ends after this call. Pass chat_id from the inbound message. By default the reply is a quote-reply to the latest inbound user message in this chat+thread — pass quote:false to opt out, or pass an explicit reply_to to thread under a specific earlier message. message_thread_id routes to a forum topic; files (absolute paths) attach images or documents.',
       inputSchema: {
         type: 'object',
         properties: {

--- a/telegram-plugin/server.ts
+++ b/telegram-plugin/server.ts
@@ -5470,8 +5470,16 @@ bot.on('callback_query:data', async ctx => {
     }
 
     // #227 grant wizard callbacks (vg:cancel bare, vg:agent:*, vg:keys:*, vg:dur:*, vg:gen)
+    //
+    // Note: pre-#265 fix this function did `await ctx.answerCallbackQuery().catch(() => {})`
+    // unconditionally up front. That meant the `vg:keys-continue` branch's
+    // toast call (`Select at least one key.`) hit a Telegram error
+    // ("query is too old or query ID is invalid") because the query was
+    // already answered, and the toast never reached the user. Each branch
+    // now owns its own ack — the spinner dismissal is part of the branch's
+    // post-condition.
     const chatId = String(ctx.chat!.id)
-    await ctx.answerCallbackQuery().catch(() => {})
+    const ackSilently = () => ctx.answerCallbackQuery().catch(() => {})
 
     // Cancel at any step
     if (data === 'vg:cancel') {
@@ -5480,12 +5488,14 @@ bot.on('callback_query:data', async ctx => {
       if (msg && 'text' in msg) {
         await ctx.editMessageText('❌ Grant wizard cancelled.').catch(() => {})
       }
+      await ackSilently()
       return
     }
 
     const state = pendingVaultOps.get(chatId)
     if (!state || state.kind !== 'grant-wizard') {
       await ctx.editMessageText('⚠️ Wizard session expired. Run /vault grant to start again.').catch(() => {})
+      await ackSilently()
       return
     }
 
@@ -5494,13 +5504,14 @@ bot.on('callback_query:data', async ctx => {
       const agent = data.slice('vg:agent:'.length)
       const msgId = (ctx.callbackQuery.message as { message_id?: number })?.message_id ?? state.wizardMsgId
       await grantWizardStep2(ctx, chatId, agent, msgId)
+      await ackSilently()
       return
     }
 
     // vg:key:<name> — step 2 toggle
     if (data.startsWith('vg:key:')) {
       const key = data.slice('vg:key:'.length)
-      if (state.step !== 'keys') return
+      if (state.step !== 'keys') { await ackSilently(); return }
       const selectedSet = new Set(state.selectedKeys ?? [])
       if (selectedSet.has(key)) {
         selectedSet.delete(key)
@@ -5511,23 +5522,27 @@ bot.on('callback_query:data', async ctx => {
       pendingVaultOps.set(chatId, updatedState)
       const kb = buildGrantKeysKeyboard(state.availableKeys ?? [], selectedSet)
       await ctx.editMessageReplyMarkup({ reply_markup: kb }).catch(() => {})
+      await ackSilently()
       return
     }
 
     // vg:keys-continue — step 2 → 3
     if (data === 'vg:keys-continue') {
-      if (state.step !== 'keys') return
+      if (state.step !== 'keys') { await ackSilently(); return }
       if (!state.selectedKeys || state.selectedKeys.length === 0) {
+        // Toast-only ack: this is the branch the unconditional pre-ack
+        // used to silently swallow. See #265.
         await ctx.answerCallbackQuery({ text: 'Select at least one key.' }).catch(() => {})
         return
       }
       await grantWizardStep3(ctx, chatId, state)
+      await ackSilently()
       return
     }
 
     // vg:dur:<value> — step 3 duration selection
     if (data.startsWith('vg:dur:')) {
-      if (state.step !== 'duration') return
+      if (state.step !== 'duration') { await ackSilently(); return }
       const dur = data.slice('vg:dur:'.length)
       if (dur === 'custom') {
         // Ask for text reply with n d|h format
@@ -5539,6 +5554,7 @@ bot.on('callback_query:data', async ctx => {
             { parse_mode: 'HTML', reply_markup: buildGrantDurationKeyboard() },
           ).catch(() => {})
         }
+        await ackSilently()
         return
       }
       let ttlSeconds: number | null
@@ -5548,30 +5564,33 @@ bot.on('callback_query:data', async ctx => {
         ttlSeconds = 365 * 86400
       } else {
         ttlSeconds = parseGrantDuration(dur)
-        if (ttlSeconds === null) return
+        if (ttlSeconds === null) { await ackSilently(); return }
       }
       const newState = { ...state, ttlSeconds, awaitingCustomDuration: false }
       await grantWizardConfirm(ctx, chatId, newState)
+      await ackSilently()
       return
     }
 
     // vg:back:duration — go back to step 2 (keys selection) from step 3
     if (data === 'vg:back:duration') {
-      if (state.step !== 'duration') return
+      if (state.step !== 'duration') { await ackSilently(); return }
       const msgId = state.wizardMsgId
       await grantWizardStep2(ctx, chatId, state.agent!, msgId)
+      await ackSilently()
       return
     }
 
     // vg:generate — final step
     if (data === 'vg:generate') {
-      if (state.step !== 'confirm') return
+      if (state.step !== 'confirm') { await ackSilently(); return }
       await executeGrantWizard(ctx, chatId, state)
+      await ackSilently()
       return
     }
 
     // Unrecognised vg: sub-action
-    await ctx.answerCallbackQuery().catch(() => {})
+    await ackSilently()
     return
   }
 

--- a/telegram-plugin/server.ts
+++ b/telegram-plugin/server.ts
@@ -1274,7 +1274,7 @@ mcp.setRequestHandler(ListToolsRequestSchema, async () => ({
     {
       name: 'stream_reply',
       description:
-        'Post the final answer for this turn. The plugin renders an event-driven progress card (Plan → Run → Done with live tool bullets, elapsed time, and status emoji) for free while the turn is in-flight, so you do not need to narrate intermediate progress. Call `stream_reply` exactly once per turn with done=true and the complete answer text. By default the streamed message quote-replies to the latest inbound user message in this chat+thread — pass quote:false to opt out, or reply_to to target a specific message. Hard-stops at 4096 chars — longer text throws; fall back to `reply`, which chunks. Calling with done=false is an error in this environment (the progress card already owns the mid-turn surface).',
+        '**Use to keep the turn alive while you work.** Pass `done=false` for interim updates (the plugin throttles edits to ~1/sec automatically) and `done=true` only when the response is final. Prefer this over `reply` whenever the response involves Agent / Bash / Task tool calls, multi-step tool chains, or any work that has not completed yet — `reply` is terminal and ends the turn. Pattern: First call `stream_reply(chat_id, "Reading the file...", done=false)` immediately on receipt of the user message; interim calls pass the FULL current text with `done=false`; final call passes the complete answer with `done=true`. By default quote-replies to the latest inbound user message in this chat+thread — pass quote:false to opt out, or reply_to to target a specific message. Hard-stops at 4096 chars — longer text throws; fall back to `reply` for chunking. The progress card runs alongside in parallel for ambient phase signal, but stream_reply is what carries narrative content.',
       inputSchema: {
         type: 'object',
         properties: {
@@ -1282,7 +1282,7 @@ mcp.setRequestHandler(ListToolsRequestSchema, async () => ({
           text: { type: 'string', description: 'Full text snapshot. NOT a delta — pass the complete current content each call.' },
           done: {
             type: 'boolean',
-            description: 'Must be true. Posts this text as the final answer for the turn and locks the message.',
+            description: 'False for interim updates while work is in flight; true for the final message that locks the turn. Pass false until you have the complete answer.',
           },
           message_thread_id: {
             type: 'string',

--- a/telegram-plugin/server.ts
+++ b/telegram-plugin/server.ts
@@ -197,6 +197,7 @@ import { createStreamController } from './stream-controller.js'
 import { handlePtyPartialPure, type PtyHandlerState } from './pty-partial-handler.js'
 import { handleStreamReply, buildAccentHeader } from './stream-reply-handler.js'
 import { createChatLock } from './chat-lock.js'
+import { summarizeToolForTitle } from './permission-title.js'
 import {
   validateInlineKeyboard,
   type AnyButton,
@@ -1185,7 +1186,10 @@ mcp.setNotificationHandler(
       expiresAt: Date.now() + PENDING_PERMISSION_TTL_MS,
     })
     const access = loadAccess()
-    const text = `🔐 Permission: ${tool_name}`
+    // Lift the most-identifying field into the title so the user can
+    // approve at a glance — e.g. `Skill (mail)` instead of bare `Skill`.
+    // See #186.
+    const text = `🔐 Permission: ${summarizeToolForTitle(tool_name, input_preview)}`
     const keyboard = new InlineKeyboard()
       .text('See more', `perm:more:${request_id}`)
       .text('✅ Allow', `perm:allow:${request_id}`)

--- a/telegram-plugin/session-tail.ts
+++ b/telegram-plugin/session-tail.ts
@@ -621,8 +621,25 @@ export function startSessionTail(config: SessionTailConfig): SessionTailHandle {
     pendingPartial: string
     hasEmittedStart: boolean
     watcher: FSWatcher | null
+    /**
+     * Last wall-clock time the file's byte count actually advanced.
+     * Used for idle-based FSWatcher cleanup — sub-agents that haven't
+     * written in IDLE_FSWATCH_TTL_MS get their watcher closed and the
+     * SubTail entry dropped. The rescan loop re-attaches if the file
+     * grows again. See MEM2 in the overnight forensic audit on #472.
+     */
+    lastActivityAt: number
   }
   const subTails = new Map<string, SubTail>() // keyed by absolute file path
+
+  /**
+   * Idle window before a sub-agent FSWatcher is considered safe to
+   * close. Sub-agents finish in seconds-to-minutes; 5 min is well
+   * past the 99th-percentile completion time and cheap on the rare
+   * very-long task (rescanSubagents picks the file back up on the
+   * next tick if it grows).
+   */
+  const IDLE_FSWATCH_TTL_MS = 5 * 60 * 1000
 
   function readSub(t: SubTail): void {
     if (stopped) return
@@ -641,6 +658,7 @@ export function startSessionTail(config: SessionTailConfig): SessionTailHandle {
         closeSync(fd)
       }
       t.cursor = stat.size
+      t.lastActivityAt = Date.now()
       const text = t.pendingPartial + buf.toString('utf-8')
       const lines = text.split('\n')
       t.pendingPartial = lines.pop() ?? ''
@@ -679,6 +697,7 @@ export function startSessionTail(config: SessionTailConfig): SessionTailHandle {
       pendingPartial: '',
       hasEmittedStart: false,
       watcher: null,
+      lastActivityAt: Date.now(),
     }
     void cursor
     try {
@@ -689,6 +708,32 @@ export function startSessionTail(config: SessionTailConfig): SessionTailHandle {
     subTails.set(file, t)
     log?.(`session-tail: attached sub ${agentId} (${file})`)
     readSub(t)
+  }
+
+  /**
+   * Drop sub-tails whose underlying file hasn't grown in
+   * IDLE_FSWATCH_TTL_MS. Closes the FSWatcher (releasing the FD) and
+   * removes the entry from `subTails`. If the file later grows again
+   * — unusual but possible if a sub-agent resumes — `rescanSubagents`
+   * will re-attach on its next tick.
+   *
+   * Pre-MEM2 fix the per-file FSWatcher lived for the entire process
+   * lifetime. With the subagent-watcher (MEM1) ALSO holding a watcher
+   * on the same file, the FD bleed was doubled.
+   */
+  function reapIdleSubTails(): void {
+    if (subTails.size === 0) return
+    const cutoff = Date.now() - IDLE_FSWATCH_TTL_MS
+    for (const [file, t] of subTails) {
+      if (t.lastActivityAt < cutoff) {
+        if (t.watcher) {
+          try { t.watcher.close() } catch { /* ignore */ }
+          t.watcher = null
+        }
+        subTails.delete(file)
+        log?.(`session-tail: reaped idle sub ${t.agentId} (${file})`)
+      }
+    }
   }
 
   /**
@@ -733,6 +778,10 @@ export function startSessionTail(config: SessionTailConfig): SessionTailHandle {
     // Always read in case fs.watch missed an event (common on WSL/network mounts)
     readNew()
     rescanSubagents()
+    // MEM2: reap subtails whose underlying JSONL has been idle for a
+    // while. The reap is guarded by IDLE_FSWATCH_TTL_MS (5 min by
+    // default) so steady-state workloads don't thrash.
+    reapIdleSubTails()
   }
 
   // Initial pass

--- a/telegram-plugin/shared/bot-runtime.ts
+++ b/telegram-plugin/shared/bot-runtime.ts
@@ -23,7 +23,7 @@
 
 import { GrammyError, type Bot, type Context } from 'grammy'
 import { run, type RunnerHandle } from '@grammyjs/runner'
-import { execFileSync, execSync } from 'child_process'
+import { execFileSync, spawnSync } from 'child_process'
 import { clearStaleTelegramPollingState } from '../startup-reset.js'
 import { createRetryApiCall } from '../retry-api-call.js'
 
@@ -92,16 +92,38 @@ export function makeSwitchroomExecCombined(cfg: CliConfig = {}) {
   const cli = cfg.cliPath ?? process.env.SWITCHROOM_CLI_PATH ?? 'switchroom'
   const config = cfg.configPath ?? process.env.SWITCHROOM_CONFIG
 
+  // Pre-#28 fix this used `execSync(\`${quoted} 2>&1\`, { shell: '/bin/bash' })`,
+  // hand-quoting each argument. The shell-quoting was correct today, but the
+  // structural shape meant any future caller passing user-controlled input
+  // would re-introduce a command-injection class of bug. spawnSync with
+  // argv array eliminates the shell entirely; we then concat stdout + stderr
+  // ourselves to preserve the merged-output contract callers depend on.
   return function switchroomExecCombined(args: string[], timeoutMs = 15000): string {
     const fullArgs = config ? ['--config', config, ...args] : args
-    const quoted = [cli, ...fullArgs].map((a) => `'${String(a).replace(/'/g, "'\\''")}'`).join(' ')
-    return execSync(`${quoted} 2>&1`, {
+    const result = spawnSync(cli, fullArgs, {
       encoding: 'utf-8',
       timeout: timeoutMs,
       env: { ...process.env, FORCE_COLOR: '0', NO_COLOR: '1' },
       maxBuffer: 4 * 1024 * 1024,
-      shell: '/bin/bash',
     })
+    const stdout = (result.stdout as string | undefined) ?? ''
+    const stderr = (result.stderr as string | undefined) ?? ''
+    const merged = stderr.length > 0 ? stdout + stderr : stdout
+    if (result.error) throw result.error
+    if (result.status !== 0) {
+      // Mirror execSync's behaviour: throw on non-zero exit, attaching the
+      // merged output so callers (which catch and inspect .stdout) can read it.
+      const err = new Error(`Command failed: ${cli} ${fullArgs.join(' ')}`) as Error & {
+        stdout?: string
+        stderr?: string
+        status?: number | null
+      }
+      err.stdout = merged
+      err.stderr = stderr
+      err.status = result.status
+      throw err
+    }
+    return merged
   }
 }
 

--- a/telegram-plugin/subagent-watcher.ts
+++ b/telegram-plugin/subagent-watcher.ts
@@ -161,6 +161,21 @@ export interface SubagentWatcherHandle {
 
 const DEFAULT_RESCAN_MS = 1000
 const DEFAULT_STALL_THRESHOLD_MS = 60_000
+/**
+ * Grace period between a sub-agent transitioning to terminal state
+ * (`done` / `failed`) and the watcher closing its FSWatcher + dropping
+ * its Map entries. The grace lets late writes (a final `turn_end`
+ * marker landing in the same poll tick as the completion event, the
+ * registry-DB UPDATE finishing, a downstream consumer reading the
+ * tail one more time) flush without losing data.
+ *
+ * Pre-fix the per-subagent FSWatcher lived for the entire process
+ * lifetime, so a long-running gateway with sustained sub-agent load
+ * accumulated FDs until it hit `ulimit -n` (default 1024 on Linux)
+ * and the process started failing every fs.watch call. See MEM1 in
+ * the overnight forensic audit on #472.
+ */
+const TERMINAL_CLEANUP_GRACE_MS = 30_000
 
 // ─── JSONL tail per sub-agent ─────────────────────────────────────────────
 
@@ -363,6 +378,13 @@ export function startSubagentWatcher(config: SubagentWatcherConfig): SubagentWat
   const clearI = config.clearInterval ?? ((ref) => {
     clearInterval((ref as { ref: ReturnType<typeof setInterval> }).ref)
   })
+  const setT = config.setTimeout ?? ((fn, ms) => {
+    const h = setTimeout(fn, ms)
+    return { ref: h }
+  })
+  const clearT = config.clearTimeout ?? ((ref) => {
+    clearTimeout((ref as { ref: ReturnType<typeof setTimeout> }).ref)
+  })
 
   // fs DI: tests pass a mock; production uses the real node:fs functions.
   const fs = config.fs ?? {
@@ -383,6 +405,10 @@ export function startSubagentWatcher(config: SubagentWatcherConfig): SubagentWat
   const dirWatchers = new Map<string, FSWatcher>()
   // Known subagent files: filePath → true
   const knownFiles = new Set<string>()
+  // Pending deferred-cleanups for terminal-state sub-agents. Keyed by
+  // agentId so a re-transition (shouldn't happen, but defensively) or
+  // a stop() call can cancel pending timers cleanly. See MEM1 fix.
+  const pendingCloses = new Map<string, { ref: unknown }>()
   /**
    * Files that existed before the watcher started (boot-time snapshot).
    * The `historical` flag on each entry suppresses two notification paths:
@@ -465,8 +491,11 @@ export function startSubagentWatcher(config: SubagentWatcherConfig): SubagentWat
     // in-flight agent that finishes while we're watching) fire.
     if (isHistorical && entry.state === 'done') {
       // Already finished before we started — mark as notified so we
-      // don't fire a spurious completion notification later.
+      // don't fire a spurious completion notification later, and
+      // schedule cleanup so the FSWatcher we just opened doesn't leak
+      // forever. See MEM1 fix.
       entry.completionNotified = true
+      scheduleTerminalCleanup(agentId)
     } else {
       maybySendStateTransition(agentId)
     }
@@ -506,7 +535,54 @@ export function startSubagentWatcher(config: SubagentWatcherConfig): SubagentWat
       } catch (err) {
         log?.(`subagent-watcher: completion notification error: ${(err as Error).message}`)
       }
+      scheduleTerminalCleanup(agentId)
     }
+    // Defensive: if state ever flips to 'failed' (currently no caller
+    // sets this, but the type allows it), still clean up the FSWatcher.
+    if (entry.state === 'failed') {
+      scheduleTerminalCleanup(agentId)
+    }
+  }
+
+  // ─── Per-agent cleanup ──────────────────────────────────────────────────
+
+  /**
+   * Schedule a deferred close of the per-subagent FSWatcher + Map
+   * entries `TERMINAL_CLEANUP_GRACE_MS` after the sub-agent transitions
+   * to terminal state. Idempotent — repeated calls for the same agent
+   * cancel the previous timer and reset the grace window.
+   */
+  function scheduleTerminalCleanup(agentId: string): void {
+    if (stopped) return
+    const existing = pendingCloses.get(agentId)
+    if (existing) {
+      clearT(existing)
+    }
+    const handle = setT(() => {
+      pendingCloses.delete(agentId)
+      cleanupTerminalAgent(agentId)
+    }, TERMINAL_CLEANUP_GRACE_MS)
+    pendingCloses.set(agentId, handle)
+  }
+
+  /**
+   * Close the FSWatcher and drop Map entries for a terminal sub-agent.
+   * Safe to call multiple times: each Map operation is a no-op for an
+   * already-deleted key.
+   */
+  function cleanupTerminalAgent(agentId: string): void {
+    const tail = tails.get(agentId)
+    if (tail?.watcher) {
+      try { tail.watcher.close() } catch { /* ignore */ }
+      tail.watcher = null
+    }
+    tails.delete(agentId)
+    const entry = registry.get(agentId)
+    if (entry?.filePath) {
+      knownFiles.delete(entry.filePath)
+    }
+    registry.delete(agentId)
+    log?.(`subagent-watcher: cleaned up terminal agent ${agentId}`)
   }
 
   // ─── Stall detection ────────────────────────────────────────────────────
@@ -666,6 +742,13 @@ export function startSubagentWatcher(config: SubagentWatcherConfig): SubagentWat
     stop(): void {
       stopped = true
       clearI(pollHandle)
+      // Cancel any pending deferred-cleanup timers — the unconditional
+      // close loop below covers their work and we don't want straggler
+      // setTimeout callbacks firing after the watcher is supposedly stopped.
+      for (const handle of pendingCloses.values()) {
+        clearT(handle)
+      }
+      pendingCloses.clear()
       for (const w of dirWatchers.values()) {
         try { w.close() } catch { /* ignore */ }
       }

--- a/telegram-plugin/tests/auto-fallback.test.ts
+++ b/telegram-plugin/tests/auto-fallback.test.ts
@@ -4,6 +4,8 @@ import {
   performAutoFallback,
   nextLockout,
   emptyLockout,
+  loadLockout,
+  saveLockout,
   DEFAULT_TRIGGER_UTILIZATION_PCT,
   DEFAULT_FALLBACK_COOLDOWN_MS,
   type LockoutRecord,
@@ -313,10 +315,6 @@ describe("nextLockout / emptyLockout", () => {
 });
 
 describe("loadLockout / saveLockout (#417)", () => {
-  // Use require to avoid hoisting the import to top of file (and to keep the
-  // existing import block untouched).
-  const { loadLockout, saveLockout } = require("../auto-fallback") as typeof import("../auto-fallback");
-
   function fakeOps() {
     const files = new Map<string, string>();
     const dirs = new Set<string>();

--- a/telegram-plugin/tests/auto-fallback.test.ts
+++ b/telegram-plugin/tests/auto-fallback.test.ts
@@ -311,3 +311,73 @@ describe("nextLockout / emptyLockout", () => {
     expect(l.lastTransitionAt).toBe(NOW);
   });
 });
+
+describe("loadLockout / saveLockout (#417)", () => {
+  // Use require to avoid hoisting the import to top of file (and to keep the
+  // existing import block untouched).
+  const { loadLockout, saveLockout } = require("../auto-fallback") as typeof import("../auto-fallback");
+
+  function fakeOps() {
+    const files = new Map<string, string>();
+    const dirs = new Set<string>();
+    return {
+      files,
+      dirs,
+      readFileSync: (p: string) => {
+        const v = files.get(p);
+        if (v === undefined) throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+        return v;
+      },
+      writeFileSync: (p: string, data: string) => {
+        files.set(p, data);
+      },
+      existsSync: (p: string) => files.has(p),
+      mkdirSync: (p: string) => {
+        dirs.add(p);
+      },
+      joinPath: (...parts: string[]) => parts.join("/"),
+    };
+  }
+
+  it("returns emptyLockout when no file exists", () => {
+    const ops = fakeOps();
+    expect(loadLockout("/agent", ops)).toEqual(emptyLockout());
+  });
+
+  it("round-trips a saved lockout", () => {
+    const ops = fakeOps();
+    const original = nextLockout("default", NOW);
+    saveLockout("/agent", original, ops);
+    expect(loadLockout("/agent", ops)).toEqual(original);
+  });
+
+  it("creates the .claude directory before writing", () => {
+    const ops = fakeOps();
+    saveLockout("/agent", nextLockout("default", NOW), ops);
+    expect(ops.dirs.has("/agent/.claude")).toBe(true);
+  });
+
+  it("falls back to emptyLockout on malformed JSON (not a hard fail)", () => {
+    const ops = fakeOps();
+    ops.files.set("/agent/.claude/auto-fallback-lockout.json", "{broken json");
+    expect(loadLockout("/agent", ops)).toEqual(emptyLockout());
+  });
+
+  it("falls back to emptyLockout on missing fields", () => {
+    const ops = fakeOps();
+    ops.files.set(
+      "/agent/.claude/auto-fallback-lockout.json",
+      JSON.stringify({ wrong: "shape" }),
+    );
+    expect(loadLockout("/agent", ops)).toEqual(emptyLockout());
+  });
+
+  it("falls back to emptyLockout on non-finite lastTransitionAt", () => {
+    const ops = fakeOps();
+    ops.files.set(
+      "/agent/.claude/auto-fallback-lockout.json",
+      JSON.stringify({ lastTransitionedFrom: "x", lastTransitionAt: "nope" }),
+    );
+    expect(loadLockout("/agent", ops)).toEqual(emptyLockout());
+  });
+});

--- a/telegram-plugin/tests/boot-probes.test.ts
+++ b/telegram-plugin/tests/boot-probes.test.ts
@@ -14,6 +14,7 @@ import { join } from 'path'
 import {
   probeAgentProcess,
   probeQuota,
+  watchAgentProcess,
 } from '../gateway/boot-probes.js'
 import { readQuotaCache, RATE_LIMIT_TTL_MS } from '../gateway/quota-cache.js'
 
@@ -309,5 +310,142 @@ describe('probeQuota — #210: 429 returns ok-with-note', () => {
     // readQuotaCache should see it as expired
     const cached = readQuotaCache({ path: cachePath })
     expect(cached).toBeNull()
+  })
+})
+
+// ── #296: watchAgentProcess follow-up re-poll ─────────────────────────────
+
+describe('watchAgentProcess — #296: re-poll after window expiry', () => {
+  /**
+   * Build a fake clock that the test can advance manually. The first
+   * call returns the start time; each subsequent `tick` advances now()
+   * by the given ms.
+   */
+  function makeFakeClock(startMs = 0) {
+    let current = startMs
+    return {
+      now: () => current,
+      tick: (ms: number) => { current += ms },
+    }
+  }
+
+  it('flips degraded → ok when agent reaches active after the follow-up re-poll', async () => {
+    const clock = makeFakeClock()
+    const sequence = makeSequence([
+      makeSystemctlOutput('inactive'),
+      makeSystemctlOutput('active', '99999'),
+    ])
+    const execFileImpl = ((...args: unknown[]) =>
+      sequence(...args)) as ExecFileFn
+    // Each sleep call advances the fake clock past the window.
+    const sleepImpl = async (ms: number) => { clock.tick(ms) }
+
+    const yields: Array<{ status: string; detail: string }> = []
+    const gen = watchAgentProcess('testbot', {
+      liveWindowMs: 100, // expire after first tick (sleep advances 1000ms past)
+      pollIntervalMs: 1000,
+      followupRepollMs: 30_000,
+      sleepImpl,
+      execFileImpl: execFileImpl as never,
+      nowImpl: clock.now,
+    })
+    for await (const result of gen) {
+      yields.push({ status: result.status, detail: result.detail ?? '' })
+    }
+
+    // First yield: degraded (within-window-expired commit). Second yield:
+    // ok (the follow-up re-poll caught the late-boot active transition).
+    expect(yields.length).toBeGreaterThanOrEqual(2)
+    const final = yields[yields.length - 1]
+    expect(final.status).toBe('ok')
+    expect(final.detail).toContain('PID 99999')
+  })
+
+  it('does NOT yield ok when agent stays inactive after the follow-up re-poll', async () => {
+    const clock = makeFakeClock()
+    const sequence = makeSequence([
+      makeSystemctlOutput('inactive'),
+      makeSystemctlOutput('inactive'),
+      makeSystemctlOutput('inactive'),
+    ])
+    const execFileImpl = ((...args: unknown[]) =>
+      sequence(...args)) as ExecFileFn
+    const sleepImpl = async (ms: number) => { clock.tick(ms) }
+
+    const yields: Array<{ status: string; detail: string }> = []
+    const gen = watchAgentProcess('testbot', {
+      liveWindowMs: 100,
+      pollIntervalMs: 1000,
+      followupRepollMs: 30_000,
+      sleepImpl,
+      execFileImpl: execFileImpl as never,
+      nowImpl: clock.now,
+    })
+    for await (const result of gen) {
+      yields.push({ status: result.status, detail: result.detail ?? '' })
+    }
+
+    // Final status must be degraded — the follow-up re-poll saw inactive
+    // again so no ok yield was added. (The number of yields varies by how
+    // many distinct "service X" detail strings the loop saw; what matters
+    // is that ok never appears.)
+    expect(yields.every((y) => y.status === 'degraded')).toBe(true)
+    expect(yields.find((y) => y.status === 'ok')).toBeUndefined()
+  })
+
+  it('skips the re-poll entirely when followupRepollMs <= 0', async () => {
+    const clock = makeFakeClock()
+    const sequence = makeSequence([makeSystemctlOutput('inactive')])
+    const execCalls: number[] = []
+    const execFileImpl = ((...args: unknown[]) => {
+      execCalls.push(1)
+      return sequence(...args)
+    }) as ExecFileFn
+
+    const yields: Array<{ status: string }> = []
+    const gen = watchAgentProcess('testbot', {
+      liveWindowMs: 100,
+      pollIntervalMs: 1000,
+      followupRepollMs: 0, // disabled
+      sleepImpl: async (ms: number) => { clock.tick(ms) },
+      execFileImpl: execFileImpl as never,
+      nowImpl: clock.now,
+    })
+    for await (const result of gen) {
+      yields.push({ status: result.status })
+    }
+
+    // followupRepollMs=0 means no follow-up after the window expires.
+    // Final yield must be degraded; no ok ever surfaces.
+    expect(yields.every((y) => y.status === 'degraded')).toBe(true)
+    expect(yields.find((y) => y.status === 'ok')).toBeUndefined()
+  })
+
+  it('returns immediately on ok within window — no follow-up needed', async () => {
+    const clock = makeFakeClock()
+    const sequence = makeSequence([makeSystemctlOutput('active', '12345')])
+    let extraCalls = 0
+    const execFileImpl = ((...args: unknown[]) => {
+      const result = sequence(...args)
+      extraCalls += 1
+      return result
+    }) as ExecFileFn
+
+    const yields: Array<{ status: string }> = []
+    const gen = watchAgentProcess('testbot', {
+      liveWindowMs: 60_000,
+      pollIntervalMs: 1000,
+      followupRepollMs: 30_000,
+      sleepImpl: async (ms: number) => { clock.tick(ms) },
+      execFileImpl: execFileImpl as never,
+      nowImpl: clock.now,
+    })
+    for await (const result of gen) {
+      yields.push({ status: result.status })
+    }
+
+    expect(yields).toHaveLength(1)
+    expect(yields[0].status).toBe('ok')
+    expect(extraCalls).toBe(1) // only the initial probe; no follow-up
   })
 })

--- a/telegram-plugin/tests/credits-watch.test.ts
+++ b/telegram-plugin/tests/credits-watch.test.ts
@@ -1,0 +1,221 @@
+/**
+ * Unit tests for the Claude-independent credit-exhaustion notify
+ * helper (#348). Covers:
+ *   - Pure decision logic across the transition table
+ *   - State persistence round-trip
+ *   - File-read robustness (missing / malformed / wrong-type field)
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import {
+  readClaudeJsonOverage,
+  evaluateCreditState,
+  loadCreditState,
+  saveCreditState,
+  emptyCreditState,
+} from "../credits-watch.js";
+
+describe("readClaudeJsonOverage", () => {
+  let tmp: string;
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), "credits-watch-"));
+  });
+
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it("returns null when .claude.json is missing", () => {
+    expect(readClaudeJsonOverage(tmp)).toBeNull();
+  });
+
+  it("returns null when .claude.json is malformed", () => {
+    writeFileSync(join(tmp, ".claude.json"), "{not valid json");
+    expect(readClaudeJsonOverage(tmp)).toBeNull();
+  });
+
+  it("returns null when the field is absent", () => {
+    writeFileSync(join(tmp, ".claude.json"), JSON.stringify({ unrelated: "x" }));
+    expect(readClaudeJsonOverage(tmp)).toBeNull();
+  });
+
+  it("returns null when the field is null", () => {
+    writeFileSync(
+      join(tmp, ".claude.json"),
+      JSON.stringify({ cachedExtraUsageDisabledReason: null }),
+    );
+    expect(readClaudeJsonOverage(tmp)).toBeNull();
+  });
+
+  it("returns null when the field is the wrong type", () => {
+    writeFileSync(
+      join(tmp, ".claude.json"),
+      JSON.stringify({ cachedExtraUsageDisabledReason: 42 }),
+    );
+    expect(readClaudeJsonOverage(tmp)).toBeNull();
+  });
+
+  it("returns the string value when present", () => {
+    writeFileSync(
+      join(tmp, ".claude.json"),
+      JSON.stringify({ cachedExtraUsageDisabledReason: "out_of_credits" }),
+    );
+    expect(readClaudeJsonOverage(tmp)).toBe("out_of_credits");
+  });
+
+  it("returns the value even when other unrelated keys exist", () => {
+    writeFileSync(
+      join(tmp, ".claude.json"),
+      JSON.stringify({
+        numStartups: 12,
+        installMethod: "npm",
+        cachedExtraUsageDisabledReason: "org_level_disabled",
+        cachedGrowthBookFeatures: { x: 1 },
+      }),
+    );
+    expect(readClaudeJsonOverage(tmp)).toBe("org_level_disabled");
+  });
+});
+
+describe("evaluateCreditState — transition decisions", () => {
+  const NOW = 1_780_000_000_000;
+  const HEALTHY = emptyCreditState();
+  const FATAL_OUT = { lastNotifiedReason: "out_of_credits", lastNotifiedAt: NOW - 1000 };
+
+  it("entry: healthy → fatal triggers a notify", () => {
+    const d = evaluateCreditState({
+      agentName: "lawgpt",
+      currentReason: "out_of_credits",
+      prev: HEALTHY,
+      now: NOW,
+    });
+    expect(d.kind).toBe("notify");
+    if (d.kind !== "notify") return;
+    expect(d.transition).toBe("entered");
+    expect(d.message).toContain("out of pre-paid credits");
+    expect(d.message).toContain("<b>lawgpt</b>");
+    expect(d.newState.lastNotifiedReason).toBe("out_of_credits");
+    expect(d.newState.lastNotifiedAt).toBe(NOW);
+  });
+
+  it("steady-state: fatal → same fatal reason skips", () => {
+    const d = evaluateCreditState({
+      agentName: "lawgpt",
+      currentReason: "out_of_credits",
+      prev: FATAL_OUT,
+      now: NOW,
+    });
+    expect(d.kind).toBe("skip");
+    if (d.kind !== "skip") return;
+    expect(d.reason).toBe("already-notified-for-this-reason");
+  });
+
+  it("change: fatal X → fatal Y triggers a notify (different message)", () => {
+    const d = evaluateCreditState({
+      agentName: "lawgpt",
+      currentReason: "org_level_disabled",
+      prev: FATAL_OUT,
+      now: NOW,
+    });
+    expect(d.kind).toBe("notify");
+    if (d.kind !== "notify") return;
+    expect(d.transition).toBe("changed");
+    expect(d.message).toContain("org admin has disabled extra usage");
+    expect(d.newState.lastNotifiedReason).toBe("org_level_disabled");
+  });
+
+  it("recovery: fatal → healthy triggers a notify (credits restored)", () => {
+    const d = evaluateCreditState({
+      agentName: "lawgpt",
+      currentReason: null,
+      prev: FATAL_OUT,
+      now: NOW,
+    });
+    expect(d.kind).toBe("notify");
+    if (d.kind !== "notify") return;
+    expect(d.transition).toBe("exited");
+    expect(d.message).toContain("credits restored");
+    expect(d.newState.lastNotifiedReason).toBeNull();
+  });
+
+  it("non-fatal current state from healthy prev skips silently", () => {
+    const d = evaluateCreditState({
+      agentName: "lawgpt",
+      currentReason: "some_unknown_transient_reason",
+      prev: HEALTHY,
+      now: NOW,
+    });
+    expect(d.kind).toBe("skip");
+    if (d.kind !== "skip") return;
+    expect(d.reason).toBe("no-fatal-state");
+  });
+
+  it("steady-state healthy skips silently", () => {
+    const d = evaluateCreditState({
+      agentName: "lawgpt",
+      currentReason: null,
+      prev: HEALTHY,
+      now: NOW,
+    });
+    expect(d.kind).toBe("skip");
+  });
+
+  it("escapes HTML in the agent name (defensive)", () => {
+    const d = evaluateCreditState({
+      agentName: "<evil>",
+      currentReason: "out_of_credits",
+      prev: HEALTHY,
+      now: NOW,
+    });
+    expect(d.kind).toBe("notify");
+    if (d.kind !== "notify") return;
+    expect(d.message).toContain("&lt;evil&gt;");
+    expect(d.message).not.toContain("<evil>");
+  });
+});
+
+describe("loadCreditState / saveCreditState — round-trip", () => {
+  let tmp: string;
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), "credits-state-"));
+  });
+
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it("returns emptyCreditState when no file exists", () => {
+    expect(loadCreditState(tmp)).toEqual(emptyCreditState());
+  });
+
+  it("round-trips a saved state", () => {
+    const state = { lastNotifiedReason: "out_of_credits", lastNotifiedAt: 1_780_000_000_000 };
+    saveCreditState(tmp, state);
+    expect(loadCreditState(tmp)).toEqual(state);
+  });
+
+  it("falls back to empty on malformed JSON (not a hard fail)", () => {
+    mkdirSync(tmp, { recursive: true });
+    writeFileSync(join(tmp, "credits-watch.json"), "{broken");
+    expect(loadCreditState(tmp)).toEqual(emptyCreditState());
+  });
+
+  it("falls back to empty on shape mismatch", () => {
+    writeFileSync(
+      join(tmp, "credits-watch.json"),
+      JSON.stringify({ lastNotifiedReason: 42, lastNotifiedAt: "nope" }),
+    );
+    expect(loadCreditState(tmp)).toEqual(emptyCreditState());
+  });
+
+  it("creates the state dir on save (if it doesn't exist yet)", () => {
+    const fresh = join(tmp, "fresh-subdir");
+    saveCreditState(fresh, { lastNotifiedReason: null, lastNotifiedAt: 0 });
+    expect(loadCreditState(fresh)).toEqual({ lastNotifiedReason: null, lastNotifiedAt: 0 });
+  });
+});

--- a/telegram-plugin/tests/foreman-create-flow.test.ts
+++ b/telegram-plugin/tests/foreman-create-flow.test.ts
@@ -157,6 +157,28 @@ describe('foreman-create-flow: handleFlowText step=asked-profile', () => {
       }
     }
   })
+
+  it('cancels with missing-name when state.name is unset (#28 item 1)', () => {
+    // Pre-#28 fix this fell back to using the profile name as the agent
+    // name. Now we cancel cleanly so the user gets a clear restart
+    // signal instead of an agent named "default".
+    const stateNoName = {
+      chatId: 'chat-1',
+      step: 'asked-profile' as const,
+      name: null,
+      profile: null,
+      botToken: null,
+      authSessionName: null,
+      loginUrl: null,
+      startedAt: Date.now(),
+      updatedAt: Date.now(),
+    }
+    const action = handleFlowText({ state: stateNoName, text: 'default', profiles: PROFILES })
+    expect(action.kind).toBe('cancel')
+    if (action.kind === 'cancel') {
+      expect(action.reason).toBe('missing-name')
+    }
+  })
 })
 
 // ─── handleFlowText — asked-bot-token step ───────────────────────────────

--- a/telegram-plugin/tests/issues-card.test.ts
+++ b/telegram-plugin/tests/issues-card.test.ts
@@ -242,4 +242,74 @@ describe("createIssuesCardHandle", () => {
     await handle.refresh([makeEvent({})]);
     expect(bot.sent[0].opts?.message_thread_id).toBe(42);
   });
+
+  it("respects retry_after on a 429 send: skips refreshes during cooldown (#442)", async () => {
+    let now = 1_000_000;
+    const bot = makeFakeBot();
+    let throwOnSend = true;
+    bot.sendMessage = async (_chat, text, opts) => {
+      if (throwOnSend) {
+        throwOnSend = false;
+        // Shape mirrors grammY's GrammyError public surface.
+        throw Object.assign(new Error("Too Many Requests"), {
+          error_code: 429,
+          parameters: { retry_after: 30 },
+        });
+      }
+      bot.sent.push({ text, opts });
+      return { message_id: 9999 };
+    };
+    const handle = createIssuesCardHandle({
+      agentName: "klanker",
+      chatId: "1",
+      bot,
+      now: () => now,
+    });
+    // First refresh: gets 429, no card recorded.
+    await handle.refresh([makeEvent({})]);
+    expect(bot.sent).toHaveLength(0);
+    expect(handle.messageId()).toBeNull();
+
+    // Second refresh inside the cooldown window: must skip silently.
+    now += 5_000; // 5s later, still within 30s cooldown
+    await handle.refresh([makeEvent({})]);
+    expect(bot.sent).toHaveLength(0);
+
+    // After the cooldown elapses, the next refresh succeeds.
+    now += 30_000;
+    await handle.refresh([makeEvent({})]);
+    expect(bot.sent).toHaveLength(1);
+    expect(handle.messageId()).toBe(9999);
+  });
+
+  it("respects retry_after on a 429 edit: skips refreshes during cooldown (#442)", async () => {
+    let now = 1_000_000;
+    const bot = makeFakeBot();
+    const handle = createIssuesCardHandle({
+      agentName: "klanker",
+      chatId: "1",
+      bot,
+      now: () => now,
+    });
+    // Initial post succeeds.
+    await handle.refresh([makeEvent({ summary: "v1" })]);
+    expect(handle.messageId()).toBe(1000);
+
+    // Next edit raises 429.
+    bot.editMessageText = async () => {
+      throw Object.assign(new Error("Too Many Requests"), {
+        error_code: 429,
+        parameters: { retry_after: 10 },
+      });
+    };
+    now += 1_000;
+    await handle.refresh([makeEvent({ summary: "v2" })]);
+    // Cooldown engaged — no re-post attempt should hit the bot until the wait elapses.
+    expect(bot.sent).toHaveLength(1);
+
+    // Within the cooldown: still skipped.
+    now += 5_000;
+    await handle.refresh([makeEvent({ summary: "v3" })]);
+    expect(bot.sent).toHaveLength(1);
+  });
 });

--- a/telegram-plugin/tests/issues-watcher.test.ts
+++ b/telegram-plugin/tests/issues-watcher.test.ts
@@ -40,13 +40,13 @@ function makeEvent(): IssueEvent {
 describe("startIssuesWatcher", () => {
   it("calls card.refresh once with the initial state on startup", async () => {
     const card = makeCard();
-    let mtime = 1000;
+    let signature: string | null = "1000:50";
     const events = [makeEvent()];
     const handle = startIssuesWatcher({
       stateDir: "/fake",
       card,
       pollIntervalMs: 60_000,
-      mtimeProvider: () => mtime,
+      signatureProvider: () => signature,
       readEvents: () => events,
       // No-op interval — we drive ticks manually.
       setInterval: ((_fn: () => void) => 1 as unknown) as typeof setInterval,
@@ -57,63 +57,88 @@ describe("startIssuesWatcher", () => {
     expect(card.refreshCalls).toHaveLength(1);
     expect(card.refreshCalls[0]).toBe(events);
     handle.stop();
-    void mtime;
+    void signature;
   });
 
-  it("does not refresh again when mtime is unchanged", async () => {
+  it("does not refresh again when signature is unchanged", async () => {
     const card = makeCard();
     const handle = startIssuesWatcher({
       stateDir: "/fake",
       card,
       pollIntervalMs: 60_000,
-      mtimeProvider: () => 1000,
+      signatureProvider: () => "1000:50",
       readEvents: () => [makeEvent()],
       setInterval: ((_fn: () => void) => 1 as unknown) as typeof setInterval,
       clearInterval: (() => {}) as typeof clearInterval,
     });
     await new Promise((r) => setImmediate(r));
-    await handle.tick(); // mtime hasn't changed
+    await handle.tick(); // signature hasn't changed
     await handle.tick();
     expect(card.refreshCalls).toHaveLength(1); // initial tick only
     handle.stop();
   });
 
-  it("refreshes again when mtime changes", async () => {
+  it("refreshes again when signature changes", async () => {
     const card = makeCard();
-    let mtime = 1000;
+    let signature = "1000:50";
     const handle = startIssuesWatcher({
       stateDir: "/fake",
       card,
       pollIntervalMs: 60_000,
-      mtimeProvider: () => mtime,
+      signatureProvider: () => signature,
       readEvents: () => [makeEvent()],
       setInterval: ((_fn: () => void) => 1 as unknown) as typeof setInterval,
       clearInterval: (() => {}) as typeof clearInterval,
     });
     await new Promise((r) => setImmediate(r));
     expect(card.refreshCalls).toHaveLength(1);
-    mtime = 2000;
+    signature = "2000:120";
     await handle.tick();
     expect(card.refreshCalls).toHaveLength(2);
     handle.stop();
   });
 
-  it("treats missing file (mtime null) as a transition", async () => {
+  it("detects two writes within the same ms via the size component (#446)", async () => {
+    // Simulates the exact scenario the issue called out: two writes
+    // produce identical mtimeMs but different file sizes (the second
+    // write appended a new line). Pre-fix the watcher would miss the
+    // second write; post-fix the size component breaks the tie.
     const card = makeCard();
-    let mtime: number | null = 1000;
+    let signature = "1714521600000.000:128";
     const handle = startIssuesWatcher({
       stateDir: "/fake",
       card,
       pollIntervalMs: 60_000,
-      mtimeProvider: () => mtime,
-      readEvents: () => (mtime == null ? [] : [makeEvent()]),
+      signatureProvider: () => signature,
+      readEvents: () => [makeEvent()],
+      setInterval: ((_fn: () => void) => 1 as unknown) as typeof setInterval,
+      clearInterval: (() => {}) as typeof clearInterval,
+    });
+    await new Promise((r) => setImmediate(r));
+    expect(card.refreshCalls).toHaveLength(1);
+    // Same mtime, larger size — must still register as a change.
+    signature = "1714521600000.000:256";
+    await handle.tick();
+    expect(card.refreshCalls).toHaveLength(2);
+    handle.stop();
+  });
+
+  it("treats missing file (signature null) as a transition", async () => {
+    const card = makeCard();
+    let signature: string | null = "1000:50";
+    const handle = startIssuesWatcher({
+      stateDir: "/fake",
+      card,
+      pollIntervalMs: 60_000,
+      signatureProvider: () => signature,
+      readEvents: () => (signature == null ? [] : [makeEvent()]),
       setInterval: ((_fn: () => void) => 1 as unknown) as typeof setInterval,
       clearInterval: (() => {}) as typeof clearInterval,
     });
     await new Promise((r) => setImmediate(r));
     expect(card.refreshCalls).toHaveLength(1);
     expect(card.refreshCalls[0]).toHaveLength(1);
-    mtime = null;
+    signature = null;
     await handle.tick();
     expect(card.refreshCalls).toHaveLength(2);
     expect(card.refreshCalls[1]).toHaveLength(0);
@@ -127,7 +152,7 @@ describe("startIssuesWatcher", () => {
       stateDir: "/fake",
       card,
       pollIntervalMs: 60_000,
-      mtimeProvider: () => 0,
+      signatureProvider: () => "0:0",
       readEvents: () => [],
       setInterval: ((_fn: () => void) => 42 as unknown) as typeof setInterval,
       clearInterval: clearSpy as typeof clearInterval,

--- a/telegram-plugin/tests/permission-title.test.ts
+++ b/telegram-plugin/tests/permission-title.test.ts
@@ -1,0 +1,71 @@
+import { describe, test, expect } from 'vitest'
+import { summarizeToolForTitle } from '../permission-title.js'
+
+describe('summarizeToolForTitle (#186)', () => {
+  test('Skill: surfaces the skill name in brackets', () => {
+    const input = JSON.stringify({ skill: 'mail' })
+    expect(summarizeToolForTitle('Skill', input)).toBe('Skill (mail)')
+  })
+
+  test('Bash: truncates long commands', () => {
+    const input = JSON.stringify({
+      command: 'find /var/log -name "*.log" -mtime -1 -exec gzip {} \\;',
+    })
+    const out = summarizeToolForTitle('Bash', input)
+    expect(out.startsWith('Bash: ')).toBe(true)
+    expect(out.length).toBeLessThanOrEqual(60)
+    expect(out.endsWith('…')).toBe(true)
+  })
+
+  test('Read/Edit/Write: shows basename only', () => {
+    const input = JSON.stringify({ file_path: '/long/absolute/path/to/server.ts' })
+    expect(summarizeToolForTitle('Read', input)).toBe('Read: server.ts')
+    expect(summarizeToolForTitle('Edit', input)).toBe('Edit: server.ts')
+    expect(summarizeToolForTitle('Write', input)).toBe('Write: server.ts')
+  })
+
+  test('Glob/Grep: surfaces the pattern', () => {
+    const input = JSON.stringify({ pattern: '**/*.ts' })
+    expect(summarizeToolForTitle('Glob', input)).toBe('Glob: **/*.ts')
+    expect(summarizeToolForTitle('Grep', input)).toBe('Grep: **/*.ts')
+  })
+
+  test('WebFetch: surfaces the URL', () => {
+    const input = JSON.stringify({ url: 'https://example.com/some/page' })
+    expect(summarizeToolForTitle('WebFetch', input)).toBe(
+      'WebFetch: https://example.com/some/page',
+    )
+  })
+
+  test('falls back to bare toolName for unrecognised tools', () => {
+    expect(summarizeToolForTitle('SomeCustomTool', JSON.stringify({ x: 1 }))).toBe(
+      'SomeCustomTool',
+    )
+  })
+
+  test('falls back to bare toolName when input_preview is malformed', () => {
+    expect(summarizeToolForTitle('Skill', 'not-json')).toBe('Skill')
+    expect(summarizeToolForTitle('Skill', '')).toBe('Skill')
+    expect(summarizeToolForTitle('Skill', undefined)).toBe('Skill')
+  })
+
+  test('falls back to bare toolName when expected key is missing', () => {
+    const input = JSON.stringify({ unrelated: 'x' })
+    expect(summarizeToolForTitle('Skill', input)).toBe('Skill')
+    expect(summarizeToolForTitle('Bash', input)).toBe('Bash')
+  })
+
+  test('Bash: collapses internal whitespace before truncating', () => {
+    const input = JSON.stringify({
+      command: 'echo  \t  hello\nworld',
+    })
+    expect(summarizeToolForTitle('Bash', input)).toBe('Bash: echo hello world')
+  })
+
+  test('NotebookEdit: prefers notebook_path when file_path absent', () => {
+    const input = JSON.stringify({ notebook_path: '/work/analysis.ipynb' })
+    expect(summarizeToolForTitle('NotebookEdit', input)).toBe(
+      'NotebookEdit: analysis.ipynb',
+    )
+  })
+})

--- a/telegram-plugin/tests/progress-card-driver.test.ts
+++ b/telegram-plugin/tests/progress-card-driver.test.ts
@@ -3328,6 +3328,7 @@ describe('progress-card driver — promote-on-sub-agent', () => {
   function promoHarness(opts?: {
     initialDelayMs?: number
     promoteOnSubAgent?: boolean
+    promoteOnParentToolCount?: number
     maxConsecutive4xx?: number
     onTurnComplete?: (args: { chatId: string; threadId?: string; summary: string; taskIndex: number; taskTotal: number }) => void
   }) {
@@ -3343,6 +3344,7 @@ describe('progress-card driver — promote-on-sub-agent', () => {
       heartbeatMs: 0,
       initialDelayMs: opts?.initialDelayMs ?? 30_000,
       promoteOnSubAgent: opts?.promoteOnSubAgent,
+      promoteOnParentToolCount: opts?.promoteOnParentToolCount,
       maxConsecutive4xx: opts?.maxConsecutive4xx,
       now: () => now,
       setTimeout: (fn, ms) => {
@@ -3624,6 +3626,63 @@ describe('progress-card driver — promote-on-sub-agent', () => {
     // timer must have been cancelled by promote — no second isFirstEmit.
     advance(40_000)
     expect(emits.filter((e) => e.isFirstEmit)).toHaveLength(1)
+  })
+
+  // ─── #478 — promote-on-parent-tool-count ────────────────────────────────
+
+  it('parent tools during suppression promote the card after threshold (#478)', () => {
+    const { driver, emits, advance } = promoHarness({
+      initialDelayMs: 30_000,
+      promoteOnParentToolCount: 3,
+    })
+    driver.startTurn({ chatId: 'c', userText: 'do work' })
+    advance(2_000)
+    expect(emits).toHaveLength(0) // suppressed during initialDelay
+
+    // First two parent tool calls — still suppressed (under threshold).
+    driver.ingest({ kind: 'tool_use', toolName: 'Read', toolUseId: 't1', input: { file_path: '/a' } }, 'c')
+    driver.ingest({ kind: 'tool_use', toolName: 'Grep', toolUseId: 't2', input: { pattern: 'foo' } }, 'c')
+    advance(0)
+    expect(emits).toHaveLength(0)
+
+    // Third parent tool — threshold met, promotion fires.
+    driver.ingest({ kind: 'tool_use', toolName: 'Bash', toolUseId: 't3', input: { command: 'ls' } }, 'c')
+    advance(0)
+    expect(emits.length).toBeGreaterThan(0)
+    expect(emits[0].isFirstEmit).toBe(true)
+  })
+
+  it('parent tools below threshold do NOT promote — fast turns still suppressed (#478)', () => {
+    const { driver, emits, advance } = promoHarness({
+      initialDelayMs: 30_000,
+      promoteOnParentToolCount: 3,
+    })
+    driver.startTurn({ chatId: 'c', userText: 'quick lookup' })
+    advance(1_000)
+    driver.ingest({ kind: 'tool_use', toolName: 'Read', toolUseId: 't1', input: { file_path: '/a' } }, 'c')
+    driver.ingest({ kind: 'tool_use', toolName: 'Read', toolUseId: 't2', input: { file_path: '/b' } }, 'c')
+    advance(0)
+    expect(emits).toHaveLength(0) // 2 tools < threshold of 3
+
+    // Turn ends fast — fast-turn suppression in flush() wins.
+    driver.ingest({ kind: 'turn_end', durationMs: 1500 }, 'c')
+    advance(60_000)
+    expect(emits).toHaveLength(0)
+  })
+
+  it('promoteOnParentToolCount very high effectively disables (#478)', () => {
+    const { driver, emits, advance } = promoHarness({
+      initialDelayMs: 30_000,
+      promoteOnParentToolCount: 999, // effectively disabled
+    })
+    driver.startTurn({ chatId: 'c', userText: 'work' })
+    advance(2_000)
+    for (let i = 0; i < 10; i++) {
+      driver.ingest({ kind: 'tool_use', toolName: 'Read', toolUseId: `t${i}`, input: { file_path: `/${i}` } }, 'c')
+    }
+    advance(0)
+    // 10 tools but threshold is 999 — no promote, normal initialDelay rules apply.
+    expect(emits).toHaveLength(0)
   })
 })
 

--- a/telegram-plugin/tests/progress-card-golden.test.ts
+++ b/telegram-plugin/tests/progress-card-golden.test.ts
@@ -110,8 +110,11 @@ describe('progress-card golden turn', () => {
     expect(html).not.toContain('user-req')
     expect(html).toContain('✅ <b>Done</b>')
 
-    // Text events create narrative steps; the final text block becomes a narrative
-    expect(html).toContain('● <s>Tests fixed but push was rejected.</s>')
+    // Text events create narrative steps; the final text block becomes a narrative.
+    // #320: done items render WITHOUT <s> wrap (the bullet symbol + plain weight
+    // is the done signal; strikethrough rendered red and read as "deleted").
+    expect(html).toContain('● Tests fixed but push was rejected.')
+    expect(html).not.toContain('<s>')
 
     // Tool items are still rendered as fallback (narrative takes priority,
     // but tool items still appear when no narrative covers them)

--- a/telegram-plugin/tests/progress-card.test.ts
+++ b/telegram-plugin/tests/progress-card.test.ts
@@ -305,7 +305,10 @@ describe('progress-card render', () => {
       { kind: 'tool_result', toolUseId: 'x', toolName: 'Read' },
     ])
     const out = render(s, 1300)
+    // #320: no <s> wrap on done items. The ● symbol + plain weight
+    // (vs ◉ + bold for active) distinguishes done from active.
     expect(out).toContain('● <code>Read</code>')
+    expect(out).not.toContain('<s>')
     expect(out).not.toContain('(00:00)')
   })
 
@@ -314,8 +317,10 @@ describe('progress-card render', () => {
     st = reduce(st, { kind: 'tool_use', toolName: 'Bash' }, 1100)
     st = reduce(st, { kind: 'tool_result', toolUseId: 'x', toolName: 'Bash' }, 4200)
     const out = render(st, 4300)
+    // #320: no <s> wrap on done items. Duration stays as <i>(...)</i>.
     expect(out).toContain('● <code>Bash</code>')
     expect(out).toContain('(00:03)')
+    expect(out).not.toContain('<s>')
   })
 
   it('rolls up 2+ consecutive identical done tools (threshold lowered from 5)', () => {
@@ -483,7 +488,9 @@ describe('progress-card render', () => {
     // Text events now create narrative steps; thought bubble suppressed when narratives exist
     expect(render(st, 1500)).toContain('◉ <b>thinking…</b>')
     st = reduce(st, { kind: 'turn_end', durationMs: 500 }, 1700)
-    expect(render(st, 1700)).toContain('● <s>thinking…</s>')
+    // #320: done items render without <s> wrap.
+    expect(render(st, 1700)).toContain('● thinking…')
+    expect(render(st, 1700)).not.toContain('<s>')
     expect(render(st, 1700)).not.toContain('💭')
   })
 
@@ -514,8 +521,10 @@ describe('progress-card render', () => {
     st = reduce(st, { kind: 'text', text: 'Found the issue in merge.ts' }, 2000)
     st = reduce(st, { kind: 'tool_use', toolName: 'Edit' }, 2100)
     const out = render(st, 3000)
-    // Narrative steps are primary — no tool names visible
-    expect(out).toContain('● <s>Let me check the test files</s>')
+    // Narrative steps are primary — no tool names visible.
+    // #320: done step renders without <s> wrap (bullet symbol is the done signal).
+    expect(out).toContain('● Let me check the test files')
+    expect(out).not.toContain('<s>')
     expect(out).toContain('◉ <b>Found the issue in merge.ts</b>')
     expect(out).not.toContain('Read')
     expect(out).not.toContain('Edit')
@@ -1356,7 +1365,10 @@ describe('progress-card reducer — multi-agent correlation', () => {
       // After #315 dedup: main blockquote has the one-line summary; expandable
       // blockquote has the per-sub-agent forensics. Tool count moves to its own
       // line in the expandable, so check assertions independently.
+      // #320: completed items render WITHOUT strikethrough — bullet
+      // symbol + plain weight is the done signal.
       expect(html).toMatch(/● task A/)
+      expect(html).not.toContain('<s>')
       expect(html).toContain('1 tools')
       // Active tool spinner (◉) must not appear in a done state.
       expect(html).not.toContain('◉')

--- a/telegram-plugin/tests/session-tail.test.ts
+++ b/telegram-plugin/tests/session-tail.test.ts
@@ -499,3 +499,26 @@ describe('projectSubagentLine', () => {
     expect(st.hasEmittedStart).toBe(false)
   })
 })
+
+describe('idle sub-tail reap (MEM2)', () => {
+  // Pre-MEM2 fix the per-sub-agent FSWatcher in startSessionTail
+  // lived for the entire process lifetime. A long-running gateway
+  // with sustained sub-agent load eventually FD-exhausted. The reap
+  // logic is invoked from the rescan tick; full-path testing requires
+  // injectable time, so we pin the structural shape via source-grep
+  // and rely on the existing rescan-tick tests to prove the rest.
+  it('source declares lastActivityAt + reap on the sub-tail path', async () => {
+    const { readFileSync } = await import('node:fs')
+    const { resolve, join: joinPath } = await import('node:path')
+    const { fileURLToPath } = await import('node:url')
+    const TEST_DIR = resolve(fileURLToPath(import.meta.url), '..')
+    const REPO_ROOT = resolve(TEST_DIR, '..', '..')
+    const src = readFileSync(joinPath(REPO_ROOT, 'telegram-plugin/session-tail.ts'), 'utf-8')
+
+    expect(src).toContain('lastActivityAt: number')
+    expect(src).toContain('reapIdleSubTails')
+    expect(src).toContain('IDLE_FSWATCH_TTL_MS')
+    // Must be invoked from the rescan tick, not just declared.
+    expect(src).toMatch(/rescanSubagents\(\)\s*[\s\S]*?reapIdleSubTails\(\)/)
+  })
+})

--- a/telegram-plugin/tests/spawn-detached-cgroup-escape.test.ts
+++ b/telegram-plugin/tests/spawn-detached-cgroup-escape.test.ts
@@ -1,0 +1,51 @@
+/**
+ * Regression test for #177: detached spawns from the gateway must escape
+ * the gateway's cgroup so a gateway restart (kicked off by the same
+ * detached child as part of /new or auto-failover) doesn't cgroup-kill
+ * the child mid-flight before it can reach the second systemctl call.
+ *
+ * The fix wraps every spawn through `systemd-run --user --scope --collect`
+ * when systemd-run is available, falling back to direct spawn on hosts
+ * without it (dev containers, CI without systemd-user).
+ *
+ * This is a structural source-grep test rather than a runtime exercise
+ * because spawnSwitchroomDetached isn't exported and exercising the
+ * actual cgroup behaviour requires a real systemd session.
+ */
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { resolve, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const TEST_DIR = resolve(fileURLToPath(import.meta.url), '..')
+const REPO_ROOT = resolve(TEST_DIR, '..', '..')
+
+describe('spawnSwitchroomDetached cgroup-escape (#177)', () => {
+  const src = readFileSync(
+    join(REPO_ROOT, 'telegram-plugin/gateway/gateway.ts'),
+    'utf-8',
+  )
+
+  it('declares a resolveSystemdRunPath helper', () => {
+    expect(src).toContain('function resolveSystemdRunPath(')
+  })
+
+  it('uses --scope --collect via systemd-run when available', () => {
+    expect(src).toContain("'--user', '--scope', '--collect'")
+  })
+
+  it('uses --quiet so the wrapper does not log a banner per spawn', () => {
+    expect(src).toMatch(/'--user',\s*'--scope',\s*'--collect',\s*'--quiet'/)
+  })
+
+  it('falls back to direct spawn when systemd-run is unavailable', () => {
+    // The fallback path should still pass SWITCHROOM_CLI as the spawn
+    // binary; the systemd-run path adds it as an arg via `--`.
+    expect(src).toMatch(/spawnBin\s*=\s*systemdRun\s*\?\?\s*SWITCHROOM_CLI/)
+  })
+
+  it('caches the resolution per process (no command -v on every spawn)', () => {
+    expect(src).toContain('let _systemdRunPath')
+    expect(src).toMatch(/if\s*\(_systemdRunPath\s*!==\s*undefined\)\s*return/)
+  })
+})

--- a/telegram-plugin/tests/subagent-watcher.test.ts
+++ b/telegram-plugin/tests/subagent-watcher.test.ts
@@ -192,6 +192,7 @@ function makeHarness(opts: {
 
   // Injected timers
   const intervals: Array<{ fn: () => void; ms: number; ref: number; fireAt: number }> = []
+  const timeouts: Array<{ fn: () => void; ref: number; fireAt: number }> = []
   let nextRef = 1
 
   const watcher = startSubagentWatcher({
@@ -210,6 +211,16 @@ function makeHarness(opts: {
       const idx = intervals.findIndex((i) => i.ref === ref)
       if (idx !== -1) intervals.splice(idx, 1)
     },
+    setTimeout: (fn, ms) => {
+      const ref = nextRef++
+      timeouts.push({ fn, ref, fireAt: currentTime + ms })
+      return { ref }
+    },
+    clearTimeout: (handle) => {
+      const { ref } = handle as { ref: number }
+      const idx = timeouts.findIndex((t) => t.ref === ref)
+      if (idx !== -1) timeouts.splice(idx, 1)
+    },
     fs: mockFs,
     log: (msg: string) => { logs.push(msg) },
   })
@@ -222,6 +233,15 @@ function makeHarness(opts: {
       const next = intervals[0]
       if (!next || next.fireAt > currentTime) break
       next.fireAt += next.ms
+      next.fn()
+    }
+    // Fire any one-shot timeouts whose fireAt <= currentTime — drain
+    // the queue (oneshots, so remove on fire).
+    for (;;) {
+      timeouts.sort((a, b) => a.fireAt - b.fireAt)
+      const next = timeouts[0]
+      if (!next || next.fireAt > currentTime) break
+      timeouts.shift()
       next.fn()
     }
   }
@@ -239,6 +259,8 @@ function makeHarness(opts: {
     watcher,
     now: () => currentTime,
     mockFs,
+    fakeWatchers,
+    pendingTimeouts: () => timeouts.length,
   }
 }
 
@@ -343,9 +365,11 @@ describe('startSubagentWatcher', () => {
       notifications: string[]
       poll: () => void
       watcher: ReturnType<typeof startSubagentWatcher>
+      fireScheduledCleanups: () => number
     } {
       const notifications: string[] = []
       const intervals: Array<{ fn: () => void; ref: number }> = []
+      const timeouts: Array<{ fn: () => void; ref: number }> = []
       let nextRef = 1
       const watcher = startSubagentWatcher({
         agentDir: opts.agentDir,
@@ -363,6 +387,16 @@ describe('startSubagentWatcher', () => {
           const idx = intervals.findIndex((i) => i.ref === ref)
           if (idx !== -1) intervals.splice(idx, 1)
         },
+        setTimeout: (fn) => {
+          const ref = nextRef++
+          timeouts.push({ fn, ref })
+          return { ref }
+        },
+        clearTimeout: (handle) => {
+          const { ref } = handle as { ref: number }
+          const idx = timeouts.findIndex((t) => t.ref === ref)
+          if (idx !== -1) timeouts.splice(idx, 1)
+        },
         log: () => {},
       })
       startedWatchers.push(watcher)
@@ -370,6 +404,17 @@ describe('startSubagentWatcher', () => {
         notifications,
         poll: () => intervals[0]?.fn(),
         watcher,
+        // Drain any scheduled deferred-cleanups regardless of fireAt time
+        // (tests use this to advance past the 30s grace deterministically).
+        fireScheduledCleanups: () => {
+          let fired = 0
+          while (timeouts.length) {
+            const next = timeouts.shift()!
+            next.fn()
+            fired++
+          }
+          return fired
+        },
       }
     }
 
@@ -461,6 +506,69 @@ describe('startSubagentWatcher', () => {
 
       const completionNotifs = h.notifications.filter((n) => n.includes('Worker done'))
       expect(completionNotifs).toHaveLength(1)
+    })
+
+    it('drops the FSWatcher + Map entries after terminal-state grace fires (MEM1)', () => {
+      // Pre-MEM1 fix: per-subagent FSWatcher entries lived for the
+      // entire process lifetime. With sustained sub-agent load a
+      // long-running gateway hit ulimit -n. This test pins the deferred
+      // cleanup contract: completion → fire grace timer → tails/registry
+      // entries removed → underlying FSWatcher closed.
+      const agentDir = join(tmpRoot, 'agent')
+      const subagentsDir = join(agentDir, '.claude', 'projects', 'p1', 'session-abc', 'subagents')
+      mkdirSync(subagentsDir, { recursive: true })
+      const jsonlPath = join(subagentsDir, 'agent-cleanme.jsonl')
+      writeFileSync(jsonlPath, buildJSONL(subAgentUserMsg('Do the task')))
+
+      const h = startWatcherSync({ agentDir })
+
+      // Discover + register the agent (running state).
+      h.poll()
+      expect(h.watcher.getRegistry().has('cleanme')).toBe(true)
+
+      // Append turn_end → done state → completion notification + scheduled cleanup.
+      appendFileSync(jsonlPath, buildJSONL(subAgentTurnDuration()))
+      h.poll()
+      expect(h.notifications.some((n) => n.includes('Worker done'))).toBe(true)
+      // Registry still has it during the 30s grace window.
+      expect(h.watcher.getRegistry().has('cleanme')).toBe(true)
+
+      // Drain pending timeouts (simulates 30s elapsing).
+      const fired = h.fireScheduledCleanups()
+      expect(fired).toBeGreaterThan(0)
+
+      // Post-grace: registry entry gone, downstream consumers see no
+      // dangling FSWatcher.
+      expect(h.watcher.getRegistry().has('cleanme')).toBe(false)
+    })
+
+    it('cleans up historical-and-already-done agents after grace (MEM1)', () => {
+      // Historical files (pre-existing at boot, already done) used to
+      // keep their FSWatcher open forever — they bypass the
+      // maybySendStateTransition done branch because completionNotified
+      // is set to true in the registerAgent path. Cleanup must still
+      // schedule there.
+      const agentDir = join(tmpRoot, 'agent')
+      const subagentsDir = join(agentDir, '.claude', 'projects', 'p1', 'session-abc', 'subagents')
+      mkdirSync(subagentsDir, { recursive: true })
+      const jsonlPath = join(subagentsDir, 'agent-historical.jsonl')
+      // Already-done at boot: contains turn_end already.
+      writeFileSync(jsonlPath, buildJSONL(
+        subAgentUserMsg('From a prior session'),
+        subAgentTurnDuration(),
+      ))
+
+      const h = startWatcherSync({ agentDir })
+
+      // Boot scan picks it up as historical-and-done; no completion
+      // notification fires (would be a spurious replay).
+      expect(h.notifications.filter((n) => n.includes('Worker done'))).toHaveLength(0)
+      expect(h.watcher.getRegistry().has('historical')).toBe(true)
+
+      // Cleanup is still scheduled (the FSWatcher would otherwise leak).
+      const fired = h.fireScheduledCleanups()
+      expect(fired).toBeGreaterThan(0)
+      expect(h.watcher.getRegistry().has('historical')).toBe(false)
     })
   })
 

--- a/telegram-plugin/tests/telegram-format.test.ts
+++ b/telegram-plugin/tests/telegram-format.test.ts
@@ -130,6 +130,37 @@ describe('markdownToHtml', () => {
     expect(result).not.toContain('</code></code>')
   })
 
+  test('inline code containing asterisks does not get re-matched by italic regex (#415)', () => {
+    // Regression for #415: inline-code spans containing `*` (e.g. C
+    // pointer syntax) used to be restored from their placeholder BEFORE
+    // the italic pass, so the italic regex would see `<code>size_t *p</code>`
+    // and try to wrap `p</code>...` in <i>...</i>, producing invalid HTML
+    // that Telegram rejected with 400 Bad Request, sending the caller into
+    // a `format: text` fallback for the rest of the chunk.
+    const result = markdownToHtml('Use `size_t *p` to declare a pointer.')
+    expect(result).toContain('<code>size_t *p</code>')
+    // No stray <i> wrapping the asterisk — pre-fix the buggy output was
+    // `<code>size_t <i>p</code> to declare a pointer.</i>`.
+    expect(result).not.toMatch(/<i>[^<]*<\/code>/)
+    expect(result).not.toMatch(/<code>[^<]*<i>/)
+  })
+
+  test('inline code containing double-asterisks does not get re-matched by bold regex (#415)', () => {
+    const result = markdownToHtml('Pattern is `**glob**` not regex.')
+    expect(result).toContain('<code>**glob**</code>')
+    // The bold regex must not have wrapped the literal asterisks inside <code>.
+    expect(result).not.toMatch(/<b>[^<]*<\/code>/)
+    expect(result).not.toMatch(/<code>[^<]*<b>/)
+  })
+
+  test('code block containing asterisks does not get re-matched by italic regex (#415)', () => {
+    const input = '```c\nsize_t *p = NULL;\n```'
+    const result = markdownToHtml(input)
+    expect(result).toContain('size_t *p = NULL;')
+    expect(result).not.toMatch(/<i>[^<]*<\/code>/)
+    expect(result).not.toMatch(/<i>[^<]*<\/pre>/)
+  })
+
   test('does not double-wrap when inline code sits alongside prose with file refs', () => {
     // Regression for the user-observed bug: messages that mixed inline code
     // spans (backticks around filenames) with prose produced

--- a/telegram-plugin/tests/turn-active-marker.test.ts
+++ b/telegram-plugin/tests/turn-active-marker.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Unit tests for the turn-active marker (#412 fix). The marker file
+ * exists exactly during in-flight turns; the bash watchdog reads its
+ * mtime to distinguish "wedged mid-turn" from "healthy idle".
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, rmSync, existsSync, readFileSync, statSync, utimesSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  TURN_ACTIVE_MARKER_FILE,
+  writeTurnActiveMarker,
+  touchTurnActiveMarker,
+  removeTurnActiveMarker,
+} from '../gateway/turn-active-marker.js'
+
+describe('turn-active-marker (#412)', () => {
+  let tmp: string
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), 'turn-active-'))
+  })
+
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true })
+  })
+
+  it('writeTurnActiveMarker creates a JSON file with the expected payload', () => {
+    writeTurnActiveMarker(tmp, {
+      turnKey: 'chat:1:1700000000000',
+      chatId: 'chat',
+      threadId: null,
+      startedAt: 1700000000000,
+    })
+    const path = join(tmp, TURN_ACTIVE_MARKER_FILE)
+    expect(existsSync(path)).toBe(true)
+    const parsed = JSON.parse(readFileSync(path, 'utf-8'))
+    expect(parsed.turnKey).toBe('chat:1:1700000000000')
+    expect(parsed.chatId).toBe('chat')
+    expect(parsed.startedAt).toBe(1700000000000)
+  })
+
+  it('writeTurnActiveMarker is idempotent (overwrites existing)', () => {
+    writeTurnActiveMarker(tmp, {
+      turnKey: 'k1',
+      chatId: 'c',
+      threadId: null,
+      startedAt: 1,
+    })
+    writeTurnActiveMarker(tmp, {
+      turnKey: 'k2',
+      chatId: 'c',
+      threadId: null,
+      startedAt: 2,
+    })
+    const parsed = JSON.parse(readFileSync(join(tmp, TURN_ACTIVE_MARKER_FILE), 'utf-8'))
+    expect(parsed.turnKey).toBe('k2')
+  })
+
+  it('touchTurnActiveMarker bumps the mtime', async () => {
+    writeTurnActiveMarker(tmp, {
+      turnKey: 'k',
+      chatId: 'c',
+      threadId: null,
+      startedAt: 1,
+    })
+    const path = join(tmp, TURN_ACTIVE_MARKER_FILE)
+    // Force the mtime to 5 minutes in the past so the touch is visible.
+    const past = new Date(Date.now() - 5 * 60 * 1000)
+    utimesSync(path, past, past)
+    const before = statSync(path).mtimeMs
+
+    touchTurnActiveMarker(tmp)
+    const after = statSync(path).mtimeMs
+    expect(after).toBeGreaterThan(before)
+  })
+
+  it('touchTurnActiveMarker is a no-op when no marker exists', () => {
+    // Must not throw, must not create the file.
+    touchTurnActiveMarker(tmp)
+    expect(existsSync(join(tmp, TURN_ACTIVE_MARKER_FILE))).toBe(false)
+  })
+
+  it('removeTurnActiveMarker deletes the file', () => {
+    writeTurnActiveMarker(tmp, {
+      turnKey: 'k',
+      chatId: 'c',
+      threadId: null,
+      startedAt: 1,
+    })
+    const path = join(tmp, TURN_ACTIVE_MARKER_FILE)
+    expect(existsSync(path)).toBe(true)
+    removeTurnActiveMarker(tmp)
+    expect(existsSync(path)).toBe(false)
+  })
+
+  it('removeTurnActiveMarker is idempotent (no throw on missing file)', () => {
+    expect(() => removeTurnActiveMarker(tmp)).not.toThrow()
+    expect(() => removeTurnActiveMarker(tmp)).not.toThrow()
+  })
+
+  it('writeTurnActiveMarker creates the state dir if missing', () => {
+    const fresh = join(tmp, 'fresh', 'subdir')
+    writeTurnActiveMarker(fresh, {
+      turnKey: 'k',
+      chatId: 'c',
+      threadId: null,
+      startedAt: 1,
+    })
+    expect(existsSync(join(fresh, TURN_ACTIVE_MARKER_FILE))).toBe(true)
+  })
+
+  it('writes mode 0600 (operator-only readable)', () => {
+    writeTurnActiveMarker(tmp, {
+      turnKey: 'k',
+      chatId: 'c',
+      threadId: null,
+      startedAt: 1,
+    })
+    const path = join(tmp, TURN_ACTIVE_MARKER_FILE)
+    const mode = statSync(path).mode & 0o777
+    expect(mode).toBe(0o600)
+  })
+})

--- a/telegram-plugin/tests/vault-grant-wizard.test.ts
+++ b/telegram-plugin/tests/vault-grant-wizard.test.ts
@@ -6,8 +6,10 @@
  * Grammy/Bot harness. We pin the behaviour at the file level with grep
  * against the source so a regression in either file is caught.
  *
- * Note: this PR wires the wizard in server.ts (monolith polling mode)
- * only. gateway/gateway.ts wiring is filed as a follow-up.
+ * Both surfaces are tested in parallel: server.ts (monolith polling
+ * mode) and gateway/gateway.ts (split mode). The gateway port landed
+ * in PR #262; this file's gateway describe-block was added in
+ * follow-up #265.
  */
 import { describe, it, expect } from 'vitest'
 import { readFileSync } from 'node:fs'
@@ -80,5 +82,77 @@ describe('/vault grant inline-keyboard wizard (#227)', () => {
     )
     expect(slice).not.toMatch(/console\.log[^;]*\.token\b/)
     expect(slice).not.toMatch(/logger\.[a-z]+[^;]*\.token\b/)
+  })
+
+  it('server.ts: agent name validated before path join (#265 item 1)', () => {
+    // Pre-#265 fix `state.agent!` flowed straight into a path join. The
+    // wizard is admin-DM-only, but defense-in-depth: assertSafeAgentName
+    // should bracket the executeGrantWizard path-write.
+    const slice = serverSrc.slice(
+      serverSrc.indexOf('async function executeGrantWizard'),
+      serverSrc.indexOf('async function executeGrantWizard') + 4000,
+    )
+    expect(slice).toMatch(/assertSafeAgentName\(\s*state\.agent/)
+  })
+
+  it('server.ts: keys-continue empty branch can show its toast (#265 item 2)', () => {
+    // The unconditional `await ctx.answerCallbackQuery().catch(() => {})`
+    // up front used to swallow the keys-continue toast. The fix moved
+    // ack into per-branch tails. Pin the structural shape so a future
+    // rework that re-adds the unconditional pre-ack regresses loudly.
+    const wizardSlice = serverSrc.slice(
+      serverSrc.indexOf("// #227 grant wizard callbacks"),
+      serverSrc.indexOf("// #227 grant wizard callbacks") + 6000,
+    )
+    expect(wizardSlice).toContain("Select at least one key.")
+    // Ensure the per-branch ack helper exists (proves no unconditional
+    // pre-ack at the top of the wizard block).
+    expect(wizardSlice).toContain('const ackSilently')
+  })
+})
+
+describe('/vault grant inline-keyboard wizard — gateway parity (#262, #265)', () => {
+  // Gateway port of the wizard. Mirrors the server.ts assertions so a
+  // change to one file without the other is caught by CI.
+  const gatewaySrc = readSrc('telegram-plugin/gateway/gateway.ts')
+
+  it('gateway.ts: dispatches /vault grant to the wizard entry', () => {
+    expect(gatewaySrc).toMatch(/\/vault grant/i)
+    expect(gatewaySrc).toContain("kind: 'grant-wizard'")
+  })
+
+  it('gateway.ts: wizard state-machine has step transitions', () => {
+    expect(gatewaySrc).toContain('grantWizardStep3')
+    expect(gatewaySrc).toContain('grantWizardConfirm')
+    expect(gatewaySrc).toContain('executeGrantWizard')
+  })
+
+  it('gateway.ts: wizard callback prefix vg: is registered', () => {
+    expect(gatewaySrc).toContain('vg:')
+  })
+
+  it('gateway.ts: expired-wizard sessions reply with a clear error', () => {
+    expect(gatewaySrc).toMatch(/Wizard session expired|Run \/vault grant to start again/i)
+  })
+
+  it('gateway.ts: custom-duration text-reply path exists', () => {
+    expect(gatewaySrc).toContain('awaitingCustomDuration')
+  })
+
+  it('gateway.ts: agent name validated before path join (#265 item 1)', () => {
+    const slice = gatewaySrc.slice(
+      gatewaySrc.indexOf('async function executeGrantWizard'),
+      gatewaySrc.indexOf('async function executeGrantWizard') + 4000,
+    )
+    expect(slice).toMatch(/assertSafeAgentName\(\s*state\.agent/)
+  })
+
+  it('gateway.ts: keys-continue empty branch can show its toast (#265 item 2)', () => {
+    const wizardSlice = gatewaySrc.slice(
+      gatewaySrc.indexOf("// #227 grant wizard callbacks"),
+      gatewaySrc.indexOf("// #227 grant wizard callbacks") + 6000,
+    )
+    expect(wizardSlice).toContain("Select at least one key.")
+    expect(wizardSlice).toContain('const ackSilently')
   })
 })

--- a/tests/lifecycle-restart-reason.test.ts
+++ b/tests/lifecycle-restart-reason.test.ts
@@ -117,6 +117,40 @@ describe("lifecycle: restart-reason marker", () => {
   });
 });
 
+describe("lifecycle: restartAgent ordering (#177)", () => {
+  // Pre-#177 fix: gateway service was restarted FIRST, agent service
+  // SECOND. Problem: when a detached child of the gateway calls
+  // restartAgent, that child is in the gateway's cgroup. systemctl
+  // restart of the gateway cgroup-kills the child mid-flight, before
+  // the second `systemctl restart` (the agent service) ever runs.
+  // The user types /new, sees the gateway bounce, but the session
+  // doesn't actually rotate.
+  //
+  // This test pins the source ordering so a future re-edit can't
+  // silently regress.
+  it("calls systemctl restart on the agent service BEFORE the gateway service", async () => {
+    const { readFileSync } = await import("node:fs");
+    const { resolve, join: joinPath } = await import("node:path");
+    const { fileURLToPath } = await import("node:url");
+    const TEST_DIR = resolve(fileURLToPath(import.meta.url), "..");
+    const REPO_ROOT = resolve(TEST_DIR, "..");
+    const src = readFileSync(joinPath(REPO_ROOT, "src/agents/lifecycle.ts"), "utf-8");
+
+    // Find the restartAgent function body and inspect ordering.
+    const funcStart = src.indexOf("export function restartAgent(");
+    const funcEnd = src.indexOf("\n}\n", funcStart);
+    expect(funcStart).toBeGreaterThan(0);
+    const body = src.slice(funcStart, funcEnd);
+
+    const agentRestartIdx = body.indexOf('systemctl(["restart", serviceName(name)])');
+    const gatewayRestartIdx = body.indexOf('systemctlIfExists("restart", gatewayServiceName(name))');
+    expect(agentRestartIdx).toBeGreaterThan(0);
+    expect(gatewayRestartIdx).toBeGreaterThan(0);
+    // Agent first, gateway second — the post-#177 fix.
+    expect(agentRestartIdx).toBeLessThan(gatewayRestartIdx);
+  });
+});
+
 describe("lifecycle: buildCliRestartReason", () => {
   it("returns 'cli: restart' when buildCommit is null (npm-installed, no build-info)", () => {
     expect(buildCliRestartReason({ buildCommit: null })).toBe("cli: restart");

--- a/tests/merge.test.ts
+++ b/tests/merge.test.ts
@@ -239,6 +239,22 @@ describe("mergeAgentConfig", () => {
     expect(result.memory?.recall?.max_memories).toBe(3);
   });
 
+  it("agent setting memory.recall.<other-key> does NOT clobber defaults.memory.recall.max_memories (DOC2)", () => {
+    // Pre-DOC2 fix the recall sub-object was shallow-merged: agent setting
+    // any recall.* key replaced the entire recall object, silently dropping
+    // every other recall.* default. The fix deep-merges the recall block
+    // (one level) so individual knobs override independently.
+    const defaults: AgentDefaults = {
+      memory: { recall: { max_memories: 12, cache_ttl_secs: 600 } },
+    };
+    const agent = baseAgent({
+      memory: { recall: { cache_ttl_secs: 30 } },
+    });
+    const result = mergeAgentConfig(defaults, agent);
+    expect(result.memory?.recall?.max_memories).toBe(12); // preserved from defaults
+    expect(result.memory?.recall?.cache_ttl_secs).toBe(30); // agent override
+  });
+
   it("prepends defaults.schedule to agent.schedule", () => {
     const defaults: AgentDefaults = {
       schedule: [{ cron: "0 8 * * *", prompt: "Morning check-in" }],

--- a/tests/reconcile-hooks-drift.test.ts
+++ b/tests/reconcile-hooks-drift.test.ts
@@ -66,7 +66,7 @@ describe("buildSettingsHooksBlock", () => {
     const subagentPreEntry = preHooks.find(e =>
       e.hooks.some(h => h.command.includes("subagent-tracker-pretool.mjs")),
     );
-    expect(subagentPreEntry?.matcher).toBe("Agent");
+    expect(subagentPreEntry?.matcher).toBe("^(Agent|Task)$");
 
     expect(result.PostToolUse).toBeDefined();
     const postHooks = result.PostToolUse as Array<{ matcher?: string; hooks: Array<{ command: string }> }>;
@@ -75,7 +75,7 @@ describe("buildSettingsHooksBlock", () => {
     const subagentPostEntry = postHooks.find(e =>
       e.hooks.some(h => h.command.includes("subagent-tracker-posttool.mjs")),
     );
-    expect(subagentPostEntry?.matcher).toBe("Agent");
+    expect(subagentPostEntry?.matcher).toBe("^(Agent|Task)$");
   });
 
   it("with user hooks declared merges them with switchroom-owned hooks", () => {

--- a/tests/scaffold.test.ts
+++ b/tests/scaffold.test.ts
@@ -1933,6 +1933,81 @@ describe("scaffoldAgent with global defaults cascade", () => {
     expect(startSh).toMatch(/exec claude.*'--effort' 'high' '--add-dir' '\/tmp\/has space'/);
   });
 
+  it("add_dirs become repeated --add-dir flags (#199)", () => {
+    const agentConfig = makeAgentConfig({
+      add_dirs: ["/share/collab", "/home/me/finance"],
+    });
+    const result = scaffoldAgent(
+      "adddirs-agent",
+      agentConfig,
+      tmpDir,
+      telegramConfig,
+    );
+    const startSh = readFileSync(join(result.agentDir, "start.sh"), "utf-8");
+    expect(startSh).toContain("--add-dir '/share/collab'");
+    expect(startSh).toContain("--add-dir '/home/me/finance'");
+  });
+
+  it("allowed_tools become a single quoted --allowedTools flag (#199)", () => {
+    const agentConfig = makeAgentConfig({
+      allowed_tools: ["Bash(git *)", "Bash(npm *)", "Edit"],
+    });
+    const result = scaffoldAgent(
+      "allowedtools-agent",
+      agentConfig,
+      tmpDir,
+      telegramConfig,
+    );
+    const startSh = readFileSync(join(result.agentDir, "start.sh"), "utf-8");
+    expect(startSh).toMatch(/--allowedTools 'Bash\(git \*\) Bash\(npm \*\) Edit'/);
+  });
+
+  it("disallowed_tools become a single quoted --disallowedTools flag (#199)", () => {
+    const agentConfig = makeAgentConfig({
+      disallowed_tools: ["WebFetch", "Bash(rm *)"],
+    });
+    const result = scaffoldAgent(
+      "disallowedtools-agent",
+      agentConfig,
+      tmpDir,
+      telegramConfig,
+    );
+    const startSh = readFileSync(join(result.agentDir, "start.sh"), "utf-8");
+    expect(startSh).toMatch(/--disallowedTools 'WebFetch Bash\(rm \*\)'/);
+  });
+
+  it("add_dirs + allowed_tools + cli_args coexist (#199)", () => {
+    const agentConfig = makeAgentConfig({
+      cli_args: ["--effort", "high"],
+      add_dirs: ["/share"],
+      allowed_tools: ["Edit"],
+    });
+    const result = scaffoldAgent(
+      "combined-agent",
+      agentConfig,
+      tmpDir,
+      telegramConfig,
+    );
+    const startSh = readFileSync(join(result.agentDir, "start.sh"), "utf-8");
+    expect(startSh).toContain("'--effort' 'high'");
+    expect(startSh).toContain("--add-dir '/share'");
+    expect(startSh).toContain("--allowedTools 'Edit'");
+  });
+
+  it("agents with no add_dirs/allowed_tools/disallowed_tools render no flags (#199)", () => {
+    const agentConfig = makeAgentConfig();
+    const result = scaffoldAgent(
+      "bare-agent",
+      agentConfig,
+      tmpDir,
+      telegramConfig,
+    );
+    const startSh = readFileSync(join(result.agentDir, "start.sh"), "utf-8");
+    expect(startSh).not.toContain("--add-dir");
+    expect(startSh).not.toContain("--allowedTools");
+    expect(startSh).not.toContain("--disallowedTools");
+  });
+
   it("channels.telegram.plugin: 'switchroom' writes .mcp.json for forked telegram plugin", () => {
     const agentConfig = makeAgentConfig({
       channels: { telegram: { plugin: "switchroom" } },

--- a/tests/scaffold.test.ts
+++ b/tests/scaffold.test.ts
@@ -2875,6 +2875,28 @@ describe("session freshness in start.sh", () => {
     expect(startSh).not.toContain(".resume-next-start");
   });
 
+  it("session.max_idle wires SWITCHROOM_SESSION_MAX_IDLE_SECS into auto-mode resume (#218)", () => {
+    const agentConfig = makeAgentConfig({
+      session: { max_idle: "2h" },
+      session_continuity: { resume_mode: "auto" },
+    });
+    const result = scaffoldAgent(
+      "idle-bound-agent",
+      agentConfig,
+      tmpDir,
+      telegramConfig,
+    );
+    const startSh = readFileSync(join(result.agentDir, "start.sh"), "utf-8");
+
+    // Configured max_idle is exported as the env var (2h = 7200s).
+    expect(startSh).toContain('SWITCHROOM_SESSION_MAX_IDLE_SECS="7200"');
+    // Auto-mode comparison consults the env var (with 7d default fallback).
+    expect(startSh).toContain('"${SWITCHROOM_SESSION_MAX_IDLE_SECS:-604800}"');
+    // The hard-coded 604800 from the comparison should no longer appear
+    // — it now lives only in the bash-default fallback.
+    expect(startSh).not.toMatch(/-lt 604800 ];/);
+  });
+
   it("installs the Stop hook for handoff by default", () => {
     const agentConfig = makeAgentConfig();
     const switchroomConfig: SwitchroomConfig = {

--- a/tests/telegram-plugin-manifest.test.ts
+++ b/tests/telegram-plugin-manifest.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Phase 1 of #233: telegram-plugin manifest scaffolding (#229).
+ *
+ * The manifest establishes the path for #230 (scaffold.ts switching from
+ * the hand-installed .mcp.json + hook commands to plugin-driven
+ * `enabledPlugins: { 'switchroom-telegram': true }`). This phase changes
+ * no agent behaviour — it just adds files. Tests pin existence + JSON
+ * shape so a future template edit can't silently regress the manifest.
+ */
+
+import { describe, it, expect } from "vitest";
+import { existsSync, readFileSync } from "node:fs";
+import { resolve, join } from "node:path";
+
+const REPO_ROOT = resolve(__dirname, "..");
+
+describe("telegram-plugin manifest (#229)", () => {
+  it("plugin.json exists and declares switchroom-telegram", () => {
+    const path = join(REPO_ROOT, "telegram-plugin", ".claude-plugin", "plugin.json");
+    expect(existsSync(path)).toBe(true);
+    const m = JSON.parse(readFileSync(path, "utf-8"));
+    expect(m.name).toBe("switchroom-telegram");
+    expect(typeof m.version).toBe("string");
+    expect(m.version.length).toBeGreaterThan(0);
+  });
+
+  it(".mcp.json declares the switchroom-telegram MCP server", () => {
+    const path = join(REPO_ROOT, "telegram-plugin", ".mcp.json");
+    expect(existsSync(path)).toBe(true);
+    const m = JSON.parse(readFileSync(path, "utf-8"));
+    expect(m.mcpServers).toBeDefined();
+    expect(m.mcpServers["switchroom-telegram"]).toBeDefined();
+    const server = m.mcpServers["switchroom-telegram"];
+    expect(server.command).toBe("bun");
+    expect(Array.isArray(server.args)).toBe(true);
+    // Must use ${CLAUDE_PLUGIN_ROOT} so the plugin loader resolves the
+    // cwd correctly when installed from the marketplace.
+    expect(server.args.some((a: string) => a.includes("${CLAUDE_PLUGIN_ROOT}"))).toBe(true);
+  });
+
+  it("hooks/hooks.json declares the four hook events the plugin owns", () => {
+    const path = join(REPO_ROOT, "telegram-plugin", "hooks", "hooks.json");
+    expect(existsSync(path)).toBe(true);
+    const m = JSON.parse(readFileSync(path, "utf-8"));
+    expect(m.hooks).toBeDefined();
+    expect(Array.isArray(m.hooks.PreToolUse)).toBe(true);
+    expect(Array.isArray(m.hooks.PostToolUse)).toBe(true);
+    expect(Array.isArray(m.hooks.Stop)).toBe(true);
+  });
+
+  it("hook commands all use ${CLAUDE_PLUGIN_ROOT}", () => {
+    // Every hook command in the plugin must be portable across install
+    // paths — that's the whole point of the manifest. Hardcoded absolute
+    // paths would break the moment someone installs from a different
+    // marketplace or a different repo location.
+    const path = join(REPO_ROOT, "telegram-plugin", "hooks", "hooks.json");
+    const m = JSON.parse(readFileSync(path, "utf-8")) as {
+      hooks: Record<string, Array<{ hooks: Array<{ command: string }> }>>;
+    };
+    const allCommands: string[] = [];
+    for (const eventGroups of Object.values(m.hooks)) {
+      for (const group of eventGroups) {
+        for (const h of group.hooks) {
+          allCommands.push(h.command);
+        }
+      }
+    }
+    expect(allCommands.length).toBeGreaterThan(0);
+    for (const c of allCommands) {
+      expect(c).toContain("${CLAUDE_PLUGIN_ROOT}");
+    }
+  });
+
+  it("hook commands cover the same five hook surfaces scaffold.ts wires today", () => {
+    // The plugin manifest must own the same set of hook scripts the
+    // scaffold currently writes by hand. This pins the migration
+    // contract: #230 swaps scaffold's hand-wired path for the plugin
+    // path, but the scripts that run must be identical.
+    const path = join(REPO_ROOT, "telegram-plugin", "hooks", "hooks.json");
+    const m = JSON.parse(readFileSync(path, "utf-8")) as {
+      hooks: Record<string, Array<{ hooks: Array<{ command: string }> }>>;
+    };
+    const all = JSON.stringify(m);
+    expect(all).toContain("secret-guard-pretool.mjs");
+    expect(all).toContain("subagent-tracker-pretool.mjs");
+    expect(all).toContain("subagent-tracker-posttool.mjs");
+    expect(all).toContain("secret-scrub-stop.mjs");
+    expect(all).toContain("silent-end-interrupt-stop.mjs");
+  });
+
+  it("subagent-tracker hooks gate on Agent or Task (regex matcher)", () => {
+    // Pre-#262: matcher was the literal "Agent". Post-fix: regex
+    // covering both `Agent` and `Task` for Claude Code version
+    // compatibility. Pin so the plugin manifest stays aligned with
+    // the gate the tracker hooks themselves enforce.
+    const path = join(REPO_ROOT, "telegram-plugin", "hooks", "hooks.json");
+    const m = JSON.parse(readFileSync(path, "utf-8")) as {
+      hooks: Record<string, Array<{ matcher?: string; hooks: Array<{ command: string }> }>>;
+    };
+    const trackerEntries = [...(m.hooks.PreToolUse ?? []), ...(m.hooks.PostToolUse ?? [])].filter((g) =>
+      g.hooks.some((h) => h.command.includes("subagent-tracker"))
+    );
+    expect(trackerEntries.length).toBeGreaterThanOrEqual(2);
+    for (const entry of trackerEntries) {
+      expect(entry.matcher).toBe("^(Agent|Task)$");
+    }
+  });
+});
+
+describe("marketplace.json — switchroom-telegram entry (#229)", () => {
+  it("includes a second plugin entry pointing at telegram-plugin/", () => {
+    const path = join(REPO_ROOT, ".claude-plugin", "marketplace.json");
+    expect(existsSync(path)).toBe(true);
+    const m = JSON.parse(readFileSync(path, "utf-8")) as {
+      plugins: Array<{ name: string; source: string; category?: string }>;
+    };
+    expect(m.plugins.length).toBeGreaterThanOrEqual(2);
+    const telegramEntry = m.plugins.find((p) => p.name === "switchroom-telegram");
+    expect(telegramEntry).toBeDefined();
+    expect(telegramEntry!.source).toBe("./telegram-plugin");
+    expect(telegramEntry!.category).toBe("messaging");
+  });
+
+  it("marketplace source path resolves to a real directory", () => {
+    const path = join(REPO_ROOT, ".claude-plugin", "marketplace.json");
+    const m = JSON.parse(readFileSync(path, "utf-8")) as {
+      plugins: Array<{ source: string }>;
+    };
+    for (const p of m.plugins) {
+      // Resolve relative to the repo root since `source` paths are repo-relative.
+      const resolved = resolve(REPO_ROOT, p.source);
+      expect(existsSync(resolved)).toBe(true);
+    }
+  });
+});

--- a/tests/workspace-dynamic-hook.test.ts
+++ b/tests/workspace-dynamic-hook.test.ts
@@ -24,6 +24,11 @@ function runHook(opts: {
   agentName?: string;
   cacheDir: string;
   shimDir: string;
+  /** Override the workspace dir the mtime fast-skip walks. Default is
+   * `~/.switchroom/agents/<agentName>/workspace`. Tests use this to
+   * point at a tmp tree so they can touch source files to invalidate
+   * the cache deterministically. */
+  agentDirOverride?: string;
 }): RunResult {
   const env: Record<string, string> = {
     ...process.env as Record<string, string>,
@@ -34,6 +39,11 @@ function runHook(opts: {
     env.SWITCHROOM_AGENT_NAME = opts.agentName;
   } else {
     delete env.SWITCHROOM_AGENT_NAME;
+  }
+  if (opts.agentDirOverride !== undefined) {
+    env.SWITCHROOM_AGENT_DIR = opts.agentDirOverride;
+  } else {
+    delete env.SWITCHROOM_AGENT_DIR;
   }
   try {
     const stdout = execFileSync("bash", [HOOK], { env, encoding: "utf-8" });
@@ -72,6 +82,13 @@ describe("workspace-dynamic-hook.sh", () => {
   let cacheDir: string;
   let shimDir: string;
 
+  // The hook date-keys cache filenames so the calendar-day rollover
+  // invalidates yesterday's cache (the renderer embeds today's daily
+  // path in the body). Compute the same UTC date the script does.
+  function todayUtc(): string {
+    return new Date().toISOString().slice(0, 10);
+  }
+
   beforeEach(() => {
     tmp = mkdtempSync(join(tmpdir(), "ws-dyn-hook-"));
     cacheDir = join(tmp, "claude");
@@ -89,7 +106,7 @@ describe("workspace-dynamic-hook.sh", () => {
     expect(r.exitCode).toBe(0);
     expect(r.stdout).toBe("");
     // Critically: NO cache file. Otherwise we'd re-emit empty forever.
-    const hookCache = join(cacheDir, "switchroom-hookcache", "workspace-dynamic.hash");
+    const hookCache = join(cacheDir, "switchroom-hookcache", `workspace-dynamic.${todayUtc()}.hash`);
     expect(existsSync(hookCache)).toBe(false);
   });
 
@@ -101,8 +118,9 @@ describe("workspace-dynamic-hook.sh", () => {
     expect(r.stdout).toContain("thing one");
     expect(r.stdout).toContain("thing two");
 
-    const hashFile = join(cacheDir, "switchroom-hookcache", "workspace-dynamic.hash");
-    const bodyFile = join(cacheDir, "switchroom-hookcache", "workspace-dynamic.body");
+    const date = todayUtc();
+    const hashFile = join(cacheDir, "switchroom-hookcache", `workspace-dynamic.${date}.hash`);
+    const bodyFile = join(cacheDir, "switchroom-hookcache", `workspace-dynamic.${date}.body`);
     expect(existsSync(hashFile)).toBe(true);
     expect(existsSync(bodyFile)).toBe(true);
     expect(readFileSync(bodyFile, "utf-8")).toContain("thing one");
@@ -119,17 +137,44 @@ describe("workspace-dynamic-hook.sh", () => {
     expect(a.stdout).toContain("stable-payload-");
   });
 
-  it("re-emits and re-caches when the render output changes", () => {
+  it("re-emits and re-caches when the render output changes", async () => {
+    // The mtime-fastskip path emits the cached body when no workspace
+    // source file is newer than it. To exercise the content-changed
+    // path deterministically we use a tmp agent dir + touch a source
+    // file between runs. Without this the fast-skip would short-circuit
+    // and the second runHook would never call the new shim.
+    const fakeAgentDir = join(tmp, "agent");
+    const wsDir = join(fakeAgentDir, "workspace");
+    mkdirSync(wsDir, { recursive: true });
+    const memPath = join(wsDir, "MEMORY.md");
+    writeFileSync(memPath, "v1");
+
     makeShim(shimDir, "first body content");
-    const a = runHook({ agentName: "klanker", cacheDir, shimDir });
+    const a = runHook({
+      agentName: "klanker",
+      cacheDir,
+      shimDir,
+      agentDirOverride: fakeAgentDir,
+    });
     expect(a.stdout).toContain("first body");
 
+    // Sleep ≥ 1s so the next stat-based mtime tick is observable
+    // (stat -c %Y returns whole seconds).
+    await new Promise((r) => setTimeout(r, 1100));
+    writeFileSync(memPath, "v2"); // bumps mtime past the body file
+
     makeShim(shimDir, "second body content");
-    const b = runHook({ agentName: "klanker", cacheDir, shimDir });
+    const b = runHook({
+      agentName: "klanker",
+      cacheDir,
+      shimDir,
+      agentDirOverride: fakeAgentDir,
+    });
     expect(b.stdout).toContain("second body");
     expect(b.stdout).not.toBe(a.stdout);
 
-    const bodyFile = join(cacheDir, "switchroom-hookcache", "workspace-dynamic.body");
+    const date = todayUtc();
+    const bodyFile = join(cacheDir, "switchroom-hookcache", `workspace-dynamic.${date}.body`);
     expect(readFileSync(bodyFile, "utf-8")).toContain("second body");
   });
 

--- a/vendor/hindsight-memory/scripts/lib/client.py
+++ b/vendor/hindsight-memory/scripts/lib/client.py
@@ -149,6 +149,46 @@ class HindsightClient:
         }
         return self._request("POST", path, body, timeout=timeout)
 
+    def list_directives(
+        self,
+        bank_id: str,
+        active_only: bool = True,
+        tags: Optional[list] = None,
+        timeout: int = 5,
+    ) -> dict:
+        """List active directives for a bank.
+
+        Switchroom-local: this method was missing in the vendored
+        HindsightClient even though `lib/directives.py` (also
+        switchroom-local, the workaround for upstream
+        vectorize-io/hindsight#1269) calls it on every recall hook.
+        Without this method the directives fetch always raised
+        AttributeError → silently caught at directives.py:47-49 → no
+        directives ever surfaced in the recall block.
+
+        The upstream REST endpoint is `GET
+        /v1/default/banks/{bank_id}/directives` with `active_only` and
+        optional `tags` query params (see upstream
+        `hindsight-clients/python/hindsight_client_api/api/directives_api.py`).
+
+        Returns the raw response dict, expected to have an `items` list
+        of directives where each item has at least `id`, `name`,
+        `content`, `priority`, `is_active`, `tags`. Caller (directives.py)
+        already defends against missing/malformed entries.
+        """
+        params = {}
+        if active_only:
+            # Server expects lowercase string per the OpenAPI spec.
+            params["active_only"] = "true"
+        if tags:
+            # Hindsight accepts repeated `tags=` query params for
+            # multi-tag filtering. urlencode with doseq=True handles it.
+            params["tags"] = tags
+        path = f"/v1/default/banks/{urllib.parse.quote(bank_id, safe='')}/directives"
+        if params:
+            path = f"{path}?{urllib.parse.urlencode(params, doseq=True)}"
+        return self._request("GET", path, timeout=timeout)
+
     def set_bank_mission(
         self, bank_id: str, mission: str, retain_mission: Optional[str] = None, timeout: int = 15
     ) -> dict:


### PR DESCRIPTION
## Summary

Six coupled UX/cleanup fixes for the chat surface. Each closes its own issue; they ship together because they all touch the user's first interaction with the agent.

**Closes:** `#61` (defense #1), `#320`, `#403`, `#443`, `#478`, `#479`

## What changed

### #479 — pre-alloc placeholder in groups (not just DMs)
`gateway.ts` — drop the `isDmChatId(chat_id)` gate. Pre-fix the `🔵 thinking…` placeholder fired only in DMs; groups (including the standard switchroom forum-topic layout) saw nothing until the progress card promoted at ≥30s. The `messageThreadId == null` guard is preserved (sendMessageDraft doesn't accept message_thread_id; full forum-topic placeholder is a separate change).

### #478 — promote progress card on parent-tool count
`progress-card-driver.ts` — new `promoteOnParentToolCount` config (default 3). After ≥3 parent-side tool calls during the suppression window, the card promotes. Symmetric to existing `promoteOnSubAgent`. Fast-turn suppression in `flush()` is unchanged.

### #320 + #403 — drop strikethrough on done items
`progress-card.ts` — three render paths now consistent: no `<s>` wrap on done items. Telegram desktop renders strikethrough red, which users read as "deleted/failed". The `●` bullet + plain weight already differentiates done from active. Closes both #320 and #403 (which proposed opposite directions; the user-complaint resolution wins).

### #443 — /issues clear requires --confirm
`gateway.ts` — bare `/issues clear` now prints "this will resolve N issues" + asks for `/issues clear --confirm`. A fat-finger no longer mass-resolves the visibility surface in one shot.

### #61 (defense #1) — switchroom agent restart warns on non-main branch
`src/cli/agent.ts` — pre-restart `checkSwitchroomBranch()` probe. Gateway runs source directly via `bun gateway.ts` (no compile step), so whatever branch is checked out IS what the gateway picks up. Warning forces operator acknowledgment before `--force`. Best-effort: any git error returns null so npm-global installs aren't broken.

## Test plan

- [x] vitest sweep clean (4198 passed)
- [x] `bun test tests/progress-card-driver.test.ts` — 144 pass (3 new for #478)
- [x] `bun test tests/progress-card.test.ts` — 135 pass (3 updated for #320)
- [ ] Smoke: send a message in a group / forum topic → `🔵 thinking…` placeholder appears within ~1s
- [ ] Smoke: turn with 3 Read/Grep/Bash calls in <30s → progress card surfaces; 1-2 tool calls in <30s → card stays suppressed
- [ ] Smoke: `/issues clear` (bare) → asks for confirmation; `/issues clear --confirm` → executes
- [ ] Smoke: `switchroom agent restart` from a feature branch → warning appears; `--force` proceeds

## Notes

- **`#480`** (true token-streaming) is the umbrella; this PR ships the prompt-driven streaming reliability path A from #480's notes. The bigger bridge → gateway PTY-partial IPC (#482b) is deferred — see audit comment on #482.
- **`#134`** (silent non-response) — adjacent but needs separate investigation.
- **`#61` defense #4** (doctor probe for running gateway commit) — separate, larger ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
