### PR TITLE
fix(orchestrator): register timer rollback BEFORE installScheduleTimers (#26)

### DIFF
--- a/src/agents/create-orchestrator.test.ts
+++ b/src/agents/create-orchestrator.test.ts
@@ -84,6 +84,7 @@ import {
   installUnit,
   uninstallUnit,
   resolveGatewayUnitName,
+  installScheduleTimers,
 } from "./systemd.js";
 import { startAuthSession, submitAuthCode } from "../auth/manager.js";
 import { startAgent } from "./lifecycle.js";
@@ -659,5 +660,60 @@ describe("createAgent + completeCreation end-to-end", () => {
 
     expect(completion.outcome.kind).toBe("success");
     expect(completion.started).toBe(true);
+  });
+
+  it("rolls back partially-installed timers when installScheduleTimers throws mid-loop (#26)", async () => {
+    // Pre-#26 fix: rollback was registered AFTER installScheduleTimers
+    // returned. If it threw mid-loop (e.g. ENOSPC after timer 0 but
+    // before timer 1), the rollback was never pushed and orphan
+    // .timer/.service files for the partial write stayed on disk
+    // forever. Post-fix: rollback is pushed BEFORE the call, so
+    // partial-failure cleanup also runs.
+    const agentDir = makeAgentDir();
+    vi.mocked(loadConfig).mockReturnValue({
+      agents: {
+        gymbro: {
+          extends: "health-coach",
+          channels: { telegram: { plugin: "switchroom" } },
+          schedule: [
+            { cron: "0 8 * * *", prompt: "Morning" },
+            { cron: "0 20 * * *", prompt: "Evening" },
+          ],
+        },
+      },
+      telegram: { bot_token: "stub", forum_chat_id: "-100111111111" },
+    } as any);
+
+    // Simulate: ScheduleTimers throws on first call (the one inside the
+    // forward path). The rollback path's invocation (with empty schedule)
+    // should still succeed.
+    let invocationCount = 0;
+    vi.mocked(installScheduleTimers).mockImplementation(
+      (_name: string, _dir: string, schedule: Array<unknown>) => {
+        invocationCount++;
+        // Forward call has the populated schedule; rollback call has [].
+        if (schedule.length > 0) {
+          throw new Error("ENOSPC: no space left on device");
+        }
+        // Rollback path — succeed.
+      },
+    );
+
+    await expect(
+      createAgent({
+        name: "gymbro",
+        profile: "health-coach",
+        telegramBotToken: "123:abc",
+        configPath: join(agentDir, "switchroom.yaml"),
+        rollbackOnFail: true,
+      }),
+    ).rejects.toThrow("ENOSPC");
+
+    // Rollback fired — the empty-schedule cleanup invocation was made.
+    // Pre-fix this would not have happened (the rollback was never registered).
+    expect(invocationCount).toBeGreaterThanOrEqual(2);
+    const calls = vi.mocked(installScheduleTimers).mock.calls;
+    const rollbackCall = calls.find((c) => Array.isArray(c[2]) && c[2].length === 0);
+    expect(rollbackCall).toBeDefined();
   });
 });

--- a/src/agents/create-orchestrator.ts
+++ b/src/agents/create-orchestrator.ts
@@ -253,12 +253,20 @@ export async function createAgent(
   const schedule = agentConfig.schedule ?? [];
   if (schedule.length > 0) {
     await withRollback(() => {
-      installScheduleTimers(name, agentDir, schedule);
-      // Push timer rollback BEFORE enabling so partial installs are also cleaned up.
+      // #26 fix: push the timer-cleanup rollback entry BEFORE
+      // installScheduleTimers runs, not after. The previous order left a
+      // window where the loop inside installScheduleTimers could throw
+      // mid-write (e.g. ENOSPC after timer 0 written but before timer 1)
+      // and the rollback was never registered — orphan .timer + .service
+      // files for partially-written units stayed on disk forever. The
+      // rollback is idempotent (calls installScheduleTimers with empty
+      // schedule, which removes every timer file for this agent
+      // regardless of how many were written), so registering it before
+      // the work is safe.
       rollbackStack.push(() => {
-        // Uninstall timers by passing an empty schedule (removes all timer units).
         try { installScheduleTimers(name, agentDir, []); } catch { /* best effort */ }
       });
+      installScheduleTimers(name, agentDir, schedule);
       daemonReload();
       enableScheduleTimers(name, schedule.length);
     });


### PR DESCRIPTION
## Summary

Fixes #26 — partial-failure in `installScheduleTimers` could leave orphaned timer files because the rollback was registered after the install call. If the install threw mid-loop (after creating some `.timer` files but before completing), the rollback never fired, leaving orphans on disk.

Move the rollback registration ahead of the install so it always covers the full operation, even on partial failures. Adds a regression test that simulates a throw mid-loop and asserts the empty-schedule cleanup runs.

## Test plan
- [x] `npm run lint` clean
- [x] New test in `create-orchestrator.test.ts` exercises the partial-failure path
- [ ] CI green