### PR TITLE
test(inject): per-allowlist + per-blocklist coverage (#725)

### DIFF
--- a/src/agents/inject.test.ts
+++ b/src/agents/inject.test.ts
@@ -17,6 +17,7 @@ import {
   injectSlashCommand,
   injectSlashCommandWith,
   validateInjectCommand,
+  type TmuxRunner,
 } from "./inject.js";
 
 describe("validateInjectCommand", () => {
@@ -295,18 +296,6 @@ describe("injectSlashCommand (default runner — validation only)", () => {
   });
 });
 
-import {
-  describe as descAllow,
-  it as itAllow,
-  expect as expectAllow,
-} from "vitest";
-import {
-  INJECT_BLOCKED,
-  INJECT_COMMANDS,
-  injectSlashCommandWith,
-  type TmuxRunner,
-} from "./inject";
-
 /**
  * Per-allowlist-entry coverage: every command in INJECT_COMMANDS must
  * round-trip through injectSlashCommandWith and produce the expected
@@ -339,50 +328,50 @@ function makeFakeRunner(paneAfter: string): TmuxRunner {
   return runner;
 }
 
-descAllow("INJECT_COMMANDS — per-entry classifier coverage (#725)", () => {
+describe("INJECT_COMMANDS — per-entry classifier coverage (#725)", () => {
   for (const [verb, meta] of INJECT_COMMANDS.entries()) {
-    itAllow(`${verb} (expectsOutput=${meta.expectsOutput}) classifies ok when capture has output`, async () => {
+    it(`${verb} (expectsOutput=${meta.expectsOutput}) classifies ok when capture has output`, async () => {
       const paneAfter = `❯ ${verb}\n  rendered output line 1\n  rendered output line 2\n`;
       const runner = makeFakeRunner(paneAfter);
       const r = await injectSlashCommandWith(runner, {
         socket: "test", session: "test", command: verb,
         settleMs: 50, timeoutMs: 200,
       });
-      expectAllow(r.outcome, `expected ok for ${verb}`).toBe("ok");
-      expectAllow(r.command).toBe(verb);
-      expectAllow(r.meta).not.toBeNull();
-      expectAllow(r.meta?.description).toBe(meta.description);
-      expectAllow(r.meta?.expectsOutput).toBe(meta.expectsOutput);
-      expectAllow(r.output.length, `output for ${verb}`).toBeGreaterThan(0);
+      expect(r.outcome, `expected ok for ${verb}`).toBe("ok");
+      expect(r.command).toBe(verb);
+      expect(r.meta).not.toBeNull();
+      expect(r.meta?.description).toBe(meta.description);
+      expect(r.meta?.expectsOutput).toBe(meta.expectsOutput);
+      expect(r.output.length, `output for ${verb}`).toBeGreaterThan(0);
     });
 
-    itAllow(`${verb} classifies ok_no_output when capture is empty`, async () => {
+    it(`${verb} classifies ok_no_output when capture is empty`, async () => {
       const runner = makeFakeRunner("");
       const r = await injectSlashCommandWith(runner, {
         socket: "test", session: "test", command: verb,
         settleMs: 50, timeoutMs: 200,
       });
-      expectAllow(r.outcome).toBe("ok_no_output");
-      expectAllow(r.command).toBe(verb);
+      expect(r.outcome).toBe("ok_no_output");
+      expect(r.command).toBe(verb);
       // silentNote propagates verbatim when the metadata declares one.
-      expectAllow(r.meta?.silentNote).toBe(meta.silentNote);
-      expectAllow(r.output).toBe("");
+      expect(r.meta?.silentNote).toBe(meta.silentNote);
+      expect(r.output).toBe("");
     });
   }
 });
 
-descAllow("INJECT_BLOCKED — per-entry coverage (#725)", () => {
+describe("INJECT_BLOCKED — per-entry coverage (#725)", () => {
   for (const [verb, meta] of INJECT_BLOCKED.entries()) {
-    itAllow(`${verb} returns failed:blocked with the configured reason`, async () => {
+    it(`${verb} returns failed:blocked with the configured reason`, async () => {
       const runner = makeFakeRunner("");
       const r = await injectSlashCommandWith(runner, {
         socket: "test", session: "test", command: verb,
         settleMs: 50, timeoutMs: 200,
       });
-      expectAllow(r.outcome).toBe("failed");
-      expectAllow(r.errorCode).toBe("blocked");
+      expect(r.outcome).toBe("failed");
+      expect(r.errorCode).toBe("blocked");
       // The user-facing error message should mention the configured reason.
-      expectAllow(r.errorMessage).toContain(meta.reason);
+      expect(r.errorMessage).toContain(meta.reason);
     });
   }
 });

--- a/src/agents/inject.test.ts
+++ b/src/agents/inject.test.ts
@@ -294,3 +294,95 @@ describe("injectSlashCommand (default runner — validation only)", () => {
     });
   });
 });
+
+import {
+  describe as descAllow,
+  it as itAllow,
+  expect as expectAllow,
+} from "vitest";
+import {
+  INJECT_BLOCKED,
+  INJECT_COMMANDS,
+  injectSlashCommandWith,
+  type TmuxRunner,
+} from "./inject";
+
+/**
+ * Per-allowlist-entry coverage: every command in INJECT_COMMANDS must
+ * round-trip through injectSlashCommandWith and produce the expected
+ * outcome shape, with the right metadata wired through. Catches drift
+ * between the metadata map and the classifier.
+ *
+ * Mirrors the response-shape contract per command:
+ *  - expectsOutput=true + we return realistic pane bytes → outcome=ok
+ *  - expectsOutput=true + we return empty pane → outcome=ok_no_output
+ *  - expectsOutput=false + we return empty pane → outcome=ok_no_output
+ *    (with silentNote propagating through meta when present)
+ */
+function makeFakeRunner(paneAfter: string): TmuxRunner {
+  const sent: string[][] = [];
+  let captures = 0;
+  const runner: TmuxRunner = {
+    capture: () => {
+      captures++;
+      // First capture (before send) returns empty; subsequent (after
+      // send) return the simulated post-inject pane.
+      return captures === 1 ? "" : paneAfter;
+    },
+    send: (_socket, _session, args) => {
+      sent.push(args);
+    },
+    hasSession: () => true,
+  };
+  // expose for assertions if needed
+  (runner as unknown as { __sent: string[][] }).__sent = sent;
+  return runner;
+}
+
+descAllow("INJECT_COMMANDS — per-entry classifier coverage (#725)", () => {
+  for (const [verb, meta] of INJECT_COMMANDS.entries()) {
+    itAllow(`${verb} (expectsOutput=${meta.expectsOutput}) classifies ok when capture has output`, async () => {
+      const paneAfter = `❯ ${verb}\n  rendered output line 1\n  rendered output line 2\n`;
+      const runner = makeFakeRunner(paneAfter);
+      const r = await injectSlashCommandWith(runner, {
+        socket: "test", session: "test", command: verb,
+        settleMs: 50, timeoutMs: 200,
+      });
+      expectAllow(r.outcome, `expected ok for ${verb}`).toBe("ok");
+      expectAllow(r.command).toBe(verb);
+      expectAllow(r.meta).not.toBeNull();
+      expectAllow(r.meta?.description).toBe(meta.description);
+      expectAllow(r.meta?.expectsOutput).toBe(meta.expectsOutput);
+      expectAllow(r.output.length, `output for ${verb}`).toBeGreaterThan(0);
+    });
+
+    itAllow(`${verb} classifies ok_no_output when capture is empty`, async () => {
+      const runner = makeFakeRunner("");
+      const r = await injectSlashCommandWith(runner, {
+        socket: "test", session: "test", command: verb,
+        settleMs: 50, timeoutMs: 200,
+      });
+      expectAllow(r.outcome).toBe("ok_no_output");
+      expectAllow(r.command).toBe(verb);
+      // silentNote propagates verbatim when the metadata declares one.
+      expectAllow(r.meta?.silentNote).toBe(meta.silentNote);
+      expectAllow(r.output).toBe("");
+    });
+  }
+});
+
+descAllow("INJECT_BLOCKED — per-entry coverage (#725)", () => {
+  for (const [verb, meta] of INJECT_BLOCKED.entries()) {
+    itAllow(`${verb} returns failed:blocked with the configured reason`, async () => {
+      const runner = makeFakeRunner("");
+      const r = await injectSlashCommandWith(runner, {
+        socket: "test", session: "test", command: verb,
+        settleMs: 50, timeoutMs: 200,
+      });
+      expectAllow(r.outcome).toBe("failed");
+      expectAllow(r.errorCode).toBe("blocked");
+      // The user-facing error message should mention the configured reason.
+      expectAllow(r.errorMessage).toContain(meta.reason);
+    });
+  }
+});


### PR DESCRIPTION
Parameterized tests assert every entry in INJECT_COMMANDS round-trips through injectSlashCommandWith with the right outcome shape:

- For each allowlist verb: classifies as 'ok' when capture has output (output non-empty); classifies as 'ok_no_output' when capture is empty (silentNote propagates from metadata when present).
- For each blocklist verb: returns failed/blocked with the configured reason in the user-facing message.

Catches drift between the metadata map and the classifier — will fail loudly if a future allowlist edit forgets to wire metadata correctly.

20 new tests (8 verbs × 2 ok-shape + 4 blocked × 1); 41 total inject tests green. `bun lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)