### PR TITLE
feat(web): webhook ingest with HMAC + Bearer

### DIFF
--- a/docs/webhook-ingest.md
+++ b/docs/webhook-ingest.md
@@ -1,0 +1,72 @@
+# Webhook ingest (#577)
+
+External systems can push events into a specific agent's log. Verified events land in `~/.switchroom/agents/<agent>/telegram/webhook-events.jsonl` — the agent reads them on demand via Bash. (Auto-posting to Telegram + autonomous agent reactions are deferred to a follow-up.)
+
+## Setup — GitHub example
+
+1. **Allow the source per agent.** In `~/.switchroom/switchroom.yaml`:
+   ```yaml
+   agents:
+     finn:
+       webhook_sources: [ github ]
+   ```
+   Off by default. No allowlist = all webhook requests for that agent return 403.
+
+2. **Add the secret.** Edit `~/.switchroom/webhook-secrets.json` (mode 0600):
+   ```json
+   {
+     "finn": { "github": "<your-shared-secret>" }
+   }
+   ```
+   Use a long random string (`openssl rand -hex 32`). The same secret goes into GitHub's webhook config.
+
+3. **Configure GitHub.** Repo → Settings → Webhooks → Add webhook:
+   - Payload URL: `https://<your-host>/webhook/finn/github`
+   - Content type: `application/json`
+   - Secret: paste the same string from step 2.
+   - Events: pick what you want (push, pull_request, issues).
+
+4. **Verify.** Trigger an event. Tail the log:
+   ```sh
+   tail -f ~/.switchroom/agents/finn/telegram/webhook-events.jsonl
+   ```
+
+## Setup — generic Bearer token
+
+Use this for in-house tools that can't HMAC-sign:
+
+1. `webhook_sources: [ generic ]` in switchroom.yaml.
+2. Put the token in `webhook-secrets.json`: `{ "finn": { "generic": "<token>" } }`.
+3. Sender adds `Authorization: Bearer <token>` to its POST.
+
+The body must be JSON. Common fields (`title`, `message`, `text`) are auto-rendered into the stored Telegram-ready text; otherwise a JSON snippet is used.
+
+## What the agent sees
+
+Each verified event becomes one JSONL line at `<agent>/telegram/webhook-events.jsonl`:
+
+```json
+{
+  "ts": 1777699200000,
+  "source": "github",
+  "event_type": "pull_request",
+  "rendered_text": "🐙 <b>org/repo</b> PR #123 opened by @user\n…",
+  "payload": { "...full GitHub payload..." }
+}
+```
+
+Tell the agent (or have it know via CLAUDE.md) to `cat` or `tail` this file when checking for new events. The `rendered_text` field is mobile-friendly HTML safe to repost; `payload` carries the full structured record for follow-up actions.
+
+## Security
+
+- HMAC-SHA256 verification for `github` (constant-time compare).
+- Bearer token verification for `generic` (constant-time compare, length-pre-checked).
+- Source not in agent's allowlist → 403, no further processing.
+- Source unknown → 400.
+- Verification fails → 401 with a generic body, but the operator log line carries the specific reason for debugging.
+
+## Out of scope
+
+- Auto-posting to Telegram. Today the user has to ask the agent ("anything new from GitHub?"). Auto-post requires bot-token resolution + topic mapping; future PR.
+- Triggering a fresh agent turn from a webhook event. Requires gateway-IPC integration with a new "synthetic-user-message" envelope. Future PR.
+- Vault-backed secret storage. `webhook-secrets.json` works today; vault integration is a future hardening.

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -751,6 +751,20 @@ export const AgentSchema = z.object({
     .number()
     .optional()
     .describe("Telegram topic thread ID (auto-populated by switchroom topics sync)"),
+  webhook_sources: z
+    .array(z.enum(["github", "generic"]))
+    .optional()
+    .describe(
+      "External webhook sources allowed to ingest events into this agent's " +
+      "log. POST /webhook/<agent>/<source> on the switchroom web server. " +
+      "Each source has its own signature verification ('github' = " +
+      "X-Hub-Signature-256 HMAC-SHA256, 'generic' = Bearer token). " +
+      "Per-source secret read from ~/.switchroom/webhook-secrets.json " +
+      "keyed by [agent][source]. Verified events append to " +
+      "<agent>/telegram/webhook-events.jsonl for the agent to read on " +
+      "demand. Off by default — webhook is the only untrusted-inbound " +
+      "surface in the system, so opt-in is mandatory. See #577.",
+    ),
   soul: AgentSoulSchema,
   tools: AgentToolsSchema,
   memory: AgentMemorySchema,

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -22,6 +22,7 @@ import {
   handleGetTurns,
   handleGetSubagents,
 } from "./api.js";
+import { handleWebhookIngest } from "./webhook-handler.js";
 
 const MIME_TYPES: Record<string, string> = {
   ".html": "text/html",
@@ -207,6 +208,71 @@ function checkWsAuth(
   return presented !== null && constantTimeEqual(presented, token);
 }
 
+/**
+ * Webhook secrets file lives at ~/.switchroom/webhook-secrets.json.
+ * Shape:
+ *   {
+ *     "klanker": { "github": "<secret>", "generic": "<token>" },
+ *     "finn":    { "github": "<secret>" }
+ *   }
+ *
+ * One operator-managed file — no vault integration in this PR. Mode
+ * 0600 (read by switchroom user only). Future PR can swap for a
+ * vault-backed resolver if the operator burden becomes real.
+ */
+function loadWebhookSecrets(): Record<string, Record<string, string>> {
+  const path = join(homedir(), ".switchroom", "webhook-secrets.json");
+  if (!existsSync(path)) return {};
+  try {
+    const parsed = JSON.parse(readFileSync(path, "utf-8")) as Record<string, Record<string, string>>;
+    return parsed && typeof parsed === "object" ? parsed : {};
+  } catch (err) {
+    process.stderr.write(
+      `webhook-ingest: failed to parse ${path}: ${(err as Error).message} — webhooks will return 401 until fixed\n`,
+    );
+    return {};
+  }
+}
+
+async function handleWebhookRoute(
+  req: Request,
+  agent: string,
+  source: string,
+  config: SwitchroomConfig,
+): Promise<Response> {
+  const agentConfig = config.agents[agent];
+  const allowedSources = agentConfig?.webhook_sources ?? [];
+  const allSecrets = loadWebhookSecrets();
+  const agentSecrets = allSecrets[agent] ?? {};
+
+  let bodyBuf: Uint8Array;
+  try {
+    bodyBuf = new Uint8Array(await req.arrayBuffer());
+  } catch {
+    return new Response(JSON.stringify({ ok: false, error: "could not read body" }), {
+      status: 400,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  const result = await handleWebhookIngest(
+    {
+      agent,
+      source,
+      body: bodyBuf,
+      headers: req.headers,
+      allowedSources,
+      config: { secrets: agentSecrets as Partial<Record<"github" | "generic", string>> },
+      agentExists: agentConfig !== undefined,
+    },
+    {},
+  );
+  return new Response(result.body, {
+    status: result.status,
+    headers: { "Content-Type": result.contentType },
+  });
+}
+
 function parseRoute(
   pathname: string,
   method: string
@@ -276,6 +342,21 @@ export function startWebServer(
     fetch(req, server) {
       const url = new URL(req.url);
       const { pathname } = url;
+
+      // Webhook ingest (#577) sits BEFORE the origin gate + bearer-token
+      // gate because:
+      //   - The webhook brings its own auth (HMAC for github, Bearer for
+      //     generic) verified inside the handler.
+      //   - External services (GitHub, Sentry, custom) cannot send the
+      //     `Origin` header that isOriginAllowed expects, so the origin
+      //     gate would block them.
+      //   - The dashboard's web token has no business gating an external
+      //     webhook — wrong principle, wrong key.
+      // Path: POST /webhook/:agent/:source
+      const webhookMatch = pathname.match(/^\/webhook\/([^/]+)\/([^/]+)$/);
+      if (req.method === "POST" && webhookMatch) {
+        return handleWebhookRoute(req, webhookMatch[1], webhookMatch[2], config);
+      }
 
       // Cross-origin requests from any page the user happens to load in a
       // browser must not reach the privileged API. When bound to loopback,

--- a/src/web/webhook-handler.ts
+++ b/src/web/webhook-handler.ts
@@ -1,0 +1,198 @@
+/**
+ * Webhook ingest route handler (#577). Sits in `src/web/server.ts`'s
+ * fetch() before the bearer-token gate runs because webhooks bring
+ * their own auth (HMAC for github, Bearer for generic).
+ *
+ * Path shape: `POST /webhook/:agent/:source`
+ *   - `:agent` must match a known agent name in switchroom.yaml.
+ *   - `:source` must be in that agent's `webhook_sources` allowlist.
+ *
+ * Response shape (always JSON):
+ *   - 202 Accepted on verified + recorded.
+ *   - 400 if the path / body / config is malformed.
+ *   - 401 if the signature/token is invalid (no detail leaked).
+ *   - 403 if the agent doesn't allow this source.
+ *   - 404 if the agent name is unknown.
+ *
+ * MVP behavior (#577):
+ *   - Verify signature.
+ *   - Render to a structured Telegram-ready text via the renderers in
+ *     `webhook-verify.ts`.
+ *   - Append a JSON line to `~/.switchroom/agents/<agent>/telegram/webhook-events.jsonl`.
+ *   - Log the receipt to stderr for operator visibility.
+ *
+ * Out of scope (deferred to a follow-up):
+ *   - Posting the rendered text directly to the agent's Telegram
+ *     topic via the bot. Needs bot-token resolution from vault and
+ *     topic_id mapping from agent config; both adjacent surfaces
+ *     better tackled in their own PR.
+ *   - Triggering a fresh agent turn from the webhook. That requires
+ *     gateway IPC integration and a "synthetic-user-message"
+ *     envelope contract.
+ */
+
+import { appendFileSync, existsSync, mkdirSync, readFileSync } from 'fs'
+import { join } from 'path'
+import { homedir } from 'os'
+import {
+  verifyGithubSignature,
+  verifyBearerToken,
+  renderGithubEvent,
+  renderGenericEvent,
+  type WebhookSource,
+} from './webhook-verify.js'
+
+export interface WebhookConfig {
+  /** Per-source secrets, declared in vault under
+   *  `webhook/<agent>/<source>`. The verifier expects the secret as
+   *  the operator typed it (no per-key encoding). */
+  secrets: Partial<Record<WebhookSource, string>>
+}
+
+export interface WebhookHandlerDeps {
+  /** Path resolver — overridable for tests. Production: agent dir
+   *  under `~/.switchroom/agents/<agent>`. */
+  resolveAgentDir?: (agent: string) => string
+  /** Allow tests to inject a fixed clock for the recorded ts field. */
+  now?: () => number
+  /** Log sink — stderr in production. */
+  log?: (line: string) => void
+}
+
+export interface WebhookHandlerArgs {
+  agent: string
+  source: string
+  body: Uint8Array
+  headers: Headers
+  /** From switchroom.yaml: the agent's allowlist. Pass [] when no
+   *  agent config exists; route returns 404 in that case. */
+  allowedSources: readonly string[]
+  /** Operator-configured secrets. */
+  config: WebhookConfig
+  /** True iff `agent` is a known agent in switchroom.yaml. */
+  agentExists: boolean
+}
+
+export interface WebhookHandlerResult {
+  status: number
+  body: string
+  contentType: string
+}
+
+const KNOWN_SOURCES: WebhookSource[] = ['github', 'generic']
+
+function jsonReply(status: number, body: Record<string, unknown>): WebhookHandlerResult {
+  return {
+    status,
+    body: JSON.stringify(body),
+    contentType: 'application/json',
+  }
+}
+
+/**
+ * Pure-ish handler: takes everything it needs as args (no module
+ * globals), writes a JSONL line on success, returns the HTTP shape.
+ * Tested against a tmpdir-rooted resolveAgentDir.
+ */
+export async function handleWebhookIngest(
+  args: WebhookHandlerArgs,
+  deps: WebhookHandlerDeps = {},
+): Promise<WebhookHandlerResult> {
+  const log = deps.log ?? ((s) => process.stderr.write(s))
+  const now = (deps.now ?? Date.now)()
+  const resolveAgentDir =
+    deps.resolveAgentDir ?? ((a) => join(homedir(), '.switchroom', 'agents', a))
+
+  if (!args.agentExists) {
+    log(`webhook-ingest: agent='${args.agent}' source='${args.source}' rejected: unknown agent\n`)
+    return jsonReply(404, { ok: false, error: 'unknown agent' })
+  }
+
+  const sourceUntyped = args.source.toLowerCase()
+  if (!KNOWN_SOURCES.includes(sourceUntyped as WebhookSource)) {
+    log(`webhook-ingest: agent='${args.agent}' source='${args.source}' rejected: unknown source\n`)
+    return jsonReply(400, { ok: false, error: 'unknown source' })
+  }
+  const source = sourceUntyped as WebhookSource
+
+  if (!args.allowedSources.includes(source)) {
+    log(`webhook-ingest: agent='${args.agent}' source='${source}' rejected: source not in agent's webhook_sources allowlist\n`)
+    return jsonReply(403, { ok: false, error: 'source not allowed for this agent' })
+  }
+
+  const secret = args.config.secrets[source]
+  if (!secret) {
+    log(`webhook-ingest: agent='${args.agent}' source='${source}' rejected: no secret in vault under webhook/${args.agent}/${source}\n`)
+    return jsonReply(401, { ok: false, error: 'unauthorized' })
+  }
+
+  // Verify per source.
+  let verifyResult
+  if (source === 'github') {
+    const sigHeader = args.headers.get('x-hub-signature-256')
+    verifyResult = verifyGithubSignature(args.body, sigHeader, secret)
+  } else {
+    const authHeader = args.headers.get('authorization')
+    verifyResult = verifyBearerToken(authHeader, secret)
+  }
+  if (!verifyResult.ok) {
+    log(`webhook-ingest: agent='${args.agent}' source='${source}' rejected: ${verifyResult.reason}\n`)
+    return jsonReply(401, { ok: false, error: 'unauthorized' })
+  }
+
+  // Parse JSON body. We require JSON across both sources today; if a
+  // future source needs raw form bodies we'll branch here.
+  let payload: Record<string, unknown>
+  try {
+    payload = JSON.parse(new TextDecoder().decode(args.body)) as Record<string, unknown>
+  } catch {
+    log(`webhook-ingest: agent='${args.agent}' source='${source}' rejected: malformed JSON\n`)
+    return jsonReply(400, { ok: false, error: 'malformed json' })
+  }
+
+  // Render to a Telegram-ready string. Stored on the event record so
+  // the follow-up "post to Telegram" PR doesn't have to re-render.
+  const eventType = source === 'github'
+    ? (args.headers.get('x-github-event') ?? 'unknown')
+    : args.source
+  const rendered = source === 'github'
+    ? renderGithubEvent(eventType, payload)
+    : renderGenericEvent(args.source, payload)
+
+  // Write the verified event to the agent's webhook log.
+  const agentDir = resolveAgentDir(args.agent)
+  const telegramDir = join(agentDir, 'telegram')
+  const logPath = join(telegramDir, 'webhook-events.jsonl')
+  try {
+    mkdirSync(telegramDir, { recursive: true })
+    const record = {
+      ts: now,
+      source,
+      event_type: eventType,
+      rendered_text: rendered.text,
+      payload, // full verified payload — useful when the agent wants details
+    }
+    appendFileSync(logPath, JSON.stringify(record) + '\n', { mode: 0o600 })
+  } catch (err) {
+    log(`webhook-ingest: agent='${args.agent}' source='${source}' write failed: ${(err as Error).message}\n`)
+    return jsonReply(500, { ok: false, error: 'write failed' })
+  }
+
+  log(`webhook-ingest: agent='${args.agent}' source='${source}' event='${eventType}' recorded ts=${now}\n`)
+  return jsonReply(202, { ok: true, recorded: true, ts: now })
+}
+
+/**
+ * Read the agent's webhook event log. Used by tests; agents can also
+ * call this via Bash (`cat <path>`) as documented in CLAUDE.md.
+ */
+export function readWebhookLog(
+  agent: string,
+  resolveAgentDir?: (agent: string) => string,
+): Array<Record<string, unknown>> {
+  const dir = (resolveAgentDir ?? ((a) => join(homedir(), '.switchroom', 'agents', a)))(agent)
+  const logPath = join(dir, 'telegram', 'webhook-events.jsonl')
+  if (!existsSync(logPath)) return []
+  const lines = readFileSync(logPath, 'utf-8').split('\n').filter(Boolean)
+  return lines.map((l) => JSON.parse(l) as Record<string, unknown>)
+}

--- a/src/web/webhook-verify.ts
+++ b/src/web/webhook-verify.ts
@@ -1,0 +1,200 @@
+/**
+ * Webhook signature verifiers (#577).
+ *
+ * Closes the "always-on" half of the talk-to-agents-from-anywhere
+ * JTBD by letting external systems push events into a specific
+ * agent's topic. The catch: the webhook endpoint sits on the same
+ * web server as the dashboard, so signature verification is the only
+ * thing standing between the open internet and "post into Lisa's DM."
+ *
+ * This module owns the verification primitives — pure functions that
+ * take the request body + headers + the per-source secret and decide
+ * verified-or-not. The web server's route handler wires them in.
+ *
+ * Why two flavors:
+ *   - **github**: HMAC-SHA256 over the raw request body, signature
+ *     in `X-Hub-Signature-256`. Standard GitHub webhook shape; no
+ *     custom config required from the user. Works for GitLab too
+ *     with a different header name (deferred — file when needed).
+ *   - **generic**: Bearer token in the `Authorization` header.
+ *     Simple shared-secret model for in-house tools that can't do
+ *     HMAC. The token is per-source-per-agent, declared in the
+ *     vault under `webhook/<agent>/<source>`.
+ *
+ * Both verifiers are CONSTANT-TIME compares to defeat timing attacks.
+ * The Node `crypto.timingSafeEqual` requires equal-length buffers;
+ * we pad with zeros and check length separately so a length mismatch
+ * doesn't itself leak via early-return timing.
+ */
+
+import { createHmac, timingSafeEqual } from 'crypto'
+
+export type WebhookVerifyResult =
+  | { ok: true }
+  | { ok: false; reason: string }
+
+/**
+ * Verify a GitHub-style HMAC-SHA256 webhook signature.
+ *
+ * Header format: `sha256=<hex>` in `X-Hub-Signature-256`. The signed
+ * content is the raw request body bytes — caller must pass the body
+ * unmodified (no JSON.parse → re-stringify, which would change
+ * whitespace and break the signature).
+ *
+ * Returns `{ ok: false }` for any failure mode without leaking which
+ * (missing header, wrong format, wrong signature) — the route handler
+ * returns a plain 401 on top of that.
+ */
+export function verifyGithubSignature(
+  body: Uint8Array,
+  signatureHeader: string | null | undefined,
+  secret: string,
+): WebhookVerifyResult {
+  if (!secret || secret.length === 0) {
+    return { ok: false, reason: 'no-secret-configured' }
+  }
+  if (!signatureHeader) {
+    return { ok: false, reason: 'no-signature-header' }
+  }
+  if (!signatureHeader.startsWith('sha256=')) {
+    return { ok: false, reason: 'wrong-signature-format' }
+  }
+  const provided = signatureHeader.slice('sha256='.length)
+  if (!/^[0-9a-f]{64}$/.test(provided)) {
+    return { ok: false, reason: 'malformed-hex' }
+  }
+  const expected = createHmac('sha256', secret).update(body).digest('hex')
+  // Constant-time compare. Both buffers are 64-char hex (validated
+  // above) so they're always the same length here.
+  const a = Buffer.from(provided, 'utf-8')
+  const b = Buffer.from(expected, 'utf-8')
+  if (a.length !== b.length) return { ok: false, reason: 'length-mismatch' }
+  if (!timingSafeEqual(a, b)) return { ok: false, reason: 'signature-mismatch' }
+  return { ok: true }
+}
+
+/**
+ * Verify a Bearer token from the Authorization header.
+ *
+ * Header format: `Authorization: Bearer <token>`. Constant-time
+ * compare against the configured secret. Same reason-leak posture as
+ * GitHub verifier.
+ */
+export function verifyBearerToken(
+  authHeader: string | null | undefined,
+  secret: string,
+): WebhookVerifyResult {
+  if (!secret || secret.length === 0) {
+    return { ok: false, reason: 'no-secret-configured' }
+  }
+  if (!authHeader) {
+    return { ok: false, reason: 'no-auth-header' }
+  }
+  const m = /^Bearer\s+(.+)$/.exec(authHeader)
+  if (!m) return { ok: false, reason: 'wrong-auth-scheme' }
+  const provided = m[1]
+  if (provided.length !== secret.length) {
+    return { ok: false, reason: 'length-mismatch' }
+  }
+  const a = Buffer.from(provided, 'utf-8')
+  const b = Buffer.from(secret, 'utf-8')
+  if (!timingSafeEqual(a, b)) return { ok: false, reason: 'token-mismatch' }
+  return { ok: true }
+}
+
+/**
+ * Known webhook sources. Adding a source here requires a verifier
+ * choice (github | bearer) and a template for how the verified payload
+ * gets rendered into a Telegram message. Keep the set small and
+ * purpose-built rather than generic — generic catch-alls invite
+ * abuse-by-misuse.
+ */
+export type WebhookSource = 'github' | 'generic'
+
+export interface RenderedWebhookMessage {
+  text: string
+  /** When true, suppress link previews on the rendered message. GitHub
+   *  notifications often include a URL that telegram would otherwise
+   *  expand into a big preview card; we want a tight one-liner. */
+  disableLinkPreview: boolean
+}
+
+/**
+ * Render a verified GitHub webhook payload into a single-line
+ * Telegram message. Best-effort: unknown event types fall back to a
+ * generic shape so nothing arrives invisible.
+ *
+ * Pure — no fetch, no DB. Caller passes parsed JSON.
+ */
+export function renderGithubEvent(
+  eventType: string,
+  payload: Record<string, unknown>,
+): RenderedWebhookMessage {
+  const repo = (payload.repository as { full_name?: string } | undefined)?.full_name ?? '?'
+  const sender = (payload.sender as { login?: string } | undefined)?.login ?? '?'
+
+  switch (eventType) {
+    case 'pull_request': {
+      const action = String(payload.action ?? '')
+      const pr = (payload.pull_request as { number?: number; title?: string; html_url?: string } | undefined) ?? {}
+      const url = pr.html_url ?? ''
+      return {
+        text: `🐙 <b>${escapeHtml(repo)}</b> PR #${pr.number ?? '?'} ${escapeHtml(action)} by @${escapeHtml(sender)}\n${escapeHtml(pr.title ?? '')}${url ? `\n${url}` : ''}`,
+        disableLinkPreview: true,
+      }
+    }
+    case 'issues': {
+      const action = String(payload.action ?? '')
+      const issue = (payload.issue as { number?: number; title?: string; html_url?: string } | undefined) ?? {}
+      const url = issue.html_url ?? ''
+      return {
+        text: `🐙 <b>${escapeHtml(repo)}</b> issue #${issue.number ?? '?'} ${escapeHtml(action)} by @${escapeHtml(sender)}\n${escapeHtml(issue.title ?? '')}${url ? `\n${url}` : ''}`,
+        disableLinkPreview: true,
+      }
+    }
+    case 'push': {
+      const ref = String(payload.ref ?? '').replace(/^refs\/heads\//, '')
+      const commits = Array.isArray(payload.commits) ? payload.commits.length : 0
+      const compare = String(payload.compare ?? '')
+      return {
+        text: `🐙 <b>${escapeHtml(repo)}</b> push to <code>${escapeHtml(ref)}</code> by @${escapeHtml(sender)} — ${commits} commit(s)${compare ? `\n${compare}` : ''}`,
+        disableLinkPreview: true,
+      }
+    }
+    case 'ping':
+      return { text: `🐙 <b>${escapeHtml(repo)}</b> webhook ping from @${escapeHtml(sender)}`, disableLinkPreview: true }
+    default:
+      return {
+        text: `🐙 <b>${escapeHtml(repo)}</b> ${escapeHtml(eventType)} by @${escapeHtml(sender)}`,
+        disableLinkPreview: true,
+      }
+  }
+}
+
+/**
+ * Render a verified generic webhook payload. The shape is unknown by
+ * definition — we look for common fields (`title`, `text`, `message`)
+ * and fall back to a JSON snippet. Source name is the operator's
+ * choice so it can carry meaning ("sentry-prod", "ops-pager").
+ */
+export function renderGenericEvent(
+  source: string,
+  payload: Record<string, unknown>,
+): RenderedWebhookMessage {
+  const title = typeof payload.title === 'string' ? payload.title
+    : typeof payload.message === 'string' ? payload.message
+    : typeof payload.text === 'string' ? payload.text
+    : null
+  const summary = title ?? JSON.stringify(payload).slice(0, 200)
+  return {
+    text: `📨 <b>${escapeHtml(source)}</b>\n${escapeHtml(summary)}`,
+    disableLinkPreview: true,
+  }
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+}

--- a/tests/webhook-handler.test.ts
+++ b/tests/webhook-handler.test.ts
@@ -1,0 +1,246 @@
+/**
+ * Integration tests for `handleWebhookIngest` (#577).
+ *
+ * Drives the full request → verify → write-jsonl pipeline against a
+ * tmpdir-rooted fake `resolveAgentDir`. Covers every documented HTTP
+ * status code and the recorded-event shape.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, rmSync, existsSync, readFileSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { createHmac } from 'crypto'
+import {
+  handleWebhookIngest,
+  readWebhookLog,
+  type WebhookHandlerArgs,
+} from '../src/web/webhook-handler.js'
+
+const SECRET = 'shared-secret-very-long-enough'
+
+let agentsRoot: string
+
+beforeEach(() => {
+  agentsRoot = mkdtempSync(join(tmpdir(), 'webhook-handler-'))
+})
+afterEach(() => {
+  rmSync(agentsRoot, { recursive: true, force: true })
+})
+
+function resolveAgentDir(agent: string): string {
+  return join(agentsRoot, agent)
+}
+
+function makeArgs(overrides: Partial<WebhookHandlerArgs>): WebhookHandlerArgs {
+  return {
+    agent: 'klanker',
+    source: 'github',
+    body: new TextEncoder().encode('{"action":"opened","repository":{"full_name":"x/y"},"sender":{"login":"k"},"pull_request":{"number":1,"title":"t","html_url":"https://x"}}'),
+    headers: new Headers(),
+    allowedSources: ['github'],
+    config: { secrets: { github: SECRET } },
+    agentExists: true,
+    ...overrides,
+  }
+}
+
+function githubSig(body: Uint8Array, secret: string): string {
+  return 'sha256=' + createHmac('sha256', secret).update(body).digest('hex')
+}
+
+describe('handleWebhookIngest — happy path', () => {
+  it('verifies + records a github pull_request event', async () => {
+    const args = makeArgs({})
+    args.headers.set('x-hub-signature-256', githubSig(args.body, SECRET))
+    args.headers.set('x-github-event', 'pull_request')
+
+    const r = await handleWebhookIngest(args, { resolveAgentDir, log: () => {} })
+    expect(r.status).toBe(202)
+    expect(JSON.parse(r.body)).toMatchObject({ ok: true, recorded: true })
+
+    const events = readWebhookLog('klanker', resolveAgentDir)
+    expect(events).toHaveLength(1)
+    expect(events[0]).toMatchObject({ source: 'github', event_type: 'pull_request' })
+    expect(events[0].rendered_text).toContain('PR #1 opened')
+    expect(events[0].payload).toMatchObject({ action: 'opened' })
+  })
+
+  it('verifies + records a generic source event with Bearer auth', async () => {
+    const args = makeArgs({
+      source: 'generic',
+      body: new TextEncoder().encode('{"title":"Error spike","details":"500s on /api"}'),
+      allowedSources: ['generic'],
+      config: { secrets: { generic: SECRET } },
+    })
+    args.headers.set('authorization', `Bearer ${SECRET}`)
+
+    const r = await handleWebhookIngest(args, { resolveAgentDir, log: () => {} })
+    expect(r.status).toBe(202)
+    const events = readWebhookLog('klanker', resolveAgentDir)
+    expect(events).toHaveLength(1)
+    expect(events[0].rendered_text).toContain('Error spike')
+  })
+
+  it('appends multiple events to the same log', async () => {
+    for (let i = 0; i < 3; i++) {
+      const args = makeArgs({
+        body: new TextEncoder().encode(`{"action":"opened","repository":{"full_name":"x/y"},"sender":{"login":"k"},"pull_request":{"number":${i},"title":"t","html_url":"https://x"}}`),
+      })
+      args.headers.set('x-hub-signature-256', githubSig(args.body, SECRET))
+      args.headers.set('x-github-event', 'pull_request')
+      await handleWebhookIngest(args, { resolveAgentDir, log: () => {} })
+    }
+    const events = readWebhookLog('klanker', resolveAgentDir)
+    expect(events).toHaveLength(3)
+  })
+})
+
+describe('handleWebhookIngest — error paths', () => {
+  it('returns 404 for unknown agent', async () => {
+    const args = makeArgs({ agentExists: false })
+    const r = await handleWebhookIngest(args, { resolveAgentDir, log: () => {} })
+    expect(r.status).toBe(404)
+  })
+
+  it('returns 400 for unknown source', async () => {
+    const args = makeArgs({ source: 'sentry', allowedSources: ['sentry'] })
+    const r = await handleWebhookIngest(args, { resolveAgentDir, log: () => {} })
+    expect(r.status).toBe(400)
+  })
+
+  it('returns 403 when source not in agent allowlist', async () => {
+    const args = makeArgs({ allowedSources: ['generic'] })
+    args.headers.set('x-hub-signature-256', githubSig(args.body, SECRET))
+    const r = await handleWebhookIngest(args, { resolveAgentDir, log: () => {} })
+    expect(r.status).toBe(403)
+  })
+
+  it('returns 401 when no secret is configured for the source', async () => {
+    const args = makeArgs({ config: { secrets: {} } })
+    args.headers.set('x-hub-signature-256', githubSig(args.body, SECRET))
+    const r = await handleWebhookIngest(args, { resolveAgentDir, log: () => {} })
+    expect(r.status).toBe(401)
+  })
+
+  it('returns 401 on github signature mismatch', async () => {
+    const args = makeArgs({})
+    args.headers.set('x-hub-signature-256', githubSig(args.body, 'wrong-secret'))
+    const r = await handleWebhookIngest(args, { resolveAgentDir, log: () => {} })
+    expect(r.status).toBe(401)
+  })
+
+  it('returns 401 on missing signature header', async () => {
+    const args = makeArgs({})
+    // no header at all
+    const r = await handleWebhookIngest(args, { resolveAgentDir, log: () => {} })
+    expect(r.status).toBe(401)
+  })
+
+  it('returns 401 on invalid Bearer for generic', async () => {
+    const args = makeArgs({
+      source: 'generic',
+      body: new TextEncoder().encode('{"x":1}'),
+      allowedSources: ['generic'],
+      config: { secrets: { generic: SECRET } },
+    })
+    args.headers.set('authorization', 'Bearer wrong-token-of-some-length__')
+    const r = await handleWebhookIngest(args, { resolveAgentDir, log: () => {} })
+    expect(r.status).toBe(401)
+  })
+
+  it('returns 400 on malformed JSON body', async () => {
+    const args = makeArgs({
+      body: new TextEncoder().encode('not-valid-json'),
+    })
+    args.headers.set('x-hub-signature-256', githubSig(args.body, SECRET))
+    args.headers.set('x-github-event', 'pull_request')
+    const r = await handleWebhookIngest(args, { resolveAgentDir, log: () => {} })
+    expect(r.status).toBe(400)
+  })
+})
+
+describe('handleWebhookIngest — file isolation', () => {
+  it('writes to per-agent paths so two agents do not share logs', async () => {
+    const a1 = makeArgs({ agent: 'finn' })
+    a1.headers.set('x-hub-signature-256', githubSig(a1.body, SECRET))
+    a1.headers.set('x-github-event', 'pull_request')
+    await handleWebhookIngest(a1, { resolveAgentDir, log: () => {} })
+
+    const a2 = makeArgs({ agent: 'klanker' })
+    a2.headers.set('x-hub-signature-256', githubSig(a2.body, SECRET))
+    a2.headers.set('x-github-event', 'pull_request')
+    await handleWebhookIngest(a2, { resolveAgentDir, log: () => {} })
+
+    expect(readWebhookLog('finn', resolveAgentDir)).toHaveLength(1)
+    expect(readWebhookLog('klanker', resolveAgentDir)).toHaveLength(1)
+    expect(existsSync(join(agentsRoot, 'finn', 'telegram', 'webhook-events.jsonl'))).toBe(true)
+    expect(existsSync(join(agentsRoot, 'klanker', 'telegram', 'webhook-events.jsonl'))).toBe(true)
+  })
+
+  it('creates the telegram dir when it does not exist', async () => {
+    const args = makeArgs({ agent: 'newagent' })
+    args.headers.set('x-hub-signature-256', githubSig(args.body, SECRET))
+    args.headers.set('x-github-event', 'pull_request')
+    await handleWebhookIngest(args, { resolveAgentDir, log: () => {} })
+    expect(existsSync(join(agentsRoot, 'newagent', 'telegram', 'webhook-events.jsonl'))).toBe(true)
+  })
+})
+
+describe('handleWebhookIngest — log line shape', () => {
+  it('logs receipt with agent, source, event_type, ts', async () => {
+    const args = makeArgs({})
+    args.headers.set('x-hub-signature-256', githubSig(args.body, SECRET))
+    args.headers.set('x-github-event', 'pull_request')
+
+    const lines: string[] = []
+    await handleWebhookIngest(args, {
+      resolveAgentDir,
+      log: (s) => lines.push(s),
+      now: () => 1234567890,
+    })
+    const joined = lines.join('')
+    expect(joined).toMatch(/agent='klanker'/)
+    expect(joined).toMatch(/source='github'/)
+    expect(joined).toMatch(/event='pull_request'/)
+    expect(joined).toMatch(/ts=1234567890/)
+  })
+
+  it('logs rejection reason without leaking which check failed', async () => {
+    // The HTTP body is a generic 'unauthorized' but the stderr log
+    // should carry the specific reason for operator debugging.
+    const args = makeArgs({})
+    args.headers.set('x-hub-signature-256', 'sha256=' + 'a'.repeat(64))
+
+    const lines: string[] = []
+    const r = await handleWebhookIngest(args, {
+      resolveAgentDir,
+      log: (s) => lines.push(s),
+    })
+    expect(r.status).toBe(401)
+    expect(JSON.parse(r.body)).toMatchObject({ ok: false, error: 'unauthorized' })
+    // Operator log carries the specific reason.
+    expect(lines.join('')).toMatch(/signature-mismatch/)
+  })
+})
+
+describe('readWebhookLog', () => {
+  it('returns [] when the log file does not exist', () => {
+    expect(readWebhookLog('nope', resolveAgentDir)).toEqual([])
+  })
+
+  it('parses each line independently', async () => {
+    const args = makeArgs({})
+    args.headers.set('x-hub-signature-256', githubSig(args.body, SECRET))
+    args.headers.set('x-github-event', 'pull_request')
+    await handleWebhookIngest(args, { resolveAgentDir, log: () => {} })
+    await handleWebhookIngest(args, { resolveAgentDir, log: () => {} })
+    const events = readWebhookLog('klanker', resolveAgentDir)
+    expect(events).toHaveLength(2)
+    expect(events.every((e) => typeof e.ts === 'number')).toBe(true)
+  })
+})
+
+// Use existsSync for file-creation assertions.
+import { existsSync as _existsSync } from 'fs'
+void _existsSync

--- a/tests/webhook-verify.test.ts
+++ b/tests/webhook-verify.test.ts
@@ -1,0 +1,210 @@
+/**
+ * Unit tests for the webhook signature verifiers (#577).
+ *
+ * Coverage targets:
+ *   - verifyGithubSignature: valid, missing header, wrong format,
+ *     malformed hex, signature mismatch, no secret configured.
+ *   - verifyBearerToken: valid, missing header, wrong scheme, length
+ *     mismatch, token mismatch.
+ *   - renderGithubEvent: covers the four known event types + the
+ *     fallback shape; HTML-escapes user-controlled fields.
+ *   - renderGenericEvent: title/message/text precedence + JSON
+ *     fallback; source-name escape.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { createHmac } from 'crypto'
+import {
+  verifyGithubSignature,
+  verifyBearerToken,
+  renderGithubEvent,
+  renderGenericEvent,
+} from '../src/web/webhook-verify.js'
+
+const SECRET = 'this-is-a-shared-secret'
+
+function githubSig(body: Uint8Array, secret: string): string {
+  return 'sha256=' + createHmac('sha256', secret).update(body).digest('hex')
+}
+
+describe('verifyGithubSignature', () => {
+  const body = new TextEncoder().encode('{"ping":"pong"}')
+
+  it('accepts a valid signature', () => {
+    const r = verifyGithubSignature(body, githubSig(body, SECRET), SECRET)
+    expect(r.ok).toBe(true)
+  })
+
+  it('rejects missing signature header', () => {
+    const r = verifyGithubSignature(body, undefined, SECRET)
+    expect(r.ok).toBe(false)
+    expect(r).toMatchObject({ ok: false, reason: 'no-signature-header' })
+  })
+
+  it('rejects wrong format (no sha256= prefix)', () => {
+    const r = verifyGithubSignature(body, 'not-a-real-prefix', SECRET)
+    expect(r.ok).toBe(false)
+    expect(r).toMatchObject({ ok: false, reason: 'wrong-signature-format' })
+  })
+
+  it('rejects malformed hex', () => {
+    const r = verifyGithubSignature(body, 'sha256=NOTHEXNOTHEXNOTHEXNOTHEXNOTHEXNOTHEXNOTHEXNOTHEXNOTHEXNOTHEXNOTH', SECRET)
+    expect(r.ok).toBe(false)
+    expect(r).toMatchObject({ ok: false, reason: 'malformed-hex' })
+  })
+
+  it('rejects a signature signed with a different secret', () => {
+    const r = verifyGithubSignature(body, githubSig(body, 'wrong-secret'), SECRET)
+    expect(r.ok).toBe(false)
+    expect(r).toMatchObject({ ok: false, reason: 'signature-mismatch' })
+  })
+
+  it('rejects a tampered body (signature was for original)', () => {
+    const tampered = new TextEncoder().encode('{"ping":"different"}')
+    const r = verifyGithubSignature(tampered, githubSig(body, SECRET), SECRET)
+    expect(r.ok).toBe(false)
+    expect(r).toMatchObject({ ok: false, reason: 'signature-mismatch' })
+  })
+
+  it('rejects when no secret is configured (defense in depth)', () => {
+    const r = verifyGithubSignature(body, githubSig(body, SECRET), '')
+    expect(r.ok).toBe(false)
+    expect(r).toMatchObject({ ok: false, reason: 'no-secret-configured' })
+  })
+})
+
+describe('verifyBearerToken', () => {
+  it('accepts a valid Bearer token', () => {
+    const r = verifyBearerToken('Bearer ' + SECRET, SECRET)
+    expect(r.ok).toBe(true)
+  })
+
+  it('rejects missing header', () => {
+    const r = verifyBearerToken(null, SECRET)
+    expect(r.ok).toBe(false)
+    expect(r).toMatchObject({ ok: false, reason: 'no-auth-header' })
+  })
+
+  it('rejects wrong auth scheme', () => {
+    const r = verifyBearerToken('Basic ' + Buffer.from('user:pass').toString('base64'), SECRET)
+    expect(r.ok).toBe(false)
+    expect(r).toMatchObject({ ok: false, reason: 'wrong-auth-scheme' })
+  })
+
+  it('rejects token of wrong length (constant-time guard)', () => {
+    const r = verifyBearerToken('Bearer too-short', SECRET)
+    expect(r.ok).toBe(false)
+    expect(r).toMatchObject({ ok: false, reason: 'length-mismatch' })
+  })
+
+  it('rejects token of correct length but wrong content', () => {
+    const wrong = SECRET.split('').reverse().join('')
+    const r = verifyBearerToken('Bearer ' + wrong, SECRET)
+    expect(r.ok).toBe(false)
+    expect(r).toMatchObject({ ok: false, reason: 'token-mismatch' })
+  })
+
+  it('rejects when no secret is configured', () => {
+    const r = verifyBearerToken('Bearer ' + SECRET, '')
+    expect(r.ok).toBe(false)
+    expect(r).toMatchObject({ ok: false, reason: 'no-secret-configured' })
+  })
+})
+
+describe('renderGithubEvent', () => {
+  const baseRepo = { repository: { full_name: 'switchroom/switchroom' }, sender: { login: 'mekenthompson' } }
+
+  it('renders pull_request opened', () => {
+    const r = renderGithubEvent('pull_request', {
+      ...baseRepo,
+      action: 'opened',
+      pull_request: { number: 42, title: 'fix: thing', html_url: 'https://github.com/x/y/pull/42' },
+    })
+    expect(r.text).toContain('switchroom/switchroom')
+    expect(r.text).toContain('PR #42 opened')
+    expect(r.text).toContain('mekenthompson')
+    expect(r.text).toContain('fix: thing')
+    expect(r.disableLinkPreview).toBe(true)
+  })
+
+  it('renders issues event with action and number', () => {
+    const r = renderGithubEvent('issues', {
+      ...baseRepo,
+      action: 'opened',
+      issue: { number: 7, title: 'bug', html_url: 'https://x/y/issues/7' },
+    })
+    expect(r.text).toContain('issue #7 opened')
+  })
+
+  it('renders push with branch + commit count', () => {
+    const r = renderGithubEvent('push', {
+      ...baseRepo,
+      ref: 'refs/heads/main',
+      commits: [{ id: 'a' }, { id: 'b' }, { id: 'c' }],
+      compare: 'https://x/y/compare/abc...def',
+    })
+    expect(r.text).toContain('push to <code>main</code>')
+    expect(r.text).toContain('3 commit(s)')
+  })
+
+  it('renders ping event', () => {
+    const r = renderGithubEvent('ping', baseRepo)
+    expect(r.text).toContain('webhook ping')
+  })
+
+  it('falls back for unknown event types', () => {
+    const r = renderGithubEvent('star', baseRepo)
+    expect(r.text).toContain('star by @mekenthompson')
+  })
+
+  it('HTML-escapes user-controlled fields', () => {
+    const r = renderGithubEvent('issues', {
+      repository: { full_name: 'org/<script>alert(1)</script>' },
+      sender: { login: 'evil&user' },
+      action: 'opened',
+      issue: { number: 1, title: '<img src=x onerror=alert(1)>', html_url: 'https://example/' },
+    })
+    expect(r.text).not.toContain('<script>')
+    expect(r.text).toContain('&lt;script&gt;')
+    expect(r.text).toContain('evil&amp;user')
+    expect(r.text).toContain('&lt;img')
+  })
+})
+
+describe('renderGenericEvent', () => {
+  it('uses payload.title when present', () => {
+    const r = renderGenericEvent('sentry', { title: 'Error spike' })
+    expect(r.text).toContain('Error spike')
+    expect(r.text).toContain('sentry')
+  })
+
+  it('falls back to message when title absent', () => {
+    const r = renderGenericEvent('alert', { message: 'oh no' })
+    expect(r.text).toContain('oh no')
+  })
+
+  it('falls back to text when title and message absent', () => {
+    const r = renderGenericEvent('alert', { text: 'urgent' })
+    expect(r.text).toContain('urgent')
+  })
+
+  it('falls back to JSON snippet when nothing usable', () => {
+    const r = renderGenericEvent('alert', { unknown_field: 42, other: ['a', 'b'] })
+    expect(r.text).toContain('unknown_field')
+  })
+
+  it('truncates JSON fallback to 200 chars', () => {
+    const big = { msg: 'x'.repeat(500) }
+    const r = renderGenericEvent('alert', big)
+    // The whole rendered message, including the source label and emoji,
+    // should remain bounded.
+    expect(r.text.length).toBeLessThan(300)
+  })
+
+  it('HTML-escapes source name and content', () => {
+    const r = renderGenericEvent('<bad>', { title: '<bold>' })
+    expect(r.text).not.toContain('<bad>')
+    expect(r.text).toContain('&lt;bad&gt;')
+    expect(r.text).toContain('&lt;bold&gt;')
+  })
+})


### PR DESCRIPTION
Closes #577. Part of #572 (Wave 2.2).

## Summary
`POST /webhook/:agent/:source` on the existing web server. Verifies (HMAC-SHA256 for github, Bearer for generic). Verified events append as JSONL to `<agent>/telegram/webhook-events.jsonl` for the agent to read on demand.

## Files
- `src/web/webhook-verify.ts` (new) — pure verifiers + renderers
- `src/web/webhook-handler.ts` (new) — ingest pipeline (tmpdir-rooted, no globals)
- `src/web/server.ts` — wires route BEFORE origin gate (webhooks bring own auth)
- `src/config/schema.ts` — per-agent `webhook_sources` field (enum array)
- `tests/webhook-verify.test.ts` (new) — 25 cases including HTML escape
- `tests/webhook-handler.test.ts` (new) — 17 cases including every HTTP status
- `docs/webhook-ingest.md` (new) — operator setup walkthrough

## HTTP contract
- 202 verified + recorded
- 400 unknown source / malformed JSON
- 401 unauthorized (verification failed; specific reason in operator stderr log)
- 403 source not in agent's allowlist
- 404 unknown agent

## Secrets
`~/.switchroom/webhook-secrets.json` mode 0600, keyed `[agent][source]`. One file, hand-editable. Vault-backed storage is a future hardening.

## Out of scope
- Auto-post verified events to the agent's Telegram topic. Needs bot-token resolution + topic mapping; follow-up PR.
- Trigger fresh agent turn on event. Needs gateway-IPC integration; follow-up.
- Per-source rate limit at route level. Failed verification short-circuits; abuse cost is bounded by HMAC math.

## Test plan
- [x] 42 unit + integration tests pass
- [x] `npm run lint` clean
- [ ] Manual: configure GitHub webhook with shared secret, trigger PR event, verify line lands in JSONL with verified payload