### PR TITLE
fix(progress-card): emoji header counters + active-in-flight bullet

### DIFF
--- a/reference/status-card-design.md
+++ b/reference/status-card-design.md
@@ -27,17 +27,26 @@ from active work, and from done.
 ## Layout
 
 ```
-<icon> <label> · ⏱ <elapsed> · <tools>t · <subs>s
+<icon> <label> · ⏱ <elapsed> · 🔧 <tools> · 🤖 <subs>
 
 PARENT
 ● <main-agent tool> [...]
 ● <main-agent tool> [...]
+◉ <b><active tool></b> [...]    ← last bullet while in flight
 
 FLEET (N)
 <icon> <role> <id6> · <tools>t · <last activity>
 <icon> <role> <id6> · <tools>t · <last activity>
 + N more
 ```
+
+The header counters are emoji-prefixed (🔧 = tool calls, 🤖 = sub-agents)
+rather than the cryptic `Nt` / `Ns` shorthand. The `🤖 <subs>` segment is
+omitted entirely when the fleet is empty. The parent zone's LAST bullet
+is rendered with `◉ <b>tool</b>` while the parent turn is still in
+flight (`stage !== 'done'`), so the active step is visibly distinct from
+completed history; once the parent reaches `done` every bullet renders
+plain (`●`).
 
 `PARENT` is omitted if the main agent has emitted no tool calls this
 turn. `FLEET` is omitted when no sub-agents have ever participated in
@@ -58,9 +67,10 @@ and yields exactly one of:
 | 🙊 | Ended without reply | Parent terminal AND no reply tool fired AND no captured text |
 | ⚠ | Forced close | Watchdog-driven turn close; supersedes all others |
 
-Counters: `Nt` total tool calls across all contributors (cap `99+`),
-`Ns` total sub-agents that ever participated this turn (running +
-terminal). Elapsed measured from parent `turn_start`.
+Counters: `🔧 N` total tool calls across all contributors (cap `99+`),
+`🤖 N` total sub-agents that ever participated this turn (running +
+terminal; segment omitted when fleet is empty). Elapsed measured from
+parent `turn_start`.
 
 ## Parent zone
 

--- a/telegram-plugin/tests/two-zone-card-snapshot.test.ts
+++ b/telegram-plugin/tests/two-zone-card-snapshot.test.ts
@@ -50,7 +50,7 @@ describe('two-zone-card snapshots', () => {
       fleet: new Map(),
       now: NOW,
     })
-    expect(out).toBe('⚙️ <b>Working…</b> · ⏱ 00:05 · 0t')
+    expect(out).toBe('⚙️ <b>Working…</b> · ⏱ 00:05 · 🔧 0')
   })
 
   it('3 members mixed', () => {
@@ -65,7 +65,7 @@ describe('two-zone-card snapshots', () => {
       now: NOW,
     })
     expect(out).toBe(
-      '⚙️ <b>Working…</b> · ⏱ 00:30 · 14t · 3s\n' +
+      '⚙️ <b>Working…</b> · ⏱ 00:30 · 🔧 14 · 🤖 3\n' +
       '\n' +
       '<b>FLEET (3)</b>\n' +
       '↻ researcher <code>aaaaaa</code> · 4t · Grep <code>TODO</code> (2s ago)\n' +
@@ -85,7 +85,7 @@ describe('two-zone-card snapshots', () => {
       now: NOW,
     })
     expect(out).toBe(
-      '✅ <b>Done</b> · ⏱ 00:20 · 8t · 2s\n' +
+      '✅ <b>Done</b> · ⏱ 00:20 · 🔧 8 · 🤖 2\n' +
       '\n' +
       '<b>FLEET (2)</b>\n' +
       '✓ reviewer <code>bbbbbb</code> · 3t · done 5s ago\n' +
@@ -104,7 +104,7 @@ describe('two-zone-card snapshots', () => {
       now: NOW,
     })
     expect(out).toBe(
-      '⚠ <b>Stalled</b> · ⏱ 01:35 · 2t · 2s\n' +
+      '⚠ <b>Stalled</b> · ⏱ 01:35 · 🔧 2 · 🤖 2\n' +
       '\n' +
       '<b>FLEET (2)</b>\n' +
       '⚠ worker <code>bbbbbb</code> · 1t · idle 1m20s ago\n' +
@@ -123,7 +123,7 @@ describe('two-zone-card snapshots', () => {
       now: NOW,
     })
     expect(out).toBe(
-      '⏸ <b>Background</b> · ⏱ 01:30 · 17t · 2s\n' +
+      '⏸ <b>Background</b> · ⏱ 01:30 · 🔧 17 · 🤖 2\n' +
       '\n' +
       '<b>FLEET (2)</b>\n' +
       '⏸ background <code>bbbbbb</code> · 12t · Bash <code>long-job.sh</code> (1s ago)\n' +

--- a/telegram-plugin/tests/two-zone-snapshot-extras.test.ts
+++ b/telegram-plugin/tests/two-zone-snapshot-extras.test.ts
@@ -65,7 +65,7 @@ describe('PR-C2: two-zone card snapshot extras', () => {
       opts: { silentEnd: true },
     })
     expect(out).toBe(
-      '🙊 <b>Ended without reply</b> · ⏱ 00:30 · 7t · 1s\n' +
+      '🙊 <b>Ended without reply</b> · ⏱ 00:30 · 🔧 7 · 🤖 1\n' +
       '\n' +
       '<b>FLEET (1)</b>\n' +
       '⏸ background <code>aaaaaa</code> · 7t · Bash <code>long.sh</code> (2s ago)',
@@ -104,5 +104,40 @@ describe('PR-C2: two-zone card snapshot extras', () => {
     expect(out).toContain('<code>f4.ts</code>')
     // f3 (the latest hidden) must not appear as a bullet code block.
     expect(out).not.toContain('<code>f3.ts</code>')
+  })
+
+  it('parent zone: in-flight last bullet uses ◉ <b>tool</b>; earlier use ● tool', () => {
+    const items = [
+      { tool: 'Read', label: 'a.ts' },
+      { tool: 'Read', label: 'b.ts' },
+      { tool: 'Bash', label: 'ls' },
+    ]
+    const out = renderTwoZoneCard({
+      state: st({ stage: 'run', turnStartedAt: NOW - 5000, items }),
+      fleet: new Map(),
+      now: NOW,
+    })
+    // last item active
+    expect(out).toContain('◉ <b>Bash</b> <code>ls</code>')
+    // earlier items plain
+    expect(out).toContain('● Read <code>a.ts</code>')
+    expect(out).toContain('● Read <code>b.ts</code>')
+    // last item is NOT plain
+    expect(out).not.toContain('● Bash <code>ls</code>')
+  })
+
+  it('parent zone: when stage=done all bullets render as ● (no active marker)', () => {
+    const items = [
+      { tool: 'Read', label: 'a.ts' },
+      { tool: 'Bash', label: 'ls' },
+    ]
+    const out = renderTwoZoneCard({
+      state: st({ stage: 'done', turnStartedAt: NOW - 5000, items }),
+      fleet: new Map(),
+      now: NOW,
+    })
+    expect(out).toContain('● Read <code>a.ts</code>')
+    expect(out).toContain('● Bash <code>ls</code>')
+    expect(out).not.toContain('◉')
   })
 })

--- a/telegram-plugin/two-zone-card.ts
+++ b/telegram-plugin/two-zone-card.ts
@@ -140,8 +140,8 @@ function renderHeader(
 ): string {
   const tools = totalTools >= 100 ? '99+' : String(totalTools)
   const elapsed = formatDuration(elapsedMs)
-  const parts = [`${phase.icon} <b>${escapeHtml(phase.label)}</b>`, `⏱ ${elapsed}`, `${tools}t`]
-  if (subCount > 0) parts.push(`${subCount}s`)
+  const parts = [`${phase.icon} <b>${escapeHtml(phase.label)}</b>`, `⏱ ${elapsed}`, `🔧 ${tools}`]
+  if (subCount > 0) parts.push(`🤖 ${subCount}`)
   if (taskNum && taskNum.total > 1) parts.push(`#${taskNum.index}/${taskNum.total}`)
   return parts.join(' · ')
 }
@@ -155,10 +155,17 @@ function renderParentZone(state: ProgressCardState): string {
   const visible = items.slice(-PARENT_BULLET_CAP)
   const earlier = items.length - visible.length
   if (earlier > 0) lines.push(`(+${earlier} earlier)`)
-  for (const it of visible) {
+  const inFlight = state.stage !== 'done'
+  const lastIdx = visible.length - 1
+  for (let i = 0; i < visible.length; i++) {
+    const it = visible[i]
     const tool = escapeHtml(it.tool || '')
     const label = it.label ? ` <code>${escapeHtml(truncate(it.label, 80))}</code>` : ''
-    lines.push(`● ${tool}${label}`)
+    if (inFlight && i === lastIdx) {
+      lines.push(`◉ <b>${tool}</b>${label}`)
+    } else {
+      lines.push(`● ${tool}${label}`)
+    }
   }
   return lines.join('\n')
 }


### PR DESCRIPTION
## Summary

Two v1→v2 regressions Ken flagged in the two-zone status card:

1. **Header counters** were cryptic shorthand (`14t`, `3s`) — hard to parse on mobile. Now emoji-prefixed: `🔧 14` (tool calls) and `🤖 3` (sub-agents).
2. **Parent zone** lost the v1 distinction between done (`●` plain) and active in-flight (`◉` bold) bullets. Restored: the last visible parent bullet renders as `◉ <b>tool</b>` while `state.stage !== 'done'`; all earlier (and post-done) bullets render plain `●`.

### Before
```
⚙️ <b>Working…</b> · ⏱ 00:30 · 14t · 3s

PARENT
● Read <code>a.ts</code>
● Bash <code>ls</code>
```

### After
```
⚙️ <b>Working…</b> · ⏱ 00:30 · 🔧 14 · 🤖 3

PARENT
● Read <code>a.ts</code>
◉ <b>Bash</b> <code>ls</code>
```

The `99+` tool cap is preserved. The `🤖 N` segment is still omitted when the fleet is empty. Fleet zone glyphs are unchanged.

Design doc (`reference/status-card-design.md`) Layout + Header sections updated to match.

## Test plan

- [x] `vitest run telegram-plugin/tests/two-zone*` — 92 tests pass (existing snapshot expectations updated, new cases added for active-bullet vs. all-done parent zone)
- [x] `vitest run telegram-plugin/tests/progress-card*` — 89 tests pass (no collateral damage)
- [x] `tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)