### PR TITLE
feat(progress-card): per-sub-agent pinned cards behind PROGRESS_CARD_PER_AGENT_PINS

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -8649,7 +8649,7 @@ if (streamMode === 'checklist') {
   }
 
   progressDriver = createProgressDriver({
-    emit: ({ chatId, threadId, turnKey, html, done, isFirstEmit, replyToMessageId }) => {
+    emit: ({ chatId, threadId, turnKey, html, done, isFirstEmit, replyToMessageId, agentId }) => {
       const args = {
         chat_id: chatId, text: html, done, message_thread_id: threadId,
         lane: 'progress', format: 'html', turnKey,
@@ -8714,21 +8714,33 @@ if (streamMode === 'checklist') {
         // #203: progress-card edit is a user-visible signal.
         signalTracker.noteSignal(statusKey(chatId, threadId != null ? Number(threadId) : undefined), Date.now())
         if (!result?.messageId) return
+        // Per-agent cards (#per-agent-cards): thread `agentId` through to
+        // the pin manager so each sub-agent card pins under its own
+        // composite key. Absent for parent-card emits — the manager
+        // defaults to the parent sentinel.
         pinMgr.considerPin({
           chatId,
           threadId,
           turnKey,
           messageId: result.messageId,
           isFirstEmit,
+          ...(agentId != null ? { agentId } : {}),
         })
         // Heartbeat watchdog: after the initial pin has been recorded,
         // every subsequent (non-final) emit probes Telegram to confirm
         // our pin is still the one on display. Rate-limited internally.
         if (!isFirstEmit && !done) {
-          const expectedId = pinMgr.pinnedMessageId(turnKey)
+          const expectedId = pinMgr.pinnedMessageId(turnKey, agentId)
           if (expectedId != null) {
             void pinWatchdog.verify({ chatId, turnKey, expectedMessageId: expectedId })
           }
+        }
+        // Sub-agent card finalize: when an emit comes through with both
+        // `agentId` and `done`, that's the registry's terminal frame for
+        // this card. Unpin its message; the parent's onTurnComplete
+        // path covers the parent-card case.
+        if (done && agentId != null) {
+          pinMgr.completeTurn({ chatId, threadId, turnKey, agentId })
         }
       }).catch((err: unknown) => {
         const msg = err instanceof Error ? err.message : String(err)

--- a/telegram-plugin/progress-card-driver.ts
+++ b/telegram-plugin/progress-card-driver.ts
@@ -25,6 +25,11 @@ import {
   type TaskNum,
   type SubAgentState,
 } from './progress-card.js'
+import {
+  createSubAgentCardRegistry,
+  isPerAgentPinsEnabled,
+  type SubAgentCardRegistry,
+} from './subagent-card.js'
 import { isTelegramReplyTool } from './tool-names.js'
 
 /**
@@ -85,6 +90,15 @@ export interface ProgressDriverConfig {
      * reply_parameters.message_id on the initial sendMessage.
      */
     replyToMessageId?: number
+    /**
+     * Per-agent card identity. Absent for parent-card emits (the
+     * gateway treats absence as the parent sentinel `__parent__`).
+     * Present for sub-agent-card emits when `PROGRESS_CARD_PER_AGENT_PINS=1`
+     * is set, in which case the gateway must thread it through to
+     * `pinMgr.considerPin` / `pinMgr.completeTurn` so each sub-agent
+     * card pins independently. See `subagent-card.ts`.
+     */
+    agentId?: string
   }) => void
   /**
    * Optional callback fired once per turn immediately after the final
@@ -774,6 +788,40 @@ export function createProgressDriver(config: ProgressDriverConfig): ProgressDriv
   // a fake-clock advance in tests.
   const lastSubAgentTickBucket = new Map<string, number>()
 
+  // Per-sub-agent card registry (#per-agent-cards). Off by default; opt
+  // in with PROGRESS_CARD_PER_AGENT_PINS=1. When enabled, the registry
+  // tracks one pinned Telegram card per running sub-agent (alongside
+  // the parent card) and emits via the same `config.emit` callback —
+  // gated by a synthetic turnKey so the gateway's existing stream-reply
+  // infra routes them as separate messages.
+  const subAgentCards: SubAgentCardRegistry = createSubAgentCardRegistry(
+    { enabled: isPerAgentPinsEnabled() },
+    {
+      emit: (args) => {
+        config.emit({
+          chatId: args.chatId,
+          threadId: args.threadId,
+          turnKey: args.turnKey,
+          agentId: args.agentId,
+          html: args.html,
+          done: args.done,
+          isFirstEmit: args.isFirstEmit,
+        })
+      },
+      now,
+      // Reuse the driver's coalesce/min-interval defaults so per-agent
+      // cards behave consistently with the parent card. The wider
+      // `multiCardCoalesceMs` is tuned for the multi-card edit-budget
+      // case (§6) — when ≥ 2 sub-agent cards are active in the same
+      // chat+thread the registry expands its coalesce window.
+      coalesceMs,
+      multiCardCoalesceMs: 800,
+      minIntervalMs,
+      heartbeatMs,
+      log: (line) => process.stderr.write(line),
+    },
+  )
+
   /**
    * Fire completion callbacks + delete chatState + tidy bookkeeping.
    * Idempotent via `completionFired`. Does not touch the reducer or
@@ -871,6 +919,11 @@ export function createProgressDriver(config: ProgressDriverConfig): ProgressDriv
       clearT(cs.timePromoteTimer)
       cs.timePromoteTimer = null
     }
+    // Per-agent cards (#per-agent-cards): force-finalize any sub-agent
+    // cards still tracked under this parent turn so they emit a final
+    // done=true frame and the gateway can unpin them. No-op when the
+    // env flag is off (registry has nothing tracked).
+    subAgentCards.finalizeAll(cs.turnKey, now())
     chats.delete(cs.turnKey)
     lastHeartbeatBucket.delete(cs.turnKey)
     lastSubAgentTickBucket.delete(cs.turnKey)
@@ -1598,6 +1651,17 @@ export function createProgressDriver(config: ProgressDriverConfig): ProgressDriv
         // regressions in the sync path (or a code path that bypasses
         // closeZombie) still produce a visible card instead of a
         // silently-suppressed turn.
+        // Per-agent card sync for carried-over sub-agents on the new
+        // turn — without this, sub-agents that survive across turn
+        // boundaries (#334) wouldn't get their per-agent cards spawned
+        // until the next event landed.
+        subAgentCards.syncFromParent({
+          state: chatState.state,
+          chatId: chatState.chatId,
+          threadId: chatState.threadId,
+          parentTurnKey: chatState.turnKey,
+          now: now(),
+        })
         if (promoteOnSubAgent && carriedOver != null && carriedOver.size > 0) {
           promoteFirstEmit(chatState, 'carried_over_subagents')
         } else {
@@ -1632,6 +1696,17 @@ export function createProgressDriver(config: ProgressDriverConfig): ProgressDriv
       chatState.lastEventAt = now()
       const stageChanged = chatState.state.stage !== prev.stage
       const visibleChanged = visibleDiff(prev, chatState.state)
+
+      // Per-agent card sync (#per-agent-cards): walk the post-reduce
+      // state.subAgents map and spawn / flush / finalize per-sub-agent
+      // cards. No-op when PROGRESS_CARD_PER_AGENT_PINS is unset.
+      subAgentCards.syncFromParent({
+        state: chatState.state,
+        chatId: chatState.chatId,
+        threadId: chatState.threadId,
+        parentTurnKey: chatState.turnKey,
+        now: now(),
+      })
 
       // Issue #334/#399: mirror sub-agent state changes into the chat-scoped
       // running-sub-agent registry so new turns can seed from it.
@@ -2036,6 +2111,14 @@ export function createProgressDriver(config: ProgressDriverConfig): ProgressDriv
     },
 
     dispose(opts?: { preservePending?: boolean }) {
+      // Per-agent card registry (#per-agent-cards): only dispose
+      // outright when we're not preserving pending. With
+      // preservePending the registry continues ticking heartbeats for
+      // any cards whose parent chats are still alive — finalizeAll
+      // for them fires from the eventual completeTurnFully.
+      if (opts?.preservePending !== true) {
+        subAgentCards.dispose()
+      }
       if (opts?.preservePending === true) {
         // Selective dispose: preserve chats with pendingCompletion=true so
         // their heartbeat and deferred-completion timeout continue firing

--- a/telegram-plugin/progress-card.ts
+++ b/telegram-plugin/progress-card.ts
@@ -1334,7 +1334,12 @@ export function render(
   // Issue #352: prepend an always-visible summary header before the per-agent
   // expandable blocks so the user sees status counts at a glance.
   const expandableParts: string[] = []
-  if (multiAgentActive && state.subAgents.size > 0) {
+  // Per-agent cards (#per-agent-cards): when the env flag is on each
+  // sub-agent gets its own pinned card — the parent's expandable block
+  // becomes redundant and is suppressed entirely. Off by default so the
+  // legacy stacked-card behaviour persists during soft rollout.
+  const skipSubAgentExpandables = process.env.PROGRESS_CARD_PER_AGENT_PINS === '1'
+  if (!skipSubAgentExpandables && multiAgentActive && state.subAgents.size > 0) {
     // #378 sub-issue 6: dropped the "🤖 Sub-agents · 🔄 N · ✅ N · ❌ N"
     // rollup header. Per-row icons + state labels already convey the same
     // info, and a header above three rows that each say "✅ done" was

--- a/telegram-plugin/subagent-card.ts
+++ b/telegram-plugin/subagent-card.ts
@@ -1,0 +1,485 @@
+/**
+ * Per-sub-agent pinned status card registry.
+ *
+ * Sits alongside the existing parent progress card in
+ * `progress-card-driver.ts`. Where the driver tracks one
+ * `PerChatState` per turn (and renders sub-agents as nested
+ * `<blockquote expandable>` rows inside it), this registry tracks one
+ * `SubAgentCardState` per running sub-agent and emits a separate pinned
+ * Telegram message for each — driving the CLI-style status row +
+ * TaskList block via the pure `renderAgentCard` / `projectAgentSlice`
+ * helpers.
+ *
+ * Lifecycle:
+ *   - Spawn lazily on the first *content* event for an agentId (the
+ *     sub-agent has a `currentTool`, `currentNarrative`,
+ *     `firstNarrativeText`, or has completed at least one tool). Avoids
+ *     empty placeholder cards for orphan starts.
+ *   - Each sync schedules a coalesced emit so bursts don't multiply
+ *     edits; `lastEmittedAt` enforces the per-card hard floor.
+ *   - On the sub-agent's terminal state (`done` / `failed`) the
+ *     registry emits one final card with `done=true` and stops
+ *     tracking. The gateway's existing `pinMgr.completeTurn` path
+ *     unpins it.
+ *
+ * The registry uses a synthetic turnKey of the form
+ * `${parentTurnKey}::${agentId}` for each sub-agent card. The
+ * gateway's stream-reply infrastructure keys on turnKey for stream
+ * identity so distinct turnKeys yield distinct messages — this keeps
+ * sub-agent cards independent of the parent card without parallel
+ * stream-reply plumbing.
+ *
+ * Gating:
+ *   The registry only acts when `PROGRESS_CARD_PER_AGENT_PINS=1` is
+ *   set (or the explicit `enabled` config flag passed by tests). Off
+ *   by default for soft rollout — the legacy parent card with
+ *   sub-agent expandables stays the default until per-agent pins are
+ *   validated in production.
+ */
+
+import type {
+  ProgressCardState,
+  SubAgentState,
+} from './progress-card.js'
+import {
+  projectAgentSlice,
+  renderAgentCard,
+} from './progress-card.js'
+
+/**
+ * Synthetic turnKey for a sub-agent card. Uses `::` as a separator —
+ * not a legal character in real turnKeys (which are
+ * `${chatId}:${threadId}:${seq}`) so collisions are impossible.
+ */
+export function subAgentTurnKey(parentTurnKey: string, agentId: string): string {
+  return `${parentTurnKey}::${agentId}`
+}
+
+export interface SubAgentCardEmitArgs {
+  chatId: string
+  threadId?: string
+  /** Synthetic turnKey unique to this sub-agent card. */
+  turnKey: string
+  /** Sub-agent identity for the pin manager. */
+  agentId: string
+  html: string
+  done: boolean
+  /** True only on the very first emit for this card. */
+  isFirstEmit: boolean
+}
+
+export interface SubAgentCardRegistryDeps {
+  emit: (args: SubAgentCardEmitArgs) => void
+  /** Wall-clock ms. Defaults to `Date.now`. */
+  now?: () => number
+  /** Coalesce burst window. Defaults to 400ms. */
+  coalesceMs?: number
+  /** Per-card hard floor between edits. Defaults to 500ms. */
+  minIntervalMs?: number
+  /**
+   * Multi-card coalesce window (raised when ≥ 2 cards active in the
+   * same chat+thread). Defaults to 800ms — the existing per-chat
+   * Telegram edit budget is shared across N cards so N-card bursts
+   * benefit from a wider coalesce window.
+   */
+  multiCardCoalesceMs?: number
+  /**
+   * Heartbeat for the elapsed-counter tick when no events flow.
+   * Defaults to 5000ms. Set 0 to disable.
+   */
+  heartbeatMs?: number
+  /** Logger. Defaults to no-op. */
+  log?: (line: string) => void
+  /** Test injection. */
+  setT?: (fn: () => void, ms: number) => { ref: unknown }
+  clearT?: (handle: { ref: unknown }) => void
+  setI?: (fn: () => void, ms: number) => { ref: unknown }
+  clearI?: (handle: { ref: unknown }) => void
+}
+
+export interface SubAgentCardConfig {
+  /**
+   * Required opt-in. Off by default — parent-card-with-expandables
+   * remains the default until per-agent pins are validated.
+   * Tests pass `true`; production reads `PROGRESS_CARD_PER_AGENT_PINS=1`
+   * via {@link isPerAgentPinsEnabled}.
+   */
+  enabled: boolean
+}
+
+export interface SubAgentCardRegistry {
+  /**
+   * Reconcile the registry against a ProgressCardState. Spawns cards
+   * for newly-content-bearing sub-agents, schedules emits for ongoing
+   * ones, finalizes terminals.
+   */
+  syncFromParent(args: {
+    state: ProgressCardState
+    chatId: string
+    threadId?: string
+    parentTurnKey: string
+    now: number
+  }): void
+  /**
+   * Force-finalize every card under a parentTurnKey. Used on parent
+   * `turn_end` so any sub-agent whose `sub_agent_turn_end` was missed
+   * still gets a final emit + unpin signal.
+   */
+  finalizeAll(parentTurnKey: string, now: number): void
+  /**
+   * Stop all timers, clear state. Idempotent.
+   */
+  dispose(): void
+  /** Test-only: snapshot of currently-tracked agentIds for a parent turn. */
+  trackedAgentIds(parentTurnKey: string): ReadonlyArray<string>
+}
+
+/**
+ * Read the per-agent-pins env flag. Centralised so the gateway, driver,
+ * and parent-card render share one definition of "is the new path on?"
+ */
+export function isPerAgentPinsEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  return env.PROGRESS_CARD_PER_AGENT_PINS === '1'
+}
+
+interface CardRecord {
+  agentId: string
+  chatId: string
+  threadId?: string
+  parentTurnKey: string
+  synthTurnKey: string
+  spawnedAt: number
+  /**
+   * Wall-clock ms when the first emit for this card fired. Used as the
+   * card's own elapsed clock. 0 until first emit.
+   */
+  cardStartedAt: number
+  lastEmittedAt: number
+  lastEmittedHtml: string
+  pendingTimer: { ref: unknown } | null
+  glyphTick: number
+  isFirstEmit: boolean
+  /** True once the registry has emitted with done=true for this card. */
+  finalEmitted: boolean
+}
+
+/**
+ * True when a sub-agent has produced at least one signal worth showing
+ * — used to gate lazy spawn so we don't pin empty placeholder cards
+ * for orphan or about-to-die sub-agents.
+ */
+function hasContentSignal(sa: SubAgentState): boolean {
+  if (sa.currentTool != null) return true
+  if (sa.currentNarrative != null && sa.currentNarrative.length > 0) return true
+  if (sa.firstNarrativeText != null && sa.firstNarrativeText.length > 0) return true
+  if (sa.toolCount > 0) return true
+  if (sa.tasks.length > 0) return true
+  if (sa.lastCompletedTool != null) return true
+  // Already terminal (e.g. cold-jsonl synth) — emit one final card so
+  // the user sees what the sub-agent did before it closed.
+  if (sa.state === 'done' || sa.state === 'failed') return true
+  return false
+}
+
+export function createSubAgentCardRegistry(
+  config: SubAgentCardConfig,
+  deps: SubAgentCardRegistryDeps,
+): SubAgentCardRegistry {
+  const now = deps.now ?? Date.now
+  const log = deps.log ?? (() => {})
+  const coalesceMs = deps.coalesceMs ?? 400
+  const multiCardCoalesceMs = deps.multiCardCoalesceMs ?? 800
+  const minIntervalMs = deps.minIntervalMs ?? 500
+  const heartbeatMs = deps.heartbeatMs ?? 5_000
+  const setT: (fn: () => void, ms: number) => { ref: unknown } =
+    deps.setT ??
+    ((fn, ms) => ({ ref: setTimeout(fn, ms) }))
+  const clearT: (handle: { ref: unknown }) => void =
+    deps.clearT ??
+    ((handle) => {
+      clearTimeout(handle.ref as ReturnType<typeof setTimeout>)
+    })
+  const setI: (fn: () => void, ms: number) => { ref: unknown } =
+    deps.setI ??
+    ((fn, ms) => ({ ref: setInterval(fn, ms) }))
+  const clearI: (handle: { ref: unknown }) => void =
+    deps.clearI ??
+    ((handle) => {
+      clearInterval(handle.ref as ReturnType<typeof setInterval>)
+    })
+
+  // Keyed by synthTurnKey — each sub-agent card is unique across the
+  // session.
+  const cards = new Map<string, CardRecord>()
+
+  let heartbeatHandle: { ref: unknown } | null = null
+  // Captured so the heartbeat can refresh elapsed counters even when
+  // no new events flow. Updated on every syncFromParent.
+  const lastSyncCtx = new Map<string, {
+    state: ProgressCardState
+    chatId: string
+    threadId?: string
+    parentTurnKey: string
+  }>()
+
+  function ensureHeartbeat(): void {
+    if (config.enabled === false) return
+    if (heartbeatMs <= 0) return
+    if (heartbeatHandle != null) return
+    heartbeatHandle = setI(() => {
+      if (cards.size === 0) return
+      // Re-render every running card with a fresh `now` so elapsed
+      // ticks visibly. We don't refresh `state` — heartbeats only
+      // matter for the elapsed counter, and the slice projector is
+      // pure-state-of-now anyway.
+      for (const card of cards.values()) {
+        if (card.finalEmitted) continue
+        const ctx = lastSyncCtx.get(card.parentTurnKey)
+        if (!ctx) continue
+        scheduleEmit(card, ctx, now())
+      }
+    }, heartbeatMs)
+  }
+
+  function maybeStopHeartbeat(): void {
+    if (heartbeatHandle == null) return
+    if (cards.size > 0) return
+    clearI(heartbeatHandle)
+    heartbeatHandle = null
+  }
+
+  /** All cards belonging to a given chat+thread (for k-of-n labeling). */
+  function siblingsFor(chatId: string, threadId: string | undefined): CardRecord[] {
+    const out: CardRecord[] = []
+    for (const card of cards.values()) {
+      if (card.chatId !== chatId) continue
+      if (card.threadId !== threadId) continue
+      out.push(card)
+    }
+    // Stable spawn-order so k is deterministic across renders.
+    out.sort((a, b) => a.spawnedAt - b.spawnedAt)
+    return out
+  }
+
+  function renderCard(
+    card: CardRecord,
+    ctx: { state: ProgressCardState },
+    nowMs: number,
+  ): string | null {
+    const siblings = siblingsFor(card.chatId, card.threadId)
+    const k = siblings.findIndex((s) => s === card) + 1
+    const n = siblings.length
+    if (k <= 0) return null
+    const slice = projectAgentSlice({
+      state: ctx.state,
+      agentId: card.agentId,
+      kind: 'sub',
+      k: k + 1, // reserve k=1 for the parent card; sub-agents start at #2
+      n: n + 1, // include parent in the total
+      glyphTick: card.glyphTick,
+      now: nowMs,
+    })
+    if (!slice) return null
+    return renderAgentCard(slice)
+  }
+
+  function emitNow(card: CardRecord, html: string, done: boolean, nowMs: number): void {
+    const isFirst = card.isFirstEmit
+    if (isFirst) {
+      card.isFirstEmit = false
+      card.cardStartedAt = nowMs
+    }
+    card.lastEmittedHtml = html
+    card.lastEmittedAt = nowMs
+    card.glyphTick += 1
+    if (done) card.finalEmitted = true
+    try {
+      deps.emit({
+        chatId: card.chatId,
+        threadId: card.threadId,
+        turnKey: card.synthTurnKey,
+        agentId: card.agentId,
+        html,
+        done,
+        isFirstEmit: isFirst,
+      })
+    } catch (err) {
+      log(
+        `subagent-card: emit failed agentId=${card.agentId} err="${(err as Error)?.message ?? err}"\n`,
+      )
+    }
+  }
+
+  function scheduleEmit(
+    card: CardRecord,
+    ctx: { state: ProgressCardState; chatId: string; threadId?: string; parentTurnKey: string },
+    nowMs: number,
+  ): void {
+    if (card.finalEmitted) return
+    // Cancel any pending coalesce timer — the new event takes over.
+    if (card.pendingTimer != null) {
+      clearT(card.pendingTimer)
+      card.pendingTimer = null
+    }
+    const sa = ctx.state.subAgents.get(card.agentId)
+    const terminal = sa != null && (sa.state === 'done' || sa.state === 'failed')
+    const html = renderCard(card, ctx, nowMs)
+    if (!html) return
+    const timeSinceLast = nowMs - card.lastEmittedAt
+    const sibCount = siblingsFor(card.chatId, card.threadId).length
+    const window = sibCount > 1 ? multiCardCoalesceMs : coalesceMs
+    if (terminal) {
+      // Terminal events fire immediately — final emits must not be
+      // coalesced lest the card appear "running" forever.
+      emitNow(card, html, true, nowMs)
+      cards.delete(card.synthTurnKey)
+      maybeStopHeartbeat()
+      return
+    }
+    // Allow first emit to fire immediately (subject to the floor); for
+    // subsequent emits, coalesce.
+    if (card.isFirstEmit) {
+      if (timeSinceLast < minIntervalMs && card.lastEmittedAt > 0) {
+        // Should not happen on first emit since lastEmittedAt is 0,
+        // but guard anyway.
+        const wait = minIntervalMs - timeSinceLast
+        card.pendingTimer = setT(() => {
+          card.pendingTimer = null
+          const refreshed = renderCard(card, ctx, now())
+          if (refreshed) emitNow(card, refreshed, false, now())
+        }, wait)
+        return
+      }
+      // Skip emit if the first event is itself terminal-only with no
+      // content — render returned `idle` only, edge case.
+      // (Render returns "idle" verb for empty state, that's still
+      //  worth pinning so leave as-is.)
+      emitNow(card, html, false, nowMs)
+      return
+    }
+    // Subsequent events: coalesce within `window`, but always respect
+    // `minIntervalMs` floor.
+    const debounce = Math.max(window, minIntervalMs - timeSinceLast)
+    card.pendingTimer = setT(() => {
+      card.pendingTimer = null
+      const refreshed = renderCard(card, ctx, now())
+      if (refreshed) emitNow(card, refreshed, false, now())
+    }, debounce)
+  }
+
+  function spawnCard(args: {
+    agentId: string
+    chatId: string
+    threadId?: string
+    parentTurnKey: string
+    spawnedAt: number
+  }): CardRecord {
+    const card: CardRecord = {
+      agentId: args.agentId,
+      chatId: args.chatId,
+      threadId: args.threadId,
+      parentTurnKey: args.parentTurnKey,
+      synthTurnKey: subAgentTurnKey(args.parentTurnKey, args.agentId),
+      spawnedAt: args.spawnedAt,
+      cardStartedAt: 0,
+      lastEmittedAt: 0,
+      lastEmittedHtml: '',
+      pendingTimer: null,
+      glyphTick: 0,
+      isFirstEmit: true,
+      finalEmitted: false,
+    }
+    cards.set(card.synthTurnKey, card)
+    log(
+      `subagent-card: spawn agentId=${args.agentId} parentTurnKey=${args.parentTurnKey}\n`,
+    )
+    return card
+  }
+
+  return {
+    syncFromParent(args) {
+      if (!config.enabled) return
+      const { state, chatId, threadId, parentTurnKey, now: nowMs } = args
+      lastSyncCtx.set(parentTurnKey, { state, chatId, threadId, parentTurnKey })
+      // Two-pass: spawn all eligible cards first so `siblingsFor()` —
+      // which the emit path consults to compute the k-of-n header — sees
+      // every newcomer in this sync. Otherwise the first sibling to emit
+      // would render "Agent 2 of 2" and the second "Agent 3 of 3", with
+      // the first card's k-of-n stuck at the stale value until its next
+      // edit.
+      const toSchedule: CardRecord[] = []
+      for (const [agentId, sa] of state.subAgents) {
+        const synth = subAgentTurnKey(parentTurnKey, agentId)
+        let card = cards.get(synth)
+        if (card == null) {
+          if (!hasContentSignal(sa)) continue
+          card = spawnCard({ agentId, chatId, threadId, parentTurnKey, spawnedAt: sa.startedAt })
+          ensureHeartbeat()
+        }
+        toSchedule.push(card)
+      }
+      for (const card of toSchedule) {
+        scheduleEmit(card, { state, chatId, threadId, parentTurnKey }, nowMs)
+      }
+      // For agents that vanished from state.subAgents (shouldn't
+      // normally happen — the reducer never deletes; but defensive),
+      // finalize their cards.
+      for (const card of [...cards.values()]) {
+        if (card.parentTurnKey !== parentTurnKey) continue
+        if (state.subAgents.has(card.agentId)) continue
+        if (card.finalEmitted) continue
+        const html = renderCard(card, { state }, nowMs)
+        if (html) emitNow(card, html, true, nowMs)
+        cards.delete(card.synthTurnKey)
+      }
+      maybeStopHeartbeat()
+    },
+
+    finalizeAll(parentTurnKey, nowMs) {
+      const ctx = lastSyncCtx.get(parentTurnKey)
+      for (const card of [...cards.values()]) {
+        if (card.parentTurnKey !== parentTurnKey) continue
+        if (card.finalEmitted) continue
+        if (card.pendingTimer != null) {
+          clearT(card.pendingTimer)
+          card.pendingTimer = null
+        }
+        if (ctx != null) {
+          const html = renderCard(card, ctx, nowMs)
+          if (html) emitNow(card, html, true, nowMs)
+        } else {
+          // No context to re-render with — best-effort emit using the
+          // last rendered HTML so the gateway's final-emit path can
+          // still flush the pin into a clean state.
+          if (card.lastEmittedHtml) {
+            emitNow(card, card.lastEmittedHtml, true, nowMs)
+          }
+        }
+        cards.delete(card.synthTurnKey)
+      }
+      lastSyncCtx.delete(parentTurnKey)
+      maybeStopHeartbeat()
+    },
+
+    dispose() {
+      for (const card of cards.values()) {
+        if (card.pendingTimer != null) clearT(card.pendingTimer)
+      }
+      cards.clear()
+      lastSyncCtx.clear()
+      if (heartbeatHandle != null) {
+        clearI(heartbeatHandle)
+        heartbeatHandle = null
+      }
+    },
+
+    trackedAgentIds(parentTurnKey) {
+      const out: string[] = []
+      for (const card of cards.values()) {
+        if (card.parentTurnKey === parentTurnKey) out.push(card.agentId)
+      }
+      out.sort()
+      return out
+    },
+  }
+}

--- a/telegram-plugin/tests/subagent-card.test.ts
+++ b/telegram-plugin/tests/subagent-card.test.ts
@@ -1,0 +1,358 @@
+/**
+ * Lifecycle tests for the per-sub-agent card registry.
+ *
+ * Wires a fake clock + manual timer dispatcher around
+ * `createSubAgentCardRegistry` so we can assert on emit sequencing,
+ * lazy spawn, coalesce, and finalize without touching real timers.
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+  createSubAgentCardRegistry,
+  isPerAgentPinsEnabled,
+  subAgentTurnKey,
+  type SubAgentCardEmitArgs,
+} from '../subagent-card.js'
+import {
+  initialState,
+  reduce,
+  type ProgressCardState,
+} from '../progress-card.js'
+import type { SessionEvent } from '../session-tail.js'
+
+const BASE_TIME = 1_700_000_000_000
+const PARENT_TURN_KEY = 'chat-1:42:1'
+const CHAT_ID = 'chat-1'
+const THREAD_ID = '42'
+
+interface PendingTimer {
+  fn: () => void
+  ms: number
+  cancelled: boolean
+  fired: boolean
+}
+
+function mkHarness(opts: { enabled?: boolean; now?: () => number } = {}) {
+  let nowVal = BASE_TIME
+  const emits: SubAgentCardEmitArgs[] = []
+  const tlog: string[] = []
+  const timers: PendingTimer[] = []
+  const intervals: PendingTimer[] = []
+
+  const advance = (ms: number) => {
+    nowVal += ms
+  }
+
+  const fireDueTimers = () => {
+    for (const t of timers) {
+      if (t.cancelled || t.fired) continue
+      t.fired = true
+      t.fn()
+    }
+  }
+
+  const registry = createSubAgentCardRegistry(
+    { enabled: opts.enabled ?? true },
+    {
+      emit: (args) => emits.push(args),
+      now: opts.now ?? (() => nowVal),
+      coalesceMs: 100,
+      multiCardCoalesceMs: 200,
+      minIntervalMs: 50,
+      heartbeatMs: 1000,
+      log: (line) => tlog.push(line),
+      setT: (fn, ms) => {
+        const entry: PendingTimer = { fn, ms, cancelled: false, fired: false }
+        timers.push(entry)
+        return { ref: entry }
+      },
+      clearT: (handle) => {
+        const entry = handle.ref as PendingTimer
+        entry.cancelled = true
+      },
+      setI: (fn, ms) => {
+        const entry: PendingTimer = { fn, ms, cancelled: false, fired: false }
+        intervals.push(entry)
+        return { ref: entry }
+      },
+      clearI: (handle) => {
+        const entry = handle.ref as PendingTimer
+        entry.cancelled = true
+      },
+    },
+  )
+
+  return {
+    registry,
+    emits,
+    tlog,
+    timers,
+    intervals,
+    advance,
+    fireDueTimers,
+    now: () => nowVal,
+  }
+}
+
+function enqueue(): SessionEvent {
+  return { kind: 'enqueue', rawContent: '<channel>do work</channel>', messageId: 'm1' } as unknown as SessionEvent
+}
+
+function subStart(agentId: string, firstPromptText = 'go'): SessionEvent {
+  return {
+    kind: 'sub_agent_started',
+    agentId,
+    firstPromptText,
+  } as unknown as SessionEvent
+}
+
+function subToolUse(agentId: string, toolName = 'Read', toolUseId = 'tu_1'): SessionEvent {
+  return {
+    kind: 'sub_agent_tool_use',
+    agentId,
+    toolName,
+    toolUseId,
+    input: { file_path: '/tmp/x.ts' },
+  } as SessionEvent
+}
+
+function subToolResult(agentId: string, toolUseId = 'tu_1'): SessionEvent {
+  return {
+    kind: 'sub_agent_tool_result',
+    agentId,
+    toolUseId,
+    isError: false,
+  } as unknown as SessionEvent
+}
+
+function subTurnEnd(agentId: string): SessionEvent {
+  return { kind: 'sub_agent_turn_end', agentId } as unknown as SessionEvent
+}
+
+function ingest(state: ProgressCardState, events: SessionEvent[], now: number): ProgressCardState {
+  let s = state
+  for (const e of events) s = reduce(s, e, now)
+  return s
+}
+
+describe('subAgentTurnKey', () => {
+  it('joins parent + agent with `::`', () => {
+    expect(subAgentTurnKey('chat:42:1', 'sub-A')).toBe('chat:42:1::sub-A')
+  })
+})
+
+describe('isPerAgentPinsEnabled', () => {
+  it('returns true only when env flag is exactly "1"', () => {
+    expect(isPerAgentPinsEnabled({ PROGRESS_CARD_PER_AGENT_PINS: '1' })).toBe(true)
+    expect(isPerAgentPinsEnabled({ PROGRESS_CARD_PER_AGENT_PINS: '0' })).toBe(false)
+    expect(isPerAgentPinsEnabled({})).toBe(false)
+    expect(isPerAgentPinsEnabled({ PROGRESS_CARD_PER_AGENT_PINS: 'true' })).toBe(false)
+  })
+})
+
+describe('lazy spawn — first content event', () => {
+  it('does NOT spawn a card on sub_agent_started alone', () => {
+    const h = mkHarness()
+    let state = initialState()
+    state = ingest(state, [enqueue(), subStart('sub-A')], BASE_TIME)
+    h.registry.syncFromParent({ state, chatId: CHAT_ID, threadId: THREAD_ID, parentTurnKey: PARENT_TURN_KEY, now: h.now() })
+    expect(h.emits).toEqual([])
+    expect(h.registry.trackedAgentIds(PARENT_TURN_KEY)).toEqual([])
+  })
+
+  it('spawns + emits on the first sub_agent_tool_use', () => {
+    const h = mkHarness()
+    let state = initialState()
+    state = ingest(state, [enqueue(), subStart('sub-A'), subToolUse('sub-A')], BASE_TIME)
+    h.registry.syncFromParent({ state, chatId: CHAT_ID, threadId: THREAD_ID, parentTurnKey: PARENT_TURN_KEY, now: h.now() })
+    expect(h.emits).toHaveLength(1)
+    expect(h.emits[0].agentId).toBe('sub-A')
+    expect(h.emits[0].turnKey).toBe('chat-1:42:1::sub-A')
+    expect(h.emits[0].chatId).toBe(CHAT_ID)
+    expect(h.emits[0].threadId).toBe(THREAD_ID)
+    expect(h.emits[0].isFirstEmit).toBe(true)
+    expect(h.emits[0].done).toBe(false)
+    expect(h.registry.trackedAgentIds(PARENT_TURN_KEY)).toEqual(['sub-A'])
+  })
+
+  it('spawns even when first content event is the terminal close', () => {
+    // Cold-jsonl synth: a sub_agent_turn_end may arrive without prior
+    // tool_use. Should still emit one card so the user sees what
+    // happened.
+    const h = mkHarness()
+    let state = initialState()
+    state = ingest(state, [enqueue(), subStart('sub-A'), subTurnEnd('sub-A')], BASE_TIME)
+    h.registry.syncFromParent({ state, chatId: CHAT_ID, threadId: THREAD_ID, parentTurnKey: PARENT_TURN_KEY, now: h.now() })
+    // Terminal: the registry emits done=true on first sync.
+    expect(h.emits).toHaveLength(1)
+    expect(h.emits[0].done).toBe(true)
+  })
+})
+
+describe('coalesce — burst events fire as one render', () => {
+  it('a second sync within the coalesce window does NOT double-emit', () => {
+    const h = mkHarness()
+    let state = initialState()
+    state = ingest(state, [enqueue(), subStart('sub-A'), subToolUse('sub-A')], BASE_TIME)
+    h.registry.syncFromParent({ state, chatId: CHAT_ID, threadId: THREAD_ID, parentTurnKey: PARENT_TURN_KEY, now: h.now() })
+    expect(h.emits).toHaveLength(1)
+
+    // Burst: another tool_use → another sync within the coalesce window.
+    h.advance(20)
+    state = ingest(state, [subToolResult('sub-A'), subToolUse('sub-A', 'Bash', 'tu_2')], h.now())
+    h.registry.syncFromParent({ state, chatId: CHAT_ID, threadId: THREAD_ID, parentTurnKey: PARENT_TURN_KEY, now: h.now() })
+    expect(h.emits).toHaveLength(1) // still pending in the coalesce timer
+
+    // Fire the coalesce timer.
+    h.advance(150)
+    h.fireDueTimers()
+    expect(h.emits).toHaveLength(2)
+    expect(h.emits[1].agentId).toBe('sub-A')
+    expect(h.emits[1].isFirstEmit).toBe(false)
+  })
+})
+
+describe('finalize — terminal state emits done=true exactly once', () => {
+  it('sub_agent_turn_end after activity → done emit', () => {
+    const h = mkHarness()
+    let state = initialState()
+    state = ingest(state, [enqueue(), subStart('sub-A'), subToolUse('sub-A')], BASE_TIME)
+    h.registry.syncFromParent({ state, chatId: CHAT_ID, threadId: THREAD_ID, parentTurnKey: PARENT_TURN_KEY, now: h.now() })
+    expect(h.emits).toHaveLength(1)
+
+    h.advance(100)
+    state = ingest(state, [subToolResult('sub-A'), subTurnEnd('sub-A')], h.now())
+    h.registry.syncFromParent({ state, chatId: CHAT_ID, threadId: THREAD_ID, parentTurnKey: PARENT_TURN_KEY, now: h.now() })
+    expect(h.emits).toHaveLength(2)
+    expect(h.emits[1].done).toBe(true)
+    expect(h.registry.trackedAgentIds(PARENT_TURN_KEY)).toEqual([])
+  })
+
+  it('finalizeAll force-finalizes any remaining cards', () => {
+    const h = mkHarness()
+    let state = initialState()
+    state = ingest(state, [enqueue(), subStart('sub-A'), subToolUse('sub-A')], BASE_TIME)
+    h.registry.syncFromParent({ state, chatId: CHAT_ID, threadId: THREAD_ID, parentTurnKey: PARENT_TURN_KEY, now: h.now() })
+
+    h.advance(50)
+    h.registry.finalizeAll(PARENT_TURN_KEY, h.now())
+    // The final emit fires.
+    const finalEmit = h.emits[h.emits.length - 1]
+    expect(finalEmit.done).toBe(true)
+    expect(h.registry.trackedAgentIds(PARENT_TURN_KEY)).toEqual([])
+  })
+})
+
+describe('multi-agent: distinct cards, k-of-n indexing', () => {
+  it('three sub-agents → three distinct emits with distinct turnKeys', () => {
+    const h = mkHarness()
+    let state = initialState()
+    state = ingest(
+      state,
+      [
+        enqueue(),
+        subStart('sub-A'), subToolUse('sub-A', 'Read', 'tu_a'),
+        subStart('sub-B'), subToolUse('sub-B', 'Bash', 'tu_b'),
+        subStart('sub-C'), subToolUse('sub-C', 'Grep', 'tu_c'),
+      ],
+      BASE_TIME,
+    )
+    h.registry.syncFromParent({ state, chatId: CHAT_ID, threadId: THREAD_ID, parentTurnKey: PARENT_TURN_KEY, now: h.now() })
+    expect(h.emits).toHaveLength(3)
+    const turnKeys = h.emits.map((e) => e.turnKey).sort()
+    expect(turnKeys).toEqual([
+      'chat-1:42:1::sub-A',
+      'chat-1:42:1::sub-B',
+      'chat-1:42:1::sub-C',
+    ])
+    const agentIds = h.emits.map((e) => e.agentId).sort()
+    expect(agentIds).toEqual(['sub-A', 'sub-B', 'sub-C'])
+    expect(h.registry.trackedAgentIds(PARENT_TURN_KEY).sort()).toEqual(['sub-A', 'sub-B', 'sub-C'])
+  })
+
+  it('one sub-agent finishing leaves siblings tracked', () => {
+    const h = mkHarness()
+    let state = initialState()
+    state = ingest(
+      state,
+      [
+        enqueue(),
+        subStart('sub-A'), subToolUse('sub-A', 'Read', 'tu_a'),
+        subStart('sub-B'), subToolUse('sub-B', 'Bash', 'tu_b'),
+      ],
+      BASE_TIME,
+    )
+    h.registry.syncFromParent({ state, chatId: CHAT_ID, threadId: THREAD_ID, parentTurnKey: PARENT_TURN_KEY, now: h.now() })
+    expect(h.registry.trackedAgentIds(PARENT_TURN_KEY).sort()).toEqual(['sub-A', 'sub-B'])
+
+    h.advance(100)
+    state = ingest(state, [subToolResult('sub-A', 'tu_a'), subTurnEnd('sub-A')], h.now())
+    h.registry.syncFromParent({ state, chatId: CHAT_ID, threadId: THREAD_ID, parentTurnKey: PARENT_TURN_KEY, now: h.now() })
+    expect(h.registry.trackedAgentIds(PARENT_TURN_KEY)).toEqual(['sub-B'])
+  })
+
+  it('renders k-of-n where k starts at 2 (parent reserves k=1)', () => {
+    const h = mkHarness()
+    let state = initialState()
+    state = ingest(
+      state,
+      [
+        enqueue(),
+        subStart('sub-A'), subToolUse('sub-A', 'Read', 'tu_a'),
+        subStart('sub-B'), subToolUse('sub-B', 'Bash', 'tu_b'),
+      ],
+      BASE_TIME,
+    )
+    h.registry.syncFromParent({ state, chatId: CHAT_ID, threadId: THREAD_ID, parentTurnKey: PARENT_TURN_KEY, now: h.now() })
+    expect(h.emits).toHaveLength(2)
+    // Both render rows include "Agent X of 3" — parent counts as 1, two
+    // sub-agents make total 3. k for sub-A is 2, k for sub-B is 3 (or
+    // vice versa depending on spawn order).
+    for (const e of h.emits) {
+      expect(e.html).toMatch(/Agent [23] of 3/)
+    }
+    // Each card should mention exactly one of the agentIds in its title fallback chain.
+    expect(h.emits.some((e) => e.html.includes('Agent 2 of 3'))).toBe(true)
+    expect(h.emits.some((e) => e.html.includes('Agent 3 of 3'))).toBe(true)
+  })
+})
+
+describe('disabled mode — no-op', () => {
+  it('with enabled=false, syncFromParent is inert', () => {
+    const h = mkHarness({ enabled: false })
+    let state = initialState()
+    state = ingest(state, [enqueue(), subStart('sub-A'), subToolUse('sub-A')], BASE_TIME)
+    h.registry.syncFromParent({ state, chatId: CHAT_ID, threadId: THREAD_ID, parentTurnKey: PARENT_TURN_KEY, now: h.now() })
+    expect(h.emits).toEqual([])
+    expect(h.registry.trackedAgentIds(PARENT_TURN_KEY)).toEqual([])
+  })
+})
+
+describe('dispose — cleans timers and state', () => {
+  it('idempotent and clears tracked agentIds', () => {
+    const h = mkHarness()
+    let state = initialState()
+    state = ingest(state, [enqueue(), subStart('sub-A'), subToolUse('sub-A')], BASE_TIME)
+    h.registry.syncFromParent({ state, chatId: CHAT_ID, threadId: THREAD_ID, parentTurnKey: PARENT_TURN_KEY, now: h.now() })
+    expect(h.registry.trackedAgentIds(PARENT_TURN_KEY)).toEqual(['sub-A'])
+
+    h.registry.dispose()
+    expect(h.registry.trackedAgentIds(PARENT_TURN_KEY)).toEqual([])
+    // Calling again is safe.
+    expect(() => h.registry.dispose()).not.toThrow()
+  })
+})
+
+describe('end-to-end: events drive emits with correct content', () => {
+  it('first emit HTML contains title + status row + glyph', () => {
+    const h = mkHarness()
+    let state = initialState()
+    state = ingest(state, [enqueue(), subStart('sub-A', 'go research'), subToolUse('sub-A', 'Read', 'tu_a')], BASE_TIME)
+    h.registry.syncFromParent({ state, chatId: CHAT_ID, threadId: THREAD_ID, parentTurnKey: PARENT_TURN_KEY, now: h.now() })
+    expect(h.emits).toHaveLength(1)
+    const html = h.emits[0].html
+    expect(html).toContain('<b>Agent 2 of 2</b>')
+    // Read tool with file path renders as the verb.
+    expect(html).toMatch(/<i>Read /)
+  })
+})


### PR DESCRIPTION
## Summary

Each running sub-agent gets its own pinned Telegram status card, driven
by the CLI-style status row + ◼/◻/✔ TaskList block from #624. Off by
default — opt in with `PROGRESS_CARD_PER_AGENT_PINS=1`. When the flag
is on, the parent card's `<blockquote expandable>` sub-agent block is
suppressed (sub-agents have their own cards now); when off, the legacy
stacked-card behaviour is preserved.

This is the integration layer on top of the foundations in #624 (pin
manager composite key + TodoWrite reducer + `renderAgentCard` /
`projectAgentSlice` pure functions).

## Design contract

- **Outcome:** advances *Visibility* and *Multi-agent fleet*. Each
  active worker gets its own ambient surface, addressing the
  `know-what-my-agent-is-doing` JTBD anti-pattern of "Sub-agent work
  happening on a surface the parent never references" by giving each
  sub-agent a peer-level pinned card in the same chat/topic.
- **Docs test:** operator-facing rollout flag, follows the precedent
  of `PROGRESS_CARD_DRAFT_TRANSPORT` and `PROGRESS_CARD_MULTI_AGENT`
  (also undocumented; live in code comments).
- **Defaults test:** flag default off; fresh `switchroom setup`
  unchanged.
- **Consistency test:** same emit signature, pin manager, render
  template philosophy as the parent card path.

## What's in this PR

**New module: `telegram-plugin/subagent-card.ts`**
- Lightweight per-card state (chatId, threadId, parentTurnKey,
  agentId, messageId, glyphTick, timers).
- Lazy spawn: only when the sub-agent has a content signal
  (currentTool / currentNarrative / firstNarrativeText / tasks /
  completed tool / terminal). Avoids empty placeholder cards for
  orphan starts.
- Synthetic turnKey of the form `${parentTurnKey}::${agentId}` so the
  gateway's existing stream-reply infra routes each card as its own
  Telegram message — no parallel plumbing.
- Two-pass `syncFromParent`: spawn all eligible cards first so
  `k`-of-`n` sibling counts are stable across a burst of emits.
- Per-card coalesce + heartbeat timers; `multiCardCoalesceMs` (800ms
  default) when ≥ 2 cards active in the same chat+thread to share the
  existing 60s edit budget across siblings.
- `finalizeAll(parentTurnKey)` for catastrophic cleanup paths so any
  sub-agent whose `sub_agent_turn_end` was missed still gets a final
  emit + unpin.

**Driver wiring (`progress-card-driver.ts`)**
- Registry instantiated at boot, gated on `isPerAgentPinsEnabled()`.
- `syncFromParent` after every `reduce` in `ingest()`, including the
  carried-over-sub-agents path on enqueue.
- `finalizeAll` from `completeTurnFully` before `chats.delete`.
- `dispose()` forwards to `registry.dispose()` unless
  `preservePending`, in which case the registry continues ticking
  heartbeats for cards whose parent chats are still alive.
- Optional `agentId` field on the `emit` callback signature.

**Gateway wiring (`gateway.ts`)**
- `emit` handler destructures `agentId` and threads it to
  `pinMgr.considerPin` / `pinMgr.pinnedMessageId`.
- When emit args include `done && agentId`, calls
  `pinMgr.completeTurn` to unpin the sub-agent card. Parent-card
  unpin still goes through `onTurnComplete` unchanged.

**Render-side flag (`progress-card.ts`)**
- When `PROGRESS_CARD_PER_AGENT_PINS=1`, the parent card's
  `<blockquote expandable>` sub-agent block is suppressed entirely.
  Off by default during soft rollout.

## Test plan

- [x] `npm run lint` clean (52 pre-existing type-debt errors in
  unrelated files, tracked separately)
- [x] `npm run build` clean
- [x] `bun test telegram-plugin` — 3249 pass / 0 fail (+14 new tests
  cover registry lifecycle: lazy spawn, coalesce, finalize,
  multi-agent k-of-n indexing, disabled-mode no-op, dispose cleanup,
  end-to-end events→registry→html).
- [x] `npm run test:vitest` — 4760 pass / 0 fail.
- [ ] Live Telegram verification with
  `PROGRESS_CARD_PER_AGENT_PINS=1` on one agent — to land before
  flipping the default.

## Soft rollout plan

1. Land this PR with the flag default off — no behaviour change.
2. Flip on for one agent in production for 24–48h. Watch for:
   pin-clutter complaints, edit-budget warnings in journalctl, ghost
   pins on bridge disconnect.
3. Follow-up PR flips the default on and removes the parent's
   expandable sub-agent block entirely.

## Deferred to follow-ups

- §6 cross-card edit-budget fairness scheduler.
- §7 `PROGRESS_CARD_MAX_PINS_PER_TOPIC` cap + parent-pinned-last
  header preference.
- Token count + thinking-duration ingestion (require session-tail
  event-schema work; blocked on upstream).
- Parent-card backreference to active sub-agents (one-line "+N
  sub-agents" so the parent surface still mentions the children) —
  noted from JTBD review of `know-what-my-agent-is-doing`
  anti-patterns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)