### PR TITLE
fix(gateway): treat 400 'chat not found' as log-only, not shutdown

### DIFF
--- a/telegram-plugin/gateway/unhandled-rejection-policy.ts
+++ b/telegram-plugin/gateway/unhandled-rejection-policy.ts
@@ -57,7 +57,20 @@ export function classifyRejection(
     // failure so we can fix the root cause, but don't crash the gateway
     // into a restart loop (issue #101).
     desc.includes("can't parse entities") ||
-    desc.includes('unsupported start tag')
+    desc.includes('unsupported start tag') ||
+    // 'chat not found' fires when an allowlisted chat id (typically a
+    // group in access.json/groups{}) is no longer reachable — bot was
+    // removed, group was deleted, or the id was stale config from a
+    // prior bot pairing. Boot-time pin sweep + various other checks
+    // call getChat against every allowlisted chat; a single unreachable
+    // entry was crashing the gateway into restart loops on ziggy
+    // (2026-05-02 12:05) even though boot-probe-failed already logged
+    // the failure structurally. The wrapped sweep handles the visible
+    // case; this policy entry covers any leaked rejection from the
+    // same family so a single bad chat id can't restart-loop the
+    // process. The visible boot-probe-failed log is the primary
+    // diagnostic; this is the can't-restart-loop guarantee.
+    desc.includes('chat not found')
   ) {
     return 'log_only'
   }

--- a/telegram-plugin/tests/unhandled-rejection-policy.test.ts
+++ b/telegram-plugin/tests/unhandled-rejection-policy.test.ts
@@ -68,6 +68,18 @@ describe('classifyRejection — benign Telegram 400s', () => {
     expect(classifyRejection(err)).toBe('log_only')
   })
 
+  it('returns "log_only" for "chat not found" (ziggy 2026-05-02 — stale group id in access.json crashed gateway)', () => {
+    // Boot-time pin sweep + various other checks call getChat against
+    // every allowlisted chat. Stale ids (bot removed from group, group
+    // deleted, leftover config from a prior bot pairing) return this
+    // 400. The wrapped sweep catches it visibly via boot-probe-failed,
+    // but a leaked rejection from the same family was still crashing
+    // the gateway into a restart loop. Don't restart-loop on
+    // unreachable chats — log them and move on.
+    const err = grammyError(400, 'Bad Request: chat not found')
+    expect(classifyRejection(err)).toBe('log_only')
+  })
+
   it('case-insensitive description match', () => {
     const err = grammyError(400, 'Bad Request: MESSAGE IS NOT MODIFIED: blah')
     expect(classifyRejection(err)).toBe('log_only')
@@ -97,7 +109,10 @@ describe('classifyRejection — genuine errors still crash', () => {
   })
 
   it('returns "shutdown" for GrammyError 400 with NEW unknown description', () => {
-    const err = grammyError(400, 'Bad Request: chat not found')
+    // Use a description that's not in the benign list — the policy is
+    // intentionally narrow so genuinely new bug categories still crash
+    // (and surface via systemd restart) rather than silently masking.
+    const err = grammyError(400, 'Bad Request: PHOTO_INVALID_DIMENSIONS')
     expect(classifyRejection(err)).toBe('shutdown')
   })
 


### PR DESCRIPTION
## Summary
Ziggy crashed into a restart loop on 2026-05-02 12:05 because its access.json carried a stale group id (`-1003852747971`) the bot could no longer reach. Boot pin sweep called getChat → 400 → boot-probe-failed logged → unhandled-rejection handler crashed the process anyway.

Wrapped layers handle the visible case (try/catch in the sweep callback + active-pins-sweep). Leaked rejections from the same family kept crashing. Add `chat not found` to the benign list in `classifyRejection` alongside the other five recoverable 400s.

## Why
Logging is the right diagnostic for an unreachable chat id; restart-looping isn't. The benign list stays narrow — any other 400 still shuts down so new bug categories surface.

## Test plan
- [x] `bun test telegram-plugin/tests/unhandled-rejection-policy.test.ts` — 15 pass (was 14)
- [x] `npm run lint` clean
- [ ] Manual: ziggy boots cleanly with stale group ids in access.json without restart-looping