### PR TITLE
fix(watchdog): foreground sub-agent activity refreshes parent turn-active marker (closes #501)

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -8875,6 +8875,14 @@ void (async () => {
               // write liveness/stall/turn_end updates to the registry DB.
               // Liveness writes are now persisted across the gateway lifetime.
               db: turnsDb,
+              // Issue #501: parent state dir so foreground sub-agent activity
+              // refreshes the parent's `turn-active.json` mtime. Without this
+              // a foreground sub-agent silent for >TURN_HANG_SECS (default
+              // 300s) lets the parent's marker age out and the watchdog
+              // restarts the parent — even though real work is happening
+              // inside the sub-agent. Belt-and-braces with PR #557's
+              // multi-signal progress gate.
+              parentStateDir: STATE_DIR,
               sendNotification: (text: string) => {
                 const ownerChatId = loadAccess().allowFrom[0]
                 if (!ownerChatId) return

--- a/telegram-plugin/subagent-watcher.ts
+++ b/telegram-plugin/subagent-watcher.ts
@@ -43,6 +43,7 @@ import { homedir } from 'os'
 import { projectSubagentLine } from './session-tail.js'
 import { escapeHtml, truncate } from './card-format.js'
 import { bumpSubagentActivity, recordSubagentStall, recordSubagentEnd, reapStuckRunningRows } from './registry/subagents-schema.js'
+import { touchTurnActiveMarker } from './gateway/turn-active-marker.js'
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -132,6 +133,19 @@ export interface SubagentWatcherConfig {
    * Passing `null` or omitting this field disables DB writes entirely.
    */
   db?: SubagentLivenessDb | null
+  /**
+   * Parent agent's state directory — the directory containing the parent's
+   * `turn-active.json` marker (issue #412). When provided, every time a
+   * **foreground** sub-agent's JSONL grows, the watcher touches the parent
+   * marker's mtime so the watchdog (`bin/bridge-watchdog.sh`) doesn't read
+   * the parent as wedged just because all the in-turn activity is happening
+   * inside a sub-agent that hasn't emitted a JSONL line for a while
+   * (issue #501). Background sub-agents are EXCLUDED — they have their own
+   * lifecycle decoupled from the parent's turn boundary, and refreshing the
+   * parent's marker on background activity would mask real parent-side hangs.
+   * If unset, the touch is skipped (preserves pre-#501 behaviour).
+   */
+  parentStateDir?: string | null
   /** Optional logger for debug output. */
   log?: (msg: string) => void
   /**
@@ -288,6 +302,7 @@ function readSubTail(
   fs: FsLike,
   log?: (msg: string) => void,
   db?: SubagentLivenessDb | null,
+  parentStateDir?: string | null,
 ): void {
   try {
     const stat = fs.statSync(entry.filePath)
@@ -312,18 +327,43 @@ function readSubTail(
     // the row by jsonl_agent_id and bump using the actual tool_use_id PK.
     // If the row doesn't exist yet (Phase 2 Pre hook hasn't fired), the UPDATE
     // is a no-op — log and continue, don't INSERT here.
+    //
+    // Issue #501: also use the row to decide whether the sub-agent is
+    // foreground; if so, refresh the PARENT's `turn-active.json` mtime so the
+    // watchdog doesn't kill the parent during a long-running foreground
+    // sub-agent that the parent is awaiting. Background sub-agents are
+    // excluded — they have their own lifecycle and shouldn't mask
+    // parent-side hangs.
+    let isForeground = false
     if (db != null) {
       try {
         const existing = db
-          .prepare('SELECT id FROM subagents WHERE jsonl_agent_id = ?')
-          .get(entry.agentId) as { id: string } | null
+          .prepare('SELECT id, background FROM subagents WHERE jsonl_agent_id = ?')
+          .get(entry.agentId) as { id: string; background: number } | null
         if (existing == null) {
           log?.(`subagent-watcher: liveness skip ${entry.agentId} — row not in DB yet (Phase 2 Pre hook pending)`)
         } else {
           bumpSubagentActivity(db, { id: existing.id, ts: now })
+          isForeground = existing.background === 0
         }
       } catch (dbErr) {
         log?.(`subagent-watcher: liveness write error ${entry.agentId}: ${(dbErr as Error).message}`)
+      }
+    }
+
+    // Issue #501 fix: foreground sub-agent activity refreshes the parent's
+    // turn-active marker. Without this, a foreground sub-agent doing pure
+    // computation or waiting on a slow API for >300s would let the marker
+    // age past TURN_HANG_SECS, and the watchdog would kill the parent even
+    // though real work is happening. The watchdog's multi-signal progress
+    // gate (PR #557) already protects most cases via JSONL liveness, but a
+    // sub-agent that goes silent for the threshold window is the one
+    // remaining gap this fix closes.
+    if (isForeground && parentStateDir) {
+      try {
+        touchTurnActiveMarker(parentStateDir)
+      } catch (touchErr) {
+        log?.(`subagent-watcher: parent marker touch error ${entry.agentId}: ${(touchErr as Error).message}`)
       }
     }
 
@@ -389,6 +429,7 @@ export function startSubagentWatcher(config: SubagentWatcherConfig): SubagentWat
   const rescanMs = config.rescanMs ?? DEFAULT_RESCAN_MS
   const log = config.log
   const db = config.db ?? null
+  const parentStateDir = config.parentStateDir ?? null
   const nowFn = config.now ?? (() => Date.now())
 
   const setI = config.setInterval ?? ((fn, ms) => {
@@ -498,7 +539,7 @@ export function startSubagentWatcher(config: SubagentWatcherConfig): SubagentWat
     // Initial read
     readSubTail(entry, tail, n, (desc) => {
       log?.(`subagent-watcher: description updated for ${agentId}: ${desc}`)
-    }, fs, log, db)
+    }, fs, log, db, parentStateDir)
 
     // If the JSONL already contained a turn_end at registration time
     // (file written-then-watched), fire the state-transition + completion
@@ -529,7 +570,7 @@ export function startSubagentWatcher(config: SubagentWatcherConfig): SubagentWat
         if (!entry || !t) return
         readSubTail(entry, t, nowFn(), (desc) => {
           log?.(`subagent-watcher: description updated for ${agentId}: ${desc}`)
-        }, fs, log, db)
+        }, fs, log, db, parentStateDir)
         maybySendStateTransition(agentId)
       })
     } catch (err) {
@@ -743,7 +784,7 @@ export function startSubagentWatcher(config: SubagentWatcherConfig): SubagentWat
       if (!tail) continue
       readSubTail(entry, tail, n, (desc) => {
         log?.(`subagent-watcher: description updated for ${agentId}: ${desc}`)
-      }, fs, log, db)
+      }, fs, log, db, parentStateDir)
       maybySendStateTransition(agentId)
     }
 

--- a/telegram-plugin/tests/subagent-watcher-parent-marker.test.ts
+++ b/telegram-plugin/tests/subagent-watcher-parent-marker.test.ts
@@ -1,0 +1,274 @@
+/**
+ * Issue #501: foreground sub-agent activity refreshes the parent's
+ * `turn-active.json` mtime so the watchdog's TURN_HANG_SECS gate
+ * (default 300s) doesn't kill the parent during a long sub-agent
+ * task whose JSONL went silent for the threshold window.
+ *
+ * Background sub-agents are EXPLICITLY excluded — their lifecycle is
+ * decoupled from the parent's turn boundary, so refreshing the parent
+ * marker on background activity would mask real parent-side hangs.
+ *
+ * Belt-and-braces with PR #557's multi-signal progress gate in
+ * bin/bridge-watchdog.sh — the marker touch closes the residual gap
+ * when a sub-agent has no JSONL emits for the threshold window.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import * as fsReal from 'fs'
+import { mkdtempSync, mkdirSync, rmSync, statSync, writeFileSync, readFileSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { startSubagentWatcher } from '../subagent-watcher.js'
+import type { SubagentLivenessDb } from '../subagent-watcher.js'
+import {
+  writeTurnActiveMarker,
+  TURN_ACTIVE_MARKER_FILE,
+} from '../gateway/turn-active-marker.js'
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function buildJSONL(...lines: object[]): string {
+  return lines.map((l) => JSON.stringify(l)).join('\n') + '\n'
+}
+
+function subAgentUserMsg(text: string) {
+  return { type: 'user', message: { content: [{ type: 'text', text }] } }
+}
+
+function subAgentToolUse(name: string, id: string) {
+  return { type: 'assistant', message: { content: [{ type: 'tool_use', name, id, input: {} }] } }
+}
+
+/**
+ * Minimal fake DB matching SubagentLivenessDb.
+ * Returns rows whose `jsonl_agent_id` matches the lookup parameter so the
+ * watcher can resolve `background` for the parent-marker decision.
+ */
+function makeFakeDb(rows: Record<string, Record<string, unknown>>): SubagentLivenessDb {
+  return {
+    prepare(sql: string) {
+      return {
+        run() { /* noop — we don't assert DB writes here */ },
+        get(...params: unknown[]) {
+          if (/SELECT.*FROM subagents WHERE jsonl_agent_id/i.test(sql)) {
+            const jsonlId = params[0] as string
+            return Object.values(rows).find((r) => r['jsonl_agent_id'] === jsonlId) ?? null
+          }
+          return null
+        },
+      }
+    },
+  }
+}
+
+describe('subagent-watcher: parent turn-active marker refresh (#501)', () => {
+  let tmpRoot = ''
+  const startedWatchers: Array<{ stop(): void }> = []
+
+  beforeEach(() => {
+    vi.restoreAllMocks()
+    tmpRoot = mkdtempSync(join(tmpdir(), 'switchroom-501-test-'))
+  })
+
+  afterEach(() => {
+    while (startedWatchers.length) {
+      try { startedWatchers.pop()?.stop() } catch { /* ignore */ }
+    }
+    try { rmSync(tmpRoot, { recursive: true, force: true }) } catch { /* ignore */ }
+  })
+
+  function makeWatcher(opts: {
+    agentDir: string
+    db: SubagentLivenessDb | null
+    parentStateDir: string | null
+  }): { poll: () => void; watcher: ReturnType<typeof startSubagentWatcher> } {
+    const intervals: Array<{ fn: () => void; ref: number }> = []
+    let nextRef = 1
+    const watcher = startSubagentWatcher({
+      agentDir: opts.agentDir,
+      sendNotification: () => { /* noop */ },
+      stallThresholdMs: 60_000,
+      rescanMs: 500,
+      now: () => Date.now(),
+      setInterval: (fn) => {
+        const ref = nextRef++
+        intervals.push({ fn, ref })
+        return { ref }
+      },
+      clearInterval: (handle) => {
+        const { ref } = handle as { ref: number }
+        const idx = intervals.findIndex((i) => i.ref === ref)
+        if (idx !== -1) intervals.splice(idx, 1)
+      },
+      log: () => { /* noop */ },
+      db: opts.db,
+      parentStateDir: opts.parentStateDir,
+    })
+    startedWatchers.push(watcher)
+    return { poll: () => intervals[0]?.fn(), watcher }
+  }
+
+  function setupSubagentJsonl(jsonlContent: string, agentId: string): {
+    agentDir: string
+    jsonlPath: string
+  } {
+    const agentDir = join(tmpRoot, 'agent')
+    const subagentsDir = join(agentDir, '.claude', 'projects', 'p1', 'session-abc', 'subagents')
+    mkdirSync(subagentsDir, { recursive: true })
+    const jsonlPath = join(subagentsDir, `agent-${agentId}.jsonl`)
+    writeFileSync(jsonlPath, jsonlContent)
+    return { agentDir, jsonlPath }
+  }
+
+  it('foreground sub-agent JSONL growth touches the parent turn-active marker', () => {
+    const jsonlStem = 'foreground01'
+    const toolUseId = 'toolu_fg_01'
+    const initialContent = buildJSONL(subAgentUserMsg('Do work'))
+    const { agentDir, jsonlPath } = setupSubagentJsonl(initialContent, jsonlStem)
+
+    // Parent state dir with a turn-active marker, mtime stamped well in the past
+    // so a fresh touch is observable.
+    const parentStateDir = join(tmpRoot, 'parent-state')
+    mkdirSync(parentStateDir, { recursive: true })
+    writeTurnActiveMarker(parentStateDir, {
+      turnKey: 'k1',
+      chatId: 'c1',
+      threadId: null,
+      startedAt: 0,
+    })
+    const markerPath = join(parentStateDir, TURN_ACTIVE_MARKER_FILE)
+    // Force the mtime to "long ago" so the touch from the fix is the only
+    // thing that could move it back to ~now.
+    const longAgo = new Date(Date.now() - 10 * 60_000) // 10 minutes ago
+    fsReal.utimesSync(markerPath, longAgo, longAgo)
+    const mtimeBefore = statSync(markerPath).mtimeMs
+
+    // Foreground row: background=0
+    const db = makeFakeDb({
+      [toolUseId]: {
+        id: toolUseId,
+        jsonl_agent_id: jsonlStem,
+        background: 0,
+        status: 'running',
+      },
+    })
+
+    const h = makeWatcher({ agentDir, db, parentStateDir })
+
+    // Boot scan registers the file as historical; subsequent appends are picked
+    // up by the next poll. Append a tool_use to trigger a JSONL bump.
+    const grown = initialContent + buildJSONL(subAgentToolUse('Bash', 'x1'))
+    writeFileSync(jsonlPath, grown)
+    h.poll()
+
+    const mtimeAfter = statSync(markerPath).mtimeMs
+    expect(mtimeAfter).toBeGreaterThan(mtimeBefore)
+    // Sanity: marker payload still parseable
+    expect(() => JSON.parse(readFileSync(markerPath, 'utf8'))).not.toThrow()
+  })
+
+  it('background sub-agent JSONL growth does NOT touch the parent marker', () => {
+    const jsonlStem = 'background01'
+    const toolUseId = 'toolu_bg_01'
+    const initialContent = buildJSONL(subAgentUserMsg('Do background work'))
+    const { agentDir, jsonlPath } = setupSubagentJsonl(initialContent, jsonlStem)
+
+    const parentStateDir = join(tmpRoot, 'parent-state')
+    mkdirSync(parentStateDir, { recursive: true })
+    writeTurnActiveMarker(parentStateDir, {
+      turnKey: 'k1',
+      chatId: 'c1',
+      threadId: null,
+      startedAt: 0,
+    })
+    const markerPath = join(parentStateDir, TURN_ACTIVE_MARKER_FILE)
+    const longAgo = new Date(Date.now() - 10 * 60_000)
+    fsReal.utimesSync(markerPath, longAgo, longAgo)
+    const mtimeBefore = statSync(markerPath).mtimeMs
+
+    // Background row: background=1
+    const db = makeFakeDb({
+      [toolUseId]: {
+        id: toolUseId,
+        jsonl_agent_id: jsonlStem,
+        background: 1,
+        status: 'running',
+      },
+    })
+
+    const h = makeWatcher({ agentDir, db, parentStateDir })
+
+    const grown = initialContent + buildJSONL(subAgentToolUse('Bash', 'x1'))
+    writeFileSync(jsonlPath, grown)
+    h.poll()
+
+    const mtimeAfter = statSync(markerPath).mtimeMs
+    // Marker stays stale — background activity must not refresh it.
+    expect(mtimeAfter).toBe(mtimeBefore)
+  })
+
+  it('parentStateDir unset → no marker touch attempted (preserves pre-#501 behaviour)', () => {
+    const jsonlStem = 'fg_no_state_dir'
+    const toolUseId = 'toolu_fg_02'
+    const initialContent = buildJSONL(subAgentUserMsg('Work'))
+    const { agentDir, jsonlPath } = setupSubagentJsonl(initialContent, jsonlStem)
+
+    // We still write a marker into a known location — but we will NOT pass
+    // parentStateDir to the watcher. The marker must therefore be untouched.
+    const parentStateDir = join(tmpRoot, 'parent-state')
+    mkdirSync(parentStateDir, { recursive: true })
+    writeTurnActiveMarker(parentStateDir, {
+      turnKey: 'k1', chatId: 'c1', threadId: null, startedAt: 0,
+    })
+    const markerPath = join(parentStateDir, TURN_ACTIVE_MARKER_FILE)
+    const longAgo = new Date(Date.now() - 10 * 60_000)
+    fsReal.utimesSync(markerPath, longAgo, longAgo)
+    const mtimeBefore = statSync(markerPath).mtimeMs
+
+    const db = makeFakeDb({
+      [toolUseId]: {
+        id: toolUseId,
+        jsonl_agent_id: jsonlStem,
+        background: 0,
+        status: 'running',
+      },
+    })
+
+    const h = makeWatcher({ agentDir, db, parentStateDir: null })
+
+    const grown = initialContent + buildJSONL(subAgentToolUse('Bash', 'x1'))
+    writeFileSync(jsonlPath, grown)
+    h.poll()
+
+    expect(statSync(markerPath).mtimeMs).toBe(mtimeBefore)
+  })
+
+  it('foreground activity is a no-op when no marker file exists (touchTurnActiveMarker is idempotent)', () => {
+    const jsonlStem = 'fg_no_marker'
+    const toolUseId = 'toolu_fg_03'
+    const initialContent = buildJSONL(subAgentUserMsg('Work'))
+    const { agentDir, jsonlPath } = setupSubagentJsonl(initialContent, jsonlStem)
+
+    const parentStateDir = join(tmpRoot, 'parent-state-empty')
+    mkdirSync(parentStateDir, { recursive: true })
+    // Intentionally NO marker file.
+
+    const db = makeFakeDb({
+      [toolUseId]: {
+        id: toolUseId,
+        jsonl_agent_id: jsonlStem,
+        background: 0,
+        status: 'running',
+      },
+    })
+
+    const h = makeWatcher({ agentDir, db, parentStateDir })
+
+    const grown = initialContent + buildJSONL(subAgentToolUse('Bash', 'x1'))
+    writeFileSync(jsonlPath, grown)
+
+    // Should not throw — touchTurnActiveMarker silently no-ops on missing file.
+    expect(() => h.poll()).not.toThrow()
+    expect(fsReal.existsSync(join(parentStateDir, TURN_ACTIVE_MARKER_FILE))).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary

Closes #501.

A long-running foreground sub-agent (>5 min) that goes silent on JSONL emits — slow API call, pure computation, big model thinking pause — lets the parent's `turn-active.json` marker age past `TURN_HANG_SECS` (default 300s). The watchdog then reads the parent as wedged and restarts it, even though real work is happening inside the sub-agent.

PR #557's multi-signal progress gate already protects most cases via JSONL-liveness fingerprinting (any tool use / text event keeps the parent alive). The remaining gap audited in #501 is sub-agents that go silent on the JSONL for the full threshold window.

## Fix (Option A from the audit)

In `telegram-plugin/subagent-watcher.ts`, when a sub-agent's JSONL grows AND the sub-agent is foreground (registry row `background = 0`), call `touchTurnActiveMarker(parentStateDir)`. Background sub-agents are explicitly excluded — their lifecycle is decoupled from the parent's turn boundary, and refreshing the parent marker on background activity would mask real parent-side hangs.

`parentStateDir` is wired from `STATE_DIR` (the same `TELEGRAM_STATE_DIR` the gateway already uses for marker writes). When unset, the touch is skipped — preserves pre-#501 behaviour.

Belt-and-braces: the watchdog progress gate from #557 stays in place. Together they form two independent layers (parent-side gate + parent-side proactive refresh).

## Test plan

- [x] New test: `telegram-plugin/tests/subagent-watcher-parent-marker.test.ts` (4 cases)
  - foreground sub-agent JSONL growth refreshes the parent marker mtime
  - background sub-agent JSONL growth does NOT touch the marker
  - `parentStateDir` unset → no touch attempted (preserves pre-fix behaviour)
  - foreground activity is a no-op when no marker file exists
- [x] `npm run lint` clean
- [x] All subagent-watcher tests green (34 vitest, 69 bun registry)
- [x] No regressions in pre-existing passing tests; the 33 vitest + 20 bun pre-existing failures all reproduce on clean `upstream/main` (unrelated `cli.issues` / `boot-self-test` / vault-broker tests that need a build first)

🤖 Generated with [Claude Code](https://claude.com/claude-code)