### PR TITLE
feat(scaffold): role-gate switchroom-* skill auto-install (#235 follow-up)

### DIFF
--- a/docs/skills.md
+++ b/docs/skills.md
@@ -20,9 +20,23 @@ Different populations answer different questions:
 - "What does a *developer* working on switchroom need?" → bundled developer skills (read in dev contexts, not auto-injected into fleet agents)
 - "What does *this user's* fleet need beyond the defaults?" → user-managed personal skills
 
-## ⚠️ Known issue: `switchroom-*` skills auto-install into every agent
+## Foreman opt-in for bundled `switchroom-*` skills
 
-`installSwitchroomSkills()` blindly symlinks every `<repo>/skills/switchroom-*/` directory into every agent's `.claude/skills/`. The current set is:
+The 6 bundled `switchroom-*` operator skills are role-gated — only agents with `role: "foreman"` in their config get them auto-symlinked into `.claude/skills/`. Default `assistant` role (the implicit default for fleet agents) gets none of them.
+
+```yaml
+agents:
+  clerk:
+    topic_name: "General"
+    # role omitted → assistant → no operator skills auto-installed
+  foreman:
+    topic_name: "Fleet manager"
+    role: foreman   # → operator skills auto-installed
+```
+
+Reconcile honors role flips both ways: `assistant → foreman` installs the symlinks, `foreman → assistant` retracts them (only switchroom-installed symlinks; never real dirs the operator placed manually).
+
+The 6 bundled operator skills:
 
 - `switchroom-architecture` — explains how switchroom works internally
 - `switchroom-cli` — runs CLI operations
@@ -31,9 +45,7 @@ Different populations answer different questions:
 - `switchroom-manage` — manage the fleet
 - `switchroom-status` — show running agents
 
-These are operator/foreman skills — they make sense for an agent that *manages other agents* (e.g. a foreman bot, a developer agent) but not for a fleet agent like `clerk` doing user-facing tasks. A fleet agent never needs to call `switchroom-install` or `switchroom-manage`, so injecting them adds cognitive overhead per turn for no benefit.
-
-**Tracking issue:** the auto-install logic should be opt-in (e.g. via `agent.role: "foreman"` or `defaults.skills_auto: ["switchroom-*"]`). Until that lands, every fleet agent carries the operator skills as dead weight.
+A fleet agent like `clerk` doing user-facing tasks never needs to call `switchroom-install` or `switchroom-manage`, so the assistant default keeps their tool list focused. A foreman bot or developer agent (`role: foreman`) gets the operator surface for free.
 
 ## What gets bundled vs what doesn't
 
@@ -41,12 +53,12 @@ Current `<repo>/skills/` inventory:
 
 | Skill | Population | Notes |
 |---|---|---|
-| `switchroom-architecture` | fleet (auto) | Operator skill — see issue above |
-| `switchroom-cli` | fleet (auto) | Operator skill — see issue above |
-| `switchroom-health` | fleet (auto) | Operator skill — see issue above |
-| `switchroom-install` | fleet (auto) | Operator skill — see issue above |
-| `switchroom-manage` | fleet (auto) | Operator skill — see issue above |
-| `switchroom-status` | fleet (auto) | Operator skill — see issue above |
+| `switchroom-architecture` | foreman-only (auto when `role: foreman`) | Operator skill |
+| `switchroom-cli` | foreman-only (auto when `role: foreman`) | Operator skill |
+| `switchroom-health` | foreman-only (auto when `role: foreman`) | Operator skill |
+| `switchroom-install` | foreman-only (auto when `role: foreman`) | Operator skill |
+| `switchroom-manage` | foreman-only (auto when `role: foreman`) | Operator skill |
+| `switchroom-status` | foreman-only (auto when `role: foreman`) | Operator skill |
 | `humanizer` | developer (opt-in) | Strips AI-writing patterns from replies; opt in via `defaults.skills` |
 | `humanizer-calibrate` | developer (opt-in) | Builds a personal voice template; companion to `humanizer` |
 | `buildkite-*` (8 skills) | developer (opt-in) | Switchroom CI work; not for fleet agents |
@@ -87,9 +99,15 @@ For a switchroom-bundled developer skill (everyone working on switchroom benefit
 1. Create the skill directory at `<repo>/skills/<name>/SKILL.md`
 2. Open a PR
 
-For a switchroom-bundled fleet skill (auto-installed everywhere):
+For a switchroom-bundled foreman skill (auto-installed when `role: foreman`):
 
-1. **Don't.** Use the per-user model instead — auto-install for fleet agents is a known anti-pattern (see issue above) and adding more entries to it makes the problem worse. Open an issue to discuss before adding.
+1. Create the skill directory at `<repo>/skills/switchroom-<name>/SKILL.md`
+2. Document it in the table above
+3. Open a PR
+
+For a switchroom-bundled fleet-default skill (every agent regardless of role):
+
+1. **Don't auto-install.** Add it as a developer-pool skill instead and let operators opt in via `defaults.skills`. Auto-injecting into every agent's tool list adds cognitive overhead per turn for users who'll never call it. The `role: foreman` opt-in is the right escape hatch for the operator-skill case.
 
 ## Related code
 

--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -569,43 +569,82 @@ function syncGlobalSkills(
  * Symlink every switchroom-* skill from the switchroom project's built-in skills/
  * directory into <agentDir>/.claude/skills/<name>.
  *
- * This runs unconditionally on every scaffold/reconcile so all agents
- * automatically get the management skills (switchroom-cli, switchroom-health,
- * etc.) without needing to list them in switchroom.yaml.
+ * **Role gate (#235 follow-up).** Only `role: "foreman"` agents get
+ * the bundled operator skills. Default-role assistants are fleet
+ * agents doing user-facing tasks; loading switchroom-manage / install
+ * / health into their tool list adds cognitive overhead per turn for
+ * no benefit (they never call these skills). For non-foreman roles
+ * this function actively REMOVES any pre-existing operator skill
+ * symlinks (idempotent retraction) so a role flip foreman → assistant
+ * cleans up correctly on the next reconcile.
  *
  * Rules:
  *   - Only directories that start with "switchroom-" and contain a SKILL.md
- *     file are linked.
+ *     file are linked (when installing).
  *   - The destination .claude/skills/ directory is created if absent.
- *   - Existing entries at the destination are left untouched (idempotent).
+ *   - Existing entries at the destination are left untouched on install
+ *     (idempotent symlink refresh; pre-existing real dirs/files preserved).
+ *   - On retraction, only switchroom-installed symlinks are removed —
+ *     never real dirs/files (operator may have placed those manually).
  */
-export function installSwitchroomSkills(agentDir: string): void {
+export function installSwitchroomSkills(
+  agentDir: string,
+  opts: { role?: "assistant" | "foreman" } = {},
+): void {
   const builtinSkillsDir = resolve(import.meta.dirname, "../../skills");
   if (!existsSync(builtinSkillsDir)) return;
 
   const targetDir = join(agentDir, ".claude", "skills");
   mkdirSync(targetDir, { recursive: true });
 
+  // Discover the universe of switchroom-* skills upfront so the same
+  // list drives both install and retract paths.
   let entries: string[];
   try {
     entries = readdirSync(builtinSkillsDir);
   } catch {
     return;
   }
-
-  for (const name of entries) {
-    if (!name.startsWith("switchroom-")) continue;
+  const switchroomSkillNames = entries.filter((name) => {
+    if (!name.startsWith("switchroom-")) return false;
     const src = join(builtinSkillsDir, name);
-    // Only link directories that contain SKILL.md
-    let srcStat;
     try {
-      srcStat = lstatSync(src);
+      const st = lstatSync(src);
+      return st.isDirectory() && existsSync(join(src, "SKILL.md"));
     } catch {
-      continue;
+      return false;
     }
-    if (!srcStat.isDirectory()) continue;
-    if (!existsSync(join(src, "SKILL.md"))) continue;
+  });
 
+  // Role gate: only foreman agents get the operator skills auto-installed.
+  // For other roles, retract any pre-existing symlinks (idempotent).
+  if (opts.role !== "foreman") {
+    for (const name of switchroomSkillNames) {
+      const dest = join(targetDir, name);
+      let existing;
+      try {
+        existing = lstatSync(dest);
+      } catch {
+        continue; // nothing to retract
+      }
+      // Only remove symlinks we plausibly installed. Don't touch real
+      // dirs or files the operator placed there manually.
+      if (!existing.isSymbolicLink()) continue;
+      let currentTarget: string | null = null;
+      try {
+        currentTarget = readlinkSync(dest);
+      } catch { /* unreadable — assume foreign, leave alone */ }
+      if (currentTarget !== join(builtinSkillsDir, name)) continue;
+      try {
+        rmSync(dest, { force: true });
+      } catch { /* best effort */ }
+    }
+    return;
+  }
+
+  // Foreman path: install (or refresh stale) symlinks for each skill.
+  for (const name of switchroomSkillNames) {
+    const src = join(builtinSkillsDir, name);
     const dest = join(targetDir, name);
     // Idempotent: leave correctly-pointing symlinks and real dirs alone.
     // But refresh stale symlinks whose target is a different switchroom-
@@ -1878,7 +1917,10 @@ export function scaffoldAgent(
   }
 
   // --- Install built-in switchroom-* skills into .claude/skills/ ---
-  installSwitchroomSkills(agentDir);
+  // Role-gated (#235 follow-up): only foreman agents get the operator
+  // skills auto-symlinked. Default `assistant` role retracts any stale
+  // ones that may exist from before this gate landed.
+  installSwitchroomSkills(agentDir, { role: agentConfig.role });
 
   // --- Set up plugin symlinks ---
   setupPlugins(agentDir, usesSwitchroomTelegramPlugin(agentConfig));
@@ -2993,7 +3035,10 @@ Don't wait for a slash command. Don't ask permission. Memory work is table stake
   }
 
   // --- Install built-in switchroom-* skills into .claude/skills/ ---
-  installSwitchroomSkills(agentDir);
+  // Role-gated (#235 follow-up). Reconcile honors role flips both
+  // ways: assistant → foreman installs the symlinks; foreman →
+  // assistant retracts them.
+  installSwitchroomSkills(agentDir, { role: agentConfig.role });
 
   // --- Reconcile .mcp.json (switchroom-telegram plugin agents only) ---
   if (usesSwitchroomTelegramPlugin(agentConfig)) {

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -712,6 +712,17 @@ export const AgentSchema = z.object({
     .string()
     .optional()
     .describe("Emoji for the topic (e.g., '🏋️')"),
+  role: z
+    .enum(["assistant", "foreman"])
+    .optional()
+    .describe(
+      "Agent role. Default (omitted) is `assistant` — a fleet agent doing " +
+      "user-facing tasks. `foreman` opts the agent in to switchroom's bundled " +
+      "operator skills (switchroom-architecture / cli / health / install / manage " +
+      "/ status), auto-symlinked into the agent's .claude/skills/ on scaffold and " +
+      "reconcile. Fleet agents (assistant role) get no operator skills; reconcile " +
+      "actively retracts them if the role flips back. See docs/skills.md for the model.",
+    ),
   topic_id: z
     .number()
     .optional()

--- a/tests/scaffold.test.ts
+++ b/tests/scaffold.test.ts
@@ -3435,13 +3435,13 @@ describe("installSwitchroomSkills", () => {
     expect(existsSync(join(freshAgentDir, ".claude", "skills", "switchroom-manage"))).toBe(true);
   });
 
-  it("scaffoldAgent installs switchroom skills into .claude/skills/ automatically", () => {
+  it("scaffoldAgent installs switchroom skills when role: foreman (#235 follow-up)", () => {
     // The real installSwitchroomSkills resolves to the project's skills/ directory.
     // Verify that after scaffoldAgent the .claude/skills directory exists and
-    // contains at least one switchroom-* symlink (assuming the real skills/ is present).
+    // contains at least one switchroom-* symlink for foreman-role agents.
     const result = scaffoldAgent(
-      "auto-skills-agent",
-      makeAgentConfig(),
+      "auto-skills-foreman",
+      makeAgentConfig({ role: "foreman" }),
       tmpDir,
       telegramConfig,
     );
@@ -3453,25 +3453,65 @@ describe("installSwitchroomSkills", () => {
     expect(switchroomEntries.length).toBeGreaterThan(0);
   });
 
-  it("reconcileAgent installs switchroom skills into .claude/skills/ automatically", () => {
-    const agentConfig = makeAgentConfig();
+  it("scaffoldAgent does NOT install switchroom skills for default-role assistant agents", () => {
+    // Role gate: assistant agents (the default) get no operator skills.
+    // The .claude/skills/ directory still gets created (other skill paths
+    // may use it), but no switchroom-* entries should land there.
+    const result = scaffoldAgent(
+      "auto-skills-assistant",
+      makeAgentConfig(),
+      tmpDir,
+      telegramConfig,
+    );
+    const claudeSkillsDir = join(result.agentDir, ".claude", "skills");
+    expect(existsSync(claudeSkillsDir)).toBe(true);
+    const entries = require("node:fs").readdirSync(claudeSkillsDir) as string[];
+    const switchroomEntries = entries.filter((e: string) => e.startsWith("switchroom-"));
+    expect(switchroomEntries).toEqual([]);
+  });
+
+  it("reconcileAgent installs switchroom skills when role: foreman", () => {
+    const agentConfig = makeAgentConfig({ role: "foreman" });
     const switchroomConfig: SwitchroomConfig = {
       switchroom: { version: 1, agents_dir: tmpDir },
       telegram: telegramConfig,
-      agents: { "rec-skills": agentConfig },
+      agents: { "rec-skills-foreman": agentConfig },
     } as SwitchroomConfig;
 
-    scaffoldAgent("rec-skills", agentConfig, tmpDir, telegramConfig, switchroomConfig);
+    scaffoldAgent("rec-skills-foreman", agentConfig, tmpDir, telegramConfig, switchroomConfig);
     // Remove .claude/skills to simulate a fresh state
-    rmSync(join(tmpDir, "rec-skills", ".claude", "skills"), { recursive: true, force: true });
+    rmSync(join(tmpDir, "rec-skills-foreman", ".claude", "skills"), { recursive: true, force: true });
 
-    reconcileAgent("rec-skills", agentConfig, tmpDir, telegramConfig, switchroomConfig);
+    reconcileAgent("rec-skills-foreman", agentConfig, tmpDir, telegramConfig, switchroomConfig);
 
-    const claudeSkillsDir = join(tmpDir, "rec-skills", ".claude", "skills");
+    const claudeSkillsDir = join(tmpDir, "rec-skills-foreman", ".claude", "skills");
     expect(existsSync(claudeSkillsDir)).toBe(true);
     const entries = require("node:fs").readdirSync(claudeSkillsDir) as string[];
     const switchroomEntries = entries.filter((e: string) => e.startsWith("switchroom-"));
     expect(switchroomEntries.length).toBeGreaterThan(0);
+  });
+
+  it("reconcileAgent retracts switchroom skills when role flips foreman → assistant", () => {
+    // Setup: scaffold as foreman, confirm operator skills present.
+    const foremanCfg = makeAgentConfig({ role: "foreman" });
+    const switchroomConfig: SwitchroomConfig = {
+      switchroom: { version: 1, agents_dir: tmpDir },
+      telegram: telegramConfig,
+      agents: { "role-flip": foremanCfg },
+    } as SwitchroomConfig;
+    scaffoldAgent("role-flip", foremanCfg, tmpDir, telegramConfig, switchroomConfig);
+    const claudeSkillsDir = join(tmpDir, "role-flip", ".claude", "skills");
+    let entries = require("node:fs").readdirSync(claudeSkillsDir) as string[];
+    expect(entries.filter((e: string) => e.startsWith("switchroom-")).length).toBeGreaterThan(0);
+
+    // Flip role to assistant and reconcile — operator skills should retract.
+    const assistantCfg = makeAgentConfig(); // role omitted = assistant default
+    reconcileAgent("role-flip", assistantCfg, tmpDir, telegramConfig, {
+      ...switchroomConfig,
+      agents: { "role-flip": assistantCfg },
+    } as SwitchroomConfig);
+    entries = require("node:fs").readdirSync(claudeSkillsDir) as string[];
+    expect(entries.filter((e: string) => e.startsWith("switchroom-"))).toEqual([]);
   });
 });
 


### PR DESCRIPTION
Switchroom's bundled \`switchroom-*\` operator skills (architecture / cli / health / install / manage / status) were auto-symlinked into **every** agent's \`.claude/skills/\` regardless of the agent's purpose. A fleet agent like \`clerk\` doing user-facing tasks never calls \`switchroom-install\` or \`switchroom-manage\`, but the skills still counted toward its tool list and added cognitive overhead per turn. This PR closes the anti-pattern flagged in \`docs/skills.md\` (PR #527).

## Behaviour change

| Agent role | Before | After |
|---|---|---|
| \`role\` omitted (default assistant) | All 6 switchroom-* skills auto-installed | None auto-installed (existing ones retracted on next reconcile) |
| \`role: \"assistant\"\` (explicit) | Same as above | Same as above |
| \`role: \"foreman\"\` | Same as above (no opt-in needed before this PR) | All 6 switchroom-* skills auto-installed (idempotent symlink refresh) |

Retraction is conservative: only symlinks pointing at the bundled skill source are removed. Real dirs the operator placed manually, or symlinks pointing elsewhere, are preserved.

## Migration

Existing fleet agents will lose their (unused) operator skill symlinks on the next \`switchroom agent reconcile <name>\`. **No behavioral change for them** — those symlinks weren't being called. A foreman bot operator who wants the skills back declares \`role: foreman\` in switchroom.yaml and reconciles.

## Files

| File | Change |
|---|---|
| \`src/config/schema.ts\` | New optional \`role: enum([\"assistant\", \"foreman\"])\` on \`AgentConfigSchema\`. Optional so existing yamls parse unchanged. |
| \`src/agents/scaffold.ts:installSwitchroomSkills\` | Accepts \`opts: { role? }\`. When role !== \"foreman\", retracts our symlinks instead of installing. Both call sites (scaffold + reconcile) pass \`agentConfig.role\`. |
| \`tests/scaffold.test.ts\` | Drops the 2 \"auto-installs everywhere\" assertions; adds 4 role-gated assertions: foreman installs, assistant doesn't install, reconcile-with-foreman installs, reconcile-with-assistant retracts after a foreman → assistant flip. |
| \`docs/skills.md\` | Drops the \"known anti-pattern\" warning section (this PR closes it); updates the inventory table; adds the foreman opt-in pattern to the \"adding a new skill\" guide. |

## Verification

- [x] \`npm run lint\` — clean
- [x] \`npm run build\` — clean
- [x] \`npm test\` — 4360 vitest + 429 bun pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)