### PR TITLE
feat(progress-card): opt-in sendMessageDraft transport for pinned card (#354 spike)

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -8476,12 +8476,47 @@ if (streamMode === 'checklist') {
           ? { reply_to: String(replyToMessageId) }
           : {}),
       }
+      // #354 spike: opt-in draft transport for the pinned card body.
+      // The agent's stream_reply tool already uses sendMessageDraft in
+      // DMs (continuous trailing-edge bouncing-dots animation, no edit
+      // budget burn). The progress card's emit doesn't, so the pinned
+      // card never gets the same liveness signal between explicit
+      // tool_use events. Wiring it on here passes `isPrivateChat` +
+      // `sendMessageDraft` into handleStreamReply — the existing draft
+      // transport selection in stream-reply-handler picks it up.
+      //
+      // Default OFF pending operator validation of the spike unknowns
+      // documented in #354:
+      //   1. Can a draft message be PINNED? `pinMgr.considerPin` runs
+      //      after handleStreamReply returns a messageId — if drafts
+      //      can't be pinned, pin would silently fail and the card
+      //      wouldn't pin until materialize on turn_end (UX shift).
+      //   2. What happens if the bot dies mid-draft? Telegram may
+      //      orphan the draft visibly, leaving a half-rendered card.
+      //   3. Group/forum chats fall through to the legacy edit path
+      //      (isPrivateChat=false → resolvedTransport='message' in
+      //      stream-reply-handler.ts). Forum topics in DMs don't exist;
+      //      we still defend against future shape changes by guarding
+      //      on threadId presence.
+      //
+      // To enable: PROGRESS_CARD_DRAFT_TRANSPORT=1. Run for a day on a
+      // single agent, watch journalctl for "progress-card emit failed"
+      // bursts and confirm cards pin correctly. If clean, flip the
+      // default in a follow-up PR.
+      const draftFlagOn = process.env.PROGRESS_CARD_DRAFT_TRANSPORT === '1'
+      const draftEligible = draftFlagOn && isDmChatId(chatId) && threadId == null
       handleStreamReply(args, { activeDraftStreams, activeDraftParseModes, suppressPtyPreview }, {
         bot: lockedBot, retry: robustApiCall, markdownToHtml, escapeMarkdownV2, repairEscapedWhitespace,
         takeHandoffPrefix: () => '', assertAllowedChat, resolveThreadId, disableLinkPreview: true,
         defaultFormat: 'html', logStreamingEvent, endStatusReaction,
         historyEnabled: false, recordOutbound: () => {},
         writeError: (line) => process.stderr.write(line),
+        ...(draftEligible
+          ? {
+              isPrivateChat: true,
+              ...(sendMessageDraftFn != null ? { sendMessageDraft: sendMessageDraftFn } : {}),
+            }
+          : {}),
       }).then((result) => {
         // Successful API call — reset the consecutive-4xx counter.
         progressDriver?.reportApiSuccess(turnKey)

--- a/telegram-plugin/tests/progress-card-draft-flag.test.ts
+++ b/telegram-plugin/tests/progress-card-draft-flag.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Pin the wiring for #354's PROGRESS_CARD_DRAFT_TRANSPORT env flag.
+ *
+ * Two regressions this guards against:
+ *
+ *   1. The flag drifting silently — someone refactors the progress-
+ *      card emit and forgets to thread isPrivateChat / sendMessageDraft
+ *      when the flag is on. Result: the card stays on the legacy edit
+ *      path even though the operator opted in.
+ *
+ *   2. The flag turning on by default before the spike unknowns are
+ *      validated. Default-OFF is load-bearing: until we know drafts
+ *      can be pinned and survive bot crashes, the legacy path is the
+ *      safe one.
+ *
+ * Source-level pinning rather than behavioural — the gateway emit
+ * lives inside the bot startup wiring and is hard to drive in
+ * isolation. The contract here is the literal env-var check + the
+ * fact that draft deps are conditional on it.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+const gatewaySrc = readFileSync(
+  resolve(__dirname, '..', 'gateway', 'gateway.ts'),
+  'utf-8',
+)
+
+describe('progress-card draft transport flag (#354)', () => {
+  it('is gated behind PROGRESS_CARD_DRAFT_TRANSPORT=1 (default OFF)', () => {
+    // The flag check must be an explicit `=== '1'` not a truthy check
+    // — `process.env.X === '1'` is the project convention, and a
+    // truthy check would mis-fire on `=0` or `=false`.
+    expect(gatewaySrc).toMatch(
+      /process\.env\.PROGRESS_CARD_DRAFT_TRANSPORT\s*===\s*['"]1['"]/,
+    )
+  })
+
+  it('only enables draft when the chat is a DM (no threads, isDmChatId)', () => {
+    // Drafts don't support forum topics. The flag-check block must
+    // gate on isDmChatId(chatId) and threadId == null — otherwise a
+    // forum-topic message would be sent via draft and Telegram would
+    // reject with DRAFT_CHAT_UNSUPPORTED.
+    const block = extractDraftBlock(gatewaySrc)
+    expect(block).toMatch(/isDmChatId\(chatId\)/)
+    expect(block).toMatch(/threadId\s*==\s*null/)
+  })
+
+  it('passes both isPrivateChat AND sendMessageDraft when eligible', () => {
+    // Without sendMessageDraft, stream-reply-handler resolves transport
+    // to 'message' (line 432: `isForumTopic || deps.sendMessageDraft == null`).
+    // Both deps must be threaded together for the draft path to fire.
+    const block = extractDraftBlock(gatewaySrc)
+    expect(block).toMatch(/isPrivateChat:\s*true/)
+    expect(block).toMatch(/sendMessageDraft:\s*sendMessageDraftFn/)
+  })
+
+  it('documents the spike unknowns from #354 inline so an operator can validate', () => {
+    // The flag exists because pinning + crash behavior are unverified.
+    // The block comment must call out both so a future contributor
+    // doesn't flip the default to ON without doing the spike first.
+    const block = extractDraftBlock(gatewaySrc)
+    expect(block.toLowerCase()).toMatch(/pin/)
+    expect(block.toLowerCase()).toMatch(/spike|unknown/)
+  })
+})
+
+/** Pull the #354 spike block out of gateway.ts for source-level assertions. */
+function extractDraftBlock(src: string): string {
+  // The block starts at the spike comment marker and ends at the next
+  // `handleStreamReply(` invocation. Big enough to span the gate +
+  // the conditional draft-deps spread.
+  const start = src.indexOf('// #354 spike')
+  expect(start, '#354 spike block not found in gateway.ts').toBeGreaterThan(0)
+  const end = src.indexOf(').then', start)
+  expect(end, '#354 spike block end not found').toBeGreaterThan(start)
+  return src.slice(start, end)
+}


### PR DESCRIPTION
## Summary

Wires the same draft transport that the agent's `stream_reply` tool already uses into the progress card's emit path, **behind a default-off feature flag**.

The agent's stream_reply path (gateway.ts:2490) uses `sendMessageDraft` for continuous trailing-edge bouncing-dots animation in DMs. The progress-card emit (gateway.ts:8479) currently does NOT pass `isPrivateChat` / `sendMessageDraft` to `handleStreamReply`, so its pinned card always uses the legacy `sendMessage` + `editMessageText` path.

### What this change does

When `PROGRESS_CARD_DRAFT_TRANSPORT=1` and the chat is a DM with no forum thread, the progress-card's `handleStreamReply` call passes the two draft deps. The existing transport selection in `stream-reply-handler.ts` (line 432: `isForumTopic || deps.sendMessageDraft == null` → `'message'`) automatically picks `'draft'` from there.

### Why default OFF

#354 lists four spike unknowns that need runtime validation. The existing infrastructure for drafts is solid (it's been in production for `stream_reply` for weeks), but the **pinning** behaviour is unverified for drafts — and the progress card is a pinned message. Risks:

1. **Can a draft be PINNED?** `pinMgr.considerPin` runs after each emit using `result.messageId`. If drafts can't be pinned, the card would only pin on materialize at `turn_end` — a UX regression.
2. **Bot crash mid-draft.** Telegram may orphan the draft visibly.
3. **Edit-budget** on draft updates vs `editMessageText`.
4. **Full-content rewrites** — the card replaces the whole body each tick, not append-style.

### To validate

```sh
# Single-agent canary
PROGRESS_CARD_DRAFT_TRANSPORT=1 switchroom agent restart <one-agent>
# Watch journal for a day
journalctl -u switchroom-<agent>-gateway -g 'progress-card emit failed'
# Confirm cards still pin (manual check on Telegram)
```

If clean, a follow-up PR can flip the default to ON.

## Test plan

- [x] 4 pinning tests in `progress-card-draft-flag.test.ts` — guards the `=== '1'` check, DM-only gating, both deps threaded together, and the spike-unknowns block-comment
- [x] `npm run test:vitest` — 4589 pass
- [x] `bun test telegram-plugin/tests/` — 3025 pass
- [x] `npm run lint` — clean
- [x] `npm run build` — green
- [ ] **Operator action**: enable on one agent, observe for 24 h, decide on default flip

## JTBD / outcome

Serves outcome **#1 Visibility**. Today the pinned card looks frozen between explicit `tool_use` events (the only thing that drives a fresh edit). Drafts give a free, no-edit-budget animation that signals "still working" without burning Telegram's rate limit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)