### PR TITLE
chore: release v0.5.1 — fix v0.5.0 packaging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,34 @@
 
 ## [Unreleased]
 
+## v0.5.1 — 2026-05-03
+
+### Fixed
+
+- **v0.5.0 release packaging — gateway service unit pointed at
+  unshipped paths.** v0.5.0 introduced a split `claude` + `gateway`
+  systemd-unit architecture whose `ExecStart` references
+  `~/.bun/install/global/node_modules/switchroom-ai/telegram-plugin/gateway/gateway.ts`
+  and `~/.bun/install/global/node_modules/switchroom-ai/bin/autoaccept.exp`,
+  but the `package.json` `files` array only included `dist`,
+  `profiles`, `skills`, `README.md`, `LICENSE`. Result: every
+  agent's gateway service failed at boot with
+  `Module not found "...telegram-plugin/gateway/gateway.ts"` until
+  systemd hit the start-limit. Agents went silent on Telegram.
+- **Telegram-plugin runtime deps not in root `dependencies`.**
+  `@grammyjs/runner`, `@modelcontextprotocol/sdk`, `@secretlint/*`,
+  `@xterm/headless`, `grammy` were declared on the workspace
+  package only — not on `switchroom-ai`. Fresh consumer installs
+  couldn't resolve these imports from the gateway. Promoted them to
+  root `dependencies` so `npm i -g switchroom-ai` pulls them.
+
+### Migration
+
+`bun add -g switchroom-ai@0.5.1` (or `npm i -g switchroom-ai@0.5.1`)
+then `switchroom agent restart all` — units pick up the now-shipped
+source. v0.5.0 outboundDedup hotfix (#625) and per-agent card
+foundations (#624, #627) are inherited from v0.5.0 unchanged.
+
 ## v0.5.0 — 2026-05-03
 
 ### Added

--- a/bun.lock
+++ b/bun.lock
@@ -5,9 +5,16 @@
     "": {
       "name": "clerk-ai",
       "dependencies": {
+        "@grammyjs/runner": "^2.0.3",
+        "@modelcontextprotocol/sdk": "^1.0.0",
+        "@secretlint/core": "^12.2.0",
+        "@secretlint/secretlint-rule-preset-recommend": "^12.2.0",
+        "@secretlint/types": "^12.2.0",
+        "@xterm/headless": "^6.0.0",
         "bcryptjs": "^3.0.3",
         "chalk": "^5.4.0",
         "commander": "^13.1.0",
+        "grammy": "^1.21.0",
         "handlebars": "^4.7.8",
         "posthog-node": "^5.29.2",
         "yaml": "^2.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "switchroom-ai",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Run Claude Code 24/7 on your Claude Pro/Max subscription over Telegram. Open-source alternative to OpenClaw and NanoClaw — no API keys, no Docker.",
   "type": "module",
   "bin": {
@@ -11,6 +11,8 @@
     "dist",
     "profiles",
     "skills",
+    "telegram-plugin",
+    "bin",
     "README.md",
     "LICENSE"
   ],
@@ -27,9 +29,16 @@
     "prepublishOnly": "npm run build && npm run lint && npm test"
   },
   "dependencies": {
+    "@grammyjs/runner": "^2.0.3",
+    "@modelcontextprotocol/sdk": "^1.0.0",
+    "@secretlint/core": "^12.2.0",
+    "@secretlint/secretlint-rule-preset-recommend": "^12.2.0",
+    "@secretlint/types": "^12.2.0",
+    "@xterm/headless": "^6.0.0",
     "bcryptjs": "^3.0.3",
     "chalk": "^5.4.0",
     "commander": "^13.1.0",
+    "grammy": "^1.21.0",
     "handlebars": "^4.7.8",
     "posthog-node": "^5.29.2",
     "yaml": "^2.7.0",


### PR DESCRIPTION
## Summary

v0.5.0 introduced a split `claude` + `gateway` systemd-unit
architecture but didn't ship the source paths the units reference.
Every agent's gateway service failed at boot until systemd hit the
start-limit, leaving the fleet silent on Telegram.

## Root cause

The new gateway unit's `ExecStart` references:
```
/home/.../node_modules/switchroom-ai/telegram-plugin/gateway/gateway.ts
/home/.../node_modules/switchroom-ai/bin/autoaccept.exp
```

But `package.json` `files` only included `dist`, `profiles`,
`skills`, `README.md`, `LICENSE`. Both `telegram-plugin/` and `bin/`
were missing from the published artifact.

Symptom in `journalctl --user -u switchroom-<agent>-gateway`:
```
error: Module not found "...telegram-plugin/gateway/gateway.ts"
switchroom-clerk-gateway.service: Start request repeated too quickly.
switchroom-clerk-gateway.service: Failed with result 'start-limit-hit'.
```

## Fix

- Add `telegram-plugin` and `bin` to `package.json` `files`.
- Promote telegram-plugin's runtime deps to root `dependencies` so
  consumer installs can resolve them: `@grammyjs/runner`,
  `@modelcontextprotocol/sdk`, `@secretlint/core`,
  `@secretlint/secretlint-rule-preset-recommend`, `@secretlint/types`,
  `@xterm/headless`, `grammy`.
- Bump `0.5.0` → `0.5.1`.

## Verification

`npm pack --dry-run` on this branch:
- v0.5.0: 327 files, 989 kB
- **v0.5.1: 663 files, 1.6 MB** (now includes `telegram-plugin/` (328 files) and `bin/` (5 files))
- `bin/autoaccept.exp` and `telegram-plugin/gateway/gateway.ts` both present

Lint clean, build clean. The behavioural surface is unchanged from
v0.5.0 — this is a packaging-only fix.

## Migration

```
bun add -g switchroom-ai@0.5.1     # or npm i -g
switchroom agent restart all       # units pick up the now-shipped source
```

## Notes

- v0.5.0 outboundDedup hotfix (#625), per-agent card foundations
  (#624), and per-sub-agent driver (#627) inherited unchanged.
- The local fleet has been mitigated via symlinks
  (`~/.bun/install/global/node_modules/switchroom-ai/{telegram-plugin,bin}`
  → workspace) — `bun add -g switchroom-ai@0.5.1` will replace those
  symlinks with the proper packaged dirs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)