### PR TITLE
fix(telegram): boot-time orphan progress card reaper (#689)

### DIFF
--- a/telegram-plugin/active-pins-sweep.ts
+++ b/telegram-plugin/active-pins-sweep.ts
@@ -26,12 +26,28 @@
 import { readActivePins, clearActivePins, type ActivePin } from "./active-pins.js";
 
 export type UnpinFn = (chatId: string, messageId: number) => Promise<unknown>;
+/**
+ * Optional pre-unpin hook. Called once per sidecar entry before the
+ * unpin fires. Used by the boot-time orphan-pin reaper (#689) to edit
+ * the message body to a "Restart interrupted this work" banner, so the
+ * user sees WHY the card stopped updating rather than silently losing
+ * the pin.
+ *
+ * Hook errors are logged and swallowed: a banner edit failing must
+ * never block the unpin (frozen card is worse than no card).
+ */
+export type EditBeforeUnpinFn = (pin: ActivePin) => Promise<unknown>;
 
 export interface SweepOptions {
   /** Upper bound on how long to wait for all unpin calls before returning. */
   timeoutMs?: number;
   /** Optional log hook — called with human-readable progress/error lines. */
   log?: (msg: string) => void;
+  /**
+   * Optional per-pin edit hook fired BEFORE the unpin. Failures are
+   * caught and logged; the unpin still runs. See {@link EditBeforeUnpinFn}.
+   */
+  editBeforeUnpin?: EditBeforeUnpinFn;
 }
 
 export interface SweepResult {
@@ -57,9 +73,22 @@ export async function sweepActivePins(
   if (pins.length === 0) return { swept: [], timedOut: false };
 
   log(`sweeping ${pins.length} active pin(s)`);
+  const editBeforeUnpin = options.editBeforeUnpin;
   const attempts = pins.map((pin) =>
     Promise.resolve()
-      .then(() => unpin(pin.chatId, pin.messageId))
+      .then(async () => {
+        if (editBeforeUnpin != null) {
+          try {
+            await editBeforeUnpin(pin);
+          } catch (err) {
+            // Banner edits are best-effort — message may already be gone
+            // or the bot may have lost edit rights. Don't block unpin.
+            const msg = err instanceof Error ? err.message : String(err);
+            log(`banner edit failed for ${pin.chatId}/${pin.messageId}: ${msg}`);
+          }
+        }
+        return unpin(pin.chatId, pin.messageId);
+      })
       .catch((err: unknown) => {
         const msg = err instanceof Error ? err.message : String(err);
         log(`unpin failed for ${pin.chatId}/${pin.messageId}: ${msg}`);

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -8879,10 +8879,37 @@ process.on('SIGINT', () => void shutdown('SIGINT'))
 if (streamMode === 'checklist') {
   const startupAgentDir = resolveAgentDirFromEnv()
   if (startupAgentDir != null) {
+    // #689: boot-time orphan-pin reaper. Backstop for SIGKILL/OOM/panic
+    // where the SIGTERM handler (PR #690) never ran. For each pin still
+    // recorded in the sidecar, edit the message body to a "Restart
+    // interrupted this work" banner BEFORE unpinning so the user sees
+    // why the card stopped updating instead of a silent disappearance.
+    //
+    // Banner subtitle is sourced from clean-shutdown.json when fresh
+    // (<CLEAN_SHUTDOWN_MAX_AGE_MS) — for an OOM/panic that wrote no
+    // marker, we fall back to a generic "previous process exited
+    // unexpectedly" line. The sweep is bounded by ~5s so a wedged
+    // Telegram API can't block boot.
+    const cleanMarker = readCleanShutdownMarker(GATEWAY_CLEAN_SHUTDOWN_MARKER_PATH)
+    const markerFresh =
+      cleanMarker != null && Date.now() - cleanMarker.ts < CLEAN_SHUTDOWN_MAX_AGE_MS
+    const subtitle =
+      markerFresh && cleanMarker?.reason != null && cleanMarker.reason.length > 0
+        ? `${cleanMarker.signal}: ${cleanMarker.reason}`
+        : markerFresh && cleanMarker != null
+          ? cleanMarker.signal
+          : 'previous process exited unexpectedly'
+    const banner = `⚠️ <b>Restart interrupted this work</b>\n<i>${escapeHtmlForTg(subtitle)}</i>`
     void sweepActivePins(
       startupAgentDir,
       (chatId, messageId) => lockedBot.api.unpinChatMessage(chatId, messageId),
-      { log: (msg) => process.stderr.write(`telegram gateway: startup pin sweep — ${msg}\n`) },
+      {
+        log: (msg) => process.stderr.write(`telegram gateway: startup pin sweep — ${msg}\n`),
+        timeoutMs: 5_000,
+        editBeforeUnpin: async (pin) => {
+          await lockedBot.api.editMessageText(pin.chatId, pin.messageId, banner, { parse_mode: 'HTML' })
+        },
+      },
     )
   }
 

--- a/telegram-plugin/tests/active-pins-boot-reaper.test.ts
+++ b/telegram-plugin/tests/active-pins-boot-reaper.test.ts
@@ -1,0 +1,211 @@
+/**
+ * Regression test for #689 — boot-time orphan-pin reaper.
+ *
+ * Backstop for SIGKILL/OOM/panic where the SIGTERM handler (PR #690)
+ * never ran. PR #690 covers clean shutdowns: it walks `pinnedEntries()`
+ * in-memory before the process exits. But on a hard kill the in-memory
+ * map dies with the process, so the next boot must rely on the disk
+ * sidecar (`active-pins.ts`) to find the orphans and finalize them.
+ *
+ * Shape under test (the new `editBeforeUnpin` hook on `sweepActivePins`):
+ *
+ *   1. Pin lifecycle records to sidecar (already covered by
+ *      active-pins.test.ts) — we just simulate "process died with
+ *      sidecar populated" by calling `addActivePin` directly.
+ *   2. On next boot, `sweepActivePins` is invoked with an
+ *      `editBeforeUnpin` callback that renders the banner.
+ *   3. Each entry: editFn runs first; unpin runs after; sidecar gets
+ *      cleared.
+ *   4. Banner edit failure (e.g. "message to edit not found") is caught
+ *      and the unpin still fires — frozen card is worse than no card.
+ *   5. Clean-shutdown unpin path (via pinManager.completeTurn) removes
+ *      the sidecar entry, so a clean shutdown leaves nothing for the
+ *      reaper to find — only crashes leave entries behind.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { mkdtempSync, rmSync, existsSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  addActivePin,
+  readActivePins,
+  writeActivePins,
+  ACTIVE_PINS_FILENAME,
+  type ActivePin,
+} from '../active-pins.js'
+import { sweepActivePins } from '../active-pins-sweep.js'
+import {
+  createPinManager,
+  type PinManagerDeps,
+  type TimerHandle,
+} from '../progress-card-pin-manager.js'
+
+interface PendingTimer { fn: () => void; cancelled: boolean; fired: boolean }
+
+function mkPinManagerHarness(overrides: Partial<PinManagerDeps> = {}) {
+  const timers: PendingTimer[] = []
+  const deps = {
+    pin: vi.fn(async () => true),
+    unpin: vi.fn(async () => true),
+    deleteMessage: vi.fn(async () => true),
+    addPin: vi.fn(),
+    removePin: vi.fn(),
+    log: vi.fn(),
+  }
+  const scheduleTimer = (fn: () => void): TimerHandle => {
+    const entry: PendingTimer = { fn, cancelled: false, fired: false }
+    timers.push(entry)
+    return { cancel() { entry.cancelled = true } }
+  }
+  const mgr = createPinManager({ ...deps, now: () => 10_000, scheduleTimer, ...overrides })
+  const fireTimers = (): void => {
+    for (const t of [...timers]) {
+      if (t.cancelled || t.fired) continue
+      t.fired = true
+      t.fn()
+    }
+  }
+  return { mgr, deps, fireTimers }
+}
+
+describe('boot-time orphan-pin reaper (#689)', () => {
+  let tmp: string
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), 'pin-reaper-'))
+  })
+
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true })
+  })
+
+  const makePin = (overrides: Partial<ActivePin> = {}): ActivePin => ({
+    chatId: '100',
+    messageId: 42,
+    turnKey: '100:0:1',
+    pinnedAt: 1_700_000_000_000,
+    agentId: '__parent__',
+    ...overrides,
+  })
+
+  it('hard-kill mid-turn: next boot sees the sidecar entry, edits banner, then unpins', async () => {
+    // Simulate: prior process pinned but never got to unpin (SIGKILL/OOM).
+    addActivePin(tmp, makePin({ chatId: 'A', messageId: 101 }))
+    addActivePin(tmp, makePin({ chatId: 'B', messageId: 202, turnKey: 'B:0:1' }))
+
+    // Now boot: invoke the reaper.
+    const editCalls: Array<{ chatId: string; messageId: number; banner: string }> = []
+    const unpinCalls: Array<[string, number]> = []
+    const banner = '⚠️ <b>Restart interrupted this work</b>\n<i>SIGKILL: oom</i>'
+
+    const result = await sweepActivePins(
+      tmp,
+      async (chatId, messageId) => { unpinCalls.push([chatId, messageId]) },
+      {
+        editBeforeUnpin: async (pin) => {
+          editCalls.push({ chatId: pin.chatId, messageId: pin.messageId, banner })
+        },
+      },
+    )
+
+    // Both pins were edited THEN unpinned.
+    expect(editCalls.sort((a, b) => a.messageId - b.messageId)).toEqual([
+      { chatId: 'A', messageId: 101, banner },
+      { chatId: 'B', messageId: 202, banner },
+    ])
+    expect(unpinCalls.sort()).toEqual([['A', 101], ['B', 202]])
+    expect(result.swept).toHaveLength(2)
+    expect(existsSync(join(tmp, ACTIVE_PINS_FILENAME))).toBe(false)
+  })
+
+  it('banner edit failure does not block the unpin (frozen card is worse than no card)', async () => {
+    addActivePin(tmp, makePin({ chatId: 'A', messageId: 101 }))
+
+    const unpinCalls: Array<[string, number]> = []
+    const result = await sweepActivePins(
+      tmp,
+      async (chatId, messageId) => { unpinCalls.push([chatId, messageId]) },
+      {
+        editBeforeUnpin: async () => {
+          throw new Error('Bad Request: message to edit not found')
+        },
+      },
+    )
+
+    expect(unpinCalls).toEqual([['A', 101]])
+    expect(result.swept).toHaveLength(1)
+    expect(existsSync(join(tmp, ACTIVE_PINS_FILENAME))).toBe(false)
+  })
+
+  it('edit fires BEFORE unpin (ordering matters — never unpin a card with stale Working… body)', async () => {
+    addActivePin(tmp, makePin({ chatId: 'A', messageId: 101 }))
+
+    const order: string[] = []
+    await sweepActivePins(
+      tmp,
+      async () => { order.push('unpin') },
+      {
+        editBeforeUnpin: async () => { order.push('edit') },
+      },
+    )
+
+    expect(order).toEqual(['edit', 'unpin'])
+  })
+
+  it('clean unpin path removes sidecar entry, leaving nothing for the reaper', async () => {
+    // Simulate the pinManager addPin/removePin sidecar wiring used in
+    // gateway.ts: addPin appends to disk, removePin filters out.
+    const h = mkPinManagerHarness({
+      addPin: (entry) => addActivePin(tmp, entry),
+      removePin: (chatId, messageId) => {
+        const next = readActivePins(tmp).filter(
+          (p) => !(p.chatId === chatId && p.messageId === messageId),
+        )
+        writeActivePins(tmp, next)
+      },
+    })
+
+    // Pin
+    h.mgr.considerPin({
+      chatId: 'A', threadId: '7', turnKey: 'A:7:1',
+      messageId: 101, isFirstEmit: true,
+    })
+    h.fireTimers()
+    await h.mgr.drainInFlight()
+    expect(readActivePins(tmp)).toHaveLength(1)
+
+    // Clean unpin (e.g. via completeTurn at end of turn)
+    h.mgr.completeTurn({ chatId: 'A', threadId: '7', turnKey: 'A:7:1' })
+    await h.mgr.drainInFlight()
+
+    // Sidecar is empty — the boot reaper would find nothing.
+    expect(readActivePins(tmp)).toEqual([])
+
+    // And confirm the reaper would no-op:
+    const editCalls: ActivePin[] = []
+    const result = await sweepActivePins(
+      tmp,
+      async () => {},
+      { editBeforeUnpin: async (p) => { editCalls.push(p) } },
+    )
+    expect(editCalls).toEqual([])
+    expect(result.swept).toEqual([])
+  })
+
+  it('respects the timeout budget when banner edits hang', async () => {
+    addActivePin(tmp, makePin({ chatId: 'A', messageId: 101 }))
+
+    const result = await sweepActivePins(
+      tmp,
+      async () => {},
+      {
+        timeoutMs: 50,
+        editBeforeUnpin: () => new Promise(() => {}), // never resolves
+      },
+    )
+
+    expect(result.timedOut).toBe(true)
+    // Sidecar still cleared — Telegram unpin is idempotent.
+    expect(existsSync(join(tmp, ACTIVE_PINS_FILENAME))).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary

Backstop for SIGKILL/OOM/panic where the SIGTERM handler from #690 never runs. On those paths, the in-memory pin map dies with the process, the SIGTERM-time flush doesn't fire, and pinned cards stay frozen on \"Working…\" forever.

The disk sidecar (`active-pins.ts`) already records every pinned card; what was missing was a banner edit on the existing boot-time `sweepActivePins` so the user sees WHY the card stopped updating rather than a silent unpin.

## What I changed

- `telegram-plugin/active-pins-sweep.ts` — new optional `editBeforeUnpin` hook on `SweepOptions`, fired per pin before the unpin. Hook errors are caught and logged — frozen card is worse than no card, so the unpin always runs.
- `telegram-plugin/gateway/gateway.ts` — boot sweep call now passes `editBeforeUnpin` that renders a `⚠️ Restart interrupted this work` banner with subtitle sourced from `clean-shutdown.json` when fresh (under `CLEAN_SHUTDOWN_MAX_AGE_MS`), falling back to `previous process exited unexpectedly` for true crashes that wrote no marker. Bounded by `timeoutMs: 5_000`.
- `telegram-plugin/tests/active-pins-boot-reaper.test.ts` — new regression covering: hard-kill → next-boot edit-then-unpin; banner edit failure still unpins; edit-before-unpin ordering; clean-unpin path leaves sidecar empty (so reaper finds nothing); timeout budget honored.

## Composition with #690

#690 covers clean shutdowns: walks `pinnedEntries()` in-memory before exit. This PR covers everything else (SIGKILL/OOM/panic). The two compose because clean shutdowns also clear the sidecar via `pinManager.completeTurn → doUnpin → removePin`, so a clean exit leaves the sidecar empty and the boot reaper finds nothing.

## Test plan

- [x] `npx vitest run tests/active-pins-boot-reaper.test.ts tests/active-pins-sweep.test.ts tests/progress-card-sigterm-pin-flush.test.ts tests/progress-card-pin-manager.test.ts` → 65 passed
- [x] `npm run lint:tsc` → clean
- [x] `npm test` → 4637 passed (5 new), 39 pre-existing failures in cli.issues / run-hook / boot-self-test / bridge-watchdog all confirmed present on `upstream/main` (same exact set; cli.issues/run-hook/boot-self-test all need a built `dist/cli/switchroom.js`; bridge-watchdog noted as pre-existing in #690).
- [ ] Manual smoke: kill -9 the gateway mid-turn, restart, confirm pinned card edits to the banner and unpins. Operator validation step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)