### PR TITLE
chore: release v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,48 @@
 
 ## [Unreleased]
 
+
+## v0.6.0 — 2026-05-03
+
+### Fixed
+
+- **Multiple status messages emitted during single turn (#626).** The
+  progress-card emit lifecycle had a structural failure mode: when
+  `stream_reply(done=true)` finalized the lane, it deleted
+  `activeDraftStreams[sKey]` — and any subsequent emit on the same
+  lane+turnKey created a fresh `sendMessage` instead of editing the
+  pinned card. The 2026-04-23 sub-agent fix covered ONE path; the RCA
+  on this issue identified 7 more (deferred completion, zombie close,
+  forceDone, dedup-key mismatch, etc.). All collapse to the same
+  symptom: the user sees multiple separate status messages where one
+  anchor message edited in place was expected.
+
+  Root-cause-shaped fix: a new `lookupExistingMessageId` hook in
+  `stream-reply-handler.ts` lets the gateway feed back the anchor
+  message id from the pin manager. When the handler is about to create
+  a fresh stream because `activeDraftStreams[sKey]` was deleted, it
+  consults the hook; if the pin manager already knows the id for this
+  turnKey, the new stream initializes with that id so the very next
+  update fires `editMessageText` instead of `sendMessage`. Stale ids
+  fall back gracefully via the existing not-found path.
+
+  Closes the bug class structurally — every previously-known path now
+  collapses to "edit the existing anchor."
+
+### Added
+
+- **`anchorMessageCount(chatId, threadId?)`** harness invariant in
+  `real-gateway-harness.ts` — returns the count of fresh `sendMessage`
+  calls (NOT edits) for a chat. Anything > 1 across a single logical
+  turn IS the duplicate-status-message bug class. New I7 describe
+  block in `real-gateway-i6-...` pins the invariant. Catches ANY
+  future regression in any of the 8 RCA paths the moment a second
+  anchor lands — verified to flag 5/6 historical dup-message bugs
+  (#546, #251, #549, #371, #489) and all 8 paths.
+
+- **`initialMessageId`** optional config on `createDraftStream` and
+  `createStreamController`. Plumbing for the lookup hook above.
+  Purely additive — back-compat verified.
 ## v0.5.1 — 2026-05-03
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "switchroom-ai",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "Run Claude Code 24/7 on your Claude Pro/Max subscription over Telegram. Open-source alternative to OpenClaw and NanoClaw — no API keys, no Docker.",
   "type": "module",
   "bin": {

--- a/src/build-info.ts
+++ b/src/build-info.ts
@@ -2,8 +2,8 @@
 // Tracked in git so `tsc --noEmit` works on a fresh clone before `npm run build`.
 // Values are refreshed every time `npm run build` runs.
 
-export const VERSION: string = "0.5.0";
-export const COMMIT_SHA: string | null = "0ba0f0a";
-export const COMMIT_DATE: string | null = "2026-05-03T14:20:08+10:00";
-export const LATEST_PR: number | null = 628;
-export const COMMITS_AHEAD_OF_TAG: number | null = 0;
+export const VERSION: string = "0.6.0";
+export const COMMIT_SHA: string | null = "4cc972d";
+export const COMMIT_DATE: string | null = "2026-05-03T16:06:07+10:00";
+export const LATEST_PR: number | null = 630;
+export const COMMITS_AHEAD_OF_TAG: number | null = 1;


### PR DESCRIPTION
Ships the #626 duplicate-status-message fix (PR #630, merged via \`4cc972d\`) to npm.

Fleet agents run telegram-plugin from the npm-installed global package, so the fix only reaches them after a published release. Without this release, agents continue running v0.5.1 even though main has the fix.

## Changes

- \`package.json\`: 0.5.1 → 0.6.0
- \`CHANGELOG.md\`: new v0.6.0 section documenting the fix + the harness invariant + the new \`initialMessageId\` config
- \`src/build-info.ts\`: regenerated by \`bun run build\` so the runtime reports the new version

## Why minor (not patch)

The fix introduces new (additive, opt-in) public API on:
- \`DraftStreamConfig.initialMessageId\` — optional config
- \`StreamControllerConfig.initialMessageId\` — passes through
- \`StreamReplyDeps.lookupExistingMessageId\` — optional hook
- \`RealGatewayHarnessHandle.anchorMessageCount\` — new helper

Per semver, additive API surface = minor bump. (Could argue patch since none of these are documented as stable plugin API, but operator-facing it's a meaningful upgrade — minor is the safer signal.)

## After merge

1. Tag v0.6.0 on the merge commit
2. \`npm publish\` from the canonical repo
3. Bump global install on the deployed fleet
4. Restart agents to pick up v0.6.0 (the duplicate-status-message bug is fixed only after this step)

🤖 Generated with [Claude Code](https://claude.com/claude-code)