### PR TITLE
feat(drive): Google Drive MCP integration (RFC C)

### DIFF
--- a/docs/rfcs/gdrive-mcp.md
+++ b/docs/rfcs/gdrive-mcp.md
@@ -12,7 +12,7 @@ Add a Google Drive MCP server so agents can read and (with explicit approval) wr
 
 ## 2. MCP server choice
 
-**Pinned:** [`taylorwilsdon/google_workspace_mcp`](https://github.com/taylorwilsdon/google_workspace_mcp), pin tag `v0.5.x` (latest stable as of 2026-05). Track a specific commit SHA in `switchroom.yaml` rather than a floating tag so upgrades are explicit.
+**Pinned:** [`taylorwilsdon/google_workspace_mcp`](https://github.com/taylorwilsdon/google_workspace_mcp), pinned to **v1.20.3** (commit `f3c7dc5df2641c8545abc9e8f402d794f2853745`), MIT-licensed. The RFC originally targeted `v0.5.x`, but no such tag exists upstream — v1.20.3 is the validated pin used by the implementation. Track the explicit commit SHA in `switchroom.yaml` rather than a floating tag so upgrades are explicit.
 
 - **Runtime:** Python 3.11+, run via `uvx` so no system-wide install is required. Switchroom's existing MCP-subprocess machinery already supports `uvx`-launched servers.
 - **License:** MIT.

--- a/src/drive/disconnect.test.ts
+++ b/src/drive/disconnect.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Killswitch / disconnect path tests (RFC C §4.3).
+ *
+ * The load-bearing assertion: local cleanup ALWAYS happens, even when the
+ * Google revoke endpoint fails or the network is down. The user is told
+ * about the Google failure separately so they can manually revoke at
+ * myaccount.google.com/permissions.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+import { mkdtempSync, rmSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { disconnectDrive } from "./disconnect.js";
+import { writeRefreshToken, readRefreshToken } from "./vault-slots.js";
+import { createVault } from "../vault/vault.js";
+
+let dir: string;
+let vaultPath: string;
+const PASS = "test-pass";
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "drive-disconnect-"));
+  vaultPath = join(dir, "vault.enc");
+  createVault(PASS, vaultPath);
+  writeRefreshToken({
+    passphrase: PASS,
+    vaultPath,
+    agentUnit: "klanker",
+    refreshToken: "rt-abc",
+  });
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe("disconnectDrive", () => {
+  it("clears local slots even when Google revoke fails", async () => {
+    const fakeFetch = mock(
+      async () => new Response("oops", { status: 503 }),
+    ) as unknown as typeof fetch;
+    const r = await disconnectDrive({
+      passphrase: PASS,
+      vaultPath,
+      agentUnit: "klanker",
+      fetchImpl: fakeFetch,
+    });
+
+    expect(r.local_revoked).toBe(true);
+    expect(r.google_revoke).toBe("failed");
+    expect(
+      readRefreshToken({ passphrase: PASS, vaultPath, agentUnit: "klanker" }),
+    ).toBe(null);
+  });
+
+  it("clears local slots even when fetch itself throws (network down)", async () => {
+    const fakeFetch = mock(async () => {
+      throw new Error("ECONNREFUSED");
+    }) as unknown as typeof fetch;
+    const r = await disconnectDrive({
+      passphrase: PASS,
+      vaultPath,
+      agentUnit: "klanker",
+      fetchImpl: fakeFetch,
+    });
+
+    expect(r.local_revoked).toBe(true);
+    expect(r.google_revoke).toBe("failed");
+    expect(
+      readRefreshToken({ passphrase: PASS, vaultPath, agentUnit: "klanker" }),
+    ).toBe(null);
+  });
+
+  it("returns ok when Google accepts the revoke", async () => {
+    const fakeFetch = mock(
+      async () => new Response("", { status: 200 }),
+    ) as unknown as typeof fetch;
+    const r = await disconnectDrive({
+      passphrase: PASS,
+      vaultPath,
+      agentUnit: "klanker",
+      fetchImpl: fakeFetch,
+    });
+    expect(r.google_revoke).toBe("ok");
+    expect(r.local_revoked).toBe(true);
+  });
+
+  it("skipped when no refresh token is present (idempotent revoke)", async () => {
+    // Wipe first
+    await disconnectDrive({
+      passphrase: PASS,
+      vaultPath,
+      agentUnit: "klanker",
+      fetchImpl: mock(async () => new Response("", { status: 200 })) as unknown as typeof fetch,
+    });
+    // Second call — slot already empty
+    const r = await disconnectDrive({
+      passphrase: PASS,
+      vaultPath,
+      agentUnit: "klanker",
+      fetchImpl: mock(async () => new Response("", { status: 200 })) as unknown as typeof fetch,
+    });
+    expect(r.google_revoke).toBe("skipped");
+    expect(r.local_revoked).toBe(true);
+  });
+
+  it("vault file still exists after disconnect (we wipe slots, not the vault)", async () => {
+    await disconnectDrive({
+      passphrase: PASS,
+      vaultPath,
+      agentUnit: "klanker",
+      fetchImpl: mock(async () => new Response("", { status: 200 })) as unknown as typeof fetch,
+    });
+    expect(existsSync(vaultPath)).toBe(true);
+  });
+});

--- a/src/drive/disconnect.ts
+++ b/src/drive/disconnect.ts
@@ -1,10 +1,10 @@
 /**
  * Drive disconnect / killswitch path per RFC C §4.3.
  *
- * Order of operations matters: revoke locally FIRST so a Google API outage
- * cannot leave the agent with a live refresh token in vault. Best-effort
- * Google revoke runs after; failure is surfaced but does NOT block local
- * cleanup.
+ * Order of operations matters: delete the local refresh token before
+ * contacting Google so an outage can't leave a live token in vault.
+ * Best-effort Google revoke runs after; failure is surfaced but does NOT
+ * block local cleanup.
  *
  * Composes the OAuth `revokeRefreshToken()` helper with the vault-slot
  * `deleteSlots()` helper. Returned record tells the caller (CLI, killswitch

--- a/src/drive/disconnect.ts
+++ b/src/drive/disconnect.ts
@@ -1,0 +1,78 @@
+/**
+ * Drive disconnect / killswitch path per RFC C §4.3.
+ *
+ * Order of operations matters: revoke locally FIRST so a Google API outage
+ * cannot leave the agent with a live refresh token in vault. Best-effort
+ * Google revoke runs after; failure is surfaced but does NOT block local
+ * cleanup.
+ *
+ * Composes the OAuth `revokeRefreshToken()` helper with the vault-slot
+ * `deleteSlots()` helper. Returned record tells the caller (CLI, killswitch
+ * orchestrator) what happened so the user can be told "we cleared it on our
+ * end, but Google's revoke endpoint failed — visit
+ * myaccount.google.com/permissions to be sure."
+ */
+
+import { revokeRefreshToken } from "./oauth.js";
+import { deleteSlots, readRefreshToken } from "./vault-slots.js";
+
+export interface DisconnectResult {
+  /** The agent slug we disconnected. */
+  agent_unit: string;
+  /** True iff the local vault slots were removed (or were already absent). */
+  local_revoked: boolean;
+  /**
+   * `ok` — Google's revoke endpoint accepted the token (or already rejected
+   *        it as invalid, which we count as "consistent").
+   * `failed` — Google rejected the revoke for an unexpected reason.
+   * `skipped` — there was no refresh token to revoke (slot already empty).
+   */
+  google_revoke: "ok" | "failed" | "skipped";
+  google_revoke_detail?: string;
+}
+
+export async function disconnectDrive(args: {
+  passphrase: string;
+  vaultPath: string;
+  agentUnit: string;
+  fetchImpl?: typeof fetch;
+}): Promise<DisconnectResult> {
+  const result: DisconnectResult = {
+    agent_unit: args.agentUnit,
+    local_revoked: false,
+    google_revoke: "skipped",
+  };
+
+  // Read FIRST (so we have the token to send to Google), then delete locally
+  // before contacting Google. If the network call hangs or fails, the local
+  // state is still cleaned up — which is what the killswitch promises.
+  let refreshToken: string | null = null;
+  try {
+    refreshToken = readRefreshToken({
+      passphrase: args.passphrase,
+      vaultPath: args.vaultPath,
+      agentUnit: args.agentUnit,
+    });
+  } catch {
+    refreshToken = null;
+  }
+
+  deleteSlots({
+    passphrase: args.passphrase,
+    vaultPath: args.vaultPath,
+    agentUnit: args.agentUnit,
+  });
+  result.local_revoked = true;
+
+  if (refreshToken) {
+    const r = await revokeRefreshToken(refreshToken, args.fetchImpl);
+    if (r.ok) {
+      result.google_revoke = "ok";
+    } else {
+      result.google_revoke = "failed";
+      result.google_revoke_detail = `${r.status}: ${r.detail}`;
+    }
+  }
+
+  return result;
+}

--- a/src/drive/grants.test.ts
+++ b/src/drive/grants.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Drive grants — write-namespace separation tests (RFC C §12).
+ */
+
+import { describe, expect, it } from "bun:test";
+import { scopeFor, canFulfill, prefixMatches } from "./grants.js";
+
+describe("scopeFor", () => {
+  it("read all → doc:gdrive:**", () => {
+    expect(scopeFor({ kind: "all" }, "read")).toBe("doc:gdrive:**");
+  });
+  it("write all → doc:gdrive:write:**", () => {
+    expect(scopeFor({ kind: "all" }, "write")).toBe("doc:gdrive:write:**");
+  });
+  it("read folder", () => {
+    expect(scopeFor({ kind: "folder", folder_id: "F1" }, "read")).toBe(
+      "doc:gdrive:folder/F1/**",
+    );
+  });
+  it("write folder", () => {
+    expect(scopeFor({ kind: "folder", folder_id: "F1" }, "write")).toBe(
+      "doc:gdrive:write:folder/F1/**",
+    );
+  });
+  it("read doc", () => {
+    expect(scopeFor({ kind: "doc", doc_id: "D1" }, "read")).toBe(
+      "doc:gdrive:D1",
+    );
+  });
+  it("write doc", () => {
+    expect(scopeFor({ kind: "doc", doc_id: "D1" }, "write")).toBe(
+      "doc:gdrive:write:D1",
+    );
+  });
+});
+
+describe("canFulfill — write isolation (the load-bearing rule)", () => {
+  it("read grant CANNOT fulfill a write request, even on the same doc id", () => {
+    expect(
+      canFulfill({
+        decisionScope: "doc:gdrive:D1",
+        decisionAction: "read",
+        requestedScope: "doc:gdrive:write:D1",
+        requestedAction: "write",
+      }),
+    ).toBe(false);
+  });
+
+  it("read grant on doc:gdrive:** CANNOT fulfill a write request", () => {
+    expect(
+      canFulfill({
+        decisionScope: "doc:gdrive:**",
+        decisionAction: "read",
+        requestedScope: "doc:gdrive:write:D1",
+        requestedAction: "write",
+      }),
+    ).toBe(false);
+  });
+
+  it("write grant CAN fulfill a write request on a covered doc", () => {
+    expect(
+      canFulfill({
+        decisionScope: "doc:gdrive:write:**",
+        decisionAction: "write",
+        requestedScope: "doc:gdrive:write:D1",
+        requestedAction: "write",
+      }),
+    ).toBe(true);
+  });
+
+  it("read grant fulfills a read request via prefix match", () => {
+    expect(
+      canFulfill({
+        decisionScope: "doc:gdrive:folder/F1/**",
+        decisionAction: "read",
+        requestedScope: "doc:gdrive:folder/F1/sub/D1",
+        requestedAction: "read",
+      }),
+    ).toBe(true);
+  });
+
+  it("action mismatch (read decision, write request) is rejected even when scope matches", () => {
+    expect(
+      canFulfill({
+        decisionScope: "doc:gdrive:write:D1",
+        decisionAction: "write",
+        requestedScope: "doc:gdrive:write:D1",
+        requestedAction: "read",
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("prefixMatches", () => {
+  it(":** matches everything in the colon-namespace", () => {
+    expect(prefixMatches("doc:gdrive:**", "doc:gdrive:anything")).toBe(true);
+    expect(prefixMatches("doc:gdrive:**", "doc:gdrive:write:D1")).toBe(true);
+  });
+
+  it("/** matches descendants only", () => {
+    expect(
+      prefixMatches("doc:gdrive:folder/F/**", "doc:gdrive:folder/F/sub"),
+    ).toBe(true);
+    expect(
+      prefixMatches("doc:gdrive:folder/F/**", "doc:gdrive:folder/G/sub"),
+    ).toBe(false);
+  });
+
+  it("exact strings match themselves", () => {
+    expect(prefixMatches("doc:gdrive:D1", "doc:gdrive:D1")).toBe(true);
+  });
+});

--- a/src/drive/grants.ts
+++ b/src/drive/grants.ts
@@ -1,0 +1,98 @@
+/**
+ * Drive grants — scope shapes + write-namespace separation per RFC C §12.
+ *
+ * Read scopes:
+ *   doc:gdrive:**                  whole-Drive read (default onboarding pick)
+ *   doc:gdrive:folder/<id>/**      folder + descendants
+ *   doc:gdrive:<id>                single doc
+ *
+ * Write scopes (separate namespace — a read grant NEVER fulfills a write):
+ *   doc:gdrive:write:**
+ *   doc:gdrive:write:folder/<id>/**
+ *   doc:gdrive:write:<id>
+ *
+ * The kernel's scope-prefix matching (RFC B) handles the `**` glob. This
+ * module provides `scopeForRead/Write()` builders, `actionGrammar()` to map
+ * an operation to the action keyword stored on the decision row, and
+ * `canFulfill()` to assert at lookup time that a candidate decision actually
+ * authorizes the requested action.
+ */
+
+export type DriveAction = "read" | "write";
+
+export type DriveTarget =
+  | { kind: "all" }
+  | { kind: "folder"; folder_id: string }
+  | { kind: "doc"; doc_id: string };
+
+/** Build the kernel `scope` string for a given target + action. */
+export function scopeFor(target: DriveTarget, action: DriveAction): string {
+  const writePrefix = action === "write" ? "write:" : "";
+  switch (target.kind) {
+    case "all":
+      return `doc:gdrive:${writePrefix}**`;
+    case "folder":
+      return `doc:gdrive:${writePrefix}folder/${target.folder_id}/**`;
+    case "doc":
+      return `doc:gdrive:${writePrefix}${target.doc_id}`;
+  }
+}
+
+/** action_grammar value to store on the kernel decision row. */
+export function actionGrammar(action: DriveAction): string {
+  return action;
+}
+
+/**
+ * Predicate: can a decision recorded for `decisionScope` (with its stored
+ * `action_grammar`) fulfill an incoming request for `requestedScope` +
+ * `requestedAction`?
+ *
+ * Hard constraint per §12: read grants do NOT fulfill write requests, even
+ * when the doc/folder id matches. This is enforced here regardless of what
+ * the kernel's scope-prefix matcher might say — the write namespace prefix
+ * (`doc:gdrive:write:`) is structurally distinct so the kernel matcher
+ * already rejects, but we double-check by looking at the action_grammar.
+ */
+export function canFulfill(args: {
+  decisionScope: string;
+  decisionAction: string;
+  requestedScope: string;
+  requestedAction: DriveAction;
+}): boolean {
+  // Action mismatch — always reject.
+  if (args.decisionAction !== args.requestedAction) return false;
+
+  // Both scopes must live in the SAME namespace (read vs write). A read
+  // scope cannot match a write request even if the kernel's prefix matcher
+  // is loosened in future.
+  const decisionIsWrite = args.decisionScope.startsWith("doc:gdrive:write:");
+  const requestedIsWrite = args.requestedScope.startsWith("doc:gdrive:write:");
+  if (decisionIsWrite !== requestedIsWrite) return false;
+
+  // Prefix match (handles `**` globs the kernel stores literally).
+  return prefixMatches(args.decisionScope, args.requestedScope);
+}
+
+/**
+ * Trivial prefix matcher mirroring RFC B's scope semantics:
+ *   `foo:**` matches `foo:anything`.
+ *   `foo:bar/**` matches `foo:bar/anything`.
+ *   exact strings match themselves.
+ *
+ * The real kernel matcher is more elaborate; here we only need enough to
+ * correctly answer "does this decision authorize this request" for unit
+ * tests of the write-isolation rule.
+ */
+export function prefixMatches(decisionScope: string, requestedScope: string): boolean {
+  if (decisionScope === requestedScope) return true;
+  if (decisionScope.endsWith("/**")) {
+    const prefix = decisionScope.slice(0, -2); // keep trailing slash
+    return requestedScope.startsWith(prefix);
+  }
+  if (decisionScope.endsWith(":**")) {
+    const prefix = decisionScope.slice(0, -2); // keep trailing colon
+    return requestedScope.startsWith(prefix);
+  }
+  return false;
+}

--- a/src/drive/oauth.test.ts
+++ b/src/drive/oauth.test.ts
@@ -1,0 +1,248 @@
+/**
+ * Tests for OAuth tier auto-selection + refresh-token rotation handling.
+ */
+
+import { describe, expect, it, mock } from "bun:test";
+import {
+  detectHeadless,
+  selectInitialTier,
+  nextTier,
+  refreshAccessToken,
+  InvalidGrantError,
+  pollDeviceToken,
+  buildOobAuthUrl,
+  exchangeOobCode,
+  revokeRefreshToken,
+} from "./oauth.js";
+
+const cfg = {
+  client_id: "cid",
+  client_secret: "csecret",
+  scopes: ["https://www.googleapis.com/auth/drive.readonly"],
+};
+
+describe("detectHeadless", () => {
+  it("treats SSH session with no display as headless", () => {
+    expect(
+      detectHeadless({ SSH_CONNECTION: "1.2.3.4 22 5.6.7.8 22" }),
+    ).toBe(true);
+  });
+
+  it("treats laptop with $DISPLAY set as not headless", () => {
+    expect(detectHeadless({ DISPLAY: ":0" })).toBe(false);
+  });
+
+  it("treats Wayland display as not headless", () => {
+    expect(detectHeadless({ WAYLAND_DISPLAY: "wayland-0" })).toBe(false);
+  });
+
+  it("ignores empty DISPLAY/WAYLAND_DISPLAY strings (real-world env shape)", () => {
+    expect(
+      detectHeadless({ DISPLAY: "", WAYLAND_DISPLAY: "", SSH_TTY: "/dev/pts/0" }),
+    ).toBe(true);
+  });
+
+  it("non-SSH headless box still treated as headless (no display means no browser)", () => {
+    expect(detectHeadless({})).toBe(true);
+  });
+});
+
+describe("selectInitialTier", () => {
+  it("picks device_code on headless SSH boxes", () => {
+    expect(
+      selectInitialTier({ SSH_CONNECTION: "x" }),
+    ).toBe("device_code");
+  });
+
+  it("picks device_code on laptops with display (still simpler than loopback)", () => {
+    expect(selectInitialTier({ DISPLAY: ":0" })).toBe("device_code");
+  });
+
+  it("honours SWITCHROOM_DRIVE_OAUTH_TIER override", () => {
+    expect(
+      selectInitialTier({
+        DISPLAY: ":0",
+        SWITCHROOM_DRIVE_OAUTH_TIER: "desktop_loopback",
+      }),
+    ).toBe("desktop_loopback");
+  });
+});
+
+describe("nextTier", () => {
+  it("falls device_code → oob_paste", () => {
+    expect(nextTier("device_code", { SSH_CONNECTION: "x" })).toBe("oob_paste");
+  });
+
+  it("falls oob_paste → desktop_loopback when display present", () => {
+    expect(nextTier("oob_paste", { DISPLAY: ":0" })).toBe("desktop_loopback");
+  });
+
+  it("falls oob_paste → null on truly headless boxes", () => {
+    expect(nextTier("oob_paste", { SSH_CONNECTION: "x" })).toBe(null);
+  });
+
+  it("returns null after desktop_loopback (last tier)", () => {
+    expect(nextTier("desktop_loopback", { DISPLAY: ":0" })).toBe(null);
+  });
+});
+
+describe("refreshAccessToken — invalid_grant rotation", () => {
+  it("throws InvalidGrantError when Google rejects the refresh token", async () => {
+    const fakeFetch = mock(async () =>
+      new Response(
+        JSON.stringify({
+          error: "invalid_grant",
+          error_description: "Token has been expired or revoked.",
+        }),
+        { status: 400, headers: { "content-type": "application/json" } },
+      ),
+    ) as unknown as typeof fetch;
+
+    await expect(refreshAccessToken(cfg, "rt", fakeFetch)).rejects.toBeInstanceOf(
+      InvalidGrantError,
+    );
+  });
+
+  it("returns the new access token on success", async () => {
+    const fakeFetch = mock(async () =>
+      new Response(
+        JSON.stringify({
+          access_token: "at-new",
+          expires_in: 3600,
+          token_type: "Bearer",
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      ),
+    ) as unknown as typeof fetch;
+    const r = await refreshAccessToken(cfg, "rt", fakeFetch);
+    expect(r.access_token).toBe("at-new");
+    expect(r.expires_in).toBe(3600);
+  });
+
+  it("rethrows non-invalid_grant errors as plain Error", async () => {
+    const fakeFetch = mock(async () =>
+      new Response(JSON.stringify({ error: "internal_error" }), {
+        status: 500,
+        headers: { "content-type": "application/json" },
+      }),
+    ) as unknown as typeof fetch;
+    await expect(refreshAccessToken(cfg, "rt", fakeFetch)).rejects.toThrow(
+      /refresh failed/,
+    );
+  });
+});
+
+describe("pollDeviceToken", () => {
+  it("returns access_token on first non-pending poll", async () => {
+    let calls = 0;
+    const fakeFetch = mock(async () => {
+      calls++;
+      if (calls === 1) {
+        return new Response(JSON.stringify({ error: "authorization_pending" }), {
+          status: 400,
+        });
+      }
+      return new Response(
+        JSON.stringify({
+          access_token: "at",
+          refresh_token: "rt",
+          expires_in: 3600,
+          token_type: "Bearer",
+        }),
+        { status: 200 },
+      );
+    }) as unknown as typeof fetch;
+
+    const tok = await pollDeviceToken(
+      cfg,
+      { device_code: "dc", user_code: "uc", verification_url: "v", expires_in: 600, interval: 1 },
+      { fetchImpl: fakeFetch, sleepMs: async () => undefined },
+    );
+    expect(tok.access_token).toBe("at");
+    expect(tok.refresh_token).toBe("rt");
+  });
+
+  it("backs off on slow_down then succeeds", async () => {
+    let calls = 0;
+    const fakeFetch = mock(async () => {
+      calls++;
+      if (calls === 1) {
+        return new Response(JSON.stringify({ error: "slow_down" }), { status: 400 });
+      }
+      return new Response(
+        JSON.stringify({ access_token: "at", expires_in: 3600, token_type: "Bearer" }),
+        { status: 200 },
+      );
+    }) as unknown as typeof fetch;
+    const tok = await pollDeviceToken(
+      cfg,
+      { device_code: "dc", user_code: "uc", verification_url: "v", expires_in: 600, interval: 1 },
+      { fetchImpl: fakeFetch, sleepMs: async () => undefined },
+    );
+    expect(tok.access_token).toBe("at");
+  });
+
+  it("throws on access_denied", async () => {
+    const fakeFetch = mock(
+      async () => new Response(JSON.stringify({ error: "access_denied" }), { status: 400 }),
+    ) as unknown as typeof fetch;
+    await expect(
+      pollDeviceToken(
+        cfg,
+        { device_code: "dc", user_code: "uc", verification_url: "v", expires_in: 600, interval: 1 },
+        { fetchImpl: fakeFetch, sleepMs: async () => undefined },
+      ),
+    ).rejects.toThrow(/denied/);
+  });
+});
+
+describe("OOB-paste flow", () => {
+  it("buildOobAuthUrl includes redirect_uri=urn:ietf:wg:oauth:2.0:oob", () => {
+    const url = buildOobAuthUrl(cfg);
+    expect(url).toContain("redirect_uri=urn%3Aietf%3Awg%3Aoauth%3A2.0%3Aoob");
+    expect(url).toContain("client_id=cid");
+    expect(url).toContain("access_type=offline");
+  });
+
+  it("exchangeOobCode round-trips via the token endpoint", async () => {
+    const fakeFetch = mock(async () =>
+      new Response(
+        JSON.stringify({ access_token: "at", refresh_token: "rt", expires_in: 3600, token_type: "Bearer" }),
+        { status: 200 },
+      ),
+    ) as unknown as typeof fetch;
+    const tok = await exchangeOobCode(cfg, "pasted-code", fakeFetch);
+    expect(tok.refresh_token).toBe("rt");
+  });
+});
+
+describe("revokeRefreshToken", () => {
+  it("returns ok on Google 200", async () => {
+    const fakeFetch = mock(async () => new Response("", { status: 200 })) as unknown as typeof fetch;
+    expect(await revokeRefreshToken("rt", fakeFetch)).toEqual({ ok: true });
+  });
+
+  it("returns ok on Google 400 (already invalidated counts as consistent)", async () => {
+    const fakeFetch = mock(
+      async () => new Response(JSON.stringify({ error: "invalid_token" }), { status: 400 }),
+    ) as unknown as typeof fetch;
+    expect(await revokeRefreshToken("rt", fakeFetch)).toEqual({ ok: true });
+  });
+
+  it("returns failed on unexpected non-2xx", async () => {
+    const fakeFetch = mock(
+      async () => new Response("oops", { status: 503 }),
+    ) as unknown as typeof fetch;
+    const r = await revokeRefreshToken("rt", fakeFetch);
+    expect(r.ok).toBe(false);
+  });
+
+  it("returns failed when fetch itself throws (network down)", async () => {
+    const fakeFetch = mock(async () => {
+      throw new Error("ECONNREFUSED");
+    }) as unknown as typeof fetch;
+    const r = await revokeRefreshToken("rt", fakeFetch);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.detail).toContain("ECONNREFUSED");
+  });
+});

--- a/src/drive/oauth.ts
+++ b/src/drive/oauth.ts
@@ -39,12 +39,11 @@ export function detectHeadless(env: OAuthEnv): boolean {
     (env.SSH_CONNECTION && env.SSH_CONNECTION.trim() !== "") ||
     (env.SSH_TTY && env.SSH_TTY.trim() !== ""),
   );
-  if (hasDisplay) return false;
-  // No display + SSH = definitely headless. No display + not SSH could be a
-  // Linux server console; treat as headless too because we still can't open
-  // a browser.
-  if (inSsh) return true;
-  return !hasDisplay;
+  // "Local desktop" = DISPLAY/WAYLAND set AND not over SSH (X-forwarding
+  // can set DISPLAY remotely, in which case we still can't reliably pop a
+  // browser on the user's screen). Anything else is headless.
+  if (hasDisplay && !inSsh) return false;
+  return true;
 }
 
 /**

--- a/src/drive/oauth.ts
+++ b/src/drive/oauth.ts
@@ -1,0 +1,321 @@
+/**
+ * Google Drive OAuth flow — three-tier auto-selection (RFC C §3).
+ *
+ * Tier preference (in order):
+ *   1. RFC 8628 device-code (preferred — works over SSH, no port binding).
+ *   2. OOB-paste (fallback — Google may reject device-code for Drive scopes).
+ *   3. Desktop loopback (last resort — only when a local browser is reachable).
+ *
+ * Auto-detect headlessness from env: if `$DISPLAY` and `$WAYLAND_DISPLAY` are
+ * both empty AND we are inside an SSH session (`$SSH_CONNECTION` present),
+ * the host is headless and we MUST avoid the loopback path.
+ *
+ * Pure functions where possible. Network I/O lives in the `*Exchange` helpers
+ * so unit tests can drive the selector and the polling logic without hitting
+ * Google.
+ */
+
+export type OAuthTier = "device_code" | "oob_paste" | "desktop_loopback";
+
+export interface OAuthEnv {
+  DISPLAY?: string;
+  WAYLAND_DISPLAY?: string;
+  SSH_CONNECTION?: string;
+  SSH_TTY?: string;
+  /** Test override: force a tier regardless of env. */
+  SWITCHROOM_DRIVE_OAUTH_TIER?: string;
+}
+
+/**
+ * Decide whether the host is headless. A host is "headless" when there is no
+ * graphical display server AND we are inside an SSH login.
+ */
+export function detectHeadless(env: OAuthEnv): boolean {
+  const hasDisplay = Boolean(
+    (env.DISPLAY && env.DISPLAY.trim() !== "") ||
+    (env.WAYLAND_DISPLAY && env.WAYLAND_DISPLAY.trim() !== ""),
+  );
+  const inSsh = Boolean(
+    (env.SSH_CONNECTION && env.SSH_CONNECTION.trim() !== "") ||
+    (env.SSH_TTY && env.SSH_TTY.trim() !== ""),
+  );
+  if (hasDisplay) return false;
+  // No display + SSH = definitely headless. No display + not SSH could be a
+  // Linux server console; treat as headless too because we still can't open
+  // a browser.
+  if (inSsh) return true;
+  return !hasDisplay;
+}
+
+/**
+ * Pick the preferred OAuth tier given the host environment.
+ *
+ * The selector is conservative: it returns the tier we'll TRY FIRST.
+ * Runtime fall-through (device-code rejected by Google for the configured
+ * scopes → OOB-paste) is the caller's responsibility.
+ */
+export function selectInitialTier(env: OAuthEnv): OAuthTier {
+  const override = env.SWITCHROOM_DRIVE_OAUTH_TIER;
+  if (override === "device_code" || override === "oob_paste" || override === "desktop_loopback") {
+    return override;
+  }
+
+  if (detectHeadless(env)) {
+    // Headless: device-code first, OOB on rejection.
+    return "device_code";
+  }
+
+  // Has a display: device-code is still simpler (no port binding) so
+  // prefer it; loopback is the last resort.
+  return "device_code";
+}
+
+/**
+ * Compute the fall-through tier given the current tier failed.
+ * Returns null when there are no more tiers to try.
+ */
+export function nextTier(current: OAuthTier, env: OAuthEnv): OAuthTier | null {
+  if (current === "device_code") {
+    // Device-code failed (e.g. Google rejected it for Drive scopes) →
+    // OOB-paste works universally over SSH.
+    return "oob_paste";
+  }
+  if (current === "oob_paste") {
+    // OOB-paste failed → only loopback remains, and only if we have a
+    // browser. On a truly headless host, return null.
+    if (detectHeadless(env)) return null;
+    return "desktop_loopback";
+  }
+  return null;
+}
+
+// ─── Network shapes (Google's RFC 8628 + token endpoint) ─────────────────────
+
+export interface DeviceCodeResponse {
+  device_code: string;
+  user_code: string;
+  verification_url: string;
+  expires_in: number;
+  interval: number;
+}
+
+export interface TokenResponse {
+  access_token: string;
+  refresh_token?: string;
+  expires_in: number;
+  token_type: string;
+  scope?: string;
+}
+
+export interface OAuthClientConfig {
+  client_id: string;
+  client_secret: string;
+  scopes: string[];
+}
+
+/**
+ * RFC 8628 §3.1: device-authorization request.
+ * Hits https://oauth2.googleapis.com/device/code with form-urlencoded body.
+ * Throws OAuthTierRejected when Google refuses the scope set.
+ */
+export async function requestDeviceCode(
+  cfg: OAuthClientConfig,
+  fetchImpl: typeof fetch = fetch,
+): Promise<DeviceCodeResponse> {
+  const body = new URLSearchParams({
+    client_id: cfg.client_id,
+    scope: cfg.scopes.join(" "),
+  });
+  const res = await fetchImpl("https://oauth2.googleapis.com/device/code", {
+    method: "POST",
+    headers: { "content-type": "application/x-www-form-urlencoded" },
+    body: body.toString(),
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    // Google returns 403 / 400 with `invalid_scope` or `disabled_client` when
+    // device-code is not whitelisted for the requested scopes.
+    if (res.status === 400 || res.status === 403) {
+      throw new OAuthTierRejected(
+        `device_code rejected (${res.status}): ${text}`,
+      );
+    }
+    throw new Error(`device_code request failed (${res.status}): ${text}`);
+  }
+  return (await res.json()) as DeviceCodeResponse;
+}
+
+/**
+ * Poll the token endpoint until the user completes consent or we time out.
+ * Implements RFC 8628 §3.5 polling semantics: respect `interval`, back off on
+ * `slow_down`, terminate on `access_denied` / `expired_token`.
+ */
+export async function pollDeviceToken(
+  cfg: OAuthClientConfig,
+  device: DeviceCodeResponse,
+  opts: {
+    fetchImpl?: typeof fetch;
+    sleepMs?: (ms: number) => Promise<void>;
+    now?: () => number;
+  } = {},
+): Promise<TokenResponse> {
+  const fetchImpl = opts.fetchImpl ?? fetch;
+  const sleepMs = opts.sleepMs ?? ((ms) => new Promise((r) => setTimeout(r, ms)));
+  const now = opts.now ?? Date.now;
+
+  let interval = device.interval > 0 ? device.interval : 5;
+  const deadline = now() + device.expires_in * 1000;
+
+  while (now() < deadline) {
+    await sleepMs(interval * 1000);
+    const body = new URLSearchParams({
+      client_id: cfg.client_id,
+      client_secret: cfg.client_secret,
+      device_code: device.device_code,
+      grant_type: "urn:ietf:params:oauth:grant-type:device_code",
+    });
+    const res = await fetchImpl("https://oauth2.googleapis.com/token", {
+      method: "POST",
+      headers: { "content-type": "application/x-www-form-urlencoded" },
+      body: body.toString(),
+    });
+    const json = (await res.json()) as Record<string, unknown>;
+    if (res.ok && typeof json.access_token === "string") {
+      return json as unknown as TokenResponse;
+    }
+    const err = json.error;
+    if (err === "authorization_pending") continue;
+    if (err === "slow_down") {
+      interval += 5;
+      continue;
+    }
+    if (err === "access_denied") {
+      throw new Error("User denied the consent request.");
+    }
+    if (err === "expired_token") {
+      throw new Error("Device code expired before consent.");
+    }
+    throw new Error(`Token poll failed: ${JSON.stringify(json)}`);
+  }
+  throw new Error("Device-code consent timed out.");
+}
+
+/**
+ * Build the OOB consent URL the user opens in any browser; they paste back the
+ * code Google shows them. Universal fallback when device-code is rejected.
+ */
+export function buildOobAuthUrl(cfg: OAuthClientConfig): string {
+  const u = new URL("https://accounts.google.com/o/oauth2/auth");
+  u.searchParams.set("client_id", cfg.client_id);
+  u.searchParams.set("redirect_uri", "urn:ietf:wg:oauth:2.0:oob");
+  u.searchParams.set("response_type", "code");
+  u.searchParams.set("scope", cfg.scopes.join(" "));
+  u.searchParams.set("access_type", "offline");
+  u.searchParams.set("prompt", "consent");
+  return u.toString();
+}
+
+/** Exchange a pasted OOB auth code for tokens. */
+export async function exchangeOobCode(
+  cfg: OAuthClientConfig,
+  code: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<TokenResponse> {
+  const body = new URLSearchParams({
+    client_id: cfg.client_id,
+    client_secret: cfg.client_secret,
+    code,
+    grant_type: "authorization_code",
+    redirect_uri: "urn:ietf:wg:oauth:2.0:oob",
+  });
+  const res = await fetchImpl("https://oauth2.googleapis.com/token", {
+    method: "POST",
+    headers: { "content-type": "application/x-www-form-urlencoded" },
+    body: body.toString(),
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`OOB token exchange failed (${res.status}): ${text}`);
+  }
+  return (await res.json()) as TokenResponse;
+}
+
+/**
+ * Refresh an access token using the durable refresh token.
+ * Throws InvalidGrantError when Google has rotated/revoked the refresh token
+ * — caller (drive wrapper) catches and updates the sidecar status slot.
+ */
+export class InvalidGrantError extends Error {
+  constructor(public detail: string) {
+    super(`invalid_grant: ${detail}`);
+    this.name = "InvalidGrantError";
+  }
+}
+
+export class OAuthTierRejected extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "OAuthTierRejected";
+  }
+}
+
+export async function refreshAccessToken(
+  cfg: OAuthClientConfig,
+  refreshToken: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<TokenResponse> {
+  const body = new URLSearchParams({
+    client_id: cfg.client_id,
+    client_secret: cfg.client_secret,
+    refresh_token: refreshToken,
+    grant_type: "refresh_token",
+  });
+  const res = await fetchImpl("https://oauth2.googleapis.com/token", {
+    method: "POST",
+    headers: { "content-type": "application/x-www-form-urlencoded" },
+    body: body.toString(),
+  });
+  const json = (await res.json()) as Record<string, unknown>;
+  if (!res.ok) {
+    if (typeof json.error === "string" && json.error === "invalid_grant") {
+      throw new InvalidGrantError(
+        typeof json.error_description === "string"
+          ? json.error_description
+          : "refresh token rejected by Google",
+      );
+    }
+    throw new Error(`refresh failed (${res.status}): ${JSON.stringify(json)}`);
+  }
+  return json as unknown as TokenResponse;
+}
+
+/**
+ * Best-effort revoke. Google's revoke endpoint returns 200 on success and
+ * 400 ({error: invalid_token}) when the token is already invalid. We treat
+ * both as "the local view is now consistent with Google's view."
+ */
+export async function revokeRefreshToken(
+  refreshToken: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<{ ok: true } | { ok: false; status: number; detail: string }> {
+  try {
+    const res = await fetchImpl("https://oauth2.googleapis.com/revoke", {
+      method: "POST",
+      headers: { "content-type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({ token: refreshToken }).toString(),
+    });
+    if (res.ok) return { ok: true };
+    if (res.status === 400) {
+      // already invalidated — treat as success for our purposes
+      return { ok: true };
+    }
+    const text = await res.text();
+    return { ok: false, status: res.status, detail: text };
+  } catch (e) {
+    return {
+      ok: false,
+      status: 0,
+      detail: e instanceof Error ? e.message : String(e),
+    };
+  }
+}

--- a/src/drive/onboarding.test.ts
+++ b/src/drive/onboarding.test.ts
@@ -1,15 +1,16 @@
 /**
- * Onboarding card structure tests (RFC C §5).
+ * Onboarding card structure tests (RFC C §5, kernel-client v2).
  */
 
 import { describe, expect, it } from "bun:test";
 import { buildOnboardingCard, buildReconnectCard } from "./onboarding.js";
 
 describe("buildOnboardingCard", () => {
-  it("surface is mcp:gdrive (not 'system' — onboarding is per-MCP)", () => {
+  it("uses agent_unit + onboard action per RFC B v2 kernel client", () => {
     const c = buildOnboardingCard("klanker");
-    expect(c.surface).toBe("mcp:gdrive");
-    expect(c.agent).toBe("klanker");
+    expect(c.agent_unit).toBe("klanker");
+    expect(c.scope).toBe("system:onboarding:gdrive");
+    expect(c.action).toBe("onboard");
   });
 
   it("first option is the recommended Allow-my-Drive read grant (default per §5)", () => {
@@ -40,10 +41,11 @@ describe("buildOnboardingCard", () => {
 });
 
 describe("buildReconnectCard", () => {
-  it("surface is system (per RFC §4.2)", () => {
+  it("uses system:reconnect:gdrive scope + reconnect_drive action (per RFC §4.2)", () => {
     const c = buildReconnectCard("klanker");
-    expect(c.surface).toBe("system");
-    expect(c.action_grammar).toBe("reconnect_drive");
+    expect(c.scope).toBe("system:reconnect:gdrive");
+    expect(c.action).toBe("reconnect_drive");
+    expect(c.agent_unit).toBe("klanker");
   });
 
   it("includes Reconnect + Disconnect-permanently buttons", () => {

--- a/src/drive/onboarding.test.ts
+++ b/src/drive/onboarding.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Onboarding card structure tests (RFC C §5).
+ */
+
+import { describe, expect, it } from "bun:test";
+import { buildOnboardingCard, buildReconnectCard } from "./onboarding.js";
+
+describe("buildOnboardingCard", () => {
+  it("surface is mcp:gdrive (not 'system' — onboarding is per-MCP)", () => {
+    const c = buildOnboardingCard("klanker");
+    expect(c.surface).toBe("mcp:gdrive");
+    expect(c.agent).toBe("klanker");
+  });
+
+  it("first option is the recommended Allow-my-Drive read grant (default per §5)", () => {
+    const c = buildOnboardingCard("klanker");
+    const first = c.options[0];
+    expect(first.choice).toEqual({ kind: "allow_drive_read" });
+    expect(first.grant_scope).toBe("doc:gdrive:**");
+    expect(first.grant_action).toBe("read");
+    expect(first.label.toLowerCase()).toContain("recommended");
+  });
+
+  it("includes the per-doc warning option", () => {
+    const c = buildOnboardingCard("klanker");
+    const perDoc = c.options.find((o) => o.choice.kind === "per_doc");
+    expect(perDoc).toBeDefined();
+    expect(perDoc?.grant_scope).toBe(null);
+  });
+
+  it("body warns explicitly about prompt-flood for per-doc choice", () => {
+    const c = buildOnboardingCard("klanker");
+    expect(c.body).toContain("20+ prompts");
+  });
+
+  it("body names the agent so the user can verify on small screens", () => {
+    const c = buildOnboardingCard("klanker");
+    expect(c.body).toContain("klanker");
+  });
+});
+
+describe("buildReconnectCard", () => {
+  it("surface is system (per RFC §4.2)", () => {
+    const c = buildReconnectCard("klanker");
+    expect(c.surface).toBe("system");
+    expect(c.action_grammar).toBe("reconnect_drive");
+  });
+
+  it("includes Reconnect + Disconnect-permanently buttons", () => {
+    const c = buildReconnectCard("klanker");
+    const labels = c.options.map((o) => o.action);
+    expect(labels).toContain("reconnect");
+    expect(labels).toContain("disconnect");
+  });
+
+  it("propagates Google's invalid_grant detail when provided", () => {
+    const c = buildReconnectCard("klanker", "Token has been expired or revoked.");
+    expect(c.body).toContain("Token has been expired or revoked");
+  });
+});

--- a/src/drive/onboarding.ts
+++ b/src/drive/onboarding.ts
@@ -8,6 +8,12 @@
  * structures returned here as the request payload, then waits for the
  * decision through the same pending/granted flow as any other approval.
  *
+ * Per RFC B v2, the kernel-client request shape is:
+ *   { agent_unit, scope, action, approver_set, why?, ttl_ms? }
+ * `surface` and `action_grammar` are not part of the v2 protocol; the
+ * card spec exposes only the fields that flow into the kernel call plus
+ * the user-facing UI body/options.
+ *
  * RFC C §5 spells out three options:
  *   1. Allow my Drive (read-only) — recommended (writes the kernel grant
  *      `doc:gdrive:**` action `read`)
@@ -21,7 +27,7 @@
  * deny button.
  */
 
-import { scopeFor, actionGrammar, type DriveAction } from "./grants.js";
+import { scopeFor, type DriveAction } from "./grants.js";
 
 export type OnboardingChoice =
   | { kind: "allow_drive_read" }
@@ -30,11 +36,11 @@ export type OnboardingChoice =
   | { kind: "cancel" };
 
 export interface OnboardingCardSpec {
-  agent: string;
-  surface: "mcp:gdrive";
+  agent_unit: string;
   /** Top-level scope used for the onboarding card itself (system-level). */
   scope: "system:onboarding:gdrive";
-  action_grammar: "onboard";
+  /** Kernel action keyword (per RFC B v2 — was `action_grammar` in v1). */
+  action: "onboard";
   body: string;
   options: Array<{
     label: string;
@@ -45,14 +51,13 @@ export interface OnboardingCardSpec {
   }>;
 }
 
-export function buildOnboardingCard(agent: string): OnboardingCardSpec {
+export function buildOnboardingCard(agent_unit: string): OnboardingCardSpec {
   return {
-    agent,
-    surface: "mcp:gdrive",
+    agent_unit,
     scope: "system:onboarding:gdrive",
-    action_grammar: "onboard",
+    action: "onboard",
     body:
-      `Google Drive enabled for ${agent}.\n\n` +
+      `Google Drive enabled for ${agent_unit}.\n\n` +
       `Most users pick "Allow my Drive" — one tap now, then it just works.\n` +
       `"Per-doc approval" prompts you for every single file the agent opens ` +
       `(20+ prompts in the first hour is typical). Pick that only if you ` +
@@ -89,10 +94,10 @@ export function buildOnboardingCard(agent: string): OnboardingCardSpec {
 }
 
 export interface ReconnectCardSpec {
-  agent: string;
-  surface: "system";
+  agent_unit: string;
   scope: "system:reconnect:gdrive";
-  action_grammar: "reconnect_drive";
+  /** Kernel action keyword (per RFC B v2 — was `action_grammar` in v1). */
+  action: "reconnect_drive";
   body: string;
   /** What the [Reconnect] / [Disconnect permanently] buttons run. */
   options: Array<{
@@ -101,15 +106,14 @@ export interface ReconnectCardSpec {
   }>;
 }
 
-export function buildReconnectCard(agent: string, detail?: string): ReconnectCardSpec {
+export function buildReconnectCard(agent_unit: string, detail?: string): ReconnectCardSpec {
   const detailLine = detail ? `\n\nGoogle said: ${detail}` : "";
   return {
-    agent,
-    surface: "system",
+    agent_unit,
     scope: "system:reconnect:gdrive",
-    action_grammar: "reconnect_drive",
+    action: "reconnect_drive",
     body:
-      `Drive disconnected — reconnect ${agent}?\n\n` +
+      `Drive disconnected — reconnect ${agent_unit}?\n\n` +
       `The refresh token Google issued has been rotated or revoked. ` +
       `This usually means the password changed or the app's access was ` +
       `removed in the Google Account dashboard.${detailLine}`,

--- a/src/drive/onboarding.ts
+++ b/src/drive/onboarding.ts
@@ -1,0 +1,121 @@
+/**
+ * Onboarding + reconnect card builders per RFC C §5 and §4.2.
+ *
+ * These are pure structure-builders — the real Telegram emit lives in
+ * the gateway plugin (telegram-plugin/gateway/approval-card.ts). The CLI
+ * `switchroom drive connect <agent>` command calls into the kernel via
+ * `approvalRequest()` from src/vault/approvals/client.ts using the
+ * structures returned here as the request payload, then waits for the
+ * decision through the same pending/granted flow as any other approval.
+ *
+ * RFC C §5 spells out three options:
+ *   1. Allow my Drive (read-only) — recommended (writes the kernel grant
+ *      `doc:gdrive:**` action `read`)
+ *   2. Allow specific folder — deferred-folder-picker, currently surfaces
+ *      a "paste a folder ID" prompt; see §6 (folder picker is out of
+ *      scope, so this option is intentionally low-key)
+ *   3. Per-doc prompts — writes nothing; future doc accesses each go
+ *      through requestApproval. Copy warns "20+ prompts on day 1".
+ *
+ * The fourth option (Cancel) is rendered by the gateway as a standard
+ * deny button.
+ */
+
+import { scopeFor, actionGrammar, type DriveAction } from "./grants.js";
+
+export type OnboardingChoice =
+  | { kind: "allow_drive_read" }
+  | { kind: "allow_folder"; folder_id: string }
+  | { kind: "per_doc" }
+  | { kind: "cancel" };
+
+export interface OnboardingCardSpec {
+  agent: string;
+  surface: "mcp:gdrive";
+  /** Top-level scope used for the onboarding card itself (system-level). */
+  scope: "system:onboarding:gdrive";
+  action_grammar: "onboard";
+  body: string;
+  options: Array<{
+    label: string;
+    choice: OnboardingChoice;
+    /** Scope to write on selection (null for `cancel` and `per_doc`). */
+    grant_scope: string | null;
+    grant_action: DriveAction | null;
+  }>;
+}
+
+export function buildOnboardingCard(agent: string): OnboardingCardSpec {
+  return {
+    agent,
+    surface: "mcp:gdrive",
+    scope: "system:onboarding:gdrive",
+    action_grammar: "onboard",
+    body:
+      `Google Drive enabled for ${agent}.\n\n` +
+      `Most users pick "Allow my Drive" — one tap now, then it just works.\n` +
+      `"Per-doc approval" prompts you for every single file the agent opens ` +
+      `(20+ prompts in the first hour is typical). Pick that only if you ` +
+      `want a tap-by-tap audit trail.`,
+    options: [
+      {
+        label: "✅ Allow my Drive (read-only) — recommended",
+        choice: { kind: "allow_drive_read" },
+        grant_scope: scopeFor({ kind: "all" }, "read"),
+        grant_action: "read",
+      },
+      {
+        label: "📁 Allow specific folder (paste folder ID)",
+        // The folder ID is filled in by the gateway when this option is
+        // tapped; the spec here is a template.
+        choice: { kind: "allow_folder", folder_id: "<pending>" },
+        grant_scope: null, // deferred — gateway prompts for folder ID
+        grant_action: "read",
+      },
+      {
+        label: "🔒 Per-doc approval — high-touch, high-friction",
+        choice: { kind: "per_doc" },
+        grant_scope: null,
+        grant_action: null,
+      },
+      {
+        label: "❌ Cancel — don't enable Drive",
+        choice: { kind: "cancel" },
+        grant_scope: null,
+        grant_action: null,
+      },
+    ],
+  };
+}
+
+export interface ReconnectCardSpec {
+  agent: string;
+  surface: "system";
+  scope: "system:reconnect:gdrive";
+  action_grammar: "reconnect_drive";
+  body: string;
+  /** What the [Reconnect] / [Disconnect permanently] buttons run. */
+  options: Array<{
+    label: string;
+    action: "reconnect" | "disconnect";
+  }>;
+}
+
+export function buildReconnectCard(agent: string, detail?: string): ReconnectCardSpec {
+  const detailLine = detail ? `\n\nGoogle said: ${detail}` : "";
+  return {
+    agent,
+    surface: "system",
+    scope: "system:reconnect:gdrive",
+    action_grammar: "reconnect_drive",
+    body:
+      `Drive disconnected — reconnect ${agent}?\n\n` +
+      `The refresh token Google issued has been rotated or revoked. ` +
+      `This usually means the password changed or the app's access was ` +
+      `removed in the Google Account dashboard.${detailLine}`,
+    options: [
+      { label: "🔁 Reconnect", action: "reconnect" },
+      { label: "🚫 Disconnect permanently", action: "disconnect" },
+    ],
+  };
+}

--- a/src/drive/reconciler.test.ts
+++ b/src/drive/reconciler.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Reconciler three-state tests (RFC C §8).
+ */
+
+import { describe, expect, it } from "bun:test";
+import { reconcile, isNewer, hashMetadata } from "./reconciler.js";
+
+describe("reconcile — three-state detection", () => {
+  it("404 → missing(not_found)", () => {
+    const v = reconcile(null, { modifiedTime: "2026-01-01T00:00:00Z" });
+    expect(v.state).toBe("missing");
+    if (v.state === "missing") expect(v.reason).toBe("not_found");
+  });
+
+  it("200 with trashed:true → missing(trashed)", () => {
+    const v = reconcile(
+      { id: "x", trashed: true, modifiedTime: "2026-01-01T00:00:00Z" },
+      { modifiedTime: "2026-01-01T00:00:00Z" },
+    );
+    expect(v.state).toBe("missing");
+    if (v.state === "missing") expect(v.reason).toBe("trashed");
+  });
+
+  it("first observation → present (no baseline to diff)", () => {
+    const v = reconcile({ id: "x", modifiedTime: "2026-01-01T00:00:00Z" }, null);
+    expect(v.state).toBe("present");
+  });
+
+  it("identical metadata → present", () => {
+    const seen = { modifiedTime: "2026-01-01T00:00:00Z", contentHash: "abc" };
+    const v = reconcile({ id: "x", ...seen }, seen);
+    expect(v.state).toBe("present");
+  });
+
+  it("modifiedTime newer → conflict(modified_time_newer)", () => {
+    const v = reconcile(
+      { id: "x", modifiedTime: "2026-02-01T00:00:00Z" },
+      { modifiedTime: "2026-01-01T00:00:00Z" },
+    );
+    expect(v.state).toBe("conflict");
+    if (v.state === "conflict") {
+      expect(v.reasons).toContain("modified_time_newer");
+    }
+  });
+
+  it("contentHash differs → conflict(content_hash_changed)", () => {
+    const v = reconcile(
+      { id: "x", contentHash: "new" },
+      { contentHash: "old" },
+    );
+    expect(v.state).toBe("conflict");
+    if (v.state === "conflict") expect(v.reasons).toContain("content_hash_changed");
+  });
+
+  it("mimeType change (Doc→PDF) → conflict(mime_type_changed)", () => {
+    const v = reconcile(
+      { id: "x", mimeType: "application/pdf" },
+      { mimeType: "application/vnd.google-apps.document" },
+    );
+    expect(v.state).toBe("conflict");
+    if (v.state === "conflict") expect(v.reasons).toContain("mime_type_changed");
+  });
+
+  it("ownerExcluded:true → conflict(owner_excluded)", () => {
+    const v = reconcile({ id: "x", ownerExcluded: true }, {});
+    expect(v.state).toBe("conflict");
+    if (v.state === "conflict") expect(v.reasons).toContain("owner_excluded");
+  });
+
+  it("multiple deltas → all reasons surfaced", () => {
+    const v = reconcile(
+      {
+        id: "x",
+        modifiedTime: "2026-02-01T00:00:00Z",
+        contentHash: "new",
+        mimeType: "application/pdf",
+      },
+      {
+        modifiedTime: "2026-01-01T00:00:00Z",
+        contentHash: "old",
+        mimeType: "application/vnd.google-apps.document",
+      },
+    );
+    expect(v.state).toBe("conflict");
+    if (v.state === "conflict") {
+      expect(v.reasons).toEqual(
+        expect.arrayContaining([
+          "modified_time_newer",
+          "content_hash_changed",
+          "mime_type_changed",
+        ]),
+      );
+    }
+  });
+});
+
+describe("isNewer", () => {
+  it("compares RFC 3339 timestamps via Date.parse", () => {
+    expect(isNewer("2026-02-01T00:00:00Z", "2026-01-01T00:00:00Z")).toBe(true);
+    expect(isNewer("2026-01-01T00:00:00Z", "2026-02-01T00:00:00Z")).toBe(false);
+    expect(isNewer("2026-01-01T00:00:00Z", "2026-01-01T00:00:00Z")).toBe(false);
+  });
+});
+
+describe("hashMetadata", () => {
+  it("produces stable SHA-256 hex", async () => {
+    const a = await hashMetadata({
+      mimeType: "x",
+      modifiedTime: "2026-01-01T00:00:00Z",
+      size: 100,
+    });
+    const b = await hashMetadata({
+      mimeType: "x",
+      modifiedTime: "2026-01-01T00:00:00Z",
+      size: 100,
+    });
+    expect(a).toBe(b);
+    expect(a).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it("differs when any field differs", async () => {
+    const a = await hashMetadata({ mimeType: "x", modifiedTime: "t", size: 1 });
+    const b = await hashMetadata({ mimeType: "x", modifiedTime: "t", size: 2 });
+    expect(a).not.toBe(b);
+  });
+});

--- a/src/drive/reconciler.ts
+++ b/src/drive/reconciler.ts
@@ -1,0 +1,137 @@
+/**
+ * Reconciler — three-state per RFC C §8.
+ *
+ *   present  — files.get returns 200, hash unchanged.
+ *   missing  — files.get returns 404 OR `trashed: true`.
+ *   conflict — modifiedTime newer / hash differs / mimeType changed /
+ *              permissions changed in a way that excludes the agent.
+ *
+ * The "last seen" snapshot is provided by the caller (kept on the grant row;
+ * see `grants-store.ts`). The reconciler is pure: feed it `(remote, lastSeen)`,
+ * get a verdict.
+ */
+
+export interface DriveFileMetadata {
+  id: string;
+  name?: string;
+  mimeType?: string;
+  modifiedTime?: string; // RFC 3339 from Google
+  /** SHA-256 hex of (mimeType + modifiedTime + size) — see hashFile() below. */
+  contentHash?: string;
+  trashed?: boolean;
+  /** True when the agent's identity is no longer in the permissions list. */
+  ownerExcluded?: boolean;
+}
+
+export interface LastSeenSnapshot {
+  modifiedTime?: string;
+  contentHash?: string;
+  mimeType?: string;
+}
+
+export type ReconcilerVerdict =
+  | { state: "present"; meta: DriveFileMetadata }
+  | { state: "missing"; reason: "not_found" | "trashed" }
+  | {
+      state: "conflict";
+      meta: DriveFileMetadata;
+      reasons: ConflictReason[];
+    };
+
+export type ConflictReason =
+  | "modified_time_newer"
+  | "content_hash_changed"
+  | "mime_type_changed"
+  | "owner_excluded";
+
+/**
+ * Simulate a `files.get` response into a verdict.
+ *
+ * Inputs:
+ *   - `remote`:   what `files.get` returned. `null` = 404. The `trashed`
+ *                 flag (when present and true) is treated as missing.
+ *   - `lastSeen`: snapshot from the grant row, or `null` if this is the
+ *                 first observation (in which case `present` is always the
+ *                 verdict — we don't have a baseline to diff against yet).
+ */
+export function reconcile(
+  remote: DriveFileMetadata | null,
+  lastSeen: LastSeenSnapshot | null,
+): ReconcilerVerdict {
+  if (remote === null) return { state: "missing", reason: "not_found" };
+  if (remote.trashed === true) return { state: "missing", reason: "trashed" };
+
+  // First observation — establish baseline, no conflict possible.
+  if (lastSeen === null) return { state: "present", meta: remote };
+
+  const reasons: ConflictReason[] = [];
+
+  if (
+    lastSeen.modifiedTime !== undefined &&
+    remote.modifiedTime !== undefined &&
+    isNewer(remote.modifiedTime, lastSeen.modifiedTime)
+  ) {
+    reasons.push("modified_time_newer");
+  }
+
+  if (
+    lastSeen.contentHash !== undefined &&
+    remote.contentHash !== undefined &&
+    lastSeen.contentHash !== remote.contentHash
+  ) {
+    reasons.push("content_hash_changed");
+  }
+
+  if (
+    lastSeen.mimeType !== undefined &&
+    remote.mimeType !== undefined &&
+    lastSeen.mimeType !== remote.mimeType
+  ) {
+    reasons.push("mime_type_changed");
+  }
+
+  if (remote.ownerExcluded === true) {
+    reasons.push("owner_excluded");
+  }
+
+  if (reasons.length === 0) return { state: "present", meta: remote };
+  return { state: "conflict", meta: remote, reasons };
+}
+
+/** Compare two RFC 3339 timestamps. Strings are compared via Date so the */
+/* fractional-second precision Google sometimes returns is honored. */
+export function isNewer(a: string, b: string): boolean {
+  const ta = Date.parse(a);
+  const tb = Date.parse(b);
+  if (Number.isNaN(ta) || Number.isNaN(tb)) return a !== b;
+  return ta > tb;
+}
+
+/**
+ * Stable content hash from the metadata fields Drive returns cheaply (we
+ * don't want to download the body just to hash it — `files.get` is the only
+ * round-trip we want per access). Hash inputs:
+ *   - mimeType   (catches doc→pdf conversions)
+ *   - modifiedTime (catches edits)
+ *   - size       (catches body churn that didn't bump modifiedTime)
+ *
+ * If Google's response is missing any of these, the hash is computed over
+ * what's present. Two hashes computed from disjoint field sets will diff
+ * and trigger a conflict — that's the correct behavior.
+ */
+export async function hashMetadata(parts: {
+  mimeType?: string;
+  modifiedTime?: string;
+  size?: string | number;
+}): Promise<string> {
+  const canonical = JSON.stringify({
+    mimeType: parts.mimeType ?? null,
+    modifiedTime: parts.modifiedTime ?? null,
+    size: parts.size ?? null,
+  });
+  const data = new TextEncoder().encode(canonical);
+  const buf = await crypto.subtle.digest("SHA-256", data);
+  return [...new Uint8Array(buf)]
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}

--- a/src/drive/vault-slots.test.ts
+++ b/src/drive/vault-slots.test.ts
@@ -1,0 +1,111 @@
+/**
+ * vault-slots — round-trip + idempotent delete tests.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  refreshTokenSlot,
+  statusSlot,
+  writeRefreshToken,
+  readRefreshToken,
+  writeStatus,
+  readStatus,
+  deleteSlots,
+} from "./vault-slots.js";
+import { createVault } from "../vault/vault.js";
+
+let dir: string;
+let vaultPath: string;
+const PASS = "p";
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "drive-slots-"));
+  vaultPath = join(dir, "vault.enc");
+  createVault(PASS, vaultPath);
+});
+afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+describe("slot key shapes (RFC C §4)", () => {
+  it("refreshTokenSlot follows gdrive:<unit>:refresh_token", () => {
+    expect(refreshTokenSlot("klanker")).toBe("gdrive:klanker:refresh_token");
+  });
+  it("statusSlot follows gdrive:<unit>:status", () => {
+    expect(statusSlot("klanker")).toBe("gdrive:klanker:status");
+  });
+});
+
+describe("round-trip", () => {
+  it("stores and reads back the refresh token", () => {
+    writeRefreshToken({
+      passphrase: PASS,
+      vaultPath,
+      agentUnit: "klanker",
+      refreshToken: "rt-1",
+    });
+    expect(
+      readRefreshToken({ passphrase: PASS, vaultPath, agentUnit: "klanker" }),
+    ).toBe("rt-1");
+  });
+
+  it("overwrites prior token (no version history)", () => {
+    writeRefreshToken({
+      passphrase: PASS,
+      vaultPath,
+      agentUnit: "k",
+      refreshToken: "old",
+    });
+    writeRefreshToken({
+      passphrase: PASS,
+      vaultPath,
+      agentUnit: "k",
+      refreshToken: "new",
+    });
+    expect(
+      readRefreshToken({ passphrase: PASS, vaultPath, agentUnit: "k" }),
+    ).toBe("new");
+  });
+
+  it("stores and reads back status sidecar", () => {
+    writeStatus({
+      passphrase: PASS,
+      vaultPath,
+      agentUnit: "k",
+      status: "invalid_grant",
+      detail: "rotated",
+      now: 1234,
+    });
+    const s = readStatus({ passphrase: PASS, vaultPath, agentUnit: "k" });
+    expect(s?.status).toBe("invalid_grant");
+    expect(s?.detail).toBe("rotated");
+    expect(s?.ts).toBe(1234);
+  });
+
+  it("readStatus returns null when slot absent (healthy / never connected)", () => {
+    expect(
+      readStatus({ passphrase: PASS, vaultPath, agentUnit: "k" }),
+    ).toBe(null);
+  });
+});
+
+describe("deleteSlots", () => {
+  it("removes both slots and is idempotent", () => {
+    writeRefreshToken({ passphrase: PASS, vaultPath, agentUnit: "k", refreshToken: "rt" });
+    writeStatus({
+      passphrase: PASS,
+      vaultPath,
+      agentUnit: "k",
+      status: "connected",
+    });
+    deleteSlots({ passphrase: PASS, vaultPath, agentUnit: "k" });
+    deleteSlots({ passphrase: PASS, vaultPath, agentUnit: "k" });
+    expect(
+      readRefreshToken({ passphrase: PASS, vaultPath, agentUnit: "k" }),
+    ).toBe(null);
+    expect(
+      readStatus({ passphrase: PASS, vaultPath, agentUnit: "k" }),
+    ).toBe(null);
+  });
+});

--- a/src/drive/vault-slots.ts
+++ b/src/drive/vault-slots.ts
@@ -1,0 +1,146 @@
+/**
+ * Vault slot helpers for RFC C §4.
+ *
+ * Slots:
+ *   - `gdrive:<agent_unit>:refresh_token` — durable refresh token (string).
+ *   - `gdrive:<agent_unit>:status` — sidecar with `connected` |
+ *     `invalid_grant` | `reconnect_pending` plus a timestamp. Absent slot
+ *     means "healthy / never connected" — callers must distinguish based on
+ *     refresh-token presence.
+ *
+ * Access tokens NEVER touch this module — they live in process memory only.
+ */
+
+import {
+  setStringSecret,
+  getStringSecret,
+  removeSecret,
+  type VaultEntryScope,
+} from "../vault/vault.js";
+
+export type DriveStatus = "connected" | "invalid_grant" | "reconnect_pending";
+
+export interface DriveStatusRecord {
+  status: DriveStatus;
+  ts: number;
+  detail?: string;
+}
+
+export function refreshTokenSlot(agentUnit: string): string {
+  return `gdrive:${agentUnit}:refresh_token`;
+}
+
+export function statusSlot(agentUnit: string): string {
+  return `gdrive:${agentUnit}:status`;
+}
+
+/**
+ * Persist the refresh token. ACL grants the agent's unit only — no other
+ * agent can read the token. Overwrites any prior value (no version history,
+ * per §4.1 — Google may have already invalidated it).
+ */
+export function writeRefreshToken(args: {
+  passphrase: string;
+  vaultPath: string;
+  agentUnit: string;
+  refreshToken: string;
+}): void {
+  const scope: VaultEntryScope = { allow: [args.agentUnit] };
+  setStringSecret(
+    args.passphrase,
+    args.vaultPath,
+    refreshTokenSlot(args.agentUnit),
+    args.refreshToken,
+    undefined,
+    scope,
+  );
+}
+
+export function readRefreshToken(args: {
+  passphrase: string;
+  vaultPath: string;
+  agentUnit: string;
+}): string | null {
+  return getStringSecret(
+    args.passphrase,
+    args.vaultPath,
+    refreshTokenSlot(args.agentUnit),
+  );
+}
+
+export function writeStatus(args: {
+  passphrase: string;
+  vaultPath: string;
+  agentUnit: string;
+  status: DriveStatus;
+  detail?: string;
+  now?: number;
+}): void {
+  const record: DriveStatusRecord = {
+    status: args.status,
+    ts: args.now ?? Date.now(),
+    detail: args.detail,
+  };
+  const scope: VaultEntryScope = { allow: [args.agentUnit] };
+  setStringSecret(
+    args.passphrase,
+    args.vaultPath,
+    statusSlot(args.agentUnit),
+    JSON.stringify(record),
+    "json",
+    scope,
+  );
+}
+
+export function readStatus(args: {
+  passphrase: string;
+  vaultPath: string;
+  agentUnit: string;
+}): DriveStatusRecord | null {
+  const raw = getStringSecret(
+    args.passphrase,
+    args.vaultPath,
+    statusSlot(args.agentUnit),
+  );
+  if (raw === null) return null;
+  try {
+    const parsed = JSON.parse(raw) as Partial<DriveStatusRecord>;
+    if (
+      parsed &&
+      typeof parsed.status === "string" &&
+      typeof parsed.ts === "number"
+    ) {
+      return parsed as DriveStatusRecord;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Delete BOTH the refresh-token slot and the status slot for the agent.
+ * Used by `switchroom drive disconnect <agent>` and the kernel's
+ * `/revoke-all` killswitch path. Idempotent — removing a missing slot is
+ * not an error.
+ */
+export function deleteSlots(args: {
+  passphrase: string;
+  vaultPath: string;
+  agentUnit: string;
+}): void {
+  try {
+    removeSecret(
+      args.passphrase,
+      args.vaultPath,
+      refreshTokenSlot(args.agentUnit),
+    );
+  } catch {
+    /* slot was absent — that's fine */
+  }
+  try {
+    removeSecret(args.passphrase, args.vaultPath, statusSlot(args.agentUnit));
+  } catch {
+    /* slot was absent — that's fine */
+  }
+}

--- a/src/drive/wrapper.test.ts
+++ b/src/drive/wrapper.test.ts
@@ -1,0 +1,108 @@
+/**
+ * DriveTokenCache — refresh + invalid_grant rotation tests.
+ */
+
+import { describe, expect, it, mock } from "bun:test";
+import { DriveTokenCache } from "./wrapper.js";
+import { InvalidGrantError } from "./oauth.js";
+
+const oauth = {
+  client_id: "cid",
+  client_secret: "csec",
+  scopes: ["x"],
+};
+
+function tokenResp(opts: { status?: number; body?: unknown } = {}): Response {
+  return new Response(
+    JSON.stringify(
+      opts.body ?? { access_token: "at", expires_in: 3600, token_type: "Bearer" },
+    ),
+    { status: opts.status ?? 200 },
+  );
+}
+
+describe("DriveTokenCache", () => {
+  it("mints a fresh access token on first call", async () => {
+    const cache = new DriveTokenCache({
+      oauth,
+      loadRefreshToken: async () => "rt",
+      onInvalidGrant: async () => {
+        throw new Error("should not be called");
+      },
+      fetchImpl: mock(async () => tokenResp()) as unknown as typeof fetch,
+      now: () => 1_000_000,
+    });
+    const handle = await cache.getAccessToken();
+    expect(handle.access_token).toBe("at");
+    // 30s safety margin baked in
+    expect(handle.expires_at).toBe(1_000_000 + (3600 - 30) * 1000);
+  });
+
+  it("returns the cached token on a subsequent call within window", async () => {
+    let calls = 0;
+    const cache = new DriveTokenCache({
+      oauth,
+      loadRefreshToken: async () => "rt",
+      onInvalidGrant: async () => undefined,
+      fetchImpl: mock(async () => {
+        calls++;
+        return tokenResp();
+      }) as unknown as typeof fetch,
+      now: () => 1_000_000,
+    });
+    await cache.getAccessToken();
+    await cache.getAccessToken();
+    expect(calls).toBe(1);
+  });
+
+  it("throws when no refresh token in vault", async () => {
+    const cache = new DriveTokenCache({
+      oauth,
+      loadRefreshToken: async () => null,
+      onInvalidGrant: async () => undefined,
+    });
+    await expect(cache.getAccessToken()).rejects.toThrow(/not connected/);
+  });
+
+  it("calls onInvalidGrant + rethrows when Google rotates the refresh token", async () => {
+    const onInvalidGrant = mock(async (_d: string) => undefined);
+    const cache = new DriveTokenCache({
+      oauth,
+      loadRefreshToken: async () => "rt",
+      onInvalidGrant,
+      fetchImpl: mock(async () =>
+        tokenResp({
+          status: 400,
+          body: {
+            error: "invalid_grant",
+            error_description: "Token revoked.",
+          },
+        }),
+      ) as unknown as typeof fetch,
+    });
+    await expect(cache.getAccessToken()).rejects.toBeInstanceOf(InvalidGrantError);
+    expect(onInvalidGrant).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onReconnected when a fresh token is minted after a prior invalid_grant", async () => {
+    const onReconnected = mock(async () => undefined);
+    let attempt = 0;
+    const cache = new DriveTokenCache({
+      oauth,
+      loadRefreshToken: async () => "rt",
+      onInvalidGrant: async () => undefined,
+      onReconnected,
+      fetchImpl: mock(async () => {
+        attempt++;
+        if (attempt === 1) {
+          return tokenResp({ status: 400, body: { error: "invalid_grant" } });
+        }
+        return tokenResp();
+      }) as unknown as typeof fetch,
+    });
+    await expect(cache.getAccessToken()).rejects.toBeInstanceOf(InvalidGrantError);
+    // User reconnected; vault now has a fresh token (loadRefreshToken returns "rt" still — fine for the test).
+    await cache.getAccessToken();
+    expect(onReconnected).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/drive/wrapper.ts
+++ b/src/drive/wrapper.ts
@@ -48,6 +48,11 @@ export interface WrapperDeps {
   /**
    * Called the first time we successfully mint an access token after a prior
    * invalid_grant. Used to flip the sidecar status slot back to `connected`.
+   *
+   * Caller is responsible for: (a) writing `status: 'connected'` back to
+   * the vault status slot, (b) editing or removing the prior reconnect
+   * card if still pending. The wrapper itself only signals — it does not
+   * touch the status slot or any UI surface.
    */
   onReconnected?: () => Promise<void>;
   /** Google OAuth client config (client_id / client_secret / scopes). */

--- a/src/drive/wrapper.ts
+++ b/src/drive/wrapper.ts
@@ -1,0 +1,132 @@
+/**
+ * Drive MCP wrapper — refreshes access tokens on demand, handles
+ * `invalid_grant` rotation per RFC C §4.2.
+ *
+ * Pure orchestration; no side-effecting I/O lives here directly. The two
+ * collaborators it uses are both injectable so unit tests don't need a vault
+ * or a network:
+ *
+ *   - `loadRefreshToken()` — pulls the durable token from the vault.
+ *   - `markInvalidGrant()` — flips the sidecar status slot AND fires a
+ *     kernel approval card titled "reconnect google drive". The approval
+ *     surface is `system` so it goes through the standard kernel channel.
+ *
+ * The wrapper holds the access token in process memory only. On any
+ * `invalid_grant` from Google we drop the cached access token AND mark the
+ * status slot — the next call will re-attempt refresh and (if the user has
+ * re-connected) recover; otherwise the request_approval card is the user's
+ * recovery path.
+ */
+
+import {
+  refreshAccessToken,
+  InvalidGrantError,
+  type OAuthClientConfig,
+  type TokenResponse,
+} from "./oauth.js";
+
+export interface DriveAccessHandle {
+  /** Bearer token for Authorization: Bearer <token>. */
+  access_token: string;
+  /** Unix-ms when this access token expires (with a small safety margin). */
+  expires_at: number;
+}
+
+export interface WrapperDeps {
+  /** Read the refresh token from the vault for this agent. */
+  loadRefreshToken: () => Promise<string | null>;
+  /**
+   * Called when Google rotates/revokes the refresh token. Implementations
+   * should:
+   *   1. Write status slot = `invalid_grant`.
+   *   2. Fire a kernel `request_approval` card with surface `system`,
+   *      action `reconnect_drive`. On user tap, run `switchroom drive
+   *      connect <agent>` again.
+   * The wrapper does not block on the approval — it just signals.
+   */
+  onInvalidGrant: (detail: string) => Promise<void>;
+  /**
+   * Called the first time we successfully mint an access token after a prior
+   * invalid_grant. Used to flip the sidecar status slot back to `connected`.
+   */
+  onReconnected?: () => Promise<void>;
+  /** Google OAuth client config (client_id / client_secret / scopes). */
+  oauth: OAuthClientConfig;
+  /** Injectable for tests. */
+  fetchImpl?: typeof fetch;
+  /** Injectable for tests. */
+  now?: () => number;
+}
+
+/**
+ * Per-agent in-memory cache of the access token. One instance per running
+ * agent process. NOT shared across processes (each process refreshes
+ * independently — Google permits parallel refresh).
+ */
+export class DriveTokenCache {
+  private cached: DriveAccessHandle | null = null;
+  /** Tracks whether the previous refresh attempt failed with invalid_grant. */
+  private inInvalidGrant = false;
+
+  constructor(private readonly deps: WrapperDeps) {}
+
+  /**
+   * Return a valid access token, minting a new one if the cache is cold or
+   * within `refreshWindowMs` of expiry. Throws when no refresh token is
+   * available (caller should surface "drive disconnected") or when refresh
+   * itself fails for a non-invalid_grant reason.
+   *
+   * On invalid_grant: drops cache, calls `onInvalidGrant`, and rethrows
+   * InvalidGrantError so the caller can surface the disconnect. Subsequent
+   * calls keep failing the same way until the user reconnects (writing a
+   * fresh refresh token to the vault).
+   */
+  async getAccessToken(refreshWindowMs = 60_000): Promise<DriveAccessHandle> {
+    const now = (this.deps.now ?? Date.now)();
+    if (this.cached && this.cached.expires_at > now + refreshWindowMs) {
+      return this.cached;
+    }
+    const refreshToken = await this.deps.loadRefreshToken();
+    if (!refreshToken) {
+      throw new Error(
+        "Drive not connected for this agent (no refresh token in vault). " +
+          "Run `switchroom drive connect <agent>`.",
+      );
+    }
+    let resp: TokenResponse;
+    try {
+      resp = await refreshAccessToken(
+        this.deps.oauth,
+        refreshToken,
+        this.deps.fetchImpl ?? fetch,
+      );
+    } catch (e) {
+      if (e instanceof InvalidGrantError) {
+        this.cached = null;
+        this.inInvalidGrant = true;
+        await this.deps.onInvalidGrant(e.detail);
+        throw e;
+      }
+      throw e;
+    }
+    // Successful refresh — clear the invalid_grant flag if we were in it.
+    const handle: DriveAccessHandle = {
+      access_token: resp.access_token,
+      expires_at: now + (resp.expires_in - 30) * 1000,
+    };
+    this.cached = handle;
+    if (this.inInvalidGrant) {
+      this.inInvalidGrant = false;
+      if (this.deps.onReconnected) {
+        await this.deps.onReconnected();
+      }
+    }
+    return handle;
+  }
+
+  /** Drop the cached access token. Used by tests + after explicit revoke. */
+  reset(): void {
+    this.cached = null;
+    this.inInvalidGrant = false;
+  }
+}

--- a/src/memory/scaffold-integration.ts
+++ b/src/memory/scaffold-integration.ts
@@ -51,6 +51,47 @@ export function getPlaywrightMcpSettingsEntry(): { key: string; value: McpServer
 }
 
 /**
+ * Return the MCP server entry for the Google Workspace MCP (Drive + Docs +
+ * Sheets + Calendar + Gmail) per RFC C §2.
+ *
+ * Pinned to a specific upstream commit SHA — RFC C requires this rather
+ * than a floating tag so upgrades are explicit. The chosen SHA corresponds
+ * to taylorwilsdon/google_workspace_mcp v0.5.x as of 2026-05.
+ *
+ * The server is launched via `uvx --from git+https://...@<sha>` so no
+ * system-wide install is required and the version is reproducible.
+ *
+ * Default OFF — the server only does anything useful after the operator
+ * has run `switchroom drive connect <agent>` and consented through the
+ * onboarding card. Agents that need it opt-in via
+ * `mcp_servers: { gdrive: true }`; opt-out (the usual default-MCP shape)
+ * is `mcp_servers: { gdrive: false }`. The reconciler honours either.
+ */
+export function getGdriveMcpSettingsEntry(): { key: string; value: McpServerConfig } {
+  // Specific commit SHA — bump deliberately. Replace with a real upstream
+  // SHA at integration time; this pin is the v0.5.0 tag commit on
+  // taylorwilsdon/google_workspace_mcp.
+  const PINNED_SHA = "v0.5.0";
+  return {
+    key: "gdrive",
+    value: {
+      command: "uvx",
+      args: [
+        "--from",
+        `git+https://github.com/taylorwilsdon/google_workspace_mcp.git@${PINNED_SHA}`,
+        "google-workspace-mcp",
+      ],
+      env: {
+        // The MCP wrapper reads the refresh token from the broker on
+        // startup; the bridging script (drive-mcp-launcher.ts, future
+        // work) injects GOOGLE_OAUTH_REFRESH_TOKEN at spawn time.
+        GOOGLE_OAUTH_TOKEN_FROM_VAULT: "1",
+      },
+    },
+  };
+}
+
+/**
  * Describes a single built-in default MCP entry.
  *
  * - `key`: the mcpServers key in settings.json (e.g. "playwright")

--- a/src/memory/scaffold-integration.ts
+++ b/src/memory/scaffold-integration.ts
@@ -68,10 +68,13 @@ export function getPlaywrightMcpSettingsEntry(): { key: string; value: McpServer
  * is `mcp_servers: { gdrive: false }`. The reconciler honours either.
  */
 export function getGdriveMcpSettingsEntry(): { key: string; value: McpServerConfig } {
-  // Specific commit SHA — bump deliberately. Replace with a real upstream
-  // SHA at integration time; this pin is the v0.5.0 tag commit on
-  // taylorwilsdon/google_workspace_mcp.
-  const PINNED_SHA = "v0.5.0";
+  // Specific commit SHA — bump deliberately. Pinning to a 40-char commit
+  // SHA (not a tag) means upstream history rewrites can't change what we
+  // run. google_workspace_mcp v1.20.3 = f3c7dc5df2641c8545abc9e8f402d794f2853745;
+  // verified MIT-licensed at this SHA on 2026-05-06.
+  // (Note: RFC C originally referenced v0.5.0; that tag does not exist on
+  // upstream — v1.20.3 is the latest stable as of this pin.)
+  const PINNED_SHA = "f3c7dc5df2641c8545abc9e8f402d794f2853745";
   return {
     key: "gdrive",
     value: {


### PR DESCRIPTION
## Summary

Implements **RFC C** — Google Drive MCP integration. Builds on top of the RFC B approval kernel (just merged in #762).

**What's in:**
- **OAuth flow** (`src/drive/oauth.ts`) — three-tier auto-selection: desktop-browser loopback, headless device-code (RFC 8628), and explicit `--headless`. Refresh tokens land in the vault.
- **Vault slots + token cache** (`src/drive/vault-slots.ts`) — per-agent refresh-token storage; access-token cache with rotation on \`invalid_grant\`.
- **Three-state reconciler** (`src/drive/reconciler.ts`) — present / missing / conflict, per RFC §8.
- **Write-namespace separation** (`src/drive/grants.ts`, `src/drive/wrapper.ts`) — read and write grants are distinct; write callsites traverse the approval kernel.
- **Onboarding card + killswitch** (`src/drive/onboarding.ts`, `src/drive/disconnect.ts`) — first-run flip away from per-doc prompt-flood; one-tap disconnect.
- **Scaffold integration** (`src/memory/scaffold-integration.ts`) — wires Drive into the existing memory scaffolding.

**Doc patch (important):** `docs/rfcs/gdrive-mcp.md` §2 originally specified \`taylorwilsdon/google_workspace_mcp v0.5.x\` — but no \`v0.5.x\` tag exists upstream. The implementation pins **v1.20.3** (commit \`f3c7dc5df2641c8545abc9e8f402d794f2853745\`, MIT-licensed). The RFC text has been corrected to match reality.

**What's deferred:**
- CLI commands (\`switchroom drive connect/disconnect/status\`) and live \`onInvalidGrant\` wiring — blocked on a short-poll \`approval.wait\` helper from RFC B Phase 2. Will land in a follow-up issue once that helper is available.

## Reviewer verdict

APPROVE (after fix-loop — see \`fix(gdrive): address RFC C reviewer blockers\`).

## Tests

- \`bun test src/drive/\` → **75 pass / 0 fail**.
- \`npm run lint:tsc\` → clean for all touched files.

## Branching note

Cherry-picked from \`feat/gdrive-mcp-rfc-c\` (\`ac94fdd5\`) onto \`upstream/main\` (now containing RFC B) to avoid fork-divergence conflicts.