### PR TITLE
Phase 2b: approval kernel IPC port — socket-path-resolver client + agent-name ACL

### DIFF
--- a/src/vault/approvals/acl.test.ts
+++ b/src/vault/approvals/acl.test.ts
@@ -1,0 +1,47 @@
+/**
+ * Unit tests for `checkApprovalAclByAgent` — Phase 2b agent-name ACL.
+ */
+
+import { describe, it, expect } from "vitest";
+import { checkApprovalAclByAgent } from "./acl.js";
+
+describe("checkApprovalAclByAgent (Phase 2b)", () => {
+  it("allows when claim matches listener agent", () => {
+    expect(checkApprovalAclByAgent("alice", "alice").allow).toBe(true);
+  });
+
+  it("denies cross-agent claim — alice listener cannot serve bob requests", () => {
+    const r = checkApprovalAclByAgent("alice", "bob");
+    expect(r.allow).toBe(false);
+    if (!r.allow) expect(r.reason).toMatch(/mismatch.*alice.*bob/);
+  });
+
+  it("denies all 6 (i,j i!=j) pairs across alice/bob/carol", () => {
+    const agents = ["alice", "bob", "carol"];
+    for (const i of agents) {
+      for (const j of agents) {
+        if (i === j) {
+          expect(checkApprovalAclByAgent(i, j).allow).toBe(true);
+        } else {
+          expect(checkApprovalAclByAgent(i, j).allow).toBe(false);
+        }
+      }
+    }
+  });
+
+  it("denies an empty listener agent (fail-closed)", () => {
+    const r = checkApprovalAclByAgent("", "alice");
+    expect(r.allow).toBe(false);
+    if (!r.allow) expect(r.reason).toMatch(/no bound agent identity/);
+  });
+
+  it("denies an empty claim", () => {
+    const r = checkApprovalAclByAgent("alice", "");
+    expect(r.allow).toBe(false);
+    if (!r.allow) expect(r.reason).toMatch(/no agent_unit/);
+  });
+
+  it("is case-sensitive — Alice != alice", () => {
+    expect(checkApprovalAclByAgent("alice", "Alice").allow).toBe(false);
+  });
+});

--- a/src/vault/approvals/acl.ts
+++ b/src/vault/approvals/acl.ts
@@ -1,0 +1,58 @@
+/**
+ * Phase 2b — approval kernel ACL by agent name.
+ *
+ * Symmetric with `src/vault/broker/acl.ts:checkAclByAgent` (Phase 2a). The
+ * kernel binds a per-agent listener at `/run/switchroom/kernel/<agent>/sock`
+ * (see `kernel-server.ts`); the listener's bind-time agent name is the
+ * trusted identity for any connection accepted on it. NO wire-payload field
+ * — including `agent_unit` — can override that.
+ *
+ * What this guard checks:
+ *
+ *   - Was the connection accepted on a listener with a known agent name?
+ *     (The kernel-server today rejects unidentified listeners at bind, so
+ *     the runtime invariant is "agentName non-empty by construction" —
+ *     but this helper is fail-closed for tests / future callers that pass
+ *     an empty string.)
+ *
+ *   - Does the wire-claimed `agent_unit` match the listener's agent? When
+ *     they disagree the request is DENIED — the wire claim has no power,
+ *     and we surface the mismatch in the audit row so a forensic reviewer
+ *     can spot misconfigured agent-side code.
+ *
+ * The kernel does NOT carry a per-key allowlist analogous to the broker's
+ * `schedule[i].secrets`. Per-agent isolation IS the security model: every
+ * approval-kernel row is keyed on `agent_unit`, and a listener bound for
+ * `alice` can only ever write `alice` rows. So the ACL surface is just
+ * the name-equality check; once it passes, the kernel.ts code paths
+ * naturally scope their reads/writes to `agent_unit = <listener>`.
+ */
+
+export type ApprovalAclResult =
+  | { allow: true }
+  | { allow: false; reason: string };
+
+export function checkApprovalAclByAgent(
+  listenerAgent: string,
+  claimedAgentUnit: string,
+): ApprovalAclResult {
+  if (!listenerAgent) {
+    return {
+      allow: false,
+      reason: "listener has no bound agent identity (kernel-server bind misconfiguration)",
+    };
+  }
+  if (!claimedAgentUnit) {
+    return {
+      allow: false,
+      reason: "request has no agent_unit; refusing to attribute to listener identity by default",
+    };
+  }
+  if (claimedAgentUnit !== listenerAgent) {
+    return {
+      allow: false,
+      reason: `agent_unit mismatch: socket=${listenerAgent}, claim=${claimedAgentUnit}`,
+    };
+  }
+  return { allow: true };
+}

--- a/src/vault/approvals/client.test.ts
+++ b/src/vault/approvals/client.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Phase 2b — approval-kernel client resolver unit tests.
+ *
+ * The resolver picks where to connect based on opts + env. Pure function;
+ * no socket I/O — that's covered end-to-end by the docker integration
+ * test (tests/docker/phase2b-kernel-ipc.test.ts).
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { resolveKernelSocketPath } from "./client.js";
+
+describe("resolveKernelSocketPath (Phase 2b)", () => {
+  let savedEnv: string | undefined;
+
+  beforeEach(() => {
+    savedEnv = process.env.SWITCHROOM_KERNEL_SOCKET;
+    delete process.env.SWITCHROOM_KERNEL_SOCKET;
+  });
+
+  afterEach(() => {
+    if (savedEnv === undefined) {
+      delete process.env.SWITCHROOM_KERNEL_SOCKET;
+    } else {
+      process.env.SWITCHROOM_KERNEL_SOCKET = savedEnv;
+    }
+  });
+
+  it("returns null when no opts and no env (host mode)", () => {
+    expect(resolveKernelSocketPath()).toBeNull();
+    expect(resolveKernelSocketPath({})).toBeNull();
+  });
+
+  it("prefers explicit opts.socket above all", () => {
+    process.env.SWITCHROOM_KERNEL_SOCKET = "/run/switchroom/kernel/alice/sock";
+    expect(
+      resolveKernelSocketPath({ socket: "/tmp/explicit.sock", kernelSocket: "/tmp/k.sock" }),
+    ).toBe("/tmp/explicit.sock");
+  });
+
+  it("uses SWITCHROOM_KERNEL_SOCKET when no opts.socket", () => {
+    process.env.SWITCHROOM_KERNEL_SOCKET = "/run/switchroom/kernel/alice/sock";
+    expect(resolveKernelSocketPath()).toBe("/run/switchroom/kernel/alice/sock");
+    expect(resolveKernelSocketPath({})).toBe("/run/switchroom/kernel/alice/sock");
+  });
+
+  it("falls through to opts.kernelSocket when env is unset", () => {
+    expect(resolveKernelSocketPath({ kernelSocket: "/tmp/k.sock" })).toBe(
+      "/tmp/k.sock",
+    );
+  });
+
+  it("treats empty SWITCHROOM_KERNEL_SOCKET as unset (host mode)", () => {
+    process.env.SWITCHROOM_KERNEL_SOCKET = "";
+    expect(resolveKernelSocketPath()).toBeNull();
+    expect(resolveKernelSocketPath({ kernelSocket: "/tmp/k.sock" })).toBe(
+      "/tmp/k.sock",
+    );
+  });
+
+  it("env beats kernelSocket — docker overrides programmatic default", () => {
+    process.env.SWITCHROOM_KERNEL_SOCKET = "/run/switchroom/kernel/alice/sock";
+    expect(
+      resolveKernelSocketPath({ kernelSocket: "/tmp/programmatic.sock" }),
+    ).toBe("/run/switchroom/kernel/alice/sock");
+  });
+});

--- a/src/vault/approvals/client.ts
+++ b/src/vault/approvals/client.ts
@@ -17,6 +17,66 @@ import type {
   ApprovalDecisionMode,
 } from "../broker/protocol.js";
 
+/**
+ * Phase 2b — approval-kernel socket resolver.
+ *
+ * The approval kernel runs as its own container under docker (Phase 1c
+ * shipped `kernel-server.ts`). Each agent container has a per-agent kernel
+ * socket bind-mounted at `/run/switchroom/kernel/<agent>/sock`, and the
+ * compose generator injects this path as `SWITCHROOM_KERNEL_SOCKET` into
+ * every agent's environment block (see src/agents/compose.ts).
+ *
+ * Resolution order — first match wins:
+ *   1. Explicit `opts.socket` — caller-supplied override, e.g. integration
+ *      tests pointing at a host-bind-mounted kernel socket.
+ *   2. `SWITCHROOM_KERNEL_SOCKET` env — set by the docker compose generator
+ *      inside agent containers (Phase 2b runtime). Identifies the kernel
+ *      container as the target, distinct from the broker.
+ *   3. `opts.kernelSocket` — programmatic override matching docker's env
+ *      shape; useful for in-process callers that aren't going through env.
+ *   4. `null` — host-mode fallback. Caller does NOT receive a kernel-
+ *      specific socket; subsequent `rpcRaw` falls through to the legacy
+ *      broker socket resolver, preserving today's host-native behaviour
+ *      where broker and kernel-ish ops share a socket.
+ *
+ * IMPORTANT: this resolver returns null in host mode (case 4). Callers
+ * should pass-through opts unchanged to `rpcRaw` so the broker resolver
+ * picks up. This preserves "host-mode behaviour unchanged" — no callers
+ * outside docker need to set anything.
+ */
+export interface ApprovalKernelClientOpts extends BrokerClientOpts {
+  /**
+   * Override path for the approval kernel socket. Mirrors the env shape
+   * (`SWITCHROOM_KERNEL_SOCKET`) for callers who want to set it in code
+   * rather than via the environment.
+   */
+  kernelSocket?: string;
+}
+
+export function resolveKernelSocketPath(
+  opts?: ApprovalKernelClientOpts,
+): string | null {
+  if (opts?.socket) return opts.socket;
+  const env = process.env.SWITCHROOM_KERNEL_SOCKET;
+  if (env && env.length > 0) return env;
+  if (opts?.kernelSocket) return opts.kernelSocket;
+  return null;
+}
+
+/**
+ * Build the rpcRaw opts for an approval call. When a kernel-specific
+ * socket is in scope (docker mode), we set `opts.socket` to it so rpcRaw
+ * connects to the kernel container; otherwise we forward opts unchanged
+ * so the broker resolver applies (host mode, unchanged behaviour).
+ */
+function withKernelOpts(
+  opts?: ApprovalKernelClientOpts,
+): BrokerClientOpts | undefined {
+  const sock = resolveKernelSocketPath(opts);
+  if (sock === null) return opts;
+  return { ...(opts ?? {}), socket: sock };
+}
+
 export interface ApprovalRequestArgs {
   agent_unit: string;
   scope: string;
@@ -53,7 +113,7 @@ export interface ApprovalConsumeResult {
 
 export async function approvalRequest(
   args: ApprovalRequestArgs,
-  opts?: BrokerClientOpts,
+  opts?: ApprovalKernelClientOpts,
 ): Promise<ApprovalRequestResult | null> {
   const r = await rpcRaw(
     {
@@ -66,7 +126,7 @@ export async function approvalRequest(
       why: args.why,
       ttl_ms: args.ttl_ms,
     },
-    opts,
+    withKernelOpts(opts),
   );
   if (r.kind !== "response" || !r.resp.ok) return null;
   if (!("kind" in r.resp) || r.resp.kind !== "approval_request") return null;
@@ -87,7 +147,7 @@ export async function approvalLookup(
     action: string;
     current_approver_set: string[];
   },
-  opts?: BrokerClientOpts,
+  opts?: ApprovalKernelClientOpts,
 ): Promise<ApprovalLookupResult | null> {
   const r = await rpcRaw(
     {
@@ -98,7 +158,7 @@ export async function approvalLookup(
       action: args.action,
       current_approver_set: args.current_approver_set,
     },
-    opts,
+    withKernelOpts(opts),
   );
   if (r.kind !== "response" || !r.resp.ok) return null;
   if (!("state" in r.resp) || typeof r.resp.state !== "string") return null;
@@ -121,9 +181,9 @@ export async function approvalLookup(
 
 export async function approvalConsume(
   request_id: string,
-  opts?: BrokerClientOpts,
+  opts?: ApprovalKernelClientOpts,
 ): Promise<ApprovalConsumeResult | null> {
-  const r = await rpcRaw({ v: 1, op: "approval_consume", request_id }, opts);
+  const r = await rpcRaw({ v: 1, op: "approval_consume", request_id }, withKernelOpts(opts));
   if (r.kind !== "response" || !r.resp.ok) return null;
   if (!("consumed" in r.resp)) return null;
   return {
@@ -139,11 +199,11 @@ export async function approvalRevoke(
   decision_id: string,
   actor: string,
   reason?: string,
-  opts?: BrokerClientOpts,
+  opts?: ApprovalKernelClientOpts,
 ): Promise<boolean | null> {
   const r = await rpcRaw(
     { v: 1, op: "approval_revoke", decision_id, actor, reason },
-    opts,
+    withKernelOpts(opts),
   );
   if (r.kind !== "response" || !r.resp.ok) return null;
   if (!("revoked" in r.resp)) return null;
@@ -158,7 +218,7 @@ export async function approvalRecord(
     granted_by_user_id: number;
     ttl_ms?: number | null;
   },
-  opts?: BrokerClientOpts,
+  opts?: ApprovalKernelClientOpts,
 ): Promise<string | null> {
   const r = await rpcRaw(
     {
@@ -170,7 +230,7 @@ export async function approvalRecord(
       granted_by_user_id: args.granted_by_user_id,
       ttl_ms: args.ttl_ms ?? null,
     },
-    opts,
+    withKernelOpts(opts),
   );
   if (r.kind !== "response" || !r.resp.ok) return null;
   if (!("decision_id" in r.resp)) return null;
@@ -179,9 +239,9 @@ export async function approvalRecord(
 
 export async function approvalList(
   agent_unit?: string,
-  opts?: BrokerClientOpts,
+  opts?: ApprovalKernelClientOpts,
 ): Promise<ApprovalDecisionMeta[] | null> {
-  const r = await rpcRaw({ v: 1, op: "approval_list", agent_unit }, opts);
+  const r = await rpcRaw({ v: 1, op: "approval_list", agent_unit }, withKernelOpts(opts));
   if (r.kind !== "response" || !r.resp.ok) return null;
   if (!("decisions" in r.resp)) return null;
   return r.resp.decisions as ApprovalDecisionMeta[];

--- a/src/vault/approvals/kernel-server.ts
+++ b/src/vault/approvals/kernel-server.ts
@@ -61,6 +61,8 @@ import {
 } from "./kernel.js";
 import { migrateApprovalSchema } from "./schema.js";
 import { allocateAgentUid } from "../../agents/compose.js";
+import { checkApprovalAclByAgent } from "./acl.js";
+import { getPeerCred } from "../broker/peercred-ffi.js";
 
 const DEFAULT_SOCKET_PARENT = "/run/switchroom/kernel";
 const DEFAULT_DB_PATH = "/state/approvals/kernel.db";
@@ -155,6 +157,20 @@ function handleConnection(
   // `agent` is the trusted identity — it came from the listener's directory
   // name, established at bind time before the connection existed. No
   // wire-payload field can override this.
+  //
+  // Phase 2b: capture SO_PEERCRED UID once at accept(2) time. Forensic only
+  // — never used to gate ACL. Best-effort: getPeerCred returns null on
+  // non-Linux or when the FFI symbol isn't available.
+  let peerUid: number | null = null;
+  try {
+    type SocketWithFd = net.Socket & { _handle?: { fd?: number } };
+    const fd = (socket as SocketWithFd)._handle?.fd;
+    if (typeof fd === "number" && fd >= 0) {
+      const cred = getPeerCred(fd);
+      if (cred !== null) peerUid = cred.uid;
+    }
+  } catch { /* best-effort; ACL doesn't depend on this */ }
+
   let buffer = "";
   socket.on("data", (chunk: Buffer) => {
     buffer += chunk.toString("utf8");
@@ -176,7 +192,7 @@ function handleConnection(
         continue;
       }
       try {
-        handleRequest(socket, req, agent, db);
+        handleRequest(socket, req, agent, db, peerUid);
       } catch (err) {
         socket.write(encodeResponse(errorResponse("INTERNAL", (err as Error).message)));
       }
@@ -190,13 +206,15 @@ function handleRequest(
   req: BrokerRequest,
   agent: string,
   db: Database,
+  peerUid: number | null,
 ): void {
   // Only approval ops are served here. Anything else (vault_get, list_grants,
   // etc.) is the broker's territory and gets a hard error.
   if (req.op === "approval_request") {
-    // Identity guard: reject any wire claim that doesn't match this listener.
-    if (req.agent_unit !== agent) {
-      socket.write(encodeResponse(errorResponse("DENIED", `agent_unit mismatch: socket=${agent}, claim=${req.agent_unit}`)));
+    // Phase 2b — explicit ACL gate by listener-bound agent name.
+    const acl = checkApprovalAclByAgent(agent, req.agent_unit);
+    if (!acl.allow) {
+      socket.write(encodeResponse(errorResponse("DENIED", acl.reason)));
       return;
     }
     const counts = countPendingNonces(db);
@@ -216,6 +234,9 @@ function handleRequest(
       approver_set: req.approver_set,
       why: req.why,
       ttl_ms: req.ttl_ms,
+      // Phase 2b — additive audit context, no schema migration.
+      ...(peerUid !== null ? { peer_uid: peerUid } : {}),
+      agent_name: agent,
     });
     socket.write(encodeResponse({
       ok: true,
@@ -227,8 +248,9 @@ function handleRequest(
     return;
   }
   if (req.op === "approval_lookup") {
-    if (req.agent_unit !== agent) {
-      socket.write(encodeResponse(errorResponse("DENIED", `agent_unit mismatch`)));
+    const acl = checkApprovalAclByAgent(agent, req.agent_unit);
+    if (!acl.allow) {
+      socket.write(encodeResponse(errorResponse("DENIED", acl.reason)));
       return;
     }
     const r = lookupDecision(db, {

--- a/src/vault/approvals/kernel.ts
+++ b/src/vault/approvals/kernel.ts
@@ -30,6 +30,21 @@ export interface ApprovalRequestInput {
   approver_set: string[];   // current allowFrom; canonicalized + stored on grant
   why?: string;
   ttl_ms?: number;          // nonce expiry; defaults to 5 minutes per §8.1
+  /**
+   * Phase 2b — optional informational fields populated by the kernel-server
+   * IPC entrypoint (kernel-server.ts). Both flow into the `approval_audit`
+   * row's `context` JSON blob — additive, NO schema migration.
+   *
+   * `peer_uid` — SO_PEERCRED UID captured at accept(2). Forensic only;
+   * never used to gate ACL (agent identity is the listener's socket path).
+   *
+   * `agent_name` — agent slug derived from the listener's socket-dir,
+   * matching what the kernel-server bound at startup. When present, this
+   * is the trusted identity used for the ACL decision; any mismatch with
+   * agent_unit is rejected upstream by checkApprovalAclByAgent.
+   */
+  peer_uid?: number;
+  agent_name?: string;
 }
 
 export interface RequestApprovalResult {
@@ -217,7 +232,13 @@ export function requestApproval(
     agent_unit: input.agent_unit,
     scope: input.scope,
     action: input.action,
-    context: { request_id, why: input.why },
+    context: {
+      request_id,
+      why: input.why,
+      // Phase 2b additive fields — only present on the docker IPC path.
+      ...(input.peer_uid !== undefined ? { peer_uid: input.peer_uid } : {}),
+      ...(input.agent_name !== undefined ? { agent_name: input.agent_name } : {}),
+    },
   });
 
   return { request_id, expires_at };

--- a/tests/docker/phase2b-kernel-ipc.test.ts
+++ b/tests/docker/phase2b-kernel-ipc.test.ts
@@ -1,0 +1,456 @@
+/**
+ * Phase 2b — approval kernel IPC integration test (socket-path-as-identity).
+ *
+ * Acceptance criteria (RFC §Phase 2):
+ *
+ *   1. Three agents — alice / bob / carol — each connect on their own
+ *      per-agent kernel socket (/run/switchroom/kernel/<agent>/sock inside
+ *      the kernel container; bound by kernel-server at boot). Each agent's
+ *      `approval_request` for its own agent_unit is accepted; cross-agent
+ *      claims are DENIED.
+ *
+ *   2. Cross-agent denial matrix: 6 (i,j i!=j) pairs across alice/bob/carol
+ *      all return { ok:false, error:"DENIED", message:/mismatch/ }. Identity
+ *      comes from the listener's directory; nothing on the wire can override.
+ *
+ *   3. waitForApproval-style short-poll works end-to-end across the
+ *      container boundary: client sends approval_request, server returns
+ *      a request_id, client lookups by (agent_unit, scope, action) and
+ *      sees `state: pending` while the nonce is unconsumed.
+ *
+ *   4. Schema-stability invariant: kernel.db PRAGMA schema_version is
+ *      identical pre and post the test traffic. NO migration runs as part
+ *      of Phase 2b.
+ *
+ *   5. Production-host safety: every container carries
+ *      `switchroom.test=phase2b` + a per-run UUID. Teardown is exclusively
+ *      label-filtered. Pre/post sudo-docker-ps snapshots are diffed and any
+ *      production drift is logged loudly. The Coolify et al. containers
+ *      MUST be untouched.
+ *
+ * Skip discipline: cleanly skipped when docker is unreachable OR the
+ * phase2b-test kernel image isn't built. Build instructions are in the
+ * skip-sentinel `it()` body.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { execSync, spawnSync } from "node:child_process";
+import {
+  mkdtempSync,
+  rmSync,
+  mkdirSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { connect } from "node:net";
+import { randomUUID } from "node:crypto";
+
+// ─── Phase 2b label helpers ───────────────────────────────────────────────────
+//
+// _label-helpers.ts hard-codes "phase1c" — same rationale as Phase 2a, we
+// override locally rather than churn the shared helper. Per-run UUID still
+// flows through. NEVER touches non-phase2b containers.
+const RUN_ID = randomUUID();
+const PHASE_LABEL = "switchroom.test=phase2b";
+
+function labelArgv(): string[] {
+  return [
+    "--label", PHASE_LABEL,
+    "--label", `switchroom.test.run=${RUN_ID}`,
+  ];
+}
+
+function safeLabelTeardownPhase2b(): void {
+  for (const filter of [
+    `label=switchroom.test.run=${RUN_ID}`,
+    PHASE_LABEL,
+  ]) {
+    try {
+      const ids = execSync(`docker ps -aq --filter ${filter}`, {
+        stdio: ["ignore", "pipe", "ignore"],
+      })
+        .toString()
+        .trim();
+      if (ids.length === 0) continue;
+      execSync(`docker rm -f ${ids.split(/\s+/).join(" ")}`, { stdio: "ignore" });
+    } catch {
+      /* best-effort */
+    }
+  }
+}
+
+// ─── Image presence ───────────────────────────────────────────────────────────
+
+const KERNEL_IMAGE = "switchroom/kernel:phase2b-test";
+
+function hasDocker(): boolean {
+  try {
+    execSync("docker version --format '{{.Server.Version}}'", {
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+function hasImage(ref: string): boolean {
+  try {
+    execSync(`docker image inspect ${ref}`, { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+const dockerOk = hasDocker();
+const imageOk = dockerOk && hasImage(KERNEL_IMAGE);
+
+// ─── Fixture ──────────────────────────────────────────────────────────────────
+
+interface Fixture {
+  workdir: string;
+  socketParent: string; // host path mounted at /run/switchroom/kernel
+  stateDir: string; // host path mounted at /state/approvals
+  containerName: string;
+  initialSchemaVersion: number | null;
+  prodSnapshot: string;
+}
+
+let fx: Fixture | null = null;
+
+const AGENTS = ["alice", "bob", "carol"];
+
+function snapshotProductionContainers(): string {
+  try {
+    return execSync(
+      "sudo docker ps --no-trunc --format '{{.Names}}|{{.ID}}|{{.Status}}'",
+      { stdio: ["ignore", "pipe", "pipe"] },
+    ).toString();
+  } catch {
+    try {
+      return execSync(
+        "docker ps --no-trunc --format '{{.Names}}|{{.ID}}|{{.Status}}'",
+        { stdio: ["ignore", "pipe", "pipe"] },
+      ).toString();
+    } catch {
+      return "";
+    }
+  }
+}
+
+/**
+ * Read PRAGMA schema_version from the kernel.db inside the container.
+ * Returns null if the DB hasn't been opened yet.
+ */
+function readKernelSchemaVersion(containerName: string): number | null {
+  const dbPath = "/state/approvals/kernel.db";
+  try {
+    const out = execSync(
+      `docker exec ${containerName} bun -e ` +
+        `'const{Database}=require("bun:sqlite");` +
+        `const db=new Database("${dbPath}",{readonly:true});` +
+        `const row=db.query("PRAGMA schema_version").get();` +
+        `console.log(row.schema_version);'`,
+      { stdio: ["ignore", "pipe", "pipe"], encoding: "utf8" },
+    ).trim();
+    const n = Number.parseInt(out, 10);
+    return Number.isFinite(n) ? n : null;
+  } catch {
+    return null;
+  }
+}
+
+beforeAll(() => {
+  if (!imageOk) return;
+
+  const prodSnapshot = snapshotProductionContainers();
+
+  const workdir = mkdtempSync(join(tmpdir(), "phase2b-kernel-"));
+  const socketParent = join(workdir, "kernel-sockets");
+  const stateDir = join(workdir, "approvals-state");
+  mkdirSync(socketParent, { recursive: true, mode: 0o755 });
+  mkdirSync(stateDir, { recursive: true, mode: 0o755 });
+
+  // Pre-create per-agent subdirs at the socket parent. The kernel-server's
+  // boot-time agent enumeration walks readdirSync(socketParent) and binds
+  // one listener per subdirectory. Without these the server falls through
+  // to single-socket fallback mode (not what we want to test).
+  for (const a of AGENTS) {
+    mkdirSync(join(socketParent, a), { recursive: true, mode: 0o755 });
+  }
+
+  const containerName = `switchroom-phase2b-kernel-${process.pid}-${RUN_ID.slice(0, 8)}`;
+  // Idempotent best-effort cleanup.
+  try {
+    execSync(`docker rm -f ${containerName}`, { stdio: "ignore" });
+  } catch {
+    /* */
+  }
+
+  const runArgs = [
+    "run",
+    "-d",
+    "--name", containerName,
+    ...labelArgv(),
+    "--user", "0:0",
+    "-v", `${socketParent}:/run/switchroom/kernel`,
+    "-v", `${stateDir}:/state/approvals`,
+    "-e", "SWITCHROOM_KERNEL_DB_PATH=/state/approvals/kernel.db",
+    "-e", "SWITCHROOM_KERNEL_SOCKET=/run/switchroom/kernel/approval-kernel.sock",
+    KERNEL_IMAGE,
+  ];
+  const r = spawnSync("docker", runArgs, { encoding: "utf8" });
+  if (r.status !== 0) {
+    throw new Error(
+      `docker run failed (status=${r.status}): ${r.stderr}\n` +
+      `args: ${runArgs.join(" ")}`,
+    );
+  }
+
+  // Wait for per-agent sockets to bind.
+  const deadline = Date.now() + 15_000;
+  while (Date.now() < deadline) {
+    const allBound = AGENTS.every((a) => {
+      try {
+        const out = execSync(
+          `docker exec ${containerName} stat -c '%F' /run/switchroom/kernel/${a}/sock`,
+          { stdio: ["ignore", "pipe", "ignore"] },
+        ).toString();
+        return out.includes("socket");
+      } catch {
+        return false;
+      }
+    });
+    if (allBound) break;
+    execSync("sleep 0.5");
+  }
+
+  // Open up modes for host-side connections (test-only). In production each
+  // socket is 0660 owned by the agent UID; the host uid here (1000) needs
+  // 0666 to connect via the bind-mount. Production identity is enforced by
+  // the listener's bound directory name, NOT the file mode.
+  try {
+    execSync(
+      `docker exec ${containerName} sh -c 'chmod 0666 /run/switchroom/kernel/*/sock && chmod 0755 /run/switchroom/kernel/*'`,
+      { stdio: "ignore" },
+    );
+  } catch {
+    /* */
+  }
+
+  fx = {
+    workdir,
+    socketParent,
+    stateDir,
+    containerName,
+    initialSchemaVersion: readKernelSchemaVersion(containerName),
+    prodSnapshot,
+  };
+}, 90_000);
+
+afterAll(() => {
+  if (fx) {
+    try {
+      execSync(`docker rm -f ${fx.containerName}`, { stdio: "ignore" });
+    } catch {
+      /* */
+    }
+    safeLabelTeardownPhase2b();
+    try {
+      rmSync(fx.workdir, { recursive: true, force: true });
+    } catch {
+      /* */
+    }
+
+    // Production-host safety check.
+    const after = snapshotProductionContainers();
+    const filterPhase = (s: string): string =>
+      s.split("\n")
+        .filter((l) => l && !l.includes("phase2b"))
+        .sort()
+        .join("\n");
+    const beforeFiltered = filterPhase(fx.prodSnapshot);
+    const afterFiltered = filterPhase(after);
+    if (beforeFiltered !== afterFiltered) {
+      // eslint-disable-next-line no-console
+      console.error(
+        `[phase2b teardown] PRODUCTION CONTAINER DRIFT DETECTED:\n` +
+        `BEFORE:\n${beforeFiltered}\n` +
+        `AFTER:\n${afterFiltered}`,
+      );
+    }
+  }
+}, 60_000);
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function ndjsonOnce(socketPath: string, payload: object, timeoutMs = 4000): Promise<unknown> {
+  return new Promise((resolveP, rejectP) => {
+    const c = connect(socketPath);
+    let buf = "";
+    const timer = setTimeout(() => {
+      c.destroy();
+      rejectP(new Error(`timeout after ${timeoutMs}ms on ${socketPath}`));
+    }, timeoutMs);
+    c.on("connect", () => {
+      c.write(JSON.stringify(payload) + "\n");
+    });
+    c.on("data", (chunk) => {
+      buf += chunk.toString("utf8");
+      const nl = buf.indexOf("\n");
+      if (nl !== -1) {
+        clearTimeout(timer);
+        const line = buf.slice(0, nl);
+        c.destroy();
+        try {
+          resolveP(JSON.parse(line));
+        } catch (e) {
+          rejectP(new Error(`parse error: ${(e as Error).message} for line: ${line}`));
+        }
+      }
+    });
+    c.on("error", (err) => {
+      clearTimeout(timer);
+      rejectP(err);
+    });
+  });
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe.skipIf(!imageOk)(
+  "phase2b — kernel IPC with socket-path-as-identity",
+  () => {
+    it(
+      "each agent's per-agent kernel socket accepts only its own agent_unit; cross-agent denied",
+      async () => {
+        if (!fx) throw new Error("fixture not initialized");
+
+        // Step 1: each agent CAN open an approval_request for itself.
+        const requestIds = new Map<string, string>();
+        for (const a of AGENTS) {
+          const sock = join(fx.socketParent, a, "sock");
+          const resp = (await ndjsonOnce(sock, {
+            v: 1,
+            op: "approval_request",
+            agent_unit: a,
+            scope: `secret:${a.toUpperCase()}_KEY`,
+            action: "read",
+            approver_set: ["operator"],
+            why: `phase2b smoke test for ${a}`,
+            ttl_ms: 60_000,
+          })) as {
+            ok: boolean;
+            kind?: string;
+            state?: string;
+            request_id?: string;
+            expires_at?: number;
+          };
+          expect(resp.ok).toBe(true);
+          expect(resp.kind).toBe("approval_request");
+          expect(resp.state).toBe("pending");
+          expect(typeof resp.request_id).toBe("string");
+          expect((resp.request_id ?? "").length).toBeGreaterThan(0);
+          requestIds.set(a, resp.request_id ?? "");
+        }
+
+        // Step 2: cross-agent denial matrix — all 6 (i,j i!=j) pairs.
+        const denials: Array<{ requester: string; target: string; ok: boolean; code: string | undefined; msg: string | undefined }> = [];
+        for (const requester of AGENTS) {
+          for (const target of AGENTS) {
+            if (requester === target) continue;
+            const sock = join(fx.socketParent, requester, "sock");
+            const resp = (await ndjsonOnce(sock, {
+              v: 1,
+              op: "approval_request",
+              agent_unit: target, // claim target's identity over requester's socket
+              scope: `secret:${target.toUpperCase()}_KEY`,
+              action: "read",
+              approver_set: ["operator"],
+            })) as { ok: boolean; code?: string; msg?: string };
+            denials.push({
+              requester,
+              target,
+              ok: resp.ok,
+              code: resp.code,
+              msg: resp.msg,
+            });
+            expect(resp.ok).toBe(false);
+            expect(resp.code).toBe("DENIED");
+            expect(resp.msg ?? "").toMatch(/mismatch/i);
+          }
+        }
+        // Sanity — exactly 6 denials with the right shape.
+        expect(denials).toHaveLength(6);
+
+        // Step 3: short-poll lookup works end-to-end. After step 1, each
+        // agent has a pending nonce; lookup with a matching scope+action
+        // should NOT yet return granted (no consume + record happened).
+        for (const a of AGENTS) {
+          const sock = join(fx.socketParent, a, "sock");
+          const resp = (await ndjsonOnce(sock, {
+            v: 1,
+            op: "approval_lookup",
+            agent_unit: a,
+            scope: `secret:${a.toUpperCase()}_KEY`,
+            action: "read",
+            current_approver_set: ["operator"],
+          })) as { ok: boolean; state?: string };
+          expect(resp.ok).toBe(true);
+          // Without a recorded decision the kernel returns no_decision.
+          // (`pending` only surfaces when callers query a by-id path; this
+          // op queries by (agent, scope, action) and reports decision
+          // state, not nonce state.)
+          expect(["no_decision", "pending"]).toContain(resp.state);
+        }
+      },
+      90_000,
+    );
+
+    it(
+      "schema-stability invariant — kernel.db PRAGMA schema_version unchanged",
+      () => {
+        if (!fx) throw new Error("fixture not initialized");
+        const after = readKernelSchemaVersion(fx.containerName);
+        if (fx.initialSchemaVersion !== null && after !== null) {
+          expect(after).toBe(fx.initialSchemaVersion);
+        } else {
+          expect(fx.initialSchemaVersion).toBe(after);
+        }
+      },
+      30_000,
+    );
+
+    it(
+      "non-approval ops are rejected — kernel does not serve broker ops",
+      async () => {
+        if (!fx) throw new Error("fixture not initialized");
+        const sock = join(fx.socketParent, "alice", "sock");
+        const resp = (await ndjsonOnce(sock, {
+          v: 1,
+          op: "get",
+          key: "alice_key",
+        })) as { ok: boolean; code?: string; msg?: string };
+        expect(resp.ok).toBe(false);
+        // The kernel-server returns BAD_REQUEST for non-approval ops.
+        // (Decoder may also reject upstream — accept either shape.)
+        expect(["BAD_REQUEST", "DENIED"]).toContain(resp.code);
+      },
+      30_000,
+    );
+  },
+);
+
+describe.skipIf(imageOk)(
+  "phase2b — sentinel (image not built)",
+  () => {
+    it("documents the build instruction visible to operators", () => {
+      const reason = !dockerOk
+        ? "docker daemon unreachable"
+        : `image ${KERNEL_IMAGE} not built — build with:\n` +
+          `  npm run build\n` +
+          `  docker buildx build --build-arg BASE_IMAGE=switchroom/base:phase1b-test \\\n` +
+          `    -t ${KERNEL_IMAGE} -f docker/Dockerfile.kernel --load .`;
+      expect(reason).toBeTruthy();
+    });
+  },
+);


### PR DESCRIPTION
## Summary

Phase 2b of the Docker multi-container migration (RFC §Phase 2). Mirrors
Phase 2a's broker IPC port, applied to the approval kernel:

- **Client socket-path resolver** (`src/vault/approvals/client.ts`):
  approval RPC calls now route to the kernel container's per-agent
  socket when `SWITCHROOM_KERNEL_SOCKET` is set in the environment
  (compose generator already injects this — Phase 1c). Host-mode
  callers are unchanged: when the env is unset, opts pass through
  unmodified and `rpcRaw` falls back to the broker socket. New
  `ApprovalKernelClientOpts` extends `BrokerClientOpts` with a
  programmatic `kernelSocket` override.

- **Kernel ACL by agent name** (`src/vault/approvals/acl.ts`):
  `checkApprovalAclByAgent(listenerAgent, claimedAgentUnit)` — symmetric
  with `src/vault/broker/acl.ts:checkAclByAgent`. Agent identity is the
  listener's bind-time directory name; the wire-claimed `agent_unit`
  must match. Pure function, fail-closed on empty inputs. Wired into
  `kernel-server.ts`, replacing the inline name-equality guard.

- **Audit additive fields** (`src/vault/approvals/kernel.ts`):
  `ApprovalRequestInput` now optionally carries `peer_uid` + `agent_name`,
  populated by `kernel-server.ts` from SO_PEERCRED + the listener's
  bound agent. Both flow into the existing `approval_audit.context` JSON
  blob — **no schema migration**. `peer_uid` is forensic only; never
  used to gate ACL.

## Files

- `src/vault/approvals/client.ts` — resolver + opts widening + 6 call-site updates
- `src/vault/approvals/client.test.ts` — 6 resolver unit tests
- `src/vault/approvals/acl.ts` — new `checkApprovalAclByAgent`
- `src/vault/approvals/acl.test.ts` — 6 ACL unit tests (incl. full 9-cell i,j matrix)
- `src/vault/approvals/kernel.ts` — additive `peer_uid` / `agent_name` on `ApprovalRequestInput` + audit context
- `src/vault/approvals/kernel-server.ts` — peer_uid capture, threaded into `requestApproval`, ACL helper wired
- `tests/docker/phase2b-kernel-ipc.test.ts` — 3-agent integration test (alice/bob/carol)

## Test evidence

Approval suites (host mode):
```
$ bun test src/vault/approvals/
 42 pass / 0 fail / 106 expect()
```

Resolver + ACL units (vitest):
```
$ bun run test:vitest -- src/vault/approvals/client.test.ts src/vault/approvals/acl.test.ts
 12 passed (12)
```

Phase 2b integration test:
```
$ bun run test:vitest -- tests/docker/phase2b-kernel-ipc
 3 passed | 1 skipped (4)
```

Phase 2a still green (no regression):
```
$ bun run test:vitest -- tests/docker/phase2a-broker-ipc
 3 passed | 1 skipped (4)
```

Cross-agent denial matrix (verified by integration test):
```
alice→bob   DENIED  (mismatch: socket=alice, claim=bob)
alice→carol DENIED  (mismatch: socket=alice, claim=carol)
bob→alice   DENIED
bob→carol   DENIED
carol→alice DENIED
carol→bob   DENIED
alice→alice ALLOWED  (state=pending)
bob→bob     ALLOWED
carol→carol ALLOWED
```

## Schema stability

`PRAGMA schema_version` of `kernel.db` is asserted equal pre/post the
integration test traffic. NO migration runs as part of Phase 2b — all
additive audit fields go into the existing `approval_audit.context`
JSON column.

## Production-host safety

Pre/post `sudo docker ps` snapshot was captured. Zero phase2b-labeled
containers remain after teardown:
```
$ sudo docker ps -a --filter label=switchroom.test=phase2b
CONTAINER ID   IMAGE     COMMAND   CREATED   STATUS    PORTS     NAMES
(empty)
```

The 25 production containers on the test host (Coolify et al., hindsight,
nginx-tunnel-gateway, all 9 Coolify-managed apps) are untouched. Test
discipline: every container carries `switchroom.test=phase2b` plus the
per-run UUID. Teardown via named `docker rm -f <name>` plus
`safeLabelTeardownPhase2b` (label-filtered) belt + braces — never `docker
ps -a | xargs`, never `prune`.

## Test plan

- [x] Existing approval suites pass (`bun test src/vault/approvals/` — 42/42)
- [x] New resolver unit tests cover host mode + opts.socket + env + kernelSocket precedence (6/6)
- [x] New ACL unit tests cover the full 9-cell same/cross-agent matrix + empty-input fail-closed (6/6)
- [x] Integration test 3-agent fleet runs end-to-end across the container boundary
- [x] All 6 (i,j i!=j) cross-agent denial pairs verified
- [x] `waitForApproval`-style short-poll lookup round-trips
- [x] kernel.db PRAGMA schema_version unchanged pre/post
- [x] No phase2b containers left on host after teardown
- [x] Phase 2a integration test still passes (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)