### PR TITLE
fix(webhook-dispatch): keep node on PATH for spawned agent processes

### DIFF
--- a/src/web/webhook-dispatch.ts
+++ b/src/web/webhook-dispatch.ts
@@ -37,10 +37,84 @@
  * ```
  */
 
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs'
+import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from 'fs'
 import { join } from 'path'
 import { homedir } from 'os'
 import { spawn } from 'child_process'
+
+/**
+ * When the parent process (typically the systemd-launched switchroom-web)
+ * was started without nvm in PATH, `node` won't resolve for spawned
+ * children — so any agent hook that uses `node /path/to/hook.mjs` exits
+ * 127 and the agent's issue sink lights up. This is invisible to the
+ * operator until the first webhook fires.
+ *
+ * Detect an nvm install (in priority order: `NVM_DIR`, `~/.nvm`) and
+ * resolve a node bin directory by reading `alias/default` first, then
+ * falling back to the lexicographically newest version directory. Returns
+ * undefined when no usable nvm install is found, in which case the caller
+ * leaves PATH untouched.
+ *
+ * Exported for tests.
+ */
+export function resolveNvmNodeBin(env: NodeJS.ProcessEnv): string | undefined {
+  const nvmDir = env.NVM_DIR ?? join(env.HOME ?? homedir(), '.nvm')
+  if (!existsSync(nvmDir)) return undefined
+
+  const versionsDir = join(nvmDir, 'versions', 'node')
+  if (!existsSync(versionsDir)) return undefined
+
+  const tryVersion = (v: string): string | undefined => {
+    const bin = join(versionsDir, v, 'bin')
+    return existsSync(join(bin, 'node')) ? bin : undefined
+  }
+
+  // Prefer the user's default alias if set.
+  const defaultAliasPath = join(nvmDir, 'alias', 'default')
+  try {
+    if (existsSync(defaultAliasPath)) {
+      const aliased = readFileSync(defaultAliasPath, 'utf-8').trim()
+      if (aliased) {
+        const bin = tryVersion(aliased.startsWith('v') ? aliased : `v${aliased}`)
+        if (bin) return bin
+      }
+    }
+  } catch {
+    // Fall through to dir scan
+  }
+
+  // Otherwise: lexicographic max across installed versions.
+  try {
+    const versions = readdirSync(versionsDir).filter((v) => v.startsWith('v')).sort()
+    for (let i = versions.length - 1; i >= 0; i--) {
+      const bin = tryVersion(versions[i])
+      if (bin) return bin
+    }
+  } catch {
+    return undefined
+  }
+
+  return undefined
+}
+
+/**
+ * Returns a copy of `env` with `node` guaranteed to be on PATH where
+ * possible. No-op when `node` already resolves via the inherited PATH or
+ * when no nvm install is present.
+ *
+ * Exported for tests.
+ */
+export function ensureNodeOnPath(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+  const path = env.PATH ?? ''
+  // Cheap pre-check: if any PATH entry already contains a node binary, no-op.
+  const existing = path.split(':').some((dir) => dir && existsSync(join(dir, 'node')))
+  if (existing) return env
+
+  const nvmBin = resolveNvmNodeBin(env)
+  if (!nvmBin) return env
+
+  return { ...env, PATH: path ? `${nvmBin}:${path}` : nvmBin }
+}
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -365,14 +439,14 @@ export function spawnAgentOneShot(
   const claudeConfigDir = join(agentDir, '.claude')
   const telegramStateDir = join(agentDir, 'telegram')
 
-  const env: NodeJS.ProcessEnv = {
+  const env: NodeJS.ProcessEnv = ensureNodeOnPath({
     ...process.env,
     FORCE_COLOR: '0',
     NO_COLOR: '1',
     CLAUDE_CONFIG_DIR: claudeConfigDir,
     SWITCHROOM_AGENT_NAME: agent,
     TELEGRAM_STATE_DIR: telegramStateDir,
-  }
+  })
 
   // Unset ANTHROPIC_API_KEY to force OAuth auth (mirrors cron script pattern).
   delete env.ANTHROPIC_API_KEY


### PR DESCRIPTION
## Bug

When the operator's switchroom-web service is launched by systemd-user without nvm bootstrapped into PATH (the common case), webhook-dispatched child processes inherit a PATH like `/home/<u>/.bun/bin:/usr/local/bin:/usr/bin:/bin` — no nvm. Hooks that invoke `node /path/to/hook.mjs` (e.g. `secret-guard-pretool.mjs`) exit 127 and the agent's issue sink starts flashing red.

## Fix

In `spawnAgentOneShot`, prepend the resolved nvm node bin to PATH when `node` isn't already on PATH:

1. Read `NVM_DIR` (fall back to `~/.nvm`).
2. Prefer `alias/default`; otherwise scan `versions/node` and pick the lex-newest.
3. No-op when node is already on PATH or nvm isn't installed.

Existing `...process.env` inheritance is preserved — this only adds one entry when needed.

## Test plan

- [x] `bun run lint:tsc` clean
- [x] `bun test src/web/ tests/webhook` — 89 pass
- [ ] After merge + redeploy: trigger a webhook; `hook:secret-guard-pretool` no longer exits 127