### PR TITLE
fix(gateway): checklist-task notify fail-CLOSED on empty allowlist (#472 #13)

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -6979,7 +6979,14 @@ function handleChecklistUpdate(
     const access = loadAccess()
 
     // Only notify if this chat is allowlisted — same guard as inbound user messages.
-    if (!access.allowFrom.includes(chat_id) && access.allowFrom.length > 0) return
+    // Closes #472 finding #13. Pre-fix the `&& access.allowFrom.length > 0`
+    // tail made this fail-OPEN when the allowlist was empty: every chat's
+    // checklist tasks would forward to the agent. Sibling guards (the
+    // inbound-message gate at line ~588 and the operator-event broadcast
+    // at line ~1221) are both fail-closed for empty allowlists. The
+    // empty-allowlist case is the most likely state for a misconfiguration
+    // (e.g. /unpair just ran), so fail-OPEN is the worst default.
+    if (!access.allowFrom.includes(chat_id)) return
 
     const message_id = String(msg.message_id)
     const ts = msg.date ?? Math.floor(Date.now() / 1000)


### PR DESCRIPTION
## Summary

Closes hot-path finding #13 from the 2026-05-01 forensic review (#472).

The checklist-task-changed handler had a fail-OPEN guard:

\`\`\`ts
if (!access.allowFrom.includes(chat_id) && access.allowFrom.length > 0) return
\`\`\`

When \`access.allowFrom\` was empty (the most likely state for a misconfiguration — e.g. \`/unpair\` just ran, fresh agent), the length-check short-circuited and every checklist tick from any chat forwarded to the agent. Sibling guards in the same gateway are all fail-**CLOSED** on empty:

- inbound-message gate at ~L588: bare \`.includes()\` check, empty = drop
- operator-event broadcast at ~L1221: explicit empty-list early return, \"no allowlist (recorded only)\"

Drop the length tail so checklist updates match. **Empty allowlist now means \"nobody is allowed\"**, consistent with the rest of the codebase.

## Why this matters

Empty-allowFrom is the dominant misconfiguration path. Every other inbound surface in the gateway treats it as no-one-allowed; only this one treated it as everyone-allowed. A user who unpaired their bot and forgot to re-pair would silently leak every checklist interaction from any chat to their agent until they noticed.

## Test plan
- [x] \`npm run lint\` clean
- [x] \`bun test\` 2868/2869 pass (1 pre-existing skip)
- [ ] CI green