### PR TITLE
fix(heartbeat): dedup ticks that produce identical text

### DIFF
--- a/telegram-plugin/placeholder-heartbeat.ts
+++ b/telegram-plugin/placeholder-heartbeat.ts
@@ -152,6 +152,10 @@ export function startHeartbeat(
 
   let timer: ReturnType<typeof setTimeout> | null = null
   let cancelled = false
+  // Dedup state — last text we actually emitted to sendMessageDraft.
+  // null on first tick; subsequent ticks compare composed text against
+  // this and skip the API call when unchanged. See dedup branch below.
+  let lastEmittedText: string | null = null
 
   const tick = (): void => {
     if (cancelled) return
@@ -179,6 +183,28 @@ export function startHeartbeat(
 
     const label = getCurrentLabel(chatId)
     const text = composeHeartbeatText(label, elapsedMs)
+
+    // Dedup: skip the API call when the new text equals the last
+    // emitted text for this heartbeat. Defends against operator
+    // intervals that don't align with formatElapsed precision tiers
+    // (e.g. 2s ticks land 2-3× in the same 5s bucket and produce
+    // the same text). Telegram would respond "message not modified"
+    // which is wasted bandwidth + log noise. Stays correct under §4
+    // enrichment because label changes produce different text.
+    if (text === lastEmittedText) {
+      log?.(`telegram gateway: heartbeat tick chatId=${chatId} text="${text}" (deduped — no edit)`)
+      if (!cancelled) {
+        timer = setTimeout(tick, intervalMs)
+      }
+      return
+    }
+
+    lastEmittedText = text
+
+    // Diagnostic: log every tick so operators can confirm the
+    // heartbeat is firing without resorting to inspecting Telegram.
+    // Cheap (one stderr line per ~5s per active chat).
+    log?.(`telegram gateway: heartbeat tick chatId=${chatId} text="${text}"`)
 
     // Fire-and-forget. Errors (rate limit, deleted message, etc.)
     // are swallowed by design — next tick will either succeed or

--- a/telegram-plugin/tests/placeholder-heartbeat.test.ts
+++ b/telegram-plugin/tests/placeholder-heartbeat.test.ts
@@ -297,4 +297,65 @@ describe('startHeartbeat — §3 lifecycle (with fake timers)', () => {
     expect(DEFAULT_MAX_DURATION_MS).toBe(5 * 60 * 1000)
     expect(DEFAULT_HEARTBEAT_LABEL).toBe('🔵 thinking')
   })
+
+  describe('dedup — skip edit when text unchanged', () => {
+    it('dedups when 2s interval lands multiple ticks in the same 5s formatElapsed bucket', () => {
+      // Live-traffic finding: at intervalMs=2000, formatElapsed's 5s
+      // precision in the 10-59s window means consecutive ticks
+      // produce identical text ("· 10s", "· 10s", "· 15s"). Without
+      // dedup these become wasted Telegram editMessageText calls
+      // returning "message not modified". Pin the dedup so an operator
+      // tuning the interval doesn't rediscover the issue.
+      const { calls, deps } = makeDeps({ intervalMs: 2000 })
+      startHeartbeat('123', 99, Date.now(), deps)
+
+      vi.advanceTimersByTime(20000)
+      // Ticks fire at: 2s, 4s, 6s, 8s, 10s, 12s, 14s, 16s, 18s, 20s
+      // formatElapsed produces:
+      //   2s, 4s, 6s, 8s, 10s, 10s (12s rounds to 10), 15s, 15s, 20s, 20s
+      // Distinct: 2s, 4s, 6s, 8s, 10s, 15s, 20s = 7 unique texts
+      // Without dedup: 10 sendMessageDraft calls
+      // With dedup: 7 sendMessageDraft calls
+      expect(calls.length).toBe(7)
+      const texts = calls.map((c) => c.text)
+      expect(texts).toEqual([
+        `${DEFAULT_HEARTBEAT_LABEL} · 2s`,
+        `${DEFAULT_HEARTBEAT_LABEL} · 4s`,
+        `${DEFAULT_HEARTBEAT_LABEL} · 6s`,
+        `${DEFAULT_HEARTBEAT_LABEL} · 8s`,
+        `${DEFAULT_HEARTBEAT_LABEL} · 10s`,
+        `${DEFAULT_HEARTBEAT_LABEL} · 15s`,
+        `${DEFAULT_HEARTBEAT_LABEL} · 20s`,
+      ])
+    })
+
+    it('does NOT dedup when label changes mid-bucket (forward-compat with §4 enrichment)', () => {
+      // §4 enrichment: recall.py / session-tail change the label
+      // mid-tick. Even if the elapsed bucket is the same, a label
+      // change MUST emit because the visible text differs.
+      let currentLabel: string | null = null
+      const { calls, deps } = makeDeps({
+        intervalMs: 2000,
+        getCurrentLabel: vi.fn(() => currentLabel),
+      })
+      startHeartbeat('123', 99, Date.now(), deps)
+
+      vi.advanceTimersByTime(2000)
+      expect(calls[0]!.text).toBe(`${DEFAULT_HEARTBEAT_LABEL} · 2s`)
+
+      // Label changes — same bucket would normally dedup, but the
+      // text actually differs because of the new label.
+      currentLabel = '📚 recalling memories'
+      vi.advanceTimersByTime(2000)
+      expect(calls[1]!.text).toBe('📚 recalling memories · 4s')
+      expect(calls.length).toBe(2)
+    })
+
+    it('first tick always emits (no prior text to compare against)', () => {
+      const { calls, deps } = makeDeps({ intervalMs: 5000 })
+      startHeartbeat('123', 99, Date.now(), deps)
+      vi.advanceTimersByTime(5000)
+      expect(calls.length).toBe(1)
+    })
+  })
 })


### PR DESCRIPTION
## Summary

Small follow-up to PR #514. Live testing at \`intervalMs=2000\` revealed that ~30% of heartbeat ticks produced identical text to the previous one (because \`formatElapsed\`'s 5s precision in the 10-59s window doesn't align with 2s ticks). Each duplicate is a wasted \`sendMessageDraft\` call returning \"message not modified.\"

At the default 5s interval this can't happen, but operators tuning the interval shouldn't have to know about the precision-tier alignment. Dedup makes it self-healing.

## Fix

Track \`lastEmittedText\` per heartbeat. Skip the API call when the composed text equals the previous emit. Tick still schedules; just no wasted edit. Diagnostic log shows \`(deduped — no edit)\` so operators can see it firing.

Forward-compat with §4 enrichment: when label changes mid-bucket (recall.py / session-tail change the label even though the elapsed bucket is the same), the text differs and dedup correctly fires the edit.

## Tests (3 new)

- 2s interval over 20s simulated time: 10 raw ticks → 7 unique texts → 7 actual API calls
- Label change mid-bucket emits even when bucket unchanged (§4 forward-compat)
- First tick always emits (no prior text)

## Verification

\`\`\`
$ npm run lint        # clean
$ cd telegram-plugin && bun test
…
 2917 pass / 0 fail across 149 files
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)