### PR TITLE
fix(#725): document /inject in /commands help (CI green)

### DIFF
--- a/telegram-plugin/welcome-text.ts
+++ b/telegram-plugin/welcome-text.ts
@@ -332,6 +332,7 @@ export function switchroomHelpText(agentName: string): string {
     `<code>/vault grants [agent]</code> — list active capability grants (tap to revoke)`,
     `<code>/doctor</code> — health check (deps, services, MCP)`,
     `<code>/usage</code> — Pro/Max plan quota (5h + 7d windows)`,
+    `<code>/inject &lt;slash&gt;</code> — inject a Claude Code REPL slash command (e.g. <code>/inject /cost</code>; allowlisted)`,
     `<code>/commands</code> — this help`,
     ``,
     `<i>Tip: <code>/update</code> picks up new code; <code>/restart</code> bounces a stuck agent; <code>/version</code> checks what's running.</i>`,


### PR DESCRIPTION
Phase 2 #727 registered `/inject` in `setMyCommands` but didn't add a corresponding entry in the `/commands` help body. `welcome-text.test.ts` asserts every menu command appears in the help — that test has been failing on CI since #727.

One-line fix; 54/54 welcome-text tests pass; tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)