### PR TITLE
fix(gateway): tighten materializeBotToken catch + align approval-callback signature

### DIFF
--- a/telegram-plugin/foreman/foreman.ts
+++ b/telegram-plugin/foreman/foreman.ts
@@ -116,9 +116,28 @@ try {
 // ─── Bot token ────────────────────────────────────────────────────────────
 // Issue #758: when bot_token is a `vault:` ref and no .env was written,
 // materialize it from the vault at startup (in-memory only).
-let TOKEN: string
+//
+// The outer try/catch is narrowed (post-#761 review) to ONLY catch
+// ERR_MODULE_NOT_FOUND from the dynamic import. Other errors (e.g. throws
+// from inside materializeBotToken that aren't BotTokenMaterializeError)
+// must propagate so we don't mask real bugs behind the legacy "set in .env"
+// hint.
+type MaterializeMod = typeof import('../../src/telegram/materialize-bot-token.js')
+let materializeMod: MaterializeMod | null = null
 try {
-  const { materializeBotToken, BotTokenMaterializeError } = await import('../../src/telegram/materialize-bot-token.js')
+  materializeMod = await import('../../src/telegram/materialize-bot-token.js')
+} catch (err) {
+  const code = (err as NodeJS.ErrnoException | undefined)?.code
+  if (code === 'ERR_MODULE_NOT_FOUND' || code === 'MODULE_NOT_FOUND') {
+    // Module missing — fall through with materializeMod=null.
+  } else {
+    throw err
+  }
+}
+
+let TOKEN: string
+if (materializeMod !== null) {
+  const { materializeBotToken, BotTokenMaterializeError } = materializeMod
   try {
     TOKEN = await materializeBotToken()
   } catch (err) {
@@ -128,18 +147,16 @@ try {
     }
     throw err
   }
-} catch (err) {
-  if (process.env.TELEGRAM_BOT_TOKEN) {
-    TOKEN = process.env.TELEGRAM_BOT_TOKEN
-  } else {
-    process.stderr.write(
-      `foreman: TELEGRAM_BOT_TOKEN required\n` +
-      `  set in ${ENV_FILE}\n` +
-      `  format: TELEGRAM_BOT_TOKEN=123456789:AAH...\n` +
-      `  (token-materialization helper failed to load: ${(err as Error).message})\n`,
-    )
-    process.exit(1)
-  }
+} else if (process.env.TELEGRAM_BOT_TOKEN) {
+  TOKEN = process.env.TELEGRAM_BOT_TOKEN
+} else {
+  process.stderr.write(
+    `foreman: TELEGRAM_BOT_TOKEN required\n` +
+    `  set in ${ENV_FILE}\n` +
+    `  format: TELEGRAM_BOT_TOKEN=123456789:AAH...\n` +
+    `  (token-materialization helper not found)\n`,
+  )
+  process.exit(1)
 }
 
 // ─── Access list ──────────────────────────────────────────────────────────

--- a/telegram-plugin/gateway/approval-callback.ts
+++ b/telegram-plugin/gateway/approval-callback.ts
@@ -27,6 +27,7 @@ import {
   approvalConsume,
   approvalRecord,
 } from "../../src/vault/approvals/client.js";
+import type { ApprovalDecisionMode } from "../../src/vault/approvals/schema.js";
 
 export async function handleApprovalCallback(
   ctx: Context,
@@ -50,16 +51,19 @@ export async function handleApprovalCallback(
     return;
   }
 
-  // Compute granted + ttl from the choice variant.
+  // Compute decision + ttl from the choice variant.
+  let decision: ApprovalDecisionMode;
   let granted: boolean;
   let ttl_ms: number | null = null;
   let displayMode: string;
   switch (parsed.choice.kind) {
     case "deny":
+      decision = "deny";
       granted = false;
       displayMode = "denied";
       break;
     case "once":
+      decision = "allow_once";
       granted = true;
       // No expiry — recorded as a one-shot grant; the agent calls
       // approval_lookup at most once, then proceeds. /approvals revoke
@@ -67,10 +71,12 @@ export async function handleApprovalCallback(
       displayMode = "granted once";
       break;
     case "always":
+      decision = "allow_always";
       granted = true;
       displayMode = "granted always";
       break;
     case "ttl": {
+      decision = "allow_ttl";
       granted = true;
       const ms = ttlMsFromToken(parsed.choice.param);
       if (ms === null) {
@@ -83,18 +89,18 @@ export async function handleApprovalCallback(
     }
   }
 
-  const approver_user_id = ctx.from?.id?.toString() ?? "unknown";
+  const granted_by_user_id = ctx.from?.id ?? 0;
   // Approver set at decision time = the chat that received the card. We
   // store the singleton for now; the gateway-side approver-set lookup
   // (drift detection input) will widen this in the per-callsite wire-up
   // when each surface migrates and starts passing access.allowFrom.
-  const approver_set = [approver_user_id];
+  const approver_set = [String(granted_by_user_id)];
 
   const decision_id = await approvalRecord({
     request_id: parsed.request_id,
-    granted,
+    decision,
     approver_set,
-    approver_user_id,
+    granted_by_user_id,
     ttl_ms,
   });
 

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -384,9 +384,32 @@ try {
 // never written because bot_token in switchroom.yaml is a `vault:` reference),
 // materialize it from the vault at startup. Resolved value is held in
 // process.env only — never written back to disk.
-let TOKEN: string
+//
+// The outer try/catch is narrowed (post-#761 review) to ONLY catch the case
+// where the helper module itself fails to load (ERR_MODULE_NOT_FOUND from the
+// dynamic import). Anything else — including throws from inside
+// materializeBotToken that aren't BotTokenMaterializeError — must propagate
+// with its original message so we don't mask real bugs behind the legacy
+// "set in .env" hint.
+type MaterializeMod = typeof import('../../src/telegram/materialize-bot-token.js')
+let materializeMod: MaterializeMod | null = null
 try {
-  const { materializeBotToken, BotTokenMaterializeError } = await import('../../src/telegram/materialize-bot-token.js')
+  materializeMod = await import('../../src/telegram/materialize-bot-token.js')
+} catch (err) {
+  const code = (err as NodeJS.ErrnoException | undefined)?.code
+  if (code === 'ERR_MODULE_NOT_FOUND' || code === 'MODULE_NOT_FOUND') {
+    // Module genuinely missing — fall through with materializeMod=null and
+    // handle below.
+  } else {
+    // Programming error, side-effect failure during module init, etc.
+    // Propagate the real message rather than masking it.
+    throw err
+  }
+}
+
+let TOKEN: string
+if (materializeMod !== null) {
+  const { materializeBotToken, BotTokenMaterializeError } = materializeMod
   try {
     TOKEN = await materializeBotToken({ agentName: process.env.SWITCHROOM_AGENT_NAME })
   } catch (err) {
@@ -396,20 +419,16 @@ try {
     }
     throw err
   }
-} catch (err) {
-  // Fallback if the helper module failed to load — preserve the legacy
-  // error so installs without the new module still surface a clear hint.
-  if (process.env.TELEGRAM_BOT_TOKEN) {
-    TOKEN = process.env.TELEGRAM_BOT_TOKEN
-  } else {
-    process.stderr.write(
-      `telegram gateway: TELEGRAM_BOT_TOKEN required\n` +
-      `  set in ${ENV_FILE}\n` +
-      `  format: TELEGRAM_BOT_TOKEN=123456789:AAH...\n` +
-      `  (token-materialization helper failed to load: ${(err as Error).message})\n`,
-    )
-    process.exit(1)
-  }
+} else if (process.env.TELEGRAM_BOT_TOKEN) {
+  TOKEN = process.env.TELEGRAM_BOT_TOKEN
+} else {
+  process.stderr.write(
+    `telegram gateway: TELEGRAM_BOT_TOKEN required\n` +
+    `  set in ${ENV_FILE}\n` +
+    `  format: TELEGRAM_BOT_TOKEN=123456789:AAH...\n` +
+    `  (token-materialization helper not found)\n`,
+  )
+  process.exit(1)
 }
 
 const STATIC = process.env.TELEGRAM_ACCESS_MODE === 'static'


### PR DESCRIPTION
Two reviewer/worker-found fixes in already-shipped code:

1. **#761 follow-up**: outer try/catch in `gateway.ts` and `foreman.ts` only swallows `ERR_MODULE_NOT_FOUND` now. Programming errors in materializeBotToken propagate with original messages instead of being masked by '.env' fallback.

2. **#762 latent bug**: `approval-callback.ts` was calling `approvalRecord` with the pre-RFC-B-v2 signature (`granted: bool`, `approver_user_id`). Updated to v2 signature (`decision: ApprovalDecisionMode`, `granted_by_user_id`). Bug didn't fire in production yet because no callsite wires `apv:*` taps to real flows; would have on next migration wave.

## Test plan
- [x] tsc clean for changed files
- [x] approval kernel tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)