### PR TITLE
feat(telegram): P0 fleet state + watcher exposure (#662)

### DIFF
--- a/telegram-plugin/fleet-state.ts
+++ b/telegram-plugin/fleet-state.ts
@@ -1,0 +1,207 @@
+/**
+ * P0 of #662 — fleet state struct + pure transition functions.
+ *
+ * `FleetMember` is the per-sub-agent unit the v2 two-zone status card
+ * (P1) will render. This module is pure data plumbing: the driver
+ * shadows a `Map<agentId, FleetMember>` alongside the legacy
+ * `chatState.subAgents` map and updates it through the reducers below
+ * at the same sites the legacy map is mutated. No render code, no
+ * timers, no globals — clocks and IDs are caller-supplied so tests can
+ * drive deterministic transitions.
+ *
+ * Status derivation (verified in #662): `session-tail.ts:101` defines
+ * `sub_agent_turn_end` as `{kind, agentId}` with NO terminal-status
+ * field, so failure must be derived: any `sub_agent_tool_result` with
+ * `isError=true` accumulates into `errorSeen`, and `applyTurnEnd` flips
+ * `status` to `failed` if any error was seen, else `done`.
+ */
+
+const ROLE_FALLBACK_LEN = 20
+const SANITISE_MAX_LEN = 120
+
+export type FleetStatus = 'running' | 'background' | 'done' | 'failed' | 'stuck' | 'killed'
+
+export interface FleetMember {
+  agentId: string
+  /** Display label: description / subagentType / first-prompt slice / 'agent'. */
+  role: string
+  /** ms epoch when this member was registered (driver snapshot of `now()`). */
+  startedAt: number
+  toolCount: number
+  /** ms epoch of the most recent tool_use / tool_result for this member. */
+  lastActivityAt: number
+  /** Most recent tool call observed (name + sanitised arg for display). */
+  lastTool: { name: string; sanitisedArg: string } | null
+  status: FleetStatus
+  /** ms epoch when status became terminal (done/failed/killed); null otherwise. */
+  terminalAt: number | null
+  /** True if any sub_agent_tool_result with isError=true has been observed. */
+  errorSeen: boolean
+  /** Snapshot of driver's currentTurnKey at sub_agent_started. Stable across turns. */
+  originatingTurnKey: string
+}
+
+export interface CreateFleetMemberArgs {
+  agentId: string
+  role: string
+  startedAt: number
+  originatingTurnKey: string
+}
+
+export function createFleetMember(args: CreateFleetMemberArgs): FleetMember {
+  return {
+    agentId: args.agentId,
+    role: args.role,
+    startedAt: args.startedAt,
+    toolCount: 0,
+    lastActivityAt: args.startedAt,
+    lastTool: null,
+    status: 'running',
+    terminalAt: null,
+    errorSeen: false,
+    originatingTurnKey: args.originatingTurnKey,
+  }
+}
+
+export function applyToolUse(
+  member: FleetMember,
+  toolName: string,
+  input: Record<string, unknown> | undefined,
+  now: number,
+): FleetMember {
+  return {
+    ...member,
+    toolCount: member.toolCount + 1,
+    lastActivityAt: now,
+    lastTool: { name: toolName, sanitisedArg: sanitiseToolArg(toolName, input ?? {}) },
+  }
+}
+
+export function applyToolResult(member: FleetMember, isError: boolean | undefined): FleetMember {
+  if (!isError) return member
+  if (member.errorSeen) return member
+  return { ...member, errorSeen: true }
+}
+
+export function applyTurnEnd(member: FleetMember, now: number): FleetMember {
+  // Idempotent — if already terminal, do nothing.
+  if (member.terminalAt != null) return member
+  return {
+    ...member,
+    status: member.errorSeen ? 'failed' : 'done',
+    terminalAt: now,
+    lastActivityAt: now,
+  }
+}
+
+export function markStuck(member: FleetMember, now: number, idleMs: number = 60_000): FleetMember {
+  if (member.status !== 'running') return member
+  if (now - member.lastActivityAt <= idleMs) return member
+  return { ...member, status: 'stuck' }
+}
+
+export function cap(
+  members: readonly FleetMember[],
+  n: number = 5,
+): { visible: FleetMember[]; hidden: number } {
+  const sorted = [...members].sort((a, b) => b.lastActivityAt - a.lastActivityAt)
+  if (sorted.length <= n) return { visible: sorted, hidden: 0 }
+  return { visible: sorted.slice(0, n), hidden: sorted.length - n }
+}
+
+/**
+ * Sanitise a tool input for display on the fleet row.
+ *
+ * - Path-bearing tools (Read/Edit/Write/NotebookEdit) → basename only,
+ *   so absolute paths under `/etc/secrets/` etc. don't leak into the
+ *   pinned card.
+ * - Bash/command-bearing tools → the command, but with bearer-token-
+ *   shaped substrings replaced with `[redacted]`.
+ * - Anything else → empty string. Renderer falls back to tool name only.
+ *
+ * Hard-capped at 120 chars; the fleet row is one line and Telegram caps
+ * the whole card at ~4096 bytes.
+ */
+export function sanitiseToolArg(name: string, raw: Record<string, unknown>): string {
+  let out = ''
+  switch (name) {
+    case 'Read':
+    case 'Edit':
+    case 'Write':
+    case 'NotebookEdit': {
+      const fp = raw.file_path
+      if (typeof fp === 'string' && fp.length > 0) out = basename(fp)
+      break
+    }
+    case 'Bash': {
+      const cmd = raw.command
+      if (typeof cmd === 'string') out = redactSecrets(cmd)
+      break
+    }
+    case 'Grep':
+    case 'Glob': {
+      const pat = raw.pattern
+      if (typeof pat === 'string') out = pat
+      break
+    }
+    case 'WebFetch':
+    case 'WebSearch': {
+      const url = raw.url ?? raw.query
+      if (typeof url === 'string') out = redactSecrets(url)
+      break
+    }
+    default: {
+      // Generic best-effort: the first string-valued field.
+      for (const v of Object.values(raw)) {
+        if (typeof v === 'string' && v.length > 0) {
+          out = redactSecrets(v)
+          break
+        }
+      }
+    }
+  }
+  if (out.length > SANITISE_MAX_LEN) out = out.slice(0, SANITISE_MAX_LEN - 1) + '…'
+  return out
+}
+
+function basename(p: string): string {
+  const idx = p.lastIndexOf('/')
+  return idx === -1 ? p : p.slice(idx + 1)
+}
+
+// Bearer / sk-/secret-shaped tokens (>= 16 chars of base64-ish run). The pattern
+// is intentionally conservative — we'd rather miss a token than blow away
+// legitimate command text. The renderer's job is to be readable; secret
+// scanning lives elsewhere.
+const SECRET_PATTERNS: ReadonlyArray<RegExp> = [
+  /Bearer\s+[A-Za-z0-9._\-+/=]{16,}/g,
+  /sk-[A-Za-z0-9_\-]{16,}/g,
+  /\b[A-Fa-f0-9]{32,}\b/g, // long hex (e.g. API keys)
+]
+
+function redactSecrets(text: string): string {
+  let out = text
+  for (const re of SECRET_PATTERNS) out = out.replace(re, '[redacted]')
+  return out
+}
+
+/**
+ * Resolve the fleet-row label for a freshly-dispatched sub-agent.
+ *
+ * Fallback chain (per #662 P0 spec): description → subagentType →
+ * first 20 chars of firstPromptText → "agent". `description` comes
+ * from the parent's Agent/Task tool_use input; `subagentType` is
+ * Claude Code's slot label (e.g. "general-purpose"); the prompt slice
+ * is the last-resort handle for ad-hoc dispatches that omit both.
+ */
+export function roleFromDispatch(
+  description: string | undefined,
+  subagentType: string | undefined,
+  firstPromptText: string,
+): string {
+  if (description != null && description.trim().length > 0) return description.trim()
+  if (subagentType != null && subagentType.trim().length > 0) return subagentType.trim()
+  const slice = firstPromptText.slice(0, ROLE_FALLBACK_LEN).trim()
+  if (slice.length > 0) return firstPromptText.slice(0, ROLE_FALLBACK_LEN)
+  return 'agent'
+}

--- a/telegram-plugin/progress-card-driver.ts
+++ b/telegram-plugin/progress-card-driver.ts
@@ -31,6 +31,14 @@ import {
   type SubAgentCardRegistry,
 } from './subagent-card.js'
 import { isTelegramReplyTool } from './tool-names.js'
+import {
+  applyToolResult as fleetApplyToolResult,
+  applyToolUse as fleetApplyToolUse,
+  applyTurnEnd as fleetApplyTurnEnd,
+  createFleetMember,
+  roleFromDispatch,
+  type FleetMember,
+} from './fleet-state.js'
 
 /**
  * Classification of a Telegram API error for failure-escalation purposes.
@@ -534,6 +542,13 @@ interface PerChatState {
    * double-registration if a real `sub_agent_started` arrives later.
    */
   promotedSpawnIds: Set<string>
+  /**
+   * P0 of #662 — shadow fleet map updated alongside `state.subAgents` at
+   * every sub_agent_* event. Coexists with the legacy map; P1/P2/P3 build
+   * the v2 two-zone status card on this without disturbing the existing
+   * renderer. See fleet-state.ts for the pure transitions.
+   */
+  fleet: Map<string, FleetMember>
 }
 
 export interface ProgressDriver {
@@ -620,6 +635,12 @@ export interface ProgressDriver {
   }
   /** Current state for a chat (for tests / inspection). */
   peek(chatId: string, threadId?: string): ProgressCardState | undefined
+  /**
+   * P0 of #662 — fetch the shadow fleet map for a chat. Used by tests
+   * and (eventually) by the v2 renderer. Same lookup semantics as
+   * `peek`. Returns undefined when no active card exists.
+   */
+  peekFleet(chatId: string, threadId?: string): Map<string, FleetMember> | undefined
   /**
    * True when the driver is still managing an active card for this chat+
    * thread — either a normal turn or a deferred-completion turn waiting on
@@ -1547,6 +1568,79 @@ export function createProgressDriver(config: ProgressDriverConfig): ProgressDriv
     return false
   }
 
+  // P0 of #662 — shadow fleet maintenance. Mutates cs.fleet in place
+  // by replacing entries with new immutable FleetMember objects from the
+  // pure transition functions in fleet-state.ts.
+  function updateFleetForEvent(cs: PerChatState, event: SessionEvent): void {
+    switch (event.kind) {
+      case 'sub_agent_started': {
+        // Idempotent — late duplicates of the same agentId keep the
+        // original startedAt + originatingTurnKey snapshot.
+        if (cs.fleet.has(event.agentId)) return
+        const role = roleFromDispatch(undefined, event.subagentType, event.firstPromptText)
+        cs.fleet.set(
+          event.agentId,
+          createFleetMember({
+            agentId: event.agentId,
+            role,
+            startedAt: now(),
+            originatingTurnKey: currentTurnKey ?? cs.turnKey,
+          }),
+        )
+        return
+      }
+      case 'sub_agent_tool_use': {
+        const m = cs.fleet.get(event.agentId)
+        if (m == null) return
+        cs.fleet.set(event.agentId, fleetApplyToolUse(m, event.toolName, event.input, now()))
+        return
+      }
+      case 'sub_agent_tool_result': {
+        const m = cs.fleet.get(event.agentId)
+        if (m == null) return
+        cs.fleet.set(event.agentId, fleetApplyToolResult(m, event.isError))
+        return
+      }
+      case 'sub_agent_turn_end': {
+        const m = cs.fleet.get(event.agentId)
+        if (m == null) return
+        cs.fleet.set(event.agentId, fleetApplyTurnEnd(m, now()))
+        return
+      }
+      default:
+        return
+    }
+  }
+
+  // Cardinality reconciler: the legacy state.subAgents map can grow
+  // through paths the fleet shadow doesn't know about (parent Agent
+  // tool_use synthesised correlations, heartbeat orphan promotions,
+  // cross-turn carry-over). Mirror those into fleet so the invariant
+  // that `fleet` is a superset-or-equal of `subAgents` (by key) holds.
+  function reconcileFleetWithSubAgents(cs: PerChatState): void {
+    for (const [agentId, sa] of cs.state.subAgents) {
+      if (!cs.fleet.has(agentId)) {
+        cs.fleet.set(
+          agentId,
+          createFleetMember({
+            agentId,
+            role: sa.description ?? 'agent',
+            startedAt: now(),
+            originatingTurnKey: currentTurnKey ?? cs.turnKey,
+          }),
+        )
+      }
+    }
+    // Drop fleet entries the legacy map no longer tracks (rare — only
+    // when a parent tool_result correlation prunes a sub-agent before
+    // any sub_agent_turn_end arrived).
+    for (const agentId of [...cs.fleet.keys()]) {
+      if (!cs.state.subAgents.has(agentId)) {
+        cs.fleet.delete(agentId)
+      }
+    }
+  }
+
   return {
     ingest(event, chatIdMaybe, threadId) {
       // An `enqueue` event carries its own chatId (extracted from the XML
@@ -1678,6 +1772,7 @@ export function createProgressDriver(config: ProgressDriverConfig): ProgressDriv
           parentTurnEndAt: null,
           parentDoneRendered: false,
           promotedSpawnIds: new Set(),
+          fleet: new Map<string, FleetMember>(),
         }
         chats.set(slot.turnKey, chatState)
         if (event.isSync) {
@@ -1741,6 +1836,19 @@ export function createProgressDriver(config: ProgressDriverConfig): ProgressDriv
       const prev = chatState.state
       chatState.state = reduce(chatState.state, event, now())
       chatState.lastEventAt = now()
+
+      // P0 of #662 — shadow fleet map. Mirror sub_agent_* events into
+      // the parallel FleetMember map using the pure transitions from
+      // fleet-state.ts. Legacy state.subAgents is unchanged; P1/P2/P3
+      // build on `fleet` without touching the existing renderer.
+      updateFleetForEvent(chatState, event)
+      // Reconcile shadow with legacy map: any sub-agent that appears in
+      // state.subAgents (e.g. via parent-tool-result correlation, the
+      // heartbeat orphan-promotion path, or carry-over) but is missing
+      // from fleet gets a synthetic FleetMember so the cardinality
+      // invariant holds. Conversely, drop fleet entries that legacy
+      // dropped (these are already terminal in the watcher's view).
+      reconcileFleetWithSubAgents(chatState)
       const stageChanged = chatState.state.stage !== prev.stage
       const visibleChanged = visibleDiff(prev, chatState.state)
 
@@ -2077,6 +2185,19 @@ export function createProgressDriver(config: ProgressDriverConfig): ProgressDriv
         `telegram gateway: progress-card: takeOverCard turnKey=${target.turnKey} wasEmitted=${wasEmitted}\n`,
       )
       return { wasEmitted, turnKey: target.turnKey }
+    },
+
+    peekFleet(chatId, threadId) {
+      if (currentTurnKey != null) {
+        const cs = chats.get(currentTurnKey)
+        if (cs != null && cs.chatId === chatId && cs.threadId === threadId) {
+          return cs.fleet
+        }
+      }
+      for (const cs of chats.values()) {
+        if (cs.chatId === chatId && cs.threadId === threadId) return cs.fleet
+      }
+      return undefined
     },
 
     peek(chatId, threadId) {

--- a/telegram-plugin/subagent-watcher.ts
+++ b/telegram-plugin/subagent-watcher.ts
@@ -41,6 +41,7 @@ import {
 import { basename, join } from 'path'
 import { homedir } from 'os'
 import { projectSubagentLine } from './session-tail.js'
+import { sanitiseToolArg } from './fleet-state.js'
 import { escapeHtml, truncate } from './card-format.js'
 import { bumpSubagentActivity, recordSubagentStall, recordSubagentEnd, reapStuckRunningRows } from './registry/subagents-schema.js'
 import { touchTurnActiveMarker } from './gateway/turn-active-marker.js'
@@ -86,6 +87,13 @@ export interface WorkerEntry {
   completionNotified: boolean
   /** Short summary from last completed tool / narrative, for completion message. */
   lastSummaryLine: string
+  /**
+   * Most recent tool call observed on this sub-agent's JSONL tail —
+   * tool name + sanitised arg for fleet-row display (P0 of #662). Null
+   * before any `sub_agent_tool_use` event has been seen. Replace-on-write;
+   * the renderer only ever shows the latest.
+   */
+  lastTool: { name: string; sanitisedArg: string } | null
   /**
    * True if the underlying JSONL file existed before the watcher started.
    * Historical entries are tracked for late state transitions but are
@@ -385,6 +393,14 @@ function readSubTail(
         entry.lastActivityAt = now
         if (ev.kind === 'sub_agent_tool_use') {
           entry.toolCount++
+          // P0 of #662: surface the most recent tool name + sanitised
+          // arg so the driver's fleet-state shadow can render the
+          // last-tool column on the v2 status card. Sanitiser lives in
+          // fleet-state.ts to keep the watcher dependency surface small.
+          entry.lastTool = {
+            name: ev.toolName,
+            sanitisedArg: sanitiseToolArg(ev.toolName, ev.input ?? {}),
+          }
         } else if (ev.kind === 'sub_agent_text') {
           // Do NOT overwrite description with narrative text — description is
           // set at dispatch time (from the parent Agent/Task tool_use input)
@@ -516,6 +532,7 @@ export function startSubagentWatcher(config: SubagentWatcherConfig): SubagentWat
       stallNotified: false,
       completionNotified: false,
       lastSummaryLine: '',
+      lastTool: null,
       historical: isHistorical,
     }
     registry.set(agentId, entry)

--- a/telegram-plugin/tests/fleet-state-watcher.test.ts
+++ b/telegram-plugin/tests/fleet-state-watcher.test.ts
@@ -1,0 +1,101 @@
+/**
+ * P0 of #662 — watcher exposes `lastTool` on WorkerEntry.
+ *
+ * The driver shadow needs the most recent tool name + sanitised arg
+ * for each running sub-agent. The watcher already projects
+ * `sub_agent_tool_use` events from the JSONL tail; this test pins the
+ * new field so subsequent driver work can rely on it.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { startSubagentWatcher } from '../subagent-watcher.js'
+
+function buildJSONL(...lines: object[]): string {
+  return lines.map((l) => JSON.stringify(l)).join('\n') + '\n'
+}
+
+function userMsg(text: string) {
+  return { type: 'user', message: { content: [{ type: 'text', text }] } }
+}
+
+function toolUse(name: string, id: string, input: Record<string, unknown>) {
+  return {
+    type: 'assistant',
+    message: { content: [{ type: 'tool_use', name, id, input }] },
+  }
+}
+
+describe('subagent-watcher: WorkerEntry.lastTool', () => {
+  let tmpRoot = ''
+  const stops: Array<{ stop(): void }> = []
+
+  beforeEach(() => {
+    tmpRoot = mkdtempSync(join(tmpdir(), 'fleet-watcher-'))
+  })
+
+  afterEach(() => {
+    while (stops.length) {
+      try { stops.pop()?.stop() } catch { /* */ }
+    }
+    try { rmSync(tmpRoot, { recursive: true, force: true }) } catch { /* */ }
+  })
+
+  function startWatcher(agentDir: string): {
+    watcher: ReturnType<typeof startSubagentWatcher>
+    poll: () => void
+  } {
+    const intervals: Array<{ fn: () => void }> = []
+    const w = startSubagentWatcher({
+      agentDir,
+      sendNotification: () => {},
+      stallThresholdMs: 60_000,
+      rescanMs: 500,
+      now: () => Date.now(),
+      setInterval: (fn) => { intervals.push({ fn }); return { ref: intervals.length } },
+      clearInterval: () => {},
+      setTimeout: () => ({ ref: 0 }),
+      clearTimeout: () => {},
+      log: () => {},
+    })
+    stops.push(w)
+    return { watcher: w, poll: () => intervals[0]?.fn() }
+  }
+
+  it('populates lastTool with most recent tool name + sanitised arg', () => {
+    const content = buildJSONL(
+      userMsg('do work'),
+      toolUse('Read', 'id1', { file_path: '/etc/secrets/foo.key' }),
+      toolUse('Bash', 'id2', { command: 'ls -la /tmp' }),
+    )
+    const agentDir = join(tmpRoot, 'agent')
+    const subDir = join(agentDir, '.claude', 'projects', 'p1', 'session-x', 'subagents')
+    mkdirSync(subDir, { recursive: true })
+    writeFileSync(join(subDir, 'agent-deadbeef.jsonl'), content)
+
+    const h = startWatcher(agentDir)
+    h.poll()
+
+    const entry = h.watcher.getRegistry().get('deadbeef')
+    expect(entry).toBeDefined()
+    expect(entry?.lastTool).toEqual({ name: 'Bash', sanitisedArg: 'ls -la /tmp' })
+    expect(entry?.toolCount).toBe(2)
+  })
+
+  it('lastTool is null before any tool_use event', () => {
+    const content = buildJSONL(userMsg('hello'))
+    const agentDir = join(tmpRoot, 'agent')
+    const subDir = join(agentDir, '.claude', 'projects', 'p1', 'session-x', 'subagents')
+    mkdirSync(subDir, { recursive: true })
+    writeFileSync(join(subDir, 'agent-cafef00d.jsonl'), content)
+
+    const h = startWatcher(agentDir)
+    h.poll()
+
+    const entry = h.watcher.getRegistry().get('cafef00d')
+    expect(entry).toBeDefined()
+    expect(entry?.lastTool).toBeNull()
+  })
+})

--- a/telegram-plugin/tests/fleet-state.test.ts
+++ b/telegram-plugin/tests/fleet-state.test.ts
@@ -1,0 +1,185 @@
+/**
+ * P0 of #662 — pure-function unit tests for FleetMember transitions.
+ *
+ * These tests document the contract the renderer (P1) and the
+ * background-persistence registry (P2) will rely on. The reducer is
+ * intentionally side-effect-free; clocks and randomness are passed in.
+ */
+
+import { describe, it, expect } from 'vitest'
+
+import {
+  createFleetMember,
+  applyToolUse,
+  applyToolResult,
+  applyTurnEnd,
+  markStuck,
+  cap,
+  sanitiseToolArg,
+  roleFromDispatch,
+  type FleetMember,
+} from '../fleet-state.js'
+
+const T0 = 1_700_000_000_000
+
+function freshMember(overrides: Partial<Parameters<typeof createFleetMember>[0]> = {}): FleetMember {
+  return createFleetMember({
+    agentId: 'a1',
+    role: 'worker',
+    startedAt: T0,
+    originatingTurnKey: 'chat:thr:1',
+    ...overrides,
+  })
+}
+
+describe('createFleetMember', () => {
+  it('initialises sane defaults', () => {
+    const m = freshMember()
+    expect(m.agentId).toBe('a1')
+    expect(m.role).toBe('worker')
+    expect(m.startedAt).toBe(T0)
+    expect(m.toolCount).toBe(0)
+    expect(m.lastActivityAt).toBe(T0)
+    expect(m.lastTool).toBeNull()
+    expect(m.status).toBe('running')
+    expect(m.terminalAt).toBeNull()
+    expect(m.errorSeen).toBe(false)
+    expect(m.originatingTurnKey).toBe('chat:thr:1')
+  })
+})
+
+describe('applyToolUse', () => {
+  it('bumps toolCount and lastActivityAt; updates lastTool with sanitised arg', () => {
+    const m0 = freshMember()
+    const m1 = applyToolUse(m0, 'Read', { file_path: '/etc/secrets/foo.key' }, T0 + 100)
+    expect(m1.toolCount).toBe(1)
+    expect(m1.lastActivityAt).toBe(T0 + 100)
+    expect(m1.lastTool).toEqual({ name: 'Read', sanitisedArg: 'foo.key' })
+    const m2 = applyToolUse(m1, 'Bash', { command: 'ls' }, T0 + 200)
+    expect(m2.toolCount).toBe(2)
+    expect(m2.lastTool?.name).toBe('Bash')
+  })
+
+  it('does not mutate the input member', () => {
+    const m0 = freshMember()
+    applyToolUse(m0, 'Read', {}, T0 + 100)
+    expect(m0.toolCount).toBe(0)
+    expect(m0.lastTool).toBeNull()
+  })
+})
+
+describe('applyToolResult', () => {
+  it('flips errorSeen on isError=true', () => {
+    const m = applyToolResult(freshMember(), true)
+    expect(m.errorSeen).toBe(true)
+  })
+  it('keeps errorSeen=false when isError=false', () => {
+    const m = applyToolResult(freshMember(), false)
+    expect(m.errorSeen).toBe(false)
+  })
+  it('does not unset errorSeen once set', () => {
+    const m1 = applyToolResult(freshMember(), true)
+    const m2 = applyToolResult(m1, false)
+    expect(m2.errorSeen).toBe(true)
+  })
+})
+
+describe('applyTurnEnd', () => {
+  it('marks done if no errors seen', () => {
+    const m = applyTurnEnd(freshMember(), T0 + 500)
+    expect(m.status).toBe('done')
+    expect(m.terminalAt).toBe(T0 + 500)
+  })
+  it('marks failed if errorSeen', () => {
+    const m0 = applyToolResult(freshMember(), true)
+    const m1 = applyTurnEnd(m0, T0 + 500)
+    expect(m1.status).toBe('failed')
+    expect(m1.terminalAt).toBe(T0 + 500)
+  })
+})
+
+describe('markStuck', () => {
+  it('flips running → stuck after idleMs threshold', () => {
+    const m0 = freshMember()
+    const m1 = markStuck(m0, T0 + 60_001, 60_000)
+    expect(m1.status).toBe('stuck')
+  })
+  it('is no-op when not yet idle long enough', () => {
+    const m0 = freshMember()
+    const m1 = markStuck(m0, T0 + 59_000, 60_000)
+    expect(m1.status).toBe('running')
+  })
+  it('is idempotent on terminal states', () => {
+    const done = applyTurnEnd(freshMember(), T0 + 100)
+    const stillDone = markStuck(done, T0 + 999_999, 60_000)
+    expect(stillDone.status).toBe('done')
+  })
+  it('is idempotent on already-stuck', () => {
+    const m0 = freshMember()
+    const m1 = markStuck(m0, T0 + 60_001, 60_000)
+    const m2 = markStuck(m1, T0 + 120_000, 60_000)
+    expect(m2.status).toBe('stuck')
+    // No new mutation churn — same object reference is fine but not required
+  })
+})
+
+describe('cap', () => {
+  it('orders by lastActivityAt desc and reports hidden count', () => {
+    const members: FleetMember[] = [
+      { ...freshMember({ agentId: 'a' }), lastActivityAt: T0 + 100 },
+      { ...freshMember({ agentId: 'b' }), lastActivityAt: T0 + 500 },
+      { ...freshMember({ agentId: 'c' }), lastActivityAt: T0 + 300 },
+      { ...freshMember({ agentId: 'd' }), lastActivityAt: T0 + 900 },
+      { ...freshMember({ agentId: 'e' }), lastActivityAt: T0 + 700 },
+      { ...freshMember({ agentId: 'f' }), lastActivityAt: T0 + 50 },
+      { ...freshMember({ agentId: 'g' }), lastActivityAt: T0 + 800 },
+    ]
+    const { visible, hidden } = cap(members, 5)
+    expect(visible.map((m) => m.agentId)).toEqual(['d', 'g', 'e', 'b', 'c'])
+    expect(hidden).toBe(2)
+  })
+  it('hidden=0 when under cap', () => {
+    const members: FleetMember[] = [freshMember({ agentId: 'a' })]
+    const { visible, hidden } = cap(members, 5)
+    expect(visible.length).toBe(1)
+    expect(hidden).toBe(0)
+  })
+})
+
+describe('sanitiseToolArg', () => {
+  it('basenames absolute file paths', () => {
+    expect(sanitiseToolArg('Read', { file_path: '/etc/secrets/foo.key' })).toBe('foo.key')
+  })
+  it('basenames Edit/Write targets', () => {
+    expect(sanitiseToolArg('Edit', { file_path: '/home/u/code/x.ts' })).toBe('x.ts')
+    expect(sanitiseToolArg('Write', { file_path: '/tmp/out.json' })).toBe('out.json')
+  })
+  it('redacts bearer-token-like strings in Bash commands', () => {
+    const out = sanitiseToolArg('Bash', { command: 'curl -H "Authorization: Bearer sk-ant-1234567890abcdef" https://x' })
+    expect(out).not.toContain('sk-ant-1234567890abcdef')
+    expect(out.toLowerCase()).toContain('redacted')
+  })
+  it('returns empty string when no recognisable arg', () => {
+    expect(sanitiseToolArg('Unknown', {})).toBe('')
+  })
+  it('truncates very long args', () => {
+    const long = 'x'.repeat(500)
+    const out = sanitiseToolArg('Bash', { command: long })
+    expect(out.length).toBeLessThanOrEqual(120)
+  })
+})
+
+describe('roleFromDispatch', () => {
+  it('prefers description', () => {
+    expect(roleFromDispatch('Run tests', 'general-purpose', 'Please run')).toBe('Run tests')
+  })
+  it('falls back to subagentType', () => {
+    expect(roleFromDispatch(undefined, 'researcher', 'Find facts')).toBe('researcher')
+  })
+  it('falls back to first 20 chars of firstPromptText', () => {
+    expect(roleFromDispatch(undefined, undefined, 'Find me the truth about everything')).toBe('Find me the truth ab')
+  })
+  it('falls back to "agent" when nothing supplied', () => {
+    expect(roleFromDispatch(undefined, undefined, '')).toBe('agent')
+  })
+})

--- a/telegram-plugin/tests/progress-card-driver-fleet-shadow.test.ts
+++ b/telegram-plugin/tests/progress-card-driver-fleet-shadow.test.ts
@@ -1,0 +1,123 @@
+/**
+ * P0 of #662 — invariant test that the driver's `fleet` shadow Map
+ * stays in lockstep with the legacy `chatState.subAgents` map across a
+ * full sub-agent lifecycle.
+ *
+ * We drive the real driver via createProgressDriver (no Telegram bot
+ * required — the emit callback just records calls) and feed a complete
+ * lifecycle: started → 3× tool_use → tool_result(isError=true) →
+ * turn_end. After every event we assert:
+ *   - cardinality matches between fleet and subAgents
+ *   - on terminal turn_end: status='failed' (errorSeen accumulated)
+ *   - originatingTurnKey was snapshotted from currentTurnKey
+ *   - lastTool reflects the most recent tool_use's sanitised arg
+ */
+
+import { describe, it, expect } from 'vitest'
+import { createProgressDriver } from '../progress-card-driver.js'
+import type { SessionEvent } from '../session-tail.js'
+
+function harness() {
+  let now = 1000
+  const timers: Array<{ fireAt: number; fn: () => void; ref: number; repeat?: number }> = []
+  let nextRef = 0
+  const driver = createProgressDriver({
+    emit: () => {},
+    minIntervalMs: 500,
+    coalesceMs: 400,
+    initialDelayMs: 0,
+    promoteAfterMs: 999_999,
+    now: () => now,
+    setTimeout: (fn, ms) => {
+      const ref = nextRef++
+      timers.push({ fireAt: now + ms, fn, ref })
+      return { ref }
+    },
+    clearTimeout: (h) => {
+      const ref = (h as { ref: number }).ref
+      const idx = timers.findIndex((t) => t.ref === ref)
+      if (idx !== -1) timers.splice(idx, 1)
+    },
+    setInterval: (fn, ms) => {
+      const ref = nextRef++
+      timers.push({ fireAt: now + ms, fn, ref, repeat: ms })
+      return { ref }
+    },
+    clearInterval: (h) => {
+      const ref = (h as { ref: number }).ref
+      const idx = timers.findIndex((t) => t.ref === ref)
+      if (idx !== -1) timers.splice(idx, 1)
+    },
+  })
+  return { driver, advance: (ms: number) => { now += ms } }
+}
+
+const enqueue = (chatId: string): SessionEvent => ({
+  kind: 'enqueue',
+  chatId,
+  messageId: '1',
+  threadId: null,
+  rawContent: `<channel chat_id="${chatId}">go</channel>`,
+})
+
+describe('driver fleet-state shadow', () => {
+  it('shadow Map stays in lockstep with chatState.subAgents through a failed sub-agent lifecycle', () => {
+    const { driver } = harness()
+    const CHAT = 'c1'
+    driver.ingest(enqueue(CHAT), null)
+
+    const events: SessionEvent[] = [
+      { kind: 'sub_agent_started', agentId: 'sa1', firstPromptText: 'do work', subagentType: 'worker' },
+      { kind: 'sub_agent_tool_use', agentId: 'sa1', toolUseId: 't1', toolName: 'Read', input: { file_path: '/etc/secrets/k.key' } },
+      { kind: 'sub_agent_tool_use', agentId: 'sa1', toolUseId: 't2', toolName: 'Bash', input: { command: 'ls' } },
+      { kind: 'sub_agent_tool_use', agentId: 'sa1', toolUseId: 't3', toolName: 'Edit', input: { file_path: '/tmp/x.ts' } },
+      { kind: 'sub_agent_tool_result', agentId: 'sa1', toolUseId: 't3', isError: true, errorText: 'boom' },
+    ]
+
+    for (const ev of events) {
+      driver.ingest(ev, CHAT)
+      const state = driver.peek(CHAT)
+      const fleet = driver.peekFleet(CHAT)
+      expect(state).toBeDefined()
+      expect(fleet).toBeDefined()
+      // Cardinality invariant — every sub-agent in the legacy map has a
+      // shadow entry, and vice versa.
+      expect(fleet!.size).toBe(state!.subAgents.size)
+      for (const id of state!.subAgents.keys()) {
+        expect(fleet!.has(id)).toBe(true)
+      }
+    }
+
+    // Pre-turn-end: fleet member exists, status still running, errorSeen true.
+    const midFleet = driver.peekFleet(CHAT)!
+    const midMember = midFleet.get('sa1')!
+    expect(midMember.status).toBe('running')
+    expect(midMember.errorSeen).toBe(true)
+    expect(midMember.toolCount).toBe(3)
+    expect(midMember.lastTool).toEqual({ name: 'Edit', sanitisedArg: 'x.ts' })
+    expect(midMember.role).toBe('worker') // from subagentType fallback
+    // Snapshotted from currentTurnKey at sub_agent_started.
+    expect(midMember.originatingTurnKey).toMatch(/^c1:/)
+
+    // Now end the sub-agent's turn — fleet member should flip to failed.
+    driver.ingest({ kind: 'sub_agent_turn_end', agentId: 'sa1' }, CHAT)
+    const finalFleet = driver.peekFleet(CHAT)!
+    const finalMember = finalFleet.get('sa1')!
+    expect(finalMember.status).toBe('failed')
+    expect(finalMember.terminalAt).not.toBeNull()
+  })
+
+  it('uses description as role when present', () => {
+    const { driver } = harness()
+    driver.ingest(enqueue('c2'), null)
+    // session-tail's sub_agent_started doesn't carry description directly,
+    // but the watcher path supplies subagentType — verify the fallback chain
+    // works when neither is set: first 20 chars of firstPromptText.
+    driver.ingest(
+      { kind: 'sub_agent_started', agentId: 'sa2', firstPromptText: 'investigate the auth bug end-to-end' },
+      'c2',
+    )
+    const m = driver.peekFleet('c2')!.get('sa2')!
+    expect(m.role).toBe('investigate the auth')
+  })
+})

--- a/telegram-plugin/tests/subagent-watcher.test.ts
+++ b/telegram-plugin/tests/subagent-watcher.test.ts
@@ -30,6 +30,7 @@ function makeEntry(overrides: Partial<WorkerEntry> = {}): WorkerEntry {
     stallNotified: false,
     completionNotified: false,
     lastSummaryLine: '',
+    lastTool: null,
     historical: false,
     ...overrides,
   }


### PR DESCRIPTION
Foundation for #662 two-zone status card v2. Pure data plumbing — no UI change.

## Scope (P0 of #662)
- New `telegram-plugin/fleet-state.ts` — `FleetMember` struct + pure transitions (`createFleetMember`, `applyToolUse`, `applyToolResult`, `applyTurnEnd`, `markStuck`, `cap`, `sanitiseToolArg`, `roleFromDispatch`)
- `subagent-watcher.ts` `WorkerEntry.lastTool` field — populated from `sub_agent_tool_use` events
- Driver shadow: `fleet: Map<string, FleetMember>` coexists with legacy `chatState.subAgents`. P1/P2/P3 build on fleet; legacy renderer keeps using subAgents until P4 cutover.
- Snapshots `currentTurnKey` at `sub_agent_started` ingest — the data field AC-1 (background sub-agent persistence) depends on.

## Tests
- 23 pure-function tests in `tests/fleet-state.test.ts`
- Watcher integration in `tests/fleet-state-watcher.test.ts`
- Shadow-invariant test in `tests/progress-card-driver-fleet-shadow.test.ts` — drives real lifecycle via existing harness, asserts fleet matches subAgents at every step + correct derived state (failed vs done)

## Refs
- #662 — implementation tracker
- #661 — design spec
- #64 — background sub-agent visibility (the snapshotted turnKey is the prereq)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>