### PR TITLE
fix(telegram): unfreeze progress card timer + surface pin failures

### DIFF
--- a/telegram-plugin/progress-card-driver.ts
+++ b/telegram-plugin/progress-card-driver.ts
@@ -2326,6 +2326,7 @@ export function createProgressDriver(config: ProgressDriverConfig): ProgressDriv
       if (target.completionFired) return
       process.stderr.write(`telegram gateway: progress-card: forceCompleteTurn turnKey=${target.turnKey} (external completion signal, e.g. stream_reply done=true)\n`)
       const durationMs = Math.max(0, now() - target.state.turnStartedAt)
+      target.parentTurnEndAt = now()
       target.state = reduce(target.state, { kind: 'turn_end', durationMs }, now())
       target.lastEventAt = now()
       flush(target, /*forceDone*/ true)

--- a/telegram-plugin/progress-card-pin-manager.ts
+++ b/telegram-plugin/progress-card-pin-manager.ts
@@ -345,7 +345,10 @@ export function createPinManager(deps: PinManagerDeps): PinManager {
       .catch(
         (err: Error) => {
           const ms = now() - pinStart
-          log(`telegram gateway: progress-card pin failed turnKey=${turnKey} agentId=${agentId} msgId=${messageId} durationMs=${ms} error="${err?.message ?? err}"\n`)
+          const errMsg = err?.message ?? String(err)
+          const line = `telegram gateway: progress-card pin failed [WARN] chatId=${chatId} msgId=${messageId} turnKey=${turnKey} agentId=${agentId} durationMs=${ms} error="${errMsg}"\n`
+          log(line)
+          process.stderr.write(line)
           // Pin API failed — drop from the in-memory map so a later
           // unpin attempt doesn't fire `deps.unpin` for a message we
           // never actually pinned. Do NOT add to `unpinned` — we never


### PR DESCRIPTION
Fixes #686.

## Summary
- Set `parentTurnEndAt = now()` in `forceCompleteTurn` so the heartbeat's `parentDone` branch fires and the elapsed counter keeps ticking through `subAgentTickIntervalMs` while sub-agents finish in the background. Mirrors the existing `turn_end` path at `progress-card-driver.ts:2191`.
- Promote pin-failure log line to WARN, include `chatId`, `msgId`, `turnKey`, `agentId`, `durationMs`, `error`. Also write to `process.stderr` so failures appear in `journalctl -u switchroom-<agent>` — pin code is unconditional today and any Telegram error was swallowed.

## Test plan
- [x] `npm run build` clean
- [x] `tsc --noEmit` clean
- [x] vitest: `progress-card-pin-manager.test.ts`, `progress-card-driver-eviction.test.ts`, `progress-card-driver-fleet-shadow.test.ts` — 49/49 pass
- [ ] Manual: dispatch background sub-agent fleet, finalize parent turn with `stream_reply done=true`, confirm card shows `⏸ Background` with elapsed counter advancing until fleet drains
- [ ] Manual: trigger a pin failure (e.g. revoke bot pin permission in a group) and confirm WARN line appears in `journalctl`

🤖 Generated with [Claude Code](https://claude.com/claude-code)