### PR TITLE
docs(estimates): switchroom default — estimate in agent minutes, not dev hours

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,6 +122,11 @@ globally. During local work on src/, prefer `bun run dev` over rebuilding.
 - **Commit style:** Conventional Commits (`feat(scope):`, `fix(scope):`,
   `docs(scope):`, `test(scope):`, `chore(scope):`). Recent history is a
   good reference — `git log --oneline -20`.
+- **Effort estimates:** in **agent minutes** (wall-clock for a
+  current-generation Claude agent doing the work end-to-end including
+  tests), not human dev hours. "12 dev hours" is the wrong unit;
+  "~25 agent minutes" is the right one. Reserve human-time estimates
+  only for work that explicitly needs the user's review or input.
 
 ## Repo model & dev flow
 

--- a/profiles/default/workspace/CLAUDE.md.hbs
+++ b/profiles/default/workspace/CLAUDE.md.hbs
@@ -116,6 +116,15 @@ When operating in a group chat (more than one person in the room):
 Quality > quantity. If you wouldn't send it in a real group chat with
 friends, don't send it.
 
+## Effort estimates
+
+When estimating implementation, research, or refactor work, estimate in
+**agent minutes** — wall-clock time for a current-generation Claude
+agent (the actual worker, not a human) to complete the work end-to-end
+including tests. A "12 dev hours" plan is the wrong unit; "~25 agent
+minutes" is the right one. Reserve human-time estimates only for work
+that explicitly requires the user's review or input.
+
 ## Scope
 
 {{#if agentConfig.purpose}}


### PR DESCRIPTION
Two-file doc change. Sets a switchroom-default rule for ALL agents (not just one user's config) that effort estimates should be in **agent minutes** — wall-clock for a current-generation Claude agent doing the work end-to-end — instead of human dev hours.

Plans like "~12 dev hours" mis-size work because the actual worker is the model, not a human. A blended "agent minutes" unit avoids per-model splits while staying calibrated to who's actually doing it.

- `profiles/default/workspace/CLAUDE.md.hbs` — every new/reconciled agent inherits
- `/CLAUDE.md` — anyone working on switchroom itself follows the same rule

🤖 Generated with [Claude Code](https://claude.com/claude-code)