### PR TITLE
chore: release v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,38 @@
 
 ## [Unreleased]
 
+## v0.6.0 — 2026-05-03
+
+### Added
+
+- **`/auth share <label>` — one-shot account-add + fleet-wide enable
+  (#634).** Collapses the two-step "register account, then enable on
+  every agent" flow into a single command. CLI: `switchroom auth share
+  <label> [--from-agent <name>]`; Telegram: `/auth share <label>
+  [--from-agent <name>]`. Auto-defaults `--from-agent` when only one
+  agent is configured (the fresh-install case). Auto-restarts every
+  affected agent so claude picks up the freshly fanned-out
+  credentials. Refuses with a hint when the account already exists
+  (*"use 'switchroom auth enable <label> all' instead"*).
+
+- **`all` keyword for `auth enable` / `auth disable` (#634).**
+  Operators don't have to enumerate the fleet:
+  - `switchroom auth enable <label> all` — wire the account to every
+    claude-enabled agent in `switchroom.yaml`.
+  - `switchroom auth disable <label> all` — unwire from every agent.
+  - Telegram surfaces the same shape: `/auth enable <label> all`.
+
+  Edge case: a literal agent named `all` in `switchroom.yaml` triggers
+  a stderr warning and the keyword still wins; rename the agent to
+  disambiguate.
+
+### Why
+
+Closes the ergonomic gap from `share-auth-across-the-fleet.md` JTBD.
+PR #621 delivered the underlying account-as-unit capability, but the
+common case ("one Pro subscription drives my whole fleet") still
+required two commands plus N agent names. The new verbs make it one
+command, mobile-native.
 
 ## v0.5.2 — 2026-05-03
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "switchroom-ai",
-  "version": "0.5.2",
+  "version": "0.6.0",
   "description": "Run Claude Code 24/7 on your Claude Pro/Max subscription over Telegram. Open-source alternative to OpenClaw and NanoClaw — no API keys, no Docker.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

Cuts v0.6.0. Bumps `package.json` 0.5.2 → 0.6.0 and adds the v0.6.0 CHANGELOG section.

## Headline change

- **`/auth share <label>` + `all` keyword** for fleet-wide account fanout (#634). Mobile users go from "two commands plus N agent names" to one command — the JTBD `share-auth-across-the-fleet.md` ergonomic gap closed.

## Note on the version number

PR #631 previously merged a `chore: release v0.6.0` commit, then PR #632 reverted that to v0.5.2 (correction: #626 fix is a patch, not a minor). v0.6.0 was never published to npm. This PR uses v0.6.0 cleanly for the new feature, which IS a minor (new CLI verbs + parser kinds, no breaking changes).

## Test plan

- [x] `npm run lint` clean
- [x] `npm run build` clean
- [x] 8049 tests passing (pre-merge of #634)

🤖 Generated with [Claude Code](https://claude.com/claude-code)