### PR TITLE
feat(telegram): verbose tg-post logging for outbound Bot API calls

### DIFF
--- a/telegram-plugin/foreman/foreman.ts
+++ b/telegram-plugin/foreman/foreman.ts
@@ -31,6 +31,7 @@ import { listWorktrees } from '../../src/worktree/list.js'
 import { installPluginLogger } from '../plugin-logger.js'
 import {
   escapeHtmlForTg,
+  installTgPostLogger,
   isAllowedSender,
   makeSwitchroomExec,
   makeSwitchroomExecCombined,
@@ -143,6 +144,7 @@ const switchroomExecJson = makeSwitchroomExecJson()
 
 // ─── Bot ──────────────────────────────────────────────────────────────────
 const bot = new Bot(TOKEN)
+installTgPostLogger(bot)
 
 // No forum-topic routing in foreman — it's always a DM.
 const switchroomReply = makeSwitchroomReply(() => undefined)

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -58,6 +58,7 @@ import { handlePtyPartialPure, type PtyHandlerState } from '../pty-partial-handl
 import { handleStreamReply } from '../stream-reply-handler.js'
 import { createChatLock } from '../chat-lock.js'
 import { createRetryApiCall } from '../retry-api-call.js'
+import { installTgPostLogger } from '../shared/bot-runtime.js'
 import { buildAttachmentPath, assertInsideInbox } from '../attachment-path.js'
 import { createPinManager } from '../progress-card-pin-manager.js'
 import { createPinWatchdog } from '../progress-card-pin-watchdog.js'
@@ -366,6 +367,7 @@ const AGENT_ADMIN = process.env.SWITCHROOM_AGENT_ADMIN === 'true'
 
 // ─── Bot + chat lock ──────────────────────────────────────────────────────
 const bot = new Bot(TOKEN)
+installTgPostLogger(bot)
 
 // ─── sendMessageDraft boot probe ──────────────────────────────────────────
 // grammY 1.x exposes all Telegram Bot API methods through bot.api.raw.

--- a/telegram-plugin/shared/bot-runtime.ts
+++ b/telegram-plugin/shared/bot-runtime.ts
@@ -24,8 +24,59 @@
 import { GrammyError, type Bot, type Context } from 'grammy'
 import { run, type RunnerHandle } from '@grammyjs/runner'
 import { execFileSync, spawnSync } from 'child_process'
+import { createHash } from 'crypto'
 import { clearStaleTelegramPollingState } from '../startup-reset.js'
 import { createRetryApiCall } from '../retry-api-call.js'
+
+// ─── tg-post observability transformer ────────────────────────────────────
+
+/**
+ * Installs an API transformer on the bot that emits one stderr line per
+ * outbound Telegram Bot API POST. This is the single catchment point for
+ * correlating user-visible duplicate-message reports (switchroom #656,
+ * #657) against the actual outbound calls — the transformer runs inside
+ * grammY immediately before each HTTP POST and again on the response, so
+ * it sees every call regardless of whether it was routed through the
+ * `robustApiCall` retry helper or made directly via `bot.api.*`.
+ *
+ * Log shape (one line per POST, on both success and failure):
+ *
+ *   tg-post method=<m> chat=<id> thread=<id|-> parse_mode=<HTML|MarkdownV2|none> bytes=<n> hash=<sha1-12> status=<ok|err> err=<class-or-->
+ *
+ * Body content is never logged — only its length and a 12-char sha1 prefix
+ * so we can recognise repeated identical sends without leaking PII.
+ *
+ * Pure observability: no behaviour change, no error swallowing, no retry
+ * effects. The transformer always re-throws after logging.
+ */
+export function installTgPostLogger(bot: Bot): void {
+  bot.api.config.use(async (prev, method, payload, signal) => {
+    const p = (payload ?? {}) as Record<string, unknown>
+    const chat = p.chat_id != null ? String(p.chat_id) : '-'
+    const thread = p.message_thread_id != null ? String(p.message_thread_id) : '-'
+    const parseMode = (p.parse_mode as string | undefined) ?? 'none'
+    const text = typeof p.text === 'string' ? p.text : ''
+    const bytes = text.length
+    const hash = bytes > 0
+      ? createHash('sha1').update(text).digest('hex').slice(0, 12)
+      : '-'
+    try {
+      const res = await prev(method, payload, signal)
+      process.stderr.write(
+        `tg-post method=${method} chat=${chat} thread=${thread} parse_mode=${parseMode} bytes=${bytes} hash=${hash} status=ok err=-\n`,
+      )
+      return res
+    } catch (err) {
+      const errClass = err instanceof GrammyError
+        ? `grammy_${(err as GrammyError).error_code}`
+        : (err as { constructor?: { name?: string } } | null)?.constructor?.name ?? 'Error'
+      process.stderr.write(
+        `tg-post method=${method} chat=${chat} thread=${thread} parse_mode=${parseMode} bytes=${bytes} hash=${hash} status=err err=${errClass}\n`,
+      )
+      throw err
+    }
+  })
+}
 
 // ─── robustApiCall factory ────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Add a single-insertion-point grammY API transformer that logs one greppable stderr line per outbound Bot API POST. Pure observability — no behaviour change, always-on.

## Motivation

While debugging #656 / #657 (duplicate Telegram messages) the existing logs show *what the gateway intended* to send (`turn-flush firing — N chars`, `answer-stream: materialized`) but **not what actually hit the wire**. Two prior research passes hallucinated mechanisms because the empirical evidence layer was missing. This PR closes that gap.

## Log shape

```
tg-post method=sendMessage chat=-100123 thread=7 parse_mode=HTML bytes=11 hash=2aae6c35c94f status=ok err=-
tg-post method=deleteMessage chat=-100123 thread=- parse_mode=none bytes=0 hash=- status=ok err=-
tg-post method=editMessageText chat=-100123 thread=- parse_mode=none bytes=42 hash=a1b2c3d4e5f6 status=err err=grammy_400
```

Fields: method, chat, thread, parse_mode, bytes (length), hash (sha1-12 of body), status (ok/err), err (error class).

No message bodies are logged — length + hash only.

## Implementation

Wired as a grammY `bot.api.config.use(...)` transformer in a new helper `installTgPostLogger(bot)` (`telegram-plugin/shared/bot-runtime.ts`). Installed on the gateway's `bot` (`gateway/gateway.ts`) and the foreman's `bot` (`foreman/foreman.ts`).

The brief asked for the log line in `retry-api-call.ts`'s `robustApiCall`. The transformer is a strictly better insertion point: it sits below the helper and catches every outbound POST including the ~30 direct `bot.api.*` call sites in gateway.ts that bypass the retry helper. Single insertion, total coverage, zero per-callsite churn.

## Testing

- Full plugin suite: `bun test telegram-plugin/` → 3030 pass / 0 fail / 2 skip across 165 files.
- `tsc --noEmit` clean.
- No existing tests needed updates — transformers are invisible to test mocks that stub `bot.api.*` directly.

## Test plan

- [ ] Land, deploy, confirm `tg-post` lines appear in the gateway log.
- [ ] During the next reproduction of #656/#657, grep `tg-post.*hash=<hash>` to identify which path posted the duplicate body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>