### PR TITLE
feat(issues-card): render remediation hint under each issue

### DIFF
--- a/src/agents/sub-agent-telegram-prompt.ts
+++ b/src/agents/sub-agent-telegram-prompt.ts
@@ -106,8 +106,16 @@ export function buildCronTelegramGuidance(args: {
 If something half-broken happens during this run (e.g. an upstream API timed out, a vault key was missing, a non-fatal data gap), record it via:
 
 \`\`\`
-switchroom issues record --severity warn --source "cron:${args.jobSlug}" --code <stable-code> --summary "<one-line>"
+switchroom issues record --severity warn --source "cron:${args.jobSlug}" --code <stable-code> --summary "<one-line>" --detail "Fix: <one-line remediation, e.g. exact command the user can run>"
 \`\`\`
+
+The \`--detail\` field is rendered as a "→ Fix: ..." line under the issue on the user's Telegram card. Make it actionable — a copy-pastable command or a one-line action, not a description of the problem. Examples:
+
+- \`--detail "Fix: switchroom vault unlock"\` (when the vault broker is locked)
+- \`--detail "Fix: re-run \`claude setup-token\` for ken@example.com"\` (when an account is unauthenticated)
+- \`--detail "Fix: \\\`switchroom auth heal --account=<name>\\\`"\` (when an OAuth token expired)
+
+Skip \`--detail\` if there's no clean one-line fix — leaving it empty means the card shows just the summary, which is fine.
 
 Use the EXACT \`--source "cron:${args.jobSlug}"\` shown above — the cron wrapper auto-resolves issues with that source on a clean run. Picking a different source means the issue persists across recoveries.
 `

--- a/telegram-plugin/issues-card.ts
+++ b/telegram-plugin/issues-card.ts
@@ -103,7 +103,14 @@ export function renderIssuesCard(opts: RenderIssuesCardOpts): string | null {
     const emoji = SEVERITY_EMOJI[e.severity];
     const occ = e.occurrences > 1 ? ` <i>(×${e.occurrences})</i>` : "";
     const ago = relTime(now - e.last_seen);
-    return `${emoji} <code>${escapeHtml(e.fingerprint)}</code>  ${escapeHtml(e.summary)}${occ} — <i>${ago}</i>`;
+    const head = `${emoji} <code>${escapeHtml(e.fingerprint)}</code>  ${escapeHtml(e.summary)}${occ} — <i>${ago}</i>`;
+    // Render the `detail` line below the summary when present and short
+    // enough to be a remediation hint (not a multi-line stderr tail).
+    // Convention from the cron prompt template: agents put "Fix: <cmd>"
+    // or "→ <cmd>" in detail. Long stderr details are omitted from the
+    // card to keep the layout tight; users can run /issues to see them.
+    const remediation = formatRemediation(e.detail);
+    return remediation == null ? head : `${head}\n  → <i>${escapeHtml(remediation)}</i>`;
   });
 
   const lines = [header, "", ...rows];
@@ -112,6 +119,32 @@ export function renderIssuesCard(opts: RenderIssuesCardOpts): string | null {
     lines.push(`<i>+${overflow} more not shown — run <code>/issues</code></i>`);
   }
   return lines.join("\n");
+}
+
+/**
+ * Extract a remediation hint from the `detail` field, or null if the
+ * detail is missing / not remediation-shaped.
+ *
+ * Convention: agents (and CLI callers) put a short, single-line
+ * remediation in `--detail` prefixed with "Fix:" or "→". Multi-line
+ * stderr tails are not surfaced here — too noisy for the card, and
+ * `/issues` shows the full detail anyway.
+ *
+ * Cap at REMEDIATION_MAX_CHARS so a stray-detail issue doesn't blow
+ * up the card layout.
+ */
+const REMEDIATION_MAX_CHARS = 140;
+function formatRemediation(detail: string | undefined): string | null {
+  if (!detail) return null;
+  // Strip leading whitespace and the conventional prefixes ("Fix:", "→").
+  const trimmed = detail.replace(/^[\s ]+/, "");
+  const m = trimmed.match(/^(?:fix:|→)\s*(.+?)(?:\n|$)/i);
+  if (!m) return null;
+  const hint = m[1].trim();
+  if (hint.length === 0) return null;
+  return hint.length > REMEDIATION_MAX_CHARS
+    ? hint.slice(0, REMEDIATION_MAX_CHARS - 1) + "…"
+    : hint;
 }
 
 function relTime(deltaMs: number): string {

--- a/telegram-plugin/tests/issues-card.test.ts
+++ b/telegram-plugin/tests/issues-card.test.ts
@@ -44,6 +44,70 @@ describe("renderIssuesCard", () => {
     expect(out).toContain("3 issues");
   });
 
+  // ─── Remediation rendering (the "Fix:" → arrow under the issue) ─────
+  describe("remediation hint from detail field", () => {
+    it("renders a 'Fix:' detail as a → line under the issue", () => {
+      const events = [
+        makeEvent({
+          summary: "Morning brief skipped — vault locked",
+          detail: "Fix: switchroom vault unlock",
+        }),
+      ];
+      const out = renderIssuesCard({ agentName: "kengpt", events });
+      expect(out).toContain("→ <i>switchroom vault unlock</i>");
+      // Summary still rendered above the remediation.
+      expect(out).toContain("Morning brief skipped");
+    });
+
+    it("renders a → prefixed detail (no 'Fix:' literal needed)", () => {
+      const events = [
+        makeEvent({
+          detail: "→ run `switchroom auth heal --account=ken`",
+        }),
+      ];
+      const out = renderIssuesCard({ agentName: "kengpt", events });
+      expect(out).toMatch(/→ <i>run.*auth heal/);
+    });
+
+    it("ignores multi-line detail (likely stderr tail, not remediation)", () => {
+      // A common pattern: --detail "stderr line 1\nstderr line 2".
+      // Card omits these to keep layout tight; /issues shows full detail.
+      const events = [
+        makeEvent({
+          summary: "claude -p exited 1",
+          detail: "Traceback (most recent call last):\n  File '/x.py'...",
+        }),
+      ];
+      const out = renderIssuesCard({ agentName: "kengpt", events });
+      expect(out).not.toContain("→");
+      expect(out).not.toContain("Traceback");
+    });
+
+    it("ignores empty detail", () => {
+      const events = [makeEvent({ detail: "" })];
+      const out = renderIssuesCard({ agentName: "kengpt", events });
+      expect(out).not.toContain("→");
+    });
+
+    it("truncates remediation longer than 140 chars", () => {
+      const longFix = "Fix: " + "a".repeat(200);
+      const events = [makeEvent({ detail: longFix })];
+      const out = renderIssuesCard({ agentName: "kengpt", events });
+      expect(out).toContain("…");
+      // Issue card shouldn't carry a 200-char single line.
+      expect((out ?? "").split("\n").every((line) => line.length < 600)).toBe(true);
+    });
+
+    it("escapes HTML in remediation hints", () => {
+      const events = [
+        makeEvent({ detail: "Fix: <script>alert('xss')</script>" }),
+      ];
+      const out = renderIssuesCard({ agentName: "kengpt", events });
+      expect(out).not.toContain("<script>");
+      expect(out).toContain("&lt;script&gt;");
+    });
+  });
+
   it("uses singular 'issue' for one event", () => {
     const events = [makeEvent({})];
     const out = renderIssuesCard({ agentName: "klanker", events });


### PR DESCRIPTION
User feedback: \"cron warnings should provide the solution to remediate the warning, not just the warning.\"

Today the issues card shows summary + age + count, but no actionable fix. A user sees \"Morning brief skipped — vault broker is locked\" and has no idea what to type next.

## Changes

**1. \`issues-card.ts\` renders the \`detail\` field as a remediation hint.**

When \`detail\` starts with \`Fix:\` or \`→\` (and is single-line), the card surfaces it as a \`→ <hint>\` line under the summary. Multi-line stderr-tail details are excluded from the card (still visible via \`/issues\`). Capped at 140 chars and HTML-escaped.

**2. The cron prompt teaches agents to include remediation.**

Updated \`sub-agent-telegram-prompt.ts\` to instruct agents recording transient issues to add \`--detail \"Fix: <command>\"\`, with concrete examples:
- \`Fix: switchroom vault unlock\` (vault locked)
- \`Fix: re-run claude setup-token for X\` (auth missing)
- \`Fix: switchroom auth heal --account=Y\` (token expired)

The \`detail\` field already exists in the issue schema (\`IssueInput.detail\`) and is accepted by \`switchroom issues record --detail\`. No schema change. Just rendering + prompt guidance.

## Visible result

Before:
\`\`\`
⚠️ KenGPT · 1 issue

⚠️ cron:morning-brief::vault-locked  Morning brief skipped — vault locked — 2d ago
\`\`\`

After:
\`\`\`
⚠️ KenGPT · 1 issue

⚠️ cron:morning-brief::vault-locked  Morning brief skipped — vault locked — 2d ago
  → switchroom vault unlock
\`\`\`

## Test plan
- [x] \`npm run lint\` clean
- [x] 28 issues-card tests pass (6 new for remediation rendering: Fix-literal, →-prefix, multi-line ignored, empty ignored, 140-char truncation, HTML escaping)
- [x] Existing 22 tests unaffected

## Cross-reference

Surfaced when KenGPT's morning-brief cron repeatedly emitted the vault-locked warning with no actionable hint. Agent had to be re-prompted to figure out the fix; this PR teaches the agent (via prompt) and the user (via card) at the same time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)