### PR TITLE
fix(gateway): drop setImmediate around recordTurn DB writes (#472 #11)

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -2592,22 +2592,26 @@ function handleSessionEvent(ev: SessionEvent): void {
           currentTurnRegistryKey = turnKey
           // Phase 1 of #332: capture first ~200 chars of the user's message.
           const userPromptPreview = extractUserPromptPreview(ev.rawContent)
-          // Non-blocking: defer the DB write so it doesn't stall the turn handler.
-          // The SIGTERM path writes synchronously (see shutdown handler below).
-          const _db = turnsDb
-          setImmediate(() => {
-            try {
-              recordTurnStart(_db, {
-                turnKey,
-                chatId: String(ev.chatId),
-                threadId: ev.threadId != null ? String(ev.threadId) : null,
-                lastUserMsgId: ev.messageId != null ? String(ev.messageId) : null,
-                userPromptPreview,
-              })
-            } catch (err) {
-              process.stderr.write(`telegram gateway: recordTurnStart failed turnKey=${turnKey}: ${(err as Error).message}\n`)
-            }
-          })
+          // Closes #472 finding #11. Pre-fix: this write was scheduled
+          // via setImmediate to "avoid stalling the turn handler" — but
+          // SQLite local writes are sub-millisecond, and the deferral
+          // opened a SIGTERM race window: a kill landing in the gap
+          // between scheduling and firing left a turn with no start
+          // row, invisible to the resume protocol (the user sent a
+          // message, the gateway lost it, no SWITCHROOM_PENDING_TURN
+          // env on next boot). Sibling writeTurnActiveMarker has always
+          // been synchronous here; this matches it.
+          try {
+            recordTurnStart(turnsDb, {
+              turnKey,
+              chatId: String(ev.chatId),
+              threadId: ev.threadId != null ? String(ev.threadId) : null,
+              lastUserMsgId: ev.messageId != null ? String(ev.messageId) : null,
+              userPromptPreview,
+            })
+          } catch (err) {
+            process.stderr.write(`telegram gateway: recordTurnStart failed turnKey=${turnKey}: ${(err as Error).message}\n`)
+          }
           // #412: turn-active marker for the bridge-watchdog. File exists
           // for the duration of the in-flight turn; mtime advances on
           // every tool_use; deleted on turn_complete. The watchdog
@@ -3067,25 +3071,25 @@ function handleSessionEvent(ev: SessionEvent): void {
         const assistantReplyPreview = capturedJoined
           ? capturedJoined.slice(0, TURN_PREVIEW_MAX)
           : null
-        // Non-blocking: defer the DB write so it doesn't stall the turn handler.
-        // The SIGTERM path writes synchronously (see shutdown handler below).
-        const _db = turnsDb
+        // Closes #472 finding #11 — same SIGTERM race as recordTurnStart
+        // above. Sub-ms SQLite write; the setImmediate deferral wasn't
+        // saving anything observable but was opening a window where a
+        // SIGTERM between turn_end and the microtask losing the end row
+        // (turn appears in DB as still-running, then 3c relabels it as
+        // 'sigterm' on shutdown — false negative for clean completion).
         const _turnKey = currentTurnRegistryKey
-        const _endArgs = {
-          turnKey: _turnKey,
-          endedVia: 'stop' as const,
-          lastAssistantMsgId: currentTurnLastAssistantMsgId,
-          lastAssistantDone: currentTurnLastAssistantDone,
-          assistantReplyPreview,
-          toolCallCount: currentTurnToolCallCount,
+        try {
+          recordTurnEnd(turnsDb, {
+            turnKey: _turnKey,
+            endedVia: 'stop' as const,
+            lastAssistantMsgId: currentTurnLastAssistantMsgId,
+            lastAssistantDone: currentTurnLastAssistantDone,
+            assistantReplyPreview,
+            toolCallCount: currentTurnToolCallCount,
+          })
+        } catch (err) {
+          process.stderr.write(`telegram gateway: recordTurnEnd(stop) failed turnKey=${_turnKey}: ${(err as Error).message}\n`)
         }
-        setImmediate(() => {
-          try {
-            recordTurnEnd(_db, _endArgs)
-          } catch (err) {
-            process.stderr.write(`telegram gateway: recordTurnEnd(stop) failed turnKey=${_turnKey}: ${(err as Error).message}\n`)
-          }
-        })
       }
       currentTurnRegistryKey = null
       currentSessionChatId = null


### PR DESCRIPTION
## Summary

Closes hot-path finding #11 from the 2026-05-01 forensic review (#472).

\`recordTurnStart\` and \`recordTurnEnd\` were both scheduled via \`setImmediate\` to \"avoid stalling the turn handler\" — but SQLite local writes are sub-millisecond, and the deferral opened a SIGTERM race window:

- **\`recordTurnStart\`:** SIGTERM landing in the gap between scheduling and firing left a turn with no start row, invisible to the resume protocol. The user sent a message, the gateway lost it, no \`SWITCHROOM_PENDING_TURN\` env on next boot.
- **\`recordTurnEnd(stop)\`:** same gap left a clean turn-end without a row. Stage 3c then relabels the still-running entry as \`endedVia='sigterm'\` during shutdown — false negative for clean completion in registry analytics.

## Approach

Make both writes synchronous. Sibling \`writeTurnActiveMarker\` has always been synchronous in the same code path, so this just matches the existing posture rather than introducing a new latency cost.

## Test plan
- [x] \`npm run lint\` clean
- [x] \`bun test\` 2868/2869 pass (1 pre-existing skip)
- [ ] CI green