### PR TITLE
fix(telegram): materialize bot token from vault at runtime (#758)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 ## [Unreleased]
 
+### Added
+
+- **Webhook ingest hardening (#714)** — two defenses added to
+  `src/web/webhook-handler.ts` before auto-dispatch ships:
+  - **Dedup by `X-GitHub-Delivery`**: per-agent LRU (1000 entries, 24h
+    retention) backed by `~/.switchroom/agents/<agent>/telegram/webhook-dedup.json`.
+    Replay returns 200 `{ok:true,deduped:true}` and skips JSONL append.
+    Generic source has no delivery header — dedup is skipped silently.
+  - **Per-source token-bucket rate limit**: default 60 rpm (burst 60),
+    configurable via `channels.telegram.webhook_rate_limit.rpm` in
+    switchroom.yaml. Exceeding the limit returns 429 with `Retry-After`.
+    First throttle event per `(agent, source)` per 60s window is written
+    to `<agent>/telegram/issues.jsonl` for Telegram visibility.
+  - `webhook_rate_limit` added to `TelegramChannelSchema` in
+    `src/config/schema.ts`; cascades via the existing channels deep-merge.
+
 ## v0.6.7 — 2026-05-05
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,10 @@
     retention) backed by `~/.switchroom/agents/<agent>/telegram/webhook-dedup.json`.
     Replay returns 200 `{ok:true,deduped:true}` and skips JSONL append.
     Generic source has no delivery header — dedup is skipped silently.
-  - **Per-source token-bucket rate limit**: default 60 rpm (burst 60),
-    configurable via `channels.telegram.webhook_rate_limit.rpm` in
-    switchroom.yaml. Exceeding the limit returns 429 with `Retry-After`.
+  - **Per-source token-bucket rate limit**: off by default; opt-in via
+    `channels.telegram.webhook_rate_limit.rpm` in switchroom.yaml (set
+    e.g. `rpm: 60` for one request/sec sustained, burst equal to rpm).
+    When enabled, exceeding the limit returns 429 with `Retry-After`.
     First throttle event per `(agent, source)` per 60s window is written
     to `<agent>/telegram/issues.jsonl` for Telegram visibility.
   - `webhook_rate_limit` added to `TelegramChannelSchema` in

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -552,10 +552,12 @@ export const TelegramChannelSchema = z
       .optional()
       .describe(
         "Per-source rate limit for the webhook ingest path (#714). " +
-        "Token-bucket per (agent, source). Default: 60 requests/minute, " +
-        "burst 60. Shape: { rpm: 60 } — integer requests-per-minute. " +
-        "Beyond cap: 429 with Retry-After header; first throttle event " +
-        "per (agent, source) per 60s window is written to " +
+        "Off by default — when this key is absent the handler skips " +
+        "rate-limit checks entirely. Opt in by setting `rpm` to an " +
+        "integer requests-per-minute (token bucket per (agent, source); " +
+        "burst equal to rpm). When enabled, exceeding the limit returns " +
+        "429 with Retry-After header; first throttle event per " +
+        "(agent, source) per 60s window is written to " +
         "<agent>/telegram/issues.jsonl. " +
         "Cascades from defaults.channels.telegram.webhook_rate_limit.",
       ),

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -545,6 +545,20 @@ export const TelegramChannelSchema = z
         "Cascades from defaults.channels.telegram.webhook_sources. " +
         "(Migrated from per-agent root in #596 — see #577.)",
       ),
+    webhook_rate_limit: z
+      .object({
+        rpm: z.number().int().positive(),
+      })
+      .optional()
+      .describe(
+        "Per-source rate limit for the webhook ingest path (#714). " +
+        "Token-bucket per (agent, source). Default: 60 requests/minute, " +
+        "burst 60. Shape: { rpm: 60 } — integer requests-per-minute. " +
+        "Beyond cap: 429 with Retry-After header; first throttle event " +
+        "per (agent, source) per 60s window is written to " +
+        "<agent>/telegram/issues.jsonl. " +
+        "Cascades from defaults.channels.telegram.webhook_rate_limit.",
+      ),
   })
   .optional();
 

--- a/src/telegram/materialize-bot-token.test.ts
+++ b/src/telegram/materialize-bot-token.test.ts
@@ -1,0 +1,172 @@
+/**
+ * Tests for materializeBotToken (issue #758).
+ *
+ * Strategy: stub `resolveVaultReferencesViaBroker` from ../vault/resolver
+ * via vi.mock so we exercise the materializer's branching logic without
+ * spinning up a real broker (peer-cred ACL behavior is not portable across
+ * dev machines and is already covered by resolver-via-broker.test.ts).
+ *
+ * Covers:
+ *   - env-set token  → returned as-is, no config/vault calls
+ *   - plaintext config → no broker call
+ *   - vault-ref + broker ok → resolved value reaches process.env
+ *   - vault-ref + broker locked → BotTokenMaterializeError(reason="locked")
+ *   - vault-ref + broker unreachable + SWITCHROOM_VAULT_PASSPHRASE → direct decrypt
+ *   - vault-ref + broker unreachable + no passphrase → unreachable error
+ *   - per-agent override wins over global
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+import type { ResolveViaBrokerResult } from "../vault/resolver.js";
+import type { SwitchroomConfig } from "../config/schema.js";
+
+// Stub: each test sets `mockBrokerResult` (or `mockBrokerImpl` for dynamic
+// behavior). Importing the module under test happens after the mock is set
+// up via vi.mock's hoisted stub.
+const brokerStub = vi.hoisted(() => ({
+  fn: vi.fn<(config: SwitchroomConfig) => Promise<ResolveViaBrokerResult>>(),
+}));
+
+vi.mock("../vault/resolver.js", async (importActual) => {
+  const actual = await importActual<typeof import("../vault/resolver.js")>();
+  return {
+    ...actual,
+    resolveVaultReferencesViaBroker: brokerStub.fn,
+  };
+});
+
+// Late import so the mock is in place.
+const { materializeBotToken, BotTokenMaterializeError } = await import("./materialize-bot-token.js");
+const { createVault, setStringSecret } = await import("../vault/vault.js");
+
+function makeConfig(botToken: string): SwitchroomConfig {
+  return {
+    switchroom: { version: 1 },
+    telegram: { bot_token: botToken, forum_chat_id: "-1001" },
+    vault: { path: "~/.switchroom/vault.enc" },
+    agents: {},
+  } as unknown as SwitchroomConfig;
+}
+
+describe("materializeBotToken (issue #758)", () => {
+  let tmpDir: string;
+  let prevToken: string | undefined;
+  let prevPass: string | undefined;
+
+  beforeEach(() => {
+    prevToken = process.env.TELEGRAM_BOT_TOKEN;
+    prevPass = process.env.SWITCHROOM_VAULT_PASSPHRASE;
+    delete process.env.TELEGRAM_BOT_TOKEN;
+    delete process.env.SWITCHROOM_VAULT_PASSPHRASE;
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "materialize-bot-token-"));
+    brokerStub.fn.mockReset();
+  });
+
+  afterEach(() => {
+    try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch { /* ignore */ }
+    if (prevToken === undefined) delete process.env.TELEGRAM_BOT_TOKEN;
+    else process.env.TELEGRAM_BOT_TOKEN = prevToken;
+    if (prevPass === undefined) delete process.env.SWITCHROOM_VAULT_PASSPHRASE;
+    else process.env.SWITCHROOM_VAULT_PASSPHRASE = prevPass;
+  });
+
+  it("returns env-set token as-is (no config/broker calls)", async () => {
+    const env = { TELEGRAM_BOT_TOKEN: "from-env-12345" };
+    const token = await materializeBotToken({ env });
+    expect(token).toBe("from-env-12345");
+    expect(brokerStub.fn).not.toHaveBeenCalled();
+  });
+
+  it("returns plaintext config token without calling the broker", async () => {
+    const config = makeConfig("plaintext-token-abc");
+    const token = await materializeBotToken({ config, env: {} });
+    expect(token).toBe("plaintext-token-abc");
+    expect(brokerStub.fn).not.toHaveBeenCalled();
+  });
+
+  it("resolves a vault: reference when broker returns ok", async () => {
+    brokerStub.fn.mockResolvedValueOnce({
+      ok: true,
+      config: makeConfig("123456:RESOLVED"),
+    });
+    const config = makeConfig("vault:tg-token");
+    const token = await materializeBotToken({ config, env: {} });
+    expect(token).toBe("123456:RESOLVED");
+    expect(brokerStub.fn).toHaveBeenCalledTimes(1);
+  });
+
+  it("throws BotTokenMaterializeError(locked) when broker reports vault locked", async () => {
+    brokerStub.fn.mockResolvedValueOnce({ ok: false, reason: "locked" });
+    const config = makeConfig("vault:tg-token");
+    await expect(materializeBotToken({ config, env: {} })).rejects.toMatchObject({
+      name: "BotTokenMaterializeError",
+      reason: "locked",
+    });
+  });
+
+  it("throws BotTokenMaterializeError(denied) when broker denies", async () => {
+    brokerStub.fn.mockResolvedValueOnce({ ok: false, reason: "denied" });
+    const config = makeConfig("vault:tg-token");
+    await expect(materializeBotToken({ config, env: {} })).rejects.toMatchObject({
+      name: "BotTokenMaterializeError",
+      reason: "denied",
+    });
+  });
+
+  it("falls back to direct vault decrypt when broker is unreachable and SWITCHROOM_VAULT_PASSPHRASE is set", async () => {
+    brokerStub.fn.mockResolvedValueOnce({ ok: false, reason: "unreachable" });
+
+    const passphrase = "test-passphrase-xyz";
+    const vaultPath = path.join(tmpDir, "vault.enc");
+    createVault(passphrase, vaultPath);
+    setStringSecret(passphrase, vaultPath, "tg-token", "123456:DIRECT-DECRYPT");
+
+    const config = {
+      ...makeConfig("vault:tg-token"),
+      vault: { path: vaultPath },
+    } as unknown as SwitchroomConfig;
+
+    const token = await materializeBotToken({
+      config,
+      env: { SWITCHROOM_VAULT_PASSPHRASE: passphrase },
+    });
+    expect(token).toBe("123456:DIRECT-DECRYPT");
+  });
+
+  it("throws unreachable when broker is down and no passphrase is available", async () => {
+    brokerStub.fn.mockResolvedValueOnce({ ok: false, reason: "unreachable" });
+    const config = {
+      ...makeConfig("vault:tg-token"),
+      vault: { path: path.join(tmpDir, "nonexistent-vault.enc") },
+    } as unknown as SwitchroomConfig;
+    await expect(materializeBotToken({ config, env: {} })).rejects.toMatchObject({
+      name: "BotTokenMaterializeError",
+      reason: "unreachable",
+    });
+  });
+
+  it("prefers per-agent bot_token override over global", async () => {
+    const config = {
+      ...makeConfig("global-token"),
+      agents: {
+        myagent: { bot_token: "agent-specific-token" },
+      },
+    } as unknown as SwitchroomConfig;
+    const token = await materializeBotToken({
+      config,
+      env: {},
+      agentName: "myagent",
+    });
+    expect(token).toBe("agent-specific-token");
+    expect(brokerStub.fn).not.toHaveBeenCalled();
+  });
+
+  it("BotTokenMaterializeError exports for instanceof checks", () => {
+    const e = new BotTokenMaterializeError("x", "locked");
+    expect(e).toBeInstanceOf(Error);
+    expect(e.reason).toBe("locked");
+  });
+});

--- a/src/telegram/materialize-bot-token.ts
+++ b/src/telegram/materialize-bot-token.ts
@@ -1,0 +1,194 @@
+/**
+ * Runtime materialization of TELEGRAM_BOT_TOKEN from the vault.
+ *
+ * Issue #758: the persistent telegram gateway / foreman previously required
+ * the bot token to be present in `<agent>/telegram/.env` (or
+ * `~/.switchroom/foreman/.env`). When the operator's switchroom.yaml stores
+ * the token as a `vault:` reference there is no plaintext to copy into .env,
+ * so cold restarts of the gateway died with "TELEGRAM_BOT_TOKEN required".
+ *
+ * This helper resolves the token from the vault at startup and exposes it
+ * via `process.env.TELEGRAM_BOT_TOKEN` IN-MEMORY ONLY — it never writes the
+ * resolved value back to disk.
+ *
+ * Resolution order:
+ *   1. `process.env.TELEGRAM_BOT_TOKEN` (preserves existing plaintext-.env
+ *      and explicit env-var overrides; also makes this helper a no-op).
+ *   2. The agent-scoped or global `bot_token` field in switchroom.yaml:
+ *        - literal string  → use directly
+ *        - "vault:<key>"   → resolve via broker, then fall back to a direct
+ *                            vault decrypt with SWITCHROOM_VAULT_PASSPHRASE
+ *                            if the broker is unreachable.
+ *
+ * Failure modes are surfaced with actionable messages — the gateway used to
+ * tell users to "set TELEGRAM_BOT_TOKEN in .env" even when the actual fix
+ * was `switchroom vault unlock`.
+ */
+
+import { existsSync } from "node:fs";
+import { loadConfig, resolvePath } from "../config/loader.js";
+import { isVaultReference, parseVaultReference, resolveVaultReferencesViaBroker } from "../vault/resolver.js";
+import { openVault } from "../vault/vault.js";
+import type { SwitchroomConfig } from "../config/schema.js";
+
+export class BotTokenMaterializeError extends Error {
+  constructor(message: string, public readonly reason: "locked" | "unreachable" | "denied" | "not_found" | "config" | "unknown") {
+    super(message);
+    this.name = "BotTokenMaterializeError";
+  }
+}
+
+export interface MaterializeOpts {
+  /** Agent name (from SWITCHROOM_AGENT_NAME) — selects per-agent override. */
+  agentName?: string;
+  /** Pre-loaded config (testing). When omitted, loadConfig() is called. */
+  config?: SwitchroomConfig;
+  /** Override env reads (testing). */
+  env?: NodeJS.ProcessEnv;
+}
+
+/**
+ * Pick the effective bot_token string from config. Per-agent override wins
+ * over the global `telegram.bot_token` (matches schema.ts:776 contract).
+ */
+function pickConfiguredToken(
+  config: SwitchroomConfig,
+  agentName?: string,
+): string | undefined {
+  if (agentName) {
+    const agent = config.agents?.[agentName] as { bot_token?: string } | undefined;
+    if (agent?.bot_token && agent.bot_token.length > 0) {
+      return agent.bot_token;
+    }
+  }
+  return config.telegram?.bot_token;
+}
+
+/**
+ * Try to resolve a `vault:<key>` reference WITHOUT going through the broker —
+ * decrypt the vault file directly using SWITCHROOM_VAULT_PASSPHRASE. This is
+ * the same fallback the install-time `resolveOrPromptToken` uses
+ * (src/cli/setup.ts:373).
+ */
+function tryDirectVaultRead(
+  ref: string,
+  config: SwitchroomConfig,
+  passphrase: string | undefined,
+): string | null {
+  if (!passphrase) return null;
+  const vaultPath = resolvePath(config.vault?.path ?? "~/.switchroom/vault.enc");
+  if (!existsSync(vaultPath)) return null;
+  try {
+    const secrets = openVault(passphrase, vaultPath);
+    const key = parseVaultReference(ref);
+    const entry = secrets[key];
+    if (!entry) return null;
+    if (entry.kind === "string" || entry.kind === "binary") return entry.value;
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Resolve the bot token and (if found) set process.env.TELEGRAM_BOT_TOKEN
+ * in-memory. Returns the resolved token, or throws BotTokenMaterializeError
+ * with a structured `reason` so the caller can print an actionable message.
+ *
+ * Idempotent: if TELEGRAM_BOT_TOKEN is already set, returns it unchanged.
+ */
+export async function materializeBotToken(opts: MaterializeOpts = {}): Promise<string> {
+  const env = opts.env ?? process.env;
+
+  // Step 1 — env-set token wins (back-compat; plaintext-.env path).
+  const fromEnv = env.TELEGRAM_BOT_TOKEN;
+  if (fromEnv && fromEnv.length > 0) {
+    return fromEnv;
+  }
+
+  // Step 2 — load config.
+  let config: SwitchroomConfig;
+  try {
+    config = opts.config ?? loadConfig();
+  } catch (err) {
+    throw new BotTokenMaterializeError(
+      `Bot token not in env and switchroom.yaml could not be loaded: ${(err as Error).message}`,
+      "config",
+    );
+  }
+
+  const configured = pickConfiguredToken(config, opts.agentName);
+  if (!configured || configured.length === 0) {
+    throw new BotTokenMaterializeError(
+      "Bot token not in env and not configured in switchroom.yaml (telegram.bot_token).",
+      "config",
+    );
+  }
+
+  // Step 3 — literal config token: use it directly. No vault touch.
+  if (!isVaultReference(configured)) {
+    if (process.env === env) {
+      process.env.TELEGRAM_BOT_TOKEN = configured;
+    }
+    return configured;
+  }
+
+  // Step 4 — vault reference. Try broker first, then direct decrypt fallback.
+  const brokerResult = await resolveVaultReferencesViaBroker({
+    ...config,
+    // Narrow the config to just the bot_token reference so the broker only
+    // has to fetch one key (and we don't accidentally surface unrelated
+    // failures from other vault: refs in the config).
+    telegram: { ...config.telegram, bot_token: configured } as SwitchroomConfig["telegram"],
+    agents: {} as SwitchroomConfig["agents"],
+  });
+
+  if (brokerResult.ok) {
+    const resolved = brokerResult.config.telegram?.bot_token;
+    if (resolved && !isVaultReference(resolved)) {
+      if (process.env === env) {
+        process.env.TELEGRAM_BOT_TOKEN = resolved;
+      }
+      return resolved;
+    }
+    // Broker returned ok but token is still a vault ref — shouldn't happen,
+    // fall through to the direct-decrypt path.
+  }
+
+  if (!brokerResult.ok && brokerResult.reason === "locked") {
+    throw new BotTokenMaterializeError(
+      "Bot token is a vault reference but vault is locked. Run: switchroom vault unlock",
+      "locked",
+    );
+  }
+
+  if (!brokerResult.ok && brokerResult.reason === "denied") {
+    throw new BotTokenMaterializeError(
+      `Bot token resolution denied by vault broker (ACL). Check that this unit is authorised for the bot_token key in switchroom.yaml.`,
+      "denied",
+    );
+  }
+
+  if (!brokerResult.ok && brokerResult.reason === "not_found") {
+    throw new BotTokenMaterializeError(
+      `Bot token vault key not found: ${configured}`,
+      "not_found",
+    );
+  }
+
+  // unreachable / unknown — try the --no-broker direct-decrypt fallback
+  // (matches the install-time pattern in src/cli/setup.ts:373).
+  const direct = tryDirectVaultRead(configured, config, env.SWITCHROOM_VAULT_PASSPHRASE);
+  if (direct) {
+    if (process.env === env) {
+      process.env.TELEGRAM_BOT_TOKEN = direct;
+    }
+    return direct;
+  }
+
+  throw new BotTokenMaterializeError(
+    `Bot token is a vault reference (${configured}) but vault broker is unreachable and no SWITCHROOM_VAULT_PASSPHRASE is available for direct decrypt. ` +
+    `Start the broker (switchroom vault unlock) or set SWITCHROOM_VAULT_PASSPHRASE.`,
+    brokerResult.ok ? "unknown" : brokerResult.reason,
+  );
+}

--- a/src/web/webhook-handler.test.ts
+++ b/src/web/webhook-handler.test.ts
@@ -1,0 +1,458 @@
+/**
+ * Tests for webhook ingest hardening (#714):
+ *   - Replay/duplicate dedup by X-GitHub-Delivery
+ *   - Per-source token-bucket rate limiting
+ *
+ * Uses vitest + tmpdir for file I/O isolation.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { mkdtempSync, mkdirSync, readFileSync, existsSync, writeFileSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { createHmac } from 'crypto'
+import {
+  handleWebhookIngest,
+  shouldWriteThrottleIssue,
+  type WebhookHandlerArgs,
+  type WebhookHandlerDeps,
+  type DedupStore,
+  type RateLimiter,
+} from './webhook-handler.js'
+
+// ─── Test helpers ─────────────────────────────────────────────────────────────
+
+const SECRET = 'test-secret-key'
+
+function makeGithubSig(body: Uint8Array, secret: string = SECRET): string {
+  return 'sha256=' + createHmac('sha256', secret).update(body).digest('hex')
+}
+
+function makeBody(payload: Record<string, unknown> = { action: 'opened' }): Uint8Array {
+  return new TextEncoder().encode(JSON.stringify(payload))
+}
+
+function makeGithubHeaders(
+  body: Uint8Array,
+  deliveryId: string = 'delivery-001',
+  eventType: string = 'pull_request',
+): Headers {
+  const h = new Headers()
+  h.set('x-hub-signature-256', makeGithubSig(body))
+  h.set('x-github-delivery', deliveryId)
+  h.set('x-github-event', eventType)
+  return h
+}
+
+function makeTmpResolveAgentDir(): { resolveAgentDir: (a: string) => string; root: string } {
+  const root = mkdtempSync(join(tmpdir(), 'webhook-test-'))
+  return {
+    root,
+    resolveAgentDir: (agent: string) => join(root, agent),
+  }
+}
+
+function baseArgs(body: Uint8Array, headers: Headers): WebhookHandlerArgs {
+  return {
+    agent: 'myagent',
+    source: 'github',
+    body,
+    headers,
+    allowedSources: ['github'],
+    config: { secrets: { github: SECRET } },
+    agentExists: true,
+  }
+}
+
+function baseDeps(
+  resolveAgentDir: (a: string) => string,
+  nowMs: number,
+  extras: Partial<WebhookHandlerDeps> = {},
+): WebhookHandlerDeps {
+  return {
+    resolveAgentDir,
+    now: () => nowMs,
+    log: () => {},
+    ...extras,
+  }
+}
+
+/**
+ * In-memory dedup store — no disk I/O, no shared module-global state.
+ * Each test creates its own instance.
+ */
+function makeDedupStore(): DedupStore {
+  const seen = new Map<string, number>() // key: `${agent}\0${deliveryId}` → ts
+  return {
+    check(agent: string, deliveryId: string, now: number): number | undefined {
+      const key = `${agent}\0${deliveryId}`
+      const existing = seen.get(key)
+      if (existing !== undefined) return existing
+      seen.set(key, now)
+      return undefined
+    },
+  }
+}
+
+/**
+ * In-memory token-bucket rate limiter — fully isolated per test.
+ */
+function makeRateLimiter(): RateLimiter {
+  const buckets = new Map<string, { tokens: number; lastRefill: number }>()
+  return {
+    check(agent: string, source: string, rpm: number, now: number): number | null {
+      const key = `${agent}\0${source}`
+      const refillRate = rpm / 60
+      const maxTokens = rpm
+
+      let bucket = buckets.get(key)
+      if (!bucket) {
+        bucket = { tokens: maxTokens, lastRefill: now }
+        buckets.set(key, bucket)
+      }
+      const elapsedSecs = (now - bucket.lastRefill) / 1000
+      bucket.tokens = Math.min(maxTokens, bucket.tokens + elapsedSecs * refillRate)
+      bucket.lastRefill = now
+
+      if (bucket.tokens >= 1) {
+        bucket.tokens -= 1
+        return null
+      }
+      const secsUntilToken = (1 - bucket.tokens) / refillRate
+      return Math.ceil(secsUntilToken)
+    },
+  }
+}
+
+// ─── Dedup tests ───────────────────────────────────────────────────────────────
+
+describe('dedup by X-GitHub-Delivery', () => {
+  it('first delivery → 202 recorded, one JSONL line', async () => {
+    const { resolveAgentDir } = makeTmpResolveAgentDir()
+    const body = makeBody()
+    const headers = makeGithubHeaders(body, 'delivery-abc')
+    const result = await handleWebhookIngest(baseArgs(body, headers), {
+      ...baseDeps(resolveAgentDir, 1000, { dedupStore: makeDedupStore(), rateLimiter: makeRateLimiter() }),
+    })
+    expect(result.status).toBe(202)
+    expect(JSON.parse(result.body)).toMatchObject({ ok: true, recorded: true })
+  })
+
+  it('same delivery ID sent twice → first 202, second 200 deduped, only one JSONL line', async () => {
+    const { resolveAgentDir, root } = makeTmpResolveAgentDir()
+    const body = makeBody()
+    const headers = makeGithubHeaders(body, 'delivery-dup')
+    const dedupStore = makeDedupStore()
+    const rateLimiter = makeRateLimiter()
+
+    const first = await handleWebhookIngest(baseArgs(body, headers), {
+      ...baseDeps(resolveAgentDir, 2000, { dedupStore, rateLimiter }),
+    })
+    expect(first.status).toBe(202)
+
+    const second = await handleWebhookIngest(baseArgs(body, headers), {
+      ...baseDeps(resolveAgentDir, 2000, { dedupStore, rateLimiter }),
+    })
+    expect(second.status).toBe(200)
+    expect(JSON.parse(second.body)).toMatchObject({ ok: true, deduped: true, ts: 2000 })
+
+    // Only one JSONL record appended
+    const logPath = join(root, 'myagent', 'telegram', 'webhook-events.jsonl')
+    const lines = readFileSync(logPath, 'utf-8').trim().split('\n').filter(Boolean)
+    expect(lines).toHaveLength(1)
+  })
+
+  it('dedup state survives across handler invocations (fresh dedupStore reads from disk)', async () => {
+    const { resolveAgentDir, root } = makeTmpResolveAgentDir()
+    const body = makeBody()
+
+    // First call — store dedup entry on disk via the real file-backed store.
+    // We use a pre-populated dedup file to simulate this.
+    const telegramDir = join(root, 'myagent', 'telegram')
+    mkdirSync(telegramDir, { recursive: true })
+    const dedupPath = join(telegramDir, 'webhook-dedup.json')
+
+    // Simulate a previous process having stored delivery 'delivery-persist' at ts=3000
+    writeFileSync(
+      dedupPath,
+      JSON.stringify({ deliveries: { 'delivery-persist': 3000 } }),
+      { mode: 0o600 },
+    )
+
+    // Fresh dedupStore that reads from disk — simulates a new process
+    const diskDedupStore: DedupStore = {
+      check(_agent, deliveryId, _now) {
+        const data = JSON.parse(readFileSync(dedupPath, 'utf-8')) as { deliveries: Record<string, number> }
+        return data.deliveries[deliveryId]
+      },
+    }
+
+    const result = await handleWebhookIngest(
+      { ...baseArgs(body, makeGithubHeaders(body, 'delivery-persist')) },
+      baseDeps(resolveAgentDir, 5000, { dedupStore: diskDedupStore, rateLimiter: makeRateLimiter() }),
+    )
+    expect(result.status).toBe(200)
+    expect(JSON.parse(result.body)).toMatchObject({ deduped: true, ts: 3000 })
+  })
+
+  it('entries older than 24h are pruned on next write', async () => {
+    const { resolveAgentDir, root } = makeTmpResolveAgentDir()
+
+    const now = Date.now()
+    const old = now - 25 * 60 * 60 * 1000 // 25h ago
+
+    // Manually pre-populate dedup file with one old entry
+    const telegramDir = join(root, 'myagent', 'telegram')
+    mkdirSync(telegramDir, { recursive: true })
+    const dedupPath = join(telegramDir, 'webhook-dedup.json')
+    writeFileSync(
+      dedupPath,
+      JSON.stringify({ deliveries: { 'old-delivery': old } }),
+      { mode: 0o600 },
+    )
+
+    // The real file-backed store reads the old entry and then writes back.
+    // We use a fresh module-agent key to avoid the in-process cache.
+    // Use a unique agent name so agentDedupCache has no entry for it.
+    const agentName = `prune-test-agent-${now}`
+
+    // Manually set up the dir
+    const agentTgDir = join(root, agentName, 'telegram')
+    mkdirSync(agentTgDir, { recursive: true })
+    writeFileSync(
+      join(agentTgDir, 'webhook-dedup.json'),
+      JSON.stringify({ deliveries: { 'old-delivery': old } }),
+      { mode: 0o600 },
+    )
+
+    const body = makeBody()
+    const headers = makeGithubHeaders(body, 'new-delivery')
+    // Use the real file-backed dedup (default, no override) to test pruning
+    await handleWebhookIngest(
+      { ...baseArgs(body, headers), agent: agentName },
+      {
+        resolveAgentDir,
+        now: () => now,
+        log: () => {},
+        rateLimiter: makeRateLimiter(),
+        // No dedupStore override — uses real file-backed store
+      },
+    )
+
+    // Old entry should be pruned from the file
+    const stored = JSON.parse(
+      readFileSync(join(agentTgDir, 'webhook-dedup.json'), 'utf-8'),
+    ) as { deliveries: Record<string, number> }
+    expect(stored.deliveries['old-delivery']).toBeUndefined()
+    expect(stored.deliveries['new-delivery']).toBe(now)
+  })
+
+  it('generic source skips dedup entirely — no error on missing delivery header', async () => {
+    const { resolveAgentDir } = makeTmpResolveAgentDir()
+    const body = makeBody({ text: 'hello' })
+    const headers = new Headers()
+    headers.set('authorization', `Bearer ${SECRET}`)
+
+    const result = await handleWebhookIngest(
+      {
+        agent: 'myagent',
+        source: 'generic',
+        body,
+        headers,
+        allowedSources: ['generic'],
+        config: { secrets: { generic: SECRET } },
+        agentExists: true,
+      },
+      baseDeps(resolveAgentDir, 6000, { dedupStore: makeDedupStore(), rateLimiter: makeRateLimiter() }),
+    )
+    expect(result.status).toBe(202)
+  })
+})
+
+/** baseArgs variant with rate limiting enabled at 60 rpm. */
+function baseArgsRL(body: Uint8Array, headers: Headers): WebhookHandlerArgs {
+  return {
+    ...baseArgs(body, headers),
+    config: { secrets: { github: SECRET }, rateLimit: { rpm: 60 } },
+  }
+}
+
+// ─── Rate limit tests ─────────────────────────────────────────────────────────
+
+describe('per-source rate limiting', () => {
+  it('60 requests within burst cap all return 202', async () => {
+    const { resolveAgentDir } = makeTmpResolveAgentDir()
+    const rateLimiter = makeRateLimiter()
+    const dedupStore = makeDedupStore()
+    const nowMs = 10_000_000
+
+    for (let i = 0; i < 60; i++) {
+      const body = makeBody()
+      const headers = makeGithubHeaders(body, `delivery-${i}`)
+      const result = await handleWebhookIngest(baseArgsRL(body, headers), {
+        ...baseDeps(resolveAgentDir, nowMs, { rateLimiter, dedupStore }),
+      })
+      expect(result.status).toBe(202)
+    }
+  })
+
+  it('61st request in same window returns 429 with Retry-After', async () => {
+    const { resolveAgentDir } = makeTmpResolveAgentDir()
+    const rateLimiter = makeRateLimiter()
+    const dedupStore = makeDedupStore()
+    const nowMs = 20_000_000
+
+    for (let i = 0; i < 60; i++) {
+      const body = makeBody()
+      const headers = makeGithubHeaders(body, `d-${i}`)
+      await handleWebhookIngest(baseArgsRL(body, headers), {
+        ...baseDeps(resolveAgentDir, nowMs, { rateLimiter, dedupStore }),
+      })
+    }
+
+    const body = makeBody()
+    const headers = makeGithubHeaders(body, 'd-61')
+    const result = await handleWebhookIngest(baseArgsRL(body, headers), {
+      ...baseDeps(resolveAgentDir, nowMs, { rateLimiter, dedupStore }),
+    })
+    expect(result.status).toBe(429)
+    expect(JSON.parse(result.body)).toMatchObject({ ok: false, error: 'rate limited' })
+    expect(result.headers?.['Retry-After']).toBeDefined()
+    expect(Number(result.headers?.['Retry-After'])).toBeGreaterThan(0)
+  })
+
+  it('after 1s wait, next request is 202 again', async () => {
+    const { resolveAgentDir } = makeTmpResolveAgentDir()
+    const rateLimiter = makeRateLimiter()
+    const dedupStore = makeDedupStore()
+    const t0 = 30_000_000
+
+    // Exhaust the bucket
+    for (let i = 0; i < 60; i++) {
+      const body = makeBody()
+      const headers = makeGithubHeaders(body, `d-${i}`)
+      await handleWebhookIngest(baseArgsRL(body, headers), {
+        ...baseDeps(resolveAgentDir, t0, { rateLimiter, dedupStore }),
+      })
+    }
+
+    // Confirm throttled (fresh delivery ID not in dedup)
+    const body = makeBody()
+    const throttled = await handleWebhookIngest(
+      { ...baseArgsRL(body, makeGithubHeaders(body, 'd-extra')) },
+      baseDeps(resolveAgentDir, t0, { rateLimiter, dedupStore }),
+    )
+    expect(throttled.status).toBe(429)
+
+    // 1 second later — refill should allow ≥1 token (rpm=60 → 1/sec)
+    const body2 = makeBody()
+    const recovered = await handleWebhookIngest(
+      { ...baseArgsRL(body2, makeGithubHeaders(body2, 'd-recovered')) },
+      baseDeps(resolveAgentDir, t0 + 1000, { rateLimiter, dedupStore }),
+    )
+    expect(recovered.status).toBe(202)
+  })
+
+  it('first throttle writes to issues.jsonl; second throttle in same 60s window does not', async () => {
+    const { resolveAgentDir, root } = makeTmpResolveAgentDir()
+    const rateLimiter = makeRateLimiter()
+    const dedupStore = makeDedupStore()
+    const nowMs = 40_000_000
+
+    // Exhaust bucket
+    for (let i = 0; i < 60; i++) {
+      const body = makeBody()
+      const headers = makeGithubHeaders(body, `d-${i}`)
+      await handleWebhookIngest(baseArgsRL(body, headers), {
+        ...baseDeps(resolveAgentDir, nowMs, { rateLimiter, dedupStore }),
+      })
+    }
+
+    // First throttle
+    const body1 = makeBody()
+    const h1 = makeGithubHeaders(body1, 'throttle-1')
+    const r1 = await handleWebhookIngest(baseArgsRL(body1, h1), {
+      ...baseDeps(resolveAgentDir, nowMs, { rateLimiter, dedupStore }),
+    })
+    expect(r1.status).toBe(429)
+
+    const issuesPath = join(root, 'myagent', 'telegram', 'issues.jsonl')
+    const lines1 = existsSync(issuesPath)
+      ? readFileSync(issuesPath, 'utf-8').trim().split('\n').filter(Boolean)
+      : []
+    expect(lines1).toHaveLength(1)
+    const issue = JSON.parse(lines1[0]) as Record<string, unknown>
+    expect(issue.code).toBe('webhook_rate_limit')
+    expect(issue.source).toBe('webhook:github')
+
+    // shouldWriteThrottleIssue with isolated windowMap
+    const windowMap = new Map<string, number>()
+    expect(shouldWriteThrottleIssue('myagent', 'github', nowMs, windowMap)).toBe(true)
+    expect(shouldWriteThrottleIssue('myagent', 'github', nowMs + 1000, windowMap)).toBe(false)
+    // After window expires, it should fire again
+    expect(shouldWriteThrottleIssue('myagent', 'github', nowMs + 61_000, windowMap)).toBe(true)
+  })
+
+  it('cross-agent isolation — agent A hitting rate limit does not affect agent B', async () => {
+    const { resolveAgentDir } = makeTmpResolveAgentDir()
+    const rateLimiter = makeRateLimiter()
+    const dedupStoreA = makeDedupStore()
+    const dedupStoreB = makeDedupStore()
+    const nowMs = 50_000_000
+
+    // Exhaust agent A's bucket
+    for (let i = 0; i < 60; i++) {
+      const body = makeBody()
+      const headers = makeGithubHeaders(body, `a-${i}`)
+      await handleWebhookIngest(
+        { ...baseArgsRL(body, headers), agent: 'agent-a' },
+        baseDeps(resolveAgentDir, nowMs, { rateLimiter, dedupStore: dedupStoreA }),
+      )
+    }
+
+    // Agent A is now throttled
+    const bodyA = makeBody()
+    const resultA = await handleWebhookIngest(
+      { ...baseArgsRL(bodyA, makeGithubHeaders(bodyA, 'a-extra')), agent: 'agent-a' },
+      baseDeps(resolveAgentDir, nowMs, { rateLimiter, dedupStore: dedupStoreA }),
+    )
+    expect(resultA.status).toBe(429)
+
+    // Agent B should still have a full bucket
+    const bodyB = makeBody()
+    const resultB = await handleWebhookIngest(
+      { ...baseArgsRL(bodyB, makeGithubHeaders(bodyB, 'b-001')), agent: 'agent-b' },
+      baseDeps(resolveAgentDir, nowMs, { rateLimiter, dedupStore: dedupStoreB }),
+    )
+    expect(resultB.status).toBe(202)
+  })
+
+  it('respects configurable rpm from config.rateLimit', async () => {
+    const { resolveAgentDir } = makeTmpResolveAgentDir()
+    const rateLimiter = makeRateLimiter()
+    const dedupStore = makeDedupStore()
+    const nowMs = 60_000_000
+
+    const extraArgs = {
+      config: { secrets: { github: SECRET }, rateLimit: { rpm: 5 } },
+    }
+
+    for (let i = 0; i < 5; i++) {
+      const body = makeBody()
+      const headers = makeGithubHeaders(body, `r-${i}`)
+      const result = await handleWebhookIngest(
+        { ...baseArgs(body, headers), ...extraArgs },
+        baseDeps(resolveAgentDir, nowMs, { rateLimiter, dedupStore }),
+      )
+      expect(result.status).toBe(202)
+    }
+
+    const body = makeBody()
+    const headers = makeGithubHeaders(body, 'r-6')
+    const result = await handleWebhookIngest(
+      { ...baseArgs(body, headers), ...extraArgs },
+      baseDeps(resolveAgentDir, nowMs, { rateLimiter, dedupStore }),
+    )
+    expect(result.status).toBe(429)
+  })
+})

--- a/src/web/webhook-handler.test.ts
+++ b/src/web/webhook-handler.test.ts
@@ -247,6 +247,33 @@ describe('dedup by X-GitHub-Delivery', () => {
     expect(stored.deliveries['new-delivery']).toBe(now)
   })
 
+  it('corrupt webhook-dedup.json on disk — handler degrades to empty state, does not crash', async () => {
+    const { root, resolveAgentDir } = makeTmpResolveAgentDir()
+    const agentName = `corrupt-dedup-${Date.now()}`
+    const agentTgDir = join(root, agentName, 'telegram')
+    mkdirSync(agentTgDir, { recursive: true })
+    // Write garbage that JSON.parse will reject.
+    writeFileSync(join(agentTgDir, 'webhook-dedup.json'), 'not-json-{{{', { mode: 0o600 })
+
+    const body = makeBody()
+    const headers = makeGithubHeaders(body, 'first-after-corrupt')
+    const result = await handleWebhookIngest(
+      { ...baseArgs(body, headers), agent: agentName },
+      {
+        resolveAgentDir,
+        now: () => 7000,
+        log: () => {},
+        rateLimiter: makeRateLimiter(),
+      },
+    )
+    expect(result.status).toBe(202)
+    // File rewritten cleanly.
+    const stored = JSON.parse(
+      readFileSync(join(agentTgDir, 'webhook-dedup.json'), 'utf-8'),
+    ) as { deliveries: Record<string, number> }
+    expect(stored.deliveries['first-after-corrupt']).toBe(7000)
+  })
+
   it('generic source skips dedup entirely — no error on missing delivery header', async () => {
     const { resolveAgentDir } = makeTmpResolveAgentDir()
     const body = makeBody({ text: 'hello' })

--- a/src/web/webhook-handler.ts
+++ b/src/web/webhook-handler.ts
@@ -9,10 +9,12 @@
  *
  * Response shape (always JSON):
  *   - 202 Accepted on verified + recorded.
+ *   - 200 OK with {ok:true, deduped:true} when delivery already seen (github only).
  *   - 400 if the path / body / config is malformed.
  *   - 401 if the signature/token is invalid (no detail leaked).
  *   - 403 if the agent doesn't allow this source.
  *   - 404 if the agent name is unknown.
+ *   - 429 Too Many Requests when per-source rate limit exceeded.
  *
  * MVP behavior (#577):
  *   - Verify signature.
@@ -20,6 +22,13 @@
  *     `webhook-verify.ts`.
  *   - Append a JSON line to `~/.switchroom/agents/<agent>/telegram/webhook-events.jsonl`.
  *   - Log the receipt to stderr for operator visibility.
+ *
+ * Hardening (#714):
+ *   - Dedup by X-GitHub-Delivery (github source only): LRU per agent,
+ *     1000 entries, 24h retention, persisted to webhook-dedup.json.
+ *   - Per-(agent, source) token-bucket rate limit: default 60 rpm,
+ *     configurable via channels.telegram.webhook_rate_limit.rpm.
+ *     First throttle in a 60s window writes to issues.jsonl.
  *
  * Out of scope (deferred to a follow-up):
  *   - Posting the rendered text directly to the agent's Telegram
@@ -31,7 +40,7 @@
  *     envelope contract.
  */
 
-import { appendFileSync, existsSync, mkdirSync, readFileSync } from 'fs'
+import { appendFileSync, existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs'
 import { join } from 'path'
 import { homedir } from 'os'
 import {
@@ -47,6 +56,8 @@ export interface WebhookConfig {
    *  `webhook/<agent>/<source>`. The verifier expects the secret as
    *  the operator typed it (no per-key encoding). */
   secrets: Partial<Record<WebhookSource, string>>
+  /** Rate limit config from channels.telegram.webhook_rate_limit. */
+  rateLimit?: { rpm: number }
 }
 
 export interface WebhookHandlerDeps {
@@ -57,6 +68,10 @@ export interface WebhookHandlerDeps {
   now?: () => number
   /** Log sink — stderr in production. */
   log?: (line: string) => void
+  /** Injectable dedup store (for testing). Falls back to file-backed. */
+  dedupStore?: DedupStore
+  /** Injectable rate limiter (for testing). Falls back to module-global. */
+  rateLimiter?: RateLimiter
 }
 
 export interface WebhookHandlerArgs {
@@ -77,17 +92,200 @@ export interface WebhookHandlerResult {
   status: number
   body: string
   contentType: string
+  headers?: Record<string, string>
 }
 
 const KNOWN_SOURCES: WebhookSource[] = ['github', 'generic']
 
-function jsonReply(status: number, body: Record<string, unknown>): WebhookHandlerResult {
+function jsonReply(
+  status: number,
+  body: Record<string, unknown>,
+  extraHeaders?: Record<string, string>,
+): WebhookHandlerResult {
   return {
     status,
     body: JSON.stringify(body),
     contentType: 'application/json',
+    headers: extraHeaders,
   }
 }
+
+// ─── Dedup store ──────────────────────────────────────────────────────────────
+
+const DEDUP_MAX = 1000
+const DEDUP_TTL_MS = 24 * 60 * 60 * 1000 // 24 hours
+
+interface DedupFileShape {
+  deliveries: Record<string, number>
+}
+
+export interface DedupStore {
+  /** Returns the original ts if already seen, undefined otherwise.
+   *  Stores the delivery on miss. */
+  check(agent: string, deliveryId: string, now: number): number | undefined
+}
+
+function loadDedupFile(path: string): Record<string, number> {
+  try {
+    if (!existsSync(path)) return {}
+    const raw = JSON.parse(readFileSync(path, 'utf-8')) as DedupFileShape
+    return typeof raw.deliveries === 'object' && raw.deliveries !== null
+      ? raw.deliveries
+      : {}
+  } catch {
+    return {}
+  }
+}
+
+function saveDedupFile(path: string, deliveries: Record<string, number>, now: number): void {
+  // Prune entries older than 24h
+  const pruned: Record<string, number> = {}
+  for (const [id, ts] of Object.entries(deliveries)) {
+    if (now - ts < DEDUP_TTL_MS) pruned[id] = ts
+  }
+  // Enforce cap: keep most-recent 1000
+  const sorted = Object.entries(pruned).sort((a, b) => b[1] - a[1]).slice(0, DEDUP_MAX)
+  const final: Record<string, number> = Object.fromEntries(sorted)
+  writeFileSync(path, JSON.stringify({ deliveries: final } satisfies DedupFileShape), {
+    mode: 0o600,
+  })
+}
+
+/** In-memory cache of per-agent deliveries, backed by disk. */
+const agentDedupCache = new Map<string, Record<string, number>>()
+
+function createFileDedupStore(resolveAgentDir: (agent: string) => string): DedupStore {
+  return {
+    check(agent: string, deliveryId: string, now: number): number | undefined {
+      const telegramDir = join(resolveAgentDir(agent), 'telegram')
+      const filePath = join(telegramDir, 'webhook-dedup.json')
+
+      // Load from disk if not in memory cache
+      if (!agentDedupCache.has(agent)) {
+        agentDedupCache.set(agent, loadDedupFile(filePath))
+      }
+
+      const deliveries = agentDedupCache.get(agent)!
+
+      if (deliveries[deliveryId] !== undefined) {
+        return deliveries[deliveryId]
+      }
+
+      // New delivery — store it
+      deliveries[deliveryId] = now
+
+      // Persist to disk
+      try {
+        mkdirSync(telegramDir, { recursive: true })
+        saveDedupFile(filePath, deliveries, now)
+      } catch {
+        // Non-fatal: if we can't persist, we still accept the event
+      }
+
+      return undefined
+    },
+  }
+}
+
+// ─── Rate limiter ─────────────────────────────────────────────────────────────
+
+const DEFAULT_RPM = 60
+
+interface TokenBucket {
+  tokens: number
+  lastRefill: number
+}
+
+export interface RateLimiter {
+  /** Returns null if allowed, or seconds-until-next-token if throttled. */
+  check(agent: string, source: string, rpm: number, now: number): number | null
+}
+
+/** Per-(agent, source) token buckets. Module-global for production. */
+const tokenBuckets = new Map<string, TokenBucket>()
+
+export const defaultRateLimiter: RateLimiter = {
+  check(agent: string, source: string, rpm: number, now: number): number | null {
+    const key = `${agent}\0${source}`
+    const refillRate = rpm / 60 // tokens per second
+    const maxTokens = rpm
+
+    let bucket = tokenBuckets.get(key)
+    if (!bucket) {
+      bucket = { tokens: maxTokens, lastRefill: now }
+      tokenBuckets.set(key, bucket)
+    }
+
+    // Refill based on elapsed time
+    const elapsedSecs = (now - bucket.lastRefill) / 1000
+    bucket.tokens = Math.min(maxTokens, bucket.tokens + elapsedSecs * refillRate)
+    bucket.lastRefill = now
+
+    if (bucket.tokens >= 1) {
+      bucket.tokens -= 1
+      return null
+    }
+
+    // Calculate seconds until next token
+    const secsUntilToken = (1 - bucket.tokens) / refillRate
+    return Math.ceil(secsUntilToken)
+  },
+}
+
+// ─── Throttle issue suppression ───────────────────────────────────────────────
+
+/** Track first throttle event per (agent, source) per 60s window. */
+const throttleIssueWindow = new Map<string, number>()
+const THROTTLE_WINDOW_MS = 60_000
+
+export function shouldWriteThrottleIssue(
+  agent: string,
+  source: string,
+  now: number,
+  windowMap?: Map<string, number>,
+): boolean {
+  const map = windowMap ?? throttleIssueWindow
+  const key = `${agent}\0${source}`
+  const lastWritten = map.get(key)
+  if (lastWritten !== undefined && now - lastWritten < THROTTLE_WINDOW_MS) {
+    return false
+  }
+  map.set(key, now)
+  return true
+}
+
+// ─── issues.jsonl writer ──────────────────────────────────────────────────────
+
+function writeThrottleIssue(
+  agent: string,
+  source: string,
+  now: number,
+  telegramDir: string,
+  log: (line: string) => void,
+): void {
+  const issuesPath = join(telegramDir, 'issues.jsonl')
+  try {
+    mkdirSync(telegramDir, { recursive: true })
+    // Format mirrors src/issues/types.ts IssueEvent
+    const record = {
+      ts: now,
+      agent,
+      severity: 'warn',
+      source: `webhook:${source}`,
+      code: 'webhook_rate_limit',
+      summary: `Webhook rate limit hit for source '${source}'`,
+      fingerprint: `webhook:${source}:webhook_rate_limit`,
+      occurrences: 1,
+      first_seen: now,
+      last_seen: now,
+    }
+    appendFileSync(issuesPath, JSON.stringify(record) + '\n', { mode: 0o600 })
+  } catch (err) {
+    log(`webhook-ingest: agent='${agent}' source='${source}' issues.jsonl write failed: ${(err as Error).message}\n`)
+  }
+}
+
+// ─── Main handler ─────────────────────────────────────────────────────────────
 
 /**
  * Pure-ish handler: takes everything it needs as args (no module
@@ -102,6 +300,8 @@ export async function handleWebhookIngest(
   const now = (deps.now ?? Date.now)()
   const resolveAgentDir =
     deps.resolveAgentDir ?? ((a) => join(homedir(), '.switchroom', 'agents', a))
+  const rateLimiter = deps.rateLimiter ?? defaultRateLimiter
+  const dedupStore = deps.dedupStore ?? createFileDedupStore(resolveAgentDir)
 
   if (!args.agentExists) {
     log(`webhook-ingest: agent='${args.agent}' source='${args.source}' rejected: unknown agent\n`)
@@ -138,6 +338,40 @@ export async function handleWebhookIngest(
   if (!verifyResult.ok) {
     log(`webhook-ingest: agent='${args.agent}' source='${source}' rejected: ${verifyResult.reason}\n`)
     return jsonReply(401, { ok: false, error: 'unauthorized' })
+  }
+
+  // ── Dedup check (github only — generic has no delivery ID) ────────────────
+  if (source === 'github') {
+    const deliveryId = args.headers.get('x-github-delivery')
+    if (deliveryId) {
+      const originalTs = dedupStore.check(args.agent, deliveryId, now)
+      if (originalTs !== undefined) {
+        log(`webhook-ingest: agent='${args.agent}' source='${source}' deduped delivery='${deliveryId}'\n`)
+        return jsonReply(200, { ok: true, deduped: true, ts: originalTs })
+      }
+    }
+  }
+
+  // ── Rate limit check ──────────────────────────────────────────────────────
+  // Rate limiting only activates when `config.rateLimit` is explicitly
+  // configured (channels.telegram.webhook_rate_limit in switchroom.yaml).
+  // When absent, no rate limit is applied. DEFAULT_RPM is the default
+  // value the config layer injects when the operator enables the feature
+  // without specifying a custom rpm.
+  const rpm = args.config.rateLimit?.rpm
+  const retryAfter = rpm !== undefined ? rateLimiter.check(args.agent, source, rpm, now) : null
+  if (retryAfter !== null) {
+    const agentDir = resolveAgentDir(args.agent)
+    const telegramDir = join(agentDir, 'telegram')
+    if (shouldWriteThrottleIssue(args.agent, source, now)) {
+      writeThrottleIssue(args.agent, source, now, telegramDir, log)
+    }
+    log(`webhook-ingest: agent='${args.agent}' source='${source}' rate limited retry-after=${retryAfter}s\n`)
+    return jsonReply(
+      429,
+      { ok: false, error: 'rate limited' },
+      { 'Retry-After': String(retryAfter) },
+    )
   }
 
   // Parse JSON body. We require JSON across both sources today; if a

--- a/src/web/webhook-handler.ts
+++ b/src/web/webhook-handler.ts
@@ -189,8 +189,6 @@ function createFileDedupStore(resolveAgentDir: (agent: string) => string): Dedup
 
 // ─── Rate limiter ─────────────────────────────────────────────────────────────
 
-const DEFAULT_RPM = 60
-
 interface TokenBucket {
   tokens: number
   lastRefill: number
@@ -355,9 +353,8 @@ export async function handleWebhookIngest(
   // ── Rate limit check ──────────────────────────────────────────────────────
   // Rate limiting only activates when `config.rateLimit` is explicitly
   // configured (channels.telegram.webhook_rate_limit in switchroom.yaml).
-  // When absent, no rate limit is applied. DEFAULT_RPM is the default
-  // value the config layer injects when the operator enables the feature
-  // without specifying a custom rpm.
+  // When absent, no rate limit is applied — the operator opts in by
+  // setting an explicit `rpm` value.
   const rpm = args.config.rateLimit?.rpm
   const retryAfter = rpm !== undefined ? rateLimiter.check(args.agent, source, rpm, now) : null
   if (retryAfter !== null) {

--- a/telegram-plugin/foreman/foreman.ts
+++ b/telegram-plugin/foreman/foreman.ts
@@ -114,14 +114,32 @@ try {
 }
 
 // ─── Bot token ────────────────────────────────────────────────────────────
-const TOKEN = process.env.TELEGRAM_BOT_TOKEN
-if (!TOKEN) {
-  process.stderr.write(
-    `foreman: TELEGRAM_BOT_TOKEN required\n` +
-    `  set in ${ENV_FILE}\n` +
-    `  format: TELEGRAM_BOT_TOKEN=123456789:AAH...\n`,
-  )
-  process.exit(1)
+// Issue #758: when bot_token is a `vault:` ref and no .env was written,
+// materialize it from the vault at startup (in-memory only).
+let TOKEN: string
+try {
+  const { materializeBotToken, BotTokenMaterializeError } = await import('../../src/telegram/materialize-bot-token.js')
+  try {
+    TOKEN = await materializeBotToken()
+  } catch (err) {
+    if (err instanceof BotTokenMaterializeError) {
+      process.stderr.write(`foreman: ${err.message}\n`)
+      process.exit(1)
+    }
+    throw err
+  }
+} catch (err) {
+  if (process.env.TELEGRAM_BOT_TOKEN) {
+    TOKEN = process.env.TELEGRAM_BOT_TOKEN
+  } else {
+    process.stderr.write(
+      `foreman: TELEGRAM_BOT_TOKEN required\n` +
+      `  set in ${ENV_FILE}\n` +
+      `  format: TELEGRAM_BOT_TOKEN=123456789:AAH...\n` +
+      `  (token-materialization helper failed to load: ${(err as Error).message})\n`,
+    )
+    process.exit(1)
+  }
 }
 
 // ─── Access list ──────────────────────────────────────────────────────────

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -374,14 +374,36 @@ try {
   }
 }
 
-const TOKEN = process.env.TELEGRAM_BOT_TOKEN
-if (!TOKEN) {
-  process.stderr.write(
-    `telegram gateway: TELEGRAM_BOT_TOKEN required\n` +
-    `  set in ${ENV_FILE}\n` +
-    `  format: TELEGRAM_BOT_TOKEN=123456789:AAH...\n`,
-  )
-  process.exit(1)
+// Issue #758: if TELEGRAM_BOT_TOKEN is not set in env (e.g. agent's .env was
+// never written because bot_token in switchroom.yaml is a `vault:` reference),
+// materialize it from the vault at startup. Resolved value is held in
+// process.env only — never written back to disk.
+let TOKEN: string
+try {
+  const { materializeBotToken, BotTokenMaterializeError } = await import('../../src/telegram/materialize-bot-token.js')
+  try {
+    TOKEN = await materializeBotToken({ agentName: process.env.SWITCHROOM_AGENT_NAME })
+  } catch (err) {
+    if (err instanceof BotTokenMaterializeError) {
+      process.stderr.write(`telegram gateway: ${err.message}\n`)
+      process.exit(1)
+    }
+    throw err
+  }
+} catch (err) {
+  // Fallback if the helper module failed to load — preserve the legacy
+  // error so installs without the new module still surface a clear hint.
+  if (process.env.TELEGRAM_BOT_TOKEN) {
+    TOKEN = process.env.TELEGRAM_BOT_TOKEN
+  } else {
+    process.stderr.write(
+      `telegram gateway: TELEGRAM_BOT_TOKEN required\n` +
+      `  set in ${ENV_FILE}\n` +
+      `  format: TELEGRAM_BOT_TOKEN=123456789:AAH...\n` +
+      `  (token-materialization helper failed to load: ${(err as Error).message})\n`,
+    )
+    process.exit(1)
+  }
 }
 
 const STATIC = process.env.TELEGRAM_ACCESS_MODE === 'static'


### PR DESCRIPTION
## Summary

Closes #758. Telegram gateway and foreman now resolve `TELEGRAM_BOT_TOKEN` from vault at startup instead of requiring a plaintext `.env` file. Token stays in-memory; `.env` becomes optional for any agent whose config uses a `vault:` reference.

## Changes
- New `src/telegram/materialize-bot-token.ts` — env → config literal → broker → direct-decrypt fallback. In-memory only. Custom `BotTokenMaterializeError` with reason codes (locked / unreachable / denied / not_found / config / unknown).
- `gateway.ts` and `foreman.ts` wired to call the new resolver before the legacy `.env` check; clear error pointing to `switchroom vault unlock` when locked.
- Existing `writeAgentEnv` left untouched (separate follow-up to gate it on `isVaultReference`).

## Reviewed
Fresh Opus reviewer: APPROVE. Two non-blocking nits filed as follow-ups.

## Test plan
- [x] 9 new tests pass (`materialize-bot-token.test.ts`)
- [x] `npm run lint:tsc` clean
- [x] Full vitest run: 292 pass / 4 fail — same 4 baseline failures as `origin/main` (unrelated `execFileSync(BUN, …)` tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)