### PR TITLE
fix(#725): address reviewer-flagged coverage gaps from #731

### DIFF
--- a/src/agents/inject.integration.test.ts
+++ b/src/agents/inject.integration.test.ts
@@ -1,12 +1,17 @@
 /**
- * Real-tmux E2E smoke test for inject argv shape (#725 / #728).
+ * Real-tmux E2E test for inject runner (#725 / #728).
  *
  * Pure unit tests (`inject.test.ts`) mock `TmuxRunner` and so can't
  * catch argv-ordering bugs against the real `tmux` binary — that's how
- * #728 (`-t target` placement) escaped. This test spawns a transient
- * tmux session on a unique socket and exercises the runner directly:
- * send-keys with the literal text + Enter, then assert the bytes
- * actually arrived in the pane via capture-pane.
+ * #728 (`-t target` placement) escaped. This file pairs two checks:
+ *
+ *  1) An argv-shape pre-check that drives raw `spawnSync` directly to
+ *     confirm tmux's own grammar still accepts the canonical order.
+ *  2) The load-bearing test: drive the production `makeTmuxRunner`
+ *     factory itself against a real transient tmux session. A
+ *     regression of the splice fix in `src/agents/inject.ts` would
+ *     fail this test because the literal payload would be corrupted
+ *     with a glued-on `-t<session>` suffix when typed into the pane.
  *
  * Skips cleanly when `tmux` is absent so CI environments without the
  * binary don't break.
@@ -15,6 +20,7 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { execFileSync, spawnSync } from "node:child_process";
 import { existsSync } from "node:fs";
+import { makeTmuxRunner } from "./inject.js";
 
 function tmuxAvailable(): boolean {
   try {
@@ -45,8 +51,6 @@ describe.skipIf(!TMUX_PRESENT)("inject — real-tmux argv smoke (#728 regression
   beforeEach(() => {
     // Spawn a fresh detached session that just runs `cat` so anything
     // we send-keys lands in stdin and gets echoed back to the pane.
-    // 80x24 is the default; small enough to read, large enough to fit
-    // a one-liner.
     const r = tmux([
       "new-session",
       "-d",
@@ -71,13 +75,12 @@ describe.skipIf(!TMUX_PRESENT)("inject — real-tmux argv smoke (#728 regression
     tmux(["kill-server"]);
   });
 
-  it("send-keys -l <text> then Enter delivers bytes to the pane", async () => {
-    // Wait for the bash inside the pane to actually start cat-ing.
+  it("argv-shape pre-check: send-keys -l -t <session> <text> + Enter delivers bytes", async () => {
+    // Fast pre-check — directly exercises tmux grammar (no runner) so
+    // a tmux upgrade that changes argv parsing surfaces with a clear
+    // failure here before the runner-level test below.
     await sleep(300);
 
-    // Use the same argv shape the runner emits in src/agents/inject.ts:
-    //   tmux -L <socket> send-keys -l -t <session> <text>
-    //   tmux -L <socket> send-keys    -t <session> Enter
     const text = "hello-from-inject";
 
     let r = tmux(["send-keys", "-l", "-t", SESSION, text]);
@@ -86,37 +89,41 @@ describe.skipIf(!TMUX_PRESENT)("inject — real-tmux argv smoke (#728 regression
     r = tmux(["send-keys", "-t", SESSION, "Enter"]);
     expect(r.status).toBe(0);
 
-    // Settle window — `cat` echoes back on flush; give it a moment.
     await sleep(300);
 
     const cap = tmux(["capture-pane", "-p", "-t", SESSION, "-S", "-200"]);
     expect(cap.status).toBe(0);
-    // The literal text must appear in the pane (cat echoed it back).
     expect(cap.stdout).toContain(text);
-    // Sanity: it should NOT contain the corrupted form that #728
-    // produced (text-then-target-flag glued together).
     expect(cap.stdout).not.toContain(`${text}-t`);
     expect(cap.stdout).not.toContain(`${text} -t ${SESSION}`);
   });
 
-  it("argv ordering: send-keys positional after -t, not before", async () => {
-    // Direct shape assertion — pre-#728 the runner emitted
-    //   send-keys -l <text> -t <session>
-    // which tmux interpreted as send-keys -l "<text>" "-t" "<session>"
-    // — i.e. the target flag was typed as keystrokes. This test
-    // documents the canonical order: subcmd, leading flags, -t, keys.
-    await sleep(200);
+  it("makeTmuxRunner.send delivers literal slash payload + Enter to pane (#728 regression)", async () => {
+    // Load-bearing assertion: drive the same factory production uses.
+    // If the splice in inject.ts:158-166 regresses, the pane would
+    // receive `/test-payload-tinjecttest` instead of `/test-payload`.
+    await sleep(300);
 
-    const text = "argv-order-check";
-    // Correct order (matches inject.ts:158-166 splice logic):
-    const r = tmux(["send-keys", "-l", "-t", SESSION, text]);
-    expect(r.status).toBe(0);
+    const runner = makeTmuxRunner("tmux");
 
-    tmux(["send-keys", "-t", SESSION, "Enter"]);
-    await sleep(250);
+    // Sanity: hasSession returns true for a session that exists.
+    expect(runner.hasSession(SOCKET, SESSION)).toBe(true);
 
-    const cap = tmux(["capture-pane", "-p", "-t", SESSION, "-S", "-200"]);
-    expect(cap.stdout).toContain(text);
+    const payload = "/test-payload";
+    runner.send(SOCKET, SESSION, ["send-keys", "-l", payload]);
+    runner.send(SOCKET, SESSION, ["send-keys", "Enter"]);
+
+    await sleep(300);
+
+    const captured = runner.capture(SOCKET, SESSION) ?? "";
+
+    // The literal slash payload must appear, with no -t/session
+    // contamination glued on.
+    expect(captured).toContain(payload);
+    expect(captured).not.toContain(`${payload}-t`);
+    expect(captured).not.toContain(`${payload}-t${SESSION}`);
+    expect(captured).not.toContain(`${payload} -t ${SESSION}`);
+    expect(captured).not.toContain(`${payload}-tinjecttest`);
   });
 });
 

--- a/src/agents/inject.ts
+++ b/src/agents/inject.ts
@@ -130,13 +130,22 @@ function defaultSocketName(agentName: string): string {
   return `switchroom-${agentName}`;
 }
 
-interface TmuxRunner {
+export interface TmuxRunner {
   capture(socket: string, session: string): string | null;
   send(socket: string, session: string, args: string[]): void;
   hasSession(socket: string, session: string): boolean;
 }
 
-function makeTmuxRunner(tmuxBin: string): TmuxRunner {
+/**
+ * Build a TmuxRunner backed by the real `tmux` binary at `tmuxBin`.
+ *
+ * Exported (vs the original module-private factory) so integration
+ * tests can drive the same splice logic as production rather than
+ * hand-constructing argv via `spawnSync`. A regression of the #728
+ * splice fix should be observable through `runner.send` — the unit
+ * test mocks the runner, so it can't see that.
+ */
+export function makeTmuxRunner(tmuxBin: string): TmuxRunner {
   return {
     capture(socket, session) {
       try {

--- a/src/agents/lifecycle.ts
+++ b/src/agents/lifecycle.ts
@@ -485,6 +485,14 @@ export function resolveAgentPid(unitName: string, useTmux: boolean): number | nu
       nonWrapper.sort((a, b) => b.rss - a.rss);
       return nonWrapper[0].pid;
     }
+    // We enumerated candidates but every one was a wrapper (tmux/expect/
+    // script/bash/sh) — no claude pid yet. Emit a single-line breadcrumb
+    // so operators can correlate "PID looks wrong" with this state via
+    // journalctl. We DO NOT log when the cgroup walk found zero processes
+    // (the legitimate boot-window race) — that path returns earlier.
+    process.stderr.write(
+      `[switchroom] resolveAgentPid: cgroup walk found ${candidates.length} processes, no claude match — falling back to MainPID for unit=${unitName}\n`,
+    );
     return mainPidFromSystemd();
   } catch {
     return mainPidFromSystemd();

--- a/telegram-plugin/gateway/boot-probes.ts
+++ b/telegram-plugin/gateway/boot-probes.ts
@@ -319,6 +319,14 @@ async function resolveTmuxSupervisorPid(
       nonWrapper.sort((a, b) => b.rss - a.rss)
       return nonWrapper[0].pid
     }
+    // Candidates enumerated but every one was a wrapper (tmux/expect/
+    // script/bash/sh). Emit a breadcrumb mirroring the one in
+    // src/agents/lifecycle.ts:resolveAgentPid so journalctl shows the
+    // same state on both sides. The boot-window race (zero pids) returns
+    // earlier without logging, by design.
+    process.stderr.write(
+      `[switchroom] resolveTmuxSupervisorPid: cgroup walk found ${candidates.length} processes, no claude match — falling back to MainPID for unit=switchroom-${agentName}.service\n`,
+    )
     return null
   } catch {
     return null

--- a/telegram-plugin/tests/pty-tail-tmux-fragment.test.ts
+++ b/telegram-plugin/tests/pty-tail-tmux-fragment.test.ts
@@ -11,6 +11,22 @@
  * Fixture: small synthesized Ink-style fragment containing a
  * `● switchroom-telegram - reply (MCP)(... text: "...")` marker.
  * Kept ≤2KB.
+ *
+ * Recapture procedure (for future maintainers):
+ *
+ *   To regenerate this fixture from a live tmux-supervised agent:
+ *     1. tail -c 250 "$AGENT_DIR/service.log" \
+ *          > telegram-plugin/tests/fixtures/pty-tail-tmux-fragment.bin
+ *        (adjust byte count as needed; aim for the smallest tail that
+ *        still contains a complete `● switchroom-telegram - reply (MCP)`
+ *        block including the `text: "..."` argument).
+ *     2. Run this test; it should still parse the marker.
+ *
+ *   If the parse breaks after Ink rendering changes upstream (Claude
+ *   updates how MCP tool calls are rendered, terminal width changes,
+ *   etc.), recapture from a known-good agent and confirm the
+ *   `V1Extractor` still finds `● switchroom-telegram - reply (MCP)`
+ *   in the rendered terminal output.
  */
 
 import { describe, expect, it } from 'vitest'

--- a/tests/systemd-restart.test.ts
+++ b/tests/systemd-restart.test.ts
@@ -303,31 +303,7 @@ describe("generateGatewayUnit — tmux supervisor env propagation (#725)", () =>
   });
 });
 
-const runIntegration = process.env.RUN_SYSTEMD_INTEGRATION_TESTS === "1";
-
-describe.skipIf(!runIntegration)(
-  "integration: restart actually changes claude PID (issue #361) [requires RUN_SYSTEMD_INTEGRATION_TESTS=1]",
-  () => {
-    it(
-      "claude PID after restart differs from claude PID before restart",
-      async () => {
-        // This test body intentionally left as a stub.
-        // Full implementation requires:
-        //   1. scaffoldAgent() + installUnit() for a test agent
-        //   2. systemctl --user start switchroom-<agent>.service
-        //   3. pgrep -f "claude.*<agent>" to capture PID
-        //   4. systemctl --user restart switchroom-<agent>.service
-        //   5. pgrep again — assert new PID !== old PID
-        //   6. systemctl --user stop + uninstall cleanup
-        //
-        // Until a full harness is wired up, skip with a descriptive error
-        // so anyone who sets the env var gets a clear signal to implement.
-        throw new Error(
-          "Integration test stub: implement the PID-change assertion described in the comment above. " +
-          "Set RUN_SYSTEMD_INTEGRATION_TESTS=1 to run."
-        );
-      },
-      60_000,
-    );
-  },
-);
+// Removed: a long-broken stub gated on RUN_SYSTEMD_INTEGRATION_TESTS=1
+// that threw unconditionally rather than implementing the PID-change
+// assertion. Real systemd-interaction coverage now lives in
+// `tests/cgroup-kill.integration.test.ts`.


### PR DESCRIPTION
Addresses 4 MINOR findings from #731 review.

1. `inject.integration.test.ts` now drives `makeTmuxRunner`'s `runner.send` end-to-end (not hand-constructed argv). Would have caught the #728 splice regression.
2. `resolveAgentPid` + `resolveTmuxSupervisorPid` log a single-line stderr breadcrumb when cgroup walk finds candidates but no claude match. Boot-window race (empty cgroup) stays silent.
3. `pty-tail-tmux-fragment.test.ts` header documents the recapture procedure.
4. Pre-existing throwing stub at `tests/systemd-restart.test.ts:308-333` removed; comment points at `tests/cgroup-kill.integration.test.ts`.

Reviewer (separate process): APPROVE. 1 NIT (describe-block title slightly undersells the test now). Tests pass: 142/143 (1 skipped without host tools). tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)