### PR TITLE
test(telegram-plugin): waiting-UX deterministic E2E harness (Phase 1, #545)

### DIFF
--- a/telegram-plugin/docs/waiting-ux-spec.md
+++ b/telegram-plugin/docs/waiting-ux-spec.md
@@ -1,0 +1,90 @@
+# Waiting-for-reply UX — deterministic time-sequence spec
+
+Tracks: [#545](https://github.com/mekenthompson/switchroom/issues/545)
+
+This document codifies the user-perceived contract for what happens between
+"I sent a Telegram message" and "the agent's reply is locked in." The contract
+varies by **turn class**. Phase 1 of #545 lands an E2E harness
+(`tests/waiting-ux.e2e.test.ts`) that asserts these invariants in fake-timer
+deterministic time.
+
+## Three turn classes
+
+### Class A — Instant reply (no tool calls, < ~2s of model time)
+
+| Surface              | Contract                                                                |
+| -------------------- | ----------------------------------------------------------------------- |
+| Status reaction      | 👀 lands within **800ms** of inbound. Terminates with 👍.               |
+| Progress card        | **Never rendered.** `initialDelayMs` (~30s) suppresses it entirely.     |
+| Draft answer         | Streams via `stream_reply` direct. No card scaffolding.                 |
+| Ladder               | 👀 → (optional 🤔 burst) → 👍. No tool reactions.                       |
+
+User experience: feels like a chat partner typing back.
+
+### Class B — Short turn (1–3 tool calls, < ~15s)
+
+| Surface              | Contract                                                                |
+| -------------------- | ----------------------------------------------------------------------- |
+| Status reaction      | 👀 within 800ms. Ladder progresses through 🤔 / tool-glyphs (🔥/✍/👨‍💻/⚡) before 👍. **Must NOT collapse straight to 👍.** |
+| Progress card        | Optional. Renders if turn exceeds `initialDelayMs` threshold (configurable, default 30s) with live tool bullets. |
+| Pre-tool preamble    | Refreshes ≥1 time across step transitions (new tool category, or >Ns since last refresh). **Must NOT be a single static line for the entire turn.** |
+| Final                | 👍 + locked stream answer.                                              |
+
+### Class C — Long-running / multi-agent (sub-agents, background workers)
+
+| Surface              | Contract                                                                |
+| -------------------- | ----------------------------------------------------------------------- |
+| Status reaction      | 👀 within 800ms. Settles to 👍 only after full quiescence (all sub-agents + workers terminal). |
+| Progress card        | Renders early — **before turn_end** — and stays stable. Each sub-agent + background worker has its own bullet. |
+| Card "Done" timestamp | Must be **≥ last sub-agent terminal timestamp**. Card does not mark Done while any worker is still in flight. |
+| Ladder               | Tool reactions throughout, settling to 👍 only after full quiescence.   |
+
+## Failure modes the harness must catch
+
+These are the four observed regressions from the live demo on 2026-04-30:
+
+| ID  | Symptom                                                                    | Class | Test                                            |
+| --- | -------------------------------------------------------------------------- | ----- | ----------------------------------------------- |
+| F1  | Ladder collapses straight to 👍 (skips 👀 → 🤔 → 🔥)                       | B     | `Class B — short turn > ladder integrity`       |
+| F2  | No instant draft / typing signal — chat sits silent "for ages"             | All   | `Class A > first-paint deadline`, `Class C > first-paint`         |
+| F3  | Progress card renders late (after turn_end, or never on long turns)        | C     | `Class C > progress card renders early`         |
+| F4  | Pre-tool interim text is static — one preamble then silence                | B     | `Class B > interim refresh`                     |
+
+## Test methodology
+
+- **Time control**: `vi.useFakeTimers()` + `vi.setSystemTime` for deterministic
+  wall-clock assertions. The harness records every outbound `bot.api` call with
+  `Date.now()` at invocation, so first-paint and ladder deltas are
+  reproducibly measurable.
+- **Recorder**: a `Recorder` object exposes the helpers tests need
+  (`firstReactionMs`, `progressCardSendMs`, `reactionSequence`,
+  `lastReactionEmoji`, `edits`, `sentTexts`).
+- **Production wiring**: the harness uses the actual
+  `StatusReactionController` and `createProgressDriver` from production —
+  not mocks. The bot.api layer below is a recording fake.
+- **Out of scope**: gateway message-coalescing, foreman queue, inbound update
+  handler, and IPC surfaces are not exercised by this harness. See
+  "Known limitation" below.
+
+## Known limitation (Phase 1)
+
+The harness drives `controller.*` and `driver.*` methods directly from a
+hand-written `feedSessionEvent` adapter that mirrors the relevant `case`
+branches in `gateway/gateway.ts`'s session-tail dispatcher. This means the
+harness asserts the contract is upheld **inside the controller + driver
+components** but does not catch failures introduced by:
+
+- Gateway-side message gating / queueing latency before the controller is constructed
+- Session-tail parser bugs (events dropped or mis-tagged before reaching dispatch)
+- IPC bridge dropouts that desynchronise the two halves of the system
+
+A Phase 2 harness that drives the real gateway through a synthetic update
+stream is filed as a follow-up. Until then, integration-boundary regressions
+remain CI-invisible.
+
+## CI gate
+
+The harness runs as part of the root vitest suite via `npm test` →
+`vitest run`. It picks up
+`telegram-plugin/tests/waiting-ux.e2e.test.ts` automatically — no separate
+config required.

--- a/telegram-plugin/first-paint.ts
+++ b/telegram-plugin/first-paint.ts
@@ -93,6 +93,17 @@ export interface FirstPaintDeps {
   logStreamingEvent: (ev: { kind: 'inbound_ack'; chatId: string; messageId: number; ackDelayMs: number }) => void
   /** Clock — defaults to Date.now in production; tests inject fake. */
   now?: () => number
+  /**
+   * Factory for the per-turn StatusReactionController. Defaults to constructing
+   * a real `StatusReactionController(cb)`. Tests inject a recording stub so
+   * the harness can decouple from the real controller's internal scheduling.
+   */
+  controllerFactory?: (cb: (emoji: string) => Promise<void>) => StatusReactionController
+  /**
+   * Sink for stderr-style error reporting from the seam. Defaults to writing
+   * to `process.stderr`. Tests inject a recorder.
+   */
+  logError?: (msg: string) => void
 }
 
 export interface FirstPaintResult {
@@ -165,7 +176,8 @@ export async function firstPaintTurn(
         }
         deps.suppressPtyPreview.delete(sKey)
 
-        const ctrl = new StatusReactionController(async (emoji) => {
+        const makeCtrl = deps.controllerFactory ?? ((cb) => new StatusReactionController(cb))
+        const ctrl = makeCtrl(async (emoji) => {
           await deps.bot.api.setMessageReaction(chatId, msgId, [
             { type: 'emoji', emoji: emoji as ReactionTypeEmoji['emoji'] },
           ])
@@ -218,7 +230,8 @@ export async function firstPaintTurn(
         replyToMessageId: msgId != null ? msgId : undefined,
       })
     } catch (err) {
-      process.stderr.write(`telegram gateway: progress-card startTurn failed: ${(err as Error).message}\n`)
+      const log = deps.logError ?? ((m: string) => process.stderr.write(m))
+      log(`telegram gateway: progress-card startTurn failed: ${(err as Error).message}\n`)
     }
   }
 

--- a/telegram-plugin/first-paint.ts
+++ b/telegram-plugin/first-paint.ts
@@ -1,0 +1,226 @@
+/**
+ * First-paint seam (Phase 1 of #545).
+ *
+ * Pure function extracted from gateway.ts `handleInbound` for the
+ * status-reaction + progress-card-startTurn slice. Production behavior is
+ * unchanged: gateway.ts calls this with its module-level singletons. The
+ * seam exists so the waiting-UX harness can drive the real first-paint
+ * code path with fakes and assert wall-clock call timing of
+ *   - bot.api.setMessageReaction (the 👀 ack)
+ *   - progressDriver.startTurn (the progress card)
+ *
+ * Scope is deliberately narrow:
+ *   - status-reaction setup (cancel-prior + setQueued, or 🤝/👀 for
+ *     steer/queued mid-turn)
+ *   - progressDriver.startTurn for fresh turns
+ * Out of scope (stays inline in gateway.ts):
+ *   - draft pre-allocation, forum-topic placeholder, heartbeat scheduling
+ *
+ * The motivation for the narrow scope: pre-alloc/heartbeat code touches
+ * 6 more module-scoped maps + functions and would balloon this seam
+ * without making F2/F3 (no instant draft / late card) any more testable
+ * — those are about the FIRST visible signal (👀 + card.startTurn).
+ */
+
+import type { ReactionTypeEmoji } from 'grammy/types'
+import { StatusReactionController } from './status-reactions.js'
+import type { DraftStreamHandle } from './draft-stream.js'
+
+// ─── Types ────────────────────────────────────────────────────────────────
+
+export interface FirstPaintBotApi {
+  setMessageReaction(
+    chatId: string | number,
+    messageId: number,
+    reactions: Array<{ type: 'emoji'; emoji: ReactionTypeEmoji['emoji'] }>,
+  ): Promise<unknown>
+}
+
+export interface FirstPaintProgressDriver {
+  startTurn(args: {
+    chatId: string
+    threadId?: string
+    userText: string
+    replyToMessageId?: number
+  }): void
+}
+
+export interface FirstPaintAccess {
+  /** When false, all status-reaction posting is suppressed. */
+  statusReactions?: boolean
+  /** Optional alternate ack emoji used when statusReactions is suppressed. */
+  ackReaction?: string
+}
+
+export interface FirstPaintCtx {
+  chatId: string
+  messageId: number | undefined
+  messageThreadId: number | undefined
+  isSteerPrefix: boolean
+  effectiveText: string
+  /** ms epoch — used for the inbound_ack metric delta. */
+  inboundReceivedAt: number
+  access: FirstPaintAccess
+}
+
+export interface FirstPaintDeps {
+  bot: { api: FirstPaintBotApi }
+  progressDriver: FirstPaintProgressDriver | undefined
+  activeStatusReactions: Map<string, StatusReactionController>
+  activeReactionMsgIds: Map<string, { chatId: string; messageId: number }>
+  activeTurnStartedAt: Map<string, number>
+  progressUpdateTurnCount: Map<string, number>
+  activeDraftStreams: Map<string, DraftStreamHandle>
+  activeDraftParseModes: Map<string, 'HTML' | 'MarkdownV2' | undefined>
+  suppressPtyPreview: Set<string>
+  /** Compute the status/stream key. Production uses `${chatId}:${threadId ?? '_'}`. */
+  statusKey: (chatId: string, threadId?: number) => string
+  streamKey: (chatId: string, threadId?: number) => string
+  /** Wipes activeReactionMsgIds + activeTurnStartedAt for the key. */
+  purgeReactionTracking: (key: string) => void
+  /** Records signal emission (issue #203 metrics). */
+  signalTracker: {
+    noteSignal: (key: string, ts: number) => void
+    reset: (key: string, ts: number) => void
+  }
+  /** Side-channel for active-reactions disk persistence. */
+  resolveAgentDirFromEnv: () => string | null | undefined
+  addActiveReaction: (
+    agentDir: string,
+    entry: { chatId: string; messageId: number; threadId: number | null; reactedAt: number },
+  ) => void
+  /** Streaming-metrics emitter (#203). */
+  logStreamingEvent: (ev: { kind: 'inbound_ack'; chatId: string; messageId: number; ackDelayMs: number }) => void
+  /** Clock — defaults to Date.now in production; tests inject fake. */
+  now?: () => number
+}
+
+export interface FirstPaintResult {
+  isSteering: boolean
+  priorTurnStartedAt: number | undefined
+}
+
+// ─── Seam ────────────────────────────────────────────────────────────────
+
+/**
+ * Run the first-paint slice for an inbound user message. Mirrors lines
+ * 3973-4072 of gateway.ts as of `waiting-ux-harness` head. Returns the
+ * `isSteering` and `priorTurnStartedAt` signals the caller needs to gate
+ * downstream pre-alloc behavior.
+ *
+ * Behavior is identical to inline production:
+ *   - missing msgId → nothing happens (no reaction, no card)
+ *   - prior turn in flight + steer prefix → 🤝 on inbound, no new turn
+ *   - prior turn in flight (queued mid-turn) → 👀 on inbound, no new turn
+ *   - fresh turn → cancel any stale controller, start a new one, setQueued,
+ *     reset signal tracker, persist active-reaction to disk, then
+ *     progressDriver.startTurn
+ *   - access.statusReactions === false + access.ackReaction → custom ack
+ *     emoji on inbound; no controller; no startTurn
+ */
+export async function firstPaintTurn(
+  deps: FirstPaintDeps,
+  ctx: FirstPaintCtx,
+): Promise<FirstPaintResult> {
+  const now = deps.now ?? Date.now
+  const { chatId, messageId: msgId, messageThreadId, isSteerPrefix, effectiveText, inboundReceivedAt, access } = ctx
+
+  let isSteering = false
+  let priorTurnStartedAt: number | undefined
+
+  if (msgId != null) {
+    const key = deps.statusKey(chatId, messageThreadId)
+    const priorActive = deps.activeStatusReactions.get(key)
+    const priorTurnInFlight = priorActive != null
+    isSteering = priorTurnInFlight && isSteerPrefix
+    if (priorTurnInFlight) priorTurnStartedAt = deps.activeTurnStartedAt.get(key)
+
+    if (access.statusReactions !== false) {
+      if (isSteering) {
+        void deps.bot.api
+          .setMessageReaction(chatId, msgId, [{ type: 'emoji', emoji: '🤝' as ReactionTypeEmoji['emoji'] }])
+          .catch(() => {})
+      } else if (priorTurnInFlight) {
+        void deps.bot.api
+          .setMessageReaction(chatId, msgId, [{ type: 'emoji', emoji: '👀' as ReactionTypeEmoji['emoji'] }])
+          .catch(() => {})
+        deps.logStreamingEvent({
+          kind: 'inbound_ack',
+          chatId,
+          messageId: msgId,
+          ackDelayMs: now() - inboundReceivedAt,
+        })
+      } else {
+        // Fresh turn
+        if (priorActive) {
+          priorActive.cancel()
+          deps.purgeReactionTracking(key)
+        }
+        const sKey = deps.streamKey(chatId, messageThreadId)
+        const priorStream = deps.activeDraftStreams.get(sKey)
+        if (priorStream && !priorStream.isFinal()) {
+          deps.activeDraftStreams.delete(sKey)
+          deps.activeDraftParseModes.delete(sKey)
+          await priorStream.finalize().catch(() => {})
+        }
+        deps.suppressPtyPreview.delete(sKey)
+
+        const ctrl = new StatusReactionController(async (emoji) => {
+          await deps.bot.api.setMessageReaction(chatId, msgId, [
+            { type: 'emoji', emoji: emoji as ReactionTypeEmoji['emoji'] },
+          ])
+          deps.signalTracker.noteSignal(key, now())
+        })
+        deps.activeStatusReactions.set(key, ctrl)
+        deps.activeReactionMsgIds.set(key, { chatId, messageId: msgId })
+        deps.activeTurnStartedAt.set(key, now())
+        deps.progressUpdateTurnCount.set(key, 0)
+        ctrl.setQueued()
+        deps.logStreamingEvent({
+          kind: 'inbound_ack',
+          chatId,
+          messageId: msgId,
+          ackDelayMs: now() - inboundReceivedAt,
+        })
+        deps.signalTracker.reset(deps.statusKey(chatId, messageThreadId), now())
+        const agentDir = deps.resolveAgentDirFromEnv()
+        if (agentDir != null) {
+          deps.addActiveReaction(agentDir, {
+            chatId,
+            messageId: msgId,
+            threadId: messageThreadId ?? null,
+            reactedAt: now(),
+          })
+        }
+      }
+    } else if (access.ackReaction) {
+      void deps.bot.api
+        .setMessageReaction(chatId, msgId, [
+          { type: 'emoji', emoji: access.ackReaction as ReactionTypeEmoji['emoji'] },
+        ])
+        .catch(() => {})
+      deps.logStreamingEvent({
+        kind: 'inbound_ack',
+        chatId,
+        messageId: msgId,
+        ackDelayMs: now() - inboundReceivedAt,
+      })
+    }
+  }
+
+  // Start a new progress card only for fresh turns (no prior turn in flight).
+  if (!isSteering && priorTurnStartedAt == null) {
+    try {
+      deps.progressDriver?.startTurn({
+        chatId,
+        threadId: messageThreadId != null ? String(messageThreadId) : undefined,
+        userText: effectiveText,
+        replyToMessageId: msgId != null ? msgId : undefined,
+      })
+    } catch (err) {
+      process.stderr.write(`telegram gateway: progress-card startTurn failed: ${(err as Error).message}\n`)
+    }
+  }
+
+  return { isSteering, priorTurnStartedAt }
+}

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -4008,10 +4008,12 @@ async function handleInbound(
   const isSteering = firstPaintResult.isSteering
   const priorTurnStartedAt = firstPaintResult.priorTurnStartedAt
 
-  // Start a new progress card only for fresh turns (no prior turn in flight).
-  // (progressDriver.startTurn itself is now in firstPaintTurn; the pre-alloc
-  // path below stays inline — it depends on too much module-level state to
-  // include in the seam without ballooning the deps surface.)
+  // Fresh-turn-only block: progressDriver.startTurn already fired inside
+  // firstPaintTurn above. What stays inline here is the pre-alloc draft +
+  // forum-topic placeholder + heartbeat scheduling — gated by the same
+  // !isSteering && no-prior-turn condition because they're all "first
+  // visible signal" siblings of startTurn. They depend on too much
+  // module-level state to fold into the seam without ballooning deps.
   if (!isSteering && priorTurnStartedAt == null) {
     // Issue #416 — pre-allocate a sendMessageDraft for instant visual feedback
     // in DMs. The agent's first stream_reply consumes this draft id instead

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -41,6 +41,7 @@ import {
   type Phase,
 } from '../placeholder-phase.js'
 import { StatusReactionController } from '../status-reactions.js'
+import { firstPaintTurn } from '../first-paint.js'
 import { isTelegramReplyTool, isTelegramSurfaceTool } from '../tool-names.js'
 import { createTypingWrapper } from '../typing-wrap.js'
 import { type DraftStreamHandle } from '../draft-stream.js'
@@ -3970,107 +3971,48 @@ async function handleInbound(
     return
   }
 
-  // Status reaction controller
-  let isSteering = false
-  let priorTurnStartedAt: number | undefined
-  if (msgId != null) {
-    const key = statusKey(chat_id, messageThreadId)
-    const priorActive = activeStatusReactions.get(key)
-    const priorTurnInFlight = priorActive != null
-    // New default: mid-turn messages are queued unless the user explicitly
-    // steers. isSteering is true only when the steer prefix is present.
-    // (Legacy: without any prefix the old behavior was isSteering=true; now
-    // it's false so the message goes through as queued="true".)
-    isSteering = priorTurnInFlight && isSteerPrefix
-    if (priorTurnInFlight) priorTurnStartedAt = activeTurnStartedAt.get(key)
-
-    if (access.statusReactions !== false) {
-      if (isSteering) {
-        // Explicit steer: mark with 🤝 on the inbound message; leave the
-        // existing StatusReactionController running for the in-flight turn.
-        void bot.api.setMessageReaction(chat_id, msgId, [{ type: 'emoji', emoji: '🤝' }]).catch(() => {})
-      } else if (priorTurnInFlight) {
-        // Queued mid-turn message (new default): don't touch the existing
-        // controller; just ack the inbound message with 👀 so the user
-        // knows we received it, without disrupting the in-flight reaction.
-        void bot.api.setMessageReaction(chat_id, msgId, [{ type: 'emoji', emoji: '👀' }]).catch(() => {})
-        // #203: time-to-ack metric — measure gateway-receive → ack-post delta.
-        logStreamingEvent({ kind: 'inbound_ack', chatId: chat_id, messageId: msgId, ackDelayMs: Date.now() - inboundReceivedAt })
-      } else {
-        // Fresh turn (no prior turn in flight): cancel any stale controller
-        // and start a new one for this message.
-        if (priorActive) {
-          priorActive.cancel()
-          purgeReactionTracking(key)
-        }
-        const sKey = streamKey(chat_id, messageThreadId)
-        const priorStream = activeDraftStreams.get(sKey)
-        if (priorStream && !priorStream.isFinal()) {
-          // Closes #472 finding #17 — pre-fix this finalize was
-          // fire-and-forget. The new turn's reply tool would then create
-          // a fresh stream and send its first chunk while the prior
-          // stream's terminal sendMessage was still in flight. The
-          // late-materialise landed AFTER the new turn's content,
-          // visible to the user as a stale "Done" message followed by
-          // the new reply (or worse — duplicate content).
-          //
-          // Awaiting here costs the few hundred ms the final API call
-          // takes, but only on rapid follow-ups where the prior turn
-          // hadn't yet flushed. The latency hit beats the duplicate-
-          // content bug. Delete from the map FIRST so any concurrent
-          // reads can't see the stale stream while we await.
-          activeDraftStreams.delete(sKey)
-          activeDraftParseModes.delete(sKey)
-          await priorStream.finalize().catch(() => {})
-        }
-        suppressPtyPreview.delete(sKey)
-
-        const ctrl = new StatusReactionController(async (emoji) => {
-          await bot.api.setMessageReaction(chat_id, msgId, [
-            { type: 'emoji', emoji: emoji as ReactionTypeEmoji['emoji'] },
-          ])
-          // #203: every status-reaction transition is a user-visible signal.
-          signalTracker.noteSignal(key, Date.now())
-        })
-        activeStatusReactions.set(key, ctrl)
-        activeReactionMsgIds.set(key, { chatId: chat_id, messageId: msgId })
-        activeTurnStartedAt.set(key, Date.now())
-        progressUpdateTurnCount.set(key, 0)  // Reset turn counter
-        ctrl.setQueued()
-        // #203: time-to-ack metric — setQueued() triggers the initial 👀 reaction
-        // asynchronously through the controller chain.
-        logStreamingEvent({ kind: 'inbound_ack', chatId: chat_id, messageId: msgId, ackDelayMs: Date.now() - inboundReceivedAt })
-        // #203: signal tracker — start tracking silent gaps for this fresh turn.
-        signalTracker.reset(statusKey(chat_id, messageThreadId), Date.now())
-        const agentDir = resolveAgentDirFromEnv()
-        if (agentDir != null) {
-          addActiveReaction(agentDir, { chatId: chat_id, messageId: msgId, threadId: messageThreadId ?? null, reactedAt: Date.now() })
-        }
-      }
-    } else if (access.ackReaction) {
-      void bot.api.setMessageReaction(chat_id, msgId, [
-        { type: 'emoji', emoji: access.ackReaction as ReactionTypeEmoji['emoji'] },
-      ]).catch(() => {})
-      // #203: time-to-ack metric for the custom-ack-reaction path.
-      logStreamingEvent({ kind: 'inbound_ack', chatId: chat_id, messageId: msgId, ackDelayMs: Date.now() - inboundReceivedAt })
-    }
-  }
+  // First-paint slice: status-reaction setup + progressDriver.startTurn for
+  // fresh turns. Extracted to telegram-plugin/first-paint.ts so the
+  // waiting-UX harness can drive the real path with fakes (Phase 1 of #545).
+  // Behavior here is unchanged — the seam is a thin wrapper around the
+  // existing logic with module-level state passed via deps.
+  const firstPaintResult = await firstPaintTurn(
+    {
+      bot,
+      progressDriver,
+      activeStatusReactions,
+      activeReactionMsgIds,
+      activeTurnStartedAt,
+      progressUpdateTurnCount,
+      activeDraftStreams,
+      activeDraftParseModes,
+      suppressPtyPreview,
+      statusKey,
+      streamKey,
+      purgeReactionTracking,
+      signalTracker,
+      resolveAgentDirFromEnv,
+      addActiveReaction,
+      logStreamingEvent,
+    },
+    {
+      chatId: chat_id,
+      messageId: msgId,
+      messageThreadId,
+      isSteerPrefix,
+      effectiveText,
+      inboundReceivedAt,
+      access,
+    },
+  )
+  const isSteering = firstPaintResult.isSteering
+  const priorTurnStartedAt = firstPaintResult.priorTurnStartedAt
 
   // Start a new progress card only for fresh turns (no prior turn in flight).
-  // Queued mid-turn messages piggyback on the existing card; steer messages
-  // also don't start a new card (the in-flight turn owns it).
+  // (progressDriver.startTurn itself is now in firstPaintTurn; the pre-alloc
+  // path below stays inline — it depends on too much module-level state to
+  // include in the seam without ballooning the deps surface.)
   if (!isSteering && priorTurnStartedAt == null) {
-    try {
-      progressDriver?.startTurn({
-        chatId: chat_id,
-        threadId: messageThreadId != null ? String(messageThreadId) : undefined,
-        userText: effectiveText,
-        replyToMessageId: msgId != null ? msgId : undefined,
-      })
-    } catch (err) {
-      process.stderr.write(`telegram gateway: progress-card startTurn failed: ${(err as Error).message}\n`)
-    }
-
     // Issue #416 — pre-allocate a sendMessageDraft for instant visual feedback
     // in DMs. The agent's first stream_reply consumes this draft id instead
     // of allocating a new one, so the user sees a placeholder draft within

--- a/telegram-plugin/tests/first-paint.test.ts
+++ b/telegram-plugin/tests/first-paint.test.ts
@@ -1,0 +1,258 @@
+/**
+ * First-paint seam tests — Phase 2 of #545.
+ *
+ * Drives `firstPaintTurn` directly with fake bot api, fake progress driver,
+ * and a stub `controllerFactory`. Measures wall-clock deltas against the
+ * spec-doc deadlines (waiting-ux-spec.md):
+ *
+ *   F2 ("instant draft / status reaction"):
+ *      bot.api.setMessageReaction(... '👀' ...) within 800ms of seam entry.
+ *   F3 ("progress card start"):
+ *      progressDriver.startTurn within 800ms of seam entry. (The spec only
+ *      pins 800ms on the status reaction; we mirror that bound here because
+ *      progress-card start is a synchronous side effect of the same seam
+ *      and shares the "first visible signal" contract.)
+ *
+ * The seam is a pure async fn, so 'within Xms' really means 'before any
+ * fake-timer advance' — we assert with the wall clock pinned, then verify
+ * elapsed-fake-time stays <800ms.
+ *
+ * RED-or-GREEN: Phase 2 is allowed to surface real seam bugs. Do NOT alter
+ * production code to force these green; if a deadline is missed, that's a
+ * bug to file.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import {
+  firstPaintTurn,
+  type FirstPaintCtx,
+  type FirstPaintDeps,
+} from '../first-paint.js'
+import type { StatusReactionController } from '../status-reactions.js'
+import type { DraftStreamHandle } from '../draft-stream.js'
+
+const CHAT = '8248703757'
+const INBOUND_MSG = 100
+const STATUS_REACTION_DEADLINE_MS = 800
+const PROGRESS_CARD_DEADLINE_MS = 800
+
+type ReactionCall = {
+  chatId: string | number
+  messageId: number
+  emoji: string
+  /** Wall-clock at invocation (Date.now under fake timers). */
+  ts: number
+}
+
+type StartTurnCall = {
+  chatId: string
+  threadId?: string
+  userText: string
+  replyToMessageId?: number
+  ts: number
+}
+
+interface Harness {
+  deps: FirstPaintDeps
+  ctx: FirstPaintCtx
+  reactionCalls: ReactionCall[]
+  startTurnCalls: StartTurnCall[]
+  controllerCalls: { setQueued: number; cancel: number }
+  errors: string[]
+}
+
+function makeHarness(overrides: { ctx?: Partial<FirstPaintCtx> } = {}): Harness {
+  const reactionCalls: ReactionCall[] = []
+  const startTurnCalls: StartTurnCall[] = []
+  const controllerCalls = { setQueued: 0, cancel: 0 }
+  const errors: string[] = []
+
+  const fakeController = {
+    setQueued: () => {
+      controllerCalls.setQueued += 1
+    },
+    cancel: () => {
+      controllerCalls.cancel += 1
+    },
+    // Surface enough of the public API to satisfy callers; unused here.
+    setThinking: () => {},
+    setTool: () => {},
+    setCompacting: () => {},
+    setDone: () => {},
+    setSilent: () => {},
+    setError: () => {},
+  } as unknown as StatusReactionController
+
+  const deps: FirstPaintDeps = {
+    bot: {
+      api: {
+        setMessageReaction: async (chatId, messageId, reactions) => {
+          for (const r of reactions) {
+            reactionCalls.push({
+              chatId,
+              messageId,
+              emoji: r.emoji as string,
+              ts: Date.now(),
+            })
+          }
+        },
+      },
+    },
+    progressDriver: {
+      startTurn: (args) => {
+        startTurnCalls.push({ ...args, ts: Date.now() })
+      },
+    },
+    activeStatusReactions: new Map(),
+    activeReactionMsgIds: new Map(),
+    activeTurnStartedAt: new Map(),
+    progressUpdateTurnCount: new Map(),
+    activeDraftStreams: new Map<string, DraftStreamHandle>(),
+    activeDraftParseModes: new Map(),
+    suppressPtyPreview: new Set(),
+    statusKey: (chatId, threadId) => `${chatId}:${threadId ?? '_'}`,
+    streamKey: (chatId, threadId) => `${chatId}:${threadId ?? '_'}`,
+    purgeReactionTracking: () => {},
+    signalTracker: {
+      noteSignal: () => {},
+      reset: () => {},
+    },
+    resolveAgentDirFromEnv: () => null,
+    addActiveReaction: () => {},
+    logStreamingEvent: () => {},
+    controllerFactory: () => fakeController,
+    logError: (m) => {
+      errors.push(m)
+    },
+  }
+
+  const ctx: FirstPaintCtx = {
+    chatId: CHAT,
+    messageId: INBOUND_MSG,
+    messageThreadId: undefined,
+    isSteerPrefix: false,
+    effectiveText: 'hi',
+    inboundReceivedAt: Date.now(),
+    access: { statusReactions: true },
+    ...overrides.ctx,
+  }
+
+  return { deps, ctx, reactionCalls, startTurnCalls, controllerCalls, errors }
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  vi.setSystemTime(new Date('2026-05-01T00:00:00.000Z'))
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('firstPaintTurn — first-paint seam', () => {
+  it('happy path: fresh turn fires status reaction (👀 via setQueued path) and startTurn in order', async () => {
+    const h = makeHarness()
+    const t0 = Date.now()
+
+    await firstPaintTurn(h.deps, h.ctx)
+
+    // Fresh turn: controllerFactory was used, setQueued called once.
+    expect(h.controllerCalls.setQueued).toBe(1)
+    expect(h.controllerCalls.cancel).toBe(0)
+
+    // The fake controller is a stub, so the bot.api.setMessageReaction
+    // path here is exercised only via the steer/queued branches — for a
+    // fresh turn the seam delegates the actual emoji emission to the
+    // controller (which our stub records as `setQueued`). Either way the
+    // FIRST visible signal happens within the seam call. Assert startTurn
+    // fired and the controller was queued before any timer advance.
+    expect(h.startTurnCalls).toHaveLength(1)
+    expect(h.startTurnCalls[0].chatId).toBe(CHAT)
+    expect(h.startTurnCalls[0].userText).toBe('hi')
+    expect(h.startTurnCalls[0].replyToMessageId).toBe(INBOUND_MSG)
+
+    // No fake-time advance happened; both side effects fired synchronously.
+    expect(Date.now() - t0).toBe(0)
+    expect(h.errors).toHaveLength(0)
+  })
+
+  it('F2 — instant draft: status reaction fires within 800ms of seam entry (fresh turn)', async () => {
+    const h = makeHarness()
+    const t0 = Date.now()
+
+    await firstPaintTurn(h.deps, h.ctx)
+
+    // The "first visible signal" for a fresh turn is the controller's
+    // queued state. Production wires this through the controller's emit
+    // callback (which calls bot.api.setMessageReaction with 👀). Our
+    // controllerFactory stub records `setQueued` instead — so we assert
+    // setQueued landed within the deadline.
+    expect(h.controllerCalls.setQueued).toBe(1)
+    const elapsed = Date.now() - t0
+    expect(elapsed).toBeLessThan(STATUS_REACTION_DEADLINE_MS)
+  })
+
+  it('F2 — instant draft (queued mid-turn branch): 👀 reaction fires synchronously within 800ms', async () => {
+    const h = makeHarness()
+    // Simulate prior turn in flight by seeding activeStatusReactions.
+    const key = `${CHAT}:_`
+    const placeholderCtrl = {
+      cancel: () => {},
+      setQueued: () => {},
+    } as unknown as StatusReactionController
+    h.deps.activeStatusReactions.set(key, placeholderCtrl)
+    h.deps.activeTurnStartedAt.set(key, Date.now() - 5_000)
+
+    const t0 = Date.now()
+    await firstPaintTurn(h.deps, h.ctx)
+
+    // Mid-turn queued branch posts 👀 directly via bot.api.
+    const eyes = h.reactionCalls.find((c) => c.emoji === '👀')
+    expect(eyes, 'expected a 👀 reaction call in mid-turn queued branch').toBeDefined()
+    expect((eyes!.ts) - t0).toBeLessThan(STATUS_REACTION_DEADLINE_MS)
+  })
+
+  it('F3 — progress card: startTurn fires within 800ms of seam entry on a fresh turn', async () => {
+    const h = makeHarness()
+    const t0 = Date.now()
+
+    await firstPaintTurn(h.deps, h.ctx)
+
+    expect(h.startTurnCalls).toHaveLength(1)
+    const elapsed = h.startTurnCalls[0].ts - t0
+    expect(elapsed).toBeLessThan(PROGRESS_CARD_DEADLINE_MS)
+  })
+
+  it('F3 — does NOT fire startTurn when a prior turn is in flight (steer branch)', async () => {
+    const h = makeHarness({ ctx: { isSteerPrefix: true } })
+    const key = `${CHAT}:_`
+    const placeholderCtrl = {
+      cancel: () => {},
+      setQueued: () => {},
+    } as unknown as StatusReactionController
+    h.deps.activeStatusReactions.set(key, placeholderCtrl)
+    h.deps.activeTurnStartedAt.set(key, Date.now() - 5_000)
+
+    const result = await firstPaintTurn(h.deps, h.ctx)
+
+    expect(result.isSteering).toBe(true)
+    expect(h.startTurnCalls).toHaveLength(0)
+    // Steer branch posts 🤝, not a new card.
+    expect(h.reactionCalls.find((c) => c.emoji === '🤝')).toBeDefined()
+  })
+
+  it('logError dep captures progress-card startTurn failures (does not write to stderr)', async () => {
+    const h = makeHarness()
+    h.deps.progressDriver = {
+      startTurn: () => {
+        throw new Error('boom')
+      },
+    }
+
+    await firstPaintTurn(h.deps, h.ctx)
+
+    expect(h.errors).toHaveLength(1)
+    expect(h.errors[0]).toContain('progress-card startTurn failed')
+    expect(h.errors[0]).toContain('boom')
+  })
+})

--- a/telegram-plugin/tests/first-paint.test.ts
+++ b/telegram-plugin/tests/first-paint.test.ts
@@ -142,7 +142,6 @@ function makeHarness(overrides: { ctx?: Partial<FirstPaintCtx> } = {}): Harness 
 
 beforeEach(() => {
   vi.useFakeTimers()
-  vi.setSystemTime(new Date('2026-05-01T00:00:00.000Z'))
 })
 
 afterEach(() => {

--- a/telegram-plugin/tests/waiting-ux-harness.ts
+++ b/telegram-plugin/tests/waiting-ux-harness.ts
@@ -1,0 +1,372 @@
+/**
+ * Waiting-UX E2E harness — Phase 1 of #545.
+ *
+ * Wires the production status-reaction controller, progress-card driver,
+ * and a recording fake-bot under vitest fake timers. The goal is to make
+ * the four observed waiting-UX failure modes catchable in CI by asserting
+ * the wall-clock contract that varies by turn class:
+ *   A — instant reply (no tools, <2s)
+ *   B — short turn (1–3 tools, <15s)
+ *   C — long / multi-agent (sub-agents, background workers)
+ *
+ * The harness simulates the slice of server.ts that determines the
+ * user-perceived timing:
+ *   inbound update      → setQueued() (👀)        + progressDriver.startTurn()
+ *   session 'thinking'  → setThinking() (🤔)
+ *   session 'tool_use'  → setTool(name) (🔥/✍/👨‍💻/⚡)
+ *   stream_reply        → editMessageText / sendMessage on bot.api
+ *   session 'turn_end'  → setDone() (👍)          + driver flush + onTurnComplete
+ *
+ * Anything not on that path (auth, history, ipc, foreman) is intentionally
+ * out of scope — those don't influence the four failures.
+ *
+ * Time control is via `vi.useFakeTimers()`; tests advance time with
+ * `clock.advance(ms)` which delegates to `vi.advanceTimersByTimeAsync`.
+ * Every recorded outbound API call is timestamped with the simulated
+ * `Date.now()` at the moment of the call.
+ */
+
+import { vi, type MockInstance } from 'vitest'
+import { StatusReactionController } from '../status-reactions.js'
+import { createProgressDriver, type ProgressDriver } from '../progress-card-driver.js'
+import type { SessionEvent } from '../session-tail.js'
+
+// ─── Recorder ────────────────────────────────────────────────────────────
+
+export type RecordedKind =
+  | 'sendMessage'
+  | 'editMessageText'
+  | 'setMessageReaction'
+  | 'sendChatAction'
+  | 'deleteMessage'
+  | 'pinChatMessage'
+
+export interface RecordedCall {
+  ts: number
+  kind: RecordedKind
+  chat_id: string
+  message_id?: number
+  payload?: string
+  args: unknown[]
+}
+
+export interface Recorder {
+  calls: RecordedCall[]
+  reactionSequence(): string[]
+  sentTexts(chat_id: string): string[]
+  edits(chat_id: string): RecordedCall[]
+  /**
+   * Detects the progress card sendMessage by payload heuristic
+   * (Working… / ⚙️ / ⏳ glyphs that the production card uses).
+   */
+  progressCardSendMs(chat_id: string): number | null
+  firstReactionMs(chat_id: string): number | null
+  lastReactionEmoji(chat_id: string): string | null
+}
+
+// ─── Clock ───────────────────────────────────────────────────────────────
+
+export interface HarnessClock {
+  now(): number
+  advance(ms: number): Promise<void>
+}
+
+// ─── Fake bot.api with recording ─────────────────────────────────────────
+
+type Method = (...args: unknown[]) => Promise<unknown>
+
+export interface FakeBotApi {
+  sendMessage: MockInstance<Method>
+  editMessageText: MockInstance<Method>
+  setMessageReaction: MockInstance<Method>
+  sendChatAction: MockInstance<Method>
+  deleteMessage: MockInstance<Method>
+  pinChatMessage: MockInstance<Method>
+  unpinChatMessage: MockInstance<Method>
+  editMessageReplyMarkup: MockInstance<Method>
+  getFile: MockInstance<Method>
+}
+
+export interface HarnessHandle {
+  bot: { api: FakeBotApi }
+  clock: HarnessClock
+  recorder: Recorder
+  controller: StatusReactionController
+  driver: ProgressDriver
+  inbound(opts: { chatId: string; messageId: number; text?: string }): void
+  feedSessionEvent(ev: SessionEvent): void
+  /** Convenience for class-A direct stream_reply path. */
+  streamReply(opts: { chat_id: string; text: string; done?: boolean }): Promise<void>
+  finalize(): void
+}
+
+function makeRecorderAndApi(): { recorder: Recorder; api: FakeBotApi } {
+  let nextId = 5000
+  const calls: RecordedCall[] = []
+
+  const sendMessage = vi.fn(async (...args: unknown[]) => {
+    const message_id = nextId++
+    calls.push({
+      ts: Date.now(),
+      kind: 'sendMessage',
+      chat_id: String(args[0]),
+      message_id,
+      payload: String(args[1] ?? ''),
+      args,
+    })
+    return { message_id }
+  }) as unknown as MockInstance<Method>
+
+  const editMessageText = vi.fn(async (...args: unknown[]) => {
+    calls.push({
+      ts: Date.now(),
+      kind: 'editMessageText',
+      chat_id: String(args[0]),
+      message_id: Number(args[1]),
+      payload: String(args[2] ?? ''),
+      args,
+    })
+    return true
+  }) as unknown as MockInstance<Method>
+
+  const setMessageReaction = vi.fn(async (...args: unknown[]) => {
+    const reactions = args[2] as Array<{ emoji?: string }> | undefined
+    const emoji = reactions?.[0]?.emoji
+    calls.push({
+      ts: Date.now(),
+      kind: 'setMessageReaction',
+      chat_id: String(args[0]),
+      message_id: Number(args[1]),
+      payload: emoji,
+      args,
+    })
+    return true
+  }) as unknown as MockInstance<Method>
+
+  const sendChatAction = vi.fn(async (...args: unknown[]) => {
+    calls.push({
+      ts: Date.now(),
+      kind: 'sendChatAction',
+      chat_id: String(args[0]),
+      payload: String(args[1] ?? ''),
+      args,
+    })
+    return true
+  }) as unknown as MockInstance<Method>
+
+  const deleteMessage = vi.fn(async (...args: unknown[]) => {
+    calls.push({
+      ts: Date.now(),
+      kind: 'deleteMessage',
+      chat_id: String(args[0]),
+      message_id: Number(args[1]),
+      args,
+    })
+    return true
+  }) as unknown as MockInstance<Method>
+
+  const pinChatMessage = vi.fn(async (...args: unknown[]) => {
+    calls.push({
+      ts: Date.now(),
+      kind: 'pinChatMessage',
+      chat_id: String(args[0]),
+      message_id: Number(args[1]),
+      args,
+    })
+    return true
+  }) as unknown as MockInstance<Method>
+
+  const unpinChatMessage = vi.fn(async () => true) as unknown as MockInstance<Method>
+  const editMessageReplyMarkup = vi.fn(async () => true) as unknown as MockInstance<Method>
+  const getFile = vi.fn(async () => ({ file_path: 'x' })) as unknown as MockInstance<Method>
+
+  const api: FakeBotApi = {
+    sendMessage,
+    editMessageText,
+    setMessageReaction,
+    sendChatAction,
+    deleteMessage,
+    pinChatMessage,
+    unpinChatMessage,
+    editMessageReplyMarkup,
+    getFile,
+  }
+
+  const isCardPayload = (text: string | undefined): boolean =>
+    text != null &&
+    (text.includes('Working') ||
+      text.includes('⚙') ||
+      text.includes('⏳') ||
+      text.includes('• '))
+
+  const recorder: Recorder = {
+    calls,
+    reactionSequence: () =>
+      calls.filter((c) => c.kind === 'setMessageReaction').map((c) => c.payload ?? ''),
+    sentTexts: (chat_id) =>
+      calls
+        .filter((c) => c.kind === 'sendMessage' && c.chat_id === chat_id)
+        .map((c) => c.payload ?? ''),
+    edits: (chat_id) => calls.filter((c) => c.kind === 'editMessageText' && c.chat_id === chat_id),
+    progressCardSendMs: (chat_id) => {
+      const hit = calls.find(
+        (c) => c.kind === 'sendMessage' && c.chat_id === chat_id && isCardPayload(c.payload),
+      )
+      return hit ? hit.ts : null
+    },
+    firstReactionMs: (chat_id) => {
+      const hit = calls.find((c) => c.kind === 'setMessageReaction' && c.chat_id === chat_id)
+      return hit ? hit.ts : null
+    },
+    lastReactionEmoji: (chat_id) => {
+      const hits = calls.filter((c) => c.kind === 'setMessageReaction' && c.chat_id === chat_id)
+      return hits.length === 0 ? null : (hits[hits.length - 1].payload ?? null)
+    },
+  }
+
+  return { recorder, api }
+}
+
+// ─── Public factory ──────────────────────────────────────────────────────
+
+export interface CreateHarnessOpts {
+  allowedReactions?: Set<string> | null
+  debounceMs?: number
+  driverCoalesceMs?: number
+  driverMinIntervalMs?: number
+  /**
+   * Progress-card initial-delay-ms. Production default is 30s (cards are
+   * suppressed for fast turns). Tests for class B/C should set this small
+   * (e.g. 0–500) so the deferred first emit can fire inside the test.
+   */
+  driverInitialDelayMs?: number
+  /** Heartbeat ms; pass 0 to disable. */
+  driverHeartbeatMs?: number
+}
+
+export function createWaitingUxHarness(opts: CreateHarnessOpts = {}): HarnessHandle {
+  // vi.useFakeTimers() must be called by the test (so afterEach can reset).
+  // The harness assumes fake timers are active.
+  const { recorder, api } = makeRecorderAndApi()
+  const bot = { api }
+
+  let primaryChatId: string | null = null
+  let primaryMessageId: number | null = null
+  let currentChatId: string | null = null
+
+  const controller = new StatusReactionController(
+    async (emoji) => {
+      if (primaryChatId == null || primaryMessageId == null) return
+      await api.setMessageReaction(primaryChatId, primaryMessageId, [
+        { type: 'emoji', emoji },
+      ])
+    },
+    opts.allowedReactions ?? null,
+    {
+      debounceMs: opts.debounceMs ?? 700,
+    },
+  )
+
+  const cardMessageIds = new Map<string, number>()
+
+  async function renderCard(a: { chatId: string; html: string; done: boolean; isFirstEmit: boolean }): Promise<void> {
+    const existing = cardMessageIds.get(a.chatId)
+    if (existing == null) {
+      const result = (await api.sendMessage(a.chatId, a.html, { parse_mode: 'HTML' })) as { message_id: number }
+      cardMessageIds.set(a.chatId, result.message_id)
+    } else {
+      await api.editMessageText(a.chatId, existing, a.html, { parse_mode: 'HTML' })
+    }
+  }
+
+  const driver = createProgressDriver({
+    emit: (a) => {
+      void renderCard(a)
+    },
+    coalesceMs: opts.driverCoalesceMs ?? 400,
+    minIntervalMs: opts.driverMinIntervalMs ?? 500,
+    initialDelayMs: opts.driverInitialDelayMs ?? 30000,
+    heartbeatMs: opts.driverHeartbeatMs,
+  })
+
+  function feedSessionEvent(ev: SessionEvent): void {
+    switch (ev.kind) {
+      case 'enqueue':
+        if (ev.chatId) currentChatId = ev.chatId
+        break
+      case 'thinking':
+        controller.setThinking()
+        break
+      case 'tool_use':
+        if (!isTelegramSurfaceTool(ev.toolName)) {
+          controller.setTool(ev.toolName)
+        }
+        break
+      case 'turn_end':
+        controller.setDone()
+        break
+      default:
+        break
+    }
+    driver.ingest(ev, currentChatId, undefined)
+  }
+
+  function inbound(args: { chatId: string; messageId: number; text?: string }): void {
+    primaryChatId = args.chatId
+    primaryMessageId = args.messageId
+    // 👀 immediately — same line as server.ts:6118.
+    controller.setQueued()
+    // Prime the progress card synchronously, same as server.ts:6147.
+    driver.startTurn({ chatId: args.chatId, userText: args.text ?? '' })
+  }
+
+  const streamMsgs = new Map<string, number>()
+
+  async function streamReply(args: { chat_id: string; text: string; done?: boolean }): Promise<void> {
+    const key = args.chat_id
+    const existingId = streamMsgs.get(key)
+    if (existingId == null) {
+      const r = (await api.sendMessage(args.chat_id, args.text, { parse_mode: 'HTML' })) as { message_id: number }
+      streamMsgs.set(key, r.message_id)
+    } else {
+      await api.editMessageText(args.chat_id, existingId, args.text, { parse_mode: 'HTML' })
+    }
+    if (args.done === true) {
+      controller.setDone()
+    }
+  }
+
+  function finalize(): void {
+    try { driver.dispose?.() } catch { /* ignore */ }
+  }
+
+  const clock: HarnessClock = {
+    now: () => Date.now(),
+    advance: async (ms) => {
+      await vi.advanceTimersByTimeAsync(ms)
+    },
+  }
+
+  return {
+    bot,
+    clock,
+    recorder,
+    controller,
+    driver,
+    inbound,
+    feedSessionEvent,
+    streamReply,
+    finalize,
+  }
+}
+
+function isTelegramSurfaceTool(name: string): boolean {
+  const n = name.toLowerCase()
+  return (
+    n.endsWith('__reply') ||
+    n.endsWith('__stream_reply') ||
+    n.endsWith('__edit_message') ||
+    n === 'reply' ||
+    n === 'stream_reply'
+  )
+}

--- a/telegram-plugin/tests/waiting-ux-harness.ts
+++ b/telegram-plugin/tests/waiting-ux-harness.ts
@@ -343,7 +343,16 @@ export function createWaitingUxHarness(opts: CreateHarnessOpts = {}): HarnessHan
   const clock: HarnessClock = {
     now: () => Date.now(),
     advance: async (ms) => {
-      await vi.advanceTimersByTimeAsync(ms)
+      // vi.advanceTimersByTimeAsync isn't implemented by Bun's vitest shim,
+      // so fall back to the sync variant + microtask flush. Same semantics
+      // for these tests; lets the harness run under both vitest and `bun test`.
+      const viAny = vi as { advanceTimersByTimeAsync?: (ms: number) => Promise<void> }
+      if (typeof viAny.advanceTimersByTimeAsync === 'function') {
+        await viAny.advanceTimersByTimeAsync(ms)
+        return
+      }
+      vi.advanceTimersByTime(ms)
+      for (let i = 0; i < 5; i++) await Promise.resolve()
     },
   }
 

--- a/telegram-plugin/tests/waiting-ux.e2e.test.ts
+++ b/telegram-plugin/tests/waiting-ux.e2e.test.ts
@@ -1,0 +1,235 @@
+/**
+ * Waiting-UX E2E contract tests — Phase 1 of #545 (RED).
+ *
+ * These tests assert the deterministic time-sequence contract for the
+ * three turn classes specified in #545. They are intentionally RED on
+ * `main` — each one catches one of the four observed failure modes from
+ * the live demo:
+ *
+ *   F1. Status reaction collapses straight to 👍 (skips 👀→🤔→🔥).
+ *   F2. No instant draft/typing signal — silence "for ages" after inbound.
+ *   F3. Progress card renders late.
+ *   F4. Pre-tool interim text is static — no refresh on step transitions.
+ *
+ * Phase 1 scope is tests-only — no production fixes. Once these go green
+ * we know the underlying behaviour matches the spec.
+ *
+ * All time control is via `vi.useFakeTimers()`. The harness records every
+ * outbound bot.api call with `Date.now()` at invocation time, so first-
+ * paint and ladder assertions are wall-clock deterministic.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { createWaitingUxHarness, type HarnessHandle } from './waiting-ux-harness.js'
+import type { SessionEvent } from '../session-tail.js'
+
+const CHAT = '8248703757'
+const INBOUND_MSG = 100
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  // Pin the clock to a recognisable epoch so ts deltas are easy to read.
+  vi.setSystemTime(new Date('2026-05-01T00:00:00.000Z'))
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+// ─── Class A — Instant reply (no tool calls, <2s) ────────────────────────
+
+describe('Class A — instant reply', () => {
+  it('first-paint deadline: 👀 reaction lands within 800ms of inbound (catches F2)', async () => {
+    const h = createWaitingUxHarness()
+    const inboundAt = h.clock.now()
+    h.inbound({ chatId: CHAT, messageId: INBOUND_MSG, text: 'hi' })
+    // Allow microtasks + the controller's queued (immediate, no debounce).
+    await h.clock.advance(50)
+    const firstReaction = h.recorder.firstReactionMs(CHAT)
+    expect(firstReaction).not.toBeNull()
+    expect((firstReaction ?? Infinity) - inboundAt).toBeLessThan(800)
+    expect(h.recorder.reactionSequence()[0]).toBe('👀')
+    h.finalize()
+  })
+
+  it('no progress card is sent for an instant turn (catches F3 / spec class A)', async () => {
+    const h = createWaitingUxHarness({ driverInitialDelayMs: 30_000 })
+    h.inbound({ chatId: CHAT, messageId: INBOUND_MSG, text: 'hi' })
+    // Class A: enqueue → small thinking burst → reply → turn_end, all <2s.
+    h.feedSessionEvent({ kind: 'enqueue', chatId: CHAT, messageId: '1', threadId: null, rawContent: 'hi' })
+    await h.clock.advance(100)
+    h.feedSessionEvent({ kind: 'thinking' })
+    await h.clock.advance(200)
+    await h.streamReply({ chat_id: CHAT, text: 'hello back', done: true })
+    h.feedSessionEvent({ kind: 'turn_end', durationMs: 1500 })
+    await h.clock.advance(2_000)
+    expect(h.recorder.progressCardSendMs(CHAT)).toBeNull()
+    h.finalize()
+  })
+
+  it('terminates with 👍 and no spurious intermediate states', async () => {
+    const h = createWaitingUxHarness()
+    h.inbound({ chatId: CHAT, messageId: INBOUND_MSG, text: 'hi' })
+    h.feedSessionEvent({ kind: 'enqueue', chatId: CHAT, messageId: '1', threadId: null, rawContent: 'hi' })
+    await h.clock.advance(50)
+    await h.streamReply({ chat_id: CHAT, text: 'hello back', done: true })
+    h.feedSessionEvent({ kind: 'turn_end', durationMs: 800 })
+    await h.clock.advance(1_500)
+    expect(h.recorder.lastReactionEmoji(CHAT)).toBe('👍')
+    h.finalize()
+  })
+})
+
+// ─── Class B — short turn (1–3 tools, <15s) ──────────────────────────────
+
+describe('Class B — short turn', () => {
+  it('ladder integrity: 👀 → (🤔 or working glyph) before 👍 — catches F1 (straight-to-👍 collapse)', async () => {
+    const h = createWaitingUxHarness({ debounceMs: 700 })
+    h.inbound({ chatId: CHAT, messageId: INBOUND_MSG, text: 'read foo.txt' })
+    h.feedSessionEvent({ kind: 'enqueue', chatId: CHAT, messageId: '1', threadId: null, rawContent: 'read foo.txt' })
+    // 200ms in — model starts thinking
+    await h.clock.advance(200)
+    h.feedSessionEvent({ kind: 'thinking' })
+    // 1s in — Read tool (debounced by 700ms — should still land before turn_end)
+    await h.clock.advance(800)
+    h.feedSessionEvent({ kind: 'tool_use', toolName: 'Read', toolUseId: 't1' })
+    // Wait long enough for the tool reaction to flush past debounce.
+    await h.clock.advance(1_500)
+    h.feedSessionEvent({ kind: 'tool_result', toolUseId: 't1', toolName: 'Read' })
+    await h.streamReply({ chat_id: CHAT, text: 'contents: ...', done: true })
+    h.feedSessionEvent({ kind: 'turn_end', durationMs: 4_000 })
+    await h.clock.advance(2_000)
+
+    const seq = h.recorder.reactionSequence()
+    // Must start with 👀
+    expect(seq[0]).toBe('👀')
+    // Must NOT collapse straight to 👍 — at least one intermediate before final.
+    expect(seq.length).toBeGreaterThanOrEqual(3)
+    const finalIdx = seq.length - 1
+    expect(seq[finalIdx]).toBe('👍')
+    // Intermediate states must include a thinking/working emoji, not just 👀.
+    const intermediates = seq.slice(1, finalIdx)
+    const hasIntermediate = intermediates.some((e) =>
+      ['🤔', '🤓', '✍', '⚡', '👌', '👨‍💻', '🔥'].includes(e),
+    )
+    expect(hasIntermediate, `ladder collapsed: ${JSON.stringify(seq)}`).toBe(true)
+    h.finalize()
+  })
+
+  it('interim refresh: pre-tool preamble updates ≥1× across step transitions (catches F4)', async () => {
+    const h = createWaitingUxHarness()
+    h.inbound({ chatId: CHAT, messageId: INBOUND_MSG, text: 'do thing' })
+    h.feedSessionEvent({ kind: 'enqueue', chatId: CHAT, messageId: '1', threadId: null, rawContent: 'do thing' })
+    // Initial preamble before any tool runs.
+    await h.streamReply({ chat_id: CHAT, text: 'looking…' })
+    await h.clock.advance(500)
+    // Step transition #1 — tool_use lands.
+    h.feedSessionEvent({ kind: 'tool_use', toolName: 'Read', toolUseId: 't1' })
+    await h.clock.advance(500)
+    // Step transition #2 — second different tool category.
+    h.feedSessionEvent({ kind: 'tool_use', toolName: 'WebFetch', toolUseId: 't2' })
+    await h.clock.advance(500)
+    await h.streamReply({ chat_id: CHAT, text: 'final answer', done: true })
+    h.feedSessionEvent({ kind: 'turn_end', durationMs: 3_000 })
+
+    // Across the two step transitions we must see ≥1 update to the
+    // pre-tool preamble surface (sendMessage or editMessageText for the
+    // active stream). Today's behaviour: a single static preamble then
+    // silence — this assertion catches that.
+    const edits = h.recorder.edits(CHAT)
+    expect(edits.length, 'pre-tool preamble never refreshed').toBeGreaterThanOrEqual(1)
+    h.finalize()
+  })
+})
+
+// ─── Class C — long / multi-agent ────────────────────────────────────────
+
+describe('Class C — long / multi-agent', () => {
+  it('progress card renders early, before turn_end, for a multi-second turn (catches F3)', async () => {
+    const h = createWaitingUxHarness({
+      driverInitialDelayMs: 500, // production tunes this; harness asserts the contract
+      driverCoalesceMs: 100,
+      driverMinIntervalMs: 100,
+    })
+    const inboundAt = h.clock.now()
+    h.inbound({ chatId: CHAT, messageId: INBOUND_MSG, text: 'big task' })
+    h.feedSessionEvent({ kind: 'enqueue', chatId: CHAT, messageId: '1', threadId: null, rawContent: 'big task' })
+    await h.clock.advance(200)
+    h.feedSessionEvent({ kind: 'thinking' })
+    await h.clock.advance(300)
+    h.feedSessionEvent({ kind: 'tool_use', toolName: 'Bash', toolUseId: 't1' })
+    // By 2s, the card MUST be visible — not at turn_end.
+    await h.clock.advance(1_500)
+    const cardAt = h.recorder.progressCardSendMs(CHAT)
+    expect(cardAt, 'progress card never rendered').not.toBeNull()
+    expect((cardAt ?? Infinity) - inboundAt).toBeLessThan(2_500)
+    // Drain the rest of the turn so afterEach doesn't leak timers.
+    h.feedSessionEvent({ kind: 'tool_result', toolUseId: 't1', toolName: 'Bash' })
+    await h.streamReply({ chat_id: CHAT, text: 'done', done: true })
+    h.feedSessionEvent({ kind: 'turn_end', durationMs: 5_000 })
+    await h.clock.advance(2_000)
+    h.finalize()
+  })
+
+  it('card stays stable until ALL background work hits terminal — Done ≥ last sub-agent terminal', async () => {
+    const h = createWaitingUxHarness({
+      driverInitialDelayMs: 200,
+      driverCoalesceMs: 100,
+      driverMinIntervalMs: 100,
+    })
+    h.inbound({ chatId: CHAT, messageId: INBOUND_MSG, text: 'multi-agent' })
+    h.feedSessionEvent({ kind: 'enqueue', chatId: CHAT, messageId: '1', threadId: null, rawContent: 'multi-agent' })
+    await h.clock.advance(300)
+    // Spawn two sub-agents.
+    h.feedSessionEvent({ kind: 'sub_agent_started', agentId: 'a1', firstPromptText: 'a1' })
+    h.feedSessionEvent({ kind: 'sub_agent_started', agentId: 'a2', firstPromptText: 'a2' })
+    await h.clock.advance(1_000)
+    // a1 finishes early.
+    h.feedSessionEvent({ kind: 'sub_agent_turn_end', agentId: 'a1' })
+    const a1TerminalAt = h.clock.now()
+    await h.clock.advance(2_000)
+    // Main turn_end arrives BEFORE a2 finishes — the card must NOT mark
+    // Done yet (spec: stable until all workers terminal).
+    h.feedSessionEvent({ kind: 'turn_end', durationMs: 3_000 })
+    await h.clock.advance(500)
+    // a2 finishes last — this is the true terminal.
+    h.feedSessionEvent({ kind: 'sub_agent_turn_end', agentId: 'a2' })
+    const a2TerminalAt = h.clock.now()
+    await h.clock.advance(2_000)
+
+    // Find the card edit/send that marks Done. Production cards
+    // typically include a "Done" / "✅" / "✓" glyph in the final HTML.
+    const cardOps = h.recorder.calls.filter(
+      (c) =>
+        (c.kind === 'sendMessage' || c.kind === 'editMessageText') &&
+        c.chat_id === CHAT &&
+        (c.payload?.includes('Done') === true ||
+          c.payload?.includes('✅') === true ||
+          c.payload?.includes('✓') === true),
+    )
+    expect(cardOps.length, 'card never reached a Done state').toBeGreaterThan(0)
+    const doneAt = cardOps[cardOps.length - 1].ts
+    expect(
+      doneAt,
+      `card Done (${doneAt}) fired before last sub-agent terminal (${a2TerminalAt})`,
+    ).toBeGreaterThanOrEqual(a2TerminalAt)
+    // Sanity: a1 was earlier than a2.
+    expect(a1TerminalAt).toBeLessThan(a2TerminalAt)
+    h.finalize()
+  })
+
+  it('first-paint deadline still ≤800ms even on long turns', async () => {
+    const h = createWaitingUxHarness({ driverInitialDelayMs: 500 })
+    const inboundAt = h.clock.now()
+    h.inbound({ chatId: CHAT, messageId: INBOUND_MSG, text: 'long' })
+    await h.clock.advance(50)
+    const firstReaction = h.recorder.firstReactionMs(CHAT)
+    expect(firstReaction).not.toBeNull()
+    expect((firstReaction ?? Infinity) - inboundAt).toBeLessThan(800)
+    // Cleanup.
+    h.feedSessionEvent({ kind: 'enqueue', chatId: CHAT, messageId: '1', threadId: null, rawContent: 'long' })
+    h.feedSessionEvent({ kind: 'turn_end', durationMs: 100 })
+    await h.clock.advance(2_000)
+    h.finalize()
+  })
+})

--- a/telegram-plugin/tests/waiting-ux.e2e.test.ts
+++ b/telegram-plugin/tests/waiting-ux.e2e.test.ts
@@ -28,8 +28,6 @@ const INBOUND_MSG = 100
 
 beforeEach(() => {
   vi.useFakeTimers()
-  // Pin the clock to a recognisable epoch so ts deltas are easy to read.
-  vi.setSystemTime(new Date('2026-05-01T00:00:00.000Z'))
 })
 
 afterEach(() => {


### PR DESCRIPTION
## Summary

Phase 1 of #545. Lands the spec doc and a fake-timer E2E harness that wires the real `StatusReactionController` + `createProgressDriver` against a recording fake `bot.api`, plus eight tests covering the three turn classes from the spec (A instant / B short / C long).

- `telegram-plugin/docs/waiting-ux-spec.md` — codifies the timing contract per turn class and the four observed failure modes (F1-F4).
- `telegram-plugin/tests/waiting-ux-harness.ts` — recorder + controller/driver wiring.
- `telegram-plugin/tests/waiting-ux.e2e.test.ts` — eight tests asserting first-paint deadlines, ladder integrity, card timing, interim refresh, and "Done ≥ last sub-agent terminal".

All 8 tests are currently green against `main`.

## Honest scope note

The harness drives `controller.*` and `driver.*` methods directly via a hand-written adapter that mirrors `gateway/gateway.ts`'s session-tail dispatcher branches. This means:

- It DOES catch regressions inside `StatusReactionController` and `createProgressDriver`.
- It does NOT catch failures introduced by gateway-side message gating, foreman queueing, or session-tail parser bugs.

The four observed UX failures from the live demo (F1-F4) may originate above this layer. A Phase 2 harness that drives the real gateway through a synthetic update stream is filed as a follow-up — see "Known limitation" in the spec doc. Until that lands, integration-boundary regressions remain CI-invisible.

## Test plan

- [x] `bunx vitest run telegram-plugin/tests/waiting-ux.e2e.test.ts` → 8/8 pass
- [ ] CI (root vitest) green on this PR

Refs #545

## Phase 2 update

- Extracted `firstPaintTurn` seam from `gateway.ts` into `telegram-plugin/first-paint.ts` (commit `6e64a46`).
- Tightened the seam with `controllerFactory` + `logError` deps; added 6 tests in `telegram-plugin/tests/first-paint.test.ts` covering F2/F3 deadlines plus steer/queued branches (commit `682cf50`).
- **Honest finding:** all tests pass at the seam because `firstPaintTurn` is sync-async and every side effect fires before return — sub-second deadlines are trivially satisfied. The real F2/F3 failures live upstream (gateway coalescing, foreman queue gating, IPC bridge, polling latency). Phase 3 needed.
- Phase 3 tracked in #553 — a real-gateway synthetic-update harness that drives `gateway.ts` end-to-end so F1–F4 regressions become CI-visible.
