### PR TITLE
feat(scaffold): dm_only agent flag — suppress noisy boot probe for DM-only bots

### DIFF
--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -3355,13 +3355,20 @@ function buildAccessJson(
   const access: Record<string, unknown> = {
     dmPolicy: "allowlist",
     allowFrom,
-    groups: {
+  };
+  // DM-only bots opt out of inheriting the global forum_chat_id into the
+  // access list. Without this, the boot probe sweeps a chat the bot isn't
+  // a member of and emits a noisy "boot-probe-failed: 400 chat not found"
+  // every restart (plus a misleading user-facing notification). See the
+  // schema doc on `dm_only` for the design rationale.
+  if (!agentConfig.dm_only) {
+    access.groups = {
       [telegramConfig.forum_chat_id]: {
         requireMention: false,
         allowFrom,
       },
-    },
-  };
+    };
+  }
 
   // #596: project resolved telegram-channel features (stickers, voice_in,
   // telegraph) into access.json so the gateway picks them up at runtime

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -811,6 +811,19 @@ export const AgentSchema = z.object({
       "Account routing for switchroom-auth-broker. See " +
       "reference/share-auth-across-the-fleet.md for the unit-of-authentication model.",
     ),
+  dm_only: z
+    .boolean()
+    .optional()
+    .describe(
+      "Mark this agent as a DM-only bot — has its own bot_token and lives " +
+      "exclusively in a private chat with the operator. Suppresses " +
+      "scaffolding's default behavior of inheriting the global " +
+      "telegram.forum_chat_id into the agent's access.json `groups` entry " +
+      "(the forum chat the bot isn't a member of, which would otherwise " +
+      "trigger a 'boot-probe-failed: 400 chat not found' warning every " +
+      "restart). topic_name is still schema-required but unused — set it " +
+      "to a display label like 'DM' for /switchroom status output.",
+    ),
   topic_name: z.string().describe("Telegram forum topic display name"),
   topic_emoji: z
     .string()

--- a/src/setup/onboarding.ts
+++ b/src/setup/onboarding.ts
@@ -68,23 +68,38 @@ export function copyOnboardingState(
 /**
  * Build an access.json for an agent's telegram directory.
  * Uses the official Telegram plugin format with dmPolicy, allowFrom,
- * and groups sections.
+ * and (optionally) groups sections.
+ *
+ * When `dmOnly` is true, the `groups` entry is omitted entirely. This
+ * is the right shape for bots that only ever live in a private DM with
+ * the operator and have no business in the fleet's forum supergroup.
+ * Without this opt-out, scaffold inherits the global `forum_chat_id`
+ * into the access list, and the boot probe correctly reports it as
+ * unreachable (the bot isn't a member) — surfacing as a noisy
+ * "boot-probe-failed: 400 Bad Request: chat not found" warning every
+ * restart, with a notification to the operator's DM chat. The warning
+ * is accurate but the chat isn't actually used for routing — the right
+ * fix is to not put unreachable chats in the access list. (#carrie /
+ * issue surfaced 2026-05-03.)
  */
 export function buildAccessJson(
   userId: string,
   forumChatId: string,
   topicId?: number,
+  opts: { dmOnly?: boolean } = {},
 ): string {
   const access: Record<string, unknown> = {
     dmPolicy: "allowlist",
     allowFrom: [userId],
-    groups: {
+  };
+  if (!opts.dmOnly) {
+    access.groups = {
       [forumChatId]: {
         requireMention: false,
         allowFrom: [],
       },
-    },
-  };
+    };
+  }
 
   return JSON.stringify(access, null, 2) + "\n";
 }
@@ -130,12 +145,13 @@ export function writeAccessJson(
   userId: string,
   forumChatId: string,
   topicId?: number,
+  opts: { dmOnly?: boolean } = {},
 ): void {
   const telegramDir = join(agentDir, "telegram");
   mkdirSync(telegramDir, { recursive: true });
 
   const accessPath = join(telegramDir, "access.json");
-  writeFileSync(accessPath, buildAccessJson(userId, forumChatId, topicId), {
+  writeFileSync(accessPath, buildAccessJson(userId, forumChatId, topicId, opts), {
     encoding: "utf-8",
     mode: 0o600,
   });

--- a/tests/setup.test.ts
+++ b/tests/setup.test.ts
@@ -121,6 +121,33 @@ describe("buildAccessJson", () => {
 
     expect(parsed).not.toHaveProperty("topic_id");
   });
+
+  it("dmOnly=true omits the groups entry entirely (suppresses noisy boot probe)", () => {
+    // DM-only bots have their own bot_token and live in a private chat.
+    // The default scaffold inherits the global telegram.forum_chat_id
+    // into access.json's groups, but the DM bot isn't a member of that
+    // chat — the boot probe correctly emits
+    // "boot-probe-failed: 400 Bad Request: chat not found" every restart
+    // plus a misleading user-facing notification. Setting dmOnly drops
+    // the groups entry; the probe sweeps nothing it can't reach.
+    const json = buildAccessJson("12345", "-100987654321", undefined, { dmOnly: true });
+    const parsed = JSON.parse(json);
+    expect(parsed.dmPolicy).toBe("allowlist");
+    expect(parsed.allowFrom).toEqual(["12345"]);
+    expect(parsed).not.toHaveProperty("groups");
+  });
+
+  it("dmOnly=false (default) keeps the legacy groups shape for back-compat", () => {
+    const json = buildAccessJson("12345", "-100987654321", undefined, { dmOnly: false });
+    const parsed = JSON.parse(json);
+    expect(parsed.groups["-100987654321"]).toBeDefined();
+  });
+
+  it("opts omitted entirely behaves identically to dmOnly=false", () => {
+    const a = JSON.parse(buildAccessJson("12345", "-100987654321"));
+    const b = JSON.parse(buildAccessJson("12345", "-100987654321", undefined, {}));
+    expect(a).toEqual(b);
+  });
 });
 
 // ─── findExistingClaudeJson ──────────────────────────────────────────────────


### PR DESCRIPTION
## The noise

DM-only agents (own bot_token, lives exclusively in operator's private chat) currently inherit the global \`telegram.forum_chat_id\` into their \`access.json\` groups entry via scaffold's default behavior. The bot isn't a member of that forum chat, so every gateway start emits:

\`\`\`
telegram gateway: boot-probe-failed: chatId=-1003... reason="400 Bad Request: chat not found"
⚠️ Boot probe failed
Could not reach chat -1003... at startup — bot may not be a member.
\`\`\`

The warning is correct (the bot can't reach the chat) but the chat isn't actually used for routing — it's pure inheritance noise from \`extends: default\`.

## Strategic solve

New \`dm_only?: boolean\` field on \`AgentSchema\`. When true, both buildAccessJson sites omit the groups entry entirely. The bot's access list now matches its actual reachability — the probe sweeps nothing it can't reach, no false-positive warning.

## Two write sites covered

| File | Path | Trigger |
|---|---|---|
| \`src/setup/onboarding.ts\` | \`buildAccessJson\` / \`writeAccessJson\` | initial scaffold (agent create) |
| \`src/agents/scaffold.ts\` | \`buildAccessJson\` (reconcile path) | every reconcile |

Both gated on \`!agentConfig.dm_only\`.

## Test coverage

3 new tests in \`tests/setup.test.ts\` covering \`dmOnly=true\` (no groups), \`dmOnly=false\` (legacy shape), and opts-omitted-equals-default invariants. Full vitest sweep: 4,828 passed.

## Migration

After merge, set \`dm_only: true\` on each DM-only agent in switchroom.yaml (carrie is the current example). Next reconcile rewrites their access.json without the bad group entry. Existing access.json files keep their stale group entry until reconcile fires — operators can manually edit if they want immediate effect.

## Test plan

- [x] \`npm run lint\` clean (tsc + plugin-references)
- [x] \`npm run test:vitest\` — 4,828 passed
- [ ] Post-merge: set \`dm_only: true\` on carrie, reconcile, confirm no boot-probe-failed line in journal

🤖 Generated with [Claude Code](https://claude.com/claude-code)