### PR TITLE
test(secret-detect): allow optional log arg on redact pin

### DIFF
--- a/telegram-plugin/tests/secret-detect-oauth-code.test.ts
+++ b/telegram-plugin/tests/secret-detect-oauth-code.test.ts
@@ -208,7 +208,9 @@ describe('pendingReauthFlows intercept — deleteMessage sequencing (Blocker 1)'
     // the redaction call. Bounds the window so we don't accidentally
     // match a downstream auth-code path's redaction.
     const window = src.slice(interceptIdx, interceptIdx + 2000)
-    expect(window).toMatch(/redactAuthCodeMessage\(bot\.api,\s*chat_id,\s*msgId\)/)
+    // Allow the optional 4th `log` argument added in #561 (diagnostic
+     // sink for redaction failures) — required is the first three args.
+     expect(window).toMatch(/redactAuthCodeMessage\(bot\.api,\s*chat_id,\s*msgId(?:,\s*[^)]+)?\)/)
   })
 
   it('redaction lands AFTER the success/error reply renders', () => {


### PR DESCRIPTION
Static-analysis test broke after #561 added a 4th `log` arg to `redactAuthCodeMessage`. Loosen the regex to accept an optional 4th arg while still requiring the first three (bot.api, chat_id, msgId). The pin's purpose — every intercept goes through the helper — is unchanged. `bun test telegram-plugin/tests/secret-detect-oauth-code.test.ts` → 24 pass.