### PR TITLE
feat(cli): switchroom telegram voice-in + webhook verbs (#597 phase 2)

### DIFF
--- a/src/cli/telegram-yaml.ts
+++ b/src/cli/telegram-yaml.ts
@@ -10,7 +10,7 @@
  * created on demand.
  */
 
-import { parseDocument, type Document, isMap, type YAMLMap } from "yaml";
+import { parseDocument, type Document, isMap, isSeq, type YAMLMap, type YAMLSeq } from "yaml";
 
 export type TelegramFeature = "voice_in" | "telegraph" | "webhook_sources";
 
@@ -79,4 +79,76 @@ function pruneEmptyMap(doc: Document, path: string[]): void {
   if (isMap(node) && (node as YAMLMap).items.length === 0) {
     doc.deleteIn(path);
   }
+}
+
+/**
+ * Add a webhook source (string) to `agents.<agent>.channels.telegram.webhook_sources`.
+ *
+ * webhook_sources is an array, not a single value — each element names a
+ * source whose secret lives in vault at `vault:webhook/<agent>/<source>`.
+ * The runtime joins on this array to know which inbound webhook payloads
+ * to accept; appending is the common case ("add github webhook to klanker"
+ * shouldn't blow away an existing 'generic' source).
+ *
+ * Idempotent: appending an already-present source returns the YAML
+ * unchanged (so a re-run after an interrupted enable doesn't produce
+ * duplicate entries).
+ */
+export function addWebhookSource(
+  yamlText: string,
+  agentName: string,
+  source: string,
+): string {
+  const doc = parseDocument(yamlText);
+  ensureAgent(doc, agentName);
+  const existing = doc.getIn(["agents", agentName, "channels", "telegram", "webhook_sources"]);
+  if (isSeq(existing)) {
+    const seq = existing as YAMLSeq;
+    for (const item of seq.items) {
+      // YAML seq items are Scalar nodes; .value is the string.
+      const v = (item as { value?: unknown }).value ?? item;
+      if (v === source) return yamlText; // idempotent
+    }
+    seq.add(source);
+  } else {
+    doc.setIn(
+      ["agents", agentName, "channels", "telegram", "webhook_sources"],
+      [source],
+    );
+  }
+  return String(doc);
+}
+
+/**
+ * Remove a webhook source from the array. No-op when the source isn't
+ * present. When the array becomes empty, the parent webhook_sources
+ * entry is dropped (and empty parent maps pruned) so the YAML doesn't
+ * accumulate `webhook_sources: []` debris.
+ */
+export function removeWebhookSource(
+  yamlText: string,
+  agentName: string,
+  source: string,
+): string {
+  const doc = parseDocument(yamlText);
+  if (!hasAgent(doc, agentName)) return yamlText;
+  const existing = doc.getIn(["agents", agentName, "channels", "telegram", "webhook_sources"]);
+  if (!isSeq(existing)) return yamlText;
+  const seq = existing as YAMLSeq;
+  const beforeLen = seq.items.length;
+  // Iterate from the end so splice indices remain stable. yaml's
+  // YAMLSeq doesn't expose indexOf for primitive values cleanly, so
+  // walk the array.
+  for (let i = seq.items.length - 1; i >= 0; i--) {
+    const item = seq.items[i];
+    const v = (item as { value?: unknown })?.value ?? item;
+    if (v === source) seq.delete(i);
+  }
+  if (seq.items.length === beforeLen) return yamlText; // no change
+  if (seq.items.length === 0) {
+    doc.deleteIn(["agents", agentName, "channels", "telegram", "webhook_sources"]);
+    pruneEmptyMap(doc, ["agents", agentName, "channels", "telegram"]);
+    pruneEmptyMap(doc, ["agents", agentName, "channels"]);
+  }
+  return String(doc);
 }

--- a/src/cli/telegram.ts
+++ b/src/cli/telegram.ts
@@ -5,16 +5,25 @@
  * hint" so enabling voice-in / telegraph / webhook is one command, not
  * three files. Builds on the cascade-canonical schema landed in #596.
  *
- * Initial scope: `status` + telegraph enable/disable. Voice-in (vault +
- * api-key) and webhook (vault + secret) land in a follow-up.
+ * Phase 1: status + telegraph enable/disable.
+ * Phase 2 (this commit): voice-in (vault + OpenAI api-key) and webhook
+ *   (vault + signature secret per source).
  */
 
 import type { Command } from "commander";
 import chalk from "chalk";
-import { readFileSync, writeFileSync } from "node:fs";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { createInterface } from "node:readline";
+import { resolvePath, loadConfig } from "../config/loader.js";
+import { createVault, setStringSecret } from "../vault/vault.js";
 import { getConfig, getConfigPath, withConfigError } from "./helpers.js";
 import { resolveAgentConfig } from "../config/merge.js";
-import { setTelegramFeature, removeTelegramFeature } from "./telegram-yaml.js";
+import {
+  setTelegramFeature,
+  removeTelegramFeature,
+  addWebhookSource,
+  removeWebhookSource,
+} from "./telegram-yaml.js";
 
 export function registerTelegramCommand(program: Command): void {
   const tg = program
@@ -133,6 +142,65 @@ function registerEnableVerb(tg: Command, program: Command): void {
         await applyYamlEdit(program, opts.agent, "telegraph", value, opts.dryRun ?? false);
       }),
     );
+
+  // ─── voice-in (#597 phase 2) ─────────────────────────────────────────────
+  enable
+    .command("voice-in")
+    .description(
+      "Enable voice-message transcription via OpenAI Whisper. Vault-stores the API key under 'openai/api-key' and points the agent's voice_in.api_key at it.",
+    )
+    .requiredOption("--agent <name>", "Agent name (must exist in switchroom.yaml)")
+    .requiredOption("--api-key <key>", "OpenAI API key (sk-...). Stored in the vault, never written to switchroom.yaml.")
+    .option("--provider <name>", "Transcription provider", "openai")
+    .option("--language <iso639>", "Optional language hint (e.g. 'en'). Improves accuracy when the user's language is known.")
+    .option("--vault-key <key>", "Vault key under which to store the API key", "openai/api-key")
+    .option("--dry-run", "Print the YAML diff without writing or vaulting anything")
+    .action(
+      withConfigError(async (opts: VoiceInEnableOpts) => {
+        if (opts.provider !== "openai") {
+          fail(`--provider currently only supports 'openai' (got '${opts.provider}'). Other providers will land in a follow-up.`);
+        }
+        if (!opts.apiKey.startsWith("sk-")) {
+          // Soft validation — OpenAI keys all start with sk-. Catches an
+          // operator pasting the wrong thing (e.g. the org id) at write
+          // time rather than discovering it via a 401 at first voice msg.
+          fail(`--api-key doesn't look like an OpenAI key (expected prefix 'sk-', got '${opts.apiKey.slice(0, 6)}…'). If this is intentional, please file a bug.`);
+        }
+        if (!opts.dryRun) {
+          await vaultPut(program, opts.vaultKey, opts.apiKey);
+        }
+        const value: Record<string, unknown> = {
+          enabled: true,
+          provider: opts.provider,
+          api_key: `vault:${opts.vaultKey}`,
+        };
+        if (opts.language) value.language = opts.language;
+        await applyYamlEdit(program, opts.agent, "voice_in", value, opts.dryRun ?? false);
+      }),
+    );
+
+  // ─── webhook (#597 phase 2) ──────────────────────────────────────────────
+  enable
+    .command("webhook")
+    .description(
+      "Enable a webhook source for the agent. Vault-stores the signature secret under 'webhook/<agent>/<source>' and appends the source to the agent's webhook_sources array.",
+    )
+    .requiredOption("--agent <name>", "Agent name (must exist in switchroom.yaml)")
+    .requiredOption("--source <name>", "Source identifier (e.g. 'github', 'generic', 'stripe'). Used for the vault key and to label inbound payloads.")
+    .requiredOption("--secret <value>", "Webhook signature secret. Stored in the vault, never in switchroom.yaml.")
+    .option("--dry-run", "Print the YAML diff without writing or vaulting")
+    .action(
+      withConfigError(async (opts: WebhookEnableOpts) => {
+        if (!/^[a-z][a-z0-9_-]{0,63}$/.test(opts.source)) {
+          fail(`--source must be lowercase alphanumeric (with -/_), 1-64 chars (got '${opts.source}'). The source name is used as a vault key segment and as a label on inbound payloads.`);
+        }
+        const vaultKey = `webhook/${opts.agent}/${opts.source}`;
+        if (!opts.dryRun) {
+          await vaultPut(program, vaultKey, opts.secret);
+        }
+        await applyYamlAddWebhook(program, opts.agent, opts.source, opts.dryRun ?? false);
+      }),
+    );
 }
 
 interface TelegraphEnableOpts {
@@ -140,6 +208,22 @@ interface TelegraphEnableOpts {
   threshold: string;
   shortName?: string;
   authorName?: string;
+  dryRun?: boolean;
+}
+
+interface VoiceInEnableOpts {
+  agent: string;
+  apiKey: string;
+  provider: string;
+  language?: string;
+  vaultKey: string;
+  dryRun?: boolean;
+}
+
+interface WebhookEnableOpts {
+  agent: string;
+  source: string;
+  secret: string;
   dryRun?: boolean;
 }
 
@@ -158,6 +242,33 @@ function registerDisableVerb(tg: Command, program: Command): void {
     .action(
       withConfigError(async (opts: { agent: string; dryRun?: boolean }) => {
         await applyYamlRemove(program, opts.agent, "telegraph", opts.dryRun ?? false);
+      }),
+    );
+
+  disable
+    .command("voice-in")
+    .description(
+      "Disable voice-in for the agent. Removes the voice_in entry from switchroom.yaml; leaves the vault key in place so re-enable doesn't require re-entering the key.",
+    )
+    .requiredOption("--agent <name>", "Agent name")
+    .option("--dry-run", "Print the YAML diff without writing")
+    .action(
+      withConfigError(async (opts: { agent: string; dryRun?: boolean }) => {
+        await applyYamlRemove(program, opts.agent, "voice_in", opts.dryRun ?? false);
+      }),
+    );
+
+  disable
+    .command("webhook")
+    .description(
+      "Remove a single webhook source from the agent. Other sources (if any) remain enabled. The vault entry for the source's signature secret is NOT deleted — re-enable doesn't require re-entering it.",
+    )
+    .requiredOption("--agent <name>", "Agent name")
+    .requiredOption("--source <name>", "Source identifier to remove")
+    .option("--dry-run", "Print the YAML diff without writing")
+    .action(
+      withConfigError(async (opts: { agent: string; source: string; dryRun?: boolean }) => {
+        await applyYamlRemoveWebhook(program, opts.agent, opts.source, opts.dryRun ?? false);
       }),
     );
 }
@@ -246,4 +357,150 @@ function makeUnifiedDiff(before: string, after: string): string {
 function fail(msg: string): never {
   console.error(chalk.red(`Error: ${msg}`));
   process.exit(1);
+}
+
+// ─── shared helpers for #597 phase 2 ─────────────────────────────────────────
+
+async function applyYamlAddWebhook(
+  program: Command,
+  agent: string,
+  source: string,
+  dryRun: boolean,
+): Promise<void> {
+  const path = getConfigPath(program);
+  const before = readFileSync(path, "utf-8");
+  let after: string;
+  try {
+    after = addWebhookSource(before, agent, source);
+  } catch (err) {
+    fail((err as Error).message);
+  }
+  if (before === after) {
+    console.log(
+      chalk.yellow(
+        `No change — webhook source '${source}' was already enabled for agent '${agent}'.`,
+      ),
+    );
+    return;
+  }
+  emitDiffOrWrite(path, before, after, dryRun);
+  if (!dryRun) {
+    console.log(chalk.green(`✓ Enabled webhook source '${source}' for agent '${agent}'`));
+    console.log(
+      chalk.gray(`  Vault key: webhook/${agent}/${source}`),
+    );
+    console.log(
+      chalk.gray(`  Run 'switchroom agent restart ${agent}' to pick up the change.`),
+    );
+  }
+}
+
+async function applyYamlRemoveWebhook(
+  program: Command,
+  agent: string,
+  source: string,
+  dryRun: boolean,
+): Promise<void> {
+  const path = getConfigPath(program);
+  const before = readFileSync(path, "utf-8");
+  const after = removeWebhookSource(before, agent, source);
+  if (before === after) {
+    console.log(
+      chalk.yellow(
+        `No change — webhook source '${source}' is not currently enabled for agent '${agent}'.`,
+      ),
+    );
+    return;
+  }
+  emitDiffOrWrite(path, before, after, dryRun);
+  if (!dryRun) {
+    console.log(chalk.green(`✓ Disabled webhook source '${source}' for agent '${agent}'`));
+    console.log(
+      chalk.gray(`  Vault key webhook/${agent}/${source} left in place — re-enable will reuse it.`),
+    );
+    console.log(
+      chalk.gray(`  Run 'switchroom agent restart ${agent}' to pick up the change.`),
+    );
+  }
+}
+
+/**
+ * Vault-put helper for the voice-in / webhook verbs. Resolves the
+ * vault path from the loaded config (falls back to the canonical
+ * default), prompts for the passphrase if not set via env, and writes
+ * the secret as a string entry. Mirrors the pattern in cli/setup.ts.
+ *
+ * Creates the vault on first use — operators who haven't run
+ * `switchroom vault init` yet shouldn't see the verb fail with a
+ * confusing "vault not found" error when the natural action is to
+ * create it.
+ */
+async function vaultPut(program: Command, key: string, value: string): Promise<void> {
+  const configPath = (program.optsWithGlobals().config as string | undefined) ?? undefined;
+  const vaultPath = resolveVaultPath(configPath);
+  const passphrase = await getVaultPassphrase();
+  if (!existsSync(vaultPath)) {
+    createVault(passphrase, vaultPath);
+    console.log(chalk.gray(`  Created new vault at ${vaultPath}`));
+  }
+  setStringSecret(passphrase, vaultPath, key, value);
+  console.log(chalk.green(`✓ Stored secret in vault as '${key}'`));
+}
+
+function resolveVaultPath(configPath?: string): string {
+  try {
+    const config = loadConfig(configPath);
+    return resolvePath(config.vault?.path ?? "~/.switchroom/vault.enc");
+  } catch {
+    return resolvePath("~/.switchroom/vault.enc");
+  }
+}
+
+async function getVaultPassphrase(): Promise<string> {
+  const env = process.env.SWITCHROOM_VAULT_PASSPHRASE;
+  if (env) return env;
+  const passphrase = await promptHidden("Vault passphrase: ");
+  if (!passphrase) throw new Error("Vault passphrase cannot be empty");
+  return passphrase;
+}
+
+function promptHidden(prompt: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const rl = createInterface({ input: process.stdin, output: process.stdout });
+    if (process.stdin.isTTY) {
+      process.stdout.write(prompt);
+      const stdin = process.stdin;
+      stdin.setRawMode(true);
+      stdin.resume();
+      let input = "";
+      const onData = (data: Buffer) => {
+        const char = data.toString("utf8");
+        if (char === "\n" || char === "\r") {
+          stdin.setRawMode(false);
+          stdin.removeListener("data", onData);
+          rl.close();
+          process.stdout.write("\n");
+          resolve(input);
+        } else if (char === "") {
+          stdin.setRawMode(false);
+          stdin.removeListener("data", onData);
+          rl.close();
+          process.stdout.write("\n");
+          reject(new Error("Aborted"));
+        } else if (char === "" || char === "\b") {
+          if (input.length > 0) input = input.slice(0, -1);
+        } else {
+          input += char;
+        }
+      };
+      stdin.on("data", onData);
+    } else {
+      // Non-TTY: read a single line. Operator can pipe the passphrase
+      // through stdin for scripted use.
+      rl.question(prompt, (answer) => {
+        rl.close();
+        resolve(answer);
+      });
+    }
+  });
 }

--- a/tests/cli.telegram.test.ts
+++ b/tests/cli.telegram.test.ts
@@ -148,3 +148,124 @@ describe("telegram-yaml: removeTelegramFeature", () => {
     expect(after).toBe(before);
   });
 });
+
+// ─── #597 phase 2: webhook source array helpers ─────────────────────────────
+
+import { addWebhookSource, removeWebhookSource } from "../src/cli/telegram-yaml.js";
+
+describe("telegram-yaml: addWebhookSource (#597 phase 2)", () => {
+  it("creates the webhook_sources array on first source", () => {
+    const before = "agents:\n  klanker:\n    topic_name: K\n";
+    const after = addWebhookSource(before, "klanker", "github");
+    expect(after).toContain("channels:");
+    expect(after).toContain("telegram:");
+    expect(after).toContain("webhook_sources:");
+    expect(after).toContain("github");
+  });
+
+  it("appends a new source to an existing array (preserves prior sources)", () => {
+    const before = [
+      "agents:",
+      "  klanker:",
+      "    channels:",
+      "      telegram:",
+      "        webhook_sources:",
+      "          - generic",
+      "",
+    ].join("\n");
+    const after = addWebhookSource(before, "klanker", "github");
+    expect(after).toContain("- generic");
+    expect(after).toContain("- github");
+  });
+
+  it("is idempotent — appending an already-present source returns the YAML unchanged", () => {
+    const before = [
+      "agents:",
+      "  klanker:",
+      "    channels:",
+      "      telegram:",
+      "        webhook_sources:",
+      "          - github",
+      "",
+    ].join("\n");
+    const after = addWebhookSource(before, "klanker", "github");
+    expect(after).toBe(before);
+  });
+
+  it("throws when the agent isn't declared in switchroom.yaml", () => {
+    const before = "agents:\n  klanker:\n    topic_name: K\n";
+    expect(() => addWebhookSource(before, "ghost", "github")).toThrow(/not declared/);
+  });
+});
+
+describe("telegram-yaml: removeWebhookSource (#597 phase 2)", () => {
+  it("removes one source while preserving siblings", () => {
+    const before = [
+      "agents:",
+      "  klanker:",
+      "    channels:",
+      "      telegram:",
+      "        webhook_sources:",
+      "          - generic",
+      "          - github",
+      "",
+    ].join("\n");
+    const after = removeWebhookSource(before, "klanker", "github");
+    expect(after).toContain("- generic");
+    expect(after).not.toContain("- github");
+  });
+
+  it("prunes empty webhook_sources + parent maps when the last source is removed", () => {
+    const before = [
+      "agents:",
+      "  klanker:",
+      "    channels:",
+      "      telegram:",
+      "        webhook_sources:",
+      "          - github",
+      "",
+    ].join("\n");
+    const after = removeWebhookSource(before, "klanker", "github");
+    expect(after).not.toContain("webhook_sources");
+    expect(after).not.toContain("telegram:");
+    expect(after).not.toContain("channels:");
+  });
+
+  it("preserves sibling features when pruning (only the empty webhook_sources goes)", () => {
+    const before = [
+      "agents:",
+      "  klanker:",
+      "    channels:",
+      "      telegram:",
+      "        telegraph:",
+      "          enabled: true",
+      "        webhook_sources:",
+      "          - github",
+      "",
+    ].join("\n");
+    const after = removeWebhookSource(before, "klanker", "github");
+    expect(after).not.toContain("webhook_sources");
+    expect(after).toContain("telegraph:");
+    expect(after).toContain("enabled: true");
+  });
+
+  it("is a no-op when the source isn't present", () => {
+    const before = [
+      "agents:",
+      "  klanker:",
+      "    channels:",
+      "      telegram:",
+      "        webhook_sources:",
+      "          - generic",
+      "",
+    ].join("\n");
+    const after = removeWebhookSource(before, "klanker", "github");
+    expect(after).toBe(before);
+  });
+
+  it("is a no-op when the agent doesn't exist (no throw)", () => {
+    const before = "agents:\n  klanker:\n    topic_name: K\n";
+    const after = removeWebhookSource(before, "ghost", "github");
+    expect(after).toBe(before);
+  });
+});


### PR DESCRIPTION
## Summary

Phase 2 of the `switchroom telegram` verb introduced in #605. Fills out the two remaining phone-first features so each one is a single operator gesture instead of a vault-put + YAML edit + restart dance.

```sh
switchroom telegram enable voice-in --agent gymbro --api-key sk-...
switchroom telegram disable voice-in --agent gymbro
switchroom telegram enable webhook --agent klanker --source github --secret whsec_...
switchroom telegram disable webhook --agent klanker --source github
```

- **voice-in**: vault-puts the OpenAI key, sets `channels.telegram.voice_in`, validates the key shape so the typo surfaces at write-time not first-use. Disable removes only the YAML so re-enable doesn't ask for the secret again.
- **webhook**: validates source name (alphanumeric + `-`/`_`, becomes both vault-key segment and payload label), vault-puts the signing secret, appends to `webhook_sources` idempotently. Disable removes one source; siblings stay; final removal prunes empty parent maps so the YAML stays clean.
- **YAML editor**: `addWebhookSource` / `removeWebhookSource` for the array-typed field (the existing `setTelegramFeature` was single-value-only).
- **vault helper**: small inline `vaultPut` mirroring `cli/setup.ts` — operators who haven't `vault init`ed yet get vault auto-created instead of "vault not found".

## Design contract

- **Outcome served**: *talk to my agents from anywhere* — phone-first features (voice-in, webhook) become as easy to enable as `auth login`, no YAML editing.
- **Docs test**: ✅ — every verb is discoverable via `switchroom telegram --help`; same shape as phase 1.
- **Defaults test**: ✅ — works on a fresh agent; vault auto-creates if missing; provider defaults to `openai`.
- **Consistency test**: ✅ — same CLI shape, same vault syntax, same restart hint as phase 1 telegraph verb.

## Out of scope

- Auto-restart of the affected agent (CLI prints the explicit restart instruction; same as phase 1).
- Operator-friendly retry on wrong vault passphrase (fails loudly with the underlying decrypt error; same as phase 1).

## Test plan

- [x] `npm run lint` clean
- [x] 19/19 tests in `tests/cli.telegram.test.ts` pass (9 new for the array helpers)
- [ ] Manual smoke: enable voice-in on a real agent, send a voice message, confirm transcription flows
- [ ] Manual smoke: enable webhook on a real agent with a github source, hit the webhook URL, confirm payload routes

🤖 Generated with [Claude Code](https://claude.com/claude-code)