### PR TITLE
autoaccept: replace expect wrapper with TS pane-poller (#725 PR-4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@
 
 ### Changed
 
+- **First-run autoaccept now uses a TS pane-poller instead of `expect`
+  (#725 PR-4)** — the small set of first-run claude TUI prompts (theme
+  picker, MCP trust, dev-channels acknowledgement, API provider) are
+  now dispatched by a `tmux capture-pane` + `tmux send-keys` poller
+  fired from the agent unit's `ExecStartPost=`. Soft-fail throughout;
+  exits cleanly after ~30s of pane idle. The legacy `expect` wrapper
+  (`bin/autoaccept.exp`) is preserved as a one-release rollback knob:
+  set `experimental.legacy_autoaccept_expect: true` per-agent to revert
+  to the historical wrapper while the new path stabilises.
 - **`!` interrupt marker now delivers SIGINT via `tmux send-keys C-c`
   for tmux-supervised agents (#725 PR-3)**, falling back to
   `systemctl kill --signal=INT` on send-keys failure. Better signal

--- a/src/agents/autoaccept.ts
+++ b/src/agents/autoaccept.ts
@@ -1,0 +1,217 @@
+// First-run autoaccept pane-poller (#725 PR-4).
+//
+// Replaces `bin/autoaccept.exp` (the `expect` wrapper) with a small TS
+// pane-poller that uses `tmux capture-pane -p -t <name>` + `tmux send-keys`
+// to dispatch keystrokes for the small set of first-run claude TUI
+// prompts (theme picker, MCP trust, dev-channels acknowledgement,
+// API provider picker, generic confirm).
+//
+// Why poll a tmux pane instead of attaching to the PTY: under the tmux
+// supervisor (#725 PR-1, default since that PR) claude is already inside
+// a tmux session — there's no PTY to spawn around it. tmux gives us a
+// safe, side-effect-free read of the rendered screen via `capture-pane`
+// and a safe write via `send-keys`. Both are pure observation/injection;
+// neither alters the pane lifecycle.
+//
+// Hard contracts:
+//   * Soft-fail throughout. tmux gone? Log to stderr and continue.
+//   * Never throw out of `runAutoaccept`. Worst case: idle-timeout and
+//     return cleanly.
+//   * Never call destructive tmux verbs. Only `capture-pane` and
+//     `send-keys`. No kill-session, no respawn, no detach.
+//   * After ~30s with no prompt match, exit cleanly. claude has either
+//     reached the REPL or wedged in a way the poller can't fix; either
+//     way, leaving the pane untouched is the right move.
+//   * Each prompt fires at most `maxFires` times (default 1). The pane
+//     scrollback retains old prompt text; without a fire-cap the poller
+//     would re-dispatch keystrokes every 250ms forever once a prompt
+//     scrolled past.
+//
+// The prompt regexes are translated faithfully from `bin/autoaccept.exp`.
+// If you change one, change both — the legacy expect wrapper is still
+// gated behind `experimental.legacy_autoaccept_expect: true` as a
+// rollback path for one release.
+
+import { execFileSync } from "node:child_process";
+
+export interface PromptRule {
+  /** human-readable name, used for logging */
+  name: string;
+  /** regex against the captured pane text */
+  match: RegExp;
+  /** keystrokes to send via `tmux send-keys -t <agent>`. e.g. ["Enter"] or ["Down", "Enter"] */
+  keys: string[];
+  /** Optional: only match this prompt at most N times. Default 1. */
+  maxFires?: number;
+}
+
+export interface AutoacceptOptions {
+  agentName: string;
+  /** Per-prompt timeout in ms. Default 30000. After this many ms with no prompt match, exit cleanly. */
+  idleTimeoutMs?: number;
+  /** Per-poll interval in ms. Default 250. */
+  pollIntervalMs?: number;
+  /** Override prompt set for tests. Default: built-in PROMPTS. */
+  prompts?: PromptRule[];
+  /** Test seam: cap total polls before giving up regardless of timer wall-clock. */
+  maxPolls?: number;
+  /** Test seam: clock + sleep override so unit tests don't burn real wall-clock. */
+  now?: () => number;
+  sleep?: (ms: number) => Promise<void> | void;
+}
+
+export interface AutoacceptResult {
+  fired: string[];
+  reason: "idle-timeout" | "manual-stop";
+}
+
+// Translated from `bin/autoaccept.exp`. The expect script uses `.{1,30}`
+// bounded wildcards because claude's TUI inserts ANSI cursor-right
+// sequences (`\033[1C`) between words, breaking naive literal matching.
+// We see the same rendered bytes through `tmux capture-pane -p` (without
+// `-e` for ANSI), so the regexes here can match the visible text without
+// the `\033[1C` noise — but we keep the bounded wildcards to stay robust
+// against minor TUI rewording.
+//
+// IMPORTANT: keep this list in sync with `bin/autoaccept.exp`. The legacy
+// wrapper is still wired in when `experimental.legacy_autoaccept_expect`
+// is true (one-release rollback knob).
+export const PROMPTS: PromptRule[] = [
+  {
+    // Dev-channels acknowledgement — shown once per machine when
+    // --dangerously-load-development-channels is first used. Tightly
+    // scoped to "development channels" to avoid over-matching per-tool
+    // confirmations like "Yes, I accept this file edit." (those must
+    // fall through to the plugin's permission_request flow).
+    name: "dev-channels",
+    match: /I.{0,5}accept.{0,80}development.{0,10}channels/,
+    // Down + Enter — selects the second option (the "I accept" one).
+    keys: ["Down", "Enter"],
+  },
+  {
+    // MCP server trust prompt.
+    name: "mcp-trust",
+    match: /Use this and all future MCP servers/,
+    keys: ["Enter"],
+  },
+  {
+    // First-run theme selection — pick option 1 (Auto).
+    name: "theme",
+    match: /Choose.{1,30}text.{1,30}style/,
+    keys: ["Enter"],
+  },
+  {
+    // First-run API provider selection — pick Anthropic (option 1).
+    name: "provider",
+    match: /Anthropic.{1,80}Bedrock/,
+    keys: ["Enter"],
+  },
+  {
+    // Generic "Enter to confirm" — last because the more specific
+    // matchers above should take precedence on the same screen.
+    name: "enter-to-confirm",
+    match: /Enter.{1,30}confirm/,
+    keys: ["Enter"],
+  },
+];
+
+const DEFAULT_IDLE_MS = 30_000;
+const DEFAULT_POLL_MS = 250;
+
+function defaultSleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+/**
+ * Capture a single pane snapshot. Returns "" on any tmux error (soft-fail).
+ */
+export function capturePane(agentName: string): string {
+  const socket = `switchroom-${agentName}`;
+  try {
+    const out = execFileSync(
+      "tmux",
+      ["-L", socket, "capture-pane", "-p", "-t", agentName],
+      {
+        timeout: 3000,
+        stdio: ["ignore", "pipe", "pipe"],
+        maxBuffer: 4 * 1024 * 1024,
+      },
+    );
+    return out.toString("utf8");
+  } catch (err) {
+    console.error(
+      `[autoaccept] ${agentName}: capture-pane failed: ${(err as Error).message}`,
+    );
+    return "";
+  }
+}
+
+/**
+ * Send keystrokes via tmux. Soft-fail.
+ */
+export function sendKeys(agentName: string, keys: string[]): boolean {
+  const socket = `switchroom-${agentName}`;
+  try {
+    execFileSync(
+      "tmux",
+      ["-L", socket, "send-keys", "-t", agentName, ...keys],
+      { timeout: 3000, stdio: ["ignore", "pipe", "pipe"] },
+    );
+    return true;
+  } catch (err) {
+    console.error(
+      `[autoaccept] ${agentName}: send-keys ${keys.join(" ")} failed: ${(err as Error).message}`,
+    );
+    return false;
+  }
+}
+
+/**
+ * Run the autoaccept poller until idle-timeout. Resolves with the list of
+ * fired prompt names. Never throws.
+ */
+export async function runAutoaccept(
+  opts: AutoacceptOptions,
+): Promise<AutoacceptResult> {
+  const idleTimeoutMs = opts.idleTimeoutMs ?? DEFAULT_IDLE_MS;
+  const pollIntervalMs = opts.pollIntervalMs ?? DEFAULT_POLL_MS;
+  const rules = (opts.prompts ?? PROMPTS).map((r) => ({
+    rule: r,
+    fired: 0,
+    cap: r.maxFires ?? 1,
+  }));
+  const fired: string[] = [];
+  const now = opts.now ?? Date.now;
+  const sleep = opts.sleep ?? defaultSleep;
+  const maxPolls = opts.maxPolls ?? Number.POSITIVE_INFINITY;
+
+  let lastFire = now();
+  let polls = 0;
+
+  while (polls < maxPolls) {
+    polls++;
+    const text = capturePane(opts.agentName);
+    let matchedThisPoll = false;
+    if (text) {
+      for (const entry of rules) {
+        if (entry.fired >= entry.cap) continue;
+        if (entry.rule.match.test(text)) {
+          entry.fired++;
+          matchedThisPoll = true;
+          fired.push(entry.rule.name);
+          console.error(
+            `[autoaccept] ${opts.agentName}: fired ${entry.rule.name} (${entry.rule.keys.join("+")})`,
+          );
+          sendKeys(opts.agentName, entry.rule.keys);
+        }
+      }
+    }
+    if (matchedThisPoll) {
+      lastFire = now();
+    } else if (now() - lastFire >= idleTimeoutMs) {
+      return { fired, reason: "idle-timeout" };
+    }
+    await sleep(pollIntervalMs);
+  }
+  return { fired, reason: "manual-stop" };
+}

--- a/src/agents/systemd.ts
+++ b/src/agents/systemd.ts
@@ -37,9 +37,11 @@ export function generateUnit(
   gatewayUnitName?: string,
   timezone?: string,
   legacyPty = false,
+  legacyAutoacceptExpect = false,
 ): string {
   const logFile = resolve(agentDir, "service.log");
   const autoacceptExp = resolve(import.meta.dirname, "../../bin/autoaccept.exp");
+  const autoacceptPollEntry = resolve(import.meta.dirname, "../cli/autoaccept-poll.ts");
   const tmuxConfPath = resolve(agentDir, "tmux.conf");
   const tmuxSocket = `switchroom-${name}`;
 
@@ -62,13 +64,34 @@ export function generateUnit(
   if (!legacyPty) {
     serviceType = "forking";
     delegateLine = "Delegate=yes\n";
-    const inner = useAutoaccept
-      ? `expect -f ${autoacceptExp} ${agentDir}/start.sh`
-      : `bash -l ${agentDir}/start.sh`;
+    // #725 PR-4 — under the tmux supervisor, default to launching claude
+    // directly via `bash -l start.sh` (no expect wrapper). The first-run
+    // TUI prompts are dispatched by the TS pane-poller fired from
+    // ExecStartPost below. Operators can roll back to the legacy expect
+    // wrapper for one release by setting
+    // `experimental.legacy_autoaccept_expect: true`.
+    let inner: string;
+    if (useAutoaccept && legacyAutoacceptExpect) {
+      inner = `expect -f ${autoacceptExp} ${agentDir}/start.sh`;
+    } else {
+      inner = `bash -l ${agentDir}/start.sh`;
+    }
     execStart = `/usr/bin/tmux -L ${tmuxSocket} -f ${tmuxConfPath} new-session -A -d -s ${name} -x 400 -y 50 '${inner}'`;
     // pipe-pane proxies the tmux pane's stdout to service.log so existing
     // log consumers (pty-tail, journald followers) keep working unchanged.
     extraStartPost = `ExecStartPost=/usr/bin/tmux -L ${tmuxSocket} pipe-pane -o -t ${name} 'cat >> ${logFile}'\n`;
+    // #725 PR-4 — fire the TS autoaccept pane-poller in the background.
+    // ExecStartPost commands run synchronously, so wrap the bun invocation
+    // in `bash -c '... &'` to detach. The poller itself exits cleanly after
+    // ~30s of pane idle (no prompt match), so it doesn't linger past the
+    // first-run window. Soft-fail throughout — the wrapper exits 0 even
+    // if bun is missing or the script throws, keeping the unit healthy.
+    // Skipped when the operator opted into the legacy expect wrapper.
+    if (useAutoaccept && !legacyAutoacceptExpect) {
+      const homeDir = process.env.HOME ?? "/root";
+      const bunBin = resolve(homeDir, ".bun/bin/bun");
+      extraStartPost += `ExecStartPost=/bin/bash -c '${bunBin} ${autoacceptPollEntry} ${name} >> ${logFile} 2>&1 &'\n`;
+    }
     // Leading `-` on ExecStop tells systemd to ignore non-zero exits from
     // the kill-session call. Without it, the script→tmux supervisor
     // transition's first restart logs FAILURE because the OLD unit (still
@@ -563,6 +586,8 @@ export function installAllUnits(config: SwitchroomConfig): void {
     const resolved = resolveAgentConfig(config.defaults, config.profiles, agent);
     const timezone = resolveTimezone(config, resolved);
     const legacyPty = resolved.experimental?.legacy_pty === true;
+    const legacyAutoacceptExpect =
+      resolved.experimental?.legacy_autoaccept_expect === true;
 
     // tmux is the default supervisor (#725 PR-1) — drop a managed tmux.conf
     // alongside start.sh unless this agent has opted out via legacy_pty.
@@ -573,7 +598,15 @@ export function installAllUnits(config: SwitchroomConfig): void {
       writeAgentTmuxConf(agentDir);
     }
 
-    const content = generateUnit(agentName, agentDir, useAutoaccept, gwName, timezone, legacyPty);
+    const content = generateUnit(
+      agentName,
+      agentDir,
+      useAutoaccept,
+      gwName,
+      timezone,
+      legacyPty,
+      legacyAutoacceptExpect,
+    );
     installUnit(agentName, content);
     installedAgents.push(unitName(agentName));
 

--- a/src/cli/autoaccept-poll.ts
+++ b/src/cli/autoaccept-poll.ts
@@ -1,0 +1,39 @@
+#!/usr/bin/env bun
+// Small CLI wrapper around `runAutoaccept` (#725 PR-4).
+//
+// Invoked from the per-agent systemd unit's `ExecStartPost=` (see
+// `src/agents/systemd.ts`) when the tmux supervisor is the active mode
+// (default since #725 PR-1) AND the agent has not opted into the legacy
+// `expect`-based autoaccept wrapper via
+// `experimental.legacy_autoaccept_expect: true`.
+//
+// argv[2] = agent name. Always exits 0 — the poller is best-effort and
+// must never fail the unit start. tmux not running yet, capture-pane
+// erroring, send-keys racing the prompt: all soft-failures.
+
+import { runAutoaccept } from "../agents/autoaccept.js";
+
+async function main(): Promise<void> {
+  const agentName = process.argv[2];
+  if (!agentName) {
+    console.error("[autoaccept-poll] missing agent name argv");
+    process.exit(0);
+  }
+  try {
+    const res = await runAutoaccept({ agentName });
+    console.error(
+      `[autoaccept-poll] ${agentName}: done reason=${res.reason} fired=${
+        res.fired.length ? res.fired.join(",") : "(none)"
+      }`,
+    );
+  } catch (err) {
+    // runAutoaccept is contracted to never throw, but defence-in-depth:
+    // any synchronous-throw at boot must not fail the agent unit.
+    console.error(
+      `[autoaccept-poll] ${agentName}: unexpected throw: ${(err as Error).message}`,
+    );
+  }
+  process.exit(0);
+}
+
+main();

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -735,6 +735,16 @@ export const ExperimentalSchema = z
         "`tmux_supervisor: true` migrates to `legacy_pty: false`. A " +
         "one-time deprecation warning is emitted to stderr per process.",
       ),
+    legacy_autoaccept_expect: z
+      .boolean()
+      .optional()
+      .describe(
+        "Use the legacy `expect`-based autoaccept wrapper for first-run " +
+        "TUI prompts (theme picker, MCP trust, dev-channels). Default " +
+        "false (new TS pane-poller introduced in #725 PR-4). Set true to " +
+        "roll back during stabilisation; this rollback knob is kept for " +
+        "one release.",
+      ),
   })
   .optional()
   .transform((val) => {

--- a/tests/autoaccept.test.ts
+++ b/tests/autoaccept.test.ts
@@ -1,0 +1,281 @@
+// Unit tests for the TS autoaccept pane-poller (#725 PR-4).
+//
+// We mock `node:child_process` so the test never shells out to real tmux.
+// Each `execFileSync` call is steered by a queue of canned pane-text /
+// outcomes set up per-test, mirroring the way `tests/tmux-capture.test.ts`
+// drives `captureAgentPane`.
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+vi.mock("node:child_process", () => {
+  return {
+    execFileSync: vi.fn(),
+  };
+});
+
+import { execFileSync } from "node:child_process";
+import {
+  runAutoaccept,
+  PROMPTS,
+  capturePane,
+  sendKeys,
+  type PromptRule,
+} from "../src/agents/autoaccept.js";
+
+const mockedExec = execFileSync as unknown as ReturnType<typeof vi.fn>;
+
+/**
+ * Build a stub for execFileSync that branches on the tmux subcommand.
+ * `captureScreens` is consumed in order for each capture-pane call;
+ * once exhausted, returns "".
+ */
+function setupTmux(captureScreens: string[]) {
+  const sentKeys: string[][] = [];
+  let captureIdx = 0;
+  mockedExec.mockImplementation((_bin: string, args: readonly string[]) => {
+    const subcmd = args[2];
+    if (subcmd === "capture-pane") {
+      const next = captureIdx < captureScreens.length
+        ? captureScreens[captureIdx]
+        : "";
+      captureIdx++;
+      return Buffer.from(next, "utf8");
+    }
+    if (subcmd === "send-keys") {
+      // args: ["-L", socket, "send-keys", "-t", agent, ...keys]
+      sentKeys.push([...args.slice(5)]);
+      return Buffer.from("");
+    }
+    return Buffer.from("");
+  });
+  return { sentKeys };
+}
+
+beforeEach(() => {
+  mockedExec.mockReset();
+});
+
+describe("runAutoaccept", () => {
+  it("fires a single prompt once when the pane matches (theme picker)", async () => {
+    const { sentKeys } = setupTmux([
+      // poll 1: theme prompt visible
+      "Choose the text style you'd like\n[1] Auto",
+      // poll 2..N: nothing — falls through to idle-timeout
+      "",
+    ]);
+    const res = await runAutoaccept({
+      agentName: "klanker",
+      idleTimeoutMs: 5,
+      pollIntervalMs: 0,
+      now: () => 0, // never advances; rely on maxPolls
+      sleep: () => {},
+      maxPolls: 5,
+    });
+    expect(res.fired).toContain("theme");
+    expect(sentKeys).toEqual([["Enter"]]);
+  });
+
+  it("dispatches multi-prompt sequence in order: theme → mcp-trust → dev-channels", async () => {
+    const { sentKeys } = setupTmux([
+      "Choose the text style", // theme
+      "Use this and all future MCP servers", // mcp-trust
+      "I accept the use of development channels", // dev-channels
+    ]);
+    const res = await runAutoaccept({
+      agentName: "a",
+      idleTimeoutMs: 1,
+      pollIntervalMs: 0,
+      now: () => 0,
+      sleep: () => {},
+      maxPolls: 4,
+    });
+    expect(res.fired).toEqual(["theme", "mcp-trust", "dev-channels"]);
+    expect(sentKeys).toEqual([
+      ["Enter"],
+      ["Enter"],
+      ["Down", "Enter"],
+    ]);
+  });
+
+  it("maxFires=1 prevents double-ack when the prompt re-appears in the scrollback", async () => {
+    const { sentKeys } = setupTmux([
+      "Choose the text style please",
+      "Choose the text style please", // still in scrollback — must NOT re-fire
+      "Choose the text style please",
+    ]);
+    const res = await runAutoaccept({
+      agentName: "a",
+      idleTimeoutMs: 1,
+      pollIntervalMs: 0,
+      now: () => 0,
+      sleep: () => {},
+      maxPolls: 5,
+    });
+    expect(res.fired).toEqual(["theme"]);
+    expect(sentKeys).toHaveLength(1);
+  });
+
+  it("exits cleanly with idle-timeout when no prompts match", async () => {
+    setupTmux(["claude > _", "claude > _", "claude > _"]);
+    let t = 0;
+    const res = await runAutoaccept({
+      agentName: "a",
+      idleTimeoutMs: 100,
+      pollIntervalMs: 0,
+      // wall-clock advances 50ms per call → after 3 polls we hit 150ms idle
+      now: () => {
+        t += 50;
+        return t;
+      },
+      sleep: () => {},
+      maxPolls: 50,
+    });
+    expect(res.reason).toBe("idle-timeout");
+    expect(res.fired).toEqual([]);
+  });
+
+  it("soft-fails on tmux capture-pane errors (does not throw)", async () => {
+    mockedExec.mockImplementation((_bin: string, args: readonly string[]) => {
+      const subcmd = args[2];
+      if (subcmd === "capture-pane") {
+        throw new Error("tmux: no server running");
+      }
+      return Buffer.from("");
+    });
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const res = await runAutoaccept({
+      agentName: "a",
+      idleTimeoutMs: 1,
+      pollIntervalMs: 0,
+      now: () => 0,
+      sleep: () => {},
+      maxPolls: 3,
+    });
+    // The poll loop ran, captures all failed (logged), no fires, exits via maxPolls.
+    expect(res.fired).toEqual([]);
+    expect(errSpy).toHaveBeenCalled();
+    errSpy.mockRestore();
+  });
+
+  it("soft-fails on send-keys errors (continues polling)", async () => {
+    mockedExec.mockImplementation((_bin: string, args: readonly string[]) => {
+      const subcmd = args[2];
+      if (subcmd === "capture-pane") {
+        return Buffer.from("Choose the text style", "utf8");
+      }
+      if (subcmd === "send-keys") {
+        throw new Error("send-keys boom");
+      }
+      return Buffer.from("");
+    });
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const res = await runAutoaccept({
+      agentName: "a",
+      idleTimeoutMs: 1,
+      pollIntervalMs: 0,
+      now: () => 0,
+      sleep: () => {},
+      maxPolls: 2,
+    });
+    // The match still fires (we tried), maxFires caps further dispatch.
+    expect(res.fired).toContain("theme");
+    errSpy.mockRestore();
+  });
+
+  it("respects custom prompts override and maxFires=2", async () => {
+    const rule: PromptRule = {
+      name: "blip",
+      match: /BLIP/,
+      keys: ["Enter"],
+      maxFires: 2,
+    };
+    const { sentKeys } = setupTmux(["BLIP", "BLIP", "BLIP", "BLIP"]);
+    const res = await runAutoaccept({
+      agentName: "a",
+      idleTimeoutMs: 1,
+      pollIntervalMs: 0,
+      now: () => 0,
+      sleep: () => {},
+      maxPolls: 6,
+      prompts: [rule],
+    });
+    expect(res.fired).toEqual(["blip", "blip"]);
+    expect(sentKeys).toHaveLength(2);
+  });
+});
+
+describe("PROMPTS — regex sanity (translated from bin/autoaccept.exp)", () => {
+  // Canned fixture strings drawn from the same prompt phrases the legacy
+  // expect script's regex was tuned against. If claude's TUI rewords any
+  // of these, both this test and bin/autoaccept.exp need updating.
+  const fixtures: Array<{ text: string; expected: string }> = [
+    {
+      text: "Choose the text style that looks best with your terminal",
+      expected: "theme",
+    },
+    {
+      text: "Use this and all future MCP servers in this project",
+      expected: "mcp-trust",
+    },
+    {
+      text: "Yes, I accept the use of development channels",
+      expected: "dev-channels",
+    },
+    {
+      text: "Anthropic API   /   Bedrock   /   Vertex",
+      expected: "provider",
+    },
+    {
+      text: "Press Enter to confirm your selection",
+      expected: "enter-to-confirm",
+    },
+  ];
+
+  for (const { text, expected } of fixtures) {
+    it(`matches the ${expected} prompt`, () => {
+      const hit = PROMPTS.find((p) => p.match.test(text));
+      expect(hit?.name).toBe(expected);
+    });
+  }
+
+  it("does NOT match per-tool 'Yes, I accept this file edit' style prompts", () => {
+    // Critical: per-tool permission prompts must fall through to the
+    // plugin's permission_request flow, not be auto-accepted here.
+    const text = "Yes, I accept this file edit";
+    const hit = PROMPTS.find((p) => p.match.test(text));
+    expect(hit).toBeUndefined();
+  });
+});
+
+describe("capturePane / sendKeys helpers", () => {
+  it("capturePane returns '' on tmux error (soft-fail)", () => {
+    mockedExec.mockImplementation(() => {
+      throw new Error("nope");
+    });
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const out = capturePane("a");
+    expect(out).toBe("");
+    errSpy.mockRestore();
+  });
+
+  it("sendKeys returns false on tmux error (soft-fail)", () => {
+    mockedExec.mockImplementation(() => {
+      throw new Error("nope");
+    });
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const ok = sendKeys("a", ["Enter"]);
+    expect(ok).toBe(false);
+    errSpy.mockRestore();
+  });
+
+  it("capturePane uses the per-agent socket and target", () => {
+    mockedExec.mockReturnValue(Buffer.from("hello"));
+    capturePane("klanker");
+    const args = mockedExec.mock.calls[0]?.[1] as string[];
+    expect(args).toContain("-L");
+    expect(args).toContain("switchroom-klanker");
+    expect(args).toContain("capture-pane");
+    expect(args).toContain("-t");
+    expect(args).toContain("klanker");
+  });
+});

--- a/tests/experimental-schema.test.ts
+++ b/tests/experimental-schema.test.ts
@@ -88,4 +88,27 @@ describe("ExperimentalSchema — Zod transform (#725 PR-1)", () => {
     expect(out).not.toHaveProperty("tmux_supervisor");
     warn.mockRestore();
   });
+
+  // #725 PR-4 — legacy_autoaccept_expect rollback flag.
+  it("legacy_autoaccept_expect: true is preserved as-is", () => {
+    const out = ExperimentalSchema.parse({ legacy_autoaccept_expect: true });
+    expect(out).toEqual({
+      legacy_pty: false,
+      legacy_autoaccept_expect: true,
+    });
+  });
+
+  it("legacy_autoaccept_expect: false is preserved as-is", () => {
+    const out = ExperimentalSchema.parse({ legacy_autoaccept_expect: false });
+    expect(out).toEqual({
+      legacy_pty: false,
+      legacy_autoaccept_expect: false,
+    });
+  });
+
+  it("omitted legacy_autoaccept_expect → undefined (treated as false at use site)", () => {
+    const out = ExperimentalSchema.parse({});
+    expect(out).toEqual({ legacy_pty: false });
+    expect(out).not.toHaveProperty("legacy_autoaccept_expect");
+  });
 });

--- a/tests/fanout-migration.test.ts
+++ b/tests/fanout-migration.test.ts
@@ -51,11 +51,16 @@ describe("default-flip: tmux supervisor is the default", () => {
     expect(execStop(legacy)).toBe("");
   });
 
-  it("autoaccept default → legacy: ExecStart wraps autoaccept.exp under both shapes", () => {
+  it("autoaccept default (PR-4): ExecStart no longer wraps autoaccept.exp; legacy_pty path does", () => {
+    // #725 PR-4 — under the tmux supervisor (default) the expect wrapper
+    // is gone; first-run prompts are dispatched by the TS pane-poller
+    // fired from ExecStartPost. Legacy_pty path (no tmux) still uses
+    // expect because there's no pane to poll.
     const def = generateUnit("clerk", "/tmp/clerk", true, "clerk-gateway");
     const legacy = generateUnit("clerk", "/tmp/clerk", true, "clerk-gateway", undefined, true);
-    expect(execStart(def)).toContain("autoaccept.exp");
+    expect(execStart(def)).not.toContain("autoaccept.exp");
     expect(execStart(def)).toContain("/usr/bin/tmux -L switchroom-clerk");
+    expect(execStart(def)).toContain("bash -l /tmp/clerk/start.sh");
     expect(execStart(legacy)).toContain("autoaccept.exp");
     expect(execStart(legacy)).toContain("/usr/bin/script -qfc");
   });

--- a/tests/systemd-restart.test.ts
+++ b/tests/systemd-restart.test.ts
@@ -75,8 +75,10 @@ describe("generateUnit — cgroup kill semantics (issue #361)", () => {
     expect(autoSvc).toContain("KillMode=control-group");
     expect(autoSvc).toContain("SendSIGKILL=yes");
     expect(autoSvc).toContain("TimeoutStopSec=15");
-    // PTY wrapper still present
-    expect(autoUnit).toContain("autoaccept.exp");
+    // #725 PR-4 — autoaccept is now a TS pane-poller fired from
+    // ExecStartPost; the expect wrapper is opt-in only.
+    expect(autoUnit).not.toContain("autoaccept.exp");
+    expect(autoUnit).toContain("autoaccept-poll.ts");
   });
 });
 

--- a/tests/systemd.test.ts
+++ b/tests/systemd.test.ts
@@ -147,20 +147,43 @@ describe("generateUnit", () => {
     expect(unit).toContain("WantedBy=default.target");
   });
 
-  it("uses expect autoaccept wrapper when useAutoaccept=true", () => {
+  it("uses TS pane-poller (not expect) by default when useAutoaccept=true (#725 PR-4)", () => {
+    // PR-4: the default first-run autoaccept path is the TS pane-poller
+    // fired from ExecStartPost. The expect wrapper is gated behind the
+    // legacy_autoaccept_expect rollback flag.
     const unit = generateUnit("fork", "/tmp/fork", true);
-    expect(unit).toContain("expect -f");
-    expect(unit).toContain("autoaccept.exp");
-    expect(unit).toContain("/tmp/fork/start.sh");
+    expect(unit).not.toContain("expect -f");
+    expect(unit).not.toContain("autoaccept.exp");
+    expect(unit).toContain("bash -l /tmp/fork/start.sh");
+    expect(unit).toContain("autoaccept-poll.ts");
+    expect(unit).toContain(" fork");
     // Should NOT reference the old Python autoaccept script
     expect(unit).not.toContain("autoaccept.py");
     expect(unit).not.toContain("/usr/bin/python3");
   });
 
-  it("does not use expect wrapper when useAutoaccept=false", () => {
+  it("uses expect autoaccept wrapper when legacy_autoaccept_expect=true (rollback)", () => {
+    const unit = generateUnit(
+      "fork",
+      "/tmp/fork",
+      true, // useAutoaccept
+      undefined,
+      undefined,
+      false, // legacyPty
+      true, // legacyAutoacceptExpect
+    );
+    expect(unit).toContain("expect -f");
+    expect(unit).toContain("autoaccept.exp");
+    expect(unit).toContain("/tmp/fork/start.sh");
+    // Poller must NOT also fire when expect is in charge.
+    expect(unit).not.toContain("autoaccept-poll.ts");
+  });
+
+  it("does not use expect wrapper or poller when useAutoaccept=false", () => {
     const unit = generateUnit("plain", "/tmp/plain", false);
     expect(unit).not.toContain("autoaccept.exp");
     expect(unit).not.toContain("expect -f");
+    expect(unit).not.toContain("autoaccept-poll.ts");
     // Default supervisor wraps `bash -l ...start.sh` inside tmux.
     expect(unit).toContain("bash -l /tmp/plain/start.sh");
   });
@@ -209,18 +232,38 @@ describe("generateUnit", () => {
       expect(unit).not.toContain("/usr/bin/tmux");
     });
 
-    it("default + autoaccept: tmux ExecStart wraps autoaccept inside the session", () => {
+    it("default + autoaccept: tmux ExecStart runs start.sh directly; poller fires from ExecStartPost (#725 PR-4)", () => {
       const unit = generateUnit("gymbro", "/tmp/gymbro", true, "gymbro-gateway");
       expect(unit).toContain("Type=forking");
       expect(unit).toContain("Delegate=yes");
-      expect(unit).toContain("ExecStart=/usr/bin/tmux -L switchroom-gymbro -f /tmp/gymbro/tmux.conf new-session -A -d -s gymbro -x 400 -y 50 'expect -f");
-      expect(unit).toContain("/tmp/gymbro/start.sh");
+      // No expect wrapper inside the tmux session — claude launches directly.
+      expect(unit).toContain("new-session -A -d -s gymbro -x 400 -y 50 'bash -l /tmp/gymbro/start.sh'");
+      expect(unit).not.toContain("'expect -f");
+      // Pipe-pane unchanged.
       expect(unit).toContain("ExecStartPost=/usr/bin/tmux -L switchroom-gymbro pipe-pane -o -t gymbro 'cat >> /tmp/gymbro/service.log'");
+      // Autoaccept poller fires in the background after the session is up.
+      expect(unit).toContain("autoaccept-poll.ts gymbro");
       // Leading `-` on ExecStop = ignore non-zero exit (silences the
       // script→tmux migration FAILURE on the first restart).
       expect(unit).toContain("ExecStop=-/usr/bin/tmux -L switchroom-gymbro kill-session -t gymbro");
       expect(unit).not.toContain("ExecStop=/usr/bin/tmux");
       expect(unit).not.toContain("/usr/bin/script -qfc");
+    });
+
+    it("default + autoaccept + legacy_autoaccept_expect=true: tmux wraps expect (rollback path)", () => {
+      const unit = generateUnit(
+        "gymbro",
+        "/tmp/gymbro",
+        true,
+        "gymbro-gateway",
+        undefined,
+        false,
+        true,
+      );
+      expect(unit).toContain("ExecStart=/usr/bin/tmux -L switchroom-gymbro -f /tmp/gymbro/tmux.conf new-session -A -d -s gymbro -x 400 -y 50 'expect -f");
+      expect(unit).toContain("/tmp/gymbro/start.sh");
+      // Poller must NOT fire alongside the legacy wrapper.
+      expect(unit).not.toContain("autoaccept-poll.ts");
     });
 
     it("default + no autoaccept: tmux ExecStart wraps `bash -l start.sh`", () => {
@@ -510,11 +553,15 @@ describe("autoaccept detection via usesSwitchroomTelegramPlugin", () => {
     const officialAgent = { profile: "default", channels: { telegram: { plugin: "official" } } } as AgentConfig;
 
     const autoUnit = generateUnit("dev", "/tmp/dev", usesSwitchroomTelegramPlugin(defaultAgent));
-    expect(autoUnit).toContain("autoaccept.exp");
-    expect(autoUnit).toContain("expect -f");
+    // #725 PR-4 — default first-run autoaccept is the TS pane-poller, not expect.
+    expect(autoUnit).not.toContain("autoaccept.exp");
+    expect(autoUnit).not.toContain("expect -f");
+    expect(autoUnit).toContain("autoaccept-poll.ts dev");
+    expect(autoUnit).toContain("bash -l /tmp/dev/start.sh");
 
     const plainUnit = generateUnit("plain", "/tmp/plain", usesSwitchroomTelegramPlugin(officialAgent));
     expect(plainUnit).not.toContain("autoaccept.exp");
+    expect(plainUnit).not.toContain("autoaccept-poll.ts");
     expect(plainUnit).toContain("bash -l");
   });
 });


### PR DESCRIPTION
## Summary

PR-4 of 4 in epic #725. Retires `bin/autoaccept.exp` (the `expect` wrapper that handles first-run claude TUI prompts) by replacing it with a small TS pane-poller that uses `tmux capture-pane -p` + `tmux send-keys`. The expect path remains opt-in for one release as a rollback safety-net.

## Behaviour

- Default (tmux supervisor + autoaccept enabled): the agent unit's `ExecStart=` runs `bash -l start.sh` directly inside the tmux session; an `ExecStartPost=` line fires `bun src/cli/autoaccept-poll.ts <name>` in the background. The poller polls the pane every 250ms, dispatches keystrokes for matched prompts, and exits cleanly after 30s of pane idle.
- Legacy: `experimental.legacy_pty: true` agents are unchanged (no tmux, no poller). The expect wrapper continues to wrap `script -qfc` for that path.
- Rollback: a new flag `experimental.legacy_autoaccept_expect: true` (default false) reverts the tmux path to the old expect wrapper for one release.

## Soft-fail contract

The poller never throws. tmux gone? Log + continue. capture-pane errored? Continue. send-keys raced the prompt? `maxFires` cap stops re-dispatch. Bun missing in `ExecStartPost`? The bash wrapper exits 0 anyway. Worst case: 30s idle-timeout with `fired: []` and the operator interacts with the pane manually.

## Prompt set

Translated faithfully from `bin/autoaccept.exp`:
- `theme` — first-run text style picker → `Enter`
- `mcp-trust` — MCP server trust prompt → `Enter`
- `dev-channels` — dev-channels acknowledgement → `Down, Enter`
- `provider` — API provider picker (Anthropic/Bedrock/Vertex) → `Enter`
- `enter-to-confirm` — generic confirm → `Enter`

Per-tool permission prompts ("Yes, I accept this file edit") are deliberately NOT matched — those flow through the plugin's `permission_request` UX. There's a regression test for that.

## Files

New:
- `src/agents/autoaccept.ts` — `runAutoaccept`, `PROMPTS`, soft-fail tmux helpers
- `src/cli/autoaccept-poll.ts` — bun entrypoint for ExecStartPost
- `tests/autoaccept.test.ts` — 16 unit tests covering single/multi-prompt, maxFires cap, idle-timeout, soft-fail on capture/send errors, prompt-regex sanity (incl. negative test for per-tool prompts)

Modified:
- `src/config/schema.ts` — adds `experimental.legacy_autoaccept_expect`
- `src/agents/systemd.ts` — gates expect-vs-poller on the new flag, adds the `ExecStartPost=` poller line
- `tests/experimental-schema.test.ts` — coverage for the new flag
- `tests/systemd.test.ts`, `tests/systemd-restart.test.ts`, `tests/fanout-migration.test.ts` — updated assertions that previously hardcoded the old `autoaccept.exp` default; added tests for the rollback path
- `CHANGELOG.md`

## Test plan

- [x] `bunx tsc --noEmit` clean
- [x] `bunx vitest run tests/autoaccept.test.ts tests/experimental-schema.test.ts tests/systemd.test.ts tests/systemd-restart.test.ts tests/fanout-migration.test.ts` — 148 pass
- [ ] Manual: install on a clean host, agent first-boot, verify theme/MCP-trust prompts get dispatched and claude reaches REPL
- [ ] Manual rollback: set `experimental.legacy_autoaccept_expect: true`, reconcile + restart, verify the expect wrapper is in `ExecStart=` and the poller is NOT in `ExecStartPost=`

🤖 Generated with [Claude Code](https://claude.com/claude-code)