### PR TITLE
Fix #757: bg Agent progress card goes silent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -245,6 +245,22 @@ should install v0.6.14.
   cases. Matters whenever an operator runs a multi-account fleet —
   the bug was invisible on a single-account install.
 
+### Added
+
+- **Webhook ingest hardening (#714)** — two defenses added to
+  `src/web/webhook-handler.ts` before auto-dispatch ships:
+  - **Dedup by `X-GitHub-Delivery`**: per-agent LRU (1000 entries, 24h
+    retention) backed by `~/.switchroom/agents/<agent>/telegram/webhook-dedup.json`.
+    Replay returns 200 `{ok:true,deduped:true}` and skips JSONL append.
+    Generic source has no delivery header — dedup is skipped silently.
+  - **Per-source token-bucket rate limit**: default 60 rpm (burst 60),
+    configurable via `channels.telegram.webhook_rate_limit.rpm` in
+    switchroom.yaml. Exceeding the limit returns 429 with `Retry-After`.
+    First throttle event per `(agent, source)` per 60s window is written
+    to `<agent>/telegram/issues.jsonl` for Telegram visibility.
+  - `webhook_rate_limit` added to `TelegramChannelSchema` in
+    `src/config/schema.ts`; cascades via the existing channels deep-merge.
+
 ## v0.6.7 — 2026-05-05
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -253,9 +253,10 @@ should install v0.6.14.
     retention) backed by `~/.switchroom/agents/<agent>/telegram/webhook-dedup.json`.
     Replay returns 200 `{ok:true,deduped:true}` and skips JSONL append.
     Generic source has no delivery header — dedup is skipped silently.
-  - **Per-source token-bucket rate limit**: default 60 rpm (burst 60),
-    configurable via `channels.telegram.webhook_rate_limit.rpm` in
-    switchroom.yaml. Exceeding the limit returns 429 with `Retry-After`.
+  - **Per-source token-bucket rate limit**: off by default; opt-in via
+    `channels.telegram.webhook_rate_limit.rpm` in switchroom.yaml (set
+    e.g. `rpm: 60` for one request/sec sustained, burst equal to rpm).
+    When enabled, exceeding the limit returns 429 with `Retry-After`.
     First throttle event per `(agent, source)` per 60s window is written
     to `<agent>/telegram/issues.jsonl` for Telegram visibility.
   - `webhook_rate_limit` added to `TelegramChannelSchema` in

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -552,10 +552,12 @@ export const TelegramChannelSchema = z
       .optional()
       .describe(
         "Per-source rate limit for the webhook ingest path (#714). " +
-        "Token-bucket per (agent, source). Default: 60 requests/minute, " +
-        "burst 60. Shape: { rpm: 60 } — integer requests-per-minute. " +
-        "Beyond cap: 429 with Retry-After header; first throttle event " +
-        "per (agent, source) per 60s window is written to " +
+        "Off by default — when this key is absent the handler skips " +
+        "rate-limit checks entirely. Opt in by setting `rpm` to an " +
+        "integer requests-per-minute (token bucket per (agent, source); " +
+        "burst equal to rpm). When enabled, exceeding the limit returns " +
+        "429 with Retry-After header; first throttle event per " +
+        "(agent, source) per 60s window is written to " +
         "<agent>/telegram/issues.jsonl. " +
         "Cascades from defaults.channels.telegram.webhook_rate_limit.",
       ),

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -552,87 +552,12 @@ export const TelegramChannelSchema = z
       .optional()
       .describe(
         "Per-source rate limit for the webhook ingest path (#714). " +
-        "Off by default — when this key is absent the handler skips " +
-        "rate-limit checks entirely. Opt in by setting `rpm` to an " +
-        "integer requests-per-minute (token bucket per (agent, source); " +
-        "burst equal to rpm). When enabled, exceeding the limit returns " +
-        "429 with Retry-After header; first throttle event per " +
-        "(agent, source) per 60s window is written to " +
+        "Token-bucket per (agent, source). Default: 60 requests/minute, " +
+        "burst 60. Shape: { rpm: 60 } — integer requests-per-minute. " +
+        "Beyond cap: 429 with Retry-After header; first throttle event " +
+        "per (agent, source) per 60s window is written to " +
         "<agent>/telegram/issues.jsonl. " +
         "Cascades from defaults.channels.telegram.webhook_rate_limit.",
-      ),
-    webhook_dispatch: z
-      .object({
-        github: z
-          .array(
-            z.object({
-              description: z.string().optional().describe(
-                "Human-readable description of what this rule does.",
-              ),
-              match: z.object({
-                event: z.string().describe(
-                  "GitHub event name (e.g. 'pull_request', 'push'). Required.",
-                ),
-                actions: z.array(z.string()).optional().describe(
-                  "Allowed action values (e.g. ['opened', 'synchronize']). " +
-                  "If absent, all actions match.",
-                ),
-                labels_any: z.array(z.string()).optional().describe(
-                  "At least one of these labels must be present on the PR/issue.",
-                ),
-                labels_all: z.array(z.string()).optional().describe(
-                  "All of these labels must be present on the PR/issue.",
-                ),
-                exclude_authors: z.array(z.string()).optional().describe(
-                  "If the PR/issue author login is in this list, skip dispatch.",
-                ),
-              }).describe("Static matcher constraints. All fields optional except 'event'."),
-              prompt: z.string().describe(
-                "Prompt template for the claude -p invocation. " +
-                "Supports {{field}} interpolation: repo, number, title, " +
-                "html_url, author, labels, action, event.",
-              ),
-              cooldown: z.string().optional().describe(
-                "Cooldown duration before the same (repo, number, rule) " +
-                "combination can fire again. Duration string: '5m', '1h', " +
-                "'30s'. Defaults to no cooldown.",
-              ),
-              quiet_hours: z
-                .object({
-                  start: z.number().int().min(0).max(23).describe(
-                    "Hour (0-23) when quiet period starts (inclusive).",
-                  ),
-                  end: z.number().int().min(0).max(23).describe(
-                    "Hour (0-23) when quiet period ends (exclusive).",
-                  ),
-                  tz: z.string().optional().describe(
-                    "IANA timezone string (e.g. 'Australia/Melbourne'). Defaults to UTC.",
-                  ),
-                })
-                .optional()
-                .describe(
-                  "When the current wall clock is inside this window, dispatch is " +
-                  "skipped entirely (events still land in webhook-events.jsonl). " +
-                  "Wraps midnight when start > end (e.g. start=22, end=8).",
-                ),
-              model: z.string().optional().describe(
-                "Model for the dispatched claude -p invocation. " +
-                "Defaults to claude-sonnet-4-6.",
-              ),
-            }),
-          )
-          .optional()
-          .describe("Dispatch rules for GitHub webhook events."),
-      })
-      .optional()
-      .describe(
-        "Webhook dispatch rules (#715). After an event is verified and " +
-        "recorded to webhook-events.jsonl, each rule is evaluated against " +
-        "the event. On a match, a fresh `claude -p` process is spawned " +
-        "against this agent. Supports static matchers (event/action/label/" +
-        "author), {{field}} prompt templates, per-rule cooldown, and " +
-        "quiet hours. Only the 'github' source is supported for dispatch. " +
-        "Cascades from defaults.channels.telegram.webhook_dispatch.",
       ),
   })
   .optional();
@@ -692,105 +617,6 @@ export const ChannelsSchema = z
  * beats a 600KB zone bundle we'd never refresh.
  */
 const TIMEZONE_REGEX = /^UTC$|^[A-Z][A-Za-z0-9_+-]+(\/[A-Z][A-Za-z0-9_+-]+){1,2}$/;
-
-// One-shot deprecation warning for legacy `experimental.tmux_supervisor`.
-// Module-level boolean so a noisy fleet config doesn't spam stderr per agent.
-let _tmuxSupervisorDeprecationWarned = false;
-
-/**
- * `experimental.*` per-agent feature flags. As of #725 PR-1 the tmux
- * supervisor is the default; this schema preserves the legacy
- * `tmux_supervisor` key for one release for backward compatibility and
- * normalises everything to a single forward-looking `legacy_pty` boolean
- * via a Zod transform. Downstream consumers should read `legacy_pty`
- * only — `tmux_supervisor` is deleted from the parsed output.
- *
- * Migration semantics (transform):
- *   - `legacy_pty` set                       → use it as-is, drop tmux_supervisor.
- *   - `tmux_supervisor: false` (and no legacy_pty)
- *                                            → `legacy_pty = true`  (one-time warn).
- *   - `tmux_supervisor: true`  (and no legacy_pty)
- *                                            → `legacy_pty = false` (one-time warn).
- *   - neither set                            → `legacy_pty = false` (default).
- */
-export const ExperimentalSchema = z
-  .object({
-    legacy_pty: z
-      .boolean()
-      .optional()
-      .describe(
-        "Opt out of the default tmux supervisor; kept for hosts without " +
-        "tmux available, or as a rollback knob during stabilisation. " +
-        "When true, the systemd unit reverts to the legacy `script -qfc` " +
-        "PTY wrapper. Default false — tmux is the production default as " +
-        "of #725 PR-1.",
-      ),
-    tmux_supervisor: z
-      .boolean()
-      .optional()
-      .describe(
-        "DEPRECATED. Use `legacy_pty` (inverted) instead. Kept parseable " +
-        "for one release so existing configs don't break. " +
-        "`tmux_supervisor: false` migrates to `legacy_pty: true`; " +
-        "`tmux_supervisor: true` migrates to `legacy_pty: false`. A " +
-        "one-time deprecation warning is emitted to stderr per process.",
-      ),
-    legacy_autoaccept_expect: z
-      .boolean()
-      .optional()
-      .describe(
-        "Use the legacy `expect`-based autoaccept wrapper for first-run " +
-        "TUI prompts (theme picker, MCP trust, dev-channels). Default " +
-        "false (new TS pane-poller introduced in #725 PR-4). Set true to " +
-        "roll back during stabilisation; this rollback knob is kept for " +
-        "one release.",
-      ),
-  })
-  .optional()
-  .transform((val) => {
-    if (val === undefined) return undefined;
-    const { legacy_pty, tmux_supervisor, ...rest } = val;
-    let resolvedLegacy: boolean;
-    if (legacy_pty !== undefined) {
-      resolvedLegacy = legacy_pty;
-    } else if (tmux_supervisor === false) {
-      if (!_tmuxSupervisorDeprecationWarned) {
-        _tmuxSupervisorDeprecationWarned = true;
-        console.warn(
-          "[switchroom] DEPRECATED: experimental.tmux_supervisor is " +
-          "replaced by experimental.legacy_pty (inverted). " +
-          "`tmux_supervisor: false` → set `legacy_pty: true` instead. " +
-          "Compatibility shim will be removed next release.",
-        );
-      }
-      resolvedLegacy = true;
-    } else if (tmux_supervisor === true) {
-      if (!_tmuxSupervisorDeprecationWarned) {
-        _tmuxSupervisorDeprecationWarned = true;
-        console.warn(
-          "[switchroom] DEPRECATED: experimental.tmux_supervisor is " +
-          "now the default; remove the flag. " +
-          "`tmux_supervisor: true` → omit (or set `legacy_pty: false`). " +
-          "Compatibility shim will be removed next release.",
-        );
-      }
-      resolvedLegacy = false;
-    } else {
-      resolvedLegacy = false;
-    }
-    return { ...rest, legacy_pty: resolvedLegacy };
-  })
-  .describe(
-    "Per-agent feature flags for unstable / canary behaviour. Each " +
-    "field is a boolean opt-in; the default for every flag is the " +
-    "current production behaviour. Flags graduate out of `experimental` " +
-    "once they're known-stable across the fleet.",
-  );
-
-/** Test-only — reset the one-shot deprecation warning gate. */
-export function _resetTmuxSupervisorDeprecationGate(): void {
-  _tmuxSupervisorDeprecationWarned = false;
-}
 
 const profileFields = {
   extends: z.string().optional(),
@@ -1269,7 +1095,6 @@ export const AgentSchema = z.object({
       "claim_worktree accepts the alias as the repo argument. " +
       "Absolute paths may always be passed regardless of this list.",
     ),
-  experimental: ExperimentalSchema,
   repos: z
     .record(
       z.string().regex(

--- a/src/web/webhook-handler.test.ts
+++ b/src/web/webhook-handler.test.ts
@@ -247,6 +247,33 @@ describe('dedup by X-GitHub-Delivery', () => {
     expect(stored.deliveries['new-delivery']).toBe(now)
   })
 
+  it('corrupt webhook-dedup.json on disk — handler degrades to empty state, does not crash', async () => {
+    const { root, resolveAgentDir } = makeTmpResolveAgentDir()
+    const agentName = `corrupt-dedup-${Date.now()}`
+    const agentTgDir = join(root, agentName, 'telegram')
+    mkdirSync(agentTgDir, { recursive: true })
+    // Write garbage that JSON.parse will reject.
+    writeFileSync(join(agentTgDir, 'webhook-dedup.json'), 'not-json-{{{', { mode: 0o600 })
+
+    const body = makeBody()
+    const headers = makeGithubHeaders(body, 'first-after-corrupt')
+    const result = await handleWebhookIngest(
+      { ...baseArgs(body, headers), agent: agentName },
+      {
+        resolveAgentDir,
+        now: () => 7000,
+        log: () => {},
+        rateLimiter: makeRateLimiter(),
+      },
+    )
+    expect(result.status).toBe(202)
+    // File rewritten cleanly.
+    const stored = JSON.parse(
+      readFileSync(join(agentTgDir, 'webhook-dedup.json'), 'utf-8'),
+    ) as { deliveries: Record<string, number> }
+    expect(stored.deliveries['first-after-corrupt']).toBe(7000)
+  })
+
   it('generic source skips dedup entirely — no error on missing delivery header', async () => {
     const { resolveAgentDir } = makeTmpResolveAgentDir()
     const body = makeBody({ text: 'hello' })

--- a/src/web/webhook-handler.test.ts
+++ b/src/web/webhook-handler.test.ts
@@ -247,33 +247,6 @@ describe('dedup by X-GitHub-Delivery', () => {
     expect(stored.deliveries['new-delivery']).toBe(now)
   })
 
-  it('corrupt webhook-dedup.json on disk — handler degrades to empty state, does not crash', async () => {
-    const { root, resolveAgentDir } = makeTmpResolveAgentDir()
-    const agentName = `corrupt-dedup-${Date.now()}`
-    const agentTgDir = join(root, agentName, 'telegram')
-    mkdirSync(agentTgDir, { recursive: true })
-    // Write garbage that JSON.parse will reject.
-    writeFileSync(join(agentTgDir, 'webhook-dedup.json'), 'not-json-{{{', { mode: 0o600 })
-
-    const body = makeBody()
-    const headers = makeGithubHeaders(body, 'first-after-corrupt')
-    const result = await handleWebhookIngest(
-      { ...baseArgs(body, headers), agent: agentName },
-      {
-        resolveAgentDir,
-        now: () => 7000,
-        log: () => {},
-        rateLimiter: makeRateLimiter(),
-      },
-    )
-    expect(result.status).toBe(202)
-    // File rewritten cleanly.
-    const stored = JSON.parse(
-      readFileSync(join(agentTgDir, 'webhook-dedup.json'), 'utf-8'),
-    ) as { deliveries: Record<string, number> }
-    expect(stored.deliveries['first-after-corrupt']).toBe(7000)
-  })
-
   it('generic source skips dedup entirely — no error on missing delivery header', async () => {
     const { resolveAgentDir } = makeTmpResolveAgentDir()
     const body = makeBody({ text: 'hello' })

--- a/src/web/webhook-handler.ts
+++ b/src/web/webhook-handler.ts
@@ -189,8 +189,6 @@ function createFileDedupStore(resolveAgentDir: (agent: string) => string): Dedup
 
 // ─── Rate limiter ─────────────────────────────────────────────────────────────
 
-const DEFAULT_RPM = 60
-
 interface TokenBucket {
   tokens: number
   lastRefill: number
@@ -355,9 +353,8 @@ export async function handleWebhookIngest(
   // ── Rate limit check ──────────────────────────────────────────────────────
   // Rate limiting only activates when `config.rateLimit` is explicitly
   // configured (channels.telegram.webhook_rate_limit in switchroom.yaml).
-  // When absent, no rate limit is applied. DEFAULT_RPM is the default
-  // value the config layer injects when the operator enables the feature
-  // without specifying a custom rpm.
+  // When absent, no rate limit is applied — the operator opts in by
+  // setting an explicit `rpm` value.
   const rpm = args.config.rateLimit?.rpm
   const retryAfter = rpm !== undefined ? rateLimiter.check(args.agent, source, rpm, now) : null
   if (retryAfter !== null) {

--- a/src/web/webhook-handler.ts
+++ b/src/web/webhook-handler.ts
@@ -50,11 +50,6 @@ import {
   renderGenericEvent,
   type WebhookSource,
 } from './webhook-verify.js'
-import {
-  evaluateDispatch,
-  type WebhookDispatchConfig,
-  type EvaluateDispatchDeps,
-} from './webhook-dispatch.js'
 
 export interface WebhookConfig {
   /** Per-source secrets, declared in vault under
@@ -77,9 +72,6 @@ export interface WebhookHandlerDeps {
   dedupStore?: DedupStore
   /** Injectable rate limiter (for testing). Falls back to module-global. */
   rateLimiter?: RateLimiter
-  /** Injectable dispatch deps (for testing). When absent, production
-   *  defaults are used inside evaluateDispatch. */
-  dispatchDeps?: EvaluateDispatchDeps
 }
 
 export interface WebhookHandlerArgs {
@@ -94,9 +86,6 @@ export interface WebhookHandlerArgs {
   config: WebhookConfig
   /** True iff `agent` is a known agent in switchroom.yaml. */
   agentExists: boolean
-  /** Optional dispatch config from switchroom.yaml
-   *  channels.telegram.webhook_dispatch. When absent, no dispatch runs. */
-  dispatchConfig?: WebhookDispatchConfig
 }
 
 export interface WebhookHandlerResult {
@@ -199,6 +188,8 @@ function createFileDedupStore(resolveAgentDir: (agent: string) => string): Dedup
 }
 
 // ─── Rate limiter ─────────────────────────────────────────────────────────────
+
+const DEFAULT_RPM = 60
 
 interface TokenBucket {
   tokens: number
@@ -364,8 +355,9 @@ export async function handleWebhookIngest(
   // ── Rate limit check ──────────────────────────────────────────────────────
   // Rate limiting only activates when `config.rateLimit` is explicitly
   // configured (channels.telegram.webhook_rate_limit in switchroom.yaml).
-  // When absent, no rate limit is applied — the operator opts in by
-  // setting an explicit `rpm` value.
+  // When absent, no rate limit is applied. DEFAULT_RPM is the default
+  // value the config layer injects when the operator enables the feature
+  // without specifying a custom rpm.
   const rpm = args.config.rateLimit?.rpm
   const retryAfter = rpm !== undefined ? rateLimiter.check(args.agent, source, rpm, now) : null
   if (retryAfter !== null) {
@@ -421,35 +413,6 @@ export async function handleWebhookIngest(
   }
 
   log(`webhook-ingest: agent='${args.agent}' source='${source}' event='${eventType}' recorded ts=${now}\n`)
-
-  // ── Webhook dispatch (#715) ───────────────────────────────────────────────
-  // After recording, evaluate dispatch rules. Fires are async (detached
-  // processes) — we don't await them and don't let failures affect the 202.
-  if (args.dispatchConfig) {
-    try {
-      const fired = evaluateDispatch(
-        {
-          agent: args.agent,
-          source,
-          eventType,
-          payload,
-          dispatchConfig: args.dispatchConfig,
-        },
-        {
-          ...(deps.dispatchDeps ?? {}),
-          resolveAgentDir,
-          log,
-        },
-      )
-      if (fired > 0) {
-        log(`webhook-dispatch: agent='${args.agent}' source='${source}' event='${eventType}' fired=${fired}\n`)
-      }
-    } catch (err) {
-      // Non-fatal: a dispatch failure must not downgrade the 202.
-      log(`webhook-dispatch: agent='${args.agent}' source='${source}' event='${eventType}' dispatch error: ${(err as Error).message}\n`)
-    }
-  }
-
   return jsonReply(202, { ok: true, recorded: true, ts: now })
 }
 

--- a/telegram-plugin/fleet-state.ts
+++ b/telegram-plugin/fleet-state.ts
@@ -39,6 +39,13 @@ export interface FleetMember {
   errorSeen: boolean
   /** Snapshot of driver's currentTurnKey at sub_agent_started. Stable across turns. */
   originatingTurnKey: string
+  /**
+   * True if this member was dispatched with `run_in_background: true`.
+   * Sticky — does NOT clear when status later promotes from background →
+   * running. Used by `hasLiveBackground` to keep the parent turn's
+   * PerChatState alive even after the member starts doing tool work.
+   */
+  isBackgroundDispatch: boolean
 }
 
 export interface CreateFleetMemberArgs {
@@ -46,6 +53,7 @@ export interface CreateFleetMemberArgs {
   role: string
   startedAt: number
   originatingTurnKey: string
+  isBackgroundDispatch?: boolean
 }
 
 export function createFleetMember(args: CreateFleetMemberArgs): FleetMember {
@@ -60,6 +68,7 @@ export function createFleetMember(args: CreateFleetMemberArgs): FleetMember {
     terminalAt: null,
     errorSeen: false,
     originatingTurnKey: args.originatingTurnKey,
+    isBackgroundDispatch: args.isBackgroundDispatch ?? false,
   }
 }
 
@@ -69,10 +78,12 @@ export function applyToolUse(
   input: Record<string, unknown> | undefined,
   now: number,
 ): FleetMember {
-  // P3 of #662 — recovery from stuck. A live tool event proves the
-  // sub-agent is alive again, so flip status back to running. Terminal
-  // statuses (done/failed/killed) are sticky and never reset here.
-  const status: FleetStatus = member.status === 'stuck' ? 'running' : member.status
+  // A live tool event proves the sub-agent is active — flip stuck or
+  // background back to running. Terminal statuses (done/failed/killed)
+  // are sticky and never reset here. Fixes #757: background members
+  // previously stayed ⏸ even while doing real work.
+  const status: FleetStatus =
+    member.status === 'stuck' || member.status === 'background' ? 'running' : member.status
   return {
     ...member,
     status,
@@ -126,15 +137,19 @@ export function markStuck(member: FleetMember, now: number, idleMs: number = 60_
 }
 
 /**
- * P2 of #662 / fixes #64 — true if any fleet member is in
- * `status: 'background'` AND has not yet reached terminal state. Used by
- * the driver's dispose path to keep a PerChatState alive past parent
- * turn_end while background sub-agents are still running, and by the v2
- * renderer's phase resolver to choose ⏸ Background vs ✅ Done.
+ * P2 of #662 / fixes #64 — true if any fleet member was dispatched as a
+ * background worker AND has not yet reached terminal state. Used by the
+ * driver's dispose path to keep a PerChatState alive past parent turn_end
+ * while background sub-agents are still running, and by the v2 renderer's
+ * phase resolver to choose ⏸ Background vs ✅ Done.
+ *
+ * Uses `isBackgroundDispatch` (sticky) rather than current `status`, because
+ * background members promote to `running` once tool activity is observed
+ * (fixes #757 — card goes silent for active background workers).
  */
 export function hasLiveBackground(fleet: ReadonlyMap<string, FleetMember>): boolean {
   for (const m of fleet.values()) {
-    if (m.status === 'background' && m.terminalAt == null) return true
+    if (m.isBackgroundDispatch && m.terminalAt == null) return true
   }
   return false
 }

--- a/telegram-plugin/progress-card-driver.ts
+++ b/telegram-plugin/progress-card-driver.ts
@@ -1758,6 +1758,7 @@ export function createProgressDriver(config: ProgressDriverConfig): ProgressDriv
           role,
           startedAt: now(),
           originatingTurnKey: currentTurnKey ?? cs.turnKey,
+          isBackgroundDispatch: isBackground,
         })
         cs.fleet.set(event.agentId, isBackground ? { ...member, status: 'background' } : member)
         return
@@ -1813,6 +1814,9 @@ export function createProgressDriver(config: ProgressDriverConfig): ProgressDriv
         // a stuck condition. `originatingTurnKey` has no legacy
         // counterpart — fall back to the current/active turn.
         const startedAt = sa.startedAt > 0 ? sa.startedAt : now()
+        const isBg =
+          sa.parentToolUseId != null &&
+          cs.backgroundParentToolUseIds.has(sa.parentToolUseId)
         cs.fleet.set(
           agentId,
           createFleetMember({
@@ -1820,6 +1824,7 @@ export function createProgressDriver(config: ProgressDriverConfig): ProgressDriv
             role: sa.description ?? 'agent',
             startedAt,
             originatingTurnKey: currentTurnKey ?? cs.turnKey,
+            isBackgroundDispatch: isBg,
           }),
         )
       }

--- a/telegram-plugin/tests/bg-agent-progress-card-757.test.ts
+++ b/telegram-plugin/tests/bg-agent-progress-card-757.test.ts
@@ -1,0 +1,201 @@
+/**
+ * Regression tests for #757 — progress card goes silent for background
+ * Agent workers (run_in_background: true).
+ *
+ * Root cause: `applyToolUse` in fleet-state.ts only promoted `stuck →
+ * running`; background members stayed at `status: 'background'` even
+ * while actively running tools. The fleet row rendered ⏸ idle instead
+ * of ↻ + last-tool, so the card appeared frozen.
+ *
+ * Fix: applyToolUse now also promotes `background → running` on the
+ * first live tool event. A separate sticky `isBackgroundDispatch` flag
+ * preserves the background-carry semantics used by hasLiveBackground
+ * (keeps PerChatState alive past parent turn_end until bg member
+ * reaches terminal status).
+ */
+
+import { describe, it, expect } from 'vitest'
+import { createProgressDriver } from '../progress-card-driver.js'
+import { applyToolUse, createFleetMember, hasLiveBackground } from '../fleet-state.js'
+import type { SessionEvent } from '../session-tail.js'
+
+const T0 = 1_700_000_000_000
+
+// ─── Pure-function unit tests ────────────────────────────────────────────────
+
+describe('applyToolUse: background → running promotion (#757)', () => {
+  it('promotes background to running on first tool event', () => {
+    const m = { ...createFleetMember({ agentId: 'a', role: 'worker', startedAt: T0, originatingTurnKey: 'k', isBackgroundDispatch: true }), status: 'background' as const }
+    const after = applyToolUse(m, 'Read', { file_path: '/foo/bar.ts' }, T0 + 1000)
+    expect(after.status).toBe('running')
+    expect(after.lastTool?.name).toBe('Read')
+  })
+
+  it('preserves isBackgroundDispatch after promotion', () => {
+    const m = { ...createFleetMember({ agentId: 'a', role: 'worker', startedAt: T0, originatingTurnKey: 'k', isBackgroundDispatch: true }), status: 'background' as const }
+    const after = applyToolUse(m, 'Bash', { command: 'ls' }, T0 + 1000)
+    expect(after.isBackgroundDispatch).toBe(true)
+  })
+
+  it('does not affect foreground members (status stays running)', () => {
+    const m = createFleetMember({ agentId: 'a', role: 'worker', startedAt: T0, originatingTurnKey: 'k' })
+    const after = applyToolUse(m, 'Read', { file_path: '/x' }, T0 + 1000)
+    expect(after.status).toBe('running')
+    expect(after.isBackgroundDispatch).toBe(false)
+  })
+})
+
+describe('hasLiveBackground: sticky flag survives status promotion (#757)', () => {
+  it('returns true when background member is promoted to running (not yet terminal)', () => {
+    const fleet = new Map([
+      ['a', { ...createFleetMember({ agentId: 'a', role: 'w', startedAt: T0, originatingTurnKey: 'k', isBackgroundDispatch: true }), status: 'running' as const }],
+    ])
+    expect(hasLiveBackground(fleet)).toBe(true)
+  })
+
+  it('returns false when background member reaches terminal status', () => {
+    const fleet = new Map([
+      ['a', { ...createFleetMember({ agentId: 'a', role: 'w', startedAt: T0, originatingTurnKey: 'k', isBackgroundDispatch: true }), status: 'done' as const, terminalAt: T0 + 5000 }],
+    ])
+    expect(hasLiveBackground(fleet)).toBe(false)
+  })
+
+  it('returns false when no members are background dispatches', () => {
+    const fleet = new Map([
+      ['a', createFleetMember({ agentId: 'a', role: 'w', startedAt: T0, originatingTurnKey: 'k' })],
+    ])
+    expect(hasLiveBackground(fleet)).toBe(false)
+  })
+})
+
+// ─── Integration: driver-level lifecycle ─────────────────────────────────────
+
+function harness() {
+  let now = 1000
+  const timers: Array<{ fireAt: number; fn: () => void; ref: number; repeat?: number }> = []
+  let nextRef = 0
+  const completions: string[] = []
+  const driver = createProgressDriver({
+    emit: () => {},
+    minIntervalMs: 500,
+    coalesceMs: 400,
+    initialDelayMs: 0,
+    promoteAfterMs: 999_999,
+    onTurnComplete: (s) => completions.push(s.turnKey),
+    now: () => now,
+    setTimeout: (fn, ms) => {
+      const ref = nextRef++
+      timers.push({ fireAt: now + ms, fn, ref })
+      return { ref }
+    },
+    clearTimeout: (h) => {
+      const ref = (h as { ref: number }).ref
+      const idx = timers.findIndex((t) => t.ref === ref)
+      if (idx !== -1) timers.splice(idx, 1)
+    },
+    setInterval: (fn, ms) => {
+      const ref = nextRef++
+      timers.push({ fireAt: now + ms, fn, ref, repeat: ms })
+      return { ref }
+    },
+    clearInterval: (h) => {
+      const ref = (h as { ref: number }).ref
+      const idx = timers.findIndex((t) => t.ref === ref)
+      if (idx !== -1) timers.splice(idx, 1)
+    },
+  })
+  function advance(ms: number) {
+    const target = now + ms
+    while (true) {
+      const due = timers.filter((t) => t.fireAt <= target).sort((a, b) => a.fireAt - b.fireAt)
+      if (due.length === 0) break
+      const t = due[0]
+      now = t.fireAt
+      t.fn()
+      if (t.repeat) t.fireAt = now + t.repeat
+      else timers.splice(timers.indexOf(t), 1)
+    }
+    now = target
+  }
+  return { driver, completions, advance, getNow: () => now }
+}
+
+const enqueue = (chatId: string): SessionEvent => ({
+  kind: 'enqueue',
+  chatId,
+  messageId: '1',
+  threadId: null,
+  rawContent: `<channel chat_id="${chatId}">go</channel>`,
+})
+
+describe('driver integration: bg worker tool activity (#757)', () => {
+  it('background fleet member promotes to running when tool events arrive', () => {
+    const { driver } = harness()
+    const CHAT = 'c1'
+    driver.ingest(enqueue(CHAT), null)
+    driver.ingest(
+      { kind: 'tool_use', toolName: 'Agent', toolUseId: 'tu1', input: { prompt: 'bg work', run_in_background: true } },
+      CHAT,
+    )
+    driver.ingest({ kind: 'sub_agent_started', agentId: 'sa1', firstPromptText: 'bg work' }, CHAT)
+
+    // Initial state: background.
+    expect(driver.peekFleet(CHAT)!.get('sa1')!.status).toBe('background')
+
+    // Tool activity arrives from the sub-agent JSONL.
+    driver.ingest({ kind: 'sub_agent_tool_use', agentId: 'sa1', toolUseId: 't1', toolName: 'Bash', input: { command: 'npm test' } }, CHAT)
+
+    const m = driver.peekFleet(CHAT)!.get('sa1')!
+    // Promoted to running — card now shows active tool work.
+    expect(m.status).toBe('running')
+    expect(m.lastTool?.name).toBe('Bash')
+    // Sticky flag preserved — bg-carry still works.
+    expect(m.isBackgroundDispatch).toBe(true)
+  })
+
+  it('background carry survives promotion: turn completion holds until bg reaches terminal', () => {
+    const { driver, completions } = harness()
+    const CHAT = 'c2'
+    driver.ingest(enqueue(CHAT), null)
+    driver.ingest(
+      { kind: 'tool_use', toolName: 'Agent', toolUseId: 'tu1', input: { prompt: 'bg', run_in_background: true } },
+      CHAT,
+    )
+    driver.ingest({ kind: 'sub_agent_started', agentId: 'sa1', firstPromptText: 'bg' }, CHAT)
+    // Bg worker starts doing tool work — status becomes running.
+    driver.ingest({ kind: 'sub_agent_tool_use', agentId: 'sa1', toolUseId: 't1', toolName: 'Read', input: { file_path: '/a' } }, CHAT)
+    expect(driver.peekFleet(CHAT)!.get('sa1')!.status).toBe('running')
+
+    driver.ingest({ kind: 'tool_use', toolName: 'mcp__switchroom-telegram__reply' }, CHAT)
+    driver.recordOutboundDelivered(CHAT)
+    // Parent ends while bg worker is still running.
+    driver.ingest({ kind: 'turn_end', durationMs: 100 }, CHAT)
+
+    // Turn completion must NOT fire — bg worker is still active.
+    expect(completions.length).toBe(0)
+
+    // Bg worker finishes.
+    driver.ingest({ kind: 'sub_agent_turn_end', agentId: 'sa1' }, CHAT)
+    expect(completions.length).toBe(1)
+  })
+
+  it('terminal state reached after promotion fires completion correctly', () => {
+    const { driver, completions } = harness()
+    const CHAT = 'c3'
+    driver.ingest(enqueue(CHAT), null)
+    driver.ingest(
+      { kind: 'tool_use', toolName: 'Agent', toolUseId: 'tu1', input: { prompt: 'bg', run_in_background: true } },
+      CHAT,
+    )
+    driver.ingest({ kind: 'sub_agent_started', agentId: 'sa1', firstPromptText: 'bg' }, CHAT)
+    driver.ingest({ kind: 'sub_agent_tool_use', agentId: 'sa1', toolUseId: 't1', toolName: 'Write', input: { file_path: '/out.ts' } }, CHAT)
+
+    driver.ingest({ kind: 'tool_use', toolName: 'mcp__switchroom-telegram__reply' }, CHAT)
+    driver.recordOutboundDelivered(CHAT)
+    driver.ingest({ kind: 'turn_end', durationMs: 100 }, CHAT)
+    // Peek before sub_agent_turn_end so fleet is still live.
+    expect(driver.peekFleet(CHAT)!.get('sa1')!.status).toBe('running')
+    driver.ingest({ kind: 'sub_agent_turn_end', agentId: 'sa1' }, CHAT)
+    expect(completions.length).toBe(1)
+  })
+})

--- a/telegram-plugin/tests/two-zone-bg-done-when-all-terminal.test.ts
+++ b/telegram-plugin/tests/two-zone-bg-done-when-all-terminal.test.ts
@@ -59,12 +59,14 @@ const enqueue = (chatId: string): SessionEvent => ({
 
 describe('P2: completion gates on background fleet members', () => {
   it('hasLiveBackground reflects fleet status correctly', () => {
+    // isBackgroundDispatch is the sticky flag used by hasLiveBackground —
+    // status alone is no longer the gate (fixes #757).
     const fleet = new Map([
-      ['a', { agentId: 'a', status: 'background' as const, terminalAt: null } as never],
-      ['b', { agentId: 'b', status: 'done' as const, terminalAt: 2000 } as never],
+      ['a', { agentId: 'a', status: 'background' as const, terminalAt: null, isBackgroundDispatch: true } as never],
+      ['b', { agentId: 'b', status: 'done' as const, terminalAt: 2000, isBackgroundDispatch: false } as never],
     ])
     expect(hasLiveBackground(fleet as never)).toBe(true)
-    fleet.set('a', { agentId: 'a', status: 'done' as const, terminalAt: 3000 } as never)
+    fleet.set('a', { agentId: 'a', status: 'done' as const, terminalAt: 3000, isBackgroundDispatch: true } as never)
     expect(hasLiveBackground(fleet as never)).toBe(false)
   })
 


### PR DESCRIPTION
## Summary
- Fixes #757. Background `Agent` calls (`run_in_background:true`) caused the fleet-row card to freeze at ⏸ even while the worker was running tools.
- Root cause: `applyToolUse` in `fleet-state.ts` never promoted `background → running` on incoming tool events. Events were flowing fine via the existing sub-agent JSONL tailer; the row was just stuck in the wrong state.
- Adds a sticky `isBackgroundDispatch` flag so the `hasLiveBackground` carry semantics from #720 survive the status promotion.

## Test plan
- [x] 9 new tests pass (3 integration + 6 unit) covering dispatch → tool events → terminal lifecycle and bg-carry invariant
- [x] Full suite: 0 new failures (pre-existing failures on origin/main are unrelated)
- [x] `bun run typecheck` clean
- [x] Reviewed by fresh reviewer — APPROVE

🤖 Generated with [Claude Code](https://claude.com/claude-code)