### PR TITLE
feat(agent-add): profile/skill picker in n+1 wizard (#543 WS4, closes #190)

### DIFF
--- a/src/agents/add-orchestrator.test.ts
+++ b/src/agents/add-orchestrator.test.ts
@@ -38,6 +38,17 @@ vi.mock("../setup/onboarding.js", () => ({
   }),
 }));
 
+vi.mock("../setup/profile-picker.js", () => ({
+  // Default stub — fast-path with whatever profile the test passes,
+  // pretending zero bundled skills (so pruneBundledSkills no-ops).
+  runProfilePicker: vi.fn(async (opts: { existingProfile?: string }) => ({
+    profile: opts.existingProfile ?? "default",
+    skills: [],
+    allSkills: [],
+    pickerShown: false,
+  })),
+}));
+
 vi.mock("../setup/telegram-api.js", () => ({
   pollForDmStart: vi.fn(),
   // Stubbed so the BotFather walkthrough's fast path (existingToken
@@ -52,8 +63,9 @@ vi.mock("../setup/telegram-api.js", () => ({
   assertBotUsernameMatchesAgent: vi.fn(),
 }));
 
-import { addAgent, runFinalPreflight } from "./add-orchestrator.js";
+import { addAgent, runFinalPreflight, pruneBundledSkills } from "./add-orchestrator.js";
 import { createAgent, completeCreation } from "./create-orchestrator.js";
+import { runProfilePicker } from "../setup/profile-picker.js";
 
 // Default BotFather walkthrough stub — every addAgent test injects this so
 // the orchestrator never reaches the real validateBotToken (no network).
@@ -606,5 +618,172 @@ describe("runFinalPreflight", () => {
     });
     expect(report.systemdActive.ok).toBe(false);
     expect(report.systemdActive.detail).toMatch(/switchroom agent start bot/);
+  });
+});
+
+describe("addAgent — profile picker wiring (#190)", () => {
+  it("invokes the picker with existingProfile when --profile supplied, and threads result into createAgent", async () => {
+    const { agentDir } = setupAgentDir();
+    writeFileSync(
+      join(process.env.HOME!, ".config/systemd/user/switchroom-bot.service"),
+      "[Unit]\nExecStart=expect ...\n",
+    );
+
+    (createAgent as any).mockResolvedValue({
+      sessionName: "s",
+      agentDir,
+      loginUrl: undefined,
+    });
+    (completeCreation as any).mockResolvedValue({
+      outcome: { kind: "success" },
+      started: true,
+      instructions: [],
+    });
+
+    // Override the default picker stub so we can assert the resolved
+    // profile is the one the orchestrator passes to createAgent.
+    (runProfilePicker as any).mockResolvedValueOnce({
+      profile: "health-coach",
+      skills: ["check-in"],
+      allSkills: ["check-in", "weekly-review"],
+      pickerShown: false,
+    });
+
+    const result = await addAgent({
+      name: "bot",
+      profile: "health-coach",
+      skills: "check-in",
+      botToken: "fake:token",
+      topology: "dm",
+      runBotFather: fakeBotFather(),
+      allowFromUserId: "1",
+      readOAuthCode: async () => "code",
+      isUnitActive: () => true,
+      log: () => {},
+    });
+
+    expect(runProfilePicker).toHaveBeenCalled();
+    const pickerCall = (runProfilePicker as any).mock.calls.at(-1)![0];
+    expect(pickerCall.existingProfile).toBe("health-coach");
+    expect(pickerCall.existingSkills).toBe("check-in");
+    expect((createAgent as any).mock.calls[0]![0].profile).toBe("health-coach");
+    expect(result.profile).toBe("health-coach");
+    expect(result.skills).toEqual(["check-in"]);
+  });
+
+  it("runs the picker interactively when --profile is omitted", async () => {
+    const { agentDir } = setupAgentDir();
+    writeFileSync(
+      join(process.env.HOME!, ".config/systemd/user/switchroom-bot.service"),
+      "[Unit]\nExecStart=expect ...\n",
+    );
+
+    (createAgent as any).mockResolvedValue({
+      sessionName: "s",
+      agentDir,
+      loginUrl: undefined,
+    });
+    (completeCreation as any).mockResolvedValue({
+      outcome: { kind: "success" },
+      started: true,
+      instructions: [],
+    });
+
+    (runProfilePicker as any).mockResolvedValueOnce({
+      profile: "coding",
+      skills: ["architecture", "code-review"],
+      allSkills: ["architecture", "code-review"],
+      pickerShown: true,
+    });
+
+    const result = await addAgent({
+      name: "bot",
+      // profile intentionally omitted
+      botToken: "fake:token",
+      topology: "dm",
+      runBotFather: fakeBotFather(),
+      allowFromUserId: "1",
+      readOAuthCode: async () => "code",
+      readLine: async () => "1",
+      isUnitActive: () => true,
+      log: () => {},
+    });
+
+    expect(runProfilePicker).toHaveBeenCalled();
+    const pickerCall = (runProfilePicker as any).mock.calls.at(-1)![0];
+    expect(pickerCall.existingProfile).toBeUndefined();
+    expect(typeof pickerCall.readLine).toBe("function");
+    expect(result.profile).toBe("coding");
+  });
+
+  it("aborts the wizard when the picker throws, before scaffolding", async () => {
+    const { agentDir } = setupAgentDir();
+    (createAgent as any).mockResolvedValue({
+      sessionName: "s",
+      agentDir,
+      loginUrl: undefined,
+    });
+
+    (runProfilePicker as any).mockRejectedValueOnce(
+      new Error('Unknown profile: "nope"'),
+    );
+
+    await expect(
+      addAgent({
+        name: "bot",
+        profile: "nope",
+        botToken: "fake:token",
+        topology: "dm",
+        runBotFather: fakeBotFather(),
+        allowFromUserId: "1",
+        readOAuthCode: async () => "code",
+        log: () => {},
+      }),
+    ).rejects.toThrow(/Unknown profile/);
+
+    expect(createAgent).not.toHaveBeenCalled();
+  });
+});
+
+describe("pruneBundledSkills", () => {
+  it("removes scoped subdirs that aren't in keep, leaves others alone", () => {
+    const { mkdtempSync, mkdirSync, writeFileSync, existsSync } =
+      require("node:fs") as typeof import("node:fs");
+    const root = mkdtempSync(join(tmpdir(), "prune-skills-"));
+    const skillsDir = join(root, ".claude", "skills");
+    mkdirSync(skillsDir, { recursive: true });
+    // bundled (in scope) subdirs
+    mkdirSync(join(skillsDir, "check-in"));
+    writeFileSync(join(skillsDir, "check-in", "SKILL.md"), "x");
+    mkdirSync(join(skillsDir, "weekly-review"));
+    // global skill (not in scope) — must be left untouched
+    mkdirSync(join(skillsDir, "humanizer"));
+
+    const removed = pruneBundledSkills(
+      root,
+      ["check-in"],
+      ["check-in", "weekly-review"],
+    );
+
+    expect(removed).toEqual(["weekly-review"]);
+    expect(existsSync(join(skillsDir, "check-in"))).toBe(true);
+    expect(existsSync(join(skillsDir, "weekly-review"))).toBe(false);
+    expect(existsSync(join(skillsDir, "humanizer"))).toBe(true);
+  });
+
+  it("no-ops when .claude/skills is missing", () => {
+    const { mkdtempSync } = require("node:fs") as typeof import("node:fs");
+    const root = mkdtempSync(join(tmpdir(), "prune-skills-empty-"));
+    expect(pruneBundledSkills(root, [], ["a", "b"])).toEqual([]);
+  });
+
+  it("no-ops when scope is empty (profile ships nothing)", () => {
+    const { mkdtempSync, mkdirSync } =
+      require("node:fs") as typeof import("node:fs");
+    const root = mkdtempSync(join(tmpdir(), "prune-skills-noscope-"));
+    mkdirSync(join(root, ".claude", "skills", "humanizer"), { recursive: true });
+    expect(pruneBundledSkills(root, [], [])).toEqual([]);
+    const { existsSync } = require("node:fs") as typeof import("node:fs");
+    expect(existsSync(join(root, ".claude", "skills", "humanizer"))).toBe(true);
   });
 });

--- a/src/agents/add-orchestrator.ts
+++ b/src/agents/add-orchestrator.ts
@@ -25,8 +25,8 @@
  * deployment.
  */
 
-import { resolve } from "node:path";
-import { existsSync } from "node:fs";
+import { resolve, join } from "node:path";
+import { existsSync, readdirSync, rmSync, statSync } from "node:fs";
 import { execFileSync } from "node:child_process";
 import { createAgent, completeCreation } from "./create-orchestrator.js";
 import { writeAccessJson } from "../setup/onboarding.js";
@@ -35,14 +35,30 @@ import {
   runBotFatherWalkthrough,
   type BotFatherWalkthroughOpts,
 } from "../setup/botfather-walkthrough.js";
+import {
+  runProfilePicker,
+  type ProfilePickerOpts,
+} from "../setup/profile-picker.js";
 
 export type AgentTopology = "dm" | "forum";
 
 export interface AddAgentOpts {
   /** Agent slug (e.g. "ziggy"). */
   name: string;
-  /** Profile to extend from (e.g. "health-coach"). */
-  profile: string;
+  /**
+   * Profile to extend from (e.g. "health-coach"). Optional — when
+   * omitted the wizard runs the interactive profile picker (#190),
+   * which requires a `readLine`. Supplying a profile up-front skips
+   * the picker and validates the name against listAvailableProfiles().
+   */
+  profile?: string;
+  /**
+   * Optional skill-set selector for the chosen profile's bundled
+   * skills/* directories. One of "all" (default), "none", or a
+   * comma-separated subset of skill names. When omitted alongside an
+   * interactive profile pick, the picker prompts for a selection.
+   */
+  skills?: string;
   /**
    * BotFather token for the new agent's bot. Optional — when omitted the
    * wizard runs the BotFather walkthrough (#188) to guide the operator
@@ -102,6 +118,16 @@ export interface AddAgentOpts {
     bot: { username: string };
   }>;
   /**
+   * Test seam — overrides `runProfilePicker` so unit tests can exercise
+   * the wiring without touching the real profiles/ directory. Receives
+   * the same opts object the orchestrator builds internally.
+   */
+  runProfilePicker?: (opts: ProfilePickerOpts) => Promise<{
+    profile: string;
+    skills: string[];
+    allSkills?: string[];
+  }>;
+  /**
    * Optional override of the pairing poller. Tests inject a fake; the
    * wizard otherwise calls pollForDmStart from telegram-api.
    */
@@ -125,6 +151,10 @@ export interface AddAgentResult {
   agentDir: string;
   /** User ID that ended up in allowFrom (paired or supplied). */
   userId: string;
+  /** Profile the agent was scaffolded from (resolved by the picker). */
+  profile: string;
+  /** Bundled skills retained from the profile's skills/* dir. */
+  skills: string[];
   /** True iff every preflight check passed. */
   preflightOk: boolean;
   /** Per-check status for the final preflight. */
@@ -184,21 +214,44 @@ export async function addAgent(opts: AddAgentOpts): Promise<AddAgentResult> {
   const resolvedBotToken = wt.token;
   log(`[1/6] Bot token validated for @${wt.bot.username}`);
 
-  // ── Step 1b: profile/skill picker (#190) — stub ──────────────────────────
-  // TODO(#190): replace the --profile flag with an interactive picker that
-  // ports skills + persona files (SOUL.md, IDENTITY.md, USER.md) from a
-  // chosen template.
+  // ── Step 1b: profile / skill picker (#190) ───────────────────────────────
+  // Either validate the profile the operator already picked (--profile flag)
+  // or run the interactive picker. Same shape as the BotFather walkthrough:
+  // fast-path when the flag is supplied, interactive otherwise.
+  const pickerRunner = opts.runProfilePicker ?? runProfilePicker;
+  const pick = await pickerRunner({
+    existingProfile: opts.profile,
+    existingSkills: opts.skills,
+    readLine: opts.readLine,
+    log,
+  });
+  const resolvedProfile = pick.profile;
+  const resolvedSkills = pick.skills;
+  log(
+    `[1/6] Profile "${resolvedProfile}" selected ` +
+      `(skills: ${resolvedSkills.length === 0 ? "(none)" : resolvedSkills.join(", ")})`,
+  );
 
-  log(`\n[1/6] Scaffolding agent "${opts.name}" (profile=${opts.profile}, topology=${opts.topology})`);
+  log(`\n[1/6] Scaffolding agent "${opts.name}" (profile=${resolvedProfile}, topology=${opts.topology})`);
 
   // ── Step 2: scaffold + auth session ──────────────────────────────────────
   const created = await createAgent({
     name: opts.name,
-    profile: opts.profile,
+    profile: resolvedProfile,
     telegramBotToken: resolvedBotToken,
     configPath: opts.configPath,
     rollbackOnFail: true,
   });
+
+  // ── Step 2b: prune bundled skills the operator dropped ───────────────────
+  // copyProfileSkills (inside scaffold) copies the entire profile skills/
+  // tree. If the picker narrowed the set, remove the subdirs that weren't
+  // selected. Idempotent — silently skips when .claude/skills is absent.
+  const pickAllSkills = pick.allSkills ?? resolvedSkills;
+  const removed = pruneBundledSkills(created.agentDir, resolvedSkills, pickAllSkills);
+  if (removed.length > 0) {
+    log(`      Dropped ${removed.length} bundled skill(s): ${removed.join(", ")}`);
+  }
 
   log(`[2/6] Auth session started: ${created.sessionName}`);
   if (created.loginUrl) {
@@ -289,7 +342,14 @@ export async function addAgent(opts: AddAgentOpts): Promise<AddAgentResult> {
     log(`      [${mark}] ${k}: ${v.detail}`);
   }
 
-  return { agentDir, userId, preflightOk: ok, preflight };
+  return {
+    agentDir,
+    userId,
+    profile: resolvedProfile,
+    skills: resolvedSkills,
+    preflightOk: ok,
+    preflight,
+  };
 }
 
 // ─── Final preflight ──────────────────────────────────────────────────────────
@@ -525,6 +585,54 @@ export function runFinalPreflight(inputs: PreflightInputs): PreflightReport {
     mcpServersConfigured: mcp,
     vaultBotTokenManaged: vaultMgd,
   };
+}
+
+/**
+ * Drop bundled-skill subdirs that the picker excluded. The scaffold
+ * step always copies the full profile skills/ tree — this prunes after
+ * the fact based on the picker's resolved subset. Returns the names of
+ * directories that were removed (for logging).
+ *
+ * `scope` is the full set of bundled skill names from the profile (as
+ * reported by the picker's allSkills). We only consider entries in
+ * scope as candidates for removal — global skill symlinks and other
+ * files that happen to live alongside under .claude/skills/ are left
+ * untouched.
+ *
+ * Exported for tests. Skips silently when .claude/skills doesn't exist
+ * (profile shipped no skills, or scaffold mocked out).
+ */
+export function pruneBundledSkills(
+  agentDir: string,
+  keep: string[],
+  scope: string[],
+): string[] {
+  const skillsDir = resolve(agentDir, ".claude", "skills");
+  if (!existsSync(skillsDir)) {
+    return [];
+  }
+  const keepSet = new Set(keep);
+  const scopeSet = new Set(scope);
+  const removed: string[] = [];
+  for (const entry of scopeSet) {
+    if (keepSet.has(entry)) continue;
+    const entryPath = join(skillsDir, entry);
+    if (!existsSync(entryPath)) continue;
+    let isDir = false;
+    try {
+      isDir = statSync(entryPath).isDirectory();
+    } catch {
+      continue;
+    }
+    if (!isDir) continue;
+    try {
+      rmSync(entryPath, { recursive: true, force: true });
+      removed.push(entry);
+    } catch {
+      // best-effort — surface via log but don't fail the wizard
+    }
+  }
+  return removed;
 }
 
 function defaultIsUnitActive(unitName: string): boolean {

--- a/src/build-info.ts
+++ b/src/build-info.ts
@@ -3,7 +3,7 @@
 // Values are refreshed every time `npm run build` runs.
 
 export const VERSION: string = "0.4.0";
-export const COMMIT_SHA: string | null = "a0799ae";
-export const COMMIT_DATE: string | null = "2026-05-02T08:37:30+10:00";
-export const LATEST_PR: number | null = 551;
-export const COMMITS_AHEAD_OF_TAG: number | null = 111;
+export const COMMIT_SHA: string | null = "1764eff";
+export const COMMIT_DATE: string | null = "2026-05-02T08:47:27+10:00";
+export const LATEST_PR: number | null = 552;
+export const COMMITS_AHEAD_OF_TAG: number | null = 112;

--- a/src/cli/agent.ts
+++ b/src/cli/agent.ts
@@ -1852,7 +1852,14 @@ export function registerAgentCommand(program: Command): void {
     .description(
       "n+1 bot wizard — scaffold + auth + start + DM-pair + preflight in one verb (epic #543)."
     )
-    .requiredOption("--profile <profile>", "Profile to extend from (e.g. 'health-coach')")
+    .option(
+      "--profile <profile>",
+      "Profile to extend from (e.g. 'health-coach'). Omit to run the interactive picker (#190); or set SWITCHROOM_PROFILE.",
+    )
+    .option(
+      "--skills <selector>",
+      'Bundled-skill subset for the chosen profile: "all" (default), "none", or a comma-separated list of skill names. Or set SWITCHROOM_SKILLS.',
+    )
     .option(
       "--topology <topology>",
       "Channel topology: 'dm' (default) or 'forum' (forum support deferred — see #190)",
@@ -1882,7 +1889,8 @@ export function registerAgentCommand(program: Command): void {
       withConfigError(async (
         name: string,
         opts: {
-          profile: string;
+          profile?: string;
+          skills?: string;
           topology: string;
           botToken?: string;
           botUsername?: string;
@@ -1955,7 +1963,8 @@ export function registerAgentCommand(program: Command): void {
         try {
           const result = await addAgent({
             name,
-            profile: opts.profile,
+            profile: opts.profile ?? process.env.SWITCHROOM_PROFILE,
+            skills: opts.skills ?? process.env.SWITCHROOM_SKILLS,
             botToken,
             botUsername: opts.botUsername,
             loose: opts.loose,

--- a/src/setup/profile-picker.test.ts
+++ b/src/setup/profile-picker.test.ts
@@ -1,0 +1,270 @@
+/**
+ * Tests for src/setup/profile-picker.ts (epic #543, workstream 4 — closes #190).
+ *
+ * Covers:
+ *   - Fast path: --profile flag is validated against listAvailableProfiles
+ *     and returned without entering the interactive picker.
+ *   - Fast path errors: unknown profile name → actionable error.
+ *   - Interactive path: numbered list, pick by number, pick by name,
+ *     bad input re-prompts up to maxAttempts then throws.
+ *   - Skills: --skills "all" / "none" / comma-list resolved correctly,
+ *     unknown skill name throws, "" defaults to all.
+ *   - Interactive skills: empty input → keep all, "none" → drop, list →
+ *     subset.
+ *   - No reader + no --profile → throws (non-interactive, no fallback).
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import {
+  runProfilePicker,
+  resolveSkillsSelection,
+  defaultListProfileSkills,
+} from "./profile-picker.js";
+
+const PROFILES = ["coding", "default", "executive-assistant", "health-coach"];
+const SKILLS_BY_PROFILE: Record<string, string[]> = {
+  coding: ["architecture", "code-review"],
+  default: [],
+  "executive-assistant": ["daily-briefing", "meeting-prep"],
+  "health-coach": ["check-in", "weekly-review"],
+};
+
+const fakeListProfiles = () => [...PROFILES];
+const fakeListProfileSkills = (name: string) => [...(SKILLS_BY_PROFILE[name] ?? [])];
+
+describe("runProfilePicker — fast path (--profile flag)", () => {
+  it("validates and returns the profile without prompting", async () => {
+    const log = vi.fn();
+    const readLine = vi.fn();
+    const result = await runProfilePicker({
+      existingProfile: "health-coach",
+      readLine,
+      log,
+      listProfiles: fakeListProfiles,
+      listProfileSkills: fakeListProfileSkills,
+    });
+    expect(result.profile).toBe("health-coach");
+    expect(result.skills).toEqual(["check-in", "weekly-review"]);
+    expect(result.allSkills).toEqual(["check-in", "weekly-review"]);
+    expect(result.pickerShown).toBe(false);
+    expect(readLine).not.toHaveBeenCalled();
+  });
+
+  it("rejects an unknown profile with the available list", async () => {
+    await expect(
+      runProfilePicker({
+        existingProfile: "totally-bogus",
+        listProfiles: fakeListProfiles,
+        listProfileSkills: fakeListProfileSkills,
+      }),
+    ).rejects.toThrow(/Unknown profile.*coding.*health-coach/s);
+  });
+
+  it("honours --skills none alongside --profile", async () => {
+    const result = await runProfilePicker({
+      existingProfile: "coding",
+      existingSkills: "none",
+      listProfiles: fakeListProfiles,
+      listProfileSkills: fakeListProfileSkills,
+    });
+    expect(result.skills).toEqual([]);
+    expect(result.allSkills).toEqual(["architecture", "code-review"]);
+  });
+
+  it("honours --skills with a comma-separated subset", async () => {
+    const result = await runProfilePicker({
+      existingProfile: "coding",
+      existingSkills: "code-review",
+      listProfiles: fakeListProfiles,
+      listProfileSkills: fakeListProfileSkills,
+    });
+    expect(result.skills).toEqual(["code-review"]);
+  });
+
+  it("rejects --skills naming a skill the profile doesn't bundle", async () => {
+    await expect(
+      runProfilePicker({
+        existingProfile: "coding",
+        existingSkills: "code-review,does-not-exist",
+        listProfiles: fakeListProfiles,
+        listProfileSkills: fakeListProfileSkills,
+      }),
+    ).rejects.toThrow(/Unknown skill "does-not-exist"/);
+  });
+});
+
+describe("runProfilePicker — interactive", () => {
+  it("picks by number", async () => {
+    const log = vi.fn();
+    const readLine = vi
+      .fn()
+      .mockResolvedValueOnce("2") // pick "default" (alphabetically second)
+      .mockResolvedValueOnce(""); // skill prompt — keep all
+    const result = await runProfilePicker({
+      readLine,
+      log,
+      listProfiles: fakeListProfiles,
+      listProfileSkills: fakeListProfileSkills,
+    });
+    expect(result.profile).toBe("default");
+    expect(result.skills).toEqual([]); // default ships no skills, no prompt
+    expect(result.pickerShown).toBe(true);
+    // skill prompt is skipped when allSkills is empty, so readLine is
+    // called exactly once (for the profile choice).
+    expect(readLine).toHaveBeenCalledTimes(1);
+  });
+
+  it("picks by name", async () => {
+    const readLine = vi
+      .fn()
+      .mockResolvedValueOnce("health-coach")
+      .mockResolvedValueOnce(""); // keep all skills
+    const result = await runProfilePicker({
+      readLine,
+      log: () => {},
+      listProfiles: fakeListProfiles,
+      listProfileSkills: fakeListProfileSkills,
+    });
+    expect(result.profile).toBe("health-coach");
+    expect(result.skills).toEqual(["check-in", "weekly-review"]);
+  });
+
+  it('skill prompt: "none" drops all', async () => {
+    const readLine = vi
+      .fn()
+      .mockResolvedValueOnce("coding")
+      .mockResolvedValueOnce("none");
+    const result = await runProfilePicker({
+      readLine,
+      log: () => {},
+      listProfiles: fakeListProfiles,
+      listProfileSkills: fakeListProfileSkills,
+    });
+    expect(result.profile).toBe("coding");
+    expect(result.skills).toEqual([]);
+    expect(result.allSkills).toEqual(["architecture", "code-review"]);
+  });
+
+  it("skill prompt: comma-list of numbers and names", async () => {
+    const readLine = vi
+      .fn()
+      .mockResolvedValueOnce("coding")
+      .mockResolvedValueOnce("1,code-review"); // 1=architecture + code-review (de-duped if needed)
+    const result = await runProfilePicker({
+      readLine,
+      log: () => {},
+      listProfiles: fakeListProfiles,
+      listProfileSkills: fakeListProfileSkills,
+    });
+    expect(result.skills).toEqual(["architecture", "code-review"]);
+  });
+
+  it("re-prompts on bad profile input then succeeds", async () => {
+    const readLine = vi
+      .fn()
+      .mockResolvedValueOnce("99") // out of range
+      .mockResolvedValueOnce("nope") // unknown
+      .mockResolvedValueOnce("coding")
+      .mockResolvedValueOnce(""); // keep all skills
+    const result = await runProfilePicker({
+      readLine,
+      log: () => {},
+      listProfiles: fakeListProfiles,
+      listProfileSkills: fakeListProfileSkills,
+      maxAttempts: 5,
+    });
+    expect(result.profile).toBe("coding");
+  });
+
+  it("throws after maxAttempts of bad profile input", async () => {
+    const readLine = vi
+      .fn()
+      .mockResolvedValueOnce("nope")
+      .mockResolvedValueOnce("nope")
+      .mockResolvedValueOnce("nope");
+    await expect(
+      runProfilePicker({
+        readLine,
+        log: () => {},
+        listProfiles: fakeListProfiles,
+        listProfileSkills: fakeListProfileSkills,
+        maxAttempts: 3,
+      }),
+    ).rejects.toThrow(/Profile picker failed after 3 attempts/);
+  });
+
+  it("throws when no profile flag and no readLine supplied", async () => {
+    await expect(
+      runProfilePicker({
+        listProfiles: fakeListProfiles,
+        listProfileSkills: fakeListProfileSkills,
+      }),
+    ).rejects.toThrow(/No --profile supplied.*coding.*health-coach/s);
+  });
+
+  it("throws when listProfiles returns an empty array", async () => {
+    await expect(
+      runProfilePicker({
+        existingProfile: "default",
+        listProfiles: () => [],
+        listProfileSkills: fakeListProfileSkills,
+      }),
+    ).rejects.toThrow(/No profiles are available/);
+  });
+});
+
+describe("resolveSkillsSelection", () => {
+  it('treats undefined / "" / "all" as keep-all', () => {
+    expect(resolveSkillsSelection("coding", undefined, fakeListProfileSkills)).toEqual([
+      "architecture",
+      "code-review",
+    ]);
+    expect(resolveSkillsSelection("coding", "", fakeListProfileSkills)).toEqual([
+      "architecture",
+      "code-review",
+    ]);
+    expect(resolveSkillsSelection("coding", "all", fakeListProfileSkills)).toEqual([
+      "architecture",
+      "code-review",
+    ]);
+    expect(resolveSkillsSelection("coding", "ALL", fakeListProfileSkills)).toEqual([
+      "architecture",
+      "code-review",
+    ]);
+  });
+
+  it('treats "none" (any case) as empty', () => {
+    expect(resolveSkillsSelection("coding", "none", fakeListProfileSkills)).toEqual([]);
+    expect(resolveSkillsSelection("coding", "NONE", fakeListProfileSkills)).toEqual([]);
+  });
+
+  it("de-dupes a repeated skill name", () => {
+    expect(
+      resolveSkillsSelection(
+        "coding",
+        "code-review,code-review,architecture",
+        fakeListProfileSkills,
+      ),
+    ).toEqual(["code-review", "architecture"]);
+  });
+
+  it("rejects unknown skill names with the available list", () => {
+    expect(() =>
+      resolveSkillsSelection("coding", "nope", fakeListProfileSkills),
+    ).toThrow(/Unknown skill "nope".*architecture, code-review/s);
+  });
+});
+
+describe("defaultListProfileSkills", () => {
+  it("returns [] for a profile that doesn't exist on disk", () => {
+    expect(defaultListProfileSkills("totally-bogus-profile-xyz")).toEqual([]);
+  });
+
+  it("lists at least one entry for a known profile bundling skills", () => {
+    // health-coach ships at least 'check-in' and 'weekly-review' in
+    // the repo at the time of writing — be tolerant in case the bundle
+    // changes, but assert non-empty.
+    const skills = defaultListProfileSkills("health-coach");
+    expect(skills.length).toBeGreaterThan(0);
+  });
+});

--- a/src/setup/profile-picker.ts
+++ b/src/setup/profile-picker.ts
@@ -1,0 +1,359 @@
+/**
+ * Profile / skill picker — workstream 4 of epic #543, closes #190.
+ *
+ * Replaces the `--profile <name>` required-flag stub in
+ * `switchroom agent add` with a guided picker:
+ *
+ *   1. If a profile was supplied up-front (--profile / SWITCHROOM_PROFILE),
+ *      validate it against the filesystem (listAvailableProfiles) and
+ *      return. Same fast path the BotFather walkthrough uses.
+ *   2. Otherwise, print a numbered list of available profiles with a
+ *      one-line gloss for each, and let the operator pick by number or
+ *      by name. Re-prompt on bad input rather than hard-failing.
+ *   3. After a profile is chosen, optionally narrow the bundled skill
+ *      set: list the profile's skills/* subdirs and let the operator
+ *      keep all (default), drop them all, or pass an explicit
+ *      comma-separated subset via --skills.
+ *
+ * Stays flag-driven for non-interactive flows: passing --profile and
+ * --skills (or SWITCHROOM_PROFILE / SWITCHROOM_SKILLS env vars) skips
+ * the picker entirely. The interactive path is only entered when the
+ * profile flag is absent AND a `readLine` reader is available.
+ *
+ * All I/O is injected:
+ *   - log: where the picker copy goes (defaults to console.log)
+ *   - readLine: how we slurp the operator's choice (no default)
+ *   - listProfiles: how we discover candidates (defaults to
+ *     listAvailableProfiles — tests inject a fake to avoid touching
+ *     the real profiles/ dir)
+ *   - listProfileSkills: how we discover bundled skills under a
+ *     profile (defaults to a real readdir on profiles/<name>/skills)
+ */
+
+import { existsSync, readdirSync, statSync } from "node:fs";
+import { resolve } from "node:path";
+import { listAvailableProfiles } from "../agents/profiles.js";
+
+/**
+ * Short description per profile — kept as a static map so the picker UI
+ * has something to show even if the profile dir doesn't ship a README.
+ * Unknown profiles render with an empty gloss; that's fine.
+ */
+const PROFILE_GLOSSES: Record<string, string> = {
+  default: "minimal baseline — generic chat helper, no opinion.",
+  coding: "developer copilot — architecture + code-review skills.",
+  "executive-assistant": "schedule + comms — daily briefing, meeting prep.",
+  "health-coach": "wellness coach — daily check-ins, weekly reviews.",
+};
+
+export interface ProfilePickerOpts {
+  /** Optional: profile already chosen (--profile flag or env). Skips the picker. */
+  existingProfile?: string;
+  /**
+   * Optional: explicit skills selector (--skills flag or env). One of:
+   *   - "all"  → keep every bundled skill (the default behaviour)
+   *   - "none" → drop them all
+   *   - "a,b"  → comma-separated subset; unknown names error loudly
+   * When omitted we either run the interactive picker (if readLine is
+   * present) or default to "all".
+   */
+  existingSkills?: string;
+  /**
+   * Reader used for the interactive prompt. When omitted and no
+   * existingProfile is supplied, the picker throws — non-interactive
+   * runs must supply --profile up-front.
+   */
+  readLine?: (prompt: string) => Promise<string>;
+  /** Logger for picker copy. Defaults to console.log. */
+  log?: (line: string) => void;
+  /** Test seam — defaults to listAvailableProfiles. */
+  listProfiles?: () => string[];
+  /**
+   * Test seam — given a profile name, return the names of subdirs under
+   * profiles/<name>/skills/ (each is a bundled skill). Defaults to a
+   * real readdir against the project's profiles/ root.
+   */
+  listProfileSkills?: (profileName: string) => string[];
+  /**
+   * Maximum number of re-prompts on bad input before giving up. Default 3.
+   */
+  maxAttempts?: number;
+}
+
+export interface ProfilePickerResult {
+  /** The validated profile name to extend from. */
+  profile: string;
+  /**
+   * The set of bundled skill names to keep (matches subdir names under
+   * profiles/<profile>/skills/). Empty array means "drop all bundled
+   * skills". When the chosen profile ships no skills/, this is also [].
+   */
+  skills: string[];
+  /**
+   * The full set of bundled skill names available under the chosen
+   * profile, before any picker narrowing. Empty if the profile ships
+   * no skills/. Useful for downstream pruning ("which subdirs should
+   * I touch?") so we don't accidentally remove unrelated files.
+   */
+  allSkills: string[];
+  /** True iff the picker ran interactively (i.e. no --profile flag). */
+  pickerShown: boolean;
+}
+
+const DEFAULT_MAX_ATTEMPTS = 3;
+const PROFILES_ROOT = resolve(import.meta.dirname, "../../profiles");
+
+/**
+ * Default real-fs implementation of listProfileSkills. Returns the
+ * subdirectory names under profiles/<name>/skills/, or [] if that path
+ * doesn't exist.
+ */
+export function defaultListProfileSkills(profileName: string): string[] {
+  const skillsDir = resolve(PROFILES_ROOT, profileName, "skills");
+  if (!existsSync(skillsDir)) {
+    return [];
+  }
+  try {
+    return readdirSync(skillsDir)
+      .filter((entry) => {
+        try {
+          return statSync(resolve(skillsDir, entry)).isDirectory();
+        } catch {
+          return false;
+        }
+      })
+      .sort();
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Run the picker. Returns the validated profile + skill subset, or
+ * throws with an actionable message.
+ */
+export async function runProfilePicker(
+  opts: ProfilePickerOpts,
+): Promise<ProfilePickerResult> {
+  const log = opts.log ?? ((s: string) => console.log(s));
+  const listProfiles = opts.listProfiles ?? listAvailableProfiles;
+  const listSkills = opts.listProfileSkills ?? defaultListProfileSkills;
+  const maxAttempts = opts.maxAttempts ?? DEFAULT_MAX_ATTEMPTS;
+
+  const available = listProfiles();
+  if (available.length === 0) {
+    throw new Error(
+      "No profiles are available on disk. Expected at least 'default' under profiles/.",
+    );
+  }
+
+  // ── Fast path: profile already in hand ────────────────────────────────────
+  if (opts.existingProfile) {
+    if (!available.includes(opts.existingProfile)) {
+      throw new Error(
+        `Unknown profile: "${opts.existingProfile}". ` +
+          `Available: ${available.join(", ")}.`,
+      );
+    }
+    const skills = resolveSkillsSelection(
+      opts.existingProfile,
+      opts.existingSkills,
+      listSkills,
+    );
+    return {
+      profile: opts.existingProfile,
+      skills,
+      allSkills: listSkills(opts.existingProfile),
+      pickerShown: false,
+    };
+  }
+
+  // ── Interactive path requires a reader ────────────────────────────────────
+  if (!opts.readLine) {
+    throw new Error(
+      "No --profile supplied and no interactive reader available. " +
+        `Re-run with --profile <name> (one of: ${available.join(", ")}) or set SWITCHROOM_PROFILE.`,
+    );
+  }
+
+  const profile = await pickProfileInteractive({
+    available,
+    readLine: opts.readLine,
+    log,
+    maxAttempts,
+  });
+
+  const allSkills = listSkills(profile);
+  let skills: string[];
+  if (opts.existingSkills !== undefined) {
+    // --skills was passed alongside the interactive profile pick: honour it.
+    skills = resolveSkillsSelection(profile, opts.existingSkills, listSkills);
+  } else if (allSkills.length === 0) {
+    skills = [];
+  } else {
+    skills = await pickSkillsInteractive({
+      profile,
+      allSkills,
+      readLine: opts.readLine,
+      log,
+      maxAttempts,
+    });
+  }
+
+  return { profile, skills, allSkills, pickerShown: true };
+}
+
+interface PickProfileArgs {
+  available: string[];
+  readLine: (prompt: string) => Promise<string>;
+  log: (line: string) => void;
+  maxAttempts: number;
+}
+
+async function pickProfileInteractive(args: PickProfileArgs): Promise<string> {
+  const { available, readLine, log, maxAttempts } = args;
+  log("");
+  log("  Pick a profile for this agent:");
+  log("");
+  available.forEach((name, idx) => {
+    const gloss = PROFILE_GLOSSES[name] ?? "";
+    const padded = String(idx + 1).padStart(2, " ");
+    if (gloss) {
+      log(`    ${padded}. ${name}  —  ${gloss}`);
+    } else {
+      log(`    ${padded}. ${name}`);
+    }
+  });
+  log("");
+
+  let lastErr: string | undefined;
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    const prompt =
+      attempt === 1
+        ? "  Choose a profile (number or name): "
+        : `  Choose a profile (attempt ${attempt}/${maxAttempts}): `;
+    const raw = (await readLine(prompt)).trim();
+    if (!raw) {
+      lastErr = "empty input";
+      log("  ! Empty selection — try again.");
+      continue;
+    }
+    // Number?
+    const num = Number.parseInt(raw, 10);
+    if (Number.isFinite(num) && String(num) === raw) {
+      if (num >= 1 && num <= available.length) {
+        return available[num - 1]!;
+      }
+      lastErr = `out-of-range (${num})`;
+      log(`  ! ${num} is out of range (1..${available.length}).`);
+      continue;
+    }
+    // Name match?
+    if (available.includes(raw)) {
+      return raw;
+    }
+    lastErr = `unknown profile "${raw}"`;
+    log(`  ! Unknown profile "${raw}". Valid: ${available.join(", ")}.`);
+  }
+  throw new Error(
+    `Profile picker failed after ${maxAttempts} attempts (last: ${lastErr ?? "unknown"}). ` +
+      `Re-run with --profile <name>.`,
+  );
+}
+
+interface PickSkillsArgs {
+  profile: string;
+  allSkills: string[];
+  readLine: (prompt: string) => Promise<string>;
+  log: (line: string) => void;
+  maxAttempts: number;
+}
+
+async function pickSkillsInteractive(args: PickSkillsArgs): Promise<string[]> {
+  const { profile, allSkills, readLine, log, maxAttempts } = args;
+  log("");
+  log(`  Profile "${profile}" bundles ${allSkills.length} skill${allSkills.length === 1 ? "" : "s"}:`);
+  allSkills.forEach((name, idx) => {
+    const padded = String(idx + 1).padStart(2, " ");
+    log(`    ${padded}. ${name}`);
+  });
+  log("");
+  log('  Press Enter to keep all, type "none" to drop all, or pass a comma-');
+  log("  separated subset (numbers or names, e.g. 1,3 or check-in,weekly-review).");
+  log("");
+
+  let lastErr: string | undefined;
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    const raw = (await readLine("  Skills: ")).trim();
+    if (!raw) {
+      return [...allSkills];
+    }
+    if (raw.toLowerCase() === "all") {
+      return [...allSkills];
+    }
+    if (raw.toLowerCase() === "none") {
+      return [];
+    }
+    const parts = raw.split(",").map((s) => s.trim()).filter(Boolean);
+    const picked: string[] = [];
+    let badPart: string | undefined;
+    for (const part of parts) {
+      const num = Number.parseInt(part, 10);
+      if (Number.isFinite(num) && String(num) === part) {
+        if (num >= 1 && num <= allSkills.length) {
+          picked.push(allSkills[num - 1]!);
+        } else {
+          badPart = `out-of-range (${num})`;
+          break;
+        }
+      } else if (allSkills.includes(part)) {
+        picked.push(part);
+      } else {
+        badPart = `unknown skill "${part}"`;
+        break;
+      }
+    }
+    if (badPart) {
+      lastErr = badPart;
+      log(`  ! ${badPart}. Try again.`);
+      continue;
+    }
+    // De-dupe while preserving order.
+    return [...new Set(picked)];
+  }
+  throw new Error(
+    `Skill picker failed after ${maxAttempts} attempts (last: ${lastErr ?? "unknown"}). ` +
+      `Re-run with --skills all|none|<comma-list>.`,
+  );
+}
+
+/**
+ * Parse the --skills selector against the bundled skill list. Exported
+ * so the CLI can validate up-front (before kicking off the wizard) when
+ * --skills is supplied with --profile.
+ */
+export function resolveSkillsSelection(
+  profile: string,
+  selector: string | undefined,
+  listSkills: (profileName: string) => string[],
+): string[] {
+  const all = listSkills(profile);
+  if (selector === undefined || selector === "" || selector.toLowerCase() === "all") {
+    return all;
+  }
+  if (selector.toLowerCase() === "none") {
+    return [];
+  }
+  const parts = selector.split(",").map((s) => s.trim()).filter(Boolean);
+  const picked: string[] = [];
+  for (const part of parts) {
+    if (!all.includes(part)) {
+      throw new Error(
+        `Unknown skill "${part}" for profile "${profile}". ` +
+          `Available: ${all.length ? all.join(", ") : "(none)"}.`,
+      );
+    }
+    picked.push(part);
+  }
+  return [...new Set(picked)];
+}


### PR DESCRIPTION
## Summary

Replaces the required `--profile <name>` flag in `switchroom agent add` with a guided profile + skill picker — workstream 4 of epic #543, closes #190.

- **Fast path unchanged.** Passing `--profile` (or `SWITCHROOM_PROFILE`) validates against `listAvailableProfiles` and skips the picker. Same shape as the BotFather walkthrough (#188 / WS2).
- **Interactive profile pick.** Numbered menu with one-line glosses; choose by number or name. Bad input re-prompts up to 3× before erroring with "re-run with `--profile <name>`".
- **Interactive skill narrowing.** After the profile is picked, the wizard lists bundled skills under `profiles/<name>/skills/` and lets the operator keep all (Enter / "all"), drop all ("none"), or pass a comma-separated subset by number or name. Also honoured up-front via `--skills` / `SWITCHROOM_SKILLS`.
- **Orchestrator prunes only what the picker scoped.** `pruneBundledSkills` removes excluded subdirs under `.claude/skills/` while leaving global skill symlinks alone.

CI / scripts that pass both flags up-front are unaffected.

## Test plan

- [x] `bun run build` clean, no `/home/kenthompson` PII in dist
- [x] `bun run test` green — 4435 vitest pass + 289 bun-test pass (12 skips, 0 fail)
- [x] New `src/setup/profile-picker.test.ts` covers fast path + interactive paths + skill resolver edge cases
- [x] `src/agents/add-orchestrator.test.ts` extended for picker wiring + `pruneBundledSkills`
- [ ] Manual smoke: `switchroom agent add foo` (no flags) → menu appears
- [ ] Manual smoke: `switchroom agent add foo --profile coding --skills code-review` → fast path, only `code-review` survives under `.claude/skills/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)