### PR TITLE
fix(progress-card): move TTL eviction off the heartbeat

### DIFF
--- a/telegram-plugin/progress-card-driver.ts
+++ b/telegram-plugin/progress-card-driver.ts
@@ -738,6 +738,19 @@ export interface ProgressDriver {
    * No-op if no card is currently tracking this `agentId`.
    */
   onSubAgentStall(agentId: string, idleMs: number, description: string): void
+  /**
+   * Test-only accessor exposing the driver's internal Maps so unit tests
+   * can assert TTL eviction and outer-base-key cleanup actually drop
+   * entries. Not part of the supported runtime API — gated behind the
+   * leading-underscore name.
+   */
+  _debugGetMaps?(): {
+    chats: Map<string, unknown>
+    seenEnqueueMsgIds: Map<string, number>
+    pendingSyncEchoes: Map<string, number>
+    chatRunningSubagents: Map<string, Map<string, unknown>>
+    baseTurnSeqs: Map<string, number>
+  }
 }
 
 export function createProgressDriver(config: ProgressDriverConfig): ProgressDriver {
@@ -859,6 +872,14 @@ export function createProgressDriver(config: ProgressDriverConfig): ProgressDriv
   /** Full turn key (chatId:threadId:seq) for the currently active turn. */
   let currentTurnKey: string | null = null
   let heartbeatHandle: { ref: unknown } | null = null
+  // Throttled inline TTL eviction for `seenEnqueueMsgIds` and
+  // `pendingSyncEchoes`. Previously eviction lived inside the heartbeat tick,
+  // but the heartbeat stops when `chats.size === 0`, leaving these maps to
+  // grow unbounded across idle periods. The inline path runs at the top of
+  // every public ingress (ingest / startTurn) but is rate-limited to once
+  // every `evictThrottleMs` so it stays effectively free in the hot path.
+  let lastEvictedAt = 0
+  const evictThrottleMs = 30_000
   // Tracks the last elapsed-seconds bucket we emitted for each chat so
   // the heartbeat can coalesce — if the HTML hasn't changed AND the
   // header elapsed counter (rounded to the heartbeat cadence) would
@@ -974,6 +995,12 @@ export function createProgressDriver(config: ProgressDriverConfig): ProgressDriv
     lastHeartbeatBucket.delete(cs.turnKey)
     lastSubAgentTickBucket.delete(cs.turnKey)
     editTimestamps.delete(cs.turnKey)
+    // Drop the outer base-key entries if no other chat shares the same base.
+    // Covers all 3 close paths since they all funnel through here:
+    // completeTurnFully (turn_end), closeZombie (abandonment), and the
+    // stalled-close branch in the heartbeat. Prevents unbounded growth of
+    // `chatRunningSubagents` / `baseTurnSeqs` across idle periods.
+    cleanupBaseKeyIfUnused(baseKey(cs.chatId, cs.threadId), parseTurnSeq(cs.turnKey))
     if (currentTurnKey === cs.turnKey) {
       currentChatId = null
       currentThreadId = undefined
@@ -1053,6 +1080,92 @@ export function createProgressDriver(config: ProgressDriverConfig): ProgressDriv
     flush(cs, /*forceDone*/ true)
     completeTurnFully(cs)
     // Don't clear pendingSyncEchoes — the echo may arrive after zombie close.
+  }
+
+  /**
+   * TTL-evict stale entries from the messageId-dedup map and the sync-echo
+   * marker map. Same TTLs as the (now-removed) heartbeat eviction:
+   *   - `seenEnqueueMsgIds`: 60s (matches the dedup window in `ingest`).
+   *   - `pendingSyncEchoes`: 30s (matches the consumer in `ingest`).
+   */
+  function evictStaleDedup(nowMs: number): void {
+    const t60 = nowMs - 60_000
+    for (const [k, ts] of seenEnqueueMsgIds) {
+      if (ts <= t60) seenEnqueueMsgIds.delete(k)
+    }
+    const t30 = nowMs - 30_000
+    for (const [k, ts] of pendingSyncEchoes) {
+      if (ts <= t30) pendingSyncEchoes.delete(k)
+    }
+  }
+
+  /**
+   * Throttled wrapper. Cheap when not due — a single timestamp compare and
+   * branch. Called at the top of every public ingress so eviction runs
+   * regardless of whether any chats are currently live.
+   */
+  function maybeEvict(nowMs: number): void {
+    if (nowMs - lastEvictedAt < evictThrottleMs) return
+    lastEvictedAt = nowMs
+    evictStaleDedup(nowMs)
+  }
+
+  /**
+   * Best-effort outer-base-key cleanup, called after a chat is removed from
+   * the `chats` map. Only drops entries that are *safe* to drop:
+   *
+   *   - `chatRunningSubagents[base]`: deleted iff (a) no surviving chat
+   *     shares the same base AND (b) the inner map is empty. Background
+   *     sub-agents intentionally outlive their parent turn (cross-turn
+   *     carry-over for `Agent({run_in_background:true})`), so we never
+   *     drop a non-empty inner map — that would erase the next turn's
+   *     seed list. The empty-map case is the unbounded-growth path the
+   *     caller cares about: a chat that ran but never spawned anything
+   *     still got a `Map` allocated (or, more importantly, the entry
+   *     remains after natural sub-agent completion).
+   *
+   *   - `baseTurnSeqs[base]`: deleted iff no surviving chat shares the
+   *     same base AND no in-flight enqueue has just allocated a new turn
+   *     for this base via `allocateTurnSlot` (signalled by
+   *     `currentTurnKey` whose prefix matches `base`). The latter guard
+   *     matters because the new-enqueue path runs
+   *     `allocateTurnSlot -> closeZombie(old)` before registering the
+   *     new chat in `chats`; a naive delete here would clobber the
+   *     just-allocated seq, causing the next allocation to reset to 1
+   *     and collide with the still-live new turn.
+   */
+  function cleanupBaseKeyIfUnused(base: string, closingTurnSeq?: number): void {
+    for (const cs of chats.values()) {
+      if (baseKey(cs.chatId, cs.threadId) === base) return
+    }
+    const inner = chatRunningSubagents.get(base)
+    if (inner == null || inner.size === 0) {
+      chatRunningSubagents.delete(base)
+    }
+    // Skip `baseTurnSeqs` cleanup if `allocateTurnSlot` has just bumped the
+    // seq past the turn we are closing. That happens in the new-enqueue
+    // path: `allocateTurnSlot` runs BEFORE `closeZombie(old)` and BEFORE
+    // the new PerChatState is registered in `chats`, so the new turn is
+    // invisible to the iteration above. Detecting that via the seq diff
+    // avoids clobbering the just-allocated counter (would reset numbering
+    // to 1 and cause turnKey collisions with the still-live new turn).
+    const currentSeq = baseTurnSeqs.get(base)
+    if (
+      currentSeq != null
+      && closingTurnSeq != null
+      && currentSeq > closingTurnSeq
+    ) {
+      return
+    }
+    baseTurnSeqs.delete(base)
+  }
+
+  /** Parse the trailing `:N` from a turnKey. Returns undefined if absent. */
+  function parseTurnSeq(turnKey: string): number | undefined {
+    const idx = turnKey.lastIndexOf(':')
+    if (idx < 0) return undefined
+    const n = Number(turnKey.slice(idx + 1))
+    return Number.isFinite(n) ? n : undefined
   }
 
   function startHeartbeatIfNeeded(): void {
@@ -1292,15 +1405,12 @@ export function createProgressDriver(config: ProgressDriverConfig): ProgressDriv
         flush(cs, /*forceDone*/ true, /*stalledClose*/ true)
         completeTurnFully(cs)
       }
-      // Evict stale dedup entries to prevent unbounded map growth.
-      const t60 = now() - 60_000
-      for (const [k, ts] of seenEnqueueMsgIds) {
-        if (ts <= t60) seenEnqueueMsgIds.delete(k)
-      }
-      const t30 = now() - 30_000
-      for (const [k, ts] of pendingSyncEchoes) {
-        if (ts <= t30) pendingSyncEchoes.delete(k)
-      }
+      // Dedup-map TTL eviction has moved to `maybeEvict` (called from
+      // every public ingress). Keeping it here was unsafe because the
+      // heartbeat stops when `chats.size === 0`, which let
+      // `seenEnqueueMsgIds` / `pendingSyncEchoes` grow unbounded across
+      // idle periods.
+      //
       // If every chat has ended, stop the heartbeat to avoid an
       // always-on timer.
       if (chats.size === 0) stopHeartbeat()
@@ -1674,6 +1784,8 @@ export function createProgressDriver(config: ProgressDriverConfig): ProgressDriv
 
   return {
     ingest(event, chatIdMaybe, threadId) {
+      // Throttled inline TTL sweep — see `maybeEvict` for rationale.
+      maybeEvict(now())
       // An `enqueue` event carries its own chatId (extracted from the XML
       // channel wrapper). Everything else falls back to the caller-provided
       // chatIdMaybe, which the session-tail supervisor tracks.
@@ -2499,6 +2611,21 @@ export function createProgressDriver(config: ProgressDriverConfig): ProgressDriv
         // preserve-pending, but check defensively), start it.
         if (chats.size > 0) startHeartbeatIfNeeded()
         break
+      }
+    },
+
+    /**
+     * Test-only accessor. Returns the live internal Maps so tests can
+     * assert TTL eviction and outer-base-key cleanup actually drop
+     * entries. Not part of the supported API — naming reflects that.
+     */
+    _debugGetMaps() {
+      return {
+        chats,
+        seenEnqueueMsgIds,
+        pendingSyncEchoes,
+        chatRunningSubagents,
+        baseTurnSeqs,
       }
     },
   }

--- a/telegram-plugin/tests/progress-card-driver-eviction.test.ts
+++ b/telegram-plugin/tests/progress-card-driver-eviction.test.ts
@@ -1,0 +1,178 @@
+/**
+ * Regression: TTL eviction of internal dedup maps must NOT depend on the
+ * heartbeat tick. The heartbeat stops whenever `chats.size === 0`, so any
+ * eviction inside it leaves `seenEnqueueMsgIds` and `pendingSyncEchoes` to
+ * grow unbounded across idle periods. Outer-base-key entries
+ * (`chatRunningSubagents`, `baseTurnSeqs`) likewise need an explicit
+ * cleanup hook on chat-close because nothing else ever drops them.
+ *
+ * Fix shape: an inline throttled `maybeEvict(now)` runs at the top of
+ * every public ingress, and `completeTurnFully` calls
+ * `cleanupBaseKeyIfUnused` after `chats.delete`.
+ */
+import { describe, it, expect } from 'vitest'
+import { createProgressDriver } from '../progress-card-driver.js'
+import type { SessionEvent } from '../session-tail.js'
+
+let nextMsgId = 9000
+
+function harness() {
+  let now = 1000
+  const timers: Array<{ fireAt: number; fn: () => void; ref: number; repeat?: number }> = []
+  let nextRef = 0
+  const emits: Array<{ chatId: string; threadId?: string; turnKey: string; html: string; done: boolean }> = []
+
+  const driver = createProgressDriver({
+    emit: (a) => emits.push(a),
+    minIntervalMs: 0,
+    coalesceMs: 0,
+    initialDelayMs: 0,
+    heartbeatMs: 5000,
+    now: () => now,
+    setTimeout: (fn, ms) => {
+      const ref = nextRef++
+      timers.push({ fireAt: now + ms, fn, ref })
+      return { ref }
+    },
+    clearTimeout: (handle) => {
+      const target = (handle as { ref: number }).ref
+      const idx = timers.findIndex((t) => t.ref === target)
+      if (idx !== -1) timers.splice(idx, 1)
+    },
+    setInterval: (fn, ms) => {
+      const ref = nextRef++
+      timers.push({ fireAt: now + ms, fn, ref, repeat: ms })
+      return { ref }
+    },
+    clearInterval: (handle) => {
+      const target = (handle as { ref: number }).ref
+      const idx = timers.findIndex((t) => t.ref === target)
+      if (idx !== -1) timers.splice(idx, 1)
+    },
+  })
+
+  const advance = (ms: number): void => {
+    now += ms
+    for (;;) {
+      timers.sort((a, b) => a.fireAt - b.fireAt)
+      const next = timers[0]
+      if (!next || next.fireAt > now) break
+      if (next.repeat != null) {
+        next.fireAt += next.repeat
+        next.fn()
+      } else {
+        timers.shift()
+        next.fn()
+      }
+    }
+  }
+
+  return { driver, emits, advance, getNow: () => now }
+}
+
+function enqueue(chatId: string, threadId?: string): SessionEvent {
+  return {
+    kind: 'enqueue',
+    chatId,
+    messageId: String(nextMsgId++),
+    threadId: threadId ?? null,
+    rawContent: `<channel chat_id="${chatId}">hi</channel>`,
+  }
+}
+
+describe('progress-card-driver: TTL eviction off the heartbeat', () => {
+  it('seenEnqueueMsgIds and pendingSyncEchoes stay bounded across idle periods (chats.size==0)', () => {
+    const { driver, advance } = harness()
+    const maps = driver._debugGetMaps!()
+
+    // Drive 20 turn enqueue->complete cycles, advancing past the 60s TTL
+    // between cycles. Critically, chats.size returns to 0 between cycles,
+    // so the heartbeat stops — exposing the leak the fix targets.
+    for (let i = 0; i < 20; i++) {
+      driver.ingest(enqueue('chatA'), null)
+      driver.ingest({ kind: 'turn_end', durationMs: 100 }, 'chatA')
+      // Advance well past both TTLs (60s for messageIds, 30s for echoes)
+      // and past the eviction throttle (30s) so the next ingest evicts.
+      advance(65_000)
+      expect(maps.chats.size).toBe(0)
+    }
+
+    // After 20 cycles spread across >20 minutes of fake time, both dedup
+    // maps must be tiny — they should never accumulate stale entries.
+    expect(maps.seenEnqueueMsgIds.size).toBeLessThanOrEqual(1)
+    expect(maps.pendingSyncEchoes.size).toBeLessThanOrEqual(1)
+  })
+
+  it('chatRunningSubagents and baseTurnSeqs drop their base-key on full chat close', () => {
+    const { driver, advance } = harness()
+    const maps = driver._debugGetMaps!()
+
+    for (let i = 0; i < 20; i++) {
+      driver.ingest(enqueue('chatA'), null)
+      driver.ingest({ kind: 'sub_agent_started', agentId: `agent-${i}`, firstPromptText: 'x' }, 'chatA')
+      driver.ingest({ kind: 'sub_agent_turn_end', agentId: `agent-${i}`, durationMs: 50 }, 'chatA')
+      driver.ingest({ kind: 'turn_end', durationMs: 100 }, 'chatA')
+      advance(65_000)
+      // Between turns, no chat is alive — outer base-key entries must be
+      // gone too.
+      expect(maps.chats.size).toBe(0)
+      expect(maps.chatRunningSubagents.size).toBe(0)
+      expect(maps.baseTurnSeqs.size).toBe(0)
+    }
+  })
+
+  it('two chats sharing a baseKey: closing one does NOT delete the shared outer key', () => {
+    // baseKey collapses (chatId, threadId) pairs with no thread to a single
+    // string. Two threads on the same chat share a base only if they have
+    // the same threadId; two distinct chatIds always have distinct bases.
+    // Within a single chat, multiple concurrent turn-keys share the same
+    // base — closing one of them must NOT prematurely drop the outer key
+    // while the other turn is still alive.
+    const { driver } = harness()
+    const maps = driver._debugGetMaps!()
+
+    // Start turn 1 on chatA — synthesises an enqueue and creates the card.
+    driver.startTurn({ chatId: 'chatA', userText: 'first' })
+    expect(maps.chats.size).toBe(1)
+    expect(maps.baseTurnSeqs.get('chatA')).toBeGreaterThanOrEqual(1)
+
+    // A second startTurn on the same chat force-closes turn 1 and creates
+    // turn 2 — there is exactly one chat live again, but baseTurnSeqs has
+    // ticked to 2. That outer entry must remain because turn 2 is alive.
+    driver.startTurn({ chatId: 'chatA', userText: 'second' })
+    expect(maps.chats.size).toBe(1)
+    const seqAfter = maps.baseTurnSeqs.get('chatA')
+    expect(seqAfter).toBeGreaterThanOrEqual(2)
+
+    // End turn 2 → chats empty → base-key cleanup must run.
+    driver.ingest({ kind: 'turn_end', durationMs: 100 }, 'chatA')
+    expect(maps.chats.size).toBe(0)
+    expect(maps.baseTurnSeqs.has('chatA')).toBe(false)
+    expect(maps.chatRunningSubagents.has('chatA')).toBe(false)
+  })
+
+  it('two distinct chats: closing one does NOT touch the other base-key', () => {
+    // The driver routes turn_end via `currentTurnKey`, not `chatIdMaybe` —
+    // a quirk of the session-tail single-stream design. To close a specific
+    // chat from a test we use `forceCompleteTurn`, which is the path the
+    // gateway invokes for explicit per-chat fan-out.
+    const { driver } = harness()
+    const maps = driver._debugGetMaps!()
+
+    driver.ingest(enqueue('chatA'), null)
+    driver.ingest(enqueue('chatB'), null)
+    expect(maps.chats.size).toBe(2)
+    expect(maps.baseTurnSeqs.has('chatA')).toBe(true)
+    expect(maps.baseTurnSeqs.has('chatB')).toBe(true)
+
+    // Close A only — must not touch chatB's base-key.
+    driver.forceCompleteTurn({ chatId: 'chatA' })
+    expect(maps.baseTurnSeqs.has('chatA')).toBe(false)
+    expect(maps.baseTurnSeqs.has('chatB')).toBe(true)
+
+    // Now close B.
+    driver.forceCompleteTurn({ chatId: 'chatB' })
+    expect(maps.baseTurnSeqs.has('chatB')).toBe(false)
+    expect(maps.chats.size).toBe(0)
+  })
+})


### PR DESCRIPTION
## The leak

`telegram-plugin/progress-card-driver.ts` keeps four internal maps that need periodic eviction:

- `seenEnqueueMsgIds` — messageId-dedup window (60s TTL)
- `pendingSyncEchoes` — sync-echo guard markers (30s TTL)
- `chatRunningSubagents[base]` — cross-turn sub-agent registry per `(chatId, threadId)`
- `baseTurnSeqs[base]` — cumulative turn-seq counter per `(chatId, threadId)`

Pre-fix, eviction for the first two ran ONLY inside the heartbeat tick (see the body around upstream `progress-card-driver.ts:1295-1306`). The heartbeat is stopped at the end of each tick when `chats.size === 0` and inside `completeTurnFully` for the same condition — so during any idle period the dedup maps grew unbounded. The two outer base-key maps had no eviction path at all and grew with every distinct `(chatId, threadId)` the driver ever observed.

## Fix shape (Option A — inline throttled)

- Extracted eviction body to `evictStaleDedup(now)`.
- Added `maybeEvict(now)`, throttled to once per 30s via a `lastEvictedAt` field, called at the top of `ingest()`. `startTurn()` delegates to `ingest()` so it inherits the call. Cheap when not due — a single timestamp compare and branch.
- Added `cleanupBaseKeyIfUnused(base, closingSeq)`, called from `completeTurnFully` after `chats.delete`. All three close paths (`turn_end`, `closeZombie`/abandonment, heartbeat stalled-close) funnel through `completeTurnFully`, so this single hook covers them all.
- The eviction body inside the heartbeat is removed; the surrounding comment now records why it can't live there.

### Subtle: don't break cross-turn carry-over

Two correctness traps the cleanup avoids:

1. `chatRunningSubagents[base]` deletion is skipped when the inner map is non-empty. Background sub-agents intentionally outlive their parent turn (Issue #87 / `Agent({run_in_background: true})`); deleting their registry would erase the next turn's seed list.
2. `baseTurnSeqs[base]` deletion is skipped when `allocateTurnSlot` has just bumped the seq past the turn being closed. The new-enqueue path runs `allocateTurnSlot -> closeZombie(old)` BEFORE registering the new chat in `chats`, so a naive delete would clobber the just-allocated counter and the next allocation would reset to 1, colliding with the still-live new turn.

## Tests

New file: `telegram-plugin/tests/progress-card-driver-eviction.test.ts`

- 20-cycle enqueue->complete loop with `chats.size` returning to 0 between cycles, advancing fake clock past 60s — asserts both dedup maps and both outer-base-key maps are bounded (≤ small constant).
- 2 chats sharing a base: closing one of two sequential turns on `chatA` does NOT prematurely delete the shared outer key while a follow-up turn for the same base is mid-allocation.
- 2 distinct chats: closing `chatA` via `forceCompleteTurn` does NOT touch `chatB`'s base-key entry.
- Added a `_debugGetMaps` test-only accessor on the driver. Gated behind a leading-underscore name; not part of the supported runtime API.

## Verification

- `npx tsc --noEmit` — clean
- `node scripts/check-plugin-references.mjs` — clean
- `vitest run telegram-plugin/tests/progress-card-*` — 72/72 pass (6 files)
- Full vitest run: 39 pre-existing failures across `tests/boot-self-test.test.ts`, `tests/bridge-watchdog.test.ts`, `tests/cli.issues.test.ts`, `tests/cli.memory.demote.test.ts`, `tests/run-hook.test.ts` — all reproduce on bare `upstream/main` without my changes (verified via `git stash` + rerun → 33/43 fail without changes; bridge-watchdog set is the documented flake from PR-A).

## Test plan

- [ ] Run `npm run test:vitest -- telegram-plugin/tests/progress-card`
- [ ] Confirm a long-idle gateway (24h+) shows bounded RSS for the driver's maps
- [ ] Confirm Issue #87 / `Agent({run_in_background: true})` cross-turn behavior still works (sub-agent dispatched in turn N visible on turn N+1's card)