### PR TITLE
feat(auth-dashboard): v3b — active-row marking, mini-bars, one-tap promote

### DIFF
--- a/src/cli/auth-accounts-yaml.ts
+++ b/src/cli/auth-accounts-yaml.ts
@@ -73,6 +73,55 @@ export function removeAccountFromAgent(
 }
 
 /**
+ * Move `label` to position 0 in `agents.<agent>.auth.accounts` so it
+ * becomes the agent's primary on the next fanout. Used by
+ * `switchroom auth promote`. Pure: returns the new YAML string.
+ *
+ * Behaviour:
+ *   - Label not in the list → throws (caller validates first; reaching
+ *     this branch is a bug, not a no-op the operator should silently
+ *     accept).
+ *   - Label already at position 0 → returns yamlText unchanged
+ *     (byte-identical, no parseDocument round-trip).
+ *   - Label at any other position → moved to head; relative order of
+ *     the other entries preserved.
+ *   - Agent not declared → throws (same contract as appendAccountToAgent).
+ *
+ * Why a pure-string short-circuit on already-primary: parseDocument
+ * normalizes whitespace and can drop a leading newline, surprising
+ * callers that diff the file to detect "did anything change?". The
+ * `enable` polish (#697) hit this exact corner.
+ */
+export function promoteAccountForAgent(
+  yamlText: string,
+  agentName: string,
+  label: string,
+): string {
+  const doc = parseDocument(yamlText);
+  ensureAgent(doc, agentName);
+  const existing = doc.getIn(["agents", agentName, "auth", "accounts"]);
+  if (!isSeq(existing)) {
+    throw new Error(
+      `agent '${agentName}' has no auth.accounts list — enable '${label}' first.`,
+    );
+  }
+  const seq = existing as YAMLSeq;
+  const labels = seq.items.map(
+    (item) => (item as { value?: unknown }).value ?? item,
+  );
+  const idx = labels.indexOf(label);
+  if (idx === -1) {
+    throw new Error(
+      `account '${label}' is not enabled on agent '${agentName}' — enable it first.`,
+    );
+  }
+  if (idx === 0) return yamlText; // already primary — no-op
+  const moved = seq.items.splice(idx, 1)[0];
+  seq.items.unshift(moved);
+  return String(doc);
+}
+
+/**
  * Read the current `agents.<agent>.auth.accounts` list without mutating.
  * Returns [] if absent or shape-mismatched. Useful for the `list` verb +
  * the rm-refusal logic.

--- a/src/cli/auth-accounts.ts
+++ b/src/cli/auth-accounts.ts
@@ -39,6 +39,7 @@ import {
 import {
   appendAccountToAgent,
   getAccountsForAgent,
+  promoteAccountForAgent,
   removeAccountFromAgent,
   renameAccountInAllAgents,
 } from "./auth-accounts-yaml.js";
@@ -63,6 +64,7 @@ export function registerAuthAccountSubcommands(
 
   registerEnable(authParent, program);
   registerDisable(authParent, program);
+  registerPromote(authParent, program);
   registerShare(authParent, program);
   registerRefreshAccounts(authParent, program);
 }
@@ -284,11 +286,23 @@ function registerAccountList(account: Command, program: Command): void {
         const config = getConfig(program);
         const labels = listAccounts();
         const enabledMap = new Map<string, string[]>();
+        // primaryForMap[label] = [agents whose auth.accounts:[0] === label].
+        // Mirrors enabledMap but only counts agents where this label sits
+        // at position 0 — the post-fanout active for that agent. Used by
+        // the Telegram dashboard's `▶ Active` row.
+        const primaryForMap = new Map<string, string[]>();
         for (const label of labels) {
           enabledMap.set(
             label,
             Object.entries(config.agents)
               .filter(([, a]) => (a.auth?.accounts ?? []).includes(label))
+              .map(([n]) => n)
+              .sort(),
+          );
+          primaryForMap.set(
+            label,
+            Object.entries(config.agents)
+              .filter(([, a]) => (a.auth?.accounts ?? [])[0] === label)
               .map(([n]) => n)
               .sort(),
           );
@@ -315,6 +329,7 @@ function registerAccountList(account: Command, program: Command): void {
                 : {}),
               ...(info.email ? { email: info.email } : {}),
               agents: enabledMap.get(info.label) ?? [],
+              primaryForAgents: primaryForMap.get(info.label) ?? [],
             }));
           console.log(JSON.stringify(payload));
           return;
@@ -676,6 +691,134 @@ function registerDisable(authParent: Command, program: Command): void {
           );
         }
         console.log();
+      }),
+    );
+}
+
+/* ── promote (move an enabled account to position 0 → new primary) ─── */
+
+/**
+ * `switchroom auth promote <label> <agents...>` — move an already-enabled
+ * label to position 0 of each agent's `auth.accounts:` list, making it
+ * the agent's new primary, and immediately fan out fresh credentials.
+ *
+ * Why this verb exists separately from `enable`:
+ *   - `enable` of an already-enabled label is a no-op (idempotent
+ *     append). Operators have no way to say "I want this one to be
+ *     active now" without manually editing YAML.
+ *   - The Telegram dashboard's `⤴ Promote` button maps 1:1 to this
+ *     verb. Single source of truth for the YAML mutation + fanout.
+ *
+ * Refuses (throws) when the label isn't already enabled on the agent —
+ * promotion only reorders; it doesn't enable. This avoids "promote
+ * silently enabled it" confusion.
+ *
+ * Idempotent at the `already-primary` boundary: if the label is
+ * already at position 0, the YAML stays byte-identical and we skip
+ * the fanout (no point rewriting unchanged credentials).
+ */
+function registerPromote(authParent: Command, program: Command): void {
+  authParent
+    .command("promote <label> <agents...>")
+    .description(
+      "Move an already-enabled account to position 0 (primary) on the listed agents — re-fans credentials and tells you what to restart.",
+    )
+    .action(
+      withConfigError(async (label: string, agents: string[]) => {
+        validateAccountLabel(label);
+        if (!accountExists(label)) {
+          throw new Error(
+            `Account "${label}" does not exist. Add it first with 'switchroom auth account add ${label}'.`,
+          );
+        }
+        const config = getConfig(program);
+        agents = expandAllAgents(agents, config);
+        const agentsDir = resolveAgentsDir(config);
+        for (const name of agents) {
+          if (!config.agents[name]) {
+            throw new Error(
+              `agent '${name}' is not declared in switchroom.yaml`,
+            );
+          }
+        }
+
+        const yamlPath = getConfigPath(program);
+        const before = readFileSync(yamlPath, "utf-8");
+        // Pre-validate every agent has the label in its list. Fail
+        // before mutating so we don't half-promote across the fleet.
+        for (const name of agents) {
+          const current = getAccountsForAgent(before, name);
+          if (!current.includes(label)) {
+            throw new Error(
+              `account '${label}' is not enabled on agent '${name}' — enable it first with 'switchroom auth enable ${label} ${name}'.`,
+            );
+          }
+        }
+
+        let after = before;
+        const promoted: string[] = [];
+        const alreadyPrimary: string[] = [];
+        for (const name of agents) {
+          const current = getAccountsForAgent(after, name);
+          if (current[0] === label) {
+            alreadyPrimary.push(name);
+            continue;
+          }
+          after = promoteAccountForAgent(after, name, label);
+          promoted.push(name);
+        }
+        if (after !== before) {
+          writeFileSync(yamlPath, after);
+        }
+
+        // Fan the (now-primary) label only to the agents we moved. The
+        // already-primary set is a no-op — their on-disk credentials
+        // already match the YAML head.
+        const fanTargets = promoted.map((name) => ({
+          name,
+          agentDir: resolve(agentsDir, name),
+        }));
+        const outcomes =
+          fanTargets.length > 0
+            ? fanoutAccountToAgents(label, fanTargets)
+            : [];
+        const fanned = outcomes
+          .filter((o) => o.kind === "fanned-out")
+          .map((o) => o.agent);
+        const fanFails = outcomes.filter((o) => o.kind === "fanout-failed");
+
+        console.log();
+        if (promoted.length === 0) {
+          console.log(
+            `No change — ${chalk.bold(label)} is already primary on: ${alreadyPrimary.join(", ")}`,
+          );
+        } else {
+          console.log(
+            `${chalk.green("✓")} Promoted ${chalk.bold(label)} to primary on: ${promoted.join(", ")}`,
+          );
+          if (alreadyPrimary.length > 0) {
+            console.log(
+              `  Already primary on: ${alreadyPrimary.join(", ")}`,
+            );
+          }
+        }
+        if (fanned.length > 0) {
+          console.log(`  Credentials fanned out to: ${fanned.join(", ")}`);
+        }
+        for (const f of fanFails) {
+          if (f.kind === "fanout-failed") {
+            console.log(
+              chalk.yellow(`  ⚠ Fanout failed for ${f.agent}: ${f.error}`),
+            );
+          }
+        }
+        console.log();
+        if (promoted.length > 0) {
+          console.log(
+            `Next: 'switchroom agent restart ${promoted.join(" ")}' to load the new active credentials.`,
+          );
+          console.log();
+        }
       }),
     );
 }

--- a/telegram-plugin/auth-dashboard.ts
+++ b/telegram-plugin/auth-dashboard.ts
@@ -438,6 +438,16 @@ export function buildDashboardText(state: DashboardState): string {
     lines.push("");
   }
 
+  // Slot ID lookup: under the new account model, slot IDs (`default`,
+  // etc.) are an internal mount-point identifier — not what the
+  // operator authorized. When we know which account is the post-fanout
+  // active for THIS agent, surface its label in place of the slot ID
+  // in the slot row + Pool line. The slot ID itself ("default" or
+  // whatever was synthesised) carries zero information for the
+  // operator; the account label is the identity they recognize.
+  const activeAccountLabel =
+    state.accounts?.find((a) => a.activeForThisAgent === true)?.label ?? null;
+
   if (state.slots.length === 0) {
     lines.push("<i>No account slots. Tap [➕ Add slot] to attach a subscription.</i>");
   } else {
@@ -446,8 +456,16 @@ export function buildDashboardText(state: DashboardState): string {
       const marker = slot.active ? "●" : "○";
       const badge = healthBadge(slot.health);
       const label = healthLabel(slot.health);
+      // Display name: account label for the active slot when we know
+      // it; otherwise the raw slot ID. Non-active slots also use the
+      // raw ID — there's no account-label to substitute since we only
+      // know the ACTIVE account's identity from the cascade head.
+      const displayName =
+        slot.active && activeAccountLabel != null
+          ? activeAccountLabel
+          : slot.slot;
       lines.push(
-        `  ${marker} <code>${escapeHtml(slot.slot)}</code>${slot.active ? " (active)" : ""}  ${badge} ${label}`,
+        `  ${marker} <code>${escapeHtml(displayName)}</code>${slot.active ? " (active)" : ""}  ${badge} ${label}`,
       );
       const detail = slotDetailLine(slot);
       if (detail) lines.push(`    └ ${detail}`);
@@ -455,11 +473,13 @@ export function buildDashboardText(state: DashboardState): string {
   }
 
   // Pool / fallback summary — show when accounts exist, so the user
-  // understands how slots and accounts relate.
+  // understands how slots and accounts relate. Pool line uses the
+  // account label too when we know it (parity with the slot row).
   if (state.accounts != null && state.accounts.length > 0 && state.slots.length > 0) {
     const activeSlot = state.slots.find((s) => s.active);
     if (activeSlot) {
-      lines.push(`  Pool: slot <code>${escapeHtml(activeSlot.slot)}</code> is active`);
+      const poolDisplayName = activeAccountLabel ?? activeSlot.slot;
+      lines.push(`  Pool: <code>${escapeHtml(poolDisplayName)}</code> is active`);
     }
   }
 

--- a/telegram-plugin/auth-dashboard.ts
+++ b/telegram-plugin/auth-dashboard.ts
@@ -148,6 +148,19 @@ export interface AccountSummary {
    * Nh Mm" rather than the percentage row.
    */
   readonly quotaExhaustedUntil?: number;
+  /**
+   * True when this account sits at index 0 of THIS agent's
+   * `auth.accounts:` list — i.e. it's the post-fanout active for this
+   * agent. Drives the `▶` glyph + "Active" framing in the dashboard
+   * render and suppresses the per-account `⤴ Promote` button (you
+   * can't promote what's already primary).
+   *
+   * Populated by the gateway from the new `primaryForAgents` field on
+   * `auth account list --json` (added v0.6.9). Optional: undefined
+   * means "old CLI without the field" — render falls back to the
+   * pre-v3 unmarked layout.
+   */
+  readonly activeForThisAgent?: boolean;
 }
 
 /**
@@ -194,6 +207,13 @@ export type CallbackAction =
   | { kind: "account-rm"; agent: string; label: string }
   | { kind: "account-rm-confirm"; agent: string; label: string }
   | { kind: "account-reauth"; agent: string; label: string }
+  // v3b: in-place promote — moves a fallback to primary without leaving
+  // the dashboard. Two-stage confirm mirrors enable/disable. Verbs `apr`
+  // / `cpr` are 3 chars max so a 40-char agent + 64-char label still
+  // fits the 64-byte callback_data cap (auth:cpr:agent:label = 12 +
+  // agent + label ≤ 64).
+  | { kind: "account-promote"; agent: string; label: string }
+  | { kind: "confirm-account-promote"; agent: string; label: string }
   | { kind: "noop" };
 
 const CALLBACK_PREFIX = "auth:";
@@ -241,6 +261,10 @@ export function encodeCallbackData(action: CallbackAction): string {
       return `${CALLBACK_PREFIX}armc:${action.agent}:${action.label}`;
     case "account-reauth":
       return `${CALLBACK_PREFIX}ara:${action.agent}:${action.label}`;
+    case "account-promote":
+      return `${CALLBACK_PREFIX}apr:${action.agent}:${action.label}`;
+    case "confirm-account-promote":
+      return `${CALLBACK_PREFIX}cpr:${action.agent}:${action.label}`;
     case "noop":
       return `${CALLBACK_PREFIX}noop`;
   }
@@ -264,7 +288,8 @@ export function parseCallbackData(data: string): CallbackAction {
   // segment instead of a slot. We branch on verb first so each segment
   // is validated against its own regex.
   if (verb === "ae" || verb === "ad" || verb === "cae" || verb === "cad" ||
-      verb === "av" || verb === "arm" || verb === "armc" || verb === "ara") {
+      verb === "av" || verb === "arm" || verb === "armc" || verb === "ara" ||
+      verb === "apr" || verb === "cpr") {
     if (!isSafeAgentName(agent ?? "")) return { kind: "noop" };
     if (!third || !isSafeAccountLabel(third)) return { kind: "noop" };
     const label = third;
@@ -275,8 +300,10 @@ export function parseCallbackData(data: string): CallbackAction {
     if (verb === "av") return { kind: "account-view", agent, label };
     if (verb === "arm") return { kind: "account-rm", agent, label };
     if (verb === "armc") return { kind: "account-rm-confirm", agent, label };
-    // verb === "ara"
-    return { kind: "account-reauth", agent, label };
+    if (verb === "ara") return { kind: "account-reauth", agent, label };
+    if (verb === "apr") return { kind: "account-promote", agent, label };
+    // verb === "cpr"
+    return { kind: "confirm-account-promote", agent, label };
   }
   if (verb === "sf") {
     if (!isSafeAgentName(agent ?? "")) return { kind: "noop" };
@@ -380,21 +407,30 @@ export function buildDashboardText(state: DashboardState): string {
 
   // v3a: accounts appear above slots — accounts are first-class, slots
   // are an implementation detail of how credentials attach to a process.
+  // v3b: active account (the one at this agent's auth.accounts[0])
+  // floats to the top with a `▶` glyph; remaining rows render under a
+  // "Fallback:" subhead in agent-list order. When `activeForThisAgent`
+  // is unset on every entry (older CLI without primaryForAgents in
+  // --json), we fall back to the v3a layout — bullets only, no header.
   if (state.accounts != null && state.accounts.length > 0) {
     lines.push(`<b>Anthropic accounts (${state.accounts.length})</b>`);
     const visible = state.accounts.slice(0, ACCOUNTS_DISPLAY_CAP);
-    for (const acc of visible) {
-      const badge = accountHealthBadge(acc.health);
-      const suffix = healthSuffix(acc.health);
-      lines.push(`  • <code>${escapeHtml(acc.label)}</code>  ${badge}${suffix}`);
-      // Per-account quota row: "5h: 47%  · 7d: 12%" when the gateway
-      // probed the account. Hidden until at least one of the two
-      // values is known so we don't show "5h: -  · 7d: -" on a
-      // freshly-added account whose probe hasn't run yet — the
-      // operator sees a clean account-only row first, then the
-      // numbers populate on the next refresh tap.
-      const quotaLine = formatAccountQuotaLine(acc);
-      if (quotaLine) lines.push(`    └ ${quotaLine}`);
+    const active = visible.find((a) => a.activeForThisAgent === true);
+    const fallbacks = visible.filter((a) => a !== active);
+    const haveActiveSignal = active != null;
+    if (haveActiveSignal && active != null) {
+      lines.push(renderActiveAccountRow(active));
+    }
+    if (fallbacks.length > 0) {
+      // Only emit the subhead when there's a distinguished active row;
+      // otherwise the list is just "all accounts, no opinion" and a
+      // header would be misleading.
+      if (haveActiveSignal) lines.push(`  <i>Fallback ↓:</i>`);
+      for (const acc of fallbacks) {
+        lines.push(renderFallbackAccountRow(acc, haveActiveSignal));
+        const quotaLine = formatAccountQuotaLine(acc);
+        if (quotaLine) lines.push(`    └ ${quotaLine}`);
+      }
     }
     if (state.accountsTruncated) {
       lines.push(`  … ${state.accounts.length - ACCOUNTS_DISPLAY_CAP} more (use CLI)`);
@@ -439,6 +475,59 @@ export function buildDashboardText(state: DashboardState): string {
   }
 
   return lines.join("\n");
+}
+
+/**
+ * Render the active account row — the post-fanout primary for this
+ * agent. Uses the `▶` glyph + bold label + an inline quota summary
+ * carrying mini-bars when both percentages are known. Falls back to
+ * the plain `formatAccountQuotaLine` text on the next line if quota
+ * isn't probed yet — keeps the row honest about uncertainty.
+ */
+function renderActiveAccountRow(acc: AccountSummary): string {
+  const badge = accountHealthBadge(acc.health);
+  const suffix = healthSuffix(acc.health);
+  const head = `▶ <b><code>${escapeHtml(acc.label)}</code></b>  ${badge}${suffix}`;
+  const inline = formatActiveQuotaInline(acc);
+  return inline ? `${head}\n    ${inline}` : head;
+}
+
+/**
+ * Render an indented fallback account row. `haveActiveSignal` controls
+ * the bullet vs. tree-prefix character — when there's a distinguished
+ * active row above, we use `↳` to imply ordering; without one we fall
+ * back to a plain `•` bullet so the layout matches v3a for older CLIs.
+ */
+function renderFallbackAccountRow(
+  acc: AccountSummary,
+  haveActiveSignal: boolean,
+): string {
+  const badge = accountHealthBadge(acc.health);
+  const suffix = healthSuffix(acc.health);
+  const prefix = haveActiveSignal ? "  ↳" : "  •";
+  return `${prefix} <code>${escapeHtml(acc.label)}</code>  ${badge}${suffix}`;
+}
+
+/**
+ * Inline quota summary for the active row. When BOTH 5h and 7d are
+ * known, emit the mini-bar form (`5h ████░░ 47%  ·  7d █░░░░░ 12%`).
+ * When the account is exhausted, defer to the existing
+ * `formatAccountQuotaLine` (it has the reset-time copy). Otherwise
+ * return null and let the caller skip the line.
+ */
+function formatActiveQuotaInline(acc: AccountSummary): string | null {
+  if (acc.quotaExhaustedUntil != null && acc.quotaExhaustedUntil > Date.now()) {
+    return formatAccountQuotaLine(acc);
+  }
+  if (acc.fiveHourPct == null || acc.sevenDayPct == null) {
+    return formatAccountQuotaLine(acc);
+  }
+  const fiveBar = formatQuotaBar(acc.fiveHourPct);
+  const sevenBar = formatQuotaBar(acc.sevenDayPct);
+  return (
+    `<i>5h</i> <code>${fiveBar}</code> ${formatQuotaPct(acc.fiveHourPct)}  ` +
+    `·  <i>7d</i> <code>${sevenBar}</code> ${formatQuotaPct(acc.sevenDayPct)}`
+  );
 }
 
 /** Health badge for an account (not a slot). */
@@ -500,8 +589,15 @@ export function buildDashboardKeyboard(state: DashboardState): InlineKeyboard {
   // drills into the per-account sub-view. No inline ✓/○ toggles on the
   // main board — the toggles are an implementation detail; the sub-view
   // surface is the right place for per-account actions.
+  // v3b: each non-active account also gets a `⤴ Promote` button on the
+  // row beneath it. Active rows are unchanged (already at primary —
+  // promoting them is a no-op). The promote button uses the same
+  // 64-byte render-time guard as the drill-down button.
   if (state.accounts != null && state.accounts.length > 0) {
     const visible = state.accounts.slice(0, ACCOUNTS_DISPLAY_CAP);
+    const haveActiveSignal = visible.some(
+      (a) => a.activeForThisAgent === true,
+    );
     for (const acc of visible) {
       const action: CallbackAction = { kind: "account-view", agent: state.agent, label: acc.label };
       const encoded = encodeCallbackData(action);
@@ -509,15 +605,37 @@ export function buildDashboardKeyboard(state: DashboardState): InlineKeyboard {
       // 64-byte cap (pathological agent + label lengths), fall back
       // to a noop button labelled with the raw account name so the
       // row is visible-but-inert. Operator can fall back to the CLI.
+      const labelPrefix = acc.activeForThisAgent ? "▶ " : "";
       if (Buffer.byteLength(encoded, "utf8") > CALLBACK_BUDGET_BYTES) {
         kb.text(
           `⚠ ${truncateLabel(acc.label)} (use CLI)`,
           encodeCallbackData({ kind: "noop" }),
         );
       } else {
-        kb.text(`${acc.label}${healthSuffix(acc.health)}`, encoded);
+        kb.text(`${labelPrefix}${acc.label}${healthSuffix(acc.health)}`, encoded);
       }
       kb.row();
+      // v3b promote row — only meaningful when we know which account is
+      // active (so we can suppress the button on it). Without that
+      // signal (older CLI), we skip every promote button rather than
+      // ambiguously offer "promote" on every row.
+      if (haveActiveSignal && !acc.activeForThisAgent) {
+        const promoteAction: CallbackAction = {
+          kind: "account-promote",
+          agent: state.agent,
+          label: acc.label,
+        };
+        const promoteEncoded = encodeCallbackData(promoteAction);
+        if (Buffer.byteLength(promoteEncoded, "utf8") > CALLBACK_BUDGET_BYTES) {
+          kb.text(
+            `⤴ Promote ${truncateLabel(acc.label)} (use CLI)`,
+            encodeCallbackData({ kind: "noop" }),
+          );
+        } else {
+          kb.text(`⤴ Promote ${acc.label}`, promoteEncoded);
+        }
+        kb.row();
+      }
     }
     if (state.accountsTruncated) {
       kb.text(
@@ -670,6 +788,31 @@ function formatQuotaPct(pct: number): string {
   return `${rounded}%`;
 }
 
+/**
+ * Render a Unicode mini-bar for a 0–100 percentage. Six cells wide —
+ * the active row carries two of these (5h + 7d) and they need to fit
+ * one mobile line alongside the labels and percentages.
+ *
+ *   formatQuotaBar(0)   → ░░░░░░
+ *   formatQuotaBar(47)  → ███░░░
+ *   formatQuotaBar(99)  → █████░  (clamps below full so 99% reads
+ *                                  visibly different from 100%)
+ *   formatQuotaBar(100) → ██████
+ *
+ * Used only on the active-account row (the one running quota right
+ * now). Fallback rows still render plain percentages because the bars
+ * eat horizontal space the indented "↳" rows don't have.
+ */
+export function formatQuotaBar(pct: number, cells: number = 6): string {
+  if (cells <= 0) return "";
+  const clamped = Math.max(0, Math.min(100, pct));
+  // Math.floor for the filled cell count — 100% gets all cells, 99%
+  // gets cells-1, anything below the per-cell threshold gets 0.
+  const filled =
+    clamped >= 100 ? cells : Math.floor((clamped / 100) * cells);
+  return "█".repeat(filled) + "░".repeat(cells - filled);
+}
+
 function formatRelativeMs(ms: number): string {
   const totalMin = Math.max(1, Math.floor(ms / 60_000));
   if (totalMin < 60) return `${totalMin}m`;
@@ -708,6 +851,27 @@ export function escapeHtml(text: string): string {
 export function buildRemoveConfirmKeyboard(agent: string, slot: string): InlineKeyboard {
   return new InlineKeyboard()
     .text(`⚠️ Confirm remove: ${slot}`, encodeCallbackData({ kind: "confirm-rm", agent, slot }))
+    .row()
+    .text("↩️ Cancel", encodeCallbackData({ kind: "refresh", agent }));
+}
+
+/**
+ * Two-stage confirmation for the account promote action — mirrors
+ * `buildAccountConfirmKeyboard` but with the promote-specific verb so
+ * the confirm row's callback dispatches to `confirm-account-promote`.
+ *
+ * Why a separate helper instead of extending the existing one's `kind`
+ * parameter: the `enable | disable` discriminant is already in widely-
+ * used callsites; threading a third value through them would force
+ * cascading test updates. A dedicated helper is cleaner.
+ */
+export function buildAccountPromoteConfirmKeyboard(
+  agent: string,
+  label: string,
+): InlineKeyboard {
+  const action: CallbackAction = { kind: "confirm-account-promote", agent, label };
+  return new InlineKeyboard()
+    .text(`⚠️ Confirm promote: ${label}`, encodeCallbackData(action))
     .row()
     .text("↩️ Cancel", encodeCallbackData({ kind: "refresh", agent }));
 }

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -86,6 +86,7 @@ import {
   buildDashboard,
   buildRemoveConfirmKeyboard,
   buildAccountConfirmKeyboard,
+  buildAccountPromoteConfirmKeyboard,
   buildAccountSubViewText,
   buildAccountSubViewKeyboard,
   buildAccountRemoveConfirmKeyboard,
@@ -6618,6 +6619,11 @@ function fetchDashboardState(agent: string): DashboardState | null {
     quotaExhaustedUntil?: number
     email?: string
     agents: string[]
+    /** v0.6.9+: agents for which this label is at index 0 of
+     *  auth.accounts: (i.e. the post-fanout active for that agent).
+     *  Optional — older CLIs without the field cause the dashboard to
+     *  fall back to the v3a unmarked render. */
+    primaryForAgents?: string[]
   }
   let accounts: AccountSummary[] | undefined
   let accountsTruncated = false
@@ -6636,6 +6642,9 @@ function fetchDashboardState(agent: string): DashboardState | null {
           label: a.label,
           health: a.health,
           enabledHere: Array.isArray(a.agents) && a.agents.includes(agent),
+          ...(Array.isArray(a.primaryForAgents)
+            ? { activeForThisAgent: a.primaryForAgents.includes(agent) }
+            : {}),
           ...(a.subscriptionType ? { subscriptionType: a.subscriptionType } : {}),
           ...(a.expiresAt != null ? { expiresAt: a.expiresAt } : {}),
           ...(a.quotaExhaustedUntil != null
@@ -7634,6 +7643,33 @@ async function handleAuthDashboardCallback(ctx: Context): Promise<void> {
       // The CLI's `disable` doesn't auto-restart (it expects the operator
       // to drain manually); the dashboard tap is implicit "I'm done with
       // this account on this agent now," so we restart on their behalf.
+      await runSwitchroomCommand(ctx, ['agent', 'restart', action.agent], `restart ${action.agent}`)
+      clearAccountQuotaCache()
+      await sendAuthDashboard(ctx, action.agent, { edit: true })
+      return
+    }
+    case 'account-promote': {
+      // Two-stage confirm — same UX as enable/disable, just a different
+      // verb on the confirm row's callback. The CLI verb does the
+      // YAML reorder + fanout.
+      await ctx.answerCallbackQuery({ text: `Confirm promote ${action.label}?` }).catch(() => {})
+      try {
+        await ctx.editMessageReplyMarkup({
+          reply_markup: buildAccountPromoteConfirmKeyboard(action.agent, action.label),
+        })
+      } catch { /* ignore */ }
+      return
+    }
+    case 'confirm-account-promote': {
+      await ctx.answerCallbackQuery({ text: `Promoting ${action.label}…` }).catch(() => {})
+      try { assertSafeAgentName(action.agent) } catch { return }
+      await runSwitchroomCommand(
+        ctx,
+        ['auth', 'promote', action.label, action.agent],
+        `auth promote ${action.label} ${action.agent}`,
+      )
+      // Promotion changes the active credential — must restart so
+      // claude reloads the new primary's tokens.
       await runSwitchroomCommand(ctx, ['agent', 'restart', action.agent], `restart ${action.agent}`)
       clearAccountQuotaCache()
       await sendAuthDashboard(ctx, action.agent, { edit: true })

--- a/telegram-plugin/tests/auth-dashboard-v3b.test.ts
+++ b/telegram-plugin/tests/auth-dashboard-v3b.test.ts
@@ -1,0 +1,328 @@
+/**
+ * Dashboard v3b — active/fallback marking + promote verb tests.
+ *
+ * Three surfaces under test:
+ *   1. encodeCallbackData / parseCallbackData round-trip for the new
+ *      `account-promote` + `confirm-account-promote` verbs (`apr`/`cpr`).
+ *   2. formatQuotaBar — the mini-bar renderer used on the active row.
+ *   3. buildDashboardText / buildDashboardKeyboard — verifies the `▶`
+ *      glyph floats the active account, the "Fallback ↓:" subhead
+ *      appears when there's a distinguished active row, and that the
+ *      v3a unmarked layout is preserved when no account claims active
+ *      (older CLI without primaryForAgents).
+ *
+ * Pure module — no gateway/Telegram side effects.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  encodeCallbackData,
+  parseCallbackData,
+  formatQuotaBar,
+  buildDashboardText,
+  buildDashboardKeyboard,
+  buildAccountPromoteConfirmKeyboard,
+  CALLBACK_BUDGET_BYTES,
+  type AccountSummary,
+  type DashboardState,
+} from "../auth-dashboard.js";
+
+const baseState: Omit<DashboardState, "accounts"> = {
+  agent: "clerk",
+  bankId: "clerk",
+  plan: "max",
+  rateLimitTier: "default_claude_max_20x",
+  slots: [],
+  quotaHot: false,
+};
+
+const acc = (
+  label: string,
+  overrides: Partial<AccountSummary> = {},
+): AccountSummary => ({
+  label,
+  health: "healthy",
+  enabledHere: true,
+  ...overrides,
+});
+
+describe("v3b: account-promote callback round-trip", () => {
+  it("encodes and decodes account-promote (verb apr)", () => {
+    const encoded = encodeCallbackData({
+      kind: "account-promote",
+      agent: "clerk",
+      label: "pixsoul@gmail.com",
+    });
+    expect(encoded).toBe("auth:apr:clerk:pixsoul@gmail.com");
+    expect(parseCallbackData(encoded)).toEqual({
+      kind: "account-promote",
+      agent: "clerk",
+      label: "pixsoul@gmail.com",
+    });
+  });
+
+  it("encodes and decodes confirm-account-promote (verb cpr)", () => {
+    const encoded = encodeCallbackData({
+      kind: "confirm-account-promote",
+      agent: "clerk",
+      label: "me@kenthompson.com.au",
+    });
+    expect(encoded).toBe("auth:cpr:clerk:me@kenthompson.com.au");
+    expect(parseCallbackData(encoded)).toEqual({
+      kind: "confirm-account-promote",
+      agent: "clerk",
+      label: "me@kenthompson.com.au",
+    });
+  });
+
+  it("rejects labels with disallowed characters", () => {
+    // `/` is rejected by isSafeAccountLabel — would create on-disk
+    // ambiguity under ~/.switchroom/accounts/.
+    expect(parseCallbackData("auth:apr:clerk:bad/label")).toEqual({
+      kind: "noop",
+    });
+    // Whitespace, quotes, etc.
+    expect(parseCallbackData("auth:apr:clerk:bad label")).toEqual({
+      kind: "noop",
+    });
+  });
+
+  it("rejects payloads beyond the 64-byte cap", () => {
+    const longLabel = "a".repeat(60);
+    const overlong = `auth:cpr:agent:${longLabel}`;
+    // sanity — payload exceeds the cap
+    expect(Buffer.byteLength(overlong, "utf8")).toBeGreaterThan(
+      CALLBACK_BUDGET_BYTES,
+    );
+    expect(parseCallbackData(overlong)).toEqual({ kind: "noop" });
+  });
+
+  it("rejects empty label segment", () => {
+    expect(parseCallbackData("auth:apr:clerk:")).toEqual({ kind: "noop" });
+  });
+});
+
+describe("v3b: formatQuotaBar", () => {
+  it("renders all-empty for 0%", () => {
+    expect(formatQuotaBar(0)).toBe("░░░░░░");
+  });
+
+  it("renders all-full for 100%", () => {
+    expect(formatQuotaBar(100)).toBe("██████");
+  });
+
+  it("clamps below full for 99% so the bar reads visibly under the cap", () => {
+    // Critical UX point: a 99% account is one bad turn from exhaustion.
+    // The bar must NOT show as full. The cell math floors, so 99/100*6
+    // = 5.94 → 5 filled cells.
+    expect(formatQuotaBar(99)).toBe("█████░");
+  });
+
+  it("scales linearly across the range", () => {
+    expect(formatQuotaBar(50)).toBe("███░░░");
+    expect(formatQuotaBar(33)).toBe("█░░░░░"); // 33/100*6=1.98 → 1
+    expect(formatQuotaBar(17)).toBe("█░░░░░"); // 17/100*6=1.02 → 1
+    expect(formatQuotaBar(83)).toBe("████░░"); // 83/100*6=4.98 → 4
+  });
+
+  it("clamps negative or >100 inputs to the legal range", () => {
+    expect(formatQuotaBar(-5)).toBe("░░░░░░");
+    expect(formatQuotaBar(150)).toBe("██████");
+  });
+
+  it("supports a custom cell count", () => {
+    expect(formatQuotaBar(50, 10)).toBe("█████░░░░░");
+    expect(formatQuotaBar(0, 0)).toBe("");
+  });
+});
+
+describe("v3b: buildDashboardText — active-row marking", () => {
+  it("floats the activeForThisAgent row to the top with a ▶ glyph", () => {
+    const state: DashboardState = {
+      ...baseState,
+      accounts: [
+        acc("pixsoul@gmail.com", { activeForThisAgent: true }),
+        acc("me@kenthompson.com.au"),
+        acc("ken.thompson@outlook.com.au"),
+      ],
+    };
+    const text = buildDashboardText(state);
+    const pixIdx = text.indexOf("pixsoul@gmail.com");
+    const meIdx = text.indexOf("me@kenthompson.com.au");
+    expect(pixIdx).toBeGreaterThan(-1);
+    expect(meIdx).toBeGreaterThan(-1);
+    // Active row precedes fallbacks in the rendered text.
+    expect(pixIdx).toBeLessThan(meIdx);
+    // ▶ glyph appears on the active row, before the label.
+    const arrowIdx = text.indexOf("▶");
+    expect(arrowIdx).toBeGreaterThan(-1);
+    expect(arrowIdx).toBeLessThan(pixIdx);
+  });
+
+  it("emits a 'Fallback ↓:' subhead when there's a distinguished active row", () => {
+    const state: DashboardState = {
+      ...baseState,
+      accounts: [
+        acc("pixsoul@gmail.com", { activeForThisAgent: true }),
+        acc("me@kenthompson.com.au"),
+      ],
+    };
+    expect(buildDashboardText(state)).toContain("Fallback");
+  });
+
+  it("falls back to the v3a unmarked layout when no account claims active", () => {
+    // Older CLI without primaryForAgents → activeForThisAgent is unset
+    // on every account → no ▶ glyph, no Fallback subhead. The v3a
+    // bullet-list rendering still works.
+    const state: DashboardState = {
+      ...baseState,
+      accounts: [acc("pixsoul@gmail.com"), acc("me@kenthompson.com.au")],
+    };
+    const text = buildDashboardText(state);
+    expect(text).not.toContain("▶");
+    expect(text).not.toContain("Fallback");
+    // Both labels still appear.
+    expect(text).toContain("pixsoul@gmail.com");
+    expect(text).toContain("me@kenthompson.com.au");
+  });
+
+  it("renders inline mini-bars on the active row when both percentages are known", () => {
+    const state: DashboardState = {
+      ...baseState,
+      accounts: [
+        acc("pixsoul@gmail.com", {
+          activeForThisAgent: true,
+          fiveHourPct: 47,
+          sevenDayPct: 12,
+        }),
+      ],
+    };
+    const text = buildDashboardText(state);
+    // Both bars present (the "█"/"░" cells appear in the active-row's
+    // inline summary). Spot-check the 47% → "██░░░░░" (47/100*6=2.82
+    // → 2 filled cells) and 12% → "░░░░░░" (12/100*6=0.72 → 0 filled).
+    expect(text).toContain(formatQuotaBar(47));
+    expect(text).toContain(formatQuotaBar(12));
+    expect(text).toContain("47%");
+    expect(text).toContain("12%");
+  });
+
+  it("falls back to the legacy quota-line on the active row when only one percentage is known", () => {
+    const state: DashboardState = {
+      ...baseState,
+      accounts: [
+        acc("pixsoul@gmail.com", {
+          activeForThisAgent: true,
+          fiveHourPct: 47,
+          // sevenDayPct intentionally absent
+        }),
+      ],
+    };
+    const text = buildDashboardText(state);
+    // No mini-bar (would require both); the legacy line shows just 5h.
+    expect(text).toContain("47%");
+    expect(text).not.toContain("12%");
+  });
+
+  it("uses the existing 'exhausted · resets in …' line when active is exhausted", () => {
+    const state: DashboardState = {
+      ...baseState,
+      accounts: [
+        acc("pixsoul@gmail.com", {
+          activeForThisAgent: true,
+          quotaExhaustedUntil: Date.now() + 90 * 60_000,
+          fiveHourPct: 100,
+          sevenDayPct: 50,
+        }),
+      ],
+    };
+    const text = buildDashboardText(state);
+    expect(text).toContain("exhausted");
+    expect(text).toContain("resets in");
+  });
+});
+
+describe("v3b: buildDashboardKeyboard — promote button row", () => {
+  const renderRows = (
+    accounts: AccountSummary[],
+  ): Array<Array<{ text: string; data: string }>> => {
+    const kb = buildDashboardKeyboard({ ...baseState, accounts });
+    // grammY's InlineKeyboard exposes its internal layout via `inline_keyboard`.
+    const raw = (kb as unknown as { inline_keyboard: Array<Array<{ text: string; callback_data: string }>> })
+      .inline_keyboard;
+    return raw.map((row) =>
+      row.map((b) => ({ text: b.text, data: b.callback_data })),
+    );
+  };
+
+  it("emits a `⤴ Promote <label>` button under each non-active account", () => {
+    const rows = renderRows([
+      acc("pixsoul@gmail.com", { activeForThisAgent: true }),
+      acc("me@kenthompson.com.au"),
+      acc("ken.thompson@outlook.com.au"),
+    ]);
+    const promoteRows = rows.flat().filter((b) => b.text.startsWith("⤴ Promote"));
+    expect(promoteRows.length).toBe(2); // me@ + ken@
+    const labels = promoteRows.map((b) => b.text.replace("⤴ Promote ", ""));
+    expect(labels.sort()).toEqual(
+      ["ken.thompson@outlook.com.au", "me@kenthompson.com.au"].sort(),
+    );
+    // Promote callbacks dispatch to account-promote (verb apr).
+    for (const b of promoteRows) {
+      expect(b.data.startsWith("auth:apr:clerk:")).toBe(true);
+    }
+  });
+
+  it("does NOT emit a promote button for the active row", () => {
+    const rows = renderRows([
+      acc("pixsoul@gmail.com", { activeForThisAgent: true }),
+      acc("me@kenthompson.com.au"),
+    ]);
+    const promoteRows = rows.flat().filter((b) => b.text.startsWith("⤴ Promote"));
+    // Only one — the fallback. The active row gets none.
+    expect(promoteRows.length).toBe(1);
+    expect(promoteRows[0].text).toBe("⤴ Promote me@kenthompson.com.au");
+  });
+
+  it("emits NO promote buttons when no account claims active (older CLI)", () => {
+    // Without a distinguished active row we can't tell which one to
+    // suppress, so we suppress all of them rather than offer ambiguous
+    // "promote" actions on every row.
+    const rows = renderRows([
+      acc("pixsoul@gmail.com"),
+      acc("me@kenthompson.com.au"),
+    ]);
+    const promoteRows = rows.flat().filter((b) => b.text.startsWith("⤴ Promote"));
+    expect(promoteRows.length).toBe(0);
+  });
+
+  it("renders a noop fallback when the promote payload would exceed 64 bytes", () => {
+    // Pathological agent + label lengths. Guard renders the row inert
+    // rather than letting Telegram reject the message.
+    const longAgent = "a".repeat(50);
+    const longLabel = "b".repeat(50);
+    const kb = buildDashboardKeyboard({
+      ...baseState,
+      agent: longAgent,
+      accounts: [
+        acc(longLabel, { activeForThisAgent: false }),
+        acc("pixsoul", { activeForThisAgent: true }),
+      ],
+    });
+    const raw = (kb as unknown as { inline_keyboard: Array<Array<{ text: string; callback_data: string }>> }).inline_keyboard;
+    const guarded = raw.flat().find((b) => b.text.includes("⤴ Promote") && b.text.includes("(use CLI)"));
+    expect(guarded).toBeDefined();
+    expect(guarded?.callback_data).toBe("auth:noop");
+  });
+});
+
+describe("v3b: buildAccountPromoteConfirmKeyboard", () => {
+  it("emits a confirm row whose callback dispatches confirm-account-promote", () => {
+    const kb = buildAccountPromoteConfirmKeyboard("clerk", "pixsoul@gmail.com");
+    const raw = (kb as unknown as { inline_keyboard: Array<Array<{ text: string; callback_data: string }>> }).inline_keyboard;
+    const confirm = raw.flat().find((b) => b.text.includes("Confirm promote"));
+    expect(confirm?.callback_data).toBe("auth:cpr:clerk:pixsoul@gmail.com");
+    const cancel = raw.flat().find((b) => b.text.includes("Cancel"));
+    expect(cancel?.callback_data).toBe("auth:refresh:clerk");
+  });
+});

--- a/telegram-plugin/tests/auth-dashboard-v3b.test.ts
+++ b/telegram-plugin/tests/auth-dashboard-v3b.test.ts
@@ -316,6 +316,59 @@ describe("v3b: buildDashboardKeyboard — promote button row", () => {
   });
 });
 
+describe("v3b: slot row uses account label, not slot ID, when active is known", () => {
+  // Real-world wedge: the slot ID ("default") is a meaningless
+  // implementation detail for operators who reason in account labels.
+  // Pin the substitution so a refactor can't silently re-surface
+  // "default" in the operator-facing slot row.
+  const slotRowState = (
+    activeAccountLabel: string | null,
+  ): DashboardState => ({
+    ...baseState,
+    slots: [
+      {
+        slot: "default",
+        active: true,
+        health: "active",
+      },
+    ],
+    accounts:
+      activeAccountLabel != null
+        ? [
+            acc(activeAccountLabel, { activeForThisAgent: true }),
+            acc("ken.thompson@outlook.com.au"),
+          ]
+        : [acc("ken.thompson@outlook.com.au")],
+  });
+
+  it("substitutes the account label for the slot ID in the active slot row", () => {
+    const text = buildDashboardText(slotRowState("pixsoul@gmail.com"));
+    // Slots section shows the email wrapped in <code>, NOT "default".
+    expect(text).toContain("<code>pixsoul@gmail.com</code> (active)");
+    // The literal slot ID "default" should NOT appear in the rendered
+    // slot section. (We do still need it as the data identity inside
+    // the gateway, but it's not for the operator's eyes.)
+    const slotsSection = text.split("Slots (")[1] ?? "";
+    expect(slotsSection).not.toContain("<code>default</code>");
+  });
+
+  it("falls back to the slot ID when no account claims active (older CLI)", () => {
+    const text = buildDashboardText(slotRowState(null));
+    // Without an active signal we can't tell which label to substitute,
+    // so the legacy slot ID is preserved.
+    expect(text).toContain("<code>default</code> (active)");
+  });
+
+  it("uses the account label in the Pool line too", () => {
+    const text = buildDashboardText(slotRowState("pixsoul@gmail.com"));
+    expect(text).toContain("Pool:");
+    expect(text).toContain("pixsoul@gmail.com");
+    // Pool line specifically must not still say "slot default is active"
+    // — the user filed this complaint by name.
+    expect(text).not.toMatch(/Pool:[^\n]*default/);
+  });
+});
+
 describe("v3b: buildAccountPromoteConfirmKeyboard", () => {
   it("emits a confirm row whose callback dispatches confirm-account-promote", () => {
     const kb = buildAccountPromoteConfirmKeyboard("clerk", "pixsoul@gmail.com");

--- a/tests/auth-promote-yaml.test.ts
+++ b/tests/auth-promote-yaml.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Unit tests for `promoteAccountForAgent` — the pure YAML helper that
+ * moves a label to position 0 of `agents.<agent>.auth.accounts:`.
+ *
+ * Why these specific cases: the helper is the source of truth for what
+ * "primary preservation + promotion" mean to the cascade, and is shared
+ * by the CLI verb + the Telegram dashboard's `⤴ Promote` flow. Cover
+ * the head/middle/tail/missing/empty/already-primary branches so a
+ * future refactor can't silently change the contract.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  appendAccountToAgent,
+  getAccountsForAgent,
+  promoteAccountForAgent,
+} from "../src/cli/auth-accounts-yaml.js";
+
+const seed = `
+version: 1
+agents:
+  fresh:
+    topic_name: Fresh
+  one:
+    auth:
+      accounts: [pixsoul@gmail.com]
+  many:
+    auth:
+      accounts:
+        - pixsoul@gmail.com
+        - me@kenthompson.com.au
+        - ken.thompson@outlook.com.au
+`;
+
+describe("promoteAccountForAgent", () => {
+  it("moves a middle entry to position 0", () => {
+    const next = promoteAccountForAgent(seed, "many", "me@kenthompson.com.au");
+    expect(getAccountsForAgent(next, "many")).toEqual([
+      "me@kenthompson.com.au",
+      "pixsoul@gmail.com",
+      "ken.thompson@outlook.com.au",
+    ]);
+  });
+
+  it("moves a tail entry to position 0", () => {
+    const next = promoteAccountForAgent(
+      seed,
+      "many",
+      "ken.thompson@outlook.com.au",
+    );
+    expect(getAccountsForAgent(next, "many")).toEqual([
+      "ken.thompson@outlook.com.au",
+      "pixsoul@gmail.com",
+      "me@kenthompson.com.au",
+    ]);
+  });
+
+  it("returns the input byte-identical when the label is already primary", () => {
+    // The CLI uses byte-equality (before === after) to decide whether to
+    // rewrite the file + restart-hint. parseDocument round-trips can
+    // normalize whitespace, so the helper short-circuits explicitly
+    // when no movement is needed. Pin that contract.
+    const next = promoteAccountForAgent(seed, "many", "pixsoul@gmail.com");
+    expect(next).toBe(seed);
+  });
+
+  it("throws when the label is not enabled on the agent", () => {
+    expect(() =>
+      promoteAccountForAgent(seed, "many", "not-enabled@example.com"),
+    ).toThrowError(/not enabled/);
+  });
+
+  it("throws when the agent has no auth.accounts list yet", () => {
+    expect(() =>
+      promoteAccountForAgent(seed, "fresh", "pixsoul@gmail.com"),
+    ).toThrowError(/no auth\.accounts list/);
+  });
+
+  it("throws when the agent is not declared", () => {
+    expect(() =>
+      promoteAccountForAgent(seed, "ghost", "pixsoul@gmail.com"),
+    ).toThrowError(/not declared/);
+  });
+
+  it("preserves the relative order of other entries when promoting", () => {
+    // me@ → primary; the relative order of the remaining two should be
+    // [pixsoul, ken] — i.e. unchanged from the original list, not
+    // re-shuffled.
+    const next = promoteAccountForAgent(seed, "many", "me@kenthompson.com.au");
+    const list = getAccountsForAgent(next, "many");
+    expect(list.indexOf("pixsoul@gmail.com")).toBeLessThan(
+      list.indexOf("ken.thompson@outlook.com.au"),
+    );
+  });
+
+  it("composes with appendAccountToAgent — append-then-promote == single-step promote", () => {
+    // Real CLI flow: an operator runs `auth enable <new>` (append) then
+    // `auth promote <new>`. Pin that the helpers compose the way callers
+    // assume: the post-append-then-promote list is the same as
+    // [<new>, …existing] in original order.
+    const appended = appendAccountToAgent(seed, "one", "new@example.com");
+    const promoted = promoteAccountForAgent(appended, "one", "new@example.com");
+    expect(getAccountsForAgent(promoted, "one")).toEqual([
+      "new@example.com",
+      "pixsoul@gmail.com",
+    ]);
+  });
+
+  it("works with email-shaped labels containing @ and +", () => {
+    const yaml = `
+version: 1
+agents:
+  alpha:
+    auth:
+      accounts:
+        - pixsoul@gmail.com
+        - ken+work@example.com
+`;
+    const next = promoteAccountForAgent(yaml, "alpha", "ken+work@example.com");
+    expect(getAccountsForAgent(next, "alpha")).toEqual([
+      "ken+work@example.com",
+      "pixsoul@gmail.com",
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

Phase 1 of the auth-card v3 redesign — answers three operator questions in one glance:

1. **Which account is driving traffic right now?** → \`▶\` glyph + bold + inline mini-bars (\`5h ████░░ 47%  ·  7d █░░░░░ 12%\`)
2. **Which accounts are failover targets?** → indented under a \"Fallback ↓:\" subhead, in YAML-list order (the actual failover order, load-bearing post-#697)
3. **How do I switch primary without leaving Telegram?** → \`⤴ Promote <label>\` button under each fallback, two-stage confirm

## What ships

**New CLI verb** — \`switchroom auth promote <label> <agents...>\`:
- Moves the label to position 0 of each agent's \`auth.accounts:\`
- Refuses when the label isn't already enabled (promote reorders; enable enables)
- Idempotent at the already-primary boundary
- Console output distinguishes \"promoted (now active)\" vs. \"already primary\"

**CLI plumbing** — \`auth account list --json\` gains \`primaryForAgents: string[]\` so the gateway can set \`activeForThisAgent\` on each \`AccountSummary\`.

**Dashboard module**:
- \`AccountSummary.activeForThisAgent\` (optional — undefined falls back to v3a unmarked layout for older CLIs)
- \`formatQuotaBar(pct)\` — Unicode mini-bar, 6 cells. **Clamps below full at 99%** so a near-exhaustion account reads visibly different from a fresh one (critical UX point)
- \`account-promote\` / \`confirm-account-promote\` callback verbs (\`apr\`/\`cpr\` — 3 chars so 64-byte cap holds for 64-char labels)
- \`buildAccountPromoteConfirmKeyboard\` — separate helper from the enable/disable variant

**Gateway dispatch** — \`account-promote\` → confirm keyboard; \`confirm-account-promote\` → CLI invoke + restart + cache clear + dashboard refresh.

## Out of scope (Phase 2 follow-up)

- Hiding the slots section (high test churn — defer until v3 layout is validated in production)
- Replacing the per-account drilldown buttons on the main board
- Active-row gets its own zone above fallbacks

## Test plan

- [x] \`npm run lint\` clean
- [x] 9 vitest cases on \`promoteAccountForAgent\` (head/middle/tail/missing/empty/already-primary/composes-with-append/email-shape labels)
- [x] 22 bun-test cases on the v3b dashboard surface (callback round-trip + mini-bar rendering + active-row marking + Fallback subhead + per-fallback promote button + 64-byte cap fallback + confirm keyboard)
- [x] Existing dashboard tests still pass (146/146 in \`auth-dashboard.test.ts\` + edge-cases)
- [ ] CI green
- [ ] Manual e2e: open \`/auth\` on clerk → see ▶ pixsoul on top with mini-bars + Fallback subhead + ⤴ Promote buttons; tap a promote → confirm → see new active swap

## Design contract

- **Vision:** advances *Subscription-honest* — multi-account fleet management is now legible from Telegram alone.
- **Docs test:** ✓ icons + glyphs are tap-to-discover; no docs needed.
- **Defaults test:** ✓ no new config; v3a layout is the graceful-degradation path for older CLIs.
- **Consistency test:** ✓ same callback format, same edit-in-place refresh, same two-stage confirm pattern as enable/disable.
- **JTBD:** \`share-auth-across-the-fleet.md\` — operator manages accounts, switchroom routes them to consumers; promote is the missing reorder verb.

🤖 Generated with [Claude Code](https://claude.com/claude-code)