### PR TITLE
fix(telegram): inline-keyboard tap feedback (#710)

### DIFF
--- a/telegram-plugin/bridge/bridge.ts
+++ b/telegram-plugin/bridge/bridge.ts
@@ -110,7 +110,7 @@ const TOOL_SCHEMAS = [
         quote_text: { type: 'string', description: 'Surgical quote: specific text to highlight from the reply_to message. Requires reply_to.' },
         inline_keyboard: {
           type: 'array',
-          description: 'Optional 2D array of tappable buttons rendered under the message. Outer array = rows; inner array = buttons in each row (max 8 per row, 8 rows). Each button needs a `text` (label, max 64 chars) plus EXACTLY ONE of: `url` (opens link in browser; must start with http(s):// or tg://) or `callback_data` (string, max 58 chars; tap is delivered to this agent as an inbound channel event with meta.button_callback_data=<the data> and the original button_text). Use buttons for single-tap approval/triage flows like [Approve] [Hold]; one tap on mobile beats asking the user to type YES/NO.',
+          description: 'Optional 2D array of tappable buttons rendered under the message. Outer array = rows; inner array = buttons in each row (max 8 per row, 8 rows). Each button needs a `text` (label, max 64 chars) plus EXACTLY ONE of: `url` (opens link in browser; must start with http(s):// or tg://) or `callback_data` (string, max 58 chars; tap is delivered to this agent as an inbound channel event with meta.button_callback_data=<the data> and the original button_text). Use buttons for single-tap approval/triage flows like [Approve] [Hold]; one tap on mobile beats asking the user to type YES/NO. By default a tap shows a brief "✓ received" toast and removes the entire keyboard so the user can\'t double-fire — override per-button via `ack_text` (custom toast text, max 200 chars) and `single_use: false` (preserve the keyboard so e.g. a [Refresh] button stays tappable).',
           items: {
             type: 'array',
             items: {
@@ -119,6 +119,8 @@ const TOOL_SCHEMAS = [
                 text: { type: 'string', description: 'Button label visible to the user. Max 64 chars.' },
                 url: { type: 'string', description: 'Open this URL when tapped. Mutually exclusive with callback_data.' },
                 callback_data: { type: 'string', description: 'Opaque tag delivered back to the agent on tap. Max 58 chars (gateway prepends an `agent:` prefix to the 64-byte Telegram limit). Mutually exclusive with url.' },
+                ack_text: { type: 'string', description: 'Toast text shown to the user the instant they tap this button (#710). Default "✓ received". Max ~200 chars (Telegram answerCallbackQuery limit). Has no effect on URL buttons.' },
+                single_use: { type: 'boolean', description: 'When true (default) tapping any single_use button on the message removes the entire keyboard so the user can\'t double-fire. Set false on buttons that should stay tappable (e.g. a "Refresh" button). If ANY button on the message has single_use:false the keyboard is preserved on tap.' },
               },
               required: ['text'],
             },
@@ -146,7 +148,7 @@ const TOOL_SCHEMAS = [
         quote_text: { type: 'string', description: 'Surgical quote: specific text to highlight from the reply_to message. Requires reply_to.' },
         inline_keyboard: {
           type: 'array',
-          description: '2D array of tappable buttons under the final message. Same shape and constraints as `reply.inline_keyboard` — each button has `text` and EXACTLY ONE of `url` or `callback_data`. Tap on a callback_data button is delivered to this agent as an inbound channel event with meta.button_callback_data set.',
+          description: '2D array of tappable buttons under the final message. Same shape and constraints as `reply.inline_keyboard` — each button has `text` and EXACTLY ONE of `url` or `callback_data`, plus optional `ack_text` (custom tap-toast; default "✓ received") and `single_use` (default true; set false to keep the keyboard tappable after a tap). Tap on a callback_data button is delivered to this agent as an inbound channel event with meta.button_callback_data set.',
           items: {
             type: 'array',
             items: {
@@ -155,6 +157,8 @@ const TOOL_SCHEMAS = [
                 text: { type: 'string' },
                 url: { type: 'string' },
                 callback_data: { type: 'string' },
+                ack_text: { type: 'string', description: 'Toast text shown on tap. Default "✓ received".' },
+                single_use: { type: 'boolean', description: 'Default true. Set false to keep the keyboard tappable after this button is tapped.' },
               },
               required: ['text'],
             },

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -133,6 +133,9 @@ import {
 import {
   wrapAgentCallbacks,
   parseAgentCallback,
+  extractAgentButtonMeta,
+  keyboardIsSingleUse,
+  type AgentButtonMeta,
 } from '../inline-keyboard-callbacks.js'
 import {
   startText as buildStartText,
@@ -1202,6 +1205,32 @@ const pendingAskUser = new Map<string, PendingAskUser>()
 const pendingReauthFlows = new Map<string, { agent: string; startedAt: number }>()
 const REAUTH_INTERCEPT_TTL_MS = 10 * 60_000
 
+// #710: per-message agent-button metadata (ack_text / single_use). Keyed by
+// `${chatId}:${messageId}` → Map<rawCallbackData, AgentButtonMeta>. Populated
+// when an agent-emitted inline_keyboard is sent; consumed by the
+// callback_query handler to honor agent-specified post-tap UX. Bounded by
+// AGENT_BUTTON_META_MAX (LRU-ish — oldest insertion deleted when over cap)
+// so a long-lived gateway can't grow the map unbounded. Restart-safe by
+// design: when this map is empty (e.g. fresh process) the defaults apply
+// (`'✓ received'` toast + strip keyboard) — the agent only loses any
+// custom ack_text override.
+const agentButtonMeta = new Map<string, Map<string, AgentButtonMeta>>()
+const AGENT_BUTTON_META_MAX = 1000
+function rememberAgentButtonMeta(
+  chatId: string | number,
+  messageId: number,
+  meta: Map<string, AgentButtonMeta>,
+): void {
+  if (meta.size === 0) return
+  const key = `${chatId}:${messageId}`
+  agentButtonMeta.set(key, meta)
+  while (agentButtonMeta.size > AGENT_BUTTON_META_MAX) {
+    const oldest = agentButtonMeta.keys().next().value
+    if (oldest === undefined) break
+    agentButtonMeta.delete(oldest)
+  }
+}
+
 // Vault
 const vaultPassphraseCache = new Map<string, { passphrase: string; expiresAt: number }>()
 const VAULT_PASSPHRASE_TTL_MS = 30 * 60 * 1000
@@ -2245,6 +2274,7 @@ async function executeReply(args: Record<string, unknown>): Promise<{ content: A
   // pass through unchanged. Attached to the LAST chunk only so buttons
   // appear on the final visible message.
   let replyMarkup: { inline_keyboard: AnyButton[][] } | undefined
+  let replyButtonMeta: Map<string, AgentButtonMeta> | undefined
   const rawKeyboard = args.inline_keyboard as AnyButton[][] | undefined
   if (rawKeyboard != null) {
     const validationErrors = validateInlineKeyboard(rawKeyboard)
@@ -2254,6 +2284,7 @@ async function executeReply(args: Record<string, unknown>): Promise<{ content: A
         .join('; ')
       throw new Error(`inline_keyboard validation failed: ${summary}`)
     }
+    replyButtonMeta = extractAgentButtonMeta(rawKeyboard)
     replyMarkup = { inline_keyboard: wrapAgentCallbacks(rawKeyboard) }
   }
 
@@ -2368,6 +2399,16 @@ async function executeReply(args: Record<string, unknown>): Promise<{ content: A
     throw new Error(`reply failed after ${sentIds.length} of ${chunks.length} chunk(s) sent: ${msg}`)
   } finally {
     stopTypingLoop(chat_id)
+  }
+
+  // #710: remember per-button agent meta (ack_text / single_use) keyed
+  // by the message that actually carries the keyboard — that's the last
+  // text chunk, since the keyboard is attached only on isLastChunk.
+  if (replyButtonMeta != null && replyButtonMeta.size > 0 && sentIds.length >= chunks.length) {
+    const keyboardMsgId = sentIds[chunks.length - 1]
+    if (typeof keyboardMsgId === 'number') {
+      rememberAgentButtonMeta(chat_id, keyboardMsgId, replyButtonMeta)
+    }
   }
 
   // #273: when files is 2-10 photos, batch them into a single
@@ -2514,6 +2555,7 @@ async function executeStreamReply(args: Record<string, unknown>): Promise<unknow
   // this agent. Only attached on done=true so buttons land on the
   // final answer message, not on intermediate draft edits.
   let streamReplyMarkup: { inline_keyboard: AnyButton[][] } | undefined
+  let streamButtonMeta: Map<string, AgentButtonMeta> | undefined
   const rawStreamKeyboard = args.inline_keyboard as AnyButton[][] | undefined
   if (rawStreamKeyboard != null && Boolean(args.done)) {
     const validationErrors = validateInlineKeyboard(rawStreamKeyboard)
@@ -2523,6 +2565,7 @@ async function executeStreamReply(args: Record<string, unknown>): Promise<unknow
         .join('; ')
       throw new Error(`inline_keyboard validation failed: ${summary}`)
     }
+    streamButtonMeta = extractAgentButtonMeta(rawStreamKeyboard)
     streamReplyMarkup = { inline_keyboard: wrapAgentCallbacks(rawStreamKeyboard) }
   }
 
@@ -2610,6 +2653,16 @@ async function executeStreamReply(args: Record<string, unknown>): Promise<unknow
         Date.now(),
       )
     } catch { /* best-effort signal */ }
+  }
+  // #710: stash agent-button meta keyed by the final message id so the
+  // callback handler can honor ack_text / single_use on tap.
+  if (
+    args.done === true
+    && result.messageId != null
+    && streamButtonMeta != null
+    && streamButtonMeta.size > 0
+  ) {
+    rememberAgentButtonMeta(args.chat_id as string, result.messageId, streamButtonMeta)
   }
   // #546 dedup record: capture the final stream_reply text on the
   // terminal call so a subsequent retry (different bridge, same
@@ -8144,11 +8197,21 @@ bot.on('callback_query:data', async ctx => {
       await ctx.answerCallbackQuery({ text: 'Not authorized.' }).catch(() => {})
       return
     }
-    // Ack the spinner FIRST so the user doesn't see it stick if the
-    // forward path takes a moment.
-    await ctx.answerCallbackQuery().catch(() => {})
     const cbChatId = String(ctx.chat?.id ?? ctx.from.id)
     const cbMessageId = ctx.callbackQuery?.message?.message_id
+    // #710: look up agent-supplied per-button meta (ack_text / single_use)
+    // stashed at send time. Empty map after a gateway restart — defaults
+    // still give the user-visible toast + keyboard removal.
+    const metaForMessage = cbMessageId != null
+      ? agentButtonMeta.get(`${cbChatId}:${cbMessageId}`)
+      : undefined
+    const tapMeta = metaForMessage?.get(agentCb.raw)
+    const ackText = (typeof tapMeta?.ack_text === 'string' && tapMeta.ack_text.length > 0)
+      ? tapMeta.ack_text
+      : '✓ received'
+    // Ack the spinner FIRST with a visible toast so the user knows the
+    // tap registered (#710 — empty ack showed nothing, users re-tapped).
+    await ctx.answerCallbackQuery({ text: ackText }).catch(() => {})
     const buttonText = (() => {
       // Best-effort: pull the tapped button's label from the source
       // message's keyboard so the agent gets a human-readable echo.
@@ -8208,6 +8271,21 @@ bot.on('callback_query:data', async ctx => {
         '⏳ Agent is restarting — your button tap was queued but won\'t be processed until it comes back.',
         cbThreadId != null ? { message_thread_id: cbThreadId } : {},
       ).catch(() => {})
+    }
+    // #710: strip the keyboard after tap so the buttons can't be
+    // double-fired. Default policy is single-use — preserve the
+    // keyboard only if at least one button on the message explicitly
+    // opts out via `single_use: false`. With no stashed meta (e.g.
+    // gateway restarted between send and tap) the default fires too,
+    // which is the desired UX.
+    const stripKeyboard = metaForMessage == null || keyboardIsSingleUse(metaForMessage)
+    if (stripKeyboard && cbMessageId != null) {
+      await ctx.editMessageReplyMarkup({
+        reply_markup: { inline_keyboard: [] },
+      }).catch(() => {})
+      if (metaForMessage != null) {
+        agentButtonMeta.delete(`${cbChatId}:${cbMessageId}`)
+      }
     }
     return
   }

--- a/telegram-plugin/inline-keyboard-callbacks.ts
+++ b/telegram-plugin/inline-keyboard-callbacks.ts
@@ -45,9 +45,35 @@ export const AGENT_CALLBACK_PREFIX = 'agent:'
 export const AGENT_CALLBACK_DATA_MAX = 64 - AGENT_CALLBACK_PREFIX.length
 
 /**
+ * Per-button agent-supplied metadata that controls post-tap UX (#710).
+ * These fields are stripped before the keyboard is sent to Telegram —
+ * they are NOT part of the Bot API. The gateway extracts and stores
+ * them via {@link extractAgentButtonMeta} so the callback handler can
+ * honor them when the user taps.
+ */
+export interface AgentButtonMeta {
+  /** Toast text shown via answerCallbackQuery on tap. Default `'✓ received'`. */
+  ack_text?: string
+  /**
+   * When false, the button keyboard is preserved after tap (re-tappable).
+   * When true (default), tapping ANY single_use button on the message
+   * removes the entire keyboard to prevent double-fire.
+   */
+  single_use?: boolean
+}
+
+/** Fields the gateway adds to button objects — not valid Telegram API fields. */
+const AGENT_META_FIELDS: ReadonlyArray<keyof AgentButtonMeta> = ['ack_text', 'single_use']
+
+/**
  * Wrap every callback_data field in a 2D inline-keyboard with the
  * gateway's `agent:` namespace prefix. URL-only buttons pass through
  * unchanged. Returns a fresh array — does not mutate the input.
+ *
+ * Also strips agent-only meta fields (`ack_text`, `single_use`) so they
+ * don't leak into the Telegram API request. Use
+ * {@link extractAgentButtonMeta} on the raw keyboard BEFORE wrapping to
+ * recover those fields for the callback handler.
  *
  * Throws when an agent-supplied callback_data exceeds the effective
  * 58-byte budget (so the operator sees a clear error, not a silent
@@ -56,7 +82,9 @@ export const AGENT_CALLBACK_DATA_MAX = 64 - AGENT_CALLBACK_PREFIX.length
 export function wrapAgentCallbacks(keyboard: AnyButton[][]): AnyButton[][] {
   return keyboard.map((row) =>
     row.map((btn) => {
-      if (typeof btn.callback_data !== 'string') return btn
+      const cleaned: AnyButton = { ...btn }
+      for (const f of AGENT_META_FIELDS) delete cleaned[f]
+      if (typeof btn.callback_data !== 'string') return cleaned
       const raw = btn.callback_data
       const rawBytes = new TextEncoder().encode(raw).byteLength
       if (rawBytes > AGENT_CALLBACK_DATA_MAX) {
@@ -65,9 +93,50 @@ export function wrapAgentCallbacks(keyboard: AnyButton[][]): AnyButton[][] {
           `(actual=${rawBytes}, raw="${raw.slice(0, 32)}${raw.length > 32 ? '…' : ''}")`,
         )
       }
-      return { ...btn, callback_data: `${AGENT_CALLBACK_PREFIX}${raw}` }
+      cleaned.callback_data = `${AGENT_CALLBACK_PREFIX}${raw}`
+      return cleaned
     }),
   )
+}
+
+/**
+ * Extract per-button {@link AgentButtonMeta} from a raw (pre-wrap)
+ * keyboard. Returns a map keyed by the raw (unprefixed) callback_data
+ * string. Buttons without callback_data or without any meta fields are
+ * omitted. Used by the gateway to remember post-tap UX preferences for
+ * each button on a sent message.
+ */
+export function extractAgentButtonMeta(
+  keyboard: AnyButton[][],
+): Map<string, AgentButtonMeta> {
+  const out = new Map<string, AgentButtonMeta>()
+  for (const row of keyboard) {
+    for (const btn of row) {
+      if (typeof btn.callback_data !== 'string') continue
+      const meta: AgentButtonMeta = {}
+      if (typeof btn.ack_text === 'string') meta.ack_text = btn.ack_text
+      if (typeof btn.single_use === 'boolean') meta.single_use = btn.single_use
+      if (meta.ack_text != null || meta.single_use != null) {
+        out.set(btn.callback_data, meta)
+      }
+    }
+  }
+  return out
+}
+
+/**
+ * Aggregate the message-level "should we strip the keyboard after a tap"
+ * decision (#710). Default policy is single-use=true. The keyboard is
+ * preserved only when at least one button on the message explicitly opts
+ * out via `single_use: false`.
+ */
+export function keyboardIsSingleUse(
+  metaByRawData: Map<string, AgentButtonMeta>,
+): boolean {
+  for (const meta of metaByRawData.values()) {
+    if (meta.single_use === false) return false
+  }
+  return true
 }
 
 /**


### PR DESCRIPTION
Closes #710.

## Summary

Two layers of feedback when a user taps an agent-emitted inline-keyboard button — previously the tap registered silently with no toast and the keyboard stayed live, so users re-tapped and the agent saw duplicate events.

- **Toast on ack.** `answerCallbackQuery` now passes `text` — default `'✓ received'`, overridable per-button via a new `ack_text` field on the agent-supplied button spec.
- **Single-use keyboard.** After forwarding the tap to the agent, the gateway strips the message's `reply_markup` so the buttons can't be tapped again. Per-button `single_use` field (default `true`) lets agents opt out for buttons that should remain tappable (e.g. a Refresh button) — if ANY button on the message has `single_use: false`, the keyboard is preserved.

## Implementation

- `inline-keyboard-callbacks.ts` — new `extractAgentButtonMeta()` and `keyboardIsSingleUse()` helpers; `wrapAgentCallbacks()` now strips the agent-only meta fields so they don't leak into the Telegram API call.
- `gateway/gateway.ts` — bounded in-process map (1000 entries, LRU-ish) keyed by `chatId:messageId` remembers per-button meta from send time so the callback handler can honor `ack_text`. Restart-safe: empty map after a fresh boot still gives the default `'✓ received'` toast and keyboard removal.
- `bridge/bridge.ts` — MCP tool schemas for `reply` and `stream_reply` document the new optional `ack_text` and `single_use` fields.

## Test plan

- [x] `bun test` — 3129 pass / 0 fail / 2 skip across 207 files
- [x] `bunx tsc --noEmit` — clean
- [ ] Manual: tap an agent button on Telegram; confirm toast appears and keyboard disappears
- [ ] Manual: emit a button with `single_use: false`; confirm keyboard stays after tap
- [ ] Manual: emit a button with `ack_text: "Filing…"`; confirm custom toast text shows

🤖 Generated with [Claude Code](https://claude.com/claude-code)