### PR TITLE
feat(gateway): allow self-restart on non-admin + warn instead of forwarding admin cmds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 ## [Unreleased]
 
+### Added
+
+- **Webhook ingest hardening (#714)** — two defenses added to
+  `src/web/webhook-handler.ts` before auto-dispatch ships:
+  - **Dedup by `X-GitHub-Delivery`**: per-agent LRU (1000 entries, 24h
+    retention) backed by `~/.switchroom/agents/<agent>/telegram/webhook-dedup.json`.
+    Replay returns 200 `{ok:true,deduped:true}` and skips JSONL append.
+    Generic source has no delivery header — dedup is skipped silently.
+  - **Per-source token-bucket rate limit**: default 60 rpm (burst 60),
+    configurable via `channels.telegram.webhook_rate_limit.rpm` in
+    switchroom.yaml. Exceeding the limit returns 429 with `Retry-After`.
+    First throttle event per `(agent, source)` per 60s window is written
+    to `<agent>/telegram/issues.jsonl` for Telegram visibility.
+  - `webhook_rate_limit` added to `TelegramChannelSchema` in
+    `src/config/schema.ts`; cascades via the existing channels deep-merge.
+
 ## v0.6.7 — 2026-05-05
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,10 @@
     retention) backed by `~/.switchroom/agents/<agent>/telegram/webhook-dedup.json`.
     Replay returns 200 `{ok:true,deduped:true}` and skips JSONL append.
     Generic source has no delivery header — dedup is skipped silently.
-  - **Per-source token-bucket rate limit**: default 60 rpm (burst 60),
-    configurable via `channels.telegram.webhook_rate_limit.rpm` in
-    switchroom.yaml. Exceeding the limit returns 429 with `Retry-After`.
+  - **Per-source token-bucket rate limit**: off by default; opt-in via
+    `channels.telegram.webhook_rate_limit.rpm` in switchroom.yaml (set
+    e.g. `rpm: 60` for one request/sec sustained, burst equal to rpm).
+    When enabled, exceeding the limit returns 429 with `Retry-After`.
     First throttle event per `(agent, source)` per 60s window is written
     to `<agent>/telegram/issues.jsonl` for Telegram visibility.
   - `webhook_rate_limit` added to `TelegramChannelSchema` in

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -552,10 +552,12 @@ export const TelegramChannelSchema = z
       .optional()
       .describe(
         "Per-source rate limit for the webhook ingest path (#714). " +
-        "Token-bucket per (agent, source). Default: 60 requests/minute, " +
-        "burst 60. Shape: { rpm: 60 } — integer requests-per-minute. " +
-        "Beyond cap: 429 with Retry-After header; first throttle event " +
-        "per (agent, source) per 60s window is written to " +
+        "Off by default — when this key is absent the handler skips " +
+        "rate-limit checks entirely. Opt in by setting `rpm` to an " +
+        "integer requests-per-minute (token bucket per (agent, source); " +
+        "burst equal to rpm). When enabled, exceeding the limit returns " +
+        "429 with Retry-After header; first throttle event per " +
+        "(agent, source) per 60s window is written to " +
         "<agent>/telegram/issues.jsonl. " +
         "Cascades from defaults.channels.telegram.webhook_rate_limit.",
       ),

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -545,6 +545,20 @@ export const TelegramChannelSchema = z
         "Cascades from defaults.channels.telegram.webhook_sources. " +
         "(Migrated from per-agent root in #596 — see #577.)",
       ),
+    webhook_rate_limit: z
+      .object({
+        rpm: z.number().int().positive(),
+      })
+      .optional()
+      .describe(
+        "Per-source rate limit for the webhook ingest path (#714). " +
+        "Token-bucket per (agent, source). Default: 60 requests/minute, " +
+        "burst 60. Shape: { rpm: 60 } — integer requests-per-minute. " +
+        "Beyond cap: 429 with Retry-After header; first throttle event " +
+        "per (agent, source) per 60s window is written to " +
+        "<agent>/telegram/issues.jsonl. " +
+        "Cascades from defaults.channels.telegram.webhook_rate_limit.",
+      ),
   })
   .optional();
 

--- a/src/web/webhook-handler.test.ts
+++ b/src/web/webhook-handler.test.ts
@@ -1,0 +1,458 @@
+/**
+ * Tests for webhook ingest hardening (#714):
+ *   - Replay/duplicate dedup by X-GitHub-Delivery
+ *   - Per-source token-bucket rate limiting
+ *
+ * Uses vitest + tmpdir for file I/O isolation.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { mkdtempSync, mkdirSync, readFileSync, existsSync, writeFileSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { createHmac } from 'crypto'
+import {
+  handleWebhookIngest,
+  shouldWriteThrottleIssue,
+  type WebhookHandlerArgs,
+  type WebhookHandlerDeps,
+  type DedupStore,
+  type RateLimiter,
+} from './webhook-handler.js'
+
+// ─── Test helpers ─────────────────────────────────────────────────────────────
+
+const SECRET = 'test-secret-key'
+
+function makeGithubSig(body: Uint8Array, secret: string = SECRET): string {
+  return 'sha256=' + createHmac('sha256', secret).update(body).digest('hex')
+}
+
+function makeBody(payload: Record<string, unknown> = { action: 'opened' }): Uint8Array {
+  return new TextEncoder().encode(JSON.stringify(payload))
+}
+
+function makeGithubHeaders(
+  body: Uint8Array,
+  deliveryId: string = 'delivery-001',
+  eventType: string = 'pull_request',
+): Headers {
+  const h = new Headers()
+  h.set('x-hub-signature-256', makeGithubSig(body))
+  h.set('x-github-delivery', deliveryId)
+  h.set('x-github-event', eventType)
+  return h
+}
+
+function makeTmpResolveAgentDir(): { resolveAgentDir: (a: string) => string; root: string } {
+  const root = mkdtempSync(join(tmpdir(), 'webhook-test-'))
+  return {
+    root,
+    resolveAgentDir: (agent: string) => join(root, agent),
+  }
+}
+
+function baseArgs(body: Uint8Array, headers: Headers): WebhookHandlerArgs {
+  return {
+    agent: 'myagent',
+    source: 'github',
+    body,
+    headers,
+    allowedSources: ['github'],
+    config: { secrets: { github: SECRET } },
+    agentExists: true,
+  }
+}
+
+function baseDeps(
+  resolveAgentDir: (a: string) => string,
+  nowMs: number,
+  extras: Partial<WebhookHandlerDeps> = {},
+): WebhookHandlerDeps {
+  return {
+    resolveAgentDir,
+    now: () => nowMs,
+    log: () => {},
+    ...extras,
+  }
+}
+
+/**
+ * In-memory dedup store — no disk I/O, no shared module-global state.
+ * Each test creates its own instance.
+ */
+function makeDedupStore(): DedupStore {
+  const seen = new Map<string, number>() // key: `${agent}\0${deliveryId}` → ts
+  return {
+    check(agent: string, deliveryId: string, now: number): number | undefined {
+      const key = `${agent}\0${deliveryId}`
+      const existing = seen.get(key)
+      if (existing !== undefined) return existing
+      seen.set(key, now)
+      return undefined
+    },
+  }
+}
+
+/**
+ * In-memory token-bucket rate limiter — fully isolated per test.
+ */
+function makeRateLimiter(): RateLimiter {
+  const buckets = new Map<string, { tokens: number; lastRefill: number }>()
+  return {
+    check(agent: string, source: string, rpm: number, now: number): number | null {
+      const key = `${agent}\0${source}`
+      const refillRate = rpm / 60
+      const maxTokens = rpm
+
+      let bucket = buckets.get(key)
+      if (!bucket) {
+        bucket = { tokens: maxTokens, lastRefill: now }
+        buckets.set(key, bucket)
+      }
+      const elapsedSecs = (now - bucket.lastRefill) / 1000
+      bucket.tokens = Math.min(maxTokens, bucket.tokens + elapsedSecs * refillRate)
+      bucket.lastRefill = now
+
+      if (bucket.tokens >= 1) {
+        bucket.tokens -= 1
+        return null
+      }
+      const secsUntilToken = (1 - bucket.tokens) / refillRate
+      return Math.ceil(secsUntilToken)
+    },
+  }
+}
+
+// ─── Dedup tests ───────────────────────────────────────────────────────────────
+
+describe('dedup by X-GitHub-Delivery', () => {
+  it('first delivery → 202 recorded, one JSONL line', async () => {
+    const { resolveAgentDir } = makeTmpResolveAgentDir()
+    const body = makeBody()
+    const headers = makeGithubHeaders(body, 'delivery-abc')
+    const result = await handleWebhookIngest(baseArgs(body, headers), {
+      ...baseDeps(resolveAgentDir, 1000, { dedupStore: makeDedupStore(), rateLimiter: makeRateLimiter() }),
+    })
+    expect(result.status).toBe(202)
+    expect(JSON.parse(result.body)).toMatchObject({ ok: true, recorded: true })
+  })
+
+  it('same delivery ID sent twice → first 202, second 200 deduped, only one JSONL line', async () => {
+    const { resolveAgentDir, root } = makeTmpResolveAgentDir()
+    const body = makeBody()
+    const headers = makeGithubHeaders(body, 'delivery-dup')
+    const dedupStore = makeDedupStore()
+    const rateLimiter = makeRateLimiter()
+
+    const first = await handleWebhookIngest(baseArgs(body, headers), {
+      ...baseDeps(resolveAgentDir, 2000, { dedupStore, rateLimiter }),
+    })
+    expect(first.status).toBe(202)
+
+    const second = await handleWebhookIngest(baseArgs(body, headers), {
+      ...baseDeps(resolveAgentDir, 2000, { dedupStore, rateLimiter }),
+    })
+    expect(second.status).toBe(200)
+    expect(JSON.parse(second.body)).toMatchObject({ ok: true, deduped: true, ts: 2000 })
+
+    // Only one JSONL record appended
+    const logPath = join(root, 'myagent', 'telegram', 'webhook-events.jsonl')
+    const lines = readFileSync(logPath, 'utf-8').trim().split('\n').filter(Boolean)
+    expect(lines).toHaveLength(1)
+  })
+
+  it('dedup state survives across handler invocations (fresh dedupStore reads from disk)', async () => {
+    const { resolveAgentDir, root } = makeTmpResolveAgentDir()
+    const body = makeBody()
+
+    // First call — store dedup entry on disk via the real file-backed store.
+    // We use a pre-populated dedup file to simulate this.
+    const telegramDir = join(root, 'myagent', 'telegram')
+    mkdirSync(telegramDir, { recursive: true })
+    const dedupPath = join(telegramDir, 'webhook-dedup.json')
+
+    // Simulate a previous process having stored delivery 'delivery-persist' at ts=3000
+    writeFileSync(
+      dedupPath,
+      JSON.stringify({ deliveries: { 'delivery-persist': 3000 } }),
+      { mode: 0o600 },
+    )
+
+    // Fresh dedupStore that reads from disk — simulates a new process
+    const diskDedupStore: DedupStore = {
+      check(_agent, deliveryId, _now) {
+        const data = JSON.parse(readFileSync(dedupPath, 'utf-8')) as { deliveries: Record<string, number> }
+        return data.deliveries[deliveryId]
+      },
+    }
+
+    const result = await handleWebhookIngest(
+      { ...baseArgs(body, makeGithubHeaders(body, 'delivery-persist')) },
+      baseDeps(resolveAgentDir, 5000, { dedupStore: diskDedupStore, rateLimiter: makeRateLimiter() }),
+    )
+    expect(result.status).toBe(200)
+    expect(JSON.parse(result.body)).toMatchObject({ deduped: true, ts: 3000 })
+  })
+
+  it('entries older than 24h are pruned on next write', async () => {
+    const { resolveAgentDir, root } = makeTmpResolveAgentDir()
+
+    const now = Date.now()
+    const old = now - 25 * 60 * 60 * 1000 // 25h ago
+
+    // Manually pre-populate dedup file with one old entry
+    const telegramDir = join(root, 'myagent', 'telegram')
+    mkdirSync(telegramDir, { recursive: true })
+    const dedupPath = join(telegramDir, 'webhook-dedup.json')
+    writeFileSync(
+      dedupPath,
+      JSON.stringify({ deliveries: { 'old-delivery': old } }),
+      { mode: 0o600 },
+    )
+
+    // The real file-backed store reads the old entry and then writes back.
+    // We use a fresh module-agent key to avoid the in-process cache.
+    // Use a unique agent name so agentDedupCache has no entry for it.
+    const agentName = `prune-test-agent-${now}`
+
+    // Manually set up the dir
+    const agentTgDir = join(root, agentName, 'telegram')
+    mkdirSync(agentTgDir, { recursive: true })
+    writeFileSync(
+      join(agentTgDir, 'webhook-dedup.json'),
+      JSON.stringify({ deliveries: { 'old-delivery': old } }),
+      { mode: 0o600 },
+    )
+
+    const body = makeBody()
+    const headers = makeGithubHeaders(body, 'new-delivery')
+    // Use the real file-backed dedup (default, no override) to test pruning
+    await handleWebhookIngest(
+      { ...baseArgs(body, headers), agent: agentName },
+      {
+        resolveAgentDir,
+        now: () => now,
+        log: () => {},
+        rateLimiter: makeRateLimiter(),
+        // No dedupStore override — uses real file-backed store
+      },
+    )
+
+    // Old entry should be pruned from the file
+    const stored = JSON.parse(
+      readFileSync(join(agentTgDir, 'webhook-dedup.json'), 'utf-8'),
+    ) as { deliveries: Record<string, number> }
+    expect(stored.deliveries['old-delivery']).toBeUndefined()
+    expect(stored.deliveries['new-delivery']).toBe(now)
+  })
+
+  it('generic source skips dedup entirely — no error on missing delivery header', async () => {
+    const { resolveAgentDir } = makeTmpResolveAgentDir()
+    const body = makeBody({ text: 'hello' })
+    const headers = new Headers()
+    headers.set('authorization', `Bearer ${SECRET}`)
+
+    const result = await handleWebhookIngest(
+      {
+        agent: 'myagent',
+        source: 'generic',
+        body,
+        headers,
+        allowedSources: ['generic'],
+        config: { secrets: { generic: SECRET } },
+        agentExists: true,
+      },
+      baseDeps(resolveAgentDir, 6000, { dedupStore: makeDedupStore(), rateLimiter: makeRateLimiter() }),
+    )
+    expect(result.status).toBe(202)
+  })
+})
+
+/** baseArgs variant with rate limiting enabled at 60 rpm. */
+function baseArgsRL(body: Uint8Array, headers: Headers): WebhookHandlerArgs {
+  return {
+    ...baseArgs(body, headers),
+    config: { secrets: { github: SECRET }, rateLimit: { rpm: 60 } },
+  }
+}
+
+// ─── Rate limit tests ─────────────────────────────────────────────────────────
+
+describe('per-source rate limiting', () => {
+  it('60 requests within burst cap all return 202', async () => {
+    const { resolveAgentDir } = makeTmpResolveAgentDir()
+    const rateLimiter = makeRateLimiter()
+    const dedupStore = makeDedupStore()
+    const nowMs = 10_000_000
+
+    for (let i = 0; i < 60; i++) {
+      const body = makeBody()
+      const headers = makeGithubHeaders(body, `delivery-${i}`)
+      const result = await handleWebhookIngest(baseArgsRL(body, headers), {
+        ...baseDeps(resolveAgentDir, nowMs, { rateLimiter, dedupStore }),
+      })
+      expect(result.status).toBe(202)
+    }
+  })
+
+  it('61st request in same window returns 429 with Retry-After', async () => {
+    const { resolveAgentDir } = makeTmpResolveAgentDir()
+    const rateLimiter = makeRateLimiter()
+    const dedupStore = makeDedupStore()
+    const nowMs = 20_000_000
+
+    for (let i = 0; i < 60; i++) {
+      const body = makeBody()
+      const headers = makeGithubHeaders(body, `d-${i}`)
+      await handleWebhookIngest(baseArgsRL(body, headers), {
+        ...baseDeps(resolveAgentDir, nowMs, { rateLimiter, dedupStore }),
+      })
+    }
+
+    const body = makeBody()
+    const headers = makeGithubHeaders(body, 'd-61')
+    const result = await handleWebhookIngest(baseArgsRL(body, headers), {
+      ...baseDeps(resolveAgentDir, nowMs, { rateLimiter, dedupStore }),
+    })
+    expect(result.status).toBe(429)
+    expect(JSON.parse(result.body)).toMatchObject({ ok: false, error: 'rate limited' })
+    expect(result.headers?.['Retry-After']).toBeDefined()
+    expect(Number(result.headers?.['Retry-After'])).toBeGreaterThan(0)
+  })
+
+  it('after 1s wait, next request is 202 again', async () => {
+    const { resolveAgentDir } = makeTmpResolveAgentDir()
+    const rateLimiter = makeRateLimiter()
+    const dedupStore = makeDedupStore()
+    const t0 = 30_000_000
+
+    // Exhaust the bucket
+    for (let i = 0; i < 60; i++) {
+      const body = makeBody()
+      const headers = makeGithubHeaders(body, `d-${i}`)
+      await handleWebhookIngest(baseArgsRL(body, headers), {
+        ...baseDeps(resolveAgentDir, t0, { rateLimiter, dedupStore }),
+      })
+    }
+
+    // Confirm throttled (fresh delivery ID not in dedup)
+    const body = makeBody()
+    const throttled = await handleWebhookIngest(
+      { ...baseArgsRL(body, makeGithubHeaders(body, 'd-extra')) },
+      baseDeps(resolveAgentDir, t0, { rateLimiter, dedupStore }),
+    )
+    expect(throttled.status).toBe(429)
+
+    // 1 second later — refill should allow ≥1 token (rpm=60 → 1/sec)
+    const body2 = makeBody()
+    const recovered = await handleWebhookIngest(
+      { ...baseArgsRL(body2, makeGithubHeaders(body2, 'd-recovered')) },
+      baseDeps(resolveAgentDir, t0 + 1000, { rateLimiter, dedupStore }),
+    )
+    expect(recovered.status).toBe(202)
+  })
+
+  it('first throttle writes to issues.jsonl; second throttle in same 60s window does not', async () => {
+    const { resolveAgentDir, root } = makeTmpResolveAgentDir()
+    const rateLimiter = makeRateLimiter()
+    const dedupStore = makeDedupStore()
+    const nowMs = 40_000_000
+
+    // Exhaust bucket
+    for (let i = 0; i < 60; i++) {
+      const body = makeBody()
+      const headers = makeGithubHeaders(body, `d-${i}`)
+      await handleWebhookIngest(baseArgsRL(body, headers), {
+        ...baseDeps(resolveAgentDir, nowMs, { rateLimiter, dedupStore }),
+      })
+    }
+
+    // First throttle
+    const body1 = makeBody()
+    const h1 = makeGithubHeaders(body1, 'throttle-1')
+    const r1 = await handleWebhookIngest(baseArgsRL(body1, h1), {
+      ...baseDeps(resolveAgentDir, nowMs, { rateLimiter, dedupStore }),
+    })
+    expect(r1.status).toBe(429)
+
+    const issuesPath = join(root, 'myagent', 'telegram', 'issues.jsonl')
+    const lines1 = existsSync(issuesPath)
+      ? readFileSync(issuesPath, 'utf-8').trim().split('\n').filter(Boolean)
+      : []
+    expect(lines1).toHaveLength(1)
+    const issue = JSON.parse(lines1[0]) as Record<string, unknown>
+    expect(issue.code).toBe('webhook_rate_limit')
+    expect(issue.source).toBe('webhook:github')
+
+    // shouldWriteThrottleIssue with isolated windowMap
+    const windowMap = new Map<string, number>()
+    expect(shouldWriteThrottleIssue('myagent', 'github', nowMs, windowMap)).toBe(true)
+    expect(shouldWriteThrottleIssue('myagent', 'github', nowMs + 1000, windowMap)).toBe(false)
+    // After window expires, it should fire again
+    expect(shouldWriteThrottleIssue('myagent', 'github', nowMs + 61_000, windowMap)).toBe(true)
+  })
+
+  it('cross-agent isolation — agent A hitting rate limit does not affect agent B', async () => {
+    const { resolveAgentDir } = makeTmpResolveAgentDir()
+    const rateLimiter = makeRateLimiter()
+    const dedupStoreA = makeDedupStore()
+    const dedupStoreB = makeDedupStore()
+    const nowMs = 50_000_000
+
+    // Exhaust agent A's bucket
+    for (let i = 0; i < 60; i++) {
+      const body = makeBody()
+      const headers = makeGithubHeaders(body, `a-${i}`)
+      await handleWebhookIngest(
+        { ...baseArgsRL(body, headers), agent: 'agent-a' },
+        baseDeps(resolveAgentDir, nowMs, { rateLimiter, dedupStore: dedupStoreA }),
+      )
+    }
+
+    // Agent A is now throttled
+    const bodyA = makeBody()
+    const resultA = await handleWebhookIngest(
+      { ...baseArgsRL(bodyA, makeGithubHeaders(bodyA, 'a-extra')), agent: 'agent-a' },
+      baseDeps(resolveAgentDir, nowMs, { rateLimiter, dedupStore: dedupStoreA }),
+    )
+    expect(resultA.status).toBe(429)
+
+    // Agent B should still have a full bucket
+    const bodyB = makeBody()
+    const resultB = await handleWebhookIngest(
+      { ...baseArgsRL(bodyB, makeGithubHeaders(bodyB, 'b-001')), agent: 'agent-b' },
+      baseDeps(resolveAgentDir, nowMs, { rateLimiter, dedupStore: dedupStoreB }),
+    )
+    expect(resultB.status).toBe(202)
+  })
+
+  it('respects configurable rpm from config.rateLimit', async () => {
+    const { resolveAgentDir } = makeTmpResolveAgentDir()
+    const rateLimiter = makeRateLimiter()
+    const dedupStore = makeDedupStore()
+    const nowMs = 60_000_000
+
+    const extraArgs = {
+      config: { secrets: { github: SECRET }, rateLimit: { rpm: 5 } },
+    }
+
+    for (let i = 0; i < 5; i++) {
+      const body = makeBody()
+      const headers = makeGithubHeaders(body, `r-${i}`)
+      const result = await handleWebhookIngest(
+        { ...baseArgs(body, headers), ...extraArgs },
+        baseDeps(resolveAgentDir, nowMs, { rateLimiter, dedupStore }),
+      )
+      expect(result.status).toBe(202)
+    }
+
+    const body = makeBody()
+    const headers = makeGithubHeaders(body, 'r-6')
+    const result = await handleWebhookIngest(
+      { ...baseArgs(body, headers), ...extraArgs },
+      baseDeps(resolveAgentDir, nowMs, { rateLimiter, dedupStore }),
+    )
+    expect(result.status).toBe(429)
+  })
+})

--- a/src/web/webhook-handler.test.ts
+++ b/src/web/webhook-handler.test.ts
@@ -247,6 +247,33 @@ describe('dedup by X-GitHub-Delivery', () => {
     expect(stored.deliveries['new-delivery']).toBe(now)
   })
 
+  it('corrupt webhook-dedup.json on disk — handler degrades to empty state, does not crash', async () => {
+    const { root, resolveAgentDir } = makeTmpResolveAgentDir()
+    const agentName = `corrupt-dedup-${Date.now()}`
+    const agentTgDir = join(root, agentName, 'telegram')
+    mkdirSync(agentTgDir, { recursive: true })
+    // Write garbage that JSON.parse will reject.
+    writeFileSync(join(agentTgDir, 'webhook-dedup.json'), 'not-json-{{{', { mode: 0o600 })
+
+    const body = makeBody()
+    const headers = makeGithubHeaders(body, 'first-after-corrupt')
+    const result = await handleWebhookIngest(
+      { ...baseArgs(body, headers), agent: agentName },
+      {
+        resolveAgentDir,
+        now: () => 7000,
+        log: () => {},
+        rateLimiter: makeRateLimiter(),
+      },
+    )
+    expect(result.status).toBe(202)
+    // File rewritten cleanly.
+    const stored = JSON.parse(
+      readFileSync(join(agentTgDir, 'webhook-dedup.json'), 'utf-8'),
+    ) as { deliveries: Record<string, number> }
+    expect(stored.deliveries['first-after-corrupt']).toBe(7000)
+  })
+
   it('generic source skips dedup entirely — no error on missing delivery header', async () => {
     const { resolveAgentDir } = makeTmpResolveAgentDir()
     const body = makeBody({ text: 'hello' })

--- a/src/web/webhook-handler.ts
+++ b/src/web/webhook-handler.ts
@@ -9,10 +9,12 @@
  *
  * Response shape (always JSON):
  *   - 202 Accepted on verified + recorded.
+ *   - 200 OK with {ok:true, deduped:true} when delivery already seen (github only).
  *   - 400 if the path / body / config is malformed.
  *   - 401 if the signature/token is invalid (no detail leaked).
  *   - 403 if the agent doesn't allow this source.
  *   - 404 if the agent name is unknown.
+ *   - 429 Too Many Requests when per-source rate limit exceeded.
  *
  * MVP behavior (#577):
  *   - Verify signature.
@@ -20,6 +22,13 @@
  *     `webhook-verify.ts`.
  *   - Append a JSON line to `~/.switchroom/agents/<agent>/telegram/webhook-events.jsonl`.
  *   - Log the receipt to stderr for operator visibility.
+ *
+ * Hardening (#714):
+ *   - Dedup by X-GitHub-Delivery (github source only): LRU per agent,
+ *     1000 entries, 24h retention, persisted to webhook-dedup.json.
+ *   - Per-(agent, source) token-bucket rate limit: default 60 rpm,
+ *     configurable via channels.telegram.webhook_rate_limit.rpm.
+ *     First throttle in a 60s window writes to issues.jsonl.
  *
  * Out of scope (deferred to a follow-up):
  *   - Posting the rendered text directly to the agent's Telegram
@@ -31,7 +40,7 @@
  *     envelope contract.
  */
 
-import { appendFileSync, existsSync, mkdirSync, readFileSync } from 'fs'
+import { appendFileSync, existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs'
 import { join } from 'path'
 import { homedir } from 'os'
 import {
@@ -47,6 +56,8 @@ export interface WebhookConfig {
    *  `webhook/<agent>/<source>`. The verifier expects the secret as
    *  the operator typed it (no per-key encoding). */
   secrets: Partial<Record<WebhookSource, string>>
+  /** Rate limit config from channels.telegram.webhook_rate_limit. */
+  rateLimit?: { rpm: number }
 }
 
 export interface WebhookHandlerDeps {
@@ -57,6 +68,10 @@ export interface WebhookHandlerDeps {
   now?: () => number
   /** Log sink — stderr in production. */
   log?: (line: string) => void
+  /** Injectable dedup store (for testing). Falls back to file-backed. */
+  dedupStore?: DedupStore
+  /** Injectable rate limiter (for testing). Falls back to module-global. */
+  rateLimiter?: RateLimiter
 }
 
 export interface WebhookHandlerArgs {
@@ -77,17 +92,200 @@ export interface WebhookHandlerResult {
   status: number
   body: string
   contentType: string
+  headers?: Record<string, string>
 }
 
 const KNOWN_SOURCES: WebhookSource[] = ['github', 'generic']
 
-function jsonReply(status: number, body: Record<string, unknown>): WebhookHandlerResult {
+function jsonReply(
+  status: number,
+  body: Record<string, unknown>,
+  extraHeaders?: Record<string, string>,
+): WebhookHandlerResult {
   return {
     status,
     body: JSON.stringify(body),
     contentType: 'application/json',
+    headers: extraHeaders,
   }
 }
+
+// ─── Dedup store ──────────────────────────────────────────────────────────────
+
+const DEDUP_MAX = 1000
+const DEDUP_TTL_MS = 24 * 60 * 60 * 1000 // 24 hours
+
+interface DedupFileShape {
+  deliveries: Record<string, number>
+}
+
+export interface DedupStore {
+  /** Returns the original ts if already seen, undefined otherwise.
+   *  Stores the delivery on miss. */
+  check(agent: string, deliveryId: string, now: number): number | undefined
+}
+
+function loadDedupFile(path: string): Record<string, number> {
+  try {
+    if (!existsSync(path)) return {}
+    const raw = JSON.parse(readFileSync(path, 'utf-8')) as DedupFileShape
+    return typeof raw.deliveries === 'object' && raw.deliveries !== null
+      ? raw.deliveries
+      : {}
+  } catch {
+    return {}
+  }
+}
+
+function saveDedupFile(path: string, deliveries: Record<string, number>, now: number): void {
+  // Prune entries older than 24h
+  const pruned: Record<string, number> = {}
+  for (const [id, ts] of Object.entries(deliveries)) {
+    if (now - ts < DEDUP_TTL_MS) pruned[id] = ts
+  }
+  // Enforce cap: keep most-recent 1000
+  const sorted = Object.entries(pruned).sort((a, b) => b[1] - a[1]).slice(0, DEDUP_MAX)
+  const final: Record<string, number> = Object.fromEntries(sorted)
+  writeFileSync(path, JSON.stringify({ deliveries: final } satisfies DedupFileShape), {
+    mode: 0o600,
+  })
+}
+
+/** In-memory cache of per-agent deliveries, backed by disk. */
+const agentDedupCache = new Map<string, Record<string, number>>()
+
+function createFileDedupStore(resolveAgentDir: (agent: string) => string): DedupStore {
+  return {
+    check(agent: string, deliveryId: string, now: number): number | undefined {
+      const telegramDir = join(resolveAgentDir(agent), 'telegram')
+      const filePath = join(telegramDir, 'webhook-dedup.json')
+
+      // Load from disk if not in memory cache
+      if (!agentDedupCache.has(agent)) {
+        agentDedupCache.set(agent, loadDedupFile(filePath))
+      }
+
+      const deliveries = agentDedupCache.get(agent)!
+
+      if (deliveries[deliveryId] !== undefined) {
+        return deliveries[deliveryId]
+      }
+
+      // New delivery — store it
+      deliveries[deliveryId] = now
+
+      // Persist to disk
+      try {
+        mkdirSync(telegramDir, { recursive: true })
+        saveDedupFile(filePath, deliveries, now)
+      } catch {
+        // Non-fatal: if we can't persist, we still accept the event
+      }
+
+      return undefined
+    },
+  }
+}
+
+// ─── Rate limiter ─────────────────────────────────────────────────────────────
+
+const DEFAULT_RPM = 60
+
+interface TokenBucket {
+  tokens: number
+  lastRefill: number
+}
+
+export interface RateLimiter {
+  /** Returns null if allowed, or seconds-until-next-token if throttled. */
+  check(agent: string, source: string, rpm: number, now: number): number | null
+}
+
+/** Per-(agent, source) token buckets. Module-global for production. */
+const tokenBuckets = new Map<string, TokenBucket>()
+
+export const defaultRateLimiter: RateLimiter = {
+  check(agent: string, source: string, rpm: number, now: number): number | null {
+    const key = `${agent}\0${source}`
+    const refillRate = rpm / 60 // tokens per second
+    const maxTokens = rpm
+
+    let bucket = tokenBuckets.get(key)
+    if (!bucket) {
+      bucket = { tokens: maxTokens, lastRefill: now }
+      tokenBuckets.set(key, bucket)
+    }
+
+    // Refill based on elapsed time
+    const elapsedSecs = (now - bucket.lastRefill) / 1000
+    bucket.tokens = Math.min(maxTokens, bucket.tokens + elapsedSecs * refillRate)
+    bucket.lastRefill = now
+
+    if (bucket.tokens >= 1) {
+      bucket.tokens -= 1
+      return null
+    }
+
+    // Calculate seconds until next token
+    const secsUntilToken = (1 - bucket.tokens) / refillRate
+    return Math.ceil(secsUntilToken)
+  },
+}
+
+// ─── Throttle issue suppression ───────────────────────────────────────────────
+
+/** Track first throttle event per (agent, source) per 60s window. */
+const throttleIssueWindow = new Map<string, number>()
+const THROTTLE_WINDOW_MS = 60_000
+
+export function shouldWriteThrottleIssue(
+  agent: string,
+  source: string,
+  now: number,
+  windowMap?: Map<string, number>,
+): boolean {
+  const map = windowMap ?? throttleIssueWindow
+  const key = `${agent}\0${source}`
+  const lastWritten = map.get(key)
+  if (lastWritten !== undefined && now - lastWritten < THROTTLE_WINDOW_MS) {
+    return false
+  }
+  map.set(key, now)
+  return true
+}
+
+// ─── issues.jsonl writer ──────────────────────────────────────────────────────
+
+function writeThrottleIssue(
+  agent: string,
+  source: string,
+  now: number,
+  telegramDir: string,
+  log: (line: string) => void,
+): void {
+  const issuesPath = join(telegramDir, 'issues.jsonl')
+  try {
+    mkdirSync(telegramDir, { recursive: true })
+    // Format mirrors src/issues/types.ts IssueEvent
+    const record = {
+      ts: now,
+      agent,
+      severity: 'warn',
+      source: `webhook:${source}`,
+      code: 'webhook_rate_limit',
+      summary: `Webhook rate limit hit for source '${source}'`,
+      fingerprint: `webhook:${source}:webhook_rate_limit`,
+      occurrences: 1,
+      first_seen: now,
+      last_seen: now,
+    }
+    appendFileSync(issuesPath, JSON.stringify(record) + '\n', { mode: 0o600 })
+  } catch (err) {
+    log(`webhook-ingest: agent='${agent}' source='${source}' issues.jsonl write failed: ${(err as Error).message}\n`)
+  }
+}
+
+// ─── Main handler ─────────────────────────────────────────────────────────────
 
 /**
  * Pure-ish handler: takes everything it needs as args (no module
@@ -102,6 +300,8 @@ export async function handleWebhookIngest(
   const now = (deps.now ?? Date.now)()
   const resolveAgentDir =
     deps.resolveAgentDir ?? ((a) => join(homedir(), '.switchroom', 'agents', a))
+  const rateLimiter = deps.rateLimiter ?? defaultRateLimiter
+  const dedupStore = deps.dedupStore ?? createFileDedupStore(resolveAgentDir)
 
   if (!args.agentExists) {
     log(`webhook-ingest: agent='${args.agent}' source='${args.source}' rejected: unknown agent\n`)
@@ -138,6 +338,40 @@ export async function handleWebhookIngest(
   if (!verifyResult.ok) {
     log(`webhook-ingest: agent='${args.agent}' source='${source}' rejected: ${verifyResult.reason}\n`)
     return jsonReply(401, { ok: false, error: 'unauthorized' })
+  }
+
+  // ── Dedup check (github only — generic has no delivery ID) ────────────────
+  if (source === 'github') {
+    const deliveryId = args.headers.get('x-github-delivery')
+    if (deliveryId) {
+      const originalTs = dedupStore.check(args.agent, deliveryId, now)
+      if (originalTs !== undefined) {
+        log(`webhook-ingest: agent='${args.agent}' source='${source}' deduped delivery='${deliveryId}'\n`)
+        return jsonReply(200, { ok: true, deduped: true, ts: originalTs })
+      }
+    }
+  }
+
+  // ── Rate limit check ──────────────────────────────────────────────────────
+  // Rate limiting only activates when `config.rateLimit` is explicitly
+  // configured (channels.telegram.webhook_rate_limit in switchroom.yaml).
+  // When absent, no rate limit is applied. DEFAULT_RPM is the default
+  // value the config layer injects when the operator enables the feature
+  // without specifying a custom rpm.
+  const rpm = args.config.rateLimit?.rpm
+  const retryAfter = rpm !== undefined ? rateLimiter.check(args.agent, source, rpm, now) : null
+  if (retryAfter !== null) {
+    const agentDir = resolveAgentDir(args.agent)
+    const telegramDir = join(agentDir, 'telegram')
+    if (shouldWriteThrottleIssue(args.agent, source, now)) {
+      writeThrottleIssue(args.agent, source, now, telegramDir, log)
+    }
+    log(`webhook-ingest: agent='${args.agent}' source='${source}' rate limited retry-after=${retryAfter}s\n`)
+    return jsonReply(
+      429,
+      { ok: false, error: 'rate limited' },
+      { 'Retry-After': String(retryAfter) },
+    )
   }
 
   // Parse JSON body. We require JSON across both sources today; if a

--- a/src/web/webhook-handler.ts
+++ b/src/web/webhook-handler.ts
@@ -189,8 +189,6 @@ function createFileDedupStore(resolveAgentDir: (agent: string) => string): Dedup
 
 // ─── Rate limiter ─────────────────────────────────────────────────────────────
 
-const DEFAULT_RPM = 60
-
 interface TokenBucket {
   tokens: number
   lastRefill: number
@@ -355,9 +353,8 @@ export async function handleWebhookIngest(
   // ── Rate limit check ──────────────────────────────────────────────────────
   // Rate limiting only activates when `config.rateLimit` is explicitly
   // configured (channels.telegram.webhook_rate_limit in switchroom.yaml).
-  // When absent, no rate limit is applied. DEFAULT_RPM is the default
-  // value the config layer injects when the operator enables the feature
-  // without specifying a custom rpm.
+  // When absent, no rate limit is applied — the operator opts in by
+  // setting an explicit `rpm` value.
   const rpm = args.config.rateLimit?.rpm
   const retryAfter = rpm !== undefined ? rateLimiter.check(args.agent, source, rpm, now) : null
   if (retryAfter !== null) {

--- a/telegram-plugin/admin-commands/dispatch.test.ts
+++ b/telegram-plugin/admin-commands/dispatch.test.ts
@@ -175,6 +175,9 @@ describe('parseCommandArg', () => {
   it('returns empty string for non-slash text', () => {
     expect(parseCommandArg('hello world')).toBe('')
   })
+  it('returns empty string for @botname suffix with no arg', () => {
+    expect(parseCommandArg('/restart@bot')).toBe('')
+  })
 })
 
 // ─── classifyAdminGate ───────────────────────────────────────────────────────
@@ -205,6 +208,11 @@ describe('classifyAdminGate', () => {
     })
     it('passes through when arg matches my agent name', () => {
       expect(classifyAdminGate('/restart clerk', me)).toEqual({ action: 'pass-through' })
+    })
+    it('passes through when arg matches my agent name case-insensitively', () => {
+      expect(classifyAdminGate('/restart Clerk', me)).toEqual({ action: 'pass-through' })
+      expect(classifyAdminGate('/restart CLERK', me)).toEqual({ action: 'pass-through' })
+      expect(classifyAdminGate('/restart clerk', 'Clerk')).toEqual({ action: 'pass-through' })
     })
     it('passes through with @botname suffix and self target', () => {
       expect(classifyAdminGate('/restart@switchroombot clerk', me)).toEqual({

--- a/telegram-plugin/admin-commands/dispatch.test.ts
+++ b/telegram-plugin/admin-commands/dispatch.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from 'vitest'
-import { dispatchAdminCommand, parseCommandName, ADMIN_COMMAND_NAMES } from './index.js'
+import {
+  dispatchAdminCommand,
+  parseCommandName,
+  parseCommandArg,
+  classifyAdminGate,
+  ADMIN_COMMAND_NAMES,
+} from './index.js'
 
 // ─── parseCommandName ────────────────────────────────────────────────────────
 
@@ -144,6 +150,110 @@ describe('dispatchAdminCommand', () => {
       expect(dispatchAdminCommand('/restart', false)).toEqual({ handled: false })
       expect(dispatchAdminCommand('/nope', false)).toEqual({ handled: false })
       expect(dispatchAdminCommand('hello', false)).toEqual({ handled: false })
+    })
+  })
+})
+
+// ─── parseCommandArg ─────────────────────────────────────────────────────────
+
+describe('parseCommandArg', () => {
+  it('returns empty string when no arg', () => {
+    expect(parseCommandArg('/restart')).toBe('')
+  })
+  it('returns empty string when only whitespace', () => {
+    expect(parseCommandArg('/restart   ')).toBe('')
+  })
+  it('returns single arg', () => {
+    expect(parseCommandArg('/restart foo')).toBe('foo')
+  })
+  it('returns multi-word arg trimmed', () => {
+    expect(parseCommandArg('/restart   foo bar  ')).toBe('foo bar')
+  })
+  it('works with @botname suffix', () => {
+    expect(parseCommandArg('/restart@bot foo')).toBe('foo')
+  })
+  it('returns empty string for non-slash text', () => {
+    expect(parseCommandArg('hello world')).toBe('')
+  })
+})
+
+// ─── classifyAdminGate ───────────────────────────────────────────────────────
+
+describe('classifyAdminGate', () => {
+  const me = 'clerk'
+
+  it('passes through plain text', () => {
+    expect(classifyAdminGate('hello there', me)).toEqual({ action: 'pass-through' })
+  })
+
+  it('passes through unknown slash commands', () => {
+    expect(classifyAdminGate('/whatever', me)).toEqual({ action: 'pass-through' })
+  })
+
+  it('passes through non-admin commands', () => {
+    expect(classifyAdminGate('/version', me)).toEqual({ action: 'pass-through' })
+    expect(classifyAdminGate('/auth', me)).toEqual({ action: 'pass-through' })
+    expect(classifyAdminGate('/new', me)).toEqual({ action: 'pass-through' })
+  })
+
+  describe('/restart', () => {
+    it('passes through with no arg (self-restart)', () => {
+      expect(classifyAdminGate('/restart', me)).toEqual({ action: 'pass-through' })
+    })
+    it('passes through with whitespace-only arg', () => {
+      expect(classifyAdminGate('/restart   ', me)).toEqual({ action: 'pass-through' })
+    })
+    it('passes through when arg matches my agent name', () => {
+      expect(classifyAdminGate('/restart clerk', me)).toEqual({ action: 'pass-through' })
+    })
+    it('passes through with @botname suffix and self target', () => {
+      expect(classifyAdminGate('/restart@switchroombot clerk', me)).toEqual({
+        action: 'pass-through',
+      })
+    })
+    it('blocks when targeting a different agent', () => {
+      expect(classifyAdminGate('/restart finn', me)).toEqual({
+        action: 'block',
+        reason: 'other-agent',
+        cmd: 'restart',
+      })
+    })
+    it('blocks when targeting `all`', () => {
+      expect(classifyAdminGate('/restart all', me)).toEqual({
+        action: 'block',
+        reason: 'other-agent',
+        cmd: 'restart',
+      })
+    })
+  })
+
+  describe('other admin commands', () => {
+    it('blocks /logs with admin-required reason', () => {
+      expect(classifyAdminGate('/logs', me)).toEqual({
+        action: 'block',
+        reason: 'admin-required',
+        cmd: 'logs',
+      })
+    })
+    it('blocks /grant with admin-required reason regardless of args', () => {
+      expect(classifyAdminGate('/grant clerk telegram', me)).toEqual({
+        action: 'block',
+        reason: 'admin-required',
+        cmd: 'grant',
+      })
+    })
+    it('blocks /agents, /update, /vault, /permissions', () => {
+      for (const c of ['agents', 'update', 'vault', 'permissions', 'stop', 'agentstart', 'reconcile', 'dangerous', 'memory', 'topics']) {
+        const r = classifyAdminGate(`/${c}`, me)
+        expect(r).toEqual({ action: 'block', reason: 'admin-required', cmd: c })
+      }
+    })
+    it('handles @botname suffix', () => {
+      expect(classifyAdminGate('/logs@switchroombot 50', me)).toEqual({
+        action: 'block',
+        reason: 'admin-required',
+        cmd: 'logs',
+      })
     })
   })
 })

--- a/telegram-plugin/admin-commands/index.ts
+++ b/telegram-plugin/admin-commands/index.ts
@@ -91,6 +91,75 @@ export function parseCommandName(text: string): string | null {
  *     commands to Claude (when adminEnabled=false).
  *  2. By tests to verify the dispatch table is correct without starting a bot.
  */
+/**
+ * Parse the argument portion of a slash command (everything after the command
+ * token, trimmed). Returns '' when no argument is present.
+ *
+ *   parseCommandArg('/restart')           === ''
+ *   parseCommandArg('/restart   ')        === ''
+ *   parseCommandArg('/restart foo')       === 'foo'
+ *   parseCommandArg('/restart@bot foo')   === 'foo'
+ *   parseCommandArg('/restart foo bar')   === 'foo bar'
+ */
+export function parseCommandArg(text: string): string {
+  if (!text.startsWith('/')) return ''
+  const spaceIdx = text.indexOf(' ')
+  if (spaceIdx === -1) return ''
+  return text.slice(spaceIdx + 1).trim()
+}
+
+/**
+ * Result of admin-gate classification used by the gateway middleware to decide
+ * how to handle an inbound slash command when admin gating is OFF.
+ *
+ *  - `pass-through` — let the command fall through to the gateway's local
+ *    bot.command() handler. Used for non-admin commands AND for `/restart`
+ *    targeting the current agent (self-restart is always allowed).
+ *  - `block` — the gateway should reply with an "admin required" warning and
+ *    NOT forward the message to Claude.
+ *
+ * `reason` distinguishes the two block cases for the audit log:
+ *  - `other-agent` — `/restart` aimed at a different agent
+ *  - `admin-required` — any other ADMIN_COMMAND_NAMES verb
+ */
+export type AdminGateDecision =
+  | { action: 'pass-through' }
+  | { action: 'block'; reason: 'other-agent' | 'admin-required'; cmd: string }
+
+/**
+ * Decide what the gateway middleware should do with an inbound text message
+ * when SWITCHROOM_AGENT_ADMIN=false.
+ *
+ * Rules:
+ *  - Non-slash text → pass-through.
+ *  - Unknown / non-admin slash command → pass-through.
+ *  - `/restart` with no arg, or arg matching `myAgentName` → pass-through
+ *    (gateway's local bot.command('restart', …) handles self-restart).
+ *  - `/restart <other-agent>` → block (reason='other-agent').
+ *  - Any other ADMIN_COMMAND_NAMES verb → block (reason='admin-required').
+ *
+ * This function is pure and synchronous so it can be unit-tested without a
+ * Grammy context. The middleware in gateway.ts does the side effects.
+ */
+export function classifyAdminGate(
+  text: string,
+  myAgentName: string,
+): AdminGateDecision {
+  if (!text.startsWith('/')) return { action: 'pass-through' }
+  const cmd = parseCommandName(text)
+  if (cmd === null || !ADMIN_COMMAND_NAMES.has(cmd)) {
+    return { action: 'pass-through' }
+  }
+  if (cmd === 'restart') {
+    const arg = parseCommandArg(text)
+    if (arg === '' || arg === myAgentName) {
+      return { action: 'pass-through' }
+    }
+    return { action: 'block', reason: 'other-agent', cmd }
+  }
+  return { action: 'block', reason: 'admin-required', cmd }
+}
+
 export function dispatchAdminCommand(
   text: string,
   adminEnabled: boolean,

--- a/telegram-plugin/admin-commands/index.ts
+++ b/telegram-plugin/admin-commands/index.ts
@@ -75,23 +75,6 @@ export function parseCommandName(text: string): string | null {
 }
 
 /**
- * Decide whether an inbound message should be intercepted as an admin command.
- *
- * Returns `{ handled: true }` when:
- *   - `adminEnabled` is true (SWITCHROOM_AGENT_ADMIN=true)
- *   - `text` starts with `/`
- *   - The command name is in ADMIN_COMMAND_NAMES
- *
- * Returns `{ handled: false }` in all other cases — the message should fall
- * through to normal processing (forwarded to Claude via IPC).
- *
- * Note: this function does NOT execute the command. Execution is performed by
- * Grammy's bot.command() handlers in gateway.ts. This function is used:
- *  1. By the gateway middleware to decide whether to forward non-admin-gated
- *     commands to Claude (when adminEnabled=false).
- *  2. By tests to verify the dispatch table is correct without starting a bot.
- */
-/**
  * Parse the argument portion of a slash command (everything after the command
  * token, trimmed). Returns '' when no argument is present.
  *
@@ -152,7 +135,9 @@ export function classifyAdminGate(
   }
   if (cmd === 'restart') {
     const arg = parseCommandArg(text)
-    if (arg === '' || arg === myAgentName) {
+    // Case-insensitive: assertSafeAgentName allows mixed case, so `/restart Clerk`
+    // must still self-target an agent named `clerk`.
+    if (arg === '' || arg.toLowerCase() === myAgentName.toLowerCase()) {
       return { action: 'pass-through' }
     }
     return { action: 'block', reason: 'other-agent', cmd }
@@ -160,6 +145,23 @@ export function classifyAdminGate(
   return { action: 'block', reason: 'admin-required', cmd }
 }
 
+/**
+ * Decide whether an inbound message should be intercepted as an admin command.
+ *
+ * Returns `{ handled: true }` when:
+ *   - `adminEnabled` is true (SWITCHROOM_AGENT_ADMIN=true)
+ *   - `text` starts with `/`
+ *   - The command name is in ADMIN_COMMAND_NAMES
+ *
+ * Returns `{ handled: false }` in all other cases — the message should fall
+ * through to normal processing (forwarded to Claude via IPC).
+ *
+ * Note: this function does NOT execute the command. Execution is performed by
+ * Grammy's bot.command() handlers in gateway.ts. This function is used:
+ *  1. By the gateway middleware to decide whether to forward non-admin-gated
+ *     commands to Claude (when adminEnabled=false).
+ *  2. By tests to verify the dispatch table is correct without starting a bot.
+ */
 export function dispatchAdminCommand(
   text: string,
   adminEnabled: boolean,

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -251,7 +251,7 @@ import { StagingMap } from '../secret-detect/staging.js'
 import { maskToken } from '../secret-detect/mask.js'
 import { defaultVaultWrite, defaultVaultList } from '../secret-detect/vault-write.js'
 import { detectSecrets } from '../secret-detect/index.js'
-import { ADMIN_COMMAND_NAMES, parseCommandName } from '../admin-commands/index.js'
+import { classifyAdminGate } from '../admin-commands/index.js'
 import {
   startSubagentWatcher,
   type SubagentWatcherHandle,
@@ -5690,28 +5690,35 @@ async function runSwitchroomCommandFormatted(ctx: Context, args: string[], label
 }
 
 // ─── Admin-command gating middleware ─────────────────────────────────────
-// When AGENT_ADMIN=false (default), admin slash commands like /agents, /logs,
-// /restart etc. should fall through to Claude rather than being executed
-// locally. Grammy's bot.command() handlers fire BEFORE bot.on('message:text'),
-// so without this middleware the commands would silently execute (or no-op
-// due to isAuthorizedSender) and never reach handleInboundCoalesced.
+// When AGENT_ADMIN=false (default), admin slash commands (/agents, /logs,
+// /grant, etc.) must NOT execute locally — this agent isn't admin-flagged
+// and routing them through Claude burns tokens for no benefit. Reply with a
+// concise "admin required" warning instead.
 //
-// Middleware registered BEFORE bot.command() calls intercepts text messages
-// first. If admin gating is off and the command is in ADMIN_COMMAND_NAMES, we
-// redirect to handleInboundCoalesced so Claude sees the message.
+// Special case: `/restart` with no arg, or `/restart <my-agent-name>`, is
+// allowed to fall through to the local bot.command('restart', …) handler so
+// every agent can self-restart without admin privilege. `/restart <other>`
+// is blocked just like any other admin verb.
 //
 // Invariant: when AGENT_ADMIN=true, this middleware is a no-op — bot.command()
-// handlers run normally and Claude never sees admin commands.
+// handlers run normally for all admin verbs and Claude never sees them.
 bot.use(async (ctx, next) => {
   if (!AGENT_ADMIN && ctx.message?.text) {
-    const cmd = parseCommandName(ctx.message.text)
-    if (cmd !== null && ADMIN_COMMAND_NAMES.has(cmd)) {
-      // Redirect admin command text to Claude via the normal inbound path.
-      // We intentionally do NOT call next() so bot.command() never fires.
+    const myName = getMyAgentName()
+    const decision = classifyAdminGate(ctx.message.text, myName)
+    if (decision.action === 'block') {
+      // Block admin commands the LLM should never see. Reply with a concise
+      // "admin required" warning instead of forwarding to Claude.
       process.stderr.write(
-        `telegram gateway: admin-gate redirect cmd=/${cmd} agent=${process.env.SWITCHROOM_AGENT_NAME ?? '-'} (AGENT_ADMIN=false)\n`,
+        `telegram gateway: admin-gate blocked cmd=/${decision.cmd} agent=${process.env.SWITCHROOM_AGENT_NAME ?? '-'} reason=${decision.reason} (AGENT_ADMIN=false)\n`,
       )
-      await handleInboundCoalesced(ctx, ctx.message.text, undefined)
+      const cmdHtml = escapeHtmlForTg(`/${decision.cmd}`)
+      const nameHtml = escapeHtmlForTg(myName)
+      const text =
+        decision.reason === 'other-agent'
+          ? `⚠️ <code>${cmdHtml}</code> targeting another agent is an admin operation — this agent (<code>${nameHtml}</code>) isn't admin-flagged. Run it from an admin agent, or set <code>admin: true</code> for this agent in switchroom.yaml. (Self-restart is allowed: send <code>/restart</code> with no arg.)`
+          : `⚠️ <code>${cmdHtml}</code> is an admin command — this agent (<code>${nameHtml}</code>) isn't admin-flagged. Run it from an admin agent, or set <code>admin: true</code> for this agent in switchroom.yaml.`
+      await switchroomReply(ctx, text, { html: true })
       return
     }
   }


### PR DESCRIPTION
## Summary
- `/restart` with no arg or self-targeting now falls through to the local handler on non-admin agents — every agent can self-restart, no admin privilege needed.
- All other admin verbs (and `/restart <other-agent>`) on non-admin agents now get a direct gateway reply pointing the user at `admin: true` in switchroom.yaml. The LLM never sees them — saves tokens and avoids model-generated "you can't do that" prose.
- Logic extracted into pure `classifyAdminGate(text, myAgentName)` helper in `admin-commands/index.ts` with full unit coverage. Audit log changed `redirect` → `blocked` with `reason=other-agent` / `reason=admin-required`.

## Test plan
- [x] `npx vitest run telegram-plugin/admin-commands/dispatch.test.ts` — 41 passing (added 22 new cases covering pass-through, block-other-agent, block-admin-required across `/restart`, `/logs`, `/grant`, `/agents`, `/update`, `/vault`, `/permissions`, `/stop`, `/agentstart`, `/reconcile`, `/dangerous`, `/memory`, `/topics`, plus `parseCommandArg`).
- [x] `npx tsc --noEmit` clean for the touched files.
- [ ] Manual smoke on a non-admin agent: `/restart` self-restarts; `/restart other-agent` and `/logs` return the admin-required warning without invoking Claude.

🤖 Generated with [Claude Code](https://claude.com/claude-code)