### PR TITLE
feat(drive): drive: config block (replaces/supplements env vars)

### DIFF
--- a/src/cli/drive.test.ts
+++ b/src/cli/drive.test.ts
@@ -8,16 +8,32 @@
 
 import { describe, it, expect, beforeEach, vi } from "vitest";
 
-vi.mock("../config/loader.js", () => ({
-  loadConfig: vi.fn(() => ({
+// Mutable config seam so individual tests can swap in `drive:` blocks.
+const configMock = {
+  current: {
     switchroom: { version: 1 },
     telegram: { bot_token: "x", forum_chat_id: "1" },
     agents: { klanker: {} },
     vault: { path: "~/.switchroom/vault.enc" },
-  })),
+  } as Record<string, unknown>,
+};
+
+vi.mock("../config/loader.js", () => ({
+  loadConfig: vi.fn(() => configMock.current),
   resolvePath: (p: string) => p.replace(/^~/, "/tmp"),
   findConfigFile: () => "/tmp/switchroom.yaml",
   ConfigError: class ConfigError extends Error {},
+}));
+
+// Vault-secret resolver seam: tests opt in by populating this map and
+// configuring drive.google_client_id = 'vault:<key>'.
+const vaultMock = {
+  secrets: {} as Record<string, { kind: string; value: string } | null>,
+};
+vi.mock("../vault/vault.js", () => ({
+  getSecret: vi.fn((_pp: string, _vp: string, key: string) =>
+    vaultMock.secrets[key] ?? null,
+  ),
 }));
 
 import { __test, type DriveCliDeps } from "./drive.js";
@@ -84,6 +100,13 @@ describe("drive connect", () => {
     process.env.SWITCHROOM_GOOGLE_CLIENT_ID = "cid";
     process.env.SWITCHROOM_GOOGLE_CLIENT_SECRET = "csec";
     process.env.SWITCHROOM_APPROVER_USER_ID = "42";
+    configMock.current = {
+      switchroom: { version: 1 },
+      telegram: { bot_token: "x", forum_chat_id: "1" },
+      agents: { klanker: {} },
+      vault: { path: "~/.switchroom/vault.enc" },
+    };
+    vaultMock.secrets = {};
   });
 
   it("granted: writes vault slots and exits 0", async () => {
@@ -212,6 +235,155 @@ describe("drive connect", () => {
     const { deps, exit } = makeDeps();
     await __test.runConnect({ agentName: "klanker" }, deps);
     expect(exit.code).toBe(4);
+  });
+
+  // ─── drive: config block ────────────────────────────────────────────────
+  // Precedence is env > config: env vars exist for one-off override (CI,
+  // emergency rotation) and back-compat with the env-only flow shipped in
+  // #766. Config is the persistent baseline.
+
+  it("config: reads google_client_id/secret from drive: block when env is unset", async () => {
+    delete process.env.SWITCHROOM_GOOGLE_CLIENT_ID;
+    delete process.env.SWITCHROOM_GOOGLE_CLIENT_SECRET;
+    delete process.env.SWITCHROOM_APPROVER_USER_ID;
+    configMock.current = {
+      ...configMock.current,
+      drive: {
+        google_client_id: "cfg-id",
+        google_client_secret: "cfg-secret",
+        approvers: [42],
+      },
+    };
+    const { deps, exit, writes } = makeDeps();
+    await __test.runConnect({ agentName: "klanker" }, deps);
+    expect(exit.code).toBe(0);
+    expect(writes.token).toBe(1);
+    const oauthSpy = deps.runOAuth as ReturnType<typeof vi.fn>;
+    const cfgArg = oauthSpy.mock.calls[0]?.[0] as { client_id: string; client_secret: string };
+    expect(cfgArg.client_id).toBe("cfg-id");
+    expect(cfgArg.client_secret).toBe("cfg-secret");
+  });
+
+  it("config: env wins over config (precedence: env > config)", async () => {
+    process.env.SWITCHROOM_GOOGLE_CLIENT_ID = "env-id";
+    process.env.SWITCHROOM_GOOGLE_CLIENT_SECRET = "env-secret";
+    configMock.current = {
+      ...configMock.current,
+      drive: {
+        google_client_id: "cfg-id",
+        google_client_secret: "cfg-secret",
+        approvers: [42],
+      },
+    };
+    const { deps, exit } = makeDeps();
+    await __test.runConnect({ agentName: "klanker" }, deps);
+    expect(exit.code).toBe(0);
+    const oauthSpy = deps.runOAuth as ReturnType<typeof vi.fn>;
+    const cfgArg = oauthSpy.mock.calls[0]?.[0] as { client_id: string; client_secret: string };
+    expect(cfgArg.client_id).toBe("env-id");
+    expect(cfgArg.client_secret).toBe("env-secret");
+  });
+
+  it("config: vault: refs in google_client_id/secret are resolved", async () => {
+    delete process.env.SWITCHROOM_GOOGLE_CLIENT_ID;
+    delete process.env.SWITCHROOM_GOOGLE_CLIENT_SECRET;
+    vaultMock.secrets = {
+      "google-oauth-client-id": { kind: "string", value: "resolved-id" },
+      "google-oauth-client-secret": { kind: "string", value: "resolved-secret" },
+    };
+    configMock.current = {
+      ...configMock.current,
+      drive: {
+        google_client_id: "vault:google-oauth-client-id",
+        google_client_secret: "vault:google-oauth-client-secret",
+        approvers: [42],
+      },
+    };
+    const { deps, exit } = makeDeps();
+    await __test.runConnect({ agentName: "klanker" }, deps);
+    expect(exit.code).toBe(0);
+    const oauthSpy = deps.runOAuth as ReturnType<typeof vi.fn>;
+    const cfgArg = oauthSpy.mock.calls[0]?.[0] as { client_id: string; client_secret: string };
+    expect(cfgArg.client_id).toBe("resolved-id");
+    expect(cfgArg.client_secret).toBe("resolved-secret");
+  });
+
+  it("config: missing vault entry referenced by drive.google_client_id exits 4", async () => {
+    delete process.env.SWITCHROOM_GOOGLE_CLIENT_ID;
+    delete process.env.SWITCHROOM_GOOGLE_CLIENT_SECRET;
+    configMock.current = {
+      ...configMock.current,
+      drive: {
+        google_client_id: "vault:nope",
+        google_client_secret: "raw",
+        approvers: [42],
+      },
+    };
+    const { deps, exit, errOut } = makeDeps();
+    await __test.runConnect({ agentName: "klanker" }, deps);
+    expect(exit.code).toBe(4);
+    expect(errOut.join("\n")).toMatch(/vault key 'nope'/);
+  });
+
+  it("config: per-agent drive.approvers wins over top-level drive.approvers", async () => {
+    delete process.env.SWITCHROOM_APPROVER_USER_ID;
+    configMock.current = {
+      ...configMock.current,
+      agents: { klanker: { drive: { approvers: [777] } } },
+      drive: {
+        google_client_id: "id",
+        google_client_secret: "secret",
+        approvers: [42],
+      },
+    };
+    const { deps, exit } = makeDeps();
+    await __test.runConnect({ agentName: "klanker" }, deps);
+    expect(exit.code).toBe(0);
+    const waitSpy = deps.waitForApproval as ReturnType<typeof vi.fn>;
+    const callArg = waitSpy.mock.calls[0]?.[0] as { approver_set: string[] };
+    expect(callArg.approver_set).toEqual(["user:777"]);
+  });
+
+  it("config: top-level drive.approvers used when no env, no flag, no per-agent override", async () => {
+    delete process.env.SWITCHROOM_APPROVER_USER_ID;
+    configMock.current = {
+      ...configMock.current,
+      drive: {
+        google_client_id: "id",
+        google_client_secret: "secret",
+        approvers: [42],
+      },
+    };
+    const { deps, exit } = makeDeps();
+    await __test.runConnect({ agentName: "klanker" }, deps);
+    expect(exit.code).toBe(0);
+    const waitSpy = deps.waitForApproval as ReturnType<typeof vi.fn>;
+    const callArg = waitSpy.mock.calls[0]?.[0] as { approver_set: string[] };
+    expect(callArg.approver_set).toEqual(["user:42"]);
+  });
+
+  it("missing all sources (env + config): exits 4 with helpful message naming both", async () => {
+    delete process.env.SWITCHROOM_GOOGLE_CLIENT_ID;
+    delete process.env.SWITCHROOM_GOOGLE_CLIENT_SECRET;
+    delete process.env.SWITCHROOM_APPROVER_USER_ID;
+    const { deps, exit, errOut } = makeDeps();
+    await __test.runConnect({ agentName: "klanker" }, deps);
+    expect(exit.code).toBe(4);
+    const blob = errOut.join("\n");
+    expect(blob).toMatch(/switchroom\.yaml/);
+    expect(blob).toMatch(/SWITCHROOM_GOOGLE_CLIENT_ID/);
+  });
+
+  it("missing approver across all sources: exits 4 naming both options", async () => {
+    delete process.env.SWITCHROOM_APPROVER_USER_ID;
+    // client id/secret still come from env; only approver is missing.
+    const { deps, exit, errOut } = makeDeps();
+    await __test.runConnect({ agentName: "klanker" }, deps);
+    expect(exit.code).toBe(4);
+    const blob = errOut.join("\n");
+    expect(blob).toMatch(/drive\.approvers/);
+    expect(blob).toMatch(/SWITCHROOM_APPROVER_USER_ID/);
+    expect(blob).toMatch(/--approver/);
   });
 });
 

--- a/src/cli/drive.ts
+++ b/src/cli/drive.ts
@@ -6,17 +6,20 @@
  * follow-up so the operator gets a Telegram approval card after a successful
  * Google OAuth and the CLI blocks until they tap.
  *
- * Sourcing of inputs that aren't covered by the existing config schema:
- *   - Google OAuth client id/secret: env vars
- *       SWITCHROOM_GOOGLE_CLIENT_ID, SWITCHROOM_GOOGLE_CLIENT_SECRET.
+ * Sourcing of inputs (precedence: env > config, with --approver winning
+ * over both for the approver field):
+ *   - Google OAuth client id/secret:
+ *       env: SWITCHROOM_GOOGLE_CLIENT_ID, SWITCHROOM_GOOGLE_CLIENT_SECRET
+ *       config: drive.google_client_id, drive.google_client_secret
+ *         (raw strings or 'vault:<key>' refs resolved against the unlocked vault)
  *   - Approver user id (Telegram numeric id, prefixed `user:` per the kernel
- *     canonicalization convention used elsewhere): env var
- *       SWITCHROOM_APPROVER_USER_ID
- *     (or pass `--approver` on the command).
+ *     canonicalization convention used elsewhere):
+ *       --approver flag, OR env SWITCHROOM_APPROVER_USER_ID, OR
+ *       config agents.<agent>.drive.approvers (per-agent), OR
+ *       config drive.approvers (top-level)
  *
- * These deliberately avoid a schema change — the drive CLI ships before the
- * config-side wiring is settled. A follow-up will likely move both into
- * switchroom.yaml under a `drive:` block.
+ * Env-only operation is preserved for back-compat — agents that were
+ * configured before the `drive:` block existed continue to work unchanged.
  */
 
 import type { Command } from "commander";
@@ -48,6 +51,8 @@ import {
   waitForApproval,
   type WaitForApprovalResult,
 } from "../vault/approvals/wait.js";
+import { isVaultReference, parseVaultReference } from "../vault/resolver.js";
+import { getSecret } from "../vault/vault.js";
 
 // ── Exit codes (documented in command help) ──────────────────────────────────
 //   0 = success
@@ -256,23 +261,48 @@ async function runConnect(args: ConnectArgs, deps: DriveCliDeps): Promise<void> 
   }
 
   // 2. Resolve OAuth client + approver.
-  const clientId = process.env.SWITCHROOM_GOOGLE_CLIENT_ID;
-  const clientSecret = process.env.SWITCHROOM_GOOGLE_CLIENT_SECRET;
-  if (!clientId || !clientSecret) {
+  //
+  // Precedence (env > config) is deliberate: env vars are used for one-off
+  // overrides (CI, debugging, emergency rotation) while the config block is
+  // the persistent baseline. This also preserves back-compat with operators
+  // who set the env vars before the `drive:` block existed.
+  //
+  // Values from config that look like 'vault:<key>' are resolved AFTER the
+  // passphrase prompt below (we don't have the unlocked vault yet here).
+  const driveCfg = config.drive;
+  const agentDriveCfg = config.agents[args.agentName]?.drive;
+
+  let clientIdRaw = process.env.SWITCHROOM_GOOGLE_CLIENT_ID ?? driveCfg?.google_client_id;
+  let clientSecretRaw = process.env.SWITCHROOM_GOOGLE_CLIENT_SECRET ?? driveCfg?.google_client_secret;
+  if (!clientIdRaw || !clientSecretRaw) {
     err(
       chalk.red(
-        "Error: SWITCHROOM_GOOGLE_CLIENT_ID and SWITCHROOM_GOOGLE_CLIENT_SECRET must be set.",
+        "Error: missing Google OAuth client credentials. Set drive.google_client_id " +
+          "and drive.google_client_secret in switchroom.yaml (vault:<key> refs supported), " +
+          "or set env vars SWITCHROOM_GOOGLE_CLIENT_ID and SWITCHROOM_GOOGLE_CLIENT_SECRET.",
       ),
     );
     return exit(EXIT_ERROR);
   }
-  const approver =
-    args.approver ?? process.env.SWITCHROOM_APPROVER_USER_ID ?? "";
+
+  // Approver: --approver flag > env > per-agent config > top-level config.
+  // Per-agent config replaces (does not extend) the top-level approvers list.
+  let approver = args.approver ?? process.env.SWITCHROOM_APPROVER_USER_ID ?? "";
+  if (!approver) {
+    const cfgApprovers = agentDriveCfg?.approvers ?? driveCfg?.approvers;
+    if (cfgApprovers && cfgApprovers.length > 0) {
+      // Use the first entry. Multi-approver-set is supported by the kernel
+      // but the CLI's current model is one approver per connect invocation
+      // (any one of the set is sufficient — but we only pass one here for
+      // back-compat with the existing wait flow).
+      approver = String(cfgApprovers[0]);
+    }
+  }
   if (!approver) {
     err(
       chalk.red(
-        "Error: no approver configured. Pass --approver <user_id> or set " +
-          "SWITCHROOM_APPROVER_USER_ID.",
+        "Error: no approver configured. Pass --approver <user_id>, set " +
+          "drive.approvers in switchroom.yaml, or set SWITCHROOM_APPROVER_USER_ID.",
       ),
     );
     return exit(EXIT_ERROR);
@@ -293,12 +323,6 @@ async function runConnect(args: ConnectArgs, deps: DriveCliDeps): Promise<void> 
     return exit(EXIT_ERROR);
   }
   const approverPrincipal = `user:${approverRaw}`;
-
-  const oauthCfg: OAuthClientConfig = {
-    client_id: clientId,
-    client_secret: clientSecret,
-    scopes: DEFAULT_SCOPES,
-  };
 
   // 3. Resolve passphrase BEFORE OAuth (fail-fast). If the passphrase is
   // wrong, the OAuth flow would otherwise complete and the freshly-minted
@@ -366,6 +390,51 @@ async function runConnect(args: ConnectArgs, deps: DriveCliDeps): Promise<void> 
     // already handled above; defensive only
     existingToken = null;
   }
+
+  // Resolve any 'vault:<key>' references that came from the config block.
+  // Env-supplied values are used as-is (operators set raw values in env).
+  const resolveMaybeVaultRef = (raw: string, label: string): string | null => {
+    if (!isVaultReference(raw)) return raw;
+    const key = parseVaultReference(raw);
+    try {
+      const entry = getSecret(passphrase, vaultPath, key);
+      if (!entry) {
+        err(
+          chalk.red(
+            `Error: ${label} references vault key '${key}' but no such secret is in the vault.`,
+          ),
+        );
+        return null;
+      }
+      if (entry.kind !== "string") {
+        err(
+          chalk.red(
+            `Error: ${label} vault entry '${key}' is not a string (kind=${entry.kind}).`,
+          ),
+        );
+        return null;
+      }
+      return entry.value;
+    } catch (e) {
+      err(
+        chalk.red(
+          `Error resolving ${label} vault ref '${key}': ${(e as Error).message}`,
+        ),
+      );
+      return null;
+    }
+  };
+
+  const clientId = resolveMaybeVaultRef(clientIdRaw, "google_client_id");
+  if (clientId === null) return exit(EXIT_ERROR);
+  const clientSecret = resolveMaybeVaultRef(clientSecretRaw, "google_client_secret");
+  if (clientSecret === null) return exit(EXIT_ERROR);
+
+  const oauthCfg: OAuthClientConfig = {
+    client_id: clientId,
+    client_secret: clientSecret,
+    scopes: DEFAULT_SCOPES,
+  };
 
   if (!existingToken) {
     // 5. Pick OAuth tier and run the flow.
@@ -603,9 +672,11 @@ export function registerDriveCommand(program: Command, deps: DriveCliDeps = {}):
     .command("connect <agent>")
     .description(
       "Run Google OAuth for <agent>, persist refresh token to vault, then " +
-        "block on a Telegram approval card. Requires SWITCHROOM_GOOGLE_CLIENT_ID, " +
-        "SWITCHROOM_GOOGLE_CLIENT_SECRET, and either --approver or " +
-        "SWITCHROOM_APPROVER_USER_ID.",
+        "block on a Telegram approval card. Recommended: configure the `drive:` " +
+        "block in switchroom.yaml (google_client_id, google_client_secret — " +
+        "vault:<key> refs supported — and approvers list). Env vars " +
+        "SWITCHROOM_GOOGLE_CLIENT_ID / SWITCHROOM_GOOGLE_CLIENT_SECRET / " +
+        "SWITCHROOM_APPROVER_USER_ID still work and override the config block.",
     )
     .option(
       "--approver <user_id>",

--- a/src/config/schema.test.ts
+++ b/src/config/schema.test.ts
@@ -10,7 +10,14 @@
  */
 
 import { describe, expect, it } from "vitest";
-import { AgentSchema, ScheduleEntrySchema, VaultConfigSchema } from "./schema.js";
+import {
+  AgentDriveConfigSchema,
+  AgentSchema,
+  DriveConfigSchema,
+  ScheduleEntrySchema,
+  SwitchroomConfigSchema,
+  VaultConfigSchema,
+} from "./schema.js";
 
 describe("ScheduleEntrySchema.secrets", () => {
   it("accepts a list of valid vault key names", () => {
@@ -224,6 +231,112 @@ describe("AgentSchema.fallback_model", () => {
   it("rejects model names with shell-special characters", () => {
     expect(() =>
       AgentSchema.parse(baseAgentInput({ fallback_model: "model$foo" })),
+    ).toThrow();
+  });
+});
+
+describe("DriveConfigSchema (top-level drive: block)", () => {
+  it("parses a fully-populated block", () => {
+    const result = DriveConfigSchema.parse({
+      google_client_id: "raw-id",
+      google_client_secret: "raw-secret",
+      approvers: [8248703757],
+    });
+    expect(result?.google_client_id).toBe("raw-id");
+    expect(result?.approvers).toEqual([8248703757]);
+  });
+
+  it("accepts vault: refs for client id/secret", () => {
+    const result = DriveConfigSchema.parse({
+      google_client_id: "vault:google-oauth-client-id",
+      google_client_secret: "vault:google-oauth-client-secret",
+      approvers: [8248703757],
+    });
+    expect(result?.google_client_id).toBe("vault:google-oauth-client-id");
+    expect(result?.google_client_secret).toBe("vault:google-oauth-client-secret");
+  });
+
+  it("accepts numeric-string approver ids", () => {
+    const result = DriveConfigSchema.parse({
+      google_client_id: "id",
+      google_client_secret: "secret",
+      approvers: ["8248703757", "111"],
+    });
+    expect(result?.approvers).toEqual(["8248703757", "111"]);
+  });
+
+  it("rejects non-numeric string approver", () => {
+    expect(() =>
+      DriveConfigSchema.parse({
+        google_client_id: "id",
+        google_client_secret: "secret",
+        approvers: ["ken"],
+      }),
+    ).toThrow();
+  });
+
+  it("requires at least one approver when block is present", () => {
+    expect(() =>
+      DriveConfigSchema.parse({
+        google_client_id: "id",
+        google_client_secret: "secret",
+        approvers: [],
+      }),
+    ).toThrow();
+  });
+
+  it("requires google_client_id and google_client_secret when block is present", () => {
+    expect(() =>
+      DriveConfigSchema.parse({ approvers: [1] }),
+    ).toThrow();
+    expect(() =>
+      DriveConfigSchema.parse({
+        google_client_id: "id",
+        approvers: [1],
+      }),
+    ).toThrow();
+  });
+
+  it("is fully optional — undefined is accepted (back-compat with env-only flow)", () => {
+    expect(DriveConfigSchema.parse(undefined)).toBeUndefined();
+  });
+
+  it("is wired onto the top-level SwitchroomConfigSchema as `drive`", () => {
+    const result = SwitchroomConfigSchema.parse({
+      switchroom: { version: 1 },
+      telegram: { bot_token: "x", forum_chat_id: "1" },
+      drive: {
+        google_client_id: "vault:google-oauth-client-id",
+        google_client_secret: "vault:google-oauth-client-secret",
+        approvers: [8248703757],
+      },
+      agents: {},
+    });
+    expect(result.drive?.google_client_id).toBe("vault:google-oauth-client-id");
+  });
+});
+
+describe("AgentDriveConfigSchema (per-agent override)", () => {
+  it("accepts an approvers override", () => {
+    const result = AgentDriveConfigSchema.parse({ approvers: [123, 456] });
+    expect(result?.approvers).toEqual([123, 456]);
+  });
+
+  it("is optional everywhere — block can be omitted on the agent", () => {
+    const result = AgentSchema.parse(baseAgentInput());
+    expect(result.drive).toBeUndefined();
+  });
+
+  it("is wired onto AgentSchema as `drive`", () => {
+    const result = AgentSchema.parse(
+      baseAgentInput({ drive: { approvers: [999] } }),
+    );
+    expect(result.drive?.approvers).toEqual([999]);
+  });
+
+  it("rejects an empty approvers list when the block is present", () => {
+    expect(() =>
+      AgentSchema.parse(baseAgentInput({ drive: { approvers: [] } })),
     ).toThrow();
   });
 });

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -620,6 +620,58 @@ export const ChannelsSchema = z
  */
 const TIMEZONE_REGEX = /^UTC$|^[A-Z][A-Za-z0-9_+-]+(\/[A-Z][A-Za-z0-9_+-]+){1,2}$/;
 
+const ApproverIdSchema = z.union([z.number(), z.string().regex(/^\d+$/)]);
+
+/**
+ * Top-level drive config block. Centralizes Google OAuth client credentials
+ * and the approver allowlist used by `switchroom drive connect` so operators
+ * don't have to manage env vars. The block is optional — when omitted, the
+ * CLI falls back to env vars (SWITCHROOM_GOOGLE_CLIENT_ID/_SECRET,
+ * SWITCHROOM_APPROVER_USER_ID). When both are set, env wins (deliberate:
+ * env is for one-off overrides; config is the persistent baseline).
+ */
+export const DriveConfigSchema = z
+  .object({
+    google_client_id: z
+      .string()
+      .min(1)
+      .describe(
+        "Google OAuth client ID (literal string or vault reference e.g. 'vault:google-oauth-client-id')"
+      ),
+    google_client_secret: z
+      .string()
+      .min(1)
+      .describe(
+        "Google OAuth client secret (literal string or vault reference e.g. 'vault:google-oauth-client-secret')"
+      ),
+    approvers: z
+      .array(ApproverIdSchema)
+      .min(1)
+      .describe(
+        "Array of numeric Telegram user IDs authorized to approve drive onboarding. " +
+        "At least one must be specified."
+      ),
+  })
+  .optional();
+
+/**
+ * Per-agent drive override. Currently just narrows the approver set for a
+ * single agent. google_client_id/secret are not per-agent — those live at
+ * the top level (one OAuth client per switchroom install).
+ */
+export const AgentDriveConfigSchema = z
+  .object({
+    approvers: z
+      .array(ApproverIdSchema)
+      .min(1)
+      .optional()
+      .describe(
+        "Per-agent approver override. When set, replaces (does not extend) " +
+        "the top-level drive.approvers list for this agent's onboarding card."
+      ),
+  })
+  .optional();
+
 const profileFields = {
   extends: z.string().optional(),
   bot_token: z.string().optional(),
@@ -1097,6 +1149,11 @@ export const AgentSchema = z.object({
       "claim_worktree accepts the alias as the repo argument. " +
       "Absolute paths may always be passed regardless of this list.",
     ),
+  drive: AgentDriveConfigSchema.describe(
+    "Per-agent drive onboarding overrides (currently just approvers). " +
+    "When set, replaces the top-level drive.approvers list for this agent. " +
+    "google_client_id/secret are not per-agent — they live at the top level.",
+  ),
   repos: z
     .record(
       z.string().regex(
@@ -1276,6 +1333,14 @@ export const SwitchroomConfigSchema = z.object({
   telegram: TelegramConfigSchema,
   memory: MemoryBackendConfigSchema.optional(),
   vault: VaultConfigSchema.optional(),
+  drive: DriveConfigSchema.describe(
+    "Optional drive onboarding configuration. When set, supplies Google " +
+    "OAuth client credentials and the approver allowlist for `switchroom " +
+    "drive connect`. Env vars (SWITCHROOM_GOOGLE_CLIENT_ID, " +
+    "SWITCHROOM_GOOGLE_CLIENT_SECRET, SWITCHROOM_APPROVER_USER_ID) take " +
+    "precedence over this block when set, preserving back-compat with " +
+    "the env-only flow shipped in #766.",
+  ),
   quota: QuotaConfigSchema.optional().describe(
     "Optional weekly/monthly USD spend budgets rendered in the session " +
     "greeting. Usage is read from ccusage at runtime; no network calls.",
@@ -1319,6 +1384,8 @@ export type ScheduleEntry = z.infer<typeof ScheduleEntrySchema>;
 export type TelegramConfig = z.infer<typeof TelegramConfigSchema>;
 export type MemoryBackendConfig = z.infer<typeof MemoryBackendConfigSchema>;
 export type VaultConfig = z.infer<typeof VaultConfigSchema>;
+export type DriveConfig = z.infer<typeof DriveConfigSchema>;
+export type AgentDriveConfig = z.infer<typeof AgentDriveConfigSchema>;
 export type VaultBrokerConfig = z.infer<typeof VaultConfigSchema>["broker"];
 export type QuotaConfig = z.infer<typeof QuotaConfigSchema>;
 export type CodeRepoEntry = z.infer<typeof CodeRepoEntrySchema>;


### PR DESCRIPTION
## Summary

- Adds top-level `drive:` block to switchroom.yaml schema carrying `google_client_id`, `google_client_secret` (`vault:<key>` refs supported), and an `approvers` list.
- Per-agent `agents.<name>.drive.approvers` overrides the top-level approvers list.
- Wires `switchroom drive connect` to read from the config block, falling back to env vars exactly as today.

## Precedence (env > config)

Env wins over config for `google_client_id`, `google_client_secret`, and the approver. Rationale: env vars are the natural one-off-override surface (CI, emergency rotation, debugging), and this preserves the env-only flow shipped in #766 — operators with no `drive:` block see no behaviour change.

For the approver field specifically: `--approver` flag > env > per-agent config > top-level config.

## Vault refs

`vault:<key>` references in the config block are resolved against the unlocked vault using the passphrase the `connect` command already prompts for. No new prompts; bad/missing refs surface as exit-4 with a clear message.

## Tests

- 12 new schema tests (block parses, vault refs accepted, missing fields rejected, numeric/numeric-string approvers, top-level + per-agent wiring).
- 8 new CLI tests (config-only path, env-wins-over-config, vault-ref resolved, per-agent override beats top-level, missing-everything error message).
- All 14 existing drive CLI tests still pass.
- Total: 60/60 in the touched files. Pre-existing tsc/test failures on main are unrelated and unchanged.

## Test plan

- [x] `npx vitest run src/cli/drive.test.ts src/config/schema.test.ts` — 60 passed
- [x] `npm run lint:tsc` — only pre-existing errors remain (verified on `main` baseline)
- [ ] Smoke: operator with existing env-only setup (no `drive:` block) re-runs `switchroom drive connect <agent>` and observes identical behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)