### PR TITLE
feat(progress-card): deterministic tool-call labels via PreToolUse hook (#783)

### DIFF
--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -2298,6 +2298,17 @@ export function buildSettingsHooksBlock(p: HooksBlockParams): Record<string, unk
       timeout: 5,
       async: false,
     });
+    // Reaper for the PreToolUse tool-label sidecar files (#783).
+    // Runs on every Stop; idempotent age + count rotation.
+    stopHooks.push({
+      type: "command",
+      command: wrap(
+        "hook:tool-label-stop",
+        `node "${join(REPO_ROOT, "telegram-plugin", "hooks", "tool-label-stop.mjs")}"`,
+      ),
+      timeout: 5,
+      async: true,
+    });
   }
   const switchroomStop = stopHooks.length > 0 ? [{ hooks: stopHooks }] : [];
 
@@ -2330,6 +2341,21 @@ export function buildSettingsHooksBlock(p: HooksBlockParams): Record<string, unk
                 `node "${join(REPO_ROOT, "telegram-plugin", "hooks", "subagent-tracker-pretool.mjs")}"`,
               ),
               timeout: 10,
+            },
+          ],
+        },
+        {
+          // Catch-all PreToolUse: deterministic tool-call labels (#783).
+          // Hook always exits 0; never emits stdout JSON; writes one line
+          // to $TELEGRAM_STATE_DIR/tool-labels-${session_id}.jsonl.
+          hooks: [
+            {
+              type: "command",
+              command: wrap(
+                "hook:tool-label-pretool",
+                `node "${join(REPO_ROOT, "telegram-plugin", "hooks", "tool-label-pretool.mjs")}"`,
+              ),
+              timeout: 5,
             },
           ],
         },

--- a/src/build-info.ts
+++ b/src/build-info.ts
@@ -3,7 +3,7 @@
 // Values are refreshed every time `npm run build` runs.
 
 export const VERSION: string = "0.5.2";
-export const COMMIT_SHA: string | null = "79050383";
-export const COMMIT_DATE: string | null = "2026-05-07T12:34:49+10:00";
+export const COMMIT_SHA: string | null = "09eeafec";
+export const COMMIT_DATE: string | null = "2026-05-07T12:38:16+10:00";
 export const LATEST_PR: number | null = null;
-export const COMMITS_AHEAD_OF_TAG: number | null = 1;
+export const COMMITS_AHEAD_OF_TAG: number | null = 2;

--- a/src/build-info.ts
+++ b/src/build-info.ts
@@ -2,8 +2,8 @@
 // Tracked in git so `tsc --noEmit` works on a fresh clone before `npm run build`.
 // Values are refreshed every time `npm run build` runs.
 
-export const VERSION: string = "0.5.1";
-export const COMMIT_SHA: string | null = "469cde1f";
-export const COMMIT_DATE: string | null = "2026-05-07T11:52:35+10:00";
-export const LATEST_PR: number | null = 778;
-export const COMMITS_AHEAD_OF_TAG: number | null = 0;
+export const VERSION: string = "0.5.2";
+export const COMMIT_SHA: string | null = "79050383";
+export const COMMIT_DATE: string | null = "2026-05-07T12:34:49+10:00";
+export const LATEST_PR: number | null = null;
+export const COMMITS_AHEAD_OF_TAG: number | null = 1;

--- a/telegram-plugin/hooks/hooks.json
+++ b/telegram-plugin/hooks/hooks.json
@@ -19,6 +19,15 @@
             "timeout": 10
           }
         ]
+      },
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/tool-label-pretool.mjs\"",
+            "timeout": 5
+          }
+        ]
       }
     ],
     "PostToolUse": [
@@ -50,6 +59,16 @@
             "type": "command",
             "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/silent-end-interrupt-stop.mjs\"",
             "timeout": 5
+          }
+        ]
+      },
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/tool-label-stop.mjs\"",
+            "timeout": 5,
+            "async": true
           }
         ]
       }

--- a/telegram-plugin/hooks/tool-label-pretool.mjs
+++ b/telegram-plugin/hooks/tool-label-pretool.mjs
@@ -1,0 +1,216 @@
+#!/usr/bin/env node
+/**
+ * PreToolUse hook — emits a deterministic human label per tool call.
+ *
+ * Claude Code PreToolUse protocol (v1):
+ *   Input:  JSON on stdin — { session_id, tool_name, tool_input, tool_use_id, cwd, ... }
+ *   Output: exit 0 + empty stdout → allow. We NEVER emit JSON to stdout
+ *           (would risk hookSpecificOutput.updatedInput collisions). We
+ *           NEVER exit non-zero (exit 2 BLOCKS the tool call).
+ *
+ * Side effect: appends one JSON line to
+ *   $TELEGRAM_STATE_DIR/tool-labels-${session_id}.jsonl
+ * with shape { ts, tool_use_id, agent_id, label, tool_name }.
+ *
+ * If $TELEGRAM_STATE_DIR is unset → silent skip (renderer just falls back
+ * to its existing precedence ladder). If session_id or tool_use_id is
+ * missing → skip (the row could never be joined anyway). If the rule
+ * table doesn't produce a label for the tool → skip.
+ *
+ * Tools intentionally NOT labeled here (handled by existing description
+ * / TodoWrite / sub-agent panels in the renderer):
+ *   Bash, Task, Agent, TodoWrite
+ *
+ * Issue #783.
+ */
+
+import { readFileSync, mkdirSync, appendFileSync, existsSync } from 'node:fs'
+import { join, basename } from 'node:path'
+
+function readStdin() {
+  try {
+    return readFileSync(0, 'utf8')
+  } catch {
+    return ''
+  }
+}
+
+/**
+ * One-line, length-bounded escape of a value for inclusion in a label.
+ * Newlines collapsed, very long strings truncated with an ellipsis.
+ */
+function clip(s, max = 80) {
+  if (s == null) return ''
+  let v = String(s).replace(/\s+/g, ' ').trim()
+  if (v.length > max) v = v.slice(0, max - 1) + '…'
+  return v
+}
+
+function safeBasename(p) {
+  if (!p || typeof p !== 'string') return ''
+  try {
+    const b = basename(p)
+    return b || p
+  } catch {
+    return p
+  }
+}
+
+function urlHostPath(u) {
+  if (!u || typeof u !== 'string') return ''
+  try {
+    const x = new URL(u)
+    return x.host + (x.pathname && x.pathname !== '/' ? x.pathname : '')
+  } catch {
+    return u
+  }
+}
+
+/**
+ * Compute a label for a (toolName, input) pair. Returns null when the
+ * tool should NOT be labeled (suppress / fall through to existing
+ * renderer precedence).
+ */
+export function computeLabel(toolName, input) {
+  const i = input ?? {}
+
+  // Tools whose labels are already handled elsewhere — emit nothing so
+  // the existing description / TodoWrite / sub-agent paths win.
+  switch (toolName) {
+    case 'Bash':
+    case 'Task':
+    case 'Agent':
+    case 'TodoWrite':
+    case 'ToolSearch':
+      return null
+  }
+
+  // Built-in rule table.
+  switch (toolName) {
+    case 'Read':
+      return `Reading ${clip(safeBasename(i.file_path))}`.trim()
+    case 'Edit':
+      return `Editing ${clip(safeBasename(i.file_path))}`.trim()
+    case 'Write':
+      return `Writing ${clip(safeBasename(i.file_path))}`.trim()
+    case 'Grep': {
+      const path = i.path ? clip(String(i.path), 40) : '.'
+      const pat = clip(String(i.pattern ?? ''), 40)
+      return `Searching ${path} for ${pat}`
+    }
+    case 'Glob':
+      return `Finding files matching ${clip(String(i.pattern ?? ''), 60)}`
+    case 'WebFetch':
+      return `Fetching ${clip(urlHostPath(i.url), 60)}`
+    case 'WebSearch':
+      return `Searching the web for ${clip(String(i.query ?? ''), 60)}`
+    case 'NotebookEdit':
+      return `Editing notebook ${clip(safeBasename(i.notebook_path))}`
+    case 'BashOutput':
+      return 'Reading background output'
+    case 'KillBash':
+    case 'KillShell':
+      return 'Stopping background process'
+  }
+
+  // MCP allowlist.
+  if (typeof toolName === 'string' && toolName.startsWith('mcp__')) {
+    switch (toolName) {
+      case 'mcp__switchroom-telegram__reply':
+      case 'mcp__switchroom-telegram__stream_reply':
+        return 'Replying'
+      case 'mcp__switchroom-telegram__react': {
+        const emoji = clip(String(i.emoji ?? ''), 8)
+        return emoji ? `Reacting ${emoji}` : 'Reacting'
+      }
+      case 'mcp__switchroom-telegram__get_recent_messages':
+        return 'Reading chat history'
+      case 'mcp__hindsight__recall':
+      case 'mcp__hindsight__reflect':
+        return 'Searching memory'
+      case 'mcp__hindsight__retain':
+        return 'Saving memory'
+      // Explicit suppressions — return null so we don't emit a sidecar
+      // line at all. (Falling through to the default below produces the
+      // same effect, but listing these makes the intent obvious.)
+      case 'mcp__switchroom-telegram__send_typing':
+      case 'mcp__hindsight__sync_retain':
+        return null
+    }
+    // Any other mcp__* tool: not on the allowlist, no label.
+    return null
+  }
+
+  return null
+}
+
+function main() {
+  const raw = readStdin().trim()
+  if (!raw) process.exit(0)
+
+  let event
+  try {
+    event = JSON.parse(raw)
+  } catch {
+    process.exit(0)
+  }
+
+  const stateDir = process.env.TELEGRAM_STATE_DIR
+  if (!stateDir || stateDir.length === 0) process.exit(0)
+
+  const sessionId = event.session_id
+  const toolUseId = event.tool_use_id
+  const toolName = event.tool_name
+  if (!sessionId || !toolUseId || !toolName) process.exit(0)
+
+  let label
+  try {
+    label = computeLabel(toolName, event.tool_input)
+  } catch {
+    process.exit(0)
+  }
+  if (!label) process.exit(0)
+
+  // agent_id: Claude Code does not pass sub-agent agent_id directly to
+  // the hook; fall back to SWITCHROOM_AGENT_NAME or the cwd basename.
+  const agentId =
+    process.env.SWITCHROOM_AGENT_NAME ??
+    (event.cwd ? safeBasename(event.cwd) : null) ??
+    null
+
+  const line = JSON.stringify({
+    ts: Date.now(),
+    tool_use_id: toolUseId,
+    agent_id: agentId,
+    label,
+    tool_name: toolName,
+  }) + '\n'
+
+  try {
+    if (!existsSync(stateDir)) {
+      mkdirSync(stateDir, { recursive: true })
+    }
+    const target = join(stateDir, `tool-labels-${sessionId}.jsonl`)
+    appendFileSync(target, line)
+  } catch (err) {
+    // Never block. Surface to stderr (captured by plugin-logger).
+    try {
+      process.stderr.write(
+        `[tool-label-pretool] write failed: ${err?.message ?? err}\n`,
+      )
+    } catch { /* ignore */ }
+  }
+
+  process.exit(0)
+}
+
+// Skip main() when imported (for unit tests of computeLabel).
+const isMain = (() => {
+  try {
+    const argv1 = process.argv[1] ?? ''
+    return argv1.endsWith('tool-label-pretool.mjs')
+  } catch {
+    return false
+  }
+})()
+if (isMain) main()

--- a/telegram-plugin/hooks/tool-label-stop.mjs
+++ b/telegram-plugin/hooks/tool-label-stop.mjs
@@ -1,0 +1,63 @@
+#!/usr/bin/env node
+/**
+ * Stop hook — reaps stale tool-label sidecar files.
+ *
+ * Removes $TELEGRAM_STATE_DIR/tool-labels-*.jsonl files older than 24h.
+ * If more than 50 sidecar files exist, removes the oldest down to 50.
+ * Always exits 0.
+ *
+ * Issue #783.
+ */
+
+import { readdirSync, statSync, unlinkSync } from 'node:fs'
+import { join } from 'node:path'
+
+const TWENTY_FOUR_HOURS_MS = 24 * 60 * 60 * 1000
+const MAX_SIDECARS = 50
+
+function main() {
+  const stateDir = process.env.TELEGRAM_STATE_DIR
+  if (!stateDir || stateDir.length === 0) process.exit(0)
+
+  let entries
+  try {
+    entries = readdirSync(stateDir)
+  } catch {
+    process.exit(0)
+  }
+
+  const now = Date.now()
+  const sidecars = []
+  for (const name of entries) {
+    if (!name.startsWith('tool-labels-') || !name.endsWith('.jsonl')) continue
+    const full = join(stateDir, name)
+    try {
+      const st = statSync(full)
+      sidecars.push({ path: full, mtime: st.mtimeMs })
+    } catch {
+      // ignore
+    }
+  }
+
+  // 1) Age-based reap
+  for (const s of sidecars) {
+    if (now - s.mtime > TWENTY_FOUR_HOURS_MS) {
+      try { unlinkSync(s.path) } catch { /* ignore */ }
+      s._removed = true
+    }
+  }
+
+  // 2) Cap by count — drop oldest beyond MAX_SIDECARS
+  const remaining = sidecars.filter((s) => !s._removed)
+  if (remaining.length > MAX_SIDECARS) {
+    remaining.sort((a, b) => a.mtime - b.mtime)
+    const toDrop = remaining.length - MAX_SIDECARS
+    for (let i = 0; i < toDrop; i++) {
+      try { unlinkSync(remaining[i].path) } catch { /* ignore */ }
+    }
+  }
+
+  process.exit(0)
+}
+
+main()

--- a/telegram-plugin/progress-card.ts
+++ b/telegram-plugin/progress-card.ts
@@ -504,7 +504,7 @@ export function reduce(
         id: state.items.length,
         toolUseId: event.toolUseId ?? null,
         tool: event.toolName,
-        label: toolLabel(event.toolName, event.input, preamble),
+        label: toolLabel(event.toolName, event.input, preamble, event.precomputedLabel),
         humanAuthored: isHumanDescription(event.toolName, event.input),
         state: 'running',
         startedAt: now,
@@ -833,7 +833,7 @@ export function reduce(
         currentTool: event.toolUseId
           ? {
               tool: event.toolName,
-              label: toolLabel(event.toolName, event.input, preamble),
+              label: toolLabel(event.toolName, event.input, preamble, event.precomputedLabel),
               humanAuthored: isHumanDescription(event.toolName, event.input),
               toolUseId: event.toolUseId,
               startedAt: now,

--- a/telegram-plugin/session-tail.ts
+++ b/telegram-plugin/session-tail.ts
@@ -36,6 +36,7 @@ import { homedir } from 'os'
 import { basename, join } from 'path'
 import { isMultiAgentEnabled } from './progress-card.js'
 import { classifyClaudeError, type OperatorEventKind } from './operator-events.js'
+import { createToolLabelSidecar, type ToolLabelSidecar } from './tool-label-sidecar.js'
 
 /** Match Claude Code's cli.js VX() function. */
 export function sanitizeCwdToProjectName(cwd: string): string {
@@ -86,7 +87,7 @@ export type SessionEvent =
   | { kind: 'enqueue'; chatId: string | null; messageId: string | null; threadId: string | null; rawContent: string; isSync?: boolean }
   | { kind: 'dequeue' }
   | { kind: 'thinking' }
-  | { kind: 'tool_use'; toolName: string; toolUseId?: string | null; input?: Record<string, unknown> }
+  | { kind: 'tool_use'; toolName: string; toolUseId?: string | null; input?: Record<string, unknown>; precomputedLabel?: string }
   | { kind: 'text'; text: string }
   | { kind: 'tool_result'; toolUseId: string; toolName: string | null; isError?: boolean; errorText?: string }
   | { kind: 'turn_end'; durationMs: number }
@@ -94,7 +95,7 @@ export type SessionEvent =
   // filename stem (e.g. "aac6f1…"). Routed through the same ingest path
   // as parent events; the reducer fans them out to per-sub-agent state.
   | { kind: 'sub_agent_started'; agentId: string; firstPromptText: string; subagentType?: string }
-  | { kind: 'sub_agent_tool_use'; agentId: string; toolUseId: string | null; toolName: string; input?: Record<string, unknown> }
+  | { kind: 'sub_agent_tool_use'; agentId: string; toolUseId: string | null; toolName: string; input?: Record<string, unknown>; precomputedLabel?: string }
   | { kind: 'sub_agent_text'; agentId: string; text: string }
   | { kind: 'sub_agent_narrative'; agentId: string; text: string }
   | { kind: 'sub_agent_tool_result'; agentId: string; toolUseId: string; isError?: boolean; errorText?: string }
@@ -499,10 +500,52 @@ export function startSessionTail(config: SessionTailConfig): SessionTailHandle {
   const projectsDir = getProjectsDirForCwd(cwd, claudeHome)
   const rescanMs = config.rescanIntervalMs ?? 500
   const log = config.log
-  const onEvent = config.onEvent
+  const rawOnEvent = config.onEvent
   const onOperatorEvent = config.onOperatorEvent
 
   log?.(`session-tail: projectsDir=${projectsDir}`)
+
+  // PreToolUse sidecar readers (#783) keyed by sessionId. Created lazily
+  // the first time we observe a tool_use / sub_agent_tool_use whose
+  // toolUseId could be looked up. The hook writes to
+  // $TELEGRAM_STATE_DIR/tool-labels-<session_id>.jsonl. Each sub-agent
+  // has its OWN sessionId (its jsonl filename stem), so we key by that.
+  const sidecars = new Map<string, ToolLabelSidecar>()
+  const stateDirForSidecar = process.env.TELEGRAM_STATE_DIR ?? null
+  function sessionIdForFile(file: string | null): string | null {
+    if (!file) return null
+    const b = file.endsWith('.jsonl') ? basename(file, '.jsonl') : null
+    return b && b.length > 0 ? b : null
+  }
+  function ensureSidecar(sessionId: string): ToolLabelSidecar | null {
+    if (!stateDirForSidecar) return null
+    const existing = sidecars.get(sessionId)
+    if (existing) return existing
+    try {
+      const s = createToolLabelSidecar({ stateDir: stateDirForSidecar, sessionId })
+      sidecars.set(sessionId, s)
+      return s
+    } catch (err) {
+      log?.(`session-tail: sidecar create failed: ${(err as Error).message}`)
+      return null
+    }
+  }
+  function decorate(ev: SessionEvent, sessionId: string | null): SessionEvent {
+    if (!sessionId) return ev
+    if (ev.kind !== 'tool_use' && ev.kind !== 'sub_agent_tool_use') return ev
+    if (!ev.toolUseId) return ev
+    const s = ensureSidecar(sessionId)
+    if (!s) return ev
+    // One quick poll attempt before lookup — the hook is synchronous from
+    // Claude Code's perspective and the sidecar line is typically on disk
+    // before the JSONL row is appended, but the file watcher is on a
+    // 250ms tick. Forcing a poll closes the race for the common case.
+    s.poll()
+    const label = s.getLabel(ev.toolUseId)
+    if (!label) return ev
+    return { ...ev, precomputedLabel: label }
+  }
+  const onEvent = (ev: SessionEvent): void => rawOnEvent(ev)
 
   let currentFile: string | null = null
   let cursor = 0 // byte offset of next read
@@ -550,9 +593,10 @@ export function startSessionTail(config: SessionTailConfig): SessionTailHandle {
       for (const line of lines) {
         if (!line) continue
         const events = projectTranscriptLine(line)
+        const sid = sessionIdForFile(currentFile)
         for (const ev of events) {
           try {
-            onEvent(ev)
+            onEvent(decorate(ev, sid))
           } catch (err) {
             log?.(`session-tail: onEvent threw: ${(err as Error).message}`)
           }
@@ -721,7 +765,12 @@ export function startSessionTail(config: SessionTailConfig): SessionTailHandle {
             t.hasSeenTerminal = true
           }
           try {
-            onEvent(ev)
+            // Sub-agent JSONLs have their own sessionId (the file's stem
+            // — sub-agent files are typically named agent-<id>.jsonl).
+            // Hook fires inside the sub-agent process with that
+            // session_id, so we look up the sidecar by it.
+            const subSid = sessionIdForFile(t.file)
+            onEvent(decorate(ev, subSid))
           } catch (err) {
             log?.(`session-tail: sub onEvent threw: ${(err as Error).message}`)
           }
@@ -872,6 +921,10 @@ export function startSessionTail(config: SessionTailConfig): SessionTailHandle {
         }
       }
       subTails.clear()
+      for (const s of sidecars.values()) {
+        try { s.stop() } catch { /* ignore */ }
+      }
+      sidecars.clear()
       if (pollTimer) {
         clearInterval(pollTimer)
         pollTimer = null

--- a/telegram-plugin/tests/tool-label-sidecar.test.ts
+++ b/telegram-plugin/tests/tool-label-sidecar.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, rmSync, appendFileSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { createToolLabelSidecar } from '../tool-label-sidecar.js'
+
+/**
+ * Unit tests for tool-label-sidecar.ts (#783).
+ *
+ * Uses an injected scheduler so we drive polls deterministically — no
+ * setTimeout, no flake.
+ */
+
+function makeManualScheduler() {
+  let tickFn: (() => void) | null = null
+  return {
+    setInterval: (cb: () => void, _ms: number) => {
+      tickFn = cb
+      return Symbol('handle')
+    },
+    clearInterval: (_h: unknown) => {
+      tickFn = null
+    },
+    tick: () => { if (tickFn) tickFn() },
+  }
+}
+
+describe('tool-label-sidecar', () => {
+  let stateDir: string
+  beforeEach(() => {
+    stateDir = mkdtempSync(join(tmpdir(), 'tool-label-sidecar-'))
+  })
+  afterEach(() => {
+    rmSync(stateDir, { recursive: true, force: true })
+  })
+
+  it('returns undefined when sidecar file is missing', () => {
+    const sched = makeManualScheduler()
+    const s = createToolLabelSidecar({ stateDir, sessionId: 'no-such', scheduler: sched })
+    expect(s.getLabel('whatever')).toBeUndefined()
+    s.stop()
+  })
+
+  it('reads existing sidecar lines on construction', () => {
+    const sessionId = 'sess1'
+    const f = join(stateDir, `tool-labels-${sessionId}.jsonl`)
+    writeFileSync(f, JSON.stringify({ ts: 1, tool_use_id: 'A', agent_id: 'g', label: 'Reading foo.ts', tool_name: 'Read' }) + '\n')
+    const sched = makeManualScheduler()
+    const s = createToolLabelSidecar({ stateDir, sessionId, scheduler: sched })
+    expect(s.getLabel('A')).toBe('Reading foo.ts')
+    expect(s.getLabel('B')).toBeUndefined()
+    s.stop()
+  })
+
+  it('picks up appended lines on poll() (renderer reads, hook then writes)', () => {
+    const sessionId = 'sess2'
+    const sched = makeManualScheduler()
+    const s = createToolLabelSidecar({ stateDir, sessionId, scheduler: sched })
+    expect(s.getLabel('A')).toBeUndefined()
+
+    const f = join(stateDir, `tool-labels-${sessionId}.jsonl`)
+    appendFileSync(f, JSON.stringify({ ts: 1, tool_use_id: 'A', agent_id: null, label: 'Replying', tool_name: 'mcp__switchroom-telegram__reply' }) + '\n')
+    s.poll()
+    expect(s.getLabel('A')).toBe('Replying')
+    s.stop()
+  })
+
+  it('fires onLabel subscribers as new lines arrive', () => {
+    const sessionId = 'sess3'
+    const sched = makeManualScheduler()
+    const s = createToolLabelSidecar({ stateDir, sessionId, scheduler: sched })
+    const seen: Array<[string, string]> = []
+    s.onLabel((id, label) => seen.push([id, label]))
+
+    const f = join(stateDir, `tool-labels-${sessionId}.jsonl`)
+    appendFileSync(f, JSON.stringify({ ts: 1, tool_use_id: 'X', agent_id: null, label: 'Reading a.ts', tool_name: 'Read' }) + '\n')
+    s.poll()
+    expect(seen).toEqual([['X', 'Reading a.ts']])
+
+    appendFileSync(f, JSON.stringify({ ts: 2, tool_use_id: 'Y', agent_id: null, label: 'Editing b.ts', tool_name: 'Edit' }) + '\n')
+    s.poll()
+    expect(seen).toEqual([['X', 'Reading a.ts'], ['Y', 'Editing b.ts']])
+    s.stop()
+  })
+
+  it('ignores malformed JSON lines', () => {
+    const sessionId = 'sess4'
+    const sched = makeManualScheduler()
+    const f = join(stateDir, `tool-labels-${sessionId}.jsonl`)
+    writeFileSync(
+      f,
+      'not-json\n' +
+      JSON.stringify({ tool_use_id: 'good', label: 'Saved memory', ts: 1, tool_name: 'mcp__hindsight__retain', agent_id: null }) + '\n' +
+      '{partial\n',
+    )
+    const s = createToolLabelSidecar({ stateDir, sessionId, scheduler: sched })
+    expect(s.getLabel('good')).toBe('Saved memory')
+    s.stop()
+  })
+
+  it('first write wins (idempotent on duplicates)', () => {
+    const sessionId = 'sess5'
+    const sched = makeManualScheduler()
+    const f = join(stateDir, `tool-labels-${sessionId}.jsonl`)
+    writeFileSync(
+      f,
+      JSON.stringify({ tool_use_id: 'A', label: 'first', ts: 1, tool_name: 'Read', agent_id: null }) + '\n' +
+      JSON.stringify({ tool_use_id: 'A', label: 'second', ts: 2, tool_name: 'Read', agent_id: null }) + '\n',
+    )
+    const s = createToolLabelSidecar({ stateDir, sessionId, scheduler: sched })
+    expect(s.getLabel('A')).toBe('first')
+    s.stop()
+  })
+})

--- a/telegram-plugin/tool-label-sidecar.ts
+++ b/telegram-plugin/tool-label-sidecar.ts
@@ -1,0 +1,140 @@
+/**
+ * Sidecar reader for $TELEGRAM_STATE_DIR/tool-labels-${session_id}.jsonl —
+ * the per-tool-call human labels emitted by the PreToolUse hook
+ * `tool-label-pretool.mjs` (#783).
+ *
+ * Two surfaces:
+ *
+ *   getLabel(toolUseId): string | undefined
+ *     Returns the label if the sidecar has already produced one for this
+ *     tool_use. Synchronous, in-memory.
+ *
+ *   onLabel(cb): unsubscribe
+ *     Subscribes to "label arrived for this tool_use_id" notifications,
+ *     used by the renderer to re-emit a checklist row when a label
+ *     arrives AFTER the matching JSONL `tool_use` has been processed.
+ *
+ * Design notes:
+ *   - Plain stat()-poll watcher (every 250ms) — simpler than fs.watch and
+ *     robust to all the platform quirks. The hot path is two-digit ms.
+ *   - Append-only: we track a per-file byte offset and only read the new
+ *     suffix on each tick, so re-reading is cheap.
+ *   - One reader per session_id. The driver instantiates a reader when a
+ *     session JSONL is first observed; old readers are stopped when the
+ *     session is evicted from the chat-state TTL map.
+ *
+ * Pure module — no globals. Tests inject a custom directory and clock.
+ */
+
+import { existsSync, readFileSync, statSync } from 'node:fs'
+import { join } from 'node:path'
+
+export interface ToolLabelRow {
+  ts: number
+  tool_use_id: string
+  agent_id: string | null
+  label: string
+  tool_name: string
+}
+
+export interface ToolLabelSidecar {
+  /** Synchronous label lookup. */
+  getLabel(toolUseId: string): string | undefined
+  /** Subscribe to "label arrived" notifications. */
+  onLabel(cb: (toolUseId: string, label: string) => void): () => void
+  /** Force a re-poll (tests). */
+  poll(): void
+  /** Stop polling and release resources. */
+  stop(): void
+}
+
+export interface SidecarOptions {
+  stateDir: string
+  sessionId: string
+  /** Polling interval in ms. Default 250. */
+  pollMs?: number
+  /** Inject for tests; defaults to setInterval. */
+  scheduler?: {
+    setInterval: (cb: () => void, ms: number) => unknown
+    clearInterval: (handle: unknown) => void
+  }
+}
+
+export function createToolLabelSidecar(opts: SidecarOptions): ToolLabelSidecar {
+  const path = join(opts.stateDir, `tool-labels-${opts.sessionId}.jsonl`)
+  const labels = new Map<string, string>()
+  const subscribers = new Set<(toolUseId: string, label: string) => void>()
+  let offset = 0
+  let stopped = false
+
+  const sched = opts.scheduler ?? {
+    setInterval: (cb, ms) => setInterval(cb, ms),
+    clearInterval: (h) => clearInterval(h as ReturnType<typeof setInterval>),
+  }
+
+  function ingestSuffix(text: string): void {
+    if (!text) return
+    const lines = text.split('\n')
+    for (const raw of lines) {
+      const line = raw.trim()
+      if (!line) continue
+      let row: ToolLabelRow | null = null
+      try {
+        row = JSON.parse(line) as ToolLabelRow
+      } catch {
+        continue
+      }
+      if (!row || typeof row.tool_use_id !== 'string' || typeof row.label !== 'string') continue
+      // First write wins — sidecar lines are append-only and we don't
+      // expect duplicates, but if one lands we keep the earliest.
+      if (labels.has(row.tool_use_id)) continue
+      labels.set(row.tool_use_id, row.label)
+      for (const cb of subscribers) {
+        try { cb(row.tool_use_id, row.label) } catch { /* ignore */ }
+      }
+    }
+  }
+
+  function poll(): void {
+    if (stopped) return
+    if (!existsSync(path)) return
+    let size = 0
+    try { size = statSync(path).size } catch { return }
+    if (size <= offset) {
+      // Truncation safety: if the file shrank (rotation / manual delete),
+      // reset offset so we re-read from the start.
+      if (size < offset) offset = 0
+      else return
+    }
+    let text = ''
+    try {
+      const buf = readFileSync(path)
+      text = buf.subarray(offset).toString('utf8')
+      offset = buf.length
+    } catch {
+      return
+    }
+    ingestSuffix(text)
+  }
+
+  // Initial drain, in case the file already exists when we start.
+  poll()
+  const handle = sched.setInterval(poll, opts.pollMs ?? 250) as unknown
+
+  return {
+    getLabel(toolUseId) {
+      return labels.get(toolUseId)
+    },
+    onLabel(cb) {
+      subscribers.add(cb)
+      return () => subscribers.delete(cb)
+    },
+    poll,
+    stop() {
+      if (stopped) return
+      stopped = true
+      try { sched.clearInterval(handle) } catch { /* ignore */ }
+      subscribers.clear()
+    },
+  }
+}

--- a/telegram-plugin/tool-labels.ts
+++ b/telegram-plugin/tool-labels.ts
@@ -155,7 +155,15 @@ export function toolLabel(
   tool: string,
   input?: Record<string, unknown>,
   preamble?: string,
+  precomputedLabel?: string,
 ): string {
+  // Precomputed sidecar label (PreToolUse hook, #783) — top of the
+  // precedence ladder per spec. The hook deliberately emits NO label
+  // for Bash/Task/Agent/TodoWrite, so falling through to the
+  // existing description path for those is automatic.
+  if (precomputedLabel && precomputedLabel.trim().length > 0) {
+    return truncate(firstLine(precomputedLabel.trim()), MAX_DESCRIPTION_CHARS)
+  }
   if (!input || typeof input !== 'object') return ''
   const str = (k: string): string | undefined =>
     typeof input[k] === 'string' ? (input[k] as string) : undefined

--- a/tests/scaffold.test.ts
+++ b/tests/scaffold.test.ts
@@ -1758,6 +1758,12 @@ describe("scaffoldAgent with global defaults cascade", () => {
             timeout: 5,
             async: false,
           },
+          {
+            type: "command",
+            command: expect.stringContaining("tool-label-stop.mjs"),
+            timeout: 5,
+            async: true,
+          },
         ],
       },
     ]);
@@ -3160,6 +3166,34 @@ describe("secret-detect hook wiring", () => {
     expect(serialized).not.toContain("secret-scrub-stop.mjs");
     // PreToolUse should be entirely absent (no user hooks configured).
     expect(settings.hooks?.PreToolUse).toBeUndefined();
+  });
+
+  it("wires tool-label-pretool.mjs and tool-label-stop.mjs when plugin is switchroom (#783)", () => {
+    const agentConfig = makeAgentConfig();
+    const result = scaffoldAgent(
+      "sd-tool-label-agent",
+      agentConfig,
+      tmpDir,
+      telegramConfig,
+      makeConfig("sd-tool-label-agent", agentConfig),
+    );
+    const settings = JSON.parse(
+      readFileSync(join(result.agentDir, ".claude", "settings.json"), "utf-8"),
+    );
+    const pre = settings.hooks.PreToolUse as Array<{ matcher?: string; hooks: Array<{ command: string; timeout?: number }> }>;
+    const allPre = pre.flatMap((e) => e.hooks);
+    const labelHook = allPre.find((h) => h.command.includes("tool-label-pretool.mjs"));
+    expect(labelHook).toBeDefined();
+    // Spec requires explicit timeout: 5 (default 600 could wedge agents).
+    expect(labelHook!.timeout).toBe(5);
+    // Catch-all matcher: the entry that contains the label hook MUST NOT have a matcher.
+    const labelEntry = pre.find((e) => e.hooks.some((h) => h.command.includes("tool-label-pretool.mjs")));
+    expect(labelEntry?.matcher).toBeUndefined();
+
+    const stop = settings.hooks.Stop as Array<{ hooks: Array<{ command: string; async?: boolean }> }>;
+    const reaper = stop.flatMap((e) => e.hooks).find((h) => h.command.includes("tool-label-stop.mjs"));
+    expect(reaper).toBeDefined();
+    expect(reaper!.async).toBe(true);
   });
 
   it("preserves user-declared PreToolUse hooks alongside secret-guard", () => {

--- a/tests/tool-label-pretool.test.ts
+++ b/tests/tool-label-pretool.test.ts
@@ -1,0 +1,274 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync, readFileSync, existsSync, readdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+/**
+ * Unit tests for telegram-plugin/hooks/tool-label-pretool.mjs (#783).
+ *
+ * Spawns the .mjs as a child process, feeds Claude Code's PreToolUse
+ * stdin payload, and asserts the resulting sidecar JSONL line.
+ * Every test asserts exit 0 and empty stdout (per Claude Code's hook
+ * contract: stdout JSON would risk hookSpecificOutput.updatedInput
+ * collisions; non-zero exit BLOCKS the tool call).
+ */
+
+const HOOK = resolve(
+  __dirname,
+  "..",
+  "telegram-plugin",
+  "hooks",
+  "tool-label-pretool.mjs",
+);
+
+interface RunResult {
+  status: number;
+  stdout: string;
+  stderr: string;
+  sidecarLines: Array<Record<string, unknown>>;
+}
+
+function run(
+  payload: Record<string, unknown> | string,
+  stateDir: string | null,
+  sessionId = "sess-test",
+): RunResult {
+  const env: Record<string, string> = { ...process.env } as Record<string, string>;
+  if (stateDir) env.TELEGRAM_STATE_DIR = stateDir;
+  else delete env.TELEGRAM_STATE_DIR;
+  // Strip SWITCHROOM_AGENT_NAME so the hook's agent_id derivation falls
+  // back to cwd basename — keeps tests deterministic.
+  delete env.SWITCHROOM_AGENT_NAME;
+
+  const stdin = typeof payload === "string" ? payload : JSON.stringify(payload);
+  const r = spawnSync(process.execPath, [HOOK], {
+    input: stdin,
+    env,
+    encoding: "utf8",
+  });
+
+  let sidecarLines: Array<Record<string, unknown>> = [];
+  if (stateDir) {
+    const f = join(stateDir, `tool-labels-${sessionId}.jsonl`);
+    if (existsSync(f)) {
+      const text = readFileSync(f, "utf8");
+      sidecarLines = text
+        .split("\n")
+        .filter((l) => l.trim().length > 0)
+        .map((l) => JSON.parse(l) as Record<string, unknown>);
+    }
+  }
+
+  return {
+    status: r.status ?? 0,
+    stdout: r.stdout ?? "",
+    stderr: r.stderr ?? "",
+    sidecarLines,
+  };
+}
+
+describe("tool-label-pretool.mjs", () => {
+  let stateDir: string;
+
+  beforeEach(() => {
+    stateDir = mkdtempSync(join(tmpdir(), "tool-label-pretool-"));
+  });
+
+  afterEach(() => {
+    rmSync(stateDir, { recursive: true, force: true });
+  });
+
+  it("always exits 0 with empty stdout — even on bad input", () => {
+    for (const bad of ["", "not-json", "{}", "{\"tool_name\":\"Read\"}"]) {
+      const r = run(bad, stateDir);
+      expect(r.status).toBe(0);
+      expect(r.stdout).toBe("");
+    }
+  });
+
+  it("Read → 'Reading <basename>'", () => {
+    const r = run(
+      {
+        session_id: "sess-test",
+        tool_use_id: "toolu_1",
+        tool_name: "Read",
+        tool_input: { file_path: "/abs/path/to/scaffold.ts" },
+      },
+      stateDir,
+    );
+    expect(r.status).toBe(0);
+    expect(r.stdout).toBe("");
+    expect(r.sidecarLines).toHaveLength(1);
+    expect(r.sidecarLines[0].label).toBe("Reading scaffold.ts");
+    expect(r.sidecarLines[0].tool_use_id).toBe("toolu_1");
+    expect(r.sidecarLines[0].tool_name).toBe("Read");
+  });
+
+  it("Edit / Write / NotebookEdit produce matching verbs", () => {
+    const cases: Array<[string, Record<string, unknown>, string]> = [
+      ["Edit", { file_path: "/x/foo.ts" }, "Editing foo.ts"],
+      ["Write", { file_path: "/x/bar.md" }, "Writing bar.md"],
+      ["NotebookEdit", { notebook_path: "/x/n.ipynb" }, "Editing notebook n.ipynb"],
+    ];
+    for (const [tool, input, expected] of cases) {
+      const r = run(
+        { session_id: "sess-test", tool_use_id: `t-${tool}`, tool_name: tool, tool_input: input },
+        stateDir,
+      );
+      expect(r.status).toBe(0);
+      const line = r.sidecarLines.find((l) => l.tool_use_id === `t-${tool}`);
+      expect(line?.label).toBe(expected);
+    }
+  });
+
+  it("Grep with and without path", () => {
+    const r1 = run(
+      {
+        session_id: "sess-test",
+        tool_use_id: "g1",
+        tool_name: "Grep",
+        tool_input: { pattern: "hindsight", path: "src/" },
+      },
+      stateDir,
+    );
+    expect(r1.sidecarLines[0].label).toBe("Searching src/ for hindsight");
+
+    const r2 = run(
+      {
+        session_id: "sess-test",
+        tool_use_id: "g2",
+        tool_name: "Grep",
+        tool_input: { pattern: "TODO" },
+      },
+      stateDir,
+    );
+    const g2 = r2.sidecarLines.find((l) => l.tool_use_id === "g2");
+    expect(g2?.label).toBe("Searching . for TODO");
+  });
+
+  it("Glob / WebFetch / WebSearch", () => {
+    const cases: Array<[string, Record<string, unknown>, string]> = [
+      ["Glob", { pattern: "**/*.ts" }, "Finding files matching **/*.ts"],
+      ["WebFetch", { url: "https://example.com/path?x=1" }, "Fetching example.com/path"],
+      ["WebSearch", { query: "claude code hooks" }, "Searching the web for claude code hooks"],
+    ];
+    for (const [tool, input, expected] of cases) {
+      const r = run(
+        { session_id: "sess-test", tool_use_id: `t-${tool}`, tool_name: tool, tool_input: input },
+        stateDir,
+      );
+      const line = r.sidecarLines.find((l) => l.tool_use_id === `t-${tool}`);
+      expect(line?.label).toBe(expected);
+    }
+  });
+
+  it("BashOutput / KillBash / KillShell", () => {
+    for (const [tool, expected] of [
+      ["BashOutput", "Reading background output"],
+      ["KillBash", "Stopping background process"],
+      ["KillShell", "Stopping background process"],
+    ] as const) {
+      const r = run(
+        { session_id: "sess-test", tool_use_id: `t-${tool}`, tool_name: tool, tool_input: {} },
+        stateDir,
+      );
+      const line = r.sidecarLines.find((l) => l.tool_use_id === `t-${tool}`);
+      expect(line?.label).toBe(expected);
+    }
+  });
+
+  it("MCP allowlist (telegram + hindsight)", () => {
+    const cases: Array<[string, Record<string, unknown>, string]> = [
+      ["mcp__switchroom-telegram__reply", { text: "hi" }, "Replying"],
+      ["mcp__switchroom-telegram__stream_reply", { text: "hi" }, "Replying"],
+      ["mcp__switchroom-telegram__react", { emoji: "👍" }, "Reacting 👍"],
+      ["mcp__switchroom-telegram__get_recent_messages", {}, "Reading chat history"],
+      ["mcp__hindsight__recall", { query: "x" }, "Searching memory"],
+      ["mcp__hindsight__reflect", { query: "x" }, "Searching memory"],
+      ["mcp__hindsight__retain", { content: "x" }, "Saving memory"],
+    ];
+    for (const [tool, input, expected] of cases) {
+      const r = run(
+        { session_id: "sess-test", tool_use_id: `t-${tool}`, tool_name: tool, tool_input: input },
+        stateDir,
+      );
+      const line = r.sidecarLines.find((l) => l.tool_use_id === `t-${tool}`);
+      expect(line?.label, `${tool}`).toBe(expected);
+    }
+  });
+
+  it("suppressed tools (Bash, Task, Agent, TodoWrite, send_typing, sync_retain, exotic mcp__) emit nothing", () => {
+    const cases: Array<[string, Record<string, unknown>]> = [
+      ["Bash", { command: "ls" }],
+      ["Task", { description: "x", prompt: "y" }],
+      ["Agent", { description: "x", prompt: "y" }],
+      ["TodoWrite", { todos: [] }],
+      ["mcp__switchroom-telegram__send_typing", {}],
+      ["mcp__hindsight__sync_retain", {}],
+      ["mcp__some-other-server__random_tool", { foo: "bar" }],
+      ["ToolSearch", {}],
+    ];
+    for (const [tool, input] of cases) {
+      const r = run(
+        { session_id: "sess-test", tool_use_id: `t-${tool}`, tool_name: tool, tool_input: input },
+        stateDir,
+      );
+      expect(r.status).toBe(0);
+      expect(r.stdout).toBe("");
+    }
+    // No sidecar file at all should have been created (no labels emitted).
+    const files = readdirSync(stateDir).filter((f) => f.startsWith("tool-labels-"));
+    expect(files).toHaveLength(0);
+  });
+
+  it("missing TELEGRAM_STATE_DIR → silent skip, exit 0", () => {
+    const r = run(
+      {
+        session_id: "sess-test",
+        tool_use_id: "t-x",
+        tool_name: "Read",
+        tool_input: { file_path: "/x/foo.ts" },
+      },
+      null,
+    );
+    expect(r.status).toBe(0);
+    expect(r.stdout).toBe("");
+    expect(r.sidecarLines).toHaveLength(0);
+  });
+
+  it("missing session_id or tool_use_id → silent skip", () => {
+    const r1 = run(
+      { tool_use_id: "t", tool_name: "Read", tool_input: { file_path: "/a/b" } },
+      stateDir,
+    );
+    expect(r1.status).toBe(0);
+    expect(r1.sidecarLines).toHaveLength(0);
+
+    const r2 = run(
+      { session_id: "s", tool_name: "Read", tool_input: { file_path: "/a/b" } },
+      stateDir,
+    );
+    expect(r2.status).toBe(0);
+    expect(r2.sidecarLines).toHaveLength(0);
+  });
+
+  it("oversize input gets clipped to a single line", () => {
+    const huge = "x".repeat(2000) + "\nsecond line";
+    const r = run(
+      {
+        session_id: "sess-test",
+        tool_use_id: "t-big",
+        tool_name: "WebSearch",
+        tool_input: { query: huge },
+      },
+      stateDir,
+    );
+    expect(r.status).toBe(0);
+    const line = r.sidecarLines[0];
+    expect(line).toBeDefined();
+    const label = String(line.label);
+    expect(label.length).toBeLessThanOrEqual(120);
+    expect(label.includes("\n")).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #783.

Adds a PreToolUse hook that maps each `(tool_name, tool_input)` to a deterministic human label and writes it to `$TELEGRAM_STATE_DIR/tool-labels-${session_id}.jsonl`. The progress-card renderer joins on `tool_use_id` and surfaces the label in place of raw filenames.

## Result

Before: `Read scaffold.ts` / `Edit boot-card.ts` / `Grep "hindsight" boot-probes.ts`
After: `Reading scaffold.ts` / `Editing boot-card.ts` / `Searching boot-probes.ts for 'hindsight'`

Bash/Task/Agent/TodoWrite untouched (their `description` param / fleet panel still wins).

## Phases

- A: Hook script + scaffold register + hooks.json
- B: Sidecar reader + session-tail decorate + renderer rung-1 lookup
- E: 17 new tests, full plugin suite still green

## Guards

✅ exit 0 every path · ✅ timeout 5 · ✅ skip mcp__\* unless allowlisted · ✅ no `updatedInput` mutation · ✅ per-session sidecar + 24h reaper · ✅ buffer-tolerant lookup

🤖 Generated with [Claude Code](https://claude.com/claude-code)