### PR TITLE
sec(topic-manager): redact bot token in network-error messages (#472 #12)

### DIFF
--- a/src/setup/telegram-api.ts
+++ b/src/setup/telegram-api.ts
@@ -2,17 +2,7 @@
  * Telegram Bot API helpers for the setup wizard.
  */
 
-/**
- * Telegram's Bot API requires the token as a URL path segment. If the
- * underlying fetch error ever includes the request URL — or if a caller
- * ever stringifies a Response object that preserves `.url` — the token
- * would leak to whatever log sink consumes the error. This helper scrubs
- * the literal token from a string before it escapes to the caller.
- */
-function redactToken(message: string, token: string): string {
-  if (!token || token.length < 8) return message;
-  return message.split(token).join("<redacted-bot-token>");
-}
+import { redactToken } from "../telegram/redact-token.js";
 
 export interface BotInfo {
   id: number;

--- a/src/telegram/redact-token.test.ts
+++ b/src/telegram/redact-token.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { redactToken } from "./redact-token.js";
+
+describe("redactToken", () => {
+  it("replaces every occurrence of the token with the placeholder", () => {
+    const token = "1234567890:ABCDEFghijklmnopqrstuvwxyz_-12345";
+    const msg = `Network error: failed to fetch https://api.telegram.org/bot${token}/createForumTopic`;
+    const out = redactToken(msg, token);
+    expect(out).not.toContain(token);
+    expect(out).toContain("<redacted-bot-token>");
+  });
+
+  it("redacts multiple occurrences in the same message", () => {
+    const token = "tok-abcdefgh-12345678";
+    const msg = `${token} happened, then ${token} again`;
+    expect(redactToken(msg, token)).toBe("<redacted-bot-token> happened, then <redacted-bot-token> again");
+  });
+
+  it("returns the message unchanged when token is empty", () => {
+    expect(redactToken("hello", "")).toBe("hello");
+  });
+
+  it("returns the message unchanged when token is implausibly short", () => {
+    // Avoid over-redacting innocuous strings like "1" or short fingerprints.
+    expect(redactToken("the value 1234 is here", "1234")).toBe("the value 1234 is here");
+  });
+
+  it("handles tokens that contain regex metacharacters safely", () => {
+    // Uses split/join so regex metacharacters are treated literally — no
+    // need for the caller to escape the token.
+    const token = "weird.token+with*meta?chars";
+    const msg = `error fetching with ${token} happened`;
+    expect(redactToken(msg, token)).toBe("error fetching with <redacted-bot-token> happened");
+  });
+});

--- a/src/telegram/redact-token.ts
+++ b/src/telegram/redact-token.ts
@@ -1,0 +1,30 @@
+/**
+ * Shared bot-token redaction helper.
+ *
+ * Telegram's Bot API requires the token as a URL path segment
+ * (`https://api.telegram.org/bot<TOKEN>/...`). Any error path that
+ * stringifies the request URL — node fetch DNS failures, `Response.url`
+ * preserved across error boundaries, an SDK that captures `req.url`
+ * into its error message — leaks the token to whatever log sink
+ * consumes the error.
+ *
+ * Use this helper at every API-call boundary that catches errors and
+ * surfaces them outward. Keep the redaction string identical across
+ * call sites so log scrapers can grep for the marker.
+ *
+ * Closes #472 finding #12 (topic-manager.ts errors leaking the token);
+ * this module also de-duplicates the previously-private helper in
+ * src/setup/telegram-api.ts so adding the next call site is mechanical.
+ */
+
+const REDACTED_PLACEHOLDER = "<redacted-bot-token>";
+
+/**
+ * Replace every literal occurrence of `token` in `message` with the
+ * standard placeholder. No-ops when token is empty or implausibly short
+ * (avoids over-redacting innocuous strings like "1" or fingerprints).
+ */
+export function redactToken(message: string, token: string): string {
+  if (!token || token.length < 8) return message;
+  return message.split(token).join(REDACTED_PLACEHOLDER);
+}

--- a/src/telegram/topic-manager.ts
+++ b/src/telegram/topic-manager.ts
@@ -1,5 +1,6 @@
 import type { SwitchroomConfig } from "../config/schema.js";
 import { loadTopicState, saveTopicState, type TopicState, type TopicEntry } from "./state.js";
+import { redactToken } from "./redact-token.js";
 
 export interface TopicSyncResult {
   agent: string;
@@ -80,8 +81,11 @@ async function createForumTopic(
       body: JSON.stringify(body),
     });
   } catch (err) {
+    // Closes #472 finding #12 — node fetch errors can include the request
+    // URL (DNS, ECONNREFUSED, TLS), which carries the bot token as a
+    // path segment. Redact before the message escapes to operator logs.
     throw new TopicSyncError(
-      `Network error calling Telegram API: ${(err as Error).message}`
+      redactToken(`Network error calling Telegram API: ${(err as Error).message}`, botToken)
     );
   }
 


### PR DESCRIPTION
## Summary

Closes hot-path finding #12 from the 2026-05-01 forensic review (#472).

\`src/telegram/topic-manager.ts\` logs Telegram-API fetch errors that include the bot token as a URL path segment when the underlying error preserves the request URL (DNS failures, ECONNREFUSED, TLS errors). \`src/setup/telegram-api.ts\` already had a private \`redactToken\` helper for exactly this — \`topic-manager.ts\` didn't.

## Approach

Extract the helper to \`src/telegram/redact-token.ts\` so both callers share one definition + the next API-call site is mechanical to wire. Apply at the \`createForumTopic\` network-error site (the only path in topic-manager that embeds the URL in the surfaced message — \`closeForumTopic\` catches silently and surfaces nothing).

## Why split into a module

- One redaction string across all sites means log scrapers can grep for \`<redacted-bot-token>\` reliably.
- Adding the next API call site (e.g. delete-topic, archive-topic if/when supported) becomes \`import + wrap\` rather than copy-paste-or-forget.

## Test plan
- [x] \`npm run lint\` clean
- [x] 5 new tests in \`redact-token.test.ts\` (multi-occurrence, regex-meta safety, empty-token, short-token, basic case)
- [x] Existing 20 \`topic-manager.test.ts\` tests still pass
- [ ] CI green