### PR TITLE
chore: release v0.6.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,35 @@
 
 ## [Unreleased]
 
+## v0.6.8 — 2026-05-05
+
+### Added
+
+- **Per-account quota utilization on `/auth` (#696)** — the Telegram
+  auth dashboard now renders 5h + 7d quota under each account row
+  alongside the existing per-slot probe (`5h: 47% · 7d: 12%`, or
+  `exhausted · resets in Nh Mm`). Wired through a new
+  `fetchAccountQuota(label)` helper that probes Anthropic's
+  `anthropic-ratelimit-unified-*` headers using the account's stored
+  access token, with a 30 s in-process cache and background prefetch.
+  Cache is invalidated on `enable` / `disable` / `share` / `rm` so
+  the dashboard stays consistent with the YAML cascade.
+
+### Fixed
+
+- **`auth enable <fallback>` no longer hot-swaps the active fanout
+  (#697)** — adding an account as a fallback used to overwrite each
+  agent's runtime credentials with the just-enabled label, silently
+  flipping the primary. Now `enable` preserves the YAML-list primary
+  on each agent (the first entry in `auth.accounts:`) and only fans
+  out the just-enabled label when an agent has no prior accounts
+  (fresh-fleet bootstrap). Console output distinguishes
+  `fanned out (now active)` from `added as fallback (active stays X)`,
+  and the restart hint is suppressed when no runtime change occurred.
+  New helper `groupAgentsByPrimaryAccount` unit-tested across 7
+  cases. Matters whenever an operator runs a multi-account fleet —
+  the bug was invisible on a single-account install.
+
 ## v0.6.7 — 2026-05-05
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "switchroom-ai",
-  "version": "0.6.7",
+  "version": "0.6.8",
   "description": "Run Claude Code 24/7 on your Claude Pro/Max subscription over Telegram. Open-source alternative to OpenClaw and NanoClaw — no API keys, no Docker.",
   "type": "module",
   "bin": {

--- a/src/build-info.ts
+++ b/src/build-info.ts
@@ -2,8 +2,8 @@
 // Tracked in git so `tsc --noEmit` works on a fresh clone before `npm run build`.
 // Values are refreshed every time `npm run build` runs.
 
-export const VERSION: string = "0.6.6";
-export const COMMIT_SHA: string | null = "94c0338b";
-export const COMMIT_DATE: string | null = "2026-05-05T11:33:11+10:00";
-export const LATEST_PR: number | null = 693;
-export const COMMITS_AHEAD_OF_TAG: number | null = 26;
+export const VERSION: string = "0.6.8";
+export const COMMIT_SHA: string | null = "66376b4b";
+export const COMMIT_DATE: string | null = "2026-05-05T14:39:50+10:00";
+export const LATEST_PR: number | null = 697;
+export const COMMITS_AHEAD_OF_TAG: number | null = 2;


### PR DESCRIPTION
## Summary

Bundles the two polish PRs that landed today:
- **#696** — per-account quota utilization on the `/auth` Telegram dashboard
- **#697** — `auth enable` preserves existing primary; no more silent active-fanout hot-swap when adding fallbacks

## Why now

Both issues were discovered while wiring three accounts (`pixsoul@gmail.com`, `me@kenthompson.com.au`, `ken.thompson@outlook.com.au`) across the live eight-agent fleet. Multi-account is the new headline workflow (`share-auth-across-the-fleet.md`); it has to feel safe and honest. v0.6.8 closes both polish gaps in one cut.

## Test plan

- [x] `npm run lint` clean
- [x] `npm run build` regenerates `src/build-info.ts` to v0.6.8 / 66376b4b
- [x] `npx vitest run` for the polish tests — green
- [ ] CI green
- [ ] Post-merge: tag `v0.6.8`, `npm publish`, run `switchroom update` on the live fleet

🤖 Generated with [Claude Code](https://claude.com/claude-code)