### PR TITLE
fix(vault): force --with-key=host on auto-unlock encrypt; drop --user scope

### DIFF
--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -931,8 +931,7 @@ async function stepAutoUnlock(
     return;
   }
 
-  const detection = detectSystemdCreds();
-  if (!detection) {
+  if (!detectSystemdCreds()) {
     console.log(chalk.gray("  Skipping (systemd-creds not on PATH)."));
     return;
   }
@@ -986,7 +985,7 @@ async function stepAutoUnlock(
 
     let scope: string;
     try {
-      scope = await encryptCredential(passphrase, credPath, detection.supportsUser);
+      scope = await encryptCredential(passphrase, credPath);
     } catch (err) {
       if (err instanceof EncryptCancelledError) {
         console.log(chalk.gray("  Skipped (user declined sudo)."));

--- a/src/cli/vault-auto-unlock.ts
+++ b/src/cli/vault-auto-unlock.ts
@@ -34,7 +34,7 @@ import { askYesNo } from "../setup/prompt.js";
 
 export const HOST_SECRET = "/var/lib/systemd/credential.secret";
 
-export type EncryptScope = "user" | "host" | "host-sudo";
+export type EncryptScope = "host" | "host-sudo";
 
 export type EncryptErrorClass =
   | "polkit-required"
@@ -61,49 +61,58 @@ export function classifyEncryptStderr(stderr: string): EncryptErrorClass {
 }
 
 /**
- * Detect whether `systemd-creds` is available and supports `--user`. The
- * `--user` flag was added in systemd 256; earlier releases reject it as
- * unrecognized. Returns null if the binary isn't on PATH.
+ * Detect whether `systemd-creds` is available on PATH. We don't care about
+ * version-specific feature flags — every flag we use (`--with-key=host`,
+ * `--name=`, `--quiet`) is supported in every systemd-creds release we
+ * target. Returns null when the binary is missing.
  */
-export function detectSystemdCreds(): { supportsUser: boolean } | null {
+export function detectSystemdCreds(): { available: true } | null {
   try {
-    const versionOut = execFileSync("systemd-creds", ["--version"], {
-      stdio: ["ignore", "pipe", "ignore"],
-      encoding: "utf8",
+    execFileSync("systemd-creds", ["--version"], {
+      stdio: ["ignore", "ignore", "ignore"],
     });
-    const m = versionOut.match(/systemd\s+(\d+)/);
-    return { supportsUser: m ? parseInt(m[1], 10) >= 256 : false };
+    return { available: true };
   } catch {
     return null;
   }
 }
 
 /**
- * Run a single systemd-creds encrypt invocation in the requested scope.
- * Returns an outcome object instead of throwing — caller orchestrates the
- * fall-through cascade.
+ * Why `--with-key=host` and not the systemd-creds default ("auto")?
+ *
+ * `auto` picks `tpm2+host` when a TPM is present. The resulting credential
+ * needs `/dev/tpmrm0` access at *decrypt* time — i.e., when the broker user
+ * unit starts at boot. Ubuntu's default permissions on `/dev/tpmrm0` require
+ * group `tss`, which kenthompson-style user accounts aren't members of by
+ * default. Result: encrypt succeeds, decrypt at unit start fails with
+ * "Permission denied" on /dev/tpmrm0 → systemd refuses to start the unit
+ * with `status=243/CREDENTIALS`. By forcing `host`, the credential needs
+ * only the host secret — which user-systemd brokers via the system manager
+ * for any user unit, no group membership required. Trade-off: no TPM
+ * sealing. Acceptable, since the encrypted file lives at mode 0600 in the
+ * user's home and the real defence is filesystem perms, not TPM binding.
+ *
+ * Run a single systemd-creds encrypt invocation in host scope. Returns an
+ * outcome object instead of throwing — caller orchestrates the fall-through
+ * cascade.
  *
  * Passphrase is piped via stdin so it never appears in argv, environ, or
  * any process listing. stderr is captured (not inherited) so we can
  * classify the failure; stdout is empty on success because of --quiet.
  */
-export function tryEncrypt(
-  scope: "user" | "host",
-  passphrase: string,
-  credPath: string,
-): EncryptOutcome {
-  const args = ["encrypt", "--name=vault-passphrase"];
-  if (scope === "user") args.push("--user");
-  args.push("--quiet", "-", credPath);
-
-  const result = spawnSync("systemd-creds", args, {
-    input: passphrase,
-    stdio: ["pipe", "ignore", "pipe"],
-    encoding: "utf8",
-  });
+export function tryEncrypt(passphrase: string, credPath: string): EncryptOutcome {
+  const result = spawnSync(
+    "systemd-creds",
+    ["encrypt", "--with-key=host", "--name=vault-passphrase", "--quiet", "-", credPath],
+    {
+      input: passphrase,
+      stdio: ["pipe", "ignore", "pipe"],
+      encoding: "utf8",
+    },
+  );
 
   if (result.status === 0) {
-    return { ok: true, scope };
+    return { ok: true, scope: "host" };
   }
   const stderr = (result.stderr ?? "") + (result.error ? `\n${result.error.message}` : "");
   return { ok: false, class: classifyEncryptStderr(stderr), stderr };
@@ -127,6 +136,7 @@ export function runSudoEncrypt(
       "[sudo] password to encrypt vault auto-unlock credential: ",
       "systemd-creds",
       "encrypt",
+      "--with-key=host",
       "--name=vault-passphrase",
       "--quiet",
       "-",
@@ -200,7 +210,6 @@ export class EncryptFailedError extends Error {
 export async function encryptCredential(
   passphrase: string,
   credPath: string,
-  systemdCredsSupportsUser: boolean,
   opts: EncryptOptions = {},
 ): Promise<EncryptScope> {
   const log = opts.log ?? ((s: string) => console.log(s));
@@ -209,35 +218,26 @@ export async function encryptCredential(
 
   mkdirSync(dirname(credPath), { recursive: true, mode: 0o700 });
 
+  // Host-scope encrypt-as-user only works when the host keystore is present
+  // AND readable to the user (default Ubuntu has it root-only at mode 0400,
+  // so this is mostly a fast-path for systems where it's been intentionally
+  // shared). When that fails we escalate to sudo, which can always read it.
   let lastFail: EncryptOutcome | null = null;
 
-  if (systemdCredsSupportsUser) {
-    const r = tryEncrypt("user", passphrase, credPath);
+  if (existsSync(HOST_SECRET)) {
+    const r = tryEncrypt(passphrase, credPath);
     if (r.ok) return r.scope;
     lastFail = r;
   }
 
-  // Host-scope encrypt-as-user only works when the host keystore exists AND
-  // polkit allows the call. If the keystore is missing, skip straight to sudo
-  // — there's nothing to attempt.
-  if (existsSync(HOST_SECRET)) {
-    const r = tryEncrypt("host", passphrase, credPath);
-    if (r.ok) {
-      if (lastFail) {
-        log("  (--user encryption was unavailable; used host-scope instead)");
-      }
-      return r.scope;
-    }
-    lastFail = r;
-  }
-
-  // Both unprivileged paths exhausted. Decide whether to escalate.
+  // Unprivileged path exhausted. Decide whether to escalate.
+  const sudoEncryptCmd = `sudo systemd-creds encrypt --with-key=host --name=vault-passphrase - ${credPath}`;
   if (!isTTY) {
     err("systemd-creds encrypt failed and stdin is not a TTY; refusing to auto-escalate via sudo.");
     if (lastFail) err(`  Last error: ${lastFail.stderr.trim().split("\n")[0]}`);
     err("");
     err("  Run interactively, or run this manually with sudo:");
-    err(`    sudo systemd-creds encrypt --name=vault-passphrase - ${credPath}`);
+    err(`    ${sudoEncryptCmd}`);
     err(`    sudo chown $USER:$USER ${credPath} && chmod 600 ${credPath}`);
     throw new EncryptFailedError(credPath, "non-tty: cannot auto-escalate");
   }
@@ -249,15 +249,15 @@ export async function encryptCredential(
     log(`  ${firstLine}`);
   }
   log("");
-  log("This is the default state of Ubuntu 24.04+ with systemd ≥256:");
-  log("  the system varlink socket is polkit-gated for non-root callers");
-  log("  and no user-scope socket ships out of the box. sudo bypasses both.");
+  log("This is the default state of Ubuntu 24.04+: the host secret at");
+  log(`  ${HOST_SECRET} is mode 0400 root-only, so unprivileged callers`);
+  log("  can't read it. sudo bypasses that.");
   log("");
 
   const proceed = opts.assumeYesSudo ?? (await askYesNo("Encrypt with sudo (one-time prompt)?", true));
   if (!proceed) {
     err("Aborted. To finish manually:");
-    err(`  sudo systemd-creds encrypt --name=vault-passphrase - ${credPath}`);
+    err(`  ${sudoEncryptCmd}`);
     err(`  sudo chown $USER:$USER ${credPath} && chmod 600 ${credPath}`);
     throw new EncryptCancelledError(credPath);
   }
@@ -315,7 +315,9 @@ export async function applyAutoUnlock(opts: ApplyOptions = {}): Promise<void> {
   const err = opts.err ?? ((s: string) => console.error(s));
   const runSystemctl =
     opts.runSystemctl ?? ((args: string[]) => spawnSync("systemctl", args, { stdio: "inherit" }));
-  const verifyTimeoutMs = opts.verifyTimeoutMs ?? 5000;
+  // 10s default — generous enough for cold-cache decrypt on slow boxes, short
+  // enough that a real cred-decrypt failure surfaces before the user gives up.
+  const verifyTimeoutMs = opts.verifyTimeoutMs ?? 10000;
 
   const configPath = opts.configPath ?? findConfigFile();
   setVaultBrokerAutoUnlock(configPath, true);

--- a/src/cli/vault-broker.ts
+++ b/src/cli/vault-broker.ts
@@ -342,8 +342,7 @@ export function registerVaultBrokerCommand(vaultCmd: Command, program: Command):
         process.exit(1);
       }
 
-      const detection = detectSystemdCreds();
-      if (!detection) {
+      if (!detectSystemdCreds()) {
         console.error(
           "systemd-creds not found on PATH. Requires systemd >= 250. " +
           "Try: sudo apt install systemd",
@@ -376,7 +375,7 @@ export function registerVaultBrokerCommand(vaultCmd: Command, program: Command):
         }
 
         try {
-          scope = await encryptCredential(passphrase, credPath, detection.supportsUser);
+          scope = await encryptCredential(passphrase, credPath);
         } catch (err) {
           // encryptCredential prints its own diagnostics; we just need to exit.
           if (err instanceof EncryptCancelledError || err instanceof EncryptFailedError) {

--- a/tests/vault-auto-unlock.test.ts
+++ b/tests/vault-auto-unlock.test.ts
@@ -1,15 +1,15 @@
 /**
  * Tests for the vault auto-unlock encryption cascade and YAML mutation.
  *
- * The cascade has four real-world environments:
- *   1. systemd <256 + host keystore present + polkit allows non-root
- *      → host-scope succeeds (no sudo)
- *   2. systemd >=256 + user-scope socket up
- *      → user-scope succeeds
- *   3. systemd >=256 + no user-scope socket + host keystore + polkit denies
- *      → all unprivileged paths fail; sudo escalation needed
- *   4. systemd >=256, polkit denies, stdin not a TTY
- *      → cannot auto-escalate; throws EncryptFailedError
+ * The cascade is intentionally minimal: host-scope encrypt with `--with-key=host`
+ * (no TPM dependency, decryptable in user units), tried as user first and
+ * escalated to sudo when the host secret is root-only-readable.
+ *
+ *   1. host secret readable to user (rare on default Ubuntu) → host-as-user wins
+ *   2. host secret root-only (default Ubuntu 24.04+) → polkit-denies-as-user → sudo
+ *   3. polkit denies + non-TTY → cannot auto-escalate; EncryptFailedError
+ *   4. user declines sudo → EncryptCancelledError
+ *   5. host secret missing → straight to sudo (root creates it on first encrypt)
  *
  * We exercise each by mocking `spawnSync` and existsSync.
  */
@@ -108,36 +108,11 @@ describe("encryptCredential cascade", () => {
     vi.clearAllMocks();
   });
 
-  it("user-scope succeeds on first try (systemd >=256, socket up)", async () => {
-    existsMock.mockReturnValue(true); // mkdirSync of credPath dir uses existsSync internally on some libs; safe default
-    spawnQueue.push({ status: 0 }); // tryEncrypt user-scope success
-
-    const scope = await encryptCredential("p4ss", credPath, /*supportsUser=*/ true, {
-      isTTY: true,
-      log: () => {},
-      err: () => {},
-    });
-    expect(scope).toBe("user");
-  });
-
-  it("falls back to host-scope when user-scope fails varlink and keystore exists", async () => {
+  it("host-as-user succeeds when host secret is readable", async () => {
     existsMock.mockImplementation((p: string) => p === HOST_SECRET);
-    spawnQueue.push({ status: 1, stderr: "Failed to encrypt: io.systemd.System" }); // user-scope fails
-    spawnQueue.push({ status: 0 }); // host-scope succeeds
+    spawnQueue.push({ status: 0 }); // host-scope encrypt as user succeeds
 
-    const scope = await encryptCredential("p4ss", credPath, true, {
-      isTTY: true,
-      log: () => {},
-      err: () => {},
-    });
-    expect(scope).toBe("host");
-  });
-
-  it("on systemd <256, skips user-scope and uses host-scope", async () => {
-    existsMock.mockImplementation((p: string) => p === HOST_SECRET);
-    spawnQueue.push({ status: 0 }); // host-scope succeeds; no user-scope attempt
-
-    const scope = await encryptCredential("p4ss", credPath, /*supportsUser=*/ false, {
+    const scope = await encryptCredential("p4ss", credPath, {
       isTTY: true,
       log: () => {},
       err: () => {},
@@ -149,12 +124,11 @@ describe("encryptCredential cascade", () => {
     existsMock.mockImplementation((p: string) => p === HOST_SECRET);
     askYesNoMock.mockResolvedValue(true);
 
-    spawnQueue.push({ status: 1, stderr: "Failed to encrypt: io.systemd.System" }); // user-scope: socket gone
-    spawnQueue.push({ status: 1, stderr: "Failed to encrypt: io.systemd.InteractiveAuthenticationRequired" }); // host-scope: polkit
+    spawnQueue.push({ status: 1, stderr: "Failed to encrypt: io.systemd.InteractiveAuthenticationRequired" }); // polkit denies
     spawnQueue.push({ status: 0 }); // sudo systemd-creds encrypt
     spawnQueue.push({ status: 0 }); // sudo -n chown
 
-    const scope = await encryptCredential("p4ss", credPath, true, {
+    const scope = await encryptCredential("p4ss", credPath, {
       isTTY: true,
       log: () => {},
       err: () => {},
@@ -165,11 +139,10 @@ describe("encryptCredential cascade", () => {
 
   it("refuses to auto-escalate when stdin is not a TTY", async () => {
     existsMock.mockImplementation((p: string) => p === HOST_SECRET);
-    spawnQueue.push({ status: 1, stderr: "io.systemd.System" });
     spawnQueue.push({ status: 1, stderr: "InteractiveAuthenticationRequired" });
 
     await expect(
-      encryptCredential("p4ss", credPath, true, {
+      encryptCredential("p4ss", credPath, {
         isTTY: false,
         log: () => {},
         err: () => {},
@@ -182,11 +155,10 @@ describe("encryptCredential cascade", () => {
     existsMock.mockImplementation((p: string) => p === HOST_SECRET);
     askYesNoMock.mockResolvedValue(false);
 
-    spawnQueue.push({ status: 1, stderr: "io.systemd.System" });
     spawnQueue.push({ status: 1, stderr: "InteractiveAuthenticationRequired" });
 
     await expect(
-      encryptCredential("p4ss", credPath, true, {
+      encryptCredential("p4ss", credPath, {
         isTTY: true,
         log: () => {},
         err: () => {},
@@ -194,22 +166,51 @@ describe("encryptCredential cascade", () => {
     ).rejects.toBeInstanceOf(EncryptCancelledError);
   });
 
-  it("escalates straight to sudo when host keystore is absent (no host-scope attempt)", async () => {
+  it("escalates straight to sudo when host keystore is absent (no host-as-user attempt)", async () => {
     existsMock.mockReturnValue(false); // no HOST_SECRET
     askYesNoMock.mockResolvedValue(true);
 
-    spawnQueue.push({ status: 1, stderr: "io.systemd.System" }); // user-scope only
     spawnQueue.push({ status: 0 }); // sudo encrypt
     spawnQueue.push({ status: 0 }); // sudo -n chown
 
-    const scope = await encryptCredential("p4ss", credPath, true, {
+    const scope = await encryptCredential("p4ss", credPath, {
       isTTY: true,
       log: () => {},
       err: () => {},
     });
     expect(scope).toBe("host-sudo");
-    // exactly 3 spawnSync calls: user-encrypt, sudo-encrypt, sudo-chown
+    // exactly 2 spawnSync calls (no host-as-user attempt): sudo-encrypt + sudo-chown
     expect(spawnQueue.length).toBe(0);
+  });
+
+  it("always passes --with-key=host to systemd-creds (regression: TPM auto-default broke decrypt at unit start)", async () => {
+    // Capture argv from spawnSync so we can assert.
+    const seenArgs: string[][] = [];
+    spawnQueue.push({ status: 0 });
+    existsMock.mockImplementation((p: string) => p === HOST_SECRET);
+
+    const cp = await import("node:child_process");
+    const original = vi.mocked(cp.spawnSync);
+    original.mockImplementationOnce((_cmd: string, args: string[]) => {
+      seenArgs.push(args);
+      const next = spawnQueue.shift()!;
+      return {
+        status: next.status,
+        stderr: next.stderr ?? "",
+        stdout: "",
+        signal: null,
+        output: [null, "", next.stderr ?? ""],
+        pid: 0,
+      } as ReturnType<typeof cp.spawnSync>;
+    });
+
+    await encryptCredential("p4ss", credPath, {
+      isTTY: true,
+      log: () => {},
+      err: () => {},
+    });
+
+    expect(seenArgs[0]).toContain("--with-key=host");
   });
 });
 


### PR DESCRIPTION
## Summary

Companion fix to #538. UAT on a real Ubuntu 25.04 box (systemd 257) caught two stacked failures in the encrypt cascade that #538 introduced — the resulting credential encrypted fine but failed to decrypt at broker unit start with \`status=243/CREDENTIALS\`. Root causes:

1. **TPM auto-binding.** systemd-creds' default key selection is \`tpm2+host\` when a TPM is present. The TPM half of the key requires \`/dev/tpmrm0\` access at *decrypt* time. On Ubuntu \`/dev/tpmrm0\` is owned \`tss:tss\` mode 0660 and normal user accounts aren't in \`tss\` — so user-systemd reading the credential at unit start gets \`Failed to open TCTI device file /dev/tpmrm0: Permission denied\`. Encrypt happily uses TPM (root has access); decrypt-at-boot can't.

2. **\`--user\` scope.** The \`--user\` flag puts the credential in the per-user keystore, which user-systemd's credential-decryption path doesn't broker the same way it brokers host-scope creds for user units. Even when TPM was avoided, \`--user\`-scope creds didn't decrypt in the broker user unit on this box.

## Fix

- **Force \`--with-key=host\` on every encrypt.** No TPM dependency; decrypts cleanly in user units via systemd's normal user→system credential broker path, no group-membership prerequisites.
- **Drop the \`--user\` cascade entry.** The cascade is now: host-scope as user → host-scope via sudo. Simpler, more portable.
- **\`detectSystemdCreds()\`** no longer parses \`--version\`. Every flag we use is in every systemd-creds release we target; the \`supportsUser\` field was the only reason to probe.
- **Verify-poll timeout** bumped 5s → 10s (was a noted follow-up in the #538 review). The original 5s wasn't long enough to surface the 243/CREDENTIALS restart-loop on the box that motivated this fix; 10s gives slow boxes (cold TPM cache, busy systemd) headroom while still surfacing real failures.
- **Updated polkit diagnostic message:** it no longer references the user-scope socket; it now points at the host-secret mode/perms as the single root cause to check.

## Why this is policy, not workaround

TPM auto-binding by default makes the credential's decryptability depend on which device nodes the user happens to have access to — a fragile coupling that breaks silently and has no clean diagnostic in our codebase. Forcing \`host\` makes encryption portable: the credential works anywhere the host secret is reachable, no group setup required. TPM-bound creds should be an explicit user choice, not the silent default.

## Test plan

- [x] \`npm run lint\` clean
- [x] \`npm test\` clean (4375 vitest + 289 bun, including new regression test that asserts \`--with-key=host\` is in spawnSync args)
- [ ] UAT on the same Ubuntu 25.04 box that motivated this fix — re-run \`enable-auto-unlock\` after merge, confirm broker comes up unlocked.

## Followups

- **Doctor checks** (still tracked from #538): detect \`autoUnlock=true\` + missing/wrong-perms credential file and offer \`enable-auto-unlock\` as the fix; also detect a \`status=243/CREDENTIALS\` broker and surface the journal hint.
- **Permissive host-secret detection**: when host-scope encrypt fails with the \"permissive access mode, refusing\" stderr signature (someone's been editing ACLs by hand), suggest the \`setfacl -b\` + \`chmod 0400\` repair inline rather than just falling through to sudo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)