### PR TITLE
test(progress-card): tighten reviewer-flagged nits from #678

### DIFF
--- a/telegram-plugin/tests/progress-card-edit-timestamps-budget.test.ts
+++ b/telegram-plugin/tests/progress-card-edit-timestamps-budget.test.ts
@@ -51,10 +51,11 @@ describe('PR-C2: editTimestamps stays bounded under sustained emit burst', () =>
     const sizes = [...maps.editTimestamps.values()].map((a) => a.length)
     expect(sizes.length).toBeGreaterThan(0)
     const max = Math.max(...sizes)
-    // 60s window / 3s spacing = 20 entries. Allow generous slack (up to
-    // 30) for boundary timestamps recorded by the harness's setup
-    // (initial enqueue, heartbeat ticks, etc.).
-    expect(max).toBeLessThanOrEqual(30)
+    // 60s window / 3s spacing = 20 entries. Allow tight slack (<= 22)
+    // for one or two boundary timestamps recorded by the harness's
+    // setup (initial enqueue, etc.) — anything looser fails to catch
+    // off-by-N regressions in the sliding-window cleanup.
+    expect(max).toBeLessThanOrEqual(22)
     // And critically, NOT 100+ — that would mean cleanup never ran.
     expect(max).toBeLessThan(100)
   })

--- a/telegram-plugin/tests/progress-card-memory-bounds.test.ts
+++ b/telegram-plugin/tests/progress-card-memory-bounds.test.ts
@@ -72,9 +72,13 @@ describe('PR-C2: end-to-end memory bounds across 100 turn cycles', () => {
       advance(65_000)
     }
 
-    // chats may hold the originating bg-pending state OR have rolled it
-    // forward; either way the count is small and bounded — NOT 50+.
-    expect(maps.chats.size).toBeLessThanOrEqual(2)
+    // After 50 clean surrounding turns each followed by `advance(65_000)`
+    // (well past TTL + eviction throttle), every chatState — including
+    // the originating one whose bg sub-agent never finished — has been
+    // rolled forward and evicted. Empty is the correct steady state, not
+    // the "≤ 2" the original PR shipped. What this test really proves
+    // is that `chats` doesn't grow with cycle count.
+    expect(maps.chats.size).toBe(0)
     expect(maps.baseTurnSeqs.size).toBeLessThanOrEqual(1)
   })
 })

--- a/telegram-plugin/tests/progress-card-pin-failure-paths.test.ts
+++ b/telegram-plugin/tests/progress-card-pin-failure-paths.test.ts
@@ -39,7 +39,7 @@ function makeHarness() {
   let unpinReject: Error | null = null
 
   const mgr = createPinManager({
-    pin: async (chatId, messageId) => {
+    pin: async (_chatId, _messageId) => {
       pinCalls++
       if (pinReject) {
         const e = pinReject
@@ -48,7 +48,7 @@ function makeHarness() {
       }
       return true
     },
-    unpin: async (chatId, messageId) => {
+    unpin: async (_chatId, _messageId) => {
       unpinCalls++
       if (unpinReject) {
         const e = unpinReject

--- a/telegram-plugin/tests/two-zone-bg-carry-full-lifecycle.test.ts
+++ b/telegram-plugin/tests/two-zone-bg-carry-full-lifecycle.test.ts
@@ -20,7 +20,7 @@ import { makeHarness, enqueue } from './_progress-card-harness.js'
 
 describe('PR-C2: two-zone bg-carry full lifecycle (turn A → turn B → bg done)', () => {
   it('phase transitions A=Background, B=Working, B-after-bg-done=Done', () => {
-    const { driver, advance, getNow } = makeHarness({
+    const { driver, advance, getNow, completions } = makeHarness({
       minIntervalMs: 500,
       coalesceMs: 400,
       promoteAfterMs: 999_999,
@@ -59,6 +59,10 @@ describe('PR-C2: two-zone bg-carry full lifecycle (turn A → turn B → bg done
       const a = all.find((e) => e.turnKey.endsWith(':1'))
       expect(a).toBeDefined()
     }
+    // Capture A's turnKey for the deferred-completion assertion below.
+    const turnKeyA = (driver as unknown as {
+      peekAllFleets?: () => Array<{ turnKey: string; fleet: Map<string, unknown> }>
+    }).peekAllFleets!().find((e) => e.fleet.has('saBG'))!.turnKey
 
     // ── Turn B: fresh enqueue. The bg member carries forward. ─────────
     advance(50)
@@ -119,5 +123,9 @@ describe('PR-C2: two-zone bg-carry full lifecycle (turn A → turn B → bg done
       // Whichever turn still holds saBG, it must be terminal (done/failed/killed)
       expect(['done', 'failed', 'killed']).toContain(m.status)
     }
+    // Critical: A's deferred completion MUST have fired now that saBG
+    // reached sub_agent_turn_end. Without this assertion the loop above
+    // trivially passes when allAfter is empty.
+    expect(completions).toContain(turnKeyA)
   })
 })


### PR DESCRIPTION
Polish-grade test cleanups from review of #678. No production code changes.

## Summary

- **`edit-timestamps-budget`** — tighten max-array bound from `<= 30` to `<= 22`. The original `30` was too loose to catch off-by-N regressions in the sliding-window cleanup; `22` matches the comment's "60s window / 3s spacing = 20 entries" plus a small slack for harness boundary timestamps.
- **`memory-bounds`** (long-lived bg sub-agent test) — replace unjustified `expect(chats.size).toBeLessThanOrEqual(2)` with `expect(chats.size).toBe(0)`. After 50 clean surrounding turns each followed by `advance(65_000)` (well past TTL + eviction throttle), the steady state is empty. Comment explains the reasoning.
- **`two-zone-bg-carry-full-lifecycle`** — capture `turnKeyA` from `peekAllFleets()` before turn B starts, then assert `expect(completions).toContain(turnKeyA)` after saBG finishes. The pre-existing "if saBG present, status terminal" loop trivially passed when the fleets map was empty; this nails down that A's deferred completion actually fired.
- **`pin-failure-paths`** — prefix unused `chatId` / `messageId` mock params with `_`.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] All 4 targeted tests green: `npx vitest run telegram-plugin/tests/progress-card-edit-timestamps-budget.test.ts telegram-plugin/tests/progress-card-memory-bounds.test.ts telegram-plugin/tests/two-zone-bg-carry-full-lifecycle.test.ts telegram-plugin/tests/progress-card-pin-failure-paths.test.ts` → 6 passed (6)

Closes #680
Follow-up to #678

🤖 Generated with [Claude Code](https://claude.com/claude-code)