### PR TITLE
test: isolate bridge-watchdog test harness from real HOME (#691)

### DIFF
--- a/tests/bridge-watchdog.test.ts
+++ b/tests/bridge-watchdog.test.ts
@@ -384,8 +384,14 @@ function runWatchdog(
   const opts: ExecFileSyncOptions = {
     env: {
       PATH: `${h.binDir}:/usr/bin:/bin`,
-      // HOME and USER sometimes matter for bash shell init.
-      HOME: process.env.HOME ?? "/tmp",
+      // Isolate HOME to the per-test tmpdir so the progress gate added in
+      // PR #557 (agent_progress_snapshot reads
+      // ${HOME}/.switchroom/agents/${name}/.claude/{projects,tasks}) does
+      // NOT see live JSONL from the real agent running on the dev host.
+      // Without this, every test on the dev box would log
+      // `decision=defer-progress-fresh` against the running klanker agent
+      // and skip the restart we're asserting on. See switchroom#691.
+      HOME: h.root,
       USER: process.env.USER ?? "nobody",
       WATCHDOG_STATE_DIR: wdState,
       ...env,


### PR DESCRIPTION
## Summary

Fixes #691. Six behavioural tests in `tests/bridge-watchdog.test.ts` were silently failing on `main` because the harness passed real `process.env.HOME` plus agent name `klanker` — the live agent on the dev host. PR #557's progress gate (`agent_progress_snapshot` reading `${HOME}/.switchroom/agents/${name}/.claude/{projects,tasks}`) saw `jsonl_age=0s` from the running agent and logged `decision=defer-progress-fresh` instead of restarting.

Production behaviour is correct; the tests were wrong. Fix is one-line: set `HOME=h.root` (per-test tmpdir) in the watchdog runner env. The agent-progress tree doesn't exist under the tmpdir, so `agent_has_recent_progress` returns false and the assertions land.

## Notes

- All 37 tests in `bridge-watchdog.test.ts` now pass (was 6 fail / 31 pass).
- File is already auto-discovered by `vitest run` via the default `tests/**/*.test.ts` glob — no `package.json` change needed. Confirmed by running the full vitest suite and counting 37 bridge-watchdog tests executing.
- Other 33 vitest failures on main (`tests/cli.issues.test.ts`, `tests/boot-self-test.test.ts`, `tests/cli.memory.demote.test.ts`, `tests/run-hook.test.ts`) pre-exist this branch and are unrelated.

## Test plan

- [x] npx vitest run tests/bridge-watchdog.test.ts — 37/37 pass
- [x] Full npx vitest run — no new regressions; pre-existing failures unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)