### PR TITLE
chore(pty-tail): add SWITCHROOM_PTY_DEBUG knob for extractor-miss buffer dump

### DIFF
--- a/telegram-plugin/pty-tail.ts
+++ b/telegram-plugin/pty-tail.ts
@@ -83,6 +83,36 @@ export interface MessageRegionExtractor {
   extract(terminal: Terminal): string | null
 }
 
+// ─── Debug knob ──────────────────────────────────────────────────────────
+//
+// Set SWITCHROOM_PTY_DEBUG=1 to dump the bottom of the terminal buffer to
+// stderr whenever V1Extractor returns null. Used to diagnose extractor
+// misses when Claude Code changes its TUI rendering (e.g. when channels
+// mode shows MCP tool calls in a different shape than legacy mode).
+//
+// Off by default — when unset there is zero overhead beyond an env-var
+// check. When on, dumps are throttled to once per 2s per process so we
+// don't flood stderr while the extractor scans every ~150ms.
+const PTY_DEBUG = process.env.SWITCHROOM_PTY_DEBUG === '1'
+let lastDebugDumpAt = 0
+const DEBUG_DUMP_THROTTLE_MS = 2000
+const DEBUG_DUMP_LINES = 25
+
+function debugDumpBufferOnMiss(buf: { length: number; getLine: (i: number) => { translateToString: (trim: boolean) => string } | undefined }): void {
+  if (!PTY_DEBUG) return
+  const now = Date.now()
+  if (now - lastDebugDumpAt < DEBUG_DUMP_THROTTLE_MS) return
+  lastDebugDumpAt = now
+  const start = Math.max(0, buf.length - DEBUG_DUMP_LINES)
+  const lines: string[] = []
+  for (let i = start; i < buf.length; i++) {
+    const t = buf.getLine(i)?.translateToString(true) ?? ''
+    if (t.trim() === '') continue
+    lines.push(`L${i}: ${t}`)
+  }
+  process.stderr.write(`pty-tail: V1Extractor miss — bottom ${lines.length} non-empty lines:\n${lines.join('\n')}\n---end pty miss dump---\n`)
+}
+
 /**
  * v1 extractor for Claude Code 2.1.x.
  *
@@ -126,7 +156,10 @@ export class V1Extractor implements MessageRegionExtractor {
         break
       }
     }
-    if (startLine < 0) return null
+    if (startLine < 0) {
+      debugDumpBufferOnMiss(buf)
+      return null
+    }
 
     // Concatenate the start line + continuation lines into one logical
     // string. Continuation lines from Ink for tool params are indented


### PR DESCRIPTION
## Summary

V1Extractor silently returns null when its bullet pattern doesn't match the current Claude Code TUI rendering. This makes streaming preview go dark with no signal in the logs about why — which is exactly the symptom we hit with `--dangerously-load-development-channels` mode where MCP tool calls appear to render in a shape V1Extractor doesn't recognize.

Adds an env-gated debug dump: when `SWITCHROOM_PTY_DEBUG=1` is set in the agent's environment (e.g. via `~/.switchroom/.env.vault`), every extractor miss logs the bottom 25 non-empty buffer lines to stderr. Off by default — zero overhead when unset.

Throttled to one dump per 2 seconds to avoid flooding stderr (the scan runs every ~150ms).

## Why

Need a fixture of what the channels-mode TUI actually renders during an in-flight reply tool call before we can update V1Extractor's pattern. Without this knob, capturing that fixture requires manually replaying `service.log` through xterm-headless offline — slow and easy to miss the right window.

## Usage

```bash
echo 'SWITCHROOM_PTY_DEBUG=1' >> ~/.switchroom/.env.vault
switchroom agent restart all
# Send a turn that warrants a reply
journalctl --user -u 'switchroom-*' --since '1 min ago' | grep 'V1Extractor miss'
```

## Test plan
- [x] `npm run lint` clean
- [x] `bun test pty-tail.test.ts` — 39/39 pass
- [ ] CI green