### PR TITLE
ux(placeholder): drop trailing ellipsis from draft-stream placeholder text

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -3772,10 +3772,13 @@ async function handleInbound(
     // ~1 s. Only fires for fresh DM turns; if the agent finishes the turn
     // without calling stream_reply, turn_end clears the orphan.
     //
-    // Placeholder content is meaningful ('🔵 thinking…') rather than '…'
+    // Placeholder content is meaningful ('🔵 thinking') rather than '…'
     // so the user sees a real "I'm working" signal, not three dots that
-    // could read as "still loading the message." Hooks can refine this
-    // mid-turn via the `update_placeholder` IPC message.
+    // could read as "still loading the message." No trailing ellipsis —
+    // sendMessageDraft already animates a "typing" indicator on the
+    // user's client, so a `…` after the word is redundant visual noise.
+    // Hooks can refine the placeholder text mid-turn via the
+    // `update_placeholder` IPC message.
     // #479 fix: drop the DM-only gate so non-forum group chats also get
     // the 🔵 thinking… placeholder within ~1s. Pre-fix the placeholder UX
     // was locked to DMs even though sendMessageDraft works in groups —
@@ -3793,7 +3796,7 @@ async function handleInbound(
       // Best-effort, non-blocking: any failure (transport down, API not
       // available, group rejects sendMessageDraft) falls through to
       // today's behavior — the existing .catch already silently logs.
-      void sendMessageDraftFn(chat_id, draftId, '🔵 thinking…')
+      void sendMessageDraftFn(chat_id, draftId, '🔵 thinking')
         .then(() => {
           preAllocatedDrafts.set(chat_id, { draftId, allocatedAt: Date.now() })
         })

--- a/vendor/hindsight-memory/scripts/recall.py
+++ b/vendor/hindsight-memory/scripts/recall.py
@@ -429,15 +429,17 @@ def main():
 
     session_id = hook_input.get("session_id") or ""
 
-    # Switchroom #303 — push a "📚 recalling…" status to the user's
-    # pre-allocated Telegram draft so the gap between inbound and the
-    # model's first content token isn't 25 s of dead air. Best-effort
-    # and silent on every failure path; the gateway no-ops the IPC
-    # message when there's no draft for this chat (forum topic, fresh
-    # session before pre-alloc lands, etc.).
+    # Switchroom #303 — push a "📚 recalling memories" status to the
+    # user's pre-allocated Telegram draft so the gap between inbound and
+    # the model's first content token isn't 25 s of dead air. No
+    # trailing ellipsis: sendMessageDraft already animates a "typing"
+    # indicator on the user's client, so a `…` is redundant noise.
+    # Best-effort and silent on every failure path; the gateway no-ops
+    # the IPC message when there's no draft for this chat (forum topic,
+    # fresh session before pre-alloc lands, etc.).
     placeholder_chat_id = extract_chat_id_from_prompt(prompt)
     if placeholder_chat_id:
-        update_placeholder(placeholder_chat_id, "📚 recalling memories…")
+        update_placeholder(placeholder_chat_id, "📚 recalling memories")
 
     # Resolve API URL (handles all three connection modes)
     def _dbg(*a):
@@ -637,9 +639,11 @@ def main():
 
     # Switchroom #303 — recall is done, model is about to start the long
     # TTFT. Update the placeholder so the user doesn't keep staring at
-    # `📚 recalling…` for the next 15–20 s of opus thinking.
+    # `📚 recalling memories` for the next 15–20 s of opus thinking.
+    # No trailing ellipsis — sendMessageDraft already animates the
+    # "typing" indicator, the `…` is redundant.
     if placeholder_chat_id:
-        update_placeholder(placeholder_chat_id, "💭 thinking…")
+        update_placeholder(placeholder_chat_id, "💭 thinking")
 
     # If neither block has content, there's nothing to inject — exit
     # silently to avoid emitting an empty hookSpecificOutput.


### PR DESCRIPTION
## Summary

The pre-allocated draft transport (\`sendMessageDraft\`) renders an animated "typing" indicator on the user's Telegram client for the lifetime of the draft. With the animation already signalling "in progress," the trailing \`…\` on placeholder text like \`🔵 thinking…\` is redundant — visual noise stacking on top of the animation.

## Changes

| File:Line | Before | After |
|---|---|---|
| \`gateway.ts:3796\` | \`'🔵 thinking…'\` | \`'🔵 thinking'\` |
| \`recall.py:440\` | \`"📚 recalling memories…"\` | \`"📚 recalling memories"\` |
| \`recall.py:642\` | \`"💭 thinking…"\` | \`"💭 thinking"\` |

Test fixtures that happen to contain these strings as test-input data are left alone — they test IPC round-trip and model-emitted text, not the literal placeholder content.

## Verification

\`\`\`
$ npm run lint        # clean
$ cd telegram-plugin && bun test
…
 2795 pass
 1 skip
 0 fail
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)