### PR TITLE
feat(webhook): dispatch rules — cron-style claude -p spawn on verified events (#715)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,34 @@
 
 ### Added
 
+- **Webhook dispatch (#715)** — verified webhook events now trigger fresh
+  `claude -p` invocations so agents can react in Telegram without polling
+  `webhook-events.jsonl` manually.
+  - New module `src/web/webhook-dispatch.ts`:
+    - **Static matcher** (`event`, `actions`, `labels_any`, `labels_all`,
+      `exclude_authors`) — no CEL/expression parser; fully JSON-Schema-validatable.
+    - **`{{field}}` template rendering** against a flat helper bag:
+      `repo`, `number`, `title`, `html_url`, `author`, `labels`, `action`, `event`.
+    - **Cooldown** — same `(event, repo, number, rule-index)` combination
+      coalesces within the window. State on disk per-agent at
+      `<agent>/telegram/webhook-cooldown.json`.
+    - **Quiet hours** — wraps midnight when `start > end`. Skips dispatch
+      entirely (event still in JSONL for manual review).
+    - **`spawnAgentOneShot()`** — same env setup as `buildCronScript` in
+      `scaffold.ts`: OAuth forced, `ANTHROPIC_API_KEY` unset, token injected
+      from `.oauth-token`, `CLAUDE_CONFIG_DIR` and `SWITCHROOM_AGENT_NAME` set.
+  - `WebhookHandlerArgs` gains optional `dispatchConfig` field; handler
+    calls `evaluateDispatch()` after JSONL append (non-fatal — dispatch
+    errors never downgrade the 202).
+  - `webhook_dispatch` added to `TelegramChannelSchema` in
+    `src/config/schema.ts`; cascades via existing channels deep-merge.
+  - **CLI**: `switchroom telegram dispatch test --agent <name> --payload
+    <file.json> --event <type>` — dry-runs matchers offline, prints which
+    rules match and the rendered prompt without spawning.
+  - Test fixtures in `tests/fixtures/` (GitHub PR opened/labeled/dependabot/push).
+  - 35 unit tests covering all matcher combinations, template rendering,
+    cooldown state machine, quiet hours, and `evaluateDispatch` integration.
+
 - **Webhook ingest hardening (#714)** — two defenses added to
   `src/web/webhook-handler.ts` before auto-dispatch ships:
   - **Dedup by `X-GitHub-Delivery`**: per-agent LRU (1000 entries, 24h

--- a/src/cli/telegram.ts
+++ b/src/cli/telegram.ts
@@ -13,6 +13,14 @@
 import type { Command } from "commander";
 import chalk from "chalk";
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import {
+  evaluateDispatch,
+  matchesRule,
+  buildGithubContext,
+  renderTemplate,
+  parseDurationMs,
+  isQuietHour,
+} from "../web/webhook-dispatch.js";
 import { createInterface } from "node:readline";
 import { resolvePath, loadConfig } from "../config/loader.js";
 import { createVault, setStringSecret } from "../vault/vault.js";
@@ -35,6 +43,7 @@ export function registerTelegramCommand(program: Command): void {
   registerStatusVerb(tg, program);
   registerEnableVerb(tg, program);
   registerDisableVerb(tg, program);
+  registerDispatchVerb(tg, program);
 }
 
 // ─── status ──────────────────────────────────────────────────────────────────
@@ -462,6 +471,115 @@ async function getVaultPassphrase(): Promise<string> {
   const passphrase = await promptHidden("Vault passphrase: ");
   if (!passphrase) throw new Error("Vault passphrase cannot be empty");
   return passphrase;
+}
+
+// ─── dispatch ────────────────────────────────────────────────────────────────
+
+function registerDispatchVerb(tg: Command, _program: Command): void {
+  const dispatch = tg
+    .command("dispatch")
+    .description("Webhook dispatch utilities.");
+
+  dispatch
+    .command("test")
+    .description(
+      "Dry-run dispatch rule matching against a captured payload file. " +
+      "Prints which rules would match and the rendered prompt, without " +
+      "spawning a claude -p process.",
+    )
+    .requiredOption("--agent <name>", "Agent name (must exist in switchroom.yaml)")
+    .requiredOption("--payload <file>", "Path to a JSON payload file")
+    .requiredOption("--event <type>", "GitHub event type (e.g. 'pull_request', 'push')")
+    .option("--source <name>", "Webhook source (default: github)", "github")
+    .action(
+      withConfigError(async (opts: DispatchTestOpts) => {
+        const config = getConfig(_program);
+        const agentRaw = config.agents[opts.agent];
+        if (!agentRaw) {
+          fail(`Unknown agent '${opts.agent}'. Check switchroom.yaml.`);
+        }
+        const resolved = resolveAgentConfig(config.defaults, config.profiles, agentRaw);
+        const dispatchConfig = resolved.channels?.telegram?.webhook_dispatch;
+        if (!dispatchConfig) {
+          console.log(
+            chalk.yellow(`No webhook_dispatch config found for agent '${opts.agent}'.`),
+          );
+          return;
+        }
+
+        let payload: Record<string, unknown>;
+        try {
+          payload = JSON.parse(readFileSync(opts.payload, "utf-8")) as Record<string, unknown>;
+        } catch (err) {
+          fail(`Could not read payload file '${opts.payload}': ${(err as Error).message}`);
+        }
+
+        // Collect matches without spawning
+        const rules = opts.source === "github" ? (dispatchConfig.github ?? []) : [];
+        if (rules.length === 0) {
+          console.log(chalk.yellow(`No dispatch rules for source '${opts.source}'.`));
+          return;
+        }
+
+        let matchCount = 0;
+        const now = new Date();
+
+        for (let i = 0; i < rules.length; i++) {
+          const rule = rules[i];
+          const matched = matchesRule(opts.event, payload, rule.match);
+          const prefix = matched ? chalk.green("✓ MATCH") : chalk.dim("✗ no match");
+          const desc = rule.description ? ` — ${rule.description}` : ` — rule ${i}`;
+          console.log(`${prefix}  rule ${i}${desc}`);
+
+          if (!matched) continue;
+          matchCount++;
+
+          // Quiet hours status
+          if (rule.quiet_hours) {
+            const quiet = isQuietHour(rule.quiet_hours, now);
+            console.log(
+              `  quiet hours: ${quiet ? chalk.yellow("ACTIVE (would skip)") : chalk.green("inactive")}`,
+            );
+          }
+
+          // Cooldown note
+          if (rule.cooldown) {
+            const ms = parseDurationMs(rule.cooldown);
+            console.log(
+              `  cooldown: ${rule.cooldown} (${ms}ms) — state tracked in webhook-cooldown.json`,
+            );
+          }
+
+          // Rendered prompt
+          const ctx = buildGithubContext(opts.event, payload);
+          const rendered = renderTemplate(rule.prompt, ctx);
+          console.log(chalk.bold("  rendered prompt:"));
+          for (const line of rendered.split("\n")) {
+            console.log(`    ${line}`);
+          }
+          console.log(`  model: ${rule.model ?? "claude-sonnet-4-6"}`);
+        }
+
+        console.log();
+        if (matchCount === 0) {
+          console.log(chalk.yellow("No rules matched — no dispatch would fire."));
+        } else {
+          console.log(
+            chalk.green(
+              `${matchCount} rule(s) matched. ` +
+              `Run without --dry-run in production to spawn claude -p.`,
+            ),
+          );
+        }
+      }),
+    );
+}
+
+interface DispatchTestOpts {
+  agent: string;
+  payload: string;
+  event: string;
+  source: string;
 }
 
 function promptHidden(prompt: string): Promise<string> {

--- a/src/cli/telegram.ts
+++ b/src/cli/telegram.ts
@@ -14,7 +14,6 @@ import type { Command } from "commander";
 import chalk from "chalk";
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import {
-  evaluateDispatch,
   matchesRule,
   buildGithubContext,
   renderTemplate,

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -561,6 +561,79 @@ export const TelegramChannelSchema = z
         "<agent>/telegram/issues.jsonl. " +
         "Cascades from defaults.channels.telegram.webhook_rate_limit.",
       ),
+    webhook_dispatch: z
+      .object({
+        github: z
+          .array(
+            z.object({
+              description: z.string().optional().describe(
+                "Human-readable description of what this rule does.",
+              ),
+              match: z.object({
+                event: z.string().describe(
+                  "GitHub event name (e.g. 'pull_request', 'push'). Required.",
+                ),
+                actions: z.array(z.string()).optional().describe(
+                  "Allowed action values (e.g. ['opened', 'synchronize']). " +
+                  "If absent, all actions match.",
+                ),
+                labels_any: z.array(z.string()).optional().describe(
+                  "At least one of these labels must be present on the PR/issue.",
+                ),
+                labels_all: z.array(z.string()).optional().describe(
+                  "All of these labels must be present on the PR/issue.",
+                ),
+                exclude_authors: z.array(z.string()).optional().describe(
+                  "If the PR/issue author login is in this list, skip dispatch.",
+                ),
+              }).describe("Static matcher constraints. All fields optional except 'event'."),
+              prompt: z.string().describe(
+                "Prompt template for the claude -p invocation. " +
+                "Supports {{field}} interpolation: repo, number, title, " +
+                "html_url, author, labels, action, event.",
+              ),
+              cooldown: z.string().optional().describe(
+                "Cooldown duration before the same (repo, number, rule) " +
+                "combination can fire again. Duration string: '5m', '1h', " +
+                "'30s'. Defaults to no cooldown.",
+              ),
+              quiet_hours: z
+                .object({
+                  start: z.number().int().min(0).max(23).describe(
+                    "Hour (0-23) when quiet period starts (inclusive).",
+                  ),
+                  end: z.number().int().min(0).max(23).describe(
+                    "Hour (0-23) when quiet period ends (exclusive).",
+                  ),
+                  tz: z.string().optional().describe(
+                    "IANA timezone string (e.g. 'Australia/Melbourne'). Defaults to UTC.",
+                  ),
+                })
+                .optional()
+                .describe(
+                  "When the current wall clock is inside this window, dispatch is " +
+                  "skipped entirely (events still land in webhook-events.jsonl). " +
+                  "Wraps midnight when start > end (e.g. start=22, end=8).",
+                ),
+              model: z.string().optional().describe(
+                "Model for the dispatched claude -p invocation. " +
+                "Defaults to claude-sonnet-4-6.",
+              ),
+            }),
+          )
+          .optional()
+          .describe("Dispatch rules for GitHub webhook events."),
+      })
+      .optional()
+      .describe(
+        "Webhook dispatch rules (#715). After an event is verified and " +
+        "recorded to webhook-events.jsonl, each rule is evaluated against " +
+        "the event. On a match, a fresh `claude -p` process is spawned " +
+        "against this agent. Supports static matchers (event/action/label/" +
+        "author), {{field}} prompt templates, per-rule cooldown, and " +
+        "quiet hours. Only the 'github' source is supported for dispatch. " +
+        "Cascades from defaults.channels.telegram.webhook_dispatch.",
+      ),
   })
   .optional();
 

--- a/src/web/webhook-dispatch.test.ts
+++ b/src/web/webhook-dispatch.test.ts
@@ -70,9 +70,10 @@ describe('buildGithubContext', () => {
     expect(ctx.event).toBe('pull_request')
   })
 
-  it('extracts push fields', () => {
+  it('extracts push fields including first commit message as title', () => {
     const ctx = buildGithubContext('push', pushPayload)
     expect(ctx.repo).toBe('acme/myrepo')
+    expect(ctx.title).toBe('Update README')
     expect(ctx.action).toBe('')
     expect(ctx.event).toBe('push')
   })

--- a/src/web/webhook-dispatch.test.ts
+++ b/src/web/webhook-dispatch.test.ts
@@ -1,0 +1,438 @@
+/**
+ * Tests for webhook dispatch (#715):
+ *   - Static matcher (event/action/label/author combinations)
+ *   - Template rendering
+ *   - Cooldown state machine
+ *   - Quiet hours
+ *   - evaluateDispatch integration (matcher → spawn)
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+import { mkdtempSync, mkdirSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import {
+  matchesRule,
+  renderTemplate,
+  buildGithubContext,
+  parseDurationMs,
+  isQuietHour,
+  evaluateDispatch,
+  createFileCooldownStore,
+  type DispatchMatcher,
+  type DispatchRule,
+  type WebhookDispatchConfig,
+  type TemplateContext,
+  type QuietHours,
+} from './webhook-dispatch.js'
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+const FIXTURES = resolve(import.meta.dirname, '../../tests/fixtures')
+
+function loadFixture(name: string): Record<string, unknown> {
+  return JSON.parse(readFileSync(join(FIXTURES, name), 'utf-8')) as Record<string, unknown>
+}
+
+const prOpened = loadFixture('github-pr-opened.json')
+const prLabeled = loadFixture('github-pr-labeled.json')
+const prDependabot = loadFixture('github-pr-dependabot.json')
+const pushPayload = loadFixture('github-push.json')
+
+// ─── parseDurationMs ──────────────────────────────────────────────────────────
+
+describe('parseDurationMs', () => {
+  it('parses seconds', () => expect(parseDurationMs('30s')).toBe(30_000))
+  it('parses minutes', () => expect(parseDurationMs('5m')).toBe(300_000))
+  it('parses hours', () => expect(parseDurationMs('1h')).toBe(3_600_000))
+  it('parses days', () => expect(parseDurationMs('2d')).toBe(172_800_000))
+  it('parses bare number as ms', () => expect(parseDurationMs('500')).toBe(500))
+  it('returns 0 for empty / invalid', () => {
+    expect(parseDurationMs('')).toBe(0)
+    expect(parseDurationMs('abc')).toBe(0)
+  })
+})
+
+// ─── buildGithubContext ───────────────────────────────────────────────────────
+
+describe('buildGithubContext', () => {
+  it('extracts PR fields', () => {
+    const ctx = buildGithubContext('pull_request', prOpened)
+    expect(ctx.repo).toBe('acme/myrepo')
+    expect(ctx.number).toBe('42')
+    expect(ctx.title).toBe('Add dark mode support')
+    expect(ctx.html_url).toBe('https://github.com/acme/myrepo/pull/42')
+    expect(ctx.author).toBe('alice')
+    expect(ctx.labels).toBe('needs-review, enhancement')
+    expect(ctx.action).toBe('opened')
+    expect(ctx.event).toBe('pull_request')
+  })
+
+  it('extracts push fields', () => {
+    const ctx = buildGithubContext('push', pushPayload)
+    expect(ctx.repo).toBe('acme/myrepo')
+    expect(ctx.action).toBe('')
+    expect(ctx.event).toBe('push')
+  })
+})
+
+// ─── renderTemplate ───────────────────────────────────────────────────────────
+
+describe('renderTemplate', () => {
+  const ctx: TemplateContext = {
+    repo: 'acme/myrepo',
+    number: '42',
+    title: 'Add dark mode',
+    html_url: 'https://github.com/acme/myrepo/pull/42',
+    author: 'alice',
+    labels: 'needs-review',
+    action: 'opened',
+    event: 'pull_request',
+  }
+
+  it('interpolates known fields', () => {
+    const out = renderTemplate('PR {{repo}} #{{number}}: {{title}}', ctx)
+    expect(out).toBe('PR acme/myrepo #42: Add dark mode')
+  })
+
+  it('replaces missing fields with empty string', () => {
+    const out = renderTemplate('{{missing}}', ctx)
+    expect(out).toBe('')
+  })
+
+  it('handles multi-line templates', () => {
+    const tmpl = 'PR #{{number}}: {{title}}\n{{html_url}}'
+    const out = renderTemplate(tmpl, ctx)
+    expect(out).toBe('PR #42: Add dark mode\nhttps://github.com/acme/myrepo/pull/42')
+  })
+})
+
+// ─── matchesRule ─────────────────────────────────────────────────────────────
+
+describe('matchesRule', () => {
+  const baseMatcher: DispatchMatcher = { event: 'pull_request' }
+
+  it('matches on event alone', () => {
+    expect(matchesRule('pull_request', prOpened, baseMatcher)).toBe(true)
+  })
+
+  it('rejects wrong event', () => {
+    expect(matchesRule('push', prOpened, baseMatcher)).toBe(false)
+  })
+
+  it('matches when action is in list', () => {
+    const m: DispatchMatcher = { event: 'pull_request', actions: ['opened', 'synchronize'] }
+    expect(matchesRule('pull_request', prOpened, m)).toBe(true)
+  })
+
+  it('rejects when action not in list', () => {
+    const m: DispatchMatcher = { event: 'pull_request', actions: ['closed'] }
+    expect(matchesRule('pull_request', prOpened, m)).toBe(false)
+  })
+
+  it('matches labels_any when at least one label present', () => {
+    const m: DispatchMatcher = { event: 'pull_request', labels_any: ['needs-review', 'bug'] }
+    expect(matchesRule('pull_request', prOpened, m)).toBe(true)
+  })
+
+  it('rejects labels_any when none match', () => {
+    const m: DispatchMatcher = { event: 'pull_request', labels_any: ['bug', 'wontfix'] }
+    expect(matchesRule('pull_request', prOpened, m)).toBe(false)
+  })
+
+  it('matches labels_all when all labels present', () => {
+    const m: DispatchMatcher = {
+      event: 'pull_request',
+      labels_all: ['needs-review', 'enhancement'],
+    }
+    expect(matchesRule('pull_request', prOpened, m)).toBe(true)
+  })
+
+  it('rejects labels_all when any label missing', () => {
+    const m: DispatchMatcher = {
+      event: 'pull_request',
+      labels_all: ['needs-review', 'missing-label'],
+    }
+    expect(matchesRule('pull_request', prOpened, m)).toBe(false)
+  })
+
+  it('excludes dependabot author', () => {
+    const m: DispatchMatcher = {
+      event: 'pull_request',
+      exclude_authors: ['dependabot[bot]'],
+    }
+    expect(matchesRule('pull_request', prDependabot, m)).toBe(false)
+  })
+
+  it('allows non-excluded author', () => {
+    const m: DispatchMatcher = {
+      event: 'pull_request',
+      exclude_authors: ['dependabot[bot]'],
+    }
+    expect(matchesRule('pull_request', prOpened, m)).toBe(true)
+  })
+
+  it('full combined rule matches correctly', () => {
+    const m: DispatchMatcher = {
+      event: 'pull_request',
+      actions: ['opened', 'synchronize', 'ready_for_review'],
+      labels_any: ['needs-review'],
+      exclude_authors: ['dependabot[bot]', 'coolify[bot]'],
+    }
+    expect(matchesRule('pull_request', prOpened, m)).toBe(true)
+    expect(matchesRule('pull_request', prDependabot, m)).toBe(false)
+    expect(matchesRule('push', pushPayload, m)).toBe(false)
+  })
+})
+
+// ─── isQuietHour ─────────────────────────────────────────────────────────────
+
+describe('isQuietHour', () => {
+  it('returns false when outside quiet window (same-day range)', () => {
+    const qh: QuietHours = { start: 9, end: 17, tz: 'UTC' }
+    const morning = new Date('2026-05-06T08:00:00Z')
+    const evening = new Date('2026-05-06T17:30:00Z')
+    expect(isQuietHour(qh, morning)).toBe(false)
+    expect(isQuietHour(qh, evening)).toBe(false)
+  })
+
+  it('returns true when inside quiet window (same-day range)', () => {
+    const qh: QuietHours = { start: 9, end: 17, tz: 'UTC' }
+    const noon = new Date('2026-05-06T12:00:00Z')
+    expect(isQuietHour(qh, noon)).toBe(true)
+  })
+
+  it('handles wrap-midnight range (22-8)', () => {
+    const qh: QuietHours = { start: 22, end: 8, tz: 'UTC' }
+    const midnight = new Date('2026-05-06T00:30:00Z') // 00:30 UTC, inside 22-8
+    const noon = new Date('2026-05-06T12:00:00Z')     // 12:00 UTC, outside
+    const lateEvening = new Date('2026-05-06T22:30:00Z') // 22:30 UTC, inside
+    expect(isQuietHour(qh, midnight)).toBe(true)
+    expect(isQuietHour(qh, noon)).toBe(false)
+    expect(isQuietHour(qh, lateEvening)).toBe(true)
+  })
+})
+
+// ─── CooldownStore ────────────────────────────────────────────────────────────
+
+describe('createFileCooldownStore', () => {
+  function makeTmpDir(): { resolveAgentDir: (a: string) => string } {
+    const root = mkdtempSync(join(tmpdir(), 'dispatch-test-'))
+    return {
+      resolveAgentDir: (agent: string) => {
+        const dir = join(root, agent)
+        mkdirSync(join(dir, 'telegram'), { recursive: true })
+        return dir
+      },
+    }
+  }
+
+  it('returns false on first call and records dispatch', () => {
+    const { resolveAgentDir } = makeTmpDir()
+    const store = createFileCooldownStore(resolveAgentDir)
+    const result = store.isCoolingDown('agent1', 'key1', 300_000, 1_000_000)
+    expect(result).toBe(false)
+  })
+
+  it('returns true on second call within cooldown window', () => {
+    const { resolveAgentDir } = makeTmpDir()
+    const store = createFileCooldownStore(resolveAgentDir)
+    store.isCoolingDown('agent1', 'key1', 300_000, 1_000_000)
+    const result = store.isCoolingDown('agent1', 'key1', 300_000, 1_100_000)
+    expect(result).toBe(true)
+  })
+
+  it('returns false after cooldown expires', () => {
+    const { resolveAgentDir } = makeTmpDir()
+    const store = createFileCooldownStore(resolveAgentDir)
+    store.isCoolingDown('agent1', 'key1', 300_000, 1_000_000)
+    // Advance past cooldown window (5 min = 300_000ms)
+    const result = store.isCoolingDown('agent1', 'key1', 300_000, 1_400_000)
+    expect(result).toBe(false)
+  })
+
+  it('zero cooldown always returns false', () => {
+    const { resolveAgentDir } = makeTmpDir()
+    const store = createFileCooldownStore(resolveAgentDir)
+    store.isCoolingDown('agent1', 'key1', 0, 1_000_000)
+    expect(store.isCoolingDown('agent1', 'key1', 0, 1_000_001)).toBe(false)
+  })
+})
+
+// ─── evaluateDispatch ─────────────────────────────────────────────────────────
+
+describe('evaluateDispatch', () => {
+  function makeTmpResolveAgentDir(): (a: string) => string {
+    const root = mkdtempSync(join(tmpdir(), 'dispatch-eval-'))
+    return (agent: string) => {
+      const dir = join(root, agent)
+      mkdirSync(join(dir, 'telegram'), { recursive: true })
+      return dir
+    }
+  }
+
+  const baseRule: DispatchRule = {
+    match: {
+      event: 'pull_request',
+      actions: ['opened'],
+      labels_any: ['needs-review'],
+      exclude_authors: ['dependabot[bot]'],
+    },
+    prompt: 'Review PR #{{number}}: {{title}}\n{{html_url}}',
+    model: 'claude-sonnet-4-6',
+  }
+
+  it('fires spawn when rule matches', () => {
+    const resolveAgentDir = makeTmpResolveAgentDir()
+    const spawned: Array<{ cmd: string; args: string[] }> = []
+    const config: WebhookDispatchConfig = { github: [baseRule] }
+
+    const count = evaluateDispatch(
+      {
+        agent: 'reggie',
+        source: 'github',
+        eventType: 'pull_request',
+        payload: prOpened,
+        dispatchConfig: config,
+      },
+      {
+        resolveAgentDir,
+        now: () => 1_000_000,
+        log: () => {},
+        spawnFn: (cmd, args) => {
+          spawned.push({ cmd, args })
+          return { on: () => {}, pid: 9999 }
+        },
+      },
+    )
+
+    expect(count).toBe(1)
+    expect(spawned).toHaveLength(1)
+    expect(spawned[0].cmd).toBe('claude')
+    expect(spawned[0].args[0]).toBe('-p')
+    expect(spawned[0].args[1]).toContain('#42')
+    expect(spawned[0].args[1]).toContain('Add dark mode support')
+  })
+
+  it('skips dependabot PR', () => {
+    const resolveAgentDir = makeTmpResolveAgentDir()
+    const spawned: Array<unknown> = []
+    const config: WebhookDispatchConfig = { github: [baseRule] }
+
+    const count = evaluateDispatch(
+      {
+        agent: 'reggie',
+        source: 'github',
+        eventType: 'pull_request',
+        payload: prDependabot,
+        dispatchConfig: config,
+      },
+      {
+        resolveAgentDir,
+        now: () => 1_000_000,
+        log: () => {},
+        spawnFn: (_, args) => { spawned.push(args); return { on: () => {} } },
+      },
+    )
+
+    expect(count).toBe(0)
+    expect(spawned).toHaveLength(0)
+  })
+
+  it('returns 0 for non-github source', () => {
+    const resolveAgentDir = makeTmpResolveAgentDir()
+    const config: WebhookDispatchConfig = { github: [baseRule] }
+    const count = evaluateDispatch(
+      {
+        agent: 'reggie',
+        source: 'generic',
+        eventType: 'push',
+        payload: pushPayload,
+        dispatchConfig: config,
+      },
+      { resolveAgentDir, log: () => {} },
+    )
+    expect(count).toBe(0)
+  })
+
+  it('skips during quiet hours', () => {
+    const resolveAgentDir = makeTmpResolveAgentDir()
+    const spawned: Array<unknown> = []
+    const ruleWithQH: DispatchRule = {
+      ...baseRule,
+      quiet_hours: { start: 0, end: 23, tz: 'UTC' }, // always quiet
+    }
+    const config: WebhookDispatchConfig = { github: [ruleWithQH] }
+
+    const count = evaluateDispatch(
+      {
+        agent: 'reggie',
+        source: 'github',
+        eventType: 'pull_request',
+        payload: prOpened,
+        dispatchConfig: config,
+      },
+      {
+        resolveAgentDir,
+        nowDate: () => new Date('2026-05-06T10:00:00Z'),
+        now: () => 1_000_000,
+        log: () => {},
+        spawnFn: (_, args) => { spawned.push(args); return { on: () => {} } },
+      },
+    )
+
+    expect(count).toBe(0)
+    expect(spawned).toHaveLength(0)
+  })
+
+  it('respects cooldown — second fire within window is skipped', () => {
+    const resolveAgentDir = makeTmpResolveAgentDir()
+    const spawned: Array<unknown> = []
+    const ruleWithCooldown: DispatchRule = { ...baseRule, cooldown: '5m' }
+    const config: WebhookDispatchConfig = { github: [ruleWithCooldown] }
+
+    const deps = {
+      resolveAgentDir,
+      now: () => 1_000_000,
+      log: () => {},
+      spawnFn: (_cmd: string, args: string[]) => { spawned.push(args); return { on: () => {} } },
+    }
+
+    evaluateDispatch(
+      { agent: 'reggie', source: 'github', eventType: 'pull_request', payload: prOpened, dispatchConfig: config },
+      deps,
+    )
+    const count2 = evaluateDispatch(
+      { agent: 'reggie', source: 'github', eventType: 'pull_request', payload: prOpened, dispatchConfig: config },
+      { ...deps, now: () => 1_060_000 }, // 1 minute later, still in cooldown
+    )
+
+    expect(spawned).toHaveLength(1)
+    expect(count2).toBe(0)
+  })
+
+  it('fires multiple matching rules', () => {
+    const resolveAgentDir = makeTmpResolveAgentDir()
+    const spawned: Array<unknown> = []
+    const rule2: DispatchRule = {
+      match: { event: 'pull_request', labels_any: ['enhancement'] },
+      prompt: 'Enhancement PR opened: {{title}}',
+    }
+    const config: WebhookDispatchConfig = { github: [baseRule, rule2] }
+
+    const count = evaluateDispatch(
+      { agent: 'reggie', source: 'github', eventType: 'pull_request', payload: prOpened, dispatchConfig: config },
+      {
+        resolveAgentDir,
+        now: () => 1_000_000,
+        log: () => {},
+        spawnFn: (_, args) => { spawned.push(args); return { on: () => {} } },
+      },
+    )
+
+    expect(count).toBe(2)
+    expect(spawned).toHaveLength(2)
+  })
+})

--- a/src/web/webhook-dispatch.ts
+++ b/src/web/webhook-dispatch.ts
@@ -1,0 +1,491 @@
+/**
+ * Webhook dispatch (#715). After an event is verified and recorded by
+ * `webhook-handler.ts`, this module evaluates per-rule matchers and, for
+ * each match, spawns a fresh `claude -p` invocation against the agent so
+ * it can react to the event via Telegram.
+ *
+ * Design principles:
+ *   - **Static matcher** (no CEL/expression parser). Fields: `event`,
+ *     `actions`, `labels_any`, `labels_all`, `exclude_authors`. All
+ *     optional except `event`; absent fields are treated as wildcards.
+ *   - **Template rendering**: simple `{{field}}` interpolation against
+ *     a flat helper bag derived from the GitHub payload.
+ *   - **Cooldown**: same `(repo, number)` re-trigger within window
+ *     coalesces. State stored per-agent on disk.
+ *   - **Quiet hours**: skip dispatch entirely when the wall clock is
+ *     inside the configured window (events still in JSONL).
+ *   - **Spawn pattern**: same shape as cron one-shots — `claude -p`
+ *     with `--no-session-persistence`, env vars matching `buildCronScript`.
+ *
+ * Configuration (in switchroom.yaml under agents.<name>.channels.telegram):
+ *
+ * ```yaml
+ * webhook_dispatch:
+ *   github:
+ *     - description: "Auto-review labelled PRs"
+ *       match:
+ *         event: pull_request
+ *         actions: [opened, synchronize, ready_for_review]
+ *         labels_any: [needs-review]
+ *         exclude_authors: [dependabot[bot], coolify[bot]]
+ *       prompt: |
+ *         PR review please — {{repo}} #{{number}}: {{title}}
+ *         {{html_url}}
+ *       cooldown: 5m
+ *       quiet_hours: { start: 22, end: 8, tz: Australia/Melbourne }
+ *       model: claude-opus-4-7
+ * ```
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs'
+import { join } from 'path'
+import { homedir } from 'os'
+import { spawn } from 'child_process'
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export interface DispatchMatcher {
+  /** GitHub event name (e.g. "pull_request", "push"). Required. */
+  event: string
+  /** Allowed action values. If absent, all actions match. */
+  actions?: string[]
+  /** At least one of these labels must be present on the PR/issue. */
+  labels_any?: string[]
+  /** All of these labels must be present on the PR/issue. */
+  labels_all?: string[]
+  /** If the author login matches any of these, skip dispatch. */
+  exclude_authors?: string[]
+}
+
+export interface QuietHours {
+  /** Hour (0-23) when quiet period starts (inclusive). */
+  start: number
+  /** Hour (0-23) when quiet period ends (exclusive). */
+  end: number
+  /** IANA timezone string (e.g. "Australia/Melbourne"). Defaults to UTC. */
+  tz?: string
+}
+
+export interface DispatchRule {
+  description?: string
+  match: DispatchMatcher
+  /** Handlebars-style `{{field}}` template for the claude -p prompt. */
+  prompt: string
+  /** Cooldown duration string: "5m", "1h", "30s". Defaults to "0" (no cooldown). */
+  cooldown?: string
+  quiet_hours?: QuietHours
+  /** Model override. Defaults to claude-sonnet-4-6. */
+  model?: string
+}
+
+export interface WebhookDispatchConfig {
+  github?: DispatchRule[]
+}
+
+/** Flat helper bag for template interpolation. */
+export interface TemplateContext {
+  repo: string
+  number: string
+  title: string
+  html_url: string
+  author: string
+  labels: string
+  action: string
+  event: string
+  [key: string]: string
+}
+
+// ─── Template rendering ──────────────────────────────────────────────────────
+
+/**
+ * Render a `{{field}}` template against a context object.
+ * Missing fields are replaced with an empty string.
+ * No HTML escaping — the prompt goes to the CLI model, not a browser.
+ */
+export function renderTemplate(template: string, ctx: TemplateContext): string {
+  return template.replace(/\{\{(\w+)\}\}/g, (_, key: string) => ctx[key] ?? '')
+}
+
+/**
+ * Build the flat TemplateContext from a GitHub payload + event type.
+ * Handles pull_request, issues, push, and generic fallback shapes.
+ */
+export function buildGithubContext(
+  eventType: string,
+  payload: Record<string, unknown>,
+): TemplateContext {
+  const repo =
+    (payload.repository as Record<string, unknown> | undefined)?.full_name as string ?? ''
+
+  // Prefer pull_request sub-object, then issue sub-object
+  const pr = payload.pull_request as Record<string, unknown> | undefined
+  const issue = payload.issue as Record<string, unknown> | undefined
+  const obj = pr ?? issue
+
+  const number = String(payload.number ?? obj?.number ?? '')
+  const title = String(obj?.title ?? (payload.commits as unknown[] | undefined)?.[0] ?? '')
+  const html_url = String(obj?.html_url ?? payload.html_url ?? '')
+  const author = String(
+    (obj?.user as Record<string, unknown> | undefined)?.login ??
+    (payload.sender as Record<string, unknown> | undefined)?.login ??
+    '',
+  )
+  const rawLabels = (obj?.labels as Array<Record<string, unknown>> | undefined) ?? []
+  const labels = rawLabels.map((l) => String(l.name ?? '')).join(', ')
+  const action = String(payload.action ?? '')
+
+  return { repo, number, title, html_url, author, labels, action, event: eventType }
+}
+
+// ─── Static matcher ───────────────────────────────────────────────────────────
+
+/**
+ * Returns true iff the payload matches all constraints in the matcher.
+ *
+ * @param eventType  The X-GitHub-Event header value.
+ * @param payload    Parsed JSON body.
+ * @param matcher    Rule matcher constraints.
+ */
+export function matchesRule(
+  eventType: string,
+  payload: Record<string, unknown>,
+  matcher: DispatchMatcher,
+): boolean {
+  // Event name must match.
+  if (matcher.event !== eventType) return false
+
+  // Build context for label/author access.
+  const ctx = buildGithubContext(eventType, payload)
+
+  // action filter — if specified, the payload's action must be in the list.
+  if (matcher.actions && matcher.actions.length > 0) {
+    if (!matcher.actions.includes(ctx.action)) return false
+  }
+
+  // exclude_authors — skip if author is in the exclusion list.
+  if (matcher.exclude_authors && matcher.exclude_authors.length > 0) {
+    if (matcher.exclude_authors.includes(ctx.author)) return false
+  }
+
+  // labels_any — at least one label in the list must be present.
+  if (matcher.labels_any && matcher.labels_any.length > 0) {
+    const pr = payload.pull_request as Record<string, unknown> | undefined
+    const issue = payload.issue as Record<string, unknown> | undefined
+    const rawLabels =
+      ((pr ?? issue)?.labels as Array<Record<string, unknown>> | undefined) ?? []
+    const labelNames = new Set(rawLabels.map((l) => String(l.name ?? '')))
+    const hasAny = matcher.labels_any.some((l) => labelNames.has(l))
+    if (!hasAny) return false
+  }
+
+  // labels_all — every label in the list must be present.
+  if (matcher.labels_all && matcher.labels_all.length > 0) {
+    const pr = payload.pull_request as Record<string, unknown> | undefined
+    const issue = payload.issue as Record<string, unknown> | undefined
+    const rawLabels =
+      ((pr ?? issue)?.labels as Array<Record<string, unknown>> | undefined) ?? []
+    const labelNames = new Set(rawLabels.map((l) => String(l.name ?? '')))
+    const hasAll = matcher.labels_all.every((l) => labelNames.has(l))
+    if (!hasAll) return false
+  }
+
+  return true
+}
+
+// ─── Cooldown ─────────────────────────────────────────────────────────────────
+
+/** Parse duration strings like "5m", "1h", "30s" into milliseconds. */
+export function parseDurationMs(d: string): number {
+  const m = d.trim().match(/^(\d+)(s|m|h|d)?$/)
+  if (!m) return 0
+  const n = parseInt(m[1], 10)
+  switch (m[2]) {
+    case 's': return n * 1_000
+    case 'm': return n * 60_000
+    case 'h': return n * 3_600_000
+    case 'd': return n * 86_400_000
+    default: return n
+  }
+}
+
+interface CooldownFileShape {
+  dispatches: Record<string, number>
+}
+
+function cooldownKey(eventType: string, repo: string, number: string, ruleIndex: number): string {
+  return `${eventType}:${repo}:${number}:${ruleIndex}`
+}
+
+function loadCooldownFile(path: string): Record<string, number> {
+  try {
+    if (!existsSync(path)) return {}
+    const raw = JSON.parse(readFileSync(path, 'utf-8')) as CooldownFileShape
+    return typeof raw.dispatches === 'object' && raw.dispatches !== null
+      ? raw.dispatches
+      : {}
+  } catch {
+    return {}
+  }
+}
+
+function saveCooldownFile(path: string, dispatches: Record<string, number>): void {
+  try {
+    writeFileSync(path, JSON.stringify({ dispatches } satisfies CooldownFileShape), {
+      mode: 0o600,
+    })
+  } catch {
+    // Non-fatal
+  }
+}
+
+export interface CooldownStore {
+  /** Returns true if the key is within cooldown (should skip). Also records on miss. */
+  isCoolingDown(
+    agent: string,
+    key: string,
+    cooldownMs: number,
+    now: number,
+  ): boolean
+}
+
+export function createFileCooldownStore(
+  resolveAgentDir: (agent: string) => string,
+): CooldownStore {
+  const cache = new Map<string, Record<string, number>>()
+  return {
+    isCoolingDown(agent: string, key: string, cooldownMs: number, now: number): boolean {
+      if (cooldownMs <= 0) return false
+
+      const telegramDir = join(resolveAgentDir(agent), 'telegram')
+      const filePath = join(telegramDir, 'webhook-cooldown.json')
+
+      if (!cache.has(agent)) {
+        cache.set(agent, loadCooldownFile(filePath))
+      }
+
+      const dispatches = cache.get(agent)!
+      const lastDispatch = dispatches[key]
+
+      if (lastDispatch !== undefined && now - lastDispatch < cooldownMs) {
+        return true // still cooling
+      }
+
+      // Record this dispatch
+      dispatches[key] = now
+      try {
+        mkdirSync(telegramDir, { recursive: true })
+        saveCooldownFile(filePath, dispatches)
+      } catch {
+        // Non-fatal
+      }
+
+      return false
+    },
+  }
+}
+
+// ─── Quiet hours ──────────────────────────────────────────────────────────────
+
+/**
+ * Returns true when the current wall clock is inside the quiet window.
+ * `start` and `end` are hours (0-23). When start > end the window wraps
+ * midnight (e.g. start=22, end=8 = quiet from 10pm to 8am).
+ */
+export function isQuietHour(qh: QuietHours, now: Date): boolean {
+  const tz = qh.tz ?? 'UTC'
+  // Get current hour in the target timezone.
+  let hour: number
+  try {
+    const formatter = new Intl.DateTimeFormat('en-US', {
+      timeZone: tz,
+      hour: 'numeric',
+      hour12: false,
+    })
+    const parts = formatter.formatToParts(now)
+    const hourPart = parts.find((p) => p.type === 'hour')
+    hour = parseInt(hourPart?.value ?? '0', 10)
+  } catch {
+    // Unknown timezone — fall back to UTC
+    hour = now.getUTCHours()
+  }
+
+  const { start, end } = qh
+  if (start < end) {
+    // Simple range: e.g. 9-17
+    return hour >= start && hour < end
+  } else {
+    // Wraps midnight: e.g. 22-8
+    return hour >= start || hour < end
+  }
+}
+
+// ─── Spawner ──────────────────────────────────────────────────────────────────
+
+export interface SpawnAgentOneShotDeps {
+  /** Override to capture spawn args in tests. */
+  spawnFn?: (
+    cmd: string,
+    args: string[],
+    opts: { env: NodeJS.ProcessEnv; stdio: [string, string, string] },
+  ) => { on: (event: string, cb: (code: number | null) => void) => void; pid?: number }
+  /** Override agent dir resolver for tests. */
+  resolveAgentDir?: (agent: string) => string
+  /** Injectable cooldown store for tests. */
+  cooldownStore?: CooldownStore
+  /** Clock override for tests. */
+  now?: () => number
+  /** Log sink. */
+  log?: (line: string) => void
+}
+
+/**
+ * Spawn a fresh `claude -p` process for the given agent and prompt.
+ * Follows the same env setup as `buildCronScript` in scaffold.ts:
+ *   - CLAUDE_CONFIG_DIR → <agentDir>/.claude
+ *   - SWITCHROOM_AGENT_NAME → <agentName>
+ *   - TELEGRAM_STATE_DIR → <agentDir>/telegram
+ *   - CLAUDE_CODE_OAUTH_TOKEN injected from disk if present
+ *   - ANTHROPIC_API_KEY unset to force OAuth
+ */
+export function spawnAgentOneShot(
+  agent: string,
+  prompt: string,
+  model: string,
+  deps: SpawnAgentOneShotDeps = {},
+): void {
+  const log = deps.log ?? ((s) => process.stderr.write(s))
+  const resolveAgentDir =
+    deps.resolveAgentDir ?? ((a) => join(homedir(), '.switchroom', 'agents', a))
+  const agentDir = resolveAgentDir(agent)
+  const claudeConfigDir = join(agentDir, '.claude')
+  const telegramStateDir = join(agentDir, 'telegram')
+
+  const env: NodeJS.ProcessEnv = {
+    ...process.env,
+    FORCE_COLOR: '0',
+    NO_COLOR: '1',
+    CLAUDE_CONFIG_DIR: claudeConfigDir,
+    SWITCHROOM_AGENT_NAME: agent,
+    TELEGRAM_STATE_DIR: telegramStateDir,
+  }
+
+  // Unset ANTHROPIC_API_KEY to force OAuth auth (mirrors cron script pattern).
+  delete env.ANTHROPIC_API_KEY
+
+  // Inject OAuth token from disk if not already in env.
+  if (!env.CLAUDE_CODE_OAUTH_TOKEN) {
+    const tokenPath = join(claudeConfigDir, '.oauth-token')
+    try {
+      if (existsSync(tokenPath)) {
+        env.CLAUDE_CODE_OAUTH_TOKEN = readFileSync(tokenPath, 'utf-8').trim()
+      }
+    } catch {
+      // Non-fatal — claude will fall back to .credentials.json
+    }
+  }
+
+  const spawnFn = deps.spawnFn ?? (
+    (cmd: string, args: string[], opts: { env: NodeJS.ProcessEnv; stdio: [string, string, string] }) =>
+      spawn(cmd, args, { ...opts, stdio: opts.stdio as ['ignore', 'ignore', 'pipe'] })
+  )
+
+  const child = spawnFn('claude', ['-p', prompt, '--model', model, '--no-session-persistence'], {
+    env,
+    stdio: ['ignore', 'ignore', 'pipe'],
+  })
+
+  log(`webhook-dispatch: agent='${agent}' model='${model}' pid=${child.pid ?? '?'} spawned\n`)
+
+  child.on('close', (code) => {
+    if (code !== 0) {
+      log(`webhook-dispatch: agent='${agent}' claude -p exited with code ${code}\n`)
+    }
+  })
+}
+
+// ─── Main dispatch evaluator ──────────────────────────────────────────────────
+
+export interface EvaluateDispatchArgs {
+  agent: string
+  source: string
+  eventType: string
+  payload: Record<string, unknown>
+  dispatchConfig: WebhookDispatchConfig
+}
+
+export interface EvaluateDispatchDeps extends SpawnAgentOneShotDeps {
+  /** Overridable Date for quiet-hours evaluation. */
+  nowDate?: () => Date
+}
+
+/**
+ * Evaluate all dispatch rules for the incoming event. For each matching
+ * rule that is not in cooldown and not in quiet hours, spawn a fresh
+ * `claude -p` process.
+ *
+ * Returns the number of dispatches fired (0 if nothing matched).
+ */
+export function evaluateDispatch(
+  args: EvaluateDispatchArgs,
+  deps: EvaluateDispatchDeps = {},
+): number {
+  const log = deps.log ?? ((s) => process.stderr.write(s))
+  const now = (deps.now ?? Date.now)()
+  const nowDate = deps.nowDate ?? (() => new Date(now))
+  const resolveAgentDir =
+    deps.resolveAgentDir ?? ((a) => join(homedir(), '.switchroom', 'agents', a))
+  const cooldownStore =
+    deps.cooldownStore ?? createFileCooldownStore(resolveAgentDir)
+
+  // Only github source is supported for dispatch in this iteration.
+  if (args.source !== 'github') return 0
+
+  const rules = args.dispatchConfig.github
+  if (!rules || rules.length === 0) return 0
+
+  const ctx = buildGithubContext(args.eventType, args.payload)
+  let fired = 0
+
+  for (let i = 0; i < rules.length; i++) {
+    const rule = rules[i]
+
+    if (!matchesRule(args.eventType, args.payload, rule.match)) continue
+
+    // Quiet hours check
+    if (rule.quiet_hours && isQuietHour(rule.quiet_hours, nowDate())) {
+      log(
+        `webhook-dispatch: agent='${args.agent}' rule=${i} skipped (quiet hours)\n`,
+      )
+      continue
+    }
+
+    // Cooldown check
+    const cooldownMs = rule.cooldown ? parseDurationMs(rule.cooldown) : 0
+    if (cooldownMs > 0) {
+      const ck = cooldownKey(args.eventType, ctx.repo, ctx.number, i)
+      if (cooldownStore.isCoolingDown(args.agent, ck, cooldownMs, now)) {
+        log(
+          `webhook-dispatch: agent='${args.agent}' rule=${i} skipped (cooldown)\n`,
+        )
+        continue
+      }
+    }
+
+    const prompt = renderTemplate(rule.prompt, ctx)
+    const model = rule.model ?? 'claude-sonnet-4-6'
+
+    log(
+      `webhook-dispatch: agent='${args.agent}' rule=${i} matched event='${args.eventType}' action='${ctx.action}' firing\n`,
+    )
+
+    spawnAgentOneShot(args.agent, prompt, model, {
+      ...deps,
+      resolveAgentDir,
+      cooldownStore,
+    })
+
+    fired++
+  }
+
+  return fired
+}

--- a/src/web/webhook-dispatch.ts
+++ b/src/web/webhook-dispatch.ts
@@ -123,7 +123,8 @@ export function buildGithubContext(
   const obj = pr ?? issue
 
   const number = String(payload.number ?? obj?.number ?? '')
-  const title = String(obj?.title ?? (payload.commits as unknown[] | undefined)?.[0] ?? '')
+  const firstCommit = (payload.commits as Array<Record<string, unknown>> | undefined)?.[0]
+  const title = String(obj?.title ?? firstCommit?.message ?? '')
   const html_url = String(obj?.html_url ?? payload.html_url ?? '')
   const author = String(
     (obj?.user as Record<string, unknown> | undefined)?.login ??
@@ -251,6 +252,10 @@ export interface CooldownStore {
 export function createFileCooldownStore(
   resolveAgentDir: (agent: string) => string,
 ): CooldownStore {
+  // In-memory cache: loaded once per agent per process lifetime.
+  // Safe because the webhook handler runs in a single-process gateway;
+  // if this ever moves to a multi-worker deployment, the cache layer
+  // would need a cross-process invalidation mechanism (or removal).
   const cache = new Map<string, Record<string, number>>()
   return {
     isCoolingDown(agent: string, key: string, cooldownMs: number, now: number): boolean {
@@ -396,9 +401,21 @@ export function spawnAgentOneShot(
 
   log(`webhook-dispatch: agent='${agent}' model='${model}' pid=${child.pid ?? '?'} spawned\n`)
 
+  // Drain stderr to prevent the OS pipe buffer (~64KB) from blocking
+  // the child process. We log the last few lines on failure so operators
+  // can debug a broken dispatch without attaching a PTY.
+  let stderrTail = ''
+  const stderrStream = (child as unknown as { stderr?: { on: (e: string, cb: (d: Buffer) => void) => void } }).stderr
+  if (stderrStream) {
+    stderrStream.on('data', (d: Buffer) => {
+      stderrTail = (stderrTail + d.toString('utf-8')).slice(-2048)
+    })
+  }
+
   child.on('close', (code) => {
     if (code !== 0) {
-      log(`webhook-dispatch: agent='${agent}' claude -p exited with code ${code}\n`)
+      const tail = stderrTail.trim().split('\n').slice(-3).join(' | ')
+      log(`webhook-dispatch: agent='${agent}' claude -p exited with code ${code}${tail ? `: ${tail}` : ''}\n`)
     }
   })
 }

--- a/src/web/webhook-handler.ts
+++ b/src/web/webhook-handler.ts
@@ -50,6 +50,11 @@ import {
   renderGenericEvent,
   type WebhookSource,
 } from './webhook-verify.js'
+import {
+  evaluateDispatch,
+  type WebhookDispatchConfig,
+  type EvaluateDispatchDeps,
+} from './webhook-dispatch.js'
 
 export interface WebhookConfig {
   /** Per-source secrets, declared in vault under
@@ -72,6 +77,9 @@ export interface WebhookHandlerDeps {
   dedupStore?: DedupStore
   /** Injectable rate limiter (for testing). Falls back to module-global. */
   rateLimiter?: RateLimiter
+  /** Injectable dispatch deps (for testing). When absent, production
+   *  defaults are used inside evaluateDispatch. */
+  dispatchDeps?: EvaluateDispatchDeps
 }
 
 export interface WebhookHandlerArgs {
@@ -86,6 +94,9 @@ export interface WebhookHandlerArgs {
   config: WebhookConfig
   /** True iff `agent` is a known agent in switchroom.yaml. */
   agentExists: boolean
+  /** Optional dispatch config from switchroom.yaml
+   *  channels.telegram.webhook_dispatch. When absent, no dispatch runs. */
+  dispatchConfig?: WebhookDispatchConfig
 }
 
 export interface WebhookHandlerResult {
@@ -410,6 +421,35 @@ export async function handleWebhookIngest(
   }
 
   log(`webhook-ingest: agent='${args.agent}' source='${source}' event='${eventType}' recorded ts=${now}\n`)
+
+  // ── Webhook dispatch (#715) ───────────────────────────────────────────────
+  // After recording, evaluate dispatch rules. Fires are async (detached
+  // processes) — we don't await them and don't let failures affect the 202.
+  if (args.dispatchConfig) {
+    try {
+      const fired = evaluateDispatch(
+        {
+          agent: args.agent,
+          source,
+          eventType,
+          payload,
+          dispatchConfig: args.dispatchConfig,
+        },
+        {
+          ...(deps.dispatchDeps ?? {}),
+          resolveAgentDir,
+          log,
+        },
+      )
+      if (fired > 0) {
+        log(`webhook-dispatch: agent='${args.agent}' source='${source}' event='${eventType}' fired=${fired}\n`)
+      }
+    } catch (err) {
+      // Non-fatal: a dispatch failure must not downgrade the 202.
+      log(`webhook-dispatch: agent='${args.agent}' source='${source}' event='${eventType}' dispatch error: ${(err as Error).message}\n`)
+    }
+  }
+
   return jsonReply(202, { ok: true, recorded: true, ts: now })
 }
 

--- a/tests/fixtures/github-pr-dependabot.json
+++ b/tests/fixtures/github-pr-dependabot.json
@@ -1,0 +1,14 @@
+{
+  "action": "opened",
+  "number": 12,
+  "pull_request": {
+    "html_url": "https://github.com/acme/myrepo/pull/12",
+    "title": "Bump lodash from 4.17.20 to 4.17.21",
+    "user": { "login": "dependabot[bot]" },
+    "labels": [
+      { "name": "needs-review" },
+      { "name": "dependencies" }
+    ]
+  },
+  "repository": { "full_name": "acme/myrepo" }
+}

--- a/tests/fixtures/github-pr-labeled.json
+++ b/tests/fixtures/github-pr-labeled.json
@@ -1,0 +1,13 @@
+{
+  "action": "labeled",
+  "number": 99,
+  "pull_request": {
+    "html_url": "https://github.com/acme/myrepo/pull/99",
+    "title": "Refactor auth module",
+    "user": { "login": "bob" },
+    "labels": [
+      { "name": "needs-review" }
+    ]
+  },
+  "repository": { "full_name": "acme/myrepo" }
+}

--- a/tests/fixtures/github-pr-opened.json
+++ b/tests/fixtures/github-pr-opened.json
@@ -1,0 +1,14 @@
+{
+  "action": "opened",
+  "number": 42,
+  "pull_request": {
+    "html_url": "https://github.com/acme/myrepo/pull/42",
+    "title": "Add dark mode support",
+    "user": { "login": "alice" },
+    "labels": [
+      { "name": "needs-review" },
+      { "name": "enhancement" }
+    ]
+  },
+  "repository": { "full_name": "acme/myrepo" }
+}

--- a/tests/fixtures/github-push.json
+++ b/tests/fixtures/github-push.json
@@ -1,0 +1,10 @@
+{
+  "ref": "refs/heads/main",
+  "before": "0000000000000000000000000000000000000000",
+  "after": "abc1234def5678",
+  "repository": { "full_name": "acme/myrepo" },
+  "pusher": { "name": "alice" },
+  "commits": [
+    { "id": "abc1234def5678", "message": "Update README", "author": { "name": "Alice" } }
+  ]
+}


### PR DESCRIPTION
Closes #715. Supersedes #722 (same changes, cleanly rebased onto upstream/main).

## Summary

- New `src/web/webhook-dispatch.ts` module: static matcher, `{{field}}` template rendering, per-rule cooldown (disk-backed), quiet hours (IANA tz, wraps midnight), and `spawnAgentOneShot()` matching the cron env setup in `scaffold.ts`.
- `WebhookHandlerArgs` gains optional `dispatchConfig`; handler calls `evaluateDispatch()` after the JSONL append — non-fatal, never downgrades the 202.
- `webhook_dispatch` schema added to `TelegramChannelSchema` in `src/config/schema.ts`, cascades via existing channels deep-merge.
- CLI: `switchroom telegram dispatch test --agent <name> --payload <file.json> --event <type>` for offline dry-run of matcher rules.
- Test fixtures: `tests/fixtures/github-pr-{opened,labeled,dependabot}.json` + `github-push.json`.
- 47 tests pass (35 new + 12 existing webhook-handler, no regressions).
- Reviewer verdict: APPROVE (2 rounds — stderr drain + push commit title fix applied between rounds).

## Test plan

- [ ] `bun test ./src/web/webhook-dispatch.test.ts` — 35 pass
- [ ] `bun test ./src/web/webhook-handler.test.ts` — 12 pass (no regressions)
- [ ] `switchroom telegram dispatch test --agent reggie --payload tests/fixtures/github-pr-opened.json --event pull_request` prints match output
- [ ] Cooldown: fire twice within window, second is skipped
- [ ] Quiet hours: fire during window, skipped; outside window, fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)