### PR TITLE
feat(profiles): move worker worktree isolation default to coding profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 ## [Unreleased]
 
+### Changed
+
+- **Worker worktree isolation moved from global defaults to the `coding`
+  profile (#682).** `examples/switchroom.yaml` previously shipped
+  `defaults.subagents.worker.isolation: worktree`, which hard-failed
+  every agent whose cwd was not a git repo (most switchroom agents,
+  which run from `~/.switchroom/agents/<name>`). The default now lives
+  in an inline `profiles.coding` block; agents pick it up via
+  `extends: coding`. Sub-agent merge is now field-level on name
+  conflict (a profile or agent overriding one field no longer drops the
+  rest of the worker definition). Operators whose existing yaml still
+  carries the old global default see a one-time NOTICE on the next
+  config load — no auto-rewrite. Migration: add `extends: coding` to
+  coding-shaped agents, or paste the two-line override directly under
+  those agents.
+
 ## v0.6.5 — 2026-05-04
 
 ### Added

--- a/examples/switchroom.yaml
+++ b/examples/switchroom.yaml
@@ -67,7 +67,12 @@ defaults:
       description: "Handles implementation tasks: writing, editing, building, testing. Use for any task that takes more than a few seconds."
       model: sonnet
       background: true
-      isolation: worktree
+      # NOTE: `isolation: worktree` used to live here as a global default
+      # but moved to the `coding` profile in switchroom 0.6.6 (#682). It
+      # hard-failed for any agent whose cwd was not a git repo — i.e. the
+      # majority of switchroom agents, which run from
+      # `~/.switchroom/agents/<name>` with no git init. Worktree isolation
+      # is opt-in via `extends: coding` now. See CHANGELOG and #682.
       # 100 turns is a comfortable budget for most worker tasks; if a
       # worker exhausts this mid-flow, it'll be reported as #423-style
       # ceiling. Bump to 200 for genuinely long PR-shipping flows or
@@ -113,6 +118,19 @@ defaults:
 # Inline profiles here take priority over filesystem profiles/<name>/
 # (which can additionally bundle CLAUDE.md.hbs + skills/).
 profiles:
+  # The `coding` profile pairs with `profiles/coding/` on disk (which
+  # ships the CLAUDE.md template and skills). Its inline counterpart
+  # here carries the YAML-level defaults that the filesystem assets
+  # advertise — worktree-isolated workers chief among them. Agents
+  # whose cwd IS a git checkout (a real code repo) should
+  # `extends: coding` to pick this up. Agents whose cwd is the default
+  # `~/.switchroom/agents/<name>` (no git) should NOT — Claude Code
+  # cannot create a worktree off a non-repo and the worker will fail.
+  coding:
+    subagents:
+      worker:
+        isolation: worktree
+
   coder:
     tools:
       allow: [Bash, Read, Write, Edit, Grep, Glob]

--- a/src/config/merge.ts
+++ b/src/config/merge.ts
@@ -170,6 +170,25 @@ export function resolveAgentConfig(
   profiles: Record<string, Profile> | undefined,
   agent: AgentConfig,
 ): AgentConfig {
+  // #682: surface the worker-isolation move once per process. The check
+  // lives here (not inside mergeAgentConfig) because mergeAgentConfig
+  // gets called recursively with synthesized "defaults" derived from
+  // profiles, and we'd false-positive on those. resolveAgentConfig sees
+  // only the operator-supplied root defaults.
+  if (
+    !mergeAgentConfig.suppressDeprecationLogs
+    && !mergeAgentConfig.notifiedWorkerIsolationMove
+    && defaults?.subagents?.worker?.isolation === "worktree"
+  ) {
+    mergeAgentConfig.notifiedWorkerIsolationMove = true;
+    console.warn(
+      "[switchroom] NOTICE: defaults.subagents.worker.isolation moved to the "
+      + "`coding` profile in switchroom 0.6.6 (#682). Agents extending coding "
+      + "still get worktree-isolated workers; other agents would have hard-failed "
+      + "the first time they delegated. See CHANGELOG.",
+    );
+  }
+
   const name = agent.extends;
   const profile = name && profiles ? profiles[name] : undefined;
 
@@ -418,16 +437,33 @@ export function mergeAgentConfig(
     };
   }
 
-  // --- subagents: per-key merge, agent wins on name conflict ---
+  // --- subagents: per-key merge, with field-level merge on conflict ---
   //
-  // A default sub-agent "worker" can be overridden entirely by an
-  // agent-level "worker" definition. No field-level merge within a
-  // single sub-agent — if you override, you replace the whole def.
+  // When the same sub-agent name (e.g. "worker") appears in both layers,
+  // we merge field-by-field (override wins per field, undefined fields
+  // fall through). This lets a profile add a single field — e.g. the
+  // coding profile setting `subagents.worker.isolation: worktree` — without
+  // having to re-declare the worker's description, model, maxTurns, etc
+  // from the defaults block. Pre-#682 this was a whole-def replacement,
+  // which made the inline coding profile's one-line override silently drop
+  // every other worker field.
   if (defaults.subagents || merged.subagents) {
-    merged.subagents = {
-      ...(defaults.subagents ?? {}),
-      ...(merged.subagents ?? {}),
-    };
+    const dSub = defaults.subagents ?? {};
+    const mSub = merged.subagents ?? {};
+    const out: Record<string, unknown> = { ...dSub };
+    for (const [name, override] of Object.entries(mSub)) {
+      const base = (dSub as Record<string, unknown>)[name];
+      if (base && typeof base === "object" && override && typeof override === "object") {
+        const combined: Record<string, unknown> = { ...(base as Record<string, unknown>) };
+        for (const [k, v] of Object.entries(override as Record<string, unknown>)) {
+          if (v !== undefined) combined[k] = v;
+        }
+        out[name] = combined;
+      } else {
+        out[name] = override;
+      }
+    }
+    merged.subagents = out as AgentConfig["subagents"];
   }
 
   // --- session: shallow field merge, agent wins ---
@@ -558,4 +594,12 @@ export function mergeAgentConfig(
 // eslint-disable-next-line @typescript-eslint/no-namespace
 export namespace mergeAgentConfig {
   export let suppressDeprecationLogs = false;
+  /**
+   * One-shot guard for the #682 worker-isolation migration notice. Reset
+   * to `false` in tests that exercise the notice path so the emission
+   * is observable; left `true` in tests that don't care, to keep stderr
+   * clean. Production code never resets it — the notice fires once per
+   * process by design.
+   */
+  export let notifiedWorkerIsolationMove = false;
 }

--- a/tests/merge.test.ts
+++ b/tests/merge.test.ts
@@ -416,6 +416,103 @@ describe("mergeAgentConfig subagents", () => {
     );
     expect(result.subagents?.w?.description).toBe("d");
   });
+
+  it("field-merges sub-agent definitions on name conflict (#682)", () => {
+    // Pre-#682 this was a whole-def replacement and the override below
+    // would have silently dropped description + model. The coding-profile
+    // refactor in #682 needs single-field overrides to compose with the
+    // defaults' worker definition.
+    const defaults: AgentDefaults = {
+      subagents: {
+        worker: {
+          description: "default worker",
+          model: "sonnet",
+          maxTurns: 100,
+        },
+      },
+    };
+    const agent = baseAgent({
+      subagents: {
+        worker: { isolation: "worktree" },
+      },
+    });
+    const result = mergeAgentConfig(defaults, agent);
+    expect(result.subagents?.worker?.description).toBe("default worker");
+    expect(result.subagents?.worker?.model).toBe("sonnet");
+    expect(result.subagents?.worker?.maxTurns).toBe(100);
+    expect(result.subagents?.worker?.isolation).toBe("worktree");
+  });
+});
+
+describe("coding profile resolution (#682)", () => {
+  it("agents extending `coding` get worktree-isolated workers", () => {
+    // Mirrors the inline profile shape shipped in examples/switchroom.yaml
+    // after #682. The coding profile contributes only isolation; the
+    // worker's description/model/maxTurns flow from defaults.
+    const defaults: AgentDefaults = {
+      subagents: {
+        worker: {
+          description: "default worker",
+          model: "sonnet",
+          maxTurns: 100,
+        },
+      },
+    };
+    const profiles: Record<string, Profile> = {
+      coding: {
+        subagents: {
+          worker: { isolation: "worktree" },
+        },
+      },
+    };
+    const agent = baseAgent({ extends: "coding" });
+    const result = resolveAgentConfig(defaults, profiles, agent);
+    expect(result.subagents?.worker?.isolation).toBe("worktree");
+    expect(result.subagents?.worker?.description).toBe("default worker");
+    expect(result.subagents?.worker?.model).toBe("sonnet");
+  });
+
+  it("emits a one-time NOTICE when legacy defaults.subagents.worker.isolation is present", () => {
+    mergeAgentConfig.notifiedWorkerIsolationMove = false;
+    const warns: string[] = [];
+    const originalWarn = console.warn;
+    console.warn = (msg: string) => warns.push(msg);
+    try {
+      const defaults: AgentDefaults = {
+        subagents: {
+          worker: { description: "default worker", isolation: "worktree" },
+        },
+      };
+      resolveAgentConfig(defaults, undefined, baseAgent());
+      // Second call should NOT re-emit
+      resolveAgentConfig(defaults, undefined, baseAgent());
+    } finally {
+      console.warn = originalWarn;
+    }
+    const notices = warns.filter((m) => m.includes("#682"));
+    expect(notices.length).toBe(1);
+    expect(notices[0]).toMatch(/coding.*profile/i);
+    // Reset so it doesn't bleed into other tests
+    mergeAgentConfig.notifiedWorkerIsolationMove = true;
+  });
+
+  it("agents NOT extending `coding` do not get worktree isolation by default", () => {
+    const defaults: AgentDefaults = {
+      subagents: {
+        worker: { description: "default worker", model: "sonnet" },
+      },
+    };
+    const profiles: Record<string, Profile> = {
+      coding: {
+        subagents: {
+          worker: { isolation: "worktree" },
+        },
+      },
+    };
+    const agent = baseAgent(); // no extends
+    const result = resolveAgentConfig(defaults, profiles, agent);
+    expect(result.subagents?.worker?.isolation).toBeUndefined();
+  });
 });
 
 describe("mergeAgentConfig session policy", () => {


### PR DESCRIPTION
Closes #682.

## Summary

- Remove `isolation: worktree` from `defaults.subagents.worker` in `examples/switchroom.yaml`. The global default hard-failed for any agent whose cwd was not a git repo (most switchroom agents — they run from `~/.switchroom/agents/<name>` with no git init).
- Add an inline `profiles.coding` block setting `subagents.worker.isolation: worktree`. Worktree isolation is opt-in via `extends: coding` from now on.
- Make sub-agent merge field-level on name conflict. Pre-#682 a profile (or agent) overriding `subagents.worker.isolation` would have silently dropped the worker's description / model / maxTurns from defaults. Field-level merge keeps both layers' contributions.
- Reconcile-time NOTICE: when an operator's existing `switchroom.yaml` still carries `defaults.subagents.worker.isolation: worktree`, log a one-line CHANGELOG-style notice once per process. No auto-rewrite.
- CHANGELOG entry under `[Unreleased]`.
- Tests: coding-profile resolution, no-extends absence, field-level merge composition, one-time NOTICE emission.

## Migration notes (operators)

Existing yaml that relied on the global default and wants to keep worktree-isolated workers should either:

1. Add `extends: coding` to the affected agent (preferred — picks up the rest of the coding profile too), or
2. Paste the override directly under that agent:

```yaml
agents:
  myagent:
    subagents:
      worker:
        isolation: worktree
```

Field-level sub-agent merge means option 2 only contributes `isolation` — the worker's description / model / maxTurns continue to flow from defaults.

The legacy default is no longer required, but it still works (with a one-time NOTICE) until you remove it. No breaking change for operators who haven't touched the file.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `vitest run tests/merge.test.ts tests/config.test.ts tests/cli.agent-create-profile.test.ts src/config/schema.test.ts` — 129/129 passing
- [x] `node scripts/check-plugin-references.mjs` clean
- [ ] Manual: scaffold a coding-profile agent, observe `.claude/agents/worker.md` carries `isolation: worktree`
- [ ] Manual: scaffold a default-profile agent, observe `.claude/agents/worker.md` does NOT carry `isolation: worktree`
- [ ] Manual: run `switchroom apply` against an old yaml that still has the legacy default; observe single NOTICE on stderr

🤖 Generated with [Claude Code](https://claude.com/claude-code)