### PR TITLE
fix(release): bundle autoaccept-poll, point systemd unit at .js

### DIFF
--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -113,6 +113,27 @@ if (cliEscape.changed) {
   console.log(`[build] ASCII-escaped ${cliEscape.nonAsciiCount} non-ASCII code units in dist/cli/switchroom.js`);
 }
 
+// Bundle the autoaccept-poll entrypoint. The agent unit's ExecStartPost
+// invokes this in the background to dispatch first-run TUI prompts via
+// `tmux capture-pane` + `tmux send-keys`. Must ship in dist/ because
+// package.json files-array does not include src/.
+console.log("[build] bundling src/cli/autoaccept-poll.ts -> dist/cli/autoaccept-poll.js");
+execSync(
+  `bun build ${JSON.stringify(resolve(root, "src/cli/autoaccept-poll.ts"))} --outdir ${JSON.stringify(outDir)} --target node`,
+  { stdio: "inherit", cwd: root }
+);
+const pollOutFile = resolve(outDir, "autoaccept-poll.js");
+let pollSrc = readFileSync(pollOutFile, "utf8");
+if (pollSrc.startsWith("#!/usr/bin/env node")) {
+  pollSrc = pollSrc.replace(/^#!\/usr\/bin\/env node/, "#!/usr/bin/env bun");
+  writeFileSync(pollOutFile, pollSrc);
+}
+chmodSync(pollOutFile, 0o755);
+const pollEscape = escapeBundleNonAscii(pollOutFile);
+if (pollEscape.changed) {
+  console.log(`[build] ASCII-escaped ${pollEscape.nonAsciiCount} non-ASCII code units in dist/cli/autoaccept-poll.js`);
+}
+
 // Build the telegram-plugin self-contained dist (#634 strategic
 // packaging fix). The plugin's gateway / server / bridge entry points
 // reach across into `src/` (auth, config, vault-broker, build-info).

--- a/src/agents/systemd.ts
+++ b/src/agents/systemd.ts
@@ -41,7 +41,17 @@ export function generateUnit(
 ): string {
   const logFile = resolve(agentDir, "service.log");
   const autoacceptExp = resolve(import.meta.dirname, "../../bin/autoaccept.exp");
-  const autoacceptPollEntry = resolve(import.meta.dirname, "../cli/autoaccept-poll.ts");
+  // Resolve the autoaccept-poll entrypoint preferring the bundled .js.
+  // Published npm packages ship dist/ only (no src/), so .js is the only
+  // available file in production; in dev (`bun bin/switchroom.ts` from a
+  // source checkout) only .ts exists until the first build. Probe both
+  // and use whichever is on disk so dev and published installs both work.
+  const autoacceptPollCandidates = [
+    resolve(import.meta.dirname, "../cli/autoaccept-poll.js"),
+    resolve(import.meta.dirname, "../cli/autoaccept-poll.ts"),
+  ];
+  const autoacceptPollEntry =
+    autoacceptPollCandidates.find((p) => existsSync(p)) ?? autoacceptPollCandidates[0];
   const tmuxConfPath = resolve(agentDir, "tmux.conf");
   const tmuxSocket = `switchroom-${name}`;
 

--- a/src/build-info.ts
+++ b/src/build-info.ts
@@ -3,7 +3,7 @@
 // Values are refreshed every time `npm run build` runs.
 
 export const VERSION: string = "0.7.2";
-export const COMMIT_SHA: string | null = "24565fa0";
-export const COMMIT_DATE: string | null = "2026-05-06T13:17:23+10:00";
-export const LATEST_PR: number | null = 745;
-export const COMMITS_AHEAD_OF_TAG: number | null = 1;
+export const COMMIT_SHA: string | null = "6a4ec1e4";
+export const COMMIT_DATE: string | null = "2026-05-06T13:18:17+10:00";
+export const LATEST_PR: number | null = 746;
+export const COMMITS_AHEAD_OF_TAG: number | null = 0;

--- a/tests/autoaccept-poll-bundled.test.ts
+++ b/tests/autoaccept-poll-bundled.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from "vitest";
+import { existsSync, statSync } from "node:fs";
+import { resolve } from "node:path";
+
+// Lock in that the autoaccept-poll entrypoint actually ships in dist/.
+// Regression guard for the v0.7.0 release-day bug: the systemd agent unit
+// referenced `dist/cli/autoaccept-poll.ts`, but scripts/build.mjs only
+// bundled bin/switchroom.ts and package.json files-array doesn't include
+// src/, so the published package shipped no autoaccept-poll at all and
+// every fresh agent boot wedged on the first-run TUI prompt.
+
+const distRoot = resolve(import.meta.dirname, "..", "dist", "cli");
+const builtPoll = resolve(distRoot, "autoaccept-poll.js");
+
+describe("autoaccept-poll bundled output (release-shape regression)", () => {
+  it("dist/cli/autoaccept-poll.js exists after build", () => {
+    expect(existsSync(builtPoll), `expected ${builtPoll} to exist after npm run build`).toBe(true);
+  });
+
+  it("dist/cli/autoaccept-poll.js is non-empty and executable", () => {
+    if (!existsSync(builtPoll)) return; // first assertion already failed
+    const st = statSync(builtPoll);
+    expect(st.size).toBeGreaterThan(1024);
+    // owner-execute bit
+    expect(st.mode & 0o100).not.toBe(0);
+  });
+
+  it("dist/cli/autoaccept-poll.js has bun shebang", async () => {
+    if (!existsSync(builtPoll)) return;
+    const { readFileSync } = await import("node:fs");
+    const head = readFileSync(builtPoll, "utf-8").slice(0, 20);
+    expect(head).toMatch(/^#!\/usr\/bin\/env bun/);
+  });
+});


### PR DESCRIPTION
## Release-day bug — v0.7.0/v0.7.2 unusable on fresh agent boot

`v0.7.0` added `src/cli/autoaccept-poll.ts` as the new TS pane-poller (replacing `expect`), but:

1. `scripts/build.mjs` only bundles `bin/switchroom.ts` — autoaccept-poll never gets compiled into `dist/`.
2. `package.json` files-array doesn't include `src/` — published npm packages ship no source.

Net: every fresh agent boot's `ExecStartPost=… bun .../dist/cli/autoaccept-poll.ts` failed with `error: Module not found`. Agents wedged on the first-run dev-channels confirmation prompt with no auto-ack. Verified against gymbro on a v0.7.2 install — manual `tmux send-keys Enter` was needed to unblock.

## Fix

- `scripts/build.mjs`: bundle `src/cli/autoaccept-poll.ts` → `dist/cli/autoaccept-poll.js` (bun shebang + chmod 755).
- `src/agents/systemd.ts`: probe `.js` (production) and `.ts` (source-checkout dev) and use whichever exists. Both code paths supported.
- `tests/autoaccept-poll-bundled.test.ts`: regression guard. Asserts `dist/cli/autoaccept-poll.js` exists, is non-empty, is executable, has the bun shebang. Runs in vitest under `prepublishOnly` so this can't ship broken again.

## Followup

Cut v0.7.3 immediately.