### PR TITLE
fix(gateway): 👍 fires on real delivery, not turn_end (Bug D + Z)

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -3368,7 +3368,25 @@ function handleSessionEvent(ev: SessionEvent): void {
               const recentCount = getRecentOutboundCount(backstopChatId, 2)
               if (recentCount > 0) {
                 process.stderr.write(`telegram gateway: turn-flush suppressed — reply tool sent ${recentCount} message(s) within 2s\n`)
-                if (backstopCtrl) backstopCtrl.setDone()
+                // Bug D fix: do NOT fire setDone here. The previous code
+                // assumed `recentCount > 0` was sufficient proof of delivery
+                // — and it is, since recordOutbound is called synchronously
+                // after sendMessage success. But firing setDone here races
+                // with the stream_reply done=true callback (Bug Z) which now
+                // fires endStatusReaction after finalize() resolves (i.e.
+                // after the final edit lands in Telegram). Both racing on
+                // setDone is harmless (setDone is idempotent post-terminal),
+                // but the dedup branch firing FIRST means we'd be claiming
+                // delivery from a 500ms-lagged read of local history rather
+                // than from the actual API confirmation. Letting Bug Z's
+                // post-finalize callback own the 👍 transition keeps the
+                // emoji tied to true delivery. Note: for the legacy `reply`
+                // tool path (which does not yet wire endStatusReaction),
+                // this leaves the controller in a non-terminal intermediate
+                // state until purgeReactionTracking removes it — meaning no
+                // 👍 will render on plain `reply` turns whose only outbound
+                // came from the reply tool. Tracked separately; the spec
+                // for this PR explicitly scopes Bug Z to stream_reply only.
                 purgeReactionTracking(statusKey(backstopChatId, backstopThreadId))
                 return
               }

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -2165,6 +2165,23 @@ async function executeReply(args: Record<string, unknown>): Promise<{ content: A
     } catch { /* best-effort signal */ }
     // #203: fresh sendMessage from reply tool is a user-visible signal.
     signalTracker.noteSignal(statusKey(chat_id, threadId), Date.now())
+    // PR #602 follow-up: fire the terminal 👍 here so plain `reply`-only
+    // turns get the same delivery-confirmed reaction as stream_reply
+    // (Bug Z). Pre-follow-up, the dedup-suppress branch in the gateway
+    // turn_end handler was the sole 👍 emitter for reply-tool-only
+    // turns; removing its setDone call (Bug D) left those turns with no
+    // 👍 at all. Mirror the stream_reply contract: only fire after at
+    // least one sendMessage has resolved successfully (sentIds.length>0
+    // guarantees this), so the emoji means "the reply landed in
+    // Telegram", not "the reply tool was invoked". The reply tool has
+    // no lane concept — every reply is the user-visible answer — so no
+    // lane gate is needed (unlike stream_reply where named lanes are
+    // internal driver emits).
+    try {
+      endStatusReaction(chat_id, threadId, 'done')
+    } catch (err) {
+      process.stderr.write(`telegram gateway: reply: endStatusReaction hook threw: ${err}\n`)
+    }
   }
 
   process.stderr.write(`telegram channel: reply: finalized chatId=${chat_id} messageIds=[${sentIds.join(',')}] chunks=${chunks.length}\n`)
@@ -3380,13 +3397,12 @@ function handleSessionEvent(ev: SessionEvent): void {
                 // delivery from a 500ms-lagged read of local history rather
                 // than from the actual API confirmation. Letting Bug Z's
                 // post-finalize callback own the 👍 transition keeps the
-                // emoji tied to true delivery. Note: for the legacy `reply`
-                // tool path (which does not yet wire endStatusReaction),
-                // this leaves the controller in a non-terminal intermediate
-                // state until purgeReactionTracking removes it — meaning no
-                // 👍 will render on plain `reply` turns whose only outbound
-                // came from the reply tool. Tracked separately; the spec
-                // for this PR explicitly scopes Bug Z to stream_reply only.
+                // emoji tied to true delivery. The plain `reply` tool path
+                // (PR #602 follow-up) now also fires endStatusReaction
+                // directly from executeReply after sendMessage resolves,
+                // mirroring this contract — so reply-only turns transition
+                // to terminal 👍 in their own success path rather than
+                // relying on this dedup heuristic.
                 purgeReactionTracking(statusKey(backstopChatId, backstopThreadId))
                 return
               }

--- a/telegram-plugin/stream-reply-handler.ts
+++ b/telegram-plugin/stream-reply-handler.ts
@@ -489,10 +489,40 @@ export async function handleStreamReply(
     await stream.finalize()
     state.activeDraftStreams.delete(sKey)
     state.activeDraftParseModes?.delete(sKey)
-    // Intentionally NOT firing the terminal 👍 here. A turn can call
-    // stream_reply(done=true) mid-flight and then do more tool work or
-    // send additional replies. The 👍 now fires only from turn_end in
-    // server.ts, which is the true agent-idle boundary.
+    // Bug Z fix: fire the terminal 👍 here, gated to the default
+    // (unnamed) lane and only after finalize() resolves so the emoji is
+    // tied to the final edit actually landing in Telegram.
+    //
+    // History (see prior comment removed in this commit): we previously
+    // deferred the 👍 to turn_end on the theory that a turn might call
+    // stream_reply(done=true) mid-flight and continue working. In
+    // practice the dedup-suppress branch in turn_end was firing setDone
+    // off a 500ms-lagged read of local history rather than from a real
+    // delivery confirmation, and the disconnect-flush path was leaving
+    // 👍 firing on disconnect even when the final edit had failed.
+    // Wiring endStatusReaction at the post-finalize callback keeps the
+    // emoji honest — it now means "the final draft edit hit Telegram".
+    //
+    // Gated to the default lane: named lanes (lane:'progress',
+    // lane:'thinking', lane:'activity', etc.) are internal driver
+    // emits, not user-visible answers — they must not be allowed to
+    // claim turn-completion. A lane:'progress' emit firing setDone
+    // would race the actual answer.
+    //
+    // Mid-turn done=true tradeoff: a turn that calls
+    // stream_reply(done=true) on the default lane and then continues
+    // working will fire 👍 early; subsequent intermediate emojis become
+    // no-ops (setDone is terminal). This is the contract: done=true on
+    // the default lane is "the answer is delivered". Agents that need
+    // to continue should use additional `reply` calls or named lanes.
+    const isDefaultLaneForCompletion = args.lane == null || args.lane.length === 0
+    if (isDefaultLaneForCompletion && stream.getMessageId() != null) {
+      try {
+        deps.endStatusReaction(chat_id, threadId, 'done')
+      } catch (err) {
+        deps.writeError(`telegram channel: stream_reply: endStatusReaction hook threw: ${err}\n`)
+      }
+    }
 
     // Hard-fail surface: if the stream finalized without ever assigning
     // a message id, the initial send never landed (4096+ chars hits

--- a/telegram-plugin/tests/reply-terminal-reaction.test.ts
+++ b/telegram-plugin/tests/reply-terminal-reaction.test.ts
@@ -1,0 +1,149 @@
+/**
+ * PR #602 follow-up — plain `reply` tool must fire the terminal 👍
+ * reaction on real delivery (post-sendMessage), mirroring Bug Z's
+ * stream_reply contract.
+ *
+ * Background. Bug D removed the premature `setDone()` call from the
+ * gateway's turn-flush dedup-suppress branch (it was firing 👍 off a
+ * 500ms-lagged read of local history rather than from a real Telegram
+ * delivery confirmation). Bug Z then wired stream_reply's
+ * post-finalize callback to fire `endStatusReaction('done')` on
+ * delivery.
+ *
+ * That left a regression: turns whose only outbound came through the
+ * plain `reply` tool (not `stream_reply`) had no remaining 👍 emitter
+ * — the dedup branch's setDone was the only thing firing for that
+ * path, and removing it meant reply-only turns silently lost their
+ * terminal reaction.
+ *
+ * The follow-up wires `executeReply` to call
+ * `endStatusReaction(chat_id, threadId, 'done')` after at least one
+ * `bot.api.sendMessage` resolves successfully (i.e. `sentIds.length
+ * > 0`). The reply tool has no lane concept (unlike stream_reply, where
+ * named lanes like 'progress'/'thinking' are internal driver emits),
+ * so no lane gate is needed — every reply is by definition the
+ * user-visible answer.
+ *
+ * The gateway IIFE / executeReply body are too entangled to import
+ * directly. Following the same pattern as
+ * `turn-flush-dedup-controller.test.ts`, we model the contract as a
+ * pure function below and pin the post-fix invariant. If executeReply
+ * is ever refactored to extract this branch, the same assertions
+ * apply unchanged.
+ */
+import { describe, it, expect, vi } from 'vitest'
+
+interface ReplyTerminalDeps {
+  endStatusReaction: (chatId: string, threadId: number | undefined, outcome: 'done' | 'error') => void
+  writeError: (line: string) => void
+}
+
+/**
+ * Extract of the gateway executeReply post-send block. Mirrors the
+ * code at `telegram-plugin/gateway/gateway.ts` (post-fix, in the
+ * `if (sentIds.length > 0) { ... }` block after the send loop).
+ *
+ * Returns true if the terminal 👍 was fired.
+ */
+function applyReplyTerminalReaction(
+  chatId: string,
+  threadId: number | undefined,
+  sentIdsLength: number,
+  deps: ReplyTerminalDeps,
+): boolean {
+  if (sentIdsLength <= 0) return false
+  try {
+    deps.endStatusReaction(chatId, threadId, 'done')
+    return true
+  } catch (err) {
+    deps.writeError(`telegram gateway: reply: endStatusReaction hook threw: ${err}\n`)
+    return false
+  }
+}
+
+describe('PR #602 follow-up — plain reply tool terminal 👍', () => {
+  it('fires endStatusReaction("done") after at least one chunk lands', () => {
+    const endStatusReaction = vi.fn()
+    const writeError = vi.fn()
+
+    const fired = applyReplyTerminalReaction('-100', 42, 1, {
+      endStatusReaction,
+      writeError,
+    })
+
+    expect(fired).toBe(true)
+    expect(endStatusReaction).toHaveBeenCalledTimes(1)
+    expect(endStatusReaction).toHaveBeenCalledWith('-100', 42, 'done')
+    expect(writeError).not.toHaveBeenCalled()
+  })
+
+  it('passes threadId=undefined through unchanged for non-forum chats', () => {
+    // Plain DMs and non-forum supergroups don't carry a thread id —
+    // the controller key is `chatId:_`, not `chatId:<thread>`. Pin
+    // that the wiring forwards undefined rather than coercing to 0.
+    const endStatusReaction = vi.fn()
+    const writeError = vi.fn()
+
+    applyReplyTerminalReaction('123', undefined, 3, {
+      endStatusReaction,
+      writeError,
+    })
+
+    expect(endStatusReaction).toHaveBeenCalledWith('123', undefined, 'done')
+  })
+
+  it('does NOT fire when sentIds is empty (zero successful sends)', () => {
+    // The send loop's catch arm rethrows on persistent failure; we
+    // never reach the post-send block in that case. But pin the
+    // gating invariant: sentIds.length > 0 is the necessary
+    // precondition. A reply that fails before any chunk lands must
+    // not claim delivery.
+    const endStatusReaction = vi.fn()
+    const writeError = vi.fn()
+
+    const fired = applyReplyTerminalReaction('-200', undefined, 0, {
+      endStatusReaction,
+      writeError,
+    })
+
+    expect(fired).toBe(false)
+    expect(endStatusReaction).not.toHaveBeenCalled()
+  })
+
+  it('swallows endStatusReaction throws and surfaces them via writeError', () => {
+    // Defence-in-depth: the controller lookup may race a concurrent
+    // purge. The reply path must not surface a status-reaction
+    // bookkeeping failure to the agent — the message itself already
+    // landed. Pin that the throw is logged, not propagated.
+    const endStatusReaction = vi.fn(() => {
+      throw new Error('controller missing')
+    })
+    const writeError = vi.fn()
+
+    const fired = applyReplyTerminalReaction('-300', undefined, 1, {
+      endStatusReaction,
+      writeError,
+    })
+
+    expect(fired).toBe(false)
+    expect(endStatusReaction).toHaveBeenCalledTimes(1)
+    expect(writeError).toHaveBeenCalledTimes(1)
+    expect(writeError.mock.calls[0][0]).toMatch(/endStatusReaction hook threw/)
+  })
+
+  it('fires for multi-chunk replies as well as single-chunk', () => {
+    // Long replies are split across multiple sendMessage calls. As
+    // long as at least one chunk landed, the user saw the answer —
+    // the terminal 👍 reflects "delivered", not "delivered in one
+    // piece".
+    const endStatusReaction = vi.fn()
+    const writeError = vi.fn()
+
+    applyReplyTerminalReaction('-400', 7, 5, {
+      endStatusReaction,
+      writeError,
+    })
+
+    expect(endStatusReaction).toHaveBeenCalledWith('-400', 7, 'done')
+  })
+})

--- a/telegram-plugin/tests/stream-reply-handler.test.ts
+++ b/telegram-plugin/tests/stream-reply-handler.test.ts
@@ -180,11 +180,18 @@ describe('handleStreamReply', () => {
     expect(bot.api.sendMessage).toHaveBeenCalledTimes(1)
   })
 
-  it('done=true finalizes and deletes from map (does NOT fire terminal reaction)', async () => {
-    // Pins the intentional non-behavior: stream_reply(done=true) must NOT
-    // fire the 👍 terminal reaction. That is now the exclusive job of
-    // server.ts's turn_end handler, because a turn can call
-    // stream_reply(done=true) mid-flight and then continue working.
+  it('done=true finalizes and fires terminal 👍 on default lane after finalize resolves', async () => {
+    // Bug Z fix: stream_reply(done=true) on the default (unnamed) lane
+    // now fires endStatusReaction('done') AFTER stream.finalize()
+    // resolves. This ties the 👍 emoji to actual Telegram delivery
+    // (the final draft edit landing) rather than to JSONL turn_end
+    // (which races the disconnect-flush and the dedup-suppress paths).
+    //
+    // Previously this test asserted endStatusReaction was NOT called,
+    // and the gateway turn_end handler was the sole 👍 emitter. That
+    // design left 👍 firing off either (a) a 500ms-lagged read of
+    // local history (turn-flush dedup branch), or (b) a disconnect
+    // event that may have fired before any verification of delivery.
     const state = makeState()
     const endStatusReaction = vi.fn()
     const deps = makeDeps(bot, { endStatusReaction })
@@ -199,6 +206,47 @@ describe('handleStreamReply', () => {
 
     expect(result.status).toBe('finalized')
     expect(state.activeDraftStreams.size).toBe(0)
+    expect(endStatusReaction).toHaveBeenCalledTimes(1)
+    expect(endStatusReaction).toHaveBeenCalledWith('1', undefined, 'done')
+  })
+
+  it('done=true on a named lane does NOT fire terminal 👍', async () => {
+    // Named lanes (lane:'progress', lane:'thinking', lane:'activity'
+    // etc.) are internal driver emits, not user-visible answers. They
+    // must not be allowed to claim turn-completion: a progress-lane
+    // emit firing setDone would race the actual answer message.
+    const state = makeState()
+    const endStatusReaction = vi.fn()
+    const deps = makeDeps(bot, { endStatusReaction })
+
+    const pending = handleStreamReply(
+      { chat_id: '1', text: 'progress snapshot', done: true, lane: 'progress' },
+      state,
+      deps,
+    )
+    await microtaskFlush()
+    await pending
+
+    expect(endStatusReaction).not.toHaveBeenCalled()
+  })
+
+  it('done=true does NOT fire 👍 if finalize never produced a messageId', async () => {
+    // The over-limit branch throws before getMessageId() is non-null.
+    // Even if it didn't throw, a null messageId means the initial send
+    // never landed, so 👍 must not fire. Pinning that the gating on
+    // `getMessageId() != null` holds.
+    const state = makeState()
+    const endStatusReaction = vi.fn()
+    const deps = makeDeps(bot, { endStatusReaction })
+
+    await expect(
+      handleStreamReply(
+        { chat_id: '1', text: 'x'.repeat(5000), done: true },
+        state,
+        deps,
+      ),
+    ).rejects.toThrow(/exceeds Telegram's 4096-char limit/)
+
     expect(endStatusReaction).not.toHaveBeenCalled()
   })
 

--- a/telegram-plugin/tests/turn-flush-dedup-controller.test.ts
+++ b/telegram-plugin/tests/turn-flush-dedup-controller.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Bug D — turn-flush dedup branch must NOT prematurely fire setDone on
+ * the status-reaction controller.
+ *
+ * Background. The gateway's turn_end handler has three exits:
+ *   (1) `silent-marker` skip — drops streams, fires ctrl.setDone(), purges.
+ *   (2) `flush` — schedules an async IIFE that waits 500ms and either:
+ *       (2a) suppresses the flush because `getRecentOutboundCount > 0`
+ *            (the reply tool already sent something), OR
+ *       (2b) fires the captured text via bot.api.sendMessage as a backstop.
+ *   (3) main path — ctrl.setDone(), purge, telemetry.
+ *
+ * Path (2a) used to call `backstopCtrl.setDone()` on a 500ms-lagged read
+ * of local history — not a confirmation that anything actually reached
+ * Telegram. With Bug Z's fix, stream_reply(done=true) on the default
+ * lane fires `endStatusReaction('done')` AFTER `stream.finalize()`
+ * resolves (meaning the final draft edit landed in Telegram). So the
+ * authoritative 👍 source is the post-finalize callback, not the
+ * dedup-branch heuristic.
+ *
+ * This test pins the contract for the dedup branch: when
+ * `getRecentOutboundCount > 0`, the dedup branch must NOT fire setDone
+ * on the controller. The controller's terminal transition is left to
+ * the stream_reply post-finalize callback (already exercised in
+ * stream-reply-handler.test.ts).
+ *
+ * The gateway IIFE is too entangled to import directly. Rather than
+ * refactor the entire turn_end handler for testability in this PR, we
+ * model the dedup-branch logic as a pure function below and pin the
+ * post-fix invariant. If the gateway is ever refactored to extract
+ * this branch, the same assertions apply unchanged.
+ */
+import { describe, it, expect, vi } from 'vitest'
+
+interface MockController {
+  setDone: () => void
+  setError: () => void
+}
+
+interface DedupBranchDeps {
+  getRecentOutboundCount: (chatId: string, withinSec: number) => number
+  purgeReactionTracking: (key: string) => void
+  ctrl: MockController | null
+}
+
+/**
+ * Extract of the gateway turn-flush IIFE's dedup branch. Mirrors the
+ * code at `telegram-plugin/gateway/gateway.ts` lines ~3365-3376
+ * (post-fix). Returns true if the flush should be suppressed.
+ */
+function applyDedupBranch(
+  chatId: string,
+  statusKeyValue: string,
+  deps: DedupBranchDeps,
+): boolean {
+  const recentCount = deps.getRecentOutboundCount(chatId, 2)
+  if (recentCount > 0) {
+    // Bug D fix: do NOT fire setDone here. The post-finalize callback
+    // in stream-reply-handler.ts owns the terminal 👍 transition.
+    deps.purgeReactionTracking(statusKeyValue)
+    return true
+  }
+  return false
+}
+
+describe('Bug D — turn-flush dedup branch (post-fix)', () => {
+  it('suppresses flush when recentCount > 0 AND does NOT prematurely fire setDone', () => {
+    const setDone = vi.fn()
+    const setError = vi.fn()
+    const purgeReactionTracking = vi.fn()
+    const getRecentOutboundCount = vi.fn(() => 1) // dedup case: 1 outbound landed within 2s
+
+    const suppressed = applyDedupBranch(
+      '-100',
+      '-100:_',
+      {
+        getRecentOutboundCount,
+        purgeReactionTracking,
+        ctrl: { setDone, setError },
+      },
+    )
+
+    expect(suppressed).toBe(true)
+    expect(getRecentOutboundCount).toHaveBeenCalledWith('-100', 2)
+    expect(purgeReactionTracking).toHaveBeenCalledWith('-100:_')
+    // Critical: the controller is NOT touched here. Bug Z's
+    // post-finalize callback in stream-reply-handler.ts is what
+    // transitions the controller to terminal 👍 — and only after the
+    // final draft edit confirmedly lands in Telegram.
+    expect(setDone).not.toHaveBeenCalled()
+    expect(setError).not.toHaveBeenCalled()
+  })
+
+  it('falls through (returns false) when recentCount == 0 — backstop send required', () => {
+    // The other branch path: no recent outbound, so the IIFE will
+    // proceed to bot.api.sendMessage and (on success) call setDone
+    // there. This test pins that the dedup branch does NOT short-
+    // circuit when there's nothing to dedup against.
+    const setDone = vi.fn()
+    const purgeReactionTracking = vi.fn()
+    const getRecentOutboundCount = vi.fn(() => 0)
+
+    const suppressed = applyDedupBranch(
+      '-200',
+      '-200:_',
+      {
+        getRecentOutboundCount,
+        purgeReactionTracking,
+        ctrl: { setDone, setError: vi.fn() },
+      },
+    )
+
+    expect(suppressed).toBe(false)
+    expect(getRecentOutboundCount).toHaveBeenCalledWith('-200', 2)
+    // Neither side-effect should fire — the IIFE's backstop-send arm
+    // owns those (purge in the finally block, setDone after sendMessage
+    // resolves).
+    expect(purgeReactionTracking).not.toHaveBeenCalled()
+    expect(setDone).not.toHaveBeenCalled()
+  })
+
+  it('handles a missing controller gracefully (no throw)', () => {
+    // Defence-in-depth: the IIFE captures `backstopCtrl = ctrl` which
+    // may be null if no status-reaction was ever queued for this
+    // chat+thread. The guard previously read `if (backstopCtrl)
+    // backstopCtrl.setDone()`. With setDone removed entirely this is a
+    // non-issue, but pin the invariant anyway.
+    const purgeReactionTracking = vi.fn()
+    const getRecentOutboundCount = vi.fn(() => 5)
+
+    expect(() =>
+      applyDedupBranch(
+        '-300',
+        '-300:_',
+        {
+          getRecentOutboundCount,
+          purgeReactionTracking,
+          ctrl: null,
+        },
+      ),
+    ).not.toThrow()
+    expect(purgeReactionTracking).toHaveBeenCalledWith('-300:_')
+  })
+})


### PR DESCRIPTION
## Summary

Two related fixes that tighten when the 👍 status reaction fires. Both untether 👍 from JSONL turn_end / disconnect-flush heuristics and bind it to actual Telegram delivery confirmations.

### Bug D — turn-flush dedup branch fired setDone off lagged history

`telegram-plugin/gateway/gateway.ts:3371` (pre-fix). Inside the turn-flush async IIFE, the dedup-suppress arm fires after a 500ms wait. Pre-fix, when `getRecentOutboundCount > 0` the branch called `backstopCtrl.setDone()` — but that count is read from local history, not from a Telegram delivery confirmation. If sendMessage failed after recordOutbound was queued (or the wait window missed an in-flight failure), the user saw 👍 with no reply.

Fix: remove the premature `setDone()` from the dedup branch. The controller's terminal transition flows through Bug Z's post-finalize callback below, which is bound to the actual edit landing.

### Bug Z — stream_reply declared endStatusReaction but never called it

`telegram-plugin/stream-reply-handler.ts:204` declares the dep; the handler never invoked it. So 👍 timing was gated on JSONL turn_end (or the racy disconnect flush), not on `stream_reply(done=true)` actually delivering.

Fix: on `done=true`, AFTER `stream.finalize()` resolves AND only when the final messageId is non-null, fire `deps.endStatusReaction(chat_id, threadId, 'done')`. Gated to the default (unnamed) lane so internal driver emits (`lane:'progress'`, `'thinking'`, `'activity'`) do not claim turn-completion.

## Files

- `telegram-plugin/gateway/gateway.ts` — Bug D fix + extensive comment explaining why
- `telegram-plugin/stream-reply-handler.ts` — Bug Z fix at the post-finalize hook
- `telegram-plugin/tests/turn-flush-dedup-controller.test.ts` (new) — pins post-fix invariant
- `telegram-plugin/tests/stream-reply-handler.test.ts` — inverts the prior "does NOT fire" assertion + two new tests for the lane-gate and the null-messageId-gate

## Tradeoffs flagged

1. **Mid-turn done=true on default lane**: a turn that calls `stream_reply(done=true)` on the default lane and then keeps working will fire 👍 early. `setDone` is terminal — subsequent intermediate emojis become no-ops. The contract is now: `done=true` on the default lane means "the answer is delivered". Agents that need to continue should use named lanes or follow-up `reply` calls.

2. **Plain `reply` tool not wired**: the legacy `reply` path does NOT call `endStatusReaction`. Turns whose only outbound came through `reply` will leave the controller non-terminal until `purgeReactionTracking` removes it from the active map — meaning **no 👍 will render** on plain-reply turns post-fix. Per spec scope, Bug Z is stream_reply only; wiring `reply` is a follow-up.

## Coexistence

This PR does not touch `onClientDisconnected` (owned by `fix/553-disconnect-flush-hotfix` Bug A) or the IPC validator (Bug B).

## Test plan

- [x] `npm run lint` clean
- [x] `npx vitest run` — 4408 passing, 12 skipped
- [x] `cd telegram-plugin && bun test` — 2983 passing, 1 skip
- [x] New `turn-flush-dedup-controller.test.ts` — 3 tests, all pass
- [x] Modified `stream-reply-handler.test.ts` — 45 tests including 3 new/changed for Bug Z, all pass
- [ ] Live verification on `clerk` agent: send a stream_reply turn, confirm 👍 lands ONLY after the final edit visibly resolves
- [ ] Live regression check: send a `reply`-only turn, observe whether the missing-👍 regression is acceptable for now or needs an immediate follow-up wire-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)