### PR TITLE
feat(inject): tagged outcome + accent-headed responses (#725)

### DIFF
--- a/src/agents/inject.test.ts
+++ b/src/agents/inject.test.ts
@@ -3,15 +3,15 @@
  *
  * The real tmux process is faked via the TmuxRunner test seam — these
  * tests assert the validation rules, the session-existence check, the
- * pane-diff logic, and the basic happy-path output capture.
+ * pane-diff logic, and outcome classification.
  *
  * Run: npx vitest run src/agents/inject.test.ts
  */
 
 import { describe, it, expect } from "vitest";
 import {
-  INJECT_ALLOWLIST,
-  INJECT_BLOCKLIST,
+  INJECT_COMMANDS,
+  INJECT_BLOCKED,
   InjectError,
   diffPane,
   injectSlashCommand,
@@ -21,7 +21,7 @@ import {
 
 describe("validateInjectCommand", () => {
   it("accepts every command in the allowlist", () => {
-    for (const cmd of INJECT_ALLOWLIST) {
+    for (const cmd of INJECT_COMMANDS.keys()) {
       expect(validateInjectCommand(cmd)).toBe(cmd);
     }
   });
@@ -35,7 +35,7 @@ describe("validateInjectCommand", () => {
   });
 
   it("throws blocked for /login, /logout, /exit, /quit", () => {
-    for (const cmd of INJECT_BLOCKLIST) {
+    for (const cmd of INJECT_BLOCKED.keys()) {
       const err = (() => {
         try {
           validateInjectCommand(cmd);
@@ -71,25 +71,82 @@ describe("validateInjectCommand", () => {
   });
 });
 
+describe("INJECT_COMMANDS metadata", () => {
+  it("provides expected metadata shape for every entry", () => {
+    for (const [verb, meta] of INJECT_COMMANDS) {
+      expect(verb.startsWith("/")).toBe(true);
+      expect(typeof meta.description).toBe("string");
+      expect(typeof meta.expectsOutput).toBe("boolean");
+    }
+  });
+
+  it("/compact carries a silentNote", () => {
+    expect(INJECT_COMMANDS.get("/compact")?.silentNote).toBe(
+      "compaction runs silently",
+    );
+  });
+
+  it("/clear has expectsOutput=false and no silentNote", () => {
+    const meta = INJECT_COMMANDS.get("/clear");
+    expect(meta?.expectsOutput).toBe(false);
+    expect(meta?.silentNote).toBeUndefined();
+  });
+});
+
 describe("diffPane", () => {
-  it("returns lines in after that aren't in before", () => {
+  it("returns lines in after that aren't in before (set-diff fallback)", () => {
     const before = "line one\nline two\n";
     const after = "line one\nline two\nline three\n";
-    expect(diffPane(before, after)).toBe("line three");
+    const r = diffPane(before, after);
+    expect(r.output).toBe("line three");
+    expect(r.anchored).toBe(false);
   });
 
   it("ignores empty lines", () => {
     const before = "a\nb\n";
     const after = "\n\na\nb\nc\n\n";
-    expect(diffPane(before, after)).toBe("c");
+    expect(diffPane(before, after).output).toBe("c");
   });
 
   it("returns empty string when nothing new", () => {
-    expect(diffPane("a\nb", "a\nb")).toBe("");
+    expect(diffPane("a\nb", "a\nb").output).toBe("");
+  });
+
+  it("anchors on the LAST command-echo line in `after`", () => {
+    const before = `❯ /usage
+   Status   Config   Usage   Stats
+  Session
+  Total cost: $0.50
+  Esc to cancel`;
+    const after = `❯ /usage
+   Status   Config   Usage   Stats
+  Session
+  Total cost: $0.50
+  Esc to cancel
+some-narrative
+❯ /usage
+   Status   Config   Usage   Stats
+  Session
+  Total cost: $0.75
+  Esc to cancel`;
+    const r = diffPane(before, after, "/usage");
+    expect(r.output).toContain("Status   Config   Usage   Stats");
+    expect(r.output).toContain("$0.75");
+    expect(r.output).not.toContain("Esc to cancel");
+    expect(r.anchored).toBe(true);
+  });
+
+  it("falls back to line-set diff when command anchor is absent", () => {
+    const before = "old line A\nold line B";
+    const after = "old line A\nold line B\nnew line C\nnew line D";
+    const r = diffPane(before, after, "/cost");
+    expect(r.output).toContain("new line C");
+    expect(r.output).toContain("new line D");
+    expect(r.anchored).toBe(false);
   });
 });
 
-// ─── injectSlashCommandWith — happy path + error paths via fake runner ─────
+// ─── injectSlashCommandWith — outcome classification ───────────────────────
 
 interface FakeRunner {
   hasSession: (s: string, n: string) => boolean;
@@ -99,8 +156,9 @@ interface FakeRunner {
 
 function makeFake(opts: {
   hasSession?: boolean;
-  captures?: string[]; // sequence returned in order
+  captures?: string[];
   onSend?: (args: string[]) => void;
+  sendThrows?: Error;
 }): FakeRunner {
   let i = 0;
   const captures = opts.captures ?? [];
@@ -112,31 +170,51 @@ function makeFake(opts: {
       return v;
     },
     send: (_s, _n, args) => {
+      if (opts.sendThrows) throw opts.sendThrows;
       opts.onSend?.(args);
     },
   };
 }
 
-describe("injectSlashCommandWith", () => {
-  it("throws session_missing when has-session returns false", async () => {
+describe("injectSlashCommandWith — outcomes", () => {
+  it("outcome=failed (session_missing) when has-session returns false", async () => {
     const runner = makeFake({ hasSession: false });
-    await expect(
-      injectSlashCommandWith(runner, {
-        socket: "switchroom-x",
-        session: "x",
-        command: "/cost",
-        settleMs: 50,
-        timeoutMs: 100,
-      }),
-    ).rejects.toMatchObject({ code: "session_missing" });
+    const r = await injectSlashCommandWith(runner, {
+      socket: "switchroom-x",
+      session: "x",
+      command: "/cost",
+      settleMs: 50,
+      timeoutMs: 100,
+    });
+    expect(r.outcome).toBe("failed");
+    expect(r.errorCode).toBe("session_missing");
+    expect(r.command).toBe("/cost");
+    expect(r.meta).not.toBeNull();
   });
 
-  it("captures diff between before and after pane snapshots", async () => {
+  it("outcome=failed (tmux_failed) when send-keys throws", async () => {
+    const runner = makeFake({
+      hasSession: true,
+      captures: ["before\n"],
+      sendThrows: new Error("connection refused"),
+    });
+    const r = await injectSlashCommandWith(runner, {
+      socket: "switchroom-x",
+      session: "x",
+      command: "/cost",
+      settleMs: 50,
+      timeoutMs: 100,
+    });
+    expect(r.outcome).toBe("failed");
+    expect(r.errorCode).toBe("tmux_failed");
+    expect(r.errorMessage).toContain("connection refused");
+  });
+
+  it("outcome=ok with non-empty capture", async () => {
     const before = "$ \n";
     const after = "$ /cost\n\nTotal cost: $0.42\n$ \n";
     const runner = makeFake({
       hasSession: true,
-      // returns: 1) before-snapshot, 2..) after-snapshots (stable)
       captures: [before, after, after, after, after],
     });
     const sent: string[][] = [];
@@ -154,26 +232,52 @@ describe("injectSlashCommandWith", () => {
       ["send-keys", "-l", "/cost"],
       ["send-keys", "Enter"],
     ]);
+    expect(result.outcome).toBe("ok");
     expect(result.output).toContain("Total cost: $0.42");
     expect(result.truncated).toBe(false);
+    expect(result.command).toBe("/cost");
+    expect(result.meta?.expectsOutput).toBe(true);
   });
 
-  it("flags truncated when output exceeds 3000 bytes", async () => {
+  it("outcome=ok with diagnostic=truncated_output when over byte cap", async () => {
     const before = "";
     const big = Array.from({ length: 200 }, (_, i) => `line ${i} ${"x".repeat(40)}`).join("\n");
     const runner = makeFake({
       hasSession: true,
       captures: [before, big, big, big, big],
     });
-    const result = await injectSlashCommandWith(runner, {
+    const r = await injectSlashCommandWith(runner, {
       socket: "switchroom-x",
       session: "x",
       command: "/cost",
       settleMs: 50,
       timeoutMs: 1000,
     });
-    expect(result.truncated).toBe(true);
-    expect(Buffer.byteLength(result.output, "utf-8")).toBeLessThanOrEqual(3000);
+    expect(r.outcome).toBe("ok");
+    expect(r.truncated).toBe(true);
+    expect(r.diagnostic).toBe("truncated_output");
+    expect(Buffer.byteLength(r.output, "utf-8")).toBeLessThanOrEqual(3000);
+  });
+
+  it("outcome=ok_no_output with diagnostic=anchor_missing when capture is empty", async () => {
+    // Pre and post identical (no anchor, no new lines) → empty output.
+    const buf = "$ \n";
+    const runner = makeFake({
+      hasSession: true,
+      captures: [buf, buf, buf, buf, buf],
+    });
+    const r = await injectSlashCommandWith(runner, {
+      socket: "switchroom-x",
+      session: "x",
+      command: "/clear",
+      settleMs: 30,
+      timeoutMs: 200,
+    });
+    expect(r.outcome).toBe("ok_no_output");
+    expect(r.output).toBe("");
+    expect(r.diagnostic).toBe("anchor_missing");
+    expect(r.command).toBe("/clear");
+    expect(r.meta?.expectsOutput).toBe(false);
   });
 });
 
@@ -188,50 +292,5 @@ describe("injectSlashCommand (default runner — validation only)", () => {
     await expect(injectSlashCommand("any", "/foo")).rejects.toMatchObject({
       code: "not_allowed",
     });
-  });
-});
-
-import { describe as describeAnchor, it as itAnchor, expect as expectAnchor } from "vitest";
-import { diffPane as diffPaneFn } from "./inject";
-
-describeAnchor("diffPane — command-anchor diff (regression for repeated-call empty-output bug)", () => {
-  itAnchor("returns response below the LAST command-echo line in `after`", () => {
-    const before = `❯ /usage
-   Status   Config   Usage   Stats
-  Session
-  Total cost: $0.50
-  Esc to cancel`;
-    const after = `❯ /usage
-   Status   Config   Usage   Stats
-  Session
-  Total cost: $0.50
-  Esc to cancel
-some-narrative
-❯ /usage
-   Status   Config   Usage   Stats
-  Session
-  Total cost: $0.75
-  Esc to cancel`;
-    const out = diffPaneFn(before, after, "/usage");
-    expectAnchor(out).toContain("Status   Config   Usage   Stats");
-    expectAnchor(out).toContain("$0.75");
-    // The trailing affordance should be stripped
-    expectAnchor(out).not.toContain("Esc to cancel");
-  });
-
-  itAnchor("falls back to line-set diff when command anchor is absent", () => {
-    const before = "old line A\nold line B";
-    const after = "old line A\nold line B\nnew line C\nnew line D";
-    const out = diffPaneFn(before, after, "/cost");
-    expectAnchor(out).toContain("new line C");
-    expectAnchor(out).toContain("new line D");
-    expectAnchor(out).not.toContain("old line A");
-  });
-
-  itAnchor("works without a command argument (legacy line-set diff)", () => {
-    const before = "x\ny";
-    const after = "x\ny\nz";
-    const out = diffPaneFn(before, after);
-    expectAnchor(out).toBe("z");
   });
 });

--- a/src/agents/inject.ts
+++ b/src/agents/inject.ts
@@ -12,6 +12,14 @@
  * blocklist exists purely to give a more specific error message for
  * those four — anything else outside the allowlist returns `not_allowed`.
  *
+ * UX upgrade (epic #725): rather than throwing on every non-happy path,
+ * `injectSlashCommandWith` now returns a tagged `InjectResult` whose
+ * `outcome` field is one of `ok | ok_no_output | failed`. Validation
+ * still throws (it's a programming error to pass an unvalidated cmd
+ * down the seam) — but the runtime classification is data, not
+ * exceptions, so callers (Telegram handler, CLI) can fan out without
+ * re-implementing try/catch dispatch trees.
+ *
  * FUTURE GAP — turn-lifecycle idle gate. This implementation always
  * sends keys immediately. If the agent is mid-tool-call (e.g. running
  * a long bash command) the slash inject lands in claude's input buffer
@@ -27,20 +35,52 @@ import { promisify } from "node:util";
 const execFileAsync = promisify(execFile);
 
 /**
+ * Per-command metadata for the inject allowlist. `expectsOutput` is a
+ * hint used to decide whether an empty capture is suspicious (warn) or
+ * expected (silent). `silentNote` overrides the empty-capture display
+ * for verbs that intentionally render nothing on success.
+ */
+export interface InjectCommandMeta {
+  description: string;
+  expectsOutput: boolean;
+  silentNote?: string;
+}
+
+/**
  * Hard-coded set of injectable slash commands. Read-only commands that
  * render information without mutating Claude's auth/session state. Add
  * with care — every entry expands the surface area of inject calls.
  */
-export const INJECT_ALLOWLIST: ReadonlySet<string> = new Set([
-  "/cost",
-  "/status",
-  "/model",
-  "/clear",
-  "/compact",
-  "/memory",
-  "/hooks",
-  "/usage",
+export const INJECT_COMMANDS: ReadonlyMap<string, InjectCommandMeta> = new Map([
+  ["/cost", { description: "Show session cost", expectsOutput: true }],
+  ["/status", { description: "Show session status", expectsOutput: true }],
+  ["/usage", { description: "Show plan quota", expectsOutput: true }],
+  ["/hooks", { description: "List configured hooks", expectsOutput: true }],
+  ["/memory", { description: "Open memory picker", expectsOutput: true }],
+  ["/model", { description: "Open model picker", expectsOutput: true }],
+  [
+    "/clear",
+    { description: "Clear session screen", expectsOutput: false },
+  ],
+  [
+    "/compact",
+    {
+      description: "Compact conversation history",
+      expectsOutput: false,
+      silentNote: "compaction runs silently",
+    },
+  ],
 ]);
+
+/**
+ * Backwards-compat: a few callers (and tests) still want a plain Set of
+ * allowed verbs. Derived from `INJECT_COMMANDS` so the two never drift.
+ */
+export const INJECT_ALLOWLIST: ReadonlySet<string> = new Set(INJECT_COMMANDS.keys());
+
+export interface InjectBlockedMeta {
+  reason: string;
+}
 
 /**
  * Commands explicitly refused with a `blocked` (vs `not_allowed`) error
@@ -48,12 +88,17 @@ export const INJECT_ALLOWLIST: ReadonlySet<string> = new Set([
  * destructive / session-ending commands an operator must never trigger
  * from a remote surface.
  */
-export const INJECT_BLOCKLIST: ReadonlySet<string> = new Set([
-  "/login",
-  "/logout",
-  "/exit",
-  "/quit",
+export const INJECT_BLOCKED: ReadonlyMap<string, InjectBlockedMeta> = new Map([
+  ["/login", { reason: "would mutate auth state" }],
+  ["/logout", { reason: "would terminate the agent's auth session" }],
+  ["/exit", { reason: "would kill the agent process" }],
+  ["/quit", { reason: "would kill the agent process" }],
 ]);
+
+/**
+ * Backwards-compat Set view over the blocklist keys.
+ */
+export const INJECT_BLOCKLIST: ReadonlySet<string> = new Set(INJECT_BLOCKED.keys());
 
 export type InjectErrorCode =
   | "not_allowed"
@@ -89,9 +134,39 @@ export interface InjectOpts {
   timeoutMs?: number;
 }
 
+/**
+ * Three outcomes only:
+ *  - `ok` — non-empty capture; render output to the user.
+ *  - `ok_no_output` — send-keys completed, capture empty. Could be
+ *    expected (e.g. `/clear`) or suspicious (`/cost` with no output).
+ *  - `failed` — validation rejected, session missing, or send-keys
+ *    threw. `errorCode` and `errorMessage` carry the reason.
+ *
+ * Classification is derived from runtime capture, not from
+ * `expectsOutput` — that field is a UX hint only.
+ */
+export type InjectOutcome = "ok" | "ok_no_output" | "failed";
+
+export type InjectDiagnostic =
+  | "anchor_missing"
+  | "truncated_output"
+  | "timeout"
+  | "modal_partial";
+
 export interface InjectResult {
+  outcome: InjectOutcome;
+  /** Empty for `ok_no_output` and `failed`. */
   output: string;
   truncated: boolean;
+  /** Bare verb (e.g. `/cost`). Empty for `failed` w/ invalid input. */
+  command: string;
+  /** Allowlist metadata; null when the call failed before validation. */
+  meta: InjectCommandMeta | null;
+  diagnostic?: InjectDiagnostic;
+  /** Set on `failed` outcomes. */
+  errorCode?: InjectErrorCode;
+  /** Short user-facing message for `failed` outcomes. */
+  errorMessage?: string;
 }
 
 const POLL_INTERVAL_MS = 150;
@@ -111,16 +186,18 @@ export function validateInjectCommand(command: string): string {
   }
   const bare = trimmed.split(/\s+/, 1)[0].toLowerCase();
   // Block first so /login etc. get the more specific message.
-  if (INJECT_BLOCKLIST.has(bare)) {
+  const blockedMeta = INJECT_BLOCKED.get(bare);
+  if (blockedMeta) {
     throw new InjectError(
       "blocked",
-      `${bare} is explicitly blocked from inject (would mutate session/auth state).`,
+      `${bare} is explicitly blocked from inject (${blockedMeta.reason}).`,
     );
   }
-  if (!INJECT_ALLOWLIST.has(bare)) {
+  if (!INJECT_COMMANDS.has(bare)) {
+    const allowed = [...INJECT_COMMANDS.keys()].sort().join(", ");
     throw new InjectError(
       "not_allowed",
-      `${bare} is not in the inject allowlist. Allowed: ${[...INJECT_ALLOWLIST].sort().join(", ")}`,
+      `${bare} is not in the inject allowlist. Allowed: ${allowed}`,
     );
   }
   return bare;
@@ -192,6 +269,18 @@ function sleep(ms: number): Promise<void> {
 }
 
 /**
+ * Result of {@link diffPane}. `anchored` is true when the diff was
+ * computed against the command-echo line in the post-capture; false
+ * when the function fell back to line-set diff against `before`.
+ * Callers use the flag to set the `anchor_missing` diagnostic when
+ * the fallback also yielded no output.
+ */
+export interface DiffPaneResult {
+  output: string;
+  anchored: boolean;
+}
+
+/**
  * Extract the response to a slash command from a post-inject pane
  * capture. We anchor on the LAST occurrence of Claude's prompt-echo
  * line for the command (`❯ <command>` — Ink renders the user's input
@@ -210,19 +299,12 @@ function sleep(ms: number): Promise<void> {
  * command-echo anchor is found in the post-capture, fall back to
  * line-set diff so unusual TUI shapes still surface something.
  */
-export function diffPane(before: string, after: string, command?: string): string {
+export function diffPane(before: string, after: string, command?: string): DiffPaneResult {
   if (command) {
-    // Build a regex that tolerates Ink's right-arrow input prefix and
-    // any leading whitespace; match exact command verb plus optional
-    // args (we already validated allowlist/blocklist upstream).
     const escaped = command.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
     const lines = after.split("\n");
     let anchorIdx = -1;
     for (let i = lines.length - 1; i >= 0; i--) {
-      // Match `❯ /command` or `> /command` (some terminals render it
-      // differently). Allow trailing args. Strict-anchor at end of
-      // line to avoid catching the prompt that contains the command
-      // as a substring inside narrative text.
       if (/[❯>]\s+/.test(lines[i]) && lines[i].includes(escaped)) {
         anchorIdx = i;
         break;
@@ -230,8 +312,6 @@ export function diffPane(before: string, after: string, command?: string): strin
     }
     if (anchorIdx >= 0) {
       const tail = lines.slice(anchorIdx + 1);
-      // Trim leading and trailing blank lines, and drop common
-      // modal-affordance footers that aren't part of the response.
       const trimmed: string[] = [];
       for (const raw of tail) {
         const line = raw.trimEnd();
@@ -241,14 +321,12 @@ export function diffPane(before: string, after: string, command?: string): strin
       while (trimmed.length > 0 && trimmed[trimmed.length - 1].length === 0) {
         trimmed.pop();
       }
-      // Drop trailing affordance lines (case-insensitive). These are
-      // Ink modal hints that aren't part of the slash output.
       const affordances = /^(esc to cancel|press any key|↵ select)/i;
       while (trimmed.length > 0 && affordances.test(trimmed[trimmed.length - 1].trim())) {
         trimmed.pop();
       }
       if (trimmed.length > 0) {
-        return trimmed.join("\n");
+        return { output: trimmed.join("\n"), anchored: true };
       }
       // Anchor found but tail is empty — fall through to set-diff.
     }
@@ -262,12 +340,14 @@ export function diffPane(before: string, after: string, command?: string): strin
     if (beforeSet.has(line)) continue;
     newLines.push(line);
   }
-  return newLines.join("\n");
+  return { output: newLines.join("\n"), anchored: false };
 }
 
 /**
- * Inject a slash command into an agent's tmux pane. Returns the diff
- * of new lines that appeared in the pane after the inject.
+ * Inject a slash command into an agent's tmux pane. Returns an
+ * `InjectResult` describing the outcome — never throws for runtime
+ * problems (session missing, send-keys failure). Validation errors
+ * still throw `InjectError` because they indicate a caller bug.
  *
  * Suitable execution states: agent prompt is idle (not mid-tool-call).
  * See FUTURE GAP comment at the top of this file.
@@ -297,6 +377,11 @@ export async function injectSlashCommand(
 /**
  * Test seam. Same logic as `injectSlashCommand` but takes a pre-built
  * `TmuxRunner` so unit tests can fake the tmux subprocess.
+ *
+ * Classification rules:
+ *   - validation/session/send-keys failure  → outcome=`failed`
+ *   - non-empty captured output             → outcome=`ok`
+ *   - empty output, send-keys completed     → outcome=`ok_no_output`
  */
 export async function injectSlashCommandWith(
   runner: TmuxRunner,
@@ -310,11 +395,39 @@ export async function injectSlashCommandWith(
 ): Promise<InjectResult> {
   const { socket, session, command, settleMs, timeoutMs } = args;
 
+  // Re-validate so the seam itself enforces the contract. The bare
+  // verb is what we'll surface in `result.command` / lookup metadata.
+  let bareVerb: string;
+  try {
+    bareVerb = validateInjectCommand(command);
+  } catch (err) {
+    if (err instanceof InjectError) {
+      return {
+        outcome: "failed",
+        output: "",
+        truncated: false,
+        command: command.trim().split(/\s+/, 1)[0]?.toLowerCase() ?? "",
+        meta: null,
+        errorCode: err.code,
+        errorMessage: err.message,
+      };
+    }
+    throw err;
+  }
+  const meta = INJECT_COMMANDS.get(bareVerb) ?? null;
+
   if (!runner.hasSession(socket, session)) {
-    throw new InjectError(
-      "session_missing",
-      `tmux session "${session}" on socket "${socket}" not found. Is the agent running with experimental.tmux_supervisor=true?`,
-    );
+    return {
+      outcome: "failed",
+      output: "",
+      truncated: false,
+      command: bareVerb,
+      meta,
+      errorCode: "session_missing",
+      errorMessage:
+        `tmux session "${session}" on socket "${socket}" not found. ` +
+        `Is the agent running with experimental.tmux_supervisor=true?`,
+    };
   }
 
   const before = runner.capture(socket, session) ?? "";
@@ -326,10 +439,15 @@ export async function injectSlashCommandWith(
     runner.send(socket, session, ["send-keys", "-l", command]);
     runner.send(socket, session, ["send-keys", "Enter"]);
   } catch (err) {
-    throw new InjectError(
-      "tmux_failed",
-      `tmux send-keys failed: ${err instanceof Error ? err.message : String(err)}`,
-    );
+    return {
+      outcome: "failed",
+      output: "",
+      truncated: false,
+      command: bareVerb,
+      meta,
+      errorCode: "tmux_failed",
+      errorMessage: `tmux send-keys failed: ${err instanceof Error ? err.message : String(err)}`,
+    };
   }
 
   // Poll capture-pane every POLL_INTERVAL_MS until two consecutive
@@ -346,8 +464,6 @@ export async function injectSlashCommandWith(
       if (stableSince === null) {
         stableSince = Date.now();
       } else if (Date.now() - stableSince >= POLL_INTERVAL_MS) {
-        // Two consecutive equal captures past the first stable mark —
-        // good enough.
         last = cur;
         break;
       }
@@ -356,25 +472,40 @@ export async function injectSlashCommandWith(
     }
     last = cur;
     if (Date.now() - start >= settleMs && cur !== before) {
-      // Past the settle window with at least one change — return what
-      // we have rather than burning to the hard timeout.
       break;
     }
   }
 
-  let output = diffPane(before, last, command);
+  const { output: rawOutput, anchored } = diffPane(before, last, command);
+  let output = rawOutput;
   let truncated = false;
   const bytes = Buffer.byteLength(output, "utf-8");
   if (bytes > OUTPUT_BYTE_CAP) {
-    // Trim from the front; the tail is more interesting (the result of
-    // the command, not the echoed prompt).
     while (Buffer.byteLength(output, "utf-8") > OUTPUT_BYTE_CAP) {
       output = output.slice(Math.floor(output.length * 0.1) + 1);
     }
     truncated = true;
   }
 
-  return { output, truncated };
+  if (output.trim().length === 0) {
+    return {
+      outcome: "ok_no_output",
+      output: "",
+      truncated: false,
+      command: bareVerb,
+      meta,
+      ...(anchored ? {} : { diagnostic: "anchor_missing" as const }),
+    };
+  }
+
+  return {
+    outcome: "ok",
+    output,
+    truncated,
+    command: bareVerb,
+    meta,
+    ...(truncated ? { diagnostic: "truncated_output" as const } : {}),
+  };
 }
 
 // Avoid unused-import warning when execFileAsync is reserved for

--- a/src/cli/agent.ts
+++ b/src/cli/agent.ts
@@ -1323,23 +1323,47 @@ export function registerAgentCommand(program: Command): void {
         }
         // Lazy import so the CLI doesn't pay for it on every invocation.
         const { injectSlashCommand, InjectError } = await import("../agents/inject.js");
+        // Exit-code contract:
+        //   0  — outcome=ok, OR outcome=ok_no_output (the inject did run).
+        //   1  — outcome=failed (validation, session missing, tmux error).
+        // Output routing:
+        //   ok                          → captured output to stdout.
+        //   ok_no_output (silentNote)   → "✓ <verb> — <silentNote>" to stdout.
+        //   ok_no_output (expects out)  → "⚠ <verb> — empty capture" to stderr.
+        //   ok_no_output (silent verb)  → bare "✓ <verb>" to stdout.
+        //   failed                      → error message to stderr, exit 1.
         try {
-          const { output, truncated } = await injectSlashCommand(name, slashCommand, {
+          const result = await injectSlashCommand(name, slashCommand, {
             timeoutMs: parseInt(opts.timeout, 10) || 5000,
             settleMs: parseInt(opts.settle, 10) || 2000,
           });
-          if (output.trim().length === 0) {
-            console.log(chalk.dim("(no new output captured)"));
-          } else {
-            console.log(output);
+          if (result.outcome === "ok") {
+            console.log(result.output);
+            if (result.truncated) {
+              console.log(chalk.yellow("\n... (output truncated to 3000 bytes)"));
+            }
+            return;
           }
-          if (truncated) {
-            console.log(chalk.yellow("\n... (output truncated to 3000 bytes)"));
+          if (result.outcome === "ok_no_output") {
+            const meta = result.meta;
+            if (meta?.silentNote) {
+              console.log(chalk.green(`✓ ${result.command} — ${meta.silentNote}`));
+            } else if (meta?.expectsOutput) {
+              console.error(chalk.yellow(`⚠ ${result.command} — empty capture`));
+            } else {
+              console.log(chalk.green(`✓ ${result.command}`));
+            }
+            return;
           }
+          // outcome === 'failed'
+          const code = result.errorCode ?? "tmux_failed";
+          const msg = result.errorMessage ?? "unknown error";
+          console.error(chalk.red(`inject failed (${code}): ${msg}`));
+          process.exit(1);
         } catch (err) {
           if (err instanceof InjectError) {
             console.error(chalk.red(`inject failed (${err.code}): ${err.message}`));
-            process.exit(2);
+            process.exit(1);
           }
           throw err;
         }

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -5947,7 +5947,9 @@ bot.command('inject', async ctx => {
   await handleInjectCommand(ctx, {
     isAuthorized: isAuthorizedSender,
     inject: injectSlashCommandImpl,
-    reply: switchroomReply,
+    // accent is already inlined into the body by the handler via
+    // buildAccentHeader; switchroomReply doesn't need to know about it.
+    reply: async (ctx, text, opts) => switchroomReply(ctx, text, { html: opts?.html }),
     getAgentName: getMyAgentName,
     getArgs: getCommandArgs,
     escapeHtml: escapeHtmlForTg,

--- a/telegram-plugin/gateway/inject-handler.test.ts
+++ b/telegram-plugin/gateway/inject-handler.test.ts
@@ -1,5 +1,5 @@
 /**
- * Unit tests for the /inject Telegram handler (#725 Phase 2).
+ * Unit tests for the /inject Telegram handler (#725 epic UX upgrade).
  *
  * The handler is factored out of gateway.ts so we can exercise it
  * without booting grammy/Bot. Real tmux is never touched — the inject
@@ -10,22 +10,32 @@
 
 import { describe, it, expect, vi } from 'vitest'
 import type { Context } from 'grammy'
-import { handleInjectCommand, type InjectDeps } from './inject-handler.js'
-import { InjectError } from '../../src/agents/inject.js'
+import { handleInjectCommand, type InjectDeps, type InjectAccent } from './inject-handler.js'
+import { InjectError, INJECT_COMMANDS, type InjectResult } from '../../src/agents/inject.js'
 
 function fakeCtx(): Context {
-  // Cast: we never read real fields off ctx; deps shim everything.
   return {} as unknown as Context
+}
+
+interface CapturedReply {
+  text: string
+  opts?: { html?: boolean; accent?: InjectAccent }
 }
 
 function makeDeps(overrides: Partial<InjectDeps> = {}): {
   deps: InjectDeps
-  replies: Array<{ text: string; opts?: { html?: boolean } }>
+  replies: CapturedReply[]
 } {
-  const replies: Array<{ text: string; opts?: { html?: boolean } }> = []
+  const replies: CapturedReply[] = []
   const deps: InjectDeps = {
     isAuthorized: () => true,
-    inject: vi.fn().mockResolvedValue({ output: 'mock', truncated: false }),
+    inject: vi.fn().mockResolvedValue({
+      outcome: 'ok',
+      output: 'mock',
+      truncated: false,
+      command: '/cost',
+      meta: INJECT_COMMANDS.get('/cost') ?? null,
+    } satisfies InjectResult),
     reply: async (_ctx, text, opts) => {
       replies.push({ text, opts })
     },
@@ -38,7 +48,44 @@ function makeDeps(overrides: Partial<InjectDeps> = {}): {
   return { deps, replies }
 }
 
-describe('handleInjectCommand', () => {
+function okResult(verb: string, output: string, truncated = false): InjectResult {
+  return {
+    outcome: 'ok',
+    output,
+    truncated,
+    command: verb,
+    meta: INJECT_COMMANDS.get(verb) ?? null,
+    ...(truncated ? { diagnostic: 'truncated_output' as const } : {}),
+  }
+}
+
+function noOutputResult(verb: string): InjectResult {
+  return {
+    outcome: 'ok_no_output',
+    output: '',
+    truncated: false,
+    command: verb,
+    meta: INJECT_COMMANDS.get(verb) ?? null,
+  }
+}
+
+function failedResult(
+  verb: string,
+  errorCode: NonNullable<InjectResult['errorCode']>,
+  errorMessage: string,
+): InjectResult {
+  return {
+    outcome: 'failed',
+    output: '',
+    truncated: false,
+    command: verb,
+    meta: INJECT_COMMANDS.get(verb) ?? null,
+    errorCode,
+    errorMessage,
+  }
+}
+
+describe('handleInjectCommand — guards', () => {
   it('drops messages from unauthorized senders without replying', async () => {
     const { deps, replies } = makeDeps({ isAuthorized: () => false })
     await handleInjectCommand(fakeCtx(), deps)
@@ -55,58 +102,120 @@ describe('handleInjectCommand', () => {
     expect(replies[0].text).toContain('Usage')
     expect(replies[0].text).toContain('/cost')
   })
+})
 
-  it('passes the slash-command verbatim to inject and renders output as <pre>', async () => {
-    const inject = vi.fn().mockResolvedValue({ output: 'Total cost: $0.42', truncated: false })
+describe('handleInjectCommand — outcome=ok', () => {
+  it('renders verb + pre-block, accent=done', async () => {
+    const inject = vi.fn().mockResolvedValue(okResult('/cost', 'Total cost: $0.42'))
     const { deps, replies } = makeDeps({ getArgs: () => '/cost', inject })
     await handleInjectCommand(fakeCtx(), deps)
-    expect(inject).toHaveBeenCalledWith('gymbro', '/cost')
     expect(replies).toHaveLength(1)
-    expect(replies[0].text).toBe('<pre>Total cost: $0.42</pre>')
-    expect(replies[0].opts).toEqual({ html: true })
+    expect(replies[0].opts?.accent).toBe('done')
+    expect(replies[0].text).toContain('✅')
+    expect(replies[0].text).toContain('<code>/cost</code>')
+    expect(replies[0].text).toContain('<pre>Total cost: $0.42</pre>')
+  })
+
+  it('appends <i>truncated</i> when output truncated', async () => {
+    const inject = vi.fn().mockResolvedValue(okResult('/cost', 'a lot of text', true))
+    const { deps, replies } = makeDeps({ getArgs: () => '/cost', inject })
+    await handleInjectCommand(fakeCtx(), deps)
+    expect(replies[0].text).toContain('<i>truncated</i>')
+    expect(replies[0].opts?.accent).toBe('done')
   })
 
   it('prepends slash if the operator omitted it', async () => {
-    const inject = vi.fn().mockResolvedValue({ output: 'ok', truncated: false })
+    const inject = vi.fn().mockResolvedValue(okResult('/cost', 'ok'))
     const { deps } = makeDeps({ getArgs: () => 'cost', inject })
     await handleInjectCommand(fakeCtx(), deps)
     expect(inject).toHaveBeenCalledWith('gymbro', '/cost')
   })
+})
 
-  it('replies with an empty-output notice when nothing new was captured', async () => {
-    const inject = vi.fn().mockResolvedValue({ output: '   \n  ', truncated: false })
-    const { deps, replies } = makeDeps({ getArgs: () => '/cost', inject })
+describe('handleInjectCommand — outcome=ok_no_output', () => {
+  it('uses silentNote when meta provides one (e.g. /compact)', async () => {
+    const inject = vi.fn().mockResolvedValue(noOutputResult('/compact'))
+    const { deps, replies } = makeDeps({ getArgs: () => '/compact', inject })
     await handleInjectCommand(fakeCtx(), deps)
-    expect(replies[0].text).toContain('no new output captured')
+    expect(replies[0].opts?.accent).toBe('done')
+    expect(replies[0].text).toContain('<code>/compact</code>')
+    expect(replies[0].text).toContain('compaction runs silently')
+    expect(replies[0].text).not.toContain('<pre>')
   })
 
-  it('appends a truncation suffix when the result is truncated', async () => {
-    const inject = vi.fn().mockResolvedValue({ output: 'a lot of text', truncated: true })
+  it('warns with accent=issue when expectsOutput=true and capture empty (/cost)', async () => {
+    const inject = vi.fn().mockResolvedValue(noOutputResult('/cost'))
     const { deps, replies } = makeDeps({ getArgs: () => '/cost', inject })
     await handleInjectCommand(fakeCtx(), deps)
-    expect(replies[0].text).toContain('output truncated')
+    expect(replies[0].opts?.accent).toBe('issue')
+    expect(replies[0].text).toContain('⚠️')
+    expect(replies[0].text).toContain('empty capture')
   })
 
-  it('surfaces InjectError code + message when validation fails (not_allowed)', async () => {
-    const inject = vi.fn().mockRejectedValue(new InjectError('not_allowed', '/foo not in allowlist'))
+  it('bare ack with accent=done when expectsOutput=false and no silentNote (/clear)', async () => {
+    const inject = vi.fn().mockResolvedValue(noOutputResult('/clear'))
+    const { deps, replies } = makeDeps({ getArgs: () => '/clear', inject })
+    await handleInjectCommand(fakeCtx(), deps)
+    expect(replies[0].opts?.accent).toBe('done')
+    expect(replies[0].text).toContain('<code>/clear</code>')
+    expect(replies[0].text).not.toContain('empty capture')
+    expect(replies[0].text).not.toContain('<pre>')
+  })
+})
+
+describe('handleInjectCommand — outcome=failed', () => {
+  it('not_allowed: lists allowed verbs, accent=issue', async () => {
+    const inject = vi
+      .fn()
+      .mockResolvedValue(failedResult('/foo', 'not_allowed', '/foo not in allowlist'))
     const { deps, replies } = makeDeps({ getArgs: () => '/foo', inject })
     await handleInjectCommand(fakeCtx(), deps)
-    expect(replies[0].text).toContain('inject failed')
-    expect(replies[0].text).toContain('not_allowed')
-    expect(replies[0].text).toContain('not in allowlist')
+    expect(replies[0].opts?.accent).toBe('issue')
+    expect(replies[0].text).toContain('not allowed')
+    expect(replies[0].text).toContain('/cost')
+    expect(replies[0].text).toContain('/clear')
   })
 
-  it('surfaces InjectError when the agent has no tmux session (session_missing)', async () => {
-    const inject = vi.fn().mockRejectedValue(new InjectError('session_missing', 'session "gymbro" not found'))
-    const { deps, replies } = makeDeps({ getArgs: () => '/cost', inject })
+  it('blocked: surfaces parenthetical reason', async () => {
+    const inject = vi
+      .fn()
+      .mockResolvedValue(
+        failedResult('/login', 'blocked', '/login is explicitly blocked from inject (would mutate auth state).'),
+      )
+    const { deps, replies } = makeDeps({ getArgs: () => '/login', inject })
     await handleInjectCommand(fakeCtx(), deps)
-    expect(replies[0].text).toContain('session_missing')
+    expect(replies[0].opts?.accent).toBe('issue')
+    expect(replies[0].text).toContain('<code>/login</code>')
+    expect(replies[0].text).toContain('blocked: would mutate auth state')
   })
 
-  it('falls back to a generic message for unknown errors', async () => {
-    const inject = vi.fn().mockRejectedValue(new Error('boom'))
+  it('session_missing: hints at experimental.tmux_supervisor', async () => {
+    const inject = vi
+      .fn()
+      .mockResolvedValue(failedResult('/cost', 'session_missing', 'session not found'))
     const { deps, replies } = makeDeps({ getArgs: () => '/cost', inject })
     await handleInjectCommand(fakeCtx(), deps)
-    expect(replies[0].text).toContain('boom')
+    expect(replies[0].opts?.accent).toBe('issue')
+    expect(replies[0].text).toContain('tmux session not found')
+    expect(replies[0].text).toContain('experimental.tmux_supervisor=true')
+  })
+
+  it('tmux_failed: surfaces escaped error message', async () => {
+    const inject = vi
+      .fn()
+      .mockResolvedValue(failedResult('/cost', 'tmux_failed', 'connection <refused>'))
+    const { deps, replies } = makeDeps({ getArgs: () => '/cost', inject })
+    await handleInjectCommand(fakeCtx(), deps)
+    expect(replies[0].opts?.accent).toBe('issue')
+    expect(replies[0].text).toContain('tmux send-keys failed')
+    expect(replies[0].text).toContain('connection &lt;refused&gt;')
+  })
+
+  it('thrown InjectError from inject() is normalized to outcome=failed', async () => {
+    const inject = vi.fn().mockRejectedValue(new InjectError('not_allowed', '/foo not allowed'))
+    const { deps, replies } = makeDeps({ getArgs: () => '/foo', inject })
+    await handleInjectCommand(fakeCtx(), deps)
+    expect(replies[0].opts?.accent).toBe('issue')
+    expect(replies[0].text).toContain('not allowed')
   })
 })

--- a/telegram-plugin/gateway/inject-handler.ts
+++ b/telegram-plugin/gateway/inject-handler.ts
@@ -4,20 +4,37 @@
  * Lives in its own module so the unit tests can import it without
  * triggering gateway.ts's top-level `new Bot(TOKEN)` initialisation.
  * gateway.ts wires this into bot.command('inject', ...).
+ *
+ * UX upgrade: the underlying inject primitive now returns a tagged
+ * `InjectResult` (outcome of `ok | ok_no_output | failed`). This
+ * handler switches on that outcome and shapes a single Telegram
+ * reply per the table in the epic spec — accent header from
+ * stream-reply-handler's `buildAccentHeader` + a short body.
  */
 
 import type { Context } from 'grammy'
 import {
-  InjectError,
-  INJECT_ALLOWLIST,
+  INJECT_COMMANDS,
   injectSlashCommand as defaultInject,
   type InjectResult,
 } from '../../src/agents/inject.js'
+import { buildAccentHeader } from '../stream-reply-handler.js'
+
+export type InjectAccent = 'done' | 'issue' | 'in-progress'
 
 export interface InjectDeps {
   isAuthorized: (ctx: Context) => boolean
   inject: (agent: string, command: string) => Promise<InjectResult>
-  reply: (ctx: Context, text: string, opts?: { html?: boolean }) => Promise<void>
+  /**
+   * Send a reply. The optional `accent` lifts the status header into
+   * the rendered HTML body via `buildAccentHeader`. The handler always
+   * sends `html: true` so callers can prepend the accent header.
+   */
+  reply: (
+    ctx: Context,
+    text: string,
+    opts?: { html?: boolean; accent?: InjectAccent },
+  ) => Promise<void>
   getAgentName: () => string
   /** Pull the slash-command body out of the message (defaults to ctx.match-style logic). */
   getArgs: (ctx: Context) => string
@@ -29,11 +46,98 @@ export interface InjectDeps {
   formatOutput?: (s: string) => string
 }
 
+/**
+ * Render the inject reply body. Accent header is prepended HERE so
+ * tests can assert exact final text — `deps.reply` is treated as a
+ * dumb sender. Returns { body, accent } for the caller to hand to
+ * `deps.reply`.
+ */
+function shapeReply(
+  result: InjectResult,
+  slashCommand: string,
+  deps: Pick<InjectDeps, 'escapeHtml' | 'preBlock' | 'formatOutput'>,
+): { body: string; accent: InjectAccent } {
+  const verbHtml = `<code>${deps.escapeHtml(result.command || slashCommand)}</code>`
+
+  if (result.outcome === 'ok') {
+    const formatted = deps.formatOutput ? deps.formatOutput(result.output) : result.output
+    let body = `${verbHtml}\n${deps.preBlock(formatted)}`
+    if (result.diagnostic === 'truncated_output' || result.truncated) {
+      body += '\n<i>truncated</i>'
+    }
+    return { body, accent: 'done' }
+  }
+
+  if (result.outcome === 'ok_no_output') {
+    const meta = result.meta
+    if (meta?.silentNote) {
+      return {
+        body: `${verbHtml} — ${deps.escapeHtml(meta.silentNote)}`,
+        accent: 'done',
+      }
+    }
+    if (meta?.expectsOutput) {
+      return {
+        body: `${verbHtml} — empty capture; agent may be busy or pane scrolled`,
+        accent: 'issue',
+      }
+    }
+    // expectsOutput=false, no silentNote — bare ack.
+    return { body: verbHtml, accent: 'done' }
+  }
+
+  // outcome === 'failed'
+  const code = result.errorCode ?? 'tmux_failed'
+  const msg = result.errorMessage ?? 'unknown error'
+  if (code === 'blocked') {
+    // errorMessage already mentions the reason; keep the body focused.
+    return {
+      body: `${verbHtml} — blocked: ${deps.escapeHtml(stripBlockedPrefix(msg))}`,
+      accent: 'issue',
+    }
+  }
+  if (code === 'not_allowed') {
+    const allowed = [...INJECT_COMMANDS.keys()].sort().join(' ')
+    return {
+      body: `${verbHtml} — not allowed. Try: ${deps.escapeHtml(allowed)}`,
+      accent: 'issue',
+    }
+  }
+  if (code === 'session_missing') {
+    return {
+      body: 'tmux session not found — agent needs <code>experimental.tmux_supervisor=true</code>',
+      accent: 'issue',
+    }
+  }
+  if (code === 'invalid') {
+    return {
+      body: 'usage: <code>/inject /&lt;command&gt;</code>',
+      accent: 'issue',
+    }
+  }
+  // tmux_failed / timeout / other
+  return {
+    body: `tmux send-keys failed: ${deps.escapeHtml(msg)}`,
+    accent: 'issue',
+  }
+}
+
+/**
+ * Strip the boilerplate "X is explicitly blocked from inject (" wrapper
+ * from a blocked-error message so the surfaced reason is just the
+ * parenthetical reason text. Defensive — falls through to the original
+ * message when the shape doesn't match.
+ */
+function stripBlockedPrefix(msg: string): string {
+  const m = /\(([^)]+)\)\.?$/.exec(msg)
+  return m ? m[1] : msg
+}
+
 export async function handleInjectCommand(ctx: Context, deps: InjectDeps): Promise<void> {
   if (!deps.isAuthorized(ctx)) return
   const arg = deps.getArgs(ctx).trim()
   if (!arg) {
-    const allow = [...INJECT_ALLOWLIST].sort().join(', ')
+    const allow = [...INJECT_COMMANDS.keys()].sort().join(', ')
     await deps.reply(
       ctx,
       `Usage: <code>/inject &lt;slashCommand&gt;</code>\nAllowed: <code>${deps.escapeHtml(allow)}</code>`,
@@ -43,32 +147,44 @@ export async function handleInjectCommand(ctx: Context, deps: InjectDeps): Promi
   }
   const slashCommand = arg.startsWith('/') ? arg : `/${arg}`
   const agentName = deps.getAgentName()
+
+  let result: InjectResult
   try {
-    const { output, truncated } = await deps.inject(agentName, slashCommand)
-    if (output.trim().length === 0) {
-      await deps.reply(
-        ctx,
-        `<i>(no new output captured for ${deps.escapeHtml(slashCommand)})</i>`,
-        { html: true },
-      )
-      return
-    }
-    const formatted = deps.formatOutput ? deps.formatOutput(output) : output
-    const body = deps.preBlock(formatted)
-    const suffix = truncated ? '\n<i>... (output truncated)</i>' : ''
-    await deps.reply(ctx, body + suffix, { html: true })
+    result = await deps.inject(agentName, slashCommand)
   } catch (err) {
-    if (err instanceof InjectError) {
-      await deps.reply(
-        ctx,
-        `<b>inject failed</b> (<code>${deps.escapeHtml(err.code)}</code>): ${deps.escapeHtml(err.message)}`,
-        { html: true },
-      )
-      return
+    // The default runner throws InjectError on validation failures (so
+    // CLI use that doesn't pre-validate still works). Surface as
+    // outcome=failed for shaping. Anything non-InjectError is an
+    // unexpected runtime — bubble a generic failure body.
+    const anyErr = err as { code?: string; message?: string; name?: string }
+    if (anyErr?.name === 'InjectError' && typeof anyErr.code === 'string') {
+      result = {
+        outcome: 'failed',
+        output: '',
+        truncated: false,
+        command: slashCommand.split(/\s+/, 1)[0]?.toLowerCase() ?? '',
+        meta: null,
+        errorCode: anyErr.code as InjectResult['errorCode'],
+        errorMessage: anyErr.message ?? 'inject failed',
+      }
+    } else {
+      result = {
+        outcome: 'failed',
+        output: '',
+        truncated: false,
+        command: slashCommand.split(/\s+/, 1)[0]?.toLowerCase() ?? '',
+        meta: null,
+        errorCode: 'tmux_failed',
+        errorMessage: err instanceof Error ? err.message : String(err),
+      }
     }
-    const msg = err instanceof Error ? err.message : String(err)
-    await deps.reply(ctx, `<b>inject failed:</b> ${deps.escapeHtml(msg)}`, { html: true })
   }
+
+  const { body, accent } = shapeReply(result, slashCommand, deps)
+  // Prepend accent header into the body so callers downstream of
+  // deps.reply (and tests) see a single, fully-rendered string.
+  const finalText = buildAccentHeader(accent) + body
+  await deps.reply(ctx, finalText, { html: true, accent })
 }
 
 export { defaultInject }


### PR DESCRIPTION
Reworks inject response messages per principles review.

## What changes

- **3 outcomes** (`ok | ok_no_output | failed`); granular reasons go to private `diagnostic` field for logs only
- **Allowlist metadata**: `INJECT_COMMANDS: ReadonlyMap<verb, {description, expectsOutput, silentNote?}>` replaces the old Set. Each verb annotated with whether it expects output and an optional silent-note for commands like `/clear` and `/compact`
- **Reuse Telegram accent system**: status renders via `buildAccentHeader` (same helper as the MCP `reply` path) — produces `✅ Done` / `⚠️ Issue` headers. No hand-rolled glyphs in the body.
- **Classification derived from runtime capture**, not from `expectsOutput`. The flag only feeds the warning when output is empty AND no `silentNote` AND `expectsOutput=true`.
- **CLI exit codes**: `0` for ok/ok_no_output, `1` for failed. Documented inline.

## Response shape table

| Outcome | accent | body |
|---|---|---|
| ok | done | `<code>/cost</code>\n<pre>{output}</pre>` |
| ok_no_output (silentNote) | done | `<code>/compact</code> — compaction runs silently` |
| ok_no_output (expectsOutput=true, no silentNote) | issue | `<code>/cost</code> — empty capture; agent may be busy or pane scrolled` |
| ok_no_output (expectsOutput=false, no silentNote) | done | `<code>/clear</code>` |
| failed (blocked) | issue | `<code>/login</code> — blocked: would mutate auth state` |
| failed (not_allowed) | issue | `<code>/foo</code> — not allowed. Try: …` |
| failed (session_missing/tmux_failed/timeout/invalid) | issue | terse honest one-liner |

## Process

Plan was reviewed against switchroom's vision/principles (REQUEST_CHANGES on padding); revised plan implemented; impl reviewed (APPROVE) by separate process. 2 LOW nits noted, none blocking.

## Tests

- `inject.test.ts`: outcome cases + diagnostic field cases + INJECT_COMMANDS metadata
- `inject-handler.test.ts`: 13 tests across the response-shape table
- `bun lint` clean. 161 targeted tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)