### PR TITLE
fix(progress-card): F3 — time-based first-emit promotion (#553 PR 4)

### DIFF
--- a/telegram-plugin/progress-card-driver.ts
+++ b/telegram-plugin/progress-card-driver.ts
@@ -222,6 +222,23 @@ export interface ProgressDriverConfig {
    */
   promoteOnParentToolCount?: number
   /**
+   * Time-based first-emit promotion (#553 F3): if the turn has been
+   * running this long with no tool/sub-agent that already triggered
+   * promotion, force the card to emit. Without this, single- or two-
+   * tool turns that take 5–30s never cross any existing promotion
+   * threshold and the card stays suppressed until `initialDelayMs`,
+   * at which point fast-turn-suppression cancels it on `turn_end`.
+   *
+   * Symmetric to `promoteOnParentToolCount`: pure additive promotion,
+   * never delays an emit that would otherwise fire. Fast-turn
+   * suppression in `flush()` is unchanged — sub-`promoteAfterMs` turns
+   * still skip the card.
+   *
+   * Default 5000 (5 seconds). Set to a large value (e.g. 999_999) to
+   * effectively disable.
+   */
+  promoteAfterMs?: number
+  /**
    * Number of consecutive 4xx Telegram API failures on card edits before
    * the card is marked terminal and all further edits are suppressed for
    * this turn. Transient (5xx/network) errors and "message is not modified"
@@ -365,6 +382,14 @@ interface PerChatState {
   isFirstEmit: boolean
   /** Timer for the deferred first emit (initial-delay suppression). */
   deferredFirstEmitTimer: unknown
+  /**
+   * F3 fix (#553): timer for the time-based first-emit promotion.
+   * Scheduled on the first ingest event; fires after `promoteAfterMs`
+   * to force-promote turns that don't trip parent-tool-count or
+   * sub-agent thresholds (e.g. one long Bash). Cleared on
+   * `promoteFirstEmit` or turn end.
+   */
+  timePromoteTimer: unknown
   /**
    * The Telegram message_id of the user's original inbound message that
    * triggered this turn. Set via startTurn({ replyToMessageId }). Passed
@@ -646,6 +671,7 @@ export function createProgressDriver(config: ProgressDriverConfig): ProgressDriv
   const initialDelayMs = config.initialDelayMs ?? 30_000
   const promoteOnSubAgent = config.promoteOnSubAgent ?? true
   const promoteOnParentToolCount = config.promoteOnParentToolCount ?? 3
+  const promoteAfterMs = config.promoteAfterMs ?? 5_000
   const maxConsecutive4xx = config.maxConsecutive4xx ?? 3
   const orphanPromotionMs = config.orphanPromotionMs ?? 5_000
   const coldSubAgentThresholdMs = config.coldSubAgentThresholdMs ?? 30_000
@@ -822,6 +848,10 @@ export function createProgressDriver(config: ProgressDriverConfig): ProgressDriv
     if (cs.deferredFirstEmitTimer != null) {
       clearT(cs.deferredFirstEmitTimer)
       cs.deferredFirstEmitTimer = null
+    }
+    if (cs.timePromoteTimer != null) {
+      clearT(cs.timePromoteTimer)
+      cs.timePromoteTimer = null
     }
     chats.delete(cs.turnKey)
     lastHeartbeatBucket.delete(cs.turnKey)
@@ -1321,11 +1351,46 @@ export function createProgressDriver(config: ProgressDriverConfig): ProgressDriv
     if (cs.deferredFirstEmitTimer != null) {
       clearT(cs.deferredFirstEmitTimer)
     }
+    if (cs.timePromoteTimer != null) {
+      clearT(cs.timePromoteTimer)
+      cs.timePromoteTimer = null
+    }
     cs.deferredFirstEmitTimer = DELAY_ELAPSED
     process.stderr.write(
       `telegram gateway: progress-card: promoteFirstEmit turnKey=${cs.turnKey} reason=${reason}\n`,
     )
     flush(cs, /*forceDone*/ false)
+  }
+
+  /**
+   * F3 fix (#553): schedule a one-shot timer that force-promotes the
+   * card after `promoteAfterMs` if no other promotion path has fired
+   * by then. Idempotent — safe to call repeatedly. The timer is
+   * cleared by `promoteFirstEmit` (so the existing promotion paths
+   * still win when they fire first) and at turn end.
+   *
+   * Without this proactive timer, a long single-tool turn (e.g. one
+   * 10s Bash) never crosses any existing promotion threshold and
+   * the card stays suppressed until `initialDelayMs` (30s by
+   * default). Fast-turn-suppression then cancels it on `turn_end`.
+   */
+  function ensureTimePromoteScheduled(cs: PerChatState): void {
+    if (!cs.isFirstEmit) return
+    if (cs.deferredFirstEmitTimer === DELAY_ELAPSED) return
+    if (cs.apiFailures.terminal) return
+    if (cs.timePromoteTimer != null) return
+    if (promoteAfterMs <= 0) return
+    const elapsed = now() - cs.state.turnStartedAt
+    const remaining = Math.max(0, promoteAfterMs - elapsed)
+    const capturedTurnKey = cs.turnKey
+    cs.timePromoteTimer = setT(() => {
+      if (!chats.has(capturedTurnKey)) return
+      const cs2 = chats.get(capturedTurnKey)!
+      cs2.timePromoteTimer = null
+      // Idempotency belt-and-braces: promoteFirstEmit no-ops if already
+      // promoted by another path between scheduling and firing.
+      promoteFirstEmit(cs2, `time_${promoteAfterMs}ms`)
+    }, remaining)
   }
 
   /**
@@ -1482,6 +1547,7 @@ export function createProgressDriver(config: ProgressDriverConfig): ProgressDriv
           pendingTimer: null,
           isFirstEmit: true,
           deferredFirstEmitTimer: null,
+          timePromoteTimer: null,
           lastEventAt: now(),
           pendingCompletion: false,
           completionFired: false,
@@ -1599,6 +1665,13 @@ export function createProgressDriver(config: ProgressDriverConfig): ProgressDriv
       ) {
         promoteFirstEmit(chatState, `parent_tool_count_${chatState.state.items.length}`)
       }
+
+      // F3 fix (#553): schedule the time-based promotion timer on
+      // every ingest event (idempotent — only the first call schedules;
+      // subsequent calls are no-ops). Without this, a long single-tool
+      // turn never crossed parent_tool_count or sub_agent thresholds
+      // and the card stayed suppressed until initialDelayMs (30s).
+      ensureTimePromoteScheduled(chatState)
 
       // Issue #132: track whether the agent has called `reply` or
       // `stream_reply` at least once this turn so the renderer can

--- a/telegram-plugin/tests/progress-card-driver.test.ts
+++ b/telegram-plugin/tests/progress-card-driver.test.ts
@@ -17,6 +17,8 @@ function harness(
     heartbeatMs?: number
     maxIdleMs?: number
     initialDelayMs?: number
+    /** F3 (#553): time-based first-emit promotion. Default 0 (disabled in tests). */
+    promoteAfterMs?: number
     onTurnComplete?: (args: { chatId: string; threadId?: string; summary: string; taskIndex: number; taskTotal: number }) => void
   },
 ) {
@@ -35,6 +37,10 @@ function harness(
     heartbeatMs: opts?.heartbeatMs,
     maxIdleMs: opts?.maxIdleMs,
     initialDelayMs: opts?.initialDelayMs ?? 0,
+    // F3 (#553): default to disabled in unit tests so existing
+    // initial-delay assertions stay isolated from time-based promotion.
+    // Tests that want to exercise it pass an explicit value.
+    promoteAfterMs: opts?.promoteAfterMs ?? 999_999,
     now: () => now,
     setTimeout: (fn, ms) => {
       const ref = nextRef++
@@ -1437,7 +1443,15 @@ describe('forceCompleteTurn — external completion signal', () => {
     // initialDelayMs=30s elapses), and stream_reply(done=true) fires
     // forceCompleteTurn. The deferred first-emit timer must be cancelled
     // so it can't fire at +30s with a ghost card.
-    const { driver, emits, advance } = harness(0, 0, { initialDelayMs: 30_000 })
+    // Disable F3 time-based promotion (default 5s) so this test isolates
+    // the cusp-race behaviour pre-existed the F3 fix — forceCompleteTurn
+    // must cancel the deferred-first-emit timer regardless. With time-
+    // promotion enabled, the card would correctly emit at +5s; that's
+    // covered by the F3 tests, not this one.
+    const { driver, emits, advance } = harness(0, 0, {
+      initialDelayMs: 30_000,
+      promoteAfterMs: 999_999,
+    })
 
     driver.startTurn({ chatId: 'c', userText: 'quick question' })
     advance(0)
@@ -3329,6 +3343,8 @@ describe('progress-card driver — promote-on-sub-agent', () => {
     initialDelayMs?: number
     promoteOnSubAgent?: boolean
     promoteOnParentToolCount?: number
+    /** F3 (#553): time-based first-emit promotion. Default disabled in tests. */
+    promoteAfterMs?: number
     maxConsecutive4xx?: number
     onTurnComplete?: (args: { chatId: string; threadId?: string; summary: string; taskIndex: number; taskTotal: number }) => void
   }) {
@@ -3345,6 +3361,9 @@ describe('progress-card driver — promote-on-sub-agent', () => {
       initialDelayMs: opts?.initialDelayMs ?? 30_000,
       promoteOnSubAgent: opts?.promoteOnSubAgent,
       promoteOnParentToolCount: opts?.promoteOnParentToolCount,
+      // F3 (#553): default disabled in unit tests so initial-delay assertions
+      // stay isolated from time-based promotion.
+      promoteAfterMs: opts?.promoteAfterMs ?? 999_999,
       maxConsecutive4xx: opts?.maxConsecutive4xx,
       now: () => now,
       setTimeout: (fn, ms) => {
@@ -3411,9 +3430,13 @@ describe('progress-card driver — promote-on-sub-agent', () => {
   })
 
   it('promoteOnSubAgent:false — sub-agent does NOT promote, card waits full delay', () => {
+    // Also disable F3 time-based promotion so this test cleanly isolates
+    // the promoteOnSubAgent flag (otherwise the time promote at +5s
+    // would fire before the sub-agent gate is exercised).
     const { driver, emits, advance } = promoHarness({
       initialDelayMs: 30_000,
       promoteOnSubAgent: false,
+      promoteAfterMs: 999_999,
     })
     driver.startTurn({ chatId: 'c', userText: 'q' })
     advance(5_000)

--- a/telegram-plugin/tests/real-gateway-f3-late-card.test.ts
+++ b/telegram-plugin/tests/real-gateway-f3-late-card.test.ts
@@ -1,0 +1,123 @@
+/**
+ * F3 — "late progress card" — regression test against real-gateway harness.
+ *
+ * Symptom from #545: on long-running turns (Class C), the progress card
+ * renders late — sometimes after `turn_end`, sometimes never. User sits
+ * watching status reactions cycle for 10+ seconds with no card visible,
+ * then either gets a sudden card right before the reply or just the
+ * reply with no card at all.
+ *
+ * Root cause: `progress-card-driver` defaults `initialDelayMs=30000`
+ * (30 seconds — designed to suppress cards for instant replies). The
+ * existing `promoteFirstEmit` mechanism short-circuits the wait under
+ * specific conditions:
+ *
+ *   - parent tool count ≥ `promoteOnParentToolCount` (default 3)
+ *   - any sub-agent started
+ *   - carried-over sub-agents at enqueue
+ *   - sub-agent stalled
+ *
+ * **Gap**: a long single-tool turn (e.g. one Bash that takes 10 seconds)
+ * never crosses any promotion threshold. Card waits the full 30s, then
+ * fast-turn-suppression cancels it at `turn_end`. F3 directly observed.
+ *
+ * Fix: add a time-based promotion — after Ns of activity (any session
+ * event) in still-`isFirstEmit` state, promote. 5s gives users a clear
+ * "agent is working" signal without breaking instant-reply suppression
+ * (sub-2s turns still skip the card).
+ *
+ * Spec contract from `waiting-ux-spec.md` Class C:
+ *   - Status card renders early, **stays pinned-feel and stable**
+ *
+ * Tracking: #545 (parent), #553 (Phase 3).
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createRealGatewayHarness } from './real-gateway-harness.js'
+
+const CHAT = '8248703757'
+const INBOUND_MSG = 100
+
+beforeEach(() => { vi.useFakeTimers() })
+afterEach(() => { vi.useRealTimers() })
+
+describe('F3 — progress card renders early on long turns', () => {
+  it('long single-tool turn (~10s): card renders before turn_end', async () => {
+    // Production defaults: initialDelayMs=30000, promoteOnParentToolCount=3.
+    // A 10s single-tool turn crosses neither — card waits the full 30s,
+    // then fast-turn-suppression cancels it. This is exactly F3.
+    const h = createRealGatewayHarness({ gapMs: 0 })
+    const inboundAt = h.clock.now()
+    h.inbound({ chatId: CHAT, messageId: INBOUND_MSG, text: 'long task' })
+    h.feedSessionEvent({ kind: 'enqueue', chatId: CHAT, messageId: '1', threadId: null, rawContent: 'long task' })
+    await h.clock.advance(200)
+    h.feedSessionEvent({ kind: 'thinking' })
+    await h.clock.advance(500)
+    h.feedSessionEvent({ kind: 'tool_use', toolName: 'Bash', toolUseId: 't1' })
+    // Tool runs ~10s — well past the 5s promotion threshold the fix introduces.
+    await h.clock.advance(10_000)
+    h.feedSessionEvent({ kind: 'tool_result', toolUseId: 't1', toolName: 'Bash' })
+    await h.clock.advance(200)
+
+    // Spec: card MUST be visible by now (well within the 10s tool window).
+    const cardAt = h.recorder.progressCardSendMs(CHAT)
+    expect(cardAt, 'progress card never rendered for a 10s long turn').not.toBeNull()
+    // Card should have rendered within ~5s of inbound (the time-promotion
+    // threshold), not at the 30s initialDelay.
+    expect((cardAt ?? Infinity) - inboundAt).toBeLessThan(8_000)
+
+    // Drain the rest of the turn so afterEach doesn't leak timers.
+    await h.streamReply({ chat_id: CHAT, text: 'done', done: true })
+    h.feedSessionEvent({ kind: 'turn_end', durationMs: 11_000 })
+    await h.clock.advance(2_000)
+    h.finalize()
+  })
+
+  it('two-tool turn (~6s): card renders within 5-6s of inbound', async () => {
+    // 2 tools — below the parent_tool_count promotion threshold (3).
+    // Without time-based promotion, this turn would wait 30s then
+    // suppress. With the fix, it promotes around the 5s mark.
+    const h = createRealGatewayHarness({ gapMs: 0 })
+    const inboundAt = h.clock.now()
+    h.inbound({ chatId: CHAT, messageId: INBOUND_MSG, text: 'two tools' })
+    h.feedSessionEvent({ kind: 'enqueue', chatId: CHAT, messageId: '1', threadId: null, rawContent: 'two tools' })
+    await h.clock.advance(200)
+    h.feedSessionEvent({ kind: 'thinking' })
+    await h.clock.advance(500)
+    h.feedSessionEvent({ kind: 'tool_use', toolName: 'Read', toolUseId: 't1' })
+    await h.clock.advance(2_000)
+    h.feedSessionEvent({ kind: 'tool_result', toolUseId: 't1', toolName: 'Read' })
+    h.feedSessionEvent({ kind: 'tool_use', toolName: 'Bash', toolUseId: 't2' })
+    await h.clock.advance(3_000)
+    h.feedSessionEvent({ kind: 'tool_result', toolUseId: 't2', toolName: 'Bash' })
+    await h.clock.advance(500)
+
+    const cardAt = h.recorder.progressCardSendMs(CHAT)
+    expect(cardAt, 'progress card never rendered for a 6s 2-tool turn').not.toBeNull()
+    expect((cardAt ?? Infinity) - inboundAt).toBeLessThan(7_000)
+
+    // Drain
+    await h.streamReply({ chat_id: CHAT, text: 'done', done: true })
+    h.feedSessionEvent({ kind: 'turn_end', durationMs: 7_000 })
+    await h.clock.advance(2_000)
+    h.finalize()
+  })
+
+  it('instant reply (Class A, <2s, no tools): card is STILL suppressed (regression guard)', async () => {
+    // The fix must not regress fast-turn suppression — a sub-2s turn
+    // with no tools should still skip the card entirely.
+    const h = createRealGatewayHarness({ gapMs: 0 })
+    h.inbound({ chatId: CHAT, messageId: INBOUND_MSG, text: 'hi' })
+    h.feedSessionEvent({ kind: 'enqueue', chatId: CHAT, messageId: '1', threadId: null, rawContent: 'hi' })
+    await h.clock.advance(200)
+    h.feedSessionEvent({ kind: 'thinking' })
+    await h.clock.advance(500)
+    await h.streamReply({ chat_id: CHAT, text: 'hello back', done: true })
+    h.feedSessionEvent({ kind: 'turn_end', durationMs: 1_500 })
+    await h.clock.advance(2_000)
+
+    // Class A: no card. Pin so the F3 fix doesn't blanket-promote.
+    expect(h.recorder.progressCardSendMs(CHAT)).toBeNull()
+    h.finalize()
+  })
+})


### PR DESCRIPTION
## Summary

Pre-fix, single- or two-tool turns that took 5–30s never crossed any existing promotion threshold (\`parent_tool_count_3\`, \`sub_agent_started\`, etc). The card stayed suppressed until \`initialDelayMs\` (30s default), at which point fast-turn-suppression cancelled it on \`turn_end\`. User saw status reactions cycling for 10+ seconds with no card — exactly F3 from #545.

## Fix

Schedule a one-shot \`timePromoteTimer\` on the first ingest event that fires after \`promoteAfterMs\` (default 5s) and force-promotes the card if no other promotion path has fired by then. Pure additive — never delays an emit; sub-5s instant replies still hit fast-turn-suppression as before.

### Implementation

- New \`promoteAfterMs?: number\` (default 5000) on \`ProgressDriverConfig\`
- New \`timePromoteTimer\` field on \`PerChatState\`
- New \`ensureTimePromoteScheduled(cs)\` helper — idempotent timer setup
- \`promoteFirstEmit\` clears the timer when any other promotion path wins
- Cleanup in turn-end / chat-delete paths

## Tests

- **3 new tests** in \`real-gateway-f3-late-card.test.ts\` against the Phase 3 harness with PRODUCTION defaults (\`initialDelayMs=30000\`, \`promoteOnParentToolCount=3\`):
  - long single-tool turn (~10s): card renders within ~5s
  - two-tool turn (~6s): card renders within 5-6s
  - instant reply (Class A, <2s): card STILL suppressed (regression guard)
- **Updated \`progress-card-driver.test.ts\`** harness factories to default \`promoteAfterMs=999_999\` so existing initial-delay assertions stay isolated from time-based promotion. Two tests (cusp-race + promoteOnSubAgent:false) annotated with rationale.
- **All 144** existing driver tests still pass.
- **Full plugin suite**: 3031/3031 pass.

## Spec contract

For Class C turns (long/multi-agent), the card renders within \`promoteAfterMs\` (default 5s) of inbound, regardless of tool count or sub-agent presence.

## Out of scope

F4 (static interim text) — separate code area (narrative rendering, not promotion timing), tracked for a follow-up PR.

## Test plan

- [x] \`npm run lint\` clean
- [x] \`npx vitest run telegram-plugin/tests/real-gateway-f3-late-card.test.ts telegram-plugin/tests/progress-card-driver.test.ts\` → 147/147
- [x] \`(cd telegram-plugin && bun test)\` → 3031/3031
- [ ] CI green
- [ ] Manual: send a single 10s task to a live agent; confirm the card renders within ~5s instead of waiting 30s

🤖 Generated with [Claude Code](https://claude.com/claude-code)