### PR TITLE
fix(schema): declare experimental, webhook_dispatch, dispatchConfig fields used at runtime

### DIFF
--- a/src/build-info.ts
+++ b/src/build-info.ts
@@ -2,8 +2,8 @@
 // Tracked in git so `tsc --noEmit` works on a fresh clone before `npm run build`.
 // Values are refreshed every time `npm run build` runs.
 
-export const VERSION: string = "0.5.0";
-export const COMMIT_SHA: string | null = "80f3f2b6";
-export const COMMIT_DATE: string | null = "2026-05-06T14:47:22+10:00";
-export const LATEST_PR: number | null = 747;
-export const COMMITS_AHEAD_OF_TAG: number | null = 1;
+export const VERSION: string = "0.5.1";
+export const COMMIT_SHA: string | null = "469cde1f";
+export const COMMIT_DATE: string | null = "2026-05-07T11:52:35+10:00";
+export const LATEST_PR: number | null = 778;
+export const COMMITS_AHEAD_OF_TAG: number | null = 0;

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -545,6 +545,42 @@ export const TelegramChannelSchema = z
         "Cascades from defaults.channels.telegram.webhook_sources. " +
         "(Migrated from per-agent root in #596 — see #577.)",
       ),
+    webhook_dispatch: z
+      .object({
+        github: z
+          .array(
+            z.object({
+              description: z.string().optional(),
+              match: z
+                .object({
+                  event: z.string(),
+                  actions: z.array(z.string()).optional(),
+                  labels_any: z.array(z.string()).optional(),
+                  labels_all: z.array(z.string()).optional(),
+                  exclude_authors: z.array(z.string()).optional(),
+                })
+                .passthrough(),
+              prompt: z.string(),
+              cooldown: z.string().optional(),
+              quiet_hours: z
+                .object({
+                  start: z.number().int().min(0).max(23),
+                  end: z.number().int().min(0).max(23),
+                  tz: z.string().optional(),
+                })
+                .optional(),
+              model: z.string().optional(),
+            }),
+          )
+          .optional(),
+      })
+      .optional()
+      .describe(
+        "Auto-dispatch rules: when a verified webhook event matches a rule, " +
+        "spawn a one-shot `claude -p` turn for the agent with the rendered " +
+        "prompt. Supports cooldowns, quiet hours, and label/action matchers. " +
+        "Off by default — opt in per agent. See src/web/webhook-dispatch.ts.",
+      ),
     webhook_rate_limit: z
       .object({
         rpm: z.number().int().positive(),
@@ -787,6 +823,28 @@ const profileFields = {
       "to the stable bootstrap render. Loaded once at session start via " +
       "`--append-system-prompt`. Missing files are silently skipped. " +
       "Example: ['BRIEF.md', 'CONTEXT.md'].",
+    ),
+  experimental: z
+    .object({
+      legacy_pty: z
+        .boolean()
+        .optional()
+        .describe(
+          "Opt out of the default tmux supervisor (#725) and run the agent under " +
+          "the legacy PTY supervisor instead. Default: false (tmux is the default).",
+        ),
+      legacy_autoaccept_expect: z
+        .boolean()
+        .optional()
+        .describe(
+          "Opt the autoaccept gateway back into the legacy expect-script behaviour " +
+          "instead of the tmux send-keys path. Default: false.",
+        ),
+    })
+    .optional()
+    .describe(
+      "Opt-in flags for experimental / legacy behaviours. Cascades through " +
+      "defaults → profile → per-agent.",
     ),
 };
 
@@ -1185,6 +1243,28 @@ export const AgentSchema = z.object({
       "shared bare clone at ~/.switchroom/repos/<slug>.git. The worktree path is injected " +
       "into the agent's environment as SWITCHROOM_REPO_<SLUG_UPPER>. " +
       "Agents without this field continue to work unchanged.",
+    ),
+  experimental: z
+    .object({
+      legacy_pty: z
+        .boolean()
+        .optional()
+        .describe(
+          "Opt out of the default tmux supervisor (#725) and run the agent " +
+          "under the legacy PTY supervisor instead. Default: false.",
+        ),
+      legacy_autoaccept_expect: z
+        .boolean()
+        .optional()
+        .describe(
+          "Opt the autoaccept gateway back into the legacy expect-script " +
+          "behaviour instead of the tmux send-keys path. Default: false.",
+        ),
+    })
+    .optional()
+    .describe(
+      "Opt-in flags for experimental / legacy behaviours. Cascades through " +
+      "defaults → profile → per-agent.",
     ),
 });
 

--- a/src/web/webhook-handler.ts
+++ b/src/web/webhook-handler.ts
@@ -50,6 +50,7 @@ import {
   renderGenericEvent,
   type WebhookSource,
 } from './webhook-verify.js'
+import type { WebhookDispatchConfig } from './webhook-dispatch.js'
 
 export interface WebhookConfig {
   /** Per-source secrets, declared in vault under
@@ -86,6 +87,13 @@ export interface WebhookHandlerArgs {
   config: WebhookConfig
   /** True iff `agent` is a known agent in switchroom.yaml. */
   agentExists: boolean
+  /**
+   * Optional dispatch rules from `channels.telegram.webhook_dispatch`.
+   * When present, verified events are evaluated against the rules and
+   * matching ones spawn one-shot `claude -p` turns. Passed through to
+   * the dispatch evaluator; the ingest path itself does not consume it.
+   */
+  dispatchConfig?: WebhookDispatchConfig
 }
 
 export interface WebhookHandlerResult {

--- a/telegram-plugin/gateway/approvals-commands.ts
+++ b/telegram-plugin/gateway/approvals-commands.ts
@@ -63,7 +63,7 @@ export function registerApprovalsCommands(
       // Top-level summary by agent, mirroring the GitHub-style permissions UI
       // referenced in RFC §9.
       const byAgent = new Map<string, number>();
-      for (const d of decisions) byAgent.set(d.agent, (byAgent.get(d.agent) ?? 0) + 1);
+      for (const d of decisions) byAgent.set(d.agent_unit, (byAgent.get(d.agent_unit) ?? 0) + 1);
       const summary = Array.from(byAgent.entries())
         .map(([a, n]) => `• <b>${escapeHtml(a)}</b>: ${n}`)
         .join("\n");
@@ -71,14 +71,14 @@ export function registerApprovalsCommands(
         .slice(0, 20)
         .map((d) => {
           const ttl =
-            d.expires_at === null
+            d.ttl_expires_at === null
               ? "always"
-              : `until ${new Date(d.expires_at).toISOString().slice(0, 16).replace("T", " ")}`;
+              : `until ${new Date(d.ttl_expires_at).toISOString().slice(0, 16).replace("T", " ")}`;
           return (
             `<code>${escapeHtml(d.id.slice(0, 8))}</code> ` +
-            `${escapeHtml(d.agent)} → ` +
+            `${escapeHtml(d.agent_unit)} → ` +
             `<code>${escapeHtml(d.scope)}</code> ` +
-            `(${escapeHtml(d.action_grammar)}, ${ttl}) ` +
+            `(${escapeHtml(d.action)}, ${ttl}) ` +
             `· /approvals revoke ${escapeHtml(d.id)}`
           );
         })


### PR DESCRIPTION
## Why

`npm publish` is blocked: `prepublishOnly` runs `npm run lint` which runs `tsc --noEmit`, and main has 11 pre-existing tsc errors — all callsites referencing properties not declared on the config schema. Build is clean; this is type-system catch-up.

## What

Purely additive — declaring optional fields to match how the config is already read at runtime. No behaviour changes.

- `src/config/schema.ts` — add `experimental.{legacy_pty, legacy_autoaccept_expect}` to `profileFields` (cascading) and `AgentSchema` (per-agent). Used at `lifecycle.ts:374,645`, `systemd.ts:598,600`, `agent.ts:571,573,1399,1422`.
- `src/config/schema.ts` — add `webhook_dispatch.github[]` (DispatchRule shape mirrored from `src/web/webhook-dispatch.ts`) to `TelegramChannelSchema`. Used at `telegram.ts:501` and `server.ts:278`.
- `src/web/webhook-handler.ts` — add optional `dispatchConfig?: WebhookDispatchConfig` to `WebhookHandlerArgs`. Passed at `server.ts:278`.
- `telegram-plugin/gateway/approvals-commands.ts` — rename stale field reads (`agent → agent_unit`, `expires_at → ttl_expires_at`, `action_grammar → action`) to match the decision shape from `vault/broker/protocol.ts`. Surfaced once the main tsc check passes (the `check-plugin-references.mjs` script previously short-circuited on the schema errors above).

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run build` — clean
- [ ] Reviewer sanity-check: schema additions match runtime callsite shapes; nothing renamed or removed