### PR TITLE
feat(foreman): /setup wizard parity with /create-agent (#189, #190)

### DIFF
--- a/telegram-plugin/foreman/foreman.ts
+++ b/telegram-plugin/foreman/foreman.ts
@@ -622,7 +622,10 @@ async function handleSetupFlowText(
   setupState: NonNullable<ReturnType<typeof getSetupState>>,
 ): Promise<void> {
   const callerId = String(ctx.from?.id ?? '')
-  const action = handleSetupText({ state: setupState, text, callerId })
+  // #190: pass live profiles into the wizard so the asked-profile step can
+  // validate against the operator's actual profile set.
+  const profiles = listAvailableProfiles()
+  const action = handleSetupText({ state: setupState, text, callerId, profiles })
 
   switch (action.kind) {
     // ── Slug step ──────────────────────────────────────────────────────────
@@ -632,7 +635,7 @@ async function handleSetupFlowText(
       await switchroomReply(ctx, [
         `Slug: <code>${escapeHtmlForTg(action.slug)}</code>`,
         '',
-        'Step 2/5: What persona name should this agent have?',
+        'Step 2/6: What persona name should this agent have?',
         '<i>e.g. <code>Gym Bro</code> — displayed in greetings</i>',
       ].join('\n'), { html: true })
       return
@@ -649,7 +652,7 @@ async function handleSetupFlowText(
       await switchroomReply(ctx, [
         `Persona: <b>${escapeHtmlForTg(action.persona)}</b>`,
         '',
-        'Step 3/5: Which Claude model should this agent use?',
+        'Step 3/6: Which Claude model should this agent use?',
         'Options: <code>sonnet</code>, <code>opus</code>, <code>haiku</code>, or a full model ID.',
         'Type <code>skip</code> to use the profile default.',
       ].join('\n'), { html: true })
@@ -669,27 +672,45 @@ async function handleSetupFlowText(
       await switchroomReply(ctx, [
         modelNote,
         '',
-        'Step 4/5: What emoji should represent this agent\'s Telegram topic?',
+        'Step 4/6: What emoji should represent this agent\'s Telegram topic?',
         'Type <code>skip</code> to use the default.',
       ].join('\n'), { html: true })
       return
     }
 
-    // ── Emoji step ─────────────────────────────────────────────────────────
-    case 'ask-bot-token': {
+    // ── Emoji step → Profile selector (#190) ───────────────────────────────
+    case 'ask-profile': {
       const updated = advanceSetupState(setupState, {
-        step: 'asked-bot-token',
+        step: 'asked-profile',
         emoji: action.emoji,
       })
       setSetupState(updated)
       const emojiNote = action.emoji
         ? `Emoji: ${action.emoji}`
         : 'Emoji: <i>default</i>'
-      // TODO(#188): BotFather auto-flow — currently user creates bot manually
       await switchroomReply(ctx, [
         emojiNote,
         '',
-        'Step 5/5: Paste the BotFather token for the new agent\'s bot.',
+        `Step 5/6: Choose a profile for this agent.`,
+        `Available: ${action.profiles.map(p => `<code>${escapeHtmlForTg(p)}</code>`).join(', ')}`,
+        '',
+        '<i>The profile sets the agent\'s base persona, system prompt, and skill bundle. Pick <code>default</code> if unsure.</i>',
+      ].join('\n'), { html: true })
+      return
+    }
+
+    // ── Profile step ───────────────────────────────────────────────────────
+    case 'ask-bot-token': {
+      const updated = advanceSetupState(setupState, {
+        step: 'asked-bot-token',
+        profile: action.profile,
+      })
+      setSetupState(updated)
+      // TODO(#188): BotFather auto-flow — currently user creates bot manually
+      await switchroomReply(ctx, [
+        `Profile: <code>${escapeHtmlForTg(action.profile)}</code>`,
+        '',
+        'Step 6/6: Paste the BotFather token for the new agent\'s bot.',
         '',
         '<b>To create a bot:</b>',
         '1. Open @BotFather in Telegram',
@@ -720,9 +741,22 @@ async function handleSetupFlowText(
       return
     }
 
-    // ── Allowlist confirmation step → provision agent ──────────────────────
-    case 'call-reconcile': {
-      const { slug, persona, model, emoji, botToken, allowedUserId } = action
+    // ── Allowlist confirmation step → provision agent (#189: split path) ──
+    //
+    // Pre-fix this was a single 'call-reconcile' that ran createAgent inline
+    // and told the user to run `switchroom auth code` from a terminal. Per
+    // #189 + #190, the flow now splits into three coordinated steps:
+    //
+    //   call-create-agent   → run createAgent (returns loginUrl)
+    //   ask-oauth-code      → render the URL prompt; user pastes back
+    //   call-complete-creation → run completeCreation + start the agent
+    //
+    // Mirrors the create-flow's existing call-create-agent/asked-oauth-code/
+    // call-complete-creation triad. The two flows have parallel state
+    // machines and parallel orchestrator handlers.
+    case 'call-create-agent': {
+      const { slug, persona, model, emoji, profile, botToken, allowedUserId } = action
+      void model; void emoji; void allowedUserId // captured in state earlier; createAgent reads from yaml
       const updated = advanceSetupState(setupState, {
         step: 'reconciling',
         allowedUserId,
@@ -749,14 +783,6 @@ async function handleSetupFlowText(
       const botUsername = botInfo?.username ?? null
       await switchroomReply(ctx, `Token OK (@${escapeHtmlForTg(botUsername ?? '?')}). Provisioning agent <b>${escapeHtmlForTg(slug)}</b>…`, { html: true })
 
-      // Use 'default' profile — skills/profile selection is deferred
-      // TODO(#178): Skills selector — currently uses 'default' profile always
-      const profile = 'default'
-
-      // Build model override: if user picked a model, set it in persona config
-      // after scaffolding. For now we pass it via a comment; the scaffold uses
-      // profile defaults. Full model override is handled post-scaffold.
-      // TODO(#189): OAuth code paste step — currently shows manual terminal instruction
       try {
         const result = await createAgent({
           name: slug,
@@ -765,33 +791,36 @@ async function handleSetupFlowText(
           rollbackOnFail: true,
         })
 
-        // Mark flow done
-        const doneState = advanceSetupState(updated, { step: 'done' })
-        setSetupState(doneState)
-        clearSetupState(chatId)
-
-        const oauthLines = result.loginUrl
-          ? [
+        if (result.loginUrl) {
+          // #189: in-wizard OAuth path. Stash the auth session + URL on the
+          // wizard state and ask the user to paste the code in chat.
+          const oauthState = advanceSetupState(updated, {
+            step: 'asked-oauth-code',
+            authSessionName: result.sessionName,
+            loginUrl: result.loginUrl,
+          })
+          setSetupState(oauthState)
+          const kb = new InlineKeyboard().url('Open OAuth URL', result.loginUrl)
+          await ctx.reply(
+            [
+              `<b>${escapeHtmlForTg(persona)}</b> (@${escapeHtmlForTg(botUsername ?? slug)}) is scaffolded!`,
               '',
-              '<b>Complete OAuth:</b>',
-              `<a href="${result.loginUrl}">Open this URL to log in</a>`,
-              `Then run: <code>switchroom auth code ${escapeHtmlForTg(slug)}</code>`,
-            ]
-          : [
-              '',
-              // TODO(#189): OAuth code paste step — currently shows manual terminal instruction
-              '<b>Complete OAuth from terminal:</b>',
-              `<code>switchroom auth code ${escapeHtmlForTg(slug)}</code>`,
-            ]
-
-        // Skills can be added later
-        // TODO(#190): Skills selector — currently shows placeholder message
-        await switchroomReply(ctx, [
-          `<b>${escapeHtmlForTg(persona)}</b> (@${escapeHtmlForTg(botUsername ?? slug)}) is scaffolded!`,
-          ...oauthLines,
-          '',
-          '<i>Skills can be added later via yaml or future /skills command.</i>',
-        ].join('\n'), { html: true })
+              '<b>Step 6 of 6 — OAuth:</b>',
+              'Open the URL below, log in to Claude, then paste the code back here.',
+            ].join('\n'),
+            { parse_mode: 'HTML', reply_markup: kb },
+          )
+        } else {
+          // No loginUrl returned — agent doesn't need OAuth (rare). Mark done.
+          const doneState = advanceSetupState(updated, { step: 'done' })
+          setSetupState(doneState)
+          clearSetupState(chatId)
+          await switchroomReply(ctx, [
+            `<b>${escapeHtmlForTg(persona)}</b> (@${escapeHtmlForTg(botUsername ?? slug)}) is scaffolded and ready!`,
+            '',
+            '<i>Skills can be added later via yaml or future /skills command.</i>',
+          ].join('\n'), { html: true })
+        }
       } catch (err) {
         // Rollback happened inside createAgent — reset to bot-token step
         const updatedBack = advanceSetupState(updated, { step: 'asked-bot-token' })
@@ -800,6 +829,71 @@ async function handleSetupFlowText(
           `<b>Provisioning failed:</b> ${escapeHtmlForTg((err as Error).message)}`,
           '',
           'To retry, paste a bot token again. Or type <code>cancel</code> to abort.',
+        ].join('\n'), { html: true })
+      }
+      return
+    }
+
+    // ── ask-oauth-code is currently dispatched only by call-create-agent
+    //    above (which goes straight to the InlineKeyboard render before
+    //    setting state). The handler below covers any future path that
+    //    emits it as a discrete action — currently dead-code-style
+    //    safety, but keeping the case keeps the union check exhaustive.
+    case 'ask-oauth-code': {
+      const updated = advanceSetupState(setupState, {
+        step: 'asked-oauth-code',
+        loginUrl: action.loginUrl,
+      })
+      setSetupState(updated)
+      const promptLines = action.loginUrl
+        ? ['Open this URL to log in, then paste the code back here:']
+        : ['Auth session started. Paste the OAuth code back here:']
+      if (action.loginUrl) {
+        const kb = new InlineKeyboard().url('Open OAuth URL', action.loginUrl)
+        await ctx.reply(promptLines.join('\n'), { reply_markup: kb })
+      } else {
+        await switchroomReply(ctx, promptLines.join('\n'), { html: false })
+      }
+      return
+    }
+
+    // ── OAuth-code paste step → run completeCreation + start the agent ────
+    case 'call-complete-creation': {
+      const { slug, persona, code } = action
+      await switchroomReply(ctx, 'Submitting OAuth code…', { html: false })
+      try {
+        const result = await completeCreation(slug, code)
+        if (result.outcome.kind === 'success' && result.started) {
+          const doneState = advanceSetupState(setupState, { step: 'done' })
+          setSetupState(doneState)
+          clearSetupState(chatId)
+          await switchroomReply(ctx, [
+            `<b>${escapeHtmlForTg(persona)}</b> is online! DM its bot to say hi.`,
+            '',
+            '<i>Skills can be added later via yaml or future /skills command.</i>',
+          ].join('\n'), { html: true })
+        } else if (result.outcome.kind === 'success') {
+          const doneState = advanceSetupState(setupState, { step: 'done' })
+          setSetupState(doneState)
+          clearSetupState(chatId)
+          await switchroomReply(ctx, [
+            `Auth succeeded but agent start failed.`,
+            '',
+            `Try: <code>switchroom agent start ${escapeHtmlForTg(slug)}</code>`,
+          ].join('\n'), { html: true })
+        } else {
+          // Bad code — stay in asked-oauth-code so the user can paste again.
+          await switchroomReply(
+            ctx,
+            `Code rejected (${result.outcome.kind}). Paste the code again, or type <code>cancel</code> to abort:`,
+            { html: true },
+          )
+        }
+      } catch (err) {
+        await switchroomReply(ctx, [
+          `<b>completeCreation failed:</b> ${escapeHtmlForTg((err as Error).message)}`,
+          '',
+          'Type <code>cancel</code> to abort, or paste the code again to retry:',
         ].join('\n'), { html: true })
       }
       return

--- a/telegram-plugin/foreman/setup-flow.ts
+++ b/telegram-plugin/foreman/setup-flow.ts
@@ -29,9 +29,17 @@ export type SetupFlowAction =
   | { kind: 'ask-persona'; slug: string }
   | { kind: 'ask-model'; slug: string; persona: string }
   | { kind: 'ask-emoji'; slug: string; persona: string; model: string | null }
-  | { kind: 'ask-bot-token'; slug: string; persona: string; model: string | null; emoji: string | null }
+  | { kind: 'ask-profile'; slug: string; persona: string; model: string | null; emoji: string | null; profiles: string[] }
+  | { kind: 'ask-bot-token'; slug: string; persona: string; model: string | null; emoji: string | null; profile: string }
   | { kind: 'confirm-allowlist'; slug: string; callerId: string }
-  | { kind: 'call-reconcile'; slug: string; persona: string; model: string | null; emoji: string | null; botToken: string; allowedUserId: string }
+  // Pre-fix this was call-reconcile (single-step that did createAgent inline +
+  // told the user to run `switchroom auth code` from a terminal). Split per
+  // #189/#190 into call-create-agent (returns loginUrl) → asked-oauth-code
+  // (collects the code via Telegram) → call-complete-creation (runs the
+  // submit + starts the agent).
+  | { kind: 'call-create-agent'; slug: string; persona: string; model: string | null; emoji: string | null; profile: string; botToken: string; allowedUserId: string }
+  | { kind: 'ask-oauth-code'; slug: string; loginUrl: string | null }
+  | { kind: 'call-complete-creation'; slug: string; persona: string; code: string }
   | { kind: 'done'; slug: string; botUsername: string | null }
   | { kind: 'error'; message: string; stayInStep: boolean }
   | { kind: 'cancel'; reason: string }
@@ -105,6 +113,9 @@ export interface SetupStepInput {
   text: string
   /** The Telegram user_id of the foreman caller (used for allowlist confirmation). */
   callerId: string
+  /** Available profile names — passed through to the asked-profile step.
+   *  Foreman calls listAvailableProfiles() and forwards the list. */
+  profiles: string[]
 }
 
 /**
@@ -112,7 +123,7 @@ export interface SetupStepInput {
  * Returns 'cancel' with reason='user-cancelled' when the user types /cancel.
  */
 export function handleSetupText(input: SetupStepInput): SetupFlowAction {
-  const { state, text, callerId } = input
+  const { state, text, callerId, profiles } = input
   const trimmed = text.trim()
 
   if (!state) {
@@ -169,24 +180,41 @@ export function handleSetupText(input: SetupStepInput): SetupFlowAction {
       const slug = state.slug ?? ''
       const persona = state.persona ?? ''
       const model = state.model ?? null
-      if (isSkip(trimmed)) {
-        return { kind: 'ask-bot-token', slug, persona, model, emoji: null }
-      }
-      if (!isValidEmoji(trimmed)) {
+      const emoji = isSkip(trimmed) ? null : trimmed
+      if (!isSkip(trimmed) && !isValidEmoji(trimmed)) {
         return {
           kind: 'error',
           message: 'Emoji must be 1-16 characters. Try again, or type <code>skip</code>:',
           stayInStep: true,
         }
       }
-      return { kind: 'ask-bot-token', slug, persona, model, emoji: trimmed }
+      // #190: gate on the profile selector before bot-token. The previous
+      // wizard skipped straight to bot-token and hard-coded profile='default'.
+      return { kind: 'ask-profile', slug, persona, model, emoji, profiles }
+    }
+
+    case 'asked-profile': {
+      // #190: validate against the live list passed in by the foreman.
+      if (!profiles.includes(trimmed)) {
+        return {
+          kind: 'error',
+          message: `Unknown profile "${escapeForMessage(trimmed)}". Choose one of: ${profiles.join(', ')}`,
+          stayInStep: true,
+        }
+      }
+      const slug = state.slug ?? ''
+      const persona = state.persona ?? ''
+      const model = state.model ?? null
+      const emoji = state.emoji ?? null
+      if (!slug || !persona) {
+        return { kind: 'cancel', reason: 'missing-slug-or-persona' }
+      }
+      return { kind: 'ask-bot-token', slug, persona, model, emoji, profile: trimmed }
     }
 
     case 'asked-bot-token': {
       const slug = state.slug ?? ''
       const persona = state.persona ?? ''
-      const model = state.model ?? null
-      const emoji = state.emoji ?? null
       // Basic bot token shape check
       if (!trimmed.includes(':') || trimmed.length < 20) {
         return {
@@ -206,6 +234,10 @@ export function handleSetupText(input: SetupStepInput): SetupFlowAction {
       const persona = state.persona ?? ''
       const model = state.model ?? null
       const emoji = state.emoji ?? null
+      // #190: profile is captured in asked-profile. Default to 'default' for
+      // legacy in-flight flows that started before the selector was added —
+      // they pre-date the schema migration and have profile=null.
+      const profile = state.profile ?? 'default'
       const botToken = state.botToken ?? ''
       const allowedUserId = trimmed.toLowerCase() === 'yes' || trimmed.toLowerCase() === 'y'
         ? callerId
@@ -218,7 +250,26 @@ export function handleSetupText(input: SetupStepInput): SetupFlowAction {
           stayInStep: true,
         }
       }
-      return { kind: 'call-reconcile', slug, persona, model, emoji, botToken, allowedUserId }
+      // #189: was 'call-reconcile' (createAgent + send-to-terminal); now
+      // 'call-create-agent' which returns loginUrl so we can ask for the
+      // OAuth code in-wizard. completeCreation runs in the next state.
+      return { kind: 'call-create-agent', slug, persona, model, emoji, profile, botToken, allowedUserId }
+    }
+
+    case 'asked-oauth-code': {
+      // #189: collect the OAuth code pasted by the user and pass it to
+      // call-complete-creation. Same shape as the create-flow's equivalent.
+      const slug = state.slug ?? ''
+      const persona = state.persona ?? ''
+      if (!slug) return { kind: 'cancel', reason: 'missing-slug' }
+      if (trimmed.length < 4) {
+        return {
+          kind: 'error',
+          message: 'That code looks too short. Paste the full code from the browser:',
+          stayInStep: true,
+        }
+      }
+      return { kind: 'call-complete-creation', slug, persona, code: trimmed }
     }
 
     case 'reconciling':
@@ -235,6 +286,13 @@ export function handleSetupText(input: SetupStepInput): SetupFlowAction {
   }
 }
 
+/** Tiny HTML-escape for inline error messages. The foreman renders these
+ *  via switchroomReply with html: true, so user-supplied text needs the
+ *  same escape pass the rest of the wizard does. */
+function escapeForMessage(s: string): string {
+  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+}
+
 // ─── State factory helpers ────────────────────────────────────────────────
 
 export function makeSetupInitialState(
@@ -249,8 +307,11 @@ export function makeSetupInitialState(
     persona: null,
     model: null,
     emoji: null,
+    profile: null,
     botToken: null,
     allowedUserId: null,
+    authSessionName: null,
+    loginUrl: null,
     startedAt: now,
     updatedAt: now,
   }
@@ -274,9 +335,11 @@ export function setupStepLabel(step: SetupFlowStep): string {
     case 'asked-persona': return 'waiting for persona name'
     case 'asked-model': return 'waiting for model choice'
     case 'asked-emoji': return 'waiting for emoji'
+    case 'asked-profile': return 'waiting for profile selection'
     case 'asked-bot-token': return 'waiting for BotFather token'
     case 'confirming-allowlist': return 'waiting for allowlist confirmation'
     case 'reconciling': return 'provisioning agent'
+    case 'asked-oauth-code': return 'waiting for OAuth code'
     case 'done': return 'done'
   }
 }

--- a/telegram-plugin/foreman/setup-state.ts
+++ b/telegram-plugin/foreman/setup-state.ts
@@ -33,9 +33,11 @@ export type SetupFlowStep =
   | 'asked-persona'
   | 'asked-model'
   | 'asked-emoji'
+  | 'asked-profile'        // #190: skills/profile selector before bot-token
   | 'asked-bot-token'
   | 'confirming-allowlist'
   | 'reconciling'
+  | 'asked-oauth-code'     // #189: in-wizard OAuth code paste (replaces "go to terminal")
   | 'done'
 
 export interface SetupFlowState {
@@ -45,8 +47,16 @@ export interface SetupFlowState {
   persona: string | null
   model: string | null
   emoji: string | null
+  /** #190: which profile to use when scaffolding. Defaults to 'default'
+   *  for flows that started before the profile-selector step landed. */
+  profile: string | null
   botToken: string | null
   allowedUserId: string | null
+  /** #189: foreman captures these from createAgent's return value so the
+   *  asked-oauth-code step can render the URL and the call-complete-creation
+   *  action can find the right session. Null until call-create-agent runs. */
+  authSessionName: string | null
+  loginUrl: string | null
   startedAt: number
   updatedAt: number
 }
@@ -86,6 +96,22 @@ function getSetupDb(): Database {
     );
   `)
 
+  // #189/#190: idempotent column additions for installs that pre-date the
+  // profile + OAuth-code steps. ALTER TABLE ADD COLUMN is a no-op when the
+  // column already exists in SQLite ≥ 3.35; older versions throw — wrap in
+  // try/catch so the migration is forward-compatible.
+  for (const migration of [
+    `ALTER TABLE setup_flow ADD COLUMN profile TEXT`,
+    `ALTER TABLE setup_flow ADD COLUMN auth_session_name TEXT`,
+    `ALTER TABLE setup_flow ADD COLUMN login_url TEXT`,
+  ]) {
+    try {
+      _setupDb.exec(migration)
+    } catch {
+      // Column already exists. Ignore.
+    }
+  }
+
   return _setupDb
 }
 
@@ -102,6 +128,10 @@ interface SetupFlowRow {
   allowed_user_id: string | null
   started_at: number
   updated_at: number
+  // #189/#190: nullable in legacy rows that pre-date the migration.
+  profile: string | null
+  auth_session_name: string | null
+  login_url: string | null
 }
 
 function rowToState(row: SetupFlowRow): SetupFlowState {
@@ -112,8 +142,11 @@ function rowToState(row: SetupFlowRow): SetupFlowState {
     persona: row.persona,
     model: row.model,
     emoji: row.emoji,
+    profile: row.profile,
     botToken: row.bot_token,
     allowedUserId: row.allowed_user_id,
+    authSessionName: row.auth_session_name,
+    loginUrl: row.login_url,
     startedAt: row.started_at,
     updatedAt: row.updated_at,
   }
@@ -126,18 +159,23 @@ export function setSetupState(state: SetupFlowState): void {
   const db = getSetupDb()
   db.prepare(`
     INSERT INTO setup_flow
-      (chat_id, step, slug, persona, model, emoji, bot_token, allowed_user_id, started_at, updated_at)
+      (chat_id, step, slug, persona, model, emoji, profile, bot_token,
+       allowed_user_id, auth_session_name, login_url, started_at, updated_at)
     VALUES
-      ($chatId, $step, $slug, $persona, $model, $emoji, $botToken, $allowedUserId, $startedAt, $updatedAt)
+      ($chatId, $step, $slug, $persona, $model, $emoji, $profile, $botToken,
+       $allowedUserId, $authSessionName, $loginUrl, $startedAt, $updatedAt)
     ON CONFLICT(chat_id) DO UPDATE SET
-      step            = excluded.step,
-      slug            = excluded.slug,
-      persona         = excluded.persona,
-      model           = excluded.model,
-      emoji           = excluded.emoji,
-      bot_token       = excluded.bot_token,
-      allowed_user_id = excluded.allowed_user_id,
-      updated_at      = excluded.updated_at
+      step              = excluded.step,
+      slug              = excluded.slug,
+      persona           = excluded.persona,
+      model             = excluded.model,
+      emoji             = excluded.emoji,
+      profile           = excluded.profile,
+      bot_token         = excluded.bot_token,
+      allowed_user_id   = excluded.allowed_user_id,
+      auth_session_name = excluded.auth_session_name,
+      login_url         = excluded.login_url,
+      updated_at        = excluded.updated_at
   `).run({
     $chatId: state.chatId,
     $step: state.step,
@@ -145,8 +183,11 @@ export function setSetupState(state: SetupFlowState): void {
     $persona: state.persona,
     $model: state.model,
     $emoji: state.emoji,
+    $profile: state.profile,
     $botToken: state.botToken,
     $allowedUserId: state.allowedUserId,
+    $authSessionName: state.authSessionName,
+    $loginUrl: state.loginUrl,
     $startedAt: state.startedAt,
     $updatedAt: state.updatedAt,
   })
@@ -156,7 +197,8 @@ export function setSetupState(state: SetupFlowState): void {
 export function getSetupState(chatId: string): SetupFlowState | null {
   const db = getSetupDb()
   const row = db.prepare<SetupFlowRow, [string]>(`
-    SELECT chat_id, step, slug, persona, model, emoji, bot_token, allowed_user_id, started_at, updated_at
+    SELECT chat_id, step, slug, persona, model, emoji, profile, bot_token,
+           allowed_user_id, auth_session_name, login_url, started_at, updated_at
     FROM setup_flow
     WHERE chat_id = ?
   `).get(chatId)
@@ -178,7 +220,8 @@ export function listActiveSetupFlows(maxAgeMs = 60 * 60 * 1000): SetupFlowState[
   const db = getSetupDb()
   const cutoff = Date.now() - maxAgeMs
   const rows = db.prepare<SetupFlowRow, [number]>(`
-    SELECT chat_id, step, slug, persona, model, emoji, bot_token, allowed_user_id, started_at, updated_at
+    SELECT chat_id, step, slug, persona, model, emoji, profile, bot_token,
+           allowed_user_id, auth_session_name, login_url, started_at, updated_at
     FROM setup_flow
     WHERE step != 'done' AND updated_at > ?
     ORDER BY updated_at DESC

--- a/telegram-plugin/tests/setup-flow.test.ts
+++ b/telegram-plugin/tests/setup-flow.test.ts
@@ -29,6 +29,11 @@ import type { SetupFlowState } from '../foreman/setup-state.js'
 
 const CALLER = '12345678'
 
+// #190: setup-flow now needs the operator's profile list. Tests that don't
+// care about the profile validation just pass `default` so the asked-profile
+// step accepts any input that maps to one of these.
+const PROFILES = ['default', 'coding', 'health-coach', 'executive-assistant']
+
 function makeState(overrides: Partial<SetupFlowState> = {}): SetupFlowState {
   return {
     chatId: 'chat1',
@@ -37,12 +42,34 @@ function makeState(overrides: Partial<SetupFlowState> = {}): SetupFlowState {
     persona: null,
     model: null,
     emoji: null,
+    profile: null,
     botToken: null,
     allowedUserId: null,
+    authSessionName: null,
+    loginUrl: null,
     startedAt: 1000,
     updatedAt: 1000,
     ...overrides,
   }
+}
+
+/**
+ * Test helper — wraps handleSetupText with a default profiles list so the
+ * 30+ existing call sites don't need to be rewritten one-by-one. Tests that
+ * specifically exercise the asked-profile validation pass their own
+ * profiles via the `opts` argument.
+ */
+function call(
+  state: SetupFlowState | null,
+  text: string,
+  opts: { callerId?: string; profiles?: string[] } = {},
+) {
+  return handleSetupText({
+    state,
+    text,
+    callerId: opts.callerId ?? CALLER,
+    profiles: opts.profiles ?? PROFILES,
+  })
 }
 
 // ─── isValidSlug ─────────────────────────────────────────────────────────
@@ -223,19 +250,72 @@ describe('handleSetupText: asked-model', () => {
 
 // ─── handleSetupText: step asked-emoji ───────────────────────────────────
 
-describe('handleSetupText: asked-emoji', () => {
-  it('advances to ask-bot-token with skip', () => {
+describe('handleSetupText: asked-emoji (#190 — now transitions to ask-profile)', () => {
+  it('advances to ask-profile with skip (no emoji)', () => {
     const state = makeState({ step: 'asked-emoji', slug: 'gymbro', persona: 'Gym Bro', model: 'sonnet' })
-    const action = handleSetupText({ state, text: 'skip', callerId: CALLER })
-    expect(action.kind).toBe('ask-bot-token')
-    if (action.kind === 'ask-bot-token') expect(action.emoji).toBeNull()
+    const action = call(state, 'skip')
+    expect(action.kind).toBe('ask-profile')
+    if (action.kind === 'ask-profile') {
+      expect(action.emoji).toBeNull()
+      expect(action.profiles).toEqual(PROFILES)
+    }
   })
 
-  it('advances to ask-bot-token with emoji', () => {
+  it('advances to ask-profile carrying the emoji', () => {
     const state = makeState({ step: 'asked-emoji', slug: 'gymbro', persona: 'Gym Bro', model: null })
-    const action = handleSetupText({ state, text: '🏋️', callerId: CALLER })
+    const action = call(state, '🏋️')
+    expect(action.kind).toBe('ask-profile')
+    if (action.kind === 'ask-profile') expect(action.emoji).toBe('🏋️')
+  })
+})
+
+// ─── handleSetupText: step asked-profile (#190) ──────────────────────────
+
+describe('handleSetupText: asked-profile (#190)', () => {
+  function profileState(): SetupFlowState {
+    return makeState({
+      step: 'asked-profile',
+      slug: 'gymbro',
+      persona: 'Gym Bro',
+      model: 'sonnet',
+      emoji: '🏋️',
+    })
+  }
+
+  it('advances to ask-bot-token when profile is in the live list', () => {
+    const action = call(profileState(), 'health-coach')
     expect(action.kind).toBe('ask-bot-token')
-    if (action.kind === 'ask-bot-token') expect(action.emoji).toBe('🏋️')
+    if (action.kind === 'ask-bot-token') {
+      expect(action.profile).toBe('health-coach')
+      expect(action.slug).toBe('gymbro')
+      expect(action.emoji).toBe('🏋️')
+    }
+  })
+
+  it('returns error stayInStep when profile is unknown', () => {
+    const action = call(profileState(), 'nonexistent')
+    expect(action.kind).toBe('error')
+    if (action.kind === 'error') {
+      expect(action.stayInStep).toBe(true)
+      expect(action.message).toContain('nonexistent')
+    }
+  })
+
+  it('lists valid profiles in error message', () => {
+    const action = call(profileState(), 'bogus')
+    if (action.kind === 'error') {
+      for (const p of PROFILES) expect(action.message).toContain(p)
+    }
+  })
+
+  it('cancels when slug or persona missing', () => {
+    const action = call(makeState({ step: 'asked-profile' }), 'default')
+    expect(action.kind).toBe('cancel')
+  })
+
+  it('respects a different profiles list per call', () => {
+    const action = call(profileState(), 'tiny-bundle', { profiles: ['tiny-bundle'] })
+    expect(action.kind).toBe('ask-bot-token')
   })
 })
 
@@ -279,36 +359,90 @@ describe('handleSetupText: asked-bot-token', () => {
 
 // ─── handleSetupText: step confirming-allowlist ───────────────────────────
 
-describe('handleSetupText: confirming-allowlist', () => {
+describe('handleSetupText: confirming-allowlist (#189 — now transitions to call-create-agent)', () => {
   const baseState = makeState({
     step: 'confirming-allowlist',
     slug: 'gymbro',
     persona: 'Gym Bro',
     model: null,
     emoji: null,
+    profile: 'default',
     botToken: '1234567890:AAHxxxxxxxxxxxxxxxxxxxxxxx',
   })
 
-  it('advances to call-reconcile on "yes"', () => {
-    const action = handleSetupText({ state: baseState, text: 'yes', callerId: CALLER })
-    expect(action.kind).toBe('call-reconcile')
-    if (action.kind === 'call-reconcile') {
+  it('advances to call-create-agent on "yes"', () => {
+    const action = call(baseState, 'yes')
+    expect(action.kind).toBe('call-create-agent')
+    if (action.kind === 'call-create-agent') {
       expect(action.allowedUserId).toBe(CALLER)
       expect(action.slug).toBe('gymbro')
       expect(action.persona).toBe('Gym Bro')
+      expect(action.profile).toBe('default')
     }
   })
 
-  it('advances to call-reconcile on "y"', () => {
-    const action = handleSetupText({ state: baseState, text: 'y', callerId: CALLER })
-    expect(action.kind).toBe('call-reconcile')
-    if (action.kind === 'call-reconcile') expect(action.allowedUserId).toBe(CALLER)
+  it('advances to call-create-agent on "y"', () => {
+    const action = call(baseState, 'y')
+    expect(action.kind).toBe('call-create-agent')
+    if (action.kind === 'call-create-agent') expect(action.allowedUserId).toBe(CALLER)
   })
 
   it('uses custom user_id when not "yes"', () => {
-    const action = handleSetupText({ state: baseState, text: '99999999', callerId: CALLER })
-    expect(action.kind).toBe('call-reconcile')
-    if (action.kind === 'call-reconcile') expect(action.allowedUserId).toBe('99999999')
+    const action = call(baseState, '99999999')
+    expect(action.kind).toBe('call-create-agent')
+    if (action.kind === 'call-create-agent') expect(action.allowedUserId).toBe('99999999')
+  })
+
+  it('falls back to "default" profile for legacy in-flight flows where profile is null', () => {
+    // Simulates a flow that started before the #190 schema migration —
+    // SQLite returns NULL for the new `profile` column, the wizard
+    // shouldn't break.
+    const legacy = makeState({
+      step: 'confirming-allowlist',
+      slug: 'oldgymbro',
+      persona: 'Old Gym',
+      botToken: '1234567890:AAHxxxxxxxxxxxxxxxxxxxxxxx',
+      profile: null,
+    })
+    const action = call(legacy, 'yes')
+    expect(action.kind).toBe('call-create-agent')
+    if (action.kind === 'call-create-agent') expect(action.profile).toBe('default')
+  })
+})
+
+// ─── handleSetupText: step asked-oauth-code (#189) ───────────────────────
+
+describe('handleSetupText: asked-oauth-code (#189)', () => {
+  function oauthState(): SetupFlowState {
+    return makeState({
+      step: 'asked-oauth-code',
+      slug: 'gymbro',
+      persona: 'Gym Bro',
+      profile: 'default',
+      botToken: '1234567890:AAHxxxxxxxxxxxxxxxxxxxxxxx',
+      authSessionName: 'gymbro-foreman',
+      loginUrl: 'https://example.com/login',
+    })
+  }
+
+  it('advances to call-complete-creation with a valid-shape code', () => {
+    const action = call(oauthState(), 'a1b2c3d4e5')
+    expect(action.kind).toBe('call-complete-creation')
+    if (action.kind === 'call-complete-creation') {
+      expect(action.slug).toBe('gymbro')
+      expect(action.code).toBe('a1b2c3d4e5')
+    }
+  })
+
+  it('returns error stayInStep on too-short code', () => {
+    const action = call(oauthState(), 'abc')
+    expect(action.kind).toBe('error')
+    if (action.kind === 'error') expect(action.stayInStep).toBe(true)
+  })
+
+  it('cancels when slug missing (corrupt state)', () => {
+    const action = call(makeState({ step: 'asked-oauth-code' }), 'a1b2c3d4e5')
+    expect(action.kind).toBe('cancel')
   })
 })
 


### PR DESCRIPTION
## Summary

Brings the `/setup` wizard to feature parity with `/create-agent`. Both gaps closed in this PR were "leave Telegram, go to a terminal, come back" — exactly the friction the wizard was supposed to remove.

**Closes:** `#189`, `#190`

## What changed

The `/setup` wizard goes from 5 steps to 6:

```
slug → persona → model → emoji → profile (#190) →
  bot-token → confirm-allowlist → create →
  oauth-code (#189) → done
```

### #190 — skills/profile selector
Pre-fix: `profile = 'default'` hard-coded in the orchestrator. Now the wizard asks the user to pick from `listAvailableProfiles()` (validated server-side) before the bot-token step.

### #189 — in-wizard OAuth code paste
Pre-fix: after scaffolding the agent, the user was told to run `switchroom auth code <slug>` from a terminal. Now `createAgent`'s returned `loginUrl` is rendered as an InlineKeyboard URL button + the wizard advances to a new `asked-oauth-code` state. The user pastes the code in chat; `completeCreation` runs + the agent starts.

Mirror of the create-flow's existing pattern. Both flows now have parallel state machines; future divergence will be a regression rather than a default.

## Schema migration

`setup_flow` table gains 3 nullable columns: `profile`, `auth_session_name`, `login_url`. ALTER TABLE migrations are idempotent + wrapped in try/catch so the migration is forward-compatible. Legacy in-flight rows resume cleanly: `profile=null` defaults to `'default'` in the orchestrator (with a regression test pinning the fallback).

## Test plan

- [x] vitest sweep: 4244 pass (up from 4198 — +46 from this PR)
- [x] `bun test tests/setup-flow.test.ts tests/setup-state.test.ts` — 92 pass (up from 78)
- [x] type-check clean
- [ ] Manual: `/setup gymbro` from a fresh Telegram DM → walks through all 6 steps → InlineKeyboard URL appears → paste OAuth code → agent starts
- [ ] Manual: trigger `/setup` mid-flow restart of the foreman → SQLite state survives → resume continues from the same step

## Notes

- `#188` (BotFather auto-flow) remains TODO — separate, larger ticket.
- The two wizard flows now have intentional parallel state machines. A future cleanup might unify them, but that's a separate refactor and the parallel shape keeps the diffs minimal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
