### PR TITLE
feat(agent-add): BotFather walkthrough in n+1 wizard (#543 WS2, closes #188)

### DIFF
--- a/src/agents/add-orchestrator.test.ts
+++ b/src/agents/add-orchestrator.test.ts
@@ -40,10 +40,28 @@ vi.mock("../setup/onboarding.js", () => ({
 
 vi.mock("../setup/telegram-api.js", () => ({
   pollForDmStart: vi.fn(),
+  // Stubbed so the BotFather walkthrough's fast path (existingToken
+  // supplied) doesn't hit the network in tests that don't inject a
+  // runBotFather override.
+  validateBotToken: vi.fn().mockResolvedValue({
+    id: 1,
+    is_bot: true,
+    first_name: "Bot",
+    username: "ken_bot",
+  }),
+  assertBotUsernameMatchesAgent: vi.fn(),
 }));
 
 import { addAgent, runFinalPreflight } from "./add-orchestrator.js";
 import { createAgent, completeCreation } from "./create-orchestrator.js";
+
+// Default BotFather walkthrough stub — every addAgent test injects this so
+// the orchestrator never reaches the real validateBotToken (no network).
+const fakeBotFather = (username = "ken_bot") =>
+  vi.fn().mockResolvedValue({
+    token: "fake:token",
+    bot: { username },
+  });
 
 function setupAgentDir(): { agentDir: string } {
   const root = mkdtempSync(join(tmpdir(), "agent-add-"));
@@ -121,6 +139,7 @@ describe("addAgent", () => {
       profile: "general",
       botToken: "fake:token",
       topology: "dm",
+      runBotFather: fakeBotFather(),
       readOAuthCode: async () => "browser-code",
       pollForPair,
       isUnitActive,
@@ -164,6 +183,7 @@ describe("addAgent", () => {
       profile: "general",
       botToken: "fake:token",
       topology: "dm",
+      runBotFather: fakeBotFather(),
       allowFromUserId: "9999",
       readOAuthCode: async () => "code",
       pollForPair,
@@ -238,6 +258,130 @@ describe("addAgent", () => {
         log: () => {},
       }),
     ).rejects.toThrow(/No OAuth code provided/);
+  });
+});
+
+describe("addAgent — BotFather walkthrough wiring (#188)", () => {
+  it("invokes the walkthrough with existingToken when --bot-token supplied", async () => {
+    const { agentDir } = setupAgentDir();
+    writeFileSync(
+      join(process.env.HOME!, ".config/systemd/user/switchroom-bot.service"),
+      "[Unit]\nExecStart=expect ...\n",
+    );
+
+    (createAgent as any).mockResolvedValue({
+      sessionName: "s",
+      agentDir,
+      loginUrl: undefined,
+    });
+    (completeCreation as any).mockResolvedValue({
+      outcome: { kind: "success" },
+      started: true,
+      instructions: [],
+    });
+
+    const runBotFather = vi.fn().mockResolvedValue({
+      token: "fake:token",
+      bot: { username: "bot_user" },
+    });
+
+    await addAgent({
+      name: "bot",
+      profile: "general",
+      botToken: "fake:token",
+      botUsername: "bot_user",
+      loose: false,
+      topology: "dm",
+      allowFromUserId: "1",
+      readOAuthCode: async () => "code",
+      isUnitActive: () => true,
+      log: () => {},
+      runBotFather,
+    });
+
+    expect(runBotFather).toHaveBeenCalledOnce();
+    const call = runBotFather.mock.calls[0]![0];
+    expect(call.agentSlug).toBe("bot");
+    expect(call.existingToken).toBe("fake:token");
+    expect(call.expectedUsername).toBe("bot_user");
+    expect(call.loose).toBe(false);
+  });
+
+  it("walkthrough resolves a token interactively when no --bot-token supplied", async () => {
+    const { agentDir } = setupAgentDir();
+    writeFileSync(
+      join(process.env.HOME!, ".config/systemd/user/switchroom-bot.service"),
+      "[Unit]\nExecStart=expect ...\n",
+    );
+
+    (createAgent as any).mockResolvedValue({
+      sessionName: "s",
+      agentDir,
+      loginUrl: undefined,
+    });
+    (completeCreation as any).mockResolvedValue({
+      outcome: { kind: "success" },
+      started: true,
+      instructions: [],
+    });
+
+    const runBotFather = vi.fn().mockResolvedValue({
+      token: "freshly-pasted:token",
+      bot: { username: "bot_walkthrough_bot" },
+    });
+
+    await addAgent({
+      name: "bot",
+      profile: "general",
+      // botToken intentionally omitted — wizard should fall through to
+      // the walkthrough.
+      topology: "dm",
+      allowFromUserId: "1",
+      readOAuthCode: async () => "code",
+      readLine: async () => "freshly-pasted:token",
+      isUnitActive: () => true,
+      log: () => {},
+      runBotFather,
+    });
+
+    expect(runBotFather).toHaveBeenCalledOnce();
+    const call = runBotFather.mock.calls[0]![0];
+    expect(call.existingToken).toBeUndefined();
+    expect(typeof call.readLine).toBe("function");
+
+    // The token returned by the walkthrough must be threaded into
+    // createAgent — otherwise the bot would scaffold without credentials.
+    expect((createAgent as any).mock.calls[0]![0].telegramBotToken).toBe(
+      "freshly-pasted:token",
+    );
+  });
+
+  it("aborts the wizard when the walkthrough throws", async () => {
+    const { agentDir } = setupAgentDir();
+    (createAgent as any).mockResolvedValue({
+      sessionName: "s",
+      agentDir,
+      loginUrl: undefined,
+    });
+    const runBotFather = vi
+      .fn()
+      .mockRejectedValue(new Error("Telegram rejected the token: Unauthorized"));
+
+    await expect(
+      addAgent({
+        name: "bot",
+        profile: "general",
+        botToken: "broken:token",
+        topology: "dm",
+        readOAuthCode: async () => "code",
+        log: () => {},
+        runBotFather,
+      }),
+    ).rejects.toThrow(/Telegram rejected the token/);
+
+    // createAgent must not be called when bot-token validation fails —
+    // otherwise we'd scaffold an agent we'd then have to roll back.
+    expect(createAgent).not.toHaveBeenCalled();
   });
 });
 

--- a/src/agents/add-orchestrator.ts
+++ b/src/agents/add-orchestrator.ts
@@ -31,6 +31,10 @@ import { execFileSync } from "node:child_process";
 import { createAgent, completeCreation } from "./create-orchestrator.js";
 import { writeAccessJson } from "../setup/onboarding.js";
 import { pollForDmStart } from "../setup/telegram-api.js";
+import {
+  runBotFatherWalkthrough,
+  type BotFatherWalkthroughOpts,
+} from "../setup/botfather-walkthrough.js";
 
 export type AgentTopology = "dm" | "forum";
 
@@ -39,8 +43,31 @@ export interface AddAgentOpts {
   name: string;
   /** Profile to extend from (e.g. "health-coach"). */
   profile: string;
-  /** BotFather token for the new agent's bot. */
-  botToken: string;
+  /**
+   * BotFather token for the new agent's bot. Optional — when omitted the
+   * wizard runs the BotFather walkthrough (#188) to guide the operator
+   * through @BotFather, validates the resulting token via getMe, and
+   * asserts the bot's username matches the agent slug. Supplying a token
+   * up-front (--bot-token / SWITCHROOM_BOT_TOKEN) skips the walkthrough
+   * entirely — the validate-and-assert path still runs.
+   */
+  botToken?: string;
+  /**
+   * Optional explicit bot username — passed through to the walkthrough
+   * for exact-equality assertion when the bot is intentionally named
+   * without the slug.
+   */
+  botUsername?: string;
+  /**
+   * Downgrade the slug-in-username assertion to warn-only. Off by default.
+   */
+  loose?: boolean;
+  /**
+   * Stdin reader injected by the CLI (or tests). Used both for the OAuth
+   * code prompt and — when the BotFather walkthrough runs — for the
+   * "paste the token" loop.
+   */
+  readLine?: (prompt: string) => Promise<string>;
   /** Topology — "dm" today; "forum" reserved for #190 forum-pairing UX. */
   topology: AgentTopology;
   /**
@@ -65,10 +92,15 @@ export interface AddAgentOpts {
   /** Logger — defaults to console.log; tests inject a sink. */
   log?: (line: string) => void;
   /**
-   * Stub hook for BotFather automation (#188). Not yet implemented —
-   * present only so wiring tests can confirm the seam exists.
+   * Test seam — overrides `runBotFatherWalkthrough` so unit tests can
+   * exercise the wiring without touching Telegram. Defaults to the real
+   * walkthrough (which calls validateBotToken under the hood). Receives
+   * the same opts object the orchestrator builds internally.
    */
-  botFatherStub?: () => Promise<void>;
+  runBotFather?: (opts: BotFatherWalkthroughOpts) => Promise<{
+    token: string;
+    bot: { username: string };
+  }>;
   /**
    * Optional override of the pairing poller. Tests inject a fake; the
    * wizard otherwise calls pollForDmStart from telegram-api.
@@ -135,13 +167,22 @@ export async function addAgent(opts: AddAgentOpts): Promise<AddAgentResult> {
   const pollPair = opts.pollForPair ?? pollForDmStart;
   const isActive = opts.isUnitActive ?? defaultIsUnitActive;
 
-  // ── Step 1: BotFather automation (#188) — stub ───────────────────────────
-  // TODO(#188): when BotFather automation lands this hook will create the
-  // bot, capture the token, and feed it into createAgent. Today the caller
-  // supplies the token via CLI flag.
-  if (opts.botFatherStub) {
-    await opts.botFatherStub();
-  }
+  // ── Step 1: BotFather walkthrough (#188) ─────────────────────────────────
+  // Either validate the token the operator already has, or guide them
+  // through @BotFather to create one. Both paths end with a getMe call
+  // and a slug-in-username assertion so a stale / wrong-bot token is
+  // caught here rather than at first restart.
+  const walkthroughRunner = opts.runBotFather ?? runBotFatherWalkthrough;
+  const wt = await walkthroughRunner({
+    agentSlug: opts.name,
+    existingToken: opts.botToken,
+    expectedUsername: opts.botUsername,
+    loose: opts.loose,
+    readLine: opts.readLine,
+    log,
+  });
+  const resolvedBotToken = wt.token;
+  log(`[1/6] Bot token validated for @${wt.bot.username}`);
 
   // ── Step 1b: profile/skill picker (#190) — stub ──────────────────────────
   // TODO(#190): replace the --profile flag with an interactive picker that
@@ -154,7 +195,7 @@ export async function addAgent(opts: AddAgentOpts): Promise<AddAgentResult> {
   const created = await createAgent({
     name: opts.name,
     profile: opts.profile,
-    telegramBotToken: opts.botToken,
+    telegramBotToken: resolvedBotToken,
     configPath: opts.configPath,
     rollbackOnFail: true,
   });
@@ -201,7 +242,7 @@ export async function addAgent(opts: AddAgentOpts): Promise<AddAgentResult> {
     log(`      Open Telegram and DM your new bot: send /start`);
     let pair: Awaited<ReturnType<typeof pollPair>>;
     try {
-      pair = await pollPair(opts.botToken, pairTimeout);
+      pair = await pollPair(resolvedBotToken, pairTimeout);
     } catch (err) {
       throw new Error(
         `Pairing timed out after ${(pairTimeout / 1000).toFixed(0)}s. ` +

--- a/src/build-info.ts
+++ b/src/build-info.ts
@@ -3,7 +3,7 @@
 // Values are refreshed every time `npm run build` runs.
 
 export const VERSION: string = "0.4.0";
-export const COMMIT_SHA: string | null = "3b0aa1a";
-export const COMMIT_DATE: string | null = "2026-05-01T19:50:14+10:00";
-export const LATEST_PR: number | null = 539;
-export const COMMITS_AHEAD_OF_TAG: number | null = 107;
+export const COMMIT_SHA: string | null = "a0799ae";
+export const COMMIT_DATE: string | null = "2026-05-02T08:37:30+10:00";
+export const LATEST_PR: number | null = 551;
+export const COMMITS_AHEAD_OF_TAG: number | null = 111;

--- a/src/cli/agent.ts
+++ b/src/cli/agent.ts
@@ -1860,7 +1860,15 @@ export function registerAgentCommand(program: Command): void {
     )
     .option(
       "--bot-token <token>",
-      "BotFather token for the new agent's bot (or set SWITCHROOM_BOT_TOKEN env var)",
+      "BotFather token for the new agent's bot. Omit to run the interactive @BotFather walkthrough (#188); or set SWITCHROOM_BOT_TOKEN env var to avoid leaking the token into shell history.",
+    )
+    .option(
+      "--bot-username <username>",
+      "Optional explicit bot username for exact-equality validation (use when the bot's username deliberately doesn't contain the agent slug).",
+    )
+    .option(
+      "--loose",
+      "Downgrade the slug-in-username assertion to a warning. Use when the bot is intentionally named without the agent slug.",
     )
     .option(
       "--allow-from <user_id>",
@@ -1877,21 +1885,19 @@ export function registerAgentCommand(program: Command): void {
           profile: string;
           topology: string;
           botToken?: string;
+          botUsername?: string;
+          loose?: boolean;
           allowFrom?: string;
           pairTimeoutMs?: string;
         },
       ) => {
         const configPath = getConfigPath(program);
 
+        // No bot-token? That's fine — the BotFather walkthrough (#188)
+        // will guide the operator through @BotFather and capture the
+        // token interactively. We only short-circuit when the operator
+        // already has a token (flag or env var).
         const botToken = opts.botToken ?? process.env.SWITCHROOM_BOT_TOKEN;
-        if (!botToken) {
-          console.error(
-            chalk.red(
-              "Error: --bot-token is required (or set SWITCHROOM_BOT_TOKEN env var to keep it out of shell history).",
-            ),
-          );
-          process.exit(1);
-        }
 
         if (opts.topology !== "dm" && opts.topology !== "forum") {
           console.error(
@@ -1919,15 +1925,11 @@ export function registerAgentCommand(program: Command): void {
 
         console.log(chalk.bold(`\nswitchroom agent add: ${name}\n`));
 
-        // Read OAuth code from stdin, mirroring bootstrap's terminal stub.
-        // (Foreman bot relay path is the future replacement — see #175.)
-        const readOAuthCode = async (loginUrl: string | undefined): Promise<string> => {
-          if (loginUrl) {
-            console.log(chalk.bold(`\n  Open this URL in your browser to authenticate:\n`));
-            console.log(chalk.cyan(`  ${loginUrl}\n`));
-          }
-          process.stdout.write(chalk.bold("  Paste the browser code here: "));
-          return new Promise<string>((resolveCode) => {
+        // Generic stdin line reader — shared between the BotFather
+        // walkthrough's "paste the token" step and the OAuth code prompt.
+        const readLine = (prompt: string): Promise<string> => {
+          process.stdout.write(chalk.bold(prompt));
+          return new Promise<string>((resolveLine) => {
             process.stdin.setEncoding("utf-8");
             let buf = "";
             const onData = (chunk: Buffer | string) => {
@@ -1935,11 +1937,19 @@ export function registerAgentCommand(program: Command): void {
               const newlineIdx = buf.indexOf("\n");
               if (newlineIdx !== -1) {
                 process.stdin.removeListener("data", onData);
-                resolveCode(buf.slice(0, newlineIdx).trim());
+                resolveLine(buf.slice(0, newlineIdx).trim());
               }
             };
             process.stdin.on("data", onData);
           });
+        };
+
+        const readOAuthCode = async (loginUrl: string | undefined): Promise<string> => {
+          if (loginUrl) {
+            console.log(chalk.bold(`\n  Open this URL in your browser to authenticate:\n`));
+            console.log(chalk.cyan(`  ${loginUrl}\n`));
+          }
+          return readLine("  Paste the browser code here: ");
         };
 
         try {
@@ -1947,11 +1957,14 @@ export function registerAgentCommand(program: Command): void {
             name,
             profile: opts.profile,
             botToken,
+            botUsername: opts.botUsername,
+            loose: opts.loose,
             topology,
             allowFromUserId: opts.allowFrom,
             pairTimeoutMs,
             configPath,
             readOAuthCode,
+            readLine,
           });
 
           if (result.preflightOk) {

--- a/src/setup/botfather-walkthrough.test.ts
+++ b/src/setup/botfather-walkthrough.test.ts
@@ -1,0 +1,230 @@
+/**
+ * Tests for the BotFather walkthrough (epic #543, workstream 2 — closes #188).
+ *
+ * All Telegram I/O is mocked via the injectable `validate` hook, and all
+ * console output / stdin is captured via injected `log` / `readLine`.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import {
+  runBotFatherWalkthrough,
+  suggestUsername,
+  printWalkthrough,
+} from "./botfather-walkthrough.js";
+
+describe("suggestUsername", () => {
+  it("appends _bot to the slug", () => {
+    expect(suggestUsername("ziggy")).toBe("ziggy_bot");
+  });
+
+  it("lowercases and sanitises the slug", () => {
+    expect(suggestUsername("Health-Coach")).toBe("health_coach_bot");
+  });
+});
+
+describe("printWalkthrough", () => {
+  it("references the suggested username and BotFather URL", () => {
+    const lines: string[] = [];
+    printWalkthrough("ziggy", (l) => lines.push(l));
+    const all = lines.join("\n");
+    expect(all).toMatch(/@BotFather/);
+    expect(all).toMatch(/t\.me\/BotFather/);
+    expect(all).toMatch(/ziggy_bot/);
+    expect(all).toMatch(/\/newbot/);
+  });
+});
+
+describe("runBotFatherWalkthrough", () => {
+  it("fast path: validates an existingToken without printing the walkthrough", async () => {
+    const validate = vi.fn().mockResolvedValue({
+      id: 1,
+      is_bot: true,
+      first_name: "Ken",
+      username: "ken_bot",
+    });
+    const log = vi.fn();
+    const result = await runBotFatherWalkthrough({
+      agentSlug: "ken",
+      existingToken: "1:abcdefghijklmnopqrstuvwxyz",
+      log,
+      validate,
+    });
+    expect(result.token).toBe("1:abcdefghijklmnopqrstuvwxyz");
+    expect(result.bot.username).toBe("ken_bot");
+    expect(result.walkthroughShown).toBe(false);
+    expect(log).not.toHaveBeenCalled();
+    expect(validate).toHaveBeenCalledOnce();
+  });
+
+  it("fast path: throws when the bot username doesn't contain the agent slug", async () => {
+    const validate = vi.fn().mockResolvedValue({
+      id: 1,
+      is_bot: true,
+      first_name: "Different",
+      username: "totally_unrelated_bot",
+    });
+    await expect(
+      runBotFatherWalkthrough({
+        agentSlug: "ziggy",
+        existingToken: "1:fake",
+        validate,
+        log: () => {},
+      }),
+    ).rejects.toThrow(/expected username to contain "ziggy"/);
+  });
+
+  it("fast path: --loose downgrades username mismatch to a warn", async () => {
+    const validate = vi.fn().mockResolvedValue({
+      id: 1,
+      is_bot: true,
+      first_name: "Different",
+      username: "totally_unrelated_bot",
+    });
+    const warn = vi.fn();
+    const result = await runBotFatherWalkthrough({
+      agentSlug: "ziggy",
+      existingToken: "1:fake",
+      loose: true,
+      validate,
+      log: () => {},
+      warn,
+    });
+    expect(result.token).toBe("1:fake");
+    expect(warn).toHaveBeenCalled();
+    expect(warn.mock.calls.flat().join(" ")).toMatch(/--loose was set/);
+  });
+
+  it("interactive path: prints walkthrough then accepts the pasted token", async () => {
+    const validate = vi.fn().mockResolvedValue({
+      id: 1,
+      is_bot: true,
+      first_name: "Ziggy",
+      username: "ziggy_bot",
+    });
+    const log = vi.fn();
+    const readLine = vi.fn().mockResolvedValue("123456:AAH-pasted-from-botfather-XX");
+
+    const result = await runBotFatherWalkthrough({
+      agentSlug: "ziggy",
+      readLine,
+      validate,
+      log,
+    });
+
+    expect(result.walkthroughShown).toBe(true);
+    expect(result.token).toBe("123456:AAH-pasted-from-botfather-XX");
+    expect(readLine).toHaveBeenCalledOnce();
+    // Walkthrough copy was emitted.
+    const all = log.mock.calls.flat().join("\n");
+    expect(all).toMatch(/@BotFather/);
+    expect(all).toMatch(/ok — bot @ziggy_bot \(Ziggy\) accepted/);
+  });
+
+  it("interactive path: re-prompts on validation failure, succeeds on retry", async () => {
+    const validate = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("Invalid bot token: Unauthorized"))
+      .mockResolvedValueOnce({
+        id: 2,
+        is_bot: true,
+        first_name: "Ziggy",
+        username: "ziggy_bot",
+      });
+    const readLine = vi
+      .fn()
+      .mockResolvedValueOnce("first:badtoken")
+      .mockResolvedValueOnce("123456:AAH-real-token-XX");
+    const log = vi.fn();
+
+    const result = await runBotFatherWalkthrough({
+      agentSlug: "ziggy",
+      readLine,
+      validate,
+      log,
+    });
+
+    expect(result.token).toBe("123456:AAH-real-token-XX");
+    expect(readLine).toHaveBeenCalledTimes(2);
+    expect(log.mock.calls.flat().join("\n")).toMatch(/Telegram rejected the token/);
+  });
+
+  it("interactive path: re-prompts on username mismatch, succeeds on retry", async () => {
+    const validate = vi
+      .fn()
+      .mockResolvedValueOnce({
+        id: 3,
+        is_bot: true,
+        first_name: "Wrong",
+        username: "some_other_bot",
+      })
+      .mockResolvedValueOnce({
+        id: 4,
+        is_bot: true,
+        first_name: "Ziggy",
+        username: "ziggy_bot",
+      });
+    const readLine = vi
+      .fn()
+      .mockResolvedValueOnce("1:wrong")
+      .mockResolvedValueOnce("2:right");
+
+    const result = await runBotFatherWalkthrough({
+      agentSlug: "ziggy",
+      readLine,
+      validate,
+      log: () => {},
+    });
+
+    expect(result.token).toBe("2:right");
+    expect(readLine).toHaveBeenCalledTimes(2);
+  });
+
+  it("interactive path: gives up after maxAttempts and throws actionable error", async () => {
+    const validate = vi.fn().mockRejectedValue(new Error("Invalid bot token: Unauthorized"));
+    const readLine = vi.fn().mockResolvedValue("nope:nope");
+    await expect(
+      runBotFatherWalkthrough({
+        agentSlug: "ziggy",
+        readLine,
+        validate,
+        log: () => {},
+        maxAttempts: 2,
+      }),
+    ).rejects.toThrow(/failed after 2 attempts/);
+    expect(validate).toHaveBeenCalledTimes(2);
+  });
+
+  it("interactive path: empty paste re-prompts without burning a network call", async () => {
+    const validate = vi.fn().mockResolvedValue({
+      id: 1,
+      is_bot: true,
+      first_name: "Ziggy",
+      username: "ziggy_bot",
+    });
+    const readLine = vi
+      .fn()
+      .mockResolvedValueOnce("")
+      .mockResolvedValueOnce("1:real");
+
+    const result = await runBotFatherWalkthrough({
+      agentSlug: "ziggy",
+      readLine,
+      validate,
+      log: () => {},
+    });
+
+    expect(result.token).toBe("1:real");
+    // Only the second (non-empty) attempt should call validate.
+    expect(validate).toHaveBeenCalledTimes(1);
+    expect(validate).toHaveBeenCalledWith("1:real");
+  });
+
+  it("throws when no token and no readLine are supplied (non-interactive)", async () => {
+    await expect(
+      runBotFatherWalkthrough({
+        agentSlug: "ziggy",
+        log: () => {},
+      }),
+    ).rejects.toThrow(/no interactive reader|--bot-token/);
+  });
+});

--- a/src/setup/botfather-walkthrough.ts
+++ b/src/setup/botfather-walkthrough.ts
@@ -1,0 +1,220 @@
+/**
+ * BotFather walkthrough — workstream 2 of epic #543, closes #188.
+ *
+ * Replaces the bare "paste token" step in the `switchroom agent add`
+ * wizard with a guided @BotFather flow:
+ *
+ *   1. Detect: does the operator already have a token (env var / flag)?
+ *      If yes — validate via getMe, optionally assert slug match, return.
+ *   2. Otherwise — print a step-by-step walkthrough (open @BotFather,
+ *      /newbot, pick name + username, copy token), wait for the operator
+ *      to paste the token, validate it, and assert the bot's username
+ *      contains the agent slug so a copy-paste mistake (e.g. clerk's token
+ *      pasted while creating finn) doesn't quietly succeed.
+ *
+ * Stays flag-driven: in non-interactive mode (token supplied up-front via
+ * --bot-token / SWITCHROOM_BOT_TOKEN) the walkthrough is skipped entirely
+ * and we run the same validate-and-assert path. The interactive path is
+ * only entered when no token is supplied AND a `readLine` is available.
+ *
+ * All I/O is injected:
+ *   - log: where the step copy goes (defaults to console.log)
+ *   - readLine: how we slurp the pasted token (defaults to stdin readline)
+ *   - validate: getMe call (defaults to validateBotToken)
+ * Tests inject all three.
+ */
+
+import {
+  validateBotToken,
+  assertBotUsernameMatchesAgent,
+  type BotInfo,
+} from "./telegram-api.js";
+
+export interface BotFatherWalkthroughOpts {
+  /** Agent slug — used to suggest a username and to validate the resolved bot. */
+  agentSlug: string;
+  /**
+   * Optional: token already in hand (e.g. supplied via --bot-token or
+   * SWITCHROOM_BOT_TOKEN). When present we skip the walkthrough copy and
+   * go straight to validate + assert.
+   */
+  existingToken?: string;
+  /**
+   * Optional explicit bot username — when set, used for an exact-equality
+   * assert against the bot's getMe username instead of the
+   * "slug must appear in username" default. Mirrors the
+   * assertBotUsernameMatchesAgent contract.
+   */
+  expectedUsername?: string;
+  /**
+   * If true the username assertion downgrades from throw to warn-only.
+   * Useful when the operator deliberately names the bot without the slug
+   * and hasn't yet declared bot_username in switchroom.yaml.
+   */
+  loose?: boolean;
+  /**
+   * Reader used for the interactive paste step. When omitted and no
+   * existingToken is supplied, the walkthrough throws — non-interactive
+   * runs must supply the token up-front.
+   */
+  readLine?: (prompt: string) => Promise<string>;
+  /** Logger for walkthrough copy. Defaults to console.log. */
+  log?: (line: string) => void;
+  /** Logger for warnings (non-fatal hints). Defaults to console.warn. */
+  warn?: (line: string) => void;
+  /** Test seam — defaults to validateBotToken (real getMe call). */
+  validate?: (token: string) => Promise<BotInfo>;
+  /**
+   * Maximum number of paste attempts before giving up. The wizard
+   * re-prompts on validation failure to recover from copy-paste typos.
+   * Default 3.
+   */
+  maxAttempts?: number;
+}
+
+export interface BotFatherWalkthroughResult {
+  /** The validated bot token. */
+  token: string;
+  /** Bot info from getMe. */
+  bot: BotInfo;
+  /** True iff the walkthrough copy was printed (i.e. interactive path). */
+  walkthroughShown: boolean;
+}
+
+const DEFAULT_MAX_ATTEMPTS = 3;
+
+/**
+ * Suggest a BotFather username for the agent slug. BotFather requires the
+ * username to end in "bot" or "Bot" and to be 5-32 chars. We default to
+ * `<slug>_bot` and let the operator customise — the only hard rule we
+ * enforce later is that the slug appears in the username.
+ */
+export function suggestUsername(agentSlug: string): string {
+  const cleaned = agentSlug.toLowerCase().replace(/[^a-z0-9_]/g, "_");
+  return `${cleaned}_bot`;
+}
+
+/**
+ * Run the walkthrough. Returns the validated token + bot info, or throws
+ * with an actionable message.
+ */
+export async function runBotFatherWalkthrough(
+  opts: BotFatherWalkthroughOpts,
+): Promise<BotFatherWalkthroughResult> {
+  const log = opts.log ?? ((s: string) => console.log(s));
+  const warn = opts.warn ?? ((s: string) => console.warn(s));
+  const validate = opts.validate ?? validateBotToken;
+  const maxAttempts = opts.maxAttempts ?? DEFAULT_MAX_ATTEMPTS;
+
+  // ── Fast path: token already in hand ─────────────────────────────────────
+  if (opts.existingToken) {
+    const bot = await validate(opts.existingToken);
+    enforceUsername(bot.username, opts.agentSlug, opts.expectedUsername, opts.loose, warn);
+    return { token: opts.existingToken, bot, walkthroughShown: false };
+  }
+
+  // ── Interactive path requires a reader ───────────────────────────────────
+  if (!opts.readLine) {
+    throw new Error(
+      `No bot token supplied for agent "${opts.agentSlug}" and no interactive reader available. ` +
+        `Re-run with --bot-token <token> or set SWITCHROOM_BOT_TOKEN.`,
+    );
+  }
+
+  printWalkthrough(opts.agentSlug, log);
+
+  // ── Paste loop with retry ────────────────────────────────────────────────
+  let lastErr: Error | undefined;
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    const raw = await opts.readLine(
+      attempt === 1
+        ? "  Paste the bot token from BotFather: "
+        : `  Paste the bot token (attempt ${attempt}/${maxAttempts}): `,
+    );
+    const token = raw.trim();
+    if (!token) {
+      lastErr = new Error("Empty token entered.");
+      log(`  ! Token was empty — try again.`);
+      continue;
+    }
+    if (!/^\d+:[A-Za-z0-9_-]{20,}$/.test(token)) {
+      // Cheap structural sanity check — a real BotFather token is
+      // <id>:<35-char-base64ish>. We don't reject on mismatch — Telegram
+      // will be the source of truth via getMe — but we warn early so a
+      // stray quote / partial paste is caught before the network call.
+      log(`  ! That doesn't look like a BotFather token (expected <id>:<secret>). Trying anyway…`);
+    }
+    try {
+      const bot = await validate(token);
+      try {
+        enforceUsername(bot.username, opts.agentSlug, opts.expectedUsername, opts.loose, warn);
+      } catch (assertErr) {
+        // Username mismatch is recoverable — most likely the operator
+        // pasted a token from a different bot. Re-prompt rather than
+        // hard-fail so they don't lose the rest of the wizard's progress.
+        lastErr = assertErr as Error;
+        log(`  ! ${lastErr.message}`);
+        log(`  ! Paste the token for the bot you just created in @BotFather, or re-run with --loose.`);
+        continue;
+      }
+      log(`  ok — bot @${bot.username} (${bot.first_name}) accepted.`);
+      return { token, bot, walkthroughShown: true };
+    } catch (err) {
+      lastErr = err as Error;
+      log(`  ! Telegram rejected the token: ${lastErr.message}`);
+    }
+  }
+
+  throw new Error(
+    `BotFather walkthrough failed after ${maxAttempts} attempts. ` +
+      `Last error: ${lastErr?.message ?? "unknown"}. ` +
+      `Re-run \`switchroom agent add\` once you have a working token, or pass --bot-token directly.`,
+  );
+}
+
+/**
+ * Print the step-by-step BotFather copy. Exported for tests + so the CLI
+ * can reuse the same wording in --help / docs without duplicating it.
+ */
+export function printWalkthrough(agentSlug: string, log: (line: string) => void): void {
+  const suggested = suggestUsername(agentSlug);
+  log("");
+  log("  No --bot-token supplied — let's create one with @BotFather.");
+  log("");
+  log("  Step 1. Open Telegram and DM @BotFather:");
+  log("            https://t.me/BotFather");
+  log("");
+  log("  Step 2. Send /newbot and follow the prompts:");
+  log(`            - Name (display): something like "${agentSlug}"`);
+  log(`            - Username (must end in "bot"): try "${suggested}"`);
+  log(`              (the username must contain "${agentSlug}" so the wizard can`);
+  log(`               match it back to this agent — pick anything else and we'll`);
+  log(`               re-prompt unless you pass --loose).`);
+  log("");
+  log("  Step 3. BotFather replies with a token of the form:");
+  log("            123456789:AAH...redacted...");
+  log("          Copy the whole thing.");
+  log("");
+  log("  Step 4. (Optional) /setprivacy → Disable, so the bot can read group");
+  log("          messages if you ever move it to a forum topology.");
+  log("");
+}
+
+function enforceUsername(
+  username: string,
+  agentSlug: string,
+  expectedUsername: string | undefined,
+  loose: boolean | undefined,
+  warn: (line: string) => void,
+): void {
+  try {
+    assertBotUsernameMatchesAgent(username, agentSlug, expectedUsername);
+  } catch (err) {
+    if (loose) {
+      warn(`  warn: ${(err as Error).message}`);
+      warn(`         Continuing because --loose was set.`);
+      return;
+    }
+    throw err;
+  }
+}


### PR DESCRIPTION
## Summary

Workstream 2 of epic #543 — closes #188.

Replaces the bare "paste a token" step in `switchroom agent add` with a guided @BotFather walkthrough.

- **Fast path** (`--bot-token` or `SWITCHROOM_BOT_TOKEN` supplied): validate via `getMe`, assert the bot's username contains the agent slug, continue. No walkthrough copy printed — non-interactive scripts unchanged.
- **Interactive path** (no token supplied): print step-by-step BotFather copy (open @BotFather → `/newbot` → name → username suggestion → copy token), wait for the operator to paste the token, validate it, re-prompt on failure (3 attempts), re-prompt on username mismatch.
- **Username assertion** catches copy-paste mistakes (e.g. `clerk`'s token pasted while creating `finn`). Opt out with `--loose` or pin exact username with `--bot-username`.
- **Wiring**: `addAgent` now accepts `botToken` as optional and grew `botUsername`, `loose`, `readLine`, and a `runBotFather` test seam. The CLI shares one `readLine` between the BotFather paste step and the OAuth code prompt.

New module: `src/setup/botfather-walkthrough.ts`. All Telegram I/O is injected for tests.

## Test plan

- [x] `bunx vitest run src/setup/botfather-walkthrough.test.ts src/agents/add-orchestrator.test.ts` — 31/31 passing
- [x] Full suite — 4410 passing, 12 skipped (pre-existing)
- [x] `bun run build` clean
- [x] Post-build PII grep `grep -c "/home/kenthompson" dist/cli/switchroom.js` → `0`
- [ ] Manual: dry-run `switchroom agent add foo --profile general` (no token) prints walkthrough copy and waits on stdin
- [ ] Manual: `switchroom agent add foo --profile general --bot-token <real>` skips walkthrough, validates, proceeds

Refs #543, closes #188.

🤖 Generated with [Claude Code](https://claude.com/claude-code)