### PR TITLE
chore: release v0.6.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 ## [Unreleased]
 
+## v0.6.14 — 2026-05-05
+
+Bundle re-release. v0.6.13's /reauth removal is in this version too —
+v0.6.13 was tagged on GitHub but the npm publish was rejected by
+prepublishOnly (the architectural-pin test for `redactAuthCodeMessage`
+call sites needed its floor lowered after the /reauth handler was
+removed). v0.6.14 ships both:
+
+- **#705** — remove /reauth typed Telegram command
+- **#706** — update redactAuthCodeMessage call-site pin (test floor
+  3 → 2; docstring updated to reflect the 2 remaining call sites:
+  generic intercept + /auth code intent)
+
+The v0.6.13 git tag stays for historical accuracy; npm consumers
+should install v0.6.14.
+
 ## v0.6.13 — 2026-05-05
 
 ### Removed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "switchroom-ai",
-  "version": "0.6.13",
+  "version": "0.6.14",
   "description": "Run Claude Code 24/7 on your Claude Pro/Max subscription over Telegram. Open-source alternative to OpenClaw and NanoClaw — no API keys, no Docker.",
   "type": "module",
   "bin": {

--- a/src/build-info.ts
+++ b/src/build-info.ts
@@ -2,8 +2,8 @@
 // Tracked in git so `tsc --noEmit` works on a fresh clone before `npm run build`.
 // Values are refreshed every time `npm run build` runs.
 
-export const VERSION: string = "0.6.13";
-export const COMMIT_SHA: string | null = "530a020b";
-export const COMMIT_DATE: string | null = "2026-05-05T18:59:48+10:00";
-export const LATEST_PR: number | null = 704;
-export const COMMITS_AHEAD_OF_TAG: number | null = 0;
+export const VERSION: string = "0.6.14";
+export const COMMIT_SHA: string | null = "cd67d7ca";
+export const COMMIT_DATE: string | null = "2026-05-05T19:33:03+10:00";
+export const LATEST_PR: number | null = 706;
+export const COMMITS_AHEAD_OF_TAG: number | null = 1;


### PR DESCRIPTION
Bundles v0.6.13's /reauth removal (#705) + the pin-test fix that prepublishOnly caught (#706). v0.6.13 was tagged on GitHub but never reached npm — v0.6.14 is what consumers install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)