### PR TITLE
fix: autoaccept new dev-channels prompt + reconcile systemd-unit drift

### DIFF
--- a/bin/autoaccept.exp
+++ b/bin/autoaccept.exp
@@ -34,13 +34,36 @@ expect {
         # spawned shell. Without this the loop hangs forever and expect
         # owns stdin, dropping any injected keystrokes.
     }
+    -re {Loading.{1,30}development.{1,30}channels} {
+        # NEW dev-channels prompt wording (Claude Code mid-2026+):
+        #   WARNING: Loading development channels
+        #   ❯ 1. I am using this for local development
+        #     2. Exit
+        # Option 1 ("local development") is already highlighted, so just
+        # press Enter — no Down keystroke needed. Tightly scoped to the
+        # literal "Loading … development channels" warning header so we
+        # don't over-match anywhere else.
+        sleep 0.5
+        send "\r"
+        exp_continue
+    }
+    -re {using this for local development} {
+        # Belt-and-suspenders for the new prompt: match on the option-row
+        # text in case the WARNING header has scrolled out of the capture
+        # window. Same scoping discipline — "local development" is unique
+        # to this prompt and won't appear in per-tool confirmations.
+        sleep 0.5
+        send "\r"
+        exp_continue
+    }
     -re {I.{0,5}accept.{0,80}development.{0,10}channels} {
-        # Dev-channels acknowledgement — shown once per machine when
-        # --dangerously-load-development-channels is first used. Tightly
-        # scoped to the literal "development channels" phrase to avoid
-        # over-matching per-tool confirmations that start with "Yes, I
-        # accept" e.g. "Yes, I accept this file edit." Those must fall
-        # through to the plugin's permission_request flow.
+        # LEGACY dev-channels acknowledgement — old wording before the
+        # 2026 TUI rename ("Yes, I accept the use of development channels").
+        # Kept as a fallback for older Claude Code releases. Tightly scoped
+        # to the literal "development channels" phrase to avoid over-matching
+        # per-tool confirmations that start with "Yes, I accept" e.g.
+        # "Yes, I accept this file edit." Those must fall through to the
+        # plugin's permission_request flow.
         sleep 0.5
         send "\033\[B\r"
         exp_continue

--- a/src/agents/autoaccept.ts
+++ b/src/agents/autoaccept.ts
@@ -78,14 +78,36 @@ export interface AutoacceptResult {
 // is true (one-release rollback knob).
 export const PROMPTS: PromptRule[] = [
   {
-    // Dev-channels acknowledgement — shown once per machine when
-    // --dangerously-load-development-channels is first used. Tightly
-    // scoped to "development channels" to avoid over-matching per-tool
-    // confirmations like "Yes, I accept this file edit." (those must
-    // fall through to the plugin's permission_request flow).
+    // NEW dev-channels prompt wording (Claude Code mid-2026+):
+    //   WARNING: Loading development channels
+    //   ❯ 1. I am using this for local development
+    //     2. Exit
+    // Option 1 is already highlighted, so just Enter — no Down needed.
+    // Tightly scoped to "Loading … development channels" so we don't
+    // over-match anywhere else.
+    name: "dev-channels-loading",
+    match: /Loading.{1,30}development.{1,30}channels/,
+    keys: ["Enter"],
+  },
+  {
+    // Belt-and-suspenders for the new prompt: match on the option-row
+    // text in case the WARNING header has scrolled past the capture
+    // window. "local development" is unique to this prompt and won't
+    // appear in per-tool confirmations.
+    name: "dev-channels-local",
+    match: /using this for local development/,
+    keys: ["Enter"],
+  },
+  {
+    // LEGACY dev-channels acknowledgement — old wording before the 2026
+    // TUI rename ("Yes, I accept the use of development channels"). Kept
+    // as a fallback for older Claude Code releases. Tightly scoped to
+    // "development channels" to avoid over-matching per-tool confirmations
+    // like "Yes, I accept this file edit." (those must fall through to
+    // the plugin's permission_request flow).
     name: "dev-channels",
     match: /I.{0,5}accept.{0,80}development.{0,10}channels/,
-    // Down + Enter — selects the second option (the "I accept" one).
+    // Down + Enter — selects the second option (the legacy "I accept" one).
     keys: ["Down", "Enter"],
   },
   {

--- a/src/cli/agent.ts
+++ b/src/cli/agent.ts
@@ -524,11 +524,32 @@ export interface ReconcileAndRestartOpts {
  * and every restart picks them up without the operator having to
  * remember to run `switchroom systemd install`.
  */
-export function regenerateSystemdUnitsForAgent(
+/**
+ * Pure planning function — given resolved config, decide which systemd
+ * units (agent + optional gateway) should exist for an agent and whether
+ * each one's content drifts from disk.
+ *
+ * No fs writes, no daemon-reload. Split out from
+ * `regenerateSystemdUnitsForAgent` so unit tests can drive the decision
+ * logic directly without scribbling on the real ~/.config/systemd/user
+ * dir or shelling out to systemctl. The `readUnit` test seam lets tests
+ * inject canned on-disk content per path.
+ */
+export interface UnitDriftRecord {
+  unitName: string;
+  unitPath: string;
+  desired: string;
+  current: string;
+  drifted: boolean;
+}
+
+export function planAgentSystemdUnits(
   name: string,
   config: SwitchroomConfig,
   agentsDir: string,
-): string[] {
+  readUnit: (path: string) => string = (p) =>
+    existsSync(p) ? readFileSync(p, "utf-8") : "",
+): UnitDriftRecord[] {
   const agentConfig = config.agents[name];
   if (!agentConfig) return [];
 
@@ -538,35 +559,76 @@ export function regenerateSystemdUnitsForAgent(
 
   const resolved = resolveAgentConfig(config.defaults, config.profiles, agentConfig);
   const timezone = resolveTimezone(config, resolved);
+  // Without resolving these flags here, generateUnit() defaulted both to
+  // false, so a legacy_pty:true agent would render the tmux unit on every
+  // reconcile pass — disagreeing with what installAllUnits writes and
+  // ping-ponging the unit file. Mirror what installAllUnits does so the
+  // drift comparison below answers the right question.
+  const legacyPty = resolved.experimental?.legacy_pty === true;
+  const legacyAutoacceptExpect =
+    resolved.experimental?.legacy_autoaccept_expect === true;
 
-  const changed: string[] = [];
+  const records: UnitDriftRecord[] = [];
 
-  const desiredUnit = generateUnit(name, agentDir, useAutoaccept, gwName, timezone);
+  const desiredUnit = generateUnit(
+    name,
+    agentDir,
+    useAutoaccept,
+    gwName,
+    timezone,
+    legacyPty,
+    legacyAutoacceptExpect,
+  );
   const agentUnitPath = unitFilePath(name);
-  const currentUnit = existsSync(agentUnitPath) ? readFileSync(agentUnitPath, "utf-8") : "";
-  if (currentUnit !== desiredUnit) {
-    installUnit(name, desiredUnit);
-    changed.push(agentUnitPath);
-  }
+  const currentUnit = readUnit(agentUnitPath);
+  records.push({
+    unitName: name,
+    unitPath: agentUnitPath,
+    desired: desiredUnit,
+    current: currentUnit,
+    drifted: currentUnit !== desiredUnit,
+  });
 
   if (useAutoaccept && gwName) {
     const stateDir = resolve(agentDir, "telegram");
     const adminEnabled = resolved.admin === true;
-    const desiredGw = generateGatewayUnit(stateDir, name, adminEnabled);
+    // Pass legacyPty so the gateway env (SWITCHROOM_TMUX_SUPERVISOR=1) is
+    // stamped consistently with installAllUnits — without it, drift detection
+    // would falsely flag (or skip) gateway-unit changes whenever legacy_pty
+    // toggled.
+    const desiredGw = generateGatewayUnit(stateDir, name, adminEnabled, legacyPty);
     const gwUnitPath = unitFilePath(gwName);
-    const currentGw = existsSync(gwUnitPath) ? readFileSync(gwUnitPath, "utf-8") : "";
-    if (currentGw !== desiredGw) {
-      installUnit(gwName, desiredGw);
-      changed.push(gwUnitPath);
-    }
+    const currentGw = readUnit(gwUnitPath);
+    records.push({
+      unitName: gwName,
+      unitPath: gwUnitPath,
+      desired: desiredGw,
+      current: currentGw,
+      drifted: currentGw !== desiredGw,
+    });
   }
 
+  return records;
+}
+
+export function regenerateSystemdUnitsForAgent(
+  name: string,
+  config: SwitchroomConfig,
+  agentsDir: string,
+): string[] {
+  const plan = planAgentSystemdUnits(name, config, agentsDir);
+  const changed: string[] = [];
+  for (const rec of plan) {
+    if (rec.drifted) {
+      installUnit(rec.unitName, rec.desired);
+      changed.push(rec.unitPath);
+    }
+  }
   if (changed.length > 0) {
     // Re-read disk so systemd picks up the new ExecStart / Environment /
     // EnvironmentFile directives before the next `restart` fires.
     daemonReload();
   }
-
   return changed;
 }
 
@@ -1488,20 +1550,35 @@ export function registerAgentCommand(program: Command): void {
               configPath,
               { preserveClaudeMd: opts.preserveClaudeMd },
             );
-            if (result.changes.length === 0) {
+            // Also regenerate systemd units so a yaml change that affects
+            // which unit template gets rendered (legacy_pty toggle, fresh
+            // agent that should default to tmux but currently has a stale
+            // legacy unit on disk, etc.) actually triggers regen + daemon-
+            // reload instead of falsely reporting "already in sync". This
+            // mirrors what reconcileAndRestartAgent already does for the
+            // restart-bearing path; without it the standalone `reconcile`
+            // CLI verb misses systemd-unit drift entirely.
+            const unitChanges = regenerateSystemdUnitsForAgent(n, config, agentsDir);
+            const allChanges = [...result.changes, ...unitChanges];
+            if (allChanges.length === 0) {
               console.log(chalk.gray(`  ${n}: already in sync`));
             } else {
               agentsTouched++;
-              totalChanges += result.changes.length;
-              console.log(chalk.green(`  ${n}: reconciled (${result.changes.length} file${result.changes.length === 1 ? "" : "s"})`));
+              totalChanges += allChanges.length;
+              console.log(chalk.green(`  ${n}: reconciled (${allChanges.length} file${allChanges.length === 1 ? "" : "s"})`));
 
               // Categorize and display changes by reload semantics
               const semantics = result.changesBySemantics;
               if (semantics) {
-                const { hot, staleTillRestart, restartRequired } = semantics;
+                const { hot, staleTillRestart } = semantics;
+                // Treat changed systemd units as restart-required: an
+                // ExecStart / Type / EnvironmentFile flip only takes effect
+                // after `systemctl restart`. daemon-reload alone does not
+                // re-spawn the running process under the new unit.
+                const restartRequired = [...semantics.restartRequired, ...unitChanges];
 
                 if (restartRequired.length > 0) {
-                  console.log(chalk.yellow("\n  Changed (restart required — soul/MCP/settings/launch):"));
+                  console.log(chalk.yellow("\n  Changed (restart required — soul/MCP/settings/launch/systemd):"));
                   for (const f of restartRequired) {
                     console.log(chalk.yellow(`    - ${f}`));
                   }
@@ -1544,13 +1621,17 @@ export function registerAgentCommand(program: Command): void {
             }
 
             // Determine whether to restart: explicit flag, graceful flag, or auto-restart
-            // triggered by restart-required changes (soul fields, MCP, settings, etc.)
+            // triggered by restart-required changes (soul fields, MCP, settings,
+            // or a regenerated systemd unit). Unit drift counts as restart-required
+            // because daemon-reload alone does not re-spawn the running process
+            // under the new ExecStart / Type.
             const changesBySemantics = result.changesBySemantics;
             const autoRestartNeeded =
               !opts.noRestart &&
-              changesBySemantics !== undefined &&
-              changesBySemantics.restartRequired.length > 0;
-            const shouldRestart = (opts.restart || opts.gracefulRestart || autoRestartNeeded) && result.changes.length > 0;
+              ((changesBySemantics !== undefined &&
+                changesBySemantics.restartRequired.length > 0) ||
+                unitChanges.length > 0);
+            const shouldRestart = (opts.restart || opts.gracefulRestart || autoRestartNeeded) && allChanges.length > 0;
 
             if (shouldRestart) {
               try {

--- a/tests/autoaccept.test.ts
+++ b/tests/autoaccept.test.ts
@@ -222,6 +222,18 @@ describe("PROMPTS — regex sanity (translated from bin/autoaccept.exp)", () => 
       expected: "dev-channels",
     },
     {
+      // NEW prompt wording (mid-2026+): WARNING header.
+      text: "WARNING: Loading development channels",
+      expected: "dev-channels-loading",
+    },
+    {
+      // NEW prompt wording (mid-2026+): option-row text. The header
+      // matcher is preferred (defined first) but if scrollback hides it,
+      // the option-row matcher catches the prompt.
+      text: "❯ 1. I am using this for local development",
+      expected: "dev-channels-local",
+    },
+    {
       text: "Anthropic API   /   Bedrock   /   Vertex",
       expected: "provider",
     },
@@ -244,6 +256,83 @@ describe("PROMPTS — regex sanity (translated from bin/autoaccept.exp)", () => 
     const text = "Yes, I accept this file edit";
     const hit = PROMPTS.find((p) => p.match.test(text));
     expect(hit).toBeUndefined();
+  });
+
+  it("does NOT match other 'accept ... development' phrasings that aren't the dev-channels prompt", () => {
+    // Defensive: confirm the new matchers don't fire on tangentially
+    // related strings. Per-tool confirmations and any other dialog must
+    // remain the security boundary.
+    const negatives = [
+      "Yes, accept this development file edit",
+      "Allow Claude to make development changes to this file?",
+      "I am using this for production",
+    ];
+    for (const text of negatives) {
+      const hit = PROMPTS.find((p) => p.match.test(text));
+      expect(hit, `unexpectedly matched: ${text}`).toBeUndefined();
+    }
+  });
+});
+
+describe("runAutoaccept — new dev-channels prompt dispatch", () => {
+  // Re-declare the local helper here so this block can drive captures
+  // independent of the module-level setup.
+  function setupTmuxLocal(captureScreens: string[]) {
+    const sentKeys: string[][] = [];
+    let captureIdx = 0;
+    mockedExec.mockImplementation((_bin: string, args: readonly string[]) => {
+      const subcmd = args[2];
+      if (subcmd === "capture-pane") {
+        const next = captureIdx < captureScreens.length
+          ? captureScreens[captureIdx]
+          : "";
+        captureIdx++;
+        return Buffer.from(next, "utf8");
+      }
+      if (subcmd === "send-keys") {
+        sentKeys.push([...args.slice(5)]);
+        return Buffer.from("");
+      }
+      return Buffer.from("");
+    });
+    return { sentKeys };
+  }
+
+  it("fires the new 'Loading development channels' prompt with Enter only (no Down)", async () => {
+    const { sentKeys } = setupTmuxLocal([
+      "WARNING: Loading development channels\n❯ 1. I am using this for local development\n  2. Exit",
+      "",
+    ]);
+    const res = await runAutoaccept({
+      agentName: "a",
+      idleTimeoutMs: 1,
+      pollIntervalMs: 0,
+      now: () => 0,
+      sleep: () => {},
+      maxPolls: 4,
+    });
+    // The header matcher is defined first and wins.
+    expect(res.fired).toContain("dev-channels-loading");
+    // Critical: keys are Enter only — no Down keystroke would land on the
+    // "Exit" option and kill claude on first launch.
+    expect(sentKeys[0]).toEqual(["Enter"]);
+  });
+
+  it("still fires the legacy dev-channels prompt with Down+Enter for older Claude Code releases", async () => {
+    const { sentKeys } = setupTmuxLocal([
+      "Yes, I accept the use of development channels",
+      "",
+    ]);
+    const res = await runAutoaccept({
+      agentName: "a",
+      idleTimeoutMs: 1,
+      pollIntervalMs: 0,
+      now: () => 0,
+      sleep: () => {},
+      maxPolls: 4,
+    });
+    expect(res.fired).toContain("dev-channels");
+    expect(sentKeys[0]).toEqual(["Down", "Enter"]);
   });
 });
 

--- a/tests/reconcile-systemd-drift.test.ts
+++ b/tests/reconcile-systemd-drift.test.ts
@@ -1,0 +1,174 @@
+// Bug 2 regression — reconcile must include systemd-unit drift in its
+// "in sync" decision. Symptom: an operator added a fresh agent block to
+// switchroom.yaml (no explicit experimental.legacy_pty), expecting the
+// fleet default of tmux supervisor. `switchroom agent reconcile <agent>`
+// reported "already in sync" while the on-disk unit was the LEGACY one
+// (Type=simple, script -qfc) — so `restart` kept booting the agent under
+// the wrong supervisor. Forcing `switchroom systemd install` regenerated
+// the correct tmux unit. Root cause: the standalone `agent reconcile`
+// CLI verb wasn't comparing the rendered systemd unit to disk; it only
+// looked at in-agent-dir files (settings.json, .mcp.json, start.sh, ...).
+//
+// The decision logic is split out of `regenerateSystemdUnitsForAgent`
+// into the pure `planAgentSystemdUnits` so we can drive it without
+// shelling out to systemctl or touching ~/.config/systemd/user.
+
+import { describe, it, expect } from "vitest";
+import { planAgentSystemdUnits } from "../src/cli/agent.js";
+import type { AgentConfig, SwitchroomConfig } from "../src/config/schema.js";
+
+function makeConfig(agents: Record<string, AgentConfig>): SwitchroomConfig {
+  return {
+    switchroom: {
+      version: 1,
+      agents_dir: "~/.switchroom/agents",
+      skills_dir: "~/.switchroom/skills",
+    },
+    telegram: { bot_token: "vault:telegram-bot-token" },
+    defaults: {},
+    agents,
+  } as unknown as SwitchroomConfig;
+}
+
+describe("planAgentSystemdUnits — legacy_pty drives unit content", () => {
+  it("legacy_pty:true vs unset produce DIFFERENT effective agent units", () => {
+    const tmuxAgent: AgentConfig = {
+      soul: "test soul",
+    } as unknown as AgentConfig;
+    const legacyAgent: AgentConfig = {
+      soul: "test soul",
+      experimental: { legacy_pty: true },
+    } as unknown as AgentConfig;
+
+    // Disk reads return "" — i.e. nothing on disk. Both will report
+    // drifted, but with DIFFERENT desired content. That difference is
+    // what the bug-2 fix has to detect.
+    const tmuxPlan = planAgentSystemdUnits(
+      "alpha",
+      makeConfig({ alpha: tmuxAgent }),
+      "/agents",
+      () => "",
+    );
+    const legacyPlan = planAgentSystemdUnits(
+      "alpha",
+      makeConfig({ alpha: legacyAgent }),
+      "/agents",
+      () => "",
+    );
+
+    const tmuxUnit = tmuxPlan[0].desired;
+    const legacyUnit = legacyPlan[0].desired;
+
+    expect(tmuxUnit).not.toBe(legacyUnit);
+    // Spot-check the structural differences that would matter to an
+    // operator debugging "wrong supervisor on disk".
+    expect(tmuxUnit).toContain("Type=forking");
+    expect(tmuxUnit).toContain("/usr/bin/tmux");
+    expect(legacyUnit).toContain("Type=simple");
+    expect(legacyUnit).toContain("/usr/bin/script -qfc");
+  });
+
+  it("detects drift when on-disk unit is legacy but resolved config is tmux (the reported bug)", () => {
+    // Resolved config: tmux (no legacy_pty flag set).
+    const config = makeConfig({
+      alpha: { soul: "test" } as unknown as AgentConfig,
+    });
+
+    // On-disk unit: render the legacy variant by planning with a synthetic
+    // legacy config, then feed THAT content as the "current" disk read
+    // for the tmux planning call. This simulates the production scenario:
+    // operator changed yaml from legacy_pty:true to (omitted), reconcile
+    // sees tmux as the desired but legacy on disk.
+    const legacyConfig = makeConfig({
+      alpha: {
+        soul: "test",
+        experimental: { legacy_pty: true },
+      } as unknown as AgentConfig,
+    });
+    const legacyOnDisk = planAgentSystemdUnits(
+      "alpha",
+      legacyConfig,
+      "/agents",
+      () => "",
+    )[0].desired;
+
+    const plan = planAgentSystemdUnits(
+      "alpha",
+      config,
+      "/agents",
+      (_path) => legacyOnDisk,
+    );
+
+    // plan[0] is the agent unit; plan[1] (if present) is the gateway.
+    expect(plan.length).toBeGreaterThanOrEqual(1);
+    expect(plan[0].unitName).toBe("alpha");
+    expect(plan[0].drifted).toBe(true);
+    expect(plan[0].current).toContain("Type=simple"); // legacy on disk
+    expect(plan[0].desired).toContain("Type=forking"); // tmux desired
+  });
+
+  it("reports NO drift when on-disk unit matches resolved config (steady state)", () => {
+    const config = makeConfig({
+      alpha: { soul: "test" } as unknown as AgentConfig,
+    });
+    // First pass: figure out what the desired tmux unit looks like.
+    const desiredTmux = planAgentSystemdUnits(
+      "alpha",
+      config,
+      "/agents",
+      () => "",
+    )[0].desired;
+
+    // Second pass: feed that same content back as the on-disk content.
+    // Drift detection should now report no change.
+    const plan = planAgentSystemdUnits(
+      "alpha",
+      config,
+      "/agents",
+      () => desiredTmux,
+    );
+
+    expect(plan[0].drifted).toBe(false);
+  });
+
+  it("flips back to drift when legacy_pty toggles from true to unset", () => {
+    // The original installAllUnits run wrote the legacy unit (operator had
+    // experimental.legacy_pty:true at the time). Operator then removed the
+    // flag from yaml — now we should detect that the disk is stale.
+    const legacyConfig = makeConfig({
+      alpha: {
+        soul: "test",
+        experimental: { legacy_pty: true },
+      } as unknown as AgentConfig,
+    });
+    const tmuxConfig = makeConfig({
+      alpha: { soul: "test" } as unknown as AgentConfig,
+    });
+
+    const legacyOnDisk = planAgentSystemdUnits(
+      "alpha",
+      legacyConfig,
+      "/agents",
+      () => "",
+    )[0].desired;
+
+    // Sanity: with legacy still in yaml, no drift against the legacy
+    // on-disk unit.
+    const stillLegacy = planAgentSystemdUnits(
+      "alpha",
+      legacyConfig,
+      "/agents",
+      () => legacyOnDisk,
+    );
+    expect(stillLegacy[0].drifted).toBe(false);
+
+    // Now: yaml flipped to tmux, disk still has legacy. Must drift.
+    const flipped = planAgentSystemdUnits(
+      "alpha",
+      tmuxConfig,
+      "/agents",
+      () => legacyOnDisk,
+    );
+    expect(flipped[0].drifted).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Two production bugs hit on a real host today (finn agent stuck in watchdog-restart loop). Both fixed independently.

### Bug 1 — autoaccept doesn't dismiss the new dev-channels prompt
Claude Code recently changed the wording of the \`--dangerously-load-development-channels\` confirmation. New menu reads \`1. I am using this for local development / 2. Exit\` (was \`I accept ... development channels\`). Both \`bin/autoaccept.exp\` (legacy) and \`src/agents/autoaccept.ts\` (default tmux poller) now recognize both wordings. Agents launched with the flag were hanging at the menu, bridge never connecting, watchdog killing every ~12 min.

### Bug 2 — \`agent reconcile\` doesn't detect systemd-unit drift
\`switchroom agent reconcile <name>\` reported \"already in sync\" while on-disk unit was the legacy \`script -qfc\` ExecStart even when resolved config should have produced a tmux \`Type=forking\` unit. Two root causes:

1. The \`reconcile\` CLI verb never compared rendered systemd unit to disk; only \`restart\` did.
2. \`regenerateSystemdUnitsForAgent\` called \`generateUnit()\` without resolving \`legacyPty\` / \`legacyAutoacceptExpect\` from agent config.

Refactored \`regenerateSystemdUnitsForAgent\` into a pure \`planAgentSystemdUnits\` (test seam) + imperative wrapper, resolves legacy flags from merged config, and wires unit drift into the reconcile change total. Auto-restart fires on drift unless \`--no-restart\`.

## Test plan

- [x] \`bun test tests/autoaccept.test.ts\` — 21 pass
- [x] \`bun test tests/reconcile-systemd-drift.test.ts\` — 4 pass (new)
- [x] \`bun test tests/systemd.test.ts\` — no regressions
- [x] Manual: hot-patched on host, finn boots cleanly under tmux + bridge connects
- [x] Negative test: \`Yes, I accept this file edit\` still NOT matched (security boundary preserved)

## Non-blocking follow-ups (out of scope)

- \`agent create\` has the same legacy_pty resolution bug at \`src/cli/agent.ts:1023, 1035\` — fresh agents with \`experimental.legacy_pty: true\` write wrong unit until next reconcile.
- Multiple autoaccept rules can co-fire on one poll cycle (existing behavior; new rules don't make it worse).
- No defensive \`❯\` cursor cross-check before sending Enter (consistent with existing rules).

🤖 Generated with [Claude Code](https://claude.com/claude-code)