### PR TITLE
feat(gateway): `!`-prefix interrupt marker

### DIFF
--- a/profiles/_shared/telegram-style.md.hbs
+++ b/profiles/_shared/telegram-style.md.hbs
@@ -63,6 +63,8 @@ The env vars are one-shot — start.sh deletes the file after sourcing. So this 
 
 If `SWITCHROOM_PENDING_TURN` is unset or empty, do nothing special — the previous turn ended cleanly.
 
+**`!` interrupt marker.** The gateway treats a Telegram message starting with `!` (single bang, not `!!` or `!!!`) as a deliberate interrupt: SIGINT to the active turn, strip the `!`, deliver the rest as a fresh turn. If the user sends `! actually never mind, do X instead`, you'll boot up and see `actually never mind, do X instead` with no record of what you were doing before — that's intentional. **If a user asks how to stop you mid-turn, tell them: "Start your message with `!` — it interrupts whatever I'm doing and treats the rest as a fresh request."** Doubled `!!` (typo / emphasis) reaches you verbatim. Empty `!` gets a "Send your replacement instruction now" reply from the gateway and never reaches you. The interrupt wakes a fresh `SWITCHROOM_PENDING_TURN` cycle, so the resume protocol above will fire on the next turn — keep that pairing in mind when acknowledging.
+
 **Wake audit — every fresh boot, check what you owe before responding.** When `start.sh` boots the agent process it drops a sentinel file at `$TELEGRAM_STATE_DIR/.wake-audit-pending`. On your first turn after a fresh boot, before answering whatever the user just sent, check three things and surface anything outstanding. After acting on the findings (or confirming none), `rm -f` the sentinel so subsequent turns in the same session don't re-audit. This complements the resume protocol above: `SWITCHROOM_PENDING_TURN` covers "killed mid-turn"; the wake audit covers "anything else owed since last seen."
 
 ```bash

--- a/reference/steer-or-queue-mid-flight.md
+++ b/reference/steer-or-queue-mid-flight.md
@@ -55,6 +55,13 @@ user thinking they steered when they actually queued, or vice versa.
 - Treating "I changed my mind" as "I have a new request" or vice versa,
   with no way for the user to correct the classification.
 
+## How switchroom answers this today
+
+- **Steer** = no marker. Send a follow-up while a turn is in flight; the inbound coalescer (default 1500ms gap) merges rapid-fire messages so the agent receives a single combined turn with both signals visible. Slower follow-ups arrive as fresh turns the agent sees in its next iteration.
+- **Interrupt + new task** = `!`-prefix marker (#575, gateway-side). A message starting with `!` SIGINTs the agent, strips the marker, and forwards the body as a fresh turn. Empty `!` triggers a "send your replacement instruction now" reply rather than forwarding nothing. The CLAUDE.md template tells the agent the rule so it can teach the user when asked.
+- **What the user sees**: ⚡ reaction on the `!` message confirms the interrupt landed. The agent's normal first-turn protocol then runs against the new body — so the chosen path is visible, not inferred.
+- **Still open** if it surfaces in practice: the JTBD's "queue cleanly behind, with isolated context" sense (file a new task that runs strictly AFTER the current one finishes) isn't a first-class operation today. Today's coalescer-as-queue means second-message effectively becomes amendment context. If a real "queue this for after" workflow shows up, file an issue against this JTBD.
+
 ## UAT prompts
 
 - **Mid-task correction.** Start a long task, send a follow-up that

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -33,6 +33,7 @@ import {
   type AskUserArgs,
   type AskUserOutcome,
 } from '../ask-user.js'
+import { parseInterruptMarker } from '../interrupt-marker.js'
 import { decideShouldPreAlloc, PRE_ALLOC_PLACEHOLDER_TEXT } from '../pre-alloc-decision.js'
 import { sendForumTopicPlaceholder, clearForumTopicPlaceholder } from '../forum-topic-placeholder.js'
 import { handleUpdatePlaceholder } from '../update-placeholder-handler.js'
@@ -3731,6 +3732,17 @@ async function handleInboundCoalesced(
   // legacy invariant that media never gets merged with sibling text.
   if (downloadImage || attachment) return handleInbound(ctx, text, downloadImage, attachment)
 
+  // `!`-prefix interrupt (#575) ALSO bypasses coalescing. If we let an
+  // interrupt sit in the coalesce window, an earlier non-`!` message
+  // arriving in the same window would prepend itself and the marker
+  // would no longer be at position 0 — handleInbound's parser would
+  // miss it and the user's interrupt would silently get merged into a
+  // normal turn. Bypass to handleInbound directly so the marker
+  // stays at the start of the text.
+  if (parseInterruptMarker(text).isInterrupt) {
+    return handleInbound(ctx, text, undefined, undefined)
+  }
+
   const from = ctx.from
   if (!from) return
 
@@ -3824,6 +3836,63 @@ async function handleInbound(
   const msgId = ctx.message?.message_id
 
   if (messageThreadId != null) chatThreadMap.set(chat_id, messageThreadId)
+
+  // `!`-prefix interrupt (#575). Closes
+  // `reference/steer-or-queue-mid-flight.md`'s correction path.
+  //
+  // Behavior:
+  //   1. SIGINT the agent service. This kills any in-flight turn —
+  //      same primitive that powers `switchroom agent interrupt`.
+  //      It's heavy, but the user explicitly asked for it; correctness
+  //      beats elegance here.
+  //   2. Strip the `!` and forward the body as a fresh turn so the
+  //      agent sees clean intent. If the body is empty (just `!`),
+  //      send a clarifying reply instead — forwarding empty text
+  //      would just yield a tool-result-of-nothing.
+  //   3. React with ⚡ on the `!` message so the user has a visible
+  //      ack that the interrupt landed (separate from the 👀 the
+  //      coalescer-bypass path skipped).
+  //
+  // Authorization: same allowFrom gate as any inbound message —
+  // unauthorized senders never reach this code (gate() above).
+  // Interrupt requires the same trust as sending a normal message.
+  const interrupt = parseInterruptMarker(text)
+  if (interrupt.isInterrupt) {
+    const agentName = process.env.SWITCHROOM_AGENT_NAME
+    process.stderr.write(
+      `telegram gateway: interrupt-marker received chat_id=${chat_id} agent=${agentName ?? '-'} ` +
+      `body_len=${interrupt.body.length} empty=${interrupt.emptyBody}\n`,
+    )
+    if (msgId != null) {
+      void bot.api.setMessageReaction(chat_id, msgId, [
+        { type: 'emoji', emoji: '⚡' as ReactionTypeEmoji['emoji'] },
+      ]).catch(() => {})
+    }
+    if (agentName) {
+      try {
+        const { interruptAgent } = await import('../../src/agents/lifecycle.js')
+        const { pid } = interruptAgent(agentName)
+        process.stderr.write(`telegram gateway: interrupt-marker SIGINT sent agent=${agentName} pid=${pid}\n`)
+      } catch (err) {
+        process.stderr.write(`telegram gateway: interrupt-marker SIGINT failed: ${(err as Error).message}\n`)
+      }
+    }
+    if (interrupt.emptyBody) {
+      try {
+        await bot.api.sendMessage(
+          chat_id,
+          '⚡ Interrupted. Send your replacement instruction now.',
+          messageThreadId != null ? { message_thread_id: messageThreadId } : {},
+        )
+      } catch {
+        /* swallow — the reaction already acked */
+      }
+      return
+    }
+    // Replace the inbound text with the body and continue normal
+    // processing. The agent receives a fresh turn with no `!` prefix.
+    text = interrupt.body
+  }
 
   // Issue #109: when the user has to ask "status?" mid-turn, the live progress
   // surface (pinned card + status reactions) has failed its job. Log the

--- a/telegram-plugin/interrupt-marker.ts
+++ b/telegram-plugin/interrupt-marker.ts
@@ -1,0 +1,66 @@
+/**
+ * `!`-prefix interrupt marker — closes #575 / part of `reference/steer-or-queue-mid-flight.md`.
+ *
+ * The product contract: when the user starts a Telegram message with
+ * `!`, they're saying "drop what you're doing and handle this
+ * instead." The gateway:
+ *   1. Bypasses the inbound coalescer so the `!` always lands at
+ *      the start of the parsed text (otherwise an earlier non-`!`
+ *      message inside the same coalesce window would prepend itself
+ *      and the marker would no longer be at position 0).
+ *   2. Sends SIGINT to the agent service so any in-flight turn dies.
+ *   3. Forwards the message with the `!` stripped as a fresh turn,
+ *      so the agent sees clean intent without the marker character
+ *      bleeding into its prompt.
+ *
+ * Pure helper — no side effects. Parses the marker; the gateway
+ * decides what to do with the verdict. Tested in
+ * `tests/interrupt-marker.test.ts` without grammY.
+ */
+
+export interface InterruptParseResult {
+  /** True iff the message is a deliberate interrupt request. */
+  isInterrupt: boolean
+  /** The text the agent should see, minus the marker + leading whitespace. */
+  body: string
+  /** True iff the body would be empty (just `!` with nothing useful after).
+   *  Caller may want to send a clarifying reply rather than forward an
+   *  empty turn to the agent. */
+  emptyBody: boolean
+}
+
+/**
+ * Parse an inbound text body for the `!` interrupt marker.
+ *
+ * Rules:
+ *   - Marker is `!` at position 0 of the trimmed body.
+ *   - Doubled `!!` is NOT an interrupt — common typo / emphasis. The
+ *     agent sees the literal `!!...` text. Single `!` is the rule.
+ *   - Markdown-bold `*!*` or any other escape is NOT an interrupt.
+ *     Strict literal match keeps the rule learnable.
+ *   - The marker is consumed; the body returned is everything after,
+ *     leading whitespace trimmed. So `! do this instead` → body `do
+ *     this instead`.
+ *
+ * Why not other prefixes (e.g. `/stop`, `STOP`, `interrupt`):
+ *   - `/`-prefixed strings are reserved for Telegram bot commands.
+ *   - Word prefixes collide with normal speech ("Stop, that's wrong").
+ *   - `!` is a single keystroke, hard to type by accident, easy to
+ *     teach. Same convention as e.g. linuz90/claude-telegram-bot.
+ */
+export function parseInterruptMarker(text: string): InterruptParseResult {
+  const trimmed = text.trimStart()
+  if (!trimmed.startsWith('!')) {
+    return { isInterrupt: false, body: text, emptyBody: false }
+  }
+  // Doubled `!!` is intentional emphasis or typo — not a marker.
+  if (trimmed.startsWith('!!')) {
+    return { isInterrupt: false, body: text, emptyBody: false }
+  }
+  const body = trimmed.slice(1).trimStart()
+  return {
+    isInterrupt: true,
+    body,
+    emptyBody: body.length === 0,
+  }
+}

--- a/telegram-plugin/tests/interrupt-marker.test.ts
+++ b/telegram-plugin/tests/interrupt-marker.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Unit tests for `parseInterruptMarker` — the `!`-prefix interrupt
+ * detector for the steer-or-queue-mid-flight JTBD (#575).
+ *
+ * The gateway-side wiring (bypass-coalesce, SIGINT, forward-stripped)
+ * is covered by integration tests; these focus on the pure parsing
+ * contract so the rule stays unambiguous.
+ */
+
+import { describe, it, expect } from 'bun:test'
+import { parseInterruptMarker } from '../interrupt-marker.js'
+
+describe('parseInterruptMarker — positive cases (interrupt fires)', () => {
+  it('fires on a leading `!` with body', () => {
+    const r = parseInterruptMarker('!stop and do this instead')
+    expect(r.isInterrupt).toBe(true)
+    expect(r.body).toBe('stop and do this instead')
+    expect(r.emptyBody).toBe(false)
+  })
+
+  it('fires on `! body` with space after the marker', () => {
+    const r = parseInterruptMarker('! drop everything')
+    expect(r.isInterrupt).toBe(true)
+    expect(r.body).toBe('drop everything')
+  })
+
+  it('fires on leading whitespace + `!`', () => {
+    const r = parseInterruptMarker('   ! cancel')
+    expect(r.isInterrupt).toBe(true)
+    expect(r.body).toBe('cancel')
+  })
+
+  it('strips ALL leading whitespace after the marker, not just one space', () => {
+    const r = parseInterruptMarker('!\n\n  newline-prefixed body')
+    expect(r.isInterrupt).toBe(true)
+    expect(r.body).toBe('newline-prefixed body')
+  })
+
+  it('flags emptyBody when only `!` is sent', () => {
+    const r = parseInterruptMarker('!')
+    expect(r.isInterrupt).toBe(true)
+    expect(r.body).toBe('')
+    expect(r.emptyBody).toBe(true)
+  })
+
+  it('flags emptyBody when `!` is followed by only whitespace', () => {
+    const r = parseInterruptMarker('!   \n  ')
+    expect(r.isInterrupt).toBe(true)
+    expect(r.body).toBe('')
+    expect(r.emptyBody).toBe(true)
+  })
+})
+
+describe('parseInterruptMarker — negative cases (no interrupt)', () => {
+  it('does NOT fire on doubled `!!` (typo / emphasis)', () => {
+    const r = parseInterruptMarker('!!emphasis on this')
+    expect(r.isInterrupt).toBe(false)
+    expect(r.body).toBe('!!emphasis on this')
+  })
+
+  it('does NOT fire on `!!!` or any longer run of bangs', () => {
+    expect(parseInterruptMarker('!!!hold on').isInterrupt).toBe(false)
+    expect(parseInterruptMarker('!!!!').isInterrupt).toBe(false)
+  })
+
+  it('does NOT fire when `!` is mid-string', () => {
+    const r = parseInterruptMarker('whoops! actually')
+    expect(r.isInterrupt).toBe(false)
+    expect(r.body).toBe('whoops! actually')
+  })
+
+  it('does NOT fire on markdown-style `*!*`', () => {
+    const r = parseInterruptMarker('*!* keep going')
+    expect(r.isInterrupt).toBe(false)
+  })
+
+  it('does NOT fire on `/` slash-commands (reserved for bot commands)', () => {
+    const r = parseInterruptMarker('/stop the agent')
+    expect(r.isInterrupt).toBe(false)
+  })
+
+  it('does NOT fire on uppercase STOP / cancel keywords', () => {
+    expect(parseInterruptMarker('STOP').isInterrupt).toBe(false)
+    expect(parseInterruptMarker('cancel that').isInterrupt).toBe(false)
+  })
+
+  it('does NOT fire on empty text', () => {
+    const r = parseInterruptMarker('')
+    expect(r.isInterrupt).toBe(false)
+    expect(r.body).toBe('')
+  })
+
+  it('does NOT fire on whitespace-only text', () => {
+    const r = parseInterruptMarker('   \n  \t  ')
+    expect(r.isInterrupt).toBe(false)
+  })
+
+  it('passes through normal prose unchanged', () => {
+    const original = 'Hi, can you check the calendar for next week?'
+    const r = parseInterruptMarker(original)
+    expect(r.isInterrupt).toBe(false)
+    expect(r.body).toBe(original)
+  })
+})
+
+describe('parseInterruptMarker — body preservation', () => {
+  it('preserves multi-line bodies after the marker', () => {
+    const r = parseInterruptMarker('!\nLine 1\nLine 2')
+    expect(r.isInterrupt).toBe(true)
+    expect(r.body).toBe('Line 1\nLine 2')
+  })
+
+  it('preserves embedded `!` inside the body', () => {
+    const r = parseInterruptMarker('! WAIT! actually do X')
+    expect(r.isInterrupt).toBe(true)
+    expect(r.body).toBe('WAIT! actually do X')
+  })
+
+  it('preserves trailing whitespace inside the body', () => {
+    // Caller may want to display verbatim; we don't trimEnd in the
+    // body — only the leading whitespace after the marker.
+    const r = parseInterruptMarker('!keep this   ')
+    expect(r.isInterrupt).toBe(true)
+    expect(r.body).toBe('keep this   ')
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -93,6 +93,9 @@ export default defineConfig({
       // ask-user.test.ts uses bun:test (#574 ask_user MCP tool) —
       // excluded here, run via test:bun.
       "**/telegram-plugin/tests/ask-user.test.ts",
+      // interrupt-marker.test.ts uses bun:test (#575 ! interrupt) —
+      // excluded here, run via test:bun.
+      "**/telegram-plugin/tests/interrupt-marker.test.ts",
     ],
     coverage: {
       provider: "v8",


### PR DESCRIPTION
Closes #575. Part of #572 (Wave 1.3). Closes the in-flight correction half of `reference/steer-or-queue-mid-flight.md`.

## Summary
`!` at the start of a Telegram message = interrupt the current turn. SIGINT to the agent, strip the bang, forward the body as a fresh turn. ⚡ reaction acks the interrupt.

## Files
- `telegram-plugin/interrupt-marker.ts` (new) — pure parser
- `telegram-plugin/gateway/gateway.ts` — bypass coalescer + interrupt action
- `telegram-plugin/tests/interrupt-marker.test.ts` (new) — 18 unit cases
- `profiles/_shared/telegram-style.md.hbs` — agent-facing doc + how to teach the user
- `reference/steer-or-queue-mid-flight.md` — JTBD updated with current answer
- `vitest.config.ts` — exclude bun:test file

## Edge cases
- `!!` and `!!!` reach the agent verbatim (typo/emphasis)
- Empty `!` gets a clarifying reply, doesn't forward empty
- Mid-string `whoops!` does NOT fire
- `/` and word prefixes (STOP, cancel) do NOT fire — `/` is reserved for bot commands; words collide with speech

## Test plan
- [x] `bun test telegram-plugin/tests/interrupt-marker.test.ts` — 18 pass
- [x] Full plugin suite — 2956 pass / 0 fail
- [x] `npm run lint` clean