### PR TITLE
fix(auth): enable preserves existing primary, doesn't hot-swap active

### DIFF
--- a/src/cli/auth-accounts.ts
+++ b/src/cli/auth-accounts.ts
@@ -67,6 +67,43 @@ export function registerAuthAccountSubcommands(
   registerRefreshAccounts(authParent, program);
 }
 
+/* ── helpers: per-agent primary-preserving fanout grouping ──────────── */
+
+/**
+ * Group a list of agents by the account label that should be fanned
+ * out to each — namely the FIRST entry in each agent's
+ * `auth.accounts:` list (the primary). Used by `auth enable` so a new
+ * account added as a fallback doesn't overwrite the existing
+ * primary's runtime fanout.
+ *
+ * Pure function: takes the post-mutation YAML text and the list of
+ * agents being enabled, returns a Map<primaryLabel, agents[]>. Caller
+ * iterates and calls `fanoutAccountToAgents(primaryLabel, agents)`
+ * once per group.
+ *
+ * Defensive fallback: if an agent's account list is somehow empty
+ * post-append (shouldn't happen — `appendAccountToAgent` always
+ * leaves at least the just-added label), the agent gets grouped
+ * under `defaultLabel` so the fanout still authenticates it.
+ *
+ * Exported for unit testing.
+ */
+export function groupAgentsByPrimaryAccount(
+  yamlText: string,
+  agents: ReadonlyArray<string>,
+  defaultLabel: string,
+): Map<string, string[]> {
+  const out = new Map<string, string[]>();
+  for (const name of agents) {
+    const list = getAccountsForAgent(yamlText, name);
+    const primary = list[0] ?? defaultLabel;
+    const arr = out.get(primary) ?? [];
+    arr.push(name);
+    out.set(primary, arr);
+  }
+  return out;
+}
+
 /* ── helpers: `all` agent expansion ──────────────────────────────────── */
 
 /**
@@ -474,13 +511,58 @@ function registerEnable(authParent: Command, program: Command): void {
           writeFileSync(yamlPath, after);
         }
 
-        // Immediate fanout — don't wait for the next refresh tick to push
-        // credentials into the just-enabled agents' .claude/ dirs.
-        const targets = agents.map((name) => ({
-          name,
-          agentDir: resolve(agentsDir, name),
-        }));
-        const outcomes = fanoutAccountToAgents(label, targets);
+        // Per-agent immediate fanout — preserve the YAML-list primary
+        // as the active fanout. The first entry in `auth.accounts:` is
+        // the agent's preferred (primary) account; subsequent entries
+        // are failover targets. `appendAccountToAgent` always appends,
+        // so the existing primary stays first when this enable adds a
+        // fallback. We therefore fan whatever the post-mutation first
+        // entry is on each agent — which is:
+        //   - the existing primary (when this enable adds a fallback)
+        //   - the just-enabled account (when this is the agent's first
+        //     account, i.e. fresh-fleet bootstrap)
+        // Result: enabling a fallback no longer hot-swaps the runtime
+        // active credentials. Fixes the polish gap discovered while
+        // wiring `me@kenthompson.com.au` and `ken.thompson@outlook.com.au`
+        // alongside `pixsoul@gmail.com` — `enable` of either fallback
+        // was overwriting the active fanout with the new account's
+        // creds, leaking primary→fallback under the operator's feet.
+        //
+        // Group agents by the label that should be fanned to them so
+        // we still call `fanoutAccountToAgents` once per label rather
+        // than once per agent. See `groupAgentsByPrimaryAccount` for
+        // the pure-function explanation.
+        const groups = groupAgentsByPrimaryAccount(after, agents, label);
+        type FanTarget = { name: string; agentDir: string };
+        const fanoutByLabel = new Map<string, FanTarget[]>();
+        for (const [primary, names] of groups) {
+          fanoutByLabel.set(
+            primary,
+            names.map((name) => ({
+              name,
+              agentDir: resolve(agentsDir, name),
+            })),
+          );
+        }
+        const allOutcomes: Array<{
+          kind: string;
+          agent: string;
+          fannedLabel: string;
+          error?: string;
+        }> = [];
+        for (const [fanLabel, fanTargets] of fanoutByLabel) {
+          const out = fanoutAccountToAgents(fanLabel, fanTargets);
+          for (const o of out) {
+            allOutcomes.push({
+              kind: o.kind,
+              agent: o.agent,
+              fannedLabel: fanLabel,
+              ...((o as { error?: string }).error
+                ? { error: (o as { error?: string }).error }
+                : {}),
+            });
+          }
+        }
 
         console.log();
         if (changed.length === 0) {
@@ -492,24 +574,53 @@ function registerEnable(authParent: Command, program: Command): void {
             `${chalk.green("✓")} Enabled ${chalk.bold(label)} on: ${changed.join(", ")}`,
           );
         }
-        const fanned = outcomes
-          .filter((o) => o.kind === "fanned-out")
+        // Distinguish "now active" (just-enabled label became the
+        // agent's primary because there was nothing earlier in the
+        // list) from "added as fallback" (existing primary preserved,
+        // no runtime change). The two paths have different restart
+        // semantics — a fallback add doesn't need a restart at all.
+        const fannedAsPrimary = allOutcomes
+          .filter((o) => o.kind === "fanned-out" && o.fannedLabel === label)
           .map((o) => o.agent);
-        const fanFails = outcomes.filter((o) => o.kind === "fanout-failed");
-        if (fanned.length > 0) {
-          console.log(`  Credentials fanned out to: ${fanned.join(", ")}`);
+        const fannedPreservingPrimary = allOutcomes
+          .filter((o) => o.kind === "fanned-out" && o.fannedLabel !== label)
+          .map((o) => ({ agent: o.agent, primary: o.fannedLabel }));
+        const fanFails = allOutcomes.filter((o) => o.kind === "fanout-failed");
+        if (fannedAsPrimary.length > 0) {
+          console.log(
+            `  Credentials fanned out (now active) to: ${fannedAsPrimary.join(", ")}`,
+          );
         }
-        for (const f of fanFails) {
-          if (f.kind === "fanout-failed") {
+        if (fannedPreservingPrimary.length > 0) {
+          const byPrimary = new Map<string, string[]>();
+          for (const { agent, primary } of fannedPreservingPrimary) {
+            const arr = byPrimary.get(primary) ?? [];
+            arr.push(agent);
+            byPrimary.set(primary, arr);
+          }
+          for (const [primary, ags] of byPrimary) {
             console.log(
-              chalk.yellow(`  ⚠ Fanout failed for ${f.agent}: ${f.error}`),
+              `  Added as fallback (active stays ${chalk.bold(primary)}) on: ${ags.join(", ")}`,
             );
           }
         }
+        for (const f of fanFails) {
+          console.log(
+            chalk.yellow(`  ⚠ Fanout failed for ${f.agent}${f.error ? ": " + f.error : ""}`),
+          );
+        }
         console.log();
-        console.log(
-          `Next: 'switchroom agent restart ${agents.join(" ")}' to load the new credentials.`,
-        );
+        // Restart hint only meaningful when runtime creds actually
+        // changed. Pure-fallback adds don't need a restart.
+        if (fannedAsPrimary.length > 0) {
+          console.log(
+            `Next: 'switchroom agent restart ${fannedAsPrimary.join(" ")}' to load the new credentials.`,
+          );
+        } else if (changed.length > 0) {
+          console.log(
+            `No restart needed — ${chalk.bold(label)} is wired as a fallback; runtime active stays the same.`,
+          );
+        }
         console.log();
       }),
     );

--- a/tests/auth-enable-preserve-primary.test.ts
+++ b/tests/auth-enable-preserve-primary.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Unit tests for the per-agent primary-preserving fanout helper used by
+ * `switchroom auth enable`. Polish for the bug discovered while wiring
+ * three accounts onto every agent — each `enable` was overwriting the
+ * runtime active credentials with the just-added account, even when the
+ * existing primary should have remained active.
+ *
+ * The fix: `enable` appends to `auth.accounts:` (the YAML-list head is
+ * the primary, fallbacks follow) and fans out whatever the post-append
+ * FIRST entry is — i.e. the existing primary when adding a fallback,
+ * the just-added label when this is the agent's first account.
+ */
+
+import { describe, it, expect } from "vitest";
+import { groupAgentsByPrimaryAccount } from "../src/cli/auth-accounts.js";
+import { appendAccountToAgent } from "../src/cli/auth-accounts-yaml.js";
+
+const baseYaml = `
+version: 1
+agents:
+  fresh:
+    topic_name: Fresh
+  primary-set:
+    topic_name: Existing
+    auth:
+      accounts: [pixsoul@gmail.com]
+  multi:
+    topic_name: Multi
+    auth:
+      accounts: [pixsoul@gmail.com, me@kenthompson.com.au]
+`;
+
+describe("groupAgentsByPrimaryAccount", () => {
+  it("returns empty map when no agents are passed", () => {
+    expect(groupAgentsByPrimaryAccount(baseYaml, [], "fallback")).toEqual(
+      new Map(),
+    );
+  });
+
+  it("groups a single agent with no existing accounts under the new label", () => {
+    const yaml = appendAccountToAgent(baseYaml, "fresh", "new@example.com");
+    const groups = groupAgentsByPrimaryAccount(
+      yaml,
+      ["fresh"],
+      "new@example.com",
+    );
+    expect(groups.size).toBe(1);
+    expect(groups.get("new@example.com")).toEqual(["fresh"]);
+  });
+
+  it("groups a single agent with existing primary under the EXISTING primary, not the new label", () => {
+    // Operator runs `auth enable me@kenthompson.com.au primary-set` —
+    // primary-set already has pixsoul@gmail.com first. The fix means
+    // we fan out pixsoul (preserve), not me@kenthompson (the new
+    // fallback). primary-set's runtime active stays on pixsoul.
+    const yaml = appendAccountToAgent(
+      baseYaml,
+      "primary-set",
+      "me@kenthompson.com.au",
+    );
+    const groups = groupAgentsByPrimaryAccount(
+      yaml,
+      ["primary-set"],
+      "me@kenthompson.com.au",
+    );
+    expect(groups.size).toBe(1);
+    expect(groups.get("pixsoul@gmail.com")).toEqual(["primary-set"]);
+    expect(groups.get("me@kenthompson.com.au")).toBeUndefined();
+  });
+
+  it("groups multi-agent enable correctly: each agent gets its own primary", () => {
+    // Operator runs `auth enable new@example.com fresh primary-set
+    // multi` (or the `all` keyword). Three distinct outcomes:
+    //   - fresh has no accounts pre-append → new@example.com is primary
+    //   - primary-set has pixsoul → pixsoul stays primary, new@ is
+    //     fallback
+    //   - multi already has pixsoul + me@ → pixsoul stays primary, new@
+    //     becomes a third fallback
+    let yaml = baseYaml;
+    yaml = appendAccountToAgent(yaml, "fresh", "new@example.com");
+    yaml = appendAccountToAgent(yaml, "primary-set", "new@example.com");
+    yaml = appendAccountToAgent(yaml, "multi", "new@example.com");
+
+    const groups = groupAgentsByPrimaryAccount(
+      yaml,
+      ["fresh", "primary-set", "multi"],
+      "new@example.com",
+    );
+
+    expect(groups.size).toBe(2);
+    expect(groups.get("new@example.com")).toEqual(["fresh"]);
+    // Both pre-existing-primary agents share pixsoul as their primary.
+    expect(groups.get("pixsoul@gmail.com")?.sort()).toEqual([
+      "multi",
+      "primary-set",
+    ]);
+  });
+
+  it("falls back to defaultLabel when an agent's account list is somehow empty post-append", () => {
+    // Defensive — `appendAccountToAgent` always leaves at least the
+    // just-added label, so this is the "yaml mutation lost the entry"
+    // failure mode. Should never regress to leaving the agent
+    // unauthenticated; falling back to the just-enabled label is the
+    // safe choice.
+    const groups = groupAgentsByPrimaryAccount(
+      baseYaml, // unmutated — `fresh` has no auth.accounts yet
+      ["fresh"],
+      "new@example.com",
+    );
+    expect(groups.get("new@example.com")).toEqual(["fresh"]);
+  });
+
+  it("preserves spawn order within a primary group", () => {
+    // The fanout helper later iterates this list to call
+    // `agent restart` — order matters for the operator-visible
+    // restart sequence (rolling-restart settle gate considers each
+    // in turn). Pin the order so a refactor of the Map iteration
+    // doesn't silently shuffle agents.
+    let yaml = baseYaml;
+    yaml = appendAccountToAgent(yaml, "primary-set", "new@example.com");
+    yaml = appendAccountToAgent(yaml, "multi", "new@example.com");
+    const groups = groupAgentsByPrimaryAccount(
+      yaml,
+      ["multi", "primary-set"],
+      "new@example.com",
+    );
+    // Iteration order matches input order.
+    expect(groups.get("pixsoul@gmail.com")).toEqual(["multi", "primary-set"]);
+  });
+
+  it("works with email-shaped labels (regex parity test for v0.6.7+)", () => {
+    // Sanity: groupAgentsByPrimaryAccount doesn't need to validate
+    // labels itself — it just looks them up — but pin that it
+    // tolerates email-shape labels through the YAML round-trip.
+    let yaml = `
+version: 1
+agents:
+  alpha:
+    auth:
+      accounts: [pixsoul@gmail.com, ken+work@example.com]
+`;
+    yaml = appendAccountToAgent(yaml, "alpha", "ken.thompson@outlook.com.au");
+    const groups = groupAgentsByPrimaryAccount(
+      yaml,
+      ["alpha"],
+      "ken.thompson@outlook.com.au",
+    );
+    expect(groups.get("pixsoul@gmail.com")).toEqual(["alpha"]);
+  });
+});


### PR DESCRIPTION
## Summary

- Per-agent primary-preserving fanout in `switchroom auth enable`: adding a fallback no longer overwrites the runtime active credentials with the just-enabled label.
- Console output distinguishes "fanned out (now active)" from "added as fallback (active stays X)" so operators can see whether a restart is actually needed; restart hint is suppressed for pure-fallback adds.
- Extracted `groupAgentsByPrimaryAccount` as a pure helper with 7 unit tests covering empty input, fresh-fleet bootstrap, primary preservation, mixed-primary multi-agent enable, defensive fallback, ordering, and email-shape labels.

## Why

Discovered while wiring three accounts (`pixsoul@gmail.com`, `me@kenthompson.com.au`, `ken.thompson@outlook.com.au`) across the eight-agent fleet. Each `auth enable <fallback>` was silently hot-swapping the runtime fanout to the just-enabled account — agents whose primary should have stayed `pixsoul@gmail.com` were leaking onto fallbacks until the operator manually re-fanned. The bug stays invisible until you run a multi-account fleet, which is exactly the workflow `share-auth-across-the-fleet.md` is supposed to make easy.

## How it works now

After appending the new label to each agent's `auth.accounts:`, group agents by the post-mutation FIRST entry (= the primary) and fan THAT label out, not the just-enabled one:

- Fresh agent (no accounts yet) → just-enabled label IS the primary → fanned as active, restart hint shown.
- Agent with existing primary → primary preserved → just-enabled label sits as fallback → no restart hint (no runtime change).

## Test plan

- [x] `npm run lint` clean
- [x] `npx vitest run tests/auth-enable-preserve-primary.test.ts tests/auth-accounts-yaml.test.ts` — 23/23 green
- [ ] CI green
- [ ] Manual e2e on live fleet: `switchroom auth enable me@kenthompson.com.au clerk` → console says "added as fallback (active stays pixsoul@gmail.com)"; `agent restart clerk`-then-quota-probe still shows pixsoul's utilisation, not me@'s

## Design contract

- **Vision:** advances *Subscription-honest* — multi-account fleet management is a no-op without this fix.
- **Docs test:** ✓ console output is the docs.
- **Defaults test:** ✓ no new config; behavior change is internal to `enable`.
- **Consistency test:** ✓ same fanout primitive (`fanoutAccountToAgents`), same YAML cascade, same agent-restart contract; only the per-agent label selection changes.
- **JTBD:** `share-auth-across-the-fleet.md` — operator manages accounts, switchroom routes them to consumers without surprises.

🤖 Generated with [Claude Code](https://claude.com/claude-code)