### PR TITLE
chore: remove deprecated CLI aliases, /reconcile handlers, suppress_stdout field

### DIFF
--- a/src/build-info.ts
+++ b/src/build-info.ts
@@ -2,8 +2,8 @@
 // Tracked in git so `tsc --noEmit` works on a fresh clone before `npm run build`.
 // Values are refreshed every time `npm run build` runs.
 
-export const VERSION: string = "0.3.0";
-export const COMMIT_SHA: string | null = "49fd0a4";
-export const COMMIT_DATE: string | null = "2026-04-28T23:30:14+10:00";
-export const LATEST_PR: number | null = 18;
-export const COMMITS_AHEAD_OF_TAG: number | null = 102;
+export const VERSION: string = "0.4.0";
+export const COMMIT_SHA: string | null = "4824672";
+export const COMMIT_DATE: string | null = "2026-05-01T10:59:49+10:00";
+export const LATEST_PR: number | null = 495;
+export const COMMITS_AHEAD_OF_TAG: number | null = 68;

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,7 +1,6 @@
 import { Command } from "commander";
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
-import { execFileSync } from "node:child_process";
 import { registerInitCommand } from "./init.js";
 import { registerAgentCommand } from "./agent.js";
 import { registerSystemdCommand } from "./systemd.js";
@@ -66,30 +65,3 @@ registerDepsCommand(program);
 registerWorkspaceCommand(program);
 registerDebugCommand(program);
 registerWorktreeCommand(program);
-
-// Deprecated aliases — kept for one release, will be removed after.
-// Invoking these prints a clear deprecation warning and delegates to `update`.
-for (const oldVerb of ["upgrade", "rebuild", "reconcile"] as const) {
-  program
-    .command(oldVerb, { hidden: true })
-    .description(`[DEPRECATED] Use 'switchroom update' instead`)
-    .allowUnknownOption(true)
-    .action(() => {
-      console.warn(
-        `\n  ⚠  '${oldVerb}' is deprecated — use 'switchroom update' instead.\n`
-      );
-      // Delegate by re-invoking with the canonical verb. argv layout for
-      // a CLI invocation is [node, /path/to/switchroom, <verb>, ...rest],
-      // so slice(3) drops the deprecated verb and keeps the rest of the
-      // user's flags. Test harnesses that mock argv differently must
-      // construct the array themselves.
-      try {
-        const self = process.argv[1];
-        execFileSync(process.execPath, [self, "update", ...process.argv.slice(3)], {
-          stdio: "inherit",
-        });
-      } catch (err: any) {
-        process.exit(err.status ?? 1);
-      }
-    });
-}

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -40,16 +40,6 @@ export const ScheduleEntrySchema = z.object({
       "anyone with the vault passphrase can read the vault file directly. " +
       "See docs/configuration.md for the full framing.",
     ),
-  suppress_stdout: z
-    .boolean()
-    .default(false)
-    .describe(
-      "DEPRECATED — accepted but ignored as of #269. All cron tasks now " +
-      "deliver their Telegram message via the MCP `reply` tool, with stdout " +
-      "always discarded. Existing configs that set this field will not error, " +
-      "but the value has no effect. The field will be removed in a future " +
-      "release.",
-    ),
 });
 
 export const AgentSoulSchema = z

--- a/src/vault/broker/acl.test.ts
+++ b/src/vault/broker/acl.test.ts
@@ -36,7 +36,6 @@ function makeConfig(
         cron: s.cron,
         prompt: s.prompt,
         secrets: s.secrets ?? [],
-        suppress_stdout: false,
       })),
     };
   }

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -4136,7 +4136,7 @@ function resolveBootChatId(
 /**
  * Stamp a user-facing restart reason into the clean-shutdown marker
  * (same file the SIGTERM handler writes to and the next session greeting
- * consumes). Called by /restart, /reconcile, /new, /reset BEFORE the
+ * consumes). Called by /restart, /new, /reset BEFORE the
  * detached `switchroom agent restart …` CLI fires — so the agent-side
  * greeting card shows who asked ("user: /restart from chat") instead of
  * the downstream CLI's "cli: restart" default.
@@ -6642,23 +6642,6 @@ bot.command('doctor', async ctx => {
   } catch (err: unknown) {
     await switchroomReply(ctx, `<b>doctor failed:</b>\n${preBlock(formatSwitchroomOutput((err as any).message ?? 'unknown error'))}`, { html: true })
   }
-})
-
-// Deprecated: /reconcile is now /update. Kept for one release with a warning.
-bot.command('reconcile', async ctx => {
-  if (!isAuthorizedSender(ctx)) return
-  await switchroomReply(
-    ctx,
-    `⚠️ <b>/reconcile is deprecated</b> — use <code>/update</code> instead.\n\nRunning <b>switchroom update</b> now…`,
-    { html: true },
-  )
-  await sweepBeforeSelfRestart()
-  const chatId = String(ctx.chat!.id)
-  const threadId = resolveThreadId(chatId, ctx.message?.message_thread_id)
-  spawnSwitchroomDetached(
-    ['update'],
-    notifyDetachedFailure(chatId, threadId ?? null, 'update (via deprecated /reconcile)'),
-  )
 })
 
 bot.command('grant', async ctx => {

--- a/telegram-plugin/server.ts
+++ b/telegram-plugin/server.ts
@@ -2535,10 +2535,9 @@ if (streamMode === 'checklist') {
   // Failsafe: unpin any progress cards left over from a prior session
   // that crashed or was killed mid-turn. The in-memory pin map is lost
   // on restart, so without this sweep the stale pins stick forever.
-  // The /restart, /reconcile --restart, and /update command handlers
-  // also call sweepActivePins proactively before spawning the restart
-  // child — this startup sweep is the backstop for crash/kill paths
-  // that never reach that code.
+  // The /restart and /update command handlers also call sweepActivePins
+  // proactively before spawning the restart child — this startup sweep is
+  // the backstop for crash/kill paths that never reach that code.
   const startupAgentDir = resolveAgentDirFromEnv()
   if (startupAgentDir != null) {
     void sweepActivePins(
@@ -3700,9 +3699,9 @@ function clearRestartMarker(): void {
 }
 
 /**
- * Spawn `switchroom` in a detached background process. Used by `/restart`,
- * `/reconcile --restart`, and `/update` when the target operation would
- * SIGTERM the bot's own systemd unit — execFileSync would die mid-call
+ * Spawn `switchroom` in a detached background process. Used by `/restart`
+ * and `/update` when the target operation would SIGTERM the bot's own
+ * systemd unit — execFileSync would die mid-call
  * and the user would see a misleading "command failed" error even
  * though the operation succeeded.
  *
@@ -3726,9 +3725,9 @@ function clearRestartMarker(): void {
  * ever observe the exit, so any exit we DO see is almost certainly a
  * fail-fast CLI error (bad agent name, bad args, missing config). That
  * matters because the production bug — gateway unit not exporting
- * SWITCHROOM_AGENT_NAME — makes `/restart`, `/reconcile`, `/update`
- * resolve the agent as "telegram", which fails validation in the CLI
- * and used to disappear silently into detached-spawn.log.
+ * SWITCHROOM_AGENT_NAME — makes `/restart` and `/update` resolve the
+ * agent as "telegram", which fails validation in the CLI and used to
+ * disappear silently into detached-spawn.log.
  */
 function spawnSwitchroomDetached(
   args: string[],
@@ -3814,10 +3813,9 @@ function notifyDetachedFailure(
  * crashes and SIGKILLs that never reach command handlers, but we
  * want the pins to disappear *as the user reads the ack message*
  * rather than a few seconds later when the new bot boots. Call this
- * from /restart, /reconcile --restart, and /update right after
- * sending the ack and before spawning the detached switchroom
- * child. Bounded by a 2s timeout so a hung Telegram API can't
- * block the restart.
+ * from /restart and /update right after sending the ack and before
+ * spawning the detached switchroom child. Bounded by a 2s timeout so a
+ * hung Telegram API can't block the restart.
  */
 async function sweepPinsBeforeSelfRestart(): Promise<void> {
   const agentDir = resolveAgentDirFromEnv()
@@ -4897,23 +4895,6 @@ bot.command('doctor', async ctx => {
       { html: true },
     )
   }
-})
-
-// Deprecated: /reconcile → /update. Kept for one release with a deprecation notice.
-bot.command('reconcile', async ctx => {
-  if (!isAuthorizedSender(ctx)) return
-  await switchroomReply(
-    ctx,
-    `⚠️ <b>/reconcile is deprecated</b> — use <code>/update</code> instead.\n\nRunning <b>switchroom update</b> now…`,
-    { html: true },
-  )
-  await sweepPinsBeforeSelfRestart()
-  const chatId = String(ctx.chat!.id)
-  const threadId = resolveThreadId(chatId, ctx.message?.message_thread_id)
-  spawnSwitchroomDetached(
-    ['update'],
-    notifyDetachedFailure(chatId, threadId ?? null, 'update (via deprecated /reconcile)'),
-  )
 })
 
 // /grant <tool> [agent] — add a tool permission and reconcile.

--- a/tests/scaffold.test.ts
+++ b/tests/scaffold.test.ts
@@ -2595,26 +2595,9 @@ describe("scheduled task cron script generation", () => {
     expect(content).toContain("HEARTBEAT_OK");
   });
 
-  it("suppress_stdout field is accepted (now a no-op — all crons use MCP path)", () => {
-    const agentConfig = makeAgentConfig({
-      schedule: [
-        // suppress_stdout is now ignored; MCP path is always used
-        { cron: "0 7 * * *", prompt: "mcp-only", suppress_stdout: true },
-      ],
-    });
-    const result = scaffoldAgent("mcp-cron", agentConfig, tmpDir, telegramConfig);
-    const content = readFileSync(
-      join(result.agentDir, "telegram", "cron-0.sh"),
-      "utf-8",
-    );
-    expect(content).toContain("exec claude -p");
-    expect(content).not.toContain("api.telegram.org");
-    expect(content).not.toContain("OUTPUT=");
-  });
-
-  it("reconcile regenerates cron scripts when suppress_stdout is removed", () => {
-    // Both with and without suppress_stdout now produce the same MCP-path
-    // script. If the prompt is the same, reconcile should detect no diff.
+  it("reconcile regenerates cron scripts when prompt content changes", () => {
+    // Sanity check that the MCP-path cron script is what we expect, and
+    // that prompt edits propagate through reconcile to the .sh file.
     const baseAgent = makeAgentConfig({
       schedule: [{ cron: "0 6 * * *", prompt: "test" }],
     });


### PR DESCRIPTION
## Summary

Three deprecated paths whose "kept for one release" window has fully elapsed. Current tag is **v0.4.0**; v0.3.0 has shipped since each of these landed. Comments in the source explicitly state "kept for one release" — that release has come and gone.

**113 deletions / 21 insertions** across 7 files.

## What's removed

### 1. CLI verbs: `upgrade`, `rebuild`, `reconcile`

- `src/cli/index.ts` — the `for (const oldVerb of ["upgrade", "rebuild", "reconcile"]) { ... }` deprecation shim. Added 2026-04-25 in PR #65 (commit `f46f364`) when the CLI surface was collapsed to `update / restart / version`. Two releases later (v0.3.0, v0.4.0), time to drop it.
- The now-unused `execFileSync` import is also removed.

### 2. Telegram `/reconcile` command

- `telegram-plugin/server.ts` — `bot.command('reconcile', …)` + comment.
- `telegram-plugin/gateway/gateway.ts` — same parallel implementation.

Both labeled \`Kept for one release with a deprecation notice\`. Same age cohort as the CLI aliases. Users who type `/reconcile` from now on will get Telegraf's default "command not found" — which is the right signal: use `/update`.

Stale comment references to `/reconcile` were also updated:

- `server.ts:2538` — sweepActivePins docstring (`/restart, /reconcile --restart, and /update` → `/restart and /update`)
- `server.ts:3704` — `spawnSwitchroomDetached` header (same)
- `server.ts:3729` — bug-note about `SWITCHROOM_AGENT_NAME` (same)
- `server.ts:3817` — `sweepPinsBeforeSelfRestart` docstring (same)
- `gateway.ts:4139` — `stampRestartReason` callsite list (`/restart, /reconcile, /new, /reset` → `/restart, /new, /reset`)

The literal token "reconcile" still appears elsewhere in source — those are genuine internal *operations* ("reconcile the agent's config files"), not the removed command.

### 3. `suppress_stdout` cron config field

- `src/config/schema.ts` — DEPRECATED per #269. Already documented as removed in `docs/scheduling.md:41`. Removing the schema entry brings code in line with docs.
- Existing yaml configs that still set the field will have the property silently stripped by Zod's default `.strip()` semantics — **no parse error, no runtime break**.
- `tests/scaffold.test.ts` — the test that explicitly verified the field was accepted-as-no-op is gone; the adjacent reconcile-regenerates test was retitled (its body never used `suppress_stdout`).
- `src/vault/broker/acl.test.ts` — fixture had `suppress_stdout: false`; removed.

## Deliberately out of scope

The audit also flagged `migrateLegacyIfNeeded` in `src/auth/accounts.ts` for removal. On closer inspection it's actively called from seven sites in `src/auth/manager.ts` as defensive auth-init — every auth operation re-runs it idempotently. Removing it needs its own deprecation cycle and isn't in this PR.

## Verification

| Step | Result |
|---|---|
| `npm run lint` (`tsc --noEmit`) | clean |
| `npm run build` (288 modules, 1.56 MB) | clean |
| `npm run test:vitest` | **4,274 pass / 0 fail / 7 skipped** (213 files) |
| `npm run test:bun` | **429 pass / 0 fail / 2 skipped** (29 files) |

## Suggested release note

> The CLI verbs `switchroom upgrade`, `switchroom rebuild`, and `switchroom reconcile` (deprecated since v0.3.0) have been removed. Use `switchroom update` instead. The Telegram `/reconcile` command is also removed; use `/update`. The `suppress_stdout` cron schema field (deprecated and ignored since #269) has been dropped; existing configs that still set it parse cleanly with the field silently stripped.