### PR TITLE
feat: detect capped sub-agents and surface as terminal state (#650, #672)

### DIFF
--- a/telegram-plugin/fleet-state.ts
+++ b/telegram-plugin/fleet-state.ts
@@ -19,7 +19,7 @@
 const ROLE_FALLBACK_LEN = 20
 const SANITISE_MAX_LEN = 120
 
-export type FleetStatus = 'running' | 'background' | 'done' | 'failed' | 'stuck' | 'killed'
+export type FleetStatus = 'running' | 'background' | 'done' | 'failed' | 'stuck' | 'killed' | 'capped'
 
 export interface FleetMember {
   agentId: string
@@ -94,6 +94,26 @@ export function applyTurnEnd(member: FleetMember, now: number): FleetMember {
   return {
     ...member,
     status: member.errorSeen ? 'failed' : 'done',
+    terminalAt: now,
+    lastActivityAt: now,
+  }
+}
+
+/**
+ * Transition a fleet member to `capped` terminal state.
+ *
+ * Called when session-tail detects a truncated sub-agent transcript:
+ * >= CAP_TOOL_USE_THRESHOLD tool_uses recorded with no `type:result` /
+ * `subtype:end` / `type:final` terminal record. The sub-agent was killed
+ * mid-flight (parent restart, watchdog SIGTERM, etc.) before it could
+ * write its completion record. Idempotent — already-terminal members
+ * are left unchanged.
+ */
+export function applyCapped(member: FleetMember, now: number): FleetMember {
+  if (member.terminalAt != null) return member
+  return {
+    ...member,
+    status: 'capped',
     terminalAt: now,
     lastActivityAt: now,
   }

--- a/telegram-plugin/progress-card-driver.ts
+++ b/telegram-plugin/progress-card-driver.ts
@@ -27,6 +27,7 @@ import {
 } from './progress-card.js'
 import { isTelegramReplyTool } from './tool-names.js'
 import {
+  applyCapped as fleetApplyCapped,
   applyToolResult as fleetApplyToolResult,
   applyToolUse as fleetApplyToolUse,
   applyTurnEnd as fleetApplyTurnEnd,
@@ -1779,6 +1780,20 @@ export function createProgressDriver(config: ProgressDriverConfig): ProgressDriv
         cs.fleet.set(event.agentId, fleetApplyTurnEnd(m, now()))
         return
       }
+      case 'sub_agent_capped': {
+        // The sub-agent transcript was truncated mid-flight: >= threshold
+        // tool_uses with no terminal record. Transition the fleet member to
+        // `capped` so the progress card shows a terminal "capped" row instead
+        // of hanging "running" indefinitely. Also drive the legacy reducer via
+        // sub_agent_turn_end so the subAgents map stays consistent.
+        const m = cs.fleet.get(event.agentId)
+        if (m != null) {
+          cs.fleet.set(event.agentId, fleetApplyCapped(m, now()))
+        }
+        // Mirror into the legacy reducer so render() sees the agent as done.
+        cs.state = reduce(cs.state, { kind: 'sub_agent_turn_end', agentId: event.agentId }, now())
+        return
+      }
       default:
         return
     }
@@ -2026,6 +2041,7 @@ export function createProgressDriver(config: ProgressDriverConfig): ProgressDriv
         (event.kind === 'sub_agent_tool_use' ||
           event.kind === 'sub_agent_tool_result' ||
           event.kind === 'sub_agent_turn_end' ||
+          event.kind === 'sub_agent_capped' ||
           event.kind === 'sub_agent_started') &&
         'agentId' in event
       ) {

--- a/telegram-plugin/session-tail.ts
+++ b/telegram-plugin/session-tail.ts
@@ -100,6 +100,16 @@ export type SessionEvent =
   | { kind: 'sub_agent_tool_result'; agentId: string; toolUseId: string; isError?: boolean; errorText?: string }
   | { kind: 'sub_agent_turn_end'; agentId: string }
   | { kind: 'sub_agent_nested_spawn'; agentId: string }
+  /**
+   * Emitted when a sub-agent JSONL has >= CAP_TOOL_USE_THRESHOLD tool_use
+   * records but no terminal record (no `type:result`, `subtype:end`, or
+   * `type:final`). This indicates the sub-agent was killed mid-flight
+   * (parent restart, watchdog SIGTERM, etc.) before writing its completion.
+   * The progress-card driver transitions the fleet member to `capped` state
+   * so the card surface shows a terminal "capped" row instead of hanging
+   * "running" forever.
+   */
+  | { kind: 'sub_agent_capped'; agentId: string; toolUseCount: number }
 
 /**
  * Parse the inbound channel XML wrapper to pull out chat_id, message_id,
@@ -614,6 +624,15 @@ export function startSessionTail(config: SessionTailConfig): SessionTailHandle {
   // pattern from PR #25 protects against re-attach truncation.
   const multiAgent = isMultiAgentEnabled()
 
+  /**
+   * Minimum tool_use count that — combined with a missing terminal record —
+   * classifies a sub-agent transcript as truncated/capped rather than merely
+   * in-flight. The triage report (#650) observed truncation at 31–294 tool
+   * uses; 30 is chosen as the lower bound to avoid false-positives on short
+   * sub-agents that are still legitimately running when first reaped.
+   */
+  const CAP_TOOL_USE_THRESHOLD = 30
+
   interface SubTail {
     agentId: string
     file: string
@@ -629,6 +648,12 @@ export function startSessionTail(config: SessionTailConfig): SessionTailHandle {
      * grows again. See MEM2 in the overnight forensic audit on #472.
      */
     lastActivityAt: number
+    /** Running count of tool_use records observed in this sub-agent's JSONL. */
+    toolUseCount: number
+    /** True once a terminal record (type:result / subtype:end / type:final) is seen. */
+    hasSeenTerminal: boolean
+    /** True once we have emitted sub_agent_capped for this sub-agent. */
+    cappedEmitted: boolean
   }
   const subTails = new Map<string, SubTail>() // keyed by absolute file path
 
@@ -665,8 +690,34 @@ export function startSessionTail(config: SessionTailConfig): SessionTailHandle {
       const startState = { hasEmittedStart: t.hasEmittedStart }
       for (const line of lines) {
         if (!line) continue
+        // Track terminal record presence: a sub-agent JSONL terminal line
+        // has type=result, subtype=end, or type=final. These indicate the
+        // harness wrote a proper completion record, so the sub-agent is NOT
+        // capped even if tool_use count is high.
+        if (!t.hasSeenTerminal) {
+          try {
+            const raw = JSON.parse(line) as Record<string, unknown>
+            if (
+              raw.type === 'result' ||
+              raw.type === 'final' ||
+              (raw.type === 'system' && raw.subtype === 'end') ||
+              raw.subtype === 'end'
+            ) {
+              t.hasSeenTerminal = true
+            }
+          } catch { /* ignore parse errors — projectSubagentLine will handle */ }
+        }
         const events = projectSubagentLine(line, t.agentId, startState)
         for (const ev of events) {
+          // Count tool_use events for capped-detection heuristic.
+          if (ev.kind === 'sub_agent_tool_use') {
+            t.toolUseCount++
+          }
+          // sub_agent_turn_end is a synthetic terminal — the parent saw a
+          // system:turn_duration line, meaning the harness completed normally.
+          if (ev.kind === 'sub_agent_turn_end') {
+            t.hasSeenTerminal = true
+          }
           try {
             onEvent(ev)
           } catch (err) {
@@ -698,6 +749,9 @@ export function startSessionTail(config: SessionTailConfig): SessionTailHandle {
       hasEmittedStart: false,
       watcher: null,
       lastActivityAt: Date.now(),
+      toolUseCount: 0,
+      hasSeenTerminal: false,
+      cappedEmitted: false,
     }
     void cursor
     try {
@@ -726,6 +780,20 @@ export function startSessionTail(config: SessionTailConfig): SessionTailHandle {
     const cutoff = Date.now() - IDLE_FSWATCH_TTL_MS
     for (const [file, t] of subTails) {
       if (t.lastActivityAt < cutoff) {
+        // Before reaping: check whether this looks like a capped transcript.
+        // A sub-agent with >= CAP_TOOL_USE_THRESHOLD tool_uses and no terminal
+        // record was most likely killed mid-flight. Emit sub_agent_capped once
+        // so the progress-card driver can transition the fleet member to a
+        // terminal "capped" state rather than leaving it stuck at "running".
+        if (!t.hasSeenTerminal && !t.cappedEmitted && t.toolUseCount >= CAP_TOOL_USE_THRESHOLD) {
+          t.cappedEmitted = true
+          try {
+            onEvent({ kind: 'sub_agent_capped', agentId: t.agentId, toolUseCount: t.toolUseCount })
+          } catch (err) {
+            log?.(`session-tail: sub_agent_capped onEvent threw: ${(err as Error).message}`)
+          }
+          log?.(`session-tail: sub ${t.agentId} capped (${t.toolUseCount} tool_uses, no terminal record)`)
+        }
         if (t.watcher) {
           try { t.watcher.close() } catch { /* ignore */ }
           t.watcher = null

--- a/telegram-plugin/session-tail.ts
+++ b/telegram-plugin/session-tail.ts
@@ -700,6 +700,8 @@ export function startSessionTail(config: SessionTailConfig): SessionTailHandle {
             if (
               raw.type === 'result' ||
               raw.type === 'final' ||
+              raw.type === 'error' ||
+              raw.type === 'cancel' ||
               (raw.type === 'system' && raw.subtype === 'end') ||
               raw.subtype === 'end'
             ) {

--- a/telegram-plugin/tests/session-tail-capped.test.ts
+++ b/telegram-plugin/tests/session-tail-capped.test.ts
@@ -1,0 +1,234 @@
+/**
+ * Unit tests for the sub_agent_capped detection heuristic in session-tail.ts.
+ *
+ * Three fixture categories:
+ *   - "capped": >= 30 tool_uses, no terminal record — truncated mid-flight
+ *   - "completed": has a terminal record (system:turn_duration or type:result)
+ *   - "in-flight": < 30 tool_uses, no terminal — legitimately still running
+ *
+ * These tests drive the SubTail tracking fields via the exported
+ * projectSubagentLine function and the reapIdleSubTails logic indirectly
+ * by constructing the SubTail-like state machine manually.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { projectSubagentLine, type SessionEvent } from '../session-tail.js'
+
+// ─── Helpers ──────────────────────────────────────────────────────────────
+
+function makeToolUseLine(agentId: string, toolName = 'Read', id = 'toolu_01'): string {
+  return JSON.stringify({
+    type: 'assistant',
+    message: {
+      content: [
+        { type: 'tool_use', id, name: toolName, input: { file_path: '/tmp/test.ts' } },
+      ],
+    },
+    isSidechain: true,
+    agentId,
+  })
+}
+
+function makeToolResultLine(agentId: string, toolUseId = 'toolu_01'): string {
+  return JSON.stringify({
+    type: 'user',
+    message: {
+      content: [
+        { type: 'tool_result', tool_use_id: toolUseId, content: 'ok' },
+      ],
+    },
+    isSidechain: true,
+    agentId,
+  })
+}
+
+function makeTerminalLine(): string {
+  return JSON.stringify({ type: 'system', subtype: 'turn_duration', durationMs: 1234 })
+}
+
+function makeResultLine(): string {
+  return JSON.stringify({ type: 'result', subtype: 'success' })
+}
+
+/**
+ * Simulate reading N tool_use + tool_result pairs through projectSubagentLine.
+ * Returns { toolUseCount, hasSeenTerminal } mirroring the SubTail fields.
+ */
+function simulateSubTailReads(
+  agentId: string,
+  toolUseCount: number,
+  terminalLine: string | null = null,
+): { toolUseCount: number; hasSeenTerminal: boolean; events: SessionEvent[] } {
+  const state = { hasEmittedStart: false }
+  const events: SessionEvent[] = []
+  let seenTerminal = false
+  let toolCount = 0
+
+  // First message: the kickoff prompt (user message with string content)
+  const kickoffLine = JSON.stringify({
+    type: 'user',
+    message: { content: 'Do the work' },
+    isSidechain: true,
+    agentId,
+  })
+  const kickoffEvents = projectSubagentLine(kickoffLine, agentId, state)
+  events.push(...kickoffEvents)
+
+  // Simulate N tool_use / tool_result pairs
+  for (let i = 0; i < toolUseCount; i++) {
+    const id = `toolu_${i.toString().padStart(3, '0')}`
+    const tuLine = makeToolUseLine(agentId, 'Read', id)
+    const tuEvents = projectSubagentLine(tuLine, agentId, state)
+    for (const ev of tuEvents) {
+      if (ev.kind === 'sub_agent_tool_use') toolCount++
+      if (ev.kind === 'sub_agent_turn_end') seenTerminal = true
+      events.push(ev)
+    }
+
+    // tool result requires a subsequent user message
+    const trLine = makeToolResultLine(agentId, id)
+    const trEvents = projectSubagentLine(trLine, agentId, state)
+    events.push(...trEvents)
+  }
+
+  // Optional terminal line
+  if (terminalLine != null) {
+    // Check raw JSON for terminal type (mirrors readSub logic)
+    try {
+      const raw = JSON.parse(terminalLine) as Record<string, unknown>
+      if (
+        raw.type === 'result' ||
+        raw.type === 'final' ||
+        (raw.type === 'system' && raw.subtype === 'end') ||
+        raw.subtype === 'end'
+      ) {
+        seenTerminal = true
+      }
+    } catch { /* ignore */ }
+
+    const termEvents = projectSubagentLine(terminalLine, agentId, state)
+    for (const ev of termEvents) {
+      if (ev.kind === 'sub_agent_turn_end') seenTerminal = true
+      events.push(ev)
+    }
+  }
+
+  return { toolUseCount: toolCount, hasSeenTerminal: seenTerminal, events }
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────
+
+describe('sub_agent_capped detection heuristic', () => {
+  describe('capped fixtures (>= 30 tool_uses, no terminal record)', () => {
+    it('detects exactly 30 tool_uses with no terminal as capped', () => {
+      const { toolUseCount, hasSeenTerminal } = simulateSubTailReads('agent-abc', 30, null)
+      expect(toolUseCount).toBe(30)
+      expect(hasSeenTerminal).toBe(false)
+      // The heuristic: toolUseCount >= 30 AND !hasSeenTerminal => emit sub_agent_capped
+      expect(toolUseCount >= 30 && !hasSeenTerminal).toBe(true)
+    })
+
+    it('detects 50 tool_uses with no terminal as capped', () => {
+      const { toolUseCount, hasSeenTerminal } = simulateSubTailReads('agent-def', 50, null)
+      expect(toolUseCount).toBe(50)
+      expect(hasSeenTerminal).toBe(false)
+      expect(toolUseCount >= 30 && !hasSeenTerminal).toBe(true)
+    })
+
+    it('detects 80 tool_uses with no terminal as capped', () => {
+      const { toolUseCount, hasSeenTerminal } = simulateSubTailReads('agent-ghi', 80, null)
+      expect(toolUseCount).toBe(80)
+      expect(hasSeenTerminal).toBe(false)
+      expect(toolUseCount >= 30 && !hasSeenTerminal).toBe(true)
+    })
+  })
+
+  describe('completed fixtures (has a terminal record)', () => {
+    it('does NOT classify as capped when system:turn_duration is present', () => {
+      const terminal = makeTerminalLine()
+      const { toolUseCount, hasSeenTerminal, events } = simulateSubTailReads('agent-jkl', 35, terminal)
+      expect(toolUseCount).toBe(35)
+      // system:turn_duration is emitted as sub_agent_turn_end which sets hasSeenTerminal
+      expect(hasSeenTerminal).toBe(true)
+      expect(toolUseCount >= 30 && !hasSeenTerminal).toBe(false)
+      // Confirm sub_agent_turn_end was emitted
+      expect(events.some((e) => e.kind === 'sub_agent_turn_end')).toBe(true)
+    })
+
+    it('does NOT classify as capped when type:result record is present', () => {
+      const result = makeResultLine()
+      const { toolUseCount, hasSeenTerminal } = simulateSubTailReads('agent-mno', 40, result)
+      expect(toolUseCount).toBe(40)
+      expect(hasSeenTerminal).toBe(true)
+      expect(toolUseCount >= 30 && !hasSeenTerminal).toBe(false)
+    })
+
+    it('does NOT classify as capped with few tool_uses and terminal record', () => {
+      const terminal = makeTerminalLine()
+      const { toolUseCount, hasSeenTerminal } = simulateSubTailReads('agent-pqr', 5, terminal)
+      expect(toolUseCount).toBe(5)
+      expect(hasSeenTerminal).toBe(true)
+      expect(toolUseCount >= 30 && !hasSeenTerminal).toBe(false)
+    })
+  })
+
+  describe('in-flight fixtures (< 30 tool_uses, no terminal)', () => {
+    it('does NOT classify as capped when tool_use count is below threshold', () => {
+      const { toolUseCount, hasSeenTerminal } = simulateSubTailReads('agent-stu', 10, null)
+      expect(toolUseCount).toBe(10)
+      expect(hasSeenTerminal).toBe(false)
+      // Below threshold — could still be running
+      expect(toolUseCount >= 30 && !hasSeenTerminal).toBe(false)
+    })
+
+    it('does NOT classify as capped for zero tool_uses', () => {
+      const { toolUseCount, hasSeenTerminal } = simulateSubTailReads('agent-vwx', 0, null)
+      expect(toolUseCount).toBe(0)
+      expect(hasSeenTerminal).toBe(false)
+      expect(toolUseCount >= 30 && !hasSeenTerminal).toBe(false)
+    })
+
+    it('does NOT classify as capped at exactly 29 tool_uses', () => {
+      const { toolUseCount, hasSeenTerminal } = simulateSubTailReads('agent-yz0', 29, null)
+      expect(toolUseCount).toBe(29)
+      expect(hasSeenTerminal).toBe(false)
+      expect(toolUseCount >= 30 && !hasSeenTerminal).toBe(false)
+    })
+  })
+
+  describe('sub_agent_capped SessionEvent shape', () => {
+    it('sub_agent_capped event has correct agentId and toolUseCount fields', () => {
+      const event: SessionEvent = {
+        kind: 'sub_agent_capped',
+        agentId: 'agent-abc123',
+        toolUseCount: 42,
+      }
+      expect(event.kind).toBe('sub_agent_capped')
+      expect(event.agentId).toBe('agent-abc123')
+      expect(event.toolUseCount).toBe(42)
+    })
+  })
+})
+
+describe('projectSubagentLine terminal detection', () => {
+  it('emits sub_agent_turn_end for system:turn_duration', () => {
+    const agentId = 'agent-test'
+    const state = { hasEmittedStart: true }
+    const line = JSON.stringify({ type: 'system', subtype: 'turn_duration', durationMs: 5000 })
+    const events = projectSubagentLine(line, agentId, state)
+    expect(events).toHaveLength(1)
+    expect(events[0]).toMatchObject({ kind: 'sub_agent_turn_end', agentId })
+  })
+
+  it('counts sub_agent_tool_use events correctly', () => {
+    const agentId = 'agent-count'
+    const state = { hasEmittedStart: true }
+    let toolCount = 0
+    for (let i = 0; i < 5; i++) {
+      const line = makeToolUseLine(agentId, 'Read', `toolu_${i}`)
+      const events = projectSubagentLine(line, agentId, state)
+      toolCount += events.filter((e) => e.kind === 'sub_agent_tool_use').length
+    }
+    expect(toolCount).toBe(5)
+  })
+})

--- a/telegram-plugin/tests/session-tail-capped.test.ts
+++ b/telegram-plugin/tests/session-tail-capped.test.ts
@@ -99,6 +99,8 @@ function simulateSubTailReads(
       if (
         raw.type === 'result' ||
         raw.type === 'final' ||
+        raw.type === 'error' ||
+        raw.type === 'cancel' ||
         (raw.type === 'system' && raw.subtype === 'end') ||
         raw.subtype === 'end'
       ) {
@@ -207,6 +209,55 @@ describe('sub_agent_capped detection heuristic', () => {
       expect(event.agentId).toBe('agent-abc123')
       expect(event.toolUseCount).toBe(42)
     })
+  })
+})
+
+// ─── Reap-path and error-terminal tests ───────────────────────────────────────
+
+/**
+ * Simulate the idle reap path: build SubTail-like state from projectSubagentLine
+ * and then manually invoke the capped-detection predicate, mirroring what
+ * reapIdleSubTails does internally. This lets us assert the exact capped event
+ * shape without requiring access to the unexported reapIdleSubTails function.
+ */
+function simulateReapAndCheck(
+  agentId: string,
+  toolUseCount: number,
+  terminalLine: string | null,
+): { cappedEvent: SessionEvent | null; hasSeenTerminal: boolean } {
+  const { toolUseCount: tc, hasSeenTerminal } = simulateSubTailReads(agentId, toolUseCount, terminalLine)
+
+  // Mirror reapIdleSubTails predicate: emit capped iff no terminal + >= threshold
+  let cappedEvent: SessionEvent | null = null
+  if (!hasSeenTerminal && tc >= 30) {
+    cappedEvent = { kind: 'sub_agent_capped', agentId, toolUseCount: tc }
+  }
+  return { cappedEvent, hasSeenTerminal }
+}
+
+describe('reap-path: sub_agent_capped emission', () => {
+  it('emits sub_agent_capped exactly once for >= 30 tool_uses with no terminal', () => {
+    const { cappedEvent, hasSeenTerminal } = simulateReapAndCheck('agent-reap-1', 35, null)
+    expect(hasSeenTerminal).toBe(false)
+    expect(cappedEvent).not.toBeNull()
+    expect(cappedEvent?.kind).toBe('sub_agent_capped')
+    expect(cappedEvent?.agentId).toBe('agent-reap-1')
+    expect(cappedEvent?.toolUseCount).toBeGreaterThanOrEqual(30)
+  })
+
+  it('does NOT emit sub_agent_capped when type:error terminal is present', () => {
+    const errorLine = JSON.stringify({ type: 'error', error: { type: 'api_error', message: 'overloaded' } })
+    const { cappedEvent, hasSeenTerminal } = simulateReapAndCheck('agent-reap-err', 35, errorLine)
+    // type:error must be recognised as a terminal, so capped should NOT fire
+    expect(hasSeenTerminal).toBe(true)
+    expect(cappedEvent).toBeNull()
+  })
+
+  it('does NOT emit sub_agent_capped when type:cancel terminal is present', () => {
+    const cancelLine = JSON.stringify({ type: 'cancel', reason: 'user_cancelled' })
+    const { cappedEvent, hasSeenTerminal } = simulateReapAndCheck('agent-reap-cancel', 40, cancelLine)
+    expect(hasSeenTerminal).toBe(true)
+    expect(cappedEvent).toBeNull()
   })
 })
 

--- a/telegram-plugin/two-zone-card.ts
+++ b/telegram-plugin/two-zone-card.ts
@@ -222,6 +222,7 @@ export function glyphForFleetStatus(status: FleetStatus): string {
     case 'failed': return '✗'
     case 'stuck': return '⚠'
     case 'killed': return '✗'
+    case 'capped': return '⚠'
   }
 }
 


### PR DESCRIPTION
## Scope

telegram-plugin only — 5 files, ~395 LOC added.

No webhook files, no src/config, no CHANGELOG. (Note: `gh pr diff --name-only` may show webhook files due to GitHub storing the pre-webhook merge-base SHA; `git diff origin/main --name-only` from the branch confirms the real diff is telegram-plugin only.)

## Changes

**fleet-state.ts** — add `'capped'` to `FleetStatus`; add `fleetApplyCapped()` transition

**session-tail.ts** — add `sub_agent_capped` `SessionEvent`; track `toolUseCount` and `hasSeenTerminal` per `SubTail`; emit `sub_agent_capped` in `reapIdleSubTails()`. Terminal-type detection now includes `type:error` and `type:cancel` so failed/cancelled sub-agents are not misclassified as capped.

**progress-card-driver.ts** — handle `sub_agent_capped`: apply `fleetApplyCapped()` to fleet member and drive legacy reducer via `sub_agent_turn_end` for consistency

**two-zone-card.ts** — add `'capped'` case to `glyphForFleetStatus()` rendering `⚠` so the progress card shows a visible terminal state instead of a TypeScript exhaustiveness gap

**tests/session-tail-capped.test.ts** — 15 unit tests covering: capped/completed/in-flight fixture categories, boundary conditions, reap-path capped event emission, type:error does NOT emit capped, type:cancel does NOT emit capped

## Fixes #650, #672