### PR TITLE
feat(config): bot_username per-agent override for restart preflight

### DIFF
--- a/src/cli/agent.ts
+++ b/src/cli/agent.ts
@@ -574,7 +574,7 @@ export async function reconcileAndRestartAgent(
       if (match) {
         const token = match[1].trim();
         try {
-          await validateBotTokenMatchesAgent(token, name);
+          await validateBotTokenMatchesAgent(token, name, agentConfig.bot_username);
         } catch (err) {
           const msg = err instanceof Error ? err.message : String(err);
           // Fail loudly — do not restart with a wrong token.

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -684,6 +684,16 @@ export const AgentSchema = z.object({
     .string()
     .optional()
     .describe("Per-agent Telegram bot token or vault reference (overrides global telegram.bot_token)"),
+  bot_username: z
+    .string()
+    .optional()
+    .describe(
+      "Per-agent Telegram bot username (without leading @) when it doesn't " +
+      "contain the agent slug. Replaces the default 'username includes slug' " +
+      "preflight check with an exact (case-insensitive) match. Use when an " +
+      "agent and its bot have intentionally divergent names (e.g. agent " +
+      "'lawgpt' paired with bot '@meken_law_bot').",
+    ),
   timezone: z
     .string()
     .regex(

--- a/src/setup/telegram-api.test.ts
+++ b/src/setup/telegram-api.test.ts
@@ -69,6 +69,36 @@ describe("assertBotUsernameMatchesAgent", () => {
       assertBotUsernameMatchesAgent("", "finn"),
     ).toThrow();
   });
+
+  describe("with expectedUsername override", () => {
+    it("accepts an exact match (case-insensitive) even when slug isn't in the username", () => {
+      expect(() =>
+        assertBotUsernameMatchesAgent("meken_law_bot", "lawgpt", "meken_law_bot"),
+      ).not.toThrow();
+      expect(() =>
+        assertBotUsernameMatchesAgent("MEKEN_LAW_BOT", "lawgpt", "meken_law_bot"),
+      ).not.toThrow();
+    });
+
+    it("rejects a username that doesn't equal the declared expected one", () => {
+      let caught: Error | null = null;
+      try {
+        assertBotUsernameMatchesAgent("meken_other_bot", "lawgpt", "meken_law_bot");
+      } catch (err) {
+        caught = err as Error;
+      }
+      expect(caught).not.toBeNull();
+      expect(caught!.message).toMatch(/@meken_other_bot/);
+      expect(caught!.message).toMatch(/@meken_law_bot/);
+      expect(caught!.message).toMatch(/bot_username/);
+    });
+
+    it("substring match alone is not enough when an exact override is set", () => {
+      expect(() =>
+        assertBotUsernameMatchesAgent("meken_law_bot_v2", "lawgpt", "meken_law_bot"),
+      ).toThrow();
+    });
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/setup/telegram-api.ts
+++ b/src/setup/telegram-api.ts
@@ -73,22 +73,35 @@ export async function validateBotToken(token: string): Promise<BotInfo> {
  * BotFather history. The minimal convention we enforce is that the slug
  * appears somewhere in the username (case-insensitive).
  *
- * Throws with a human-readable message when the username does not contain
- * the slug, so the caller can surface it as a loud error.
+ * When `expectedUsername` is supplied, the check is exact (case-
+ * insensitive) equality against that value instead — used when the agent
+ * config explicitly declares its bot username because the slug doesn't
+ * appear in it (e.g. agent `lawgpt` paired with bot `@meken_law_bot`).
  *
- * @param username - The bot username returned by getMe (without leading @).
- * @param agentSlug - The agent name / slug (e.g. "finn", "gymbro").
+ * Throws with a human-readable message when the username does not match,
+ * so the caller can surface it as a loud error.
  */
 export function assertBotUsernameMatchesAgent(
   username: string,
   agentSlug: string,
+  expectedUsername?: string,
 ): void {
   const lowerUsername = username.toLowerCase();
+  if (expectedUsername) {
+    if (lowerUsername !== expectedUsername.toLowerCase()) {
+      throw new Error(
+        `agent "${agentSlug}" bot_token resolves to @${username} — expected @${expectedUsername} (from bot_username in switchroom.yaml). ` +
+          `Check switchroom.yaml or the vault entry (bot_token key may point to the wrong bot).`,
+      );
+    }
+    return;
+  }
   const lowerSlug = agentSlug.toLowerCase();
   if (!lowerUsername.includes(lowerSlug)) {
     throw new Error(
       `agent "${agentSlug}" bot_token resolves to @${username} — expected username to contain "${agentSlug}". ` +
-        `Check switchroom.yaml or the vault entry (bot_token key may point to the wrong bot).`,
+        `Check switchroom.yaml or the vault entry (bot_token key may point to the wrong bot). ` +
+        `If the bot is intentionally named without the slug, declare \`bot_username\` on the agent in switchroom.yaml.`,
     );
   }
 }
@@ -105,9 +118,10 @@ export function assertBotUsernameMatchesAgent(
 export async function validateBotTokenMatchesAgent(
   token: string,
   agentSlug: string,
+  expectedUsername?: string,
 ): Promise<BotInfo> {
   const botInfo = await validateBotToken(token);
-  assertBotUsernameMatchesAgent(botInfo.username, agentSlug);
+  assertBotUsernameMatchesAgent(botInfo.username, agentSlug, expectedUsername);
   return botInfo;
 }
 


### PR DESCRIPTION
## Summary

Adds an optional per-agent `bot_username` field to `switchroom.yaml` so the restart preflight can verify a bot whose username doesn't contain the agent slug.

## Motivation

`switchroom restart <agent>` runs `validateBotTokenMatchesAgent` to catch copy-paste mistakes (clerk's token in finn's .env, etc.). The current heuristic is:

```ts
if (!username.toLowerCase().includes(slug.toLowerCase())) throw …
```

It has no escape hatch for the legitimate case where the bot and agent are intentionally named differently — e.g. agent `lawgpt` paired with bot `@meken_law_bot` (slug `lawgpt` doesn't appear in `meken_law_bot`). Today the operator's only options are:

- `--force` — skips *all* preflights, not just this one
- Rename the bot in BotFather

## Change

### Schema

```yaml
agents:
  lawgpt:
    bot_token: "vault:lawgpt-bot-token"
    bot_username: "meken_law_bot"   # optional; default = slug substring
```

### Behaviour

- **`bot_username` unset** (default): existing slug-substring check, no behaviour change.
- **`bot_username` set**: preflight checks resolved username **equals** (case-insensitively) the declared value. Mismatch errors name both names and the config key.

### Files

- `src/config/schema.ts` — new optional `bot_username: z.string()` on the agent schema next to `bot_token`.
- `src/setup/telegram-api.ts` — `assertBotUsernameMatchesAgent` and `validateBotTokenMatchesAgent` accept an optional `expectedUsername` parameter.
- `src/cli/agent.ts` — restart preflight passes `agentConfig.bot_username` to the validator.
- `src/setup/telegram-api.test.ts` — 3 new tests under \`describe("with expectedUsername override")\`: exact match, mismatch error format, substring-not-enough-when-override-set.

## Backward compatibility

Both the YAML field and the function parameter are optional. The create-orchestrator path and any other call sites that don't pass `expectedUsername` retain the substring-against-slug semantics.

## Verification

- `npm run lint` clean
- `npx vitest run src/setup/telegram-api.test.ts` — 17/17 pass (14 existing + 3 new)
- Live: `switchroom restart lawgpt` succeeds with `bot_username: meken_law_bot` in switchroom.yaml. Previously failed with: \`Bot token mismatch ... agent "lawgpt" bot_token resolves to @meken_law_bot — expected username to contain "lawgpt"\`.