### PR TITLE
chore: release v0.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## v0.5.2 — 2026-05-07
+
+Patch release. Unblocks `npm publish` (the v0.5.1 prepublish hook
+failed on pre-existing tsc errors that masked stale field reads in the
+approvals-list command).
+
+### Fixed
+
+- **Type-system catch-up to runtime usage (#779)** — declare
+  `experimental` (`{ legacy_pty?, legacy_autoaccept_expect? }`),
+  `telegram.webhook_dispatch`, and `WebhookHandlerArgs.dispatchConfig`
+  on the config schema. Purely additive; no behaviour change. Follow-up
+  #780 tracks extracting `ExperimentalSchema` with the
+  `tmux_supervisor` → `legacy_pty` migration transform.
+- **`/approvals list` field renames (#779)** — bring
+  `telegram-plugin/gateway/approvals-commands.ts` field reads in line
+  with the real `ApprovalDecisionMeta` shape (`agent_unit`, `action`,
+  `ttl_expires_at`). Was silently rendering `undefined` for those
+  columns.
+
 ## v0.5.1 — 2026-05-07
 
 Twenty commits since v0.5.0. Headlines: approval-kernel RFC B

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "switchroom",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "switchroom",
-      "version": "0.5.1",
+      "version": "0.5.2",
       "license": "MIT",
       "workspaces": [
         "telegram-plugin"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "switchroom",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Run Claude Code 24/7 on your Claude Pro/Max subscription over Telegram. Open-source alternative to OpenClaw and NanoClaw — no API keys, no Docker.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Patch release to unblock `npm publish`. v0.5.1 was tagged + merged but `npm publish` failed on pre-existing tsc errors fixed by #779. v0.5.2 wraps that fix into a publishable release.

Diff vs v0.5.1: just the version bumps + CHANGELOG entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)