### PR TITLE
chore(skills): clean up stale cross-references and tighten descriptions

### DIFF
--- a/skills/switchroom-cli/SKILL.md
+++ b/skills/switchroom-cli/SKILL.md
@@ -121,17 +121,33 @@ No side effects. Safe to run at any time.
 
 Surface the resolved effective config for a specific agent. Use for "how is X configured", "what tools does X have", or cascade-resolution questions.
 
-### Step 1 — Find the config
+### Step 1 — Pick the right inspector
+
+For a high-level view (model, profile, topic, status, uptime):
 
 ```bash
 switchroom agent list --json
 ```
 
-This returns per-agent `name`, `model`, `extends`, `topic_name`, `topic_emoji`, `status`, `uptime`. For the full merged config (including tools, soul, memory, hooks, skills), inspect the scaffolded files:
+For the full merged settings file (tools, hooks, MCP servers):
 
 ```bash
 cat ~/.switchroom/agents/<name>/.claude/settings.json
 ```
+
+For the **exact prompt + system message** an agent sends Claude on its next turn:
+
+```bash
+switchroom debug turn <name>
+```
+
+For the rendered workspace bootstrap block (CLAUDE.md, SOUL.md, skills wiring):
+
+```bash
+switchroom workspace render <name>
+```
+
+`debug turn` and `workspace render` are the authoritative answers when the user asks "why is X behaving this way" or "what is X actually being told".
 
 ### Step 2 — Explain the cascade
 

--- a/skills/switchroom-health/SKILL.md
+++ b/skills/switchroom-health/SKILL.md
@@ -5,7 +5,7 @@ description: Runs a health check and diagnostics on the switchroom setup. Use wh
 
 # Agent Health Diagnostics
 
-When the user reports an agent failing, says their agents are broken, asks "what's wrong with my agent(s)", mentions errors, asks to diagnose, or asks to troubleshoot the setup, run this skill to perform a full health check. This skill answers the *what's wrong* question by checking the whole stack (CLI, auth, units, files, memory); use `switchroom-logs` only when the user specifically asks for logs of a particular crash.
+When the user reports an agent failing, says their agents are broken, asks "what's wrong with my agent(s)", mentions errors, asks to diagnose, or asks to troubleshoot the setup, run this skill to perform a full health check. This skill answers the *what's wrong* question by checking the whole stack (CLI, auth, units, files, memory); defer to `switchroom-cli` (logs section) only when the user specifically asks for logs of a particular crash.
 
 ## Step 1 — Run switchroom doctor
 

--- a/skills/switchroom-status/SKILL.md
+++ b/skills/switchroom-status/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: switchroom-status
-description: Shows which switchroom agents are running right now, their uptime, and current state. Use when the user asks 'what agents are running', 'show agent info', 'show me uptime', 'list all switchroom agents', 'are my agents OK', agent status, agent overview, or wants a snapshot of all running agents.
+description: List running switchroom agents with their uptime, model, and per-agent state. Use when the user asks 'what agents are running', 'list switchroom agents', 'how long has X been up', or wants a per-agent snapshot. Do NOT use for switchroom-wide version/health summary (use switchroom-cli's `switchroom version`) or "something is broken" diagnostics (use switchroom-health).
 ---
 
 # Agent Status
@@ -66,4 +66,4 @@ coach — stopped
 3 of 3 agents configured, 2 running.
 ```
 
-If the user wants more detail on a specific agent, suggest `switchroom agent logs <name>` or ask them to use the `switchroom-logs` skill.
+If the user wants more detail on a specific agent, suggest `switchroom agent logs <name>` (covered by the `switchroom-cli` skill).

--- a/skills/token-helpers/SKILL.md
+++ b/skills/token-helpers/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: token-helpers
-description: Refresh OAuth access tokens for Google Calendar and Microsoft Graph. Use when another skill needs a fresh access token (calendar sync, Graph API calls) and only has a refresh token on hand. Shared utility consumed by skills like garmin, doctor-appointments, and compass.
+description: Refresh OAuth access tokens for Google Calendar and Microsoft Graph from refresh tokens stored in the switchroom vault. Library skill — invoked by other skills that need a short-lived access token to call calendar or Graph APIs, not directly by the user.
 allowed-tools: Bash(switchroom vault *), Bash(./scripts/*)
 ---
 
@@ -8,7 +8,7 @@ allowed-tools: Bash(switchroom vault *), Bash(./scripts/*)
 
 Shared shell scripts that exchange a long-lived OAuth refresh token for a short-lived access token and persist the new access token back to the Switchroom vault.
 
-This is a library skill — other skills call into it rather than the user invoking it directly. It replaces the OpenClaw `google-cal-token` and `ms-graph-token` skills, consolidated here so a single refresh pipeline covers both providers.
+This is a library skill — other skills call into it rather than the user invoking it directly. A single refresh pipeline covers both Google and Microsoft providers.
 
 ## When to use
 


### PR DESCRIPTION
## Summary

Audit pass on the switchroom-shipped skills (`switchroom-*`, `token-helpers`, `humanizer`, `file-bug`, `telegram-test-harness`). Most are healthy; this PR fixes the four issues found.

- **switchroom-cli** — config-inspection section now references `switchroom debug turn` and `switchroom workspace render`, the authoritative inspectors per `CLAUDE.md`. Previously the skill only suggested `cat ~/.switchroom/agents/<name>/.claude/settings.json`, which misses the rendered prompt + bootstrap block.
- **switchroom-status** — frontmatter description was broad enough ("agent overview", "are my agents OK") to fight switchroom-cli's version/health summary trigger zone. Narrowed to per-agent listing and added explicit "do NOT use for…" carve-outs.
- **switchroom-status** + **switchroom-health** — both still cross-referenced `switchroom-logs`, which was deleted in #65 (commit 9e3b1ca, the 6→1 CLI consolidation). Now point at `switchroom-cli` (logs section).
- **token-helpers** — frontmatter named consumer skills (`garmin`, `doctor-appointments`, `compass`) that don't exist in this repo. Reworded to honestly describe it as a library skill without naming non-existent consumers. Also dropped the OpenClaw migration note.

JTBD: serves the **consistency** principle (skills should agree about what exists) and the **docs test** (skill descriptions shouldn't lie about their surface area).

## Test plan

- [ ] `grep -rn "switchroom-logs\|switchroom-restart\|switchroom-config\|switchroom-schedule\|switchroom-reconcile" skills/` returns no hits
- [ ] Each modified `SKILL.md` still parses (frontmatter intact)
- [ ] Manual eyeball of the diff — no behavioral code changes, just skill content

🤖 Generated with [Claude Code](https://claude.com/claude-code)