### PR TITLE
fix(gateway): close boot-card dedupe race window (#489)

### DIFF
--- a/telegram-plugin/gateway/boot-card.ts
+++ b/telegram-plugin/gateway/boot-card.ts
@@ -121,6 +121,14 @@ export interface BootCardGate {
    * (2026-04-26 11:19:47).
    */
   activeBootCard: { messageId: number } | null
+  /**
+   * True while a boot card emission is in-flight (sendMessage round-trip
+   * not yet resolved). Closes the race window where bridge-reconnect ran
+   * during the boot path's await and saw activeBootCard still null —
+   * observed as klanker msgId 4715 + 4716 (2026-05-01 10:13:15, issue #489).
+   * Optional for backward compatibility with callers that pre-date the flag.
+   */
+  bootCardPending?: boolean
 }
 
 export interface BootCardSkipDecision {
@@ -137,13 +145,18 @@ export interface BootCardSkipDecision {
  * registers; without this guard it posts a duplicate card.
  *
  * Boot path: never skip — it's the primary post site.
- * Bridge-reconnect: skip if a card was already posted this lifetime.
+ * Bridge-reconnect: skip if a card is in-flight OR was already posted
+ * this lifetime. The in-flight check closes the race against an
+ * unresolved sendMessage await (issue #489).
  */
 export function shouldSkipDuplicateBootCard(
   gate: BootCardGate,
   site: BootCardSite,
 ): BootCardSkipDecision {
   if (site === 'boot') return { skip: false }
+  if (gate.bootCardPending) {
+    return { skip: true, reason: 'in-flight-on-boot-path' }
+  }
   if (gate.activeBootCard != null) {
     return {
       skip: true,

--- a/telegram-plugin/tests/boot-card-dedupe.test.ts
+++ b/telegram-plugin/tests/boot-card-dedupe.test.ts
@@ -66,3 +66,59 @@ describe('shouldSkipDuplicateBootCard — reason format', () => {
     expect(decision.reason).toBeUndefined()
   })
 })
+
+// ---------------------------------------------------------------------------
+// In-flight race window (issue #489)
+//
+// Before #489, the gate only saw activeBootCard, which is only assigned
+// AFTER the boot path's `await startBootCard(...)` resolved. If the agent's
+// IPC client connected during that 1–2s sendMessage round-trip,
+// onClientRegistered would dedupe-check, see activeBootCard = null, and
+// fire its own boot card. Klanker on 2026-05-01 10:13:15 produced msgId
+// 4715 + 4716 from the same gateway PID via this race. The bootCardPending
+// flag is set synchronously before the await so the dedupe sees in-flight.
+// ---------------------------------------------------------------------------
+
+describe('shouldSkipDuplicateBootCard — in-flight (race window, #489)', () => {
+  it('skips bridge-reconnect when boot path is still awaiting sendMessage', () => {
+    const decision = shouldSkipDuplicateBootCard(
+      { activeBootCard: null, bootCardPending: true },
+      'bridge-reconnect',
+    )
+    expect(decision.skip).toBe(true)
+    expect(decision.reason).toMatch(/in-flight/i)
+  })
+
+  it('skips bridge-reconnect when both pending and active are set (post-resolution overlap)', () => {
+    // A bridge-reconnect can fire after activeBootCard was assigned but
+    // before the finally-clears bootCardPending — both true is legal.
+    const decision = shouldSkipDuplicateBootCard(
+      { activeBootCard: { messageId: 4715 }, bootCardPending: true },
+      'bridge-reconnect',
+    )
+    expect(decision.skip).toBe(true)
+    // In-flight wins because it's checked first; either reason is fine
+    // for observability — the card is correctly skipped either way.
+    expect(decision.reason).toBeDefined()
+  })
+
+  it('does not skip boot path even when something else is in-flight', () => {
+    // The boot path is the primary site — it's the only thing that should
+    // ever set bootCardPending=true in the first place. Defensive check.
+    const decision = shouldSkipDuplicateBootCard(
+      { activeBootCard: null, bootCardPending: true },
+      'boot',
+    )
+    expect(decision.skip).toBe(false)
+  })
+
+  it('treats undefined bootCardPending as "not pending" for backward compat', () => {
+    // Callers that pre-date the flag still pass { activeBootCard } only.
+    // Their behaviour must not change.
+    const decision = shouldSkipDuplicateBootCard(
+      { activeBootCard: null },
+      'bridge-reconnect',
+    )
+    expect(decision.skip).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary

Completes the boot-card race fix that PR #488 (commit `96c344a`) only half-landed. PR #488 included the gateway-side `bootCardPending` state tracking as a side-effect of its OAuth-redaction work but did not update `BootCardGate` / `shouldSkipDuplicateBootCard` to consult it — so the dedupe still fires only when `activeBootCard` is set, and the in-flight race window stays open. Every gateway restart still emits two boot cards in production.

## Repro (klanker, 2026-05-01 10:13 AEST)

```
10:13:13  boot.clean_shutdown_detected reason="cli: switchroom restart"
10:13:13  boot: posting boot card reason=graceful chat_id=…
10:13:14  ipc — client connected
10:13:14  bridge registered — agent=klanker
10:13:15  boot-card: posted msgId=4715 reason=graceful   ← boot IIFE
10:13:15  boot-card: posted msgId=4716 reason=graceful   ← bridge-reconnect
```

The boot IIFE awaits its `sendMessage` round-trip (~1–2 s); the agent's IPC client connects during that window; `onClientRegistered` checks `activeBootCard`, sees `null` (the IIFE's `.then` hasn't fired yet), and posts its own duplicate.

## Change

- `telegram-plugin/gateway/boot-card.ts`
  - `BootCardGate` gains optional `bootCardPending?: boolean`.
  - `shouldSkipDuplicateBootCard` now skips on the bridge-reconnect path when `bootCardPending` is truthy, with reason `in-flight-on-boot-path`. Falls through to the existing `activeBootCard` check when not pending.
- `telegram-plugin/tests/boot-card-dedupe.test.ts`
  - Four new tests under \`describe("in-flight (race window, #489)")\` covering: bridge-reconnect skipping during in-flight, both flags-set overlap, boot path never skipping, undefined backward-compat.

The flag is already set / cleared synchronously around the boot IIFE's `await` in `gateway.ts` (lines 7778, 7793) and the bridge-reconnect path (lines 1464, 1478) from PR #488. This PR just makes the dedupe actually consult it.

## Backward compatibility

`bootCardPending` is optional. Any caller that pre-dates the flag (passing `{ activeBootCard }` only) gets the same behaviour as before.

## Verification

- `npm run lint` clean (`tsc --noEmit`)
- `bun test telegram-plugin/tests/boot-card-dedupe.test.ts` — 10/10 pass (6 existing + 4 new)
- Live on a running klanker: gateway journal after restart shows

  ```
  bridge-reconnect: skipping boot card (in-flight-on-boot-path)
  boot-card: posted msgId=4719 reason=graceful
  ```

  Exactly one boot card. Issues card emission is independent and still fires correctly.

Closes #489