### PR TITLE
fix(auth): redaction-failure logging + drop unfixable credentials_missing warn

### DIFF
--- a/src/cli/auth.ts
+++ b/src/cli/auth.ts
@@ -116,14 +116,26 @@ export function diagnoseAuthState(claudeConfigDir: string): AuthDiagnosis {
       summary: "needs first-time login — send /auth in this chat to start the flow",
     });
   } else if (!hasCreds) {
-    // .oauth-token alone is the legacy state — works for in-process
-    // claude (start.sh exports it) but `claude -p` from hooks needs
-    // .credentials.json to refresh. Warn rather than error.
-    findings.push({
-      code: "credentials_missing",
-      severity: "warn",
-      summary: "send /auth in this chat to refresh credentials (hooks need them)",
-    });
+    // `.oauth-token`-only IS switchroom's intended steady state. The
+    // auth flow (src/auth/manager.ts:writeOAuthToken + the deliberate
+    // `rmSync(credentialsPath(...))` at line 922) explicitly persists
+    // ONLY the bearer token; the temp `.credentials.json` written by
+    // `claude setup-token` is wiped to prevent state-drift incidents
+    // (gymbro 2026-04-25). Hooks that shell `claude -p` get the token
+    // via the `CLAUDE_CODE_OAUTH_TOKEN` env var injected at start.sh
+    // (and re-injected by `defaultClaudeCliRunner` when the parent
+    // strips it) — they never read `.credentials.json`.
+    //
+    // So `.credentials.json` absence is NOT a problem under
+    // switchroom's design. Earlier versions of this diagnoser
+    // (inherited from claude CLI's assumptions) flagged it as a warn
+    // and told users to `/auth` to fix — but `/auth` produces the
+    // same `.oauth-token`-only state, so the warning was unfixable
+    // and the user-facing message was a UX dead end. Suppress it.
+    //
+    // Token-expiry tracking lives in `.oauth-token.meta.json`
+    // (createdAt + expiresAt) — that's where any future "your token
+    // is about to expire" warning belongs, not in this branch.
   } else {
     let parsed:
       | { claudeAiOauth?: { accessToken?: string; refreshToken?: string; expiresAt?: number } }

--- a/telegram-plugin/auth-code-redact.ts
+++ b/telegram-plugin/auth-code-redact.ts
@@ -44,19 +44,40 @@ interface BotApi {
  * @param api Bot API surface (lockedBot.api in production)
  * @param chatId Stringified Telegram chat id
  * @param messageId Numeric message id to redact, or null for no-op
+ * @param log Optional log sink — receives a single line on every
+ *            attempt (success or failure). When the function silently
+ *            swallowed errors before, operators had no way to diagnose
+ *            why a paste was still visible in chat (#488 follow-up).
  *
  * Both calls are fire-and-forget. The reaction is dispatched first so
  * fast clients see the 🔑 land before the message is gone — most clients
  * actually only render whichever wins the race, which is fine either way.
+ *
+ * Failures are logged (when a sink is provided) but never re-thrown:
+ * delete can fail if the message is too old (Telegram limits bots to
+ * 48h), if the user already deleted it, or if the bot lacks permission
+ * (group chats without delete rights). Reactions can fail similarly.
+ * Visibility-into-failure is the operator-facing fix; the silent path
+ * left tokens lingering in chat history with no diagnostic trail.
  */
 export function redactAuthCodeMessage(
   api: BotApi,
   chatId: string,
   messageId: number | null,
+  log?: (line: string) => void,
 ): void {
-  if (messageId == null) return
+  if (messageId == null) {
+    log?.('telegram gateway: auth-code redact: no message_id, skipping\n')
+    return
+  }
   void api.setMessageReaction(chatId, messageId, [
     { type: 'emoji', emoji: '🔑' },
-  ]).catch(() => {})
-  void api.deleteMessage(chatId, messageId).catch(() => {})
+  ]).then(
+    () => log?.(`telegram gateway: auth-code redact: 🔑 reaction added msgId=${messageId} chatId=${chatId}\n`),
+    (err: unknown) => log?.(`telegram gateway: auth-code redact: reaction FAILED msgId=${messageId} chatId=${chatId}: ${(err as Error).message}\n`),
+  )
+  void api.deleteMessage(chatId, messageId).then(
+    () => log?.(`telegram gateway: auth-code redact: deleted msgId=${messageId} chatId=${chatId}\n`),
+    (err: unknown) => log?.(`telegram gateway: auth-code redact: delete FAILED msgId=${messageId} chatId=${chatId}: ${(err as Error).message} — token may still be visible in chat\n`),
+  )
 }

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -3709,7 +3709,7 @@ async function handleInbound(
       // Single-use code so a third party can't replay it after exchange,
       // but plaintext OAuth tokens in chat history are still poor
       // hygiene. The helper handles delete + 🔑 reaction silently.
-      redactAuthCodeMessage(bot.api, chat_id, msgId)
+      redactAuthCodeMessage(bot.api, chat_id, msgId, line => process.stderr.write(line))
       return
     }
     pendingReauthFlows.delete(chat_id)
@@ -5761,7 +5761,7 @@ bot.command('auth', async ctx => {
     }
     pendingReauthFlows.delete(String(ctx.chat!.id))
     // Redact the OAuth code from chat history (#488).
-    redactAuthCodeMessage(bot.api, String(ctx.chat!.id), ctx.message?.message_id ?? null)
+    redactAuthCodeMessage(bot.api, String(ctx.chat!.id), ctx.message?.message_id ?? null, line => process.stderr.write(line))
     return
   }
   if (intent.kind === 'cancel') {
@@ -6835,7 +6835,7 @@ bot.command('reauth', async ctx => {
     }
     pendingReauthFlows.delete(chatId)
     // Redact the OAuth code from chat history (#488).
-    redactAuthCodeMessage(bot.api, chatId, ctx.message?.message_id ?? null)
+    redactAuthCodeMessage(bot.api, chatId, ctx.message?.message_id ?? null, line => process.stderr.write(line))
     return
   }
   // raw is treated as an agent name

--- a/tests/auth-heal-diagnose.test.ts
+++ b/tests/auth-heal-diagnose.test.ts
@@ -57,15 +57,22 @@ describe("diagnoseAuthState", () => {
     expect(r.recommendation.join("\n")).toContain("switchroom auth reauth");
   });
 
-  it("downgrades to warn when .oauth-token is present but creds missing", () => {
+  it("treats .oauth-token-only as OK — switchroom's intended steady state", () => {
+    // Regression for the unfixable-warning UX dead end (klanker
+    // screenshot 2026-05-02): the user followed the boot-self-test
+    // recommendation ("send /auth in this chat to refresh
+    // credentials"), the auth flow completed, and the warning still
+    // showed because `/auth` writes only `.oauth-token` (deliberate —
+    // see auth/manager.ts:922 rmSync of credentialsPath). Telling
+    // users to do something that won't fix the problem violates the
+    // docs-test principle. Switchroom's hooks get the token via
+    // CLAUDE_CODE_OAUTH_TOKEN env injection at start.sh, NOT via
+    // .credentials.json self-refresh.
     writeOauthToken("sk-ant-oat01-something");
     const r = diagnoseAuthState(configDir);
-    expect(r.severity).toBe("warn");
-    expect(r.findings[0]).toMatchObject({
-      code: "credentials_missing",
-      severity: "warn",
-    });
-    expect(r.findings[0].summary).toMatch(/\/auth/);
+    expect(r.severity).toBe("ok");
+    expect(r.findings).toHaveLength(0);
+    expect(r.recommendation).toHaveLength(0);
   });
 
   it("flags malformed JSON as error/credentials_malformed", () => {


### PR DESCRIPTION
## Summary
Two related auth-UX bugs from one user screenshot (klanker, 2026-05-02 11:25). Both made promises the runtime didn't keep.

### Bug 1 — pasted OAuth code stays visible in chat
`redactAuthCodeMessage` was `void api.deleteMessage(...).catch(() => {})` — silent on every failure. User's pasted token visible in chat 46 min after exchange, no 🔑 reaction either; no diagnostic to tell why.

**Fix**: thread a log sink through `redactAuthCodeMessage`, emit one line per attempt (success or failure with the actual error). Wired at all three call sites in gateway.ts. Next stuck paste leaves a trail in `gateway.log` for root-causing.

### Bug 2 — "send /auth to refresh credentials" warning that /auth can't fix
Diagnoser warned on `.oauth-token`-only state, asking the user to `/auth` to fix. But `/auth` deliberately writes only `.oauth-token` and `rmSync`s `.credentials.json` (see auth/manager.ts:922 + the gymbro 2026-04-25 state-drift fix). So the recommendation was unfixable; the warning persisted forever.

Hooks that shell `claude -p` get the token via `CLAUDE_CODE_OAUTH_TOKEN` env-injection at start.sh / `defaultClaudeCliRunner` — not via `.credentials.json` self-refresh. Token expiry tracking is in `.oauth-token.meta.json`, separate from the credentials.json path.

**Fix**: suppress the warning. `hasOauthToken && !hasCreds` is switchroom's intended steady state — record no findings, return severity OK. The "never authenticated" error and the credentials.json-present cases (expiry + refreshToken checks) are unchanged.

## JTBDs served (`reference/`)
- `restart-and-know-what-im-running.md` — auth-flow recommendations now match what the runtime actually does.
- `dont-leak-secrets.md` — operators get a diagnostic trail when token redaction fails.

## Principle checks
- **Docs test** ✅ — user no longer needs to know switchroom's internal auth design to interpret the warning.
- **Defaults test** ✅ — fresh `/auth` flows now report severity OK without operator intervention.
- **Consistency test** ✅ — diagnoser semantics now match the actual auth-flow output (was: claude-CLI assumption mismatch).

## Test plan
- [x] `bunx vitest run tests/auth-heal-diagnose.test.ts` — 10 cases pass; "downgrades to warn" replaced with "treats .oauth-token-only as OK"
- [x] `bunx vitest run tests/boot-self-test.test.ts` — 9 integration cases pass; both-missing → error path unchanged
- [x] `npm run lint` clean
- [ ] Manual: existing klanker `credentials_missing` warn auto-clears on next boot-self-test run via the existing pre-resolve loop
- [ ] Manual: paste an OAuth code; check `gateway.log` for `[redact]` lines; if delete fails, the error message should now name the cause