### PR TITLE
feat(cli): switchroom memory demote — close the recall-log → demote operator loop

### DIFF
--- a/src/cli/memory.ts
+++ b/src/cli/memory.ts
@@ -1,6 +1,11 @@
 import type { Command } from "commander";
 import chalk from "chalk";
-import { getCollectionForAgent, isStrictIsolation } from "../memory/hindsight.js";
+import {
+  getCollectionForAgent,
+  isStrictIsolation,
+  addMemoryTag,
+  DEMOTE_FROM_RECALL_TAG,
+} from "../memory/hindsight.js";
 import { searchMemory, getMemoryStats, reflectAcrossAgents } from "../memory/search.js";
 import { withConfigError, getConfig, getConfigPath } from "./helpers.js";
 import {
@@ -440,5 +445,100 @@ export function registerMemoryCommand(program: Command): void {
         }
         console.log();
       }),
+    );
+
+  // switchroom memory demote <agent> <memory-id> [--tag <tag>]
+  //
+  // Closes the operator loop opened by #432 4.3 (recall_log shows
+  // memory IDs that surfaced) + #432 4.4 (demote tag is honoured by
+  // recall.py) + #475 (overlap gate). When the operator spots a noisy
+  // memory in `switchroom memory recall-log <agent>`, this verb adds
+  // the `[demote-from-recall]` tag without leaving the terminal.
+  // After the next agent restart (or naturally on the next cache
+  // miss), the demoted memory stops surfacing in auto-recall while
+  // remaining queryable via `mcp__hindsight__recall` and `reflect`.
+  memory
+    .command("demote <agent> <memory-id>")
+    .description(
+      "Tag a memory in the agent's bank to exclude it from auto-recall (closes the recall-log → demote loop, #475 follow-up)",
+    )
+    .option(
+      "--tag <tag>",
+      `Override the demote tag (default: ${DEMOTE_FROM_RECALL_TAG})`,
+      DEMOTE_FROM_RECALL_TAG,
+    )
+    .option(
+      "--timeout <ms>",
+      "Timeout for each Hindsight API call in milliseconds (default: 5000)",
+      "5000",
+    )
+    .action(
+      withConfigError(
+        async (
+          agent: string,
+          memoryId: string,
+          opts: { tag: string; timeout: string },
+        ) => {
+          const config = getConfig(program);
+
+          if (!config.agents[agent]) {
+            console.error(
+              chalk.red(`Agent "${agent}" is not defined in switchroom.yaml`),
+            );
+            process.exit(1);
+          }
+          if (!memoryId || memoryId.trim().length === 0) {
+            console.error(chalk.red("Memory ID is required"));
+            process.exit(1);
+          }
+
+          const collection = getCollectionForAgent(agent, config);
+          const apiUrl =
+            (config.memory?.config?.url as string | undefined) ??
+            "http://localhost:8888/mcp/";
+          const timeoutMs = Math.max(500, parseInt(opts.timeout, 10) || 5000);
+
+          console.log(
+            chalk.bold(`\nDemoting memory ${chalk.cyan(memoryId)}`),
+          );
+          console.log(
+            chalk.gray(
+              `  agent=${agent}  bank=${collection}  tag=${opts.tag}`,
+            ),
+          );
+          console.log(chalk.gray(`  api=${apiUrl}\n`));
+
+          const result = await addMemoryTag(
+            apiUrl,
+            collection,
+            memoryId,
+            opts.tag,
+            { timeoutMs },
+          );
+
+          if (result.ok) {
+            console.log(
+              chalk.green("✓ Tag applied."),
+              chalk.gray(
+                "Recall.py's filter excludes the memory on the next auto-recall (or after agent restart if a session cache is warm).",
+              ),
+            );
+            return;
+          }
+
+          console.error(
+            chalk.red("✗ Tag failed:"),
+            chalk.gray(result.reason),
+          );
+          console.error(
+            chalk.gray(
+              "  The Hindsight MCP `update_memory` tool may not be exposed by your deployment, or the memory ID may be wrong. Try `switchroom memory recall-log " +
+                agent +
+                " --json` to confirm the ID surfaced recently.",
+            ),
+          );
+          process.exit(1);
+        },
+      ),
     );
 }

--- a/src/memory/hindsight.ts
+++ b/src/memory/hindsight.ts
@@ -571,3 +571,116 @@ export async function updateBankMissions(
     return { ok: false, reason: String(err) };
   }
 }
+
+/**
+ * Append a tag to an existing memory in a Hindsight bank.
+ *
+ * Wraps the Hindsight MCP `update_memory` tool. Used by
+ * `switchroom memory demote` (#475 follow-up) to add the
+ * `[demote-from-recall]` tag to noisy memories that the operator
+ * spots in the recall-log. Once tagged, recall.py's
+ * `_is_demoted_memory` filter (#432 4.4) excludes the memory from
+ * subsequent auto-recall blocks while keeping it queryable via
+ * `mcp__hindsight__recall` and `reflect`.
+ *
+ * Best-effort with timeout; never throws. Mirrors `updateBankMissions`
+ * shape so the caller pattern stays consistent across switchroom's
+ * Hindsight-touching helpers.
+ */
+export async function addMemoryTag(
+  apiUrl: string,
+  bankId: string,
+  memoryId: string,
+  tag: string,
+  opts?: { fetchImpl?: typeof fetch; timeoutMs?: number },
+): Promise<{ ok: true } | { ok: false; reason: string }> {
+  const fetchImpl = opts?.fetchImpl ?? fetch;
+  const timeoutMs = opts?.timeoutMs ?? 5000;
+
+  try {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), timeoutMs);
+
+    // Step 1: initialize MCP session (required for any subsequent tools/call).
+    const initResponse = await fetchImpl(`${apiUrl}`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "Accept": "application/json, text/event-stream",
+        "X-Bank-Id": bankId,
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: {
+          protocolVersion: "2024-11-05",
+          capabilities: {},
+          clientInfo: { name: "switchroom", version: "0.1" },
+        },
+      }),
+      signal: controller.signal,
+    });
+
+    clearTimeout(timeout);
+
+    if (!initResponse.ok) {
+      return { ok: false, reason: `HTTP ${initResponse.status}` };
+    }
+
+    const sessionId = initResponse.headers.get("mcp-session-id");
+    if (!sessionId) {
+      return { ok: false, reason: "No session ID returned" };
+    }
+
+    // Step 2: call update_memory with `add_tags` to append (rather than
+    // replace) the tag. Hindsight's update_memory accepts an `add_tags`
+    // list per the MCP tool schema; if the deployment is older and only
+    // accepts `tags` (replace), the tool call returns ok but the tag
+    // may overwrite. Operators on stale deployments should bump the
+    // plugin (#438 Tier 1).
+    const timeout2 = setTimeout(() => controller.abort(), timeoutMs);
+    const toolResponse = await fetchImpl(`${apiUrl}`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "Accept": "application/json, text/event-stream",
+        "X-Bank-Id": bankId,
+        "mcp-session-id": sessionId,
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 2,
+        method: "tools/call",
+        params: {
+          name: "update_memory",
+          arguments: {
+            bank_id: bankId,
+            memory_id: memoryId,
+            add_tags: [tag],
+          },
+        },
+      }),
+      signal: controller.signal,
+    });
+
+    clearTimeout(timeout2);
+
+    if (!toolResponse.ok) {
+      return { ok: false, reason: `Tool call HTTP ${toolResponse.status}` };
+    }
+
+    return { ok: true };
+  } catch (err) {
+    if ((err as Error).name === "AbortError") {
+      return { ok: false, reason: "Timeout" };
+    }
+    return { ok: false, reason: String(err) };
+  }
+}
+
+/** Canonical demote tag honoured by `_is_demoted_memory` in
+ *  `vendor/hindsight-memory/scripts/recall.py` (#432 phase 4.4).
+ *  Exported so CLI commands and tests stay in lockstep with the
+ *  Python-side filter without hard-coding the literal in two places. */
+export const DEMOTE_FROM_RECALL_TAG = "[demote-from-recall]";

--- a/tests/cli.memory.demote.test.ts
+++ b/tests/cli.memory.demote.test.ts
@@ -1,0 +1,159 @@
+/**
+ * Integration tests for `switchroom memory demote <agent> <memory-id>`.
+ *
+ * Shells out to the built CLI under bun (matches what hooks invoke in
+ * production). The HTTP path to Hindsight is NOT exercised here —
+ * `tests/memory.add-memory-tag.test.ts` covers the wire shape with a
+ * mocked fetch. These tests exercise the commander wiring + arg
+ * validation + agent-existence preflight.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+const CLI = resolve(__dirname, "..", "dist", "cli", "switchroom.js");
+const BUN = process.env.BUN_PATH ?? "bun";
+
+let cfgDir: string;
+let cfgPath: string;
+
+function run(
+  args: string[],
+  opts: { expectError?: boolean } = {},
+): { stdout: string; stderr: string; status: number } {
+  try {
+    const stdout = execFileSync(BUN, [CLI, "--config", cfgPath, ...args], {
+      stdio: ["ignore", "pipe", "pipe"],
+      encoding: "utf-8",
+      env: process.env as Record<string, string>,
+    });
+    return { stdout, stderr: "", status: 0 };
+  } catch (err) {
+    const e = err as {
+      stdout?: Buffer | string;
+      stderr?: Buffer | string;
+      status?: number;
+    };
+    if (!opts.expectError) throw err;
+    return {
+      stdout:
+        typeof e.stdout === "string"
+          ? e.stdout
+          : (e.stdout ?? Buffer.alloc(0)).toString(),
+      stderr:
+        typeof e.stderr === "string"
+          ? e.stderr
+          : (e.stderr ?? Buffer.alloc(0)).toString(),
+      status: e.status ?? 1,
+    };
+  }
+}
+
+beforeEach(() => {
+  cfgDir = mkdtempSync(join(tmpdir(), "memory-demote-cli-"));
+  cfgPath = join(cfgDir, "switchroom.yaml");
+  // Minimal valid switchroom.yaml with one agent. The `clerk` collection
+  // defaults from agent name (no explicit `memory.collection`).
+  // Hindsight is pointed at a closed port so the demote call fails fast
+  // (ECONNREFUSED) rather than hitting a real service — sufficient to
+  // verify the dispatcher reaches the API layer.
+  writeFileSync(
+    cfgPath,
+    [
+      "switchroom:",
+      "  version: 1",
+      "telegram:",
+      '  bot_token: "vault:telegram-bot-token"',
+      '  forum_chat_id: "-100"',
+      "memory:",
+      "  backend: hindsight",
+      "  config:",
+      "    url: http://127.0.0.1:1/mcp/",
+      "agents:",
+      "  clerk:",
+      '    topic_name: "Test"',
+      "",
+    ].join("\n"),
+  );
+});
+
+afterEach(() => {
+  rmSync(cfgDir, { recursive: true, force: true });
+});
+
+describe("memory demote — argument validation", () => {
+  it("--help lists the verb and shows the default tag", () => {
+    const { stdout, status } = run(["memory", "demote", "--help"]);
+    expect(status).toBe(0);
+    expect(stdout).toContain("demote");
+    expect(stdout).toContain("memory-id");
+    expect(stdout).toContain("[demote-from-recall]");
+    expect(stdout).toContain("--tag");
+    expect(stdout).toContain("--timeout");
+  });
+
+  it("rejects unknown agent with non-zero exit and helpful stderr", () => {
+    const { status, stderr } = run(
+      ["memory", "demote", "ghost-agent", "mem-abc"],
+      { expectError: true },
+    );
+    expect(status).toBe(1);
+    expect(stderr).toContain("ghost-agent");
+    expect(stderr).toMatch(/not defined in switchroom\.yaml/);
+  });
+
+  it("commander rejects when memory-id positional is missing", () => {
+    const { status, stderr } = run(["memory", "demote", "clerk"], {
+      expectError: true,
+    });
+    // Commander exits non-zero with usage on missing required arg.
+    expect(status).not.toBe(0);
+    expect(stderr).toMatch(/missing required argument|usage/i);
+  });
+});
+
+describe("memory demote — happy-path wiring", () => {
+  it("attempts the API call when agent + memory-id are valid (network failure surfaces cleanly)", () => {
+    // Hindsight is pointed at port 1 (closed) so the call fails fast
+    // with a connection error. Exit 1 with a clear "Tag failed:" line
+    // tells us the dispatcher reached the API layer; the actual API
+    // wire shape is covered by tests/memory.add-memory-tag.test.ts.
+    const { status, stdout, stderr } = run(
+      ["memory", "demote", "clerk", "mem-abc-123", "--timeout", "2000"],
+      { expectError: true },
+    );
+    expect(status).toBe(1);
+    // Banner lines are on stdout (chalk-coloured but readable).
+    expect(stdout).toContain("Demoting memory");
+    expect(stdout).toContain("mem-abc-123");
+    expect(stdout).toContain("clerk");
+    expect(stdout).toContain("[demote-from-recall]");
+    // Failure line is on stderr.
+    expect(stderr).toMatch(/Tag failed/);
+    // Hint references the recall-log workflow so operators know how to
+    // verify the ID is valid.
+    expect(stderr).toContain("recall-log clerk");
+  });
+
+  it("respects a custom --tag override", () => {
+    const { stdout } = run(
+      [
+        "memory",
+        "demote",
+        "clerk",
+        "mem-abc-123",
+        "--tag",
+        "anti-pattern:misleading",
+        "--timeout",
+        "2000",
+      ],
+      { expectError: true },
+    );
+    expect(stdout).toContain("anti-pattern:misleading");
+    // Default tag should not appear when --tag overrides it.
+    expect(stdout).not.toContain("[demote-from-recall]");
+  });
+});

--- a/tests/memory.add-memory-tag.test.ts
+++ b/tests/memory.add-memory-tag.test.ts
@@ -1,0 +1,204 @@
+/**
+ * Unit tests for `addMemoryTag` — the TS wrapper that calls Hindsight's
+ * `update_memory` MCP tool to append a tag to an existing memory.
+ *
+ * Mirrors the pattern in `tests/memory.bank-missions.test.ts` (which
+ * tests the sibling `updateBankMissions`).
+ *
+ * Closes the operator loop opened by #432 4.3 (recall_log surfaces
+ * memory IDs) + #432 4.4 (demote tag honoured by recall.py) + #475
+ * (overlap gate). The CLI dispatcher (`switchroom memory demote`)
+ * is covered by `tests/cli.memory.demote.test.ts`.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import {
+  addMemoryTag,
+  DEMOTE_FROM_RECALL_TAG,
+} from "../src/memory/hindsight.js";
+
+describe("DEMOTE_FROM_RECALL_TAG", () => {
+  it("matches the canonical Python-side filter literal", () => {
+    // Source of truth: vendor/hindsight-memory/scripts/recall.py
+    // `DEMOTE_TAG_VARIANTS` set (#432 phase 4.4). The bracketed form
+    // is the canonical one we write; the Python filter also accepts
+    // the bracket-less variant and "no-recall" for robustness.
+    expect(DEMOTE_FROM_RECALL_TAG).toBe("[demote-from-recall]");
+  });
+});
+
+describe("addMemoryTag — happy path", () => {
+  it("calls update_memory with add_tags after MCP initialize", async () => {
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        headers: new Map([["mcp-session-id", "test-session"]]),
+      } as any)
+      .mockResolvedValueOnce({ ok: true } as any);
+
+    const result = await addMemoryTag(
+      "http://test.local/mcp/",
+      "clerk",
+      "mem-abc123",
+      DEMOTE_FROM_RECALL_TAG,
+      { fetchImpl: mockFetch as any, timeoutMs: 5000 },
+    );
+
+    expect(result).toEqual({ ok: true });
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+
+    // Initialize step: POST /mcp/, body includes method=initialize.
+    const initCall = mockFetch.mock.calls[0];
+    expect(initCall[0]).toBe("http://test.local/mcp/");
+    const initBody = JSON.parse(initCall[1].body);
+    expect(initBody.method).toBe("initialize");
+    expect(initBody.params.protocolVersion).toBe("2024-11-05");
+    expect(initCall[1].headers["X-Bank-Id"]).toBe("clerk");
+
+    // Tool call step: tools/call → update_memory with add_tags.
+    const toolCall = mockFetch.mock.calls[1];
+    const toolBody = JSON.parse(toolCall[1].body);
+    expect(toolBody.method).toBe("tools/call");
+    expect(toolBody.params.name).toBe("update_memory");
+    expect(toolBody.params.arguments).toEqual({
+      bank_id: "clerk",
+      memory_id: "mem-abc123",
+      add_tags: ["[demote-from-recall]"],
+    });
+    // Session id from the init response must be threaded into the tool call.
+    expect(toolCall[1].headers["mcp-session-id"]).toBe("test-session");
+  });
+
+  it("supports a custom tag (operator may use lesson:foo or anti-pattern:bar)", async () => {
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        headers: new Map([["mcp-session-id", "s"]]),
+      } as any)
+      .mockResolvedValueOnce({ ok: true } as any);
+
+    const result = await addMemoryTag(
+      "http://test.local/mcp/",
+      "clerk",
+      "mem-abc",
+      "anti-pattern:misleading-reply",
+      { fetchImpl: mockFetch as any },
+    );
+
+    expect(result).toEqual({ ok: true });
+    const toolBody = JSON.parse(mockFetch.mock.calls[1][1].body);
+    expect(toolBody.params.arguments.add_tags).toEqual([
+      "anti-pattern:misleading-reply",
+    ]);
+  });
+});
+
+describe("addMemoryTag — error paths", () => {
+  it("returns error when initialize HTTP fails", async () => {
+    const mockFetch = vi.fn().mockResolvedValueOnce({
+      ok: false,
+      status: 503,
+    } as any);
+    const result = await addMemoryTag(
+      "http://test.local/mcp/",
+      "clerk",
+      "mem-abc",
+      DEMOTE_FROM_RECALL_TAG,
+      { fetchImpl: mockFetch as any },
+    );
+    expect(result).toEqual({ ok: false, reason: "HTTP 503" });
+    // Tool-call step must not fire.
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns error when initialize returns no session ID", async () => {
+    const mockFetch = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      headers: new Map(), // no mcp-session-id
+    } as any);
+    const result = await addMemoryTag(
+      "http://test.local/mcp/",
+      "clerk",
+      "mem-abc",
+      DEMOTE_FROM_RECALL_TAG,
+      { fetchImpl: mockFetch as any },
+    );
+    expect(result).toEqual({ ok: false, reason: "No session ID returned" });
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns error when tools/call HTTP fails", async () => {
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        headers: new Map([["mcp-session-id", "s"]]),
+      } as any)
+      .mockResolvedValueOnce({ ok: false, status: 400 } as any);
+    const result = await addMemoryTag(
+      "http://test.local/mcp/",
+      "clerk",
+      "bad-mem-id",
+      DEMOTE_FROM_RECALL_TAG,
+      { fetchImpl: mockFetch as any },
+    );
+    expect(result).toEqual({ ok: false, reason: "Tool call HTTP 400" });
+  });
+
+  it("returns Timeout reason on AbortError", async () => {
+    const mockFetch = vi.fn().mockImplementationOnce(() => {
+      const err = new Error("aborted");
+      err.name = "AbortError";
+      throw err;
+    });
+    const result = await addMemoryTag(
+      "http://test.local/mcp/",
+      "clerk",
+      "mem-abc",
+      DEMOTE_FROM_RECALL_TAG,
+      { fetchImpl: mockFetch as any, timeoutMs: 1 },
+    );
+    expect(result).toEqual({ ok: false, reason: "Timeout" });
+  });
+
+  it("wraps generic errors in the reason field", async () => {
+    const mockFetch = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("ECONNREFUSED"));
+    const result = await addMemoryTag(
+      "http://test.local/mcp/",
+      "clerk",
+      "mem-abc",
+      DEMOTE_FROM_RECALL_TAG,
+      { fetchImpl: mockFetch as any },
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toContain("ECONNREFUSED");
+    }
+  });
+});
+
+describe("addMemoryTag — defaults", () => {
+  it("uses 5000ms default timeout when not specified", async () => {
+    // We can't easily observe the timeout value through mockFetch, but
+    // we can confirm the call shape works without an explicit timeoutMs.
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        headers: new Map([["mcp-session-id", "s"]]),
+      } as any)
+      .mockResolvedValueOnce({ ok: true } as any);
+    const result = await addMemoryTag(
+      "http://test.local/mcp/",
+      "clerk",
+      "mem-abc",
+      DEMOTE_FROM_RECALL_TAG,
+      { fetchImpl: mockFetch as any },
+    );
+    expect(result).toEqual({ ok: true });
+  });
+});


### PR DESCRIPTION
## Summary

Adds a thin operator workflow on top of the quality work shipped in #475 / #432: when a noisy memory surfaces in `switchroom memory recall-log <agent>`, this verb adds the canonical `[demote-from-recall]` tag without leaving the terminal. After the next agent restart (or naturally on the next cache miss), the demoted memory stops surfacing in auto-recall while remaining queryable via `mcp__hindsight__recall` and `reflect`.

## Why

Closes the operator loop opened by:

- **#432 4.3** — recall_log.jsonl shows memory IDs that surfaced
- **#432 4.4** — `[demote-from-recall]` tag honoured by recall.py
- **#475** — lexical-overlap relevance gate (drops weak matches at the wire)

Without this verb, demoting required either calling `mcp__hindsight__update_memory` from inside an agent's claude session or hitting the Hindsight HTTP API by hand. Both work but break the operator's flow when they're scanning recall-log output and want to act fast.

JTBD: `remember-across-sessions` — *\"The user can correct a stored fact, and the correction sticks.\"*

## Surface

```
switchroom memory demote <agent> <memory-id> [--tag <tag>] [--timeout <ms>]
```

- Default tag: `[demote-from-recall]` (matches `DEMOTE_TAG_VARIANTS` in `vendor/hindsight-memory/scripts/recall.py`).
- `--tag` lets operators apply other curation tags (e.g. `anti-pattern:misleading-reply` per #398's lineage).
- `--timeout` defaults to 5s; tunes per-call MCP timeout.

## Implementation

- **`addMemoryTag(apiUrl, bankId, memoryId, tag, opts?)`** in `src/memory/hindsight.ts` — mirrors the existing `updateBankMissions` pattern: initialize MCP session, then `tools/call` with `update_memory` + `add_tags: [tag]`. Best-effort with timeout, never throws.
- **`DEMOTE_FROM_RECALL_TAG`** constant exported so the CLI and tests stay in lockstep with the Python-side filter literal.
- **CLI verb** in `src/cli/memory.ts` — resolves agent → bank → API URL, prints a banner of what's about to happen, calls the helper, prints success or a hint pointing back to `recall-log` for ID verification.

## Test plan

- [x] **`tests/memory.add-memory-tag.test.ts`** (9 cases) — wire shape with mocked fetch:
  - happy path (default tag), custom tag (anti-pattern:foo)
  - init HTTP failure, missing session ID, tool-call HTTP failure
  - AbortError → Timeout reason
  - generic error wrapping in `reason` field
  - default 5000ms timeout works without explicit override
- [x] **`tests/cli.memory.demote.test.ts`** (5 cases) — shells out to built CLI:
  - `--help` lists the verb + default tag + flags
  - unknown agent exits non-zero with helpful stderr
  - missing memory-id surfaces commander's usage error
  - happy-path wiring: network failure (closed port 1) surfaces cleanly through the dispatcher with the recall-log hint
  - `--tag` override replaces the default
- [x] `npm run lint` — clean
- [x] `npm test` — 4289 vitest + 289 bun pass, 0 fail
- [ ] **Manual on a real fleet agent**: `switchroom memory recall-log <agent>` → spot a noisy ID → `switchroom memory demote <agent> <id>` → verify next recall (after restart or cache miss) excludes that memory

## Out of scope

- **Multi-ID batch demote**: v1 is one ID per invocation. Operators with several IDs can shell-loop. A `<memory-id...>` variadic is a 5-line follow-up if requested.
- **Self-recognition / auto-demote** of low-relevance memories: that's the larger #398 epic (Option 1 — anti-pattern tagging at retain time). This PR is the operator surface; auto-tagging would build on top.
- **Lesson-first ranking in reflect** (#398 Option 2): different code path (recall vs reflect routing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)