### PR TITLE
fix(quota-check): pass opts.home to writeAccountQuota

### DIFF
--- a/telegram-plugin/quota-check.ts
+++ b/telegram-plugin/quota-check.ts
@@ -358,6 +358,7 @@ export async function fetchAccountQuota(
       writeAccountQuota(
         label,
         snapshotFromQuotaUtilization(result.data, new Date(now)),
+        opts.home,
       );
     } catch {
       /* best-effort */

--- a/telegram-plugin/tests/quota-check.test.ts
+++ b/telegram-plugin/tests/quota-check.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest'
-import { mkdtempSync, writeFileSync, rmSync, mkdirSync } from 'fs'
+import { mkdtempSync, writeFileSync, rmSync, mkdirSync, existsSync, readFileSync } from 'fs'
 import { tmpdir } from 'os'
 import { join } from 'path'
 import {
@@ -375,6 +375,42 @@ describe('fetchAccountQuota — cache + token resolution', () => {
         now,
       })
       expect(callCount).toBe(2)
+    } finally {
+      rmSync(home, { recursive: true, force: true })
+    }
+  })
+
+  it('persists the snapshot under the supplied home, not the real homedir (issue #708 regression)', async () => {
+    const home = makeAccountHome({
+      'work@example.com': { accessToken: 'tok' },
+    })
+    const fakeFetch = async () =>
+      new Response('{}', {
+        status: 200,
+        headers: {
+          'anthropic-ratelimit-unified-5h-utilization': '0.42',
+          'anthropic-ratelimit-unified-7d-utilization': '0.17',
+        },
+      })
+    try {
+      const r = await fetchAccountQuota('work@example.com', {
+        home,
+        fetchImpl: fakeFetch as typeof fetch,
+      })
+      expect(r.ok).toBe(true)
+      const snapPath = join(
+        home,
+        '.switchroom',
+        'accounts',
+        'work@example.com',
+        'quota.json',
+      )
+      // The bug: writeAccountQuota was called without opts.home, so the
+      // snapshot landed under the real $HOME instead of the test home.
+      expect(existsSync(snapPath)).toBe(true)
+      const snap = JSON.parse(readFileSync(snapPath, 'utf-8'))
+      expect(snap.fiveHourPct).toBeCloseTo(42, 0)
+      expect(snap.sevenDayPct).toBeCloseTo(17, 0)
     } finally {
       rmSync(home, { recursive: true, force: true })
     }


### PR DESCRIPTION
## Summary
- `fetchAccountQuota(label, opts)` accepts `opts.home` and uses it to resolve the access token, but the snapshot-persistence call to `writeAccountQuota(label, snapshot)` was missing the third argument
- As a result the snapshot was always written under the real `\$HOME` instead of the supplied home — silent home-leak that makes sandboxed tests / callers see stale data forever
- One-line fix: forward `opts.home`. Plus a regression test that proves the snapshot lands under the supplied home

## Test plan
- [x] New regression test `persists the snapshot under the supplied home, not the real homedir (issue #708 regression)` fails on `main`, passes with the fix
- [x] Full `quota-check.test.ts` suite green (29 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)