### PR TITLE
feat(auth-dashboard): account-level buttons + share-fleet bootstrap

### DIFF
--- a/src/cli/auth-accounts.ts
+++ b/src/cli/auth-accounts.ts
@@ -235,21 +235,14 @@ function registerAccountList(account: Command, program: Command): void {
   account
     .command("list")
     .description("List Anthropic accounts and which agents use each")
+    .option(
+      "--json",
+      "Emit account inventory as JSON (used by the Telegram /auth dashboard to render account-level buttons)",
+    )
     .action(
-      withConfigError(async () => {
+      withConfigError(async (opts: { json?: boolean }) => {
         const config = getConfig(program);
         const labels = listAccounts();
-        if (labels.length === 0) {
-          console.log();
-          console.log(
-            "No accounts yet. Add one with 'switchroom auth account add <label>'.",
-          );
-          console.log(`  Storage: ${accountsRoot()}`);
-          console.log();
-          return;
-        }
-
-        const infos = getAccountInfos();
         const enabledMap = new Map<string, string[]>();
         for (const label of labels) {
           enabledMap.set(
@@ -261,6 +254,43 @@ function registerAccountList(account: Command, program: Command): void {
           );
         }
 
+        if (opts.json) {
+          // Stable, sorted-by-label JSON for the Telegram dashboard.
+          // Empty array (not null) when no accounts exist — keeps the
+          // gateway's null-check shape consistent with "old CLI without
+          // --json" vs "new CLI, zero accounts."
+          const infos = labels.length === 0 ? [] : getAccountInfos();
+          const payload = infos
+            .slice()
+            .sort((a, b) => a.label.localeCompare(b.label))
+            .map((info) => ({
+              label: info.label,
+              health: info.health,
+              ...(info.subscriptionType
+                ? { subscriptionType: info.subscriptionType }
+                : {}),
+              ...(info.expiresAt != null ? { expiresAt: info.expiresAt } : {}),
+              ...(info.quotaExhaustedUntil != null
+                ? { quotaExhaustedUntil: info.quotaExhaustedUntil }
+                : {}),
+              ...(info.email ? { email: info.email } : {}),
+              agents: enabledMap.get(info.label) ?? [],
+            }));
+          console.log(JSON.stringify(payload));
+          return;
+        }
+
+        if (labels.length === 0) {
+          console.log();
+          console.log(
+            "No accounts yet. Add one with 'switchroom auth account add <label>'.",
+          );
+          console.log(`  Storage: ${accountsRoot()}`);
+          console.log();
+          return;
+        }
+
+        const infos = getAccountInfos();
         console.log();
         for (const info of infos) {
           const agents = enabledMap.get(info.label) ?? [];

--- a/telegram-plugin/auth-dashboard.ts
+++ b/telegram-plugin/auth-dashboard.ts
@@ -83,6 +83,46 @@ export interface DashboardState {
    * start over BEFORE the challenge actually drifts.
    */
   pendingSessionSlot?: string | null;
+  /**
+   * Per-account summaries derived from `switchroom auth account list
+   * --json`. Optional: undefined when the gateway can't reach the CLI
+   * or the CLI is older than v0.6.x (no --json flag). When present
+   * (even as an empty array), the dashboard renders the accounts
+   * section. The `enabledHere` flag drives the ✓/○ marker — `agents`
+   * field from the JSON, with `agents.includes(state.agent)` mapped
+   * into this struct by the gateway.
+   */
+  accounts?: ReadonlyArray<AccountSummary>;
+  /** True when more accounts exist than `ACCOUNTS_DISPLAY_CAP` — the
+   *  render appends a noop "more accounts (use CLI)" row. */
+  accountsTruncated?: boolean;
+  /**
+   * True when this agent has slot credentials we could promote into a
+   * shared account via `auth share`. Drives the bootstrap "🌐 Share to
+   * fleet" button visibility — only useful when no accounts exist yet.
+   */
+  canBootstrapShare?: boolean;
+}
+
+/**
+ * Per-account summary for the inline-keyboard dashboard's accounts
+ * section. Mirrors the JSON shape `auth account list --json` emits,
+ * collapsed to the fields the renderer needs. Pure data — no behaviour.
+ */
+export type AccountHealth =
+  | "healthy"
+  | "quota-exhausted"
+  | "expired"
+  | "missing-credentials"
+  | "missing-refresh-token";
+
+export interface AccountSummary {
+  readonly label: string;
+  readonly health: AccountHealth;
+  /** True when this agent appears in the account's `agents` list. */
+  readonly enabledHere: boolean;
+  readonly subscriptionType?: string;
+  readonly expiresAt?: number;
 }
 
 /**
@@ -96,6 +136,15 @@ export interface DashboardState {
  */
 export const QUOTA_HOT_THRESHOLD_PCT = 90;
 
+/** Max account rows rendered inline. Beyond this, the dashboard adds a
+ *  truncated-noop row pointing the user to the CLI for the rest. Five
+ *  is enough for typical fleets without overflowing a mobile screen. */
+export const ACCOUNTS_DISPLAY_CAP = 5;
+
+/** Telegram caps callback_data at 64 bytes. Render-time guard rejects
+ *  encoded payloads beyond this and renders a noop fallback button. */
+export const CALLBACK_BUDGET_BYTES = 64;
+
 export type CallbackAction =
   | { kind: "refresh"; agent: string }
   | { kind: "reauth"; agent: string; slot?: string }
@@ -106,6 +155,14 @@ export type CallbackAction =
   | { kind: "fallback"; agent: string }
   | { kind: "usage"; agent: string }
   | { kind: "restart-flow"; agent: string; slot: string }
+  // Account-level (#per-agent-cards / #share-auth-across-the-fleet).
+  // Single-character verbs (ae/ad/cae/cad/sf) maximise label headroom
+  // inside the 64-byte callback_data cap.
+  | { kind: "account-enable"; agent: string; label: string }
+  | { kind: "account-disable"; agent: string; label: string }
+  | { kind: "confirm-account-enable"; agent: string; label: string }
+  | { kind: "confirm-account-disable"; agent: string; label: string }
+  | { kind: "share-fleet"; agent: string }
   | { kind: "noop" };
 
 const CALLBACK_PREFIX = "auth:";
@@ -135,6 +192,16 @@ export function encodeCallbackData(action: CallbackAction): string {
       return `${CALLBACK_PREFIX}usage:${action.agent}`;
     case "restart-flow":
       return `${CALLBACK_PREFIX}restart-flow:${action.agent}:${action.slot}`;
+    case "account-enable":
+      return `${CALLBACK_PREFIX}ae:${action.agent}:${action.label}`;
+    case "account-disable":
+      return `${CALLBACK_PREFIX}ad:${action.agent}:${action.label}`;
+    case "confirm-account-enable":
+      return `${CALLBACK_PREFIX}cae:${action.agent}:${action.label}`;
+    case "confirm-account-disable":
+      return `${CALLBACK_PREFIX}cad:${action.agent}:${action.label}`;
+    case "share-fleet":
+      return `${CALLBACK_PREFIX}sf:${action.agent}`;
     case "noop":
       return `${CALLBACK_PREFIX}noop`;
   }
@@ -145,10 +212,33 @@ export function encodeCallbackData(action: CallbackAction): string {
  *  caller should still answerCallbackQuery() but otherwise drop. */
 export function parseCallbackData(data: string): CallbackAction {
   if (!data.startsWith(CALLBACK_PREFIX)) return { kind: "noop" };
+  // Reject payloads beyond Telegram's 64-byte cap. Telegram itself
+  // refuses to deliver those, but the parser stays defensive in case
+  // a test or fuzzer hands us one.
+  if (Buffer.byteLength(data, "utf8") > CALLBACK_BUDGET_BYTES) {
+    return { kind: "noop" };
+  }
   const rest = data.slice(CALLBACK_PREFIX.length);
   const parts = rest.split(":");
-  const [verb, agent, slot] = parts;
+  const [verb, agent, third] = parts;
+  // Account-level verbs (single-char) accept a label as the third
+  // segment instead of a slot. We branch on verb first so each segment
+  // is validated against its own regex.
+  if (verb === "ae" || verb === "ad" || verb === "cae" || verb === "cad") {
+    if (!isSafeAgentName(agent ?? "")) return { kind: "noop" };
+    if (!third || !isSafeAccountLabel(third)) return { kind: "noop" };
+    const label = third;
+    if (verb === "ae") return { kind: "account-enable", agent, label };
+    if (verb === "ad") return { kind: "account-disable", agent, label };
+    if (verb === "cae") return { kind: "confirm-account-enable", agent, label };
+    return { kind: "confirm-account-disable", agent, label };
+  }
+  if (verb === "sf") {
+    if (!isSafeAgentName(agent ?? "")) return { kind: "noop" };
+    return { kind: "share-fleet", agent };
+  }
   if (!isSafeAgentName(agent ?? "")) return { kind: "noop" };
+  const slot = third;
   switch (verb) {
     case "refresh":
       return { kind: "refresh", agent };
@@ -185,6 +275,23 @@ function isSafeAgentName(name: string): boolean {
 
 function isSafeSlotName(name: string): boolean {
   return /^[a-zA-Z0-9_-]{1,32}$/.test(name);
+}
+
+/**
+ * Account labels match the CLI's `validateAccountLabel` regex
+ * (`src/auth/account-store.ts`): `[A-Za-z0-9._-]{1,64}`. The `.` is
+ * the only delta from `isSafeSlotName` and is what makes labels like
+ * `acme.team` legal. Dashboard-side validator so the parser doesn't
+ * need to import from `src/`.
+ *
+ * The `.` and `..` reservations match the CLI's defensive guards
+ * — those tokens are valid characters but are reserved as filesystem
+ * lookalikes and would create ambiguous on-disk paths under
+ * `~/.switchroom/accounts/`.
+ */
+export function isSafeAccountLabel(name: string): boolean {
+  if (name === "." || name === "..") return false;
+  return /^[A-Za-z0-9._-]{1,64}$/.test(name);
 }
 
 /**
@@ -233,6 +340,20 @@ export function buildDashboardText(state: DashboardState): string {
     );
     const detail = slotDetailLine(slot);
     if (detail) lines.push(`  └ ${detail}`);
+  }
+
+  // Accounts summary — one line under the slot list when the gateway
+  // surfaced account state. Hidden when accounts == null (older CLI
+  // without --json) so the dashboard degrades gracefully.
+  if (state.accounts != null) {
+    const total = state.accounts.length;
+    const enabledHere = state.accounts.filter((a) => a.enabledHere).length;
+    if (total > 0) {
+      lines.push("");
+      lines.push(
+        `Accounts: <b>${enabledHere}/${total}</b> shared on this agent`,
+      );
+    }
   }
 
   lines.push("");
@@ -314,6 +435,52 @@ export function buildDashboardKeyboard(state: DashboardState): InlineKeyboard {
   }
   if (removableSlots.length > 0) kb.row();
 
+  // Row 3.5 (NEW): account-level toggles. One row per account so
+  // labels stay readable on mobile and the per-button callback_data
+  // stays well under the 64-byte budget. Only renders when the
+  // gateway successfully fetched account state (`accounts != null`).
+  // Empty `accounts` falls through to the bootstrap branch below.
+  if (state.accounts != null && state.accounts.length > 0) {
+    const visible = state.accounts.slice(0, ACCOUNTS_DISPLAY_CAP);
+    for (const acc of visible) {
+      const action: CallbackAction = acc.enabledHere
+        ? { kind: "account-disable", agent: state.agent, label: acc.label }
+        : { kind: "account-enable", agent: state.agent, label: acc.label };
+      const encoded = encodeCallbackData(action);
+      // Render-time guard: if the synthesised payload exceeds the
+      // 64-byte cap (pathological agent + label lengths), fall back
+      // to a noop button labelled with the raw account name so the
+      // row is visible-but-inert. Operator can fall back to the CLI.
+      if (Buffer.byteLength(encoded, "utf8") > CALLBACK_BUDGET_BYTES) {
+        kb.text(
+          `⚠ ${truncateLabel(acc.label)} (use CLI)`,
+          encodeCallbackData({ kind: "noop" }),
+        );
+      } else {
+        const marker = acc.enabledHere ? "✓" : "○";
+        kb.text(`${marker} ${acc.label}${healthSuffix(acc.health)}`, encoded);
+      }
+      kb.row();
+    }
+    if (state.accountsTruncated) {
+      kb.text(
+        `… ${state.accounts.length - ACCOUNTS_DISPLAY_CAP} more (use CLI)`,
+        encodeCallbackData({ kind: "noop" }),
+      );
+      kb.row();
+    }
+  } else if (state.canBootstrapShare) {
+    // Bootstrap one-tap: zero accounts exist, but this agent has
+    // healthy slot creds we could promote. Synthesises label="default"
+    // at the gateway so the user gets a reasonable starting state in
+    // one tap; rename via CLI later if "default" doesn't suit.
+    kb.text(
+      "🌐 Share to fleet",
+      encodeCallbackData({ kind: "share-fleet", agent: state.agent }),
+    );
+    kb.row();
+  }
+
   // Row 4: pending-flow recovery. Shown ONLY when an auth flow is
   // pending (session meta file on disk). Lets the user explicitly
   // kill + restart the flow. Pairs with the automatic stale-session
@@ -385,4 +552,54 @@ export function buildRemoveConfirmKeyboard(agent: string, slot: string): InlineK
     .text(`⚠️ Confirm remove: ${slot}`, encodeCallbackData({ kind: "confirm-rm", agent, slot }))
     .row()
     .text("↩️ Cancel", encodeCallbackData({ kind: "refresh", agent }));
+}
+
+/**
+ * Two-stage confirmation for account toggles. Mirrors
+ * `buildRemoveConfirmKeyboard`'s shape — one confirm row + a cancel
+ * that re-renders the dashboard. `kind` selects enable vs disable so
+ * one helper covers both directions.
+ */
+export function buildAccountConfirmKeyboard(
+  agent: string,
+  label: string,
+  kind: "enable" | "disable",
+): InlineKeyboard {
+  const action: CallbackAction = kind === "enable"
+    ? { kind: "confirm-account-enable", agent, label }
+    : { kind: "confirm-account-disable", agent, label };
+  const verb = kind === "enable" ? "enable" : "disable";
+  return new InlineKeyboard()
+    .text(`⚠️ Confirm ${verb}: ${label}`, encodeCallbackData(action))
+    .row()
+    .text("↩️ Cancel", encodeCallbackData({ kind: "refresh", agent }));
+}
+
+/**
+ * Health affix for the account button label. Keeps healthy accounts
+ * unadorned (the ✓/○ marker carries the enabled-here signal) and
+ * surfaces the failure modes that need operator attention. Quota and
+ * expiry use distinct icons so the user can tell which boundary the
+ * account hit.
+ */
+function healthSuffix(health: AccountHealth): string {
+  switch (health) {
+    case "quota-exhausted":
+      return " ⚠️";
+    case "expired":
+    case "missing-refresh-token":
+      return " ⌛";
+    case "missing-credentials":
+      return " ❌";
+    case "healthy":
+    default:
+      return "";
+  }
+}
+
+/** Trim long labels in the noop fallback button so the row stays
+ *  readable on a narrow mobile screen. */
+function truncateLabel(label: string): string {
+  if (label.length <= 32) return label;
+  return label.slice(0, 31) + "…";
 }

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -84,12 +84,16 @@ import {
 import {
   buildDashboard,
   buildRemoveConfirmKeyboard,
+  buildAccountConfirmKeyboard,
   parseCallbackData,
   encodeCallbackData,
   isQuotaHot,
+  ACCOUNTS_DISPLAY_CAP,
   type DashboardState,
   type DashboardSlot,
   type SlotHealth,
+  type AccountSummary,
+  type AccountHealth,
 } from '../auth-dashboard.js'
 import {
   initHistory, recordInbound, recordOutbound, recordEdit,
@@ -6494,6 +6498,51 @@ function fetchDashboardState(agent: string): DashboardState | null {
   // only fires on actual PKCE challenge drift).
   const pendingSessionSlot = readPendingSessionSlot(agent)
 
+  // Account-level state for the dashboard's accounts section. The CLI
+  // emits a sorted, JSON array via `auth account list --json` (added
+  // in v0.6.x). We map it to the dashboard's `AccountSummary` shape,
+  // computing `enabledHere` from the per-account `agents` list.
+  //
+  // Wrapped in try/catch so an older CLI without --json (or any other
+  // failure) leaves `accounts` undefined — the renderer hides the
+  // section gracefully.
+  type AccountListItem = {
+    label: string
+    health: AccountHealth
+    subscriptionType?: string
+    expiresAt?: number
+    quotaExhaustedUntil?: number
+    email?: string
+    agents: string[]
+  }
+  let accounts: AccountSummary[] | undefined
+  let accountsTruncated = false
+  try {
+    const raw = switchroomExecJson<AccountListItem[]>([
+      'auth', 'account', 'list', '--json',
+    ])
+    if (Array.isArray(raw)) {
+      accounts = raw.map((a) => ({
+        label: a.label,
+        health: a.health,
+        enabledHere: Array.isArray(a.agents) && a.agents.includes(agent),
+        ...(a.subscriptionType ? { subscriptionType: a.subscriptionType } : {}),
+        ...(a.expiresAt != null ? { expiresAt: a.expiresAt } : {}),
+      }))
+      accountsTruncated = accounts.length > ACCOUNTS_DISPLAY_CAP
+    }
+  } catch {
+    /* leave accounts undefined */
+  }
+
+  // `canBootstrapShare` decides whether to surface the "🌐 Share to
+  // fleet" button when zero accounts exist. We only show it when this
+  // agent has slot creds we could promote — otherwise the share verb
+  // would fail at the credentials lookup.
+  const canBootstrapShare = slots.some(
+    (s) => s.health === 'healthy' || s.health === 'active',
+  )
+
   return {
     agent,
     bankId,
@@ -6503,6 +6552,9 @@ function fetchDashboardState(agent: string): DashboardState | null {
     quotaHot: isQuotaHot(slots),
     generatedAt: new Date().toISOString().replace(/\.\d{3}Z$/, 'Z'),
     pendingSessionSlot,
+    accounts,
+    accountsTruncated,
+    canBootstrapShare,
   }
 }
 
@@ -7381,6 +7433,75 @@ async function handleAuthDashboardCallback(ctx: Context): Promise<void> {
       } catch (err) {
         await switchroomReply(ctx, `Quota fetch failed: ${escapeHtmlForTg(String(err))}`, { html: true })
       }
+      return
+    }
+    // Account-level toggles (#share-auth-across-the-fleet). Two-stage
+    // confirm pattern mirrors `rm`/`confirm-rm` so a stray tap doesn't
+    // re-shuffle credentials. The CLI verb is the one source of truth
+    // for the YAML mutation + fanout; we only translate the tap into
+    // a `runSwitchroomCommand` call and refresh the dashboard.
+    case 'account-enable': {
+      await ctx.answerCallbackQuery({ text: `Confirm enable ${action.label}?` }).catch(() => {})
+      try {
+        await ctx.editMessageReplyMarkup({
+          reply_markup: buildAccountConfirmKeyboard(action.agent, action.label, 'enable'),
+        })
+      } catch { /* ignore */ }
+      return
+    }
+    case 'account-disable': {
+      await ctx.answerCallbackQuery({ text: `Confirm disable ${action.label}?` }).catch(() => {})
+      try {
+        await ctx.editMessageReplyMarkup({
+          reply_markup: buildAccountConfirmKeyboard(action.agent, action.label, 'disable'),
+        })
+      } catch { /* ignore */ }
+      return
+    }
+    case 'confirm-account-enable': {
+      await ctx.answerCallbackQuery({ text: `Enabling ${action.label}…` }).catch(() => {})
+      try { assertSafeAgentName(action.agent) } catch { return }
+      // CLI does the YAML mutation + per-agent credential fanout. The
+      // restart afterwards is what actually loads the new credentials
+      // into the running claude process.
+      await runSwitchroomCommand(
+        ctx,
+        ['auth', 'enable', action.label, action.agent],
+        `auth enable ${action.label} ${action.agent}`,
+      )
+      await runSwitchroomCommand(ctx, ['agent', 'restart', action.agent], `restart ${action.agent}`)
+      await sendAuthDashboard(ctx, action.agent, { edit: true })
+      return
+    }
+    case 'confirm-account-disable': {
+      await ctx.answerCallbackQuery({ text: `Disabling ${action.label}…` }).catch(() => {})
+      try { assertSafeAgentName(action.agent) } catch { return }
+      await runSwitchroomCommand(
+        ctx,
+        ['auth', 'disable', action.label, action.agent],
+        `auth disable ${action.label} ${action.agent}`,
+      )
+      // Force restart so claude drops the stale credentials immediately.
+      // The CLI's `disable` doesn't auto-restart (it expects the operator
+      // to drain manually); the dashboard tap is implicit "I'm done with
+      // this account on this agent now," so we restart on their behalf.
+      await runSwitchroomCommand(ctx, ['agent', 'restart', action.agent], `restart ${action.agent}`)
+      await sendAuthDashboard(ctx, action.agent, { edit: true })
+      return
+    }
+    case 'share-fleet': {
+      // Bootstrap one-tap: zero accounts exist, this agent has healthy
+      // slot creds. Synthesise label="default" so the user gets a
+      // sensible starting state in one tap; rename via CLI later.
+      await ctx.answerCallbackQuery({ text: 'Sharing to fleet…' }).catch(() => {})
+      try { assertSafeAgentName(action.agent) } catch { return }
+      await runSwitchroomCommand(
+        ctx,
+        ['auth', 'share', 'default', '--from-agent', action.agent],
+        `auth share default --from-agent ${action.agent}`,
+      )
+      await runSwitchroomCommand(ctx, ['agent', 'restart', action.agent], `restart ${action.agent}`)
+      await sendAuthDashboard(ctx, action.agent, { edit: true })
       return
     }
     case 'noop':

--- a/telegram-plugin/tests/auth-dashboard.test.ts
+++ b/telegram-plugin/tests/auth-dashboard.test.ts
@@ -311,3 +311,274 @@ describe("escapeHtml", () => {
     expect(escapeHtml('<foo bar="baz">&')).toBe("&lt;foo bar=&quot;baz&quot;&gt;&amp;");
   });
 });
+
+// ─── Account-level dashboard ──────────────────────────────────────────
+
+import {
+  buildAccountConfirmKeyboard,
+  ACCOUNTS_DISPLAY_CAP,
+  CALLBACK_BUDGET_BYTES,
+  isSafeAccountLabel,
+  type AccountSummary,
+  type AccountHealth,
+} from "../auth-dashboard";
+
+function mkAccount(overrides: Partial<AccountSummary> = {}): AccountSummary {
+  return {
+    label: "default",
+    health: "healthy",
+    enabledHere: false,
+    ...overrides,
+  };
+}
+
+function mkState(overrides: Partial<DashboardState> = {}): DashboardState {
+  return {
+    agent: "clerk",
+    bankId: "clerk",
+    plan: "max",
+    rateLimitTier: null,
+    slots: [mkSlot({ active: true, health: "active" })],
+    quotaHot: false,
+    generatedAt: "2026-05-03T12:00:00Z",
+    pendingSessionSlot: null,
+    ...overrides,
+  };
+}
+
+describe("isSafeAccountLabel", () => {
+  it("accepts the CLI-validated regex including '.' for labels like acme.team", () => {
+    expect(isSafeAccountLabel("default")).toBe(true);
+    expect(isSafeAccountLabel("acme.team")).toBe(true);
+    expect(isSafeAccountLabel("ken_personal")).toBe(true);
+    expect(isSafeAccountLabel("co-2024")).toBe(true);
+    expect(isSafeAccountLabel("a")).toBe(true);
+    expect(isSafeAccountLabel("a".repeat(64))).toBe(true);
+  });
+
+  it("rejects empty, oversized, and dangerous characters", () => {
+    expect(isSafeAccountLabel("")).toBe(false);
+    expect(isSafeAccountLabel("a".repeat(65))).toBe(false);
+    expect(isSafeAccountLabel("with space")).toBe(false);
+    expect(isSafeAccountLabel("a/b")).toBe(false);
+    expect(isSafeAccountLabel("a:b")).toBe(false); // colon would corrupt callback parsing
+    expect(isSafeAccountLabel("a;rm -rf")).toBe(false);
+    expect(isSafeAccountLabel("../escape")).toBe(false);
+  });
+});
+
+describe("encodeCallbackData / parseCallbackData — account verbs", () => {
+  it("account-enable round-trips with a simple label", () => {
+    const action = { kind: "account-enable" as const, agent: "clerk", label: "work" };
+    const encoded = encodeCallbackData(action);
+    expect(encoded).toBe("auth:ae:clerk:work");
+    expect(parseCallbackData(encoded)).toEqual(action);
+  });
+
+  it("account-disable round-trips", () => {
+    const action = { kind: "account-disable" as const, agent: "clerk", label: "work" };
+    const encoded = encodeCallbackData(action);
+    expect(encoded).toBe("auth:ad:clerk:work");
+    expect(parseCallbackData(encoded)).toEqual(action);
+  });
+
+  it("confirm-account-enable round-trips", () => {
+    const action = { kind: "confirm-account-enable" as const, agent: "klanker", label: "work" };
+    const encoded = encodeCallbackData(action);
+    expect(encoded).toBe("auth:cae:klanker:work");
+    expect(parseCallbackData(encoded)).toEqual(action);
+  });
+
+  it("confirm-account-disable round-trips", () => {
+    const action = { kind: "confirm-account-disable" as const, agent: "klanker", label: "work" };
+    const encoded = encodeCallbackData(action);
+    expect(encoded).toBe("auth:cad:klanker:work");
+    expect(parseCallbackData(encoded)).toEqual(action);
+  });
+
+  it("share-fleet round-trips (no label segment)", () => {
+    const action = { kind: "share-fleet" as const, agent: "clerk" };
+    const encoded = encodeCallbackData(action);
+    expect(encoded).toBe("auth:sf:clerk");
+    expect(parseCallbackData(encoded)).toEqual(action);
+  });
+
+  it("preserves labels with '.' through the round-trip (acme.team)", () => {
+    const action = { kind: "account-enable" as const, agent: "clerk", label: "acme.team" };
+    const encoded = encodeCallbackData(action);
+    expect(parseCallbackData(encoded)).toEqual(action);
+  });
+
+  it("rejects malformed account labels (parses to noop)", () => {
+    expect(parseCallbackData("auth:ae:clerk:bad label")).toEqual({ kind: "noop" });
+    expect(parseCallbackData("auth:ae:clerk:..")).toEqual({ kind: "noop" });
+    expect(parseCallbackData("auth:ae:clerk:")).toEqual({ kind: "noop" });
+    expect(parseCallbackData("auth:ae:clerk")).toEqual({ kind: "noop" }); // missing label segment
+  });
+
+  it("rejects malformed agent in account verbs", () => {
+    expect(parseCallbackData("auth:ae:bad agent:work")).toEqual({ kind: "noop" });
+    expect(parseCallbackData("auth:ae::work")).toEqual({ kind: "noop" });
+  });
+
+  it("rejects payloads beyond the 64-byte cap as noop", () => {
+    const oversize = "auth:ae:" + "a".repeat(80) + ":" + "b".repeat(80);
+    expect(parseCallbackData(oversize)).toEqual({ kind: "noop" });
+  });
+});
+
+describe("buildDashboardKeyboard — accounts section", () => {
+  function rows(state: DashboardState): Array<Array<{ text: string; callback_data?: string }>> {
+    return buildDashboardKeyboard(state).inline_keyboard as unknown as Array<
+      Array<{ text: string; callback_data?: string }>
+    >;
+  }
+
+  function flatTexts(state: DashboardState): string[] {
+    return rows(state).flat().map((b) => b.text);
+  }
+
+  it("renders nothing when accounts is undefined (degraded fallback)", () => {
+    const state = mkState({ accounts: undefined });
+    const texts = flatTexts(state);
+    expect(texts.find((t) => t.startsWith("✓") || t.startsWith("○"))).toBeUndefined();
+    expect(texts).not.toContain("🌐 Share to fleet");
+  });
+
+  it("renders the bootstrap button when accounts is empty AND canBootstrapShare is true", () => {
+    const state = mkState({ accounts: [], canBootstrapShare: true });
+    const texts = flatTexts(state);
+    expect(texts).toContain("🌐 Share to fleet");
+  });
+
+  it("hides the bootstrap button when canBootstrapShare is false", () => {
+    const state = mkState({ accounts: [], canBootstrapShare: false });
+    const texts = flatTexts(state);
+    expect(texts).not.toContain("🌐 Share to fleet");
+  });
+
+  it("renders ✓ for an account enabled here, with a disable callback", () => {
+    const state = mkState({
+      accounts: [mkAccount({ label: "work", enabledHere: true })],
+    });
+    const allButtons = rows(state).flat();
+    const acctBtn = allButtons.find((b) => b.text.includes("work"));
+    expect(acctBtn?.text).toBe("✓ work");
+    expect(acctBtn?.callback_data).toBe("auth:ad:clerk:work");
+  });
+
+  it("renders ○ for an account NOT enabled here, with an enable callback", () => {
+    const state = mkState({
+      accounts: [mkAccount({ label: "work", enabledHere: false })],
+    });
+    const allButtons = rows(state).flat();
+    const acctBtn = allButtons.find((b) => b.text.includes("work"));
+    expect(acctBtn?.text).toBe("○ work");
+    expect(acctBtn?.callback_data).toBe("auth:ae:clerk:work");
+  });
+
+  it("appends a health suffix for non-healthy accounts", () => {
+    const state = mkState({
+      accounts: [
+        mkAccount({ label: "expired-acct", health: "expired", enabledHere: true }),
+        mkAccount({ label: "quota-acct", health: "quota-exhausted", enabledHere: false }),
+      ],
+    });
+    const texts = flatTexts(state);
+    expect(texts.some((t) => t.startsWith("✓ expired-acct ⌛"))).toBe(true);
+    expect(texts.some((t) => t.startsWith("○ quota-acct ⚠️"))).toBe(true);
+  });
+
+  it("caps visible accounts at ACCOUNTS_DISPLAY_CAP and adds a truncated noop row", () => {
+    const tooMany: AccountSummary[] = [];
+    for (let i = 0; i < ACCOUNTS_DISPLAY_CAP + 2; i++) {
+      tooMany.push(mkAccount({ label: `acct-${i}`, enabledHere: false }));
+    }
+    const state = mkState({ accounts: tooMany, accountsTruncated: true });
+    const allButtons = rows(state).flat();
+    const acctBtns = allButtons.filter((b) => /^[✓○]/.test(b.text));
+    expect(acctBtns).toHaveLength(ACCOUNTS_DISPLAY_CAP);
+    expect(allButtons.find((b) => b.text.startsWith("…"))?.callback_data).toBe(
+      "auth:noop",
+    );
+  });
+
+  it("hides the bootstrap button once accounts exist (per-account toggles take over)", () => {
+    const state = mkState({
+      accounts: [mkAccount({ label: "work", enabledHere: false })],
+      canBootstrapShare: true,
+    });
+    const texts = flatTexts(state);
+    expect(texts).not.toContain("🌐 Share to fleet");
+  });
+
+  it("falls back to a noop button when the synthesised callback exceeds the 64-byte cap", () => {
+    // Pathological: 60-char label + 40-char agent → "auth:ad:" (8) +
+    // 40 + ":" + 60 = 109 bytes, well over the 64-byte cap.
+    const longLabel = "a".repeat(60);
+    const state = mkState({
+      agent: "x".repeat(40),
+      accounts: [mkAccount({ label: longLabel, enabledHere: true })],
+    });
+    const allButtons = rows(state).flat();
+    const noopBtn = allButtons.find((b) => b.text.startsWith("⚠"));
+    expect(noopBtn?.callback_data).toBe("auth:noop");
+    expect(noopBtn?.text).toMatch(/use CLI/);
+  });
+
+  it("non-account verbs still encode under the 64-byte budget for typical names", () => {
+    expect(
+      Buffer.byteLength(
+        encodeCallbackData({ kind: "account-enable", agent: "clerk", label: "work" }),
+        "utf8",
+      ),
+    ).toBeLessThanOrEqual(CALLBACK_BUDGET_BYTES);
+  });
+});
+
+describe("buildAccountConfirmKeyboard", () => {
+  it("emits an enable confirm + cancel row", () => {
+    const kb = buildAccountConfirmKeyboard("clerk", "work", "enable");
+    const buttons = (kb.inline_keyboard as unknown as Array<Array<{ text: string; callback_data?: string }>>).flat();
+    expect(buttons).toHaveLength(2);
+    expect(buttons[0].text).toBe("⚠️ Confirm enable: work");
+    expect(buttons[0].callback_data).toBe("auth:cae:clerk:work");
+    expect(buttons[1].text).toBe("↩️ Cancel");
+    expect(buttons[1].callback_data).toBe("auth:refresh:clerk");
+  });
+
+  it("emits a disable confirm with the disable callback", () => {
+    const kb = buildAccountConfirmKeyboard("clerk", "work", "disable");
+    const buttons = (kb.inline_keyboard as unknown as Array<Array<{ text: string; callback_data?: string }>>).flat();
+    expect(buttons[0].text).toBe("⚠️ Confirm disable: work");
+    expect(buttons[0].callback_data).toBe("auth:cad:clerk:work");
+  });
+});
+
+describe("buildDashboardText — accounts summary line", () => {
+  it("omits the line when accounts is undefined", () => {
+    const text = buildDashboardText(mkState({ accounts: undefined }));
+    expect(text).not.toMatch(/Accounts:/);
+  });
+
+  it("omits the line when accounts is an empty array (no totals to summarise)", () => {
+    const text = buildDashboardText(mkState({ accounts: [] }));
+    expect(text).not.toMatch(/Accounts:/);
+  });
+
+  it("renders <enabledHere>/<total> when accounts exist", () => {
+    const text = buildDashboardText(
+      mkState({
+        accounts: [
+          mkAccount({ label: "work", enabledHere: true }),
+          mkAccount({ label: "home", enabledHere: false }),
+          mkAccount({ label: "test", enabledHere: false }),
+        ],
+      }),
+    );
+    expect(text).toMatch(/Accounts: <b>1\/3<\/b> shared on this agent/);
+  });
+});
+
+const _AccountHealthCheck: AccountHealth = "healthy"; // type-import smoke
+void _AccountHealthCheck;


### PR DESCRIPTION
## Summary

The `/auth` dashboard already has per-slot buttons (Reauth, Add slot, Use, Remove, Fall back, Full quota, Refresh). The new account verbs from #634 (`auth account add` / `enable` / `disable` / `share` + the `all` keyword) were typable on Telegram but not button-tappable. This PR closes the gap.

**New buttons:**
- One row per account with ✓ marker (enabled here) or ○ marker (account exists, not enabled here). Tap → two-stage confirm → `auth enable/disable <label> <agent>` + restart.
- "🌐 Share to fleet" bootstrap button when no accounts exist but this agent has slot creds we can promote. Tap → `auth share default --from-agent <agent>` + restart.
- Truncated noop row when more than `ACCOUNTS_DISPLAY_CAP` (5) accounts exist.
- Render-time noop fallback when synthesised callback would exceed the 64-byte budget.

**New CLI:** `auth account list --json` — sorted account inventory the gateway probes for the dashboard's accounts section.

## Design contract

**Vision:** advances *Subscription-honest* and *Multi-agent fleet*. One Pro pays for many agents, one tap manages membership from mobile.

**JTBD `share-auth-across-the-fleet.md`:** *"the user manages accounts; switchroom routes them to consumers"* — dashboard now visually shows the cross-product (✓ / ○) and offers a one-tap bootstrap when no accounts exist.

**Principles:**

| Check | Verdict |
|---|---|
| Docs test | ✓ ✓ / ○ icons and plain labels are tap-to-discover; no docs needed. |
| Defaults test | ✓ Section appears only when accounts exist (or bootstrap is offered); zero config; older CLIs without `--json` degrade gracefully. |
| Consistency test | ✓ Same callback_data format (`auth:<verb>:<agent>[:<label>]`), same edit-in-place refresh pattern, same two-stage confirm shape as `rm`/`confirm-rm`. |

## What's NOT in this PR (Phase 2)

- "📋 All accounts" drill-down screen with health badges, expiry countdowns, per-account agent lists, `account rm` buttons. Keeping the surface minimal while the per-agent toggles land cleanly.

## share-fleet label choice (review-worthy)

The bootstrap button synthesises `label = "default"` rather than prompting via ForceReply (one extra round-trip). Trigger is "zero accounts exist" so there's nothing to disambiguate against. User can rename via CLI later. Pushback welcome.

## Test plan

- [x] `npm run lint` clean
- [x] `npm run build` clean
- [x] **8113 tests pass** (3301 bun + 4812 vitest), 0 fail. +32 new tests in `auth-dashboard.test.ts`.

Coverage:
- Round-trip per new verb (`account-enable`, `account-disable`, `confirm-account-*`, `share-fleet`) with `.`-containing labels.
- Validator rejects empty / oversized / spaces / colons / `..` / path-traversal lookalikes.
- Render variants: undefined / empty + bootstrap on/off / single ✓ / single ○ / multi / truncation cap / overflow guard / accounts hide bootstrap.
- `buildAccountConfirmKeyboard` enable + disable shapes.
- `buildDashboardText` accounts summary line: hidden when undefined / empty; rendered as `N/M shared` when populated.

## Manual verification (post-merge)

```
# Fresh fleet, clerk has slot creds, no accounts:
/auth                  → see "🌐 Share to fleet"
tap                    → "Sharing to fleet…" toast → ✓ default appears

# Other agent (klanker) opens /auth:
/auth                  → see "○ default"
tap                    → confirm row → tap confirm → ✓ default + restart

# Disable one:
tap "✓ default" on klanker  →  confirm row  →  ○ default + restart
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)