### PR TITLE
test: align with #557 telegram-first auth + larger CLAUDE.md cap

### DIFF
--- a/tests/boot-self-test.test.ts
+++ b/tests/boot-self-test.test.ts
@@ -145,7 +145,11 @@ describe("boot-self-test.sh", () => {
     const missing = issues.find((i) => i.code === "credentials_missing");
     expect(missing).toBeDefined();
     expect(missing!.severity).toBe("error");
-    expect(missing!.summary).toContain("no .credentials.json");
+    // Telegram-first summary (rewritten in #557): the user-facing string is
+    // an action prompt routing to the inline /auth dashboard. Technical
+    // fingerprint stays in `code`.
+    expect(missing!.summary).toMatch(/\/auth/);
+    expect(missing!.summary).toMatch(/this chat/);
   });
 
   it("records auth.token_expired when expiresAt is in the past", { timeout: 15_000 }, () => {

--- a/tests/scaffold.persona.test.ts
+++ b/tests/scaffold.persona.test.ts
@@ -109,9 +109,12 @@ describe("scaffoldAgent — persona (Phase 2)", () => {
     const claudeMd = readFileSync(join(result.agentDir, "CLAUDE.md"), "utf-8");
 
     // CLAUDE.md should be significantly smaller without persona block.
-    // Cap raised from 12000 → 16000: the template grew with vault, hindsight,
-    // sub-agent delegation, and Telegram interaction guidance added in v0.3-v0.4.
+    // Cap raised from 12000 → 16000 for vault/hindsight/sub-agent/Telegram
+    // additions in v0.3-v0.4; raised again 16000 → 24000 for the lifecycle
+    // additions in #557 (wake-audit + restart-visibility sections in
+    // telegram-style.md.hbs, both load-bearing — agent needs them to
+    // answer "why did you restart?" and audit owed replies on wake).
     // The doc is load-bearing — trimming risks cutting useful guidance.
-    expect(claudeMd.length).toBeLessThan(16000); // generous cap; target is lean but not 3KB
+    expect(claudeMd.length).toBeLessThan(24000); // generous cap; target is lean but not 3KB
   });
 });


### PR DESCRIPTION
## Summary

Tests-only fix to get main green after #557 (lifecycle) and #558 (bundled-skills) landed back-to-back. Build #706 (just lifecycle) passed but #707 (lifecycle + bundled-skills merge commit) went red on two tests that the lifecycle changes invalidated:

- \`tests/boot-self-test.test.ts > records auth.credentials_missing\` — \`diagnoseAuthState\` summaries were rewritten in #557 to be Telegram-first action prompts ("send /auth in this chat to refresh credentials"). The test still asserted the old jargon string \`.credentials.json\`. Updated to pin the new contract (mentions \`/auth\` and \`this chat\`).

- \`tests/scaffold.persona.test.ts > CLAUDE.md is slim\` — the wake-audit + restart-visibility sections added to \`profiles/_shared/telegram-style.md.hbs\` in #557 are load-bearing (agent needs them to answer "why did you restart?" and audit owed replies on wake). They push CLAUDE.md from ~17 KB to ~20 KB; cap raised 16000 → 24000.

No production code changes; tests only.

## Test plan

- [x] \`npx vitest run tests/boot-self-test.test.ts tests/scaffold.persona.test.ts\` → 13/13
- [x] \`npm run lint\` clean
- [x] \`(cd telegram-plugin && bun test)\` → 3002/3002

🤖 Generated with [Claude Code](https://claude.com/claude-code)