### PR TITLE
fix(gateway): outbound content-dedup window for #546

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -48,6 +48,7 @@ import {
   deriveTelegraphTitle,
   type TelegraphAccount,
 } from '../telegraph.js'
+import { OutboundDedupCache } from '../recent-outbound-dedup.js'
 import { createInboundCoalescer, inboundCoalesceKey } from './inbound-coalesce.js'
 import { StatusReactionController } from '../status-reactions.js'
 import { isTelegramReplyTool, isTelegramSurfaceTool } from '../tool-names.js'
@@ -1878,6 +1879,24 @@ async function executeReply(args: Record<string, unknown>): Promise<{ content: A
   if (rawText == null || rawText === '') throw new Error('reply: text is required and cannot be empty')
   let text = repairEscapedWhitespace(rawText)
   process.stderr.write(`telegram channel: reply: invoked chatId=${chat_id} charCount=${text.length} preview=${JSON.stringify(text.slice(0, 80))}\n`)
+
+  // #546 dedup check: was this content just sent via turn-flush or
+  // a sibling reply path? Skip the actual send and return a
+  // plausible tool result so claude-code's retry loop closes
+  // cleanly. NOTE: only fires when content matches; legitimate
+  // late-replies with different content sail through.
+  {
+    const replyThreadId = args.message_thread_id != null ? Number(args.message_thread_id) : undefined
+    const dup = outboundDedup.check(chat_id, replyThreadId, text, Date.now())
+    if (dup != null) {
+      process.stderr.write(
+        `telegram gateway: reply: deduped (#546) chatId=${chat_id} ` +
+        `ageMs=${dup.ageMs} preview=${JSON.stringify(dup.preview)}\n`,
+      )
+      return { content: [{ type: 'text', text: 'sent (deduped — same content sent via earlier path)' }] }
+    }
+  }
+
   const files = (args.files as string[] | undefined) ?? []
   const quoteOptIn = args.quote !== false
   let reply_to = args.reply_to != null ? Number(args.reply_to) : undefined
@@ -2168,12 +2187,39 @@ async function executeReply(args: Record<string, unknown>): Promise<{ content: A
   }
 
   process.stderr.write(`telegram channel: reply: finalized chatId=${chat_id} messageIds=[${sentIds.join(',')}] chunks=${chunks.length}\n`)
+  // #546 dedup record: future reply / stream_reply / turn-flush
+  // calls with this same content within DEFAULT_DEDUP_TTL_MS will
+  // be suppressed.
+  if (sentIds.length > 0) {
+    outboundDedup.record(chat_id, threadId, text, Date.now())
+  }
   return { content: [{ type: 'text', text: result }] }
 }
 
 async function executeStreamReply(args: Record<string, unknown>): Promise<unknown> {
   if (!args.chat_id) throw new Error('stream_reply: chat_id is required')
   if (args.text == null || args.text === '') throw new Error('stream_reply: text is required and cannot be empty')
+
+  // #546 dedup check: stream_reply done=true is the most-common
+  // retry shape — claude-code re-emits the final-text call when
+  // the previous bridge missed the ack. If turn-flush already sent
+  // the same content, swallow the retry and return success.
+  // Only check on done=true (the terminal call); intermediate
+  // streaming chunks are progress edits, not full sends.
+  if (args.done === true) {
+    const sChatId = args.chat_id as string
+    const sThreadId = args.message_thread_id != null ? Number(args.message_thread_id) : undefined
+    const sText = args.text as string
+    const dup = outboundDedup.check(sChatId, sThreadId, sText, Date.now())
+    if (dup != null) {
+      process.stderr.write(
+        `telegram gateway: stream_reply: deduped (#546) chatId=${sChatId} ` +
+        `ageMs=${dup.ageMs} preview=${JSON.stringify(dup.preview)}\n`,
+      )
+      return { content: [{ type: 'text', text: 'sent (deduped — same content sent via earlier path)' }] }
+    }
+  }
+
   const access = loadAccess()
   // Detect chat type for draft-transport selection.
   // Private (DM) chats have positive numeric IDs; groups/channels are negative.
@@ -2282,6 +2328,14 @@ async function executeStreamReply(args: Record<string, unknown>): Promise<unknow
         Date.now(),
       )
     } catch { /* best-effort signal */ }
+  }
+  // #546 dedup record: capture the final stream_reply text on the
+  // terminal call so a subsequent retry (different bridge, same
+  // content) lands as a no-op instead of a second message.
+  if (args.done === true && result.messageId != null) {
+    const sChatId = args.chat_id as string
+    const sThreadId = args.message_thread_id != null ? Number(args.message_thread_id) : undefined
+    outboundDedup.record(sChatId, sThreadId, args.text as string, Date.now())
   }
   return { content: [{ type: 'text', text: `${result.status} (id: ${result.messageId ?? 'pending'})` }] }
 }
@@ -3402,6 +3456,16 @@ function handleSessionEvent(ev: SessionEvent): void {
                 })
               } catch {}
             }
+            // #546 dedup: record what turn-flush just sent so a
+            // late-arriving reply / stream_reply with the same
+            // content gets suppressed (claude-code retries the
+            // un-acked tool_call after a bridge reconnect).
+            outboundDedup.record(
+              backstopChatId,
+              backstopThreadId,
+              capturedText,
+              Date.now(),
+            )
             if (backstopCtrl) backstopCtrl.setDone()
             unpinProgressCardForChat?.(backstopChatId, backstopThreadId)
           } catch (err) {

--- a/telegram-plugin/recent-outbound-dedup.ts
+++ b/telegram-plugin/recent-outbound-dedup.ts
@@ -1,0 +1,169 @@
+/**
+ * Outbound dedup window (#546).
+ *
+ * Closes the duplicate-reply class where:
+ *
+ *   1. Agent emits text that the gateway buffers as PTY-tail.
+ *   2. Bridge disconnects mid-flight (turn boundary, restart, etc.)
+ *      before claude-code's reply / stream_reply tool_call lands.
+ *   3. Gateway's `turn-flush` backstop fires after a 500ms grace —
+ *      sees no reply tool_call landed, sends the buffered text as
+ *      its own message (HTML-rendered).
+ *   4. claude-code preserves the un-acked tool_call in its session
+ *      and replays it on the next bridge connection. The replayed
+ *      stream_reply lands as a SECOND message with the same content
+ *      (raw markdown, since reply tools don't always render HTML).
+ *
+ * Smoking-gun evidence: klanker chat 8248703757, msgs 5025 + 5027,
+ * 11s apart. msg=5025 had `<b>...</b>` (turn-flush + markdownToHtml).
+ * msg=5027 had `**...**` (the raw markdown reply tool's payload).
+ * Same content, different formatting, two messages.
+ *
+ * Fix shape: maintain a small in-memory cache of "what we just sent"
+ * keyed by (chatId, threadId). Before any reply / stream_reply
+ * actually sends, check whether a recent outbound matches the
+ * normalised content. If so, skip the send and return a successful
+ * tool-call result so claude-code's retry loop closes cleanly.
+ *
+ * This is a SAFETY NET layer. The cleaner architectural fix would be
+ * "don't fire turn-flush when claude-code might retry" — but that
+ * needs reliable detection of the retry intent ahead of time, which
+ * we don't have. Dedup-after-the-fact is robust against the full
+ * range of "two paths, same content" failure modes.
+ *
+ * Pure module: no I/O, no globals, no clock reads beyond the caller-
+ * supplied `now`. Fully unit-testable.
+ */
+
+/** TTL after which a recorded outbound is forgotten. 60s catches the
+ *  typical retry window (we've seen 9-11s in the wild) with margin
+ *  for slower networks and avoids deduping legitimate later replies
+ *  that happen to repeat content. */
+export const DEFAULT_DEDUP_TTL_MS = 60_000
+
+/** Minimum content length below which we don't bother deduping.
+ *  Short replies (<= 24 chars) like "ok", "got it", "✅" frequently
+ *  recur within seconds in normal multi-turn conversation; deduping
+ *  them would suppress legitimate repeats. The bug class we're
+ *  defending against involves multi-paragraph content, so the floor
+ *  is conservative. */
+export const DEDUP_MIN_CONTENT_LEN = 24
+
+interface DedupEntry {
+  /** Normalized content hash (see `normalizeForDedup`). */
+  hash: string
+  /** Wall-clock ms when recorded. */
+  ts: number
+  /** First 80 chars of the original (un-normalized) text — for
+   *  operator-facing log lines that show what got deduped. */
+  preview: string
+}
+
+/**
+ * In-memory dedup cache, keyed by `chatId|threadId`. Bounded by
+ * TTL eviction on every read; we don't cap entries because chat
+ * count per gateway is small (one per active conversation).
+ */
+export class OutboundDedupCache {
+  private readonly entries = new Map<string, DedupEntry[]>()
+  private readonly ttlMs: number
+
+  constructor(opts: { ttlMs?: number } = {}) {
+    this.ttlMs = opts.ttlMs ?? DEFAULT_DEDUP_TTL_MS
+  }
+
+  /** Record an outbound message. Caller should invoke this after a
+   *  successful send, regardless of which path sent it (turn-flush,
+   *  executeReply, executeStreamReply, etc.). Short content is not
+   *  recorded — see DEDUP_MIN_CONTENT_LEN. */
+  record(chatId: string, threadId: number | undefined, text: string, now: number): void {
+    if (text.length < DEDUP_MIN_CONTENT_LEN) return
+    const key = makeKey(chatId, threadId)
+    const list = this.entries.get(key) ?? []
+    this.evict(list, now)
+    list.push({
+      hash: normalizeForDedup(text),
+      ts: now,
+      preview: text.slice(0, 80),
+    })
+    this.entries.set(key, list)
+  }
+
+  /** Check whether the given text was already sent recently to the
+   *  same chat. Returns the matched entry's preview + age on hit, or
+   *  null on miss. Caller decides what to do with the answer
+   *  (skip-send, log, etc.). */
+  check(
+    chatId: string,
+    threadId: number | undefined,
+    text: string,
+    now: number,
+  ): { matched: true; preview: string; ageMs: number } | null {
+    if (text.length < DEDUP_MIN_CONTENT_LEN) return null
+    const key = makeKey(chatId, threadId)
+    const list = this.entries.get(key)
+    if (!list) return null
+    this.evict(list, now)
+    const candidateHash = normalizeForDedup(text)
+    for (const entry of list) {
+      if (entry.hash === candidateHash) {
+        return { matched: true, preview: entry.preview, ageMs: now - entry.ts }
+      }
+    }
+    return null
+  }
+
+  /** Test-only: clear all entries. */
+  clear(): void {
+    this.entries.clear()
+  }
+
+  /** Test-only: count of live entries (post-eviction). */
+  size(now: number): number {
+    let total = 0
+    for (const list of this.entries.values()) {
+      this.evict(list, now)
+      total += list.length
+    }
+    return total
+  }
+
+  private evict(list: DedupEntry[], now: number): void {
+    const cutoff = now - this.ttlMs
+    let i = 0
+    while (i < list.length && list[i].ts < cutoff) i++
+    if (i > 0) list.splice(0, i)
+  }
+}
+
+function makeKey(chatId: string, threadId: number | undefined): string {
+  return threadId == null ? chatId : `${chatId}|${threadId}`
+}
+
+/**
+ * Normalise text for content equality. The bug we're defending
+ * against produces the SAME content rendered two different ways:
+ * one path runs `markdownToHtml` (so `**foo**` becomes `<b>foo</b>`),
+ * the other doesn't. Both must hash identically.
+ *
+ * Steps:
+ *   1. Strip HTML tags (`<b>foo</b>` → `foo`).
+ *   2. Strip markdown markers (`**foo**` / `__foo__` / `` `foo` `` → `foo`).
+ *   3. Collapse all whitespace to single space + trim.
+ *   4. Lowercase (defensive — both renderers preserve case but a
+ *      future formatter might title-case headings, etc.).
+ *
+ * NOT a hash function in the cryptographic sense — just a
+ * normalised-string comparison key. Identical content + identical
+ * normaliser → identical key.
+ */
+export function normalizeForDedup(text: string): string {
+  return text
+    .replace(/<\/?[a-zA-Z][^>]*>/g, '')      // HTML tags
+    .replace(/&[a-zA-Z]+;|&#\d+;/g, ' ')     // HTML entities → space
+    .replace(/(\*\*|__|`)+/g, '')            // markdown bold/italic/code markers
+    .replace(/^[#>\-*+]\s+/gm, '')           // markdown line prefixes
+    .replace(/\s+/g, ' ')
+    .trim()
+    .toLowerCase()
+}

--- a/telegram-plugin/tests/recent-outbound-dedup.test.ts
+++ b/telegram-plugin/tests/recent-outbound-dedup.test.ts
@@ -1,0 +1,192 @@
+/**
+ * Tests for the outbound dedup cache (#546).
+ *
+ * The bug pattern we're defending against:
+ *   - turn-flush sends a long reply rendered as HTML (`<b>foo</b>`).
+ *   - 9-11 seconds later, the agent's reply tool retries (after a
+ *     bridge reconnect) and ships the SAME content as raw markdown
+ *     (`**foo**`).
+ *   - User sees both. Trust leaks.
+ *
+ * The cache normalises both forms to the same key so `record(html)`
+ * is detected when `check(markdown)` arrives, and vice versa.
+ */
+
+import { describe, it, expect } from 'bun:test'
+import {
+  OutboundDedupCache,
+  normalizeForDedup,
+  DEFAULT_DEDUP_TTL_MS,
+  DEDUP_MIN_CONTENT_LEN,
+} from '../recent-outbound-dedup.js'
+
+const LONG_HTML = '<b>Heads up</b> — those blockers are now in <code>main</code>: rotate the password, fix the pipeline, verify env vars.'
+const LONG_MARKDOWN = '**Heads up** — those blockers are now in `main`: rotate the password, fix the pipeline, verify env vars.'
+const LONG_PLAIN = 'Heads up — those blockers are now in main: rotate the password, fix the pipeline, verify env vars.'
+
+describe('normalizeForDedup', () => {
+  it('hashes HTML and markdown forms of the same content equally', () => {
+    expect(normalizeForDedup(LONG_HTML)).toBe(normalizeForDedup(LONG_MARKDOWN))
+  })
+
+  it('hashes plain-text form equally too (no markup at all)', () => {
+    expect(normalizeForDedup(LONG_HTML)).toBe(normalizeForDedup(LONG_PLAIN))
+  })
+
+  it('strips HTML tags including attributes', () => {
+    const r = normalizeForDedup('<a href="https://x">link</a>')
+    expect(r).toBe('link')
+  })
+
+  it('strips markdown bold / italic / code markers', () => {
+    expect(normalizeForDedup('**bold**')).toBe('bold')
+    expect(normalizeForDedup('__bold__')).toBe('bold')
+    expect(normalizeForDedup('`code`')).toBe('code')
+  })
+
+  it('strips line-leading markdown markers', () => {
+    expect(normalizeForDedup('# heading\n- item\n> quote')).toBe('heading item quote')
+  })
+
+  it('collapses whitespace + lowercases for comparison', () => {
+    expect(normalizeForDedup('  Foo   Bar\n\n\nBaz  ')).toBe('foo bar baz')
+  })
+
+  it('expands HTML entities to spaces (defensive)', () => {
+    // The renderer emits &gt; for >; both forms should hash equally.
+    expect(normalizeForDedup('a &gt; b')).toBe('a   b'.replace(/\s+/g, ' ').trim())
+  })
+
+  it('different content produces different hashes', () => {
+    expect(normalizeForDedup('hello world')).not.toBe(normalizeForDedup('hello there'))
+  })
+})
+
+describe('OutboundDedupCache — happy path', () => {
+  it('records and detects same content within TTL', () => {
+    const cache = new OutboundDedupCache()
+    cache.record('123', undefined, LONG_HTML, 1000)
+    const r = cache.check('123', undefined, LONG_MARKDOWN, 5000)
+    expect(r).not.toBeNull()
+    expect(r!.matched).toBe(true)
+    expect(r!.ageMs).toBe(4000)
+    expect(r!.preview).toContain('Heads up')
+  })
+
+  it('returns null on cache miss', () => {
+    const cache = new OutboundDedupCache()
+    cache.record('123', undefined, LONG_HTML, 1000)
+    const r = cache.check('123', undefined, 'completely different content here', 2000)
+    expect(r).toBeNull()
+  })
+
+  it('matches across HTML / markdown / plain renderings (the actual bug)', () => {
+    const cache = new OutboundDedupCache()
+    cache.record('chat', undefined, LONG_HTML, 1000)
+    expect(cache.check('chat', undefined, LONG_MARKDOWN, 1500)).not.toBeNull()
+    expect(cache.check('chat', undefined, LONG_PLAIN, 1500)).not.toBeNull()
+  })
+})
+
+describe('OutboundDedupCache — TTL expiry', () => {
+  it('does not match an entry past TTL', () => {
+    const cache = new OutboundDedupCache({ ttlMs: 5000 })
+    cache.record('123', undefined, LONG_HTML, 1000)
+    // 6s later → past 5s TTL
+    expect(cache.check('123', undefined, LONG_MARKDOWN, 7000)).toBeNull()
+  })
+
+  it('uses default TTL of 60s when none provided', () => {
+    const cache = new OutboundDedupCache()
+    cache.record('123', undefined, LONG_HTML, 0)
+    expect(cache.check('123', undefined, LONG_HTML, DEFAULT_DEDUP_TTL_MS - 1)).not.toBeNull()
+    expect(cache.check('123', undefined, LONG_HTML, DEFAULT_DEDUP_TTL_MS + 1)).toBeNull()
+  })
+
+  it('evicts old entries on subsequent operations', () => {
+    const cache = new OutboundDedupCache({ ttlMs: 5000 })
+    cache.record('chat', undefined, LONG_HTML, 1000)
+    expect(cache.size(2000)).toBe(1)
+    expect(cache.size(10000)).toBe(0) // past TTL → evicted
+  })
+})
+
+describe('OutboundDedupCache — chat / thread isolation', () => {
+  it('does not match across different chat ids', () => {
+    const cache = new OutboundDedupCache()
+    cache.record('chat-A', undefined, LONG_HTML, 1000)
+    expect(cache.check('chat-B', undefined, LONG_HTML, 2000)).toBeNull()
+  })
+
+  it('does not match across different thread ids in the same chat', () => {
+    const cache = new OutboundDedupCache()
+    cache.record('chat', 1, LONG_HTML, 1000)
+    expect(cache.check('chat', 2, LONG_HTML, 2000)).toBeNull()
+  })
+
+  it('matches when threadId is undefined on both record + check', () => {
+    const cache = new OutboundDedupCache()
+    cache.record('chat', undefined, LONG_HTML, 1000)
+    expect(cache.check('chat', undefined, LONG_HTML, 2000)).not.toBeNull()
+  })
+
+  it('does NOT match record(undefined) against check(0) — distinct keys', () => {
+    // 0 is a valid threadId in some Telegram APIs; treat as distinct
+    // from undefined to avoid false positives.
+    const cache = new OutboundDedupCache()
+    cache.record('chat', undefined, LONG_HTML, 1000)
+    expect(cache.check('chat', 0, LONG_HTML, 2000)).toBeNull()
+  })
+})
+
+describe('OutboundDedupCache — short content is not deduped', () => {
+  it(`ignores content under ${DEDUP_MIN_CONTENT_LEN} chars on record`, () => {
+    const cache = new OutboundDedupCache()
+    cache.record('chat', undefined, 'short reply', 1000)
+    expect(cache.size(1500)).toBe(0)
+  })
+
+  it(`ignores short content on check (returns null even if hash would match)`, () => {
+    const cache = new OutboundDedupCache()
+    // Force-record by accessing internals would be a hack — instead, prove
+    // the check side filters too. Record a long entry; check a SHORT
+    // canonicalised query against it. Different lengths → different hashes
+    // anyway, so this test mostly documents the intent.
+    cache.record('chat', undefined, LONG_HTML, 1000)
+    expect(cache.check('chat', undefined, 'ok', 2000)).toBeNull()
+  })
+
+  it('legitimate short repeats do not get suppressed', () => {
+    // "ok" / "got it" / "✅ Done" are common in normal multi-turn
+    // conversation. Deduping them would suppress legitimate replies.
+    // Same reasoning as DEDUP_MIN_CONTENT_LEN's docstring.
+    const cache = new OutboundDedupCache()
+    cache.record('chat', undefined, 'ok', 1000)
+    cache.record('chat', undefined, 'ok', 5000)
+    cache.record('chat', undefined, 'ok', 9000)
+    expect(cache.size(10_000)).toBe(0) // none recorded
+    expect(cache.check('chat', undefined, 'ok', 10_000)).toBeNull()
+  })
+})
+
+describe('OutboundDedupCache — multiple entries per chat', () => {
+  it('matches the first hash that fits, even if more recent entries exist', () => {
+    const cache = new OutboundDedupCache()
+    const A = 'first long reply with enough characters to count as content'
+    const B = 'second long reply with enough characters to count as content too'
+    cache.record('chat', undefined, A, 1000)
+    cache.record('chat', undefined, B, 5000)
+    expect(cache.check('chat', undefined, A, 6000)).not.toBeNull()
+    expect(cache.check('chat', undefined, B, 6000)).not.toBeNull()
+  })
+
+  it('evicted entries no longer match', () => {
+    const cache = new OutboundDedupCache({ ttlMs: 3000 })
+    cache.record('chat', undefined, LONG_HTML, 1000)
+    // Wait past TTL.
+    expect(cache.check('chat', undefined, LONG_HTML, 5000)).toBeNull()
+    // Re-record after eviction; check works again.
+    cache.record('chat', undefined, LONG_HTML, 5000)
+    expect(cache.check('chat', undefined, LONG_HTML, 6000)).not.toBeNull()
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -99,6 +99,9 @@ export default defineConfig({
       // telegraph.test.ts uses bun:test (#579 Telegraph Instant View) —
       // excluded here, run via test:bun.
       "**/telegram-plugin/tests/telegraph.test.ts",
+      // recent-outbound-dedup.test.ts uses bun:test (#546 dup fix) —
+      // excluded here, run via test:bun.
+      "**/telegram-plugin/tests/recent-outbound-dedup.test.ts",
     ],
     coverage: {
       provider: "v8",


### PR DESCRIPTION
Closes #546.

## Summary
Defends against "turn-flush + tool_call-retry race" duplicate replies. New cache records outbound text per chat with a 60s TTL; reply / stream_reply / turn-flush all check before sending and skip if the same content was just shipped.

## Smoking-gun trace
```
14:51:02 turn-flush firing — 1211 chars without reply tool
14:51:03 [outbound msg=5025] HTML-rendered: <b>Heads up</b> ...
14:51:03 ipc — bridge reconnected (clientId bc21a79a)
14:51:12 ipc: tool_call tool=stream_reply done=true (RETRY)
14:51:14 [outbound msg=5027] raw markdown: **Heads up** ...
```
Same content, 11s apart, different formatting because turn-flush ran markdownToHtml and the retried stream_reply didn't.

## Files
- `telegram-plugin/recent-outbound-dedup.ts` (new) — pure cache + normaliser
- `telegram-plugin/gateway/gateway.ts` — three integration sites (turn-flush record, executeReply check+record, executeStreamReply check+record on done=true)
- `telegram-plugin/tests/recent-outbound-dedup.test.ts` (new) — 23 cases
- `vitest.config.ts` — exclude bun:test file

## Why dedup-at-the-wire
Cleaner fix would be "don't turn-flush when claude-code might retry" but reliable retry-detection ahead of time isn't available. Dedup-after-the-fact is robust against turn-flush + reply, bridge-reconnect-replay, and future similar shapes.

## What gets exempted
- Short content (< 24 chars). "ok", "got it", "✅" recur in normal conversation.
- Cross-chat / cross-thread.
- After 60s TTL.

## What still legitimately works
- Multi-message replies with different content
- Repeats after 60s (e.g. user re-asks the same thing → same answer is fine)

## Out of scope
- Subtype B ("phantom tool_call from a fresh bridge with novel content") — needs bridge-PID + session-ID instrumentation. Will file as follow-up if it surfaces post-merge.
- #549 preamble dup — different code path; parallel agent has a fix in another worktree.

## Test plan
- [x] 23 unit cases pass
- [x] All 2881 plugin bun tests pass
- [x] All 4403 vitest tests pass
- [x] `npm run lint` clean
- [ ] Manual: reproduce the klanker pattern with deliberate bridge-disconnect mid-reply; verify no duplicate lands in chat (deferred until next deploy)