### PR TITLE
revert: restore 14 placeholder-related files accidentally deleted by #589

### DIFF
--- a/telegram-plugin/forum-topic-placeholder.ts
+++ b/telegram-plugin/forum-topic-placeholder.ts
@@ -1,0 +1,138 @@
+/**
+ * Forum-topic placeholder lifecycle (issue #479 forum-topic case).
+ *
+ * Background: the pre-alloc-draft path (`pre-alloc-decision.ts` + the
+ * `sendMessageDraftFn` block in `gateway.ts`) gives DMs and non-forum
+ * groups a `🔵 thinking` placeholder visible within ~1s of inbound.
+ * Forum topics are excluded because Telegram's `sendMessageDraft` API
+ * doesn't accept `message_thread_id` — the draft would land at the
+ * topic-zero level, not in the actual topic the user is in.
+ *
+ * For forum topics we substitute a regular `sendMessage` with the
+ * thread_id, tracked here so we can delete it on turn_end. The UX is:
+ *
+ *   t=0   user sends inbound
+ *   t≈1s  `🔵 thinking` appears in the topic
+ *   t≈Ns  agent's first stream_reply lands as a separate message —
+ *         BOTH are briefly visible (no edit-in-place yet)
+ *   t≈N+1s turn_end → placeholder is deleted, only the agent's reply
+ *         remains
+ *
+ * The brief overlap (placeholder + reply visible simultaneously between
+ * stream_reply arrival and turn_end) is the documented compromise vs.
+ * the cleaner draft-based UX. Edit-in-place is a future enhancement
+ * (would require teaching the stream_reply path to consume an existing
+ * message instead of always sending a new one).
+ *
+ * State is module-local (one gateway process owns its placeholders).
+ * Keyed on `chat:thread` so a single forum chat with multiple active
+ * topics tracks each independently.
+ */
+
+/**
+ * Minimal Bot-API surface needed for the placeholder lifecycle. Tests
+ * inject a mock; production uses grammy's `bot.api`.
+ */
+export interface ForumTopicPlaceholderApi {
+  sendMessage: (
+    chatId: number | string,
+    text: string,
+    opts?: { message_thread_id?: number | string },
+  ) => Promise<{ message_id: number }>
+  deleteMessage: (chatId: number | string, messageId: number) => Promise<unknown>
+}
+
+interface PlaceholderEntry {
+  messageId: number
+  allocatedAt: number
+}
+
+const placeholders = new Map<string, PlaceholderEntry>()
+
+/**
+ * Map key for a forum-topic placeholder.
+ *
+ * `chat_id` alone is not enough because one forum chat can have
+ * multiple active topics — each gets its own placeholder. Joining
+ * with a separator that can't appear in either id keeps the namespace
+ * collision-free for any plausible Telegram id.
+ */
+export function forumTopicPlaceholderKey(
+  chatId: number | string,
+  threadId: number | string,
+): string {
+  return `${String(chatId)}::${String(threadId)}`
+}
+
+/**
+ * Send a placeholder message into a forum topic and track it for
+ * later cleanup. Returns the new message_id, or null if the API call
+ * failed (placeholder is best-effort — never blocks the turn).
+ *
+ * If a placeholder for this (chat, thread) already exists, the
+ * existing one is left in place and `null` is returned. Idempotent
+ * within a turn; the caller's "should we send?" gate (e.g. a fresh
+ * inbound message gate) is the dedupe authority.
+ */
+export async function sendForumTopicPlaceholder(
+  api: ForumTopicPlaceholderApi,
+  chatId: number | string,
+  threadId: number | string,
+  opts: { now?: () => number; placeholderText?: string } = {},
+): Promise<number | null> {
+  const key = forumTopicPlaceholderKey(chatId, threadId)
+  if (placeholders.has(key)) return null
+
+  const now = opts.now ?? Date.now
+  const text = opts.placeholderText ?? '🔵 thinking'
+  try {
+    const sent = await api.sendMessage(chatId, text, { message_thread_id: threadId })
+    placeholders.set(key, { messageId: sent.message_id, allocatedAt: now() })
+    return sent.message_id
+  } catch {
+    // Best-effort. Caller doesn't need to know — the placeholder UX
+    // degrades gracefully: the user just doesn't get a placeholder,
+    // same as today's pre-fix forum-topic behaviour.
+    return null
+  }
+}
+
+/**
+ * Delete the placeholder for (chat, thread) if one exists. No-op if
+ * none was tracked. Always clears the map entry (whether or not the
+ * delete succeeds) so a flaky network can't leave stale state.
+ */
+export async function clearForumTopicPlaceholder(
+  api: ForumTopicPlaceholderApi,
+  chatId: number | string,
+  threadId: number | string,
+): Promise<void> {
+  const key = forumTopicPlaceholderKey(chatId, threadId)
+  const entry = placeholders.get(key)
+  if (entry == null) return
+  placeholders.delete(key)
+  try {
+    await api.deleteMessage(chatId, entry.messageId)
+  } catch {
+    // Best-effort. The user might see a leftover placeholder if the
+    // delete fails — annoying but not actionable from this layer.
+  }
+}
+
+/**
+ * Test/inspection helper: snapshot of currently-tracked placeholders.
+ * Returns a fresh object so callers can't mutate internal state.
+ */
+export function getForumTopicPlaceholderState(): ReadonlyMap<string, PlaceholderEntry> {
+  return new Map(placeholders)
+}
+
+/**
+ * Test helper: clear all tracked state. Production code never calls
+ * this — placeholders are cleaned up via `clearForumTopicPlaceholder`
+ * on turn_end. Exposed for unit tests that want a clean slate
+ * between cases.
+ */
+export function _resetForumTopicPlaceholdersForTest(): void {
+  placeholders.clear()
+}

--- a/telegram-plugin/placeholder-heartbeat.ts
+++ b/telegram-plugin/placeholder-heartbeat.ts
@@ -1,0 +1,242 @@
+/**
+ * Placeholder heartbeat — keeps the user-visible draft message moving
+ * during the model's TTFT window so the chat never feels frozen.
+ *
+ * Design: docs/heartbeat-placeholder-design.md (§3 minimum shape).
+ * This module implements the zero-extractor version: a per-chat
+ * setTimeout chain that edits the placeholder draft every
+ * `intervalMs` with the elapsed wait time.
+ *
+ * Lives in its own module so the formatter + lifecycle logic is
+ * unit-testable without booting the gateway. The gateway-side wiring
+ * (start at pre-alloc success, cancel at all three preAllocatedDrafts
+ * delete sites) is in `gateway.ts`.
+ *
+ * Failure modes (specified in design §3.4):
+ * - sendMessageDraft errors are swallowed; next tick still fires
+ * - isPlaceholderActive returning false stops the chain immediately
+ * - maxDurationMs is a safety cap; default 5min, far longer than any
+ *   realistic turn
+ *
+ * §4 enrichment (label-map coordination, session-tail tool labels)
+ * is intentionally NOT in this module — that's a follow-up PR. The
+ * `getCurrentLabel` callback is included as a forward-compatible
+ * seam: §3 minimum passes a constant-returning function; §4 will
+ * pass a label-map reader.
+ */
+
+/** Default placeholder text when no enrichment source has set a label. */
+export const DEFAULT_HEARTBEAT_LABEL = '🔵 thinking'
+
+/** Max sane heartbeat duration. Beyond this we stop ticking — the turn
+ * is either genuinely runaway or something has wedged. The placeholder
+ * stays visible at its last text; user can re-send if needed. */
+export const DEFAULT_MAX_DURATION_MS = 5 * 60 * 1000  // 5 min
+
+/** Default tick interval. See §5.1 in the design doc for the
+ * Telegram-cap / perception / mobile-battery rationale. */
+export const DEFAULT_INTERVAL_MS = 5000
+
+/**
+ * Format an elapsed milliseconds value as a short human-readable string.
+ *
+ * Precision tiers from §3.2:
+ * - 0–9s:    1s precision   →  "5s", "9s"
+ * - 10–59s:  5s precision   →  "10s", "15s", "55s"
+ * - 1–9m:    minute precision → "1m", "1m 30s", "2m"
+ * - ≥10m:    minute-only     → "10m+"
+ *
+ * The 5s precision in the 10-59s window matches the heartbeat tick
+ * interval — every tick produces a different displayed value, so the
+ * visible change is always meaningful (not "incremented by 1 then 1
+ * then 1, hard to notice").
+ */
+export function formatElapsed(elapsedMs: number): string {
+  // Defensive: negative inputs (clock skew, test races) → "0s"
+  const seconds = Math.max(0, Math.floor(elapsedMs / 1000))
+  if (seconds < 10) return `${seconds}s`
+  if (seconds < 60) {
+    // Round to nearest 5s — matches tick cadence
+    const rounded = Math.round(seconds / 5) * 5
+    return `${rounded}s`
+  }
+  const totalMinutes = Math.floor(seconds / 60)
+  if (totalMinutes >= 10) return '10m+'
+  const remainderSec = Math.round((seconds - totalMinutes * 60) / 5) * 5
+  // Snap remainder up to a clean minute when it would round to 60
+  if (remainderSec >= 60) return `${totalMinutes + 1}m`
+  if (remainderSec === 0) return `${totalMinutes}m`
+  return `${totalMinutes}m ${remainderSec}s`
+}
+
+/**
+ * Compose the heartbeat placeholder text from a label + elapsed.
+ *
+ * Pattern: `${label} · ${elapsed}` — the middle dot is `·` (U+00B7),
+ * which renders cleanly across iOS/Android/desktop Telegram clients.
+ *
+ * If `label` already ends with a `·`-separated token (e.g. recall.py
+ * pushed `📚 recalling memories · 5s` somehow), don't double-append —
+ * strip the trailing token and re-render with the current elapsed.
+ * Mostly a defensive guard for the §4 enrichment path; in §3 minimum
+ * the label is always the constant DEFAULT_HEARTBEAT_LABEL.
+ */
+export function composeHeartbeatText(label: string | null, elapsedMs: number): string {
+  const baseLabel = (label ?? DEFAULT_HEARTBEAT_LABEL).trim()
+  // Strip any trailing ` · <something>` so we don't accumulate.
+  const stripped = baseLabel.replace(/\s*·\s*[^·]+$/, '').trimEnd()
+  // If stripping removed everything (label was JUST an elapsed string),
+  // fall back to the default.
+  const cleanLabel = stripped.length > 0 ? stripped : DEFAULT_HEARTBEAT_LABEL
+  return `${cleanLabel} · ${formatElapsed(elapsedMs)}`
+}
+
+/**
+ * Dependencies the heartbeat needs. Every external interaction is
+ * injected so the module can be tested without booting the gateway.
+ */
+export interface HeartbeatDeps {
+  /** Bound `sendMessageDraft` for this gateway instance. Same shape
+   * as gateway.ts's `sendMessageDraftFn`. */
+  sendMessageDraft: (chatId: string, draftId: number, text: string) => Promise<unknown>
+  /** Returns true while the placeholder draft for this chat is still
+   * the bridge's responsibility — i.e. while
+   * `preAllocatedDrafts.has(chatId)` is true in the gateway. The
+   * heartbeat exits cleanly the first time this returns false. */
+  isPlaceholderActive: (chatId: string) => boolean
+  /** Returns the current label text for this chat, or null to use
+   * `DEFAULT_HEARTBEAT_LABEL`. In §3 minimum this always returns null;
+   * §4 enrichment swaps in a label-map reader. */
+  getCurrentLabel: (chatId: string) => string | null
+  /** Tick interval. See §5.1. */
+  intervalMs: number
+  /** Safety cap. See `DEFAULT_MAX_DURATION_MS`. */
+  maxDurationMs: number
+  /** Optional logger; when omitted, no diagnostic lines are written.
+   * Production gateway passes `(msg) => process.stderr.write(...)`. */
+  log?: (msg: string) => void
+}
+
+/** Returned from `startHeartbeat`. The cancel function is idempotent. */
+export interface HeartbeatHandle {
+  cancel: () => void
+}
+
+/**
+ * Start a heartbeat for a placeholder draft. Returns a handle whose
+ * `cancel()` stops the next pending tick.
+ *
+ * The first tick fires at `+intervalMs` (NOT immediately) because the
+ * placeholder text was just written by pre-alloc and showing
+ * `🔵 thinking · 0s` would be redundant. By T+intervalMs the user has
+ * been waiting long enough for an elapsed counter to be informative.
+ *
+ * `cancel()` clears any scheduled tick; idempotent (safe to call
+ * multiple times).
+ */
+export function startHeartbeat(
+  chatId: string,
+  draftId: number,
+  startedAt: number,
+  deps: HeartbeatDeps,
+): HeartbeatHandle {
+  const { sendMessageDraft, isPlaceholderActive, getCurrentLabel, intervalMs, maxDurationMs, log } = deps
+
+  // intervalMs = 0 is the operator opt-out signal (see §5 + §10.1
+  // rollback plan). Return a no-op handle so the caller doesn't
+  // have to special-case it.
+  if (intervalMs <= 0) {
+    log?.(`telegram gateway: heartbeat disabled chatId=${chatId} (intervalMs=${intervalMs})`)
+    return { cancel: () => {} }
+  }
+
+  let timer: ReturnType<typeof setTimeout> | null = null
+  let cancelled = false
+  // Dedup state — last text we actually emitted to sendMessageDraft.
+  // null on first tick; subsequent ticks compare composed text against
+  // this and skip the API call when unchanged. See dedup branch below.
+  let lastEmittedText: string | null = null
+
+  const tick = (): void => {
+    if (cancelled) return
+    const elapsedMs = Date.now() - startedAt
+
+    // Safety cap: stop ticking after maxDurationMs even if the
+    // placeholder is somehow still active. Protects against runaway
+    // turns and any bug that prevents normal cancel.
+    if (elapsedMs >= maxDurationMs) {
+      log?.(`telegram gateway: heartbeat max-duration reached chatId=${chatId} elapsedMs=${elapsedMs}`)
+      cancelled = true
+      timer = null
+      return
+    }
+
+    // Honour the placeholder lifecycle: if the gateway already
+    // consumed/deleted the draft, stop now without making another
+    // edit (which would either fail or revive a closed message).
+    if (!isPlaceholderActive(chatId)) {
+      log?.(`telegram gateway: heartbeat stopped chatId=${chatId} reason=placeholder-inactive`)
+      cancelled = true
+      timer = null
+      return
+    }
+
+    const label = getCurrentLabel(chatId)
+    const text = composeHeartbeatText(label, elapsedMs)
+
+    // Dedup: skip the API call when the new text equals the last
+    // emitted text for this heartbeat. Defends against operator
+    // intervals that don't align with formatElapsed precision tiers
+    // (e.g. 2s ticks land 2-3× in the same 5s bucket and produce
+    // the same text). Telegram would respond "message not modified"
+    // which is wasted bandwidth + log noise. Stays correct under §4
+    // enrichment because label changes produce different text.
+    if (text === lastEmittedText) {
+      log?.(`telegram gateway: heartbeat tick chatId=${chatId} text="${text}" (deduped — no edit)`)
+      if (!cancelled) {
+        timer = setTimeout(tick, intervalMs)
+      }
+      return
+    }
+
+    lastEmittedText = text
+
+    // Diagnostic: log every tick so operators can confirm the
+    // heartbeat is firing without resorting to inspecting Telegram.
+    // Cheap (one stderr line per ~5s per active chat).
+    log?.(`telegram gateway: heartbeat tick chatId=${chatId} text="${text}"`)
+
+    // Fire-and-forget. Errors (rate limit, deleted message, etc.)
+    // are swallowed by design — next tick will either succeed or
+    // exit on the isPlaceholderActive check.
+    void sendMessageDraft(chatId, draftId, text).catch((err: unknown) => {
+      log?.(
+        `telegram gateway: heartbeat edit failed chatId=${chatId} draftId=${draftId}: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      )
+    })
+
+    // Schedule next tick if we're still alive.
+    if (!cancelled) {
+      timer = setTimeout(tick, intervalMs)
+    }
+  }
+
+  // First tick fires at +intervalMs. Pre-alloc text is fresh; no
+  // immediate edit needed.
+  timer = setTimeout(tick, intervalMs)
+  log?.(`telegram gateway: heartbeat started chatId=${chatId} draftId=${draftId} intervalMs=${intervalMs}`)
+
+  return {
+    cancel: () => {
+      if (cancelled) return
+      cancelled = true
+      if (timer != null) {
+        clearTimeout(timer)
+        timer = null
+      }
+      log?.(`telegram gateway: heartbeat cancelled chatId=${chatId}`)
+    },
+  }
+}

--- a/telegram-plugin/placeholder-phase.ts
+++ b/telegram-plugin/placeholder-phase.ts
@@ -1,0 +1,249 @@
+/**
+ * Placeholder phases — outcome-focused labels for what the agent is
+ * doing, expressed in language non-technical users understand.
+ *
+ * Design: docs/heartbeat-phases-design.md.
+ *
+ * The user perceives a sequence of phases during the model's TTFT
+ * window:
+ *
+ *   T+~500ms  🔵 thinking                                   (pre-alloc)
+ *   T+~1s     🔵 Got your message, working on it…           (auto-ack)
+ *   T+~1s     📚 Looking through what we've talked about    (recall)
+ *   T+~7s     💭 Thinking it through · 7s                   (post-recall)
+ *   T+~12s    🔍 Looking something up · 12s                 (file read)
+ *   T+~18s    🤖 Asking a specialist for help · 18s         (sub-agent)
+ *   T+~25s    ✍️ Writing your reply · 25s                  (model writes)
+ *
+ * No technical jargon — `🔍 Looking something up` not `Read X` or
+ * `grep`. `🤖 Asking a specialist` not `Agent(subagent_type='Explore')`.
+ *
+ * This module is pure: maps tool names + Bash command strings to
+ * phases. Wiring (subscribers, gateway state) lives in `gateway.ts`.
+ */
+
+export type PhaseKind =
+  | 'acknowledged'
+  | 'recalling'
+  | 'thinking'
+  | 'looking_up'
+  | 'checking'
+  | 'working'
+  | 'asking_specialist'
+  | 'writing_reply'
+
+export interface Phase {
+  /** Stable identifier — use for state map keys, telemetry, tests. */
+  kind: PhaseKind
+  /** User-facing text. Includes the leading emoji. Never technical. */
+  label: string
+}
+
+/**
+ * Canonical phase labels. Single source of truth for the user-facing
+ * text. Updating these updates everywhere they're rendered.
+ */
+export const PHASES: Record<PhaseKind, Phase> = {
+  acknowledged: {
+    kind: 'acknowledged',
+    label: '🔵 Got your message, working on it…',
+  },
+  recalling: {
+    kind: 'recalling',
+    label: "📚 Looking through what we've talked about",
+  },
+  thinking: {
+    kind: 'thinking',
+    label: '💭 Thinking it through',
+  },
+  looking_up: {
+    kind: 'looking_up',
+    label: '🔍 Looking something up',
+  },
+  checking: {
+    kind: 'checking',
+    label: '⚙️ Checking on something',
+  },
+  working: {
+    kind: 'working',
+    label: '✏️ Making changes',
+  },
+  asking_specialist: {
+    kind: 'asking_specialist',
+    label: '🤖 Asking a specialist for help',
+  },
+  writing_reply: {
+    kind: 'writing_reply',
+    label: '✍️ Writing your reply',
+  },
+}
+
+/**
+ * Lookup table — built-in tools we've seen + their phase mapping.
+ * Unknown tools (anything not here) produce no phase change; the
+ * current phase persists. See §3.1 phase rule 5.
+ */
+const TOOL_PHASE_MAP: Record<string, PhaseKind | 'no_change'> = {
+  // Looking things up — passive read activity
+  Read: 'looking_up',
+  Grep: 'looking_up',
+  Glob: 'looking_up',
+  WebFetch: 'looking_up',
+  WebSearch: 'looking_up',
+
+  // Making changes — active write activity
+  Edit: 'working',
+  Write: 'working',
+  NotebookEdit: 'working',
+
+  // Specialist dispatch
+  Task: 'asking_specialist',
+  Agent: 'asking_specialist',
+
+  // Telegram surface tools — model is about to write a reply
+  reply: 'writing_reply',
+  stream_reply: 'writing_reply',
+
+  // MCP tools that don't warrant a phase change (cosmetic / ambient)
+  react: 'no_change',
+  send_typing: 'no_change',
+  edit_message: 'no_change',
+  delete_message: 'no_change',
+  forward_message: 'no_change',
+  pin_message: 'no_change',
+  download_attachment: 'no_change',
+  get_recent_messages: 'no_change',
+
+  // TodoWrite, AskUserQuestion etc. — agent self-organisation, not
+  // user-relevant
+  TodoWrite: 'no_change',
+  AskUserQuestion: 'no_change',
+
+  // Bash is handled separately via toolUseToPhase; not in this map
+}
+
+/**
+ * Read-only Bash heuristic — strict starts-with on the FIRST word
+ * of the command (or on `git <subcommand>` for git's read-only ops).
+ *
+ * False negatives (calling `working` when actually read-only) are
+ * SAFER than false positives (calling `checking` when actually
+ * destructive). Keep narrow.
+ */
+const READ_ONLY_FIRST_WORD = new Set([
+  'ls',
+  'cat',
+  'pwd',
+  'which',
+  'head',
+  'tail',
+  'wc',
+  'du',
+  'ps',
+  'df',
+  'echo',
+  'printenv',
+  'env',
+  'stat',
+  'file',
+  'whoami',
+  'date',
+])
+
+const READ_ONLY_GIT_SUBCOMMANDS = new Set([
+  'status',
+  'log',
+  'diff',
+  'show',
+  'branch',
+  'remote',
+  'config',
+  'rev-parse',
+  'describe',
+  'blame',
+])
+
+/**
+ * Decide whether a Bash command is read-only. Examines the FIRST
+ * shell command in the string (treats `|` and `&&` as separators
+ * — classifies on the first command only).
+ */
+export function isReadOnlyBashCommand(command: string): boolean {
+  const trimmed = command.trim()
+  if (trimmed.length === 0) return false
+
+  // Take the first command only — split on pipes / && / ;
+  const firstCmd = trimmed.split(/[|&;]/)[0]?.trim() ?? ''
+  if (firstCmd.length === 0) return false
+
+  // First word
+  const parts = firstCmd.split(/\s+/)
+  const firstWord = parts[0] ?? ''
+
+  if (READ_ONLY_FIRST_WORD.has(firstWord)) return true
+
+  // git <subcommand> — only if subcommand is in the read-only set
+  if (firstWord === 'git' && parts.length >= 2) {
+    return READ_ONLY_GIT_SUBCOMMANDS.has(parts[1] ?? '')
+  }
+
+  return false
+}
+
+/**
+ * Map a tool_use event to a phase change. Returns:
+ *   - `Phase` — the new phase (caller writes it to currentPhase map)
+ *   - `null` — no phase change (current phase persists)
+ *
+ * Bash splits into `checking` (read-only) vs `working` (everything
+ * else). Other tools follow the static lookup table.
+ *
+ * Unknown tools return null (current phase persists). This is the
+ * default — we don't speculate about tools we haven't catalogued.
+ */
+export function toolUseToPhase(
+  toolName: string,
+  input?: Record<string, unknown>,
+): Phase | null {
+  // Bash special case
+  if (toolName === 'Bash') {
+    const command = typeof input?.command === 'string' ? input.command : ''
+    return isReadOnlyBashCommand(command) ? PHASES.checking : PHASES.working
+  }
+
+  // MCP tools come through with `mcp__server__tool` naming; strip
+  // the prefix to match the unqualified name in the lookup.
+  const unqualified = toolName.startsWith('mcp__')
+    ? (toolName.split('__').pop() ?? toolName)
+    : toolName
+
+  const mapped = TOOL_PHASE_MAP[unqualified]
+  if (mapped === 'no_change' || mapped === undefined) return null
+  return PHASES[mapped]
+}
+
+/**
+ * Resolve recall.py's existing literal text to a phase, for
+ * backward-compat with the current `update_placeholder` IPC contract.
+ * recall.py emits these strings today — we map them to canonical
+ * phases without requiring a coordinated change.
+ *
+ * Returns the phase if the text matches a known recall transition,
+ * or null if it's a custom literal label that should pass through
+ * unchanged. (See `update-placeholder-handler.ts` for the fall-through
+ * behavior.)
+ */
+export function recallTextToPhase(text: string): Phase | null {
+  const normalized = text.trim()
+
+  // recall.py PR #496 dropped trailing ellipsis but check both shapes
+  // for forward+backward compat:
+  if (normalized === '📚 recalling memories' || normalized === '📚 recalling memories…') {
+    return PHASES.recalling
+  }
+  if (normalized === '💭 thinking' || normalized === '💭 thinking…') {
+    return PHASES.thinking
+  }
+
+  return null
+}

--- a/telegram-plugin/pre-alloc-decision.ts
+++ b/telegram-plugin/pre-alloc-decision.ts
@@ -1,0 +1,83 @@
+/**
+ * Pre-allocate-draft decision logic for inbound messages.
+ *
+ * Lives in its own module (separate from gateway.ts) so the contract
+ * can be unit-tested without booting the gateway. The gateway-side
+ * call site at `gateway.ts` (search for `decideShouldPreAlloc`) wraps
+ * this with the actual `sendMessageDraft` call.
+ *
+ * Decision history:
+ * - #416 — original pre-alloc, DM-only (was `isDmChatId(chat_id)`)
+ * - #479 / PR #491 — drop the DM-only gate so groups also get the
+ *   `🔵 thinking` placeholder. Forum topics still excluded because
+ *   `sendMessageDraft` doesn't accept `message_thread_id` on the same
+ *   path; that needs a separate non-draft fallback (tracked separately).
+ *
+ * The pre-alloc placeholder is the user's first signal that the agent
+ * heard them — a draft message appears in the chat within ~1s, the
+ * client renders an animated "typing" indicator, and the message text
+ * (`🔵 thinking`) is meaningful rather than three dots.
+ */
+
+export interface PreAllocDecisionInput {
+  /**
+   * Whether `sendMessageDraft` is available on this gateway. Comes
+   * from the boot probe at gateway.ts (set to non-null when the API
+   * binding is present, null when grammy/Bot API doesn't expose it).
+   */
+  sendMessageDraftAvailable: boolean
+  /**
+   * The Telegram `message_thread_id` from the inbound message, or
+   * null/undefined when the chat isn't a forum topic. Forum topics
+   * are explicitly excluded from pre-alloc because `sendMessageDraft`
+   * doesn't accept `message_thread_id`.
+   */
+  messageThreadId: number | string | null | undefined
+  /**
+   * Whether a pre-allocated draft already exists for this chat (i.e.
+   * an earlier turn's pre-alloc hasn't been consumed yet). When true,
+   * skip — we don't want to leak draft ids.
+   */
+  alreadyHasDraft: boolean
+}
+
+export type PreAllocDecision =
+  | { allocate: true }
+  | { allocate: false; reason: 'no-draft-api' | 'forum-topic' | 'already-allocated' }
+
+/**
+ * Decide whether to pre-allocate a draft for this inbound message.
+ *
+ * Returns `{ allocate: true }` when all three guards pass: the API is
+ * available, the chat isn't a forum topic, and we don't already have
+ * a draft outstanding. Returns `{ allocate: false, reason }` on the
+ * three drop branches so callers + tests can introspect why a
+ * particular drop happened.
+ *
+ * Notably, this returns `allocate: true` for both DMs and group chats
+ * — that's the post-#479 behaviour. Pre-#479 the function would have
+ * also returned false when `chat_id` was negative (group). After the
+ * fix, group chats get the same placeholder UX as DMs.
+ */
+export function decideShouldPreAlloc(input: PreAllocDecisionInput): PreAllocDecision {
+  if (!input.sendMessageDraftAvailable) {
+    return { allocate: false, reason: 'no-draft-api' }
+  }
+  if (input.messageThreadId != null && input.messageThreadId !== '') {
+    return { allocate: false, reason: 'forum-topic' }
+  }
+  if (input.alreadyHasDraft) {
+    return { allocate: false, reason: 'already-allocated' }
+  }
+  return { allocate: true }
+}
+
+/**
+ * The placeholder text the gateway writes to the pre-allocated draft.
+ *
+ * No trailing ellipsis: the draft transport already animates a
+ * "typing" indicator on the user's Telegram client, so a `…` after
+ * the word stacks redundant visual noise. Test fixture `tests/
+ * placeholder-text.test.ts` pins this.
+ */
+export const PRE_ALLOC_PLACEHOLDER_TEXT = '🔵 thinking'

--- a/telegram-plugin/tests/forum-topic-placeholder.test.ts
+++ b/telegram-plugin/tests/forum-topic-placeholder.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Unit tests for forum-topic-placeholder.ts (issue #479).
+ *
+ * The forum-topic placeholder is the substitute for sendMessageDraft
+ * (which can't target message_thread_id). We send a regular message
+ * with thread_id on inbound, track it, then delete on turn_end.
+ *
+ * These tests focus on the lifecycle contract: send + track, dedupe
+ * within a (chat, thread), clear by deleting and dropping the entry,
+ * and graceful degradation when the API errors.
+ */
+
+import { describe, it, expect, beforeEach } from 'bun:test'
+import {
+  sendForumTopicPlaceholder,
+  clearForumTopicPlaceholder,
+  forumTopicPlaceholderKey,
+  getForumTopicPlaceholderState,
+  _resetForumTopicPlaceholdersForTest,
+  type ForumTopicPlaceholderApi,
+} from '../forum-topic-placeholder.js'
+
+beforeEach(() => {
+  _resetForumTopicPlaceholdersForTest()
+})
+
+function makeApi(opts: {
+  sendShouldThrow?: boolean
+  deleteShouldThrow?: boolean
+} = {}): { api: ForumTopicPlaceholderApi; calls: { sent: unknown[]; deleted: unknown[] } } {
+  const calls = { sent: [] as unknown[], deleted: [] as unknown[] }
+  let nextMessageId = 100
+  const api: ForumTopicPlaceholderApi = {
+    sendMessage: async (chatId, text, msgOpts) => {
+      calls.sent.push({ chatId, text, msgOpts })
+      if (opts.sendShouldThrow) throw new Error('boom')
+      return { message_id: nextMessageId++ }
+    },
+    deleteMessage: async (chatId, messageId) => {
+      calls.deleted.push({ chatId, messageId })
+      if (opts.deleteShouldThrow) throw new Error('boom')
+      return undefined
+    },
+  }
+  return { api, calls }
+}
+
+describe('forumTopicPlaceholderKey', () => {
+  it('namespaces (chat, thread) so different topics in the same chat are independent', () => {
+    const k1 = forumTopicPlaceholderKey('chat-A', 1)
+    const k2 = forumTopicPlaceholderKey('chat-A', 2)
+    const k3 = forumTopicPlaceholderKey('chat-B', 1)
+    expect(k1).not.toBe(k2)
+    expect(k1).not.toBe(k3)
+    expect(k2).not.toBe(k3)
+  })
+
+  it('handles numeric and string ids consistently', () => {
+    expect(forumTopicPlaceholderKey(123, 456)).toBe('123::456')
+    expect(forumTopicPlaceholderKey('123', '456')).toBe('123::456')
+  })
+})
+
+describe('sendForumTopicPlaceholder', () => {
+  it('sends with message_thread_id and tracks the resulting messageId', async () => {
+    const { api, calls } = makeApi()
+    const mid = await sendForumTopicPlaceholder(api, 'chat-1', 42)
+    expect(mid).toBe(100)
+    expect(calls.sent).toHaveLength(1)
+    expect(calls.sent[0]).toEqual({
+      chatId: 'chat-1',
+      text: '🔵 thinking',
+      msgOpts: { message_thread_id: 42 },
+    })
+    const state = getForumTopicPlaceholderState()
+    expect(state.size).toBe(1)
+    expect(state.get(forumTopicPlaceholderKey('chat-1', 42))?.messageId).toBe(100)
+  })
+
+  it('returns null and skips a second send for the same (chat, thread)', async () => {
+    const { api, calls } = makeApi()
+    const first = await sendForumTopicPlaceholder(api, 'chat-1', 42)
+    expect(first).toBe(100)
+    const second = await sendForumTopicPlaceholder(api, 'chat-1', 42)
+    expect(second).toBeNull()
+    expect(calls.sent).toHaveLength(1)
+  })
+
+  it('allows independent placeholders in different topics of the same chat', async () => {
+    const { api } = makeApi()
+    await sendForumTopicPlaceholder(api, 'chat-1', 1)
+    await sendForumTopicPlaceholder(api, 'chat-1', 2)
+    const state = getForumTopicPlaceholderState()
+    expect(state.size).toBe(2)
+  })
+
+  it('returns null and tracks nothing when the API throws (best-effort)', async () => {
+    const { api } = makeApi({ sendShouldThrow: true })
+    const mid = await sendForumTopicPlaceholder(api, 'chat-1', 42)
+    expect(mid).toBeNull()
+    expect(getForumTopicPlaceholderState().size).toBe(0)
+  })
+
+  it('respects a custom placeholderText override', async () => {
+    const { api, calls } = makeApi()
+    await sendForumTopicPlaceholder(api, 'c', 1, { placeholderText: '⏳ working' })
+    expect((calls.sent[0] as { text: string }).text).toBe('⏳ working')
+  })
+})
+
+describe('clearForumTopicPlaceholder', () => {
+  it('deletes the tracked message and drops the map entry', async () => {
+    const { api, calls } = makeApi()
+    await sendForumTopicPlaceholder(api, 'chat-1', 42)
+    expect(getForumTopicPlaceholderState().size).toBe(1)
+    await clearForumTopicPlaceholder(api, 'chat-1', 42)
+    expect(calls.deleted).toEqual([{ chatId: 'chat-1', messageId: 100 }])
+    expect(getForumTopicPlaceholderState().size).toBe(0)
+  })
+
+  it('is a no-op when no placeholder is tracked for the (chat, thread)', async () => {
+    const { api, calls } = makeApi()
+    await clearForumTopicPlaceholder(api, 'chat-untracked', 99)
+    expect(calls.deleted).toHaveLength(0)
+  })
+
+  it('drops the map entry even when deleteMessage throws', async () => {
+    // Network flakes happen — the map must self-heal so a stuck entry
+    // doesn't block the next inbound's placeholder dedupe forever.
+    const { api } = makeApi({ deleteShouldThrow: true })
+    await sendForumTopicPlaceholder(api, 'chat-1', 42)
+    await clearForumTopicPlaceholder(api, 'chat-1', 42)
+    expect(getForumTopicPlaceholderState().size).toBe(0)
+  })
+
+  it('only clears the targeted (chat, thread) — sibling topics in the same chat are untouched', async () => {
+    const { api } = makeApi()
+    await sendForumTopicPlaceholder(api, 'chat-1', 1)
+    await sendForumTopicPlaceholder(api, 'chat-1', 2)
+    await clearForumTopicPlaceholder(api, 'chat-1', 1)
+    const state = getForumTopicPlaceholderState()
+    expect(state.size).toBe(1)
+    expect(state.has(forumTopicPlaceholderKey('chat-1', 2))).toBe(true)
+  })
+})

--- a/telegram-plugin/tests/gateway-heartbeat-call-sites.test.ts
+++ b/telegram-plugin/tests/gateway-heartbeat-call-sites.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Architectural pin: every `preAllocatedDrafts.delete(chat_id)` call
+ * site in gateway.ts must be paired with `cancelPlaceholderHeartbeat(chat_id)`.
+ *
+ * If a future PR adds a fourth delete site without canceling the
+ * heartbeat, this test fails — and the failure message points at the
+ * exact pattern to follow.
+ *
+ * Counterpart pin: there's exactly ONE `startPlaceholderHeartbeat`
+ * call (at pre-alloc success). If a future PR adds another start
+ * site without coordinating with cancel logic, that's a leak — also
+ * caught here.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, resolve } from 'node:path'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const GATEWAY_SRC = readFileSync(
+  resolve(__dirname, '..', 'gateway', 'gateway.ts'),
+  'utf8',
+)
+
+describe('gateway heartbeat — start/cancel structural pairing', () => {
+  // Strip comments so we don't count examples in docstrings.
+  // Single-line `//` comments AND multi-line `/* ... */` blocks.
+  const codeOnly = GATEWAY_SRC
+    .replace(/\/\/.*/g, '')
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+
+  // Helper: count call sites, excluding the function definition itself
+  // (which matches `startPlaceholderHeartbeat(`/`cancelPlaceholderHeartbeat(`
+  // when preceded by `function `).
+  function countCallSites(needle: string): number {
+    const re = new RegExp(`(?<!function\\s)${needle}\\s*\\(`, 'g')
+    return (codeOnly.match(re) ?? []).length
+  }
+
+  it('counts: 1 startPlaceholderHeartbeat call site (only pre-alloc success)', () => {
+    // Strict equality — adding a second start site is a leak unless
+    // the corresponding cancel logic is also rethought.
+    expect(countCallSites('startPlaceholderHeartbeat')).toBe(1)
+  })
+
+  it('counts: cancelPlaceholderHeartbeat call count >= preAllocatedDrafts.delete count', () => {
+    // Every delete must be paired with a cancel. The "by 200 chars"
+    // proximity test (below) catches the per-site pairing — this
+    // count check catches a delete site that has no nearby cancel
+    // at all.
+    //
+    // Allowed extras: the start function itself defensively calls
+    // cancel before starting (in case a prior heartbeat is still
+    // running). That's not a "delete" pairing — it's safety.
+    // So `cancelCount >= deleteCount` is the right bar, with a
+    // tolerance budget of 1-2 for defensive cancels.
+    const cancelCallCount = countCallSites('cancelPlaceholderHeartbeat')
+    const deleteCallCount = (codeOnly.match(/preAllocatedDrafts\.delete\s*\(/g) ?? []).length
+
+    expect(cancelCallCount).toBeGreaterThanOrEqual(deleteCallCount)
+    expect(cancelCallCount - deleteCallCount).toBeLessThanOrEqual(3)
+    // Sanity: there ARE delete sites today. After #472 #9 introduced the
+    // consume-mark pattern, the count dropped from 3 to 2 (turn_end orphan +
+    // catch-path); two former delete sites now mark `consumed = true`
+    // instead, paired with cancel.
+    expect(deleteCallCount).toBeGreaterThanOrEqual(2)
+  })
+
+  it('every preAllocatedDrafts.delete is followed by cancelPlaceholderHeartbeat within 300 chars (success/turn-end paths only)', () => {
+    // Stronger pin: not just count match, but proximity. The cancel
+    // must be on the next line or a couple lines later — not buried
+    // 50 lines away in a different function.
+    //
+    // Exception: the pre-alloc API .catch() path deletes the entry on
+    // sendMessageDraft failure. Heartbeat hasn't been STARTED on the
+    // error path (start fires only inside the .then()), so there's
+    // nothing to cancel — pairing it would be a no-op. The marker
+    // string `pre-allocate draft failed` identifies this site.
+    const deleteIdxs: number[] = []
+    const re = /preAllocatedDrafts\.delete\s*\(/g
+    let match: RegExpExecArray | null
+    while ((match = re.exec(codeOnly)) != null) {
+      deleteIdxs.push(match.index)
+    }
+    expect(deleteIdxs.length).toBeGreaterThan(0)
+    for (const idx of deleteIdxs) {
+      const window = codeOnly.slice(idx, idx + 400)
+      const isCatchSite = /pre-allocate draft failed/.test(window)
+      if (isCatchSite) continue
+      expect(window).toMatch(/cancelPlaceholderHeartbeat\s*\(/)
+    }
+  })
+
+  it('startPlaceholderHeartbeat is called inside the pre-alloc success branch', () => {
+    // Sequencing: the start call must be inside the
+    // `void sendMessageDraftFn!(...).then(...)` block — i.e. fires
+    // only on successful pre-alloc, never on the error path. Anchor on
+    // the success-branch's success log line which is unique to that
+    // branch in the gateway code (#472 #8 changed the entry-set pattern
+    // to a synchronous pre-seed before the API call, so the old
+    // `.set(...)` anchor no longer marks the success branch).
+    const successBlock = codeOnly.indexOf('pre-allocate draft ok chatId=')
+    expect(successBlock).toBeGreaterThan(0)
+    const window = codeOnly.slice(successBlock, successBlock + 800)
+    expect(window).toMatch(/startPlaceholderHeartbeat\s*\(/)
+  })
+
+  it('imports the heartbeat helpers from the dedicated module', () => {
+    // Pins the module boundary — heartbeat logic lives in
+    // ../placeholder-heartbeat, NOT inlined into gateway.ts.
+    expect(GATEWAY_SRC).toMatch(/from ['"]\.\.\/placeholder-heartbeat\.js['"]/)
+  })
+
+  it('heartbeat config respects SWITCHROOM_TG_PLACEHOLDER_HEARTBEAT_MS env override', () => {
+    // Pins the rollback path from §10.1 — the env var must be honored.
+    expect(GATEWAY_SRC).toContain('SWITCHROOM_TG_PLACEHOLDER_HEARTBEAT_MS')
+  })
+
+  // ─── Path A §4 phase enrichment — additional structural pins ───
+
+  it('clearPhaseState is called near every preAllocatedDrafts.delete site (phase lifecycle)', () => {
+    // Each delete must clear the phase map + auto-ack timer for that
+    // chat. Same proximity rule as the heartbeat cancel pin.
+    // Skips the .catch site where neither heartbeat nor phase state
+    // was ever set up (the .then() never ran).
+    const deleteIdxs: number[] = []
+    const re = /preAllocatedDrafts\.delete\s*\(/g
+    let match: RegExpExecArray | null
+    while ((match = re.exec(codeOnly)) != null) {
+      deleteIdxs.push(match.index)
+    }
+    expect(deleteIdxs.length).toBeGreaterThan(0)
+    for (const idx of deleteIdxs) {
+      const window = codeOnly.slice(idx, idx + 400)
+      const isCatchSite = /pre-allocate draft failed/.test(window)
+      if (isCatchSite) continue
+      expect(window).toMatch(/clearPhaseState\s*\(/)
+    }
+  })
+
+  it('imports the phase helpers from the dedicated module', () => {
+    expect(GATEWAY_SRC).toMatch(/from ['"]\.\.\/placeholder-phase\.js['"]/)
+  })
+
+  it('scheduleAutoAck fires from the pre-alloc success branch', () => {
+    // Auto-ack must be scheduled inside the success branch, not on
+    // the .catch path. Same anchor as startPlaceholderHeartbeat.
+    const successBlock = codeOnly.indexOf('pre-allocate draft ok chatId=')
+    expect(successBlock).toBeGreaterThan(0)
+    const window = codeOnly.slice(successBlock, successBlock + 800)
+    expect(window).toMatch(/scheduleAutoAck\s*\(/)
+  })
+
+  it('tool_use → phase: gateway calls toolUseToPhase in the session-event handler', () => {
+    expect(codeOnly).toMatch(/toolUseToPhase\s*\(/)
+    expect(codeOnly).toMatch(/setCurrentPhase\s*\(/)
+  })
+
+  it('update_placeholder handler maps recall.py text to phases', () => {
+    expect(codeOnly).toMatch(/recallTextToPhase\s*\(/)
+  })
+})

--- a/telegram-plugin/tests/ipc-server-validate-update-placeholder.test.ts
+++ b/telegram-plugin/tests/ipc-server-validate-update-placeholder.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Validation contract for `update_placeholder` IPC messages.
+ *
+ * The hook (recall.py / future others) sends a JSON line over the
+ * gateway socket; `validateClientMessage` is the gate before the
+ * gateway acts on it. Keeps the contract narrow so a rogue process on
+ * the same socket can't push arbitrary content into the user's
+ * Telegram draft.
+ *
+ * Companion to the operator_event validator tests
+ * (`ipc-server-validate-operator.test.ts`).
+ */
+
+import { describe, it, expect } from 'vitest'
+import { validateClientMessage } from '../gateway/ipc-server.js'
+
+function base() {
+  return {
+    type: 'update_placeholder' as const,
+    chatId: '8248703757',
+    text: '📚 recalling memories…',
+  }
+}
+
+describe('validateClientMessage — update_placeholder', () => {
+  it('accepts a well-formed DM message', () => {
+    expect(validateClientMessage(base())).toBe(true)
+  })
+
+  it('accepts negative chat ids (groups / channels)', () => {
+    expect(validateClientMessage({ ...base(), chatId: '-1001234567890' })).toBe(true)
+  })
+
+  it('rejects non-numeric chatIds', () => {
+    expect(validateClientMessage({ ...base(), chatId: 'not-a-number' })).toBe(false)
+    expect(validateClientMessage({ ...base(), chatId: '12abc' })).toBe(false)
+    expect(validateClientMessage({ ...base(), chatId: '12 34' })).toBe(false)
+    expect(validateClientMessage({ ...base(), chatId: '<script>' })).toBe(false)
+  })
+
+  it('rejects empty chatId', () => {
+    expect(validateClientMessage({ ...base(), chatId: '' })).toBe(false)
+  })
+
+  it('rejects oversized chatId (would imply a malformed sender)', () => {
+    expect(validateClientMessage({ ...base(), chatId: '1'.repeat(33) })).toBe(false)
+  })
+
+  it('requires chatId to be a string', () => {
+    expect(validateClientMessage({ ...base(), chatId: 123 })).toBe(false)
+    expect(validateClientMessage({ ...base(), chatId: null })).toBe(false)
+    const noChat = { ...base() } as Record<string, unknown>
+    delete noChat.chatId
+    expect(validateClientMessage(noChat)).toBe(false)
+  })
+
+  it('rejects empty text', () => {
+    expect(validateClientMessage({ ...base(), text: '' })).toBe(false)
+  })
+
+  it('caps text at 500 chars', () => {
+    expect(validateClientMessage({ ...base(), text: 'x'.repeat(500) })).toBe(true)
+    expect(validateClientMessage({ ...base(), text: 'x'.repeat(501) })).toBe(false)
+  })
+
+  it('requires text to be a string', () => {
+    expect(validateClientMessage({ ...base(), text: 42 })).toBe(false)
+    expect(validateClientMessage({ ...base(), text: null })).toBe(false)
+    const noText = { ...base() } as Record<string, unknown>
+    delete noText.text
+    expect(validateClientMessage(noText)).toBe(false)
+  })
+
+  it('rejects unknown type values', () => {
+    expect(validateClientMessage({ ...base(), type: 'something_else' })).toBe(false)
+  })
+})

--- a/telegram-plugin/tests/placeholder-heartbeat.test.ts
+++ b/telegram-plugin/tests/placeholder-heartbeat.test.ts
@@ -1,0 +1,361 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
+
+import {
+  startHeartbeat,
+  formatElapsed,
+  composeHeartbeatText,
+  DEFAULT_HEARTBEAT_LABEL,
+  DEFAULT_INTERVAL_MS,
+  DEFAULT_MAX_DURATION_MS,
+} from '../placeholder-heartbeat.js'
+
+/**
+ * Pure-function tests. Pin the §3.2 elapsed-time format boundaries
+ * and the §4.6 label-composition behaviour.
+ */
+describe('formatElapsed — §3.2 precision tiers', () => {
+  describe('0–9s window: 1s precision', () => {
+    it('formats 0 as "0s"', () => expect(formatElapsed(0)).toBe('0s'))
+    it('formats 1000 as "1s"', () => expect(formatElapsed(1000)).toBe('1s'))
+    it('formats 5000 as "5s"', () => expect(formatElapsed(5000)).toBe('5s'))
+    it('formats 9000 as "9s"', () => expect(formatElapsed(9000)).toBe('9s'))
+    it('floors sub-second remainders ("5.7s" → "5s")', () => {
+      expect(formatElapsed(5700)).toBe('5s')
+    })
+  })
+
+  describe('10–59s window: 5s precision (matches tick cadence)', () => {
+    it('rounds 10000 to "10s"', () => expect(formatElapsed(10000)).toBe('10s'))
+    it('rounds 12000 to "10s"', () => expect(formatElapsed(12000)).toBe('10s'))
+    it('rounds 13000 to "15s" (5s rounding bumps up)', () => {
+      expect(formatElapsed(13000)).toBe('15s')
+    })
+    it('rounds 17000 to "15s"', () => expect(formatElapsed(17000)).toBe('15s'))
+    it('rounds 55000 to "55s"', () => expect(formatElapsed(55000)).toBe('55s'))
+    it('rounds 57000 to "55s"', () => expect(formatElapsed(57000)).toBe('55s'))
+    it('rounds 58000 to "60s" — wait that rolls over to 1m', () => {
+      // 58s rounds to 60s, but our threshold is < 60s for the 5s window.
+      // The 1m+ branch handles this via Math.floor on totalMinutes.
+      // 58s → totalMinutes=0, branches into the 5s window → 60s.
+      // Document the boundary: anything >= 58s in the 5s window snaps
+      // to the next minute via the rounding rule.
+      // Spec lock: at exactly 58s we hit the second tier returning "60s"
+      // — which is technically a degenerate "0m" case. Verify what the
+      // function actually does here so we know.
+      const result = formatElapsed(58000)
+      expect(['60s', '1m']).toContain(result)
+    })
+  })
+
+  describe('1–9m window: minute precision', () => {
+    it('formats 60000 as "1m"', () => expect(formatElapsed(60000)).toBe('1m'))
+    it('formats 65000 as "1m 5s"', () => expect(formatElapsed(65000)).toBe('1m 5s'))
+    it('formats 90000 as "1m 30s"', () => expect(formatElapsed(90000)).toBe('1m 30s'))
+    it('formats 120000 as "2m"', () => expect(formatElapsed(120000)).toBe('2m'))
+    it('formats 540000 (9m) as "9m"', () => expect(formatElapsed(540000)).toBe('9m'))
+    it('snaps remainder up to the next minute when rounding crosses 60s', () => {
+      // 1m 58s → seconds=118, totalMinutes=1, remainderSec=58 → rounds
+      // to 60 → bumps minute to 2 → "2m"
+      expect(formatElapsed(118000)).toBe('2m')
+    })
+  })
+
+  describe('≥10m: minute-only ceiling', () => {
+    it('formats 600000 (10m) as "10m+"', () => expect(formatElapsed(600000)).toBe('10m+'))
+    it('formats 1000000 as "10m+"', () => expect(formatElapsed(1000000)).toBe('10m+'))
+    it('formats 1 hour as "10m+"', () => expect(formatElapsed(60 * 60 * 1000)).toBe('10m+'))
+  })
+
+  describe('defensive cases', () => {
+    it('treats negative input as 0s', () => {
+      // Clock skew or test races could produce negative elapsed.
+      expect(formatElapsed(-1000)).toBe('0s')
+    })
+    it('treats NaN as 0s without throwing', () => {
+      // Math.floor(NaN/1000) is NaN; Math.max(0, NaN) is NaN; we
+      // need to handle this defensively. If the function throws,
+      // the heartbeat tick crashes — bad. Document the behaviour.
+      // This test lets the implementation either return "0s" or
+      // crash; if it crashes, fix the implementation.
+      expect(() => formatElapsed(NaN)).not.toThrow()
+    })
+  })
+})
+
+describe('composeHeartbeatText — §4.6 label composition', () => {
+  it('uses default label when none provided', () => {
+    expect(composeHeartbeatText(null, 5000)).toBe(`${DEFAULT_HEARTBEAT_LABEL} · 5s`)
+  })
+
+  it('uses provided label as-is', () => {
+    expect(composeHeartbeatText('📚 recalling memories', 5000))
+      .toBe('📚 recalling memories · 5s')
+  })
+
+  it('strips a trailing elapsed token if the label already contains one', () => {
+    // Defensive guard: if recall.py somehow pushes a label that already
+    // includes ` · 3s`, don't double-append. Prevents the
+    // "📚 recalling memories · 3s · 8s" wart.
+    expect(composeHeartbeatText('📚 recalling memories · 3s', 8000))
+      .toBe('📚 recalling memories · 8s')
+  })
+
+  it('passes a single-token label through unchanged (strip only triggers on " · token" patterns)', () => {
+    // The strip regex (composeHeartbeatText) only fires when the label
+    // already contains ` · X` — guarding against double-elapsed
+    // appends. A label that's JUST an elapsed-shaped string ("5s") with
+    // no separator passes through verbatim. Different scenario.
+    expect(composeHeartbeatText('5s', 10000)).toBe('5s · 10s')
+  })
+
+  it('treats empty string the same as null', () => {
+    expect(composeHeartbeatText('', 5000)).toBe(`${DEFAULT_HEARTBEAT_LABEL} · 5s`)
+  })
+
+  it('uses · separator (U+00B7), not raw "..." or "."', () => {
+    // Pinning the exact separator character. iOS/Android/desktop
+    // Telegram all render U+00B7 cleanly; ASCII alternatives like
+    // "•" or "..." render inconsistently across clients.
+    const result = composeHeartbeatText(null, 5000)
+    expect(result).toContain(' · ')
+    expect(result).not.toContain(' . ')
+    expect(result).not.toContain(' ... ')
+  })
+})
+
+describe('startHeartbeat — §3 lifecycle (with fake timers)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  function makeDeps(overrides: Partial<Parameters<typeof startHeartbeat>[3]> = {}) {
+    const calls: Array<{ chatId: string; draftId: number; text: string; at: number }> = []
+    const sendMessageDraft = vi.fn(async (chatId: string, draftId: number, text: string) => {
+      calls.push({ chatId, draftId, text, at: Date.now() })
+      return true as const
+    })
+    return {
+      calls,
+      deps: {
+        sendMessageDraft,
+        isPlaceholderActive: vi.fn(() => true),
+        getCurrentLabel: vi.fn(() => null),
+        intervalMs: 5000,
+        maxDurationMs: 60_000,
+        log: undefined,
+        ...overrides,
+      },
+    }
+  }
+
+  it('first tick fires at +intervalMs (NOT immediately)', () => {
+    const { calls, deps } = makeDeps()
+    const startedAt = Date.now()
+    startHeartbeat('123', 99, startedAt, deps)
+
+    // Before the first tick: zero calls.
+    expect(calls.length).toBe(0)
+    // At intervalMs - 1: still zero.
+    vi.advanceTimersByTime(4999)
+    expect(calls.length).toBe(0)
+    // At intervalMs: first call.
+    vi.advanceTimersByTime(1)
+    expect(calls.length).toBe(1)
+    expect(calls[0]!.text).toBe(`${DEFAULT_HEARTBEAT_LABEL} · 5s`)
+  })
+
+  it('emits exactly N calls between t=0 and t=N*intervalMs', () => {
+    const { calls, deps } = makeDeps()
+    startHeartbeat('123', 99, Date.now(), deps)
+
+    vi.advanceTimersByTime(15000)  // 3 ticks at 5s interval
+
+    expect(calls.length).toBe(3)
+    expect(calls[0]!.text).toBe(`${DEFAULT_HEARTBEAT_LABEL} · 5s`)
+    expect(calls[1]!.text).toBe(`${DEFAULT_HEARTBEAT_LABEL} · 10s`)
+    expect(calls[2]!.text).toBe(`${DEFAULT_HEARTBEAT_LABEL} · 15s`)
+  })
+
+  it('stops when isPlaceholderActive returns false', () => {
+    let active = true
+    const { calls, deps } = makeDeps({
+      isPlaceholderActive: vi.fn(() => active),
+    })
+    startHeartbeat('123', 99, Date.now(), deps)
+
+    vi.advanceTimersByTime(5000)
+    expect(calls.length).toBe(1)
+
+    // Simulate placeholder consumption
+    active = false
+    vi.advanceTimersByTime(5000)
+    expect(calls.length).toBe(1)  // No second call — exited cleanly
+
+    vi.advanceTimersByTime(60000)  // Plenty of time
+    expect(calls.length).toBe(1)  // Still no further calls
+  })
+
+  it('respects maxDurationMs even if isPlaceholderActive stays true', () => {
+    const { calls, deps } = makeDeps({
+      maxDurationMs: 12_000,  // Stop after 12s, well before 60s
+    })
+    startHeartbeat('123', 99, Date.now(), deps)
+
+    vi.advanceTimersByTime(15000)
+    // 5s tick: yes (elapsed=5s < 12s cap)
+    // 10s tick: yes (elapsed=10s < 12s cap)
+    // 15s tick: NO (elapsed=15s >= 12s cap, exits without editing)
+    expect(calls.length).toBe(2)
+  })
+
+  it('cancel() prevents the next pending tick', () => {
+    const { calls, deps } = makeDeps()
+    const handle = startHeartbeat('123', 99, Date.now(), deps)
+
+    vi.advanceTimersByTime(5000)
+    expect(calls.length).toBe(1)
+
+    handle.cancel()
+
+    vi.advanceTimersByTime(60000)
+    expect(calls.length).toBe(1)  // No further ticks after cancel
+  })
+
+  it('cancel() is idempotent (safe to call multiple times)', () => {
+    const { deps } = makeDeps()
+    const handle = startHeartbeat('123', 99, Date.now(), deps)
+
+    expect(() => {
+      handle.cancel()
+      handle.cancel()
+      handle.cancel()
+    }).not.toThrow()
+  })
+
+  it('swallows sendMessageDraft errors and continues ticking', () => {
+    let attempts = 0
+    const sendMessageDraft = vi.fn(async (_chatId: string, _draftId: number, _text: string) => {
+      attempts++
+      if (attempts === 2) throw new Error('Bad Request: rate limited')
+      return true as const
+    })
+    const { deps } = makeDeps({
+      sendMessageDraft,
+    })
+
+    startHeartbeat('123', 99, Date.now(), deps)
+    vi.advanceTimersByTime(15000)
+
+    // 3 ticks fired; 2nd one's promise rejected, but next tick still scheduled
+    expect(attempts).toBe(3)
+  })
+
+  it('reads getCurrentLabel on each tick (label can change between ticks)', () => {
+    let currentLabel: string | null = null
+    const { calls, deps } = makeDeps({
+      getCurrentLabel: vi.fn(() => currentLabel),
+    })
+    startHeartbeat('123', 99, Date.now(), deps)
+
+    vi.advanceTimersByTime(5000)
+    expect(calls[0]!.text).toBe(`${DEFAULT_HEARTBEAT_LABEL} · 5s`)
+
+    // Simulate recall.py update_placeholder
+    currentLabel = '📚 recalling memories'
+    vi.advanceTimersByTime(5000)
+    expect(calls[1]!.text).toBe('📚 recalling memories · 10s')
+
+    // Simulate post-recall transition
+    currentLabel = '💭 thinking'
+    vi.advanceTimersByTime(5000)
+    expect(calls[2]!.text).toBe('💭 thinking · 15s')
+  })
+
+  it('intervalMs=0 returns a no-op handle (operator opt-out per §10.1)', () => {
+    const { calls, deps } = makeDeps({ intervalMs: 0 })
+    const handle = startHeartbeat('123', 99, Date.now(), deps)
+
+    vi.advanceTimersByTime(60000)
+    expect(calls.length).toBe(0)
+    expect(() => handle.cancel()).not.toThrow()
+  })
+
+  it('intervalMs negative returns a no-op handle (defensive)', () => {
+    const { calls, deps } = makeDeps({ intervalMs: -100 })
+    startHeartbeat('123', 99, Date.now(), deps)
+
+    vi.advanceTimersByTime(60000)
+    expect(calls.length).toBe(0)
+  })
+
+  it('exposes module defaults that match design doc §5', () => {
+    expect(DEFAULT_INTERVAL_MS).toBe(5000)
+    expect(DEFAULT_MAX_DURATION_MS).toBe(5 * 60 * 1000)
+    expect(DEFAULT_HEARTBEAT_LABEL).toBe('🔵 thinking')
+  })
+
+  describe('dedup — skip edit when text unchanged', () => {
+    it('dedups when 2s interval lands multiple ticks in the same 5s formatElapsed bucket', () => {
+      // Live-traffic finding: at intervalMs=2000, formatElapsed's 5s
+      // precision in the 10-59s window means consecutive ticks
+      // produce identical text ("· 10s", "· 10s", "· 15s"). Without
+      // dedup these become wasted Telegram editMessageText calls
+      // returning "message not modified". Pin the dedup so an operator
+      // tuning the interval doesn't rediscover the issue.
+      const { calls, deps } = makeDeps({ intervalMs: 2000 })
+      startHeartbeat('123', 99, Date.now(), deps)
+
+      vi.advanceTimersByTime(20000)
+      // Ticks fire at: 2s, 4s, 6s, 8s, 10s, 12s, 14s, 16s, 18s, 20s
+      // formatElapsed produces:
+      //   2s, 4s, 6s, 8s, 10s, 10s (12s rounds to 10), 15s, 15s, 20s, 20s
+      // Distinct: 2s, 4s, 6s, 8s, 10s, 15s, 20s = 7 unique texts
+      // Without dedup: 10 sendMessageDraft calls
+      // With dedup: 7 sendMessageDraft calls
+      expect(calls.length).toBe(7)
+      const texts = calls.map((c) => c.text)
+      expect(texts).toEqual([
+        `${DEFAULT_HEARTBEAT_LABEL} · 2s`,
+        `${DEFAULT_HEARTBEAT_LABEL} · 4s`,
+        `${DEFAULT_HEARTBEAT_LABEL} · 6s`,
+        `${DEFAULT_HEARTBEAT_LABEL} · 8s`,
+        `${DEFAULT_HEARTBEAT_LABEL} · 10s`,
+        `${DEFAULT_HEARTBEAT_LABEL} · 15s`,
+        `${DEFAULT_HEARTBEAT_LABEL} · 20s`,
+      ])
+    })
+
+    it('does NOT dedup when label changes mid-bucket (forward-compat with §4 enrichment)', () => {
+      // §4 enrichment: recall.py / session-tail change the label
+      // mid-tick. Even if the elapsed bucket is the same, a label
+      // change MUST emit because the visible text differs.
+      let currentLabel: string | null = null
+      const { calls, deps } = makeDeps({
+        intervalMs: 2000,
+        getCurrentLabel: vi.fn(() => currentLabel),
+      })
+      startHeartbeat('123', 99, Date.now(), deps)
+
+      vi.advanceTimersByTime(2000)
+      expect(calls[0]!.text).toBe(`${DEFAULT_HEARTBEAT_LABEL} · 2s`)
+
+      // Label changes — same bucket would normally dedup, but the
+      // text actually differs because of the new label.
+      currentLabel = '📚 recalling memories'
+      vi.advanceTimersByTime(2000)
+      expect(calls[1]!.text).toBe('📚 recalling memories · 4s')
+      expect(calls.length).toBe(2)
+    })
+
+    it('first tick always emits (no prior text to compare against)', () => {
+      const { calls, deps } = makeDeps({ intervalMs: 5000 })
+      startHeartbeat('123', 99, Date.now(), deps)
+      vi.advanceTimersByTime(5000)
+      expect(calls.length).toBe(1)
+    })
+  })
+})

--- a/telegram-plugin/tests/placeholder-phase.test.ts
+++ b/telegram-plugin/tests/placeholder-phase.test.ts
@@ -1,0 +1,271 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  PHASES,
+  toolUseToPhase,
+  isReadOnlyBashCommand,
+  recallTextToPhase,
+  type PhaseKind,
+} from '../placeholder-phase.js'
+
+describe('PHASES — canonical labels', () => {
+  it('exposes all 8 phases from the design doc', () => {
+    const expected: PhaseKind[] = [
+      'acknowledged',
+      'recalling',
+      'thinking',
+      'looking_up',
+      'checking',
+      'working',
+      'asking_specialist',
+      'writing_reply',
+    ]
+    expect(Object.keys(PHASES).sort()).toEqual(expected.sort())
+  })
+
+  it('every label starts with an emoji (visual cue) and contains no technical jargon', () => {
+    const technicalWords = [
+      'grep', 'CLAUDE.md', 'bash', 'Edit(',
+      'Read(', 'Task(', 'Agent(', 'Bash(',
+      'subagent_type', 'JSONL', 'API',
+      'mcp__', 'sendMessage', 'tool_use',
+    ]
+    for (const phase of Object.values(PHASES)) {
+      // Has a leading emoji-ish character (any non-ASCII letter)
+      expect(phase.label).toMatch(/^[^\x00-\x7F]/)
+      // No technical leakage
+      for (const tech of technicalWords) {
+        expect(phase.label).not.toContain(tech)
+      }
+    }
+  })
+
+  it('labels are short enough for Telegram + room for elapsed suffix', () => {
+    // Composed text is `${label} · ${elapsed}` — Telegram caps at
+    // 4096 chars but the placeholder should be much shorter for UX.
+    // Pin a soft cap so labels stay scannable.
+    for (const phase of Object.values(PHASES)) {
+      expect(phase.label.length).toBeLessThan(80)
+    }
+  })
+
+  it('every kind matches its key', () => {
+    for (const [key, phase] of Object.entries(PHASES)) {
+      expect(phase.kind).toBe(key)
+    }
+  })
+})
+
+describe('toolUseToPhase — built-in tool mapping', () => {
+  describe('looking_up phase', () => {
+    it('Read → looking_up', () => {
+      expect(toolUseToPhase('Read')?.kind).toBe('looking_up')
+    })
+    it('Grep → looking_up', () => {
+      expect(toolUseToPhase('Grep')?.kind).toBe('looking_up')
+    })
+    it('Glob → looking_up', () => {
+      expect(toolUseToPhase('Glob')?.kind).toBe('looking_up')
+    })
+    it('WebFetch → looking_up', () => {
+      expect(toolUseToPhase('WebFetch')?.kind).toBe('looking_up')
+    })
+    it('WebSearch → looking_up', () => {
+      expect(toolUseToPhase('WebSearch')?.kind).toBe('looking_up')
+    })
+  })
+
+  describe('working phase', () => {
+    it('Edit → working', () => {
+      expect(toolUseToPhase('Edit')?.kind).toBe('working')
+    })
+    it('Write → working', () => {
+      expect(toolUseToPhase('Write')?.kind).toBe('working')
+    })
+    it('NotebookEdit → working', () => {
+      expect(toolUseToPhase('NotebookEdit')?.kind).toBe('working')
+    })
+  })
+
+  describe('asking_specialist phase', () => {
+    it('Task → asking_specialist', () => {
+      expect(toolUseToPhase('Task')?.kind).toBe('asking_specialist')
+    })
+    it('Agent → asking_specialist', () => {
+      expect(toolUseToPhase('Agent')?.kind).toBe('asking_specialist')
+    })
+  })
+
+  describe('writing_reply phase', () => {
+    it('reply → writing_reply', () => {
+      expect(toolUseToPhase('reply')?.kind).toBe('writing_reply')
+    })
+    it('stream_reply → writing_reply', () => {
+      expect(toolUseToPhase('stream_reply')?.kind).toBe('writing_reply')
+    })
+  })
+
+  describe('no_change tools', () => {
+    it.each([
+      'react', 'send_typing', 'edit_message', 'delete_message',
+      'forward_message', 'pin_message', 'download_attachment',
+      'get_recent_messages', 'TodoWrite', 'AskUserQuestion',
+    ])('%s returns null (no phase change)', (name) => {
+      expect(toolUseToPhase(name)).toBeNull()
+    })
+  })
+
+  describe('unknown tools', () => {
+    it('returns null for tools not in the table', () => {
+      expect(toolUseToPhase('SomeRandomTool')).toBeNull()
+      expect(toolUseToPhase('CompletelyMadeUp')).toBeNull()
+    })
+    it('returns null for empty toolName', () => {
+      expect(toolUseToPhase('')).toBeNull()
+    })
+  })
+
+  describe('MCP-prefixed tools', () => {
+    it('strips mcp__server__ prefix and matches the unqualified name', () => {
+      // `mcp__switchroom-telegram__reply` should map the same as `reply`
+      expect(toolUseToPhase('mcp__switchroom-telegram__reply')?.kind)
+        .toBe('writing_reply')
+      expect(toolUseToPhase('mcp__hindsight__sync_retain')).toBeNull()
+    })
+  })
+})
+
+describe('isReadOnlyBashCommand', () => {
+  describe('read-only commands → true', () => {
+    it.each([
+      'ls',
+      'ls -la',
+      'cat README.md',
+      'pwd',
+      'which node',
+      'head -5 file.txt',
+      'tail -f log',
+      'echo hello',
+      'git status',
+      'git log --oneline -10',
+      'git diff HEAD',
+      'git show abc123',
+      'git branch -a',
+      'git remote -v',
+      'git config --list',
+      'wc -l *.ts',
+      'env',
+      'printenv PATH',
+      'whoami',
+      'date',
+    ])('"%s" is read-only', (cmd) => {
+      expect(isReadOnlyBashCommand(cmd)).toBe(true)
+    })
+
+    it('classifies pipelines starting with read-only as read-only', () => {
+      expect(isReadOnlyBashCommand('ls | grep ts')).toBe(true)
+      expect(isReadOnlyBashCommand('cat file.txt | head -5')).toBe(true)
+    })
+  })
+
+  describe('write/destructive commands → false', () => {
+    it.each([
+      'rm -rf /tmp/foo',
+      'cp src dst',
+      'mv old new',
+      'mkdir -p /foo',
+      'touch newfile',
+      'chmod +x script',
+      'npm install',
+      'bun test',
+      'git push',
+      'git commit -m "x"',
+      'git checkout main',
+      'git stash',
+      'git rebase',
+      'sed -i "s/foo/bar/" file',
+      'tee output',
+      'curl -X POST url',
+    ])('"%s" is NOT read-only', (cmd) => {
+      expect(isReadOnlyBashCommand(cmd)).toBe(false)
+    })
+
+    it('git stash / git push / git rebase are NOT read-only (despite git prefix)', () => {
+      expect(isReadOnlyBashCommand('git stash')).toBe(false)
+      expect(isReadOnlyBashCommand('git push origin main')).toBe(false)
+      expect(isReadOnlyBashCommand('git rebase upstream/main')).toBe(false)
+    })
+
+    it('classifies pipelines starting with write as write', () => {
+      // The whole pipeline is classified by the FIRST command —
+      // imperfect (pipe-into-write is rare but would misclassify) —
+      // safer to default to working.
+      expect(isReadOnlyBashCommand('rm file.txt')).toBe(false)
+      expect(isReadOnlyBashCommand('mv old new && echo done')).toBe(false)
+    })
+  })
+
+  describe('edge cases', () => {
+    it('empty command → false', () => {
+      expect(isReadOnlyBashCommand('')).toBe(false)
+      expect(isReadOnlyBashCommand('   ')).toBe(false)
+    })
+
+    it('only whitespace + pipe → false', () => {
+      expect(isReadOnlyBashCommand(' | ')).toBe(false)
+    })
+
+    it('git with no subcommand → false (defensive)', () => {
+      expect(isReadOnlyBashCommand('git')).toBe(false)
+    })
+  })
+})
+
+describe('toolUseToPhase — Bash branching', () => {
+  it('Bash with read-only command → checking', () => {
+    expect(toolUseToPhase('Bash', { command: 'ls -la' })?.kind).toBe('checking')
+    expect(toolUseToPhase('Bash', { command: 'git status' })?.kind).toBe('checking')
+  })
+
+  it('Bash with destructive command → working', () => {
+    expect(toolUseToPhase('Bash', { command: 'rm -rf /tmp/x' })?.kind).toBe('working')
+    expect(toolUseToPhase('Bash', { command: 'npm install' })?.kind).toBe('working')
+  })
+
+  it('Bash with no command (defensive) → working', () => {
+    // Missing input → assume worst case → working
+    expect(toolUseToPhase('Bash')?.kind).toBe('working')
+    expect(toolUseToPhase('Bash', {})?.kind).toBe('working')
+  })
+
+  it('Bash with non-string command (defensive) → working', () => {
+    expect(toolUseToPhase('Bash', { command: 42 })?.kind).toBe('working')
+    expect(toolUseToPhase('Bash', { command: null })?.kind).toBe('working')
+  })
+})
+
+describe('recallTextToPhase — backward compat with recall.py', () => {
+  it('maps current recall.py texts to phases', () => {
+    expect(recallTextToPhase('📚 recalling memories')?.kind).toBe('recalling')
+    expect(recallTextToPhase('💭 thinking')?.kind).toBe('thinking')
+  })
+
+  it('maps pre-#496 texts (with trailing ellipsis) too', () => {
+    expect(recallTextToPhase('📚 recalling memories…')?.kind).toBe('recalling')
+    expect(recallTextToPhase('💭 thinking…')?.kind).toBe('thinking')
+  })
+
+  it('returns null for unknown text (allows custom literals to pass through)', () => {
+    expect(recallTextToPhase('🤖 doing something custom')).toBeNull()
+    expect(recallTextToPhase('hello world')).toBeNull()
+  })
+
+  it('handles whitespace defensively', () => {
+    expect(recallTextToPhase('  📚 recalling memories  ')?.kind).toBe('recalling')
+  })
+
+  it('returns null for empty / whitespace-only', () => {
+    expect(recallTextToPhase('')).toBeNull()
+    expect(recallTextToPhase('   ')).toBeNull()
+  })
+})

--- a/telegram-plugin/tests/placeholder-text-no-ellipsis.test.ts
+++ b/telegram-plugin/tests/placeholder-text-no-ellipsis.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Architectural pin for PR #496 — placeholder text must not end with
+ * a trailing ellipsis (`…` or `...`). The draft transport already
+ * animates a "typing" indicator on the user's Telegram client; a
+ * trailing ellipsis stacks redundant visual noise.
+ *
+ * Three production strings are pinned here:
+ *   1. gateway.ts pre-alloc      — "🔵 thinking"
+ *   2. recall.py hook start      — "📚 recalling memories"
+ *   3. recall.py post-recall     — "💭 thinking"
+ *
+ * The pure unit tests for the gateway placeholder live in
+ * `pre-alloc-decision.test.ts` (the constant is exported from
+ * `pre-alloc-decision.ts`). This file pins the recall.py strings
+ * structurally so a future Python refactor can't quietly re-add
+ * the ellipsis.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, resolve } from 'node:path'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const REPO_ROOT = resolve(__dirname, '..', '..')
+const RECALL_PY = readFileSync(
+  resolve(REPO_ROOT, 'vendor', 'hindsight-memory', 'scripts', 'recall.py'),
+  'utf8',
+)
+const GATEWAY_TS = readFileSync(
+  resolve(REPO_ROOT, 'telegram-plugin', 'gateway', 'gateway.ts'),
+  'utf8',
+)
+
+describe('placeholder text — no trailing ellipsis (PR #496 regression guard)', () => {
+  describe('recall.py — Hindsight hook placeholders', () => {
+    it('hook-start placeholder is "📚 recalling memories" (no `…`)', () => {
+      // Locate the call: update_placeholder(placeholder_chat_id, "...")
+      // at the start of the recall hook.
+      expect(RECALL_PY).toContain('update_placeholder(placeholder_chat_id, "📚 recalling memories")')
+      expect(RECALL_PY).not.toContain('"📚 recalling memories…"')
+      expect(RECALL_PY).not.toContain('"📚 recalling…"')
+    })
+
+    it('post-recall placeholder is "💭 thinking" (no `…`)', () => {
+      // After Hindsight finishes, switch the placeholder so the user
+      // doesn't keep staring at "📚 recalling" during the model's TTFT.
+      expect(RECALL_PY).toContain('update_placeholder(placeholder_chat_id, "💭 thinking")')
+      expect(RECALL_PY).not.toContain('"💭 thinking…"')
+    })
+
+    it('no recall.py update_placeholder call ends with ellipsis', () => {
+      // Catch-all: any update_placeholder("X…") in recall.py is a
+      // regression of #496, regardless of what `X` is. Future
+      // additions of new placeholder transitions need to follow the
+      // no-trailing-ellipsis rule.
+      const ellipsisCalls = RECALL_PY.match(/update_placeholder\([^)]*…"\)/g) ?? []
+      expect(ellipsisCalls).toEqual([])
+    })
+  })
+
+  describe('gateway.ts — pre-alloc placeholder', () => {
+    it('does NOT contain a literal "🔵 thinking…" anywhere', () => {
+      // The gateway uses PRE_ALLOC_PLACEHOLDER_TEXT from
+      // pre-alloc-decision.ts; this pin guards against anyone
+      // sneaking a literal back in for "performance" or by accident.
+      // Comments are the one allowed place — they reference the
+      // historical pre-#496 value for context — so we only forbid
+      // the literal in code (not docstring/comment surfaces).
+      const codeOnly = GATEWAY_TS.replace(/\/\/.*/g, '').replace(/\/\*[\s\S]*?\*\//g, '')
+      expect(codeOnly).not.toContain("'🔵 thinking…'")
+      expect(codeOnly).not.toContain('"🔵 thinking…"')
+    })
+  })
+})

--- a/telegram-plugin/tests/pre-alloc-decision.test.ts
+++ b/telegram-plugin/tests/pre-alloc-decision.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  decideShouldPreAlloc,
+  PRE_ALLOC_PLACEHOLDER_TEXT,
+} from '../pre-alloc-decision.js'
+
+/**
+ * Pins the pre-allocate-draft decision contract that drives the
+ * `🔵 thinking` placeholder UX. The gateway-side wrapper at
+ * gateway.ts (search for `decideShouldPreAlloc`) adds the actual
+ * `sendMessageDraft` call; this file pins the decision, the
+ * placeholder text, and (most importantly) the post-#479 behaviour
+ * that group chats now get the placeholder too.
+ */
+describe('decideShouldPreAlloc', () => {
+  describe('allocate path', () => {
+    it('allocates for a private DM (positive chat id)', () => {
+      // The original (pre-#479) shape — DM, no thread, draft API up,
+      // no prior draft. Pinned here to make sure the post-#479
+      // refactor didn't accidentally break the original case.
+      expect(decideShouldPreAlloc({
+        sendMessageDraftAvailable: true,
+        messageThreadId: null,
+        alreadyHasDraft: false,
+      })).toEqual({ allocate: true })
+    })
+
+    it('allocates for a group chat (the #479 fix)', () => {
+      // The whole point of #479: groups should get the placeholder
+      // too. Pre-fix this returned false because of an
+      // `isDmChatId(chat_id)` gate that lived in the gateway. The
+      // gate is gone; now the only chat-shape gate is the forum
+      // topic guard below. The chat id itself doesn't enter the
+      // decision at all.
+      expect(decideShouldPreAlloc({
+        sendMessageDraftAvailable: true,
+        messageThreadId: null,
+        alreadyHasDraft: false,
+      })).toEqual({ allocate: true })
+    })
+
+    it('allocates regardless of chat-id sign — the helper is chat-id-agnostic', () => {
+      // Belt-and-braces: prove the decision doesn't sniff chat id at
+      // all. If a future PR re-adds an `isDmChatId(chat_id)` gate
+      // here it'll need a new input field, breaking this test.
+      // (The chat id isn't even passed in.)
+      const result = decideShouldPreAlloc({
+        sendMessageDraftAvailable: true,
+        messageThreadId: null,
+        alreadyHasDraft: false,
+      })
+      expect(result.allocate).toBe(true)
+    })
+  })
+
+  describe('drop branches', () => {
+    it('drops when sendMessageDraft API is unavailable', () => {
+      // The boot probe at gateway.ts can find sendMessageDraft is
+      // missing on some grammy/Bot API combinations. In that case
+      // pre-alloc is a no-op — the user gets the legacy "no
+      // placeholder" UX rather than a crash.
+      expect(decideShouldPreAlloc({
+        sendMessageDraftAvailable: false,
+        messageThreadId: null,
+        alreadyHasDraft: false,
+      })).toEqual({ allocate: false, reason: 'no-draft-api' })
+    })
+
+    it('drops for forum topics — sendMessageDraft does not accept message_thread_id', () => {
+      // Forum topics are the standard switchroom layout — but
+      // sendMessageDraft (the API) doesn't accept
+      // message_thread_id, so a draft sent into a forum-topic
+      // thread would land in the wrong place (the General topic of
+      // the supergroup). Until a thread-aware fallback path lands,
+      // we skip and the user falls back to typing-indicator-only.
+      expect(decideShouldPreAlloc({
+        sendMessageDraftAvailable: true,
+        messageThreadId: 42,
+        alreadyHasDraft: false,
+      })).toEqual({ allocate: false, reason: 'forum-topic' })
+    })
+
+    it('drops for forum topics with string message_thread_id (some grammy variants pass strings)', () => {
+      expect(decideShouldPreAlloc({
+        sendMessageDraftAvailable: true,
+        messageThreadId: '42',
+        alreadyHasDraft: false,
+      })).toEqual({ allocate: false, reason: 'forum-topic' })
+    })
+
+    it('treats empty-string messageThreadId as "no thread" (not forum topic)', () => {
+      // Defensive: some upstream paths normalise undefined → ""
+      // rather than null. Treat empty as "no thread set".
+      expect(decideShouldPreAlloc({
+        sendMessageDraftAvailable: true,
+        messageThreadId: '',
+        alreadyHasDraft: false,
+      })).toEqual({ allocate: true })
+    })
+
+    it('drops when a draft is already pre-allocated for this chat (avoid leaking ids)', () => {
+      // The gateway's pre-allocated map carries an entry until the
+      // draft is consumed (by reply/stream_reply) or cleared (by
+      // turn_end). Re-allocating before that would orphan the prior
+      // draft. The decision returns a recognisable reason so the
+      // gateway log can be specific.
+      expect(decideShouldPreAlloc({
+        sendMessageDraftAvailable: true,
+        messageThreadId: null,
+        alreadyHasDraft: true,
+      })).toEqual({ allocate: false, reason: 'already-allocated' })
+    })
+  })
+
+  describe('drop ordering (cascade)', () => {
+    it('no-draft-api wins over forum-topic', () => {
+      expect(decideShouldPreAlloc({
+        sendMessageDraftAvailable: false,
+        messageThreadId: 42,
+        alreadyHasDraft: false,
+      })).toEqual({ allocate: false, reason: 'no-draft-api' })
+    })
+
+    it('forum-topic wins over already-allocated', () => {
+      expect(decideShouldPreAlloc({
+        sendMessageDraftAvailable: true,
+        messageThreadId: 42,
+        alreadyHasDraft: true,
+      })).toEqual({ allocate: false, reason: 'forum-topic' })
+    })
+  })
+})
+
+describe('PRE_ALLOC_PLACEHOLDER_TEXT', () => {
+  it('is the meaningful "🔵 thinking" string (not bare ellipsis)', () => {
+    // Pre-#469 the placeholder was `…` — three dots that read as
+    // "still loading the message" instead of "agent is working".
+    // The post-#469 placeholder text is meaningful prose with the
+    // 🔵 emoji as a "I'm working" signal.
+    expect(PRE_ALLOC_PLACEHOLDER_TEXT).toBe('🔵 thinking')
+  })
+
+  it('does NOT have a trailing ellipsis (PR #496)', () => {
+    // The draft transport renders an animated "typing" indicator on
+    // the user's Telegram client for the lifetime of the draft. With
+    // the animation already signalling "in progress," a `…` after
+    // the word stacks redundant visual noise. PR #496 dropped the
+    // trailing ellipsis from all three placeholder strings:
+    //   - 🔵 thinking            (gateway pre-alloc)
+    //   - 📚 recalling memories  (recall.py hook start)
+    //   - 💭 thinking            (recall.py post-recall)
+    // This pin guards the regression. If a future PR re-adds a `…`
+    // to the gateway placeholder, the test fails loudly.
+    expect(PRE_ALLOC_PLACEHOLDER_TEXT.endsWith('…')).toBe(false)
+    expect(PRE_ALLOC_PLACEHOLDER_TEXT.endsWith('...')).toBe(false)
+  })
+
+  it('starts with the 🔵 emoji (the visual cue users have learned)', () => {
+    expect(PRE_ALLOC_PLACEHOLDER_TEXT.startsWith('🔵')).toBe(true)
+  })
+})

--- a/telegram-plugin/tests/update-placeholder-handler.e2e.test.ts
+++ b/telegram-plugin/tests/update-placeholder-handler.e2e.test.ts
@@ -1,0 +1,278 @@
+/**
+ * E2E behavioural tests for the `update_placeholder` IPC handler.
+ *
+ * Pins the contract that drives the user-visible placeholder
+ * transitions (`🔵 thinking` → `📚 recalling memories` → `💭 thinking`
+ * → final reply). The pure-decision logic for "should we pre-allocate
+ * a draft at all" is tested separately in `pre-alloc-decision.test.ts`;
+ * this file tests the side-effecting "we have a draft, edit it now"
+ * path.
+ *
+ * Uses a hand-mocked `sendMessageDraftFn` rather than fake-bot-api
+ * because `sendMessageDraft` isn't part of grammy's standard API
+ * (it's a recent Bot API addition we expose via raw call). The
+ * mock matches the function signature the gateway uses in production.
+ *
+ * See HARNESS.md for general harness usage; this file demonstrates
+ * the "test an extracted handler against a mocked external API" pattern.
+ */
+
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+  handleUpdatePlaceholder,
+  PLACEHOLDER_TEXT_MAX_LEN,
+  type PreAllocatedDraftEntry,
+  type UpdatePlaceholderOutcome,
+} from '../update-placeholder-handler.js'
+
+function makeDraftFn() {
+  return vi.fn(async (_chatId: string, _draftId: number, _text: string): Promise<unknown> => true)
+}
+
+function preAllocMap(entries: Record<string, PreAllocatedDraftEntry> = {}): Map<string, PreAllocatedDraftEntry> {
+  return new Map(Object.entries(entries))
+}
+
+describe('handleUpdatePlaceholder — happy path', () => {
+  it('edits the pre-allocated draft when chatId has one', () => {
+    const sendMessageDraftFn = makeDraftFn()
+    const preAllocatedDrafts = preAllocMap({
+      '12345': { draftId: 99, allocatedAt: 1000 },
+    })
+    const result = handleUpdatePlaceholder({
+      msg: { chatId: '12345', text: '📚 recalling memories' },
+      sendMessageDraftFn,
+      preAllocatedDrafts,
+    })
+
+    expect(result).toEqual({
+      kind: 'edited',
+      chatId: '12345',
+      draftId: 99,
+      text: '📚 recalling memories',
+    })
+
+    // Confirm the underlying API call landed with the right args.
+    // No await — handler returns synchronously and dispatches the
+    // promise without blocking.
+    expect(sendMessageDraftFn).toHaveBeenCalledTimes(1)
+    expect(sendMessageDraftFn).toHaveBeenCalledWith('12345', 99, '📚 recalling memories')
+  })
+
+  it('handles the second transition in the recall.py sequence (📚 → 💭)', () => {
+    // The real recall.py flow does two updates in succession:
+    //   1. update_placeholder(chat, "📚 recalling memories")  [hook start]
+    //   2. update_placeholder(chat, "💭 thinking")            [post-recall]
+    // Both targets the same draft id. Pin both transitions land.
+    const sendMessageDraftFn = makeDraftFn()
+    const preAllocatedDrafts = preAllocMap({
+      '12345': { draftId: 99, allocatedAt: 1000 },
+    })
+
+    handleUpdatePlaceholder({
+      msg: { chatId: '12345', text: '📚 recalling memories' },
+      sendMessageDraftFn,
+      preAllocatedDrafts,
+    })
+    handleUpdatePlaceholder({
+      msg: { chatId: '12345', text: '💭 thinking' },
+      sendMessageDraftFn,
+      preAllocatedDrafts,
+    })
+
+    expect(sendMessageDraftFn).toHaveBeenCalledTimes(2)
+    expect(sendMessageDraftFn.mock.calls[0]).toEqual(['12345', 99, '📚 recalling memories'])
+    expect(sendMessageDraftFn.mock.calls[1]).toEqual(['12345', 99, '💭 thinking'])
+  })
+
+  it('isolates by chatId — only the matching draft is edited', () => {
+    // Multi-chat gateway: the handler must edit ONLY the draft for
+    // the chatId in the message, not every draft in the map. Pin
+    // chat-isolation against an accidental "edit all drafts" bug.
+    const sendMessageDraftFn = makeDraftFn()
+    const preAllocatedDrafts = preAllocMap({
+      '11111': { draftId: 100, allocatedAt: 1000 },
+      '22222': { draftId: 200, allocatedAt: 2000 },
+      '33333': { draftId: 300, allocatedAt: 3000 },
+    })
+
+    handleUpdatePlaceholder({
+      msg: { chatId: '22222', text: '💭 thinking' },
+      sendMessageDraftFn,
+      preAllocatedDrafts,
+    })
+
+    expect(sendMessageDraftFn).toHaveBeenCalledTimes(1)
+    expect(sendMessageDraftFn).toHaveBeenCalledWith('22222', 200, '💭 thinking')
+  })
+})
+
+describe('handleUpdatePlaceholder — silent skip branches', () => {
+  it('skips silently when sendMessageDraftFn is null (API unavailable)', () => {
+    const preAllocatedDrafts = preAllocMap({
+      '12345': { draftId: 99, allocatedAt: 1000 },
+    })
+    const result = handleUpdatePlaceholder({
+      msg: { chatId: '12345', text: '📚 recalling memories' },
+      sendMessageDraftFn: null,
+      preAllocatedDrafts,
+    })
+    expect(result).toEqual({ kind: 'skipped', reason: 'no-draft-api' })
+  })
+
+  it('skips silently when no pre-alloc draft exists for this chat (forum topic, race)', () => {
+    // The pre-alloc decision drops forum topics (see
+    // pre-alloc-decision.test.ts). When recall.py later sends an
+    // update_placeholder for that chat, the handler must silently
+    // skip — no spurious API call, no thrown error.
+    const sendMessageDraftFn = makeDraftFn()
+    const preAllocatedDrafts = preAllocMap({
+      // chat 99999 has a draft, but the message targets chat 12345
+      '99999': { draftId: 100, allocatedAt: 1000 },
+    })
+    const result = handleUpdatePlaceholder({
+      msg: { chatId: '12345', text: '💭 thinking' },
+      sendMessageDraftFn,
+      preAllocatedDrafts,
+    })
+    expect(result).toEqual({ kind: 'skipped', reason: 'no-draft-for-chat' })
+    expect(sendMessageDraftFn).not.toHaveBeenCalled()
+  })
+
+  it('skips silently when text is empty', () => {
+    const sendMessageDraftFn = makeDraftFn()
+    const preAllocatedDrafts = preAllocMap({
+      '12345': { draftId: 99, allocatedAt: 1000 },
+    })
+    const result = handleUpdatePlaceholder({
+      msg: { chatId: '12345', text: '' },
+      sendMessageDraftFn,
+      preAllocatedDrafts,
+    })
+    expect(result).toEqual({ kind: 'skipped', reason: 'empty-text' })
+    expect(sendMessageDraftFn).not.toHaveBeenCalled()
+  })
+
+  it('skips silently when text is null/undefined coerced to empty string', () => {
+    const sendMessageDraftFn = makeDraftFn()
+    const preAllocatedDrafts = preAllocMap({
+      '12345': { draftId: 99, allocatedAt: 1000 },
+    })
+    const result = handleUpdatePlaceholder({
+      msg: { chatId: '12345', text: null as unknown as string },
+      sendMessageDraftFn,
+      preAllocatedDrafts,
+    })
+    expect(result).toEqual({ kind: 'skipped', reason: 'empty-text' })
+  })
+})
+
+describe('handleUpdatePlaceholder — text length cap', () => {
+  it(`caps text at ${PLACEHOLDER_TEXT_MAX_LEN} chars`, () => {
+    const sendMessageDraftFn = makeDraftFn()
+    const preAllocatedDrafts = preAllocMap({
+      '12345': { draftId: 99, allocatedAt: 1000 },
+    })
+    const longText = 'x'.repeat(PLACEHOLDER_TEXT_MAX_LEN + 100)
+    const result = handleUpdatePlaceholder({
+      msg: { chatId: '12345', text: longText },
+      sendMessageDraftFn,
+      preAllocatedDrafts,
+    })
+
+    if (result.kind !== 'edited') throw new Error(`expected edited, got ${result.kind}`)
+    expect(result.text.length).toBe(PLACEHOLDER_TEXT_MAX_LEN)
+    expect(sendMessageDraftFn).toHaveBeenCalledWith('12345', 99, 'x'.repeat(PLACEHOLDER_TEXT_MAX_LEN))
+  })
+
+  it('passes through text shorter than the cap unchanged', () => {
+    const sendMessageDraftFn = makeDraftFn()
+    const preAllocatedDrafts = preAllocMap({
+      '12345': { draftId: 99, allocatedAt: 1000 },
+    })
+    handleUpdatePlaceholder({
+      msg: { chatId: '12345', text: '💭 thinking' },
+      sendMessageDraftFn,
+      preAllocatedDrafts,
+    })
+    expect(sendMessageDraftFn).toHaveBeenCalledWith('12345', 99, '💭 thinking')
+  })
+})
+
+describe('handleUpdatePlaceholder — error handling', () => {
+  it('reports edit-failed via onResult callback when the API throws', async () => {
+    const failingDraftFn = vi.fn(async () => {
+      throw new Error('Bad Request: message to edit not found')
+    })
+    const preAllocatedDrafts = preAllocMap({
+      '12345': { draftId: 99, allocatedAt: 1000 },
+    })
+    const outcomes: UpdatePlaceholderOutcome[] = []
+
+    const result = handleUpdatePlaceholder(
+      {
+        msg: { chatId: '12345', text: '💭 thinking' },
+        sendMessageDraftFn: failingDraftFn,
+        preAllocatedDrafts,
+      },
+      (r) => outcomes.push(r),
+    )
+
+    // Synchronous outcome reports the intent.
+    expect(result.kind).toBe('edited')
+
+    // Drain microtasks so the .catch fires.
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    // onResult fired twice — once with intent, once with the
+    // settled failure. Tests + gateway both rely on this shape:
+    // gateway logs only on `edit-failed`.
+    expect(outcomes).toHaveLength(2)
+    expect(outcomes[0]!.kind).toBe('edited')
+    expect(outcomes[1]!.kind).toBe('edit-failed')
+    if (outcomes[1]!.kind === 'edit-failed') {
+      expect(outcomes[1]!.error.message).toMatch(/message to edit not found/)
+      expect(outcomes[1]!.chatId).toBe('12345')
+      expect(outcomes[1]!.draftId).toBe(99)
+    }
+  })
+
+  it('does NOT throw synchronously on API error (callers do not need try/catch)', () => {
+    const failingDraftFn = vi.fn(async () => {
+      throw new Error('Bad Request: message to edit not found')
+    })
+    const preAllocatedDrafts = preAllocMap({
+      '12345': { draftId: 99, allocatedAt: 1000 },
+    })
+
+    // Bare invocation must not throw — the gateway's IPC dispatch
+    // loop calls this synchronously and a sync throw would crash
+    // the loop.
+    expect(() => handleUpdatePlaceholder({
+      msg: { chatId: '12345', text: '💭 thinking' },
+      sendMessageDraftFn: failingDraftFn,
+      preAllocatedDrafts,
+    })).not.toThrow()
+  })
+
+  it('returns synchronously without awaiting the API call', () => {
+    // Pin the fire-and-forget contract: even with an
+    // infinitely-pending API call, the handler returns immediately.
+    const stuckDraftFn = vi.fn(() => new Promise(() => {})) // never resolves
+    const preAllocatedDrafts = preAllocMap({
+      '12345': { draftId: 99, allocatedAt: 1000 },
+    })
+
+    const start = Date.now()
+    const result = handleUpdatePlaceholder({
+      msg: { chatId: '12345', text: '💭 thinking' },
+      sendMessageDraftFn: stuckDraftFn,
+      preAllocatedDrafts,
+    })
+    const elapsed = Date.now() - start
+
+    expect(result.kind).toBe('edited')
+    expect(elapsed).toBeLessThan(50) // would be ~∞ if we awaited
+  })
+})

--- a/telegram-plugin/tests/update-placeholder-handler.test.ts
+++ b/telegram-plugin/tests/update-placeholder-handler.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Unit tests for handleUpdatePlaceholder — the pure handler that decides
+ * whether a hook's `update_placeholder` IPC fires an editMessageDraft or
+ * skips. Closes the race-condition class flagged in #472 findings #8 + #9.
+ *
+ * Three lifecycle states the handler must distinguish:
+ *   - apiPending=true: pre-alloc fired sendMessageDraft but it hasn't
+ *     resolved yet. Edit MUST proceed — Telegram serializes by draftId.
+ *   - consumed=true: executeReply / executeStreamReply has handed the
+ *     draft to the agent's reply path. Edit MUST bail.
+ *   - neither flag set: normal allocated entry. Edit proceeds.
+ */
+
+import { describe, expect, it } from 'bun:test'
+import {
+  handleUpdatePlaceholder,
+  type PreAllocatedDraftEntry,
+  type UpdatePlaceholderOutcome,
+} from '../update-placeholder-handler.js'
+
+interface DraftCall {
+  chatId: string
+  draftId: number
+  text: string
+}
+
+function makeFakeApi(throws = false) {
+  const calls: DraftCall[] = []
+  const api = (chatId: string, draftId: number, text: string): Promise<unknown> => {
+    calls.push({ chatId, draftId, text })
+    return throws ? Promise.reject(new Error('boom')) : Promise.resolve()
+  }
+  return { calls, api }
+}
+
+describe('handleUpdatePlaceholder lifecycle (#472 8/9)', () => {
+  it('proceeds when the entry is freshly allocated', () => {
+    const map = new Map<string, PreAllocatedDraftEntry>([
+      ['chat-1', { draftId: 7, allocatedAt: 1 }],
+    ])
+    const { calls, api } = makeFakeApi()
+    const result = handleUpdatePlaceholder({
+      msg: { chatId: 'chat-1', text: '📚 recalling' },
+      sendMessageDraftFn: api,
+      preAllocatedDrafts: map,
+    })
+    expect(result).toEqual({ kind: 'edited', chatId: 'chat-1', draftId: 7, text: '📚 recalling' })
+    expect(calls).toEqual([{ chatId: 'chat-1', draftId: 7, text: '📚 recalling' }])
+  })
+
+  it('proceeds even when apiPending=true (#472 finding #8 — closes the .then() race)', () => {
+    // The pre-alloc API call hasn't resolved yet — but the entry IS in
+    // the map (synchronous seed). Pre-fix this case used to silently no-op
+    // because the .then() set the entry only after API resolution.
+    const map = new Map<string, PreAllocatedDraftEntry>([
+      ['chat-1', { draftId: 7, allocatedAt: 1, apiPending: true }],
+    ])
+    const { calls, api } = makeFakeApi()
+    const result = handleUpdatePlaceholder({
+      msg: { chatId: 'chat-1', text: '🟦 thinking' },
+      sendMessageDraftFn: api,
+      preAllocatedDrafts: map,
+    })
+    expect(result.kind).toBe('edited')
+    // The edit lands at TG's server; if it arrives before the initial
+    // post the server queues it on the same draftId (this is the
+    // safety property we're relying on by going synchronous).
+    expect(calls).toHaveLength(1)
+  })
+
+  it('bails when consumed=true (#472 finding #9 — closes the consume/clear race)', () => {
+    // executeReply already took the draft. A racing update_placeholder
+    // must NOT edit — pre-fix the empty-text clear and the recalling
+    // edit raced on TG's server, leaving "📚 recalling" visible after
+    // the agent's reply landed.
+    const map = new Map<string, PreAllocatedDraftEntry>([
+      ['chat-1', { draftId: 7, allocatedAt: 1, consumed: true }],
+    ])
+    const { calls, api } = makeFakeApi()
+    const result = handleUpdatePlaceholder({
+      msg: { chatId: 'chat-1', text: '📚 recalling' },
+      sendMessageDraftFn: api,
+      preAllocatedDrafts: map,
+    })
+    expect(result).toEqual({ kind: 'skipped', reason: 'draft-consumed' })
+    expect(calls).toHaveLength(0)
+  })
+
+  it('still skips with no-draft-for-chat when the entry is missing', () => {
+    const map = new Map<string, PreAllocatedDraftEntry>()
+    const { calls, api } = makeFakeApi()
+    const result = handleUpdatePlaceholder({
+      msg: { chatId: 'chat-1', text: 'hi' },
+      sendMessageDraftFn: api,
+      preAllocatedDrafts: map,
+    })
+    expect(result).toEqual({ kind: 'skipped', reason: 'no-draft-for-chat' })
+    expect(calls).toHaveLength(0)
+  })
+
+  it('still skips with no-draft-api when sendMessageDraftFn is null', () => {
+    const map = new Map<string, PreAllocatedDraftEntry>([
+      ['chat-1', { draftId: 7, allocatedAt: 1 }],
+    ])
+    const result = handleUpdatePlaceholder({
+      msg: { chatId: 'chat-1', text: 'hi' },
+      sendMessageDraftFn: null,
+      preAllocatedDrafts: map,
+    })
+    expect(result).toEqual({ kind: 'skipped', reason: 'no-draft-api' })
+  })
+
+  it('still skips with empty-text when text is empty', () => {
+    const map = new Map<string, PreAllocatedDraftEntry>([
+      ['chat-1', { draftId: 7, allocatedAt: 1 }],
+    ])
+    const { calls, api } = makeFakeApi()
+    const result = handleUpdatePlaceholder({
+      msg: { chatId: 'chat-1', text: '' },
+      sendMessageDraftFn: api,
+      preAllocatedDrafts: map,
+    })
+    expect(result).toEqual({ kind: 'skipped', reason: 'empty-text' })
+    expect(calls).toHaveLength(0)
+  })
+
+  it('reports edit-failed via onResult when the API rejects', async () => {
+    const map = new Map<string, PreAllocatedDraftEntry>([
+      ['chat-1', { draftId: 7, allocatedAt: 1 }],
+    ])
+    const { api } = makeFakeApi(true)
+    const results: UpdatePlaceholderOutcome[] = []
+    handleUpdatePlaceholder(
+      {
+        msg: { chatId: 'chat-1', text: 'hi' },
+        sendMessageDraftFn: api,
+        preAllocatedDrafts: map,
+      },
+      (r) => results.push(r),
+    )
+    // First synchronous emit is `edited`; second async emit is `edit-failed`.
+    await new Promise((r) => setImmediate(r))
+    expect(results.length).toBe(2)
+    expect(results[0].kind).toBe('edited')
+    expect(results[1].kind).toBe('edit-failed')
+  })
+})

--- a/telegram-plugin/update-placeholder-handler.ts
+++ b/telegram-plugin/update-placeholder-handler.ts
@@ -1,0 +1,152 @@
+/**
+ * Pure handler for the `update_placeholder` IPC message.
+ *
+ * The bridge / hooks send `update_placeholder` over IPC so the gateway
+ * can edit the user's pre-allocated draft mid-turn — `🔵 thinking` →
+ * `📚 recalling memories` → `💭 thinking` → final reply, instead of a
+ * static placeholder for the entire model TTFT.
+ *
+ * Lives in its own module (separate from gateway.ts) so the
+ * behaviour is testable against `fake-bot-api.ts` without booting the
+ * full gateway. The gateway-side wrapper at `gateway.ts` (search for
+ * `handleUpdatePlaceholder`) does nothing but pass the closure-state
+ * dependencies in.
+ *
+ * Best-effort, silent on three legitimate misses:
+ *   1. No pre-alloc draft for this chat (forum topic, sendMessageDraft
+ *      API absent, pre-alloc API call still in flight).
+ *   2. Telegram API rejects the edit (rate limit, invalid text).
+ *   3. The draft was already consumed by reply / stream_reply.
+ */
+
+/** Sanity cap on placeholder text length (chars). Anything longer is
+ * almost certainly a misuse — the placeholder is meant to be a short
+ * status indicator, not a long-form message. */
+export const PLACEHOLDER_TEXT_MAX_LEN = 200
+
+/** Outcome enum for tests + observability. */
+export type UpdatePlaceholderOutcome =
+  | { kind: 'edited'; chatId: string; draftId: number; text: string }
+  | { kind: 'skipped'; reason: 'no-draft-api' | 'no-draft-for-chat' | 'empty-text' | 'draft-consumed' }
+  | { kind: 'edit-failed'; chatId: string; draftId: number; error: Error }
+
+/**
+ * Pre-allocated draft entry — same shape as gateway.ts's
+ * `preAllocatedDrafts` map values. Defined here so the test module
+ * doesn't have to import from gateway.ts.
+ */
+export interface PreAllocatedDraftEntry {
+  draftId: number
+  allocatedAt: number
+  /**
+   * Optional flag set by gateway.ts during the small window between
+   * allocateDraftId() and the sendMessageDraft API resolving. The
+   * handler treats apiPending entries as valid — Telegram serializes
+   * ops by draftId, so an edit racing the initial post is sequenced
+   * safely on the server side. Closes #472 finding #8.
+   */
+  apiPending?: boolean
+  /**
+   * Optional flag set by executeReply / executeStreamReply once the
+   * draft has been handed off to the agent's reply path. The handler
+   * MUST bail (kind: 'skipped', reason: 'draft-consumed') when set —
+   * otherwise a hook update_placeholder racing the consume can leave
+   * a stale "thinking" overlay visible alongside the agent's reply.
+   * Closes #472 finding #9.
+   */
+  consumed?: boolean
+}
+
+export interface UpdatePlaceholderInput {
+  /** The IPC message body. */
+  msg: { chatId: string; text: string }
+  /**
+   * The bound `sendMessageDraft` API call (or null when the API is
+   * unavailable on this gateway). Same value as `sendMessageDraftFn`
+   * in gateway.ts.
+   */
+  sendMessageDraftFn:
+    | ((chatId: string, draftId: number, text: string) => Promise<unknown>)
+    | null
+  /**
+   * The gateway's `preAllocatedDrafts` Map — passed by reference so
+   * the handler can look up by chatId. Mutated only by reads here;
+   * the gateway is the sole writer.
+   */
+  preAllocatedDrafts: Map<string, PreAllocatedDraftEntry>
+}
+
+/**
+ * Handle one `update_placeholder` IPC message. Returns a discriminated
+ * outcome; the gateway-side wrapper logs `edit-failed` to stderr.
+ *
+ * Returns synchronously with the decision; the actual `editMessageText`
+ * call is fired-and-forgotten via `void`. The promise's eventual
+ * outcome is delivered through the `onResult` callback if provided.
+ *
+ * The synchronous return shape is what makes this testable: the test
+ * can assert `{ kind: 'edited' }` immediately, then await
+ * `await Promise.resolve()` to settle the .then callback if it cares
+ * about the success/failure tail.
+ */
+export function handleUpdatePlaceholder(
+  input: UpdatePlaceholderInput,
+  onResult?: (result: UpdatePlaceholderOutcome) => void,
+): UpdatePlaceholderOutcome {
+  const { msg, sendMessageDraftFn, preAllocatedDrafts } = input
+
+  if (sendMessageDraftFn == null) {
+    const result: UpdatePlaceholderOutcome = { kind: 'skipped', reason: 'no-draft-api' }
+    onResult?.(result)
+    return result
+  }
+
+  const preAllocated = preAllocatedDrafts.get(msg.chatId)
+  if (preAllocated == null) {
+    const result: UpdatePlaceholderOutcome = { kind: 'skipped', reason: 'no-draft-for-chat' }
+    onResult?.(result)
+    return result
+  }
+
+  // Closes #472 finding #9 — the consume sites in gateway.ts mark the
+  // entry consumed instead of deleting it, precisely so this race-window
+  // can be detected. An update_placeholder edit landing AFTER the agent's
+  // reply has cleared the draft would resurrect "📚 recalling" text under
+  // the just-sent reply.
+  if (preAllocated.consumed === true) {
+    const result: UpdatePlaceholderOutcome = { kind: 'skipped', reason: 'draft-consumed' }
+    onResult?.(result)
+    return result
+  }
+
+  const text = String(msg.text ?? '').slice(0, PLACEHOLDER_TEXT_MAX_LEN)
+  if (text.length === 0) {
+    const result: UpdatePlaceholderOutcome = { kind: 'skipped', reason: 'empty-text' }
+    onResult?.(result)
+    return result
+  }
+
+  const editedResult: UpdatePlaceholderOutcome = {
+    kind: 'edited',
+    chatId: msg.chatId,
+    draftId: preAllocated.draftId,
+    text,
+  }
+
+  // Fire-and-forget the API call. `onResult` fires twice in the
+  // failure path: once with `edited` (intent), then with `edit-failed`
+  // (settled outcome). The gateway-side wrapper logs the failure to
+  // stderr; tests await the .catch to assert on it.
+  void sendMessageDraftFn(msg.chatId, preAllocated.draftId, text)
+    .catch((err: unknown) => {
+      onResult?.({
+        kind: 'edit-failed',
+        chatId: msg.chatId,
+        draftId: preAllocated.draftId,
+        error: err instanceof Error ? err : new Error(String(err)),
+      })
+    })
+
+  onResult?.(editedResult)
+  return editedResult
+}


### PR DESCRIPTION
## Why
PR #589 was meant to be a one-line CLAUDE.md size-budget bump (24k → 26k) for the merged #572 epic additions. **It also accidentally deleted 14 files.** My fork's main was stale relative to upstream when I branched, so the PR diff included the bump PLUS the inverse of every commit my fork had fallen behind on. The squash-merge shipped all of it.

## Files restored
All restored verbatim from `c3460dd` (the commit before #589):
- `telegram-plugin/forum-topic-placeholder.ts`
- `telegram-plugin/placeholder-heartbeat.ts`
- `telegram-plugin/placeholder-phase.ts`
- `telegram-plugin/pre-alloc-decision.ts`
- `telegram-plugin/update-placeholder-handler.ts`
- 9 corresponding `.test.ts` files

## What stays
The CLAUDE.md size-budget bump that #589 intended to ship is preserved on main — `tests/scaffold.persona.test.ts` still has the 26000-byte cap with the comment trail. Only the unintended deletions are reverted.

## Root cause + lessons
Operator-side discipline failure on my part:
1. Should have run `git fetch upstream main && git reset --hard upstream/main` BEFORE branching for the fix.
2. Should have run `gh pr view --json files` after creating the PR and BEFORE merging — would have shown 14 unexpected files.

Adding both as must-checks for future fix-forward PRs.

## Verification
- `npm run lint` clean.
- All 14 files present + restored to their pre-deletion content.

Targeted apology: this is exactly the kind of accidental destruction the safety rails are meant to prevent. Won't happen again.