### PR TITLE
hotfix(gateway): declare outboundDedup + lint check for the bug class

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,9 @@
     "test:vitest": "vitest run",
     "test:bun": "bun test src/vault/grants.test.ts src/vault/broker/server-grants.test.ts src/vault/broker/client-token.test.ts src/vault/broker/server-unlock.test.ts src/vault/broker/auto-unlock.test.ts tests/vault-broker-passphrase.test.ts src/cli/vault-get-broker.test.ts src/vault/resolver-via-broker.test.ts src/vault/broker/scope.test.ts src/vault/broker/server.test.ts telegram-plugin/tests/boot-probes.test.ts telegram-plugin/tests/setup-state.test.ts telegram-plugin/tests/history.test.ts telegram-plugin/tests/ipc-server-client.test.ts telegram-plugin/tests/ipc-server-race.test.ts telegram-plugin/tests/gateway-bridge.test.ts telegram-plugin/tests/gateway-startup-mutex.test.ts telegram-plugin/tests/gateway-clean-shutdown-marker.test.ts telegram-plugin/tests/foreman-state.test.ts telegram-plugin/tests/boot-card-dedupe.test.ts telegram-plugin/tests/boot-card-reason.test.ts telegram-plugin/tests/progress-update.test.ts telegram-plugin/tests/quota-cache.test.ts telegram-plugin/tests/silent-reply-guard.test.ts telegram-plugin/tests/unhandled-rejection-policy.test.ts telegram-plugin/tests/registry-turns.test.ts telegram-plugin/registry/subagents.test.ts telegram-plugin/tests/turns-writer.test.ts telegram-plugin/tests/resolve-calling-subagent.test.ts telegram-plugin/tests/gateway-update-placeholder-dispatch.test.ts",
     "test:watch": "vitest",
-    "lint": "tsc --noEmit",
+    "lint": "tsc --noEmit && node scripts/check-plugin-references.mjs",
+    "lint:tsc": "tsc --noEmit",
+    "lint:plugin-references": "node scripts/check-plugin-references.mjs",
     "prepublishOnly": "npm run build && npm run lint && npm test"
   },
   "dependencies": {

--- a/scripts/check-plugin-references.mjs
+++ b/scripts/check-plugin-references.mjs
@@ -1,0 +1,108 @@
+#!/usr/bin/env node
+/**
+ * Check telegram-plugin source for undeclared-identifier (TS2304) and
+ * related "name not found" errors that the main `npm run lint` misses.
+ *
+ * Why this script exists:
+ *
+ * The repo's `tsconfig.json` does not include `telegram-plugin/` in its
+ * `include` array (the file is bun-bundled, not tsc-compiled), so the
+ * 7000-line gateway.ts is invisible to the type checker. PR #599 (the
+ * #546 dedup fix, commit 5bed5b7) added 4 read sites of `outboundDedup`
+ * but never declared the variable. `npm run lint` was clean. The bug
+ * shipped to main and broke every reply on every agent — the agent's
+ * own prose quoted "outboundDedup is not defined" inside ANOTHER reply
+ * call (which also threw).
+ *
+ * This script catches the same class going forward. It runs `tsc
+ * --noEmit` against a tsconfig that DOES include the plugin, filters
+ * the output to ONLY the dangerous error codes (undeclared names,
+ * cannot-invoke-undefined, typo-suggestions), and exits non-zero if
+ * any are found.
+ *
+ * The 50+ pre-existing type-debt errors in plugin source (TS2345 type
+ * mismatches, TS2339 missing properties, etc.) are NOT failed on here
+ * — they're real but not the bug class that breaks production. A
+ * follow-up issue tracks cleaning them up so the full tsc check can
+ * be enabled.
+ *
+ * Codes filtered (pick the ones that mean "ReferenceError-class bug"):
+ *   TS2304 — Cannot find name 'X'
+ *   TS2552 — Cannot find name 'X'. Did you mean 'Y'?
+ *   TS2722 — Cannot invoke an object which is possibly 'undefined'
+ *   TS2561 — Object literal may only specify known properties, but 'X'
+ *            does not exist in type 'Y'. Did you mean to write 'Z'?
+ *
+ * Run: `npm run lint:plugin-references` (also part of `npm run lint`).
+ */
+
+import { execSync } from 'node:child_process'
+import { writeFileSync, unlinkSync, existsSync } from 'node:fs'
+import { resolve, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const repoRoot = resolve(__dirname, '..')
+
+// Codes that catch the bug class that broke clerk in PR #599.
+// Adding TS6133 (unused declaration) would catch dead variables but
+// flag too much pre-existing debt; leave it off for now.
+const DANGEROUS_CODES = ['TS2304', 'TS2552', 'TS2722', 'TS2561']
+
+const tmpConfig = resolve(repoRoot, 'tsconfig.plugin-refcheck.json')
+const tmpConfigBody = {
+  extends: './tsconfig.json',
+  // Override include so plugin source is in scope. Tests excluded —
+  // their type debt is separate; in-scope tests would balloon the
+  // false-positive count.
+  include: [
+    'src/**/*.ts',
+    'bin/**/*.ts',
+    'scripts/**/*.ts',
+    'telegram-plugin/**/*.ts',
+  ],
+  exclude: [
+    'node_modules',
+    'dist',
+    'telegram-plugin/tests/**/*',
+    'telegram-plugin/dist/**/*',
+  ],
+}
+
+writeFileSync(tmpConfig, JSON.stringify(tmpConfigBody, null, 2))
+
+let out = ''
+try {
+  out = execSync(`npx tsc --noEmit -p ${tmpConfig}`, {
+    cwd: repoRoot,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  })
+} catch (err) {
+  out = (err.stdout || '') + (err.stderr || '')
+} finally {
+  if (existsSync(tmpConfig)) unlinkSync(tmpConfig)
+}
+
+const lines = out.split('\n')
+const dangerous = lines.filter((l) =>
+  DANGEROUS_CODES.some((code) => l.includes(`error ${code}`))
+)
+
+if (dangerous.length > 0) {
+  console.error('plugin-references: found dangerous-class type errors:\n')
+  for (const line of dangerous) console.error('  ' + line)
+  console.error(
+    `\nThese errors mean a reference, invocation, or property is wrong — ` +
+    `the kind of bug that ships to production undetected because tsc doesn't ` +
+    `cover telegram-plugin/. See scripts/check-plugin-references.mjs for context.`
+  )
+  process.exit(1)
+}
+
+const totalErrors = lines.filter((l) => l.includes('error TS')).length
+console.log(
+  `plugin-references: clean (no TS2304/TS2552/TS2722/TS2561 errors in plugin source). ` +
+  `${totalErrors} other type-debt errors ignored — tracked separately.`
+)
+process.exit(0)

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -1856,7 +1856,10 @@ const ipcServer: IpcServer = createIpcServer({
         if (ad) clearActiveReactions(ad)
       },
       disposeProgressDriver: () => {
-        progressDriver?.dispose({ preservePending: true })
+        // dispose is optional on the ProgressDriver interface — chain
+        // through both possibly-undefined hops. Caught by
+        // scripts/check-plugin-references.mjs (TS2722).
+        progressDriver?.dispose?.({ preservePending: true })
       },
       log: (msg) => process.stderr.write(`${msg}\n`),
     })
@@ -2694,13 +2697,16 @@ async function executeProgressUpdate(args: Record<string, unknown>): Promise<unk
     { verb: 'sendMessage', chat_id, threadId },
   )
 
-  // Record in sent-message history
+  // Record in sent-message history. RecordOutboundArgs uses `texts`
+  // (parallel array to message_ids), not `text` — the singular-name
+  // typo silently omitted progress_update outbounds from the history
+  // DB. Caught by scripts/check-plugin-references.mjs (TS2561).
   if (HISTORY_ENABLED) {
     recordOutbound({
       chat_id,
       thread_id: threadId ?? null,
       message_ids: [sent.message_id],
-      text,
+      texts: [text],
     })
   }
 

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -775,6 +775,13 @@ if (!STATIC) setInterval(checkApprovals, 5000).unref()
 const chatThreadMap = new Map<string, number>()
 const activeStatusReactions = new Map<string, StatusReactionController>()
 const activeReactionMsgIds = new Map<string, { chatId: string; messageId: number }>()
+
+// #546 — outbound content-dedup window. PR #599 introduced the four read
+// sites (`outboundDedup.check` / `.record` in executeReply, executeStreamReply,
+// turn-flush) but the declaration was lost in a merge somewhere — every reply
+// path threw `outboundDedup is not defined` at runtime, blocking ALL outbound
+// from the agent. Restore the module-level singleton here.
+const outboundDedup = new OutboundDedupCache()
 /**
  * Per-chat cache of `available_reactions` from `getChat`. Populated lazily —
  * the FIRST message in a chat creates a controller without the filter (null


### PR DESCRIPTION
Replaces #622 (which had unrelated auth-account commits swept in due to the source branch being based on \`feat/global-auth-accounts\`). This branch is fresh off upstream/main, contains only the hotfix + the lint catcher.

## #622 SUMMARY (preserved from the original)

**Production smoking gun** from clerk's gateway.log:
\`\`\`
telegram channel: reply: invoked chatId=... preview=\"stream_reply just threw \`outboundDedup is not defined\` — looks like a regression\"
\`\`\`

User-facing: agent thumbs-ups and doesn't respond. Every \`reply\` / \`stream_reply\` tool call with \`done=true\` threw at runtime. The agent's prose then quoted the error inside ANOTHER reply call — which also threw.

**Root cause:** PR #599 (#546 fix, commit \`5bed5b7\`) added 4 read sites of \`outboundDedup.check\` / \`.record\` but never added the module-level declaration \`const outboundDedup = new OutboundDedupCache()\`.

**Why testing missed it:** \`tsconfig.json\` doesn't include \`telegram-plugin/\` in its \`include\` array (the file is bun-bundled, not tsc-compiled), so the 7000-line gateway.ts is invisible to the type checker. \`npm run lint\` was clean even with 4 undeclared identifier reads.

**Latent in main since 2026-05-03** (when #599 merged). Hit clerk this evening when the agent restarted with a fresh gateway and tried to reply.

## Commit 1 — declare the singleton (3 lines)

\`const outboundDedup = new OutboundDedupCache()\` at the same module-level state block as \`activeStatusReactions\`, etc.

## Commit 2 — lint check that catches this bug class

\`scripts/check-plugin-references.mjs\` runs \`tsc --noEmit\` against a temp tsconfig that DOES include \`telegram-plugin/\` source (excluding tests). Filters output to four bug-class error codes:
- **TS2304** — Cannot find name 'X' (the outboundDedup case)
- **TS2552** — Cannot find name 'X'. Did you mean 'Y'?
- **TS2722** — Cannot invoke an object which is possibly 'undefined'
- **TS2561** — Object literal may only specify known properties, but 'X' does not exist in type 'Y'. Did you mean to write 'Z'?

Wired into \`npm run lint\` (composed with \`tsc --noEmit\`). Standalone access via \`npm run lint:plugin-references\`.

**Two real latent bugs surfaced and fixed by the new check:**
1. \`gateway.ts:1859\` — \`progressDriver?.dispose({...})\` (TS2722). \`dispose\` is optional on the interface; chained optional via \`progressDriver?.dispose?.({...})\`.
2. \`gateway.ts:2706\` — \`recordOutbound({ ..., text })\` (TS2561). The type field is \`texts: string[]\`. The singular-name typo silently omitted progress_update outbounds from the history DB.

The 52 other pre-existing type-debt errors in plugin source (TS2345 type mismatches, etc.) are NOT failed on. Cleaning them up to enable full \`tsc\` over the plugin is tracked in #623.

## Test plan
- [x] \`npm run lint\` green — both \`tsc --noEmit\` and \`check-plugin-references\` pass
- [x] \`npm test\` green — 4698 vitest + bun pass; 0 fail
- [x] Live verification: applied the declaration to clerk's working tree + restarted; reply path now works

## Closes
- The runtime symptom from #549's continued user reports
- Supersedes #622 (will close that PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)