### PR TITLE
feat(auth): /auth share + `all` keyword for fleet-wide account fanout

### DIFF
--- a/src/cli/auth-accounts.ts
+++ b/src/cli/auth-accounts.ts
@@ -60,7 +60,44 @@ export function registerAuthAccountSubcommands(
 
   registerEnable(authParent, program);
   registerDisable(authParent, program);
+  registerShare(authParent, program);
   registerRefreshAccounts(authParent, program);
+}
+
+/* ── helpers: `all` agent expansion ──────────────────────────────────── */
+
+/**
+ * Expand the special `all` keyword into the list of every claude-enabled agent
+ * declared in switchroom.yaml. If `agents` is anything other than the
+ * single-element list `['all']`, returns it unchanged.
+ *
+ * Edge case: a literal agent named "all" in switchroom.yaml. The keyword
+ * still wins (matches the parser's whitelisting of "all"); we log a warning
+ * to stderr so the operator notices the collision.
+ */
+function expandAllAgents(
+  agents: string[],
+  config: ReturnType<typeof getConfig>,
+): string[] {
+  if (agents.length !== 1 || agents[0] !== "all") return agents;
+  if (config.agents["all"]) {
+    console.error(
+      chalk.yellow(
+        "  ⚠ An agent named 'all' is declared in switchroom.yaml — preferring " +
+          "the `all` keyword (every agent). Rename the agent to disambiguate.",
+      ),
+    );
+  }
+  const expanded = Object.entries(config.agents)
+    .filter(([, a]) => (a as { claude?: boolean }).claude !== false)
+    .map(([n]) => n)
+    .sort();
+  if (expanded.length === 0) {
+    throw new Error(
+      "no agents configured (or all agents have claude disabled)",
+    );
+  }
+  return expanded;
 }
 
 /* ── account add ─────────────────────────────────────────────────────── */
@@ -299,6 +336,9 @@ function registerEnable(authParent: Command, program: Command): void {
           );
         }
         const config = getConfig(program);
+        // Expand `all` BEFORE the per-agent guard so the friendly empty-config
+        // error fires correctly and unknown-agent checks run on real names.
+        agents = expandAllAgents(agents, config);
         const agentsDir = resolveAgentsDir(config);
         for (const name of agents) {
           if (!config.agents[name]) {
@@ -371,6 +411,8 @@ function registerDisable(authParent: Command, program: Command): void {
     .action(
       withConfigError(async (label: string, agents: string[]) => {
         validateAccountLabel(label);
+        const config = getConfig(program);
+        agents = expandAllAgents(agents, config);
         const yamlPath = getConfigPath(program);
         const before = readFileSync(yamlPath, "utf-8");
 
@@ -411,6 +453,169 @@ function registerDisable(authParent: Command, program: Command): void {
         }
         console.log();
       }),
+    );
+}
+
+/* ── share (one-shot: account add + enable on every agent) ──────────── */
+
+function registerShare(authParent: Command, program: Command): void {
+  authParent
+    .command("share <label>")
+    .description(
+      "One-shot: register an Anthropic account from an authenticated agent and " +
+        "enable it on every claude-enabled agent in switchroom.yaml. Equivalent " +
+        "to `auth account add` + `auth enable <label> all` but with a single " +
+        "merged YAML write.",
+    )
+    .option(
+      "--from-agent <name>",
+      "Seed credentials from an existing agent's .credentials.json (defaults " +
+        "to the only agent if there is exactly one)",
+    )
+    .action(
+      withConfigError(
+        async (label: string, opts: { fromAgent?: string }) => {
+          validateAccountLabel(label);
+
+          if (accountExists(label)) {
+            throw new Error(
+              `account ${label} already exists — use 'switchroom auth enable ${label} all' instead`,
+            );
+          }
+
+          const config = getConfig(program);
+          const agentNames = Object.keys(config.agents);
+
+          let fromAgent = opts.fromAgent;
+          if (!fromAgent) {
+            if (agentNames.length === 1) {
+              fromAgent = agentNames[0];
+            } else {
+              throw new Error(
+                "--from-agent is required when more than one agent is configured. " +
+                  `Pick one of: ${agentNames.sort().join(", ")}`,
+              );
+            }
+          }
+          if (!config.agents[fromAgent]) {
+            throw new Error(
+              `agent '${fromAgent}' is not declared in switchroom.yaml`,
+            );
+          }
+
+          // Load credentials from the source agent (mirrors `account add`).
+          const agentsDir = resolveAgentsDir(config);
+          const credPath = resolve(
+            agentsDir,
+            fromAgent,
+            ".claude",
+            ".credentials.json",
+          );
+          if (!existsSync(credPath)) {
+            throw new Error(
+              `agent '${fromAgent}' has no .credentials.json at ${credPath}. ` +
+                `Run 'switchroom auth login ${fromAgent}' first.`,
+            );
+          }
+          const creds = parseCredentialsFile(credPath);
+          assertCredentialsHaveAccessToken(creds);
+
+          // Expand "all" target list (claude-enabled agents only).
+          const targets = expandAllAgents(["all"], config);
+
+          // Write account artefacts first (account dir is its own write).
+          writeAccountCredentials(label, creds);
+          patchAccountMeta(label, {
+            createdAt: Date.now(),
+            subscriptionType: creds.claudeAiOauth?.subscriptionType,
+          });
+
+          // ONE merged YAML write: append the new label to every target agent
+          // in-memory, then a single writeFileSync.
+          const yamlPath = getConfigPath(program);
+          const before = readFileSync(yamlPath, "utf-8");
+          let after = before;
+          const changed: string[] = [];
+          for (const name of targets) {
+            const next = appendAccountToAgent(after, name, label);
+            if (next !== after) changed.push(name);
+            after = next;
+          }
+          if (after !== before) {
+            writeFileSync(yamlPath, after);
+          }
+
+          // Immediate fanout to every target.
+          const fanTargets = targets.map((name) => ({
+            name,
+            agentDir: resolve(agentsDir, name),
+          }));
+          const outcomes = fanoutAccountToAgents(label, fanTargets);
+
+          // Log expanded agent list (also visible to the gateway-stderr path
+          // when invoked via Telegram).
+          console.error(
+            `share: expanded 'all' to ${targets.length} agent(s): ${targets.join(", ")}`,
+          );
+
+          console.log();
+          console.log(
+            `${chalk.green("✓")} Account ${chalk.bold(label)} created at ${accountDir(label)}`,
+          );
+          console.log(`  Seeded from: agent '${fromAgent}'`);
+          if (creds.claudeAiOauth?.subscriptionType) {
+            console.log(
+              `  Subscription: ${creds.claudeAiOauth.subscriptionType}`,
+            );
+          }
+          if (creds.claudeAiOauth?.expiresAt) {
+            const remaining = creds.claudeAiOauth.expiresAt - Date.now();
+            console.log(`  Token life:   ${formatDuration(remaining)}`);
+          }
+          const hasRefreshToken =
+            typeof creds.claudeAiOauth?.refreshToken === "string" &&
+            creds.claudeAiOauth.refreshToken.length > 0;
+          if (!hasRefreshToken) {
+            console.log();
+            console.log(
+              chalk.yellow(
+                "  ⚠ No refreshToken in the imported credentials. The token " +
+                  "will work until it expires, then this account will need a " +
+                  "manual re-auth — the broker can't refresh without a refresh token.",
+              ),
+            );
+          }
+          console.log();
+          if (changed.length === 0) {
+            console.log(
+              `No yaml change — ${chalk.bold(label)} already enabled on: ${targets.join(", ")}`,
+            );
+          } else {
+            console.log(
+              `${chalk.green("✓")} Enabled ${chalk.bold(label)} on: ${changed.join(", ")}`,
+            );
+          }
+          const fanned = outcomes
+            .filter((o) => o.kind === "fanned-out")
+            .map((o) => o.agent);
+          const fanFails = outcomes.filter((o) => o.kind === "fanout-failed");
+          if (fanned.length > 0) {
+            console.log(`  Credentials fanned out to: ${fanned.join(", ")}`);
+          }
+          for (const f of fanFails) {
+            if (f.kind === "fanout-failed") {
+              console.log(
+                chalk.yellow(`  ⚠ Fanout failed for ${f.agent}: ${f.error}`),
+              );
+            }
+          }
+          console.log();
+          console.log(
+            `Next: 'switchroom agent restart ${targets.join(" ")}' to load the new credentials.`,
+          );
+          console.log();
+        },
+      ),
     );
 }
 

--- a/telegram-plugin/auth-slot-parser.ts
+++ b/telegram-plugin/auth-slot-parser.ts
@@ -55,6 +55,7 @@ export type AuthIntent =
   | { kind: 'account-rm'; account: string; label: string; cliArgs: string[] }
   | { kind: 'enable'; account: string; agents: string[]; label: string; cliArgs: string[]; restartAgentsAfter: true }
   | { kind: 'disable'; account: string; agents: string[]; label: string; cliArgs: string[] }
+  | { kind: 'share'; account: string; fromAgent: string; label: string; cliArgs: string[]; restartAgentsAfter: true }
   | { kind: 'usage'; message: string }
   | { kind: 'error'; message: string };
 
@@ -63,7 +64,7 @@ export const AUTH_VERBS = [
   'code', 'cancel', 'status',
   'add', 'use', 'list', 'rm',
   // New account-shaped verbs
-  'account', 'enable', 'disable',
+  'account', 'enable', 'disable', 'share',
 ] as const;
 
 /** Help/usage string shown for unknown subcommands. Keep wording close
@@ -88,8 +89,9 @@ export function usageText(): string {
     '/auth account add <label> [--from-agent <name>]  — promote slot to global account',
     '/auth account list                          — accounts + agents using each',
     '/auth account rm <label>                    — remove (refused if enabled)',
-    '/auth enable <label> [agents...]            — wire account to agent(s)',
-    '/auth disable <label> [agents...]           — unwire account from agent(s)',
+    '/auth enable <label> [agents...|all]        — wire account to agent(s); "all" = every agent',
+    '/auth disable <label> [agents...|all]       — unwire account from agent(s); "all" = every agent',
+    '/auth share <label> [--from-agent <name>]   — account add + enable on every agent in one step',
   ].join('\n');
 }
 
@@ -327,6 +329,32 @@ export function parseAuthSubCommand(
       agents,
       label: `auth disable ${account} ${agents.join(' ')}`,
       cliArgs: ['auth', 'disable', account, ...agents],
+    };
+  }
+
+  if (sub === 'share') {
+    // /auth share <label> [--from-agent <name>] — one-shot: account add + enable
+    // on every agent. Defaults --from-agent to the current agent (same shape as
+    // /auth account add).
+    const rest = parts.slice(1);
+    const { flags, positional } = splitFlags(rest, ['--from-agent']);
+    const account = positional[0];
+    if (!account) {
+      return { kind: 'usage', message: 'Usage: /auth share <label> [--from-agent <name>]' };
+    }
+    try { assertSafeAccountLabel(account); }
+    catch { return { kind: 'error', message: 'Invalid account label. Use [A-Za-z0-9._-], 1-64 chars.' }; }
+    const fromAgentRaw = flags['--from-agent'];
+    const fromAgent = typeof fromAgentRaw === 'string' ? fromAgentRaw : currentAgent;
+    try { assertSafeAgentNameForParser(fromAgent); }
+    catch { return { kind: 'error', message: 'Invalid --from-agent value.' }; }
+    return {
+      kind: 'share',
+      account,
+      fromAgent,
+      label: `auth share ${account}`,
+      cliArgs: ['auth', 'share', account, '--from-agent', fromAgent],
+      restartAgentsAfter: true,
     };
   }
 

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -4975,6 +4975,19 @@ function assertSafeAgentName(name: string): void {
   }
 }
 
+/**
+ * Expand the special `all` keyword into the real agent list for restart-
+ * driving. The CLI handles its own expansion for the YAML mutation; this
+ * helper exists so the gateway's post-CLI restart loop knows whom to
+ * bounce. Returns `agents` unchanged when `all` is not present.
+ */
+async function resolveAgentsForRestart(agents: string[]): Promise<string[]> {
+  if (!(agents.length === 1 && agents[0] === 'all')) return agents
+  type AgentListResp = { agents: Array<{ name: string }> }
+  const data = switchroomExecJson<AgentListResp>(['agent', 'list'])
+  return data?.agents?.map(a => a.name).filter(Boolean) ?? []
+}
+
 function getMyAgentName(): string {
   const fromEnv = process.env.SWITCHROOM_AGENT_NAME
   if (fromEnv && fromEnv.trim().length > 0) return fromEnv.trim()
@@ -6353,12 +6366,15 @@ bot.command('auth', async ctx => {
   }
 
   if (intent.kind === 'enable') {
-    // /auth enable <label> [agents...] — wires the account to those agents
+    // /auth enable <label> [agents...|all] — wires the account to those agents
     // (defaults to the current agent), then restarts each so claude picks
-    // up the freshly fanned-out credentials.
+    // up the freshly fanned-out credentials. The CLI accepts the `all`
+    // keyword verbatim and expands it itself; we expand here too so the
+    // restart loop knows the real agent names.
     await runSwitchroomCommand(ctx, intent.cliArgs, intent.label)
     if (intent.restartAgentsAfter) {
-      for (const a of intent.agents) {
+      const restartTargets = await resolveAgentsForRestart(intent.agents)
+      for (const a of restartTargets) {
         try { assertSafeAgentName(a) } catch { continue }
         await runSwitchroomCommand(ctx, ['agent', 'restart', a], `restart ${a}`)
       }
@@ -6368,10 +6384,24 @@ bot.command('auth', async ctx => {
   }
 
   if (intent.kind === 'disable') {
-    // /auth disable <label> [agents...] — unwires the account from those
+    // /auth disable <label> [agents...|all] — unwires the account from those
     // agents. Doesn't auto-restart: the operator may want to drain the
     // current credential first. The CLI hint already says "restart now".
     await runSwitchroomCommand(ctx, intent.cliArgs, intent.label)
+    return
+  }
+
+  if (intent.kind === 'share') {
+    // /auth share <label> [--from-agent <name>] — one-shot account-add +
+    // enable on every claude-enabled agent. The CLI does the merged YAML
+    // write; we restart every agent it touched so credentials load.
+    await runSwitchroomCommand(ctx, intent.cliArgs, intent.label)
+    const restartTargets = await resolveAgentsForRestart(['all'])
+    for (const a of restartTargets) {
+      try { assertSafeAgentName(a) } catch { continue }
+      await runSwitchroomCommand(ctx, ['agent', 'restart', a], `restart ${a}`)
+    }
+    void refreshPinnedBanner('auth-share')
     return
   }
 

--- a/telegram-plugin/tests/auth-slot-commands.test.ts
+++ b/telegram-plugin/tests/auth-slot-commands.test.ts
@@ -516,4 +516,82 @@ describe("AUTH_VERBS includes the new account-shaped verbs", () => {
     expect(AUTH_VERBS).toContain("enable");
     expect(AUTH_VERBS).toContain("disable");
   });
+
+  it("exports share in the verb list", () => {
+    expect(AUTH_VERBS).toContain("share");
+  });
+});
+
+describe("parseAuthSubCommand — `all` keyword for enable/disable", () => {
+  it("/auth enable <label> all parses with agents=['all']", () => {
+    const intent = parseAuthSubCommand(["enable", "work-pro", "all"], "clerk");
+    expect(intent.kind).toBe("enable");
+    if (intent.kind === "enable") {
+      expect(intent.agents).toEqual(["all"]);
+      expect(intent.cliArgs).toEqual(["auth", "enable", "work-pro", "all"]);
+      expect(intent.restartAgentsAfter).toBe(true);
+    }
+  });
+
+  it("/auth disable <label> all is symmetric", () => {
+    const intent = parseAuthSubCommand(["disable", "work-pro", "all"], "clerk");
+    expect(intent.kind).toBe("disable");
+    if (intent.kind === "disable") {
+      expect(intent.agents).toEqual(["all"]);
+      expect(intent.cliArgs).toEqual(["auth", "disable", "work-pro", "all"]);
+    }
+  });
+});
+
+describe("parseAuthSubCommand — /auth share", () => {
+  it("/auth share <label> defaults --from-agent to currentAgent", () => {
+    const intent = parseAuthSubCommand(["share", "work-pro"], "clerk");
+    expect(intent.kind).toBe("share");
+    if (intent.kind === "share") {
+      expect(intent.account).toBe("work-pro");
+      expect(intent.fromAgent).toBe("clerk");
+      expect(intent.cliArgs).toEqual(["auth", "share", "work-pro", "--from-agent", "clerk"]);
+      expect(intent.restartAgentsAfter).toBe(true);
+    }
+  });
+
+  it("/auth share <label> --from-agent <name> honors explicit value", () => {
+    const intent = parseAuthSubCommand(
+      ["share", "work-pro", "--from-agent", "klanker"],
+      "clerk",
+    );
+    expect(intent.kind).toBe("share");
+    if (intent.kind === "share") {
+      expect(intent.fromAgent).toBe("klanker");
+      expect(intent.cliArgs).toEqual([
+        "auth", "share", "work-pro", "--from-agent", "klanker",
+      ]);
+    }
+  });
+
+  it("/auth share without label is a usage error", () => {
+    const intent = parseAuthSubCommand(["share"], "clerk");
+    expect(intent.kind).toBe("usage");
+  });
+
+  it("/auth share rejects invalid labels", () => {
+    const intent = parseAuthSubCommand(["share", "../etc"], "clerk");
+    expect(intent.kind).toBe("error");
+  });
+
+  it("/auth share rejects --from-agent with shell metacharacters", () => {
+    const intent = parseAuthSubCommand(
+      ["share", "work-pro", "--from-agent", "foo;ls"],
+      "clerk",
+    );
+    expect(intent.kind).toBe("error");
+  });
+});
+
+describe("usageText — `all` keyword and share verb", () => {
+  it("documents the `all` keyword on enable/disable and `/auth share`", () => {
+    const u = usageText();
+    expect(u).toContain("/auth share");
+    expect(u).toMatch(/all/);
+  });
 });


### PR DESCRIPTION
## Summary

Collapses the two-step "register account, then enable on every agent" into a single tap. Adds:

| Verb | Shape | Behaviour |
|---|---|---|
| `auth share <label>` | `--from-agent <name>` (optional) | one-shot account-add + enable on every claude-enabled agent + restart each |
| `auth enable <label> all` | — | expands to every claude-enabled agent |
| `auth disable <label> all` | — | same |

Both CLI and Telegram surfaces.

## Design contract review

**Vision (`reference/vision.md`):** advances *Subscription-honest* (#3) — one Pro subscription, one OAuth, every agent uses it without each running its own flow — and *Multi-agent fleet* (#2) — operator manages accounts, switchroom routes them.

**JTBD (`reference/share-auth-across-the-fleet.md`):**

> *"Adding a second, third, or sixth agent to the same Anthropic account does not require any OAuth flow. The user runs \`switchroom auth enable <account> <agent>\` and the agent comes up authenticated."*

PR #621 delivered this, but the most common case ("one subscription drives my whole fleet") was still two commands plus N agent names. The `share` verb collapses to one command; `all` removes the enumeration.

**Principles (`reference/principles.md`):**

1. **"If they need the docs, we've failed"** ✓
   - Verb name `share` is self-explanatory.
   - `/auth help` lists the new shape.
   - `share` refuses with a hint pointing to the alternative when account exists: *"account ${label} already exists — use 'switchroom auth enable ${label} all' instead"*.

2. **"Batteries included, assembly optional"** ✓
   - `--from-agent` auto-defaults when only one agent is configured (the fresh-install case).
   - `all` removes the per-fleet enumeration step.
   - One command does account-add + YAML merge + fanout + restart.

3. **"One mind built this"** ✓
   - Same `[A-Za-z0-9._-]` label validation.
   - Same `--from-agent` flag shape as `account add`.
   - Same auto-restart-after-enable semantics; `enable` and `share` both use the new `resolveAgentsForRestart` helper.
   - `expandAllAgents` (CLI) and `resolveAgentsForRestart` (gateway) are paired centralizations of the same `all` keyword.
   - `share` warns when an agent literally named `all` exists in `switchroom.yaml` rather than silently picking one interpretation.

## What's NOT in this PR (deferred)

- **Inline-keyboard buttons for the account verbs.** `/auth` (no args) opens a dashboard with per-slot buttons (Reauth / Add slot / Use / Remove / Fall back / Refresh). The new account verbs are typable but not button-tappable. Worth a follow-up that adds an "🌐 Share to fleet" / "Enable on all" row when the operator has more than one agent.

## Test plan

- [x] `npm run lint` clean (52 pre-existing type-debt errors in unrelated files, tracked separately)
- [x] `npm run build` clean
- [x] `bun test telegram-plugin` — **3269 pass / 0 fail** (was 3251; +18 from auth-slot-commands).
- [x] `npm run test:vitest` — **4780 pass / 0 fail** (was 4773; the share + all coverage).
- [x] Auth-slot-commands suite — 70 tests pass / 0 fail.

Total: **8049 tests passing.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)