### PR TITLE
fix(evals): sync trigger + quality datasets to post-consolidation skill set

### DIFF
--- a/evals/dataset.yaml
+++ b/evals/dataset.yaml
@@ -107,7 +107,7 @@ evals:
   # ── switchroom-config ──────────────────────────────────────────────────────────────
   - id: "config-001"
     question: "What model is the assistant agent using?"
-    primary_skill: "switchroom-config"
+    primary_skill: "switchroom-cli"
     expected_contains:
       - "model|configuration|config|settings"
     expected_not_contains:
@@ -116,35 +116,35 @@ evals:
 
   - id: "config-002"
     question: "Show me the full config for the scheduler agent"
-    primary_skill: "switchroom-config"
+    primary_skill: "switchroom-cli"
     expected_contains:
       - "config|configuration|settings"
     tags: ["config"]
 
   - id: "config-003"
     question: "What tools does the assistant have access to?"
-    primary_skill: "switchroom-config"
+    primary_skill: "switchroom-cli"
     expected_contains:
       - "tools|config|configuration|settings"
     tags: ["config", "tools"]
 
   - id: "config-004"
     question: "What's the system prompt for my agent?"
-    primary_skill: "switchroom-config"
+    primary_skill: "switchroom-cli"
     expected_contains:
       - "system prompt|config|configuration"
     tags: ["config"]
 
   - id: "config-005"
     question: "Show the active settings for my switchroom agents"
-    primary_skill: "switchroom-config"
+    primary_skill: "switchroom-cli"
     expected_contains:
       - "settings|config|configuration"
     tags: ["config"]
 
   - id: "config-006"
     question: "Which model am I running on?"
-    primary_skill: "switchroom-config"
+    primary_skill: "switchroom-cli"
     expected_contains:
       - "model|config|configuration"
     tags: ["config"]
@@ -152,7 +152,7 @@ evals:
   # ── switchroom-schedule ────────────────────────────────────────────────────────────
   - id: "schedule-001"
     question: "Show me all scheduled tasks"
-    primary_skill: "switchroom-schedule"
+    primary_skill: "switchroom-cli"
     expected_contains:
       - "schedule|cron|timer|scheduled"
     expected_not_contains:
@@ -161,35 +161,35 @@ evals:
 
   - id: "schedule-002"
     question: "Create a cron job to run a digest every morning at 8am"
-    primary_skill: "switchroom-schedule"
+    primary_skill: "switchroom-cli"
     expected_contains:
       - "cron|schedule|0 8|8:00|morning"
     tags: ["schedule", "cron"]
 
   - id: "schedule-003"
     question: "What timers are set up for the assistant?"
-    primary_skill: "switchroom-schedule"
+    primary_skill: "switchroom-cli"
     expected_contains:
       - "timer|schedule|cron"
     tags: ["schedule"]
 
   - id: "schedule-004"
     question: "List all cron schedules"
-    primary_skill: "switchroom-schedule"
+    primary_skill: "switchroom-cli"
     expected_contains:
       - "cron|schedule|list"
     tags: ["schedule", "cron"]
 
   - id: "schedule-005"
     question: "Delete the weekly report schedule"
-    primary_skill: "switchroom-schedule"
+    primary_skill: "switchroom-cli"
     expected_contains:
       - "schedule|delete|remove|cron"
     tags: ["schedule"]
 
   - id: "schedule-006"
     question: "Add a trigger that runs every hour"
-    primary_skill: "switchroom-schedule"
+    primary_skill: "switchroom-cli"
     expected_contains:
       - "schedule|cron|trigger|every hour|0 \\*"
     tags: ["schedule", "cron"]
@@ -197,7 +197,7 @@ evals:
   # ── switchroom-restart ─────────────────────────────────────────────────────────────
   - id: "restart-001"
     question: "Restart the assistant agent"
-    primary_skill: "switchroom-restart"
+    primary_skill: "switchroom-cli"
     expected_contains:
       - "restart|confirm|are you sure|switchroom agent restart"
     expected_not_contains:
@@ -206,28 +206,28 @@ evals:
 
   - id: "restart-002"
     question: "Reboot the scheduler"
-    primary_skill: "switchroom-restart"
+    primary_skill: "switchroom-cli"
     expected_contains:
       - "restart|reboot|confirm"
     tags: ["restart"]
 
   - id: "restart-003"
     question: "My agent is frozen, restart it"
-    primary_skill: "switchroom-restart"
+    primary_skill: "switchroom-cli"
     expected_contains:
       - "restart|confirm|switchroom agent restart"
     tags: ["restart"]
 
   - id: "restart-004"
     question: "Do a hard restart of the monitor agent"
-    primary_skill: "switchroom-restart"
+    primary_skill: "switchroom-cli"
     expected_contains:
       - "restart|confirm|switchroom agent restart"
     tags: ["restart"]
 
   - id: "restart-005"
     question: "Bounce all agents"
-    primary_skill: "switchroom-restart"
+    primary_skill: "switchroom-cli"
     expected_contains:
       - "restart|bounce|confirm|all agents"
     tags: ["restart"]
@@ -235,7 +235,7 @@ evals:
   # ── switchroom-reconcile ───────────────────────────────────────────────────────────
   - id: "reconcile-001"
     question: "Re-apply my agent config"
-    primary_skill: "switchroom-reconcile"
+    primary_skill: "switchroom-cli"
     expected_contains:
       - "reconcile|apply|config|re-apply"
     expected_not_contains:
@@ -244,28 +244,28 @@ evals:
 
   - id: "reconcile-002"
     question: "I updated the CLAUDE.md, push the changes to the agent"
-    primary_skill: "switchroom-reconcile"
+    primary_skill: "switchroom-cli"
     expected_contains:
       - "reconcile|apply|update|config"
     tags: ["reconcile"]
 
   - id: "reconcile-003"
     question: "Sync the latest config to the running agent"
-    primary_skill: "switchroom-reconcile"
+    primary_skill: "switchroom-cli"
     expected_contains:
       - "reconcile|sync|apply|config"
     tags: ["reconcile"]
 
   - id: "reconcile-004"
     question: "Update the assistant agent settings without restarting"
-    primary_skill: "switchroom-reconcile"
+    primary_skill: "switchroom-cli"
     expected_contains:
       - "reconcile|update|settings|config"
     tags: ["reconcile"]
 
   - id: "reconcile-005"
     question: "Apply my profile changes to all agents"
-    primary_skill: "switchroom-reconcile"
+    primary_skill: "switchroom-cli"
     expected_contains:
       - "reconcile|apply|profile|config"
     tags: ["reconcile"]
@@ -273,7 +273,7 @@ evals:
   # ── switchroom-logs ────────────────────────────────────────────────────────────────
   - id: "logs-001"
     question: "Show me the logs for the assistant agent"
-    primary_skill: "switchroom-logs"
+    primary_skill: "switchroom-cli"
     expected_contains:
       - "logs|log|output|switchroom"
     expected_not_contains:
@@ -282,35 +282,35 @@ evals:
 
   - id: "logs-002"
     question: "What did the scheduler agent do in the last hour?"
-    primary_skill: "switchroom-logs"
+    primary_skill: "switchroom-cli"
     expected_contains:
       - "logs|log|output|history"
     tags: ["logs"]
 
   - id: "logs-003"
     question: "Tail the logs for the monitor agent"
-    primary_skill: "switchroom-logs"
+    primary_skill: "switchroom-cli"
     expected_contains:
       - "logs|tail|log|output"
     tags: ["logs"]
 
   - id: "logs-004"
     question: "Show recent errors from my agents"
-    primary_skill: "switchroom-logs"
+    primary_skill: "switchroom-cli"
     expected_contains:
       - "logs|error|log|output"
     tags: ["logs", "errors"]
 
   - id: "logs-005"
     question: "Get the last 100 lines of assistant logs"
-    primary_skill: "switchroom-logs"
+    primary_skill: "switchroom-cli"
     expected_contains:
       - "logs|log|lines|output"
     tags: ["logs"]
 
   - id: "logs-006"
     question: "What was the last thing the agent did?"
-    primary_skill: "switchroom-logs"
+    primary_skill: "switchroom-cli"
     expected_contains:
       - "logs|log|recent|history|output"
     tags: ["logs"]

--- a/evals/run_trigger.py
+++ b/evals/run_trigger.py
@@ -26,11 +26,7 @@ ROUTABLE_SKILLS = [
     "switchroom-health",
     "switchroom-install",
     "switchroom-manage",
-    "switchroom-config",
-    "switchroom-schedule",
-    "switchroom-restart",
-    "switchroom-reconcile",
-    "switchroom-logs",
+    "switchroom-cli",
     "switchroom-architecture",
 ]
 

--- a/evals/trigger_dataset.yaml
+++ b/evals/trigger_dataset.yaml
@@ -3,193 +3,199 @@ trigger_evals:
   - id: "t-status-001"
     query: "Are my agents running?"
     expected_skill: "switchroom-status"
-    expected_not_skills: ["switchroom-health", "switchroom-restart"]
+    expected_not_skills: ["switchroom-health", "switchroom-cli"]
     tags: ["routing", "status"]
 
   - id: "t-status-002"
     query: "What's the current state of all my agents?"
     expected_skill: "switchroom-status"
-    expected_not_skills: ["switchroom-health", "switchroom-logs"]
+    expected_not_skills: ["switchroom-health", "switchroom-cli"]
     tags: ["routing", "status"]
 
   - id: "t-status-003"
     query: "Show me agent uptime"
     expected_skill: "switchroom-status"
-    expected_not_skills: ["switchroom-health", "switchroom-logs"]
+    expected_not_skills: ["switchroom-health", "switchroom-cli"]
+    tags: ["routing", "status"]
+
+  - id: "t-status-004"
+    query: "Is the monitor agent online or offline?"
+    expected_skill: "switchroom-status"
+    expected_not_skills: ["switchroom-cli", "switchroom-health"]
     tags: ["routing", "status"]
 
   - id: "t-health-001"
     query: "Something is wrong with my agent, can you diagnose it?"
     expected_skill: "switchroom-health"
-    expected_not_skills: ["switchroom-status", "switchroom-restart"]
+    expected_not_skills: ["switchroom-status", "switchroom-cli"]
     tags: ["routing", "health"]
 
   - id: "t-health-002"
     query: "Run a diagnostic check on my setup"
     expected_skill: "switchroom-health"
-    expected_not_skills: ["switchroom-status", "switchroom-config"]
+    expected_not_skills: ["switchroom-status", "switchroom-cli"]
     tags: ["routing", "health"]
 
   - id: "t-health-003"
     query: "My agent keeps failing, what's wrong?"
     expected_skill: "switchroom-health"
-    expected_not_skills: ["switchroom-status", "switchroom-logs"]
+    expected_not_skills: ["switchroom-status", "switchroom-cli"]
     tags: ["routing", "health"]
 
-  # ── restart vs reconcile (both change agent state) ────────────────────────────
-  - id: "t-restart-001"
+  # ── cli operational verbs (logs/restart/update/version/config inspection) ────
+  # Post-consolidation: restart, reconcile, logs, config inspection, schedule
+  # listing all live in switchroom-cli. Disambiguation now is "this is a CLI
+  # operation, not status / not health / not architecture / not install".
+
+  - id: "t-cli-restart-001"
     query: "Restart the assistant agent"
-    expected_skill: "switchroom-restart"
-    expected_not_skills: ["switchroom-reconcile", "switchroom-status"]
-    tags: ["routing", "restart"]
+    expected_skill: "switchroom-cli"
+    expected_not_skills: ["switchroom-status", "switchroom-health"]
+    tags: ["routing", "cli", "restart"]
 
-  - id: "t-restart-002"
+  - id: "t-cli-restart-002"
     query: "The agent is frozen, reboot it"
-    expected_skill: "switchroom-restart"
-    expected_not_skills: ["switchroom-reconcile", "switchroom-health"]
-    tags: ["routing", "restart"]
+    expected_skill: "switchroom-cli"
+    expected_not_skills: ["switchroom-health", "switchroom-status"]
+    tags: ["routing", "cli", "restart"]
 
-  - id: "t-restart-003"
+  - id: "t-cli-restart-003"
     query: "Kill and restart all agents"
-    expected_skill: "switchroom-restart"
-    expected_not_skills: ["switchroom-reconcile", "switchroom-status"]
-    tags: ["routing", "restart"]
+    expected_skill: "switchroom-cli"
+    expected_not_skills: ["switchroom-status", "switchroom-manage"]
+    tags: ["routing", "cli", "restart"]
 
-  - id: "t-reconcile-001"
+  - id: "t-cli-update-001"
     query: "I updated my CLAUDE.md, apply the new config"
-    expected_skill: "switchroom-reconcile"
-    expected_not_skills: ["switchroom-restart", "switchroom-config"]
-    tags: ["routing", "reconcile"]
+    expected_skill: "switchroom-cli"
+    expected_not_skills: ["switchroom-architecture", "switchroom-manage"]
+    tags: ["routing", "cli", "update"]
 
-  - id: "t-reconcile-002"
-    query: "Sync my latest settings to the running agent without restarting"
-    expected_skill: "switchroom-reconcile"
-    expected_not_skills: ["switchroom-restart", "switchroom-config"]
-    tags: ["routing", "reconcile"]
+  - id: "t-cli-update-002"
+    query: "Pull the latest switchroom code and restart everything"
+    expected_skill: "switchroom-cli"
+    expected_not_skills: ["switchroom-install", "switchroom-manage"]
+    tags: ["routing", "cli", "update"]
 
-  - id: "t-reconcile-003"
+  - id: "t-cli-update-003"
     query: "Re-apply my agent profile"
-    expected_skill: "switchroom-reconcile"
-    expected_not_skills: ["switchroom-restart", "switchroom-schedule"]
-    tags: ["routing", "reconcile"]
+    expected_skill: "switchroom-cli"
+    expected_not_skills: ["switchroom-architecture", "switchroom-manage"]
+    tags: ["routing", "cli", "update"]
 
-  # ── config vs architecture (both about how switchroom works) ───────────────────────
-  - id: "t-config-001"
+  - id: "t-cli-config-001"
     query: "What model is my agent using?"
-    expected_skill: "switchroom-config"
+    expected_skill: "switchroom-cli"
     expected_not_skills: ["switchroom-architecture", "switchroom-status"]
-    tags: ["routing", "config"]
+    tags: ["routing", "cli", "config"]
 
-  - id: "t-config-002"
+  - id: "t-cli-config-002"
     query: "Show the tools available to the assistant"
-    expected_skill: "switchroom-config"
+    expected_skill: "switchroom-cli"
     expected_not_skills: ["switchroom-architecture", "switchroom-status"]
-    tags: ["routing", "config"]
+    tags: ["routing", "cli", "config"]
 
-  - id: "t-config-003"
+  - id: "t-cli-config-003"
     query: "What's the active system prompt for my agent?"
-    expected_skill: "switchroom-config"
-    expected_not_skills: ["switchroom-architecture", "switchroom-logs"]
-    tags: ["routing", "config"]
+    expected_skill: "switchroom-cli"
+    expected_not_skills: ["switchroom-architecture", "switchroom-status"]
+    tags: ["routing", "cli", "config"]
+
+  - id: "t-cli-logs-001"
+    query: "Show me the recent log output from the assistant"
+    expected_skill: "switchroom-cli"
+    expected_not_skills: ["switchroom-status", "switchroom-health"]
+    tags: ["routing", "cli", "logs"]
+
+  - id: "t-cli-logs-002"
+    query: "What did my agent do in the last 30 minutes?"
+    expected_skill: "switchroom-cli"
+    expected_not_skills: ["switchroom-status", "switchroom-health"]
+    tags: ["routing", "cli", "logs"]
+
+  - id: "t-cli-logs-003"
+    query: "Tail the logs for the monitor agent"
+    expected_skill: "switchroom-cli"
+    expected_not_skills: ["switchroom-status", "switchroom-health"]
+    tags: ["routing", "cli", "logs"]
+
+  - id: "t-cli-schedule-001"
+    query: "List my cron jobs"
+    expected_skill: "switchroom-cli"
+    expected_not_skills: ["switchroom-status", "switchroom-architecture"]
+    tags: ["routing", "cli", "schedule"]
+
+  - id: "t-cli-schedule-002"
+    query: "Show me what runs automatically and when"
+    expected_skill: "switchroom-cli"
+    expected_not_skills: ["switchroom-architecture", "switchroom-status"]
+    tags: ["routing", "cli", "schedule"]
+
+  - id: "t-cli-version-001"
+    query: "What version of switchroom is running?"
+    expected_skill: "switchroom-cli"
+    expected_not_skills: ["switchroom-architecture", "switchroom-status"]
+    tags: ["routing", "cli", "version"]
+
+  # ── architecture vs cli (reference vs operational) ────────────────────────────
+  # Architecture explains *how it works*; cli config inspection shows *current
+  # state*. The router should route conceptual questions to architecture, not
+  # config-lookup ones.
 
   - id: "t-arch-001"
     query: "How does switchroom actually work under the hood?"
     expected_skill: "switchroom-architecture"
-    expected_not_skills: ["switchroom-config", "switchroom-status"]
+    expected_not_skills: ["switchroom-cli", "switchroom-status"]
     tags: ["routing", "architecture"]
 
   - id: "t-arch-002"
     query: "Explain the config cascade and how agents inherit settings"
     expected_skill: "switchroom-architecture"
-    expected_not_skills: ["switchroom-config", "switchroom-reconcile"]
+    expected_not_skills: ["switchroom-cli", "switchroom-manage"]
     tags: ["routing", "architecture"]
 
   - id: "t-arch-003"
     query: "What's the difference between a profile and an agent?"
     expected_skill: "switchroom-architecture"
-    expected_not_skills: ["switchroom-config", "switchroom-status"]
+    expected_not_skills: ["switchroom-cli", "switchroom-manage"]
     tags: ["routing", "architecture"]
 
-  # ── logs vs status (both about agent info) ────────────────────────────────────
-  - id: "t-logs-001"
-    query: "Show me the recent log output from the assistant"
-    expected_skill: "switchroom-logs"
-    expected_not_skills: ["switchroom-status", "switchroom-health"]
-    tags: ["routing", "logs"]
-
-  - id: "t-logs-002"
-    query: "What did my agent do in the last 30 minutes?"
-    expected_skill: "switchroom-logs"
-    expected_not_skills: ["switchroom-status", "switchroom-health"]
-    tags: ["routing", "logs"]
-
-  - id: "t-logs-003"
-    query: "Tail the logs for the monitor agent"
-    expected_skill: "switchroom-logs"
-    expected_not_skills: ["switchroom-status", "switchroom-health"]
-    tags: ["routing", "logs"]
-
-  - id: "t-status-004"
-    query: "Is the monitor agent online or offline?"
-    expected_skill: "switchroom-status"
-    expected_not_skills: ["switchroom-logs", "switchroom-health"]
-    tags: ["routing", "status"]
-
-  # ── schedule edge cases ────────────────────────────────────────────────────────
-  - id: "t-schedule-001"
-    query: "Set up a daily 9am digest"
-    expected_skill: "switchroom-schedule"
-    expected_not_skills: ["switchroom-config", "switchroom-reconcile"]
-    tags: ["routing", "schedule"]
-
-  - id: "t-schedule-002"
-    query: "List my cron jobs"
-    expected_skill: "switchroom-schedule"
-    expected_not_skills: ["switchroom-status", "switchroom-config"]
-    tags: ["routing", "schedule"]
-
-  - id: "t-schedule-003"
-    query: "Delete the weekly report trigger"
-    expected_skill: "switchroom-schedule"
-    expected_not_skills: ["switchroom-reconcile", "switchroom-restart"]
-    tags: ["routing", "schedule"]
+  - id: "t-arch-004"
+    query: "What's the switchroom plugin system and how do hooks work?"
+    expected_skill: "switchroom-architecture"
+    expected_not_skills: ["switchroom-cli", "switchroom-manage"]
+    tags: ["routing", "architecture", "near-miss"]
 
   # ── harder near-miss scenarios ─────────────────────────────────────────────────
   - id: "t-near-001"
     query: "The assistant crashed, what happened?"
-    expected_skill: "switchroom-logs"
-    expected_not_skills: ["switchroom-health", "switchroom-restart"]
-    tags: ["routing", "near-miss"]
+    expected_skill: "switchroom-cli"
+    expected_not_skills: ["switchroom-health", "switchroom-status"]
+    tags: ["routing", "near-miss", "logs"]
 
   - id: "t-near-002"
     query: "Is switchroom healthy?"
     expected_skill: "switchroom-health"
-    expected_not_skills: ["switchroom-status", "switchroom-logs"]
+    expected_not_skills: ["switchroom-status", "switchroom-cli"]
     tags: ["routing", "near-miss"]
 
   - id: "t-near-003"
     query: "Apply my updated config file to the running agent"
-    expected_skill: "switchroom-reconcile"
-    expected_not_skills: ["switchroom-restart", "switchroom-config"]
+    expected_skill: "switchroom-cli"
+    expected_not_skills: ["switchroom-architecture", "switchroom-manage"]
     tags: ["routing", "near-miss"]
 
   - id: "t-near-004"
-    query: "What's the switchroom plugin system and how do hooks work?"
-    expected_skill: "switchroom-architecture"
-    expected_not_skills: ["switchroom-config", "switchroom-reconcile"]
-    tags: ["routing", "near-miss", "architecture"]
-
-  - id: "t-near-005"
     query: "Show agent info"
     expected_skill: "switchroom-status"
-    expected_not_skills: ["switchroom-logs", "switchroom-config"]
+    expected_not_skills: ["switchroom-cli", "switchroom-health"]
     tags: ["routing", "near-miss"]
 
-  # ── switchroom-install vs switchroom-manage / switchroom-health ──────────────────────────────
+  # ── switchroom-install vs switchroom-manage / switchroom-health ──────────────
   - id: "t-install-001"
     query: "Install switchroom on this machine"
     expected_skill: "switchroom-install"
-    expected_not_skills: ["switchroom-manage", "switchroom-health", "switchroom-reconcile"]
+    expected_not_skills: ["switchroom-manage", "switchroom-health", "switchroom-cli"]
     tags: ["routing", "install"]
 
   - id: "t-install-002"
@@ -201,26 +207,26 @@ trigger_evals:
   - id: "t-install-003"
     query: "Bootstrap switchroom from scratch"
     expected_skill: "switchroom-install"
-    expected_not_skills: ["switchroom-reconcile", "switchroom-manage"]
+    expected_not_skills: ["switchroom-cli", "switchroom-manage"]
     tags: ["routing", "install"]
 
   - id: "t-install-004"
     query: "Set up switchroom for the first time"
     expected_skill: "switchroom-install"
-    expected_not_skills: ["switchroom-manage", "switchroom-config"]
+    expected_not_skills: ["switchroom-manage", "switchroom-cli"]
     tags: ["routing", "install"]
 
   - id: "t-install-005"
     query: "I'm new to switchroom, where do I begin?"
     expected_skill: "switchroom-install"
-    expected_not_skills: ["switchroom-architecture", "switchroom-telegram-guide"]
+    expected_not_skills: ["switchroom-architecture", "switchroom-manage"]
     tags: ["routing", "install", "onboarding"]
 
   # Near-miss: "install a new agent" is NOT switchroom-install (that's switchroom-manage)
   - id: "t-install-near-001"
     query: "Add a new agent to my switchroom setup"
     expected_skill: "switchroom-manage"
-    expected_not_skills: ["switchroom-install"]
+    expected_not_skills: ["switchroom-install", "switchroom-cli"]
     tags: ["routing", "near-miss", "install"]
 
   - id: "t-install-near-002"
@@ -228,3 +234,24 @@ trigger_evals:
     expected_skill: "switchroom-manage"
     expected_not_skills: ["switchroom-install"]
     tags: ["routing", "near-miss", "install"]
+
+  # ── manage vs cli (lifecycle vs operational) ──────────────────────────────────
+  # Adding/removing agents is manage; restarting/inspecting/logging is cli.
+
+  - id: "t-manage-001"
+    query: "Remove the dev-bot agent from switchroom"
+    expected_skill: "switchroom-manage"
+    expected_not_skills: ["switchroom-cli", "switchroom-install"]
+    tags: ["routing", "manage"]
+
+  - id: "t-manage-002"
+    query: "Create a new agent called klanker"
+    expected_skill: "switchroom-manage"
+    expected_not_skills: ["switchroom-cli", "switchroom-install"]
+    tags: ["routing", "manage"]
+
+  - id: "t-manage-003"
+    query: "Store an API key in my vault"
+    expected_skill: "switchroom-manage"
+    expected_not_skills: ["switchroom-cli", "switchroom-architecture"]
+    tags: ["routing", "manage", "vault"]


### PR DESCRIPTION
## Summary

The 2026-04-20 CLI consolidation (#65, 9e3b1ca) merged six single-op skills into `switchroom-cli`, but the eval datasets still referenced the deleted skill names. Last successful run was 2026-04-16, so the breakage hasn't surfaced — but it would have on the next run.

- **`run_trigger.py`** — `ROUTABLE_SKILLS` now lists the real six: status, health, install, manage, cli, architecture.
- **`trigger_dataset.yaml`** — 40 cases (was 37), all targeting real skills. Cases that previously disambiguated restart/reconcile/logs/config/schedule from each other now route to `switchroom-cli`; the new disambiguation focus is *operational CLI verb vs status vs health vs architecture vs manage*. Added three new `cli-vs-manage` cases (create/remove agent, vault) to cover the boundary that didn't exist before.
- **`dataset.yaml`** — 28 cases remapped from deleted skills → `switchroom-cli` so `run_quality.py` loads the right SKILL.md as system prompt. Without this fix, `load_skill_content` returns `""` for deleted skills and the quality eval silently runs without skill context.

JTBD: serves the **consistency** principle — evals should test the skills that actually ship.

## Cost note

These changes will trigger the `evals-trigger` and `evals-quality` Buildkite steps (gated by `if_changed` on these exact files). The pipeline runs `concurrency: 1`, prefers `ANTHROPIC_API_KEY` over the subscription OAuth token, and soft-fails so eval flakiness doesn't block merges. Per-call cost is small — one routing prompt → one short JSON response.

## Test plan

- [ ] CI passes (lint + tests)
- [ ] Buildkite `evals-trigger` step runs and reports pass rate (soft-fail expected on first run while the model adapts to the new skill set)
- [ ] Buildkite `evals-quality` step runs and reports pass rate
- [ ] No grep hits for deleted skills:
  ```
  grep -rn "switchroom-\(logs\|restart\|reconcile\|config\|schedule\)" evals/
  ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)