### PR TITLE
fix(telegram): remove /reauth typed command (v0.6.13)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 ## [Unreleased]
 
+## v0.6.13 — 2026-05-05
+
+### Removed
+
+- **`/reauth` typed Telegram command gone.** Same consolidation
+  rationale as `/authfallback` in v0.6.12: the `/auth` dashboard's
+  `🔄 Reauth default` button fires the identical flow (calls
+  `runSwitchroomAuthCommand` with `auth reauth <agent>` and seeds
+  `pendingReauthFlows`). Two paths to the same outcome made the auth
+  surface confusing.
+  - The OAuth code paste-back still works without a typed command —
+    the generic message intercept watches `pendingReauthFlows` and
+    exchanges any code-shaped paste automatically.
+  - Slash-menu entry, autocomplete name list, and help-text line all
+    dropped.
+  - The `/auth` slash-menu description updated to reflect the
+    consolidated surface ("Auth dashboard — accounts, quota, reauth,
+    switch primary").
+
+### Tests
+
+- `welcome-text` regression test pinning that `/reauth` is absent
+  from the menu, autocomplete, and as a top-level help entry — same
+  shape as the `/authfallback` regression test from v0.6.12.
+
 ## v0.6.12 — 2026-05-05
 
 ### Removed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "switchroom-ai",
-  "version": "0.6.12",
+  "version": "0.6.13",
   "description": "Run Claude Code 24/7 on your Claude Pro/Max subscription over Telegram. Open-source alternative to OpenClaw and NanoClaw — no API keys, no Docker.",
   "type": "module",
   "bin": {

--- a/src/build-info.ts
+++ b/src/build-info.ts
@@ -2,8 +2,8 @@
 // Tracked in git so `tsc --noEmit` works on a fresh clone before `npm run build`.
 // Values are refreshed every time `npm run build` runs.
 
-export const VERSION: string = "0.6.12";
-export const COMMIT_SHA: string | null = "642ffc55";
-export const COMMIT_DATE: string | null = "2026-05-05T18:35:20+10:00";
-export const LATEST_PR: number | null = 703;
+export const VERSION: string = "0.6.13";
+export const COMMIT_SHA: string | null = "530a020b";
+export const COMMIT_DATE: string | null = "2026-05-05T18:59:48+10:00";
+export const LATEST_PR: number | null = 704;
 export const COMMITS_AHEAD_OF_TAG: number | null = 0;

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -7813,40 +7813,16 @@ async function handleAuthDashboardCallback(ctx: Context): Promise<void> {
   }
 }
 
-bot.command('reauth', async ctx => {
-  if (!isAuthorizedSender(ctx)) return
-  const raw = getCommandArgs(ctx).trim()
-  const name = getMyAgentName()
-  const chatId = String(ctx.chat!.id)
-  if (!raw) {
-    await runSwitchroomAuthCommand(ctx, ['auth', 'reauth', name], `auth reauth ${name}`)
-    pendingReauthFlows.set(chatId, { agent: name, startedAt: Date.now() })
-    return
-  }
-  if (raw.startsWith('http') || looksLikeAuthCode(raw)) {
-    const { result, errorText } = execAuthCode(name, raw)
-    if (errorText) {
-      await switchroomReply(ctx, `<b>auth code ${escapeHtmlForTg(name)} failed:</b>\n${preBlock(formatSwitchroomOutput(errorText))}`, { html: true })
-    } else if (result) {
-      const outcomeMsg = renderAuthCodeOutcome(result.outcome)
-      if (outcomeMsg) {
-        await switchroomReply(ctx, outcomeMsg, { html: true })
-      } else {
-        const output = result.instructions.join('\n')
-        const formatted = formatAuthOutputForTelegram(output)
-        await switchroomReply(ctx, formatted.text, { html: true })
-      }
-    }
-    pendingReauthFlows.delete(chatId)
-    // Redact the OAuth code from chat history (#488).
-    redactAuthCodeMessage(bot.api as never, chatId, ctx.message?.message_id ?? null, line => process.stderr.write(line))
-    return
-  }
-  // raw is treated as an agent name
-  try { assertSafeAgentName(raw) } catch { await switchroomReply(ctx, 'Invalid agent name.'); return }
-  await runSwitchroomAuthCommand(ctx, ['auth', 'reauth', raw], `auth reauth ${raw}`)
-  pendingReauthFlows.set(chatId, { agent: raw, startedAt: Date.now() })
-})
+// /reauth was removed in v0.6.13 — the `/auth` dashboard's
+// `🔄 Reauth default` button fires the same flow (the `case 'reauth':`
+// callback dispatch calls `runSwitchroomAuthCommand` and seeds
+// `pendingReauthFlows`). The OAuth code paste-back is caught by the
+// generic message intercept that watches `pendingReauthFlows` —
+// pasting the code into chat now Just Works without a typed entry
+// point. Removed surfaces in this PR:
+//   - bot.command('reauth', ...)              → use /auth → 🔄 Reauth
+//   - /reauth <code|url>  paste-back          → paste into chat
+//   - /reauth <other-agent> targeting         → use that agent's /auth
 
 bot.command('vault', async ctx => {
   if (!isAuthorizedSender(ctx)) return

--- a/telegram-plugin/tests/welcome-text.test.ts
+++ b/telegram-plugin/tests/welcome-text.test.ts
@@ -340,6 +340,33 @@ describe("TELEGRAM_MENU_COMMANDS (slash-menu shape)", () => {
     );
   });
 
+  it("does NOT register /reauth (removed in v0.6.13)", () => {
+    // /reauth was a typed entry point for the same flow the `/auth`
+    // dashboard's `🔄 Reauth` button fires. Two paths to the same
+    // outcome confused operators; the dashboard button is the right
+    // surface (one-tap from the same place quota / promote / add
+    // live). OAuth code paste-back still works without a typed
+    // command — the generic message intercept watches
+    // `pendingReauthFlows` and exchanges any code-shaped paste
+    // automatically.
+    const menuNames = TELEGRAM_MENU_COMMANDS.map(c => c.command);
+    expect(menuNames, "/reauth must not be in the slash menu").not.toContain(
+      "reauth",
+    );
+    expect(
+      switchroomHelpCommandNames as readonly string[],
+      "/reauth must not be in the autocomplete name list",
+    ).not.toContain("reauth");
+    const helpDoc = switchroomHelpText("clerk");
+    // The /auth description string still mentions "reauth" as a
+    // dashboard verb — that's intentional, not a registered command.
+    // Pin that there's no top-level <code>/reauth ...</code> entry.
+    expect(
+      helpDoc,
+      "/reauth must not appear as a top-level command in help text",
+    ).not.toMatch(/<code>\/reauth\b/);
+  });
+
   it("menu is short enough for a mobile keyboard (<= 20 entries)", () => {
     // Hard cap: Telegram autocomplete on mobile shows ~8-10 commands
     // without scrolling. 20 is a generous upper bound.

--- a/telegram-plugin/welcome-text.ts
+++ b/telegram-plugin/welcome-text.ts
@@ -211,11 +211,15 @@ export const switchroomHelpCommandNames = [
   "new", "reset", "approve", "deny", "pending", "interrupt",
   // Agents
   "agents", "agentstart", "stop", "restart", "logs", "memory",
-  // Auth & config. /authfallback was removed in v0.6.12 — the
-  // dashboard's Switch primary picker is the only operator-facing
-  // surface; the auto-fallback poller still handles the
-  // automatic-on-quota-wall case transparently.
-  "auth", "reauth",
+  // Auth & config. The auth surface consolidated onto the `/auth`
+  // dashboard:
+  //   - /authfallback removed in v0.6.12 (Switch primary picker
+  //     handles the operator case; auto-fallback poller handles the
+  //     transparent on-quota-wall case)
+  //   - /reauth removed in v0.6.13 (dashboard's `🔄 Reauth` button
+  //     fires the same flow; paste-back of the OAuth code is caught
+  //     by the generic message intercept on `pendingReauthFlows`)
+  "auth",
   "topics", "update", "version",
   "permissions", "grant", "dangerous", "vault", "doctor",
   "commands",
@@ -269,8 +273,7 @@ export const TELEGRAM_MENU_COMMANDS = [
   // ("keep my subscription the only thing I'm paying for" JTBD: "the
   // user can state in one sentence what they're paying for"). A one-tap
   // menu entry for each action is the mobile-native behaviour.
-  { command: "auth", description: "Auth status (add/list/use/rm/reauth/code)" },
-  { command: "reauth", description: "Re-auth Claude for this agent" },
+  { command: "auth", description: "Auth dashboard — accounts, quota, reauth, switch primary" },
   // Escape hatch — shows the full catalogue including CLI-only commands
   { command: "commands", description: "Full command list" },
 ] as const;
@@ -314,7 +317,6 @@ export function switchroomHelpText(agentName: string): string {
     `<code>/auth list [agent]</code> — list account slots and health`,
     `<code>/auth use [agent] &lt;slot&gt;</code> — switch active slot and restart`,
     `<code>/auth rm [agent] &lt;slot&gt; [--force]</code> — remove a slot`,
-    `<code>/reauth [agent]</code> — start Claude browser auth`,
     `<code>/topics</code> — topic-to-agent mappings`,
     `<code>/permissions [agent]</code> — show agent permissions`,
     `<code>/grant &lt;tool&gt;</code> — grant a tool permission`,


### PR DESCRIPTION
## Summary

Drops the `/reauth` typed Telegram command. Same consolidation rationale as `/authfallback` in v0.6.12 — the `/auth` dashboard's `🔄 Reauth default` button fires the identical flow.

## What works after the removal

- **Start reauth**: `/auth` → tap `🔄 Reauth default`. Same `runSwitchroomAuthCommand` call, same `pendingReauthFlows.set` seeding.
- **Paste OAuth code back**: paste the URL or code into chat. The generic message intercept watches `pendingReauthFlows` and exchanges code-shaped pastes automatically — no typed command needed.
- **Reauth a different agent**: open that agent's `/auth` and tap its Reauth button (this is how typed agents already worked since cross-agent ops are rare).

## Removed surfaces

- `bot.command('reauth', ...)` handler in gateway.ts
- `"reauth"` entry from `switchroomHelpCommandNames` autocomplete list
- `{ command: "reauth", ... }` from `TELEGRAM_MENU_COMMANDS` slash menu
- `<code>/reauth [agent]</code>` help line in `switchroomHelpText`
- `/auth` menu description updated to reflect the consolidated surface

## Regression test

Pins that `/reauth` is absent from menu, autocomplete, and as a top-level help entry. Same shape as the `/authfallback` regression test from v0.6.12.

## Test plan

- [x] `npm run lint` clean
- [x] 54/54 welcome-text tests green
- [ ] Live verification: `/reauth` no longer in Telegram autocomplete; `/auth` → Reauth button still works; paste-back of code still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)