### PR TITLE
fix(subagent-registry): reaper for stuck-running rows (#522)

### DIFF
--- a/telegram-plugin/registry/subagents-schema.ts
+++ b/telegram-plugin/registry/subagents-schema.ts
@@ -125,11 +125,38 @@ export interface RecordSubagentEndArgs {
 export interface RecordSubagentStallArgs {
   id: string
   stalledAt: number
+  /**
+   * Optional human-readable reason written to `result_summary`. Used by the
+   * reaper to record WHY a row was stalled out (e.g. "reaped: stuck in
+   * running for 47h with no jsonl linkage"). Omitted for the watcher's
+   * normal stall-detection path so existing callers are unchanged.
+   */
+  reason?: string
 }
 
 export interface BumpSubagentActivityArgs {
   id: string
   ts: number
+}
+
+export interface ReapStuckRunningArgs {
+  /**
+   * Maximum age (ms since `last_activity_at`, or since `started_at` for rows
+   * that never had liveness writes) before a `running` background row is
+   * considered orphaned. Default 1h is enough that a real long-running
+   * sub-agent isn't false-positived but a watcher-missed row is caught
+   * within a window the operator notices.
+   */
+  ttlMs: number
+  /** Current time (DI for tests). */
+  now: number
+}
+
+export interface ReapStuckRunningResult {
+  /** How many rows were transitioned. */
+  reaped: number
+  /** Tool-use ids of rows that were reaped — for logging / tests. */
+  ids: string[]
 }
 
 // ---------------------------------------------------------------------------
@@ -361,12 +388,74 @@ export function recordSubagentEnd(db: SqliteDatabase, args: RecordSubagentEndArg
  */
 export function recordSubagentStall(db: SqliteDatabase, args: RecordSubagentStallArgs): void {
   void args.stalledAt // available for callers that want to log it; not stored (no ended_at)
+  // When `reason` is supplied, write it to result_summary so a later
+  // operator (or `switchroom debug` output) can see why the row was
+  // stalled — distinguishes "JSONL idle past stall threshold" from
+  // "reaped because no jsonl linkage was ever established."
+  // result_summary is preserved (COALESCE) for callers without a reason.
+  if (args.reason !== undefined) {
+    db.prepare(`
+      UPDATE subagents
+      SET status         = 'stalled',
+          result_summary = ?
+      WHERE id = ?
+        AND status NOT IN ('completed', 'failed')
+    `).run(args.reason, args.id)
+    return
+  }
   db.prepare(`
     UPDATE subagents
     SET status = 'stalled'
     WHERE id = ?
       AND status NOT IN ('completed', 'failed')
   `).run(args.id)
+}
+
+/**
+ * Reap any background subagent row that's been stuck in `status='running'`
+ * past `ttlMs` of inactivity. Transitions to `status='stalled'` with a
+ * result_summary recording the reason — same terminal-ish state as a normal
+ * stall (resumable if activity returns, but the row no longer counts as
+ * an in-flight worker for fleet-status purposes).
+ *
+ * Rationale: the watcher's `sub_agent_turn_end` handler and `checkStalls`
+ * both update rows by `jsonl_agent_id`. Rows whose JSONL was never linked
+ * (backfill failed — meta.json missing, descriptor mismatch, etc.) are
+ * invisible to both paths and stay in `running` indefinitely. The reaper
+ * is the unconditional safety net.
+ *
+ * Activity test:
+ *   - prefer `last_activity_at` (set by Phase 3 liveness writes)
+ *   - fall back to `started_at` (the row was inserted but no JSONL ever
+ *     bumped activity — strong signal the linkage never happened)
+ *
+ * Foreground rows are excluded — their lifecycle goes through PostToolUse
+ * which writes `completed` directly; if those are stuck it's a different
+ * bug than the JSONL-linkage gap this reaper addresses.
+ */
+export function reapStuckRunningRows(
+  db: SqliteDatabase,
+  args: ReapStuckRunningArgs,
+): ReapStuckRunningResult {
+  const cutoff = args.now - args.ttlMs
+  const candidates = db
+    .prepare(`
+      SELECT id FROM subagents
+      WHERE status = 'running'
+        AND background = 1
+        AND COALESCE(last_activity_at, started_at) < ?
+    `)
+    .all(cutoff) as Array<{ id: string }>
+
+  for (const row of candidates) {
+    recordSubagentStall(db, {
+      id: row.id,
+      stalledAt: args.now,
+      reason: `reaped: stuck in running past ${Math.round(args.ttlMs / 60_000)}min ttl (jsonl linkage likely missing)`,
+    })
+  }
+
+  return { reaped: candidates.length, ids: candidates.map((r) => r.id) }
 }
 
 /**

--- a/telegram-plugin/registry/subagents.test.ts
+++ b/telegram-plugin/registry/subagents.test.ts
@@ -26,6 +26,7 @@ import {
   recordSubagentStall,
   bumpSubagentActivity,
   getSubagent,
+  reapStuckRunningRows,
 } from './subagents-schema.js'
 
 // ---------------------------------------------------------------------------
@@ -371,5 +372,105 @@ describe('bumpSubagentActivity', () => {
     const row = getSubagent(db, 'sa-mono')
     expect(row!.last_activity_at).toBe(4000)
     db.close()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// recordSubagentStall — reason field (issue #522)
+// ---------------------------------------------------------------------------
+
+describe('recordSubagentStall — reason field', () => {
+  it('writes reason into result_summary when supplied', () => {
+    const db = openFreshSubagentsDbInMemory()
+    recordSubagentStart(db, { id: 'sa-r1', background: true, startedAt: 1000 })
+    recordSubagentStall(db, { id: 'sa-r1', stalledAt: 2000, reason: 'reaped: test reason' })
+    const row = getSubagent(db, 'sa-r1')
+    expect(row!.status).toBe('stalled')
+    expect(row!.result_summary).toBe('reaped: test reason')
+    db.close()
+  })
+
+  it('preserves existing result_summary when reason is omitted (existing callers unchanged)', () => {
+    const db = openFreshSubagentsDbInMemory()
+    recordSubagentStart(db, { id: 'sa-r2', background: true, startedAt: 1000 })
+    // Simulate a prior write that set result_summary directly via SQL.
+    db.prepare('UPDATE subagents SET result_summary = ? WHERE id = ?').run('prior summary', 'sa-r2')
+    recordSubagentStall(db, { id: 'sa-r2', stalledAt: 2000 })
+    const row = getSubagent(db, 'sa-r2')
+    expect(row!.status).toBe('stalled')
+    expect(row!.result_summary).toBe('prior summary')
+    db.close()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// reapStuckRunningRows (issue #522)
+// ---------------------------------------------------------------------------
+
+describe('reapStuckRunningRows', () => {
+  it('reaps a background row whose last_activity_at is past ttl', () => {
+    const db = openFreshSubagentsDbInMemory()
+    recordSubagentStart(db, { id: 'sa-stuck', background: true, startedAt: 1000 })
+    bumpSubagentActivity(db, { id: 'sa-stuck', ts: 1500 })
+    const result = reapStuckRunningRows(db, { ttlMs: 500, now: 5000 })
+    expect(result.reaped).toBe(1)
+    expect(result.ids).toEqual(['sa-stuck'])
+    const row = getSubagent(db, 'sa-stuck')
+    expect(row!.status).toBe('stalled')
+    expect(row!.result_summary).toMatch(/reaped: stuck in running/)
+  })
+
+  it('reaps rows that never had a liveness bump after start (still on initial last_activity_at)', () => {
+    // Production failure mode: backfill never linked the JSONL so liveness
+    // writes never fired. recordSubagentStart seeds last_activity_at=started_at,
+    // so the reaper compares COALESCE(last_activity_at, started_at) — same
+    // outcome whether or not bumpSubagentActivity ever ran.
+    const db = openFreshSubagentsDbInMemory()
+    recordSubagentStart(db, { id: 'sa-noactivity', background: true, startedAt: 1000 })
+    const row0 = getSubagent(db, 'sa-noactivity')
+    expect(row0!.last_activity_at).toBe(1000)
+    const result = reapStuckRunningRows(db, { ttlMs: 500, now: 5000 })
+    expect(result.reaped).toBe(1)
+    const row = getSubagent(db, 'sa-noactivity')
+    expect(row!.status).toBe('stalled')
+  })
+
+  it('does not reap rows still within ttl', () => {
+    const db = openFreshSubagentsDbInMemory()
+    recordSubagentStart(db, { id: 'sa-fresh', background: true, startedAt: 4000 })
+    bumpSubagentActivity(db, { id: 'sa-fresh', ts: 4500 })
+    const result = reapStuckRunningRows(db, { ttlMs: 1000, now: 5000 })
+    expect(result.reaped).toBe(0)
+    const row = getSubagent(db, 'sa-fresh')
+    expect(row!.status).toBe('running')
+  })
+
+  it('does not reap foreground rows (not the JSONL-linkage failure mode)', () => {
+    const db = openFreshSubagentsDbInMemory()
+    recordSubagentStart(db, { id: 'sa-fg', background: false, startedAt: 1000 })
+    const result = reapStuckRunningRows(db, { ttlMs: 100, now: 5000 })
+    expect(result.reaped).toBe(0)
+    const row = getSubagent(db, 'sa-fg')
+    expect(row!.status).toBe('running')
+  })
+
+  it('does not re-reap rows already in terminal status (idempotent)', () => {
+    const db = openFreshSubagentsDbInMemory()
+    recordSubagentStart(db, { id: 'sa-done', background: true, startedAt: 1000 })
+    recordSubagentEnd(db, { id: 'sa-done', endedAt: 2000, status: 'completed' })
+    const result = reapStuckRunningRows(db, { ttlMs: 100, now: 9000 })
+    expect(result.reaped).toBe(0)
+    const row = getSubagent(db, 'sa-done')
+    expect(row!.status).toBe('completed')
+  })
+
+  it('handles many stuck rows in one pass', () => {
+    const db = openFreshSubagentsDbInMemory()
+    for (let i = 0; i < 5; i++) {
+      recordSubagentStart(db, { id: `sa-${i}`, background: true, startedAt: 1000 + i })
+    }
+    const result = reapStuckRunningRows(db, { ttlMs: 100, now: 9999 })
+    expect(result.reaped).toBe(5)
+    expect(result.ids.sort()).toEqual(['sa-0', 'sa-1', 'sa-2', 'sa-3', 'sa-4'])
   })
 })

--- a/telegram-plugin/subagent-watcher.ts
+++ b/telegram-plugin/subagent-watcher.ts
@@ -42,7 +42,7 @@ import { basename, join } from 'path'
 import { homedir } from 'os'
 import { projectSubagentLine } from './session-tail.js'
 import { escapeHtml, truncate } from './card-format.js'
-import { bumpSubagentActivity, recordSubagentStall, recordSubagentEnd } from './registry/subagents-schema.js'
+import { bumpSubagentActivity, recordSubagentStall, recordSubagentEnd, reapStuckRunningRows } from './registry/subagents-schema.js'
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -109,6 +109,22 @@ export interface SubagentWatcherConfig {
    */
   stallThresholdMs?: number
   /**
+   * Reaper TTL (ms): background rows in `status='running'` whose
+   * `last_activity_at` (or `started_at` if liveness never wrote) is older
+   * than this are transitioned to `status='stalled'` with a result_summary
+   * explaining the reap. Default 1h. The reaper exists because the normal
+   * stall + completion paths both look up rows by `jsonl_agent_id`; if
+   * backfill never linked the JSONL to the row, neither path can update
+   * it and it sits in `running` forever (issue #522).
+   */
+  reaperTtlMs?: number
+  /**
+   * How often to run the reaper (ms). Default 15 minutes. Also runs once
+   * synchronously at watcher startup to catch rows left over from a
+   * previous gateway process.
+   */
+  reaperIntervalMs?: number
+  /**
    * Optional registry DB for Phase 3 liveness writes. When provided, the
    * watcher calls `bumpSubagentActivity` each time a sub-agent JSONL grows
    * (i.e. mtime advances). If the matching row does not yet exist (Phase 2
@@ -161,6 +177,8 @@ export interface SubagentWatcherHandle {
 
 const DEFAULT_RESCAN_MS = 1000
 const DEFAULT_STALL_THRESHOLD_MS = 60_000
+const DEFAULT_REAPER_TTL_MS = 60 * 60_000          // 1 hour
+const DEFAULT_REAPER_INTERVAL_MS = 15 * 60_000     // 15 minutes
 /**
  * Grace period between a sub-agent transitioning to terminal state
  * (`done` / `failed`) and the watcher closing its FSWatcher + dropping
@@ -366,6 +384,8 @@ function readSubTail(
 export function startSubagentWatcher(config: SubagentWatcherConfig): SubagentWatcherHandle {
   const agentDir = config.agentDir
   const stallThresholdMs = config.stallThresholdMs ?? DEFAULT_STALL_THRESHOLD_MS
+  const reaperTtlMs = config.reaperTtlMs ?? DEFAULT_REAPER_TTL_MS
+  const reaperIntervalMs = config.reaperIntervalMs ?? DEFAULT_REAPER_INTERVAL_MS
   const rescanMs = config.rescanMs ?? DEFAULT_RESCAN_MS
   const log = config.log
   const db = config.db ?? null
@@ -736,12 +756,37 @@ export function startSubagentWatcher(config: SubagentWatcherConfig): SubagentWat
   rescanSubagentDirs()
   bootScanInProgress = false
 
+  // ─── Reaper for stuck-running rows (issue #522) ─────────────────────────
+  // Background subagents whose JSONL was never linked to their registry row
+  // (backfill failed) are invisible to the normal stall + completion paths,
+  // both of which look up rows by `jsonl_agent_id`. Without this reaper they
+  // sit in `status='running'` forever. Run once at startup to clean up rows
+  // left by a previous gateway, then on a periodic timer.
+  function runReaper(): void {
+    if (db == null) return
+    try {
+      const result = reapStuckRunningRows(db, { ttlMs: reaperTtlMs, now: nowFn() })
+      if (result.reaped > 0) {
+        log?.(`subagent-watcher: reaper transitioned ${result.reaped} stuck-running row(s) to stalled (ttl=${Math.round(reaperTtlMs / 60_000)}min)`)
+      }
+    } catch (err) {
+      log?.(`subagent-watcher: reaper error: ${(err as Error).message}`)
+    }
+  }
+  runReaper()
+
+  // Register the poll interval BEFORE the reaper interval. Existing tests'
+  // harness `poll()` helper grabs `intervals[0]` and fires it, treating the
+  // first-registered interval as the poll loop. Keep the reaper second to
+  // preserve that contract.
   const pollHandle = setI(poll, rescanMs)
+  const reaperHandle = setI(runReaper, reaperIntervalMs)
 
   return {
     stop(): void {
       stopped = true
       clearI(pollHandle)
+      clearI(reaperHandle)
       // Cancel any pending deferred-cleanup timers — the unconditional
       // close loop below covers their work and we don't want straggler
       // setTimeout callbacks firing after the watcher is supposedly stopped.


### PR DESCRIPTION
## Summary

Background subagents whose JSONL was never linked to their registry row sit in `status='running'` indefinitely. Both terminal paths in `telegram-plugin/subagent-watcher.ts` look up rows by `jsonl_agent_id`; rows with NULL `jsonl_agent_id` are invisible to both.

Production data at issue-file time: 7 stuck rows on clerk + klanker, oldest 57h old.

## Fix

- `registry/subagents-schema.ts`:
  - `recordSubagentStall` gains an optional `reason` field → written to `result_summary` so the operator can tell a reaped row apart from a normal idle-stall. Existing callers unchanged.
  - New `reapStuckRunningRows(db, { ttlMs, now })` transitions all `running` background rows whose activity is older than `ttlMs` to `stalled`, with an explanatory result_summary. Foreground rows excluded.
- `subagent-watcher.ts`: new `reaperTtlMs` (1h) + `reaperIntervalMs` (15min) config; reaper runs once at startup (catches rows from previous process) + on the periodic timer.

## Tests

- 7 new tests under `registry/subagents.test.ts`:
  - `recordSubagentStall — reason field` (×2): writes reason; preserves existing summary on no-reason.
  - `reapStuckRunningRows` (×5): stuck row reaped, no-liveness row reaped via started_at fallback, fresh row not reaped, foreground excluded, terminal-status idempotent, batch reap.
- All 19 pre-existing watcher tests still pass.

## Verification

| Step | Result |
|---|---|
| `npm run lint` | clean |
| `npm run test:vitest` | **4,326 pass / 0 fail / 7 skipped** (221 files) |
| `npm run test:bun` | **437 pass / 0 fail / 2 skipped** (29 files) |

## Production effect

After this lands and the gateway restarts, the synchronous startup reaper will sweep the 7 currently-stuck rows on clerk + klanker. No data loss — the rows get a clear `result_summary` explaining the reap.

Closes #522