### PR TITLE
feat(scaffold): auto-resolve cron issues on clean exit

### DIFF
--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -373,8 +373,16 @@ export function buildCronScript(
   userId: string | undefined,
   secrets: string[] = [],
   brokerSocket?: string,
+  jobSlug?: string,
 ): string {
-  const wrappedPrompt = applyCronTelegramGuidance(prompt, { chatId });
+  // jobSlug is the stable identifier used for issue auto-resolve. Defaults
+  // to a dash if not supplied — tests covering the legacy 7-arg signature
+  // still pass, but production scaffold/reconcile call sites always pass
+  // `cron-<index>` so the trailer can target unresolved issues whose source
+  // is `cron:<jobSlug>`. See applyCronTelegramGuidance for the matching
+  // instruction on the prompt side.
+  const slug = jobSlug ?? "unknown";
+  const wrappedPrompt = applyCronTelegramGuidance(prompt, { chatId, jobSlug: slug });
   const secretsComment = secrets.length > 0
     ? `# Allowed vault keys for this cron (broker ACL): ${secrets.join(", ")}\n`
     : "";
@@ -416,10 +424,27 @@ fi
 # Stderr remains open so systemd captures auth/network/bad-prompt errors
 # via journalctl — silently swallowing those would make a broken cron job
 # invisible to operators.
-exec claude -p ${shellSingleQuote(wrappedPrompt)} \\
+#
+# We deliberately do NOT use \`exec\` here — the success-trailer below must
+# run after \`claude -p\` returns. Same reasoning as PR #565: when a cron
+# completes cleanly, any unresolved issues filed against this job's source
+# get auto-closed. Failure (non-zero exit) leaves issues open for the
+# Telegram surface to render, exactly as before.
+export TELEGRAM_STATE_DIR=${shellSingleQuote(join(agentDir, "telegram"))}
+claude -p ${shellSingleQuote(wrappedPrompt)} \\
   --model ${shellSingleQuote(model)} \\
   --no-session-persistence \\
   > /dev/null
+rc=$?
+if [ $rc -eq 0 ]; then
+  # Best-effort auto-resolve. Failure here (e.g. switchroom not on PATH in a
+  # weird environment) must NOT mask the cron's own success — hence the
+  # trailing \`|| true\`. PR #565 added bulk-close-by-source; we use the same
+  # source string the agent's own \`issues record\` calls should use.
+  switchroom issues resolve --source "cron:${slug}" --quiet \\
+    --state-dir "$TELEGRAM_STATE_DIR" >/dev/null 2>&1 || true
+fi
+exit $rc
 `;
 }
 
@@ -1895,7 +1920,7 @@ export function scaffoldAgent(
     for (let i = 0; i < agentConfig.schedule!.length; i++) {
       const entry = agentConfig.schedule![i];
       const model = entry.model ?? "claude-sonnet-4-6";
-      const script = buildCronScript(agentDir, entry.prompt, model, telegramConfig.forum_chat_id, userId, entry.secrets ?? [], brokerSocket);
+      const script = buildCronScript(agentDir, entry.prompt, model, telegramConfig.forum_chat_id, userId, entry.secrets ?? [], brokerSocket, `cron-${i}`);
       const scriptPath = join(agentDir, "telegram", `cron-${i}.sh`);
       writeFileSync(scriptPath, script, { encoding: "utf-8", mode: 0o700 });
     }
@@ -3035,6 +3060,7 @@ Don't wait for a slash command. Don't ask permission. Memory work is table stake
       const script = buildCronScript(
         agentDir, entry.prompt, model,
         telegramConfig.forum_chat_id, cronUserId, entry.secrets ?? [], reconBrokerSocket,
+        `cron-${i}`,
       );
       const scriptPath = join(agentDir, "telegram", `cron-${i}.sh`);
       const before = existsSync(scriptPath) ? readFileSync(scriptPath, "utf-8") : "";

--- a/src/agents/sub-agent-telegram-prompt.ts
+++ b/src/agents/sub-agent-telegram-prompt.ts
@@ -90,7 +90,29 @@ export function applyTelegramProgressGuidance(
  */
 export function buildCronTelegramGuidance(args: {
   chatId: string
+  jobSlug?: string
 }): string {
+  // The cron wrapper auto-resolves any issue whose source is `cron:<jobSlug>`
+  // when this script exits 0. So if THIS task records an issue mid-run, it
+  // must use that exact source string — otherwise the auto-resolve trailer
+  // can't find it and the issue stays open forever even after a successful
+  // re-run. The block below is appended only when jobSlug is known
+  // (production scaffold/reconcile always supplies one).
+  const issuesBlock = args.jobSlug
+    ? `
+
+## If you need to record a transient issue
+
+If something half-broken happens during this run (e.g. an upstream API timed out, a vault key was missing, a non-fatal data gap), record it via:
+
+\`\`\`
+switchroom issues record --severity warn --source "cron:${args.jobSlug}" --code <stable-code> --summary "<one-line>"
+\`\`\`
+
+Use the EXACT \`--source "cron:${args.jobSlug}"\` shown above — the cron wrapper auto-resolves issues with that source on a clean run. Picking a different source means the issue persists across recoveries.
+`
+    : ""
+
   return `
 
 ## Delivery instructions (cron context)
@@ -108,7 +130,7 @@ The \`reply\` tool handles markdown→HTML conversion, chunking, and all formatt
 After calling \`reply\`, print \`HEARTBEAT_OK\` as your final stdout line and nothing else. This confirms successful execution to the cron watchdog.
 
 If you have nothing useful to say (data is dull, all signals are nominal), print \`HEARTBEAT_OK\` without calling \`reply\` — a silent heartbeat is correct behaviour, not an error.
-`
+${issuesBlock}`
 }
 
 /**
@@ -117,9 +139,9 @@ If you have nothing useful to say (data is dull, all signals are nominal), print
  */
 export function applyCronTelegramGuidance(
   body: string,
-  args: { chatId: string | undefined },
+  args: { chatId: string | undefined; jobSlug?: string },
 ): string {
   if (!args.chatId) return body
   const trimmed = body.replace(/\s+$/, '')
-  return trimmed + buildCronTelegramGuidance({ chatId: args.chatId })
+  return trimmed + buildCronTelegramGuidance({ chatId: args.chatId, jobSlug: args.jobSlug })
 }

--- a/src/cli/issues.ts
+++ b/src/cli/issues.ts
@@ -161,6 +161,7 @@ export function registerIssuesCommand(program: Command): void {
       "Compose fingerprint from --source + --code instead of passing one",
     )
     .option("--code <id>", "Used with --source")
+    .option("--quiet", "Suppress the resolved-count line on stdout", false)
     .action(
       (
         fingerprint: string | undefined,
@@ -169,6 +170,7 @@ export function registerIssuesCommand(program: Command): void {
           stateDir?: string;
           source?: string;
           code?: string;
+          quiet?: boolean;
         },
       ) => {
         try {
@@ -190,7 +192,9 @@ export function registerIssuesCommand(program: Command): void {
             );
             process.exit(2);
           }
-          process.stdout.write(`${flipped}\n`);
+          if (!opts.quiet) {
+            process.stdout.write(`${flipped}\n`);
+          }
         } catch (err) {
           process.stderr.write(`issues resolve: ${(err as Error).message}\n`);
           process.exit(1);

--- a/tests/scaffold.test.ts
+++ b/tests/scaffold.test.ts
@@ -2588,9 +2588,17 @@ describe("scheduled task cron script generation", () => {
       join(result.agentDir, "telegram", "cron-0.sh"),
       "utf-8",
     );
-    // MCP path: exec replaces the shell, stdout goes to /dev/null.
-    expect(content).toContain("exec claude -p");
+    // MCP path: claude runs as a child (not exec) so the success-trailer can
+    // run after it; stdout goes to /dev/null. The trailer auto-resolves any
+    // unresolved issues with source=cron:cron-<index> on a 0 exit (PR
+    // following #565). Stderr stays attached for journalctl.
+    expect(content).toContain("claude -p");
+    expect(content).not.toContain("exec claude -p");
     expect(content).toMatch(/> \/dev\/null(?!\s*2>&1)/); // stdout-only, stderr left for journal
+    // Success-trailer: bulk-resolve issues filed under this job's source.
+    expect(content).toContain('switchroom issues resolve --source "cron:cron-0"');
+    expect(content).toContain("--quiet");
+    expect(content).toContain("exit $rc");
     expect(content).not.toContain("> /dev/null 2>&1"); // don't swallow stderr
     expect(content).not.toContain("api.telegram.org");
     expect(content).not.toContain("OUTPUT=");
@@ -2613,7 +2621,8 @@ describe("scheduled task cron script generation", () => {
     scaffoldAgent("flip-cron", baseAgent, tmpDir, telegramConfig, switchroomConfig);
     const scriptPath = join(tmpDir, "flip-cron", "telegram", "cron-0.sh");
     // Both scripts are identical — MCP path always used
-    expect(readFileSync(scriptPath, "utf-8")).toContain("exec claude -p");
+    expect(readFileSync(scriptPath, "utf-8")).toContain("claude -p");
+    expect(readFileSync(scriptPath, "utf-8")).not.toContain("exec claude -p");
     expect(readFileSync(scriptPath, "utf-8")).not.toContain("api.telegram.org");
 
     const updated = makeAgentConfig({
@@ -2626,8 +2635,44 @@ describe("scheduled task cron script generation", () => {
     const result = reconcileAgent("flip-cron", updated, tmpDir, telegramConfig, updatedConfig);
     expect(result.changes).toContain(scriptPath);
     const updatedScript = readFileSync(scriptPath, "utf-8");
-    expect(updatedScript).toContain("exec claude -p");
+    expect(updatedScript).toContain("claude -p");
+    expect(updatedScript).not.toContain("exec claude -p");
     expect(updatedScript).not.toContain("api.telegram.org");
+  });
+
+  it("cron script appends success-trailer that auto-resolves issues by source", () => {
+    // PR following #565: when claude -p exits 0, the script bulk-resolves
+    // any unresolved issue whose source is `cron:cron-<index>`. The trailer
+    // is `|| true`-guarded so a missing CLI never masks a real failure.
+    const agentConfig = makeAgentConfig({
+      schedule: [
+        { cron: "0 8 * * *", prompt: "first" },
+        { cron: "0 9 * * *", prompt: "second" },
+      ],
+    });
+    const result = scaffoldAgent("trailer-cron", agentConfig, tmpDir, telegramConfig);
+
+    const c0 = readFileSync(join(result.agentDir, "telegram", "cron-0.sh"), "utf-8");
+    const c1 = readFileSync(join(result.agentDir, "telegram", "cron-1.sh"), "utf-8");
+
+    // Each script targets ITS OWN slug — cron-0 must not auto-resolve cron-1's issues.
+    expect(c0).toContain('switchroom issues resolve --source "cron:cron-0"');
+    expect(c0).not.toContain('"cron:cron-1"');
+    expect(c1).toContain('switchroom issues resolve --source "cron:cron-1"');
+    expect(c1).not.toContain('"cron:cron-0"');
+
+    // Required trailer shape: capture rc, gate on success, exit with rc.
+    expect(c0).toMatch(/rc=\$\?/);
+    expect(c0).toMatch(/if \[ \$rc -eq 0 \]; then/);
+    expect(c0).toContain("|| true");
+    expect(c0).toMatch(/exit \$rc/);
+
+    // State dir is exported so the CLI can find issues.jsonl.
+    expect(c0).toContain("export TELEGRAM_STATE_DIR=");
+
+    // Prompt-side guidance teaches the model the matching --source string
+    // so any issues it records during the run are auto-resolved on success.
+    expect(c0).toContain('--source "cron:cron-0"');
   });
 
   it("reconcile regenerates cron scripts when prompt changes", () => {


### PR DESCRIPTION
## Summary
- Wraps generated `cron-N.sh` so a clean `claude -p` exit (rc=0) auto-resolves any unresolved issues whose source is `cron:cron-<index>`. Producer writes on failure, success bulk-clears — same model as `run-hook.sh` for hooks.
- Adds `--quiet` to `switchroom issues resolve` for the success trailer.
- Extends `applyCronTelegramGuidance` to tell the agent the exact `--source` string to use when recording transient issues, so producer and resolver agree.

Builds on #565 (which added `resolveAllBySource`).

## Why
Cron-emitted issues had no automatic resolver anywhere — `run-hook.sh` only fires for Claude Code hook wrappers, and crons `exec claude -p` directly. Result: a one-day-old `cron:morning-brief::vault-locked` warning kept showing on the issues card even after the underlying broker was unlocked and 14h of successful cron runs.

## Test plan
- [x] `bunx vitest run tests/scaffold.test.ts` — 151/151 green locally
- [ ] CI green
- [ ] After merge: rebuild + restart clerk so cron-N.sh re-renders, manually resolve the legacy `cron:morning-brief` source (different from new slug `cron:cron-0`), confirm issues card refreshes

🤖 Generated with [Claude Code](https://claude.com/claude-code)