### PR TITLE
chore: release v0.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## v0.7.2 — 2026-05-06
+
+### Fixed
+
+- **`switchroom agent restart` preflight no longer rejects v0.7.0+
+  units (#745)** — the preflight in `src/cli/agent.ts` was written
+  against the legacy `expect autoaccept.exp` wrapper and refused to
+  start any unit that didn't contain it. v0.7.0 flipped the default
+  to the TS `autoaccept-poll` ExecStartPost, which broke restarts
+  fleet-wide. Preflight now accepts either handler and only requires
+  the `expect` binary on PATH when the legacy wrapper is in use.
+  Versions 0.7.0 and 0.7.1 are unusable in default mode without
+  `--force` — upgrade directly to 0.7.2.
+
 ## v0.7.0 — 2026-05-06
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "switchroom-ai",
-  "version": "0.7.0",
+  "version": "0.7.2",
   "description": "Run Claude Code 24/7 on your Claude Pro/Max subscription over Telegram. Open-source alternative to OpenClaw and NanoClaw — no API keys, no Docker.",
   "type": "module",
   "bin": {

--- a/src/build-info.ts
+++ b/src/build-info.ts
@@ -2,8 +2,8 @@
 // Tracked in git so `tsc --noEmit` works on a fresh clone before `npm run build`.
 // Values are refreshed every time `npm run build` runs.
 
-export const VERSION: string = "0.7.0";
-export const COMMIT_SHA: string | null = "915b4500";
-export const COMMIT_DATE: string | null = "2026-05-06T12:36:58+10:00";
-export const LATEST_PR: number | null = 743;
-export const COMMITS_AHEAD_OF_TAG: number | null = 23;
+export const VERSION: string = "0.7.2";
+export const COMMIT_SHA: string | null = "24565fa0";
+export const COMMIT_DATE: string | null = "2026-05-06T13:17:23+10:00";
+export const LATEST_PR: number | null = 745;
+export const COMMITS_AHEAD_OF_TAG: number | null = 1;


### PR DESCRIPTION
Hotfix release. v0.7.0/v0.7.1 unusable in default mode without --force.

- #745 — fix(preflight): accept autoaccept-poll wiring (v0.7.0 default)