### PR TITLE
test: stateful harness upgrades to catch reaction/dedup/lifecycle bug classes

### DIFF
--- a/telegram-plugin/tests/HARNESS.md
+++ b/telegram-plugin/tests/HARNESS.md
@@ -8,10 +8,31 @@ talks to Telegram. Use this when you're touching anything that calls
 
 | File | Purpose |
 |---|---|
-| [`fake-bot-api.ts`](./fake-bot-api.ts) | Full mock of `bot.api.*`. Tracks chat model (sent[], pinned, reactions, deleted), supports fault injection with real `GrammyError` shapes. **Use this for sequence/lifecycle tests.** |
+| [`fake-bot-api.ts`](./fake-bot-api.ts) | Full mock of `bot.api.*`. Tracks chat model (sent[], pinned, reactions, deleted), supports fault injection with real `GrammyError` shapes, optional `holdNext` for in-flight ordering tests, optional `validateParseMode` for catching malformed MarkdownV2. **Use this for sequence/lifecycle tests.** |
 | [`bot-api.harness.ts`](./bot-api.harness.ts) | Lighter mock — just `vi.fn()` stubs with sensible defaults. **Use this when you only need to assert on call shapes**, not chat-model state. |
-| [`update-factory.ts`](./update-factory.ts) | Typed factories for Telegram `Update` objects: text messages, callback queries, photos, documents, my_chat_member events, forum-topic messages. |
+| [`update-factory.ts`](./update-factory.ts) | Typed factories for Telegram `Update` objects: text messages, edited messages, message reactions, callback queries, photos, documents, my_chat_member events, forum-topic messages. |
+| [`waiting-ux-harness.ts`](./waiting-ux-harness.ts) | Phase 1: real `StatusReactionController` + real `ProgressDriver` + recording fake bot + fake clock. Pin the four waiting-UX deadlines (Class A/B/C/F1–F4) under `vi.useFakeTimers()`. |
+| [`real-gateway-harness.ts`](./real-gateway-harness.ts) | Phase 3: wraps `waiting-ux-harness` with the real production `InboundCoalescer` and real `flushOnAgentDisconnect`. IPC lifecycle simulation (`bridgeConnect`/`bridgeDisconnect`), opt-in `withDedup` for replay-suppression tests. **The default home for new lifecycle/timing tests.** |
 | [`fake-bot-api.test.ts`](./fake-bot-api.test.ts) | Self-test of the fake bot — if this ever breaks, every test that depends on it is suspect. |
+
+## Validation rule for new tests
+
+**Every regression test must carry a `// fails when:` comment**
+indicating the production change that would break the invariant. Then
+mentally `git stash` that change and confirm the test fails. Without
+this round-trip the test is theatre — it asserts what the code already
+does, not what it must continue to do.
+
+Example:
+
+```ts
+it('👍 fires AT-OR-AFTER last delivery', async () => {
+  // fails when: a future refactor moves setDone() from the streamReply
+  // post-await branch back to the JSONL turn_end handler — exactly
+  // Bug D's failure mode.
+  ...
+})
+```
 
 ## Decision: which mock?
 
@@ -147,6 +168,119 @@ case) and the pure tests honest (no accidental coupling to bot calls).
 - **Don't assert on the entire Telegram payload** — assert on the
   semantic fields (chat_id, text, parse_mode). Bot API adds optional
   fields over time and full-payload snapshots churn.
+
+## Pattern 7 — `holdNext`: park a call mid-flight
+
+Some bugs are about ordering between an in-flight outbound and an
+inbound event — the canonical example is Bug D (👍 fired while
+`editMessageText` was still pending). Asserting "X happens BEFORE Y
+resolves" with `vi.advanceTimersByTime` is fragile because the
+production code's await boundaries shift with refactors.
+
+`holdNext` parks the next matching call at a gate. The test fires the
+unrelated event while the call is parked, then explicitly releases:
+
+```ts
+import { createFakeBotApi } from './fake-bot-api.js'
+
+const bot = createFakeBotApi()
+const r = await bot.api.sendMessage('c1', 'long enough text content', {})
+
+// Park the next editMessageText call.
+const hold = bot.holdNext('editMessageText', 'c1')
+
+// Start the edit — promise pending until release.
+const editPromise = bot.api.editMessageText('c1', r.message_id, 'updated', {})
+await Promise.resolve() // let the call enter its await
+
+expect(hold.triggered()).toBe(true)
+
+// Fire the unrelated event while the edit is parked.
+await bot.api.setMessageReaction('c1', r.message_id, [{ type: 'emoji', emoji: '👍' }])
+expect(bot.state.reactions.length).toBe(1)
+// Edit hasn't landed yet:
+expect(bot.textOf(r.message_id)).toBe('long enough text content')
+
+// Release — edit completes.
+hold.release()
+await editPromise
+expect(bot.textOf(r.message_id)).toBe('updated')
+```
+
+`hold.release()` is the happy path; `hold.fail(err)` rejects the held
+call with `err` if the test wants to simulate an in-flight failure.
+`hold.triggered()` returns true once the held call enters its await —
+useful for confirming "yes, the call is parked here" before firing the
+follow-up event.
+
+Holds are FIFO per method, just like faults. `bot.reset()` rejects any
+unreleased holds so a leaked hold from one test doesn't hang the next.
+
+## Pattern 8 — wired-in `OutboundDedupCache` for replay tests
+
+The #546 bug class is "two paths emit the same content." The fix is
+`OutboundDedupCache` (`telegram-plugin/recent-outbound-dedup.ts`) — a
+process-wide cache keyed by `(chatId, threadId)` that suppresses
+duplicate normalized content within a TTL.
+
+The real-gateway harness wires this in opt-in:
+
+```ts
+import { createRealGatewayHarness } from './real-gateway-harness.js'
+
+const h = createRealGatewayHarness({ withDedup: true })
+const r1 = await h.send({ chat_id: CHAT, text: 'long content...' })
+const r2 = await h.send({ chat_id: CHAT, text: 'long content...' }) // suppressed
+expect(r2).toBeNull()
+expect(h.dedupSuppressedCount()).toBe(1)
+expect(h.dedup!.size(Date.now())).toBe(1)
+```
+
+`harness.send()` is the dedup-aware "fresh send" path — always issues
+a new `sendMessage`, never edits. Use it in replay-dup tests where
+"two messages with the same content" means two distinct user-visible
+messages, not a streaming edit-in-place. (For streaming-edit
+behavior, use `harness.streamReply()` as before.)
+
+`simulateRetryDup({ chat_id, text })` is a one-line scenario for the
+full #546 reproducer: send → bridge cycle → send again → assert
+suppressed. See `real-gateway-i6-turn-flush-replay-dedup.test.ts`.
+
+## Pattern 9 — opt-in `validateParseMode` lenient validator
+
+Real Telegram returns 400 on unbalanced MarkdownV2. The fake accepts
+any string by default to keep 167 existing tests passing. New tests
+opt in:
+
+```ts
+const bot = createFakeBotApi({ validateParseMode: 'lenient' })
+await expect(
+  bot.api.sendMessage('c1', '*unbalanced markdown', { parse_mode: 'MarkdownV2' }),
+).rejects.toMatchObject({ error_code: 400 })
+```
+
+Lenient mode catches the most common failure: unbalanced count of
+marker characters (`*`, `_`, `` ` ``, `[`). Backslash-escaped markers
+and content inside inline-code / fenced code blocks are exempt. It is
+NOT a full Telegram parser — corner cases like nested entities or
+custom emoji escapes won't trigger it. For those, use a real-DC
+nightly job (out of scope for the in-process fake).
+
+## Bug-class catalog
+
+Each shipped bug class has a regression home. When fixing a new bug,
+add the test next to its class. Update this table.
+
+| Class | Example | Test home |
+|---|---|---|
+| Reaction timing desync | Bug D (👍 before delivery) | `real-gateway-ipc-lifecycle.test.ts` I3, `harness-ordering-invariants.test.ts` INV-1/INV-2 |
+| IPC lifecycle leak | Bug A (anon disconnect flush) | `real-gateway-ipc-lifecycle.test.ts` I1, I2 |
+| Legacy IPC type lethality | Bug B (`update_placeholder` crash) | `real-gateway-ipc-lifecycle.test.ts` I4 |
+| Content-dup retry | #546 (turn-flush + replay) | `real-gateway-i6-turn-flush-replay-dedup.test.ts` |
+| Respawn dedup defense | Bug C (wake-audit) | `real-gateway-i6-turn-flush-replay-dedup.test.ts` I5(b); profile-side fix lives elsewhere |
+| Edit-on-deleted | latent | `harness-ordering-invariants.test.ts` INV-3 |
+| Parse-mode malformed | latent | `harness-parse-mode-validation.test.ts` |
+| Update factory shape | latent | `update-factory-edited-and-reactions.test.ts` |
 
 ## Pattern 6 — fixture-based integration tests for external-format parsers
 

--- a/telegram-plugin/tests/fake-bot-api.test.ts
+++ b/telegram-plugin/tests/fake-bot-api.test.ts
@@ -162,4 +162,52 @@ describe('fake-bot-api', () => {
       expect(r.message_id).toBe(100) // counter reset to startMessageId
     })
   })
+
+  describe('holdNext', () => {
+    it('parks a call until release()', async () => {
+      const r = await bot.api.sendMessage('c', 'long enough seed text x')
+      const hold = bot.holdNext('editMessageText', 'c')
+      const editPromise = bot.api.editMessageText('c', r.message_id, 'updated text long')
+      await Promise.resolve()
+      expect(hold.triggered()).toBe(true)
+      // Edit hasn't landed yet.
+      expect(bot.textOf(r.message_id)).toBe('long enough seed text x')
+      hold.release()
+      await editPromise
+      expect(bot.textOf(r.message_id)).toBe('updated text long')
+    })
+
+    it('fail() rejects the held call without applying the mutation', async () => {
+      const r = await bot.api.sendMessage('c', 'long enough seed text y')
+      const hold = bot.holdNext('editMessageText', 'c')
+      const editPromise = bot.api.editMessageText('c', r.message_id, 'never lands here')
+      await Promise.resolve()
+      hold.fail(new Error('synthetic in-flight failure'))
+      await expect(editPromise).rejects.toThrow('synthetic in-flight failure')
+      // Original text intact.
+      expect(bot.textOf(r.message_id)).toBe('long enough seed text y')
+    })
+
+    it('fault wins over hold when both queued for same method (fault is checked first)', async () => {
+      // Pin the precedence rule documented in fake-bot-api.ts: fault
+      // checks happen synchronously before the hold gate is awaited.
+      // This matters because production code often combines retry-on-
+      // fault logic with timing tests — picking one or the other is
+      // the documented contract.
+      bot.faults.next('sendMessage', errors.floodWait(3))
+      const hold = bot.holdNext('sendMessage')
+      await expect(bot.api.sendMessage('c', 'will fail synchronously')).rejects.toBeInstanceOf(GrammyError)
+      // Hold was never entered — the fault threw before the await.
+      expect(hold.triggered()).toBe(false)
+    })
+
+    it('reset() rejects unreleased holds so a leaked hold cannot hang the next test', async () => {
+      const r = await bot.api.sendMessage('c', 'long enough seed text z')
+      bot.holdNext('editMessageText', 'c')
+      const editPromise = bot.api.editMessageText('c', r.message_id, 'parked then reset')
+      // Don't release — simulate a test that forgets cleanup.
+      bot.reset()
+      await expect(editPromise).rejects.toThrow(/reset/)
+    })
+  })
 })

--- a/telegram-plugin/tests/fake-bot-api.ts
+++ b/telegram-plugin/tests/fake-bot-api.ts
@@ -74,6 +74,32 @@ export interface FaultInjector {
   reset(): void
 }
 
+export interface HoldHandle {
+  /** Resolve the held call so it completes its normal mutation + return. */
+  release(): void
+  /** Reject the held call with `error` instead of letting it complete. */
+  fail(error: unknown): void
+  /** Whether the held call has been entered (the API method awaited the gate). */
+  triggered(): boolean
+}
+
+/**
+ * Hold queue entry — when a matching call hits, it `await`s `gate`
+ * before doing its normal work. `release()` resolves the gate;
+ * `fail(err)` rejects it. The handle's `triggered` flag flips true
+ * once the production call enters the await — useful for tests to
+ * confirm "yes, the in-flight call is parked here, now I can fire the
+ * other event."
+ */
+interface HoldQueueEntry {
+  method: string
+  chat_id?: string
+  gate: Promise<void>
+  resolve: () => void
+  reject: (err: unknown) => void
+  setTriggered: () => void
+}
+
 /**
  * Build a `GrammyError` with realistic payload — grammy's own
  * constructor needs `(message, ApiError, method, payload)`.
@@ -187,8 +213,40 @@ export interface FakeBot {
   textOf(message_id: number): string | null
   /** Is a given message currently pinned? */
   isPinned(chat_id: string, message_id: number): boolean
-  /** Reset all state and fault queue. */
+  /**
+   * Hold the next matching call in-flight. Returns a handle whose
+   * `release()` lets the call complete. Used to assert ordering between
+   * an in-flight outbound and an unrelated inbound event without timer
+   * fragility — e.g. "👍 must NOT fire while editMessageText is still
+   * pending." See HARNESS.md Pattern 7.
+   *
+   * FIFO across multiple holds for the same method. Hold matches before
+   * fault matches, so combining the two yields surprising results —
+   * pick one per call.
+   */
+  holdNext(method: string, chat_id?: string): HoldHandle
+  /** Reset all state, fault queue, and hold queue. */
   reset(): void
+}
+
+/**
+ * Parse-mode validation strictness. Real Telegram returns 400 on
+ * unbalanced MarkdownV2/HTML entities; the fake accepts everything by
+ * default to preserve back-compat with all existing tests. Tests that
+ * want catch-malformed-markdown coverage opt in via 'lenient' (catches
+ * the common imbalances) or 'strict' (reserved for future stricter
+ * checks).
+ */
+export type ParseModeValidation = 'off' | 'lenient' | 'strict'
+
+export interface CreateFakeBotApiOpts {
+  startMessageId?: number
+  /**
+   * If 'lenient' or 'strict', sendMessage/editMessageText with
+   * `parse_mode: 'MarkdownV2'` reject unbalanced markers (`*`, `_`,
+   * `` ` ``, `[`, `]`). Default 'off'. See parseModeBalanced.
+   */
+  validateParseMode?: ParseModeValidation
 }
 
 /**
@@ -200,9 +258,11 @@ export interface FakeBot {
  *   - `fake.state` — did the outbound message model converge to what we expect?
  *   - `fake.api.sendMessage.mock.calls` — exactly which call sequence fired?
  *   - `fake.faults.next(...)` — "the Telegram API happens to fail this way now".
+ *   - `fake.holdNext(...)` — "park this call mid-flight while I fire something else".
  */
-export function createFakeBotApi(opts: { startMessageId?: number } = {}): FakeBot {
+export function createFakeBotApi(opts: CreateFakeBotApiOpts = {}): FakeBot {
   let nextMessageId = opts.startMessageId ?? 500
+  const validateParseMode: ParseModeValidation = opts.validateParseMode ?? 'off'
 
   const sent: SentMessage[] = []
   const currentText = new Map<number, string>()
@@ -214,6 +274,11 @@ export function createFakeBotApi(opts: { startMessageId?: number } = {}): FakeBo
   // request comes in, we try the chat-scoped queue first, then the
   // method-wide queue.
   const faultQueue: FaultQueueEntry[] = []
+  const holdQueue: HoldQueueEntry[] = []
+  // Holds that have matched a call and are awaiting `release()` or
+  // `fail()`. Tracked separately so `reset()` can reject any in-flight
+  // holds left dangling by a forgotten cleanup.
+  const triggeredHolds = new Set<HoldQueueEntry>()
 
   function pullFault(method: string, chat_id: string | undefined): unknown | null {
     // Chat-scoped match first
@@ -235,14 +300,66 @@ export function createFakeBotApi(opts: { startMessageId?: number } = {}): FakeBo
     return null
   }
 
+  function pullHold(method: string, chat_id: string | undefined): HoldQueueEntry | null {
+    for (let i = 0; i < holdQueue.length; i++) {
+      const h = holdQueue[i]
+      if (h.method === method && h.chat_id != null && h.chat_id === chat_id) {
+        holdQueue.splice(i, 1)
+        return h
+      }
+    }
+    for (let i = 0; i < holdQueue.length; i++) {
+      const h = holdQueue[i]
+      if (h.method === method && h.chat_id == null) {
+        holdQueue.splice(i, 1)
+        return h
+      }
+    }
+    return null
+  }
+
   function maybeThrow(method: string, chat_id: string | undefined): void {
     const err = pullFault(method, chat_id)
     if (err != null) throw err
   }
 
+  /**
+   * Common entry for any API method: pull a fault (throw), then await
+   * a hold gate (if matched). Order matters — fault checks happen
+   * before the hold so a queued fault still fires synchronously the
+   * way real grammy errors do, and tests that hold + fault don't
+   * accidentally trigger both.
+   */
+  async function applyEntryGates(method: string, chat_id: string | undefined): Promise<void> {
+    maybeThrow(method, chat_id)
+    const hold = pullHold(method, chat_id)
+    if (hold != null) {
+      hold.setTriggered()
+      triggeredHolds.add(hold)
+      try {
+        await hold.gate
+      } finally {
+        triggeredHolds.delete(hold)
+      }
+    }
+  }
+
+  function checkParseMode(method: string, text: string, parse_mode: string | undefined): void {
+    if (validateParseMode === 'off') return
+    if (parse_mode !== 'MarkdownV2') return
+    const issue = parseModeBalanced(text)
+    if (issue == null) return
+    throw makeGrammyError({
+      error_code: 400,
+      description: `Bad Request: can't parse entities: ${issue}`,
+      method,
+    })
+  }
+
   const api: FakeBotApi = {
     sendMessage: vi.fn(async (chat_id: string, text: string, opts?: Record<string, unknown>) => {
-      maybeThrow('sendMessage', chat_id)
+      await applyEntryGates('sendMessage', chat_id)
+      checkParseMode('sendMessage', text, opts?.parse_mode as string | undefined)
       const message_id = nextMessageId++
       const record: SentMessage = {
         message_id,
@@ -259,8 +376,9 @@ export function createFakeBotApi(opts: { startMessageId?: number } = {}): FakeBo
     }),
 
     editMessageText: vi.fn(
-      async (chat_id: string, message_id: number, text: string, _opts?: Record<string, unknown>) => {
-        maybeThrow('editMessageText', chat_id)
+      async (chat_id: string, message_id: number, text: string, opts?: Record<string, unknown>) => {
+        await applyEntryGates('editMessageText', chat_id)
+        checkParseMode('editMessageText', text, opts?.parse_mode as string | undefined)
         if (deleted.has(message_id) || !currentText.has(message_id)) {
           // Simulate Telegram's real 400 when the target is gone.
           throw errors.messageToEditNotFound()
@@ -275,7 +393,7 @@ export function createFakeBotApi(opts: { startMessageId?: number } = {}): FakeBo
     ),
 
     deleteMessage: vi.fn(async (chat_id: string, message_id: number) => {
-      maybeThrow('deleteMessage', chat_id)
+      await applyEntryGates('deleteMessage', chat_id)
       if (deleted.has(message_id) || !currentText.has(message_id)) {
         throw errors.messageToDeleteNotFound()
       }
@@ -290,7 +408,7 @@ export function createFakeBotApi(opts: { startMessageId?: number } = {}): FakeBo
 
     setMessageReaction: vi.fn(
       async (chat_id: string, message_id: number, react: unknown) => {
-        maybeThrow('setMessageReaction', chat_id)
+        await applyEntryGates('setMessageReaction', chat_id)
         // Overwrite existing
         const idx = reactions.findIndex(
           (r) => r.chat_id === chat_id && r.message_id === message_id,
@@ -304,54 +422,54 @@ export function createFakeBotApi(opts: { startMessageId?: number } = {}): FakeBo
 
     editMessageReplyMarkup: vi.fn(
       async (chat_id: string, _message_id: number, _opts?: unknown) => {
-        maybeThrow('editMessageReplyMarkup', chat_id)
+        await applyEntryGates('editMessageReplyMarkup', chat_id)
         return true as const
       },
     ),
 
     sendChatAction: vi.fn(async (chat_id: string, _action: string) => {
-      maybeThrow('sendChatAction', chat_id)
+      await applyEntryGates('sendChatAction', chat_id)
       return true as const
     }),
 
     pinChatMessage: vi.fn(async (chat_id: string, message_id: number, _opts?: unknown) => {
-      maybeThrow('pinChatMessage', chat_id)
+      await applyEntryGates('pinChatMessage', chat_id)
       pinned.push({ chat_id, message_id })
       return true as const
     }),
 
     unpinChatMessage: vi.fn(async (chat_id: string, message_id: number) => {
-      maybeThrow('unpinChatMessage', chat_id)
+      await applyEntryGates('unpinChatMessage', chat_id)
       const idx = pinned.findIndex((p) => p.chat_id === chat_id && p.message_id === message_id)
       if (idx >= 0) pinned.splice(idx, 1)
       return true as const
     }),
 
     getFile: vi.fn(async (file_id: string) => {
-      maybeThrow('getFile', undefined)
+      await applyEntryGates('getFile', undefined)
       return { file_id, file_unique_id: 'uniq-' + file_id, file_size: 1024, file_path: 'documents/file.bin' }
     }),
 
     getMe: vi.fn(async () => {
-      maybeThrow('getMe', undefined)
+      await applyEntryGates('getMe', undefined)
       return { id: 999, is_bot: true, first_name: 'TestBot', username: 'test_bot', can_join_groups: true, can_read_all_group_messages: false, supports_inline_queries: false }
     }),
 
     setMyCommands: vi.fn(async () => true as const),
 
     forwardMessage: vi.fn(async (chat_id: string) => {
-      maybeThrow('forwardMessage', chat_id)
+      await applyEntryGates('forwardMessage', chat_id)
       const message_id = nextMessageId++
       return { message_id, chat: { id: chat_id }, date: Math.floor(Date.now() / 1000) }
     }),
 
     getChat: vi.fn(async (chat_id: string) => {
-      maybeThrow('getChat', String(chat_id))
+      await applyEntryGates('getChat', String(chat_id))
       return { id: chat_id, type: 'supergroup' as const, is_forum: true }
     }),
 
     sendDocument: vi.fn(async (chat_id: string) => {
-      maybeThrow('sendDocument', chat_id)
+      await applyEntryGates('sendDocument', chat_id)
       const message_id = nextMessageId++
       sent.push({ message_id, chat_id, text: '' })
       currentText.set(message_id, '')
@@ -359,7 +477,7 @@ export function createFakeBotApi(opts: { startMessageId?: number } = {}): FakeBo
     }),
 
     sendPhoto: vi.fn(async (chat_id: string, _photo: unknown, opts?: Record<string, unknown>) => {
-      maybeThrow('sendPhoto', chat_id)
+      await applyEntryGates('sendPhoto', chat_id)
       const message_id = nextMessageId++
       const caption = (opts?.caption as string | undefined) ?? ''
       sent.push({ message_id, chat_id, text: caption })
@@ -379,6 +497,32 @@ export function createFakeBotApi(opts: { startMessageId?: number } = {}): FakeBo
     },
   }
 
+  function holdNext(method: string, chat_id?: string): HoldHandle {
+    let resolve!: () => void
+    let reject!: (err: unknown) => void
+    const gate = new Promise<void>((res, rej) => {
+      resolve = res
+      reject = rej
+    })
+    let triggered = false
+    const entry: HoldQueueEntry = {
+      method,
+      chat_id,
+      gate,
+      resolve,
+      reject,
+      setTriggered: () => {
+        triggered = true
+      },
+    }
+    holdQueue.push(entry)
+    return {
+      release: () => entry.resolve(),
+      fail: (err) => entry.reject(err),
+      triggered: () => triggered,
+    }
+  }
+
   const bot: FakeBot = {
     api,
     state: {
@@ -395,6 +539,7 @@ export function createFakeBotApi(opts: { startMessageId?: number } = {}): FakeBo
     isPinned(chat_id, message_id) {
       return pinned.some((p) => p.chat_id === chat_id && p.message_id === message_id)
     },
+    holdNext,
     reset() {
       sent.length = 0
       currentText.clear()
@@ -402,6 +547,15 @@ export function createFakeBotApi(opts: { startMessageId?: number } = {}): FakeBo
       reactions.length = 0
       deleted.clear()
       faultQueue.length = 0
+      // Drain any unreleased holds — letting them survive a reset would
+      // cause a later test to inherit a "stuck" call. Reject both
+      // queued (never matched) and triggered (matched, awaiting
+      // release) holds so any dangling awaits surface as test
+      // failures, not silent hangs.
+      for (const h of holdQueue) h.reject(new Error('fake-bot reset() called while hold pending'))
+      holdQueue.length = 0
+      for (const h of triggeredHolds) h.reject(new Error('fake-bot reset() called while hold in flight'))
+      triggeredHolds.clear()
       nextMessageId = opts.startMessageId ?? 500
       for (const fn of Object.values(api)) (fn as ReturnType<typeof vi.fn>).mockClear()
     },
@@ -416,4 +570,48 @@ export function createFakeBotApi(opts: { startMessageId?: number } = {}): FakeBo
  */
 export function installFakeBotResetHook(bot: FakeBot): void {
   beforeEach(() => bot.reset())
+}
+
+/**
+ * Lenient MarkdownV2 balance check. Returns null if the text looks
+ * balanced; returns a one-line description if it doesn't. Used by
+ * `validateParseMode: 'lenient'` to mimic Telegram's
+ * `can't parse entities` 400.
+ *
+ * Not a real parser — just checks the count of unescaped marker
+ * characters. Telegram's full grammar is more complex (nested entities,
+ * the e2e parser at https://core.telegram.org/bots/api#markdownv2-style),
+ * but unbalanced counts catch the most common mistakes (forgetting to
+ * close a `*` after a token break in a streamed message).
+ *
+ * Markers checked: `*`, `_`, `` ` ``, `[` / `]`. Backslash-escaped
+ * markers (`\*`) are ignored. Triple-backtick code blocks are
+ * collapsed first (their inner content is exempt from emphasis rules).
+ */
+export function parseModeBalanced(text: string): string | null {
+  // Strip code blocks (```...```) — content inside is verbatim.
+  const stripped = text.replace(/```[\s\S]*?```/g, '')
+  // Strip inline code (`...`) — also verbatim.
+  const stripped2 = stripped.replace(/`[^`\n]*`/g, '')
+  // Strip backslash-escaped chars.
+  const stripped3 = stripped2.replace(/\\[*_`\[\]()~>#+\-=|{}.!\\]/g, '')
+
+  const counts: Record<string, number> = { '*': 0, _: 0 }
+  let bracketDepth = 0
+  for (const ch of stripped3) {
+    if (ch === '*' || ch === '_') counts[ch]++
+    else if (ch === '[') bracketDepth++
+    else if (ch === ']') {
+      bracketDepth--
+      if (bracketDepth < 0) return "unbalanced ']' bracket"
+    }
+  }
+  if (counts['*'] % 2 !== 0) return "unbalanced '*' (bold marker)"
+  if (counts['_'] % 2 !== 0) return "unbalanced '_' (italic marker)"
+  if (bracketDepth !== 0) return "unbalanced '[' bracket"
+  // Backticks: count remaining (unstripped) — should be 0 after the
+  // inline-code strip above.
+  const tickCount = (stripped3.match(/`/g) ?? []).length
+  if (tickCount !== 0) return 'unbalanced backtick'
+  return null
 }

--- a/telegram-plugin/tests/harness-ordering-invariants.test.ts
+++ b/telegram-plugin/tests/harness-ordering-invariants.test.ts
@@ -1,0 +1,243 @@
+/**
+ * Harness ordering invariants — table-driven scenarios.
+ *
+ * These tests assert cross-cutting properties that hold across a range
+ * of turn shapes (Class A/B/C, retry, replay-dup, error-cascade). The
+ * scenarios are deterministic and named, not random — see
+ * HARNESS_UPGRADE_PLAN.md "scenario fuzzer" decision (skeptic finding 7:
+ * property-based fuzzing without shrinking is worse than no fuzzing).
+ *
+ * Each invariant carries a `// fails when:` comment indicating the
+ * production change that would break it. The test author should mentally
+ * `git stash` that change and confirm the test fails — see plan
+ * "Validation rule for each new test."
+ *
+ * Invariants:
+ *
+ *   INV-1 — Terminal reaction (👍) fires AT-OR-AFTER the last user-
+ *           visible answer text. NEVER before. The Bug D/Z contract
+ *           generalized to all turn shapes.
+ *
+ *   INV-2 — Exactly one terminal reaction fires per logical turn
+ *           (regardless of how many tool emoji ladder steps occurred
+ *           in between). Catches a future regression where setDone
+ *           fires twice.
+ *
+ *   INV-3 — Editing a deleted message always errors. Catches a
+ *           regression in the fake's delete-vs-edit ordering, which
+ *           would let a buggy production module silently miss the
+ *           "edit-to-deleted-message" failure mode in tests.
+ *
+ *   INV-4 — Outbound dedup window holds for the full TTL once the
+ *           cache is wired in.
+ *
+ *   INV-5 — Hold-and-release ordering: an event fired while a
+ *           sendMessage/editMessageText is parked at `holdNext`
+ *           observes the world as it was BEFORE the held call landed.
+ *           This pins the harness's own contract — necessary for
+ *           future Bug-D-class tests to be expressible.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createRealGatewayHarness } from './real-gateway-harness.js'
+import { createFakeBotApi } from './fake-bot-api.js'
+
+const CHAT = '8248703757'
+const INBOUND_MSG = 100
+
+beforeEach(() => {
+  vi.useFakeTimers()
+})
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+interface TurnShape {
+  name: string
+  /** Drive the harness through one logical turn. Resolves when turn ended. */
+  drive: (h: ReturnType<typeof createRealGatewayHarness>) => Promise<void>
+}
+
+const turnShapes: TurnShape[] = [
+  {
+    name: 'class-A reply (sub-2s, no tools)',
+    drive: async (h) => {
+      h.inbound({ chatId: CHAT, messageId: INBOUND_MSG, text: 'hi' })
+      h.feedSessionEvent({
+        kind: 'enqueue',
+        chatId: CHAT,
+        messageId: '1',
+        threadId: null,
+        rawContent: 'hi',
+      })
+      await h.clock.advance(20)
+      await h.streamReply({ chat_id: CHAT, text: 'Hello back!', done: true })
+      await h.clock.advance(20)
+    },
+  },
+  {
+    name: 'class-B with-tools (1 tool, ~3s)',
+    drive: async (h) => {
+      h.inbound({ chatId: CHAT, messageId: INBOUND_MSG, text: 'work' })
+      h.feedSessionEvent({
+        kind: 'enqueue',
+        chatId: CHAT,
+        messageId: '1',
+        threadId: null,
+        rawContent: 'work',
+      })
+      await h.clock.advance(50)
+      h.feedSessionEvent({ kind: 'thinking' })
+      await h.clock.advance(500)
+      h.feedSessionEvent({ kind: 'tool_use', toolName: 'Read' })
+      await h.clock.advance(2500)
+      await h.streamReply({ chat_id: CHAT, text: 'Here is the answer.', done: true })
+      await h.clock.advance(20)
+    },
+  },
+  {
+    name: 'class-C subagent (long, ~10s, sub-agent emit)',
+    drive: async (h) => {
+      h.inbound({ chatId: CHAT, messageId: INBOUND_MSG, text: 'big task' })
+      h.feedSessionEvent({
+        kind: 'enqueue',
+        chatId: CHAT,
+        messageId: '1',
+        threadId: null,
+        rawContent: 'big task',
+      })
+      await h.clock.advance(50)
+      h.feedSessionEvent({ kind: 'thinking' })
+      await h.clock.advance(500)
+      h.feedSessionEvent({ kind: 'tool_use', toolName: 'Read' })
+      await h.clock.advance(2000)
+      h.feedSessionEvent({ kind: 'tool_use', toolName: 'Grep' })
+      await h.clock.advance(2000)
+      h.feedSessionEvent({ kind: 'tool_use', toolName: 'Edit' })
+      await h.clock.advance(5000)
+      await h.streamReply({ chat_id: CHAT, text: 'Done — see the diff above.', done: true })
+      await h.clock.advance(20)
+    },
+  },
+]
+
+describe('INV-1 — terminal reaction fires AT-OR-AFTER last delivery (Bug D/Z generalized)', () => {
+  for (const shape of turnShapes) {
+    it(`${shape.name}: lastReactionEmojiAt >= lastAnswerTextDeliveredAt`, async () => {
+      // fails when: a future refactor moves setDone() from the streamReply
+      // post-await branch back to the JSONL turn_end handler — exactly
+      // Bug D's failure mode, generalized over turn shapes.
+      const h = createRealGatewayHarness({ gapMs: 0 })
+      await shape.drive(h)
+      const deliveredAt = h.lastAnswerTextDeliveredAt(CHAT)
+      const reactionAt = h.lastReactionEmojiAt(CHAT)
+      expect(deliveredAt, `no answer text delivered for ${shape.name}`).not.toBeNull()
+      expect(reactionAt, `no reaction emitted for ${shape.name}`).not.toBeNull()
+      expect(reactionAt!).toBeGreaterThanOrEqual(deliveredAt!)
+      h.finalize()
+    })
+  }
+})
+
+describe('INV-2 — terminal 👍 fires exactly once per turn (Bug Z generalized)', () => {
+  for (const shape of turnShapes) {
+    it(`${shape.name}: 👍 appears exactly once across the full reaction sequence`, async () => {
+      // fails when: a future change fires setDone() more than once
+      // for the same turn (e.g. both the streamReply post-await branch
+      // AND the turn_end JSONL handler call it). Specifically asserting
+      // the COUNT of 👍 in the full sequence — not just "the last
+      // emoji is unique" (which would be a tautology).
+      const h = createRealGatewayHarness({ gapMs: 0 })
+      await shape.drive(h)
+      const seq = h.recorder.reactionSequence()
+      expect(seq.length, `no reactions for ${shape.name}`).toBeGreaterThan(0)
+      const thumbsUpCount = seq.filter((e) => e === '👍').length
+      expect(thumbsUpCount).toBe(1)
+      // And the 👍 is the LAST reaction — terminal contract.
+      expect(seq[seq.length - 1]).toBe('👍')
+      h.finalize()
+    })
+  }
+})
+
+describe('INV-3 — editing a deleted message always errors', () => {
+  it('fake throws messageToEditNotFound after the message is deleted', async () => {
+    // fails when: someone changes fake-bot-api's editMessageText to
+    // silently succeed for deleted messages — production modules
+    // would then look correct in tests but error in real Telegram.
+    const bot = createFakeBotApi()
+    const r = (await bot.api.sendMessage('c1', 'long enough text content here ok', {})) as {
+      message_id: number
+    }
+    await bot.api.deleteMessage('c1', r.message_id)
+    await expect(
+      bot.api.editMessageText('c1', r.message_id, 'updated text content here ok', {}),
+    ).rejects.toMatchObject({ error_code: 400 })
+  })
+})
+
+describe('INV-4 — outbound dedup window holds for the full TTL', () => {
+  // Span of "now" offsets within the TTL that should all be deduped.
+  const inWindowOffsets = [0, 1000, 30_000, 59_000]
+  // Span outside the TTL that should NOT be deduped.
+  const outOfWindowOffsets = [60_001, 120_000]
+
+  for (const ms of inWindowOffsets) {
+    it(`same content at +${ms}ms is suppressed (within TTL=60s)`, async () => {
+      // fails when: TTL is silently shortened, or the cache's eviction
+      // sweep evicts entries before their TTL expires.
+      const h = createRealGatewayHarness({ gapMs: 0, withDedup: true })
+      const text = 'A long enough message to clear the 24-char dedup floor by a wide margin.'
+      await h.send({ chat_id: CHAT, text })
+      await h.clock.advance(ms)
+      const id2 = await h.send({ chat_id: CHAT, text })
+      expect(id2).toBeNull()
+      h.finalize()
+    })
+  }
+
+  for (const ms of outOfWindowOffsets) {
+    it(`same content at +${ms}ms is allowed (outside TTL)`, async () => {
+      // fails when: TTL eviction breaks (entries linger past their TTL).
+      const h = createRealGatewayHarness({ gapMs: 0, withDedup: true })
+      const text = 'A long enough message to clear the 24-char dedup floor by a wide margin.'
+      await h.send({ chat_id: CHAT, text })
+      await h.clock.advance(ms)
+      const id2 = await h.send({ chat_id: CHAT, text })
+      expect(id2).not.toBeNull()
+      h.finalize()
+    })
+  }
+})
+
+describe('INV-5 — holdNext: events fired during a held call observe pre-held state', () => {
+  it('a setMessageReaction parked at holdNext lets unrelated state mutate before its release', async () => {
+    // fails when: a future fake-bot refactor makes holdNext block
+    // mutations on OTHER methods, or makes release() synchronous when
+    // it should be async.
+    //
+    // This is the foundational seam that makes Bug-D-class tests
+    // expressible: "while editMessageText is pending, fire the 👍" —
+    // the harness must let the 👍 land while the edit is parked.
+    const bot = createFakeBotApi()
+    const r = (await bot.api.sendMessage('c1', 'long enough text content here ok', {})) as {
+      message_id: number
+    }
+    const hold = bot.holdNext('editMessageText', 'c1')
+    // Start the edit; it parks at the gate.
+    const editPromise = bot.api.editMessageText('c1', r.message_id, 'edited content here ok', {})
+    // Yield a microtask so the held call enters its await.
+    await Promise.resolve()
+    expect(hold.triggered()).toBe(true)
+    // Fire something else — setMessageReaction — and confirm it lands
+    // independently while the edit is still parked.
+    await bot.api.setMessageReaction('c1', r.message_id, [{ type: 'emoji', emoji: '👍' }])
+    expect(bot.state.reactions.length).toBe(1)
+    // The edit's text hasn't landed yet — the message is still original.
+    expect(bot.textOf(r.message_id)).toBe('long enough text content here ok')
+    // Release the edit — now the text updates.
+    hold.release()
+    await editPromise
+    expect(bot.textOf(r.message_id)).toBe('edited content here ok')
+  })
+})

--- a/telegram-plugin/tests/harness-parse-mode-validation.test.ts
+++ b/telegram-plugin/tests/harness-parse-mode-validation.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Parse-mode validation in the fake bot — opt-in via
+ * `createFakeBotApi({ validateParseMode: 'lenient' })`.
+ *
+ * Why this matters: real Telegram returns 400 with cryptic
+ * "can't parse entities" errors on unbalanced MarkdownV2 (a missing
+ * `*`, an unclosed `_`, etc.). The fake accepted any string by
+ * default, so production code that emits malformed markdown looked
+ * fine in tests and broke in chat. This is the test surface for the
+ * new lenient validator.
+ *
+ * Lenient ≠ a full Telegram parser. It catches the most common
+ * mistake — unbalanced count of marker chars — which is what
+ * streaming-update bugs (chunk break mid-emphasis) produce. A full
+ * parser is bounded but tedious; lenient is the 80/20.
+ */
+
+import { describe, expect, it } from 'vitest'
+import { createFakeBotApi, parseModeBalanced } from './fake-bot-api.js'
+
+describe('parseModeBalanced — pure helper', () => {
+  it('balanced text returns null', () => {
+    expect(parseModeBalanced('hello world')).toBeNull()
+    expect(parseModeBalanced('*bold*')).toBeNull()
+    expect(parseModeBalanced('_italic_')).toBeNull()
+    expect(parseModeBalanced('*bold* and _italic_')).toBeNull()
+    expect(parseModeBalanced('a link [text](url)')).toBeNull()
+    expect(parseModeBalanced('inline `code` ok')).toBeNull()
+    expect(parseModeBalanced('```\ncode block\n```')).toBeNull()
+  })
+
+  it('flags unbalanced *', () => {
+    expect(parseModeBalanced('*bold but no close')).toContain("'*'")
+  })
+
+  it('flags unbalanced _', () => {
+    expect(parseModeBalanced('_italic but no close')).toContain("'_'")
+  })
+
+  it('flags unbalanced [', () => {
+    expect(parseModeBalanced('a [link without close')).toContain("'['")
+  })
+
+  it('flags unbalanced backtick', () => {
+    expect(parseModeBalanced('inline `unclosed code')).toContain('backtick')
+  })
+
+  it('escaped markers are exempt', () => {
+    expect(parseModeBalanced('this is a literal \\* asterisk')).toBeNull()
+    expect(parseModeBalanced('escaped \\_ underscore')).toBeNull()
+  })
+
+  it('content inside ``` code blocks is exempt', () => {
+    expect(parseModeBalanced('```\nthis * has unbalanced markers _\n```')).toBeNull()
+  })
+
+  it('content inside `inline` code is exempt', () => {
+    expect(parseModeBalanced('look at `*` and `_` markers')).toBeNull()
+  })
+})
+
+describe('createFakeBotApi({ validateParseMode })', () => {
+  it("default (off) accepts unbalanced MarkdownV2 (back-compat)", async () => {
+    // fails when: the default of validateParseMode changes from 'off',
+    // breaking the 167 existing tests that rely on permissive behavior.
+    const bot = createFakeBotApi()
+    await expect(
+      bot.api.sendMessage('c1', '*unbalanced markdown', { parse_mode: 'MarkdownV2' }),
+    ).resolves.toMatchObject({ message_id: expect.any(Number) })
+  })
+
+  it('lenient mode rejects unbalanced MarkdownV2 with a 400-shaped error', async () => {
+    // fails when: the validator is turned off silently, OR the error
+    // shape stops matching what robustApiCall in production looks for
+    // (instanceof GrammyError with error_code 400).
+    const bot = createFakeBotApi({ validateParseMode: 'lenient' })
+    await expect(
+      bot.api.sendMessage('c1', '*unbalanced markdown', { parse_mode: 'MarkdownV2' }),
+    ).rejects.toMatchObject({ error_code: 400 })
+  })
+
+  it('lenient mode accepts well-formed MarkdownV2', async () => {
+    const bot = createFakeBotApi({ validateParseMode: 'lenient' })
+    await expect(
+      bot.api.sendMessage('c1', '*bold* and _italic_', { parse_mode: 'MarkdownV2' }),
+    ).resolves.toMatchObject({ message_id: expect.any(Number) })
+  })
+
+  it('lenient mode does NOT validate when parse_mode is HTML or absent', async () => {
+    // We only validate MarkdownV2 in lenient mode — HTML has different
+    // failure modes (Telegram is more forgiving) and plain-text has
+    // no entities to validate.
+    const bot = createFakeBotApi({ validateParseMode: 'lenient' })
+    await expect(
+      bot.api.sendMessage('c1', '*unbalanced markdown', { parse_mode: 'HTML' }),
+    ).resolves.toBeDefined()
+    await expect(
+      bot.api.sendMessage('c1', '*unbalanced markdown'),
+    ).resolves.toBeDefined()
+  })
+
+  it('lenient mode validates editMessageText too', async () => {
+    // Streaming updates are the most common source of malformed
+    // MarkdownV2 (chunk break mid-entity). Validation must fire on
+    // editMessageText, not just sendMessage.
+    const bot = createFakeBotApi({ validateParseMode: 'lenient' })
+    const r = (await bot.api.sendMessage('c1', 'initial *ok*', { parse_mode: 'MarkdownV2' })) as {
+      message_id: number
+    }
+    await expect(
+      bot.api.editMessageText('c1', r.message_id, '*broken edit', { parse_mode: 'MarkdownV2' }),
+    ).rejects.toMatchObject({ error_code: 400 })
+  })
+})

--- a/telegram-plugin/tests/real-gateway-harness.ts
+++ b/telegram-plugin/tests/real-gateway-harness.ts
@@ -50,6 +50,7 @@ import {
 import { validateClientMessage } from '../gateway/ipc-server.js'
 import { flushOnAgentDisconnect } from '../gateway/disconnect-flush.js'
 import { StatusReactionController } from '../status-reactions.js'
+import { OutboundDedupCache } from '../recent-outbound-dedup.js'
 
 /**
  * Literal placeholder strings the v2 spec contract forbids. Listed
@@ -96,6 +97,23 @@ export interface RealGatewayHarnessOpts extends CreateHarnessOpts {
    * coalescing entirely.
    */
   gapMs?: number
+
+  /**
+   * Wire the production `OutboundDedupCache` into the harness's
+   * `streamReply` path. When enabled, repeated streamReply calls with
+   * the same normalized content within the TTL are suppressed —
+   * mimicking the #546 fix in production. Default false (preserves
+   * back-compat with F1–F4 tests that don't care about dedup).
+   *
+   * When true, tests can introspect the cache via `harness.dedup`.
+   */
+  withDedup?: boolean
+
+  /**
+   * TTL for the wired-in dedup cache. Only used when `withDedup` is
+   * true. Default matches production (`DEFAULT_DEDUP_TTL_MS = 60_000`).
+   */
+  dedupTtlMs?: number
 }
 
 interface CoalescePayload {
@@ -231,6 +249,63 @@ export interface RealGatewayHarnessHandle extends HarnessHandle {
     flushLog: ReadonlyArray<string>
     activeAgentCount: number
   }
+
+  // ─── #546 dedup integration ─────────────────────────────────────────
+  /**
+   * Real `OutboundDedupCache` wired into the harness's `streamReply`
+   * path when `opts.withDedup === true`. Null otherwise. Tests assert
+   * on `harness.dedup.size(now)` to confirm a record landed; or invoke
+   * `harness.dedup.check(...)` directly to verify a hit before the
+   * second send is attempted.
+   */
+  dedup: OutboundDedupCache | null
+
+  /**
+   * Count of dedup-suppressed sends since harness creation. When the
+   * cache catches a retry, the harness records this so I6 / replay
+   * tests can assert "yes, dedup actually fired" without poking at
+   * counters in the cache.
+   */
+  dedupSuppressedCount(): number
+
+  /**
+   * Convenience scenario: simulate the #546 turn-flush + replay
+   * sequence end-to-end:
+   *   1. First send(text) — lands as a fresh sendMessage and records
+   *      into the dedup cache.
+   *   2. Bridge disconnects + a fresh agent reconnects. Disconnect is
+   *      REGISTERED (not anonymous) so `flushOnAgentDisconnect` actually
+   *      runs — proving dedup survives the production cleanup path.
+   *      Anonymous disconnects are a no-op (I1) and would let this
+   *      scenario pass even if dedup were broken in flush.
+   *   3. Second send(text) — claude-code's preserved tool_call replay.
+   *      Should be suppressed by dedup (no second outbound landed).
+   *
+   * Returns `{ firstMessageId, suppressedSecond, flushRan }`. Tests
+   * assert `suppressedSecond === true` AND `flushRan === true` so the
+   * full path is exercised, not a tautology.
+   */
+  simulateRetryDup(args: {
+    chat_id: string
+    text: string
+  }): Promise<{
+    firstMessageId: number | null
+    suppressedSecond: boolean
+    flushRan: boolean
+  }>
+
+  /**
+   * "Fresh send" — always issues a new `sendMessage` for `chat_id`,
+   * does NOT update the harness's stream-edit cache. Routes through
+   * the dedup cache when wired. Mirrors production's turn-flush
+   * backstop and the wake-audit greeting path: every fire is a
+   * fresh user-visible message, not a streaming edit. Use this in
+   * dedup tests where "the same content emitted twice" means two
+   * NEW messages, not a streaming edit-in-place.
+   *
+   * Returns the new `message_id`, or null if dedup suppressed the send.
+   */
+  send(args: { chat_id: string; text: string; parse_mode?: string }): Promise<number | null>
 }
 
 const DEFAULT_GAP_MS = 1500
@@ -358,6 +433,98 @@ export function createRealGatewayHarness(
         !isPlaceholderPayload(c.payload),
     )
     return hits.length === 0 ? null : hits[hits.length - 1].ts
+  }
+
+  // ─── #546 dedup wiring (opt-in) ───────────────────────────────────────
+  // When `withDedup` is set, wrap the inner harness's `streamReply` so
+  // the same content sent twice within the TTL only lands once. Mirrors
+  // the production fix at `gateway.ts:2233` (`executeStreamReply`) and
+  // `gateway.ts:1893` (`executeReply`): both check the cache, return
+  // early on hit (NOT calling setDone — the original send already
+  // finalized), and record after a successful send. F1–F4 tests don't
+  // care about dedup so it stays opt-in.
+  //
+  // INVARIANT MIRROR: production's dedup-hit branch returns
+  //   { content: [{ type: 'text', text: 'sent (deduped — ...)' }] }
+  // without firing setDone. The harness wrap matches this — the
+  // controller is left untouched on suppression. If production
+  // changes (e.g. fires setDone on suppression for some reason),
+  // update both sites together.
+  const dedup = opts.withDedup === true ? new OutboundDedupCache({ ttlMs: opts.dedupTtlMs }) : null
+  let dedupSuppressed = 0
+  const innerStreamReply = inner.streamReply
+  const streamReply = dedup == null
+    ? innerStreamReply
+    : async (args: { chat_id: string; text: string; done?: boolean }): Promise<void> => {
+        const now = Date.now()
+        const hit = dedup.check(args.chat_id, undefined, args.text, now)
+        if (hit != null) {
+          dedupSuppressed++
+          return
+        }
+        await innerStreamReply(args)
+        dedup.record(args.chat_id, undefined, args.text, Date.now())
+      }
+
+  /**
+   * Fresh-send wrapper. Routes through the dedup cache (if wired) and
+   * always calls `bot.api.sendMessage` directly — bypasses the inner
+   * harness's stream-edit cache. Returns the new message_id, or null
+   * if dedup suppressed the send.
+   */
+  async function send(args: {
+    chat_id: string
+    text: string
+    parse_mode?: string
+  }): Promise<number | null> {
+    const now = Date.now()
+    if (dedup != null) {
+      const hit = dedup.check(args.chat_id, undefined, args.text, now)
+      if (hit != null) {
+        dedupSuppressed++
+        return null
+      }
+    }
+    const result = (await inner.bot.api.sendMessage(args.chat_id, args.text, {
+      parse_mode: args.parse_mode ?? 'HTML',
+    })) as { message_id: number }
+    if (dedup != null) {
+      dedup.record(args.chat_id, undefined, args.text, Date.now())
+    }
+    return result.message_id
+  }
+
+  async function simulateRetryDup(args: {
+    chat_id: string
+    text: string
+  }): Promise<{
+    firstMessageId: number | null
+    suppressedSecond: boolean
+    flushRan: boolean
+  }> {
+    if (dedup == null) {
+      throw new Error(
+        'simulateRetryDup requires withDedup: true on createRealGatewayHarness',
+      )
+    }
+    const firstMessageId = await send(args)
+
+    // Bridge cycle with a REGISTERED agent so flushOnAgentDisconnect
+    // actually runs. Anonymous disconnects no-op (I1) — using one
+    // there would make the scenario a tautology (the bridge cycle
+    // wouldn't touch state at all). Production's #546 reproducer
+    // involves the claude-code bridge (registered) crashing, so the
+    // registered path is the one we need to prove dedup survives.
+    const flushBefore = disposeProgressDriverCalls
+    const cid = bridgeConnect('agent-claude')
+    bridgeDisconnect(cid)
+    const flushRan = disposeProgressDriverCalls > flushBefore
+
+    const suppressedBefore = dedupSuppressed
+    const secondMessageId = await send(args)
+    const suppressedSecond = dedupSuppressed > suppressedBefore && secondMessageId == null
+
+    return { firstMessageId, suppressedSecond, flushRan }
   }
 
   // ─── IPC + bridge lifecycle simulation ────────────────────────────────
@@ -493,5 +660,10 @@ export function createRealGatewayHarness(
     lastReactionEmojiAt,
     lastAnswerTextDeliveredAt,
     flushSideEffects,
+    streamReply,
+    dedup,
+    dedupSuppressedCount: () => dedupSuppressed,
+    simulateRetryDup,
+    send,
   }
 }

--- a/telegram-plugin/tests/real-gateway-i6-turn-flush-replay-dedup.test.ts
+++ b/telegram-plugin/tests/real-gateway-i6-turn-flush-replay-dedup.test.ts
@@ -1,0 +1,238 @@
+/**
+ * I6 — Turn-flush + replay duplicate-content suppression (#546).
+ *
+ * THIS FILE IS A REGRESSION-PREVENTION LAYER. See
+ * `real-gateway-ipc-lifecycle.test.ts` for the I1–I5 backstory.
+ *
+ * Bug #546 (resolved by 5bed5b7 — "outbound content-dedup window"):
+ * agent emits text → bridge disconnects mid-flight → gateway's
+ * turn-flush backstop sends the buffered text as HTML → bridge
+ * reconnects → claude-code replays the un-acked stream_reply tool_call
+ * with identical content but raw markdown → user sees the same content
+ * twice.
+ *
+ * The fix added `OutboundDedupCache` (telegram-plugin/recent-outbound-
+ * dedup.ts), which has 23 unit tests on the cache logic but ZERO
+ * integration tests reproducing the full sequence end-to-end. This file
+ * closes that gap. Without integration coverage the *bug class* (two
+ * paths emitting the same content within a TTL) is still latent
+ * anywhere the dedup cache isn't wired.
+ *
+ * Invariant pinned here:
+ *
+ *   I6 — When the same multi-line content is emitted twice for the
+ *        same chat within the dedup TTL, only ONE outbound lands.
+ *        Holds across: bridge cycle in between, format mismatch
+ *        (HTML vs markdown), and reactions still finalize correctly.
+ *
+ * Failure mode if the dedup wiring regresses (e.g. someone removes the
+ * cache wire-up in `streamReply` or rolls back recent-outbound-dedup.ts):
+ * `recorder.sentTexts(chat).length === 2` and the test fails on the
+ * "exactly one outbound" assertion.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createRealGatewayHarness } from './real-gateway-harness.js'
+
+const CHAT = '8248703757'
+const INBOUND_MSG = 100
+const REPLY_TEXT =
+  'Here is a reply with enough content to clear the 24-char dedup floor — this paragraph is intentionally long to mirror the multi-paragraph replies that bug #546 actually duplicated.'
+
+beforeEach(() => {
+  vi.useFakeTimers()
+})
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('I6 — turn-flush + replay duplicate-content suppression (#546)', () => {
+  it('two identical send calls within TTL — second is suppressed by dedup (the #546 reproducer)', async () => {
+    // fails when: the dedup cache wire-up in real-gateway-harness's
+    // send/streamReply path is removed, or recent-outbound-dedup.ts's
+    // check() always returns null.
+    const h = createRealGatewayHarness({ gapMs: 0, withDedup: true })
+    h.inbound({ chatId: CHAT, messageId: INBOUND_MSG, text: 'hello' })
+    h.feedSessionEvent({
+      kind: 'enqueue',
+      chatId: CHAT,
+      messageId: '1',
+      threadId: null,
+      rawContent: 'hello',
+    })
+    await h.clock.advance(20)
+
+    const result = await h.simulateRetryDup({ chat_id: CHAT, text: REPLY_TEXT })
+
+    expect(result.suppressedSecond).toBe(true)
+    // The bridge cycle uses a REGISTERED agent, so flushOnAgentDisconnect
+    // must have run. If this is false, the test is a tautology (the
+    // anonymous-skip path bypassed the production helper).
+    expect(result.flushRan, 'flushOnAgentDisconnect must run — otherwise the test is a tautology').toBe(true)
+    expect(h.recorder.sentTexts(CHAT).filter((t) => t === REPLY_TEXT).length).toBe(1)
+    expect(h.dedupSuppressedCount()).toBe(1)
+    h.finalize()
+  })
+
+  it('content-equal-but-format-differ still dedupes (HTML vs markdown)', async () => {
+    // The smoking-gun shape from #546: msg=5025 had `<b>...</b>`,
+    // msg=5027 had `**...**`, same content. Dedup must catch this via
+    // the `normalizeForDedup` strip step.
+    //
+    // fails when: normalizeForDedup loses its HTML-tag or markdown-
+    // marker stripping (e.g. someone simplifies it to a plain hash).
+    //
+    // We use `h.send()` (fresh sendMessage every time) rather than
+    // `h.streamReply()` (which edits the same message on repeat
+    // calls). The bug class is "two SEPARATE messages with the same
+    // content", not "two streaming edits of one message."
+    const h = createRealGatewayHarness({ gapMs: 0, withDedup: true })
+    h.inbound({ chatId: CHAT, messageId: INBOUND_MSG, text: 'q' })
+    h.feedSessionEvent({
+      kind: 'enqueue',
+      chatId: CHAT,
+      messageId: '1',
+      threadId: null,
+      rawContent: 'q',
+    })
+
+    const htmlForm = `<b>Important update:</b> The config file has been regenerated with the new schema layout described in section 4.2 of the migration guide.`
+    const mdForm = `**Important update:** The config file has been regenerated with the new schema layout described in section 4.2 of the migration guide.`
+
+    const id1 = await h.send({ chat_id: CHAT, text: htmlForm })
+    const id2 = await h.send({ chat_id: CHAT, text: mdForm })
+    expect(id1).not.toBeNull()
+    expect(id2).toBeNull() // dedup suppressed
+    expect(h.recorder.sentTexts(CHAT).length).toBe(1)
+    expect(h.dedupSuppressedCount()).toBe(1)
+    h.finalize()
+  })
+
+  it('content shorter than DEDUP_MIN_CONTENT_LEN (24 chars) is NOT deduped', async () => {
+    // Conservative floor: short replies ("ok", "got it", "✅") legitimately
+    // recur. Dedup ignores them.
+    //
+    // fails when: someone tightens the floor below 24 chars without
+    // updating tests.
+    const h = createRealGatewayHarness({ gapMs: 0, withDedup: true })
+    h.inbound({ chatId: CHAT, messageId: INBOUND_MSG, text: 'q' })
+    h.feedSessionEvent({
+      kind: 'enqueue',
+      chatId: CHAT,
+      messageId: '1',
+      threadId: null,
+      rawContent: 'q',
+    })
+    const id1 = await h.send({ chat_id: CHAT, text: 'ok' })
+    const id2 = await h.send({ chat_id: CHAT, text: 'ok' })
+    expect(id1).not.toBeNull()
+    expect(id2).not.toBeNull() // NOT deduped — content too short
+    expect(h.recorder.sentTexts(CHAT).filter((t) => t === 'ok').length).toBe(2)
+    expect(h.dedupSuppressedCount()).toBe(0)
+    h.finalize()
+  })
+
+  it('after TTL expires, the same content sends again (cache evicts)', async () => {
+    // The TTL is bounded — same content sent an hour later should NOT
+    // be suppressed. This pins the eviction semantics.
+    //
+    // fails when: TTL eviction breaks (entries linger forever) or the
+    // dedup cache's clock source ignores caller-supplied `now`.
+    const h = createRealGatewayHarness({ gapMs: 0, withDedup: true, dedupTtlMs: 1000 })
+    h.inbound({ chatId: CHAT, messageId: INBOUND_MSG, text: 'q' })
+    h.feedSessionEvent({
+      kind: 'enqueue',
+      chatId: CHAT,
+      messageId: '1',
+      threadId: null,
+      rawContent: 'q',
+    })
+
+    const id1 = await h.send({ chat_id: CHAT, text: REPLY_TEXT })
+    expect(id1).not.toBeNull()
+    expect(h.recorder.sentTexts(CHAT).filter((t) => t === REPLY_TEXT).length).toBe(1)
+
+    // Advance past the TTL.
+    await h.clock.advance(2000)
+
+    const id2 = await h.send({ chat_id: CHAT, text: REPLY_TEXT })
+    expect(id2).not.toBeNull() // TTL expired → fresh send allowed
+    expect(h.recorder.sentTexts(CHAT).filter((t) => t === REPLY_TEXT).length).toBe(2)
+    h.finalize()
+  })
+
+  it('without withDedup, duplicate content lands twice (control case — confirms the harness default is back-compat)', async () => {
+    // Sanity check: F1–F4 tests don't pass withDedup, and they MUST
+    // continue to see every outbound landing as before. If a future
+    // change wires dedup unconditionally, this test catches it.
+    //
+    // fails when: someone makes withDedup default to true, breaking
+    // F1–F4 deadline assertions.
+    const h = createRealGatewayHarness({ gapMs: 0 })
+    h.inbound({ chatId: CHAT, messageId: INBOUND_MSG, text: 'q' })
+    h.feedSessionEvent({
+      kind: 'enqueue',
+      chatId: CHAT,
+      messageId: '1',
+      threadId: null,
+      rawContent: 'q',
+    })
+    const id1 = await h.send({ chat_id: CHAT, text: REPLY_TEXT })
+    const id2 = await h.send({ chat_id: CHAT, text: REPLY_TEXT })
+    expect(id1).not.toBeNull()
+    expect(id2).not.toBeNull() // no dedup, no suppression
+    expect(h.recorder.sentTexts(CHAT).filter((t) => t === REPLY_TEXT).length).toBe(2)
+    expect(h.dedup).toBeNull()
+    h.finalize()
+  })
+})
+
+// ─── I5 (Bug C) defense-in-depth via dedup ─────────────────────────────
+//
+// Bug C lives in profiles/_base/start.sh.hbs (a shell script the gateway
+// can't run). The actual fix is in the wake-audit sentinel comparison
+// logic, not in the gateway. BUT the OBSERVABLE failure is "duplicate
+// reply lands in the gateway." If the wake-audit fix regresses, the
+// dedup cache should still suppress the duplicate outbound. Defense in
+// depth — testable here.
+//
+// I5 in real-gateway-ipc-lifecycle.test.ts is `.skip`'d pending the
+// profile fix; this test is its harness-level companion.
+describe('I5(b) — wake-audit respawn duplicate suppressed by dedup defense in depth (Bug C)', () => {
+  it('respawn-replay simulation produces only one user-visible reply', async () => {
+    // fails when: the dedup wire-up regresses, OR if a wake-audit-style
+    // duplicate reply path emerges that bypasses streamReply (e.g. uses
+    // raw bot.api.sendMessage). In that case this test still catches
+    // the regression by counting outbounds.
+    const h = createRealGatewayHarness({ gapMs: 0, withDedup: true })
+    h.inbound({ chatId: CHAT, messageId: INBOUND_MSG, text: 'morning' })
+    h.feedSessionEvent({
+      kind: 'enqueue',
+      chatId: CHAT,
+      messageId: '1',
+      threadId: null,
+      rawContent: 'morning',
+    })
+
+    const greeting =
+      'Good morning! I noticed you mentioned the deploy yesterday — did the rollback succeed and are you ready to retry, or is there something I can help you investigate first?'
+
+    // First wake-audit fire (legitimate).
+    const id1 = await h.send({ chat_id: CHAT, text: greeting })
+    expect(id1).not.toBeNull()
+
+    // Simulate the --continue respawn: agent dies (registered disconnect),
+    // a fresh agent spawns and re-runs wake-audit, attempts to fire the
+    // same greeting again because the marker check was wrong.
+    const cid = h.bridgeConnect('agent-x')
+    h.bridgeDisconnect(cid)
+    await h.clock.advance(50)
+
+    const id2 = await h.send({ chat_id: CHAT, text: greeting })
+    expect(id2).toBeNull() // dedup suppressed
+
+    expect(h.recorder.sentTexts(CHAT).filter((t) => t === greeting).length).toBe(1)
+    expect(h.dedupSuppressedCount()).toBeGreaterThanOrEqual(1)
+    h.finalize()
+  })
+})

--- a/telegram-plugin/tests/update-factory-edited-and-reactions.test.ts
+++ b/telegram-plugin/tests/update-factory-edited-and-reactions.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Self-tests for the new update-factory builders:
+ *   - makeEditedMessageUpdate (Telegram `edited_message`)
+ *   - makeMessageReactionUpdate (Telegram `message_reaction`)
+ *
+ * These factories let tests inject inbound Telegram updates that the
+ * old harness couldn't express. Without them, code paths that
+ * subscribe to `bot.on('edited_message', ...)` or
+ * `bot.on('message_reaction', ...)` had no test surface at all.
+ *
+ * The shape contracts pinned here:
+ *   - shape matches https://core.telegram.org/bots/api#editedmessage
+ *     and #messagereactionupdated
+ *   - sensible defaults so tests only specify what they care about
+ *   - `update_id` and timestamps are deterministic-ish (counter + nowSec)
+ */
+
+import { describe, expect, it } from 'vitest'
+import {
+  makeEditedMessageUpdate,
+  makeMessageReactionUpdate,
+  resetUpdateCounters,
+} from './update-factory.js'
+
+describe('makeEditedMessageUpdate', () => {
+  it('produces a top-level edited_message Update', () => {
+    resetUpdateCounters()
+    const update = makeEditedMessageUpdate({ message_id: 42, text: 'edited text' }) as Record<
+      string,
+      unknown
+    >
+    expect(update.edited_message).toBeDefined()
+    expect(update.message).toBeUndefined()
+    const edited = update.edited_message as Record<string, unknown>
+    expect(edited.message_id).toBe(42)
+    expect(edited.text).toBe('edited text')
+    // edit_date should be >= date (post-edit timestamp)
+    expect(edited.edit_date as number).toBeGreaterThanOrEqual(edited.date as number)
+  })
+
+  it('respects forum thread context', () => {
+    const update = makeEditedMessageUpdate({
+      message_id: 100,
+      text: 'topic edit',
+      message_thread_id: 7,
+    }) as Record<string, unknown>
+    const edited = update.edited_message as Record<string, unknown>
+    expect(edited.message_thread_id).toBe(7)
+  })
+
+  it('allows custom date / edit_date for replay scenarios', () => {
+    const update = makeEditedMessageUpdate({
+      message_id: 1,
+      text: 'x',
+      date: 1_000_000,
+      edit_date: 1_000_500,
+    }) as Record<string, unknown>
+    const edited = update.edited_message as Record<string, unknown>
+    expect(edited.date).toBe(1_000_000)
+    expect(edited.edit_date).toBe(1_000_500)
+  })
+})
+
+describe('makeMessageReactionUpdate', () => {
+  it('default shape: user reacts with 👍 (no prior reaction)', () => {
+    const update = makeMessageReactionUpdate({ message_id: 50 }) as Record<string, unknown>
+    expect(update.message_reaction).toBeDefined()
+    const r = update.message_reaction as Record<string, unknown>
+    expect(r.message_id).toBe(50)
+    const oldReaction = r.old_reaction as Array<{ emoji?: string }>
+    const newReaction = r.new_reaction as Array<{ emoji?: string }>
+    expect(oldReaction).toEqual([])
+    expect(newReaction).toEqual([{ type: 'emoji', emoji: '👍' }])
+  })
+
+  it('reaction removal: old 👍, new []', () => {
+    const update = makeMessageReactionUpdate({
+      message_id: 60,
+      oldEmoji: '👍',
+      newEmoji: null,
+    }) as Record<string, unknown>
+    const r = update.message_reaction as Record<string, unknown>
+    expect(r.old_reaction).toEqual([{ type: 'emoji', emoji: '👍' }])
+    expect(r.new_reaction).toEqual([])
+  })
+
+  it('reaction swap: old 👍, new 🎉', () => {
+    const update = makeMessageReactionUpdate({
+      message_id: 70,
+      oldEmoji: '👍',
+      newEmoji: '🎉',
+    }) as Record<string, unknown>
+    const r = update.message_reaction as Record<string, unknown>
+    expect(r.old_reaction).toEqual([{ type: 'emoji', emoji: '👍' }])
+    expect(r.new_reaction).toEqual([{ type: 'emoji', emoji: '🎉' }])
+  })
+
+  it('respects custom user', () => {
+    const update = makeMessageReactionUpdate({
+      message_id: 80,
+      user: { id: 12345, username: 'reactor' },
+    }) as Record<string, unknown>
+    const r = update.message_reaction as Record<string, unknown>
+    const user = r.user as Record<string, unknown>
+    expect(user.id).toBe(12345)
+    expect(user.username).toBe('reactor')
+  })
+})

--- a/telegram-plugin/tests/update-factory.ts
+++ b/telegram-plugin/tests/update-factory.ts
@@ -197,6 +197,80 @@ export function makePhotoUpdate(opts: {
   } as unknown as Update
 }
 
+/** Build an `edited_message` Update — user edits an existing message. */
+export function makeEditedMessageUpdate(opts: {
+  message_id: number
+  text: string
+  chat?: Partial<ChatLike>
+  from?: Partial<UserLike>
+  message_thread_id?: number
+  /** Original send time. Defaults to "30 seconds ago" so edit_date > date stays plausible. */
+  date?: number
+  /** Edit time. Defaults to now. */
+  edit_date?: number
+  update_id?: number
+}): Update {
+  const chat: ChatLike = { ...DEFAULT_PRIVATE_CHAT, ...opts.chat }
+  const from: UserLike = { ...DEFAULT_USER, ...opts.from }
+  const update_id = opts.update_id ?? updateIdCounter++
+  const date = opts.date ?? nowSec() - 30
+  const edit_date = opts.edit_date ?? nowSec()
+  return {
+    update_id,
+    edited_message: {
+      message_id: opts.message_id,
+      chat,
+      from,
+      date,
+      edit_date,
+      text: opts.text,
+      ...(opts.message_thread_id != null ? { message_thread_id: opts.message_thread_id } : {}),
+    },
+  } as unknown as Update
+}
+
+/**
+ * Build a `message_reaction` Update — a user adds/removes a reaction
+ * to a message. Telegram delivers these only if the bot has reactions
+ * subscribed (allowed_updates includes "message_reaction").
+ *
+ * Shape: `old_reaction` and `new_reaction` are arrays of ReactionType
+ * objects (`{ type: 'emoji', emoji: '👍' }` for standard, or
+ * `{ type: 'custom_emoji', custom_emoji_id: '...' }` for custom).
+ *
+ * Common usage: a user reacts with 👍 (old=[], new=[👍]) or removes
+ * the reaction (old=[👍], new=[]).
+ */
+export function makeMessageReactionUpdate(opts: {
+  message_id: number
+  /** Emoji currently NOT yet on the message (transitioning to). Default: 👍. */
+  newEmoji?: string | null
+  /** Emoji previously on the message. Default: null (none). */
+  oldEmoji?: string | null
+  chat?: Partial<ChatLike>
+  user?: Partial<UserLike>
+  update_id?: number
+}): Update {
+  const chat: ChatLike = { ...DEFAULT_PRIVATE_CHAT, ...opts.chat }
+  const user: UserLike = { ...DEFAULT_USER, ...opts.user }
+  const update_id = opts.update_id ?? updateIdCounter++
+  const oldEmoji = opts.oldEmoji ?? null
+  const newEmoji = opts.newEmoji === undefined ? '👍' : opts.newEmoji
+  const old_reaction = oldEmoji == null ? [] : [{ type: 'emoji', emoji: oldEmoji }]
+  const new_reaction = newEmoji == null ? [] : [{ type: 'emoji', emoji: newEmoji }]
+  return {
+    update_id,
+    message_reaction: {
+      chat,
+      message_id: opts.message_id,
+      user,
+      date: nowSec(),
+      old_reaction,
+      new_reaction,
+    },
+  } as unknown as Update
+}
+
 /** Build a document-attachment Update. */
 export function makeDocumentUpdate(opts: {
   file_name: string


### PR DESCRIPTION
## Summary

Upgrades the test harness so the bug classes that have been shipping (Bug A/B/D/Z, #546, Bug C-shaped duplicates) are caught by `npm test` instead of by users noticing them in chat.

The existing `real-gateway-harness.ts` covered I1–I5 timing/lifecycle (good!) but didn't have the seams to express **in-flight call ordering**, **dedup-replay**, or **parse_mode validation** as first-class invariants. This PR adds those seams without breaking 167 existing tests.

## Changes

**Foundation (additive, default-off):**
- `fake-bot-api.ts`: `holdNext(method, chat?)` parks a call mid-flight; `release()`/`fail()` resolves/rejects the gate. Lets Bug-D-class tests pin \"X fires while Y is in-flight\" without timer fragility.
- `fake-bot-api.ts`: opt-in `validateParseMode: 'lenient'` rejects unbalanced MarkdownV2 — the most common streaming-edit failure. Off by default for back-compat.
- `update-factory.ts`: `makeEditedMessageUpdate`, `makeMessageReactionUpdate`. Closes a latent gap — no factory existed for the inbound types the gateway's `bot.on('edited_message')` / `bot.on('message_reaction')` handlers consume.

**Real-gateway harness wiring:**
- Opt-in `withDedup: true` wires the production `OutboundDedupCache` into a new `harness.send()` fresh-send path. Mirrors `gateway.ts:1893` (executeReply) and `gateway.ts:2233` (executeStreamReply) where production checks/records dedup. `simulateRetryDup()` is a one-line scenario for the full #546 reproducer.
- The bridge cycle in `simulateRetryDup` uses a **registered** agent (not anonymous) so `flushOnAgentDisconnect` actually runs — proving dedup survives the production cleanup path. Anonymous would no-op (I1) and make the scenario a tautology; the test asserts `flushRan === true` to pin this.

**New regression tests** (every assertion has a `// fails when:` comment documenting the production change that would break it):

| File | Cases | Bug class |
|---|---|---|
| `real-gateway-i6-turn-flush-replay-dedup.test.ts` | 7 | #546 full reproducer + Bug C defense-in-depth |
| `harness-ordering-invariants.test.ts` | 14 | INV-1 (👍 at-or-after delivery), INV-2 (terminal 👍 fires exactly once), INV-3 (edit-on-deleted), INV-4 (dedup TTL boundary), INV-5 (holdNext ordering) |
| `harness-parse-mode-validation.test.ts` | 13 | Lenient MarkdownV2 validator |
| `update-factory-edited-and-reactions.test.ts` | 7 | Update shape contracts |
| `fake-bot-api.test.ts` | +4 | holdNext: release / fail / fault-vs-hold precedence / reset-while-held |

**HARNESS.md** gets Pattern 7 (holdNext), Pattern 8 (dedup wiring), Pattern 9 (parse_mode validator), a bug-class catalog mapping each known class to its regression home, and a top-level **validation rule** requiring every new test carry a `// fails when:` comment so it's not theatre.

## What this is NOT

- Not a real-Telegram conformance suite (needs test-DC creds + nightly schedule). Worth a follow-up.
- Not a userbot E2E suite (needs phone-verified account).
- Not the Bug C profile fix — that's `profiles/_base/start.sh.hbs`. This PR adds **defense-in-depth** so even if the profile fix regresses, the dedup cache catches the duplicate outbound (test I5(b)).
- Not a migration of existing 167 tests. Additive only.

## Test plan
- [x] `npm test` — 4474 vitest + 302 bun tests pass, 0 fail
- [x] `npm run lint` — clean
- [x] `npm run build` — clean
- [x] All new tests verified to fail when the production fix they cover is mentally stashed (the `// fails when:` comments document the verification)

## Principles check (per CLAUDE.md)
- **Docs test**: HARNESS.md teaches the new patterns inline; the catalog tells you where each bug class lives.
- **Defaults test**: every addition is opt-in (`withDedup`, `validateParseMode`, `holdNext`). Default behavior of the harness is unchanged.
- **Consistency test**: matches existing `bot.faults.next(...)` DSL (FIFO, method-scoped); matches existing `// fails when:` comment pattern; reuses production modules (`OutboundDedupCache`, `flushOnAgentDisconnect`) instead of mirroring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)