### PR TITLE
fix(gateway,watchdog): close four restart-storm windows that could waste Claude quota

### DIFF
--- a/bin/bridge-watchdog.sh
+++ b/bin/bridge-watchdog.sh
@@ -311,6 +311,76 @@ stamp_restart_reason() {
   fi
 }
 
+# ─── Restart rate cap ──────────────────────────────────────────────────
+#
+# Belt-and-suspenders for runaway restart loops (#550 follow-up). Even
+# with the in-flight detector + progress-fingerprint defences above,
+# there are pathological combinations (e.g. a stuck marker file the
+# sweep can't clear, a bridge that ESTAB-flaps once a minute) where
+# the watchdog could chew through Claude quota by restarting the same
+# agent N times an hour — every restart loads model context fresh.
+#
+# Rule: a single agent cannot be restarted by THIS watchdog more than
+# `MAX_RESTARTS_PER_WINDOW` times within `RESTART_RATE_WINDOW_SECS`.
+# When the cap trips, the restart is logged-and-skipped with a clear
+# `restart-rate-capped` reason so an operator can see the throttle
+# fired in `journalctl -t switchroom-watchdog | grep rate-capped`.
+#
+# The cap covers ALL three restart paths (bridge-disconnect, turn-hang,
+# journal-silence) plus the service-inactive heal — anything that
+# would cost a fresh `claude` startup. systemd's own
+# StartLimitBurst/IntervalSec is not enough on its own because each
+# `switchroom agent restart` resets that counter.
+#
+# State file: `${WATCHDOG_STATE_DIR}/${agent}.restarts` — newline-
+# separated epoch timestamps, trimmed to the window on every check.
+# tmpfs → cleared on logout, which is what we want (don't carry a
+# stale 30-min window across a reboot).
+: "${MAX_RESTARTS_PER_WINDOW:=5}"
+: "${RESTART_RATE_WINDOW_SECS:=1800}"
+
+# Returns 0 (allow) when the agent is under the cap. Returns 1 (block)
+# and emits a `[skip]` log line when the cap would be exceeded. Pure
+# read — does NOT record the restart; call restart_rate_record on the
+# allowed path.
+restart_rate_check() {
+  local agent="$1"
+  local reason_tag="$2"
+  local rate_file="${WATCHDOG_STATE_DIR}/${agent}.restarts"
+  [[ -f "$rate_file" ]] || return 0
+  local now cutoff count=0
+  now=$(now_epoch)
+  cutoff=$(( now - RESTART_RATE_WINDOW_SECS ))
+  while IFS= read -r ts; do
+    [[ "$ts" =~ ^[0-9]+$ ]] || continue
+    (( ts >= cutoff )) && count=$(( count + 1 ))
+  done < "$rate_file"
+  if (( count >= MAX_RESTARTS_PER_WINDOW )); then
+    wd_log skip "agent=${agent} reason=${reason_tag} decision=restart-rate-capped recent=${count} max=${MAX_RESTARTS_PER_WINDOW} window=${RESTART_RATE_WINDOW_SECS}s (operator intervention required — investigate before clearing ${rate_file})"
+    return 1
+  fi
+  return 0
+}
+
+# Append a restart timestamp and trim to the window. Best-effort I/O.
+restart_rate_record() {
+  local agent="$1"
+  local rate_file="${WATCHDOG_STATE_DIR}/${agent}.restarts"
+  local now cutoff
+  now=$(now_epoch)
+  cutoff=$(( now - RESTART_RATE_WINDOW_SECS ))
+  local tmp="${rate_file}.tmp-$$"
+  {
+    if [[ -f "$rate_file" ]]; then
+      while IFS= read -r ts; do
+        [[ "$ts" =~ ^[0-9]+$ ]] || continue
+        (( ts >= cutoff )) && echo "$ts"
+      done < "$rate_file"
+    fi
+    echo "$now"
+  } > "$tmp" 2>/dev/null && mv -f "$tmp" "$rate_file" 2>/dev/null || rm -f "$tmp" 2>/dev/null || true
+}
+
 # Discover active gateway units. systemd's list-units output includes only
 # currently-loaded units; we filter to the switchroom-*-gateway.service
 # pattern and strip the prefix/suffix to get the agent name.
@@ -377,7 +447,11 @@ for gateway_svc in "${gateway_services[@]}"; do
       wd_log skip "agent=${agent} reason=service-failed decision=needs-operator-reset state=${state} $(agent_progress_snapshot "$agent") (unit in failed state; needs operator reset-failed)"
       continue
     fi
+    if ! restart_rate_check "$agent" "service-inactive"; then
+      continue
+    fi
     wd_log restart "agent=${agent} reason=service-inactive state=${state} action=start $(agent_progress_snapshot "$agent") (agent service is inactive)"
+    restart_rate_record "$agent"
     systemctl --user start "$agent_svc" || {
       wd_log error "agent=${agent} systemctl start failed"
     }
@@ -498,7 +572,11 @@ for gateway_svc in "${gateway_services[@]}"; do
   fi
 
   wd_log detect "agent=${agent} reason=bridge-disconnect disc_duration=${disc_duration}s threshold=${DISCONNECT_GRACE_SECS}s ${observation}"
+  if ! restart_rate_check "$agent" "bridge-disconnect"; then
+    continue
+  fi
   wd_log restart "agent=${agent} reason=bridge-disconnect disc_duration=${disc_duration}s threshold=${DISCONNECT_GRACE_SECS}s ${observation}"
+  restart_rate_record "$agent"
   # Clear the marker so post-restart we don't immediately re-trip on
   # the still-old tail. The uptime grace will cover the startup window
   # anyway, but removing the marker keeps state clean.
@@ -615,12 +693,16 @@ for agent_svc in "${agent_services[@]}"; do
           continue
         fi
         wd_log detect "agent=${agent} reason=turn-hang turn_age=${turn_age}s threshold=${TURN_HANG_SECS}s ${observation} (no progress fingerprints within ${JSONL_LIVENESS_SECS}s — wedged mid-turn)"
+        if ! restart_rate_check "$agent" "turn-hang"; then
+          continue
+        fi
         # Stamp the reason BEFORE the restart so the next greeting
         # card renders "Restarted  watchdog: …".
         stamp_restart_reason \
           "${agent_state_dir}/clean-shutdown.json" \
           "watchdog: turn-active marker stale ${turn_age}s with no JSONL activity"
         wd_log restart "agent=${agent} reason=turn-hang turn_age=${turn_age}s threshold=${TURN_HANG_SECS}s ${observation}"
+        restart_rate_record "$agent"
         # Resolve the switchroom CLI (same belt-and-suspenders as below)
         switchroom_cli=""
         for candidate in "${HOME}/.bun/bin/switchroom" "${HOME}/.local/bin/switchroom"; do
@@ -734,11 +816,15 @@ for agent_svc in "${agent_services[@]}"; do
   # This matches the production hang pattern (issue #116). Restart
   # via the switchroom CLI.
   wd_log detect "agent=${agent} reason=journal-silence journal_age=${journal_age}s silence_duration=${silence_duration}s threshold=${JOURNAL_SILENCE_HARD_SECS}s ${observation} (no progress fingerprints — wedged)"
+  if ! restart_rate_check "$agent" "journal-silence"; then
+    continue
+  fi
   agent_state_dir="${HOME}/.switchroom/agents/${agent}/telegram"
   stamp_restart_reason \
     "${agent_state_dir}/clean-shutdown.json" \
     "watchdog: journal silent for ${journal_age}s with no progress activity"
   wd_log restart "agent=${agent} reason=journal-silence journal_age=${journal_age}s silence_duration=${silence_duration}s threshold=${JOURNAL_SILENCE_HARD_SECS}s ${observation}"
+  restart_rate_record "$agent"
   rm -f "$silence_marker" 2>/dev/null || true
 
   # Use `switchroom agent restart` (not raw systemctl) — the project

--- a/src/agents/systemd.ts
+++ b/src/agents/systemd.ts
@@ -267,6 +267,11 @@ StandardOutput=journal
 StandardError=journal
 Restart=always
 RestartSec=3
+# Spread restart attempts across a 5s window so a fleet-wide crash
+# doesn't produce a synchronized thundering herd of claude processes
+# coming back at the same instant. The [Unit] section's start-limit
+# above caps the absolute rate; this adds jitter inside that envelope.
+RandomizedDelaySec=5
 # Cgroup-wide kill so restart actually kills the gateway process (issue #361).
 # Same script PTY cgroup-escape issue as the agent unit — see generateUnit().
 KillMode=control-group
@@ -329,6 +334,10 @@ StandardOutput=journal
 StandardError=journal
 Restart=always
 RestartSec=3
+# Same jitter rationale as the gateway unit: smear restart timing within
+# the StartLimitBurst envelope so a host-wide crash doesn't produce a
+# synchronized restart wave.
+RandomizedDelaySec=5
 # Cgroup-wide kill so restart actually kills the foreman process (issue #361).
 # Same script PTY cgroup-escape issue as the agent unit — see generateUnit().
 KillMode=control-group

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -172,6 +172,7 @@ import {
   loadLockout,
   nextLockout,
   saveLockout,
+  DEFAULT_FALLBACK_COOLDOWN_MS,
   type LockoutRecord,
   type LockoutPersistOps,
 } from '../auto-fallback.js'
@@ -1145,6 +1146,43 @@ const DEFERRED_SECRET_TTL_MS = 24 * 60 * 60_000 // 24 h — ignored one-tap card
 // restart (the `--force` SIGKILL fallback documented in the spec).
 const PENDING_RESTART_DRAIN_CAP_MS = 60_000
 
+/**
+ * Compact one-line summary of a turn-active marker payload, for the
+ * [markersweep] log line. Resilient to malformed JSON — returns
+ * `payload=unparseable` rather than throwing.
+ */
+function summariseMarkerPayload(payload: string | null): string {
+  if (!payload) return 'payload=missing'
+  try {
+    const parsed = JSON.parse(payload) as { turnKey?: unknown; chatId?: unknown; startedAt?: unknown }
+    const turnKey = typeof parsed.turnKey === 'string' ? parsed.turnKey : 'unknown'
+    const chatId = typeof parsed.chatId === 'string' ? parsed.chatId : 'unknown'
+    const startedAt = typeof parsed.startedAt === 'number' ? parsed.startedAt : 0
+    return `turnKey=${turnKey} chat=${chatId} started=${new Date(startedAt).toISOString()}`
+  } catch {
+    return 'payload=unparseable'
+  }
+}
+
+/**
+ * Returns true when the persisted auto-fallback lockout for this
+ * agent's directory shows we just rotated slots within the cooldown
+ * window. Used by the pending-restart drain cap to defer a forced
+ * restart that would otherwise stack on top of an in-flight slot
+ * rotation. Best-effort: any read error returns false (fail-open),
+ * matching the lockout's "noise filter, not a security boundary" role.
+ */
+function isAutoFallbackCooldownActive(_agentName: string, now: number): boolean {
+  try {
+    const agentDir = resolveAgentDirFromEnv()
+    const persisted = loadLockout(agentDir, lockoutOps)
+    if (!persisted.lastTransitionedFrom) return false
+    return now - persisted.lastTransitionAt < DEFAULT_FALLBACK_COOLDOWN_MS
+  } catch {
+    return false
+  }
+}
+
 // 60-second sweep drops anything past its documented TTL.
 const pendingStateReaper = setInterval(() => {
   const now = Date.now()
@@ -1176,22 +1214,52 @@ const pendingStateReaper = setInterval(() => {
   // under the watchdog's TURN_HANG_SECS=300s threshold for the in-
   // flight case but generous enough that real long-running tool calls
   // (which touch mtime on every tool_use) won't trip the idle path.
+  //
+  // Logging: include agent name + age + reason + payload so a marker
+  // leak (or a real wedge) leaves enough breadcrumbs in journalctl to
+  // diagnose without needing to inspect the file (which is gone after
+  // the sweep). `journalctl -u switchroom-<agent>-gateway -g markersweep`
+  // is the audit trail.
   try {
-    const swept = sweepStaleTurnActiveMarker(STATE_DIR, {
+    sweepStaleTurnActiveMarker(STATE_DIR, {
       turnInFlight: currentTurnRegistryKey != null,
       idleSweepMs: 60_000,
       hardTtlMs: 10 * 60_000,
       now,
+      onRemove: ({ ageMs, reason, payload }) => {
+        const agent = getMyAgentName()
+        const ageSec = Math.round(ageMs / 1000)
+        const turnInFlight = currentTurnRegistryKey != null
+        const summary = summariseMarkerPayload(payload)
+        process.stderr.write(
+          `telegram gateway: [markersweep] removed agent=${agent} age=${ageSec}s reason=${reason} turn_in_flight=${turnInFlight} ${summary}\n`,
+        )
+      },
     })
-    if (swept) {
-      process.stderr.write(`telegram gateway: turn-active marker swept (stale, no live turn)\n`)
-    }
   } catch { /* best-effort */ }
   // Drain cap: if a scheduled restart has been waiting >60s for a turn
   // to complete, force it through anyway (spec: 60s cap → SIGKILL fallback).
+  //
+  // Auto-fallback cooldown gate: if the persisted lockout shows we just
+  // rotated this agent's slot inside the cooldown window, defer the
+  // forced restart by another tick. This closes a churn window where a
+  // 429-driven fallback already spawned a restart, and a parallel
+  // schedule_restart IPC sat in pendingRestarts — without this gate the
+  // drain cap would fire a SECOND restart 60s later. Bound: at most
+  // FALLBACK_COOLDOWN_MS / 60s extra deferrals per pending restart.
   for (const [agentName, requestedAt] of pendingRestarts.entries()) {
     if (now - requestedAt > PENDING_RESTART_DRAIN_CAP_MS) {
-      process.stderr.write(`telegram gateway: pending restart drain cap exceeded for ${agentName} (waited ${Math.round((now - requestedAt) / 1000)}s) — forcing restart\n`)
+      const waitedSec = Math.round((now - requestedAt) / 1000)
+      const cooldownActive = isAutoFallbackCooldownActive(agentName, now)
+      if (cooldownActive) {
+        process.stderr.write(
+          `telegram gateway: [restart-drain] deferred agent=${agentName} waited=${waitedSec}s reason=auto-fallback-cooldown-active\n`,
+        )
+        continue
+      }
+      process.stderr.write(
+        `telegram gateway: [restart-drain] forcing agent=${agentName} waited=${waitedSec}s threshold=${Math.round(PENDING_RESTART_DRAIN_CAP_MS / 1000)}s\n`,
+      )
       pendingRestarts.delete(agentName)
       try {
         spawn(
@@ -1205,7 +1273,7 @@ const pendingStateReaper = setInterval(() => {
           { detached: true, stdio: 'ignore' },
         ).unref()
       } catch (err) {
-        process.stderr.write(`telegram gateway: forced restart spawn failed for ${agentName}: ${err}\n`)
+        process.stderr.write(`telegram gateway: [restart-drain] forced restart spawn failed agent=${agentName}: ${err}\n`)
       }
     }
   }
@@ -5799,6 +5867,9 @@ type AutoFallbackCheckResult =
   | { kind: 'error'; message: string }
 
 async function runAutoFallbackCheck(opts: { trigger: 'scheduled' | 'manual' }): Promise<AutoFallbackCheckResult> {
+  // All log lines in this path use the `[autofallback]` tag so a single
+  // grep against journalctl reconstructs the full decision history of
+  // a slot rotation: `journalctl -u switchroom-<agent>-gateway -g autofallback`.
   try {
     const agentDir = resolveAgentDirFromEnv()
     const agentName = getMyAgentName()
@@ -5812,8 +5883,14 @@ async function runAutoFallbackCheck(opts: { trigger: 'scheduled' | 'manual' }): 
       lockout: autoFallbackLockout,
     })
     if (decision.action !== 'fallback') {
+      process.stderr.write(
+        `telegram gateway: [autofallback] noop trigger=${opts.trigger} agent=${agentName} active=${active ?? 'none'} reason=${decision.reason}\n`,
+      )
       return { kind: 'no-action', reason: decision.reason, decision: 'noop' }
     }
+    process.stderr.write(
+      `telegram gateway: [autofallback] decision=fallback trigger=${opts.trigger} agent=${agentName} active=${active ?? 'none'} reason=${decision.triggerReason} util=${decision.utilizationPct?.toFixed(1) ?? 'n/a'}%\n`,
+    )
     const plan = performAutoFallback({
       agentDir,
       agentName,
@@ -5826,12 +5903,13 @@ async function runAutoFallbackCheck(opts: { trigger: 'scheduled' | 'manual' }): 
       ownerChatId,
       plan,
       onError: (err) => {
-        process.stderr.write(`telegram gateway: auto-fallback notify failed (${opts.trigger}): ${err}\n`)
+        process.stderr.write(`telegram gateway: [autofallback] notify failed trigger=${opts.trigger} agent=${agentName}: ${err}\n`)
       },
     })
     if (plan.kind === 'executed') {
       try { assertSafeAgentName(plan.agentName) }
       catch {
+        process.stderr.write(`telegram gateway: [autofallback] invalid-agent-name agent=${plan.agentName}\n`)
         return { kind: 'error', message: `invalid agent name: ${plan.agentName}` }
       }
       try {
@@ -5843,20 +5921,26 @@ async function runAutoFallbackCheck(opts: { trigger: 'scheduled' | 'manual' }): 
         if (plan.triggerReason !== '429-response') {
           restartArgs.push('--graceful-restart')
         }
+        process.stderr.write(
+          `telegram gateway: [autofallback] executed agent=${plan.agentName} prev=${plan.previousSlot} next=${plan.newSlot} restart=${plan.triggerReason === '429-response' ? 'hard' : 'graceful'}\n`,
+        )
         switchroomExec(restartArgs)
       } catch (err) {
-        process.stderr.write(`telegram gateway: auto-fallback restart failed: ${err}\n`)
+        process.stderr.write(`telegram gateway: [autofallback] restart failed agent=${plan.agentName}: ${err}\n`)
       }
       autoFallbackLockout = nextLockout(plan.previousSlot, Date.now())
       persistLockout(agentDir)
       void refreshPinnedBanner('auto-fallback')
       return { kind: 'executed', previousSlot: plan.previousSlot, newSlot: plan.newSlot }
     }
+    process.stderr.write(
+      `telegram gateway: [autofallback] exhausted-all agent=${agentName} active=${plan.activeSlot}\n`,
+    )
     autoFallbackLockout = nextLockout(plan.activeSlot, Date.now())
     persistLockout(agentDir)
     return { kind: 'exhausted-all', activeSlot: plan.activeSlot }
   } catch (err) {
-    process.stderr.write(`telegram gateway: auto-fallback ${opts.trigger} poll error: ${err}\n`)
+    process.stderr.write(`telegram gateway: [autofallback] ${opts.trigger} poll error: ${err}\n`)
     return { kind: 'error', message: String((err as Error).message ?? err) }
   }
 }

--- a/telegram-plugin/gateway/turn-active-marker.ts
+++ b/telegram-plugin/gateway/turn-active-marker.ts
@@ -126,6 +126,17 @@ export function sweepStaleTurnActiveMarker(
     idleSweepMs: number;
     hardTtlMs: number;
     now?: number;
+    /**
+     * Optional diagnostic callback invoked when the marker is removed.
+     * Best-effort: keeps the function pure (no logger coupling) while
+     * letting the caller emit a structured journalctl line. Must not
+     * throw — exceptions from this callback are swallowed.
+     */
+    onRemove?: (info: {
+      ageMs: number;
+      reason: "idle-stale" | "hard-ttl";
+      payload: string | null;
+    }) => void;
   },
 ): boolean {
   const path = join(stateDir, TURN_ACTIVE_MARKER_FILE);
@@ -137,16 +148,26 @@ export function sweepStaleTurnActiveMarker(
     const hardExpired = ageMs > opts.hardTtlMs;
     const idleExpired = !opts.turnInFlight && ageMs > opts.idleSweepMs;
     if (!hardExpired && !idleExpired) return false;
-    // Also drop if the writing process is gone (best-effort — the
-    // marker JSON doesn't include pid today, so this is a no-op stub
-    // unless extended later. Reading the file lets a future caller
-    // attach pid liveness without changing the signature.)
+    // Best-effort read so the diagnostic callback can include the
+    // payload (turnKey, chatId, startedAt) for forensic logging.
+    let payload: string | null = null;
     try {
-      readFileSync(path, "utf8");
+      payload = readFileSync(path, "utf8");
     } catch {
-      /* unreadable — fall through to unlink */
+      /* unreadable — still drop the marker */
     }
     unlinkSync(path);
+    if (opts.onRemove) {
+      try {
+        opts.onRemove({
+          ageMs,
+          reason: hardExpired ? "hard-ttl" : "idle-stale",
+          payload,
+        });
+      } catch {
+        /* swallow — diagnostics must never break the sweep */
+      }
+    }
     return true;
   } catch {
     // ENOENT race or stat failure — nothing actionable.

--- a/tests/bridge-watchdog.test.ts
+++ b/tests/bridge-watchdog.test.ts
@@ -205,6 +205,22 @@ describe("bridge-watchdog.sh — static regression guards", () => {
     expect(script).toMatch(/stamp_restart_reason \\?\s*"\$\{gateway_state_dir\}\/clean-shutdown\.json"/);
     expect(script).toMatch(/stamp_restart_reason \\?\s*"\$\{agent_state_dir\}\/clean-shutdown\.json"/);
   });
+
+  it("defines a restart-rate-cap helper and gates every restart path through it", () => {
+    // Belt-and-suspenders for runaway restart loops — the script's three
+    // restart paths plus the service-inactive heal must all consult the
+    // rate cap before issuing a restart, so a single agent can't burn
+    // Claude quota by being restarted N times in a window.
+    expect(script).toMatch(/restart_rate_check\(\)/);
+    expect(script).toMatch(/restart_rate_record\(\)/);
+    expect(script).toMatch(/MAX_RESTARTS_PER_WINDOW/);
+    expect(script).toMatch(/RESTART_RATE_WINDOW_SECS/);
+    // Every restart path must call restart_rate_check before acting.
+    const restartCheckCalls = script.match(/restart_rate_check "\$agent"/g) ?? [];
+    expect(restartCheckCalls.length).toBeGreaterThanOrEqual(4);
+    const restartRecordCalls = script.match(/restart_rate_record "\$agent"/g) ?? [];
+    expect(restartRecordCalls.length).toBeGreaterThanOrEqual(4);
+  });
 });
 
 // ---------------------------------------------------------------
@@ -360,12 +376,18 @@ function runWatchdog(
   h: Harness,
   env: Record<string, string> = {},
 ): { stdout: string; stderr: string; code: number; audit: string } {
+  // Per-test isolation for the rate-cap state dir — without this, accumulated
+  // restarts across the suite would eventually trip the cap and produce
+  // confusing skip behaviour. controlDir is recreated per `makeHarness()`.
+  const wdState = join(h.controlDir, "wd-state");
+  mkdirSync(wdState, { recursive: true });
   const opts: ExecFileSyncOptions = {
     env: {
       PATH: `${h.binDir}:/usr/bin:/bin`,
       // HOME and USER sometimes matter for bash shell init.
       HOME: process.env.HOME ?? "/tmp",
       USER: process.env.USER ?? "nobody",
+      WATCHDOG_STATE_DIR: wdState,
       ...env,
     },
     encoding: "utf8",
@@ -609,6 +631,57 @@ describe("bridge-watchdog.sh — behavioural integration", () => {
     const longAgo = Math.floor(Date.now() / 1000) - 200;
     writeFileSync(join(h.stateDir, ".watchdog-disconnect-since"), String(longAgo));
     const r = runWatchdog(h, { DISCONNECT_GRACE_SECS: "120", LIVENESS_GRACE_SECS: "30" });
+    expect(r.code).toBe(0);
+    expect(restartIssued(r.audit, "switchroom-klanker.service")).toBe(true);
+  });
+
+  it("restart rate cap blocks the Nth+1 restart within the window", () => {
+    // Simulate that this agent has already been restarted N=MAX times
+    // within the rate-cap window. The next restart attempt should
+    // log-and-skip rather than proceed, even though every other guard
+    // (uptime, disconnect grace, progress) says "restart now".
+    setEstabCount(h, 0);
+    writeGatewayLog(h, ["telegram gateway: bridge registered"]);
+    const longAgo = Math.floor(Date.now() / 1000) - 200;
+    writeFileSync(join(h.stateDir, ".watchdog-disconnect-since"), String(longAgo));
+
+    // Pre-seed the rate-cap state with 5 recent timestamps (the default
+    // MAX_RESTARTS_PER_WINDOW).
+    const wdState = join(h.controlDir, "wd-state");
+    mkdirSync(wdState, { recursive: true });
+    const now = Math.floor(Date.now() / 1000);
+    const recent = [now - 60, now - 120, now - 300, now - 600, now - 900].join("\n") + "\n";
+    writeFileSync(join(wdState, "klanker.restarts"), recent);
+
+    const r = runWatchdog(h, {
+      DISCONNECT_GRACE_SECS: "120",
+      LIVENESS_GRACE_SECS: "30",
+    });
+    expect(r.code).toBe(0);
+    // The cap fired — no restart issued.
+    expect(restartIssued(r.audit, "switchroom-klanker.service")).toBe(false);
+    expect(r.stdout).toMatch(/restart-rate-capped/);
+  });
+
+  it("restart rate cap does NOT block when prior restart timestamps are outside the window", () => {
+    // Old timestamps (further back than RESTART_RATE_WINDOW_SECS) must
+    // be trimmed and not counted toward the cap.
+    setEstabCount(h, 0);
+    writeGatewayLog(h, ["telegram gateway: bridge registered"]);
+    const longAgo = Math.floor(Date.now() / 1000) - 200;
+    writeFileSync(join(h.stateDir, ".watchdog-disconnect-since"), String(longAgo));
+
+    const wdState = join(h.controlDir, "wd-state");
+    mkdirSync(wdState, { recursive: true });
+    // 5 timestamps, all OLDER than the default 1800s window.
+    const now = Math.floor(Date.now() / 1000);
+    const old = [now - 5000, now - 4500, now - 4000, now - 3500, now - 3000].join("\n") + "\n";
+    writeFileSync(join(wdState, "klanker.restarts"), old);
+
+    const r = runWatchdog(h, {
+      DISCONNECT_GRACE_SECS: "120",
+      LIVENESS_GRACE_SECS: "30",
+    });
     expect(r.code).toBe(0);
     expect(restartIssued(r.audit, "switchroom-klanker.service")).toBe(true);
   });

--- a/tests/systemd-restart.test.ts
+++ b/tests/systemd-restart.test.ts
@@ -110,6 +110,10 @@ describe("generateGatewayUnit — cgroup kill semantics (issue #361)", () => {
   it("preserves Restart=always", () => {
     expect(svc).toContain("Restart=always");
   });
+
+  it("smears restart timing with RandomizedDelaySec to avoid thundering herd", () => {
+    expect(svc).toContain("RandomizedDelaySec=5");
+  });
 });
 
 // ─── Foreman unit ─────────────────────────────────────────────────────────────
@@ -140,6 +144,10 @@ describe("generateForemanUnit — cgroup kill semantics (issue #361)", () => {
 
   it("preserves Restart=always", () => {
     expect(svc).toContain("Restart=always");
+  });
+
+  it("smears restart timing with RandomizedDelaySec to avoid thundering herd", () => {
+    expect(svc).toContain("RandomizedDelaySec=5");
   });
 });
 


### PR DESCRIPTION
## Summary

Audit of restart/respawn paths uncovered four low-probability windows where a flapping agent could chew through Claude subscription quota by being restarted faster than productive work could happen. Each is unlikely on its own; together they form a class worth defending against. None require user action — defaults are conservative.

- **`src/agents/systemd.ts`** — `RandomizedDelaySec=5` on gateway + foreman units. Spreads restart timing inside the existing `StartLimitBurst`/`IntervalSec` envelope so a host-wide crash doesn't produce a synchronized thundering herd of fresh `claude` processes.
- **`telegram-plugin/gateway/gateway.ts`** — `pendingStateReaper` drain-cap now consults the persisted auto-fallback lockout (#417). If the agent's slot was just rotated inside the cooldown window, the forced restart is deferred a tick. Closes the chain-restart window where a 429-driven fallback restart and a parallel `schedule_restart` IPC could stack into a second restart 60s later.
- **`bin/bridge-watchdog.sh`** — restart rate cap (`MAX_RESTARTS_PER_WINDOW=5` per `RESTART_RATE_WINDOW_SECS=1800`) gates ALL four restart paths (service-inactive heal, bridge-disconnect, turn-hang, journal-silence). Belt-and-suspenders for the worst-case marker-leak scenario where every other defence fails and the watchdog would otherwise restart the agent every 60s indefinitely. State persists in `WATCHDOG_STATE_DIR`.
- **Logging convention** — every decision in the three subsystems uses a grep-friendly bracket tag so a single `journalctl` filter recovers the full decision history:
  ```
  journalctl -u switchroom-<agent>-gateway -g markersweep
  journalctl -u switchroom-<agent>-gateway -g autofallback
  journalctl -u switchroom-<agent>-gateway -g restart-drain
  journalctl -t switchroom-watchdog -g rate-capped
  ```
  `sweepStaleTurnActiveMarker` gained an optional `onRemove` callback carrying `ageMs`/`reason`/`payload` so the gateway can emit a structured log line without coupling the pure helper to a logger.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run test:vitest` — 4447 pass, 13 skipped (no regressions)
- [x] Targeted: `tests/bridge-watchdog.test.ts` (37 tests, including 2 new behavioural tests for the rate cap)
- [x] Targeted: `tests/systemd-restart.test.ts` (pins `RandomizedDelaySec=5` on both units)
- [x] `bun test telegram-plugin/tests/turn-active-marker.test.ts` — 13 pass
- [x] `bun test telegram-plugin/tests/auto-fallback.test.ts` — 25 pass
- [x] `npm run build` — green
- [ ] Operator soak: deploy to a fleet, run `journalctl -t switchroom-watchdog -g rate-capped` after 24 h; expect zero hits unless something is genuinely flapping.

## JTBD / outcome

Serves outcome **#4 Always-on**: an agent that gets stuck in a restart loop while the operator is asleep is the inverse of always-on. The rate cap converts "silent quota burn" into a single-line journal alert that an operator can act on after the fact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)