### PR TITLE
fix(telegram): stream_reply HTML parse failure must edit, not duplicate (#657)

### DIFF
--- a/telegram-plugin/html-sanitize.ts
+++ b/telegram-plugin/html-sanitize.ts
@@ -1,0 +1,244 @@
+/**
+ * Telegram-HTML sanitizer.
+ *
+ * Telegram's HTML parser is strict: it accepts only a small whitelist of
+ * tags (b/strong, i/em, u/ins, s/strike/del, code, pre, a, tg-spoiler,
+ * span class="tg-spoiler", tg-emoji, blockquote) and rejects the entire
+ * message with `400 Bad Request: can't parse entities` when it encounters
+ * an unknown tag, an unbalanced tag, or a stray `<` that doesn't open a
+ * known tag.
+ *
+ * `markdownToHtml()` already produces well-formed HTML for content the
+ * model wrote *as markdown*. This module is the second line of defence
+ * for content the model wrote *as raw HTML* (or as a mix that produces
+ * malformed HTML after rendering): we run the rendered string through a
+ * pure-text scanner that:
+ *
+ *   1. Escapes any `<` / `>` that doesn't open or close a whitelisted
+ *      tag (e.g. `<frobnicate>` → `&lt;frobnicate&gt;`,
+ *      `1 < 2 < 3` → `1 &lt; 2 &lt; 3`).
+ *   2. Escapes attributes that aren't on the small per-tag allowlist
+ *      (only `<a href>`, `<code class>`, `<span class="tg-spoiler">`,
+ *      `<tg-emoji emoji-id>`, `<blockquote expandable>` are accepted —
+ *      everything else gets stripped from the tag).
+ *   3. Auto-closes any tag opened but never closed (so an "unclosed
+ *      `<b>` at end of message" doesn't trip Telegram's parser).
+ *   4. Drops any unmatched closing tag (e.g. `</foo>` without an opener).
+ *
+ * The sanitizer is conservative: when in doubt, escape. The output is
+ * guaranteed to round-trip through Telegram's HTML parser without a
+ * `can't parse entities` 400 — at the cost of some false positives where
+ * raw `<` characters inside model prose end up as `&lt;` (which is the
+ * correct Telegram-HTML behaviour anyway).
+ *
+ * Idempotent: sanitize(sanitize(x)) === sanitize(x).
+ */
+
+/** Telegram's parse_mode=HTML allowed tag names. */
+const ALLOWED_TAGS = new Set([
+  'b', 'strong',
+  'i', 'em',
+  'u', 'ins',
+  's', 'strike', 'del',
+  'a',
+  'code',
+  'pre',
+  'span',
+  'tg-spoiler',
+  'tg-emoji',
+  'blockquote',
+])
+
+/**
+ * Per-tag attribute allowlist. Keys are tag names; values are the set of
+ * attribute names that survive the sanitizer. Anything not listed is
+ * silently dropped from the opening tag.
+ */
+const ALLOWED_ATTRS: Record<string, Set<string>> = {
+  a: new Set(['href']),
+  code: new Set(['class']),
+  span: new Set(['class']),
+  'tg-emoji': new Set(['emoji-id']),
+  blockquote: new Set(['expandable']),
+  pre: new Set(['language']),
+}
+
+/** Allowed schemes for `<a href>` — block javascript:, data:, etc. */
+const ALLOWED_HREF_SCHEMES = /^(?:https?|mailto|tel|tg):/i
+
+/**
+ * Strip every `<…>` from a string, escaping the `<` and `>`. Used as the
+ * fallback when the input genuinely cannot be made HTML-safe.
+ */
+export function escapeAllHtml(text: string): string {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+}
+
+/**
+ * Sanitize a string of Telegram HTML so it cannot trip the
+ * `can't parse entities` 400. See module docstring for the rules.
+ *
+ * @param input - the rendered HTML (post markdownToHtml).
+ * @returns the sanitized HTML, guaranteed parse-mode=HTML safe.
+ */
+export function sanitizeTelegramHtml(input: string): string {
+  // Walk the input character by character. When we see `<`, try to match
+  // a tag against our whitelist. If it matches, emit a normalized form;
+  // otherwise escape the `<` and continue.
+  //
+  // Tag regex: opening tag name, optional attributes (anything up to
+  // the next `>` that isn't inside a quoted string), and the closing
+  // `>`. We use a small hand-rolled parser rather than a generic regex
+  // because we need to validate attributes per-tag.
+  const out: string[] = []
+  const stack: string[] = [] // names of open tags, oldest-first
+  let i = 0
+  const len = input.length
+
+  while (i < len) {
+    const ch = input[i]
+
+    if (ch === '&') {
+      // Pass through known entities verbatim; escape bare `&`.
+      // A "known entity" is `&` followed by [a-z]+; or `&#` followed by digits;
+      // both terminated by `;` within ~10 chars.
+      const m = /^&(?:#\d+|#x[0-9a-f]+|[a-z]+);/i.exec(input.slice(i, i + 12))
+      if (m) {
+        out.push(m[0])
+        i += m[0].length
+      } else {
+        out.push('&amp;')
+        i++
+      }
+      continue
+    }
+
+    if (ch !== '<') {
+      out.push(ch)
+      i++
+      continue
+    }
+
+    // We're at a `<`. Try to parse a tag.
+    const tagMatch = /^<\s*(\/?)\s*([a-zA-Z][a-zA-Z0-9-]*)\b([^>]*)>/.exec(input.slice(i))
+    if (!tagMatch) {
+      // Stray `<` — escape it.
+      out.push('&lt;')
+      i++
+      continue
+    }
+    const isClose = tagMatch[1] === '/'
+    const tagName = tagMatch[2].toLowerCase()
+    const attrText = tagMatch[3]
+
+    if (!ALLOWED_TAGS.has(tagName)) {
+      // Unknown tag — escape the whole `<…>` literal.
+      out.push(escapeAllHtml(tagMatch[0]))
+      i += tagMatch[0].length
+      continue
+    }
+
+    if (isClose) {
+      // Closing tag: only emit if it matches the most recently opened
+      // tag of the same name. If the stack contains a matching opener
+      // earlier, close out everything above it (auto-close any
+      // unbalanced inner tags). If there's no matching opener at all,
+      // drop the closing tag silently.
+      const idx = stack.lastIndexOf(tagName)
+      if (idx === -1) {
+        // No matching opener — drop the close tag.
+        i += tagMatch[0].length
+        continue
+      }
+      // Auto-close anything above the matching opener.
+      while (stack.length > idx + 1) {
+        const top = stack.pop()!
+        out.push(`</${top}>`)
+      }
+      stack.pop()
+      out.push(`</${tagName}>`)
+      i += tagMatch[0].length
+      continue
+    }
+
+    // Opening tag: filter attributes.
+    const cleanAttrs = sanitizeAttrs(tagName, attrText)
+    out.push(`<${tagName}${cleanAttrs}>`)
+    // Self-closing void tags? Telegram has none — every allowed tag is
+    // a container. Push onto stack so we can auto-close later.
+    stack.push(tagName)
+    i += tagMatch[0].length
+  }
+
+  // Auto-close any unclosed tags so the output is balanced.
+  while (stack.length > 0) {
+    const top = stack.pop()!
+    out.push(`</${top}>`)
+  }
+
+  return out.join('')
+}
+
+/**
+ * Filter the attribute string of an opening tag against the per-tag
+ * allowlist. Returns the cleaned attribute string with a leading space
+ * (or empty string when no attributes survive).
+ */
+function sanitizeAttrs(tagName: string, attrText: string): string {
+  const allowed = ALLOWED_ATTRS[tagName]
+  if (!allowed || allowed.size === 0) return ''
+
+  // Match attribute name=value or bare name. Value may be double-quoted,
+  // single-quoted, or unquoted.
+  const attrRe = /([a-zA-Z_][a-zA-Z0-9_-]*)(?:\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s>]+)))?/g
+  const kept: string[] = []
+  let m: RegExpExecArray | null
+  while ((m = attrRe.exec(attrText)) != null) {
+    const name = m[1].toLowerCase()
+    if (!allowed.has(name)) continue
+    const rawValue = m[2] ?? m[3] ?? m[4] ?? ''
+
+    // Per-attribute value sanitization.
+    if (tagName === 'a' && name === 'href') {
+      const trimmed = rawValue.trim()
+      if (!ALLOWED_HREF_SCHEMES.test(trimmed)) continue
+      kept.push(`href="${escapeAttrValue(trimmed)}"`)
+      continue
+    }
+    if (rawValue.length === 0) {
+      // Bare attribute like `<blockquote expandable>`.
+      kept.push(name)
+      continue
+    }
+    kept.push(`${name}="${escapeAttrValue(rawValue)}"`)
+  }
+  return kept.length > 0 ? ' ' + kept.join(' ') : ''
+}
+
+function escapeAttrValue(v: string): string {
+  return v
+    .replace(/&/g, '&amp;')
+    .replace(/"/g, '&quot;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+}
+
+/**
+ * Convert a rendered HTML body to a plain-text fallback. Used when
+ * Telegram still rejects the (presumably-already-sanitized) HTML — we
+ * strip every tag and unescape entities so the message lands as text
+ * instead of disappearing.
+ */
+export function htmlToPlainText(html: string): string {
+  return html
+    // Drop tags entirely.
+    .replace(/<\/?[a-zA-Z][a-zA-Z0-9-]*\b[^>]*>/g, '')
+    // Unescape the four entities the encoder produces.
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&amp;/g, '&')
+}

--- a/telegram-plugin/shared/bot-runtime.ts
+++ b/telegram-plugin/shared/bot-runtime.ts
@@ -41,10 +41,14 @@ import { createRetryApiCall } from '../retry-api-call.js'
  *
  * Log shape (one line per POST, on both success and failure):
  *
- *   tg-post method=<m> chat=<id> thread=<id|-> parse_mode=<HTML|MarkdownV2|none> bytes=<n> hash=<sha1-12> status=<ok|err> err=<class-or-->
+ *   tg-post method=<m> chat=<id> thread=<id|-> parse_mode=<HTML|MarkdownV2|none> bytes=<n> hash=<sha1-12> status=<ok|err> err=<class-or--> code=<http-or--> desc=<short|-->
  *
  * Body content is never logged — only its length and a 12-char sha1 prefix
- * so we can recognise repeated identical sends without leaking PII.
+ * so we can recognise repeated identical sends without leaking PII. The
+ * `code` field carries the Telegram error_code (400/403/429/etc.) on
+ * failure and the short `desc` is the first ~80 chars of the API
+ * description — together these let us correlate "duplicate message"
+ * reports with the precise rejection reason (issue #657).
  *
  * Pure observability: no behaviour change, no error swallowing, no retry
  * effects. The transformer always re-throws after logging.
@@ -63,15 +67,25 @@ export function installTgPostLogger(bot: Bot): void {
     try {
       const res = await prev(method, payload, signal)
       process.stderr.write(
-        `tg-post method=${method} chat=${chat} thread=${thread} parse_mode=${parseMode} bytes=${bytes} hash=${hash} status=ok err=-\n`,
+        `tg-post method=${method} chat=${chat} thread=${thread} parse_mode=${parseMode} bytes=${bytes} hash=${hash} status=ok err=- code=- desc=-\n`,
       )
       return res
     } catch (err) {
       const errClass = err instanceof GrammyError
         ? `grammy_${(err as GrammyError).error_code}`
         : (err as { constructor?: { name?: string } } | null)?.constructor?.name ?? 'Error'
+      const code = err instanceof GrammyError ? String((err as GrammyError).error_code) : '-'
+      const rawDesc = err instanceof GrammyError
+        ? (err as GrammyError).description
+        : (err instanceof Error ? err.message : '')
+      // Sanitise the description for single-line log output — collapse
+      // whitespace, strip newlines, cap at 80 chars. PII-safe: Telegram
+      // error descriptions are server-generated and don't echo body.
+      const desc = rawDesc
+        ? rawDesc.replace(/\s+/g, ' ').slice(0, 80).replace(/[\r\n]/g, ' ') || '-'
+        : '-'
       process.stderr.write(
-        `tg-post method=${method} chat=${chat} thread=${thread} parse_mode=${parseMode} bytes=${bytes} hash=${hash} status=err err=${errClass}\n`,
+        `tg-post method=${method} chat=${chat} thread=${thread} parse_mode=${parseMode} bytes=${bytes} hash=${hash} status=err err=${errClass} code=${code} desc=${desc}\n`,
       )
       throw err
     }

--- a/telegram-plugin/stream-controller.ts
+++ b/telegram-plugin/stream-controller.ts
@@ -17,6 +17,28 @@
  */
 
 import { createDraftStream, type DraftStreamHandle, type StreamDraftFn } from './draft-stream.js'
+import { htmlToPlainText } from './html-sanitize.js'
+
+/**
+ * Telegram returns `400 Bad Request: can't parse entities: …` when the
+ * body contains malformed HTML / MarkdownV2 / nested unbalanced tags.
+ * Detect that specific error class so we can fall back to plain text
+ * without confusing it with other 400s (rate-limit, message-not-found,
+ * thread-not-found, etc.).
+ */
+function isParseEntitiesError(err: unknown): boolean {
+  const msg =
+    typeof err === 'string'
+      ? err
+      : err instanceof Error
+        ? err.message
+        : typeof err === 'object' && err != null && 'description' in err
+          ? typeof (err as { description: unknown }).description === 'string'
+            ? (err as { description: string }).description
+            : ''
+          : ''
+  return /can't parse entities|can't find end of the entity|unsupported start tag|unmatched end tag/i.test(msg)
+}
 
 /**
  * Minimal bot.api surface the controller needs. Real callers pass grammy's
@@ -208,21 +230,71 @@ export function createStreamController(cfg: StreamControllerConfig): DraftStream
     ...(protectContent === true ? { protect_content: true } : {}),
   }
 
+  // Strip parse_mode from a copy of opts — used for the parse-entities
+  // fallback path. We keep thread/preview/reply markup untouched.
+  const sendOptsPlain: StreamSendOpts = { ...sendOpts }
+  delete sendOptsPlain.parse_mode
+  const baseOptsPlain: StreamSendOpts = { ...baseOpts }
+  delete baseOptsPlain.parse_mode
+
   return createDraftStream(
     async (text) => {
-      const sent = await retry(
-        () => bot.api.sendMessage(chatId, text, sendOpts),
-        { threadId, chat_id: chatId },
-      )
-      onSend?.(sent.message_id, text.length)
-      return sent.message_id
+      try {
+        const sent = await retry(
+          () => bot.api.sendMessage(chatId, text, sendOpts),
+          { threadId, chat_id: chatId },
+        )
+        onSend?.(sent.message_id, text.length)
+        return sent.message_id
+      } catch (err) {
+        if (parseMode != null && isParseEntitiesError(err)) {
+          // First send rejected for parse_mode error. There is no
+          // message_id to edit (the send 400'd before any message was
+          // created), so a single fresh send in plain-text is the
+          // correct recovery — see issue #657. Strip tags from the
+          // body so the user sees readable prose, not raw markup.
+          warn?.(
+            `stream-controller: sendMessage parse-entities rejected — retrying once as plain text (${err instanceof Error ? err.message : String(err)})`,
+          )
+          const plainText = htmlToPlainText(text)
+          const sent = await retry(
+            () => bot.api.sendMessage(chatId, plainText, sendOptsPlain),
+            { threadId, chat_id: chatId },
+          )
+          onSend?.(sent.message_id, plainText.length)
+          return sent.message_id
+        }
+        throw err
+      }
     },
     async (id, text) => {
-      await retry(
-        () => bot.api.editMessageText(chatId, id, text, baseOpts),
-        { threadId, chat_id: chatId },
-      )
-      onEdit?.(id, text.length)
+      try {
+        await retry(
+          () => bot.api.editMessageText(chatId, id, text, baseOpts),
+          { threadId, chat_id: chatId },
+        )
+        onEdit?.(id, text.length)
+      } catch (err) {
+        if (parseMode != null && isParseEntitiesError(err)) {
+          // Edit rejected for parse_mode error — DO NOT send a fresh
+          // message. The whole point of issue #657 is that the previous
+          // implementation sent a duplicate plain-text message every
+          // time HTML rejection fired. Retry the edit on the SAME
+          // message_id with parse_mode stripped and the body
+          // tag-stripped to plain text.
+          warn?.(
+            `stream-controller: editMessageText parse-entities rejected — retrying same id=${id} as plain text (${err instanceof Error ? err.message : String(err)})`,
+          )
+          const plainText = htmlToPlainText(text)
+          await retry(
+            () => bot.api.editMessageText(chatId, id, plainText, baseOptsPlain),
+            { threadId, chat_id: chatId },
+          )
+          onEdit?.(id, plainText.length)
+          return
+        }
+        throw err
+      }
     },
     {
       ...(throttleMs != null ? { throttleMs } : {}),

--- a/telegram-plugin/stream-reply-handler.ts
+++ b/telegram-plugin/stream-reply-handler.ts
@@ -22,6 +22,7 @@ import {
   type StreamBotApi,
   type RetryPolicy,
 } from './stream-controller.js'
+import { sanitizeTelegramHtml } from './html-sanitize.js'
 
 /**
  * Builds the inline status-accent header line for `reply` / `stream_reply`.
@@ -342,7 +343,11 @@ export async function handleStreamReply(
   let effectiveText: string
   if (format === 'html') {
     parseMode = 'HTML'
-    effectiveText = deps.markdownToHtml(rawText)
+    // Pre-validate the rendered HTML against Telegram's tag allowlist
+    // before send. The sanitizer escapes unknown tags, drops disallowed
+    // attributes, and auto-closes unbalanced tags so we don't trip
+    // Telegram's `400 Bad Request: can't parse entities` (issue #657).
+    effectiveText = sanitizeTelegramHtml(deps.markdownToHtml(rawText))
   } else if (format === 'markdownv2') {
     parseMode = 'MarkdownV2'
     effectiveText = deps.escapeMarkdownV2(rawText)
@@ -360,7 +365,14 @@ export async function handleStreamReply(
   // Unrecognised values are silently ignored (empty string returned).
   if (args.accent != null) {
     const accentHeader = buildAccentHeader(args.accent)
-    if (accentHeader.length > 0) effectiveText = accentHeader + effectiveText
+    if (accentHeader.length > 0) {
+      effectiveText = accentHeader + effectiveText
+      // Re-sanitize after prepending the HTML header so the combined
+      // body is still guaranteed parse-mode=HTML safe.
+      if (parseMode === 'HTML') {
+        effectiveText = sanitizeTelegramHtml(effectiveText)
+      }
+    }
   }
 
   // Over-limit pre-check. Throws BEFORE touching stream state so that

--- a/telegram-plugin/tests/html-sanitize.test.ts
+++ b/telegram-plugin/tests/html-sanitize.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Unit tests for the Telegram-HTML sanitizer (issue #657).
+ *
+ * The sanitizer is the pre-validation layer that runs after
+ * markdownToHtml() and before bot.api.sendMessage. Its job is to
+ * guarantee that whatever HTML it emits, Telegram will accept under
+ * parse_mode=HTML — closing the `400 Bad Request: can't parse entities`
+ * loophole that produced the duplicate-message symptom in #657.
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+  sanitizeTelegramHtml,
+  htmlToPlainText,
+  escapeAllHtml,
+} from '../html-sanitize.js'
+
+describe('sanitizeTelegramHtml', () => {
+  it('passes whitelisted tags through unchanged', () => {
+    expect(sanitizeTelegramHtml('<b>bold</b>')).toBe('<b>bold</b>')
+    expect(sanitizeTelegramHtml('<i>italic</i>')).toBe('<i>italic</i>')
+    expect(sanitizeTelegramHtml('<code>x</code>')).toBe('<code>x</code>')
+    expect(sanitizeTelegramHtml('<pre>block</pre>')).toBe('<pre>block</pre>')
+    expect(sanitizeTelegramHtml('<blockquote>q</blockquote>')).toBe('<blockquote>q</blockquote>')
+  })
+
+  it('escapes unknown tags', () => {
+    expect(sanitizeTelegramHtml('<frobnicate>x</frobnicate>')).toBe(
+      '&lt;frobnicate&gt;x&lt;/frobnicate&gt;',
+    )
+    expect(sanitizeTelegramHtml('<div>hi</div>')).toBe('&lt;div&gt;hi&lt;/div&gt;')
+  })
+
+  it('escapes stray < that does not open a tag', () => {
+    expect(sanitizeTelegramHtml('1 < 2 < 3')).toBe('1 &lt; 2 &lt; 3')
+    expect(sanitizeTelegramHtml('a < b')).toBe('a &lt; b')
+  })
+
+  it('auto-closes unclosed whitelisted tags', () => {
+    expect(sanitizeTelegramHtml('<b>unfinished')).toBe('<b>unfinished</b>')
+    expect(sanitizeTelegramHtml('<b><i>nested')).toBe('<b><i>nested</i></b>')
+  })
+
+  it('drops unmatched closing tags', () => {
+    expect(sanitizeTelegramHtml('hello</b>')).toBe('hello')
+    expect(sanitizeTelegramHtml('</i>plain')).toBe('plain')
+  })
+
+  it('auto-closes inner tags when an outer is closed early', () => {
+    // <b><i>x</b>  →  <b><i>x</i></b>
+    const out = sanitizeTelegramHtml('<b><i>x</b>')
+    expect(out).toBe('<b><i>x</i></b>')
+  })
+
+  it('strips disallowed attributes', () => {
+    expect(sanitizeTelegramHtml('<b class="evil" onclick="x()">x</b>')).toBe('<b>x</b>')
+    // <code class> is allowed
+    expect(sanitizeTelegramHtml('<code class="language-ts">x</code>')).toBe(
+      '<code class="language-ts">x</code>',
+    )
+  })
+
+  it('blocks dangerous href schemes', () => {
+    expect(sanitizeTelegramHtml('<a href="javascript:alert(1)">x</a>')).toBe('<a>x</a>')
+    expect(sanitizeTelegramHtml('<a href="data:text/html,x">x</a>')).toBe('<a>x</a>')
+    expect(sanitizeTelegramHtml('<a href="https://example.com">x</a>')).toBe(
+      '<a href="https://example.com">x</a>',
+    )
+  })
+
+  it('escapes naked ampersands but preserves entities', () => {
+    expect(sanitizeTelegramHtml('a & b')).toBe('a &amp; b')
+    expect(sanitizeTelegramHtml('a &amp; b')).toBe('a &amp; b')
+    expect(sanitizeTelegramHtml('a &lt;b&gt;')).toBe('a &lt;b&gt;')
+    expect(sanitizeTelegramHtml('a &#123;')).toBe('a &#123;')
+  })
+
+  it('is idempotent', () => {
+    const fixtures = [
+      '<b>x</b>',
+      '<b><i>nested</i></b>',
+      '<b>unclosed',
+      '<frobnicate>x</frobnicate>',
+      '1 < 2',
+      '<b><i>x</b>',
+      'a & b & c',
+    ]
+    for (const f of fixtures) {
+      const once = sanitizeTelegramHtml(f)
+      const twice = sanitizeTelegramHtml(once)
+      expect(twice).toBe(once)
+    }
+  })
+
+  it('handles the #657 repro fixture (1799-char "Where I route" message shape)', () => {
+    // Reconstruct the structural shape of the body that tripped Telegram.
+    // The exact text isn't checked into the repo; what matters is the
+    // pattern: nested <code> inside <b> inside <pre>, plus a stray `<`
+    // in the middle of the prose, plus an unclosed tag near the end.
+    const fixture = [
+      '<b>Where I route:</b>',
+      '',
+      '<pre><b><code>switchroom &lt;cmd&gt;</code></b></pre>',
+      '',
+      'When the user types `cmd <args>` in the bridge, the gateway forwards…',
+      '',
+      '<b>Some unclosed bold here',
+      '<frobnicate>not a real tag</frobnicate>',
+    ].join('\n')
+
+    const out = sanitizeTelegramHtml(fixture)
+
+    // Must not contain any unknown tag literally.
+    expect(out).not.toMatch(/<frobnicate/)
+    // Stray < (in `cmd <args>`) is escaped.
+    expect(out).toContain('&lt;args&gt;')
+    // The unclosed <b> at end has been auto-closed.
+    const opens = (out.match(/<b\b[^>]*>/g) ?? []).length
+    const closes = (out.match(/<\/b>/g) ?? []).length
+    expect(opens).toBe(closes)
+  })
+
+  it('treats an attribute on a void/unknown tag like any unknown tag', () => {
+    expect(sanitizeTelegramHtml('<img src="x">')).toBe('&lt;img src="x"&gt;')
+  })
+
+  it('preserves blockquote expandable bare attribute', () => {
+    expect(sanitizeTelegramHtml('<blockquote expandable>x</blockquote>')).toBe(
+      '<blockquote expandable>x</blockquote>',
+    )
+  })
+})
+
+describe('htmlToPlainText', () => {
+  it('strips tags and unescapes entities', () => {
+    expect(htmlToPlainText('<b>hi</b>')).toBe('hi')
+    expect(htmlToPlainText('<b>a</b> &lt;b&gt; c')).toBe('a <b> c')
+    expect(htmlToPlainText('a &amp; b')).toBe('a & b')
+  })
+})
+
+describe('escapeAllHtml', () => {
+  it('escapes all three HTML metachars', () => {
+    expect(escapeAllHtml('<b>&hi</b>')).toBe('&lt;b&gt;&amp;hi&lt;/b&gt;')
+  })
+})

--- a/telegram-plugin/tests/status-accent.test.ts
+++ b/telegram-plugin/tests/status-accent.test.ts
@@ -51,7 +51,7 @@ function makeDeps(
 ): StreamReplyDeps {
   return {
     bot,
-    markdownToHtml: (t) => `<html>${t}</html>`,
+    markdownToHtml: (t) => `<b>${t}</b>`,
     escapeMarkdownV2: (t) => `\\${t}\\`,
     repairEscapedWhitespace: (t) => t,
     takeHandoffPrefix: () => '',
@@ -90,7 +90,7 @@ describe('handleStreamReply accent integration', () => {
 
     const sent = bot.api.sendMessage.mock.calls[0][1] as string
     expect(sent).toMatch(/^🔵 <i>In progress…<\/i>\n\n/)
-    expect(sent).toBe('🔵 <i>In progress…</i>\n\n<html>Still working...</html>')
+    expect(sent).toBe('🔵 <i>In progress…</i>\n\n<b>Still working...</b>')
   })
 
   it("accent='done' prepends the checkmark header before the body", async () => {
@@ -106,7 +106,7 @@ describe('handleStreamReply accent integration', () => {
     await pending
 
     const sent = bot.api.sendMessage.mock.calls[0][1] as string
-    expect(sent).toBe('✅ <b>Done</b>\n\n<html>Task complete.</html>')
+    expect(sent).toBe('✅ <b>Done</b>\n\n<b>Task complete.</b>')
   })
 
   it("accent='issue' prepends the warning header before the body", async () => {
@@ -122,7 +122,7 @@ describe('handleStreamReply accent integration', () => {
     await pending
 
     const sent = bot.api.sendMessage.mock.calls[0][1] as string
-    expect(sent).toBe('⚠️ <b>Issue</b>\n\n<html>Blocked on X.</html>')
+    expect(sent).toBe('⚠️ <b>Issue</b>\n\n<b>Blocked on X.</b>')
   })
 
   it('no accent — output is unchanged from today (regression guard)', async () => {
@@ -138,7 +138,7 @@ describe('handleStreamReply accent integration', () => {
     await pending
 
     const sent = bot.api.sendMessage.mock.calls[0][1] as string
-    expect(sent).toBe('<html>Hello world</html>')
+    expect(sent).toBe('<b>Hello world</b>')
   })
 
   it('invalid accent is silently ignored — output equals no-accent path', async () => {
@@ -154,7 +154,7 @@ describe('handleStreamReply accent integration', () => {
     await pending
 
     const sent = bot.api.sendMessage.mock.calls[0][1] as string
-    expect(sent).toBe('<html>Hello world</html>')
+    expect(sent).toBe('<b>Hello world</b>')
   })
 
   it('accent header is included on every call that passes it (full-text replace model)', async () => {
@@ -181,6 +181,6 @@ describe('handleStreamReply accent integration', () => {
     await p2
 
     const edited = bot.api.editMessageText.mock.calls[0][2] as string
-    expect(edited).toBe('🔵 <i>In progress…</i>\n\n<html>Part one Part two</html>')
+    expect(edited).toBe('🔵 <i>In progress…</i>\n\n<b>Part one Part two</b>')
   })
 })

--- a/telegram-plugin/tests/stream-controller-html-fallback.test.ts
+++ b/telegram-plugin/tests/stream-controller-html-fallback.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Integration tests for stream-controller HTML parse-failure fallback
+ * (issue #657).
+ *
+ * Contract:
+ *   - When the FIRST sendMessage with parse_mode=HTML returns
+ *     `400 Bad Request: can't parse entities`, the recovery is a single
+ *     fresh sendMessage with parse_mode stripped — no edit (there is no
+ *     message_id to edit yet). Total outbound: ONE message_id, not two.
+ *   - When a subsequent editMessageText with parse_mode=HTML returns the
+ *     same 400, the recovery is editMessageText AGAIN on the same
+ *     message_id (with parse_mode stripped). Never sendMessage.
+ *
+ * The previous behaviour (the bug #657 fixes) was a duplicate plain-text
+ * sendMessage on every HTML parse rejection — visible to the user as two
+ * messages, one with raw `<b>` tags and one rendered correctly.
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+import { createStreamController } from '../stream-controller.js'
+import { createFakeBotApi, errors } from './fake-bot-api.js'
+
+describe('stream-controller HTML parse-failure fallback (#657)', () => {
+  it('first send: parse-entities 400 → ONE retry without parse_mode, same outbound count', async () => {
+    const bot = createFakeBotApi({ startMessageId: 1000 })
+    // Inject a parse-entities 400 for the first sendMessage. The
+    // controller must catch it and retry with parse_mode stripped.
+    bot.faults.next(
+      'sendMessage',
+      errors.badRequest("can't parse entities: Unsupported start tag \"frobnicate\""),
+    )
+
+    const stream = createStreamController({
+      bot: bot as unknown as { api: ReturnType<typeof createFakeBotApi>['api'] },
+      chatId: 'c1',
+      parseMode: 'HTML',
+      throttleMs: 0,
+    })
+
+    await stream.update('<frobnicate>hello</frobnicate>')
+    await stream.finalize()
+
+    // Exactly one message landed.
+    expect(bot.state.sent).toHaveLength(1)
+    // The recovery send had no parse_mode.
+    expect(bot.state.sent[0].parse_mode).toBeUndefined()
+    // The body was rendered as plain text (tags stripped).
+    expect(bot.state.sent[0].text).toContain('hello')
+    expect(bot.state.sent[0].text).not.toContain('<frobnicate>')
+    // The stream's message id matches the surviving send.
+    expect(stream.getMessageId()).toBe(bot.state.sent[0].message_id)
+  })
+
+  it('edit on existing message: parse-entities 400 → editMessageText retry on SAME id, never sendMessage', async () => {
+    const bot = createFakeBotApi({ startMessageId: 2000 })
+
+    const stream = createStreamController({
+      bot: bot as unknown as { api: ReturnType<typeof createFakeBotApi>['api'] },
+      chatId: 'c1',
+      parseMode: 'HTML',
+      throttleMs: 0,
+    })
+
+    // First update lands cleanly as a sendMessage.
+    await stream.update('<b>v1</b>')
+    expect(bot.state.sent).toHaveLength(1)
+    const firstId = bot.state.sent[0].message_id
+
+    // Second update: inject a parse-entities 400 on editMessageText.
+    bot.faults.next(
+      'editMessageText',
+      errors.badRequest("can't parse entities: Unmatched end tag at byte offset 12"),
+    )
+
+    await stream.update('<b>v2 broken</b><i>extra')
+    await stream.finalize()
+
+    // Critical assertion: still ONE outbound message_id total — the
+    // recovery was an edit on the same id, NOT a fresh send.
+    expect(bot.state.sent).toHaveLength(1)
+    expect(stream.getMessageId()).toBe(firstId)
+
+    // The recovery editMessageText fired on the same id.
+    const editCalls = (bot.api.editMessageText as ReturnType<typeof vi.fn>).mock.calls
+    expect(editCalls.length).toBeGreaterThanOrEqual(2)
+    for (const call of editCalls) {
+      expect(call[1]).toBe(firstId) // same message_id
+    }
+    // The final edit had parse_mode stripped (key absent).
+    const finalCall = editCalls[editCalls.length - 1]
+    expect(finalCall[3].parse_mode).toBeUndefined()
+    // The stored text reflects the plain-text fallback.
+    const finalText = bot.state.currentText.get(firstId)
+    expect(finalText).toBeDefined()
+    expect(finalText).not.toContain('<b>')
+  })
+
+  it('non-parse 400 (e.g. message-not-found) is NOT swallowed by the fallback', async () => {
+    const bot = createFakeBotApi({ startMessageId: 3000 })
+
+    const stream = createStreamController({
+      bot: bot as unknown as { api: ReturnType<typeof createFakeBotApi>['api'] },
+      chatId: 'c1',
+      parseMode: 'HTML',
+      throttleMs: 0,
+    })
+
+    await stream.update('<b>v1</b>')
+    const firstId = bot.state.sent[0].message_id
+
+    // Inject message-not-found on the next edit. This is NOT a parse
+    // error — the existing not-found recovery in draft-stream.ts should
+    // handle it (clear messageId, re-send) and our parse-fallback
+    // wrapper must let it propagate.
+    bot.faults.next('editMessageText', errors.messageToEditNotFound())
+
+    await stream.update('<b>v2</b>')
+    await stream.finalize()
+
+    // The not-found recovery path produces a fresh send — that's the
+    // pre-existing contract. We're asserting it still fires after our
+    // changes (i.e. we didn't accidentally catch this error class too).
+    // After: 1 original send + 1 re-send = 2 messages.
+    expect(bot.state.sent.length).toBeGreaterThanOrEqual(2)
+    expect(bot.state.sent[0].message_id).toBe(firstId)
+  })
+})

--- a/telegram-plugin/tests/stream-reply-handler.test.ts
+++ b/telegram-plugin/tests/stream-reply-handler.test.ts
@@ -32,7 +32,7 @@ function makeDeps(
 ): StreamReplyDeps {
   return {
     bot,
-    markdownToHtml: (t) => `<html>${t}</html>`,
+    markdownToHtml: (t) => `<b>${t}</b>`,
     escapeMarkdownV2: (t) => `\\${t}\\`,
     repairEscapedWhitespace: (t) => t,
     takeHandoffPrefix: () => '',
@@ -68,7 +68,7 @@ describe('handleStreamReply', () => {
     expect(result.status).toBe('updated')
     expect(result.messageId).toBe(500)
     expect(bot.api.sendMessage).toHaveBeenCalledTimes(1)
-    expect(bot.api.sendMessage.mock.calls[0][1]).toBe('<html>hi</html>')
+    expect(bot.api.sendMessage.mock.calls[0][1]).toBe('<b>hi</b>')
     expect(bot.api.sendMessage.mock.calls[0][2]?.parse_mode).toBe('HTML')
     expect(state.activeDraftStreams.size).toBe(1)
   })
@@ -117,14 +117,14 @@ describe('handleStreamReply', () => {
     await p1
     // Prefix is prepended AFTER format rendering (it's already format-safe
     // because takeHandoffPrefix takes the format tag).
-    expect(bot.api.sendMessage.mock.calls[0][1]).toBe('↩️ <html>first</html>')
+    expect(bot.api.sendMessage.mock.calls[0][1]).toBe('↩️ <b>first</b>')
 
     // Second call: handoff not consumed again
     vi.advanceTimersByTime(1000)
     const p2 = handleStreamReply({ chat_id: '1', text: 'second' }, state, deps)
     await microtaskFlush()
     await p2
-    expect(bot.api.editMessageText.mock.calls[0][2]).toBe('<html>second</html>')
+    expect(bot.api.editMessageText.mock.calls[0][2]).toBe('<b>second</b>')
     expect(deps.takeHandoffPrefix).toHaveBeenCalledTimes(1)
   })
 
@@ -341,7 +341,7 @@ describe('handleStreamReply', () => {
     expect(bot.api.sendMessage).toHaveBeenCalledTimes(1)
     expect(bot.api.editMessageText).toHaveBeenCalledTimes(1)
     expect(bot.api.editMessageText.mock.calls[0][1]).toBe(500) // same id
-    expect(bot.api.editMessageText.mock.calls[0][2]).toBe('<html>step 2</html>')
+    expect(bot.api.editMessageText.mock.calls[0][2]).toBe('<b>step 2</b>')
   })
 
   it('passes repairEscapedWhitespace through before rendering', async () => {
@@ -355,7 +355,7 @@ describe('handleStreamReply', () => {
     await pending
 
     // repair happens first; then markdownToHtml wraps the repaired text
-    expect(bot.api.sendMessage.mock.calls[0][1]).toBe('<html>a\nb</html>')
+    expect(bot.api.sendMessage.mock.calls[0][1]).toBe('<b>a\nb</b>')
   })
 
   it('different lanes for same chat produce independent Telegram messages', async () => {
@@ -408,7 +408,7 @@ describe('handleStreamReply', () => {
 
     expect(bot.api.sendMessage).toHaveBeenCalledTimes(1)
     expect(bot.api.editMessageText).toHaveBeenCalledTimes(1)
-    expect(bot.api.editMessageText.mock.calls[0][2]).toBe('<html>step 1 — step 2</html>')
+    expect(bot.api.editMessageText.mock.calls[0][2]).toBe('<b>step 1 — step 2</b>')
   })
 
   it('done=true on one lane does not affect other lanes', async () => {
@@ -477,8 +477,8 @@ describe('handleStreamReply', () => {
     expect(state.activeDraftStreams.has('1:_:progress:1:_:2')).toBe(true)
 
     // Each message carried its own turn's text.
-    expect(bot.api.sendMessage.mock.calls[0][1]).toBe('<html>turn A step 1</html>')
-    expect(bot.api.sendMessage.mock.calls[1][1]).toBe('<html>turn B step 1</html>')
+    expect(bot.api.sendMessage.mock.calls[0][1]).toBe('<b>turn A step 1</b>')
+    expect(bot.api.sendMessage.mock.calls[1][1]).toBe('<b>turn B step 1</b>')
   })
 
   it('subsequent updates with same turnKey reuse the stream (edit in place)', async () => {
@@ -507,7 +507,7 @@ describe('handleStreamReply', () => {
     expect(bot.api.sendMessage).toHaveBeenCalledTimes(1)
     expect(bot.api.editMessageText).toHaveBeenCalledTimes(1)
     expect(bot.api.editMessageText.mock.calls[0][1]).toBe(500)
-    expect(bot.api.editMessageText.mock.calls[0][2]).toBe('<html>A first + second</html>')
+    expect(bot.api.editMessageText.mock.calls[0][2]).toBe('<b>A first + second</b>')
     expect(state.activeDraftStreams.size).toBe(1)
     expect(state.activeDraftStreams.has('1:_:progress:1:_:1')).toBe(true)
   })
@@ -563,8 +563,8 @@ describe('handleStreamReply', () => {
 
     // And each edit carries its own turn's text — no cross-contamination.
     const editTexts = bot.api.editMessageText.mock.calls.map((c) => c[2])
-    expect(editTexts).toContain('<html>A step 1 + 2</html>')
-    expect(editTexts).toContain('<html>B step 1 + 2</html>')
+    expect(editTexts).toContain('<b>A step 1 + 2</b>')
+    expect(editTexts).toContain('<b>B step 1 + 2</b>')
   })
 
   it('done=true on one turnKey does not close the other concurrent turn', async () => {
@@ -849,7 +849,7 @@ describe('handleStreamReply', () => {
       const result = await pending
 
       expect(bot.api.sendMessage).toHaveBeenCalledTimes(1)
-      expect(bot.api.sendMessage.mock.calls[0][1]).toBe('<html>working...</html>')
+      expect(bot.api.sendMessage.mock.calls[0][1]).toBe('<b>working...</b>')
       expect(result.status).toBe('updated')
       // PTY-preview slot is claimed because the model is now the
       // answer-lane surface owner — late PTY partials should defer to
@@ -872,7 +872,7 @@ describe('handleStreamReply', () => {
       const result = await pending
 
       expect(bot.api.sendMessage).toHaveBeenCalledTimes(1)
-      expect(bot.api.sendMessage.mock.calls[0][1]).toBe('<html>final answer</html>')
+      expect(bot.api.sendMessage.mock.calls[0][1]).toBe('<b>final answer</b>')
       expect(result.status).toBe('finalized')
       expect(result.messageId).toBe(500)
     })


### PR DESCRIPTION
## Summary

Closes #657. When `stream_reply` rendered HTML and Telegram rejected `parse_mode=HTML` with `can't parse entities`, the prior path silently sent a fresh plain-text message — leaving the user with two adjacent messages, one with raw `<b>...</b>` tags and one rendered correctly.

Three changes implement the contract from the issue:

- **Edit, never duplicate.** `stream-controller.ts` now catches the parse-entities 400 around both `sendMessage` and `editMessageText`. On a failed edit the recovery is `editMessageText` again on the SAME `message_id` with `parse_mode` stripped and the body tag-stripped to plain text — never a fresh `sendMessage`. Only the very first send (when no `message_id` exists yet) falls back to a single fresh `sendMessage`, which is correct since there is nothing to edit. Non-parse 400s (message-not-found, flood-wait, thread-not-found, etc.) continue to flow through the existing recovery paths unchanged.
- **Pre-validate HTML.** New `telegram-plugin/html-sanitize.ts` runs after `markdownToHtml()` (and again after the status-accent header is prepended) inside `stream-reply-handler.ts`. It enforces Telegram's tag allowlist (`b/strong, i/em, u/ins, s/strike/del, a, code, pre, span, tg-spoiler, tg-emoji, blockquote`), drops disallowed attributes, blocks dangerous `href` schemes, auto-closes unbalanced tags, and is idempotent. Pre-validation makes the fallback path a true last resort rather than the load-bearing case.
- **Verbose Telegram POST logging.** `shared/bot-runtime.ts`'s `tg-post` transformer now emits `code=<error_code>` and `desc=<short>` on failure (PII-safe — body still hashed, descriptions are server-generated and capped at 80 chars), so duplicate-message reports can be correlated against the precise rejection reason without re-running the turn.

The 1799-char clerk fixture (chat 8248703757, msg 9948 + sibling, turnKey 8248703757:14) is captured shape-wise in the unit-test repro in `html-sanitize.test.ts`.

Related (closed) siblings: #656, #546, #549, #654 — same family of duplicate-message symptoms with different RCAs.

## Test plan

- [x] `bun test telegram-plugin/` — 3118 pass, 0 fail
- [x] `tsc --noEmit` clean
- [x] New: 12 unit tests for `sanitizeTelegramHtml` (whitelist, escape, attribute filter, scheme allowlist, auto-close, idempotency, #657 repro fixture)
- [x] New: 3 integration tests for `stream-controller` HTML fallback (first-send 400 → 1 plain send total, edit 400 → editMessageText on same id, non-parse 400 not swallowed)
- [x] Existing: `stream-reply-handler` and `status-accent` test fixtures updated to use whitelisted tag (`<b>` instead of placeholder `<html>`) — sanitizer correctly escapes the latter, which surfaced the test mocks were sending non-Telegram HTML

🤖 Generated with [Claude Code](https://claude.com/claude-code)