### PR TITLE
docs(readme): refresh for v0.5.2 — IA reorder, approvals/drive/audit-log/diagrams

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,29 +9,19 @@
 [![Trigger evals](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fmekenthompson%2F002f3482b19111d35e57c1903b3733e2%2Fraw%2Fswitchroom-trigger-evals.json)](https://buildkite.com/ken-thompson/switchroom)
 [![Quality evals](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fmekenthompson%2F002f3482b19111d35e57c1903b3733e2%2Fraw%2Fswitchroom-quality-evals.json)](https://buildkite.com/ken-thompson/switchroom)
 
-**Your Claude Pro or Max, as a fleet of always-on agents in Telegram. Opinionated UX, done properly.**
+**A switchboard for your Pro or Max.** Your Claude subscription, as a fleet of always-on specialist agents you talk to from Telegram. Opinionated UX, done properly.
 
 > *I loved OpenClaw + Telegram. I wanted my Claude subscription. And the UX done properly. So I built this.*
 
-**Compliance-by-design.** Switchroom leverages Claude Code natively — unmodified `claude` CLI, no Agent SDK, no direct API. It sets up the CLI the way you would, then gets out of the way. See the [Compliance Attestation](docs/compliance-attestation.md) for detail.
+[Latest release notes →](CHANGELOG.md)
 
-## Right, so what's this about
+## See what your agent is doing
 
-So you had the bright idea. Run Claude Code agents 24/7 on a cheap Linux box, talk to them from Telegram, use the Claude Pro or Max subscription you're already paying for. Sensible. Obvious, even.
+Every time an agent starts work, a **progress card** pins into its Telegram topic and updates in place as tools execute. Each Read, Bash, Edit, Grep is visible as it happens, with elapsed time so you can tell if something's stuck. Sub-agents surface in the same card. When the agent finishes, the card flips to Done and unpins.
 
-Then you tried OpenClaw. Followed the docs, spun it up, got it running, only to realise halfway through that you're pinging the Anthropic API on your own key and your token bill is quietly ticking over in the background. Bit of a bait and switch, that one. You signed up for "use your subscription," not "buy API credits on top of your subscription."
+No silent gaps. No ghosts. No squinting into a black box.
 
-So you gave Claude Code's built-in Telegram channel a crack instead. Sent a message. Waited. Something happened, maybe. Eventually a reply came back. What did the agent actually do? No idea. Which tools ran? No idea. Did it get stuck, crash, spawn a sub-agent, read half your repo? No idea. It's an MVP black box of death, and I got sick of squinting into it.
-
-So I built this.
-
-## What Switchroom is, and isn't
-
-Switchroom is an opinionated implementation of a Telegram plugin and agent lifecycle layer, sitting on top of the official `claude` CLI. No fork. No custom runtime in Docker. No API key interception. Your Claude Pro or Max subscription does the work, the same way it does on your desktop, authenticated via the same OAuth flow, fully compliant with Anthropic's terms.
-
-It is not trying to be a general-purpose LLM orchestrator. It doesn't care about OpenAI, Gemini, Llama, or swapping model providers. It is not a multi-channel bridge for Slack, Discord, Teams. It does one thing: makes Telegram the best possible interaction surface for Claude Code. Unashamedly.
-
-The whole thing is built around one idea. Every time an agent starts work, a **progress card** pops into Telegram and stays pinned while the task runs. It updates in place as tools execute, so you see each Read, Bash, Edit, Grep happen as it happens.
+<p align="center"><img src="docs/diagrams/progress-card-anatomy.svg" width="700" alt="Annotated progress card: pin badge, user quote, last 5 steps, collapsed older, in-flight pulse, elapsed timer, sub-agent indent"></p>
 
 ```
 ⚙️ Working… · ⏱ 12s
@@ -43,63 +33,112 @@ The whole thing is built around one idea. Every time an agent starts work, a **p
   🤖 Edit src/auth/jwt.ts · 4s
 ```
 
-When the agent finishes, the card flips to Done and unpins. Two agents working at the same time? Each gets its own card, labelled `(1/2)` and `(2/2)`, so you can follow both without losing the plot.
+The card is the headline UX. The rest of the product is in service of it.
 
-## The UX bits that matter
+- Cards update at most once every 5 seconds. Fast enough to follow, not so fast it floods.
+- Last 5 steps stay visible. Older ones collapse into `(+N more earlier steps)`.
+- Running steps show elapsed time so a stuck tool is obvious.
+- Tool labels are deterministic, written by a `PreToolUse` hook, so the card never lies about what's running.
+- Two agents working at once? Each gets its own card, labelled `(1/2)` and `(2/2)`.
 
-- Cards update at most once every 5 seconds. Fast enough to follow, not so fast it floods
-- Last 5 steps are always visible, older ones collapse into `(+N more earlier steps)`
-- Running steps show elapsed time so you can tell if something's stuck
-- Sub-agents get their own section in the card, so nested work is visible, not hidden
-- No silent gaps. No ghosts.
+### Sub-agent visibility
+
+When an agent delegates to a sub-agent — Opus plans, Sonnet implements — the sub-agent's work shows up indented inside the parent's pinned card. One pinned surface per task, however many processes it spawns underneath. Nothing gets buried in a side-channel you have to go look for.
+
+### Right, so what's this about
+
+So you had the bright idea. Run Claude Code agents 24/7 on a cheap Linux box, talk to them from Telegram, use the Claude Pro or Max subscription you're already paying for. Sensible. Obvious, even.
+
+Then you tried OpenClaw. Followed the docs, spun it up, got it running, only to realise halfway through that you're pinging the Anthropic API on your own key and your token bill is quietly ticking over in the background. Bit of a bait and switch, that one. You signed up for "use your subscription," not "buy API credits on top of your subscription."
+
+So you gave Claude Code's built-in Telegram channel a crack instead. Sent a message. Waited. Something happened, maybe. Eventually a reply came back. What did the agent actually do? No idea. Which tools ran? No idea. Did it get stuck, crash, spawn a sub-agent, read half your repo? No idea. It's an MVP black box of death, and I got sick of squinting into it.
+
+So I built this.
+
+## What you get
+
+| Feature | What it does |
+|---|---|
+| **Progress cards** | Pinned, in-place, every tool call visible. The headline UX. |
+| **Claude Pro/Max auth** | OAuth, not API keys. No per-token billing. Multi-account fallback pool per agent. |
+| **Approval kernel** | Inline allow/deny cards in Telegram for every gated tool. TTL'd grants, full audit trail. |
+| **Sub-agents** | Opus plans, Sonnet implements. Sub-agent work surfaces in the parent card. |
+| **Config cascade** | Defaults, then profiles, then per-agent YAML. Change one line, every agent updates. |
+| **Scheduled tasks** | Cron-based systemd timers. Survive reboots. Headless secret access via the vault broker. |
+| **Persistent memory** | Hindsight semantic memory with knowledge graphs and mental models. |
+| **Session continuity** | Resume across restarts with freshness gating and a wake-audit. |
+| **Encrypted vault** | AES-256-GCM for secrets. Optional auto-unlock keyed off `/etc/machine-id`. |
+| **Drive MCP** | Read Google Docs, Sheets, and Drive files inline. Per-agent OAuth, no shared key. |
+| **Card audit log** | Every progress-card edit appended to `card-events.jsonl` for retrospective debugging. |
+| **15 Telegram MCP tools** | Reply, stream replies, edit, pin, react, native checklists, sticker aliases, voice-in transcription, attachments, history. |
 
 ## Architecture
 
-One Claude Code REPL per agent, dressed up with systemd and a Telegram bot. Two systemd units per agent: the Claude process (`switchroom-<agent>.service`) and its Telegram gateway (`switchroom-<agent>-gateway.service`). See [`docs/architecture.md`](docs/architecture.md) for the process model, IPC layout, and how each layer maps to the `claude` CLI.
+One Claude Code REPL per agent, dressed up with systemd, a Telegram bot, and a couple of brokers. Each agent runs the unmodified `claude` binary, authenticated directly with Anthropic via official OAuth. No fork, no Agent SDK, no API key interception. The whole thing is scaffolding and lifecycle around the CLI you'd run by hand.
 
 ```
 You (Telegram)
     │
     ▼
-@YourBot ──── switchroom-telegram MCP ──── Claude Code CLI
-                  │                        │
-                  ├─ Progress cards         ├─ .claude/agents/*.md (sub-agents)
-                  ├─ Pin / unpin lifecycle  ├─ settings.json (tools, hooks, MCP)
-                  ├─ SQLite history         ├─ Hindsight plugin (memory)
-                  ├─ Emoji reactions        └─ systemd (agent + cron timers)
-                  └─ Format conversion
+@YourBot ──┬── switchroom-telegram MCP ──┬── tmux supervisor ──── Claude Code CLI
+           │       (15 tools)            │     (per-agent)        │
+           │                             │                        ├─ .claude/agents/*.md (sub-agents)
+           ├─ Progress cards             ├─ Approval kernel ◄─────┤   settings.json (tools, hooks, MCP)
+           ├─ Pin / unpin lifecycle      │   (allow/deny broker)  ├─ Hindsight plugin (memory)
+           ├─ SQLite history             ├─ Vault broker ◄────────┤   Drive MCP, Playwright MCP, …
+           ├─ Card-events.jsonl audit    │   (cron secrets, IPC)  └─ systemd (agent + cron timers)
+           ├─ Emoji reactions            │
+           └─ Format conversion          └─ Watchdog + crash-pane capture
 ```
 
-Switchroom is **not a harness**. Each agent runs the unmodified `claude` binary, authenticated directly with Anthropic via official OAuth. No credential interception, no API key routing.
+See [`docs/architecture.md`](docs/architecture.md) for the process model, IPC layout, and how each layer maps to the `claude` CLI.
 
-## Everything else you get
+## Approvals & safety
 
-| Feature | What it does |
-|---------|-------------|
-| **Claude Pro/Max auth** | OAuth, not API keys. No per-token billing. |
-| **Multi-agent** | Opus plans, Sonnet implements in the background. Sub-agent work surfaces in the card. |
-| **Config cascade** | Defaults, then profiles, then per-agent YAML. Change one line, every agent updates. |
-| **Scheduled tasks** | Cron-based systemd timers. Survive reboots. |
-| **Persistent memory** | Hindsight semantic memory with knowledge graphs. |
-| **Session continuity** | Resume sessions across restarts with freshness gating. |
-| **Encrypted vault** | AES-256-GCM for secrets. |
-| **12 Telegram MCP tools** | Reply, stream replies, pin, react, history, attachments, native checklists, all of it. |
+Tools that touch the world — Bash, Edit, Write, anything not on an agent's pre-approved allowlist — pause for explicit approval. Switchroom's **approval kernel** (shipped in v0.5.1) routes every gated tool call through an inline Telegram card with the actual diff or command shown. Tap Allow and the tool resumes. Tap Deny and the agent gets a clean refusal it can recover from.
 
-## How it stacks up against the alternatives
+<p align="center"><img src="docs/diagrams/approval-grant-flow.svg" width="700" alt="Approval grant flow: agent tool call pauses at the kernel, broker writes pending grant to sqlite, user taps Allow on the Telegram card, broker releases the gate, tool resumes"></p>
+
+- **Inline cards.** Allow / Deny / Allow once / Allow for 1h. No leaving Telegram.
+- **TTL'd grants.** "Allow Bash for 1h" expires automatically. No silent permanent escalation.
+- **Audit trail.** Every grant, denial, and expiry written to a per-agent log you can replay.
+- **Per-agent allowlist.** `switchroom agent grant <name> <tool>` for the boring ones you don't want to be asked about.
+
+The kernel runs as an out-of-process broker over a unix socket. The agent process never decides its own permissions; it asks and waits.
+
+### Compliance posture
+
+Switchroom never intercepts auth, never proxies inference, never patches the CLI. The `claude` binary you run is the one Anthropic ships. See the [Compliance Attestation](docs/compliance-attestation.md) for the full analysis against Anthropic's April 2026 third-party policy.
+
+## Survives real life
+
+Agents are systemd user units running inside tmux sessions. They survive reboots, network drops, and your laptop closing. But "always on" isn't enough on its own. Things still die. The product has to handle that gracefully or the illusion breaks.
+
+<p align="center"><img src="docs/diagrams/wake-audit-lifecycle.svg" width="700" alt="Wake-audit lifecycle: kill, crash-pane snapshot, systemd restart, start.sh sets SWITCHROOM_PENDING_TURN, agent acks with three options"></p>
+
+- **Watchdog.** A user-level systemd unit watches every agent for stuck turns, dead bridges, and runaway resource use. When it has to act, it captures a **crash pane snapshot** of the tmux pty so you can see what the agent was looking at when it died.
+- **Resume protocol.** When an agent reboots mid-turn, `start.sh` exports `SWITCHROOM_PENDING_TURN=true` plus the original chat / message ids. The agent's first action on boot is to acknowledge the gap and ask the user how to proceed (start over, summarise and continue, or drop it).
+- **Wake-audit.** On every fresh boot the agent checks for owed replies, orphan sub-agents, and stale in-progress todos. If everything's clean it stays quiet. If it owed you a reply, it tells you.
+- **Token refresh.** Runs unattended for weeks via a `refresh-tick` daemon. Multi-account fallback pool kicks in when the active slot hits its quota window.
+
+## How it stacks up
 
 | | Switchroom | Claude Code channels | OpenClaw | NanoClaw |
 |---|---|---|---|---|
-| Progress visibility | Live progress cards, pinned | None, black box | None | None |
+| Progress visibility | Live cards, pinned | Black box | None | None |
 | Runtime | Claude Code CLI | Claude Code CLI | Custom runtime | Agents SDK |
 | Auth | Pro/Max OAuth | Pro/Max OAuth | API key | API key |
-| Sub-agent tracking | Yes, visible in card | No | No | No |
+| Sub-agent tracking | Yes, in card | No | No | No |
 | Parallel task display | Labelled cards `(1/N)` | No | No | No |
+| Approval UX | Inline Telegram cards | None | None | None |
 | Config | YAML with cascade | None | JSON/TOML | Env vars |
 | Setup | `switchroom setup` | Built-in (limited) | Docker compose | Docker compose |
 
 ## Install
 
 Ubuntu 24.04 LTS, 4GB RAM. Linux only.
+
+> **Heads up on the package name.** The npm package was originally `switchroom-ai`. It's now just `switchroom`. The old name is deprecated and will stop receiving updates — `npm install -g switchroom` is the current path.
 
 ### From inside Claude Code (the on-ramp)
 
@@ -111,7 +150,7 @@ If you already use Claude Code, this is the shortest path. Inside any session:
 /switchroom:setup
 ```
 
-`/switchroom:setup` walks you through deps, `switchroom setup` (Telegram + vault + first agent), and `switchroom agent start`. Once it's done you have `/switchroom:start`, `/switchroom:stop`, and `/switchroom:status` for day-to-day. See [`docs/publishing.md`](docs/publishing.md).
+`/switchroom:setup` walks you through deps, `switchroom setup` (Telegram + vault + first agent), and `switchroom agent start`. Day-to-day: `/switchroom:start`, `/switchroom:stop`, `/switchroom:status`. See [`docs/publishing.md`](docs/publishing.md).
 
 ### One-liner (fresh box)
 
@@ -139,7 +178,7 @@ npm install -g @anthropic-ai/claude-code switchroom
 switchroom setup
 ```
 
-Node 20.11+. `switchroom setup` is the interactive first-time wizard — scaffolds config, handles Telegram wiring, sets up the vault.
+Node 20.11+. `switchroom setup` is the interactive first-time wizard. Scaffolds config, handles Telegram wiring, sets up the vault.
 
 ### One-shot happy path (no wizard)
 
@@ -151,7 +190,7 @@ switchroom auth login coach
 switchroom agent start coach
 ```
 
-## Example Configuration
+## Example configuration
 
 ```yaml
 switchroom:
@@ -195,11 +234,7 @@ See [docs/configuration.md](docs/configuration.md) for the full reference.
 
 ## Vault broker (cron secrets)
 
-Scheduled tasks run headless via `systemd --user` timers, so they cannot prompt
-for the vault passphrase. The vault broker is a long-running user-level systemd
-unit that holds the vault decrypted in memory after a one-time interactive
-unlock. Cron tasks fetch the specific keys they declare via a unix socket; the
-passphrase never sits on disk.
+Scheduled tasks run headless via `systemd --user` timers, so they can't prompt for the vault passphrase. The vault broker is a long-running user-level systemd unit that holds the vault decrypted in memory after a one-time interactive unlock. Cron tasks fetch the specific keys they declare via a unix socket. The passphrase never sits on disk.
 
 **Declare per-cron secrets in `switchroom.yaml`:**
 
@@ -221,60 +256,29 @@ switchroom update                       # installs the broker systemd unit
 switchroom vault broker unlock          # prompt for passphrase, primes broker
 ```
 
-Or just run `switchroom vault get <key>` from a TTY — the broker offers to
-take the unlocked state with `[Y/n]` so you don't have to remember a separate
-unlock command.
+Or just run `switchroom vault get <key>` from a TTY. The broker offers to take the unlocked state with `[Y/n]` so you don't have to remember a separate unlock command.
 
-**Identity model.** On Linux, the broker reads `/proc/<pid>/cgroup` to find
-the connecting cron's systemd unit (`switchroom-<agent>-cron-<i>.service`).
-Cgroup membership is set by systemd as root and is unspoofable from
-userspace, so a compromised agent cannot pose as another agent's cron and
-read its keys. macOS and other platforms degrade to UID-only via the socket
-file mode 0600 — fine for desktop use, not recommended for production cron.
+**Identity model.** On Linux, the broker reads `/proc/<pid>/cgroup` to find the connecting cron's systemd unit (`switchroom-<agent>-cron-<i>.service`). Cgroup membership is set by systemd as root and is unspoofable from userspace, so a compromised agent cannot pose as another agent's cron and read its keys. macOS and other platforms degrade to UID-only via the socket file mode 0600. Fine for desktop use, not recommended for production cron.
 
-The broker locks on `SIGTERM` (so a `restart` zeros the in-memory state)
-and on demand via `switchroom vault broker lock`. Use
-`switchroom vault get <key> --no-broker` to bypass and prompt locally.
+The broker locks on `SIGTERM` (so a `restart` zeros the in-memory state) and on demand via `switchroom vault broker lock`. Use `switchroom vault get <key> --no-broker` to bypass and prompt locally.
 
 Unit installed at `~/.config/systemd/user/switchroom-vault-broker.service`.
 
 ### Auto-unlock on boot (opt-in)
 
-By default, the broker holds the unlocked state in memory only — every
-restart (host reboot, service crash, reconcile that re-renders the unit)
-wipes it and requires `switchroom vault broker unlock` again. For
-unattended hosts where this is too painful, switchroom can encrypt the
-passphrase with a key derived from `/etc/machine-id` and have the broker
-unlock itself at boot:
+By default, the broker holds the unlocked state in memory only. Every restart (host reboot, service crash, reconcile that re-renders the unit) wipes it and requires `switchroom vault broker unlock` again. For unattended hosts where this is too painful, switchroom can encrypt the passphrase with a key derived from `/etc/machine-id` and have the broker unlock itself at boot:
 
 ```bash
 switchroom vault broker enable-auto-unlock   # one-time setup, prompts for passphrase
 ```
 
-Done. The wizard prompts for your vault passphrase, encrypts it with
-AES-256-GCM keyed off `/etc/machine-id`, writes the result to
-`~/.config/switchroom/auto-unlock.bin` (mode 0600), flips
-`vault.broker.autoUnlock: true` in `switchroom.yaml`, restarts the
-broker, and verifies the vault came up unlocked. Every subsequent boot
-the broker reads + decrypts + unlocks itself.
+Done. The wizard prompts for your vault passphrase, encrypts it with AES-256-GCM keyed off `/etc/machine-id`, writes the result to `~/.config/switchroom/auto-unlock.bin` (mode 0600), flips `vault.broker.autoUnlock: true` in `switchroom.yaml`, restarts the broker, and verifies the vault came up unlocked. Every subsequent boot the broker reads + decrypts + unlocks itself.
 
 Disable with `switchroom vault broker disable-auto-unlock`.
 
-**Security tradeoff — read this before enabling.** The encrypted blob
-lives at mode 0600 in your home directory; the encryption key is
-derived from `/etc/machine-id` plus a per-file random salt. This means
-disk theft is safe (the blob doesn't decrypt on any other machine) and
-other UNIX users on the same box can't read it — but root on the host
-*can* read both the blob and the machine-id, so once root is on the
-machine the passphrase is recoverable. Same blast radius as the
-running broker process (anything with code-exec as you can already
-attach to the broker socket and exfiltrate secrets), but it shifts the
-convenience-vs-security knob: auto-unlock means a lost laptop is a lost
-vault even if the vault file itself is encrypted at rest. Use only on
-hosts you trust. See [docs/auto-unlock.md](docs/auto-unlock.md) for the
-full threat model and recovery instructions.
+**Security tradeoff. Read this before enabling.** The encrypted blob lives at mode 0600 in your home directory; the encryption key is derived from `/etc/machine-id` plus a per-file random salt. Disk theft is safe (the blob doesn't decrypt on any other machine) and other UNIX users on the same box can't read it. But root on the host *can* read both the blob and the machine-id, so once root is on the machine the passphrase is recoverable. Same blast radius as the running broker process (anything with code-exec as you can already attach to the broker socket and exfiltrate secrets), but it shifts the convenience-vs-security knob: auto-unlock means a lost laptop is a lost vault even if the vault file itself is encrypted at rest. Use only on hosts you trust. See [docs/auto-unlock.md](docs/auto-unlock.md) for the full threat model and recovery instructions.
 
-## CLI Reference
+## CLI reference
 
 ```bash
 switchroom setup                              # Interactive wizard
@@ -313,10 +317,7 @@ Model aliases: the bare names `opus`, `sonnet`, `haiku` are accepted alongside t
 
 ### Authentication (multi-account slot pool)
 
-Each agent has a pool of Claude OAuth slots. The **active** slot is what
-the agent uses; other slots are automatic fallbacks when the active slot
-hits its quota window. Every `<slot>` option defaults to the active slot
-if omitted.
+Each agent has a pool of Claude OAuth slots. The **active** slot is what the agent uses; other slots are automatic fallbacks when the active slot hits its quota window. Every `<slot>` option defaults to the active slot if omitted.
 
 ```bash
 switchroom auth status                            # All agents, one table
@@ -333,15 +334,11 @@ switchroom auth list <agent> [--json]             # Show slots: health, quota st
 switchroom auth rm <agent> <slot> [--force]       # Remove a slot (refuses active/last slot)
 ```
 
-The fallback pool also works from Telegram. The switchroom MCP plugin
-exposes the same verbs as `/auth add|use|list|rm` inside the chat.
+The fallback pool also works from Telegram. The switchroom MCP plugin exposes the same verbs as `/auth add|use|list|rm` inside the chat.
 
 ### Workspace (agent bootstrap layer)
 
-Each agent has a workspace directory (`~/.switchroom/agents/<name>/workspace/`)
-with editable stable files (`AGENTS.md`, `SOUL.md`, `USER.md`, `IDENTITY.md`,
-`TOOLS.md`) and dynamic files (`MEMORY.md`, `memory/YYYY-MM-DD.md`,
-`HEARTBEAT.md`) that are injected into the model's context at turn time.
+Each agent has a workspace directory (`~/.switchroom/agents/<name>/workspace/`) with editable stable files (`AGENTS.md`, `SOUL.md`, `USER.md`, `IDENTITY.md`, `TOOLS.md`) and dynamic files (`MEMORY.md`, `memory/YYYY-MM-DD.md`, `HEARTBEAT.md`) that are injected into the model's context at turn time.
 
 ```bash
 switchroom workspace path <agent>                 # Print the workspace dir
@@ -361,6 +358,8 @@ switchroom debug turn <agent>                     # Dump the exact prompt layeri
 switchroom memory setup|search|stats|reflect      # Hindsight memory
 ```
 
+The progress card driver also writes a per-agent `card-events.jsonl` audit log: every edit, pin, unpin, and tool-label transition the user sees in Telegram, captured locally so a debug session doesn't depend on Telegram's history. Tail it like any other journal.
+
 ### Other
 
 ```bash
@@ -374,7 +373,7 @@ switchroom web                                    # Web dashboard
 
 `scripts/import-openclaw-credentials.ts` is a one-shot migration script that lifts `/data/openclaw-config/credentials/` into the Switchroom vault. It ships with a small set of default mappings for filenames OpenClaw documents out of the box.
 
-User-specific credential filenames (your custom bot tokens, SSH keys, and so on) belong in a local overlay file — not in the source repository. Create `~/.switchroom/import-openclaw.yaml`:
+User-specific credential filenames (your custom bot tokens, SSH keys, and so on) belong in a local overlay file, not the source repository. Create `~/.switchroom/import-openclaw.yaml`:
 
 ```yaml
 # ~/.switchroom/import-openclaw.yaml
@@ -395,10 +394,11 @@ Overlay entries win on collision with built-in defaults. Unknown files that appe
 ## Documentation
 
 | Guide | Description |
-|-------|-------------|
+|---|---|
+| **[Changelog](CHANGELOG.md)** | Release notes, every version |
 | **[Configuration](docs/configuration.md)** | Full field reference, cascade semantics, profiles |
 | **[Vault](docs/vault.md)** | Architecture, per-cron secrets, ACL, audit log, threat model |
-| **[Telegram Plugin](docs/telegram-plugin.md)** | Progress cards, 10 MCP tools, emoji reactions |
+| **[Telegram Plugin](docs/telegram-plugin.md)** | Progress cards, 15 MCP tools, native checklists, sticker aliases, voice-in |
 | **[Sub-Agents](docs/sub-agents.md)** | Model routing, delegation patterns, frontmatter spec |
 | **[Scheduling](docs/scheduling.md)** | Cron tasks, systemd timers, model selection |
 | **[Session Management](docs/session-optimization.md)** | Continuity, compaction, freshness policy |
@@ -409,7 +409,7 @@ Overlay entries win on collision with built-in defaults. Unknown files that appe
 
 ## Telemetry
 
-Switchroom reports anonymous usage events and errors to PostHog so we can spot regressions and understand which commands are used. **No personal data, code, or message content leaves your machine.** The anonymous ID lives at `~/.switchroom/analytics-id` and is a random UUID. Not tied to your username, email, IP, or machine identifier (we pass `disableGeoip: true` on every event).
+Switchroom reports anonymous usage events and errors to PostHog so I can spot regressions and understand which commands are used. **No personal data, code, or message content leaves your machine.** The anonymous ID lives at `~/.switchroom/analytics-id` and is a random UUID. Not tied to your username, email, IP, or machine identifier (we pass `disableGeoip: true` on every event).
 
 To opt out, set this in your shell profile:
 
@@ -431,7 +431,7 @@ The built-in channel is message in, message out, with zero visibility into what 
 Yes. Each agent gets its own Telegram forum topic. When multiple agents are working simultaneously, each has its own pinned progress card labelled `(1/N)`, `(2/N)` and so on.
 
 **Can I see what sub-agents are doing?**
-Yes. When an agent delegates to a sub-agent (a worker, a researcher), the sub-agent's activity shows up in its own section of the progress card. You see the full hierarchy, not just the top-level agent.
+Yes. When an agent delegates to a sub-agent (a worker, a researcher), the sub-agent's activity shows up in its own indented section of the parent's progress card. You see the full hierarchy, not just the top-level agent.
 
 **What does it cost to run?**
 A cheap Linux VPS (around $6/mo on Hetzner, DigitalOcean, wherever), plus your existing Claude Pro ($20/mo) or Max ($100/mo) subscription. Switchroom itself is MIT-licensed, free.

--- a/docs/diagrams/approval-grant-flow.svg
+++ b/docs/diagrams/approval-grant-flow.svg
@@ -1,0 +1,102 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 420" width="900" height="420" font-family="Caveat, 'Bradley Hand', 'Segoe Print', cursive">
+  <defs>
+    <style>
+      @import url('https://fonts.googleapis.com/css2?family=Caveat:wght@500;700&amp;display=swap');
+      .ink { fill: none; stroke: #14171C; stroke-width: 2; stroke-linecap: round; stroke-linejoin: round; }
+      .ink-thin { fill: none; stroke: #14171C; stroke-width: 1.4; stroke-linecap: round; stroke-linejoin: round; }
+      .brass { fill: none; stroke: #B8873A; stroke-width: 2.4; stroke-linecap: round; stroke-linejoin: round; }
+      .cord { fill: none; stroke: #C8302C; stroke-width: 2.4; stroke-linecap: round; stroke-linejoin: round; }
+      .label { font-size: 22px; fill: #14171C; }
+      .label-sm { font-size: 18px; fill: #14171C; }
+      .num { font-size: 22px; font-weight: 700; fill: #C8302C; }
+      .body { font-family: 'Menlo', 'Consolas', monospace; font-size: 13px; fill: #14171C; }
+      .btn-allow { fill: #E8B657; }
+      .btn-deny { fill: #FAF7EF; }
+    </style>
+    <marker id="arrowhead-brass" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="9" markerHeight="9" orient="auto">
+      <path d="M0,0 L10,5 L0,10 z" fill="#B8873A"/>
+    </marker>
+  </defs>
+
+  <rect width="900" height="420" fill="#FAF7EF"/>
+
+  <!-- Phone with approval card (left) -->
+  <g transform="translate(40,55) rotate(-1)">
+    <rect x="0" y="0" width="220" height="320" rx="22" ry="22" fill="#F5F1E8" class="ink"/>
+    <text x="20" y="34" class="body" style="font-weight:700;">⚠ approval requested</text>
+    <line x1="20" y1="42" x2="200" y2="42" class="ink-thin"/>
+    <text x="20" y="64" class="body">tool: Bash</text>
+    <text x="20" y="84" class="body">agent: coder</text>
+    <text x="20" y="110" class="body" style="font-weight:700;">$ rm -rf node_modules</text>
+    <text x="20" y="130" class="body">$ bun install</text>
+    <line x1="20" y1="148" x2="200" y2="148" class="ink-thin"/>
+    <!-- buttons -->
+    <rect x="20" y="170" width="80" height="34" rx="6" class="btn-allow"/>
+    <rect x="20" y="170" width="80" height="34" rx="6" class="ink"/>
+    <text x="60" y="192" text-anchor="middle" class="body" style="font-weight:700;">Allow</text>
+
+    <rect x="110" y="170" width="80" height="34" rx="6" class="btn-deny"/>
+    <rect x="110" y="170" width="80" height="34" rx="6" class="ink"/>
+    <text x="150" y="192" text-anchor="middle" class="body">Deny</text>
+
+    <rect x="20" y="216" width="170" height="30" rx="6" class="btn-deny"/>
+    <rect x="20" y="216" width="170" height="30" rx="6" class="ink"/>
+    <text x="105" y="236" text-anchor="middle" class="body">Allow Bash for 1h</text>
+
+    <text x="20" y="276" class="body" fill="#5A6069">grant expires automatically</text>
+    <text x="20" y="294" class="body" fill="#5A6069">tap to allow once or for 1h</text>
+  </g>
+  <text x="150" y="395" text-anchor="middle" class="label" style="font-weight:700;">Telegram approval card</text>
+
+  <!-- Broker (middle) -->
+  <g transform="translate(395,140) rotate(0.6)">
+    <rect x="0" y="0" width="160" height="140" rx="10" fill="#F5F1E8" class="ink"/>
+    <text x="80" y="32" text-anchor="middle" class="label" style="font-weight:700;">approval</text>
+    <text x="80" y="56" text-anchor="middle" class="label" style="font-weight:700;">kernel</text>
+    <line x1="20" y1="70" x2="140" y2="70" class="ink-thin"/>
+    <!-- sqlite icon -->
+    <ellipse cx="80" cy="92" rx="36" ry="8" class="ink"/>
+    <path d="M44,92 L44,108 Q44,116 80,116 Q116,116 116,108 L116,92" class="ink"/>
+    <ellipse cx="80" cy="108" rx="36" ry="8" fill="none" class="ink-thin"/>
+    <text x="80" y="135" text-anchor="middle" class="body">grants.sqlite</text>
+  </g>
+  <text x="475" y="310" text-anchor="middle" class="label">IPC broker (unix socket)</text>
+
+  <!-- Agent process (right) -->
+  <g transform="translate(685,140) rotate(-0.5)">
+    <rect x="0" y="0" width="170" height="140" rx="10" fill="#F5F1E8" class="ink"/>
+    <text x="85" y="36" text-anchor="middle" class="label" style="font-weight:700;">claude</text>
+    <text x="85" y="60" text-anchor="middle" class="label" style="font-weight:700;">agent process</text>
+    <line x1="20" y1="74" x2="150" y2="74" class="ink-thin"/>
+    <text x="85" y="96" text-anchor="middle" class="body">paused at gate</text>
+    <text x="85" y="116" text-anchor="middle" class="body">waiting…</text>
+    <!-- spinner-ish -->
+    <circle cx="85" cy="128" r="4" fill="#C8302C"/>
+  </g>
+  <text x="770" y="310" text-anchor="middle" class="label">agent (tmux + systemd)</text>
+
+  <!-- Arrows with numbers -->
+  <!-- 1: tool call (agent → broker, but reading right-to-left) -->
+  <path d="M680,200 Q620,180 565,200" class="brass" marker-end="url(#arrowhead-brass)"/>
+  <text x="620" y="170" text-anchor="middle" class="num">1</text>
+  <text x="620" y="148" text-anchor="middle" class="label-sm">tool call</text>
+
+  <!-- 2: kernel pause notify → phone -->
+  <path d="M395,225 Q330,250 270,235" class="brass" marker-end="url(#arrowhead-brass)"/>
+  <text x="335" y="270" text-anchor="middle" class="num">2</text>
+  <text x="335" y="290" text-anchor="middle" class="label-sm">push card to user</text>
+
+  <!-- 3: user taps Allow → broker -->
+  <path d="M270,160 Q330,130 395,170" class="brass" marker-end="url(#arrowhead-brass)"/>
+  <text x="335" y="118" text-anchor="middle" class="num">3</text>
+  <text x="335" y="98" text-anchor="middle" class="label-sm">user taps Allow</text>
+
+  <!-- 4: tool resumes → agent -->
+  <path d="M560,180 Q620,200 680,210" class="brass" marker-end="url(#arrowhead-brass)"/>
+  <text x="620" y="252" text-anchor="middle" class="num">4</text>
+  <text x="620" y="272" text-anchor="middle" class="label-sm">tool resumes</text>
+
+  <!-- footer -->
+  <line x1="200" y1="408" x2="700" y2="410" class="cord"/>
+  <text x="450" y="34" text-anchor="middle" class="label" style="font-size:26px; font-weight:700;">approval kernel — out of process, every grant logged</text>
+</svg>

--- a/docs/diagrams/progress-card-anatomy.svg
+++ b/docs/diagrams/progress-card-anatomy.svg
@@ -1,0 +1,103 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 520" width="800" height="520" font-family="Caveat, 'Bradley Hand', 'Segoe Print', cursive">
+  <defs>
+    <style>
+      @import url('https://fonts.googleapis.com/css2?family=Caveat:wght@500;700&amp;display=swap');
+      .ink { fill: none; stroke: #14171C; stroke-width: 2; stroke-linecap: round; stroke-linejoin: round; }
+      .ink-thin { fill: none; stroke: #14171C; stroke-width: 1.4; stroke-linecap: round; stroke-linejoin: round; }
+      .brass { fill: none; stroke: #B8873A; stroke-width: 2.2; stroke-linecap: round; stroke-linejoin: round; }
+      .label { font-size: 22px; fill: #14171C; }
+      .label-sm { font-size: 18px; fill: #14171C; }
+      .arrow { fill: #B8873A; }
+      .body { font-family: 'Menlo', 'Consolas', monospace; font-size: 14px; fill: #14171C; }
+      .pin-fill { fill: #E8B657; }
+      .pulse { fill: #C8302C; }
+    </style>
+    <marker id="arrowhead" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto">
+      <path d="M0,0 L10,5 L0,10 z" class="arrow"/>
+    </marker>
+  </defs>
+
+  <rect width="800" height="520" fill="#FAF7EF"/>
+
+  <!-- Phone frame (the card) -->
+  <g transform="translate(230,40) rotate(-0.6)">
+    <rect x="0" y="0" width="340" height="380" rx="18" ry="18" fill="#F5F1E8" class="ink"/>
+    <!-- pin badge -->
+    <g transform="translate(20,22)">
+      <circle cx="10" cy="10" r="11" class="pin-fill"/>
+      <circle cx="10" cy="10" r="11" class="ink"/>
+      <path d="M5,7 L15,7 L13,13 L7,13 z M10,13 L10,18" class="ink-thin"/>
+    </g>
+    <text x="50" y="36" class="body" style="font-weight:700;">📌 Pinned · ⚙️ Working… · ⏱ 12s</text>
+
+    <!-- pulse dot -->
+    <circle cx="316" cy="30" r="6" class="pulse"/>
+    <circle cx="316" cy="30" r="11" fill="none" stroke="#C8302C" stroke-width="1.4" opacity="0.5"/>
+
+    <!-- user quote line -->
+    <line x1="20" y1="58" x2="320" y2="58" class="ink-thin"/>
+    <text x="20" y="80" class="body">💬 refactor the auth module to use JWT</text>
+    <line x1="20" y1="96" x2="320" y2="96" class="ink-thin"/>
+
+    <!-- collapsed older -->
+    <text x="20" y="124" class="body" fill="#5A6069">… (+3 more earlier steps)</text>
+
+    <!-- step list -->
+    <text x="20" y="156" class="body">✅ Read src/auth/session.ts</text>
+    <text x="20" y="180" class="body">✅ Grep "cookie" (in src/)</text>
+    <text x="20" y="204" class="body">✅ Read src/auth/jwt.ts</text>
+    <text x="20" y="228" class="body">✅ Bash bun test auth/</text>
+    <text x="20" y="252" class="body" style="font-weight:700;">🤖 Edit src/auth/jwt.ts · 4s</text>
+
+    <!-- sub-agent indent -->
+    <line x1="40" y1="276" x2="40" y2="338" class="brass"/>
+    <text x="56" y="284" class="body" fill="#B8873A">└─ @worker (sub-agent)</text>
+    <text x="56" y="306" class="body">   ✅ Read tests/auth.test.ts</text>
+    <text x="56" y="328" class="body">   🤖 Write tests/jwt.test.ts</text>
+
+    <!-- footer timer -->
+    <line x1="20" y1="350" x2="320" y2="350" class="ink-thin"/>
+    <text x="20" y="370" class="body" fill="#5A6069">elapsed 12s · 5 of 8 steps · last update 1s ago</text>
+  </g>
+
+  <!-- Annotations: arrows + labels -->
+  <!-- pin badge -->
+  <text x="40" y="56" class="label">pin badge</text>
+  <path d="M120,60 Q180,68 248,72" class="brass" marker-end="url(#arrowhead)"/>
+
+  <!-- user quote -->
+  <text x="40" y="96" class="label">user's prompt</text>
+  <path d="M150,98 Q200,92 250,86" class="brass" marker-end="url(#arrowhead)"/>
+
+  <!-- pulse -->
+  <text x="610" y="62" class="label">in-flight pulse</text>
+  <path d="M608,58 Q580,46 558,42" class="brass" marker-end="url(#arrowhead)"/>
+
+  <!-- elapsed timer (top) -->
+  <text x="610" y="106" class="label">elapsed timer</text>
+  <path d="M608,102 Q540,86 478,72" class="brass" marker-end="url(#arrowhead)"/>
+
+  <!-- collapsed older -->
+  <text x="40" y="166" class="label">older steps,</text>
+  <text x="40" y="186" class="label">collapsed</text>
+  <path d="M150,168 Q200,162 250,162" class="brass" marker-end="url(#arrowhead)"/>
+
+  <!-- last 5 visible -->
+  <text x="610" y="210" class="label">last 5 steps,</text>
+  <text x="610" y="230" class="label">always visible</text>
+  <path d="M608,222 Q580,212 558,208" class="brass" marker-end="url(#arrowhead)"/>
+
+  <!-- in-flight tool -->
+  <text x="610" y="288" class="label">running step,</text>
+  <text x="610" y="308" class="label">w/ duration</text>
+  <path d="M608,294 Q570,286 538,290" class="brass" marker-end="url(#arrowhead)"/>
+
+  <!-- sub-agent -->
+  <text x="40" y="338" class="label">sub-agent,</text>
+  <text x="40" y="358" class="label">indented inline</text>
+  <path d="M150,340 Q200,332 256,326" class="brass" marker-end="url(#arrowhead)"/>
+
+  <!-- footer caption -->
+  <text x="400" y="468" text-anchor="middle" class="label" style="font-size:24px; font-weight:700;">one pinned card per task. updates in place. nothing buried.</text>
+  <line x1="160" y1="478" x2="640" y2="482" class="brass"/>
+</svg>

--- a/docs/diagrams/wake-audit-lifecycle.svg
+++ b/docs/diagrams/wake-audit-lifecycle.svg
@@ -1,0 +1,98 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 360" width="1000" height="360" font-family="Caveat, 'Bradley Hand', 'Segoe Print', cursive">
+  <defs>
+    <style>
+      @import url('https://fonts.googleapis.com/css2?family=Caveat:wght@500;700&amp;display=swap');
+      .ink { fill: none; stroke: #14171C; stroke-width: 2; stroke-linecap: round; stroke-linejoin: round; }
+      .ink-thin { fill: none; stroke: #14171C; stroke-width: 1.4; stroke-linecap: round; stroke-linejoin: round; }
+      .brass { fill: none; stroke: #B8873A; stroke-width: 2.4; stroke-linecap: round; stroke-linejoin: round; }
+      .cord { fill: none; stroke: #C8302C; stroke-width: 2.4; stroke-linecap: round; stroke-linejoin: round; }
+      .label { font-size: 20px; fill: #14171C; }
+      .label-sm { font-size: 16px; fill: #14171C; }
+      .body { font-family: 'Menlo', 'Consolas', monospace; font-size: 12px; fill: #14171C; }
+      .panel { fill: #F5F1E8; }
+    </style>
+    <marker id="arrowhead-b" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="9" markerHeight="9" orient="auto">
+      <path d="M0,0 L10,5 L0,10 z" fill="#B8873A"/>
+    </marker>
+  </defs>
+
+  <rect width="1000" height="360" fill="#FAF7EF"/>
+
+  <!-- Title -->
+  <text x="500" y="38" text-anchor="middle" class="label" style="font-size:26px; font-weight:700;">when an agent dies mid-turn — the wake-audit lifecycle</text>
+  <line x1="240" y1="48" x2="760" y2="50" class="cord"/>
+
+  <!-- Timeline baseline -->
+  <line x1="60" y1="220" x2="940" y2="220" class="brass"/>
+
+  <!-- Step 1: kill (skull) -->
+  <g transform="translate(80,140) rotate(-1.2)">
+    <rect x="0" y="0" width="130" height="100" rx="10" class="panel ink"/>
+    <!-- skull -->
+    <g transform="translate(45,18)">
+      <circle cx="20" cy="20" r="18" class="ink"/>
+      <circle cx="13" cy="18" r="3" fill="#14171C"/>
+      <circle cx="27" cy="18" r="3" fill="#14171C"/>
+      <path d="M14,30 L18,34 L22,30 L26,34" class="ink-thin"/>
+      <rect x="10" y="38" width="20" height="6" class="ink"/>
+    </g>
+    <text x="65" y="92" text-anchor="middle" class="body">SIGKILL / panic</text>
+  </g>
+  <text x="145" y="262" text-anchor="middle" class="label">1. process dies</text>
+
+  <!-- Step 2: crash-pane snapshot -->
+  <g transform="translate(250,140) rotate(0.8)">
+    <rect x="0" y="0" width="150" height="100" rx="6" class="panel ink"/>
+    <text x="75" y="24" text-anchor="middle" class="label-sm" style="font-weight:700;">crash-pane.txt</text>
+    <line x1="14" y1="32" x2="136" y2="32" class="ink-thin"/>
+    <text x="14" y="48" class="body">$ bun run build</text>
+    <text x="14" y="62" class="body">error TS2304:</text>
+    <text x="14" y="76" class="body">  cannot find name…</text>
+    <text x="14" y="90" class="body" fill="#C8302C">[killed by watchdog]</text>
+  </g>
+  <text x="325" y="262" text-anchor="middle" class="label">2. tmux pane captured</text>
+
+  <!-- Step 3: systemd restart -->
+  <g transform="translate(440,140) rotate(-0.5)">
+    <rect x="0" y="0" width="130" height="100" rx="10" class="panel ink"/>
+    <text x="65" y="38" text-anchor="middle" class="label" style="font-weight:700;">systemd</text>
+    <text x="65" y="62" text-anchor="middle" class="label-sm">Restart=always</text>
+    <!-- arrow loop -->
+    <path d="M40,76 Q65,90 90,76" class="cord" marker-end="url(#arrowhead-b)"/>
+  </g>
+  <text x="505" y="262" text-anchor="middle" class="label">3. systemd respawns</text>
+
+  <!-- Step 4: start.sh sets env -->
+  <g transform="translate(620,140) rotate(0.6)">
+    <rect x="0" y="0" width="170" height="100" rx="6" class="panel ink"/>
+    <text x="85" y="24" text-anchor="middle" class="label-sm" style="font-weight:700;">start.sh</text>
+    <line x1="14" y1="32" x2="156" y2="32" class="ink-thin"/>
+    <text x="14" y="50" class="body">SWITCHROOM_PENDING_</text>
+    <text x="14" y="64" class="body">  TURN=true</text>
+    <text x="14" y="78" class="body">PENDING_CHAT_ID=…</text>
+    <text x="14" y="92" class="body">PENDING_USER_MSG=…</text>
+  </g>
+  <text x="705" y="262" text-anchor="middle" class="label">4. env sentinel set</text>
+
+  <!-- Step 5: agent ack -->
+  <g transform="translate(820,130) rotate(-0.8)">
+    <rect x="0" y="0" width="150" height="120" rx="14" class="panel ink"/>
+    <text x="75" y="22" text-anchor="middle" class="body" style="font-weight:700;">⚠ killed mid-turn</text>
+    <line x1="14" y1="30" x2="136" y2="30" class="ink-thin"/>
+    <text x="14" y="50" class="body">want me to:</text>
+    <text x="14" y="68" class="body">(a) start over</text>
+    <text x="14" y="84" class="body">(b) summarise &amp;</text>
+    <text x="14" y="98" class="body">    continue</text>
+    <text x="14" y="114" class="body">(c) drop it</text>
+  </g>
+  <text x="895" y="278" text-anchor="middle" class="label">5. ack &amp; ask user</text>
+
+  <!-- baseline arrows between steps -->
+  <path d="M210,220 L250,220" class="brass" marker-end="url(#arrowhead-b)"/>
+  <path d="M400,220 L440,220" class="brass" marker-end="url(#arrowhead-b)"/>
+  <path d="M570,220 L620,220" class="brass" marker-end="url(#arrowhead-b)"/>
+  <path d="M790,220 L820,220" class="brass" marker-end="url(#arrowhead-b)"/>
+
+  <!-- footer caption -->
+  <text x="500" y="330" text-anchor="middle" class="label" style="font-weight:700;">no silent dropped work. the agent tells you it forgot, and asks how to recover.</text>
+</svg>


### PR DESCRIPTION
Brings README up to current product (was ~2 minor releases behind).

## Changes
- IA reorder: lead with progress card (the genuinely-unique differentiator); compliance demoted to footer of Approvals section
- New **Approvals & safety** section (kernel #762, TTL grants, audit trail, broker)
- New **Survives real life** section (watchdog, wake-audit, resume protocol)
- Added Drive MCP, card audit log, native checklists, sticker aliases, voice-in to feature table
- 3 inline SVG diagrams under `docs/diagrams/` (progress-card anatomy, approval grant flow, wake-audit lifecycle) — hand-drawn aesthetic matching site
- Reconciled MCP tool count (15, verified against `telegram-plugin/bridge/bridge.ts`)
- Mentioned `switchroom-ai` → `switchroom` rename in install
- Refreshed ASCII architecture (added tmux + approval kernel + vault broker + watchdog)
- Preserved Ken's existing voice (rant, OpenClaw quote)
- Reviewed by independent Opus reviewer: APPROVE

## Known follow-up
Codebase still defaults to `claude-opus-4-6` / `claude-sonnet-4-6` (`src/agents/scaffold.ts:279`). README stays at 4-6 to match. Will file a separate issue to bump defaults to 4-7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)