### PR TITLE
feat(agent): pre-flight vault-locked check on restart

### DIFF
--- a/src/cli/agent-vault-preflight.test.ts
+++ b/src/cli/agent-vault-preflight.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from "vitest";
+import type { SwitchroomConfig } from "../config/schema.js";
+import type { BrokerStatus } from "../vault/broker/protocol.js";
+import {
+  checkVaultPreflight,
+  checkVaultPreflightBulk,
+  effectiveBotToken,
+  formatLockedRefusal,
+  formatLockedRefusalBulk,
+} from "./agent-vault-preflight.js";
+
+function mkConfig(opts: {
+  globalToken?: string;
+  agents: Record<string, { bot_token?: string }>;
+}): SwitchroomConfig {
+  return {
+    telegram: {
+      bot_token: opts.globalToken ?? "global-plain-token",
+      forum_chat_id: "-100123",
+    },
+    agents: opts.agents as SwitchroomConfig["agents"],
+  } as unknown as SwitchroomConfig;
+}
+
+const unlocked = (): Promise<BrokerStatus | null> =>
+  Promise.resolve({ unlocked: true, keyCount: 1, uptimeSec: 1 });
+const locked = (): Promise<BrokerStatus | null> =>
+  Promise.resolve({ unlocked: false, keyCount: 0, uptimeSec: 1 });
+const unreachable = (): Promise<BrokerStatus | null> => Promise.resolve(null);
+
+describe("effectiveBotToken", () => {
+  it("uses per-agent bot_token when set", () => {
+    const c = mkConfig({
+      globalToken: "GLOBAL",
+      agents: { foo: { bot_token: "PER_AGENT" } },
+    });
+    expect(effectiveBotToken(c, "foo")).toBe("PER_AGENT");
+  });
+
+  it("falls back to global telegram.bot_token", () => {
+    const c = mkConfig({ globalToken: "GLOBAL", agents: { foo: {} } });
+    expect(effectiveBotToken(c, "foo")).toBe("GLOBAL");
+  });
+});
+
+describe("checkVaultPreflight", () => {
+  it("plaintext bot_token + vault locked → skip (no check)", async () => {
+    const c = mkConfig({
+      globalToken: "1234:plaintext",
+      agents: { foo: {} },
+    });
+    const v = await checkVaultPreflight(c, "foo", { status: locked });
+    expect(v).toEqual({ kind: "skip", reason: "plaintext-token" });
+  });
+
+  it("vault: bot_token + vault unlocked → ok", async () => {
+    const c = mkConfig({ agents: { foo: { bot_token: "vault:foo.bot_token" } } });
+    const v = await checkVaultPreflight(c, "foo", { status: unlocked });
+    expect(v).toEqual({ kind: "ok" });
+  });
+
+  it("vault: bot_token + vault locked → locked (reachable)", async () => {
+    const c = mkConfig({ agents: { foo: { bot_token: "vault:foo.bot_token" } } });
+    const v = await checkVaultPreflight(c, "foo", { status: locked });
+    expect(v).toEqual({ kind: "locked", reachable: true });
+  });
+
+  it("vault: bot_token + broker unreachable → locked (unreachable)", async () => {
+    const c = mkConfig({ agents: { foo: { bot_token: "vault:foo.bot_token" } } });
+    const v = await checkVaultPreflight(c, "foo", { status: unreachable });
+    expect(v).toEqual({ kind: "locked", reachable: false });
+  });
+
+  it("global vault: token, no per-agent override → still gates", async () => {
+    const c = mkConfig({
+      globalToken: "vault:telegram-bot-token",
+      agents: { foo: {} },
+    });
+    const v = await checkVaultPreflight(c, "foo", { status: locked });
+    expect(v).toEqual({ kind: "locked", reachable: true });
+  });
+});
+
+describe("checkVaultPreflightBulk", () => {
+  it("returns blocked=[] when no agent has a vault: token (no broker call)", async () => {
+    const c = mkConfig({
+      globalToken: "PLAIN",
+      agents: { foo: {}, bar: { bot_token: "PLAIN_PER" } },
+    });
+    let called = 0;
+    const r = await checkVaultPreflightBulk(c, ["foo", "bar"], {
+      status: () => {
+        called++;
+        return locked();
+      },
+    });
+    expect(r.blocked).toEqual([]);
+    expect(called).toBe(0);
+  });
+
+  it("flags ALL vault-ref agents when vault is locked", async () => {
+    const c = mkConfig({
+      globalToken: "vault:tg",
+      agents: { foo: {}, bar: { bot_token: "PLAIN" }, baz: { bot_token: "vault:baz.tok" } },
+    });
+    const r = await checkVaultPreflightBulk(c, ["foo", "bar", "baz"], { status: locked });
+    expect(r.blocked.map((b) => b.agent).sort()).toEqual(["baz", "foo"]);
+    expect(r.reachable).toBe(true);
+  });
+
+  it("treats unreachable broker as locked", async () => {
+    const c = mkConfig({ agents: { foo: { bot_token: "vault:foo.tok" } } });
+    const r = await checkVaultPreflightBulk(c, ["foo"], { status: unreachable });
+    expect(r.blocked).toHaveLength(1);
+    expect(r.reachable).toBe(false);
+  });
+
+  it("returns blocked=[] when broker reachable + unlocked", async () => {
+    const c = mkConfig({ agents: { foo: { bot_token: "vault:foo.tok" } } });
+    const r = await checkVaultPreflightBulk(c, ["foo"], { status: unlocked });
+    expect(r.blocked).toEqual([]);
+    expect(r.reachable).toBe(true);
+  });
+});
+
+describe("formatLockedRefusal", () => {
+  it("includes unlock + retry + force-locked guidance (reachable)", () => {
+    const m = formatLockedRefusal("klanker", { kind: "locked", reachable: true });
+    expect(m).toContain("vault is locked");
+    expect(m).toContain("switchroom vault broker unlock");
+    expect(m).toContain("switchroom agent restart klanker");
+    expect(m).toContain("--force-locked");
+  });
+
+  it("differentiates unreachable wording", () => {
+    const m = formatLockedRefusal("klanker", { kind: "locked", reachable: false });
+    expect(m).toContain("unreachable");
+  });
+});
+
+describe("formatLockedRefusalBulk", () => {
+  it("lists every blocked agent", () => {
+    const m = formatLockedRefusalBulk(
+      [{ agent: "foo" }, { agent: "bar" }],
+      true,
+    );
+    expect(m).toContain("foo");
+    expect(m).toContain("bar");
+    expect(m).toContain("--force-locked");
+  });
+});

--- a/src/cli/agent-vault-preflight.ts
+++ b/src/cli/agent-vault-preflight.ts
@@ -1,0 +1,155 @@
+/**
+ * Vault-locked pre-flight check for `switchroom agent restart`.
+ *
+ * Restarting an agent whose `bot_token` is a `vault:` reference while the
+ * vault broker is locked produces a dead agent: the gateway boots, can't
+ * resolve the token, can't reach Telegram, and the operator has to dig
+ * through journal logs to figure out why their bot went silent. This
+ * pre-flight catches that before issuing the systemctl restart.
+ *
+ * Plaintext bot_token values are unaffected — the check only fires when
+ * the effective token (per-agent override → global) starts with `vault:`.
+ *
+ * Broker-unreachable is treated as locked: if we can't ask the broker
+ * whether it's unlocked, we don't know if the restart will succeed, and
+ * the safe default is to refuse rather than risk a silent outage.
+ */
+import type { SwitchroomConfig } from "../config/schema.js";
+import { isVaultReference } from "../vault/resolver.js";
+import { statusViaBroker } from "../vault/broker/client.js";
+import type { BrokerStatus } from "../vault/broker/protocol.js";
+
+export type VaultPreflightVerdict =
+  | { kind: "ok" }
+  | { kind: "skip"; reason: "plaintext-token" | "no-token" }
+  | { kind: "locked"; reachable: boolean };
+
+/**
+ * Resolve the effective bot_token string for an agent, applying the
+ * per-agent override → global fallback contract documented in
+ * `src/telegram/materialize-bot-token.ts`.
+ */
+export function effectiveBotToken(
+  config: SwitchroomConfig,
+  agentName: string,
+): string | undefined {
+  const agent = config.agents?.[agentName] as { bot_token?: string } | undefined;
+  if (agent?.bot_token && agent.bot_token.length > 0) return agent.bot_token;
+  return config.telegram?.bot_token;
+}
+
+export interface VaultPreflightDeps {
+  /** Test seam — defaults to the real broker client. */
+  status?: () => Promise<BrokerStatus | null>;
+}
+
+/**
+ * Run the vault-locked pre-flight for a single agent. Returns a verdict
+ * the caller turns into a CLI message + exit code.
+ */
+export async function checkVaultPreflight(
+  config: SwitchroomConfig,
+  agentName: string,
+  deps: VaultPreflightDeps = {},
+): Promise<VaultPreflightVerdict> {
+  const token = effectiveBotToken(config, agentName);
+  if (!token) return { kind: "skip", reason: "no-token" };
+  if (!isVaultReference(token)) return { kind: "skip", reason: "plaintext-token" };
+
+  const fetch = deps.status ?? (() => statusViaBroker());
+  const status = await fetch();
+  if (status === null) {
+    // Broker unreachable. We can't verify; treat as locked.
+    return { kind: "locked", reachable: false };
+  }
+  if (!status.unlocked) {
+    return { kind: "locked", reachable: true };
+  }
+  return { kind: "ok" };
+}
+
+/**
+ * Run the pre-flight against multiple agents in one pass. The broker
+ * status RPC is made once and shared — bulk restart shouldn't ping the
+ * broker N times. Returns the list of agents whose restart would be
+ * blocked by a locked vault.
+ */
+export async function checkVaultPreflightBulk(
+  config: SwitchroomConfig,
+  agentNames: string[],
+  deps: VaultPreflightDeps = {},
+): Promise<{
+  blocked: { agent: string; verdict: Extract<VaultPreflightVerdict, { kind: "locked" }> }[];
+  reachable: boolean;
+}> {
+  // Decide whether ANY agent has a vault: token. If none do, skip the
+  // broker call entirely.
+  const vaultAgents = agentNames.filter((n) => {
+    const t = effectiveBotToken(config, n);
+    return typeof t === "string" && isVaultReference(t);
+  });
+  if (vaultAgents.length === 0) {
+    return { blocked: [], reachable: true };
+  }
+
+  const fetch = deps.status ?? (() => statusViaBroker());
+  const status = await fetch();
+  if (status === null) {
+    return {
+      blocked: vaultAgents.map((agent) => ({
+        agent,
+        verdict: { kind: "locked", reachable: false } as const,
+      })),
+      reachable: false,
+    };
+  }
+  if (status.unlocked) {
+    return { blocked: [], reachable: true };
+  }
+  return {
+    blocked: vaultAgents.map((agent) => ({
+      agent,
+      verdict: { kind: "locked", reachable: true } as const,
+    })),
+    reachable: true,
+  };
+}
+
+/**
+ * Format a refusal message for a single locked-vault verdict. Exported
+ * so the CLI command and tests share one source of truth for wording.
+ */
+export function formatLockedRefusal(
+  agentName: string,
+  verdict: Extract<VaultPreflightVerdict, { kind: "locked" }>,
+): string {
+  const head = verdict.reachable
+    ? `Cannot restart ${agentName}: bot_token is a vault reference (vault:...) but vault is locked.`
+    : `Cannot restart ${agentName}: bot_token is a vault reference (vault:...) and the vault broker is unreachable (treating as locked).`;
+  return [
+    head,
+    "",
+    "  Run: switchroom vault broker unlock",
+    `  Then retry: switchroom agent restart ${agentName}`,
+    "",
+    `  To restart anyway (will hard-fail with cleaner error): switchroom agent restart ${agentName} --force-locked`,
+  ].join("\n");
+}
+
+export function formatLockedRefusalBulk(
+  blocked: { agent: string }[],
+  reachable: boolean,
+): string {
+  const head = reachable
+    ? `Cannot restart: vault is locked and the following agents have vault: bot_token references:`
+    : `Cannot restart: vault broker is unreachable and the following agents have vault: bot_token references (treating as locked):`;
+  return [
+    head,
+    ...blocked.map((b) => `    ${b.agent}`),
+    "",
+    "  Run: switchroom vault broker unlock",
+    "  Then retry the restart.",
+    "",
+    "  To restart anyway (will hard-fail with cleaner error): re-run with --force-locked",
+  ].join("\n");
+}

--- a/src/cli/agent.ts
+++ b/src/cli/agent.ts
@@ -49,6 +49,10 @@ import { addAgent, type AgentTopology } from "../agents/add-orchestrator.js";
 import { renameAgent, type HindsightMode } from "../agents/rename-orchestrator.js";
 import { validateBotTokenMatchesAgent } from "../setup/telegram-api.js";
 import { registerAgentPerfCommand } from "./perf.js";
+import {
+  checkVaultPreflightBulk,
+  formatLockedRefusalBulk,
+} from "./agent-vault-preflight.js";
 
 /**
  * Pre-restart preflight check. Verifies the agent's runtime
@@ -1159,16 +1163,47 @@ export function registerAgentCommand(program: Command): void {
       "Override --wait timeout in milliseconds (default 300000)"
     )
     .option("--graceful-restart", "Wait for active turn to complete before restarting (via gateway IPC)")
+    .option(
+      "--force-locked",
+      "Restart even when bot_token is a vault: reference and the vault is locked (the agent will fail to reach Telegram until the vault is unlocked)"
+    )
     .action(
       withConfigError(
         async (
           name: string,
-          opts: { force?: boolean; wait?: boolean; waitTimeout?: string; gracefulRestart?: boolean }
+          opts: {
+            force?: boolean;
+            wait?: boolean;
+            waitTimeout?: string;
+            gracefulRestart?: boolean;
+            forceLocked?: boolean;
+          }
         ) => {
           const config = getConfig(program);
           const agentsDir = resolveAgentsDir(config);
           const names =
             name === "all" ? Object.keys(config.agents) : [name];
+
+          // Vault-locked pre-flight. Runs once across all targets so we
+          // don't ping the broker N times. Catches the "vault: bot_token +
+          // locked broker = dead agent" foot-gun BEFORE issuing any
+          // systemctl restart. --force / --force-locked skips.
+          if (!opts.force && !opts.forceLocked) {
+            const targets = names.filter((n) => config.agents[n] != null);
+            if (targets.length > 0) {
+              const result = await checkVaultPreflightBulk(config, targets);
+              if (result.blocked.length > 0) {
+                console.error(chalk.red("\n  " + formatLockedRefusalBulk(result.blocked, result.reachable) + "\n"));
+                process.exit(4);
+              }
+            }
+          } else if (opts.forceLocked) {
+            console.error(
+              chalk.yellow(
+                "  ⚠ --force-locked: skipping vault-locked pre-flight. Agent will hard-fail at startup if vault is still locked.\n"
+              )
+            );
+          }
 
           // #61 defense #1: warn if the switchroom checkout is on a non-main
           // branch. The gateway runs source directly via `bun gateway.ts`


### PR DESCRIPTION
## Summary

Restarting an agent whose `bot_token` is a `vault:` reference while the vault broker is locked produces a dead agent: it boots, can't resolve the token, can't reach Telegram, and the operator has to dig through journalctl to figure out why their bot went silent. This adds a pre-flight check on `switchroom agent restart` that refuses with a clear unlock-and-retry message.

- New `src/cli/agent-vault-preflight.ts` (`checkVaultPreflight`, `checkVaultPreflightBulk`, formatters). One broker status RPC per `restart` invocation, shared across bulk targets; broker call is skipped entirely when no target has a `vault:` token.
- Plaintext `bot_token` -> no broker call, restart proceeds (back-compat).
- `vault:` `bot_token` + locked / unreachable broker -> refuse, exit 4, print unlock + retry + `--force-locked` guidance.
- New `--force-locked` flag is the escape hatch (warns and proceeds).
- Bulk restart (`agent restart all`): refuses if ANY targeted agent would be hit.

## Test plan

- [x] `npx vitest run src/cli/agent-vault-preflight.test.ts` (14 tests covering plaintext-skip, locked, unlocked, unreachable, per-agent override vs global fallback, no-broker-ping-when-no-vault-refs path, bulk multi-agent flagging)
- [x] All existing CLI tests still pass (`drive.test.ts` 22 tests)
- [x] `tsc --noEmit` clean for the changed files (no new errors)
- [ ] Manual: lock broker, run `switchroom agent restart <vault-token-agent>`, expect refusal; pass `--force-locked`, expect proceed-with-warning

## Auto-unlock context

This host (Ken's) has auto-unlock CONFIGURED and WORKING (`~/.config/switchroom/auto-unlock.bin` present, `vault broker status` reports `unlocked:true uptimeSec:56935`). For Ken specifically, the "vault locked at startup" failure mode is rare in practice — auto-unlock recovers the broker after every reboot. The pre-flight is still worthwhile because (a) `vault broker lock` is a manual operator action that bypasses auto-unlock, (b) the cost is one socket RPC per restart, and (c) the failure mode it catches is exactly the kind of silent outage that erodes trust. Recommend pairing with the foreman/Telegram-unlock work eventually so the agent can self-recover when locked, but the pre-flight is sufficient as a standalone safety floor.

## Note

Per the operator: opened but NOT auto-merged. The reviewer agent goes next.