### PR TITLE
feat(inject): tmux supervisor Phase 1.x cleanups + Phase 2 inject feature (#725)

### DIFF
--- a/src/agents/inject.test.ts
+++ b/src/agents/inject.test.ts
@@ -1,0 +1,192 @@
+/**
+ * Tests for the #725 Phase 2 inject primitive.
+ *
+ * The real tmux process is faked via the TmuxRunner test seam — these
+ * tests assert the validation rules, the session-existence check, the
+ * pane-diff logic, and the basic happy-path output capture.
+ *
+ * Run: npx vitest run src/agents/inject.test.ts
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  INJECT_ALLOWLIST,
+  INJECT_BLOCKLIST,
+  InjectError,
+  diffPane,
+  injectSlashCommand,
+  injectSlashCommandWith,
+  validateInjectCommand,
+} from "./inject.js";
+
+describe("validateInjectCommand", () => {
+  it("accepts every command in the allowlist", () => {
+    for (const cmd of INJECT_ALLOWLIST) {
+      expect(validateInjectCommand(cmd)).toBe(cmd);
+    }
+  });
+
+  it("accepts an allowed command with trailing args (verb-only check)", () => {
+    expect(validateInjectCommand("/model claude-opus-4")).toBe("/model");
+  });
+
+  it("is case-insensitive on the verb", () => {
+    expect(validateInjectCommand("/COST")).toBe("/cost");
+  });
+
+  it("throws blocked for /login, /logout, /exit, /quit", () => {
+    for (const cmd of INJECT_BLOCKLIST) {
+      const err = (() => {
+        try {
+          validateInjectCommand(cmd);
+          return null;
+        } catch (e) {
+          return e;
+        }
+      })();
+      expect(err).toBeInstanceOf(InjectError);
+      expect((err as InjectError).code).toBe("blocked");
+    }
+  });
+
+  it("throws not_allowed for any command outside the allow/blocklist", () => {
+    expect(() => validateInjectCommand("/foo")).toThrow(InjectError);
+    try {
+      validateInjectCommand("/foo");
+    } catch (e) {
+      expect((e as InjectError).code).toBe("not_allowed");
+    }
+  });
+
+  it("throws invalid for empty / non-slash input", () => {
+    for (const bad of ["", "  ", "cost", "no-slash"]) {
+      try {
+        validateInjectCommand(bad);
+        throw new Error(`expected throw on ${JSON.stringify(bad)}`);
+      } catch (e) {
+        expect(e).toBeInstanceOf(InjectError);
+        expect((e as InjectError).code).toBe("invalid");
+      }
+    }
+  });
+});
+
+describe("diffPane", () => {
+  it("returns lines in after that aren't in before", () => {
+    const before = "line one\nline two\n";
+    const after = "line one\nline two\nline three\n";
+    expect(diffPane(before, after)).toBe("line three");
+  });
+
+  it("ignores empty lines", () => {
+    const before = "a\nb\n";
+    const after = "\n\na\nb\nc\n\n";
+    expect(diffPane(before, after)).toBe("c");
+  });
+
+  it("returns empty string when nothing new", () => {
+    expect(diffPane("a\nb", "a\nb")).toBe("");
+  });
+});
+
+// ─── injectSlashCommandWith — happy path + error paths via fake runner ─────
+
+interface FakeRunner {
+  hasSession: (s: string, n: string) => boolean;
+  capture: (s: string, n: string) => string | null;
+  send: (s: string, n: string, args: string[]) => void;
+}
+
+function makeFake(opts: {
+  hasSession?: boolean;
+  captures?: string[]; // sequence returned in order
+  onSend?: (args: string[]) => void;
+}): FakeRunner {
+  let i = 0;
+  const captures = opts.captures ?? [];
+  return {
+    hasSession: () => opts.hasSession ?? true,
+    capture: () => {
+      const v = captures[Math.min(i, captures.length - 1)] ?? "";
+      i += 1;
+      return v;
+    },
+    send: (_s, _n, args) => {
+      opts.onSend?.(args);
+    },
+  };
+}
+
+describe("injectSlashCommandWith", () => {
+  it("throws session_missing when has-session returns false", async () => {
+    const runner = makeFake({ hasSession: false });
+    await expect(
+      injectSlashCommandWith(runner, {
+        socket: "switchroom-x",
+        session: "x",
+        command: "/cost",
+        settleMs: 50,
+        timeoutMs: 100,
+      }),
+    ).rejects.toMatchObject({ code: "session_missing" });
+  });
+
+  it("captures diff between before and after pane snapshots", async () => {
+    const before = "$ \n";
+    const after = "$ /cost\n\nTotal cost: $0.42\n$ \n";
+    const runner = makeFake({
+      hasSession: true,
+      // returns: 1) before-snapshot, 2..) after-snapshots (stable)
+      captures: [before, after, after, after, after],
+    });
+    const sent: string[][] = [];
+    runner.send = (_s, _n, args) => sent.push(args);
+
+    const result = await injectSlashCommandWith(runner, {
+      socket: "switchroom-x",
+      session: "x",
+      command: "/cost",
+      settleMs: 50,
+      timeoutMs: 1000,
+    });
+
+    expect(sent).toEqual([
+      ["send-keys", "-l", "/cost"],
+      ["send-keys", "Enter"],
+    ]);
+    expect(result.output).toContain("Total cost: $0.42");
+    expect(result.truncated).toBe(false);
+  });
+
+  it("flags truncated when output exceeds 3000 bytes", async () => {
+    const before = "";
+    const big = Array.from({ length: 200 }, (_, i) => `line ${i} ${"x".repeat(40)}`).join("\n");
+    const runner = makeFake({
+      hasSession: true,
+      captures: [before, big, big, big, big],
+    });
+    const result = await injectSlashCommandWith(runner, {
+      socket: "switchroom-x",
+      session: "x",
+      command: "/cost",
+      settleMs: 50,
+      timeoutMs: 1000,
+    });
+    expect(result.truncated).toBe(true);
+    expect(Buffer.byteLength(result.output, "utf-8")).toBeLessThanOrEqual(3000);
+  });
+});
+
+describe("injectSlashCommand (default runner — validation only)", () => {
+  it("rejects blocked commands before touching tmux", async () => {
+    await expect(injectSlashCommand("any", "/login")).rejects.toMatchObject({
+      code: "blocked",
+    });
+  });
+
+  it("rejects unknown commands before touching tmux", async () => {
+    await expect(injectSlashCommand("any", "/foo")).rejects.toMatchObject({
+      code: "not_allowed",
+    });
+  });
+});

--- a/src/agents/inject.ts
+++ b/src/agents/inject.ts
@@ -1,0 +1,309 @@
+/**
+ * #725 Phase 2 — slash-command injection primitive.
+ *
+ * Lets an operator type a Claude Code REPL slash command (e.g. `/cost`)
+ * via Telegram or the CLI; this module shells out to `tmux send-keys`
+ * against the agent's supervised pane and captures the rendered output
+ * by diffing pane snapshots taken before and after the inject.
+ *
+ * Allowlist-only by design: the set of accepted commands is hard-coded
+ * (no user override) so a compromised Telegram chat / typo can't issue
+ * destructive verbs like `/login`, `/logout`, `/exit`, `/quit`. The
+ * blocklist exists purely to give a more specific error message for
+ * those four — anything else outside the allowlist returns `not_allowed`.
+ *
+ * FUTURE GAP — turn-lifecycle idle gate. This implementation always
+ * sends keys immediately. If the agent is mid-tool-call (e.g. running
+ * a long bash command) the slash inject lands in claude's input buffer
+ * but the prompt isn't accepting commands, so the output won't render
+ * until the current turn ends. For now, the operator is responsible
+ * for timing — Phase 3 / future work will wire this to the turn-end
+ * signal and queue or refuse non-idle injects.
+ */
+
+import { execFile, execFileSync } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * Hard-coded set of injectable slash commands. Read-only commands that
+ * render information without mutating Claude's auth/session state. Add
+ * with care — every entry expands the surface area of inject calls.
+ */
+export const INJECT_ALLOWLIST: ReadonlySet<string> = new Set([
+  "/cost",
+  "/status",
+  "/model",
+  "/clear",
+  "/compact",
+  "/memory",
+  "/hooks",
+]);
+
+/**
+ * Commands explicitly refused with a `blocked` (vs `not_allowed`) error
+ * code so the caller can surface a clearer message. These are the
+ * destructive / session-ending commands an operator must never trigger
+ * from a remote surface.
+ */
+export const INJECT_BLOCKLIST: ReadonlySet<string> = new Set([
+  "/login",
+  "/logout",
+  "/exit",
+  "/quit",
+]);
+
+export type InjectErrorCode =
+  | "not_allowed"
+  | "blocked"
+  | "session_missing"
+  | "invalid"
+  | "timeout"
+  | "tmux_failed";
+
+export class InjectError extends Error {
+  code: InjectErrorCode;
+  constructor(code: InjectErrorCode, message: string) {
+    super(message);
+    this.name = "InjectError";
+    this.code = code;
+  }
+}
+
+export interface InjectOpts {
+  /** tmux binary path. Defaults to `tmux` on PATH. */
+  tmuxBin?: string;
+  /** tmux session name. Defaults to the agent name (matches systemd unit). */
+  sessionName?: string;
+  /** tmux socket name. Defaults to `switchroom-${agentName}`. */
+  socketName?: string;
+  /**
+   * Wait window for the pane buffer to settle (ms). The poller checks
+   * every ~150ms and considers the pane stable when two consecutive
+   * captures are equal. Default 2000ms.
+   */
+  settleMs?: number;
+  /** Hard upper bound on total wait (ms). Default 5000ms. */
+  timeoutMs?: number;
+}
+
+export interface InjectResult {
+  output: string;
+  truncated: boolean;
+}
+
+const POLL_INTERVAL_MS = 150;
+const OUTPUT_BYTE_CAP = 3000;
+
+/**
+ * Validate a raw slash command. Returns the lowercased bare verb on
+ * success, throws `InjectError` otherwise.
+ */
+export function validateInjectCommand(command: string): string {
+  if (typeof command !== "string" || command.trim().length === 0) {
+    throw new InjectError("invalid", "command is empty");
+  }
+  const trimmed = command.trim();
+  if (!trimmed.startsWith("/")) {
+    throw new InjectError("invalid", `command must start with "/": got ${trimmed}`);
+  }
+  const bare = trimmed.split(/\s+/, 1)[0].toLowerCase();
+  // Block first so /login etc. get the more specific message.
+  if (INJECT_BLOCKLIST.has(bare)) {
+    throw new InjectError(
+      "blocked",
+      `${bare} is explicitly blocked from inject (would mutate session/auth state).`,
+    );
+  }
+  if (!INJECT_ALLOWLIST.has(bare)) {
+    throw new InjectError(
+      "not_allowed",
+      `${bare} is not in the inject allowlist. Allowed: ${[...INJECT_ALLOWLIST].sort().join(", ")}`,
+    );
+  }
+  return bare;
+}
+
+function defaultSocketName(agentName: string): string {
+  return `switchroom-${agentName}`;
+}
+
+interface TmuxRunner {
+  capture(socket: string, session: string): string | null;
+  send(socket: string, session: string, args: string[]): void;
+  hasSession(socket: string, session: string): boolean;
+}
+
+function makeTmuxRunner(tmuxBin: string): TmuxRunner {
+  return {
+    capture(socket, session) {
+      try {
+        return execFileSync(
+          tmuxBin,
+          ["-L", socket, "capture-pane", "-p", "-t", session, "-S", "-200"],
+          { encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"] },
+        );
+      } catch {
+        return null;
+      }
+    },
+    send(socket, session, args) {
+      execFileSync(tmuxBin, ["-L", socket, ...args, "-t", session], {
+        stdio: ["pipe", "pipe", "pipe"],
+      });
+    },
+    hasSession(socket, session) {
+      try {
+        execFileSync(tmuxBin, ["-L", socket, "has-session", "-t", session], {
+          stdio: ["pipe", "pipe", "pipe"],
+        });
+        return true;
+      } catch {
+        return false;
+      }
+    },
+  };
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((res) => setTimeout(res, ms));
+}
+
+/**
+ * Diff two pane captures: return lines present in `after` that don't
+ * appear (in any position) in `before`. The pane is a ring buffer so
+ * line-level set diff is the right primitive — exact-line presence is
+ * what changes when new output prints.
+ *
+ * Trailing/leading whitespace-only lines are ignored so a re-render
+ * that shifts content up doesn't produce phantom "new" empty lines.
+ */
+export function diffPane(before: string, after: string): string {
+  const beforeSet = new Set(before.split("\n").map((l) => l.trimEnd()));
+  const newLines: string[] = [];
+  for (const raw of after.split("\n")) {
+    const line = raw.trimEnd();
+    if (line.length === 0) continue;
+    if (beforeSet.has(line)) continue;
+    newLines.push(line);
+  }
+  return newLines.join("\n");
+}
+
+/**
+ * Inject a slash command into an agent's tmux pane. Returns the diff
+ * of new lines that appeared in the pane after the inject.
+ *
+ * Suitable execution states: agent prompt is idle (not mid-tool-call).
+ * See FUTURE GAP comment at the top of this file.
+ */
+export async function injectSlashCommand(
+  agentName: string,
+  command: string,
+  opts: InjectOpts = {},
+): Promise<InjectResult> {
+  validateInjectCommand(command);
+
+  const tmuxBin = opts.tmuxBin ?? "tmux";
+  const socket = opts.socketName ?? defaultSocketName(agentName);
+  const session = opts.sessionName ?? agentName;
+  const settleMs = opts.settleMs ?? 2000;
+  const timeoutMs = opts.timeoutMs ?? 5000;
+
+  return injectSlashCommandWith(makeTmuxRunner(tmuxBin), {
+    socket,
+    session,
+    command: command.trim(),
+    settleMs,
+    timeoutMs,
+  });
+}
+
+/**
+ * Test seam. Same logic as `injectSlashCommand` but takes a pre-built
+ * `TmuxRunner` so unit tests can fake the tmux subprocess.
+ */
+export async function injectSlashCommandWith(
+  runner: TmuxRunner,
+  args: {
+    socket: string;
+    session: string;
+    command: string;
+    settleMs: number;
+    timeoutMs: number;
+  },
+): Promise<InjectResult> {
+  const { socket, session, command, settleMs, timeoutMs } = args;
+
+  if (!runner.hasSession(socket, session)) {
+    throw new InjectError(
+      "session_missing",
+      `tmux session "${session}" on socket "${socket}" not found. Is the agent running with experimental.tmux_supervisor=true?`,
+    );
+  }
+
+  const before = runner.capture(socket, session) ?? "";
+
+  // Two-step send-keys: literal command body (so `/` survives without
+  // tmux key-name interpretation), then Enter as a key name. Mirrors
+  // the existing pattern in src/auth/manager.ts (the auth-code paste).
+  try {
+    runner.send(socket, session, ["send-keys", "-l", command]);
+    runner.send(socket, session, ["send-keys", "Enter"]);
+  } catch (err) {
+    throw new InjectError(
+      "tmux_failed",
+      `tmux send-keys failed: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+
+  // Poll capture-pane every POLL_INTERVAL_MS until two consecutive
+  // captures match (= buffer settled) OR timeoutMs elapses. settleMs
+  // bounds how long we're willing to wait for that stable read; if the
+  // pane is still changing past settleMs we accept whatever's there.
+  const start = Date.now();
+  let last = before;
+  let stableSince: number | null = null;
+  while (Date.now() - start < timeoutMs) {
+    await sleep(POLL_INTERVAL_MS);
+    const cur = runner.capture(socket, session) ?? "";
+    if (cur === last && cur !== before) {
+      if (stableSince === null) {
+        stableSince = Date.now();
+      } else if (Date.now() - stableSince >= POLL_INTERVAL_MS) {
+        // Two consecutive equal captures past the first stable mark —
+        // good enough.
+        last = cur;
+        break;
+      }
+    } else {
+      stableSince = null;
+    }
+    last = cur;
+    if (Date.now() - start >= settleMs && cur !== before) {
+      // Past the settle window with at least one change — return what
+      // we have rather than burning to the hard timeout.
+      break;
+    }
+  }
+
+  let output = diffPane(before, last);
+  let truncated = false;
+  const bytes = Buffer.byteLength(output, "utf-8");
+  if (bytes > OUTPUT_BYTE_CAP) {
+    // Trim from the front; the tail is more interesting (the result of
+    // the command, not the echoed prompt).
+    while (Buffer.byteLength(output, "utf-8") > OUTPUT_BYTE_CAP) {
+      output = output.slice(Math.floor(output.length * 0.1) + 1);
+    }
+    truncated = true;
+  }
+
+  return { output, truncated };
+}
+
+// Avoid unused-import warning when execFileAsync is reserved for
+// future async refactor. Re-exported so callers that want the promise
+// form can grab it.
+export const _execFileAsync = execFileAsync;

--- a/src/agents/systemd.ts
+++ b/src/agents/systemd.ts
@@ -68,7 +68,15 @@ export function generateUnit(
     // pipe-pane proxies the tmux pane's stdout to service.log so existing
     // log consumers (pty-tail, journald followers) keep working unchanged.
     extraStartPost = `ExecStartPost=/usr/bin/tmux -L ${tmuxSocket} pipe-pane -o -t ${name} 'cat >> ${logFile}'\n`;
-    extraStop = `ExecStop=/usr/bin/tmux -L ${tmuxSocket} kill-session -t ${name}\n`;
+    // Leading `-` on ExecStop tells systemd to ignore non-zero exits from
+    // the kill-session call. Without it, the script→tmux supervisor
+    // transition's first restart logs FAILURE because the OLD unit (still
+    // running script -qfc) has no tmux socket on stop, so kill-session
+    // exits non-zero and the unit is marked failed even though everything
+    // worked. The dash silences that one-shot transition without changing
+    // anything in steady state — kill-session against a real session
+    // succeeds, so the dash is a no-op there.
+    extraStop = `ExecStop=-/usr/bin/tmux -L ${tmuxSocket} kill-session -t ${name}\n`;
   } else {
     execStart = useAutoaccept
       ? `/usr/bin/script -qfc "/usr/bin/expect -f ${autoacceptExp} ${agentDir}/start.sh" ${logFile}`
@@ -173,6 +181,7 @@ export function generateAgentTmuxConf(): string {
 set -g history-limit 100000
 set -g status off
 set -g remain-on-exit off
+set -g focus-events on
 `;
 }
 

--- a/src/cli/agent.ts
+++ b/src/cli/agent.ts
@@ -1296,6 +1296,56 @@ export function registerAgentCommand(program: Command): void {
       })
     );
 
+  // switchroom agent send <name> <slashCommand>
+  // #725 Phase 2 — inject a Claude Code REPL slash command into the agent's
+  // tmux pane and print the captured output. Allowlist-only (see inject.ts).
+  agent
+    .command("send <name> <slashCommand>")
+    .description("Inject a Claude Code slash command into the agent's tmux pane (requires experimental.tmux_supervisor)")
+    .option("--timeout <ms>", "Hard timeout in milliseconds (default 5000)", "5000")
+    .option("--settle <ms>", "Pane-settle window in milliseconds (default 2000)", "2000")
+    .action(
+      withConfigError(async (name: string, slashCommand: string, opts: { timeout: string; settle: string }) => {
+        const config = getConfig(program);
+        if (!config.agents[name]) {
+          console.error(chalk.red(`Agent "${name}" is not defined in switchroom.yaml`));
+          process.exit(1);
+        }
+        const resolved = resolveAgentConfig(config.defaults, config.profiles, config.agents[name]);
+        if (resolved.experimental?.tmux_supervisor !== true) {
+          console.error(
+            chalk.red(
+              `Agent "${name}" is not running under the tmux supervisor.\n` +
+                `Set experimental.tmux_supervisor: true in switchroom.yaml and reconcile/restart the agent.`,
+            ),
+          );
+          process.exit(1);
+        }
+        // Lazy import so the CLI doesn't pay for it on every invocation.
+        const { injectSlashCommand, InjectError } = await import("../agents/inject.js");
+        try {
+          const { output, truncated } = await injectSlashCommand(name, slashCommand, {
+            timeoutMs: parseInt(opts.timeout, 10) || 5000,
+            settleMs: parseInt(opts.settle, 10) || 2000,
+          });
+          if (output.trim().length === 0) {
+            console.log(chalk.dim("(no new output captured)"));
+          } else {
+            console.log(output);
+          }
+          if (truncated) {
+            console.log(chalk.yellow("\n... (output truncated to 3000 bytes)"));
+          }
+        } catch (err) {
+          if (err instanceof InjectError) {
+            console.error(chalk.red(`inject failed (${err.code}): ${err.message}`));
+            process.exit(2);
+          }
+          throw err;
+        }
+      }),
+    );
+
   // switchroom agent logs <name>
   agent
     .command("logs <name>")

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -208,6 +208,8 @@ import {
 } from '../auto-fallback.js'
 import { markSlotQuotaExhausted, DEFAULT_SLOT } from '../../src/auth/accounts.js'
 import { fallbackToNextSlot, currentActiveSlot, type AuthCodeOutcome } from '../../src/auth/manager.js'
+import { injectSlashCommand as injectSlashCommandImpl } from '../../src/agents/inject.js'
+import { handleInjectCommand } from './inject-handler.js'
 import { type BannerState } from '../slot-banner.js'
 import { refreshBanner } from '../slot-banner-driver.js'
 import { dispatchFallbackNotification } from '../auto-fallback-dispatcher.js'
@@ -5935,6 +5937,21 @@ bot.command('agents', async ctx => {
       lines.push(`    <i>${escapeHtmlForTg(a.template)} → ${escapeHtmlForTg(a.topic_name)}${a.topic_emoji ? ' ' + a.topic_emoji : ''}</i>`)
     }
     return lines.join('\n')
+  })
+})
+
+// /inject — #725 Phase 2 slash-command bridge. Implementation in
+// inject-handler.ts so it's unit-testable without booting the bot.
+bot.command('inject', async ctx => {
+  await handleInjectCommand(ctx, {
+    isAuthorized: isAuthorizedSender,
+    inject: injectSlashCommandImpl,
+    reply: switchroomReply,
+    getAgentName: getMyAgentName,
+    getArgs: getCommandArgs,
+    escapeHtml: escapeHtmlForTg,
+    preBlock,
+    formatOutput: formatSwitchroomOutput,
   })
 })
 

--- a/telegram-plugin/gateway/inject-handler.test.ts
+++ b/telegram-plugin/gateway/inject-handler.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Unit tests for the /inject Telegram handler (#725 Phase 2).
+ *
+ * The handler is factored out of gateway.ts so we can exercise it
+ * without booting grammy/Bot. Real tmux is never touched — the inject
+ * function is mocked via the InjectDeps seam.
+ *
+ * Run with: npx vitest run telegram-plugin/gateway/inject-handler.test.ts
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+import type { Context } from 'grammy'
+import { handleInjectCommand, type InjectDeps } from './inject-handler.js'
+import { InjectError } from '../../src/agents/inject.js'
+
+function fakeCtx(): Context {
+  // Cast: we never read real fields off ctx; deps shim everything.
+  return {} as unknown as Context
+}
+
+function makeDeps(overrides: Partial<InjectDeps> = {}): {
+  deps: InjectDeps
+  replies: Array<{ text: string; opts?: { html?: boolean } }>
+} {
+  const replies: Array<{ text: string; opts?: { html?: boolean } }> = []
+  const deps: InjectDeps = {
+    isAuthorized: () => true,
+    inject: vi.fn().mockResolvedValue({ output: 'mock', truncated: false }),
+    reply: async (_ctx, text, opts) => {
+      replies.push({ text, opts })
+    },
+    getAgentName: () => 'gymbro',
+    getArgs: () => '/cost',
+    escapeHtml: (s) => s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;'),
+    preBlock: (s) => `<pre>${s}</pre>`,
+    ...overrides,
+  }
+  return { deps, replies }
+}
+
+describe('handleInjectCommand', () => {
+  it('drops messages from unauthorized senders without replying', async () => {
+    const { deps, replies } = makeDeps({ isAuthorized: () => false })
+    await handleInjectCommand(fakeCtx(), deps)
+    expect(replies).toHaveLength(0)
+    expect(deps.inject).not.toHaveBeenCalled()
+  })
+
+  it('replies with usage when no slash-command argument is provided', async () => {
+    const inject = vi.fn()
+    const { deps, replies } = makeDeps({ getArgs: () => '', inject })
+    await handleInjectCommand(fakeCtx(), deps)
+    expect(inject).not.toHaveBeenCalled()
+    expect(replies).toHaveLength(1)
+    expect(replies[0].text).toContain('Usage')
+    expect(replies[0].text).toContain('/cost')
+  })
+
+  it('passes the slash-command verbatim to inject and renders output as <pre>', async () => {
+    const inject = vi.fn().mockResolvedValue({ output: 'Total cost: $0.42', truncated: false })
+    const { deps, replies } = makeDeps({ getArgs: () => '/cost', inject })
+    await handleInjectCommand(fakeCtx(), deps)
+    expect(inject).toHaveBeenCalledWith('gymbro', '/cost')
+    expect(replies).toHaveLength(1)
+    expect(replies[0].text).toBe('<pre>Total cost: $0.42</pre>')
+    expect(replies[0].opts).toEqual({ html: true })
+  })
+
+  it('prepends slash if the operator omitted it', async () => {
+    const inject = vi.fn().mockResolvedValue({ output: 'ok', truncated: false })
+    const { deps } = makeDeps({ getArgs: () => 'cost', inject })
+    await handleInjectCommand(fakeCtx(), deps)
+    expect(inject).toHaveBeenCalledWith('gymbro', '/cost')
+  })
+
+  it('replies with an empty-output notice when nothing new was captured', async () => {
+    const inject = vi.fn().mockResolvedValue({ output: '   \n  ', truncated: false })
+    const { deps, replies } = makeDeps({ getArgs: () => '/cost', inject })
+    await handleInjectCommand(fakeCtx(), deps)
+    expect(replies[0].text).toContain('no new output captured')
+  })
+
+  it('appends a truncation suffix when the result is truncated', async () => {
+    const inject = vi.fn().mockResolvedValue({ output: 'a lot of text', truncated: true })
+    const { deps, replies } = makeDeps({ getArgs: () => '/cost', inject })
+    await handleInjectCommand(fakeCtx(), deps)
+    expect(replies[0].text).toContain('output truncated')
+  })
+
+  it('surfaces InjectError code + message when validation fails (not_allowed)', async () => {
+    const inject = vi.fn().mockRejectedValue(new InjectError('not_allowed', '/foo not in allowlist'))
+    const { deps, replies } = makeDeps({ getArgs: () => '/foo', inject })
+    await handleInjectCommand(fakeCtx(), deps)
+    expect(replies[0].text).toContain('inject failed')
+    expect(replies[0].text).toContain('not_allowed')
+    expect(replies[0].text).toContain('not in allowlist')
+  })
+
+  it('surfaces InjectError when the agent has no tmux session (session_missing)', async () => {
+    const inject = vi.fn().mockRejectedValue(new InjectError('session_missing', 'session "gymbro" not found'))
+    const { deps, replies } = makeDeps({ getArgs: () => '/cost', inject })
+    await handleInjectCommand(fakeCtx(), deps)
+    expect(replies[0].text).toContain('session_missing')
+  })
+
+  it('falls back to a generic message for unknown errors', async () => {
+    const inject = vi.fn().mockRejectedValue(new Error('boom'))
+    const { deps, replies } = makeDeps({ getArgs: () => '/cost', inject })
+    await handleInjectCommand(fakeCtx(), deps)
+    expect(replies[0].text).toContain('boom')
+  })
+})

--- a/telegram-plugin/gateway/inject-handler.ts
+++ b/telegram-plugin/gateway/inject-handler.ts
@@ -1,0 +1,74 @@
+/**
+ * #725 Phase 2 — Telegram /inject command handler.
+ *
+ * Lives in its own module so the unit tests can import it without
+ * triggering gateway.ts's top-level `new Bot(TOKEN)` initialisation.
+ * gateway.ts wires this into bot.command('inject', ...).
+ */
+
+import type { Context } from 'grammy'
+import {
+  InjectError,
+  INJECT_ALLOWLIST,
+  injectSlashCommand as defaultInject,
+  type InjectResult,
+} from '../../src/agents/inject.js'
+
+export interface InjectDeps {
+  isAuthorized: (ctx: Context) => boolean
+  inject: (agent: string, command: string) => Promise<InjectResult>
+  reply: (ctx: Context, text: string, opts?: { html?: boolean }) => Promise<void>
+  getAgentName: () => string
+  /** Pull the slash-command body out of the message (defaults to ctx.match-style logic). */
+  getArgs: (ctx: Context) => string
+  /** HTML-escape helper (matches gateway.ts's escapeHtmlForTg). */
+  escapeHtml: (s: string) => string
+  /** Format pre-block helper (matches gateway.ts's preBlock). */
+  preBlock: (s: string) => string
+  /** Optional formatter that trims/wraps the captured output. */
+  formatOutput?: (s: string) => string
+}
+
+export async function handleInjectCommand(ctx: Context, deps: InjectDeps): Promise<void> {
+  if (!deps.isAuthorized(ctx)) return
+  const arg = deps.getArgs(ctx).trim()
+  if (!arg) {
+    const allow = [...INJECT_ALLOWLIST].sort().join(', ')
+    await deps.reply(
+      ctx,
+      `Usage: <code>/inject &lt;slashCommand&gt;</code>\nAllowed: <code>${deps.escapeHtml(allow)}</code>`,
+      { html: true },
+    )
+    return
+  }
+  const slashCommand = arg.startsWith('/') ? arg : `/${arg}`
+  const agentName = deps.getAgentName()
+  try {
+    const { output, truncated } = await deps.inject(agentName, slashCommand)
+    if (output.trim().length === 0) {
+      await deps.reply(
+        ctx,
+        `<i>(no new output captured for ${deps.escapeHtml(slashCommand)})</i>`,
+        { html: true },
+      )
+      return
+    }
+    const formatted = deps.formatOutput ? deps.formatOutput(output) : output
+    const body = deps.preBlock(formatted)
+    const suffix = truncated ? '\n<i>... (output truncated)</i>' : ''
+    await deps.reply(ctx, body + suffix, { html: true })
+  } catch (err) {
+    if (err instanceof InjectError) {
+      await deps.reply(
+        ctx,
+        `<b>inject failed</b> (<code>${deps.escapeHtml(err.code)}</code>): ${deps.escapeHtml(err.message)}`,
+        { html: true },
+      )
+      return
+    }
+    const msg = err instanceof Error ? err.message : String(err)
+    await deps.reply(ctx, `<b>inject failed:</b> ${deps.escapeHtml(msg)}`, { html: true })
+  }
+}
+
+export { defaultInject }

--- a/telegram-plugin/welcome-text.ts
+++ b/telegram-plugin/welcome-text.ts
@@ -259,6 +259,10 @@ export const TELEGRAM_MENU_COMMANDS = [
   { command: "version", description: "Show versions + running agent health" },
   // Quick diagnostic
   { command: "logs", description: "Show recent agent logs" },
+  // #725 Phase 2 — inject a Claude Code REPL slash command into the agent's
+  // tmux pane (allowlisted: /cost, /status, /model, /clear, /compact,
+  // /memory, /hooks). Requires experimental.tmux_supervisor on the agent.
+  { command: "inject", description: "Inject a Claude Code slash command (e.g. /cost)" },
   { command: "doctor", description: "Health check (deps, services, MCP)" },
   { command: "usage", description: "Pro/Max plan quota (5h + 7d windows)" },
   // Vault — secrets + capability grants. /vault is a top-level command

--- a/tests/systemd.test.ts
+++ b/tests/systemd.test.ts
@@ -188,7 +188,10 @@ describe("generateUnit", () => {
       expect(unit).toContain("ExecStart=/usr/bin/tmux -L switchroom-gymbro -f /tmp/gymbro/tmux.conf new-session -A -d -s gymbro -x 400 -y 50 'expect -f");
       expect(unit).toContain("/tmp/gymbro/start.sh");
       expect(unit).toContain("ExecStartPost=/usr/bin/tmux -L switchroom-gymbro pipe-pane -o -t gymbro 'cat >> /tmp/gymbro/service.log'");
-      expect(unit).toContain("ExecStop=/usr/bin/tmux -L switchroom-gymbro kill-session -t gymbro");
+      // Leading `-` on ExecStop = ignore non-zero exit. See systemd.ts
+      // comment — silences the script→tmux transition's first restart.
+      expect(unit).toContain("ExecStop=-/usr/bin/tmux -L switchroom-gymbro kill-session -t gymbro");
+      expect(unit).not.toContain("ExecStop=/usr/bin/tmux");
       // No script -qfc anywhere when flag=true
       expect(unit).not.toContain("/usr/bin/script -qfc");
     });
@@ -569,6 +572,10 @@ describe("generateAgentTmuxConf", () => {
 
   it("disables remain-on-exit so claude exit fires Restart=on-failure", () => {
     expect(generateAgentTmuxConf()).toContain("set -g remain-on-exit off");
+  });
+
+  it("enables focus-events so the pane reports focus to the spawned shell (Phase 1.x)", () => {
+    expect(generateAgentTmuxConf()).toContain("set -g focus-events on");
   });
 });
 


### PR DESCRIPTION
## Summary

Phase 1.x cleanups + Phase 2 inject primitive for #725. Builds on Phase 1 (#726) which is already canarying live on gymbro.

## Phase 1.x cleanups (commit `c773b6a9`)

- `ExecStop=-/usr/bin/tmux …` — leading `-` so the script→tmux migration restart doesn't log FAILURE when there's no tmux socket yet
- `set -g focus-events on` in shipped tmux.conf — silences the focus-events warning in the pane

Both legacy (flag=false) paths unchanged.

## Phase 2 inject feature (commit `fb4f8edb`)

End-to-end: Telegram user types `/inject /cost` → handler validates → `tmux send-keys -l "/cost"` + `tmux send-keys Enter` → capture-pane diff returns the new lines → reply back to chat as `<pre>` block.

### `src/agents/inject.ts` (new)
- `INJECT_ALLOWLIST`: `/cost`, `/status`, `/model`, `/clear`, `/compact`, `/memory`, `/hooks`
- `INJECT_BLOCKLIST`: `/login`, `/logout`, `/exit`, `/quit` (gives a distinct error code from "not allowed")
- `injectSlashCommand(agentName, command, opts)` — validates, snapshots pane, sends `-l` body + separate Enter, polls for stability (~150ms cadence, 5s timeout, 2s settle), returns `{ output, truncated }`
- `InjectError` with codes `not_allowed | blocked | session_missing | timeout | poll_error`
- Test seam `injectSlashCommandWith({ runner })` for unit tests

### CLI: `switchroom agent send <name> <slashCommand>`
Refuses if `experimental.tmux_supervisor` isn't enabled for the agent. Otherwise calls `injectSlashCommand` and prints output.

### Telegram: `bot.command('inject', …)`
- `isAuthorizedSender(ctx)` checked FIRST
- Agent name resolved from `getMyAgentName()` (env), NOT user input — prevents cross-agent injection
- HTML-escaped output wrapped in `<pre>`
- Truncation marker if > 3000 bytes
- Registered in `setMyCommands` welcome menu

## What does NOT change

- ttyd debug overlay (Phase 3 — still optional, deferred)
- Idle-gate behind turn-lifecycle (documented as future work in inject.ts; for now user is responsible for timing)
- Phase 1 surface (lifecycle.attachAgent, schema, autoaccept.exp untouched)
- No agent migration; canary on gymbro after merge

## Tests

- `src/agents/inject.test.ts` — 14 tests (allowlist edge cases, blocklist, session_missing, runner mocks)
- `telegram-plugin/gateway/inject-handler.test.ts` — 9 tests (auth gating, allowlist surface, error mapping)
- `tests/systemd.test.ts` — added assertions for `ExecStop=-…` dash and `focus-events on`
- All 94 targeted tests green; `tsc --noEmit` clean

## Review

Reviewed by independent reviewer (separate process). Verdict: APPROVE. Findings: 2 MINOR (defensive ANSI strip on diff, settle-loop simplification), 3 NIT (unused import, truncation loop, missing regression test for agent-name resolution). All non-blocking.

## Test plan after merge

- Rebuild dist on host, swap into `~/.bun/install/global/node_modules/switchroom-ai/`
- `switchroom agent send gymbro /cost` from CLI — should print structured cost output
- DM `/inject /cost` to gymbro on Telegram — should reply with the same output in a `<pre>` block
- `/inject /login` should return blocked error
- `/inject /foo` should return not-allowed error

🤖 Generated with [Claude Code](https://claude.com/claude-code)