### PR TITLE
fix(telegram): drop materialize on no-reply turn_end; turn-flush owns the emit (#656)

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -3572,56 +3572,22 @@ function handleSessionEvent(ev: SessionEvent): void {
       // followed) is the answer; the suppressor's emitAnswer callback
       // would no-op against a nulled stream, silently dropping the text
       // (regression for short no-tool replies). Order matters here: this
-      // call must come before the materialize/null block.
+      // call must come before the retract/null block.
       preambleSuppressor.flushNow()
-      // Issue #195: materialize the answer-lane stream as a fresh
-      // sendMessage so the user's device gets a push notification on
-      // turn completion (edits don't fire pushes).
-      //
-      // Guard with !currentTurnReplyCalled: the existing reply path is
-      // authoritative for the user-visible answer text. The agent normally
-      // calls reply/stream_reply during the turn, which posts the canonical
-      // message. Materializing the answer-lane on top of that produces a
-      // duplicate. Only materialize when no reply tool was invoked — which
-      // covers the case where the model emitted text but the agent never
-      // committed it via a tool call (rare, but the JTBD wants the user to
-      // see SOMETHING in that case rather than nothing).
-      //
-      // Either way we stop+null the stream — even when the reply path won,
-      // we don't want a leaked stream lingering past turn_end.
+      // #656: always retract the answer-lane stream at turn_end. Turn-flush
+      // (gateway.ts ~3475) is the sole canonical emitter for no-reply turns —
+      // it runs markdownToHtml and records to outboundDedup. Materializing
+      // here would race turn-flush and post raw model text (no HTML conv).
       if (activeAnswerStream != null) {
         const stream = activeAnswerStream
         activeAnswerStream = null
-        if (!currentTurnReplyCalled) {
-          void stream
-            .materialize()
-            .catch((err) => {
-              process.stderr.write(
-                `telegram gateway: answer-stream materialize failed: ${
-                  err instanceof Error ? err.message : String(err)
-                }\n`,
-              )
-            })
-            .finally(() => {
-              stream.stop()
-            })
-        } else {
-          // Reply path won — retract any preliminary answer-lane message
-          // so the user sees only the canonical stream_reply output.
-          // Issue #251: without retraction the answer-stream's raw-markdown
-          // preview (sent when captured text hit the minInitialChars threshold)
-          // coexists with the properly-rendered stream_reply message, producing
-          // a duplicate ~26 s apart with different formatting.
-          // retract() is best-effort: if deleteMessage fails the preliminary
-          // message lingers but no exception escapes to break turn_end.
-          void stream.retract().catch((err) => {
-            process.stderr.write(
-              `telegram gateway: answer-stream retract failed: ${
-                err instanceof Error ? err.message : String(err)
-              }\n`,
-            )
-          })
-        }
+        void stream.retract().catch((err) => {
+          process.stderr.write(
+            `telegram gateway: answer-stream retract failed: ${
+              err instanceof Error ? err.message : String(err)
+            }\n`,
+          )
+        })
       }
       if (currentSessionChatId == null) return
       const chatId = currentSessionChatId

--- a/telegram-plugin/tests/gateway-no-reply-single-emit.test.ts
+++ b/telegram-plugin/tests/gateway-no-reply-single-emit.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { createAnswerStream, __resetDraftIdForTests } from '../answer-stream.js'
+
+/**
+ * #656 — gateway turn_end no-reply path.
+ *
+ * Background: gateway.ts at the turn_end handler used to materialize() the
+ * answer-lane stream when no reply tool was called, in parallel with the
+ * turn-flush emitter (gateway.ts ~3475). Both gates fire on the same
+ * `!replyCalled && capturedText.length > 0` condition, no dedup between
+ * them, and materialize() posts the raw model text without HTML conversion
+ * — producing a visible duplicate where one copy shows raw <b> tags and
+ * the other renders cleanly.
+ *
+ * Fix: drop the materialize branch entirely. Always retract() the
+ * answer-stream at turn_end. Turn-flush is the sole canonical emitter for
+ * no-reply turns (it runs markdownToHtml + records to outboundDedup).
+ *
+ * This test pins the contract that retract() does NOT emit a fresh
+ * sendMessage — only deletes any preliminary message previously sent. The
+ * gateway's no-reply path now relies on this property.
+ */
+
+async function flushMicrotasks(times = 10): Promise<void> {
+  for (let i = 0; i < times; i++) {
+    await Promise.resolve()
+  }
+}
+
+let nextMessageId = 5000
+
+beforeEach(() => {
+  __resetDraftIdForTests()
+  nextMessageId = 5000
+  vi.useFakeTimers()
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('#656 — answer-stream retract() at turn_end emits nothing', () => {
+  it('retract before any preliminary send: no sendMessage, no deleteMessage', async () => {
+    const sendMessage = vi.fn(async () => ({ message_id: nextMessageId++ }))
+    const editMessageText = vi.fn(async () => {})
+    const deleteMessage = vi.fn(async () => {})
+
+    const stream = createAnswerStream({
+      chatId: 'chat-no-reply',
+      isPrivateChat: false,
+      minInitialChars: 400,
+      throttleMs: 250,
+      sendMessage: sendMessage as never,
+      editMessageText: editMessageText as never,
+      deleteMessage: deleteMessage as never,
+    })
+
+    // Seed a sub-threshold blob so nothing has been sent yet
+    stream.update('x'.repeat(50))
+    await flushMicrotasks()
+    expect(sendMessage).not.toHaveBeenCalled()
+
+    await stream.retract()
+
+    // Critically: retract() must NOT emit a fresh sendMessage. The gateway's
+    // no-reply path delegates the user-visible emit to turn-flush.
+    expect(sendMessage).not.toHaveBeenCalled()
+    expect(deleteMessage).not.toHaveBeenCalled()
+  })
+
+  it('retract after a preliminary send: deletes the prelim, no fresh sendMessage', async () => {
+    const THROTTLE = 1000
+    const sendMessage = vi.fn(async () => ({ message_id: nextMessageId++ }))
+    const editMessageText = vi.fn(async () => {})
+    const deleteMessage = vi.fn(async () => {})
+
+    const stream = createAnswerStream({
+      chatId: 'chat-no-reply',
+      isPrivateChat: false,
+      minInitialChars: 10,
+      throttleMs: THROTTLE,
+      sendMessage: sendMessage as never,
+      editMessageText: editMessageText as never,
+      deleteMessage: deleteMessage as never,
+    })
+
+    // Cross threshold so a preliminary send fires
+    stream.update('x'.repeat(50))
+    await flushMicrotasks()
+    vi.advanceTimersByTime(THROTTLE)
+    await flushMicrotasks()
+    expect(sendMessage).toHaveBeenCalledTimes(1)
+
+    const sendCallsBefore = sendMessage.mock.calls.length
+
+    await stream.retract()
+
+    // Retract should delete the preliminary message (cleanup) but must NOT
+    // emit any new sendMessage — turn-flush owns the user-visible emit.
+    expect(deleteMessage).toHaveBeenCalledTimes(1)
+    expect(sendMessage.mock.calls.length).toBe(sendCallsBefore)
+  })
+})


### PR DESCRIPTION
## Summary

Closes #656. The duplicate-Telegram-message bug on no-reply turns has been firing for months, surviving #647 / #649. Root cause is two parallel emitters with identical gates and zero dedup between them. This PR makes turn-flush the sole canonical emitter for no-reply turns.

## RCA (verified against current code, no theory)

When a Claude Code turn ends without calling `reply` / `stream_reply`:

1. **Emitter A — turn-flush** at `gateway.ts:3475-3520`. Runs `markdownToHtml(capturedText)` (line 3483), posts via `bot.api.sendMessage` (line 3489), records to `outboundDedup` (line 3506). Renders cleanly.
2. **Emitter B — answer-stream materialize** triggered at `gateway.ts:3271-3303`: `if (!currentTurnReplyCalled) void stream.materialize()`. Posts via `answer-stream.ts:445` with `parse_mode:'HTML'` but **no `markdownToHtml` conversion anywhere in `answer-stream.ts`** (verified zero refs). Sends raw model text → that's the user-visible raw-`<b>` copy.
3. Both gates are **identical** (`!currentTurnReplyCalled`). The author's comment at `gateway.ts:3260-3268` even acknowledged the design intent ("see SOMETHING rather than nothing") but did not coordinate with `decideTurnFlush` (`turn-flush-safety.ts:89`), which fires for the same condition.
4. No dedup interaction: `outboundDedup` is referenced in gateway.ts at lines 1899, 2220, 2239, 2364, 3506; **zero refs in answer-stream.ts**. Turn-flush records but materialize neither checks nor records.
5. Disconnect-flush does NOT re-emit captured text (refuted prior theory): `disconnect-flush.ts:60-109` only does setDone / disposeProgressDriver / draft `finalize()` — no `sendMessage` of captured text. The bridge disconnect/reconnect interleaved in original log is incidental (likely watchdog).

Result: every no-reply turn fires both emitters in parallel. Materialize wins the race (no 500ms delay) and posts raw markdown; turn-flush follows ~500ms later with the rendered version. User sees 2 messages, one with raw HTML tags.

## The fix

Drop the materialize branch from the no-reply path. Always retract the answer-stream at turn_end. Turn-flush becomes the sole canonical emitter. JTBD ("see SOMETHING when the model emits text without a tool call") is still satisfied — turn-flush will fire, just ~500ms later than materialize would have. Acceptable tradeoff for eliminating the duplicate + raw-HTML hazard.

Single hunk in `gateway/gateway.ts:3260-3303`.

## Test

`telegram-plugin/tests/gateway-no-reply-single-emit.test.ts` pins the contract that `retract()` never emits a fresh `sendMessage` (with and without a prior preliminary send). 2/2 pass.

## Why prior PRs missed it

#647 / #649 added dedup and turn-flush replay handling but kept materialize as a parallel emitter. The closure-capture / RCA hypotheses in earlier prep work for this bug were hallucinated — line numbers and parameter names that don't exist in the current code. This PR re-derived the mechanism from scratch with verified file:line citations.

## Test results

- New test: 2/2 pass.
- `bun test telegram-plugin/`: all green, no regressions in answer-stream tests (the `materialize()` API still exists and behaves identically — only the gateway no longer invokes it at turn_end).
- 37 pre-existing failures in CLI suite are unrelated (missing `dist/cli/switchroom.js` build artifact on fresh checkout).

## Test plan

- [ ] Land, deploy to clerk agent.
- [ ] Use the new `tg-post` logging from #659 to confirm exactly one POST per no-reply turn.
- [ ] Watch for any user reports of "missing reply" on plain-text turns (should not happen — turn-flush always fires, just ~500ms slower).

## Related

- #647, #649 — prior partial fixes that left materialize as parallel emitter.
- #659 — observability sister PR (verbose tg-post logging).
- #251 — the symmetric reply-tool-called duplicate that prompted the existing `retract()` branch (now applied unconditionally).
- #658 — meta-issue on gateway.ts ergonomics (8891 lines hostile to autonomous fixes; bug class survived because no test drives the real lifecycle).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>