### PR TITLE
fix(ux): streaming/UX bundle rebased onto current main (supersedes #487)

### DIFF
--- a/src/cli/agent.ts
+++ b/src/cli/agent.ts
@@ -57,6 +57,59 @@ import { registerAgentPerfCommand } from "./perf.js";
  *
  * Returns an array of error strings. Empty = all checks passed.
  */
+/**
+ * Defense-in-depth (#61): detect when the switchroom checkout is on a
+ * non-main branch or has a dirty working tree. The gateway runs source
+ * directly via `bun gateway.ts` (no compile step), so whatever branch
+ * is checked out IS what the gateway picks up after restart. Restarting
+ * from a feature branch silently bypasses release tags + PR-merged fixes.
+ *
+ * Returns:
+ *   - null when on main with a clean tree (or git is unavailable —
+ *     swallow the error rather than break the restart path)
+ *   - a one-line warning string otherwise
+ *
+ * The check uses execFileSync against git in the cwd. Any git error
+ * (not a repo, no main ref, no remote, etc) returns null so this
+ * never blocks restart on hosts that aren't running from a git
+ * checkout (npm-global installs, prebuilt dist, etc).
+ */
+function checkSwitchroomBranch(): string | null {
+  // Locate the switchroom install directory. The CLI may be running
+  // from a global install (in which case there's no git checkout) or
+  // from `bun run dev` (in which case the cwd is the checkout).
+  // process.cwd() works for the dev path; the global path returns a
+  // non-git error which we swallow.
+  try {
+    // node-fetch-style execFileSync for predictable shell-free invocation.
+    const { execFileSync } = require("node:child_process") as typeof import("node:child_process");
+    const cwd = process.cwd();
+    const branch = execFileSync("git", ["-C", cwd, "rev-parse", "--abbrev-ref", "HEAD"], {
+      encoding: "utf-8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+    if (branch === "" || branch === "HEAD") return null; // detached or empty — punt
+    if (branch === "main" || branch === "master") {
+      // On main — check for uncommitted changes (which would also alter
+      // gateway behaviour).
+      const status = execFileSync("git", ["-C", cwd, "status", "--porcelain"], {
+        encoding: "utf-8",
+        stdio: ["ignore", "pipe", "ignore"],
+      });
+      if (status.trim().length > 0) {
+        return `switchroom checkout has uncommitted changes on ${branch}`;
+      }
+      return null;
+    }
+    return `switchroom checkout is on branch '${branch}', not main`;
+  } catch {
+    // Not a git repo, or git unavailable, or any other error — assume
+    // the host runs from a non-checkout install (npm-global, prebuilt
+    // dist, etc) and skip the warning.
+    return null;
+  }
+}
+
 function preflightCheck(
   name: string,
   agentDir: string,
@@ -986,6 +1039,30 @@ export function registerAgentCommand(program: Command): void {
           const agentsDir = resolveAgentsDir(config);
           const names =
             name === "all" ? Object.keys(config.agents) : [name];
+
+          // #61 defense #1: warn if the switchroom checkout is on a non-main
+          // branch. The gateway runs source directly via `bun gateway.ts`
+          // (no compile step), so whatever branch is checked out IS what the
+          // gateway will pick up after restart. Restarting from a feature
+          // branch silently bypasses release tags + PR-merged fixes — which
+          // is exactly the scenario most likely to surface bugs.
+          if (!opts.force) {
+            const branchWarning = checkSwitchroomBranch();
+            if (branchWarning != null) {
+              console.error(chalk.yellow(`\n  ⚠ ${branchWarning}`));
+              console.error(
+                chalk.gray(
+                  `\n  The gateway will run code from this branch after restart.`
+                )
+              );
+              console.error(
+                chalk.gray(
+                  `  Switch to main with \`git checkout main && git pull\`, or use --force to proceed anyway.\n`
+                )
+              );
+              process.exit(1);
+            }
+          }
 
           let sawAbort = false;
 

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -3776,15 +3776,23 @@ async function handleInbound(
     // so the user sees a real "I'm working" signal, not three dots that
     // could read as "still loading the message." Hooks can refine this
     // mid-turn via the `update_placeholder` IPC message.
+    // #479 fix: drop the DM-only gate so non-forum group chats also get
+    // the 🔵 thinking… placeholder within ~1s. Pre-fix the placeholder UX
+    // was locked to DMs even though sendMessageDraft works in groups —
+    // exactly the population (groups, including the standard switchroom
+    // forum-topic layout) that reported "feels dead until the status
+    // card appears." Forum topics still excluded via the messageThreadId
+    // guard because sendMessageDraft doesn't accept message_thread_id;
+    // forum-topic placeholder needs a separate path (out of scope here).
     if (
       sendMessageDraftFn != null
-      && isDmChatId(chat_id)
       && messageThreadId == null
       && !preAllocatedDrafts.has(chat_id)
     ) {
       const draftId = allocateDraftId()
       // Best-effort, non-blocking: any failure (transport down, API not
-      // available) falls through to today's behavior.
+      // available, group rejects sendMessageDraft) falls through to
+      // today's behavior — the existing .catch already silently logs.
       void sendMessageDraftFn(chat_id, draftId, '🔵 thinking…')
         .then(() => {
           preAllocatedDrafts.set(chat_id, { draftId, allocatedAt: Date.now() })

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -6583,27 +6583,53 @@ bot.command('issues', async ctx => {
     // "Clear all" = list current, resolve each. The CLI's `prune` is
     // for retention; clearing live issues is a UI concern. Implement
     // here by walking the list and resolving each. Best-effort.
+    //
+    // #443: require an explicit `--confirm` flag. A fat-finger
+    // `/issues clear` used to mass-resolve every unresolved entry in
+    // one shot — destructive verbs deserve a guard. Bare `/issues
+    // clear` now counts and prints the prompt; `--confirm` actually
+    // executes.
     try {
       const stateDir = process.env.TELEGRAM_STATE_DIR
-      if (stateDir) {
-        const events = listIssues(stateDir)
-        let n = 0
-        for (const e of events) {
-          n += resolveIssue(stateDir, e.fingerprint)
-        }
-        await switchroomReply(ctx, `Resolved ${n} issue${n === 1 ? '' : 's'}.`, { html: true })
+      if (!stateDir) {
+        await switchroomReply(ctx, 'clear: no TELEGRAM_STATE_DIR; cannot operate.', { html: true })
         return
       }
+      const confirmed = parts.slice(1).includes('--confirm')
+      if (!confirmed) {
+        const events = listIssues(stateDir)
+        const n = events.length
+        if (n === 0) {
+          await switchroomReply(ctx, 'No unresolved issues to clear.', { html: true })
+          return
+        }
+        const noun = n === 1 ? 'issue' : 'issues'
+        await switchroomReply(
+          ctx,
+          [
+            `This will resolve <b>${n} ${noun}</b>. To confirm, run:`,
+            '',
+            '<code>/issues clear --confirm</code>',
+          ].join('\n'),
+          { html: true },
+        )
+        return
+      }
+      const events = listIssues(stateDir)
+      let n = 0
+      for (const e of events) {
+        n += resolveIssue(stateDir, e.fingerprint)
+      }
+      await switchroomReply(ctx, `Resolved ${n} issue${n === 1 ? '' : 's'}.`, { html: true })
+      return
     } catch (err) {
       await switchroomReply(ctx, `clear failed: ${escapeHtmlForTg((err as Error).message)}`, { html: true })
       return
     }
-    await switchroomReply(ctx, 'clear: no TELEGRAM_STATE_DIR; cannot operate.', { html: true })
-    return
   }
   await switchroomReply(
     ctx,
-    'Usage: <code>/issues</code> | <code>/issues resolve &lt;fingerprint&gt;</code> | <code>/issues clear</code>',
+    'Usage: <code>/issues</code> | <code>/issues resolve &lt;fingerprint&gt;</code> | <code>/issues clear [--confirm]</code>',
     { html: true },
   )
 })

--- a/telegram-plugin/progress-card-driver.ts
+++ b/telegram-plugin/progress-card-driver.ts
@@ -206,6 +206,22 @@ export interface ProgressDriverConfig {
    */
   promoteOnSubAgent?: boolean
   /**
+   * Promote the card out of initial-delay suppression once the agent has
+   * issued this many parent-side tool calls in the suppression window.
+   * Closes #478 — the user sees no progress card for the first 30s of a
+   * substantial turn that does parent-side work (Read/Grep/Bash/Edit)
+   * but never dispatches a sub-agent.
+   *
+   * Symmetric to `promoteOnSubAgent`. Default 3: a turn with ≥3 tool
+   * calls is not "short" by any reasonable definition, so the
+   * fast-turn suppression goal (no clutter on quick replies) still
+   * holds. Set to a large value (e.g. 999) to effectively disable.
+   *
+   * Fast-turn suppression in `flush()` is unchanged — if the turn
+   * ends before promotion, the card still skips the emit.
+   */
+  promoteOnParentToolCount?: number
+  /**
    * Number of consecutive 4xx Telegram API failures on card edits before
    * the card is marked terminal and all further edits are suppressed for
    * this turn. Transient (5xx/network) errors and "message is not modified"
@@ -629,6 +645,7 @@ export function createProgressDriver(config: ProgressDriverConfig): ProgressDriv
   const maxIdleMs = config.maxIdleMs ?? 30 * 60_000
   const initialDelayMs = config.initialDelayMs ?? 30_000
   const promoteOnSubAgent = config.promoteOnSubAgent ?? true
+  const promoteOnParentToolCount = config.promoteOnParentToolCount ?? 3
   const maxConsecutive4xx = config.maxConsecutive4xx ?? 3
   const orphanPromotionMs = config.orphanPromotionMs ?? 5_000
   const coldSubAgentThresholdMs = config.coldSubAgentThresholdMs ?? 30_000
@@ -1564,6 +1581,23 @@ export function createProgressDriver(config: ProgressDriverConfig): ProgressDriv
         && !chatState.apiFailures.terminal
       ) {
         promoteFirstEmit(chatState, 'sub_agent_started')
+      }
+
+      // #478: promote the card when the agent has issued enough parent-
+      // side tool calls during the suppression window. The previous
+      // logic only promoted on sub-agent dispatch, so a turn that did
+      // 5 Read/Grep/Bash calls in 30s never showed a card — user saw
+      // typing-indicator-only and described it as "feels dead." A turn
+      // with ≥3 parent tools is not "short" by any reasonable
+      // definition, so this doesn't regress the fast-turn-suppression
+      // goal (which continues to fire in flush() for sub-3-tool turns).
+      if (
+        chatState.isFirstEmit
+        && chatState.deferredFirstEmitTimer !== DELAY_ELAPSED
+        && !chatState.apiFailures.terminal
+        && chatState.state.items.length >= promoteOnParentToolCount
+      ) {
+        promoteFirstEmit(chatState, `parent_tool_count_${chatState.state.items.length}`)
       }
 
       // Issue #132: track whether the agent has called `reply` or

--- a/telegram-plugin/progress-card.ts
+++ b/telegram-plugin/progress-card.ts
@@ -1294,7 +1294,13 @@ function renderNarrativeChecklist(
         lines.push(`${STEP_ACTIVE} <b>${escapeHtml(step.text)}</b> <i>(${dur})</i>`)
       }
     } else {
-      lines.push(`${STEP_DONE} <s>${escapeHtml(step.text)}</s>`)
+      // #320: drop the <s>...</s> wrap on done items. Telegram desktop
+      // renders strikethrough with a salmon/red strike-line in both
+      // light and dark themes — users read it as "deleted/failed/error",
+      // not "done". The leading STEP_DONE bullet (●) + the symbol
+      // distinction (vs ◉ for active) + bold-vs-plain weight already
+      // signal completion without the alarm. See #320 Option A.
+      lines.push(`${STEP_DONE} ${escapeHtml(step.text)}`)
     }
   }
 }
@@ -1339,6 +1345,13 @@ function renderMainItem(
     }
     const dur = formatDuration(item.finishedAt - item.startedAt)
     const needsDuration = item.finishedAt - item.startedAt >= 1000
+    // #320: no <s> wrap on done items here either. The symbol
+    // distinction (● vs ◉) + the bold-vs-plain treatment already
+    // differentiate done from active; strikethrough renders red in
+    // Telegram desktop and reads as "deleted/failed". See #320
+    // Option A — this aligns the rolled-card path with the
+    // narrative-checklist + sub-agent-expandable paths now that all
+    // three drop strikethrough.
     return `${indent}${symbol} ${renderItemCore(item.tool, item.label, false, humanAuthored)}${needsDuration ? ` <i>(${dur})</i>` : ''}`
   }
   void subAgents
@@ -1508,15 +1521,20 @@ function renderSubAgentExpandable(
       innerLines.push(`↳ ${sa.toolCount} tool${sa.toolCount !== 1 ? 's' : ''} completed`)
     }
   } else {
-    // Running state: show recent completed actions (strikethrough) + current (↳).
+    // Running state: show recent completed actions + current (↳).
     //
     // `recentCompletedTools` holds up to 2 previously completed tools.
-    // `currentTool` is the in-flight tool (shown with ↳, no strikethrough).
+    // `currentTool` is the in-flight tool (shown with ↳).
     // Together they give up to 3 action lines per the spec.
+    //
+    // #320: no <s> wrap on completed actions here. The active line is
+    // distinguished by its `↳` prefix; the recent-completed lines have
+    // no prefix. Strikethrough adds a salmon/red line that reads as
+    // "deleted/failed" rather than "done" — drop it for visual calm.
     const recent = sa.recentCompletedTools ?? []
     for (const t of recent) {
       // renderItemCore returns HTML (with <code> tags) — do NOT re-escape it.
-      innerLines.push(`<s>${renderItemCore(t.tool, t.label, false, t.humanAuthored)}</s>`)
+      innerLines.push(renderItemCore(t.tool, t.label, false, t.humanAuthored))
     }
 
     if (sa.currentTool) {

--- a/telegram-plugin/tests/progress-card-driver.test.ts
+++ b/telegram-plugin/tests/progress-card-driver.test.ts
@@ -3328,6 +3328,7 @@ describe('progress-card driver — promote-on-sub-agent', () => {
   function promoHarness(opts?: {
     initialDelayMs?: number
     promoteOnSubAgent?: boolean
+    promoteOnParentToolCount?: number
     maxConsecutive4xx?: number
     onTurnComplete?: (args: { chatId: string; threadId?: string; summary: string; taskIndex: number; taskTotal: number }) => void
   }) {
@@ -3343,6 +3344,7 @@ describe('progress-card driver — promote-on-sub-agent', () => {
       heartbeatMs: 0,
       initialDelayMs: opts?.initialDelayMs ?? 30_000,
       promoteOnSubAgent: opts?.promoteOnSubAgent,
+      promoteOnParentToolCount: opts?.promoteOnParentToolCount,
       maxConsecutive4xx: opts?.maxConsecutive4xx,
       now: () => now,
       setTimeout: (fn, ms) => {
@@ -3624,6 +3626,63 @@ describe('progress-card driver — promote-on-sub-agent', () => {
     // timer must have been cancelled by promote — no second isFirstEmit.
     advance(40_000)
     expect(emits.filter((e) => e.isFirstEmit)).toHaveLength(1)
+  })
+
+  // ─── #478 — promote-on-parent-tool-count ────────────────────────────────
+
+  it('parent tools during suppression promote the card after threshold (#478)', () => {
+    const { driver, emits, advance } = promoHarness({
+      initialDelayMs: 30_000,
+      promoteOnParentToolCount: 3,
+    })
+    driver.startTurn({ chatId: 'c', userText: 'do work' })
+    advance(2_000)
+    expect(emits).toHaveLength(0) // suppressed during initialDelay
+
+    // First two parent tool calls — still suppressed (under threshold).
+    driver.ingest({ kind: 'tool_use', toolName: 'Read', toolUseId: 't1', input: { file_path: '/a' } }, 'c')
+    driver.ingest({ kind: 'tool_use', toolName: 'Grep', toolUseId: 't2', input: { pattern: 'foo' } }, 'c')
+    advance(0)
+    expect(emits).toHaveLength(0)
+
+    // Third parent tool — threshold met, promotion fires.
+    driver.ingest({ kind: 'tool_use', toolName: 'Bash', toolUseId: 't3', input: { command: 'ls' } }, 'c')
+    advance(0)
+    expect(emits.length).toBeGreaterThan(0)
+    expect(emits[0].isFirstEmit).toBe(true)
+  })
+
+  it('parent tools below threshold do NOT promote — fast turns still suppressed (#478)', () => {
+    const { driver, emits, advance } = promoHarness({
+      initialDelayMs: 30_000,
+      promoteOnParentToolCount: 3,
+    })
+    driver.startTurn({ chatId: 'c', userText: 'quick lookup' })
+    advance(1_000)
+    driver.ingest({ kind: 'tool_use', toolName: 'Read', toolUseId: 't1', input: { file_path: '/a' } }, 'c')
+    driver.ingest({ kind: 'tool_use', toolName: 'Read', toolUseId: 't2', input: { file_path: '/b' } }, 'c')
+    advance(0)
+    expect(emits).toHaveLength(0) // 2 tools < threshold of 3
+
+    // Turn ends fast — fast-turn suppression in flush() wins.
+    driver.ingest({ kind: 'turn_end', durationMs: 1500 }, 'c')
+    advance(60_000)
+    expect(emits).toHaveLength(0)
+  })
+
+  it('promoteOnParentToolCount very high effectively disables (#478)', () => {
+    const { driver, emits, advance } = promoHarness({
+      initialDelayMs: 30_000,
+      promoteOnParentToolCount: 999, // effectively disabled
+    })
+    driver.startTurn({ chatId: 'c', userText: 'work' })
+    advance(2_000)
+    for (let i = 0; i < 10; i++) {
+      driver.ingest({ kind: 'tool_use', toolName: 'Read', toolUseId: `t${i}`, input: { file_path: `/${i}` } }, 'c')
+    }
+    advance(0)
+    // 10 tools but threshold is 999 — no promote, normal initialDelay rules apply.
+    expect(emits).toHaveLength(0)
   })
 })
 

--- a/telegram-plugin/tests/progress-card-golden.test.ts
+++ b/telegram-plugin/tests/progress-card-golden.test.ts
@@ -110,8 +110,11 @@ describe('progress-card golden turn', () => {
     expect(html).not.toContain('user-req')
     expect(html).toContain('✅ <b>Done</b>')
 
-    // Text events create narrative steps; the final text block becomes a narrative
-    expect(html).toContain('● <s>Tests fixed but push was rejected.</s>')
+    // Text events create narrative steps; the final text block becomes a narrative.
+    // #320: done items render WITHOUT <s> wrap (the bullet symbol + plain weight
+    // is the done signal; strikethrough rendered red and read as "deleted").
+    expect(html).toContain('● Tests fixed but push was rejected.')
+    expect(html).not.toContain('<s>')
 
     // Tool items are still rendered as fallback (narrative takes priority,
     // but tool items still appear when no narrative covers them)

--- a/telegram-plugin/tests/progress-card.test.ts
+++ b/telegram-plugin/tests/progress-card.test.ts
@@ -305,7 +305,10 @@ describe('progress-card render', () => {
       { kind: 'tool_result', toolUseId: 'x', toolName: 'Read' },
     ])
     const out = render(s, 1300)
+    // #320: no <s> wrap on done items. The ● symbol + plain weight
+    // (vs ◉ + bold for active) distinguishes done from active.
     expect(out).toContain('● <code>Read</code>')
+    expect(out).not.toContain('<s>')
     expect(out).not.toContain('(00:00)')
   })
 
@@ -314,8 +317,10 @@ describe('progress-card render', () => {
     st = reduce(st, { kind: 'tool_use', toolName: 'Bash' }, 1100)
     st = reduce(st, { kind: 'tool_result', toolUseId: 'x', toolName: 'Bash' }, 4200)
     const out = render(st, 4300)
+    // #320: no <s> wrap on done items. Duration stays as <i>(...)</i>.
     expect(out).toContain('● <code>Bash</code>')
     expect(out).toContain('(00:03)')
+    expect(out).not.toContain('<s>')
   })
 
   it('rolls up 2+ consecutive identical done tools (threshold lowered from 5)', () => {
@@ -483,7 +488,9 @@ describe('progress-card render', () => {
     // Text events now create narrative steps; thought bubble suppressed when narratives exist
     expect(render(st, 1500)).toContain('◉ <b>thinking…</b>')
     st = reduce(st, { kind: 'turn_end', durationMs: 500 }, 1700)
-    expect(render(st, 1700)).toContain('● <s>thinking…</s>')
+    // #320: done items render without <s> wrap.
+    expect(render(st, 1700)).toContain('● thinking…')
+    expect(render(st, 1700)).not.toContain('<s>')
     expect(render(st, 1700)).not.toContain('💭')
   })
 
@@ -514,8 +521,10 @@ describe('progress-card render', () => {
     st = reduce(st, { kind: 'text', text: 'Found the issue in merge.ts' }, 2000)
     st = reduce(st, { kind: 'tool_use', toolName: 'Edit' }, 2100)
     const out = render(st, 3000)
-    // Narrative steps are primary — no tool names visible
-    expect(out).toContain('● <s>Let me check the test files</s>')
+    // Narrative steps are primary — no tool names visible.
+    // #320: done step renders without <s> wrap (bullet symbol is the done signal).
+    expect(out).toContain('● Let me check the test files')
+    expect(out).not.toContain('<s>')
     expect(out).toContain('◉ <b>Found the issue in merge.ts</b>')
     expect(out).not.toContain('Read')
     expect(out).not.toContain('Edit')
@@ -1356,7 +1365,10 @@ describe('progress-card reducer — multi-agent correlation', () => {
       // After #315 dedup: main blockquote has the one-line summary; expandable
       // blockquote has the per-sub-agent forensics. Tool count moves to its own
       // line in the expandable, so check assertions independently.
+      // #320: completed items render WITHOUT strikethrough — bullet
+      // symbol + plain weight is the done signal.
       expect(html).toMatch(/● task A/)
+      expect(html).not.toContain('<s>')
       expect(html).toContain('1 tools')
       // Active tool spinner (◉) must not appear in a done state.
       expect(html).not.toContain('◉')


### PR DESCRIPTION
## Summary

Rebased version of #487. The original branch (\`chore/streaming-ux-bundle\`, off an older base) became conflicting after #471, #483, #485, #486, and #490 landed on \`main\`. Most of #487's commits had already shipped via #471 — only the last 3 were genuinely new work. This PR cherry-picks just those 3 onto current \`main\`.

**Closes:** #61 (defense #1), #320, #403, #443, #478, #479
**Supersedes:** #487 (close as superseded)

## What ships (3 commits)

### #478 + #479 — pre-alloc placeholder in groups + parent-tool promotion
\`telegram-plugin/gateway/gateway.ts\` — drop the \`isDmChatId(chat_id)\` gate. Pre-fix the \`🔵 thinking…\` placeholder fired only in DMs; groups (the standard switchroom forum-topic layout) saw nothing until the progress card promoted at ≥30s. The \`messageThreadId == null\` guard is preserved.

\`telegram-plugin/progress-card-driver.ts\` — new \`promoteOnParentToolCount\` config (default 3). After ≥3 parent-side tool calls during the suppression window, the card promotes. Symmetric to existing \`promoteOnSubAgent\`. Fast-turn suppression in \`flush()\` is unchanged.

### #320 + #403 — drop strikethrough on done items
\`telegram-plugin/progress-card.ts\` — three render paths now consistent: no \`<s>\` wrap on done items. Telegram desktop renders strikethrough red, which users read as "deleted/failed". The \`●\` bullet + plain weight already differentiates done from active. Closes both #320 and #403 (which proposed opposite directions; the user-complaint resolution wins).

### #443 + #61 (defense #1) — /issues clear --confirm + restart branch warn
\`telegram-plugin/gateway/gateway.ts\` — bare \`/issues clear\` now prints "this will resolve N issues" + asks for \`/issues clear --confirm\`. A fat-finger no longer mass-resolves the visibility surface in one shot.

\`src/cli/agent.ts\` — pre-restart \`checkSwitchroomBranch()\` probe. Gateway runs source directly via \`bun gateway.ts\` (no compile step), so whatever branch is checked out IS what the gateway picks up. Warning forces operator acknowledgment before \`--force\`. Best-effort: any git error returns null so npm-global installs aren't broken.

## Verification

\`\`\`
$ npm run lint        # clean (tsc --noEmit)
$ npm test            # 4238 vitest passed (1 vitest-worker RPC timeout flake — infrastructure, not a test fail)
$ cd telegram-plugin && bun test
…
 2795 pass
 1 skip
 0 fail
 6091 expect() calls
Ran 2796 tests across 140 files. [17.45s]
\`\`\`

## Why this PR exists

The original PR #487 was opened from \`chore/streaming-ux-bundle\` — a branch off an older \`main\` snapshot. After PRs #471/#483/#485/#486/#490 landed, the diff exploded to 67 files / +3612 because most of the branch was already on main in different form. Rebasing in place would have produced a 50+ file conflict. Cherry-picking the 3 truly-new commits onto fresh \`main\` yields 8 files / +256.

🤖 Generated with [Claude Code](https://claude.com/claude-code)