### PR TITLE
fix(auth-dashboard): quota persistence + remove Fall back button (v0.6.11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 ## [Unreleased]
 
+## v0.6.11 — 2026-05-05
+
+### Fixed
+
+- **Per-account quota mini-bars now persist past the cache TTL.**
+  Pre-v0.6.11 `getCachedAccountQuota` treated stale entries as a
+  miss, which meant the boot-warmed cache vanished after 30s and the
+  operator saw empty quota rows on the first `/auth` tap of any
+  session past that window. Now the sync read returns whatever's
+  cached regardless of staleness; the background prefetch
+  (`prefetchAccountQuotaIfStale`) keeps the cache fresh on every
+  dashboard render. Cache TTL also bumped from 30s → 5min — quota
+  doesn't move that fast, and the prefetch path keeps it fresh
+  whenever the operator interacts.
+
+### Removed
+
+- **`[⚠️ Fall back now]` button gone from `/auth`.** The Switch
+  primary picker (v0.6.10) is the operator-facing surface for "active
+  is hot, swap to a fallback"; the auto-fallback poller still handles
+  the automatic case when the active hits its quota wall. Two paths
+  doing the same thing was confusing. The `fallback` callback verb
+  stays in the parser/dispatcher for legacy reachability of any
+  pinned messages bearing the pre-v0.6.11 button.
+
 ## v0.6.10 — 2026-05-05
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "switchroom-ai",
-  "version": "0.6.10",
+  "version": "0.6.11",
   "description": "Run Claude Code 24/7 on your Claude Pro/Max subscription over Telegram. Open-source alternative to OpenClaw and NanoClaw — no API keys, no Docker.",
   "type": "module",
   "bin": {

--- a/src/build-info.ts
+++ b/src/build-info.ts
@@ -2,8 +2,8 @@
 // Tracked in git so `tsc --noEmit` works on a fresh clone before `npm run build`.
 // Values are refreshed every time `npm run build` runs.
 
-export const VERSION: string = "0.6.10";
-export const COMMIT_SHA: string | null = "a762a597";
-export const COMMIT_DATE: string | null = "2026-05-05T17:31:16+10:00";
-export const LATEST_PR: number | null = 701;
-export const COMMITS_AHEAD_OF_TAG: number | null = 1;
+export const VERSION: string = "0.6.11";
+export const COMMIT_SHA: string | null = "6c273d58";
+export const COMMIT_DATE: string | null = "2026-05-05T18:11:37+10:00";
+export const LATEST_PR: number | null = 702;
+export const COMMITS_AHEAD_OF_TAG: number | null = 0;

--- a/telegram-plugin/auth-dashboard.ts
+++ b/telegram-plugin/auth-dashboard.ts
@@ -702,11 +702,16 @@ export function buildDashboardKeyboard(state: DashboardState): InlineKeyboard {
     kb.row();
   }
 
-  // Quota row. [Fall back now] only when the dashboard flagged
-  // quotaHot; always show [Full quota] as the escape hatch.
-  if (state.quotaHot) {
-    kb.text("⚠️ Fall back now", encodeCallbackData({ kind: "fallback", agent: state.agent }));
-  }
+  // Quota row. [📊 Full quota] is the escape hatch when the
+  // operator wants the live numbers behind the cached mini-bars.
+  // The legacy `[⚠️ Fall back now]` button (manual auto-fallback at
+  // the slot level) was removed in v0.6.11 — the Switch primary
+  // picker is the operator-facing surface for "active is hot, swap
+  // to a fallback," and the auto-fallback poller still handles the
+  // automatic case when the active hits its quota wall. The
+  // `fallback` callback verb stays in the parser/dispatcher for
+  // legacy reachability of any pinned messages still bearing the
+  // pre-v0.6.11 button, but no new buttons emit it.
   kb.text("📊 Full quota", encodeCallbackData({ kind: "usage", agent: state.agent }));
   kb.row();
 

--- a/telegram-plugin/quota-check.ts
+++ b/telegram-plugin/quota-check.ts
@@ -290,10 +290,15 @@ type AccountQuotaCacheEntry = {
   result: QuotaResult;
 };
 
-/** TTL for the per-account quota cache. 30s balances "dashboard
- *  refresh feels live" against "stop hammering the Anthropic API on
- *  every tap." Shared cache across the gateway process. */
-export const ACCOUNT_QUOTA_CACHE_TTL_MS = 30_000;
+/** TTL for the per-account quota cache — controls when
+ *  `prefetchAccountQuotaIfStale` re-probes Anthropic and when
+ *  `fetchAccountQuota`'s cache-bypass kicks in. 5 min: quota numbers
+ *  don't move within a few minutes for human-scale usage; the
+ *  prefetch fires on every dashboard render so the cache stays fresh
+ *  whenever the operator interacts. The dashboard's sync read
+ *  (`getCachedAccountQuota`) returns last-known data regardless of
+ *  staleness — see that function's docstring for why. */
+export const ACCOUNT_QUOTA_CACHE_TTL_MS = 5 * 60_000;
 
 const accountQuotaCache = new Map<string, AccountQuotaCacheEntry>();
 
@@ -356,22 +361,36 @@ export function clearAccountQuotaCache(label?: string): void {
 }
 
 /**
- * Sync read of the account quota cache. Returns `null` when there's
- * no entry (the dashboard renders the row without a quota line) or
- * when the entry is older than the TTL (treats it as a miss to keep
- * the dashboard's view fresh).
+ * Sync read of the account quota cache. Returns whatever's cached for
+ * this label — `null` only when there's NO entry at all. Stale-but-
+ * present cache entries are returned on purpose:
  *
- * Used by `fetchDashboardState` (which is sync) so the dashboard can
- * render with cached quota without awaiting an async probe. The
- * background prefetch path warms the cache for the next render.
+ *   - The dashboard renders sync; awaiting a fresh probe would block
+ *     the user-visible message (and a probe can stall on Anthropic
+ *     latency or network).
+ *   - Showing yesterday's number is dramatically better UX than
+ *     showing nothing — quota changes slowly enough that "the cached
+ *     value" is almost always close to truth.
+ *   - The background prefetch (`prefetchAccountQuotaIfStale`) keeps
+ *     the cache fresh across renders. Within the 5-min TTL it
+ *     no-ops; past the TTL it kicks off a fresh probe whose result
+ *     is visible on the operator's NEXT render (refresh tap or
+ *     auto-refresh after an action).
+ *
+ * Pre-v0.6.11 this function treated stale entries as a miss, which
+ * meant the boot-warmed cache vanished after 30s and the operator
+ * saw empty quota rows on the first /auth tap of any day after the
+ * gateway restart. That's the bug this docstring exists to keep
+ * fixed.
  */
 export function getCachedAccountQuota(
-  label: string,
-  now: number = Date.now(),
+  _label: string,
+  _now: number = Date.now(),
 ): QuotaResult | null {
-  const cached = accountQuotaCache.get(label);
+  // Note the unused params — we keep the signature stable for callers
+  // that pass `now` (test helpers) even though we no longer use it.
+  const cached = accountQuotaCache.get(_label);
   if (!cached) return null;
-  if (now - cached.fetchedAt >= ACCOUNT_QUOTA_CACHE_TTL_MS) return null;
   return cached.result;
 }
 

--- a/telegram-plugin/tests/auth-dashboard.test.ts
+++ b/telegram-plugin/tests/auth-dashboard.test.ts
@@ -200,7 +200,7 @@ describe("buildDashboardKeyboard", () => {
     expect(useButtons[1].text).toContain("work");
   });
 
-  it("shows [Fall back now] only when quotaHot is true", () => {
+  it("never shows [Fall back now] (removed in v0.6.11 — Switch primary is the operator-facing surface; the auto-fallback poller handles the automatic case)", () => {
     const cold = buildDashboardKeyboard({
       agent: "clerk",
       bankId: "a",
@@ -216,7 +216,7 @@ describe("buildDashboardKeyboard", () => {
     const coldTexts = cold.inline_keyboard.flat().map((b) => b.text);
     const hotTexts = hot.inline_keyboard.flat().map((b) => b.text);
     expect(coldTexts.some((t) => t.includes("Fall back"))).toBe(false);
-    expect(hotTexts.some((t) => t.includes("Fall back"))).toBe(true);
+    expect(hotTexts.some((t) => t.includes("Fall back"))).toBe(false);
   });
 
   it("always ends with a Refresh button", () => {

--- a/telegram-plugin/tests/quota-check.test.ts
+++ b/telegram-plugin/tests/quota-check.test.ts
@@ -413,12 +413,18 @@ describe('getCachedAccountQuota + prefetchAccountQuotaIfStale', () => {
     }
   })
 
-  it('treats stale entries as a cache miss', async () => {
+  it("returns stale entries verbatim — staleness is the prefetch path's concern, not the read path's (v0.6.11)", async () => {
+    // The dashboard renders sync. Pre-v0.6.11 this function treated
+    // stale cache as a miss → the boot-warmed cache vanished after
+    // 30s and the operator saw empty quota rows on the first /auth
+    // tap of any session past that window. Now stale-but-present
+    // entries are returned; the background prefetch keeps the cache
+    // fresh across renders.
     const home = makeAccountHome({
       'work@example.com': { accessToken: 'tok' },
     })
     try {
-      let nowVal = 1_000_000
+      const nowVal = 1_000_000
       await fetchAccountQuota('work@example.com', {
         home,
         fetchImpl: (async () =>
@@ -432,13 +438,23 @@ describe('getCachedAccountQuota + prefetchAccountQuotaIfStale', () => {
         now: () => nowVal,
       })
       // Within TTL — cached.
-      expect(getCachedAccountQuota('work@example.com', nowVal)).not.toBeNull()
-      // Past TTL — treated as miss.
+      const fresh = getCachedAccountQuota('work@example.com', nowVal)
+      expect(fresh).not.toBeNull()
+      // Past TTL — STILL returned, identical to the within-TTL read.
       const after = nowVal + ACCOUNT_QUOTA_CACHE_TTL_MS + 1
-      expect(getCachedAccountQuota('work@example.com', after)).toBeNull()
+      const stale = getCachedAccountQuota('work@example.com', after)
+      expect(stale).not.toBeNull()
+      expect(stale).toEqual(fresh)
     } finally {
       rmSync(home, { recursive: true, force: true })
     }
+  })
+
+  it('returns null when the label has never been probed', async () => {
+    // The only "no data" path: the cache map has no entry. After
+    // the first probe the entry persists for the lifetime of the
+    // gateway process, regardless of staleness.
+    expect(getCachedAccountQuota('never-probed@example.com')).toBeNull()
   })
 
   it('prefetchAccountQuotaIfStale is a noop when cache is fresh', async () => {


### PR DESCRIPTION
## Why

A real /auth screenshot showed empty quota rows on the active account row 8 minutes after agent restart, even with v0.6.10's eager-warm. Plus the legacy `[⚠️ Fall back now]` button was now redundant alongside the Switch primary picker.

## Fixes

### Quota persistence

Boot-warm fills the in-process cache at gateway startup. Then `getCachedAccountQuota` treated entries past the 30s TTL as a miss — so the boot-warmed values vanished within seconds of accepting the first message. Every subsequent /auth render saw empty rows until the user tapped Refresh and the prefetch round-trip completed.

- Cache TTL bumped 30s → 5min.
- `getCachedAccountQuota` returns whatever's cached regardless of staleness. The prefetch path handles freshness; the sync read just hands back last-known data so the dashboard renders with numbers rather than empty rows.

### Remove `[⚠️ Fall back now]` button

The Switch primary picker (v0.6.10) is the operator-facing surface for "swap to a fallback." The auto-fallback poller still handles the automatic-on-quota-wall case. Two paths doing the same thing was confusing. Legacy `fallback` callback verb stays in the parser for any pinned messages bearing the old button.

## Test plan

- [x] `npm run lint` clean
- [x] 200/200 dashboard + quota tests green
- [x] Quota stale-tolerance test inverted (now asserts persistence)
- [x] Fall-back-button test inverted (now asserts absence)
- [ ] Live verification: open `/auth` on clerk → mini-bars visible immediately on the active row, no `Fall back now` button regardless of quota state

🤖 Generated with [Claude Code](https://claude.com/claude-code)