### PR TITLE
fix(bundle): externalize node-fetch — fixes 'Network request failed' under bun

### DIFF
--- a/telegram-plugin/scripts/build.mjs
+++ b/telegram-plugin/scripts/build.mjs
@@ -33,8 +33,26 @@ for (const { src, out, label } of entries) {
   mkdirSync(outDirForEntry, { recursive: true });
 
   console.log(`[build] bundling ${src} -> dist/${out}`);
+  // `--external node-fetch`: grammy depends on node-fetch@2 which is a
+  // CJS package using node's `http`/`stream` directly. When bundled with
+  // `--target node`, bun's bundler INLINES node-fetch as the fetch
+  // implementation. Under bun runtime that inlined node-fetch breaks
+  // grammy's API calls with a generic "Network request failed!" — the
+  // gateway boot then loops 8x retrying getMe and exits, rendering the
+  // entire fleet unresponsive (every reply path fails, agent thumbs-up
+  // works but no message lands).
+  //
+  // Externalizing node-fetch keeps the bundle target-node compatible
+  // for npm-i-g users on a node runtime (grammy declares node-fetch as
+  // a dep so it'll be present in node_modules) AND lets bun's native
+  // fetch shim take over when the bundle runs under bun (the actual
+  // production deployment via `systemd ExecStart=bun gateway.js`).
+  //
+  // Verified: the un-externalized bundle reproducibly fails under bun
+  // with "HttpError: Network request for 'getMe' failed!" within 1s of
+  // boot. The externalized bundle boots cleanly and polls successfully.
   execSync(
-    `bun build ${JSON.stringify(srcPath)} --outdir ${JSON.stringify(outDirForEntry)} --target node`,
+    `bun build ${JSON.stringify(srcPath)} --outdir ${JSON.stringify(outDirForEntry)} --target node --external node-fetch`,
     { stdio: "inherit", cwd: root }
   );
 


### PR DESCRIPTION
After PR #634's bundling-mode flip, the entire fleet went unresponsive on restart: agents thumbs-up'd inbound messages but no replies landed. Gateway logs showed:

\`\`\`
telegram gateway: deleteWebhook on startup failed: HttpError: Network request for 'deleteWebhook' failed!
telegram gateway: startup network error (attempt 1/8), retrying in 1s: HttpError: Network request for 'getMe' failed!
... (8x exponential backoff, then exit)
\`\`\`

\`curl\` to api.telegram.org with the same token returned 200 in <1s. \`bun -e \"fetch('https://api.telegram.org/bot\$TOKEN/getMe')\"\` worked. Running \`bun gateway.ts\` (source) worked. Running \`bun gateway.js\` (bundled output) didn't. Same bot, same network, same runtime.

## Root cause

grammy 1.42 declares \`node-fetch@2.7.0\` as a runtime dep. node-fetch v2 is a CJS package using node's \`http\` / \`https\` / \`stream\` modules directly.

When \`bun build --target node\` bundles gateway.ts, it **inlines** node-fetch into the output bundle (you can grep \`require_lib2 = __commonJS\` for the embedded copy). Inlined node-fetch v2 has issues running under bun runtime — grammy's \`fetch()\` calls return generic \"Network request failed!\" without underlying detail.

When the same source runs as \`.ts\` directly, bun's runtime resolves \`node-fetch\` to its own native fetch shim (bun ships a compat layer that delegates to bun's native fetch). The native path works; the bundled-as-CJS path doesn't.

## Fix

One flag: \`--external node-fetch\`. The bundle no longer inlines node-fetch; instead, the \`require('node-fetch')\` is preserved as a runtime resolution. Both deployments now work:

- **Under bun runtime (production via systemd \`ExecStart=bun gateway.js\`)**: bun resolves node-fetch to its native fetch shim → works.
- **Under node runtime (npm-i-g users on bun-less systems)**: node resolves node-fetch from node_modules (grammy declares it as a dep, so it's always present in a fresh \`npm i\`) → works.

## Verification

**Before fix:** \`bun dist/gateway/gateway.js\` → loops \`HttpError: Network request for 'getMe' failed!\` 8x, exits.

**After fix:** \`bun dist/gateway/gateway.js\` → \`polling as @clerk_meken_bot\` within 1s, boot card posted.

Bundle size: 2.0 MB → 1.65 MB (node-fetch removed).

The full fleet (carrie, clerk, finn, gymbro, klanker, lawgpt, ziggy) now runs cleanly from \`dist/gateway/gateway.js\` per #634's strategic default. Before this fix, they had to run from \`gateway.ts\` source as a workaround.

🤖 Generated with [Claude Code](https://claude.com/claude-code)