### PR TITLE
feat(issues): allow `issues resolve --source <s>` to bulk-close

### DIFF
--- a/src/cli/issues.ts
+++ b/src/cli/issues.ts
@@ -7,6 +7,7 @@ import {
   prune as pruneStore,
   record as recordStore,
   resolve as resolveStore,
+  resolveAllBySource,
   SEVERITY_RANK,
   type IssueSeverity,
 } from "../issues/index.js";
@@ -172,18 +173,23 @@ export function registerIssuesCommand(program: Command): void {
       ) => {
         try {
           const stateDir = resolveStateDir(opts);
-          let fp: string;
+          let flipped: number;
           if (opts.source && opts.code) {
-            fp = computeFingerprint(opts.source, opts.code);
+            flipped = resolveStore(
+              stateDir,
+              computeFingerprint(opts.source, opts.code),
+            );
+          } else if (opts.source && !fingerprint) {
+            // Bulk-close: every unresolved entry whose source matches.
+            flipped = resolveAllBySource(stateDir, opts.source);
           } else if (fingerprint) {
-            fp = fingerprint;
+            flipped = resolveStore(stateDir, fingerprint);
           } else {
             process.stderr.write(
-              "issues resolve: need either <fingerprint> or --source + --code\n",
+              "issues resolve: need either <fingerprint>, --source, or --source + --code\n",
             );
             process.exit(2);
           }
-          const flipped = resolveStore(stateDir, fp);
           process.stdout.write(`${flipped}\n`);
         } catch (err) {
           process.stderr.write(`issues resolve: ${(err as Error).message}\n`);

--- a/src/issues/index.ts
+++ b/src/issues/index.ts
@@ -15,6 +15,7 @@ export {
   readAll,
   record,
   resolve,
+  resolveAllBySource,
   ISSUES_FILE,
   ISSUES_LOCK,
   type ListOptions,

--- a/src/issues/store.ts
+++ b/src/issues/store.ts
@@ -204,6 +204,36 @@ export function resolve(
 }
 
 /**
+ * Mark all unresolved entries with this `source` resolved, regardless
+ * of code/fingerprint. No-op (and idempotent) if none exist or all are
+ * already resolved. Returns the number of entries flipped.
+ *
+ * Mirrors `resolve()` above but matches on `source` rather than
+ * `fingerprint` — useful when a whole class of issues from one source
+ * has been remediated and the operator wants a bulk close.
+ */
+export function resolveAllBySource(
+  stateDir: string,
+  source: string,
+  nowFn: () => number = Date.now,
+): number {
+  if (!existsSync(join(stateDir, ISSUES_FILE))) return 0;
+  return withLock(stateDir, () => {
+    const all = readAll(stateDir);
+    const now = nowFn();
+    let flipped = 0;
+    for (const e of all) {
+      if (e.source === source && e.resolved_at == null) {
+        e.resolved_at = now;
+        flipped++;
+      }
+    }
+    if (flipped > 0) writeAll(stateDir, all);
+    return flipped;
+  });
+}
+
+/**
  * Drop entries per the retention rules. Resolved entries older than
  * `resolvedOlderThanMs` always go. Unresolved entries are kept by
  * default (silence on a stuck issue would defeat the sink's purpose).

--- a/tests/issues.store.test.ts
+++ b/tests/issues.store.test.ts
@@ -16,6 +16,7 @@ import {
   readAll,
   record,
   resolve,
+  resolveAllBySource,
 } from "../src/issues/index.js";
 
 let tmp: string;
@@ -197,6 +198,43 @@ describe("resolve", () => {
 
   it("returns 0 for unknown fingerprint", () => {
     expect(resolve(tmp, "nope::no")).toBe(0);
+  });
+});
+
+describe("resolveAllBySource", () => {
+  it("flips only unresolved entries whose source matches", () => {
+    record(
+      tmp,
+      { agent: "a", severity: "error", source: "src-a", code: "c1", summary: "x" },
+      tick,
+    );
+    record(
+      tmp,
+      { agent: "a", severity: "error", source: "src-a", code: "c2", summary: "y" },
+      tick,
+    );
+    record(
+      tmp,
+      { agent: "a", severity: "error", source: "src-b", code: "c1", summary: "z" },
+      tick,
+    );
+    record(
+      tmp,
+      { agent: "a", severity: "error", source: "src-b", code: "c2", summary: "w" },
+      tick,
+    );
+
+    expect(resolveAllBySource(tmp, "src-a", tick)).toBe(2);
+
+    const all = readAll(tmp);
+    const bySource = (s: string) => all.filter((e) => e.source === s);
+    expect(bySource("src-a").every((e) => e.resolved_at != null)).toBe(true);
+    expect(bySource("src-b").every((e) => e.resolved_at == null)).toBe(true);
+
+    // Idempotent.
+    expect(resolveAllBySource(tmp, "src-a", tick)).toBe(0);
+    // Unknown source.
+    expect(resolveAllBySource(tmp, "nope", tick)).toBe(0);
   });
 });
 


### PR DESCRIPTION
## Summary
- Add `resolveAllBySource(stateDir, source)` to `src/issues/store.ts` (and re-export it). Mirrors the lockfile + atomic-write pattern of `resolve()`.
- Loosen `switchroom issues resolve` so `--source <s>` without `--code` or a fingerprint marks every unresolved entry from that source resolved. Existing single-fingerprint and `--source + --code` paths unchanged.
- New unit test in `tests/issues.store.test.ts` seeds two sources (two entries each) and asserts only the matching source flips, plus idempotency and unknown-source paths.

## Test plan
- [x] `bunx vitest run tests/issues.store.test.ts` — 27/27 green