### PR TITLE
feat(vault): auto-unlock end-to-end on Ubuntu 24.04+

### DIFF
--- a/src/build-info.ts
+++ b/src/build-info.ts
@@ -3,7 +3,7 @@
 // Values are refreshed every time `npm run build` runs.
 
 export const VERSION: string = "0.4.0";
-export const COMMIT_SHA: string | null = "f787921";
-export const COMMIT_DATE: string | null = "2026-05-01T16:00:01+10:00";
-export const LATEST_PR: number | null = 535;
-export const COMMITS_AHEAD_OF_TAG: number | null = 96;
+export const COMMIT_SHA: string | null = "174db61";
+export const COMMIT_DATE: string | null = "2026-05-01T16:34:14+10:00";
+export const LATEST_PR: number | null = 521;
+export const COMMITS_AHEAD_OF_TAG: number | null = 103;

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -8,7 +8,15 @@ import { scaffoldAgent } from "../agents/scaffold.js";
 import { installAllUnits, installForemanUnit } from "../agents/systemd.js";
 import { syncTopics } from "../telegram/topic-manager.js";
 import { loadTopicState } from "../telegram/state.js";
-import { createVault, setStringSecret } from "../vault/vault.js";
+import { createVault, openVault, setStringSecret } from "../vault/vault.js";
+import {
+  applyAutoUnlock,
+  detectSystemdCreds,
+  encryptCredential,
+  EncryptCancelledError,
+  EncryptFailedError,
+} from "./vault-auto-unlock.js";
+import { promptPassphrase } from "./vault-broker.js";
 import { getAuthStatus } from "../auth/manager.js";
 import {
   validateBotToken,
@@ -128,13 +136,16 @@ export function registerSetupCommand(program: Command): void {
           switchroomConfigPath,
         );
 
-        // ── Step 8: Dangerous mode ──────────────────────────────
+        // ── Step 8: Vault auto-unlock at boot ────────────────────
+        await stepAutoUnlock(config, switchroomConfigPath, nonInteractive);
+
+        // ── Step 9: Dangerous mode ──────────────────────────────
         await stepDangerousMode(config, nonInteractive);
 
-        // ── Step 9: Agent onboarding guidance ────────────────────
+        // ── Step 10: Agent onboarding guidance ───────────────────
         await stepOnboardingGuidance(config, nonInteractive);
 
-        // ── Step 10: Verification ────────────────────────────────
+        // ── Step 11: Verification ────────────────────────────────
         await stepVerification(config, nonInteractive);
 
         await captureEvent("setup_completed", {
@@ -886,13 +897,133 @@ async function stepScaffoldAgents(
   }
 }
 
-// ─── Step 8: Dangerous Mode ─────────────────────────────────────────────────
+// ─── Step 8: Vault Auto-Unlock ──────────────────────────────────────────────
+
+/**
+ * Offer to enable vault auto-unlock at boot. The "defaults test" in
+ * reference/principles.md says the product should work on a fresh setup
+ * with zero post-wizard config — and on Linux that means the vault
+ * should unlock itself after every reboot, with no terminal session
+ * required. We ask once here and run the same flow as
+ * `switchroom vault broker enable-auto-unlock --apply` inline.
+ *
+ * Skip silently when:
+ *   - non-interactive (CI / scripts shouldn't trigger sudo prompts)
+ *   - non-Linux (systemd-creds is Linux-only)
+ *   - systemd-creds binary is missing (older or stripped systemd)
+ *   - the vault doesn't exist yet (no broker to auto-unlock)
+ *   - auto-unlock is already configured AND the credential file is
+ *     already on disk (idempotency)
+ */
+async function stepAutoUnlock(
+  config: SwitchroomConfig,
+  switchroomConfigPath: string,
+  nonInteractive: boolean,
+): Promise<void> {
+  stepHeader(8, "Vault auto-unlock at boot", STEP_ACTIVE);
+
+  if (nonInteractive) {
+    console.log(chalk.gray("  Skipping in non-interactive mode."));
+    return;
+  }
+  if (process.platform !== "linux") {
+    console.log(chalk.gray("  Skipping (auto-unlock requires Linux + systemd-creds)."));
+    return;
+  }
+
+  const detection = detectSystemdCreds();
+  if (!detection) {
+    console.log(chalk.gray("  Skipping (systemd-creds not on PATH)."));
+    return;
+  }
+
+  const vaultPath = resolvePath(config.vault?.path ?? "~/.switchroom/vault.enc");
+  if (!existsSync(vaultPath)) {
+    console.log(chalk.gray("  Skipping (vault not created yet)."));
+    return;
+  }
+
+  const credPathRaw =
+    config.vault?.broker?.autoUnlockCredentialPath ??
+    "~/.config/credstore.encrypted/vault-passphrase";
+  const credPath = resolvePath(credPathRaw);
+  if (config.vault?.broker?.autoUnlock === true && existsSync(credPath)) {
+    console.log(chalk.green(`  ${STEP_DONE} Already configured (${credPath})`));
+    return;
+  }
+
+  console.log(chalk.gray("  Without this, vault must be unlocked manually after every reboot."));
+  const enable = await askYesNo("  Enable vault auto-unlock at boot?", true);
+  if (!enable) {
+    console.log(chalk.gray("  Skipped. Run later with: switchroom vault broker enable-auto-unlock"));
+    return;
+  }
+
+  // Re-prompt with masked input. The wizard uses plain `ask()` for the
+  // vault passphrase elsewhere, but we deliberately use the masked path
+  // here because we're handing the value to systemd-creds, not echoing
+  // it back to the user.
+  let passphrase: string;
+  try {
+    passphrase = await promptPassphrase();
+  } catch (err) {
+    console.log(chalk.yellow(`  Skipped: ${err instanceof Error ? err.message : String(err)}`));
+    return;
+  }
+
+  try {
+    try {
+      openVault(passphrase, vaultPath);
+    } catch (err) {
+      console.log(
+        chalk.yellow(
+          `  Skipped: passphrase verification failed (${err instanceof Error ? err.message : String(err)}).`,
+        ),
+      );
+      console.log(chalk.gray("  Run later with: switchroom vault broker enable-auto-unlock"));
+      return;
+    }
+
+    let scope: string;
+    try {
+      scope = await encryptCredential(passphrase, credPath, detection.supportsUser);
+    } catch (err) {
+      if (err instanceof EncryptCancelledError) {
+        console.log(chalk.gray("  Skipped (user declined sudo)."));
+        return;
+      }
+      if (err instanceof EncryptFailedError) {
+        console.log(chalk.yellow("  Could not encrypt credential. Continuing setup."));
+        console.log(chalk.gray("  Retry later with: switchroom vault broker enable-auto-unlock"));
+        return;
+      }
+      throw err;
+    }
+    console.log(chalk.green(`  ${STEP_DONE} Encrypted credential (scope: ${scope})`));
+  } finally {
+    passphrase = "";
+  }
+
+  try {
+    await applyAutoUnlock({ configPath: switchroomConfigPath });
+    console.log(chalk.green(`  ${STEP_DONE} Auto-unlock active`));
+  } catch (err) {
+    console.log(
+      chalk.yellow(
+        `  Credential is encrypted but apply step failed: ${err instanceof Error ? err.message : String(err)}`,
+      ),
+    );
+    console.log(chalk.gray("  Retry with: switchroom reconcile && systemctl --user restart switchroom-vault-broker.service"));
+  }
+}
+
+// ─── Step 9: Dangerous Mode ─────────────────────────────────────────────────
 
 async function stepDangerousMode(
   config: SwitchroomConfig,
   nonInteractive: boolean,
 ): Promise<void> {
-  stepHeader(8, "Auto-approve mode", STEP_ACTIVE);
+  stepHeader(9, "Auto-approve mode", STEP_ACTIVE);
 
   let enableDangerous = false;
 
@@ -950,13 +1081,13 @@ async function stepDangerousMode(
   }
 }
 
-// ─── Step 9: Agent Onboarding Guidance ───────────────────────────────────────
+// ─── Step 10: Agent Onboarding Guidance ──────────────────────────────────────
 
 async function stepOnboardingGuidance(
   config: SwitchroomConfig,
   nonInteractive: boolean,
 ): Promise<void> {
-  stepHeader(9, "Agent onboarding", STEP_ACTIVE);
+  stepHeader(10, "Agent onboarding", STEP_ACTIVE);
 
   const agentsDir = resolveAgentsDir(config);
   const agentNames = Object.keys(config.agents);
@@ -1011,13 +1142,13 @@ async function stepOnboardingGuidance(
   }
 }
 
-// ─── Step 9: Verification ────────────────────────────────────────────────────
+// ─── Step 11: Verification ───────────────────────────────────────────────────
 
 async function stepVerification(
   config: SwitchroomConfig,
   nonInteractive: boolean,
 ): Promise<void> {
-  stepHeader(10, "Verification", STEP_ACTIVE);
+  stepHeader(11, "Verification", STEP_ACTIVE);
 
   const agentNames = Object.keys(config.agents);
   const firstName = agentNames[0];

--- a/src/cli/vault-auto-unlock.ts
+++ b/src/cli/vault-auto-unlock.ts
@@ -1,0 +1,363 @@
+/**
+ * Vault auto-unlock setup — shared logic between `vault broker enable-auto-unlock`
+ * and the `switchroom setup` wizard.
+ *
+ * The job here is encrypting the vault passphrase via systemd-creds and writing
+ * it to a credential file the broker unit can `LoadCredentialEncrypted=` at boot.
+ *
+ * The hard part is that systemd-creds offers three encryption scopes — user,
+ * host, and root-via-sudo — and which one works depends on the systemd version,
+ * whether the user-scope varlink socket is up, whether the host keystore
+ * exists, and whether polkit is willing to authenticate the call. On a fresh
+ * Ubuntu 24.04+ box (systemd ≥256, no user-scope socket shipped, polkit gates
+ * the system socket for non-root callers) every unprivileged path fails; sudo
+ * is the only option. We detect that case from systemd-creds' own error
+ * classes (io.systemd.System / io.systemd.InteractiveAuthenticationRequired)
+ * and offer to escalate once, with a single confirmation prompt.
+ */
+
+import { execFileSync, spawnSync } from "node:child_process";
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname } from "node:path";
+import YAML from "yaml";
+
+import { findConfigFile, loadConfig, resolvePath } from "../config/loader.js";
+import { installAllUnits } from "../agents/systemd.js";
+import { statusViaBroker } from "../vault/broker/client.js";
+import { askYesNo } from "../setup/prompt.js";
+
+export const HOST_SECRET = "/var/lib/systemd/credential.secret";
+
+export type EncryptScope = "user" | "host" | "host-sudo";
+
+export type EncryptErrorClass =
+  | "polkit-required"
+  | "varlink-unreachable"
+  | "no-host-keystore"
+  | "other";
+
+export type EncryptOutcome =
+  | { ok: true; scope: EncryptScope }
+  | { ok: false; class: EncryptErrorClass; stderr: string };
+
+/**
+ * Map systemd-creds stderr output to an actionable error class. We branch on
+ * intent (is this polkit gating us? is the varlink socket missing?) rather
+ * than on environmental flags (does the host keystore file exist?) — the
+ * filesystem axis was a bad proxy that masked the real failure mode on
+ * Ubuntu 24.04+.
+ */
+export function classifyEncryptStderr(stderr: string): EncryptErrorClass {
+  if (/InteractiveAuthenticationRequired/i.test(stderr)) return "polkit-required";
+  if (/io\.systemd\.System(?!\w)/i.test(stderr)) return "varlink-unreachable";
+  if (/credential\.secret.*No such file|host key.*not.*found/i.test(stderr)) return "no-host-keystore";
+  return "other";
+}
+
+/**
+ * Detect whether `systemd-creds` is available and supports `--user`. The
+ * `--user` flag was added in systemd 256; earlier releases reject it as
+ * unrecognized. Returns null if the binary isn't on PATH.
+ */
+export function detectSystemdCreds(): { supportsUser: boolean } | null {
+  try {
+    const versionOut = execFileSync("systemd-creds", ["--version"], {
+      stdio: ["ignore", "pipe", "ignore"],
+      encoding: "utf8",
+    });
+    const m = versionOut.match(/systemd\s+(\d+)/);
+    return { supportsUser: m ? parseInt(m[1], 10) >= 256 : false };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Run a single systemd-creds encrypt invocation in the requested scope.
+ * Returns an outcome object instead of throwing — caller orchestrates the
+ * fall-through cascade.
+ *
+ * Passphrase is piped via stdin so it never appears in argv, environ, or
+ * any process listing. stderr is captured (not inherited) so we can
+ * classify the failure; stdout is empty on success because of --quiet.
+ */
+export function tryEncrypt(
+  scope: "user" | "host",
+  passphrase: string,
+  credPath: string,
+): EncryptOutcome {
+  const args = ["encrypt", "--name=vault-passphrase"];
+  if (scope === "user") args.push("--user");
+  args.push("--quiet", "-", credPath);
+
+  const result = spawnSync("systemd-creds", args, {
+    input: passphrase,
+    stdio: ["pipe", "ignore", "pipe"],
+    encoding: "utf8",
+  });
+
+  if (result.status === 0) {
+    return { ok: true, scope };
+  }
+  const stderr = (result.stderr ?? "") + (result.error ? `\n${result.error.message}` : "");
+  return { ok: false, class: classifyEncryptStderr(stderr), stderr };
+}
+
+/**
+ * Run sudo systemd-creds encrypt, then sudo chown the file back to the user.
+ * Passphrase via stdin (never argv). The chown converts a root-owned cred
+ * file (which broker user-units can't open) into a user-owned one with
+ * mode 0600 — same end-state as a successful unprivileged encrypt.
+ */
+export function runSudoEncrypt(
+  passphrase: string,
+  credPath: string,
+): { ok: true } | { ok: false; reason: string } {
+  // -p customizes the prompt so the user sees what they're authenticating for.
+  const encrypt = spawnSync(
+    "sudo",
+    [
+      "-p",
+      "[sudo] password to encrypt vault auto-unlock credential: ",
+      "systemd-creds",
+      "encrypt",
+      "--name=vault-passphrase",
+      "--quiet",
+      "-",
+      credPath,
+    ],
+    {
+      input: passphrase,
+      stdio: ["pipe", "inherit", "inherit"],
+    },
+  );
+
+  if (encrypt.status !== 0) {
+    return { ok: false, reason: `sudo systemd-creds encrypt exited ${encrypt.status}` };
+  }
+
+  const uid = process.getuid?.() ?? -1;
+  const gid = process.getgid?.() ?? -1;
+  if (uid < 0 || gid < 0) {
+    return { ok: false, reason: "could not determine current uid/gid for chown" };
+  }
+
+  // The first sudo above primed the cache; -n keeps this from re-prompting in
+  // the common case. Fall back to interactive sudo if the cache expired.
+  const owner = `${uid}:${gid}`;
+  let chown = spawnSync("sudo", ["-n", "chown", owner, credPath], { stdio: "pipe" });
+  if (chown.status !== 0) {
+    chown = spawnSync("sudo", ["chown", owner, credPath], { stdio: "inherit" });
+  }
+  if (chown.status !== 0) {
+    return { ok: false, reason: "sudo chown failed (credential is root-owned and unreadable by the broker)" };
+  }
+
+  try {
+    chmodSync(credPath, 0o600);
+  } catch {
+    // systemd-creds already restricts mode; chmod is belt-and-braces.
+  }
+
+  return { ok: true };
+}
+
+export interface EncryptOptions {
+  /** Skip the interactive sudo confirmation (used in tests and --yes flows). */
+  assumeYesSudo?: boolean;
+  /** Override TTY detection (used in tests). */
+  isTTY?: boolean;
+  /** Logger — defaults to console; tests inject a buffer. */
+  log?: (line: string) => void;
+  err?: (line: string) => void;
+}
+
+/**
+ * Encrypt the vault passphrase, walking the user → host → sudo cascade as
+ * needed. Returns the scope that succeeded so callers can describe what just
+ * happened. Throws `EncryptCancelledError` if the user declined sudo.
+ */
+export class EncryptCancelledError extends Error {
+  constructor(public credPath: string) {
+    super("auto-unlock encrypt cancelled by user");
+    this.name = "EncryptCancelledError";
+  }
+}
+
+export class EncryptFailedError extends Error {
+  constructor(public credPath: string, public detail: string) {
+    super(detail);
+    this.name = "EncryptFailedError";
+  }
+}
+
+export async function encryptCredential(
+  passphrase: string,
+  credPath: string,
+  systemdCredsSupportsUser: boolean,
+  opts: EncryptOptions = {},
+): Promise<EncryptScope> {
+  const log = opts.log ?? ((s: string) => console.log(s));
+  const err = opts.err ?? ((s: string) => console.error(s));
+  const isTTY = opts.isTTY ?? process.stdin.isTTY === true;
+
+  mkdirSync(dirname(credPath), { recursive: true, mode: 0o700 });
+
+  let lastFail: EncryptOutcome | null = null;
+
+  if (systemdCredsSupportsUser) {
+    const r = tryEncrypt("user", passphrase, credPath);
+    if (r.ok) return r.scope;
+    lastFail = r;
+  }
+
+  // Host-scope encrypt-as-user only works when the host keystore exists AND
+  // polkit allows the call. If the keystore is missing, skip straight to sudo
+  // — there's nothing to attempt.
+  if (existsSync(HOST_SECRET)) {
+    const r = tryEncrypt("host", passphrase, credPath);
+    if (r.ok) {
+      if (lastFail) {
+        log("  (--user encryption was unavailable; used host-scope instead)");
+      }
+      return r.scope;
+    }
+    lastFail = r;
+  }
+
+  // Both unprivileged paths exhausted. Decide whether to escalate.
+  if (!isTTY) {
+    err("systemd-creds encrypt failed and stdin is not a TTY; refusing to auto-escalate via sudo.");
+    if (lastFail) err(`  Last error: ${lastFail.stderr.trim().split("\n")[0]}`);
+    err("");
+    err("  Run interactively, or run this manually with sudo:");
+    err(`    sudo systemd-creds encrypt --name=vault-passphrase - ${credPath}`);
+    err(`    sudo chown $USER:$USER ${credPath} && chmod 600 ${credPath}`);
+    throw new EncryptFailedError(credPath, "non-tty: cannot auto-escalate");
+  }
+
+  log("");
+  log("Unprivileged systemd-creds encrypt was refused on this host:");
+  if (lastFail) {
+    const firstLine = lastFail.stderr.trim().split("\n")[0] || "(no detail)";
+    log(`  ${firstLine}`);
+  }
+  log("");
+  log("This is the default state of Ubuntu 24.04+ with systemd ≥256:");
+  log("  the system varlink socket is polkit-gated for non-root callers");
+  log("  and no user-scope socket ships out of the box. sudo bypasses both.");
+  log("");
+
+  const proceed = opts.assumeYesSudo ?? (await askYesNo("Encrypt with sudo (one-time prompt)?", true));
+  if (!proceed) {
+    err("Aborted. To finish manually:");
+    err(`  sudo systemd-creds encrypt --name=vault-passphrase - ${credPath}`);
+    err(`  sudo chown $USER:$USER ${credPath} && chmod 600 ${credPath}`);
+    throw new EncryptCancelledError(credPath);
+  }
+
+  const sudoResult = runSudoEncrypt(passphrase, credPath);
+  if (!sudoResult.ok) {
+    err(`sudo encrypt failed: ${sudoResult.reason}`);
+    throw new EncryptFailedError(credPath, sudoResult.reason);
+  }
+
+  return "host-sudo";
+}
+
+/**
+ * Set `vault.broker.autoUnlock: <value>` in the user's switchroom.yaml,
+ * preserving comments, key ordering, and surrounding formatting. Mirrors
+ * the YAML.parseDocument pattern used by `updateAgentExtendsInConfig` in
+ * src/cli/agent.ts.
+ *
+ * If the user's config has neither `vault:` nor `vault.broker:` blocks,
+ * we add them as plain maps. The cascade resolver in `src/config/merge.ts`
+ * fills in any other broker defaults at load time, so we don't need to
+ * write them here.
+ */
+export function setVaultBrokerAutoUnlock(configPath: string, value: boolean): void {
+  const raw = readFileSync(configPath, "utf-8");
+  const doc = YAML.parseDocument(raw);
+  doc.setIn(["vault", "broker", "autoUnlock"], value);
+  writeFileSync(configPath, doc.toString(), "utf-8");
+}
+
+export interface ApplyOptions {
+  configPath?: string;
+  log?: (line: string) => void;
+  err?: (line: string) => void;
+  /** Override systemctl invocation in tests. */
+  runSystemctl?: (args: string[]) => { status: number | null };
+  /** Override status polling in tests. */
+  pollStatus?: () => Promise<{ unlocked: boolean } | null>;
+  /** How long to wait for the broker to come up unlocked. */
+  verifyTimeoutMs?: number;
+}
+
+/**
+ * Flip vault.broker.autoUnlock=true in switchroom.yaml, regenerate units,
+ * restart the broker, and poll status to confirm the vault came up unlocked.
+ *
+ * The whole thing is one call so callers don't have to re-implement the
+ * 3-step "Next steps" list. If anything fails we throw with a clear message
+ * — the credential file is already on disk by this point so re-running is
+ * cheap.
+ */
+export async function applyAutoUnlock(opts: ApplyOptions = {}): Promise<void> {
+  const log = opts.log ?? ((s: string) => console.log(s));
+  const err = opts.err ?? ((s: string) => console.error(s));
+  const runSystemctl =
+    opts.runSystemctl ?? ((args: string[]) => spawnSync("systemctl", args, { stdio: "inherit" }));
+  const verifyTimeoutMs = opts.verifyTimeoutMs ?? 5000;
+
+  const configPath = opts.configPath ?? findConfigFile();
+  setVaultBrokerAutoUnlock(configPath, true);
+  log(`✓ Set vault.broker.autoUnlock=true in ${configPath}`);
+
+  // Reload the config from disk so we pass the freshly-flipped value into
+  // installAllUnits — otherwise the broker unit gets re-rendered without the
+  // LoadCredentialEncrypted= line.
+  const config = loadConfig(configPath);
+  installAllUnits(config);
+  log("✓ Reconciled broker unit");
+
+  runSystemctl(["--user", "daemon-reload"]);
+  const restart = runSystemctl(["--user", "restart", "switchroom-vault-broker.service"]);
+  if (restart.status !== 0) {
+    err(
+      "Broker restart failed. Check:\n" +
+        "  systemctl --user status switchroom-vault-broker.service\n" +
+        "  journalctl --user -u switchroom-vault-broker.service -e",
+    );
+    throw new Error(`broker restart exited ${restart.status}`);
+  }
+  log("✓ Restarted switchroom-vault-broker.service");
+
+  const socket = resolvePath(config.vault?.broker?.socket ?? "~/.switchroom/vault-broker.sock");
+  const poll = opts.pollStatus ?? (() => statusViaBroker({ socket }));
+
+  const deadline = Date.now() + verifyTimeoutMs;
+  while (Date.now() < deadline) {
+    const status = await poll();
+    if (status?.unlocked) {
+      log("✓ Vault unlocked via auto-unlock credential");
+      return;
+    }
+    await new Promise((r) => setTimeout(r, 250));
+  }
+
+  err(
+    "Broker restarted but vault did not unlock within " +
+      `${verifyTimeoutMs}ms. Check:\n` +
+      "  systemctl --user status switchroom-vault-broker.service\n" +
+      "  journalctl --user -u switchroom-vault-broker.service -e",
+  );
+  throw new Error("verification timeout: broker did not unlock");
+}

--- a/src/cli/vault-broker.ts
+++ b/src/cli/vault-broker.ts
@@ -15,10 +15,10 @@
  */
 
 import type { Command } from "commander";
-import { readFileSync, existsSync, mkdirSync, chmodSync, unlinkSync } from "node:fs";
-import { resolve, dirname } from "node:path";
+import { readFileSync, existsSync, unlinkSync } from "node:fs";
+import { resolve } from "node:path";
 import { homedir } from "node:os";
-import { spawn, execFileSync } from "node:child_process";
+import { spawn } from "node:child_process";
 import { loadConfig } from "../config/loader.js";
 import { resolvePath } from "../config/loader.js";
 import {
@@ -29,6 +29,13 @@ import {
 } from "../vault/broker/client.js";
 import { VaultBroker, registerShutdownHandlers } from "../vault/broker/server.js";
 import { openVault } from "../vault/vault.js";
+import {
+  applyAutoUnlock,
+  detectSystemdCreds,
+  encryptCredential,
+  EncryptCancelledError,
+  EncryptFailedError,
+} from "./vault-auto-unlock.js";
 
 const DEFAULT_PID_FILE = "~/.switchroom/vault-broker.pid";
 const DEFAULT_SOCKET_PATH = "~/.switchroom/vault-broker.sock";
@@ -308,17 +315,26 @@ export function registerVaultBrokerCommand(vaultCmd: Command, program: Command):
 
   // ── enable-auto-unlock ───────────────────────────────────────────────────
   // Encrypt the vault passphrase via systemd-creds and write it to the
-  // configured credential path. After this, the broker unit (re-rendered
-  // with vault.broker.autoUnlock=true) can declare LoadCredentialEncrypted=
-  // and systemd will inject the passphrase at start time without further
-  // user interaction. See issue #152 and README "Auto-unlock on boot".
+  // configured credential path, then flip vault.broker.autoUnlock=true,
+  // reconcile, and restart the broker. After this the broker unit declares
+  // LoadCredentialEncrypted= and systemd injects the passphrase at every
+  // boot — no user interaction required. See issue #152.
+  //
+  // The encryption cascade (user-scope → host-scope → sudo) is handled in
+  // ./vault-auto-unlock.ts so the same flow can run inside the setup wizard.
   broker
     .command("enable-auto-unlock")
     .description(
-      "Encrypt vault passphrase via systemd-creds and write to the credential path. " +
-      "After this, set vault.broker.autoUnlock=true and reconcile to take effect.",
+      "Set up vault auto-unlock at boot: encrypt the passphrase via systemd-creds, " +
+      "enable vault.broker.autoUnlock, and restart the broker.",
     )
-    .action(async () => {
+    .option(
+      "--no-apply",
+      "Stage the credential file only; don't flip vault.broker.autoUnlock or restart the broker.",
+    )
+    .action(async (opts: { apply?: boolean }) => {
+      // commander negates --no-apply by setting opts.apply=false; default true.
+      const apply = opts.apply !== false;
       const parentOpts = program.opts();
 
       if (process.platform !== "linux") {
@@ -326,21 +342,8 @@ export function registerVaultBrokerCommand(vaultCmd: Command, program: Command):
         process.exit(1);
       }
 
-      // Verify systemd-creds is on PATH and detect version. The --user flag
-      // was added in systemd 256; on older releases (e.g. Ubuntu 24.04 ships
-      // 255) we must omit it or the encrypt call fails with
-      // "unrecognized option '--user'".
-      let systemdCredsSupportsUser = false;
-      try {
-        const versionOut = execFileSync("systemd-creds", ["--version"], {
-          stdio: ["ignore", "pipe", "ignore"],
-          encoding: "utf8",
-        });
-        const m = versionOut.match(/systemd\s+(\d+)/);
-        if (m) {
-          systemdCredsSupportsUser = parseInt(m[1], 10) >= 256;
-        }
-      } catch {
+      const detection = detectSystemdCreds();
+      if (!detection) {
         console.error(
           "systemd-creds not found on PATH. Requires systemd >= 250. " +
           "Try: sudo apt install systemd",
@@ -351,36 +354,6 @@ export function registerVaultBrokerCommand(vaultCmd: Command, program: Command):
       const credPath = getAutoUnlockCredPath(parentOpts.config);
       const vaultPath = getVaultPath(parentOpts.config);
 
-      // Pre-flight: on systemd <256, encrypt-as-user uses the host credential
-      // keystore at /var/lib/systemd/credential.secret. On fresh Ubuntu 24.04
-      // boxes that file doesn't exist yet (lazily created, only by root), so
-      // we'd otherwise fail late with an opaque "Permission denied". Surface
-      // the fix up front — before prompting for a passphrase we can't use.
-      const HOST_SECRET = "/var/lib/systemd/credential.secret";
-      if (!systemdCredsSupportsUser && !existsSync(HOST_SECRET)) {
-        console.error(
-          "systemd-creds cannot encrypt as your user on this system.\n" +
-          "\n" +
-          "  Cause: systemd <256 (e.g. Ubuntu 24.04 ships 255) lacks --user\n" +
-          `  support, and ${HOST_SECRET}\n` +
-          "  doesn't exist yet — only root can create it.\n" +
-          "\n" +
-          "  Fix (one-time, with sudo):\n" +
-          `    sudo systemd-creds encrypt --name=vault-passphrase - ${credPath}\n` +
-          "    # paste the vault passphrase, then Ctrl-D\n" +
-          `    sudo chown $USER:$USER ${credPath}\n` +
-          `    chmod 600 ${credPath}\n` +
-          "\n" +
-          "  Then continue with:\n" +
-          "    1. Set vault.broker.autoUnlock: true in switchroom.yaml\n" +
-          "    2. switchroom reconcile\n" +
-          "    3. systemctl --user restart switchroom-vault-broker.service\n" +
-          "\n" +
-          "  Or upgrade to systemd >=256 for native --user support.",
-        );
-        process.exit(1);
-      }
-
       // Prompt + verify BEFORE writing anything. We must not encrypt a typo.
       let passphrase: string;
       try {
@@ -388,67 +361,53 @@ export function registerVaultBrokerCommand(vaultCmd: Command, program: Command):
       } catch (err) {
         console.error(err instanceof Error ? err.message : String(err));
         process.exit(1);
+        return; // unreachable; satisfies TS narrowing
       }
 
-      // Wrap the verify + encrypt block in try/finally so the passphrase
-      // variable is zeroed on every exit path — including openVault failure.
+      let scope: string;
       try {
         try {
           openVault(passphrase, vaultPath);
         } catch (err) {
-          console.error(`Passphrase verification failed: ${err instanceof Error ? err.message : String(err)}`);
+          console.error(
+            `Passphrase verification failed: ${err instanceof Error ? err.message : String(err)}`,
+          );
           process.exit(1);
         }
 
-        mkdirSync(dirname(credPath), { recursive: true, mode: 0o700 });
-
-        // systemd-creds encrypt --name=vault-passphrase [--user] --quiet - <credPath>
-        // Stdin: passphrase. Output: encrypted credential at credPath.
-        // The --name=vault-passphrase binding is required — systemd validates the
-        // embedded name matches the LoadCredentialEncrypted= id at decrypt time.
-        // --user is only added on systemd >= 256 (where the flag exists). On
-        // older systemd, host-scope encryption still decrypts inside user units.
         try {
-          const args = ["encrypt", "--name=vault-passphrase"];
-          if (systemdCredsSupportsUser) args.push("--user");
-          args.push("--quiet", "-", credPath);
-          execFileSync("systemd-creds", args, {
-            input: passphrase,
-            stdio: ["pipe", "inherit", "inherit"],
-          });
+          scope = await encryptCredential(passphrase, credPath, detection.supportsUser);
         } catch (err) {
-          const msg = err instanceof Error ? err.message : String(err);
-          console.error(`systemd-creds encrypt failed: ${msg}`);
-          if (!systemdCredsSupportsUser) {
-            console.error(
-              "\n" +
-              "  On systemd <256 this can also fail when the host credential\n" +
-              "  keystore exists but isn't readable by your user. Try the sudo\n" +
-              "  workaround:\n" +
-              `    sudo systemd-creds encrypt --name=vault-passphrase - ${credPath}\n` +
-              `    sudo chown $USER:$USER ${credPath} && chmod 600 ${credPath}`,
-            );
+          // encryptCredential prints its own diagnostics; we just need to exit.
+          if (err instanceof EncryptCancelledError || err instanceof EncryptFailedError) {
+            process.exit(1);
           }
-          process.exit(1);
+          throw err;
         }
       } finally {
         passphrase = "";
       }
 
-      try {
-        chmodSync(credPath, 0o600);
-      } catch {
-        /* non-fatal — systemd-creds already restricts mode */
+      console.log(`✓ Auto-unlock credential written to ${credPath} (scope: ${scope!})`);
+
+      if (!apply) {
+        console.log("");
+        console.log("Staged only (--no-apply). To activate:");
+        console.log("  1. Set vault.broker.autoUnlock: true in switchroom.yaml");
+        console.log("  2. switchroom reconcile        # re-renders the broker unit");
+        console.log("  3. systemctl --user restart switchroom-vault-broker.service");
+        return;
       }
 
-      console.log(`Auto-unlock credential written to ${credPath}`);
+      try {
+        await applyAutoUnlock({ configPath: parentOpts.config });
+      } catch (err) {
+        console.error(err instanceof Error ? err.message : String(err));
+        process.exit(1);
+      }
+
       console.log("");
-      console.log("Next steps:");
-      console.log("  1. Set vault.broker.autoUnlock: true in switchroom.yaml");
-      console.log("  2. switchroom reconcile        # re-renders the broker unit");
-      console.log("  3. systemctl --user restart switchroom-vault-broker.service");
-      console.log("");
-      console.log("Verify with: switchroom vault broker status (after restart)");
+      console.log("Done. Vault will unlock automatically on every boot.");
     });
 
   // ── disable-auto-unlock ──────────────────────────────────────────────────

--- a/tests/vault-auto-unlock.test.ts
+++ b/tests/vault-auto-unlock.test.ts
@@ -1,0 +1,260 @@
+/**
+ * Tests for the vault auto-unlock encryption cascade and YAML mutation.
+ *
+ * The cascade has four real-world environments:
+ *   1. systemd <256 + host keystore present + polkit allows non-root
+ *      → host-scope succeeds (no sudo)
+ *   2. systemd >=256 + user-scope socket up
+ *      → user-scope succeeds
+ *   3. systemd >=256 + no user-scope socket + host keystore + polkit denies
+ *      → all unprivileged paths fail; sudo escalation needed
+ *   4. systemd >=256, polkit denies, stdin not a TTY
+ *      → cannot auto-escalate; throws EncryptFailedError
+ *
+ * We exercise each by mocking `spawnSync` and existsSync.
+ */
+
+import { mkdtempSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Hoisted spawnSync mock — both `tryEncrypt` and `runSudoEncrypt` call into
+// node:child_process.spawnSync, so we drive the whole cascade from one queue.
+const spawnQueue: Array<{ status: number; stderr?: string }> = [];
+
+vi.mock("node:child_process", async () => {
+  const actual = await vi.importActual<typeof import("node:child_process")>("node:child_process");
+  return {
+    ...actual,
+    spawnSync: vi.fn((_cmd: string, _args: string[]) => {
+      const next = spawnQueue.shift();
+      if (!next) {
+        throw new Error("spawnSync called more times than the test queued responses");
+      }
+      return {
+        status: next.status,
+        stderr: next.stderr ?? "",
+        stdout: "",
+        signal: null,
+        output: [null, "", next.stderr ?? ""],
+        pid: 0,
+      };
+    }),
+  };
+});
+
+// existsSync is hit for the host keystore probe; mock it per-test.
+const existsMock = vi.fn<(p: string) => boolean>();
+vi.mock("node:fs", async () => {
+  const actual = await vi.importActual<typeof import("node:fs")>("node:fs");
+  return {
+    ...actual,
+    existsSync: vi.fn((p: string) => existsMock(p)),
+  };
+});
+
+// askYesNo is awaited inside encryptCredential when sudo escalation is
+// considered. We swap the implementation per-test.
+const askYesNoMock = vi.fn<() => Promise<boolean>>();
+vi.mock("../src/setup/prompt.js", () => ({
+  askYesNo: vi.fn(() => askYesNoMock()),
+  isInteractive: vi.fn(() => true),
+}));
+
+import {
+  classifyEncryptStderr,
+  encryptCredential,
+  EncryptCancelledError,
+  EncryptFailedError,
+  HOST_SECRET,
+  setVaultBrokerAutoUnlock,
+} from "../src/cli/vault-auto-unlock.js";
+
+describe("classifyEncryptStderr", () => {
+  it("recognizes polkit interactive-auth errors", () => {
+    expect(classifyEncryptStderr("Failed to encrypt: io.systemd.InteractiveAuthenticationRequired"))
+      .toBe("polkit-required");
+  });
+
+  it("recognizes io.systemd.System (varlink unreachable)", () => {
+    expect(classifyEncryptStderr("Failed to encrypt: io.systemd.System")).toBe("varlink-unreachable");
+  });
+
+  it("does not match io.systemd.SystemdSomething (avoid false positive)", () => {
+    expect(classifyEncryptStderr("Failed to encrypt: io.systemd.Systemctl")).not.toBe("varlink-unreachable");
+  });
+
+  it("recognizes missing host keystore", () => {
+    expect(classifyEncryptStderr("/var/lib/systemd/credential.secret: No such file or directory"))
+      .toBe("no-host-keystore");
+  });
+
+  it("falls back to other for unknown classes", () => {
+    expect(classifyEncryptStderr("some unrelated error")).toBe("other");
+  });
+});
+
+describe("encryptCredential cascade", () => {
+  const credPath = join(tmpdir(), "vault-auto-unlock-test.cred");
+
+  beforeEach(() => {
+    spawnQueue.length = 0;
+    existsMock.mockReset();
+    askYesNoMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("user-scope succeeds on first try (systemd >=256, socket up)", async () => {
+    existsMock.mockReturnValue(true); // mkdirSync of credPath dir uses existsSync internally on some libs; safe default
+    spawnQueue.push({ status: 0 }); // tryEncrypt user-scope success
+
+    const scope = await encryptCredential("p4ss", credPath, /*supportsUser=*/ true, {
+      isTTY: true,
+      log: () => {},
+      err: () => {},
+    });
+    expect(scope).toBe("user");
+  });
+
+  it("falls back to host-scope when user-scope fails varlink and keystore exists", async () => {
+    existsMock.mockImplementation((p: string) => p === HOST_SECRET);
+    spawnQueue.push({ status: 1, stderr: "Failed to encrypt: io.systemd.System" }); // user-scope fails
+    spawnQueue.push({ status: 0 }); // host-scope succeeds
+
+    const scope = await encryptCredential("p4ss", credPath, true, {
+      isTTY: true,
+      log: () => {},
+      err: () => {},
+    });
+    expect(scope).toBe("host");
+  });
+
+  it("on systemd <256, skips user-scope and uses host-scope", async () => {
+    existsMock.mockImplementation((p: string) => p === HOST_SECRET);
+    spawnQueue.push({ status: 0 }); // host-scope succeeds; no user-scope attempt
+
+    const scope = await encryptCredential("p4ss", credPath, /*supportsUser=*/ false, {
+      isTTY: true,
+      log: () => {},
+      err: () => {},
+    });
+    expect(scope).toBe("host");
+  });
+
+  it("escalates to sudo when polkit denies and user confirms (the Ubuntu 24.04+ path)", async () => {
+    existsMock.mockImplementation((p: string) => p === HOST_SECRET);
+    askYesNoMock.mockResolvedValue(true);
+
+    spawnQueue.push({ status: 1, stderr: "Failed to encrypt: io.systemd.System" }); // user-scope: socket gone
+    spawnQueue.push({ status: 1, stderr: "Failed to encrypt: io.systemd.InteractiveAuthenticationRequired" }); // host-scope: polkit
+    spawnQueue.push({ status: 0 }); // sudo systemd-creds encrypt
+    spawnQueue.push({ status: 0 }); // sudo -n chown
+
+    const scope = await encryptCredential("p4ss", credPath, true, {
+      isTTY: true,
+      log: () => {},
+      err: () => {},
+    });
+    expect(scope).toBe("host-sudo");
+    expect(askYesNoMock).toHaveBeenCalledOnce();
+  });
+
+  it("refuses to auto-escalate when stdin is not a TTY", async () => {
+    existsMock.mockImplementation((p: string) => p === HOST_SECRET);
+    spawnQueue.push({ status: 1, stderr: "io.systemd.System" });
+    spawnQueue.push({ status: 1, stderr: "InteractiveAuthenticationRequired" });
+
+    await expect(
+      encryptCredential("p4ss", credPath, true, {
+        isTTY: false,
+        log: () => {},
+        err: () => {},
+      }),
+    ).rejects.toBeInstanceOf(EncryptFailedError);
+    expect(askYesNoMock).not.toHaveBeenCalled();
+  });
+
+  it("aborts with EncryptCancelledError when user declines sudo", async () => {
+    existsMock.mockImplementation((p: string) => p === HOST_SECRET);
+    askYesNoMock.mockResolvedValue(false);
+
+    spawnQueue.push({ status: 1, stderr: "io.systemd.System" });
+    spawnQueue.push({ status: 1, stderr: "InteractiveAuthenticationRequired" });
+
+    await expect(
+      encryptCredential("p4ss", credPath, true, {
+        isTTY: true,
+        log: () => {},
+        err: () => {},
+      }),
+    ).rejects.toBeInstanceOf(EncryptCancelledError);
+  });
+
+  it("escalates straight to sudo when host keystore is absent (no host-scope attempt)", async () => {
+    existsMock.mockReturnValue(false); // no HOST_SECRET
+    askYesNoMock.mockResolvedValue(true);
+
+    spawnQueue.push({ status: 1, stderr: "io.systemd.System" }); // user-scope only
+    spawnQueue.push({ status: 0 }); // sudo encrypt
+    spawnQueue.push({ status: 0 }); // sudo -n chown
+
+    const scope = await encryptCredential("p4ss", credPath, true, {
+      isTTY: true,
+      log: () => {},
+      err: () => {},
+    });
+    expect(scope).toBe("host-sudo");
+    // exactly 3 spawnSync calls: user-encrypt, sudo-encrypt, sudo-chown
+    expect(spawnQueue.length).toBe(0);
+  });
+});
+
+describe("setVaultBrokerAutoUnlock", () => {
+  let tmp: string;
+  let configPath: string;
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), "switchroom-yaml-"));
+    configPath = join(tmp, "switchroom.yaml");
+  });
+
+  it("creates vault.broker.autoUnlock when config has none of those keys", () => {
+    writeFileSync(
+      configPath,
+      "# header comment\nagents:\n  alice:\n    extends: default\n",
+      "utf-8",
+    );
+    setVaultBrokerAutoUnlock(configPath, true);
+    const after = readFileSync(configPath, "utf-8");
+    expect(after).toContain("autoUnlock: true");
+    expect(after).toContain("# header comment"); // comment preserved
+    expect(after).toContain("alice:"); // existing keys preserved
+  });
+
+  it("flips an existing false value to true without disturbing siblings", () => {
+    writeFileSync(
+      configPath,
+      [
+        "vault:",
+        "  path: ~/.switchroom/vault.enc",
+        "  broker:",
+        "    autoUnlock: false  # toggled by enable-auto-unlock",
+        "    socket: ~/.switchroom/vault-broker.sock",
+        "agents: {}",
+        "",
+      ].join("\n"),
+      "utf-8",
+    );
+    setVaultBrokerAutoUnlock(configPath, true);
+    const after = readFileSync(configPath, "utf-8");
+    expect(after).toMatch(/autoUnlock: true/);
+    expect(after).toContain("path: ~/.switchroom/vault.enc"); // sibling preserved
+    expect(after).toContain("socket: ~/.switchroom/vault-broker.sock"); // sibling preserved
+    // Inline comment near autoUnlock survives YAML round-trip
+    expect(after).toContain("# toggled by enable-auto-unlock");
+  });
+});


### PR DESCRIPTION
## Summary

`switchroom vault broker enable-auto-unlock` failed on every fresh Ubuntu 24.04+ box. systemd 256 added polkit gating for non-root callers of the `io.systemd.Credentials` varlink service, and the user-scope socket isn't shipped on Ubuntu — so both unprivileged encrypt paths returned `io.systemd.System` / `io.systemd.InteractiveAuthenticationRequired` and the CLI exited with a 4-line sudo recipe. The user then had to run sudo manually, chown the file, edit `switchroom.yaml`, run `switchroom reconcile`, and restart the broker — five hand steps for what should be one command.

This PR makes the command match the UX we want for the product:

```
$ switchroom vault broker enable-auto-unlock
Vault passphrase: ********
Encrypt with sudo (one-time prompt)? [Y/n]
[sudo] password to encrypt vault auto-unlock credential: ********
✓ Auto-unlock credential written to ~/.config/credstore.encrypted/vault-passphrase (scope: host-sudo)
✓ Set vault.broker.autoUnlock=true in switchroom.yaml
✓ Reconciled broker unit
✓ Restarted switchroom-vault-broker.service
✓ Vault unlocked via auto-unlock credential
Done. Vault will unlock automatically on every boot.
```

One command. One passphrase. One sudo prompt. Done.

## What changed

- **New module `src/cli/vault-auto-unlock.ts`** — owns the encrypt cascade (user-scope → host-scope → sudo escalation) and the apply flow (YAML mutation, reconcile, restart, verify). Reused from the broker CLI command **and** the setup wizard so we don't have two copies.
- **Error-class detection.** Branching now classifies systemd-creds stderr by intent (`polkit-required` / `varlink-unreachable` / `no-host-keystore` / `other`) instead of probing the host keystore file. The previous file-existence axis was a poor proxy that masked the real failure mode on Ubuntu 24.04+.
- **Sudo escalation.** When both unprivileged paths fail and stdin is a TTY, the command asks once ("Encrypt with sudo? [Y/n]") and runs `sudo systemd-creds encrypt` with the passphrase piped via stdin (never argv), then `sudo chown $UID:$GID` so the broker user-unit can read the credential. Non-TTY callers are refused — we don't silently sudo from CI.
- **`enable-auto-unlock` defaults to apply.** Flips `vault.broker.autoUnlock=true` via comment-preserving YAML mutation, reloads config, regenerates the broker unit, restarts it via `systemctl --user`, and polls `statusViaBroker` to confirm the vault came up unlocked. `--no-apply` keeps the staged-only behaviour (the previous default).
- **`switchroom setup` gains step 8 "Vault auto-unlock at boot."** Asks once after agent scaffolding, runs the same flow inline. Skipped on non-Linux, non-interactive runs, or when systemd-creds is missing. This is what makes the *defaults test* pass.
- **14 new vitest cases** cover the cascade across the four real environments (systemd <256 / >=256 × user-socket up/down × polkit allow/deny) plus YAML mutation preserving comments.

## Why this passes the design contract

**JTBD — `survive-reboots-and-real-life`.** Auto-unlock is the load-bearing mechanism for *"agents come back cleanly after reboots without the user poking anything."* Failing on Ubuntu 24.04+ defeats the purpose of the feature.

**Principle checks (`reference/principles.md`):**
- *Docs test:* ✓ Single command. No manual sudo recipe to copy-paste.
- *Defaults test:* ✓ Fresh `switchroom setup` on Ubuntu 24.04+ ends with auto-unlock active.
- *Consistency test:* ✓ Same CLI shape (`--apply` / `--no-apply`, in-process reconcile, masked passphrase prompt) as adjacent vault commands.

## Test plan

- [x] `npm run lint` clean (TypeScript).
- [x] `npm test` — full vitest + bun suite passes (4374 + 289 tests).
- [x] `bun run dev -- vault broker enable-auto-unlock --help` shows the new `--no-apply` flag.
- [ ] Manual UAT on the box that motivated this PR (Ubuntu 24.04, systemd 257): run the new `enable-auto-unlock`, confirm sudo prompt fires, credential lands at `~/.config/credstore.encrypted/vault-passphrase`, broker restarts, vault comes up unlocked.
- [ ] Manual UAT on a fresh `switchroom setup` to verify step 8 runs end-to-end.
- [ ] Reboot the host once and confirm the broker comes up with the vault unlocked.

## Follow-ups (separate PRs)

- **Doctor checks.** Detect `autoUnlock=true` + missing/wrong-perms credential file and offer `enable-auto-unlock` as the fix.
- **`disable-auto-unlock`.** Mirror the same apply-by-default shape (flip YAML to false, reconcile, restart, then remove cred file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)