### PR TITLE
chore: release v0.6.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 ## [Unreleased]
 
+
+## v0.6.4 — 2026-05-03
+
+### Added
+
+- **`dm_only?: boolean` agent flag (#644).** Marks an agent as a
+  DM-only bot — has its own bot_token and lives exclusively in a
+  private chat with the operator. Suppresses scaffolding's default
+  behavior of inheriting the global `telegram.forum_chat_id` into the
+  agent's `access.json` `groups` entry. Without this opt-out, the
+  boot probe sweeps a chat the bot isn't a member of and emits a
+  noisy `boot-probe-failed: 400 Bad Request: chat not found` warning
+  every restart (plus a misleading user-facing notification).
+  `topic_name` is still schema-required but unused — set it to a
+  display label like 'DM' for `/switchroom status` output.
+
+### Migration
+
+Set `dm_only: true` on each DM-only agent in switchroom.yaml. Next
+reconcile rewrites the agent's access.json without the bad group
+entry. Existing access.json files keep their stale group entry until
+reconcile fires — operators can manually edit `~/.switchroom/agents/
+<name>/telegram/access.json` to drop the `groups` block for immediate
+effect.
 ## v0.6.3 — 2026-05-03
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "switchroom-ai",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "Run Claude Code 24/7 on your Claude Pro/Max subscription over Telegram. Open-source alternative to OpenClaw and NanoClaw — no API keys, no Docker.",
   "type": "module",
   "bin": {

--- a/src/build-info.ts
+++ b/src/build-info.ts
@@ -2,8 +2,8 @@
 // Tracked in git so `tsc --noEmit` works on a fresh clone before `npm run build`.
 // Values are refreshed every time `npm run build` runs.
 
-export const VERSION: string = "0.6.1";
-export const COMMIT_SHA: string | null = "83344345";
-export const COMMIT_DATE: string | null = "2026-05-03T17:34:28+10:00";
-export const LATEST_PR: number | null = 633;
+export const VERSION: string = "0.6.4";
+export const COMMIT_SHA: string | null = "d4858a1a";
+export const COMMIT_DATE: string | null = "2026-05-03T20:11:47+10:00";
+export const LATEST_PR: number | null = 644;
 export const COMMITS_AHEAD_OF_TAG: number | null = 1;


### PR DESCRIPTION
Ships #644's `dm_only` agent flag. Carrie's boot-probe noise goes away after this lands and `dm_only: true` is set on her switchroom.yaml block.