### PR TITLE
Phase 3a-1: import.meta.url sweep + entry-guard hardening (restores lost fork-PR #26 fix)

### DIFF
--- a/src/scheduler/index.ts
+++ b/src/scheduler/index.ts
@@ -138,7 +138,16 @@ export async function main(): Promise<void> {
   process.on("SIGINT", shutdown);
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+// Entry guard — only run main() when this file is invoked directly as the
+// scheduler bundle (dist/scheduler/index.js or src/scheduler/index.ts).
+// Without the filename check, when this module is bundled INTO another
+// entry point (e.g. dist/cli/switchroom.js), bun's bundler rewrites
+// `import.meta.url` to point at the OUTPUT bundle and the naive
+// comparison fires for any CLI invocation. See PR #807 / Phase 3a CI fix.
+if (
+  import.meta.url === `file://${process.argv[1]}` &&
+  /(?:^|[/\\])scheduler[/\\]index\.(?:js|ts)$/.test(process.argv[1] ?? "")
+) {
   main().catch((err) => {
     process.stderr.write(`scheduler fatal: ${err instanceof Error ? err.stack : err}\n`);
     process.exit(1);

--- a/src/vault/approvals/kernel-server.ts
+++ b/src/vault/approvals/kernel-server.ts
@@ -466,7 +466,18 @@ function registerShutdown(stop: () => void): void {
   process.on("SIGINT", handler);
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+// Entry guard — only run main() when this file is invoked directly as the
+// approval-kernel bundle (dist/vault/approvals/kernel-server.js or src/vault/
+// approvals/kernel-server.ts). Without the filename check, when this module
+// is bundled INTO another entry point (e.g. dist/cli/switchroom.js), bun's
+// bundler rewrites `import.meta.url` to point at the OUTPUT bundle and the
+// naive comparison fires for any CLI invocation. See PR #807 / Phase 3a CI fix.
+if (
+  import.meta.url === `file://${process.argv[1]}` &&
+  /(?:^|[/\\])(?:vault[/\\]approvals[/\\])?kernel-server\.(?:js|ts)$/.test(
+    process.argv[1] ?? "",
+  )
+) {
   main().catch((err) => {
     process.stderr.write(`approval-kernel fatal: ${err instanceof Error ? err.stack : err}\n`);
     process.exit(1);

--- a/src/vault/broker/server.ts
+++ b/src/vault/broker/server.ts
@@ -1703,7 +1703,21 @@ export async function main(): Promise<void> {
   );
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+// Entry guard — only run main() when this file is invoked directly as the
+// broker server bundle (dist/vault/broker/server.js or src/vault/broker/
+// server.ts). The naive `import.meta.url === file://${process.argv[1]}`
+// guard fires spuriously when this module is bundled INTO another entry
+// point (e.g. dist/cli/switchroom.js): bun's bundler rewrites
+// `import.meta.url` to point at the OUTPUT bundle, so the comparison
+// matches argv[1] for any CLI invocation and the broker tries to boot
+// from random verbs like `issues list`. We additionally require the
+// bundle filename to look like the broker entry. See PR #807 / CI fix.
+if (
+  import.meta.url === `file://${process.argv[1]}` &&
+  /(?:^|[/\\])(?:vault[/\\]broker[/\\])?server\.(?:js|ts)$/.test(
+    process.argv[1] ?? "",
+  )
+) {
   main().catch((err) => {
     process.stderr.write(
       `vault-broker fatal: ${err instanceof Error ? err.stack : err}\n`,

--- a/tests/entry-guard-bundler.test.ts
+++ b/tests/entry-guard-bundler.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Phase 3a-1: Entry-guard bundler sweep.
+ *
+ * When bun's bundler inlines a module that has an
+ * `if (import.meta.url === \`file://${process.argv[1]}\`)` entry guard
+ * INTO another bundle (e.g. dist/cli/switchroom.js), `import.meta.url`
+ * is rewritten to point at the OUTPUT bundle. The naive guard then
+ * compares `file://<output-path>` to argv[1] (the same output path) and
+ * matches — causing the inlined module's main() to fire for any CLI
+ * invocation. This regressed CI in the Phase 1c kernel work and was
+ * fixed in fork PR #26 for the broker; the squash to main reverted it.
+ *
+ * This test guards against re-regression by:
+ *   1. Asserting the entry-guard regex for each affected module accepts
+ *      its OWN bundle / source path.
+ *   2. Asserting the regex REJECTS dist/cli/switchroom.js (the merged
+ *      CLI entry point) so a guard cannot fire when bundled inside it.
+ *   3. Smoke-testing that running `bun dist/cli/switchroom.js --help`
+ *      exits cleanly and does NOT emit any of the modules' fatal
+ *      stderr banners (e.g. "vault-broker fatal", "approval-kernel
+ *      fatal", "scheduler fatal").
+ */
+
+import { describe, expect, it } from "vitest";
+import { spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { resolve } from "node:path";
+
+// Mirror the regexes embedded in each module's entry guard. If you
+// change a guard regex in src/, mirror the change here — divergence is
+// the bug we're guarding against.
+const guards: Record<string, RegExp> = {
+  broker: /(?:^|[/\\])(?:vault[/\\]broker[/\\])?server\.(?:js|ts)$/,
+  "approval-kernel":
+    /(?:^|[/\\])(?:vault[/\\]approvals[/\\])?kernel-server\.(?:js|ts)$/,
+  scheduler: /(?:^|[/\\])scheduler[/\\]index\.(?:js|ts)$/,
+};
+
+describe("entry-guard regexes — per-module (Phase 3a-1)", () => {
+  it("broker regex accepts its own bundle/source paths", () => {
+    expect(guards.broker.test("/opt/sr/dist/vault/broker/server.js")).toBe(
+      true,
+    );
+    expect(guards.broker.test("src/vault/broker/server.ts")).toBe(true);
+    expect(guards.broker.test("server.js")).toBe(true);
+  });
+
+  it("broker regex rejects the merged CLI bundle", () => {
+    expect(guards.broker.test("/opt/sr/dist/cli/switchroom.js")).toBe(false);
+    expect(guards.broker.test("dist/cli/switchroom.js")).toBe(false);
+  });
+
+  it("approval-kernel regex accepts its own bundle/source paths", () => {
+    expect(
+      guards["approval-kernel"].test(
+        "/opt/sr/dist/vault/approvals/kernel-server.js",
+      ),
+    ).toBe(true);
+    expect(
+      guards["approval-kernel"].test(
+        "src/vault/approvals/kernel-server.ts",
+      ),
+    ).toBe(true);
+    expect(guards["approval-kernel"].test("kernel-server.js")).toBe(true);
+  });
+
+  it("approval-kernel regex rejects the merged CLI bundle and broker bundle", () => {
+    expect(
+      guards["approval-kernel"].test("/opt/sr/dist/cli/switchroom.js"),
+    ).toBe(false);
+    expect(
+      guards["approval-kernel"].test("/opt/sr/dist/vault/broker/server.js"),
+    ).toBe(false);
+  });
+
+  it("scheduler regex accepts its own bundle/source paths", () => {
+    expect(guards.scheduler.test("/opt/sr/dist/scheduler/index.js")).toBe(
+      true,
+    );
+    expect(guards.scheduler.test("src/scheduler/index.ts")).toBe(true);
+  });
+
+  it("scheduler regex rejects the merged CLI bundle and a generic index.js", () => {
+    expect(guards.scheduler.test("/opt/sr/dist/cli/switchroom.js")).toBe(
+      false,
+    );
+    expect(guards.scheduler.test("/opt/sr/dist/foo/index.js")).toBe(false);
+  });
+});
+
+describe("dist/cli/switchroom.js — no inlined-guard misfires (Phase 3a-1)", () => {
+  const cli = resolve(
+    __dirname,
+    "..",
+    "dist",
+    "cli",
+    "switchroom.js",
+  );
+
+  it.skipIf(!existsSync(cli))(
+    "running --help does not boot broker / kernel / scheduler",
+    () => {
+      const res = spawnSync("bun", [cli, "--help"], {
+        encoding: "utf8",
+        env: { ...process.env, HOME: "/tmp/empty-fakehome" },
+        timeout: 30_000,
+      });
+      const blob = `${res.stdout ?? ""}\n${res.stderr ?? ""}`;
+      expect(res.status).toBe(0);
+      expect(blob).not.toMatch(/vault-broker fatal/);
+      expect(blob).not.toMatch(/approval-kernel fatal/);
+      expect(blob).not.toMatch(/scheduler fatal/);
+      // None of these modules should print their boot banners either.
+      expect(blob).not.toMatch(/vault-broker: listening on/);
+      expect(blob).not.toMatch(/scheduler: registered/);
+    },
+  );
+});


### PR DESCRIPTION
## Summary

Restores and extends the `import.meta.url` entry-guard hardening that landed in fork PR mekenthompson/switchroom#26 but was effectively reverted by the squash from `feat/docker-phase1c-kernel` to `main`. Without this, when bun bundles modules with naive entry guards into `dist/cli/switchroom.js`, the bundler rewrites `import.meta.url` to point at the output bundle and the inlined module's `main()` fires for any CLI invocation — booting broker/kernel/scheduler from random verbs and breaking CI.

## Bundler-rewrite class

bun's bundler rewrites `import.meta.url` of an inlined module to point at the OUTPUT bundle. So `import.meta.url === \`file://${process.argv[1]}\`` matches **whenever the OUTPUT bundle is invoked**, regardless of which inlined module the guard is in. Adding a regex check on `process.argv[1]` that the filename matches the inlined module's OWN intended entry-point name fixes this — the guard only fires when the module is genuinely the entry.

## Guards fixed

| File | Line | Status |
| --- | --- | --- |
| `src/vault/broker/server.ts` | 1716 | RESTORED (lost from fork PR #26 squash) |
| `src/vault/approvals/kernel-server.ts` | 469 | NEW (was naive on main) |
| `src/scheduler/index.ts` | 141 | NEW (was naive on main) |

`scripts/import-openclaw-credentials.ts` already uses the robust `fileURLToPath()` pattern and is not bundled into `dist/cli`, so it is left as-is.

## Test evidence

New `tests/entry-guard-bundler.test.ts` (7 tests, all passing):
- Per-module regex unit tests: each accepts its own bundle/source path AND rejects `dist/cli/switchroom.js`.
- Smoke test: `bun dist/cli/switchroom.js --help` exits 0 and emits no broker/kernel/scheduler boot or fatal banners.

Phase 1c regression check — with `HOME=/tmp/empty-fakehome` (Buildkite agent env without `switchroom.yaml`):
```
bunx vitest run tests/run-hook.test.ts tests/cli.issues.test.ts \
  tests/cli.memory.demote.test.ts tests/experimental-schema.test.ts \
  tests/boot-self-test.test.ts
→ 43 passed (the 12 experimental-schema failures are pre-existing on main,
  unrelated to entry guards)
```

Full `bun run test:vitest`: 5279 passed, 12 failed. The 12 failures are pre-existing on pristine `main` (verified by reverting the three guard files and re-running) — they live in `src/drive/*`, `src/vault/approvals/kernel.test.ts`, `src/vault/broker/server-approvals.test.ts`, `tests/docker/phase2c-vault-integration.test.ts`, `tests/experimental-schema.test.ts`. Out of scope for this sweep.

## Out of scope (handled in later phase 3a parts per agreed split)

- 3a-2: HARD RULES + helper for entry-guard discipline.
- 3a-3: GHCR publish.

## Test plan

- [x] New entry-guard regex unit tests pass.
- [x] dist/cli/switchroom.js smoke test passes.
- [x] `bun dist/cli/switchroom.js --help` runs cleanly with empty HOME.
- [x] Phase 1c regression target tests (43 of them) all pass.
- [ ] Reviewer validates each regex matches the right bundle and rejects the merged CLI bundle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)