### PR TITLE
feat(inject): add /usage to inject allowlist (#725)

### DIFF
--- a/src/agents/inject.ts
+++ b/src/agents/inject.ts
@@ -39,6 +39,7 @@ export const INJECT_ALLOWLIST: ReadonlySet<string> = new Set([
   "/compact",
   "/memory",
   "/hooks",
+  "/usage",
 ]);
 
 /**


### PR DESCRIPTION
Adds Claude Code's undocumented `/usage` command to `INJECT_ALLOWLIST` so operators can pull weekly-quota-limit info via Telegram `/inject /usage`.

Read-only — renders quota bar without mutating session/auth state, same shape as `/cost`. One-line addition.

Tests still 14/14 green; tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)