### PR TITLE
chore: release v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## v0.7.0 — 2026-05-06
 
 ### Changed
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "switchroom-ai",
-  "version": "0.6.14",
+  "version": "0.7.0",
   "description": "Run Claude Code 24/7 on your Claude Pro/Max subscription over Telegram. Open-source alternative to OpenClaw and NanoClaw — no API keys, no Docker.",
   "type": "module",
   "bin": {

--- a/src/build-info.ts
+++ b/src/build-info.ts
@@ -2,8 +2,8 @@
 // Tracked in git so `tsc --noEmit` works on a fresh clone before `npm run build`.
 // Values are refreshed every time `npm run build` runs.
 
-export const VERSION: string = "0.6.14";
-export const COMMIT_SHA: string | null = "cd67d7ca";
-export const COMMIT_DATE: string | null = "2026-05-05T19:33:03+10:00";
-export const LATEST_PR: number | null = 706;
-export const COMMITS_AHEAD_OF_TAG: number | null = 1;
+export const VERSION: string = "0.7.0";
+export const COMMIT_SHA: string | null = "915b4500";
+export const COMMIT_DATE: string | null = "2026-05-06T12:36:58+10:00";
+export const LATEST_PR: number | null = 743;
+export const COMMITS_AHEAD_OF_TAG: number | null = 23;


### PR DESCRIPTION
## Headline

tmux supervisor is now the default. Legacy `script -qfc` PTY path is opt-in via `experimental.legacy_pty: true`.

## Bundles

- #738 — flip default + rename `experimental.tmux_supervisor` → `experimental.legacy_pty` (one-release deprecation shim)
- #740 — watchdog crash-time pane capture → `~/.switchroom/agents/<agent>/crash-reports/`
- #742 — `!` interrupt routes via `tmux send-keys C-c` for tmux agents, cgroup fallback preserved
- #743 — autoaccept TS pane-poller replaces `expect` wrapper (rollback flag: `experimental.legacy_autoaccept_expect`)

## Migration

- Existing agents are NOT auto-restarted by the upgrade.
- New defaults materialise on next agent restart after `switchroom apply`.
- Hosts without `tmux` must opt agents in to legacy via `experimental.legacy_pty: true` (or install tmux).
- `experimental.tmux_supervisor` still parses for one release with a stderr deprecation warning.

## Open follow-ups

- #739 — pipe-pane log rotation (service.log unbounded under tmux-default)
- #741 — tighten crash-report file perms to 0600/0700

## Test plan

- `bunx tsc --noEmit` clean on the release branch
- All four bundle PRs merged with fresh-process reviewer APPROVE
- Unit-test coverage: 9 schema, 8 capture, 13 interrupt, 16 autoaccept
- End-to-end on a live agent: pending (canary planned post-merge once npm publish is out)