### PR TITLE
fix(web): wire dispatchConfig into webhook route (#715 follow-up)

### DIFF
--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -275,6 +275,7 @@ async function handleWebhookRoute(
       allowedSources,
       config: { secrets: agentSecrets as Partial<Record<"github" | "generic", string>> },
       agentExists: agentConfig !== undefined,
+      dispatchConfig: agentConfig?.channels?.telegram?.webhook_dispatch,
     },
     {},
   );


### PR DESCRIPTION
## Bug

`handleWebhookIngest` guards dispatch on `if (args.dispatchConfig)` (`webhook-handler.ts:428`) but `handleWebhookRoute` in `src/web/server.ts` never resolved or passed it. Result: #715 dispatch matchers in `switchroom.yaml` are silent no-ops in production — every webhook is recorded but no `claude -p` ever fires.

## Fix

One-line: pass `agentConfig?.channels?.telegram?.webhook_dispatch` through to the handler args.

## Caught by

Smoke-testing reggie's auto-review wiring on a real PR — webhook recorded, dispatch never fired. Logs showed `webhook-ingest` lines but zero `webhook-dispatch` lines.

## Test plan

- [x] `bun run lint:tsc` clean
- [x] `bun test src/web/` — 47 pass
- [ ] After merge + redeploy: open a PR on switchroom/switchroom, confirm reggie receives the dispatched DM