### PR TITLE
Issue #769: aq: ask-user stays on pendingAskUser (option B)

### DIFF
--- a/src/vault/approvals/MIGRATION.md
+++ b/src/vault/approvals/MIGRATION.md
@@ -40,15 +40,26 @@ agents using capability tokens, and the kernel is the read path for
 
 ## 3. ask_user dispatch (`aq:` callbacks)
 
-**Where:** `telegram-plugin/gateway/gateway.ts:8321` (dispatch) and
-`ask-user.ts` (callback shape).
+**Where:** `telegram-plugin/gateway/gateway.ts` (dispatch + `pendingAskUser`
+in-process map) and `telegram-plugin/ask-user.ts` (callback shape).
 
-**Plan:** `aq:` is already kernel-shaped — it has a request_id, a card
-with allow/deny choices, and a result that flows back to a waiting agent.
-The migration is mostly cosmetic: rename the prefix to `apv:`, route the
-tap through `approvalConsume` + `recordDecision`, and surface the
-decision via `approvalLookup` to the waiting agent. The reaction
-lifecycle and topic routing in `aq:` should be preserved verbatim.
+**Plan: do not migrate.** `aq:` and the approval kernel solve different
+problems and the schemas don't line up:
+
+- `aq:` is an **N-choice question primitive** — 2–8 arbitrary option
+  strings, callback shape `aq:<idx>:<askId>`, result returned to the
+  agent as `{ kind: 'answered', choice: string, idx: number }`.
+- The approval kernel (`apv:`) is a **binary grant/deny primitive** —
+  `parseApprovalCallback` only recognizes `once|always|deny|ttl`, and
+  `ApprovalDecisionModeSchema` only encodes `allow_once|allow_always|
+  allow_ttl|deny|deny_perm`. There is no field on `approvalRecord` /
+  `approvalLookup` to carry "user picked option idx 4 of 7".
+
+`aq:` therefore stays on the existing in-process `pendingAskUser` map
+in the gateway. The kernel handles only binary approvals (secrets,
+vault grants, MCP requests). If a future RFC needs multi-choice
+approvals, that's a kernel-schema extension, not a rename — see
+issue #769 for the decision (option B).
 
 ## 4. Permission-rule prompts (`perm:more`, `perm:allow`, `perm:deny`)
 

--- a/telegram-plugin/ask-user.ts
+++ b/telegram-plugin/ask-user.ts
@@ -1,3 +1,4 @@
+// Ask-user uses pendingAskUser, not the approval kernel — see #769 for rationale.
 /**
  * Pure helpers for the `ask_user` MCP tool.
  *


### PR DESCRIPTION
## Summary

- Rewrites `src/vault/approvals/MIGRATION.md` §3 to remove the incorrect "mostly cosmetic" framing.
- States explicitly that `aq:` (N-choice question primitive) stays on the in-process `pendingAskUser` map and will NOT migrate to the binary approval kernel.
- Adds a one-line pointer comment in `telegram-plugin/ask-user.ts` so future readers find #769 fast.

## Rationale

Per discussion in #769: `aq:` carries 2–8 arbitrary option strings + an idx, while `apv:` only encodes binary `allow/deny|once|always|ttl`. There's no field in the kernel schema to carry "user picked option 4 of 7", so a rename is not enough — it would need a real schema extension. Option B (keep them separate) wins for now; revisit if a future RFC genuinely needs multi-choice approvals.

Closes #769

## Test plan

- [x] `MIGRATION.md` reads coherently end-to-end
- [x] no code paths changed (doc + comment only)