### PR TITLE
fix: compose + scaffold + apply blockers (v0.7 PR-A1)

### DIFF
--- a/src/agents/compose.ts
+++ b/src/agents/compose.ts
@@ -112,6 +112,21 @@ export interface ComposeGeneratorOptions {
    * still references the source tree's `docker/Dockerfile.*`.
    */
   buildContext?: string;
+  /**
+   * Absolute path to the operator's home directory — baked into every
+   * host-path bind mount source at apply time.
+   *
+   * Why not `${HOME}`: compose interpolates env vars at the time the
+   * `docker compose` CLI runs. When the operator runs `sudo docker
+   * compose up -d`, sudo strips HOME by default (or sets it to /root),
+   * so `${HOME}/.switchroom/...` resolves to `/root/.switchroom/...`
+   * — wrong filesystem location, agent containers see empty volumes.
+   *
+   * Baking the absolute path at apply time eliminates the env-var
+   * dependency. Optional for back-compat with callers that haven't
+   * been updated yet (defaults to `${HOME}` interpolation).
+   */
+  homeDir?: string;
 }
 
 /** Resolve the image ref for one of the four service images. */
@@ -193,6 +208,12 @@ export function generateCompose(opts: ComposeGeneratorOptions): string {
   const warn = opts.warn ?? ((m: string) => process.stderr.write(m + "\n"));
   const buildMode = opts.buildMode ?? "pull";
   const buildContext = opts.buildContext;
+  // homePrefix is the leading segment of every host-path bind source.
+  // When the caller passes homeDir we bake an absolute path so compose
+  // interpolation under sudo can't mis-resolve HOME to /root. Default
+  // preserves the older `${HOME}` shape for callers that haven't been
+  // updated.
+  const homePrefix = opts.homeDir ?? "${HOME}";
   if (buildMode === "local" && !buildContext) {
     throw new Error(
       `compose: buildMode="local" requires buildContext (the absolute path to the switchroom checkout)`,
@@ -206,6 +227,14 @@ export function generateCompose(opts: ComposeGeneratorOptions): string {
   lines.push("# switchroom.yaml and re-run the regenerating command.");
   lines.push("");
   lines.push(`# image tag: ${imageTag}`);
+  lines.push("");
+  // Top-level project name — belt-and-braces collision protection. A
+  // Coolify-managed (or any other) compose stack on the same host can't
+  // accidentally claim our service/container names because compose
+  // namespaces by project; pinning the name at file scope means
+  // `docker compose -f <path> ...` invocations always target the same
+  // project even when the operator forgets `-p switchroom`.
+  lines.push(`name: switchroom`);
   lines.push("");
   lines.push(`services:`);
 
@@ -234,7 +263,7 @@ export function generateCompose(opts: ComposeGeneratorOptions): string {
   for (const a of describeAgents(config)) {
     lines.push(`      - broker-${a.name}-sock:/run/switchroom/broker/${a.name}`);
   }
-  lines.push(`      - \${HOME}/.switchroom/vault:/state/vault`);
+  lines.push(`      - ${homePrefix}/.switchroom/vault:/state/vault`);
   lines.push(``);
 
   // ── approval-kernel (singleton) ────────────────────────────────────
@@ -260,7 +289,7 @@ export function generateCompose(opts: ComposeGeneratorOptions): string {
   for (const a of describeAgents(config)) {
     lines.push(`      - kernel-${a.name}-sock:/run/switchroom/kernel/${a.name}`);
   }
-  lines.push(`      - \${HOME}/.switchroom/approvals:/state/approvals`);
+  lines.push(`      - ${homePrefix}/.switchroom/approvals:/state/approvals`);
   lines.push(``);
 
   // ── switchroom-cron (singleton scheduler) ──────────────────────────
@@ -282,8 +311,8 @@ export function generateCompose(opts: ComposeGeneratorOptions): string {
   // which is a write op against the daemon API. Read-only would
   // silently break dispatch with cryptic permission errors.
   lines.push(`      - /var/run/docker.sock:/var/run/docker.sock`);
-  lines.push(`      - \${HOME}/.switchroom:/state/config:ro`);
-  lines.push(`      - \${HOME}/.switchroom/scheduler:/state/scheduler`);
+  lines.push(`      - ${homePrefix}/.switchroom:/state/config:ro`);
+  lines.push(`      - ${homePrefix}/.switchroom/scheduler:/state/scheduler`);
   lines.push(`    environment:`);
   lines.push(`      SWITCHROOM_CONFIG: /state/config/switchroom.yaml`);
   // SQLite audit sink for scheduler fires (Phase 1b — wires
@@ -297,7 +326,7 @@ export function generateCompose(opts: ComposeGeneratorOptions): string {
     if (a.strippedCaps.length > 0) {
       warn(`compose: stripping cap_add ${JSON.stringify(a.strippedCaps)} from agent "${a.name}" (Docker mode forbids capability extras; see RFC §security)`);
     }
-    emitAgentService(lines, a, imageTag, buildMode, buildContext);
+    emitAgentService(lines, a, imageTag, buildMode, buildContext, homePrefix);
   }
 
   // ── volumes ────────────────────────────────────────────────────────
@@ -317,6 +346,7 @@ function emitAgentService(
   imageTag: string,
   buildMode: "pull" | "local",
   buildContext: string | undefined,
+  homePrefix: string,
 ): void {
   lines.push(`  agent-${a.name}:`);
   emitImageOrBuild(lines, "agent", imageTag, buildMode, buildContext);
@@ -364,9 +394,9 @@ function emitAgentService(
   // invariant on every regenerated compose.
   lines.push(`      - broker-${a.name}-sock:/run/switchroom/broker`);
   lines.push(`      - kernel-${a.name}-sock:/run/switchroom/kernel`);
-  lines.push(`      - \${HOME}/.switchroom/agents/${a.name}:/state/agent`);
-  lines.push(`      - \${HOME}/.claude/projects/${a.name}:/state/.claude`);
-  lines.push(`      - \${HOME}/.switchroom/logs/${a.name}:/var/log/switchroom`);
+  lines.push(`      - ${homePrefix}/.switchroom/agents/${a.name}:/state/agent`);
+  lines.push(`      - ${homePrefix}/.claude/projects/${a.name}:/state/.claude`);
+  lines.push(`      - ${homePrefix}/.switchroom/logs/${a.name}:/var/log/switchroom`);
   lines.push(``);
   void imageTag;
 }

--- a/src/agents/compose.ts
+++ b/src/agents/compose.ts
@@ -278,7 +278,10 @@ export function generateCompose(opts: ComposeGeneratorOptions): string {
   lines.push(`    cap_drop:`);
   lines.push(`      - "ALL"`);
   lines.push(`    volumes:`);
-  lines.push(`      - /var/run/docker.sock:/var/run/docker.sock:ro`);
+  // docker.sock mounted read-write: scheduler needs `docker exec`
+  // which is a write op against the daemon API. Read-only would
+  // silently break dispatch with cryptic permission errors.
+  lines.push(`      - /var/run/docker.sock:/var/run/docker.sock`);
   lines.push(`      - \${HOME}/.switchroom:/state/config:ro`);
   lines.push(`      - \${HOME}/.switchroom/scheduler:/state/scheduler`);
   lines.push(`    environment:`);

--- a/src/agents/scaffold.test.ts
+++ b/src/agents/scaffold.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+/**
+ * Unit tests for {@link alignAgentUid}.
+ *
+ * The function shells out to `chown` (and falls back to `sudo chown`)
+ * to fix bind-mount ownership for an agent's per-agent state dir.
+ * We mock `node:child_process` and `node:fs` so the tests run
+ * deterministically regardless of the runner's UID, sudo policy, or
+ * filesystem state.
+ */
+
+// Mock factories must declare their state inside the factory body —
+// vi.mock is hoisted, so anything referenced here must be self-contained.
+vi.mock("node:child_process", () => {
+  return {
+    execSync: vi.fn(),
+    execFileSync: vi.fn(),
+  };
+});
+
+vi.mock("node:fs", async () => {
+  const actual = await vi.importActual<typeof import("node:fs")>("node:fs");
+  return {
+    ...actual,
+    existsSync: vi.fn(() => true),
+    statSync: vi.fn(),
+  };
+});
+
+// Imports MUST come after vi.mock so the mocks are applied.
+import { execFileSync } from "node:child_process";
+import { existsSync, statSync } from "node:fs";
+import { alignAgentUid } from "./scaffold.js";
+
+const mockedExecFileSync = vi.mocked(execFileSync);
+const mockedExistsSync = vi.mocked(existsSync);
+const mockedStatSync = vi.mocked(statSync);
+
+describe("alignAgentUid", () => {
+  beforeEach(() => {
+    mockedExecFileSync.mockReset();
+    mockedExistsSync.mockReset();
+    mockedStatSync.mockReset();
+    mockedExistsSync.mockReturnValue(true);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("is a no-op when the dir is already owned by the target uid (idempotent fast-path)", () => {
+    mockedStatSync.mockReturnValue({ uid: 10042, gid: 10042 } as never);
+
+    const res = alignAgentUid("agent", "/fake/state/agent", 10042, {
+      writeOut: () => {},
+    });
+
+    expect(res.chowned).toBe(false);
+    expect(res.paths).toEqual(["/fake/state/agent"]);
+    expect(mockedExecFileSync).not.toHaveBeenCalled();
+  });
+
+  it("tries unprivileged chown first, returns success when it works", () => {
+    mockedStatSync.mockReturnValue({ uid: 1000, gid: 1000 } as never);
+    mockedExecFileSync.mockImplementationOnce(() => Buffer.from(""));
+
+    const res = alignAgentUid("agent", "/fake/state/agent", 10042, {
+      writeOut: () => {},
+      confirm: false,
+    });
+
+    expect(res.chowned).toBe(true);
+    expect(mockedExecFileSync).toHaveBeenCalledTimes(1);
+    const [bin, args] = mockedExecFileSync.mock.calls[0];
+    expect(bin).toBe("chown");
+    expect(args).toEqual(["-R", "10042:10042", "/fake/state/agent"]);
+  });
+
+  it("falls back to `sudo chown` when unprivileged chown fails (EPERM)", () => {
+    mockedStatSync.mockReturnValue({ uid: 1000, gid: 1000 } as never);
+    mockedExecFileSync
+      .mockImplementationOnce(() => {
+        const e = new Error("EPERM: operation not permitted");
+        throw e;
+      })
+      .mockImplementationOnce(() => Buffer.from(""));
+
+    const res = alignAgentUid("agent", "/fake/state/agent", 10042, {
+      writeOut: () => {},
+      confirm: false,
+    });
+
+    expect(res.chowned).toBe(true);
+    expect(mockedExecFileSync).toHaveBeenCalledTimes(2);
+    const [bin1] = mockedExecFileSync.mock.calls[0];
+    const [bin2, args2] = mockedExecFileSync.mock.calls[1];
+    expect(bin1).toBe("chown");
+    expect(bin2).toBe("sudo");
+    expect(args2).toEqual([
+      "chown",
+      "-R",
+      "10042:10042",
+      "/fake/state/agent",
+    ]);
+  });
+
+  it("throws an actionable error when both unprivileged AND sudo chown fail", () => {
+    mockedStatSync.mockReturnValue({ uid: 1000, gid: 1000 } as never);
+    mockedExecFileSync.mockImplementation(() => {
+      throw new Error("nope");
+    });
+
+    expect(() =>
+      alignAgentUid("agent", "/fake/state/agent", 10042, {
+        writeOut: () => {},
+        confirm: false,
+      }),
+    ).toThrow(/sudo chown failed.*Run manually: sudo chown -R 10042:10042/);
+    expect(mockedExecFileSync).toHaveBeenCalledTimes(2);
+  });
+
+  it("respects dryRun: never shells out even if uids mismatch", () => {
+    mockedStatSync.mockReturnValue({ uid: 1000, gid: 1000 } as never);
+
+    const res = alignAgentUid("agent", "/fake/state/agent", 10042, {
+      writeOut: () => {},
+      confirm: false,
+      dryRun: true,
+    });
+
+    expect(res.chowned).toBe(false);
+    expect(mockedExecFileSync).not.toHaveBeenCalled();
+  });
+
+  it("returns immediately with no paths when the agentDir does not exist", () => {
+    mockedExistsSync.mockReturnValue(false);
+
+    const res = alignAgentUid("agent", "/missing/agent", 10042, {
+      writeOut: () => {},
+      confirm: false,
+    });
+
+    expect(res.chowned).toBe(false);
+    expect(res.paths).toEqual([]);
+    expect(mockedExecFileSync).not.toHaveBeenCalled();
+  });
+});

--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -67,6 +67,99 @@ export interface ScaffoldResult {
 }
 
 /**
+ * Align ownership of an agent's per-agent state directories with the
+ * deterministic container UID assigned by compose.ts.
+ *
+ * Why this is required: in Docker mode the agent container runs as
+ * `user: <uid>` (a hash-derived value in 10001–10999). The container
+ * bind-mounts the host's `~/.switchroom/agents/<name>` etc. into
+ * `/state/agent`. If those host directories are still owned by the
+ * operator (uid 1000), the container UID (10001+) cannot write to
+ * them and the agent silently fails to write logs / state / Claude
+ * settings on first boot. The fix is to chown the dirs once at
+ * scaffold time so the bind-mount lands writable.
+ *
+ * Implementation note: the chown target is well outside the operator's
+ * uid space, so `chownSync` typically needs CAP_CHOWN — i.e. sudo.
+ * We try the unprivileged chown first (works if the agent already
+ * exists from a prior run); on EPERM we shell out to `sudo chown -R`
+ * which prompts the operator's password. Set `confirm` to false to
+ * skip the inline prompt (apply --non-interactive path).
+ *
+ * Returns the list of paths chown'd. Throws only when sudo itself
+ * exits non-zero — that's an operator-actionable failure (wrong
+ * password, no sudoers entry).
+ */
+export interface AlignAgentUidOptions {
+  /** Suppress the y/n prompt; assume yes. Used by `--non-interactive`. */
+  confirm?: boolean;
+  /** Stdout writer for status lines; defaults to console.log. */
+  writeOut?: (s: string) => void;
+  /** Skip the chown entirely (dry-run / tests). */
+  dryRun?: boolean;
+}
+
+export function alignAgentUid(
+  name: string,
+  agentDir: string,
+  uid: number,
+  opts: AlignAgentUidOptions = {},
+): { chowned: boolean; paths: string[] } {
+  const writeOut = opts.writeOut ?? ((s: string) => process.stdout.write(s));
+  const paths: string[] = [];
+  if (existsSync(agentDir)) paths.push(agentDir);
+  if (paths.length === 0) return { chowned: false, paths: [] };
+
+  // Fast path: already correctly owned (idempotent re-runs).
+  try {
+    const st = statSync(agentDir);
+    if (st.uid === uid && st.gid === uid) {
+      return { chowned: false, paths };
+    }
+  } catch { /* fall through to chown */ }
+
+  if (opts.dryRun) return { chowned: false, paths };
+
+  if (opts.confirm !== false && process.stdin.isTTY) {
+    // Interactive prompt: explain why we're shelling sudo. We use
+    // execFileSync below with stdio inherited so the password prompt
+    // appears on the operator's terminal.
+    writeOut(
+      chalk.gray(
+        `  · aligning ${name} state dir ownership to uid ${uid} (sudo chown)\n`,
+      ),
+    );
+  }
+
+  // Try unprivileged chown first; sudo only if EPERM.
+  try {
+    // Recursive chown via shell — node's fs.chownSync isn't recursive
+    // and rolling our own walk just to fall back to sudo is wasted code.
+    execFileSync("chown", ["-R", `${uid}:${uid}`, agentDir], {
+      stdio: ["ignore", "ignore", "pipe"],
+    });
+    return { chowned: true, paths };
+  } catch {
+    // chown failed — most commonly EPERM because the operator's uid
+    // doesn't have CAP_CHOWN. Fall through to sudo. We don't try to
+    // discriminate on errno here because execFileSync's error shape
+    // is messy across node versions; the sudo path is the
+    // operator-actionable fix regardless.
+  }
+
+  try {
+    execFileSync("sudo", ["chown", "-R", `${uid}:${uid}`, agentDir], {
+      stdio: "inherit",
+    });
+    return { chowned: true, paths };
+  } catch {
+    throw new Error(
+      `alignAgentUid: sudo chown failed for ${agentDir} (target uid ${uid}). Run manually: sudo chown -R ${uid}:${uid} ${agentDir}`,
+    );
+  }
+}
+
+/**
  * Resolve a bot token value. If it's a vault reference, try to resolve it
  * via SWITCHROOM_VAULT_PASSPHRASE or fall back to TELEGRAM_BOT_TOKEN env var.
  * Returns the resolved token or undefined if unresolvable.

--- a/src/build-info.ts
+++ b/src/build-info.ts
@@ -3,7 +3,7 @@
 // Values are refreshed every time `npm run build` runs.
 
 export const VERSION: string = "0.5.2";
-export const COMMIT_SHA: string | null = "fb4e0f55";
-export const COMMIT_DATE: string | null = "2026-05-09T08:26:24+10:00";
+export const COMMIT_SHA: string | null = "7581c3ec";
+export const COMMIT_DATE: string | null = "2026-05-09T08:34:42+10:00";
 export const LATEST_PR: number | null = null;
-export const COMMITS_AHEAD_OF_TAG: number | null = 4;
+export const COMMITS_AHEAD_OF_TAG: number | null = 5;

--- a/src/build-info.ts
+++ b/src/build-info.ts
@@ -3,7 +3,7 @@
 // Values are refreshed every time `npm run build` runs.
 
 export const VERSION: string = "0.5.2";
-export const COMMIT_SHA: string | null = "7581c3ec";
-export const COMMIT_DATE: string | null = "2026-05-09T08:34:42+10:00";
+export const COMMIT_SHA: string | null = "b502743a";
+export const COMMIT_DATE: string | null = "2026-05-09T08:38:49+10:00";
 export const LATEST_PR: number | null = null;
-export const COMMITS_AHEAD_OF_TAG: number | null = 5;
+export const COMMITS_AHEAD_OF_TAG: number | null = 6;

--- a/src/build-info.ts
+++ b/src/build-info.ts
@@ -3,7 +3,7 @@
 // Values are refreshed every time `npm run build` runs.
 
 export const VERSION: string = "0.5.2";
-export const COMMIT_SHA: string | null = "0565a71d";
-export const COMMIT_DATE: string | null = "2026-05-09T08:22:53+10:00";
+export const COMMIT_SHA: string | null = "fb4e0f55";
+export const COMMIT_DATE: string | null = "2026-05-09T08:26:24+10:00";
 export const LATEST_PR: number | null = null;
-export const COMMITS_AHEAD_OF_TAG: number | null = 3;
+export const COMMITS_AHEAD_OF_TAG: number | null = 4;

--- a/src/build-info.ts
+++ b/src/build-info.ts
@@ -3,7 +3,7 @@
 // Values are refreshed every time `npm run build` runs.
 
 export const VERSION: string = "0.5.2";
-export const COMMIT_SHA: string | null = "47f1f8d3";
-export const COMMIT_DATE: string | null = "2026-05-09T07:14:40+10:00";
+export const COMMIT_SHA: string | null = "0565a71d";
+export const COMMIT_DATE: string | null = "2026-05-09T08:22:53+10:00";
 export const LATEST_PR: number | null = null;
-export const COMMITS_AHEAD_OF_TAG: number | null = 5;
+export const COMMITS_AHEAD_OF_TAG: number | null = 3;

--- a/src/cli/apply.test.ts
+++ b/src/cli/apply.test.ts
@@ -1,8 +1,9 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { mkdtemp, readFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { runApply, runApplyPreflight } from "./apply.js";
+import * as scaffoldModule from "../agents/scaffold.js";
 import type { SwitchroomConfig } from "../config/schema.js";
 
 /**
@@ -61,6 +62,86 @@ describe("runApply", () => {
       telegram: { bot_token: "vault:telegram_bot_token" },
     } as unknown as SwitchroomConfig;
     expect(() => runApplyPreflight(cfg)).toThrow(/vault/i);
+  });
+
+  describe("UID alignment failure handling", () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let scaffoldSpy: any;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let alignSpy: any;
+
+    beforeEach(() => {
+      // Force scaffoldAgent to look like it succeeded so we reach the
+      // alignAgentUid call site. The real scaffoldAgent needs a fully
+      // wired profile / telegram config which is out of scope here.
+      // Note: do NOT mockReset/mockClear these spies between tests —
+      // that wipes the implementation and the real function runs again.
+      scaffoldSpy = vi
+        .spyOn(scaffoldModule, "scaffoldAgent")
+        .mockImplementation(
+          () => ({ created: ["fake.txt"] }) as never,
+        );
+      alignSpy = vi
+        .spyOn(scaffoldModule, "alignAgentUid")
+        .mockImplementation(() => {
+          throw new Error("simulated chown EPERM");
+        });
+    });
+
+    afterEach(() => {
+      scaffoldSpy.mockRestore();
+      alignSpy.mockRestore();
+    });
+
+    it("fails hard by default when chown fails", async () => {
+      const dir = await mkdtemp(join(tmpdir(), "switchroom-apply-fail-"));
+      const sink: string[] = [];
+      await expect(
+        runApply(
+          makeStubConfig(join(dir, "agents")),
+          { outPath: join(dir, "docker-compose.yml") },
+          { writeOut: (s) => sink.push(s), writeErr: (s) => sink.push(s) },
+        ),
+      ).rejects.toThrow(/UID alignment failed|allow-unaligned/i);
+      const all = sink.join("");
+      expect(all).toMatch(/could not chown/);
+      expect(all).toMatch(/--allow-unaligned/);
+    });
+
+    it("warns and continues when --allow-unaligned is passed", async () => {
+      const dir = await mkdtemp(join(tmpdir(), "switchroom-apply-allow-"));
+      const sink: string[] = [];
+      const res = await runApply(
+        makeStubConfig(join(dir, "agents")),
+        {
+          outPath: join(dir, "docker-compose.yml"),
+          allowUnaligned: true,
+        },
+        { writeOut: (s) => sink.push(s), writeErr: (s) => sink.push(s) },
+      );
+      expect(res.scaffolded).toBe(1);
+      const all = sink.join("");
+      expect(all).toMatch(/could not chown/);
+      expect(all).toMatch(/continuing/i);
+    });
+  });
+
+  describe("compose v2 preflight", () => {
+    const realPath = process.env.PATH;
+
+    afterEach(() => {
+      process.env.PATH = realPath;
+    });
+
+    it("preflight throws with friendly message when `docker compose` v2 is missing", () => {
+      // Empty PATH so `docker` is not findable — execFileSync throws,
+      // detectComposeV2 returns the friendly error string.
+      process.env.PATH = "/nonexistent-switchroom-test-path";
+      const cfg = makeStubConfig("/tmp/agents");
+      expect(() => runApplyPreflight(cfg)).toThrow(
+        /docker compose.*v2|Compose v2 plugin/i,
+      );
+    });
   });
 
   it("returns the count of agents scaffolded", async () => {

--- a/src/cli/apply.test.ts
+++ b/src/cli/apply.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from "vitest";
 import { mkdtemp, readFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { runApply } from "./apply.js";
+import { runApply, runApplyPreflight } from "./apply.js";
 import type { SwitchroomConfig } from "../config/schema.js";
 
 /**
@@ -50,6 +50,17 @@ describe("runApply", () => {
 
     const onDisk = await readFile(outPath, "utf8");
     expect(onDisk).toMatch(/services:/);
+  });
+
+  it("preflight throws when config has vault refs but vault.enc is missing", () => {
+    // Point vault path at a non-existent file under a temp dir.
+    const fakeVault = join(tmpdir(), `nonexistent-vault-${Date.now()}.enc`);
+    const cfg = {
+      ...makeStubConfig("/tmp/agents"),
+      vault: { path: fakeVault },
+      telegram: { bot_token: "vault:telegram_bot_token" },
+    } as unknown as SwitchroomConfig;
+    expect(() => runApplyPreflight(cfg)).toThrow(/vault/i);
   });
 
   it("returns the count of agents scaffolded", async () => {

--- a/src/cli/apply.ts
+++ b/src/cli/apply.ts
@@ -60,6 +60,13 @@ export interface ApplyOptions {
    * non-interactively. Default: prompts when stdin is a TTY.
    */
   nonInteractive?: boolean;
+  /**
+   * When true, treat a chown failure during UID alignment as a soft
+   * warning instead of a hard error. Default false: an unaligned state
+   * dir will silently break the agent on first boot, so we fail loudly
+   * unless the operator opts into the unsafe path.
+   */
+  allowUnaligned?: boolean;
 }
 
 export interface ApplyDeps {
@@ -169,6 +176,10 @@ export async function runApply(
 
   // ── 1. Scaffold each agent ────────────────────────────────────────
   let scaffolded = 0;
+  // Sentinel-typed error class so the outer per-agent try/catch can
+  // re-raise UID alignment failures without swallowing them as a soft
+  // `x ${name}` log line.
+  class UidAlignmentAbort extends Error {}
   for (const name of agentNames) {
     const agentConfig = config.agents[name];
     try {
@@ -199,14 +210,30 @@ export async function runApply(
           writeOut,
         });
       } catch (alignErr) {
-        writeOut(
-          chalk.yellow(
-            `    ! could not chown ${name} state dir: ${(alignErr as Error).message}\n`,
-          ),
-        );
+        const msg = (alignErr as Error).message;
+        if (options.allowUnaligned) {
+          writeOut(
+            chalk.yellow(
+              `    ! could not chown ${name} state dir: ${msg}\n` +
+              `      continuing because --allow-unaligned was passed; agent may fail on first write.\n`,
+            ),
+          );
+        } else {
+          writeOut(
+            chalk.red(
+              `    x could not chown ${name} state dir: ${msg}\n` +
+              `      The bind-mounted state dir must be owned by the container's UID or the agent will fail on first write.\n` +
+              `      Fix: run \`switchroom apply\` from a TTY so it can prompt for sudo, OR run the suggested chown manually, OR re-run with --allow-unaligned to skip this check.\n`,
+            ),
+          );
+          throw new UidAlignmentAbort(
+            `UID alignment failed for agent ${name}; aborting apply (pass --allow-unaligned to override).`,
+          );
+        }
       }
       scaffolded++;
     } catch (err) {
+      if (err instanceof UidAlignmentAbort) throw err;
       writeOut(chalk.red(`  x ${name}: ${(err as Error).message}\n`));
     }
   }
@@ -311,12 +338,17 @@ export function registerApplyCommand(program: Command): void {
       "--non-interactive",
       "Skip prompts (e.g. sudo-chown explainer for UID alignment). Use in CI / scripts.",
     )
+    .option(
+      "--allow-unaligned",
+      "Treat UID-alignment chown failures as warnings instead of hard errors. Unsafe: an unaligned state dir will break the agent on first write. Use only if you know you'll fix ownership out-of-band.",
+    )
     .action(
       async (opts: {
         buildLocal?: boolean | string;
         out?: string;
         example?: string;
         nonInteractive?: boolean;
+        allowUnaligned?: boolean;
       }) => {
         try {
           if (opts.example) {
@@ -342,6 +374,7 @@ export function registerApplyCommand(program: Command): void {
               outPath: opts.out,
               example: opts.example,
               nonInteractive: opts.nonInteractive ?? false,
+              allowUnaligned: opts.allowUnaligned ?? false,
             },
             {},
             switchroomConfigPath,

--- a/src/cli/apply.ts
+++ b/src/cli/apply.ts
@@ -21,6 +21,9 @@ import { copyFileSync, existsSync } from "node:fs";
 import { mkdir, writeFile } from "node:fs/promises";
 import { dirname, join, resolve } from "node:path";
 import { homedir } from "node:os";
+import { execFileSync } from "node:child_process";
+import { isVaultReference } from "../vault/resolver.js";
+import { resolvePath } from "../config/loader.js";
 import {
   loadConfig,
   resolveAgentsDir,
@@ -74,6 +77,72 @@ export interface ApplyResult {
 }
 
 /**
+ * Walk a value recursively and return true if any string property is a
+ * `vault:<key>` reference. Used by the preflight check below so we can
+ * fail fast when the config wants vault-resolved secrets but the
+ * vault hasn't been initialised yet.
+ */
+function hasVaultRefs(value: unknown): boolean {
+  if (typeof value === "string") return isVaultReference(value);
+  if (Array.isArray(value)) return value.some(hasVaultRefs);
+  if (value && typeof value === "object") {
+    return Object.values(value).some(hasVaultRefs);
+  }
+  return false;
+}
+
+/**
+ * Detect whether `docker compose` (the v2 plugin, not the deprecated
+ * `docker-compose` v1 binary) is installed. Returns a friendly error
+ * string explaining how to upgrade if it isn't, otherwise null.
+ */
+function detectComposeV2(): string | null {
+  try {
+    const out = execFileSync("docker", ["compose", "version"], {
+      stdio: ["ignore", "pipe", "pipe"],
+      encoding: "utf8",
+    });
+    // v2 output looks like: "Docker Compose version v2.27.0".
+    // v1 (`docker-compose`) wouldn't be invoked via this subcommand —
+    // `docker compose` exits non-zero if only v1 is on PATH — so any
+    // successful return here implies v2.
+    if (!/Docker Compose version v?\d/.test(out)) {
+      return `\`docker compose version\` returned unexpected output:\n${out.trim()}`;
+    }
+    return null;
+  } catch {
+    return (
+      "`docker compose` (v2) not found. switchroom requires the Docker " +
+      "Compose v2 plugin (the `docker compose` subcommand), not the " +
+      "deprecated standalone `docker-compose` v1 binary.\n" +
+      "Upgrade: https://docs.docker.com/compose/install/linux/"
+    );
+  }
+}
+
+/**
+ * Run the preflight gate. Fail fast (throws) when the config requires
+ * vault-resolved secrets but ~/.switchroom/vault.enc is missing, or
+ * when `docker compose` v2 is unavailable. Both conditions would have
+ * surfaced as cryptic mid-apply / mid-up failures otherwise.
+ */
+export function runApplyPreflight(config: SwitchroomConfig): void {
+  const vaultPath = resolvePath(
+    config.vault?.path ?? "~/.switchroom/vault.enc",
+  );
+  if (hasVaultRefs(config) && !existsSync(vaultPath)) {
+    throw new Error(
+      `Config references vault keys (vault:<name>) but ${vaultPath} is missing. ` +
+      `Run \`switchroom setup\` first to initialise the vault.`,
+    );
+  }
+  const composeErr = detectComposeV2();
+  if (composeErr) {
+    throw new Error(composeErr);
+  }
+}
+
+/**
  * Pure orchestrator. Exported for unit tests and the deprecation aliases
  * (`switchroom up`, `switchroom init`) which forward straight to here.
  *
@@ -87,6 +156,11 @@ export async function runApply(
   switchroomConfigPath?: string,
 ): Promise<ApplyResult> {
   const writeOut = deps.writeOut ?? ((s) => process.stdout.write(s));
+
+  // Fail-fast on missing prerequisites before we touch anything.
+  // Both checks throw with operator-actionable messages; the action
+  // wrapper catches and prints them red.
+  runApplyPreflight(config);
 
   const agentsDir = resolveAgentsDir(config);
   const agentNames = Object.keys(config.agents);

--- a/src/cli/apply.ts
+++ b/src/cli/apply.ts
@@ -27,8 +27,8 @@ import {
   findConfigFile,
   ConfigError,
 } from "../config/loader.js";
-import { scaffoldAgent } from "../agents/scaffold.js";
-import { generateCompose } from "../agents/compose.js";
+import { scaffoldAgent, alignAgentUid } from "../agents/scaffold.js";
+import { generateCompose, allocateAgentUid } from "../agents/compose.js";
 import type { SwitchroomConfig } from "../config/schema.js";
 import { captureEvent, captureException } from "../analytics/posthog.js";
 
@@ -51,6 +51,12 @@ export interface ApplyOptions {
   outPath?: string;
   /** Optional example name to copy before applying (e.g. "minimal"). */
   example?: string;
+  /**
+   * When true, skip any prompts (e.g. the sudo-chown explainer in
+   * alignAgentUid) and assume yes. Required for CI / `apply` invoked
+   * non-interactively. Default: prompts when stdin is a TTY.
+   */
+  nonInteractive?: boolean;
 }
 
 export interface ApplyDeps {
@@ -109,6 +115,22 @@ export async function runApply(
         chalk.green(`  + ${name}`) +
           chalk.gray(` (${agentConfig.extends ?? "default"}) — ${detail}\n`),
       );
+      // Align per-agent dir ownership with the container UID assigned
+      // by compose.ts. Without this the bind-mount lands read-only
+      // for the in-container UID and the agent fails on first write.
+      try {
+        const uid = allocateAgentUid(name);
+        alignAgentUid(name, join(agentsDir, name), uid, {
+          confirm: !options.nonInteractive,
+          writeOut,
+        });
+      } catch (alignErr) {
+        writeOut(
+          chalk.yellow(
+            `    ! could not chown ${name} state dir: ${(alignErr as Error).message}\n`,
+          ),
+        );
+      }
       scaffolded++;
     } catch (err) {
       writeOut(chalk.red(`  x ${name}: ${(err as Error).message}\n`));
@@ -211,11 +233,16 @@ export function registerApplyCommand(program: Command): void {
       "--example <name>",
       "Copy an example config into cwd before applying (e.g., 'switchroom' or 'minimal').",
     )
+    .option(
+      "--non-interactive",
+      "Skip prompts (e.g. sudo-chown explainer for UID alignment). Use in CI / scripts.",
+    )
     .action(
       async (opts: {
         buildLocal?: boolean | string;
         out?: string;
         example?: string;
+        nonInteractive?: boolean;
       }) => {
         try {
           if (opts.example) {
@@ -240,6 +267,7 @@ export function registerApplyCommand(program: Command): void {
               buildContext: buildLocal ? buildContext : undefined,
               outPath: opts.out,
               example: opts.example,
+              nonInteractive: opts.nonInteractive ?? false,
             },
             {},
             switchroomConfigPath,

--- a/src/cli/apply.ts
+++ b/src/cli/apply.ts
@@ -121,6 +121,9 @@ export async function runApply(
     config,
     buildMode: options.buildLocal ? "local" : "pull",
     buildContext: options.buildContext,
+    // Bake the operator's HOME absolute path into volume sources at
+    // apply time. Avoids `${HOME}` resolving to /root under sudo.
+    homeDir: homedir(),
   });
   await mkdir(dirname(composePath), { recursive: true });
   await writeFile(composePath, composeContent, {

--- a/src/scheduler/dispatch.ts
+++ b/src/scheduler/dispatch.ts
@@ -4,7 +4,11 @@
  * Phase 1a slice. Reads the cascade-resolved config, walks every agent's
  * `schedule[]`, registers each entry with node-cron against the same
  * cron expressions cronToOnCalendar parses today, and on fire dispatches
- * via `docker exec agent-<name> claude -p "<prompt>"`.
+ * via `docker exec switchroom-<name> claude -p "<prompt>"`.
+ *
+ * The container name MUST match `container_name:` set by compose.ts —
+ * `switchroom-<agent>` — not the compose service name `agent-<agent>`.
+ * `docker exec` resolves against container names, not service names.
  *
  * Identity boundary: the scheduler container is privileged (it mounts
  * /var/run/docker.sock to invoke `docker exec`) but does NOT see secret
@@ -72,7 +76,7 @@ export type ExecRunner = (
 ) => Promise<{ exitCode: number; output: string }>;
 
 /**
- * Default exec runner — shells `docker exec -i agent-<name> claude -p`,
+ * Default exec runner — shells `docker exec -i switchroom-<name> claude -p`,
  * piping the prompt on stdin (avoids embedding the prompt in argv where
  * it'd show up in `ps` and shell history). Tests inject a mock.
  */
@@ -98,7 +102,10 @@ export async function dispatchEntry(
   runner: ExecRunner = defaultExecRunner,
 ): Promise<DispatchResult> {
   const startedAt = Date.now();
-  const containerName = `agent-${entry.agent}`;
+  // Must match compose.ts `container_name: switchroom-<agent>`. The
+  // compose service name (`agent-<name>`) is not what `docker exec`
+  // resolves against — it resolves against container names.
+  const containerName = `switchroom-${entry.agent}`;
   // -i: keep stdin open so we can pipe the prompt in.
   // claude -p: print mode, single prompt, exits when done.
   const args = ["exec", "-i", containerName, "claude", "-p"];

--- a/tests/.baseline-failures.txt
+++ b/tests/.baseline-failures.txt
@@ -1,0 +1,10 @@
+# Baseline failing test files on upstream/main as of 2026-05-09
+# Captured via: bun run build && bun run test:vitest 2>&1 | grep '^ FAIL '
+# Subsequent commits in the v0.7 PR series (PR-A1..) must not introduce NEW
+# failing test files. The set produced by current HEAD must remain a subset
+# of this list.
+tests/boot-self-test.test.ts
+tests/docker/broker-ipc-race.test.ts
+tests/docker/per-agent-isolation.test.ts
+tests/docker/phase2a-broker-ipc.test.ts
+tests/docker/phase2b-kernel-ipc.test.ts

--- a/tests/docker/compose-generator.test.ts
+++ b/tests/docker/compose-generator.test.ts
@@ -170,10 +170,13 @@ describe("generateCompose", () => {
     expect(matches.length).toBe(2);
   });
 
-  it("emits scheduler service with docker.sock mount", () => {
+  it("emits scheduler service with docker.sock mount (read-write)", () => {
     const out = generateCompose({ config: makeConfig({}) });
     expect(out).toContain("switchroom-cron:");
-    expect(out).toContain("/var/run/docker.sock:/var/run/docker.sock:ro");
+    // RW, NOT :ro — `docker exec` is a write op against the daemon
+    // API. A :ro bind silently breaks dispatch.
+    expect(out).toContain("/var/run/docker.sock:/var/run/docker.sock\n");
+    expect(out).not.toContain("/var/run/docker.sock:/var/run/docker.sock:ro");
   });
 
   it("emits per-agent named volumes for broker AND kernel", () => {

--- a/tests/docker/compose-generator.test.ts
+++ b/tests/docker/compose-generator.test.ts
@@ -207,12 +207,37 @@ describe("generateCompose", () => {
     expect(tildeLines).toEqual([]);
   });
 
-  it("uses ${HOME} for host-path bind mounts", () => {
+  it("uses ${HOME} for host-path bind mounts when no homeDir is given", () => {
     const out = generateCompose({ config: makeConfig({ a: {} }) });
     expect(out).toContain("${HOME}/.switchroom/vault:/state/vault");
     expect(out).toContain("${HOME}/.switchroom/approvals:/state/approvals");
     expect(out).toContain("${HOME}/.switchroom:/state/config:ro");
     expect(out).toContain("${HOME}/.switchroom/agents/a:/state/agent");
+  });
+
+  it("bakes the absolute homeDir into bind sources when given (sudo-safe)", () => {
+    // Why: under `sudo docker compose`, ${HOME} resolves to /root, not
+    // the operator's home. apply.ts passes os.homedir() so the YAML
+    // captures the right path independent of who runs compose.
+    const out = generateCompose({
+      config: makeConfig({ a: {} }),
+      homeDir: "/home/op",
+    });
+    expect(out).toContain("/home/op/.switchroom/vault:/state/vault");
+    expect(out).toContain("/home/op/.switchroom/approvals:/state/approvals");
+    expect(out).toContain("/home/op/.switchroom:/state/config:ro");
+    expect(out).toContain("/home/op/.switchroom/agents/a:/state/agent");
+    expect(out).toContain("/home/op/.switchroom/logs/a:/var/log/switchroom");
+    expect(out).toContain("/home/op/.claude/projects/a:/state/.claude");
+    expect(out).not.toContain("${HOME}");
+  });
+
+  it("emits top-level project name 'switchroom' for collision protection", () => {
+    // Belt-and-braces vs Coolify-managed (or other) compose stacks on
+    // the same host. Pinning name: at file scope means
+    // `docker compose -f <path>` always targets the same project.
+    const out = generateCompose({ config: makeConfig({ a: {} }) });
+    expect(out).toMatch(/^name: switchroom$/m);
   });
 
   // ── security hardening defaults ────────────────────────────────────

--- a/tests/docker/scheduler.test.ts
+++ b/tests/docker/scheduler.test.ts
@@ -81,7 +81,7 @@ describe("dispatchEntry", () => {
       return { exitCode: 0, output: "ok" };
     };
     await dispatchEntry(entry, runner);
-    expect(captured!.args).toEqual(["exec", "-i", "agent-klanker", "claude", "-p"]);
+    expect(captured!.args).toEqual(["exec", "-i", "switchroom-klanker", "claude", "-p"]);
     expect(captured!.stdin).toBe("morning briefing");
   });
 


### PR DESCRIPTION
## Summary

PR-A1 of the v0.7 docker-cutover series. Scope is **just the four hygiene fixes** identified in the pre-cutover review of compose / scaffold / apply — **no legacy-systemd removal, no Dockerfile changes, no docs** in this PR. Smaller and safer makes it reviewable; subsequent PRs handle the bigger surface.

### Commits

0. `chore(tests): pin baseline failing test files` — capture the 5 test files failing on `upstream/main` today (mostly docker IPC tests that are fragile in CI sandboxes) so future PRs in this series can prove "no new failures introduced" without being blocked by pre-existing flakes.
1. `fix(compose): use container_name for docker exec, mount sock RW` — scheduler dispatched against compose service name `agent-<n>` but the container is named `switchroom-<n>`; every scheduled run would have failed with 'No such container'. Also drop `:ro` from `/var/run/docker.sock` (it's a write op against the daemon API).
2. `fix(compose): emit top-level name + bake absolute HOME at apply time` — `${HOME}` resolves to `/root` under `sudo docker compose`, breaking every host-path bind. `apply.ts` now passes `os.homedir()` and the generator bakes the absolute path. Top-level `name: switchroom` added for collision protection vs Coolify-managed stacks.
3. `fix(scaffold): re-add UID alignment for bind mounts` — `apply` now chowns `~/.switchroom/agents/<n>` to the container's deterministic UID (10001-10999) so the bind-mount lands writable. Tries unprivileged chown first, falls back to `sudo chown -R` (operator sees the password prompt). New `--non-interactive` flag silences the explainer for CI.
4. `feat(apply): vault broker preflight; compose-v2 detection` — fail fast if the config has `vault:<key>` refs but `~/.switchroom/vault.enc` is missing, or if `docker compose` v2 isn't on PATH. Both errors carry an operator-actionable remediation message.

### Out of scope (deferred)

- Legacy systemd removal → **PR-A3**
- `Dockerfile.base` / `Dockerfile.scheduler` changes → **PR-A2**
- vault-auto-unlock rewire → **PR-A2 or A3**
- Docs / migration sweep → **PR-A4**

### Validation

- `bun run build` — clean
- `npm run lint` (tsc + plugin-references) — clean
- `bun run test:vitest` — failures are a strict subset of `tests/.baseline-failures.txt` (the 5 pre-existing docker / boot-self-test failures from `upstream/main`); no new failures introduced.

### Reviewer note

The Phase-2a broker IPC identity primitive (`socketPathToAgent` in `src/vault/broker/peercred.ts`) is **not touched**. The `systemdUnit` field in the broker is informational/audit only — removing systemd setup paths in later PRs won't affect broker boot or identity.

## Test plan

- [ ] `bun run build` clean
- [ ] `npm run lint` clean
- [ ] `bun run test:vitest` — verify failures are subset of `tests/.baseline-failures.txt`
- [ ] Smoke `switchroom apply --non-interactive` against a config with no vault refs
- [ ] Smoke `switchroom apply` against a config WITH vault refs but no vault.enc → expect fail-fast