### PR TITLE
docs: overnight accuracy sweep (2026-05-02)

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Switchroom is **not a harness**. Each agent runs the unmodified `claude` binary,
 | **Persistent memory** | Hindsight semantic memory with knowledge graphs. |
 | **Session continuity** | Resume sessions across restarts with freshness gating. |
 | **Encrypted vault** | AES-256-GCM for secrets. |
-| **10 Telegram MCP tools** | Reply, pin, react, history, attachments, stream progress, all of it. |
+| **12 Telegram MCP tools** | Reply, stream replies, pin, react, history, attachments, native checklists, all of it. |
 
 ## How it stacks up against the alternatives
 
@@ -272,9 +272,15 @@ switchroom restart [agent] [--force]          # Bounce agent(s); drains in-fligh
 switchroom version                            # Show versions + running agent health summary
 
 switchroom agent list                         # Status of all agents
+switchroom agent status <name>                # Status of one agent
+switchroom agent add [name]                   # Wizard: scaffold a new agent end-to-end (#543)
 switchroom agent create <name> [--profile <p>] # Scaffold + install timers; --profile writes yaml entry
+switchroom agent bootstrap <name> --profile <p> --bot-token <t>  # One-shot scaffold + auth + start
 switchroom agent reconcile <name|all>         # Re-apply switchroom.yaml (without pulling/building)
 switchroom agent start|stop|restart <name>    # Lifecycle (with preflight)
+switchroom agent interrupt <name>             # Cancel in-flight turn without restarting
+switchroom agent rename <old> <new>           # Rename an agent slug (#168)
+switchroom agent destroy <name>               # Tear down systemd units + scaffold dir
 switchroom agent attach <name>                # Interactive tmux session
 switchroom agent logs <name> [-f]             # View logs
 switchroom agent grant <name> <tool>          # Grant a tool permission

--- a/docs/REVIEW-2026-05-02.md
+++ b/docs/REVIEW-2026-05-02.md
@@ -1,0 +1,138 @@
+# Doc Review Punch List — 2026-05-02
+
+Overnight accuracy sweep, follow-ups requiring judgement (Ken to triage).
+Items here are *not* one-line accuracy fixes (those landed directly in this
+PR). They are restructures, voice calls, or features whose shipping status
+I could not confirm from code alone.
+
+## High signal
+
+- **`docs/sub-agents.md`** — does not mention `progress_update` (the
+  sub-agent → progress card hook the parent task brief calls out). Code
+  evidence: `telegram-plugin/progress-card.ts`,
+  `telegram-plugin/tests/progress-update.test.ts`,
+  `src/agents/sub-agent-telegram-prompt.ts`. Recommendation: add a short
+  "Live progress in the parent's card" section explaining how a sub-agent's
+  tool calls surface in the parent agent's progress card and how
+  `progress_update` is wired in via the sub-agent prompt.
+
+- **`docs/telegram-plugin.md` (entire file)** — read flows top-to-bottom but
+  the "Streaming modes" section is tucked under "Opting out", which is
+  semantically wrong (streaming applies to the switchroom fork, not to
+  opting out of it). Recommendation: promote "Streaming modes" to a
+  top-level section above "Opting out".
+
+- **`docs/architecture.md`** — not opened in this sweep beyond the
+  reference from README. Worth a careful pass for the gateway/server
+  split (#235 wave 3 F4 cleanup deleted the legacy monolith on
+  2026-05-01) — confirm the architecture diagram matches the current
+  bridge ↔ gateway IPC layout. See `telegram-plugin/docs/gateway-server-split.md`
+  for the canonical inventory.
+
+- **`telegram-plugin/README.md`** — "Switchroom slash-commands" bullet
+  (line 36) lists `/agents`, `/restart`, `/logs`, `/memory`, `/grant`,
+  `/dangerous`, `/permissions`, `/reconcile`. The list is correct, but
+  the reader has to scroll to "Switchroom bot commands" further down to
+  see the auth router (`/auth …`). Worth a one-line cross-reference and
+  a mention that #527 (Wave 1 surface rename) renamed
+  `/switchroomstart` → `/agentstart` and `/switchroomhelp` → `/commands`.
+
+- **`README.md`** — "Architecture" section's ASCII diagram lists
+  `Hindsight plugin (memory)` under Claude Code CLI but does not mention
+  the gateway daemon (long-running systemd unit that the MCP bridge
+  proxies into). Casual readers may not realise the gateway is a
+  *separate* persistent process — the model-side bridge is ephemeral.
+  Recommendation: extend the diagram or add one sentence calling out the
+  gateway daemon vs. the per-session MCP bridge.
+
+## Medium signal
+
+- **`README.md` install snippet** — `switchroom auth login coach` is
+  shown as the post-create step. With the new `agent bootstrap` and
+  `agent add` wizard, the recommended path is now arguably
+  `switchroom agent add` for new users (it handles scaffold + auth +
+  start in one wizard). Recommendation: lead with `agent add` for the
+  "first time" flow and demote the manual three-step recipe to a
+  "scripted / advanced" subsection.
+
+- **`docs/telegram-plugin.md` "Auto-fallback on quota exhaustion"** —
+  references `telegram-plugin/auto-fallback.ts` and
+  `src/auth/accounts.ts`. Both files exist. But the doc does not
+  describe the *user-visible* notice ("Slot X exhausted, swapped to
+  slot Y") nor the multi-account banner shown in chat. Worth one extra
+  paragraph so users know what to expect to see.
+
+- **`docs/configuration.md`** (not deeply reviewed) — confirm the
+  `channels.telegram.stream_mode` field, the `secrets:` per-cron field,
+  the `subagents:` cascade behaviour, and the `vault.broker.autoUnlock`
+  flag are all documented in the field reference. If any are missing
+  the doc is undersold. Spot-check only — needs a careful pass.
+
+- **`reference/know-what-my-agent-is-doing.md`** — referenced from
+  agent CLAUDE.md as the source-of-truth for the "status?" UX-failure
+  rule. Worth confirming the doc still aligns with the agent CLAUDE.md
+  wording so the two don't drift.
+
+- **`telegram-plugin/README.md` "Setup" section** — still says
+  `bun server.ts` as the start command. server.ts now exists as a
+  thin dispatcher (the legacy 6661-line monolith was deleted in
+  9814485 / Wave 3 F4 / #235). The `bun server.ts` command still
+  works, but new readers might benefit from a note that the gateway
+  daemon is the production path and `server.ts` is the dispatcher
+  that delegates to it. Same applies to the `telegram-plugin/docs/gateway-server-split.md`
+  reference.
+
+## Low signal / housekeeping
+
+- **`README.md` "Documentation" table** — does not link
+  `docs/auto-unlock.md`, `docs/vault-broker.md`, `docs/skills.md`,
+  `docs/streaming-deterministic.md`, `docs/workspace-files.md`,
+  `docs/architecture.md`, `docs/publishing.md`. Some are rightly
+  internal/contributor-only, but `architecture.md` and `auto-unlock.md`
+  are user-facing and arguably belong in the table.
+
+- **`README.md`** — telemetry section mentions PostHog opt-out but
+  does not say what to do with the `~/.switchroom/analytics-id` file
+  on shared machines. Edge case, low priority.
+
+- **`README.md` FAQ** — could add "How does multi-account / quota
+  fallback work?" as a question, given the heavy week of slot work
+  (multi-account auth, auto-failover). The answer is in the body but
+  there is no FAQ entry pointing readers there.
+
+- **CHANGELOG.md "Unreleased"** — current entry only mentions the
+  switchroom-mcp removal. The "heavy week of shipping" enumerated in
+  the parent task (multi-account auth, auto-failover, checklists,
+  inline keyboards, accent headers, scheduled-task refactor #269/#251,
+  sanitizer, vault broker auto-unlock #538/#540/#541, agent doctor
+  scaffold) is present in earlier release sections (#272 / #271 /
+  #328 / vault entries are all in v0.4.0) — but anything shipped on
+  main *after* v0.4.0 (2026-04-29) belongs under Unreleased. Quick
+  triage: agent rename (#168), agent add wizard (#543), vault auto-
+  unlock UX overhaul (#538/#539/#540/#541), agent destroy, agent
+  interrupt, gateway split Wave 3 F4 (#235/#536), gateway-split docs
+  inventory (#529/#534/#88), boot-card / heartbeat refinements (#519
+  / #531), `/auth` router on Telegram side. Verify each landed on
+  main since v0.4.0, then add to Unreleased.
+
+## Out of scope (no action)
+
+- `clerk-export/` — opaque data dump from another agent; not part of
+  the public surface. Skip.
+- `.claude/worktrees/` — branch worktrees, not real docs.
+- `vendor/hindsight-memory/` — vendored repo with its own README.
+- `profiles/*/skills/*/SKILL.md` — bundled skills, not user docs.
+- `skills/buildkite-*/` — buildkite-specific skills, separate concern.
+- `private/` — private overlays.
+
+## What landed in this sweep
+
+- `README.md` — fixed "10 MCP tools" → 12; added `agent add`,
+  `bootstrap`, `interrupt`, `rename`, `destroy`, `status` to the CLI
+  reference (all shipped, were invisible).
+- `docs/telegram-plugin.md` — refreshed the tool table to include
+  `send_checklist` / `update_checklist` (#272), documented the
+  `accent` parameter (#328), and added an "Inline keyboard URL
+  buttons" subsection (#271).
+- `telegram-plugin/README.md` — bumped tool count and named the two
+  checklist tools.

--- a/docs/telegram-plugin.md
+++ b/docs/telegram-plugin.md
@@ -8,12 +8,12 @@ The official Telegram plugin provides basic message send/receive. Switchroom's f
 
 ## What the switchroom fork adds
 
-### Message tools (10 MCP tools)
+### Message tools (12 MCP tools)
 
 | Tool | What it does |
 |------|-------------|
-| `reply` | Send text, photos, or documents. Supports threading, topic routing, and multi-file attachments. |
-| `stream_reply` | Edit a single message in place as work progresses (~1/sec throttle). Avoids spamming the chat with many short messages. |
+| `reply` | Send text, photos, or documents. Supports threading, topic routing, multi-file attachments, inline keyboard URL buttons, `protect_content`, `quote_text`, and an optional `accent` status header (`in-progress`/`done`/`issue`). |
+| `stream_reply` | Edit a single message in place as work progresses (~1/sec throttle). Same `accent` and inline-keyboard support as `reply`. Optional `lane` parameter splits parallel streams (e.g. `thinking` vs default answer) per chat+thread. |
 | `react` | Add emoji reactions to messages (Telegram whitelist: 👍 👎 ❤️ 🔥 👀 🎉 etc). |
 | `edit_message` | Update a previously sent message. |
 | `delete_message` | Remove a bot-sent message (48h Telegram limit). |
@@ -22,6 +22,16 @@ The official Telegram plugin provides basic message send/receive. Switchroom's f
 | `send_typing` | Show typing indicator during long operations (5s auto-expire). |
 | `download_attachment` | Fetch files attached to inbound messages. |
 | `get_recent_messages` | Query the local SQLite history buffer with pagination and thread filtering. |
+| `send_checklist` | Native Telegram checklist message — fixed-order items with per-item state. Returns a checklist id usable with `update_checklist` (#272). |
+| `update_checklist` | Patch the state of items on a previously sent checklist (e.g. mark item 2 done) without re-sending the whole message. |
+
+### Status accent headers
+
+Both `reply` and `stream_reply` accept an optional `accent: 'in-progress' | 'done' | 'issue'` parameter that prepends a status indicator line (`🔵 In progress…`, `✅ Done`, `⚠️ Issue`) above the message body. Use it for status communication on long-running work and completion announcements; omit it for routine conversational replies. (#328)
+
+### Inline keyboard URL buttons
+
+`reply` and `stream_reply` accept an `inline_keyboard` parameter — an array of rows, each row an array of `{ text, url }` buttons — for tap-to-open links rendered as Telegram inline buttons (#271).
 
 ### Emoji status reactions
 

--- a/telegram-plugin/README.md
+++ b/telegram-plugin/README.md
@@ -36,9 +36,11 @@ adds the ergonomics and reliability that an always-on agent fleet needs:
 - **Switchroom slash-commands** — `/agents`, `/restart`, `/logs`, `/memory`,
   `/grant`, `/dangerous`, `/permissions`, `/reconcile` etc., handled by the
   plugin without consuming Claude Code tokens.
-- **10 MCP tools** — `reply`, `stream_reply`, `react`, `edit_message`,
+- **12 MCP tools** — `reply`, `stream_reply`, `react`, `edit_message`,
   `delete_message`, `forward_message`, `pin_message`, `send_typing`,
-  `download_attachment`, `get_recent_messages`.
+  `download_attachment`, `get_recent_messages`, `send_checklist`,
+  `update_checklist` (the latter two ship native Telegram checklists,
+  see #272).
 
 The fork is the **default** for switchroom agents (no config needed). Set
 `channels.telegram.plugin: official` to fall back to the upstream plugin.


### PR DESCRIPTION
## Summary

Overnight documentation accuracy sweep against the current code on `main`
after a heavy week of shipping (multi-account auth slots, auto-failover,
Telegram checklists, inline keyboards, accent headers, scheduled-task
refactor for #269/#251, gateway/server split Wave 3 F4 cleanup, vault
broker auto-unlock UX, agent add/rename/destroy CLI verbs).

## Docs touched

- `README.md` — fixed stale "10 Telegram MCP tools" claim (bridge now
  exposes 12 — `send_checklist` and `update_checklist` were added in
  #272). Added missing `agent` CLI verbs to the reference: `add`
  (the wizard from #543), `bootstrap`, `interrupt`, `rename` (#168),
  `destroy`, `status`. All shipped, all were invisible in the README.
- `docs/telegram-plugin.md` — refreshed the MCP tool table to 12 tools,
  added a "Status accent headers" subsection documenting the `accent`
  parameter (#328), and added an "Inline keyboard URL buttons" note
  (#271). Touched `reply` and `stream_reply` rows to mention
  `protect_content`, `quote_text`, and `lane`.
- `telegram-plugin/README.md` — bumped tool count from 10 → 12 and
  named the two new checklist tools.

## Punch list (follow-up, not in this PR)

Bigger items needing judgement (restructure, voice, ambiguous
shipping status) are catalogued in **`docs/REVIEW-2026-05-02.md`**.
High-signal recommendations include: documenting `progress_update`
in `docs/sub-agents.md`; promoting "Streaming modes" out of the
"Opting out" section in `docs/telegram-plugin.md`; refreshing the
`README.md` install snippet to lead with `switchroom agent add`;
auditing `CHANGELOG.md` Unreleased for everything shipped to main
since v0.4.0 (2026-04-29).

## Test plan

- [ ] Skim each touched doc top-to-bottom on the rendered GitHub
      preview to catch markdown table breakage.
- [ ] Verify CLI verbs in the README exist: run
      `switchroom agent --help` and cross-check against the table.
- [ ] Confirm the bridge tool count by grepping
      `telegram-plugin/bridge/bridge.ts` for `name:` (currently 12).
- [ ] Triage `docs/REVIEW-2026-05-02.md` — accept / reject / defer
      each item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)