### PR TITLE
feat(agent-add): forum topology — closes #543

### DIFF
--- a/src/agents/add-orchestrator.test.ts
+++ b/src/agents/add-orchestrator.test.ts
@@ -27,13 +27,26 @@ vi.mock("./create-orchestrator.js", () => ({
 }));
 
 vi.mock("../setup/onboarding.js", () => ({
-  writeAccessJson: vi.fn((agentDir: string, userId: string) => {
+  writeAccessJson: vi.fn((
+    agentDir: string,
+    userId: string,
+    forumChatId?: string,
+    topicId?: number,
+  ) => {
     const fs = require("node:fs") as typeof import("node:fs");
     const dir = join(agentDir, "telegram");
     fs.mkdirSync(dir, { recursive: true });
+    const groups: Record<string, unknown> = {};
+    if (forumChatId) {
+      groups[forumChatId] = {
+        requireMention: false,
+        allowFrom: [],
+        ...(topicId !== undefined ? { topicId } : {}),
+      };
+    }
     fs.writeFileSync(
       join(dir, "access.json"),
-      JSON.stringify({ allowFrom: [userId], groups: {} }, null, 2) + "\n",
+      JSON.stringify({ allowFrom: [userId], groups }, null, 2) + "\n",
     );
   }),
 }));
@@ -66,6 +79,7 @@ vi.mock("../setup/telegram-api.js", () => ({
 import { addAgent, runFinalPreflight, pruneBundledSkills } from "./add-orchestrator.js";
 import { createAgent, completeCreation } from "./create-orchestrator.js";
 import { runProfilePicker } from "../setup/profile-picker.js";
+import { writeAccessJson } from "../setup/onboarding.js";
 
 // Default BotFather walkthrough stub — every addAgent test injects this so
 // the orchestrator never reaches the real validateBotToken (no network).
@@ -785,5 +799,149 @@ describe("pruneBundledSkills", () => {
     expect(pruneBundledSkills(root, [], [])).toEqual([]);
     const { existsSync } = require("node:fs") as typeof import("node:fs");
     expect(existsSync(join(root, ".claude", "skills", "humanizer"))).toBe(true);
+  });
+});
+
+describe("addAgent — forum topology (#543 acceptance)", () => {
+  it("forum mode without forumChatId throws before scaffolding", async () => {
+    const runBotFather = fakeBotFather();
+    await expect(
+      addAgent({
+        name: "bot",
+        profile: "general",
+        botToken: "fake:token",
+        topology: "forum",
+        runBotFather,
+        readOAuthCode: async () => "browser-code",
+        skipStart: true,
+      }),
+    ).rejects.toThrow(/forum requires --forum-chat-id/);
+    // Should fail before any scaffolding work happens.
+    expect(createAgent).not.toHaveBeenCalled();
+  });
+
+  it("forum happy path writes access.json with the supplied forum-chat-id and topic-id", async () => {
+    const { agentDir } = setupAgentDir();
+    writeFileSync(
+      join(process.env.HOME!, ".config/systemd/user/switchroom-bot.service"),
+      "[Unit]\nExecStart=expect autoaccept\n",
+    );
+    (createAgent as any).mockResolvedValue({
+      sessionName: "auth-1",
+      agentDir,
+      loginUrl: undefined,
+    });
+    (completeCreation as any).mockResolvedValue({
+      outcome: { kind: "success" },
+      started: true,
+      instructions: [],
+    });
+
+    const result = await addAgent({
+      name: "bot",
+      profile: "general",
+      botToken: "fake:token",
+      topology: "forum",
+      forumChatId: "-1001234567890",
+      forumTopicId: 42,
+      allowFromUserId: "777",
+      runBotFather: fakeBotFather(),
+      readOAuthCode: async () => "browser-code",
+      isUnitActive: vi.fn().mockReturnValue(true),
+    });
+
+    expect(result.userId).toBe("777");
+    expect(writeAccessJson).toHaveBeenCalledWith(
+      agentDir,
+      "777",
+      "-1001234567890",
+      42,
+    );
+    // The mock captured the right shape — verify it on disk too.
+    const fs = require("node:fs") as typeof import("node:fs");
+    const access = JSON.parse(
+      fs.readFileSync(join(agentDir, "telegram", "access.json"), "utf-8"),
+    );
+    expect(access.allowFrom).toEqual(["777"]);
+    expect(access.groups["-1001234567890"]).toBeDefined();
+    expect(access.groups["-1001234567890"].topicId).toBe(42);
+  });
+
+  it("forum mode without topic-id still writes a group entry", async () => {
+    const { agentDir } = setupAgentDir();
+    writeFileSync(
+      join(process.env.HOME!, ".config/systemd/user/switchroom-bot.service"),
+      "[Unit]\nExecStart=expect autoaccept\n",
+    );
+    (createAgent as any).mockResolvedValue({
+      sessionName: "auth-1",
+      agentDir,
+      loginUrl: undefined,
+    });
+    (completeCreation as any).mockResolvedValue({
+      outcome: { kind: "success" },
+      started: true,
+      instructions: [],
+    });
+
+    await addAgent({
+      name: "bot",
+      profile: "general",
+      botToken: "fake:token",
+      topology: "forum",
+      forumChatId: "-1009999999999",
+      allowFromUserId: "888",
+      runBotFather: fakeBotFather(),
+      readOAuthCode: async () => "browser-code",
+      isUnitActive: vi.fn().mockReturnValue(true),
+    });
+
+    expect(writeAccessJson).toHaveBeenCalledWith(
+      agentDir,
+      "888",
+      "-1009999999999",
+      undefined,
+    );
+  });
+
+  it("DM mode ignores forumChatId / forumTopicId if accidentally passed", async () => {
+    const { agentDir } = setupAgentDir();
+    writeFileSync(
+      join(process.env.HOME!, ".config/systemd/user/switchroom-bot.service"),
+      "[Unit]\nExecStart=expect autoaccept\n",
+    );
+    (createAgent as any).mockResolvedValue({
+      sessionName: "auth-1",
+      agentDir,
+      loginUrl: undefined,
+    });
+    (completeCreation as any).mockResolvedValue({
+      outcome: { kind: "success" },
+      started: true,
+      instructions: [],
+    });
+
+    await addAgent({
+      name: "bot",
+      profile: "general",
+      botToken: "fake:token",
+      topology: "dm",
+      // Operator misuse: forum flags passed alongside topology=dm. The
+      // orchestrator silently drops them rather than throwing — the CLI
+      // surfaces a warning at the boundary.
+      forumChatId: "-100should-be-ignored",
+      forumTopicId: 99,
+      allowFromUserId: "555",
+      runBotFather: fakeBotFather(),
+      readOAuthCode: async () => "browser-code",
+      isUnitActive: vi.fn().mockReturnValue(true),
+    });
+
+    expect(writeAccessJson).toHaveBeenCalledWith(
+      agentDir,
+      "555",
+      "",
+      undefined,
+    );
   });
 });

--- a/src/agents/add-orchestrator.ts
+++ b/src/agents/add-orchestrator.ts
@@ -1,28 +1,30 @@
 /**
- * Workstream 1 of epic #543 — `switchroom agent add` n+1 bot wizard.
+ * `switchroom agent add` n+1 bot wizard — closes epic #543.
  *
- * Layers on top of `createAgent` / `completeCreation` (Phase 2 orchestrator)
- * to collapse the n+1 bot creation flow into a single CLI verb. Adds:
- *   - topology selection (dm | forum) — currently both write the same
- *     access.json shape but the topology argument is captured for forward
- *     compatibility with the forum-pairing flow (see #190).
- *   - DM pairing block — after auth completes the wizard polls Telegram
- *     for a `/start` DM from the new bot, then auto-writes
- *     telegram/access.json with the captured user_id. No second
- *     `switchroom setup` run required.
- *   - Final preflight loud-fail — autoaccept wrapper, bot token present,
- *     systemd unit running, access.json populated, MCP servers configured,
- *     and bot token managed via vault reference (workstream 3 of #543,
- *     closes #364 / #424 silent-failure modes). Each failed check produces
- *     an actionable error message rather than silent breakage.
+ * Single CLI verb that takes a new agent from "I want a bot for X" to
+ * "X is online, paired, with persona seeded" with zero hand-edits to
+ * switchroom.yaml, access.json, vault, or systemd. Steps:
  *
- * BotFather automation (#188) and the profile/skill picker (#190) are out
- * of scope for this workstream — both are stubbed with TODO markers
- * referencing those issues.
+ *   1. BotFather walkthrough (or validate a pre-supplied --bot-token).
+ *      Asserts the bot's username matches the agent slug. (#552 / WS2)
+ *   2. Profile + skill picker (or validate --profile / --skills). The
+ *      picker copies bundled skills from profiles/<name>/skills into
+ *      the agent's .claude/skills/ tree. (#554 / WS4)
+ *   3. createAgent — scaffold (CLAUDE.md, SOUL.md, IDENTITY.md, USER.md,
+ *      MEMORY.md), systemd unit, MCP servers, and switchroom.yaml entry.
+ *   4. OAuth code relay — terminal stdin or test seam.
+ *   5. completeCreation — submit code, start the agent.
+ *   6. Pairing block — for DM topology, polls Telegram for the
+ *      operator's first /start DM then auto-writes telegram/access.json.
+ *      For forum topology (--forum-chat-id required), still uses the
+ *      DM /start to capture allowFrom but adds a forum group entry.
+ *   7. Final preflight loud-fail — autoaccept wrapper, vault token
+ *      reference, systemd active, access.json populated, MCP servers
+ *      configured. (#551 / WS3)
  *
  * The pairing step is skippable via `allowFromUserId` — useful for
- * non-interactive tests and for re-running against an already-paired
- * deployment.
+ * non-interactive tests and redeploys against an already-paired
+ * operator.
  */
 
 import { resolve, join } from "node:path";
@@ -84,8 +86,29 @@ export interface AddAgentOpts {
    * "paste the token" loop.
    */
   readLine?: (prompt: string) => Promise<string>;
-  /** Topology — "dm" today; "forum" reserved for #190 forum-pairing UX. */
+  /**
+   * Channel topology. "dm" pairs the bot to a single user via /start;
+   * "forum" routes inbound messages from a Telegram supergroup forum
+   * topic. Forum mode requires `forumChatId` (and optionally
+   * `forumTopicId`) — supplied by the operator since the wizard can't
+   * yet auto-create a forum group.
+   */
   topology: AgentTopology;
+  /**
+   * Forum chat ID — required when topology is "forum". The chat ID of
+   * the supergroup that this bot will receive messages from. Supergroup
+   * IDs are negative ("-100…"); the wizard does not validate the sign
+   * but does require the value to be non-empty in forum mode. Ignored
+   * when topology is "dm".
+   */
+  forumChatId?: string;
+  /**
+   * Optional Telegram message-thread (topic) ID inside the forum chat.
+   * When set, persisted into access.json so the gateway can scope the
+   * agent's group policy to a single topic. Ignored when topology is
+   * "dm".
+   */
+  forumTopicId?: number;
   /**
    * Optional: skip the DM pairing block and write access.json with this
    * user ID directly. Useful for test runs and for redeploys against an
@@ -181,13 +204,16 @@ const DEFAULT_PAIR_TIMEOUT_MS = 5 * 60 * 1000;
  * Run the n+1 bot wizard end-to-end.
  *
  * Sequencing:
- *   1. (stub) BotFather automation — see #188.
+ *   1. BotFather walkthrough (or validate --bot-token) — captures and
+ *      verifies the agent's bot token, asserts username/slug match.
+ *   1b. Profile + skill picker (or validate --profile / --skills).
  *   2. createAgent — scaffold + systemd + auth session.
  *   3. readOAuthCode — caller relays the OAuth dance (terminal stdin or
  *      a future foreman bot).
  *   4. completeCreation — submit code + start the agent.
  *   5. Pairing block — pollForDmStart unless allowFromUserId is given.
- *      Writes telegram/access.json with the captured user_id.
+ *      Writes telegram/access.json with the captured user_id and (for
+ *      forum topology) the supplied forum-chat-id / topic-id.
  *   6. Final preflight — autoaccept wrapper, vault token, systemd active,
  *      access.json populated.
  */
@@ -196,6 +222,18 @@ export async function addAgent(opts: AddAgentOpts): Promise<AddAgentResult> {
   const pairTimeout = opts.pairTimeoutMs ?? DEFAULT_PAIR_TIMEOUT_MS;
   const pollPair = opts.pollForPair ?? pollForDmStart;
   const isActive = opts.isUnitActive ?? defaultIsUnitActive;
+
+  // Forum mode requires the operator to supply the supergroup chat-id
+  // up-front. Auto-creating forum groups via Bot API isn't supported,
+  // and falling back to DM shape (the pre-WS5 behaviour) is the silent-
+  // failure mode #543 explicitly wants to retire.
+  if (opts.topology === "forum" && !opts.forumChatId) {
+    throw new Error(
+      "topology=forum requires --forum-chat-id <id>. " +
+        "Find your forum supergroup ID by forwarding a message from it to @userinfobot, " +
+        "or run `switchroom topics list` once the bot is in the group.",
+    );
+  }
 
   // ── Step 1: BotFather walkthrough (#188) ─────────────────────────────────
   // Either validate the token the operator already has, or guide them
@@ -310,14 +348,23 @@ export async function addAgent(opts: AddAgentOpts): Promise<AddAgentResult> {
   }
 
   // ── Step 5b: write access.json ───────────────────────────────────────────
-  // Topology is captured for forward-compat — today both shapes use the
-  // same allowFrom + groups skeleton (writeAccessJson). The forum-chat-id
-  // is left as a placeholder; #190's profile/picker will fill the actual
-  // forum chat once the topology=forum branch grows real semantics.
+  // DM mode: only the per-user `allowFrom` matters; the `groups` block is
+  // written with an empty key and ignored by the gateway.
+  // Forum mode: the operator supplied --forum-chat-id, which becomes the
+  // group key, and (optionally) --topic-id which scopes the policy to a
+  // single forum topic.
   const agentDir = created.agentDir;
-  const forumChatId = ""; // forum support deferred — see #190
-  writeAccessJson(agentDir, userId, forumChatId);
-  log(`[5/6] Wrote access.json with allowFrom=[${userId}]`);
+  const forumChatId = opts.topology === "forum" ? (opts.forumChatId ?? "") : "";
+  const forumTopicId = opts.topology === "forum" ? opts.forumTopicId : undefined;
+  writeAccessJson(agentDir, userId, forumChatId, forumTopicId);
+  log(
+    `[5/6] Wrote access.json (allowFrom=[${userId}]` +
+      (opts.topology === "forum"
+        ? `, forum_chat_id=${forumChatId}` +
+          (forumTopicId !== undefined ? `, topic_id=${forumTopicId}` : "")
+        : "") +
+      `)`,
+  );
 
   // ── Step 6: final preflight — loud-fail per check ────────────────────────
   log(`[6/6] Running final preflight…`);

--- a/src/cli/agent.ts
+++ b/src/cli/agent.ts
@@ -1896,16 +1896,17 @@ export function registerAgentCommand(program: Command): void {
 
   // switchroom agent add <name>
   //
-  // Workstream 1 of epic #543 — n+1 bot wizard. Single verb that takes a
-  // new bot from zero to running, paired, with persona seeded. Wraps
+  // n+1 bot wizard (epic #543). Single verb takes a new bot from zero
+  // to running, paired, persona seeded, with no hand-edits. Wraps
   // bootstrap (createAgent + completeCreation) and adds:
-  //   - topology selection (--topology dm|forum)
-  //   - DM pairing block (poll Telegram for /start, auto-write access.json)
-  //   - final preflight loud-fail (autoaccept, token, systemd, access.json)
+  //   - BotFather walkthrough (or validate an existing --bot-token)
+  //   - profile + skill picker (or validate --profile / --skills)
+  //   - topology selection (dm | forum, with --forum-chat-id)
+  //   - pairing block (poll Telegram for /start, auto-write access.json)
+  //   - final preflight loud-fail (autoaccept, token, systemd, MCP, vault)
   //
-  // BotFather automation (#188) and profile/skill picker (#190) are stubbed
-  // — supply --profile and --bot-token from the existing setup until those
-  // ship.
+  // See src/agents/add-orchestrator.ts for the orchestration. All five
+  // workstreams of #543 are now wired here.
   agent
     .command("add <name>")
     .description(
@@ -1921,8 +1922,16 @@ export function registerAgentCommand(program: Command): void {
     )
     .option(
       "--topology <topology>",
-      "Channel topology: 'dm' (default) or 'forum' (forum support deferred — see #190)",
+      "Channel topology: 'dm' (default — pair the bot to a single user via /start) or 'forum' (route inbound messages from a Telegram supergroup forum topic; requires --forum-chat-id).",
       "dm",
+    )
+    .option(
+      "--forum-chat-id <id>",
+      "Telegram supergroup chat ID (negative integer) for forum topology. Required when --topology forum. Forward a message from the group to @userinfobot to find it.",
+    )
+    .option(
+      "--topic-id <id>",
+      "Telegram message-thread (topic) ID inside the forum chat. Optional; scopes the agent's group policy to a single forum topic. Only meaningful with --topology forum.",
     )
     .option(
       "--bot-token <token>",
@@ -1951,6 +1960,8 @@ export function registerAgentCommand(program: Command): void {
           profile?: string;
           skills?: string;
           topology: string;
+          forumChatId?: string;
+          topicId?: string;
           botToken?: string;
           botUsername?: string;
           loose?: boolean;
@@ -1973,13 +1984,30 @@ export function registerAgentCommand(program: Command): void {
           process.exit(1);
         }
         const topology = opts.topology as AgentTopology;
-        if (topology === "forum") {
-          console.warn(
-            chalk.yellow(
-              "Note: --topology forum is accepted but the forum-pairing UX is deferred to #190. " +
-                "Falling back to DM access.json shape (a placeholder allowFrom for the forum chat).",
+        if (topology === "forum" && !opts.forumChatId) {
+          console.error(
+            chalk.red(
+              "Error: --topology forum requires --forum-chat-id <id>. " +
+                "Forward a message from the supergroup to @userinfobot to find the chat ID.",
             ),
           );
+          process.exit(1);
+        }
+        if (topology === "dm" && (opts.forumChatId || opts.topicId)) {
+          console.warn(
+            chalk.yellow(
+              "Warning: --forum-chat-id / --topic-id are ignored when --topology=dm.",
+            ),
+          );
+        }
+
+        let forumTopicId: number | undefined;
+        if (opts.topicId !== undefined) {
+          forumTopicId = Number.parseInt(opts.topicId, 10);
+          if (!Number.isFinite(forumTopicId) || forumTopicId < 0) {
+            console.error(chalk.red(`Invalid --topic-id: "${opts.topicId}". Must be a non-negative integer.`));
+            process.exit(1);
+          }
         }
 
         const pairTimeoutMs = opts.pairTimeoutMs
@@ -2028,6 +2056,8 @@ export function registerAgentCommand(program: Command): void {
             botUsername: opts.botUsername,
             loose: opts.loose,
             topology,
+            forumChatId: opts.forumChatId,
+            forumTopicId,
             allowFromUserId: opts.allowFrom,
             pairTimeoutMs,
             configPath,


### PR DESCRIPTION
## Summary

Final wizard polish for epic **#543**. `--topology forum` is now fully wired; previously it accepted the flag, printed a "deferred to #190" warning, and silently fell back to DM access.json shape. Now it requires `--forum-chat-id`, accepts an optional `--topic-id`, and writes the correct group entry.

## What ships

- **`switchroom agent add --topology forum --forum-chat-id <id> [--topic-id <id>]`** — fully working forum mode. Validation: forum without chat-id errors before scaffolding; DM with forum flags warns at the boundary.
- **Stale-comment cleanup** — removes "stubbed — see #188 / #190" markers (both shipped as #552 / #554) and the "(stub) BotFather automation" annotation. Header rewritten to reflect the post-WS5 state.
- **4 new tests** (`addAgent — forum topology (#543 acceptance)`):
  - forum without chat-id throws before scaffolding (no `createAgent` side effects)
  - forum happy path persists chat-id + topic-id into `access.json` `groups`
  - forum happy path without topic-id (forum_chat_id only)
  - DM mode drops accidentally-supplied forum flags

## Why this closes #543

Epic acceptance:
> A new bot — for any family member, **any topology** — goes from "I want a bot for X" to "X has a bot, paired, with persona seeded" in **one wizard run**, with **zero hand-edits**.

Status by workstream:
- **WS1** wizard core — #544 ✓
- **WS2** BotFather walkthrough — #552 ✓
- **WS3** Loud preflight — #551 ✓
- **WS4** Profile / skill picker — #554 ✓
- **WS5** Plugin install on-ramp — #555 ✓
- **Forum topology** — *this PR* ✓

Cross-cutting items the epic listed (#47 global injection, #322 native rearch, #230/#231/#239 plugin path, #424 silent failures, #161 Telegram-as-2FA) are tracked as their own issues; the epic's "would massively help" wording explicitly defers them.

## Test plan

- [x] `npm run lint` — passes
- [x] `npx vitest run src/agents/add-orchestrator.test.ts` — 29/29 (4 new + 25 existing)
- [x] `npm run test:vitest` — 4434/4447, 13 skipped, 0 fail
- [x] `npm run build` — clean
- [x] `bun run dev -- agent add --help` — new flags surface in help with the right descriptions

## Principle checks

- **Docs test** ✅ — `--help` is self-documenting; the error message tells the operator how to find their forum chat-id (forward to @userinfobot).
- **Defaults test** ✅ — DM remains the default; existing `switchroom agent add` invocations are unchanged.
- **Consistency test** ✅ — `--forum-chat-id` matches the existing flag style (`--bot-token`, `--allow-from`, etc.).

🤖 Generated with [Claude Code](https://claude.com/claude-code)