### PR TITLE
ci(buildkite): add Python unittest step for Hindsight scripts (#472 #15)

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -221,6 +221,27 @@ steps:
         - exit_status: 143
           limit: 2
 
+  - label: ":snake: Python tests (Hindsight scripts)"
+    key: tests-python
+    timeout_in_minutes: 5
+    # Closes #472 finding #15 — pre-fix the 80+ Python tests under
+    # vendor/hindsight-memory/scripts/tests/ only ran on dev machines.
+    # Every Python test added by #468/#469/#470 (recall integration,
+    # gateway IPC, directives) was on the honor system. python3 is on
+    # the hosted-agent image by default; no install step needed.
+    if_changed:
+      - "vendor/hindsight-memory/scripts/**"
+      - ".buildkite/pipeline.yml"
+    command: |
+      cd vendor/hindsight-memory/scripts
+      python3 -m unittest discover tests/
+    retry:
+      automatic:
+        - exit_status: -1
+          limit: 2
+        - exit_status: 143
+          limit: 2
+
   - label: ":telegram: Plugin tests (402)"
     key: tests-plugin
     timeout_in_minutes: 8


### PR DESCRIPTION
## Summary

Closes hot-path finding #15 from the 2026-05-01 forensic review (#472).

**80+ Python tests** under \`vendor/hindsight-memory/scripts/tests/\` (recall integration, gateway IPC, directives) **only ran on dev machines**. Every Python test added by #468/#469/#470 was on the honor system — a regression in any of them slips through Buildkite as silently as the class of bugs that motivated #424's silent-failure epic.

This single trivial pipeline addition unblocks confidence in the entire Python test surface added by recent PRs.

## Approach

Mirrors the plugin-tests step shape:
- Gated on \`vendor/hindsight-memory/scripts/**\` changes (keeps unrelated CI cheap)
- No install step (python3 is on the hosted-agent image)
- 5-minute timeout (suite finishes in ~25ms locally)

## Verified locally

\`\`\`
$ cd vendor/hindsight-memory/scripts && python3 -m unittest discover tests/
................................................................................
----------------------------------------------------------------------
Ran 80 tests in 0.023s

OK
\`\`\`

## Test plan
- [ ] CI green — including the new \`tests-python\` step