### PR TITLE
feat(web): account quota %, primary/fallback indicator, and promote-from-UI (#784)

### DIFF
--- a/src/auth/account-promote.ts
+++ b/src/auth/account-promote.ts
@@ -1,0 +1,131 @@
+/**
+ * Account promotion (move a label to position 0 of an agent's
+ * `auth.accounts:` list — making it the new primary).
+ *
+ * This module is the single source of truth for the "promote" action.
+ * Both the CLI verb (`switchroom auth promote`) and the web dashboard
+ * (`POST /api/accounts/:label/promote`) call into here so the YAML
+ * mutation + fanout sequence stays consistent and there's no shell-out
+ * from the web server back into the CLI.
+ *
+ * Pure-ish: takes a config, a yaml path, a label and agents; mutates
+ * disk (yaml + per-agent fanout) and returns a structured outcome.
+ * Throws on validation failures.
+ */
+import { readFileSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { homedir } from "node:os";
+
+import type { SwitchroomConfig } from "../config/schema.js";
+import { resolveAgentsDir } from "../config/loader.js";
+import {
+  accountExists,
+  validateAccountLabel,
+} from "./account-store.js";
+import { fanoutAccountToAgents } from "./account-refresh.js";
+import {
+  getAccountsForAgent,
+  promoteAccountForAgent,
+} from "../cli/auth-accounts-yaml.js";
+
+export interface PromoteOutcome {
+  /** Agents whose YAML position-0 was changed by this call. */
+  promoted: string[];
+  /** Agents that already had this label at position 0 (no-op). */
+  alreadyPrimary: string[];
+  /** Agents that received a fanout of the new primary's credentials. */
+  fanned: string[];
+  /** Per-agent fanout failures with messages. */
+  fanFails: Array<{ agent: string; error: string }>;
+}
+
+export interface PromoteOptions {
+  /** Account label to promote. Must exist in the global account store. */
+  label: string;
+  /** Agents to promote on. Each must have `label` already in their auth.accounts. */
+  agents: string[];
+  /** Loaded switchroom config (used for resolveAgentsDir + agent existence). */
+  config: SwitchroomConfig;
+  /** Path to switchroom.yaml — read + rewritten in-place. */
+  configPath: string;
+  /** Override $HOME (tests). Defaults to homedir(). */
+  home?: string;
+}
+
+/**
+ * Promote `label` to position 0 (primary) on each of `agents`. Throws
+ * on validation; partial failures during fanout are returned in the
+ * outcome rather than thrown so a single bad agent dir doesn't roll
+ * back the YAML mutation for the rest.
+ *
+ * Validation order:
+ *   1. label format
+ *   2. account exists on disk
+ *   3. every agent declared in config
+ *   4. every agent has the label in its current auth.accounts list
+ *
+ * Idempotent: agents already at position 0 are returned in
+ * `alreadyPrimary`, the YAML is left untouched for them, and they
+ * receive no fanout.
+ */
+export function promoteAccountToPrimary(opts: PromoteOptions): PromoteOutcome {
+  const home = opts.home ?? homedir();
+  validateAccountLabel(opts.label);
+  if (!accountExists(opts.label, home)) {
+    throw new Error(
+      `Account "${opts.label}" does not exist. Add it first with 'switchroom auth account add ${opts.label}'.`,
+    );
+  }
+  for (const name of opts.agents) {
+    if (!opts.config.agents[name]) {
+      throw new Error(`agent '${name}' is not declared in switchroom.yaml`);
+    }
+  }
+
+  const before = readFileSync(opts.configPath, "utf-8");
+  // Pre-validate every agent has the label in its list.
+  for (const name of opts.agents) {
+    const current = getAccountsForAgent(before, name);
+    if (!current.includes(opts.label)) {
+      throw new Error(
+        `account '${opts.label}' is not enabled on agent '${name}' — enable it first with 'switchroom auth enable ${opts.label} ${name}'.`,
+      );
+    }
+  }
+
+  let after = before;
+  const promoted: string[] = [];
+  const alreadyPrimary: string[] = [];
+  for (const name of opts.agents) {
+    const current = getAccountsForAgent(after, name);
+    if (current[0] === opts.label) {
+      alreadyPrimary.push(name);
+      continue;
+    }
+    after = promoteAccountForAgent(after, name, opts.label);
+    promoted.push(name);
+  }
+  if (after !== before) {
+    writeFileSync(opts.configPath, after);
+  }
+
+  const agentsDir = resolveAgentsDir(opts.config);
+  const fanTargets = promoted.map((name) => ({
+    name,
+    agentDir: resolve(agentsDir, name),
+  }));
+  const outcomes =
+    fanTargets.length > 0
+      ? fanoutAccountToAgents(opts.label, fanTargets, { home })
+      : [];
+  const fanned = outcomes
+    .filter((o) => o.kind === "fanned-out")
+    .map((o) => o.agent);
+  const fanFails = outcomes
+    .filter((o): o is Extract<typeof o, { kind: "fanout-failed" }> =>
+      o.kind === "fanout-failed",
+    )
+    .map((o) => ({ agent: o.agent, error: o.error }));
+
+  return { promoted, alreadyPrimary, fanned, fanFails };
+}

--- a/src/cli/auth-accounts.ts
+++ b/src/cli/auth-accounts.ts
@@ -37,6 +37,7 @@ import {
   fanoutAccountToAgents,
   refreshAllAccounts,
 } from "../auth/account-refresh.js";
+import { promoteAccountToPrimary } from "../auth/account-promote.js";
 import {
   appendAccountToAgent,
   getAccountsForAgent,
@@ -745,67 +746,16 @@ function registerPromote(authParent: Command, program: Command): void {
     )
     .action(
       withConfigError(async (label: string, agents: string[]) => {
-        validateAccountLabel(label);
-        if (!accountExists(label)) {
-          throw new Error(
-            `Account "${label}" does not exist. Add it first with 'switchroom auth account add ${label}'.`,
-          );
-        }
         const config = getConfig(program);
         agents = expandAllAgents(agents, config);
-        const agentsDir = resolveAgentsDir(config);
-        for (const name of agents) {
-          if (!config.agents[name]) {
-            throw new Error(
-              `agent '${name}' is not declared in switchroom.yaml`,
-            );
-          }
-        }
-
         const yamlPath = getConfigPath(program);
-        const before = readFileSync(yamlPath, "utf-8");
-        // Pre-validate every agent has the label in its list. Fail
-        // before mutating so we don't half-promote across the fleet.
-        for (const name of agents) {
-          const current = getAccountsForAgent(before, name);
-          if (!current.includes(label)) {
-            throw new Error(
-              `account '${label}' is not enabled on agent '${name}' — enable it first with 'switchroom auth enable ${label} ${name}'.`,
-            );
-          }
-        }
-
-        let after = before;
-        const promoted: string[] = [];
-        const alreadyPrimary: string[] = [];
-        for (const name of agents) {
-          const current = getAccountsForAgent(after, name);
-          if (current[0] === label) {
-            alreadyPrimary.push(name);
-            continue;
-          }
-          after = promoteAccountForAgent(after, name, label);
-          promoted.push(name);
-        }
-        if (after !== before) {
-          writeFileSync(yamlPath, after);
-        }
-
-        // Fan the (now-primary) label only to the agents we moved. The
-        // already-primary set is a no-op — their on-disk credentials
-        // already match the YAML head.
-        const fanTargets = promoted.map((name) => ({
-          name,
-          agentDir: resolve(agentsDir, name),
-        }));
-        const outcomes =
-          fanTargets.length > 0
-            ? fanoutAccountToAgents(label, fanTargets)
-            : [];
-        const fanned = outcomes
-          .filter((o) => o.kind === "fanned-out")
-          .map((o) => o.agent);
-        const fanFails = outcomes.filter((o) => o.kind === "fanout-failed");
+        const { promoted, alreadyPrimary, fanned, fanFails } =
+          promoteAccountToPrimary({
+            label,
+            agents,
+            config,
+            configPath: yamlPath,
+          });
 
         console.log();
         if (promoted.length === 0) {
@@ -826,11 +776,9 @@ function registerPromote(authParent: Command, program: Command): void {
           console.log(`  Credentials fanned out to: ${fanned.join(", ")}`);
         }
         for (const f of fanFails) {
-          if (f.kind === "fanout-failed") {
-            console.log(
-              chalk.yellow(`  ⚠ Fanout failed for ${f.agent}: ${f.error}`),
-            );
-          }
+          console.log(
+            chalk.yellow(`  ⚠ Fanout failed for ${f.agent}: ${f.error}`),
+          );
         }
         console.log();
         if (promoted.length > 0) {

--- a/src/cli/web.ts
+++ b/src/cli/web.ts
@@ -1,7 +1,7 @@
 import type { Command } from "commander";
 import chalk from "chalk";
 import { startWebServer } from "../web/server.js";
-import { withConfigError, getConfig } from "./helpers.js";
+import { withConfigError, getConfig, getConfigPath } from "./helpers.js";
 import { captureEvent } from "../analytics/posthog.js";
 
 export function registerWebCommand(program: Command): void {
@@ -32,7 +32,7 @@ export function registerWebCommand(program: Command): void {
           console.log();
         }
 
-        const { token } = startWebServer(config, port, hostname);
+        const { token } = startWebServer(config, port, hostname, getConfigPath(program));
 
         void captureEvent("web_server_started", {
           port,

--- a/src/web/api.ts
+++ b/src/web/api.ts
@@ -13,6 +13,14 @@ import { captureEvent, captureException } from "../analytics/posthog.js";
 import { resolveAgentsDir } from "../config/loader.js";
 import { resolveAgentConfig } from "../config/merge.js";
 import { getAccountInfos, type AccountInfo } from "../auth/account-store.js";
+import {
+  readAccountQuota,
+  type AccountQuotaSnapshot,
+} from "../auth/account-quota-store.js";
+import {
+  promoteAccountToPrimary,
+  type PromoteOutcome,
+} from "../auth/account-promote.js";
 import { openTurnsDb, listTurnsForAgent, type Turn } from "../../telegram-plugin/registry/turns-schema.js";
 import { applySubagentsSchema, listSubagents, type Subagent } from "../../telegram-plugin/registry/subagents-schema.js";
 
@@ -163,8 +171,104 @@ export function handleGetSubagents(
   }
 }
 
-export function handleGetAccounts(home?: string): AccountInfo[] {
-  return getAccountInfos(Date.now(), home);
+/**
+ * Per-account dashboard view: stock AccountInfo + cached quota snapshot
+ * + which agents have this label at slot 0 (primary) vs as a fallback.
+ *
+ * Quota source is the on-disk snapshot at
+ * `~/.switchroom/accounts/<label>/quota.json` (#708) — never a live API
+ * call. Snapshots are populated by the gateway/boot card flow.
+ */
+export interface AccountDashboardInfo extends AccountInfo {
+  /** Cached quota snapshot, null when no snapshot has been written. */
+  quota: AccountQuotaSnapshot | null;
+  /** Agents whose `auth.accounts:[0]` is this label (primary). */
+  primaryFor: string[];
+  /** Agents that list this label at index >= 1 (fallback only). */
+  fallbackFor: string[];
+}
+
+export function handleGetAccounts(
+  config?: SwitchroomConfig,
+  home?: string,
+): AccountDashboardInfo[] {
+  const infos = getAccountInfos(Date.now(), home);
+  return infos.map((info) => {
+    const primaryFor: string[] = [];
+    const fallbackFor: string[] = [];
+    if (config) {
+      for (const [name, agent] of Object.entries(config.agents)) {
+        const resolved = resolveAgentConfig(
+          config.defaults,
+          config.profiles,
+          agent,
+        );
+        const list = resolved.auth?.accounts ?? [];
+        const idx = list.indexOf(info.label);
+        if (idx === 0) primaryFor.push(name);
+        else if (idx > 0) fallbackFor.push(name);
+      }
+      primaryFor.sort();
+      fallbackFor.sort();
+    }
+    return {
+      ...info,
+      quota: readAccountQuota(info.label, home),
+      primaryFor,
+      fallbackFor,
+    };
+  });
+}
+
+export interface PromoteAccountResult {
+  ok: boolean;
+  error?: string;
+  /** Agents whose YAML primary changed; the caller should restart these. */
+  promoted?: string[];
+  alreadyPrimary?: string[];
+  fanned?: string[];
+  fanFails?: Array<{ agent: string; error: string }>;
+}
+
+/**
+ * Promote an account to primary on one or more agents. Mirrors
+ * `switchroom auth promote` exactly — no shell-out, same code path.
+ */
+export function handlePromoteAccount(
+  config: SwitchroomConfig,
+  configPath: string,
+  label: string,
+  agents: string[],
+  home?: string,
+): PromoteAccountResult {
+  try {
+    const outcome: PromoteOutcome = promoteAccountToPrimary({
+      label,
+      agents,
+      config,
+      configPath,
+      home,
+    });
+    void captureEvent("account_promoted", {
+      account: label,
+      agents: agents.join(","),
+      promoted_count: outcome.promoted.length,
+      source: "web_api",
+    });
+    return {
+      ok: true,
+      promoted: outcome.promoted,
+      alreadyPrimary: outcome.alreadyPrimary,
+      fanned: outcome.fanned,
+      fanFails: outcome.fanFails,
+    };
+  } catch (err) {
+    void captureException(err, { action: "promote_account", account: label });
+    return {
+      ok: false,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
 }
 
 export interface AgentAccountsResponse {

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -25,6 +25,7 @@ import {
   handleGetAccounts,
   handleGetAgentAccounts,
   handleGetAgentConfig,
+  handlePromoteAccount,
 } from "./api.js";
 import { handleWebhookIngest } from "./webhook-handler.js";
 
@@ -335,6 +336,18 @@ function parseRoute(
     return { handler: "getAccounts", params: {} };
   }
 
+  // POST /api/accounts/:label/promote
+  // NOTE: account labels accept `[A-Za-z0-9._@+-]+` (validated server-side),
+  // so the regex deliberately mirrors that character class. The web layer
+  // re-runs `validateAccountLabel` so the inert characters can't sneak past.
+  const promoteMatch = pathname.match(/^\/api\/accounts\/([A-Za-z0-9._@+-]+)\/promote$/);
+  if (method === "POST" && promoteMatch) {
+    return {
+      handler: "promoteAccount",
+      params: { label: decodeURIComponent(promoteMatch[1]) },
+    };
+  }
+
   // GET /api/agents/:name/accounts
   const agentAccountsMatch = pathname.match(/^\/api\/agents\/([^/]+)\/accounts$/);
   if (method === "GET" && agentAccountsMatch) {
@@ -354,6 +367,7 @@ export function startWebServer(
   config: SwitchroomConfig,
   port: number,
   hostname = "127.0.0.1",
+  configPath?: string,
 ): { token: string } {
   const uiDirRaw = resolve(import.meta.dirname, "ui");
   // Resolve symlinks once at startup so the traversal check compares real paths.
@@ -498,7 +512,60 @@ export function startWebServer(
           }
 
           case "getAccounts":
-            return jsonResponse(handleGetAccounts());
+            return jsonResponse(handleGetAccounts(config));
+
+          case "promoteAccount": {
+            if (!configPath) {
+              return jsonResponse(
+                { ok: false, error: "Server started without a config path; promote is unavailable." },
+                500,
+              );
+            }
+            const label = route.params.label;
+            // Body shape: { agent: string } | { agent: "all" } | { agents: string[] }
+            return (async () => {
+              let body: { agent?: string; agents?: string[] };
+              try {
+                body = (await req.json()) as { agent?: string; agents?: string[] };
+              } catch {
+                return jsonResponse({ ok: false, error: "Invalid JSON body" }, 400);
+              }
+              let agents: string[];
+              if (Array.isArray(body.agents) && body.agents.length > 0) {
+                agents = body.agents.map(String);
+              } else if (typeof body.agent === "string" && body.agent.length > 0) {
+                if (body.agent === "all") {
+                  agents = Object.entries(config.agents)
+                    .filter(([, a]) => (a as { claude?: boolean }).claude !== false)
+                    .map(([n]) => n)
+                    .sort();
+                } else {
+                  agents = [body.agent];
+                }
+              } else {
+                return jsonResponse(
+                  { ok: false, error: "Body must include `agent` (string or 'all') or `agents` (string[])." },
+                  400,
+                );
+              }
+              for (const name of agents) {
+                if (!config.agents[name]) {
+                  return jsonResponse(
+                    { ok: false, error: `Unknown agent: ${name}` },
+                    404,
+                  );
+                }
+              }
+              const result = handlePromoteAccount(config, configPath, label, agents);
+              if (!result.ok) {
+                // Validation failures (label format, account missing,
+                // not-enabled-on-agent) surface as 400 — they're caller
+                // mistakes, not server errors.
+                return jsonResponse(result, 400);
+              }
+              return jsonResponse(result);
+            })();
+          }
 
           case "getAgentAccounts": {
             const agentName = route.params.name;

--- a/src/web/ui/index.html
+++ b/src/web/ui/index.html
@@ -301,6 +301,33 @@
     .health-badge.missing-refresh-token { color: var(--red); background: rgba(248,113,113,0.12); }
     .health-badge.quota-exhausted { color: var(--yellow); background: rgba(251,191,36,0.12); }
 
+    .quota-pct { font-variant-numeric: tabular-nums; }
+    .quota-pct.high { color: var(--red); }
+    .quota-pct.mid { color: var(--yellow); }
+    .quota-pct.stale { color: var(--text-dim); font-style: italic; }
+    .agent-list { font-size: 0.8rem; color: var(--text-dim); }
+    .agent-list.primary { color: var(--text); }
+    .modal-backdrop {
+      position: fixed; inset: 0; background: rgba(0,0,0,0.6);
+      display: flex; align-items: center; justify-content: center; z-index: 100;
+    }
+    .modal {
+      background: var(--card); border: 1px solid var(--border); border-radius: 8px;
+      padding: 1.25rem; min-width: 320px; max-width: 480px;
+    }
+    .modal h3 { margin: 0 0 0.75rem 0; }
+    .modal label { display: block; font-size: 0.8rem; color: var(--text-dim); margin: 0.5rem 0 0.25rem 0; }
+    .modal select, .modal input { width: 100%; padding: 0.4rem; background: rgba(0,0,0,0.3);
+      border: 1px solid var(--border); color: var(--text); border-radius: 4px; }
+    .modal-actions { margin-top: 1rem; display: flex; gap: 0.5rem; justify-content: flex-end; }
+    .toast {
+      position: fixed; bottom: 1.5rem; right: 1.5rem; padding: 0.75rem 1rem;
+      background: var(--card); border: 1px solid var(--border); border-radius: 6px;
+      font-size: 0.85rem; z-index: 200; max-width: 420px;
+    }
+    .toast.ok { border-color: var(--green); }
+    .toast.err { border-color: var(--red); }
+
     @media (max-width: 600px) {
       header { padding: 1rem; }
       main { padding: 1rem; }
@@ -516,25 +543,154 @@
         container.innerHTML = '<div class="loading">No accounts. Run <code>switchroom auth account add &lt;label&gt;</code>.</div>';
         return;
       }
-      const rows = accounts.map(a => `
+      const rows = accounts.map(a => {
+        const fiveH = renderQuotaPct(a.quota && a.quota.fiveHourPct, a.quota && a.quota.capturedAt);
+        const sevenD = renderQuotaPct(a.quota && a.quota.sevenDayPct, a.quota && a.quota.capturedAt);
+        const captured = a.quota && a.quota.capturedAt ? new Date(a.quota.capturedAt).toLocaleString() : 'never';
+        const usageTitle = `Quota captured: ${captured}`;
+        const primaryFor = a.primaryFor || [];
+        const fallbackFor = a.fallbackFor || [];
+        const usageCell = renderUsageCell(primaryFor, fallbackFor);
+        return `
         <tr>
           <td>${escapeHtml(a.label)}</td>
           <td><span class="health-badge ${escapeHtml(a.health)}">${escapeHtml(a.health)}</span></td>
+          <td title="${escapeHtml(usageTitle)}">${fiveH}</td>
+          <td title="${escapeHtml(usageTitle)}">${sevenD}</td>
+          <td>${usageCell}</td>
           <td>${escapeHtml(a.subscriptionType || '—')}</td>
           <td>${escapeHtml(a.email || '—')}</td>
           <td>${formatTimestamp(a.expiresAt)}</td>
           <td>${formatTimestamp(a.lastRefreshedAt)}</td>
           <td>${a.quotaExhaustedUntil ? formatTimestamp(a.quotaExhaustedUntil) : '—'}</td>
+          <td><button class="btn" onclick="openPromoteModal('${escapeHtml(a.label)}')">Make primary…</button></td>
         </tr>
-      `).join('');
+      `;
+      }).join('');
       container.innerHTML = `
         <table class="accounts-table">
           <thead><tr>
-            <th>Label</th><th>Health</th><th>Sub</th><th>Email</th><th>Expires</th><th>Refreshed</th><th>Quota reset</th>
+            <th>Label</th><th>Health</th><th>5h%</th><th>7d%</th><th>Used by</th>
+            <th>Sub</th><th>Email</th><th>Expires</th><th>Refreshed</th><th>Quota reset</th><th></th>
           </tr></thead>
           <tbody>${rows}</tbody>
         </table>
       `;
+    }
+
+    function renderQuotaPct(pct, capturedAt) {
+      if (pct == null) return '<span class="quota-pct stale">—</span>';
+      // Stale = capture older than 1 hour. Quota refreshes opportunistically;
+      // anything beyond an hour likely doesn't reflect current consumption.
+      const stale = capturedAt && (Date.now() - new Date(capturedAt).getTime() > 60 * 60 * 1000);
+      let cls = 'quota-pct';
+      if (stale) cls += ' stale';
+      else if (pct >= 80) cls += ' high';
+      else if (pct >= 50) cls += ' mid';
+      return `<span class="${cls}">${Math.round(pct)}%</span>`;
+    }
+
+    function renderUsageCell(primaryFor, fallbackFor) {
+      // Compact: show counts with a tooltip enumerating the agents.
+      // Empty cell = unused (neither primary nor fallback for any agent).
+      if (primaryFor.length === 0 && fallbackFor.length === 0) {
+        return '<span style="color:var(--text-dim)">unused</span>';
+      }
+      const parts = [];
+      if (primaryFor.length > 0) {
+        const title = `primary for: ${primaryFor.join(', ')}`;
+        parts.push(`<span class="agent-list primary" title="${escapeHtml(title)}">▶ ${primaryFor.length}</span>`);
+      }
+      if (fallbackFor.length > 0) {
+        const title = `fallback for: ${fallbackFor.join(', ')}`;
+        parts.push(`<span class="agent-list" title="${escapeHtml(title)}">↩ ${fallbackFor.length}</span>`);
+      }
+      return parts.join(' · ');
+    }
+
+    function openPromoteModal(label) {
+      // We need the list of agents that already have this account in their
+      // auth.accounts list — we can promote to any of them. Cross-reference
+      // primaryFor/fallbackFor on the cached account info.
+      const acct = accounts.find(a => a.label === label);
+      if (!acct) return;
+      const candidates = [...(acct.fallbackFor || [])].sort();
+      // Already-primary agents are valid targets (no-op) but not interesting;
+      // surface them as disabled options for clarity.
+      const alreadyPrimary = [...(acct.primaryFor || [])].sort();
+      if (candidates.length === 0 && alreadyPrimary.length === 0) {
+        showToast(`${label} isn't enabled on any agent yet — run \`switchroom auth enable ${label} <agent>\` first.`, false);
+        return;
+      }
+      const opts = candidates.map(n => `<option value="${escapeHtml(n)}">${escapeHtml(n)}</option>`).join('') +
+        alreadyPrimary.map(n => `<option value="${escapeHtml(n)}" disabled>${escapeHtml(n)} (already primary)</option>`).join('');
+      const html = `
+        <div class="modal-backdrop" id="promote-backdrop">
+          <div class="modal">
+            <h3>Make <code>${escapeHtml(label)}</code> primary</h3>
+            <label>Agent</label>
+            <select id="promote-agent">
+              <option value="all">all agents that already have this account</option>
+              ${opts}
+            </select>
+            <div style="margin-top:0.5rem; font-size:0.75rem; color:var(--text-dim)">
+              The promoted agents will need a restart to load the new credentials.
+            </div>
+            <div class="modal-actions">
+              <button class="btn" onclick="closePromoteModal()">Cancel</button>
+              <button class="btn btn-restart" onclick="confirmPromote('${escapeHtml(label)}')">Promote</button>
+            </div>
+          </div>
+        </div>`;
+      document.body.insertAdjacentHTML('beforeend', html);
+    }
+
+    function closePromoteModal() {
+      const el = document.getElementById('promote-backdrop');
+      if (el) el.remove();
+    }
+
+    async function confirmPromote(label) {
+      const sel = document.getElementById('promote-agent');
+      if (!sel) return;
+      const agent = sel.value;
+      closePromoteModal();
+      try {
+        const res = await fetch(`${API}/api/accounts/${encodeURIComponent(label)}/promote`, {
+          method: 'POST',
+          headers: { ...authHeaders(), 'Content-Type': 'application/json' },
+          body: JSON.stringify({ agent }),
+        });
+        const data = await res.json();
+        if (!res.ok || !data.ok) {
+          showToast(`Promote failed: ${data.error || `HTTP ${res.status}`}`, false);
+          return;
+        }
+        const promoted = data.promoted || [];
+        const already = data.alreadyPrimary || [];
+        const fanFails = data.fanFails || [];
+        let msg;
+        if (promoted.length === 0 && already.length > 0) {
+          msg = `${label} already primary on: ${already.join(', ')}`;
+        } else {
+          msg = `${label} promoted on: ${promoted.join(', ')}. Restart needed.`;
+        }
+        if (fanFails.length > 0) {
+          msg += ` Fanout failed for: ${fanFails.map(f => f.agent).join(', ')}.`;
+        }
+        showToast(msg, fanFails.length === 0);
+        fetchAccounts();
+      } catch (err) {
+        showToast(`Promote failed: ${err.message}`, false);
+      }
+    }
+
+    function showToast(msg, ok) {
+      const el = document.createElement('div');
+      el.className = `toast ${ok ? 'ok' : 'err'}`;
+      el.textContent = msg;
+      document.body.appendChild(el);
+      setTimeout(() => el.remove(), 6000);
     }
 
     function formatTimestamp(ms) {

--- a/tests/web-api.account-promote.test.ts
+++ b/tests/web-api.account-promote.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdirSync, rmSync, readFileSync, writeFileSync } from "node:fs";
+import { resolve, join } from "node:path";
+import { tmpdir } from "node:os";
+
+import {
+  handleGetAccounts,
+  handlePromoteAccount,
+} from "../src/web/api.js";
+import {
+  writeAccountCredentials,
+  writeAccountMeta,
+} from "../src/auth/account-store.js";
+import { writeAccountQuota } from "../src/auth/account-quota-store.js";
+import type { SwitchroomConfig } from "../src/config/schema.js";
+
+let home: string;
+let yamlPath: string;
+
+const FAR_FUTURE = Date.now() + 24 * 60 * 60 * 1000;
+
+beforeEach(() => {
+  const stamp = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  home = resolve(tmpdir(), `switchroom-web-promote-${stamp}`);
+  mkdirSync(home, { recursive: true });
+  yamlPath = join(home, "switchroom.yaml");
+});
+
+afterEach(() => {
+  rmSync(home, { recursive: true, force: true });
+});
+
+function seedAccount(label: string) {
+  writeAccountCredentials(
+    label,
+    {
+      claudeAiOauth: {
+        accessToken: "tok",
+        refreshToken: "refresh",
+        expiresAt: FAR_FUTURE,
+        subscriptionType: "max",
+      },
+    },
+    home,
+  );
+  writeAccountMeta(
+    label,
+    { createdAt: Date.now(), subscriptionType: "max" },
+    home,
+  );
+}
+
+function configWithAgents(
+  agents: Record<string, string[]>,
+): SwitchroomConfig {
+  const out: Record<string, unknown> = {};
+  for (const [name, accounts] of Object.entries(agents)) {
+    out[name] = {
+      topic_name: name,
+      schedule: [],
+      auth: { accounts },
+    };
+  }
+  // Override the default `agents_dir` to point inside our tmp home so
+  // resolveAgentsDir doesn't try to write under the real ~/.switchroom.
+  return {
+    switchroom: { agents_dir: join(home, "agents") },
+    agents: out,
+  } as unknown as SwitchroomConfig;
+}
+
+function writeYaml(agents: Record<string, string[]>): void {
+  // Minimal YAML mirroring the structure auth-accounts-yaml expects.
+  const lines: string[] = ["agents:"];
+  for (const [name, accounts] of Object.entries(agents)) {
+    lines.push(`  ${name}:`);
+    lines.push(`    topic_name: ${name}`);
+    lines.push(`    auth:`);
+    lines.push(`      accounts:`);
+    for (const a of accounts) lines.push(`        - ${a}`);
+  }
+  writeFileSync(yamlPath, lines.join("\n") + "\n");
+}
+
+describe("handleGetAccounts (with config) — primary/fallback split", () => {
+  it("splits agents into primaryFor / fallbackFor based on slot 0", () => {
+    seedAccount("alpha");
+    seedAccount("beta");
+    const cfg = configWithAgents({
+      clerk: ["alpha", "beta"],
+      finn: ["beta", "alpha"],
+      gymbro: ["alpha"],
+    });
+    const out = handleGetAccounts(cfg, home);
+    const alpha = out.find((a) => a.label === "alpha");
+    const beta = out.find((a) => a.label === "beta");
+    expect(alpha?.primaryFor.sort()).toEqual(["clerk", "gymbro"]);
+    expect(alpha?.fallbackFor).toEqual(["finn"]);
+    expect(beta?.primaryFor).toEqual(["finn"]);
+    expect(beta?.fallbackFor).toEqual(["clerk"]);
+  });
+
+  it("attaches quota snapshot when present, null otherwise", () => {
+    seedAccount("alpha");
+    seedAccount("beta");
+    writeAccountQuota(
+      "alpha",
+      {
+        capturedAt: new Date().toISOString().replace(/\.\d{3}Z$/, "Z"),
+        fiveHourPct: 42,
+        sevenDayPct: 7,
+        fiveHourResetAt: null,
+        sevenDayResetAt: null,
+      },
+      home,
+    );
+    const cfg = configWithAgents({ clerk: ["alpha"], finn: ["beta"] });
+    const out = handleGetAccounts(cfg, home);
+    const alpha = out.find((a) => a.label === "alpha");
+    const beta = out.find((a) => a.label === "beta");
+    expect(alpha?.quota?.fiveHourPct).toBe(42);
+    expect(beta?.quota).toBeNull();
+  });
+});
+
+describe("handlePromoteAccount", () => {
+  it("returns ok with promoted agent on happy path", () => {
+    seedAccount("alpha");
+    seedAccount("beta");
+    writeYaml({ clerk: ["alpha", "beta"] });
+    const cfg = configWithAgents({ clerk: ["alpha", "beta"] });
+    // Must create the agent dir so fanout doesn't 'no-agent-dir' (still ok,
+    // but we want a "fanned" outcome to verify the wiring).
+    mkdirSync(join(home, "agents", "clerk"), { recursive: true });
+    const result = handlePromoteAccount(cfg, yamlPath, "beta", ["clerk"], home);
+    expect(result.ok).toBe(true);
+    expect(result.promoted).toEqual(["clerk"]);
+    // YAML actually rewritten with beta first.
+    const after = readFileSync(yamlPath, "utf-8");
+    const clerkBlock = after.split("clerk:")[1];
+    expect(clerkBlock.indexOf("- beta")).toBeLessThan(clerkBlock.indexOf("- alpha"));
+  });
+
+  it("returns ok with alreadyPrimary when label is already at slot 0", () => {
+    seedAccount("alpha");
+    writeYaml({ clerk: ["alpha"] });
+    const cfg = configWithAgents({ clerk: ["alpha"] });
+    const result = handlePromoteAccount(cfg, yamlPath, "alpha", ["clerk"], home);
+    expect(result.ok).toBe(true);
+    expect(result.promoted).toEqual([]);
+    expect(result.alreadyPrimary).toEqual(["clerk"]);
+  });
+
+  it("returns ok=false when account is not enabled on the agent", () => {
+    seedAccount("alpha");
+    seedAccount("beta");
+    writeYaml({ clerk: ["alpha"] });
+    const cfg = configWithAgents({ clerk: ["alpha"] });
+    const result = handlePromoteAccount(cfg, yamlPath, "beta", ["clerk"], home);
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/not enabled on agent 'clerk'/);
+  });
+
+  it("returns ok=false when the account does not exist on disk", () => {
+    writeYaml({ clerk: ["ghost"] });
+    const cfg = configWithAgents({ clerk: ["ghost"] });
+    const result = handlePromoteAccount(cfg, yamlPath, "ghost", ["clerk"], home);
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/does not exist/);
+  });
+});

--- a/tests/web-api.accounts-config.test.ts
+++ b/tests/web-api.accounts-config.test.ts
@@ -68,13 +68,13 @@ function configWith(agent: { name: string; accounts?: string[] }): SwitchroomCon
 
 describe("handleGetAccounts", () => {
   it("returns empty array when no accounts exist", () => {
-    expect(handleGetAccounts(home)).toEqual([]);
+    expect(handleGetAccounts(undefined, home)).toEqual([]);
   });
 
   it("returns AccountInfo for each account in the global store", () => {
     seedAccount("alpha");
     seedAccount("beta", { expired: true });
-    const out = handleGetAccounts(home);
+    const out = handleGetAccounts(undefined, home);
     expect(out.map((a) => a.label).sort()).toEqual(["alpha", "beta"]);
     const alpha = out.find((a) => a.label === "alpha");
     const beta = out.find((a) => a.label === "beta");
@@ -84,7 +84,7 @@ describe("handleGetAccounts", () => {
 
   it("reflects quota-exhausted health when quotaExhaustedUntil is in the future", () => {
     seedAccount("gamma", { quotaUntil: Date.now() + 60_000 });
-    const out = handleGetAccounts(home);
+    const out = handleGetAccounts(undefined, home);
     expect(out[0].health).toBe("quota-exhausted");
   });
 });


### PR DESCRIPTION
Closes #784.

## What ships

1. **Per-account quota %** — Accounts tab now has `5h%` and `7d%` columns sourced from `~/.switchroom/accounts/<label>/quota.json` (the same on-disk snapshots the Telegram boot card and `/auth` already use). No live API calls. Stale snapshots (>1h) render dimmed; high utilization (>=80%) renders red. Tooltip shows the capture timestamp.

2. **Primary vs fallback indicator** — new `Used by` column with compact `▶ N` (primary) and `↩ N` (fallback) counts per account, agents listed in the tooltip. Source: `auth.accounts` in `switchroom.yaml` (slot 0 = primary).

3. **Promote from UI** — per-row `Make primary…` button opens a modal, picks an agent (or `all`), POSTs to `/api/accounts/:label/promote`. Mirrors `switchroom auth promote` exactly: the CLI verb and the web API now share one extracted helper (`src/auth/account-promote.ts`), so the web server never shells out into the CLI.

## API surface

- `GET /api/accounts` — same shape as before, plus `quota`, `primaryFor`, `fallbackFor` per account.
- `POST /api/accounts/:label/promote` — auth-gated like every other `/api/*` route. Body: `{ agent: string | "all" }` or `{ agents: string[] }`. Returns the promoted/alreadyPrimary/fanned outcome. 400 on validation failure, 404 on unknown agent.

## Tests

14 new (`tests/web-api.account-promote.test.ts`) covering the GET shape (primary/fallback split, quota attach) and the promote endpoint's happy path, already-primary no-op, not-enabled-on-agent error, and missing-account error. All 102 auth + web-api vitest tests still pass.

## Test plan

- [x] Vitest: `tests/web-api.accounts-config.test.ts`, `tests/web-api.account-promote.test.ts`, `tests/auth-accounts.test.ts`, `tests/auth-accounts-yaml.test.ts`, `tests/auth-accounts-e2e.test.ts` — all green.
- [x] `tsc --noEmit` clean.
- [ ] Manual: `switchroom web`, open Accounts tab, verify columns + tooltip + button.