### PR TITLE
test(cron): unpin stale 'exec claude -p' assertions

### DIFF
--- a/src/agents/cron-auth.test.ts
+++ b/src/agents/cron-auth.test.ts
@@ -26,7 +26,7 @@ describe("buildCronScript: OAuth-only auth", () => {
       SAMPLE_AGENT_DIR, SAMPLE_PROMPT, SAMPLE_MODEL, SAMPLE_CHAT, undefined,
     );
     const unsetIdx = script.indexOf("unset ANTHROPIC_API_KEY");
-    const claudeIdx = script.indexOf("exec claude -p");
+    const claudeIdx = script.search(/^claude -p /m);
     expect(unsetIdx).toBeGreaterThan(-1);
     expect(claudeIdx).toBeGreaterThan(-1);
     expect(unsetIdx).toBeLessThan(claudeIdx);
@@ -75,7 +75,7 @@ describe("buildCronScript: OAuth-only auth", () => {
     );
     const cdIdx = script.indexOf(`cd '${SAMPLE_AGENT_DIR}'`);
     const oauthIdx = script.indexOf("export CLAUDE_CODE_OAUTH_TOKEN");
-    const claudeIdx = script.indexOf("exec claude -p");
+    const claudeIdx = script.search(/^claude -p /m);
     expect(cdIdx).toBeGreaterThan(-1);
     expect(cdIdx).toBeLessThan(oauthIdx);
     expect(oauthIdx).toBeLessThan(claudeIdx);

--- a/src/agents/cron-broker.test.ts
+++ b/src/agents/cron-broker.test.ts
@@ -48,7 +48,7 @@ describe("buildCronScript: SWITCHROOM_VAULT_BROKER_SOCK export", () => {
       AGENT_DIR, PROMPT, MODEL, CHAT_ID, undefined, ["key_a"], BROKER_SOCKET,
     );
     const sockIdx = script.indexOf("SWITCHROOM_VAULT_BROKER_SOCK");
-    const claudeIdx = script.indexOf("exec claude -p");
+    const claudeIdx = script.search(/^claude -p /m);
     expect(sockIdx).toBeGreaterThan(-1);
     expect(claudeIdx).toBeGreaterThan(-1);
     expect(sockIdx).toBeLessThan(claudeIdx);

--- a/src/agents/cron-mcp-route.test.ts
+++ b/src/agents/cron-mcp-route.test.ts
@@ -59,7 +59,7 @@ describe("buildCronScript: MCP-only delivery path (issue #269)", () => {
 
   it("uses exec claude -p (not OUTPUT=$(...)) — process replacement, no subshell", () => {
     const script = buildCronScript(AGENT_DIR, PROMPT, MODEL, CHAT_ID, undefined);
-    expect(script).toContain("exec claude -p");
+    expect(script).toContain("claude -p");
     expect(script).not.toContain("OUTPUT=$(claude -p");
   });
 
@@ -75,7 +75,7 @@ describe("buildCronScript: MCP-only delivery path (issue #269)", () => {
       ["key_a"], "/home/test/.switchroom/vault-broker.sock",
     );
     expect(script).not.toContain("curl");
-    expect(script).toContain("exec claude -p");
+    expect(script).toContain("claude -p");
     expect(script).toMatch(/> \/dev\/null/);
   });
 });

--- a/src/agents/cron-secrets.test.ts
+++ b/src/agents/cron-secrets.test.ts
@@ -62,7 +62,7 @@ describe("buildCronScript: vault-broker ACL comment", () => {
   it("the ACL comment appears near the top, before the claude invocation", () => {
     const script = buildCronScript(AGENT_DIR, PROMPT, MODEL, CHAT_ID, undefined, ["foo"]);
     const commentIdx = script.indexOf("# Allowed vault keys");
-    const claudeIdx = script.indexOf("exec claude -p");
+    const claudeIdx = script.search(/^claude -p /m);
     expect(commentIdx).toBeGreaterThan(-1);
     expect(claudeIdx).toBeGreaterThan(-1);
     expect(commentIdx).toBeLessThan(claudeIdx);


### PR DESCRIPTION
Six pre-existing CI failures since PR #566 merged. Tests pinned `exec claude -p` but #566 deliberately dropped `exec` so the success-trailer can run. Two-step: drop literal `exec claude -p` (replace with `claude -p`); switch indexOf to anchored regex `/^claude -p /m` so it finds the real invocation, not the comment line that says 'runs claude -p,'. 40/40 cron tests pass. Full vitest suite: 4390 pass / 0 fail / 26 skipped.