### PR TITLE
fix(progress-card): firePin leak and phaseFor silent-end precedence

### DIFF
--- a/telegram-plugin/progress-card-pin-manager.ts
+++ b/telegram-plugin/progress-card-pin-manager.ts
@@ -346,6 +346,11 @@ export function createPinManager(deps: PinManagerDeps): PinManager {
         (err: Error) => {
           const ms = now() - pinStart
           log(`telegram gateway: progress-card pin failed turnKey=${turnKey} agentId=${agentId} msgId=${messageId} durationMs=${ms} error="${err?.message ?? err}"\n`)
+          // Pin API failed — drop from the in-memory map so a later
+          // unpin attempt doesn't fire `deps.unpin` for a message we
+          // never actually pinned. Do NOT add to `unpinned` — we never
+          // issued an unpin. Sidecar is also cleared for consistency.
+          pinned.delete(key)
           if (deps.removePin) deps.removePin(chatId, messageId)
         },
       )

--- a/telegram-plugin/tests/progress-card-pin-manager.test.ts
+++ b/telegram-plugin/tests/progress-card-pin-manager.test.ts
@@ -177,7 +177,7 @@ describe('createPinManager', () => {
   })
 
   describe('considerPin — failure rollback', () => {
-    it('pin rejection: removePin fires, pinned map entry stays (see invariant doc)', async () => {
+    it('firePin API rejection deletes from pinned map and clears sidecar', async () => {
       const h = mkHarness()
       h.deps.pin.mockRejectedValueOnce(errors.forbidden('pinChatMessage'))
 
@@ -190,16 +190,23 @@ describe('createPinManager', () => {
       h.fireTimers()
       await h.mgr.drainInFlight()
 
-      // Sidecar was rolled back when the pin rejected.
+      // Sidecar rolled back.
       expect(h.deps.removePin).toHaveBeenCalledWith('c', 500)
       expect(h.sidecar).toEqual([])
       // Log captured the failure.
       expect(h.deps.log).toHaveBeenCalledWith(
         expect.stringMatching(/progress-card pin failed/),
       )
-      // In-memory entry is retained so a later completeTurn still attempts
-      // an unpin — on the off-chance the pin partially landed on Telegram.
-      expect(h.mgr.pinnedMessageId('c:1')).toBe(500)
+      // In-memory entry is dropped — the pin never landed, so a later
+      // completeTurn must not issue an unpin against a non-existent pin.
+      expect(h.mgr.pinnedTurnKeys()).toEqual([])
+      expect(h.mgr.pinnedMessageId('c:1')).toBeUndefined()
+
+      // Trigger an unpin and assert deps.unpin was NOT called — the key
+      // was already removed from `pinned`, so completeTurn is a no-op.
+      h.mgr.completeTurn({ chatId: 'c', turnKey: 'c:1' })
+      await h.mgr.drainInFlight()
+      expect(h.deps.unpin).not.toHaveBeenCalled()
     })
 
     it('pin rejection with 429: log line still fires, no retry', async () => {

--- a/telegram-plugin/tests/two-zone-phasefor-precedence.test.ts
+++ b/telegram-plugin/tests/two-zone-phasefor-precedence.test.ts
@@ -1,0 +1,104 @@
+/**
+ * PR-A — phaseFor precedence: silent-end must be lifted above the
+ * background/done branches but gated on parentDone (or stage===done) so
+ * it can't fire while the parent is still in flight.
+ *
+ * Drives `phaseFor` across all combinations of
+ * (parentDone, silentEnd, fleetRunning, stalledClose) and asserts the
+ * resolved label.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { phaseFor } from '../two-zone-card.js'
+import type { FleetMember } from '../fleet-state.js'
+import type { ProgressCardState } from '../progress-card.js'
+
+function fm(id: string, status: FleetMember['status'], lastActivityAt: number = 100_000): FleetMember {
+  return {
+    agentId: id,
+    role: 'agent',
+    startedAt: 0,
+    toolCount: 0,
+    lastActivityAt,
+    lastTool: null,
+    status,
+    terminalAt: status === 'done' || status === 'failed' || status === 'killed' ? lastActivityAt : null,
+    errorSeen: status === 'failed',
+    originatingTurnKey: 'k',
+  }
+}
+
+function st(stage: ProgressCardState['stage']): ProgressCardState {
+  return {
+    turnStartedAt: 1,
+    items: [],
+    narratives: [],
+    stage,
+    thinking: false,
+    subAgents: new Map(),
+    pendingAgentSpawns: new Map(),
+    tasks: [],
+  }
+}
+
+const NOW = 100_000
+
+interface Row {
+  parentDone: boolean
+  silentEnd: boolean
+  fleetRunning: boolean
+  stalledClose: boolean
+  expected: string
+}
+
+// Truth table: 2^4 = 16 combinations of the four boolean inputs.
+// stalledClose dominates everything → Forced close.
+// silentEnd fires only when parentDone is true.
+// When silentEnd is gated off and parent is still running, fleetRunning
+// alone yields Working… (parent active); when parent is done +
+// fleetRunning we get Background; parentDone alone yields Done.
+const rows: Row[] = [
+  // stalledClose=true → always Forced close
+  { parentDone: false, silentEnd: false, fleetRunning: false, stalledClose: true, expected: 'Forced close' },
+  { parentDone: false, silentEnd: false, fleetRunning: true,  stalledClose: true, expected: 'Forced close' },
+  { parentDone: false, silentEnd: true,  fleetRunning: false, stalledClose: true, expected: 'Forced close' },
+  { parentDone: false, silentEnd: true,  fleetRunning: true,  stalledClose: true, expected: 'Forced close' },
+  { parentDone: true,  silentEnd: false, fleetRunning: false, stalledClose: true, expected: 'Forced close' },
+  { parentDone: true,  silentEnd: false, fleetRunning: true,  stalledClose: true, expected: 'Forced close' },
+  { parentDone: true,  silentEnd: true,  fleetRunning: false, stalledClose: true, expected: 'Forced close' },
+  { parentDone: true,  silentEnd: true,  fleetRunning: true,  stalledClose: true, expected: 'Forced close' },
+
+  // stalledClose=false
+  // parent in flight (parentDone=false)
+  { parentDone: false, silentEnd: false, fleetRunning: false, stalledClose: false, expected: 'Working…' },
+  { parentDone: false, silentEnd: false, fleetRunning: true,  stalledClose: false, expected: 'Working…' },
+  // silentEnd is GATED on parentDone — must not fire while parent in flight
+  { parentDone: false, silentEnd: true,  fleetRunning: false, stalledClose: false, expected: 'Working…' },
+  { parentDone: false, silentEnd: true,  fleetRunning: true,  stalledClose: false, expected: 'Working…' },
+
+  // parent done
+  { parentDone: true,  silentEnd: false, fleetRunning: false, stalledClose: false, expected: 'Done' },
+  { parentDone: true,  silentEnd: false, fleetRunning: true,  stalledClose: false, expected: 'Background' },
+  // silentEnd LIFTED above background/done — fires even when fleet still running
+  { parentDone: true,  silentEnd: true,  fleetRunning: false, stalledClose: false, expected: 'Ended without reply' },
+  { parentDone: true,  silentEnd: true,  fleetRunning: true,  stalledClose: false, expected: 'Ended without reply' },
+]
+
+describe('phaseFor precedence — (parentDone, silentEnd, fleetRunning, stalledClose)', () => {
+  it.each(rows)(
+    'parentDone=$parentDone silentEnd=$silentEnd fleetRunning=$fleetRunning stalledClose=$stalledClose → $expected',
+    ({ parentDone, silentEnd, fleetRunning, stalledClose, expected }) => {
+      const stage: ProgressCardState['stage'] = parentDone ? 'done' : 'run'
+      const fleet = new Map<string, FleetMember>()
+      if (fleetRunning) fleet.set('a', fm('a', 'running', NOW))
+      const opts: Record<string, unknown> = {}
+      if (silentEnd) opts.silentEnd = true
+      if (stalledClose) opts.stalledClose = true
+      // parentDone is conveyed via stage; also pass the explicit flag for parity
+      if (parentDone) opts.parentDone = true
+
+      const phase = phaseFor(st(stage), fleet, NOW, opts)
+      expect(phase.label).toBe(expected)
+    },
+  )
+})

--- a/telegram-plugin/two-zone-card.ts
+++ b/telegram-plugin/two-zone-card.ts
@@ -64,8 +64,14 @@ export function renderTwoZoneCard(input: TwoZoneCardInput): string {
 
 /**
  * Maps (parent state, fleet, opts) to a single header phase. Truth
- * table from `reference/status-card-design.md` §Header. Order matters:
- * forced-close > silent-end > done > background > stalled > working.
+ * table from `reference/status-card-design.md` §Header. Precedence:
+ * forced-close > silent-end (gated on parent terminal) > stalled >
+ * background > done > working.
+ *
+ * SilentEnd is lifted ABOVE the background/done checks so that a fleet
+ * still running can't suppress the silent-end label once the parent has
+ * terminated without a reply. It IS gated on `parentDone || stage===done`
+ * to prevent firing prematurely while the parent is still in flight.
  */
 export function phaseFor(
   state: ProgressCardState,
@@ -79,19 +85,14 @@ export function phaseFor(
 
   if (stalledClose) return { icon: '⚠', label: 'Forced close' }
 
-  const fleetTerminal = allFleetTerminal(fleet)
   const fleetRunning = anyFleetActive(fleet)
   const fleetAllStuck = fleet.size > 0 && [...fleet.values()].filter((m) => m.status === 'running' || m.status === 'stuck').every((m) => isStuck(m, now))
 
-  // Done: parent terminal + every fleet member terminal (or empty fleet)
-  if (state.stage === 'done' && fleetTerminal && !fleetRunning) {
-    if (silentEnd) return { icon: '🙊', label: 'Ended without reply' }
-    return { icon: '✅', label: 'Done' }
-  }
-
-  // Background: parentDone but at least one fleet member still running
-  if (parentDone && fleetRunning) {
-    return { icon: '⏸', label: 'Background' }
+  // SilentEnd: parent terminated without a reply. Lifted above the
+  // background/done branches so a still-running fleet can't mask it,
+  // but gated on parentDone so we don't fire while parent is in flight.
+  if (silentEnd && parentDone) {
+    return { icon: '🙊', label: 'Ended without reply' }
   }
 
   // Stalled: every running-or-stuck member is past the idle threshold.
@@ -102,15 +103,18 @@ export function phaseFor(
     return { icon: '⚠', label: 'Stalled' }
   }
 
+  // Background: parentDone but at least one fleet member still running
+  if (parentDone && fleetRunning) {
+    return { icon: '⏸', label: 'Background' }
+  }
+
+  // Done: parent terminal + no fleet still running
+  if (parentDone && !fleetRunning) {
+    return { icon: '✅', label: 'Done' }
+  }
+
   // Default: active work
   return { icon: '⚙️', label: 'Working…' }
-}
-
-function allFleetTerminal(fleet: ReadonlyMap<string, FleetMember>): boolean {
-  for (const m of fleet.values()) {
-    if (m.status === 'running' || m.status === 'background' || m.status === 'stuck') return false
-  }
-  return true
 }
 
 function anyFleetActive(fleet: ReadonlyMap<string, FleetMember>): boolean {


### PR DESCRIPTION
## Summary

Two related fixes to the two-zone progress card lifecycle.

### Fix 1 — firePin leak (`telegram-plugin/progress-card-pin-manager.ts`)

When the Telegram `pinChatMessage` API rejected, `firePin` left the entry in the in-memory `pinned` map. A subsequent `completeTurn` would then issue an `unpin` API call against a message that was never actually pinned — generating a second, avoidable API failure.

The `.catch` branch now drops `key` from `pinned` alongside the existing `deps.removePin` sidecar clear:

```ts
.catch((err: Error) => {
  log(...)
  // Pin API failed — drop from the in-memory map so a later
  // unpin attempt doesn't fire `deps.unpin` for a message we
  // never actually pinned.
  pinned.delete(key)
  if (deps.removePin) deps.removePin(chatId, messageId)
})
```

We deliberately do NOT touch `unpinned` — we never issued an unpin, so the unpin-dedup set must stay empty for that key.

### Fix 2 — phaseFor silent-end precedence (`telegram-plugin/two-zone-card.ts`)

`silentEnd` was buried inside the `state.stage === 'done' && fleetTerminal && !fleetRunning` branch. A still-running fleet member masked the silent-end label entirely — once the parent terminated without a reply, if any sub-agent was still spinning the card said "Background" instead of "Ended without reply."

`silentEnd` is now lifted above the background/done branches but gated on `parentDone || state.stage === 'done'` so it can't fire prematurely while the parent is still in flight.

New precedence (matches the updated doc-comment):

```
forced-close > silent-end (gated on parentDone) > stalled > background > done > working
```

## Tests

- Updated `progress-card-pin-manager.test.ts`: the "firePin API rejection" case now asserts `pinnedTurnKeys()` is empty after the rejection settles, and that a follow-up `completeTurn` is a no-op (`deps.unpin` was NOT called).
- New `two-zone-phasefor-precedence.test.ts`: table-drives all 16 combinations of `(parentDone, silentEnd, fleetRunning, stalledClose)` against `phaseFor`.

## Test plan

- [x] `npx vitest run telegram-plugin/tests/progress-card-pin-manager.test.ts telegram-plugin/tests/two-zone-card-header-phases.test.ts telegram-plugin/tests/two-zone-phasefor-precedence.test.ts` — 70 passing
- [x] `npm run lint` (tsc + plugin-references) — clean
- [x] Full `npm test` — 6 pre-existing failures in `tests/bridge-watchdog.test.ts` (verified to fail on `upstream/main` without these changes); all other 4609 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)