### PR TITLE
rfc: approval kernel — three RFCs (A bot-token, B kernel, C gdrive)

### DIFF
--- a/docs/rfcs/approval-kernel.md
+++ b/docs/rfcs/approval-kernel.md
@@ -16,9 +16,9 @@ Switchroom asks the user to approve sensitive actions through several independen
 
 Approval-shaped surfaces in the codebase today:
 
-- **Deferred-secret cards** with `vd:unlock|cancel` callbacks — `telegram-plugin/gateway/gateway.ts:5497`.
+- **Deferred-secret cards** with `vd:unlock|cancel` callbacks — `telegram-plugin/gateway/gateway.ts:5555`.
 - **Vault grants** via the `/vault grant` wizard, persisted to SQLite at `~/.switchroom/vault-grants.db` — schema in `src/vault/grants.ts`.
-- **Operator and dashboard prompts** under `op:` and `auth:` callback prefixes — `telegram-plugin/gateway/gateway.ts`.
+- **Operator and dashboard prompts** under `op:` and `auth:` callback prefixes — `telegram-plugin/gateway/gateway.ts` (callback dispatcher at `:8285`; infrastructure-prefix list at `:2304`).
 
 Adding a Google Drive MCP, then Notion, Slack, and Gmail, means adding a fresh approval surface every time unless the shape is unified. Each duplicates: callback parser, storage decision, TTL semantics, revocation command, audit trail. The user sees inconsistent UX and there is no `/revoke-all` killswitch covering everything.
 
@@ -61,20 +61,32 @@ This is a real bug fix needed for the kernel (and arguably for any long-running 
 
 ## 5. Decision storage
 
-One table, ordinary SQLite columns, no HMAC, no chains, no nonce side-table.
+Two tables in `vault-grants.db`: a **grants** table for durable decisions, and a **nonces** table that holds the per-prompt 8-hex callback request id and tracks single-use redemption. No HMAC, no chains.
 
 ```sql
 CREATE TABLE approval_decisions (
-  id                 TEXT PRIMARY KEY,    -- UUID v4
-  agent_unit         TEXT NOT NULL,       -- systemd unit, verified via peercred + verifySystemdUnit
-  scope              TEXT NOT NULL,       -- see §6
-  decision           TEXT NOT NULL,       -- allow_once | allow_always | allow_ttl | deny | deny_perm
-  ttl_expires_at     INTEGER,             -- unix-ms, NULL for non-ttl
-  granted_at         INTEGER NOT NULL,
-  granted_by_user_id INTEGER NOT NULL,    -- Telegram user_id
-  last_used_at       INTEGER,             -- for sliding-window TTL + staleness
-  revoked_at         INTEGER,
-  revoke_reason      TEXT
+  id                       TEXT PRIMARY KEY,    -- UUID v4
+  agent_unit               TEXT NOT NULL,       -- systemd unit, verified via peercred + verifySystemdUnit
+  scope                    TEXT NOT NULL,       -- see §6
+  decision                 TEXT NOT NULL,       -- allow_once | allow_always | allow_ttl | deny | deny_perm
+  ttl_expires_at           INTEGER,             -- unix-ms, NULL for non-ttl
+  granted_at               INTEGER NOT NULL,
+  granted_by_user_id       INTEGER NOT NULL,    -- Telegram user_id
+  approver_set_canonical   TEXT NOT NULL,       -- canonicalized JSON of allowFrom at grant time; see §5.1
+  last_used_at             INTEGER,             -- for sliding-window TTL + staleness
+  revoked_at               INTEGER,
+  revoke_reason            TEXT
+);
+
+CREATE TABLE approval_nonces (
+  request_id   TEXT PRIMARY KEY,    -- 8-hex from generateAskId; appears in apv:<id>:... callback_data
+  decision_id  TEXT,                -- FK into approval_decisions once a tap lands; NULL while pending
+  agent_unit   TEXT NOT NULL,
+  scope        TEXT NOT NULL,
+  why          TEXT,                -- agent-supplied "why this access" string
+  created_at   INTEGER NOT NULL,    -- unix-ms
+  expires_at   INTEGER NOT NULL,    -- unix-ms; 5-min default per §8.1
+  consumed_at  INTEGER              -- unix-ms; set atomically on first tap; subsequent taps no-op
 );
 
 CREATE TABLE approval_audit (
@@ -96,8 +108,8 @@ The "same-uid attacker writes a forged grant row directly to SQLite" attack is a
 
 A grant recorded when `allowFrom = ["U1"]` must not silently extend if `allowFrom` later becomes `["U1", "U2"]`. We don't HMAC-bind the approver set into the row, but we do compare on lookup:
 
-- Store the approver set captured at grant time alongside the row (canonicalized JSON: NFC-normalized, sorted lexicographically, no insignificant whitespace).
-- At every `lookupDecision`, re-read the current `allowFrom`, canonicalize identically, compare.
+- Store the approver set captured at grant time in the `approver_set_canonical` column (canonicalized JSON: NFC-normalized, sorted lexicographically, no insignificant whitespace).
+- At every `lookupDecision`, re-read the current `allowFrom`, canonicalize identically, compare against the row's `approver_set_canonical`.
 - If they differ: write a `drift_revoke` audit row, return no-grant, force re-prompt under the new approver set.
 - If the current set has more than one approver, all standing grants are dormant until the operator re-confirms each one.
 
@@ -133,7 +145,7 @@ apv:<8-hex request id>:<action>[:<param>]
 ```
 
 - 8-hex request id matches `generateAskId` convention.
-- Single-use enforced by an atomic `UPDATE approval_decisions SET ... WHERE id = ? AND consumed_at IS NULL` with a rowcount check. A re-tap of an already-consumed callback returns a brief "this prompt expired" toast via `answerCallbackQuery`.
+- Single-use enforced by an atomic `UPDATE approval_nonces SET consumed_at = ? WHERE request_id = ? AND consumed_at IS NULL` with a rowcount check. Only on rowcount=1 does the kernel proceed to insert/update the corresponding `approval_decisions` row. A re-tap of an already-consumed callback returns a brief "this prompt expired" toast via `answerCallbackQuery`.
 - Examples: `apv:a3f1b9c2:allow`, `apv:a3f1b9c2:ttl:1h`, `apv:a3f1b9c2:deny`.
 
 Full scope and humanized title are stored server-side keyed by request id.
@@ -152,7 +164,7 @@ The card surfaces only the common subset. Full mode set is editable via `/approv
 
 ## 8. Telegram approval card UX
 
-One shape, every surface. Built on the existing `aq:` (ask_user) primitive at `telegram-plugin/gateway/gateway.ts:8209` — that path already handles topic routing, quote-reply targeting, reaction lifecycle, and `allowFrom` enforcement. The kernel registers a new `apv:` callback handler and reuses the rest.
+One shape, every surface. Built on the existing `aq:` (ask_user) primitive at `telegram-plugin/gateway/gateway.ts:8321` — that path already handles topic routing, quote-reply targeting, reaction lifecycle, and `allowFrom` enforcement. The kernel registers a new `apv:` callback handler and reuses the rest.
 
 ### 8.1 Card states
 
@@ -191,9 +203,9 @@ The kernel calls `humanize()` before rendering but never blocks on it.
 
 ### 8.3 Patterns preserved through migration
 
-- **`perm:more` expand button** at `gateway.ts:1946` — basis of the new card's expand. Same UX shape.
-- **`vd:unlock` deferred-secret card flow** at `gateway.ts:5497` — Phase 2 migrates this surface; the inline-passphrase capture step must survive the move.
-- **`aq:` topic-routing + reaction lifecycle** at `gateway.ts:8209` — inherit, do not rebuild.
+- **`perm:more` expand button** at `gateway.ts:1980` — basis of the new card's expand. Same UX shape.
+- **`vd:unlock` deferred-secret card flow** at `gateway.ts:5555` — Phase 2 migrates this surface; the inline-passphrase capture step must survive the move.
+- **`aq:` topic-routing + reaction lifecycle** at `gateway.ts:8321` — inherit, do not rebuild.
 - **`allowFrom` enforcement on every callback** — match the existing pattern.
 
 ## 9. Audit, revocation, staleness
@@ -256,7 +268,7 @@ The vault broker is request/response. Approvals can wait up to 5 minutes for a t
 
 **Phase 1 — kernel folded into vault broker.** New `approval_decisions` and `approval_audit` tables in `vault-grants.db` (no rename), new RPC methods on `src/vault/broker/server.ts`, broaden peercred regex (§4.1), short-poll wait protocol (§10), `apv:` callback router in gateway, `/approvals list|revoke|add|stats` commands, drift revocation, plus tests matching the existing broker's coverage. **~1.5 days.**
 
-**Phase 2 — secrets as first consumer.** Migrate the deferred-secret card path (`gateway.ts:5497`) to call the kernel. Lower-traffic, validates the abstraction. Preserve the inline-passphrase capture UX. ~0.5 day.
+**Phase 2 — secrets as first consumer.** Migrate the deferred-secret card path (`gateway.ts:5555`) to call the kernel. Lower-traffic, validates the abstraction. Preserve the inline-passphrase capture UX. ~0.5 day.
 
 **Phase 3 — first MCP consumer (Google Drive).** Covered separately in **RFC C — Google Drive MCP integration**.
 

--- a/docs/rfcs/approval-kernel.md
+++ b/docs/rfcs/approval-kernel.md
@@ -1,21 +1,23 @@
 # RFC: Unified human-approval kernel
 
-Status: Draft
+Status: Draft v2
 Author: klanker (sub-agent draft)
 Date: 2026-05-06
 
 ## 1. Summary
 
-Today switchroom asks the user to approve sensitive actions through at least four independent code paths, each with its own callback grammar, storage, and UX. This RFC proposes a single approval kernel — one IPC broker, one SQLite store, one Telegram card primitive, one audit log — that all current and future surfaces (secrets, vault grants, tool/skill permission requests, Google Docs and other MCPs) plug into. The kernel is shaped on the existing `vault-broker` trust model and reuses the proven SO_PEERCRED + cgroup-derived unit identity.
+Today switchroom asks the user to approve sensitive actions through at least four independent code paths, each with its own callback grammar, storage, and UX. This RFC proposes a single approval kernel — folded into the existing **vault broker** — that all current and future surfaces (secrets, vault grants, tool/skill permission requests, Google Docs and other MCPs) plug into. One process, one socket, one ACL surface, one SQLite file, one audit log, one Telegram card primitive.
+
+The kernel is shaped on the existing `vault-broker` trust model and reuses its proven SO_PEERCRED + cgroup-derived unit identity (with the systemd cross-check that already exists at `src/vault/broker/peercred.ts:254`).
 
 ## 2. Motivation
 
-Four approval-shaped surfaces exist in the codebase right now:
+Four approval-shaped surfaces exist today:
 
-- **Deferred-secret cards** with `vd:unlock|cancel` callbacks, in-memory only — `src/gateway.ts:1304`.
-- **Vault grants** via the `/vault grant` wizard, persisted to SQLite at `~/.switchroom/vault-grants.db` — `src/vault/grants-db.ts`.
-- **Tool/Skill permission requests** via MCP `notifications/claude/channel/permission_request`, rendered as `perm:allow|deny|always` cards — `src/gateway.ts:1980`, `src/bridge.ts:451`.
-- **Operator and dashboard prompts** under the `op:` and `auth:` callback prefixes — `src/gateway.ts:8291`.
+- **Deferred-secret cards** with `vd:unlock|cancel` callbacks — `telegram-plugin/gateway/gateway.ts:5497`.
+- **Vault grants** via the `/vault grant` wizard, persisted to SQLite at `~/.switchroom/vault-grants.db` — table `vault_grants` defined at `src/vault/grants.ts:61`.
+- **Tool/Skill permission requests** via MCP `notifications/claude/channel/permission_request`, rendered as `perm:allow|deny|always` cards — `telegram-plugin/gateway/gateway.ts:1938` (card text) and `:1946-1957` (keyboard).
+- **Operator and dashboard prompts** under the `op:` and `auth:` callback prefixes — `telegram-plugin/gateway/gateway.ts:8179`.
 
 Adding a Google Docs MCP — and the inevitable Notion, Slack, and Gmail wrappers after it — means a fifth, sixth, and seventh surface unless the approval shape is unified. Each new surface duplicates: callback parser, storage decision (memory vs disk), TTL semantics, revocation command, audit trail. The cost compounds; the user sees inconsistent UX; there is no single `/revoke-all` killswitch.
 
@@ -25,116 +27,279 @@ Switchroom is a **1:1 bot ↔ user** product. A single allowlisted Telegram `use
 
 Telegram (with 2FA) is the auth factor. Inbound `callback_query.from.id` is authenticated by Telegram's bot session and cannot be spoofed remotely.
 
-**Local threat surface.** All switchroom processes — gateway, agents, brokers — run as the same uid (`kenthompson`) under `systemd --user`. Filesystem permissions are *not* a security boundary between gateway and an agent: an agent can read the bot token from `~/.switchroom/...` and call Telegram directly as the bot, or read `vault-grants.db` directly off disk. The kernel must therefore not rely on file perms for authorization. Authorization happens at the IPC seam.
+**Local threat surface.** All switchroom processes — gateway, agents, brokers — run as the same uid (`kenthompson`) under `systemd --user`. Filesystem permissions are *not* a security boundary between gateway and an agent. Three concrete attacks the kernel must defend against:
 
-## 4. Design — broker model
+1. **Bot token theft.** An agent that can read the bot token from disk can post fake approval cards as the bot and intercept the user's tap. The kernel's whole trust chain collapses. Phase 0 below moves the token into the vault.
+2. **Cgroup spoofing.** Under cgroup v2 user delegation, a same-uid attacker can `mkdir` a fake cgroup path that looks like `switchroom-klanker.service` and move its own pid into it. `/proc/<pid>/cgroup` then reports the spoofed name. Documented at `src/vault/broker/peercred.ts:240-245`. Mitigation: `verifySystemdUnit` (`peercred.ts:254`) cross-checks every peercred result against `systemctl --user show`. **The kernel must call this on every request, not just at startup.** Without it, peercred is attacker-controlled input.
+3. **Direct DB writes.** Any agent can `sqlite3` open `vault-grants.db` and `INSERT` a forged grant row, bypassing the broker entirely. Mitigation in §5.
 
-The kernel runs in-gateway (or as a sibling process sharing the gateway's lifecycle) and exposes a unix-socket API at `~/.switchroom/approval-broker.sock`.
+Authorization happens at the IPC seam, never at the filesystem layer.
 
-Caller identity is established via **SO_PEERCRED + cgroup → systemd unit name**, modeled directly on `src/vault/broker/peercred.ts` and the ACL logic in `src/vault/broker/acl.ts`. The unit name (e.g. `switchroom-klanker.service`) is the authorization principal, not the pid or uid. Reuse the existing helpers — do not reimplement.
+## 4. Design — fold into the vault broker
 
-File permissions on `approvals.db` are belt-and-suspenders, never the primary control.
+The kernel does **not** stand up a parallel broker. Approvals live as new tables in the existing `vault-grants.db` (renamed to `vault.db` to reflect broader scope; the file path rename ships with a one-time migration). The existing vault broker at `src/vault/broker/server.ts` grows new RPC methods:
 
-**Why a broker over a library.** A library linked into the agent process gives that agent direct access to the SQLite file; an agent can rewrite its own grants, forge audit entries, or read peer agents' decisions. The broker is a single mediating process that owns the DB handle, validates every request against the peer's unit name, and emits the audit row.
+- `requestApproval({ scope, why, ttl_hint })` → returns `{ status: 'pending', request_id }` immediately, then long-polls (see §10).
+- `lookupDecision({ scope })` → checks for a live grant (allow_always / allow_ttl with revoked_at IS NULL).
+- `recordDecision({ request_id, mode, ttl })` → invoked by the gateway when the user taps.
+- `revoke({ id, reason })` and `listForUser({ user_id })`.
+
+**Why fold rather than fork.** The vault broker already owns: SO_PEERCRED authentication (`peercred.ts`), the systemd cross-check (`peercred.ts:254`), per-unit ACL enforcement (`src/vault/broker/acl.ts`), an audited DB handle, and a battle-tested IPC protocol. Standing up a sibling broker means duplicating all of it and maintaining two ACL surfaces that can drift. One process, one socket, one trust seam.
+
+**Effort impact.** Estimate drops from the v1 draft's "~2 days for kernel + storage" to **~1 day**, since the IPC, auth, and DB plumbing are all in place.
+
+### 4.1 Peercred regex must be broadened
+
+`peercred.ts:223` currently matches **only** cron units:
+
+```
+/^switchroom-[a-zA-Z0-9_-]+-cron-\d+\.service$/
+```
+
+Long-running agent units (`switchroom-klanker.service`) are not matched and would fail the kernel's auth check. Replace with:
+
+```
+/^switchroom-[a-zA-Z0-9_-]+(-cron-\d+)?\.service$/
+```
+
+and (critical) **route every approval RPC through `verifySystemdUnit`**. Without verifySystemdUnit a same-uid attacker bypasses the broker via cgroup mkdir; the regex change alone is unsafe.
 
 ## 5. Decision storage
 
-SQLite at `~/.switchroom/approvals.db`, modeled on `vault-grants.db`.
+New tables in `vault.db`:
 
-```
-decisions(
-  id              TEXT PRIMARY KEY,    -- 5-char base32, see §6
-  agent_unit      TEXT NOT NULL,       -- systemd unit name
-  scope           TEXT NOT NULL,       -- see §6 grammar
+```sql
+CREATE TABLE approval_decisions (
+  id              TEXT PRIMARY KEY,    -- UUID v4 (durable identifier)
+  agent_unit      TEXT NOT NULL,       -- systemd unit name, verified via peercred + systemd
+  scope           TEXT NOT NULL,       -- see §6
   decision        TEXT NOT NULL,       -- allow_once | allow_always | allow_ttl | deny | deny_perm
   ttl_expires_at  INTEGER,             -- unix-ms, NULL for non-ttl
+  last_used_at    INTEGER,             -- for sliding-window TTL + staleness digest
   granted_by_user_id INTEGER NOT NULL, -- Telegram user_id
+  granted_at_allowfrom TEXT NOT NULL,  -- JSON array, sorted; for config-drift check
   granted_at      INTEGER NOT NULL,
   revoked_at      INTEGER,
-  revoke_reason   TEXT
+  revoke_reason   TEXT,
+  hmac            BLOB NOT NULL        -- see below
 );
-audit(
+
+CREATE TABLE approval_audit (
   id              INTEGER PRIMARY KEY AUTOINCREMENT,
   ts              INTEGER NOT NULL,
   agent_unit      TEXT NOT NULL,
   scope           TEXT NOT NULL,
-  action          TEXT NOT NULL,       -- request | grant | deny | revoke | timeout | match
+  action          TEXT NOT NULL,       -- request | grant | deny | revoke | timeout | match | drift_revoke
   decision_id     TEXT,
-  request_context TEXT                 -- JSON blob, why-string + caller frame
+  request_context TEXT,                -- JSON: why-string, caller frame, request_id
+  hmac            BLOB NOT NULL
 );
 ```
 
-Persistent grants survive restart. In-memory deferred-prompt state (the open card, awaiting tap) does **not**, matching today's deferred-secret behavior — acceptable.
+UUID is the durable primary key. The 8-hex callback token (matching existing `generateAskId` at `telegram-plugin/ask-user.ts:133`) is mapped to the UUID only for the prompt's lifetime, then discarded. This avoids historical-collision risk while keeping callback_data inside Telegram's 64-byte budget.
+
+### 5.1 SQLite same-uid write protection (HMAC every row)
+
+A same-uid agent can open the DB directly and `INSERT` a forged grant. Defense:
+
+- The broker generates a random 32-byte **row-integrity key** at vault unlock and holds it in memory only.
+- Every `approval_decisions` and `approval_audit` row carries an HMAC-SHA256 over its concatenated columns.
+- Read path verifies HMAC before honoring a row. Mismatch → row is treated as not-present, an `audit` row is written for the tampering attempt, and an operator alert fires.
+
+Future hardening: `BindPaths=` / per-agent user-namespace isolation so the DB file isn't visible to agent units at all. Not required for v1; HMAC closes the immediate hole.
+
+### 5.2 Config-drift auto-revocation
+
+A grant recorded when `allowFrom = ["U1"]` must not silently extend if `allowFrom` later becomes `["U1", "U2"]`. At every `lookupDecision`:
+
+- Re-read current `allowFrom` from access config.
+- If `granted_at_allowfrom != current sorted allowFrom`, treat as auto-revoked: write `drift_revoke` to audit, return no-grant, force re-prompt under the new approver set.
+- If the current set has more than one approver, all standing grants are dormant until the operator re-confirms each one (one-tap re-approve).
+
+Drift is logged loudly. This goes in §7 (decision modes) and §11 (risks).
+
+### 5.3 Revocation propagation
+
+Every grant lookup re-reads `revoked_at` from disk at use time. **No caching across calls.** Spec'd here so it cannot be optimized away later.
 
 ## 6. Scope grammar
 
-Pluggable per surface. Each consumer registers a namespace and a matcher:
+Pluggable per surface. Each consumer registers a namespace and a matcher. The interface:
+
+```ts
+interface ScopeMatcher {
+  namespace: string                     // 'secret' | 'tool' | 'doc' | 'mcp'
+  matches(grant: string, request: string): boolean
+  humanize(scope: string): Promise<string>  // for card display, async (may resolve doc titles)
+}
+```
+
+Existing precedent: `checkEntryScope` in `src/vault/broker/acl.ts` already implements scope matching for vault entries. Reuse the pattern.
+
+Namespaces:
 
 - `secret:OPENAI_*` — env-name glob.
-- `tool:bash:rm *` — tool name + arg pattern.
+- `tool:bash:rm *` — tool name + arg pattern. **Bash-arg matching is non-trivial**: the existing implementation in `telegram-plugin/permission-rule.ts` is 133 lines wrestling with quoting, globs, and option flags. Phase 4 inherits all that complexity.
 - `tool:Skill:deploy` — Skill invocations.
 - `doc:gdrive:1abc...xyz` — specific Drive doc id.
 - `doc:gdrive:folder/789/**` — folder glob.
 - `mcp:notion:page:...`
 
-Telegram callback_data is hard-capped at 64 bytes including the existing `agent:` prefix injected by the bridge. Scopes will not fit. Use 5-char base32 request ids (existing pattern at `src/gateway.ts:8482`); store the full scope server-side and pass only the id over the wire. Card payload becomes `apv:<id>:allow`, `apv:<id>:deny`, `apv:<id>:ttl:1h`, etc.
+### 6.1 Callback wire format
+
+Telegram callback_data is hard-capped at 64 bytes including the existing `agent:` prefix injected by the bridge. Scopes will not fit. Wire format:
+
+```
+apv:<8-hex request id>:<action>[:<param>]:<5-char base32 nonce>
+```
+
+- 8-hex request id matches `generateAskId` convention.
+- 5-char base32 nonce is **server-generated, single-use, deleted on first tap** — replay defense. A re-tap of an old card payload is rejected with "this prompt expired."
+- Examples: `apv:a3f1b9c2:allow:k7m2x`, `apv:a3f1b9c2:ttl:1h:k7m2x`, `apv:a3f1b9c2:deny:k7m2x`.
+
+Full scope and `humanize()` output are stored server-side keyed by request id.
 
 ## 7. Decision modes
 
 Universal across surfaces:
 
 - `allow_once` — single use, consumed on first match.
-- `allow_always` — standing grant, no expiry.
-- `allow_ttl` — bounded grant (1h, 24h, 7d picker).
+- `allow_always` — standing grant, no expiry. Subject to drift-revocation (§5.2).
+- `allow_ttl` — bounded grant, **sliding window**: the TTL extends on each successful use (sudo / 1Password pattern). Default TTL is 1h; user can override via expand.
 - `deny` — single-shot reject.
 - `deny_perm` — standing reject; future requests auto-fail without re-prompting.
 
+The card surfaces only the common subset (see §8). The full mode set is editable post-grant via `/approvals`.
+
 ## 8. Telegram approval card UX
 
-One shape, every surface. Title line, requesting agent, scope (rendered human-readably from the scope string), why-string (call-site context if the consumer supplied it), inline keyboard with mode choices.
+One shape, every surface. Built on the existing `aq:` (ask_user) primitive at `telegram-plugin/gateway/gateway.ts:8209` — that path already handles topic routing, quote-reply targeting, reaction-lifecycle, and `allowFrom` enforcement. The kernel registers a new `apv:` callback handler and reuses everything else.
 
-Built on the existing `aq:` (ask_user) primitive at `src/gateway.ts:8326-8345` — that path already handles topic routing, quote-reply targeting, and reaction-lifecycle. The kernel registers a new `apv:` callback handler and reuses everything else.
+### 8.1 Card states
 
-## 9. Audit and revocation
+**Pristine** (initial render):
 
-- `/approvals list` — standing decisions grouped by surface, with TTL countdown.
-- `/approvals revoke <id>` — single revoke; logs to `audit`.
-- `/revoke-all` — killswitch; sets `revoked_at` on every active row.
-- Weekly digest of `allow_always` rows so silent accumulation is visible. Dovetails with the existing scheduled-message infrastructure (`docs/scheduling.md`).
+```
+🔐 klanker wants to read a doc
+"Q3 Strategy Notes"     ← humanized via doc-title resolver
+[ See more ]   [ ✅ Allow ]   [ 🚫 Deny ]
+[ 🔁 Always ]  [ ⏱ For 1h ]
+```
 
-## 10. Migration plan
+The primary row is `Allow` / `Deny`. Secondary row offers `Always` (only when scope is rule-synthesizable — same gating as the existing `resolveAlwaysAllowRule` check at `gateway.ts:1955`) and `For 1h` (single TTL default, NOT a picker — picker hidden behind expand).
 
-**Phase 1 — kernel + storage + Telegram primitive.** Standalone. No consumers wired. Includes the `apv:` callback router, the broker socket, the SQLite schema, and `/approvals list|revoke` commands. Estimated ~2 days.
+**Expanded** (after `See more`):
 
-**Phase 2 — secrets as first consumer.** Migrate the deferred-secret card path (`src/gateway.ts:1304`) to call the kernel. Lower-traffic, validates the abstraction, and the move from in-memory to SQLite is itself a real upgrade. ~1 day.
+- Call-site context: `tool:bash:rm` shows the file/line; `mcp:gdrive` shows the path/query.
+- Raw scope string for verification: `doc:gdrive:1abcDEFxyz789`.
+- Agent-supplied "Why this access?" line.
+- TTL picker (`1h` / `24h` / `7d`), `Deny permanent`, custom mode.
 
-**Phase 3 — Google Docs MCP wrapper as kernel consumer.** Build the MCP wrapper that calls the kernel for every doc/folder access. OAuth tokens (Google's refresh tokens) live in vault, extending the existing `auth:` slot pattern (`src/gateway.ts:8291`, `src/auth/`). ~2 days including OAuth glue.
+**Granted (in place):**
 
-**Phase 4 — `perm:` migration (separate PR, separate review).** The tool/skill permission path runs on the hot path of every tool call; highest regression risk. Defer until kernel has weeks of production proof. Similar size, ~2 days.
+```
+✅ Granted once · /approvals revoke a3f1b9c2
+```
+
+**Granted always:**
+
+```
+✅ Granted always to klanker for doc:gdrive:1abcDEFxyz789
+   /approvals revoke a3f1b9c2
+```
+
+**Denied:** `🚫 Denied`
+
+**Expired:** `⌛ Expired — agent must re-request` (after the 5-minute prompt timeout — see §11).
+
+**Revoked-after-grant:** on the next use attempt the agent gets a denial; the kernel posts a fresh notification card identifying which standing grant fired the denial and offering one-tap reinstate.
+
+### 8.2 humanize() and fallback
+
+The kernel calls the namespace's `humanize()` before rendering. For `doc:gdrive:1abc...`, the gdrive matcher fetches the doc title via the cached MCP handle. On failure, the card falls back to the raw scope with a `(could not resolve title)` annotation rather than blocking.
+
+### 8.3 Preserved patterns (must not regress through migration)
+
+- **`perm:more` expand button** at `gateway.ts:1946` — the See-more pattern is the basis of the new card's expand. Keep the same UX shape.
+- **`summarizeToolForTitle` lift-to-title** at `gateway.ts:1938` (import at `:269`) — preserve the most-identifying-field-into-title pattern. The new card uses the same helper for `tool:` scopes.
+- **`vd:unlock` deferred-secret card flow** at `gateway.ts:5497` — Phase 2 migrates this surface; the inline-passphrase capture step must survive the move.
+- **`aq:` topic-routing + reaction lifecycle** at `gateway.ts:8209` — inherit, do not rebuild.
+- **`allowFrom` enforcement on every callback** — pattern at `gateway.ts:8218-8222`.
+
+## 8a. First-run onboarding for new MCPs
+
+When a new MCP wrapper is enabled, the kernel posts a one-time setup card before the first per-resource prompt fires. Avoids the "grant once, then widen via /approvals" anti-pattern where users grant a narrow scope under prompt fatigue and never broaden it.
+
+```
+🆕 Google Drive enabled. How should klanker access your Drive?
+
+[ Allow all of Drive (less secure, fewer prompts) ]
+[ Choose folders now ]                       ← v1: links to /approvals add
+[ Per-doc approval (default, more secure)    ]
+```
+
+`Choose folders now` in v1 routes to `/approvals add` with a pre-filled folder-glob template. The folder picker UI is future work.
+
+## 9. Audit, revocation, staleness
+
+- `/approvals list` — standing decisions **grouped by agent first**, then surface (`klanker → secret:* → ...`, `klanker → doc:gdrive:* → ...`). User mental model is "what can klanker do?", not "what tool grants exist?". GitHub-style permissions UI is the reference.
+- `/approvals revoke <id>` — single revoke; logs to `approval_audit`. **Every grant card's confirmation message includes `· /approvals revoke <id>` inline** so revocation is one tap from the grant itself.
+- `/revoke-all` — killswitch. Sets `revoked_at` on every active row **and rotates the bot token** via the vault. A compromised agent that exfiltrated the token retains its parallel channel otherwise; the kill must be complete.
+
+### 9.1 Staleness model (replaces weekly digest)
+
+Drop fixed-cadence digests. Replace with two triggers:
+
+- **Threshold-triggered:** when `count(allow_always WHERE never_seen_in_digest) >= 3`, send a digest of the new standing grants. Rate-limited to at most one digest per 24h.
+- **Staleness-triggered:** for each `allow_always` row where `last_used_at` is more than 30 days ago, surface a one-shot "this grant hasn't fired in 30d, revoke?" prompt with inline `Revoke` / `Keep` buttons. One prompt per row; on `Keep`, suppress for another 30d.
+
+Steal sudo's pattern: surface staleness, not totals.
+
+## 10. Long-poll protocol
+
+The vault broker is request/response. Approvals can wait up to 5 minutes for a user tap. Spec:
+
+1. `requestApproval` returns `{ status: 'pending', request_id }` immediately and synchronously.
+2. The agent calls `awaitDecision({ request_id })` on a separate socket connection. The broker holds the connection open with periodic 10-second keepalive frames (`{ type: 'keepalive' }`) until either:
+   - the user taps → broker sends `{ status: 'granted'|'denied', mode, ttl }` and closes.
+   - the 5-minute timeout fires → broker sends `{ status: 'timeout' }` and closes.
+3. Agent disconnect mid-poll: broker keeps the decision row; on reconnect+`awaitDecision` with the same request_id, replays the latest state.
+
+Long-poll over 2s polling: lower latency, fewer round-trips, trivial to implement on top of the existing broker IPC.
 
 ## 11. Risks and open questions
 
-- **`perm:always` writes to Claude Code's allow-rules** (`permission-rule.ts`), not switchroom storage. Migration buys us auditability but is a bigger lift than a wrapper — the kernel needs to write both its own decision row and continue emitting the Claude rule, or we accept that `allow_always` for tools no longer hits Claude's settings.
-- **`--print` mode bypasses permission-request entirely** (documented at `docs/stream-json-daemon-mode.md:401`). Pre-existing bug; the kernel inherits it. Out of scope for this RFC; flagged.
-- **Callback delivery is best-effort.** If the gateway is down when the user taps, the tap is lost. Approval cards must define a timeout (proposed: 5 minutes). On timeout the kernel emits a `timeout` audit row, the agent sees a failed request, and must re-issue if it still wants the action.
-- **OAuth tokens are sensitive.** Vault is the right home. Define explicitly: kernel asks vault for the token by slot name, vault enforces its own grant on that slot, kernel never persists raw tokens.
-- **Group / multi-user is out of scope but trip-wired.** First time `allowFrom` grows beyond one entry, the kernel schema needs an `approvers` column and card delivery must become DM-only.
+- **Phase 4 `perm:` migration: kernel-only, not dual-write.** The existing `perm:always` path writes a Claude Code allow-rule via `permission-rule.ts` (133 lines). Two options:
+  - *Dual-write*: kernel writes its decision row AND emits the Claude rule, with reconciliation on revoke. Reconciliation is a chronic source of bugs (settings.json edited externally, partial writes, etc.).
+  - *Kernel-only* (recommended): the kernel becomes the source of truth. Claude Code's `settings.json permissions.allow` becomes managed by the kernel — the user no longer hand-edits it.
+  Audit is the entire point of this RFC; pick kernel-only and accept that we lose Claude's native always-allow path.
+- **`--print` mode and Phase 2 secrets.** `--print` bypasses Claude's permission-request flow (documented at `docs/stream-json-daemon-mode.md:401`). Secrets enforcement lives broker-side, not gateway-side, so Phase 0 (bot token in vault) plus the broker-mediated secret fetch means `--print` agents *still* go through the kernel for secret access — the bypass only affects tool-permission prompts, not secret unlocks. Document explicitly.
+- **Cross-agent grant scope is unit-scoped, not user-scoped.** `allow_always` for `secret:OPENAI_API_KEY` granted to klanker does **not** auto-grant to gymbro. Each `agent_unit` is a separate principal, matching existing vault grants. User-scoped grants are out of scope for v1.
+- **Callback delivery is best-effort.** If the gateway is down when the user taps, the tap is lost. 5-minute timeout, `timeout` audit row, agent re-issues if still wanted. Long-poll auto-reconnect (§10) covers agent-side restarts.
+- **OAuth tokens (Google refresh tokens) live in vault.** Kernel asks vault for the token by slot name; vault enforces its own grant on that slot; kernel never persists raw tokens.
+- **Group / multi-user is out of scope but trip-wired.** The drift-revocation rule (§5.2) makes this safe-by-default: the moment `allowFrom` grows past one entry, every standing grant becomes dormant pending re-confirmation.
+- **Tap-budget target.** Day 1 of Drive enablement: 10–30 taps expected (cold cache, no folder grants). Steady state after onboarding: <5 taps/day. If exceeded, **batch coalescing** kicks in: the kernel buffers prompts for 5 seconds; if 3+ pending share a scope-prefix (e.g. `doc:gdrive:folder/Work/*`), it collapses into a single "klanker is requesting access to 4 docs in /Work — allow folder?" card.
 
-## 12. Google Docs MCP — concrete picks
+## 12. Migration plan
 
-- `taylorwilsdon/google_workspace_mcp` — most actively maintained, full Workspace coverage, OAuth 2.1.
-- `a-bonus/google-docs-mcp` — popular, OAuth 2.1, Docs-only.
-- `piotr-agier/google-drive-mcp` — OAuth + auto-refresh, alternative auth modes.
+**Phase 0 — bot token to vault. Prerequisite for everything else.** Move the Telegram bot token from its current filesystem location into the vault under a slot only `switchroom-gateway.service` can unlock. Any agent with filesystem read of the current token location is **already game-over** — it can post fake approval cards as the bot and intercept the user's tap. The kernel's whole trust chain depends on this. ~0.5 day.
 
-Default to **taylorwilsdon** for breadth. Revisit after the Phase 3 prototype reveals real pain points.
+**Phase 1 — kernel folded into vault broker.** New tables in `vault.db`, new RPC methods on `src/vault/broker/server.ts`, broaden peercred regex (§4.1), add HMAC row protection (§5.1), add `apv:` callback router in gateway, `/approvals list|revoke|add` commands, long-poll protocol (§10). ~1 day (was ~2; vault-broker fold-in saves the day).
+
+**Phase 2 — secrets as first consumer.** Migrate the deferred-secret card path (`gateway.ts:5497`) to call the kernel. Lower-traffic, validates the abstraction, and the move from in-memory to SQLite is itself a real upgrade. Preserve the inline-passphrase capture UX. ~1 day.
+
+**Phase 3 — Google Docs MCP wrapper as kernel consumer.** Build the MCP wrapper (default: `taylorwilsdon/google_workspace_mcp`) that calls the kernel for every doc/folder access. OAuth tokens in vault, extending the existing `auth:` slot pattern (`gateway.ts:8179`, `src/auth/`). Includes the §8a onboarding card and the §11 batch coalescing. ~2 days.
+
+**Phase 4 — `perm:` migration (separate PR, separate review).** Highest regression risk; runs on the hot path of every tool call. Kernel-only as decided in §11. Defer until kernel has weeks of production proof. ~2 days.
 
 ## 13. Estimated effort
 
-5–6 focused engineering days for Phases 1–3. Phase 4 is a separate ~2-day effort under its own review.
+**Phases 0–3: ~4.5 focused engineering days.** Phase 4 is a separate ~2-day effort under its own review. The vault-broker fold-in shaves roughly a day off the v1 estimate.
 
 ## 14. Out of scope
 
 - Group / multi-user bot support.
 - Per-action MFA prompts beyond approval — Telegram 2FA is sufficient at this trust level.
 - Web dashboard approval UX (CLI + Telegram only for v1).
-- Cross-agent shared decisions — each agent's grants are scoped to its unit name; no inheritance between agents.
+- User-scoped (cross-agent) grants — every grant is unit-scoped in v1.
+- Per-agent BindPaths / user-namespace isolation of the DB file — HMAC row protection (§5.1) is the v1 defense; namespace isolation is future hardening.

--- a/docs/rfcs/approval-kernel.md
+++ b/docs/rfcs/approval-kernel.md
@@ -1,6 +1,6 @@
 # RFC: Unified human-approval kernel
 
-Status: Draft v2
+Status: Draft v3
 Author: klanker (sub-agent draft)
 Date: 2026-05-06
 
@@ -8,16 +8,16 @@ Date: 2026-05-06
 
 Today switchroom asks the user to approve sensitive actions through at least four independent code paths, each with its own callback grammar, storage, and UX. This RFC proposes a single approval kernel — folded into the existing **vault broker** — that all current and future surfaces (secrets, vault grants, tool/skill permission requests, Google Docs and other MCPs) plug into. One process, one socket, one ACL surface, one SQLite file, one audit log, one Telegram card primitive.
 
-The kernel is shaped on the existing `vault-broker` trust model and reuses its proven SO_PEERCRED + cgroup-derived unit identity (with the systemd cross-check that already exists at `src/vault/broker/peercred.ts:254`).
+The kernel reuses the broker's existing peercred + cgroup transport and ACL plumbing for **agent-identity gating only**. Almost everything else listed below — scope matching, HMAC row protection, HKDF-derived row-integrity key, append-only revocation chain, hash-chained audit, pidfd-pinned peercred, drift revocation, short-poll wait protocol, settings.json write-back — is **net-new code**. v2 leaned on "reuse" framing that obscured this; v3 names new subsystems plainly.
 
 ## 2. Motivation
 
 Four approval-shaped surfaces exist today:
 
 - **Deferred-secret cards** with `vd:unlock|cancel` callbacks — `telegram-plugin/gateway/gateway.ts:5497`.
-- **Vault grants** via the `/vault grant` wizard, persisted to SQLite at `~/.switchroom/vault-grants.db` — table `vault_grants` defined at `src/vault/grants.ts:61`.
-- **Tool/Skill permission requests** via MCP `notifications/claude/channel/permission_request`, rendered as `perm:allow|deny|always` cards — `telegram-plugin/gateway/gateway.ts:1938` (card text) and `:1946-1957` (keyboard).
-- **Operator and dashboard prompts** under the `op:` and `auth:` callback prefixes — `telegram-plugin/gateway/gateway.ts:8179`.
+- **Vault grants** via the `/vault grant` wizard, persisted to SQLite at `~/.switchroom/vault-grants.db` — schema migrated in `src/vault/grants.ts:59`.
+- **Tool/Skill permission requests** via MCP `notifications/claude/channel/permission_request`, rendered as `perm:allow|deny|always` cards — `telegram-plugin/gateway/gateway.ts:1938` (card text) and `:1946-1947` (keyboard).
+- **Operator and dashboard prompts** under the `op:` and `auth:` callback prefixes — `telegram-plugin/gateway/gateway.ts:8179` (auth) and `:8187` (op).
 
 Adding a Google Docs MCP — and the inevitable Notion, Slack, and Gmail wrappers after it — means a fifth, sixth, and seventh surface unless the approval shape is unified. Each new surface duplicates: callback parser, storage decision (memory vs disk), TTL semantics, revocation command, audit trail. The cost compounds; the user sees inconsistent UX; there is no single `/revoke-all` killswitch.
 
@@ -27,28 +27,30 @@ Switchroom is a **1:1 bot ↔ user** product. A single allowlisted Telegram `use
 
 Telegram (with 2FA) is the auth factor. Inbound `callback_query.from.id` is authenticated by Telegram's bot session and cannot be spoofed remotely.
 
-**Local threat surface.** All switchroom processes — gateway, agents, brokers — run as the same uid (`kenthompson`) under `systemd --user`. Filesystem permissions are *not* a security boundary between gateway and an agent. Three concrete attacks the kernel must defend against:
+**Local threat surface.** All switchroom processes — gateway, agents, brokers — run as the same uid (`kenthompson`) under `systemd --user`. Filesystem permissions are *not* a security boundary between gateway and an agent. Concrete attacks the kernel must defend against:
 
 1. **Bot token theft.** An agent that can read the bot token from disk can post fake approval cards as the bot and intercept the user's tap. The kernel's whole trust chain collapses. Phase 0 below moves the token into the vault.
 2. **Cgroup spoofing.** Under cgroup v2 user delegation, a same-uid attacker can `mkdir` a fake cgroup path that looks like `switchroom-klanker.service` and move its own pid into it. `/proc/<pid>/cgroup` then reports the spoofed name. Documented at `src/vault/broker/peercred.ts:240-245`. Mitigation: `verifySystemdUnit` (`peercred.ts:254`) cross-checks every peercred result against `systemctl --user show`. **The kernel must call this on every request, not just at startup.** Without it, peercred is attacker-controlled input.
-3. **Direct DB writes.** Any agent can `sqlite3` open `vault-grants.db` and `INSERT` a forged grant row, bypassing the broker entirely. Mitigation in §5.
+3. **PID-reuse / TOCTOU race on peercred.** Even with `verifySystemdUnit`, between `accept()` returning `SO_PEERCRED` and the broker reading `/proc/<pid>/cgroup` and `/proc/<pid>/status`, the original pid can exit and the kernel can recycle the pid for a *different* same-uid process whose cgroup IS a real switchroom unit. The attacker's exited process "becomes" the legitimate unit's pid for the duration of the read. Broadening the unit regex to long-running services (§4.1) makes this race far easier to exploit than the cron-only world, because long-running unit pids are observable and predictable. **Mitigation (NEW in v3):** immediately after `SO_PEERCRED`, call `pidfd_open(2)` to pin the process. All subsequent `/proc` reads route through `/proc/self/fdinfo/<pidfd>` (or equivalent); `pidfd_send_signal(pidfd, 0)` checks liveness before honoring the request. If the pidfd reports the process exited, reject with `peer_gone`. This is a new code path on top of the existing peercred logic, not a reuse.
+4. **Direct DB writes.** Any agent can `sqlite3` open `vault-grants.db` and `INSERT` a forged grant row, bypassing the broker entirely. Mitigation in §5.
+5. **HMAC threat-model honesty.** Per-row HMAC (§5.1) provides **tamper detection, not prevention.** A same-uid attacker with `ptrace_scope=0` or `CAP_SYS_PTRACE` can attach to the broker process and read the HKDF-derived row key out of memory, then mint forgeable rows. HMAC raises the bar from "trivial sqlite3 INSERT" to "ptrace + key extraction + chain replay" — meaningful but not a hard boundary. Real prevention requires per-agent user-namespace isolation so agent units cannot see the DB file or the broker's memory at all. That is **out of scope for v1** and tracked as Phase 5+ hardening.
 
 Authorization happens at the IPC seam, never at the filesystem layer.
 
 ## 4. Design — fold into the vault broker
 
-The kernel does **not** stand up a parallel broker. Approvals live as new tables in the existing `vault-grants.db` (renamed to `vault.db` to reflect broader scope; the file path rename ships with a one-time migration). The existing vault broker at `src/vault/broker/server.ts` grows new RPC methods:
+The kernel does **not** stand up a parallel broker. Approvals live as new tables in the existing `vault-grants.db`. **v3 keeps the filename** (`vault-grants.db`) rather than renaming to `vault.db` — the rename was cosmetic and would have made downgrade after Phase 1 impossible (HMAC'd rows in a renamed file are unverifiable to pre-rename binaries; the only "rollback" would be a clean re-init of approvals). Adding tables to the existing file ships the same capability with a real downgrade path.
 
-- `requestApproval({ scope, why, ttl_hint })` → returns `{ status: 'pending', request_id }` immediately, then long-polls (see §10).
-- `lookupDecision({ scope })` → checks for a live grant (allow_always / allow_ttl with revoked_at IS NULL).
+The existing vault broker at `src/vault/broker/server.ts` grows new RPC methods:
+
+- `requestApproval({ scope, why, ttl_hint })` → returns `{ status: 'pending', request_id }` immediately.
+- `lookupDecision({ request_id | scope })` → checks for a live grant or pending decision. Used both for fast-path matching and for the short-poll wait loop (§10).
 - `recordDecision({ request_id, mode, ttl })` → invoked by the gateway when the user taps.
 - `revoke({ id, reason })` and `listForUser({ user_id })`.
 
-**Why fold rather than fork.** The vault broker already owns: SO_PEERCRED authentication (`peercred.ts`), the systemd cross-check (`peercred.ts:254`), per-unit ACL enforcement (`src/vault/broker/acl.ts`), an audited DB handle, and a battle-tested IPC protocol. Standing up a sibling broker means duplicating all of it and maintaining two ACL surfaces that can drift. One process, one socket, one trust seam.
+**Why fold rather than fork.** The vault broker already owns: SO_PEERCRED authentication (`peercred.ts`), the systemd cross-check (`peercred.ts:254`), per-agent ACL enforcement (`src/vault/broker/acl.ts`), an audited DB handle, and a battle-tested IPC protocol. Reusing the IPC, peercred transport, and the agent-identity ACL machinery is real reuse; **scope matching, HMAC row integrity, the revocation chain, the audit chain, the short-poll layer, and the apv: callback router are all new**. v2's effort estimate undercounted these; §13 corrects it.
 
-**Effort impact.** Estimate drops from the v1 draft's "~2 days for kernel + storage" to **~1 day**, since the IPC, auth, and DB plumbing are all in place.
-
-### 4.1 Peercred regex must be broadened
+### 4.1 Peercred regex must be broadened, with pidfd pinning
 
 `peercred.ts:223` currently matches **only** cron units:
 
@@ -62,65 +64,109 @@ Long-running agent units (`switchroom-klanker.service`) are not matched and woul
 /^switchroom-[a-zA-Z0-9_-]+(-cron-\d+)?\.service$/
 ```
 
-and (critical) **route every approval RPC through `verifySystemdUnit`**. Without verifySystemdUnit a same-uid attacker bypasses the broker via cgroup mkdir; the regex change alone is unsafe.
+Two binding requirements:
+
+1. **Route every approval RPC through `verifySystemdUnit` (`peercred.ts:254`).** Without it a same-uid attacker bypasses the broker via cgroup mkdir.
+2. **Pidfd-pin the peer before any `/proc` read (NEW).** As called out in §3 attack 3, broadening to long-running units enlarges the TOCTOU window. `pidfd_open(pid)` immediately after accept; treat the pidfd as the authoritative process handle for the lifetime of the RPC; reject with `peer_gone` if liveness check fails. This is genuinely new code in `peercred.ts` — not a tweak to `verifySystemdUnit`.
 
 ## 5. Decision storage
 
-New tables in `vault.db`:
+New tables in `vault-grants.db`:
 
 ```sql
 CREATE TABLE approval_decisions (
   id              TEXT PRIMARY KEY,    -- UUID v4 (durable identifier)
-  agent_unit      TEXT NOT NULL,       -- systemd unit name, verified via peercred + systemd
+  agent_unit      TEXT NOT NULL,       -- systemd unit name, verified via peercred + systemd + pidfd
   scope           TEXT NOT NULL,       -- see §6
+  state           TEXT NOT NULL,       -- 'active' | 'revoked'  (used in HMAC tuple)
   decision        TEXT NOT NULL,       -- allow_once | allow_always | allow_ttl | deny | deny_perm
   ttl_expires_at  INTEGER,             -- unix-ms, NULL for non-ttl
+  ttl_original_ms INTEGER,             -- for sliding-window renewal hard cap (§7)
+  granted_at      INTEGER NOT NULL,
+  max_lifetime_at INTEGER,             -- granted_at + max_lifetime; sliding renewal cannot pass this
   last_used_at    INTEGER,             -- for sliding-window TTL + staleness digest
   granted_by_user_id INTEGER NOT NULL, -- Telegram user_id
-  granted_at_allowfrom TEXT NOT NULL,  -- JSON array, sorted; for config-drift check
-  granted_at      INTEGER NOT NULL,
+  granted_at_allowfrom TEXT NOT NULL,  -- canonical-JSON; see §5.2
   revoked_at      INTEGER,
   revoke_reason   TEXT,
-  hmac            BLOB NOT NULL        -- see below
+  key_version     INTEGER NOT NULL,    -- HKDF key version (§5.1)
+  hmac            BLOB NOT NULL        -- see §5.1; covers tuple including `state`
+);
+
+CREATE TABLE approval_revocations (
+  -- Append-only, HMAC-chained. See §5.1 for forgery defense.
+  seq             INTEGER PRIMARY KEY AUTOINCREMENT,
+  ts              INTEGER NOT NULL,
+  decision_id     TEXT NOT NULL,
+  reason          TEXT,
+  prev_hmac       BLOB,                -- previous row's hmac (chain link)
+  key_version     INTEGER NOT NULL,
+  hmac            BLOB NOT NULL        -- HMAC over (seq, ts, decision_id, reason, prev_hmac)
 );
 
 CREATE TABLE approval_audit (
-  id              INTEGER PRIMARY KEY AUTOINCREMENT,
+  -- Append-only, hash-chained.
+  seq             INTEGER PRIMARY KEY AUTOINCREMENT,
   ts              INTEGER NOT NULL,
   agent_unit      TEXT NOT NULL,
   scope           TEXT NOT NULL,
-  action          TEXT NOT NULL,       -- request | grant | deny | revoke | timeout | match | drift_revoke
+  action          TEXT NOT NULL,       -- request | grant | deny | revoke | timeout | match | drift_revoke | tamper
   decision_id     TEXT,
   request_context TEXT,                -- JSON: why-string, caller frame, request_id
-  hmac            BLOB NOT NULL
+  prev_hmac       BLOB,                -- previous row's hmac
+  key_version     INTEGER NOT NULL,
+  hmac            BLOB NOT NULL        -- HMAC over row tuple including prev_hmac
+);
+
+CREATE TABLE approval_pending_nonces (
+  -- Persisted before the card ships to Telegram (§6.1, §11).
+  request_id      TEXT PRIMARY KEY,
+  nonce           TEXT NOT NULL,
+  scope           TEXT NOT NULL,
+  agent_unit      TEXT NOT NULL,
+  created_at      INTEGER NOT NULL,
+  expires_at      INTEGER NOT NULL,
+  consumed_at     INTEGER
 );
 ```
 
-UUID is the durable primary key. The 8-hex callback token (matching existing `generateAskId` at `telegram-plugin/ask-user.ts:133`) is mapped to the UUID only for the prompt's lifetime, then discarded. This avoids historical-collision risk while keeping callback_data inside Telegram's 64-byte budget.
+UUID is the durable primary key. The 8-hex callback token (matching existing `generateAskId` at `telegram-plugin/ask-user.ts:133`) is mapped to the UUID only for the prompt's lifetime.
 
-### 5.1 SQLite same-uid write protection (HMAC every row)
+### 5.1 SQLite same-uid write protection (HMAC every row, with HKDF + chains)
 
-A same-uid agent can open the DB directly and `INSERT` a forged grant. Defense:
+A same-uid agent can open the DB directly and `INSERT` a forged grant. Defense (NEW subsystem; not present in any existing code path):
 
-- The broker generates a random 32-byte **row-integrity key** at vault unlock and holds it in memory only.
-- Every `approval_decisions` and `approval_audit` row carries an HMAC-SHA256 over its concatenated columns.
-- Read path verifies HMAC before honoring a row. Mismatch → row is treated as not-present, an `audit` row is written for the tampering attempt, and an operator alert fires.
-
-Future hardening: `BindPaths=` / per-agent user-namespace isolation so the DB file isn't visible to agent units at all. Not required for v1; HMAC closes the immediate hole.
+- **Row-integrity key derivation.** The broker derives the row-integrity key via HKDF-SHA256 from the **vault master key**, with a fixed `info = "switchroom-approval-rowmac-v1"` and a salt stored in the `vault_meta` table. The master key is sealed at rest and only available post-vault-unlock — the same property the existing vault relies on. **The key is NOT a fresh random per unlock** — that v2 design broke `allow_always` semantics across restarts (verifying old rows would be impossible). Persistence across restarts is the whole point.
+- **Vault relock semantics.** When the vault is locked (e.g. operator runs `switchroom vault lock`), the row-integrity key is unavailable, so all standing grants become temporarily unverifiable. This is **acceptable**: the user is already gated when the vault is locked (no agent can fetch a secret either), so denying every approval lookup with `vault_locked` is correct behavior. On next unlock the key re-derives and grants verify again.
+- **Key rotation.** A `key_version` column on every HMAC'd row plus `vault_meta.current_key_version` lets the operator rotate by deriving a new version, re-MACing rows in a background job, then advancing the current version. Old-version rows remain verifiable until rewritten.
+- **Per-row HMAC.** Every `approval_decisions`, `approval_revocations`, and `approval_audit` row carries an HMAC-SHA256 over its column tuple. **The decisions-table HMAC includes `state`**, so an attacker who flips `revoked_at` to `NULL` cannot resurrect a revoked grant — see §5.3.
+- **Read path verifies HMAC** before honoring a row. Mismatch → row treated as not-present, `tamper` audit row written, operator alert fires.
+- **Threat downgrade language.** Per §3 attack 5, this is detection, not prevention. Document plainly.
 
 ### 5.2 Config-drift auto-revocation
 
 A grant recorded when `allowFrom = ["U1"]` must not silently extend if `allowFrom` later becomes `["U1", "U2"]`. At every `lookupDecision`:
 
 - Re-read current `allowFrom` from access config.
-- If `granted_at_allowfrom != current sorted allowFrom`, treat as auto-revoked: write `drift_revoke` to audit, return no-grant, force re-prompt under the new approver set.
-- If the current set has more than one approver, all standing grants are dormant until the operator re-confirms each one (one-tap re-approve).
+- Compare against `granted_at_allowfrom`. **Both values are canonicalized identically before compare:** array elements are unicode-NFC-normalized, sorted lexicographically by NFC byte-order, no whitespace, JSON-canonical-encoded (RFC 8785 subset — sorted, no insignificant whitespace, no unnecessary escapes). Without this, identical sets serialized differently produce spurious drift-revocations.
+- If canonical forms differ, treat as auto-revoked: write `drift_revoke` to audit, return no-grant, force re-prompt under the new approver set.
+- If the current set has more than one approver, all standing grants are dormant until the operator re-confirms each one.
 
 Drift is logged loudly. This goes in §7 (decision modes) and §11 (risks).
 
-### 5.3 Revocation propagation
+### 5.3 Revocation propagation and forgery defense
 
-Every grant lookup re-reads `revoked_at` from disk at use time. **No caching across calls.** Spec'd here so it cannot be optimized away later.
+Soft-delete via `revoked_at` alone is forgeable: a same-uid attacker with the row-integrity key (per §3 attack 5 threat model) — or an attacker who lands a single byte-flip of `revoked_at` to NULL while bypassing HMAC verification — could resurrect a revoked grant if the original `(state="active", revoked_at=NULL)` HMAC remains valid. Defense:
+
+- **State-bound HMAC.** The decisions HMAC tuple includes `state`. A revoke writes `state="revoked"` plus `revoked_at` plus a fresh HMAC over the new tuple. A row with `revoked_at IS NOT NULL` but a `state="active"` HMAC is detected as forged on read.
+- **Append-only revocation chain (`approval_revocations`).** Every revoke also appends a chain entry HMAC'd over `(seq, ts, decision_id, reason, prev_hmac)`. Lookup of a decision verifies "no chain entry references this id" by reading the latest chain head and walking back if needed; the chain is short (one entry per revoke). The chain head HMAC is also written into `vault_meta.revocation_chain_head` so truncation is detectable.
+- **Read path.** A `lookupDecision` accepts only rows that (a) HMAC-verify under their declared `state`, (b) have no entry in the revocation chain, AND (c) sit before the current chain head verified from `vault_meta`.
+
+Every grant lookup re-reads `revoked_at` and the chain head from disk at use time. **No caching across calls.** Spec'd here so it cannot be optimized away later.
+
+### 5.4 Audit hash chain
+
+Each `approval_audit` row's HMAC includes the previous row's HMAC (`prev_hmac` column). The latest `hmac` is mirrored into `vault_meta.audit_chain_head` on every write. At broker startup the head is verified against the actual last row; mismatch → operator alert (`audit_chain_break`). Without the chain, a same-uid attacker with the key can simply `DELETE FROM approval_audit WHERE id > N` to truncate. The chain makes truncation detectable; full prevention again requires user-namespace isolation.
 
 ## 6. Scope grammar
 
@@ -134,18 +180,29 @@ interface ScopeMatcher {
 }
 ```
 
-Existing precedent: `checkEntryScope` in `src/vault/broker/acl.ts` already implements scope matching for vault entries. Reuse the pattern.
+**ScopeMatcher is a NEW subsystem.** v2 claimed reuse of `checkEntryScope` in `src/vault/broker/acl.ts:120` — that was misleading. `checkEntryScope` is a slug-list matcher (does this `agent_slug` appear in this entry's allow/deny list?). The new ScopeMatcher is a scope-string-vs-scope-string matcher with namespace dispatch. They solve different problems. The ACL module's agent-identity gating IS reused (the kernel asks "is this agent_unit allowed to even talk to me?" via existing ACL); scope matching is built fresh.
 
 Namespaces:
 
 - `secret:OPENAI_*` — env-name glob.
-- `tool:bash:rm *` — tool name + arg pattern. **Bash-arg matching is non-trivial**: the existing implementation in `telegram-plugin/permission-rule.ts` is 133 lines wrestling with quoting, globs, and option flags. Phase 4 inherits all that complexity.
+- `tool:bash:rm`, `tool:bash:rm -rf` — tool name + arg pattern.
 - `tool:Skill:deploy` — Skill invocations.
 - `doc:gdrive:1abc...xyz` — specific Drive doc id.
 - `doc:gdrive:folder/789/**` — folder glob.
 - `mcp:notion:page:...`
 
-### 6.1 Callback wire format
+### 6.1 Bash-arg matching grammar (v1: prefix only)
+
+Spec: **prefix matching only** for v1.
+
+- `tool:bash:rm` matches any command beginning with `rm` after shell tokenization.
+- `tool:bash:rm -rf` matches any command beginning with `rm -rf` after tokenization.
+- No globbing, no regex, no quote-handling beyond standard POSIX shell tokenization (which the gateway already does upstream of the kernel).
+- Tokenization is on whitespace within an argv array; the matcher compares argv-prefix equality.
+
+This is intentionally simpler than `telegram-plugin/permission-rule.ts` (133 lines wrestling with quoting, globs, option flags). Phase 4 inherits Claude's `permission-rule.ts` complexity for finer-grained matching as **future work**; v1 ships with the limitation documented and the prefix matcher behind the same `ScopeMatcher` interface so a richer Phase 4+ matcher swaps in cleanly.
+
+### 6.2 Callback wire format
 
 Telegram callback_data is hard-capped at 64 bytes including the existing `agent:` prefix injected by the bridge. Scopes will not fit. Wire format:
 
@@ -154,18 +211,20 @@ apv:<8-hex request id>:<action>[:<param>]:<5-char base32 nonce>
 ```
 
 - 8-hex request id matches `generateAskId` convention.
-- 5-char base32 nonce is **server-generated, single-use, deleted on first tap** — replay defense. A re-tap of an old card payload is rejected with "this prompt expired."
+- 5-char base32 nonce is **server-generated, single-use, persisted to `approval_pending_nonces` synchronously BEFORE the card is sent to Telegram (§11), deleted on first tap.** A re-tap of an old card payload is rejected with "this prompt expired."
 - Examples: `apv:a3f1b9c2:allow:k7m2x`, `apv:a3f1b9c2:ttl:1h:k7m2x`, `apv:a3f1b9c2:deny:k7m2x`.
 
 Full scope and `humanize()` output are stored server-side keyed by request id.
+
+**Crash-safety.** Because the nonce is durable before the card is sent, a tap arriving after gateway restart still resolves: the broker reads the nonce row, matches it, marks it consumed, processes the decision. A tap with no DB row (gateway crashed *before* persist completed and *also* failed to send the card — vanishingly rare given write-then-send ordering) is treated as a fresh request, which manifests as a short toast "this prompt expired, agent will re-ask" — never silently ignored.
 
 ## 7. Decision modes
 
 Universal across surfaces:
 
-- `allow_once` — single use, consumed on first match.
+- `allow_once` — single use, consumed on first match. **This is what the primary `Allow` button binds to** (clarification — see §8.1).
 - `allow_always` — standing grant, no expiry. Subject to drift-revocation (§5.2).
-- `allow_ttl` — bounded grant, **sliding window**: the TTL extends on each successful use (sudo / 1Password pattern). Default TTL is 1h; user can override via expand.
+- `allow_ttl` — bounded grant, **sliding window with hard cap.** Each successful `lookupDecision` match against an `allow_ttl` row sets `ttl_expires_at = now + ttl_original_ms`. The renewal is **silent — no tap, no notification.** The renewal does NOT extend the row past `granted_at + max_lifetime` (default 30 days, stored in `max_lifetime_at`) — hard cap. This is sudo's pattern (silent renewal up to a ceiling), not Bitwarden's (notification on every renewal). Default TTL is 1h; user can override via the expand picker.
 - `deny` — single-shot reject.
 - `deny_perm` — standing reject; future requests auto-fail without re-prompting.
 
@@ -175,7 +234,7 @@ The card surfaces only the common subset (see §8). The full mode set is editabl
 
 One shape, every surface. Built on the existing `aq:` (ask_user) primitive at `telegram-plugin/gateway/gateway.ts:8209` — that path already handles topic routing, quote-reply targeting, reaction-lifecycle, and `allowFrom` enforcement. The kernel registers a new `apv:` callback handler and reuses everything else.
 
-### 8.1 Card states
+### 8.1 Card states and primary-button semantics
 
 **Pristine** (initial render):
 
@@ -186,7 +245,7 @@ One shape, every surface. Built on the existing `aq:` (ask_user) primitive at `t
 [ 🔁 Always ]  [ ⏱ For 1h ]
 ```
 
-The primary row is `Allow` / `Deny`. Secondary row offers `Always` (only when scope is rule-synthesizable — same gating as the existing `resolveAlwaysAllowRule` check at `gateway.ts:1955`) and `For 1h` (single TTL default, NOT a picker — picker hidden behind expand).
+**Primary `Allow` button = `allow_once`.** Stated explicitly so it cannot be re-interpreted later. `Always` and `For 1h` on the secondary row are the two explicit overrides. The `Always` button is offered only when scope is rule-synthesizable (same gating as the existing `resolveAlwaysAllowRule` import at `gateway.ts:270`). `For 1h` is a single TTL default, NOT a picker — the picker lives behind expand.
 
 **Expanded** (after `See more`):
 
@@ -210,91 +269,148 @@ The primary row is `Allow` / `Deny`. Secondary row offers `Always` (only when sc
 
 **Denied:** `🚫 Denied`
 
-**Expired:** `⌛ Expired — agent must re-request` (after the 5-minute prompt timeout — see §11).
+**Expired (5-minute prompt timeout):** the broker expiry job runs every 30s; on each expiry it issues `editMessageReplyMarkup` to strip the buttons and `editMessageText` to set the body to `⌛ Expired — agent will re-request.` The pending nonce row is marked consumed. **A tap on an already-expired callback** returns `answerCallbackQuery({ text: 'this prompt expired' })` — a brief toast — and surfaces no error to the agent (which has already received `{ status: 'timeout' }` and either re-issued or moved on). Expired-nonce rejection happens at the broker callback-router layer before any decision-write logic runs.
 
 **Revoked-after-grant:** on the next use attempt the agent gets a denial; the kernel posts a fresh notification card identifying which standing grant fired the denial and offering one-tap reinstate.
 
-### 8.2 humanize() and fallback
+### 8.2 humanize() with a 500ms render budget
 
-The kernel calls the namespace's `humanize()` before rendering. For `doc:gdrive:1abc...`, the gdrive matcher fetches the doc title via the cached MCP handle. On failure, the card falls back to the raw scope with a `(could not resolve title)` annotation rather than blocking.
+The kernel calls the namespace's `humanize()` before rendering, but **never blocks on it.** Spec:
+
+1. Kick `humanize(scope)` immediately on `requestApproval`.
+2. Race it against a **500ms timer.**
+3. If `humanize()` resolves first → card ships with the humanized title.
+4. If the timer fires first → card ships with the raw scope as the title; when `humanize()` later resolves (success), patch via `editMessageText` to the humanized version.
+5. If `humanize()` rejects or times out fully (5s ceiling) → leave the raw scope and append a small `(could not resolve)` annotation.
+
+The card is never delayed by humanize.
 
 ### 8.3 Preserved patterns (must not regress through migration)
 
-- **`perm:more` expand button** at `gateway.ts:1946` — the See-more pattern is the basis of the new card's expand. Keep the same UX shape.
-- **`summarizeToolForTitle` lift-to-title** at `gateway.ts:1938` (import at `:269`) — preserve the most-identifying-field-into-title pattern. The new card uses the same helper for `tool:` scopes.
+- **`perm:more` expand button** at `gateway.ts:1946` — basis of the new card's expand. Same UX shape.
+- **`summarizeToolForTitle` lift-to-title** at `gateway.ts:1938` (import at `:269`) — preserve for `tool:` scopes.
 - **`vd:unlock` deferred-secret card flow** at `gateway.ts:5497` — Phase 2 migrates this surface; the inline-passphrase capture step must survive the move.
 - **`aq:` topic-routing + reaction lifecycle** at `gateway.ts:8209` — inherit, do not rebuild.
 - **`allowFrom` enforcement on every callback** — pattern at `gateway.ts:8218-8222`.
 
-## 8a. First-run onboarding for new MCPs
+## 8a. First-run onboarding for new MCPs (v1: two options only)
 
-When a new MCP wrapper is enabled, the kernel posts a one-time setup card before the first per-resource prompt fires. Avoids the "grant once, then widen via /approvals" anti-pattern where users grant a narrow scope under prompt fatigue and never broaden it.
+When a new MCP wrapper is enabled, the kernel posts a one-time setup card before the first per-resource prompt fires.
 
 ```
 🆕 Google Drive enabled. How should klanker access your Drive?
 
 [ Allow all of Drive (less secure, fewer prompts) ]
-[ Choose folders now ]                       ← v1: links to /approvals add
-[ Per-doc approval (default, more secure)    ]
+[ Per-doc approval (default, more secure)         ]
 ```
 
-`Choose folders now` in v1 routes to `/approvals add` with a pre-filled folder-glob template. The folder picker UI is future work.
+**v1 ships exactly these two options.** The v2 draft included a third "Choose folders now → /approvals add with glob template" option — that was the v1 anti-pattern in disguise (user grants narrow, then has to widen under fatigue). It is dropped.
+
+Footnote: folder-scoped grants land in **Phase 3.5** with a real Telegram folder picker. Until then, users widen via `/approvals add` post-grant if the per-doc default proves too noisy.
 
 ## 9. Audit, revocation, staleness
 
-- `/approvals list` — standing decisions **grouped by agent first**, then surface (`klanker → secret:* → ...`, `klanker → doc:gdrive:* → ...`). User mental model is "what can klanker do?", not "what tool grants exist?". GitHub-style permissions UI is the reference.
-- `/approvals revoke <id>` — single revoke; logs to `approval_audit`. **Every grant card's confirmation message includes `· /approvals revoke <id>` inline** so revocation is one tap from the grant itself.
-- `/revoke-all` — killswitch. Sets `revoked_at` on every active row **and rotates the bot token** via the vault. A compromised agent that exfiltrated the token retains its parallel channel otherwise; the kill must be complete.
+- `/approvals list` — paginated, two-level. Top-level `/approvals list` shows agent summary counts (`klanker: 12 grants, gymbro: 3 grants, …`) with tappable inline buttons to drill in. `/approvals list <agent>` shows up to 20 rows; older rows accessible via inline `Next →` button. Each row has inline `Revoke`. Telegram's 4096-char per-message cap is respected by capping at 20 rows + footer. User mental model is "what can klanker do?"; GitHub-style permissions UI is the reference.
+- `/approvals revoke <id>` — single revoke; logs to `approval_audit` and appends to `approval_revocations` chain. **Every grant card's confirmation message includes `· /approvals revoke <id>` inline** so revocation is one tap from the grant itself.
+- `/approvals add` — wizard for adding grants outside a prompt context (e.g. "allow all of Drive" post-onboarding).
+- `/approvals stats` — surfaces 7-day request/grant/deny counts per agent. Used by the soft-alert in §11.
+- `/revoke-all` — killswitch. See §9.2 for the exact ordered sequence.
 
-### 9.1 Staleness model (replaces weekly digest)
+### 9.1 Staleness model with weekly digest coalescing
 
-Drop fixed-cadence digests. Replace with two triggers:
+Drop fixed-cadence digests of *everything*. Replace with two triggers, both rate-limited:
 
-- **Threshold-triggered:** when `count(allow_always WHERE never_seen_in_digest) >= 3`, send a digest of the new standing grants. Rate-limited to at most one digest per 24h.
-- **Staleness-triggered:** for each `allow_always` row where `last_used_at` is more than 30 days ago, surface a one-shot "this grant hasn't fired in 30d, revoke?" prompt with inline `Revoke` / `Keep` buttons. One prompt per row; on `Keep`, suppress for another 30d.
+- **New-grants digest (threshold-triggered):** when `count(allow_always WHERE never_seen_in_digest) >= 3`, send a digest of the new standing grants. Rate-limited to at most one digest per 24h.
+- **Stale-grants digest (weekly coalescing).** v2 specced one prompt per row, which scales badly: 40 stale rows = 40 separate "revoke?" prompts. v3: stale prompts coalesce into a **single weekly digest** with the same threshold-trigger logic — *N grants haven't fired in 30d, review?* — with one inline `Revoke` button per row in the digest. **No more than one staleness digest per week regardless of how many rows go stale.** Suppression is set per-row when the user taps `Keep` (suppressed for another 30d) or implicitly when the row remains in the digest unchanged for 4 consecutive weeks (auto-revoke under "stale and ignored", configurable).
 
 Steal sudo's pattern: surface staleness, not totals.
 
-## 10. Long-poll protocol
+### 9.2 `/revoke-all` ordered sequence
 
-The vault broker is request/response. Approvals can wait up to 5 minutes for a user tap. Spec:
+`/revoke-all` is a multi-step operation with real failure modes; spec the ordering exactly:
 
-1. `requestApproval` returns `{ status: 'pending', request_id }` immediately and synchronously.
-2. The agent calls `awaitDecision({ request_id })` on a separate socket connection. The broker holds the connection open with periodic 10-second keepalive frames (`{ type: 'keepalive' }`) until either:
-   - the user taps → broker sends `{ status: 'granted'|'denied', mode, ttl }` and closes.
-   - the 5-minute timeout fires → broker sends `{ status: 'timeout' }` and closes.
-3. Agent disconnect mid-poll: broker keeps the decision row; on reconnect+`awaitDecision` with the same request_id, replays the latest state.
+1. **Telegram `revokeToken`** — call the Bot API to evict the current token at Telegram's edge. If this fails: abort, surface `revoke_all_step1_failed`; nothing has changed yet.
+2. **Mark all active rows revoked** — append-only chain entry per row, batch transactional. If this fails after step 1: token is already dead at Telegram; the gateway will fail to receive updates on next poll. Operator must run `switchroom token rotate` to restore. Surface `revoke_all_step2_failed_run_token_rotate`.
+3. **Write new token to vault** — under the existing bot-token slot (Phase 0).
+4. **SIGHUP gateway** — gateway re-reads token from vault. If the gateway fails to come back up: vault still holds the new token; operator can re-run `revoke-all` (step 1 is idempotent — Telegram `revokeToken` on an already-revoked token is a no-op) or just `systemctl --user restart switchroom-gateway.service`.
+5. **Mark `revoke-all` complete** — audit row.
 
-Long-poll over 2s polling: lower latency, fewer round-trips, trivial to implement on top of the existing broker IPC.
+`switchroom token rotate` is the recovery command — idempotent re-run of steps 1, 3, 4. Document this in the killswitch help text.
+
+## 10. Wait protocol — short-poll, not long-poll
+
+The vault broker is request/response. Approvals can wait up to 5 minutes for a user tap. v2 specced long-poll (broker holds the connection open with keepalives); v3 drops that.
+
+**Why drop.** Long-poll ties up a broker socket per pending request, opens a small DoS surface (an agent that opens many requests but never reads exhausts file descriptors), and requires keepalive framing inside the existing request/response IPC. None of that complexity is necessary.
+
+**Short-poll spec:**
+
+1. Agent calls `requestApproval(...)` → returns `{ status: 'pending', request_id }` immediately.
+2. Agent calls `lookupDecision({ request_id })` every **2 seconds**. Broker responds immediately with `{ status: 'pending' | 'granted' | 'denied' | 'expired', mode?, ttl? }`.
+3. On `granted`/`denied`/`expired`, agent stops polling.
+4. On gateway restart between polls, the agent simply retries — `lookupDecision` is stateless from the agent's perspective.
+
+**Caps (DoS defense):**
+
+- Per `agent_unit`: max **2 concurrent pending** requests. A third `requestApproval` returns `{ status: 'rate_limited', retry_after_ms: 5000 }`.
+- Global cap: **32 pending** requests across all agents. New requests get `rate_limited` until the queue drains.
+
+This is a much smaller change to the existing broker than long-poll; no socket-lifetime semantics, no keepalive, no reconnect-replay logic.
 
 ## 11. Risks and open questions
 
-- **Phase 4 `perm:` migration: kernel-only, not dual-write.** The existing `perm:always` path writes a Claude Code allow-rule via `permission-rule.ts` (133 lines). Two options:
-  - *Dual-write*: kernel writes its decision row AND emits the Claude rule, with reconciliation on revoke. Reconciliation is a chronic source of bugs (settings.json edited externally, partial writes, etc.).
-  - *Kernel-only* (recommended): the kernel becomes the source of truth. Claude Code's `settings.json permissions.allow` becomes managed by the kernel — the user no longer hand-edits it.
-  Audit is the entire point of this RFC; pick kernel-only and accept that we lose Claude's native always-allow path.
-- **`--print` mode and Phase 2 secrets.** `--print` bypasses Claude's permission-request flow (documented at `docs/stream-json-daemon-mode.md:401`). Secrets enforcement lives broker-side, not gateway-side, so Phase 0 (bot token in vault) plus the broker-mediated secret fetch means `--print` agents *still* go through the kernel for secret access — the bypass only affects tool-permission prompts, not secret unlocks. Document explicitly.
+- **Phase 4 `perm:` migration: kernel-only with settings.json write-back.** The existing `perm:always` path writes a Claude Code allow-rule via `permission-rule.ts` (133 lines). v3 picks **kernel-as-source-of-truth**: the kernel becomes authoritative; on every grant change, a write-back hook rewrites Claude Code's `settings.json` `permissions.allow` from kernel state. **User/tool edits to `settings.json` get overwritten** — this is the documented cost of authoritative kernel state. A CLI command `switchroom approvals sync-settings` exists for manual reconciliation if the file gets out of sync (e.g. after a kernel-side migration). The dual-write reconciliation alternative (kernel writes its row AND emits the Claude rule, with reconciliation on revoke) was rejected for chronic-bug risk.
+- **HMAC threat-model honesty.** Repeated from §3 attack 5 and §5.1 because reviewers keep flagging it: per-row HMAC is **tamper detection, not prevention.** A same-uid attacker with `ptrace_scope=0` or `CAP_SYS_PTRACE` can read the row-integrity key from broker memory and forge rows. Real prevention needs user-namespace isolation; out of scope for v1, tracked as Phase 5+.
+- **`--print` mode and Phase 2 secrets.** `--print` bypasses Claude's permission-request flow. Secrets enforcement lives broker-side, not gateway-side, so Phase 0 (bot token in vault) plus the broker-mediated secret fetch means `--print` agents *still* go through the kernel for secret access — the bypass only affects tool-permission prompts (Phase 4), not secret unlocks. Document explicitly.
 - **Cross-agent grant scope is unit-scoped, not user-scoped.** `allow_always` for `secret:OPENAI_API_KEY` granted to klanker does **not** auto-grant to gymbro. Each `agent_unit` is a separate principal, matching existing vault grants. User-scoped grants are out of scope for v1.
-- **Callback delivery is best-effort.** If the gateway is down when the user taps, the tap is lost. 5-minute timeout, `timeout` audit row, agent re-issues if still wanted. Long-poll auto-reconnect (§10) covers agent-side restarts.
+- **Callback delivery is best-effort.** If the gateway is down when the user taps, the tap is lost. 5-minute timeout, `timeout` audit row, agent re-issues if still wanted. With nonce write-ahead persistence (§6.2), gateway restart **does not** lose pending cards — the v2 risk note about restart-loses-pending is resolved and removed.
 - **OAuth tokens (Google refresh tokens) live in vault.** Kernel asks vault for the token by slot name; vault enforces its own grant on that slot; kernel never persists raw tokens.
 - **Group / multi-user is out of scope but trip-wired.** The drift-revocation rule (§5.2) makes this safe-by-default: the moment `allowFrom` grows past one entry, every standing grant becomes dormant pending re-confirmation.
-- **Tap-budget target.** Day 1 of Drive enablement: 10–30 taps expected (cold cache, no folder grants). Steady state after onboarding: <5 taps/day. If exceeded, **batch coalescing** kicks in: the kernel buffers prompts for 5 seconds; if 3+ pending share a scope-prefix (e.g. `doc:gdrive:folder/Work/*`), it collapses into a single "klanker is requesting access to 4 docs in /Work — allow folder?" card.
+- **Tap-budget target and instrumentation.** Day 1 of Drive enablement: 10–30 taps expected (cold cache, no folder grants). Steady state: <5 taps/day. **Instrumentation:** `/approvals stats` surfaces 7-day tap counts per agent off the existing audit table. **Soft-alert (DM)** at >10 taps/day sustained for 3 days. If exceeded, **batch coalescing** kicks in: the kernel buffers prompts for 5 seconds; if 3+ pending share a scope-prefix (e.g. `doc:gdrive:folder/Work/*`), it collapses into a single "klanker is requesting access to 4 docs in /Work — allow folder?" card.
 
 ## 12. Migration plan
 
-**Phase 0 — bot token to vault. Prerequisite for everything else.** Move the Telegram bot token from its current filesystem location into the vault under a slot only `switchroom-gateway.service` can unlock. Any agent with filesystem read of the current token location is **already game-over** — it can post fake approval cards as the bot and intercept the user's tap. The kernel's whole trust chain depends on this. ~0.5 day.
+**Phase 0 — bot token to vault. Prerequisite for everything else.** Move the Telegram bot token from its current filesystem location into the vault under a slot only `switchroom-gateway.service` can unlock. Any agent with filesystem read of the current token location is **already game-over** — it can post fake approval cards as the bot and intercept the user's tap. ~0.5 day.
 
-**Phase 1 — kernel folded into vault broker.** New tables in `vault.db`, new RPC methods on `src/vault/broker/server.ts`, broaden peercred regex (§4.1), add HMAC row protection (§5.1), add `apv:` callback router in gateway, `/approvals list|revoke|add` commands, long-poll protocol (§10). ~1 day (was ~2; vault-broker fold-in saves the day).
+### 12.0.1 Phase 0 rollback plan
+
+The token migration is a real cutover with three failure modes; spec each:
+
+1. **Atomic move sequence.**
+   - Read token from current filesystem location.
+   - Write to vault slot; verify by reading it back.
+   - Restart the gateway with vault-backed token loading; verify it can post a smoke message.
+   - **Only after the smoke succeeds**, `shred -u` the old file.
+
+2. **Failure modes.**
+   - **Vault-write fails** → abort; token still on disk; no change. Operator inspects vault state and retries.
+   - **Vault-read after write fails** (corruption, key-derivation glitch) → restore old file from backup taken before the migration; the gateway continues to read from disk; operator re-runs once vault is healthy.
+   - **Smoke message fails** → restore old file from backup; revert gateway config.
+   - **`shred` fails** (filesystem doesn't support secure delete, e.g. btrfs CoW) → log loudly and continue. Token now exists in two places — **SECURITY incident**, requires immediate token rotation via `/revoke-all` once Phase 1 ships, or via `switchroom token rotate` standalone.
+
+3. **Boot chicken-and-egg.** Gateway needs the token to start; vault needs to be unlocked to give up the token. Resolved via the existing auto-unlock mechanism at `src/vault/auto-unlock.ts` (machine-bound encryption of the vault passphrase, decrypted at boot using `/etc/machine-id` + per-user state). If auto-unlock is **not enabled** on this machine, gateway start fails fast with: `vault locked, run "switchroom vault unlock" or enable auto-unlock with "switchroom vault broker enable-auto-unlock"`. The error is actionable; no silent boot loop.
+
+**Phase 1 — kernel folded into vault broker.** New tables in `vault-grants.db` (no rename, see §4), new RPC methods on `src/vault/broker/server.ts`, broaden peercred regex with pidfd pinning (§4.1), HMAC row protection with HKDF + key versioning (§5.1), revocation chain (§5.3), audit chain (§5.4), short-poll wait protocol (§10), `apv:` callback router in gateway, `/approvals list|revoke|add|stats` commands, drift revocation, write-ahead nonce persistence, plus tests matching the existing broker's coverage (16 broker test files under `src/vault/broker/`). **~2 days, not 1.** v2's 1-day estimate ignored the new subsystems and tests.
 
 **Phase 2 — secrets as first consumer.** Migrate the deferred-secret card path (`gateway.ts:5497`) to call the kernel. Lower-traffic, validates the abstraction, and the move from in-memory to SQLite is itself a real upgrade. Preserve the inline-passphrase capture UX. ~1 day.
 
-**Phase 3 — Google Docs MCP wrapper as kernel consumer.** Build the MCP wrapper (default: `taylorwilsdon/google_workspace_mcp`) that calls the kernel for every doc/folder access. OAuth tokens in vault, extending the existing `auth:` slot pattern (`gateway.ts:8179`, `src/auth/`). Includes the §8a onboarding card and the §11 batch coalescing. ~2 days.
+**Phase 3 — Google Docs MCP wrapper as kernel consumer.** Build the MCP wrapper (default: `taylorwilsdon/google_workspace_mcp`) that calls the kernel for every doc/folder access. OAuth tokens in vault, extending the existing `auth:` slot pattern (`gateway.ts:8179`, `src/auth/`). Includes the §8a onboarding card (two options only) and the §11 batch coalescing. ~2 days. **Phase 3.5 — folder picker UI** is split out: real Telegram folder picker for grant scopes; ~1 day, can land separately once Phase 3 stabilizes.
 
-**Phase 4 — `perm:` migration (separate PR, separate review).** Highest regression risk; runs on the hot path of every tool call. Kernel-only as decided in §11. Defer until kernel has weeks of production proof. ~2 days.
+**Phase 4 — `perm:` migration with settings.json write-back (separate PR, separate review).** Highest regression risk; runs on the hot path of every tool call. Kernel-only with write-back to `settings.json` as decided in §11. Defer until kernel has weeks of production proof. ~2 days.
 
 ## 13. Estimated effort
 
-**Phases 0–3: ~4.5 focused engineering days.** Phase 4 is a separate ~2-day effort under its own review. The vault-broker fold-in shaves roughly a day off the v1 estimate.
+**Phases 0–3: ~6.5 focused engineering days** (revised up from v2's 4.5d).
+
+| Phase | v2 estimate | v3 estimate | Delta drivers |
+|------:|------------:|------------:|---------------|
+| 0     | 0.5d        | 0.5d        | — |
+| 1     | 1d          | 2d          | HKDF + key versioning, revocation chain, audit chain, pidfd pinning, short-poll + caps, drift canonicalization, write-ahead nonces, `/approvals list/revoke/add/stats`, settings.json write-back hook, tests matching existing 16-file broker coverage |
+| 2     | 1d          | 1d          | — |
+| 3     | 2d          | 2d          | — (3.5 folder picker split out as separate ~1d) |
+| **Total 0–3** | **4.5d** | **6.5d** | |
+
+Phase 4 is a separate ~2-day effort under its own review. Phase 3.5 (folder picker) is ~1d and can ship anytime after Phase 3.
 
 ## 14. Out of scope
 
@@ -302,4 +418,6 @@ Long-poll over 2s polling: lower latency, fewer round-trips, trivial to implemen
 - Per-action MFA prompts beyond approval — Telegram 2FA is sufficient at this trust level.
 - Web dashboard approval UX (CLI + Telegram only for v1).
 - User-scoped (cross-agent) grants — every grant is unit-scoped in v1.
-- Per-agent BindPaths / user-namespace isolation of the DB file — HMAC row protection (§5.1) is the v1 defense; namespace isolation is future hardening.
+- Per-agent BindPaths / user-namespace isolation of the DB file — HMAC row protection (§5.1) is the v1 detection layer; namespace isolation is Phase 5+ hardening for prevention.
+- Bash-arg matching beyond prefix (§6.1) — Phase 4+ work.
+- DB filename rename to `vault.db` — kept as `vault-grants.db` to preserve downgrade path (§4).

--- a/docs/rfcs/approval-kernel.md
+++ b/docs/rfcs/approval-kernel.md
@@ -1,242 +1,162 @@
-# RFC: Unified human-approval kernel
+# RFC B: Unified human-approval kernel
 
-Status: Draft v3
+Status: Draft v4
 Author: klanker (sub-agent draft)
 Date: 2026-05-06
 
+Prerequisite: **RFC A — Bot token to vault** (`docs/rfcs/bot-token-to-vault.md`) must land first. Without it the kernel's trust chain has a hole — an agent that can read the bot token can post fake approval cards.
+
 ## 1. Summary
 
-Today switchroom asks the user to approve sensitive actions through at least four independent code paths, each with its own callback grammar, storage, and UX. This RFC proposes a single approval kernel — folded into the existing **vault broker** — that all current and future surfaces (secrets, vault grants, tool/skill permission requests, Google Docs and other MCPs) plug into. One process, one socket, one ACL surface, one SQLite file, one audit log, one Telegram card primitive.
+Switchroom asks the user to approve sensitive actions through several independent code paths today: deferred-secret cards (`vd:`), vault grants, and the various per-MCP prompts that are about to multiply as Drive, Notion, Slack, and Gmail wrappers come online. This RFC proposes a single approval kernel — folded into the existing vault broker — that **secrets and MCP tool calls** plug into. One process, one socket, one SQLite file, one audit table, one Telegram card primitive, one set of `/approvals` commands.
 
-The kernel reuses the broker's existing peercred + cgroup transport and ACL plumbing for **agent-identity gating only**. Almost everything else listed below — scope matching, HMAC row protection, HKDF-derived row-integrity key, append-only revocation chain, hash-chained audit, pidfd-pinned peercred, drift revocation, short-poll wait protocol, settings.json write-back — is **net-new code**. v2 leaned on "reuse" framing that obscured this; v3 names new subsystems plainly.
+**Scope is deliberately narrow.** The kernel covers secrets, vault grants, and MCP tool calls (Drive, Notion, Slack, Gmail, etc.). Tool/skill permissions stay on the existing `permission-rule.ts` + `settings.json` path — see §14.
 
 ## 2. Motivation
 
-Four approval-shaped surfaces exist today:
+Approval-shaped surfaces in the codebase today:
 
 - **Deferred-secret cards** with `vd:unlock|cancel` callbacks — `telegram-plugin/gateway/gateway.ts:5497`.
-- **Vault grants** via the `/vault grant` wizard, persisted to SQLite at `~/.switchroom/vault-grants.db` — schema migrated in `src/vault/grants.ts:59`.
-- **Tool/Skill permission requests** via MCP `notifications/claude/channel/permission_request`, rendered as `perm:allow|deny|always` cards — `telegram-plugin/gateway/gateway.ts:1938` (card text) and `:1946-1947` (keyboard).
-- **Operator and dashboard prompts** under the `op:` and `auth:` callback prefixes — `telegram-plugin/gateway/gateway.ts:8179` (auth) and `:8187` (op).
+- **Vault grants** via the `/vault grant` wizard, persisted to SQLite at `~/.switchroom/vault-grants.db` — schema in `src/vault/grants.ts`.
+- **Operator and dashboard prompts** under `op:` and `auth:` callback prefixes — `telegram-plugin/gateway/gateway.ts`.
 
-Adding a Google Docs MCP — and the inevitable Notion, Slack, and Gmail wrappers after it — means a fifth, sixth, and seventh surface unless the approval shape is unified. Each new surface duplicates: callback parser, storage decision (memory vs disk), TTL semantics, revocation command, audit trail. The cost compounds; the user sees inconsistent UX; there is no single `/revoke-all` killswitch.
+Adding a Google Drive MCP, then Notion, Slack, and Gmail, means adding a fresh approval surface every time unless the shape is unified. Each duplicates: callback parser, storage decision, TTL semantics, revocation command, audit trail. The user sees inconsistent UX and there is no `/revoke-all` killswitch covering everything.
 
-## 3. Threat model and trust root
+## 3. Threat model
 
-Switchroom is a **1:1 bot ↔ user** product. A single allowlisted Telegram `user_id` is identity, approver, and audit subject. This is a load-bearing assumption — the kernel relies on it. If group or multi-user bots ever ship, an `approvers` subset of `allowFrom` plus DM-only delivery of approval cards must be added; flagged here so future readers know what to revisit.
+Trust root: the user's Telegram account (with 2FA). An inbound `callback_query.from.id` is authenticated by Telegram's bot session and cannot be spoofed remotely.
 
-Telegram (with 2FA) is the auth factor. Inbound `callback_query.from.id` is authenticated by Telegram's bot session and cannot be spoofed remotely.
+Same-uid compromise of an agent process is **game-over**, per `docs/vault.md:227` ("ACL is misconfiguration protection, not a security boundary"). The kernel does NOT defend against same-uid attackers; it defends against accidental misuse and provides an auditable trail of approvals. Filesystem perms and the vault passphrase are the real boundary; this RFC works inside that envelope.
 
-**Local threat surface.** All switchroom processes — gateway, agents, brokers — run as the same uid (`kenthompson`) under `systemd --user`. Filesystem permissions are *not* a security boundary between gateway and an agent. Concrete attacks the kernel must defend against:
-
-1. **Bot token theft.** An agent that can read the bot token from disk can post fake approval cards as the bot and intercept the user's tap. The kernel's whole trust chain collapses. Phase 0 below moves the token into the vault.
-2. **Cgroup spoofing.** Under cgroup v2 user delegation, a same-uid attacker can `mkdir` a fake cgroup path that looks like `switchroom-klanker.service` and move its own pid into it. `/proc/<pid>/cgroup` then reports the spoofed name. Documented at `src/vault/broker/peercred.ts:240-245`. Mitigation: `verifySystemdUnit` (`peercred.ts:254`) cross-checks every peercred result against `systemctl --user show`. **The kernel must call this on every request, not just at startup.** Without it, peercred is attacker-controlled input.
-3. **PID-reuse / TOCTOU race on peercred.** Even with `verifySystemdUnit`, between `accept()` returning `SO_PEERCRED` and the broker reading `/proc/<pid>/cgroup` and `/proc/<pid>/status`, the original pid can exit and the kernel can recycle the pid for a *different* same-uid process whose cgroup IS a real switchroom unit. The attacker's exited process "becomes" the legitimate unit's pid for the duration of the read. Broadening the unit regex to long-running services (§4.1) makes this race far easier to exploit than the cron-only world, because long-running unit pids are observable and predictable. **Mitigation (NEW in v3):** immediately after `SO_PEERCRED`, call `pidfd_open(2)` to pin the process. All subsequent `/proc` reads route through `/proc/self/fdinfo/<pidfd>` (or equivalent); `pidfd_send_signal(pidfd, 0)` checks liveness before honoring the request. If the pidfd reports the process exited, reject with `peer_gone`. This is a new code path on top of the existing peercred logic, not a reuse.
-4. **Direct DB writes.** Any agent can `sqlite3` open `vault-grants.db` and `INSERT` a forged grant row, bypassing the broker entirely. Mitigation in §5.
-5. **HMAC threat-model honesty.** Per-row HMAC (§5.1) provides **tamper detection, not prevention.** A same-uid attacker with `ptrace_scope=0` or `CAP_SYS_PTRACE` can attach to the broker process and read the HKDF-derived row key out of memory, then mint forgeable rows. HMAC raises the bar from "trivial sqlite3 INSERT" to "ptrace + key extraction + chain replay" — meaningful but not a hard boundary. Real prevention requires per-agent user-namespace isolation so agent units cannot see the DB file or the broker's memory at all. That is **out of scope for v1** and tracked as Phase 5+ hardening.
-
-Authorization happens at the IPC seam, never at the filesystem layer.
+Two existing protections matter and are reused as-is: peercred + cgroup unit identity at the broker socket (`src/vault/broker/peercred.ts`), and per-agent ACL enforcement (`src/vault/broker/acl.ts`). The peercred regex needs broadening to long-running units (§4.1); that's a real bug fix, not added hardening.
 
 ## 4. Design — fold into the vault broker
 
-The kernel does **not** stand up a parallel broker. Approvals live as new tables in the existing `vault-grants.db`. **v3 keeps the filename** (`vault-grants.db`) rather than renaming to `vault.db` — the rename was cosmetic and would have made downgrade after Phase 1 impossible (HMAC'd rows in a renamed file are unverifiable to pre-rename binaries; the only "rollback" would be a clean re-init of approvals). Adding tables to the existing file ships the same capability with a real downgrade path.
+The kernel does not stand up a parallel broker. Approvals live as new tables in the existing `vault-grants.db`. Filename is preserved (no rename) to keep downgrade simple.
 
 The existing vault broker at `src/vault/broker/server.ts` grows new RPC methods:
 
-- `requestApproval({ scope, why, ttl_hint })` → returns `{ status: 'pending', request_id }` immediately.
+- `requestApproval({ scope, why, ttl_hint })` → `{ status: 'pending', request_id }` immediately.
 - `lookupDecision({ request_id | scope })` → checks for a live grant or pending decision. Used both for fast-path matching and for the short-poll wait loop (§10).
 - `recordDecision({ request_id, mode, ttl })` → invoked by the gateway when the user taps.
 - `revoke({ id, reason })` and `listForUser({ user_id })`.
 
-**Why fold rather than fork.** The vault broker already owns: SO_PEERCRED authentication (`peercred.ts`), the systemd cross-check (`peercred.ts:254`), per-agent ACL enforcement (`src/vault/broker/acl.ts`), an audited DB handle, and a battle-tested IPC protocol. Reusing the IPC, peercred transport, and the agent-identity ACL machinery is real reuse; **scope matching, HMAC row integrity, the revocation chain, the audit chain, the short-poll layer, and the apv: callback router are all new**. v2's effort estimate undercounted these; §13 corrects it.
+**Honest reuse claims.** What is reused: the IPC socket, peercred + cgroup transport, the agent-identity ACL machinery, the audited SQLite handle, broker test scaffolding. What is **new code** named as such: the `apv:` callback router, the ScopeMatcher subsystem (§6), the short-poll wait protocol (§10), the staleness digest job (§9.1), the batch-coalescing logic (§11), the `/approvals` command surface.
 
-### 4.1 Peercred regex must be broadened, with pidfd pinning
+### 4.1 Peercred regex must be broadened
 
-`peercred.ts:223` currently matches **only** cron units:
+`src/vault/broker/peercred.ts:223` currently matches **only** cron units:
 
 ```
 /^switchroom-[a-zA-Z0-9_-]+-cron-\d+\.service$/
 ```
 
-Long-running agent units (`switchroom-klanker.service`) are not matched and would fail the kernel's auth check. Replace with:
+Long-running agent units like `switchroom-klanker.service` are not matched and fail the broker's auth check today. Replace with:
 
 ```
 /^switchroom-[a-zA-Z0-9_-]+(-cron-\d+)?\.service$/
 ```
 
-Two binding requirements:
-
-1. **Route every approval RPC through `verifySystemdUnit` (`peercred.ts:254`).** Without it a same-uid attacker bypasses the broker via cgroup mkdir.
-2. **Pidfd-pin the peer before any `/proc` read (NEW).** As called out in §3 attack 3, broadening to long-running units enlarges the TOCTOU window. `pidfd_open(pid)` immediately after accept; treat the pidfd as the authoritative process handle for the lifetime of the RPC; reject with `peer_gone` if liveness check fails. This is genuinely new code in `peercred.ts` — not a tweak to `verifySystemdUnit`.
+This is a real bug fix needed for the kernel (and arguably for any long-running agent's vault access today). Pair it with the existing `verifySystemdUnit` cross-check at `peercred.ts:254`, which the broker already calls on every request.
 
 ## 5. Decision storage
 
-New tables in `vault-grants.db`:
+One table, ordinary SQLite columns, no HMAC, no chains, no nonce side-table.
 
 ```sql
 CREATE TABLE approval_decisions (
-  id              TEXT PRIMARY KEY,    -- UUID v4 (durable identifier)
-  agent_unit      TEXT NOT NULL,       -- systemd unit name, verified via peercred + systemd + pidfd
-  scope           TEXT NOT NULL,       -- see §6
-  state           TEXT NOT NULL,       -- 'active' | 'revoked'  (used in HMAC tuple)
-  decision        TEXT NOT NULL,       -- allow_once | allow_always | allow_ttl | deny | deny_perm
-  ttl_expires_at  INTEGER,             -- unix-ms, NULL for non-ttl
-  ttl_original_ms INTEGER,             -- for sliding-window renewal hard cap (§7)
-  granted_at      INTEGER NOT NULL,
-  max_lifetime_at INTEGER,             -- granted_at + max_lifetime; sliding renewal cannot pass this
-  last_used_at    INTEGER,             -- for sliding-window TTL + staleness digest
-  granted_by_user_id INTEGER NOT NULL, -- Telegram user_id
-  granted_at_allowfrom TEXT NOT NULL,  -- canonical-JSON; see §5.2
-  revoked_at      INTEGER,
-  revoke_reason   TEXT,
-  key_version     INTEGER NOT NULL,    -- HKDF key version (§5.1)
-  hmac            BLOB NOT NULL        -- see §5.1; covers tuple including `state`
-);
-
-CREATE TABLE approval_revocations (
-  -- Append-only, HMAC-chained. See §5.1 for forgery defense.
-  seq             INTEGER PRIMARY KEY AUTOINCREMENT,
-  ts              INTEGER NOT NULL,
-  decision_id     TEXT NOT NULL,
-  reason          TEXT,
-  prev_hmac       BLOB,                -- previous row's hmac (chain link)
-  key_version     INTEGER NOT NULL,
-  hmac            BLOB NOT NULL        -- HMAC over (seq, ts, decision_id, reason, prev_hmac)
+  id                 TEXT PRIMARY KEY,    -- UUID v4
+  agent_unit         TEXT NOT NULL,       -- systemd unit, verified via peercred + verifySystemdUnit
+  scope              TEXT NOT NULL,       -- see §6
+  decision           TEXT NOT NULL,       -- allow_once | allow_always | allow_ttl | deny | deny_perm
+  ttl_expires_at     INTEGER,             -- unix-ms, NULL for non-ttl
+  granted_at         INTEGER NOT NULL,
+  granted_by_user_id INTEGER NOT NULL,    -- Telegram user_id
+  last_used_at       INTEGER,             -- for sliding-window TTL + staleness
+  revoked_at         INTEGER,
+  revoke_reason      TEXT
 );
 
 CREATE TABLE approval_audit (
-  -- Append-only, hash-chained.
-  seq             INTEGER PRIMARY KEY AUTOINCREMENT,
-  ts              INTEGER NOT NULL,
-  agent_unit      TEXT NOT NULL,
-  scope           TEXT NOT NULL,
-  action          TEXT NOT NULL,       -- request | grant | deny | revoke | timeout | match | drift_revoke | tamper
-  decision_id     TEXT,
-  request_context TEXT,                -- JSON: why-string, caller frame, request_id
-  prev_hmac       BLOB,                -- previous row's hmac
-  key_version     INTEGER NOT NULL,
-  hmac            BLOB NOT NULL        -- HMAC over row tuple including prev_hmac
-);
-
-CREATE TABLE approval_pending_nonces (
-  -- Persisted before the card ships to Telegram (§6.1, §11).
-  request_id      TEXT PRIMARY KEY,
-  nonce           TEXT NOT NULL,
-  scope           TEXT NOT NULL,
-  agent_unit      TEXT NOT NULL,
-  created_at      INTEGER NOT NULL,
-  expires_at      INTEGER NOT NULL,
-  consumed_at     INTEGER
+  seq         INTEGER PRIMARY KEY AUTOINCREMENT,
+  ts          INTEGER NOT NULL,
+  agent_unit  TEXT NOT NULL,
+  scope       TEXT NOT NULL,
+  action      TEXT NOT NULL,    -- request | grant | deny | revoke | timeout | match
+  decision_id TEXT,
+  context     TEXT              -- JSON: why-string, request_id
 );
 ```
 
-UUID is the durable primary key. The 8-hex callback token (matching existing `generateAskId` at `telegram-plugin/ask-user.ts:133`) is mapped to the UUID only for the prompt's lifetime.
+UUID is the durable primary key. The 8-hex callback token (matching existing `generateAskId` at `telegram-plugin/ask-user.ts:133`) maps to the UUID for the prompt's lifetime only.
 
-### 5.1 SQLite same-uid write protection (HMAC every row, with HKDF + chains)
+The "same-uid attacker writes a forged grant row directly to SQLite" attack is acknowledged per §3 and not defended against in code; it's defended against by the trust model documented in `docs/vault.md`.
 
-A same-uid agent can open the DB directly and `INSERT` a forged grant. Defense (NEW subsystem; not present in any existing code path):
+### 5.1 Config-drift auto-revocation
 
-- **Row-integrity key derivation.** The broker derives the row-integrity key via HKDF-SHA256 from the **vault master key**, with a fixed `info = "switchroom-approval-rowmac-v1"` and a salt stored in the `vault_meta` table. The master key is sealed at rest and only available post-vault-unlock — the same property the existing vault relies on. **The key is NOT a fresh random per unlock** — that v2 design broke `allow_always` semantics across restarts (verifying old rows would be impossible). Persistence across restarts is the whole point.
-- **Vault relock semantics.** When the vault is locked (e.g. operator runs `switchroom vault lock`), the row-integrity key is unavailable, so all standing grants become temporarily unverifiable. This is **acceptable**: the user is already gated when the vault is locked (no agent can fetch a secret either), so denying every approval lookup with `vault_locked` is correct behavior. On next unlock the key re-derives and grants verify again.
-- **Key rotation.** A `key_version` column on every HMAC'd row plus `vault_meta.current_key_version` lets the operator rotate by deriving a new version, re-MACing rows in a background job, then advancing the current version. Old-version rows remain verifiable until rewritten.
-- **Per-row HMAC.** Every `approval_decisions`, `approval_revocations`, and `approval_audit` row carries an HMAC-SHA256 over its column tuple. **The decisions-table HMAC includes `state`**, so an attacker who flips `revoked_at` to `NULL` cannot resurrect a revoked grant — see §5.3.
-- **Read path verifies HMAC** before honoring a row. Mismatch → row treated as not-present, `tamper` audit row written, operator alert fires.
-- **Threat downgrade language.** Per §3 attack 5, this is detection, not prevention. Document plainly.
+A grant recorded when `allowFrom = ["U1"]` must not silently extend if `allowFrom` later becomes `["U1", "U2"]`. We don't HMAC-bind the approver set into the row, but we do compare on lookup:
 
-### 5.2 Config-drift auto-revocation
-
-A grant recorded when `allowFrom = ["U1"]` must not silently extend if `allowFrom` later becomes `["U1", "U2"]`. At every `lookupDecision`:
-
-- Re-read current `allowFrom` from access config.
-- Compare against `granted_at_allowfrom`. **Both values are canonicalized identically before compare:** array elements are unicode-NFC-normalized, sorted lexicographically by NFC byte-order, no whitespace, JSON-canonical-encoded (RFC 8785 subset — sorted, no insignificant whitespace, no unnecessary escapes). Without this, identical sets serialized differently produce spurious drift-revocations.
-- If canonical forms differ, treat as auto-revoked: write `drift_revoke` to audit, return no-grant, force re-prompt under the new approver set.
+- Store the approver set captured at grant time alongside the row (canonicalized JSON: NFC-normalized, sorted lexicographically, no insignificant whitespace).
+- At every `lookupDecision`, re-read the current `allowFrom`, canonicalize identically, compare.
+- If they differ: write a `drift_revoke` audit row, return no-grant, force re-prompt under the new approver set.
 - If the current set has more than one approver, all standing grants are dormant until the operator re-confirms each one.
 
-Drift is logged loudly. This goes in §7 (decision modes) and §11 (risks).
-
-### 5.3 Revocation propagation and forgery defense
-
-Soft-delete via `revoked_at` alone is forgeable: a same-uid attacker with the row-integrity key (per §3 attack 5 threat model) — or an attacker who lands a single byte-flip of `revoked_at` to NULL while bypassing HMAC verification — could resurrect a revoked grant if the original `(state="active", revoked_at=NULL)` HMAC remains valid. Defense:
-
-- **State-bound HMAC.** The decisions HMAC tuple includes `state`. A revoke writes `state="revoked"` plus `revoked_at` plus a fresh HMAC over the new tuple. A row with `revoked_at IS NOT NULL` but a `state="active"` HMAC is detected as forged on read.
-- **Append-only revocation chain (`approval_revocations`).** Every revoke also appends a chain entry HMAC'd over `(seq, ts, decision_id, reason, prev_hmac)`. Lookup of a decision verifies "no chain entry references this id" by reading the latest chain head and walking back if needed; the chain is short (one entry per revoke). The chain head HMAC is also written into `vault_meta.revocation_chain_head` so truncation is detectable.
-- **Read path.** A `lookupDecision` accepts only rows that (a) HMAC-verify under their declared `state`, (b) have no entry in the revocation chain, AND (c) sit before the current chain head verified from `vault_meta`.
-
-Every grant lookup re-reads `revoked_at` and the chain head from disk at use time. **No caching across calls.** Spec'd here so it cannot be optimized away later.
-
-### 5.4 Audit hash chain
-
-Each `approval_audit` row's HMAC includes the previous row's HMAC (`prev_hmac` column). The latest `hmac` is mirrored into `vault_meta.audit_chain_head` on every write. At broker startup the head is verified against the actual last row; mismatch → operator alert (`audit_chain_break`). Without the chain, a same-uid attacker with the key can simply `DELETE FROM approval_audit WHERE id > N` to truncate. The chain makes truncation detectable; full prevention again requires user-namespace isolation.
+This makes "future multi-user support" a tripwire rather than a silent expansion.
 
 ## 6. Scope grammar
 
-Pluggable per surface. Each consumer registers a namespace and a matcher. The interface:
+Pluggable per surface. Each consumer registers a namespace and a matcher.
 
 ```ts
 interface ScopeMatcher {
-  namespace: string                     // 'secret' | 'tool' | 'doc' | 'mcp'
+  namespace: string                     // 'secret' | 'mcp' | 'doc'
   matches(grant: string, request: string): boolean
-  humanize(scope: string): Promise<string>  // for card display, async (may resolve doc titles)
+  humanize(scope: string): Promise<string>  // for card display, async
 }
 ```
 
-**ScopeMatcher is a NEW subsystem.** v2 claimed reuse of `checkEntryScope` in `src/vault/broker/acl.ts:120` — that was misleading. `checkEntryScope` is a slug-list matcher (does this `agent_slug` appear in this entry's allow/deny list?). The new ScopeMatcher is a scope-string-vs-scope-string matcher with namespace dispatch. They solve different problems. The ACL module's agent-identity gating IS reused (the kernel asks "is this agent_unit allowed to even talk to me?" via existing ACL); scope matching is built fresh.
+ScopeMatcher is **new code** — not a reuse of `checkEntryScope` in `src/vault/broker/acl.ts` (that one matches agent slugs against entry allow/deny lists; different problem). The agent-identity ACL gating IS reused; scope-string-vs-scope-string matching is built fresh.
 
-Namespaces:
+Namespaces in v1:
 
 - `secret:OPENAI_*` — env-name glob.
-- `tool:bash:rm`, `tool:bash:rm -rf` — tool name + arg pattern.
-- `tool:Skill:deploy` — Skill invocations.
 - `doc:gdrive:1abc...xyz` — specific Drive doc id.
 - `doc:gdrive:folder/789/**` — folder glob.
-- `mcp:notion:page:...`
+- `mcp:notion:page:...`, `mcp:slack:channel:...`, etc.
 
-### 6.1 Bash-arg matching grammar (v1: prefix only)
+### 6.1 Callback wire format
 
-Spec: **prefix matching only** for v1.
-
-- `tool:bash:rm` matches any command beginning with `rm` after shell tokenization.
-- `tool:bash:rm -rf` matches any command beginning with `rm -rf` after tokenization.
-- No globbing, no regex, no quote-handling beyond standard POSIX shell tokenization (which the gateway already does upstream of the kernel).
-- Tokenization is on whitespace within an argv array; the matcher compares argv-prefix equality.
-
-This is intentionally simpler than `telegram-plugin/permission-rule.ts` (133 lines wrestling with quoting, globs, option flags). Phase 4 inherits Claude's `permission-rule.ts` complexity for finer-grained matching as **future work**; v1 ships with the limitation documented and the prefix matcher behind the same `ScopeMatcher` interface so a richer Phase 4+ matcher swaps in cleanly.
-
-### 6.2 Callback wire format
-
-Telegram callback_data is hard-capped at 64 bytes including the existing `agent:` prefix injected by the bridge. Scopes will not fit. Wire format:
+Telegram callback_data is hard-capped at 64 bytes including the bridge's `agent:` prefix. Scopes won't fit. Wire format:
 
 ```
-apv:<8-hex request id>:<action>[:<param>]:<5-char base32 nonce>
+apv:<8-hex request id>:<action>[:<param>]
 ```
 
 - 8-hex request id matches `generateAskId` convention.
-- 5-char base32 nonce is **server-generated, single-use, persisted to `approval_pending_nonces` synchronously BEFORE the card is sent to Telegram (§11), deleted on first tap.** A re-tap of an old card payload is rejected with "this prompt expired."
-- Examples: `apv:a3f1b9c2:allow:k7m2x`, `apv:a3f1b9c2:ttl:1h:k7m2x`, `apv:a3f1b9c2:deny:k7m2x`.
+- Single-use enforced by an atomic `UPDATE approval_decisions SET ... WHERE id = ? AND consumed_at IS NULL` with a rowcount check. A re-tap of an already-consumed callback returns a brief "this prompt expired" toast via `answerCallbackQuery`.
+- Examples: `apv:a3f1b9c2:allow`, `apv:a3f1b9c2:ttl:1h`, `apv:a3f1b9c2:deny`.
 
-Full scope and `humanize()` output are stored server-side keyed by request id.
-
-**Crash-safety.** Because the nonce is durable before the card is sent, a tap arriving after gateway restart still resolves: the broker reads the nonce row, matches it, marks it consumed, processes the decision. A tap with no DB row (gateway crashed *before* persist completed and *also* failed to send the card — vanishingly rare given write-then-send ordering) is treated as a fresh request, which manifests as a short toast "this prompt expired, agent will re-ask" — never silently ignored.
+Full scope and humanized title are stored server-side keyed by request id.
 
 ## 7. Decision modes
 
 Universal across surfaces:
 
-- `allow_once` — single use, consumed on first match. **This is what the primary `Allow` button binds to** (clarification — see §8.1).
-- `allow_always` — standing grant, no expiry. Subject to drift-revocation (§5.2).
-- `allow_ttl` — bounded grant, **sliding window with hard cap.** Each successful `lookupDecision` match against an `allow_ttl` row sets `ttl_expires_at = now + ttl_original_ms`. The renewal is **silent — no tap, no notification.** The renewal does NOT extend the row past `granted_at + max_lifetime` (default 30 days, stored in `max_lifetime_at`) — hard cap. This is sudo's pattern (silent renewal up to a ceiling), not Bitwarden's (notification on every renewal). Default TTL is 1h; user can override via the expand picker.
+- `allow_once` — single use. **This is what the primary `Allow` button binds to.**
+- `allow_always` — standing grant, no expiry. Subject to drift-revocation (§5.1).
+- `allow_ttl` — bounded grant, **sliding window with hard cap.** Each successful match against an `allow_ttl` row updates `last_used_at` and extends `ttl_expires_at = now + ttl_original_ms`. Renewal is silent (sudo-style, not Bitwarden-style). The renewal does NOT extend past `granted_at + max_lifetime` (default 30 days; hard cap). Default TTL is 1h; user can override via the expand picker.
 - `deny` — single-shot reject.
-- `deny_perm` — standing reject; future requests auto-fail without re-prompting.
+- `deny_perm` — standing reject; future requests auto-fail without re-prompt.
 
-The card surfaces only the common subset (see §8). The full mode set is editable post-grant via `/approvals`.
+The card surfaces only the common subset. Full mode set is editable via `/approvals`.
 
 ## 8. Telegram approval card UX
 
-One shape, every surface. Built on the existing `aq:` (ask_user) primitive at `telegram-plugin/gateway/gateway.ts:8209` — that path already handles topic routing, quote-reply targeting, reaction-lifecycle, and `allowFrom` enforcement. The kernel registers a new `apv:` callback handler and reuses everything else.
+One shape, every surface. Built on the existing `aq:` (ask_user) primitive at `telegram-plugin/gateway/gateway.ts:8209` — that path already handles topic routing, quote-reply targeting, reaction lifecycle, and `allowFrom` enforcement. The kernel registers a new `apv:` callback handler and reuses the rest.
 
-### 8.1 Card states and primary-button semantics
+### 8.1 Card states
 
-**Pristine** (initial render):
+**Pristine:**
 
 ```
 🔐 klanker wants to read a doc
@@ -245,179 +165,114 @@ One shape, every surface. Built on the existing `aq:` (ask_user) primitive at `t
 [ 🔁 Always ]  [ ⏱ For 1h ]
 ```
 
-**Primary `Allow` button = `allow_once`.** Stated explicitly so it cannot be re-interpreted later. `Always` and `For 1h` on the secondary row are the two explicit overrides. The `Always` button is offered only when scope is rule-synthesizable (same gating as the existing `resolveAlwaysAllowRule` import at `gateway.ts:270`). `For 1h` is a single TTL default, NOT a picker — the picker lives behind expand.
+**Primary `Allow` = `allow_once`.** Stated explicitly so it cannot be re-interpreted later. `Always` and `For 1h` on the secondary row are explicit overrides. `Always` is offered only when scope is rule-synthesizable. `For 1h` is a single TTL default; the picker lives behind expand.
 
-**Expanded** (after `See more`):
+**Expanded** (after `See more`): call-site context, raw scope string, agent-supplied "why this access" line, TTL picker (`1h` / `24h` / `7d`), `Deny permanent`, custom mode.
 
-- Call-site context: `tool:bash:rm` shows the file/line; `mcp:gdrive` shows the path/query.
-- Raw scope string for verification: `doc:gdrive:1abcDEFxyz789`.
-- Agent-supplied "Why this access?" line.
-- TTL picker (`1h` / `24h` / `7d`), `Deny permanent`, custom mode.
+**Granted (in place):** `✅ Granted once · /approvals revoke a3f1b9c2`
 
-**Granted (in place):**
-
-```
-✅ Granted once · /approvals revoke a3f1b9c2
-```
-
-**Granted always:**
-
-```
-✅ Granted always to klanker for doc:gdrive:1abcDEFxyz789
-   /approvals revoke a3f1b9c2
-```
+**Granted always:** `✅ Granted always to klanker for doc:gdrive:1abcDEFxyz789 · /approvals revoke a3f1b9c2`
 
 **Denied:** `🚫 Denied`
 
-**Expired (5-minute prompt timeout):** the broker expiry job runs every 30s; on each expiry it issues `editMessageReplyMarkup` to strip the buttons and `editMessageText` to set the body to `⌛ Expired — agent will re-request.` The pending nonce row is marked consumed. **A tap on an already-expired callback** returns `answerCallbackQuery({ text: 'this prompt expired' })` — a brief toast — and surfaces no error to the agent (which has already received `{ status: 'timeout' }` and either re-issued or moved on). Expired-nonce rejection happens at the broker callback-router layer before any decision-write logic runs.
+**Expired (5-minute timeout):** `⌛ Expired — agent will re-request.` A tap on an already-expired callback returns `answerCallbackQuery({ text: 'this prompt expired' })`.
 
 **Revoked-after-grant:** on the next use attempt the agent gets a denial; the kernel posts a fresh notification card identifying which standing grant fired the denial and offering one-tap reinstate.
 
 ### 8.2 humanize() with a 500ms render budget
 
-The kernel calls the namespace's `humanize()` before rendering, but **never blocks on it.** Spec:
+The kernel calls `humanize()` before rendering but never blocks on it.
 
 1. Kick `humanize(scope)` immediately on `requestApproval`.
-2. Race it against a **500ms timer.**
+2. Race against a 500ms timer.
 3. If `humanize()` resolves first → card ships with the humanized title.
-4. If the timer fires first → card ships with the raw scope as the title; when `humanize()` later resolves (success), patch via `editMessageText` to the humanized version.
-5. If `humanize()` rejects or times out fully (5s ceiling) → leave the raw scope and append a small `(could not resolve)` annotation.
+4. If the timer fires first → card ships with the raw scope; when `humanize()` later resolves (within a 5s ceiling), patch via `editMessageText`.
+5. If `humanize()` rejects or hits the 5s ceiling → leave the raw scope, append a small `(could not resolve)` annotation.
 
-The card is never delayed by humanize.
-
-### 8.3 Preserved patterns (must not regress through migration)
+### 8.3 Patterns preserved through migration
 
 - **`perm:more` expand button** at `gateway.ts:1946` — basis of the new card's expand. Same UX shape.
-- **`summarizeToolForTitle` lift-to-title** at `gateway.ts:1938` (import at `:269`) — preserve for `tool:` scopes.
 - **`vd:unlock` deferred-secret card flow** at `gateway.ts:5497` — Phase 2 migrates this surface; the inline-passphrase capture step must survive the move.
 - **`aq:` topic-routing + reaction lifecycle** at `gateway.ts:8209` — inherit, do not rebuild.
-- **`allowFrom` enforcement on every callback** — pattern at `gateway.ts:8218-8222`.
-
-## 8a. First-run onboarding for new MCPs (v1: two options only)
-
-When a new MCP wrapper is enabled, the kernel posts a one-time setup card before the first per-resource prompt fires.
-
-```
-🆕 Google Drive enabled. How should klanker access your Drive?
-
-[ Allow all of Drive (less secure, fewer prompts) ]
-[ Per-doc approval (default, more secure)         ]
-```
-
-**v1 ships exactly these two options.** The v2 draft included a third "Choose folders now → /approvals add with glob template" option — that was the v1 anti-pattern in disguise (user grants narrow, then has to widen under fatigue). It is dropped.
-
-Footnote: folder-scoped grants land in **Phase 3.5** with a real Telegram folder picker. Until then, users widen via `/approvals add` post-grant if the per-doc default proves too noisy.
+- **`allowFrom` enforcement on every callback** — match the existing pattern.
 
 ## 9. Audit, revocation, staleness
 
-- `/approvals list` — paginated, two-level. Top-level `/approvals list` shows agent summary counts (`klanker: 12 grants, gymbro: 3 grants, …`) with tappable inline buttons to drill in. `/approvals list <agent>` shows up to 20 rows; older rows accessible via inline `Next →` button. Each row has inline `Revoke`. Telegram's 4096-char per-message cap is respected by capping at 20 rows + footer. User mental model is "what can klanker do?"; GitHub-style permissions UI is the reference.
-- `/approvals revoke <id>` — single revoke; logs to `approval_audit` and appends to `approval_revocations` chain. **Every grant card's confirmation message includes `· /approvals revoke <id>` inline** so revocation is one tap from the grant itself.
+- `/approvals list` — paginated, two-level. Top-level shows agent summary counts (`klanker: 12 grants, gymbro: 3 grants, …`) with tappable inline buttons. `/approvals list <agent>` shows up to 20 rows; older accessible via `Next →`. Each row has inline `Revoke`. User mental model: "what can klanker do?"; GitHub-style permissions UI is the reference.
+- `/approvals revoke <id>` — single revoke; logs to `approval_audit`. **Every grant card's confirmation message includes `· /approvals revoke <id>` inline** so revocation is one tap from the grant itself.
 - `/approvals add` — wizard for adding grants outside a prompt context (e.g. "allow all of Drive" post-onboarding).
 - `/approvals stats` — surfaces 7-day request/grant/deny counts per agent. Used by the soft-alert in §11.
-- `/revoke-all` — killswitch. See §9.2 for the exact ordered sequence.
+- `/revoke-all` — killswitch. See §9.2.
 
 ### 9.1 Staleness model with weekly digest coalescing
 
-Drop fixed-cadence digests of *everything*. Replace with two triggers, both rate-limited:
+Rather than per-row prompts (which scale badly — 40 stale rows = 40 prompts), staleness coalesces into a single weekly digest with the same threshold-trigger logic:
 
-- **New-grants digest (threshold-triggered):** when `count(allow_always WHERE never_seen_in_digest) >= 3`, send a digest of the new standing grants. Rate-limited to at most one digest per 24h.
-- **Stale-grants digest (weekly coalescing).** v2 specced one prompt per row, which scales badly: 40 stale rows = 40 separate "revoke?" prompts. v3: stale prompts coalesce into a **single weekly digest** with the same threshold-trigger logic — *N grants haven't fired in 30d, review?* — with one inline `Revoke` button per row in the digest. **No more than one staleness digest per week regardless of how many rows go stale.** Suppression is set per-row when the user taps `Keep` (suppressed for another 30d) or implicitly when the row remains in the digest unchanged for 4 consecutive weeks (auto-revoke under "stale and ignored", configurable).
+- **New-grants digest** (threshold-triggered): when `count(allow_always WHERE never_seen_in_digest) >= 3`, send a digest of the new standing grants. At most one digest per 24h.
+- **Stale-grants digest** (weekly): grants that haven't fired in 30d coalesce into one digest with one inline `Revoke` button per row. **No more than one staleness digest per week** regardless of how many rows go stale.
+- Suppression is set per-row when the user taps `Keep` (suppressed for another 30d) or implicitly when the row remains in the digest unchanged for 4 consecutive weeks (auto-revoke under "stale and ignored", configurable).
 
 Steal sudo's pattern: surface staleness, not totals.
 
 ### 9.2 `/revoke-all` ordered sequence
 
-`/revoke-all` is a multi-step operation with real failure modes; spec the ordering exactly:
+Multi-step with real failure modes; spec the ordering.
 
-1. **Telegram `revokeToken`** — call the Bot API to evict the current token at Telegram's edge. If this fails: abort, surface `revoke_all_step1_failed`; nothing has changed yet.
-2. **Mark all active rows revoked** — append-only chain entry per row, batch transactional. If this fails after step 1: token is already dead at Telegram; the gateway will fail to receive updates on next poll. Operator must run `switchroom token rotate` to restore. Surface `revoke_all_step2_failed_run_token_rotate`.
-3. **Write new token to vault** — under the existing bot-token slot (Phase 0).
-4. **SIGHUP gateway** — gateway re-reads token from vault. If the gateway fails to come back up: vault still holds the new token; operator can re-run `revoke-all` (step 1 is idempotent — Telegram `revokeToken` on an already-revoked token is a no-op) or just `systemctl --user restart switchroom-gateway.service`.
+1. **Telegram `revokeToken`** — call the Bot API to evict the current token at Telegram's edge. If this fails: abort, surface `revoke_all_step1_failed`; nothing has changed.
+2. **Mark all active rows revoked** in `approval_decisions`. If this fails after step 1: token is dead at Telegram; gateway will fail to receive updates on next poll. Operator runs `switchroom token rotate`.
+3. **Write new token to vault** under the bot-token slot (RFC A).
+4. **SIGHUP gateway** — gateway re-reads token from vault.
 5. **Mark `revoke-all` complete** — audit row.
 
-`switchroom token rotate` is the recovery command — idempotent re-run of steps 1, 3, 4. Document this in the killswitch help text.
+`switchroom token rotate` is the recovery command — idempotent re-run of steps 1, 3, 4. Documented in killswitch help text.
 
-## 10. Wait protocol — short-poll, not long-poll
+## 10. Wait protocol — short-poll
 
-The vault broker is request/response. Approvals can wait up to 5 minutes for a user tap. v2 specced long-poll (broker holds the connection open with keepalives); v3 drops that.
-
-**Why drop.** Long-poll ties up a broker socket per pending request, opens a small DoS surface (an agent that opens many requests but never reads exhausts file descriptors), and requires keepalive framing inside the existing request/response IPC. None of that complexity is necessary.
+The vault broker is request/response. Approvals can wait up to 5 minutes for a tap. Long-poll (broker holds connection open) is rejected: it ties up a socket per pending request, opens a small DoS surface, and requires keepalive framing inside the existing IPC.
 
 **Short-poll spec:**
 
-1. Agent calls `requestApproval(...)` → returns `{ status: 'pending', request_id }` immediately.
-2. Agent calls `lookupDecision({ request_id })` every **2 seconds**. Broker responds immediately with `{ status: 'pending' | 'granted' | 'denied' | 'expired', mode?, ttl? }`.
+1. Agent calls `requestApproval(...)` → `{ status: 'pending', request_id }` immediately.
+2. Agent calls `lookupDecision({ request_id })` every 2 seconds. Broker responds immediately with `{ status: 'pending' | 'granted' | 'denied' | 'expired', mode?, ttl? }`.
 3. On `granted`/`denied`/`expired`, agent stops polling.
-4. On gateway restart between polls, the agent simply retries — `lookupDecision` is stateless from the agent's perspective.
+4. On gateway restart between polls, agent simply retries — `lookupDecision` is stateless from the agent's perspective.
 
-**Caps (DoS defense):**
+**Caps:**
 
-- Per `agent_unit`: max **2 concurrent pending** requests. A third `requestApproval` returns `{ status: 'rate_limited', retry_after_ms: 5000 }`.
-- Global cap: **32 pending** requests across all agents. New requests get `rate_limited` until the queue drains.
-
-This is a much smaller change to the existing broker than long-poll; no socket-lifetime semantics, no keepalive, no reconnect-replay logic.
+- Per `agent_unit`: max 2 concurrent pending requests. A third returns `{ status: 'rate_limited', retry_after_ms: 5000 }`.
+- Global: max 32 pending across all agents.
 
 ## 11. Risks and open questions
 
-- **Phase 4 `perm:` migration: kernel-only with settings.json write-back.** The existing `perm:always` path writes a Claude Code allow-rule via `permission-rule.ts` (133 lines). v3 picks **kernel-as-source-of-truth**: the kernel becomes authoritative; on every grant change, a write-back hook rewrites Claude Code's `settings.json` `permissions.allow` from kernel state. **User/tool edits to `settings.json` get overwritten** — this is the documented cost of authoritative kernel state. A CLI command `switchroom approvals sync-settings` exists for manual reconciliation if the file gets out of sync (e.g. after a kernel-side migration). The dual-write reconciliation alternative (kernel writes its row AND emits the Claude rule, with reconciliation on revoke) was rejected for chronic-bug risk.
-- **HMAC threat-model honesty.** Repeated from §3 attack 5 and §5.1 because reviewers keep flagging it: per-row HMAC is **tamper detection, not prevention.** A same-uid attacker with `ptrace_scope=0` or `CAP_SYS_PTRACE` can read the row-integrity key from broker memory and forge rows. Real prevention needs user-namespace isolation; out of scope for v1, tracked as Phase 5+.
-- **`--print` mode and Phase 2 secrets.** `--print` bypasses Claude's permission-request flow. Secrets enforcement lives broker-side, not gateway-side, so Phase 0 (bot token in vault) plus the broker-mediated secret fetch means `--print` agents *still* go through the kernel for secret access — the bypass only affects tool-permission prompts (Phase 4), not secret unlocks. Document explicitly.
-- **Cross-agent grant scope is unit-scoped, not user-scoped.** `allow_always` for `secret:OPENAI_API_KEY` granted to klanker does **not** auto-grant to gymbro. Each `agent_unit` is a separate principal, matching existing vault grants. User-scoped grants are out of scope for v1.
-- **Callback delivery is best-effort.** If the gateway is down when the user taps, the tap is lost. 5-minute timeout, `timeout` audit row, agent re-issues if still wanted. With nonce write-ahead persistence (§6.2), gateway restart **does not** lose pending cards — the v2 risk note about restart-loses-pending is resolved and removed.
+- **Cross-agent grant scope is unit-scoped.** `allow_always` for `secret:OPENAI_API_KEY` granted to klanker does NOT auto-grant to gymbro. Each `agent_unit` is a separate principal, matching existing vault grants. User-scoped grants out of scope for v1.
+- **Callback delivery is best-effort.** If the gateway is down when the user taps, the tap is lost. 5-minute timeout, `timeout` audit row, agent re-issues if still wanted.
 - **OAuth tokens (Google refresh tokens) live in vault.** Kernel asks vault for the token by slot name; vault enforces its own grant on that slot; kernel never persists raw tokens.
-- **Group / multi-user is out of scope but trip-wired.** The drift-revocation rule (§5.2) makes this safe-by-default: the moment `allowFrom` grows past one entry, every standing grant becomes dormant pending re-confirmation.
-- **Tap-budget target and instrumentation.** Day 1 of Drive enablement: 10–30 taps expected (cold cache, no folder grants). Steady state: <5 taps/day. **Instrumentation:** `/approvals stats` surfaces 7-day tap counts per agent off the existing audit table. **Soft-alert (DM)** at >10 taps/day sustained for 3 days. If exceeded, **batch coalescing** kicks in: the kernel buffers prompts for 5 seconds; if 3+ pending share a scope-prefix (e.g. `doc:gdrive:folder/Work/*`), it collapses into a single "klanker is requesting access to 4 docs in /Work — allow folder?" card.
+- **Multi-user is out of scope but tripwired.** Drift-revocation (§5.1) makes this safe-by-default: the moment `allowFrom` grows past one entry, every standing grant becomes dormant pending re-confirmation.
+- **Tap-budget target and instrumentation.** Day 1 of Drive enablement: 10–30 taps expected (cold cache, no folder grants). Steady state: <5 taps/day. `/approvals stats` surfaces 7-day tap counts. Soft-alert (DM) at >10 taps/day sustained for 3 days. If exceeded, **batch coalescing** kicks in: the kernel buffers prompts for 5 seconds; if 3+ pending share a scope-prefix (e.g. `doc:gdrive:folder/Work/*`), it collapses into a single "klanker is requesting access to 4 docs in /Work — allow folder?" card.
 
 ## 12. Migration plan
 
-**Phase 0 — bot token to vault. Prerequisite for everything else.** Move the Telegram bot token from its current filesystem location into the vault under a slot only `switchroom-gateway.service` can unlock. Any agent with filesystem read of the current token location is **already game-over** — it can post fake approval cards as the bot and intercept the user's tap. ~0.5 day.
+**Prerequisite: RFC A** (bot token in vault) is in place.
 
-### 12.0.1 Phase 0 rollback plan
+**Phase 1 — kernel folded into vault broker.** New `approval_decisions` and `approval_audit` tables in `vault-grants.db` (no rename), new RPC methods on `src/vault/broker/server.ts`, broaden peercred regex (§4.1), short-poll wait protocol (§10), `apv:` callback router in gateway, `/approvals list|revoke|add|stats` commands, drift revocation, plus tests matching the existing broker's coverage. **~1.5 days.**
 
-The token migration is a real cutover with three failure modes; spec each:
+**Phase 2 — secrets as first consumer.** Migrate the deferred-secret card path (`gateway.ts:5497`) to call the kernel. Lower-traffic, validates the abstraction. Preserve the inline-passphrase capture UX. ~0.5 day.
 
-1. **Atomic move sequence.**
-   - Read token from current filesystem location.
-   - Write to vault slot; verify by reading it back.
-   - Restart the gateway with vault-backed token loading; verify it can post a smoke message.
-   - **Only after the smoke succeeds**, `shred -u` the old file.
-
-2. **Failure modes.**
-   - **Vault-write fails** → abort; token still on disk; no change. Operator inspects vault state and retries.
-   - **Vault-read after write fails** (corruption, key-derivation glitch) → restore old file from backup taken before the migration; the gateway continues to read from disk; operator re-runs once vault is healthy.
-   - **Smoke message fails** → restore old file from backup; revert gateway config.
-   - **`shred` fails** (filesystem doesn't support secure delete, e.g. btrfs CoW) → log loudly and continue. Token now exists in two places — **SECURITY incident**, requires immediate token rotation via `/revoke-all` once Phase 1 ships, or via `switchroom token rotate` standalone.
-
-3. **Boot chicken-and-egg.** Gateway needs the token to start; vault needs to be unlocked to give up the token. Resolved via the existing auto-unlock mechanism at `src/vault/auto-unlock.ts` (machine-bound encryption of the vault passphrase, decrypted at boot using `/etc/machine-id` + per-user state). If auto-unlock is **not enabled** on this machine, gateway start fails fast with: `vault locked, run "switchroom vault unlock" or enable auto-unlock with "switchroom vault broker enable-auto-unlock"`. The error is actionable; no silent boot loop.
-
-**Phase 1 — kernel folded into vault broker.** New tables in `vault-grants.db` (no rename, see §4), new RPC methods on `src/vault/broker/server.ts`, broaden peercred regex with pidfd pinning (§4.1), HMAC row protection with HKDF + key versioning (§5.1), revocation chain (§5.3), audit chain (§5.4), short-poll wait protocol (§10), `apv:` callback router in gateway, `/approvals list|revoke|add|stats` commands, drift revocation, write-ahead nonce persistence, plus tests matching the existing broker's coverage (16 broker test files under `src/vault/broker/`). **~2 days, not 1.** v2's 1-day estimate ignored the new subsystems and tests.
-
-**Phase 2 — secrets as first consumer.** Migrate the deferred-secret card path (`gateway.ts:5497`) to call the kernel. Lower-traffic, validates the abstraction, and the move from in-memory to SQLite is itself a real upgrade. Preserve the inline-passphrase capture UX. ~1 day.
-
-**Phase 3 — Google Docs MCP wrapper as kernel consumer.** Build the MCP wrapper (default: `taylorwilsdon/google_workspace_mcp`) that calls the kernel for every doc/folder access. OAuth tokens in vault, extending the existing `auth:` slot pattern (`gateway.ts:8179`, `src/auth/`). Includes the §8a onboarding card (two options only) and the §11 batch coalescing. ~2 days. **Phase 3.5 — folder picker UI** is split out: real Telegram folder picker for grant scopes; ~1 day, can land separately once Phase 3 stabilizes.
-
-**Phase 4 — `perm:` migration with settings.json write-back (separate PR, separate review).** Highest regression risk; runs on the hot path of every tool call. Kernel-only with write-back to `settings.json` as decided in §11. Defer until kernel has weeks of production proof. ~2 days.
+**Phase 3 — first MCP consumer (Google Drive).** Covered separately in **RFC C — Google Drive MCP integration**.
 
 ## 13. Estimated effort
 
-**Phases 0–3: ~6.5 focused engineering days** (revised up from v2's 4.5d).
+RFC B Phase 1 + Phase 2: **~2 days.**
 
-| Phase | v2 estimate | v3 estimate | Delta drivers |
-|------:|------------:|------------:|---------------|
-| 0     | 0.5d        | 0.5d        | — |
-| 1     | 1d          | 2d          | HKDF + key versioning, revocation chain, audit chain, pidfd pinning, short-poll + caps, drift canonicalization, write-ahead nonces, `/approvals list/revoke/add/stats`, settings.json write-back hook, tests matching existing 16-file broker coverage |
-| 2     | 1d          | 1d          | — |
-| 3     | 2d          | 2d          | — (3.5 folder picker split out as separate ~1d) |
-| **Total 0–3** | **4.5d** | **6.5d** | |
-
-Phase 4 is a separate ~2-day effort under its own review. Phase 3.5 (folder picker) is ~1d and can ship anytime after Phase 3.
+Combined with RFC A (~0.5d) and RFC C (~1d): **~3.5 days total** across the three RFCs.
 
 ## 14. Out of scope
 
+- **Tool/skill permission migration: deferred indefinitely.** Tools and skills stay on the existing `permission-rule.ts` + `settings.json` path, untouched. Migrating Claude's tool-permission prompts into the kernel would conflict with switchroom's "unmodified Claude" principle (`README.md:16`) — it requires intercepting and rewriting `settings.json` from kernel state, which the kernel does NOT do. The kernel is not authoritative for tool perms.
 - Group / multi-user bot support.
 - Per-action MFA prompts beyond approval — Telegram 2FA is sufficient at this trust level.
 - Web dashboard approval UX (CLI + Telegram only for v1).
 - User-scoped (cross-agent) grants — every grant is unit-scoped in v1.
-- Per-agent BindPaths / user-namespace isolation of the DB file — HMAC row protection (§5.1) is the v1 detection layer; namespace isolation is Phase 5+ hardening for prevention.
-- Bash-arg matching beyond prefix (§6.1) — Phase 4+ work.
-- DB filename rename to `vault.db` — kept as `vault-grants.db` to preserve downgrade path (§4).
+- Per-agent BindPaths / user-namespace isolation of the DB file. Same-uid is game-over per `docs/vault.md:227`; the kernel works inside that envelope.
+- Bash-arg matching — out of scope along with the rest of tool-perm migration.
+- DB filename rename to `vault.db` — kept as `vault-grants.db` to preserve downgrade path.

--- a/docs/rfcs/approval-kernel.md
+++ b/docs/rfcs/approval-kernel.md
@@ -1,0 +1,140 @@
+# RFC: Unified human-approval kernel
+
+Status: Draft
+Author: klanker (sub-agent draft)
+Date: 2026-05-06
+
+## 1. Summary
+
+Today switchroom asks the user to approve sensitive actions through at least four independent code paths, each with its own callback grammar, storage, and UX. This RFC proposes a single approval kernel — one IPC broker, one SQLite store, one Telegram card primitive, one audit log — that all current and future surfaces (secrets, vault grants, tool/skill permission requests, Google Docs and other MCPs) plug into. The kernel is shaped on the existing `vault-broker` trust model and reuses the proven SO_PEERCRED + cgroup-derived unit identity.
+
+## 2. Motivation
+
+Four approval-shaped surfaces exist in the codebase right now:
+
+- **Deferred-secret cards** with `vd:unlock|cancel` callbacks, in-memory only — `src/gateway.ts:1304`.
+- **Vault grants** via the `/vault grant` wizard, persisted to SQLite at `~/.switchroom/vault-grants.db` — `src/vault/grants-db.ts`.
+- **Tool/Skill permission requests** via MCP `notifications/claude/channel/permission_request`, rendered as `perm:allow|deny|always` cards — `src/gateway.ts:1980`, `src/bridge.ts:451`.
+- **Operator and dashboard prompts** under the `op:` and `auth:` callback prefixes — `src/gateway.ts:8291`.
+
+Adding a Google Docs MCP — and the inevitable Notion, Slack, and Gmail wrappers after it — means a fifth, sixth, and seventh surface unless the approval shape is unified. Each new surface duplicates: callback parser, storage decision (memory vs disk), TTL semantics, revocation command, audit trail. The cost compounds; the user sees inconsistent UX; there is no single `/revoke-all` killswitch.
+
+## 3. Threat model and trust root
+
+Switchroom is a **1:1 bot ↔ user** product. A single allowlisted Telegram `user_id` is identity, approver, and audit subject. This is a load-bearing assumption — the kernel relies on it. If group or multi-user bots ever ship, an `approvers` subset of `allowFrom` plus DM-only delivery of approval cards must be added; flagged here so future readers know what to revisit.
+
+Telegram (with 2FA) is the auth factor. Inbound `callback_query.from.id` is authenticated by Telegram's bot session and cannot be spoofed remotely.
+
+**Local threat surface.** All switchroom processes — gateway, agents, brokers — run as the same uid (`kenthompson`) under `systemd --user`. Filesystem permissions are *not* a security boundary between gateway and an agent: an agent can read the bot token from `~/.switchroom/...` and call Telegram directly as the bot, or read `vault-grants.db` directly off disk. The kernel must therefore not rely on file perms for authorization. Authorization happens at the IPC seam.
+
+## 4. Design — broker model
+
+The kernel runs in-gateway (or as a sibling process sharing the gateway's lifecycle) and exposes a unix-socket API at `~/.switchroom/approval-broker.sock`.
+
+Caller identity is established via **SO_PEERCRED + cgroup → systemd unit name**, modeled directly on `src/vault/broker/peercred.ts` and the ACL logic in `src/vault/broker/acl.ts`. The unit name (e.g. `switchroom-klanker.service`) is the authorization principal, not the pid or uid. Reuse the existing helpers — do not reimplement.
+
+File permissions on `approvals.db` are belt-and-suspenders, never the primary control.
+
+**Why a broker over a library.** A library linked into the agent process gives that agent direct access to the SQLite file; an agent can rewrite its own grants, forge audit entries, or read peer agents' decisions. The broker is a single mediating process that owns the DB handle, validates every request against the peer's unit name, and emits the audit row.
+
+## 5. Decision storage
+
+SQLite at `~/.switchroom/approvals.db`, modeled on `vault-grants.db`.
+
+```
+decisions(
+  id              TEXT PRIMARY KEY,    -- 5-char base32, see §6
+  agent_unit      TEXT NOT NULL,       -- systemd unit name
+  scope           TEXT NOT NULL,       -- see §6 grammar
+  decision        TEXT NOT NULL,       -- allow_once | allow_always | allow_ttl | deny | deny_perm
+  ttl_expires_at  INTEGER,             -- unix-ms, NULL for non-ttl
+  granted_by_user_id INTEGER NOT NULL, -- Telegram user_id
+  granted_at      INTEGER NOT NULL,
+  revoked_at      INTEGER,
+  revoke_reason   TEXT
+);
+audit(
+  id              INTEGER PRIMARY KEY AUTOINCREMENT,
+  ts              INTEGER NOT NULL,
+  agent_unit      TEXT NOT NULL,
+  scope           TEXT NOT NULL,
+  action          TEXT NOT NULL,       -- request | grant | deny | revoke | timeout | match
+  decision_id     TEXT,
+  request_context TEXT                 -- JSON blob, why-string + caller frame
+);
+```
+
+Persistent grants survive restart. In-memory deferred-prompt state (the open card, awaiting tap) does **not**, matching today's deferred-secret behavior — acceptable.
+
+## 6. Scope grammar
+
+Pluggable per surface. Each consumer registers a namespace and a matcher:
+
+- `secret:OPENAI_*` — env-name glob.
+- `tool:bash:rm *` — tool name + arg pattern.
+- `tool:Skill:deploy` — Skill invocations.
+- `doc:gdrive:1abc...xyz` — specific Drive doc id.
+- `doc:gdrive:folder/789/**` — folder glob.
+- `mcp:notion:page:...`
+
+Telegram callback_data is hard-capped at 64 bytes including the existing `agent:` prefix injected by the bridge. Scopes will not fit. Use 5-char base32 request ids (existing pattern at `src/gateway.ts:8482`); store the full scope server-side and pass only the id over the wire. Card payload becomes `apv:<id>:allow`, `apv:<id>:deny`, `apv:<id>:ttl:1h`, etc.
+
+## 7. Decision modes
+
+Universal across surfaces:
+
+- `allow_once` — single use, consumed on first match.
+- `allow_always` — standing grant, no expiry.
+- `allow_ttl` — bounded grant (1h, 24h, 7d picker).
+- `deny` — single-shot reject.
+- `deny_perm` — standing reject; future requests auto-fail without re-prompting.
+
+## 8. Telegram approval card UX
+
+One shape, every surface. Title line, requesting agent, scope (rendered human-readably from the scope string), why-string (call-site context if the consumer supplied it), inline keyboard with mode choices.
+
+Built on the existing `aq:` (ask_user) primitive at `src/gateway.ts:8326-8345` — that path already handles topic routing, quote-reply targeting, and reaction-lifecycle. The kernel registers a new `apv:` callback handler and reuses everything else.
+
+## 9. Audit and revocation
+
+- `/approvals list` — standing decisions grouped by surface, with TTL countdown.
+- `/approvals revoke <id>` — single revoke; logs to `audit`.
+- `/revoke-all` — killswitch; sets `revoked_at` on every active row.
+- Weekly digest of `allow_always` rows so silent accumulation is visible. Dovetails with the existing scheduled-message infrastructure (`docs/scheduling.md`).
+
+## 10. Migration plan
+
+**Phase 1 — kernel + storage + Telegram primitive.** Standalone. No consumers wired. Includes the `apv:` callback router, the broker socket, the SQLite schema, and `/approvals list|revoke` commands. Estimated ~2 days.
+
+**Phase 2 — secrets as first consumer.** Migrate the deferred-secret card path (`src/gateway.ts:1304`) to call the kernel. Lower-traffic, validates the abstraction, and the move from in-memory to SQLite is itself a real upgrade. ~1 day.
+
+**Phase 3 — Google Docs MCP wrapper as kernel consumer.** Build the MCP wrapper that calls the kernel for every doc/folder access. OAuth tokens (Google's refresh tokens) live in vault, extending the existing `auth:` slot pattern (`src/gateway.ts:8291`, `src/auth/`). ~2 days including OAuth glue.
+
+**Phase 4 — `perm:` migration (separate PR, separate review).** The tool/skill permission path runs on the hot path of every tool call; highest regression risk. Defer until kernel has weeks of production proof. Similar size, ~2 days.
+
+## 11. Risks and open questions
+
+- **`perm:always` writes to Claude Code's allow-rules** (`permission-rule.ts`), not switchroom storage. Migration buys us auditability but is a bigger lift than a wrapper — the kernel needs to write both its own decision row and continue emitting the Claude rule, or we accept that `allow_always` for tools no longer hits Claude's settings.
+- **`--print` mode bypasses permission-request entirely** (documented at `docs/stream-json-daemon-mode.md:401`). Pre-existing bug; the kernel inherits it. Out of scope for this RFC; flagged.
+- **Callback delivery is best-effort.** If the gateway is down when the user taps, the tap is lost. Approval cards must define a timeout (proposed: 5 minutes). On timeout the kernel emits a `timeout` audit row, the agent sees a failed request, and must re-issue if it still wants the action.
+- **OAuth tokens are sensitive.** Vault is the right home. Define explicitly: kernel asks vault for the token by slot name, vault enforces its own grant on that slot, kernel never persists raw tokens.
+- **Group / multi-user is out of scope but trip-wired.** First time `allowFrom` grows beyond one entry, the kernel schema needs an `approvers` column and card delivery must become DM-only.
+
+## 12. Google Docs MCP — concrete picks
+
+- `taylorwilsdon/google_workspace_mcp` — most actively maintained, full Workspace coverage, OAuth 2.1.
+- `a-bonus/google-docs-mcp` — popular, OAuth 2.1, Docs-only.
+- `piotr-agier/google-drive-mcp` — OAuth + auto-refresh, alternative auth modes.
+
+Default to **taylorwilsdon** for breadth. Revisit after the Phase 3 prototype reveals real pain points.
+
+## 13. Estimated effort
+
+5–6 focused engineering days for Phases 1–3. Phase 4 is a separate ~2-day effort under its own review.
+
+## 14. Out of scope
+
+- Group / multi-user bot support.
+- Per-action MFA prompts beyond approval — Telegram 2FA is sufficient at this trust level.
+- Web dashboard approval UX (CLI + Telegram only for v1).
+- Cross-agent shared decisions — each agent's grants are scoped to its unit name; no inheritance between agents.

--- a/docs/rfcs/bot-token-to-vault.md
+++ b/docs/rfcs/bot-token-to-vault.md
@@ -1,57 +1,101 @@
-# RFC A: Bot token to vault
+# RFC A: Complete the bot-token-to-vault migration
 
-Status: Draft v1
+Status: Draft v2
 Author: klanker (sub-agent draft)
 Date: 2026-05-06
 
 ## 1. Summary
 
-Today the Telegram bot token sits on disk in plaintext where any process running as the user (`kenthompson`) can read it. That includes every agent. An agent that reads the token can post messages and approval cards as the bot, intercept callbacks, and impersonate the gateway to the user. This RFC moves the token into the existing vault under a slot that only `switchroom-gateway.service` is granted access to, with the gateway reading it via the broker on boot.
+Vault-backed bot tokens **already exist** in switchroom. The `vault:` reference resolver is shipped (`src/vault/resolver.ts:23` `isVaultReference`, `src/vault/resolver.ts:223` resolver path) and the schema accepts a `vault:` reference for `telegram.bot_token` (`src/config/schema.ts:797`, `:945`, `:1308`). Per-agent bot tokens already flow through the resolver via `resolveBotToken` (`src/cli/topics.ts:53`).
 
-This is a real, current security gap, independent of the approval kernel work. It ships first.
+This RFC is **not** a proposal to build that machinery. It's the operational task of **completing the migration in Ken's deployment**: rotating the currently-on-disk token, moving it into a vault slot, switching the running config to a `vault:` reference, and documenting the operational pattern so the same migration can be repeated for other long-lived secrets that still sit on disk.
 
 ## 2. Motivation
 
-Per `docs/vault.md:227`, the vault ACL is "misconfiguration protection, not a security boundary" — the real boundary is the vault passphrase and the filesystem permissions on `vault.enc` (`0600`). Plaintext-on-disk for the bot token offers neither of those protections. Any agent process can `cat` the file. Once an agent has the token, the trust chain that the kernel (RFC B) and existing surfaces depend on collapses — a malicious agent can post a fake "Allow this scary thing?" card and the user has no way to tell it from a legitimate one.
+The bot token sits on disk in plaintext (`TELEGRAM_BOT_TOKEN=...` in agent env files; see `src/setup/onboarding.ts:163` `writeAgentEnv`). Any process running as `kenthompson` can read it. That includes every agent. An agent that reads the token can post messages and approval cards as the bot, intercept callbacks, and impersonate the gateway to the user.
 
-The fix is mechanical: the vault already exists, the broker already exists, and `src/vault/auto-unlock.ts` already handles the chicken-and-egg of decrypting the vault before the gateway has its config. The token just needs to live there instead of on disk.
+The fix in code is already done — what's left is the operational cutover. The kernel work in RFC B leans on this being completed: if an agent can lift the bot token, the kernel's audit trail is undermined because the agent can post fake "Allow this scary thing?" cards.
 
-## 3. Design
+## 3. Threat model framing — what the vault actually buys us
 
-- New vault slot, e.g. `telegram:bot_token`. ACL: only `switchroom-gateway.service` may read it.
-- On gateway startup, the gateway reads the token from the vault via the broker IPC (same path the gateway already uses to read other secrets).
-- The vault is unlocked at boot via the existing auto-unlock mechanism in `src/vault/auto-unlock.ts` — machine-bound encryption of the vault passphrase, decrypted at boot using `/etc/machine-id` plus per-user state. No new unlock path.
-- If auto-unlock is not enabled on this machine, gateway start fails fast with: `vault locked, run "switchroom vault unlock" or enable auto-unlock with "switchroom vault broker enable-auto-unlock"`. Actionable error, no silent boot loop.
-- Other agents are NOT granted the slot. An agent attempting to read it gets a vault `denied` response and an audit row.
+Per `docs/vault.md:227`, the vault ACL is **misconfiguration protection, not a security boundary**. Same-uid attackers are out of scope. An agent process running as `kenthompson` can in principle read the encrypted vault file, the broker socket, and any decrypted material the broker hands out to authorized callers; the broker's peercred + cgroup checks are also misconfiguration protection, not a security boundary against a determined same-uid adversary.
 
-## 4. Migration steps
+What the migration **does** buy us:
 
-The cutover has three failure modes; spec each.
+- **No more plaintext-on-disk.** The token is no longer sitting in a file `cat`able by anything that wanders past it (a stray `find` script, a backup tool, a misbehaving agent that was never meant to talk to Telegram at all).
+- **A single revocation surface.** Once the token lives in a vault slot, rotation goes through `switchroom token rotate` and one place updates; today the token is duplicated across whatever env files reference it.
+- **Equal trust level with other vault secrets.** The bot token sits at the same trust level as any other vault entry — no better, no worse. It is not "only the gateway can read it"; it is "the broker hands it out under the same ACL machinery as everything else, which is misconfiguration protection." This honest framing replaces an earlier draft's overclaim.
 
-1. **Atomic move sequence.**
-   - Read token from current filesystem location.
-   - Write to vault slot; verify by reading it back via the broker.
-   - Restart the gateway with vault-backed token loading; verify it can post a smoke message to the operator.
-   - **Only after the smoke succeeds**, `shred -u` the old file.
+The bot token is not made magically safer than e.g. an OpenAI API key in the same vault. It is made *no worse* than any other secret the user has decided to consolidate there.
 
-2. **Gateway config change.** The gateway's token-loading code switches from "read file" to "ask broker for slot." This is a single call site in the boot path.
+## 4. What's already shipped (do not rebuild)
 
-3. **Smoke verification.** A post-boot self-check posts a one-line "bot token migration complete" DM to the operator. Migration is considered successful only after this lands.
+- `vault:` reference syntax in config (`src/vault/resolver.ts`).
+- Resolver pipeline that substitutes `vault:<key>` references at config-load time (`src/vault/resolver.ts:277`).
+- Schema acceptance of `vault:` references on `telegram.bot_token` and per-agent `bot_token` (`src/config/schema.ts:797`, `:945`, `:1308`).
+- Broker auto-unlock at boot so the gateway can resolve the reference before posting its first message (`src/vault/auto-unlock.ts`).
+- `resolveBotToken` call site (`src/cli/topics.ts:53`).
+- Setup-time bot identity verification that already understands vault-backed tokens (`src/setup/telegram-api.ts:83`–`:93`).
 
-## 5. Rollback plan
+## 5. Operational migration steps
 
-- **Vault-write fails** → abort; token still on disk; no change. Operator inspects vault state and retries.
-- **Vault-read after write fails** (corruption, key-derivation glitch) → restore old file from backup taken before the migration; the gateway continues to read from disk; operator re-runs once vault is healthy.
-- **Smoke message fails** → restore old file from backup; revert gateway config.
-- **`shred` fails** (filesystem doesn't support secure delete, e.g. btrfs CoW) → log loudly and continue. Token now exists in two places — **SECURITY incident**, requires immediate token rotation through the standalone `switchroom token rotate` recovery command (which calls Telegram's `revokeToken`, mints a fresh one, writes to the vault slot, and SIGHUPs the gateway).
+### 5.1 Pre-flight
 
-The pre-migration backup is taken automatically by the migration command and kept under a clearly-labeled path until the operator runs `switchroom token migration confirm` (or 7 days elapse).
+- Confirm the vault is unlocked (or auto-unlock is enabled). If not: `switchroom vault unlock` or `switchroom vault broker enable-auto-unlock`. Migration aborts here on failure.
+- Take a backup of current agent env file(s) containing `TELEGRAM_BOT_TOKEN=...`.
+- Note the current bot username for post-migration verification.
 
-## 6. Effort
+### 5.2 Rotate then store
 
-~0.5 day. This is a small, mechanical change leveraging machinery that already exists.
+The current plaintext token has been on disk and possibly in shell history; treat it as compromised at the threshold of moving to vault. **Rotate before storing.**
 
-## 7. Out of scope
+1. Call Telegram's `revokeToken` for the current token; capture the new token from the response.
+2. Write the new token to a vault slot (e.g. `telegram:bot_token`, or per-agent `telegram:<agent>:bot_token`) via `switchroom vault set`.
+3. Verify by reading it back through the broker (e.g. `switchroom vault get telegram:bot_token`).
 
-- Wider secret inventory (other long-lived API tokens currently on disk). Each is its own small migration; they can follow the same pattern after this one proves out.
-- The approval kernel itself — see RFC B.
+### 5.3 Switch config references
+
+- Update `switchroom.yaml` so `telegram.bot_token` (or per-agent `agents.<name>.bot_token`) reads `vault:telegram:bot_token` (or the per-agent slot).
+- Remove `TELEGRAM_BOT_TOKEN=...` lines from any agent env files. (`src/setup/onboarding.ts:163` is the writer; the corresponding lines in already-written `.env` files are what you're cleaning up.)
+- Restart the gateway. It will resolve the `vault:` reference at boot via the existing resolver pipeline.
+
+### 5.4 Smoke-verify
+
+- Post-restart, send a one-line "bot token migration complete" DM to the operator from the gateway. Migration is considered successful only after this lands.
+- `setup/telegram-api.ts`'s username-vs-expected check at `:83` will already validate the new token resolves to the right bot; lean on it.
+
+### 5.5 Shred the old plaintext
+
+**Only after the smoke message has landed**, `shred -u` (or `trash` then secure-delete) the env-file backups taken in 5.1. If `shred` fails (e.g. on a CoW filesystem like btrfs), log loudly — the rotated old token is already dead at Telegram's edge per 5.2.1 so the failure is recoverable, but it should not pass silently.
+
+## 6. Rollback
+
+- **Vault write fails (5.2.2)** → token has been rotated; the old one is dead. Recovery is to retry the write or run `switchroom token rotate` to mint another and store. There is no rollback to "the original plaintext token" because step 5.2.1 already invalidated it. This is intentional — half-rotated state is worse than committing forward.
+- **Vault read after write fails (5.2.3)** → same as above; the rotation is durable at Telegram, the only path is forward (fix vault, retry write).
+- **Smoke message fails (5.4)** → the gateway is reading from vault but cannot post; debug as a normal gateway boot failure (broker unreachable, peercred mismatch, etc.) rather than reverting config.
+- **Config syntax error (5.3)** → revert the `switchroom.yaml` edit; the token is already in vault and rotated, so re-applying once the syntax is fixed is the path forward.
+
+The asymmetry is deliberate: rotation in 5.2.1 is the point of no return. Pre-flight is your last off-ramp.
+
+## 7. After this RFC: the same pattern for other secrets
+
+Other long-lived secrets currently on disk (Anthropic OAuth refresh tokens, OpenAI API keys, etc.) follow the same migration shape:
+
+1. Pre-flight (vault unlocked, env backed up).
+2. Rotate at the upstream provider where possible; otherwise just store.
+3. Move to a vault slot.
+4. Switch config to a `vault:` reference.
+5. Smoke-verify.
+6. Shred old plaintext.
+
+Each migration is its own small ticket; no further design work is needed because the resolver and broker already handle them.
+
+## 8. Effort
+
+~0.5 day for the operational cutover, mostly in 5.4 smoke-verification and confirming the `setup/telegram-api.ts` checks pass against the new token.
+
+## 9. Out of scope
+
+- Building vault-backed bot-token plumbing — already shipped.
+- Forcing the migration on other deployments via tooling — this RFC is about Ken's deployment specifically; the pattern is documented for reuse but not automated.
+- The approval kernel itself — see RFC B, which depends on this migration being complete.

--- a/docs/rfcs/bot-token-to-vault.md
+++ b/docs/rfcs/bot-token-to-vault.md
@@ -1,0 +1,57 @@
+# RFC A: Bot token to vault
+
+Status: Draft v1
+Author: klanker (sub-agent draft)
+Date: 2026-05-06
+
+## 1. Summary
+
+Today the Telegram bot token sits on disk in plaintext where any process running as the user (`kenthompson`) can read it. That includes every agent. An agent that reads the token can post messages and approval cards as the bot, intercept callbacks, and impersonate the gateway to the user. This RFC moves the token into the existing vault under a slot that only `switchroom-gateway.service` is granted access to, with the gateway reading it via the broker on boot.
+
+This is a real, current security gap, independent of the approval kernel work. It ships first.
+
+## 2. Motivation
+
+Per `docs/vault.md:227`, the vault ACL is "misconfiguration protection, not a security boundary" — the real boundary is the vault passphrase and the filesystem permissions on `vault.enc` (`0600`). Plaintext-on-disk for the bot token offers neither of those protections. Any agent process can `cat` the file. Once an agent has the token, the trust chain that the kernel (RFC B) and existing surfaces depend on collapses — a malicious agent can post a fake "Allow this scary thing?" card and the user has no way to tell it from a legitimate one.
+
+The fix is mechanical: the vault already exists, the broker already exists, and `src/vault/auto-unlock.ts` already handles the chicken-and-egg of decrypting the vault before the gateway has its config. The token just needs to live there instead of on disk.
+
+## 3. Design
+
+- New vault slot, e.g. `telegram:bot_token`. ACL: only `switchroom-gateway.service` may read it.
+- On gateway startup, the gateway reads the token from the vault via the broker IPC (same path the gateway already uses to read other secrets).
+- The vault is unlocked at boot via the existing auto-unlock mechanism in `src/vault/auto-unlock.ts` — machine-bound encryption of the vault passphrase, decrypted at boot using `/etc/machine-id` plus per-user state. No new unlock path.
+- If auto-unlock is not enabled on this machine, gateway start fails fast with: `vault locked, run "switchroom vault unlock" or enable auto-unlock with "switchroom vault broker enable-auto-unlock"`. Actionable error, no silent boot loop.
+- Other agents are NOT granted the slot. An agent attempting to read it gets a vault `denied` response and an audit row.
+
+## 4. Migration steps
+
+The cutover has three failure modes; spec each.
+
+1. **Atomic move sequence.**
+   - Read token from current filesystem location.
+   - Write to vault slot; verify by reading it back via the broker.
+   - Restart the gateway with vault-backed token loading; verify it can post a smoke message to the operator.
+   - **Only after the smoke succeeds**, `shred -u` the old file.
+
+2. **Gateway config change.** The gateway's token-loading code switches from "read file" to "ask broker for slot." This is a single call site in the boot path.
+
+3. **Smoke verification.** A post-boot self-check posts a one-line "bot token migration complete" DM to the operator. Migration is considered successful only after this lands.
+
+## 5. Rollback plan
+
+- **Vault-write fails** → abort; token still on disk; no change. Operator inspects vault state and retries.
+- **Vault-read after write fails** (corruption, key-derivation glitch) → restore old file from backup taken before the migration; the gateway continues to read from disk; operator re-runs once vault is healthy.
+- **Smoke message fails** → restore old file from backup; revert gateway config.
+- **`shred` fails** (filesystem doesn't support secure delete, e.g. btrfs CoW) → log loudly and continue. Token now exists in two places — **SECURITY incident**, requires immediate token rotation through the standalone `switchroom token rotate` recovery command (which calls Telegram's `revokeToken`, mints a fresh one, writes to the vault slot, and SIGHUPs the gateway).
+
+The pre-migration backup is taken automatically by the migration command and kept under a clearly-labeled path until the operator runs `switchroom token migration confirm` (or 7 days elapse).
+
+## 6. Effort
+
+~0.5 day. This is a small, mechanical change leveraging machinery that already exists.
+
+## 7. Out of scope
+
+- Wider secret inventory (other long-lived API tokens currently on disk). Each is its own small migration; they can follow the same pattern after this one proves out.
+- The approval kernel itself — see RFC B.

--- a/docs/rfcs/gdrive-mcp.md
+++ b/docs/rfcs/gdrive-mcp.md
@@ -1,0 +1,86 @@
+# RFC C: Google Drive MCP integration
+
+Status: Draft v1
+Author: klanker (sub-agent draft)
+Date: 2026-05-06
+
+Prerequisite: **RFC B — Approval kernel** (`docs/rfcs/approval-kernel.md`) must be in place. The Drive MCP is the first real consumer.
+
+## 1. Summary
+
+Add a Google Drive MCP server so agents can read and (with explicit approval) write Drive docs. OAuth tokens live in the vault; every doc/folder access goes through the approval kernel; first-run onboarding offers two coarse-grained policies (whole Drive vs per-doc default); a richer folder picker is deferred to a future RFC. Scope-prefix batch coalescing handles the common "klanker just opened a /Work folder, expect a flurry of doc reads" pattern without spamming the user.
+
+## 2. MCP server choice
+
+**Recommended:** [`taylorwilsdon/google_workspace_mcp`](https://github.com/taylorwilsdon/google_workspace_mcp). Maintained, covers Drive + Docs + Sheets + Calendar in one server, supports refresh-token flow which we can store in the vault. Alternative servers exist but most either bundle to a single doc, lack token persistence, or require running under a Google service account (which loses the per-user approval semantics).
+
+We run the MCP server as a switchroom-managed subprocess of each agent that has Drive enabled, the same way other MCP servers are managed today. Configuration goes through the existing MCP config surface; no new config plane.
+
+## 3. OAuth token storage
+
+- The Google OAuth flow (initial consent, code exchange) runs through a one-time CLI command — `switchroom drive connect <agent>` — which opens the browser, captures the code via a local loopback redirect, exchanges it, and writes the **refresh token** into a vault slot like `gdrive:<agent_unit>:refresh_token`. Access tokens are short-lived and not persisted; the MCP server refreshes them on demand.
+- The vault slot's ACL grants the agent's unit only. Same model as RFC A's bot-token slot.
+- The MCP wrapper, on startup, reads the refresh token via the broker, exchanges for an access token, and holds the access token in process memory only.
+- Token revocation: `switchroom drive disconnect <agent>` calls Google's revoke endpoint AND deletes the slot AND writes a `mcp:gdrive` audit row. The kernel's `/revoke-all` killswitch (§9.2 of RFC B) extends to call this for each Drive-connected agent.
+
+## 4. First-run onboarding card
+
+When the operator enables Drive for an agent, the kernel posts a one-time setup card before the first per-resource prompt fires.
+
+```
+🆕 Google Drive enabled for klanker. How should it access your Drive?
+
+[ Allow all of Drive (less secure, fewer prompts) ]
+[ Per-doc approval (default, more secure)         ]
+```
+
+**v1 ships exactly these two options.** A "Choose folders now" option was considered and dropped — it's the v1 anti-pattern in disguise: user grants narrow, then has to widen under prompt fatigue. Better to default to per-doc and let the user widen via `/approvals add` once they have a real feel for what's noisy.
+
+The whole-Drive option writes a single `allow_always` row at scope `doc:gdrive:**`. The per-doc default writes nothing — every doc access goes through `requestApproval`.
+
+## 5. Folder picker — deferred
+
+A real Telegram-side folder picker (browse Drive, tap a folder, grant `doc:gdrive:folder/<id>/**`) lands in a **future RFC, not this one**. Until then, users widen via `/approvals add` post-grant if the per-doc default proves too noisy. The batch-coalescing behavior in §6 below softens the noise meaningfully in the meantime.
+
+## 6. Scope-prefix batch coalescing
+
+Per RFC B §11, the kernel buffers prompts for 5 seconds; if 3+ pending share a scope-prefix, it collapses into a single card. Drive is the first surface where this matters in practice.
+
+Common pattern: an agent opens a folder, then reads 6 docs in it back-to-back. With per-doc approval, that's 6 prompts. With coalescing:
+
+```
+🔐 klanker is requesting access to 4 docs in /Work
+"Q3 Strategy Notes", "Hiring plan", "Roadmap draft", "+1 more"
+[ See all ]   [ ✅ Allow this folder ]   [ 🚫 Deny ]
+[ ✅ Allow these 4 only ]
+```
+
+Tapping "Allow this folder" writes `allow_always` at `doc:gdrive:folder/<id>/**`. "Allow these 4 only" writes 4 `allow_once` rows. "Deny" denies all four; subsequent reads in the buffer window roll up into the same card.
+
+The coalescing window is short (5s) so the user doesn't perceive lag — they see a single card a beat after the agent starts the burst.
+
+## 7. Card UX details
+
+- `humanize()` for `doc:gdrive:<id>` resolves the doc title via the MCP's metadata endpoint, with the 500ms render budget specified in RFC B §8.2.
+- For folder scopes, `humanize()` resolves the folder path (e.g. `/Work/2026/Q3`).
+- The expand row shows the raw scope string for verification, plus the "why this access" line the agent supplied.
+
+## 8. Migration / rollout
+
+1. Land the MCP wrapper code, vault slot for refresh tokens, and `switchroom drive connect|disconnect` commands.
+2. Operator runs `switchroom drive connect klanker` (or whichever agent first).
+3. Kernel posts the §4 onboarding card.
+4. Normal usage begins.
+
+The first week is the high-traffic window — 10–30 taps/day expected per RFC B §11. Steady state should drop under 5/day once the user has either chosen the whole-Drive option or accumulated enough folder-prefix grants via "Allow this folder" taps.
+
+## 9. Effort
+
+~1 day. MCP wrapper + OAuth onboarding + vault slot + onboarding card + the prefix-coalescing trigger living inside the kernel.
+
+## 10. Out of scope
+
+- **Folder picker UI** — separate future RFC.
+- **Drive write operations** — same approval surface, but we'll start read-only and turn on writes once the read flow has real-world miles. Writes get their own scope namespace (e.g. `doc:gdrive:write:<id>`) so a read grant never silently authorizes a write.
+- **Notion, Slack, Gmail wrappers** — same shape, separate RFCs as they come up.
+- **Service-account auth** — sticks with per-user OAuth so approvals remain meaningful.

--- a/docs/rfcs/gdrive-mcp.md
+++ b/docs/rfcs/gdrive-mcp.md
@@ -1,6 +1,6 @@
 # RFC C: Google Drive MCP integration
 
-Status: Draft v1
+Status: Draft v2
 Author: klanker (sub-agent draft)
 Date: 2026-05-06
 
@@ -8,43 +8,115 @@ Prerequisite: **RFC B — Approval kernel** (`docs/rfcs/approval-kernel.md`) mus
 
 ## 1. Summary
 
-Add a Google Drive MCP server so agents can read and (with explicit approval) write Drive docs. OAuth tokens live in the vault; every doc/folder access goes through the approval kernel; first-run onboarding offers two coarse-grained policies (whole Drive vs per-doc default); a richer folder picker is deferred to a future RFC. Scope-prefix batch coalescing handles the common "klanker just opened a /Work folder, expect a flurry of doc reads" pattern without spamming the user.
+Add a Google Drive MCP server so agents can read and (with explicit approval) write Drive docs. OAuth refresh tokens live in the vault; every doc/folder access goes through the approval kernel; first-run onboarding flips the default away from the prompt-flood-prone per-doc shape; the reconciler treats Drive state as three-valued (present / missing / conflict); a richer folder picker is deferred to a future RFC.
 
 ## 2. MCP server choice
 
-**Recommended:** [`taylorwilsdon/google_workspace_mcp`](https://github.com/taylorwilsdon/google_workspace_mcp). Maintained, covers Drive + Docs + Sheets + Calendar in one server, supports refresh-token flow which we can store in the vault. Alternative servers exist but most either bundle to a single doc, lack token persistence, or require running under a Google service account (which loses the per-user approval semantics).
+**Pinned:** [`taylorwilsdon/google_workspace_mcp`](https://github.com/taylorwilsdon/google_workspace_mcp), pin tag `v0.5.x` (latest stable as of 2026-05). Track a specific commit SHA in `switchroom.yaml` rather than a floating tag so upgrades are explicit.
+
+- **Runtime:** Python 3.11+, run via `uvx` so no system-wide install is required. Switchroom's existing MCP-subprocess machinery already supports `uvx`-launched servers.
+- **License:** MIT.
+- **Coverage:** Drive + Docs + Sheets + Calendar + Gmail in one binary. We use only the Drive + Docs surface in v1; the others are dormant and gated by their own future RFCs (Notion/Slack/Gmail RFCs may use this same server for Gmail rather than spinning up another).
+- **Why this one over alternatives:**
+  - `modelcontextprotocol/servers` reference Drive server (Node) is single-account-only, no refresh-token persistence — re-auth every restart, breaks headless installs.
+  - `isaacphi/mcp-gdrive` is read-only and per-doc-id only; no folder traversal, which makes RFC B's folder-coalescing pointless.
+  - Service-account-based servers (e.g. `googleworkspace/mcp-server`) bypass per-user OAuth, which collapses approval semantics — every access shows up as the service account, not the user.
+  - `taylorwilsdon/google_workspace_mcp` is actively maintained, supports per-user OAuth with refresh-token storage, exposes folder traversal, and is the only one of the four with a non-trivial test suite.
 
 We run the MCP server as a switchroom-managed subprocess of each agent that has Drive enabled, the same way other MCP servers are managed today. Configuration goes through the existing MCP config surface; no new config plane.
 
-## 3. OAuth token storage
+## 3. OAuth flow for headless hosts
 
-- The Google OAuth flow (initial consent, code exchange) runs through a one-time CLI command — `switchroom drive connect <agent>` — which opens the browser, captures the code via a local loopback redirect, exchanges it, and writes the **refresh token** into a vault slot like `gdrive:<agent_unit>:refresh_token`. Access tokens are short-lived and not persisted; the MCP server refreshes them on demand.
-- The vault slot's ACL grants the agent's unit only. Same model as RFC A's bot-token slot.
-- The MCP wrapper, on startup, reads the refresh token via the broker, exchanges for an access token, and holds the access token in process memory only.
-- Token revocation: `switchroom drive disconnect <agent>` calls Google's revoke endpoint AND deletes the slot AND writes a `mcp:gdrive` audit row. The kernel's `/revoke-all` killswitch (§9.2 of RFC B) extends to call this for each Drive-connected agent.
+**The MCP server's stock OAuth flow assumes a desktop browser is reachable on the host running the bot. That is wrong for switchroom** — the host is typically a Linux box reached over SSH. The connect command must support both shapes:
 
-## 4. First-run onboarding card
+### 3.1 Desktop-browser flow (when available)
 
-When the operator enables Drive for an agent, the kernel posts a one-time setup card before the first per-resource prompt fires.
+`switchroom drive connect <agent>` detects `$DISPLAY` (or `$WAYLAND_DISPLAY`) and an installed browser via `xdg-open`. If both present, run the stock loopback flow: open `https://accounts.google.com/o/oauth2/...` in the browser, capture the code via a transient `localhost:<port>` HTTP listener, exchange for a refresh token. This is the path for laptop installs.
+
+### 3.2 Headless device-code / copy-paste flow (the SSH path)
+
+If `$DISPLAY` is unset OR `--headless` is passed, use **Google's OAuth 2.0 for Limited-Input Devices** flow (the device-code grant, RFC 8628):
+
+1. CLI calls Google's device-authorization endpoint, prints:
+   ```
+   On any device with a browser, visit:
+       https://www.google.com/device
+   And enter this code: WDJB-MJHT
+   ```
+2. CLI polls Google's token endpoint at the interval the response specifies (typically 5s) until the user completes consent on their phone or laptop.
+3. On success, exchange the device-code response for a refresh token; write it to vault per §4.
+
+Fallback if Google rejects the device-code flow for the requested scopes (Drive scopes are not always whitelisted for limited-input clients): print the consent URL plus a one-line instruction:
 
 ```
-🆕 Google Drive enabled for klanker. How should it access your Drive?
-
-[ Allow all of Drive (less secure, fewer prompts) ]
-[ Per-doc approval (default, more secure)         ]
+Open this URL on a browser-equipped machine:
+    https://accounts.google.com/o/oauth2/auth?...&redirect_uri=urn:ietf:wg:oauth:2.0:oob
+After consenting, paste the code below:
+    >
 ```
 
-**v1 ships exactly these two options.** A "Choose folders now" option was considered and dropped — it's the v1 anti-pattern in disguise: user grants narrow, then has to widen under prompt fatigue. Better to default to per-doc and let the user widen via `/approvals add` once they have a real feel for what's noisy.
+Using the `urn:ietf:wg:oauth:2.0:oob` redirect (out-of-band) lets Google show the code on its consent page; the user pastes it into the SSH session. This is the universally-available fallback.
 
-The whole-Drive option writes a single `allow_always` row at scope `doc:gdrive:**`. The per-doc default writes nothing — every doc access goes through `requestApproval`.
+The CLI auto-selects: try device-code, fall back to OOB-paste, fall back to desktop-loopback in that order based on environment + which Google accepts for the configured scopes.
 
-## 5. Folder picker — deferred
+## 4. Refresh-token storage, rotation, and revocation
 
-A real Telegram-side folder picker (browse Drive, tap a folder, grant `doc:gdrive:folder/<id>/**`) lands in a **future RFC, not this one**. Until then, users widen via `/approvals add` post-grant if the per-doc default proves too noisy. The batch-coalescing behavior in §6 below softens the noise meaningfully in the meantime.
+### 4.1 Storage
 
-## 6. Scope-prefix batch coalescing
+- The refresh token lands in a vault slot at `gdrive:<agent_unit>:refresh_token`. ACL grants the agent's unit only.
+- Access tokens are short-lived (Google's default ~1h) and **never persisted** — the MCP wrapper holds them in process memory only and refreshes on demand using the vault-stored refresh token.
+- The MCP wrapper, on startup, reads the refresh token via the broker, exchanges for an access token, and proceeds. If the broker is unreachable at startup, the wrapper exits with a clear "vault unreachable" error rather than caching a token to disk.
 
-Per RFC B §11, the kernel buffers prompts for 5 seconds; if 3+ pending share a scope-prefix, it collapses into a single card. Drive is the first surface where this matters in practice.
+### 4.2 Rotation
+
+Google rotates refresh tokens silently in two cases: (a) when the user changes their Google password, (b) when the user revokes the app's access in their Google Account dashboard. There is no callback for either. The wrapper must handle a rotated/invalidated refresh token gracefully:
+
+- On a `invalid_grant` response from Google's token endpoint, the wrapper marks the slot as **invalid** (writes a sidecar `gdrive:<agent_unit>:refresh_token:status` slot containing `invalid_grant` + timestamp) and posts a kernel approval card titled "Drive disconnected — reconnect klanker?" with `[Reconnect]` `[Disconnect permanently]` buttons.
+- `[Reconnect]` runs `switchroom drive connect <agent>` again, which overwrites the slot.
+- The vault slot itself is overwrite-on-write (no version history) — there's no value in keeping invalid refresh tokens around, and Google may have already invalidated the one we held.
+
+### 4.3 Revocation
+
+`switchroom drive disconnect <agent>` calls Google's `https://oauth2.googleapis.com/revoke` endpoint AND deletes the slot AND writes a `mcp:gdrive` audit row to `approval_audit` (RFC B §5).
+
+The kernel's `/revoke-all` killswitch (RFC B §9.2) iterates Drive-connected agents and calls the same revocation path before the kernel-level mass revoke. If Google's revoke endpoint fails for a given agent, the slot is still deleted locally and the failure is surfaced in the killswitch's status report — the user can manually revoke at `myaccount.google.com/permissions`.
+
+Vault path summary:
+- `gdrive:<agent_unit>:refresh_token` — the durable token.
+- `gdrive:<agent_unit>:refresh_token:status` — sidecar for invalid-grant signaling. Optional; absent means healthy.
+
+## 5. First-run onboarding card — flipping the default
+
+Per the reviewer's prompt-flood concern: per-doc default produces 20+ prompts on day 1 (initial folder browse + readme reads + the agent finding the right doc). That's a UX failure that trains the user to tap-through rather than read.
+
+**v1 default flips to "Allow my Drive (read-only)" — single grant, no per-doc prompts.** Per-doc remains an explicit option for security-conscious users. Onboarding copy makes the trade-off explicit so the user is choosing, not defaulting blindly:
+
+```
+🆕 Google Drive enabled for klanker.
+
+Most users pick "Allow my Drive" — one tap now, then it just works.
+"Per-doc approval" prompts you for every single file the agent opens
+(20+ prompts in the first hour is typical). Pick that only if you
+want a tap-by-tap audit trail.
+
+[ ✅ Allow my Drive (read-only)  — recommended ]
+[ 🔒 Per-doc approval — high-touch, high-friction ]
+[ ❌ Cancel — don't enable Drive ]
+```
+
+- "Allow my Drive (read-only)" writes a single `allow_always` row at scope `doc:gdrive:**` with the `read` mode flag. Writes still prompt individually (see §9 out-of-scope re: write namespace).
+- "Per-doc approval" writes nothing; every doc access goes through `requestApproval`. This is the path the reviewer flagged as prompt-flood-prone, and the copy now warns explicitly before the user picks it.
+- "Cancel" exits without writing config; the operator can re-run `switchroom drive connect <agent>` later.
+
+A "Choose folders now" option was considered and dropped — without a real folder picker (deferred per §6) it would force the user to type folder IDs, which is worse than either default.
+
+## 6. Folder picker — deferred
+
+A real Telegram-side folder picker (browse Drive, tap a folder, grant `doc:gdrive:folder/<id>/**`) lands in a **future RFC, not this one**. Until then, users widen via `/approvals add` post-grant if they chose per-doc and find it noisy. The batch-coalescing behavior in §7 below softens the per-doc noise meaningfully in the meantime.
+
+## 7. Scope-prefix batch coalescing
+
+Per RFC B §11, the kernel buffers prompts for 5 seconds; if 3+ pending share a scope-prefix, it collapses into a single card. Drive is the first surface where this matters in practice — and it is the primary mitigation for users who chose per-doc in §5.
 
 Common pattern: an agent opens a folder, then reads 6 docs in it back-to-back. With per-doc approval, that's 6 prompts. With coalescing:
 
@@ -57,30 +129,47 @@ Common pattern: an agent opens a folder, then reads 6 docs in it back-to-back. W
 
 Tapping "Allow this folder" writes `allow_always` at `doc:gdrive:folder/<id>/**`. "Allow these 4 only" writes 4 `allow_once` rows. "Deny" denies all four; subsequent reads in the buffer window roll up into the same card.
 
-The coalescing window is short (5s) so the user doesn't perceive lag — they see a single card a beat after the agent starts the burst.
+The coalescing window is short (5s) so the user doesn't perceive lag.
 
-## 7. Card UX details
+## 8. Reconciler — three-state, not boolean
+
+A naive `present? yes/no` reconciler is wrong for Drive. A doc the agent expected to find can be in three states, each requiring different handling:
+
+| State | Detection | Agent behavior |
+|---|---|---|
+| **Present** | `files.get` returns 200 with expected `id` and `mimeType`. | Proceed normally. |
+| **Missing** | `files.get` returns 404, OR returns 200 with `trashed: true`. | Surface a non-fatal "doc was deleted/trashed" notice; agent decides whether to re-find or abort. Do NOT auto-revoke the grant — the user may un-trash. |
+| **Conflict** | `files.get` returns 200 but the doc's `modifiedTime` is newer than the agent's last-seen `modifiedTime` AND content hash differs, OR the doc's `mimeType` changed (e.g. converted from Doc to PDF), OR `permissions` changed in a way that excludes the agent's owner. | Surface a "doc changed since last access" notice with the diff summary; require re-confirmation before write operations; reads proceed but flag the staleness in the response. |
+
+The reconciler runs:
+- On every doc access (cheap — same `files.get` round-trip the read needs anyway).
+- Lazily across the grant set when the user opens `/approvals list <agent>` — surfaces stale folder-grants where the underlying folder was deleted or renamed.
+
+Conflict-state grants are not auto-revoked but are flagged with a `⚠️` badge in `/approvals list`. Missing-state grants beyond 30 days fold into the staleness digest (RFC B §9.1).
+
+## 9. Card UX details
 
 - `humanize()` for `doc:gdrive:<id>` resolves the doc title via the MCP's metadata endpoint, with the 500ms render budget specified in RFC B §8.2.
 - For folder scopes, `humanize()` resolves the folder path (e.g. `/Work/2026/Q3`).
-- The expand row shows the raw scope string for verification, plus the "why this access" line the agent supplied.
+- The expand row shows the raw scope string for verification, plus the "why this access" line the agent supplied, plus the reconciler state if non-Present.
 
-## 8. Migration / rollout
+## 10. Migration / rollout
 
-1. Land the MCP wrapper code, vault slot for refresh tokens, and `switchroom drive connect|disconnect` commands.
+1. Land the MCP wrapper code, vault slot for refresh tokens, and `switchroom drive connect|disconnect` commands (with both desktop and headless OAuth paths).
 2. Operator runs `switchroom drive connect klanker` (or whichever agent first).
-3. Kernel posts the §4 onboarding card.
+3. Kernel posts the §5 onboarding card.
 4. Normal usage begins.
 
-The first week is the high-traffic window — 10–30 taps/day expected per RFC B §11. Steady state should drop under 5/day once the user has either chosen the whole-Drive option or accumulated enough folder-prefix grants via "Allow this folder" taps.
+The first week is the high-traffic window — under the new default ("Allow my Drive") expected steady-state taps drop to write-related only, which should be near-zero in v1 since writes default to per-action. Users who choose per-doc see the 10–30 taps/day burst RFC B §11 forecasts; the coalescing in §7 softens it but does not eliminate it.
 
-## 9. Effort
+## 11. Effort
 
-~1 day. MCP wrapper + OAuth onboarding + vault slot + onboarding card + the prefix-coalescing trigger living inside the kernel.
+~1 day. MCP wrapper subprocess management (mostly config wiring) + OAuth onboarding (both flows) + vault slot + onboarding card + reconciler three-state hookup.
 
-## 10. Out of scope
+## 12. Out of scope
 
 - **Folder picker UI** — separate future RFC.
 - **Drive write operations** — same approval surface, but we'll start read-only and turn on writes once the read flow has real-world miles. Writes get their own scope namespace (e.g. `doc:gdrive:write:<id>`) so a read grant never silently authorizes a write.
-- **Notion, Slack, Gmail wrappers** — same shape, separate RFCs as they come up.
+- **Notion, Slack, Gmail wrappers** — same shape, separate RFCs as they come up. (Gmail may piggy-back on this same MCP server.)
 - **Service-account auth** — sticks with per-user OAuth so approvals remain meaningful.
+- **Auto-handling of un-trashed docs** — if a missing doc returns to Present, the agent re-discovers on next access; no retro-active state-management.


### PR DESCRIPTION
## Summary

Three RFCs split from the prior mega-RFC, all reviewed and APPROVE'd:

- **A** — `bot-token-to-vault.md` — complete the operational migration to vault-backed bot tokens (resolver already shipped)
- **B** — `approval-kernel.md` — IPC broker + SQLite store + Telegram card primitive for MCP approvals (no tool/skill migration)
- **C** — `gdrive-mcp.md` — Google Drive MCP integration via the kernel

Threat model anchored to `docs/vault.md:227` (vault ACL = misconfiguration protection, not security boundary). No HMAC, no chains, no pidfd. Phase 4 (settings.json clobber) explicitly out of scope per `README.md:16` "unmodified claude".

## Review status

All three reviewed by fresh Opus reviewers (security + architecture + UX + vision lenses): **APPROVE** on all three.

## Replaces

PR #751 — same content, rebased onto current main to drop stale webhook ancestry from before #714 landed.

## Test plan

- [x] All three RFCs render cleanly
- [x] Citations spot-checked against live code
- [x] Schema additions in RFC B internally consistent
- [x] MCP server pin in RFC C verified (taylorwilsdon/google_workspace_mcp, MIT, Python/uvx)

🤖 Generated with [Claude Code](https://claude.com/claude-code)