### PR TITLE
chore: release v0.6.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,38 @@
 
 ## [Unreleased]
 
+## v0.6.9 — 2026-05-05
+
+### Added
+
+- **Auth card v3b (#699)** — Telegram `/auth` answers three operator
+  questions in one glance:
+  - Which account is driving traffic right now? `▶ pixsoul@gmail.com`
+    + inline mini-bars (`5h ██░░░░ 47%  ·  7d ░░░░░░ 12%`).
+  - Which accounts are failover targets? Indented under
+    `Fallback ↓:`, in YAML-list order (the actual failover order,
+    load-bearing post-#697).
+  - How do I switch primary without leaving Telegram? `⤴ Promote`
+    button under each fallback, two-stage confirm.
+- **`switchroom auth promote <label> <agents...>`** — moves a label
+  to position 0 of each agent's `auth.accounts:`. Refuses when not
+  already enabled (promote reorders; enable enables). Idempotent at
+  the already-primary boundary.
+- **`auth account list --json`** gains `primaryForAgents: string[]`
+  so the dashboard can mark each agent's active account.
+
+### Fixed
+
+- **Slots + Pool sections hide when the active account is known
+  (#699)** — under the new account model the Slots row and Pool line
+  duplicate the `▶ <label>` active-account row 1:1, just with an
+  internal slot ID like "default" instead of the operator's email.
+  Both sections are now suppressed when an active-account signal is
+  present, leaving a single source of truth for "what's active."
+  Bootstrap state (no accounts yet) and older CLIs without
+  `primaryForAgents` keep the legacy Slots layout for graceful
+  degradation.
+
 ## v0.6.8 — 2026-05-05
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "switchroom-ai",
-  "version": "0.6.8",
+  "version": "0.6.9",
   "description": "Run Claude Code 24/7 on your Claude Pro/Max subscription over Telegram. Open-source alternative to OpenClaw and NanoClaw — no API keys, no Docker.",
   "type": "module",
   "bin": {

--- a/src/build-info.ts
+++ b/src/build-info.ts
@@ -2,8 +2,8 @@
 // Tracked in git so `tsc --noEmit` works on a fresh clone before `npm run build`.
 // Values are refreshed every time `npm run build` runs.
 
-export const VERSION: string = "0.6.8";
-export const COMMIT_SHA: string | null = "66376b4b";
-export const COMMIT_DATE: string | null = "2026-05-05T14:39:50+10:00";
-export const LATEST_PR: number | null = 697;
-export const COMMITS_AHEAD_OF_TAG: number | null = 2;
+export const VERSION: string = "0.6.9";
+export const COMMIT_SHA: string | null = "d24d857f";
+export const COMMIT_DATE: string | null = "2026-05-05T17:04:10+10:00";
+export const LATEST_PR: number | null = 699;
+export const COMMITS_AHEAD_OF_TAG: number | null = 1;

--- a/telegram-plugin/auth-dashboard.ts
+++ b/telegram-plugin/auth-dashboard.ts
@@ -441,45 +441,48 @@ export function buildDashboardText(state: DashboardState): string {
   // Slot ID lookup: under the new account model, slot IDs (`default`,
   // etc.) are an internal mount-point identifier — not what the
   // operator authorized. When we know which account is the post-fanout
-  // active for THIS agent, surface its label in place of the slot ID
-  // in the slot row + Pool line. The slot ID itself ("default" or
-  // whatever was synthesised) carries zero information for the
-  // operator; the account label is the identity they recognize.
+  // active for THIS agent, the active slot row would render as
+  // `● pixsoul@gmail.com (active) ✓ healthy` and the Pool line would
+  // say `Pool: pixsoul@gmail.com is active` — both 1:1 duplicates of
+  // the ▶ active-account row above. So we hide both sections when an
+  // active-account signal is present. Keep them visible only when:
+  //   - No accounts data at all (older CLI without --json), OR
+  //   - Accounts exist but no entry has activeForThisAgent set (older
+  //     CLI without primaryForAgents), OR
+  //   - Empty fleet (no accounts) — slots are still the bootstrap
+  //     surface for the operator's first reauth/add taps.
   const activeAccountLabel =
     state.accounts?.find((a) => a.activeForThisAgent === true)?.label ?? null;
+  const slotsSectionRedundant =
+    activeAccountLabel != null &&
+    state.accounts != null &&
+    state.accounts.length > 0;
 
-  if (state.slots.length === 0) {
-    lines.push("<i>No account slots. Tap [➕ Add slot] to attach a subscription.</i>");
-  } else {
-    lines.push(`<b>Slots (${state.slots.length})</b>`);
-    for (const slot of state.slots) {
-      const marker = slot.active ? "●" : "○";
-      const badge = healthBadge(slot.health);
-      const label = healthLabel(slot.health);
-      // Display name: account label for the active slot when we know
-      // it; otherwise the raw slot ID. Non-active slots also use the
-      // raw ID — there's no account-label to substitute since we only
-      // know the ACTIVE account's identity from the cascade head.
-      const displayName =
-        slot.active && activeAccountLabel != null
-          ? activeAccountLabel
-          : slot.slot;
-      lines.push(
-        `  ${marker} <code>${escapeHtml(displayName)}</code>${slot.active ? " (active)" : ""}  ${badge} ${label}`,
-      );
-      const detail = slotDetailLine(slot);
-      if (detail) lines.push(`    └ ${detail}`);
+  if (!slotsSectionRedundant) {
+    if (state.slots.length === 0) {
+      lines.push("<i>No account slots. Tap [➕ Add slot] to attach a subscription.</i>");
+    } else {
+      lines.push(`<b>Slots (${state.slots.length})</b>`);
+      for (const slot of state.slots) {
+        const marker = slot.active ? "●" : "○";
+        const badge = healthBadge(slot.health);
+        const label = healthLabel(slot.health);
+        lines.push(
+          `  ${marker} <code>${escapeHtml(slot.slot)}</code>${slot.active ? " (active)" : ""}  ${badge} ${label}`,
+        );
+        const detail = slotDetailLine(slot);
+        if (detail) lines.push(`    └ ${detail}`);
+      }
     }
-  }
 
-  // Pool / fallback summary — show when accounts exist, so the user
-  // understands how slots and accounts relate. Pool line uses the
-  // account label too when we know it (parity with the slot row).
-  if (state.accounts != null && state.accounts.length > 0 && state.slots.length > 0) {
-    const activeSlot = state.slots.find((s) => s.active);
-    if (activeSlot) {
-      const poolDisplayName = activeAccountLabel ?? activeSlot.slot;
-      lines.push(`  Pool: <code>${escapeHtml(poolDisplayName)}</code> is active`);
+    // Pool / fallback summary — show when accounts exist, so the user
+    // understands how slots and accounts relate. Suppressed alongside
+    // the slots section when the active-account row already says it.
+    if (state.accounts != null && state.accounts.length > 0 && state.slots.length > 0) {
+      const activeSlot = state.slots.find((s) => s.active);
+      if (activeSlot) {
+        lines.push(`  Pool: slot <code>${escapeHtml(activeSlot.slot)}</code> is active`);
+      }
     }
   }
 

--- a/telegram-plugin/tests/auth-dashboard-v3b.test.ts
+++ b/telegram-plugin/tests/auth-dashboard-v3b.test.ts
@@ -316,11 +316,13 @@ describe("v3b: buildDashboardKeyboard — promote button row", () => {
   });
 });
 
-describe("v3b: slot row uses account label, not slot ID, when active is known", () => {
-  // Real-world wedge: the slot ID ("default") is a meaningless
-  // implementation detail for operators who reason in account labels.
-  // Pin the substitution so a refactor can't silently re-surface
-  // "default" in the operator-facing slot row.
+describe("v3b: Slots + Pool sections hide when active-account signal is present", () => {
+  // The slot row was rendering `● pixsoul@gmail.com (active) ✓ healthy`
+  // when the active label was known — a 1:1 duplicate of the
+  // `▶ pixsoul@gmail.com  ✓` active-account row above. Same for the
+  // `Pool: pixsoul@gmail.com is active` line. So we hide both sections
+  // entirely under the new account model. Pin the visibility rules so
+  // a refactor can't silently re-surface the duplication.
   const slotRowState = (
     activeAccountLabel: string | null,
   ): DashboardState => ({
@@ -341,31 +343,37 @@ describe("v3b: slot row uses account label, not slot ID, when active is known", 
         : [acc("ken.thompson@outlook.com.au")],
   });
 
-  it("substitutes the account label for the slot ID in the active slot row", () => {
+  it("hides the Slots section entirely when an active-account signal is present", () => {
     const text = buildDashboardText(slotRowState("pixsoul@gmail.com"));
-    // Slots section shows the email wrapped in <code>, NOT "default".
-    expect(text).toContain("<code>pixsoul@gmail.com</code> (active)");
-    // The literal slot ID "default" should NOT appear in the rendered
-    // slot section. (We do still need it as the data identity inside
-    // the gateway, but it's not for the operator's eyes.)
-    const slotsSection = text.split("Slots (")[1] ?? "";
-    expect(slotsSection).not.toContain("<code>default</code>");
-  });
-
-  it("falls back to the slot ID when no account claims active (older CLI)", () => {
-    const text = buildDashboardText(slotRowState(null));
-    // Without an active signal we can't tell which label to substitute,
-    // so the legacy slot ID is preserved.
-    expect(text).toContain("<code>default</code> (active)");
-  });
-
-  it("uses the account label in the Pool line too", () => {
-    const text = buildDashboardText(slotRowState("pixsoul@gmail.com"));
-    expect(text).toContain("Pool:");
+    // No "Slots (N)" header, no "default" leaking out, no Pool line.
+    expect(text).not.toContain("Slots (");
+    expect(text).not.toContain("default");
+    expect(text).not.toMatch(/Pool:/);
+    // The ▶ active row is the single source of truth for what's active.
+    expect(text).toContain("▶");
     expect(text).toContain("pixsoul@gmail.com");
-    // Pool line specifically must not still say "slot default is active"
-    // — the user filed this complaint by name.
-    expect(text).not.toMatch(/Pool:[^\n]*default/);
+  });
+
+  it("keeps the legacy Slots + Pool layout when accounts have no active signal", () => {
+    // Older CLIs don't emit primaryForAgents → no activeForThisAgent
+    // is set on any account → slots section is the only signal of
+    // "what's active." Preserve it for graceful degradation.
+    const text = buildDashboardText(slotRowState(null));
+    expect(text).toContain("Slots (");
+    expect(text).toContain("<code>default</code> (active)");
+    expect(text).toContain("Pool:");
+  });
+
+  it("keeps the Slots section visible when no accounts exist (fresh-fleet bootstrap)", () => {
+    // Bootstrap path: no accounts yet, the operator's only handle is
+    // the slot — they need [➕ Add slot] / [🔄 Reauth] to work.
+    const text = buildDashboardText({
+      ...baseState,
+      slots: [{ slot: "default", active: true, health: "active" }],
+      accounts: [],
+    });
+    expect(text).toContain("Slots (");
+    expect(text).toContain("default");
   });
 });
 


### PR DESCRIPTION
## Summary

Bundles #699 (auth card v3b) plus a follow-on polish: hide the now-redundant Slots + Pool sections when the active-account signal is present.

## Why the polish

After #699 unified the slot label with the account label, the Slots section was rendering:

\`\`\`
▶ pixsoul@gmail.com  ✓                     ← active-account row
    5h ██░░░░ 47%  ·  7d ░░░░░░ 12%

Slots (1)
  ● pixsoul@gmail.com (active)  ✓ healthy  ← duplicate
  Pool: pixsoul@gmail.com is active        ← duplicate
\`\`\`

Both sections now suppressed when a distinguished active-account exists. Bootstrap (no accounts) and older CLIs without \`primaryForAgents\` keep the legacy Slots layout.

## Final shape

\`\`\`
━━━ Auth • clerk ━━━
Bank: clerk · Plan: max_20x

Anthropic accounts (3)
▶ pixsoul@gmail.com  ✓
    5h ██░░░░ 47%  ·  7d ░░░░░░ 12%
  Fallback ↓:
  ↳ me@kenthompson.com.au  ✓
    └ 5h: 8%  · 7d: 3%
  ↳ ken.thompson@outlook.com.au  ✓
    └ 5h: 0%  · 7d: 1%
━━━━━━━━━━━━━━━━━━━
\`\`\`

## Test plan

- [x] \`npm run lint\` clean
- [x] 25 v3b dashboard tests green (3 new for slots-hidden visibility rules)
- [x] All other dashboard test files still pass
- [ ] Post-merge: tag v0.6.9, npm publish, \`switchroom update\` on the live fleet

🤖 Generated with [Claude Code](https://claude.com/claude-code)