### PR TITLE
fix(vault-broker): actionable enable-auto-unlock errors on systemd <256

### DIFF
--- a/src/cli/vault-broker.ts
+++ b/src/cli/vault-broker.ts
@@ -332,6 +332,36 @@ export function registerVaultBrokerCommand(vaultCmd: Command, program: Command):
       const credPath = getAutoUnlockCredPath(parentOpts.config);
       const vaultPath = getVaultPath(parentOpts.config);
 
+      // Pre-flight: on systemd <256, encrypt-as-user uses the host credential
+      // keystore at /var/lib/systemd/credential.secret. On fresh Ubuntu 24.04
+      // boxes that file doesn't exist yet (lazily created, only by root), so
+      // we'd otherwise fail late with an opaque "Permission denied". Surface
+      // the fix up front — before prompting for a passphrase we can't use.
+      const HOST_SECRET = "/var/lib/systemd/credential.secret";
+      if (!systemdCredsSupportsUser && !existsSync(HOST_SECRET)) {
+        console.error(
+          "systemd-creds cannot encrypt as your user on this system.\n" +
+          "\n" +
+          "  Cause: systemd <256 (e.g. Ubuntu 24.04 ships 255) lacks --user\n" +
+          `  support, and ${HOST_SECRET}\n` +
+          "  doesn't exist yet — only root can create it.\n" +
+          "\n" +
+          "  Fix (one-time, with sudo):\n" +
+          `    sudo systemd-creds encrypt --name=vault-passphrase - ${credPath}\n` +
+          "    # paste the vault passphrase, then Ctrl-D\n" +
+          `    sudo chown $USER:$USER ${credPath}\n` +
+          `    chmod 600 ${credPath}\n` +
+          "\n" +
+          "  Then continue with:\n" +
+          "    1. Set vault.broker.autoUnlock: true in switchroom.yaml\n" +
+          "    2. switchroom reconcile\n" +
+          "    3. systemctl --user restart switchroom-vault-broker.service\n" +
+          "\n" +
+          "  Or upgrade to systemd >=256 for native --user support.",
+        );
+        process.exit(1);
+      }
+
       // Prompt + verify BEFORE writing anything. We must not encrypt a typo.
       let passphrase: string;
       try {
@@ -368,7 +398,18 @@ export function registerVaultBrokerCommand(vaultCmd: Command, program: Command):
             stdio: ["pipe", "inherit", "inherit"],
           });
         } catch (err) {
-          console.error(`systemd-creds encrypt failed: ${err instanceof Error ? err.message : String(err)}`);
+          const msg = err instanceof Error ? err.message : String(err);
+          console.error(`systemd-creds encrypt failed: ${msg}`);
+          if (!systemdCredsSupportsUser) {
+            console.error(
+              "\n" +
+              "  On systemd <256 this can also fail when the host credential\n" +
+              "  keystore exists but isn't readable by your user. Try the sudo\n" +
+              "  workaround:\n" +
+              `    sudo systemd-creds encrypt --name=vault-passphrase - ${credPath}\n` +
+              `    sudo chown $USER:$USER ${credPath} && chmod 600 ${credPath}`,
+            );
+          }
           process.exit(1);
         }
       } finally {


### PR DESCRIPTION
## Summary

`switchroom vault broker enable-auto-unlock` on Ubuntu 24.04 (systemd 255) fails with an opaque message:

> Failed to determine local credential host secret: Permission denied
> systemd-creds encrypt failed: Command failed: systemd-creds encrypt --name=vault-passphrase --quiet - /home/USER/.config/credstore.encrypted/vault-passphrase

The user is left to puzzle out that `/var/lib/systemd/credential.secret` doesn't exist yet on their box, that only root can create it, and what command to run to recover. That's exactly the anti-pattern principle 1 of the design contract calls out: *"error message that says `AUTH_401`"* with no next step.

## What changed

Two fixes, both in `src/cli/vault-broker.ts`:

1. **Pre-flight check.** On systemd <256, stat `/var/lib/systemd/credential.secret` *before* prompting for a passphrase. If absent, abort with the exact `sudo systemd-creds encrypt … && sudo chown … && chmod 600 …` workaround (with `credPath` interpolated) plus the existing 1/2/3 next steps. Don't waste a passphrase entry on a doomed run.
2. **Catch-and-augment on encrypt failure.** When `systemd-creds encrypt` still errors on <256 (e.g. host secret exists but isn't readable by the invoking user), append the same workaround instead of just printing the raw stderr.

## Repro (before this PR)

On Ubuntu 24.04, fresh user, no `/var/lib/systemd/credential.secret`:

```
$ switchroom vault broker enable-auto-unlock
Vault passphrase:
Failed to determine local credential host secret: Permission denied
systemd-creds encrypt failed: Command failed: systemd-creds encrypt --name=vault-passphrase --quiet - /home/USER/.config/credstore.encrypted/vault-passphrase
```

## After this PR

```
$ switchroom vault broker enable-auto-unlock
systemd-creds cannot encrypt as your user on this system.

  Cause: systemd <256 (e.g. Ubuntu 24.04 ships 255) lacks --user
  support, and /var/lib/systemd/credential.secret
  doesn't exist yet — only root can create it.

  Fix (one-time, with sudo):
    sudo systemd-creds encrypt --name=vault-passphrase - /home/USER/.config/credstore.encrypted/vault-passphrase
    # paste the vault passphrase, then Ctrl-D
    sudo chown $USER:$USER /home/USER/.config/credstore.encrypted/vault-passphrase
    chmod 600 /home/USER/.config/credstore.encrypted/vault-passphrase

  Then continue with:
    1. Set vault.broker.autoUnlock: true in switchroom.yaml
    2. switchroom reconcile
    3. systemctl --user restart switchroom-vault-broker.service

  Or upgrade to systemd >=256 for native --user support.
```

The user passes through `enable-auto-unlock` once on a new install; the guidance has to land on first failure or it doesn't land at all.

## Test plan

- [ ] `npm run lint` — clean.
- [ ] `npx vitest run src/agents/systemd-broker-unit.test.ts` — passes (7 tests).
- [ ] On Ubuntu 24.04 with no `/var/lib/systemd/credential.secret`, run `switchroom vault broker enable-auto-unlock` and confirm the new pre-flight message appears before the passphrase prompt.
- [ ] Run the printed sudo workaround, then continue with reconcile + restart, and confirm auto-unlock works on next boot.
- [ ] On systemd ≥256 (or with a populated host secret), confirm the existing happy path is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)