### PR TITLE
feat(progress-card): per-agent card foundations — composite-key pin manager + render template

### DIFF
--- a/telegram-plugin/active-pins.ts
+++ b/telegram-plugin/active-pins.ts
@@ -28,6 +28,13 @@ export interface ActivePin {
   messageId: number;
   turnKey: string;
   pinnedAt: number;
+  /**
+   * Per-agent identity for the pin. Optional in the on-disk shape so
+   * sidecars written before per-agent cards (#per-agent-cards) still
+   * parse cleanly — readers should treat a missing field as the parent
+   * sentinel (`__parent__`).
+   */
+  agentId?: string;
 }
 
 function pinsPath(agentDir: string): string {
@@ -67,7 +74,11 @@ export function readActivePins(agentDir: string): ActivePin[] {
       typeof (item as ActivePin).turnKey === "string" &&
       typeof (item as ActivePin).pinnedAt === "number"
     ) {
-      out.push(item as ActivePin);
+      const aid = (item as ActivePin).agentId;
+      const entry: ActivePin = aid != null && typeof aid === "string"
+        ? (item as ActivePin)
+        : { ...(item as ActivePin), agentId: undefined };
+      out.push(entry);
     }
   }
   return out;

--- a/telegram-plugin/progress-card-pin-manager.ts
+++ b/telegram-plugin/progress-card-pin-manager.ts
@@ -12,24 +12,47 @@
  * progress-card-pin-manager.test.ts):
  *
  *   considerPin(candidate)
- *     - On `isFirstEmit === true` for a turnKey not yet pinned:
+ *     - On `isFirstEmit === true` for a (turnKey, agentId) pair not yet
+ *       pinned:
  *         records the pinned message id
  *         records an active-pin sidecar entry (if addPin is wired)
  *         calls bot.pin(chatId, messageId, { disable_notification: true })
  *         on pin rejection: calls removePin to keep the sidecar consistent
- *     - On subsequent emits for the same turnKey: no-op (idempotent).
+ *     - On subsequent emits for the same (turnKey, agentId): no-op
+ *       (idempotent).
  *
- *   completeTurn({ chatId, threadId, turnKey })
- *     - Looks up pinnedMessageId for turnKey; if present:
+ *   completeTurn({ chatId, threadId, turnKey, agentId? })
+ *     - Looks up pinnedMessageId for (turnKey, agentId); if present:
  *         unpins exactly once (duplicate completeTurn calls are safe)
  *         calls removePin to clear the sidecar
- *     - The unpinnedTurnKeys set is cleared on completeTurn so a future
- *       re-use of the same key (unlikely but cheap) starts fresh.
+ *     - The unpinned set entry is cleared so a future re-use of the same
+ *       composite key (unlikely but cheap) starts fresh.
+ *
+ *   completeAllForTurn({ turnKey })
+ *     - Catastrophic-cleanup helper. Unpins every pinned card for a turn,
+ *       across all agentIds. Used on bridge-disconnect / forced shutdown
+ *       paths where individual sub_agent_turn_end events may never land.
  *
  *   unpinForChat(chatId, threadId)
  *     - External hook for context-exhaustion / /restart: unpins every
- *       currently-pinned turn matching the chat+thread prefix.
+ *       currently-pinned (turnKey, agentId) matching the chat+thread
+ *       prefix.
+ *
+ * Per-agent cards (#per-agent-cards): the manager keys pin state on the
+ * composite (turnKey, agentId) so a parent card and its sub-agent cards
+ * can co-exist independently in the same turn. Callers that don't yet
+ * thread agentId through (e.g. legacy single-card-per-turn callers) get
+ * a stable default sentinel — see `PARENT_AGENT_ID` below — so existing
+ * behaviour is preserved without modification.
  */
+
+/**
+ * Sentinel agent id for the "parent" / single-card-per-turn case. Used
+ * as the default when callers don't yet pass an explicit agentId, so the
+ * composite-key bookkeeping degrades to the original turnKey-only
+ * behaviour for legacy call sites.
+ */
+export const PARENT_AGENT_ID = '__parent__'
 
 export interface PinCandidate {
   readonly chatId: string
@@ -37,6 +60,12 @@ export interface PinCandidate {
   readonly turnKey: string
   readonly messageId: number
   readonly isFirstEmit: boolean
+  /**
+   * Per-agent identity. Defaults to {@link PARENT_AGENT_ID} when omitted
+   * — callers that haven't yet been threaded for per-agent cards behave
+   * as before (one pin per turnKey).
+   */
+  readonly agentId?: string
 }
 
 export interface ActivePinEntry {
@@ -44,6 +73,12 @@ export interface ActivePinEntry {
   readonly messageId: number
   readonly turnKey: string
   readonly pinnedAt: number
+  /**
+   * Stored verbatim alongside the entry. Existing sidecar files written
+   * before the per-agent split have no agentId; readers should treat a
+   * missing field as {@link PARENT_AGENT_ID}.
+   */
+  readonly agentId?: string
 }
 
 export interface TimerHandle {
@@ -88,15 +123,37 @@ export interface PinManagerDeps {
   scheduleTimer?: (fn: () => void, ms: number) => TimerHandle
 }
 
+export interface CompleteTurnArgs {
+  chatId: string
+  threadId?: string
+  turnKey: string
+  /** Defaults to {@link PARENT_AGENT_ID}. */
+  agentId?: string
+}
+
 export interface PinManager {
   /** Decide whether to pin based on an emit's metadata. Idempotent. */
   considerPin(candidate: PinCandidate): void
-  /** Called from `onTurnComplete` — unpins the turn's pinned card. */
-  completeTurn(args: { chatId: string; threadId?: string; turnKey: string }): void
   /**
-   * External hook. Unpins every currently-pinned turn matching the chat
-   * (and optional thread). Used by context-exhaustion / external
-   * cancellation paths that need to clear all active pins for a chat.
+   * Called from `onTurnComplete` (parent) or from `sub_agent_turn_end`
+   * (per-agent) — unpins the (turnKey, agentId) composite's pinned card.
+   * `agentId` defaults to {@link PARENT_AGENT_ID} for legacy single-card
+   * call sites.
+   */
+  completeTurn(args: CompleteTurnArgs): void
+  /**
+   * Catastrophic-cleanup helper. Unpins every pinned card under a turnKey
+   * — across all agentIds. Used when a parent turn ends without per-agent
+   * sub_agent_turn_end events arriving (bridge disconnect, gateway crash,
+   * forced shutdown). Distinct from `completeTurn`, which targets a single
+   * card.
+   */
+  completeAllForTurn(args: { chatId: string; threadId?: string; turnKey: string }): void
+  /**
+   * External hook. Unpins every currently-pinned (turnKey, agentId)
+   * matching the chat (and optional thread). Used by
+   * context-exhaustion / external cancellation paths that need to clear
+   * all active pins for a chat.
    */
   unpinForChat(chatId: string, threadId: number | undefined): void
   /**
@@ -126,16 +183,37 @@ export interface PinManager {
    * doesn't keep a stale reference. Idempotent.
    */
   untrackExternalPin(chatId: string, messageId: number): void
-  /** Test-only: snapshot the currently-pinned turnKeys. */
+  /**
+   * Test-only: snapshot the unique turnKeys that currently have at
+   * least one pinned card. With per-agent cards this may collapse
+   * multiple composite entries down to a single turnKey.
+   */
   pinnedTurnKeys(): ReadonlyArray<string>
-  /** Test-only: look up the pinned message id for a turnKey. */
-  pinnedMessageId(turnKey: string): number | undefined
+  /**
+   * Test-only: snapshot the agentIds currently pinned under a turnKey.
+   * Empty array when nothing is pinned for that turn.
+   */
+  pinnedAgentIds(turnKey: string): ReadonlyArray<string>
+  /**
+   * Test-only: look up the pinned message id for a (turnKey, agentId).
+   * `agentId` defaults to {@link PARENT_AGENT_ID} for backward compat.
+   */
+  pinnedMessageId(turnKey: string, agentId?: string): number | undefined
   /**
    * Test hook to await all in-flight pin/unpin promises. Production
    * callers don't need this; tests can call it to drain the fire-and-
    * forget `.catch()` chains before asserting on side effects.
    */
   drainInFlight(): Promise<void>
+}
+
+/**
+ * Composite key for the per-agent pin maps. Uses a `::` separator that
+ * cannot appear in a turnKey (which is `${chatId}:${threadId}:${seq}`)
+ * or in any agentId (JSONL filename stems are slug-safe).
+ */
+function pinKey(turnKey: string, agentId: string): string {
+  return `${turnKey}::${agentId}`
 }
 
 export function createPinManager(deps: PinManagerDeps): PinManager {
@@ -149,22 +227,21 @@ export function createPinManager(deps: PinManagerDeps): PinManager {
       return { cancel: () => clearTimeout(t) }
     })
 
-  // Turn -> pinned message id. Populated only after a successful pin
-  // call returns; cleared on completeTurn.
+  // (turnKey, agentId) -> pinned message id. Populated only after a
+  // successful pin call returns; cleared on completeTurn for that
+  // composite.
   const pinned = new Map<string, number>()
-  // Turn -> pending pin state. Holds the candidate + timer handle while
-  // we wait pinDelayMs before actually calling the Telegram pin API. If
-  // completeTurn fires before the timer, we cancel and never pin — fast
-  // turns stay silent. Removed when the timer fires (moved to `pinned`)
-  // or when completeTurn cancels it.
+  // (turnKey, agentId) -> pending pin state. Holds the candidate +
+  // timer handle while we wait pinDelayMs before actually calling the
+  // Telegram pin API. If completeTurn fires before the timer, we cancel
+  // and never pin — fast turns stay silent. Removed when the timer
+  // fires (moved to `pinned`) or when completeTurn cancels it.
   const pendingPins = new Map<
     string,
-    { chatId: string; messageId: number; timer: TimerHandle }
+    { chatId: string; messageId: number; turnKey: string; agentId: string; timer: TimerHandle }
   >()
-  // Turns whose unpin has already fired. Guards against duplicate
-  // completeTurn calls causing a second unpin (the gateway fires
-  // onTurnComplete exactly once today, but the reducer's zombie path
-  // can also land on the same turnKey).
+  // Composite keys whose unpin has already fired. Guards against
+  // duplicate completeTurn calls causing a second unpin.
   const unpinned = new Set<string>()
   // `${chatId}:${pinnedMessageId}` -> service-message id. Populated when
   // the grammY `pinned_message` update handler forwards the wrapper
@@ -205,26 +282,27 @@ export function createPinManager(deps: PinManagerDeps): PinManager {
     )
   }
 
-  function doUnpin(turnKey: string, chatId: string, pinnedId: number): void {
-    if (unpinned.has(turnKey)) return
-    unpinned.add(turnKey)
-    log(`telegram gateway: progress-card: unpin turnKey=${turnKey} msgId=${pinnedId}\n`)
-    pinned.delete(turnKey)
-    const key = serviceKey(chatId, pinnedId)
-    const svcId = serviceMessages.get(key)
+  function doUnpin(turnKey: string, agentId: string, chatId: string, pinnedId: number): void {
+    const key = pinKey(turnKey, agentId)
+    if (unpinned.has(key)) return
+    unpinned.add(key)
+    log(`telegram gateway: progress-card: unpin turnKey=${turnKey} agentId=${agentId} msgId=${pinnedId}\n`)
+    pinned.delete(key)
+    const svcKey = serviceKey(chatId, pinnedId)
+    const svcId = serviceMessages.get(svcKey)
     if (svcId != null) {
-      serviceMessages.delete(key)
+      serviceMessages.delete(svcKey)
       deleteServiceMessage(chatId, svcId)
     }
     const unpinStart = now()
     const p = deps.unpin(chatId, pinnedId)
       .then(() => {
         const ms = now() - unpinStart
-        log(`telegram gateway: progress-card: unpin OK turnKey=${turnKey} msgId=${pinnedId} durationMs=${ms}\n`)
+        log(`telegram gateway: progress-card: unpin OK turnKey=${turnKey} agentId=${agentId} msgId=${pinnedId} durationMs=${ms}\n`)
       })
       .catch((err: Error) => {
         const ms = now() - unpinStart
-        log(`telegram gateway: progress-card unpin failed turnKey=${turnKey} msgId=${pinnedId} durationMs=${ms} error="${err?.message ?? err}"\n`)
+        log(`telegram gateway: progress-card unpin failed turnKey=${turnKey} agentId=${agentId} msgId=${pinnedId} durationMs=${ms} error="${err?.message ?? err}"\n`)
       })
       .finally(() => {
         // Keep the sidecar consistent whether the API call succeeded
@@ -236,36 +314,38 @@ export function createPinManager(deps: PinManagerDeps): PinManager {
     track(p)
   }
 
-  function firePin(turnKey: string, chatId: string, messageId: number): void {
+  function firePin(turnKey: string, agentId: string, chatId: string, messageId: number): void {
     // Called when the pin-delay timer fires. Promote from pendingPins
     // into pinned, then issue the Telegram pin API call.
-    pendingPins.delete(turnKey)
-    if (pinned.has(turnKey) || unpinned.has(turnKey)) {
+    const key = pinKey(turnKey, agentId)
+    pendingPins.delete(key)
+    if (pinned.has(key) || unpinned.has(key)) {
       // Either we already pinned (shouldn't happen — timer is the only
       // path that sets `pinned`) or the turn completed between scheduling
       // and firing and the pending entry was cleared elsewhere. Bail.
       return
     }
-    pinned.set(turnKey, messageId)
-    log(`telegram gateway: progress-card: pinned turnKey=${turnKey} msgId=${messageId}\n`)
+    pinned.set(key, messageId)
+    log(`telegram gateway: progress-card: pinned turnKey=${turnKey} agentId=${agentId} msgId=${messageId}\n`)
     if (deps.addPin) {
       deps.addPin({
         chatId,
         messageId,
         turnKey,
         pinnedAt: now(),
+        agentId,
       })
     }
     const pinStart = now()
     const p = deps.pin(chatId, messageId, { disable_notification: true })
       .then(() => {
         const ms = now() - pinStart
-        log(`telegram gateway: progress-card: pin OK turnKey=${turnKey} msgId=${messageId} durationMs=${ms}\n`)
+        log(`telegram gateway: progress-card: pin OK turnKey=${turnKey} agentId=${agentId} msgId=${messageId} durationMs=${ms}\n`)
       })
       .catch(
         (err: Error) => {
           const ms = now() - pinStart
-          log(`telegram gateway: progress-card pin failed turnKey=${turnKey} msgId=${messageId} durationMs=${ms} error="${err?.message ?? err}"\n`)
+          log(`telegram gateway: progress-card pin failed turnKey=${turnKey} agentId=${agentId} msgId=${messageId} durationMs=${ms} error="${err?.message ?? err}"\n`)
           if (deps.removePin) deps.removePin(chatId, messageId)
         },
       )
@@ -275,8 +355,10 @@ export function createPinManager(deps: PinManagerDeps): PinManager {
   return {
     considerPin(c) {
       if (!c.isFirstEmit) return
-      if (pinned.has(c.turnKey)) return
-      if (pendingPins.has(c.turnKey)) return
+      const agentId = c.agentId ?? PARENT_AGENT_ID
+      const key = pinKey(c.turnKey, agentId)
+      if (pinned.has(key)) return
+      if (pendingPins.has(key)) return
       // Schedule the pin via the injected timer. Fast-turn suppression is
       // owned upstream by the driver's `initialDelayMs` — by the time
       // considerPin sees isFirstEmit=true the card has already been
@@ -284,29 +366,70 @@ export function createPinManager(deps: PinManagerDeps): PinManager {
       // The indirection remains so tests and callers can still override
       // with a positive value if they want a pre-pin visual buffer.
       const timer = scheduleTimer(() => {
-        firePin(c.turnKey, c.chatId, c.messageId)
+        firePin(c.turnKey, agentId, c.chatId, c.messageId)
       }, pinDelayMs)
-      pendingPins.set(c.turnKey, {
+      pendingPins.set(key, {
         chatId: c.chatId,
         messageId: c.messageId,
+        turnKey: c.turnKey,
+        agentId,
         timer,
       })
     },
 
-    completeTurn({ chatId, turnKey }) {
+    completeTurn({ chatId, turnKey, agentId }) {
+      const aid = agentId ?? PARENT_AGENT_ID
+      const key = pinKey(turnKey, aid)
       // Fast-turn path: if the pin is still pending, cancel the timer
       // and we're done — no pin ever landed, no unpin needed.
-      const pending = pendingPins.get(turnKey)
+      const pending = pendingPins.get(key)
       if (pending != null) {
         pending.timer.cancel()
-        pendingPins.delete(turnKey)
+        pendingPins.delete(key)
       }
-      const pinnedId = pinned.get(turnKey)
-      if (pinnedId != null) doUnpin(turnKey, chatId, pinnedId)
-      // Once the turn is complete we never see the same turnKey again
-      // (driver generates a fresh sequence). Clearing the flag keeps
-      // the set from growing unbounded over a long-running gateway.
-      unpinned.delete(turnKey)
+      const pinnedId = pinned.get(key)
+      if (pinnedId != null) doUnpin(turnKey, aid, chatId, pinnedId)
+      // Once the turn is complete we never see the same composite again
+      // (driver generates a fresh sequence for the turn, agentIds are
+      // stable per agent lifetime). Clearing the flag keeps the set from
+      // growing unbounded over a long-running gateway.
+      unpinned.delete(key)
+    },
+
+    completeAllForTurn({ chatId, turnKey }) {
+      // Snapshot composites for this turn before mutating — pendingPins
+      // and pinned will both shrink as we go.
+      const matchingPending: Array<{ key: string; agentId: string }> = []
+      for (const [key, entry] of pendingPins) {
+        if (entry.turnKey === turnKey) matchingPending.push({ key, agentId: entry.agentId })
+      }
+      for (const { key } of matchingPending) {
+        const pending = pendingPins.get(key)
+        if (pending != null) {
+          pending.timer.cancel()
+          pendingPins.delete(key)
+        }
+      }
+      const matchingPinned: Array<{ agentId: string; pinnedId: number }> = []
+      for (const [key, pinnedId] of pinned) {
+        // Composite keys are `${turnKey}::${agentId}` — split on `::`.
+        const sep = key.lastIndexOf('::')
+        if (sep < 0) continue
+        const tk = key.slice(0, sep)
+        if (tk !== turnKey) continue
+        const agentId = key.slice(sep + 2)
+        matchingPinned.push({ agentId, pinnedId })
+      }
+      for (const { agentId, pinnedId } of matchingPinned) {
+        doUnpin(turnKey, agentId, chatId, pinnedId)
+      }
+      // Mirror completeTurn's housekeeping: clear unpinned-set entries
+      // for this turn so a future reuse (unlikely) starts fresh.
+      for (const key of [...unpinned]) {
+        const sep = key.lastIndexOf('::')
+        if (sep < 0) continue
+        if (key.slice(0, sep) === turnKey) unpinned.delete(key)
+      }
     },
 
     unpinForChat(chatId, threadId) {
@@ -314,23 +437,30 @@ export function createPinManager(deps: PinManagerDeps): PinManager {
       // Cancel any pending (not-yet-fired) timers for this chat/thread
       // first — otherwise they'd pin after we thought we cleaned up.
       const pendingMatching: string[] = []
-      for (const [turnKey] of pendingPins) {
-        if (turnKey.startsWith(`${base}:`)) pendingMatching.push(turnKey)
+      for (const [key, entry] of pendingPins) {
+        if (entry.turnKey.startsWith(`${base}:`)) pendingMatching.push(key)
       }
-      for (const turnKey of pendingMatching) {
-        const pending = pendingPins.get(turnKey)
+      for (const key of pendingMatching) {
+        const pending = pendingPins.get(key)
         if (pending != null) {
           pending.timer.cancel()
-          pendingPins.delete(turnKey)
+          pendingPins.delete(key)
         }
       }
-      // Snapshot the keys so doUnpin's map mutation doesn't invalidate
+      // Snapshot the entries so doUnpin's map mutation doesn't invalidate
       // iteration mid-loop.
-      const matching: Array<[string, number]> = []
-      for (const [turnKey, pinnedId] of pinned) {
-        if (turnKey.startsWith(`${base}:`)) matching.push([turnKey, pinnedId])
+      const matching: Array<{ turnKey: string; agentId: string; pinnedId: number }> = []
+      for (const [key, pinnedId] of pinned) {
+        const sep = key.lastIndexOf('::')
+        if (sep < 0) continue
+        const tk = key.slice(0, sep)
+        if (!tk.startsWith(`${base}:`)) continue
+        const agentId = key.slice(sep + 2)
+        matching.push({ turnKey: tk, agentId, pinnedId })
       }
-      for (const [turnKey, pinnedId] of matching) doUnpin(turnKey, chatId, pinnedId)
+      for (const { turnKey, agentId, pinnedId } of matching) {
+        doUnpin(turnKey, agentId, chatId, pinnedId)
+      }
     },
 
     captureServiceMessage({ chatId, pinnedMessageId, serviceMessageId }) {
@@ -369,11 +499,28 @@ export function createPinManager(deps: PinManagerDeps): PinManager {
     },
 
     pinnedTurnKeys() {
-      return [...pinned.keys()]
+      const seen = new Set<string>()
+      for (const key of pinned.keys()) {
+        const sep = key.lastIndexOf('::')
+        if (sep < 0) continue
+        seen.add(key.slice(0, sep))
+      }
+      return [...seen]
     },
 
-    pinnedMessageId(turnKey) {
-      return pinned.get(turnKey)
+    pinnedAgentIds(turnKey) {
+      const out: string[] = []
+      for (const key of pinned.keys()) {
+        const sep = key.lastIndexOf('::')
+        if (sep < 0) continue
+        if (key.slice(0, sep) !== turnKey) continue
+        out.push(key.slice(sep + 2))
+      }
+      return out
+    },
+
+    pinnedMessageId(turnKey, agentId) {
+      return pinned.get(pinKey(turnKey, agentId ?? PARENT_AGENT_ID))
     },
 
     async drainInFlight() {

--- a/telegram-plugin/progress-card.ts
+++ b/telegram-plugin/progress-card.ts
@@ -71,6 +71,29 @@ export interface ChecklistItem {
 export type Stage = 'plan' | 'run' | 'done'
 
 /**
+ * Task-list item, mirroring the Claude Code `TodoWrite` tool's atomic
+ * todo schema. Populated by `tool_use` (or `sub_agent_tool_use`) events
+ * with `toolName === 'TodoWrite'`. Used by the per-agent card render to
+ * draw the ◼ / ◻ / ✔ block under the status row.
+ *
+ * `content` is the imperative subject ("Refactor pin manager"); the
+ * card renders `activeForm` ("Refactoring pin manager") for the
+ * in-progress task and `content` for everything else.
+ *
+ * Token-count, thinking-duration, and the per-task elapsed counter are
+ * intentionally not tracked here — those signals require ingestion
+ * changes (token counts aren't in the JSONL today; thinking is a
+ * boolean) and are deferred to a follow-up.
+ */
+export type TaskState = 'pending' | 'in_progress' | 'completed'
+
+export interface TaskItem {
+  readonly content: string
+  readonly activeForm: string
+  readonly state: TaskState
+}
+
+/**
  * Multi-agent foundation (gated by PROGRESS_CARD_MULTI_AGENT=1):
  *
  * Per-sub-agent state, populated by the new `sub_agent_*` events. Today
@@ -182,6 +205,13 @@ export interface SubAgentState {
    * `sub_agent_turn_end` so the deferred-completion path can proceed.
    */
   readonly lastEventAt?: number
+  /**
+   * TodoWrite-driven task list for the per-agent card render. Atomic
+   * replacement: each `sub_agent_tool_use` with `toolName === 'TodoWrite'`
+   * overwrites the slice with the parsed `input.todos` array. Empty
+   * until the sub-agent calls TodoWrite at least once.
+   */
+  readonly tasks: ReadonlyArray<TaskItem>
 }
 
 /**
@@ -266,6 +296,13 @@ export interface ProgressCardState {
    * to correlate with. Keyed by the parent's `toolUseId`.
    */
   readonly pendingAgentSpawns: ReadonlyMap<string, PendingAgentSpawn>
+  /**
+   * Parent-agent TodoWrite-driven task list for the per-agent card
+   * render. Atomic replacement: each `tool_use` with `toolName ===
+   * 'TodoWrite'` overwrites the slice with the parsed `input.todos`
+   * array. Empty until the parent calls TodoWrite at least once.
+   */
+  readonly tasks: ReadonlyArray<TaskItem>
 }
 
 /**
@@ -300,7 +337,39 @@ export function initialState(): ProgressCardState {
     thinking: false,
     subAgents: new Map(),
     pendingAgentSpawns: new Map(),
+    tasks: [],
   }
+}
+
+/**
+ * Parse a `TodoWrite` tool_use input into a `TaskItem[]`. Returns null
+ * when the input shape doesn't match (no array, malformed entries) so
+ * the caller can leave the existing tasks slice unchanged. Callers
+ * should treat null as "not a recognised TodoWrite payload" rather than
+ * "empty list" — TodoWrite never legitimately fires with no todos
+ * (it's an atomic-replace tool).
+ */
+export function parseTodoWriteInput(
+  input: Record<string, unknown> | undefined,
+): TaskItem[] | null {
+  if (input == null) return null
+  const raw = (input as { todos?: unknown }).todos
+  if (!Array.isArray(raw)) return null
+  const out: TaskItem[] = []
+  for (const item of raw) {
+    if (item == null || typeof item !== 'object') continue
+    const o = item as Record<string, unknown>
+    const content = typeof o.content === 'string' ? o.content : null
+    const activeForm = typeof o.activeForm === 'string' ? o.activeForm : null
+    const status = typeof o.status === 'string' ? o.status : null
+    if (content == null || activeForm == null) continue
+    const state: TaskState =
+      status === 'in_progress' ? 'in_progress'
+        : status === 'completed' ? 'completed'
+          : 'pending'
+    out.push({ content, activeForm, state })
+  }
+  return out
 }
 
 /**
@@ -533,6 +602,17 @@ export function reduce(
         appended.length > ITEM_HISTORY_CAP
           ? appended.slice(appended.length - ITEM_HISTORY_CAP)
           : appended
+      // TodoWrite is the atomic-replace task-list tool — its input.todos
+      // is the canonical task-list state at this point in the turn. Lift
+      // it into a state slice so the per-agent card can render the
+      // ◼ / ◻ / ✔ block. When the input shape doesn't match (older
+      // event shapes, synthetic test events without input) we leave the
+      // existing tasks slice untouched.
+      let tasks = state.tasks
+      if (event.toolName === 'TodoWrite') {
+        const parsed = parseTodoWriteInput(event.input)
+        if (parsed != null) tasks = parsed
+      }
       return {
         ...state,
         items: boundedItems,
@@ -542,6 +622,7 @@ export function reduce(
         pendingAgentSpawns,
         subAgents,
         pendingPreamble: null,
+        tasks,
       }
     }
 
@@ -653,6 +734,7 @@ export function reduce(
         milestoneVersion: 1,
         lastEventAt: now,
         recentCompletedTools: [],
+        tasks: [],
       }
       const subAgents = new Map(state.subAgents)
       subAgents.set(event.agentId, sub)
@@ -732,6 +814,14 @@ export function reduce(
       // sub_agent_text pairs with it; sibling tool_uses in the same
       // assistant message fall back to filename/pattern.
       const preamble = sa.pendingPreamble ?? undefined
+      // Mirror the parent tool_use TodoWrite handling: a sub-agent's
+      // TodoWrite atomically replaces its tasks slice for the per-agent
+      // card render.
+      let tasks = sa.tasks
+      if (event.toolName === 'TodoWrite') {
+        const parsed = parseTodoWriteInput(event.input)
+        if (parsed != null) tasks = parsed
+      }
       const next = new Map(state.subAgents)
       next.set(event.agentId, {
         ...sa,
@@ -749,6 +839,7 @@ export function reduce(
           : sa.currentTool,
         pendingPreamble: null,
         lastEventAt: now,
+        tasks,
       })
       return { ...state, subAgents: next }
     }
@@ -1675,4 +1766,287 @@ export function compactItems(items: ReadonlyArray<ChecklistItem>): RolledItem[] 
   }
   flush()
   return out
+}
+
+// ─── Per-agent card renderer ────────────────────────────────────────────────
+//
+// Each active agent (parent + each sub-agent) gets its own pinned card,
+// driven by a slim CLI-style status row + a TodoWrite-driven task list.
+// The legacy `render()` above stays the single entry point for the
+// parent-card-with-sub-agent-expandables path; `renderAgentCard()` is
+// the per-agent-card path. They co-exist while the driver migration to
+// per-agent cards lands incrementally — see plan §2 / §4.
+
+/**
+ * Braille spinner frames cycled by glyph tick. Same set Claude Code's
+ * own status line uses, so the Telegram pin reads as a faithful
+ * mirror of the CLI experience.
+ */
+export const STATUS_GLYPHS = [
+  '⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏',
+] as const
+
+export const STATUS_GLYPH_DONE = '❄'
+export const STATUS_GLYPH_FAILED = '⛔'
+
+/**
+ * Pick a frame for the spinner. Tick advances per render call by the
+ * driver — never advanced by render itself, so unit tests with frozen
+ * `tick` see deterministic output.
+ */
+export function glyphForTick(tick: number): string {
+  const idx = ((tick % STATUS_GLYPHS.length) + STATUS_GLYPHS.length) % STATUS_GLYPHS.length
+  return STATUS_GLYPHS[idx]
+}
+
+/**
+ * Symbol for a task-list line. Mirrors the CLI's `◼` / `◻` / `✔`
+ * convention that the user explicitly cited as the target experience.
+ */
+export const TASK_SYMBOL: Record<TaskState, string> = {
+  pending: '◻',
+  in_progress: '◼',
+  completed: '✔',
+}
+
+/**
+ * Snapshot a sub-agent's "current activity verb" for the status row.
+ * Falls back through: in-flight tool → most-recent narrative → first
+ * narrative text → description → 'starting'.
+ */
+function subAgentVerb(sa: SubAgentState): string {
+  if (sa.state === 'done') return 'done'
+  if (sa.state === 'failed') return 'failed'
+  if (sa.currentTool) {
+    const { tool, label, humanAuthored } = sa.currentTool
+    if (humanAuthored && label) return label
+    if (label) return `${tool} ${label}`
+    return tool
+  }
+  if (sa.currentNarrative) return sa.currentNarrative
+  if (sa.firstNarrativeText) return sa.firstNarrativeText
+  if (sa.description && sa.description !== '(uncorrelated)') return sa.description
+  return 'starting'
+}
+
+/**
+ * Snapshot the parent agent's "current activity verb" for the status
+ * row. Falls back through: most-recent running item → most-recent
+ * completed item → latest text → 'starting'.
+ */
+function parentVerb(state: ProgressCardState): string {
+  if (state.stage === 'done') return 'done'
+  // Walk items newest first looking for a running tool, else the last
+  // tool we saw fly past.
+  for (let i = state.items.length - 1; i >= 0; i--) {
+    const it = state.items[i]
+    if (it.state === 'running') {
+      if (it.humanAuthored && it.label) return it.label
+      if (it.label) return `${it.tool} ${it.label}`
+      return it.tool
+    }
+  }
+  if (state.items.length > 0) {
+    const last = state.items[state.items.length - 1]
+    if (last.humanAuthored && last.label) return last.label
+    if (last.label) return `${last.tool} ${last.label}`
+    return last.tool
+  }
+  if (state.thinking) return 'thinking'
+  if (state.latestText) {
+    const line = extractNarrativeLabel(state.latestText)
+    if (line) return line
+  }
+  return 'starting'
+}
+
+/**
+ * Pure render input for a single per-agent card. The driver builds one
+ * of these per (turnKey, agentId) on each flush — see `projectAgentSlice`.
+ *
+ * `tokens` and `thinkingMs` are optional placeholders: the JSONL
+ * doesn't expose `usage` today and `thinking` is captured as a boolean
+ * with no start/end timestamps, so the renderer emits `↓?` / `—` until
+ * those signals land in a follow-up.
+ */
+export interface AgentCardRenderInput {
+  /** Card kind. Parent and sub-agents share the same template. */
+  readonly kind: 'parent' | 'sub'
+  /** Stable agent identity (parent's JSONL stem or sub-agent's). */
+  readonly agentId: string
+  /** Headline shown next to "Agent k of n —". */
+  readonly title: string
+  /** Activity verb shown after the spinner glyph. */
+  readonly verb: string
+  /** Terminal state for glyph + header text. */
+  readonly state: ItemState
+  /** Wall-clock ms when this card's clock starts (for elapsed). */
+  readonly startedAt: number
+  /** 1-based position among active cards in the chat+thread. */
+  readonly k: number
+  /** Total active cards in the chat+thread (incl. this one). */
+  readonly n: number
+  /** Glyph rotation tick. Driver bumps; render is deterministic. */
+  readonly glyphTick: number
+  /** Render time, in wall-clock ms. */
+  readonly now: number
+  /** Task-list block. Empty = no block rendered. */
+  readonly tasks: ReadonlyArray<TaskItem>
+  /** Optional cumulative input tokens for the turn. Undefined → `↓?`. */
+  readonly tokens?: number
+  /** Optional cumulative thinking duration in ms. Undefined → `—`. */
+  readonly thinkingMs?: number
+  /** Optional latest narrative line shown below the status row. */
+  readonly narrative?: string
+}
+
+/**
+ * Project a slice of `ProgressCardState` into render input for a given
+ * agent. The parent card reads top-level fields; sub-agent cards pull
+ * from `state.subAgents.get(agentId)`.
+ *
+ * Returns null when the requested agentId isn't present in the state
+ * (e.g. a sub-agent already cleaned up). Callers should drop the card.
+ */
+export function projectAgentSlice(args: {
+  state: ProgressCardState
+  agentId: string
+  /** Distinguishes the parent slice from a sub-agent slice. */
+  kind: 'parent' | 'sub'
+  k: number
+  n: number
+  glyphTick: number
+  now: number
+  /**
+   * Override startedAt for the parent — pass the driver's per-card
+   * clock origin (turn start). For sub-agents, taken from
+   * SubAgentState.startedAt.
+   */
+  parentStartedAt?: number
+}): AgentCardRenderInput | null {
+  const { state, agentId, kind, k, n, glyphTick, now, parentStartedAt } = args
+  if (kind === 'parent') {
+    return {
+      kind: 'parent',
+      agentId,
+      title: 'Main',
+      verb: parentVerb(state),
+      state:
+        state.stage === 'done'
+          ? 'done'
+          : 'running',
+      startedAt: parentStartedAt ?? state.turnStartedAt,
+      k,
+      n,
+      glyphTick,
+      now,
+      tasks: state.tasks,
+      ...(state.latestText ? { narrative: extractNarrativeLabel(state.latestText) } : {}),
+    }
+  }
+  const sa = state.subAgents.get(agentId)
+  if (!sa) return null
+  const title = subAgentDisplayDescription(sa)
+  return {
+    kind: 'sub',
+    agentId,
+    title,
+    verb: subAgentVerb(sa),
+    state: sa.state,
+    startedAt: sa.startedAt,
+    k,
+    n,
+    glyphTick,
+    now,
+    tasks: sa.tasks,
+    ...(sa.currentNarrative
+      ? { narrative: sa.currentNarrative }
+      : sa.firstNarrativeText
+        ? { narrative: sa.firstNarrativeText }
+        : {}),
+  }
+}
+
+/**
+ * Pick the spinner glyph for a card's render frame.
+ */
+function glyphForCard(input: AgentCardRenderInput): string {
+  if (input.state === 'failed') return STATUS_GLYPH_FAILED
+  if (input.state === 'done') return STATUS_GLYPH_DONE
+  return glyphForTick(input.glyphTick)
+}
+
+/**
+ * Format the status row's elapsed segment as `m:ss` (or `s` under 60s).
+ */
+function formatElapsedShort(ms: number): string {
+  const total = Math.max(0, Math.floor(ms / 1000))
+  if (total < 60) return `${total}s`
+  const m = Math.floor(total / 60)
+  const s = total % 60
+  return `${m}:${s.toString().padStart(2, '0')}`
+}
+
+function formatTokensShort(tokens: number): string {
+  if (tokens >= 1_000_000) return `${(tokens / 1_000_000).toFixed(1)}M`
+  if (tokens >= 1_000) return `${(tokens / 1_000).toFixed(1)}k`
+  return `${tokens}`
+}
+
+/**
+ * Render the task-list block (◼/◻/✔). Returns the empty string when
+ * there are no tasks — caller should not insert leading/trailing
+ * whitespace based on this. The block always shows in_progress tasks
+ * first, then pending, then completed (most useful at top).
+ */
+export function renderTaskList(tasks: ReadonlyArray<TaskItem>): string {
+  if (tasks.length === 0) return ''
+  // Stable sort: in_progress, pending, completed. Within each bucket,
+  // preserve TodoWrite's input order — that's the agent's intent.
+  const order: Record<TaskState, number> = { in_progress: 0, pending: 1, completed: 2 }
+  const sorted = [...tasks].sort((a, b) => order[a.state] - order[b.state])
+  const lines = sorted.map((t) => {
+    const sym = TASK_SYMBOL[t.state]
+    // Show `activeForm` for the in-progress line ("Refactoring pin
+    // manager"); use `content` for the others. Strikethrough on
+    // completed items mirrors the CLI experience.
+    const text = t.state === 'in_progress' ? t.activeForm : t.content
+    const safe = escapeHtml(text)
+    if (t.state === 'completed') return `${sym} <s>${safe}</s>`
+    if (t.state === 'in_progress') return `${sym} <b>${safe}</b>`
+    return `${sym} ${safe}`
+  })
+  return lines.join('\n')
+}
+
+/**
+ * Render the per-agent status card body — the CLI-style status row, an
+ * optional narrative line, and the TaskList block.
+ *
+ * Output is HTML for Telegram's `parse_mode=HTML`. Pure: no side
+ * effects, no clock reads (`now` is supplied), no globals.
+ */
+export function renderAgentCard(input: AgentCardRenderInput): string {
+  const glyph = glyphForCard(input)
+  const elapsed = formatElapsedShort(input.now - input.startedAt)
+  const tokens = input.tokens != null
+    ? `↓${formatTokensShort(input.tokens)}`
+    : '↓?'
+  const thinking = input.thinkingMs != null
+    ? `thought ${formatElapsedShort(input.thinkingMs)}`
+    : 'thought —'
+  const verbHtml = escapeHtml(input.verb || 'idle')
+  // Header:  Agent 2 of 4 — research
+  const header = `<b>Agent ${input.k} of ${input.n}</b> — ${escapeHtml(input.title)}`
+  // Status row:  ⠋ <i>verb</i> · 0:42 · ↓? · thought —
+  const statusRow = `${glyph} <i>${verbHtml}</i> · ${elapsed} · ${tokens} · ${thinking}`
+  const out: string[] = [header, statusRow]
+  if (input.narrative) {
+    out.push(`<blockquote>${escapeHtml(input.narrative)}</blockquote>`)
+  }
+  const taskBlock = renderTaskList(input.tasks)
+  if (taskBlock) {
+    out.push(taskBlock)
+  }
+  return out.join('\n')
 }

--- a/telegram-plugin/tests/progress-card-agent-card.test.ts
+++ b/telegram-plugin/tests/progress-card-agent-card.test.ts
@@ -1,0 +1,543 @@
+/**
+ * Pure-function tests for the per-agent card module: TodoWrite parsing,
+ * reducer ingestion, glyph rotation, slice projection, and the render
+ * template. These are the building blocks that the per-agent driver
+ * lifecycle (§2) wires together.
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+  STATUS_GLYPHS,
+  STATUS_GLYPH_DONE,
+  STATUS_GLYPH_FAILED,
+  TASK_SYMBOL,
+  glyphForTick,
+  initialState,
+  parseTodoWriteInput,
+  projectAgentSlice,
+  reduce,
+  renderAgentCard,
+  renderTaskList,
+  type ProgressCardState,
+  type SubAgentState,
+  type TaskItem,
+} from '../progress-card.js'
+import type { SessionEvent } from '../session-tail.js'
+
+const BASE_TIME = 1_700_000_000_000
+
+function enqueue(now = BASE_TIME): SessionEvent {
+  return { kind: 'enqueue', rawContent: '<channel>hello</channel>', messageId: 'm1' } as unknown as SessionEvent
+}
+
+function todoWrite(todos: Array<{ content: string; activeForm: string; status: string }>): SessionEvent {
+  return {
+    kind: 'tool_use',
+    toolName: 'TodoWrite',
+    toolUseId: 'tu_todo',
+    input: { todos },
+  } as SessionEvent
+}
+
+function subStart(agentId: string, parentToolUseId?: string, firstPromptText?: string): SessionEvent {
+  return {
+    kind: 'sub_agent_started',
+    agentId,
+    firstPromptText: firstPromptText ?? 'do thing',
+    subagentType: parentToolUseId ? 'researcher' : undefined,
+  } as unknown as SessionEvent
+}
+
+function subTodoWrite(agentId: string, todos: Array<{ content: string; activeForm: string; status: string }>): SessionEvent {
+  return {
+    kind: 'sub_agent_tool_use',
+    agentId,
+    toolName: 'TodoWrite',
+    toolUseId: 'tu_sub_todo',
+    input: { todos },
+  } as SessionEvent
+}
+
+describe('parseTodoWriteInput', () => {
+  it('parses a well-formed todos array', () => {
+    const out = parseTodoWriteInput({
+      todos: [
+        { content: 'A', activeForm: 'Doing A', status: 'pending' },
+        { content: 'B', activeForm: 'Doing B', status: 'in_progress' },
+        { content: 'C', activeForm: 'Doing C', status: 'completed' },
+      ],
+    })
+    expect(out).toEqual([
+      { content: 'A', activeForm: 'Doing A', state: 'pending' },
+      { content: 'B', activeForm: 'Doing B', state: 'in_progress' },
+      { content: 'C', activeForm: 'Doing C', state: 'completed' },
+    ])
+  })
+
+  it('returns null when input is undefined', () => {
+    expect(parseTodoWriteInput(undefined)).toBeNull()
+  })
+
+  it('returns null when todos field is missing', () => {
+    expect(parseTodoWriteInput({})).toBeNull()
+  })
+
+  it('returns null when todos is not an array', () => {
+    expect(parseTodoWriteInput({ todos: 'nope' as unknown as never[] })).toBeNull()
+  })
+
+  it('drops malformed entries but keeps the rest', () => {
+    const out = parseTodoWriteInput({
+      todos: [
+        { content: 'A', activeForm: 'Doing A', status: 'pending' },
+        { content: 'no activeform', status: 'pending' },
+        { activeForm: 'no content', status: 'pending' },
+        null,
+        'not-an-object',
+        { content: 'B', activeForm: 'Doing B', status: 'in_progress' },
+      ],
+    })
+    expect(out).toEqual([
+      { content: 'A', activeForm: 'Doing A', state: 'pending' },
+      { content: 'B', activeForm: 'Doing B', state: 'in_progress' },
+    ])
+  })
+
+  it('treats unknown status strings as pending', () => {
+    const out = parseTodoWriteInput({
+      todos: [{ content: 'A', activeForm: 'Doing A', status: 'wat' }],
+    })
+    expect(out).toEqual([{ content: 'A', activeForm: 'Doing A', state: 'pending' }])
+  })
+
+  it('returns an empty array when todos is empty (caller decides what to do)', () => {
+    // Distinct from null: empty array is a valid (if unusual) replacement.
+    expect(parseTodoWriteInput({ todos: [] })).toEqual([])
+  })
+})
+
+describe('reducer: TodoWrite ingestion', () => {
+  it('parent TodoWrite atomically replaces ProgressCardState.tasks', () => {
+    let state = initialState()
+    state = reduce(state, enqueue(), BASE_TIME)
+    expect(state.tasks).toEqual([])
+
+    state = reduce(
+      state,
+      todoWrite([
+        { content: 'Refactor', activeForm: 'Refactoring', status: 'in_progress' },
+        { content: 'Wire', activeForm: 'Wiring', status: 'pending' },
+      ]),
+      BASE_TIME + 1000,
+    )
+    expect(state.tasks).toEqual([
+      { content: 'Refactor', activeForm: 'Refactoring', state: 'in_progress' },
+      { content: 'Wire', activeForm: 'Wiring', state: 'pending' },
+    ])
+  })
+
+  it('atomic replace: a second TodoWrite overwrites the slice', () => {
+    let state = initialState()
+    state = reduce(state, enqueue(), BASE_TIME)
+    state = reduce(
+      state,
+      todoWrite([{ content: 'A', activeForm: 'Doing A', status: 'in_progress' }]),
+      BASE_TIME + 1000,
+    )
+    state = reduce(
+      state,
+      todoWrite([
+        { content: 'A', activeForm: 'Doing A', status: 'completed' },
+        { content: 'B', activeForm: 'Doing B', status: 'in_progress' },
+      ]),
+      BASE_TIME + 2000,
+    )
+    expect(state.tasks).toEqual([
+      { content: 'A', activeForm: 'Doing A', state: 'completed' },
+      { content: 'B', activeForm: 'Doing B', state: 'in_progress' },
+    ])
+  })
+
+  it('non-TodoWrite tool_use leaves tasks unchanged', () => {
+    let state = initialState()
+    state = reduce(state, enqueue(), BASE_TIME)
+    state = reduce(
+      state,
+      todoWrite([{ content: 'A', activeForm: 'Doing A', status: 'pending' }]),
+      BASE_TIME + 1000,
+    )
+    const tasksBefore = state.tasks
+    state = reduce(
+      state,
+      { kind: 'tool_use', toolName: 'Bash', toolUseId: 'b1', input: { command: 'ls' } } as SessionEvent,
+      BASE_TIME + 2000,
+    )
+    expect(state.tasks).toBe(tasksBefore)
+  })
+
+  it('sub-agent TodoWrite atomically replaces SubAgentState.tasks', () => {
+    let state = initialState()
+    state = reduce(state, enqueue(), BASE_TIME)
+    state = reduce(state, subStart('sub-1'), BASE_TIME + 500)
+    expect(state.subAgents.get('sub-1')?.tasks).toEqual([])
+
+    state = reduce(
+      state,
+      subTodoWrite('sub-1', [
+        { content: 'A', activeForm: 'Doing A', status: 'in_progress' },
+      ]),
+      BASE_TIME + 1000,
+    )
+    expect(state.subAgents.get('sub-1')?.tasks).toEqual([
+      { content: 'A', activeForm: 'Doing A', state: 'in_progress' },
+    ])
+
+    // Parent's tasks are unaffected.
+    expect(state.tasks).toEqual([])
+  })
+
+  it('parent and sub-agent task slices are independent', () => {
+    let state = initialState()
+    state = reduce(state, enqueue(), BASE_TIME)
+    state = reduce(state, subStart('sub-1'), BASE_TIME + 500)
+
+    state = reduce(
+      state,
+      todoWrite([{ content: 'P', activeForm: 'Doing P', status: 'in_progress' }]),
+      BASE_TIME + 1000,
+    )
+    state = reduce(
+      state,
+      subTodoWrite('sub-1', [{ content: 'S', activeForm: 'Doing S', status: 'pending' }]),
+      BASE_TIME + 2000,
+    )
+
+    expect(state.tasks).toEqual([
+      { content: 'P', activeForm: 'Doing P', state: 'in_progress' },
+    ])
+    expect(state.subAgents.get('sub-1')?.tasks).toEqual([
+      { content: 'S', activeForm: 'Doing S', state: 'pending' },
+    ])
+  })
+})
+
+describe('glyphForTick', () => {
+  it('returns frames in order', () => {
+    expect(glyphForTick(0)).toBe(STATUS_GLYPHS[0])
+    expect(glyphForTick(1)).toBe(STATUS_GLYPHS[1])
+    expect(glyphForTick(STATUS_GLYPHS.length - 1)).toBe(STATUS_GLYPHS[STATUS_GLYPHS.length - 1])
+  })
+
+  it('wraps modulo the frame count', () => {
+    expect(glyphForTick(STATUS_GLYPHS.length)).toBe(STATUS_GLYPHS[0])
+    expect(glyphForTick(STATUS_GLYPHS.length * 7 + 3)).toBe(STATUS_GLYPHS[3])
+  })
+
+  it('handles negative ticks (defensive)', () => {
+    // Driver shouldn't pass negatives, but the math should still land on a valid frame.
+    const out = glyphForTick(-1)
+    expect(STATUS_GLYPHS).toContain(out)
+  })
+})
+
+describe('projectAgentSlice — parent', () => {
+  it('uses turnStartedAt as the elapsed origin by default', () => {
+    let state = initialState()
+    state = reduce(state, enqueue(), BASE_TIME)
+    const slice = projectAgentSlice({
+      state,
+      agentId: '__parent__',
+      kind: 'parent',
+      k: 1,
+      n: 1,
+      glyphTick: 0,
+      now: BASE_TIME + 5000,
+    })
+    expect(slice).not.toBeNull()
+    expect(slice!.kind).toBe('parent')
+    expect(slice!.startedAt).toBe(BASE_TIME)
+    expect(slice!.title).toBe('Main')
+  })
+
+  it('respects parentStartedAt override', () => {
+    let state = initialState()
+    state = reduce(state, enqueue(), BASE_TIME)
+    const slice = projectAgentSlice({
+      state,
+      agentId: '__parent__',
+      kind: 'parent',
+      k: 1,
+      n: 1,
+      glyphTick: 0,
+      now: BASE_TIME + 5000,
+      parentStartedAt: BASE_TIME + 1000,
+    })
+    expect(slice!.startedAt).toBe(BASE_TIME + 1000)
+  })
+
+  it('verb falls back to "starting" before any activity', () => {
+    let state = initialState()
+    state = reduce(state, enqueue(), BASE_TIME)
+    const slice = projectAgentSlice({
+      state,
+      agentId: '__parent__',
+      kind: 'parent',
+      k: 1,
+      n: 1,
+      glyphTick: 0,
+      now: BASE_TIME + 100,
+    })!
+    expect(slice.verb).toBe('starting')
+  })
+
+  it('verb tracks the most recent running tool', () => {
+    let state = initialState()
+    state = reduce(state, enqueue(), BASE_TIME)
+    state = reduce(
+      state,
+      { kind: 'tool_use', toolName: 'Bash', toolUseId: 'b1', input: { description: 'Run tests' } } as SessionEvent,
+      BASE_TIME + 1000,
+    )
+    const slice = projectAgentSlice({
+      state, agentId: '__parent__', kind: 'parent', k: 1, n: 1, glyphTick: 0, now: BASE_TIME + 1500,
+    })!
+    // humanAuthored description path bypasses the tool prefix.
+    expect(slice.verb).toBe('Run tests')
+  })
+
+  it('exposes parent.tasks slice', () => {
+    let state = initialState()
+    state = reduce(state, enqueue(), BASE_TIME)
+    state = reduce(
+      state,
+      todoWrite([{ content: 'A', activeForm: 'Doing A', status: 'in_progress' }]),
+      BASE_TIME + 100,
+    )
+    const slice = projectAgentSlice({
+      state, agentId: '__parent__', kind: 'parent', k: 1, n: 1, glyphTick: 0, now: BASE_TIME + 200,
+    })!
+    expect(slice.tasks).toEqual([
+      { content: 'A', activeForm: 'Doing A', state: 'in_progress' },
+    ])
+  })
+})
+
+describe('projectAgentSlice — sub-agent', () => {
+  it('returns null for an unknown agentId', () => {
+    let state = initialState()
+    state = reduce(state, enqueue(), BASE_TIME)
+    const slice = projectAgentSlice({
+      state, agentId: 'sub-missing', kind: 'sub', k: 2, n: 2, glyphTick: 0, now: BASE_TIME + 500,
+    })
+    expect(slice).toBeNull()
+  })
+
+  it('uses the sub-agent startedAt as elapsed origin', () => {
+    let state = initialState()
+    state = reduce(state, enqueue(), BASE_TIME)
+    state = reduce(state, subStart('sub-1'), BASE_TIME + 1000)
+    const slice = projectAgentSlice({
+      state, agentId: 'sub-1', kind: 'sub', k: 2, n: 2, glyphTick: 5, now: BASE_TIME + 4000,
+    })!
+    expect(slice.kind).toBe('sub')
+    expect(slice.startedAt).toBe(BASE_TIME + 1000)
+    expect(slice.k).toBe(2)
+    expect(slice.n).toBe(2)
+    expect(slice.glyphTick).toBe(5)
+  })
+
+  it('verb tracks current tool, with fallback to narrative + description', () => {
+    let state = initialState()
+    state = reduce(state, enqueue(), BASE_TIME)
+    state = reduce(state, subStart('sub-1'), BASE_TIME + 1000)
+    // No tool yet → fall back to description (set via correlation).
+    let sa = state.subAgents.get('sub-1')!
+    // Manually patch description to assert the fallback chain. Reducer
+    // sets it via correlation; here we synthesise it.
+    state = {
+      ...state,
+      subAgents: new Map([['sub-1', { ...sa, description: 'research' }]]),
+    } as ProgressCardState
+    let slice = projectAgentSlice({
+      state, agentId: 'sub-1', kind: 'sub', k: 1, n: 1, glyphTick: 0, now: BASE_TIME + 1500,
+    })!
+    expect(slice.verb).toBe('research')
+
+    // Then a tool starts → verb tracks the tool label.
+    state = reduce(
+      state,
+      { kind: 'sub_agent_tool_use', agentId: 'sub-1', toolName: 'Read', toolUseId: 'tu_r', input: { file_path: '/foo/bar.ts' } } as SessionEvent,
+      BASE_TIME + 2000,
+    )
+    slice = projectAgentSlice({
+      state, agentId: 'sub-1', kind: 'sub', k: 1, n: 1, glyphTick: 0, now: BASE_TIME + 2100,
+    })!
+    expect(slice.verb).toMatch(/^Read /)
+  })
+})
+
+describe('renderTaskList', () => {
+  it('returns empty string for an empty list', () => {
+    expect(renderTaskList([])).toBe('')
+  })
+
+  it('orders in_progress, pending, completed', () => {
+    const tasks: TaskItem[] = [
+      { content: 'Pending one', activeForm: 'Doing pending one', state: 'pending' },
+      { content: 'Done one', activeForm: 'Doing done one', state: 'completed' },
+      { content: 'Active one', activeForm: 'Doing active one', state: 'in_progress' },
+    ]
+    const out = renderTaskList(tasks)
+    const lines = out.split('\n')
+    expect(lines[0]).toContain(TASK_SYMBOL.in_progress)
+    expect(lines[0]).toContain('<b>Doing active one</b>')
+    expect(lines[1]).toContain(TASK_SYMBOL.pending)
+    expect(lines[1]).toContain('Pending one')
+    expect(lines[2]).toContain(TASK_SYMBOL.completed)
+    expect(lines[2]).toContain('<s>Done one</s>')
+  })
+
+  it('escapes HTML in task text', () => {
+    const out = renderTaskList([
+      { content: '<script>x</script>', activeForm: 'Doing', state: 'pending' },
+    ])
+    expect(out).toContain('&lt;script&gt;')
+    expect(out).not.toContain('<script>')
+  })
+})
+
+describe('renderAgentCard', () => {
+  function baseInput(overrides: Partial<Parameters<typeof renderAgentCard>[0]> = {}) {
+    return {
+      kind: 'sub' as const,
+      agentId: 'sub-1',
+      title: 'research',
+      verb: 'thinking',
+      state: 'running' as const,
+      startedAt: BASE_TIME,
+      k: 1,
+      n: 1,
+      glyphTick: 0,
+      now: BASE_TIME + 5000,
+      tasks: [],
+      ...overrides,
+    }
+  }
+
+  it('renders the k-of-n header + status row', () => {
+    const out = renderAgentCard(baseInput({ k: 2, n: 4, title: 'research', verb: 'thinking' }))
+    expect(out).toContain('<b>Agent 2 of 4</b> — research')
+    expect(out).toContain('<i>thinking</i>')
+    expect(out).toContain('5s')
+    // Token + thinking placeholders for the deferred ingestion.
+    expect(out).toContain('↓?')
+    expect(out).toContain('thought —')
+  })
+
+  it('uses the spinner glyph for running', () => {
+    const out = renderAgentCard(baseInput({ glyphTick: 0, state: 'running' }))
+    expect(out.startsWith(STATUS_GLYPHS[0]) || out.includes(STATUS_GLYPHS[0])).toBe(true)
+  })
+
+  it('uses the snowflake glyph for done', () => {
+    const out = renderAgentCard(baseInput({ state: 'done' }))
+    expect(out).toContain(STATUS_GLYPH_DONE)
+  })
+
+  it('uses the no-entry glyph for failed', () => {
+    const out = renderAgentCard(baseInput({ state: 'failed' }))
+    expect(out).toContain(STATUS_GLYPH_FAILED)
+  })
+
+  it('formats elapsed under 60s as `Ns`', () => {
+    expect(renderAgentCard(baseInput({ now: BASE_TIME + 12_000 }))).toContain('12s')
+  })
+
+  it('formats elapsed at minute boundaries as `m:ss`', () => {
+    expect(renderAgentCard(baseInput({ now: BASE_TIME + 65_000 }))).toContain('1:05')
+    expect(renderAgentCard(baseInput({ now: BASE_TIME + 22 * 60_000 + 19_000 }))).toContain('22:19')
+  })
+
+  it('renders tokens when supplied', () => {
+    expect(renderAgentCard(baseInput({ tokens: 76_600 }))).toContain('↓76.6k')
+    expect(renderAgentCard(baseInput({ tokens: 2_500_000 }))).toContain('↓2.5M')
+    expect(renderAgentCard(baseInput({ tokens: 42 }))).toContain('↓42')
+  })
+
+  it('renders thinking duration when supplied', () => {
+    expect(renderAgentCard(baseInput({ thinkingMs: 8000 }))).toContain('thought 8s')
+    expect(renderAgentCard(baseInput({ thinkingMs: 75_000 }))).toContain('thought 1:15')
+  })
+
+  it('includes the narrative line as a blockquote', () => {
+    const out = renderAgentCard(baseInput({ narrative: 'Reading test fixtures' }))
+    expect(out).toContain('<blockquote>Reading test fixtures</blockquote>')
+  })
+
+  it('includes the task block under the status row', () => {
+    const out = renderAgentCard(
+      baseInput({
+        tasks: [
+          { content: 'A', activeForm: 'Doing A', state: 'in_progress' },
+          { content: 'B', activeForm: 'Doing B', state: 'pending' },
+        ],
+      }),
+    )
+    expect(out).toContain(TASK_SYMBOL.in_progress)
+    expect(out).toContain('<b>Doing A</b>')
+    expect(out).toContain(TASK_SYMBOL.pending)
+    expect(out).toContain('B')
+  })
+
+  it('escapes the title and verb for HTML safety', () => {
+    const out = renderAgentCard(
+      baseInput({ title: 'A & B', verb: '<x>' }),
+    )
+    expect(out).toContain('A &amp; B')
+    expect(out).toContain('&lt;x&gt;')
+    expect(out).not.toContain('<x>')
+  })
+
+  it('renders empty verb as "idle"', () => {
+    const out = renderAgentCard(baseInput({ verb: '' }))
+    expect(out).toContain('<i>idle</i>')
+  })
+
+  it('parent kind renders the same template', () => {
+    const out = renderAgentCard(baseInput({ kind: 'parent', title: 'Main', verb: 'Bash ls' }))
+    expect(out).toContain('<b>Agent 1 of 1</b> — Main')
+    expect(out).toContain('<i>Bash ls</i>')
+  })
+})
+
+describe('end-to-end: TodoWrite → reducer → render', () => {
+  it('drives a full status row + task list from real-shaped events', () => {
+    let state = initialState()
+    state = reduce(state, enqueue(), BASE_TIME)
+    state = reduce(state, subStart('sub-1', 'p1', 'go'), BASE_TIME + 1000)
+    // Patch description so the verb fallback shows something stable.
+    const sa = state.subAgents.get('sub-1')! as SubAgentState
+    state = {
+      ...state,
+      subAgents: new Map([['sub-1', { ...sa, description: 'research' }]]),
+    } as ProgressCardState
+    state = reduce(
+      state,
+      subTodoWrite('sub-1', [
+        { content: 'Refactor', activeForm: 'Refactoring', status: 'in_progress' },
+        { content: 'Wire', activeForm: 'Wiring', status: 'pending' },
+      ]),
+      BASE_TIME + 2000,
+    )
+    const slice = projectAgentSlice({
+      state, agentId: 'sub-1', kind: 'sub', k: 2, n: 3, glyphTick: 4, now: BASE_TIME + 22_000,
+    })!
+    const html = renderAgentCard(slice)
+    expect(html).toContain('<b>Agent 2 of 3</b> — research')
+    expect(html).toContain('21s')
+    expect(html).toContain(TASK_SYMBOL.in_progress)
+    expect(html).toContain('<b>Refactoring</b>')
+    expect(html).toContain(TASK_SYMBOL.pending)
+    expect(html).toContain('Wire')
+  })
+})

--- a/telegram-plugin/tests/progress-card-pin-manager.test.ts
+++ b/telegram-plugin/tests/progress-card-pin-manager.test.ts
@@ -111,7 +111,7 @@ describe('createPinManager', () => {
       expect(h.deps.pin).toHaveBeenCalledTimes(1)
       // Sidecar recorded the pin with the injected clock.
       expect(h.sidecar).toEqual([
-        { chatId: 'chat-1', messageId: 500, turnKey: 'chat-1:42:1', pinnedAt: 10_000 },
+        { chatId: 'chat-1', messageId: 500, turnKey: 'chat-1:42:1', pinnedAt: 10_000, agentId: '__parent__' },
       ])
       // In-memory index reflects the pin.
       expect(h.mgr.pinnedTurnKeys()).toEqual(['chat-1:42:1'])
@@ -644,6 +644,123 @@ describe('createPinManager', () => {
       h.fireTimers()
       await h.mgr.drainInFlight()
       expect(h.deps.pin).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('per-agent composite key — one pin per (turnKey, agentId)', () => {
+    it('distinct agentIds under the same turnKey pin independently', async () => {
+      const h = mkHarness()
+      h.mgr.considerPin({ chatId: 'c', turnKey: 'c:1', messageId: 500, isFirstEmit: true, agentId: 'parent' })
+      h.mgr.considerPin({ chatId: 'c', turnKey: 'c:1', messageId: 501, isFirstEmit: true, agentId: 'sub-a' })
+      h.mgr.considerPin({ chatId: 'c', turnKey: 'c:1', messageId: 502, isFirstEmit: true, agentId: 'sub-b' })
+      h.fireTimers()
+      await h.mgr.drainInFlight()
+
+      expect(h.deps.pin).toHaveBeenCalledTimes(3)
+      expect(h.mgr.pinnedTurnKeys()).toEqual(['c:1'])
+      expect(h.mgr.pinnedAgentIds('c:1').sort()).toEqual(['parent', 'sub-a', 'sub-b'])
+      expect(h.mgr.pinnedMessageId('c:1', 'parent')).toBe(500)
+      expect(h.mgr.pinnedMessageId('c:1', 'sub-a')).toBe(501)
+      expect(h.mgr.pinnedMessageId('c:1', 'sub-b')).toBe(502)
+    })
+
+    it('idempotent within a (turnKey, agentId) — second considerPin is a no-op', async () => {
+      const h = mkHarness()
+      const c = { chatId: 'c', turnKey: 'c:1', messageId: 500, isFirstEmit: true, agentId: 'sub-a' }
+      h.mgr.considerPin(c)
+      h.mgr.considerPin({ ...c, messageId: 999 })
+      h.fireTimers()
+      await h.mgr.drainInFlight()
+
+      expect(h.deps.pin).toHaveBeenCalledTimes(1)
+      expect(h.deps.pin).toHaveBeenCalledWith('c', 500, { disable_notification: true })
+      expect(h.mgr.pinnedMessageId('c:1', 'sub-a')).toBe(500)
+    })
+
+    it('completeTurn for one agentId leaves siblings under the same turnKey untouched', async () => {
+      const h = mkHarness()
+      h.mgr.considerPin({ chatId: 'c', turnKey: 'c:1', messageId: 500, isFirstEmit: true, agentId: 'parent' })
+      h.mgr.considerPin({ chatId: 'c', turnKey: 'c:1', messageId: 501, isFirstEmit: true, agentId: 'sub-a' })
+      h.fireTimers()
+      await h.mgr.drainInFlight()
+
+      h.mgr.completeTurn({ chatId: 'c', turnKey: 'c:1', agentId: 'sub-a' })
+      await h.mgr.drainInFlight()
+
+      expect(h.deps.unpin).toHaveBeenCalledTimes(1)
+      expect(h.deps.unpin).toHaveBeenCalledWith('c', 501)
+      expect(h.mgr.pinnedAgentIds('c:1')).toEqual(['parent'])
+      expect(h.mgr.pinnedMessageId('c:1', 'parent')).toBe(500)
+    })
+
+    it('legacy callers (no agentId) get the parent-sentinel default', async () => {
+      const h = mkHarness()
+      // Old call shape: no agentId. Uses PARENT_AGENT_ID under the hood.
+      h.mgr.considerPin({ chatId: 'c', turnKey: 'c:1', messageId: 500, isFirstEmit: true })
+      h.fireTimers()
+      await h.mgr.drainInFlight()
+
+      expect(h.mgr.pinnedAgentIds('c:1')).toEqual(['__parent__'])
+      // pinnedMessageId without agentId resolves the parent sentinel.
+      expect(h.mgr.pinnedMessageId('c:1')).toBe(500)
+      // completeTurn without agentId targets the parent sentinel too.
+      h.mgr.completeTurn({ chatId: 'c', turnKey: 'c:1' })
+      await h.mgr.drainInFlight()
+      expect(h.deps.unpin).toHaveBeenCalledWith('c', 500)
+    })
+
+    it('parent and a sub-agent for the legacy turnKey pin under different sentinels', async () => {
+      // Mixed call shape: parent uses no agentId (sentinel), sub-agent
+      // passes an explicit one. They must not collide.
+      const h = mkHarness()
+      h.mgr.considerPin({ chatId: 'c', turnKey: 'c:1', messageId: 500, isFirstEmit: true })
+      h.mgr.considerPin({ chatId: 'c', turnKey: 'c:1', messageId: 501, isFirstEmit: true, agentId: 'sub-a' })
+      h.fireTimers()
+      await h.mgr.drainInFlight()
+
+      expect(h.deps.pin).toHaveBeenCalledTimes(2)
+      expect(h.mgr.pinnedAgentIds('c:1').sort()).toEqual(['__parent__', 'sub-a'])
+    })
+  })
+
+  describe('completeAllForTurn — catastrophic cleanup', () => {
+    it('unpins every agentId pinned under a turnKey', async () => {
+      const h = mkHarness()
+      h.mgr.considerPin({ chatId: 'c', turnKey: 'c:1', messageId: 500, isFirstEmit: true, agentId: 'parent' })
+      h.mgr.considerPin({ chatId: 'c', turnKey: 'c:1', messageId: 501, isFirstEmit: true, agentId: 'sub-a' })
+      h.mgr.considerPin({ chatId: 'c', turnKey: 'c:1', messageId: 502, isFirstEmit: true, agentId: 'sub-b' })
+      // A different turn — must not be affected.
+      h.mgr.considerPin({ chatId: 'c', turnKey: 'c:2', messageId: 600, isFirstEmit: true, agentId: 'parent' })
+      h.fireTimers()
+      await h.mgr.drainInFlight()
+
+      h.mgr.completeAllForTurn({ chatId: 'c', turnKey: 'c:1' })
+      await h.mgr.drainInFlight()
+
+      expect(h.deps.unpin).toHaveBeenCalledTimes(3)
+      const unpinnedIds = h.deps.unpin.mock.calls.map((args) => args[1]).sort((a, b) => Number(a) - Number(b))
+      expect(unpinnedIds).toEqual([500, 501, 502])
+      expect(h.mgr.pinnedTurnKeys()).toEqual(['c:2'])
+    })
+
+    it('cancels pending (not-yet-fired) timers under the turnKey', async () => {
+      const h = mkHarness()
+      h.mgr.considerPin({ chatId: 'c', turnKey: 'c:1', messageId: 500, isFirstEmit: true, agentId: 'parent' })
+      h.mgr.considerPin({ chatId: 'c', turnKey: 'c:1', messageId: 501, isFirstEmit: true, agentId: 'sub-a' })
+      // Timers scheduled but not fired yet.
+      h.mgr.completeAllForTurn({ chatId: 'c', turnKey: 'c:1' })
+      h.fireTimers() // noop — both timers were cancelled
+      await h.mgr.drainInFlight()
+
+      expect(h.deps.pin).not.toHaveBeenCalled()
+      expect(h.deps.unpin).not.toHaveBeenCalled()
+    })
+
+    it('safe on a turnKey with no pins', async () => {
+      const h = mkHarness()
+      h.mgr.completeAllForTurn({ chatId: 'c', turnKey: 'c:never' })
+      await h.mgr.drainInFlight()
+      expect(h.deps.unpin).not.toHaveBeenCalled()
     })
   })
 })


### PR DESCRIPTION
## Summary

Foundation PR for per-agent pinned status cards (each active agent +
sub-agent gets its own pinned card instead of stacking sub-agents into
one parent card). This PR is **purely additive** — it lands the
composite-key pin manager and the new pure render functions, neither of
which is wired into the live driver yet, so user-visible behaviour is
unchanged.

The driver wiring + gateway emit threading land in a follow-up PR.

### Why two PRs

The driver integration is the load-bearing part — careful interleaving
with the existing heartbeat / zombie / cross-turn / deferred-completion
machinery. Splitting it out keeps this PR small and easy to revert; the
follow-up PR's diff is then purely the wiring (no foundations mixed in).

## What's in this PR

**1. Pin manager keyed by `(turnKey, agentId)`**
- `PinCandidate.agentId` + `ActivePinEntry.agentId` (optional in the
  on-disk shape so existing sidecars still parse).
- Internal maps keyed by composite \`pinKey = \${turnKey}::\${agentId}\`.
- New \`completeAllForTurn({ turnKey })\` for catastrophic cleanup
  (bridge disconnect / forced shutdown).
- Legacy single-card-per-turn callers keep working via a
  \`__parent__\` sentinel default — no gateway changes needed in this
  PR.

**2. TodoWrite ingestion**
- New \`TaskItem\` type + \`tasks\` slice on \`ProgressCardState\` and
  \`SubAgentState\`.
- Reducer cases for \`tool_use\` and \`sub_agent_tool_use\` with
  \`toolName === 'TodoWrite'\` atomically replace the task slice.
  \`parseTodoWriteInput\` is a defensive parser that drops malformed
  entries.

**3. Pure render module**
- \`renderAgentCard\` — CLI-style status row (\`{glyph} {verb} ·
  {elapsed} · ↓{tokens} · thought {thinking}\`), optional narrative
  blockquote, ◼/◻/✔ TaskList block.
- \`projectAgentSlice\` — slices \`ProgressCardState\` into per-agent
  render input (parent or sub-agent kind).
- \`glyphForTick\` + \`STATUS_GLYPHS\` — Braille spinner frames
  matching the Claude Code CLI.
- Tokens / thinking-duration are placeholder fields (\`↓?\`, \`thought
  —\`) until ingestion lands for those signals (deferred — JSONL
  doesn't carry usage today; thinking is captured as a boolean only).

## Test plan

- [x] \`npm run lint\` clean
- [x] \`npm run build\` clean
- [x] \`bun test telegram-plugin\` — 3235 pass / 0 fail (was 3177
  before; +50 new tests across pin-manager and render-template
  coverage)
- [x] \`npm run test:vitest\` — 4746 pass / 0 fail
- [x] Pin manager: 8 new tests cover composite-key idempotency,
  distinct-agentIds-same-turnKey, sentinel default, mixed-shape
  callers, \`completeAllForTurn\` lifecycle.
- [x] Render+reducer: 40 new tests cover TodoWrite parser,
  parent+sub-agent reducer ingestion, glyph rotation, slice projection
  for parent and sub-agents, render template across
  running/done/failed/escaped-html/elapsed-formats/tokens/thinking,
  and an end-to-end events→state→html assertion.
- [ ] No live Telegram verification yet — the pure functions aren't
  wired into the driver in this PR. End-to-end behaviour validates in
  the follow-up.

## Design contract (per CLAUDE.md)

- **Outcome:** advances *Visibility* (#1) and *Multi-agent fleet* (#2)
  — the per-agent pin replaces the stacked-expandables model so each
  active worker is visible on its own.
- **JTBD:** sub-agent visibility (\`reference/see-everything-pinned-
  to-the-chat.md\`).
- **Principles check:** docs ✓ (purely additive; no new user-facing
  surfaces in this PR), defaults ✓ (zero config; new code path is not
  reachable until the follow-up wires it in), consistency ✓ (same
  cascade, same emit signature, same pin manager).

🤖 Generated with [Claude Code](https://claude.com/claude-code)