### PR TITLE
chore(bun.lock): rename workspace name clerk-ai → switchroom

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -3,7 +3,7 @@
   "configVersion": 1,
   "workspaces": {
     "": {
-      "name": "clerk-ai",
+      "name": "switchroom",
       "dependencies": {
         "@grammyjs/runner": "^2.0.3",
         "@modelcontextprotocol/sdk": "^1.0.0",


### PR DESCRIPTION
Pre-existing drift in `bun.lock` workspace name. Cosmetic, one-line. `bun install` is a no-op.