### PR TITLE
Phase 3b-3: default-flip switchroom up to Docker on Linux + --legacy opt-out

### DIFF
--- a/docs/operators/runtime-mode.md
+++ b/docs/operators/runtime-mode.md
@@ -1,0 +1,100 @@
+# Runtime mode — Docker vs systemd
+
+Switchroom can run its agent fleet in one of two runtimes:
+
+- **Docker** — each agent runs in its own container, brought up by a
+  generated `docker-compose.yml`. This is the default on Linux as of
+  Phase 3b-3.
+- **systemd** (legacy) — each agent runs as a `switchroom-<name>` user
+  unit on the host. This is what every Switchroom install used before
+  Phase 3b and remains supported.
+
+The active runtime is recorded in `~/.switchroom/runtime-mode`, which
+contains a single line: `docker` or `host`.
+
+## How `switchroom up` chooses
+
+`switchroom up` looks at four inputs and picks one of the two
+runtimes:
+
+| Platform | Marker        | Systemd installed? | Flag        | Runtime | Marker after |
+| -------- | ------------- | ------------------ | ----------- | ------- | ------------ |
+| Linux    | _absent_      | no                 | _none_      | docker  | `docker`     |
+| Linux    | _absent_      | yes                | _none_      | host*   | _unchanged_  |
+| Linux    | _absent_      | any                | `--legacy`  | host    | `host`       |
+| Linux    | `docker`      | any                | _ignored_   | docker  | _unchanged_  |
+| Linux    | `host`        | any                | _ignored_   | host    | _unchanged_  |
+| non-Linux| any           | any                | any         | host    | _unchanged_  |
+
+*The "Linux + systemd installed + no flag" row also prints a one-time
+advisory:
+
+```
+You're on the legacy systemd runtime.
+Run `switchroom migrate to-docker` to move to the Docker runtime,
+or `switchroom up --legacy` to silence this notice.
+```
+
+The advisory keeps firing on every `up` until the operator either
+migrates or explicitly opts in with `--legacy` (which writes
+`runtime-mode = host` and silences future advisories).
+
+## Choosing a runtime
+
+Pick **Docker** if:
+
+- You're on a fresh Linux host and don't have a strong reason
+  otherwise.
+- You want hard-isolated agents — each in its own container with its
+  own UID, no shared sockets across agents.
+- You want easier upgrades (`docker compose pull && switchroom up`
+  vs systemd unit reconciliation).
+
+Pick **systemd** if:
+
+- You're already running on systemd and not ready to migrate.
+- You're on a host without Docker and don't want to install it.
+- Your environment forbids container runtimes (compliance,
+  policy).
+
+## Migrating between runtimes
+
+Use `switchroom migrate to-docker` (Phase 3b-2) to move from systemd to
+Docker. It runs preflight checks, generates compose, brings the docker
+fleet up, stops + disables the systemd units, and writes
+`runtime-mode = docker`. On any failure it rolls back automatically and
+leaves you on the original runtime.
+
+`switchroom migrate to-host` reverses the above.
+
+## The `--legacy` opt-out
+
+`switchroom up --legacy` forces the systemd path even on a fresh Linux
+host where Docker would otherwise be the default. Use it when:
+
+- You're scripting an install on a host where Docker isn't available.
+- You see the legacy advisory but explicitly want to keep using
+  systemd for the foreseeable future — `--legacy` writes the marker so
+  the advisory stops firing.
+
+`--legacy` is Linux-only (other platforms always use the systemd path
+today; macOS Docker support is Phase 3d).
+
+## Doctor: runtime-coexistence check
+
+`switchroom doctor` includes a `runtime coexistence` check (Phase
+3b-3) that warns when the marker says one runtime but the host still
+has the other one's state in place — e.g. `runtime-mode = docker` but
+`switchroom-*` systemd units are still enabled.
+
+This is **a warning, not a failure**. Coexistence is legitimate during
+a migration window — operators bring the new runtime up before tearing
+the old one down. If the warning persists after migration:
+
+- **`runtime-mode = docker` + systemd units enabled** → run
+  `systemctl --user disable --now 'switchroom-*'` to clear the
+  legacy state. (Or re-run `switchroom migrate to-docker` so the
+  finalize step takes care of it.)
+- **marker absent + systemd units enabled** → run
+  `switchroom up --legacy` to pin the marker and silence the
+  ambiguity, or run `switchroom migrate to-docker` to flip.

--- a/src/cli/doctor-docker.test.ts
+++ b/src/cli/doctor-docker.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from "vitest";
+import { checkRuntimeCoexistence, runDockerChecks } from "./doctor-docker.js";
+import type { SwitchroomConfig } from "../config/schema.js";
+
+describe("checkRuntimeCoexistence — Phase 3b-3", () => {
+  it("warns when marker=docker but systemd units remain enabled", () => {
+    const r = checkRuntimeCoexistence({
+      marker: "docker",
+      enabledSystemdUnits: [
+        "switchroom-klanker.service",
+        "switchroom-vault-broker.service",
+      ],
+    });
+    expect(r.status).toBe("warn");
+    expect(r.detail).toMatch(/runtime-mode=docker/);
+    expect(r.detail).toMatch(/switchroom-klanker/);
+    expect(r.fix).toBeTruthy();
+  });
+
+  it("ok when marker=host and systemd units are present (consistent)", () => {
+    const r = checkRuntimeCoexistence({
+      marker: "host",
+      enabledSystemdUnits: ["switchroom-klanker.service"],
+    });
+    expect(r.status).toBe("ok");
+  });
+
+  it("ok when marker=docker and no systemd units are enabled", () => {
+    const r = checkRuntimeCoexistence({
+      marker: "docker",
+      enabledSystemdUnits: [],
+    });
+    expect(r.status).toBe("ok");
+  });
+
+  it("warns when marker is absent but systemd units exist (operator hasn't pinned)", () => {
+    const r = checkRuntimeCoexistence({
+      marker: null,
+      enabledSystemdUnits: ["switchroom-klanker.service"],
+    });
+    expect(r.status).toBe("warn");
+    expect(r.detail).toMatch(/marker absent/);
+    expect(r.fix).toMatch(/--legacy/);
+  });
+
+  it("ok on a fresh host (no marker, no systemd)", () => {
+    const r = checkRuntimeCoexistence({
+      marker: null,
+      enabledSystemdUnits: [],
+    });
+    expect(r.status).toBe("ok");
+  });
+
+  it("does NOT escalate to fail (warn ceiling — coexistence is legitimate mid-migration)", () => {
+    const r = checkRuntimeCoexistence({
+      marker: "docker",
+      enabledSystemdUnits: Array.from({ length: 20 }, (_, i) => `switchroom-a${i}.service`),
+    });
+    expect(r.status).not.toBe("fail");
+    expect(r.detail).toMatch(/\.\.\./); // truncated list
+  });
+});
+
+describe("runDockerChecks — coexistence wiring", () => {
+  const cfg = { agents: { klanker: {} } } as unknown as SwitchroomConfig;
+
+  it("includes coexistence even when docker mode is inactive", () => {
+    const checks = runDockerChecks({
+      config: cfg,
+      active: false,
+      marker: "docker",
+      enabledSystemdUnits: ["switchroom-klanker.service"],
+    });
+    const co = checks.find((c) => c.name === "runtime coexistence");
+    expect(co?.status).toBe("warn");
+  });
+
+  it("includes coexistence when docker mode is active", () => {
+    const checks = runDockerChecks({
+      config: cfg,
+      active: true,
+      marker: "docker",
+      enabledSystemdUnits: [],
+    });
+    expect(checks.find((c) => c.name === "runtime coexistence")?.status).toBe("ok");
+  });
+
+  it("omits coexistence when caller doesn't supply marker/units (back-compat)", () => {
+    const checks = runDockerChecks({
+      config: cfg,
+      active: true,
+    });
+    expect(checks.find((c) => c.name === "runtime coexistence")).toBeUndefined();
+  });
+});

--- a/src/cli/doctor-docker.ts
+++ b/src/cli/doctor-docker.ts
@@ -214,6 +214,73 @@ export function checkDockerfileUserAlignment(
 }
 
 /**
+ * Coexistence check (Phase 3b-3): when the runtime-mode marker says one
+ * runtime but the host visibly still has the OTHER one's enabled state,
+ * surface a warning. Coexistence is legitimate during a migration
+ * window — operators bring the new runtime up before tearing the old
+ * one down — but if it persists, it's the kind of footgun that produces
+ * "why is my agent running twice?" tickets. Warn-not-fail.
+ *
+ * Inputs are pre-resolved by the caller so this stays pure: the marker
+ * value (`"host" | "docker" | null`) and a list of currently-enabled
+ * `switchroom-*` systemd unit names. The caller is responsible for
+ * shelling out to systemctl (or stubbing it in tests).
+ */
+export function checkRuntimeCoexistence(args: {
+  marker: "host" | "docker" | null;
+  enabledSystemdUnits: readonly string[];
+}): CheckResult {
+  const { marker, enabledSystemdUnits } = args;
+  const hasSystemd = enabledSystemdUnits.length > 0;
+  if (marker === "docker" && hasSystemd) {
+    return {
+      name: "runtime coexistence",
+      status: "warn",
+      detail:
+        `runtime-mode=docker but ${enabledSystemdUnits.length} switchroom-* systemd unit(s) still enabled: ` +
+        enabledSystemdUnits.slice(0, 5).join(", ") +
+        (enabledSystemdUnits.length > 5 ? ", ..." : ""),
+      fix:
+        "If migration is complete, disable the legacy units: `systemctl --user disable --now switchroom-*` " +
+        "(or run `switchroom migrate to-docker --finalize`). Coexistence is legitimate mid-migration; " +
+        "stale once you've cut over.",
+    };
+  }
+  if (marker === "host" && hasSystemd) {
+    return {
+      name: "runtime coexistence",
+      status: "ok",
+      detail: `runtime-mode=host with ${enabledSystemdUnits.length} systemd unit(s) — consistent`,
+    };
+  }
+  if (marker === "docker" && !hasSystemd) {
+    return {
+      name: "runtime coexistence",
+      status: "ok",
+      detail: "runtime-mode=docker with no legacy systemd units enabled — clean",
+    };
+  }
+  if (marker === null && hasSystemd) {
+    return {
+      name: "runtime coexistence",
+      status: "warn",
+      detail:
+        `runtime-mode marker absent but ${enabledSystemdUnits.length} switchroom-* systemd unit(s) enabled. ` +
+        "Run `switchroom up --legacy` to pin the marker, or `switchroom migrate to-docker` to flip.",
+      fix:
+        "Either confirm the legacy runtime explicitly with `switchroom up --legacy` (writes runtime-mode=host) " +
+        "or migrate with `switchroom migrate to-docker`.",
+    };
+  }
+  // marker === null && !hasSystemd → nothing to coexist.
+  return {
+    name: "runtime coexistence",
+    status: "ok",
+    detail: "no runtime-mode marker and no legacy systemd units — fresh host",
+  };
+}
+
+/**
  * Aggregate runner — call from doctor.ts. Always returns an array so
  * the section renders consistently.
  */
@@ -222,15 +289,37 @@ export function runDockerChecks(args: {
   composeYaml?: string;
   dockerfileAgent?: string;
   active: boolean;
+  /** Phase 3b-3 inputs for the coexistence check (optional for callers that don't resolve them). */
+  marker?: "host" | "docker" | null;
+  enabledSystemdUnits?: readonly string[];
 }): CheckResult[] {
   if (!args.active) {
-    return [{
+    const out: CheckResult[] = [{
       name: "Docker runtime",
       status: "ok",
       detail: "Docker mode not active (host-native runtime); skipping Docker-specific checks",
     }];
+    // Coexistence is informative even on a host-only fleet — we still
+    // want to flag "marker says docker, but systemd is alive" cases.
+    if (args.marker !== undefined && args.enabledSystemdUnits !== undefined) {
+      out.push(
+        checkRuntimeCoexistence({
+          marker: args.marker,
+          enabledSystemdUnits: args.enabledSystemdUnits,
+        }),
+      );
+    }
+    return out;
   }
   const out: CheckResult[] = [];
+  if (args.marker !== undefined && args.enabledSystemdUnits !== undefined) {
+    out.push(
+      checkRuntimeCoexistence({
+        marker: args.marker,
+        enabledSystemdUnits: args.enabledSystemdUnits,
+      }),
+    );
+  }
   out.push(checkAgentUidUniqueness(args.config));
   out.push(checkAgentCaps(args.config));
   if (args.composeYaml) {

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -1490,7 +1490,50 @@ function runDockerSection(config: SwitchroomConfig): CheckResult[] {
     "Dockerfile.agent",
   );
   try { dockerfileAgent = readFileSync(dockerfilePath, "utf8"); } catch { /* none */ }
-  return runDockerChecks({ config, composeYaml, dockerfileAgent, active });
+
+  // Phase 3b-3 — resolve runtime-mode marker + currently-enabled
+  // switchroom-* systemd units so the coexistence check can fire.
+  const markerPath = resolve(process.env.HOME ?? "", ".switchroom", "runtime-mode");
+  let marker: "host" | "docker" | null = null;
+  try {
+    const v = readFileSync(markerPath, "utf8").trim();
+    if (v === "host" || v === "docker") marker = v;
+  } catch { /* missing */ }
+  let enabledSystemdUnits: string[] = [];
+  try {
+    const r = spawnSync(
+      "systemctl",
+      [
+        "--user",
+        "list-unit-files",
+        "--type=service",
+        "--no-legend",
+        "--plain",
+        "switchroom-*",
+      ],
+      { encoding: "utf8" },
+    );
+    if (r.status === 0 && typeof r.stdout === "string") {
+      enabledSystemdUnits = r.stdout
+        .split("\n")
+        .map((l) => l.trim())
+        .filter(Boolean)
+        .filter((l) => {
+          const cols = l.split(/\s+/);
+          return cols[1] === "enabled" || cols[1] === "enabled-runtime";
+        })
+        .map((l) => l.split(/\s+/)[0]!);
+    }
+  } catch { /* no systemd */ }
+
+  return runDockerChecks({
+    config,
+    composeYaml,
+    dockerfileAgent,
+    active,
+    marker,
+    enabledSystemdUnits,
+  });
 }
 
 export function registerDoctorCommand(program: Command): void {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -24,6 +24,7 @@ import { registerDebugCommand } from "./debug.js";
 import { registerWorktreeCommand } from "./worktree.js";
 import { registerDriveCommand } from "./drive.js";
 import { registerMigrateCommand } from "./migrate/index.js";
+import { registerUpCommand } from "./up.js";
 import { captureEvent, installGlobalErrorHandlers } from "../analytics/posthog.js";
 
 installGlobalErrorHandlers();
@@ -71,3 +72,4 @@ registerDebugCommand(program);
 registerWorktreeCommand(program);
 registerDriveCommand(program);
 registerMigrateCommand(program);
+registerUpCommand(program);

--- a/src/cli/runtime-detection.test.ts
+++ b/src/cli/runtime-detection.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  decideRuntime,
+  readRuntimeMode,
+  hasActiveSystemdInstall,
+  legacyAdvisoryText,
+  type DecisionInput,
+  type RunCommand,
+} from "./runtime-detection.js";
+
+function input(over: Partial<DecisionInput>): DecisionInput {
+  return {
+    platform: "linux",
+    marker: null,
+    hasActiveSystemd: false,
+    legacy: false,
+    ...over,
+  };
+}
+
+describe("decideRuntime — Phase 3b-3 decision matrix", () => {
+  it("marker=docker → docker, no advisory, no marker rewrite", () => {
+    const d = decideRuntime(input({ marker: "docker", hasActiveSystemd: true }));
+    expect(d.runtime).toBe("docker");
+    expect(d.showLegacyAdvisory).toBe(false);
+    expect(d.writeDockerMarkerAfter).toBe(false);
+    expect(d.writeHostMarkerAfter).toBe(false);
+  });
+
+  it("marker=host → host, no advisory", () => {
+    const d = decideRuntime(input({ marker: "host", hasActiveSystemd: false }));
+    expect(d.runtime).toBe("host");
+    expect(d.showLegacyAdvisory).toBe(false);
+    expect(d.writeHostMarkerAfter).toBe(false);
+  });
+
+  it("non-linux (darwin) with no marker → host, no advisory, no flip", () => {
+    const d = decideRuntime(input({ platform: "darwin" }));
+    expect(d.runtime).toBe("host");
+    expect(d.showLegacyAdvisory).toBe(false);
+    expect(d.writeHostMarkerAfter).toBe(false);
+    expect(d.writeDockerMarkerAfter).toBe(false);
+  });
+
+  it("linux + --legacy on a fresh host → host, no advisory, write host marker", () => {
+    const d = decideRuntime(input({ legacy: true, hasActiveSystemd: false }));
+    expect(d.runtime).toBe("host");
+    expect(d.showLegacyAdvisory).toBe(false);
+    expect(d.writeHostMarkerAfter).toBe(true);
+  });
+
+  it("linux + --legacy + active systemd → host, no advisory (operator opted in)", () => {
+    const d = decideRuntime(input({ legacy: true, hasActiveSystemd: true }));
+    expect(d.runtime).toBe("host");
+    expect(d.showLegacyAdvisory).toBe(false);
+    expect(d.writeHostMarkerAfter).toBe(true);
+  });
+
+  it("linux + active systemd, no flag → host with legacy advisory", () => {
+    const d = decideRuntime(input({ hasActiveSystemd: true }));
+    expect(d.runtime).toBe("host");
+    expect(d.showLegacyAdvisory).toBe(true);
+    expect(d.writeHostMarkerAfter).toBe(false);
+  });
+
+  it("linux + no systemd, no marker, no flag → docker (default flip), write marker", () => {
+    const d = decideRuntime(input({}));
+    expect(d.runtime).toBe("docker");
+    expect(d.showLegacyAdvisory).toBe(false);
+    expect(d.writeDockerMarkerAfter).toBe(true);
+  });
+});
+
+describe("readRuntimeMode", () => {
+  let dir: string;
+  afterEach(() => {
+    if (dir) rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("returns null when missing", () => {
+    dir = mkdtempSync(join(tmpdir(), "rt-"));
+    expect(readRuntimeMode(join(dir, "missing"))).toBe(null);
+  });
+
+  it("returns 'host' / 'docker' for valid contents", () => {
+    dir = mkdtempSync(join(tmpdir(), "rt-"));
+    const p1 = join(dir, "m1");
+    writeFileSync(p1, "host\n");
+    expect(readRuntimeMode(p1)).toBe("host");
+    const p2 = join(dir, "m2");
+    writeFileSync(p2, "docker");
+    expect(readRuntimeMode(p2)).toBe("docker");
+  });
+
+  it("returns null for garbage contents", () => {
+    dir = mkdtempSync(join(tmpdir(), "rt-"));
+    const p = join(dir, "m");
+    writeFileSync(p, "potato");
+    expect(readRuntimeMode(p)).toBe(null);
+  });
+});
+
+describe("hasActiveSystemdInstall", () => {
+  it("returns true when systemctl reports an enabled switchroom-* unit", async () => {
+    const run: RunCommand = async () => ({
+      stdout:
+        "switchroom-klanker.service             enabled         enabled\n" +
+        "switchroom-vault-broker.service        enabled         enabled\n",
+      stderr: "",
+      exitCode: 0,
+    });
+    expect(await hasActiveSystemdInstall(run)).toBe(true);
+  });
+
+  it("returns false on empty unit list", async () => {
+    const run: RunCommand = async () => ({ stdout: "", stderr: "", exitCode: 0 });
+    expect(await hasActiveSystemdInstall(run)).toBe(false);
+  });
+
+  it("returns false when units exist but are disabled", async () => {
+    const run: RunCommand = async () => ({
+      stdout: "switchroom-foo.service        disabled        enabled\n",
+      stderr: "",
+      exitCode: 0,
+    });
+    expect(await hasActiveSystemdInstall(run)).toBe(false);
+  });
+
+  it("returns false on non-zero exit (no systemd at all)", async () => {
+    const run: RunCommand = async () => ({
+      stdout: "",
+      stderr: "command not found",
+      exitCode: 127,
+    });
+    expect(await hasActiveSystemdInstall(run)).toBe(false);
+  });
+
+  it("returns false when runner throws", async () => {
+    const run: RunCommand = async () => {
+      throw new Error("boom");
+    };
+    expect(await hasActiveSystemdInstall(run)).toBe(false);
+  });
+});
+
+describe("legacyAdvisoryText", () => {
+  it("mentions the migrate verb and the --legacy flag", () => {
+    const t = legacyAdvisoryText();
+    expect(t).toContain("switchroom migrate to-docker");
+    expect(t).toContain("--legacy");
+    expect(t).toMatch(/legacy systemd/);
+  });
+});

--- a/src/cli/runtime-detection.ts
+++ b/src/cli/runtime-detection.ts
@@ -1,0 +1,219 @@
+/**
+ * Runtime detection for `switchroom up` (Phase 3b-3).
+ *
+ * Pure helpers + a single decision function that maps
+ * `(platform, marker, systemd-installed, --legacy flag)` → which runtime
+ * `switchroom up` should use, plus whether to emit the one-time legacy
+ * advisory. No side effects — every input is injected so the unit tests
+ * can exhaustively cover the decision matrix without touching the real
+ * host.
+ *
+ * The marker file convention (`~/.switchroom/runtime-mode` containing
+ * `host` or `docker`) was introduced in Phase 3b-2; see
+ * `src/cli/migrate/preflight.ts` for the canonical reader. We re-export
+ * `readRuntimeMode` here to keep `up`'s import surface compact.
+ */
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+export type RuntimeMode = "host" | "docker" | null;
+
+export type Runtime = "docker" | "host";
+
+export interface DecisionInput {
+  /** `process.platform` — "linux" / "darwin" / "win32" / etc. */
+  platform: NodeJS.Platform;
+  /** Current marker value (`null` if absent). */
+  marker: RuntimeMode;
+  /** Does this host already have an active systemd switchroom installation? */
+  hasActiveSystemd: boolean;
+  /** Did the user pass `--legacy` to opt into the systemd runtime? */
+  legacy: boolean;
+}
+
+export interface Decision {
+  /** Which runtime `switchroom up` should drive on this invocation. */
+  runtime: Runtime;
+  /**
+   * Should the legacy-systemd advisory be printed?
+   *
+   * Fires only when the host is on systemd by default-flip-induced
+   * inertia (Linux, no marker, active systemd, no `--legacy`). Operator
+   * silences it by either migrating (`switchroom migrate to-docker`) or
+   * explicitly opting in (`switchroom up --legacy`, which writes the
+   * marker so this never fires again).
+   */
+  showLegacyAdvisory: boolean;
+  /**
+   * Should we write `runtime-mode = host` after the systemd up
+   * succeeds? Set when `--legacy` was used on a host with no marker
+   * yet, so future `up` invocations route to systemd without
+   * re-checking systemctl.
+   */
+  writeHostMarkerAfter: boolean;
+  /**
+   * Should we write `runtime-mode = docker` after compose-up succeeds?
+   * Set on the fresh-Linux default-flip path (no marker, no systemd,
+   * no `--legacy`).
+   */
+  writeDockerMarkerAfter: boolean;
+}
+
+/**
+ * Decide which runtime `switchroom up` uses, given the host context.
+ *
+ * Decision matrix (Phase 3b-3 acceptance criteria):
+ *
+ *   1. marker = "docker"               → docker (no advisory; marker authoritative)
+ *   2. marker = "host"                  → host (no advisory; operator already chose)
+ *   3. non-Linux                        → host (current behaviour; flip is Linux-only)
+ *   4. Linux + --legacy                 → host; write marker if absent
+ *   5. Linux + active systemd, no flag  → host + legacy advisory
+ *   6. Linux + no systemd, no flag      → docker (default flip); write marker
+ */
+export function decideRuntime(input: DecisionInput): Decision {
+  const { platform, marker, hasActiveSystemd, legacy } = input;
+
+  // 1, 2 — marker is authoritative when present.
+  if (marker === "docker") {
+    return {
+      runtime: "docker",
+      showLegacyAdvisory: false,
+      writeHostMarkerAfter: false,
+      writeDockerMarkerAfter: false,
+    };
+  }
+  if (marker === "host") {
+    return {
+      runtime: "host",
+      showLegacyAdvisory: false,
+      writeHostMarkerAfter: false,
+      writeDockerMarkerAfter: false,
+    };
+  }
+
+  // 3 — non-Linux: keep current behaviour (host). No marker write — Mac
+  // is deferred to Phase 3d.
+  if (platform !== "linux") {
+    return {
+      runtime: "host",
+      showLegacyAdvisory: false,
+      writeHostMarkerAfter: false,
+      writeDockerMarkerAfter: false,
+    };
+  }
+
+  // 4 — explicit --legacy opt-in.
+  if (legacy) {
+    return {
+      runtime: "host",
+      showLegacyAdvisory: false,
+      writeHostMarkerAfter: true,
+      writeDockerMarkerAfter: false,
+    };
+  }
+
+  // 5 — already-installed systemd fleet keeps using systemd, with the
+  // one-time advisory pointing to migration.
+  if (hasActiveSystemd) {
+    return {
+      runtime: "host",
+      showLegacyAdvisory: true,
+      writeHostMarkerAfter: false,
+      writeDockerMarkerAfter: false,
+    };
+  }
+
+  // 6 — fresh Linux host, no systemd, no flag → default-flip to docker.
+  return {
+    runtime: "docker",
+    showLegacyAdvisory: false,
+    writeHostMarkerAfter: false,
+    writeDockerMarkerAfter: true,
+  };
+}
+
+/* ------------------------------------------------------------------ */
+/* I/O helpers — all overridable by the caller for unit tests.         */
+/* ------------------------------------------------------------------ */
+
+export function defaultRuntimeModePath(): string {
+  return join(homedir(), ".switchroom", "runtime-mode");
+}
+
+export function readRuntimeMode(path?: string): RuntimeMode {
+  const p = path ?? defaultRuntimeModePath();
+  if (!existsSync(p)) return null;
+  try {
+    const v = readFileSync(p, "utf8").trim();
+    if (v === "host" || v === "docker") return v;
+  } catch { /* unreadable */ }
+  return null;
+}
+
+export type RunCommand = (
+  cmd: string,
+  args: readonly string[],
+) => Promise<{ stdout: string; stderr: string; exitCode: number }>;
+
+/**
+ * Detect whether this host has at least one enabled `switchroom-*`
+ * systemd user unit — the signal we use to decide "the operator is
+ * already on the legacy runtime".
+ *
+ * Implementation: `systemctl --user list-unit-files --type=service
+ * --no-legend --plain switchroom-*`. Any line whose state is `enabled`
+ * or `enabled-runtime` counts as "active install". An empty list (or a
+ * non-zero exit) means no install — return false.
+ *
+ * The function never throws; on any error it returns false so a host
+ * without systemd at all (containers, BSD jails) doesn't fail `up`.
+ */
+export async function hasActiveSystemdInstall(
+  runCommand: RunCommand,
+): Promise<boolean> {
+  let r: Awaited<ReturnType<RunCommand>>;
+  try {
+    r = await runCommand("systemctl", [
+      "--user",
+      "list-unit-files",
+      "--type=service",
+      "--no-legend",
+      "--plain",
+      "switchroom-*",
+    ]);
+  } catch {
+    return false;
+  }
+  if (r.exitCode !== 0) return false;
+  const lines = r.stdout
+    .split("\n")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+  for (const line of lines) {
+    const cols = line.split(/\s+/);
+    const unit = cols[0];
+    const state = cols[1];
+    if (
+      unit?.startsWith("switchroom-") &&
+      (state === "enabled" || state === "enabled-runtime")
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Format the legacy-systemd advisory printed when an existing systemd
+ * install is detected on Linux. Pure function so tests can snapshot the
+ * exact text without spawning a Command runner.
+ */
+export function legacyAdvisoryText(): string {
+  return [
+    "You're on the legacy systemd runtime.",
+    "Run `switchroom migrate to-docker` to move to the Docker runtime,",
+    "or `switchroom up --legacy` to silence this notice.",
+  ].join("\n");
+}

--- a/src/cli/up.test.ts
+++ b/src/cli/up.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { runUp, type UpDeps } from "./up.js";
+import type { SwitchroomConfig } from "../config/schema.js";
+
+/** Minimal config stub — runUp only forwards it through to the start* hooks. */
+const stubConfig = { agents: { klanker: {} } } as unknown as SwitchroomConfig;
+
+interface Spy {
+  startedDocker: number;
+  startedSystemd: number;
+  err: string;
+  out: string;
+}
+
+function makeDeps(over: Partial<UpDeps> & { dir: string }): UpDeps & { spy: Spy } {
+  const spy: Spy = { startedDocker: 0, startedSystemd: 0, err: "", out: "" };
+  return {
+    runtimeModePath: join(over.dir, "runtime-mode"),
+    runCommand: async () => ({ stdout: "", stderr: "", exitCode: 0 }),
+    startDockerFleet: async () => { spy.startedDocker++; },
+    startSystemdFleet: async () => { spy.startedSystemd++; },
+    writeErr: (s) => { spy.err += s; },
+    writeOut: (s) => { spy.out += s; },
+    ...over,
+    spy,
+  } as UpDeps & { spy: Spy };
+}
+
+describe("runUp — Phase 3b-3 acceptance matrix", () => {
+  let dir: string;
+  afterEach(() => { if (dir) rmSync(dir, { recursive: true, force: true }); });
+
+  it("(1) fresh Linux, no marker, no systemd → docker, marker=docker, no advisory", async () => {
+    dir = mkdtempSync(join(tmpdir(), "up-"));
+    const deps = makeDeps({ dir, platform: "linux" });
+    const res = await runUp(stubConfig, {}, deps);
+    expect(res.runtime).toBe("docker");
+    expect(res.printedAdvisory).toBe(false);
+    expect(res.markerWritten).toBe("docker");
+    expect(deps.spy.startedDocker).toBe(1);
+    expect(deps.spy.startedSystemd).toBe(0);
+    expect(readFileSync(join(dir, "runtime-mode"), "utf8").trim()).toBe("docker");
+  });
+
+  it("(2) Linux with active systemd, no marker, no flag → systemd + advisory; marker untouched", async () => {
+    dir = mkdtempSync(join(tmpdir(), "up-"));
+    const deps = makeDeps({
+      dir,
+      platform: "linux",
+      runCommand: async () => ({
+        stdout: "switchroom-klanker.service             enabled         enabled\n",
+        stderr: "",
+        exitCode: 0,
+      }),
+    });
+    const res = await runUp(stubConfig, {}, deps);
+    expect(res.runtime).toBe("host");
+    expect(res.printedAdvisory).toBe(true);
+    expect(res.markerWritten).toBe(null);
+    expect(deps.spy.startedSystemd).toBe(1);
+    expect(deps.spy.err).toContain("legacy systemd runtime");
+    expect(deps.spy.err).toContain("--legacy");
+    expect(existsSync(join(dir, "runtime-mode"))).toBe(false);
+  });
+
+  it("(3) --legacy on the same Linux+systemd host → systemd, NO advisory, marker=host", async () => {
+    dir = mkdtempSync(join(tmpdir(), "up-"));
+    const deps = makeDeps({
+      dir,
+      platform: "linux",
+      runCommand: async () => ({
+        stdout: "switchroom-klanker.service             enabled         enabled\n",
+        stderr: "",
+        exitCode: 0,
+      }),
+    });
+    const res = await runUp(stubConfig, { legacy: true }, deps);
+    expect(res.runtime).toBe("host");
+    expect(res.printedAdvisory).toBe(false);
+    expect(res.markerWritten).toBe("host");
+    expect(deps.spy.err).not.toContain("legacy systemd runtime");
+    expect(readFileSync(join(dir, "runtime-mode"), "utf8").trim()).toBe("host");
+  });
+
+  it("(4) macOS with no marker → systemd path (current behaviour), no flip, no advisory", async () => {
+    dir = mkdtempSync(join(tmpdir(), "up-"));
+    const deps = makeDeps({ dir, platform: "darwin" });
+    const res = await runUp(stubConfig, {}, deps);
+    expect(res.runtime).toBe("host");
+    expect(res.printedAdvisory).toBe(false);
+    expect(res.markerWritten).toBe(null);
+    expect(existsSync(join(dir, "runtime-mode"))).toBe(false);
+  });
+
+  it("(5) marker=docker → docker, regardless of systemd state, no advisory", async () => {
+    dir = mkdtempSync(join(tmpdir(), "up-"));
+    writeFileSync(join(dir, "runtime-mode"), "docker\n");
+    const deps = makeDeps({
+      dir,
+      platform: "linux",
+      // systemd probe should NOT be consulted; if it were, this would
+      // try to flip the result. We assert decision is unaffected.
+      runCommand: async () => ({
+        stdout: "switchroom-klanker.service enabled enabled\n",
+        stderr: "",
+        exitCode: 0,
+      }),
+    });
+    const res = await runUp(stubConfig, {}, deps);
+    expect(res.runtime).toBe("docker");
+    expect(res.printedAdvisory).toBe(false);
+    expect(res.markerWritten).toBe(null);
+    expect(deps.spy.startedDocker).toBe(1);
+  });
+
+  it("marker=host → systemd, no advisory", async () => {
+    dir = mkdtempSync(join(tmpdir(), "up-"));
+    writeFileSync(join(dir, "runtime-mode"), "host\n");
+    const deps = makeDeps({ dir, platform: "linux" });
+    const res = await runUp(stubConfig, {}, deps);
+    expect(res.runtime).toBe("host");
+    expect(res.printedAdvisory).toBe(false);
+    expect(res.markerWritten).toBe(null);
+    expect(deps.spy.startedSystemd).toBe(1);
+  });
+
+  it("--legacy on a fresh Linux host (no systemd) still uses systemd and writes marker=host", async () => {
+    dir = mkdtempSync(join(tmpdir(), "up-"));
+    const deps = makeDeps({ dir, platform: "linux" });
+    const res = await runUp(stubConfig, { legacy: true }, deps);
+    expect(res.runtime).toBe("host");
+    expect(res.markerWritten).toBe("host");
+    expect(deps.spy.startedSystemd).toBe(1);
+  });
+
+  it("propagates errors from the start hook (does not write marker on failure)", async () => {
+    dir = mkdtempSync(join(tmpdir(), "up-"));
+    const deps = makeDeps({
+      dir,
+      platform: "linux",
+      startDockerFleet: async () => { throw new Error("compose blew up"); },
+    });
+    await expect(runUp(stubConfig, {}, deps)).rejects.toThrow(/compose blew up/);
+    expect(existsSync(join(dir, "runtime-mode"))).toBe(false);
+  });
+});

--- a/src/cli/up.ts
+++ b/src/cli/up.ts
@@ -1,0 +1,195 @@
+/**
+ * `switchroom up` — Phase 3b-3 default flip.
+ *
+ * On Linux with no prior runtime-mode marker, default to the Docker
+ * runtime (Phase 3b's docker-compose-driven fleet). Hosts already
+ * running the legacy systemd installation keep using systemd and see a
+ * one-time advisory pointing to `switchroom migrate to-docker`. The
+ * `--legacy` flag lets operators explicitly opt back into systemd
+ * (silencing the advisory and pinning the marker so future invocations
+ * route to systemd without re-checking).
+ *
+ * The actual fleet bring-up primitives (compose generation, compose-up,
+ * systemd unit install/start) all live in modules this file imports
+ * from — `up` is purely the decision-and-orchestration layer. Every
+ * side-effecting call is injected via `UpDeps` so the unit tests can
+ * exercise the full decision matrix without docker or systemctl on the
+ * host.
+ */
+import type { Command } from "commander";
+import chalk from "chalk";
+import { mkdir, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { homedir } from "node:os";
+import { withConfigError, getConfig } from "./helpers.js";
+import {
+  decideRuntime,
+  defaultRuntimeModePath,
+  hasActiveSystemdInstall,
+  legacyAdvisoryText,
+  readRuntimeMode,
+  type RunCommand,
+} from "./runtime-detection.js";
+import { defaultRunCommand } from "./migrate/preflight.js";
+import type { SwitchroomConfig } from "../config/schema.js";
+
+export interface UpDeps {
+  /** `process.platform` override for tests. */
+  platform?: NodeJS.Platform;
+  /** Override the runtime-mode marker path. */
+  runtimeModePath?: string;
+  /** Subprocess runner (only used for systemctl probe). */
+  runCommand?: RunCommand;
+  /**
+   * Bring up the docker fleet (compose generate + compose up). Default
+   * shells out via the migrate executor's primitives. Tests inject a
+   * stub.
+   */
+  startDockerFleet?: (config: SwitchroomConfig) => Promise<void>;
+  /**
+   * Install + start systemd units. Default delegates to
+   * `installAllUnits` + `agent start all` semantics. Tests inject.
+   */
+  startSystemdFleet?: (config: SwitchroomConfig) => Promise<void>;
+  /** stderr writer; defaults to `process.stderr.write`. */
+  writeErr?: (s: string) => void;
+  /** stdout writer; defaults to `process.stdout.write`. */
+  writeOut?: (s: string) => void;
+}
+
+export interface UpOptions {
+  legacy?: boolean;
+}
+
+export interface UpResult {
+  /** Which runtime was used. */
+  runtime: "docker" | "host";
+  /** Did we print the legacy advisory this invocation? */
+  printedAdvisory: boolean;
+  /** What did we write the runtime-mode marker to (or null = unchanged)? */
+  markerWritten: "host" | "docker" | null;
+}
+
+async function defaultStartDockerFleet(config: SwitchroomConfig): Promise<void> {
+  const { generateCompose } = await import("../agents/compose.js");
+  const composePath = join(homedir(), ".switchroom", "compose", "docker-compose.yml");
+  const project = "switchroom";
+  const content = generateCompose({ config });
+  await mkdir(dirname(composePath), { recursive: true });
+  await writeFile(composePath, content, { encoding: "utf8", mode: 0o600 });
+  const run = defaultRunCommand;
+  const r = await run("docker", [
+    "compose",
+    "-p",
+    project,
+    "-f",
+    composePath,
+    "up",
+    "-d",
+  ]);
+  if (r.exitCode !== 0) {
+    throw new Error(
+      `docker compose up failed (exit ${r.exitCode}): ${r.stderr.trim() || r.stdout.trim()}`,
+    );
+  }
+}
+
+async function defaultStartSystemdFleet(config: SwitchroomConfig): Promise<void> {
+  const { installAllUnits } = await import("../agents/systemd.js");
+  installAllUnits(config);
+  const run = defaultRunCommand;
+  for (const name of Object.keys(config.agents)) {
+    const unit = `switchroom-${name}.service`;
+    const r = await run("systemctl", ["--user", "enable", "--now", unit]);
+    if (r.exitCode !== 0) {
+      throw new Error(
+        `systemctl --user enable --now ${unit} failed (exit ${r.exitCode}): ${r.stderr.trim() || r.stdout.trim()}`,
+      );
+    }
+  }
+}
+
+async function writeMarker(path: string, mode: "host" | "docker"): Promise<void> {
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, mode + "\n", { encoding: "utf8", mode: 0o600 });
+}
+
+/**
+ * Pure orchestrator — exported for tests. Does not parse CLI args.
+ */
+export async function runUp(
+  config: SwitchroomConfig,
+  options: UpOptions,
+  deps: UpDeps = {},
+): Promise<UpResult> {
+  const platform = deps.platform ?? process.platform;
+  const markerPath = deps.runtimeModePath ?? defaultRuntimeModePath();
+  const run = deps.runCommand ?? defaultRunCommand;
+  const writeErr = deps.writeErr ?? ((s) => process.stderr.write(s));
+  const writeOut = deps.writeOut ?? ((s) => process.stdout.write(s));
+  const startDocker = deps.startDockerFleet ?? defaultStartDockerFleet;
+  const startSystemd = deps.startSystemdFleet ?? defaultStartSystemdFleet;
+
+  const marker = readRuntimeMode(markerPath);
+  // Only probe systemd if the marker doesn't already pin us — saves a
+  // subprocess on docker-mode hosts.
+  const hasSystemd =
+    marker === null && platform === "linux"
+      ? await hasActiveSystemdInstall(run)
+      : false;
+
+  const decision = decideRuntime({
+    platform,
+    marker,
+    hasActiveSystemd: hasSystemd,
+    legacy: !!options.legacy,
+  });
+
+  let printedAdvisory = false;
+  if (decision.showLegacyAdvisory) {
+    writeErr(chalk.yellow("\n" + legacyAdvisoryText() + "\n\n"));
+    printedAdvisory = true;
+  }
+
+  if (decision.runtime === "docker") {
+    writeOut(chalk.bold("Bringing up Switchroom (docker runtime)...\n"));
+    await startDocker(config);
+  } else {
+    writeOut(chalk.bold("Bringing up Switchroom (systemd runtime)...\n"));
+    await startSystemd(config);
+  }
+
+  let markerWritten: "host" | "docker" | null = null;
+  if (decision.writeDockerMarkerAfter) {
+    await writeMarker(markerPath, "docker");
+    markerWritten = "docker";
+  } else if (decision.writeHostMarkerAfter) {
+    await writeMarker(markerPath, "host");
+    markerWritten = "host";
+  }
+
+  return { runtime: decision.runtime, printedAdvisory, markerWritten };
+}
+
+export function registerUpCommand(program: Command): void {
+  program
+    .command("up")
+    .description(
+      "Bring up the Switchroom fleet. Defaults to Docker on Linux; pass --legacy to use systemd.",
+    )
+    .option(
+      "--legacy",
+      "Force the legacy systemd runtime instead of Docker (Linux-only override).",
+    )
+    .action(
+      withConfigError(async (opts: { legacy?: boolean }) => {
+        const config = getConfig(program);
+        try {
+          await runUp(config, { legacy: !!opts.legacy });
+        } catch (err) {
+          console.error(chalk.red(`switchroom up failed: ${(err as Error).message}`));
+          process.exit(1);
+        }
+      }),
+    );
+}


### PR DESCRIPTION
## Summary

Phase 3b-3 — final piece of Phase 3b. Flips the default of `switchroom up` from systemd-host to Docker on Linux, with a `--legacy` flag preserving the systemd path. Builds on Phase 3b-1/2 (#819, #820, #821, #822 — fleet runtime, watchdog, migrate CLI).

- New `switchroom up` CLI verb (`src/cli/up.ts`) — pure orchestrator with all side effects injectable for unit testing.
- Decision logic in `src/cli/runtime-detection.ts` — covers all 6 cells of the platform × marker × systemd-state × `--legacy` matrix.
- Doctor coexistence check (`checkRuntimeCoexistence` in `doctor-docker.ts`) — warn-not-fail when the runtime-mode marker disagrees with the host's systemd state.
- Operator docs (`docs/operators/runtime-mode.md`).

## Decision matrix

| Platform | Marker  | Systemd installed? | `--legacy` | Runtime | Marker after | Advisory? |
| -------- | ------- | ------------------ | ---------- | ------- | ------------ | --------- |
| Linux    | absent  | no                 | no         | docker  | `docker`     | no        |
| Linux    | absent  | **yes**            | no         | host    | unchanged    | **yes**   |
| Linux    | absent  | any                | **yes**    | host    | `host`       | no        |
| Linux    | docker  | any                | ignored    | docker  | unchanged    | no        |
| Linux    | host    | any                | ignored    | host    | unchanged    | no        |
| non-Linux| any     | any                | any        | host    | unchanged    | no        |

The advisory keeps firing on every `up` until the operator either migrates or `--legacy`-pins the marker.

## Test evidence

- `src/cli/runtime-detection.test.ts` — 16 tests, all 7 decision-matrix cells + marker reader + systemd probe.
- `src/cli/up.test.ts` — 8 tests covering each acceptance criterion (1)–(5) plus marker=host, --legacy on fresh host, and error propagation. All side effects stubbed — no docker, no systemctl.
- `src/cli/doctor-docker.test.ts` — 9 tests for `checkRuntimeCoexistence` (every quadrant of marker × systemd) and `runDockerChecks` wiring.

`bunx vitest run` on the touched files: 33/33 pass. Full vitest matches baseline (same 19 unrelated failing files on upstream/main — drive/, vault, issues, run-hook).

`tsc --noEmit` clean.

## Out of scope (deferred)

- macOS Docker support — Phase 3d.
- Snapshot CI gate — Phase 3c.
- Real-CLI codepath test for `switchroom add agent` — Phase 3c.

## Test plan

- [ ] `switchroom up` on a fresh Linux host (no marker, no systemd) starts the docker fleet and writes `~/.switchroom/runtime-mode` = `docker`.
- [ ] `switchroom up` on a Linux host with active systemd installation prints the legacy advisory and uses systemd; subsequent invocations re-print until acted on.
- [ ] `switchroom up --legacy` on the same host: silent, marker pinned to `host`.
- [ ] `switchroom up` on macOS: keeps current behaviour, no flip.
- [ ] `switchroom doctor` warns on coexistence (`runtime-mode = docker` + enabled `switchroom-*` units), does NOT fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)