### PR TITLE
fix(bundle): ASCII-escape bundles to dodge bun parser mojibake (#642 follow-up)

### DIFF
--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -5,6 +5,7 @@ import { execSync } from "node:child_process";
 import { readFileSync, writeFileSync, chmodSync, mkdirSync, rmSync } from "node:fs";
 import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
+import { escapeBundleNonAscii } from "./escape-bundle-non-ascii.mjs";
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const outDir = resolve(root, "dist/cli");
@@ -101,6 +102,16 @@ if (src.startsWith("#!/usr/bin/env node")) {
   writeFileSync(outFile, src);
 }
 chmodSync(outFile, 0o755);
+
+// Bun parser bug workaround — see scripts/escape-bundle-non-ascii.mjs.
+// Without this, raw UTF-8 in string literals past ~172kB into the bundle
+// gets read as Latin-1 at runtime, producing double-UTF-8 mojibake in
+// stdout (agent-list "Uptime" column) and on-disk files (systemd unit
+// em-dash → `c3 a2 c2 80 c2 94`).
+const cliEscape = escapeBundleNonAscii(outFile);
+if (cliEscape.changed) {
+  console.log(`[build] ASCII-escaped ${cliEscape.nonAsciiCount} non-ASCII code units in dist/cli/switchroom.js`);
+}
 
 // Build the telegram-plugin self-contained dist (#634 strategic
 // packaging fix). The plugin's gateway / server / bridge entry points

--- a/scripts/escape-bundle-non-ascii.mjs
+++ b/scripts/escape-bundle-non-ascii.mjs
@@ -1,0 +1,64 @@
+// Post-build pass: replace every non-ASCII UTF-16 code unit in a bundle
+// with a `\uHHHH` escape, leaving the bundle pure ASCII.
+//
+// Why this exists:
+//
+// Bun's parser/runtime has a bug where raw UTF-8 bytes in source files
+// past a certain offset (~172kB into our CLI bundle) are misinterpreted
+// as Latin-1 — each UTF-8 byte becomes its own JS code unit. The em-dash
+// `e2 80 94` (one codepoint U+2014) loads as three codepoints U+00E2,
+// U+0080, U+0094 (length=3). When that string is re-emitted to stdout or
+// a file, each U+00xx codepoint encodes as two-byte UTF-8 (`c3 a2`,
+// `c2 80`, `c2 94`), producing the classic double-UTF-8 "mojibake" the
+// user reported in #642 boot cards and the agent-list "Uptime" column.
+//
+// At the top of the bundle, the same bytes parse correctly. So the bug
+// isn't bun-wide — something in bun's JS lexer flips encoding state
+// somewhere into a large bundle. Reproduced empirically by injecting a
+// `Buffer.from("\xe2\x80\x94","utf-8").toString("hex")` print at byte
+// offset 0 (clean: `e28094`) vs ~1.16MB (mojibake: `c3a2c280c294`).
+//
+// The safe, target-agnostic fix is to ship the bundle ASCII-only.
+// Every code unit > 0x7F becomes its `\uHHHH` escape; surrogate pairs
+// (astral codepoints like 💬 U+1F4AC) are escaped as two `\uHHHH` units
+// to preserve regex compatibility (`\u{...}` requires the `u` flag).
+// The transform is universal: strings, template literals, regex
+// literals, and comments all accept `\uHHHH` without semantic change.
+//
+// JS identifiers may legally contain non-ASCII chars but our codebase
+// doesn't use any (verified: every non-ASCII byte in the CLI bundle
+// sits inside a string, regex, or comment). If that ever changes,
+// replace this transform with a parser-aware one.
+//
+// This is the same defence esbuild ships under `--charset=ascii`. Bun
+// build doesn't expose a charset flag (as of 1.3.13), so we apply the
+// transform ourselves.
+
+import { readFileSync, writeFileSync, statSync, chmodSync } from "node:fs";
+
+/**
+ * @param {string} bundlePath
+ */
+export function escapeBundleNonAscii(bundlePath) {
+  const original = readFileSync(bundlePath, "utf-8");
+  // Walk JS code units (UTF-16). Every code unit > 0x7F gets escaped.
+  // Surrogate pairs (astral codepoints) become two \uHHHH escapes — safe
+  // in strings/templates/regex without the `u` flag.
+  let escaped = "";
+  let nonAsciiCount = 0;
+  for (let i = 0; i < original.length; i++) {
+    const cu = original.charCodeAt(i);
+    if (cu < 0x80) {
+      escaped += original[i];
+    } else {
+      escaped += "\\u" + cu.toString(16).padStart(4, "0");
+      nonAsciiCount++;
+    }
+  }
+  if (nonAsciiCount === 0) return { changed: false, nonAsciiCount: 0 };
+  // Preserve mode bits (the bundle is executable).
+  const mode = statSync(bundlePath).mode;
+  writeFileSync(bundlePath, escaped, { encoding: "ascii" });
+  chmodSync(bundlePath, mode);
+  return { changed: true, nonAsciiCount };
+}

--- a/telegram-plugin/scripts/build.mjs
+++ b/telegram-plugin/scripts/build.mjs
@@ -4,6 +4,7 @@ import { execSync } from "node:child_process";
 import { readFileSync, writeFileSync, chmodSync, mkdirSync, rmSync } from "node:fs";
 import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
+import { escapeBundleNonAscii } from "../../scripts/escape-bundle-non-ascii.mjs";
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const outDir = resolve(root, "dist");
@@ -62,6 +63,16 @@ for (const { src, out, label } of entries) {
     writeFileSync(outPath, content);
   }
   chmodSync(outPath, 0o755);
+
+  // Bun parser bug workaround — see scripts/escape-bundle-non-ascii.mjs.
+  // Required for the gateway bundle: without it, the boot card's `✅`
+  // and the inline `·` separator in the ack-line template literal get
+  // double-UTF-8 encoded on the wire (#642 follow-up; mojibake reported
+  // as `â LawGPT back up Â· v0.6.3`).
+  const escResult = escapeBundleNonAscii(outPath);
+  if (escResult.changed) {
+    console.log(`[build] ASCII-escaped ${escResult.nonAsciiCount} non-ASCII code units in dist/${out}`);
+  }
 }
 
 console.log("[build] done");

--- a/tests/bundle-ascii-only.test.ts
+++ b/tests/bundle-ascii-only.test.ts
@@ -1,0 +1,70 @@
+// Regression test for #642 follow-up: bundle ASCII-only invariant.
+//
+// Bun's parser/runtime has a bug where raw UTF-8 bytes in string literals
+// past a certain offset (~172kB into a large bundle) get misinterpreted
+// as Latin-1 at runtime — each UTF-8 byte becomes its own JS code unit,
+// then re-emitted as two-byte UTF-8 on stdout/file write, producing
+// classic double-encoded mojibake. The user-visible symptom was the
+// boot card showing `â LawGPT back up Â· v0.6.3` and the agent-list
+// "Uptime" column rendering as garbage.
+//
+// The fix (scripts/escape-bundle-non-ascii.mjs) post-processes built
+// bundles to escape every non-ASCII code unit as `\uHHHH`. This test
+// asserts the invariant directly: built bundles must contain no bytes
+// > 0x7F. The test runs after `npm run build` produces dist/ — it's
+// gated on the artefacts existing so a fresh checkout without a build
+// doesn't fail (vitest's --run will skip).
+//
+// If this test ever fails: either the post-build escape pass was
+// removed/skipped, or a new build target was added without wiring the
+// escape pass into it. Re-add the call to `escapeBundleNonAscii(outFile)`
+// after the bundle is written.
+
+import { existsSync, readFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, it, expect } from "vitest";
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+
+const BUNDLES = [
+  "dist/cli/switchroom.js",
+  "telegram-plugin/dist/gateway/gateway.js",
+  "telegram-plugin/dist/server.js",
+  "telegram-plugin/dist/bridge/bridge.js",
+  "telegram-plugin/dist/foreman/foreman.js",
+];
+
+describe("bundle ASCII-only invariant (#642 follow-up)", () => {
+  for (const rel of BUNDLES) {
+    const path = resolve(repoRoot, rel);
+    it(`${rel} contains no bytes > 0x7F`, () => {
+      if (!existsSync(path)) {
+        // Fresh checkout, no build yet. Skipping is fine — the lint /
+        // prepublish flow rebuilds before tests anyway.
+        return;
+      }
+      const buf = readFileSync(path);
+      const offenders: number[] = [];
+      for (let i = 0; i < buf.length; i++) {
+        if (buf[i] > 0x7f) {
+          offenders.push(i);
+          if (offenders.length >= 5) break;
+        }
+      }
+      if (offenders.length > 0) {
+        const samples = offenders.map((i) => {
+          const start = Math.max(0, i - 20);
+          const end = Math.min(buf.length, i + 20);
+          return `  @${i}: ${JSON.stringify(buf.subarray(start, end).toString("utf-8"))}`;
+        });
+        throw new Error(
+          `${rel} contains non-ASCII bytes — bun parser will mojibake them at runtime.\n` +
+            `Run \`npm run build\` (which now applies escapeBundleNonAscii). Samples:\n` +
+            samples.join("\n"),
+        );
+      }
+      expect(offenders.length).toBe(0);
+    });
+  }
+});


### PR DESCRIPTION
## Summary

- **Root cause**: bun's parser misreads raw UTF-8 source bytes as Latin-1 past ~172kB into a large bundle, expanding each multi-byte UTF-8 char into multiple JS code units; when re-emitted to stdout / `writeFileSync`, those code units get UTF-8 encoded a second time → double-UTF-8 mojibake.
- **User-visible symptoms** in v0.6.3:
  - boot cards rendered as `â LawGPT back up Â· v0.6.3`
  - `switchroom agent list` "Uptime" column rendered as garbage
  - systemd unit em-dashes written as bytes `c3 a2 c2 80 c2 94` (correct UTF-8 is `e2 80 94`)
- **Verification of root cause**: same source bytes parse correctly at byte 0 of the bundle but mojibake past ~1.16MB. Reproduced empirically by injecting `Buffer.from(\"\xe2\x80\x94\",\"utf-8\").toString(\"hex\")` at different bundle offsets — clean `e28094` at byte 0 vs `c3a2c280c294` at byte 1.16M.

## The fix

Post-build pass (`scripts/escape-bundle-non-ascii.mjs`) that walks every UTF-16 code unit in the built bundle and replaces \`> 0x7F\` with \`\uHHHH\`. Same defence esbuild ships under \`--charset=ascii\`; bun build doesn't expose one (as of 1.3.13).

Wired into both bundle builders:
- \`scripts/build.mjs\` (CLI bundle)
- \`telegram-plugin/scripts/build.mjs\` (gateway / server / bridge / foreman)

Strings, template literals, regex, and comments all accept \`\uHHHH\` without semantic change. JS identifiers can technically contain non-ASCII but our codebase doesn't (verified across the CLI bundle).

Build output reports \`[build] ASCII-escaped 1145 non-ASCII code units in dist/cli/switchroom.js\` etc. so the pass is observable.

## Regression test

\`tests/bundle-ascii-only.test.ts\` asserts all 5 built bundles contain zero bytes > 0x7F. Skips gracefully on a fresh checkout where dist/ isn't built yet.

## Test plan

- [x] \`npm run build\` runs the escape pass; bundles end up byte-clean
- [x] \`npx vitest run tests/bundle-ascii-only.test.ts\` — passes (5/5)
- [x] \`npm run lint\` — clean
- [x] Deployed to local fleet; \`switchroom agent list\` "Uptime" column now \`e2 80 94\` (clean UTF-8 em-dash); all 7 systemd gateway units regenerated clean
- [x] All 7 agents restarted; boot cards now render \`✅ AgentName back up · v0.6.3 · …\` with clean UTF-8

🤖 Generated with [Claude Code](https://claude.com/claude-code)