### PR TITLE
fix(progress-card): sub-agent count must equal rendered row count (#553 PR 2 of 5)

### DIFF
--- a/telegram-plugin/progress-card.ts
+++ b/telegram-plugin/progress-card.ts
@@ -1378,40 +1378,56 @@ interface SubAgentCounts {
   running: number
   done: number
   failed: number
-  stalled: number
 }
 
+/**
+ * Count sub-agents by their underlying state. Stalled is NOT a separate
+ * bucket: a stalled sub-agent has `state === 'running'` (the ⚠️ glyph on
+ * the per-row header is purely a render-time annotation based on
+ * lastEventAt freshness — see `renderSubAgentExpandable`). Counting
+ * stalled separately on the summary header would let it drift from the
+ * rendered row count, which is what we render for running entries:
+ * `sortSubAgentsChrono` returns ALL entries regardless of staleness, so
+ * the header `🔄 N` must equal `state === 'running'` count to match what
+ * the user actually sees (see issue #553).
+ *
+ * The `now` parameter is retained for symmetry with the renderer (and to
+ * make a future "drift older than X" classification cheap to add) but is
+ * intentionally unused.
+ */
 function countSubAgentStates(
   subAgents: ReadonlyMap<string, SubAgentState>,
-  now: number,
+  _now: number,
 ): SubAgentCounts {
   let running = 0
   let done = 0
   let failed = 0
-  let stalled = 0
   for (const sa of subAgents.values()) {
-    if (sa.state === 'running') {
-      const isStalled = sa.lastEventAt != null && (now - sa.lastEventAt) >= SUBAGENT_STALL_MS
-      if (isStalled) stalled++
-      else running++
-    } else if (sa.state === 'done') done++
+    if (sa.state === 'running') running++
+    else if (sa.state === 'done') done++
     else if (sa.state === 'failed') failed++
   }
-  return { running, done, failed, stalled }
+  return { running, done, failed }
 }
 
 /**
- * Issue #352: always-visible summary header above per-agent expandables.
- * Format: `🤖 Sub-agents · ✅ N · 🔄 N · ❌ N · ⚠️ N`
- * Omits any emoji whose count is 0.
- * When all running (no done/failed/stalled): `🤖 Sub-agents · 🔄 N`
+ * Issue #352 / #553: always-visible summary header above per-agent
+ * expandables.
+ *
+ * Format: `🤖 Sub-agents · ✅ N · 🔄 N · ❌ N`
+ *
+ * Counts mirror sub-agent `state`, which is exactly what
+ * `sortSubAgentsChrono` enumerates as rendered rows — so the `🔄` count
+ * always equals the number of running rows the user sees. Stalled rows
+ * still get a ⚠️ glyph in their per-row header (see
+ * `renderSubAgentExpandable`), but they remain `state === 'running'` and
+ * therefore count toward `🔄`. Any emoji whose count is 0 is omitted.
  */
 function renderSubAgentSummaryHeader(c: SubAgentCounts): string {
   const parts: string[] = []
   if (c.done > 0) parts.push(`✅ ${c.done}`)
   if (c.running > 0) parts.push(`🔄 ${c.running}`)
   if (c.failed > 0) parts.push(`❌ ${c.failed}`)
-  if (c.stalled > 0) parts.push(`⚠️ ${c.stalled}`)
   const counters = parts.length > 0 ? ` · ${parts.join(' · ')}` : ''
   return `<b><u>🤖 Sub-agents</u></b>${counters}`
 }

--- a/telegram-plugin/tests/progress-card.test.ts
+++ b/telegram-plugin/tests/progress-card.test.ts
@@ -2321,14 +2321,279 @@ describe('progress-card multi-agent layout snapshots', () => {
       // Render `now` is 70_000ms after the last event (>60s SUBAGENT_STALL_MS).
       const html = render(st, 72_100)
 
-      // Stalled state surfaces in both the header summary and per-agent header.
-      expect(html).toContain('<b><u>🤖 Sub-agents</u></b> · ⚠️ 1')
+      // Per #553: stalled sub-agents still count toward the 🔄 running
+      // total in the header (so the count never drifts from the rendered
+      // row count), but the per-row header still surfaces ⚠️ stalled as a
+      // render-time annotation.
+      expect(html).toContain('<b><u>🤖 Sub-agents</u></b> · 🔄 1')
       expect(html).toContain('⚠️ stalled')
+      // The old separate ⚠️ N counter on the summary header is gone.
+      expect(html).not.toContain('<b><u>🤖 Sub-agents</u></b> · ⚠️')
 
       // The sub-agent's underlying state stays 'running' — stalled is a
       // render-time classification based on lastEventAt freshness, not a
       // separate state machine value.
       expect(st.subAgents.get('A')?.state).toBe('running')
+    } finally {
+      delete process.env.PROGRESS_CARD_MULTI_AGENT
+    }
+  })
+})
+
+// ── #553 PR 2: header count must equal rendered row count ───────────────────
+//
+// Bug: the summary header counted stalled sub-agents (running + no events for
+// 60s) under a separate ⚠️ bucket, so "1 sub agent working" appeared above 4
+// rendered rows. Fix: stalled folds into the running count, since the
+// underlying `state === 'running'` and the renderer enumerates all such
+// entries as full rows. The per-row ⚠️ glyph stays — it's row-level metadata,
+// not a state-machine value.
+describe('progress-card — #553 sub-agent header count parity', () => {
+  // Build a state with N sub-agents whose lastEventAt is `ageMs` in the past
+  // at render time `now`. Returns { state, now } ready to render.
+  function buildSubAgents(
+    specs: ReadonlyArray<{ id: string; ageMs: number; description: string }>,
+    now: number,
+  ): { state: ProgressCardState; now: number } {
+    const enqueueEvt = enqueue('parallel run')
+    const toolUseEvts: SessionEvent[] = specs.map((s) => ({
+      kind: 'tool_use',
+      toolName: 'Agent',
+      toolUseId: `toolu_${s.id}`,
+      input: { description: s.description, prompt: `P-${s.id}` },
+    }))
+    let st = fold([enqueueEvt, ...toolUseEvts])
+    // Walk each spec: started + one tool_use to set lastEventAt.
+    for (const s of specs) {
+      const lastEventAt = now - s.ageMs
+      st = reduce(st, { kind: 'sub_agent_started', agentId: s.id, firstPromptText: `P-${s.id}` }, lastEventAt - 1)
+      st = reduce(
+        st,
+        { kind: 'sub_agent_tool_use', agentId: s.id, toolUseId: `t-${s.id}`, toolName: 'Bash', input: { command: 'work' } },
+        lastEventAt,
+      )
+    }
+    return { state: st, now }
+  }
+
+  // Count rendered <blockquote expandable> blocks whose collapsed header
+  // shows the given status emoji + label. Independent of the summary header.
+  function countRenderedRows(html: string, statusFragment: string): number {
+    const blocks = html.split('<blockquote expandable>').slice(1)
+    return blocks.filter((b) => b.split('</blockquote>')[0].includes(statusFragment)).length
+  }
+
+  it('header_count_eq_rendered_running_rows: 1 fresh + 3 stalled-running → 🔄 4', () => {
+    process.env.PROGRESS_CARD_MULTI_AGENT = '1'
+    try {
+      const NOW = 200_000
+      const FRESH_MS = 5_000
+      const STALLED_MS = 90_000 // > SUBAGENT_STALL_MS (60s)
+      const { state, now } = buildSubAgents(
+        [
+          { id: 'A', ageMs: FRESH_MS, description: 'fresh worker' },
+          { id: 'B', ageMs: STALLED_MS, description: 'stalled one' },
+          { id: 'C', ageMs: STALLED_MS, description: 'stalled two' },
+          { id: 'D', ageMs: STALLED_MS, description: 'stalled three' },
+        ],
+        NOW,
+      )
+      const html = render(state, now)
+
+      // Header reports 4 running, no separate stalled bucket on the header.
+      expect(html).toContain('<b><u>🤖 Sub-agents</u></b> · 🔄 4')
+      expect(html).not.toMatch(/🤖 Sub-agents<\/u><\/b>[^\n]*⚠️/)
+
+      // Rendered rows: 1 row with `🔄 working` + 3 rows with `⚠️ stalled`.
+      // Header running count (4) == fresh (1) + stalled (3) == every row
+      // whose underlying state is 'running'.
+      expect(countRenderedRows(html, '🔄 working')).toBe(1)
+      expect(countRenderedRows(html, '⚠️ stalled')).toBe(3)
+      expect((html.match(/<blockquote expandable>/g) ?? []).length).toBe(4)
+    } finally {
+      delete process.env.PROGRESS_CARD_MULTI_AGENT
+    }
+  })
+
+  it('header_count_excludes_terminal: done/failed are not in 🔄 count', () => {
+    process.env.PROGRESS_CARD_MULTI_AGENT = '1'
+    try {
+      let st = fold([
+        enqueue('mixed terminal'),
+        { kind: 'tool_use', toolName: 'Agent', toolUseId: 'toolu_a', input: { description: 'task A', prompt: 'P-A' } },
+        { kind: 'tool_use', toolName: 'Agent', toolUseId: 'toolu_b', input: { description: 'task B', prompt: 'P-B' } },
+        { kind: 'tool_use', toolName: 'Agent', toolUseId: 'toolu_c', input: { description: 'task C', prompt: 'P-C' } },
+      ])
+      st = reduce(st, { kind: 'sub_agent_started', agentId: 'A', firstPromptText: 'P-A' }, 2000)
+      st = reduce(st, { kind: 'sub_agent_started', agentId: 'B', firstPromptText: 'P-B' }, 2100)
+      st = reduce(st, { kind: 'sub_agent_started', agentId: 'C', firstPromptText: 'P-C' }, 2200)
+      // A → done, B → failed. C stays running.
+      st = reduce(st, { kind: 'tool_result', toolUseId: 'toolu_a', toolName: 'Agent', isError: false }, 2300)
+      st = reduce(st, { kind: 'tool_result', toolUseId: 'toolu_b', toolName: 'Agent', isError: true, errorText: 'boom' }, 2400)
+      const html = render(st, 3000)
+
+      // Header: ✅ 1 · 🔄 1 · ❌ 1 — the running count excludes terminal entries.
+      expect(html).toContain('<b><u>🤖 Sub-agents</u></b> · ✅ 1 · 🔄 1 · ❌ 1')
+    } finally {
+      delete process.env.PROGRESS_CARD_MULTI_AGENT
+    }
+  })
+
+  it('header_count_eq_rendered_running_rows_mixed: 1 fresh + 1 stalled + 1 done + 1 failed', () => {
+    process.env.PROGRESS_CARD_MULTI_AGENT = '1'
+    try {
+      const NOW = 300_000
+      let st = fold([
+        enqueue('mixed everything'),
+        { kind: 'tool_use', toolName: 'Agent', toolUseId: 'toolu_a', input: { description: 'fresh worker', prompt: 'P-A' } },
+        { kind: 'tool_use', toolName: 'Agent', toolUseId: 'toolu_b', input: { description: 'stalled worker', prompt: 'P-B' } },
+        { kind: 'tool_use', toolName: 'Agent', toolUseId: 'toolu_c', input: { description: 'done worker', prompt: 'P-C' } },
+        { kind: 'tool_use', toolName: 'Agent', toolUseId: 'toolu_d', input: { description: 'failed worker', prompt: 'P-D' } },
+      ])
+      // A: fresh running (recent event)
+      st = reduce(st, { kind: 'sub_agent_started', agentId: 'A', firstPromptText: 'P-A' }, NOW - 10_000)
+      st = reduce(
+        st,
+        { kind: 'sub_agent_tool_use', agentId: 'A', toolUseId: 'ta', toolName: 'Bash', input: { command: 'work' } },
+        NOW - 5_000,
+      )
+      // B: stalled running (last event > 60s ago)
+      st = reduce(st, { kind: 'sub_agent_started', agentId: 'B', firstPromptText: 'P-B' }, NOW - 200_000)
+      st = reduce(
+        st,
+        { kind: 'sub_agent_tool_use', agentId: 'B', toolUseId: 'tb', toolName: 'Bash', input: { command: 'sleep' } },
+        NOW - 90_000,
+      )
+      // C: terminal done
+      st = reduce(st, { kind: 'sub_agent_started', agentId: 'C', firstPromptText: 'P-C' }, NOW - 50_000)
+      st = reduce(st, { kind: 'tool_result', toolUseId: 'toolu_c', toolName: 'Agent', isError: false }, NOW - 40_000)
+      // D: terminal failed
+      st = reduce(st, { kind: 'sub_agent_started', agentId: 'D', firstPromptText: 'P-D' }, NOW - 30_000)
+      st = reduce(st, { kind: 'tool_result', toolUseId: 'toolu_d', toolName: 'Agent', isError: true, errorText: 'x' }, NOW - 20_000)
+
+      const html = render(st, NOW)
+
+      // Header: ✅ 1 · 🔄 2 · ❌ 1 — fresh + stalled both count toward 🔄.
+      expect(html).toContain('<b><u>🤖 Sub-agents</u></b> · ✅ 1 · 🔄 2 · ❌ 1')
+
+      // Rendered rows: 1 working + 1 stalled + 1 done + 1 failed.
+      // The two running rows (1 fresh-working + 1 stalled) match the
+      // header 🔄 2 count exactly — which is the bug this PR fixes.
+      expect(countRenderedRows(html, '🔄 working')).toBe(1)
+      expect(countRenderedRows(html, '⚠️ stalled')).toBe(1)
+      expect(countRenderedRows(html, '✅ done')).toBe(1)
+      expect(countRenderedRows(html, '❌ failed')).toBe(1)
+      expect((html.match(/<blockquote expandable>/g) ?? []).length).toBe(4)
+    } finally {
+      delete process.env.PROGRESS_CARD_MULTI_AGENT
+    }
+  })
+
+  it('regression: header counts never drift from rendered rows (property-style)', () => {
+    process.env.PROGRESS_CARD_MULTI_AGENT = '1'
+    try {
+      // Sweep a matrix of (fresh_running, stalled_running, done, failed)
+      // tuples and assert the invariant: for every rendered card, the sum
+      // of header counts equals the number of expandable rows, and the
+      // 🔄 count equals the number of rows with state === 'running' (i.e.
+      // both fresh-working and stalled rows). If a future refactor ever
+      // re-introduces a separate stalled bucket on the header without
+      // also subtracting from running, this test will catch the drift.
+      const matrix: Array<[number, number, number, number]> = [
+        [1, 0, 0, 0],
+        [0, 1, 0, 0],
+        [1, 1, 0, 0],
+        [1, 3, 0, 0], // the canonical bug shape from the user report
+        [2, 2, 1, 1],
+        [0, 0, 3, 0],
+        [0, 0, 0, 3],
+        [3, 0, 2, 1],
+      ]
+
+      for (const [nFresh, nStalled, nDone, nFailed] of matrix) {
+        const NOW = 500_000
+        const enqueueEvt = enqueue(`matrix ${nFresh}-${nStalled}-${nDone}-${nFailed}`)
+        const toolUseEvts: SessionEvent[] = []
+        const allIds: string[] = []
+        let idx = 0
+        const make = (n: number, prefix: string): string[] => {
+          const ids: string[] = []
+          for (let i = 0; i < n; i++) {
+            const id = `${prefix}${i}`
+            ids.push(id)
+            allIds.push(id)
+            toolUseEvts.push({
+              kind: 'tool_use',
+              toolName: 'Agent',
+              toolUseId: `toolu_${id}`,
+              input: { description: `${prefix} ${i}`, prompt: `P-${id}` },
+            })
+            idx++
+          }
+          return ids
+        }
+        const freshIds = make(nFresh, 'F')
+        const stalledIds = make(nStalled, 'S')
+        const doneIds = make(nDone, 'D')
+        const failedIds = make(nFailed, 'X')
+
+        let st = fold([enqueueEvt, ...toolUseEvts])
+
+        for (const id of freshIds) {
+          st = reduce(st, { kind: 'sub_agent_started', agentId: id, firstPromptText: `P-${id}` }, NOW - 10_000)
+          st = reduce(
+            st,
+            { kind: 'sub_agent_tool_use', agentId: id, toolUseId: `t-${id}`, toolName: 'Bash', input: { command: 'x' } },
+            NOW - 5_000,
+          )
+        }
+        for (const id of stalledIds) {
+          st = reduce(st, { kind: 'sub_agent_started', agentId: id, firstPromptText: `P-${id}` }, NOW - 200_000)
+          st = reduce(
+            st,
+            { kind: 'sub_agent_tool_use', agentId: id, toolUseId: `t-${id}`, toolName: 'Bash', input: { command: 'x' } },
+            NOW - 90_000,
+          )
+        }
+        for (const id of doneIds) {
+          st = reduce(st, { kind: 'sub_agent_started', agentId: id, firstPromptText: `P-${id}` }, NOW - 50_000)
+          st = reduce(st, { kind: 'tool_result', toolUseId: `toolu_${id}`, toolName: 'Agent', isError: false }, NOW - 40_000)
+        }
+        for (const id of failedIds) {
+          st = reduce(st, { kind: 'sub_agent_started', agentId: id, firstPromptText: `P-${id}` }, NOW - 30_000)
+          st = reduce(
+            st,
+            { kind: 'tool_result', toolUseId: `toolu_${id}`, toolName: 'Agent', isError: true, errorText: 'e' },
+            NOW - 20_000,
+          )
+        }
+
+        const html = render(st, NOW)
+
+        // Total expandable rows == total sub-agents.
+        const totalRows = (html.match(/<blockquote expandable>/g) ?? []).length
+        const totalSubAgents = nFresh + nStalled + nDone + nFailed
+        expect(totalRows, `tuple ${nFresh}/${nStalled}/${nDone}/${nFailed}`).toBe(totalSubAgents)
+
+        if (totalSubAgents === 0) continue
+
+        // Parse header counts from the summary line.
+        const headerMatch = html.match(/<b><u>🤖 Sub-agents<\/u><\/b>([^\n]*)/)
+        expect(headerMatch, `header missing for ${nFresh}/${nStalled}/${nDone}/${nFailed}`).toBeTruthy()
+        const headerLine = headerMatch![1]
+        const doneCount = Number(headerLine.match(/✅ (\d+)/)?.[1] ?? 0)
+        const runningCount = Number(headerLine.match(/🔄 (\d+)/)?.[1] ?? 0)
+        const failedCount = Number(headerLine.match(/❌ (\d+)/)?.[1] ?? 0)
+
+        // The invariant: 🔄 count === fresh + stalled (both have state === 'running').
+        expect(runningCount, `🔄 drift on ${nFresh}/${nStalled}/${nDone}/${nFailed}`).toBe(nFresh + nStalled)
+        expect(doneCount, `✅ drift on ${nFresh}/${nStalled}/${nDone}/${nFailed}`).toBe(nDone)
+        expect(failedCount, `❌ drift on ${nFresh}/${nStalled}/${nDone}/${nFailed}`).toBe(nFailed)
+        // Sum of header counts == total rendered rows.
+        expect(doneCount + runningCount + failedCount).toBe(totalRows)
+        // No separate ⚠️ bucket on the summary header (it would re-introduce drift).
+        expect(headerLine).not.toContain('⚠️')
+      }
     } finally {
       delete process.env.PROGRESS_CARD_MULTI_AGENT
     }


### PR DESCRIPTION
## Bug

User reported a progress card showing **\"1 sub agent working\"** in the header above **4 rendered sub-agent rows**. The count and the list disagreed by 3.

## Root cause

Two separate data sources, no atomic invariant linking them:

- **Header count** (`countSubAgentStates`, `progress-card.ts:~1384`) bucketed running sub-agents into either `running` (event within last 60s) or `stalled` (no events for ≥60s). The `🔄 N` chip on the header reflected only fresh-running.
- **Rendered rows** (`render`, `progress-card.ts:~1246`) iterates `sortSubAgentsChrono(state.subAgents)` — every entry, regardless of staleness — so stalled-running sub-agents got full rows.

Result: `🔄 1` over 4 rows whenever 3 of them had drifted past the 60s freshness threshold.

## Fix policy

Fold stalled into the running count. Stalled is non-terminal — the sub-agent may resume — so counting it as \"working\" is honest and matches what the user sees on screen. Concretely:

- `countSubAgentStates` no longer splits running by `lastEventAt` freshness; `running` is now exactly `state === 'running'` (the same predicate `sortSubAgentsChrono` enumerates).
- The `stalled` field is dropped from `SubAgentCounts`, and the `⚠️ N` counter is removed from `renderSubAgentSummaryHeader`.
- The per-row `⚠️ stalled` annotation in `renderSubAgentExpandable` is **unchanged** — that's row-level metadata about lastEventAt freshness, not a state-machine value.

Trade-off considered: alternative was to filter the renderer to match the (drifted) count. Rejected — that would hide non-terminal sub-agents from the user's view, which is the opposite of the visibility outcome in `reference/vision.md`.

## Tests

Four new tests (in a new `#553 sub-agent header count parity` describe block, `telegram-plugin/tests/progress-card.test.ts`):

1. **`header_count_eq_rendered_running_rows`** — 1 fresh + 3 stalled-running → header `🔄 4`, rendered: 1 row `🔄 working` + 3 rows `⚠️ stalled` = 4 running rows.
2. **`header_count_excludes_terminal`** — done/failed sub-agents are NOT in the `🔄` count.
3. **`header_count_eq_rendered_running_rows_mixed`** — 1 fresh + 1 stalled + 1 done + 1 failed → `✅ 1 · 🔄 2 · ❌ 1`; rendered rows match exactly.
4. **`regression: header counts never drift from rendered rows`** — property-style sweep across 8 `(fresh, stalled, done, failed)` tuples (including the canonical `1/3/0/0` bug shape) asserting `🔄 == fresh + stalled`, no `⚠️` on the summary header, and `sum(counts) == row count`. Catches a future refactor that reintroduces a separate stalled bucket without subtracting from running.

Updated the existing `snapshot: stalled state` test to expect `🔄 1` (was `⚠️ 1`).

## Verification

- `cd telegram-plugin && bun test` — 3036 pass / 0 fail / 1 skip across 161 files.
- `npm run lint` — clean.

## Scope

- Touches only the count + summary-header surface in `progress-card.ts`.
- Does NOT touch inbound/coalesce/placeholder code paths — those are PR 3-5 of the series.

Refs #553 (PR 2 of 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)