### PR TITLE
feat(test): waiting-UX v2 spec + harness extensions (#553 PR 1 of 5)

### DIFF
--- a/telegram-plugin/docs/waiting-ux-spec.md
+++ b/telegram-plugin/docs/waiting-ux-spec.md
@@ -1,141 +1,160 @@
-# Waiting-for-reply UX — deterministic time-sequence spec
+# Waiting-for-reply UX — v2 spec (three-class contract)
 
-Tracks: [#545](https://github.com/mekenthompson/switchroom/issues/545)
+Tracks: [#545](https://github.com/mekenthompson/switchroom/issues/545),
+[#553](https://github.com/mekenthompson/switchroom/issues/553) (PR series)
 
-This document codifies the user-perceived contract for what happens between
-"I sent a Telegram message" and "the agent's reply is locked in." The contract
-varies by **turn class**. Phase 1 of #545 lands an E2E harness
-(`tests/waiting-ux.e2e.test.ts`) that asserts these invariants in fake-timer
-deterministic time.
+This document codifies the user-perceived contract for what happens
+between "I sent a Telegram message" and "the agent's reply is locked
+in." The contract varies by **turn class**. The v2 rewrite (#553)
+sharpens the gates: tools alone never trigger the progress card,
+placeholder text is removed entirely, and sub-agents (= background
+workers) are the single concept for parallel work.
 
 ## Three turn classes
 
-### Class A — Instant reply (no tool calls, < ~2s of model time)
+### Class A — Instant (<2s, NO tools)
 
-| Surface              | Contract                                                                |
-| -------------------- | ----------------------------------------------------------------------- |
-| Status reaction      | 👀 lands within **800ms** of inbound. Terminates with 👍.               |
-| Progress card        | **Never rendered.** `initialDelayMs` (~30s) suppresses it entirely.     |
-| Draft answer         | Streams via `stream_reply` direct. No card scaffolding.                 |
-| Ladder               | 👀 → (optional 🤔 burst) → 👍. No tool reactions.                       |
+| Surface           | Contract                                                               |
+| ----------------- | ---------------------------------------------------------------------- |
+| Status reaction   | 👀 within 800ms of inbound. Terminates with 👍.                        |
+| Progress card     | **Never rendered.** Suppressed regardless of `initialDelayMs`.         |
+| Placeholder text  | **Never sent.** No `🔵 thinking` / `📚 recalling memories` / `💭 thinking`. |
+| Answer text       | First answer-text edit lands within **800ms** of inbound (TBD #553-PR-3). |
+| Ladder            | 👀 → 👍. Optional 🤔 if the controller debounce window is crossed.    |
 
-User experience: feels like a chat partner typing back.
+User experience: feels like a chat partner typing back instantly.
 
-### Class B — Short turn (1–3 tool calls, < ~15s)
+### Class B — Short (2–60s, tools, NO sub-agents)
 
-| Surface              | Contract                                                                |
-| -------------------- | ----------------------------------------------------------------------- |
-| Status reaction      | 👀 within 800ms. Ladder progresses through 🤔 / tool-glyphs (🔥/✍/👨‍💻/⚡) before 👍. **Must NOT collapse straight to 👍.** |
-| Progress card        | Optional. Renders if turn exceeds `initialDelayMs` threshold (configurable, default 30s) with live tool bullets. |
-| Pre-tool preamble    | Refreshes ≥1 time across step transitions (new tool category, or >Ns since last refresh). **Must NOT be a single static line for the entire turn.** |
-| Final                | 👍 + locked stream answer.                                              |
+| Surface           | Contract                                                               |
+| ----------------- | ---------------------------------------------------------------------- |
+| Status reaction   | 👀 within 800ms. Ladder progresses through 🤔 / tool-glyphs (🔥/✍/👨‍💻/⚡) before 👍. **Must NOT collapse straight to 👍.** |
+| Progress card     | **Never rendered.** The card gate is `(elapsed >= 60s) OR (sub-agent appeared)` — tools alone do NOT trigger it. |
+| Placeholder text  | **Never sent.**                                                        |
+| Answer text       | First answer-text edit lands within **<Ns** of inbound (TBD #553-PR-3). Streams progressively as the model produces tokens. |
+| Final             | 👍 + locked stream answer.                                             |
 
-### Class C — Long-running / multi-agent (sub-agents, background workers)
+User experience: live ladder of tool reactions, answer text starts
+streaming as soon as the model resumes, no fake "thinking" spacers.
 
-| Surface              | Contract                                                                |
-| -------------------- | ----------------------------------------------------------------------- |
-| Status reaction      | 👀 within 800ms. Settles to 👍 only after full quiescence (all sub-agents + workers terminal). |
-| Progress card        | Renders early — **before turn_end** — and stays stable. Each sub-agent + background worker has its own bullet. |
-| Card "Done" timestamp | Must be **≥ last sub-agent terminal timestamp**. Card does not mark Done while any worker is still in flight. |
-| Ladder               | Tool reactions throughout, settling to 👍 only after full quiescence.   |
+### Class C — Long-running (>60s OR sub-agents/background workers)
 
-## Failure modes the harness must catch
+| Surface           | Contract                                                               |
+| ----------------- | ---------------------------------------------------------------------- |
+| Status reaction   | 👀 within 800ms. Ladder throughout. Settles to 👍 only after full quiescence (all sub-agents terminal). |
+| Progress card     | Renders the moment the gate trips: `(elapsed >= 60s) OR (any sub-agent has appeared)`. Stays pinned-feel and stable. |
+| Card "Done" stamp | **≥ last sub-agent terminal timestamp.** Card never marks Done while a sub-agent is still in flight. |
+| Sub-agent header  | Header count == rendered-list-length. **No drift between summary and bullets.** |
+| Placeholder text  | **Never sent.**                                                        |
 
-These are the four observed regressions from the live demo on 2026-04-30:
+A "background worker" ≡ a sub-agent dispatched with
+`Agent({ run_in_background: true })`. There is no separate concept —
+the card gate, the bullet list, and the quiescence check all key on
+the sub-agent stream.
 
-| ID  | Symptom                                                                    | Class | Test                                            |
-| --- | -------------------------------------------------------------------------- | ----- | ----------------------------------------------- |
-| F1  | Ladder collapses straight to 👍 (skips 👀 → 🤔 → 🔥)                       | B     | `Class B — short turn > ladder integrity`       |
-| F2  | No instant draft / typing signal — chat sits silent "for ages"             | All   | `Class A > first-paint deadline`, `Class C > first-paint`         |
-| F3  | Progress card renders late (after turn_end, or never on long turns)        | C     | `Class C > progress card renders early`         |
-| F4  | Pre-tool interim text is static — one preamble then silence                | B     | `Class B > interim refresh`                     |
+## Key invariants (v2)
+
+1. **No placeholder strings** — `🔵 thinking`, `📚 recalling memories`,
+   and `💭 thinking` must never appear in any `sendMessage` /
+   `editMessageText` payload at any point in any turn class. PR 5
+   removes the production code that emits them.
+2. **Card gate** — `(elapsed >= 60s) OR (any sub-agent has appeared)`.
+   Tool-use count, tool category, and parent narrative content are
+   NOT inputs to the gate.
+3. **First-answer-text deadline** — Class A: <800ms. Class B/C: <Ns
+   (TBD by PR 3 once production measurement lands).
+4. **Sub-agent header == list length** — every render of the card.
+
+## PR 1 — foundation: spec + harness extensions (this PR)
+
+PR 1 ships:
+
+- This rewritten spec — supersedes the v1 four-failure-mode framing.
+- Three new helpers on `tests/real-gateway-harness.ts`:
+  - `expectNoPlaceholderEdits(chatId)` — returns recorded calls whose
+    payload matches a banned placeholder string. Tests assert
+    `toEqual([])`.
+  - `expectNoCardSent(chatId)` — wraps `progressCardSendMs` for
+    assertion-friendly use (`.toBeNull()`).
+  - `firstAnswerTextMs(chatId)` — first `sendMessage` /
+    `editMessageText` whose payload is neither a card payload nor a
+    placeholder string.
+- A new RED test file `tests/real-gateway-spec.test.ts` (all
+  `describe.skip`'d) pinning the three-class contract:
+  - Class A — 5 tests
+  - Class B — 4 tests
+  - Class C — 5 tests
+  Each carries a `// TODO(#553-PR-N)` marker for which subsequent PR
+  un-skips it.
+
+PR 1 does NOT change production code. The existing F1/F2/F3/F4
+regression tests stay green; the new spec tests are skipped, so they
+do not gate CI yet.
+
+## PR 2–5 — implementation roadmap
+
+| PR  | Scope                                                                | Un-skips                                            |
+| --- | -------------------------------------------------------------------- | --------------------------------------------------- |
+| 2   | Kill instant-draft placeholder; preserve early-ack 👀                | Class A no-placeholder, Class B no-placeholder      |
+| 3   | First-answer-text deadline implementation; tighten <Ns numbers       | Class A/B/C answer-text-deadline assertions         |
+| 4   | Card-gate rewrite to `(>=60s) OR (sub-agent appeared)`               | Class B no-card; Class C card-gate tests            |
+| 5   | Remove `🔵 thinking` / `📚 recalling memories` / `💭 thinking` strings; sub-agent header = list length | Remaining no-placeholder + sub-agent count tests    |
+
+## Failure-mode history (F1–F4, fixed in earlier #553 PRs)
+
+The v1 spec framed the rewrite around four observed regressions from
+the 2026-04-30 live demo. They are all fixed; the regression tests
+(`tests/real-gateway-f1-ladder-integrity.test.ts`,
+`real-gateway-f2-instant-draft.test.ts`, `real-gateway-f3-late-card.test.ts`,
+`real-gateway-f4-interim-text.test.ts`) stay in place to keep the gaps closed.
+
+| ID  | Symptom                                                                    | Class | Status                                            |
+| --- | -------------------------------------------------------------------------- | ----- | ------------------------------------------------- |
+| F1  | Ladder collapses straight to 👍 (skips 👀 → 🤔 → 🔥)                       | B     | Fixed — `StatusReactionController.finishWithState` flushes pending pre-terminal emoji. |
+| F2  | No instant draft / typing signal — chat sits silent "for ages"             | All   | Fixed — `handleInboundCoalesced` fires 👀 directly on raw arrival before the coalesce buffer. |
+| F3  | Progress card renders late (after turn_end, or never on long turns)        | C     | Fixed under v1 rules with a 5s time-promote in the driver; **superseded by PR 4**, which replaces the gate with `(>=60s) OR (sub-agent)`. |
+| F4  | Pre-tool preamble static — one preamble then silence                       | B     | Regression-guarded only; not reproducible deterministically. The v2 contract sidesteps F4 by tightening the first-answer-text deadline (Class B/C, PR 3). |
+
+The F1/F2/F3/F4 tests remain green throughout the v2 rewrite — they
+encode tighter invariants than the v2 spec relaxes. PR 4's gate
+change does not regress F3 (the F3 long-single-tool case crosses the
+60s threshold).
 
 ## Test methodology
 
-- **Time control**: `vi.useFakeTimers()` + `vi.setSystemTime` for deterministic
-  wall-clock assertions. The harness records every outbound `bot.api` call with
-  `Date.now()` at invocation, so first-paint and ladder deltas are
-  reproducibly measurable.
-- **Recorder**: a `Recorder` object exposes the helpers tests need
-  (`firstReactionMs`, `progressCardSendMs`, `reactionSequence`,
-  `lastReactionEmoji`, `edits`, `sentTexts`).
+- **Time control**: `vi.useFakeTimers()` + `vi.setSystemTime` for
+  deterministic wall-clock assertions. The harness records every
+  outbound `bot.api` call with `Date.now()` at invocation, so all
+  deadlines are reproducibly measurable.
+- **Recorder** (existing): `firstReactionMs`, `progressCardSendMs`,
+  `reactionSequence`, `lastReactionEmoji`, `edits`, `sentTexts`.
+- **Recorder** (PR 1 additions): `expectNoPlaceholderEdits`,
+  `expectNoCardSent`, `firstAnswerTextMs`.
 - **Production wiring**: the harness uses the actual
-  `StatusReactionController` and `createProgressDriver` from production —
-  not mocks. The bot.api layer below is a recording fake.
-- **Out of scope**: gateway message-coalescing, foreman queue, inbound update
-  handler, and IPC surfaces are not exercised by this harness. See
-  "Known limitation" below.
-
-## Known limitation (Phase 1)
-
-The harness drives `controller.*` and `driver.*` methods directly from a
-hand-written `feedSessionEvent` adapter that mirrors the relevant `case`
-branches in `gateway/gateway.ts`'s session-tail dispatcher. This means the
-harness asserts the contract is upheld **inside the controller + driver
-components** but does not catch failures introduced by:
-
-- Gateway-side message gating / queueing latency before the controller is constructed
-- Session-tail parser bugs (events dropped or mis-tagged before reaching dispatch)
-- IPC bridge dropouts that desynchronise the two halves of the system
-
-A Phase 2 harness that drives the real gateway through a synthetic update
-stream is filed as a follow-up. Until then, integration-boundary regressions
-remain CI-invisible.
-
-## Phase 3 — real-gateway harness (#553)
-
-The Phase 1 harness called `controller.setQueued()` synchronously inside
-its `inbound()` helper, which is why the F2 deadline passed trivially —
-not because the production code was correct, but because the harness
-was lying about the inbound flow.
-
-Phase 3 introduces `tests/real-gateway-harness.ts` which composes the
-production `InboundCoalescer` (extracted to `gateway/inbound-coalesce.ts`)
-*before* the Phase 1 controller + driver stack. This faithfully reproduces
-what every Telegram-only user sees: 👀 fires only after the coalesce
-window closes (default `gapMs=1500`), ~1500ms after their message landed
-— ~700ms over the F2 deadline.
-
-### F1, F2, F3 — fixed (commits in #553 PR series)
-
-- **F2** (no instant draft): `handleInboundCoalesced` now fires 👀
-  directly on raw arrival via `bot.api.setMessageReaction` for paired
-  DM users on a fresh turn, before the coalesce buffer. Telegram
-  dedupes the duplicate emit when the controller's later `setQueued()`
-  runs post-flush. `tests/real-gateway-f2-instant-draft.test.ts` pins
-  the 800ms deadline.
-- **F1** (ladder collapse): `StatusReactionController.finishWithState`
-  now flushes a debounced-but-not-yet-enqueued pending emoji before
-  the terminal emoji emits. Sub-debounce turns (default 700ms) no
-  longer collapse to 👀 → 👍.
-  `tests/real-gateway-f1-ladder-integrity.test.ts` pins the contract.
-- **F3** (late progress card): `progress-card-driver` now schedules a
-  one-shot `timePromoteTimer` on the first ingest event that
-  force-promotes the card after `promoteAfterMs` (default 5s) when no
-  other promotion path has fired. Long single-/two-tool turns no
-  longer wait the full 30s `initialDelayMs`.
-  `tests/real-gateway-f3-late-card.test.ts` pins the deadline.
-
-### F4 — regression guard, no reproducible failure mode (yet)
-
-The deterministic harness CAN'T currently reproduce F4 with well-spaced
-text → tool steps. Each text event passes `extractNarrativeLabel`
-(any non-empty single line is a label), gets a new narrative entry, and
-the renderer's `branch=narratives` path picks them up.
-`tests/real-gateway-f4-interim-text.test.ts` pins the well-spaced
-multi-step contract as a regression guard.
-
-Where F4 may still manifest in production (needs observation to
-narrow down before a tighter test can land):
-  - Rapid text bursts within `coalesceMs` (~400ms) — only the latest
-    narrative may survive the coalesce flush
-  - `edit_budget_threshold` throttling — subsequent edits dropped
-  - Specific text shapes that break `extractNarrativeLabel`
-    (multi-line prose with the "real" label not on line 1)
+  `StatusReactionController`, `createProgressDriver`, and
+  `createInboundCoalescer` from production — not mocks. The bot.api
+  layer below is a recording fake.
+- **Out of scope**: foreman queue, IPC bridge, auth, history. Those
+  do not influence the user-perceived waiting UX.
 
 ## CI gate
 
 The harness runs as part of the root vitest suite via `npm test` →
-`vitest run`. It picks up
-`telegram-plugin/tests/waiting-ux.e2e.test.ts` automatically — no separate
-config required.
+`vitest run`. PR 1's spec tests are `describe.skip`'d and do not
+fail CI; PRs 2–5 un-skip them as the production code lands.
+
+## Phase 1 / Phase 3 history (legacy)
+
+For posterity:
+
+- **Phase 1** (#547): `tests/waiting-ux.e2e.test.ts` — controller +
+  driver in isolation, hand-written `feedSessionEvent` adapter. F2
+  passed trivially because the harness called `setQueued()`
+  synchronously inside `inbound()`.
+- **Phase 3** (#553 PR 1, original): `tests/real-gateway-harness.ts`
+  composed the production `InboundCoalescer` before the Phase 1
+  controller stack, exposing the real F2 gap (👀 only fired after
+  the coalesce window). F2's fix landed against this harness.
+- **v2 rewrite** (this PR series, also numbered #553): same Phase 3
+  harness, plus three v2 helpers; new spec test file pins the
+  three-class contract.

--- a/telegram-plugin/tests/real-gateway-harness.ts
+++ b/telegram-plugin/tests/real-gateway-harness.ts
@@ -39,6 +39,7 @@ import {
   createWaitingUxHarness,
   type CreateHarnessOpts,
   type HarnessHandle,
+  type RecordedCall,
 } from './waiting-ux-harness.js'
 import type { SessionEvent } from '../session-tail.js'
 import {
@@ -46,6 +47,44 @@ import {
   inboundCoalesceKey,
   type InboundCoalescer,
 } from '../gateway/inbound-coalesce.js'
+
+/**
+ * Literal placeholder strings the v2 spec contract forbids. Listed
+ * centrally so the harness helpers and PR-5 removal sweep stay in
+ * sync. Must match the exact emoji + text used by production today —
+ * see `pre-alloc-decision.ts`, `placeholder-phase.ts`,
+ * `forum-topic-placeholder.ts`.
+ */
+export const PLACEHOLDER_STRINGS = [
+  '🔵 thinking',
+  '📚 recalling memories',
+  '💭 thinking',
+] as const
+
+function isPlaceholderPayload(payload: string | undefined): boolean {
+  if (payload == null) return false
+  for (const s of PLACEHOLDER_STRINGS) {
+    if (payload === s || payload === `${s}…` || payload.startsWith(`${s} `)) {
+      return true
+    }
+  }
+  return false
+}
+
+/**
+ * Mirror of the recorder's progress-card heuristic from
+ * `waiting-ux-harness.ts`. Kept in sync by hand — change both if the
+ * card text glyphs shift.
+ */
+function isCardPayload(text: string | undefined): boolean {
+  return (
+    text != null &&
+    (text.includes('Working') ||
+      text.includes('⚙') ||
+      text.includes('⏳') ||
+      text.includes('• '))
+  )
+}
 
 export interface RealGatewayHarnessOpts extends CreateHarnessOpts {
   /**
@@ -76,6 +115,46 @@ export interface RealGatewayHarnessHandle extends HarnessHandle {
    * that compute deadlines relative to the coalesce window.
    */
   gapMs: number
+
+  // ─── v2 spec helpers (PR 1 of #553 series) ──────────────────────────
+  // The waiting-UX v2 contract forbids placeholder-text edits ("🔵
+  // thinking", "📚 recalling memories", "💭 thinking"), suppresses the
+  // progress card for Class A/B turns, and pins a first-answer-text
+  // deadline. These three helpers expose those checks in a form that
+  // reads cleanly inside `expect(...)` assertions.
+
+  /**
+   * Returns recorded `sendMessage` and `editMessageText` calls for
+   * `chat_id` whose payload matches one of the literal placeholder
+   * strings the v2 spec bans. Class A and B tests assert
+   * `expect(h.recorder.expectNoPlaceholderEdits(CHAT)).toEqual([])`.
+   *
+   * NOTE: this name is a slight misnomer — it returns hits to
+   * inspect, not throws. A non-empty array IS the failure signal.
+   */
+  expectNoPlaceholderEdits(chatId: string): RecordedCall[]
+
+  /**
+   * Returns the timestamp of the first progress-card render for
+   * `chat_id`, or null if none. Thin wrapper around
+   * `recorder.progressCardSendMs` so spec tests can write
+   * `expect(h.recorder.expectNoCardSent(CHAT)).toBeNull()` for the
+   * Class A/B "no card" invariant without poking at the underlying
+   * recorder helper directly.
+   */
+  expectNoCardSent(chatId: string): number | null
+
+  /**
+   * Returns the timestamp of the first `sendMessage` or
+   * `editMessageText` for `chat_id` whose payload is plausibly
+   * answer text — i.e. NOT a progress-card payload (per
+   * `isCardPayload` heuristic) and NOT a placeholder string.
+   * Returns null if no such call has been recorded.
+   *
+   * Used to pin the v2 first-answer-text deadline (Class A: <800ms
+   * for 👀 and answer text bounded TBD by PR 3; Class B/C: TBD).
+   */
+  firstAnswerTextMs(chatId: string): number | null
 }
 
 const DEFAULT_GAP_MS = 1500
@@ -163,6 +242,30 @@ export function createRealGatewayHarness(
     inner.finalize()
   }
 
+  function expectNoPlaceholderEdits(chatId: string): RecordedCall[] {
+    return inner.recorder.calls.filter(
+      (c) =>
+        (c.kind === 'sendMessage' || c.kind === 'editMessageText') &&
+        c.chat_id === chatId &&
+        isPlaceholderPayload(c.payload),
+    )
+  }
+
+  function expectNoCardSent(chatId: string): number | null {
+    return inner.recorder.progressCardSendMs(chatId)
+  }
+
+  function firstAnswerTextMs(chatId: string): number | null {
+    const hit = inner.recorder.calls.find(
+      (c) =>
+        (c.kind === 'sendMessage' || c.kind === 'editMessageText') &&
+        c.chat_id === chatId &&
+        !isCardPayload(c.payload) &&
+        !isPlaceholderPayload(c.payload),
+    )
+    return hit ? hit.ts : null
+  }
+
   return {
     ...inner,
     inbound,
@@ -171,5 +274,8 @@ export function createRealGatewayHarness(
     coalescer,
     coalesceBufferSize: () => coalescer.size(),
     gapMs,
+    expectNoPlaceholderEdits,
+    expectNoCardSent,
+    firstAnswerTextMs,
   }
 }

--- a/telegram-plugin/tests/real-gateway-spec.test.ts
+++ b/telegram-plugin/tests/real-gateway-spec.test.ts
@@ -1,0 +1,390 @@
+/**
+ * Waiting-UX v2 spec — RED tests pinning the new three-class contract.
+ *
+ * This is PR 1 of the #553 series. All `describe` blocks here are
+ * `describe.skip`'d on purpose — these tests author the contract for
+ * the rewrite, but the production fixes that turn them green land in
+ * subsequent PRs (2 through 5). Each block carries a `// TODO(#553-PR-N)`
+ * marker for which PR un-skips it.
+ *
+ * Spec contract — three turn classes, gated on tools and elapsed time:
+ *
+ *   Class A — instant (<2s, NO tools):
+ *     👀 reaction → answer text. No placeholder. No progress card.
+ *
+ *   Class B — short (2–60s, tools, NO sub-agents):
+ *     👀 → ladder reactions (🤔, 🔥, etc.) → answer text streams.
+ *     No placeholder. No progress card.
+ *
+ *   Class C — long-running (>60s OR sub-agents/background workers):
+ *     👀 → ladder → progress card appears once
+ *     `(elapsed >= 60s) OR (any sub-agent has appeared)`. Card stays
+ *     pinned-feel until ALL work terminal.
+ *
+ * Key invariants:
+ *   - A "background worker" ≡ a sub-agent dispatched with
+ *     `Agent({ run_in_background: true })` — there is no separate concept.
+ *   - The card is gated on `(elapsed >= 60s) OR (any sub-agent appeared)`.
+ *     Tool-use alone NEVER triggers the card.
+ *   - The placeholder strings (`🔵 thinking`, `📚 recalling memories`,
+ *     `💭 thinking`) are removed entirely in PR 5 — none should appear
+ *     in any payload, ever.
+ *   - First-answer-text deadline: <800ms for Class A, TBD by PR 3 for
+ *     Class B/C.
+ *   - Sub-agent header count must equal rendered-list-length (no drift).
+ *
+ * RED-state intent: each `it(...)` is authored so that, when un-skipped
+ * against current main, it FAILS. That failure is the bug. PRs 2–5
+ * make the failure go away.
+ *
+ *   PR 2 — kill instant-draft placeholder + early 👀 path
+ *           → un-skips Class A and the ladder/no-placeholder bits of B
+ *   PR 3 — first-answer-text deadline (Class B/C TBD value)
+ *           → un-skips the answer-text-deadline assertions
+ *   PR 4 — card-gate rewrite: `(>=60s) OR (sub-agent appeared)`
+ *           → un-skips Class C card-gate tests + Class B "no card" test
+ *   PR 5 — remove placeholder strings entirely + sub-agent header
+ *           count = list length
+ *           → un-skips the "no placeholder" assertions repo-wide and
+ *           the sub-agent count = list length test
+ *
+ * Tracking: #553 (parent series), waiting-ux-spec.md (contract source).
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createRealGatewayHarness } from './real-gateway-harness.js'
+
+const CHAT = '8248703757'
+const INBOUND_MSG = 100
+
+// First-answer-text deadlines per spec. Class A is pinned at 1500ms
+// (covers the 800ms 👀 deadline + token-stream first chunk). Class
+// B/C are TBD by PR 3 — placeholder values picked here as the upper
+// bound the implementer should beat; tighten when the real numbers
+// land.
+const CLASS_A_ANSWER_TEXT_DEADLINE_MS = 1500
+const CLASS_BC_ANSWER_TEXT_DEADLINE_MS = 5_000 // TBD: PR 3
+
+beforeEach(() => { vi.useFakeTimers() })
+afterEach(() => { vi.useRealTimers() })
+
+// ─── Class A — instant (<2s, NO tools) ───────────────────────────────────
+//
+// TODO(#553-PR-2): un-skip after instant-draft placeholder removal +
+// early-ack 👀 lands. TODO(#553-PR-5): the no-placeholder assertion
+// only goes fully green once the placeholder strings are deleted from
+// the production code paths.
+describe.skip('v2 spec — Class A (instant, <2s, no tools)', () => {
+  it('emits NO placeholder text edits at any point', async () => {
+    const h = createRealGatewayHarness({ gapMs: 0 })
+    h.inbound({ chatId: CHAT, messageId: INBOUND_MSG, text: 'hi' })
+    h.feedSessionEvent({ kind: 'enqueue', chatId: CHAT, messageId: '1', threadId: null, rawContent: 'hi' })
+    await h.clock.advance(200)
+    h.feedSessionEvent({ kind: 'thinking' })
+    await h.clock.advance(300)
+    await h.streamReply({ chat_id: CHAT, text: 'hello back', done: true })
+    h.feedSessionEvent({ kind: 'turn_end', durationMs: 600 })
+    await h.clock.advance(500)
+
+    expect(h.expectNoPlaceholderEdits(CHAT)).toEqual([])
+    h.finalize()
+  })
+
+  it('emits NO progress card', async () => {
+    const h = createRealGatewayHarness({ gapMs: 0 })
+    h.inbound({ chatId: CHAT, messageId: INBOUND_MSG, text: 'hi' })
+    h.feedSessionEvent({ kind: 'enqueue', chatId: CHAT, messageId: '1', threadId: null, rawContent: 'hi' })
+    await h.clock.advance(200)
+    h.feedSessionEvent({ kind: 'thinking' })
+    await h.clock.advance(300)
+    await h.streamReply({ chat_id: CHAT, text: 'hello back', done: true })
+    h.feedSessionEvent({ kind: 'turn_end', durationMs: 600 })
+    await h.clock.advance(500)
+
+    expect(h.expectNoCardSent(CHAT)).toBeNull()
+    h.finalize()
+  })
+
+  it('👀 reaction lands within 800ms of inbound', async () => {
+    const h = createRealGatewayHarness({ gapMs: 1500 })
+    const inboundAt = h.clock.now()
+    h.inbound({ chatId: CHAT, messageId: INBOUND_MSG, text: 'hi' })
+    await h.clock.advance(800)
+
+    const firstReactionMs = h.recorder.firstReactionMs(CHAT)
+    expect(firstReactionMs).not.toBeNull()
+    expect((firstReactionMs ?? Infinity) - inboundAt).toBeLessThan(800)
+    h.finalize()
+  })
+
+  it(`first answer text lands within ${CLASS_A_ANSWER_TEXT_DEADLINE_MS}ms of inbound`, async () => {
+    const h = createRealGatewayHarness({ gapMs: 0 })
+    const inboundAt = h.clock.now()
+    h.inbound({ chatId: CHAT, messageId: INBOUND_MSG, text: 'hi' })
+    h.feedSessionEvent({ kind: 'enqueue', chatId: CHAT, messageId: '1', threadId: null, rawContent: 'hi' })
+    await h.clock.advance(200)
+    h.feedSessionEvent({ kind: 'thinking' })
+    await h.clock.advance(300)
+    await h.streamReply({ chat_id: CHAT, text: 'hello back', done: true })
+    await h.clock.advance(50)
+
+    const answerAt = h.firstAnswerTextMs(CHAT)
+    expect(answerAt, 'no answer text recorded').not.toBeNull()
+    expect((answerAt ?? Infinity) - inboundAt).toBeLessThan(CLASS_A_ANSWER_TEXT_DEADLINE_MS)
+    h.feedSessionEvent({ kind: 'turn_end', durationMs: 600 })
+    await h.clock.advance(500)
+    h.finalize()
+  })
+
+  it('emits NO `sendMessageDraft`-style placeholder draft sends', async () => {
+    // Currently the production "instant draft" flow can `sendMessage`
+    // a placeholder body that gets edited later. The v2 contract
+    // bans that — the first sendMessage to the user MUST be real
+    // answer text. We assert this by re-using the placeholder
+    // helper: any placeholder sendMessage is a draft send.
+    const h = createRealGatewayHarness({ gapMs: 0 })
+    h.inbound({ chatId: CHAT, messageId: INBOUND_MSG, text: 'hi' })
+    h.feedSessionEvent({ kind: 'enqueue', chatId: CHAT, messageId: '1', threadId: null, rawContent: 'hi' })
+    await h.clock.advance(200)
+    h.feedSessionEvent({ kind: 'thinking' })
+    await h.clock.advance(300)
+    await h.streamReply({ chat_id: CHAT, text: 'hello back', done: true })
+    h.feedSessionEvent({ kind: 'turn_end', durationMs: 600 })
+    await h.clock.advance(500)
+
+    const draftSends = h
+      .expectNoPlaceholderEdits(CHAT)
+      .filter((c) => c.kind === 'sendMessage')
+    expect(draftSends).toEqual([])
+    h.finalize()
+  })
+})
+
+// ─── Class B — short (2–60s, tools, no sub-agents) ───────────────────────
+//
+// TODO(#553-PR-2): un-skip the no-placeholder + answer-text bits.
+// TODO(#553-PR-4): un-skip "no progress card" once the card gate
+// changes from "elapsed > initialDelayMs OR tool-count threshold" to
+// "elapsed >= 60s OR sub-agent appeared".
+// TODO(#553-PR-5): ladder integrity is final-state RED only after PR 5
+// removes the placeholder fallback that currently masks the regression.
+describe.skip('v2 spec — Class B (short, 2–60s, tools, no sub-agents)', () => {
+  it('emits NO placeholder text edits', async () => {
+    const h = createRealGatewayHarness({ gapMs: 0 })
+    h.inbound({ chatId: CHAT, messageId: INBOUND_MSG, text: 'do a thing' })
+    h.feedSessionEvent({ kind: 'enqueue', chatId: CHAT, messageId: '1', threadId: null, rawContent: 'do a thing' })
+    await h.clock.advance(200)
+    h.feedSessionEvent({ kind: 'thinking' })
+    await h.clock.advance(300)
+    h.feedSessionEvent({ kind: 'tool_use', toolName: 'Bash', toolUseId: 't1' })
+    await h.clock.advance(3_000)
+    h.feedSessionEvent({ kind: 'tool_result', toolUseId: 't1', toolName: 'Bash' })
+    await h.streamReply({ chat_id: CHAT, text: 'all done', done: true })
+    h.feedSessionEvent({ kind: 'turn_end', durationMs: 4_000 })
+    await h.clock.advance(500)
+
+    expect(h.expectNoPlaceholderEdits(CHAT)).toEqual([])
+    h.finalize()
+  })
+
+  it('emits NO progress card (turn under 60s, no sub-agents)', async () => {
+    const h = createRealGatewayHarness({ gapMs: 0 })
+    h.inbound({ chatId: CHAT, messageId: INBOUND_MSG, text: 'short tool turn' })
+    h.feedSessionEvent({ kind: 'enqueue', chatId: CHAT, messageId: '1', threadId: null, rawContent: 'short tool turn' })
+    await h.clock.advance(200)
+    h.feedSessionEvent({ kind: 'thinking' })
+    await h.clock.advance(300)
+    // Two tools, total turn ~10s — well under 60s, no sub-agents.
+    h.feedSessionEvent({ kind: 'tool_use', toolName: 'Read', toolUseId: 't1' })
+    await h.clock.advance(3_000)
+    h.feedSessionEvent({ kind: 'tool_result', toolUseId: 't1', toolName: 'Read' })
+    h.feedSessionEvent({ kind: 'tool_use', toolName: 'Bash', toolUseId: 't2' })
+    await h.clock.advance(5_000)
+    h.feedSessionEvent({ kind: 'tool_result', toolUseId: 't2', toolName: 'Bash' })
+    await h.streamReply({ chat_id: CHAT, text: 'done', done: true })
+    h.feedSessionEvent({ kind: 'turn_end', durationMs: 9_000 })
+    await h.clock.advance(500)
+
+    expect(h.expectNoCardSent(CHAT)).toBeNull()
+    h.finalize()
+  })
+
+  it('ladder integrity: 👀 → at least one tool reaction → 👍 (no straight-to-👍 collapse)', async () => {
+    const h = createRealGatewayHarness({ gapMs: 0 })
+    h.inbound({ chatId: CHAT, messageId: INBOUND_MSG, text: 'ladder' })
+    h.feedSessionEvent({ kind: 'enqueue', chatId: CHAT, messageId: '1', threadId: null, rawContent: 'ladder' })
+    await h.clock.advance(200)
+    h.feedSessionEvent({ kind: 'thinking' })
+    await h.clock.advance(300)
+    h.feedSessionEvent({ kind: 'tool_use', toolName: 'Bash', toolUseId: 't1' })
+    await h.clock.advance(3_000)
+    h.feedSessionEvent({ kind: 'tool_result', toolUseId: 't1', toolName: 'Bash' })
+    await h.streamReply({ chat_id: CHAT, text: 'done', done: true })
+    h.feedSessionEvent({ kind: 'turn_end', durationMs: 4_000 })
+    await h.clock.advance(1_500)
+
+    const seq = h.recorder.reactionSequence()
+    // Dedupe consecutive duplicates (early-ack + setQueued both emit 👀).
+    const ladder: string[] = []
+    for (const e of seq) if (ladder[ladder.length - 1] !== e) ladder.push(e)
+    expect(ladder[0]).toBe('👀')
+    expect(ladder[ladder.length - 1]).toBe('👍')
+    expect(ladder.length).toBeGreaterThanOrEqual(3)
+    h.finalize()
+  })
+
+  it(`first answer text lands within ${CLASS_BC_ANSWER_TEXT_DEADLINE_MS}ms of inbound`, async () => {
+    const h = createRealGatewayHarness({ gapMs: 0 })
+    const inboundAt = h.clock.now()
+    h.inbound({ chatId: CHAT, messageId: INBOUND_MSG, text: 'short tool' })
+    h.feedSessionEvent({ kind: 'enqueue', chatId: CHAT, messageId: '1', threadId: null, rawContent: 'short tool' })
+    await h.clock.advance(200)
+    h.feedSessionEvent({ kind: 'thinking' })
+    await h.clock.advance(300)
+    h.feedSessionEvent({ kind: 'tool_use', toolName: 'Bash', toolUseId: 't1' })
+    await h.clock.advance(2_000)
+    h.feedSessionEvent({ kind: 'tool_result', toolUseId: 't1', toolName: 'Bash' })
+    // Answer text begins streaming as soon as the model resumes — pin
+    // the deadline to the spec value (TBD: PR 3 may tighten).
+    await h.streamReply({ chat_id: CHAT, text: 'partial...', done: false })
+    await h.clock.advance(50)
+
+    const answerAt = h.firstAnswerTextMs(CHAT)
+    expect(answerAt, 'no answer text recorded').not.toBeNull()
+    expect((answerAt ?? Infinity) - inboundAt).toBeLessThan(CLASS_BC_ANSWER_TEXT_DEADLINE_MS)
+
+    await h.streamReply({ chat_id: CHAT, text: 'partial... done', done: true })
+    h.feedSessionEvent({ kind: 'turn_end', durationMs: 3_000 })
+    await h.clock.advance(500)
+    h.finalize()
+  })
+})
+
+// ─── Class C — long-running (>60s OR sub-agents/background workers) ───────
+//
+// TODO(#553-PR-4): un-skip the card-gate tests once the gate is
+// `(elapsed >= 60s) OR (sub-agent appeared)`.
+// TODO(#553-PR-5): un-skip the no-placeholder + sub-agent count tests.
+describe.skip('v2 spec — Class C (long-running OR sub-agents)', () => {
+  it('progress card appears when a sub-agent dispatches (regardless of elapsed time)', async () => {
+    const h = createRealGatewayHarness({ gapMs: 0 })
+    h.inbound({ chatId: CHAT, messageId: INBOUND_MSG, text: 'spawn a worker' })
+    h.feedSessionEvent({ kind: 'enqueue', chatId: CHAT, messageId: '1', threadId: null, rawContent: 'spawn a worker' })
+    await h.clock.advance(200)
+    h.feedSessionEvent({ kind: 'thinking' })
+    await h.clock.advance(300)
+    // Sub-agent appears well under the 60s elapsed threshold — the
+    // card MUST still render because of the sub-agent gate.
+    h.feedSessionEvent({ kind: 'sub_agent_started', agentId: 'a1', firstPromptText: 'do work' })
+    await h.clock.advance(2_000)
+    h.feedSessionEvent({ kind: 'sub_agent_turn_end', agentId: 'a1' })
+    await h.clock.advance(500)
+
+    expect(h.expectNoCardSent(CHAT), 'card MUST render when a sub-agent dispatches').not.toBeNull()
+
+    await h.streamReply({ chat_id: CHAT, text: 'done', done: true })
+    h.feedSessionEvent({ kind: 'turn_end', durationMs: 3_000 })
+    await h.clock.advance(500)
+    h.finalize()
+  })
+
+  it('progress card appears when elapsed >= 60s even without a sub-agent', async () => {
+    const h = createRealGatewayHarness({ gapMs: 0 })
+    h.inbound({ chatId: CHAT, messageId: INBOUND_MSG, text: 'long single tool' })
+    h.feedSessionEvent({ kind: 'enqueue', chatId: CHAT, messageId: '1', threadId: null, rawContent: 'long single tool' })
+    await h.clock.advance(200)
+    h.feedSessionEvent({ kind: 'thinking' })
+    await h.clock.advance(300)
+    h.feedSessionEvent({ kind: 'tool_use', toolName: 'Bash', toolUseId: 't1' })
+    // Cross the 60s threshold.
+    await h.clock.advance(61_000)
+    h.feedSessionEvent({ kind: 'tool_result', toolUseId: 't1', toolName: 'Bash' })
+    await h.clock.advance(500)
+
+    expect(h.expectNoCardSent(CHAT), 'card MUST render after 60s elapsed').not.toBeNull()
+
+    await h.streamReply({ chat_id: CHAT, text: 'done', done: true })
+    h.feedSessionEvent({ kind: 'turn_end', durationMs: 62_000 })
+    await h.clock.advance(500)
+    h.finalize()
+  })
+
+  it('card stays pinned-feel: not marked Done while any sub-agent is in flight', async () => {
+    const h = createRealGatewayHarness({ gapMs: 0 })
+    h.inbound({ chatId: CHAT, messageId: INBOUND_MSG, text: 'fanout' })
+    h.feedSessionEvent({ kind: 'enqueue', chatId: CHAT, messageId: '1', threadId: null, rawContent: 'fanout' })
+    await h.clock.advance(200)
+    h.feedSessionEvent({ kind: 'thinking' })
+    await h.clock.advance(300)
+    h.feedSessionEvent({ kind: 'sub_agent_started', agentId: 'a1', firstPromptText: 'first' })
+    h.feedSessionEvent({ kind: 'sub_agent_started', agentId: 'a2', firstPromptText: 'second' })
+    await h.clock.advance(2_000)
+    h.feedSessionEvent({ kind: 'sub_agent_turn_end', agentId: 'a1' })
+    // a2 still in flight — the card must NOT show Done yet, even though
+    // the parent turn could complete.
+    await h.clock.advance(500)
+    const editsBeforeA2Done = h.recorder.edits(CHAT).map((e) => e.payload ?? '')
+    const sawPrematureDone = editsBeforeA2Done.some((p) => /done/i.test(p) && !/working/i.test(p))
+    expect(sawPrematureDone, 'card marked Done while a sub-agent was still running').toBe(false)
+
+    h.feedSessionEvent({ kind: 'sub_agent_turn_end', agentId: 'a2' })
+    await h.streamReply({ chat_id: CHAT, text: 'all done', done: true })
+    h.feedSessionEvent({ kind: 'turn_end', durationMs: 3_000 })
+    await h.clock.advance(500)
+    h.finalize()
+  })
+
+  it('emits NO placeholder text edits across the full turn', async () => {
+    const h = createRealGatewayHarness({ gapMs: 0 })
+    h.inbound({ chatId: CHAT, messageId: INBOUND_MSG, text: 'long with workers' })
+    h.feedSessionEvent({ kind: 'enqueue', chatId: CHAT, messageId: '1', threadId: null, rawContent: 'long with workers' })
+    await h.clock.advance(200)
+    h.feedSessionEvent({ kind: 'thinking' })
+    await h.clock.advance(300)
+    h.feedSessionEvent({ kind: 'sub_agent_started', agentId: 'a1', firstPromptText: 'work' })
+    await h.clock.advance(2_000)
+    h.feedSessionEvent({ kind: 'sub_agent_turn_end', agentId: 'a1' })
+    await h.streamReply({ chat_id: CHAT, text: 'done', done: true })
+    h.feedSessionEvent({ kind: 'turn_end', durationMs: 3_000 })
+    await h.clock.advance(500)
+
+    expect(h.expectNoPlaceholderEdits(CHAT)).toEqual([])
+    h.finalize()
+  })
+
+  it('sub-agent header count equals rendered-list-length (no drift)', async () => {
+    // The card header summarises "N workers"; the rendered bullet list
+    // should have exactly N entries. Pre-fix, the two diverge on rapid
+    // start/end events.
+    const h = createRealGatewayHarness({ gapMs: 0 })
+    h.inbound({ chatId: CHAT, messageId: INBOUND_MSG, text: 'spawn three' })
+    h.feedSessionEvent({ kind: 'enqueue', chatId: CHAT, messageId: '1', threadId: null, rawContent: 'spawn three' })
+    await h.clock.advance(200)
+    h.feedSessionEvent({ kind: 'thinking' })
+    await h.clock.advance(300)
+    h.feedSessionEvent({ kind: 'sub_agent_started', agentId: 'a1', firstPromptText: 'first' })
+    h.feedSessionEvent({ kind: 'sub_agent_started', agentId: 'a2', firstPromptText: 'second' })
+    h.feedSessionEvent({ kind: 'sub_agent_started', agentId: 'a3', firstPromptText: 'third' })
+    await h.clock.advance(2_000)
+
+    const cardEdits = h.recorder.calls.filter(
+      (c) => (c.kind === 'sendMessage' || c.kind === 'editMessageText') && c.chat_id === CHAT,
+    )
+    expect(cardEdits.length, 'no card render captured').toBeGreaterThan(0)
+    const last = cardEdits[cardEdits.length - 1].payload ?? ''
+    // Match a "N workers" / "N sub-agents" header and the bullet list.
+    const headerMatch = last.match(/(\d+)\s+(?:workers?|sub[- ]?agents?)/i)
+    expect(headerMatch, 'card payload missing worker-count header').not.toBeNull()
+    const headerCount = Number(headerMatch?.[1] ?? -1)
+    const bulletCount = (last.match(/^[•\-*]\s/gm) ?? []).length
+    expect(headerCount).toBe(bulletCount)
+
+    h.feedSessionEvent({ kind: 'sub_agent_turn_end', agentId: 'a1' })
+    h.feedSessionEvent({ kind: 'sub_agent_turn_end', agentId: 'a2' })
+    h.feedSessionEvent({ kind: 'sub_agent_turn_end', agentId: 'a3' })
+    await h.streamReply({ chat_id: CHAT, text: 'all done', done: true })
+    h.feedSessionEvent({ kind: 'turn_end', durationMs: 3_000 })
+    await h.clock.advance(500)
+    h.finalize()
+  })
+})


### PR DESCRIPTION
## Summary

Foundation PR for the waiting-UX v2 rewrite (#553 series, 5 PRs total).
**Zero production code changes** — this PR ships the new spec, three
new recorder helpers, and RED spec tests pinning the rewritten
three-class contract. PRs 2–5 turn the skipped tests green.

### New three-class contract

- **Class A (instant <2s, no tools):** 👀 → answer text. No
  placeholder. No progress card.
- **Class B (short 2–60s, tools, no sub-agents):** 👀 → ladder → answer
  text streams. No placeholder. No progress card.
- **Class C (>60s OR sub-agents):** 👀 → ladder → progress card
  appears. Card stays pinned-feel until full quiescence.

Key invariants:

- "Background worker" ≡ sub-agent dispatched with
  `Agent({ run_in_background: true })` — single concept.
- Card gate: `(elapsed >= 60s) OR (any sub-agent has appeared)` —
  tools alone never trigger the card.
- Placeholder strings (`🔵 thinking`, `📚 recalling memories`,
  `💭 thinking`) are removed entirely in PR 5.
- First-answer-text deadline: <800ms for Class A, <Ns TBD by PR 3 for
  Class B/C.
- Sub-agent header count must equal rendered-list-length (no drift).

### Files

- **`telegram-plugin/docs/waiting-ux-spec.md`** — rewritten around the
  three-class contract; F1/F2/F3/F4 history reframed under the new
  invariants.
- **`telegram-plugin/tests/real-gateway-harness.ts`** — three new
  helpers added (existing methods unchanged):
  - `expectNoPlaceholderEdits(chatId)` — returns recorded sends/edits
    whose payload is one of the banned placeholder strings.
  - `expectNoCardSent(chatId)` — assertion-friendly wrapper around
    `progressCardSendMs`.
  - `firstAnswerTextMs(chatId)` — first send/edit that is neither a
    card payload nor a placeholder.
- **`telegram-plugin/tests/real-gateway-spec.test.ts`** — 14 RED
  tests (`describe.skip`'d), each carrying a `// TODO(#553-PR-N)`
  marker:
  - Class A: 5 tests
  - Class B: 4 tests
  - Class C: 5 tests

### Roadmap — which PR un-skips what

| PR  | Scope                                                                | Un-skips                                            |
| --- | -------------------------------------------------------------------- | --------------------------------------------------- |
| 2   | Kill instant-draft placeholder; preserve early-ack 👀                | Class A no-placeholder, Class B no-placeholder      |
| 3   | First-answer-text deadline implementation; tighten <Ns numbers       | Class A/B/C answer-text-deadline assertions         |
| 4   | Card-gate rewrite to `(>=60s) OR (sub-agent appeared)`               | Class B no-card; Class C card-gate tests            |
| 5   | Remove `🔵 thinking` / `📚 recalling memories` / `💭 thinking`; sub-agent header = list length | Remaining no-placeholder + sub-agent count tests    |

## Test plan

- [x] `npm run lint` clean
- [x] `npx vitest run telegram-plugin/tests/real-gateway*.test.ts telegram-plugin/tests/waiting-ux*.test.ts` — 24 passed, 14 skipped (the new spec file)
- [x] `cd telegram-plugin && bun test` — 3058 pass, 15 skip, 0 fail
- [x] No production code changed (`git diff` only touches `telegram-plugin/docs/` and `telegram-plugin/tests/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)