### PR TITLE
feat(gateway): inline_keyboard buttons on reply / stream_reply (#271)

### DIFF
--- a/telegram-plugin/bridge/bridge.ts
+++ b/telegram-plugin/bridge/bridge.ts
@@ -94,7 +94,7 @@ const TOOL_SCHEMAS = [
   {
     name: 'reply',
     description:
-      'Reply on Telegram. Pass chat_id from the inbound message. By default the reply is a quote-reply to the latest inbound user message in this chat+thread — pass quote:false to opt out, or pass an explicit reply_to to thread under a specific earlier message. message_thread_id routes to a forum topic; files (absolute paths) attach images or documents.',
+      'Reply on Telegram. Pass chat_id from the inbound message. By default the reply is a quote-reply to the latest inbound user message in this chat+thread — pass quote:false to opt out, or pass an explicit reply_to to thread under a specific earlier message. message_thread_id routes to a forum topic; files (absolute paths) attach images or documents. inline_keyboard adds tappable buttons (URL or callback) under the message — single-tap actions beat asking the user to type YES.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -108,6 +108,22 @@ const TOOL_SCHEMAS = [
         disable_web_page_preview: { type: 'boolean', description: 'Disable link preview thumbnails. Default: true.' },
         protect_content: { type: 'boolean', description: 'When true, Telegram prevents the message from being forwarded or saved.' },
         quote_text: { type: 'string', description: 'Surgical quote: specific text to highlight from the reply_to message. Requires reply_to.' },
+        inline_keyboard: {
+          type: 'array',
+          description: 'Optional 2D array of tappable buttons rendered under the message. Outer array = rows; inner array = buttons in each row (max 8 per row, 8 rows). Each button needs a `text` (label, max 64 chars) plus EXACTLY ONE of: `url` (opens link in browser; must start with http(s):// or tg://) or `callback_data` (string, max 58 chars; tap is delivered to this agent as an inbound channel event with meta.button_callback_data=<the data> and the original button_text). Use buttons for single-tap approval/triage flows like [Approve] [Hold]; one tap on mobile beats asking the user to type YES/NO.',
+          items: {
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: {
+                text: { type: 'string', description: 'Button label visible to the user. Max 64 chars.' },
+                url: { type: 'string', description: 'Open this URL when tapped. Mutually exclusive with callback_data.' },
+                callback_data: { type: 'string', description: 'Opaque tag delivered back to the agent on tap. Max 58 chars (gateway prepends an `agent:` prefix to the 64-byte Telegram limit). Mutually exclusive with url.' },
+              },
+              required: ['text'],
+            },
+          },
+        },
       },
       required: ['chat_id', 'text'],
     },
@@ -115,7 +131,7 @@ const TOOL_SCHEMAS = [
   {
     name: 'stream_reply',
     description:
-      'Post the final answer for this turn. The plugin renders an event-driven progress card (Plan → Run → Done with live tool bullets, elapsed time, and status emoji) for free while the turn is in-flight, so you do not need to narrate intermediate progress. Call `stream_reply` exactly once per turn with done=true and the complete answer text. Hard-stops at 4096 chars — longer text throws; fall back to `reply`, which chunks. Calling with done=false is an error in this environment (the progress card already owns the mid-turn surface).',
+      'Post the final answer for this turn. The plugin renders an event-driven progress card (Plan → Run → Done with live tool bullets, elapsed time, and status emoji) for free while the turn is in-flight, so you do not need to narrate intermediate progress. Call `stream_reply` exactly once per turn with done=true and the complete answer text. Hard-stops at 4096 chars — longer text throws; fall back to `reply`, which chunks. Calling with done=false is an error in this environment (the progress card already owns the mid-turn surface). inline_keyboard adds tappable buttons under the final message — see `reply` for shape and constraints.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -128,6 +144,22 @@ const TOOL_SCHEMAS = [
         quote: { type: 'boolean', description: 'Opt out of the default quote-reply behavior. Default: true. Ignored when reply_to is explicitly set.' },
         protect_content: { type: 'boolean', description: 'When true, Telegram prevents the message from being forwarded or saved.' },
         quote_text: { type: 'string', description: 'Surgical quote: specific text to highlight from the reply_to message. Requires reply_to.' },
+        inline_keyboard: {
+          type: 'array',
+          description: '2D array of tappable buttons under the final message. Same shape and constraints as `reply.inline_keyboard` — each button has `text` and EXACTLY ONE of `url` or `callback_data`. Tap on a callback_data button is delivered to this agent as an inbound channel event with meta.button_callback_data set.',
+          items: {
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: {
+                text: { type: 'string' },
+                url: { type: 'string' },
+                callback_data: { type: 'string' },
+              },
+              required: ['text'],
+            },
+          },
+        },
       },
       required: ['chat_id', 'text'],
     },

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -123,6 +123,10 @@ import {
   type AnyButton,
 } from '../telegram-button-constraints.js'
 import {
+  wrapAgentCallbacks,
+  parseAgentCallback,
+} from '../inline-keyboard-callbacks.js'
+import {
   startText as buildStartText,
   helpText as buildHelpText,
   statusPairedText as buildStatusPairedText,
@@ -2175,11 +2179,12 @@ async function executeReply(args: Record<string, unknown>): Promise<{ content: A
     : chunk(effectiveText, limit, access.chunkMode ?? 'length')
   const sentIds: number[] = []
 
-  // #271 (URL-button half): validate and build reply_markup. Attached
-  // to the LAST chunk only so buttons appear on the final visible message.
-  // Mirrors the pattern in server.ts — see buttons-validator for the
-  // accepted shapes (URL buttons land here; callback_data buttons require
-  // separate IPC routing for callback_query that is not yet wired).
+  // #271: validate inline_keyboard and namespace any callback_data with
+  // the `agent:` prefix so the gateway's callback_query dispatcher can
+  // round-trip taps back to this agent without colliding with
+  // infrastructure prefixes (auth:/op:/vd:/vg:/aq:/perm:). URL buttons
+  // pass through unchanged. Attached to the LAST chunk only so buttons
+  // appear on the final visible message.
   let replyMarkup: { inline_keyboard: AnyButton[][] } | undefined
   const rawKeyboard = args.inline_keyboard as AnyButton[][] | undefined
   if (rawKeyboard != null) {
@@ -2190,7 +2195,7 @@ async function executeReply(args: Record<string, unknown>): Promise<{ content: A
         .join('; ')
       throw new Error(`inline_keyboard validation failed: ${summary}`)
     }
-    replyMarkup = { inline_keyboard: rawKeyboard }
+    replyMarkup = { inline_keyboard: wrapAgentCallbacks(rawKeyboard) }
   }
 
   const replySKey = streamKey(chat_id, threadId)
@@ -2444,9 +2449,11 @@ async function executeStreamReply(args: Record<string, unknown>): Promise<unknow
   // path has been retired along with the placeholder text it was
   // designed to overwrite cleanly.
 
-  // #271 (URL-button half): validate inline_keyboard for stream_reply.
-  // Only attached on done=true so buttons land on the final answer
-  // message, not on intermediate draft edits.
+  // #271: validate + namespace callback_data for stream_reply. Same
+  // wrapping as executeReply — URL buttons pass through, callback_data
+  // gets the `agent:` prefix so the dispatcher can route taps back to
+  // this agent. Only attached on done=true so buttons land on the
+  // final answer message, not on intermediate draft edits.
   let streamReplyMarkup: { inline_keyboard: AnyButton[][] } | undefined
   const rawStreamKeyboard = args.inline_keyboard as AnyButton[][] | undefined
   if (rawStreamKeyboard != null && Boolean(args.done)) {
@@ -2457,7 +2464,7 @@ async function executeStreamReply(args: Record<string, unknown>): Promise<unknow
         .join('; ')
       throw new Error(`inline_keyboard validation failed: ${summary}`)
     }
-    streamReplyMarkup = { inline_keyboard: rawStreamKeyboard }
+    streamReplyMarkup = { inline_keyboard: wrapAgentCallbacks(rawStreamKeyboard) }
   }
 
   const result = await handleStreamReply(
@@ -7719,6 +7726,92 @@ bot.on('callback_query:data', async ctx => {
       }
     }
     await ctx.answerCallbackQuery({ text: '✅ ' + choice.slice(0, 60) }).catch(() => {})
+    return
+  }
+
+  // #271: agent-emitted inline_keyboard callbacks. Namespaced with
+  // an `agent:` prefix in inline-keyboard-callbacks.ts so they can
+  // round-trip without colliding with infrastructure prefixes above.
+  // Strip the prefix and forward the raw payload to the connected
+  // bridge as an InboundMessage with meta.button_callback_data set.
+  // The agent treats it like any other inbound channel event — same
+  // queue, same steer/queue classification rules.
+  const agentCb = parseAgentCallback(data)
+  if (agentCb != null) {
+    // Authorization gate — same allowlist as inbound text messages.
+    // Without this any random Telegram user who could see a button
+    // could trigger an action on the agent's behalf.
+    const access = loadAccess()
+    const senderId = String(ctx.from.id)
+    if (!access.allowFrom.includes(senderId)) {
+      await ctx.answerCallbackQuery({ text: 'Not authorized.' }).catch(() => {})
+      return
+    }
+    // Ack the spinner FIRST so the user doesn't see it stick if the
+    // forward path takes a moment.
+    await ctx.answerCallbackQuery().catch(() => {})
+    const cbChatId = String(ctx.chat?.id ?? ctx.from.id)
+    const cbMessageId = ctx.callbackQuery.message?.message_id
+    const buttonText = (() => {
+      // Best-effort: pull the tapped button's label from the source
+      // message's keyboard so the agent gets a human-readable echo.
+      const msg = ctx.callbackQuery.message
+      const kb = (msg && 'reply_markup' in msg ? msg.reply_markup : undefined) as
+        | { inline_keyboard?: Array<Array<{ text?: string; callback_data?: string }>> }
+        | undefined
+      if (!kb?.inline_keyboard) return undefined
+      for (const row of kb.inline_keyboard) {
+        for (const btn of row) {
+          if (btn.callback_data === data && typeof btn.text === 'string') return btn.text
+        }
+      }
+      return undefined
+    })()
+    const cbThreadId = (() => {
+      const msg = ctx.callbackQuery.message
+      if (msg && 'is_topic_message' in msg && msg.is_topic_message && 'message_thread_id' in msg) {
+        const tid = (msg as { message_thread_id?: number }).message_thread_id
+        return typeof tid === 'number' ? tid : undefined
+      }
+      return undefined
+    })()
+    const inboundText = buttonText
+      ? `[user tapped button: ${JSON.stringify(buttonText)} → ${agentCb.raw}]`
+      : `[user tapped button: ${agentCb.raw}]`
+    const inboundMsg: InboundMessage = {
+      type: 'inbound',
+      chatId: cbChatId,
+      ...(cbThreadId != null ? { threadId: cbThreadId } : {}),
+      messageId: cbMessageId ?? 0,
+      user: ctx.from.username ?? String(ctx.from.id),
+      userId: ctx.from.id,
+      ts: Math.floor(Date.now() / 1000),
+      text: inboundText,
+      meta: {
+        chat_id: cbChatId,
+        ...(cbMessageId != null ? { message_id: String(cbMessageId) } : {}),
+        user: ctx.from.username ?? String(ctx.from.id),
+        user_id: String(ctx.from.id),
+        ts: new Date().toISOString(),
+        ...(cbThreadId != null ? { message_thread_id: String(cbThreadId) } : {}),
+        button_callback: 'true',
+        button_callback_data: agentCb.raw,
+        ...(buttonText != null ? { button_text: buttonText } : {}),
+      },
+    }
+    process.stderr.write(
+      `telegram gateway: button_callback chatId=${cbChatId} user=${ctx.from.id} data=${JSON.stringify(agentCb.raw)} btnText=${JSON.stringify(buttonText ?? null)}\n`,
+    )
+    ipcServer.broadcast(inboundMsg)
+    if (ipcServer.clientCount() === 0) {
+      // No bridge connected — the agent's gone. Tell the user so they
+      // don't think the button silently swallowed their tap.
+      void bot.api.sendMessage(
+        cbChatId,
+        '⏳ Agent is restarting — your button tap was queued but won\'t be processed until it comes back.',
+        cbThreadId != null ? { message_thread_id: cbThreadId } : {},
+      ).catch(() => {})
+    }
     return
   }
 

--- a/telegram-plugin/inline-keyboard-callbacks.ts
+++ b/telegram-plugin/inline-keyboard-callbacks.ts
@@ -1,0 +1,97 @@
+/**
+ * Agent-emitted inline-keyboard callback routing (#271).
+ *
+ * Agents emit `inline_keyboard` buttons via the `reply` / `stream_reply`
+ * MCP tools. URL buttons need no routing — Telegram opens them in the
+ * user's browser. callback_data buttons are different: the user's tap
+ * arrives as a `callback_query` update on the gateway's bot, and we
+ * need to deliver it back to the agent as an inbound channel event.
+ *
+ * Wire format
+ * ───────────
+ * The gateway namespaces agent-emitted callback_data with an `agent:`
+ * prefix BEFORE sending to Telegram. Two reasons:
+ *
+ *   1. The existing callback_query dispatcher in gateway.ts routes by
+ *      data prefix (`auth:`, `op:`, `vd:`, `vg:`, `aq:`, `perm:`).
+ *      Any unprefixed data falls through to "ack-and-ignore". Agents
+ *      could otherwise collide with infrastructure prefixes — `auth:`
+ *      from an agent would silently invoke the auth dashboard handler.
+ *
+ *   2. Round-tripping. On callback_query receipt the gateway sees the
+ *      `agent:` prefix, strips it, and forwards the raw data the agent
+ *      originally supplied. Agent code only ever sees its own opaque
+ *      payload — no leaky abstraction.
+ *
+ * Effective payload budget: 64 bytes (Telegram limit) − 6 bytes
+ * (`agent:` prefix) = 58 bytes for agent-supplied data. This is
+ * documented in the MCP tool schema.
+ */
+
+import {
+  validateInlineKeyboard,
+  type AnyButton,
+  type ButtonValidationError,
+} from './telegram-button-constraints.js'
+
+/** Prefix used to namespace agent-emitted callback_data on the wire. */
+export const AGENT_CALLBACK_PREFIX = 'agent:'
+
+/**
+ * Maximum bytes available to the agent for callback_data payloads.
+ * Telegram's hard limit is 64 bytes; the gateway reserves 6 bytes for
+ * the `agent:` prefix.
+ */
+export const AGENT_CALLBACK_DATA_MAX = 64 - AGENT_CALLBACK_PREFIX.length
+
+/**
+ * Wrap every callback_data field in a 2D inline-keyboard with the
+ * gateway's `agent:` namespace prefix. URL-only buttons pass through
+ * unchanged. Returns a fresh array — does not mutate the input.
+ *
+ * Throws when an agent-supplied callback_data exceeds the effective
+ * 58-byte budget (so the operator sees a clear error, not a silent
+ * Telegram 400 BUTTON_DATA_INVALID at send time).
+ */
+export function wrapAgentCallbacks(keyboard: AnyButton[][]): AnyButton[][] {
+  return keyboard.map((row) =>
+    row.map((btn) => {
+      if (typeof btn.callback_data !== 'string') return btn
+      const raw = btn.callback_data
+      const rawBytes = new TextEncoder().encode(raw).byteLength
+      if (rawBytes > AGENT_CALLBACK_DATA_MAX) {
+        throw new Error(
+          `inline_keyboard.callback_data exceeds ${AGENT_CALLBACK_DATA_MAX}-byte agent budget ` +
+          `(actual=${rawBytes}, raw="${raw.slice(0, 32)}${raw.length > 32 ? '…' : ''}")`,
+        )
+      }
+      return { ...btn, callback_data: `${AGENT_CALLBACK_PREFIX}${raw}` }
+    }),
+  )
+}
+
+/**
+ * Parse a callback_query.data string. Returns the raw agent payload
+ * (sans prefix) when the data is agent-emitted; null otherwise so the
+ * gateway dispatcher can fall through to its other routes.
+ */
+export function parseAgentCallback(data: string): { raw: string } | null {
+  if (!data.startsWith(AGENT_CALLBACK_PREFIX)) return null
+  return { raw: data.slice(AGENT_CALLBACK_PREFIX.length) }
+}
+
+/**
+ * Convenience: validate + wrap in one call. Returns either the
+ * wrapped keyboard or a structured error list — caller throws so the
+ * tool result carries the diagnostic upstream.
+ */
+export function validateAndWrapAgentKeyboard(
+  keyboard: AnyButton[][],
+): { ok: true; wrapped: AnyButton[][] } | { ok: false; errors: ButtonValidationError[] } {
+  const errors = validateInlineKeyboard(keyboard)
+  if (errors.length > 0) return { ok: false, errors }
+  // wrapAgentCallbacks may throw on byte-budget overflow; let it
+  // propagate so the caller surfaces the message verbatim.
+  const wrapped = wrapAgentCallbacks(keyboard)
+  return { ok: true, wrapped }
+}

--- a/telegram-plugin/tests/inline-keyboard-callbacks.test.ts
+++ b/telegram-plugin/tests/inline-keyboard-callbacks.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Unit tests for #271's agent-callback prefix wrapping + parsing.
+ *
+ * These pin the wire-format contract so the gateway's callback_query
+ * dispatcher and the inline_keyboard validation in executeReply /
+ * executeStreamReply stay in sync. If anyone adds a new infrastructure
+ * prefix in callback_query routing, these tests still pass — but the
+ * contract that `agent:` is reserved for round-tripping is enforced
+ * by the parser.
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+  AGENT_CALLBACK_PREFIX,
+  AGENT_CALLBACK_DATA_MAX,
+  wrapAgentCallbacks,
+  parseAgentCallback,
+  validateAndWrapAgentKeyboard,
+} from '../inline-keyboard-callbacks.js'
+
+describe('inline-keyboard-callbacks (#271)', () => {
+  describe('AGENT_CALLBACK_DATA_MAX', () => {
+    it('reserves room for the prefix within Telegram\'s 64-byte limit', () => {
+      // Sanity: prefix bytes + agent budget == Telegram limit (64).
+      const prefixBytes = new TextEncoder().encode(AGENT_CALLBACK_PREFIX).byteLength
+      expect(prefixBytes + AGENT_CALLBACK_DATA_MAX).toBe(64)
+    })
+  })
+
+  describe('wrapAgentCallbacks', () => {
+    it('prepends `agent:` to every callback_data field', () => {
+      const wrapped = wrapAgentCallbacks([
+        [{ text: 'Approve', callback_data: 'approve_pr_547' }],
+        [{ text: 'Hold', callback_data: 'hold' }],
+      ])
+      expect(wrapped[0]![0]!.callback_data).toBe('agent:approve_pr_547')
+      expect(wrapped[1]![0]!.callback_data).toBe('agent:hold')
+    })
+
+    it('passes URL buttons through unchanged', () => {
+      const wrapped = wrapAgentCallbacks([
+        [{ text: 'Open docs', url: 'https://example.com' }],
+      ])
+      expect(wrapped[0]![0]).toEqual({ text: 'Open docs', url: 'https://example.com' })
+      expect(wrapped[0]![0]!.callback_data).toBeUndefined()
+    })
+
+    it('handles mixed URL + callback_data buttons in one row', () => {
+      const wrapped = wrapAgentCallbacks([
+        [
+          { text: 'Open', url: 'https://x.test' },
+          { text: 'Approve', callback_data: 'ok' },
+        ],
+      ])
+      expect(wrapped[0]![0]!.url).toBe('https://x.test')
+      expect(wrapped[0]![0]!.callback_data).toBeUndefined()
+      expect(wrapped[0]![1]!.callback_data).toBe('agent:ok')
+      expect(wrapped[0]![1]!.url).toBeUndefined()
+    })
+
+    it('returns a fresh array — does not mutate input', () => {
+      const original = [[{ text: 'A', callback_data: 'a' }]]
+      const wrapped = wrapAgentCallbacks(original)
+      expect(original[0]![0]!.callback_data).toBe('a')
+      expect(wrapped[0]![0]!.callback_data).toBe('agent:a')
+      expect(wrapped).not.toBe(original)
+      expect(wrapped[0]).not.toBe(original[0])
+    })
+
+    it('throws when an agent-supplied callback_data exceeds the 58-byte budget', () => {
+      const tooLong = 'x'.repeat(AGENT_CALLBACK_DATA_MAX + 1)
+      expect(() =>
+        wrapAgentCallbacks([[{ text: 'X', callback_data: tooLong }]]),
+      ).toThrow(/exceeds 58-byte agent budget/)
+    })
+
+    it('accepts callback_data exactly at the 58-byte budget', () => {
+      const atLimit = 'x'.repeat(AGENT_CALLBACK_DATA_MAX)
+      const wrapped = wrapAgentCallbacks([[{ text: 'X', callback_data: atLimit }]])
+      const wireBytes = new TextEncoder().encode(wrapped[0]![0]!.callback_data as string).byteLength
+      expect(wireBytes).toBe(64) // hits Telegram's hard limit exactly
+    })
+
+    it('counts BYTES not chars for multi-byte UTF-8', () => {
+      // '🔐' is 4 bytes in UTF-8. 14 of them = 56 bytes — under the
+      // 58-byte budget, so should pass. 15 of them = 60 bytes — over.
+      const ok = '🔐'.repeat(14)
+      expect(() =>
+        wrapAgentCallbacks([[{ text: 'X', callback_data: ok }]]),
+      ).not.toThrow()
+
+      const bad = '🔐'.repeat(15)
+      expect(() =>
+        wrapAgentCallbacks([[{ text: 'X', callback_data: bad }]]),
+      ).toThrow(/exceeds 58-byte agent budget/)
+    })
+
+    it('handles an empty keyboard without crashing', () => {
+      expect(wrapAgentCallbacks([])).toEqual([])
+    })
+  })
+
+  describe('parseAgentCallback', () => {
+    it('strips the prefix and returns the raw payload', () => {
+      const result = parseAgentCallback('agent:approve_pr_547')
+      expect(result).toEqual({ raw: 'approve_pr_547' })
+    })
+
+    it('returns null for non-agent prefixes (lets dispatcher fall through)', () => {
+      expect(parseAgentCallback('auth:rotate:clerk')).toBeNull()
+      expect(parseAgentCallback('op:dismiss:klanker')).toBeNull()
+      expect(parseAgentCallback('vd:unlock:abc')).toBeNull()
+      expect(parseAgentCallback('aq:0:xyz')).toBeNull()
+      expect(parseAgentCallback('perm:allow:abcde')).toBeNull()
+      expect(parseAgentCallback('something_random')).toBeNull()
+    })
+
+    it('returns empty raw payload when the agent emitted bare prefix', () => {
+      // Edge case: agent emits `callback_data: ''` (zero-length). After
+      // wrap we'd send `agent:`. Round-tripping returns { raw: '' }.
+      // Validation upstream should reject empty callback_data; this is
+      // a defensive check.
+      expect(parseAgentCallback('agent:')).toEqual({ raw: '' })
+    })
+  })
+
+  describe('validateAndWrapAgentKeyboard', () => {
+    it('returns ok=true with wrapped keyboard on a valid input', () => {
+      const result = validateAndWrapAgentKeyboard([
+        [{ text: 'Approve', callback_data: 'ok' }],
+      ])
+      expect(result.ok).toBe(true)
+      if (result.ok) {
+        expect(result.wrapped[0]![0]!.callback_data).toBe('agent:ok')
+      }
+    })
+
+    it('returns ok=false with errors when validation fails', () => {
+      // Empty text fails the existing validateInlineKeyboard.
+      const result = validateAndWrapAgentKeyboard([
+        [{ text: '', callback_data: 'ok' }],
+      ])
+      expect(result.ok).toBe(false)
+      if (!result.ok) {
+        expect(result.errors.length).toBeGreaterThan(0)
+        expect(result.errors[0]!.field).toBe('text')
+      }
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Telegram inline keyboards let the agent ask "Approve & Deploy?" with `[Approve] [Hold]` buttons instead of "type YES to approve". One tap on mobile beats typing every time. The runtime plumbing for URL buttons was already there; this PR finishes the half that was missing — agent-emitted `callback_data` round-trips back to the agent as an inbound channel event.

### Surface

Added `inline_keyboard` to the **`reply`** and **`stream_reply`** MCP tool schemas in `bridge.ts` so agents can see and use the param. Each button needs `text` plus EXACTLY ONE of `url` (opens link) or `callback_data` (opaque tag round-tripped to the agent on tap). Limits: max 8 buttons per row × 8 rows; 64-char text; **58-byte callback_data** (the gateway reserves 6 bytes for an `agent:` namespace prefix).

### Round-trip

New `inline-keyboard-callbacks.ts` owns the wire format:

- `wrapAgentCallbacks(keyboard)` — prepends `agent:` to every `callback_data` before sending. URL buttons unchanged.
- `parseAgentCallback(data)` — strips the prefix on inbound `callback_query`, returns `null` for non-agent prefixes so the existing dispatcher routes (`auth:`/`op:`/`vd:`/`vg:`/`aq:`/`perm:`) keep working.

The gateway's `bot.on('callback_query:data')` handler gets a new branch BEFORE the perm-regex fallthrough: when the data starts with `agent:`, strip prefix, **authorize against `access.allowFrom`** (same gate as inbound text), ack the callback, then broadcast an `InboundMessage` with `meta.button_callback="true"`, `meta.button_callback_data=<raw>`, and a human-readable text echo (`[user tapped button: "Approve" → approve_pr_547]`). The agent's channel handler treats it like any other inbound — same queue, same steer/queue rules.

### Why namespace the prefix

The dispatcher in `gateway.ts` already routes by data prefix. Without a reserved prefix, an agent that emitted `callback_data: 'auth:rotate:clerk'` would silently invoke the auth-dashboard handler. The `agent:` prefix is added by the gateway, not the agent — agents see only their opaque payload, no leaky abstraction.

## Test plan

- [x] 14 new tests in `inline-keyboard-callbacks.test.ts` pin the wire format: prefix wrap, URL passthrough, byte budget (with multi-byte UTF-8 cases), parse round-trip, dispatcher fall-through for infrastructure prefixes
- [x] `npm run test:vitest` — 4589 pass
- [x] `bun test telegram-plugin/tests/` — 3029 pass
- [x] `npm run lint` — clean
- [x] `npm run build` — green
- [ ] Manual test: agent emits `[{text:'Approve', callback_data:'ok'}]`, tap on phone, agent's session sees the inbound with `meta.button_callback_data='ok'`

## Out of scope

- Web-app buttons (`web_app`)
- `switch_inline_query` (search-style deep links)
- `pay` (Telegram payments)

All called out as follow-ups in #271's spec.

## JTBD / outcome

Serves outcome **#1 Visibility** (clear-action surfaces remove ambiguity about what the agent is asking) and **#1 / phone-first ergonomics** more broadly — typing on mobile is slow and error-prone; tap-to-decide is the right primitive for steer/queue/approve flows from a phone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)