### PR TITLE
feat(auth): one OAuth per Anthropic account, not per agent (foundation PR)

### DIFF
--- a/reference/README.md
+++ b/reference/README.md
@@ -46,6 +46,7 @@ that touches the job.
 ### Subscription-honest — *your Pro or Max is the ceiling*
 
 - [`keep-my-subscription-honest.md`](keep-my-subscription-honest.md) — keep my subscription the only thing I'm paying for
+- [`share-auth-across-the-fleet.md`](share-auth-across-the-fleet.md) — log into Anthropic once per account, not once per agent
 
 ### Always-on — *runs while you sleep or work offline*
 

--- a/reference/share-auth-across-the-fleet.md
+++ b/reference/share-auth-across-the-fleet.md
@@ -1,0 +1,272 @@
+---
+job: log into Anthropic once per account, not once per agent
+outcome: One `claude setup-token` per Anthropic account covers every agent, sub-agent, hook, summarizer, and cron that account is enabled on. Refresh, quota state, and fallback all live at the account level. The user manages accounts; switchroom routes them to consumers.
+stakes: When auth is per-agent, six agents on one Pro subscription means six OAuth flows, six independent refresh cycles, six places quota state can drift, and six 401-storms when the user adds a seventh agent. The user starts to feel the fleet — and asks why "one subscription" demands six logins.
+---
+
+# The job
+
+The user pays Anthropic for a subscription. That subscription is the
+unit they care about: it has a bill, a quota, an expiry, and an account
+identity ("ken@example.com"). Switchroom's job is to make that
+subscription drive the fleet — not to make the user manage one fictional
+copy of it per agent.
+
+Today, every agent has its own private OAuth slot pool. Six agents
+sharing a Pro subscription means the user runs `claude setup-token` six
+times against the same Anthropic identity, ends up with six separate
+access tokens, and watches six independent refresh cycles. When the
+account hits the 5-hour cap, only the agent that tripped it knows;
+the other five blunder into the same wall a few seconds later, each
+discovering the exhaustion separately. When the user adds a seventh
+agent, it's another OAuth flow.
+
+The unit is wrong. The unit should be **the Anthropic account**. The
+agents are consumers of accounts, not owners of them. One login per
+account, then "use this account on these agents" is configuration.
+
+This change also closes a class of subprocess-auth bugs that have bitten
+the fleet repeatedly. Claude Code strips `CLAUDE_CODE_OAUTH_TOKEN` from
+every subprocess it spawns — Stop hooks, handoff summarizers, sub-agents,
+cron-launched `claude -p` all fall back to reading
+`<agent>/.claude/.credentials.json`. Today switchroom maintains a
+fragile dance between `.oauth-token` (env-injected for the parent
+process) and `.credentials.json` (read by everyone else). Make
+`.credentials.json` the only mechanism, owned by one writer, and the
+class of bugs goes away.
+
+## Signs it's working
+
+- Adding a second, third, or sixth agent to the same Anthropic account
+  does not require any OAuth flow. The user runs `switchroom auth enable
+  <account> <agent>` and the agent comes up authenticated.
+- The user can answer "which Anthropic accounts am I logged into and
+  which agents use each?" with one command. The answer fits on a screen.
+- A sub-agent dispatched from a main agent is authenticated against the
+  same account as its parent. The user does nothing to make this happen.
+- A cron-launched `claude -p` invocation in an agent's directory uses
+  the same fresh token as that agent's main process. No 401s, no env-var
+  hand-offs.
+- When an account hits the 5-hour cap, every agent using that account
+  fails over to the next account on its preference list within seconds —
+  not on each agent's next inbound message individually.
+- An agent's auth state survives a 24h+ idle gap. The next message after
+  a long quiet doesn't 401, because the broker kept the credential file
+  fresh whether the agent was awake or not.
+- Removing an account is a single explicit action, refused while any
+  agent is still enabled on it. No orphaned tokens left behind.
+- The user can audit "which agent is using which account right now" and
+  the answer matches what the agent's own claude process reports. No
+  divergence between switchroom's view and reality.
+
+## Anti-patterns: don't build this
+
+- **One credentials file shared between agents via symlink.** Claude (and
+  switchroom's refresher) writes credentials via tempfile + atomic
+  rename. Renaming onto a symlink replaces the symlink with a regular
+  file and orphans the underlying target. Other agents stop seeing
+  refreshes. The "share via inode" instinct is wrong here.
+- **One credentials file shared via hard link or bind mount.** Same
+  atomic-rename trap. Sharing a file across paths cannot survive an
+  atomic-rename writer; the only safe sharing is "one writer, many
+  copies."
+- **`CLAUDE_CODE_OAUTH_TOKEN` env injection as the primary auth path.**
+  Claude strips it from every subprocess. Anything that runs after the
+  initial fork — Stop hooks, sub-agents, summarizers, crons — falls back
+  to disk anyway. Designing around the env path means designing for the
+  rare case and leaving the common case to luck.
+- **Per-agent OAuth refresh.** Multiple processes refreshing the same
+  account against Anthropic's single-use refresh-token endpoint is a
+  race the loser silently fails. A correct design has exactly one
+  refresher per account.
+- **Per-agent quota state.** When account A is rate-limited, all agents
+  using account A are rate-limited. Tracking it per-agent means each
+  agent re-discovers the wall independently and the fallback is
+  uncoordinated.
+- **Account creation as a side effect of `auth login <agent>`.** That
+  conflates "I'm setting up my Anthropic account" with "I'm wiring this
+  agent to an existing account." The two operations should be distinct
+  verbs at the CLI surface. (Today's `switchroom auth login <agent>`
+  does both, and the cost is the per-agent OAuth flow.)
+- **Silent token sharing across accounts.** If the user has two
+  Anthropic accounts (work + personal), the product must keep them
+  visibly separate. Don't fall through one to the other on quota
+  exhaustion unless the user explicitly listed both as preferences.
+- **A new long-running daemon when the existing broker pattern would
+  do.** Switchroom already has a `vault-broker` for similar
+  "one-writer-many-readers" problems. A new auth-broker should be the
+  same shape, not a new kind of process.
+
+## Decisions
+
+These are the choices switchroom makes on the user's behalf, so the
+user doesn't have to:
+
+1. **The Anthropic account is the unit of authentication.** It has a
+   user-chosen label (`work-pro`, `personal-max`), an email, a
+   subscription type, and one canonical `.credentials.json`. Stored at
+   `~/.switchroom/accounts/<label>/`. An account is created by
+   `switchroom auth account add <label>` (which runs `claude
+   setup-token` once and stores the result globally). It is removed by
+   `switchroom auth account rm <label>`, refused while agents are
+   enabled on it.
+
+2. **Agents are consumers, not owners.** An agent declares an ordered
+   list of accounts it can use, in `switchroom.yaml`:
+
+   ```yaml
+   agents:
+     foo:
+       auth:
+         accounts: [work-pro, personal-max]   # priority order
+   ```
+
+   The first non-quota-exhausted account in the list is the agent's
+   active account. The list also drives auto-fallback.
+
+3. **`<agentDir>/.claude/.credentials.json` is a passive mirror.** It
+   is a copy of the active account's canonical credentials, refreshed
+   by the broker, not by claude. No symlinks. No bind mounts. Just an
+   atomic-write copy whose only writer is `switchroom-auth-broker`.
+
+4. **`switchroom-auth-broker` is the only writer.** A new systemd user
+   service in the same shape as `vault-broker`. Owns:
+   - the global `~/.switchroom/accounts/<label>/credentials.json` files,
+   - the OAuth refresh loop (one POST per account, regardless of how
+     many agents use it),
+   - quota state per account (single source of truth for "is this
+     account exhausted right now"),
+   - fanout: when an account refreshes, every enabled agent's mirror
+     gets atomically rewritten,
+   - failover: when an account is marked exhausted, every enabled
+     agent's mirror gets swapped to that agent's next preferred account.
+
+5. **Drop `CLAUDE_CODE_OAUTH_TOKEN` injection in `start.sh`.** The env
+   var was only useful for the parent claude process and was redundant
+   with the credentials file every other consumer reads. Removing it
+   eliminates a code path and a class of subprocess-strip bugs.
+
+6. **Drop the per-agent slot pool entirely.** The
+   `<agentDir>/.claude/accounts/<slot>/` directory tree, the `active`
+   marker, the `.oauth-token` file, the legacy mirror, and the slot-name
+   validation primitives all go away. Their job is replaced by the
+   ordered `auth.accounts` list in `switchroom.yaml` plus the broker's
+   single-mirror semantics.
+
+7. **Ephemeral consumers (one-shot crons, ad-hoc workers) talk to the
+   broker.** A small Unix-socket IPC, same shape as the vault-broker
+   protocol: `GET /credentials?account=<label>` returns the current
+   credentials JSON. The caller writes it to a tmpfs path and points
+   `CLAUDE_CONFIG_DIR` at it. No need to provision a persistent agent
+   directory.
+
+8. **Quota events propagate at the account level.** When a request to
+   account A returns 429 from any consumer, the broker marks account A
+   exhausted with a reset time. All agents currently using A are
+   immediately failed over to their next preferred account. When A's
+   reset time passes, the broker clears the mark; agents that prefer A
+   over their current fallback drift back on next idle.
+
+9. **The broker's death is degraded, not catastrophic.** If
+   `switchroom-auth-broker` is down, agents continue running on
+   whatever's already in their `<agentDir>/.claude/.credentials.json`.
+   No refreshes happen until it comes back. Token lifetime is 8 hours;
+   the broker can be down for hours without a user-visible outage. On
+   restart, the broker re-syncs from the global account files (source
+   of truth) and resumes the loop.
+
+10. **No migration shipped.** This is a new-install design. Existing
+    deployments stay on the per-agent slot model until the operator
+    manually moves them across (one-shot, not a supported CLI flow).
+    The product ships clean: no `switchroom auth migrate` verb, no
+    legacy slot-pool code paths kept "for now," no compatibility
+    shims. The cost is that the operator who is upgrading a live fleet
+    has to delete the per-agent `accounts/<slot>/` directories and
+    re-run `switchroom auth account add` + `enable` themselves. That
+    cost is paid by a small number of people (the early operators) so
+    that the design surface stays clean for everyone after.
+
+11. **The same shape on the CLI and in Telegram.** Both surfaces speak
+    "accounts," not "slots." Telegram's `/auth use work-pro` swaps the
+    agent to that account; `/auth list` shows accounts and which agent
+    is using which. The slot vocabulary disappears from the user-facing
+    surface; if any internal language still uses "slot," it is a bug
+    surfaced in review.
+
+12. **First-run does the right thing automatically.** A first-time user
+    runs `switchroom setup`, picks an agent, and is taken through one
+    OAuth flow that creates a `default` account *and* enables it on the
+    new agent in the same gesture. The two-verb model
+    (`account add` + `enable`) is the deliberate shape for the second,
+    third, and Nth agent — not a regression of the first one. The
+    legacy `switchroom auth login <agent>` verb stays as an alias that
+    does account-create-if-absent + enable, with a one-line nudge in
+    its help text pointing users at `auth account` once they have more
+    than one agent. The fast path is one command for the common case;
+    the explicit verbs surface only when the user actually has multiple
+    accounts or agents to compose.
+
+## What this enables
+
+- The user adds six agents to one Anthropic account by running OAuth
+  once and editing six lines of YAML. Today this is six OAuth flows.
+- A user with two accounts (`work-pro`, `personal-max`) can fluidly
+  weight which agents prefer which, without re-authenticating anything.
+- Quota events on a shared account propagate in seconds. The first
+  agent's 429 is the last agent's 429, not the first of N independent
+  rediscoveries.
+- Sub-agents, Stop hooks, handoff summarizers, and cron-launched `claude
+  -p` work the same way the main agent does — they all read the same
+  refreshed credentials file. No subprocess-fork auth bugs.
+- An agent that has been quiet for a week is still authenticated when
+  the user pings it on Sunday morning. The broker kept its file fresh.
+- Adding a one-shot worker outside any agent's directory ("transcribe
+  this single voice memo using my account") is a broker query away. No
+  need to provision a fake agent.
+- The product can finally answer "what am I logged into?" with a list
+  the user recognises (their Anthropic accounts) instead of a tree of
+  per-agent slots they never created consciously.
+
+## UAT prompts
+
+Use these to evaluate whether an implementation truly delivers the job:
+
+- "Add a second agent that uses an Anthropic account you already have
+  set up. Did you have to do anything beyond editing `switchroom.yaml`
+  and running one CLI command?"
+- "Read the output of `switchroom auth account list`. Does it show your
+  accounts and which agents use each, on one screen?"
+- "Have one agent's main turn dispatch a sub-agent that itself spawns a
+  Stop-hook subprocess. Did all three pick up the same fresh token
+  without re-authenticating?"
+- "Run a cron-scheduled `claude -p` task in one of your agents'
+  directories. Did it succeed without 401, with no env-var fiddling?"
+- "Drive one Anthropic account to its 5-hour cap. Did every other agent
+  using that account fall over to its next preferred account within
+  seconds?"
+- "Stop `switchroom-auth-broker`. Do agents still respond for the next
+  hour as long as their existing tokens are valid? Restart it. Does it
+  resume refreshes without losing state?"
+- "Migrate from a per-agent-slot install. Did you have to re-`claude
+  setup-token` any account, or did the existing tokens carry over?"
+- "Try to remove an account that's still enabled on an agent. Did the
+  CLI refuse with a clear message naming the agents you'd need to
+  disable first?"
+
+## See also
+
+- [`keep-my-subscription-honest.md`](keep-my-subscription-honest.md) —
+  the parent JTBD this serves: subscription-as-the-ceiling. Account-as-
+  unit makes that promise tangible at the CLI.
+- [`track-plan-quota-live.md`](track-plan-quota-live.md) — quota
+  visibility benefits directly: account-level state means the chat-
+  surface quota signal can be stated in user terms ("your work-pro
+  account has 18 minutes left in the window") rather than per-slot.
+- [`run-a-fleet-of-specialists.md`](run-a-fleet-of-specialists.md) —
+  the multi-agent fleet promise; "one Pro subscription drives N
+  specialists" is what this design operationalises.
+- [`survive-reboots-and-real-life.md`](survive-reboots-and-real-life.md)
+  — the broker's "degraded, not catastrophic" failure mode is the
+  recovery story this job inherits.
+- [`docs/vault-broker.md`](../docs/vault-broker.md) — the existing
+  one-writer-many-readers daemon that the auth-broker is shaped after.

--- a/skills/switchroom-cli/SKILL.md
+++ b/skills/switchroom-cli/SKILL.md
@@ -155,6 +155,75 @@ Agent config resolves through `defaults → extends profile → agent-specific`,
 
 ---
 
+## Auth — "share my Pro account across agents", "auth verbs", "who's logged into what"
+
+Two layers coexist. **Use the new account model when an operator wants one OAuth flow to drive multiple agents.** The legacy per-agent slot model still works for first-time agent auth.
+
+### Per-agent (slot model) — first-time agent auth + the existing Telegram /auth flow
+
+```bash
+switchroom auth login <agent>          # interactive OAuth, writes to <agent>/.claude/.credentials.json
+switchroom auth status                 # one row per agent
+switchroom auth list <agent>           # show the agent's slot pool
+switchroom auth use <agent> <slot>     # switch the agent's active slot
+switchroom auth refresh-tick           # cron entrypoint for the legacy refresh loop
+```
+
+### Anthropic accounts (new model — see `reference/share-auth-across-the-fleet.md`)
+
+The Anthropic account is the unit of authentication. One account → many agents. Storage at `~/.switchroom/accounts/<label>/`. Per-agent `.credentials.json` becomes a passive mirror that the broker keeps in sync.
+
+```bash
+# Lift an already-authenticated agent's credentials into a global account
+switchroom auth account add <label> --from-agent <agent>
+
+# Or import from a credentials.json file you already have
+switchroom auth account add <label> --from-credentials <path>
+
+switchroom auth account list           # accounts + which agents use each + health
+switchroom auth account rm <label>     # refused while any agent is enabled
+
+# Wire an account to one or more agents (writes agents.<name>.auth.accounts in switchroom.yaml + immediate fanout)
+switchroom auth enable <label> <agent...>
+switchroom auth disable <label> <agent...>
+
+# Single account-refresh tick: refresh expiring tokens, fan out to enabled agents
+switchroom auth refresh-accounts [--json]
+```
+
+### Schema
+
+```yaml
+agents:
+  foo:
+    auth:
+      accounts: [work-pro, personal-max]   # ordered priority — first non-quota-exhausted wins
+```
+
+When unset, the agent uses the legacy per-agent slot path. The two are not mutually exclusive during the transition.
+
+### Telegram parity
+
+Every CLI verb above has a Telegram twin:
+
+```
+/auth account add <label> [--from-agent <name>]
+/auth account list
+/auth account rm <label>
+/auth enable <label> [agents...]    — defaults to the current agent
+/auth disable <label> [agents...]   — defaults to the current agent
+```
+
+`/auth login`, `/auth code`, `/auth list <agent>` etc. continue to work for the per-agent path.
+
+### When auth-related questions come in
+
+- "I want one Pro/Max subscription on multiple agents" → account model. Walk them through the bootstrap (`auth login` first agent → `auth account add --from-agent` → `auth enable` others).
+- "An agent's auth expired" → check `switchroom auth account list` first. If the account is healthy but the agent isn't getting it, the broker fanout may be stale — `switchroom auth refresh-accounts` forces a tick.
+- "I hit a quota" → `switchroom auth account list` shows quota-exhausted accounts; auto-fallback handles it if the agent has multiple accounts in priority order.
+
+---
+
 ## Scheduled tasks — "what cron runs", "show me the timers"
 
 List cron jobs and scheduled tasks.
@@ -194,7 +263,8 @@ Additional features:
 - **SQLite history** — enables quote-reply defaults
 - **PI-safe envelope** — inbound text wrapped in `<channel source="telegram">` for prompt-injection safety
 - **Inline approvals** — tool permissions surface as ✅/❌ buttons or via `/approve` `/deny` `/pending`
-- **Slash commands** — `/new`, `/reset`, `/approve`, `/deny`, `/pending`, `/restart`, `/update`, `/version`, `/logs`, `/doctor`, `/switchroomhelp` (see `TELEGRAM_MENU_COMMANDS` in `telegram-plugin/welcome-text.ts`)
+- **Slash commands** — `/new`, `/reset`, `/approve`, `/deny`, `/pending`, `/restart`, `/update`, `/version`, `/logs`, `/doctor`, `/auth`, `/switchroomhelp` (see `TELEGRAM_MENU_COMMANDS` in `telegram-plugin/welcome-text.ts`)
+- **`/auth`** — full auth surface inside Telegram: per-agent slot verbs (`login`/`reauth`/`code`/`add`/`use`/`list`/`rm`) AND account-shaped verbs (`account add`/`account list`/`account rm`/`enable`/`disable`). The account verbs implement the new "one Pro account, many agents" model — see the **Auth** section above.
 - **Access control** — `dmPolicy: pairing | allowlist | disabled` per agent
 
 ---

--- a/skills/switchroom-health/SKILL.md
+++ b/skills/switchroom-health/SKILL.md
@@ -23,8 +23,13 @@ Run these diagnostics with Bash:
 # Check switchroom CLI version
 switchroom --version 2>/dev/null || echo "FAIL: switchroom not found"
 
-# Check auth status
+# Check auth status (per-agent legacy view)
 switchroom auth status 2>/dev/null || echo "FAIL: auth check failed"
+
+# Check Anthropic accounts (new model — see reference/share-auth-across-the-fleet.md)
+# Shows accounts at ~/.switchroom/accounts/<label>/, which agents use each,
+# and per-account health (healthy / quota-exhausted / expired / missing-refresh-token).
+switchroom auth account list 2>/dev/null || echo "INFO: no Anthropic accounts configured (legacy per-agent slot model in use)"
 
 # Check systemd units
 systemctl --user list-units "switchroom-*" --no-pager 2>/dev/null || echo "no switchroom systemd units"
@@ -85,7 +90,9 @@ For common failures, give the exact fix:
 | Problem | Fix |
 |---------|-----|
 | `switchroom: command not found` | `npm install -g switchroom-ai` |
-| Auth expired | `switchroom auth login` |
+| Per-agent auth expired (slot model) | `switchroom auth login <agent>` |
+| Account expired (new model — `auth account list` shows red ✗) | `switchroom auth refresh-accounts` (one tick); if no refresh-token, the account needs re-adding |
+| Account quota-exhausted (yellow ⊘ in `auth account list`) | Auto-fallback handles it if the agent has multiple accounts; otherwise wait for the reset window or `switchroom auth enable <other-account> <agent>` |
 | Unit failed | `systemctl --user reset-failed switchroom-<name>`, then restart |
 | Missing .mcp.json | `switchroom update` (full reconcile + restart) or `switchroom agent reconcile <name>` (targeted) |
 | Bot token unresolved | Check vault: `switchroom vault list` |

--- a/skills/switchroom-install/SKILL.md
+++ b/skills/switchroom-install/SKILL.md
@@ -104,6 +104,10 @@ switchroom agent list
 
 If `switchroom doctor` reports healthy and at least one agent is listed, installation is complete. Offer to invoke the `switchroom-status` or `switchroom-health` skill for a deeper look.
 
+### Optional follow-up: share one Anthropic account across multiple agents
+
+Once the first agent is up and authenticated, the user can promote that agent's auth to a global Anthropic account so additional agents share the same Pro/Max subscription without each running its own OAuth flow. See `switchroom-manage` (Anthropic accounts section) for the bootstrap flow. This is the path most users want when they add a second agent — flag it as soon as they ask "how do I add another agent?".
+
 ## What not to do
 
 - **Do not** run `switchroom setup` non-interactively or pipe input to it — it's designed for a human.

--- a/skills/switchroom-manage/SKILL.md
+++ b/skills/switchroom-manage/SKILL.md
@@ -25,6 +25,8 @@ When the user invokes `/switchroom` or asks to add, create, remove, reinstall, r
 | `/switchroom memory <query> --agent <name>` | `switchroom memory search "<query>" --agent <name>` |
 | `/switchroom vault list` | `switchroom vault list` |
 | `/switchroom topics` | `switchroom topics list` |
+| `/switchroom accounts` or "list anthropic accounts" | `switchroom auth account list` |
+| "share my Pro subscription across agents" / "add an Anthropic account" | See **Anthropic accounts** below |
 
 ### Add / create a new agent
 
@@ -33,6 +35,34 @@ When the user says "add a new agent", "add an agent to my switchroom setup", or 
 ### Reinstall / reprovision agents
 
 "Reinstall my agents" is a fleet-level reprovisioning operation, **not** a fresh switchroom install. It means: pull the latest code, re-apply `switchroom.yaml`, and restart the agents. Run `switchroom update` for the full fleet. Ask the user to confirm before running if the scope is ambiguous.
+
+### Anthropic accounts (one OAuth, many agents)
+
+The new auth model treats the Anthropic account as the unit of authentication: one `claude setup-token` per account, then enable the account on however many agents you want. See `reference/share-auth-across-the-fleet.md` for the full design.
+
+**Bootstrap flow when the user wants to share one Pro/Max subscription across agents:**
+
+1. Make sure at least one agent is already authenticated the per-agent way (existing `switchroom auth login <agent>` flow). This gives you a valid `.credentials.json` to lift from.
+2. **Create the global account** by lifting the agent's credentials:
+   ```bash
+   switchroom auth account add work-pro --from-agent <existing-agent>
+   ```
+3. **Enable** the account on every agent that should share it:
+   ```bash
+   switchroom auth enable work-pro <agent-1> <agent-2> ...
+   ```
+   This appends to `agents.<name>.auth.accounts` in `switchroom.yaml` and immediately fans out the credentials to each agent's `.claude/credentials.json`.
+4. **Restart** the affected agents so claude picks up the new credentials.
+
+Verify with `switchroom auth account list` — shows accounts, which agents use each, health, and expiry. Account-level quota and refresh state replaces the per-agent view: when one account hits its 5-hour cap, every agent on it is failed over together.
+
+**Telegram parity** — the same flow works from inside a chat:
+
+```
+/auth login                          # current agent, existing slot flow
+/auth account add work-pro           # lifts current agent → global account
+/auth enable work-pro <other-agent>  # wires another agent to the same account
+```
 
 ## Behavior
 
@@ -47,7 +77,8 @@ Switchroom commands:
   /switchroom start <name>   Start an agent
   /switchroom stop <name>    Stop an agent
   /switchroom restart <name> Restart an agent (drain by default)
-  /switchroom status         Show auth status
+  /switchroom status         Show per-agent auth status
+  /switchroom accounts       List Anthropic accounts + which agents use each
   /switchroom memory <query> Search agent memory
   /switchroom vault list     List vault secrets
   /switchroom topics         List Telegram topics
@@ -55,4 +86,5 @@ Switchroom commands:
 Fleet operations (run directly, not via /switchroom <sub>):
   switchroom update          Pull latest + reconcile + restart everything
   switchroom version         Show versions + running agent health summary
+  switchroom auth refresh-accounts  Refresh OAuth tokens + fan out (cron entrypoint)
 ```

--- a/src/auth/account-refresh.ts
+++ b/src/auth/account-refresh.ts
@@ -1,0 +1,461 @@
+/**
+ * Account-level OAuth refresh + fanout to enabled agents.
+ *
+ * The account is the unit of authentication; this module is the loop
+ * that keeps each account's credentials fresh and pushes the result to
+ * every agent that has the account in its `auth.accounts` list.
+ *
+ * Design contract
+ * ---------------
+ * Pure side-effect function: read disk → conditionally hit Anthropic →
+ * atomically rewrite the global account credentials → fan out to enabled
+ * agents. Safe to call repeatedly. When nothing needs refreshing it's a
+ * no-op (no network, no writes).
+ *
+ * Atomicity
+ * ---------
+ * Every write goes through tempfile + rename in the same directory
+ * (rename(2) is atomic intra-fs). A crash mid-tick leaves the OLD file
+ * intact, never a half-written one.
+ *
+ * Concurrency
+ * -----------
+ * No locking between concurrent ticks. A racing tick that picks the
+ * same expiring account issues a duplicate POST; the loser's atomic
+ * rename clobbers the winner's. Result: one wasted refresh API call,
+ * a valid (live) token on disk. Adding a lockfile here would buy
+ * defence against a cost we're not paying.
+ *
+ * Relation to token-refresh.ts
+ * ----------------------------
+ * `src/auth/token-refresh.ts` refreshes the legacy per-agent
+ * `.credentials.json` files. This module refreshes the new
+ * `~/.switchroom/accounts/<label>/credentials.json` files and then
+ * mirrors them into each enabled agent's `.credentials.json`. Both
+ * coexist during the transition; an agent ends up with the same
+ * credentials.json shape on disk regardless of which path produced it.
+ */
+
+import { resolve } from "node:path";
+import { existsSync, mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from "node:fs";
+import { randomBytes } from "node:crypto";
+import { join } from "node:path";
+
+import { resolveAgentsDir } from "../config/loader.js";
+import type { SwitchroomConfig } from "../config/schema.js";
+import {
+  accountCredentialsPath,
+  listAccounts,
+  patchAccountMeta,
+  readAccountCredentials,
+  writeAccountCredentials,
+  type AccountCredentials,
+} from "./account-store.js";
+
+/**
+ * Refresh threshold — refresh when the account's access token has less
+ * than this remaining. Mirrors `src/auth/token-refresh.ts` so behaviour
+ * is consistent across the legacy + new paths.
+ */
+export const REFRESH_THRESHOLD_MS = 60 * 60 * 1000;
+
+const DEFAULT_TOKEN_URL =
+  process.env.SWITCHROOM_OAUTH_TOKEN_URL ??
+  "https://console.anthropic.com/v1/oauth/token";
+
+const DEFAULT_CLIENT_ID =
+  process.env.SWITCHROOM_OAUTH_CLIENT_ID ??
+  "9d1cd16e-bcb9-40c9-a915-196412f27aa6";
+
+interface AnthropicRefreshResponse {
+  access_token?: string;
+  refresh_token?: string;
+  /** seconds */
+  expires_in?: number;
+  token_type?: string;
+  scope?: string;
+}
+
+/** Outcome of a single account's refresh attempt. */
+export type AccountRefreshOutcome =
+  | { kind: "skipped-no-credentials"; account: string }
+  | { kind: "skipped-malformed"; account: string; reason: string }
+  | { kind: "skipped-fresh"; account: string; expiresAt: number; remainingMs: number }
+  | { kind: "skipped-no-refresh-token"; account: string; expiresAt?: number }
+  | { kind: "refreshed"; account: string; oldExpiresAt?: number; newExpiresAt: number }
+  | { kind: "failed"; account: string; httpStatus?: number; error: string };
+
+/** Outcome of a single fanout attempt to one agent. */
+export type FanoutOutcome =
+  | { kind: "fanned-out"; account: string; agent: string }
+  | { kind: "fanout-skipped-no-agent-dir"; account: string; agent: string }
+  | { kind: "fanout-failed"; account: string; agent: string; error: string };
+
+export interface AccountTickSummary {
+  startedAt: number;
+  finishedAt: number;
+  refreshes: AccountRefreshOutcome[];
+  fanouts: FanoutOutcome[];
+  counts: {
+    refreshed: number;
+    skippedFresh: number;
+    skippedNoRefreshToken: number;
+    failedRefresh: number;
+    fannedOut: number;
+    failedFanout: number;
+  };
+}
+
+/** Hook for unit tests to swap the HTTP layer. */
+export type Fetcher = (
+  url: string,
+  init: { method: string; headers: Record<string, string>; body: string },
+) => Promise<{ ok: boolean; status: number; text: () => Promise<string> }>;
+
+const defaultFetcher: Fetcher = async (url, init) => {
+  const res = await fetch(url, {
+    method: init.method,
+    headers: init.headers,
+    body: init.body,
+  });
+  return { ok: res.ok, status: res.status, text: () => res.text() };
+};
+
+export interface AccountRefreshOptions {
+  /** Threshold below which we refresh. Default REFRESH_THRESHOLD_MS. */
+  thresholdMs?: number;
+  now?: () => number;
+  tokenUrl?: string;
+  clientId?: string;
+  fetcher?: Fetcher;
+  /** Override homedir() for tests. */
+  home?: string;
+}
+
+/* ── Atomic write helper (file content, JSON or text) ────────────────── */
+
+function atomicWriteText(destPath: string, value: string, mode = 0o600): void {
+  const tmp = `${destPath}.tmp-${process.pid}-${randomBytes(4).toString("hex")}`;
+  try {
+    writeFileSync(tmp, value, { mode });
+    renameSync(tmp, destPath);
+  } catch (err) {
+    try {
+      rmSync(tmp, { force: true });
+    } catch {
+      /* already gone */
+    }
+    throw err;
+  }
+}
+
+/* ── Single-account refresh ──────────────────────────────────────────── */
+
+/**
+ * If the account's access token is expiring soon AND a refreshToken is
+ * present, exchange it via Anthropic OAuth and atomically persist the
+ * new credentials. Returns a structured outcome — never throws on the
+ * network failure path.
+ */
+export async function refreshAccountIfNeeded(
+  label: string,
+  opts: AccountRefreshOptions = {},
+): Promise<AccountRefreshOutcome> {
+  const thresholdMs = opts.thresholdMs ?? REFRESH_THRESHOLD_MS;
+  const now = opts.now ?? Date.now;
+  const tokenUrl = opts.tokenUrl ?? DEFAULT_TOKEN_URL;
+  const clientId = opts.clientId ?? DEFAULT_CLIENT_ID;
+  const fetcher = opts.fetcher ?? defaultFetcher;
+  const home = opts.home;
+
+  const creds = readAccountCredentials(label, home);
+  if (!creds) {
+    return { kind: "skipped-no-credentials", account: label };
+  }
+  const oauth = creds.claudeAiOauth;
+  if (
+    !oauth ||
+    typeof oauth.accessToken !== "string" ||
+    oauth.accessToken.length === 0
+  ) {
+    return {
+      kind: "skipped-malformed",
+      account: label,
+      reason: "credentials present but missing claudeAiOauth.accessToken",
+    };
+  }
+  const expiresAt = oauth.expiresAt;
+  if (typeof expiresAt !== "number" || !Number.isFinite(expiresAt)) {
+    return {
+      kind: "skipped-malformed",
+      account: label,
+      reason: "credentials have invalid expiresAt",
+    };
+  }
+
+  const remainingMs = expiresAt - now();
+  if (remainingMs > thresholdMs) {
+    return { kind: "skipped-fresh", account: label, expiresAt, remainingMs };
+  }
+
+  if (!oauth.refreshToken || oauth.refreshToken.length === 0) {
+    return { kind: "skipped-no-refresh-token", account: label, expiresAt };
+  }
+
+  const body = JSON.stringify({
+    grant_type: "refresh_token",
+    refresh_token: oauth.refreshToken,
+    client_id: clientId,
+  });
+
+  let res: { ok: boolean; status: number; text: () => Promise<string> };
+  try {
+    res = await fetcher(tokenUrl, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json",
+      },
+      body,
+    });
+  } catch (err) {
+    return {
+      kind: "failed",
+      account: label,
+      error: `network error: ${(err as Error).message}`,
+    };
+  }
+
+  if (!res.ok) {
+    let bodyText = "";
+    try {
+      bodyText = (await res.text()).slice(0, 500);
+    } catch {
+      /* ignore */
+    }
+    return {
+      kind: "failed",
+      account: label,
+      httpStatus: res.status,
+      error: `HTTP ${res.status}${bodyText ? `: ${bodyText}` : ""}`,
+    };
+  }
+
+  let parsed: AnthropicRefreshResponse;
+  try {
+    parsed = JSON.parse(await res.text()) as AnthropicRefreshResponse;
+  } catch (err) {
+    return {
+      kind: "failed",
+      account: label,
+      httpStatus: res.status,
+      error: `unparseable response: ${(err as Error).message}`,
+    };
+  }
+
+  const newAccessToken = parsed.access_token;
+  if (typeof newAccessToken !== "string" || newAccessToken.length === 0) {
+    return {
+      kind: "failed",
+      account: label,
+      httpStatus: res.status,
+      error: "refresh response missing access_token",
+    };
+  }
+
+  const newExpiresAt =
+    typeof parsed.expires_in === "number" && Number.isFinite(parsed.expires_in)
+      ? now() + parsed.expires_in * 1000
+      : now() + 8 * 60 * 60 * 1000; // sensible default
+  const newRefreshToken =
+    typeof parsed.refresh_token === "string" && parsed.refresh_token.length > 0
+      ? parsed.refresh_token
+      : oauth.refreshToken; // some providers don't rotate
+
+  const updated: AccountCredentials = {
+    ...creds,
+    claudeAiOauth: {
+      ...oauth,
+      accessToken: newAccessToken,
+      refreshToken: newRefreshToken,
+      expiresAt: newExpiresAt,
+    },
+  };
+  try {
+    writeAccountCredentials(label, updated, home);
+  } catch (err) {
+    return {
+      kind: "failed",
+      account: label,
+      error: `failed to write credentials.json: ${(err as Error).message}`,
+    };
+  }
+  patchAccountMeta(label, { lastRefreshedAt: now() }, home);
+
+  return {
+    kind: "refreshed",
+    account: label,
+    oldExpiresAt: expiresAt,
+    newExpiresAt,
+  };
+}
+
+/* ── Fanout ──────────────────────────────────────────────────────────── */
+
+/**
+ * Copy the account's credentials.json into each agent's `.claude/`
+ * directory atomically. Idempotent: writing identical bytes is fine,
+ * the point is the agent dir always sees the most recent token.
+ *
+ * Also writes the legacy `.oauth-token` + `.oauth-token.meta.json`
+ * mirrors that the existing `start.sh` reads to inject
+ * `CLAUDE_CODE_OAUTH_TOKEN` into the parent claude process. This keeps
+ * the parent and its subprocesses on the SAME token even while the old
+ * slot-pool code path remains in place — without it, the parent would
+ * use the slot's stale env-var token while subprocesses fall back to
+ * the account's new credentials.json. The legacy mirror is removed in
+ * the follow-up PR that drops the env-var path entirely.
+ */
+export function fanoutAccountToAgents(
+  account: string,
+  agents: Array<{ name: string; agentDir: string }>,
+  opts: { home?: string } = {},
+): FanoutOutcome[] {
+  const credsPath = accountCredentialsPath(account, opts.home);
+  if (!existsSync(credsPath)) {
+    return agents.map((a) => ({
+      kind: "fanout-failed",
+      account,
+      agent: a.name,
+      error: `no credentials at ${credsPath}`,
+    }));
+  }
+  const content = readFileSync(credsPath, "utf-8");
+  let parsed: { claudeAiOauth?: { accessToken?: string; expiresAt?: number } };
+  try {
+    parsed = JSON.parse(content);
+  } catch {
+    return agents.map((a) => ({
+      kind: "fanout-failed",
+      account,
+      agent: a.name,
+      error: `account credentials are not valid JSON`,
+    }));
+  }
+  const accessToken = parsed.claudeAiOauth?.accessToken;
+  const expiresAt = parsed.claudeAiOauth?.expiresAt;
+
+  return agents.map((a): FanoutOutcome => {
+    if (!existsSync(a.agentDir)) {
+      return {
+        kind: "fanout-skipped-no-agent-dir",
+        account,
+        agent: a.name,
+      };
+    }
+    const claudeDir = join(a.agentDir, ".claude");
+    try {
+      mkdirSync(claudeDir, { recursive: true });
+      atomicWriteText(join(claudeDir, "credentials.json"), content);
+      // Mirror to the legacy paths the existing start.sh reads. Skip if
+      // accessToken is missing — better to leave the old mirror alone
+      // than to clobber it with garbage.
+      if (typeof accessToken === "string" && accessToken.length > 0) {
+        atomicWriteText(join(claudeDir, ".oauth-token"), accessToken + "\n");
+        atomicWriteText(
+          join(claudeDir, ".oauth-token.meta.json"),
+          JSON.stringify(
+            {
+              createdAt: Date.now(),
+              expiresAt: expiresAt ?? Date.now() + 8 * 60 * 60 * 1000,
+              source: `account:${account}`,
+            },
+            null,
+            2,
+          ) + "\n",
+        );
+      }
+      return { kind: "fanned-out", account, agent: a.name };
+    } catch (err) {
+      return {
+        kind: "fanout-failed",
+        account,
+        agent: a.name,
+        error: (err as Error).message,
+      };
+    }
+  });
+}
+
+/* ── Whole-tick: refresh every account, fan out to enabled agents ────── */
+
+/**
+ * Build the per-account agent list from a loaded config: an account's
+ * "enabled agents" are those whose `auth.accounts` list contains the
+ * account label.
+ */
+export function enabledAgentsForAccount(
+  account: string,
+  config: SwitchroomConfig,
+  agentsDir: string,
+): Array<{ name: string; agentDir: string }> {
+  const out: Array<{ name: string; agentDir: string }> = [];
+  for (const [name, agent] of Object.entries(config.agents)) {
+    const accounts = agent.auth?.accounts ?? [];
+    if (accounts.includes(account)) {
+      out.push({ name, agentDir: resolve(agentsDir, name) });
+    }
+  }
+  return out;
+}
+
+export async function refreshAllAccounts(
+  config: SwitchroomConfig,
+  opts: AccountRefreshOptions = {},
+): Promise<AccountTickSummary> {
+  const startedAt = Date.now();
+  const home = opts.home;
+  const agentsDir = resolveAgentsDir(config);
+
+  const refreshes: AccountRefreshOutcome[] = [];
+  const fanouts: FanoutOutcome[] = [];
+
+  for (const label of listAccounts(home)) {
+    let outcome: AccountRefreshOutcome;
+    try {
+      outcome = await refreshAccountIfNeeded(label, opts);
+    } catch (err) {
+      outcome = {
+        kind: "failed",
+        account: label,
+        error: `unexpected exception: ${(err as Error).message}`,
+      };
+    }
+    refreshes.push(outcome);
+
+    // Fanout always runs (even if refresh was skipped-fresh) so a newly
+    // enabled agent picks up an existing fresh credential without waiting
+    // for the next actual refresh.
+    const targets = enabledAgentsForAccount(label, config, agentsDir);
+    fanouts.push(...fanoutAccountToAgents(label, targets, { home }));
+  }
+
+  const counts = {
+    refreshed: refreshes.filter((o) => o.kind === "refreshed").length,
+    skippedFresh: refreshes.filter((o) => o.kind === "skipped-fresh").length,
+    skippedNoRefreshToken: refreshes.filter(
+      (o) => o.kind === "skipped-no-refresh-token",
+    ).length,
+    failedRefresh: refreshes.filter((o) => o.kind === "failed").length,
+    fannedOut: fanouts.filter((o) => o.kind === "fanned-out").length,
+    failedFanout: fanouts.filter((o) => o.kind === "fanout-failed").length,
+  };
+
+  return {
+    startedAt,
+    finishedAt: Date.now(),
+    refreshes,
+    fanouts,
+    counts,
+  };
+}

--- a/src/auth/account-store.ts
+++ b/src/auth/account-store.ts
@@ -1,0 +1,309 @@
+/**
+ * Global Anthropic-account credential store.
+ *
+ * The account is the unit of authentication (one Anthropic Pro/Max
+ * subscription = one account here). Agents are consumers that point at
+ * accounts via `agents.<name>.auth.accounts` in switchroom.yaml.
+ *
+ * Storage layout:
+ *
+ *   ~/.switchroom/accounts/
+ *     <label>/
+ *       credentials.json   ← canonical OAuth state for this account
+ *       meta.json          ← refresh state, quota state, identity
+ *
+ * `credentials.json` is the same shape as Claude Code's own
+ * `~/.claude/.credentials.json` so that an agent's per-agent mirror
+ * (kept in sync by switchroom-auth-broker) is bit-identical to what
+ * Claude Code expects.
+ *
+ * The only writer to these files is `switchroom-auth-broker`, except
+ * during the initial `switchroom auth account add` flow which writes the
+ * seed credentials. Per-agent mirrors live at `<agentDir>/.claude/
+ * .credentials.json` and are also broker-owned (see scaffold.ts).
+ *
+ * This module is a passive storage layer: validation, paths, atomic
+ * read/write. The lifecycle (refresh, fanout, fallback) lives in
+ * `src/auth/broker/` and `src/auth/refresh.ts`.
+ */
+
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  renameSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { randomBytes } from "node:crypto";
+import { homedir } from "node:os";
+import { join, resolve } from "node:path";
+
+const LABEL_MAX = 64;
+const LABEL_RE = /^[A-Za-z0-9._-]+$/;
+
+/** Subset of Claude Code's credentials.json shape we read + rewrite. */
+export interface AccountCredentials {
+  claudeAiOauth?: {
+    accessToken?: string;
+    refreshToken?: string;
+    /** Unix ms */
+    expiresAt?: number;
+    scopes?: string[];
+    subscriptionType?: string;
+    rateLimitTier?: string;
+  };
+}
+
+/** Per-account state owned by the broker (refresh, quota, identity hint). */
+export interface AccountMeta {
+  /** Unix ms when the account was first added. */
+  createdAt: number;
+  /** Optional human label for display ("ken@example.com"); inferred when known. */
+  email?: string;
+  /** Subscription identifier from Anthropic ("pro" / "max"); cached from credentials. */
+  subscriptionType?: string;
+  /** Unix ms — when set and in the future, the account is quota-exhausted. */
+  quotaExhaustedUntil?: number;
+  /** Free-form note about the last quota event. */
+  quotaReason?: string;
+  /** Unix ms of the last successful refresh tick. */
+  lastRefreshedAt?: number;
+}
+
+/** Health derived from credentials + meta. */
+export type AccountHealth =
+  | "healthy"
+  | "quota-exhausted"
+  | "expired"
+  | "missing-credentials"
+  | "missing-refresh-token";
+
+export interface AccountInfo {
+  label: string;
+  health: AccountHealth;
+  /** Unix ms — token expiry (from credentials). */
+  expiresAt?: number;
+  /** Unix ms — quota reset (from meta). */
+  quotaExhaustedUntil?: number;
+  /** Unix ms — last refresh (from meta). */
+  lastRefreshedAt?: number;
+  email?: string;
+  subscriptionType?: string;
+}
+
+/* ── Paths ───────────────────────────────────────────────────────────── */
+
+/** `~/.switchroom/accounts/`. */
+export function accountsRoot(home: string = homedir()): string {
+  return resolve(home, ".switchroom", "accounts");
+}
+
+export function accountDir(label: string, home: string = homedir()): string {
+  return join(accountsRoot(home), label);
+}
+
+export function accountCredentialsPath(
+  label: string,
+  home: string = homedir(),
+): string {
+  return join(accountDir(label, home), "credentials.json");
+}
+
+export function accountMetaPath(
+  label: string,
+  home: string = homedir(),
+): string {
+  return join(accountDir(label, home), "meta.json");
+}
+
+/* ── Label validation ────────────────────────────────────────────────── */
+
+export function validateAccountLabel(label: string): void {
+  if (typeof label !== "string" || label.length === 0) {
+    throw new Error("Account label cannot be empty");
+  }
+  if (label.length > LABEL_MAX) {
+    throw new Error(`Account label too long (max ${LABEL_MAX} chars)`);
+  }
+  if (label === "." || label === "..") {
+    throw new Error(`Account label "${label}" is reserved`);
+  }
+  if (label.includes("/") || label.includes("\\")) {
+    throw new Error("Account label cannot contain path separators");
+  }
+  if (!LABEL_RE.test(label)) {
+    throw new Error(
+      "Account label must match [A-Za-z0-9._-]+ (letters, digits, dot, underscore, dash)",
+    );
+  }
+}
+
+/* ── Listing ─────────────────────────────────────────────────────────── */
+
+export function listAccounts(home: string = homedir()): string[] {
+  const root = accountsRoot(home);
+  if (!existsSync(root)) return [];
+  try {
+    return readdirSync(root)
+      .filter((name) => {
+        try {
+          return statSync(join(root, name)).isDirectory();
+        } catch {
+          return false;
+        }
+      })
+      .sort();
+  } catch {
+    return [];
+  }
+}
+
+export function accountExists(
+  label: string,
+  home: string = homedir(),
+): boolean {
+  return existsSync(accountCredentialsPath(label, home));
+}
+
+/* ── Credentials read/write ──────────────────────────────────────────── */
+
+export function readAccountCredentials(
+  label: string,
+  home: string = homedir(),
+): AccountCredentials | null {
+  const p = accountCredentialsPath(label, home);
+  if (!existsSync(p)) return null;
+  try {
+    return JSON.parse(readFileSync(p, "utf-8")) as AccountCredentials;
+  } catch {
+    return null;
+  }
+}
+
+export function writeAccountCredentials(
+  label: string,
+  value: AccountCredentials,
+  home: string = homedir(),
+): void {
+  validateAccountLabel(label);
+  mkdirSync(accountDir(label, home), { recursive: true });
+  atomicWriteJson(accountCredentialsPath(label, home), value);
+}
+
+/* ── Meta read/write ─────────────────────────────────────────────────── */
+
+export function readAccountMeta(
+  label: string,
+  home: string = homedir(),
+): AccountMeta | null {
+  const p = accountMetaPath(label, home);
+  if (!existsSync(p)) return null;
+  try {
+    return JSON.parse(readFileSync(p, "utf-8")) as AccountMeta;
+  } catch {
+    return null;
+  }
+}
+
+export function writeAccountMeta(
+  label: string,
+  value: AccountMeta,
+  home: string = homedir(),
+): void {
+  validateAccountLabel(label);
+  mkdirSync(accountDir(label, home), { recursive: true });
+  atomicWriteJson(accountMetaPath(label, home), value);
+}
+
+/** Update a single meta field, preserving the rest. Creates if absent. */
+export function patchAccountMeta(
+  label: string,
+  patch: Partial<AccountMeta>,
+  home: string = homedir(),
+): AccountMeta {
+  const existing = readAccountMeta(label, home) ?? { createdAt: Date.now() };
+  const merged: AccountMeta = { ...existing, ...patch };
+  writeAccountMeta(label, merged, home);
+  return merged;
+}
+
+/* ── Health ──────────────────────────────────────────────────────────── */
+
+export function accountHealth(
+  label: string,
+  now: number = Date.now(),
+  home: string = homedir(),
+): AccountHealth {
+  const creds = readAccountCredentials(label, home);
+  if (!creds?.claudeAiOauth?.accessToken) return "missing-credentials";
+  const meta = readAccountMeta(label, home);
+  if (
+    meta?.quotaExhaustedUntil != null &&
+    meta.quotaExhaustedUntil > now
+  ) {
+    return "quota-exhausted";
+  }
+  const expiresAt = creds.claudeAiOauth.expiresAt;
+  if (typeof expiresAt === "number" && expiresAt <= now) {
+    if (!creds.claudeAiOauth.refreshToken) return "missing-refresh-token";
+    return "expired";
+  }
+  return "healthy";
+}
+
+export function getAccountInfos(
+  now: number = Date.now(),
+  home: string = homedir(),
+): AccountInfo[] {
+  return listAccounts(home).map((label) => {
+    const creds = readAccountCredentials(label, home);
+    const meta = readAccountMeta(label, home);
+    return {
+      label,
+      health: accountHealth(label, now, home),
+      expiresAt: creds?.claudeAiOauth?.expiresAt,
+      quotaExhaustedUntil: meta?.quotaExhaustedUntil,
+      lastRefreshedAt: meta?.lastRefreshedAt,
+      email: meta?.email,
+      subscriptionType:
+        meta?.subscriptionType ?? creds?.claudeAiOauth?.subscriptionType,
+    };
+  });
+}
+
+/* ── Removal ─────────────────────────────────────────────────────────── */
+
+/** Remove an account. The caller is responsible for refusing when agents are still enabled. */
+export function removeAccount(label: string, home: string = homedir()): void {
+  validateAccountLabel(label);
+  if (!accountExists(label, home)) {
+    throw new Error(`Account "${label}" does not exist`);
+  }
+  rmSync(accountDir(label, home), { recursive: true, force: true });
+}
+
+/* ── Atomic write helper ─────────────────────────────────────────────── */
+
+/**
+ * Write a JSON value atomically: tempfile in the same directory + rename.
+ * Same-directory rename keeps it on a single filesystem (rename(2) is
+ * only atomic intra-fs). Cleans the tempfile on failure so a crash
+ * mid-write doesn't leave a sibling turd.
+ */
+function atomicWriteJson(destPath: string, value: unknown, mode = 0o600): void {
+  const tmp = `${destPath}.tmp-${process.pid}-${randomBytes(4).toString("hex")}`;
+  try {
+    writeFileSync(tmp, JSON.stringify(value, null, 2) + "\n", { mode });
+    renameSync(tmp, destPath);
+  } catch (err) {
+    try {
+      rmSync(tmp, { force: true });
+    } catch {
+      /* already gone */
+    }
+    throw err;
+  }
+}

--- a/src/auth/accounts.ts
+++ b/src/auth/accounts.ts
@@ -45,6 +45,16 @@ export interface SlotMeta {
   quotaExhaustedUntil?: number;
   /** Free-form note about the last quota event. */
   quotaReason?: string;
+  /**
+   * Human-readable account identifier (e.g. "ken@example.com") for
+   * operator display. Anthropic doesn't expose a profile endpoint, so
+   * this is set explicitly via `setSlotLabel` and survives reauths.
+   * Bridges to the new global-account model in
+   * `reference/share-auth-across-the-fleet.md`: a label of "work-pro"
+   * here matches up with the global account at
+   * `~/.switchroom/accounts/work-pro/`.
+   */
+  accountLabel?: string;
 }
 
 export type SlotHealth =
@@ -60,6 +70,8 @@ export interface SlotInfo {
   health: SlotHealth;
   expiresAt?: number;
   quotaExhaustedUntil?: number;
+  /** Human-readable account identifier set via `setSlotLabel`. */
+  accountLabel?: string;
 }
 
 /* ── Path helpers ────────────────────────────────────────────────────── */
@@ -194,7 +206,12 @@ export function readSlotToken(agentDir: string, slot: string): string | null {
   }
 }
 
-/** Write a token + fresh meta into a slot. */
+/** Write a token + fresh meta into a slot.
+ *
+ * Preserves any pre-existing `accountLabel` on the slot — labels are
+ * operator-set and shouldn't be silently dropped on reauth (the new
+ * token is for the same human-identified account).
+ */
 export function writeSlotToken(
   agentDir: string,
   slot: string,
@@ -209,21 +226,46 @@ export function writeSlotToken(
   const now = Date.now();
   const expiresAt = opts.expiresAtMs ?? now + 365 * 24 * 60 * 60_000;
 
+  // Carry the operator-set accountLabel across the rewrite if present.
+  const existingLabel = readSlotMeta(agentDir, slot)?.accountLabel;
+
   writeFileSync(tokenPath, token.trim() + "\n", { mode: 0o600 });
-  writeFileSync(
-    metaPath,
-    JSON.stringify(
-      {
-        createdAt: now,
-        expiresAt,
-        source: opts.source ?? "claude-setup-token",
-      } satisfies SlotMeta,
-      null,
-      2,
-    ) + "\n",
-    { mode: 0o600 },
-  );
+  const meta: SlotMeta = {
+    createdAt: now,
+    expiresAt,
+    source: opts.source ?? "claude-setup-token",
+    ...(existingLabel ? { accountLabel: existingLabel } : {}),
+  };
+  writeFileSync(metaPath, JSON.stringify(meta, null, 2) + "\n", { mode: 0o600 });
   return { tokenPath, metaPath };
+}
+
+/**
+ * Attach (or clear) a human-readable label on a slot.
+ *
+ * Trims whitespace; an empty / whitespace-only / undefined value clears
+ * the label. Creates a placeholder meta with `source: "unknown"` if no
+ * meta exists yet, so an operator can label a slot before it has a
+ * token (e.g. when planning the slot pool).
+ */
+export function setSlotLabel(
+  agentDir: string,
+  slot: string,
+  label: string | undefined,
+): void {
+  validateSlotName(slot);
+  const trimmed = typeof label === "string" ? label.trim() : "";
+  const meta = readSlotMeta(agentDir, slot) ?? {
+    createdAt: Date.now(),
+    expiresAt: Date.now() + 365 * 24 * 60 * 60_000,
+    source: "unknown",
+  };
+  if (trimmed.length > 0) {
+    meta.accountLabel = trimmed;
+  } else {
+    delete meta.accountLabel;
+  }
+  writeSlotMeta(agentDir, slot, meta);
 }
 
 /* ── Legacy mirror ───────────────────────────────────────────────────── */
@@ -388,6 +430,7 @@ export function getSlotInfos(
       health,
       expiresAt: meta?.expiresAt,
       quotaExhaustedUntil: meta?.quotaExhaustedUntil,
+      accountLabel: meta?.accountLabel,
     };
   });
 }

--- a/src/build-info.ts
+++ b/src/build-info.ts
@@ -3,7 +3,7 @@
 // Values are refreshed every time `npm run build` runs.
 
 export const VERSION: string = "0.4.0";
-export const COMMIT_SHA: string | null = "ed242fd";
-export const COMMIT_DATE: string | null = "2026-05-03T11:19:55+10:00";
-export const LATEST_PR: number | null = 619;
-export const COMMITS_AHEAD_OF_TAG: number | null = 168;
+export const COMMIT_SHA: string | null = "1e0372c";
+export const COMMIT_DATE: string | null = "2026-05-03T12:21:39+10:00";
+export const LATEST_PR: number | null = null;
+export const COMMITS_AHEAD_OF_TAG: number | null = 172;

--- a/src/build-info.ts
+++ b/src/build-info.ts
@@ -3,7 +3,7 @@
 // Values are refreshed every time `npm run build` runs.
 
 export const VERSION: string = "0.4.0";
-export const COMMIT_SHA: string | null = "5bed5b7";
-export const COMMIT_DATE: string | null = "2026-05-03T04:34:27+10:00";
-export const LATEST_PR: number | null = 599;
-export const COMMITS_AHEAD_OF_TAG: number | null = 149;
+export const COMMIT_SHA: string | null = "ed242fd";
+export const COMMIT_DATE: string | null = "2026-05-03T11:19:55+10:00";
+export const LATEST_PR: number | null = 619;
+export const COMMITS_AHEAD_OF_TAG: number | null = 168;

--- a/src/cli/auth-accounts-yaml.ts
+++ b/src/cli/auth-accounts-yaml.ts
@@ -1,0 +1,113 @@
+/**
+ * YAML editor for `switchroom auth enable/disable`.
+ *
+ * Edits `agents.<agentName>.auth.accounts: [labels...]` while preserving
+ * comments and formatting elsewhere in the file. Mirrors the pattern in
+ * `telegram-yaml.ts` — pure module, string-in / string-out.
+ */
+
+import { parseDocument, type Document, isMap, isSeq, type YAMLMap, type YAMLSeq } from "yaml";
+
+/**
+ * Append an account label to `agents.<agent>.auth.accounts`. Idempotent —
+ * appending an already-present label returns the YAML unchanged. Creates
+ * intermediate maps + the array if absent.
+ *
+ * Throws if the agent is not declared in switchroom.yaml — operators
+ * should see "agent X not declared" rather than have us silently create
+ * one that wouldn't otherwise scaffold.
+ */
+export function appendAccountToAgent(
+  yamlText: string,
+  agentName: string,
+  label: string,
+): string {
+  const doc = parseDocument(yamlText);
+  ensureAgent(doc, agentName);
+  const existing = doc.getIn(["agents", agentName, "auth", "accounts"]);
+  if (isSeq(existing)) {
+    const seq = existing as YAMLSeq;
+    for (const item of seq.items) {
+      const v = (item as { value?: unknown }).value ?? item;
+      if (v === label) return yamlText; // idempotent
+    }
+    seq.add(label);
+  } else {
+    doc.setIn(["agents", agentName, "auth", "accounts"], [label]);
+  }
+  return String(doc);
+}
+
+/**
+ * Remove an account label from `agents.<agent>.auth.accounts`. No-op if
+ * the label is not present. When the array becomes empty, the parent
+ * `auth.accounts` entry is dropped (and empty parent maps pruned) so the
+ * YAML doesn't accumulate `auth: {}` debris.
+ *
+ * Returns the new YAML string. Caller is responsible for refusing the
+ * operation when it would leave the agent with no accounts (the broker
+ * needs at least one account per agent to do anything).
+ */
+export function removeAccountFromAgent(
+  yamlText: string,
+  agentName: string,
+  label: string,
+): string {
+  const doc = parseDocument(yamlText);
+  if (!hasAgent(doc, agentName)) return yamlText;
+  const existing = doc.getIn(["agents", agentName, "auth", "accounts"]);
+  if (!isSeq(existing)) return yamlText;
+  const seq = existing as YAMLSeq;
+  const beforeLen = seq.items.length;
+  for (let i = seq.items.length - 1; i >= 0; i--) {
+    const item = seq.items[i];
+    const v = (item as { value?: unknown })?.value ?? item;
+    if (v === label) seq.delete(i);
+  }
+  if (seq.items.length === beforeLen) return yamlText; // no change
+  if (seq.items.length === 0) {
+    doc.deleteIn(["agents", agentName, "auth", "accounts"]);
+    pruneEmptyMap(doc, ["agents", agentName, "auth"]);
+  }
+  return String(doc);
+}
+
+/**
+ * Read the current `agents.<agent>.auth.accounts` list without mutating.
+ * Returns [] if absent or shape-mismatched. Useful for the `list` verb +
+ * the rm-refusal logic.
+ */
+export function getAccountsForAgent(
+  yamlText: string,
+  agentName: string,
+): string[] {
+  const doc = parseDocument(yamlText);
+  if (!hasAgent(doc, agentName)) return [];
+  const existing = doc.getIn(["agents", agentName, "auth", "accounts"]);
+  if (!isSeq(existing)) return [];
+  const seq = existing as YAMLSeq;
+  return seq.items
+    .map((item) => (item as { value?: unknown }).value ?? item)
+    .filter((v): v is string => typeof v === "string");
+}
+
+function ensureAgent(doc: Document, agentName: string): void {
+  if (!hasAgent(doc, agentName)) {
+    throw new Error(
+      `agent '${agentName}' is not declared in switchroom.yaml under 'agents:'. Add it first via 'switchroom agent create' or hand-edit the file.`,
+    );
+  }
+}
+
+function hasAgent(doc: Document, agentName: string): boolean {
+  const agents = doc.get("agents");
+  if (!isMap(agents)) return false;
+  return (agents as YAMLMap).has(agentName);
+}
+
+function pruneEmptyMap(doc: Document, path: string[]): void {
+  const node = doc.getIn(path);
+  if (isMap(node) && (node as YAMLMap).items.length === 0) {
+    doc.deleteIn(path);
+  }
+}

--- a/src/cli/auth-accounts.ts
+++ b/src/cli/auth-accounts.ts
@@ -1,0 +1,504 @@
+/**
+ * `switchroom auth account` + `switchroom auth enable/disable` verbs.
+ *
+ * The account-level CLI surface for the new auth model. See
+ * `reference/share-auth-across-the-fleet.md` for the design.
+ *
+ *   switchroom auth account add <label> --from-agent <name>
+ *   switchroom auth account add <label> --from-credentials <path>
+ *   switchroom auth account list
+ *   switchroom auth account rm <label>
+ *   switchroom auth enable <label> <agent...>
+ *   switchroom auth disable <label> <agent...>
+ *   switchroom auth refresh-accounts
+ */
+
+import type { Command } from "commander";
+import chalk from "chalk";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { resolveAgentsDir } from "../config/loader.js";
+import {
+  accountDir,
+  accountExists,
+  accountsRoot,
+  getAccountInfos,
+  listAccounts,
+  patchAccountMeta,
+  removeAccount,
+  validateAccountLabel,
+  writeAccountCredentials,
+  type AccountCredentials,
+} from "../auth/account-store.js";
+import {
+  fanoutAccountToAgents,
+  refreshAllAccounts,
+} from "../auth/account-refresh.js";
+import {
+  appendAccountToAgent,
+  getAccountsForAgent,
+  removeAccountFromAgent,
+} from "./auth-accounts-yaml.js";
+import { withConfigError, getConfig, getConfigPath } from "./helpers.js";
+
+/* ── Public registration ─────────────────────────────────────────────── */
+
+export function registerAuthAccountSubcommands(
+  program: Command,
+  authParent: Command,
+): void {
+  const account = authParent
+    .command("account")
+    .description(
+      "Manage Anthropic accounts shared across agents (see reference/share-auth-across-the-fleet.md)",
+    );
+
+  registerAccountAdd(account, program);
+  registerAccountList(account, program);
+  registerAccountRm(account, program);
+
+  registerEnable(authParent, program);
+  registerDisable(authParent, program);
+  registerRefreshAccounts(authParent, program);
+}
+
+/* ── account add ─────────────────────────────────────────────────────── */
+
+function registerAccountAdd(account: Command, program: Command): void {
+  account
+    .command("add <label>")
+    .description(
+      "Register an Anthropic account at ~/.switchroom/accounts/<label>/. " +
+        "Use --from-agent to seed from an agent that's already authenticated, " +
+        "or --from-credentials to import a credentials.json file.",
+    )
+    .option(
+      "--from-agent <name>",
+      "Seed credentials from an existing agent's .credentials.json",
+    )
+    .option(
+      "--from-credentials <path>",
+      "Seed credentials from a JSON file at the given path",
+    )
+    .action(
+      withConfigError(
+        async (
+          label: string,
+          opts: { fromAgent?: string; fromCredentials?: string },
+        ) => {
+          validateAccountLabel(label);
+
+          if (accountExists(label)) {
+            throw new Error(
+              `Account "${label}" already exists at ${accountDir(label)}. ` +
+                `Remove it first with 'switchroom auth account rm ${label}' or pick a different label.`,
+            );
+          }
+          if (!opts.fromAgent && !opts.fromCredentials) {
+            throw new Error(
+              "Need a credentials source. Pass --from-agent <name> to copy from an " +
+                "agent that's already authenticated, or --from-credentials <path> to " +
+                "import from a credentials.json file. Interactive `claude setup-token` " +
+                "support will follow in a later release.",
+            );
+          }
+          if (opts.fromAgent && opts.fromCredentials) {
+            throw new Error(
+              "Pass only one of --from-agent or --from-credentials, not both.",
+            );
+          }
+
+          let creds: AccountCredentials;
+          let sourceDescription: string;
+
+          if (opts.fromAgent) {
+            const config = getConfig(program);
+            const agentsDir = resolveAgentsDir(config);
+            if (!config.agents[opts.fromAgent]) {
+              throw new Error(
+                `agent '${opts.fromAgent}' is not declared in switchroom.yaml`,
+              );
+            }
+            const credPath = resolve(
+              agentsDir,
+              opts.fromAgent,
+              ".claude",
+              ".credentials.json",
+            );
+            if (!existsSync(credPath)) {
+              throw new Error(
+                `agent '${opts.fromAgent}' has no .credentials.json at ${credPath}. ` +
+                  `Run 'switchroom auth login ${opts.fromAgent}' first.`,
+              );
+            }
+            creds = parseCredentialsFile(credPath);
+            sourceDescription = `agent '${opts.fromAgent}'`;
+          } else {
+            const credPath = resolve(opts.fromCredentials!);
+            if (!existsSync(credPath)) {
+              throw new Error(`credentials file not found: ${credPath}`);
+            }
+            creds = parseCredentialsFile(credPath);
+            sourceDescription = credPath;
+          }
+
+          assertCredentialsHaveAccessToken(creds);
+
+          writeAccountCredentials(label, creds);
+          patchAccountMeta(label, {
+            createdAt: Date.now(),
+            subscriptionType: creds.claudeAiOauth?.subscriptionType,
+          });
+
+          console.log();
+          console.log(
+            `${chalk.green("✓")} Account ${chalk.bold(label)} created at ${accountDir(label)}`,
+          );
+          console.log(`  Seeded from: ${sourceDescription}`);
+          if (creds.claudeAiOauth?.subscriptionType) {
+            console.log(
+              `  Subscription: ${creds.claudeAiOauth.subscriptionType}`,
+            );
+          }
+          if (creds.claudeAiOauth?.expiresAt) {
+            const remaining = creds.claudeAiOauth.expiresAt - Date.now();
+            console.log(`  Token life:   ${formatDuration(remaining)}`);
+          }
+          console.log();
+          console.log(
+            `Next: enable on agents with 'switchroom auth enable ${label} <agent>'`,
+          );
+          console.log();
+        },
+      ),
+    );
+}
+
+/* ── account list ────────────────────────────────────────────────────── */
+
+function registerAccountList(account: Command, program: Command): void {
+  account
+    .command("list")
+    .description("List Anthropic accounts and which agents use each")
+    .action(
+      withConfigError(async () => {
+        const config = getConfig(program);
+        const labels = listAccounts();
+        if (labels.length === 0) {
+          console.log();
+          console.log(
+            "No accounts yet. Add one with 'switchroom auth account add <label>'.",
+          );
+          console.log(`  Storage: ${accountsRoot()}`);
+          console.log();
+          return;
+        }
+
+        const infos = getAccountInfos();
+        const enabledMap = new Map<string, string[]>();
+        for (const label of labels) {
+          enabledMap.set(
+            label,
+            Object.entries(config.agents)
+              .filter(([, a]) => (a.auth?.accounts ?? []).includes(label))
+              .map(([n]) => n)
+              .sort(),
+          );
+        }
+
+        console.log();
+        for (const info of infos) {
+          const agents = enabledMap.get(info.label) ?? [];
+          const agentsText =
+            agents.length === 0
+              ? chalk.dim("(no agents enabled)")
+              : agents.join(", ");
+          const healthBadge = healthBadgeFor(info.health);
+          const subText = info.subscriptionType
+            ? `${info.subscriptionType} · `
+            : "";
+          const expiryText = info.expiresAt
+            ? `expires in ${formatDuration(info.expiresAt - Date.now())}`
+            : "no expiry recorded";
+          console.log(
+            `${healthBadge} ${chalk.bold(info.label)}  ${chalk.dim(`${subText}${expiryText}`)}`,
+          );
+          console.log(`   agents: ${agentsText}`);
+          if (info.email) console.log(`   email:  ${info.email}`);
+          console.log();
+        }
+      }),
+    );
+}
+
+/* ── account rm ──────────────────────────────────────────────────────── */
+
+function registerAccountRm(account: Command, program: Command): void {
+  account
+    .command("rm <label>")
+    .description(
+      "Remove an Anthropic account from ~/.switchroom/accounts/. Refused while any agent is enabled.",
+    )
+    .action(
+      withConfigError(async (label: string) => {
+        validateAccountLabel(label);
+        if (!accountExists(label)) {
+          throw new Error(`Account "${label}" does not exist`);
+        }
+        const config = getConfig(program);
+        const enabled = Object.entries(config.agents)
+          .filter(([, a]) => (a.auth?.accounts ?? []).includes(label))
+          .map(([n]) => n)
+          .sort();
+        if (enabled.length > 0) {
+          throw new Error(
+            `Refusing to remove account "${label}" — still enabled on: ${enabled.join(", ")}. ` +
+              `Disable each first with 'switchroom auth disable ${label} <agent>'.`,
+          );
+        }
+        removeAccount(label);
+        console.log();
+        console.log(`${chalk.green("✓")} Account ${chalk.bold(label)} removed.`);
+        console.log();
+      }),
+    );
+}
+
+/* ── enable / disable ────────────────────────────────────────────────── */
+
+function registerEnable(authParent: Command, program: Command): void {
+  authParent
+    .command("enable <label> <agents...>")
+    .description(
+      "Enable an Anthropic account on one or more agents (appends to switchroom.yaml + immediate fanout)",
+    )
+    .action(
+      withConfigError(async (label: string, agents: string[]) => {
+        validateAccountLabel(label);
+        if (!accountExists(label)) {
+          throw new Error(
+            `Account "${label}" does not exist. Add it first with 'switchroom auth account add ${label}'.`,
+          );
+        }
+        const config = getConfig(program);
+        const agentsDir = resolveAgentsDir(config);
+        for (const name of agents) {
+          if (!config.agents[name]) {
+            throw new Error(
+              `agent '${name}' is not declared in switchroom.yaml`,
+            );
+          }
+        }
+
+        const yamlPath = getConfigPath(program);
+        const before = readFileSync(yamlPath, "utf-8");
+        let after = before;
+        const changed: string[] = [];
+        for (const name of agents) {
+          const next = appendAccountToAgent(after, name, label);
+          if (next !== after) changed.push(name);
+          after = next;
+        }
+        if (after !== before) {
+          writeFileSync(yamlPath, after);
+        }
+
+        // Immediate fanout — don't wait for the next refresh tick to push
+        // credentials into the just-enabled agents' .claude/ dirs.
+        const targets = agents.map((name) => ({
+          name,
+          agentDir: resolve(agentsDir, name),
+        }));
+        const outcomes = fanoutAccountToAgents(label, targets);
+
+        console.log();
+        if (changed.length === 0) {
+          console.log(
+            `No change — ${chalk.bold(label)} already enabled on: ${agents.join(", ")}`,
+          );
+        } else {
+          console.log(
+            `${chalk.green("✓")} Enabled ${chalk.bold(label)} on: ${changed.join(", ")}`,
+          );
+        }
+        const fanned = outcomes
+          .filter((o) => o.kind === "fanned-out")
+          .map((o) => o.agent);
+        const fanFails = outcomes.filter((o) => o.kind === "fanout-failed");
+        if (fanned.length > 0) {
+          console.log(`  Credentials fanned out to: ${fanned.join(", ")}`);
+        }
+        for (const f of fanFails) {
+          if (f.kind === "fanout-failed") {
+            console.log(
+              chalk.yellow(`  ⚠ Fanout failed for ${f.agent}: ${f.error}`),
+            );
+          }
+        }
+        console.log();
+        console.log(
+          `Next: 'switchroom agent restart ${agents.join(" ")}' to load the new credentials.`,
+        );
+        console.log();
+      }),
+    );
+}
+
+function registerDisable(authParent: Command, program: Command): void {
+  authParent
+    .command("disable <label> <agents...>")
+    .description(
+      "Disable an Anthropic account on one or more agents (removes from switchroom.yaml). Refuses to leave an agent with no accounts.",
+    )
+    .action(
+      withConfigError(async (label: string, agents: string[]) => {
+        validateAccountLabel(label);
+        const yamlPath = getConfigPath(program);
+        const before = readFileSync(yamlPath, "utf-8");
+
+        // Refuse if it would empty any agent's account list.
+        for (const name of agents) {
+          const current = getAccountsForAgent(before, name);
+          if (current.length === 1 && current[0] === label) {
+            throw new Error(
+              `Refusing to disable "${label}" on agent '${name}' — it's the only account. ` +
+                `Enable another account first with 'switchroom auth enable <other> ${name}'.`,
+            );
+          }
+        }
+
+        let after = before;
+        const changed: string[] = [];
+        for (const name of agents) {
+          const next = removeAccountFromAgent(after, name, label);
+          if (next !== after) changed.push(name);
+          after = next;
+        }
+        if (after !== before) {
+          writeFileSync(yamlPath, after);
+        }
+
+        console.log();
+        if (changed.length === 0) {
+          console.log(
+            `No change — ${chalk.bold(label)} was not enabled on: ${agents.join(", ")}`,
+          );
+        } else {
+          console.log(
+            `${chalk.green("✓")} Disabled ${chalk.bold(label)} on: ${changed.join(", ")}`,
+          );
+          console.log(
+            `  Run 'switchroom agent restart ${changed.join(" ")}' to drop the now-stale credentials cache.`,
+          );
+        }
+        console.log();
+      }),
+    );
+}
+
+/* ── refresh-accounts ────────────────────────────────────────────────── */
+
+function registerRefreshAccounts(authParent: Command, program: Command): void {
+  authParent
+    .command("refresh-accounts")
+    .description(
+      "Run a single account-refresh tick: refresh expiring tokens, fan out to enabled agents",
+    )
+    .option(
+      "--json",
+      "Emit a single JSON line instead of human-readable text (for cron logging)",
+    )
+    .action(
+      withConfigError(async (opts: { json?: boolean }) => {
+        const config = getConfig(program);
+        const summary = await refreshAllAccounts(config);
+
+        if (opts.json) {
+          console.log(JSON.stringify(summary));
+          return;
+        }
+
+        const c = summary.counts;
+        const took = summary.finishedAt - summary.startedAt;
+        console.log(
+          `account refresh tick: ${c.refreshed} refreshed, ${c.skippedFresh} fresh, ` +
+            `${c.skippedNoRefreshToken} need re-auth, ${c.failedRefresh} failed; ` +
+            `${c.fannedOut} fanouts, ${c.failedFanout} fanout failures (${took}ms)`,
+        );
+        for (const o of summary.refreshes) {
+          if (o.kind === "failed") {
+            console.log(chalk.red(`  ✗ ${o.account}: ${o.error}`));
+          } else if (o.kind === "skipped-no-refresh-token") {
+            console.log(
+              chalk.yellow(
+                `  ⚠ ${o.account}: needs re-auth (no refresh token)`,
+              ),
+            );
+          }
+        }
+        for (const o of summary.fanouts) {
+          if (o.kind === "fanout-failed") {
+            console.log(
+              chalk.red(`  ✗ fanout ${o.account}→${o.agent}: ${o.error}`),
+            );
+          }
+        }
+      }),
+    );
+}
+
+/* ── helpers ─────────────────────────────────────────────────────────── */
+
+function parseCredentialsFile(path: string): AccountCredentials {
+  let raw: string;
+  try {
+    raw = readFileSync(path, "utf-8");
+  } catch (err) {
+    throw new Error(`failed to read ${path}: ${(err as Error).message}`);
+  }
+  try {
+    return JSON.parse(raw) as AccountCredentials;
+  } catch (err) {
+    throw new Error(`${path} is not valid JSON: ${(err as Error).message}`);
+  }
+}
+
+function assertCredentialsHaveAccessToken(creds: AccountCredentials): void {
+  const tok = creds.claudeAiOauth?.accessToken;
+  if (typeof tok !== "string" || tok.length === 0) {
+    throw new Error(
+      "credentials are missing claudeAiOauth.accessToken — this doesn't look like a " +
+        "Claude Code credentials.json file produced by `claude setup-token`.",
+    );
+  }
+}
+
+function healthBadgeFor(h: string): string {
+  switch (h) {
+    case "healthy":
+      return chalk.green("✓");
+    case "quota-exhausted":
+      return chalk.yellow("⊘");
+    case "expired":
+      return chalk.yellow("↻");
+    case "missing-refresh-token":
+      return chalk.red("✗");
+    case "missing-credentials":
+      return chalk.red("?");
+    default:
+      return "·";
+  }
+}
+
+function formatDuration(ms: number): string {
+  if (ms < 0) return "expired";
+  const sec = Math.floor(ms / 1000);
+  if (sec < 60) return `${sec}s`;
+  const min = Math.floor(sec / 60);
+  if (min < 60) return `${min}m`;
+  const hr = Math.floor(min / 60);
+  if (hr < 24) return `${hr}h ${min % 60}m`;
+  const day = Math.floor(hr / 24);
+  return `${day}d ${hr % 24}h`;
+}

--- a/src/cli/auth-accounts.ts
+++ b/src/cli/auth-accounts.ts
@@ -165,6 +165,23 @@ function registerAccountAdd(account: Command, program: Command): void {
             const remaining = creds.claudeAiOauth.expiresAt - Date.now();
             console.log(`  Token life:   ${formatDuration(remaining)}`);
           }
+          // Real UX cliff: an access token without a refresh token works
+          // until expiry, then dies silently. The broker's refresh tick
+          // can't recover (skipped-no-refresh-token), and the operator
+          // only learns at the next 401. Warn loudly at import time.
+          const hasRefreshToken =
+            typeof creds.claudeAiOauth?.refreshToken === "string" &&
+            creds.claudeAiOauth.refreshToken.length > 0;
+          if (!hasRefreshToken) {
+            console.log();
+            console.log(
+              chalk.yellow(
+                "  ⚠ No refreshToken in the imported credentials. The token will work " +
+                  "until it expires, then this account will need a manual re-auth — " +
+                  "the broker can't refresh without a refresh token.",
+              ),
+            );
+          }
           console.log();
           console.log(
             `Next: enable on agents with 'switchroom auth enable ${label} <agent>'`,

--- a/src/cli/auth.ts
+++ b/src/cli/auth.ts
@@ -23,6 +23,7 @@ import {
 } from "../auth/token-refresh.js";
 import { getAgentStatus, restartAgent } from "../agents/lifecycle.js";
 import { withConfigError, getConfig } from "./helpers.js";
+import { registerAuthAccountSubcommands } from "./auth-accounts.js";
 
 function printAuthTable(
   headers: string[],
@@ -286,6 +287,12 @@ export function registerAuthCommand(program: Command): void {
   const auth = program
     .command("auth")
     .description("Manage OAuth authentication per agent");
+
+  // Account-shaped verbs (new auth model — see
+  // reference/share-auth-across-the-fleet.md). Registered first so the
+  // `auth account ...` subcommand tree exists before the per-agent
+  // legacy verbs hang off the same parent.
+  registerAuthAccountSubcommands(program, auth);
 
   // switchroom auth login <name>
   auth

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -791,6 +791,26 @@ export const AgentSchema = z.object({
       "email/account cannot be read locally; the user declares it here. Appears in the Auth " +
       "row as '✓ max · <label> · expires ...'."
     ),
+  auth: z
+    .object({
+      accounts: z
+        .array(z.string())
+        .optional()
+        .describe(
+          "Ordered list of Anthropic account labels (from `~/.switchroom/accounts/`) " +
+          "this agent can use. The first non-quota-exhausted account is the active one; " +
+          "subsequent entries are auto-fallback targets. switchroom-auth-broker keeps " +
+          "`<agentDir>/.claude/credentials.json` in sync with the active account on " +
+          "every refresh and on every quota event. When unset, the agent falls back to " +
+          "a single 'default' account; if no `default` account exists, the boot self-test " +
+          "surfaces a one-line nudge to run `switchroom auth account add`.",
+        ),
+    })
+    .optional()
+    .describe(
+      "Account routing for switchroom-auth-broker. See " +
+      "reference/share-auth-across-the-fleet.md for the unit-of-authentication model.",
+    ),
   topic_name: z.string().describe("Telegram forum topic display name"),
   topic_emoji: z
     .string()

--- a/telegram-plugin/auth-slot-parser.ts
+++ b/telegram-plugin/auth-slot-parser.ts
@@ -18,6 +18,19 @@ export function assertSafeSlotName(slot: string): void {
   }
 }
 
+/** Pattern used by global account labels — matches validateAccountLabel
+ *  in src/auth/account-store.ts ([A-Za-z0-9._-]+, max 64 chars). */
+const ACCOUNT_LABEL_RE = /^[A-Za-z0-9._-]{1,64}$/;
+
+export function assertSafeAccountLabel(label: string): void {
+  if (label === '.' || label === '..') {
+    throw new Error(`invalid account label: ${label}`);
+  }
+  if (!ACCOUNT_LABEL_RE.test(label)) {
+    throw new Error(`invalid account label: ${label}`);
+  }
+}
+
 /** Agent-name check mirrored from gateway.ts so the parser doesn't
  *  need to import gateway.ts (which has top-level side effects). */
 const AGENT_NAME_RE = /^[a-zA-Z0-9_-]{1,64}$/;
@@ -36,6 +49,12 @@ export type AuthIntent =
   | { kind: 'use'; agent: string; slot: string; force: boolean; label: string; cliArgs: string[]; restartAgentAfter: true }
   | { kind: 'list'; agent: string; label: string; cliArgs: string[] }
   | { kind: 'rm'; agent: string; slot: string; force: boolean; label: string; cliArgs: string[] }
+  // ── New account-shaped verbs (see reference/share-auth-across-the-fleet.md) ──
+  | { kind: 'account-add'; account: string; fromAgent: string; label: string; cliArgs: string[] }
+  | { kind: 'account-list'; label: string; cliArgs: string[] }
+  | { kind: 'account-rm'; account: string; label: string; cliArgs: string[] }
+  | { kind: 'enable'; account: string; agents: string[]; label: string; cliArgs: string[]; restartAgentsAfter: true }
+  | { kind: 'disable'; account: string; agents: string[]; label: string; cliArgs: string[] }
   | { kind: 'usage'; message: string }
   | { kind: 'error'; message: string };
 
@@ -43,6 +62,8 @@ export const AUTH_VERBS = [
   'login', 'reauth', 'link',
   'code', 'cancel', 'status',
   'add', 'use', 'list', 'rm',
+  // New account-shaped verbs
+  'account', 'enable', 'disable',
 ] as const;
 
 /** Help/usage string shown for unknown subcommands. Keep wording close
@@ -51,15 +72,24 @@ export const AUTH_VERBS = [
 export function usageText(): string {
   return [
     'Usage:',
-    '/auth',
-    '/auth login [agent]',
-    '/auth reauth [agent]',
-    '/auth code [agent] <browser-code>',
-    '/auth cancel [agent]',
-    '/auth add [agent] [--slot <name>]',
-    '/auth use [agent] <slot> [--force]',
-    '/auth list [agent]',
-    '/auth rm [agent] <slot> [--force]',
+    '/auth                                       — status dashboard',
+    '',
+    'Per-agent (legacy slot model):',
+    '/auth login [agent]                         — start OAuth for agent',
+    '/auth reauth [agent]                        — re-auth from scratch',
+    '/auth code [agent] <browser-code>           — finish OAuth flow',
+    '/auth cancel [agent]                        — cancel pending flow',
+    '/auth add [agent] [--slot <name>]           — add another slot',
+    '/auth use [agent] <slot> [--force]          — switch active slot',
+    '/auth list [agent]                          — list slots',
+    '/auth rm [agent] <slot> [--force]           — remove a slot',
+    '',
+    'Anthropic accounts (shared across agents):',
+    '/auth account add <label> [--from-agent <name>]  — promote slot to global account',
+    '/auth account list                          — accounts + agents using each',
+    '/auth account rm <label>                    — remove (refused if enabled)',
+    '/auth enable <label> [agents...]            — wire account to agent(s)',
+    '/auth disable <label> [agents...]           — unwire account from agent(s)',
   ].join('\n');
 }
 
@@ -185,6 +215,118 @@ export function parseAuthSubCommand(
       kind: 'rm', agent, slot, force,
       label: `auth rm ${agent} ${slot}`,
       cliArgs: ['auth', 'rm', agent, slot],
+    };
+  }
+
+  // --- Account-shaped verbs (see reference/share-auth-across-the-fleet.md) ---
+
+  if (sub === 'account') {
+    const accountSub = (parts[1] ?? 'list').toLowerCase();
+
+    if (accountSub === 'add') {
+      // /auth account add <label> [--from-agent <name>]
+      // Default --from-agent to the current agent — that's the common case
+      // for a Telegram-only operator who just /auth login'd this agent.
+      const rest = parts.slice(2);
+      const { flags, positional } = splitFlags(rest, ['--from-agent']);
+      const account = positional[0];
+      if (!account) {
+        return {
+          kind: 'usage',
+          message: 'Usage: /auth account add <label> [--from-agent <name>]',
+        };
+      }
+      try { assertSafeAccountLabel(account); }
+      catch { return { kind: 'error', message: 'Invalid account label. Use [A-Za-z0-9._-], 1-64 chars.' }; }
+      const fromAgentRaw = flags['--from-agent'];
+      const fromAgent = typeof fromAgentRaw === 'string' ? fromAgentRaw : currentAgent;
+      try { assertSafeAgentNameForParser(fromAgent); }
+      catch { return { kind: 'error', message: 'Invalid --from-agent value.' }; }
+      return {
+        kind: 'account-add',
+        account,
+        fromAgent,
+        label: `auth account add ${account}`,
+        cliArgs: ['auth', 'account', 'add', account, '--from-agent', fromAgent],
+      };
+    }
+
+    if (accountSub === 'list') {
+      return {
+        kind: 'account-list',
+        label: 'auth account list',
+        cliArgs: ['auth', 'account', 'list'],
+      };
+    }
+
+    if (accountSub === 'rm') {
+      // /auth account rm <label>
+      const account = parts[2];
+      if (!account) {
+        return { kind: 'usage', message: 'Usage: /auth account rm <label>' };
+      }
+      try { assertSafeAccountLabel(account); }
+      catch { return { kind: 'error', message: 'Invalid account label.' }; }
+      return {
+        kind: 'account-rm',
+        account,
+        label: `auth account rm ${account}`,
+        cliArgs: ['auth', 'account', 'rm', account],
+      };
+    }
+
+    return {
+      kind: 'usage',
+      message: 'Usage: /auth account add | list | rm  (see /auth)',
+    };
+  }
+
+  if (sub === 'enable') {
+    // /auth enable <label> [agents...] — defaults to the current agent.
+    const rest = parts.slice(1);
+    const account = rest[0];
+    if (!account) {
+      return { kind: 'usage', message: 'Usage: /auth enable <label> [agents...]' };
+    }
+    try { assertSafeAccountLabel(account); }
+    catch { return { kind: 'error', message: 'Invalid account label.' }; }
+    const agents = rest.slice(1);
+    if (agents.length === 0) agents.push(currentAgent);
+    for (const a of agents) {
+      try { assertSafeAgentNameForParser(a); }
+      catch { return { kind: 'error', message: `Invalid agent name: ${a}` }; }
+    }
+    return {
+      kind: 'enable',
+      account,
+      agents,
+      label: `auth enable ${account} ${agents.join(' ')}`,
+      cliArgs: ['auth', 'enable', account, ...agents],
+      restartAgentsAfter: true,
+    };
+  }
+
+  if (sub === 'disable') {
+    // /auth disable <label> [agents...] — defaults to the current agent.
+    const rest = parts.slice(1);
+    const account = rest[0];
+    if (!account) {
+      return { kind: 'usage', message: 'Usage: /auth disable <label> [agents...]' };
+    }
+    try { assertSafeAccountLabel(account); }
+    catch { return { kind: 'error', message: 'Invalid account label.' }; }
+    const agents = rest.slice(1);
+    if (agents.length === 0) agents.push(currentAgent);
+    for (const a of agents) {
+      try { assertSafeAgentNameForParser(a); }
+      catch { return { kind: 'error', message: `Invalid agent name: ${a}` }; }
+    }
+    return {
+      kind: 'disable',
+      account,
+      agents,
+      label: `auth disable ${account} ${agents.join(' ')}`,
+      cliArgs: ['auth', 'disable', account, ...agents],
     };
   }
 

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -6316,6 +6316,52 @@ bot.command('auth', async ctx => {
     return
   }
 
+  // --- New account-shaped verbs (see reference/share-auth-across-the-fleet.md) ---
+
+  if (intent.kind === 'account-add') {
+    // /auth account add <label> [--from-agent <name>]
+    // Lifts an already-authenticated agent's credentials into a global
+    // account so other agents can share the same Anthropic subscription
+    // without each running its own OAuth flow.
+    await runSwitchroomCommand(ctx, intent.cliArgs, intent.label)
+    return
+  }
+
+  if (intent.kind === 'account-list') {
+    // /auth account list — table of accounts + which agents use each.
+    await runSwitchroomCommand(ctx, intent.cliArgs, intent.label)
+    return
+  }
+
+  if (intent.kind === 'account-rm') {
+    // /auth account rm <label> — refused if any agent is still enabled.
+    await runSwitchroomCommand(ctx, intent.cliArgs, intent.label)
+    return
+  }
+
+  if (intent.kind === 'enable') {
+    // /auth enable <label> [agents...] — wires the account to those agents
+    // (defaults to the current agent), then restarts each so claude picks
+    // up the freshly fanned-out credentials.
+    await runSwitchroomCommand(ctx, intent.cliArgs, intent.label)
+    if (intent.restartAgentsAfter) {
+      for (const a of intent.agents) {
+        try { assertSafeAgentName(a) } catch { continue }
+        await runSwitchroomCommand(ctx, ['agent', 'restart', a], `restart ${a}`)
+      }
+    }
+    void refreshPinnedBanner('auth-enable')
+    return
+  }
+
+  if (intent.kind === 'disable') {
+    // /auth disable <label> [agents...] — unwires the account from those
+    // agents. Doesn't auto-restart: the operator may want to drain the
+    // current credential first. The CLI hint already says "restart now".
+    await runSwitchroomCommand(ctx, intent.cliArgs, intent.label)
+    return
+  }
+
   // intent.kind === 'status' — render the inline-keyboard dashboard.
   // For the dashboard we're the bot-bound agent: we don't list every
   // agent in the switchroom config; we show THIS bot's agent with its

--- a/telegram-plugin/tests/auth-slot-commands.test.ts
+++ b/telegram-plugin/tests/auth-slot-commands.test.ts
@@ -362,4 +362,158 @@ describe("usageText", () => {
       expect(u).toContain(`/auth ${v}`);
     }
   });
+
+  it("lists the new account-shaped verbs", () => {
+    const u = usageText();
+    expect(u).toContain("/auth account add");
+    expect(u).toContain("/auth account list");
+    expect(u).toContain("/auth account rm");
+    expect(u).toContain("/auth enable");
+    expect(u).toContain("/auth disable");
+  });
+});
+
+describe("parseAuthSubCommand — account-shaped verbs", () => {
+  it("/auth account add <label> defaults --from-agent to currentAgent", () => {
+    const intent = parseAuthSubCommand(["account", "add", "work-pro"], "clerk");
+    expect(intent.kind).toBe("account-add");
+    if (intent.kind === "account-add") {
+      expect(intent.account).toBe("work-pro");
+      expect(intent.fromAgent).toBe("clerk");
+      expect(intent.cliArgs).toEqual(["auth", "account", "add", "work-pro", "--from-agent", "clerk"]);
+    }
+  });
+
+  it("/auth account add <label> --from-agent <name> uses explicit agent", () => {
+    const intent = parseAuthSubCommand(
+      ["account", "add", "work-pro", "--from-agent", "klanker"],
+      "clerk",
+    );
+    expect(intent.kind).toBe("account-add");
+    if (intent.kind === "account-add") {
+      expect(intent.fromAgent).toBe("klanker");
+      expect(intent.cliArgs).toContain("--from-agent");
+      expect(intent.cliArgs).toContain("klanker");
+    }
+  });
+
+  it("/auth account add without label is a usage error", () => {
+    const intent = parseAuthSubCommand(["account", "add"], "clerk");
+    expect(intent.kind).toBe("usage");
+  });
+
+  it("/auth account add rejects invalid labels", () => {
+    const intent = parseAuthSubCommand(["account", "add", "../etc"], "clerk");
+    expect(intent.kind).toBe("error");
+  });
+
+  it("/auth account add accepts dotted account labels (email-style)", () => {
+    const intent = parseAuthSubCommand(
+      ["account", "add", "ken.example.com"],
+      "clerk",
+    );
+    expect(intent.kind).toBe("account-add");
+  });
+
+  it("/auth account add rejects --from-agent with shell metacharacters", () => {
+    const intent = parseAuthSubCommand(
+      ["account", "add", "work", "--from-agent", "foo;ls"],
+      "clerk",
+    );
+    expect(intent.kind).toBe("error");
+  });
+
+  it("/auth account list maps to the CLI list verb", () => {
+    const intent = parseAuthSubCommand(["account", "list"], "clerk");
+    expect(intent.kind).toBe("account-list");
+    if (intent.kind === "account-list") {
+      expect(intent.cliArgs).toEqual(["auth", "account", "list"]);
+    }
+  });
+
+  it("/auth account rm <label>", () => {
+    const intent = parseAuthSubCommand(["account", "rm", "old-account"], "clerk");
+    expect(intent.kind).toBe("account-rm");
+    if (intent.kind === "account-rm") {
+      expect(intent.account).toBe("old-account");
+      expect(intent.cliArgs).toEqual(["auth", "account", "rm", "old-account"]);
+    }
+  });
+
+  it("/auth account rm without label is a usage error", () => {
+    const intent = parseAuthSubCommand(["account", "rm"], "clerk");
+    expect(intent.kind).toBe("usage");
+  });
+
+  it("/auth account with no subverb defaults to list", () => {
+    const intent = parseAuthSubCommand(["account"], "clerk");
+    expect(intent.kind).toBe("account-list");
+  });
+});
+
+describe("parseAuthSubCommand — enable / disable", () => {
+  it("/auth enable <label> defaults agents to currentAgent", () => {
+    const intent = parseAuthSubCommand(["enable", "work-pro"], "clerk");
+    expect(intent.kind).toBe("enable");
+    if (intent.kind === "enable") {
+      expect(intent.account).toBe("work-pro");
+      expect(intent.agents).toEqual(["clerk"]);
+      expect(intent.cliArgs).toEqual(["auth", "enable", "work-pro", "clerk"]);
+      expect(intent.restartAgentsAfter).toBe(true);
+    }
+  });
+
+  it("/auth enable <label> <a> <b> wires multiple agents", () => {
+    const intent = parseAuthSubCommand(
+      ["enable", "work-pro", "foo", "bar"],
+      "clerk",
+    );
+    expect(intent.kind).toBe("enable");
+    if (intent.kind === "enable") {
+      expect(intent.agents).toEqual(["foo", "bar"]);
+      expect(intent.cliArgs).toEqual(["auth", "enable", "work-pro", "foo", "bar"]);
+    }
+  });
+
+  it("/auth enable without label is a usage error", () => {
+    const intent = parseAuthSubCommand(["enable"], "clerk");
+    expect(intent.kind).toBe("usage");
+  });
+
+  it("/auth enable rejects invalid agent names", () => {
+    const intent = parseAuthSubCommand(
+      ["enable", "work-pro", "foo;ls"],
+      "clerk",
+    );
+    expect(intent.kind).toBe("error");
+  });
+
+  it("/auth disable <label> mirrors enable shape", () => {
+    const intent = parseAuthSubCommand(["disable", "work-pro"], "clerk");
+    expect(intent.kind).toBe("disable");
+    if (intent.kind === "disable") {
+      expect(intent.account).toBe("work-pro");
+      expect(intent.agents).toEqual(["clerk"]);
+      expect(intent.cliArgs).toEqual(["auth", "disable", "work-pro", "clerk"]);
+    }
+  });
+
+  it("/auth disable <label> <a> <b> for explicit agents", () => {
+    const intent = parseAuthSubCommand(
+      ["disable", "work-pro", "foo", "bar"],
+      "clerk",
+    );
+    expect(intent.kind).toBe("disable");
+    if (intent.kind === "disable") {
+      expect(intent.agents).toEqual(["foo", "bar"]);
+    }
+  });
+});
+
+describe("AUTH_VERBS includes the new account-shaped verbs", () => {
+  it("exports account / enable / disable in the verb list", () => {
+    expect(AUTH_VERBS).toContain("account");
+    expect(AUTH_VERBS).toContain("enable");
+    expect(AUTH_VERBS).toContain("disable");
+  });
 });

--- a/tests/auth-account-label.test.ts
+++ b/tests/auth-account-label.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdirSync, rmSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  getSlotInfos,
+  readSlotMeta,
+  setSlotLabel,
+  writeSlotToken,
+} from "../src/auth/accounts.js";
+
+let agentDir: string;
+
+beforeEach(() => {
+  agentDir = resolve(
+    tmpdir(),
+    `switchroom-label-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
+  mkdirSync(join(agentDir, ".claude"), { recursive: true });
+});
+
+afterEach(() => {
+  rmSync(agentDir, { recursive: true, force: true });
+});
+
+describe("setSlotLabel", () => {
+  it("attaches a label to an existing slot", () => {
+    writeSlotToken(agentDir, "default", "sk-ant-oat01-xxx");
+    setSlotLabel(agentDir, "default", "ken@example.com");
+    expect(readSlotMeta(agentDir, "default")?.accountLabel).toBe(
+      "ken@example.com",
+    );
+  });
+
+  it("trims whitespace", () => {
+    writeSlotToken(agentDir, "default", "sk-ant-oat01-xxx");
+    setSlotLabel(agentDir, "default", "  ken@example.com  ");
+    expect(readSlotMeta(agentDir, "default")?.accountLabel).toBe(
+      "ken@example.com",
+    );
+  });
+
+  it("clears the label when given undefined or empty", () => {
+    writeSlotToken(agentDir, "default", "sk-ant-oat01-xxx");
+    setSlotLabel(agentDir, "default", "ken@example.com");
+    setSlotLabel(agentDir, "default", undefined);
+    expect(readSlotMeta(agentDir, "default")?.accountLabel).toBeUndefined();
+    setSlotLabel(agentDir, "default", "ken@example.com");
+    setSlotLabel(agentDir, "default", "  ");
+    expect(readSlotMeta(agentDir, "default")?.accountLabel).toBeUndefined();
+  });
+
+  it("creates a meta file when absent", () => {
+    // No prior writeSlotToken — slot meta doesn't exist yet.
+    setSlotLabel(agentDir, "default", "ken@example.com");
+    const meta = readSlotMeta(agentDir, "default");
+    expect(meta?.accountLabel).toBe("ken@example.com");
+    expect(meta?.source).toBe("unknown");
+  });
+
+  it("rejects invalid slot names", () => {
+    expect(() => setSlotLabel(agentDir, "../etc", "x")).toThrow();
+  });
+});
+
+describe("writeSlotToken preserves label across reauth", () => {
+  it("keeps accountLabel when the token is rewritten", () => {
+    writeSlotToken(agentDir, "default", "sk-ant-oat01-aaa");
+    setSlotLabel(agentDir, "default", "ken@example.com");
+    // Simulate a reauth — token changes, meta gets rewritten.
+    writeSlotToken(agentDir, "default", "sk-ant-oat01-bbb");
+    expect(readSlotMeta(agentDir, "default")?.accountLabel).toBe(
+      "ken@example.com",
+    );
+  });
+
+  it("does not synthesize a label when none was set", () => {
+    writeSlotToken(agentDir, "default", "sk-ant-oat01-xxx");
+    expect(readSlotMeta(agentDir, "default")?.accountLabel).toBeUndefined();
+  });
+});
+
+describe("getSlotInfos exposes the label", () => {
+  it("includes accountLabel when set", () => {
+    writeSlotToken(agentDir, "default", "sk-ant-oat01-aaa");
+    writeSlotToken(agentDir, "secondary", "sk-ant-oat01-bbb");
+    setSlotLabel(agentDir, "default", "primary@example.com");
+    const infos = getSlotInfos(agentDir);
+    const primary = infos.find((s) => s.slot === "default");
+    const secondary = infos.find((s) => s.slot === "secondary");
+    expect(primary?.accountLabel).toBe("primary@example.com");
+    expect(secondary?.accountLabel).toBeUndefined();
+  });
+});

--- a/tests/auth-account-refresh.test.ts
+++ b/tests/auth-account-refresh.test.ts
@@ -1,0 +1,525 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { existsSync, mkdirSync, readFileSync, rmSync } from "node:fs";
+import { resolve, join } from "node:path";
+import { tmpdir } from "node:os";
+
+import {
+  enabledAgentsForAccount,
+  fanoutAccountToAgents,
+  refreshAccountIfNeeded,
+  refreshAllAccounts,
+  type Fetcher,
+} from "../src/auth/account-refresh.js";
+import {
+  readAccountCredentials,
+  readAccountMeta,
+  writeAccountCredentials,
+} from "../src/auth/account-store.js";
+import type { SwitchroomConfig } from "../src/config/schema.js";
+
+let home: string;
+let agentsDir: string;
+
+beforeEach(() => {
+  const stamp = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  home = resolve(tmpdir(), `switchroom-acct-refresh-${stamp}`);
+  mkdirSync(home, { recursive: true });
+  agentsDir = resolve(home, "agents");
+  mkdirSync(agentsDir, { recursive: true });
+});
+
+afterEach(() => {
+  rmSync(home, { recursive: true, force: true });
+});
+
+const NOW = 1_700_000_000_000;
+
+const okFetcher = (
+  body: Record<string, unknown>,
+  status = 200,
+): Fetcher =>
+  async () => ({
+    ok: status >= 200 && status < 300,
+    status,
+    text: async () => JSON.stringify(body),
+  });
+
+const errFetcher = (status: number, body: string): Fetcher =>
+  async () => ({
+    ok: false,
+    status,
+    text: async () => body,
+  });
+
+const throwingFetcher: Fetcher = async () => {
+  throw new Error("network down");
+};
+
+describe("refreshAccountIfNeeded — skip paths", () => {
+  it("skipped-no-credentials when account doesn't exist", async () => {
+    const out = await refreshAccountIfNeeded("ghost", { now: () => NOW, home });
+    expect(out.kind).toBe("skipped-no-credentials");
+  });
+
+  it("skipped-malformed when accessToken missing", async () => {
+    writeAccountCredentials("a", { claudeAiOauth: {} }, home);
+    const out = await refreshAccountIfNeeded("a", { now: () => NOW, home });
+    expect(out.kind).toBe("skipped-malformed");
+  });
+
+  it("skipped-malformed when expiresAt is not a number", async () => {
+    writeAccountCredentials(
+      "a",
+      // @ts-expect-error - intentionally bad shape
+      { claudeAiOauth: { accessToken: "x", expiresAt: "soon" } },
+      home,
+    );
+    const out = await refreshAccountIfNeeded("a", { now: () => NOW, home });
+    expect(out.kind).toBe("skipped-malformed");
+  });
+
+  it("skipped-fresh when token has plenty of life left", async () => {
+    writeAccountCredentials(
+      "a",
+      {
+        claudeAiOauth: {
+          accessToken: "x",
+          refreshToken: "r",
+          expiresAt: NOW + 4 * 60 * 60 * 1000, // 4 hours
+        },
+      },
+      home,
+    );
+    const out = await refreshAccountIfNeeded("a", { now: () => NOW, home });
+    expect(out.kind).toBe("skipped-fresh");
+  });
+
+  it("skipped-no-refresh-token when expiring soon but no refresh token", async () => {
+    writeAccountCredentials(
+      "a",
+      {
+        claudeAiOauth: {
+          accessToken: "x",
+          expiresAt: NOW + 5 * 60 * 1000, // 5 minutes
+        },
+      },
+      home,
+    );
+    const out = await refreshAccountIfNeeded("a", { now: () => NOW, home });
+    expect(out.kind).toBe("skipped-no-refresh-token");
+  });
+});
+
+describe("refreshAccountIfNeeded — refresh path", () => {
+  it("refreshes and writes new credentials when expiring soon", async () => {
+    writeAccountCredentials(
+      "a",
+      {
+        claudeAiOauth: {
+          accessToken: "old-access",
+          refreshToken: "old-refresh",
+          expiresAt: NOW + 5 * 60 * 1000,
+        },
+      },
+      home,
+    );
+    const out = await refreshAccountIfNeeded("a", {
+      now: () => NOW,
+      home,
+      fetcher: okFetcher({
+        access_token: "new-access",
+        refresh_token: "new-refresh",
+        expires_in: 28800,
+      }),
+    });
+    expect(out.kind).toBe("refreshed");
+    if (out.kind !== "refreshed") return;
+    expect(out.newExpiresAt).toBe(NOW + 28800 * 1000);
+
+    const written = readAccountCredentials("a", home);
+    expect(written?.claudeAiOauth?.accessToken).toBe("new-access");
+    expect(written?.claudeAiOauth?.refreshToken).toBe("new-refresh");
+    expect(written?.claudeAiOauth?.expiresAt).toBe(NOW + 28800 * 1000);
+
+    const meta = readAccountMeta("a", home);
+    expect(meta?.lastRefreshedAt).toBe(NOW);
+  });
+
+  it("preserves old refreshToken when Anthropic does not rotate it", async () => {
+    writeAccountCredentials(
+      "a",
+      {
+        claudeAiOauth: {
+          accessToken: "old",
+          refreshToken: "keep-me",
+          expiresAt: NOW + 5 * 60 * 1000,
+        },
+      },
+      home,
+    );
+    const out = await refreshAccountIfNeeded("a", {
+      now: () => NOW,
+      home,
+      fetcher: okFetcher({ access_token: "new", expires_in: 3600 }),
+    });
+    expect(out.kind).toBe("refreshed");
+    expect(readAccountCredentials("a", home)?.claudeAiOauth?.refreshToken).toBe(
+      "keep-me",
+    );
+  });
+});
+
+describe("refreshAccountIfNeeded — failure path", () => {
+  it("returns failed on network error", async () => {
+    writeAccountCredentials(
+      "a",
+      {
+        claudeAiOauth: {
+          accessToken: "old",
+          refreshToken: "r",
+          expiresAt: NOW + 5 * 60 * 1000,
+        },
+      },
+      home,
+    );
+    const out = await refreshAccountIfNeeded("a", {
+      now: () => NOW,
+      home,
+      fetcher: throwingFetcher,
+    });
+    expect(out.kind).toBe("failed");
+    if (out.kind !== "failed") return;
+    expect(out.error).toContain("network down");
+  });
+
+  it("returns failed on HTTP 401", async () => {
+    writeAccountCredentials(
+      "a",
+      {
+        claudeAiOauth: {
+          accessToken: "old",
+          refreshToken: "r",
+          expiresAt: NOW + 5 * 60 * 1000,
+        },
+      },
+      home,
+    );
+    const out = await refreshAccountIfNeeded("a", {
+      now: () => NOW,
+      home,
+      fetcher: errFetcher(401, "invalid_grant"),
+    });
+    expect(out.kind).toBe("failed");
+    if (out.kind !== "failed") return;
+    expect(out.httpStatus).toBe(401);
+  });
+
+  it("returns failed when response missing access_token", async () => {
+    writeAccountCredentials(
+      "a",
+      {
+        claudeAiOauth: {
+          accessToken: "old",
+          refreshToken: "r",
+          expiresAt: NOW + 5 * 60 * 1000,
+        },
+      },
+      home,
+    );
+    const out = await refreshAccountIfNeeded("a", {
+      now: () => NOW,
+      home,
+      fetcher: okFetcher({ expires_in: 3600 }),
+    });
+    expect(out.kind).toBe("failed");
+  });
+
+  it("does NOT clobber existing credentials on a failed refresh", async () => {
+    writeAccountCredentials(
+      "a",
+      {
+        claudeAiOauth: {
+          accessToken: "untouchable",
+          refreshToken: "r",
+          expiresAt: NOW + 5 * 60 * 1000,
+        },
+      },
+      home,
+    );
+    await refreshAccountIfNeeded("a", {
+      now: () => NOW,
+      home,
+      fetcher: errFetcher(500, "server-error"),
+    });
+    expect(readAccountCredentials("a", home)?.claudeAiOauth?.accessToken).toBe(
+      "untouchable",
+    );
+  });
+});
+
+describe("fanoutAccountToAgents", () => {
+  it("copies credentials.json to each enabled agent", () => {
+    writeAccountCredentials(
+      "work-pro",
+      {
+        claudeAiOauth: {
+          accessToken: "shared-token",
+          refreshToken: "r",
+          expiresAt: NOW + 60 * 60 * 1000,
+        },
+      },
+      home,
+    );
+    const fooDir = join(agentsDir, "foo");
+    const barDir = join(agentsDir, "bar");
+    mkdirSync(fooDir, { recursive: true });
+    mkdirSync(barDir, { recursive: true });
+
+    const outcomes = fanoutAccountToAgents(
+      "work-pro",
+      [
+        { name: "foo", agentDir: fooDir },
+        { name: "bar", agentDir: barDir },
+      ],
+      { home },
+    );
+    expect(outcomes.every((o) => o.kind === "fanned-out")).toBe(true);
+
+    const fooCreds = JSON.parse(
+      readFileSync(join(fooDir, ".claude", "credentials.json"), "utf-8"),
+    );
+    expect(fooCreds.claudeAiOauth.accessToken).toBe("shared-token");
+    const barCreds = JSON.parse(
+      readFileSync(join(barDir, ".claude", "credentials.json"), "utf-8"),
+    );
+    expect(barCreds.claudeAiOauth.accessToken).toBe("shared-token");
+  });
+
+  it("also writes the legacy .oauth-token + meta mirrors so start.sh sees the new token", () => {
+    writeAccountCredentials(
+      "work-pro",
+      {
+        claudeAiOauth: {
+          accessToken: "current-access",
+          refreshToken: "r",
+          expiresAt: NOW + 60 * 60 * 1000,
+        },
+      },
+      home,
+    );
+    const fooDir = join(agentsDir, "foo");
+    mkdirSync(fooDir, { recursive: true });
+
+    fanoutAccountToAgents(
+      "work-pro",
+      [{ name: "foo", agentDir: fooDir }],
+      { home },
+    );
+
+    const oauthTokenPath = join(fooDir, ".claude", ".oauth-token");
+    const oauthMetaPath = join(fooDir, ".claude", ".oauth-token.meta.json");
+    expect(readFileSync(oauthTokenPath, "utf-8").trim()).toBe("current-access");
+    const meta = JSON.parse(readFileSync(oauthMetaPath, "utf-8"));
+    expect(meta.source).toBe("account:work-pro");
+    expect(typeof meta.expiresAt).toBe("number");
+  });
+
+  it("does NOT write legacy mirror when account credentials lack accessToken", () => {
+    writeAccountCredentials("broken", { claudeAiOauth: {} }, home);
+    const fooDir = join(agentsDir, "foo");
+    mkdirSync(fooDir, { recursive: true });
+
+    const outcomes = fanoutAccountToAgents(
+      "broken",
+      [{ name: "foo", agentDir: fooDir }],
+      { home },
+    );
+    // The credentials.json itself does fan out (caller can deal with the
+    // empty oauth block), but the legacy mirror that would inject a
+    // garbage env var stays untouched.
+    expect(outcomes[0].kind).toBe("fanned-out");
+    expect(
+      existsSync(join(fooDir, ".claude", ".oauth-token")),
+    ).toBe(false);
+  });
+
+  it("agent file is bit-identical to the global file", () => {
+    writeAccountCredentials(
+      "work-pro",
+      {
+        claudeAiOauth: {
+          accessToken: "abc",
+          refreshToken: "def",
+          expiresAt: NOW + 60 * 60 * 1000,
+          scopes: ["user:inference"],
+        },
+      },
+      home,
+    );
+    const fooDir = join(agentsDir, "foo");
+    mkdirSync(fooDir, { recursive: true });
+
+    fanoutAccountToAgents(
+      "work-pro",
+      [{ name: "foo", agentDir: fooDir }],
+      { home },
+    );
+
+    const globalContent = readFileSync(
+      join(home, ".switchroom", "accounts", "work-pro", "credentials.json"),
+      "utf-8",
+    );
+    const agentContent = readFileSync(
+      join(fooDir, ".claude", "credentials.json"),
+      "utf-8",
+    );
+    expect(agentContent).toBe(globalContent);
+  });
+
+  it("skips fanout when agent dir does not exist", () => {
+    writeAccountCredentials(
+      "a",
+      { claudeAiOauth: { accessToken: "x" } },
+      home,
+    );
+    const outcomes = fanoutAccountToAgents(
+      "a",
+      [{ name: "ghost", agentDir: join(agentsDir, "ghost") }],
+      { home },
+    );
+    expect(outcomes[0].kind).toBe("fanout-skipped-no-agent-dir");
+  });
+
+  it("fails fanout when account credentials are missing", () => {
+    const fooDir = join(agentsDir, "foo");
+    mkdirSync(fooDir, { recursive: true });
+    const outcomes = fanoutAccountToAgents(
+      "ghost-account",
+      [{ name: "foo", agentDir: fooDir }],
+      { home },
+    );
+    expect(outcomes[0].kind).toBe("fanout-failed");
+  });
+});
+
+describe("enabledAgentsForAccount", () => {
+  it("returns agents whose auth.accounts list includes the account", () => {
+    const config = {
+      agents: {
+        foo: { auth: { accounts: ["work-pro", "personal"] } },
+        bar: { auth: { accounts: ["personal"] } },
+        baz: { auth: { accounts: ["work-pro"] } },
+        qux: {},
+      },
+    } as unknown as SwitchroomConfig;
+
+    const enabled = enabledAgentsForAccount("work-pro", config, agentsDir);
+    expect(enabled.map((a) => a.name).sort()).toEqual(["baz", "foo"]);
+    expect(enabled[0].agentDir.startsWith(agentsDir)).toBe(true);
+  });
+
+  it("returns [] when no agent uses the account", () => {
+    const config = {
+      agents: {
+        foo: { auth: { accounts: ["other"] } },
+      },
+    } as unknown as SwitchroomConfig;
+    expect(enabledAgentsForAccount("missing", config, agentsDir)).toEqual([]);
+  });
+
+  it("ignores agents without auth.accounts", () => {
+    const config = {
+      agents: { foo: {}, bar: { auth: {} } },
+    } as unknown as SwitchroomConfig;
+    expect(enabledAgentsForAccount("work-pro", config, agentsDir)).toEqual([]);
+  });
+});
+
+describe("refreshAllAccounts", () => {
+  it("fans out even when refresh was skipped-fresh (so newly enabled agents catch up)", async () => {
+    writeAccountCredentials(
+      "work-pro",
+      {
+        claudeAiOauth: {
+          accessToken: "fresh",
+          refreshToken: "r",
+          expiresAt: NOW + 4 * 60 * 60 * 1000,
+        },
+      },
+      home,
+    );
+    const fooDir = join(agentsDir, "foo");
+    mkdirSync(fooDir, { recursive: true });
+
+    // Build a minimal config object — only the fields refreshAllAccounts reads.
+    const config = {
+      switchroom: { agents_dir: agentsDir },
+      agents: {
+        foo: { auth: { accounts: ["work-pro"] } },
+      },
+    } as unknown as SwitchroomConfig;
+
+    const summary = await refreshAllAccounts(config, {
+      now: () => NOW,
+      home,
+    });
+
+    expect(summary.counts.skippedFresh).toBe(1);
+    expect(summary.counts.fannedOut).toBe(1);
+
+    const agentCreds = JSON.parse(
+      readFileSync(join(fooDir, ".claude", "credentials.json"), "utf-8"),
+    );
+    expect(agentCreds.claudeAiOauth.accessToken).toBe("fresh");
+  });
+
+  it("counts are accurate across mixed outcomes", async () => {
+    writeAccountCredentials(
+      "fresh",
+      {
+        claudeAiOauth: {
+          accessToken: "x",
+          refreshToken: "r",
+          expiresAt: NOW + 4 * 60 * 60 * 1000,
+        },
+      },
+      home,
+    );
+    writeAccountCredentials(
+      "needs-refresh",
+      {
+        claudeAiOauth: {
+          accessToken: "old",
+          refreshToken: "r",
+          expiresAt: NOW + 5 * 60 * 1000,
+        },
+      },
+      home,
+    );
+    writeAccountCredentials(
+      "no-refresh",
+      {
+        claudeAiOauth: {
+          accessToken: "old",
+          expiresAt: NOW + 5 * 60 * 1000,
+        },
+      },
+      home,
+    );
+    const config = {
+      switchroom: { agents_dir: agentsDir },
+      agents: {},
+    } as unknown as SwitchroomConfig;
+
+    const summary = await refreshAllAccounts(config, {
+      now: () => NOW,
+      home,
+      fetcher: okFetcher({ access_token: "new", expires_in: 3600 }),
+    });
+
+    expect(summary.counts.skippedFresh).toBe(1);
+    expect(summary.counts.refreshed).toBe(1);
+    expect(summary.counts.skippedNoRefreshToken).toBe(1);
+    expect(summary.counts.fannedOut).toBe(0); // no enabled agents
+  });
+});

--- a/tests/auth-account-store.test.ts
+++ b/tests/auth-account-store.test.ts
@@ -1,0 +1,338 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdirSync, rmSync, writeFileSync, readdirSync } from "node:fs";
+import { resolve } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  accountDir,
+  accountCredentialsPath,
+  accountExists,
+  accountHealth,
+  accountMetaPath,
+  accountsRoot,
+  getAccountInfos,
+  listAccounts,
+  patchAccountMeta,
+  readAccountCredentials,
+  readAccountMeta,
+  removeAccount,
+  validateAccountLabel,
+  writeAccountCredentials,
+  writeAccountMeta,
+  type AccountCredentials,
+} from "../src/auth/account-store.js";
+
+let home: string;
+
+beforeEach(() => {
+  home = resolve(
+    tmpdir(),
+    `switchroom-acct-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
+  mkdirSync(home, { recursive: true });
+});
+
+afterEach(() => {
+  rmSync(home, { recursive: true, force: true });
+});
+
+describe("validateAccountLabel", () => {
+  it("accepts valid labels", () => {
+    expect(() => validateAccountLabel("default")).not.toThrow();
+    expect(() => validateAccountLabel("work-pro")).not.toThrow();
+    expect(() => validateAccountLabel("personal_max")).not.toThrow();
+    expect(() => validateAccountLabel("ken.example.com")).not.toThrow();
+    expect(() => validateAccountLabel("a")).not.toThrow();
+  });
+
+  it("rejects empty / overlong", () => {
+    expect(() => validateAccountLabel("")).toThrow();
+    expect(() => validateAccountLabel("a".repeat(65))).toThrow();
+  });
+
+  it("rejects path-traversal shapes", () => {
+    expect(() => validateAccountLabel(".")).toThrow();
+    expect(() => validateAccountLabel("..")).toThrow();
+    expect(() => validateAccountLabel("foo/bar")).toThrow();
+    expect(() => validateAccountLabel("foo\\bar")).toThrow();
+  });
+
+  it("rejects invalid characters", () => {
+    expect(() => validateAccountLabel("foo bar")).toThrow();
+    expect(() => validateAccountLabel("foo@bar")).toThrow();
+    expect(() => validateAccountLabel("foo:bar")).toThrow();
+    expect(() => validateAccountLabel("foo!")).toThrow();
+  });
+});
+
+describe("path helpers", () => {
+  it("resolve under ~/.switchroom/accounts/<label>/", () => {
+    expect(accountsRoot(home)).toBe(resolve(home, ".switchroom", "accounts"));
+    expect(accountDir("foo", home)).toBe(
+      resolve(home, ".switchroom", "accounts", "foo"),
+    );
+    expect(accountCredentialsPath("foo", home)).toBe(
+      resolve(home, ".switchroom", "accounts", "foo", "credentials.json"),
+    );
+    expect(accountMetaPath("foo", home)).toBe(
+      resolve(home, ".switchroom", "accounts", "foo", "meta.json"),
+    );
+  });
+});
+
+describe("listAccounts", () => {
+  it("returns [] when accounts dir is missing", () => {
+    expect(listAccounts(home)).toEqual([]);
+  });
+
+  it("returns sorted list of subdirectories", () => {
+    writeAccountCredentials("zeta", { claudeAiOauth: { accessToken: "x" } }, home);
+    writeAccountCredentials("alpha", { claudeAiOauth: { accessToken: "y" } }, home);
+    writeAccountCredentials("mu", { claudeAiOauth: { accessToken: "z" } }, home);
+    expect(listAccounts(home)).toEqual(["alpha", "mu", "zeta"]);
+  });
+
+  it("ignores stray files in the accounts root", () => {
+    writeAccountCredentials("real", { claudeAiOauth: { accessToken: "x" } }, home);
+    writeFileSync(
+      resolve(accountsRoot(home), "stray.txt"),
+      "not an account\n",
+    );
+    expect(listAccounts(home)).toEqual(["real"]);
+  });
+});
+
+describe("credentials roundtrip", () => {
+  it("write then read returns the same shape", () => {
+    const creds: AccountCredentials = {
+      claudeAiOauth: {
+        accessToken: "sk-ant-oat01-aaaa",
+        refreshToken: "sk-ant-ort01-bbbb",
+        expiresAt: 1_700_000_000_000,
+        scopes: ["user:inference"],
+        subscriptionType: "max",
+      },
+    };
+    writeAccountCredentials("work-pro", creds, home);
+    expect(readAccountCredentials("work-pro", home)).toEqual(creds);
+    expect(accountExists("work-pro", home)).toBe(true);
+  });
+
+  it("returns null when credentials are absent", () => {
+    expect(readAccountCredentials("nope", home)).toBeNull();
+    expect(accountExists("nope", home)).toBe(false);
+  });
+
+  it("returns null when credentials are malformed JSON", () => {
+    mkdirSync(accountDir("broken", home), { recursive: true });
+    writeFileSync(accountCredentialsPath("broken", home), "{ not: json");
+    expect(readAccountCredentials("broken", home)).toBeNull();
+  });
+});
+
+describe("meta roundtrip + patch", () => {
+  it("write then read returns the same shape", () => {
+    writeAccountMeta(
+      "work-pro",
+      {
+        createdAt: 1000,
+        email: "ken@example.com",
+        subscriptionType: "max",
+        lastRefreshedAt: 2000,
+      },
+      home,
+    );
+    expect(readAccountMeta("work-pro", home)).toEqual({
+      createdAt: 1000,
+      email: "ken@example.com",
+      subscriptionType: "max",
+      lastRefreshedAt: 2000,
+    });
+  });
+
+  it("patchAccountMeta merges fields, preserving the rest", () => {
+    writeAccountMeta(
+      "work-pro",
+      { createdAt: 1000, email: "ken@example.com" },
+      home,
+    );
+    patchAccountMeta(
+      "work-pro",
+      { lastRefreshedAt: 9999, quotaExhaustedUntil: 8888 },
+      home,
+    );
+    expect(readAccountMeta("work-pro", home)).toEqual({
+      createdAt: 1000,
+      email: "ken@example.com",
+      lastRefreshedAt: 9999,
+      quotaExhaustedUntil: 8888,
+    });
+  });
+
+  it("patchAccountMeta on a missing meta synthesises createdAt", () => {
+    patchAccountMeta("fresh", { email: "x@y.z" }, home);
+    const meta = readAccountMeta("fresh", home);
+    expect(meta?.email).toBe("x@y.z");
+    expect(typeof meta?.createdAt).toBe("number");
+  });
+});
+
+describe("accountHealth", () => {
+  const NOW = 1_700_000_000_000;
+
+  it("returns missing-credentials when no token file", () => {
+    expect(accountHealth("ghost", NOW, home)).toBe("missing-credentials");
+  });
+
+  it("returns missing-credentials when accessToken is empty", () => {
+    writeAccountCredentials("ghost", { claudeAiOauth: {} }, home);
+    expect(accountHealth("ghost", NOW, home)).toBe("missing-credentials");
+  });
+
+  it("returns healthy when token is fresh and no quota mark", () => {
+    writeAccountCredentials(
+      "live",
+      {
+        claudeAiOauth: {
+          accessToken: "x",
+          refreshToken: "y",
+          expiresAt: NOW + 60 * 60 * 1000,
+        },
+      },
+      home,
+    );
+    expect(accountHealth("live", NOW, home)).toBe("healthy");
+  });
+
+  it("returns quota-exhausted when meta says so", () => {
+    writeAccountCredentials(
+      "live",
+      {
+        claudeAiOauth: {
+          accessToken: "x",
+          refreshToken: "y",
+          expiresAt: NOW + 60 * 60 * 1000,
+        },
+      },
+      home,
+    );
+    writeAccountMeta(
+      "live",
+      { createdAt: NOW, quotaExhaustedUntil: NOW + 30 * 60 * 1000 },
+      home,
+    );
+    expect(accountHealth("live", NOW, home)).toBe("quota-exhausted");
+  });
+
+  it("quota mark in the past does not count as exhausted", () => {
+    writeAccountCredentials(
+      "live",
+      {
+        claudeAiOauth: {
+          accessToken: "x",
+          refreshToken: "y",
+          expiresAt: NOW + 60 * 60 * 1000,
+        },
+      },
+      home,
+    );
+    writeAccountMeta(
+      "live",
+      { createdAt: NOW, quotaExhaustedUntil: NOW - 1 },
+      home,
+    );
+    expect(accountHealth("live", NOW, home)).toBe("healthy");
+  });
+
+  it("returns expired when access token expired and refresh present", () => {
+    writeAccountCredentials(
+      "stale",
+      {
+        claudeAiOauth: {
+          accessToken: "x",
+          refreshToken: "y",
+          expiresAt: NOW - 1,
+        },
+      },
+      home,
+    );
+    expect(accountHealth("stale", NOW, home)).toBe("expired");
+  });
+
+  it("returns missing-refresh-token when expired and no refresh", () => {
+    writeAccountCredentials(
+      "dead",
+      { claudeAiOauth: { accessToken: "x", expiresAt: NOW - 1 } },
+      home,
+    );
+    expect(accountHealth("dead", NOW, home)).toBe("missing-refresh-token");
+  });
+});
+
+describe("getAccountInfos", () => {
+  it("merges credentials + meta into one row per account", () => {
+    const NOW = 1_700_000_000_000;
+    writeAccountCredentials(
+      "work-pro",
+      {
+        claudeAiOauth: {
+          accessToken: "x",
+          refreshToken: "y",
+          expiresAt: NOW + 60 * 60 * 1000,
+          subscriptionType: "max",
+        },
+      },
+      home,
+    );
+    writeAccountMeta(
+      "work-pro",
+      { createdAt: NOW - 1000, email: "ken@example.com", lastRefreshedAt: NOW - 500 },
+      home,
+    );
+    writeAccountCredentials(
+      "personal",
+      { claudeAiOauth: { accessToken: "p" } },
+      home,
+    );
+
+    const infos = getAccountInfos(NOW, home);
+    expect(infos).toHaveLength(2);
+    const work = infos.find((i) => i.label === "work-pro")!;
+    expect(work.health).toBe("healthy");
+    expect(work.email).toBe("ken@example.com");
+    expect(work.subscriptionType).toBe("max");
+    expect(work.lastRefreshedAt).toBe(NOW - 500);
+
+    const personal = infos.find((i) => i.label === "personal")!;
+    // missing expiresAt → not expired path; healthy if accessToken present + no quota
+    expect(personal.health).toBe("healthy");
+    expect(personal.subscriptionType).toBeUndefined();
+  });
+});
+
+describe("removeAccount", () => {
+  it("deletes the account directory", () => {
+    writeAccountCredentials("doomed", { claudeAiOauth: { accessToken: "x" } }, home);
+    writeAccountMeta("doomed", { createdAt: 1 }, home);
+    expect(accountExists("doomed", home)).toBe(true);
+    removeAccount("doomed", home);
+    expect(accountExists("doomed", home)).toBe(false);
+    expect(listAccounts(home)).not.toContain("doomed");
+  });
+
+  it("throws when account does not exist", () => {
+    expect(() => removeAccount("ghost", home)).toThrow(/does not exist/);
+  });
+
+  it("validates the label", () => {
+    expect(() => removeAccount("../etc", home)).toThrow();
+  });
+});
+
+describe("atomic write — no tempfile remnants on success", () => {
+  it("leaves only the destination file in the dir", () => {
+    writeAccountCredentials("clean", { claudeAiOauth: { accessToken: "x" } }, home);
+    writeAccountMeta("clean", { createdAt: 1 }, home);
+    const entries = readdirSync(accountDir("clean", home)).sort();
+    expect(entries).toEqual(["credentials.json", "meta.json"]);
+  });
+});

--- a/tests/auth-accounts-e2e.test.ts
+++ b/tests/auth-accounts-e2e.test.ts
@@ -1,0 +1,276 @@
+/**
+ * End-to-end happy-path: a fresh install, adding two accounts, enabling
+ * each on a different agent, running a refresh tick, and verifying every
+ * consumer (parent claude env-var path AND subprocess credentials.json
+ * fallback) sees the right token for its agent.
+ *
+ * Exercises the four modules the foundation PR introduces, composed:
+ *   - account-store (storage)
+ *   - account-refresh (refresh + fanout)
+ *   - auth-accounts-yaml (YAML editor)
+ *   - schema (auth.accounts field)
+ *
+ * Does NOT spawn a real `claude` subprocess — that would couple the test
+ * to the user's installed claude CLI version. The proof here is that the
+ * files the runtime depends on land in the right places with the right
+ * contents; the runtime's behaviour against those files is covered by
+ * the existing per-agent tests.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { resolve, join } from "node:path";
+import { tmpdir } from "node:os";
+
+import {
+  fanoutAccountToAgents,
+  refreshAllAccounts,
+  type Fetcher,
+} from "../src/auth/account-refresh.js";
+import {
+  accountCredentialsPath,
+  accountExists,
+  getAccountInfos,
+  writeAccountCredentials,
+} from "../src/auth/account-store.js";
+import {
+  appendAccountToAgent,
+  getAccountsForAgent,
+} from "../src/cli/auth-accounts-yaml.js";
+import type { SwitchroomConfig } from "../src/config/schema.js";
+
+let home: string;
+let agentsDir: string;
+let yamlPath: string;
+
+beforeEach(() => {
+  const stamp = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  home = resolve(tmpdir(), `switchroom-acct-e2e-${stamp}`);
+  mkdirSync(home, { recursive: true });
+  agentsDir = resolve(home, "agents");
+  mkdirSync(agentsDir, { recursive: true });
+  // Pre-create the agents the scenario references.
+  for (const name of ["foo", "bar", "baz"]) {
+    mkdirSync(join(agentsDir, name), { recursive: true });
+  }
+  yamlPath = resolve(home, "switchroom.yaml");
+  writeFileSync(
+    yamlPath,
+    [
+      "switchroom:",
+      `  agents_dir: ${JSON.stringify(agentsDir)}`,
+      "telegram:",
+      "  bot_token: vault:telegram/bot",
+      "agents:",
+      "  foo:",
+      "    topic_name: Foo",
+      "  bar:",
+      "    topic_name: Bar",
+      "  baz:",
+      "    topic_name: Baz",
+      "",
+    ].join("\n"),
+  );
+});
+
+afterEach(() => {
+  rmSync(home, { recursive: true, force: true });
+});
+
+const NOW = 1_700_000_000_000;
+
+describe("end-to-end: two accounts, three agents, one tick", () => {
+  it("delivers the right credentials to each consumer path", async () => {
+    // 1. Operator runs `auth account add work-pro --from-credentials <path>`
+    //    (simulated here via direct write — the CLI wrapper just routes to
+    //    writeAccountCredentials).
+    writeAccountCredentials(
+      "work-pro",
+      {
+        claudeAiOauth: {
+          accessToken: "work-token",
+          refreshToken: "work-refresh",
+          expiresAt: NOW + 4 * 60 * 60 * 1000, // 4h — well above the 1h refresh threshold
+          subscriptionType: "max",
+        },
+      },
+      home,
+    );
+    writeAccountCredentials(
+      "personal",
+      {
+        claudeAiOauth: {
+          accessToken: "personal-token",
+          refreshToken: "personal-refresh",
+          expiresAt: NOW + 4 * 60 * 60 * 1000,
+          subscriptionType: "pro",
+        },
+      },
+      home,
+    );
+    expect(accountExists("work-pro", home)).toBe(true);
+    expect(accountExists("personal", home)).toBe(true);
+
+    // 2. Operator runs `auth enable work-pro foo bar` and
+    //    `auth enable personal baz` (simulated via YAML helpers + immediate
+    //    fanout, mirroring the CLI's behaviour).
+    let yaml = readFileSync(yamlPath, "utf-8");
+    yaml = appendAccountToAgent(yaml, "foo", "work-pro");
+    yaml = appendAccountToAgent(yaml, "bar", "work-pro");
+    yaml = appendAccountToAgent(yaml, "baz", "personal");
+    writeFileSync(yamlPath, yaml);
+
+    expect(getAccountsForAgent(yaml, "foo")).toEqual(["work-pro"]);
+    expect(getAccountsForAgent(yaml, "bar")).toEqual(["work-pro"]);
+    expect(getAccountsForAgent(yaml, "baz")).toEqual(["personal"]);
+
+    // Immediate fanout (the CLI does this without waiting for the refresh tick).
+    fanoutAccountToAgents(
+      "work-pro",
+      [
+        { name: "foo", agentDir: join(agentsDir, "foo") },
+        { name: "bar", agentDir: join(agentsDir, "bar") },
+      ],
+      { home },
+    );
+    fanoutAccountToAgents(
+      "personal",
+      [{ name: "baz", agentDir: join(agentsDir, "baz") }],
+      { home },
+    );
+
+    // 3. The cron tick runs (simulated via refreshAllAccounts on a config
+    //    that mirrors the in-memory state).
+    const config = {
+      switchroom: { agents_dir: agentsDir },
+      agents: {
+        foo: { auth: { accounts: ["work-pro"] } },
+        bar: { auth: { accounts: ["work-pro"] } },
+        baz: { auth: { accounts: ["personal"] } },
+      },
+    } as unknown as SwitchroomConfig;
+    const summary = await refreshAllAccounts(config, { now: () => NOW, home });
+
+    // Both accounts had plenty of life left → skipped-fresh.
+    expect(summary.counts.refreshed).toBe(0);
+    expect(summary.counts.skippedFresh).toBe(2);
+    // Fanout always runs — three agents, three fanouts.
+    expect(summary.counts.fannedOut).toBe(3);
+
+    // 4. Verify each agent dir has the right files (parent env-var path
+    //    AND subprocess credentials.json fallback).
+    const fooCreds = JSON.parse(
+      readFileSync(join(agentsDir, "foo", ".claude", "credentials.json"), "utf-8"),
+    );
+    const barCreds = JSON.parse(
+      readFileSync(join(agentsDir, "bar", ".claude", "credentials.json"), "utf-8"),
+    );
+    const bazCreds = JSON.parse(
+      readFileSync(join(agentsDir, "baz", ".claude", "credentials.json"), "utf-8"),
+    );
+
+    expect(fooCreds.claudeAiOauth.accessToken).toBe("work-token");
+    expect(barCreds.claudeAiOauth.accessToken).toBe("work-token");
+    expect(bazCreds.claudeAiOauth.accessToken).toBe("personal-token");
+
+    // Legacy .oauth-token mirror (for start.sh env-var injection) matches
+    // the access token in credentials.json, per agent.
+    expect(
+      readFileSync(join(agentsDir, "foo", ".claude", ".oauth-token"), "utf-8").trim(),
+    ).toBe("work-token");
+    expect(
+      readFileSync(join(agentsDir, "bar", ".claude", ".oauth-token"), "utf-8").trim(),
+    ).toBe("work-token");
+    expect(
+      readFileSync(join(agentsDir, "baz", ".claude", ".oauth-token"), "utf-8").trim(),
+    ).toBe("personal-token");
+
+    // Per-agent .oauth-token vs .credentials.json access token agree —
+    // this is the property that closes the parent/subprocess split-brain
+    // class of bugs.
+    for (const agent of ["foo", "bar", "baz"]) {
+      const envVarToken = readFileSync(
+        join(agentsDir, agent, ".claude", ".oauth-token"),
+        "utf-8",
+      ).trim();
+      const fileToken = JSON.parse(
+        readFileSync(join(agentsDir, agent, ".claude", "credentials.json"), "utf-8"),
+      ).claudeAiOauth.accessToken;
+      expect(envVarToken).toBe(fileToken);
+    }
+
+    // 5. Operator's view from `auth account list` reflects the fleet.
+    const infos = getAccountInfos(NOW, home);
+    expect(infos.find((i) => i.label === "work-pro")?.subscriptionType).toBe(
+      "max",
+    );
+    expect(infos.find((i) => i.label === "personal")?.subscriptionType).toBe(
+      "pro",
+    );
+  });
+
+  it("propagates a refresh: new token reaches every enabled agent in one tick", async () => {
+    writeAccountCredentials(
+      "shared",
+      {
+        claudeAiOauth: {
+          accessToken: "old",
+          refreshToken: "r",
+          expiresAt: NOW + 5 * 60 * 1000, // expiring soon → triggers refresh
+        },
+      },
+      home,
+    );
+
+    // Wire two agents to the same account.
+    let yaml = readFileSync(yamlPath, "utf-8");
+    yaml = appendAccountToAgent(yaml, "foo", "shared");
+    yaml = appendAccountToAgent(yaml, "bar", "shared");
+    writeFileSync(yamlPath, yaml);
+
+    const config = {
+      switchroom: { agents_dir: agentsDir },
+      agents: {
+        foo: { auth: { accounts: ["shared"] } },
+        bar: { auth: { accounts: ["shared"] } },
+      },
+    } as unknown as SwitchroomConfig;
+
+    const fetcher: Fetcher = async () => ({
+      ok: true,
+      status: 200,
+      text: async () =>
+        JSON.stringify({
+          access_token: "shiny-new",
+          refresh_token: "shiny-refresh",
+          expires_in: 28800,
+        }),
+    });
+
+    const summary = await refreshAllAccounts(config, {
+      now: () => NOW,
+      home,
+      fetcher,
+    });
+    expect(summary.counts.refreshed).toBe(1);
+    expect(summary.counts.fannedOut).toBe(2);
+
+    // One Anthropic POST; both agents received the new token.
+    for (const agent of ["foo", "bar"]) {
+      const tok = JSON.parse(
+        readFileSync(
+          join(agentsDir, agent, ".claude", "credentials.json"),
+          "utf-8",
+        ),
+      ).claudeAiOauth.accessToken;
+      expect(tok).toBe("shiny-new");
+    }
+
+    // The global account file is the source of truth.
+    const globalContent = readFileSync(
+      accountCredentialsPath("shared", home),
+      "utf-8",
+    );
+    expect(JSON.parse(globalContent).claudeAiOauth.accessToken).toBe("shiny-new");
+  });
+});

--- a/tests/auth-accounts-yaml.test.ts
+++ b/tests/auth-accounts-yaml.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect } from "vitest";
+import {
+  appendAccountToAgent,
+  getAccountsForAgent,
+  removeAccountFromAgent,
+} from "../src/cli/auth-accounts-yaml.js";
+
+const baseYaml = `
+version: 1
+telegram:
+  bot_token: vault:telegram/bot
+agents:
+  foo:
+    topic_name: Foo
+  bar:
+    topic_name: Bar
+    auth:
+      accounts: [personal]
+`;
+
+describe("appendAccountToAgent", () => {
+  it("creates auth.accounts when absent", () => {
+    const out = appendAccountToAgent(baseYaml, "foo", "work-pro");
+    expect(getAccountsForAgent(out, "foo")).toEqual(["work-pro"]);
+  });
+
+  it("appends to existing list", () => {
+    const out = appendAccountToAgent(baseYaml, "bar", "work-pro");
+    expect(getAccountsForAgent(out, "bar")).toEqual(["personal", "work-pro"]);
+  });
+
+  it("is idempotent", () => {
+    const once = appendAccountToAgent(baseYaml, "bar", "personal");
+    expect(once).toBe(baseYaml);
+  });
+
+  it("throws when agent does not exist", () => {
+    expect(() => appendAccountToAgent(baseYaml, "ghost", "x")).toThrow(/not declared/);
+  });
+
+  it("preserves comments and unrelated structure", () => {
+    const yamlWithComment = `
+# top-level comment
+version: 1
+telegram:
+  bot_token: vault:telegram/bot   # the bot
+agents:
+  foo:
+    topic_name: Foo
+`;
+    const out = appendAccountToAgent(yamlWithComment, "foo", "work-pro");
+    expect(out).toContain("# top-level comment");
+    expect(out).toContain("# the bot");
+    expect(getAccountsForAgent(out, "foo")).toEqual(["work-pro"]);
+  });
+});
+
+describe("removeAccountFromAgent", () => {
+  it("removes a label from the list", () => {
+    const yaml = `
+agents:
+  foo:
+    topic_name: Foo
+    auth:
+      accounts: [a, b, c]
+`;
+    const out = removeAccountFromAgent(yaml, "foo", "b");
+    expect(getAccountsForAgent(out, "foo")).toEqual(["a", "c"]);
+  });
+
+  it("no-op when label is absent", () => {
+    const yaml = `
+agents:
+  foo:
+    topic_name: Foo
+    auth:
+      accounts: [a]
+`;
+    expect(removeAccountFromAgent(yaml, "foo", "missing")).toBe(yaml);
+  });
+
+  it("prunes empty parents when last account removed", () => {
+    const yaml = `
+agents:
+  foo:
+    topic_name: Foo
+    auth:
+      accounts: [only]
+`;
+    const out = removeAccountFromAgent(yaml, "foo", "only");
+    expect(out).not.toMatch(/auth:/);
+    expect(out).not.toMatch(/accounts:/);
+    expect(getAccountsForAgent(out, "foo")).toEqual([]);
+  });
+
+  it("no-op when agent does not exist", () => {
+    const yaml = `agents:\n  foo:\n    topic_name: Foo\n`;
+    expect(removeAccountFromAgent(yaml, "ghost", "x")).toBe(yaml);
+  });
+});
+
+describe("getAccountsForAgent", () => {
+  it("reads a present list", () => {
+    expect(getAccountsForAgent(baseYaml, "bar")).toEqual(["personal"]);
+  });
+  it("returns [] when auth missing", () => {
+    expect(getAccountsForAgent(baseYaml, "foo")).toEqual([]);
+  });
+  it("returns [] when agent missing", () => {
+    expect(getAccountsForAgent(baseYaml, "ghost")).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Introduces the **account-as-unit** auth model designed in
[`reference/share-auth-across-the-fleet.md`](https://github.com/switchroom/switchroom/blob/main/reference/share-auth-across-the-fleet.md).
One `claude setup-token` per Anthropic account → enable that account on
N agents → one OAuth refresh per account regardless of fleet size.
Quota state, fanout, and per-agent fallback all hang off the account.

This is the **foundation** PR. It is **strictly additive** — the
existing per-agent slot-pool model stays in place. After this lands,
operators can move agents onto the new model at their own pace, then a
follow-up PR removes the legacy code paths once the user's fleet is
fully migrated.

## What ships

### Storage (`src/auth/account-store.ts`)
Global Anthropic-account credentials at `~/.switchroom/accounts/<label>/`.
Atomic read/write, label validation, health derivation
(healthy/quota-exhausted/expired/missing-refresh-token).

### Refresh + fanout (`src/auth/account-refresh.ts`)
- Refreshes each account's token via Anthropic OAuth at most once per
  tick (was: once per agent → N wasted refreshes for one shared account).
- Fans out the refreshed credentials.json to every enabled agent's
  `<agentDir>/.claude/`. Bit-identical bytes; atomic writes.
- **Crucially writes the legacy `.oauth-token` mirror too** so the
  existing `start.sh` `CLAUDE_CODE_OAUTH_TOKEN` env injection picks up
  the new token alongside the credentials.json fallback path. Without
  this, parent claude (env var) and subprocesses (file fallback) would
  drift onto different tokens during the transition.

### Schema (`src/config/schema.ts`)
New optional `agents.<name>.auth.accounts: [string]` — ordered list,
first non-quota-exhausted account is active, subsequent are auto-fallback
targets.

### CLI verbs (`src/cli/auth-accounts.ts`, `src/cli/auth-accounts-yaml.ts`)
```sh
switchroom auth account add <label> --from-agent <name>
switchroom auth account add <label> --from-credentials <path>
switchroom auth account list
switchroom auth account rm <label>            # refused while any agent is enabled
switchroom auth enable <label> <agents...>    # YAML mutation + immediate fanout
switchroom auth disable <label> <agents...>   # refused if it would empty an agent
switchroom auth refresh-accounts [--json]     # cron entrypoint
```

YAML mutation uses `parseDocument` so comments/formatting outside the
edited path survive (same pattern as `telegram-yaml.ts` from #619).

## Design contract

- **Outcome served**: *Subscription-honest* (primary), *Multi-agent fleet* (secondary)
- **Docs test**: ✅ — verbs are intuitive, every error message names the next command, `--help` is comprehensive
- **Defaults test**: ⚠️ partial — foundation requires `--from-agent` or `--from-credentials`; interactive `claude setup-token` integration deferred to a later PR. The acknowledged scope cut is documented in the design doc (decision #12).
- **Consistency test**: ✅ — verb-noun shape mirrors `vault put` / `telegram enable`; YAML editor shape matches `telegram-yaml.ts`; refresh-tick ergonomics mirror `auth refresh-tick`; `withConfigError`/`getConfig`/`getConfigPath` reuse

## Explicitly deferred to follow-up PRs

These were discussed and intentionally cut from the foundation:

1. **Drop `CLAUDE_CODE_OAUTH_TOKEN` env injection** in `start.sh` (the
   foundation keeps it; legacy mirror writes ensure it stays consistent).
2. **Drop the per-agent slot pool** entirely (storage at
   `<agentDir>/.claude/accounts/<slot>/`).
3. **Auth-broker daemon** (long-running process + Unix-socket IPC for
   ephemeral one-shot consumers). Foundation runs as a cron tick.
4. **Auto-fallback rewrite** to be account-aware (still slot-aware
   today; works because legacy mirror is updated by fanout).
5. **Telegram `/auth` verb shape** to be account-shaped (still
   slot-shaped today).
6. **Migration command** (per user request — no migration ships;
   operators move local fleets manually using the new verbs).

## Test plan

- [x] `npm run lint` clean
- [x] `npm run test:vitest` — 4,672 passed (62 new tests across 4 new
      files, no existing test regressed)
- [x] `npm run test:bun` — 422 passed (20 pre-existing vault-broker
      integration failures, unrelated to this PR; confirmed by stashing
      this PR and re-running with the same failure count)
- [x] Manual smoke: created two agents, added an account from a
      credentials file, enabled on both agents, verified
      credentials.json + `.oauth-token` mirror landed in each agent's
      `.claude/`, verified refusal cases (rm-while-enabled,
      disable-last-account, duplicate add, unknown agent)
- [ ] Operator: deploy this PR, then patch your local fleet manually
      using `switchroom auth account add --from-agent` for each existing
      agent, `switchroom auth enable` to wire each agent to its
      account(s), then run `switchroom auth refresh-accounts` once to
      confirm the broker tick is healthy

🤖 Generated with [Claude Code](https://claude.com/claude-code)