### PR TITLE
fix(telegram): flush progress card on SIGTERM (#689)

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -1621,6 +1621,13 @@ let getPinnedProgressCardMessageId: ((turnKey: string, agentId?: string) => numb
 let completeProgressCardTurn:
   | ((args: { chatId: string; threadId: number | undefined; turnKey: string }) => void)
   | null = null
+// #689: SIGTERM-time flush. For each currently-pinned progress card, edit
+// the message body to a "Restart interrupted this work" banner and unpin.
+// Returns when every entry has either resolved or the budget elapses.
+// Set inside startGatewayServer right after pinMgr is created.
+let flushProgressCardsForShutdown:
+  | ((opts: { signal: string; reason?: string; budgetMs: number }) => Promise<void>)
+  | null = null
 let subagentWatcher: SubagentWatcherHandle | null = null
 
 // ─── IPC server ───────────────────────────────────────────────────────────
@@ -8638,6 +8645,10 @@ bot.catch(err => {
 // systemd's TimeoutStopSec is set to 45s in generateGatewayUnit so we
 // have headroom.
 const SHUTDOWN_DRAIN_BUDGET_MS = 35_000
+// #689: time budget for the SIGTERM-time progress-card flush. Sits inside
+// the broader drain budget — if Telegram's API can't ack edits + unpins
+// within this window we log and exit anyway rather than block shutdown.
+const SHUTDOWN_PROGRESS_FLUSH_BUDGET_MS = 1_500
 
 /** Best-effort in-flight counter for the drain loop. Sums the maps that
  * track outstanding side-effects: permission prompts the user hasn't
@@ -8719,6 +8730,30 @@ async function shutdown(signal: string): Promise<void> {
       process.stderr.write(`telegram gateway: shutdown.turn_stamp_failed turnKey=${currentTurnRegistryKey} err=${(err as Error).message}\n`)
     }
     currentTurnRegistryKey = null
+  }
+
+  // #689: flush every pinned progress card with a "Restart interrupted"
+  // banner before drain begins. Bounded by SHUTDOWN_PROGRESS_FLUSH_BUDGET_MS
+  // so a wedged Telegram API can't block shutdown. Reads the same reason
+  // we just stamped into clean-shutdown.json so the banner mirrors the
+  // marker.
+  if (flushProgressCardsForShutdown != null) {
+    let bannerReason: string | undefined
+    try {
+      const m = readCleanShutdownMarker(GATEWAY_CLEAN_SHUTDOWN_MARKER_PATH)
+      if (m?.reason != null && m.reason.length > 0) bannerReason = m.reason
+    } catch {
+      // best-effort — banner just falls back to signal-only
+    }
+    try {
+      await flushProgressCardsForShutdown({
+        signal,
+        ...(bannerReason != null ? { reason: bannerReason } : {}),
+        budgetMs: SHUTDOWN_PROGRESS_FLUSH_BUDGET_MS,
+      })
+    } catch (err) {
+      process.stderr.write(`telegram gateway: shutdown.flush_progress_cards_failed err=${(err as Error).message}\n`)
+    }
   }
 
   // Stop the long-poll health check before draining so it doesn't trigger
@@ -8916,6 +8951,53 @@ if (streamMode === 'checklist') {
       threadId: args.threadId != null ? String(args.threadId) : undefined,
       turnKey: args.turnKey,
     })
+  }
+
+  // #689: flush every pinned progress card with a "Restart interrupted"
+  // banner before shutdown completes. Without this, cards freeze forever
+  // on "Working…" — the gateway re-bootstraps with a fresh turn counter
+  // that can collide with the abandoned turnKey, so the next-boot orphan
+  // sweep can't reliably reattach them either.
+  flushProgressCardsForShutdown = async ({ signal, reason, budgetMs }): Promise<void> => {
+    const entries = pinMgr.pinnedEntries()
+    if (entries.length === 0) return
+    const reasonLine = reason != null && reason.length > 0
+      ? `<i>${escapeHtmlForTg(`${signal}: ${reason}`)}</i>`
+      : `<i>${escapeHtmlForTg(signal)}</i>`
+    const banner = `⚠️ <b>Restart interrupted this work</b>\n${reasonLine}`
+    process.stderr.write(`telegram gateway: shutdown.flush_progress_cards count=${entries.length} signal=${signal}\n`)
+
+    const editOps = entries.map(({ chatId, threadId, turnKey, agentId, messageId }) =>
+      lockedBot.api.editMessageText(chatId, messageId, banner, { parse_mode: 'HTML' })
+        .then(() => {
+          process.stderr.write(`telegram gateway: shutdown.flush_progress_card_edit ok turnKey=${turnKey} agentId=${agentId} msgId=${messageId}\n`)
+        })
+        .catch((err: unknown) => {
+          const msg = err instanceof Error ? err.message : String(err)
+          process.stderr.write(`telegram gateway: shutdown.flush_progress_card_edit failed turnKey=${turnKey} agentId=${agentId} msgId=${messageId} err=${msg}\n`)
+        })
+        .finally(() => {
+          // Unpin regardless of whether the edit succeeded — a stale
+          // pinned card with the old "Working…" body is still better
+          // off unpinned than left frozen.
+          const tid = threadId != null ? Number(threadId) : undefined
+          pinMgr.unpinForChat(chatId, tid)
+        }),
+    )
+
+    let timedOut = false
+    const budget = new Promise<void>((resolve) => {
+      const t = setTimeout(() => { timedOut = true; resolve() }, budgetMs)
+      // unref so the timer alone can't keep the process alive past exit().
+      ;(t as unknown as { unref?: () => void }).unref?.()
+    })
+    await Promise.race([
+      Promise.allSettled(editOps).then(async () => { await pinMgr.drainInFlight() }),
+      budget,
+    ])
+    if (timedOut) {
+      process.stderr.write(`telegram gateway: shutdown.flush_progress_cards budget_exceeded budgetMs=${budgetMs}\n`)
+    }
   }
 
   /**

--- a/telegram-plugin/progress-card-pin-manager.ts
+++ b/telegram-plugin/progress-card-pin-manager.ts
@@ -200,6 +200,20 @@ export interface PinManager {
    */
   pinnedMessageId(turnKey: string, agentId?: string): number | undefined
   /**
+   * Snapshot of every pinned card currently tracked by the manager.
+   * Used by the gateway shutdown path (#689) to render a final
+   * "Restart interrupted" frame on each pinned card and unpin it
+   * synchronously, so cards don't freeze on "Working…" forever after
+   * a SIGTERM mid-turn.
+   */
+  pinnedEntries(): ReadonlyArray<{
+    turnKey: string
+    agentId: string
+    chatId: string
+    threadId?: string
+    messageId: number
+  }>
+  /**
    * Test hook to await all in-flight pin/unpin promises. Production
    * callers don't need this; tests can call it to drain the fire-and-
    * forget `.catch()` chains before asserting on side effects.
@@ -231,6 +245,11 @@ export function createPinManager(deps: PinManagerDeps): PinManager {
   // successful pin call returns; cleared on completeTurn for that
   // composite.
   const pinned = new Map<string, number>()
+  // Parallel to `pinned`: (turnKey, agentId) -> {chatId, threadId?}. Lets
+  // the shutdown flush (#689) reconstruct the chat coordinates without
+  // parsing the turnKey (which is ambiguous when no threadId is present:
+  // `chatId:seq` vs `chatId:threadId:seq`).
+  const pinnedMeta = new Map<string, { chatId: string; threadId?: string }>()
   // (turnKey, agentId) -> pending pin state. Holds the candidate +
   // timer handle while we wait pinDelayMs before actually calling the
   // Telegram pin API. If completeTurn fires before the timer, we cancel
@@ -238,7 +257,7 @@ export function createPinManager(deps: PinManagerDeps): PinManager {
   // fires (moved to `pinned`) or when completeTurn cancels it.
   const pendingPins = new Map<
     string,
-    { chatId: string; messageId: number; turnKey: string; agentId: string; timer: TimerHandle }
+    { chatId: string; threadId?: string; messageId: number; turnKey: string; agentId: string; timer: TimerHandle }
   >()
   // Composite keys whose unpin has already fired. Guards against
   // duplicate completeTurn calls causing a second unpin.
@@ -288,6 +307,7 @@ export function createPinManager(deps: PinManagerDeps): PinManager {
     unpinned.add(key)
     log(`telegram gateway: progress-card: unpin turnKey=${turnKey} agentId=${agentId} msgId=${pinnedId}\n`)
     pinned.delete(key)
+    pinnedMeta.delete(key)
     const svcKey = serviceKey(chatId, pinnedId)
     const svcId = serviceMessages.get(svcKey)
     if (svcId != null) {
@@ -314,7 +334,7 @@ export function createPinManager(deps: PinManagerDeps): PinManager {
     track(p)
   }
 
-  function firePin(turnKey: string, agentId: string, chatId: string, messageId: number): void {
+  function firePin(turnKey: string, agentId: string, chatId: string, threadId: string | undefined, messageId: number): void {
     // Called when the pin-delay timer fires. Promote from pendingPins
     // into pinned, then issue the Telegram pin API call.
     const key = pinKey(turnKey, agentId)
@@ -326,6 +346,7 @@ export function createPinManager(deps: PinManagerDeps): PinManager {
       return
     }
     pinned.set(key, messageId)
+    pinnedMeta.set(key, threadId != null ? { chatId, threadId } : { chatId })
     log(`telegram gateway: progress-card: pinned turnKey=${turnKey} agentId=${agentId} msgId=${messageId}\n`)
     if (deps.addPin) {
       deps.addPin({
@@ -351,6 +372,7 @@ export function createPinManager(deps: PinManagerDeps): PinManager {
           // never actually pinned. Do NOT add to `unpinned` — we never
           // issued an unpin. Sidecar is also cleared for consistency.
           pinned.delete(key)
+          pinnedMeta.delete(key)
           if (deps.removePin) deps.removePin(chatId, messageId)
         },
       )
@@ -371,10 +393,11 @@ export function createPinManager(deps: PinManagerDeps): PinManager {
       // The indirection remains so tests and callers can still override
       // with a positive value if they want a pre-pin visual buffer.
       const timer = scheduleTimer(() => {
-        firePin(c.turnKey, agentId, c.chatId, c.messageId)
+        firePin(c.turnKey, agentId, c.chatId, c.threadId, c.messageId)
       }, pinDelayMs)
       pendingPins.set(key, {
         chatId: c.chatId,
+        ...(c.threadId != null ? { threadId: c.threadId } : {}),
         messageId: c.messageId,
         turnKey: c.turnKey,
         agentId,
@@ -526,6 +549,32 @@ export function createPinManager(deps: PinManagerDeps): PinManager {
 
     pinnedMessageId(turnKey, agentId) {
       return pinned.get(pinKey(turnKey, agentId ?? PARENT_AGENT_ID))
+    },
+
+    pinnedEntries() {
+      const out: Array<{
+        turnKey: string
+        agentId: string
+        chatId: string
+        threadId?: string
+        messageId: number
+      }> = []
+      for (const [key, messageId] of pinned) {
+        const sep = key.lastIndexOf('::')
+        if (sep < 0) continue
+        const turnKey = key.slice(0, sep)
+        const agentId = key.slice(sep + 2)
+        const meta = pinnedMeta.get(key)
+        if (meta == null) continue
+        out.push({
+          turnKey,
+          agentId,
+          chatId: meta.chatId,
+          ...(meta.threadId != null ? { threadId: meta.threadId } : {}),
+          messageId,
+        })
+      }
+      return out
     },
 
     async drainInFlight() {

--- a/telegram-plugin/tests/progress-card-sigterm-pin-flush.test.ts
+++ b/telegram-plugin/tests/progress-card-sigterm-pin-flush.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Regression test for #689 — SIGTERM mid-turn must flush pinned progress
+ * cards with a "Restart interrupted" banner and unpin them, instead of
+ * leaving them frozen on "Working…" forever.
+ *
+ * The full SIGTERM flush logic in gateway.ts is built around a closure
+ * that needs a complete grammY bot harness, so this test exercises the
+ * pieces it composes: `pinManager.pinnedEntries()` (the new
+ * shutdown-introspection API) and `pinManager.unpinForChat()` (the
+ * synchronous unpin path). The gateway's shutdown closure is a trivial
+ * map over `pinnedEntries()` calling `editMessageText` + `unpinForChat`
+ * — covering those two primitives covers the regression.
+ */
+import { describe, it, expect, vi } from 'vitest'
+import {
+  createPinManager,
+  type PinManagerDeps,
+  type TimerHandle,
+} from '../progress-card-pin-manager.js'
+
+interface PendingTimer { fn: () => void; cancelled: boolean; fired: boolean }
+
+function mkHarness(overrides: Partial<PinManagerDeps> = {}) {
+  const timers: PendingTimer[] = []
+  const deps = {
+    pin: vi.fn(async () => true),
+    unpin: vi.fn(async () => true),
+    deleteMessage: vi.fn(async () => true),
+    addPin: vi.fn(),
+    removePin: vi.fn(),
+    log: vi.fn(),
+  }
+  const scheduleTimer = (fn: () => void): TimerHandle => {
+    const entry: PendingTimer = { fn, cancelled: false, fired: false }
+    timers.push(entry)
+    return { cancel() { entry.cancelled = true } }
+  }
+  const mgr = createPinManager({ ...deps, now: () => 10_000, scheduleTimer, ...overrides })
+  const fireTimers = (): void => {
+    for (const t of [...timers]) {
+      if (t.cancelled || t.fired) continue
+      t.fired = true
+      t.fn()
+    }
+  }
+  return { mgr, deps, fireTimers }
+}
+
+describe('SIGTERM mid-turn progress-card flush (#689)', () => {
+  it('pinnedEntries() reports chatId + threadId + messageId for every live pin', async () => {
+    const h = mkHarness()
+    h.mgr.considerPin({
+      chatId: 'chat-A', threadId: '7', turnKey: 'chat-A:7:1',
+      messageId: 101, isFirstEmit: true,
+    })
+    h.mgr.considerPin({
+      chatId: 'chat-B', turnKey: 'chat-B:1',
+      messageId: 202, isFirstEmit: true,
+    })
+    h.fireTimers()
+    await h.mgr.drainInFlight()
+
+    const entries = h.mgr.pinnedEntries()
+    expect(entries).toHaveLength(2)
+    const sorted = [...entries].sort((a, b) => a.messageId - b.messageId)
+    expect(sorted[0]).toMatchObject({
+      chatId: 'chat-A', threadId: '7', turnKey: 'chat-A:7:1',
+      messageId: 101, agentId: '__parent__',
+    })
+    expect(sorted[1]).toMatchObject({
+      chatId: 'chat-B', turnKey: 'chat-B:1',
+      messageId: 202, agentId: '__parent__',
+    })
+    // Threadless pins must not invent a threadId field — the gateway
+    // shutdown closure skips passing message_thread_id when undefined.
+    expect(sorted[1].threadId).toBeUndefined()
+  })
+
+  it('simulated SIGTERM: edit-then-unpin every pinned card with the banner', async () => {
+    const h = mkHarness()
+    h.mgr.considerPin({
+      chatId: 'chat-A', threadId: '7', turnKey: 'chat-A:7:1',
+      messageId: 101, isFirstEmit: true,
+    })
+    h.mgr.considerPin({
+      chatId: 'chat-B', turnKey: 'chat-B:1',
+      messageId: 202, isFirstEmit: true,
+    })
+    h.fireTimers()
+    await h.mgr.drainInFlight()
+
+    // Stand-in for `lockedBot.api.editMessageText`.
+    const editMessageText = vi.fn(async () => true)
+    const banner = '⚠️ <b>Restart interrupted this work</b>\n<i>SIGTERM: update: pulled X</i>'
+
+    const entries = h.mgr.pinnedEntries()
+    const ops = entries.map(({ chatId, threadId, messageId }) =>
+      editMessageText(chatId, messageId, banner, { parse_mode: 'HTML' })
+        .finally(() => {
+          h.mgr.unpinForChat(chatId, threadId != null ? Number(threadId) : undefined)
+        }),
+    )
+    await Promise.allSettled(ops)
+    await h.mgr.drainInFlight()
+
+    // Both cards saw the interrupted-banner edit.
+    expect(editMessageText).toHaveBeenCalledTimes(2)
+    expect(editMessageText).toHaveBeenCalledWith('chat-A', 101, banner, { parse_mode: 'HTML' })
+    expect(editMessageText).toHaveBeenCalledWith('chat-B', 202, banner, { parse_mode: 'HTML' })
+
+    // And both cards were unpinned afterwards.
+    expect(h.deps.unpin).toHaveBeenCalledWith('chat-A', 101)
+    expect(h.deps.unpin).toHaveBeenCalledWith('chat-B', 202)
+    expect(h.mgr.pinnedEntries()).toEqual([])
+    expect(h.mgr.pinnedTurnKeys()).toEqual([])
+  })
+
+  it('unpins even when the banner edit fails (frozen card is worse than no card)', async () => {
+    const h = mkHarness()
+    h.mgr.considerPin({
+      chatId: 'chat-A', threadId: '7', turnKey: 'chat-A:7:1',
+      messageId: 101, isFirstEmit: true,
+    })
+    h.fireTimers()
+    await h.mgr.drainInFlight()
+
+    const editMessageText = vi.fn(async () => {
+      throw new Error('Bad Request: message to edit not found')
+    })
+    const banner = '⚠️ <b>Restart interrupted this work</b>\n<i>SIGTERM</i>'
+
+    const entries = h.mgr.pinnedEntries()
+    const ops = entries.map(({ chatId, threadId, messageId }) =>
+      editMessageText(chatId, messageId, banner, { parse_mode: 'HTML' })
+        .catch(() => {})
+        .finally(() => {
+          h.mgr.unpinForChat(chatId, threadId != null ? Number(threadId) : undefined)
+        }),
+    )
+    await Promise.allSettled(ops)
+    await h.mgr.drainInFlight()
+
+    expect(h.deps.unpin).toHaveBeenCalledWith('chat-A', 101)
+    expect(h.mgr.pinnedEntries()).toEqual([])
+  })
+})


### PR DESCRIPTION
## Summary

- Fix #689: SIGTERM mid-turn left every pinned progress card frozen on `⚙️ Working…` forever because the shutdown path stamped `turns` but never touched pin state. Next-boot turn counter resets to `:1`, so the orphaned key can't be reattached.
- Before drain, iterate `pinMgr.pinnedEntries()` and for each live pin: `editMessageText` with a `⚠️ Restart interrupted this work` banner (subtitle from `clean-shutdown.json` reason) → `unpinForChat`. Bounded by `SHUTDOWN_PROGRESS_FLUSH_BUDGET_MS = 1.5s`; on budget overrun we log and exit anyway.
- New `pinManager.pinnedEntries()` API returning `{turnKey, agentId, chatId, threadId?, messageId}`. Backed by a parallel `pinnedMeta` map populated at `firePin` (parsing `chatId` from a turnKey is ambiguous: `chatId:seq` vs `chatId:threadId:seq`).

## What I changed

- `telegram-plugin/progress-card-pin-manager.ts` — new `pinnedEntries()`, threadId threaded through `pendingPins`/`firePin`, parallel `pinnedMeta` map.
- `telegram-plugin/gateway/gateway.ts` — new `flushProgressCardsForShutdown` closure wired in `shutdown()` before `pollHealthCheck.stop()`. Reads `clean-shutdown.json` for the banner subtitle.
- `telegram-plugin/tests/progress-card-sigterm-pin-flush.test.ts` — new regression covering `pinnedEntries()` shape, the simulated SIGTERM edit-then-unpin loop, and the failure path (edit fails → still unpin).

Composes with PR #687 — that one fixed the in-process freeze inside `forceCompleteTurn` by setting `parentTurnEndAt` before the reducer; this PR addresses the dies-mid-turn case where the reducer never runs at all.

## Test plan

- [x] `npx vitest run telegram-plugin/tests/progress-card-sigterm-pin-flush.test.ts telegram-plugin/tests/progress-card-pin-manager.test.ts` → 45 passed (3 new + 42 existing pin-manager tests still green)
- [x] `npm run lint:tsc` → clean
- [x] `npm test` → 4664 passed; 6 pre-existing failures in `tests/bridge-watchdog.test.ts` confirmed present on `origin/main` (unrelated)
- [ ] Manual smoke: trigger a fake SIGTERM mid-turn against a real bot, confirm the pinned card swaps to the banner text and unpins. Operator validation step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)