### PR TITLE
feat(gateway): ask_user MCP tool with inline-keyboard answers

### DIFF
--- a/telegram-plugin/ask-user.ts
+++ b/telegram-plugin/ask-user.ts
@@ -1,0 +1,179 @@
+/**
+ * Pure helpers for the `ask_user` MCP tool.
+ *
+ * The runtime side (sending the question, opening a deferred promise,
+ * waiting for a Telegram callback or a timeout, returning the chosen
+ * option to the agent) lives in `gateway/gateway.ts`. This file owns
+ * the parts that have no I/O — argument validation, callback-data
+ * encoding/decoding, ID generation — so they can be unit-tested
+ * without a grammY mock or a live IPC server.
+ *
+ * Callback data shape: `aq:<idx>:<askId>` where:
+ *   - `aq` is the prefix the gateway's callback dispatcher matches
+ *   - `<idx>` is the zero-based index into the `options` array (0-7)
+ *   - `<askId>` is an 8-char lowercase-hex token
+ *
+ * Why an integer index instead of the option text itself: Telegram
+ * caps callback_data at 64 bytes, and option text can easily exceed
+ * that. The index is constant-size; the gateway resolves it back to
+ * the option text from the `pendingAskUser` map at callback time.
+ */
+
+import { randomBytes } from 'crypto'
+
+/** Default TTL when caller doesn't pass timeout_ms. 5 min. */
+export const ASK_USER_DEFAULT_TIMEOUT_MS = 300_000
+
+/** Hard cap on TTL. 30 min. Beyond this the user has lost context;
+ *  the agent should re-ask in the next turn. */
+export const ASK_USER_MAX_TIMEOUT_MS = 1_800_000
+
+/** Floor on TTL. 5s. Below this the prompt is impossible to answer. */
+export const ASK_USER_MIN_TIMEOUT_MS = 5_000
+
+/** Telegram inline keyboards practically support 8 buttons stacked
+ *  vertically before the chat layout gets ugly. The agent should
+ *  collapse longer choice sets into category questions. */
+export const ASK_USER_MAX_OPTIONS = 8
+
+export interface AskUserArgs {
+  chat_id: string
+  question: string
+  options: string[]
+  message_thread_id?: string
+  timeout_ms?: number
+  reply_to?: string
+}
+
+export interface ValidatedAskUserArgs {
+  chatId: string
+  question: string
+  options: string[]
+  threadId?: number
+  timeoutMs: number
+  replyTo?: number
+}
+
+/**
+ * Validate raw arguments and return a normalised shape. Throws with
+ * a user-facing message on any violation. Pure — no I/O.
+ */
+export function validateAskUserArgs(args: AskUserArgs): ValidatedAskUserArgs {
+  if (typeof args.chat_id !== 'string' || args.chat_id.length === 0) {
+    throw new Error('ask_user: chat_id is required')
+  }
+  if (typeof args.question !== 'string' || args.question.trim().length === 0) {
+    throw new Error('ask_user: question is required')
+  }
+  // Telegram message body limit is 4096 chars; leave headroom for the
+  // reply markup wrapper. Question over 3500 should be a reply, not a
+  // forced-choice question.
+  if (args.question.length > 3500) {
+    throw new Error('ask_user: question too long (max 3500 chars). Send a reply for prose; ask_user is for short choices.')
+  }
+  if (!Array.isArray(args.options) || args.options.length < 2) {
+    throw new Error('ask_user: options must be an array with at least 2 entries')
+  }
+  if (args.options.length > ASK_USER_MAX_OPTIONS) {
+    throw new Error(`ask_user: too many options (max ${ASK_USER_MAX_OPTIONS})`)
+  }
+  for (let i = 0; i < args.options.length; i++) {
+    const opt = args.options[i]
+    if (typeof opt !== 'string' || opt.trim().length === 0) {
+      throw new Error(`ask_user: options[${i}] must be a non-empty string`)
+    }
+    // Telegram inline button text limit: 64 bytes (UTF-8). Reject early
+    // with a clear message instead of letting Telegram return a generic
+    // 400. Approximate via length — a long emoji-heavy label can fail
+    // earlier; catch that at send-time.
+    if (opt.length > 64) {
+      throw new Error(`ask_user: options[${i}] too long (max 64 chars). Use shorter button labels.`)
+    }
+  }
+  // Optional fields.
+  let threadId: number | undefined
+  if (args.message_thread_id != null) {
+    threadId = Number(args.message_thread_id)
+    if (!Number.isFinite(threadId) || threadId <= 0) {
+      throw new Error('ask_user: message_thread_id must be a positive integer string')
+    }
+  }
+  let replyTo: number | undefined
+  if (args.reply_to != null) {
+    replyTo = Number(args.reply_to)
+    if (!Number.isFinite(replyTo) || replyTo <= 0) {
+      throw new Error('ask_user: reply_to must be a positive integer string')
+    }
+  }
+  // Clamp timeout: floor to 5s, ceiling to 30min, default 5min.
+  let timeoutMs = args.timeout_ms ?? ASK_USER_DEFAULT_TIMEOUT_MS
+  if (typeof timeoutMs !== 'number' || !Number.isFinite(timeoutMs)) {
+    throw new Error('ask_user: timeout_ms must be a number')
+  }
+  if (timeoutMs < ASK_USER_MIN_TIMEOUT_MS) timeoutMs = ASK_USER_MIN_TIMEOUT_MS
+  if (timeoutMs > ASK_USER_MAX_TIMEOUT_MS) timeoutMs = ASK_USER_MAX_TIMEOUT_MS
+
+  return {
+    chatId: args.chat_id,
+    question: args.question,
+    options: args.options,
+    threadId,
+    timeoutMs,
+    replyTo,
+  }
+}
+
+/**
+ * Generate a callback-id token. 8 hex chars = 4 bytes random. Plenty
+ * of collision resistance for the small set of in-flight asks at any
+ * one time (typically 0-1 per chat); much smaller than a UUID, which
+ * would eat the 64-byte callback_data budget when concatenated with
+ * an option index.
+ */
+export function generateAskId(): string {
+  return randomBytes(4).toString('hex')
+}
+
+/**
+ * Encode a callback for option `idx` of a given ask. Asserts the
+ * encoded length stays within Telegram's 64-byte callback_data budget.
+ */
+export function encodeAskCallback(askId: string, idx: number): string {
+  if (!/^[0-9a-f]{8}$/.test(askId)) {
+    throw new Error(`ask_user: invalid askId shape (expected 8 hex chars, got ${askId})`)
+  }
+  if (!Number.isInteger(idx) || idx < 0 || idx >= ASK_USER_MAX_OPTIONS) {
+    throw new Error(`ask_user: invalid option index ${idx}`)
+  }
+  // Resulting shape: aq:<idx>:<askId> e.g. "aq:3:1a2b3c4d" — 14 bytes,
+  // safely under the 64-byte cap.
+  return `aq:${idx}:${askId}`
+}
+
+export interface DecodedAskCallback {
+  askId: string
+  idx: number
+}
+
+/**
+ * Parse a callback-data string. Returns null when the string is not
+ * an ask_user callback (caller should fall through to the next
+ * dispatch arm in that case — same convention as the existing
+ * permission and op: callbacks).
+ */
+export function decodeAskCallback(data: string): DecodedAskCallback | null {
+  const m = /^aq:(\d+):([0-9a-f]{8})$/.exec(data)
+  if (!m) return null
+  const idx = Number(m[1])
+  if (idx < 0 || idx >= ASK_USER_MAX_OPTIONS) return null
+  return { askId: m[2], idx }
+}
+
+/**
+ * Outcome union returned to the agent as the ask_user tool result.
+ * Keep this stable — agents will branch on `kind` in their prompts.
+ */
+export type AskUserOutcome =
+  | { kind: 'answered'; choice: string; idx: number }
+  | { kind: 'timeout' }
+  | { kind: 'cancelled'; reason: string }

--- a/telegram-plugin/bridge/bridge.ts
+++ b/telegram-plugin/bridge/bridge.ts
@@ -269,6 +269,27 @@ const TOOL_SCHEMAS = [
     },
   },
   {
+    name: 'ask_user',
+    description:
+      'Pose a multiple-choice question to the user via inline-keyboard buttons. Use when you need a deterministic choice (yes/no, option-A/B/C, severity levels) rather than free-form prose — the user taps one of the options and you receive their selection as the tool result. Returns { kind: "answered", choice: "<exact option text>" } on tap, { kind: "timeout" } if the user does not respond within timeout_ms (default 300_000ms / 5min, capped at 1_800_000ms / 30min). Do NOT use for "what would you like me to do next" generic prompts — that defeats the persistent-conversation model. Use for forced choices.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        chat_id: { type: 'string', description: 'Chat that should receive the question. Pass from inbound meta.' },
+        question: { type: 'string', description: 'The question text. Plain text or HTML. Keep it short — buttons render below.' },
+        options: {
+          type: 'array',
+          items: { type: 'string' },
+          description: 'Up to 8 button labels. Each label becomes one tappable button. Returned verbatim as `choice` on tap.',
+        },
+        message_thread_id: { type: 'string', description: 'Forum topic thread ID. Auto-applied from the last inbound message if not specified.' },
+        timeout_ms: { type: 'integer', description: 'Cancel the prompt and return { kind: "timeout" } after this long. Default 300000 (5min). Max 1800000 (30min).' },
+        reply_to: { type: 'string', description: 'Message ID to thread the question under. Default: the inbound message that triggered this turn.' },
+      },
+      required: ['chat_id', 'question', 'options'],
+    },
+  },
+  {
     name: 'update_checklist',
     description:
       'Patch an existing native Telegram checklist. Supports updating the title, adding new tasks, removing tasks, or marking tasks done/undone. Tasks with an id target existing items; tasks without an id are appended. Preserves existing task ids across edits.',

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -25,6 +25,14 @@ import { join, extname, sep, basename } from 'path'
 import { installPluginLogger } from '../plugin-logger.js'
 import { decideDmCommandGate } from '../dm-command-gate.js'
 import { redactAuthCodeMessage } from '../auth-code-redact.js'
+import {
+  validateAskUserArgs,
+  generateAskId,
+  encodeAskCallback,
+  decodeAskCallback,
+  type AskUserArgs,
+  type AskUserOutcome,
+} from '../ask-user.js'
 import { decideShouldPreAlloc, PRE_ALLOC_PLACEHOLDER_TEXT } from '../pre-alloc-decision.js'
 import { sendForumTopicPlaceholder, clearForumTopicPlaceholder } from '../forum-topic-placeholder.js'
 import { handleUpdatePlaceholder } from '../update-placeholder-handler.js'
@@ -1145,6 +1153,25 @@ const PERMISSION_REPLY_RE = /^\s*(y|yes|n|no)\s+([a-km-z]{5})\s*$/i
 const pendingPermissions = new Map<string, { tool_name: string; description: string; input_preview: string; startedAt: number }>()
 const PERMISSION_TTL_MS = 10 * 60_000
 
+// `ask_user` MCP tool — open prompts awaiting a user button-tap.
+// Keyed by askId (8 hex chars from generateAskId). Each entry holds
+// the deferred promise that resolves the originating tool call, the
+// option list (so the dispatcher can map the tapped index back to a
+// label), the chat we sent the prompt to (so timeout can edit the
+// message), the message_id of the question (so we can edit-in-place
+// on resolution / timeout), and the timer that fires the timeout.
+// Cleared on shutdown / chat-close (see clearAskUserPromptsForChat).
+interface PendingAskUser {
+  options: string[]
+  chatId: string
+  threadId?: number
+  messageId: number | null
+  resolve: (outcome: AskUserOutcome) => void
+  timer: ReturnType<typeof setTimeout>
+  startedAt: number
+}
+const pendingAskUser = new Map<string, PendingAskUser>()
+
 // Reauth flows
 const pendingReauthFlows = new Map<string, { agent: string; startedAt: number }>()
 const REAUTH_INTERCEPT_TTL_MS = 10 * 60_000
@@ -1893,6 +1920,7 @@ const ALLOWED_TOOLS = new Set([
   'edit_message', 'send_typing', 'pin_message', 'delete_message',
   'forward_message', 'get_recent_messages',
   'send_checklist', 'update_checklist',
+  'ask_user',
 ])
 
 async function executeToolCall(tool: string, args: Record<string, unknown>): Promise<unknown> {
@@ -1926,6 +1954,8 @@ async function executeToolCall(tool: string, args: Record<string, unknown>): Pro
       return executeSendChecklist(args)
     case 'update_checklist':
       return executeUpdateChecklist(args)
+    case 'ask_user':
+      return executeAskUser(args)
     default:
       throw new Error(`unknown tool: ${tool}`)
   }
@@ -2543,6 +2573,128 @@ async function executeProgressUpdate(args: Record<string, unknown>): Promise<unk
         text: JSON.stringify({ ok: true, message_id: sent.message_id }),
       },
     ],
+  }
+}
+
+/**
+ * `ask_user` MCP tool. Closes #574.
+ *
+ * The agent calls `ask_user({ chat_id, question, options[] })`; we
+ * post the question to Telegram with one inline-keyboard button per
+ * option, store the outstanding prompt in `pendingAskUser`, and
+ * return a Promise that resolves when the user taps a button (the
+ * callback dispatcher at the bottom of this file calls our resolve)
+ * or the TTL fires. Either way, the agent's `tool_call_result` is a
+ * structured `AskUserOutcome` it can branch on.
+ *
+ * Failure modes:
+ *   - assertAllowedChat throws → return error to agent, no message sent.
+ *   - sendMessage throws → reject the deferred immediately so the
+ *     agent doesn't sit forever; map to `{ kind: 'cancelled', reason }`.
+ *   - timeout → resolve `{ kind: 'timeout' }`, edit the message to
+ *     show "(no response)" so the user knows the prompt expired.
+ *   - gateway shutdown / chat-close → resolve `{ kind: 'cancelled' }`
+ *     for every outstanding ask in that chat (see
+ *     clearAskUserPromptsForChat below).
+ */
+async function executeAskUser(rawArgs: Record<string, unknown>): Promise<unknown> {
+  const args = validateAskUserArgs(rawArgs as unknown as AskUserArgs)
+  assertAllowedChat(args.chatId)
+
+  // Resolve thread + reply-to using the same auto-thread heuristic
+  // executeReply uses, so an agent that omits message_thread_id still
+  // routes into the right forum topic and quotes the user's last
+  // inbound message by default.
+  const threadId = resolveThreadId(args.chatId, args.threadId)
+  let replyTo: number | undefined = args.replyTo
+  if (replyTo == null && HISTORY_ENABLED) {
+    try {
+      const latest = getLatestInboundMessageId(args.chatId, threadId ?? null)
+      if (latest != null) replyTo = latest
+    } catch (err) {
+      process.stderr.write(`telegram gateway: ask_user quote lookup failed: ${(err as Error).message}\n`)
+    }
+  }
+
+  // Build inline keyboard — one button per option, stacked vertically
+  // so each label gets the full chat width on a phone. Telegram
+  // supports horizontal pairs, but vertical reads cleanly even on
+  // narrow screens.
+  const askId = generateAskId()
+  const keyboard = new InlineKeyboard()
+  for (let i = 0; i < args.options.length; i++) {
+    keyboard.text(args.options[i], encodeAskCallback(askId, i))
+    if (i < args.options.length - 1) keyboard.row()
+  }
+
+  // Send the question. We need the message_id back so we can edit-in-
+  // place on resolution / timeout — that's what makes the surface feel
+  // alive (button tap turns into "✅ <choice>" inline) rather than a
+  // graveyard of unanswered questions in the chat history.
+  const sendOpts: Record<string, unknown> = {
+    parse_mode: 'HTML',
+    reply_markup: keyboard,
+  }
+  if (threadId != null) sendOpts.message_thread_id = threadId
+  if (replyTo != null) sendOpts.reply_parameters = { message_id: replyTo }
+
+  let messageId: number | null = null
+  try {
+    const sent = await lockedBot.api.sendMessage(args.chatId, args.question, sendOpts)
+    messageId = sent.message_id
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err)
+    return { content: [{ type: 'text', text: JSON.stringify({ kind: 'cancelled', reason: `send-failed: ${msg}` }) }] }
+  }
+
+  // Open the deferred. The promise resolves either:
+  //   1. via the callback dispatcher (user tap), or
+  //   2. via the timeout below.
+  return new Promise<unknown>((resolveTool) => {
+    const timer = setTimeout(() => {
+      const entry = pendingAskUser.get(askId)
+      pendingAskUser.delete(askId)
+      if (!entry) return
+      // Edit the question to remove buttons + show timeout state.
+      // Best-effort: a failed edit doesn't change the outcome.
+      void lockedBot.api.editMessageText(
+        args.chatId,
+        entry.messageId!,
+        `${args.question}\n\n<i>⏱ no response within ${Math.round(args.timeoutMs / 1000)}s</i>`,
+        { parse_mode: 'HTML' },
+      ).catch((e: unknown) => {
+        process.stderr.write(`telegram gateway: ask_user timeout-edit failed askId=${askId}: ${(e as Error).message}\n`)
+      })
+      resolveTool({ content: [{ type: 'text', text: JSON.stringify({ kind: 'timeout' } satisfies AskUserOutcome) }] })
+    }, args.timeoutMs)
+
+    pendingAskUser.set(askId, {
+      options: args.options,
+      chatId: args.chatId,
+      threadId,
+      messageId,
+      startedAt: Date.now(),
+      timer,
+      resolve: (outcome: AskUserOutcome) => {
+        // Caller already deleted from map + cleared timer.
+        resolveTool({ content: [{ type: 'text', text: JSON.stringify(outcome) }] })
+      },
+    })
+  })
+}
+
+/**
+ * Cancel every outstanding ask_user in a given chat. Called when the
+ * gateway shuts down or when a turn ends without the question being
+ * answered (the next user message implicitly invalidates pending
+ * prompts — they'd otherwise leak across turns, which is confusing).
+ */
+function clearAskUserPromptsForChat(chatId: string, reason: string): void {
+  for (const [askId, entry] of pendingAskUser.entries()) {
+    if (entry.chatId !== chatId) continue
+    clearTimeout(entry.timer)
+    pendingAskUser.delete(askId)
+    entry.resolve({ kind: 'cancelled', reason })
   }
 }
 
@@ -7267,6 +7419,55 @@ bot.on('callback_query:data', async ctx => {
   // vg:cancel:<id> — dismiss
   if (data.startsWith('vg:')) {
     await handleVaultGrantCallback(ctx, data)
+    return
+  }
+
+  // ask_user callback (#574). aq:<idx>:<askId>. Same authorization
+  // gate as permission buttons — only allowFrom users can answer.
+  // Tapped option resolves the originating ask_user tool call's
+  // deferred promise; the agent receives { kind: 'answered',
+  // choice, idx } as the tool result and continues.
+  const askMatch = decodeAskCallback(data)
+  if (askMatch != null) {
+    const accessCheck = loadAccess()
+    const senderId = String(ctx.from.id)
+    if (!accessCheck.allowFrom.includes(senderId)) {
+      await ctx.answerCallbackQuery({ text: 'Not authorized.' }).catch(() => {})
+      return
+    }
+    const entry = pendingAskUser.get(askMatch.askId)
+    if (entry == null) {
+      // Stale tap — TTL fired, prompt was cancelled, or chat closed
+      // before the user got back to it. Acknowledge politely so the
+      // user doesn't see the spinner stick.
+      await ctx.answerCallbackQuery({ text: 'This question expired.' }).catch(() => {})
+      return
+    }
+    if (askMatch.idx >= entry.options.length) {
+      // Encoded an out-of-bounds index — should be impossible from
+      // our own encoding, but defend against a hostile callback.
+      await ctx.answerCallbackQuery({ text: 'Invalid option.' }).catch(() => {})
+      return
+    }
+    const choice = entry.options[askMatch.idx]
+    clearTimeout(entry.timer)
+    pendingAskUser.delete(askMatch.askId)
+    entry.resolve({ kind: 'answered', choice, idx: askMatch.idx })
+
+    // Edit the question in place to remove the buttons + show the
+    // chosen option as a checkmarked line. Makes the chat surface
+    // self-documenting — no orphaned-buttons graveyard.
+    const sourceMsg = ctx.callbackQuery.message
+    if (sourceMsg && 'text' in sourceMsg && sourceMsg.text != null) {
+      try {
+        await ctx.editMessageText(`${sourceMsg.text}\n\n✅ <b>${escapeHtmlForTg(choice)}</b>`, {
+          parse_mode: 'HTML',
+        })
+      } catch {
+        /* edit-failed is fine — the answer-callback below still acks */
+      }
+    }
+    await ctx.answerCallbackQuery({ text: '✅ ' + choice.slice(0, 60) }).catch(() => {})
     return
   }
 

--- a/telegram-plugin/tests/ask-user.test.ts
+++ b/telegram-plugin/tests/ask-user.test.ts
@@ -1,0 +1,203 @@
+/**
+ * Unit tests for the pure helpers behind the `ask_user` MCP tool (#574).
+ *
+ * Coverage targets:
+ *   - validateAskUserArgs: every error path + every clamp + every
+ *     valid edge case.
+ *   - encodeAskCallback / decodeAskCallback: round-trip, length budget,
+ *     malformed inputs, prefix non-match returns null (caller falls
+ *     through to next dispatcher arm).
+ *   - generateAskId: shape correct, low collision rate.
+ *
+ * The runtime side (executor + grammY + TTL timer + callback
+ * resolution) lives in gateway.ts and is exercised by the integration
+ * tests in real-gateway harness — these tests stay pure / fast.
+ */
+
+import { describe, it, expect } from 'bun:test'
+import {
+  validateAskUserArgs,
+  generateAskId,
+  encodeAskCallback,
+  decodeAskCallback,
+  ASK_USER_DEFAULT_TIMEOUT_MS,
+  ASK_USER_MAX_TIMEOUT_MS,
+  ASK_USER_MIN_TIMEOUT_MS,
+  ASK_USER_MAX_OPTIONS,
+} from '../ask-user.js'
+
+describe('validateAskUserArgs — required fields', () => {
+  it('accepts the minimal valid input (chat_id + question + 2 options)', () => {
+    const r = validateAskUserArgs({ chat_id: '123', question: 'OK?', options: ['Yes', 'No'] })
+    expect(r.chatId).toBe('123')
+    expect(r.question).toBe('OK?')
+    expect(r.options).toEqual(['Yes', 'No'])
+    expect(r.threadId).toBeUndefined()
+    expect(r.replyTo).toBeUndefined()
+    expect(r.timeoutMs).toBe(ASK_USER_DEFAULT_TIMEOUT_MS)
+  })
+
+  it('rejects empty chat_id', () => {
+    expect(() => validateAskUserArgs({ chat_id: '', question: 'q', options: ['a', 'b'] }))
+      .toThrow(/chat_id is required/)
+  })
+
+  it('rejects missing question', () => {
+    expect(() => validateAskUserArgs({ chat_id: '1', question: '   ', options: ['a', 'b'] }))
+      .toThrow(/question is required/)
+  })
+
+  it('rejects question over 3500 chars (forced-choice should be short)', () => {
+    expect(() => validateAskUserArgs({ chat_id: '1', question: 'x'.repeat(3501), options: ['a', 'b'] }))
+      .toThrow(/question too long/)
+  })
+})
+
+describe('validateAskUserArgs — options', () => {
+  it('rejects fewer than 2 options', () => {
+    expect(() => validateAskUserArgs({ chat_id: '1', question: 'q', options: ['only'] }))
+      .toThrow(/at least 2/)
+    expect(() => validateAskUserArgs({ chat_id: '1', question: 'q', options: [] }))
+      .toThrow(/at least 2/)
+  })
+
+  it(`accepts exactly ${ASK_USER_MAX_OPTIONS} options`, () => {
+    const opts = Array.from({ length: ASK_USER_MAX_OPTIONS }, (_, i) => `o${i}`)
+    const r = validateAskUserArgs({ chat_id: '1', question: 'q', options: opts })
+    expect(r.options).toEqual(opts)
+  })
+
+  it(`rejects more than ${ASK_USER_MAX_OPTIONS} options`, () => {
+    const opts = Array.from({ length: ASK_USER_MAX_OPTIONS + 1 }, (_, i) => `o${i}`)
+    expect(() => validateAskUserArgs({ chat_id: '1', question: 'q', options: opts }))
+      .toThrow(/too many options/)
+  })
+
+  it('rejects empty option string', () => {
+    expect(() => validateAskUserArgs({ chat_id: '1', question: 'q', options: ['Yes', ''] }))
+      .toThrow(/options\[1\] must be a non-empty string/)
+  })
+
+  it('rejects whitespace-only option', () => {
+    expect(() => validateAskUserArgs({ chat_id: '1', question: 'q', options: ['Yes', '   '] }))
+      .toThrow(/options\[1\] must be a non-empty string/)
+  })
+
+  it('rejects option label longer than 64 chars', () => {
+    expect(() => validateAskUserArgs({ chat_id: '1', question: 'q', options: ['Yes', 'x'.repeat(65)] }))
+      .toThrow(/options\[1\] too long/)
+  })
+})
+
+describe('validateAskUserArgs — optional fields', () => {
+  it('parses message_thread_id to integer', () => {
+    const r = validateAskUserArgs({ chat_id: '1', question: 'q', options: ['a', 'b'], message_thread_id: '42' })
+    expect(r.threadId).toBe(42)
+  })
+
+  it('rejects non-positive message_thread_id', () => {
+    expect(() => validateAskUserArgs({ chat_id: '1', question: 'q', options: ['a', 'b'], message_thread_id: '0' }))
+      .toThrow(/positive integer/)
+    expect(() => validateAskUserArgs({ chat_id: '1', question: 'q', options: ['a', 'b'], message_thread_id: '-5' }))
+      .toThrow(/positive integer/)
+  })
+
+  it('parses reply_to to integer', () => {
+    const r = validateAskUserArgs({ chat_id: '1', question: 'q', options: ['a', 'b'], reply_to: '99' })
+    expect(r.replyTo).toBe(99)
+  })
+})
+
+describe('validateAskUserArgs — timeout clamping', () => {
+  it('uses default when timeout_ms is omitted', () => {
+    const r = validateAskUserArgs({ chat_id: '1', question: 'q', options: ['a', 'b'] })
+    expect(r.timeoutMs).toBe(ASK_USER_DEFAULT_TIMEOUT_MS)
+  })
+
+  it('floors timeouts below the minimum', () => {
+    const r = validateAskUserArgs({ chat_id: '1', question: 'q', options: ['a', 'b'], timeout_ms: 100 })
+    expect(r.timeoutMs).toBe(ASK_USER_MIN_TIMEOUT_MS)
+  })
+
+  it('caps timeouts above the maximum', () => {
+    const r = validateAskUserArgs({ chat_id: '1', question: 'q', options: ['a', 'b'], timeout_ms: 99_999_999 })
+    expect(r.timeoutMs).toBe(ASK_USER_MAX_TIMEOUT_MS)
+  })
+
+  it('passes mid-range timeouts through unchanged', () => {
+    const r = validateAskUserArgs({ chat_id: '1', question: 'q', options: ['a', 'b'], timeout_ms: 60_000 })
+    expect(r.timeoutMs).toBe(60_000)
+  })
+
+  it('rejects non-numeric timeout_ms', () => {
+    expect(() => validateAskUserArgs({ chat_id: '1', question: 'q', options: ['a', 'b'], timeout_ms: NaN }))
+      .toThrow(/timeout_ms must be a number/)
+  })
+})
+
+describe('generateAskId', () => {
+  it('returns 8 lowercase hex chars', () => {
+    for (let i = 0; i < 50; i++) {
+      const id = generateAskId()
+      expect(id).toMatch(/^[0-9a-f]{8}$/)
+    }
+  })
+
+  it('produces distinct ids across many calls (no obvious bias)', () => {
+    const seen = new Set<string>()
+    for (let i = 0; i < 1000; i++) seen.add(generateAskId())
+    // 32 bits of entropy: collision in 1000 draws would be a real bug.
+    expect(seen.size).toBeGreaterThanOrEqual(999)
+  })
+})
+
+describe('encodeAskCallback / decodeAskCallback round-trip', () => {
+  it('round-trips for every valid index', () => {
+    const id = '1a2b3c4d'
+    for (let i = 0; i < ASK_USER_MAX_OPTIONS; i++) {
+      const data = encodeAskCallback(id, i)
+      const decoded = decodeAskCallback(data)
+      expect(decoded).toEqual({ askId: id, idx: i })
+    }
+  })
+
+  it('encoded callback stays under Telegram 64-byte budget', () => {
+    const id = generateAskId()
+    for (let i = 0; i < ASK_USER_MAX_OPTIONS; i++) {
+      const data = encodeAskCallback(id, i)
+      expect(Buffer.byteLength(data, 'utf-8')).toBeLessThanOrEqual(64)
+    }
+  })
+})
+
+describe('encodeAskCallback — input validation', () => {
+  it('rejects malformed askId', () => {
+    expect(() => encodeAskCallback('NOTHEX', 0)).toThrow(/invalid askId/)
+    expect(() => encodeAskCallback('1a2b3c4', 0)).toThrow(/invalid askId/)  // 7 chars
+    expect(() => encodeAskCallback('1a2b3c4d5', 0)).toThrow(/invalid askId/) // 9 chars
+    expect(() => encodeAskCallback('1A2B3C4D', 0)).toThrow(/invalid askId/) // uppercase
+  })
+
+  it('rejects out-of-range index', () => {
+    expect(() => encodeAskCallback('1a2b3c4d', -1)).toThrow(/invalid option index/)
+    expect(() => encodeAskCallback('1a2b3c4d', ASK_USER_MAX_OPTIONS)).toThrow(/invalid option index/)
+    expect(() => encodeAskCallback('1a2b3c4d', 1.5)).toThrow(/invalid option index/)
+  })
+})
+
+describe('decodeAskCallback — non-match falls through', () => {
+  it('returns null for non-aq prefixes (caller dispatches to next arm)', () => {
+    expect(decodeAskCallback('perm:allow:abcde')).toBeNull()
+    expect(decodeAskCallback('op:dismiss:agent')).toBeNull()
+    expect(decodeAskCallback('vd:unlock:key')).toBeNull()
+    expect(decodeAskCallback('')).toBeNull()
+  })
+
+  it('returns null for malformed aq: data', () => {
+    expect(decodeAskCallback('aq:0:short')).toBeNull()
+    expect(decodeAskCallback('aq:abc:1a2b3c4d')).toBeNull()  // non-numeric idx
+    expect(decodeAskCallback('aq::1a2b3c4d')).toBeNull()      // empty idx
+    expect(decodeAskCallback('aq:9:1a2b3c4d')).toBeNull()      // out of range (>=8)
+    expect(decodeAskCallback('aq:0:1a2b3c4d:extra')).toBeNull() // trailing junk
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -90,6 +90,9 @@ export default defineConfig({
       // update-placeholder-handler.test.ts uses bun:test — excluded here,
       // run via test:bun.
       "**/telegram-plugin/tests/update-placeholder-handler.test.ts",
+      // ask-user.test.ts uses bun:test (#574 ask_user MCP tool) —
+      // excluded here, run via test:bun.
+      "**/telegram-plugin/tests/ask-user.test.ts",
     ],
     coverage: {
       provider: "v8",


### PR DESCRIPTION
Closes #574. Part of #572 (Wave 1.2).

## Summary
New `ask_user` MCP tool that lets agents pose forced-choice clarifications via tappable buttons instead of free-form text. Returns `{ kind: 'answered', choice, idx } | { kind: 'timeout' } | { kind: 'cancelled', reason }` so the agent branches deterministically.

## Files
- `telegram-plugin/ask-user.ts` (new) — pure helpers (validation, callback encoding, ID generation)
- `telegram-plugin/gateway/gateway.ts` — runtime: pendingAskUser map, executeAskUser, callback dispatcher arm
- `telegram-plugin/bridge/bridge.ts` — TOOL_SCHEMAS entry
- `telegram-plugin/tests/ask-user.test.ts` (new) — 26 unit cases
- `vitest.config.ts` — exclude ask-user.test.ts (uses bun:test, runs via test:bun)

## Behavior
- 2-8 options, vertical button stack
- Default TTL 5min, max 30min, clamped at min 5s
- Edits the question in place on resolution (`✅ <choice>`) or timeout (`⏱ no response within Ns`)
- Same allowFrom authorization gate as permission buttons
- Stale-tap returns 'expired' to user, no agent-side leak

## JTBDs
- `know-what-my-agent-is-doing` — agent surfaces a clear forced choice instead of vague prose prompt
- `steer-or-queue-mid-flight` — user's tap is the unambiguous steer
- `talk-to-agents-from-anywhere` — one-tap on phone vs typing one of several options

## Principle checks
- **Docs** ✅ — tool schema + description self-documents the contract; outcome shape is explicit so agents don't need external refs
- **Defaults** ✅ — no config required; agent can use it from any persona
- **Consistency** ✅ — same MCP-tool dispatch shape as `reply`/`react`; same callback-prefix pattern (`aq:`) as existing `perm:`/`op:`/`vd:`/`vg:` arms

## Test plan
- [x] 26 unit cases pass (`bun test telegram-plugin/tests/ask-user.test.ts`)
- [x] `npm run lint` clean
- [x] No regression in plugin test suite (2938 pass, 0 fail)
- [ ] Manual: agent calls `ask_user` from a real session, user taps, agent receives the choice (deferred until Wave 1 ships and is deployed)