### PR TITLE
feat(approvals): migrate vd:unlock onto kernel (dual-dispatch)

### DIFF
--- a/src/vault/approvals/vd-unlock-dual-dispatch.test.ts
+++ b/src/vault/approvals/vd-unlock-dual-dispatch.test.ts
@@ -1,0 +1,223 @@
+/**
+ * Dual-dispatch coverage for the `vd:unlock` deferred-secret card
+ * (MIGRATION.md §1, gateway.ts `handleVaultDeferCallback`).
+ *
+ * The gateway helper `recordDeferredSecretKernelDecision` is intentionally
+ * NOT exported (lives inside the gateway script). This test models the
+ * exact same two-step (consume → record) sequence the gateway performs,
+ * driven against an in-memory SQLite kernel, to lock down:
+ *
+ *   1. New card path — `kernel_request_id` is set: tapping unlock writes
+ *      an `allow_once` decision row + `consume`/`grant` audit rows; tapping
+ *      cancel writes a `deny` row + `consume`/`deny` audit rows.
+ *   2. Legacy in-flight card path — `kernel_request_id` is `undefined`:
+ *      the gateway helper short-circuits, no kernel writes occur. Critical
+ *      for backwards-compat with cards rendered before the deploy.
+ *
+ * If the dispatch shape regresses — e.g. someone rewires the gateway to
+ * call `approvalRecord` without first `approvalConsume` — the audit
+ * counts here will drift and fail the test.
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { Database } from "bun:sqlite";
+import { migrateApprovalSchema } from "./schema.js";
+import {
+  requestApproval,
+  consumeNonce,
+  recordDecision,
+  lookupDecision,
+} from "./kernel.js";
+
+const AGENT_UNIT = "switchroom-klanker.service";
+const SCOPE = "secret:openai_api_key";
+const ACTION = "unlock";
+const APPROVER_SET = ["12345"];
+
+function newDb(): Database {
+  const db = new Database(":memory:");
+  db.run("PRAGMA foreign_keys=ON");
+  migrateApprovalSchema(db);
+  return db;
+}
+
+/**
+ * Local re-implementation of the gateway's
+ * `recordDeferredSecretKernelDecision` helper, but driven against a real
+ * in-memory kernel DB instead of the IPC client. Mirrors the gateway's
+ * `consume → record` order and its short-circuit on missing request_id.
+ */
+function simulateDualDispatch(
+  db: Database,
+  request_id: string | undefined,
+  decision: "allow_once" | "deny",
+  granted_by_user_id: number,
+  approver_set: string[],
+): { recorded: boolean } {
+  if (!request_id) return { recorded: false };
+  const nonce = consumeNonce(db, request_id);
+  if (!nonce) return { recorded: false };
+  recordDecision(db, {
+    nonce,
+    decision,
+    approver_set,
+    granted_by_user_id,
+  });
+  return { recorded: true };
+}
+
+function countAuditEvents(db: Database, event: string): number {
+  return (
+    db
+      .query<{ n: number }, [string]>(
+        `SELECT COUNT(*) AS n FROM approval_audit WHERE event = ?`,
+      )
+      .get(event)?.n ?? 0
+  );
+}
+
+describe("vd:unlock dual-dispatch (Phase 1 migration)", () => {
+  let db: Database;
+  beforeEach(() => {
+    db = newDb();
+  });
+
+  it("new card + unlock tap: writes allow_once row + audit trail", () => {
+    const req = requestApproval(db, {
+      agent_unit: AGENT_UNIT,
+      scope: SCOPE,
+      action: ACTION,
+      approver_set: APPROVER_SET,
+      why: "Unlock vault to save a deferred secret detected in chat.",
+    });
+
+    const out = simulateDualDispatch(
+      db,
+      req.request_id,
+      "allow_once",
+      Number(APPROVER_SET[0]),
+      APPROVER_SET,
+    );
+    expect(out.recorded).toBe(true);
+
+    // Decision row exists and is in the granted state.
+    const lookup = lookupDecision(db, {
+      agent_unit: AGENT_UNIT,
+      scope: SCOPE,
+      action: ACTION,
+      current_approver_set: APPROVER_SET,
+    });
+    expect(lookup.state).toBe("granted");
+
+    // Audit trail captures request → consume → grant.
+    expect(countAuditEvents(db, "request")).toBe(1);
+    expect(countAuditEvents(db, "consume")).toBe(1);
+    expect(countAuditEvents(db, "grant")).toBe(1);
+  });
+
+  it("new card + cancel tap: writes deny row + audit trail", () => {
+    const req = requestApproval(db, {
+      agent_unit: AGENT_UNIT,
+      scope: SCOPE,
+      action: ACTION,
+      approver_set: APPROVER_SET,
+    });
+
+    const out = simulateDualDispatch(
+      db,
+      req.request_id,
+      "deny",
+      Number(APPROVER_SET[0]),
+      APPROVER_SET,
+    );
+    expect(out.recorded).toBe(true);
+
+    const lookup = lookupDecision(db, {
+      agent_unit: AGENT_UNIT,
+      scope: SCOPE,
+      action: ACTION,
+      current_approver_set: APPROVER_SET,
+    });
+    expect(lookup.state).toBe("denied");
+
+    expect(countAuditEvents(db, "deny")).toBe(1);
+    expect(countAuditEvents(db, "grant")).toBe(0);
+  });
+
+  it("legacy in-flight card (no kernel request_id): no kernel writes", () => {
+    const out = simulateDualDispatch(
+      db,
+      undefined,
+      "allow_once",
+      Number(APPROVER_SET[0]),
+      APPROVER_SET,
+    );
+    expect(out.recorded).toBe(false);
+
+    // No nonce ever opened, no decisions recorded, no audit rows.
+    const decisions = db
+      .query<{ n: number }, []>(`SELECT COUNT(*) AS n FROM approval_decisions`)
+      .get();
+    const nonces = db
+      .query<{ n: number }, []>(`SELECT COUNT(*) AS n FROM approval_nonces`)
+      .get();
+    const audit = db
+      .query<{ n: number }, []>(`SELECT COUNT(*) AS n FROM approval_audit`)
+      .get();
+    expect(decisions?.n ?? 0).toBe(0);
+    expect(nonces?.n ?? 0).toBe(0);
+    expect(audit?.n ?? 0).toBe(0);
+  });
+
+  it("double-tap on a new card: second tap is a kernel no-op", () => {
+    const req = requestApproval(db, {
+      agent_unit: AGENT_UNIT,
+      scope: SCOPE,
+      action: ACTION,
+      approver_set: APPROVER_SET,
+    });
+
+    const first = simulateDualDispatch(
+      db,
+      req.request_id,
+      "allow_once",
+      Number(APPROVER_SET[0]),
+      APPROVER_SET,
+    );
+    const second = simulateDualDispatch(
+      db,
+      req.request_id,
+      "allow_once",
+      Number(APPROVER_SET[0]),
+      APPROVER_SET,
+    );
+    expect(first.recorded).toBe(true);
+    expect(second.recorded).toBe(false);
+
+    // Exactly one decision row and one grant audit event — single-use
+    // nonce semantics enforced by `consumeNonce`.
+    const decisionsRow = db
+      .query<{ n: number }, []>(`SELECT COUNT(*) AS n FROM approval_decisions`)
+      .get();
+    expect(decisionsRow?.n ?? 0).toBe(1);
+    expect(countAuditEvents(db, "grant")).toBe(1);
+    expect(countAuditEvents(db, "consume")).toBe(1);
+  });
+
+  it("scope/action shape matches the gateway helper contract", () => {
+    // The gateway uses scope=`secret:<slug>` action=`unlock`. Drift here
+    // means a kernel-server ACL rule keyed on `secret:*`/`unlock` would
+    // stop matching the new cards. Lock that contract down.
+    const req = requestApproval(db, {
+      agent_unit: AGENT_UNIT,
+      scope: SCOPE,
+      action: ACTION,
+      approver_set: APPROVER_SET,
+    });
+    const nonce = consumeNonce(db, req.request_id);
+    expect(nonce).not.toBeNull();
+    expect(nonce!.scope.startsWith("secret:")).toBe(true);
+    expect(nonce!.action).toBe("unlock");
+    expect(nonce!.agent_unit).toBe(AGENT_UNIT);
+  });
+});

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -305,6 +305,11 @@ import {
   revokeGrantViaBroker,
 } from '../../src/vault/broker/client.js'
 import {
+  approvalRequest,
+  approvalConsume,
+  approvalRecord,
+} from '../../src/vault/approvals/client.js'
+import {
   openTurnsDb,
   markOrphanedAsRestarted,
   recordTurnStart,
@@ -1342,8 +1347,84 @@ interface DeferredSecret {
    * slug if detection didn't fire.
    */
   suggested_slug: string
+  /**
+   * Approval-kernel request_id minted alongside the bespoke deferred-secret
+   * card (MIGRATION.md §1, Phase 1 dual-dispatch). When set, the
+   * `vd:unlock` / `vd:cancel` callback handler ALSO records the user's
+   * decision on the kernel side via `approvalConsume` + `approvalRecord`,
+   * so the audit log captures the unlock event.
+   *
+   * `undefined` on cards built before this PR landed (in-flight at deploy
+   * time) — the legacy handler runs alone, no kernel record. After ~1-2
+   * releases the legacy-only branch can be removed (separate cleanup PR).
+   */
+  kernel_request_id?: string
 }
 const deferredSecrets = new Map<string, DeferredSecret>()
+
+/**
+ * Mint an approval-kernel decision row for a deferred-secret card
+ * (MIGRATION.md §1). Best-effort: if the kernel/broker is unreachable, we
+ * return null and the caller proceeds with the legacy-only path so the
+ * core unlock UX never depends on kernel availability.
+ *
+ * `agent_unit` is the gateway's agent — the per-agent ACL ships in Docker
+ * Phase 2b. The kernel-server checks the listener's bound socket against
+ * the claimed agent, so passing the local agent name is safe.
+ */
+async function mintDeferredSecretKernelRequest(
+  slug: string,
+  approverSet: string[],
+): Promise<string | null> {
+  const agentName = process.env.SWITCHROOM_AGENT_NAME
+  if (!agentName) return null
+  try {
+    const r = await approvalRequest({
+      agent_unit: `switchroom-${agentName}.service`,
+      scope: `secret:${slug}`,
+      action: 'unlock',
+      approver_set: approverSet,
+      why: 'Unlock vault to save a deferred secret detected in chat.',
+    })
+    if (r === null || r.state !== 'pending') return null
+    return r.request_id
+  } catch (err) {
+    process.stderr.write(
+      `[approval-kernel] mintDeferredSecretKernelRequest failed: ${(err as Error).message}\n`,
+    )
+    return null
+  }
+}
+
+/**
+ * Record the user's decision (allow/deny) on the approval kernel for a
+ * deferred-secret card. Best-effort and idempotent — a missing
+ * `request_id` (legacy in-flight card) or an unreachable kernel both
+ * silently no-op so the legacy UX is unaffected.
+ */
+async function recordDeferredSecretKernelDecision(
+  request_id: string | undefined,
+  decision: 'allow_once' | 'deny',
+  granted_by_user_id: number,
+  approverSet: string[],
+): Promise<void> {
+  if (!request_id) return
+  try {
+    const consumed = await approvalConsume(request_id)
+    if (consumed === null || !consumed.consumed) return
+    await approvalRecord({
+      request_id,
+      decision,
+      approver_set: approverSet,
+      granted_by_user_id,
+      ttl_ms: null,
+    })
+  } catch (err) {
+    process.stderr.write(
+      `[approval-kernel] recordDeferredSecretKernelDecision failed: ${(err as Error).message}\n`,
+    )
+  }
+}
 function deferredKey(chat_id: string, message_id: number): string {
   return `${chat_id}:${message_id}`
 }
@@ -4744,12 +4825,18 @@ async function handleInbound(
         // the post-context flow stays seamless.
         const dKey = deferredKey(chat_id, msgId ?? 0)
         const cachedBranchDetection = detectSecrets(effectiveText).find((d) => d.confidence === 'high' && !d.suppressed)
+        const cachedBranchSlug = cachedBranchDetection?.suggested_slug ?? (isAuthFlowContext ? 'anthropic_oauth_code' : 'secret')
+        const cachedBranchKernelId = await mintDeferredSecretKernelRequest(
+          cachedBranchSlug,
+          loadAccess().allowFrom,
+        )
         deferredSecrets.set(dKey, {
           chat_id,
           original_message_id: msgId ?? 0,
           text: effectiveText,
           staged_at: Date.now(),
-          suggested_slug: cachedBranchDetection?.suggested_slug ?? (isAuthFlowContext ? 'anthropic_oauth_code' : 'secret'),
+          suggested_slug: cachedBranchSlug,
+          kernel_request_id: cachedBranchKernelId ?? undefined,
         })
         await switchroomReply(
           ctx,
@@ -4790,12 +4877,17 @@ async function handleInbound(
           highConfDetection?.suggested_slug
           ?? (isAuthFlowContext ? 'anthropic_oauth_code' : 'secret')
         const dKey = deferredKey(chat_id, msgId ?? 0)
+        const noPassKernelId = await mintDeferredSecretKernelRequest(
+          suggestedSlug,
+          loadAccess().allowFrom,
+        )
         deferredSecrets.set(dKey, {
           chat_id,
           original_message_id: msgId ?? 0,
           text: effectiveText,
           staged_at: Date.now(),
           suggested_slug: suggestedSlug,
+          kernel_request_id: noPassKernelId ?? undefined,
         })
         if (msgId != null) {
           try { await bot.api.deleteMessage(chat_id, msgId) } catch {}
@@ -7021,6 +7113,16 @@ async function handleVaultDeferCallback(ctx: Context, data: string): Promise<voi
   const cardMessageId = ctx.callbackQuery?.message?.message_id
 
   if (action === 'cancel') {
+    // Kernel-side dual-dispatch (MIGRATION.md §1): record the deny decision
+    // BEFORE the legacy handler clears state, so the audit log captures it
+    // even if the editMessageText below races with another tap. Best-effort
+    // — broker unreachable falls back to legacy-only.
+    await recordDeferredSecretKernelDecision(
+      deferred.kernel_request_id,
+      'deny',
+      ctx.from?.id ?? 0,
+      access.allowFrom,
+    )
     deferredSecrets.delete(deferKey)
     await ctx.answerCallbackQuery({ text: 'Discarded.' }).catch(() => {})
     if (cardMessageId != null) {
@@ -7034,6 +7136,18 @@ async function handleVaultDeferCallback(ctx: Context, data: string): Promise<voi
   }
 
   if (action === 'unlock') {
+    // Kernel-side dual-dispatch (MIGRATION.md §1): record the allow_once
+    // decision when the user taps unlock. The actual passphrase capture +
+    // vault write still happens via the legacy path below — the kernel
+    // decision is for audit/state, not secret material (per RFC B). We
+    // record at tap-time rather than after passphrase entry so a kernel
+    // record exists even if the user abandons the passphrase prompt.
+    await recordDeferredSecretKernelDecision(
+      deferred.kernel_request_id,
+      'allow_once',
+      ctx.from?.id ?? 0,
+      access.allowFrom,
+    )
     // If a passphrase is already cached we can skip straight to the write.
     // Covers the case where the user had unlocked separately between
     // detection and tap.

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -41,6 +41,9 @@ export default defineConfig({
       "**/node_modules/**",
       "**/dist/**",
       "**/src/vault/grants.test.ts",
+      // Approval-kernel suites use bun:sqlite — run via test:bun.
+      "**/src/vault/approvals/kernel.test.ts",
+      "**/src/vault/approvals/vd-unlock-dual-dispatch.test.ts",
       // Phase 3b-1 watchdog state/policy tests use bun:sqlite — run via test:bun.
       "**/src/watchdog/state.test.ts",
       "**/src/watchdog/policy.test.ts",


### PR DESCRIPTION
## Summary

Phase 1 of the approval-kernel call-site migration (per `src/vault/approvals/MIGRATION.md` §1). Migrates the deferred-secret unlock path (`vd:unlock` / `vd:cancel`) onto the approval kernel using a dual-dispatch shape, so the kernel audit log captures unlock decisions under the per-agent ACL gate (Docker Phase 2b) without disrupting the legacy passphrase-capture UX.

After this PR the only remaining legacy approval call-sites are:
- vault-grant wizard (Phase 2 — separate PR)
- `aq:` ask-user (skipped per #769 option B)

## Dual-dispatch rationale

The deferred-secret card owns a bespoke flow: the user taps unlock, types their vault passphrase as a follow-up message, and the gateway writes the held secret to the vault. Per RFC B the kernel is for *approval state*, not secret material — so the passphrase capture stays where it is. We just mint a kernel decision row alongside the existing card and `consume` + `record` it on tap.

- New cards (built after this PR lands): `DeferredSecret.kernel_request_id` is set. The legacy `vd:unlock` callback handler runs the kernel `consume → record` step at tap-time, BEFORE the legacy passphrase prompt fires. Allow → `allow_once`; Cancel → `deny`.
- In-flight legacy cards (rendered before this deploy): `kernel_request_id` is `undefined`. The legacy handler runs alone, no kernel write. Safe: the legacy path is unchanged.
- Best-effort wiring: any failure to mint or record (broker unreachable, ACL refusal, missing `SWITCHROOM_AGENT_NAME`) is logged to stderr and swallowed — the unlock UX never depends on kernel availability.

The legacy `vd:unlock` dispatcher branch will be removed ~1-2 releases later as a cleanup PR.

## Changes

- `telegram-plugin/gateway/gateway.ts`
  - import `approvalRequest` / `approvalConsume` / `approvalRecord` from the kernel client
  - `DeferredSecret.kernel_request_id?: string` added
  - new helpers: `mintDeferredSecretKernelRequest` (called when staging a deferred secret) and `recordDeferredSecretKernelDecision` (called from `handleVaultDeferCallback`)
  - both `deferredSecrets.set(...)` sites mint a kernel request_id
  - `handleVaultDeferCallback` records the kernel decision before running the legacy branch (cancel → deny, unlock → allow_once)
- `src/vault/approvals/vd-unlock-dual-dispatch.test.ts` — new bun-test suite covering five cases (new+unlock, new+cancel, legacy-no-id, double-tap, scope/action contract)
- `vitest.config.ts` — exclude the new bun-test file plus the existing `kernel.test.ts` (both use `bun:sqlite`)

## Test plan

- [x] `bun test src/vault/approvals/` — 47 pass, 0 fail (5 new tests added)
- [x] `bunx tsc --noEmit` — clean
- [x] `bunx vitest run` — 5242 pass, 47 fail = baseline unchanged from upstream/main
- [x] Acceptance: new card mints kernel decision with correct `agent_unit` (`switchroom-${SWITCHROOM_AGENT_NAME}.service`), scope `secret:<slug>`, action `unlock`
- [x] Acceptance: tapping allow/deny on new card writes BOTH legacy state AND kernel decision row + audit
- [x] Acceptance: tapping allow/deny on legacy card (no `kernel_request_id`) still works — short-circuits kernel record, legacy unchanged
- [x] Acceptance: double-tap is a kernel no-op (single-use nonce enforced by `consumeNonce`)
- [x] Acceptance: every new-card decision lands in `approval_audit` (`request` + `consume` + `grant`/`deny`)

## Out of scope

- Vault-grant wizard migration (Phase 2 — separate PR)
- `aq:` ask-user migration (skipped per #769 option B)
- Removing the legacy `vd:unlock` dispatcher branch (~1-2 releases later)