### PR TITLE
feat(auth): /auth account rename — Telegram-native account label rotation

### DIFF
--- a/src/auth/account-store.ts
+++ b/src/auth/account-store.ts
@@ -285,6 +285,49 @@ export function removeAccount(label: string, home: string = homedir()): void {
   rmSync(accountDir(label, home), { recursive: true, force: true });
 }
 
+/* ── Rename ──────────────────────────────────────────────────────────── */
+
+/**
+ * Rename an account on disk by moving its directory.
+ *
+ * Both labels are validated. Refuses when the source doesn't exist or
+ * the destination already does (to avoid silent merges that would
+ * lose the destination's credentials).
+ *
+ * Atomic at the filesystem level: rename(2) is atomic within a single
+ * filesystem, and accounts always live under one parent dir.
+ *
+ * The caller is responsible for downstream side effects:
+ *   1. Rewriting `agents.<name>.auth.accounts` lists in switchroom.yaml
+ *      to swap the old label for the new one.
+ *   2. Re-fanning out credentials to enabled agents (the per-agent
+ *      mirror at `<agentDir>/.claude/credentials.json` is unchanged
+ *      content-wise — just the source-of-truth label moved — so a
+ *      restart isn't strictly required, but a fanout pass keeps the
+ *      broker's view consistent).
+ */
+export function renameAccount(
+  oldLabel: string,
+  newLabel: string,
+  home: string = homedir(),
+): void {
+  validateAccountLabel(oldLabel);
+  validateAccountLabel(newLabel);
+  if (oldLabel === newLabel) {
+    throw new Error(`Account "${oldLabel}" already has that name — nothing to do`);
+  }
+  if (!accountExists(oldLabel, home)) {
+    throw new Error(`Account "${oldLabel}" does not exist`);
+  }
+  if (existsSync(accountDir(newLabel, home))) {
+    throw new Error(
+      `Cannot rename to "${newLabel}" — an account with that label already exists. ` +
+      `Remove it first with 'switchroom auth account rm ${newLabel}' or pick a different label.`,
+    );
+  }
+  renameSync(accountDir(oldLabel, home), accountDir(newLabel, home));
+}
+
 /* ── Atomic write helper ─────────────────────────────────────────────── */
 
 /**

--- a/src/cli/auth-accounts-yaml.ts
+++ b/src/cli/auth-accounts-yaml.ts
@@ -91,6 +91,50 @@ export function getAccountsForAgent(
     .filter((v): v is string => typeof v === "string");
 }
 
+/**
+ * Rewrite every `agents.<agent>.auth.accounts` list in the YAML,
+ * swapping every occurrence of `oldLabel` for `newLabel`. Returns
+ * the updated YAML string + the list of agents that were touched.
+ *
+ * Idempotent: agents whose list doesn't contain `oldLabel` are left
+ * alone. The order of remaining labels in each list is preserved.
+ *
+ * Used by `switchroom auth account rename` to keep the per-agent
+ * preference lists pointing at the renamed account without touching
+ * any other config.
+ */
+export function renameAccountInAllAgents(
+  yamlText: string,
+  oldLabel: string,
+  newLabel: string,
+): { yaml: string; touched: string[] } {
+  const doc = parseDocument(yamlText);
+  const agents = doc.get("agents");
+  if (!isMap(agents)) return { yaml: yamlText, touched: [] };
+  const touched: string[] = [];
+  for (const item of (agents as YAMLMap).items) {
+    const agentName = String((item.key as { value?: unknown }).value ?? item.key);
+    const accountsNode = doc.getIn(["agents", agentName, "auth", "accounts"]);
+    if (!isSeq(accountsNode)) continue;
+    const seq = accountsNode as YAMLSeq;
+    let mutated = false;
+    for (let i = 0; i < seq.items.length; i++) {
+      const v = (seq.items[i] as { value?: unknown }).value ?? seq.items[i];
+      if (v === oldLabel) {
+        seq.set(i, newLabel);
+        mutated = true;
+      }
+    }
+    if (mutated) touched.push(agentName);
+  }
+  // Return the original yaml string verbatim when no edits happened —
+  // serializing through parseDocument can normalize whitespace
+  // (e.g. drop a leading newline), which would surprise callers
+  // checking for byte-equality to detect "no change".
+  if (touched.length === 0) return { yaml: yamlText, touched };
+  return { yaml: String(doc), touched };
+}
+
 function ensureAgent(doc: Document, agentName: string): void {
   if (!hasAgent(doc, agentName)) {
     throw new Error(

--- a/src/cli/auth-accounts.ts
+++ b/src/cli/auth-accounts.ts
@@ -27,6 +27,7 @@ import {
   listAccounts,
   patchAccountMeta,
   removeAccount,
+  renameAccount,
   validateAccountLabel,
   writeAccountCredentials,
   type AccountCredentials,
@@ -39,6 +40,7 @@ import {
   appendAccountToAgent,
   getAccountsForAgent,
   removeAccountFromAgent,
+  renameAccountInAllAgents,
 } from "./auth-accounts-yaml.js";
 import { withConfigError, getConfig, getConfigPath } from "./helpers.js";
 
@@ -57,6 +59,7 @@ export function registerAuthAccountSubcommands(
   registerAccountAdd(account, program);
   registerAccountList(account, program);
   registerAccountRm(account, program);
+  registerAccountRename(account, program);
 
   registerEnable(authParent, program);
   registerDisable(authParent, program);
@@ -344,6 +347,86 @@ function registerAccountRm(account: Command, program: Command): void {
         removeAccount(label);
         console.log();
         console.log(`${chalk.green("✓")} Account ${chalk.bold(label)} removed.`);
+        console.log();
+      }),
+    );
+}
+
+/* ── account rename ──────────────────────────────────────────────────── */
+
+function registerAccountRename(account: Command, program: Command): void {
+  account
+    .command("rename <oldLabel> <newLabel>")
+    .description(
+      "Rename an Anthropic account on disk + update every agent's auth.accounts list in switchroom.yaml. " +
+        "No agent restart required — per-agent credentials.json mirrors are content-equivalent under the new label.",
+    )
+    .action(
+      withConfigError(async (oldLabel: string, newLabel: string) => {
+        validateAccountLabel(oldLabel);
+        validateAccountLabel(newLabel);
+        if (oldLabel === newLabel) {
+          throw new Error(
+            `Account "${oldLabel}" already has that name — nothing to do.`,
+          );
+        }
+        if (!accountExists(oldLabel)) {
+          throw new Error(`Account "${oldLabel}" does not exist`);
+        }
+        if (accountExists(newLabel)) {
+          throw new Error(
+            `Cannot rename to "${newLabel}" — an account with that label already exists.`,
+          );
+        }
+
+        // 1. Rename the global account directory.
+        renameAccount(oldLabel, newLabel);
+
+        // 2. Rewrite agents.<name>.auth.accounts lists in switchroom.yaml.
+        const yamlPath = getConfigPath(program);
+        const before = readFileSync(yamlPath, "utf-8");
+        const { yaml: after, touched } = renameAccountInAllAgents(
+          before,
+          oldLabel,
+          newLabel,
+        );
+        if (after !== before) {
+          writeFileSync(yamlPath, after);
+        }
+
+        // 3. Re-fanout under the new label so the broker's view is
+        //    consistent. Per-agent credentials.json content is identical
+        //    (the file was untouched by the directory rename), but we
+        //    re-mirror to update the legacy .oauth-token meta `source`
+        //    field from "account:<old>" to "account:<new>".
+        const config = getConfig(program);
+        const agentsDir = resolveAgentsDir(config);
+        const targets = touched.map((name) => ({
+          name,
+          agentDir: resolve(agentsDir, name),
+        }));
+        const outcomes =
+          targets.length > 0
+            ? fanoutAccountToAgents(newLabel, targets)
+            : [];
+
+        console.log();
+        console.log(
+          `${chalk.green("✓")} Renamed account ${chalk.bold(oldLabel)} → ${chalk.bold(newLabel)}.`,
+        );
+        if (touched.length > 0) {
+          console.log(
+            `  Updated ${touched.length} agent${touched.length === 1 ? "" : "s"} in switchroom.yaml: ${touched.join(", ")}`,
+          );
+        } else {
+          console.log(
+            `  No agents had ${chalk.bold(oldLabel)} in their auth.accounts list — only the global directory was renamed.`,
+          );
+        }
+        const fanned = outcomes.filter((o) => o.kind === "fanned-out").length;
+        if (fanned > 0) {
+          console.log(`  Re-fanned credentials to ${fanned} agent${fanned === 1 ? "" : "s"} (no restart required).`);
+        }
         console.log();
       }),
     );

--- a/telegram-plugin/auth-slot-parser.ts
+++ b/telegram-plugin/auth-slot-parser.ts
@@ -53,6 +53,7 @@ export type AuthIntent =
   | { kind: 'account-add'; account: string; fromAgent: string; label: string; cliArgs: string[] }
   | { kind: 'account-list'; label: string; cliArgs: string[] }
   | { kind: 'account-rm'; account: string; label: string; cliArgs: string[] }
+  | { kind: 'account-rename'; oldAccount: string; newAccount: string; label: string; cliArgs: string[] }
   | { kind: 'enable'; account: string; agents: string[]; label: string; cliArgs: string[]; restartAgentsAfter: true }
   | { kind: 'disable'; account: string; agents: string[]; label: string; cliArgs: string[] }
   | { kind: 'share'; account: string; fromAgent: string; label: string; cliArgs: string[]; restartAgentsAfter: true }
@@ -89,6 +90,7 @@ export function usageText(): string {
     '/auth account add <label> [--from-agent <name>]  — promote slot to global account',
     '/auth account list                          — accounts + agents using each',
     '/auth account rm <label>                    — remove (refused if enabled)',
+    '/auth account rename <old> <new>            — rename account + rewrite agents.<name>.auth.accounts lists',
     '/auth enable <label> [agents...|all]        — wire account to agent(s); "all" = every agent',
     '/auth disable <label> [agents...|all]       — unwire account from agent(s); "all" = every agent',
     '/auth share <label> [--from-agent <name>]   — account add + enable on every agent in one step',
@@ -281,9 +283,33 @@ export function parseAuthSubCommand(
       };
     }
 
+    if (accountSub === 'rename') {
+      // /auth account rename <oldLabel> <newLabel>
+      const oldAccount = parts[2];
+      const newAccount = parts[3];
+      if (!oldAccount || !newAccount) {
+        return {
+          kind: 'usage',
+          message: 'Usage: /auth account rename <oldLabel> <newLabel>',
+        };
+      }
+      try { assertSafeAccountLabel(oldAccount); assertSafeAccountLabel(newAccount); }
+      catch { return { kind: 'error', message: 'Invalid account label.' }; }
+      if (oldAccount === newAccount) {
+        return { kind: 'error', message: `Account "${oldAccount}" already has that name — nothing to do.` };
+      }
+      return {
+        kind: 'account-rename',
+        oldAccount,
+        newAccount,
+        label: `auth account rename ${oldAccount} ${newAccount}`,
+        cliArgs: ['auth', 'account', 'rename', oldAccount, newAccount],
+      };
+    }
+
     return {
       kind: 'usage',
-      message: 'Usage: /auth account add | list | rm  (see /auth)',
+      message: 'Usage: /auth account add | list | rm | rename  (see /auth)',
     };
   }
 

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -6413,6 +6413,15 @@ bot.command('auth', async ctx => {
     return
   }
 
+  if (intent.kind === 'account-rename') {
+    // /auth account rename <old> <new> — atomic dir rename + YAML
+    // rewrite of every agents.<name>.auth.accounts list. No agent
+    // restart required: per-agent credentials.json content is
+    // unchanged (only the source-of-truth label moved).
+    await runSwitchroomCommand(ctx, intent.cliArgs, intent.label)
+    return
+  }
+
   if (intent.kind === 'enable') {
     // /auth enable <label> [agents...|all] — wires the account to those agents
     // (defaults to the current agent), then restarts each so claude picks

--- a/telegram-plugin/tests/auth-slot-commands.test.ts
+++ b/telegram-plugin/tests/auth-slot-commands.test.ts
@@ -449,6 +449,49 @@ describe("parseAuthSubCommand — account-shaped verbs", () => {
     const intent = parseAuthSubCommand(["account"], "clerk");
     expect(intent.kind).toBe("account-list");
   });
+
+  it("/auth account rename <old> <new> produces account-rename intent with both labels", () => {
+    const intent = parseAuthSubCommand(
+      ["account", "rename", "ken-pro", "work-pro"],
+      "clerk",
+    );
+    expect(intent.kind).toBe("account-rename");
+    if (intent.kind === "account-rename") {
+      expect(intent.oldAccount).toBe("ken-pro");
+      expect(intent.newAccount).toBe("work-pro");
+      expect(intent.cliArgs).toEqual([
+        "auth",
+        "account",
+        "rename",
+        "ken-pro",
+        "work-pro",
+      ]);
+    }
+  });
+
+  it("/auth account rename without both labels is a usage error", () => {
+    expect(parseAuthSubCommand(["account", "rename"], "clerk").kind).toBe("usage");
+    expect(parseAuthSubCommand(["account", "rename", "only-one"], "clerk").kind).toBe(
+      "usage",
+    );
+  });
+
+  it("/auth account rename rejects same-name no-op as an error (not silent)", () => {
+    const intent = parseAuthSubCommand(
+      ["account", "rename", "same", "same"],
+      "clerk",
+    );
+    expect(intent.kind).toBe("error");
+  });
+
+  it("/auth account rename rejects invalid labels", () => {
+    expect(
+      parseAuthSubCommand(["account", "rename", "../etc", "ok"], "clerk").kind,
+    ).toBe("error");
+    expect(
+      parseAuthSubCommand(["account", "rename", "ok", "foo bar"], "clerk").kind,
+    ).toBe("error");
+  });
 });
 
 describe("parseAuthSubCommand — enable / disable", () => {

--- a/tests/auth-account-store.test.ts
+++ b/tests/auth-account-store.test.ts
@@ -15,6 +15,7 @@ import {
   readAccountCredentials,
   readAccountMeta,
   removeAccount,
+  renameAccount,
   validateAccountLabel,
   writeAccountCredentials,
   writeAccountMeta,
@@ -334,5 +335,61 @@ describe("atomic write — no tempfile remnants on success", () => {
     writeAccountMeta("clean", { createdAt: 1 }, home);
     const entries = readdirSync(accountDir("clean", home)).sort();
     expect(entries).toEqual(["credentials.json", "meta.json"]);
+  });
+});
+
+describe("renameAccount", () => {
+  it("moves the account directory + preserves credentials and meta", () => {
+    writeAccountCredentials(
+      "old-label",
+      { claudeAiOauth: { accessToken: "sk-ant-oat01-keep" } },
+      home,
+    );
+    writeAccountMeta(
+      "old-label",
+      { createdAt: 12345, email: "ken@example.com" },
+      home,
+    );
+    renameAccount("old-label", "new-label", home);
+    expect(accountExists("old-label", home)).toBe(false);
+    expect(accountExists("new-label", home)).toBe(true);
+    expect(readAccountCredentials("new-label", home)?.claudeAiOauth?.accessToken).toBe(
+      "sk-ant-oat01-keep",
+    );
+    expect(readAccountMeta("new-label", home)?.email).toBe("ken@example.com");
+  });
+
+  it("refuses when source does not exist", () => {
+    expect(() => renameAccount("ghost", "anything", home)).toThrow(/does not exist/);
+  });
+
+  it("refuses when destination already exists (no silent merge)", () => {
+    writeAccountCredentials(
+      "src",
+      { claudeAiOauth: { accessToken: "src-tok" } },
+      home,
+    );
+    writeAccountCredentials(
+      "dest",
+      { claudeAiOauth: { accessToken: "dest-tok" } },
+      home,
+    );
+    expect(() => renameAccount("src", "dest", home)).toThrow(
+      /an account with that label already exists/,
+    );
+    // Both untouched.
+    expect(readAccountCredentials("src", home)?.claudeAiOauth?.accessToken).toBe("src-tok");
+    expect(readAccountCredentials("dest", home)?.claudeAiOauth?.accessToken).toBe("dest-tok");
+  });
+
+  it("refuses no-op rename (same label)", () => {
+    writeAccountCredentials("same", { claudeAiOauth: { accessToken: "x" } }, home);
+    expect(() => renameAccount("same", "same", home)).toThrow(/already has that name/);
+  });
+
+  it("validates both labels", () => {
+    writeAccountCredentials("legit", { claudeAiOauth: { accessToken: "x" } }, home);
+    expect(() => renameAccount("../etc", "legit", home)).toThrow();
+    expect(() => renameAccount("legit", "foo bar", home)).toThrow();
   });
 });

--- a/tests/auth-accounts-yaml.test.ts
+++ b/tests/auth-accounts-yaml.test.ts
@@ -3,6 +3,7 @@ import {
   appendAccountToAgent,
   getAccountsForAgent,
   removeAccountFromAgent,
+  renameAccountInAllAgents,
 } from "../src/cli/auth-accounts-yaml.js";
 
 const baseYaml = `
@@ -108,5 +109,70 @@ describe("getAccountsForAgent", () => {
   });
   it("returns [] when agent missing", () => {
     expect(getAccountsForAgent(baseYaml, "ghost")).toEqual([]);
+  });
+});
+
+describe("renameAccountInAllAgents", () => {
+  const yaml = `
+agents:
+  foo:
+    topic_name: Foo
+    auth:
+      accounts: [work-pro, personal]
+  bar:
+    topic_name: Bar
+    auth:
+      accounts: [work-pro]
+  baz:
+    topic_name: Baz
+    auth:
+      accounts: [personal]
+  qux:
+    topic_name: Qux
+`;
+
+  it("swaps the label in every agent's list, preserves order, returns touched agents", () => {
+    const { yaml: out, touched } = renameAccountInAllAgents(yaml, "work-pro", "ken-pro");
+    expect(touched.sort()).toEqual(["bar", "foo"]);
+    expect(getAccountsForAgent(out, "foo")).toEqual(["ken-pro", "personal"]);
+    expect(getAccountsForAgent(out, "bar")).toEqual(["ken-pro"]);
+    // Untouched agents unchanged.
+    expect(getAccountsForAgent(out, "baz")).toEqual(["personal"]);
+    expect(getAccountsForAgent(out, "qux")).toEqual([]);
+  });
+
+  it("idempotent — renaming a label that no agent uses returns yaml unchanged", () => {
+    const { yaml: out, touched } = renameAccountInAllAgents(yaml, "missing", "anything");
+    expect(touched).toEqual([]);
+    expect(out).toBe(yaml);
+  });
+
+  it("preserves comments and unrelated structure", () => {
+    const yamlWithComment = `
+# top-level
+agents:
+  foo:
+    topic_name: Foo  # the foo
+    auth:
+      accounts: [old-name]
+`;
+    const { yaml: out } = renameAccountInAllAgents(yamlWithComment, "old-name", "new-name");
+    expect(out).toContain("# top-level");
+    expect(out).toContain("# the foo");
+    expect(getAccountsForAgent(out, "foo")).toEqual(["new-name"]);
+  });
+
+  it("touches an agent only once even if the label appears multiple times in its list", () => {
+    // Real configs would never have this, but the helper should be defensive.
+    const dupYaml = `
+agents:
+  foo:
+    topic_name: Foo
+    auth:
+      accounts: [work, work, work]
+`;
+    const { yaml: out, touched } = renameAccountInAllAgents(dupYaml, "work", "renamed");
+    expect(touched).toEqual(["foo"]);
+    expect(getAccountsForAgent(out, "foo")).toEqual(["renamed", "renamed", "renamed"]);
   });
 });


### PR DESCRIPTION
## Native Telegram surface

```
/auth account rename <oldLabel> <newLabel>
```

Closes the gap where renaming an Anthropic account label from Telegram required a multi-step \`account add → enable all → disable all → account rm\` dance (and re-OAuth or \`--from-agent\` plumbing). One verb, atomic, no agent restart.

## CLI parity

```
switchroom auth account rename <oldLabel> <newLabel>
```

Three composed steps:

1. \`mv ~/.switchroom/accounts/<old>/ ~/.switchroom/accounts/<new>/\` — atomic rename(2). Refused on missing source / existing dest / same name / invalid label.
2. Rewrites every \`agents.<name>.auth.accounts\` list in \`switchroom.yaml\` swapping old → new. Preserves order + comments. Idempotent (returns yaml unchanged if no agent referenced the old label).
3. Re-fanout under the new label so the legacy \`.oauth-token\` meta's \`source\` field stamps as \`account:<new>\`. Per-agent \`credentials.json\` bytes are unchanged — the file just lives in a renamed parent. **No agent restart needed.**

## Test coverage

13 new tests, 4,861 total passing:
- \`auth-account-store.test.ts\` +5: success preserves credentials + meta, refusal cases.
- \`auth-accounts-yaml.test.ts\` +4: order preservation, comment preservation, defensive against duplicates in a list, idempotent short-circuit.
- \`auth-slot-commands.test.ts\` +4: parser shape, usage error, no-op error, invalid-label error.

## Test plan

- [x] \`npm run lint\` clean
- [x] \`npm run test:vitest\` — 4,861 passed
- [ ] Post-merge: rename a real account from Telegram on the live fleet, verify per-agent \`credentials.json\` content is unchanged + agents continue running without restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)