### PR TITLE
fix(gateway): clear stale turn-active marker on boot — stops 2-min flap loop

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -7645,6 +7645,22 @@ void (async () => {
         didOneTimeSetup = true
         void registerSwitchroomBotCommands().catch(() => {})
 
+        // #412 boot-cleanup: clear any pre-existing turn-active marker.
+        // By definition no turn can be in flight when the gateway just
+        // started — any leftover marker is from a turn that never
+        // completed (gateway killed mid-turn, restart while waiting on
+        // a tool, etc). Without this, the watchdog reads the orphan
+        // mtime, sees age >= TURN_HANG_SECS, and restarts the agent —
+        // which kills the gateway mid-cleanup, leaving the marker
+        // again. Result: a 2-min flap loop.
+        //
+        // Safe vs the long-running background sub-agent case: this
+        // only runs at boot. A parent that's mid-flight with a
+        // background worker writes a fresh marker on its next
+        // tool_use (e.g. dispatching the worker), so the marker
+        // tracks the live turn from there.
+        try { removeTurnActiveMarker(STATE_DIR) } catch { /* best-effort */ }
+
         // Boot-time pin sweep
         try {
           const bootAccess = loadAccess()

--- a/telegram-plugin/tests/gateway-boot-marker-clear.test.ts
+++ b/telegram-plugin/tests/gateway-boot-marker-clear.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Structural pin for the boot-time turn-active marker cleanup
+ * (regression coverage for the 2026-05-01 flap-loop incident).
+ *
+ * What broke: an interrupted turn left `<stateDir>/turn-active.json`
+ * on disk. The next gateway boot saw the orphan; the watchdog read its
+ * mtime, computed `age >= TURN_HANG_SECS` (300s default), and
+ * restarted the agent — which killed the gateway mid-cleanup, leaving
+ * the marker again. Result: 2-min flap loop, observed live on `clerk`.
+ *
+ * The fix: gateway calls `removeTurnActiveMarker(STATE_DIR)` once at
+ * boot, inside the `!didOneTimeSetup` block (so it runs only on the
+ * first poll-loop entry, not on every retry attempt). By definition
+ * no turn can be in flight when the gateway just started — any
+ * leftover marker is from a turn that didn't complete.
+ *
+ * The unit tests in `turn-active-marker.test.ts` already cover the
+ * primitive's behaviour. This test pins the *call site* — fails
+ * loudly if a future refactor moves or removes the boot-time clear.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, resolve } from 'node:path'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const GATEWAY_SRC = readFileSync(
+  resolve(__dirname, '..', 'gateway', 'gateway.ts'),
+  'utf8',
+)
+
+describe('gateway boot — clear stale turn-active marker', () => {
+  it('removeTurnActiveMarker is called exactly once inside the !didOneTimeSetup block', () => {
+    // Locate the one-time setup block. It's gated on `!didOneTimeSetup`
+    // and runs after the first successful `bot.api.getMe()` so the
+    // clear only happens once per process lifetime.
+    const setupBlockStart = GATEWAY_SRC.indexOf('if (!didOneTimeSetup)')
+    expect(setupBlockStart).toBeGreaterThan(0)
+
+    // The clear should land near the top of that block — before
+    // pin-sweep, before any boot-card emission. Bound the search
+    // window to ~5KB so we don't pick up the unrelated
+    // `removeTurnActiveMarker` call in the onTurnComplete handler
+    // way down at the bottom of the file.
+    const setupWindow = GATEWAY_SRC.slice(setupBlockStart, setupBlockStart + 5000)
+    const clearMatches = setupWindow.match(/removeTurnActiveMarker\s*\(\s*STATE_DIR\s*\)/g) ?? []
+    expect(clearMatches.length).toBe(1)
+  })
+
+  it('clear is wrapped in try/catch so a disk error never blocks boot', () => {
+    // The clear is best-effort — a transient EBUSY or permission glitch
+    // must not prevent the gateway from coming up. Pin the try-wrapping
+    // to make sure a future refactor doesn't drop it.
+    const setupBlockStart = GATEWAY_SRC.indexOf('if (!didOneTimeSetup)')
+    const setupWindow = GATEWAY_SRC.slice(setupBlockStart, setupBlockStart + 5000)
+    expect(setupWindow).toMatch(/try\s*\{\s*removeTurnActiveMarker\(STATE_DIR\)\s*\}\s*catch/)
+  })
+
+  it('clear runs before the boot-time pin sweep (not after)', () => {
+    // Ordering pin: pin sweep can be slow (many chats × API calls).
+    // Clearing the marker first means the watchdog sees a clean slate
+    // immediately, even if pin sweep takes 30s+ to finish.
+    const setupBlockStart = GATEWAY_SRC.indexOf('if (!didOneTimeSetup)')
+    const setupWindow = GATEWAY_SRC.slice(setupBlockStart, setupBlockStart + 5000)
+    const clearIdx = setupWindow.indexOf('removeTurnActiveMarker(STATE_DIR)')
+    const pinSweepIdx = setupWindow.indexOf('Boot-time pin sweep')
+    expect(clearIdx).toBeGreaterThan(0)
+    expect(pinSweepIdx).toBeGreaterThan(0)
+    expect(clearIdx).toBeLessThan(pinSweepIdx)
+  })
+})


### PR DESCRIPTION
## Live incident

Agent \`clerk\` flapping every ~2 minutes. Cause: orphan \`turn-active.json\` from an interrupted turn was sitting on disk; the watchdog from #412 read its mtime, saw \`age >= TURN_HANG_SECS\` (300s default), and restarted the agent — which killed the gateway mid-cleanup, leaving the same orphan marker. Loop.

Evidence:
- clerk's marker mtime: 2026-05-01 10:43:39 (orphan from ~70min ago)
- 4 of 5 agents had no orphan, no flap
- watchdog log: \`agent clerk: turn-active marker stale (3526s >= 300s); restarting via switchroom agent restart (#412)\`

## The fix

Gateway now calls \`removeTurnActiveMarker(STATE_DIR)\` once at boot, inside the \`!didOneTimeSetup\` block. By definition no turn can be in flight when the gateway just started — any leftover marker is from a turn that didn't complete, so the clear is always safe.

- Wrapped in try/catch (best-effort, never blocks boot)
- Runs BEFORE the boot-time pin sweep (which can take 30s+) so the watchdog sees a clean slate immediately

## What's intentionally NOT fixed

A long-running foreground sub-agent (>5min) would still be killed by the watchdog because the marker is only touched on the **parent's** own \`tool_use\` events — sub-agent activity doesn't bump the parent's mtime. Pre-existing limitation, not a regression. Will track as a follow-up issue.

## Tests

\`tests/gateway-boot-marker-clear.test.ts\` — 3 structural pins:
- \`removeTurnActiveMarker\` called exactly once inside \`!didOneTimeSetup\`
- wrapped in try/catch
- runs BEFORE boot-time pin sweep

Existing \`tests/turn-active-marker.test.ts\` (8 unit tests on the primitive) unchanged.

## Verification

\`\`\`
$ npm run lint        # clean
$ cd telegram-plugin && bun test
…
 2836 pass / 0 fail across 143 files
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)