### PR TITLE
feat(plugin): /switchroom:* slash commands + Phase 0 on-ramp (#543 WS5, closes #84)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
     {
       "name": "switchroom",
       "source": "./",
-      "description": "Skills for operating switchroom: install, status, logs, config, restart, reconcile, schedule, health, architecture, and Telegram integration guidance.",
+      "description": "Slash commands and skills for operating switchroom — Phase 0 install on-ramp (/switchroom:setup), lifecycle (/switchroom:start, /switchroom:stop, /switchroom:status), plus skills for install, logs, config, restart, reconcile, schedule, health, and architecture.",
       "homepage": "https://github.com/mekenthompson/switchroom",
       "repository": "https://github.com/mekenthompson/switchroom",
       "license": "MIT",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "switchroom",
-  "version": "0.1.0",
-  "description": "Operate switchroom — a multi-agent orchestrator for Claude Code — from inside a Claude Code session via skills for install, status, logs, config, restart, reconcile, schedule, and health.",
+  "version": "0.2.0",
+  "description": "Operate switchroom — a multi-agent orchestrator for Claude Code — from inside a Claude Code session. Adds slash commands (/switchroom:setup, /switchroom:start, /switchroom:stop, /switchroom:status) and skills for install, status, logs, config, restart, reconcile, schedule, and health.",
   "author": {
     "name": "Ken Thompson"
   },

--- a/README.md
+++ b/README.md
@@ -101,6 +101,18 @@ Switchroom is **not a harness**. Each agent runs the unmodified `claude` binary,
 
 Ubuntu 24.04 LTS, 4GB RAM. Linux only.
 
+### From inside Claude Code (the on-ramp)
+
+If you already use Claude Code, this is the shortest path. Inside any session:
+
+```
+/plugin marketplace add switchroom/switchroom
+/plugin install switchroom@switchroom
+/switchroom:setup
+```
+
+`/switchroom:setup` walks you through deps, `switchroom setup` (Telegram + vault + first agent), and `switchroom agent start`. Once it's done you have `/switchroom:start`, `/switchroom:stop`, and `/switchroom:status` for day-to-day. See [`docs/publishing.md`](docs/publishing.md).
+
 ### One-liner (fresh box)
 
 ```bash

--- a/commands/setup.md
+++ b/commands/setup.md
@@ -1,0 +1,87 @@
+---
+description: Bootstrap switchroom from inside Claude Code — Phase 0 zero-to-daemon on-ramp (#84, #543)
+argument-hint: ""
+allowed-tools: [Bash, Read, Write]
+---
+
+# Switchroom — first-run bootstrap
+
+This is the Phase 0 on-ramp for users who just ran `/plugin install switchroom@switchroom`. Walk them from "plugin installed" to "daemon running, first agent paired in Telegram" in one sitting. No silent steps. Confirm before each install. Reuse the existing CLI surface — do not reimplement.
+
+## Step 0 — Detect current state
+
+Before any install action, inventory what's already on the box. Run each, capture exit code:
+
+```bash
+. /etc/os-release 2>/dev/null && echo "OS: $PRETTY_NAME" || echo "OS: unknown"
+uname -m
+free -h | awk '/^Mem:/ {print "RAM: " $2}'
+command -v bun >/dev/null && bun --version | sed 's/^/bun: /' || echo "bun: MISSING"
+command -v node >/dev/null && node --version | sed 's/^/node: /' || echo "node: MISSING"
+command -v claude >/dev/null && echo "claude: present" || echo "claude: MISSING"
+command -v switchroom >/dev/null && switchroom --version 2>/dev/null | sed 's/^/switchroom: /' || echo "switchroom: MISSING"
+command -v tmux >/dev/null && echo "tmux: present" || echo "tmux: MISSING"
+test -f ~/.switchroom/switchroom.yaml && echo "config: present at ~/.switchroom/switchroom.yaml" || echo "config: MISSING"
+```
+
+Present the inventory back as a short bulleted summary. Then decide the path:
+
+- **All present + config present + at least one agent unit running** → on-ramp is done. Hand off to `/switchroom:status` and stop.
+- **All present + config present + no units** → skip to Step 3.
+- **switchroom CLI present, no config** → skip to Step 2.
+- **switchroom CLI missing** → Step 1.
+- **Not Linux (macOS/WSL/etc.)** → stop. Switchroom needs Ubuntu 24.04 LTS or compatible Debian. Recommend a $6/mo VPS (Hetzner, DigitalOcean, Vultr).
+
+## Step 1 — Install switchroom + dependencies
+
+Confirm with the user before running anything that mutates the system. Switchroom's dependencies are `bun`, `node` 22+, `tmux`, the Claude Code CLI, and (optionally) `docker`. Recommend the one-liner — it is idempotent and source-readable:
+
+```bash
+curl -fsSL https://get.switchroom.ai | bash
+```
+
+If the user prefers manual control, walk them through the `switchroom-install` skill (it has the granular package list). After install, reload the shell or `source ~/.bashrc` so `switchroom` is on `PATH`, then verify:
+
+```bash
+switchroom --version
+```
+
+## Step 2 — Wire Telegram + scaffold first agent
+
+Run the existing wizard. It handles BotFather walk-through, vault init, profile picker, and the first DM pairing without re-runs:
+
+```bash
+switchroom setup
+```
+
+Tell the user up front: the wizard will ask them to open BotFather in Telegram, paste the bot token back into the terminal, and DM `/start` to the new bot. Stay with them until the wizard prints "agent paired".
+
+If the user wants a non-default persona, suggest passing `--profile <name>` once they pick one (the wizard's profile picker lists what is available).
+
+## Step 3 — Start the daemon, confirm liveness
+
+```bash
+switchroom agent start <name>     # if a specific agent was just scaffolded
+# or:
+switchroom update                  # reconcile + restart everything
+switchroom agent list              # uptime + state
+```
+
+Hand off to `/switchroom:status` for ongoing checks. Tell the user that from this point forward they talk to the agent in Telegram, not the terminal.
+
+## Step 4 — Slash commands they get for free
+
+Now that the plugin is installed, surface the other entry points:
+
+- `/switchroom:status` — what is running and for how long
+- `/switchroom:start <agent>` — start (or restart) a single agent
+- `/switchroom:stop <agent>` — stop an agent
+
+For deeper operations (logs, config edits, agent add, vault, doctor), point at the `switchroom-cli`, `switchroom-manage`, and `switchroom-health` skills — they are namespaced under the same plugin.
+
+## Guardrails
+
+- Never run `switchroom install` or `curl … | bash` without explicit user confirmation.
+- Never skip the BotFather step. There is no fallback path that produces a working Telegram surface.
+- If the user is on a tiny VPS (<2 GB RAM), warn them: switchroom + claude + a few agents will OOM. Recommend 4 GB+.
+- If `claude` is missing, install it via `npm install -g @anthropic-ai/claude-code` — switchroom does not ship claude itself.

--- a/commands/start.md
+++ b/commands/start.md
@@ -1,0 +1,39 @@
+---
+description: Start a switchroom agent (or all agents) via systemd
+argument-hint: "[agent-name]"
+allowed-tools: [Bash]
+---
+
+# Start switchroom agent(s)
+
+The user invoked: `/switchroom:start $ARGUMENTS`
+
+## What to do
+
+If `$ARGUMENTS` names an agent, start only that one. If empty, start everything in the configured fleet. Both paths go through the canonical CLI — never poke `systemctl --user` directly unless the CLI is unavailable.
+
+```bash
+# Single agent
+switchroom agent start "$ARGUMENTS"
+
+# All agents
+switchroom update              # reconcile + (re)start every agent
+```
+
+After starting, verify:
+
+```bash
+switchroom agent list
+```
+
+Report which agents flipped to running, their PIDs, and uptime. If any failed to start, fetch the last 20 journal lines for the offender:
+
+```bash
+switchroom agent logs <name> --lines 20
+```
+
+Surface the failure cause in plain language. Do not silently retry — failed starts mean a config or auth problem the user needs to see.
+
+## Prerequisites
+
+`switchroom` must be on `PATH`. If not, route to `/switchroom:setup` first. If the user has no config (`~/.switchroom/switchroom.yaml` missing), `/switchroom:setup` is also the right entry point.

--- a/commands/status.md
+++ b/commands/status.md
@@ -1,0 +1,31 @@
+---
+description: Show running switchroom agents, uptime, and overall fleet health
+argument-hint: ""
+allowed-tools: [Bash]
+---
+
+# Switchroom status
+
+The user invoked: `/switchroom:status`
+
+## What to do
+
+Run the canonical status command and present the output. This is the same surface the `switchroom-status` skill describes — keep them in sync.
+
+```bash
+switchroom agent list --json 2>/dev/null || switchroom agent list
+```
+
+If the JSON form succeeds, parse it and present per-agent: name, running state, uptime, model, last error (if any). If only the human form is available, paste it back verbatim and summarise.
+
+Follow up with a fleet health check when relevant:
+
+```bash
+switchroom version          # versions + boot self-test summary
+```
+
+If anything looks wedged — a process restarted in the last minute, an agent stuck "starting", a vault that won't unlock — point the user at `/switchroom:setup` (for first-run gaps), `switchroom-health` skill (for "something is broken" diagnostics), or `switchroom doctor` (for a structured self-test).
+
+## Prerequisites
+
+`switchroom` must be on `PATH`. If not, route to `/switchroom:setup`.

--- a/commands/stop.md
+++ b/commands/stop.md
@@ -1,0 +1,29 @@
+---
+description: Stop a switchroom agent (or all agents) without uninstalling
+argument-hint: "[agent-name]"
+allowed-tools: [Bash]
+---
+
+# Stop switchroom agent(s)
+
+The user invoked: `/switchroom:stop $ARGUMENTS`
+
+## What to do
+
+If `$ARGUMENTS` names an agent, stop only that one. If empty, ask the user whether they really mean *all* agents — stopping the whole fleet is a heavier action than stopping one.
+
+```bash
+# Single agent
+switchroom agent stop "$ARGUMENTS"
+
+# All agents (after confirmation)
+for a in $(switchroom agent list --names 2>/dev/null); do
+  switchroom agent stop "$a"
+done
+```
+
+After stopping, run `switchroom agent list` and confirm the targets are no longer active. Mention to the user that stopped agents stay configured — `/switchroom:start <name>` brings them back. If they want to remove an agent permanently, that's `switchroom agent remove`, not stop.
+
+## Prerequisites
+
+Same as `/switchroom:start` — `switchroom` must be on `PATH`. Otherwise route to `/switchroom:setup`.

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -17,10 +17,22 @@ Inside any Claude Code session:
 ```
 
 The first command registers this GitHub repo as a marketplace named `switchroom`.
-The second installs the `switchroom` plugin from that marketplace. Six skills
-(`switchroom-install`, `switchroom-status`, `switchroom-cli`, `switchroom-health`,
-`switchroom-manage`, `switchroom-architecture`) become available
-under the `switchroom:` namespace.
+The second installs the `switchroom` plugin from that marketplace. Four slash
+commands and the existing skills become available under the `switchroom:`
+namespace:
+
+- `/switchroom:setup` — Phase 0 on-ramp. Bootstraps a fresh box from
+  zero to a paired Telegram agent in one walk-through (deps, `switchroom
+  setup` wizard, first agent start). See
+  [#84](https://github.com/switchroom/switchroom/issues/84).
+- `/switchroom:start [agent]` — start one agent or reconcile and start
+  the whole fleet.
+- `/switchroom:stop [agent]` — stop one agent without uninstalling.
+- `/switchroom:status` — `switchroom agent list` plus fleet health.
+
+Skills also bind to the same namespace: `switchroom-install`,
+`switchroom-status`, `switchroom-cli`, `switchroom-health`,
+`switchroom-manage`, `switchroom-architecture`.
 
 To pull updates later:
 
@@ -76,6 +88,7 @@ were moved. The only new artifacts are:
 
 - `.claude-plugin/marketplace.json`
 - `.claude-plugin/plugin.json`
+- `commands/*.md` (slash commands under `/switchroom:`)
 - `docs/publishing.md` (this file)
 
 Reference: <https://docs.claude.com/en/docs/claude-code/plugin-marketplaces>

--- a/tests/plugin-onramp-manifest.test.ts
+++ b/tests/plugin-onramp-manifest.test.ts
@@ -1,0 +1,74 @@
+/**
+ * WS5 of #543 / closes #84: plugin install on-ramp.
+ *
+ * The switchroom Claude Code plugin advertises four slash commands —
+ * /switchroom:setup, /switchroom:start, /switchroom:stop, /switchroom:status —
+ * via `commands/*.md` at the plugin root. These tests pin the manifest +
+ * command file shape so a future edit can't silently break the on-ramp
+ * surface a fresh user sees after `/plugin install switchroom@switchroom`.
+ */
+
+import { describe, it, expect } from "vitest";
+import { existsSync, readFileSync } from "node:fs";
+import { resolve, join } from "node:path";
+
+const REPO_ROOT = resolve(__dirname, "..");
+
+function readCommand(name: string): { frontmatter: string; body: string } {
+  const path = join(REPO_ROOT, "commands", `${name}.md`);
+  expect(existsSync(path)).toBe(true);
+  const text = readFileSync(path, "utf-8");
+  // Frontmatter is bounded by --- on the first line and --- on a later line.
+  const m = text.match(/^---\n([\s\S]*?)\n---\n([\s\S]*)$/);
+  expect(m, `commands/${name}.md must have YAML frontmatter`).not.toBeNull();
+  return { frontmatter: m![1], body: m![2] };
+}
+
+describe("switchroom plugin on-ramp (#84, #543 WS5)", () => {
+  it("plugin.json bumped to advertise commands surface", () => {
+    const path = join(REPO_ROOT, ".claude-plugin", "plugin.json");
+    const m = JSON.parse(readFileSync(path, "utf-8"));
+    expect(m.name).toBe("switchroom");
+    // Version must be ≥ 0.2.0 — the cut that introduces /switchroom:* commands.
+    const [maj, min] = String(m.version).split(".").map((n) => parseInt(n, 10));
+    expect(Number.isFinite(maj) && Number.isFinite(min)).toBe(true);
+    expect(maj > 0 || (maj === 0 && min >= 2)).toBe(true);
+  });
+
+  it("ships the four /switchroom:* slash commands", () => {
+    for (const name of ["setup", "start", "stop", "status"]) {
+      const { frontmatter, body } = readCommand(name);
+      // Every command must declare a description so /help renders cleanly.
+      expect(frontmatter).toMatch(/^description:\s*\S/m);
+      // Body must be non-trivial — these are operator-facing playbooks, not stubs.
+      expect(body.trim().length).toBeGreaterThan(200);
+    }
+  });
+
+  it("setup command covers the Phase 0 on-ramp shape", () => {
+    const { body } = readCommand("setup");
+    // Must reference the canonical wizard verbs the user lands on after install.
+    expect(body).toMatch(/switchroom\s+setup/);
+    expect(body).toMatch(/switchroom\s+agent\s+(start|list)/);
+    // Must mention BotFather — the unavoidable human-in-the-loop step.
+    expect(body.toLowerCase()).toContain("botfather");
+  });
+
+  it("start, stop, status commands route through the canonical CLI", () => {
+    expect(readCommand("start").body).toMatch(/switchroom\s+agent\s+start/);
+    expect(readCommand("stop").body).toMatch(/switchroom\s+agent\s+stop/);
+    expect(readCommand("status").body).toMatch(/switchroom\s+agent\s+list/);
+  });
+
+  it("marketplace.json source path still resolves and lists switchroom plugin", () => {
+    const path = join(REPO_ROOT, ".claude-plugin", "marketplace.json");
+    const m = JSON.parse(readFileSync(path, "utf-8")) as {
+      plugins: Array<{ name: string; source: string }>;
+    };
+    const sw = m.plugins.find((p) => p.name === "switchroom");
+    expect(sw).toBeDefined();
+    expect(existsSync(resolve(REPO_ROOT, sw!.source))).toBe(true);
+    // The plugin root is the repo root, so commands/ must live there.
+    expect(existsSync(resolve(REPO_ROOT, sw!.source, "commands"))).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

WS5 of #543: plugin install on-ramp. Closes #84.

- Adds `commands/setup.md`, `start.md`, `stop.md`, `status.md` so the switchroom plugin exposes `/switchroom:setup`, `/switchroom:start`, `/switchroom:stop`, `/switchroom:status` after `/plugin install switchroom@switchroom`.
- `/switchroom:setup` is the Phase 0 on-ramp: detects current state (deps, config, units), routes the user through `switchroom setup` (BotFather + vault + first agent) and `switchroom agent start` without silent steps.
- All four commands route through the canonical `switchroom` CLI — single source of truth for lifecycle.
- `plugin.json` bumped to 0.2.0; `marketplace.json` description refreshed; `README.md` install section gains the in-Claude-Code path; `docs/publishing.md` documents the new surface.

The `plugin install` verb itself is owned by Claude Code — not something this repo can implement. The missing on-ramp pieces were the slash commands a fresh user lands on after install, and the Phase 0 walk-through. Both are in this PR.

## Test plan

- [x] `npx vitest run tests/plugin-onramp-manifest.test.ts` — 5/5 pass
- [x] `bun run build` — clean (1.60 MB bundle)
- [x] `grep -c "/home/kenthompson" dist/cli/switchroom.js` — 0 (no PII baked in)
- [x] Full `npx vitest run` — 4440 passed / 12 skipped / 0 failed

Refs #543, closes #84.

🤖 Generated with [Claude Code](https://claude.com/claude-code)