### PR TITLE
fix(telegram): record answer-stream materializations to SQLite history (#648)

### DIFF
--- a/telegram-plugin/answer-stream.ts
+++ b/telegram-plugin/answer-stream.ts
@@ -135,6 +135,16 @@ export interface AnswerStreamConfig {
    */
   checkDedup?: (text: string) => boolean
   recordDedup?: (text: string) => void
+
+  /**
+   * #648 — write answer-stream materializations to the SQLite history buffer
+   * so `mcp__switchroom-telegram__get_recent_messages` surfaces them. Without
+   * this, materialized messages were visible in Telegram but invisible to
+   * MCP forensics — that's the gap that let #646 slip past triage.
+   *
+   * Optional — when absent, behaviour is unchanged (no buffer write).
+   */
+  recordOutbound?: (args: { messageId: number; text: string }) => void
 }
 
 export interface AnswerStreamHandle {
@@ -194,6 +204,7 @@ export function createAnswerStream(config: AnswerStreamConfig): AnswerStreamHand
     onMetric,
     checkDedup,
     recordDedup,
+    recordOutbound,
   } = config
 
   const effectiveThrottle = Math.max(250, throttleMs)
@@ -483,6 +494,9 @@ export function createAnswerStream(config: AnswerStreamConfig): AnswerStreamHand
           // gets suppressed. Mirrors the record call in gateway.ts
           // turn-flush at line ~3795.
           recordDedup?.(textToSend)
+          // #648 — mirror turn-flush's recordOutbound so this send shows up
+          // in get_recent_messages / SQLite history.
+          recordOutbound?.({ messageId: sentId, text: textToSend })
           onMetric?.({ kind: 'answer_lane_materialized', chatId, messageId: streamMsgId })
           return sentId
         }

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -3470,6 +3470,22 @@ function handleSessionEvent(ev: SessionEvent): void {
               if (cid == null) return
               outboundDedup.record(cid, currentSessionThreadId, text, Date.now())
             },
+            // #648 — write answer-stream materializations into the SQLite
+            // history buffer so get_recent_messages can surface them. Guard
+            // with HISTORY_ENABLED, matching the turn-flush pattern at ~3783.
+            recordOutbound: ({ messageId, text }: { messageId: number; text: string }) => {
+              if (!HISTORY_ENABLED) return
+              const cid = currentSessionChatId
+              if (cid == null) return
+              try {
+                recordOutbound({
+                  chat_id: cid,
+                  thread_id: currentSessionThreadId ?? null,
+                  message_ids: [messageId],
+                  texts: [text],
+                })
+              } catch {}
+            },
           })
         }
         // #549 fix: route the chunk through the preamble suppressor

--- a/telegram-plugin/tests/answer-stream-dedup.test.ts
+++ b/telegram-plugin/tests/answer-stream-dedup.test.ts
@@ -266,3 +266,87 @@ describe('answer-stream materialize() — dedup callbacks (#646)', () => {
     expect(result).toBeUndefined()
   })
 })
+
+// ─── Tests for #648 — recordOutbound callback ─────────────────────────────────
+
+describe('answer-stream materialize() — recordOutbound callback (#648)', () => {
+  it('recordOutbound is called with messageId and text on successful materialize', async () => {
+    const sendMessage = makeSendMessage()
+    const editMessageText = makeEditMessageText()
+    const recordOutbound = vi.fn()
+
+    const stream = createAnswerStream({
+      chatId: 'chat648',
+      isPrivateChat: false,
+      minInitialChars: 0,
+      throttleMs: 250,
+      sendMessage,
+      editMessageText,
+      recordOutbound,
+    })
+
+    stream.update(LONG_TEXT)
+    vi.advanceTimersByTime(500)
+    await flushMicrotasks()
+
+    const result = await stream.materialize()
+
+    expect(result).toBeTypeOf('number')
+    expect(recordOutbound).toHaveBeenCalledOnce()
+    expect(recordOutbound).toHaveBeenCalledWith({ messageId: result, text: LONG_TEXT })
+  })
+
+  it('recordOutbound is NOT called when materialize is suppressed by checkDedup', async () => {
+    const sendMessage = makeSendMessage()
+    const editMessageText = makeEditMessageText()
+    const checkDedup = vi.fn(() => true)
+    const recordOutbound = vi.fn()
+
+    const stream = createAnswerStream({
+      chatId: 'chat648',
+      isPrivateChat: false,
+      minInitialChars: 0,
+      throttleMs: 250,
+      sendMessage,
+      editMessageText,
+      checkDedup,
+      recordOutbound,
+    })
+
+    stream.update(LONG_TEXT)
+    vi.advanceTimersByTime(500)
+    await flushMicrotasks()
+
+    const result = await stream.materialize()
+
+    expect(result).toBeUndefined()
+    expect(recordOutbound).not.toHaveBeenCalled()
+  })
+
+  it('recordOutbound is NOT called when sendMessage throws', async () => {
+    const sendMessage = vi.fn(async () => {
+      throw new Error('Telegram 500 Internal Server Error')
+    })
+    const editMessageText = makeEditMessageText()
+    const recordOutbound = vi.fn()
+
+    const stream = createAnswerStream({
+      chatId: 'chat648',
+      isPrivateChat: false,
+      minInitialChars: 0,
+      throttleMs: 250,
+      sendMessage: sendMessage as never,
+      editMessageText,
+      recordOutbound,
+    })
+
+    stream.update(LONG_TEXT)
+    vi.advanceTimersByTime(500)
+    await flushMicrotasks()
+
+    const result = await stream.materialize()
+
+    expect(result).toBeUndefined()
+    expect(recordOutbound).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
Follow-up to #646 / #647. The answer-stream materialize success path now writes sent messages to the SQLite history buffer.

## Why

Without this, messages sent via the answer-stream materialize path were visible in Telegram but invisible to `mcp__switchroom-telegram__get_recent_messages` — the forensics gap that let #646 slip past triage. Turn-flush already does this at `gateway.ts:3781-3789`; this PR brings answer-stream to parity.

## Changes

- `telegram-plugin/answer-stream.ts`: optional `recordOutbound({ messageId, text })` callback on `AnswerStreamConfig`. Called from `materialize()` immediately after a successful send and the existing `recordDedup` call.
- `telegram-plugin/gateway/gateway.ts`: wires the callback into the existing `recordOutbound(...)` helper, gated on `HISTORY_ENABLED`. Closure pattern matches `checkDedup`/`recordDedup` from #647.
- `telegram-plugin/tests/answer-stream-dedup.test.ts`: 3 new tests covering happy path (called with right args), suppressed materialize (not called), failed send (not called). All 8 tests pass.

Closes #648