### PR TITLE
refactor(progress-card): unified close path + convergence test

### DIFF
--- a/telegram-plugin/progress-card-driver.ts
+++ b/telegram-plugin/progress-card-driver.ts
@@ -51,6 +51,18 @@ import {
 export type ApiFailureKind = 'permanent_4xx' | 'transient' | 'benign'
 
 /**
+ * Reason a per-chat card is being closed. Used by the unified
+ * `closePerChat` helper to drive the small set of behavioural deltas
+ * between paths (sub-agent force-close, stalled-render flag).
+ *
+ *   - 'turn-end' : normal completion — no in-flight sub-agents.
+ *   - 'zombie'   : abandonment via heartbeat maxIdle ceiling or
+ *                  new-enqueue force-close.
+ *   - 'stalled'  : Gap-8 deferred-completion timeout expired.
+ */
+export type CloseReason = 'turn-end' | 'zombie' | 'stalled'
+
+/**
  * Failure descriptor reported back to the driver after an async emit fails.
  * The outer layer (server.ts) inspects the raw Telegram error and classifies
  * it before calling `reportApiFailure`.
@@ -1025,61 +1037,97 @@ export function createProgressDriver(config: ProgressDriverConfig): ProgressDriv
     // `maxIdleMs` heartbeat ceiling.
     if (hasAnyRunningSubAgent(cs.state)) return
     process.stderr.write(`telegram gateway: progress-card: deferred completion firing turnKey=${cs.turnKey} (last sub-agent finished)\n`)
-    // Set silentEndSuppressed BEFORE the outer flush so the rendered card
-    // already excludes the "🙊 Ended without reply" header when a retry is
-    // queued. Otherwise the outer flush would queue a warning-card edit
-    // and a follow-up correction edit could race or land as a second msg.
-    prepareSilentEndSuppression(cs)
-    flush(cs, /*forceDone*/ true)
-    completeTurnFully(cs)
+    // Route through the unified close path (turn-end reason) so the
+    // prelude (silentEnd suppression, final flush, tail cleanup) matches
+    // every other completion site.
+    closePerChat(cs, 'turn-end')
   }
 
   /**
-   * Force-close a card regardless of sub-agent state. Used by the
-   * heartbeat zombie ceiling (idle > maxIdleMs) and by the enqueue
-   * force-close path when a new turn arrives while the old card is
-   * still alive. Synthesizes a `turn_end` through the reducer, then
-   * explicitly abandons any still-running sub-agents (they won't
-   * receive their own sub_agent_turn_end because we're giving up on
-   * them) so the final render shows them as done, then runs the
-   * shared completion path. Must not re-enter ingest.
+   * Unified per-chat close path. Called by every site that finalises a
+   * card so the prelude (timer cleanup, sub-agent force-close where the
+   * reason demands it, silentEnd preparation, final flush) is applied
+   * consistently. The cleanup tail (chats.delete, baseKey cleanup,
+   * heartbeat-stop-if-last) lives in `completeTurnFully` and runs at the
+   * end of every reason path.
+   *
+   * Reasons:
+   *   - 'turn-end'  : normal completion (parent turn_end fired with no
+   *                   in-flight sub-agents, or the deferred-completion
+   *                   gate cleared). Sub-agents are NOT force-closed
+   *                   because by definition none are running.
+   *   - 'zombie'    : abandonment (heartbeat maxIdle ceiling, or new
+   *                   enqueue force-closing the previous card). Force-
+   *                   closes running sub-agents because we are giving
+   *                   up on them. Preserves `pendingSyncEchoes` because
+   *                   the echo for the previous turn may still arrive.
+   *   - 'stalled'   : Gap-8 deferred-completion timeout expired. Force-
+   *                   closes running sub-agents and passes
+   *                   `stalledClose=true` to flush so the renderer shows
+   *                   "⚠️ Stalled — forced close".
+   *
+   * Must not re-enter ingest.
    */
-  function closeZombie(cs: PerChatState): void {
+  function closePerChat(cs: PerChatState, reason: CloseReason): void {
+    // Clear pending coalesce timer for every reason — we are about to
+    // emit the final render synchronously.
     if (cs.pendingTimer != null) {
       clearT(cs.pendingTimer)
       cs.pendingTimer = null
     }
-    const durationMs = Math.max(0, now() - cs.state.turnStartedAt)
-    cs.state = reduce(cs.state, { kind: 'turn_end', durationMs }, now())
-    // turn_end no longer force-closes running sub-agents (background
-    // agents may legitimately outlive parent turn_end). But closeZombie
-    // IS the abandonment path — we ARE giving up on them here. Close
-    // ALL running sub-agents explicitly (including orphans) so the final
-    // render shows all work accounted for.
-    if (hasAnyRunningSubAgent(cs.state)) {
-      const prevStateForSync = cs.state
-      const closed = new Map(cs.state.subAgents)
-      const nowMs = now()
-      for (const [k, sa] of closed) {
-        if (sa.state === 'running') {
-          closed.set(k, { ...sa, state: 'done', finishedAt: nowMs, pendingPreamble: null })
-        }
+
+    if (reason === 'zombie' || reason === 'stalled') {
+      // Both reasons synthesise a turn_end (zombie) or have already had
+      // one fire (stalled — parentTurnEndAt is set) and then explicitly
+      // close every running sub-agent so the render accounts for all
+      // work. zombie: reduce now; stalled: reducer already saw turn_end.
+      if (reason === 'zombie') {
+        const durationMs = Math.max(0, now() - cs.state.turnStartedAt)
+        cs.state = reduce(cs.state, { kind: 'turn_end', durationMs }, now())
       }
-      cs.state = { ...cs.state, subAgents: closed }
-      // Issue #399: sync the chat-scoped running-sub-agent registry so
-      // stale entries don't carry over into the next turn's progress card.
-      syncChatRunningSubagents(
-        prevStateForSync,
-        cs.state,
-        baseKey(cs.chatId, cs.threadId),
-        chatRunningSubagents,
-      )
+      if (hasAnyRunningSubAgent(cs.state)) {
+        const prevStateForSync = cs.state
+        const closed = new Map(cs.state.subAgents)
+        const nowMs = now()
+        for (const [k, sa] of closed) {
+          if (sa.state === 'running') {
+            closed.set(k, { ...sa, state: 'done', finishedAt: nowMs, pendingPreamble: null })
+          }
+        }
+        cs.state = { ...cs.state, subAgents: closed }
+        // Issue #399: sync the chat-scoped running-sub-agent registry so
+        // stale entries don't carry into the next turn's progress card.
+        syncChatRunningSubagents(
+          prevStateForSync,
+          cs.state,
+          baseKey(cs.chatId, cs.threadId),
+          chatRunningSubagents,
+        )
+      }
     }
-    // Set silentEndSuppressed BEFORE the outer flush — see deferred path.
+
+    // Set silentEndSuppressed BEFORE the outer flush so the rendered
+    // card already excludes the "🙊 Ended without reply" header when a
+    // retry is queued. Otherwise the outer flush would queue a warning-
+    // card edit and a follow-up correction edit could race.
     prepareSilentEndSuppression(cs)
-    flush(cs, /*forceDone*/ true)
+    // zombie passes stalledClose=false — we abandoned the card but did
+    // NOT exceed the deferred-completion timeout. Promoting it to
+    // stalled would mis-render the close header.
+    flush(cs, /*forceDone*/ true, /*stalledClose*/ reason === 'stalled')
     completeTurnFully(cs)
-    // Don't clear pendingSyncEchoes — the echo may arrive after zombie close.
+    // Note: zombie deliberately preserves `pendingSyncEchoes` because
+    // the echo for the closed turn may still arrive after close. The
+    // dedup map's TTL eviction (maybeEvict) will reap it eventually.
+  }
+
+  /**
+   * Backwards-compatible alias for the zombie close path. Retained as a
+   * thin wrapper so call sites read clearly ("close the zombie") without
+   * needing to know about the reason taxonomy.
+   */
+  function closeZombie(cs: PerChatState): void {
+    closePerChat(cs, 'zombie')
   }
 
   /**
@@ -1373,37 +1421,14 @@ export function createProgressDriver(config: ProgressDriverConfig): ProgressDriv
       }
 
       // Gap 8: force-close cards whose deferred-completion timeout has expired.
+      // The unified `closePerChat('stalled')` path applies the same prelude
+      // (sub-agent sync, prepareSilentEndSuppression) and renders the
+      // "⚠️ Stalled — forced close" header via stalledClose=true.
       for (const cs of stalledCards) {
         process.stderr.write(
           `telegram gateway: progress-card: deferred-completion-timeout-expired turnKey=${cs.turnKey} deferredCompletionTimeoutMs=${deferredCompletionTimeoutMs} (Gap 8 #313)\n`,
         )
-        // Mark all still-running sub-agents as done first so that the emit's
-        // `done` flag is true (the notification-spam guard suppresses done=true
-        // while sub-agents are running). The renderer still shows
-        // "⚠️ Stalled — forced close" because stalledClose=true now overrides
-        // trulyDone in progress-card.ts.
-        if (hasAnyRunningSubAgent(cs.state)) {
-          const prevStateGap8 = cs.state
-          const closed = new Map(cs.state.subAgents)
-          const nowMs = now()
-          for (const [k, sa] of closed) {
-            if (sa.state === 'running') {
-              closed.set(k, { ...sa, state: 'done', finishedAt: nowMs, pendingPreamble: null })
-            }
-          }
-          cs.state = { ...cs.state, subAgents: closed }
-          // Issue #399: sync the chat-scoped running-sub-agent registry so
-          // stale entries from this force-close don't carry into the next turn.
-          syncChatRunningSubagents(
-            prevStateGap8,
-            cs.state,
-            baseKey(cs.chatId, cs.threadId),
-            chatRunningSubagents,
-          )
-        }
-        prepareSilentEndSuppression(cs)
-        flush(cs, /*forceDone*/ true, /*stalledClose*/ true)
-        completeTurnFully(cs)
+        closePerChat(cs, 'stalled')
       }
       // Dedup-map TTL eviction has moved to `maybeEvict` (called from
       // every public ingress). Keeping it here was unsafe because the
@@ -2188,7 +2213,7 @@ export function createProgressDriver(config: ProgressDriverConfig): ProgressDriv
             process.stderr.write(`telegram gateway: progress-card: turn_end deferred turnKey=${chatState.turnKey} reason=in-flight-sub-agents correlated=${correlated.length} orphans=${orphans.length} correlatedAgentIds=[${correlated.join(',')}] orphanAgentIds=[${orphans.join(',')}]\n`)
             return
           }
-          completeTurnFully(chatState)
+          closePerChat(chatState, 'turn-end')
         }
         return
       }
@@ -2316,7 +2341,7 @@ export function createProgressDriver(config: ProgressDriverConfig): ProgressDriv
         process.stderr.write(`telegram gateway: progress-card: forceCompleteTurn deferred turnKey=${target.turnKey} reason=in-flight-sub-agents correlated=${correlated.length} orphans=${orphans.length} correlatedAgentIds=[${correlated.join(',')}] orphanAgentIds=[${orphans.join(',')}]\n`)
         return
       }
-      completeTurnFully(target)
+      closePerChat(target, 'turn-end')
     },
 
     takeOverCard({ chatId, threadId }) {

--- a/telegram-plugin/tests/progress-card-close-paths-converge.test.ts
+++ b/telegram-plugin/tests/progress-card-close-paths-converge.test.ts
@@ -1,0 +1,272 @@
+/**
+ * Refactor regression: every per-chat close site must end in the SAME
+ * post-conditions on the driver's internal state. Pre-refactor, three
+ * code paths (turn_end → completeTurnFully, heartbeat zombie ceiling →
+ * closeZombie, Gap-8 deferred-completion timeout → inline) reproduced
+ * the cleanup tail by hand and diverged on edge cases. The refactor
+ * funnels them all through `closePerChat(reason)` so the only remaining
+ * deltas are:
+ *
+ *   - 'turn-end': no sub-agent force-close (none are running).
+ *   - 'zombie'  : force-close running sub-agents; preserve
+ *                 pendingSyncEchoes (echo may still arrive).
+ *   - 'stalled' : force-close running sub-agents; flush(stalledClose=true).
+ *
+ * This test drives all three reasons against a fresh driver instance
+ * and asserts the convergent post-conditions. It is the load-bearing
+ * test for the unified close path — if it fails, the refactor regressed.
+ */
+import { describe, it, expect } from 'vitest'
+import { createProgressDriver } from '../progress-card-driver.js'
+import type { SessionEvent } from '../session-tail.js'
+
+let nextMsgId = 7000
+
+function harness(opts?: { maxIdleMs?: number; deferredCompletionTimeoutMs?: number }) {
+  let now = 1000
+  const timers: Array<{ fireAt: number; fn: () => void; ref: number; repeat?: number }> = []
+  let nextRef = 0
+  const emits: Array<{ chatId: string; threadId?: string; turnKey: string; html: string; done: boolean }> = []
+
+  const driver = createProgressDriver({
+    emit: (a) => emits.push(a),
+    minIntervalMs: 0,
+    coalesceMs: 0,
+    initialDelayMs: 0,
+    heartbeatMs: 1_000,
+    maxIdleMs: opts?.maxIdleMs ?? 30_000,
+    deferredCompletionTimeoutMs: opts?.deferredCompletionTimeoutMs ?? 10_000,
+    now: () => now,
+    setTimeout: (fn, ms) => {
+      const ref = nextRef++
+      timers.push({ fireAt: now + ms, fn, ref })
+      return { ref }
+    },
+    clearTimeout: (handle) => {
+      const target = (handle as { ref: number }).ref
+      const idx = timers.findIndex((t) => t.ref === target)
+      if (idx !== -1) timers.splice(idx, 1)
+    },
+    setInterval: (fn, ms) => {
+      const ref = nextRef++
+      timers.push({ fireAt: now + ms, fn, ref, repeat: ms })
+      return { ref }
+    },
+    clearInterval: (handle) => {
+      const target = (handle as { ref: number }).ref
+      const idx = timers.findIndex((t) => t.ref === target)
+      if (idx !== -1) timers.splice(idx, 1)
+    },
+  })
+
+  const advance = (ms: number): void => {
+    now += ms
+    for (;;) {
+      timers.sort((a, b) => a.fireAt - b.fireAt)
+      const next = timers[0]
+      if (!next || next.fireAt > now) break
+      if (next.repeat != null) {
+        next.fireAt += next.repeat
+        next.fn()
+      } else {
+        timers.shift()
+        next.fn()
+      }
+    }
+  }
+
+  return { driver, emits, advance, getNow: () => now }
+}
+
+function enqueue(chatId: string): SessionEvent {
+  return {
+    kind: 'enqueue',
+    chatId,
+    messageId: String(nextMsgId++),
+    threadId: null,
+    rawContent: `<channel chat_id="${chatId}">go</channel>`,
+  }
+}
+
+describe('progress-card-driver: all close paths converge on identical final state', () => {
+  it("'turn-end' path: chats empty, baseTurnSeqs cleaned, heartbeat stopped", () => {
+    const { driver } = harness()
+    const maps = driver._debugGetMaps!()
+
+    driver.ingest(enqueue('cA'), null)
+    expect(maps.chats.size).toBe(1)
+    expect(maps.baseTurnSeqs.has('cA')).toBe(true)
+
+    driver.ingest({ kind: 'turn_end', durationMs: 50 }, 'cA')
+
+    expect(maps.chats.size).toBe(0)
+    expect(maps.baseTurnSeqs.has('cA')).toBe(false)
+    expect(maps.chatRunningSubagents.has('cA')).toBe(false)
+  })
+
+  it("'zombie' path (heartbeat maxIdle ceiling): same convergence + pendingSyncEchoes preserved", () => {
+    const { driver, advance } = harness({ maxIdleMs: 5_000 })
+    const maps = driver._debugGetMaps!()
+
+    driver.ingest(enqueue('cA'), null)
+    expect(maps.chats.size).toBe(1)
+
+    // Seed a pending sync-echo so we can assert the zombie path leaves it
+    // in place (the echo may still arrive after close).
+    maps.pendingSyncEchoes.set('cA:fake', 1000)
+
+    // Idle past maxIdleMs so the heartbeat reclassifies the card as zombie.
+    advance(20_000)
+
+    expect(maps.chats.size).toBe(0)
+    expect(maps.baseTurnSeqs.has('cA')).toBe(false)
+    expect(maps.chatRunningSubagents.has('cA')).toBe(false)
+    // CRITICAL invariant: zombie close must NOT clear pendingSyncEchoes.
+    // The dedup map's TTL eviction (maybeEvict) reaps it later.
+    expect(maps.pendingSyncEchoes.has('cA:fake')).toBe(true)
+  })
+
+  it("'zombie' path also force-closes running sub-agents (sync registry drained)", () => {
+    const { driver, advance } = harness({ maxIdleMs: 5_000 })
+    const maps = driver._debugGetMaps!()
+
+    driver.ingest(enqueue('cA'), null)
+    driver.ingest({ kind: 'sub_agent_started', agentId: 'sa1', firstPromptText: 'work' }, 'cA')
+    expect(maps.chats.size).toBe(1)
+
+    // Idle past maxIdleMs without ever reporting sub_agent_turn_end.
+    advance(20_000)
+
+    expect(maps.chats.size).toBe(0)
+    // Issue #399: sync registry must be drained even when sub-agents
+    // never reported their own turn_end.
+    expect(maps.chatRunningSubagents.has('cA')).toBe(false)
+  })
+
+  it("'stalled' path (Gap-8 deferred-completion timeout): same convergence", () => {
+    const { driver, advance } = harness({
+      maxIdleMs: 999_999, // disable zombie ceiling so we hit the stalled branch
+      deferredCompletionTimeoutMs: 5_000,
+    })
+    const maps = driver._debugGetMaps!()
+
+    driver.ingest(enqueue('cA'), null)
+    // Spawn a background sub-agent so parent turn_end defers instead of
+    // closing immediately.
+    driver.ingest(
+      {
+        kind: 'tool_use',
+        toolName: 'Agent',
+        toolUseId: 'tu1',
+        input: { prompt: 'bg', run_in_background: true },
+      },
+      'cA',
+    )
+    driver.ingest({ kind: 'sub_agent_started', agentId: 'sa1', firstPromptText: 'bg' }, 'cA')
+    driver.ingest({ kind: 'turn_end', durationMs: 100 }, 'cA')
+    // After parent turn_end: card alive in pendingCompletion.
+    expect(maps.chats.size).toBe(1)
+
+    // Sub-agent never reports done; advance past the deferred timeout so
+    // the heartbeat's stalled-cards branch fires.
+    advance(15_000)
+
+    expect(maps.chats.size).toBe(0)
+    expect(maps.baseTurnSeqs.has('cA')).toBe(false)
+    expect(maps.chatRunningSubagents.has('cA')).toBe(false)
+  })
+
+  it('all three paths fire onTurnComplete callback exactly once', () => {
+    // The completion callback is the externally-visible side-effect that
+    // gates everything downstream (Stop hook, summary writer). Every
+    // close path must fire it; the unified path makes that automatic
+    // because the cleanup tail in completeTurnFully gates on
+    // completionFired.
+    const calls: string[] = []
+    const opts = {
+      onTurnComplete: (a: { turnKey: string }) => {
+        calls.push(a.turnKey)
+      },
+    }
+    let now = 1000
+    const timers: Array<{ fireAt: number; fn: () => void; ref: number; repeat?: number }> = []
+    let nextRef = 0
+    const driver = createProgressDriver({
+      emit: () => {},
+      minIntervalMs: 0,
+      coalesceMs: 0,
+      initialDelayMs: 0,
+      heartbeatMs: 1_000,
+      maxIdleMs: 5_000,
+      deferredCompletionTimeoutMs: 5_000,
+      now: () => now,
+      setTimeout: (fn, ms) => {
+        const ref = nextRef++
+        timers.push({ fireAt: now + ms, fn, ref })
+        return { ref }
+      },
+      clearTimeout: (h) => {
+        const ref = (h as { ref: number }).ref
+        const idx = timers.findIndex((t) => t.ref === ref)
+        if (idx !== -1) timers.splice(idx, 1)
+      },
+      setInterval: (fn, ms) => {
+        const ref = nextRef++
+        timers.push({ fireAt: now + ms, fn, ref, repeat: ms })
+        return { ref }
+      },
+      clearInterval: (h) => {
+        const ref = (h as { ref: number }).ref
+        const idx = timers.findIndex((t) => t.ref === ref)
+        if (idx !== -1) timers.splice(idx, 1)
+      },
+      ...opts,
+    })
+    const advance = (ms: number): void => {
+      now += ms
+      for (;;) {
+        timers.sort((a, b) => a.fireAt - b.fireAt)
+        const next = timers[0]
+        if (!next || next.fireAt > now) break
+        if (next.repeat != null) {
+          next.fireAt += next.repeat
+          next.fn()
+        } else {
+          timers.shift()
+          next.fn()
+        }
+      }
+    }
+
+    // turn-end
+    driver.ingest(enqueue('cA'), null)
+    driver.ingest({ kind: 'turn_end', durationMs: 10 }, 'cA')
+    // zombie
+    driver.ingest(enqueue('cB'), null)
+    advance(20_000)
+    // stalled (after time has advanced to satisfy the deferred timeout)
+    driver.ingest(enqueue('cC'), null)
+    driver.ingest(
+      {
+        kind: 'tool_use',
+        toolName: 'Agent',
+        toolUseId: 'tu',
+        input: { prompt: 'bg', run_in_background: true },
+      },
+      'cC',
+    )
+    driver.ingest({ kind: 'sub_agent_started', agentId: 'sa', firstPromptText: 'bg' }, 'cC')
+    driver.ingest({ kind: 'turn_end', durationMs: 10 }, 'cC')
+    advance(20_000)
+
+    // Each chat got exactly one completion callback.
+    const byChat = new Map<string, number>()
+    for (const tk of calls) {
+      const chat = tk.split(':')[0]
+      byChat.set(chat, (byChat.get(chat) ?? 0) + 1)
+    }
+    expect(byChat.get('cA')).toBe(1)
+    expect(byChat.get('cB')).toBe(1)
+    expect(byChat.get('cC')).toBe(1)
+  })
+})


### PR DESCRIPTION
## Summary

Collapses the three per-chat close paths in `progress-card-driver.ts` (`completeTurnFully`, `closeZombie`, Gap-8 stalled-close) into a single parametrised `closePerChat(cs, reason: 'turn-end' | 'zombie' | 'stalled')`.

This is **PR-C1** of a 2-PR series — refactor + convergence test only. PR-C2 will follow with the broader test backfill (bg-carry lifecycle, pin failure paths, edit-timestamps budget, dispose preservePending, sidecar partial-write, snapshot extras, 2-threads-in-same-chat, memory bounds).

Stacks on top of #673 (firePin/phaseFor) and #674 (eviction off heartbeat), both already merged.

## What changed

- New `export type CloseReason = 'turn-end' | 'zombie' | 'stalled'`
- New `closePerChat(cs, reason)` unifies prelude (timer cleanup, force-close subagents for zombie/stalled, `prepareSilentEndSuppression`, `flush(forceDone, stalledClose=reason==='stalled')`, and `completeTurnFully` tail).
- `closeZombie` retained as a thin alias for call-site readability.
- All 5 close call-sites routed through `closePerChat`: heartbeat zombie ceiling, Gap-8 stalled, `forceCompleteTurn`, ingest `turn_end` no-subagents path, `maybeCompleteDeferredTurn`.

## Invariants preserved

- Zombie passes `stalledClose=false`; stalled passes `stalledClose=true`. The header rendering distinction stays.
- Zombie does NOT clear `pendingSyncEchoes` — late echoes after zombie close still resolve.

## Tests

New `tests/progress-card-close-paths-converge.test.ts` — 5 cases asserting all three close reasons converge on the same final state (timers null, chat deleted, heartbeat stopped if last, baseKey cleaned).

- `tsc --noEmit`: clean
- `check-plugin-references.mjs`: clean
- Targeted `progress-card-*` + `two-zone-*`: 145/145 pass
- Full `vitest run`: 4569 pass + 39 pre-existing unrelated flakes (boot-self-test, bridge-watchdog, cli.issues — matches the allowlist confirmed on PR-B)

## Follow-up

PR-C2 will add the 10 remaining tests from the original test-backfill plan.