### PR TITLE
feat(telegram): faster real-text path (#553 PR 3 of 5)

### DIFF
--- a/telegram-plugin/README.md
+++ b/telegram-plugin/README.md
@@ -133,7 +133,7 @@ Default chunk limit: 4000 characters (configurable via `textChunkLimit` in `acce
 
 ### Inbound message coalescing
 
-Rapid consecutive messages from the same user/chat are buffered and combined into a single delivery (joined with `\n`). The buffer flushes after `coalescingGapMs` milliseconds of silence (default: 1500ms).
+Rapid consecutive messages from the same user/chat are buffered and combined into a single delivery (joined with `\n`). The buffer flushes after `coalescingGapMs` milliseconds of silence (default: 500ms — lowered from 1500ms in #553 PR 3 to shrink the silent gap before the agent's first text lands).
 
 This prevents fragmented context when users send multi-line thoughts across several quick messages. Non-text messages (photos, documents, etc.) bypass coalescing.
 
@@ -169,7 +169,7 @@ Link previews are disabled by default in outbound messages. Control via:
   "textChunkLimit": 4000,
   "parseMode": "html",
   "disableLinkPreview": true,
-  "coalescingGapMs": 1500
+  "coalescingGapMs": 500
 }
 ```
 
@@ -178,7 +178,7 @@ Link previews are disabled by default in outbound messages. Control via:
 | `textChunkLimit` | number | 4000 | Max chars per outbound message before splitting |
 | `parseMode` | `"html"` \| `"markdownv2"` \| `"text"` | `"html"` | Default parse mode for outbound messages |
 | `disableLinkPreview` | boolean | `true` | Disable link preview thumbnails |
-| `coalescingGapMs` | number | 1500 | Debounce gap for inbound message coalescing (0 = disabled) |
+| `coalescingGapMs` | number | 500 | Debounce gap for inbound message coalescing (0 = disabled) |
 
 ### Read receipt indicator
 

--- a/telegram-plugin/answer-stream.ts
+++ b/telegram-plugin/answer-stream.ts
@@ -22,8 +22,10 @@ import {
  *   2. sendMessageDraft for DMs (detected by chatType='private'); regular
  *      sendMessage+editMessageText for groups/channels. Runtime fallback
  *      when draft API rejects (DRAFT_METHOD_UNAVAILABLE_RE / DRAFT_CHAT_UNSUPPORTED_RE).
- *   3. minInitialChars (~400) — don't open the answer lane until enough text
- *      has arrived. Short replies bypass the lane entirely.
+ *   3. minInitialChars (~50) — don't open the answer lane until enough text
+ *      has arrived. Lowered 400 → 50 in #553 PR 3 so short replies
+ *      ("yes", "done", "the answer is 42") become visible on the first
+ *      text event instead of waiting for `stream_reply` materialize.
  *   4. Turn-end materializes as a fresh sendMessage (push notification) NOT
  *      an edit-finalize — mirrors OpenClaw's materialize() pattern.
  *   5. Supersession protection — when a new turn starts while a prior
@@ -42,7 +44,7 @@ import {
  * existing callers that import from this module continue to work.
  */
 
-export const MIN_INITIAL_CHARS = 400
+export const MIN_INITIAL_CHARS = 50
 export const DEFAULT_THROTTLE_MS = 1000
 const TELEGRAM_MAX_CHARS = 4096
 

--- a/telegram-plugin/docs/waiting-ux-spec.md
+++ b/telegram-plugin/docs/waiting-ux-spec.md
@@ -19,7 +19,7 @@ workers) are the single concept for parallel work.
 | Status reaction   | 👀 within 800ms of inbound. Terminates with 👍.                        |
 | Progress card     | **Never rendered.** Suppressed regardless of `initialDelayMs`.         |
 | Placeholder text  | **Never sent.** No `🔵 thinking` / `📚 recalling memories` / `💭 thinking`. |
-| Answer text       | First answer-text edit lands within **800ms** of inbound (TBD #553-PR-3). |
+| Answer text       | First answer-text edit lands within **1500ms** of inbound (Class A budget; pinned in #553 PR 3). |
 | Ladder            | 👀 → 👍. Optional 🤔 if the controller debounce window is crossed.    |
 
 User experience: feels like a chat partner typing back instantly.
@@ -31,7 +31,7 @@ User experience: feels like a chat partner typing back instantly.
 | Status reaction   | 👀 within 800ms. Ladder progresses through 🤔 / tool-glyphs (🔥/✍/👨‍💻/⚡) before 👍. **Must NOT collapse straight to 👍.** |
 | Progress card     | **Never rendered.** The card gate is `(elapsed >= 60s) OR (sub-agent appeared)` — tools alone do NOT trigger it. |
 | Placeholder text  | **Never sent.**                                                        |
-| Answer text       | First answer-text edit lands within **<Ns** of inbound (TBD #553-PR-3). Streams progressively as the model produces tokens. |
+| Answer text       | First answer-text edit lands within **3000ms** of inbound (Class B/C budget; pinned in #553 PR 3). Streams progressively as the model produces tokens. |
 | Final             | 👍 + locked stream answer.                                             |
 
 User experience: live ladder of tool reactions, answer text starts
@@ -61,8 +61,10 @@ the sub-agent stream.
 2. **Card gate** — `(elapsed >= 60s) OR (any sub-agent has appeared)`.
    Tool-use count, tool category, and parent narrative content are
    NOT inputs to the gate.
-3. **First-answer-text deadline** — Class A: <800ms. Class B/C: <Ns
-   (TBD by PR 3 once production measurement lands).
+3. **First-answer-text deadline** — Class A: <1500ms. Class B/C:
+   <3000ms (committed in #553 PR 3). Budget: 500ms inbound coalesce +
+   ~1s minInitialChars-driven first send + ~1.5s model TTFT for short
+   replies.
 4. **Sub-agent header == list length** — every render of the card.
 
 ## PR 1 — foundation: spec + harness extensions (this PR)

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -1382,7 +1382,11 @@ type CoalescePayload = {
 const inboundCoalescer = createInboundCoalescer<CoalescePayload>({
   // Read per-call from the access file so `/access set-coalesce N` takes
   // effect on the next message without restarting the gateway.
-  gapMs: () => loadAccess().coalescingGapMs ?? 1500,
+  //
+  // Default lowered 1500 → 500 in #553 PR 3 to shrink the gateway-side
+  // contribution to first-real-text latency. Operators can still tune
+  // higher via `/access set-coalesce N` or the access file.
+  gapMs: () => loadAccess().coalescingGapMs ?? 500,
   merge: (entries) => {
     const last = entries[entries.length - 1]
     return {
@@ -3795,6 +3799,12 @@ function maybeEarlyAckReaction(ctx: Context, from: NonNullable<Context['from']>)
   void bot.api.setMessageReaction(chatId, msgId, [
     { type: 'emoji', emoji: '👀' as ReactionTypeEmoji['emoji'] },
   ]).catch(() => {})
+  // #553 PR 3: also fire the native "typing…" indicator. Bridges the
+  // visual gap between the early-ack 👀 reaction and the first real
+  // model text. No fake content — Telegram clients render this natively
+  // and it auto-expires after ~5s if not refreshed (the answer-lane
+  // first edit will land long before then under the new defaults).
+  void bot.api.sendChatAction(chatId, 'typing').catch(() => {})
 }
 
 async function handleInbound(

--- a/telegram-plugin/tests/real-gateway-spec.test.ts
+++ b/telegram-plugin/tests/real-gateway-spec.test.ts
@@ -59,14 +59,72 @@ const INBOUND_MSG = 100
 
 // First-answer-text deadlines per spec. Class A is pinned at 1500ms
 // (covers the 800ms 👀 deadline + token-stream first chunk). Class
-// B/C are TBD by PR 3 — placeholder values picked here as the upper
-// bound the implementer should beat; tighten when the real numbers
-// land.
+// B/C is pinned at 3000ms in #553 PR 3 — budget = 500ms inbound
+// coalesce + ~1s minInitialChars-driven first send + ~1.5s model
+// TTFT for short replies.
 const CLASS_A_ANSWER_TEXT_DEADLINE_MS = 1500
-const CLASS_BC_ANSWER_TEXT_DEADLINE_MS = 5_000 // TBD: PR 3
+const CLASS_BC_ANSWER_TEXT_DEADLINE_MS = 3_000
 
 beforeEach(() => { vi.useFakeTimers() })
 afterEach(() => { vi.useRealTimers() })
+
+// ─── PR 3 — first-answer-text deadlines (Class A & B) ─────────────────────
+//
+// These two tests are extracted from the Class A / Class B describe.skip
+// blocks below and un-skipped in #553 PR 3. The other tests in those
+// blocks (no-placeholder, no-card, ladder integrity) remain skipped
+// pending PRs 4 & 5. Once those land, the duplicates here can be
+// folded back into the parent describes.
+describe('v2 spec — PR 3: first-answer-text deadlines', () => {
+  it(`Class A — first answer text lands within ${CLASS_A_ANSWER_TEXT_DEADLINE_MS}ms of inbound`, async () => {
+    const h = createRealGatewayHarness({ gapMs: 0 })
+    const inboundAt = h.clock.now()
+    h.inbound({ chatId: CHAT, messageId: INBOUND_MSG, text: 'hi' })
+    h.feedSessionEvent({ kind: 'enqueue', chatId: CHAT, messageId: '1', threadId: null, rawContent: 'hi' })
+    await h.clock.advance(200)
+    h.feedSessionEvent({ kind: 'thinking' })
+    await h.clock.advance(300)
+    await h.streamReply({ chat_id: CHAT, text: 'hello back', done: true })
+    await h.clock.advance(50)
+
+    const answerAt = h.firstAnswerTextMs(CHAT)
+    expect(answerAt, 'no answer text recorded').not.toBeNull()
+    expect((answerAt ?? Infinity) - inboundAt).toBeLessThan(CLASS_A_ANSWER_TEXT_DEADLINE_MS)
+    h.feedSessionEvent({ kind: 'turn_end', durationMs: 600 })
+    await h.clock.advance(500)
+    h.finalize()
+  })
+
+  it(`Class B — first answer text lands within ${CLASS_BC_ANSWER_TEXT_DEADLINE_MS}ms of inbound`, async () => {
+    // Use the production default gapMs (500ms after PR 3) so the
+    // deadline reflects what real users see, not a coalesce-disabled
+    // best-case.
+    const h = createRealGatewayHarness({ gapMs: 500 })
+    const inboundAt = h.clock.now()
+    h.inbound({ chatId: CHAT, messageId: INBOUND_MSG, text: 'short tool' })
+    // Coalesce window flush.
+    await h.clock.advance(500)
+    h.feedSessionEvent({ kind: 'enqueue', chatId: CHAT, messageId: '1', threadId: null, rawContent: 'short tool' })
+    await h.clock.advance(200)
+    h.feedSessionEvent({ kind: 'thinking' })
+    await h.clock.advance(300)
+    h.feedSessionEvent({ kind: 'tool_use', toolName: 'Bash', toolUseId: 't1' })
+    await h.clock.advance(1_000)
+    h.feedSessionEvent({ kind: 'tool_result', toolUseId: 't1', toolName: 'Bash' })
+    // Answer text begins streaming as soon as the model resumes.
+    await h.streamReply({ chat_id: CHAT, text: 'partial...', done: false })
+    await h.clock.advance(50)
+
+    const answerAt = h.firstAnswerTextMs(CHAT)
+    expect(answerAt, 'no answer text recorded').not.toBeNull()
+    expect((answerAt ?? Infinity) - inboundAt).toBeLessThan(CLASS_BC_ANSWER_TEXT_DEADLINE_MS)
+
+    await h.streamReply({ chat_id: CHAT, text: 'partial... done', done: true })
+    h.feedSessionEvent({ kind: 'turn_end', durationMs: 3_000 })
+    await h.clock.advance(500)
+    h.finalize()
+  })
+})
 
 // ─── Class A — instant (<2s, NO tools) ───────────────────────────────────
 //


### PR DESCRIPTION
## Summary

PR 3 of the #553 five-PR series overhauling Switchroom's Telegram waiting-UX. Shrinks the gateway-side contributors to first-real-text latency so PRs 4 & 5 (raise card threshold to 60s, delete placeholder text) don't regress UX.

Spec contract: [`telegram-plugin/docs/waiting-ux-spec.md`](https://github.com/switchroom/switchroom/blob/main/telegram-plugin/docs/waiting-ux-spec.md)

## Production defaults — before / after

| Setting | Before | After | File |
| --- | --- | --- | --- |
| Inbound coalesce gap (`coalescingGapMs` fallback) | 1500ms | **500ms** | `telegram-plugin/gateway/gateway.ts` |
| Answer-lane `MIN_INITIAL_CHARS` | 400 | **50** | `telegram-plugin/answer-stream.ts` |
| Class B/C first-answer-text deadline (spec) | 5000ms (TBD) | **3000ms** (committed) | `telegram-plugin/docs/waiting-ux-spec.md` |
| Class A first-answer-text deadline (spec) | 800ms (TBD) | **1500ms** (committed) | `telegram-plugin/docs/waiting-ux-spec.md` |

Operators can still set `coalescingGapMs` explicitly via `/access set-coalesce N` or `access.json`. The 500ms default is a behaviour change for users who never set it — README updated.

### Class B/C deadline rationale

500ms inbound coalesce + ~1s minInitialChars-driven first send + ~1.5s model TTFT for short replies = **3000ms budget**. Pinned in both the spec doc and `tests/real-gateway-spec.test.ts`.

### Bonus: native typing indicator

`maybeEarlyAckReaction` now also fires `bot.api.sendChatAction(chatId, 'typing')` — same eligibility as the early-ack 👀 (paired DM users on a fresh turn). Real Telegram-native signal, no fake text, bridges the visual gap until the first answer-lane edit lands.

## Spec-test groups un-skipped

- **Class A first-answer-text deadline** — extracted into a new active `describe('v2 spec — PR 3: first-answer-text deadlines')` block in `tests/real-gateway-spec.test.ts`; parent `describe.skip('v2 spec — Class A …')` remains skipped pending PR 5.
- **Class B first-answer-text deadline** — same. Uses the production-default `gapMs: 500` so the test reflects what real users see, not a coalesce-disabled best-case.

Both tests pass with the new defaults. The Class C answer-text-deadline assertion doesn't exist in the file — Class C contracts are owned by PRs 4 & 5.

## Tests adjusted

None — existing tests pin `gapMs` and `minInitialChars` explicitly where they care, so the default change does not regress them. Verified:

- `npx vitest run telegram-plugin/tests/real-gateway-spec.test.ts telegram-plugin/tests/real-gateway-f2-instant-draft.test.ts telegram-plugin/tests/real-gateway-f4-interim-text.test.ts telegram-plugin/tests/answer-stream.test.ts telegram-plugin/tests/inbound-coalesce.test.ts` — 41 pass / 14 skipped.
- `cd telegram-plugin && bun test` — 3082 pass / 15 skipped / 0 fail.
- `npm run lint` — clean.
- `npm run test:vitest` — failures present on this branch are also present on `upstream/main` (pre-existing flakiness in `bridge-watchdog.test.ts` under parallel load; isolated runs all pass).

## Test plan

- [ ] CI green
- [ ] `npx vitest run telegram-plugin/tests/real-gateway-spec.test.ts` shows 2 PR-3 deadline tests passing
- [ ] `cd telegram-plugin && bun test` clean
- [ ] Manual smoke: send a short DM ("hi") to a paired bot — observe 👀 + typing indicator within ~1s, real reply within ~3s

🤖 Generated with [Claude Code](https://claude.com/claude-code)