### PR TITLE
fix(lifecycle): restart visibility, watchdog forensics, wake audit

### DIFF
--- a/bin/boot-self-test.sh
+++ b/bin/boot-self-test.sh
@@ -133,7 +133,11 @@ for code in "${ALL_CODES[@]}"; do
       detail="$detail
 $recommendation"
     fi
-    record "$code" "$severity" "$AGENT_NAME $summary" "$detail"
+    # Don't prepend agent name — the issue-card header already
+    # renders `<emoji> <agent> · N issues`, so duplicating the
+    # name in every row is redundant and steals row width from
+    # the actionable summary text.
+    record "$code" "$severity" "$summary" "$detail"
   fi
 done
 

--- a/bin/bridge-watchdog.sh
+++ b/bin/bridge-watchdog.sh
@@ -77,6 +77,24 @@ set -euo pipefail
 # legitimate single-tool turn (a long Bash compile maybe) but tight
 # enough to catch Stop-hook deadlocks before the user notices.
 : "${TURN_HANG_SECS:=300}"
+# Forward-progress liveness window. The gateway only bumps
+# `turn-active.json` mtime on PARENT-stream tool_use events; when the
+# parent dispatches a Task() to a sub-agent, the marker goes stale
+# even while real work is happening. The bridge can also flap
+# (transient socket close, MCP plugin restart) while a sub-agent
+# keeps working. Before any restart path acts, probe the agent's
+# `.claude/projects/**/*.jsonl` AND `.claude/tasks/**/*.json` files:
+# if EITHER was modified within JSONL_LIVENESS_SECS, the agent is
+# making forward progress and the restart is a false positive.
+#
+# Two independent fingerprints means a wedged agent has to be silent
+# on BOTH to be killed — much stronger evidence than a single signal.
+# 60s matches the in-flight detector's "recent" semantics in
+# src/agents/in-flight.ts (30s window + 60s tick spread).
+#
+# (Name kept as JSONL_LIVENESS_SECS for back-compat with operators
+# who already set it via env; the value gates both fingerprints.)
+: "${JSONL_LIVENESS_SECS:=60}"
 
 # Per-agent watchdog state lives under /run/user/$UID/switchroom-watchdog/
 # (tmpfs, cleared on logout — correct: we don't want stale silence markers
@@ -87,6 +105,211 @@ UID_VAL="${UID:-$(id -u)}"
 mkdir -p "$WATCHDOG_STATE_DIR" 2>/dev/null || true
 
 now_epoch() { date +%s; }
+
+# Unified logging — every decision goes to journalctl with the
+# `switchroom-watchdog` tag AND to the unit's own stdout (which is
+# also captured by journal via StandardOutput=journal). Use level tags
+# (`detect`, `restart`, `skip`, `error`) so `journalctl -t
+# switchroom-watchdog | grep '\[restart\]'` is a clean audit trail of
+# every action this watchdog took.
+wd_log() {
+  local level="$1"
+  shift
+  local msg="$*"
+  logger -t switchroom-watchdog "[$level] $msg" 2>/dev/null || true
+  # Stdout (not stderr) matches the prior `echo` lines so existing
+  # systemd journal capture (StandardOutput=journal) and the test
+  # harness that reads stdout from execFileSync both see the line.
+  echo "$(date -Iseconds) watchdog [$level] $msg"
+}
+
+# Returns 0 (true) iff the agent shows ANY of two independent
+# forward-progress fingerprints within the last `$2` seconds:
+#
+#   1. `.claude/projects/**/*.jsonl` — Claude Code appends to these
+#      transcripts on every event (model output, tool_use, sub-agent
+#      activity). Fresh mtime ⇒ the model or a sub-agent is alive.
+#   2. `.claude/tasks/<session>/*.json` — TodoWrite / Task-tool state
+#      files. Updated independently of the transcript stream when the
+#      agent is iterating on a task list. Catches the case where the
+#      transcript momentarily quiets (large model thinking pause)
+#      while the agent is still progressing through todos.
+#
+# OR semantics: a wedged agent has to be silent on BOTH to be
+# declared dead. Two uncorrelated fingerprints make false positives
+# (kill while still working) much rarer than a single signal.
+#
+# `find -mmin` minimum granularity is minutes; round up to be
+# conservative (better to defer a restart by an extra minute than to
+# kill a live sub-agent). Both probes are bounded — quit on first
+# match — so this stays O(1)-ish even on busy projects.
+agent_has_recent_progress() {
+  local agent_name="$1"
+  local within_secs="$2"
+  local agent_root="${HOME}/.switchroom/agents/${agent_name}/.claude"
+  [[ -d "$agent_root" ]] || return 1
+  local mmin=$(( (within_secs + 59) / 60 ))
+  [[ "$mmin" -lt 1 ]] && mmin=1
+
+  # Signal 1: transcript JSONL writes (parent or sub-agent).
+  local hit
+  hit=$(find "${agent_root}/projects" -name '*.jsonl' -mmin "-${mmin}" -print -quit 2>/dev/null)
+  [[ -n "$hit" ]] && return 0
+
+  # Signal 2: TodoWrite/Task state JSON updates.
+  hit=$(find "${agent_root}/tasks" -name '*.json' -mmin "-${mmin}" -print -quit 2>/dev/null)
+  [[ -n "$hit" ]] && return 0
+
+  return 1
+}
+
+# ─── Forensic observation helpers ──────────────────────────────────────
+# Composed at every restart/detect/skip log line so `journalctl -t
+# switchroom-watchdog` carries enough context to reconstruct WHY any
+# action was taken without re-deriving from kernel/process state
+# after the fact (which is impossible — the process is gone after a
+# restart). Each helper is best-effort, returns a compact key=value
+# fragment, and never fails the script.
+
+# Resolve the most-interesting PID in the agent's systemd cgroup —
+# i.e., the actual `claude` process, not the start.sh / `script -qfc`
+# PTY wrappers that systemd reports as MainPID. Strategy:
+#
+#   1. Look up the unit's cgroup path via systemctl.
+#   2. Read `/sys/fs/cgroup/<cgroup>/cgroup.procs` for the full list.
+#   3. Pick the PID with the largest RSS — claude is reliably the
+#      memory-heaviest member of the cgroup (start.sh: ~2MB, script:
+#      ~1MB, claude: hundreds of MB to multiple GB).
+#
+# Falls back to MainPID if the cgroup walk fails (rare — only when
+# cgroup v2 isn't mounted at /sys/fs/cgroup or systemd reports an
+# unusual unit layout). Returns 0 when nothing resolvable.
+agent_main_pid() {
+  local name="$1"
+  local unit="switchroom-${name}.service"
+  local cgroup
+  cgroup=$(systemctl --user show "$unit" -p ControlGroup --value 2>/dev/null)
+  if [[ -n "$cgroup" && -r "/sys/fs/cgroup${cgroup}/cgroup.procs" ]]; then
+    # Pick the PID whose RSS (in KB) is largest. ps -o rss= prints
+    # just the rss column; pair with -p PID-list to score them.
+    local pids
+    pids=$(tr '\n' ' ' < "/sys/fs/cgroup${cgroup}/cgroup.procs" 2>/dev/null)
+    if [[ -n "$pids" ]]; then
+      local heaviest
+      heaviest=$(ps -o pid=,rss= -p $pids 2>/dev/null \
+        | awk 'BEGIN{best_pid=0; best_rss=0} {if ($2+0 > best_rss) {best_rss=$2+0; best_pid=$1+0}} END{print best_pid}')
+      if [[ "${heaviest:-0}" -gt 0 ]]; then
+        echo "$heaviest"
+        return 0
+      fi
+    fi
+  fi
+  systemctl --user show "$unit" -p MainPID --value 2>/dev/null || echo 0
+}
+
+# Process-state snapshot: state letter (R running, S sleeping, D
+# uninterruptible sleep — usually I/O wait or kernel stuck, Z zombie,
+# T stopped), CPU%, RSS in MB. State `D` for >30s is the smoking-gun
+# signature of a genuinely wedged process (the original #116 hangs).
+# Reads /proc/<pid>/stat for the state letter (field 3) and uses
+# `ps -o` for CPU/RSS — both cheap and free of GNU/BSD portability
+# pitfalls on Linux.
+agent_proc_snapshot() {
+  local pid="$1"
+  if [[ -z "$pid" || "$pid" == "0" ]]; then
+    echo "pid=0 state=missing"
+    return 0
+  fi
+  if [[ ! -r "/proc/${pid}/stat" ]]; then
+    echo "pid=${pid} state=gone"
+    return 0
+  fi
+  # /proc/<pid>/stat field 3 is the state letter. The comm field
+  # (field 2) is parenthesized and may contain spaces — strip it
+  # before splitting so awk indexing is reliable.
+  local stat_state
+  stat_state=$(awk '{
+    line=$0;
+    sub(/.*\) /, "", line);
+    split(line, a, " ");
+    print a[1];
+  }' "/proc/${pid}/stat" 2>/dev/null || echo "?")
+  local cpu rss
+  read -r cpu rss < <(ps -o pcpu=,rss= -p "$pid" 2>/dev/null | awk '{print $1, $2}')
+  cpu="${cpu:-?}"
+  rss="${rss:-0}"
+  local rss_mb=$(( rss / 1024 ))
+  echo "pid=${pid} state=${stat_state} cpu=${cpu}% rss_mb=${rss_mb}"
+}
+
+# Per-fingerprint freshness summary. Reports the age (in seconds) of
+# the newest JSONL transcript and tasks-state file under the agent's
+# `.claude/` tree. A wedged process shows both ages climbing past the
+# threshold; a working sub-agent shows at least one stays small.
+agent_progress_snapshot() {
+  local name="$1"
+  local agent_root="${HOME}/.switchroom/agents/${name}/.claude"
+  if [[ ! -d "$agent_root" ]]; then
+    echo "jsonl_age=- tasks_age=-"
+    return 0
+  fi
+  local now
+  now=$(now_epoch)
+  # Newest JSONL mtime (may be empty if no project history yet).
+  local newest_jsonl_mtime
+  newest_jsonl_mtime=$(find "${agent_root}/projects" -name '*.jsonl' \
+    -printf '%T@\n' 2>/dev/null | awk 'BEGIN{m=0} {if ($1+0 > m) m=$1+0} END{print int(m)}')
+  local newest_tasks_mtime
+  newest_tasks_mtime=$(find "${agent_root}/tasks" -name '*.json' \
+    -printf '%T@\n' 2>/dev/null | awk 'BEGIN{m=0} {if ($1+0 > m) m=$1+0} END{print int(m)}')
+  local jsonl_age="-"
+  local tasks_age="-"
+  if [[ "${newest_jsonl_mtime:-0}" -gt 0 ]]; then
+    jsonl_age=$(( now - newest_jsonl_mtime ))s
+  fi
+  if [[ "${newest_tasks_mtime:-0}" -gt 0 ]]; then
+    tasks_age=$(( now - newest_tasks_mtime ))s
+  fi
+  echo "jsonl_age=${jsonl_age} tasks_age=${tasks_age}"
+}
+
+# Compose the full forensic observation line: process state + the
+# two progress fingerprints. Embedded in every action log message so
+# the journal entry is self-contained — operators don't need to
+# re-run probes after the fact (which would be useless if the
+# process has been restarted in the meantime).
+agent_observation() {
+  local name="$1"
+  local pid
+  pid=$(agent_main_pid "$name")
+  local proc progress
+  proc=$(agent_proc_snapshot "$pid")
+  progress=$(agent_progress_snapshot "$name")
+  echo "${proc} ${progress}"
+}
+
+# Stamp a clean-shutdown.json marker into the agent's telegram state
+# dir BEFORE issuing a restart, so the next greeting card can render
+# "Restarted  <reason>". Mirrors the inline jq/printf logic that lived
+# in the bridge-disconnect path; pulled into a function so every
+# restart path stamps consistently. Best-effort: never fails.
+stamp_restart_reason() {
+  local marker="$1"
+  local reason="$2"
+  local ts_ms
+  ts_ms=$(( $(date +%s) * 1000 ))
+  local tmp="${marker}.tmp-$$"
+  if command -v jq >/dev/null 2>&1; then
+    jq -n --argjson ts "$ts_ms" --arg reason "$reason" \
+      '{ts: $ts, signal: "SIGTERM", reason: $reason}' > "$tmp" 2>/dev/null \
+      && mv -f "$tmp" "$marker" 2>/dev/null || rm -f "$tmp" 2>/dev/null || true
+  else
+    local esc_reason
+    esc_reason=$(printf '%s' "$reason" | sed 's/\\/\\\\/g; s/"/\\"/g')
+    printf '{"ts":%s,"signal":"SIGTERM","reason":"%s"}' "$ts_ms" "$esc_reason" > "$tmp" 2>/dev/null \
+      && mv -f "$tmp" "$marker" 2>/dev/null || rm -f "$tmp" 2>/dev/null || true
+  fi
+}
 
 # Discover active gateway units. systemd's list-units output includes only
 # currently-loaded units; we filter to the switchroom-*-gateway.service
@@ -117,7 +340,7 @@ for gateway_svc in "${gateway_services[@]}"; do
     systemctl --user show "$gateway_svc" -p WorkingDirectory --value 2>/dev/null
   )"
   if [[ -z "$gateway_state_dir" ]]; then
-    echo "$(date -Iseconds) watchdog: ${agent} gateway has no WorkingDirectory; skipping"
+    wd_log error "agent=${agent} gateway has no WorkingDirectory; skipping"
     continue
   fi
   gateway_log="${gateway_state_dir}/gateway.log"
@@ -151,12 +374,12 @@ for gateway_svc in "${gateway_services[@]}"; do
     # — that needs operator intervention, not a restart loop.
     state="$(systemctl --user show "$agent_svc" -p ActiveState --value 2>/dev/null)"
     if [[ "$state" == "failed" ]]; then
-      echo "$(date -Iseconds) watchdog: ${agent_svc} is failed state; skipping (needs operator reset-failed)"
+      wd_log skip "agent=${agent} reason=service-failed decision=needs-operator-reset state=${state} $(agent_progress_snapshot "$agent") (unit in failed state; needs operator reset-failed)"
       continue
     fi
-    echo "$(date -Iseconds) watchdog: ${agent} agent service is inactive (${state}); starting ${agent_svc}"
+    wd_log restart "agent=${agent} reason=service-inactive state=${state} action=start $(agent_progress_snapshot "$agent") (agent service is inactive)"
     systemctl --user start "$agent_svc" || {
-      echo "$(date -Iseconds) watchdog: ${agent_svc} start failed"
+      wd_log error "agent=${agent} systemctl start failed"
     }
     continue
   fi
@@ -227,7 +450,7 @@ for gateway_svc in "${gateway_services[@]}"; do
       liveness_age=$(( $(now_epoch) - liveness_mtime ))
       if (( liveness_age < LIVENESS_GRACE_SECS )); then
         bridge_healthy=true
-        echo "$(date -Iseconds) watchdog: ${agent} bridge socket disconnected but liveness file is fresh (${liveness_age}s ago); bridge process alive, skipping restart"
+        wd_log skip "agent=${agent} reason=bridge-socket-flap decision=liveness-file-fresh liveness_age=${liveness_age}s threshold=${LIVENESS_GRACE_SECS}s $(agent_observation "$agent") (liveness file is fresh)"
       fi
     fi
   fi
@@ -261,7 +484,21 @@ for gateway_svc in "${gateway_services[@]}"; do
     continue
   fi
 
-  echo "$(date -Iseconds) watchdog: ${agent} bridge has been disconnected for ${disc_duration}s (>= ${DISCONNECT_GRACE_SECS}s), restarting ${agent_svc}"
+  # Progress gate — same defence as turn-hang/journal-silence. A
+  # bridge can flap (MCP plugin crash, transient socket close)
+  # while a sub-agent is still doing real work. Without this gate
+  # the bridge-disconnect path would kill any in-flight sub-agent
+  # whenever the bridge had a bad minute. Skip the restart if any
+  # forward-progress fingerprint is fresh and just keep the
+  # disconnect marker around — next tick will re-evaluate.
+  observation=$(agent_observation "$agent")
+  if agent_has_recent_progress "$agent" "$JSONL_LIVENESS_SECS"; then
+    wd_log skip "agent=${agent} reason=bridge-disconnect disc_duration=${disc_duration}s threshold=${DISCONNECT_GRACE_SECS}s decision=defer-progress-fresh ${observation}"
+    continue
+  fi
+
+  wd_log detect "agent=${agent} reason=bridge-disconnect disc_duration=${disc_duration}s threshold=${DISCONNECT_GRACE_SECS}s ${observation}"
+  wd_log restart "agent=${agent} reason=bridge-disconnect disc_duration=${disc_duration}s threshold=${DISCONNECT_GRACE_SECS}s ${observation}"
   # Clear the marker so post-restart we don't immediately re-trip on
   # the still-old tail. The uptime grace will cover the startup window
   # anyway, but removing the marker keeps state clean.
@@ -270,27 +507,34 @@ for gateway_svc in "${gateway_services[@]}"; do
   # "Restarted  watchdog: bridge disconnected for ${disc_duration}s".
   # The gateway's own SIGTERM handler writes `clean-shutdown.json` on
   # shutdown too — but its marker carries no `reason`, so the greeting
-  # omits the row. Pre-seeding here wins the race: we write it BEFORE
-  # issuing systemctl restart so it's on disk by the time the new
-  # processes boot. Best-effort: if jq is unavailable fall back to a
-  # printf-shaped JSON literal.
-  _clean_marker="${gateway_state_dir}/clean-shutdown.json"
-  _ts_ms=$(( $(date +%s) * 1000 ))
-  _reason="watchdog: bridge disconnected for ${disc_duration}s"
-  _tmp="${_clean_marker}.tmp-$$"
-  if command -v jq >/dev/null 2>&1; then
-    jq -n --argjson ts "$_ts_ms" --arg reason "$_reason" \
-      '{ts: $ts, signal: "SIGTERM", reason: $reason}' > "$_tmp" 2>/dev/null \
-      && mv -f "$_tmp" "$_clean_marker" 2>/dev/null || rm -f "$_tmp" 2>/dev/null || true
-  else
-    # Escape backslashes and double-quotes in the reason for safe JSON embedding.
-    _esc_reason=$(printf '%s' "$_reason" | sed 's/\\/\\\\/g; s/"/\\"/g')
-    printf '{"ts":%s,"signal":"SIGTERM","reason":"%s"}' "$_ts_ms" "$_esc_reason" > "$_tmp" 2>/dev/null \
-      && mv -f "$_tmp" "$_clean_marker" 2>/dev/null || rm -f "$_tmp" 2>/dev/null || true
+  # omits the row.
+  stamp_restart_reason \
+    "${gateway_state_dir}/clean-shutdown.json" \
+    "watchdog: bridge disconnected for ${disc_duration}s"
+  # Route through `switchroom agent restart` (not raw systemctl) for
+  # parity with the turn-hang and journal-silence paths: the CLI's
+  # in-flight guard is one more belt-and-suspenders check, and config
+  # reconciliation runs on every lifecycle transition per the project
+  # contract. Falls back to systemctl if the CLI isn't on PATH.
+  switchroom_cli=""
+  for candidate in "${HOME}/.bun/bin/switchroom" "${HOME}/.local/bin/switchroom"; do
+    if [[ -x "$candidate" ]]; then
+      switchroom_cli="$candidate"
+      break
+    fi
+  done
+  if [[ -z "$switchroom_cli" ]] && command -v switchroom >/dev/null 2>&1; then
+    switchroom_cli="$(command -v switchroom)"
   fi
-  systemctl --user restart "$agent_svc" || {
-    echo "$(date -Iseconds) watchdog: ${agent_svc} restart failed"
-  }
+  if [[ -n "$switchroom_cli" ]]; then
+    "$switchroom_cli" agent restart "$agent" || {
+      wd_log error "agent=${agent} switchroom agent restart failed; falling back to systemctl --user restart"
+      systemctl --user restart "$agent_svc" || true
+    }
+  else
+    wd_log error "agent=${agent} switchroom CLI not on PATH; using systemctl restart fallback"
+    systemctl --user restart "$agent_svc" || true
+  fi
 done
 
 # ─── Journal-silence check ───────────────────────────────────────────────────
@@ -358,8 +602,25 @@ for agent_svc in "${agent_services[@]}"; do
     if [[ "$turn_mtime" -gt 0 ]]; then
       turn_age=$(( $(now_epoch) - turn_mtime ))
       if [[ "$turn_age" -ge "$TURN_HANG_SECS" ]]; then
-        logger -t switchroom-watchdog "agent ${agent}: turn-active marker stale (${turn_age}s >= ${TURN_HANG_SECS}s); restarting via switchroom agent restart (#412)"
-        echo "$(date -Iseconds) watchdog: ${agent} wedged mid-turn (${turn_age}s), restarting"
+        # Progress gate — sub-agent activity does NOT bump the
+        # parent's turn-active marker, so a stale marker plus fresh
+        # JSONL writes means a sub-agent (or the main turn) is doing
+        # real work and a restart would kill it mid-flight. This was
+        # the dominant false-positive path observed in the journal
+        # 2026-05-02 (finn/klanker restarted while sub-agents had
+        # `last activity: 0s ago` per the in-flight detector).
+        observation=$(agent_observation "$agent")
+        if agent_has_recent_progress "$agent" "$JSONL_LIVENESS_SECS"; then
+          wd_log skip "agent=${agent} reason=turn-hang turn_age=${turn_age}s threshold=${TURN_HANG_SECS}s decision=defer-progress-fresh ${observation}"
+          continue
+        fi
+        wd_log detect "agent=${agent} reason=turn-hang turn_age=${turn_age}s threshold=${TURN_HANG_SECS}s ${observation} (no progress fingerprints within ${JSONL_LIVENESS_SECS}s — wedged mid-turn)"
+        # Stamp the reason BEFORE the restart so the next greeting
+        # card renders "Restarted  watchdog: …".
+        stamp_restart_reason \
+          "${agent_state_dir}/clean-shutdown.json" \
+          "watchdog: turn-active marker stale ${turn_age}s with no JSONL activity"
+        wd_log restart "agent=${agent} reason=turn-hang turn_age=${turn_age}s threshold=${TURN_HANG_SECS}s ${observation}"
         # Resolve the switchroom CLI (same belt-and-suspenders as below)
         switchroom_cli=""
         for candidate in "${HOME}/.bun/bin/switchroom" "${HOME}/.local/bin/switchroom"; do
@@ -373,10 +634,11 @@ for agent_svc in "${agent_services[@]}"; do
         fi
         if [[ -n "$switchroom_cli" ]]; then
           "$switchroom_cli" agent restart "$agent" || {
-            logger -t switchroom-watchdog "agent ${agent}: switchroom agent restart failed; falling back to systemctl"
+            wd_log error "agent=${agent} switchroom agent restart failed; falling back to systemctl --user restart"
             systemctl --user restart "$agent_svc" || true
           }
         else
+          wd_log error "agent=${agent} switchroom CLI not on PATH; using systemctl restart fallback"
           systemctl --user restart "$agent_svc" || true
         fi
         # Restarted — skip remaining checks for this agent this tick.
@@ -446,7 +708,7 @@ for agent_svc in "${agent_services[@]}"; do
   else
     echo "$now" > "$silence_marker"
     silence_since="$now"
-    logger -t switchroom-watchdog "agent ${agent}: journal silent for ${journal_age}s; recording silence marker (will restart after ${JOURNAL_SILENCE_HARD_SECS}s of sustained silence)"
+    wd_log detect "agent=${agent} reason=journal-silence journal_age=${journal_age}s threshold=${JOURNAL_SILENCE_SECS}s decision=record-silence-marker $(agent_observation "$agent") (will restart after ${JOURNAL_SILENCE_HARD_SECS}s of sustained silence)"
     continue
   fi
 
@@ -456,11 +718,27 @@ for agent_svc in "${agent_services[@]}"; do
     continue
   fi
 
+  # Progress gate — same defence as the turn-hang path. A silent
+  # agent journal can co-exist with a busy sub-agent (the parent's
+  # stdout goes quiet while the sub-agent runs). If JSONL or tasks
+  # writes are happening, real work is in progress; don't restart.
+  observation=$(agent_observation "$agent")
+  if agent_has_recent_progress "$agent" "$JSONL_LIVENESS_SECS"; then
+    wd_log skip "agent=${agent} reason=journal-silence journal_age=${journal_age}s silence_duration=${silence_duration}s threshold=${JOURNAL_SILENCE_HARD_SECS}s decision=defer-progress-fresh ${observation}"
+    rm -f "$silence_marker" 2>/dev/null || true
+    continue
+  fi
+
   # The agent has been journal-silent for >= JOURNAL_SILENCE_HARD_SECS
-  # AND has cleared the uptime grace. This matches the production hang
-  # pattern (issue #116). Restart via the switchroom CLI.
-  logger -t switchroom-watchdog "agent ${agent}: journal silent for ${journal_age}s (marker age ${silence_duration}s >= ${JOURNAL_SILENCE_HARD_SECS}s); restarting via switchroom agent restart"
-  echo "$(date -Iseconds) watchdog: ${agent} journal silent for ${journal_age}s, restarting"
+  # AND has cleared the uptime grace AND has no progress fingerprints.
+  # This matches the production hang pattern (issue #116). Restart
+  # via the switchroom CLI.
+  wd_log detect "agent=${agent} reason=journal-silence journal_age=${journal_age}s silence_duration=${silence_duration}s threshold=${JOURNAL_SILENCE_HARD_SECS}s ${observation} (no progress fingerprints — wedged)"
+  agent_state_dir="${HOME}/.switchroom/agents/${agent}/telegram"
+  stamp_restart_reason \
+    "${agent_state_dir}/clean-shutdown.json" \
+    "watchdog: journal silent for ${journal_age}s with no progress activity"
+  wd_log restart "agent=${agent} reason=journal-silence journal_age=${journal_age}s silence_duration=${silence_duration}s threshold=${JOURNAL_SILENCE_HARD_SECS}s ${observation}"
   rm -f "$silence_marker" 2>/dev/null || true
 
   # Use `switchroom agent restart` (not raw systemctl) — the project
@@ -486,13 +764,13 @@ for agent_svc in "${agent_services[@]}"; do
 
   if [[ -n "$switchroom_cli" ]]; then
     "$switchroom_cli" agent restart "$agent" || {
-      logger -t switchroom-watchdog "agent ${agent}: switchroom agent restart failed; falling back to systemctl"
+      wd_log error "agent=${agent} switchroom agent restart failed; falling back to systemctl --user restart"
       systemctl --user restart "$agent_svc" || true
     }
   else
     # Fallback: if the switchroom CLI isn't on PATH (unusual), use systemctl
     # directly and log the degraded path.
-    logger -t switchroom-watchdog "agent ${agent}: switchroom CLI not on PATH; using systemctl restart as fallback"
+    wd_log error "agent=${agent} switchroom CLI not on PATH; using systemctl restart fallback"
     systemctl --user restart "$agent_svc" || true
   fi
 done

--- a/profiles/_base/start.sh.hbs
+++ b/profiles/_base/start.sh.hbs
@@ -226,6 +226,27 @@ if [ -f "$SWITCHROOM_PENDING_TURN_ENV" ]; then
          SWITCHROOM_PENDING_STARTED_AT
 fi
 
+# --- Wake audit sentinel ---
+#
+# Every boot drops a `.wake-audit-pending` sentinel into the telegram
+# state dir. The agent's CLAUDE.md (`telegram-style.md.hbs` "Wake
+# audit" section) instructs it to detect this file at the start of
+# its first turn after boot, run a three-signal check (owed reply /
+# orphan sub-agents / open todos), surface findings to the user, and
+# `rm -f` the file. This complements the SWITCHROOM_PENDING_TURN env
+# (which only fires when a turn was in flight at SIGTERM) by also
+# catching: long silent restarts after a "I'll come back to you"
+# promise, sub-agent jobs killed by the watchdog, dropped stop-hook
+# state, and any user message that landed while the gateway was down.
+#
+# Sentinel-file approach (rather than env var) keeps the signal
+# durable across the entire process lifetime: even if the agent
+# defers the audit by N turns, the file remains until handled. start.sh
+# can't track first-turn vs subsequent-turn boundaries, but the agent
+# can — `rm -f` after the first audit makes it idempotent.
+mkdir -p "$TELEGRAM_STATE_DIR" 2>/dev/null || true
+: > "$TELEGRAM_STATE_DIR/.wake-audit-pending" 2>/dev/null || true
+
 {{#if handoffEnabled}}
 # --- Session handoff briefing ---
 # On a normal shutdown the Stop hook writes .handoff.md (compact

--- a/profiles/_shared/telegram-style.md.hbs
+++ b/profiles/_shared/telegram-style.md.hbs
@@ -63,6 +63,41 @@ The env vars are one-shot — start.sh deletes the file after sourcing. So this 
 
 If `SWITCHROOM_PENDING_TURN` is unset or empty, do nothing special — the previous turn ended cleanly.
 
+**Wake audit — every fresh boot, check what you owe before responding.** When `start.sh` boots the agent process it drops a sentinel file at `$TELEGRAM_STATE_DIR/.wake-audit-pending`. On your first turn after a fresh boot, before answering whatever the user just sent, check three things and surface anything outstanding. After acting on the findings (or confirming none), `rm -f` the sentinel so subsequent turns in the same session don't re-audit. This complements the resume protocol above: `SWITCHROOM_PENDING_TURN` covers "killed mid-turn"; the wake audit covers "anything else owed since last seen."
+
+```bash
+# Step 0: is an audit pending? (cheap test — exit if not)
+[ -f "$TELEGRAM_STATE_DIR/.wake-audit-pending" ] || exit 0
+```
+
+If the sentinel exists, run all three checks:
+
+1. **Owed replies** (the most common "you forgot me" failure). Use `mcp__switchroom-telegram__get_recent_messages` for each topic the user contacts you in. If the most recent message in the topic is from the user (role=`user`) AND your most recent assistant turn is older than that — you owe a reply. There is no in-flight env var for this case because the gateway was idle when the message arrived (or down entirely). Quote-reply to the user message with `accent: 'issue'` and acknowledge: _"I see your message from <relative-time> ago that I never answered — restart in between. Want me to handle it now?"_
+
+2. **Orphan sub-agents** (jobs the watchdog killed mid-flight). Run:
+   ```bash
+   find "$CLAUDE_CONFIG_DIR/projects" -path '*/subagents/*.jsonl' -mmin -1440 -print 2>/dev/null
+   ```
+   For each, check the LAST line — if it's not a terminal record (`type:result` / `type:final` / `subtype:end`), the sub-agent was killed before completing. Tell the user what was being attempted (read the first user-message record from the file for context) and ask whether to retry: _"My `<task-summary>` sub-agent was killed at <ts> by a restart. Want me to redispatch?"_
+
+3. **Open todos** (in-process work that never finished). Scan recent task state:
+   ```bash
+   find "$CLAUDE_CONFIG_DIR/tasks" -name '*.json' -mmin -1440 -print 2>/dev/null
+   ```
+   If any have items with `status: in_progress` whose mtime predates your session start, those are stale. Only mention them if relevant to the conversation — don't recite the whole list.
+
+**Idempotency**: after the audit (whether anything was found or not), run `rm -f "$TELEGRAM_STATE_DIR/.wake-audit-pending"`. The file's absence means "audit complete for this process boot" — every restart re-creates it.
+
+**Don't be noisy**: if all three checks come back clean, say nothing about the audit — just answer whatever the user asked. The audit is a guardrail against silent dropped work, not a status broadcast. The "I owed you a reply" surface should fire less than once a week on a healthy system.
+
+**"Why did you restart?" — read the audit trail, don't guess.** The `SWITCHROOM_PENDING_*` env vars are one-shot (cleared by start.sh on first read), so by the time a user asks "why did you restart?" they're long gone. Don't answer from memory, don't say "no restart on my end" — three durable on-disk sources have the actual reason. Check them in this order:
+
+1. **`$TELEGRAM_STATE_DIR/clean-shutdown.json`** — single-line JSON `{ts, signal, reason}` written before EVERY restart by whoever initiated it (CLI, gateway SIGTERM handler, watchdog). Fastest answer for "what was THIS boot's reason." Example: `cat "$TELEGRAM_STATE_DIR/clean-shutdown.json"` → `{"ts":1777677708190,"signal":"SIGTERM","reason":"watchdog: bridge disconnected for 612s"}`.
+2. **`journalctl --user -t switchroom-watchdog --since "2 hours ago"`** — the watchdog's audit log. Every action is one line tagged `[restart] / [skip] / [detect] / [error]` with full forensic context: `agent=NAME reason=KIND threshold=Ns observed=Ns pid=… state=… cpu=…% rss_mb=… jsonl_age=Ns tasks_age=Ns`. Use this to explain WHY the watchdog acted (or didn't) and what it observed.
+3. **`journalctl --user -u switchroom-$SWITCHROOM_AGENT_NAME --since "2 hours ago"`** — the agent unit's systemd-level history. Confirms restart timestamps, exit codes, and any `Restart=on-failure` auto-restarts that bypassed the CLI/watchdog paths.
+
+Quote the reason field verbatim when answering — don't paraphrase. If `clean-shutdown.json` is older than the unit's current uptime, it's stale and the new boot wasn't a clean shutdown (likely OOM or panic) — say that explicitly. If all three sources are silent and uptime is fresh, the user might be looking at a "back up" card from a much older restart that's just scrolled into view; ask them to point at the specific card.
+
 **"status?" / "still there?" / "any update?" is a UX-failure signal, not a feature request.** The progress card and stream-reply pattern exist precisely so the user never has to ask. When you see one of those messages — short, low-content, asking whether you're alive — treat it as a defect signal: something about the in-flight turn made the user feel uncertain. The product expectation (per `reference/know-what-my-agent-is-doing.md`) is that this rate trends to zero.
 
 Your response in this case should:

--- a/src/cli/auth.ts
+++ b/src/cli/auth.ts
@@ -102,11 +102,18 @@ export function diagnoseAuthState(claudeConfigDir: string): AuthDiagnosis {
   const hasCreds = existsSync(credsPath);
   const hasOauthToken = existsSync(oauthTokenPath);
 
+  // Summary text is the user-facing string surfaced in the boot-self-test
+  // issue card on Telegram. It must be ACTIONABLE without docs — see
+  // reference/principles.md "docs test." The technical fingerprint is
+  // preserved in `code` for forensics; `summary` tells the user what to
+  // do. Send /auth in the agent's chat to open the inline auth dashboard
+  // (telegram-plugin/auth-dashboard.ts), which has Reauth / Add / Use
+  // buttons — no terminal needed.
   if (!hasCreds && !hasOauthToken) {
     findings.push({
       code: "credentials_missing",
       severity: "error",
-      summary: "no .credentials.json AND no .oauth-token - agent has never been authenticated",
+      summary: "needs first-time login — send /auth in this chat to start the flow",
     });
   } else if (!hasCreds) {
     // .oauth-token alone is the legacy state — works for in-process
@@ -115,7 +122,7 @@ export function diagnoseAuthState(claudeConfigDir: string): AuthDiagnosis {
     findings.push({
       code: "credentials_missing",
       severity: "warn",
-      summary: ".credentials.json absent (only .oauth-token present); claude can't self-refresh",
+      summary: "send /auth in this chat to refresh credentials (hooks need them)",
     });
   } else {
     let parsed:
@@ -127,7 +134,7 @@ export function diagnoseAuthState(claudeConfigDir: string): AuthDiagnosis {
       findings.push({
         code: "credentials_malformed",
         severity: "error",
-        summary: ".credentials.json is not valid JSON - file corrupted",
+        summary: "credentials file corrupted — send /auth in this chat to reset",
       });
     }
     if (parsed) {
@@ -136,7 +143,7 @@ export function diagnoseAuthState(claudeConfigDir: string): AuthDiagnosis {
         findings.push({
           code: "credentials_malformed",
           severity: "error",
-          summary: ".credentials.json missing claudeAiOauth.accessToken - file corrupted",
+          summary: "credentials file corrupted — send /auth in this chat to reset",
         });
       } else {
         // Token shape OK; check expiry.
@@ -149,14 +156,14 @@ export function diagnoseAuthState(claudeConfigDir: string): AuthDiagnosis {
             findings.push({
               code: "credentials_malformed",
               severity: "warn",
-              summary: ".credentials.json claudeAiOauth.expiresAt is non-finite",
+              summary: "credentials file has invalid expiry — send /auth in this chat to reset",
             });
           } else if (expiresAt < Date.now()) {
             const days = Math.floor((Date.now() - expiresAt) / 86_400_000);
             findings.push({
               code: "token_expired",
               severity: "error",
-              summary: `access token expired ${days}d ago`,
+              summary: `login expired ${days}d ago — send /auth in this chat to refresh`,
             });
           }
         } else if (expiresAt !== undefined) {
@@ -166,7 +173,7 @@ export function diagnoseAuthState(claudeConfigDir: string): AuthDiagnosis {
           findings.push({
             code: "credentials_malformed",
             severity: "warn",
-            summary: ".credentials.json claudeAiOauth.expiresAt is missing or non-numeric",
+            summary: "credentials file has invalid expiry — send /auth in this chat to reset",
           });
         }
         // Refresh token: warn if missing.
@@ -174,7 +181,7 @@ export function diagnoseAuthState(claudeConfigDir: string): AuthDiagnosis {
           findings.push({
             code: "refresh_token_missing",
             severity: "warn",
-            summary: "no refreshToken - claude can't self-refresh; will break when access token expires",
+            summary: "send /auth in this chat to renew credentials before they expire",
           });
         }
       }

--- a/telegram-plugin/gateway/boot-card.ts
+++ b/telegram-plugin/gateway/boot-card.ts
@@ -140,27 +140,38 @@ export interface BootCardSkipDecision {
 /**
  * Decide whether to skip posting the boot card based on gateway state.
  *
- * The boot path runs first (in the gateway IIFE) and sets activeBootCard
- * on success. The bridge-reconnect path runs later when the agent
- * registers; without this guard it posts a duplicate card.
+ * Two emit sites contend on every gateway lifetime:
  *
- * Boot path: never skip — it's the primary post site.
- * Bridge-reconnect: skip if a card is in-flight OR was already posted
- * this lifetime. The in-flight check closes the race against an
- * unresolved sendMessage await (issue #489).
+ *   - `boot`: the gateway IIFE startup path (long: probes session
+ *     marker, clean-shutdown marker, restart marker, etc).
+ *   - `bridge-reconnect`: fires when the agent's IPC client connects
+ *     to the gateway socket.
+ *
+ * Earlier versions of this gate special-cased `boot` as "primary"
+ * and let it post unconditionally. Empirically that assumption is
+ * wrong: when the agent process boots faster than the gateway IIFE
+ * reaches its emit, bridge-reconnect runs first, posts its card,
+ * and then boot fires its own card too — both with reason=graceful
+ * within ~100ms (observed in finn 2026-05-02: msgId 673 + 674
+ * with both `posted` log lines on consecutive lines).
+ *
+ * The fix is first-write-wins: whichever site fires first claims
+ * `bootCardPending` synchronously, posts the card, and releases.
+ * The other site sees pending or active and defers. Both sites'
+ * chat resolution is identical (same restart-marker / clean-shutdown
+ * / session-marker pipeline), so it doesn't matter which one wins.
  */
 export function shouldSkipDuplicateBootCard(
   gate: BootCardGate,
   site: BootCardSite,
 ): BootCardSkipDecision {
-  if (site === 'boot') return { skip: false }
   if (gate.bootCardPending) {
-    return { skip: true, reason: 'in-flight-on-boot-path' }
+    return { skip: true, reason: `in-flight-other-site site=${site}` }
   }
   if (gate.activeBootCard != null) {
     return {
       skip: true,
-      reason: `already-posted-msgId=${gate.activeBootCard.messageId}`,
+      reason: `already-posted-msgId=${gate.activeBootCard.messageId} site=${site}`,
     }
   }
   return { skip: false }

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -41,7 +41,6 @@ import {
   type Phase,
 } from '../placeholder-phase.js'
 import { StatusReactionController } from '../status-reactions.js'
-import { firstPaintTurn } from '../first-paint.js'
 import { isTelegramReplyTool, isTelegramSurfaceTool } from '../tool-names.js'
 import { createTypingWrapper } from '../typing-wrap.js'
 import { type DraftStreamHandle } from '../draft-stream.js'
@@ -4002,50 +4001,107 @@ async function handleInbound(
     return
   }
 
-  // First-paint slice: status-reaction setup + progressDriver.startTurn for
-  // fresh turns. Extracted to telegram-plugin/first-paint.ts so the
-  // waiting-UX harness can drive the real path with fakes (Phase 1 of #545).
-  // Behavior here is unchanged — the seam is a thin wrapper around the
-  // existing logic with module-level state passed via deps.
-  const firstPaintResult = await firstPaintTurn(
-    {
-      bot,
-      progressDriver,
-      activeStatusReactions,
-      activeReactionMsgIds,
-      activeTurnStartedAt,
-      progressUpdateTurnCount,
-      activeDraftStreams,
-      activeDraftParseModes,
-      suppressPtyPreview,
-      statusKey,
-      streamKey,
-      purgeReactionTracking,
-      signalTracker,
-      resolveAgentDirFromEnv,
-      addActiveReaction,
-      logStreamingEvent,
-    },
-    {
-      chatId: chat_id,
-      messageId: msgId,
-      messageThreadId,
-      isSteerPrefix,
-      effectiveText,
-      inboundReceivedAt,
-      access,
-    },
-  )
-  const isSteering = firstPaintResult.isSteering
-  const priorTurnStartedAt = firstPaintResult.priorTurnStartedAt
+  // Status reaction controller
+  let isSteering = false
+  let priorTurnStartedAt: number | undefined
+  if (msgId != null) {
+    const key = statusKey(chat_id, messageThreadId)
+    const priorActive = activeStatusReactions.get(key)
+    const priorTurnInFlight = priorActive != null
+    // New default: mid-turn messages are queued unless the user explicitly
+    // steers. isSteering is true only when the steer prefix is present.
+    // (Legacy: without any prefix the old behavior was isSteering=true; now
+    // it's false so the message goes through as queued="true".)
+    isSteering = priorTurnInFlight && isSteerPrefix
+    if (priorTurnInFlight) priorTurnStartedAt = activeTurnStartedAt.get(key)
 
-  // Fresh-turn-only block: progressDriver.startTurn already fired inside
-  // firstPaintTurn above. What stays inline here is the pre-alloc draft +
-  // forum-topic placeholder + heartbeat scheduling — gated by the same
-  // !isSteering && no-prior-turn condition because they're all "first
-  // visible signal" siblings of startTurn. They depend on too much
-  // module-level state to fold into the seam without ballooning deps.
+    if (access.statusReactions !== false) {
+      if (isSteering) {
+        // Explicit steer: mark with 🤝 on the inbound message; leave the
+        // existing StatusReactionController running for the in-flight turn.
+        void bot.api.setMessageReaction(chat_id, msgId, [{ type: 'emoji', emoji: '🤝' }]).catch(() => {})
+      } else if (priorTurnInFlight) {
+        // Queued mid-turn message (new default): don't touch the existing
+        // controller; just ack the inbound message with 👀 so the user
+        // knows we received it, without disrupting the in-flight reaction.
+        void bot.api.setMessageReaction(chat_id, msgId, [{ type: 'emoji', emoji: '👀' }]).catch(() => {})
+        // #203: time-to-ack metric — measure gateway-receive → ack-post delta.
+        logStreamingEvent({ kind: 'inbound_ack', chatId: chat_id, messageId: msgId, ackDelayMs: Date.now() - inboundReceivedAt })
+      } else {
+        // Fresh turn (no prior turn in flight): cancel any stale controller
+        // and start a new one for this message.
+        if (priorActive) {
+          priorActive.cancel()
+          purgeReactionTracking(key)
+        }
+        const sKey = streamKey(chat_id, messageThreadId)
+        const priorStream = activeDraftStreams.get(sKey)
+        if (priorStream && !priorStream.isFinal()) {
+          // Closes #472 finding #17 — pre-fix this finalize was
+          // fire-and-forget. The new turn's reply tool would then create
+          // a fresh stream and send its first chunk while the prior
+          // stream's terminal sendMessage was still in flight. The
+          // late-materialise landed AFTER the new turn's content,
+          // visible to the user as a stale "Done" message followed by
+          // the new reply (or worse — duplicate content).
+          //
+          // Awaiting here costs the few hundred ms the final API call
+          // takes, but only on rapid follow-ups where the prior turn
+          // hadn't yet flushed. The latency hit beats the duplicate-
+          // content bug. Delete from the map FIRST so any concurrent
+          // reads can't see the stale stream while we await.
+          activeDraftStreams.delete(sKey)
+          activeDraftParseModes.delete(sKey)
+          await priorStream.finalize().catch(() => {})
+        }
+        suppressPtyPreview.delete(sKey)
+
+        const ctrl = new StatusReactionController(async (emoji) => {
+          await bot.api.setMessageReaction(chat_id, msgId, [
+            { type: 'emoji', emoji: emoji as ReactionTypeEmoji['emoji'] },
+          ])
+          // #203: every status-reaction transition is a user-visible signal.
+          signalTracker.noteSignal(key, Date.now())
+        })
+        activeStatusReactions.set(key, ctrl)
+        activeReactionMsgIds.set(key, { chatId: chat_id, messageId: msgId })
+        activeTurnStartedAt.set(key, Date.now())
+        progressUpdateTurnCount.set(key, 0)  // Reset turn counter
+        ctrl.setQueued()
+        // #203: time-to-ack metric — setQueued() triggers the initial 👀 reaction
+        // asynchronously through the controller chain.
+        logStreamingEvent({ kind: 'inbound_ack', chatId: chat_id, messageId: msgId, ackDelayMs: Date.now() - inboundReceivedAt })
+        // #203: signal tracker — start tracking silent gaps for this fresh turn.
+        signalTracker.reset(statusKey(chat_id, messageThreadId), Date.now())
+        const agentDir = resolveAgentDirFromEnv()
+        if (agentDir != null) {
+          addActiveReaction(agentDir, { chatId: chat_id, messageId: msgId, threadId: messageThreadId ?? null, reactedAt: Date.now() })
+        }
+      }
+    } else if (access.ackReaction) {
+      void bot.api.setMessageReaction(chat_id, msgId, [
+        { type: 'emoji', emoji: access.ackReaction as ReactionTypeEmoji['emoji'] },
+      ]).catch(() => {})
+      // #203: time-to-ack metric for the custom-ack-reaction path.
+      logStreamingEvent({ kind: 'inbound_ack', chatId: chat_id, messageId: msgId, ackDelayMs: Date.now() - inboundReceivedAt })
+    }
+  }
+
+  // Start a new progress card only for fresh turns (no prior turn in flight).
+  // Queued mid-turn messages piggyback on the existing card; steer messages
+  // also don't start a new card (the in-flight turn owns it).
   if (!isSteering && priorTurnStartedAt == null) {
+    try {
+      progressDriver?.startTurn({
+        chatId: chat_id,
+        threadId: messageThreadId != null ? String(messageThreadId) : undefined,
+        userText: effectiveText,
+        replyToMessageId: msgId != null ? msgId : undefined,
+      })
+    } catch (err) {
+      process.stderr.write(`telegram gateway: progress-card startTurn failed: ${(err as Error).message}\n`)
+    }
+
     // Issue #416 — pre-allocate a sendMessageDraft for instant visual feedback
     // in DMs. The agent's first stream_reply consumes this draft id instead
     // of allocating a new one, so the user sees a placeholder draft within
@@ -8209,39 +8265,50 @@ void (async () => {
 
             if (target) {
               const { chatId, threadId, ackMsgId } = target
-              process.stderr.write(`telegram gateway: boot: posting boot card reason=${reason} chat_id=${chatId} thread_id=${threadId ?? '-'} ackReply=${ackMsgId ?? '-'} boot_card=${BOOT_CARD_ENABLED}\n`)
-              ensureIssuesCard(chatId, threadId)
-              if (BOOT_CARD_ENABLED) {
-                const agentDir = resolveAgentDirFromEnv()
-                const agentSlug = process.env.SWITCHROOM_AGENT_NAME ?? '-'
-                const agentDisplayName = resolvePersonaName(agentSlug)
-                const botApiForCard: import('./boot-card.js').BotApiForBootCard = {
-                  sendMessage: (cid, text, opts) => lockedBot.api.sendMessage(cid, text, opts as Parameters<typeof lockedBot.api.sendMessage>[2]) as Promise<{ message_id: number }>,
-                  editMessageText: (cid, mid, text, opts) => lockedBot.api.editMessageText(cid, mid, text, opts as Parameters<typeof lockedBot.api.editMessageText>[3]),
-                }
-                // Claim emission ownership synchronously BEFORE the await so
-                // the bridge-reconnect dedupe (which can run during this
-                // sendMessage round-trip) sees an in-flight emit. See #489.
-                bootCardPending = true
-                try {
-                  const handle = await startBootCard(chatId, threadId, botApiForCard, {
-                    agentName: agentDisplayName,
-                    agentSlug,
-                    version: formatBootVersion(),
-                    agentDir: agentDir ?? join(homedir(), '.switchroom', 'agents', agentSlug),
-                    gatewayInfo: { pid: process.pid, startedAtMs: GATEWAY_STARTED_AT_MS },
-                    restartReason: reason,
-                    restartAgeMs: markerAgeMs,
-                  }, ackMsgId)
-                  activeBootCard = handle
-                } catch (err) {
-                  process.stderr.write(`telegram gateway: boot: boot card error: ${err}\n`)
-                } finally {
-                  bootCardPending = false
-                }
+              // First-write-wins dedupe: if bridge-reconnect already
+              // claimed (its IPC client connected before this IIFE
+              // reached the emit), defer to it. Symmetric with the
+              // bridge-reconnect side's check above. See finn 2026-05-02
+              // duplicate (msgId 673 + 674) — fix removes the boot=primary
+              // assumption that special-cased boot to never skip.
+              const bootDedupe = shouldSkipDuplicateBootCard({ activeBootCard, bootCardPending }, 'boot')
+              if (bootDedupe.skip) {
+                process.stderr.write(`telegram gateway: boot: skipping boot card (${bootDedupe.reason})\n`)
               } else {
-                const ageSec = markerAgeMs != null ? Math.max(1, Math.round(markerAgeMs / 1000)) : 0
-                postLegacyBanner(chatId, threadId, ackMsgId, ageSec, 'boot')
+                process.stderr.write(`telegram gateway: boot: posting boot card reason=${reason} chat_id=${chatId} thread_id=${threadId ?? '-'} ackReply=${ackMsgId ?? '-'} boot_card=${BOOT_CARD_ENABLED}\n`)
+                ensureIssuesCard(chatId, threadId)
+                if (BOOT_CARD_ENABLED) {
+                  const agentDir = resolveAgentDirFromEnv()
+                  const agentSlug = process.env.SWITCHROOM_AGENT_NAME ?? '-'
+                  const agentDisplayName = resolvePersonaName(agentSlug)
+                  const botApiForCard: import('./boot-card.js').BotApiForBootCard = {
+                    sendMessage: (cid, text, opts) => lockedBot.api.sendMessage(cid, text, opts as Parameters<typeof lockedBot.api.sendMessage>[2]) as Promise<{ message_id: number }>,
+                    editMessageText: (cid, mid, text, opts) => lockedBot.api.editMessageText(cid, mid, text, opts as Parameters<typeof lockedBot.api.editMessageText>[3]),
+                  }
+                  // Claim emission ownership synchronously BEFORE the await so
+                  // the bridge-reconnect dedupe (which can run during this
+                  // sendMessage round-trip) sees an in-flight emit. See #489.
+                  bootCardPending = true
+                  try {
+                    const handle = await startBootCard(chatId, threadId, botApiForCard, {
+                      agentName: agentDisplayName,
+                      agentSlug,
+                      version: formatBootVersion(),
+                      agentDir: agentDir ?? join(homedir(), '.switchroom', 'agents', agentSlug),
+                      gatewayInfo: { pid: process.pid, startedAtMs: GATEWAY_STARTED_AT_MS },
+                      restartReason: reason,
+                      restartAgeMs: markerAgeMs,
+                    }, ackMsgId)
+                    activeBootCard = handle
+                  } catch (err) {
+                    process.stderr.write(`telegram gateway: boot: boot card error: ${err}\n`)
+                  } finally {
+                    bootCardPending = false
+                  }
+                } else {
+                  const ageSec = markerAgeMs != null ? Math.max(1, Math.round(markerAgeMs / 1000)) : 0
+                  postLegacyBanner(chatId, threadId, ackMsgId, ageSec, 'boot')
+                }
               }
             } else {
               process.stderr.write(`telegram gateway: boot: no known chat for boot card (reason=${reason}) — skipping\n`)

--- a/telegram-plugin/tests/boot-card-dedupe.test.ts
+++ b/telegram-plugin/tests/boot-card-dedupe.test.ts
@@ -12,17 +12,32 @@ import { describe, it, expect } from 'bun:test'
 import { shouldSkipDuplicateBootCard } from '../gateway/boot-card.js'
 
 describe('shouldSkipDuplicateBootCard — boot path', () => {
-  it('never skips on the boot path, even when a card is already active', () => {
-    // Edge case: stale activeBootCard from a previous lifetime should not
-    // affect the boot path (it ran first; if anything's set, that's a bug).
+  it('skips on the boot path when bridge-reconnect already posted a card', () => {
+    // First-write-wins: when the agent's IPC client connects faster
+    // than the gateway IIFE reaches its emit, bridge-reconnect runs
+    // first and sets activeBootCard. The boot path must defer.
+    // Regression for finn 2026-05-02 duplicate (msgId 673 + 674)
+    // — both posted within ~100ms because the boot path was
+    // unconditionally allowed past the gate.
     const decision = shouldSkipDuplicateBootCard(
       { activeBootCard: { messageId: 42 } },
       'boot',
     )
-    expect(decision.skip).toBe(false)
+    expect(decision.skip).toBe(true)
+    expect(decision.reason).toMatch(/msgId.*42/)
+    expect(decision.reason).toMatch(/site=boot/)
   })
 
-  it('does not skip on the boot path with no active card', () => {
+  it('skips on the boot path when bridge-reconnect emit is in-flight', () => {
+    const decision = shouldSkipDuplicateBootCard(
+      { activeBootCard: null, bootCardPending: true },
+      'boot',
+    )
+    expect(decision.skip).toBe(true)
+    expect(decision.reason).toMatch(/in-flight/i)
+  })
+
+  it('does not skip on the boot path with no active card and no pending emit', () => {
     const decision = shouldSkipDuplicateBootCard({ activeBootCard: null }, 'boot')
     expect(decision.skip).toBe(false)
   })
@@ -65,6 +80,19 @@ describe('shouldSkipDuplicateBootCard — reason format', () => {
     expect(decision.skip).toBe(false)
     expect(decision.reason).toBeUndefined()
   })
+
+  it('reason carries the site label so dedupe-source is greppable in logs', () => {
+    const fromBoot = shouldSkipDuplicateBootCard(
+      { activeBootCard: { messageId: 1 } },
+      'boot',
+    )
+    expect(fromBoot.reason).toMatch(/site=boot/)
+    const fromReconnect = shouldSkipDuplicateBootCard(
+      { activeBootCard: { messageId: 1 } },
+      'bridge-reconnect',
+    )
+    expect(fromReconnect.reason).toMatch(/site=bridge-reconnect/)
+  })
 })
 
 // ---------------------------------------------------------------------------
@@ -102,14 +130,16 @@ describe('shouldSkipDuplicateBootCard — in-flight (race window, #489)', () => 
     expect(decision.reason).toBeDefined()
   })
 
-  it('does not skip boot path even when something else is in-flight', () => {
-    // The boot path is the primary site — it's the only thing that should
-    // ever set bootCardPending=true in the first place. Defensive check.
+  it('skips boot path when bridge-reconnect emit is in-flight (first-write-wins)', () => {
+    // The boot path is no longer "primary" — empirical evidence
+    // (finn 2026-05-02) shows bridge-reconnect can fire first when
+    // the agent IPC-connects before the gateway IIFE reaches its
+    // emit. Both sites consult the gate symmetrically.
     const decision = shouldSkipDuplicateBootCard(
       { activeBootCard: null, bootCardPending: true },
       'boot',
     )
-    expect(decision.skip).toBe(false)
+    expect(decision.skip).toBe(true)
   })
 
   it('treats undefined bootCardPending as "not pending" for backward compat', () => {

--- a/tests/auth-heal-diagnose.test.ts
+++ b/tests/auth-heal-diagnose.test.ts
@@ -46,7 +46,14 @@ describe("diagnoseAuthState", () => {
       code: "credentials_missing",
       severity: "error",
     });
-    expect(r.findings[0].summary).toMatch(/never been authenticated/);
+    // Summary is the user-facing string surfaced in the Telegram
+    // boot-self-test issue card. It must point users at the inline
+    // /auth dashboard — the agent's chat is the only surface a
+    // Telegram-only user has, so a "switchroom auth reauth"
+    // terminal command is wrong place. See reference/principles.md
+    // "docs test."
+    expect(r.findings[0].summary).toMatch(/\/auth/);
+    expect(r.findings[0].summary).toMatch(/this chat/);
     expect(r.recommendation.join("\n")).toContain("switchroom auth reauth");
   });
 
@@ -58,7 +65,7 @@ describe("diagnoseAuthState", () => {
       code: "credentials_missing",
       severity: "warn",
     });
-    expect(r.findings[0].summary).toMatch(/legacy|absent.*oauth-token/i);
+    expect(r.findings[0].summary).toMatch(/\/auth/);
   });
 
   it("flags malformed JSON as error/credentials_malformed", () => {
@@ -88,6 +95,7 @@ describe("diagnoseAuthState", () => {
     const expired = r.findings.find((f) => f.code === "token_expired");
     expect(expired).toBeDefined();
     expect(expired!.summary).toMatch(/expired \d+d ago/);
+    expect(expired!.summary).toMatch(/\/auth/);
   });
 
   it("flags missing refreshToken as warn/refresh_token_missing", () => {

--- a/tests/bridge-watchdog.test.ts
+++ b/tests/bridge-watchdog.test.ts
@@ -126,6 +126,85 @@ describe("bridge-watchdog.sh — static regression guards", () => {
     expect(script).toMatch(/ActiveEnterTimestamp/);
     expect(script).toMatch(/UPTIME_GRACE_SECS/);
   });
+
+  it("gates ALL three restart paths on a multi-signal progress probe", () => {
+    // 2026-05-02 incident: TURN_HANG_SECS=300 fired on long sub-agent
+    // runs because the parent's tool_use stream goes silent while a
+    // Task() sub-agent does its work. The CLI's mid-turn guard caught
+    // some, but on subsequent ticks the marker stayed stale and
+    // eventually a restart slipped through, killing the sub-agent.
+    //
+    // Fix: every restart path (bridge-disconnect, turn-hang,
+    // journal-silence) consults `agent_has_recent_progress` which
+    // ORs over TWO independent fingerprints (transcript JSONL +
+    // tasks JSON). Two uncorrelated signals mean a wedged agent has
+    // to be silent on both before we kill it.
+    expect(script).toMatch(/JSONL_LIVENESS_SECS:=/);
+    expect(script).toMatch(/agent_has_recent_progress\(\)/);
+
+    // Both fingerprints must be probed inside the helper.
+    expect(script).toMatch(/\.claude\/projects.*-name '\*\.jsonl'/s);
+    expect(script).toMatch(/\.claude\/tasks.*-name '\*\.json'/s);
+
+    // All three restart paths must call the helper before acting.
+    // Count the call-sites: should be exactly 3 (bridge-disconnect,
+    // turn-hang, journal-silence).
+    const calls = script.match(/agent_has_recent_progress "/g) ?? [];
+    expect(calls.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it("emits forensic context (process state + progress fingerprints) on every action log", () => {
+    // Operator forensics: after a restart the process is gone and
+    // its state is unrecoverable. Every [restart] / [detect] /
+    // [skip] line must carry the moment-of-decision snapshot so the
+    // journal alone is enough to reconstruct WHY the action fired.
+    // Snapshot includes: pid, /proc/<pid>/stat state letter, CPU%,
+    // RSS, JSONL-age, tasks-age.
+    expect(script).toMatch(/agent_main_pid\(\)/);
+    expect(script).toMatch(/agent_proc_snapshot\(\)/);
+    expect(script).toMatch(/agent_progress_snapshot\(\)/);
+    expect(script).toMatch(/agent_observation\(\)/);
+    // Reads the process-state letter from /proc/<pid>/stat (field 3).
+    expect(script).toMatch(/\/proc\/\$\{pid\}\/stat/);
+    // Every action log carries `agent=NAME reason=… <observation>`.
+    expect(script).toMatch(/wd_log restart .* \$\{observation\}/);
+    expect(script).toMatch(/wd_log detect .* \$\{observation\}/);
+  });
+
+  it("bridge-disconnect routes through `switchroom agent restart` (not raw systemctl)", () => {
+    // Detector B parity fix: previously the bridge-disconnect path
+    // went straight to `systemctl --user restart`, bypassing the
+    // CLI's in-flight guard and config reconciliation. Now it
+    // matches turn-hang and journal-silence: try the CLI first,
+    // fall back to systemctl only when the CLI isn't installed.
+    // Specifically, the script should resolve a `switchroom_cli`
+    // path inside the bridge-disconnect block (not just inside the
+    // journal-silence block at the bottom of the file).
+    const bridgeBlock = script.split("# ─── Journal-silence check")[0];
+    expect(bridgeBlock).toMatch(/switchroom_cli=/);
+    expect(bridgeBlock).toMatch(/"\$switchroom_cli" agent restart "\$agent"/);
+  });
+
+  it("logs every decision via `logger -t switchroom-watchdog` with a level tag", () => {
+    // Operator visibility: `journalctl -t switchroom-watchdog` should
+    // show one tagged line per action. Levels: detect (signal observed),
+    // restart (action taken), skip (action declined), error (failure).
+    expect(script).toMatch(/wd_log\(\)/);
+    expect(script).toMatch(/logger -t switchroom-watchdog/);
+    expect(script).toMatch(/wd_log restart "agent=/);
+    expect(script).toMatch(/wd_log skip "agent=/);
+    expect(script).toMatch(/wd_log detect "agent=/);
+  });
+
+  it("stamps clean-shutdown.json with the watchdog reason on EVERY restart path", () => {
+    // The bridge-disconnect path stamped a reason; the turn-hang and
+    // journal-silence paths did not, so greeting cards on those
+    // restarts silently dropped the "Restarted  <reason>" row.
+    // Pulled the stamping into a helper called from all three paths.
+    expect(script).toMatch(/stamp_restart_reason\(\)/);
+    expect(script).toMatch(/stamp_restart_reason \\?\s*"\$\{gateway_state_dir\}\/clean-shutdown\.json"/);
+    expect(script).toMatch(/stamp_restart_reason \\?\s*"\$\{agent_state_dir\}\/clean-shutdown\.json"/);
+  });
 });
 
 // ---------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Watchdog: multi-signal progress gate (JSONL + tasks mtime) prevents killing live sub-agents; every action log line carries pid+state+cpu+rss+fingerprint ages for forensic reconstruction.
- Boot card: removed `boot=primary` special case in `shouldSkipDuplicateBootCard`; symmetric first-write-wins fixes finn duplicate posts (msgId 673 + 674 within 100ms observed in gateway.log).
- Auth UX: `diagnoseAuthState` summaries rewritten as Telegram-first action prompts ("send /auth in this chat to refresh credentials") instead of `.credentials.json` jargon.
- CLAUDE.md: agent now knows where to look when a user asks "why did you restart?" — clean-shutdown.json → switchroom-watchdog journal → unit journal, with quote-verbatim rule.
- Wake audit: every fresh boot drops a sentinel; agent's first turn checks owed replies, orphan sub-agents, open todos before responding to new input. Complements SWITCHROOM_PENDING_TURN (which only covers killed-mid-turn).

## JTBDs served (`reference/`)
- `know-what-my-agent-is-doing.md` — restart visibility, watchdog forensics
- `restart-and-know-what-im-running.md` — boot-card dedupe, why-did-you-restart guidance
- `agent-stays-on-task-across-restarts.md` — wake audit (covers gaps PENDING_TURN misses)

## Principle checks
- **Docs test** ✅ — agent answers "why did you restart?" without operator opening docs; user can fix auth from Telegram without terminal.
- **Defaults test** ✅ — wake audit fires on every restart with zero config; new env vars not required.
- **Consistency test** ✅ — wake audit mirrors PENDING_TURN's one-shot pattern; all watchdog paths now use the same restart action and observation log shape.

## Test plan
- [x] \`bin/bridge-watchdog.sh\` syntax + tests
- [x] auth diagnose tests pin /auth + this chat phrasing
- [x] boot-card dedupe is symmetric
- [x] scaffold tests render the new CLAUDE.md sections
- [ ] Manual: trigger a watchdog restart, verify \`journalctl -t switchroom-watchdog\` shows \`[restart] agent=… reason=… pid=… state=…\`
- [ ] Manual: kill an agent mid-sub-agent, verify wake audit acknowledges the orphan on next user message

🤖 Generated with [Claude Code](https://claude.com/claude-code)