### PR TITLE
fix(progress-card): add fallback return after switch (CI: tsc strict)

### DIFF
--- a/telegram-plugin/progress-card.ts
+++ b/telegram-plugin/progress-card.ts
@@ -970,6 +970,11 @@ export function reduce(
       // No-op — we key off enqueue + turn_end for the turn boundary.
       return state
   }
+  // Defensive: tsc can't prove exhaustiveness across the SessionEvent
+  // discriminated union when new kinds are added incrementally (#623
+  // strict-tsc enforcement on plugin source). Fall back to current
+  // state on any future unknown kind.
+  return state
 }
 
 // ─── Renderer ───────────────────────────────────────────────────────────────


### PR DESCRIPTION
CI's plugin-references check (#623) enforces clean tsc on plugin source. `progress-card.ts:reduce()` switch covers every documented SessionEvent kind but tsc can't prove exhaustiveness, so it flags the function as missing a return. Add a defensive `return state` after the switch.

Pre-existing CI break introduced by #721 (capped sub-agents added a new SessionEvent kind without exhaustiveness coverage). Verified locally: `bun lint` (which runs tsc --noEmit + plugin-references) is now clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)