### PR TITLE
feat(progress-card): card gate >60s OR sub-agent (#553 PR 4 of 5)

### DIFF
--- a/telegram-plugin/docs/waiting-ux-spec.md
+++ b/telegram-plugin/docs/waiting-ux-spec.md
@@ -95,12 +95,21 @@ do not gate CI yet.
 
 ## PR 2–5 — implementation roadmap
 
-| PR  | Scope                                                                | Un-skips                                            |
-| --- | -------------------------------------------------------------------- | --------------------------------------------------- |
-| 2   | Kill instant-draft placeholder; preserve early-ack 👀                | Class A no-placeholder, Class B no-placeholder      |
-| 3   | First-answer-text deadline implementation; tighten <Ns numbers       | Class A/B/C answer-text-deadline assertions         |
-| 4   | Card-gate rewrite to `(>=60s) OR (sub-agent appeared)`               | Class B no-card; Class C card-gate tests            |
-| 5   | Remove `🔵 thinking` / `📚 recalling memories` / `💭 thinking` strings; sub-agent header = list length | Remaining no-placeholder + sub-agent count tests    |
+| PR  | Scope                                                                | Un-skips                                            | Status   |
+| --- | -------------------------------------------------------------------- | --------------------------------------------------- | -------- |
+| 2   | Kill instant-draft placeholder; preserve early-ack 👀                | Class A no-placeholder, Class B no-placeholder      | shipped  |
+| 3   | First-answer-text deadline implementation; tighten <Ns numbers       | Class A/B/C answer-text-deadline assertions         | shipped  |
+| 4   | Card-gate rewrite to `(>=60s) OR (sub-agent appeared)`               | Class B no-card; Class C card-gate tests            | shipped  |
+| 5   | Remove `🔵 thinking` / `📚 recalling memories` / `💭 thinking` strings; sub-agent header = list length | Remaining no-placeholder + sub-agent count tests    | pending  |
+
+**PR 4 status (this PR):** ships the card-gate rewrite. Defaults change
+from `initialDelayMs=30_000, promoteAfterMs=5_000, promoteOnParentToolCount=3`
+to `initialDelayMs=60_000, promoteAfterMs=0 (disabled), promoteOnParentToolCount=0
+(disabled)`. The Class B "no card rendered" and Class C "card renders on
+sub-agent" / "card renders after 60s" tests are un-skipped. F3's late-card
+symptom (long single-tool turn shows no card) is now intentional spec
+behaviour rather than a bug — see `real-gateway-f3-late-card.test.ts`
+header for the reframe.
 
 ## Failure-mode history (F1–F4, fixed in earlier #553 PRs)
 

--- a/telegram-plugin/progress-card-driver.ts
+++ b/telegram-plugin/progress-card-driver.ts
@@ -187,7 +187,7 @@ export interface ProgressDriverConfig {
    * starts (see `promoteOnSubAgent`) — long-running tool work and
    * background dispatches stay visible without waiting the full delay.
    *
-   * Default 30000 (30 seconds). Set to 0 to disable.
+   * Default 60000 (60 seconds, #553 PR 4). Set to 0 to disable.
    */
   initialDelayMs?: number
   /**
@@ -212,10 +212,11 @@ export interface ProgressDriverConfig {
    * substantial turn that does parent-side work (Read/Grep/Bash/Edit)
    * but never dispatches a sub-agent.
    *
-   * Symmetric to `promoteOnSubAgent`. Default 3: a turn with ≥3 tool
-   * calls is not "short" by any reasonable definition, so the
-   * fast-turn suppression goal (no clutter on quick replies) still
-   * holds. Set to a large value (e.g. 999) to effectively disable.
+   * Symmetric to `promoteOnSubAgent`. **Default 0 (disabled, #553 PR 4):**
+   * under the v2 contract tools alone never trigger the card — only
+   * sub-agents or `elapsed >= 60s`. Values of 0 or non-finite (Infinity)
+   * are treated as "never promote on tool count". Set to a positive
+   * integer (e.g. 3) to opt back in to the pre-v2 behaviour.
    *
    * Fast-turn suppression in `flush()` is unchanged — if the turn
    * ends before promotion, the card still skips the emit.
@@ -234,8 +235,12 @@ export interface ProgressDriverConfig {
    * suppression in `flush()` is unchanged — sub-`promoteAfterMs` turns
    * still skip the card.
    *
-   * Default 5000 (5 seconds). Set to a large value (e.g. 999_999) to
-   * effectively disable.
+   * **Default 0 (disabled, #553 PR 4).** The PR #570 5s time-promote was
+   * a stop-gap when `initialDelayMs` defaulted to 30s; with the new
+   * 60s `initialDelayMs` and the sub-agent promote intact, time-based
+   * promotion is no longer needed. `ensureTimePromoteScheduled` no-ops
+   * when this is 0 so the timer never schedules. Set to a positive
+   * value to opt back in to the pre-v2 behaviour.
    */
   promoteAfterMs?: number
   /**
@@ -530,7 +535,7 @@ export interface ProgressDriver {
    * Begin a new turn synchronously — called from the inbound-message
    * handler the instant a user's message clears the gate, BEFORE any
    * session-tail event arrives. Creates a fresh progress card state; the
-   * first visible render is gated by `initialDelayMs` (default 30s) so
+   * first visible render is gated by `initialDelayMs` (default 60s) so
    * turns that finish before the delay produce no card at all and the
    * user only sees the final reply.
    *
@@ -668,10 +673,23 @@ export function createProgressDriver(config: ProgressDriverConfig): ProgressDriv
   const editBudgetThreshold = config.editBudgetThreshold ?? 18
   const editBudgetCoalesceMs = config.editBudgetCoalesceMs ?? 3000
   const maxIdleMs = config.maxIdleMs ?? 30 * 60_000
-  const initialDelayMs = config.initialDelayMs ?? 30_000
+  // v2 card-gate (#553 PR 4): card visibility is `(elapsed >= 60s) OR
+  // (any sub-agent appeared)`. Tools alone never trigger the card.
+  //   - initialDelayMs: 60s (was 30s) — pushes the time-based gate to
+  //     the spec value.
+  //   - promoteOnParentToolCount: 0 (was 3) — disabled. The check below
+  //     treats 0 (and Infinity) as "never promote on tool count".
+  //   - promoteAfterMs: 0 (was 5_000) — disabled. ensureTimePromoteScheduled
+  //     no-ops when this is 0, so the timer never schedules. The PR #570
+  //     time-promote was a stop-gap when initialDelayMs was 30s; with
+  //     initialDelayMs=60s and the sub-agent promote intact, it is no
+  //     longer needed.
+  //   - promoteOnSubAgent: true (unchanged) — sub-agents/background workers
+  //     break the suppression immediately.
+  const initialDelayMs = config.initialDelayMs ?? 60_000
   const promoteOnSubAgent = config.promoteOnSubAgent ?? true
-  const promoteOnParentToolCount = config.promoteOnParentToolCount ?? 3
-  const promoteAfterMs = config.promoteAfterMs ?? 5_000
+  const promoteOnParentToolCount = config.promoteOnParentToolCount ?? 0
+  const promoteAfterMs = config.promoteAfterMs ?? 0
   const maxConsecutive4xx = config.maxConsecutive4xx ?? 3
   const orphanPromotionMs = config.orphanPromotionMs ?? 5_000
   const coldSubAgentThresholdMs = config.coldSubAgentThresholdMs ?? 30_000
@@ -1649,16 +1667,17 @@ export function createProgressDriver(config: ProgressDriverConfig): ProgressDriv
         promoteFirstEmit(chatState, 'sub_agent_started')
       }
 
-      // #478: promote the card when the agent has issued enough parent-
-      // side tool calls during the suppression window. The previous
-      // logic only promoted on sub-agent dispatch, so a turn that did
-      // 5 Read/Grep/Bash calls in 30s never showed a card — user saw
-      // typing-indicator-only and described it as "feels dead." A turn
-      // with ≥3 parent tools is not "short" by any reasonable
-      // definition, so this doesn't regress the fast-turn-suppression
-      // goal (which continues to fire in flush() for sub-3-tool turns).
+      // #478 / #553 PR 4: promote the card when the agent has issued
+      // enough parent-side tool calls during the suppression window.
+      // Disabled by default in v2 (promoteOnParentToolCount=0 / Infinity)
+      // — under the v2 contract tools alone never trigger the card. The
+      // check is preserved as a config knob for callers that want the
+      // old behaviour, but values of 0 or non-finite (Infinity) are
+      // treated as "never promote on tool count".
       if (
-        chatState.isFirstEmit
+        promoteOnParentToolCount > 0
+        && Number.isFinite(promoteOnParentToolCount)
+        && chatState.isFirstEmit
         && chatState.deferredFirstEmitTimer !== DELAY_ELAPSED
         && !chatState.apiFailures.terminal
         && chatState.state.items.length >= promoteOnParentToolCount

--- a/telegram-plugin/tests/progress-card-driver.test.ts
+++ b/telegram-plugin/tests/progress-card-driver.test.ts
@@ -1443,11 +1443,11 @@ describe('forceCompleteTurn — external completion signal', () => {
     // initialDelayMs=30s elapses), and stream_reply(done=true) fires
     // forceCompleteTurn. The deferred first-emit timer must be cancelled
     // so it can't fire at +30s with a ghost card.
-    // Disable F3 time-based promotion (default 5s) so this test isolates
-    // the cusp-race behaviour pre-existed the F3 fix — forceCompleteTurn
-    // must cancel the deferred-first-emit timer regardless. With time-
-    // promotion enabled, the card would correctly emit at +5s; that's
-    // covered by the F3 tests, not this one.
+    // Disable F3 time-based promotion explicitly (it's now 0/disabled
+    // by default under v2 #553 PR 4, but pin it here for clarity) so
+    // this test isolates the cusp-race behaviour: forceCompleteTurn
+    // must cancel the deferred-first-emit timer regardless of any
+    // promotion path.
     const { driver, emits, advance } = harness(0, 0, {
       initialDelayMs: 30_000,
       promoteAfterMs: 999_999,

--- a/telegram-plugin/tests/real-gateway-f3-late-card.test.ts
+++ b/telegram-plugin/tests/real-gateway-f3-late-card.test.ts
@@ -1,35 +1,32 @@
 /**
- * F3 — "late progress card" — regression test against real-gateway harness.
+ * F3 — "late progress card" — REFRAMED under v2 (#553 PR 4).
  *
- * Symptom from #545: on long-running turns (Class C), the progress card
- * renders late — sometimes after `turn_end`, sometimes never. User sits
- * watching status reactions cycle for 10+ seconds with no card visible,
- * then either gets a sudden card right before the reply or just the
- * reply with no card at all.
+ * Original symptom from #545: on long-running turns (Class C), the
+ * progress card rendered late — sometimes after `turn_end`, sometimes
+ * never. Under v1, the user sat watching status reactions cycle for
+ * 10+ seconds with no card visible, then either got a sudden card right
+ * before the reply or just the reply with no card at all.
  *
- * Root cause: `progress-card-driver` defaults `initialDelayMs=30000`
- * (30 seconds — designed to suppress cards for instant replies). The
- * existing `promoteFirstEmit` mechanism short-circuits the wait under
- * specific conditions:
+ * **Under v2 (#553 PR 4), F3's symptom is by design — tool-only turns
+ * never show the card.** The card now requires sub-agents OR
+ * `elapsed >= 60s`. F3-style late-card is no longer a bug; it's the
+ * spec. The driver defaults shifted from
+ * `initialDelayMs=30_000, promoteAfterMs=5_000, promoteOnParentToolCount=3`
+ * to `initialDelayMs=60_000, promoteAfterMs=0, promoteOnParentToolCount=0`.
  *
- *   - parent tool count ≥ `promoteOnParentToolCount` (default 3)
- *   - any sub-agent started
- *   - carried-over sub-agents at enqueue
- *   - sub-agent stalled
+ * What this file now covers:
+ *   - Long single-tool turn (~10s): card MUST NOT render (tools alone
+ *     don't promote).
+ *   - Two-tool turn (~6s): card MUST NOT render.
+ *   - Class A instant reply (<2s, no tools): card MUST NOT render
+ *     (regression guard, unchanged).
  *
- * **Gap**: a long single-tool turn (e.g. one Bash that takes 10 seconds)
- * never crosses any promotion threshold. Card waits the full 30s, then
- * fast-turn-suppression cancels it at `turn_end`. F3 directly observed.
+ * The "card renders after >=60s" path is covered by the v2 spec test
+ * (`real-gateway-spec.test.ts` → "Class C — progress card appears when
+ * elapsed >= 60s even without a sub-agent"). The "card renders on
+ * sub-agent" path is covered there too.
  *
- * Fix: add a time-based promotion — after Ns of activity (any session
- * event) in still-`isFirstEmit` state, promote. 5s gives users a clear
- * "agent is working" signal without breaking instant-reply suppression
- * (sub-2s turns still skip the card).
- *
- * Spec contract from `waiting-ux-spec.md` Class C:
- *   - Status card renders early, **stays pinned-feel and stable**
- *
- * Tracking: #545 (parent), #553 (Phase 3).
+ * Tracking: #545 (parent), #553 (Phase 3, PR 4 reframe).
  */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -41,30 +38,26 @@ const INBOUND_MSG = 100
 beforeEach(() => { vi.useFakeTimers() })
 afterEach(() => { vi.useRealTimers() })
 
-describe('F3 — progress card renders early on long turns', () => {
-  it('long single-tool turn (~10s): card renders before turn_end', async () => {
-    // Production defaults: initialDelayMs=30000, promoteOnParentToolCount=3.
-    // A 10s single-tool turn crosses neither — card waits the full 30s,
-    // then fast-turn-suppression cancels it. This is exactly F3.
+describe('F3 — under v2: tool-only turns intentionally show no card', () => {
+  it('long single-tool turn (~10s): NO card rendered (intentional, v2 spec)', async () => {
+    // v2 defaults: initialDelayMs=60_000, promoteAfterMs=0 (disabled),
+    // promoteOnParentToolCount=0 (disabled). A 10s single-tool turn
+    // crosses neither the 60s threshold nor any tool/sub-agent promote
+    // gate — the card is suppressed by design.
     const h = createRealGatewayHarness({ gapMs: 0 })
-    const inboundAt = h.clock.now()
     h.inbound({ chatId: CHAT, messageId: INBOUND_MSG, text: 'long task' })
     h.feedSessionEvent({ kind: 'enqueue', chatId: CHAT, messageId: '1', threadId: null, rawContent: 'long task' })
     await h.clock.advance(200)
     h.feedSessionEvent({ kind: 'thinking' })
     await h.clock.advance(500)
     h.feedSessionEvent({ kind: 'tool_use', toolName: 'Bash', toolUseId: 't1' })
-    // Tool runs ~10s — well past the 5s promotion threshold the fix introduces.
+    // Tool runs ~10s — well under the 60s spec threshold.
     await h.clock.advance(10_000)
     h.feedSessionEvent({ kind: 'tool_result', toolUseId: 't1', toolName: 'Bash' })
     await h.clock.advance(200)
 
-    // Spec: card MUST be visible by now (well within the 10s tool window).
-    const cardAt = h.recorder.progressCardSendMs(CHAT)
-    expect(cardAt, 'progress card never rendered for a 10s long turn').not.toBeNull()
-    // Card should have rendered within ~5s of inbound (the time-promotion
-    // threshold), not at the 30s initialDelay.
-    expect((cardAt ?? Infinity) - inboundAt).toBeLessThan(8_000)
+    // Spec: tools alone never trigger the card.
+    expect(h.recorder.progressCardSendMs(CHAT)).toBeNull()
 
     // Drain the rest of the turn so afterEach doesn't leak timers.
     await h.streamReply({ chat_id: CHAT, text: 'done', done: true })
@@ -73,12 +66,10 @@ describe('F3 — progress card renders early on long turns', () => {
     h.finalize()
   })
 
-  it('two-tool turn (~6s): card renders within 5-6s of inbound', async () => {
-    // 2 tools — below the parent_tool_count promotion threshold (3).
-    // Without time-based promotion, this turn would wait 30s then
-    // suppress. With the fix, it promotes around the 5s mark.
+  it('two-tool turn (~6s): NO card rendered (intentional, v2 spec)', async () => {
+    // 2 tools, ~6s — same v2 contract: tools alone don't promote, and
+    // 6s is well under the 60s threshold. Card stays suppressed.
     const h = createRealGatewayHarness({ gapMs: 0 })
-    const inboundAt = h.clock.now()
     h.inbound({ chatId: CHAT, messageId: INBOUND_MSG, text: 'two tools' })
     h.feedSessionEvent({ kind: 'enqueue', chatId: CHAT, messageId: '1', threadId: null, rawContent: 'two tools' })
     await h.clock.advance(200)
@@ -92,9 +83,7 @@ describe('F3 — progress card renders early on long turns', () => {
     h.feedSessionEvent({ kind: 'tool_result', toolUseId: 't2', toolName: 'Bash' })
     await h.clock.advance(500)
 
-    const cardAt = h.recorder.progressCardSendMs(CHAT)
-    expect(cardAt, 'progress card never rendered for a 6s 2-tool turn').not.toBeNull()
-    expect((cardAt ?? Infinity) - inboundAt).toBeLessThan(7_000)
+    expect(h.recorder.progressCardSendMs(CHAT)).toBeNull()
 
     // Drain
     await h.streamReply({ chat_id: CHAT, text: 'done', done: true })
@@ -104,8 +93,10 @@ describe('F3 — progress card renders early on long turns', () => {
   })
 
   it('instant reply (Class A, <2s, no tools): card is STILL suppressed (regression guard)', async () => {
-    // The fix must not regress fast-turn suppression — a sub-2s turn
-    // with no tools should still skip the card entirely.
+    // Unchanged from the original F3 file — the v2 contract preserves
+    // fast-turn suppression for instant replies. This is the only
+    // "card should not appear" assertion that has the same meaning
+    // pre- and post-v2.
     const h = createRealGatewayHarness({ gapMs: 0 })
     h.inbound({ chatId: CHAT, messageId: INBOUND_MSG, text: 'hi' })
     h.feedSessionEvent({ kind: 'enqueue', chatId: CHAT, messageId: '1', threadId: null, rawContent: 'hi' })
@@ -116,7 +107,7 @@ describe('F3 — progress card renders early on long turns', () => {
     h.feedSessionEvent({ kind: 'turn_end', durationMs: 1_500 })
     await h.clock.advance(2_000)
 
-    // Class A: no card. Pin so the F3 fix doesn't blanket-promote.
+    // Class A: no card.
     expect(h.recorder.progressCardSendMs(CHAT)).toBeNull()
     h.finalize()
   })

--- a/telegram-plugin/tests/real-gateway-f4-interim-text.test.ts
+++ b/telegram-plugin/tests/real-gateway-f4-interim-text.test.ts
@@ -19,10 +19,12 @@
  *   - Specific text shapes that break `extractNarrativeLabel` (multi-
  *     line prose with the "real" label not on line 1)
  *
- * The test below pins the well-spaced multi-step contract — if a
- * future change regresses it (e.g., narratives stop being appended),
- * we'll catch it here. F4 still needs production observation to
- * surface the actual failure mode for a tighter test.
+ * Under v2 (#553 PR 4): the card is suppressed for tool-only turns
+ * under 60s (Class B). The original 7s tool-chain version of this test
+ * no longer renders a card by design — preamble text in Class B lives
+ * in the answer-text stream, not the card. To keep the F4 regression
+ * guard meaningful, the test now uses a sub-agent turn (Class C) so
+ * the card actually renders and we can inspect its preamble updates.
  *
  * Spec contract from `waiting-ux-spec.md`:
  *
@@ -44,9 +46,17 @@ afterEach(() => { vi.useRealTimers() })
 
 describe('F4 — preamble refresh on step transitions (regression guard)', () => {
   it('three well-spaced text → tool steps produce three distinct preamble updates in the rendered card', async () => {
+    // Class C turn (sub-agent present) so the card actually renders
+    // under the v2 gate. The sub-agent dispatches up front (promotes
+    // the card immediately), then three text → tool step transitions
+    // exercise the F4 narrative refresh path.
     const h = createRealGatewayHarness({ gapMs: 0 })
     h.inbound({ chatId: CHAT, messageId: INBOUND_MSG, text: 'multi-step task' })
     h.feedSessionEvent({ kind: 'enqueue', chatId: CHAT, messageId: '1', threadId: null, rawContent: 'multi-step task' })
+    await h.clock.advance(200)
+
+    // Sub-agent dispatched — Class C, card renders.
+    h.feedSessionEvent({ kind: 'sub_agent_started', agentId: 'a1', firstPromptText: 'background work' })
     await h.clock.advance(200)
 
     // Step 1: text + tool
@@ -67,6 +77,7 @@ describe('F4 — preamble refresh on step transitions (regression guard)', () =>
     await h.clock.advance(2_000)
     h.feedSessionEvent({ kind: 'tool_result', toolUseId: 't3', toolName: 'Edit' })
 
+    h.feedSessionEvent({ kind: 'sub_agent_turn_end', agentId: 'a1' })
     await h.streamReply({ chat_id: CHAT, text: 'done', done: true })
     h.feedSessionEvent({ kind: 'turn_end', durationMs: 7_000 })
     await h.clock.advance(2_000)

--- a/telegram-plugin/tests/real-gateway-spec.test.ts
+++ b/telegram-plugin/tests/real-gateway-spec.test.ts
@@ -126,6 +126,80 @@ describe('v2 spec — PR 3: first-answer-text deadlines', () => {
   })
 })
 
+// ─── PR 4 — card-gate rewrite (Class B no-card; Class C card-gate) ────────
+//
+// Extracted from the Class B / Class C describe.skip blocks below and
+// un-skipped in #553 PR 4. The other tests in those blocks (no-placeholder,
+// ladder integrity, sub-agent header count) remain skipped pending PR 5.
+// Once PR 5 lands, the duplicates here can be folded back into the parent
+// describes.
+describe('v2 spec — PR 4: card gate (>=60s) OR (sub-agent appeared)', () => {
+  it('Class B — emits NO progress card (turn under 60s, no sub-agents)', async () => {
+    const h = createRealGatewayHarness({ gapMs: 0 })
+    h.inbound({ chatId: CHAT, messageId: INBOUND_MSG, text: 'short tool turn' })
+    h.feedSessionEvent({ kind: 'enqueue', chatId: CHAT, messageId: '1', threadId: null, rawContent: 'short tool turn' })
+    await h.clock.advance(200)
+    h.feedSessionEvent({ kind: 'thinking' })
+    await h.clock.advance(300)
+    // Two tools, total turn ~10s — well under 60s, no sub-agents.
+    h.feedSessionEvent({ kind: 'tool_use', toolName: 'Read', toolUseId: 't1' })
+    await h.clock.advance(3_000)
+    h.feedSessionEvent({ kind: 'tool_result', toolUseId: 't1', toolName: 'Read' })
+    h.feedSessionEvent({ kind: 'tool_use', toolName: 'Bash', toolUseId: 't2' })
+    await h.clock.advance(5_000)
+    h.feedSessionEvent({ kind: 'tool_result', toolUseId: 't2', toolName: 'Bash' })
+    await h.streamReply({ chat_id: CHAT, text: 'done', done: true })
+    h.feedSessionEvent({ kind: 'turn_end', durationMs: 9_000 })
+    await h.clock.advance(500)
+
+    expect(h.expectNoCardSent(CHAT)).toBeNull()
+    h.finalize()
+  })
+
+  it('Class C — progress card appears when a sub-agent dispatches (regardless of elapsed time)', async () => {
+    const h = createRealGatewayHarness({ gapMs: 0 })
+    h.inbound({ chatId: CHAT, messageId: INBOUND_MSG, text: 'spawn a worker' })
+    h.feedSessionEvent({ kind: 'enqueue', chatId: CHAT, messageId: '1', threadId: null, rawContent: 'spawn a worker' })
+    await h.clock.advance(200)
+    h.feedSessionEvent({ kind: 'thinking' })
+    await h.clock.advance(300)
+    // Sub-agent appears well under the 60s elapsed threshold — the
+    // card MUST still render because of the sub-agent gate.
+    h.feedSessionEvent({ kind: 'sub_agent_started', agentId: 'a1', firstPromptText: 'do work' })
+    await h.clock.advance(2_000)
+    h.feedSessionEvent({ kind: 'sub_agent_turn_end', agentId: 'a1' })
+    await h.clock.advance(500)
+
+    expect(h.expectNoCardSent(CHAT), 'card MUST render when a sub-agent dispatches').not.toBeNull()
+
+    await h.streamReply({ chat_id: CHAT, text: 'done', done: true })
+    h.feedSessionEvent({ kind: 'turn_end', durationMs: 3_000 })
+    await h.clock.advance(500)
+    h.finalize()
+  })
+
+  it('Class C — progress card appears when elapsed >= 60s even without a sub-agent', async () => {
+    const h = createRealGatewayHarness({ gapMs: 0 })
+    h.inbound({ chatId: CHAT, messageId: INBOUND_MSG, text: 'long single tool' })
+    h.feedSessionEvent({ kind: 'enqueue', chatId: CHAT, messageId: '1', threadId: null, rawContent: 'long single tool' })
+    await h.clock.advance(200)
+    h.feedSessionEvent({ kind: 'thinking' })
+    await h.clock.advance(300)
+    h.feedSessionEvent({ kind: 'tool_use', toolName: 'Bash', toolUseId: 't1' })
+    // Cross the 60s threshold.
+    await h.clock.advance(61_000)
+    h.feedSessionEvent({ kind: 'tool_result', toolUseId: 't1', toolName: 'Bash' })
+    await h.clock.advance(500)
+
+    expect(h.expectNoCardSent(CHAT), 'card MUST render after 60s elapsed').not.toBeNull()
+
+    await h.streamReply({ chat_id: CHAT, text: 'done', done: true })
+    h.feedSessionEvent({ kind: 'turn_end', durationMs: 62_000 })
+    await h.clock.advance(500)
+    h.finalize()
+  })
+})
+
 // ─── Class A — instant (<2s, NO tools) ───────────────────────────────────
 //
 // TODO(#553-PR-2): un-skip after instant-draft placeholder removal +
@@ -221,9 +295,9 @@ describe.skip('v2 spec — Class A (instant, <2s, no tools)', () => {
 // ─── Class B — short (2–60s, tools, no sub-agents) ───────────────────────
 //
 // TODO(#553-PR-2): un-skip the no-placeholder + answer-text bits.
-// TODO(#553-PR-4): un-skip "no progress card" once the card gate
-// changes from "elapsed > initialDelayMs OR tool-count threshold" to
-// "elapsed >= 60s OR sub-agent appeared".
+// PR 4 (shipped): the "no progress card" assertion is exercised by the
+// PR-4-specific describe block above; the skipped variant here remains
+// pending PR 5 cleanup of the rest of the block.
 // TODO(#553-PR-5): ladder integrity is final-state RED only after PR 5
 // removes the placeholder fallback that currently masks the regression.
 describe.skip('v2 spec — Class B (short, 2–60s, tools, no sub-agents)', () => {
@@ -320,8 +394,9 @@ describe.skip('v2 spec — Class B (short, 2–60s, tools, no sub-agents)', () =
 
 // ─── Class C — long-running (>60s OR sub-agents/background workers) ───────
 //
-// TODO(#553-PR-4): un-skip the card-gate tests once the gate is
-// `(elapsed >= 60s) OR (sub-agent appeared)`.
+// PR 4 (shipped): card-gate tests are exercised by the PR-4-specific
+// describe block above; the skipped variants here remain pending PR 5
+// (no-placeholder, sub-agent count) cleanup.
 // TODO(#553-PR-5): un-skip the no-placeholder + sub-agent count tests.
 describe.skip('v2 spec — Class C (long-running OR sub-agents)', () => {
   it('progress card appears when a sub-agent dispatches (regardless of elapsed time)', async () => {

--- a/telegram-plugin/tests/waiting-ux-harness.ts
+++ b/telegram-plugin/tests/waiting-ux-harness.ts
@@ -285,7 +285,7 @@ export function createWaitingUxHarness(opts: CreateHarnessOpts = {}): HarnessHan
     },
     coalesceMs: opts.driverCoalesceMs ?? 400,
     minIntervalMs: opts.driverMinIntervalMs ?? 500,
-    initialDelayMs: opts.driverInitialDelayMs ?? 30000,
+    initialDelayMs: opts.driverInitialDelayMs ?? 60000,
     heartbeatMs: opts.driverHeartbeatMs,
   })
 


### PR DESCRIPTION
## Summary

PR 4 of the #553 waiting-UX series. Rewrites the progress-card visibility gate to the v2 contract codified in `telegram-plugin/docs/waiting-ux-spec.md`:

> **`(elapsed >= 60s) OR (any sub-agent has appeared)`** — tools alone never trigger the card.

Class A and Class B turns never see a card. Class C turns see it the moment a sub-agent spawns or 60s passes.

## Default changes (`progress-card-driver.ts`)

| Field | Before | After | Notes |
| --- | --- | --- | --- |
| `initialDelayMs` | `30_000` | `60_000` | Pushes the time-based gate to the spec value. |
| `promoteAfterMs` | `5_000` | `0` (disabled) | `ensureTimePromoteScheduled` no-ops when `<= 0`. PR #570 was a stop-gap when `initialDelayMs` was 30s; with the new 60s and the sub-agent promote intact, time-based promotion is no longer needed. |
| `promoteOnParentToolCount` | `3` | `0` (disabled) | Tool-count check now treats `0` and `Infinity` as "never promote on tool count". |
| `promoteOnSubAgent` | `true` | `true` (unchanged) | Sub-agents/background workers still break suppression immediately. |

## Tests un-skipped (PR 4 spec assertions)

A new `v2 spec — PR 4: card gate (>=60s) OR (sub-agent appeared)` describe block in `tests/real-gateway-spec.test.ts` runs the three card-gate assertions extracted from the still-`describe.skip`'d Class B / Class C blocks (which await PR 5):

- Class B — `emits NO progress card (turn under 60s, no sub-agents)`
- Class C — `progress card appears when a sub-agent dispatches (regardless of elapsed time)`
- Class C — `progress card appears when elapsed >= 60s even without a sub-agent`

Once PR 5 lands and un-skips the parent describes, these duplicates can be folded back in.

## Existing tests updated

- **`tests/real-gateway-f3-late-card.test.ts` — F3 reframe.** Under v1, F3 was a bug: long-single-tool / two-tool turns rendered the card late (or not at all). PR #570's 5s time-promote fixed it. Under v2, **F3's symptom is by design** — tool-only turns never show the card. The two F3 tests now assert `progressCardSendMs(...) toBeNull()`. The instant-reply regression guard is preserved verbatim. The file header was rewritten to spell out the spec change.
- **`tests/real-gateway-f4-interim-text.test.ts`** — refactored to drive a Class C (sub-agent) turn so the card actually renders and the F4 preamble-refresh contract can still be exercised end-to-end.
- **`tests/progress-card-driver.test.ts`** — comment update on the cusp-race forceCompleteTurn test to reflect that `promoteAfterMs=0` is now the default rather than the explicit-disable test override.
- **`tests/waiting-ux-harness.ts`** — bumped the harness `driverInitialDelayMs` default from 30000 → 60000 to match production.

## Spec doc

`telegram-plugin/docs/waiting-ux-spec.md` PR-roadmap table now carries a Status column (PRs 2-4 shipped, PR 5 pending) plus a "PR 4 status" paragraph documenting the default changes and the F3 reframe.

## Honest note on the F3 reframe

PR #570's 5-second time-promote was the right fix for the v1 contract (where the card had to appear early on long single-tool turns). Under v2, that exact behaviour is now wrong — the spec says tools alone never trigger the card. Rather than soft-deprecate the timer, we disable it (`promoteAfterMs=0`) and update F3's tests to assert the new contract. The F3 file header is honest about the reframe: what was a bug is now spec.

## Test plan

- [x] `npm run lint` clean
- [x] `(cd telegram-plugin && bun test)` — 3129 pass / 0 fail / 15 skip
- [x] `npx vitest run` — 4560 pass / 6 pre-existing cron-* failures unrelated to this change (also fail on clean upstream/main)
- [x] F1 (ladder integrity) and F2 (instant draft) regression tests still green

🤖 Generated with [Claude Code](https://claude.com/claude-code)