### PR TITLE
tmux supervisor: flip to default; rename flag to experimental.legacy_pty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 ## [Unreleased]
 
+### Changed
+
+- **tmux supervisor is now the default (#725 PR-1)** — `script -qfc`
+  PTY wrapping is replaced by per-agent `tmux new-session` for all
+  agents by default. The user-facing flag rename is
+  `experimental.tmux_supervisor` → `experimental.legacy_pty` (inverted
+  meaning). New default behaviour materialises on the next agent
+  restart (`switchroom systemd reconcile && switchroom agent
+  restart <name>`); units are not auto-restarted by the upgrade. tmux
+  is now a hard prereq (`install.sh` enforces); hosts without tmux
+  must opt agents into legacy via `experimental.legacy_pty: true`.
+  See `docs/tmux-supervisor-fanout.md` for the rollback runbook.
+- **`experimental.tmux_supervisor` deprecated** — still parseable for
+  one release with a one-time stderr warning. Migration is automatic:
+  `tmux_supervisor: false` → `legacy_pty: true`; `tmux_supervisor:
+  true` → omit (or `legacy_pty: false`). Compatibility shim will be
+  removed in the next minor release.
+- **`SWITCHROOM_TMUX_SUPERVISOR` env var unchanged** — the user-facing
+  flag was renamed but the gateway/boot-probes/boot-card env-var
+  contract is preserved. The gateway unit stamps `=1` in the default
+  (tmux) configuration; `legacy_pty: true` omits the var.
+
 ### Added
 
 - **tmux supervisor pre-fanout hardening (#725)** — PID resolver walks

--- a/docs/tmux-supervisor-fanout.md
+++ b/docs/tmux-supervisor-fanout.md
@@ -1,162 +1,78 @@
-# tmux supervisor fanout runbook (#725)
+# Rollback to legacy PTY supervisor (#725 PR-1)
 
-This is the operational playbook for flipping
-`experimental.tmux_supervisor: true` on a single agent at a time. It
-captures everything you need to know to canary the flag safely,
-including a known cosmetic gotcha that has already been patched but is
-worth understanding when reading older boot cards.
+As of #725 PR-1, the tmux supervisor is the default for all agents.
+This doc is the operational runbook for the rare case where you need
+to roll an individual agent back to the historical `script -qfc`
+PTY-wrapped supervisor — typically because:
 
-## What the flag does
+- The host doesn't have `tmux` installed or cannot run it.
+- A regression on the tmux path breaks a specific agent and you need a
+  same-day workaround while the fix lands.
+- You're A/B-comparing supervisor behaviour during stabilisation.
 
-Without the flag (legacy default), the agent's systemd unit launches:
+## How to opt out
 
-```
-ExecStart=/usr/bin/script -qfc "/bin/bash -l <agentDir>/start.sh" service.log
-```
+Add a single per-agent flag to `switchroom.yaml`:
 
-`script -qfc` allocates a PTY so `expect`-based autoaccept can drive
-the prompt, and pipes everything to `service.log`. It works, but the
-PTY layer detaches claude from the unit cgroup and `tmux send-keys`
-cannot reach the live REPL — so injecting Claude Code slash commands
-from outside the agent (`/cost`, `/status`, etc.) is impossible.
-
-With the flag, the unit becomes:
-
-```
-[Service]
-Type=forking
-Delegate=yes
-ExecStart=/usr/bin/tmux -L switchroom-<name> -f <agentDir>/tmux.conf \
-          new-session -A -d -s <name> -x 400 -y 50 \
-          'bash -l <agentDir>/start.sh'
-ExecStartPost=/usr/bin/tmux -L switchroom-<name> pipe-pane -o -t <name> \
-              'cat >> service.log'
-ExecStop=-/usr/bin/tmux -L switchroom-<name> kill-session -t <name>
+```yaml
+agents:
+  myagent:
+    profile: default
+    experimental:
+      legacy_pty: true   # opt OUT of the tmux supervisor (default false)
 ```
 
-Claude now runs inside a per-agent tmux session on a per-agent socket
-(`switchroom-<name>`). `pipe-pane` mirrors the pane to `service.log`
-so existing log consumers (pty-tail, journald followers) keep working.
-External slash-command injection works via `tmux send-keys`.
-
-## Per-agent ordering (recommended canary plan)
-
-Stage one agent per day. Confirm the previous flip is healthy before
-moving on. **Klanker last** — that's the agent the operator may be
-actively talking to and you don't want a flip-day surprise mid-thread.
-
-Recommended order (gymbro is already on it):
-
-1. clerk
-2. finn
-3. lawgpt
-4. ziggy
-5. carrie
-6. reggie
-7. klanker
-
-## Flip procedure for a single agent
+Then reconcile + restart that one agent:
 
 ```bash
-# 1. Edit switchroom.yaml — add the flag under the agent's entry:
-#    agents:
-#      <name>:
-#        experimental:
-#          tmux_supervisor: true
-
-# 2. Re-render the systemd unit + tmux.conf
-switchroom systemd install
-
-# 3. IMPORTANT — restart immediately after install. Between `install`
-#    and `restart` the unit on disk doesn't match the running process;
-#    leaving the gap open invites a config-mismatch incident.
-systemctl --user restart switchroom-<name>.service
+switchroom systemd reconcile myagent
+switchroom agent restart myagent
 ```
 
-The agent unit is now the tmux ExecStart; the gateway unit picks up
-`Environment=SWITCHROOM_TMUX_SUPERVISOR=1` so its boot card shows the
-real claude PID instead of the tmux server PID (cosmetic note below).
+The unit re-renders with the legacy `ExecStart=/usr/bin/script -qfc …`
+shape and `Type=simple`, and the gateway unit drops
+`Environment=SWITCHROOM_TMUX_SUPERVISOR=1`. Boot cards / probes /
+inject all degrade gracefully (inject is refused with a clear error
+pointing at the flag).
 
-## Sanity checks after flip
+## Behaviour differences under `legacy_pty: true`
+
+- `switchroom agent attach` runs `tail -f service.log` instead of
+  `tmux attach` — read-only log view, no live REPL.
+- `switchroom agent send` and the `/inject` Telegram command refuse
+  with a hint to remove the flag.
+- The unit's `KillMode=control-group` still cleans up correctly; the
+  cgroup-kill fix from #361 is independent of supervisor choice.
+- `service.log` contains the raw `script -qfc` output (bytes-on-the-
+  wire same as pre-#725).
+
+## Migrating from the deprecated `tmux_supervisor` key
+
+If you have legacy configs with `experimental.tmux_supervisor: true`
+or `experimental.tmux_supervisor: false`, the schema shim normalises
+them at parse time and emits a one-time stderr warning:
+
+| Old (`tmux_supervisor`) | New (`legacy_pty`) |
+|-------------------------|--------------------|
+| `true`                  | omit (default) or `false` |
+| `false`                 | `true`             |
+| (unset)                 | (unset, default)   |
+
+The compatibility shim will be removed in the next minor release —
+update configs at your convenience but don't leave it forever.
+
+## How to verify which supervisor an agent is on
 
 ```bash
-# Unit cgroup contains tmux + claude (and bash/expect wrappers)
-systemd-cgls --user-unit switchroom-<name>.service
-
-# tmux session is live on the per-agent socket
-tmux -L switchroom-<name> ls
-# expect: <name>: 1 windows (created ...) [400x50]
-
-# Boot card PID — should be a hundreds-of-MB claude pid, NOT the
-# tmux server (~2MB). If it shows as ~2MB, see "MainPID gotcha" below.
-systemctl --user show switchroom-<name>.service \
-  -p MainPID,MemoryCurrent,ControlGroup
+systemctl --user cat switchroom-<name>.service | grep ^ExecStart=
+# default:  ExecStart=/usr/bin/tmux -L switchroom-<name> ...
+# legacy:   ExecStart=/usr/bin/script -qfc ...
 ```
 
-You can also drop into the live REPL to confirm:
+Or check the unit type:
 
 ```bash
-switchroom agent attach <name>      # uses tmux attach when flag is on
-# Detach with C-b d (the default tmux prefix) — do NOT C-c.
+systemctl --user show switchroom-<name>.service -p Type
+# default:  Type=forking
+# legacy:   Type=simple
 ```
-
-## Rollback
-
-If anything looks wrong, flip the flag back:
-
-```bash
-# 1. Edit switchroom.yaml — remove (or set false) experimental.tmux_supervisor
-# 2. Re-render and restart in one go:
-switchroom systemd install
-systemctl --user restart switchroom-<name>.service
-```
-
-The legacy `script -qfc` ExecStart is restored; existing log/tail
-consumers continue to work because pipe-pane was writing to the same
-`service.log` path.
-
-## Migration interregnum — the dash on ExecStop
-
-The first restart that flips an agent from legacy → tmux runs
-`ExecStop` against the OLD unit which has no tmux socket. Without the
-leading `-` on `ExecStop=-/usr/bin/tmux ... kill-session`, that
-non-zero exit would mark the unit as `failed` and trigger
-`Restart=on-failure` chaos. The dash silences that one-shot transition;
-in steady state `kill-session` against a real session succeeds and the
-dash is a no-op.
-
-Implication: do NOT remove the dash on ExecStop in any future template
-edit. The systemd-restart test suite asserts the dash is present
-(`tests/systemd-restart.test.ts`).
-
-## MainPID gotcha (patched, but historical)
-
-Under `Type=forking`, systemd records `MainPID` as the leader of the
-forked process group — which is the tmux server (~2MB RSS), not
-claude (hundreds of MB). Surfaces that displayed `MainPID` directly
-showed the tmux PID with a misleading 2MB memory line.
-
-Fixed in this same PR: `getAgentStatus` and the gateway boot card
-probes (`probeAgentProcess`, `watchAgentProcess`) walk the unit's
-cgroup and pick the heaviest-RSS claude/node process when the flag is
-on. The cgroup walk mirrors `agent_main_pid()` in
-`bin/bridge-watchdog.sh:187-208`.
-
-If you see a boot card with a tiny memory number on a tmux-supervised
-agent, that's the un-patched display path and worth filing — every
-known surface should now resolve correctly.
-
-## Known-good signs
-
-- `systemd-cgls` shows tmux + bash + claude under the unit cgroup
-- `tmux -L switchroom-<name> ls` returns the session within ~2s of restart
-- Boot card shows `PID <claude-pid> · up <duration> · <hundreds-of-MB>`
-- `switchroom agent attach <name>` drops into the live REPL
-- `switchroom agent inject <name> /cost` reaches Claude Code (Phase 2)
-
-## Linked
-
-- Epic #725 — tmux supervisor
-- #728 — argv-ordering bug for `tmux send-keys` (caught after #727 merged)
-- This doc lives at `docs/tmux-supervisor-fanout.md`; the epic README
-  / CHANGELOG entry should link here.

--- a/install.sh
+++ b/install.sh
@@ -61,6 +61,13 @@ else
   ok "apt packages already present"
 fi
 
+# tmux is the default agent supervisor as of #725 PR-1 — a hard prereq.
+# Hosts that genuinely cannot run tmux can opt agents into the legacy
+# PTY supervisor per-agent via `experimental.legacy_pty: true` in
+# switchroom.yaml, but the binary itself is required for the default
+# install path and to keep the unit template renderable.
+have tmux || die "tmux is required (or set experimental.legacy_pty: true per agent)"
+
 # ---- bun ----
 
 if have bun; then

--- a/src/agents/inject.ts
+++ b/src/agents/inject.ts
@@ -426,7 +426,8 @@ export async function injectSlashCommandWith(
       errorCode: "session_missing",
       errorMessage:
         `tmux session "${session}" on socket "${socket}" not found. ` +
-        `Is the agent running with experimental.tmux_supervisor=true?`,
+        `Is the agent running under the tmux supervisor (the default)? ` +
+        `If experimental.legacy_pty=true is set, inject is unsupported.`,
     };
   }
 

--- a/src/agents/lifecycle.ts
+++ b/src/agents/lifecycle.ts
@@ -4,6 +4,7 @@ import { resolve, join } from "node:path";
 import { connect } from "node:net";
 import type { SwitchroomConfig } from "../config/schema.js";
 import { resolveStatePath } from "../config/paths.js";
+import { resolveAgentConfig } from "../config/merge.js";
 
 /**
  * Resolve the per-agent gateway clean-shutdown marker path.
@@ -391,7 +392,7 @@ export function getAgentStartSha(name: string): string | null {
  * status display purposes MainPID is "good enough" (claude is the same
  * process).
  *
- * Under `experimental.tmux_supervisor=true`, MainPID points at the
+ * Under the tmux supervisor (the default as of #725 PR-1), MainPID points at the
  * tmux server (~2MB RSS) which spawns claude inside a session — that's
  * misleading for an operator looking at "how much memory is the agent
  * using?". Walk the cgroup and pick the heaviest-RSS pid; that's
@@ -401,7 +402,7 @@ export function getAgentStartSha(name: string): string | null {
  * Falls back to MainPID if cgroup walk fails (boot window, cgroup v2
  * not at `/sys/fs/cgroup`, or no resolvable claude process yet).
  */
-export function resolveAgentPid(unitName: string, useTmux: boolean): number | null {
+export function resolveAgentPid(unitName: string, useTmux: boolean = true): number | null {
   const mainPidFromSystemd = (): number | null => {
     try {
       const out = execFileSync(
@@ -499,7 +500,7 @@ export function resolveAgentPid(unitName: string, useTmux: boolean): number | nu
   }
 }
 
-export function getAgentStatus(name: string, tmuxSupervisor = false): AgentStatus {
+export function getAgentStatus(name: string, tmuxSupervisor = true): AgentStatus {
   const service = serviceName(name);
 
   let active = "unknown";
@@ -565,14 +566,22 @@ export function getAllAgentStatuses(
 ): Record<string, AgentStatus> {
   const statuses: Record<string, AgentStatus> = {};
   for (const agentName of Object.keys(config.agents)) {
-    const tmuxSupervisor =
-      config.agents[agentName]?.experimental?.tmux_supervisor === true;
+    // Cascade through profile/defaults so the legacy_pty flag can be set
+    // at any layer. The Zod transform on `experimental` (schema.ts) has
+    // already normalised any deprecated `tmux_supervisor` keys into
+    // `legacy_pty`, so this is the single read site.
+    const resolved = resolveAgentConfig(
+      config.defaults,
+      config.profiles,
+      config.agents[agentName],
+    );
+    const tmuxSupervisor = resolved.experimental?.legacy_pty !== true;
     statuses[agentName] = getAgentStatus(agentName, tmuxSupervisor);
   }
   return statuses;
 }
 
-export function attachAgent(name: string, tmuxSupervisor = false): void {
+export function attachAgent(name: string, tmuxSupervisor = true): void {
   const agentsDir = process.env.SWITCHROOM_AGENTS_DIR ?? resolveStatePath("agents");
 
   // #725 Phase 1 — when the agent opted into the tmux supervisor, attach

--- a/src/agents/systemd.ts
+++ b/src/agents/systemd.ts
@@ -36,29 +36,30 @@ export function generateUnit(
   useAutoaccept = false,
   gatewayUnitName?: string,
   timezone?: string,
-  tmuxSupervisor = false,
+  legacyPty = false,
 ): string {
   const logFile = resolve(agentDir, "service.log");
   const autoacceptExp = resolve(import.meta.dirname, "../../bin/autoaccept.exp");
   const tmuxConfPath = resolve(agentDir, "tmux.conf");
   const tmuxSocket = `switchroom-${name}`;
 
-  // Phase 1 of #725 — opt-in tmux supervisor. The legacy `script -qfc`
-  // path stays the default; only agents with experimental.tmux_supervisor=true
-  // get the new ExecStart shape. See docs in #725 epic.
+  // #725 PR-1 — tmux supervisor is the default. Agents opt OUT via
+  // `experimental.legacy_pty: true` to fall back to the historical
+  // `script -qfc` PTY wrapper (kept for hosts without tmux, or as a
+  // rollback knob during stabilisation). See docs/tmux-supervisor-fanout.md.
   //
   // Type=forking + Delegate=yes is the systemd contract for tmux:
   // `tmux new-session -d` daemonises (forks) and we want systemd to leave
   // the cgroup alone so tmux can manage its own children. KillMode stays
   // `control-group` so a `systemctl stop` cgroup-kills the whole tree
-  // (matches today's behaviour with the script wrapper).
+  // (matches the legacy script-wrapper behaviour).
   let execStart: string;
   let extraStartPost = "";
   let extraStop = "";
   let serviceType = "simple";
   let delegateLine = "";
 
-  if (tmuxSupervisor) {
+  if (!legacyPty) {
     serviceType = "forking";
     delegateLine = "Delegate=yes\n";
     const inner = useAutoaccept
@@ -307,7 +308,13 @@ function hasNodeOnPath(): boolean {
   }
 }
 
-export function generateGatewayUnit(stateDir: string, agentName: string, adminEnabled = false, tmuxSupervisor = false): string {
+// #725 PR-1 asymmetry: the user-facing flag rename is `tmux_supervisor` →
+// `legacy_pty` (inverted), but the env var name `SWITCHROOM_TMUX_SUPERVISOR`
+// is INTENTIONALLY unchanged. The gateway / boot-probes / boot-card all
+// read that env var to know whether the agent is tmux-driven; renaming
+// would require a synchronized cross-package change. Stamping `=1` when
+// NOT legacy keeps the existing readers correct without code edits.
+export function generateGatewayUnit(stateDir: string, agentName: string, adminEnabled = false, legacyPty = false): string {
   const pluginDir = resolve(import.meta.dirname, "../../telegram-plugin");
   // Prefer the bundled `dist/gateway/gateway.js` (#634 strategic
   // packaging fix) — it has all `src/` cross-imports inlined, so a
@@ -369,7 +376,7 @@ Environment=PATH=${unitPath}
 Environment=SWITCHROOM_CLI_PATH=${switchroomCli}
 Environment=TELEGRAM_STATE_DIR=${stateDir}
 Environment=SWITCHROOM_AGENT_NAME=${agentName}
-${adminEnabled ? `Environment=SWITCHROOM_AGENT_ADMIN=true\n` : ''}${tmuxSupervisor ? `Environment=SWITCHROOM_TMUX_SUPERVISOR=1\n` : ''}
+${adminEnabled ? `Environment=SWITCHROOM_AGENT_ADMIN=true\n` : ''}${!legacyPty ? `Environment=SWITCHROOM_TMUX_SUPERVISOR=1\n` : ''}
 [Install]
 WantedBy=default.target
 `;
@@ -555,17 +562,18 @@ export function installAllUnits(config: SwitchroomConfig): void {
     // `defaults.timezone` being set once for the fleet.
     const resolved = resolveAgentConfig(config.defaults, config.profiles, agent);
     const timezone = resolveTimezone(config, resolved);
-    const tmuxSupervisor = resolved.experimental?.tmux_supervisor === true;
+    const legacyPty = resolved.experimental?.legacy_pty === true;
 
-    // When opted in to the tmux supervisor (#725 Phase 1), drop a managed
-    // tmux.conf alongside start.sh. tmux 3.x ignores `-e TERM=…` for the
-    // pane's TERM under default-terminal selection — pinning it in conf
-    // is the only reliable way to get xterm-256color into the agent shell.
-    if (tmuxSupervisor) {
+    // tmux is the default supervisor (#725 PR-1) — drop a managed tmux.conf
+    // alongside start.sh unless this agent has opted out via legacy_pty.
+    // tmux 3.x ignores `-e TERM=…` for the pane's TERM under default-terminal
+    // selection — pinning it in conf is the only reliable way to get
+    // xterm-256color into the agent shell.
+    if (!legacyPty) {
       writeAgentTmuxConf(agentDir);
     }
 
-    const content = generateUnit(agentName, agentDir, useAutoaccept, gwName, timezone, tmuxSupervisor);
+    const content = generateUnit(agentName, agentDir, useAutoaccept, gwName, timezone, legacyPty);
     installUnit(agentName, content);
     installedAgents.push(unitName(agentName));
 
@@ -575,7 +583,7 @@ export function installAllUnits(config: SwitchroomConfig): void {
       // when the agent is configured with admin:true. The gateway reads this env
       // var to decide whether to intercept slash commands before forwarding to Claude.
       const adminEnabled = resolveAgentConfig(config.defaults, config.profiles, agent).admin === true;
-      const gatewayContent = generateGatewayUnit(stateDir, agentName, adminEnabled, tmuxSupervisor);
+      const gatewayContent = generateGatewayUnit(stateDir, agentName, adminEnabled, legacyPty);
       installUnit(gwName, gatewayContent);
       installedAgents.push(unitName(gwName));
     }

--- a/src/cli/agent.ts
+++ b/src/cli/agent.ts
@@ -1285,11 +1285,13 @@ export function registerAgentCommand(program: Command): void {
           process.exit(1);
         }
 
-        // #725 Phase 1 — opt-in tmux supervisor changes attach from
-        // `tail -f service.log` to `tmux attach`. Read the resolved
-        // (cascade-merged) config so the flag can be set at any layer.
+        // #725 PR-1 — tmux is the default supervisor; attach drops into
+        // the live REPL via `tmux attach`. Agents that opt out via
+        // `experimental.legacy_pty: true` fall back to `tail -f
+        // service.log`. Read the resolved (cascade-merged) config so
+        // the flag can be set at any layer.
         const resolved = resolveAgentConfig(config.defaults, config.profiles, config.agents[name]);
-        const tmuxSupervisor = resolved.experimental?.tmux_supervisor === true;
+        const tmuxSupervisor = resolved.experimental?.legacy_pty !== true;
 
         // attachAgent must exec (replace process), so this won't return on success
         attachAgent(name, tmuxSupervisor);
@@ -1301,7 +1303,7 @@ export function registerAgentCommand(program: Command): void {
   // tmux pane and print the captured output. Allowlist-only (see inject.ts).
   agent
     .command("send <name> <slashCommand>")
-    .description("Inject a Claude Code slash command into the agent's tmux pane (requires experimental.tmux_supervisor)")
+    .description("Inject a Claude Code slash command into the agent's tmux pane (refused if experimental.legacy_pty=true)")
     .option("--timeout <ms>", "Hard timeout in milliseconds (default 5000)", "5000")
     .option("--settle <ms>", "Pane-settle window in milliseconds (default 2000)", "2000")
     .action(
@@ -1312,11 +1314,11 @@ export function registerAgentCommand(program: Command): void {
           process.exit(1);
         }
         const resolved = resolveAgentConfig(config.defaults, config.profiles, config.agents[name]);
-        if (resolved.experimental?.tmux_supervisor !== true) {
+        if (resolved.experimental?.legacy_pty === true) {
           console.error(
             chalk.red(
-              `Agent "${name}" is not running under the tmux supervisor.\n` +
-                `Set experimental.tmux_supervisor: true in switchroom.yaml and reconcile/restart the agent.`,
+              `Agent "${name}" is running under the legacy PTY supervisor (experimental.legacy_pty=true).\n` +
+                `inject requires the tmux supervisor (the default). Remove the legacy_pty flag and reconcile/restart the agent.`,
             ),
           );
           process.exit(1);

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -693,6 +693,95 @@ export const ChannelsSchema = z
  */
 const TIMEZONE_REGEX = /^UTC$|^[A-Z][A-Za-z0-9_+-]+(\/[A-Z][A-Za-z0-9_+-]+){1,2}$/;
 
+// One-shot deprecation warning for legacy `experimental.tmux_supervisor`.
+// Module-level boolean so a noisy fleet config doesn't spam stderr per agent.
+let _tmuxSupervisorDeprecationWarned = false;
+
+/**
+ * `experimental.*` per-agent feature flags. As of #725 PR-1 the tmux
+ * supervisor is the default; this schema preserves the legacy
+ * `tmux_supervisor` key for one release for backward compatibility and
+ * normalises everything to a single forward-looking `legacy_pty` boolean
+ * via a Zod transform. Downstream consumers should read `legacy_pty`
+ * only — `tmux_supervisor` is deleted from the parsed output.
+ *
+ * Migration semantics (transform):
+ *   - `legacy_pty` set                       → use it as-is, drop tmux_supervisor.
+ *   - `tmux_supervisor: false` (and no legacy_pty)
+ *                                            → `legacy_pty = true`  (one-time warn).
+ *   - `tmux_supervisor: true`  (and no legacy_pty)
+ *                                            → `legacy_pty = false` (one-time warn).
+ *   - neither set                            → `legacy_pty = false` (default).
+ */
+export const ExperimentalSchema = z
+  .object({
+    legacy_pty: z
+      .boolean()
+      .optional()
+      .describe(
+        "Opt out of the default tmux supervisor; kept for hosts without " +
+        "tmux available, or as a rollback knob during stabilisation. " +
+        "When true, the systemd unit reverts to the legacy `script -qfc` " +
+        "PTY wrapper. Default false — tmux is the production default as " +
+        "of #725 PR-1.",
+      ),
+    tmux_supervisor: z
+      .boolean()
+      .optional()
+      .describe(
+        "DEPRECATED. Use `legacy_pty` (inverted) instead. Kept parseable " +
+        "for one release so existing configs don't break. " +
+        "`tmux_supervisor: false` migrates to `legacy_pty: true`; " +
+        "`tmux_supervisor: true` migrates to `legacy_pty: false`. A " +
+        "one-time deprecation warning is emitted to stderr per process.",
+      ),
+  })
+  .optional()
+  .transform((val) => {
+    if (val === undefined) return undefined;
+    const { legacy_pty, tmux_supervisor, ...rest } = val;
+    let resolvedLegacy: boolean;
+    if (legacy_pty !== undefined) {
+      resolvedLegacy = legacy_pty;
+    } else if (tmux_supervisor === false) {
+      if (!_tmuxSupervisorDeprecationWarned) {
+        _tmuxSupervisorDeprecationWarned = true;
+        console.warn(
+          "[switchroom] DEPRECATED: experimental.tmux_supervisor is " +
+          "replaced by experimental.legacy_pty (inverted). " +
+          "`tmux_supervisor: false` → set `legacy_pty: true` instead. " +
+          "Compatibility shim will be removed next release.",
+        );
+      }
+      resolvedLegacy = true;
+    } else if (tmux_supervisor === true) {
+      if (!_tmuxSupervisorDeprecationWarned) {
+        _tmuxSupervisorDeprecationWarned = true;
+        console.warn(
+          "[switchroom] DEPRECATED: experimental.tmux_supervisor is " +
+          "now the default; remove the flag. " +
+          "`tmux_supervisor: true` → omit (or set `legacy_pty: false`). " +
+          "Compatibility shim will be removed next release.",
+        );
+      }
+      resolvedLegacy = false;
+    } else {
+      resolvedLegacy = false;
+    }
+    return { ...rest, legacy_pty: resolvedLegacy };
+  })
+  .describe(
+    "Per-agent feature flags for unstable / canary behaviour. Each " +
+    "field is a boolean opt-in; the default for every flag is the " +
+    "current production behaviour. Flags graduate out of `experimental` " +
+    "once they're known-stable across the fleet.",
+  );
+
+/** Test-only — reset the one-shot deprecation warning gate. */
+export function _resetTmuxSupervisorDeprecationGate(): void {
+  _tmuxSupervisorDeprecationWarned = false;
+}
+
 const profileFields = {
   extends: z.string().optional(),
   bot_token: z.string().optional(),
@@ -1170,28 +1259,7 @@ export const AgentSchema = z.object({
       "claim_worktree accepts the alias as the repo argument. " +
       "Absolute paths may always be passed regardless of this list.",
     ),
-  experimental: z
-    .object({
-      tmux_supervisor: z
-        .boolean()
-        .optional()
-        .describe(
-          "Phase 1 of issue #725. When true, the systemd unit launches the " +
-          "agent inside a per-agent tmux session (Type=forking, " +
-          "Delegate=yes) instead of wrapping start.sh in `script -qfc`. " +
-          "Enables `switchroom agent attach` to drop into the live REPL " +
-          "and (in later phases) external slash-command injection via " +
-          "`tmux send-keys`. Default false — opt in per agent so we can " +
-          "canary on a single agent before fleet rollout.",
-        ),
-    })
-    .optional()
-    .describe(
-      "Per-agent feature flags for unstable / canary behaviour. Each " +
-      "field is a boolean opt-in; the default for every flag is the " +
-      "current production behaviour. Flags graduate out of `experimental` " +
-      "once they're known-stable across the fleet.",
-    ),
+  experimental: ExperimentalSchema,
   repos: z
     .record(
       z.string().regex(

--- a/telegram-plugin/gateway/inject-handler.test.ts
+++ b/telegram-plugin/gateway/inject-handler.test.ts
@@ -189,7 +189,7 @@ describe('handleInjectCommand — outcome=failed', () => {
     expect(replies[0].text).toContain('blocked: would mutate auth state')
   })
 
-  it('session_missing: hints at experimental.tmux_supervisor', async () => {
+  it('session_missing: hints at experimental.legacy_pty', async () => {
     const inject = vi
       .fn()
       .mockResolvedValue(failedResult('/cost', 'session_missing', 'session not found'))
@@ -197,7 +197,7 @@ describe('handleInjectCommand — outcome=failed', () => {
     await handleInjectCommand(fakeCtx(), deps)
     expect(replies[0].opts?.accent).toBe('issue')
     expect(replies[0].text).toContain('tmux session not found')
-    expect(replies[0].text).toContain('experimental.tmux_supervisor=true')
+    expect(replies[0].text).toContain('experimental.legacy_pty')
   })
 
   it('tmux_failed: surfaces escaped error message', async () => {

--- a/telegram-plugin/gateway/inject-handler.ts
+++ b/telegram-plugin/gateway/inject-handler.ts
@@ -105,7 +105,7 @@ function shapeReply(
   }
   if (code === 'session_missing') {
     return {
-      body: 'tmux session not found — agent needs <code>experimental.tmux_supervisor=true</code>',
+      body: 'tmux session not found — agent must be running under the tmux supervisor (the default). Remove <code>experimental.legacy_pty: true</code> if set.',
       accent: 'issue',
     }
   }

--- a/telegram-plugin/welcome-text.ts
+++ b/telegram-plugin/welcome-text.ts
@@ -261,7 +261,8 @@ export const TELEGRAM_MENU_COMMANDS = [
   { command: "logs", description: "Show recent agent logs" },
   // #725 Phase 2 — inject a Claude Code REPL slash command into the agent's
   // tmux pane (allowlisted: /cost, /status, /model, /clear, /compact,
-  // /memory, /hooks). Requires experimental.tmux_supervisor on the agent.
+  // /memory, /hooks). Requires the tmux supervisor (the default — refused
+  // when the agent has experimental.legacy_pty=true).
   { command: "inject", description: "Inject a Claude Code slash command (e.g. /cost)" },
   { command: "doctor", description: "Health check (deps, services, MCP)" },
   { command: "usage", description: "Pro/Max plan quota (5h + 7d windows)" },

--- a/tests/experimental-schema.test.ts
+++ b/tests/experimental-schema.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Schema-level deprecation + normalisation tests for
+ * `experimental.tmux_supervisor` → `experimental.legacy_pty` (#725 PR-1).
+ *
+ * The Zod transform on ExperimentalSchema fires at parse time and
+ * normalises every shape downstream code reads. This suite locks in:
+ *   1. Forward shape: `legacy_pty` set is preserved as-is.
+ *   2. Backward compat: deprecated `tmux_supervisor` migrates correctly.
+ *   3. Deprecation warning fires exactly once per process (gate works).
+ *   4. Default shape: `legacy_pty` defaults to `false` (tmux supervisor).
+ *   5. Forward-only field: `tmux_supervisor` is removed from the parsed
+ *      output so accidental new readers hard-fail at the type level.
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import {
+  ExperimentalSchema,
+  _resetTmuxSupervisorDeprecationGate,
+} from "../src/config/schema.js";
+
+beforeEach(() => {
+  _resetTmuxSupervisorDeprecationGate();
+});
+
+describe("ExperimentalSchema — Zod transform (#725 PR-1)", () => {
+  it("undefined input passes through as undefined (no-op)", () => {
+    const out = ExperimentalSchema.parse(undefined);
+    expect(out).toBeUndefined();
+  });
+
+  it("empty object → legacy_pty: false (tmux is the default)", () => {
+    const out = ExperimentalSchema.parse({});
+    expect(out).toEqual({ legacy_pty: false });
+  });
+
+  it("legacy_pty: true is preserved as-is", () => {
+    const out = ExperimentalSchema.parse({ legacy_pty: true });
+    expect(out).toEqual({ legacy_pty: true });
+  });
+
+  it("legacy_pty: false is preserved as-is", () => {
+    const out = ExperimentalSchema.parse({ legacy_pty: false });
+    expect(out).toEqual({ legacy_pty: false });
+  });
+
+  it("deprecated tmux_supervisor: true → legacy_pty: false (and warns)", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const out = ExperimentalSchema.parse({ tmux_supervisor: true });
+    expect(out).toEqual({ legacy_pty: false });
+    expect(warn).toHaveBeenCalledOnce();
+    expect(warn.mock.calls[0][0]).toContain("DEPRECATED");
+    warn.mockRestore();
+  });
+
+  it("deprecated tmux_supervisor: false → legacy_pty: true (and warns)", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const out = ExperimentalSchema.parse({ tmux_supervisor: false });
+    expect(out).toEqual({ legacy_pty: true });
+    expect(warn).toHaveBeenCalledOnce();
+    warn.mockRestore();
+  });
+
+  it("legacy_pty wins when both are set (no warning needed)", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const out = ExperimentalSchema.parse({
+      tmux_supervisor: true,
+      legacy_pty: true,
+    });
+    expect(out).toEqual({ legacy_pty: true });
+    // legacy_pty branch in the transform never warns — the user has
+    // already migrated; the deprecated key is just leftover noise.
+    expect(warn).not.toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it("deprecation warning fires only once per process across multiple parses", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    ExperimentalSchema.parse({ tmux_supervisor: true });
+    ExperimentalSchema.parse({ tmux_supervisor: false });
+    ExperimentalSchema.parse({ tmux_supervisor: true });
+    expect(warn).toHaveBeenCalledOnce();
+    warn.mockRestore();
+  });
+
+  it("parsed output never contains tmux_supervisor (key is dropped)", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const out = ExperimentalSchema.parse({ tmux_supervisor: true });
+    expect(out).not.toHaveProperty("tmux_supervisor");
+    warn.mockRestore();
+  });
+});

--- a/tests/fanout-migration.test.ts
+++ b/tests/fanout-migration.test.ts
@@ -1,13 +1,13 @@
 /**
- * Fanout migration test (#725 pre-fanout hardening).
+ * Default-flip migration test (#725 PR-1).
  *
- * Verifies the legacy → tmux-supervisor unit transition produces the
- * expected ExecStart + ExecStop string shapes. Pure unit test — no
- * real systemctl. Captures the migration sequence we expect during
- * fleet rollout: legacy ExecStart switches to tmux ExecStart, and the
- * new ExecStop carries a leading dash so the FIRST restart (which
- * stops the OLD script-wrapped process that has no tmux socket) does
- * not log FAILURE.
+ * As of PR-1 the tmux supervisor is the production default — agents that
+ * previously had `experimental.tmux_supervisor: true` no longer need to
+ * declare anything, and agents on hosts without tmux opt out via
+ * `experimental.legacy_pty: true`.
+ *
+ * Verifies the default ExecStart shape is tmux, and that legacy_pty=true
+ * still yields the historical `script -qfc` shape (rollback path).
  */
 
 import { describe, it, expect } from "vitest";
@@ -26,59 +26,55 @@ function execStop(unit: string): string {
   return line ?? "";
 }
 
-describe("fanout migration: legacy → tmux supervisor", () => {
-  it("legacy unit uses script -qfc and has no ExecStop line", () => {
-    const legacy = generateUnit("clerk", "/tmp/clerk", false, undefined, undefined, false);
-    const start = execStart(legacy);
-    expect(start).toContain("/usr/bin/script -qfc");
-    expect(start).toContain("/bin/bash -l /tmp/clerk/start.sh");
-    // Legacy units have no explicit ExecStop — systemd's default
-    // KillMode=control-group handles termination.
-    expect(execStop(legacy)).toBe("");
-  });
-
-  it("tmux unit uses tmux new-session and has dashed ExecStop", () => {
-    const tmuxUnit = generateUnit("clerk", "/tmp/clerk", false, undefined, undefined, true);
-    const start = execStart(tmuxUnit);
+describe("default-flip: tmux supervisor is the default", () => {
+  it("default unit (no flag) uses tmux new-session and dashed ExecStop", () => {
+    const def = generateUnit("clerk", "/tmp/clerk");
+    const start = execStart(def);
     expect(start).toContain("/usr/bin/tmux -L switchroom-clerk");
     expect(start).toContain("new-session -A -d -s clerk");
     expect(start).not.toContain("/usr/bin/script -qfc");
 
     // CRITICAL — leading dash on ExecStop. Without it, the first
-    // migration restart logs FAILURE because the OLD unit (still
-    // running script -qfc) has no tmux socket; kill-session exits
-    // non-zero and systemd marks the unit failed even though
-    // everything worked. The dash silences that one-shot transition.
-    const stop = execStop(tmuxUnit);
+    // migration restart (where the OLD running unit is still
+    // script -qfc) would log FAILURE because kill-session against a
+    // missing socket exits non-zero. The dash silences that one-shot.
+    const stop = execStop(def);
     expect(stop).toContain("ExecStop=-/usr/bin/tmux");
     expect(stop).toContain("kill-session -t clerk");
   });
 
-  it("autoaccept legacy → tmux: ExecStart wraps autoaccept.exp under both shapes", () => {
-    const legacy = generateUnit("clerk", "/tmp/clerk", true, "clerk-gateway", undefined, false);
-    const tmuxUnit = generateUnit("clerk", "/tmp/clerk", true, "clerk-gateway", undefined, true);
+  it("legacy_pty=true unit uses script -qfc and has no ExecStop line", () => {
+    const legacy = generateUnit("clerk", "/tmp/clerk", false, undefined, undefined, true);
+    const start = execStart(legacy);
+    expect(start).toContain("/usr/bin/script -qfc");
+    expect(start).toContain("/bin/bash -l /tmp/clerk/start.sh");
+    expect(execStop(legacy)).toBe("");
+  });
+
+  it("autoaccept default → legacy: ExecStart wraps autoaccept.exp under both shapes", () => {
+    const def = generateUnit("clerk", "/tmp/clerk", true, "clerk-gateway");
+    const legacy = generateUnit("clerk", "/tmp/clerk", true, "clerk-gateway", undefined, true);
+    expect(execStart(def)).toContain("autoaccept.exp");
+    expect(execStart(def)).toContain("/usr/bin/tmux -L switchroom-clerk");
     expect(execStart(legacy)).toContain("autoaccept.exp");
     expect(execStart(legacy)).toContain("/usr/bin/script -qfc");
-    expect(execStart(tmuxUnit)).toContain("autoaccept.exp");
-    expect(execStart(tmuxUnit)).toContain("/usr/bin/tmux -L switchroom-clerk");
   });
 
-  it("gateway unit picks up SWITCHROOM_TMUX_SUPERVISOR=1 only when flag is true", () => {
-    const off = generateGatewayUnit("/tmp/x/telegram", "x", false, false);
-    const on = generateGatewayUnit("/tmp/x/telegram", "x", false, true);
-    expect(off).not.toContain("SWITCHROOM_TMUX_SUPERVISOR");
-    expect(on).toContain("Environment=SWITCHROOM_TMUX_SUPERVISOR=1");
-    // Gateway ExecStart shape doesn't change between the two — only
-    // the env block — so re-installing the gateway on flip is a
-    // no-op for the long-poll connection.
-    expect(execStart(off)).toBe(execStart(on));
+  it("gateway unit stamps SWITCHROOM_TMUX_SUPERVISOR=1 by default; omits under legacy_pty", () => {
+    const def = generateGatewayUnit("/tmp/x/telegram", "x", false, false);
+    const legacy = generateGatewayUnit("/tmp/x/telegram", "x", false, true);
+    expect(def).toContain("Environment=SWITCHROOM_TMUX_SUPERVISOR=1");
+    expect(legacy).not.toContain("SWITCHROOM_TMUX_SUPERVISOR");
+    // Gateway ExecStart shape doesn't change between modes — only the env
+    // block — so flipping the flag is a no-op for the long-poll connection.
+    expect(execStart(def)).toBe(execStart(legacy));
   });
 
-  it("migration sequence (snapshot) — legacy → tmux ExecStart shapes", () => {
-    const legacy = execStart(generateUnit("ziggy", "/home/u/.switchroom/agents/ziggy", false, undefined, undefined, false));
-    const tmuxUnit = execStart(generateUnit("ziggy", "/home/u/.switchroom/agents/ziggy", false, undefined, undefined, true));
+  it("snapshot — default tmux ExecStart vs legacy_pty ExecStart shapes", () => {
+    const tmuxUnit = execStart(generateUnit("ziggy", "/home/u/.switchroom/agents/ziggy"));
+    const legacy = execStart(generateUnit("ziggy", "/home/u/.switchroom/agents/ziggy", false, undefined, undefined, true));
 
-    expect({ legacy, tmuxUnit }).toMatchInlineSnapshot(`
+    expect({ tmuxUnit, legacy }).toMatchInlineSnapshot(`
       {
         "legacy": "ExecStart=/usr/bin/script -qfc "/bin/bash -l /home/u/.switchroom/agents/ziggy/start.sh" /home/u/.switchroom/agents/ziggy/service.log",
         "tmuxUnit": "ExecStart=/usr/bin/tmux -L switchroom-ziggy -f /home/u/.switchroom/agents/ziggy/tmux.conf new-session -A -d -s ziggy -x 400 -y 50 'bash -l /home/u/.switchroom/agents/ziggy/start.sh'",

--- a/tests/systemd-restart.test.ts
+++ b/tests/systemd-restart.test.ts
@@ -61,8 +61,8 @@ describe("generateUnit — cgroup kill semantics (issue #361)", () => {
     expect(svc).toContain("TimeoutStopSec=15");
   });
 
-  it("preserves ExecStart with script -qfc (PTY must not be removed)", () => {
-    expect(unit).toContain("ExecStart=/usr/bin/script -qfc");
+  it("uses tmux ExecStart by default (#725 PR-1 — was script -qfc)", () => {
+    expect(unit).toContain("ExecStart=/usr/bin/tmux -L switchroom-clerk");
   });
 
   it("preserves Restart=on-failure", () => {
@@ -214,49 +214,44 @@ describe("kill directives placement — must be in [Service] not [Unit]", () => 
 //
 // Enable in CI by setting RUN_SYSTEMD_INTEGRATION_TESTS=1.
 
-// ─── tmux supervisor variants (issue #725 pre-fanout hardening) ──────────────
+// ─── tmux supervisor (default as of #725 PR-1) ──────────────────────────────
 //
-// When experimental.tmux_supervisor=true, the unit shape is materially
-// different: ExecStart is `tmux ... new-session -A -d`, Type=forking,
-// Delegate=yes, and ExecStop=-/usr/bin/tmux ... kill-session (with a
-// leading dash to silence the FAILURE log on the migration restart). These
-// tests assert the tmux shape survives unit re-renders so a future template
-// edit can't silently revert the supervisor opt-in.
+// tmux is the default supervisor: ExecStart is `tmux ... new-session -A -d`,
+// Type=forking, Delegate=yes, and ExecStop=-/usr/bin/tmux ... kill-session
+// (with a leading dash to silence the FAILURE log on the migration restart).
+// These tests assert the tmux shape is the default and that the legacy PTY
+// path remains reachable behind `experimental.legacy_pty: true`.
 
-describe("generateUnit — tmux supervisor shape survives re-renders (#725)", () => {
-  it("uses tmux new-session ExecStart when tmuxSupervisor=true", () => {
-    const unit = generateUnit("clerk", "/tmp/clerk", false, undefined, undefined, true);
+describe("generateUnit — tmux supervisor is the default (#725 PR-1)", () => {
+  it("uses tmux new-session ExecStart by default (no flag)", () => {
+    const unit = generateUnit("clerk", "/tmp/clerk");
     expect(unit).toContain("/usr/bin/tmux -L switchroom-clerk");
     expect(unit).toContain("new-session -A -d -s clerk");
-    // legacy script -qfc must NOT be the ExecStart under tmux supervisor
     const execStartLine = unit.split("\n").find((l) => l.startsWith("ExecStart=")) ?? "";
     expect(execStartLine).not.toContain("/usr/bin/script -qfc");
   });
 
-  it("ExecStop has a leading dash to silence migration FAILURE", () => {
-    const unit = generateUnit("clerk", "/tmp/clerk", false, undefined, undefined, true);
-    // Critical: the dash makes systemd ignore non-zero exit when stopping
-    // the OLD (script-wrapped) unit which has no tmux socket. Without it
-    // the script→tmux migration restart logs FAILURE.
-    expect(unit).toContain("ExecStop=-/usr/bin/tmux");
-    expect(unit).toContain("kill-session -t clerk");
-  });
-
-  it("uses Type=forking + Delegate=yes for tmux supervisor", () => {
-    const unit = generateUnit("clerk", "/tmp/clerk", false, undefined, undefined, true);
+  it("default is Type=forking + Delegate=yes", () => {
+    const unit = generateUnit("clerk", "/tmp/clerk");
     const svc = serviceSection(unit);
     expect(svc).toContain("Type=forking");
     expect(svc).toContain("Delegate=yes");
   });
 
+  it("ExecStop has a leading dash to silence migration FAILURE", () => {
+    const unit = generateUnit("clerk", "/tmp/clerk", false, undefined, undefined, false);
+    expect(unit).toContain("ExecStop=-/usr/bin/tmux");
+    expect(unit).toContain("kill-session -t clerk");
+  });
+
   it("includes ExecStartPost pipe-pane wiring to service.log", () => {
-    const unit = generateUnit("klanker", "/tmp/klanker", false, undefined, undefined, true);
+    const unit = generateUnit("klanker", "/tmp/klanker");
     expect(unit).toContain("ExecStartPost=/usr/bin/tmux");
     expect(unit).toContain("pipe-pane -o -t klanker");
   });
 
   it("preserves cgroup-kill semantics under tmux supervisor", () => {
-    const unit = generateUnit("clerk", "/tmp/clerk", false, undefined, undefined, true);
+    const unit = generateUnit("clerk", "/tmp/clerk");
     const svc = serviceSection(unit);
     expect(svc).toContain("KillMode=control-group");
     expect(svc).toContain("SendSIGKILL=yes");
@@ -264,16 +259,19 @@ describe("generateUnit — tmux supervisor shape survives re-renders (#725)", ()
   });
 
   it("identical input produces identical output across re-renders (deterministic)", () => {
-    const u1 = generateUnit("ziggy", "/tmp/ziggy", true, "ziggy-gateway", "Australia/Sydney", true);
-    const u2 = generateUnit("ziggy", "/tmp/ziggy", true, "ziggy-gateway", "Australia/Sydney", true);
+    const u1 = generateUnit("ziggy", "/tmp/ziggy", true, "ziggy-gateway", "Australia/Sydney");
+    const u2 = generateUnit("ziggy", "/tmp/ziggy", true, "ziggy-gateway", "Australia/Sydney");
     expect(u1).toBe(u2);
   });
 
-  it("legacy path (tmuxSupervisor=false) still uses script -qfc", () => {
-    const unit = generateUnit("clerk", "/tmp/clerk", false, undefined, undefined, false);
+  it("legacy_pty=true falls back to script -qfc", () => {
+    const unit = generateUnit("clerk", "/tmp/clerk", false, undefined, undefined, true);
     expect(unit).toContain("ExecStart=/usr/bin/script -qfc");
     expect(unit).not.toContain("ExecStart=/usr/bin/tmux");
     expect(unit).not.toContain("ExecStop=-/usr/bin/tmux");
+    const svc = serviceSection(unit);
+    expect(svc).toContain("Type=simple");
+    expect(svc).not.toContain("Delegate=yes");
   });
 });
 
@@ -291,14 +289,14 @@ describe("generateAgentTmuxConf — config regeneration is deterministic (#725)"
   });
 });
 
-describe("generateGatewayUnit — tmux supervisor env propagation (#725)", () => {
-  it("stamps SWITCHROOM_TMUX_SUPERVISOR=1 when flag is true", () => {
-    const unit = generateGatewayUnit("/tmp/clerk/telegram", "clerk", false, true);
+describe("generateGatewayUnit — tmux supervisor env propagation (#725 PR-1)", () => {
+  it("stamps SWITCHROOM_TMUX_SUPERVISOR=1 by default (legacy_pty=false)", () => {
+    const unit = generateGatewayUnit("/tmp/clerk/telegram", "clerk", false, false);
     expect(unit).toContain("Environment=SWITCHROOM_TMUX_SUPERVISOR=1");
   });
 
-  it("omits SWITCHROOM_TMUX_SUPERVISOR when flag is false", () => {
-    const unit = generateGatewayUnit("/tmp/clerk/telegram", "clerk", false, false);
+  it("omits SWITCHROOM_TMUX_SUPERVISOR when legacy_pty=true", () => {
+    const unit = generateGatewayUnit("/tmp/clerk/telegram", "clerk", false, true);
     expect(unit).not.toContain("SWITCHROOM_TMUX_SUPERVISOR");
   });
 });

--- a/tests/systemd.test.ts
+++ b/tests/systemd.test.ts
@@ -37,8 +37,22 @@ describe("generateUnit", () => {
     expect(unit).toContain("Description=switchroom agent: health-coach");
   });
 
-  it("uses script -qfc for PTY provision", () => {
+  it("uses tmux new-session by default (#725 PR-1)", () => {
     const unit = generateUnit("health-coach", "/home/user/.switchroom/agents/health-coach");
+    expect(unit).toContain("ExecStart=/usr/bin/tmux -L switchroom-health-coach");
+    expect(unit).toContain("new-session -A -d -s health-coach");
+    expect(unit).toContain("/home/user/.switchroom/agents/health-coach/start.sh");
+  });
+
+  it("uses script -qfc when legacy_pty=true (rollback)", () => {
+    const unit = generateUnit(
+      "health-coach",
+      "/home/user/.switchroom/agents/health-coach",
+      false,
+      undefined,
+      undefined,
+      true,
+    );
     expect(unit).toContain("ExecStart=/usr/bin/script -qfc");
     expect(unit).toContain("/home/user/.switchroom/agents/health-coach/start.sh");
   });
@@ -112,8 +126,13 @@ describe("generateUnit", () => {
     expect(serviceSection).not.toContain("StartLimitIntervalSec");
   });
 
-  it("sets Type=simple for script-based execution", () => {
+  it("sets Type=forking for tmux-based execution by default (#725 PR-1)", () => {
     const unit = generateUnit("test", "/tmp/test");
+    expect(unit).toContain("Type=forking");
+  });
+
+  it("sets Type=simple under legacy_pty (script-based execution)", () => {
+    const unit = generateUnit("test", "/tmp/test", false, undefined, undefined, true);
     expect(unit).toContain("Type=simple");
   });
 
@@ -130,7 +149,7 @@ describe("generateUnit", () => {
 
   it("uses expect autoaccept wrapper when useAutoaccept=true", () => {
     const unit = generateUnit("fork", "/tmp/fork", true);
-    expect(unit).toContain("/usr/bin/expect");
+    expect(unit).toContain("expect -f");
     expect(unit).toContain("autoaccept.exp");
     expect(unit).toContain("/tmp/fork/start.sh");
     // Should NOT reference the old Python autoaccept script
@@ -138,11 +157,12 @@ describe("generateUnit", () => {
     expect(unit).not.toContain("/usr/bin/python3");
   });
 
-  it("does not use expect wrapper by default", () => {
+  it("does not use expect wrapper when useAutoaccept=false", () => {
     const unit = generateUnit("plain", "/tmp/plain", false);
     expect(unit).not.toContain("autoaccept.exp");
-    expect(unit).not.toContain("/usr/bin/expect");
-    expect(unit).toContain("/bin/bash");
+    expect(unit).not.toContain("expect -f");
+    // Default supervisor wraps `bash -l ...start.sh` inside tmux.
+    expect(unit).toContain("bash -l /tmp/plain/start.sh");
   });
 
   // Regression: Ken had been hand-patching EnvironmentFile=- into
@@ -164,40 +184,47 @@ describe("generateUnit", () => {
     expect(unit).toMatch(/EnvironmentFile=-/);
   });
 
-  // ─── #725 Phase 1: opt-in tmux supervisor ───────────────────────────
-  describe("tmux supervisor (issue #725 Phase 1)", () => {
-    it("legacy script -qfc ExecStart is unchanged when flag is false", () => {
-      const unit = generateUnit("legacy", "/tmp/legacy", false, undefined, undefined, false);
+  // ─── #725 PR-1: tmux supervisor is default; legacy_pty rollback ─────
+  describe("tmux supervisor (default) and legacy_pty rollback (#725 PR-1)", () => {
+    it("default: tmux ExecStart, no script -qfc", () => {
+      const unit = generateUnit("legacy", "/tmp/legacy");
+      expect(unit).toContain("Type=forking");
+      expect(unit).toContain("Delegate=yes");
+      expect(unit).toContain("ExecStart=/usr/bin/tmux -L switchroom-legacy");
+      expect(unit).not.toContain("ExecStart=/usr/bin/script -qfc");
+    });
+
+    it("legacy_pty=true: script -qfc ExecStart, Type=simple, no Delegate", () => {
+      const unit = generateUnit("legacy", "/tmp/legacy", false, undefined, undefined, true);
       expect(unit).toContain("Type=simple");
       expect(unit).toContain("ExecStart=/usr/bin/script -qfc");
       expect(unit).not.toContain("/usr/bin/tmux");
       expect(unit).not.toContain("Delegate=yes");
     });
 
-    it("legacy autoaccept ExecStart is unchanged when flag is false", () => {
-      const unit = generateUnit("legacy", "/tmp/legacy", true, "legacy-gateway", undefined, false);
+    it("legacy_pty=true with autoaccept: script -qfc wraps autoaccept.exp", () => {
+      const unit = generateUnit("legacy", "/tmp/legacy", true, "legacy-gateway", undefined, true);
       expect(unit).toContain("ExecStart=/usr/bin/script -qfc");
       expect(unit).toContain("autoaccept.exp");
       expect(unit).not.toContain("/usr/bin/tmux");
     });
 
-    it("emits tmux ExecStart with autoaccept inside the session when flag=true and useAutoaccept=true", () => {
-      const unit = generateUnit("gymbro", "/tmp/gymbro", true, "gymbro-gateway", undefined, true);
+    it("default + autoaccept: tmux ExecStart wraps autoaccept inside the session", () => {
+      const unit = generateUnit("gymbro", "/tmp/gymbro", true, "gymbro-gateway");
       expect(unit).toContain("Type=forking");
       expect(unit).toContain("Delegate=yes");
       expect(unit).toContain("ExecStart=/usr/bin/tmux -L switchroom-gymbro -f /tmp/gymbro/tmux.conf new-session -A -d -s gymbro -x 400 -y 50 'expect -f");
       expect(unit).toContain("/tmp/gymbro/start.sh");
       expect(unit).toContain("ExecStartPost=/usr/bin/tmux -L switchroom-gymbro pipe-pane -o -t gymbro 'cat >> /tmp/gymbro/service.log'");
-      // Leading `-` on ExecStop = ignore non-zero exit. See systemd.ts
-      // comment — silences the script→tmux transition's first restart.
+      // Leading `-` on ExecStop = ignore non-zero exit (silences the
+      // script→tmux migration FAILURE on the first restart).
       expect(unit).toContain("ExecStop=-/usr/bin/tmux -L switchroom-gymbro kill-session -t gymbro");
       expect(unit).not.toContain("ExecStop=/usr/bin/tmux");
-      // No script -qfc anywhere when flag=true
       expect(unit).not.toContain("/usr/bin/script -qfc");
     });
 
-    it("emits tmux ExecStart with bash -l when flag=true and useAutoaccept=false", () => {
-      const unit = generateUnit("plain", "/tmp/plain", false, undefined, undefined, true);
+    it("default + no autoaccept: tmux ExecStart wraps `bash -l start.sh`", () => {
+      const unit = generateUnit("plain", "/tmp/plain");
       expect(unit).toContain("Type=forking");
       expect(unit).toContain("Delegate=yes");
       expect(unit).toContain("new-session -A -d -s plain -x 400 -y 50 'bash -l /tmp/plain/start.sh'");
@@ -205,8 +232,8 @@ describe("generateUnit", () => {
       expect(unit).not.toContain("/usr/bin/script -qfc");
     });
 
-    it("preserves cgroup kill semantics and memory ceilings under tmux supervisor", () => {
-      const unit = generateUnit("gymbro", "/tmp/gymbro", true, "gymbro-gateway", undefined, true);
+    it("preserves cgroup kill semantics and memory ceilings under default tmux supervisor", () => {
+      const unit = generateUnit("gymbro", "/tmp/gymbro", true, "gymbro-gateway");
       expect(unit).toContain("KillMode=control-group");
       expect(unit).toContain("KillSignal=SIGTERM");
       expect(unit).toContain("SendSIGKILL=yes");
@@ -484,11 +511,11 @@ describe("autoaccept detection via usesSwitchroomTelegramPlugin", () => {
 
     const autoUnit = generateUnit("dev", "/tmp/dev", usesSwitchroomTelegramPlugin(defaultAgent));
     expect(autoUnit).toContain("autoaccept.exp");
-    expect(autoUnit).toContain("/usr/bin/expect");
+    expect(autoUnit).toContain("expect -f");
 
     const plainUnit = generateUnit("plain", "/tmp/plain", usesSwitchroomTelegramPlugin(officialAgent));
     expect(plainUnit).not.toContain("autoaccept.exp");
-    expect(plainUnit).toContain("/bin/bash");
+    expect(plainUnit).toContain("bash -l");
   });
 });
 


### PR DESCRIPTION
## Summary

PR-1 of the #725 series. Flips the tmux supervisor from opt-in to the
production default for every agent. The legacy `script -qfc` PTY
wrapper stays reachable behind a new opt-OUT flag,
`experimental.legacy_pty: true`, for hosts without tmux or as a
rollback knob during stabilisation.

## Behaviour change

- Agents reconciled with no flag now render a tmux unit (`Type=forking`,
  `Delegate=yes`, `ExecStart=/usr/bin/tmux ... new-session -A -d ...`).
- `switchroom agent attach` drops into the live REPL via `tmux attach`.
- `switchroom agent send` / Telegram `/inject` are refused only when
  `experimental.legacy_pty: true` is set on the agent.
- `install.sh` enforces `tmux` as a hard prereq; opt agents into legacy
  via `experimental.legacy_pty: true` if you genuinely cannot run tmux.
- The flip materialises on the next agent restart — units are NOT auto-
  restarted by this PR. Run `switchroom systemd reconcile && switchroom
  agent restart <name>` per agent.

## Deprecation policy

The schema preserves `experimental.tmux_supervisor` as a parseable key
for one release with a one-time stderr warning, normalised to
`legacy_pty` (inverted) at parse time via a Zod transform. After parse
the deprecated key is dropped from the output. Compatibility shim will
be removed in the next minor release.

| old `tmux_supervisor` | new `legacy_pty` |
|-----------------------|------------------|
| `true`                | omit (or `false`) |
| `false`               | `true`            |
| (unset)               | (unset, default)  |

## Rollback

Per-agent: set `experimental.legacy_pty: true` in `switchroom.yaml`,
reconcile, restart that one agent. Full runbook in
`docs/tmux-supervisor-fanout.md`.

## Out of scope (follow-up PRs in the #725 series)

- **PR-2** — watchdog crash-capture + structured restart reasons.
- **PR-3** — signal-routing through the tmux supervisor (SIGTERM into
  pane vs. server, drain budgets).
- **PR-4** — expect retirement (drop `autoaccept.exp` once stable under
  tmux) + stop boot-cards from reading `SWITCHROOM_TMUX_SUPERVISOR`.
- Separate issue (filed alongside this PR): pipe-pane log rotation so
  `service.log` under tmux doesn't grow unbounded.

## Constraints honoured

- `SWITCHROOM_TMUX_SUPERVISOR` env var name unchanged (gateway / boot-
  probes / boot-card untouched in this PR; the env var is still stamped
  `=1` in the default tmux config and omitted under `legacy_pty`).
- `experimental` is NOT added to the `merge.ts` cascade — the Zod
  transform fires at parse time so per-agent reads see the normalised
  shape uniformly.
- `tmux_supervisor` schema key kept (deprecated, not removed).
- No changes to `submitAuthCode` in `src/auth/manager.ts`.
- No agents are auto-restarted by this PR.

## Test plan

- [x] `bunx tsc --noEmit` clean.
- [x] `bunx vitest run` delta vs baseline = 0 new failures.
- [x] New `tests/experimental-schema.test.ts` (9 tests) covers Zod
      transform, dedup of deprecation warning, key drop.
- [x] `tests/systemd.test.ts` + `tests/systemd-restart.test.ts` updated
      to default to tmux; new explicit `legacy_pty=true` rollback case.
- [x] `tests/fanout-migration.test.ts` rewritten as default-flip test.
- [x] `bun test telegram-plugin/gateway/inject-handler.test.ts` green.
- [ ] **Manual smoke (reviewer to validate on a host)**: scaffold a
      fresh agent, reconcile, observe tmux unit. Add
      `experimental.legacy_pty: true`, reconcile, observe `script -qfc`
      unit. Toggle back, observe one-time deprecation warning when an
      old `tmux_supervisor: true` is loaded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)