### PR TITLE
chore: release v0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,57 @@
 # Changelog
 
+## v0.5.1 — 2026-05-07
+
+Twenty commits since v0.5.0. Headlines: approval-kernel RFC B
+Phase 1 lands (IPC broker + SQLite kernel + Telegram card primitive),
+Google Drive MCP integration ships end-to-end (RFC C — full
+integration, desktop-loopback OAuth tier, `drive:` config block, CLI
+connect/disconnect), gateway gains a card audit log + structured
+`card-events.jsonl` tagging, and operational fixes for vault preflight,
+self-restart UX, cron DM routing, and the bg-agent silent-card bug.
+
+### Added
+
+- **Approval kernel RFC B Phase 1 (#762)** — IPC broker + SQLite kernel
+  + Telegram card primitive; the substrate for human-in-the-loop
+  approval flows.
+- **`waitForApproval` short-poll helper (#765)** — ergonomic agent-side
+  API on top of the kernel.
+- **Google Drive MCP integration — RFC C full landing (#763)**.
+- **Drive CLI: `switchroom drive connect` / `disconnect` (#766)**.
+- **Drive desktop-loopback OAuth tier (#767)** — RFC C tier 3, no
+  service-account JSON required.
+- **`drive:` config block (#768)** — first-class config, replaces /
+  supplements env-var wiring.
+- **Vault pre-flight check on `agent restart` (#773)** — fails fast
+  with a clear message instead of looping on a locked vault.
+- **Self-restart on non-admin commands + warn on admin cmds (#775)** —
+  better UX when the gateway needs to bounce itself.
+- **Card audit log (#777)** — `card-events.jsonl`, `tg-post` tagging
+  with `turnKey` / `cardMessageId`, `sub_agent_finished` events, and
+  50 MB × 5 file rotation for forensic replay.
+
+### Changed
+
+- **RFC docs land for the approval kernel (#756, #764)** — three RFCs
+  (A bot-token, B kernel, C gdrive) and a follow-up alignment of RFC B
+  with the shipped implementation (TTL default, schema columns, audit
+  split).
+- **`bun.lock` workspace name reconciled `clerk-ai` → `switchroom`
+  (#750)**.
+
+### Fixed
+
+- **Bg-agent progress card goes silent (#759, fixes #757)**.
+- **`approval-callback` signature alignment + `materializeBotToken`
+  catch tightened (#770, #771)**.
+- **Cron DM routing for `dm_only` agents (#774)**.
+- **`materialize TELEGRAM_BOT_TOKEN` from vault at startup (#758/#761)**.
+- **Webhook dispatch: prepend nvm node bin to spawn PATH (#754)**.
+- **`handleWebhookIngest` now receives `dispatchConfig` (#753)**.
+- **Autoaccept new `dev-channels` prompt + reconcile systemd-unit drift
+  (#749)**.
+
 ## v0.5.0 — 2026-05-06
 
 Initial release of `switchroom` (npm package renamed from

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "switchroom",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "switchroom",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "license": "MIT",
       "workspaces": [
         "telegram-plugin"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "switchroom",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Run Claude Code 24/7 on your Claude Pro/Max subscription over Telegram. Open-source alternative to OpenClaw and NanoClaw — no API keys, no Docker.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Twenty-one commits since v0.5.0. Headlines:

- Approval kernel RFC B Phase 1: IPC broker + SQLite kernel + Telegram card primitive (#762), waitForApproval helper (#765), RFC docs alignment (#756, #764).
- Drive MCP RFC C: full integration (#763), CLI connect/disconnect (#766), desktop-loopback OAuth tier (#767), `drive:` config block (#768).
- Operational: vault preflight on agent restart (#773), self-restart on non-admin / warn on admin (#775), bg-agent silent progress card fix (#759, fixes #757), cron DM routing for dm_only agents (#774).
- Card audit log: `card-events.jsonl` + tg-post tagging + `sub_agent_finished` + 50MB x 5 rotation (#777).
- approval-callback signature alignment + `materializeBotToken` catch tightened (#770, #771); vault token materialization (#758/#761); webhook dispatch fixes (#753, #754); autoaccept dev-channels + systemd-unit drift reconcile (#749); bun.lock workspace name reconciled (#750).

## Test plan

- [x] `npm run build` clean (gateway / bridge / foreman bundles emit without error).
- [ ] `npm run lint` — pre-existing tsc errors on `upstream/main` (10 errors in `agents/lifecycle.ts`, `agents/systemd.ts`, `cli/agent.ts`, `cli/telegram.ts`, `web/server.ts`); not introduced by this release commit. Verified by stashing the release diff and re-running lint — same failures.
- [ ] `npm test` not run.

Don't merge yet — fresh reviewer dispatch then merge + tag.