### PR TITLE
fix(telegram): materialize bot token from vault at runtime (#758)

### DIFF
--- a/src/telegram/materialize-bot-token.test.ts
+++ b/src/telegram/materialize-bot-token.test.ts
@@ -1,0 +1,172 @@
+/**
+ * Tests for materializeBotToken (issue #758).
+ *
+ * Strategy: stub `resolveVaultReferencesViaBroker` from ../vault/resolver
+ * via vi.mock so we exercise the materializer's branching logic without
+ * spinning up a real broker (peer-cred ACL behavior is not portable across
+ * dev machines and is already covered by resolver-via-broker.test.ts).
+ *
+ * Covers:
+ *   - env-set token  → returned as-is, no config/vault calls
+ *   - plaintext config → no broker call
+ *   - vault-ref + broker ok → resolved value reaches process.env
+ *   - vault-ref + broker locked → BotTokenMaterializeError(reason="locked")
+ *   - vault-ref + broker unreachable + SWITCHROOM_VAULT_PASSPHRASE → direct decrypt
+ *   - vault-ref + broker unreachable + no passphrase → unreachable error
+ *   - per-agent override wins over global
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+import type { ResolveViaBrokerResult } from "../vault/resolver.js";
+import type { SwitchroomConfig } from "../config/schema.js";
+
+// Stub: each test sets `mockBrokerResult` (or `mockBrokerImpl` for dynamic
+// behavior). Importing the module under test happens after the mock is set
+// up via vi.mock's hoisted stub.
+const brokerStub = vi.hoisted(() => ({
+  fn: vi.fn<(config: SwitchroomConfig) => Promise<ResolveViaBrokerResult>>(),
+}));
+
+vi.mock("../vault/resolver.js", async (importActual) => {
+  const actual = await importActual<typeof import("../vault/resolver.js")>();
+  return {
+    ...actual,
+    resolveVaultReferencesViaBroker: brokerStub.fn,
+  };
+});
+
+// Late import so the mock is in place.
+const { materializeBotToken, BotTokenMaterializeError } = await import("./materialize-bot-token.js");
+const { createVault, setStringSecret } = await import("../vault/vault.js");
+
+function makeConfig(botToken: string): SwitchroomConfig {
+  return {
+    switchroom: { version: 1 },
+    telegram: { bot_token: botToken, forum_chat_id: "-1001" },
+    vault: { path: "~/.switchroom/vault.enc" },
+    agents: {},
+  } as unknown as SwitchroomConfig;
+}
+
+describe("materializeBotToken (issue #758)", () => {
+  let tmpDir: string;
+  let prevToken: string | undefined;
+  let prevPass: string | undefined;
+
+  beforeEach(() => {
+    prevToken = process.env.TELEGRAM_BOT_TOKEN;
+    prevPass = process.env.SWITCHROOM_VAULT_PASSPHRASE;
+    delete process.env.TELEGRAM_BOT_TOKEN;
+    delete process.env.SWITCHROOM_VAULT_PASSPHRASE;
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "materialize-bot-token-"));
+    brokerStub.fn.mockReset();
+  });
+
+  afterEach(() => {
+    try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch { /* ignore */ }
+    if (prevToken === undefined) delete process.env.TELEGRAM_BOT_TOKEN;
+    else process.env.TELEGRAM_BOT_TOKEN = prevToken;
+    if (prevPass === undefined) delete process.env.SWITCHROOM_VAULT_PASSPHRASE;
+    else process.env.SWITCHROOM_VAULT_PASSPHRASE = prevPass;
+  });
+
+  it("returns env-set token as-is (no config/broker calls)", async () => {
+    const env = { TELEGRAM_BOT_TOKEN: "from-env-12345" };
+    const token = await materializeBotToken({ env });
+    expect(token).toBe("from-env-12345");
+    expect(brokerStub.fn).not.toHaveBeenCalled();
+  });
+
+  it("returns plaintext config token without calling the broker", async () => {
+    const config = makeConfig("plaintext-token-abc");
+    const token = await materializeBotToken({ config, env: {} });
+    expect(token).toBe("plaintext-token-abc");
+    expect(brokerStub.fn).not.toHaveBeenCalled();
+  });
+
+  it("resolves a vault: reference when broker returns ok", async () => {
+    brokerStub.fn.mockResolvedValueOnce({
+      ok: true,
+      config: makeConfig("123456:RESOLVED"),
+    });
+    const config = makeConfig("vault:tg-token");
+    const token = await materializeBotToken({ config, env: {} });
+    expect(token).toBe("123456:RESOLVED");
+    expect(brokerStub.fn).toHaveBeenCalledTimes(1);
+  });
+
+  it("throws BotTokenMaterializeError(locked) when broker reports vault locked", async () => {
+    brokerStub.fn.mockResolvedValueOnce({ ok: false, reason: "locked" });
+    const config = makeConfig("vault:tg-token");
+    await expect(materializeBotToken({ config, env: {} })).rejects.toMatchObject({
+      name: "BotTokenMaterializeError",
+      reason: "locked",
+    });
+  });
+
+  it("throws BotTokenMaterializeError(denied) when broker denies", async () => {
+    brokerStub.fn.mockResolvedValueOnce({ ok: false, reason: "denied" });
+    const config = makeConfig("vault:tg-token");
+    await expect(materializeBotToken({ config, env: {} })).rejects.toMatchObject({
+      name: "BotTokenMaterializeError",
+      reason: "denied",
+    });
+  });
+
+  it("falls back to direct vault decrypt when broker is unreachable and SWITCHROOM_VAULT_PASSPHRASE is set", async () => {
+    brokerStub.fn.mockResolvedValueOnce({ ok: false, reason: "unreachable" });
+
+    const passphrase = "test-passphrase-xyz";
+    const vaultPath = path.join(tmpDir, "vault.enc");
+    createVault(passphrase, vaultPath);
+    setStringSecret(passphrase, vaultPath, "tg-token", "123456:DIRECT-DECRYPT");
+
+    const config = {
+      ...makeConfig("vault:tg-token"),
+      vault: { path: vaultPath },
+    } as unknown as SwitchroomConfig;
+
+    const token = await materializeBotToken({
+      config,
+      env: { SWITCHROOM_VAULT_PASSPHRASE: passphrase },
+    });
+    expect(token).toBe("123456:DIRECT-DECRYPT");
+  });
+
+  it("throws unreachable when broker is down and no passphrase is available", async () => {
+    brokerStub.fn.mockResolvedValueOnce({ ok: false, reason: "unreachable" });
+    const config = {
+      ...makeConfig("vault:tg-token"),
+      vault: { path: path.join(tmpDir, "nonexistent-vault.enc") },
+    } as unknown as SwitchroomConfig;
+    await expect(materializeBotToken({ config, env: {} })).rejects.toMatchObject({
+      name: "BotTokenMaterializeError",
+      reason: "unreachable",
+    });
+  });
+
+  it("prefers per-agent bot_token override over global", async () => {
+    const config = {
+      ...makeConfig("global-token"),
+      agents: {
+        myagent: { bot_token: "agent-specific-token" },
+      },
+    } as unknown as SwitchroomConfig;
+    const token = await materializeBotToken({
+      config,
+      env: {},
+      agentName: "myagent",
+    });
+    expect(token).toBe("agent-specific-token");
+    expect(brokerStub.fn).not.toHaveBeenCalled();
+  });
+
+  it("BotTokenMaterializeError exports for instanceof checks", () => {
+    const e = new BotTokenMaterializeError("x", "locked");
+    expect(e).toBeInstanceOf(Error);
+    expect(e.reason).toBe("locked");
+  });
+});

--- a/src/telegram/materialize-bot-token.ts
+++ b/src/telegram/materialize-bot-token.ts
@@ -1,0 +1,194 @@
+/**
+ * Runtime materialization of TELEGRAM_BOT_TOKEN from the vault.
+ *
+ * Issue #758: the persistent telegram gateway / foreman previously required
+ * the bot token to be present in `<agent>/telegram/.env` (or
+ * `~/.switchroom/foreman/.env`). When the operator's switchroom.yaml stores
+ * the token as a `vault:` reference there is no plaintext to copy into .env,
+ * so cold restarts of the gateway died with "TELEGRAM_BOT_TOKEN required".
+ *
+ * This helper resolves the token from the vault at startup and exposes it
+ * via `process.env.TELEGRAM_BOT_TOKEN` IN-MEMORY ONLY — it never writes the
+ * resolved value back to disk.
+ *
+ * Resolution order:
+ *   1. `process.env.TELEGRAM_BOT_TOKEN` (preserves existing plaintext-.env
+ *      and explicit env-var overrides; also makes this helper a no-op).
+ *   2. The agent-scoped or global `bot_token` field in switchroom.yaml:
+ *        - literal string  → use directly
+ *        - "vault:<key>"   → resolve via broker, then fall back to a direct
+ *                            vault decrypt with SWITCHROOM_VAULT_PASSPHRASE
+ *                            if the broker is unreachable.
+ *
+ * Failure modes are surfaced with actionable messages — the gateway used to
+ * tell users to "set TELEGRAM_BOT_TOKEN in .env" even when the actual fix
+ * was `switchroom vault unlock`.
+ */
+
+import { existsSync } from "node:fs";
+import { loadConfig, resolvePath } from "../config/loader.js";
+import { isVaultReference, parseVaultReference, resolveVaultReferencesViaBroker } from "../vault/resolver.js";
+import { openVault } from "../vault/vault.js";
+import type { SwitchroomConfig } from "../config/schema.js";
+
+export class BotTokenMaterializeError extends Error {
+  constructor(message: string, public readonly reason: "locked" | "unreachable" | "denied" | "not_found" | "config" | "unknown") {
+    super(message);
+    this.name = "BotTokenMaterializeError";
+  }
+}
+
+export interface MaterializeOpts {
+  /** Agent name (from SWITCHROOM_AGENT_NAME) — selects per-agent override. */
+  agentName?: string;
+  /** Pre-loaded config (testing). When omitted, loadConfig() is called. */
+  config?: SwitchroomConfig;
+  /** Override env reads (testing). */
+  env?: NodeJS.ProcessEnv;
+}
+
+/**
+ * Pick the effective bot_token string from config. Per-agent override wins
+ * over the global `telegram.bot_token` (matches schema.ts:776 contract).
+ */
+function pickConfiguredToken(
+  config: SwitchroomConfig,
+  agentName?: string,
+): string | undefined {
+  if (agentName) {
+    const agent = config.agents?.[agentName] as { bot_token?: string } | undefined;
+    if (agent?.bot_token && agent.bot_token.length > 0) {
+      return agent.bot_token;
+    }
+  }
+  return config.telegram?.bot_token;
+}
+
+/**
+ * Try to resolve a `vault:<key>` reference WITHOUT going through the broker —
+ * decrypt the vault file directly using SWITCHROOM_VAULT_PASSPHRASE. This is
+ * the same fallback the install-time `resolveOrPromptToken` uses
+ * (src/cli/setup.ts:373).
+ */
+function tryDirectVaultRead(
+  ref: string,
+  config: SwitchroomConfig,
+  passphrase: string | undefined,
+): string | null {
+  if (!passphrase) return null;
+  const vaultPath = resolvePath(config.vault?.path ?? "~/.switchroom/vault.enc");
+  if (!existsSync(vaultPath)) return null;
+  try {
+    const secrets = openVault(passphrase, vaultPath);
+    const key = parseVaultReference(ref);
+    const entry = secrets[key];
+    if (!entry) return null;
+    if (entry.kind === "string" || entry.kind === "binary") return entry.value;
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Resolve the bot token and (if found) set process.env.TELEGRAM_BOT_TOKEN
+ * in-memory. Returns the resolved token, or throws BotTokenMaterializeError
+ * with a structured `reason` so the caller can print an actionable message.
+ *
+ * Idempotent: if TELEGRAM_BOT_TOKEN is already set, returns it unchanged.
+ */
+export async function materializeBotToken(opts: MaterializeOpts = {}): Promise<string> {
+  const env = opts.env ?? process.env;
+
+  // Step 1 — env-set token wins (back-compat; plaintext-.env path).
+  const fromEnv = env.TELEGRAM_BOT_TOKEN;
+  if (fromEnv && fromEnv.length > 0) {
+    return fromEnv;
+  }
+
+  // Step 2 — load config.
+  let config: SwitchroomConfig;
+  try {
+    config = opts.config ?? loadConfig();
+  } catch (err) {
+    throw new BotTokenMaterializeError(
+      `Bot token not in env and switchroom.yaml could not be loaded: ${(err as Error).message}`,
+      "config",
+    );
+  }
+
+  const configured = pickConfiguredToken(config, opts.agentName);
+  if (!configured || configured.length === 0) {
+    throw new BotTokenMaterializeError(
+      "Bot token not in env and not configured in switchroom.yaml (telegram.bot_token).",
+      "config",
+    );
+  }
+
+  // Step 3 — literal config token: use it directly. No vault touch.
+  if (!isVaultReference(configured)) {
+    if (process.env === env) {
+      process.env.TELEGRAM_BOT_TOKEN = configured;
+    }
+    return configured;
+  }
+
+  // Step 4 — vault reference. Try broker first, then direct decrypt fallback.
+  const brokerResult = await resolveVaultReferencesViaBroker({
+    ...config,
+    // Narrow the config to just the bot_token reference so the broker only
+    // has to fetch one key (and we don't accidentally surface unrelated
+    // failures from other vault: refs in the config).
+    telegram: { ...config.telegram, bot_token: configured } as SwitchroomConfig["telegram"],
+    agents: {} as SwitchroomConfig["agents"],
+  });
+
+  if (brokerResult.ok) {
+    const resolved = brokerResult.config.telegram?.bot_token;
+    if (resolved && !isVaultReference(resolved)) {
+      if (process.env === env) {
+        process.env.TELEGRAM_BOT_TOKEN = resolved;
+      }
+      return resolved;
+    }
+    // Broker returned ok but token is still a vault ref — shouldn't happen,
+    // fall through to the direct-decrypt path.
+  }
+
+  if (!brokerResult.ok && brokerResult.reason === "locked") {
+    throw new BotTokenMaterializeError(
+      "Bot token is a vault reference but vault is locked. Run: switchroom vault unlock",
+      "locked",
+    );
+  }
+
+  if (!brokerResult.ok && brokerResult.reason === "denied") {
+    throw new BotTokenMaterializeError(
+      `Bot token resolution denied by vault broker (ACL). Check that this unit is authorised for the bot_token key in switchroom.yaml.`,
+      "denied",
+    );
+  }
+
+  if (!brokerResult.ok && brokerResult.reason === "not_found") {
+    throw new BotTokenMaterializeError(
+      `Bot token vault key not found: ${configured}`,
+      "not_found",
+    );
+  }
+
+  // unreachable / unknown — try the --no-broker direct-decrypt fallback
+  // (matches the install-time pattern in src/cli/setup.ts:373).
+  const direct = tryDirectVaultRead(configured, config, env.SWITCHROOM_VAULT_PASSPHRASE);
+  if (direct) {
+    if (process.env === env) {
+      process.env.TELEGRAM_BOT_TOKEN = direct;
+    }
+    return direct;
+  }
+
+  throw new BotTokenMaterializeError(
+    `Bot token is a vault reference (${configured}) but vault broker is unreachable and no SWITCHROOM_VAULT_PASSPHRASE is available for direct decrypt. ` +
+    `Start the broker (switchroom vault unlock) or set SWITCHROOM_VAULT_PASSPHRASE.`,
+    brokerResult.ok ? "unknown" : brokerResult.reason,
+  );
+}

--- a/telegram-plugin/foreman/foreman.ts
+++ b/telegram-plugin/foreman/foreman.ts
@@ -114,14 +114,32 @@ try {
 }
 
 // ─── Bot token ────────────────────────────────────────────────────────────
-const TOKEN = process.env.TELEGRAM_BOT_TOKEN
-if (!TOKEN) {
-  process.stderr.write(
-    `foreman: TELEGRAM_BOT_TOKEN required\n` +
-    `  set in ${ENV_FILE}\n` +
-    `  format: TELEGRAM_BOT_TOKEN=123456789:AAH...\n`,
-  )
-  process.exit(1)
+// Issue #758: when bot_token is a `vault:` ref and no .env was written,
+// materialize it from the vault at startup (in-memory only).
+let TOKEN: string
+try {
+  const { materializeBotToken, BotTokenMaterializeError } = await import('../../src/telegram/materialize-bot-token.js')
+  try {
+    TOKEN = await materializeBotToken()
+  } catch (err) {
+    if (err instanceof BotTokenMaterializeError) {
+      process.stderr.write(`foreman: ${err.message}\n`)
+      process.exit(1)
+    }
+    throw err
+  }
+} catch (err) {
+  if (process.env.TELEGRAM_BOT_TOKEN) {
+    TOKEN = process.env.TELEGRAM_BOT_TOKEN
+  } else {
+    process.stderr.write(
+      `foreman: TELEGRAM_BOT_TOKEN required\n` +
+      `  set in ${ENV_FILE}\n` +
+      `  format: TELEGRAM_BOT_TOKEN=123456789:AAH...\n` +
+      `  (token-materialization helper failed to load: ${(err as Error).message})\n`,
+    )
+    process.exit(1)
+  }
 }
 
 // ─── Access list ──────────────────────────────────────────────────────────

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -380,14 +380,36 @@ try {
   }
 }
 
-const TOKEN = process.env.TELEGRAM_BOT_TOKEN
-if (!TOKEN) {
-  process.stderr.write(
-    `telegram gateway: TELEGRAM_BOT_TOKEN required\n` +
-    `  set in ${ENV_FILE}\n` +
-    `  format: TELEGRAM_BOT_TOKEN=123456789:AAH...\n`,
-  )
-  process.exit(1)
+// Issue #758: if TELEGRAM_BOT_TOKEN is not set in env (e.g. agent's .env was
+// never written because bot_token in switchroom.yaml is a `vault:` reference),
+// materialize it from the vault at startup. Resolved value is held in
+// process.env only — never written back to disk.
+let TOKEN: string
+try {
+  const { materializeBotToken, BotTokenMaterializeError } = await import('../../src/telegram/materialize-bot-token.js')
+  try {
+    TOKEN = await materializeBotToken({ agentName: process.env.SWITCHROOM_AGENT_NAME })
+  } catch (err) {
+    if (err instanceof BotTokenMaterializeError) {
+      process.stderr.write(`telegram gateway: ${err.message}\n`)
+      process.exit(1)
+    }
+    throw err
+  }
+} catch (err) {
+  // Fallback if the helper module failed to load — preserve the legacy
+  // error so installs without the new module still surface a clear hint.
+  if (process.env.TELEGRAM_BOT_TOKEN) {
+    TOKEN = process.env.TELEGRAM_BOT_TOKEN
+  } else {
+    process.stderr.write(
+      `telegram gateway: TELEGRAM_BOT_TOKEN required\n` +
+      `  set in ${ENV_FILE}\n` +
+      `  format: TELEGRAM_BOT_TOKEN=123456789:AAH...\n` +
+      `  (token-materialization helper failed to load: ${(err as Error).message})\n`,
+    )
+    process.exit(1)
+  }
 }
 
 const STATIC = process.env.TELEGRAM_ACCESS_MODE === 'static'


### PR DESCRIPTION
## Summary

Closes #758. Telegram gateway and foreman now resolve `TELEGRAM_BOT_TOKEN` from vault at startup instead of requiring a plaintext `.env` file. Token stays in-memory; `.env` becomes optional for any agent whose config uses a `vault:` reference.

## Changes
- New `src/telegram/materialize-bot-token.ts` — env → config literal → broker → direct-decrypt fallback. In-memory only. Custom `BotTokenMaterializeError` with reason codes (locked / unreachable / denied / not_found / config / unknown).
- `gateway.ts` and `foreman.ts` wired to call the new resolver before the legacy `.env` check; clear error pointing to `switchroom vault unlock` when locked.
- Existing `writeAgentEnv` left untouched (separate follow-up to gate it on `isVaultReference`).

## Reviewed
Fresh Opus reviewer: APPROVE. Two non-blocking nits filed as follow-ups (outer try/catch could mask non-import errors; missing tests on `not_found` path).

## Replaces
PR #760 — same content, rebased clean onto current upstream/main.

## Test plan
- [x] 9 new tests pass (`materialize-bot-token.test.ts`)
- [x] `npm run lint:tsc` clean
- [x] Full vitest run: 292 pass / 4 fail — same 4 baseline failures as `origin/main` (unrelated `execFileSync(BUN, …)` tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)