### PR TITLE
docs(jtbd): strip technical-substrate commitments from product surfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ So I built this.
 | **Approval kernel** | Inline allow/deny cards in Telegram for every gated tool. TTL'd grants, full audit trail. |
 | **Sub-agents** | Opus plans, Sonnet implements. Sub-agent work surfaces in the parent card. |
 | **Config cascade** | Defaults, then profiles, then per-agent YAML. Change one line, every agent updates. |
-| **Scheduled tasks** | Cron-based systemd timers. Survive reboots. Headless secret access via the vault broker. |
+| **Scheduled tasks** | Cron-syntax tasks that fire across reboots. Headless secret access via the vault broker. |
 | **Persistent memory** | Hindsight semantic memory with knowledge graphs and mental models. |
 | **Session continuity** | Resume across restarts with freshness gating and a wake-audit. |
 | **Encrypted vault** | AES-256-GCM for secrets. Optional auto-unlock keyed off `/etc/machine-id`. |
@@ -74,24 +74,24 @@ So I built this.
 
 ## Architecture
 
-One Claude Code REPL per agent, dressed up with systemd, a Telegram bot, and a couple of brokers. Each agent runs the unmodified `claude` binary, authenticated directly with Anthropic via official OAuth. No fork, no Agent SDK, no API key interception. The whole thing is scaffolding and lifecycle around the CLI you'd run by hand.
+One long-running service per agent. Each agent runs the stock `claude` CLI — not a fork, not the Agents SDK, not a wrapped harness — authenticated directly with Anthropic via official OAuth. Switchroom is scaffolding and lifecycle around the CLI you'd run by hand: a Telegram bot, an approval broker, a vault broker, a watchdog. See [`docs/architecture.md`](docs/architecture.md) for the process model and how each layer maps to the `claude` CLI.
 
 ```
 You (Telegram)
     │
     ▼
-@YourBot ──┬── switchroom-telegram MCP ──┬── tmux supervisor ──── Claude Code CLI
+@YourBot ──┬── switchroom-telegram MCP ──┬── agent supervisor ─── Claude Code CLI
            │       (15 tools)            │     (per-agent)        │
            │                             │                        ├─ .claude/agents/*.md (sub-agents)
            ├─ Progress cards             ├─ Approval kernel ◄─────┤   settings.json (tools, hooks, MCP)
            ├─ Pin / unpin lifecycle      │   (allow/deny broker)  ├─ Hindsight plugin (memory)
            ├─ SQLite history             ├─ Vault broker ◄────────┤   Drive MCP, Playwright MCP, …
-           ├─ Card-events.jsonl audit    │   (cron secrets, IPC)  └─ systemd (agent + cron timers)
+           ├─ Card-events.jsonl audit    │   (cron secrets, IPC)  └─ scheduled tasks across reboots
            ├─ Emoji reactions            │
            └─ Format conversion          └─ Watchdog + crash-pane capture
 ```
 
-See [`docs/architecture.md`](docs/architecture.md) for the process model, IPC layout, and how each layer maps to the `claude` CLI.
+See [`docs/architecture.md`](docs/architecture.md) for the process model, IPC layout, supervisor choice, and how each layer maps to the `claude` CLI.
 
 ## Approvals & safety
 
@@ -112,11 +112,11 @@ Switchroom never intercepts auth, never proxies inference, never patches the CLI
 
 ## Survives real life
 
-Agents are systemd user units running inside tmux sessions. They survive reboots, network drops, and your laptop closing. But "always on" isn't enough on its own. Things still die. The product has to handle that gracefully or the illusion breaks.
+Each agent is a long-running service. They survive reboots, network drops, and your laptop closing. But "always on" isn't enough on its own. Things still die. The product has to handle that gracefully or the illusion breaks.
 
-<p align="center"><img src="docs/diagrams/wake-audit-lifecycle.jpg" width="700" alt="Wake-audit lifecycle: kill, crash-pane snapshot, systemd restart, start.sh sets SWITCHROOM_PENDING_TURN, agent acks with three options"></p>
+<p align="center"><img src="docs/diagrams/wake-audit-lifecycle.jpg" width="700" alt="Wake-audit lifecycle: kill, crash-pane snapshot, auto-restart, agent boots with SWITCHROOM_PENDING_TURN, acks with three options"></p>
 
-- **Watchdog.** A user-level systemd unit watches every agent for stuck turns, dead bridges, and runaway resource use. When it has to act, it captures a **crash pane snapshot** of the tmux pty so you can see what the agent was looking at when it died.
+- **Watchdog.** A background watcher keeps an eye on every agent for stuck turns, dead bridges, and runaway resource use. When it has to act, it captures a **crash pane snapshot** so you can see what the agent was looking at when it died, then auto-recovers the agent with a full audit trail. No silent dropped work.
 - **Resume protocol.** When an agent reboots mid-turn, `start.sh` exports `SWITCHROOM_PENDING_TURN=true` plus the original chat / message ids. The agent's first action on boot is to acknowledge the gap and ask the user how to proceed (start over, summarise and continue, or drop it).
 - **Wake-audit.** On every fresh boot the agent checks for owed replies, orphan sub-agents, and stale in-progress todos. If everything's clean it stays quiet. If it owed you a reply, it tells you.
 - **Token refresh.** Runs unattended for weeks via a `refresh-tick` daemon. Multi-account fallback pool kicks in when the active slot hits its quota window.
@@ -134,9 +134,11 @@ Agents are systemd user units running inside tmux sessions. They survive reboots
 | Config | YAML with cascade | None | JSON/TOML | Env vars |
 | Setup | `switchroom setup` | Built-in (limited) | Docker compose | Docker compose |
 
+The wedge against OpenClaw and NanoClaw isn't the substrate — it's the stock `claude` CLI under your subscription, instead of a custom runtime under your API key.
+
 ## Install
 
-Ubuntu 24.04 LTS, 4GB RAM. Linux only.
+Runs on the box you already have. Today the supported install path is Ubuntu 24.04 LTS with 4GB RAM; other Linux distros work with minor tweaks. Container-host packaging is on the roadmap (see [RFC](reference/rfc-docker-multi-container.md)).
 
 > **Heads up on the package name.** The npm package was originally `switchroom-ai`. It's now just `switchroom`. The old name is deprecated and will stop receiving updates — `npm install -g switchroom` is the current path.
 

--- a/docs/vs-nanoclaw.md
+++ b/docs/vs-nanoclaw.md
@@ -1,12 +1,12 @@
 # Switchroom vs NanoClaw: a NanoClaw alternative for Claude Code subscribers
 
-NanoClaw is built on the Anthropic Agents SDK and runs agents in containers. Switchroom takes a different approach: use the actual `claude` CLI, authenticate with your Claude Pro/Max subscription, and manage lifecycle with systemd.
+NanoClaw is built on the Anthropic Agents SDK. Switchroom takes a different approach: use the stock `claude` CLI under your Claude Pro/Max subscription, with all the Claude Code features that come with it.
 
 ## TL;DR
 
-- **Switchroom uses the Claude Code CLI with subscription OAuth.** NanoClaw uses the Agents SDK with an API key.
-- **Switchroom runs on systemd.** NanoClaw runs in containers.
+- **Switchroom uses the stock `claude` CLI with subscription OAuth.** NanoClaw uses the Agents SDK with an API key.
 - **Switchroom's agents are interactive Claude Code sessions** with full CLI features. NanoClaw's agents are SDK-driven loops.
+- **Switchroom inherits every upstream Claude Code feature the day it ships.** NanoClaw is its own ecosystem.
 
 ## Side-by-side
 
@@ -14,11 +14,10 @@ NanoClaw is built on the Anthropic Agents SDK and runs agents in containers. Swi
 |---|---|---|
 | Auth | Claude Pro/Max OAuth | Anthropic API key |
 | Billing | Your existing subscription | Per-token API billing |
-| Runtime | Official `claude` CLI | Anthropic Agents SDK |
-| Isolation | systemd unit per agent | Container per agent |
+| Runtime | Stock `claude` CLI | Anthropic Agents SDK |
 | Channels | Telegram (enhanced) | WhatsApp, Telegram, Slack |
 | Memory | Hindsight (semantic) | Per-container |
-| Scheduling | systemd timers | Built-in scheduler |
+| Scheduling | Cron syntax in YAML, fires across reboots | Built-in scheduler |
 | Sub-agents | Native Claude Code sub-agents | N/A |
 | Config | YAML with cascade | ENV vars |
 | License | MIT | n/a |
@@ -57,7 +56,6 @@ Change the default model once, every agent inherits it. Create an `advisor` prof
 ## When NanoClaw might be the right call
 
 - You want the Agents SDK specifically, not Claude Code.
-- You need to deploy to a managed container platform that doesn't run systemd.
 - You need channels (WhatsApp, Slack) that Switchroom hasn't shipped yet.
 
 ## Migrating from NanoClaw

--- a/docs/vs-openclaw.md
+++ b/docs/vs-openclaw.md
@@ -1,12 +1,12 @@
 # Switchroom vs OpenClaw: an OpenClaw alternative that works with Claude Pro/Max
 
-If you came here because OpenClaw stopped working with your Claude subscription, or because you don't want to run Docker containers per agent, Switchroom is built for the same use case with a different set of tradeoffs.
+If you came here because OpenClaw stopped working with your Claude subscription, Switchroom is built for the same use case with a different set of tradeoffs. The wedge is simple: Switchroom drives the **stock `claude` CLI** under your existing Pro/Max subscription. OpenClaw runs a custom runtime against your Anthropic API key.
 
 ## TL;DR
 
 - **Switchroom uses your Claude Pro/Max subscription via OAuth.** OpenClaw requires an Anthropic API key and bills per token.
-- **Switchroom runs the unmodified `claude` CLI.** OpenClaw runs a custom runtime that re-implements parts of Claude Code.
-- **Switchroom uses systemd units.** OpenClaw uses Docker containers per agent.
+- **Switchroom runs the stock `claude` CLI.** OpenClaw runs a custom runtime that re-implements parts of Claude Code.
+- **Switchroom inherits every upstream Claude Code feature the day it ships.** OpenClaw has to catch up.
 - **Switchroom has a YAML config cascade** (defaults → profiles → per-agent). OpenClaw uses per-agent JSON/TOML files.
 
 ## Side-by-side
@@ -15,11 +15,10 @@ If you came here because OpenClaw stopped working with your Claude subscription,
 |---|---|---|
 | Auth | Claude Pro/Max OAuth | Anthropic API key |
 | Billing | Your existing subscription | Per-token API billing |
-| Runtime | Official `claude` CLI | Custom runtime |
-| Isolation | systemd unit per agent | Docker container per agent |
-| Channels | Telegram (enhanced fork with 10 MCP tools) | WhatsApp, Telegram, Slack |
+| Runtime | Stock `claude` CLI | Custom runtime |
+| Channels | Telegram (enhanced fork with 15 MCP tools) | WhatsApp, Telegram, Slack |
 | Memory | Hindsight (semantic, knowledge graph, mental models) | File-based |
-| Scheduling | systemd timers | Built-in cron engine |
+| Scheduling | Cron syntax in YAML, fires across reboots | Built-in cron engine |
 | Sub-agents | Native Claude Code sub-agents | Custom orchestration |
 | Config | YAML with cascade + profiles | JSON/TOML per agent |
 | Install | `switchroom setup` wizard | `docker compose up` |
@@ -34,7 +33,7 @@ Using OAuth also means:
 - No API key sitting on a server that could leak.
 - No separate billing relationship with Anthropic to manage.
 
-## Why `claude` CLI matters
+## Why the stock `claude` CLI matters
 
 OpenClaw re-implements Claude's agent loop in a custom runtime. That means when Anthropic ships a new Claude Code feature (sub-agents, skills, MCP improvements, memory tool, code execution) OpenClaw has to catch up. Switchroom inherits every upstream feature the day it lands, because each agent is literally the `claude` binary.
 
@@ -45,21 +44,21 @@ Examples of upstream features Switchroom gets for free:
 - `--continue` for session continuity
 - Hooks (PreToolUse, PostToolUse, Stop, UserPromptSubmit)
 
-## Why no Docker (per agent) matters
+## What you actually get
 
-Docker-per-agent is fine for isolation but expensive in practice:
-- Container image builds and updates take minutes.
-- Memory overhead per container adds up on a small VPS.
-- Filesystem mounts, networking, and secret injection need per-agent configuration.
-- Debugging requires `docker exec` detours.
+Substrate aside, here's what the product promises:
 
-Switchroom uses systemd units. Starting an agent is `systemctl start switchroom-agent@name`. Logs are `journalctl -u switchroom-agent@name`. Preflight checks catch broken configs before the unit is even loaded. Worktrees handle code isolation when sub-agents need it, without containers.
+- **Long-running service per agent.** Survives reboots, network drops, your laptop closing.
+- **Auto-recovery on crash, with audit trail.** A watchdog catches stuck turns, captures a crash-pane snapshot for forensics, restarts the agent. The agent then runs a wake-audit on boot for owed replies and orphan sub-agents. No silent dropped work.
+- **Per-agent isolated logs you can grep.** One process per agent, one log stream per agent.
+- **Scheduled tasks that fire across reboots.** Cron syntax in YAML, per-task model selection, output to Telegram.
+- **Live progress cards in Telegram.** Pinned per topic, every tool call visible. The headline UX.
 
 ## When OpenClaw might still be the right call
 
 - You need WhatsApp or Slack channels today and don't want to wait for Switchroom to ship them.
 - You specifically want API-key billing for compliance/procurement reasons.
-- You need the custom runtime's behavior for a feature Switchroom doesn't replicate.
+- You need the custom runtime's behaviour for a feature Switchroom doesn't replicate.
 
 ## Migrating from OpenClaw
 

--- a/install.sh
+++ b/install.sh
@@ -24,7 +24,7 @@ die()   { printf '%s✗%s %s\n' "$RED" "$RESET" "$1" >&2; exit 1; }
 
 # ---- preflight ----
 
-[ "$(uname -s)" = "Linux" ] || die "Linux only. Systemd is core to the design; macOS and Windows aren't supported."
+[ "$(uname -s)" = "Linux" ] || die "This installer targets Linux. macOS and Windows hosts aren't supported by this script today (container packaging is on the roadmap — see reference/rfc-docker-multi-container.md)."
 
 have() { command -v "$1" >/dev/null 2>&1; }
 

--- a/profiles/default/CLAUDE.md.hbs
+++ b/profiles/default/CLAUDE.md.hbs
@@ -107,7 +107,7 @@ Use your available tools when appropriate. If you lack the right tool for a task
 
 {{#if schedule}}
 ## Scheduled Tasks
-You have scheduled tasks configured. These run independently as one-shot `claude -p` calls via systemd timers — they don't use your session or context. They fire on their own schedule (typically Sonnet for cost efficiency) and send output directly to Telegram.
+You have scheduled tasks configured. These run independently as one-shot `claude -p` calls on a schedule that fires across reboots. They don't use your session or context, they fire on their own (typically Sonnet for cost efficiency) and send output directly to Telegram.
 
-You don't need to manage them — they're OS-level. If the user asks about scheduled tasks, explain that they run automatically and are configured in switchroom.yaml under `schedule:`.
+You don't need to manage them. If the user asks about scheduled tasks, explain that they run automatically and are configured in switchroom.yaml under `schedule:`.
 {{/if}}

--- a/reference/principles.md
+++ b/reference/principles.md
@@ -101,9 +101,9 @@ is work. Give them the working thing first. Let them tinker later.
 - ❌ **Bad:** Each new agent requires copying ten files of boilerplate
   before it boots.
 
-- ✅ **Good:** `switchroom update` upgrades the CLI, regenerates
-  systemd units, restarts each agent + gateway, and reports done. One
-  command, idempotent.
+- ✅ **Good:** `switchroom update` upgrades the CLI, reconciles each
+  agent's runtime, restarts each agent + gateway, and reports done.
+  One command, idempotent.
 - ❌ **Bad:** "Run `bun run build`, then `systemctl --user
   daemon-reload`, then restart each agent yourself."
 
@@ -165,11 +165,11 @@ asks users to re-learn the product.
   else."
 
 - ✅ **Good:** `switchroom agent restart` always reconciles first
-  (regenerates systemd units + daemon-reload if changed), so a restart
-  is also a mini-deploy. One mental model: *restart = pick up the
-  latest of everything*.
+  (regenerates the runtime config if changed), so a restart is also a
+  mini-deploy. One mental model: *restart = pick up the latest of
+  everything*.
 - ❌ **Bad:** `restart` only restarts the process, `reconcile` only
-  rewrites units, and you have to know which one to run when.
+  rewrites config, and you have to know which one to run when.
 
 - ✅ **Good:** Same Telegram UX surface for every agent — same `/auth`
   router, same progress card, same emoji reactions, same chunking

--- a/reference/principles.md
+++ b/reference/principles.md
@@ -52,7 +52,7 @@ Telegram thread, we've made them do our job.
   as *"⚠ skill `weekly-review` failed: missing `hindsight` MCP. Run
   `switchroom agent reconcile coach` to repair."*
 - ❌ **Bad:** Progress card shows `❌ Error` with no next step and a
-  pointer to `journalctl --user -u switchroom-coach`.
+  pointer to "check the agent logs."
 
 - ✅ **Good:** `switchroom vault set telegram-bot-token` prompts for the
   value, masks input, confirms encryption, and tells the user *"now

--- a/reference/vision.md
+++ b/reference/vision.md
@@ -11,10 +11,10 @@ audience: anyone deciding whether a feature, PR, or release belongs in switchroo
 > already pay for.
 
 Switchroom turns your Claude Pro or Max subscription into a fleet of
-always-on specialist agents you talk to from Telegram. One Linux box,
-one Telegram forum, one bot per agent, every session officially
-authenticated through the same OAuth flow you use on the desktop. No
-API keys. No harness. No second invoice.
+always-on specialist agents you talk to from Telegram. One box you
+already own, one Telegram forum, one bot per agent, every session
+officially authenticated through the same OAuth flow you use on the
+desktop. No API keys. No harness. No second invoice.
 
 It is **not** a general-purpose LLM orchestrator, **not** a multi-channel
 bridge, **not** a hosted service, **not** multi-tenant. It does one
@@ -76,20 +76,22 @@ specialist without leaving the topic.
 > protocol, doesn't forge tokens."*
 
 Switchroom is scaffolding and lifecycle management. It creates
-directories, generates systemd units, manages OAuth, routes Telegram
-messages — and gets out of the way. Each agent runs the unmodified
-`claude` binary, authenticated directly with Anthropic. No Agent SDK,
-no API-key routing, no credential interception. Fully compliant with
-Anthropic's April 2026 third-party policy.
+directories, stands up a long-running service per agent, manages
+OAuth, routes Telegram messages, and gets out of the way. Each agent
+runs the unmodified `claude` binary, authenticated directly with
+Anthropic. No Agent SDK, no API-key routing, no credential
+interception. Fully compliant with Anthropic's April 2026 third-party
+policy.
 
 One bill. The one you already pay.
 
 ### 4. Always-on — *runs while you sleep or work offline*
 
-Agents are systemd user units inside tmux sessions. They survive
-reboots, network drops, and your laptop closing. Scheduled tasks fire
-as systemd user timers. Token refresh runs unattended for weeks. The
-fleet comes back on its own after a cold boot.
+Each agent is a long-running service. They survive reboots, network
+drops, and your laptop closing. Scheduled tasks fire across reboots.
+Token refresh runs unattended for weeks. Crashed agents auto-recover
+with an audit trail. The fleet comes back on its own after a cold
+boot.
 
 Telegram IS the mobile interface. Anywhere your phone has signal, your
 fleet is reachable.
@@ -100,14 +102,14 @@ fleet is reachable.
 
 - **Solo developers** who want Claude in Telegram across devices,
   without giving up their subscription.
-- **Home-lab operators** comfortable with `systemd`, YAML, and a Linux
-  box they already own.
+- **Home-lab operators** comfortable with YAML and a box they already
+  own.
 - **Founder-operators** running a personal fleet of specialists —
   health coach, executive assistant, coding agent, research agent —
   each with its own persona and persistent memory.
 
 Built for people who already run things themselves. Configuration over
-code. Native Linux. Transparency over abstraction.
+code. Transparency over abstraction.
 
 ---
 
@@ -129,8 +131,7 @@ code. Native Linux. Transparency over abstraction.
 Technical, direct, opinionated. Speaks to builders with agency.
 Casual punctuation, assumes infrastructure literacy. Emphasises what
 the product *doesn't* do as much as what it does — because the
-absences (no harness, no API key, no fork, no Docker requirement) are
-the differentiation.
+absences (no harness, no API key, no fork) are the differentiation.
 
 This voice carries into the product surface: CLI output, error
 messages, progress cards, setup wizard. Switchroom should sound like


### PR DESCRIPTION
Removes 'no Docker requirement', 'systemd unit per agent', 'Linux only' style claims from product-facing surfaces (README hero, vision, vs-openclaw/nanoclaw, profiles default CLAUDE.md, install.sh banner). Replaces with JTBD outcomes: long-running service per agent, survives reboots, auto-recovery with audit trail, per-agent logs, stock claude CLI.

Tech detail preserved in deep-tech surfaces (vault broker section, RFCs, repo CLAUDE.md, scheduling docs).

Reviewer: APPROVE with two nits, both addressed (principles.md systemd mentions in check-examples).

Aligns with RFC #795 — product story future-proofs against the substrate migration without prematurely promising Docker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)