### PR TITLE
fix(reactions): F1 — flush pending reaction before terminal emoji (#553 PR 3)

### DIFF
--- a/telegram-plugin/status-reactions.ts
+++ b/telegram-plugin/status-reactions.ts
@@ -242,10 +242,27 @@ export class StatusReactionController {
   private finishWithState(state: ReactionState): void {
     if (this.finished) return
     this.finished = true
-    this.clearDebounceTimer()
     this.clearStallTimers()
+    // F1 fix (#553): if a non-terminal reaction is sitting in the
+    // debounce window when the turn ends, flush it BEFORE the terminal
+    // emoji emits. Pre-fix, `clearDebounceTimer()` here silently
+    // dropped the pending state — every Class B turn that completed in
+    // under `debounceMs` (default 700ms) collapsed to 👀 → 👍 with no
+    // intermediate signal that the agent did any work.
+    //
+    // Gate on `debounceTimer != null`: a `pendingEmoji` with no timer
+    // is already enqueued (immediate emit waiting on chainPromise) and
+    // re-enqueuing would produce a duplicate. Only debounced-but-not-
+    // yet-enqueued emojis need to be flushed here.
+    const flushPending = this.debounceTimer != null && this.pendingEmoji != null
+      ? this.pendingEmoji
+      : null
+    this.clearDebounceTimer()
+    if (flushPending != null && flushPending !== this.currentEmoji) {
+      this.enqueue(flushPending)
+    }
     const emoji = this.resolveEmoji(state)
-    if (emoji != null && emoji !== this.currentEmoji) {
+    if (emoji != null && emoji !== this.currentEmoji && emoji !== flushPending) {
       this.enqueue(emoji)
     }
   }

--- a/telegram-plugin/tests/real-gateway-f1-ladder-integrity.test.ts
+++ b/telegram-plugin/tests/real-gateway-f1-ladder-integrity.test.ts
@@ -1,0 +1,123 @@
+/**
+ * F1 — "ladder collapse" — regression test against real-gateway harness.
+ *
+ * Symptom from #545: on a Class B turn (1–3 tool calls, < ~15s), the
+ * status reaction jumps straight from 👀 to 👍, skipping the
+ * intermediate 🤔 (thinking) and 🔥 (tool work) states. User loses the
+ * "agent is doing things" signal.
+ *
+ * Root cause: `StatusReactionController.scheduleState()` debounces
+ * non-immediate transitions (default `debounceMs=700`). When a turn
+ * completes faster than the debounce window, intermediate states never
+ * cross the timer — `setDone()` calls `finishWithState()` which
+ * `clearDebounceTimer()`s and emits 👍 directly, dropping the pending
+ * 🤔/🔥.
+ *
+ * Spec contract from `waiting-ux-spec.md`:
+ *
+ *   F1: ladder integrity — for Class B turns, recorded reaction
+ *       sequence MUST contain 👀 followed by at least one
+ *       intermediate state (🤔 / 🔥 / a tool-specific reaction)
+ *       BEFORE 👍. No straight-to-👍 collapse.
+ *
+ * The fix flushes any pending non-terminal reaction before the
+ * terminal 👍 emits. Tracking: #545 (parent), #553 (Phase 3).
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createRealGatewayHarness } from './real-gateway-harness.js'
+
+const CHAT = '8248703757'
+const INBOUND_MSG = 100
+
+beforeEach(() => { vi.useFakeTimers() })
+afterEach(() => { vi.useRealTimers() })
+
+/**
+ * Dedupe consecutive duplicate reactions in the recorded sequence.
+ * The post-F2 harness fires 👀 twice (early-ack + controller setQueued);
+ * Telegram dedupes by emoji so consecutive duplicates are visually one
+ * step. Tests asserting ladder integrity should ignore them.
+ */
+function uniqueLadder(seq: string[]): string[] {
+  const out: string[] = []
+  for (const e of seq) {
+    if (out[out.length - 1] !== e) out.push(e)
+  }
+  return out
+}
+
+describe('F1 — ladder integrity (no straight-to-👍 collapse)', () => {
+  it('Class B sub-debounce turn (~500ms): pending tool reaction MUST emit before 👍', async () => {
+    // The exact failure case from the live demo: a turn that completes
+    // faster than the controller's 700ms debounce window. Pre-fix, the
+    // 🔥 reaction was scheduled but cancelled when setDone() cleared
+    // the debounce timer. User saw 👀 → 👍 with no intermediate state.
+    const h = createRealGatewayHarness({ gapMs: 0 })
+    h.inbound({ chatId: CHAT, messageId: INBOUND_MSG, text: 'quick task' })
+    h.feedSessionEvent({ kind: 'enqueue', chatId: CHAT, messageId: '1', threadId: null, rawContent: 'quick task' })
+    await h.clock.advance(50)
+    h.feedSessionEvent({ kind: 'thinking' })
+    await h.clock.advance(50)
+    h.feedSessionEvent({ kind: 'tool_use', toolName: 'Bash' })
+    await h.clock.advance(400) // tool runs ~400ms, total turn ~500ms — under 700ms debounce
+    h.feedSessionEvent({ kind: 'turn_end', durationMs: 500 })
+    await h.clock.advance(1500) // settle, well past debounce window
+
+    const ladder = uniqueLadder(h.recorder.reactionSequence())
+    expect(ladder[0]).toBe('👀')
+    expect(ladder[ladder.length - 1]).toBe('👍')
+    // Must contain at least one intermediate — no straight 👀 → 👍 collapse.
+    expect(ladder.length).toBeGreaterThanOrEqual(3)
+    h.finalize()
+  })
+
+  it('Class B medium turn (~2s, single tool): ladder shows 👀 → tool reaction → 👍', async () => {
+    // Slower turn (single 2s tool) — works correctly even pre-fix because
+    // 2000ms > 700ms debounce. Pin so the fix doesn't regress the working case.
+    const h = createRealGatewayHarness({ gapMs: 0 })
+    h.inbound({ chatId: CHAT, messageId: INBOUND_MSG, text: 'medium task' })
+    h.feedSessionEvent({ kind: 'enqueue', chatId: CHAT, messageId: '1', threadId: null, rawContent: 'medium task' })
+    await h.clock.advance(50)
+    h.feedSessionEvent({ kind: 'thinking' })
+    await h.clock.advance(200)
+    h.feedSessionEvent({ kind: 'tool_use', toolName: 'Bash' })
+    await h.clock.advance(2000)
+    h.feedSessionEvent({ kind: 'turn_end', durationMs: 2300 })
+    await h.clock.advance(1000)
+
+    const ladder = uniqueLadder(h.recorder.reactionSequence())
+    expect(ladder[0]).toBe('👀')
+    expect(ladder[ladder.length - 1]).toBe('👍')
+    expect(ladder.length).toBeGreaterThanOrEqual(3)
+    h.finalize()
+  })
+
+  it('Class B 3-tool series at sub-debounce intervals: each transition shows', async () => {
+    // Three rapid tool transitions inside a single debounce window.
+    // Pre-fix, only the LAST one would survive (the others got
+    // overwritten by the next setTool). We don't strictly require all
+    // three to appear (the controller can collapse same-emoji adjacent
+    // calls) — but the FINAL pending state before 👍 must emit.
+    const h = createRealGatewayHarness({ gapMs: 0 })
+    h.inbound({ chatId: CHAT, messageId: INBOUND_MSG, text: 'rapid tools' })
+    h.feedSessionEvent({ kind: 'enqueue', chatId: CHAT, messageId: '1', threadId: null, rawContent: 'rapid tools' })
+    await h.clock.advance(50)
+    h.feedSessionEvent({ kind: 'thinking' })
+    await h.clock.advance(50)
+    h.feedSessionEvent({ kind: 'tool_use', toolName: 'Read' })
+    await h.clock.advance(100)
+    h.feedSessionEvent({ kind: 'tool_use', toolName: 'Bash' })
+    await h.clock.advance(100)
+    h.feedSessionEvent({ kind: 'tool_use', toolName: 'Edit' })
+    await h.clock.advance(200)
+    h.feedSessionEvent({ kind: 'turn_end', durationMs: 500 })
+    await h.clock.advance(1500)
+
+    const ladder = uniqueLadder(h.recorder.reactionSequence())
+    expect(ladder[0]).toBe('👀')
+    expect(ladder[ladder.length - 1]).toBe('👍')
+    expect(ladder.length).toBeGreaterThanOrEqual(3)
+    h.finalize()
+  })
+})


### PR DESCRIPTION
## Summary

Pre-fix, every Class B turn (1–3 tool calls, < ~15s) that completed in under the controller's debounce window (default 700ms) collapsed the ladder to **👀 → 👍**, dropping any 🤔 / 🔥 / tool-specific reaction sitting in the debounce timer. User lost the "agent is doing things" signal — the F1 symptom from #545.

## Root cause

\`StatusReactionController.finishWithState()\` called \`clearDebounceTimer()\` unconditionally, silently cancelling any pending non-terminal emoji that hadn't crossed the debounce window. Then it emitted the terminal emoji, so the user saw a single 👀 → 👍 transition for any sub-debounce turn.

## Fix

Before clearing the debounce timer, flush the pending emoji if it was **debounced-but-not-yet-enqueued**. The gate on \`debounceTimer != null\` distinguishes:

- "scheduled, awaiting timer expiry" → flush manually before terminal
- "already in the chainPromise, mid-emit" → leave alone (re-enqueuing would double-emit)

Two-line behavioral change inside the existing \`finishWithState\`.

## Tests

- **3 new tests** in \`real-gateway-f1-ladder-integrity.test.ts\` against the Phase 3 harness (#553):
  - sub-debounce turn (~500ms): pending tool reaction MUST emit before 👍 (the bug from the live demo)
  - medium turn (~2s): ladder shows 👀 → tool → 👍 (regression guard for the case that worked pre-fix)
  - rapid 3-tool series at sub-debounce intervals: final pending emoji emits before 👍
- **All 20 existing** \`status-reactions.test.ts\` tests still pass (including the chainPromise serialisation test that initially flagged an over-eager flush in my first attempt).
- **Full plugin suite**: 3028/3028 pass.

## Spec contract pinned

For Class B turns: recorded reaction sequence (after dedup of consecutive duplicates) MUST contain at least 3 distinct emojis: 👀, ≥1 intermediate, 👍.

## Out of scope

- F3 (late progress card) and F4 (static interim text) — Phase 3 PR 4.

## Test plan

- [x] \`npm run lint\` clean
- [x] \`npx vitest run telegram-plugin/tests/real-gateway-f1-ladder-integrity.test.ts telegram-plugin/tests/status-reactions.test.ts\` → 23/23 pass
- [x] \`(cd telegram-plugin && bun test)\` → 3028/3028 pass
- [ ] CI green
- [ ] Manual: send a quick "what's the time" to a live agent; confirm the reaction ladder shows an intermediate 🔥/🤔 instead of jumping straight to 👍

🤖 Generated with [Claude Code](https://claude.com/claude-code)