### PR TITLE
feat(gateway): batch 2-10 photos into sendMediaGroup album (#273)

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -1955,19 +1955,42 @@ async function executeReply(args: Record<string, unknown>): Promise<{ content: A
     stopTypingLoop(chat_id)
   }
 
-  for (const f of files) {
-    const ext = extname(f).toLowerCase()
-    const input = new InputFile(f)
+  // #273: when files is 2-10 photos, batch them into a single
+  // sendMediaGroup album rather than N separate sendPhoto calls. The
+  // user's device fires one notification for the album instead of N
+  // (notification-budget protection per the issue's JTBD note). Falls
+  // back to the per-file path for any non-all-photo set.
+  const allPhotos = files.length >= 2 && files.length <= 10
+    && files.every((f) => PHOTO_EXTS.has(extname(f).toLowerCase()))
+  if (allPhotos) {
     const baseOpts = {
       ...(reply_to != null && replyMode !== 'off' ? { reply_parameters: { message_id: reply_to } } : {}),
       ...(threadId != null ? { message_thread_id: threadId } : {}),
     }
-    if (PHOTO_EXTS.has(ext)) {
-      const sent = await robustApiCall(() => lockedBot.api.sendPhoto(chat_id, input, baseOpts), { threadId, chat_id })
-      sentIds.push(sent.message_id)
-    } else {
-      const sent = await robustApiCall(() => lockedBot.api.sendDocument(chat_id, input, baseOpts), { threadId, chat_id })
-      sentIds.push(sent.message_id)
+    const media = files.map((f) => ({
+      type: 'photo' as const,
+      media: new InputFile(f),
+    }))
+    const sent = await robustApiCall(
+      () => lockedBot.api.sendMediaGroup(chat_id, media, baseOpts),
+      { threadId, chat_id },
+    )
+    for (const m of sent) sentIds.push(m.message_id)
+  } else {
+    for (const f of files) {
+      const ext = extname(f).toLowerCase()
+      const input = new InputFile(f)
+      const baseOpts = {
+        ...(reply_to != null && replyMode !== 'off' ? { reply_parameters: { message_id: reply_to } } : {}),
+        ...(threadId != null ? { message_thread_id: threadId } : {}),
+      }
+      if (PHOTO_EXTS.has(ext)) {
+        const sent = await robustApiCall(() => lockedBot.api.sendPhoto(chat_id, input, baseOpts), { threadId, chat_id })
+        sentIds.push(sent.message_id)
+      } else {
+        const sent = await robustApiCall(() => lockedBot.api.sendDocument(chat_id, input, baseOpts), { threadId, chat_id })
+        sentIds.push(sent.message_id)
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

Closes the sendMediaGroup half of #273. When the agent attaches 2-10 photo files to a `reply`, the gateway was sending them as N separate `sendPhoto` calls — N notification pings on the user's device, each as its own bubble. With `sendMediaGroup`, the whole set renders as a single album with one notification (notification-budget protection per the JTBD note in #273).

## Scope

Only triggers when **all** files are photos AND the count is 2-10 (Telegram's media-group constraint). Mixed types or single-file replies keep the existing per-file path. Captions aren't promoted into the album yet — text chunks continue to send as their own messages, matching existing behavior.

Other media-group variants (video albums, document groups, audio groups) are out of scope:
- Each needs its own classification + grouping branch
- Photo bursts are the dominant use case in agent replies
- Mixed photo+video albums are technically allowed by Telegram but require separate handling for video extension detection

## Items in #273 still open after this lands

- Granular `sendChatAction` (`upload_document` / `record_voice` etc.) — lower value than the typing default; defer

Items already shipped (validated this session): `protect_content`, `quote_text`, `setMyCommands`, `disable_web_page_preview`.

## Test plan
- [x] `npm run lint` clean
- [x] `bun test` 2865/2866 pass (1 pre-existing skip)
- [ ] CI green
- [ ] Manual smoke: agent attaches 3+ photos, single album bubble appears with one notification