### PR TITLE
Phase 3a-2: HARD RULES generalization + _prod-snapshot.ts helper extraction

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,14 +17,14 @@ See `README.md` for the user-facing description.
 
 ## Docker test discipline (HARD RULES)
 
-This branch's tests run on a host that ALSO runs Coolify, hindsight, nginx-tunnel-gateway, and every Coolify-managed app. Treat the host as production.
+These rules are permanent guidance for every phase of the docker migration, not phase-1c-scoped commentary. Tests run on a host that ALSO runs Coolify, hindsight, nginx-tunnel-gateway, and every Coolify-managed app. Treat the host as production.
 
-- Every test container MUST be created with the label `switchroom.test=phase1c`. Add a per-run UUID label too (e.g. `switchroom.test.run=<uuid>`).
+- Every test container MUST be created with the label `switchroom.test=<phase>` — substitute the phase you're working in (e.g. `phase1c`, `phase2c`, `phase3a`). Add a per-run UUID label too (e.g. `switchroom.test.run=<uuid>`).
 - Every `docker run` MUST use `--rm` so containers self-clean on exit.
-- The ONLY sanctioned bulk-teardown command is filtered by label:
+- The ONLY sanctioned bulk-teardown command is filtered by label — same `<phase>` value as the create label:
 
   ```
-  docker rm -f $(docker ps -aq --filter label=switchroom.test=phase1c) 2>/dev/null || true
+  docker rm -f $(docker ps -aq --filter label=switchroom.test=<phase>) 2>/dev/null || true
   ```
 
 - **Exception — detached for inter-call inspection:** if a test genuinely needs `docker run -d` (no `--rm`) because it `docker exec`s into the container between assertions, that's allowed BUT the callsite must (a) carry the standard labels, (b) have an explicit per-name `docker rm -f` in `finally`, AND (c) be covered by `safeLabelTeardown` in `afterAll`. All three. No exceptions to the exception.

--- a/tests/docker/_prod-snapshot.ts
+++ b/tests/docker/_prod-snapshot.ts
@@ -1,0 +1,98 @@
+/**
+ * Shared production-host docker snapshot helper for docker phase tests.
+ *
+ * Phase 1c+ docker tests run on a host that ALSO runs production
+ * workloads (Coolify, hindsight, nginx-tunnel-gateway, …). To guarantee
+ * a phase test never disturbs a production container, every phase test
+ * captures a `docker ps` snapshot in `beforeAll` and asserts the same
+ * snapshot in `afterAll`. Any deviation fails the suite hard.
+ *
+ * This module centralises the capture + assertion so future phase tests
+ * inherit the hard-fail behaviour by default and we don't fan out
+ * copy-pasted regex filters across N test files.
+ *
+ * Cross-phase filter rationale: when the broader docker test suite runs
+ * 2a/2b/2c (and beyond) together, sibling-phase ephemerals can appear
+ * in one snapshot but vanish before the other — that's normal noise,
+ * not production drift. We strip any container whose name matches
+ * `switchroom-phase<digit>` from BOTH sides before diffing. Production
+ * containers do not carry that name prefix, so genuine drift still
+ * trips the assertion.
+ */
+
+import { execSync } from "node:child_process";
+import { expect } from "vitest";
+
+/** Filter regex for switchroom phase-test containers (any phase). */
+const PHASE_TEST_NAME = /switchroom-phase\d/;
+
+/**
+ * A snapshot of the host's container list at one moment in time.
+ * Wrapped in a struct so callers don't accidentally pass a raw string
+ * to the wrong parameter.
+ */
+export interface ProdSnapshot {
+  readonly raw: string;
+}
+
+/**
+ * Capture the host's complete container list. Tries `sudo docker ps`
+ * first (production hosts typically require it), falls back to plain
+ * `docker ps`, and returns an empty snapshot if neither works (e.g. CI
+ * without docker).
+ *
+ * Uses `--no-trunc` so IDs are stable for diffing.
+ */
+export function captureProdSnapshot(): ProdSnapshot {
+  try {
+    return {
+      raw: execSync(
+        "sudo docker ps --no-trunc --format '{{.Names}}|{{.ID}}|{{.Status}}'",
+        { stdio: ["ignore", "pipe", "pipe"] },
+      ).toString(),
+    };
+  } catch {
+    try {
+      return {
+        raw: execSync(
+          "docker ps --no-trunc --format '{{.Names}}|{{.ID}}|{{.Status}}'",
+          { stdio: ["ignore", "pipe", "pipe"] },
+        ).toString(),
+      };
+    } catch {
+      return { raw: "" };
+    }
+  }
+}
+
+/**
+ * HARD assertion that no production-host container drift occurred
+ * between two snapshots. Filters out any switchroom phase-test
+ * container (any phase) from BOTH sides before diffing — see
+ * cross-phase rationale above.
+ *
+ * Use in `afterAll` of every docker phase test:
+ *
+ * ```ts
+ * const before = captureProdSnapshot();
+ * // ... test body ...
+ * const after = captureProdSnapshot();
+ * expectNoProdDrift(before, after);
+ * ```
+ */
+export function expectNoProdDrift(
+  before: ProdSnapshot,
+  after: ProdSnapshot,
+): void {
+  expect(filterPhaseTestContainers(after.raw)).toEqual(
+    filterPhaseTestContainers(before.raw),
+  );
+}
+
+function filterPhaseTestContainers(raw: string): string {
+  return raw
+    .split("\n")
+    .filter((l) => l && !PHASE_TEST_NAME.test(l))
+    .sort()
+    .join("\n");
+}

--- a/tests/docker/phase2a-broker-ipc.test.ts
+++ b/tests/docker/phase2a-broker-ipc.test.ts
@@ -36,6 +36,11 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { execSync, spawnSync } from "node:child_process";
 import {
+  captureProdSnapshot,
+  expectNoProdDrift,
+  type ProdSnapshot,
+} from "./_prod-snapshot";
+import {
   mkdtempSync,
   rmSync,
   writeFileSync,
@@ -129,35 +134,13 @@ interface Fixture {
   legacySock: string;
   containerName: string;
   initialSchemaVersion: number | null;
-  prodSnapshot: string;
+  prodSnapshot: ProdSnapshot;
 }
 
 let fx: Fixture | null = null;
 
 const PASSPHRASE = "phase2a-test-passphrase-do-not-use-in-prod";
 const AGENTS = ["alice", "bob", "carol"];
-
-function snapshotProductionContainers(): string {
-  // Capture the host's complete container list so afterAll can verify
-  // no production container went down. We use --no-trunc so IDs are
-  // stable for diffing.
-  try {
-    return execSync(
-      "sudo docker ps --no-trunc --format '{{.Names}}|{{.ID}}|{{.Status}}'",
-      { stdio: ["ignore", "pipe", "pipe"] },
-    ).toString();
-  } catch {
-    // Fallback to non-sudo if sudo is unavailable in CI.
-    try {
-      return execSync(
-        "docker ps --no-trunc --format '{{.Names}}|{{.ID}}|{{.Status}}'",
-        { stdio: ["ignore", "pipe", "pipe"] },
-      ).toString();
-    } catch {
-      return "";
-    }
-  }
-}
 
 /**
  * Read PRAGMA schema_version from the broker's grants DB inside the
@@ -189,7 +172,7 @@ function readGrantsSchemaVersion(containerName: string): number | null {
 beforeAll(() => {
   if (!imageOk) return;
 
-  const prodSnapshot = snapshotProductionContainers();
+  const prodSnapshot = captureProdSnapshot();
 
   const workdir = mkdtempSync(join(tmpdir(), "phase2a-broker-"));
   const socketDir = join(workdir, "broker-sockets");
@@ -355,29 +338,10 @@ afterAll(() => {
       /* */
     }
 
-    // Production-host safety check: confirm no container went down.
-    const after = snapshotProductionContainers();
-    // The phase2a container was spawned and removed during this run, so
-    // we filter both snapshots to non-phase2a names before diffing.
-    // Filter out ALL switchroom phase-test containers (any phase), not just
-    // phase2a's — when the broader docker test suite runs concurrently with
-    // 2b/2c, sibling-phase ephemerals can appear in one snapshot but vanish
-    // before the other, which is normal cross-phase noise, not production
-    // drift. Production containers do NOT carry the "switchroom-phase"
-    // name prefix, so this still catches any genuine drift.
-    const filterPhase = (s: string): string =>
-      s.split("\n")
-        .filter((l) => l && !/switchroom-phase\d/.test(l))
-        .sort()
-        .join("\n");
-    const beforeFiltered = filterPhase(fx.prodSnapshot);
-    const afterFiltered = filterPhase(after);
-    // HARD assertion (F1, post-cohesion-review): a console.error here let
-    // production drift slip past CI silently. Now we fail the suite if any
-    // non-phase2a container appeared, disappeared, or changed status during
-    // the run. The phase-name filter above keeps our own ephemeral containers
-    // out of the diff.
-    expect(afterFiltered).toBe(beforeFiltered);
+    // Production-host safety check: HARD assertion that no container
+    // appeared, disappeared, or changed status during the run. See
+    // ./_prod-snapshot.ts for the cross-phase filter rationale.
+    expectNoProdDrift(fx.prodSnapshot, captureProdSnapshot());
   }
 }, 60_000);
 

--- a/tests/docker/phase2b-kernel-ipc.test.ts
+++ b/tests/docker/phase2b-kernel-ipc.test.ts
@@ -36,6 +36,11 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { execSync, spawnSync } from "node:child_process";
 import {
+  captureProdSnapshot,
+  expectNoProdDrift,
+  type ProdSnapshot,
+} from "./_prod-snapshot";
+import {
   mkdtempSync,
   rmSync,
   mkdirSync,
@@ -112,30 +117,12 @@ interface Fixture {
   stateDir: string; // host path mounted at /state/approvals
   containerName: string;
   initialSchemaVersion: number | null;
-  prodSnapshot: string;
+  prodSnapshot: ProdSnapshot;
 }
 
 let fx: Fixture | null = null;
 
 const AGENTS = ["alice", "bob", "carol"];
-
-function snapshotProductionContainers(): string {
-  try {
-    return execSync(
-      "sudo docker ps --no-trunc --format '{{.Names}}|{{.ID}}|{{.Status}}'",
-      { stdio: ["ignore", "pipe", "pipe"] },
-    ).toString();
-  } catch {
-    try {
-      return execSync(
-        "docker ps --no-trunc --format '{{.Names}}|{{.ID}}|{{.Status}}'",
-        { stdio: ["ignore", "pipe", "pipe"] },
-      ).toString();
-    } catch {
-      return "";
-    }
-  }
-}
 
 /**
  * Read PRAGMA schema_version from the kernel.db inside the container.
@@ -162,7 +149,7 @@ function readKernelSchemaVersion(containerName: string): number | null {
 beforeAll(() => {
   if (!imageOk) return;
 
-  const prodSnapshot = snapshotProductionContainers();
+  const prodSnapshot = captureProdSnapshot();
 
   const workdir = mkdtempSync(join(tmpdir(), "phase2b-kernel-"));
   const socketParent = join(workdir, "kernel-sockets");
@@ -261,23 +248,9 @@ afterAll(() => {
       /* */
     }
 
-    // Production-host safety check.
-    const after = snapshotProductionContainers();
-    // Filter out ALL switchroom phase-test containers (any phase), not just
-    // phase2b's — sibling-phase ephemerals running concurrently are normal
-    // cross-phase noise, not production drift. See phase2a for rationale.
-    const filterPhase = (s: string): string =>
-      s.split("\n")
-        .filter((l) => l && !/switchroom-phase\d/.test(l))
-        .sort()
-        .join("\n");
-    const beforeFiltered = filterPhase(fx.prodSnapshot);
-    const afterFiltered = filterPhase(after);
-    // HARD assertion (F1, post-cohesion-review): a console.error here let
-    // production drift slip past CI silently. Now we fail the suite if any
-    // non-phase2b container appeared, disappeared, or changed status during
-    // the run.
-    expect(afterFiltered).toBe(beforeFiltered);
+    // Production-host safety check — HARD assertion. See
+    // ./_prod-snapshot.ts for the cross-phase filter rationale.
+    expectNoProdDrift(fx.prodSnapshot, captureProdSnapshot());
   }
 }, 60_000);
 

--- a/tests/docker/phase2c-vault-integration.test.ts
+++ b/tests/docker/phase2c-vault-integration.test.ts
@@ -40,6 +40,11 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { execSync, spawnSync } from "node:child_process";
 import {
+  captureProdSnapshot,
+  expectNoProdDrift,
+  type ProdSnapshot,
+} from "./_prod-snapshot";
+import {
   mkdtempSync,
   rmSync,
   writeFileSync,
@@ -130,7 +135,7 @@ interface Fixture {
   agentNames: Map<string, string>; // agent label → container name
   initialBrokerSchemaVersion: number | null;
   initialKernelSchemaVersion: number | null;
-  prodSnapshot: string;
+  prodSnapshot: ProdSnapshot;
 }
 
 let fx: Fixture | null = null;
@@ -138,25 +143,7 @@ let fx: Fixture | null = null;
 const PASSPHRASE = "phase2c-test-passphrase-do-not-use-in-prod";
 const AGENTS = ["alice", "bob", "carol"];
 
-// ─── Snapshot + schema helpers (re-used pattern from 2a/2b) ──────────────────
-
-function snapshotProductionContainers(): string {
-  try {
-    return execSync(
-      "sudo docker ps --no-trunc --format '{{.Names}}|{{.ID}}|{{.Status}}'",
-      { stdio: ["ignore", "pipe", "pipe"] },
-    ).toString();
-  } catch {
-    try {
-      return execSync(
-        "docker ps --no-trunc --format '{{.Names}}|{{.ID}}|{{.Status}}'",
-        { stdio: ["ignore", "pipe", "pipe"] },
-      ).toString();
-    } catch {
-      return "";
-    }
-  }
-}
+// ─── Schema helpers (snapshot helper lives in ./_prod-snapshot.ts) ───────────
 
 function readSchemaVersion(containerName: string, dbPath: string): number | null {
   try {
@@ -258,7 +245,7 @@ function agentNdjson(
 beforeAll(() => {
   if (!imagesOk) return;
 
-  const prodSnapshot = snapshotProductionContainers();
+  const prodSnapshot = captureProdSnapshot();
 
   const workdir = mkdtempSync(join(tmpdir(), "phase2c-integration-"));
   const brokerSocketDir = join(workdir, "broker-sockets");
@@ -506,21 +493,9 @@ afterAll(() => {
     safeLabelTeardownPhase2c();
     try { rmSync(fx.workdir, { recursive: true, force: true }); } catch { /* */ }
 
-    // Production-host safety — HARD assertion (F1 shape, applied from day one).
-    const after = snapshotProductionContainers();
-    // Filter out ALL switchroom phase-test containers (any phase) — sibling
-    // phases running concurrently in the same vitest run will create + remove
-    // ephemeral containers; that's normal cross-phase noise, not production
-    // drift. Production containers don't carry the "switchroom-phase<digit>"
-    // name prefix, so genuine drift still trips this assertion.
-    const filterPhase = (s: string): string =>
-      s.split("\n")
-        .filter((l) => l && !/switchroom-phase\d/.test(l))
-        .sort()
-        .join("\n");
-    const beforeFiltered = filterPhase(fx.prodSnapshot);
-    const afterFiltered = filterPhase(after);
-    expect(afterFiltered).toBe(beforeFiltered);
+    // Production-host safety — HARD assertion. See ./_prod-snapshot.ts
+    // for the cross-phase filter rationale.
+    expectNoProdDrift(fx.prodSnapshot, captureProdSnapshot());
   }
 }, 90_000);
 

--- a/tests/entry-guard-bundler.test.ts
+++ b/tests/entry-guard-bundler.test.ts
@@ -97,22 +97,28 @@ describe("dist/cli/switchroom.js — no inlined-guard misfires (Phase 3a-1)", ()
     "switchroom.js",
   );
 
-  it.skipIf(!existsSync(cli))(
-    "running --help does not boot broker / kernel / scheduler",
-    () => {
-      const res = spawnSync("bun", [cli, "--help"], {
-        encoding: "utf8",
-        env: { ...process.env, HOME: "/tmp/empty-fakehome" },
-        timeout: 30_000,
-      });
-      const blob = `${res.stdout ?? ""}\n${res.stderr ?? ""}`;
-      expect(res.status).toBe(0);
-      expect(blob).not.toMatch(/vault-broker fatal/);
-      expect(blob).not.toMatch(/approval-kernel fatal/);
-      expect(blob).not.toMatch(/scheduler fatal/);
-      // None of these modules should print their boot banners either.
-      expect(blob).not.toMatch(/vault-broker: listening on/);
-      expect(blob).not.toMatch(/scheduler: registered/);
-    },
-  );
+  it("running --help does not boot broker / kernel / scheduler", () => {
+    // Phase 3a-2 (was: it.skipIf(!existsSync(cli))). Silently skipping
+    // when dist/cli/switchroom.js was missing meant a fresh checkout
+    // could pass this suite without the smoke ever running. Now we
+    // assert the dist exists so the suite fails loud — run
+    // `npm run build` first (or wire it into CI as a pretest).
+    expect(
+      existsSync(cli),
+      `dist CLI missing at ${cli} — run \`npm run build\` before this test.`,
+    ).toBe(true);
+    const res = spawnSync("bun", [cli, "--help"], {
+      encoding: "utf8",
+      env: { ...process.env, HOME: "/tmp/empty-fakehome" },
+      timeout: 30_000,
+    });
+    const blob = `${res.stdout ?? ""}\n${res.stderr ?? ""}`;
+    expect(res.status).toBe(0);
+    expect(blob).not.toMatch(/vault-broker fatal/);
+    expect(blob).not.toMatch(/approval-kernel fatal/);
+    expect(blob).not.toMatch(/scheduler fatal/);
+    // None of these modules should print their boot banners either.
+    expect(blob).not.toMatch(/vault-broker: listening on/);
+    expect(blob).not.toMatch(/scheduler: registered/);
+  });
 });


### PR DESCRIPTION
## Scope

Phase 3a-2 of the Docker migration. Pure refactor + docs — no behaviour change.

Three deliverables:

1. **`tests/docker/_prod-snapshot.ts`** — extracted shared helper exposing `captureProdSnapshot()` + `expectNoProdDrift(before, after)`. The cross-phase filter regex (`/switchroom-phase\d/`) and the HARD `expect(...).toEqual(...)` shape now live in exactly one place.

2. **2a/2b/2c afterAll refactor** — `phase2a-broker-ipc.test.ts`, `phase2b-kernel-ipc.test.ts`, `phase2c-vault-integration.test.ts` now import and call the helper. Per-file `snapshotProductionContainers()` and the inline `filterPhase` closures are gone. Net: -88 lines of copy-paste.

3. **`CLAUDE.md` HARD RULES generalised** — the docker test discipline section no longer hardcodes `phase1c`. Now reads as permanent guidance with `<phase>` placeholders so each new phase substitutes its own value. The detached-with-explicit-cleanup exception (PR #812) is unchanged.

4. **`tests/entry-guard-bundler.test.ts` deferred nit (from Phase 3a-1 review)** — the smoke test used `it.skipIf(!existsSync(cli))` which meant a fresh checkout without a prior `npm run build` would pass the suite without ever running the inlined-guard regression check. Changed to a hard `expect(existsSync(cli))` assertion with a clear "run `npm run build`" message.

## Files

- `tests/docker/_prod-snapshot.ts` (new)
- `tests/docker/phase2a-broker-ipc.test.ts` (refactor)
- `tests/docker/phase2b-kernel-ipc.test.ts` (refactor)
- `tests/docker/phase2c-vault-integration.test.ts` (refactor)
- `tests/entry-guard-bundler.test.ts` (loud-fail smoke)
- `CLAUDE.md` (phase-agnostic HARD RULES)

## Validation

- `bun run test:vitest -- tests/docker/phase2 tests/entry-guard-bundler` → 17 passed, 3 skipped (skips are docker-image absence, not the smoke).
- `npm run lint` clean.
- Pre/post `sudo docker ps` snapshot identical — only production containers (Coolify, hindsight, nginx-tunnel-gateway, et al.), no `switchroom-phase*` drift.
- The helper's `expectNoProdDrift` assertion ran in 2a/2b/2c afterAll and passed against this same host.

## Notes

- No new docker fixtures created, so no new `switchroom.test=phase3a` containers exist; HARD RULES discipline in CLAUDE.md is what's being delivered, not exercised.
- Phase 3a-1 had a wrong-base bug; this PR explicitly targets `switchroom/switchroom:main`.