### PR TITLE
feat(telegram): graceful model-down UX (#394 Fix 2)

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -104,6 +104,10 @@ import {
   type OperatorEventKind,
 } from '../operator-events.js'
 import { recordOperatorEvent } from '../operator-events-history.js'
+import {
+  formatModelUnavailableCard,
+  resolveModelUnavailableFromOperatorEvent,
+} from '../model-unavailable.js'
 import { startRestartWatchdog } from './restart-watchdog.js'
 import { validateStringArray } from './access-validator.js'
 
@@ -1388,14 +1392,38 @@ function emitGatewayOperatorEvent(event: OperatorEvent): void {
     )
   }
 
-  let rendered: ReturnType<typeof renderOperatorEvent>
-  try {
-    rendered = renderOperatorEvent(event)
-  } catch (err) {
+  // Issue #394 Fix 2: when the failure is model-unavailable (quota out,
+  // overloaded, or the network can't even reach Anthropic), suppress the
+  // raw stderr/detail and post the actionable ⚠️ card instead. The card
+  // points at the three commands that move the needle (`/authfallback`,
+  // `/auth add`, `/usage`) so the user isn't left staring at "You're out
+  // of extra usage · resets May 3, 11am" with no idea what to do.
+  //
+  // Two routes match:
+  //   - kind already classified as quota-exhausted / rate-limited / unknown-5xx
+  //     by the upstream classifier
+  //   - detail string contains one of the model-unavailable text patterns
+  //     (covers raw stderr that slipped past structured classification)
+  const modelUnavailable = resolveModelUnavailableFromOperatorEvent(event)
+  let renderedText: string
+  let renderedKeyboard: ReturnType<typeof renderOperatorEvent>['keyboard'] | undefined
+  if (modelUnavailable) {
     process.stderr.write(
-      `telegram gateway: renderOperatorEvent failed agent=${agent} kind=${kind}: ${(err as Error).message}\n`,
+      `telegram gateway: operator-event suppressing-raw-stderr-for-model-unavailable agent=${agent} kind=${kind} detected=${modelUnavailable.kind}\n`,
     )
-    return
+    renderedText = formatModelUnavailableCard(modelUnavailable, agent)
+    renderedKeyboard = undefined
+  } else {
+    try {
+      const r = renderOperatorEvent(event)
+      renderedText = r.text
+      renderedKeyboard = r.keyboard
+    } catch (err) {
+      process.stderr.write(
+        `telegram gateway: renderOperatorEvent failed agent=${agent} kind=${kind}: ${(err as Error).message}\n`,
+      )
+      return
+    }
   }
 
   const access = loadAccess()
@@ -1410,9 +1438,9 @@ function emitGatewayOperatorEvent(event: OperatorEvent): void {
     `telegram gateway: operator-event posting agent=${agent} kind=${kind} to ${access.allowFrom.length} chat(s)\n`,
   )
   for (const chat_id of access.allowFrom) {
-    void bot.api.sendMessage(chat_id, rendered.text, {
+    void bot.api.sendMessage(chat_id, renderedText, {
       parse_mode: 'HTML',
-      reply_markup: rendered.keyboard,
+      ...(renderedKeyboard ? { reply_markup: renderedKeyboard } : {}),
     }).catch(e => {
       process.stderr.write(
         `telegram gateway: operator-event send to ${chat_id} failed agent=${agent} kind=${kind}: ${e}\n`,

--- a/telegram-plugin/model-unavailable.ts
+++ b/telegram-plugin/model-unavailable.ts
@@ -1,0 +1,325 @@
+/**
+ * model-unavailable.ts — graceful UX for the "model is down" failure modes.
+ *
+ * Issue #394 (Fix 2). When a user message hits Claude and the model is
+ * unreachable — quota exhausted, overloaded / 429-storm, billing dead, or
+ * the network simply timed out — the bridge used to relay Anthropic's raw
+ * stderr verbatim ("You're out of extra usage · resets May 3, 11am"). The
+ * desired UX is a clean ⚠️ card naming what failed and pointing at the
+ * three actions that actually move the needle:
+ *
+ *   - /authfallback — auto-switch to next slot
+ *   - /auth add     — attach another subscription
+ *   - /usage        — full quota breakdown
+ *
+ * This module owns:
+ *   1. `detectModelUnavailable(stderr)` — pattern-matches a raw error
+ *      string into one of three structured kinds (overload / quota_exhausted
+ *      / network), pulling out a reset Date when the source mentions one.
+ *      Returns null on lines that don't look like a model-down event so
+ *      callers can fall through to their default rendering.
+ *   2. `formatModelUnavailableCard(detection, agent)` — renders the HTML
+ *      card. Reset-time formatting routes through quota-check.ts's
+ *      `formatResetRelative` so "/usage" and this card speak the same
+ *      countdown dialect.
+ *
+ * Pure module: no IPC, no bot, no FS. Trivially unit-testable.
+ */
+
+import { formatResetRelative } from './quota-check.js'
+
+// ─── Public types ────────────────────────────────────────────────────────────
+
+export type ModelUnavailableKind = 'overload' | 'quota_exhausted' | 'network'
+
+export interface ModelUnavailableDetection {
+  kind: ModelUnavailableKind
+  /** When the source mentions a reset window, parsed best-effort to a Date. */
+  resetAt?: Date
+  /** The raw stderr string that triggered the detection. */
+  raw: string
+}
+
+// ─── Detection ───────────────────────────────────────────────────────────────
+
+/**
+ * Inspect a raw stderr / error-message string for one of the known
+ * model-unavailable patterns. Returns null when the line doesn't look
+ * like one — never throws on weird input.
+ *
+ * Detection rules (matched in priority order):
+ *   1. Quota / billing-style strings ("out of extra usage", "credit_balance_too_low",
+ *      "usage limit", "quota exhausted") → quota_exhausted
+ *   2. Overload / 429 / 5xx signals ("overloaded_error", "rate_limit_error",
+ *      "HTTP 429", "Service Unavailable", "503", "529") → overload
+ *   3. Network-layer failures (DNS, ECONNREFUSED, ETIMEDOUT, "fetch failed",
+ *      "network error", "socket hang up") → network
+ *
+ * Quota strings can also carry a reset-time hint ("resets May 3, 11am",
+ * "resets in 2h 15m", "retry after 60 seconds", ISO 8601). When present
+ * and parseable, the Date is attached.
+ */
+export function detectModelUnavailable(
+  stderr: string,
+): ModelUnavailableDetection | null {
+  if (typeof stderr !== 'string' || stderr.length === 0) return null
+  // Defend against pathological input — anything beyond a few KB is almost
+  // certainly not a clean error string and risks a regex stall.
+  const sample = stderr.length > 16_384 ? stderr.slice(0, 16_384) : stderr
+  const lower = sample.toLowerCase()
+
+  // ── 1. Quota / billing exhaustion ──────────────────────────────────────
+  const quotaSignals = [
+    'out of extra usage',
+    'extra usage',
+    'credit_balance_too_low',
+    'credit balance too low',
+    'usage limit',
+    'usage_limit',
+    'quota exhausted',
+    'quota_exhausted',
+    'plan limit',
+    'subscription limit',
+  ]
+  if (quotaSignals.some(s => lower.includes(s))) {
+    const resetAt = parseResetTime(sample)
+    return resetAt !== undefined
+      ? { kind: 'quota_exhausted', resetAt, raw: stderr }
+      : { kind: 'quota_exhausted', raw: stderr }
+  }
+
+  // ── 2. Overload / 429 / 5xx ────────────────────────────────────────────
+  const overloadSignals = [
+    'overloaded_error',
+    'overloaded',
+    'rate_limit_error',
+    'rate limit',
+    'rate-limited',
+    'http 429',
+    '"status":429',
+    'status: 429',
+    ' 429 ',
+    '503 service',
+    'service unavailable',
+    '"status":529',
+    'http 529',
+    ' 529 ',
+  ]
+  if (overloadSignals.some(s => lower.includes(s))) {
+    const resetAt = parseResetTime(sample)
+    return resetAt !== undefined
+      ? { kind: 'overload', resetAt, raw: stderr }
+      : { kind: 'overload', raw: stderr }
+  }
+
+  // ── 3. Network-layer failure ───────────────────────────────────────────
+  const networkSignals = [
+    'econnrefused',
+    'econnreset',
+    'etimedout',
+    'enotfound',
+    'eai_again',
+    'fetch failed',
+    'network error',
+    'socket hang up',
+    'request timed out',
+    'connection refused',
+    'getaddrinfo',
+  ]
+  if (networkSignals.some(s => lower.includes(s))) {
+    return { kind: 'network', raw: stderr }
+  }
+
+  return null
+}
+
+/**
+ * Best-effort reset-time extraction. Tries, in order:
+ *   - "retry after N seconds" / "retry-after: N"
+ *   - "resets in 2h 15m" (relative — anchored at parseTimeNow)
+ *   - "resets May 3, 11am" / "resets at May 3 11:00"
+ *   - bare ISO-8601 timestamp anywhere in the string
+ *
+ * Returns undefined when nothing parseable is found. The `parseTimeNow`
+ * arg lets tests pin the relative-clock anchor; production callers omit
+ * it to use Date.now().
+ */
+function parseResetTime(text: string, parseTimeNow: Date = new Date()): Date | undefined {
+  const lower = text.toLowerCase()
+
+  // "retry after 60 seconds" / "retry-after: 60"
+  const retryAfter = lower.match(/retry[\s-]*after[:\s]+(\d+)\s*(seconds?|s\b|minutes?|m\b|hours?|h\b)?/)
+  if (retryAfter) {
+    const n = Number(retryAfter[1])
+    if (Number.isFinite(n) && n > 0 && n < 7 * 24 * 3600) {
+      const unit = (retryAfter[2] ?? 'seconds').toLowerCase()
+      const ms = unit.startsWith('h')
+        ? n * 3600_000
+        : unit.startsWith('m')
+        ? n * 60_000
+        : n * 1000
+      return new Date(parseTimeNow.getTime() + ms)
+    }
+  }
+
+  // "resets in 2h 15m" / "resets in 30 minutes"
+  const relReset = lower.match(/resets?\s+in\s+([0-9hms\s]+)/)
+  if (relReset) {
+    const ms = parseRelativeDuration(relReset[1])
+    if (ms != null) return new Date(parseTimeNow.getTime() + ms)
+  }
+
+  // ISO-8601 timestamp anywhere in the text
+  const iso = text.match(/\b\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:?\d{2})?\b/)
+  if (iso) {
+    const d = new Date(iso[0])
+    if (!Number.isNaN(d.getTime())) return d
+  }
+
+  // "resets May 3, 11am" / "resets May 3 at 11:00"
+  // Conservative regex — avoid greedy backtracking on long strings.
+  const calReset = text.match(
+    /resets?\s+(?:at\s+)?([A-Z][a-z]{2,8}\s+\d{1,2}(?:,?\s*(?:\d{1,2}(?::\d{2})?\s*(?:am|pm|AM|PM)?))?)/,
+  )
+  if (calReset) {
+    // Anchor to the current year — Anthropic's user-facing strings omit it.
+    const candidate = `${calReset[1]} ${parseTimeNow.getUTCFullYear()}`
+    const d = new Date(candidate)
+    if (!Number.isNaN(d.getTime())) return d
+  }
+
+  return undefined
+}
+
+function parseRelativeDuration(s: string): number | null {
+  // "2h 15m" / "30m" / "45 seconds"
+  let total = 0
+  let matched = false
+  const re = /(\d+)\s*(h|hours?|m|minutes?|s|seconds?)/g
+  let m: RegExpExecArray | null
+  while ((m = re.exec(s)) != null) {
+    matched = true
+    const n = Number(m[1])
+    const unit = m[2].toLowerCase()
+    if (unit.startsWith('h')) total += n * 3600_000
+    else if (unit.startsWith('m')) total += n * 60_000
+    else total += n * 1000
+  }
+  return matched && total > 0 ? total : null
+}
+
+// ─── Card rendering ──────────────────────────────────────────────────────────
+
+export interface FormatCardOptions {
+  /** Slot the agent was using when the failure happened — when known,
+   *  named in the card so the user can act precisely. */
+  slot?: string | null
+  /** Anchor for relative-time formatting. Tests pin this; prod omits it. */
+  now?: Date
+}
+
+/**
+ * Render the actionable ⚠️ card for a detected model-unavailable event.
+ * HTML-formatted for Telegram. Stable shape so snapshot tests remain
+ * meaningful when the suggestion list shifts.
+ *
+ *   ⚠️ <b>Model unavailable</b> on agent <b>name</b>
+ *   Reason: quota exhausted (resets in 5h)
+ *
+ *   <b>What to try</b>
+ *   • <code>/authfallback</code> — switch to the next account slot
+ *   • <code>/auth add</code> — attach another subscription
+ *   • <code>/usage</code> — show quota breakdown
+ */
+export function formatModelUnavailableCard(
+  detection: ModelUnavailableDetection,
+  agent: string,
+  opts: FormatCardOptions = {},
+): string {
+  const now = opts.now ?? new Date()
+  const slotPart = opts.slot ? ` (slot <b>${escHtml(opts.slot)}</b>)` : ''
+  const reason = formatReason(detection, now)
+  const lines = [
+    `⚠️ <b>Model unavailable</b> on agent <b>${escHtml(agent)}</b>${slotPart}`,
+    `Reason: ${reason}`,
+    '',
+    '<b>What to try</b>',
+    '• <code>/authfallback</code> — switch to the next account slot',
+    '• <code>/auth add</code> — attach another subscription',
+    '• <code>/usage</code> — show quota breakdown',
+  ]
+  return lines.join('\n')
+}
+
+function formatReason(d: ModelUnavailableDetection, now: Date): string {
+  const reset = d.resetAt ? ` (${formatResetRelative(d.resetAt, now)})` : ''
+  switch (d.kind) {
+    case 'quota_exhausted':
+      return `quota exhausted${reset}`
+    case 'overload':
+      return `model overloaded${reset}`
+    case 'network':
+      return 'network unreachable'
+  }
+}
+
+// ─── Operator-event bridge ───────────────────────────────────────────────────
+
+/**
+ * Minimal shape for the operator-event input — kept structural to avoid a
+ * runtime dependency on `operator-events.ts`. The gateway passes its real
+ * `OperatorEvent` here; tests can pass a hand-rolled object with just the
+ * `kind` and `detail` fields.
+ *
+ * The string union covers exactly the kinds that are model-availability-
+ * relevant. Any kind outside that set falls through to text-pattern
+ * detection on `detail`.
+ */
+export interface OperatorEventLike {
+  kind: string
+  detail: string
+}
+
+/**
+ * Decide whether an operator event represents a model-unavailable failure.
+ * Returns null when it's something else (auth issue, agent crash, etc.) so
+ * the caller can fall back to its default per-kind renderer.
+ *
+ * Used by the gateway's `emitGatewayOperatorEvent` to decide whether to
+ * suppress the raw stderr-style `detail` and post the actionable card
+ * instead. Lives here (not in the gateway) so it's pure-testable without
+ * spinning up the bot.
+ *
+ * Decision order:
+ *   1. If the kind is one of the known model-unavailable kinds, build a
+ *      synthetic detection from kind + detail (passing detail through
+ *      `detectModelUnavailable` first to pick up reset-time hints).
+ *   2. Otherwise, run pattern detection on `detail` — covers cases where
+ *      a generic 4xx/5xx slipped past the upstream classifier carrying
+ *      a quota/overload message in its body.
+ */
+export function resolveModelUnavailableFromOperatorEvent(
+  ev: OperatorEventLike,
+): ModelUnavailableDetection | null {
+  const detail = typeof ev.detail === 'string' ? ev.detail : ''
+  if (ev.kind === 'quota-exhausted') {
+    return detectModelUnavailable(detail) ?? { kind: 'quota_exhausted', raw: detail }
+  }
+  if (ev.kind === 'rate-limited') {
+    return detectModelUnavailable(detail) ?? { kind: 'overload', raw: detail }
+  }
+  if (ev.kind === 'unknown-5xx') {
+    return detectModelUnavailable(detail) ?? { kind: 'overload', raw: detail }
+  }
+  return detectModelUnavailable(detail)
+}
+
+// ─── HTML escape (mirrors operator-events.ts) ────────────────────────────────
+
+function escHtml(text: string): string {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+}

--- a/telegram-plugin/quota-check.ts
+++ b/telegram-plugin/quota-check.ts
@@ -172,7 +172,13 @@ export function formatQuotaLine(q: QuotaUtilization): string {
   return `${fmt(q.fiveHourUtilizationPct)} / 5h · ${fmt(q.sevenDayUtilizationPct)} / 7d`;
 }
 
-function formatResetRelative(target: Date | null, now: Date = new Date()): string {
+/**
+ * Render a human-friendly "resets in …" countdown for a Date target.
+ * Exported so other surfaces (model-unavailable card, auth dashboard,
+ * banner helpers) speak the same dialect as `/usage`. Returns "—" for
+ * null targets and "resets now" once the target is in the past.
+ */
+export function formatResetRelative(target: Date | null, now: Date = new Date()): string {
   if (!target) return "—";
   const deltaMs = target.getTime() - now.getTime();
   if (deltaMs <= 0) return "resets now";

--- a/telegram-plugin/tests/model-unavailable.test.ts
+++ b/telegram-plugin/tests/model-unavailable.test.ts
@@ -1,0 +1,303 @@
+/**
+ * Unit tests for telegram-plugin/model-unavailable.ts.
+ *
+ * Covers the three load-bearing surfaces of issue #394 Fix 2:
+ *   - detectModelUnavailable correctly classifies the common stderr
+ *     shapes Anthropic / Claude Code emit when the model is down
+ *   - the resetAt parser handles the Anthropic-style "resets …" hints
+ *     and ISO timestamps without choking on weird input
+ *   - formatModelUnavailableCard renders a stable HTML card naming
+ *     the three actionable commands (/authfallback, /auth add, /usage)
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+  detectModelUnavailable,
+  formatModelUnavailableCard,
+  resolveModelUnavailableFromOperatorEvent,
+  type ModelUnavailableDetection,
+} from '../model-unavailable.js'
+
+// ─── detectModelUnavailable ──────────────────────────────────────────────────
+
+describe('detectModelUnavailable — quota / billing strings', () => {
+  it("classifies Anthropic's 'You're out of extra usage' message", () => {
+    const d = detectModelUnavailable("You're out of extra usage · resets May 3, 11am")
+    expect(d?.kind).toBe('quota_exhausted')
+  })
+
+  it('classifies credit_balance_too_low SDK error', () => {
+    const d = detectModelUnavailable(
+      JSON.stringify({ type: 'credit_balance_too_low', message: 'Your credit balance is too low' }),
+    )
+    expect(d?.kind).toBe('quota_exhausted')
+  })
+
+  it('classifies "usage limit" plain-text errors', () => {
+    expect(detectModelUnavailable('Reached usage limit for the 5h window')?.kind).toBe(
+      'quota_exhausted',
+    )
+  })
+
+  it('classifies "quota exhausted" verbatim', () => {
+    expect(detectModelUnavailable('quota exhausted on slot main')?.kind).toBe('quota_exhausted')
+  })
+})
+
+describe('detectModelUnavailable — overload / 429 / 5xx strings', () => {
+  it('classifies overloaded_error JSON', () => {
+    const d = detectModelUnavailable(
+      JSON.stringify({ type: 'overloaded_error', message: 'Overloaded' }),
+    )
+    expect(d?.kind).toBe('overload')
+  })
+
+  it('classifies a bare HTTP 429 line', () => {
+    expect(detectModelUnavailable('HTTP 429 Too Many Requests')?.kind).toBe('overload')
+  })
+
+  it('classifies rate_limit_error', () => {
+    expect(detectModelUnavailable('rate_limit_error: too many requests')?.kind).toBe('overload')
+  })
+
+  it('classifies HTTP 503 Service Unavailable', () => {
+    expect(detectModelUnavailable('upstream returned 503 Service Unavailable')?.kind).toBe(
+      'overload',
+    )
+  })
+})
+
+describe('detectModelUnavailable — network failures', () => {
+  it('classifies ECONNREFUSED', () => {
+    expect(detectModelUnavailable('connect ECONNREFUSED 1.2.3.4:443')?.kind).toBe('network')
+  })
+
+  it('classifies ETIMEDOUT', () => {
+    expect(detectModelUnavailable('Error: ETIMEDOUT api.anthropic.com:443')?.kind).toBe('network')
+  })
+
+  it('classifies "fetch failed"', () => {
+    expect(detectModelUnavailable('TypeError: fetch failed')?.kind).toBe('network')
+  })
+
+  it('classifies DNS getaddrinfo failures', () => {
+    expect(detectModelUnavailable('getaddrinfo EAI_AGAIN api.anthropic.com')?.kind).toBe('network')
+  })
+})
+
+describe('detectModelUnavailable — non-matches', () => {
+  it('returns null for empty / non-string input', () => {
+    expect(detectModelUnavailable('')).toBeNull()
+    expect(detectModelUnavailable(undefined as unknown as string)).toBeNull()
+  })
+
+  it('returns null for routine assistant chatter', () => {
+    expect(detectModelUnavailable('OK, I will read the file now.')).toBeNull()
+  })
+
+  it('returns null for unrelated errors (auth, malformed JSON)', () => {
+    expect(detectModelUnavailable('authentication_error: invalid bearer token')).toBeNull()
+  })
+
+  it('truncates pathologically long input rather than scanning it all', () => {
+    // 100KB of "A" then a quota signal — detector samples the first 16KB so
+    // this should NOT match. Confirms the slice guard fires.
+    const huge = 'A'.repeat(100_000) + ' out of extra usage'
+    expect(detectModelUnavailable(huge)).toBeNull()
+  })
+})
+
+describe('detectModelUnavailable — reset-time extraction', () => {
+  it('parses "retry after 60 seconds" relative to now', () => {
+    const d = detectModelUnavailable('429 rate_limit_error. Retry after 60 seconds.')
+    expect(d?.kind).toBe('overload')
+    expect(d?.resetAt).toBeInstanceOf(Date)
+  })
+
+  it('parses "resets in 2h 15m" relative to now', () => {
+    const d = detectModelUnavailable("You're out of extra usage. Resets in 2h 15m")
+    expect(d?.kind).toBe('quota_exhausted')
+    expect(d?.resetAt).toBeInstanceOf(Date)
+    // Should be within the next 3 hours
+    const deltaMs = (d?.resetAt as Date).getTime() - Date.now()
+    expect(deltaMs).toBeGreaterThan(60 * 60_000)
+    expect(deltaMs).toBeLessThan(3 * 60 * 60_000)
+  })
+
+  it('parses bare ISO-8601 timestamps embedded in the string', () => {
+    const d = detectModelUnavailable('quota exhausted, retry at 2026-05-03T11:00:00Z')
+    expect(d?.resetAt?.toISOString()).toBe('2026-05-03T11:00:00.000Z')
+  })
+
+  it('omits resetAt when nothing parseable is present', () => {
+    const d = detectModelUnavailable("You're out of extra usage")
+    expect(d?.kind).toBe('quota_exhausted')
+    expect(d?.resetAt).toBeUndefined()
+  })
+
+  it('network failures never carry a resetAt', () => {
+    const d = detectModelUnavailable('ECONNREFUSED — retry after 60 seconds')
+    expect(d?.kind).toBe('network')
+    expect(d?.resetAt).toBeUndefined()
+  })
+})
+
+// ─── formatModelUnavailableCard ──────────────────────────────────────────────
+
+describe('formatModelUnavailableCard — actionable card', () => {
+  const NOW = new Date('2026-05-03T08:00:00Z')
+
+  function detection(
+    kind: 'overload' | 'quota_exhausted' | 'network',
+    resetAt?: Date,
+  ): ModelUnavailableDetection {
+    return resetAt ? { kind, resetAt, raw: 'test' } : { kind, raw: 'test' }
+  }
+
+  it('quota_exhausted with reset → snapshot-stable card', () => {
+    const card = formatModelUnavailableCard(
+      detection('quota_exhausted', new Date('2026-05-03T13:00:00Z')),
+      'gymbro',
+      { now: NOW },
+    )
+    expect(card).toMatchInlineSnapshot(`
+      "⚠️ <b>Model unavailable</b> on agent <b>gymbro</b>
+      Reason: quota exhausted (resets in 5h)
+
+      <b>What to try</b>
+      • <code>/authfallback</code> — switch to the next account slot
+      • <code>/auth add</code> — attach another subscription
+      • <code>/usage</code> — show quota breakdown"
+    `)
+  })
+
+  it('overload without reset omits the parenthetical', () => {
+    const card = formatModelUnavailableCard(detection('overload'), 'clerk', { now: NOW })
+    expect(card).toContain('Reason: model overloaded')
+    expect(card).not.toContain('(resets')
+  })
+
+  it('network never includes a reset window', () => {
+    const card = formatModelUnavailableCard(detection('network'), 'clerk', { now: NOW })
+    expect(card).toContain('Reason: network unreachable')
+    expect(card).not.toContain('(resets')
+  })
+
+  it('always includes the three actionable suggestions', () => {
+    const card = formatModelUnavailableCard(detection('quota_exhausted'), 'gymbro', { now: NOW })
+    expect(card).toContain('<code>/authfallback</code>')
+    expect(card).toContain('<code>/auth add</code>')
+    expect(card).toContain('<code>/usage</code>')
+  })
+
+  it('names the slot in the header when one is supplied', () => {
+    const card = formatModelUnavailableCard(detection('quota_exhausted'), 'gymbro', {
+      slot: 'pro-1',
+      now: NOW,
+    })
+    expect(card).toContain('slot <b>pro-1</b>')
+  })
+
+  it('escapes HTML in agent and slot names', () => {
+    const card = formatModelUnavailableCard(detection('overload'), '<evil>', {
+      slot: '"injected"',
+      now: NOW,
+    })
+    expect(card).toContain('&lt;evil&gt;')
+    expect(card).toContain('&quot;injected&quot;')
+    expect(card).not.toContain('<evil>')
+  })
+})
+
+// ─── resolveModelUnavailableFromOperatorEvent — gateway integration ──────────
+
+describe('resolveModelUnavailableFromOperatorEvent — kind-driven mapping', () => {
+  it('always treats kind=quota-exhausted as model-unavailable, even with empty detail', () => {
+    const d = resolveModelUnavailableFromOperatorEvent({ kind: 'quota-exhausted', detail: '' })
+    expect(d?.kind).toBe('quota_exhausted')
+  })
+
+  it('always treats kind=rate-limited as overload', () => {
+    const d = resolveModelUnavailableFromOperatorEvent({ kind: 'rate-limited', detail: '' })
+    expect(d?.kind).toBe('overload')
+  })
+
+  it('always treats kind=unknown-5xx as overload', () => {
+    const d = resolveModelUnavailableFromOperatorEvent({
+      kind: 'unknown-5xx',
+      detail: 'something went wrong upstream',
+    })
+    expect(d?.kind).toBe('overload')
+  })
+
+  it('preserves the parsed reset hint from the detail when one is present', () => {
+    const d = resolveModelUnavailableFromOperatorEvent({
+      kind: 'quota-exhausted',
+      detail: "You're out of extra usage. Resets in 2h",
+    })
+    expect(d?.resetAt).toBeInstanceOf(Date)
+  })
+})
+
+describe('resolveModelUnavailableFromOperatorEvent — pattern-driven fallback', () => {
+  it('returns null for credentials-expired (auth issue, not model-down)', () => {
+    expect(
+      resolveModelUnavailableFromOperatorEvent({
+        kind: 'credentials-expired',
+        detail: 'OAuth token expired',
+      }),
+    ).toBeNull()
+  })
+
+  it('returns null for agent-crashed', () => {
+    expect(
+      resolveModelUnavailableFromOperatorEvent({
+        kind: 'agent-crashed',
+        detail: 'Process exit code 1',
+      }),
+    ).toBeNull()
+  })
+
+  it('rescues unknown-4xx when its detail carries a quota signal', () => {
+    const d = resolveModelUnavailableFromOperatorEvent({
+      kind: 'unknown-4xx',
+      detail: "You're out of extra usage",
+    })
+    expect(d?.kind).toBe('quota_exhausted')
+  })
+})
+
+// ─── End-to-end: operator-event detail → rendered card text ──────────────────
+
+describe('integration — gateway suppresses raw stderr in favour of the card', () => {
+  it("turns 'You're out of extra usage' into the actionable card, not the raw text", () => {
+    const rawStderr = "You're out of extra usage · resets May 3, 11am"
+    const detected = resolveModelUnavailableFromOperatorEvent({
+      kind: 'quota-exhausted',
+      detail: rawStderr,
+    })
+    expect(detected).not.toBeNull()
+
+    const card = formatModelUnavailableCard(detected as ModelUnavailableDetection, 'gymbro')
+
+    // The actionable card replaces the raw verbatim error.
+    expect(card).toContain('Model unavailable')
+    expect(card).toContain('quota exhausted')
+    expect(card).toContain('/authfallback')
+    expect(card).toContain('/auth add')
+    expect(card).toContain('/usage')
+
+    // And the raw stderr text never appears in the user-facing card.
+    expect(card).not.toContain('out of extra usage')
+    expect(card).not.toContain('May 3, 11am')
+  })
+
+  it('lets non-model events fall through to the default operator-event renderer', () => {
+    expect(
+      resolveModelUnavailableFromOperatorEvent({
+        kind: 'credentials-invalid',
+        detail: 'Invalid API key',
+      }),
+    ).toBeNull()
+  })
+})


### PR DESCRIPTION
Fix 2 of #394.

## Summary

When the model is unreachable (quota exhausted, overloaded / 429-storm, network down), the gateway used to relay Anthropic's raw stderr verbatim — leaving the user staring at strings like `"You're out of extra usage · resets May 3, 11am"` with no idea what to do. This PR replaces those raw relays with a clean ⚠️ card that names the three commands that actually move the needle.

## Before / After

**Before** (raw Anthropic stderr leaks into Telegram):

```
⚠️ Quota exhausted for gymbro.
You're out of extra usage · resets May 3, 11am
All account slots are at the usage limit. Switchroom will auto-fallback when another slot is available.
```

**After** (actionable card; reset time normalised to the same dialect `/usage` uses):

```
⚠️ Model unavailable on agent gymbro
Reason: quota exhausted (resets in 5h)

What to try
• /authfallback — switch to the next account slot
• /auth add — attach another subscription
• /usage — show quota breakdown
```

## What changed

- New `telegram-plugin/model-unavailable.ts`:
  - `detectModelUnavailable(stderr)` returns `null` or `{ kind: 'overload' | 'quota_exhausted' | 'network', resetAt?, raw }`. Reset-time extraction handles `retry-after`, `resets in 2h 15m`, ISO 8601, and the calendar style (`resets May 3, 11am`).
  - `formatModelUnavailableCard(detection, agent)` — HTML for Telegram. Stable shape so snapshot tests stay meaningful.
  - `resolveModelUnavailableFromOperatorEvent` — pure bridge so the gateway can branch without dragging the gateway types into the model-unavailable module.
- `telegram-plugin/gateway/gateway.ts` — wired into `emitGatewayOperatorEvent`. When detection fires, the actionable card replaces the default `renderOperatorEvent` output and the raw `detail` is suppressed. Other operator-event kinds (auth issues, agent crash, etc.) are unaffected.
- `telegram-plugin/quota-check.ts` — promoted `formatResetRelative` to a public export so `/usage` and the new card share one countdown formatter.

## Test plan

- [x] `npm run lint` clean
- [x] `npm test` — 4537 vitest tests pass, 302 bun tests pass
- [x] 36 new vitest cases in `tests/model-unavailable.test.ts` covering detector classification (429 / quota / network), reset-time extraction, the inline-snapshot for the rendered card, HTML escaping of agent + slot, and the gateway bridge end-to-end (operator event → card, raw stderr never leaks)
- [ ] Live verification on `gymbro` once merged + deployed: trigger a quota-exhausted event and confirm the new card appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)