### PR TITLE
Phase 3b-2a: switchroom migrate scaffolding (preflight + dry-run + log writer)

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -23,6 +23,7 @@ import { registerWorkspaceCommand } from "./workspace.js";
 import { registerDebugCommand } from "./debug.js";
 import { registerWorktreeCommand } from "./worktree.js";
 import { registerDriveCommand } from "./drive.js";
+import { registerMigrateCommand } from "./migrate/index.js";
 import { captureEvent, installGlobalErrorHandlers } from "../analytics/posthog.js";
 
 installGlobalErrorHandlers();
@@ -69,3 +70,4 @@ registerWorkspaceCommand(program);
 registerDebugCommand(program);
 registerWorktreeCommand(program);
 registerDriveCommand(program);
+registerMigrateCommand(program);

--- a/src/cli/migrate/index.ts
+++ b/src/cli/migrate/index.ts
@@ -1,0 +1,114 @@
+/**
+ * `switchroom migrate {to-docker,to-host}` — host ↔ docker fleet migration.
+ *
+ * Phase 3b-2a (this PR): scaffolding only.
+ *  - Both verbs accept --dry-run, --json, and (to-docker only) --shared-host.
+ *  - --dry-run runs the pre-flight checks and prints the plan.
+ *  - Without --dry-run, both verbs exit 2 with a "not yet implemented"
+ *    message. The mutation paths land in 3b-2b (to-docker happy path)
+ *    and 3b-2c (to-host reversal + e2e).
+ */
+import type { Command } from "commander";
+import chalk from "chalk";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { withConfigError, getConfig } from "../helpers.js";
+import { runPreflight, type MigrateVerb } from "./preflight.js";
+import { buildPlan, formatPlanJsonl, formatPlanText, type PlanState } from "./plan.js";
+
+interface DryRunOpts {
+  dryRun?: boolean;
+  json?: boolean;
+  sharedHost?: boolean;
+}
+
+function notImplemented(verb: MigrateVerb): never {
+  console.error(
+    chalk.red(
+      `migrate ${verb} not yet implemented in this version; use --dry-run to preview the plan`,
+    ),
+  );
+  process.exit(2);
+}
+
+async function runDryRun(
+  verb: MigrateVerb,
+  opts: DryRunOpts,
+  program: Command,
+): Promise<void> {
+  const config = getConfig(program);
+  const agents = Object.keys(config.agents ?? {}).sort();
+
+  const preflight = await runPreflight(verb, { sharedHost: !!opts.sharedHost });
+  if (!preflight.ok) {
+    const r = preflight.refusal!;
+    if (opts.json) {
+      console.log(
+        JSON.stringify({
+          kind: "preflight-refusal",
+          verb,
+          check: r.name,
+          reason: r.reason,
+          fixHint: r.fixHint,
+        }),
+      );
+    } else {
+      console.error(chalk.red(`Pre-flight refused at check: ${r.name}`));
+      console.error(`  reason: ${r.reason}`);
+      if (r.fixHint) console.error(chalk.gray(`  fix:    ${r.fixHint}`));
+    }
+    process.exit(1);
+  }
+
+  const composeProject = "switchroom-fleet";
+  const composePath = join(homedir(), ".switchroom", "compose", "docker-compose.yml");
+  const state: PlanState = {
+    agents,
+    composeProject,
+    composePath,
+    targetUid: verb === "to-docker" ? process.getuid?.() : undefined,
+  };
+  const plan = buildPlan(verb, state);
+
+  if (opts.json) {
+    process.stdout.write(formatPlanJsonl(plan));
+  } else {
+    console.log(formatPlanText(plan));
+  }
+}
+
+export function registerMigrateCommand(program: Command): void {
+  const migrate = program
+    .command("migrate")
+    .description(
+      "Migrate the switchroom fleet between host (systemd) and docker runtimes.",
+    );
+
+  migrate
+    .command("to-docker")
+    .description("Migrate the fleet from host systemd units to a docker compose stack.")
+    .option("--dry-run", "Preview the plan without executing it")
+    .option("--json", "Emit machine-readable JSONL output (with --dry-run)")
+    .option(
+      "--shared-host",
+      "Acknowledge that this Docker daemon hosts foreign containers (Coolify, hindsight, etc.)",
+    )
+    .action(
+      withConfigError(async (opts: DryRunOpts) => {
+        if (!opts.dryRun) notImplemented("to-docker");
+        await runDryRun("to-docker", opts, program);
+      }),
+    );
+
+  migrate
+    .command("to-host")
+    .description("Roll the fleet back from docker compose to host systemd units.")
+    .option("--dry-run", "Preview the plan without executing it")
+    .option("--json", "Emit machine-readable JSONL output (with --dry-run)")
+    .action(
+      withConfigError(async (opts: DryRunOpts) => {
+        if (!opts.dryRun) notImplemented("to-host");
+        await runDryRun("to-host", opts, program);
+      }),
+    );
+}

--- a/src/cli/migrate/log.test.ts
+++ b/src/cli/migrate/log.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it, beforeEach } from "vitest";
+import { mkdtempSync, readFileSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  appendMigrationLogEntry,
+  _resetLogChainForTests,
+} from "./log.js";
+
+beforeEach(() => {
+  _resetLogChainForTests();
+});
+
+function tmpLog(): string {
+  const dir = mkdtempSync(join(tmpdir(), "sr-mlog-"));
+  return join(dir, "nested", "migration.log");
+}
+
+describe("appendMigrationLogEntry", () => {
+  it("creates the log file (and parent dir) on first write", async () => {
+    const path = tmpLog();
+    expect(existsSync(path)).toBe(false);
+    await appendMigrationLogEntry(
+      { verb: "to-docker", step: "preflight", status: "ok" },
+      path,
+    );
+    expect(existsSync(path)).toBe(true);
+  });
+
+  it("writes one valid JSON object per line", async () => {
+    const path = tmpLog();
+    await appendMigrationLogEntry(
+      { verb: "to-docker", step: "compose-up", status: "ok", detail: "first" },
+      path,
+    );
+    await appendMigrationLogEntry(
+      { verb: "to-docker", step: "marker-write", status: "ok" },
+      path,
+    );
+    const lines = readFileSync(path, "utf8").trim().split("\n");
+    expect(lines).toHaveLength(2);
+    for (const l of lines) {
+      const parsed = JSON.parse(l);
+      expect(parsed.verb).toBe("to-docker");
+      expect(parsed.status).toBe("ok");
+      expect(typeof parsed.ts).toBe("string");
+      expect(() => new Date(parsed.ts).toISOString()).not.toThrow();
+    }
+  });
+
+  it("supports error and rollback statuses", async () => {
+    const path = tmpLog();
+    await appendMigrationLogEntry(
+      { verb: "to-host", step: "compose-down", status: "error", error: "boom" },
+      path,
+    );
+    await appendMigrationLogEntry(
+      { verb: "to-host", step: "compose-down", status: "rollback", detail: "restored" },
+      path,
+    );
+    const lines = readFileSync(path, "utf8").trim().split("\n").map((l) => JSON.parse(l));
+    expect(lines[0].status).toBe("error");
+    expect(lines[0].error).toBe("boom");
+    expect(lines[1].status).toBe("rollback");
+    expect(lines[1].detail).toBe("restored");
+  });
+
+  it("is concurrency-safe under parallel appends", async () => {
+    const path = tmpLog();
+    const N = 50;
+    await Promise.all(
+      Array.from({ length: N }, (_, i) =>
+        appendMigrationLogEntry(
+          { verb: "to-docker", step: `step-${i}`, status: "ok" },
+          path,
+        ),
+      ),
+    );
+    const lines = readFileSync(path, "utf8").trim().split("\n");
+    expect(lines).toHaveLength(N);
+    // Every line should be valid JSON (no interleaved partial writes)
+    const steps = new Set<string>();
+    for (const l of lines) {
+      const parsed = JSON.parse(l);
+      steps.add(parsed.step);
+    }
+    expect(steps.size).toBe(N);
+  });
+
+  it("respects an injected ts", async () => {
+    const path = tmpLog();
+    const fixed = "2025-01-01T00:00:00.000Z";
+    await appendMigrationLogEntry(
+      { verb: "to-docker", step: "x", status: "ok", ts: fixed },
+      path,
+    );
+    const parsed = JSON.parse(readFileSync(path, "utf8").trim());
+    expect(parsed.ts).toBe(fixed);
+  });
+
+  it("a write failure does not poison subsequent writes", async () => {
+    const badPath = "/proc/1/cannot-write-here";
+    await expect(
+      appendMigrationLogEntry({ verb: "to-docker", step: "x", status: "ok" }, badPath),
+    ).rejects.toBeTruthy();
+    // Following writes to a good path should still succeed
+    const good = tmpLog();
+    await appendMigrationLogEntry(
+      { verb: "to-docker", step: "y", status: "ok" },
+      good,
+    );
+    expect(existsSync(good)).toBe(true);
+  });
+});

--- a/src/cli/migrate/log.ts
+++ b/src/cli/migrate/log.ts
@@ -1,0 +1,57 @@
+/**
+ * JSONL writer for ~/.switchroom/migration.log.
+ *
+ * One line per migration event. Append-only, idempotent on file
+ * creation. Concurrency-safe within a single Node process via a
+ * promise chain; cross-process concurrency relies on POSIX append
+ * being atomic for writes < PIPE_BUF (we keep entries short).
+ */
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+import { mkdirSync } from "node:fs";
+import { appendFile } from "node:fs/promises";
+import type { MigrateVerb } from "./plan.js";
+
+export interface MigrationLogEntry {
+  ts: string; // ISO8601
+  verb: MigrateVerb;
+  step: string;
+  status: "ok" | "error" | "rollback";
+  detail?: string;
+  error?: string;
+}
+
+export function defaultMigrationLogPath(): string {
+  return join(homedir(), ".switchroom", "migration.log");
+}
+
+let chain: Promise<void> = Promise.resolve();
+
+export async function appendMigrationLogEntry(
+  entry: Omit<MigrationLogEntry, "ts"> & { ts?: string },
+  path: string = defaultMigrationLogPath(),
+): Promise<void> {
+  const full: MigrationLogEntry = {
+    ts: entry.ts ?? new Date().toISOString(),
+    verb: entry.verb,
+    step: entry.step,
+    status: entry.status,
+    ...(entry.detail !== undefined ? { detail: entry.detail } : {}),
+    ...(entry.error !== undefined ? { error: entry.error } : {}),
+  };
+  const line = JSON.stringify(full) + "\n";
+  // Serialize all writes through a process-local promise chain so that
+  // concurrent appendMigrationLogEntry callers can't interleave writes.
+  const next = chain.then(async () => {
+    mkdirSync(dirname(path), { recursive: true });
+    await appendFile(path, line, { encoding: "utf8", mode: 0o600 });
+  });
+  // Don't let one failure poison the chain.
+  chain = next.catch(() => undefined);
+  return next;
+}
+
+/** Test helper: reset the in-process serialization chain. */
+export function _resetLogChainForTests(): void {
+  chain = Promise.resolve();
+}

--- a/src/cli/migrate/plan.test.ts
+++ b/src/cli/migrate/plan.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it } from "vitest";
+import { buildPlan, formatPlanJsonl, formatPlanText, type PlanState } from "./plan.js";
+
+const baseState: PlanState = {
+  agents: ["klanker", "finn"],
+  composeProject: "switchroom-fleet",
+  composePath: "/home/u/.switchroom/compose/docker-compose.yml",
+  targetUid: 1000,
+};
+
+describe("buildPlan to-docker", () => {
+  it("emits expected step kinds in order", () => {
+    const plan = buildPlan("to-docker", baseState);
+    const kinds = plan.steps.map((s) => s.kind);
+    expect(kinds[0]).toBe("watchdog-pause");
+    expect(kinds).toContain("systemd-stop");
+    expect(kinds).toContain("systemd-disable");
+    expect(kinds).toContain("uid-align");
+    expect(kinds).toContain("compose-generate");
+    expect(kinds).toContain("compose-up");
+    expect(kinds).toContain("vault-broker-handshake");
+    expect(kinds).toContain("marker-write");
+    expect(kinds[kinds.length - 1]).toBe("watchdog-resume");
+  });
+
+  it("includes one systemd-stop+disable per agent", () => {
+    const plan = buildPlan("to-docker", baseState);
+    const stops = plan.steps.filter((s) => s.kind === "systemd-stop");
+    const disables = plan.steps.filter((s) => s.kind === "systemd-disable");
+    expect(stops).toHaveLength(2);
+    expect(disables).toHaveLength(2);
+  });
+
+  it("skips uid-align when targetUid is undefined", () => {
+    const plan = buildPlan("to-docker", { ...baseState, targetUid: undefined });
+    expect(plan.steps.filter((s) => s.kind === "uid-align")).toHaveLength(0);
+  });
+
+  it("marker step writes mode=docker", () => {
+    const plan = buildPlan("to-docker", baseState);
+    const marker = plan.steps.find((s) => s.kind === "marker-write");
+    expect(marker).toBeDefined();
+    if (marker?.kind === "marker-write") expect(marker.mode).toBe("docker");
+  });
+});
+
+describe("buildPlan to-host", () => {
+  it("emits expected step kinds in reverse direction", () => {
+    const plan = buildPlan("to-host", baseState);
+    const kinds = plan.steps.map((s) => s.kind);
+    expect(kinds[0]).toBe("watchdog-pause");
+    expect(kinds).toContain("compose-down");
+    expect(kinds).toContain("systemd-enable");
+    expect(kinds).toContain("systemd-start");
+    expect(kinds).toContain("marker-write");
+    expect(kinds[kinds.length - 1]).toBe("watchdog-resume");
+    // Should NOT include compose-generate or uid-align
+    expect(kinds).not.toContain("compose-generate");
+    expect(kinds).not.toContain("uid-align");
+  });
+
+  it("marker step writes mode=host", () => {
+    const plan = buildPlan("to-host", baseState);
+    const marker = plan.steps.find((s) => s.kind === "marker-write");
+    expect(marker).toBeDefined();
+    if (marker?.kind === "marker-write") expect(marker.mode).toBe("host");
+  });
+});
+
+describe("buildPlan warnings", () => {
+  it("warns when fleet is empty", () => {
+    const plan = buildPlan("to-docker", { ...baseState, agents: [] });
+    expect(plan.warnings.some((w) => /no agents/i.test(w))).toBe(true);
+  });
+});
+
+describe("formatPlanText snapshot", () => {
+  it("renders a stable to-docker plan", () => {
+    const plan = buildPlan("to-docker", baseState);
+    expect(formatPlanText(plan)).toMatchInlineSnapshot(`
+      "Migration plan: to-docker
+      Steps: 13
+
+         1. Pause fleet watchdog
+              rollback: watchdog-resume
+         2. Stop systemd unit switchroom-klanker.service
+              rollback: systemctl --user start switchroom-klanker.service
+         3. Disable systemd unit switchroom-klanker.service
+              rollback: systemctl --user enable switchroom-klanker.service
+         4. Stop systemd unit switchroom-finn.service
+              rollback: systemctl --user start switchroom-finn.service
+         5. Disable systemd unit switchroom-finn.service
+              rollback: systemctl --user enable switchroom-finn.service
+         6. chown agent klanker workspace to UID 1000
+              rollback: chown back to host UID (recorded in migration.log)
+         7. chown agent finn workspace to UID 1000
+              rollback: chown back to host UID (recorded in migration.log)
+         8. Generate compose file at /home/u/.switchroom/compose/docker-compose.yml (project: switchroom-fleet)
+              rollback: rm /home/u/.switchroom/compose/docker-compose.yml
+         9. docker compose -p switchroom-fleet -f /home/u/.switchroom/compose/docker-compose.yml up -d
+              rollback: docker compose -p switchroom-fleet -f /home/u/.switchroom/compose/docker-compose.yml down
+        10. Re-handshake vault-broker token for agent klanker
+              rollback: no rollback — handshake is idempotent
+        11. Re-handshake vault-broker token for agent finn
+              rollback: no rollback — handshake is idempotent
+        12. Write ~/.switchroom/runtime-mode = docker
+              rollback: marker-write host
+        13. Resume fleet watchdog
+
+      (dry-run — no side-effects performed)"
+    `);
+  });
+
+  it("renders a stable to-host plan", () => {
+    const plan = buildPlan("to-host", baseState);
+    expect(formatPlanText(plan)).toMatchInlineSnapshot(`
+      "Migration plan: to-host
+      Steps: 8
+
+         1. Pause fleet watchdog
+              rollback: watchdog-resume
+         2. docker compose -p switchroom-fleet -f /home/u/.switchroom/compose/docker-compose.yml down
+              rollback: docker compose -p switchroom-fleet -f /home/u/.switchroom/compose/docker-compose.yml up -d
+         3. Enable systemd unit switchroom-klanker.service
+              rollback: systemctl --user disable switchroom-klanker.service
+         4. Start systemd unit switchroom-klanker.service
+              rollback: systemctl --user stop switchroom-klanker.service
+         5. Enable systemd unit switchroom-finn.service
+              rollback: systemctl --user disable switchroom-finn.service
+         6. Start systemd unit switchroom-finn.service
+              rollback: systemctl --user stop switchroom-finn.service
+         7. Write ~/.switchroom/runtime-mode = host
+              rollback: marker-write docker
+         8. Resume fleet watchdog
+
+      (dry-run — no side-effects performed)"
+    `);
+  });
+});
+
+describe("formatPlanJsonl", () => {
+  it("emits one JSON object per line, ending with newline", () => {
+    const plan = buildPlan("to-host", { ...baseState, agents: ["a"] });
+    const out = formatPlanJsonl(plan);
+    expect(out.endsWith("\n")).toBe(true);
+    const lines = out.trim().split("\n");
+    for (const l of lines) {
+      expect(() => JSON.parse(l)).not.toThrow();
+    }
+    const first = JSON.parse(lines[0]);
+    expect(first.kind).toBe("header");
+    expect(first.verb).toBe("to-host");
+  });
+});

--- a/src/cli/migrate/plan.ts
+++ b/src/cli/migrate/plan.ts
@@ -1,0 +1,193 @@
+/**
+ * Migration plan builder + pretty-printer.
+ *
+ * Pure: `buildPlan(verb, state)` returns a typed list of steps that
+ * `migrate to-docker` / `migrate to-host` would execute. No side-effects.
+ *
+ * `--dry-run` in 3b-2a renders the plan; 3b-2b/c will execute it.
+ */
+
+export type MigrateVerb = "to-docker" | "to-host";
+
+export type PlanStep =
+  | { kind: "systemd-stop"; unit: string }
+  | { kind: "systemd-disable"; unit: string }
+  | { kind: "systemd-enable"; unit: string }
+  | { kind: "systemd-start"; unit: string }
+  | { kind: "compose-generate"; path: string; project: string }
+  | { kind: "compose-up"; project: string; path: string }
+  | { kind: "compose-down"; project: string; path: string }
+  | { kind: "watchdog-pause" }
+  | { kind: "watchdog-resume" }
+  | { kind: "marker-write"; mode: "host" | "docker" }
+  | { kind: "vault-broker-handshake"; agent: string }
+  | { kind: "uid-align"; agent: string; targetUid: number };
+
+export interface PlanState {
+  /** Agents in the fleet that will be migrated. */
+  agents: string[];
+  /** Compose project name (typically `switchroom-fleet`). */
+  composeProject: string;
+  /** Path to the compose file that would be generated. */
+  composePath: string;
+  /** Target UID for chown alignment in to-docker (informational only here). */
+  targetUid?: number;
+}
+
+export interface MigrationPlan {
+  verb: MigrateVerb;
+  steps: Array<PlanStep & { rollback?: string }>;
+  warnings: string[];
+}
+
+/* ------------------------------------------------------------------ */
+
+export function buildPlan(verb: MigrateVerb, state: PlanState): MigrationPlan {
+  const steps: Array<PlanStep & { rollback?: string }> = [];
+  const warnings: string[] = [];
+
+  if (state.agents.length === 0) {
+    warnings.push("No agents found in the fleet — plan will be a no-op.");
+  }
+
+  if (verb === "to-docker") {
+    steps.push({ kind: "watchdog-pause", rollback: "watchdog-resume" });
+    for (const a of state.agents) {
+      const unit = `switchroom-${a}.service`;
+      steps.push({
+        kind: "systemd-stop",
+        unit,
+        rollback: `systemctl --user start ${unit}`,
+      });
+      steps.push({
+        kind: "systemd-disable",
+        unit,
+        rollback: `systemctl --user enable ${unit}`,
+      });
+    }
+    if (typeof state.targetUid === "number") {
+      for (const a of state.agents) {
+        steps.push({
+          kind: "uid-align",
+          agent: a,
+          targetUid: state.targetUid,
+          rollback: "chown back to host UID (recorded in migration.log)",
+        });
+      }
+    }
+    steps.push({
+      kind: "compose-generate",
+      path: state.composePath,
+      project: state.composeProject,
+      rollback: `rm ${state.composePath}`,
+    });
+    steps.push({
+      kind: "compose-up",
+      project: state.composeProject,
+      path: state.composePath,
+      rollback: `docker compose -p ${state.composeProject} -f ${state.composePath} down`,
+    });
+    for (const a of state.agents) {
+      steps.push({
+        kind: "vault-broker-handshake",
+        agent: a,
+        rollback: "no rollback — handshake is idempotent",
+      });
+    }
+    steps.push({ kind: "marker-write", mode: "docker", rollback: "marker-write host" });
+    steps.push({ kind: "watchdog-resume" });
+  } else {
+    // to-host
+    steps.push({ kind: "watchdog-pause", rollback: "watchdog-resume" });
+    steps.push({
+      kind: "compose-down",
+      project: state.composeProject,
+      path: state.composePath,
+      rollback: `docker compose -p ${state.composeProject} -f ${state.composePath} up -d`,
+    });
+    for (const a of state.agents) {
+      const unit = `switchroom-${a}.service`;
+      steps.push({
+        kind: "systemd-enable",
+        unit,
+        rollback: `systemctl --user disable ${unit}`,
+      });
+      steps.push({
+        kind: "systemd-start",
+        unit,
+        rollback: `systemctl --user stop ${unit}`,
+      });
+    }
+    steps.push({ kind: "marker-write", mode: "host", rollback: "marker-write docker" });
+    steps.push({ kind: "watchdog-resume" });
+  }
+
+  return { verb, steps, warnings };
+}
+
+/* ------------------------------------------------------------------ */
+/* Pretty-printer                                                      */
+/* ------------------------------------------------------------------ */
+
+export function describeStep(step: PlanStep): string {
+  switch (step.kind) {
+    case "systemd-stop":
+      return `Stop systemd unit ${step.unit}`;
+    case "systemd-disable":
+      return `Disable systemd unit ${step.unit}`;
+    case "systemd-enable":
+      return `Enable systemd unit ${step.unit}`;
+    case "systemd-start":
+      return `Start systemd unit ${step.unit}`;
+    case "compose-generate":
+      return `Generate compose file at ${step.path} (project: ${step.project})`;
+    case "compose-up":
+      return `docker compose -p ${step.project} -f ${step.path} up -d`;
+    case "compose-down":
+      return `docker compose -p ${step.project} -f ${step.path} down`;
+    case "watchdog-pause":
+      return "Pause fleet watchdog";
+    case "watchdog-resume":
+      return "Resume fleet watchdog";
+    case "marker-write":
+      return `Write ~/.switchroom/runtime-mode = ${step.mode}`;
+    case "vault-broker-handshake":
+      return `Re-handshake vault-broker token for agent ${step.agent}`;
+    case "uid-align":
+      return `chown agent ${step.agent} workspace to UID ${step.targetUid}`;
+  }
+}
+
+export function formatPlanText(plan: MigrationPlan): string {
+  const lines: string[] = [];
+  lines.push(`Migration plan: ${plan.verb}`);
+  lines.push(`Steps: ${plan.steps.length}`);
+  lines.push("");
+  plan.steps.forEach((step, i) => {
+    const num = String(i + 1).padStart(2, " ");
+    lines.push(`  ${num}. ${describeStep(step)}`);
+    if (step.rollback) {
+      lines.push(`        rollback: ${step.rollback}`);
+    }
+  });
+  if (plan.warnings.length > 0) {
+    lines.push("");
+    lines.push("Warnings:");
+    for (const w of plan.warnings) lines.push(`  - ${w}`);
+  }
+  lines.push("");
+  lines.push("(dry-run — no side-effects performed)");
+  return lines.join("\n");
+}
+
+export function formatPlanJsonl(plan: MigrationPlan): string {
+  const lines: string[] = [];
+  lines.push(JSON.stringify({ kind: "header", verb: plan.verb, stepCount: plan.steps.length }));
+  plan.steps.forEach((step, i) => {
+    lines.push(JSON.stringify({ index: i + 1, ...step }));
+  });
+  for (const w of plan.warnings) {
+    lines.push(JSON.stringify({ kind: "warning", message: w }));
+  }
+  return lines.join("\n") + "\n";
+}

--- a/src/cli/migrate/preflight.test.ts
+++ b/src/cli/migrate/preflight.test.ts
@@ -1,0 +1,290 @@
+import { describe, expect, it } from "vitest";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  checkGitClean,
+  checkRuntimeMode,
+  checkSharedHost,
+  checkSystemdHealthy,
+  checkVaultUnlocked,
+  readRuntimeMode,
+  runPreflight,
+  type RunCommand,
+  type RunCommandResult,
+} from "./preflight.js";
+import type { BrokerStatus } from "../../vault/broker/protocol.js";
+
+function fakeRun(
+  table: Record<string, RunCommandResult | ((args: readonly string[]) => RunCommandResult)>,
+): RunCommand {
+  return async (cmd, args) => {
+    const key = `${cmd} ${args.join(" ")}`;
+    for (const [pattern, val] of Object.entries(table)) {
+      if (key.startsWith(pattern)) {
+        return typeof val === "function" ? val(args) : val;
+      }
+    }
+    return { stdout: "", stderr: `unmocked: ${key}`, exitCode: 127 };
+  };
+}
+
+const ok = (stdout = ""): RunCommandResult => ({ stdout, stderr: "", exitCode: 0 });
+
+const unlocked = (): Promise<BrokerStatus | null> =>
+  Promise.resolve({ unlocked: true, keyCount: 1, uptimeSec: 1 });
+const locked = (): Promise<BrokerStatus | null> =>
+  Promise.resolve({ unlocked: false, keyCount: 0, uptimeSec: 1 });
+const unreachable = (): Promise<BrokerStatus | null> => Promise.resolve(null);
+
+describe("checkGitClean", () => {
+  it("passes on a clean tree", async () => {
+    const r = await checkGitClean({ runCommand: fakeRun({ "git -C": ok("") }) });
+    expect(r.ok).toBe(true);
+  });
+
+  it("refuses on a dirty tree", async () => {
+    const r = await checkGitClean({
+      runCommand: fakeRun({ "git -C": ok(" M src/foo.ts\n") }),
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toMatch(/uncommitted changes/);
+  });
+
+  it("refuses if git itself fails", async () => {
+    const r = await checkGitClean({
+      runCommand: fakeRun({ "git -C": { stdout: "", stderr: "not a repo", exitCode: 128 } }),
+    });
+    expect(r.ok).toBe(false);
+  });
+});
+
+describe("checkVaultUnlocked", () => {
+  it("passes when broker reports unlocked", async () => {
+    const r = await checkVaultUnlocked({ probeBroker: unlocked });
+    expect(r.ok).toBe(true);
+  });
+
+  it("refuses when broker is locked", async () => {
+    const r = await checkVaultUnlocked({ probeBroker: locked });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toMatch(/locked/);
+  });
+
+  it("refuses when broker is unreachable", async () => {
+    const r = await checkVaultUnlocked({ probeBroker: unreachable });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toMatch(/not reachable/);
+  });
+
+  it("refuses when probe throws", async () => {
+    const r = await checkVaultUnlocked({
+      probeBroker: () => Promise.reject(new Error("boom")),
+    });
+    expect(r.ok).toBe(false);
+  });
+});
+
+describe("checkSystemdHealthy", () => {
+  it("skips for to-host", async () => {
+    const r = await checkSystemdHealthy("to-host", {
+      runCommand: fakeRun({ systemctl: { stdout: "x", stderr: "", exitCode: 0 } }),
+    });
+    expect(r.ok).toBe(true);
+  });
+
+  it("passes when no failed switchroom-* units", async () => {
+    const r = await checkSystemdHealthy("to-docker", {
+      runCommand: fakeRun({ systemctl: ok("") }),
+    });
+    expect(r.ok).toBe(true);
+  });
+
+  it("refuses when failed switchroom-* units exist", async () => {
+    const r = await checkSystemdHealthy("to-docker", {
+      runCommand: fakeRun({
+        systemctl: ok("switchroom-klanker.service loaded failed failed klanker\n"),
+      }),
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toMatch(/switchroom-klanker.service/);
+  });
+});
+
+describe("checkSharedHost", () => {
+  it("passes when fleet count == total", async () => {
+    const r = await checkSharedHost(
+      { sharedHost: false },
+      {
+        runCommand: fakeRun({
+          "docker ps -aq --filter": ok("a\nb\n"),
+          "docker ps -aq": ok("a\nb\n"),
+        }),
+      },
+    );
+    expect(r.ok).toBe(true);
+  });
+
+  it("refuses on foreign containers without --shared-host", async () => {
+    const r = await checkSharedHost(
+      { sharedHost: false },
+      {
+        runCommand: fakeRun({
+          "docker ps -aq --filter": ok("a\n"),
+          "docker ps -aq": ok("a\nb\nc\n"),
+        }),
+      },
+    );
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toMatch(/2 foreign/);
+  });
+
+  it("passes on foreign containers when --shared-host is set", async () => {
+    const r = await checkSharedHost(
+      { sharedHost: true },
+      {
+        runCommand: fakeRun({
+          "docker ps -aq --filter": ok("a\n"),
+          "docker ps -aq": ok("a\nb\nc\n"),
+        }),
+      },
+    );
+    expect(r.ok).toBe(true);
+  });
+
+  it("refuses if docker ps fails", async () => {
+    const r = await checkSharedHost(
+      { sharedHost: false },
+      {
+        runCommand: fakeRun({
+          "docker ps -aq": { stdout: "", stderr: "no daemon", exitCode: 1 },
+        }),
+      },
+    );
+    expect(r.ok).toBe(false);
+  });
+});
+
+describe("readRuntimeMode + checkRuntimeMode", () => {
+  function tmpMarker(content: string | null): string {
+    const dir = mkdtempSync(join(tmpdir(), "sr-rt-"));
+    const path = join(dir, "runtime-mode");
+    if (content !== null) writeFileSync(path, content);
+    return path;
+  }
+
+  it("returns null when missing", () => {
+    const dir = mkdtempSync(join(tmpdir(), "sr-rt-"));
+    expect(readRuntimeMode(join(dir, "missing"))).toBeNull();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("reads host/docker", () => {
+    const p1 = tmpMarker("host\n");
+    const p2 = tmpMarker("docker");
+    expect(readRuntimeMode(p1)).toBe("host");
+    expect(readRuntimeMode(p2)).toBe("docker");
+  });
+
+  it("ignores garbage", () => {
+    const p = tmpMarker("nonsense");
+    expect(readRuntimeMode(p)).toBeNull();
+  });
+
+  it("to-docker refuses if mode is already docker", async () => {
+    const p = tmpMarker("docker");
+    const r = await checkRuntimeMode("to-docker", { runtimeModePath: p });
+    expect(r.ok).toBe(false);
+  });
+
+  it("to-docker passes if mode is host or missing", async () => {
+    const p1 = tmpMarker("host");
+    expect((await checkRuntimeMode("to-docker", { runtimeModePath: p1 })).ok).toBe(true);
+    const dir = mkdtempSync(join(tmpdir(), "sr-rt-"));
+    expect(
+      (await checkRuntimeMode("to-docker", { runtimeModePath: join(dir, "x") })).ok,
+    ).toBe(true);
+  });
+
+  it("to-host refuses if mode is host or missing", async () => {
+    const p = tmpMarker("host");
+    expect((await checkRuntimeMode("to-host", { runtimeModePath: p })).ok).toBe(false);
+    const dir = mkdtempSync(join(tmpdir(), "sr-rt-"));
+    expect(
+      (await checkRuntimeMode("to-host", { runtimeModePath: join(dir, "x") })).ok,
+    ).toBe(false);
+  });
+
+  it("to-host passes if mode is docker", async () => {
+    const p = tmpMarker("docker");
+    expect((await checkRuntimeMode("to-host", { runtimeModePath: p })).ok).toBe(true);
+  });
+});
+
+describe("runPreflight composer", () => {
+  it("short-circuits at the first failing check", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "sr-rt-"));
+    const marker = join(dir, "rt");
+    writeFileSync(marker, "host");
+    const result = await runPreflight(
+      "to-docker",
+      { sharedHost: false },
+      {
+        runtimeModePath: marker,
+        probeBroker: unlocked,
+        runCommand: fakeRun({
+          "git -C": ok(" M dirty.ts\n"), // refuses here
+          systemctl: ok(""),
+          "docker ps -aq --filter": ok(""),
+          "docker ps -aq": ok(""),
+        }),
+      },
+    );
+    expect(result.ok).toBe(false);
+    expect(result.refusal?.name).toBe("git-clean");
+    expect(result.checks).toHaveLength(1);
+  });
+
+  it("returns ok=true when every check passes (to-docker)", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "sr-rt-"));
+    const marker = join(dir, "rt");
+    writeFileSync(marker, "host");
+    const result = await runPreflight(
+      "to-docker",
+      { sharedHost: false },
+      {
+        runtimeModePath: marker,
+        probeBroker: unlocked,
+        runCommand: fakeRun({
+          "git -C": ok(""),
+          systemctl: ok(""),
+          "docker ps -aq --filter": ok("a\n"),
+          "docker ps -aq": ok("a\n"),
+        }),
+      },
+    );
+    expect(result.ok).toBe(true);
+    expect(result.checks).toHaveLength(5);
+  });
+
+  it("returns ok=true for to-host with docker marker", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "sr-rt-"));
+    const marker = join(dir, "rt");
+    writeFileSync(marker, "docker");
+    const result = await runPreflight(
+      "to-host",
+      { sharedHost: false },
+      {
+        runtimeModePath: marker,
+        probeBroker: unlocked,
+        runCommand: fakeRun({
+          "git -C": ok(""),
+          systemctl: ok(""),
+          "docker ps -aq --filter": ok(""),
+          "docker ps -aq": ok(""),
+        }),
+      },
+    );
+    expect(result.ok).toBe(true);
+  });
+});

--- a/src/cli/migrate/preflight.ts
+++ b/src/cli/migrate/preflight.ts
@@ -1,0 +1,283 @@
+/**
+ * Pre-flight checks for `switchroom migrate {to-docker,to-host}`.
+ *
+ * Each check is a pure async function that takes injected dependencies
+ * (so tests can mock without spawning real subprocesses) and returns
+ * `{ok: true}` or `{ok: false, reason, fixHint?}`. The composer
+ * `runPreflight()` runs them in order and short-circuits on the first
+ * refusal.
+ *
+ * NO docker side-effects here, even on the happy path: `docker ps` is
+ * read-only and only invoked through the injected `runCommand` so unit
+ * tests can stub it.
+ */
+import { homedir } from "node:os";
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { statusViaBroker } from "../../vault/broker/client.js";
+import type { BrokerStatus } from "../../vault/broker/protocol.js";
+
+const execFileP = promisify(execFile);
+
+export type MigrateVerb = "to-docker" | "to-host";
+
+export type CheckResult =
+  | { ok: true }
+  | { ok: false; reason: string; fixHint?: string };
+
+export type RuntimeMode = "host" | "docker" | null;
+
+export interface RunCommandResult {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+}
+
+export type RunCommand = (
+  cmd: string,
+  args: readonly string[],
+) => Promise<RunCommandResult>;
+
+export const defaultRunCommand: RunCommand = async (cmd, args) => {
+  try {
+    const { stdout, stderr } = await execFileP(cmd, args, {
+      encoding: "utf8",
+      maxBuffer: 8 * 1024 * 1024,
+    });
+    return { stdout, stderr, exitCode: 0 };
+  } catch (err) {
+    const e = err as NodeJS.ErrnoException & {
+      stdout?: string;
+      stderr?: string;
+      code?: number | string;
+    };
+    return {
+      stdout: typeof e.stdout === "string" ? e.stdout : "",
+      stderr: typeof e.stderr === "string" ? e.stderr : String(err),
+      exitCode: typeof e.code === "number" ? e.code : 1,
+    };
+  }
+};
+
+export interface PreflightDeps {
+  runCommand?: RunCommand;
+  /** Override `git status` cwd; defaults to process.cwd(). */
+  gitCwd?: string;
+  /** Probe broker; defaults to {@link statusViaBroker}. */
+  probeBroker?: () => Promise<BrokerStatus | null>;
+  /** Override the runtime-mode marker path. Defaults to `~/.switchroom/runtime-mode`. */
+  runtimeModePath?: string;
+}
+
+export interface PreflightOpts {
+  sharedHost?: boolean;
+}
+
+/* ------------------------------------------------------------------ */
+/* Individual checks                                                   */
+/* ------------------------------------------------------------------ */
+
+export async function checkGitClean(deps: PreflightDeps = {}): Promise<CheckResult> {
+  const run = deps.runCommand ?? defaultRunCommand;
+  const cwd = deps.gitCwd ?? process.cwd();
+  const r = await run("git", ["-C", cwd, "status", "--porcelain"]);
+  if (r.exitCode !== 0) {
+    return {
+      ok: false,
+      reason: `git status failed in ${cwd}: ${r.stderr.trim() || "non-zero exit"}`,
+      fixHint: "Run from inside the switchroom checkout and ensure git is installed.",
+    };
+  }
+  if (r.stdout.trim().length > 0) {
+    return {
+      ok: false,
+      reason: `Working tree has uncommitted changes in ${cwd}.`,
+      fixHint: "Commit or stash your changes before migrating.",
+    };
+  }
+  return { ok: true };
+}
+
+export async function checkVaultUnlocked(deps: PreflightDeps = {}): Promise<CheckResult> {
+  const probe = deps.probeBroker ?? (() => statusViaBroker());
+  let status: BrokerStatus | null;
+  try {
+    status = await probe();
+  } catch (err) {
+    return {
+      ok: false,
+      reason: `vault-broker probe threw: ${(err as Error).message}`,
+      fixHint: "Start the vault-broker (`switchroom vault-broker start`) and unlock the vault.",
+    };
+  }
+  if (status === null) {
+    return {
+      ok: false,
+      reason: "vault-broker is not reachable.",
+      fixHint: "Start it with `switchroom vault-broker start` and unlock with `switchroom vault unlock`.",
+    };
+  }
+  if (!status.unlocked) {
+    return {
+      ok: false,
+      reason: "vault-broker is reachable but locked.",
+      fixHint: "Unlock with `switchroom vault unlock` (or via the Telegram unlock flow).",
+    };
+  }
+  return { ok: true };
+}
+
+export async function checkSystemdHealthy(
+  verb: MigrateVerb,
+  deps: PreflightDeps = {},
+): Promise<CheckResult> {
+  if (verb === "to-host") {
+    // Going TO systemd; failed units there are expected — don't gate on this.
+    return { ok: true };
+  }
+  const run = deps.runCommand ?? defaultRunCommand;
+  const r = await run("systemctl", [
+    "--user",
+    "list-units",
+    "--type=service",
+    "--state=failed",
+    "--no-legend",
+    "--plain",
+    "switchroom-*",
+  ]);
+  // Non-zero from systemctl with no failed units is unexpected but not fatal —
+  // treat empty stdout as "no failed units".
+  const lines = r.stdout
+    .split("\n")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+  const failed = lines
+    .map((l) => l.split(/\s+/, 1)[0])
+    .filter((u) => u.startsWith("switchroom-"));
+  if (failed.length > 0) {
+    return {
+      ok: false,
+      reason: `Found ${failed.length} failed switchroom-* systemd unit(s): ${failed.join(", ")}.`,
+      fixHint:
+        "Inspect with `systemctl --user status <unit>` and reset with `systemctl --user reset-failed <unit>` once resolved.",
+    };
+  }
+  return { ok: true };
+}
+
+export async function checkSharedHost(
+  opts: PreflightOpts,
+  deps: PreflightDeps = {},
+): Promise<CheckResult> {
+  const run = deps.runCommand ?? defaultRunCommand;
+  const total = await run("docker", ["ps", "-aq"]);
+  if (total.exitCode !== 0) {
+    return {
+      ok: false,
+      reason: `docker ps failed: ${total.stderr.trim() || "non-zero exit"}`,
+      fixHint: "Ensure Docker is installed and the daemon is running.",
+    };
+  }
+  const fleet = await run("docker", [
+    "ps",
+    "-aq",
+    "--filter",
+    "label=switchroom.fleet=",
+  ]);
+  if (fleet.exitCode !== 0) {
+    return {
+      ok: false,
+      reason: `docker ps --filter failed: ${fleet.stderr.trim() || "non-zero exit"}`,
+    };
+  }
+  const totalCount = total.stdout.split("\n").filter((s) => s.trim()).length;
+  const fleetCount = fleet.stdout.split("\n").filter((s) => s.trim()).length;
+  const foreign = totalCount - fleetCount;
+  if (foreign > 0 && !opts.sharedHost) {
+    return {
+      ok: false,
+      reason: `Detected ${foreign} foreign container(s) on this Docker daemon (Coolify, hindsight, etc.).`,
+      fixHint:
+        "Pass --shared-host to acknowledge label-discipline responsibility for the switchroom fleet.",
+    };
+  }
+  return { ok: true };
+}
+
+export function readRuntimeMode(path?: string): RuntimeMode {
+  const p = path ?? join(homedir(), ".switchroom", "runtime-mode");
+  if (!existsSync(p)) return null;
+  const v = readFileSync(p, "utf8").trim();
+  if (v === "host" || v === "docker") return v;
+  return null;
+}
+
+export async function checkRuntimeMode(
+  verb: MigrateVerb,
+  deps: PreflightDeps = {},
+): Promise<CheckResult> {
+  const mode = readRuntimeMode(deps.runtimeModePath);
+  if (verb === "to-docker") {
+    if (mode === "docker") {
+      return {
+        ok: false,
+        reason: "Runtime mode is already 'docker' per ~/.switchroom/runtime-mode.",
+        fixHint: "Use `switchroom migrate to-host` to revert before re-migrating.",
+      };
+    }
+    return { ok: true };
+  }
+  // to-host
+  if (mode === "host" || mode === null) {
+    return {
+      ok: false,
+      reason:
+        mode === null
+          ? "Runtime mode marker missing — nothing to roll back."
+          : "Runtime mode is already 'host'.",
+      fixHint: "to-host only makes sense when the fleet is currently running under Docker.",
+    };
+  }
+  return { ok: true };
+}
+
+/* ------------------------------------------------------------------ */
+/* Composer                                                            */
+/* ------------------------------------------------------------------ */
+
+export interface PreflightResult {
+  ok: boolean;
+  /** Per-check outcomes, in the order they ran. */
+  checks: Array<{ name: string; result: CheckResult }>;
+  /** First failing reason, for convenient display. */
+  refusal?: { name: string; reason: string; fixHint?: string };
+}
+
+export async function runPreflight(
+  verb: MigrateVerb,
+  opts: PreflightOpts,
+  deps: PreflightDeps = {},
+): Promise<PreflightResult> {
+  const order: Array<{ name: string; run: () => Promise<CheckResult> }> = [
+    { name: "git-clean", run: () => checkGitClean(deps) },
+    { name: "vault-unlocked", run: () => checkVaultUnlocked(deps) },
+    { name: "systemd-healthy", run: () => checkSystemdHealthy(verb, deps) },
+    { name: "shared-host", run: () => checkSharedHost(opts, deps) },
+    { name: "runtime-mode", run: () => checkRuntimeMode(verb, deps) },
+  ];
+  const checks: Array<{ name: string; result: CheckResult }> = [];
+  for (const c of order) {
+    const result = await c.run();
+    checks.push({ name: c.name, result });
+    if (!result.ok) {
+      return {
+        ok: false,
+        checks,
+        refusal: { name: c.name, reason: result.reason, fixHint: result.fixHint },
+      };
+    }
+  }
+  return { ok: true, checks };
+}


### PR DESCRIPTION
## Summary

First of three Phase 3b-2 sub-PRs adding `switchroom migrate {to-docker,to-host}`. This PR is **scaffolding only** — pure logic + unit tests, **no docker side-effects**.

- Pre-flight checks (`src/cli/migrate/preflight.ts`): git-clean, vault-unlocked, systemd-healthy (to-docker only), shared-host (foreign-container detection), runtime-mode marker. Composer short-circuits at first refusal. All deps injected so unit tests can stub `docker ps` / `git status` / broker probe.
- Plan builder (`src/cli/migrate/plan.ts`): typed `PlanStep` with rollback hints, snapshot-tested pretty-printer, JSONL formatter.
- Migration log writer (`src/cli/migrate/log.ts`): JSONL append-only writer for `~/.switchroom/migration.log`. In-process promise chain serializes concurrent writes.
- CLI wiring (`src/cli/migrate/index.ts`): both verbs accept `--dry-run`, `--json`; `to-docker` also accepts `--shared-host`.

## What's in / out of scope

**In:** preflight, dry-run plan rendering (text + JSONL), migration.log writer, CLI surface for both verbs.

**Out (intentional):** actually executing the plan. Without `--dry-run`, both verbs exit `2` with `"migrate <verb> not yet implemented in this version; use --dry-run to preview the plan"`. The mutation paths land in:
- 3b-2b — `to-docker` happy path (compose generation, UID alignment, watchdog pause integration).
- 3b-2c — `to-host` reversal + round-trip e2e test.

This keeps the CLI surface stable while shipping the testable foundation.

## Test plan

- [x] `npx vitest run src/cli/migrate` — 40 tests pass (24 preflight, 10 plan, 6 log).
- [x] `npm run lint` clean.
- [x] Full vitest no worse than baseline (pre-existing failures in `tests/cli.issues.test.ts`, drive tests, etc. — confirmed present on `upstream/main` too; none touch new code).
- [x] Smoke: `bun run dev -- migrate to-docker` and `migrate to-host` both print the not-implemented message.
- [x] No live docker calls — `docker ps` only invoked through injected `RunCommand` in tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)