### PR TITLE
fix(telegram): remove /authfallback + regression coverage for v3 polish (v0.6.12)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,37 @@
 
 ## [Unreleased]
 
+## v0.6.12 — 2026-05-05
+
+### Removed
+
+- **`/authfallback` typed Telegram command gone.** Duplicated the
+  work of the dashboard's Switch primary picker (operator-facing) and
+  the auto-fallback poller (transparent on-quota-wall case). Two
+  paths to the same outcome confused operators. The
+  `runAutoFallbackCheck` function and the `case 'fallback':` callback
+  dispatch stay in the codebase: any pinned messages from earlier
+  versions still work, and the auto-fallback poller still calls
+  `runAutoFallbackCheck` directly.
+  - Slash-menu entry, autocomplete name list, and help-text line
+    all dropped.
+  - Doc comments updated to point at `/auth` Switch primary instead.
+
+### Tests (regression coverage for v0.6.10–v0.6.12)
+
+- `welcome-text` — pin that `/authfallback` is absent from the slash
+  menu, autocomplete list, AND help text (3 separate surfaces).
+- `auth-dashboard-v3b` — main board renders ≤6 keyboard rows with
+  three accounts (catches the v3b 8-button explosion); no Promote
+  callback ever targets the active label (catches the screenshot
+  bug); `[⚠️ Fall back now]` button stays absent under every quotaHot
+  / slot-health / accounts-shape combination.
+- `quota-check` — boot-warm + delayed sync-read sequence returns
+  last-known data after 8.5min (the screenshot reproduction window);
+  `prefetchAccountQuotaIfStale` re-probes once past TTL but no-ops
+  while fresh; cache TTL pinned ≥60s so a future PR can't re-create
+  the empty-row bug.
+
 ## v0.6.11 — 2026-05-05
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "switchroom-ai",
-  "version": "0.6.11",
+  "version": "0.6.12",
   "description": "Run Claude Code 24/7 on your Claude Pro/Max subscription over Telegram. Open-source alternative to OpenClaw and NanoClaw — no API keys, no Docker.",
   "type": "module",
   "bin": {

--- a/src/build-info.ts
+++ b/src/build-info.ts
@@ -2,8 +2,8 @@
 // Tracked in git so `tsc --noEmit` works on a fresh clone before `npm run build`.
 // Values are refreshed every time `npm run build` runs.
 
-export const VERSION: string = "0.6.11";
-export const COMMIT_SHA: string | null = "6c273d58";
-export const COMMIT_DATE: string | null = "2026-05-05T18:11:37+10:00";
-export const LATEST_PR: number | null = 702;
+export const VERSION: string = "0.6.12";
+export const COMMIT_SHA: string | null = "642ffc55";
+export const COMMIT_DATE: string | null = "2026-05-05T18:35:20+10:00";
+export const LATEST_PR: number | null = 703;
 export const COMMITS_AHEAD_OF_TAG: number | null = 0;

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -1538,9 +1538,10 @@ function emitGatewayOperatorEvent(event: OperatorEvent): void {
   // Issue #394 Fix 2: when the failure is model-unavailable (quota out,
   // overloaded, or the network can't even reach Anthropic), suppress the
   // raw stderr/detail and post the actionable ⚠️ card instead. The card
-  // points at the three commands that move the needle (`/authfallback`,
-  // `/auth add`, `/usage`) so the user isn't left staring at "You're out
-  // of extra usage · resets May 3, 11am" with no idea what to do.
+  // points at the commands that move the needle (`/auth` Switch
+  // primary picker, `/auth add`, `/usage`) so the user isn't left
+  // staring at "You're out of extra usage · resets May 3, 11am" with
+  // no idea what to do.
   //
   // Two routes match:
   //   - kind already classified as quota-exhausted / rate-limited / unknown-5xx
@@ -6142,8 +6143,8 @@ bot.command('interrupt', async ctx => {
 })
 
 // Shared auto-fallback state. `lockout` is a per-process in-memory
-// guard against rapid re-fire between the scheduled poll and a
-// manual /authfallback trigger (see telegram-plugin/auto-fallback.ts).
+// guard against rapid re-fire between the scheduled poll and any
+// manual trigger (see telegram-plugin/auto-fallback.ts).
 //
 // Pre-#417 fix this was always emptyLockout() at process start, so a
 // gateway restart inside the cooldown window reset the timer and a
@@ -6345,23 +6346,14 @@ async function runCreditWatch(): Promise<void> {
   }
 }
 
-bot.command('authfallback', async ctx => {
-  if (!isAuthorizedSender(ctx)) return
-  const result = await runAutoFallbackCheck({ trigger: 'manual' })
-  if (result.kind === 'executed') {
-    await switchroomReply(ctx, `✅ Switched slot <code>${escapeHtmlForTg(result.previousSlot)}</code> → <code>${escapeHtmlForTg(result.newSlot)}</code>. Agent restarted.`, { html: true })
-    return
-  }
-  if (result.kind === 'exhausted-all') {
-    await switchroomReply(ctx, `🚨 All slots quota-exhausted. Run <code>/auth add</code> to attach another subscription.`, { html: true })
-    return
-  }
-  if (result.kind === 'error') {
-    await switchroomReply(ctx, `❌ /authfallback error: ${escapeHtmlForTg(result.message)}`, { html: true })
-    return
-  }
-  await switchroomReply(ctx, `No action: ${escapeHtmlForTg(result.reason)}`, { html: true })
-})
+// /authfallback was removed in v0.6.12 — it duplicated the work of
+// the dashboard's Switch primary picker (operator-facing surface) and
+// the auto-fallback poller (transparent on-quota-wall case).
+// Operators who want to manually shuffle the active credential now
+// use the picker. The `runAutoFallbackCheck` function and the
+// `case 'fallback':` callback dispatch stay in the codebase: any
+// pinned messages from earlier versions still work, and the
+// auto-fallback poller still calls runAutoFallbackCheck directly.
 
 bot.command('auth', async ctx => {
   if (!isAuthorizedSender(ctx)) return
@@ -9905,7 +9897,9 @@ void (async () => {
         //
         // Default poll cadence: every 60 minutes. Set
         // SWITCHROOM_AUTO_FALLBACK_POLL_MS=0 to disable the background
-        // poller (users can still trigger a check via /authfallback).
+        // poller. Pre-v0.6.12 a manual `/authfallback` typed command
+        // also ran the same check; that command was removed in favour
+        // of the `/auth` dashboard's Switch primary picker.
         const AUTO_FALLBACK_POLL_MS = Number(process.env.SWITCHROOM_AUTO_FALLBACK_POLL_MS ?? 60 * 60_000)
         if (AUTO_FALLBACK_POLL_MS > 0) {
           setInterval(() => { void runAutoFallbackCheck({ trigger: 'scheduled' }) }, AUTO_FALLBACK_POLL_MS).unref()

--- a/telegram-plugin/tests/auth-dashboard-v3b.test.ts
+++ b/telegram-plugin/tests/auth-dashboard-v3b.test.ts
@@ -461,3 +461,99 @@ describe("v3b: buildAccountPromoteConfirmKeyboard", () => {
     expect(cancel?.callback_data).toBe("auth:refresh:clerk");
   });
 });
+
+describe("regression: button count cap on the main board", () => {
+  // Real-world wedge: a screenshot from /auth showed 8 buttons stacked
+  // vertically on a three-account fleet (the v3b explosion). v3c
+  // collapsed everything into a Switch primary picker. Pin the cap so
+  // a future "let's add one more affordance" PR can't bring it back.
+  const renderRows = (accounts: AccountSummary[]): number => {
+    const kb = buildDashboardKeyboard({ ...baseState, accounts });
+    return (
+      kb as unknown as {
+        inline_keyboard: Array<Array<{ text: string; callback_data: string }>>;
+      }
+    ).inline_keyboard.length;
+  };
+
+  it("renders <=6 keyboard rows with three accounts (down from 8 in v3b)", () => {
+    // pixsoul (active) + 2 fallbacks. Expected layout:
+    //   row 1: 🔀 Switch primary →
+    //   row 2: 🔄 Reauth + ➕ Add slot  (2 buttons, 1 row)
+    //   row 3: 📊 Full quota
+    //   row 4: 🔁 Refresh
+    // = 4 rows. Cap at 6 leaves room for a future row without letting
+    // the v3b explosion return.
+    expect(
+      renderRows([
+        acc("pixsoul@gmail.com", { activeForThisAgent: true }),
+        acc("me@kenthompson.com.au"),
+        acc("ken.thompson@outlook.com.au"),
+      ]),
+    ).toBeLessThanOrEqual(6);
+  });
+
+  it("never emits a Promote button targeting the active account", () => {
+    // The original screenshot bug: ⤴ Promote pixsoul@gmail.com
+    // appeared even when pixsoul was the active row. Pin that no
+    // promote callback (apr/cpr verbs) targets the active label.
+    const kb = buildDashboardKeyboard({
+      ...baseState,
+      accounts: [
+        acc("pixsoul@gmail.com", { activeForThisAgent: true }),
+        acc("me@kenthompson.com.au"),
+      ],
+    });
+    const allButtons = (
+      kb as unknown as {
+        inline_keyboard: Array<Array<{ text: string; callback_data: string }>>;
+      }
+    ).inline_keyboard.flat();
+    for (const btn of allButtons) {
+      const m = btn.callback_data.match(/^auth:(?:apr|cpr):[^:]+:(.+)$/);
+      if (m) {
+        expect(m[1], "active label found in promote callback").not.toBe(
+          "pixsoul@gmail.com",
+        );
+      }
+    }
+  });
+});
+
+describe("regression: [⚠️ Fall back now] button stays gone (v0.6.11)", () => {
+  // Removed when the Switch primary picker became the operator-facing
+  // surface for the same outcome. Two paths to the same action
+  // confused operators. If quotaHot ever re-surfaces the button, this
+  // test catches it.
+  it("absent regardless of quotaHot, slot health, or accounts shape", () => {
+    const cases: Array<Parameters<typeof buildDashboardKeyboard>[0]> = [
+      { ...baseState, quotaHot: false },
+      { ...baseState, quotaHot: true },
+      {
+        ...baseState,
+        quotaHot: true,
+        slots: [{ slot: "default", active: true, health: "quota-exhausted" }],
+      },
+      {
+        ...baseState,
+        accounts: [
+          acc("pixsoul", { activeForThisAgent: true, fiveHourPct: 99 }),
+        ],
+      },
+    ];
+    for (const state of cases) {
+      const kb = buildDashboardKeyboard(state);
+      const labels = (
+        kb as unknown as {
+          inline_keyboard: Array<Array<{ text: string; callback_data: string }>>;
+        }
+      ).inline_keyboard
+        .flat()
+        .map((b) => b.text);
+      expect(
+        labels.some((t) => /fall.?back/i.test(t)),
+        `Fall back surfaced under quotaHot=${state.quotaHot}, slots=${state.slots?.length}`,
+      ).toBe(false);
+    }
+  });
+});

--- a/telegram-plugin/tests/quota-check.test.ts
+++ b/telegram-plugin/tests/quota-check.test.ts
@@ -486,6 +486,106 @@ describe('getCachedAccountQuota + prefetchAccountQuotaIfStale', () => {
   })
 })
 
+describe('regression: boot-warm + delayed sync-read (v0.6.11)', () => {
+  // The bug: gateway boot-warm fills the cache; cache TTL elapses;
+  // dashboard's sync read returns null; operator sees empty quota
+  // rows on first /auth tap of the session past TTL. Fix: sync read
+  // returns last-known data regardless of staleness; prefetch path
+  // owns the freshness contract. Pin both legs so a future TTL
+  // tweak can't silently re-introduce the bug.
+  it('returns last-known data even after multiple TTL windows have elapsed', async () => {
+    clearAccountQuotaCache()
+    const home = makeAccountHome({
+      'pixsoul@gmail.com': { accessToken: 'tok' },
+    })
+    try {
+      const t0 = 1_000_000
+      // Boot-warm: probe completes at t0.
+      await fetchAccountQuota('pixsoul@gmail.com', {
+        home,
+        fetchImpl: (async () =>
+          new Response('{}', {
+            status: 200,
+            headers: {
+              'anthropic-ratelimit-unified-5h-utilization': '0.04',
+              'anthropic-ratelimit-unified-7d-utilization': '0.78',
+            },
+          })) as typeof fetch,
+        now: () => t0,
+      })
+      // 8.5 minutes later (the screenshot-reproduction window): the
+      // dashboard fetches state. Sync read returns the boot-warmed
+      // values rather than null.
+      const tDashboard = t0 + 8.5 * 60_000
+      const cached = getCachedAccountQuota('pixsoul@gmail.com', tDashboard)
+      expect(cached).not.toBeNull()
+      if (cached?.ok) {
+        expect(cached.data.fiveHourUtilizationPct).toBe(4)
+        expect(cached.data.sevenDayUtilizationPct).toBe(78)
+      } else {
+        throw new Error('expected ok=true cached entry')
+      }
+    } finally {
+      rmSync(home, { recursive: true, force: true })
+    }
+  })
+
+  it('prefetchAccountQuotaIfStale re-probes once the TTL has elapsed', async () => {
+    clearAccountQuotaCache()
+    const home = makeAccountHome({
+      'work@example.com': { accessToken: 'tok' },
+    })
+    try {
+      const t0 = 1_000_000
+      let fetchCount = 0
+      const counterFetch: typeof fetch = async () => {
+        fetchCount++
+        return new Response('{}', {
+          status: 200,
+          headers: {
+            'anthropic-ratelimit-unified-5h-utilization': '0.10',
+            'anthropic-ratelimit-unified-7d-utilization': '0.20',
+          },
+        })
+      }
+      // First probe seeds the cache.
+      await fetchAccountQuota('work@example.com', {
+        home,
+        fetchImpl: counterFetch,
+        now: () => t0,
+      })
+      expect(fetchCount).toBe(1)
+      // Within TTL: prefetch is a no-op.
+      prefetchAccountQuotaIfStale('work@example.com', {
+        home,
+        fetchImpl: counterFetch,
+        now: () => t0 + 60_000,
+      })
+      // Give microtask queue a chance — should still be 1.
+      await new Promise((r) => setTimeout(r, 5))
+      expect(fetchCount).toBe(1)
+      // Past TTL: prefetch fires a fresh probe.
+      prefetchAccountQuotaIfStale('work@example.com', {
+        home,
+        fetchImpl: counterFetch,
+        now: () => t0 + ACCOUNT_QUOTA_CACHE_TTL_MS + 1,
+      })
+      // Wait for the fire-and-forget probe to complete.
+      await new Promise((r) => setTimeout(r, 20))
+      expect(fetchCount).toBe(2)
+    } finally {
+      rmSync(home, { recursive: true, force: true })
+    }
+  })
+
+  it('cache TTL is at least 1 minute — short TTLs cause empty-row regressions', () => {
+    // Pre-v0.6.11 was 30s, which made the boot-warm useless. If a
+    // future PR drops it below 60s, this test catches it before the
+    // empty-row regression hits production.
+    expect(ACCOUNT_QUOTA_CACHE_TTL_MS).toBeGreaterThanOrEqual(60_000)
+  })
+})
+
 describe('fetchQuota — accessToken parameter', () => {
   it('accepts a direct accessToken instead of a config dir', async () => {
     const fakeFetch = async (_url: unknown, init?: RequestInit) => {

--- a/telegram-plugin/tests/welcome-text.test.ts
+++ b/telegram-plugin/tests/welcome-text.test.ts
@@ -319,6 +319,27 @@ describe("TELEGRAM_MENU_COMMANDS (slash-menu shape)", () => {
     }
   });
 
+  it("does NOT register /authfallback (removed in v0.6.12)", () => {
+    // The /authfallback typed command duplicated the work of the
+    // dashboard's Switch primary picker (operator-facing surface) and
+    // the auto-fallback poller (transparent on-quota-wall case). It
+    // was removed from the slash-menu, the autocomplete helper-list,
+    // AND the help text. If any of those re-surface the command, this
+    // test catches the regression.
+    const menuNames = TELEGRAM_MENU_COMMANDS.map(c => c.command);
+    expect(menuNames, "/authfallback must not be in the slash menu").not.toContain(
+      "authfallback",
+    );
+    expect(
+      switchroomHelpCommandNames as readonly string[],
+      "/authfallback must not be in the autocomplete name list",
+    ).not.toContain("authfallback");
+    const helpDoc = switchroomHelpText("clerk");
+    expect(helpDoc, "/authfallback must not appear in help text").not.toContain(
+      "/authfallback",
+    );
+  });
+
   it("menu is short enough for a mobile keyboard (<= 20 entries)", () => {
     // Hard cap: Telegram autocomplete on mobile shows ~8-10 commands
     // without scrolling. 20 is a generous upper bound.

--- a/telegram-plugin/welcome-text.ts
+++ b/telegram-plugin/welcome-text.ts
@@ -211,8 +211,11 @@ export const switchroomHelpCommandNames = [
   "new", "reset", "approve", "deny", "pending", "interrupt",
   // Agents
   "agents", "agentstart", "stop", "restart", "logs", "memory",
-  // Auth & config
-  "auth", "reauth", "authfallback",
+  // Auth & config. /authfallback was removed in v0.6.12 — the
+  // dashboard's Switch primary picker is the only operator-facing
+  // surface; the auto-fallback poller still handles the
+  // automatic-on-quota-wall case transparently.
+  "auth", "reauth",
   "topics", "update", "version",
   "permissions", "grant", "dangerous", "vault", "doctor",
   "commands",
@@ -268,7 +271,6 @@ export const TELEGRAM_MENU_COMMANDS = [
   // menu entry for each action is the mobile-native behaviour.
   { command: "auth", description: "Auth status (add/list/use/rm/reauth/code)" },
   { command: "reauth", description: "Re-auth Claude for this agent" },
-  { command: "authfallback", description: "Manual quota check + fall back to next slot" },
   // Escape hatch — shows the full catalogue including CLI-only commands
   { command: "commands", description: "Full command list" },
 ] as const;
@@ -313,7 +315,6 @@ export function switchroomHelpText(agentName: string): string {
     `<code>/auth use [agent] &lt;slot&gt;</code> — switch active slot and restart`,
     `<code>/auth rm [agent] &lt;slot&gt; [--force]</code> — remove a slot`,
     `<code>/reauth [agent]</code> — start Claude browser auth`,
-    `<code>/authfallback</code> — manual quota check + fall back to next slot`,
     `<code>/topics</code> — topic-to-agent mappings`,
     `<code>/permissions [agent]</code> — show agent permissions`,
     `<code>/grant &lt;tool&gt;</code> — grant a tool permission`,


### PR DESCRIPTION
## Summary

Drops the `/authfallback` typed Telegram command and adds explicit regression coverage for every screenshot-caught polish in the v3 march (v0.6.10–v0.6.12).

## Why remove `/authfallback`

It duplicated the work of:
- the `/auth` dashboard's **Switch primary picker** (operator-facing surface), and
- the **auto-fallback poller** (transparent on-quota-wall case).

Two paths to the same outcome made the auth surface confusing. The picker is the right operator interface; the poller is the right automatic interface. The typed command had nothing to add.

The `runAutoFallbackCheck` function and the `case 'fallback':` callback dispatch stay — any pinned messages from older versions still work, and the auto-fallback poller still calls `runAutoFallbackCheck` on schedule.

## Regression coverage

The v3 polish has been a march of "screenshot caught X" fixes. This PR pins every one so the next refactor catches the regression at CI time rather than via another screenshot:

- **welcome-text** — `/authfallback` absent from menu, autocomplete, AND help text (3 surfaces).
- **auth-dashboard-v3b**:
  - main board ≤6 keyboard rows with 3 accounts (catches the v3b 8-button explosion)
  - no Promote callback ever targets the active label (catches the screenshot bug where `⤴ Promote pixsoul` showed on the active row)
  - `[⚠️ Fall back now]` absent under every quotaHot / slot-health / accounts-shape combo
- **quota-check**:
  - boot-warm + delayed sync-read returns last-known data after 8.5min (the screenshot reproduction window)
  - `prefetchAccountQuotaIfStale` re-probes once past TTL, no-ops while fresh
  - cache TTL pinned ≥60s so a future PR can't re-create the empty-row bug

## Test plan

- [x] `npm run lint` clean
- [x] 259/259 dashboard + welcome-text + quota tests green
- [ ] Live verification: `/authfallback` no longer in Telegram autocomplete; typing it gets no response (handler removed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)