### PR TITLE
fix(preflight): accept autoaccept-poll wiring (v0.7.0 default)

### DIFF
--- a/src/cli/agent.ts
+++ b/src/cli/agent.ts
@@ -170,7 +170,7 @@ function checkSwitchroomBranch(): string | null {
   }
 }
 
-function preflightCheck(
+export function preflightCheck(
   name: string,
   agentDir: string,
   usesDevChannels: boolean,
@@ -194,27 +194,35 @@ function preflightCheck(
       `systemd unit not found at ${unitPath}. Run: switchroom agent create ${name}`,
     );
   } else if (usesDevChannels) {
-    // 3. If using dev channels, the unit MUST use the expect wrapper
+    // 3. If using dev channels, the unit must dispatch the first-run
+    //    TUI prompts somehow — either the legacy `expect` wrapper, or
+    //    the v0.7.0+ `autoaccept-poll.ts` ExecStartPost poller.
     const unitContent = readFileSync(unitPath, "utf-8");
-    if (!unitContent.includes("expect")) {
+    const hasExpect = unitContent.includes("autoaccept.exp");
+    const hasPoller = unitContent.includes("autoaccept-poll");
+    if (!hasExpect && !hasPoller) {
       errors.push(
-        `systemd unit is missing the expect autoaccept wrapper — ` +
-        `dev channels will hang on the confirmation dialog. ` +
-        `Fix: switchroom systemd install (regenerates the unit)`,
+        `systemd unit has no autoaccept handler — dev channels will hang ` +
+        `on the confirmation dialog. Fix: switchroom systemd install ` +
+        `(regenerates the unit)`,
       );
     }
-  }
 
-  // 4. expect binary exists (if needed)
-  if (usesDevChannels) {
-    try {
-      const { execSync: exec } = require("node:child_process");
-      exec("which expect", { stdio: "pipe" });
-    } catch {
-      errors.push(
-        `'expect' binary not found on PATH — required for dev channels. ` +
-        `Install: sudo apt install expect`,
-      );
+    // 4. If the unit uses the legacy expect wrapper, the binary must be
+    //    on PATH. The TS poller path has no extra binary requirement
+    //    beyond tmux (already gated by install.sh).
+    if (hasExpect && !hasPoller) {
+      try {
+        const { execSync: exec } = require("node:child_process");
+        exec("which expect", { stdio: "pipe" });
+      } catch {
+        errors.push(
+          `'expect' binary not found on PATH — required by legacy autoaccept. ` +
+          `Install: sudo apt install expect (or remove ` +
+          `experimental.legacy_autoaccept_expect / legacy_pty to use the ` +
+          `default tmux poller)`,
+        );
+      }
     }
   }
 

--- a/tests/cli-preflight.test.ts
+++ b/tests/cli-preflight.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync, existsSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { resolve, join } from "node:path";
+import { preflightCheck } from "../src/cli/agent.js";
+
+// preflightCheck reads $HOME/.config/systemd/user/switchroom-<name>.service
+// and the agent's start.sh / telegram/.env from its agentDir argument. We
+// build a sandbox under a tempdir, point HOME at it, and write fixtures.
+
+describe("preflightCheck — autoaccept handler detection (v0.7.0+)", () => {
+  let sandbox: string;
+  let prevHome: string | undefined;
+
+  beforeEach(() => {
+    sandbox = mkdtempSync(join(tmpdir(), "switchroom-preflight-"));
+    prevHome = process.env.HOME;
+    process.env.HOME = sandbox;
+    mkdirSync(join(sandbox, ".config/systemd/user"), { recursive: true });
+  });
+
+  afterEach(() => {
+    if (prevHome !== undefined) process.env.HOME = prevHome;
+    else delete process.env.HOME;
+    rmSync(sandbox, { recursive: true, force: true });
+  });
+
+  function writeAgent(name: string, unit: string, withEnv = true): string {
+    const agentDir = resolve(sandbox, ".switchroom/agents", name);
+    mkdirSync(join(agentDir, "telegram"), { recursive: true });
+    writeFileSync(resolve(agentDir, "start.sh"), "#!/bin/bash\n", { mode: 0o755 });
+    if (withEnv) {
+      writeFileSync(
+        resolve(agentDir, "telegram/.env"),
+        "TELEGRAM_BOT_TOKEN=fake\n",
+      );
+    }
+    writeFileSync(
+      resolve(sandbox, ".config/systemd/user", `switchroom-${name}.service`),
+      unit,
+    );
+    return agentDir;
+  }
+
+  it("passes when unit uses autoaccept-poll (tmux-default)", () => {
+    const agentDir = writeAgent(
+      "alpha",
+      `[Service]\nExecStart=/usr/bin/tmux new-session -d -s alpha 'bash start.sh'\nExecStartPost=/bin/bash -c '/path/to/dist/cli/autoaccept-poll.ts alpha &'\n`,
+    );
+    const errors = preflightCheck("alpha", agentDir, true);
+    // Filter for handler-related errors only — token/env/etc are independent.
+    const handlerErrs = errors.filter((e) => e.includes("autoaccept") || e.includes("expect"));
+    expect(handlerErrs).toEqual([]);
+  });
+
+  it("passes when unit uses legacy expect wrapper and expect is on PATH", () => {
+    const agentDir = writeAgent(
+      "bravo",
+      `[Service]\nExecStart=/usr/bin/script -qfc "/usr/bin/expect -f /path/to/autoaccept.exp /path/start.sh"\n`,
+    );
+    const errors = preflightCheck("bravo", agentDir, true);
+    const handlerErrs = errors.filter((e) => e.includes("autoaccept handler"));
+    expect(handlerErrs).toEqual([]);
+  });
+
+  it("flags missing handler when unit has neither expect nor poller", () => {
+    const agentDir = writeAgent(
+      "charlie",
+      `[Service]\nExecStart=/usr/bin/bash /path/start.sh\n`,
+    );
+    const errors = preflightCheck("charlie", agentDir, true);
+    expect(errors.some((e) => e.includes("no autoaccept handler"))).toBe(true);
+  });
+
+  it("does not flag handler when usesDevChannels=false", () => {
+    const agentDir = writeAgent(
+      "delta",
+      `[Service]\nExecStart=/usr/bin/bash /path/start.sh\n`,
+    );
+    const errors = preflightCheck("delta", agentDir, false);
+    expect(errors.some((e) => e.includes("autoaccept handler"))).toBe(false);
+    expect(errors.some((e) => e.includes("expect"))).toBe(false);
+  });
+
+  it("prefers poller over expect when unit has both (mixed unit)", () => {
+    const agentDir = writeAgent(
+      "echo",
+      `[Service]\nExecStart=/usr/bin/tmux ... 'bash start.sh'\nExecStartPost=/bin/bash -c 'autoaccept-poll.ts echo &'\n# legacy reference autoaccept.exp commented out\n`,
+    );
+    const errors = preflightCheck("echo", agentDir, true);
+    // Should not require expect binary because poller path takes precedence.
+    expect(errors.some((e) => e.includes("'expect' binary"))).toBe(false);
+  });
+});


### PR DESCRIPTION
## Release-day bug — blocks all agent restarts on v0.7.0

\`switchroom agent restart\` preflight (\`src/cli/agent.ts:196-218\`) was written assuming the legacy \`expect autoaccept.exp\` wrapper is required in every systemd unit. v0.7.0 (#738/#743) flipped the default to tmux + \`autoaccept-poll.ts\` ExecStartPost, so freshly-applied v0.7.0 units fail preflight with:

> ✗ systemd unit is missing the expect autoaccept wrapper

…blocking every restart attempt across the fleet.

## Fix

Preflight now accepts EITHER:
- \`autoaccept.exp\` substring (legacy / opt-in via \`experimental.legacy_autoaccept_expect\` or \`experimental.legacy_pty\`)
- \`autoaccept-poll\` substring (v0.7.0+ default tmux poller)

The \`which expect\` check only fires when the unit has the legacy wrapper without the poller.

## Test plan

5 new tests in \`tests/cli-preflight.test.ts\`:
- poll-only unit passes
- legacy-expect unit passes
- unit with neither flags missing handler
- non-dev-channels skips handler check entirely
- mixed unit (both strings) prefers poller, doesn't require expect binary

\`bunx tsc --noEmit\` clean. Discovered live during the v0.7.0 canary.

## Follow-up

Cut v0.7.1 immediately after merge.