### PR TITLE
chore: rename to switchroom, release v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,41 +1,19 @@
 # Changelog
 
-## v0.7.2 — 2026-05-06
+## v0.5.0 — 2026-05-06
 
-### Fixed
+Initial release of `switchroom` (npm package renamed from
+`switchroom-ai`). The historical `switchroom-ai` package on npm is
+deprecated — see https://www.npmjs.com/package/switchroom for the new
+home. Version reset to 0.5.0; the 25 prior `switchroom-ai` tags are
+documentation-only and will be cleaned up out-of-band.
 
-- **`switchroom agent restart` preflight no longer rejects v0.7.0+
-  units (#745)** — the preflight in `src/cli/agent.ts` was written
-  against the legacy `expect autoaccept.exp` wrapper and refused to
-  start any unit that didn't contain it. v0.7.0 flipped the default
-  to the TS `autoaccept-poll` ExecStartPost, which broke restarts
-  fleet-wide. Preflight now accepts either handler and only requires
-  the `expect` binary on PATH when the legacy wrapper is in use.
-  Versions 0.7.0 and 0.7.1 are unusable in default mode without
-  `--force` — upgrade directly to 0.7.2.
-
-## v0.7.0 — 2026-05-06
+This release consolidates the in-flight work from PRs #738 / #740 /
+#742 / #743 / #745 / #747 into a single disciplined first cut on the
+new package name. Substantive changes from prior `switchroom-ai@0.6.14`:
 
 ### Changed
 
-- **First-run autoaccept now uses a TS pane-poller instead of `expect`
-  (#725 PR-4)** — the small set of first-run claude TUI prompts (theme
-  picker, MCP trust, dev-channels acknowledgement, API provider) are
-  now dispatched by a `tmux capture-pane` + `tmux send-keys` poller
-  fired from the agent unit's `ExecStartPost=`. Soft-fail throughout;
-  exits cleanly after ~30s of pane idle. The legacy `expect` wrapper
-  (`bin/autoaccept.exp`) is preserved as a one-release rollback knob:
-  set `experimental.legacy_autoaccept_expect: true` per-agent to revert
-  to the historical wrapper while the new path stabilises.
-- **`!` interrupt marker now delivers SIGINT via `tmux send-keys C-c`
-  for tmux-supervised agents (#725 PR-3)**, falling back to
-  `systemctl kill --signal=INT` on send-keys failure. Better signal
-  delivery to runaway tool children — send-keys hits the pane's
-  foreground process (claude or whatever child Bash is currently
-  spinning), where the cgroup-wide kill also wakes the tmux server
-  and supervisor wrappers and may not always reach grandchildren
-  cleanly. `experimental.legacy_pty: true` agents continue to use
-  the cgroup path unchanged.
 - **tmux supervisor is now the default (#725 PR-1)** — `script -qfc`
   PTY wrapping is replaced by per-agent `tmux new-session` for all
   agents by default. The user-facing flag rename is
@@ -46,15 +24,20 @@
   is now a hard prereq (`install.sh` enforces); hosts without tmux
   must opt agents into legacy via `experimental.legacy_pty: true`.
   See `docs/tmux-supervisor-fanout.md` for the rollback runbook.
+- **`!` interrupt marker now delivers SIGINT via `tmux send-keys C-c`
+  for tmux-supervised agents (#725 PR-3)**, falling back to
+  `systemctl kill --signal=INT` on send-keys failure. Better signal
+  delivery to runaway tool children.
+- **First-run autoaccept now uses a TS pane-poller instead of `expect`
+  (#725 PR-4)** — the small set of first-run claude TUI prompts (theme
+  picker, MCP trust, dev-channels acknowledgement, API provider) are
+  now dispatched by a `tmux capture-pane` + `tmux send-keys` poller
+  fired from the agent unit's `ExecStartPost=`. Soft-fail throughout;
+  exits cleanly after ~30s of pane idle. The legacy `expect` wrapper
+  (`bin/autoaccept.exp`) is preserved as a one-release rollback knob:
+  set `experimental.legacy_autoaccept_expect: true` per-agent to revert.
 - **`experimental.tmux_supervisor` deprecated** — still parseable for
-  one release with a one-time stderr warning. Migration is automatic:
-  `tmux_supervisor: false` → `legacy_pty: true`; `tmux_supervisor:
-  true` → omit (or `legacy_pty: false`). Compatibility shim will be
-  removed in the next minor release.
-- **`SWITCHROOM_TMUX_SUPERVISOR` env var unchanged** — the user-facing
-  flag was renamed but the gateway/boot-probes/boot-card env-var
-  contract is preserved. The gateway unit stamps `=1` in the default
-  (tmux) configuration; `legacy_pty: true` omits the var.
+  one release with a one-time stderr warning. Migration is automatic.
 
 ### Added
 
@@ -64,71 +47,19 @@
   `~/.switchroom/agents/<agent>/crash-reports/<ISO8601>-<reason>.txt`
   so RCA has the live screen state at the moment of the kill.
   Retention: 20 most recent files per agent. Size cap: 10 MB per
-  file. Capture is best-effort — a missing tmux/socket/file-write
-  failure never blocks the restart. Operator-initiated restarts
-  (`switchroom agent restart`) skip capture; only watchdog-triggered
-  restarts produce reports. New helper module `src/agents/tmux.ts`
-  exposes `captureAgentPane()` for code paths already in TS;
-  `bin/bridge-watchdog.sh` uses an inline bash mirror in the hot
-  path. See `docs/crash-reports.md`.
-- **tmux supervisor pre-fanout hardening (#725)** — PID resolver walks
-  the unit cgroup to pick the heaviest-RSS claude/node process, so
-  boot cards and `getAgentStatus` no longer report the ~2 MB tmux
-  server PID under `Type=forking`. Mirrors `agent_main_pid()` in
-  `bin/bridge-watchdog.sh`. Companion runbook for the canary fanout
-  lives at [`docs/tmux-supervisor-fanout.md`](docs/tmux-supervisor-fanout.md).
-- **tmux supervisor opt-in flag (#725 Phase 1)** — new per-agent
-  `experimental.tmux_supervisor` boolean (default `false`). When `true`,
-  the systemd unit replaces `script -qfc` with `tmux new-session` so
-  external `tmux send-keys` can drive the running Claude REPL (foundation
-  for #163 `/remotecontrol` and broader slash-command passthrough). Ships
-  a managed `tmux.conf` per agent (`default-terminal xterm-256color`,
-  `history-limit 100000`, `status off`, `remain-on-exit off`).
-  Patches `bin/autoaccept.exp` with `set timeout 30` and `interact { eof
-  exit }` so external send-keys reaches Claude. `switchroom agent attach`
-  now actually attaches to the tmux session when the flag is on.
-- **Webhook dispatch (#715)** — verified webhook events now trigger fresh
-  `claude -p` invocations so agents can react in Telegram without polling
-  `webhook-events.jsonl` manually.
-  - New module `src/web/webhook-dispatch.ts`:
-    - **Static matcher** (`event`, `actions`, `labels_any`, `labels_all`,
-      `exclude_authors`) — no CEL/expression parser; fully JSON-Schema-validatable.
-    - **`{{field}}` template rendering** against a flat helper bag:
-      `repo`, `number`, `title`, `html_url`, `author`, `labels`, `action`, `event`.
-    - **Cooldown** — same `(event, repo, number, rule-index)` combination
-      coalesces within the window. State on disk per-agent at
-      `<agent>/telegram/webhook-cooldown.json`.
-    - **Quiet hours** — wraps midnight when `start > end`. Skips dispatch
-      entirely (event still in JSONL for manual review).
-    - **`spawnAgentOneShot()`** — same env setup as `buildCronScript` in
-      `scaffold.ts`: OAuth forced, `ANTHROPIC_API_KEY` unset, token injected
-      from `.oauth-token`, `CLAUDE_CONFIG_DIR` and `SWITCHROOM_AGENT_NAME` set.
-  - `WebhookHandlerArgs` gains optional `dispatchConfig` field; handler
-    calls `evaluateDispatch()` after JSONL append (non-fatal — dispatch
-    errors never downgrade the 202).
-  - `webhook_dispatch` added to `TelegramChannelSchema` in
-    `src/config/schema.ts`; cascades via existing channels deep-merge.
-  - **CLI**: `switchroom telegram dispatch test --agent <name> --payload
-    <file.json> --event <type>` — dry-runs matchers offline, prints which
-    rules match and the rendered prompt without spawning.
-  - Test fixtures in `tests/fixtures/` (GitHub PR opened/labeled/dependabot/push).
-  - 35 unit tests covering all matcher combinations, template rendering,
-    cooldown state machine, quiet hours, and `evaluateDispatch` integration.
+  file. See `docs/crash-reports.md`.
+- **Preflight accepts `autoaccept-poll` wiring (#745)** — the
+  `switchroom agent restart` preflight in `src/cli/agent.ts` now
+  accepts either the legacy `expect autoaccept.exp` wrapper or the
+  new `autoaccept-poll` ExecStartPost, and only requires the `expect`
+  binary on PATH when the legacy wrapper is in use.
 
-- **Webhook ingest hardening (#714)** — two defenses added to
-  `src/web/webhook-handler.ts` before auto-dispatch ships:
-  - **Dedup by `X-GitHub-Delivery`**: per-agent LRU (1000 entries, 24h
-    retention) backed by `~/.switchroom/agents/<agent>/telegram/webhook-dedup.json`.
-    Replay returns 200 `{ok:true,deduped:true}` and skips JSONL append.
-    Generic source has no delivery header — dedup is skipped silently.
-  - **Per-source token-bucket rate limit**: off by default; opt-in via
-    `channels.telegram.webhook_rate_limit.rpm` in switchroom.yaml (set
-    e.g. `rpm: 60` for one request/sec sustained, burst equal to rpm).
-    When enabled, exceeding the limit returns 429 with `Retry-After`.
-    First throttle event per `(agent, source)` per 60s window is written
-    to `<agent>/telegram/issues.jsonl` for Telegram visibility.
-  - `webhook_rate_limit` added to `TelegramChannelSchema` in
-    `src/config/schema.ts`; cascades via the existing channels deep-merge.
+### Fixed
+
+- **Build now bundles `dist/cli/autoaccept-poll.js` (#747)** — the
+  systemd unit's `ExecStartPost=` references the bundled `.js`
+  artifact; prior internal cuts shipped without it, breaking
+  default-mode units on fresh installs.
 
 ## v0.6.14 — 2026-05-05
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -173,8 +173,8 @@ also a mini-deploy of any scaffold changes.
 
 `~/.bun/bin/switchroom` is typically a symlink to the workspace's
 `dist/cli/switchroom.js`. If you built with `bun run build`, the global
-CLI is already fresh — no `npm i -g` needed. An `npm i -g switchroom-ai`
-installs a separate, pinned copy at `~/.nvm/…/node_modules/switchroom-ai`;
+CLI is already fresh — no `npm i -g` needed. An `npm i -g switchroom`
+installs a separate, pinned copy at `~/.nvm/…/node_modules/switchroom`;
 PATH resolution order determines which wins. Prefer the bun-linked install
 on dev machines, the npm-global install on consumer machines.
 

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ If you already use Claude Code, this is the shortest path. Inside any session:
 curl -fsSL https://get.switchroom.ai | bash
 ```
 
-Bootstraps bun, node 22, the claude CLI, and switchroom-ai. Idempotent. Safe to re-run. Source is [`install.sh`](install.sh) in this repo.
+Bootstraps bun, node 22, the claude CLI, and switchroom. Idempotent. Safe to re-run. Source is [`install.sh`](install.sh) in this repo.
 
 Then:
 
@@ -135,7 +135,7 @@ After the last command you talk to the agent from Telegram. You don't touch the 
 ### Already have node?
 
 ```bash
-npm install -g @anthropic-ai/claude-code switchroom-ai
+npm install -g @anthropic-ai/claude-code switchroom
 switchroom setup
 ```
 

--- a/install.sh
+++ b/install.sh
@@ -2,7 +2,7 @@
 # Switchroom installer.
 #
 # Bootstraps a fresh Ubuntu box to run switchroom agents:
-# apt deps, bun, node 22 via nvm, claude CLI, switchroom-ai.
+# apt deps, bun, node 22 via nvm, claude CLI, switchroom.
 # Does NOT configure anything — run `switchroom setup` after.
 #
 # Usage:
@@ -37,7 +37,7 @@ need_sudo() {
 printf '%s\n' "$BOLD"
 cat <<'BANNER'
   Switchroom installer
-  Bootstraps bun, node, claude CLI, and switchroom-ai.
+  Bootstraps bun, node, claude CLI, and switchroom.
 BANNER
 printf '%s\n' "$RESET"
 
@@ -112,10 +112,10 @@ if [ "$need_node_install" = "1" ]; then
   ok "node installed ($(node -v))"
 fi
 
-# ---- claude CLI + switchroom-ai ----
+# ---- claude CLI + switchroom ----
 
-log "Installing @anthropic-ai/claude-code and switchroom-ai globally via npm"
-npm install -g --silent @anthropic-ai/claude-code switchroom-ai
+log "Installing @anthropic-ai/claude-code and switchroom globally via npm"
+npm install -g --silent @anthropic-ai/claude-code switchroom
 ok "CLIs installed"
 
 have claude     || warn "claude not on PATH — open a new shell or run: export PATH=\"$(npm prefix -g)/bin:\$PATH\""

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "switchroom-ai",
-  "version": "0.4.0",
+  "name": "switchroom",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "switchroom-ai",
-      "version": "0.4.0",
+      "name": "switchroom",
+      "version": "0.5.0",
       "license": "MIT",
       "workspaces": [
         "telegram-plugin"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "switchroom-ai",
-  "version": "0.7.2",
+  "name": "switchroom",
+  "version": "0.5.0",
   "description": "Run Claude Code 24/7 on your Claude Pro/Max subscription over Telegram. Open-source alternative to OpenClaw and NanoClaw — no API keys, no Docker.",
   "type": "module",
   "bin": {

--- a/scripts/switchroom-cli-wrapper.sh
+++ b/scripts/switchroom-cli-wrapper.sh
@@ -3,7 +3,7 @@
 # switchroom-cli-wrapper.sh — run the switchroom CLI via bun, not node.
 #
 # Context: the packaged `switchroom` binary installed by `bun install -g
-# switchroom-ai` has `#!/usr/bin/env node` as its shebang. On hosts that
+# switchroom` has `#!/usr/bin/env node` as its shebang. On hosts that
 # run bun but not node (which is switchroom's documented runtime), every
 # invocation of the binary ENOENTs silently.
 #

--- a/skills/switchroom-health/SKILL.md
+++ b/skills/switchroom-health/SKILL.md
@@ -89,7 +89,7 @@ For common failures, give the exact fix:
 
 | Problem | Fix |
 |---------|-----|
-| `switchroom: command not found` | `npm install -g switchroom-ai` |
+| `switchroom: command not found` | `npm install -g switchroom` |
 | Per-agent auth expired (slot model) | `switchroom auth login <agent>` |
 | Account expired (new model — `auth account list` shows red ✗) | `switchroom auth refresh-accounts` (one tick); if no refresh-token, the account needs re-adding |
 | Account quota-exhausted (yellow ⊘ in `auth account list`) | Auto-fallback handles it if the agent has multiple accounts; otherwise wait for the reset window or `switchroom auth enable <other-account> <agent>` |

--- a/skills/switchroom-manage/SKILL.md
+++ b/skills/switchroom-manage/SKILL.md
@@ -67,7 +67,7 @@ Verify with `switchroom auth account list` — shows accounts, which agents use 
 ## Behavior
 
 1. Run the matching `switchroom` command using the Bash tool.
-2. If the command fails with "command not found", tell the user that `switchroom` is not installed or not on PATH and suggest running `npm install -g switchroom-ai` or checking their installation.
+2. If the command fails with "command not found", tell the user that `switchroom` is not installed or not on PATH and suggest running `npm install -g switchroom` or checking their installation.
 3. Format the output cleanly for the user. For list commands, present results as a table or bulleted list. For start/stop/restart, confirm the action taken.
 4. If the user just types `/switchroom` with no subcommand, show this help summary:
 

--- a/skills/switchroom-status/scripts/status.sh
+++ b/skills/switchroom-status/scripts/status.sh
@@ -13,7 +13,7 @@ RESET='\033[0m'
 
 if ! command -v switchroom &>/dev/null; then
   echo "ERROR: switchroom not found on PATH"
-  echo "Install: npm install -g switchroom-ai"
+  echo "Install: npm install -g switchroom"
   exit 1
 fi
 

--- a/src/agents/reconcile-default-skills.ts
+++ b/src/agents/reconcile-default-skills.ts
@@ -49,7 +49,7 @@ export interface AgentSkillReconcileResult {
  * Switchroom package. The pool is shipped alongside the dist/ output —
  * see `package.json` "files" — so this resolves correctly whether
  * Switchroom is running from source (`bun run dev`) or from a
- * globally installed copy under `node_modules/switchroom-ai/`.
+ * globally installed copy under `node_modules/switchroom/`.
  *
  * Exposed for tests so they can override the pool location with a tmpdir.
  */

--- a/src/agents/systemd.ts
+++ b/src/agents/systemd.ts
@@ -293,7 +293,7 @@ export function resolveGatewayUnitName(
  * /reconcile, etc.).
  *
  * Historically we pointed at `~/.bun/bin/switchroom` (installed by
- * `bun install -g switchroom-ai`). That file has `#!/usr/bin/env node`
+ * `bun install -g switchroom`). That file has `#!/usr/bin/env node`
  * as its shebang, so on bun-only hosts without node on PATH the binary
  * ENOENTs silently and every gateway CLI invocation fails with no
  * Telegram-facing signal (see reference/restart-and-know-what-im-running.md
@@ -351,7 +351,7 @@ export function generateGatewayUnit(stateDir: string, agentName: string, adminEn
   const pluginDir = resolve(import.meta.dirname, "../../telegram-plugin");
   // Prefer the bundled `dist/gateway/gateway.js` (#634 strategic
   // packaging fix) — it has all `src/` cross-imports inlined, so a
-  // fresh `npm i -g switchroom-ai` install runs without needing the
+  // fresh `npm i -g switchroom` install runs without needing the
   // workspace's `src/` tree on disk. Falls back to the .ts source for
   // dev workspaces that haven't built yet (or the rare stale-dist
   // race where `dist/` was wiped without a rebuild). The fallback

--- a/src/build-info.ts
+++ b/src/build-info.ts
@@ -2,8 +2,8 @@
 // Tracked in git so `tsc --noEmit` works on a fresh clone before `npm run build`.
 // Values are refreshed every time `npm run build` runs.
 
-export const VERSION: string = "0.7.2";
-export const COMMIT_SHA: string | null = "6a4ec1e4";
-export const COMMIT_DATE: string | null = "2026-05-06T13:18:17+10:00";
-export const LATEST_PR: number | null = 746;
-export const COMMITS_AHEAD_OF_TAG: number | null = 0;
+export const VERSION: string = "0.5.0";
+export const COMMIT_SHA: string | null = "80f3f2b6";
+export const COMMIT_DATE: string | null = "2026-05-06T14:47:22+10:00";
+export const LATEST_PR: number | null = 747;
+export const COMMITS_AHEAD_OF_TAG: number | null = 1;

--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -32,7 +32,7 @@ const RESTART_SETTLE_TIMEOUT_MS = 30_000;
  *
  * Strategy:
  *   1. Walk up from this source file looking for a package.json with
- *      `"name": "switchroom-ai"` and a `.git` sibling. This handles both `bun
+ *      `"name": "switchroom"` and a `.git` sibling. This handles both `bun
  *      link`-installed and direct-checkout invocations.
  *   2. Fall back to `realpath $(command -v switchroom)` and walk up from there.
  *
@@ -46,7 +46,7 @@ function locateSwitchroomInstallDir(): string | null {
     if (existsSync(pkgPath)) {
       try {
         const pkg = JSON.parse(readFileSync(pkgPath, "utf-8"));
-        if (pkg.name === "switchroom-ai" && existsSync(join(dir, ".git"))) {
+        if (pkg.name === "switchroom" && existsSync(join(dir, ".git"))) {
           return dir;
         }
       } catch { /* ignore */ }

--- a/src/cli/version.ts
+++ b/src/cli/version.ts
@@ -74,7 +74,7 @@ function locateSwitchroomInstallDir(): string | null {
     if (existsSync(pkgPath)) {
       try {
         const pkg = JSON.parse(readFileSync(pkgPath, "utf-8"));
-        if (pkg.name === "switchroom-ai" && existsSync(join(dir, ".git"))) {
+        if (pkg.name === "switchroom" && existsSync(join(dir, ".git"))) {
           return dir;
         }
       } catch { /* ignore */ }

--- a/tests/systemd.test.ts
+++ b/tests/systemd.test.ts
@@ -387,7 +387,7 @@ describe("generateGatewayUnit", () => {
   it("references the bundled gateway dist when present, .ts fallback otherwise (#634)", () => {
     // Strategic packaging fix: the systemd unit prefers
     // `telegram-plugin/dist/gateway/gateway.js` because the npm package
-    // ships dist (so a fresh `bun add -g switchroom-ai` install runs
+    // ships dist (so a fresh `bun add -g switchroom` install runs
     // without needing the workspace's `src/` tree). Falls back to the
     // .ts source for dev workspaces that haven't built yet.
     //


### PR DESCRIPTION
## Summary

Renames the npm package from `switchroom-ai` to `switchroom` and resets the version to **0.5.0** — the first release on the new package name. This is the consolidation of today's tmux-default work (PRs #738 / #740 / #742 / #743 + preflight #745 + bundling #747) into one disciplined first cut on the new name.

## Why

- `switchroom-ai` was always a placeholder driven by npm name availability. The org / repo / brand is `switchroom`; the package name is now too.
- Today's tmux-default pipeline (#725 PR-1 → PR-4) shipped under `switchroom-ai@0.7.0` / `0.7.1` / `0.7.2` as a flurry of point releases that included a regression (#745) and a missing dist artifact (#747). Rather than carry that messy tag history into the new package, we re-cut the work as a single clean v0.5.0 under the new name.

## Version reset

- Old: `switchroom-ai@0.7.2`
- New: `switchroom@0.5.0`
- The 25 prior `switchroom-ai` tags are documentation-only and will be cleaned up out-of-band after this PR merges. Historical CHANGELOG entries (v0.6.x and below) keep their `switchroom-ai` references verbatim — that's accurate history.

## Files changed (16)

- `package.json` — name + version
- `package-lock.json` — root entries (the `@switchroom-ai/telegram-plugin` scoped sub-entry is intentionally untouched; it's a separate package)
- `install.sh`, `README.md`, `CLAUDE.md` — install commands and prose
- `CHANGELOG.md` — collapses v0.7.0 + v0.7.2 into a single new v0.5.0 entry at the top
- `src/cli/version.ts`, `src/cli/update.ts` — install-dir locator now matches `pkg.name === "switchroom"`
- `src/agents/systemd.ts`, `src/agents/reconcile-default-skills.ts`, `scripts/switchroom-cli-wrapper.sh`, `tests/systemd.test.ts` — comments referencing the package name
- `skills/switchroom-{health,manage,status}/...` — install-help strings
- `src/build-info.ts` — regenerated by build

## Out of scope (intentionally not touched)

- `@switchroom-ai/telegram-plugin` and any `@switchroom-ai/*` scoped references — separate npm package, separate lifecycle
- Git tag cleanup — separate operation after merge
- npm publish — separate step
- `bun.lock` workspace `name` field still reads `clerk-ai` (historic drift, unrelated to this rename; bun refused to rewrite it on reinstall — follow-up)

## Test plan

- [x] `bunx tsc --noEmit` clean
- [x] `npm run build` succeeds; `dist/cli/switchroom.js` contains zero `switchroom-ai` references
- [x] `bunx vitest run` — all 314 test files pass (5026 tests)
- [x] `npm run lint` clean
- [x] `node -e 'console.log(require("./package.json").name, require("./package.json").version)'` prints `switchroom 0.5.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)