### PR TITLE
feat(approval-kernel): IPC broker + SQLite kernel + Telegram card primitive (RFC B Phase 1)

### DIFF
--- a/src/vault/approvals/MIGRATION.md
+++ b/src/vault/approvals/MIGRATION.md
@@ -14,7 +14,7 @@ What's intentionally still on the legacy paths:
 the dispatcher around `:6944`.
 
 **Plan:** Replace the bespoke `vd:unlock:<deferKey>` callback with an
-`apv:<request_id>:once` callback minted via `approvalRequest({surface: 'secret', scope: 'secret:<key>', action_grammar: 'unlock'})`.
+`apv:<request_id>:once` callback minted via `approvalRequest({agent_unit, scope: 'secret:<key>', action: 'unlock'})`.
 The inline-passphrase capture step (the user types their vault passphrase
 in reply to the card) must survive: handle it inside the `apv:once` tap
 handler, then call `approvalConsume` only after the passphrase has been
@@ -70,10 +70,9 @@ import { buildApprovalCard, parseApprovalCallback }
 
 // 1. Open a request (returns 8-hex request_id)
 const req = await approvalRequest({
-  agent: 'klanker',
-  surface: 'secret',
+  agent_unit: 'switchroom-klanker.service',
   scope: 'secret:OPENAI_API_KEY',
-  action_grammar: 'read',
+  action: 'read',
   approver_set: access.allowFrom,
   why: 'Calling OpenAI to summarize a doc',
 })

--- a/src/vault/approvals/MIGRATION.md
+++ b/src/vault/approvals/MIGRATION.md
@@ -1,0 +1,113 @@
+# Approval kernel — call-site migration notes
+
+RFC B Phase 1 landed the kernel core: SQLite schema (`approval_decisions`,
+`approval_nonces`, `approval_audit`), broker RPC (`approval_request`,
+`approval_lookup`, `approval_consume`, `approval_revoke`, `approval_list`),
+the Telegram approval-card primitive, drift detection, single-use nonce
+consumption, and the `/approvals list|revoke` command surface.
+
+What's intentionally still on the legacy paths:
+
+## 1. Deferred-secret unlock (`vd:unlock` / `vd:cancel`)
+
+**Where:** `telegram-plugin/gateway/gateway.ts:5577` (card construction) and
+the dispatcher around `:6944`.
+
+**Plan:** Replace the bespoke `vd:unlock:<deferKey>` callback with an
+`apv:<request_id>:once` callback minted via `approvalRequest({surface: 'secret', scope: 'secret:<key>', action_grammar: 'unlock'})`.
+The inline-passphrase capture step (the user types their vault passphrase
+in reply to the card) must survive: handle it inside the `apv:once` tap
+handler, then call `approvalConsume` only after the passphrase has been
+validated by the broker's unlock socket. Don't write the passphrase
+through the kernel — the kernel is for *approval state*, not secret
+material.
+
+## 2. Vault-grant approval (`/vault grant` wizard, `vault-grants.db`)
+
+**Where:** `src/vault/grants.ts` and the wizard in `gateway.ts` (search
+for `vg:`).
+
+**Plan:** The wizard already produces a durable grant row. Migrate the
+*confirm* step to mint an approval kernel decision in addition to (or
+instead of) the legacy `vault_grants` row, scoped as
+`vault:<key>` / `read`. The two tables can coexist during the
+migration window — `validateGrant` in `grants.ts` is the read path for
+agents using capability tokens, and the kernel is the read path for
+"is this user-side approval still valid?" lookups. After Phase 2,
+`vault_grants.revoked_at` semantics fold into
+`approval_decisions.revoked_at` and the wizard becomes
+`/approvals add` (RFC §9 — Phase 1.5).
+
+## 3. ask_user dispatch (`aq:` callbacks)
+
+**Where:** `telegram-plugin/gateway/gateway.ts:8321` (dispatch) and
+`ask-user.ts` (callback shape).
+
+**Plan:** `aq:` is already kernel-shaped — it has a request_id, a card
+with allow/deny choices, and a result that flows back to a waiting agent.
+The migration is mostly cosmetic: rename the prefix to `apv:`, route the
+tap through `approvalConsume` + `recordDecision`, and surface the
+decision via `approvalLookup` to the waiting agent. The reaction
+lifecycle and topic routing in `aq:` should be preserved verbatim.
+
+## 4. Permission-rule prompts (`perm:more`, `perm:allow`, `perm:deny`)
+
+**Out of scope per RFC §14.** Tools and skills stay on
+`permission-rule.ts` + `settings.json`. Migrating these would require
+intercepting and rewriting Claude Code's `settings.json` from kernel
+state, which would conflict with switchroom's "unmodified Claude"
+principle. Do not migrate without a fresh RFC.
+
+## Wiring template
+
+Inside any callsite that needs approval today:
+
+```ts
+import { approvalRequest, approvalLookup, approvalConsume } from
+  '../../src/vault/approvals/client.js'
+import { buildApprovalCard, parseApprovalCallback }
+  from './approval-card.js'
+
+// 1. Open a request (returns 8-hex request_id)
+const req = await approvalRequest({
+  agent: 'klanker',
+  surface: 'secret',
+  scope: 'secret:OPENAI_API_KEY',
+  action_grammar: 'read',
+  approver_set: access.allowFrom,
+  why: 'Calling OpenAI to summarize a doc',
+})
+if (req === null) { /* broker unreachable — fail closed */ }
+
+// 2. Render the card to every approver
+const card = buildApprovalCard({
+  request_id: req.request_id,
+  agent: 'klanker',
+  scope_humanized: 'OPENAI_API_KEY',
+  why: 'Calling OpenAI…',
+})
+for (const chat_id of access.allowFrom) {
+  await bot.api.sendMessage(chat_id, card.text, {
+    reply_markup: card.reply_markup,
+    parse_mode: 'HTML',
+  })
+}
+
+// 3. In the apv: callback handler:
+const parsed = parseApprovalCallback(callbackData)
+if (parsed === null) return  // not ours
+const consumed = await approvalConsume(parsed.request_id)
+if (!consumed?.consumed) {
+  await ctx.answerCallbackQuery({ text: 'this prompt expired' })
+  return
+}
+// … then call recordDecision via approval_record (currently in-process
+//   on the broker side — Phase 1.5 will surface a recordDecision RPC)
+```
+
+A `recordDecision` RPC is intentionally NOT in this commit: the gateway
+owns the user-facing tap, so for Phase 1 we do the record step inside
+the gateway by writing directly to the broker's grants DB through a
+side channel (or by adding `approval_record` later). The kernel's
+internal `recordDecision` function is exported so a future
+`approval_record` RPC handler can call it without code duplication.

--- a/src/vault/approvals/canonical.ts
+++ b/src/vault/approvals/canonical.ts
@@ -1,0 +1,18 @@
+/**
+ * Canonicalize an approver set for drift-revocation comparison (RFC §5.1).
+ *
+ * Inputs are arbitrary `allowFrom`-style string lists (Telegram user_ids,
+ * usernames, etc). Two equivalent sets must produce byte-identical strings;
+ * the reverse must also hold. We normalize each entry with NFC, sort
+ * lexicographically, and JSON-encode with no whitespace.
+ *
+ * NOT cryptographic. The string is compared with `===` only.
+ */
+export function canonicalizeApproverSet(approvers: readonly string[]): string {
+  const normalized = approvers
+    .map((a) => a.normalize("NFC").trim())
+    .filter((a) => a.length > 0);
+  // Sort + dedupe in one pass so callers don't have to remember to dedupe.
+  const unique = Array.from(new Set(normalized)).sort();
+  return JSON.stringify(unique);
+}

--- a/src/vault/approvals/client.ts
+++ b/src/vault/approvals/client.ts
@@ -1,0 +1,180 @@
+/**
+ * Approval-kernel IPC client (RFC B §10).
+ *
+ * Thin wrapper around `rpcRaw` so callers (gateway, CLI commands, agent
+ * sub-modules) can talk to the broker's approval ops without hand-encoding
+ * JSON. Each helper returns a typed result or `null` when the broker is
+ * unreachable — same convention as `BrokerClient`.
+ *
+ * The agent-side wait loop (short-poll per RFC §10) is NOT implemented here
+ * yet. Phase 1 of the migration is broker-resident state + gateway
+ * round-trip; agents that need to wait will short-poll lookupApproval at
+ * 2s intervals. That's the next slice of work and is intentionally out of
+ * this commit so the surface area stays reviewable.
+ */
+
+import { rpcRaw, type BrokerClientOpts } from "../broker/client.js";
+import type { ApprovalDecisionMeta } from "../broker/protocol.js";
+
+export interface ApprovalRequestArgs {
+  agent: string;
+  surface: string;
+  scope: string;
+  action_grammar: string;
+  approver_set: string[];
+  why?: string;
+  ttl_ms?: number;
+}
+
+export interface ApprovalRequestResult {
+  request_id: string;
+  expires_at: number;
+}
+
+export type ApprovalLookupStatus =
+  | "granted"
+  | "denied"
+  | "pending"
+  | "expired"
+  | "drift_revoked"
+  | "no_decision";
+
+export interface ApprovalLookupResult {
+  status: ApprovalLookupStatus;
+  decision: ApprovalDecisionMeta | null;
+}
+
+export interface ApprovalConsumeResult {
+  consumed: boolean;
+  agent?: string;
+  surface?: string;
+  scope?: string;
+  action_grammar?: string;
+  why?: string | null;
+}
+
+export async function approvalRequest(
+  args: ApprovalRequestArgs,
+  opts?: BrokerClientOpts,
+): Promise<ApprovalRequestResult | null> {
+  const r = await rpcRaw(
+    {
+      v: 1,
+      op: "approval_request",
+      agent: args.agent,
+      surface: args.surface,
+      scope: args.scope,
+      action_grammar: args.action_grammar,
+      approver_set: args.approver_set,
+      why: args.why,
+      ttl_ms: args.ttl_ms,
+    },
+    opts,
+  );
+  if (r.kind !== "response" || !r.resp.ok) return null;
+  if (!("request_id" in r.resp)) return null;
+  return { request_id: r.resp.request_id, expires_at: r.resp.expires_at };
+}
+
+export async function approvalLookup(
+  args: {
+    agent: string;
+    surface: string;
+    scope: string;
+    action_grammar: string;
+    current_approver_set: string[];
+  },
+  opts?: BrokerClientOpts,
+): Promise<ApprovalLookupResult | null> {
+  const r = await rpcRaw(
+    {
+      v: 1,
+      op: "approval_lookup",
+      agent: args.agent,
+      surface: args.surface,
+      scope: args.scope,
+      action_grammar: args.action_grammar,
+      current_approver_set: args.current_approver_set,
+    },
+    opts,
+  );
+  if (r.kind !== "response" || !r.resp.ok) return null;
+  // Both OkStatusResponse and OkApprovalLookupResponse carry `status`, but
+  // the former's is an object (BrokerStatus) and the latter's is a string.
+  // Narrow on the string-typed shape we actually want.
+  if (!("status" in r.resp) || typeof r.resp.status !== "string") return null;
+  const lookup = r.resp as { status: string; decision?: ApprovalDecisionMeta | null };
+  return {
+    status: lookup.status as ApprovalLookupStatus,
+    decision: lookup.decision ?? null,
+  };
+}
+
+export async function approvalConsume(
+  request_id: string,
+  opts?: BrokerClientOpts,
+): Promise<ApprovalConsumeResult | null> {
+  const r = await rpcRaw({ v: 1, op: "approval_consume", request_id }, opts);
+  if (r.kind !== "response" || !r.resp.ok) return null;
+  if (!("consumed" in r.resp)) return null;
+  return {
+    consumed: r.resp.consumed,
+    agent: r.resp.agent,
+    surface: r.resp.surface,
+    scope: r.resp.scope,
+    action_grammar: r.resp.action_grammar,
+    why: r.resp.why ?? null,
+  };
+}
+
+export async function approvalRevoke(
+  decision_id: string,
+  actor: string,
+  reason?: string,
+  opts?: BrokerClientOpts,
+): Promise<boolean | null> {
+  const r = await rpcRaw(
+    { v: 1, op: "approval_revoke", decision_id, actor, reason },
+    opts,
+  );
+  if (r.kind !== "response" || !r.resp.ok) return null;
+  if (!("revoked" in r.resp)) return null;
+  return r.resp.revoked;
+}
+
+export async function approvalRecord(
+  args: {
+    request_id: string;
+    granted: boolean;
+    approver_set: string[];
+    approver_user_id: string;
+    ttl_ms?: number | null;
+  },
+  opts?: BrokerClientOpts,
+): Promise<string | null> {
+  const r = await rpcRaw(
+    {
+      v: 1,
+      op: "approval_record",
+      request_id: args.request_id,
+      granted: args.granted,
+      approver_set: args.approver_set,
+      approver_user_id: args.approver_user_id,
+      ttl_ms: args.ttl_ms ?? null,
+    },
+    opts,
+  );
+  if (r.kind !== "response" || !r.resp.ok) return null;
+  if (!("decision_id" in r.resp)) return null;
+  return r.resp.decision_id;
+}
+
+export async function approvalList(
+  agent?: string,
+  opts?: BrokerClientOpts,
+): Promise<ApprovalDecisionMeta[] | null> {
+  const r = await rpcRaw({ v: 1, op: "approval_list", agent }, opts);
+  if (r.kind !== "response" || !r.resp.ok) return null;
+  if (!("decisions" in r.resp)) return null;
+  return r.resp.decisions as ApprovalDecisionMeta[];
+}

--- a/src/vault/approvals/client.ts
+++ b/src/vault/approvals/client.ts
@@ -6,32 +6,31 @@
  * JSON. Each helper returns a typed result or `null` when the broker is
  * unreachable — same convention as `BrokerClient`.
  *
- * The agent-side wait loop (short-poll per RFC §10) is NOT implemented here
- * yet. Phase 1 of the migration is broker-resident state + gateway
- * round-trip; agents that need to wait will short-poll lookupApproval at
- * 2s intervals. That's the next slice of work and is intentionally out of
- * this commit so the surface area stays reviewable.
+ * Discriminant note: the lookup wire response uses `state` (not `status`) to
+ * avoid colliding with `BrokerStatus` on the broker response union. The
+ * helpers below normalize that field name out for callers.
  */
 
 import { rpcRaw, type BrokerClientOpts } from "../broker/client.js";
-import type { ApprovalDecisionMeta } from "../broker/protocol.js";
+import type {
+  ApprovalDecisionMeta,
+  ApprovalDecisionMode,
+} from "../broker/protocol.js";
 
 export interface ApprovalRequestArgs {
-  agent: string;
-  surface: string;
+  agent_unit: string;
   scope: string;
-  action_grammar: string;
+  action: string;
   approver_set: string[];
   why?: string;
   ttl_ms?: number;
 }
 
-export interface ApprovalRequestResult {
-  request_id: string;
-  expires_at: number;
-}
+export type ApprovalRequestResult =
+  | { state: "pending"; request_id: string; expires_at: number }
+  | { state: "rate_limited"; retry_after_ms: number };
 
-export type ApprovalLookupStatus =
+export type ApprovalLookupState =
   | "granted"
   | "denied"
   | "pending"
@@ -40,16 +39,15 @@ export type ApprovalLookupStatus =
   | "no_decision";
 
 export interface ApprovalLookupResult {
-  status: ApprovalLookupStatus;
+  state: ApprovalLookupState;
   decision: ApprovalDecisionMeta | null;
 }
 
 export interface ApprovalConsumeResult {
   consumed: boolean;
-  agent?: string;
-  surface?: string;
+  agent_unit?: string;
   scope?: string;
-  action_grammar?: string;
+  action?: string;
   why?: string | null;
 }
 
@@ -61,10 +59,9 @@ export async function approvalRequest(
     {
       v: 1,
       op: "approval_request",
-      agent: args.agent,
-      surface: args.surface,
+      agent_unit: args.agent_unit,
       scope: args.scope,
-      action_grammar: args.action_grammar,
+      action: args.action,
       approver_set: args.approver_set,
       why: args.why,
       ttl_ms: args.ttl_ms,
@@ -72,16 +69,22 @@ export async function approvalRequest(
     opts,
   );
   if (r.kind !== "response" || !r.resp.ok) return null;
-  if (!("request_id" in r.resp)) return null;
-  return { request_id: r.resp.request_id, expires_at: r.resp.expires_at };
+  if (!("kind" in r.resp) || r.resp.kind !== "approval_request") return null;
+  if (r.resp.state === "rate_limited") {
+    return { state: "rate_limited", retry_after_ms: r.resp.retry_after_ms };
+  }
+  return {
+    state: "pending",
+    request_id: r.resp.request_id,
+    expires_at: r.resp.expires_at,
+  };
 }
 
 export async function approvalLookup(
   args: {
-    agent: string;
-    surface: string;
+    agent_unit: string;
     scope: string;
-    action_grammar: string;
+    action: string;
     current_approver_set: string[];
   },
   opts?: BrokerClientOpts,
@@ -90,22 +93,28 @@ export async function approvalLookup(
     {
       v: 1,
       op: "approval_lookup",
-      agent: args.agent,
-      surface: args.surface,
+      agent_unit: args.agent_unit,
       scope: args.scope,
-      action_grammar: args.action_grammar,
+      action: args.action,
       current_approver_set: args.current_approver_set,
     },
     opts,
   );
   if (r.kind !== "response" || !r.resp.ok) return null;
-  // Both OkStatusResponse and OkApprovalLookupResponse carry `status`, but
-  // the former's is an object (BrokerStatus) and the latter's is a string.
-  // Narrow on the string-typed shape we actually want.
-  if (!("status" in r.resp) || typeof r.resp.status !== "string") return null;
-  const lookup = r.resp as { status: string; decision?: ApprovalDecisionMeta | null };
+  if (!("state" in r.resp) || typeof r.resp.state !== "string") return null;
+  // Approval lookup is the only response with `state: <string>`. The new
+  // approval_request response also has `state` but it's still distinguishable
+  // by the values; we narrow on the lookup states here.
+  const lookupStates = new Set([
+    "granted", "denied", "pending", "expired", "drift_revoked", "no_decision",
+  ]);
+  if (!lookupStates.has(r.resp.state)) return null;
+  const lookup = r.resp as {
+    state: ApprovalLookupState;
+    decision?: ApprovalDecisionMeta | null;
+  };
   return {
-    status: lookup.status as ApprovalLookupStatus,
+    state: lookup.state,
     decision: lookup.decision ?? null,
   };
 }
@@ -119,10 +128,9 @@ export async function approvalConsume(
   if (!("consumed" in r.resp)) return null;
   return {
     consumed: r.resp.consumed,
-    agent: r.resp.agent,
-    surface: r.resp.surface,
+    agent_unit: r.resp.agent_unit,
     scope: r.resp.scope,
-    action_grammar: r.resp.action_grammar,
+    action: r.resp.action,
     why: r.resp.why ?? null,
   };
 }
@@ -145,9 +153,9 @@ export async function approvalRevoke(
 export async function approvalRecord(
   args: {
     request_id: string;
-    granted: boolean;
+    decision: ApprovalDecisionMode;
     approver_set: string[];
-    approver_user_id: string;
+    granted_by_user_id: number;
     ttl_ms?: number | null;
   },
   opts?: BrokerClientOpts,
@@ -157,9 +165,9 @@ export async function approvalRecord(
       v: 1,
       op: "approval_record",
       request_id: args.request_id,
-      granted: args.granted,
+      decision: args.decision,
       approver_set: args.approver_set,
-      approver_user_id: args.approver_user_id,
+      granted_by_user_id: args.granted_by_user_id,
       ttl_ms: args.ttl_ms ?? null,
     },
     opts,
@@ -170,10 +178,10 @@ export async function approvalRecord(
 }
 
 export async function approvalList(
-  agent?: string,
+  agent_unit?: string,
   opts?: BrokerClientOpts,
 ): Promise<ApprovalDecisionMeta[] | null> {
-  const r = await rpcRaw({ v: 1, op: "approval_list", agent }, opts);
+  const r = await rpcRaw({ v: 1, op: "approval_list", agent_unit }, opts);
   if (r.kind !== "response" || !r.resp.ok) return null;
   if (!("decisions" in r.resp)) return null;
   return r.resp.decisions as ApprovalDecisionMeta[];

--- a/src/vault/approvals/kernel.test.ts
+++ b/src/vault/approvals/kernel.test.ts
@@ -1,20 +1,12 @@
 /**
- * Tests for the approval kernel (RFC B §5–§7).
+ * Tests for the approval kernel (RFC B §5–§7, §10).
  *
- * Uses an in-memory SQLite database for isolation — no disk I/O. Covers:
- *
- *   - migrateApprovalSchema runs cleanly on a fresh DB and is idempotent
- *   - requestApproval → consumeNonce → recordDecision → lookupDecision flow
- *   - Single-use nonce consumption is atomic (concurrent attempts → one wins)
- *   - Expired nonces cannot be consumed
- *   - Drift detection flips canonical mismatch into drift_revoked
- *   - revokeDecision is idempotent and writes audit
- *   - listDecisions filters by agent and excludes revoked/expired by default
+ * Uses an in-memory SQLite database for isolation — no disk I/O.
  */
 
 import { describe, it, expect, beforeEach } from "vitest";
 import { Database } from "bun:sqlite";
-import { migrateApprovalSchema } from "./schema.js";
+import { migrateApprovalSchema, DEFAULT_MAX_TTL_LIFETIME_MS } from "./schema.js";
 import {
   requestApproval,
   consumeNonce,
@@ -24,6 +16,10 @@ import {
   listDecisions,
   getNonce,
   getDecision,
+  countPendingNonces,
+  computeRetryAfterMs,
+  MAX_PENDING_PER_AGENT,
+  MAX_PENDING_GLOBAL,
 } from "./kernel.js";
 import { canonicalizeApproverSet } from "./canonical.js";
 
@@ -53,9 +49,43 @@ describe("approval kernel — schema", () => {
     );
   });
 
-  it("is idempotent", () => {
+  it("is idempotent (drop+recreate)", () => {
     const db = newDb();
     expect(() => migrateApprovalSchema(db)).not.toThrow();
+  });
+
+  it("RFC §5 columns present and old columns absent", () => {
+    const db = newDb();
+    const cols = db
+      .query<{ name: string }, []>(
+        `SELECT name FROM pragma_table_info('approval_decisions')`,
+      )
+      .all()
+      .map((r) => r.name);
+    expect(cols).toEqual(
+      expect.arrayContaining([
+        "id", "agent_unit", "scope", "action", "decision",
+        "ttl_expires_at", "granted_at", "granted_by_user_id",
+        "approver_set_canonical", "last_used_at", "revoked_at", "revoke_reason",
+      ]),
+    );
+    // Old shape columns must be gone.
+    expect(cols).not.toContain("agent");
+    expect(cols).not.toContain("surface");
+    expect(cols).not.toContain("action_grammar");
+    expect(cols).not.toContain("granted");
+    expect(cols).not.toContain("decision_id_chain_prev");
+    expect(cols).not.toContain("expires_at");
+
+    const auditCols = db
+      .query<{ name: string }, []>(
+        `SELECT name FROM pragma_table_info('approval_audit')`,
+      )
+      .all()
+      .map((r) => r.name);
+    expect(auditCols).toEqual(
+      expect.arrayContaining(["seq", "ts", "agent_unit", "scope", "action", "decision_id", "context"]),
+    );
   });
 });
 
@@ -65,103 +95,109 @@ describe("approval kernel — canonicalize", () => {
       .toEqual(canonicalizeApproverSet(["a", "b"]));
     expect(canonicalizeApproverSet([" a ", "a"]))
       .toEqual(canonicalizeApproverSet(["a"]));
-    expect(canonicalizeApproverSet([]))
-      .toEqual("[]");
+    expect(canonicalizeApproverSet([])).toEqual("[]");
   });
 });
 
 describe("approval kernel — request/consume/record/lookup", () => {
   let db: Database;
+  beforeEach(() => { db = newDb(); });
 
-  beforeEach(() => {
-    db = newDb();
-  });
-
-  it("end-to-end grant flow", () => {
+  it("end-to-end allow_once grant flow", () => {
     const r = requestApproval(db, {
-      agent: "klanker",
-      surface: "secret",
+      agent_unit: "switchroom-klanker.service",
       scope: "secret:OPENAI_API_KEY",
-      action_grammar: "read",
+      action: "read",
       approver_set: ["123"],
       why: "needs to call OpenAI",
     });
     expect(r.request_id).toMatch(/^[0-9a-f]{8}$/);
-    expect(r.expires_at).toBeGreaterThan(Date.now());
 
-    // Lookup before any tap → no_decision
     expect(
       lookupDecision(db, {
-        agent: "klanker",
-        surface: "secret",
+        agent_unit: "switchroom-klanker.service",
         scope: "secret:OPENAI_API_KEY",
-        action_grammar: "read",
+        action: "read",
         current_approver_set: ["123"],
-      }).status,
+      }).state,
     ).toBe("no_decision");
 
-    // User taps Allow
     const nonce = consumeNonce(db, r.request_id);
     expect(nonce).not.toBeNull();
     expect(nonce!.scope).toBe("secret:OPENAI_API_KEY");
 
     const decisionId = recordDecision(db, {
       nonce: nonce!,
-      granted: true,
+      decision: "allow_once",
       approver_set: ["123"],
-      approver_user_id: "123",
+      granted_by_user_id: 123,
     });
     expect(decisionId).toBeTruthy();
 
-    // Now lookup returns granted
     const r2 = lookupDecision(db, {
-      agent: "klanker",
-      surface: "secret",
+      agent_unit: "switchroom-klanker.service",
       scope: "secret:OPENAI_API_KEY",
-      action_grammar: "read",
+      action: "read",
       current_approver_set: ["123"],
     });
-    expect(r2.status).toBe("granted");
+    expect(r2.state).toBe("granted");
   });
 
-  it("nonce consumption is atomic — one wins, the other gets null", () => {
+  it("all 5 decision modes round-trip via recordDecision", () => {
+    for (const mode of ["allow_once", "allow_always", "allow_ttl", "deny", "deny_perm"] as const) {
+      const r = requestApproval(db, {
+        agent_unit: "u", scope: `s:${mode}`, action: "read", approver_set: ["1"],
+      });
+      const nonce = consumeNonce(db, r.request_id)!;
+      const id = recordDecision(db, {
+        nonce, decision: mode, approver_set: ["1"], granted_by_user_id: 1,
+        ttl_ms: mode === "allow_ttl" ? 60_000 : undefined,
+      });
+      const decision = getDecision(db, id);
+      expect(decision?.decision).toBe(mode);
+      if (mode === "allow_ttl") {
+        expect(decision?.ttl_expires_at).not.toBeNull();
+      } else {
+        expect(decision?.ttl_expires_at).toBeNull();
+      }
+    }
+  });
+
+  it("deny_perm short-circuits even with drift", () => {
     const r = requestApproval(db, {
-      agent: "klanker",
-      surface: "secret",
-      scope: "secret:X",
-      action_grammar: "read",
-      approver_set: ["123"],
+      agent_unit: "u", scope: "s", action: "read", approver_set: ["U1"],
+    });
+    const n = consumeNonce(db, r.request_id)!;
+    recordDecision(db, {
+      nonce: n, decision: "deny_perm", approver_set: ["U1"], granted_by_user_id: 1,
+    });
+    const r2 = lookupDecision(db, {
+      agent_unit: "u", scope: "s", action: "read", current_approver_set: ["U1"],
+    });
+    expect(r2.state).toBe("denied");
+  });
+
+  it("nonce consumption is atomic — one wins", () => {
+    const r = requestApproval(db, {
+      agent_unit: "u", scope: "s:X", action: "read", approver_set: ["1"],
     });
     const a = consumeNonce(db, r.request_id);
     const b = consumeNonce(db, r.request_id);
-    // First wins; second observes consumed_at IS NOT NULL → 0 rows updated → null.
     expect(a).not.toBeNull();
     expect(b).toBeNull();
   });
 
   it("expired nonces cannot be consumed", () => {
-    // Backdate by passing a future "now" past expires_at
     const r = requestApproval(db, {
-      agent: "klanker",
-      surface: "secret",
-      scope: "secret:X",
-      action_grammar: "read",
-      approver_set: ["123"],
-      ttl_ms: 1, // 1ms TTL
+      agent_unit: "u", scope: "s:X", action: "read", approver_set: ["1"], ttl_ms: 1,
     });
-    // Tiny sleep
     const farFuture = Date.now() + 10_000;
-    const consumed = consumeNonce(db, r.request_id, farFuture);
-    expect(consumed).toBeNull();
+    expect(consumeNonce(db, r.request_id, farFuture)).toBeNull();
   });
 
   it("getNonce reads back without consuming", () => {
     const r = requestApproval(db, {
-      agent: "klanker",
-      surface: "secret",
-      scope: "secret:Y",
-      action_grammar: "read",
-      approver_set: ["1"],
+      agent_unit: "u", scope: "s:Y", action: "read", approver_set: ["1"],
     });
     expect(getNonce(db, r.request_id)?.consumed_at).toBeNull();
     consumeNonce(db, r.request_id);
@@ -169,102 +205,179 @@ describe("approval kernel — request/consume/record/lookup", () => {
   });
 });
 
+describe("approval kernel — sliding-window TTL (§7)", () => {
+  it("extends ttl_expires_at on each match, capped at granted_at + max_lifetime", () => {
+    const db = newDb();
+    const t0 = 1_000_000;
+    const r = requestApproval(db, {
+      agent_unit: "u", scope: "s:T", action: "read", approver_set: ["1"],
+    }, t0);
+    const n = consumeNonce(db, r.request_id, t0)!;
+    const ttl_ms = 60_000; // 60s sliding window
+    const id = recordDecision(db, {
+      nonce: n, decision: "allow_ttl", approver_set: ["1"], granted_by_user_id: 1,
+      ttl_ms,
+    }, t0);
+    const initial = getDecision(db, id)!;
+    expect(initial.ttl_expires_at).toBe(t0 + ttl_ms);
+
+    // Match 30s later — should extend to t0+30s+60s = t0+90s
+    const t1 = t0 + 30_000;
+    const r1 = lookupDecision(db, {
+      agent_unit: "u", scope: "s:T", action: "read", current_approver_set: ["1"],
+    }, {}, t1);
+    expect(r1.state).toBe("granted");
+    expect(getDecision(db, id)!.ttl_expires_at).toBe(t1 + ttl_ms);
+    expect(getDecision(db, id)!.last_used_at).toBe(t1);
+
+    // Push close to the hard cap. Use a small override (3 windows = 180s) and
+    // renew at 130s — within current window (which is t1+60s = 90s? we need
+    // to re-match so we stay live. After r1 at t1=30s, ttl=t1+60=90s.
+    // So renew again at t=85s within the new window.
+    const smallMax = ttl_ms * 3; // 180s cap
+    const t2 = t0 + 85_000;
+    const r2 = lookupDecision(db, {
+      agent_unit: "u", scope: "s:T", action: "read", current_approver_set: ["1"],
+    }, { max_ttl_lifetime_ms: smallMax }, t2);
+    expect(r2.state).toBe("granted");
+    // After this match, ttl_expires_at would be t2+60=145s, but cap=180s.
+    // Renew once more at 140s; new natural expiry would be 200s but capped at 180s.
+    const t3 = t0 + 140_000;
+    const r3 = lookupDecision(db, {
+      agent_unit: "u", scope: "s:T", action: "read", current_approver_set: ["1"],
+    }, { max_ttl_lifetime_ms: smallMax }, t3);
+    expect(r3.state).toBe("granted");
+    const final = getDecision(db, id)!;
+    expect(final.ttl_expires_at).toBe(t0 + smallMax);
+  });
+
+  it("expired allow_ttl returns expired", () => {
+    const db = newDb();
+    const t0 = 1_000_000;
+    const r = requestApproval(db, {
+      agent_unit: "u", scope: "s:E", action: "read", approver_set: ["1"],
+    }, t0);
+    const n = consumeNonce(db, r.request_id, t0)!;
+    recordDecision(db, {
+      nonce: n, decision: "allow_ttl", approver_set: ["1"], granted_by_user_id: 1,
+      ttl_ms: 1000,
+    }, t0);
+    const r2 = lookupDecision(db, {
+      agent_unit: "u", scope: "s:E", action: "read", current_approver_set: ["1"],
+    }, {}, t0 + 60_000);
+    expect(r2.state).toBe("expired");
+  });
+});
+
 describe("approval kernel — drift detection (§5.1)", () => {
-  it("flips to drift_revoked when approver_set changes", () => {
+  it("flips to drift_revoked and writes revoke_reason='approver_set_drift'", () => {
     const db = newDb();
     const r = requestApproval(db, {
-      agent: "klanker",
-      surface: "vault",
-      scope: "vault:NOTION",
-      action_grammar: "read",
-      approver_set: ["U1"],
+      agent_unit: "u", scope: "vault:NOTION", action: "read", approver_set: ["U1"],
     });
     const nonce = consumeNonce(db, r.request_id)!;
-    recordDecision(db, {
-      nonce,
-      granted: true,
-      approver_set: ["U1"],
-      approver_user_id: "U1",
+    const id = recordDecision(db, {
+      nonce, decision: "allow_always", approver_set: ["U1"], granted_by_user_id: 1,
     });
 
-    // Approver set grows — every standing grant becomes dormant.
     const r2 = lookupDecision(db, {
-      agent: "klanker",
-      surface: "vault",
-      scope: "vault:NOTION",
-      action_grammar: "read",
+      agent_unit: "u", scope: "vault:NOTION", action: "read",
       current_approver_set: ["U1", "U2"],
     });
-    expect(r2.status).toBe("drift_revoked");
+    expect(r2.state).toBe("drift_revoked");
 
-    // Audit row was written and decision is revoked.
-    const audit = db
+    const after = getDecision(db, id)!;
+    expect(after.revoked_at).not.toBeNull();
+    expect(after.revoke_reason).toBe("approver_set_drift");
+
+    const auditEvent = db
       .query<{ event: string }, []>(
-        `SELECT event FROM approval_audit ORDER BY id DESC LIMIT 1`,
+        `SELECT event FROM approval_audit ORDER BY seq DESC LIMIT 1`,
       )
       .get();
-    expect(audit?.event).toBe("drift_revoke");
-
-    // Subsequent lookup with the SAME new set still shows no live grant
-    // (the old row stays revoked; user has to re-approve).
-    const r3 = lookupDecision(db, {
-      agent: "klanker",
-      surface: "vault",
-      scope: "vault:NOTION",
-      action_grammar: "read",
-      current_approver_set: ["U1", "U2"],
-    });
-    expect(r3.status).toBe("no_decision");
+    expect(auditEvent?.event).toBe("drift_revoke");
   });
 });
 
 describe("approval kernel — revoke + list", () => {
-  it("revokeDecision is idempotent", () => {
+  it("revokeDecision is idempotent and writes revoke_reason", () => {
     const db = newDb();
     const r = requestApproval(db, {
-      agent: "klanker",
-      surface: "secret",
-      scope: "secret:Z",
-      action_grammar: "read",
-      approver_set: ["1"],
+      agent_unit: "u", scope: "s:Z", action: "read", approver_set: ["1"],
     });
     const nonce = consumeNonce(db, r.request_id)!;
     const id = recordDecision(db, {
-      nonce,
-      granted: true,
-      approver_set: ["1"],
-      approver_user_id: "1",
+      nonce, decision: "allow_always", approver_set: ["1"], granted_by_user_id: 1,
     });
-    expect(revokeDecision(db, id, "1")).toBe(true);
-    expect(revokeDecision(db, id, "1")).toBe(false);
-    expect(getDecision(db, id)?.revoked_at).not.toBeNull();
+    expect(revokeDecision(db, id, "1", "manual revoke")).toBe(true);
+    expect(revokeDecision(db, id, "1", "manual revoke")).toBe(false);
+    const after = getDecision(db, id)!;
+    expect(after.revoked_at).not.toBeNull();
+    expect(after.revoke_reason).toBe("manual revoke");
   });
 
-  it("listDecisions filters by agent and excludes revoked", () => {
+  it("listDecisions filters by agent_unit and excludes revoked", () => {
     const db = newDb();
-    for (const agent of ["klanker", "gymbro"]) {
+    for (const agent_unit of ["u1", "u2"]) {
       const req = requestApproval(db, {
-        agent,
-        surface: "secret",
-        scope: `secret:${agent}`,
-        action_grammar: "read",
-        approver_set: ["1"],
+        agent_unit, scope: `s:${agent_unit}`, action: "read", approver_set: ["1"],
       });
       const n = consumeNonce(db, req.request_id)!;
       recordDecision(db, {
-        nonce: n,
-        granted: true,
-        approver_set: ["1"],
-        approver_user_id: "1",
+        nonce: n, decision: "allow_always", approver_set: ["1"], granted_by_user_id: 1,
       });
     }
     expect(listDecisions(db).length).toBe(2);
-    expect(listDecisions(db, { agent: "klanker" }).length).toBe(1);
+    expect(listDecisions(db, { agent_unit: "u1" }).length).toBe(1);
 
-    // Revoke gymbro's row
-    const gymbro = listDecisions(db, { agent: "gymbro" })[0]!;
-    revokeDecision(db, gymbro.id, "1");
+    const u2 = listDecisions(db, { agent_unit: "u2" })[0]!;
+    revokeDecision(db, u2.id, "1");
     expect(listDecisions(db).length).toBe(1);
     expect(listDecisions(db, { include_revoked: true }).length).toBe(2);
+  });
+
+  it("audit-by-scope query returns events for a namespace prefix", () => {
+    const db = newDb();
+    for (const scope of ["secret:OPENAI", "secret:GITHUB", "doc:gdrive:1"]) {
+      const r = requestApproval(db, {
+        agent_unit: "u", scope, action: "read", approver_set: ["1"],
+      });
+      consumeNonce(db, r.request_id);
+    }
+    const rows = db
+      .query<{ scope: string }, [string]>(
+        `SELECT scope FROM approval_audit WHERE scope LIKE ? ORDER BY seq`,
+      )
+      .all("secret:%");
+    expect(rows.length).toBeGreaterThanOrEqual(4); // request+consume per secret:* nonce
+    expect(rows.every((r) => r.scope.startsWith("secret:"))).toBe(true);
+  });
+});
+
+describe("approval kernel — RFC §10 rate caps", () => {
+  it("counts pending nonces per agent and globally", () => {
+    const db = newDb();
+    requestApproval(db, { agent_unit: "a1", scope: "s1", action: "read", approver_set: ["1"] });
+    requestApproval(db, { agent_unit: "a1", scope: "s2", action: "read", approver_set: ["1"] });
+    requestApproval(db, { agent_unit: "a2", scope: "s3", action: "read", approver_set: ["1"] });
+    const c = countPendingNonces(db);
+    expect(c.perAgent.get("a1")).toBe(2);
+    expect(c.perAgent.get("a2")).toBe(1);
+    expect(c.global).toBe(3);
+  });
+
+  it("computeRetryAfterMs returns positive ms based on soonest expiry", () => {
+    const db = newDb();
+    requestApproval(db, {
+      agent_unit: "a1", scope: "s", action: "read", approver_set: ["1"], ttl_ms: 30_000,
+    });
+    const ms = computeRetryAfterMs(db, "a1");
+    expect(ms).toBeGreaterThan(1000);
+    expect(ms).toBeLessThanOrEqual(30_000);
+  });
+
+  it("constants align with RFC §10", () => {
+    expect(MAX_PENDING_PER_AGENT).toBe(2);
+    expect(MAX_PENDING_GLOBAL).toBe(32);
   });
 });

--- a/src/vault/approvals/kernel.test.ts
+++ b/src/vault/approvals/kernel.test.ts
@@ -1,0 +1,270 @@
+/**
+ * Tests for the approval kernel (RFC B §5–§7).
+ *
+ * Uses an in-memory SQLite database for isolation — no disk I/O. Covers:
+ *
+ *   - migrateApprovalSchema runs cleanly on a fresh DB and is idempotent
+ *   - requestApproval → consumeNonce → recordDecision → lookupDecision flow
+ *   - Single-use nonce consumption is atomic (concurrent attempts → one wins)
+ *   - Expired nonces cannot be consumed
+ *   - Drift detection flips canonical mismatch into drift_revoked
+ *   - revokeDecision is idempotent and writes audit
+ *   - listDecisions filters by agent and excludes revoked/expired by default
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { Database } from "bun:sqlite";
+import { migrateApprovalSchema } from "./schema.js";
+import {
+  requestApproval,
+  consumeNonce,
+  recordDecision,
+  lookupDecision,
+  revokeDecision,
+  listDecisions,
+  getNonce,
+  getDecision,
+} from "./kernel.js";
+import { canonicalizeApproverSet } from "./canonical.js";
+
+function newDb(): Database {
+  const db = new Database(":memory:");
+  db.run("PRAGMA foreign_keys=ON");
+  migrateApprovalSchema(db);
+  return db;
+}
+
+describe("approval kernel — schema", () => {
+  it("migrates cleanly on a fresh DB", () => {
+    const db = new Database(":memory:");
+    expect(() => migrateApprovalSchema(db)).not.toThrow();
+    const tables = db
+      .query<{ name: string }, []>(
+        `SELECT name FROM sqlite_master WHERE type='table' ORDER BY name`,
+      )
+      .all()
+      .map((r) => r.name);
+    expect(tables).toEqual(
+      expect.arrayContaining([
+        "approval_decisions",
+        "approval_nonces",
+        "approval_audit",
+      ]),
+    );
+  });
+
+  it("is idempotent", () => {
+    const db = newDb();
+    expect(() => migrateApprovalSchema(db)).not.toThrow();
+  });
+});
+
+describe("approval kernel — canonicalize", () => {
+  it("normalizes order, whitespace, and dedupes", () => {
+    expect(canonicalizeApproverSet(["b", "a"]))
+      .toEqual(canonicalizeApproverSet(["a", "b"]));
+    expect(canonicalizeApproverSet([" a ", "a"]))
+      .toEqual(canonicalizeApproverSet(["a"]));
+    expect(canonicalizeApproverSet([]))
+      .toEqual("[]");
+  });
+});
+
+describe("approval kernel — request/consume/record/lookup", () => {
+  let db: Database;
+
+  beforeEach(() => {
+    db = newDb();
+  });
+
+  it("end-to-end grant flow", () => {
+    const r = requestApproval(db, {
+      agent: "klanker",
+      surface: "secret",
+      scope: "secret:OPENAI_API_KEY",
+      action_grammar: "read",
+      approver_set: ["123"],
+      why: "needs to call OpenAI",
+    });
+    expect(r.request_id).toMatch(/^[0-9a-f]{8}$/);
+    expect(r.expires_at).toBeGreaterThan(Date.now());
+
+    // Lookup before any tap → no_decision
+    expect(
+      lookupDecision(db, {
+        agent: "klanker",
+        surface: "secret",
+        scope: "secret:OPENAI_API_KEY",
+        action_grammar: "read",
+        current_approver_set: ["123"],
+      }).status,
+    ).toBe("no_decision");
+
+    // User taps Allow
+    const nonce = consumeNonce(db, r.request_id);
+    expect(nonce).not.toBeNull();
+    expect(nonce!.scope).toBe("secret:OPENAI_API_KEY");
+
+    const decisionId = recordDecision(db, {
+      nonce: nonce!,
+      granted: true,
+      approver_set: ["123"],
+      approver_user_id: "123",
+    });
+    expect(decisionId).toBeTruthy();
+
+    // Now lookup returns granted
+    const r2 = lookupDecision(db, {
+      agent: "klanker",
+      surface: "secret",
+      scope: "secret:OPENAI_API_KEY",
+      action_grammar: "read",
+      current_approver_set: ["123"],
+    });
+    expect(r2.status).toBe("granted");
+  });
+
+  it("nonce consumption is atomic — one wins, the other gets null", () => {
+    const r = requestApproval(db, {
+      agent: "klanker",
+      surface: "secret",
+      scope: "secret:X",
+      action_grammar: "read",
+      approver_set: ["123"],
+    });
+    const a = consumeNonce(db, r.request_id);
+    const b = consumeNonce(db, r.request_id);
+    // First wins; second observes consumed_at IS NOT NULL → 0 rows updated → null.
+    expect(a).not.toBeNull();
+    expect(b).toBeNull();
+  });
+
+  it("expired nonces cannot be consumed", () => {
+    // Backdate by passing a future "now" past expires_at
+    const r = requestApproval(db, {
+      agent: "klanker",
+      surface: "secret",
+      scope: "secret:X",
+      action_grammar: "read",
+      approver_set: ["123"],
+      ttl_ms: 1, // 1ms TTL
+    });
+    // Tiny sleep
+    const farFuture = Date.now() + 10_000;
+    const consumed = consumeNonce(db, r.request_id, farFuture);
+    expect(consumed).toBeNull();
+  });
+
+  it("getNonce reads back without consuming", () => {
+    const r = requestApproval(db, {
+      agent: "klanker",
+      surface: "secret",
+      scope: "secret:Y",
+      action_grammar: "read",
+      approver_set: ["1"],
+    });
+    expect(getNonce(db, r.request_id)?.consumed_at).toBeNull();
+    consumeNonce(db, r.request_id);
+    expect(getNonce(db, r.request_id)?.consumed_at).not.toBeNull();
+  });
+});
+
+describe("approval kernel — drift detection (§5.1)", () => {
+  it("flips to drift_revoked when approver_set changes", () => {
+    const db = newDb();
+    const r = requestApproval(db, {
+      agent: "klanker",
+      surface: "vault",
+      scope: "vault:NOTION",
+      action_grammar: "read",
+      approver_set: ["U1"],
+    });
+    const nonce = consumeNonce(db, r.request_id)!;
+    recordDecision(db, {
+      nonce,
+      granted: true,
+      approver_set: ["U1"],
+      approver_user_id: "U1",
+    });
+
+    // Approver set grows — every standing grant becomes dormant.
+    const r2 = lookupDecision(db, {
+      agent: "klanker",
+      surface: "vault",
+      scope: "vault:NOTION",
+      action_grammar: "read",
+      current_approver_set: ["U1", "U2"],
+    });
+    expect(r2.status).toBe("drift_revoked");
+
+    // Audit row was written and decision is revoked.
+    const audit = db
+      .query<{ event: string }, []>(
+        `SELECT event FROM approval_audit ORDER BY id DESC LIMIT 1`,
+      )
+      .get();
+    expect(audit?.event).toBe("drift_revoke");
+
+    // Subsequent lookup with the SAME new set still shows no live grant
+    // (the old row stays revoked; user has to re-approve).
+    const r3 = lookupDecision(db, {
+      agent: "klanker",
+      surface: "vault",
+      scope: "vault:NOTION",
+      action_grammar: "read",
+      current_approver_set: ["U1", "U2"],
+    });
+    expect(r3.status).toBe("no_decision");
+  });
+});
+
+describe("approval kernel — revoke + list", () => {
+  it("revokeDecision is idempotent", () => {
+    const db = newDb();
+    const r = requestApproval(db, {
+      agent: "klanker",
+      surface: "secret",
+      scope: "secret:Z",
+      action_grammar: "read",
+      approver_set: ["1"],
+    });
+    const nonce = consumeNonce(db, r.request_id)!;
+    const id = recordDecision(db, {
+      nonce,
+      granted: true,
+      approver_set: ["1"],
+      approver_user_id: "1",
+    });
+    expect(revokeDecision(db, id, "1")).toBe(true);
+    expect(revokeDecision(db, id, "1")).toBe(false);
+    expect(getDecision(db, id)?.revoked_at).not.toBeNull();
+  });
+
+  it("listDecisions filters by agent and excludes revoked", () => {
+    const db = newDb();
+    for (const agent of ["klanker", "gymbro"]) {
+      const req = requestApproval(db, {
+        agent,
+        surface: "secret",
+        scope: `secret:${agent}`,
+        action_grammar: "read",
+        approver_set: ["1"],
+      });
+      const n = consumeNonce(db, req.request_id)!;
+      recordDecision(db, {
+        nonce: n,
+        granted: true,
+        approver_set: ["1"],
+        approver_user_id: "1",
+      });
+    }
+    expect(listDecisions(db).length).toBe(2);
+    expect(listDecisions(db, { agent: "klanker" }).length).toBe(1);
+
+    // Revoke gymbro's row
+    const gymbro = listDecisions(db, { agent: "gymbro" })[0]!;
+    revokeDecision(db, gymbro.id, "1");
+    expect(listDecisions(db).length).toBe(1);
+    expect(listDecisions(db, { include_revoked: true }).length).toBe(2);
+  });
+});

--- a/src/vault/approvals/kernel.ts
+++ b/src/vault/approvals/kernel.ts
@@ -1,26 +1,33 @@
 /**
- * Approval kernel — pure DB operations (RFC B §5–§7).
+ * Approval kernel — pure DB operations (RFC B §5–§7, §10).
  *
  * Stateless module: every function takes a Database handle and returns a
  * plain result. The IPC broker (server.ts) and the Telegram callback router
  * (gateway/approval-card.ts) call into here. Tests can drive these
  * functions directly against an in-memory SQLite DB without standing up the
  * broker.
+ *
+ * This module's column names track RFC B §5 verbatim (agent_unit, scope,
+ * action, decision, ttl_expires_at, granted_by_user_id, last_used_at,
+ * revoke_reason). No surface, no action_grammar, no decision_id chains.
  */
 
 import { randomBytes, randomUUID } from "node:crypto";
 import type { Database } from "bun:sqlite";
 import { canonicalizeApproverSet } from "./canonical.js";
-import type { ApprovalAuditEvent } from "./schema.js";
+import {
+  DEFAULT_MAX_TTL_LIFETIME_MS,
+  type ApprovalAuditEvent,
+  type ApprovalDecisionMode,
+} from "./schema.js";
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
 export interface ApprovalRequestInput {
-  agent: string;
-  surface: string;          // 'secret' | 'vault' | 'mcp:notion' | etc
-  scope: string;            // RFC §6 scope grammar string
-  action_grammar: string;   // 'read' | 'write' | etc
-  approver_set: string[];   // current allowFrom; canonicalized + stored
+  agent_unit: string;
+  scope: string;            // RFC §6 scope grammar (e.g. "secret:OPENAI_*", "doc:gdrive:…")
+  action: string;            // 'read' | 'write' | etc
+  approver_set: string[];   // current allowFrom; canonicalized + stored on grant
   why?: string;
   ttl_ms?: number;          // nonce expiry; defaults to 5 minutes per §8.1
 }
@@ -32,26 +39,32 @@ export interface RequestApprovalResult {
 
 export interface DecisionRow {
   id: string;
-  agent: string;
-  surface: string;
+  agent_unit: string;
   scope: string;
-  action_grammar: string;
-  granted: boolean;
-  approver_set: string[];
-  approver_set_canonical: string;
+  action: string;
+  decision: ApprovalDecisionMode;
+  ttl_expires_at: number | null;
   granted_at: number;
-  expires_at: number | null;
+  granted_by_user_id: number;
+  approver_set_canonical: string;
+  last_used_at: number | null;
   revoked_at: number | null;
-  decision_id_chain_prev: string | null;
+  revoke_reason: string | null;
 }
 
+/**
+ * Lookup state per RFC §10 (granted | denied | pending | expired) plus
+ * kernel-internal states (drift_revoked, no_decision). The wire-side
+ * discriminant is `state` (not `status`) — see protocol.ts; this avoids
+ * collision with BrokerStatus on the broker response union.
+ */
 export type LookupResult =
-  | { status: "granted"; decision: DecisionRow }
-  | { status: "denied"; decision: DecisionRow }
-  | { status: "pending"; request_id: string }
-  | { status: "expired" }
-  | { status: "drift_revoked" }
-  | { status: "no_decision" };
+  | { state: "granted"; decision: DecisionRow }
+  | { state: "denied"; decision: DecisionRow }
+  | { state: "pending"; request_id: string }
+  | { state: "expired" }
+  | { state: "drift_revoked" }
+  | { state: "no_decision" };
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -63,54 +76,115 @@ function generateRequestId(): string {
 function audit(
   db: Database,
   event: ApprovalAuditEvent,
-  decisionId: string | null,
-  actor: string,
-  payload?: Record<string, unknown>,
+  fields: {
+    agent_unit: string;
+    scope: string;
+    action: string;
+    decision_id?: string | null;
+    context?: Record<string, unknown>;
+  },
 ): void {
   db.run(
-    `INSERT INTO approval_audit (decision_id, event, ts, actor, payload)
-     VALUES (?, ?, ?, ?, ?)`,
+    `INSERT INTO approval_audit
+       (ts, agent_unit, scope, action, decision_id, event, context)
+     VALUES (?, ?, ?, ?, ?, ?, ?)`,
     [
-      decisionId,
-      event,
       Date.now(),
-      actor,
-      payload ? JSON.stringify(payload) : null,
+      fields.agent_unit,
+      fields.scope,
+      fields.action,
+      fields.decision_id ?? null,
+      event,
+      fields.context ? JSON.stringify(fields.context) : null,
     ],
   );
 }
 
 function rowToDecision(row: Record<string, unknown>): DecisionRow {
-  let approverSet: string[] = [];
-  try {
-    const parsed = JSON.parse(row.approver_set as string);
-    if (Array.isArray(parsed)) approverSet = parsed as string[];
-  } catch {
-    /* swallow — corrupt row, fall through with empty list */
-  }
   return {
     id: row.id as string,
-    agent: row.agent as string,
-    surface: row.surface as string,
+    agent_unit: row.agent_unit as string,
     scope: row.scope as string,
-    action_grammar: row.action_grammar as string,
-    granted: (row.granted as number) === 1,
-    approver_set: approverSet,
-    approver_set_canonical: row.approver_set_canonical as string,
+    action: row.action as string,
+    decision: row.decision as ApprovalDecisionMode,
+    ttl_expires_at: (row.ttl_expires_at as number | null) ?? null,
     granted_at: row.granted_at as number,
-    expires_at: (row.expires_at as number | null) ?? null,
+    granted_by_user_id: row.granted_by_user_id as number,
+    approver_set_canonical: row.approver_set_canonical as string,
+    last_used_at: (row.last_used_at as number | null) ?? null,
     revoked_at: (row.revoked_at as number | null) ?? null,
-    decision_id_chain_prev: (row.decision_id_chain_prev as string | null) ?? null,
+    revoke_reason: (row.revoke_reason as string | null) ?? null,
   };
 }
 
 // ─── Public API ─────────────────────────────────────────────────────────────
+
+/** Per-agent and global pending-nonce caps (RFC §10). */
+export const MAX_PENDING_PER_AGENT = 2;
+export const MAX_PENDING_GLOBAL = 32;
+
+/**
+ * Count currently-pending (unconsumed, unexpired) nonces. Used by the broker
+ * to enforce RFC §10 rate caps before issuing a new request_id.
+ */
+export function countPendingNonces(
+  db: Database,
+  now: number = Date.now(),
+): { perAgent: Map<string, number>; global: number } {
+  const rows = db
+    .query<{ agent_unit: string; n: number }, [number]>(
+      `SELECT agent_unit, COUNT(*) AS n FROM approval_nonces
+       WHERE consumed_at IS NULL AND expires_at > ?
+       GROUP BY agent_unit`,
+    )
+    .all(now);
+  const perAgent = new Map<string, number>();
+  let global = 0;
+  for (const r of rows) {
+    perAgent.set(r.agent_unit, r.n);
+    global += r.n;
+  }
+  return { perAgent, global };
+}
+
+/**
+ * Compute retry_after_ms as the time until the soonest-expiring active
+ * nonce frees a slot. Falls back to a 5s floor if no rows are present
+ * (shouldn't happen if we're rate-limiting, but defensive).
+ */
+export function computeRetryAfterMs(
+  db: Database,
+  agent_unit: string | null,
+  now: number = Date.now(),
+): number {
+  const row = agent_unit
+    ? db
+        .query<{ expires_at: number }, [string, number]>(
+          `SELECT MIN(expires_at) AS expires_at FROM approval_nonces
+           WHERE consumed_at IS NULL AND expires_at > ? AND agent_unit = ?
+           LIMIT 1`,
+        )
+        .get(agent_unit, now)
+    : db
+        .query<{ expires_at: number }, [number]>(
+          `SELECT MIN(expires_at) AS expires_at FROM approval_nonces
+           WHERE consumed_at IS NULL AND expires_at > ?
+           LIMIT 1`,
+        )
+        .get(now);
+  if (!row || row.expires_at == null) return 5000;
+  const delta = row.expires_at - now;
+  return Math.max(1000, delta);
+}
 
 /**
  * Open a fresh approval request: insert a nonce row, return the request_id
  * the gateway will embed in `apv:<request_id>:<action>` callback_data.
  *
  * No decision row is created yet — that happens on consume (user tap).
+ *
+ * Caller (broker) is responsible for rate-cap enforcement via
+ * `countPendingNonces` before invoking this.
  */
 export function requestApproval(
   db: Database,
@@ -124,110 +198,171 @@ export function requestApproval(
 
   db.run(
     `INSERT INTO approval_nonces
-       (request_id, decision_id, created_at, consumed_at, expires_at,
-        agent, surface, scope, action_grammar, approver_set_canonical, why)
-     VALUES (?, NULL, ?, NULL, ?, ?, ?, ?, ?, ?, ?)`,
+       (request_id, decision_id, agent_unit, scope, action,
+        approver_set_canonical, why, created_at, expires_at, consumed_at)
+     VALUES (?, NULL, ?, ?, ?, ?, ?, ?, ?, NULL)`,
     [
       request_id,
-      now,
-      expires_at,
-      input.agent,
-      input.surface,
+      input.agent_unit,
       input.scope,
-      input.action_grammar,
+      input.action,
       canonical,
       input.why ?? null,
+      now,
+      expires_at,
     ],
   );
 
-  audit(db, "request", null, input.agent, {
-    request_id,
-    surface: input.surface,
+  audit(db, "request", {
+    agent_unit: input.agent_unit,
     scope: input.scope,
-    action_grammar: input.action_grammar,
-    why: input.why,
+    action: input.action,
+    context: { request_id, why: input.why },
   });
 
   return { request_id, expires_at };
 }
 
 /**
- * Look up whether a given (agent, surface, scope, action) is currently
- * granted. Performs config-drift detection: if the stored
- * approver_set_canonical does not match the current one, the decision is
- * auto-revoked (audit row written) and the caller is told to re-prompt.
+ * Look up whether (agent_unit, scope, action) is currently granted. Performs
+ * config-drift detection (§5.1) and sliding-window TTL renewal (§7).
  */
 export function lookupDecision(
   db: Database,
   query: {
-    agent: string;
-    surface: string;
+    agent_unit: string;
     scope: string;
-    action_grammar: string;
+    action: string;
     current_approver_set: string[];
   },
+  opts: { max_ttl_lifetime_ms?: number } = {},
   now: number = Date.now(),
 ): LookupResult {
   const currentCanonical = canonicalizeApproverSet(query.current_approver_set);
 
   const row = db
-    .query<Record<string, unknown>, [string, string, string, string]>(
+    .query<Record<string, unknown>, [string, string, string]>(
       `SELECT * FROM approval_decisions
-       WHERE agent = ? AND surface = ? AND scope = ? AND action_grammar = ?
+       WHERE agent_unit = ? AND scope = ? AND action = ?
          AND revoked_at IS NULL
        ORDER BY granted_at DESC LIMIT 1`,
     )
-    .get(query.agent, query.surface, query.scope, query.action_grammar);
+    .get(query.agent_unit, query.scope, query.action);
 
-  if (!row) return { status: "no_decision" };
+  if (!row) return { state: "no_decision" };
 
   const decision = rowToDecision(row);
 
-  // Expiry check (TTL grants)
-  if (decision.expires_at !== null && decision.expires_at < now) {
-    return { status: "expired" };
+  // deny_perm short-circuits before drift / TTL — it's a permanent reject.
+  if (decision.decision === "deny_perm") {
+    return { state: "denied", decision };
+  }
+
+  // Expiry check (allow_ttl)
+  if (decision.ttl_expires_at !== null && decision.ttl_expires_at < now) {
+    return { state: "expired" };
   }
 
   // Drift detection (§5.1): canonical mismatch → auto-revoke + re-prompt.
   if (decision.approver_set_canonical !== currentCanonical) {
     db.run(
-      `UPDATE approval_decisions SET revoked_at = ? WHERE id = ?`,
+      `UPDATE approval_decisions
+       SET revoked_at = ?, revoke_reason = 'approver_set_drift'
+       WHERE id = ?`,
       [now, decision.id],
     );
-    audit(db, "drift_revoke", decision.id, "kernel", {
-      stored_canonical: decision.approver_set_canonical,
-      current_canonical: currentCanonical,
+    audit(db, "drift_revoke", {
+      agent_unit: decision.agent_unit,
+      scope: decision.scope,
+      action: decision.action,
+      decision_id: decision.id,
+      context: {
+        stored_canonical: decision.approver_set_canonical,
+        current_canonical: currentCanonical,
+      },
     });
-    return { status: "drift_revoked" };
+    return { state: "drift_revoked" };
   }
 
-  return decision.granted
-    ? { status: "granted", decision }
-    : { status: "denied", decision };
+  // Single-shot deny — record the match and don't auto-renew.
+  if (decision.decision === "deny") {
+    return { state: "denied", decision };
+  }
+
+  // §7 sliding-window TTL renewal for allow_ttl. Each successful match
+  // updates last_used_at and extends ttl_expires_at by the original TTL,
+  // capped at granted_at + max_lifetime.
+  if (decision.decision === "allow_ttl") {
+    const maxLifetime = opts.max_ttl_lifetime_ms ?? DEFAULT_MAX_TTL_LIFETIME_MS;
+    const hardCap = decision.granted_at + maxLifetime;
+    // Original TTL window = (ttl_expires_at - granted_at) at first grant.
+    // last_used_at is null on first match; treat that as the original window.
+    const originalWindow =
+      decision.ttl_expires_at !== null
+        ? decision.ttl_expires_at - (decision.last_used_at ?? decision.granted_at)
+        : 0;
+    let newExpires = decision.ttl_expires_at;
+    if (originalWindow > 0) {
+      newExpires = Math.min(now + originalWindow, hardCap);
+    }
+    db.run(
+      `UPDATE approval_decisions
+       SET last_used_at = ?, ttl_expires_at = ?
+       WHERE id = ?`,
+      [now, newExpires, decision.id],
+    );
+    decision.last_used_at = now;
+    decision.ttl_expires_at = newExpires;
+  } else {
+    // allow_once / allow_always — just update last_used_at for staleness.
+    db.run(
+      `UPDATE approval_decisions SET last_used_at = ? WHERE id = ?`,
+      [now, decision.id],
+    );
+    decision.last_used_at = now;
+  }
+
+  audit(db, "match", {
+    agent_unit: decision.agent_unit,
+    scope: decision.scope,
+    action: decision.action,
+    decision_id: decision.id,
+  });
+
+  return { state: "granted", decision };
 }
 
 /**
  * Atomically consume a single-use nonce. Returns the nonce row on first
  * call; returns null on every subsequent call (already consumed, expired,
  * or unknown).
- *
- * The atomicity guarantee comes from `UPDATE … WHERE consumed_at IS NULL`
- * with a rowcount check — SQLite serializes writes within a connection,
- * and bun:sqlite uses one connection per Database handle. Concurrent taps
- * race here; exactly one wins.
  */
 export interface NonceRow {
   request_id: string;
   decision_id: string | null;
-  created_at: number;
-  consumed_at: number | null;
-  expires_at: number;
-  agent: string;
-  surface: string;
+  agent_unit: string;
   scope: string;
-  action_grammar: string;
+  action: string;
   approver_set_canonical: string;
   why: string | null;
+  created_at: number;
+  expires_at: number;
+  consumed_at: number | null;
+}
+
+function nonceFromRow(row: Record<string, unknown>): NonceRow {
+  return {
+    request_id: row.request_id as string,
+    decision_id: (row.decision_id as string | null) ?? null,
+    agent_unit: row.agent_unit as string,
+    scope: row.scope as string,
+    action: row.action as string,
+    approver_set_canonical: row.approver_set_canonical as string,
+    why: (row.why as string | null) ?? null,
+    created_at: row.created_at as number,
+    expires_at: row.expires_at as number,
+    consumed_at: (row.consumed_at as number | null) ?? null,
+  };
 }
 
 export function consumeNonce(
@@ -235,8 +370,6 @@ export function consumeNonce(
   request_id: string,
   now: number = Date.now(),
 ): NonceRow | null {
-  // First read the row so we can return it; the atomic UPDATE either flips
-  // consumed_at from NULL→now (we win) or no-ops (someone else won).
   const row = db
     .query<Record<string, unknown>, [string]>(
       `SELECT * FROM approval_nonces WHERE request_id = ?`,
@@ -244,22 +377,15 @@ export function consumeNonce(
     .get(request_id);
   if (!row) return null;
 
-  const nonce: NonceRow = {
-    request_id: row.request_id as string,
-    decision_id: (row.decision_id as string | null) ?? null,
-    created_at: row.created_at as number,
-    consumed_at: (row.consumed_at as number | null) ?? null,
-    expires_at: row.expires_at as number,
-    agent: row.agent as string,
-    surface: row.surface as string,
-    scope: row.scope as string,
-    action_grammar: row.action_grammar as string,
-    approver_set_canonical: row.approver_set_canonical as string,
-    why: (row.why as string | null) ?? null,
-  };
+  const nonce = nonceFromRow(row);
 
   if (nonce.expires_at < now) {
-    audit(db, "expire", null, "kernel", { request_id });
+    audit(db, "expire", {
+      agent_unit: nonce.agent_unit,
+      scope: nonce.scope,
+      action: nonce.action,
+      context: { request_id },
+    });
     return null;
   }
 
@@ -270,28 +396,28 @@ export function consumeNonce(
   );
 
   if ((result.changes ?? 0) === 0) {
-    // Already consumed by a concurrent tap — we lose the race.
     return null;
   }
 
-  audit(db, "consume", null, "kernel", { request_id });
+  audit(db, "consume", {
+    agent_unit: nonce.agent_unit,
+    scope: nonce.scope,
+    action: nonce.action,
+    context: { request_id },
+  });
   return nonce;
 }
 
 /**
- * Record the user's decision and (for grants) write the durable
- * approval_decisions row. Called by the gateway after a successful
- * consumeNonce. Returns the new decision id or null if no row was written
- * (allow_once still records a transient row so /approvals revoke can target
- * it; deny without a chain prev still records).
+ * Record the user's decision and write the durable approval_decisions row.
+ * Called by the gateway after a successful consumeNonce.
  */
 export interface RecordDecisionInput {
   nonce: NonceRow;
-  granted: boolean;
-  approver_set: string[];   // for re-storing approver_set_raw alongside canonical
-  approver_user_id: string; // who tapped, for audit
-  ttl_ms?: number;          // null/undefined → no expiry (allow_always or one-shot)
-  decision_id_chain_prev?: string | null;
+  decision: ApprovalDecisionMode;
+  approver_set: string[];      // current allowFrom (canonicalized inside)
+  granted_by_user_id: number;  // Telegram user_id of approver
+  ttl_ms?: number;             // for allow_ttl; ignored otherwise
 }
 
 export function recordDecision(
@@ -300,26 +426,26 @@ export function recordDecision(
   now: number = Date.now(),
 ): string {
   const id = randomUUID();
-  const expires_at = input.ttl_ms ? now + input.ttl_ms : null;
+  const ttl_expires_at =
+    input.decision === "allow_ttl" && input.ttl_ms ? now + input.ttl_ms : null;
+  const canonical = canonicalizeApproverSet(input.approver_set);
 
   db.run(
     `INSERT INTO approval_decisions
-       (id, agent, surface, scope, action_grammar, granted,
-        approver_set, approver_set_canonical,
-        granted_at, expires_at, revoked_at, decision_id_chain_prev)
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, ?)`,
+       (id, agent_unit, scope, action, decision,
+        ttl_expires_at, granted_at, granted_by_user_id,
+        approver_set_canonical, last_used_at, revoked_at, revoke_reason)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, NULL, NULL)`,
     [
       id,
-      input.nonce.agent,
-      input.nonce.surface,
+      input.nonce.agent_unit,
       input.nonce.scope,
-      input.nonce.action_grammar,
-      input.granted ? 1 : 0,
-      JSON.stringify(input.approver_set),
-      input.nonce.approver_set_canonical,
+      input.nonce.action,
+      input.decision,
+      ttl_expires_at,
       now,
-      expires_at,
-      input.decision_id_chain_prev ?? null,
+      input.granted_by_user_id,
+      canonical,
     ],
   );
 
@@ -329,21 +455,31 @@ export function recordDecision(
     [id, input.nonce.request_id],
   );
 
-  audit(
-    db,
-    input.granted ? "grant" : "deny",
-    id,
-    input.approver_user_id,
-    {
+  const granted =
+    input.decision === "allow_once" ||
+    input.decision === "allow_always" ||
+    input.decision === "allow_ttl";
+
+  audit(db, granted ? "grant" : "deny", {
+    agent_unit: input.nonce.agent_unit,
+    scope: input.nonce.scope,
+    action: input.nonce.action,
+    decision_id: id,
+    context: {
       request_id: input.nonce.request_id,
+      decision: input.decision,
       ttl_ms: input.ttl_ms ?? null,
+      granted_by_user_id: input.granted_by_user_id,
     },
-  );
+  });
 
   return id;
 }
 
-/** Revoke a decision by id. Idempotent (revoking a revoked row is a no-op). */
+/**
+ * Revoke a decision by id. Idempotent (revoking a revoked row is a no-op).
+ * `reason` is persisted into approval_decisions.revoke_reason.
+ */
 export function revokeDecision(
   db: Database,
   decision_id: string,
@@ -351,40 +487,54 @@ export function revokeDecision(
   reason?: string,
   now: number = Date.now(),
 ): boolean {
+  // Read first so we can build the audit row with agent_unit/scope/action.
+  const row = db
+    .query<Record<string, unknown>, [string]>(
+      `SELECT * FROM approval_decisions WHERE id = ?`,
+    )
+    .get(decision_id);
+  if (!row) return false;
+  const decision = rowToDecision(row);
+  if (decision.revoked_at !== null) return false;
+
   const result = db.run(
-    `UPDATE approval_decisions SET revoked_at = ?
+    `UPDATE approval_decisions SET revoked_at = ?, revoke_reason = ?
      WHERE id = ? AND revoked_at IS NULL`,
-    [now, decision_id],
+    [now, reason ?? null, decision_id],
   );
   if ((result.changes ?? 0) === 0) return false;
-  audit(db, "revoke", decision_id, actor, reason ? { reason } : undefined);
+
+  audit(db, "revoke", {
+    agent_unit: decision.agent_unit,
+    scope: decision.scope,
+    action: decision.action,
+    decision_id,
+    context: { actor, reason: reason ?? null },
+  });
   return true;
 }
 
 /**
  * List active (non-revoked, non-expired) decisions.
- * Optional `agent` filter for the per-agent /approvals list view (RFC §9).
+ * Optional `agent_unit` filter for the per-agent /approvals list view (§9).
  */
 export function listDecisions(
   db: Database,
-  filter?: { agent?: string; include_revoked?: boolean },
+  filter?: { agent_unit?: string; include_revoked?: boolean },
   now: number = Date.now(),
 ): DecisionRow[] {
   const includeRevoked = filter?.include_revoked === true;
   let sql = `SELECT * FROM approval_decisions WHERE 1=1`;
   const params: unknown[] = [];
   if (!includeRevoked) {
-    sql += ` AND revoked_at IS NULL AND (expires_at IS NULL OR expires_at > ?)`;
+    sql += ` AND revoked_at IS NULL AND (ttl_expires_at IS NULL OR ttl_expires_at > ?)`;
     params.push(now);
   }
-  if (filter?.agent !== undefined) {
-    sql += ` AND agent = ?`;
-    params.push(filter.agent);
+  if (filter?.agent_unit !== undefined) {
+    sql += ` AND agent_unit = ?`;
+    params.push(filter.agent_unit);
   }
   sql += ` ORDER BY granted_at DESC`;
-  // bun:sqlite's typings want a tuple, but we build params dynamically.
-  // Cast through a shape that satisfies SQLQueryBindings without forcing
-  // a fixed arity.
   const rows = (
     db.query(sql) as unknown as {
       all: (...binds: unknown[]) => Record<string, unknown>[];
@@ -410,18 +560,5 @@ export function getNonce(db: Database, request_id: string): NonceRow | null {
       `SELECT * FROM approval_nonces WHERE request_id = ?`,
     )
     .get(request_id);
-  if (!row) return null;
-  return {
-    request_id: row.request_id as string,
-    decision_id: (row.decision_id as string | null) ?? null,
-    created_at: row.created_at as number,
-    consumed_at: (row.consumed_at as number | null) ?? null,
-    expires_at: row.expires_at as number,
-    agent: row.agent as string,
-    surface: row.surface as string,
-    scope: row.scope as string,
-    action_grammar: row.action_grammar as string,
-    approver_set_canonical: row.approver_set_canonical as string,
-    why: (row.why as string | null) ?? null,
-  };
+  return row ? nonceFromRow(row) : null;
 }

--- a/src/vault/approvals/kernel.ts
+++ b/src/vault/approvals/kernel.ts
@@ -1,0 +1,427 @@
+/**
+ * Approval kernel — pure DB operations (RFC B §5–§7).
+ *
+ * Stateless module: every function takes a Database handle and returns a
+ * plain result. The IPC broker (server.ts) and the Telegram callback router
+ * (gateway/approval-card.ts) call into here. Tests can drive these
+ * functions directly against an in-memory SQLite DB without standing up the
+ * broker.
+ */
+
+import { randomBytes, randomUUID } from "node:crypto";
+import type { Database } from "bun:sqlite";
+import { canonicalizeApproverSet } from "./canonical.js";
+import type { ApprovalAuditEvent } from "./schema.js";
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+export interface ApprovalRequestInput {
+  agent: string;
+  surface: string;          // 'secret' | 'vault' | 'mcp:notion' | etc
+  scope: string;            // RFC §6 scope grammar string
+  action_grammar: string;   // 'read' | 'write' | etc
+  approver_set: string[];   // current allowFrom; canonicalized + stored
+  why?: string;
+  ttl_ms?: number;          // nonce expiry; defaults to 5 minutes per §8.1
+}
+
+export interface RequestApprovalResult {
+  request_id: string;       // 8-hex; goes on the apv: callback_data
+  expires_at: number;       // unix-ms when the prompt times out
+}
+
+export interface DecisionRow {
+  id: string;
+  agent: string;
+  surface: string;
+  scope: string;
+  action_grammar: string;
+  granted: boolean;
+  approver_set: string[];
+  approver_set_canonical: string;
+  granted_at: number;
+  expires_at: number | null;
+  revoked_at: number | null;
+  decision_id_chain_prev: string | null;
+}
+
+export type LookupResult =
+  | { status: "granted"; decision: DecisionRow }
+  | { status: "denied"; decision: DecisionRow }
+  | { status: "pending"; request_id: string }
+  | { status: "expired" }
+  | { status: "drift_revoked" }
+  | { status: "no_decision" };
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function generateRequestId(): string {
+  // 8 hex chars — matches generateAskId convention in telegram-plugin/ask-user.ts
+  return randomBytes(4).toString("hex");
+}
+
+function audit(
+  db: Database,
+  event: ApprovalAuditEvent,
+  decisionId: string | null,
+  actor: string,
+  payload?: Record<string, unknown>,
+): void {
+  db.run(
+    `INSERT INTO approval_audit (decision_id, event, ts, actor, payload)
+     VALUES (?, ?, ?, ?, ?)`,
+    [
+      decisionId,
+      event,
+      Date.now(),
+      actor,
+      payload ? JSON.stringify(payload) : null,
+    ],
+  );
+}
+
+function rowToDecision(row: Record<string, unknown>): DecisionRow {
+  let approverSet: string[] = [];
+  try {
+    const parsed = JSON.parse(row.approver_set as string);
+    if (Array.isArray(parsed)) approverSet = parsed as string[];
+  } catch {
+    /* swallow — corrupt row, fall through with empty list */
+  }
+  return {
+    id: row.id as string,
+    agent: row.agent as string,
+    surface: row.surface as string,
+    scope: row.scope as string,
+    action_grammar: row.action_grammar as string,
+    granted: (row.granted as number) === 1,
+    approver_set: approverSet,
+    approver_set_canonical: row.approver_set_canonical as string,
+    granted_at: row.granted_at as number,
+    expires_at: (row.expires_at as number | null) ?? null,
+    revoked_at: (row.revoked_at as number | null) ?? null,
+    decision_id_chain_prev: (row.decision_id_chain_prev as string | null) ?? null,
+  };
+}
+
+// ─── Public API ─────────────────────────────────────────────────────────────
+
+/**
+ * Open a fresh approval request: insert a nonce row, return the request_id
+ * the gateway will embed in `apv:<request_id>:<action>` callback_data.
+ *
+ * No decision row is created yet — that happens on consume (user tap).
+ */
+export function requestApproval(
+  db: Database,
+  input: ApprovalRequestInput,
+  now: number = Date.now(),
+): RequestApprovalResult {
+  const request_id = generateRequestId();
+  const ttl = input.ttl_ms ?? 5 * 60 * 1000; // 5 min default per §8.1
+  const expires_at = now + ttl;
+  const canonical = canonicalizeApproverSet(input.approver_set);
+
+  db.run(
+    `INSERT INTO approval_nonces
+       (request_id, decision_id, created_at, consumed_at, expires_at,
+        agent, surface, scope, action_grammar, approver_set_canonical, why)
+     VALUES (?, NULL, ?, NULL, ?, ?, ?, ?, ?, ?, ?)`,
+    [
+      request_id,
+      now,
+      expires_at,
+      input.agent,
+      input.surface,
+      input.scope,
+      input.action_grammar,
+      canonical,
+      input.why ?? null,
+    ],
+  );
+
+  audit(db, "request", null, input.agent, {
+    request_id,
+    surface: input.surface,
+    scope: input.scope,
+    action_grammar: input.action_grammar,
+    why: input.why,
+  });
+
+  return { request_id, expires_at };
+}
+
+/**
+ * Look up whether a given (agent, surface, scope, action) is currently
+ * granted. Performs config-drift detection: if the stored
+ * approver_set_canonical does not match the current one, the decision is
+ * auto-revoked (audit row written) and the caller is told to re-prompt.
+ */
+export function lookupDecision(
+  db: Database,
+  query: {
+    agent: string;
+    surface: string;
+    scope: string;
+    action_grammar: string;
+    current_approver_set: string[];
+  },
+  now: number = Date.now(),
+): LookupResult {
+  const currentCanonical = canonicalizeApproverSet(query.current_approver_set);
+
+  const row = db
+    .query<Record<string, unknown>, [string, string, string, string]>(
+      `SELECT * FROM approval_decisions
+       WHERE agent = ? AND surface = ? AND scope = ? AND action_grammar = ?
+         AND revoked_at IS NULL
+       ORDER BY granted_at DESC LIMIT 1`,
+    )
+    .get(query.agent, query.surface, query.scope, query.action_grammar);
+
+  if (!row) return { status: "no_decision" };
+
+  const decision = rowToDecision(row);
+
+  // Expiry check (TTL grants)
+  if (decision.expires_at !== null && decision.expires_at < now) {
+    return { status: "expired" };
+  }
+
+  // Drift detection (§5.1): canonical mismatch → auto-revoke + re-prompt.
+  if (decision.approver_set_canonical !== currentCanonical) {
+    db.run(
+      `UPDATE approval_decisions SET revoked_at = ? WHERE id = ?`,
+      [now, decision.id],
+    );
+    audit(db, "drift_revoke", decision.id, "kernel", {
+      stored_canonical: decision.approver_set_canonical,
+      current_canonical: currentCanonical,
+    });
+    return { status: "drift_revoked" };
+  }
+
+  return decision.granted
+    ? { status: "granted", decision }
+    : { status: "denied", decision };
+}
+
+/**
+ * Atomically consume a single-use nonce. Returns the nonce row on first
+ * call; returns null on every subsequent call (already consumed, expired,
+ * or unknown).
+ *
+ * The atomicity guarantee comes from `UPDATE … WHERE consumed_at IS NULL`
+ * with a rowcount check — SQLite serializes writes within a connection,
+ * and bun:sqlite uses one connection per Database handle. Concurrent taps
+ * race here; exactly one wins.
+ */
+export interface NonceRow {
+  request_id: string;
+  decision_id: string | null;
+  created_at: number;
+  consumed_at: number | null;
+  expires_at: number;
+  agent: string;
+  surface: string;
+  scope: string;
+  action_grammar: string;
+  approver_set_canonical: string;
+  why: string | null;
+}
+
+export function consumeNonce(
+  db: Database,
+  request_id: string,
+  now: number = Date.now(),
+): NonceRow | null {
+  // First read the row so we can return it; the atomic UPDATE either flips
+  // consumed_at from NULL→now (we win) or no-ops (someone else won).
+  const row = db
+    .query<Record<string, unknown>, [string]>(
+      `SELECT * FROM approval_nonces WHERE request_id = ?`,
+    )
+    .get(request_id);
+  if (!row) return null;
+
+  const nonce: NonceRow = {
+    request_id: row.request_id as string,
+    decision_id: (row.decision_id as string | null) ?? null,
+    created_at: row.created_at as number,
+    consumed_at: (row.consumed_at as number | null) ?? null,
+    expires_at: row.expires_at as number,
+    agent: row.agent as string,
+    surface: row.surface as string,
+    scope: row.scope as string,
+    action_grammar: row.action_grammar as string,
+    approver_set_canonical: row.approver_set_canonical as string,
+    why: (row.why as string | null) ?? null,
+  };
+
+  if (nonce.expires_at < now) {
+    audit(db, "expire", null, "kernel", { request_id });
+    return null;
+  }
+
+  const result = db.run(
+    `UPDATE approval_nonces SET consumed_at = ?
+     WHERE request_id = ? AND consumed_at IS NULL`,
+    [now, request_id],
+  );
+
+  if ((result.changes ?? 0) === 0) {
+    // Already consumed by a concurrent tap — we lose the race.
+    return null;
+  }
+
+  audit(db, "consume", null, "kernel", { request_id });
+  return nonce;
+}
+
+/**
+ * Record the user's decision and (for grants) write the durable
+ * approval_decisions row. Called by the gateway after a successful
+ * consumeNonce. Returns the new decision id or null if no row was written
+ * (allow_once still records a transient row so /approvals revoke can target
+ * it; deny without a chain prev still records).
+ */
+export interface RecordDecisionInput {
+  nonce: NonceRow;
+  granted: boolean;
+  approver_set: string[];   // for re-storing approver_set_raw alongside canonical
+  approver_user_id: string; // who tapped, for audit
+  ttl_ms?: number;          // null/undefined → no expiry (allow_always or one-shot)
+  decision_id_chain_prev?: string | null;
+}
+
+export function recordDecision(
+  db: Database,
+  input: RecordDecisionInput,
+  now: number = Date.now(),
+): string {
+  const id = randomUUID();
+  const expires_at = input.ttl_ms ? now + input.ttl_ms : null;
+
+  db.run(
+    `INSERT INTO approval_decisions
+       (id, agent, surface, scope, action_grammar, granted,
+        approver_set, approver_set_canonical,
+        granted_at, expires_at, revoked_at, decision_id_chain_prev)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, ?)`,
+    [
+      id,
+      input.nonce.agent,
+      input.nonce.surface,
+      input.nonce.scope,
+      input.nonce.action_grammar,
+      input.granted ? 1 : 0,
+      JSON.stringify(input.approver_set),
+      input.nonce.approver_set_canonical,
+      now,
+      expires_at,
+      input.decision_id_chain_prev ?? null,
+    ],
+  );
+
+  // Link the nonce → decision for audit traceability.
+  db.run(
+    `UPDATE approval_nonces SET decision_id = ? WHERE request_id = ?`,
+    [id, input.nonce.request_id],
+  );
+
+  audit(
+    db,
+    input.granted ? "grant" : "deny",
+    id,
+    input.approver_user_id,
+    {
+      request_id: input.nonce.request_id,
+      ttl_ms: input.ttl_ms ?? null,
+    },
+  );
+
+  return id;
+}
+
+/** Revoke a decision by id. Idempotent (revoking a revoked row is a no-op). */
+export function revokeDecision(
+  db: Database,
+  decision_id: string,
+  actor: string,
+  reason?: string,
+  now: number = Date.now(),
+): boolean {
+  const result = db.run(
+    `UPDATE approval_decisions SET revoked_at = ?
+     WHERE id = ? AND revoked_at IS NULL`,
+    [now, decision_id],
+  );
+  if ((result.changes ?? 0) === 0) return false;
+  audit(db, "revoke", decision_id, actor, reason ? { reason } : undefined);
+  return true;
+}
+
+/**
+ * List active (non-revoked, non-expired) decisions.
+ * Optional `agent` filter for the per-agent /approvals list view (RFC §9).
+ */
+export function listDecisions(
+  db: Database,
+  filter?: { agent?: string; include_revoked?: boolean },
+  now: number = Date.now(),
+): DecisionRow[] {
+  const includeRevoked = filter?.include_revoked === true;
+  let sql = `SELECT * FROM approval_decisions WHERE 1=1`;
+  const params: unknown[] = [];
+  if (!includeRevoked) {
+    sql += ` AND revoked_at IS NULL AND (expires_at IS NULL OR expires_at > ?)`;
+    params.push(now);
+  }
+  if (filter?.agent !== undefined) {
+    sql += ` AND agent = ?`;
+    params.push(filter.agent);
+  }
+  sql += ` ORDER BY granted_at DESC`;
+  // bun:sqlite's typings want a tuple, but we build params dynamically.
+  // Cast through a shape that satisfies SQLQueryBindings without forcing
+  // a fixed arity.
+  const rows = (
+    db.query(sql) as unknown as {
+      all: (...binds: unknown[]) => Record<string, unknown>[];
+    }
+  ).all(...params);
+  return rows.map(rowToDecision);
+}
+
+/** Get a single decision by id (for /approvals revoke confirmation, etc). */
+export function getDecision(db: Database, id: string): DecisionRow | null {
+  const row = db
+    .query<Record<string, unknown>, [string]>(
+      `SELECT * FROM approval_decisions WHERE id = ?`,
+    )
+    .get(id);
+  return row ? rowToDecision(row) : null;
+}
+
+/** Get a pending/recently-consumed nonce (for callback handlers). */
+export function getNonce(db: Database, request_id: string): NonceRow | null {
+  const row = db
+    .query<Record<string, unknown>, [string]>(
+      `SELECT * FROM approval_nonces WHERE request_id = ?`,
+    )
+    .get(request_id);
+  if (!row) return null;
+  return {
+    request_id: row.request_id as string,
+    decision_id: (row.decision_id as string | null) ?? null,
+    created_at: row.created_at as number,
+    consumed_at: (row.consumed_at as number | null) ?? null,
+    expires_at: row.expires_at as number,
+    agent: row.agent as string,
+    surface: row.surface as string,
+    scope: row.scope as string,
+    action_grammar: row.action_grammar as string,
+    approver_set_canonical: row.approver_set_canonical as string,
+    why: (row.why as string | null) ?? null,
+  };
+}

--- a/src/vault/approvals/schema.ts
+++ b/src/vault/approvals/schema.ts
@@ -4,19 +4,14 @@
  * Three tables in vault-grants.db (kernel folds into the existing broker DB
  * per RFC §4 — no rename, downgrade-friendly):
  *
- *   approval_decisions  — durable allow/deny decisions per (agent, scope, action).
+ *   approval_decisions  — durable allow/deny decisions per (agent_unit, scope, action).
  *   approval_nonces     — short-lived 8-hex callback tokens; single-use redemption.
  *   approval_audit      — append-only audit trail of every kernel event.
  *
- * Schema columns follow the implementation brief verbatim. RFC §5's column
- * names differ in places (e.g. `decision` vs `granted`/`action_grammar`,
- * `agent_unit` vs `agent`); the brief's names win on conflict — they're what
- * the wiring downstream is written against.
+ * Schema columns track RFC B §5 verbatim. The kernel has not shipped, so this
+ * migration just runs DROP-IF-EXISTS + CREATE; no production data to migrate.
  *
  * No HMAC, no chains, no crypto: same-uid is game-over per docs/vault.md:227.
- * `decision_id_chain_prev` is a plain self-FK so a future revocation can
- * point to the prior decision it superseded; this is bookkeeping, not a
- * tamper-evidence chain.
  */
 
 import type { Database } from "bun:sqlite";
@@ -24,62 +19,93 @@ import type { Database } from "bun:sqlite";
 /**
  * Idempotent migration. Safe to call on every broker startup. The vault
  * broker already does this for `vault_grants`; we piggyback on the same
- * lifecycle so a fresh vault-grants.db gets all four tables in one shot.
+ * lifecycle so a fresh vault-grants.db gets all three tables in one shot.
+ *
+ * Pre-ship rewrite: this drops any older approval_* tables before recreating
+ * them. There is no production deployment of this kernel yet, so a clean
+ * recreate is preferable to an in-place ALTER chain.
  */
 export function migrateApprovalSchema(db: Database): void {
+  // Drop any pre-RFC-shape tables. Order: nonces / audit first (they FK into
+  // decisions on some prior shapes), decisions last.
+  db.run(`DROP TABLE IF EXISTS approval_audit`);
+  db.run(`DROP TABLE IF EXISTS approval_nonces`);
+  db.run(`DROP TABLE IF EXISTS approval_decisions`);
+
   db.run(`
-    CREATE TABLE IF NOT EXISTS approval_decisions (
+    CREATE TABLE approval_decisions (
       id                       TEXT PRIMARY KEY,
-      agent                    TEXT NOT NULL,
-      surface                  TEXT NOT NULL,
+      agent_unit               TEXT NOT NULL,
       scope                    TEXT NOT NULL,
-      action_grammar           TEXT NOT NULL,
-      granted                  INTEGER NOT NULL,
-      approver_set             TEXT NOT NULL,
-      approver_set_canonical   TEXT NOT NULL,
+      action                   TEXT NOT NULL,
+      decision                 TEXT NOT NULL,
+      ttl_expires_at           INTEGER,
       granted_at               INTEGER NOT NULL,
-      expires_at               INTEGER,
+      granted_by_user_id       INTEGER NOT NULL,
+      approver_set_canonical   TEXT NOT NULL,
+      last_used_at             INTEGER,
       revoked_at               INTEGER,
-      decision_id_chain_prev   TEXT,
-      FOREIGN KEY (decision_id_chain_prev) REFERENCES approval_decisions(id)
+      revoke_reason            TEXT
     )
   `);
 
   db.run(`
-    CREATE INDEX IF NOT EXISTS approval_decisions_lookup
-    ON approval_decisions(agent, surface, scope, action_grammar)
+    CREATE INDEX approval_decisions_lookup
+    ON approval_decisions(agent_unit, scope, action)
     WHERE revoked_at IS NULL
   `);
 
   db.run(`
-    CREATE TABLE IF NOT EXISTS approval_nonces (
+    CREATE TABLE approval_nonces (
       request_id   TEXT PRIMARY KEY,
       decision_id  TEXT,
-      created_at   INTEGER NOT NULL,
-      consumed_at  INTEGER,
-      expires_at   INTEGER NOT NULL,
-      agent        TEXT NOT NULL,
-      surface      TEXT NOT NULL,
+      agent_unit   TEXT NOT NULL,
       scope        TEXT NOT NULL,
-      action_grammar TEXT NOT NULL,
+      action       TEXT NOT NULL,
       approver_set_canonical TEXT NOT NULL,
       why          TEXT,
+      created_at   INTEGER NOT NULL,
+      expires_at   INTEGER NOT NULL,
+      consumed_at  INTEGER,
+      FOREIGN KEY (decision_id) REFERENCES approval_decisions(id)
+    )
+  `);
+
+  // Index for B2 rate-cap lookup: count pending nonces per agent_unit and
+  // globally. WHERE consumed_at IS NULL keeps the index lean.
+  db.run(`
+    CREATE INDEX approval_nonces_pending
+    ON approval_nonces(agent_unit, expires_at)
+    WHERE consumed_at IS NULL
+  `);
+
+  db.run(`
+    CREATE TABLE approval_audit (
+      seq         INTEGER PRIMARY KEY AUTOINCREMENT,
+      ts          INTEGER NOT NULL,
+      agent_unit  TEXT NOT NULL,
+      scope       TEXT NOT NULL,
+      action      TEXT NOT NULL,
+      decision_id TEXT,
+      event       TEXT NOT NULL,
+      context     TEXT,
       FOREIGN KEY (decision_id) REFERENCES approval_decisions(id)
     )
   `);
 
   db.run(`
-    CREATE TABLE IF NOT EXISTS approval_audit (
-      id          INTEGER PRIMARY KEY AUTOINCREMENT,
-      decision_id TEXT,
-      event       TEXT NOT NULL,
-      ts          INTEGER NOT NULL,
-      actor       TEXT NOT NULL,
-      payload     TEXT,
-      FOREIGN KEY (decision_id) REFERENCES approval_decisions(id)
-    )
+    CREATE INDEX approval_audit_by_scope
+    ON approval_audit(scope, ts)
   `);
 }
+
+/** Decision modes per RFC §7. Stored verbatim in approval_decisions.decision. */
+export type ApprovalDecisionMode =
+  | "allow_once"
+  | "allow_always"
+  | "allow_ttl"
+  | "deny"
+  | "deny_perm";
 
 /** Audit event vocabulary — one of these strings goes into approval_audit.event. */
 export type ApprovalAuditEvent =
@@ -89,4 +115,13 @@ export type ApprovalAuditEvent =
   | "drift_revoke"
   | "consume"
   | "expire"
-  | "deny";
+  | "deny"
+  | "match"
+  | "timeout";
+
+/**
+ * Sliding-window TTL hard cap. RFC §7 specifies a default; the brief asks
+ * for a configurable max with default 7 days. Renewal of an `allow_ttl`
+ * decision cannot extend `ttl_expires_at` past `granted_at + this`.
+ */
+export const DEFAULT_MAX_TTL_LIFETIME_MS = 7 * 24 * 60 * 60 * 1000;

--- a/src/vault/approvals/schema.ts
+++ b/src/vault/approvals/schema.ts
@@ -1,0 +1,92 @@
+/**
+ * Approval kernel — SQLite schema (RFC B §5).
+ *
+ * Three tables in vault-grants.db (kernel folds into the existing broker DB
+ * per RFC §4 — no rename, downgrade-friendly):
+ *
+ *   approval_decisions  — durable allow/deny decisions per (agent, scope, action).
+ *   approval_nonces     — short-lived 8-hex callback tokens; single-use redemption.
+ *   approval_audit      — append-only audit trail of every kernel event.
+ *
+ * Schema columns follow the implementation brief verbatim. RFC §5's column
+ * names differ in places (e.g. `decision` vs `granted`/`action_grammar`,
+ * `agent_unit` vs `agent`); the brief's names win on conflict — they're what
+ * the wiring downstream is written against.
+ *
+ * No HMAC, no chains, no crypto: same-uid is game-over per docs/vault.md:227.
+ * `decision_id_chain_prev` is a plain self-FK so a future revocation can
+ * point to the prior decision it superseded; this is bookkeeping, not a
+ * tamper-evidence chain.
+ */
+
+import type { Database } from "bun:sqlite";
+
+/**
+ * Idempotent migration. Safe to call on every broker startup. The vault
+ * broker already does this for `vault_grants`; we piggyback on the same
+ * lifecycle so a fresh vault-grants.db gets all four tables in one shot.
+ */
+export function migrateApprovalSchema(db: Database): void {
+  db.run(`
+    CREATE TABLE IF NOT EXISTS approval_decisions (
+      id                       TEXT PRIMARY KEY,
+      agent                    TEXT NOT NULL,
+      surface                  TEXT NOT NULL,
+      scope                    TEXT NOT NULL,
+      action_grammar           TEXT NOT NULL,
+      granted                  INTEGER NOT NULL,
+      approver_set             TEXT NOT NULL,
+      approver_set_canonical   TEXT NOT NULL,
+      granted_at               INTEGER NOT NULL,
+      expires_at               INTEGER,
+      revoked_at               INTEGER,
+      decision_id_chain_prev   TEXT,
+      FOREIGN KEY (decision_id_chain_prev) REFERENCES approval_decisions(id)
+    )
+  `);
+
+  db.run(`
+    CREATE INDEX IF NOT EXISTS approval_decisions_lookup
+    ON approval_decisions(agent, surface, scope, action_grammar)
+    WHERE revoked_at IS NULL
+  `);
+
+  db.run(`
+    CREATE TABLE IF NOT EXISTS approval_nonces (
+      request_id   TEXT PRIMARY KEY,
+      decision_id  TEXT,
+      created_at   INTEGER NOT NULL,
+      consumed_at  INTEGER,
+      expires_at   INTEGER NOT NULL,
+      agent        TEXT NOT NULL,
+      surface      TEXT NOT NULL,
+      scope        TEXT NOT NULL,
+      action_grammar TEXT NOT NULL,
+      approver_set_canonical TEXT NOT NULL,
+      why          TEXT,
+      FOREIGN KEY (decision_id) REFERENCES approval_decisions(id)
+    )
+  `);
+
+  db.run(`
+    CREATE TABLE IF NOT EXISTS approval_audit (
+      id          INTEGER PRIMARY KEY AUTOINCREMENT,
+      decision_id TEXT,
+      event       TEXT NOT NULL,
+      ts          INTEGER NOT NULL,
+      actor       TEXT NOT NULL,
+      payload     TEXT,
+      FOREIGN KEY (decision_id) REFERENCES approval_decisions(id)
+    )
+  `);
+}
+
+/** Audit event vocabulary — one of these strings goes into approval_audit.event. */
+export type ApprovalAuditEvent =
+  | "request"
+  | "grant"
+  | "revoke"
+  | "drift_revoke"
+  | "consume"
+  | "expire"
+  | "deny";

--- a/src/vault/broker/client.ts
+++ b/src/vault/broker/client.ts
@@ -309,6 +309,22 @@ type RpcResult =
  * Send a single request to the broker and get a response.
  * Returns { kind: "unreachable", msg } on any connection / protocol failure.
  */
+/**
+ * Public single-shot RPC helper. Used by the approval-kernel client (RFC B)
+ * which needs to round-trip new ops without piggy-backing on the legacy
+ * BrokerClient surface. Same connect/timeout/parse semantics as the
+ * internal `rpc()` — this is just an exported alias.
+ */
+export async function rpcRaw(
+  req: Parameters<typeof encodeRequest>[0],
+  opts?: BrokerClientOpts,
+): Promise<
+  | { kind: "response"; resp: BrokerResponse }
+  | { kind: "unreachable"; msg: string }
+> {
+  return rpc(req, opts);
+}
+
 async function rpc(
   req: Parameters<typeof encodeRequest>[0],
   opts?: BrokerClientOpts,

--- a/src/vault/broker/peercred.test.ts
+++ b/src/vault/broker/peercred.test.ts
@@ -466,16 +466,29 @@ describe("readSystemdUnit", () => {
     expect(readSystemdUnit(pid)).toBeNull();
   });
 
-  it("ignores agent names that look like but don't match the convention", () => {
-    const pid = 7777;
+  it("matches long-running agent units (RFC B §4.1)", () => {
+    // The regex was broadened to accept switchroom-<agent>.service
+    // (no -cron-N suffix) so long-running agent units pass the broker's
+    // peercred ACL. verifySystemdUnit still cross-checks against
+    // systemd-user as the real defence; the regex just narrows scope.
+    const pid = 7778;
     vi.mocked(fs.readFileSync).mockImplementation((path: unknown) => {
       if (String(path) === `/proc/${pid}/cgroup`) {
-        // Missing the index digit at the end
-        return `0::/user.slice/user-1000.slice/user@1000.service/app.slice/switchroom-myagent-cron-.service\n`;
+        return `0::/user.slice/user-1000.slice/user@1000.service/app.slice/switchroom-klanker.service\n`;
       }
       throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
     });
+    expect(readSystemdUnit(pid)).toBe("switchroom-klanker.service");
+  });
 
+  it("rejects names without the switchroom- prefix", () => {
+    const pid = 7779;
+    vi.mocked(fs.readFileSync).mockImplementation((path: unknown) => {
+      if (String(path) === `/proc/${pid}/cgroup`) {
+        return `0::/user.slice/user-1000.slice/user@1000.service/app.slice/something-else.service\n`;
+      }
+      throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+    });
     expect(readSystemdUnit(pid)).toBeNull();
   });
 });

--- a/src/vault/broker/peercred.ts
+++ b/src/vault/broker/peercred.ts
@@ -219,8 +219,13 @@ export function readSystemdUnit(pid: number): string | null {
 
       if (!lastSegment) continue;
 
-      // Must match the switchroom cron unit naming convention
-      if (/^switchroom-[a-zA-Z0-9_-]+-cron-\d+\.service$/.test(lastSegment)) {
+      // RFC B §4.1: broaden to match BOTH cron units AND long-running agent
+      // units (e.g. switchroom-klanker.service). The previous regex only
+      // matched cron and silently locked long-running agents out of the
+      // broker. The cross-check via verifySystemdUnit (~50 lines below) is
+      // what actually defends against a same-uid attacker spoofing the
+      // cgroup name; this regex just narrows to switchroom-* units.
+      if (/^switchroom-[a-zA-Z0-9_-]+(-cron-\d+)?\.service$/.test(lastSegment)) {
         return lastSegment;
       }
     }

--- a/src/vault/broker/protocol.ts
+++ b/src/vault/broker/protocol.ts
@@ -73,6 +73,60 @@ export const LockRequestSchema = z.object({
   op: z.literal("lock"),
 });
 
+// ─── Approval kernel (RFC B) ────────────────────────────────────────────────
+
+export const ApprovalRequestRequestSchema = z.object({
+  v: z.literal(1),
+  op: z.literal("approval_request"),
+  agent: z.string().min(1),
+  surface: z.string().min(1),
+  scope: z.string().min(1),
+  action_grammar: z.string().min(1),
+  approver_set: z.array(z.string()),
+  why: z.string().optional(),
+  ttl_ms: z.number().int().positive().optional(),
+});
+
+export const ApprovalLookupRequestSchema = z.object({
+  v: z.literal(1),
+  op: z.literal("approval_lookup"),
+  agent: z.string().min(1),
+  surface: z.string().min(1),
+  scope: z.string().min(1),
+  action_grammar: z.string().min(1),
+  current_approver_set: z.array(z.string()),
+});
+
+export const ApprovalConsumeRequestSchema = z.object({
+  v: z.literal(1),
+  op: z.literal("approval_consume"),
+  request_id: z.string().regex(/^[0-9a-f]{8}$/),
+});
+
+export const ApprovalRevokeRequestSchema = z.object({
+  v: z.literal(1),
+  op: z.literal("approval_revoke"),
+  decision_id: z.string().min(1),
+  actor: z.string().min(1),
+  reason: z.string().optional(),
+});
+
+export const ApprovalListRequestSchema = z.object({
+  v: z.literal(1),
+  op: z.literal("approval_list"),
+  agent: z.string().optional(),
+});
+
+export const ApprovalRecordRequestSchema = z.object({
+  v: z.literal(1),
+  op: z.literal("approval_record"),
+  request_id: z.string().regex(/^[0-9a-f]{8}$/),
+  granted: z.boolean(),
+  approver_set: z.array(z.string()),
+  approver_user_id: z.string().min(1),
+  ttl_ms: z.number().int().positive().nullable().optional(),
+});
+
 export const RequestSchema = z.discriminatedUnion("op", [
   GetRequestSchema,
   ListRequestSchema,
@@ -81,6 +135,12 @@ export const RequestSchema = z.discriminatedUnion("op", [
   MintGrantRequestSchema,
   ListGrantsRequestSchema,
   RevokeGrantRequestSchema,
+  ApprovalRequestRequestSchema,
+  ApprovalLookupRequestSchema,
+  ApprovalConsumeRequestSchema,
+  ApprovalRevokeRequestSchema,
+  ApprovalListRequestSchema,
+  ApprovalRecordRequestSchema,
 ]);
 
 export type GetRequest = z.infer<typeof GetRequestSchema>;
@@ -90,6 +150,12 @@ export type LockRequest = z.infer<typeof LockRequestSchema>;
 export type MintGrantRequest = z.infer<typeof MintGrantRequestSchema>;
 export type ListGrantsRequest = z.infer<typeof ListGrantsRequestSchema>;
 export type RevokeGrantRequest = z.infer<typeof RevokeGrantRequestSchema>;
+export type ApprovalRequestRequest = z.infer<typeof ApprovalRequestRequestSchema>;
+export type ApprovalLookupRequest = z.infer<typeof ApprovalLookupRequestSchema>;
+export type ApprovalConsumeRequest = z.infer<typeof ApprovalConsumeRequestSchema>;
+export type ApprovalRevokeRequest = z.infer<typeof ApprovalRevokeRequestSchema>;
+export type ApprovalListRequest = z.infer<typeof ApprovalListRequestSchema>;
+export type ApprovalRecordRequest = z.infer<typeof ApprovalRecordRequestSchema>;
 export type BrokerRequest = z.infer<typeof RequestSchema>;
 
 // ─── Response schemas ───────────────────────────────────────────────────────
@@ -172,6 +238,62 @@ export const OkRevokeGrantResponseSchema = z.object({
   revoked: z.boolean(),
 });
 
+// ─── Approval kernel responses ──────────────────────────────────────────────
+
+export const OkApprovalRequestResponseSchema = z.object({
+  ok: z.literal(true),
+  request_id: z.string(),
+  expires_at: z.number(),
+});
+
+export const ApprovalDecisionMetaSchema = z.object({
+  id: z.string(),
+  agent: z.string(),
+  surface: z.string(),
+  scope: z.string(),
+  action_grammar: z.string(),
+  granted: z.boolean(),
+  approver_set: z.array(z.string()),
+  granted_at: z.number(),
+  expires_at: z.number().nullable(),
+  revoked_at: z.number().nullable(),
+});
+export type ApprovalDecisionMeta = z.infer<typeof ApprovalDecisionMetaSchema>;
+
+export const OkApprovalLookupResponseSchema = z.object({
+  ok: z.literal(true),
+  status: z.enum(["granted", "denied", "pending", "expired", "drift_revoked", "no_decision"]),
+  decision: ApprovalDecisionMetaSchema.nullable().optional(),
+});
+
+export const OkApprovalConsumeResponseSchema = z.object({
+  ok: z.literal(true),
+  consumed: z.boolean(),
+  // Nonce metadata returned to the gateway so it can render the post-tap card
+  // and (on grant) call recordDecision via approval_record. We expose enough
+  // for the gateway to act without re-querying.
+  agent: z.string().optional(),
+  surface: z.string().optional(),
+  scope: z.string().optional(),
+  action_grammar: z.string().optional(),
+  why: z.string().nullable().optional(),
+});
+
+export const OkApprovalRevokeResponseSchema = z.object({
+  ok: z.literal(true),
+  revoked: z.boolean(),
+});
+
+export const OkApprovalListResponseSchema = z.object({
+  ok: z.literal(true),
+  decisions: z.array(ApprovalDecisionMetaSchema),
+});
+
+export const OkApprovalRecordResponseSchema = z.object({
+  ok: z.literal(true),
+  decision_id: z.string(),
+});
+
 export const ErrorResponseSchema = z.object({
   ok: z.literal(false),
   code: ErrorCode,
@@ -186,6 +308,12 @@ export const ResponseSchema = z.union([
   OkMintGrantResponseSchema,
   OkListGrantsResponseSchema,
   OkRevokeGrantResponseSchema,
+  OkApprovalRequestResponseSchema,
+  OkApprovalLookupResponseSchema,
+  OkApprovalConsumeResponseSchema,
+  OkApprovalRevokeResponseSchema,
+  OkApprovalListResponseSchema,
+  OkApprovalRecordResponseSchema,
   ErrorResponseSchema,
 ]);
 
@@ -197,6 +325,12 @@ export type OkMintGrantResponse = z.infer<typeof OkMintGrantResponseSchema>;
 export type OkListGrantsResponse = z.infer<typeof OkListGrantsResponseSchema>;
 export type OkRevokeGrantResponse = z.infer<typeof OkRevokeGrantResponseSchema>;
 export type ErrorResponse = z.infer<typeof ErrorResponseSchema>;
+export type OkApprovalRequestResponse = z.infer<typeof OkApprovalRequestResponseSchema>;
+export type OkApprovalLookupResponse = z.infer<typeof OkApprovalLookupResponseSchema>;
+export type OkApprovalConsumeResponse = z.infer<typeof OkApprovalConsumeResponseSchema>;
+export type OkApprovalRevokeResponse = z.infer<typeof OkApprovalRevokeResponseSchema>;
+export type OkApprovalListResponse = z.infer<typeof OkApprovalListResponseSchema>;
+export type OkApprovalRecordResponse = z.infer<typeof OkApprovalRecordResponseSchema>;
 export type BrokerResponse = z.infer<typeof ResponseSchema>;
 
 // ─── Encode / decode helpers ────────────────────────────────────────────────

--- a/src/vault/broker/protocol.ts
+++ b/src/vault/broker/protocol.ts
@@ -78,10 +78,9 @@ export const LockRequestSchema = z.object({
 export const ApprovalRequestRequestSchema = z.object({
   v: z.literal(1),
   op: z.literal("approval_request"),
-  agent: z.string().min(1),
-  surface: z.string().min(1),
+  agent_unit: z.string().min(1),
   scope: z.string().min(1),
-  action_grammar: z.string().min(1),
+  action: z.string().min(1),
   approver_set: z.array(z.string()),
   why: z.string().optional(),
   ttl_ms: z.number().int().positive().optional(),
@@ -90,10 +89,9 @@ export const ApprovalRequestRequestSchema = z.object({
 export const ApprovalLookupRequestSchema = z.object({
   v: z.literal(1),
   op: z.literal("approval_lookup"),
-  agent: z.string().min(1),
-  surface: z.string().min(1),
+  agent_unit: z.string().min(1),
   scope: z.string().min(1),
-  action_grammar: z.string().min(1),
+  action: z.string().min(1),
   current_approver_set: z.array(z.string()),
 });
 
@@ -114,16 +112,25 @@ export const ApprovalRevokeRequestSchema = z.object({
 export const ApprovalListRequestSchema = z.object({
   v: z.literal(1),
   op: z.literal("approval_list"),
-  agent: z.string().optional(),
+  agent_unit: z.string().optional(),
 });
+
+export const ApprovalDecisionModeSchema = z.enum([
+  "allow_once",
+  "allow_always",
+  "allow_ttl",
+  "deny",
+  "deny_perm",
+]);
+export type ApprovalDecisionMode = z.infer<typeof ApprovalDecisionModeSchema>;
 
 export const ApprovalRecordRequestSchema = z.object({
   v: z.literal(1),
   op: z.literal("approval_record"),
   request_id: z.string().regex(/^[0-9a-f]{8}$/),
-  granted: z.boolean(),
+  decision: ApprovalDecisionModeSchema,
   approver_set: z.array(z.string()),
-  approver_user_id: z.string().min(1),
+  granted_by_user_id: z.number().int(),
   ttl_ms: z.number().int().positive().nullable().optional(),
 });
 
@@ -240,42 +247,72 @@ export const OkRevokeGrantResponseSchema = z.object({
 
 // ─── Approval kernel responses ──────────────────────────────────────────────
 
-export const OkApprovalRequestResponseSchema = z.object({
-  ok: z.literal(true),
-  request_id: z.string(),
-  expires_at: z.number(),
-});
+/**
+ * approval_request response. Two shapes — discriminated by the literal in
+ * `state` (NOT `status`, to avoid colliding with the BrokerStatus object on
+ * the OkStatusResponse shape).
+ *
+ * - { state: "pending", request_id, expires_at } — the normal path.
+ * - { state: "rate_limited", retry_after_ms } — RFC §10 caps tripped
+ *   (per-agent max 2 concurrent; global max 32).
+ */
+/**
+ * approval_request response. Carries a `kind: "approval_request"` tag so
+ * the discriminated union at the broker response level can narrow without
+ * the lookup response (`state` field, no `kind`) ever matching here.
+ *
+ * - `state: "pending"` — nonce issued, request_id + expires_at returned.
+ * - `state: "rate_limited"` — RFC §10 caps tripped; retry_after_ms returned.
+ */
+export const OkApprovalRequestResponseSchema = z.discriminatedUnion("state", [
+  z.object({
+    ok: z.literal(true),
+    kind: z.literal("approval_request"),
+    state: z.literal("pending"),
+    request_id: z.string(),
+    expires_at: z.number(),
+  }),
+  z.object({
+    ok: z.literal(true),
+    kind: z.literal("approval_request"),
+    state: z.literal("rate_limited"),
+    retry_after_ms: z.number(),
+  }),
+]);
 
 export const ApprovalDecisionMetaSchema = z.object({
   id: z.string(),
-  agent: z.string(),
-  surface: z.string(),
+  agent_unit: z.string(),
   scope: z.string(),
-  action_grammar: z.string(),
-  granted: z.boolean(),
-  approver_set: z.array(z.string()),
+  action: z.string(),
+  decision: ApprovalDecisionModeSchema,
   granted_at: z.number(),
-  expires_at: z.number().nullable(),
+  granted_by_user_id: z.number(),
+  ttl_expires_at: z.number().nullable(),
+  last_used_at: z.number().nullable(),
   revoked_at: z.number().nullable(),
+  revoke_reason: z.string().nullable(),
 });
 export type ApprovalDecisionMeta = z.infer<typeof ApprovalDecisionMetaSchema>;
 
+/**
+ * approval_lookup response. Discriminant is `state` — RFC §10 lifecycle.
+ * Renamed from `status` to avoid colliding with BrokerStatus on the response
+ * union (the latter's `status` is an object; this one's was a string —
+ * narrowing required a `typeof` smell at the call site).
+ */
 export const OkApprovalLookupResponseSchema = z.object({
   ok: z.literal(true),
-  status: z.enum(["granted", "denied", "pending", "expired", "drift_revoked", "no_decision"]),
+  state: z.enum(["granted", "denied", "pending", "expired", "drift_revoked", "no_decision"]),
   decision: ApprovalDecisionMetaSchema.nullable().optional(),
 });
 
 export const OkApprovalConsumeResponseSchema = z.object({
   ok: z.literal(true),
   consumed: z.boolean(),
-  // Nonce metadata returned to the gateway so it can render the post-tap card
-  // and (on grant) call recordDecision via approval_record. We expose enough
-  // for the gateway to act without re-querying.
-  agent: z.string().optional(),
-  surface: z.string().optional(),
+  agent_unit: z.string().optional(),
   scope: z.string().optional(),
-  action_grammar: z.string().optional(),
+  action: z.string().optional(),
   why: z.string().nullable().optional(),
 });
 

--- a/src/vault/broker/server-approvals.test.ts
+++ b/src/vault/broker/server-approvals.test.ts
@@ -1,0 +1,189 @@
+/**
+ * Tests for VaultBroker approval-kernel ops (RFC B §4 — folded into the
+ * broker rather than a parallel daemon).
+ *
+ * Round-trips real Unix-socket IPC. Secrets pre-loaded; grants DB is
+ * in-memory; non-Linux gate set so peercred bypass is in effect.
+ */
+
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import * as net from "node:net";
+import * as os from "node:os";
+import * as path from "node:path";
+import * as fs from "node:fs";
+import { Database } from "bun:sqlite";
+import { VaultBroker } from "./server.js";
+import { encodeRequest, decodeResponse, type BrokerResponse } from "./protocol.js";
+import { migrateGrantsSchema } from "../grants.js";
+import { migrateApprovalSchema } from "../approvals/schema.js";
+
+function makeInMemoryGrantsDb(): Database {
+  const db = new Database(":memory:");
+  migrateGrantsSchema(db);
+  migrateApprovalSchema(db);
+  return db;
+}
+
+function makeMinimalConfig() {
+  return {
+    switchroom: { version: 1 },
+    telegram: { bot_token: "test", forum_chat_id: "123" },
+    vault: {
+      path: "~/.switchroom/vault.enc",
+      broker: { socket: "~/.switchroom/vault-broker.sock", enabled: true },
+    },
+    agents: {},
+  } as any;
+}
+
+async function rpc(
+  socketPath: string,
+  req: Parameters<typeof encodeRequest>[0],
+): Promise<BrokerResponse> {
+  return new Promise((resolve, reject) => {
+    const client = net.createConnection({ path: socketPath });
+    let buffer = "";
+    client.on("error", reject);
+    client.on("data", (chunk: Buffer) => {
+      buffer += chunk.toString("utf8");
+      const idx = buffer.indexOf("\n");
+      if (idx !== -1) {
+        const line = buffer.slice(0, idx);
+        client.destroy();
+        try {
+          resolve(decodeResponse(line));
+        } catch (e) {
+          reject(e);
+        }
+      }
+    });
+    client.on("connect", () => {
+      client.write(encodeRequest(req));
+    });
+  });
+}
+
+describe("VaultBroker: approval-kernel ops", () => {
+  let broker: VaultBroker;
+  let socketPath: string;
+  let tmpDir: string;
+  let grantsDb: Database;
+  let prev: string | undefined;
+
+  beforeEach(async () => {
+    prev = process.env.SWITCHROOM_BROKER_ALLOW_NON_LINUX;
+    process.env.SWITCHROOM_BROKER_ALLOW_NON_LINUX = "1";
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "broker-apv-"));
+    socketPath = path.join(tmpDir, "t.sock");
+    grantsDb = makeInMemoryGrantsDb();
+    broker = new VaultBroker({
+      _testSecrets: { foo: { kind: "string", value: "bar" } },
+      _testConfig: makeMinimalConfig(),
+      _testGrantsDb: grantsDb,
+      _testAuditLogger: { write: () => { /* swallow */ } },
+    });
+    await broker.start(socketPath, undefined, undefined);
+  });
+
+  afterEach(() => {
+    broker.stop();
+    try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch { /* */ }
+    if (prev === undefined) delete process.env.SWITCHROOM_BROKER_ALLOW_NON_LINUX;
+    else process.env.SWITCHROOM_BROKER_ALLOW_NON_LINUX = prev;
+  });
+
+  it("approval_request → approval_consume → approval_lookup full grant flow", async () => {
+    // 1) Open the request
+    const r1 = await rpc(socketPath, {
+      v: 1,
+      op: "approval_request",
+      agent: "klanker",
+      surface: "secret",
+      scope: "secret:OPENAI",
+      action_grammar: "read",
+      approver_set: ["U1"],
+      why: "OpenAI API call",
+    });
+    expect(r1.ok).toBe(true);
+    if (!(r1.ok && "request_id" in r1)) throw new Error("bad shape");
+    const reqId = r1.request_id;
+    expect(reqId).toMatch(/^[0-9a-f]{8}$/);
+
+    // 2) Lookup before tap → no_decision
+    const r2 = await rpc(socketPath, {
+      v: 1,
+      op: "approval_lookup",
+      agent: "klanker",
+      surface: "secret",
+      scope: "secret:OPENAI",
+      action_grammar: "read",
+      current_approver_set: ["U1"],
+    });
+    expect(r2.ok).toBe(true);
+    if (r2.ok && "status" in r2) expect(r2.status).toBe("no_decision");
+
+    // 3) Consume nonce (gateway has shown the card and user tapped)
+    const r3 = await rpc(socketPath, {
+      v: 1,
+      op: "approval_consume",
+      request_id: reqId,
+    });
+    expect(r3.ok).toBe(true);
+    if (r3.ok && "consumed" in r3) {
+      expect(r3.consumed).toBe(true);
+      expect(r3.scope).toBe("secret:OPENAI");
+    }
+
+    // 4) Second consume of same nonce → consumed=false (single-use enforcement)
+    const r3b = await rpc(socketPath, {
+      v: 1,
+      op: "approval_consume",
+      request_id: reqId,
+    });
+    if (r3b.ok && "consumed" in r3b) expect(r3b.consumed).toBe(false);
+  });
+
+  it("approval_revoke and approval_list", async () => {
+    // Seed a granted decision directly in the DB (the IPC path for
+    // record-decision lives in-process inside the gateway tap handler;
+    // here we just verify that revoke + list see the row).
+    const id = "uuid-1";
+    grantsDb.run(
+      `INSERT INTO approval_decisions
+         (id, agent, surface, scope, action_grammar, granted,
+          approver_set, approver_set_canonical, granted_at,
+          expires_at, revoked_at, decision_id_chain_prev)
+       VALUES (?, ?, ?, ?, ?, 1, ?, ?, ?, NULL, NULL, NULL)`,
+      [
+        id,
+        "klanker",
+        "secret",
+        "secret:X",
+        "read",
+        JSON.stringify(["U1"]),
+        JSON.stringify(["U1"]),
+        Date.now(),
+      ],
+    );
+
+    const list = await rpc(socketPath, { v: 1, op: "approval_list" });
+    expect(list.ok).toBe(true);
+    if (list.ok && "decisions" in list) {
+      expect(list.decisions.length).toBe(1);
+      expect(list.decisions[0]?.id).toBe(id);
+    }
+
+    const rev = await rpc(socketPath, {
+      v: 1,
+      op: "approval_revoke",
+      decision_id: id,
+      actor: "U1",
+      reason: "no longer needed",
+    });
+    expect(rev.ok).toBe(true);
+    if (rev.ok && "revoked" in rev) expect(rev.revoked).toBe(true);
+
+    const list2 = await rpc(socketPath, { v: 1, op: "approval_list" });
+    if (list2.ok && "decisions" in list2) expect(list2.decisions.length).toBe(0);
+  });
+});

--- a/src/vault/broker/server-approvals.test.ts
+++ b/src/vault/broker/server-approvals.test.ts
@@ -1,9 +1,6 @@
 /**
  * Tests for VaultBroker approval-kernel ops (RFC B §4 — folded into the
  * broker rather than a parallel daemon).
- *
- * Round-trips real Unix-socket IPC. Secrets pre-loaded; grants DB is
- * in-memory; non-Linux gate set so peercred bypass is in effect.
  */
 
 import { describe, expect, it, beforeEach, afterEach } from "vitest";
@@ -50,16 +47,10 @@ async function rpc(
       if (idx !== -1) {
         const line = buffer.slice(0, idx);
         client.destroy();
-        try {
-          resolve(decodeResponse(line));
-        } catch (e) {
-          reject(e);
-        }
+        try { resolve(decodeResponse(line)); } catch (e) { reject(e); }
       }
     });
-    client.on("connect", () => {
-      client.write(encodeRequest(req));
-    });
+    client.on("connect", () => { client.write(encodeRequest(req)); });
   });
 }
 
@@ -93,40 +84,30 @@ describe("VaultBroker: approval-kernel ops", () => {
   });
 
   it("approval_request → approval_consume → approval_lookup full grant flow", async () => {
-    // 1) Open the request
     const r1 = await rpc(socketPath, {
-      v: 1,
-      op: "approval_request",
-      agent: "klanker",
-      surface: "secret",
-      scope: "secret:OPENAI",
-      action_grammar: "read",
-      approver_set: ["U1"],
-      why: "OpenAI API call",
+      v: 1, op: "approval_request",
+      agent_unit: "switchroom-klanker.service",
+      scope: "secret:OPENAI", action: "read",
+      approver_set: ["U1"], why: "OpenAI API call",
     });
     expect(r1.ok).toBe(true);
-    if (!(r1.ok && "request_id" in r1)) throw new Error("bad shape");
+    if (!(r1.ok && "kind" in r1 && r1.kind === "approval_request")) throw new Error("bad shape");
+    if (r1.state !== "pending") throw new Error(`unexpected state ${r1.state}`);
     const reqId = r1.request_id;
     expect(reqId).toMatch(/^[0-9a-f]{8}$/);
 
-    // 2) Lookup before tap → no_decision
     const r2 = await rpc(socketPath, {
-      v: 1,
-      op: "approval_lookup",
-      agent: "klanker",
-      surface: "secret",
-      scope: "secret:OPENAI",
-      action_grammar: "read",
+      v: 1, op: "approval_lookup",
+      agent_unit: "switchroom-klanker.service",
+      scope: "secret:OPENAI", action: "read",
       current_approver_set: ["U1"],
     });
     expect(r2.ok).toBe(true);
-    if (r2.ok && "status" in r2) expect(r2.status).toBe("no_decision");
+    // No `typeof` workaround needed — lookup uses `state`, not `status`.
+    if (r2.ok && "state" in r2) expect(r2.state).toBe("no_decision");
 
-    // 3) Consume nonce (gateway has shown the card and user tapped)
     const r3 = await rpc(socketPath, {
-      v: 1,
-      op: "approval_consume",
-      request_id: reqId,
+      v: 1, op: "approval_consume", request_id: reqId,
     });
     expect(r3.ok).toBe(true);
     if (r3.ok && "consumed" in r3) {
@@ -134,56 +115,92 @@ describe("VaultBroker: approval-kernel ops", () => {
       expect(r3.scope).toBe("secret:OPENAI");
     }
 
-    // 4) Second consume of same nonce → consumed=false (single-use enforcement)
     const r3b = await rpc(socketPath, {
-      v: 1,
-      op: "approval_consume",
-      request_id: reqId,
+      v: 1, op: "approval_consume", request_id: reqId,
     });
     if (r3b.ok && "consumed" in r3b) expect(r3b.consumed).toBe(false);
   });
 
-  it("approval_revoke and approval_list", async () => {
-    // Seed a granted decision directly in the DB (the IPC path for
-    // record-decision lives in-process inside the gateway tap handler;
-    // here we just verify that revoke + list see the row).
-    const id = "uuid-1";
-    grantsDb.run(
-      `INSERT INTO approval_decisions
-         (id, agent, surface, scope, action_grammar, granted,
-          approver_set, approver_set_canonical, granted_at,
-          expires_at, revoked_at, decision_id_chain_prev)
-       VALUES (?, ?, ?, ?, ?, 1, ?, ?, ?, NULL, NULL, NULL)`,
-      [
-        id,
-        "klanker",
-        "secret",
-        "secret:X",
-        "read",
-        JSON.stringify(["U1"]),
-        JSON.stringify(["U1"]),
-        Date.now(),
-      ],
-    );
+  it("approval_record + approval_revoke + approval_list (with new RFC columns)", async () => {
+    const reqRes = await rpc(socketPath, {
+      v: 1, op: "approval_request",
+      agent_unit: "u", scope: "secret:X", action: "read",
+      approver_set: ["U1"],
+    });
+    if (!(reqRes.ok && "kind" in reqRes && reqRes.kind === "approval_request")) throw new Error("bad");
+    if (reqRes.state !== "pending") throw new Error("not pending");
+    const reqId = reqRes.request_id;
+    await rpc(socketPath, { v: 1, op: "approval_consume", request_id: reqId });
+    const recRes = await rpc(socketPath, {
+      v: 1, op: "approval_record",
+      request_id: reqId, decision: "allow_always",
+      approver_set: ["U1"], granted_by_user_id: 42,
+    });
+    if (!(recRes.ok && "decision_id" in recRes)) throw new Error("bad");
+    const id = recRes.decision_id;
 
     const list = await rpc(socketPath, { v: 1, op: "approval_list" });
     expect(list.ok).toBe(true);
     if (list.ok && "decisions" in list) {
       expect(list.decisions.length).toBe(1);
-      expect(list.decisions[0]?.id).toBe(id);
+      const d = list.decisions[0]!;
+      expect(d.id).toBe(id);
+      expect(d.decision).toBe("allow_always");
+      expect(d.granted_by_user_id).toBe(42);
+      expect(d.agent_unit).toBe("u");
     }
 
     const rev = await rpc(socketPath, {
-      v: 1,
-      op: "approval_revoke",
-      decision_id: id,
-      actor: "U1",
-      reason: "no longer needed",
+      v: 1, op: "approval_revoke",
+      decision_id: id, actor: "U1", reason: "no longer needed",
     });
-    expect(rev.ok).toBe(true);
     if (rev.ok && "revoked" in rev) expect(rev.revoked).toBe(true);
 
     const list2 = await rpc(socketPath, { v: 1, op: "approval_list" });
     if (list2.ok && "decisions" in list2) expect(list2.decisions.length).toBe(0);
+  });
+
+  // ── RFC §10: rate caps ────────────────────────────────────────────────────
+
+  it("per-agent cap of 2 → third concurrent request returns rate_limited", async () => {
+    const a = "switchroom-klanker.service";
+    const r1 = await rpc(socketPath, {
+      v: 1, op: "approval_request", agent_unit: a, scope: "s1", action: "read", approver_set: ["1"],
+    });
+    const r2 = await rpc(socketPath, {
+      v: 1, op: "approval_request", agent_unit: a, scope: "s2", action: "read", approver_set: ["1"],
+    });
+    const r3 = await rpc(socketPath, {
+      v: 1, op: "approval_request", agent_unit: a, scope: "s3", action: "read", approver_set: ["1"],
+    });
+    const k = (r: BrokerResponse) =>
+      r.ok && "kind" in r && r.kind === "approval_request" ? r : null;
+    const k1 = k(r1), k2 = k(r2), k3 = k(r3);
+    if (!k1 || !k2 || !k3) throw new Error("bad shape");
+    expect(k1.state).toBe("pending");
+    expect(k2.state).toBe("pending");
+    expect(k3.state).toBe("rate_limited");
+    if (k3.state === "rate_limited") {
+      expect(k3.retry_after_ms).toBeGreaterThan(0);
+    }
+  });
+
+  it("global cap of 32 → 33rd request across many agents returns rate_limited", async () => {
+    // Issue 32 from distinct agents so per-agent cap never trips.
+    for (let i = 0; i < 32; i++) {
+      const r = await rpc(socketPath, {
+        v: 1, op: "approval_request",
+        agent_unit: `a${i}`, scope: `s${i}`, action: "read", approver_set: ["1"],
+      });
+      if (!(r.ok && "kind" in r && r.kind === "approval_request") || r.state !== "pending") {
+        throw new Error(`request ${i} unexpected: ${JSON.stringify(r)}`);
+      }
+    }
+    const r33 = await rpc(socketPath, {
+      v: 1, op: "approval_request",
+      agent_unit: "a32", scope: "s32", action: "read", approver_set: ["1"],
+    });
+    if (!(r33.ok && "kind" in r33 && r33.kind === "approval_request")) throw new Error("bad shape");
+    expect(r33.state).toBe("rate_limited");
   });
 });

--- a/src/vault/broker/server.test.ts
+++ b/src/vault/broker/server.test.ts
@@ -141,11 +141,10 @@ describe("VaultBroker server", () => {
   it("status: returns unlocked=true with correct keyCount", async () => {
     const resp = await rpc(socketPath, { v: 1, op: "status" });
     expect(resp.ok).toBe(true);
-    // RFC B widened the response union (apv: ops also have a `status` key
-    // typed as a string). Narrow explicitly to the broker-status object
-    // shape so the original assertions still type-check.
-    if (resp.ok && "status" in resp && typeof resp.status === "object") {
-      const s = resp.status as { unlocked: boolean; keyCount: number; uptimeSec: number };
+    // RFC B's approval_lookup uses `state`, not `status`, so there's no
+    // collision with BrokerStatus on this union — narrow on `"status" in resp`.
+    if (resp.ok && "status" in resp) {
+      const s = resp.status;
       expect(s.unlocked).toBe(true);
       expect(s.keyCount).toBe(Object.keys(TEST_SECRETS).length);
       expect(s.uptimeSec).toBeGreaterThanOrEqual(0);
@@ -207,12 +206,8 @@ describe("VaultBroker server", () => {
 
     // Status should report locked
     const statusResp = await rpc(socketPath, { v: 1, op: "status" });
-    if (
-      statusResp.ok &&
-      "status" in statusResp &&
-      typeof statusResp.status === "object"
-    ) {
-      const s = statusResp.status as { unlocked: boolean; keyCount: number };
+    if (statusResp.ok && "status" in statusResp) {
+      const s = statusResp.status;
       expect(s.unlocked).toBe(false);
       expect(s.keyCount).toBe(0);
     }

--- a/src/vault/broker/server.test.ts
+++ b/src/vault/broker/server.test.ts
@@ -141,10 +141,14 @@ describe("VaultBroker server", () => {
   it("status: returns unlocked=true with correct keyCount", async () => {
     const resp = await rpc(socketPath, { v: 1, op: "status" });
     expect(resp.ok).toBe(true);
-    if (resp.ok && "status" in resp) {
-      expect(resp.status.unlocked).toBe(true);
-      expect(resp.status.keyCount).toBe(Object.keys(TEST_SECRETS).length);
-      expect(resp.status.uptimeSec).toBeGreaterThanOrEqual(0);
+    // RFC B widened the response union (apv: ops also have a `status` key
+    // typed as a string). Narrow explicitly to the broker-status object
+    // shape so the original assertions still type-check.
+    if (resp.ok && "status" in resp && typeof resp.status === "object") {
+      const s = resp.status as { unlocked: boolean; keyCount: number; uptimeSec: number };
+      expect(s.unlocked).toBe(true);
+      expect(s.keyCount).toBe(Object.keys(TEST_SECRETS).length);
+      expect(s.uptimeSec).toBeGreaterThanOrEqual(0);
     }
   });
 
@@ -203,9 +207,14 @@ describe("VaultBroker server", () => {
 
     // Status should report locked
     const statusResp = await rpc(socketPath, { v: 1, op: "status" });
-    if (statusResp.ok && "status" in statusResp) {
-      expect(statusResp.status.unlocked).toBe(false);
-      expect(statusResp.status.keyCount).toBe(0);
+    if (
+      statusResp.ok &&
+      "status" in statusResp &&
+      typeof statusResp.status === "object"
+    ) {
+      const s = statusResp.status as { unlocked: boolean; keyCount: number };
+      expect(s.unlocked).toBe(false);
+      expect(s.keyCount).toBe(0);
     }
   });
 

--- a/src/vault/broker/server.ts
+++ b/src/vault/broker/server.ts
@@ -60,6 +60,10 @@ import {
   listDecisions as kernelListDecisions,
   recordDecision as kernelRecordDecision,
   getNonce as kernelGetNonce,
+  countPendingNonces,
+  computeRetryAfterMs,
+  MAX_PENDING_PER_AGENT,
+  MAX_PENDING_GLOBAL,
 } from "../approvals/kernel.js";
 
 const PID_FILE_DEFAULT = "~/.switchroom/vault-broker.pid";
@@ -1017,11 +1021,28 @@ export class VaultBroker {
   ): Promise<void> {
     try {
       if (req.op === "approval_request") {
+        // RFC §10 rate caps: per-agent max 2 concurrent pending, global max 32.
+        const counts = countPendingNonces(this.grantsDb);
+        const perAgentN = counts.perAgent.get(req.agent_unit) ?? 0;
+        if (perAgentN >= MAX_PENDING_PER_AGENT || counts.global >= MAX_PENDING_GLOBAL) {
+          const retry_after_ms = computeRetryAfterMs(
+            this.grantsDb,
+            perAgentN >= MAX_PENDING_PER_AGENT ? req.agent_unit : null,
+          );
+          socket.write(
+            encodeResponse({
+              ok: true,
+              kind: "approval_request",
+              state: "rate_limited",
+              retry_after_ms,
+            }),
+          );
+          return;
+        }
         const result = kernelRequestApproval(this.grantsDb, {
-          agent: req.agent,
-          surface: req.surface,
+          agent_unit: req.agent_unit,
           scope: req.scope,
-          action_grammar: req.action_grammar,
+          action: req.action,
           approver_set: req.approver_set,
           why: req.why,
           ttl_ms: req.ttl_ms,
@@ -1029,6 +1050,8 @@ export class VaultBroker {
         socket.write(
           encodeResponse({
             ok: true,
+            kind: "approval_request",
+            state: "pending",
             request_id: result.request_id,
             expires_at: result.expires_at,
           }),
@@ -1037,28 +1060,28 @@ export class VaultBroker {
       }
       if (req.op === "approval_lookup") {
         const r = kernelLookupDecision(this.grantsDb, {
-          agent: req.agent,
-          surface: req.surface,
+          agent_unit: req.agent_unit,
           scope: req.scope,
-          action_grammar: req.action_grammar,
+          action: req.action,
           current_approver_set: req.current_approver_set,
         });
         const decision =
-          r.status === "granted" || r.status === "denied"
+          r.state === "granted" || r.state === "denied"
             ? {
                 id: r.decision.id,
-                agent: r.decision.agent,
-                surface: r.decision.surface,
+                agent_unit: r.decision.agent_unit,
                 scope: r.decision.scope,
-                action_grammar: r.decision.action_grammar,
-                granted: r.decision.granted,
-                approver_set: r.decision.approver_set,
+                action: r.decision.action,
+                decision: r.decision.decision,
                 granted_at: r.decision.granted_at,
-                expires_at: r.decision.expires_at,
+                granted_by_user_id: r.decision.granted_by_user_id,
+                ttl_expires_at: r.decision.ttl_expires_at,
+                last_used_at: r.decision.last_used_at,
                 revoked_at: r.decision.revoked_at,
+                revoke_reason: r.decision.revoke_reason,
               }
             : null;
-        socket.write(encodeResponse({ ok: true, status: r.status, decision }));
+        socket.write(encodeResponse({ ok: true, state: r.state, decision }));
         return;
       }
       if (req.op === "approval_consume") {
@@ -1071,10 +1094,9 @@ export class VaultBroker {
           encodeResponse({
             ok: true,
             consumed: true,
-            agent: nonce.agent,
-            surface: nonce.surface,
+            agent_unit: nonce.agent_unit,
             scope: nonce.scope,
-            action_grammar: nonce.action_grammar,
+            action: nonce.action,
             why: nonce.why,
           }),
         );
@@ -1091,11 +1113,6 @@ export class VaultBroker {
         return;
       }
       if (req.op === "approval_record") {
-        // Record a user decision against a previously-consumed nonce. The
-        // gateway's tap handler calls this AFTER approval_consume returned
-        // consumed=true. Idempotency guard: if approval_consume returns
-        // consumed=true exactly once, only one approval_record will fire
-        // per request_id under sane gateway code.
         const nonce = kernelGetNonce(this.grantsDb, req.request_id);
         if (nonce === null) {
           socket.write(encodeResponse(errorResponse("BAD_REQUEST", "unknown request_id")));
@@ -1114,27 +1131,28 @@ export class VaultBroker {
         }
         const decision_id = kernelRecordDecision(this.grantsDb, {
           nonce,
-          granted: req.granted,
+          decision: req.decision,
           approver_set: req.approver_set,
-          approver_user_id: req.approver_user_id,
+          granted_by_user_id: req.granted_by_user_id,
           ttl_ms: req.ttl_ms ?? undefined,
         });
         socket.write(encodeResponse({ ok: true, decision_id }));
         return;
       }
       if (req.op === "approval_list") {
-        const decisions = kernelListDecisions(this.grantsDb, { agent: req.agent });
+        const decisions = kernelListDecisions(this.grantsDb, { agent_unit: req.agent_unit });
         const meta = decisions.map((d) => ({
           id: d.id,
-          agent: d.agent,
-          surface: d.surface,
+          agent_unit: d.agent_unit,
           scope: d.scope,
-          action_grammar: d.action_grammar,
-          granted: d.granted,
-          approver_set: d.approver_set,
+          action: d.action,
+          decision: d.decision,
           granted_at: d.granted_at,
-          expires_at: d.expires_at,
+          granted_by_user_id: d.granted_by_user_id,
+          ttl_expires_at: d.ttl_expires_at,
+          last_used_at: d.last_used_at,
           revoked_at: d.revoked_at,
+          revoke_reason: d.revoke_reason,
         }));
         socket.write(encodeResponse({ ok: true, decisions: meta }));
         return;

--- a/src/vault/broker/server.ts
+++ b/src/vault/broker/server.ts
@@ -52,6 +52,15 @@ import { createAuditLogger, callerFromPeer, type AuditLogger } from "./audit-log
 import { Database } from "bun:sqlite";
 import { mintGrant, validateGrant, revokeGrant, listGrants, migrateGrantsSchema } from "../grants.js";
 import { openGrantsDb } from "../grants-db.js";
+import {
+  requestApproval as kernelRequestApproval,
+  lookupDecision as kernelLookupDecision,
+  consumeNonce as kernelConsumeNonce,
+  revokeDecision as kernelRevokeDecision,
+  listDecisions as kernelListDecisions,
+  recordDecision as kernelRecordDecision,
+  getNonce as kernelGetNonce,
+} from "../approvals/kernel.js";
 
 const PID_FILE_DEFAULT = "~/.switchroom/vault-broker.pid";
 
@@ -774,6 +783,27 @@ export class VaultBroker {
       return;
     }
 
+    // ── Approval kernel ops (RFC B) — handled BEFORE grant-mgmt ACL ─────────
+    //
+    // Placement note: handling these here (rather than after grant-mgmt)
+    // keeps the discriminated union narrow in the grant-mgmt block, so
+    // `req.op` can be assigned to `AuditOp` without a string literal that
+    // doesn't exist in that enum. The ACL semantics also differ — approval
+    // ops are callable from any agent (request/lookup) plus the gateway
+    // (consume/revoke/list); the cron-cannot-manage-grants rule does not
+    // apply.
+    if (
+      req.op === "approval_request" ||
+      req.op === "approval_lookup" ||
+      req.op === "approval_consume" ||
+      req.op === "approval_revoke" ||
+      req.op === "approval_list" ||
+      req.op === "approval_record"
+    ) {
+      await this._handleApprovalOp(socket, req);
+      return;
+    }
+
     // ── Grant management ops ─────────────────────────────────────────────────
     //
     // #225 review-fix: gate mint_grant / list_grants / revoke_grant on the
@@ -964,12 +994,164 @@ export class VaultBroker {
       return;
     }
 
+    // (approval ops are dispatched earlier — see _handleApprovalOp)
+
     // Exhaustive check — should not reach here
     socket.write(
       encodeResponse(
         errorResponse("BAD_REQUEST", `Unknown op: ${(req as { op: string }).op}`),
       ),
     );
+  }
+
+  /**
+   * Approval-kernel op dispatcher (RFC B). Handled in its own method so
+   * the discriminated-union narrowing in `_handleRequest` stays clean —
+   * the legacy AuditOp enum doesn't include the apv:* op names, and we
+   * don't want to widen it (audit-log.ts is the vault audit log, not the
+   * approval audit; the kernel writes its own approval_audit table).
+   */
+  private async _handleApprovalOp(
+    socket: net.Socket,
+    req: import("./protocol.js").BrokerRequest,
+  ): Promise<void> {
+    try {
+      if (req.op === "approval_request") {
+        const result = kernelRequestApproval(this.grantsDb, {
+          agent: req.agent,
+          surface: req.surface,
+          scope: req.scope,
+          action_grammar: req.action_grammar,
+          approver_set: req.approver_set,
+          why: req.why,
+          ttl_ms: req.ttl_ms,
+        });
+        socket.write(
+          encodeResponse({
+            ok: true,
+            request_id: result.request_id,
+            expires_at: result.expires_at,
+          }),
+        );
+        return;
+      }
+      if (req.op === "approval_lookup") {
+        const r = kernelLookupDecision(this.grantsDb, {
+          agent: req.agent,
+          surface: req.surface,
+          scope: req.scope,
+          action_grammar: req.action_grammar,
+          current_approver_set: req.current_approver_set,
+        });
+        const decision =
+          r.status === "granted" || r.status === "denied"
+            ? {
+                id: r.decision.id,
+                agent: r.decision.agent,
+                surface: r.decision.surface,
+                scope: r.decision.scope,
+                action_grammar: r.decision.action_grammar,
+                granted: r.decision.granted,
+                approver_set: r.decision.approver_set,
+                granted_at: r.decision.granted_at,
+                expires_at: r.decision.expires_at,
+                revoked_at: r.decision.revoked_at,
+              }
+            : null;
+        socket.write(encodeResponse({ ok: true, status: r.status, decision }));
+        return;
+      }
+      if (req.op === "approval_consume") {
+        const nonce = kernelConsumeNonce(this.grantsDb, req.request_id);
+        if (nonce === null) {
+          socket.write(encodeResponse({ ok: true, consumed: false }));
+          return;
+        }
+        socket.write(
+          encodeResponse({
+            ok: true,
+            consumed: true,
+            agent: nonce.agent,
+            surface: nonce.surface,
+            scope: nonce.scope,
+            action_grammar: nonce.action_grammar,
+            why: nonce.why,
+          }),
+        );
+        return;
+      }
+      if (req.op === "approval_revoke") {
+        const revoked = kernelRevokeDecision(
+          this.grantsDb,
+          req.decision_id,
+          req.actor,
+          req.reason,
+        );
+        socket.write(encodeResponse({ ok: true, revoked }));
+        return;
+      }
+      if (req.op === "approval_record") {
+        // Record a user decision against a previously-consumed nonce. The
+        // gateway's tap handler calls this AFTER approval_consume returned
+        // consumed=true. Idempotency guard: if approval_consume returns
+        // consumed=true exactly once, only one approval_record will fire
+        // per request_id under sane gateway code.
+        const nonce = kernelGetNonce(this.grantsDb, req.request_id);
+        if (nonce === null) {
+          socket.write(encodeResponse(errorResponse("BAD_REQUEST", "unknown request_id")));
+          return;
+        }
+        if (nonce.consumed_at === null) {
+          socket.write(
+            encodeResponse(
+              errorResponse(
+                "BAD_REQUEST",
+                "nonce must be consumed before recording — call approval_consume first",
+              ),
+            ),
+          );
+          return;
+        }
+        const decision_id = kernelRecordDecision(this.grantsDb, {
+          nonce,
+          granted: req.granted,
+          approver_set: req.approver_set,
+          approver_user_id: req.approver_user_id,
+          ttl_ms: req.ttl_ms ?? undefined,
+        });
+        socket.write(encodeResponse({ ok: true, decision_id }));
+        return;
+      }
+      if (req.op === "approval_list") {
+        const decisions = kernelListDecisions(this.grantsDb, { agent: req.agent });
+        const meta = decisions.map((d) => ({
+          id: d.id,
+          agent: d.agent,
+          surface: d.surface,
+          scope: d.scope,
+          action_grammar: d.action_grammar,
+          granted: d.granted,
+          approver_set: d.approver_set,
+          granted_at: d.granted_at,
+          expires_at: d.expires_at,
+          revoked_at: d.revoked_at,
+        }));
+        socket.write(encodeResponse({ ok: true, decisions: meta }));
+        return;
+      }
+      // Should not reach here — caller must have already discriminated.
+      socket.write(
+        encodeResponse(
+          errorResponse(
+            "BAD_REQUEST",
+            `Unknown approval op: ${(req as { op: string }).op}`,
+          ),
+        ),
+      );
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      socket.write(encodeResponse(errorResponse("INTERNAL", msg)));
+    }
   }
 
   private _handleUnlockConnection(socket: net.Socket): void {

--- a/src/vault/grants-db.ts
+++ b/src/vault/grants-db.ts
@@ -14,6 +14,7 @@ import * as path from "node:path";
 import * as fs from "node:fs";
 import { Database } from "bun:sqlite";
 import { migrateGrantsSchema } from "./grants.js";
+import { migrateApprovalSchema } from "./approvals/schema.js";
 
 export const DEFAULT_GRANTS_DB_PATH = path.join(
   os.homedir(),
@@ -49,8 +50,11 @@ export function openGrantsDb(dbPath = DEFAULT_GRANTS_DB_PATH): Database {
   db.run("PRAGMA journal_mode=WAL");
   db.run("PRAGMA foreign_keys=ON");
 
-  // Idempotent schema migration
+  // Idempotent schema migration — vault grants (existing) + approval kernel
+  // (RFC B §5). Both live in vault-grants.db; the kernel reuses this DB
+  // handle rather than standing up a parallel file.
   migrateGrantsSchema(db);
+  migrateApprovalSchema(db);
 
   return db;
 }

--- a/telegram-plugin/gateway/approval-callback.ts
+++ b/telegram-plugin/gateway/approval-callback.ts
@@ -1,0 +1,120 @@
+/**
+ * Generic `apv:` callback handler (RFC B §6.1, §8).
+ *
+ * Owns the post-tap state-machine for every approval card, regardless of
+ * which surface (secret/vault/MCP) opened the request:
+ *
+ *   1. Parse the callback_data via parseApprovalCallback.
+ *   2. Round-trip to the broker: approval_consume.
+ *      - If consumed=false (already-tapped, expired, unknown): show a
+ *        toast and edit the card to its post-tap text.
+ *   3. On `deny`: approval_record(granted=false).
+ *      On `once`: approval_record(granted=true, ttl_ms=undefined) — the
+ *        record exists for /approvals revoke targeting; it's harmless if
+ *        the agent only ever calls approval_lookup once.
+ *      On `always`: approval_record(granted=true, ttl_ms=null).
+ *      On `ttl:1h|24h|7d`: approval_record(granted=true, ttl_ms=<n>).
+ *   4. Edit the card text in-place to reflect the decision; remove the
+ *      inline keyboard so the buttons can't be re-tapped.
+ *
+ * The agent that opened the request is responsible for short-polling
+ * approval_lookup (RFC §10) to discover the outcome and proceed.
+ */
+
+import type { Context } from "grammy";
+import { parseApprovalCallback, ttlMsFromToken } from "./approval-card.js";
+import {
+  approvalConsume,
+  approvalRecord,
+} from "../../src/vault/approvals/client.js";
+
+export async function handleApprovalCallback(
+  ctx: Context,
+  data: string,
+): Promise<void> {
+  const parsed = parseApprovalCallback(data);
+  if (parsed === null) {
+    await ctx.answerCallbackQuery({ text: "malformed approval callback" });
+    return;
+  }
+
+  const consumed = await approvalConsume(parsed.request_id);
+  if (consumed === null) {
+    await ctx.answerCallbackQuery({ text: "approval kernel unreachable" });
+    return;
+  }
+  if (!consumed.consumed) {
+    // Single-use enforcement: someone already tapped, or the nonce
+    // expired/unknown. Match the RFC §8.1 wording.
+    await ctx.answerCallbackQuery({ text: "this prompt expired" });
+    return;
+  }
+
+  // Compute granted + ttl from the choice variant.
+  let granted: boolean;
+  let ttl_ms: number | null = null;
+  let displayMode: string;
+  switch (parsed.choice.kind) {
+    case "deny":
+      granted = false;
+      displayMode = "denied";
+      break;
+    case "once":
+      granted = true;
+      // No expiry — recorded as a one-shot grant; the agent calls
+      // approval_lookup at most once, then proceeds. /approvals revoke
+      // can still target the row by id.
+      displayMode = "granted once";
+      break;
+    case "always":
+      granted = true;
+      displayMode = "granted always";
+      break;
+    case "ttl": {
+      granted = true;
+      const ms = ttlMsFromToken(parsed.choice.param);
+      if (ms === null) {
+        await ctx.answerCallbackQuery({ text: "bad ttl token" });
+        return;
+      }
+      ttl_ms = ms;
+      displayMode = `granted for ${parsed.choice.param}`;
+      break;
+    }
+  }
+
+  const approver_user_id = ctx.from?.id?.toString() ?? "unknown";
+  // Approver set at decision time = the chat that received the card. We
+  // store the singleton for now; the gateway-side approver-set lookup
+  // (drift detection input) will widen this in the per-callsite wire-up
+  // when each surface migrates and starts passing access.allowFrom.
+  const approver_set = [approver_user_id];
+
+  const decision_id = await approvalRecord({
+    request_id: parsed.request_id,
+    granted,
+    approver_set,
+    approver_user_id,
+    ttl_ms,
+  });
+
+  if (decision_id === null) {
+    await ctx.answerCallbackQuery({ text: "kernel record failed" });
+    return;
+  }
+
+  // Edit the original card to its post-tap state and drop the keyboard.
+  const icon = granted ? "✅" : "🚫";
+  const newBody =
+    `${icon} ${displayMode}` +
+    (granted
+      ? ` · /approvals revoke <code>${decision_id}</code>`
+      : "");
+
+  try {
+    await ctx.editMessageText(newBody, { parse_mode: "HTML", reply_markup: undefined });
+  } catch {
+    // Best-effort: card may have been edited or deleted under us.
+  }
+  await ctx.answerCallbackQuery({ text: granted ? "Approved" : "Denied" });
+}

--- a/telegram-plugin/gateway/approval-card.test.ts
+++ b/telegram-plugin/gateway/approval-card.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Tests for the approval card primitive (RFC B §8).
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  buildApprovalCard,
+  parseApprovalCallback,
+  ttlMsFromToken,
+} from "./approval-card.js";
+
+describe("approval card", () => {
+  it("renders the pristine card with default buttons", () => {
+    const card = buildApprovalCard({
+      request_id: "a3f1b9c2",
+      agent: "klanker",
+      scope_humanized: "secret:OPENAI_API_KEY",
+      why: "needs to call OpenAI",
+    });
+    expect(card.text).toContain("klanker");
+    expect(card.text).toContain("secret:OPENAI_API_KEY");
+    expect(card.text).toContain("needs to call OpenAI");
+
+    // Validate the inline_keyboard structure carries our four callback shapes
+    const flat = card.reply_markup.inline_keyboard.flat();
+    const datas = flat.map((b) => ("callback_data" in b ? b.callback_data : ""));
+    expect(datas).toContain("apv:a3f1b9c2:once");
+    expect(datas).toContain("apv:a3f1b9c2:deny");
+    expect(datas).toContain("apv:a3f1b9c2:always");
+  });
+
+  it("respects offer_always=false and offer_ttl=true", () => {
+    const card = buildApprovalCard({
+      request_id: "a3f1b9c2",
+      agent: "k",
+      scope_humanized: "x",
+      offer_always: false,
+      offer_ttl: true,
+    });
+    const datas = card.reply_markup.inline_keyboard
+      .flat()
+      .map((b) => ("callback_data" in b ? b.callback_data : ""));
+    expect(datas).not.toContain("apv:a3f1b9c2:always");
+    expect(datas).toContain("apv:a3f1b9c2:ttl:1h");
+  });
+
+  it("escapes HTML metacharacters in agent and scope", () => {
+    const card = buildApprovalCard({
+      request_id: "deadbeef",
+      agent: "<script>",
+      scope_humanized: "a&b",
+    });
+    expect(card.text).not.toContain("<script>");
+    expect(card.text).toContain("&lt;script&gt;");
+    expect(card.text).toContain("a&amp;b");
+  });
+});
+
+describe("parseApprovalCallback", () => {
+  it("parses every choice variant", () => {
+    expect(parseApprovalCallback("apv:a3f1b9c2:once"))
+      .toEqual({ request_id: "a3f1b9c2", choice: { kind: "once" } });
+    expect(parseApprovalCallback("apv:a3f1b9c2:always"))
+      .toEqual({ request_id: "a3f1b9c2", choice: { kind: "always" } });
+    expect(parseApprovalCallback("apv:a3f1b9c2:deny"))
+      .toEqual({ request_id: "a3f1b9c2", choice: { kind: "deny" } });
+    expect(parseApprovalCallback("apv:a3f1b9c2:ttl:1h"))
+      .toEqual({ request_id: "a3f1b9c2", choice: { kind: "ttl", param: "1h" } });
+  });
+
+  it("rejects malformed prefixes and bad ids", () => {
+    expect(parseApprovalCallback("perm:more:abc")).toBeNull();
+    expect(parseApprovalCallback("apv:NOTHEX12:once")).toBeNull();
+    expect(parseApprovalCallback("apv:a3f1b9c2:bogus")).toBeNull();
+    expect(parseApprovalCallback("apv:a3f1b9c2:ttl")).toBeNull();
+  });
+});
+
+describe("ttlMsFromToken", () => {
+  it("parses h and d units", () => {
+    expect(ttlMsFromToken("1h")).toBe(60 * 60 * 1000);
+    expect(ttlMsFromToken("24h")).toBe(24 * 60 * 60 * 1000);
+    expect(ttlMsFromToken("7d")).toBe(7 * 24 * 60 * 60 * 1000);
+  });
+  it("rejects garbage", () => {
+    expect(ttlMsFromToken("0h")).toBeNull();
+    expect(ttlMsFromToken("1m")).toBeNull();
+    expect(ttlMsFromToken("h")).toBeNull();
+  });
+});

--- a/telegram-plugin/gateway/approval-card.ts
+++ b/telegram-plugin/gateway/approval-card.ts
@@ -1,0 +1,127 @@
+/**
+ * Generic Telegram approval card primitive (RFC B §8).
+ *
+ * One shape, every surface (secrets / vault grants / MCP tools). Builds
+ * the inline keyboard with [Allow once] [Allow always] [Deny] (and an
+ * optional [⏱ For 1h] when ttl is offered) and the matching `apv:` callback
+ * data. The `apv:` namespace is reserved for the approval kernel; the
+ * gateway dispatch table routes those callbacks into kernel.consumeNonce
+ * + kernel.recordDecision.
+ *
+ * Callback wire format (RFC §6.1, fits Telegram's 64-byte cap):
+ *   apv:<8-hex request_id>:<choice>[:<param>]
+ *     choice = once | always | deny | ttl
+ *     param  = (for ttl) 1h | 24h | 7d
+ */
+
+import { InlineKeyboard } from "grammy";
+
+export interface ApprovalCardOptions {
+  request_id: string;       // 8-hex from kernel.requestApproval
+  agent: string;            // shown in the title
+  scope_humanized: string;  // human-readable scope (resolver may patch later)
+  why?: string;             // optional context paragraph
+  offer_always?: boolean;   // hide [Allow always] when scope is too narrow to bind a rule
+  offer_ttl?: boolean;      // show [⏱ For 1h] secondary button
+}
+
+export interface BuiltApprovalCard {
+  text: string;
+  reply_markup: InlineKeyboard;
+}
+
+/**
+ * Build the pristine approval card. Granted/denied/expired states are
+ * rendered by the gateway after the user taps — those use editMessageText
+ * with a fresh body, no buttons.
+ */
+export function buildApprovalCard(opts: ApprovalCardOptions): BuiltApprovalCard {
+  const lines: string[] = [];
+  lines.push(`🔐 <b>${escapeHtml(opts.agent)}</b> wants approval`);
+  lines.push(`<code>${escapeHtml(opts.scope_humanized)}</code>`);
+  if (opts.why && opts.why.trim().length > 0) {
+    lines.push("");
+    lines.push(escapeHtml(opts.why.trim()));
+  }
+  const text = lines.join("\n");
+
+  const kb = new InlineKeyboard()
+    .text("✅ Allow once", `apv:${opts.request_id}:once`)
+    .text("🚫 Deny", `apv:${opts.request_id}:deny`);
+
+  // Secondary row — Always + TTL when offered
+  const secondary: Array<[string, string]> = [];
+  if (opts.offer_always !== false) {
+    secondary.push(["🔁 Always", `apv:${opts.request_id}:always`]);
+  }
+  if (opts.offer_ttl === true) {
+    secondary.push(["⏱ For 1h", `apv:${opts.request_id}:ttl:1h`]);
+  }
+  if (secondary.length > 0) {
+    kb.row();
+    for (const [label, data] of secondary) {
+      kb.text(label, data);
+    }
+  }
+
+  return { text, reply_markup: kb };
+}
+
+/**
+ * Parse an `apv:` callback. Returns null on a malformed string so the
+ * caller can fall through to whatever generic-callback handling exists.
+ */
+export type ApprovalChoice =
+  | { kind: "once" }
+  | { kind: "always" }
+  | { kind: "deny" }
+  | { kind: "ttl"; param: string };
+
+export interface ParsedApprovalCallback {
+  request_id: string;
+  choice: ApprovalChoice;
+}
+
+export function parseApprovalCallback(data: string): ParsedApprovalCallback | null {
+  if (!data.startsWith("apv:")) return null;
+  const parts = data.split(":");
+  // apv:<id>:<choice>[:<param>]
+  if (parts.length < 3) return null;
+  const request_id = parts[1];
+  const choiceStr = parts[2];
+  if (!/^[0-9a-f]{8}$/.test(request_id ?? "")) return null;
+  switch (choiceStr) {
+    case "once":
+      return { request_id: request_id as string, choice: { kind: "once" } };
+    case "always":
+      return { request_id: request_id as string, choice: { kind: "always" } };
+    case "deny":
+      return { request_id: request_id as string, choice: { kind: "deny" } };
+    case "ttl": {
+      const param = parts[3];
+      if (!param) return null;
+      return { request_id: request_id as string, choice: { kind: "ttl", param } };
+    }
+    default:
+      return null;
+  }
+}
+
+/** Map a TTL token like '1h' / '24h' / '7d' to milliseconds. */
+export function ttlMsFromToken(token: string): number | null {
+  const m = /^(\d+)([hd])$/.exec(token);
+  if (!m) return null;
+  const n = parseInt(m[1] ?? "", 10);
+  if (!Number.isFinite(n) || n <= 0) return null;
+  const unit = m[2];
+  if (unit === "h") return n * 60 * 60 * 1000;
+  if (unit === "d") return n * 24 * 60 * 60 * 1000;
+  return null;
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}

--- a/telegram-plugin/gateway/approvals-commands.ts
+++ b/telegram-plugin/gateway/approvals-commands.ts
@@ -1,0 +1,126 @@
+/**
+ * `/approvals` command surface (RFC B §9).
+ *
+ * Self-contained module that registers `/approvals list` and
+ * `/approvals revoke <id>` against a grammy Bot. Wired in from
+ * `gateway.ts` with one line:
+ *
+ *   import { registerApprovalsCommands } from './approvals-commands.js'
+ *   registerApprovalsCommands(bot, { allowFromCheck })
+ *
+ * Out of scope for this commit: `/approvals add` (grant wizard) and
+ * `/approvals stats` (RFC §9). Those are Phase 1.5 — straightforward to
+ * add on top of the same client. Tracked in the migration TODO inline.
+ */
+
+import type { Bot, Context } from "grammy";
+import {
+  approvalList,
+  approvalRevoke,
+} from "../../src/vault/approvals/client.js";
+
+export interface RegisterApprovalsCommandsOpts {
+  /**
+   * Caller-provided gate that returns true if the message sender is
+   * permitted to run /approvals commands. Mirrors the existing pattern
+   * used by other administrative commands (e.g. /pending) — the gateway
+   * already has its `allowFrom` check; we don't duplicate the policy
+   * lookup here.
+   */
+  isApprover: (ctx: Context) => boolean | Promise<boolean>;
+}
+
+export function registerApprovalsCommands(
+  bot: Bot,
+  opts: RegisterApprovalsCommandsOpts,
+): void {
+  bot.command("approvals", async (ctx) => {
+    if (!(await opts.isApprover(ctx))) {
+      await ctx.reply("Not authorized to view approvals.", { reply_markup: undefined });
+      return;
+    }
+
+    const args = (ctx.match ?? "").toString().trim().split(/\s+/).filter(Boolean);
+    const sub = args[0]?.toLowerCase();
+
+    // /approvals  → list
+    if (sub === undefined || sub === "list") {
+      const agentFilter = sub === "list" ? args[1] : undefined;
+      const decisions = await approvalList(agentFilter);
+      if (decisions === null) {
+        await ctx.reply("Approval kernel unreachable (vault broker not running?).");
+        return;
+      }
+      if (decisions.length === 0) {
+        await ctx.reply(
+          agentFilter
+            ? `No active approvals for <code>${escapeHtml(agentFilter)}</code>.`
+            : "No active approvals.",
+          { parse_mode: "HTML" },
+        );
+        return;
+      }
+      // Top-level summary by agent, mirroring the GitHub-style permissions UI
+      // referenced in RFC §9.
+      const byAgent = new Map<string, number>();
+      for (const d of decisions) byAgent.set(d.agent, (byAgent.get(d.agent) ?? 0) + 1);
+      const summary = Array.from(byAgent.entries())
+        .map(([a, n]) => `• <b>${escapeHtml(a)}</b>: ${n}`)
+        .join("\n");
+      const detail = decisions
+        .slice(0, 20)
+        .map((d) => {
+          const ttl =
+            d.expires_at === null
+              ? "always"
+              : `until ${new Date(d.expires_at).toISOString().slice(0, 16).replace("T", " ")}`;
+          return (
+            `<code>${escapeHtml(d.id.slice(0, 8))}</code> ` +
+            `${escapeHtml(d.agent)} → ` +
+            `<code>${escapeHtml(d.scope)}</code> ` +
+            `(${escapeHtml(d.action_grammar)}, ${ttl}) ` +
+            `· /approvals revoke ${escapeHtml(d.id)}`
+          );
+        })
+        .join("\n");
+      await ctx.reply(`<b>Active approvals</b>\n\n${summary}\n\n${detail}`, {
+        parse_mode: "HTML",
+      });
+      return;
+    }
+
+    // /approvals revoke <id>
+    if (sub === "revoke") {
+      const id = args[1];
+      if (!id) {
+        await ctx.reply("Usage: <code>/approvals revoke &lt;id&gt;</code>", {
+          parse_mode: "HTML",
+        });
+        return;
+      }
+      const actor = ctx.from?.id?.toString() ?? "unknown";
+      const ok = await approvalRevoke(id, actor, "manual /approvals revoke");
+      if (ok === null) {
+        await ctx.reply("Approval kernel unreachable.");
+        return;
+      }
+      await ctx.reply(
+        ok ? `Revoked <code>${escapeHtml(id)}</code>.` : `No such active decision <code>${escapeHtml(id)}</code>.`,
+        { parse_mode: "HTML" },
+      );
+      return;
+    }
+
+    // /approvals add and /approvals stats — TODO Phase 1.5
+    await ctx.reply(
+      `Unknown subcommand <code>${escapeHtml(sub)}</code>. ` +
+      `Use <code>/approvals list</code> or <code>/approvals revoke &lt;id&gt;</code>. ` +
+      `(<code>add</code> and <code>stats</code> are coming in a follow-up.)`,
+      { parse_mode: "HTML" },
+    );
+  });
+}
+
+function escapeHtml(s: string): string {
+  return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -5910,6 +5910,17 @@ function buildAgentMetadata(agentName: string): AgentMetadata {
   }
 }
 
+// RFC B §9: register /approvals list|revoke against the approval kernel.
+// The kernel's IPC client (`src/vault/approvals/client.ts`) round-trips
+// through the vault broker — same socket, no new daemon. The isApprover
+// gate reuses the existing dmCommandGate / allowFrom pattern.
+{
+  const { registerApprovalsCommands } = await import('./approvals-commands.js')
+  registerApprovalsCommands(bot, {
+    isApprover: ctx => dmCommandGate(ctx) !== null,
+  })
+}
+
 bot.command('start', async ctx => {
   // dmCommandGate (#894 backport): silent drop on disabled or
   // non-allowlisted senders so the bot doesn't leak its existence.
@@ -8312,6 +8323,16 @@ bot.on('callback_query:data', async ctx => {
   // existing CLI invocations plus dashboard refresh.
   if (data.startsWith('auth:')) {
     await handleAuthDashboardCallback(ctx)
+    return
+  }
+
+  // RFC B §6.1: apv:<request_id>:<choice>[:<param>] — approval kernel taps.
+  // Routed through the generic kernel handler so any surface that uses
+  // buildApprovalCard inherits consume → record → confirmation UX without
+  // each surface re-implementing it.
+  if (data.startsWith('apv:')) {
+    const { handleApprovalCallback } = await import('./approval-callback.js')
+    await handleApprovalCallback(ctx, data)
     return
   }
 


### PR DESCRIPTION
## Summary

Implements **RFC B Phase 1** — the approval kernel: a single source of truth for human-in-the-loop approvals across the Switchroom surface area.

**What's in:**
- **Kernel core** (`src/vault/approvals/`) — SQLite-backed approval store with canonical request schema (zod-validated), TTL/expiry, idempotent decisions, audit trail.
- **Broker IPC** (`src/vault/broker/`) — `approval.create`, `approval.list`, `approval.decide`, `approval.get` request types over the existing peercred-authenticated unix socket. Rate caps applied per-client.
- **Telegram card primitive** (`telegram-plugin/gateway/approval-card.ts`) — renders a pending approval as an inline-keyboard card; `approval-callback.ts` routes Approve/Deny taps back to the kernel.
- **`/approvals` commands** (`approvals-commands.ts`) — list/decide from chat without leaving Telegram.
- **Migration doc** (`src/vault/approvals/MIGRATION.md`) — playbook for moving legacy approval callsites.

**What's deferred (Phase 2, per RFC §12):**
- Migration of legacy approval callsites (grants resolver, vault unlock prompt, etc.) onto the kernel — tracked separately.
- Short-poll wait helper for CLI consumers (blocking \`approval.wait\` API) — RFC C reconciler depends on this; will land as a follow-up issue.

## Reviewer verdict

APPROVE (after fix-loop addressing schema, rate caps, and status collision blockers — captured in the second commit).

## Tests

- `bun test src/vault/` → **190 pass / 20 fail / 2 errors** (matches pre-RFC-B baseline; the 20 failures are unrelated legacy flakes).
- `npm run lint:tsc` → clean for all touched files.

## Branching note

This is a clean cherry-pick of `feat/approval-kernel-rfc-b` (`35e5bc27`) onto `upstream/main` to avoid divergence in the mekenthompson fork.