### PR TITLE
fix(scaffold): export SWITCHROOM_AGENT_NAME in cron-N.sh template

### DIFF
--- a/src/agents/cron-auth.test.ts
+++ b/src/agents/cron-auth.test.ts
@@ -69,6 +69,17 @@ describe("buildCronScript: OAuth-only auth", () => {
     expect(script).toContain("--model 'claude-haiku-4-5-20251001'");
   });
 
+  it("exports SWITCHROOM_AGENT_NAME derived from agentDir basename", () => {
+    // Required so in-prompt `switchroom issues record` calls without an
+    // explicit --agent flag attribute correctly, and so the vault broker
+    // client can resolve a default agent. Mirrors the gateway unit's
+    // Environment=SWITCHROOM_AGENT_NAME= setting in src/agents/systemd.ts.
+    const script = buildCronScript(
+      SAMPLE_AGENT_DIR, SAMPLE_PROMPT, SAMPLE_MODEL, SAMPLE_CHAT, undefined,
+    );
+    expect(script).toContain("export SWITCHROOM_AGENT_NAME='sample'");
+  });
+
   it("auth setup happens after cd into agent dir, before claude invocation", () => {
     const script = buildCronScript(
       SAMPLE_AGENT_DIR, SAMPLE_PROMPT, SAMPLE_MODEL, SAMPLE_CHAT, undefined,

--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -13,7 +13,7 @@ import {
   readlinkSync,
 } from "node:fs";
 import { execSync, execFileSync } from "node:child_process";
-import { join, resolve } from "node:path";
+import { basename, join, resolve } from "node:path";
 import chalk from "chalk";
 import type { AgentConfig, QuotaConfig, SwitchroomConfig, TelegramConfig } from "../config/schema.js";
 
@@ -410,6 +410,11 @@ cd ${shellSingleQuote(agentDir)}
 # subscription quota to API billing.
 unset ANTHROPIC_API_KEY
 export CLAUDE_CONFIG_DIR=${shellSingleQuote(agentDir + "/.claude")}
+# SWITCHROOM_AGENT_NAME mirrors the gateway unit's Environment= setting
+# (see src/agents/systemd.ts). Required so in-prompt \`switchroom issues
+# record\` calls without an explicit --agent flag attribute correctly,
+# and so the vault broker client can resolve a default agent.
+export SWITCHROOM_AGENT_NAME=${shellSingleQuote(basename(agentDir))}
 
 # Inject OAuth token from the agent's own .oauth-token file.
 unset CLAUDE_CODE_OAUTH_TOKEN


### PR DESCRIPTION
## Summary

`buildCronScript` in `src/agents/scaffold.ts` emitted exports for `SWITCHROOM_VAULT_BROKER_SOCK`, `CLAUDE_CONFIG_DIR`, `CLAUDE_CODE_OAUTH_TOKEN`, and `TELEGRAM_STATE_DIR` — but not `SWITCHROOM_AGENT_NAME`. Affected every agent's `cron-*.sh` fleet-wide.

The var is required so:
- in-prompt `switchroom issues record` calls without an explicit `--agent` flag attribute correctly (`src/cli/issues.ts:38-41`)
- the vault broker client can resolve a default agent (`src/vault/broker/client.ts:160-164`)

This mirrors the gateway unit's `Environment=SWITCHROOM_AGENT_NAME=...` setting in `src/agents/systemd.ts:305`.

The delivery path itself was not broken (gateway routing handles MCP `reply` independently), so existing crons largely worked — the impact was on fallback agent resolution for in-prompt CLI calls.

Closes #675

## Changes

- `src/agents/scaffold.ts`: import `basename` from `node:path`; add `export SWITCHROOM_AGENT_NAME=${shellSingleQuote(basename(agentDir))}` to the template body.
- `src/agents/cron-auth.test.ts`: add unit test asserting the export is present and uses the basename of `agentDir`.

## Operator action after merge

Run `switchroom apply` to regenerate `cron-*.sh` scripts fleet-wide.

## Test plan

- [x] `npx vitest run src/agents/cron-auth.test.ts src/agents/cron-secrets.test.ts` — 15 passed
- [x] `npx tsc --noEmit` — clean
- [ ] Reviewer: confirm no other call sites need updating

🤖 Generated with [Claude Code](https://claude.com/claude-code)