### PR TITLE
Phase 3b-2c: switchroom migrate to-host + round-trip e2e + reviewer nits

### DIFF
--- a/src/cli/migrate/executor.test.ts
+++ b/src/cli/migrate/executor.test.ts
@@ -61,6 +61,115 @@ function setupRoot(): { root: string; deps: Required<ExecutorDeps>["logPath"] | 
   return { root, deps: root };
 }
 
+describe("executePlan to-host", () => {
+  it("happy path: stops compose, re-enables/starts systemd, marker=host", async () => {
+    const root = tmpRoot();
+    const logPath = join(root, "migration.log");
+    const composePath = join(root, "compose", "docker-compose.yml");
+    const runtimeModePath = join(root, "runtime-mode");
+    const watchdogPausePath = join(root, "watchdog.paused");
+    // Pretend we were in docker mode.
+    mkdirSync(root, { recursive: true });
+    writeFileSync(runtimeModePath, "docker\n", "utf8");
+    // Pretend the compose file exists (so compose-down's existsSync
+    // branch includes -f).
+    mkdirSync(join(root, "compose"), { recursive: true });
+    writeFileSync(composePath, "# stale compose\n", "utf8");
+
+    const { run, calls } = makeRunner();
+
+    const plan = buildPlan("to-host", {
+      agents: ["alice", "bob"],
+      composeProject: "switchroom-fleet",
+      composePath,
+    });
+
+    const result = await executePlan(
+      plan,
+      { composeProject: "switchroom-fleet", composePath },
+      {
+        runCommand: run,
+        generateComposeContent: () => "# unused for to-host\n",
+        probeAgentBroker: async () => true,
+        confirmUidAlign: async () => true,
+        chownPath: async () => undefined,
+        logPath,
+        runtimeModePath,
+        watchdogPausePath,
+        agentsRoot: join(root, "agents"),
+      },
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.completed.length).toBe(plan.steps.length);
+    expect(readFileSync(runtimeModePath, "utf8").trim()).toBe("host");
+    expect(existsSync(watchdogPausePath)).toBe(false);
+
+    const dockerDown = calls.find(
+      (c) => c.cmd === "docker" && c.args.includes("down"),
+    );
+    expect(dockerDown).toBeTruthy();
+    const enables = calls.filter(
+      (c) => c.cmd === "systemctl" && c.args.includes("enable"),
+    );
+    expect(enables.length).toBe(2);
+    const starts = calls.filter(
+      (c) => c.cmd === "systemctl" && c.args.includes("start"),
+    );
+    expect(starts.length).toBe(2);
+
+    const log = readLog(logPath);
+    expect(log.length).toBe(plan.steps.length);
+    expect(log.every((e) => e.status === "ok")).toBe(true);
+    expect(log.every((e) => e.verb === "to-host")).toBe(true);
+  });
+
+  it("rolls back when systemd-start fails on second agent", async () => {
+    const root = tmpRoot();
+    const logPath = join(root, "migration.log");
+    const composePath = join(root, "compose", "docker-compose.yml");
+    const runtimeModePath = join(root, "runtime-mode");
+    const watchdogPausePath = join(root, "watchdog.paused");
+    writeFileSync(runtimeModePath, "docker\n", "utf8");
+
+    let startCount = 0;
+    const { run } = makeRunner((cmd, args) => {
+      if (cmd === "systemctl" && args.includes("start")) {
+        startCount++;
+        if (startCount === 2) return "failed to start: unit not found";
+      }
+      return null;
+    });
+
+    const plan = buildPlan("to-host", {
+      agents: ["alice", "bob"],
+      composeProject: "switchroom-fleet",
+      composePath,
+    });
+
+    const result = await executePlan(
+      plan,
+      { composeProject: "switchroom-fleet", composePath },
+      {
+        runCommand: run,
+        generateComposeContent: () => "# stub\n",
+        probeAgentBroker: async () => true,
+        confirmUidAlign: async () => true,
+        chownPath: async () => undefined,
+        logPath,
+        runtimeModePath,
+        watchdogPausePath,
+        agentsRoot: join(root, "agents"),
+      },
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.failed?.step.kind).toBe("systemd-start");
+    // Marker must remain "docker" — marker-write hadn't run yet.
+    expect(readFileSync(runtimeModePath, "utf8").trim()).toBe("docker");
+  });
+});
+
 describe("executePlan to-docker", () => {
   it("happy path: runs all steps, writes ok log entries, exits ok", async () => {
     const root = tmpRoot();
@@ -301,6 +410,82 @@ describe("executePlan to-docker", () => {
     expect(result.ok).toBe(false);
     expect(result.failed?.step.kind).toBe("uid-align");
     expect(confirmed).toBe(1);
+  });
+
+  it("rollback log entries name the actual step they revert (not a shifted neighbour)", async () => {
+    // Regression for the 3b-2b nit: with completed.length > rollback.length
+    // (vault-broker-handshake / watchdog-resume push no hook), the previous
+    // mapping `idx = completed[completed.length - 1 - h]` mis-attributed
+    // rollback log entries. Force a failure AFTER the handshake step has
+    // run (so completed includes a hook-less step) and assert every
+    // rollback log entry references one of the steps that actually pushed
+    // a hook — never the handshake/resume.
+    const root = tmpRoot();
+    const logPath = join(root, "migration.log");
+    const composePath = join(root, "compose", "docker-compose.yml");
+    const runtimeModePath = join(root, "runtime-mode");
+    const watchdogPausePath = join(root, "watchdog.paused");
+
+    // Two agents so we exercise multiple handshake steps.
+    const plan = buildPlan("to-docker", {
+      agents: ["alice", "bob"],
+      composeProject: "switchroom-fleet",
+      composePath,
+    });
+
+    // Find the marker-write index — failing it causes rollback after
+    // both vault-broker-handshake steps already ran (they push no hook).
+    const markerIdx = plan.steps.findIndex((s) => s.kind === "marker-write");
+    expect(markerIdx).toBeGreaterThan(0);
+
+    // We can't easily fail a marker-write via runCommand; instead, fail
+    // a systemctl call indirectly by counting calls. Simpler: inject a
+    // chownPath stub that never runs (no uid-align step, targetUid omitted).
+    // To force a failure post-handshake, fail the broker probe for "bob"
+    // only — that aborts at the second handshake AFTER alice's handshake
+    // was a successful no-rollback step.
+    let probeCount = 0;
+    const { run } = makeRunner();
+    const result = await executePlan(
+      plan,
+      { composeProject: "switchroom-fleet", composePath },
+      {
+        runCommand: run,
+        generateComposeContent: () => "# stub\n",
+        probeAgentBroker: async (agent) => {
+          probeCount++;
+          return agent !== "bob"; // fail on bob
+        },
+        confirmUidAlign: async () => true,
+        chownPath: async () => undefined,
+        logPath,
+        runtimeModePath,
+        watchdogPausePath,
+        agentsRoot: join(root, "agents"),
+      },
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.failed?.step.kind).toBe("vault-broker-handshake");
+    expect(probeCount).toBe(2);
+
+    const log = readLog(logPath);
+    const rollbackEntries = log.filter((e) => e.status === "rollback");
+    expect(rollbackEntries.length).toBeGreaterThan(0);
+    // No rollback entry should be tagged as a handshake or watchdog-resume
+    // (those steps push no hook). Every rollback entry MUST correspond to
+    // a step that actually had a rollback hook.
+    for (const entry of rollbackEntries) {
+      const stepLabel = String(entry.step);
+      expect(stepLabel).not.toMatch(/vault-broker-handshake/);
+      expect(stepLabel).not.toBe("watchdog-resume");
+      // And it should match one of: watchdog-pause, systemd-stop,
+      // systemd-disable, compose-generate, compose-up, marker-write,
+      // uid-align.
+      expect(stepLabel).toMatch(
+        /^(watchdog-pause|systemd-(stop|disable|enable|start)|compose-(generate|up|down)|marker-write|uid-align)/,
+      );
+    }
   });
 
   it("preserves prior runtime-mode marker on rollback", async () => {

--- a/src/cli/migrate/executor.ts
+++ b/src/cli/migrate/executor.ts
@@ -17,8 +17,8 @@
  * exercise both happy-path and forced-failure rollback paths without
  * touching the real host.
  */
-import { existsSync, readFileSync, statSync } from "node:fs";
-import { mkdir, rm, writeFile, chown } from "node:fs/promises";
+import { existsSync, statSync } from "node:fs";
+import { mkdir, readFile, rm, writeFile, chown } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { homedir } from "node:os";
 import type {
@@ -160,8 +160,14 @@ interface StepCtx {
     >
   >;
   opts: ExecutorOpts;
-  /** Per-step rollback hooks recorded as we go (LIFO). */
-  rollback: Array<() => Promise<void>>;
+  /**
+   * Per-step rollback hooks recorded as we go (LIFO). Each hook records
+   * the original `plan.steps` index it reverses so audit-log entries can
+   * name the step accurately even when some completed steps push no hook
+   * (e.g. `vault-broker-handshake` is idempotent, `watchdog-resume` has
+   * nothing to undo).
+   */
+  rollback: Array<{ stepIndex: number; fn: () => Promise<void> }>;
 }
 
 async function runSystemctl(
@@ -213,11 +219,13 @@ async function writeMarker(path: string, content: string): Promise<void> {
   await writeFile(path, content + "\n", { encoding: "utf8", mode: 0o600 });
 }
 
-async function executeStep(ctx: StepCtx, step: PlanStep): Promise<void> {
+async function executeStep(ctx: StepCtx, step: PlanStep, stepIndex: number): Promise<void> {
+  const pushRollback = (fn: () => Promise<void>) =>
+    ctx.rollback.push({ stepIndex, fn });
   switch (step.kind) {
     case "watchdog-pause": {
       await writeMarker(ctx.deps.watchdogPausePath, "paused-by=migrate");
-      ctx.rollback.push(async () => {
+      pushRollback(async () => {
         await rm(ctx.deps.watchdogPausePath, { force: true });
       });
       return;
@@ -231,7 +239,7 @@ async function executeStep(ctx: StepCtx, step: PlanStep): Promise<void> {
     case "systemd-stop": {
       await runSystemctl(ctx, "stop", step.unit);
       const unit = step.unit;
-      ctx.rollback.push(async () => {
+      pushRollback(async () => {
         await runSystemctl(ctx, "start", unit).catch(() => undefined);
       });
       return;
@@ -239,7 +247,7 @@ async function executeStep(ctx: StepCtx, step: PlanStep): Promise<void> {
     case "systemd-disable": {
       await runSystemctl(ctx, "disable", step.unit);
       const unit = step.unit;
-      ctx.rollback.push(async () => {
+      pushRollback(async () => {
         await runSystemctl(ctx, "enable", unit).catch(() => undefined);
       });
       return;
@@ -247,7 +255,7 @@ async function executeStep(ctx: StepCtx, step: PlanStep): Promise<void> {
     case "systemd-enable": {
       await runSystemctl(ctx, "enable", step.unit);
       const unit = step.unit;
-      ctx.rollback.push(async () => {
+      pushRollback(async () => {
         await runSystemctl(ctx, "disable", unit).catch(() => undefined);
       });
       return;
@@ -255,7 +263,7 @@ async function executeStep(ctx: StepCtx, step: PlanStep): Promise<void> {
     case "systemd-start": {
       await runSystemctl(ctx, "start", step.unit);
       const unit = step.unit;
-      ctx.rollback.push(async () => {
+      pushRollback(async () => {
         await runSystemctl(ctx, "stop", unit).catch(() => undefined);
       });
       return;
@@ -265,7 +273,7 @@ async function executeStep(ctx: StepCtx, step: PlanStep): Promise<void> {
       await mkdir(dirname(step.path), { recursive: true });
       await writeFile(step.path, content, { encoding: "utf8", mode: 0o600 });
       const path = step.path;
-      ctx.rollback.push(async () => {
+      pushRollback(async () => {
         await rm(path, { force: true });
       });
       return;
@@ -274,7 +282,7 @@ async function executeStep(ctx: StepCtx, step: PlanStep): Promise<void> {
       await runComposeUp(ctx, step.project, step.path);
       const project = step.project;
       const path = step.path;
-      ctx.rollback.push(async () => {
+      pushRollback(async () => {
         await runComposeDown(ctx, project, path).catch(() => undefined);
       });
       return;
@@ -287,9 +295,9 @@ async function executeStep(ctx: StepCtx, step: PlanStep): Promise<void> {
       return;
     }
     case "marker-write": {
-      const prev = readMarkerSafe(ctx.deps.runtimeModePath);
+      const prev = await readMarkerSafe(ctx.deps.runtimeModePath);
       await writeMarker(ctx.deps.runtimeModePath, step.mode);
-      ctx.rollback.push(async () => {
+      pushRollback(async () => {
         if (prev === null) {
           await rm(ctx.deps.runtimeModePath, { force: true });
         } else {
@@ -327,7 +335,7 @@ async function executeStep(ctx: StepCtx, step: PlanStep): Promise<void> {
       const fromUid = st.uid;
       const fromGid = st.gid;
       await ctx.deps.chownPath(dir, step.targetUid, step.targetUid);
-      ctx.rollback.push(async () => {
+      pushRollback(async () => {
         await ctx.deps.chownPath(dir, fromUid, fromGid).catch(() => undefined);
       });
       return;
@@ -335,11 +343,12 @@ async function executeStep(ctx: StepCtx, step: PlanStep): Promise<void> {
   }
 }
 
-function readMarkerSafe(path: string): string | null {
+async function readMarkerSafe(path: string): Promise<string | null> {
   try {
-    if (!existsSync(path)) return null;
-    return readFileSync(path, "utf8").trim();
-  } catch {
+    const buf = await readFile(path, "utf8");
+    return buf.trim();
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return null;
     return null;
   }
 }
@@ -399,7 +408,7 @@ export async function executePlan(
     const label = describeStepShort(step);
     opts.onProgress?.(`step ${i + 1}/${plan.steps.length}: ${label}`);
     try {
-      await executeStep(ctx, step);
+      await executeStep(ctx, step, i);
       await appendMigrationLogEntry(
         { verb: plan.verb, step: label, status: "ok" },
         deps.logPath,
@@ -411,15 +420,19 @@ export async function executePlan(
         { verb: plan.verb, step: label, status: "error", error: msg },
         deps.logPath,
       );
-      // Run rollback hooks (LIFO).
+      // Run rollback hooks (LIFO). Each hook carries the step index it
+      // reverses so the audit-log entry names the right step even when
+      // some completed steps push no hook (e.g. vault-broker-handshake,
+      // watchdog-resume).
       const hooks = ctx.rollback.slice().reverse();
-      for (let h = 0; h < hooks.length; h++) {
-        const idx = completed[completed.length - 1 - h];
-        const stepIdx = typeof idx === "number" ? idx : -1;
+      for (const hook of hooks) {
+        const stepIdx = hook.stepIndex;
         const stepLabel =
-          stepIdx >= 0 ? describeStepShort(plan.steps[stepIdx]!) : `hook-${h}`;
+          stepIdx >= 0 && stepIdx < plan.steps.length
+            ? describeStepShort(plan.steps[stepIdx]!)
+            : `hook-${stepIdx}`;
         try {
-          await hooks[h]!();
+          await hook.fn();
           await appendMigrationLogEntry(
             {
               verb: plan.verb,

--- a/src/cli/migrate/index.ts
+++ b/src/cli/migrate/index.ts
@@ -23,19 +23,14 @@ interface DryRunOpts {
   sharedHost?: boolean;
 }
 
-function notImplemented(verb: MigrateVerb): never {
-  console.error(
-    chalk.red(
-      `migrate ${verb} not yet implemented in this version; use --dry-run to preview the plan`,
-    ),
-  );
-  process.exit(2);
-}
-
-async function runToDocker(opts: DryRunOpts, program: Command): Promise<void> {
+async function runMigration(
+  verb: MigrateVerb,
+  opts: DryRunOpts,
+  program: Command,
+): Promise<void> {
   const config = getConfig(program);
   const agents = Object.keys(config.agents ?? {}).sort();
-  const preflight = await runPreflight("to-docker", { sharedHost: !!opts.sharedHost });
+  const preflight = await runPreflight(verb, { sharedHost: !!opts.sharedHost });
   if (!preflight.ok) {
     const r = preflight.refusal!;
     console.error(chalk.red(`Pre-flight refused at check: ${r.name}`));
@@ -49,9 +44,9 @@ async function runToDocker(opts: DryRunOpts, program: Command): Promise<void> {
     agents,
     composeProject,
     composePath,
-    targetUid: process.getuid?.(),
+    targetUid: verb === "to-docker" ? process.getuid?.() : undefined,
   };
-  const plan = buildPlan("to-docker", state);
+  const plan = buildPlan(verb, state);
   const result = await executePlan(plan, {
     composeProject,
     composePath,
@@ -60,7 +55,7 @@ async function runToDocker(opts: DryRunOpts, program: Command): Promise<void> {
   if (!result.ok) {
     console.error(
       chalk.red(
-        `migrate to-docker FAILED at step ${result.failed!.index + 1}: ${result.failed!.error}`,
+        `migrate ${verb} FAILED at step ${result.failed!.index + 1}: ${result.failed!.error}`,
       ),
     );
     console.error(
@@ -70,7 +65,7 @@ async function runToDocker(opts: DryRunOpts, program: Command): Promise<void> {
     );
     process.exit(1);
   }
-  console.log(chalk.green(`migrate to-docker complete (${result.completed.length} steps).`));
+  console.log(chalk.green(`migrate ${verb} complete (${result.completed.length} steps).`));
 }
 
 async function runDryRun(
@@ -141,7 +136,7 @@ export function registerMigrateCommand(program: Command): void {
           await runDryRun("to-docker", opts, program);
           return;
         }
-        await runToDocker(opts, program);
+        await runMigration("to-docker", opts, program);
       }),
     );
 
@@ -152,8 +147,11 @@ export function registerMigrateCommand(program: Command): void {
     .option("--json", "Emit machine-readable JSONL output (with --dry-run)")
     .action(
       withConfigError(async (opts: DryRunOpts) => {
-        if (!opts.dryRun) notImplemented("to-host");
-        await runDryRun("to-host", opts, program);
+        if (opts.dryRun) {
+          await runDryRun("to-host", opts, program);
+          return;
+        }
+        await runMigration("to-host", opts, program);
       }),
     );
 }

--- a/tests/docker/phase3b2c-migrate-roundtrip.test.ts
+++ b/tests/docker/phase3b2c-migrate-roundtrip.test.ts
@@ -1,0 +1,340 @@
+/**
+ * Phase 3b-2c — `switchroom migrate` round-trip e2e.
+ *
+ * Headline acceptance test for Phase 3b-2: drives the executor through
+ * `to-docker` and then `to-host` against a fully isolated tmpdir
+ * "switchroom home" (runtime-mode marker, compose path, watchdog
+ * sentinel, agents root, migration.log all redirected). Real docker
+ * daemon is exercised — but only via a single labelled alpine sleep
+ * service inside a phase3b2c-scoped compose project. Systemd is faked
+ * via an injected `RunCommand` that records calls.
+ *
+ * What we assert:
+ *   1. to-docker: containers up under the test project, runtime-mode
+ *      marker == "docker", migration.log shows ok entries for every
+ *      step.
+ *   2. broker.db + kernel.db schema_version snapshots taken between
+ *      the two migrations remain stable across to-host.
+ *   3. to-host: containers down (compose-down scoped to project),
+ *      runtime-mode marker == "host", migration.log shows ok entries
+ *      for the reversal.
+ *   4. Pre/post `sudo docker ps` snapshot identical (no Coolify drift).
+ *
+ * HARD RULES compliance:
+ *   - Every test container labelled `switchroom.test=phase3b2c` plus
+ *     a per-run UUID label.
+ *   - Compose project name `switchroom-test-phase3b2c-${RUN_ID8}` —
+ *     scope guarantees compose-down only touches our fixtures.
+ *   - safeLabelTeardown() in afterAll as belt-and-braces.
+ *   - Never touches the real ~/.switchroom/ — every state path is
+ *     redirected via ExecutorDeps.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { execSync } from "node:child_process";
+import { mkdtempSync, rmSync, existsSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { randomUUID } from "node:crypto";
+// @ts-expect-error - node:sqlite is built-in on Node ≥ 22.5 but lacks ambient
+// types in this repo's tsconfig. We use it only for a schema_version PRAGMA.
+import { DatabaseSync } from "node:sqlite";
+
+import { buildPlan } from "../../src/cli/migrate/plan.js";
+import { executePlan } from "../../src/cli/migrate/executor.js";
+import { _resetLogChainForTests } from "../../src/cli/migrate/log.js";
+import type { RunCommand } from "../../src/cli/migrate/preflight.js";
+import {
+  captureProdSnapshot,
+  expectNoProdDrift,
+  type ProdSnapshot,
+} from "./_prod-snapshot";
+
+const RUN_ID = randomUUID();
+const RUN_ID_SHORT = RUN_ID.slice(0, 8);
+const COMPOSE_PROJECT = `switchroom-test-phase3b2c-${RUN_ID_SHORT}`;
+const ALPINE = "alpine:3.19";
+
+function hasDocker(): boolean {
+  try {
+    execSync("docker version --format '{{.Server.Version}}'", {
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function hasImage(ref: string): boolean {
+  try {
+    execSync(`docker image inspect ${ref}`, { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function ensureAlpine(): boolean {
+  if (hasImage(ALPINE)) return true;
+  try {
+    execSync(`docker pull ${ALPINE}`, { stdio: ["ignore", "pipe", "pipe"] });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const dockerOk = hasDocker();
+const imageOk = dockerOk && ensureAlpine();
+
+function safeLabelTeardown(): void {
+  for (const filter of [
+    `label=switchroom.test.run=${RUN_ID}`,
+    `label=switchroom.test=phase3b2c`,
+  ]) {
+    try {
+      const ids = execSync(`docker ps -aq --filter ${filter}`, {
+        stdio: ["ignore", "pipe", "ignore"],
+      })
+        .toString()
+        .trim();
+      if (ids.length === 0) continue;
+      execSync(`docker rm -f ${ids.split(/\s+/).join(" ")}`, { stdio: "ignore" });
+    } catch {
+      /* best-effort */
+    }
+  }
+  // Also: project-scoped compose down as the primary path.
+  try {
+    execSync(`docker compose -p ${COMPOSE_PROJECT} down -v --remove-orphans`, {
+      stdio: "ignore",
+    });
+  } catch {
+    /* best-effort */
+  }
+}
+
+/**
+ * Build the labelled compose YAML the executor's `compose-generate`
+ * step will write. Single alpine service running `sleep` so compose-up
+ * succeeds and the round-trip exercises real container lifecycle.
+ */
+function makeComposeYaml(): string {
+  return [
+    `services:`,
+    `  alice:`,
+    `    image: ${ALPINE}`,
+    `    container_name: phase3b2c-${RUN_ID_SHORT}-alice`,
+    `    command: ["sleep", "3600"]`,
+    `    labels:`,
+    `      switchroom.test: "phase3b2c"`,
+    `      switchroom.test.run: "${RUN_ID}"`,
+    ``,
+  ].join("\n");
+}
+
+function snapshotSchema(dbPath: string): number {
+  const db = new DatabaseSync(dbPath);
+  try {
+    const row = db.prepare("PRAGMA schema_version").get() as { schema_version: number };
+    return row.schema_version;
+  } finally {
+    db.close();
+  }
+}
+
+function seedDb(dbPath: string): void {
+  const db = new DatabaseSync(dbPath);
+  try {
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS sample (id INTEGER PRIMARY KEY, v TEXT);
+      INSERT INTO sample (v) VALUES ('seed-${RUN_ID_SHORT}');
+    `);
+  } finally {
+    db.close();
+  }
+}
+
+let prodBefore: ProdSnapshot;
+let TMP_HOME: string;
+let LOG_PATH: string;
+let COMPOSE_PATH: string;
+let RUNTIME_MODE_PATH: string;
+let WATCHDOG_PAUSE_PATH: string;
+let AGENTS_ROOT: string;
+let BROKER_DB: string;
+let KERNEL_DB: string;
+let recordedSystemctl: Array<{ args: readonly string[] }> = [];
+
+beforeAll(() => {
+  prodBefore = captureProdSnapshot();
+  TMP_HOME = mkdtempSync(join(tmpdir(), "sr-3b2c-"));
+  LOG_PATH = join(TMP_HOME, "migration.log");
+  COMPOSE_PATH = join(TMP_HOME, "compose", "docker-compose.yml");
+  RUNTIME_MODE_PATH = join(TMP_HOME, "runtime-mode");
+  WATCHDOG_PAUSE_PATH = join(TMP_HOME, "watchdog.paused");
+  AGENTS_ROOT = join(TMP_HOME, "agents");
+  mkdirSync(AGENTS_ROOT, { recursive: true });
+  mkdirSync(join(AGENTS_ROOT, "alice"), { recursive: true });
+
+  // Seed dbs to mimic broker/kernel state.
+  BROKER_DB = join(TMP_HOME, "broker.db");
+  KERNEL_DB = join(TMP_HOME, "kernel.db");
+  seedDb(BROKER_DB);
+  seedDb(KERNEL_DB);
+
+  // Pretend we start in host mode.
+  writeFileSync(RUNTIME_MODE_PATH, "host\n", "utf8");
+
+  _resetLogChainForTests();
+});
+
+afterAll(() => {
+  safeLabelTeardown();
+  if (TMP_HOME && existsSync(TMP_HOME)) {
+    rmSync(TMP_HOME, { recursive: true, force: true });
+  }
+  const after = captureProdSnapshot();
+  expectNoProdDrift(prodBefore, after);
+});
+
+const skipIfNoDocker = !dockerOk || !imageOk ? it.skip : it;
+
+describe("phase3b2c migrate round-trip (host → docker → host)", () => {
+  skipIfNoDocker(
+    "completes round-trip with stable schema and no prod drift",
+    async () => {
+      const fakeSystemctl: RunCommand = async (cmd, args) => {
+        if (cmd === "systemctl") {
+          recordedSystemctl.push({ args });
+          return { stdout: "", stderr: "", exitCode: 0 };
+        }
+        // For docker we shell out for real — see runCommandReal below.
+        return { stdout: "", stderr: "unexpected cmd via fake", exitCode: 1 };
+      };
+
+      // Compound runner: real docker, fake systemctl.
+      const runCommand: RunCommand = async (cmd, args) => {
+        if (cmd === "systemctl") return fakeSystemctl(cmd, args);
+        if (cmd === "docker") {
+          try {
+            const out = execSync(
+              `docker ${args.map((a) => JSON.stringify(a)).join(" ")}`,
+              { stdio: ["ignore", "pipe", "pipe"] },
+            ).toString();
+            return { stdout: out, stderr: "", exitCode: 0 };
+          } catch (err: any) {
+            return {
+              stdout: err.stdout?.toString() ?? "",
+              stderr: err.stderr?.toString() ?? String(err.message ?? err),
+              exitCode: err.status ?? 1,
+            };
+          }
+        }
+        return { stdout: "", stderr: `unexpected cmd ${cmd}`, exitCode: 1 };
+      };
+
+      // ---- to-docker ----------------------------------------------------
+      const toDockerPlan = buildPlan("to-docker", {
+        agents: ["alice"],
+        composeProject: COMPOSE_PROJECT,
+        composePath: COMPOSE_PATH,
+        // No targetUid → skip uid-align step (we don't want chown noise).
+      });
+
+      const toDockerResult = await executePlan(
+        toDockerPlan,
+        { composeProject: COMPOSE_PROJECT, composePath: COMPOSE_PATH },
+        {
+          runCommand,
+          generateComposeContent: () => makeComposeYaml(),
+          probeAgentBroker: async () => true,
+          confirmUidAlign: async () => true,
+          chownPath: async () => undefined,
+          logPath: LOG_PATH,
+          runtimeModePath: RUNTIME_MODE_PATH,
+          watchdogPausePath: WATCHDOG_PAUSE_PATH,
+          agentsRoot: AGENTS_ROOT,
+        },
+      );
+
+      expect(toDockerResult.ok).toBe(true);
+      expect(toDockerResult.completed.length).toBe(toDockerPlan.steps.length);
+      expect(readFileSync(RUNTIME_MODE_PATH, "utf8").trim()).toBe("docker");
+
+      // Verify the test container is up under our scoped project.
+      const psOut = execSync(
+        `docker ps --filter label=switchroom.test.run=${RUN_ID} --format '{{.Names}}'`,
+        { stdio: ["ignore", "pipe", "pipe"] },
+      )
+        .toString()
+        .trim();
+      expect(psOut).toContain(`phase3b2c-${RUN_ID_SHORT}-alice`);
+
+      // ---- mid-flight schema snapshot ----------------------------------
+      const brokerSchemaMid = snapshotSchema(BROKER_DB);
+      const kernelSchemaMid = snapshotSchema(KERNEL_DB);
+
+      // ---- to-host ------------------------------------------------------
+      const toHostPlan = buildPlan("to-host", {
+        agents: ["alice"],
+        composeProject: COMPOSE_PROJECT,
+        composePath: COMPOSE_PATH,
+      });
+
+      const toHostResult = await executePlan(
+        toHostPlan,
+        { composeProject: COMPOSE_PROJECT, composePath: COMPOSE_PATH },
+        {
+          runCommand,
+          generateComposeContent: () => makeComposeYaml(),
+          probeAgentBroker: async () => true,
+          confirmUidAlign: async () => true,
+          chownPath: async () => undefined,
+          logPath: LOG_PATH,
+          runtimeModePath: RUNTIME_MODE_PATH,
+          watchdogPausePath: WATCHDOG_PAUSE_PATH,
+          agentsRoot: AGENTS_ROOT,
+        },
+      );
+
+      expect(toHostResult.ok).toBe(true);
+      expect(toHostResult.completed.length).toBe(toHostPlan.steps.length);
+      expect(readFileSync(RUNTIME_MODE_PATH, "utf8").trim()).toBe("host");
+
+      // Container should be gone (compose down scoped to our project).
+      const psAfter = execSync(
+        `docker ps -a --filter label=switchroom.test.run=${RUN_ID} --format '{{.Names}}'`,
+        { stdio: ["ignore", "pipe", "pipe"] },
+      )
+        .toString()
+        .trim();
+      expect(psAfter).toBe("");
+
+      // ---- post schema snapshot ----------------------------------------
+      const brokerSchemaPost = snapshotSchema(BROKER_DB);
+      const kernelSchemaPost = snapshotSchema(KERNEL_DB);
+      expect(brokerSchemaPost).toBe(brokerSchemaMid);
+      expect(kernelSchemaPost).toBe(kernelSchemaMid);
+
+      // ---- migration.log shape -----------------------------------------
+      const log = readFileSync(LOG_PATH, "utf8")
+        .split("\n")
+        .filter((l) => l.trim())
+        .map((l) => JSON.parse(l) as Record<string, unknown>);
+      const okEntries = log.filter((e) => e.status === "ok");
+      const rollbackEntries = log.filter((e) => e.status === "rollback");
+      expect(okEntries.length).toBe(toDockerPlan.steps.length + toHostPlan.steps.length);
+      expect(rollbackEntries.length).toBe(0);
+
+      const verbs = new Set(log.map((e) => e.verb));
+      expect(verbs.has("to-docker")).toBe(true);
+      expect(verbs.has("to-host")).toBe(true);
+
+      // Systemctl calls were recorded for both directions.
+      expect(recordedSystemctl.length).toBeGreaterThan(0);
+    },
+    120_000,
+  );
+});


### PR DESCRIPTION
## Summary

Final piece of Phase 3b-2 — the `switchroom migrate` host ↔ docker fleet migration is now end-to-end:

- `migrate to-host` is wired to the executor (the not-implemented gate from 3b-2a is removed). The 8-step to-host plan reuses the executor handlers already in place from 3b-2b (compose-down, systemd-enable/start, marker-write, watchdog-pause/resume) — this commit just runs the plan instead of refusing.
- Headline round-trip e2e test: `tests/docker/phase3b2c-migrate-roundtrip.test.ts` drives the executor through `to-docker` → `to-host` against a fully isolated tmpdir 'switchroom home' (every state path redirected via `ExecutorDeps`, never touches real `~/.switchroom/`), with real docker exercising a labelled alpine service inside a phase3b2c-scoped compose project.
- Two non-blocking nits flagged in the 3b-2b review are fixed.

## What's now complete in Phase 3b-2

| Phase | Verb | Status |
| --- | --- | --- |
| 3b-2a | Scaffold + preflight + dry-run | merged (#820) |
| 3b-2b | `to-docker` happy path + rollback | merged (#821) |
| 3b-2c (this PR) | `to-host` reversal + round-trip e2e + nits | this PR |

The migration tooling is now usable end-to-end on a real fleet.

## Reviewer nits addressed (commit 1)

**Nit 1 — fragile rollback-index mapping (`executor.ts:778-779`).** Previously `idx = completed[completed.length - 1 - h]` assumed 1:1 between rollback hooks and completed indices, but `vault-broker-handshake` and `watchdog-resume` succeed without pushing a rollback hook. So `completed.length > rollback.length`, and the audit-log step-name tag could mis-attribute which step a hook reverted. Fixed by recording each rollback as `{stepIndex, fn}` and iterating that directly. Includes a regression test that drives a post-handshake failure with two agents and asserts no rollback log entry is mis-tagged.

**Nit 2 — sync `readFileSync` inside async executor (`executor.ts:651-661`).** `marker-write` previously called sync `readFileSync` to capture the prior marker for rollback. Converted to async `readFile` for style consistency.

## Test evidence

```
$ bun run test:vitest -- src/cli/migrate
Test Files  4 passed (4)
     Tests  49 passed (49)
```

Round-trip e2e on the real docker host:

```
$ bun run test:vitest -- tests/docker/phase3b2c-migrate-roundtrip
✓ phase3b2c migrate round-trip (host → docker → host) > completes round-trip with stable schema and no prod drift  11345ms
Test Files  1 passed (1)
     Tests  1 passed (1)
```

The e2e asserts:

1. to-docker: container up under `switchroom-test-phase3b2c-<run>`, `runtime-mode` marker == `docker`, migration.log all-ok
2. broker.db + kernel.db `PRAGMA schema_version` stable across to-host (no incidental schema mutation during round-trip)
3. to-host: container gone (compose-down scoped to project), marker == `host`, log all-ok with zero rollback entries
4. `sudo docker ps` snapshot identical pre/post via `expectNoProdDrift()` — no Coolify / hindsight / nginx-tunnel-gateway drift

`bun run lint` (tsc) clean. The wider vitest suite has 6 pre-existing failures in `tests/run-hook.test.ts` unrelated to this PR (verified by checking out upstream/main's copy and re-running).

## HARD RULES compliance

- Every test container labelled `switchroom.test=phase3b2c` + per-run UUID label.
- Compose project name `switchroom-test-phase3b2c-${RUN_ID8}` — scope guarantees compose-down only touches test fixtures, never the real fleet.
- `safeLabelTeardown()` in `afterAll` as belt-and-braces.
- Skips cleanly if docker daemon or alpine:3.19 unavailable.
- Test never touches the real `~/.switchroom/` — every state path (runtime-mode, compose, watchdog sentinel, agents root, migration.log) redirected via `ExecutorDeps`.

## Test plan

- [x] `bun run test:vitest -- src/cli/migrate` — 49 passed
- [x] `bun run test:vitest -- tests/docker/phase3b2c-migrate-roundtrip` — 1 passed (real docker)
- [x] `bun run lint` — clean
- [x] Pre/post `sudo docker ps` snapshot identical (asserted by `expectNoProdDrift`)
- [x] Pre-existing `run-hook.test.ts` failures verified to be baseline (present on `upstream/main`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)