### PR TITLE
feat(progress-card): plain-text parent rows, drop tool-name prefix and <code> styling

### DIFF
--- a/telegram-plugin/tests/two-zone-snapshot-extras.test.ts
+++ b/telegram-plugin/tests/two-zone-snapshot-extras.test.ts
@@ -100,13 +100,16 @@ describe('PR-C2: two-zone card snapshot extras', () => {
     // 12 items, cap 8 → 4 hidden.
     expect(out).toContain('(+4 earlier)')
     // The visible bullets are the LAST 8 (slice(-8) → f4..f11).
-    expect(out).toContain('<code>f11.ts</code>')
-    expect(out).toContain('<code>f4.ts</code>')
-    // f3 (the latest hidden) must not appear as a bullet code block.
-    expect(out).not.toContain('<code>f3.ts</code>')
+    // f11 is the in-flight bullet (stage=run, last index) → ◉.
+    expect(out).toContain('◉ f11.ts')
+    expect(out).toContain('● f4.ts')
+    // f3 (the latest hidden) must not appear as a bullet.
+    expect(out).not.toContain('f3.ts')
+    // No <code> wrapping around row labels anymore.
+    expect(out).not.toContain('<code>f11.ts</code>')
   })
 
-  it('parent zone: in-flight last bullet uses ◉ <b>tool</b>; earlier use ● tool', () => {
+  it('parent zone: in-flight last bullet uses ◉ <plain>; earlier use ● <plain>', () => {
     const items = [
       { tool: 'Read', label: 'a.ts' },
       { tool: 'Read', label: 'b.ts' },
@@ -117,13 +120,16 @@ describe('PR-C2: two-zone card snapshot extras', () => {
       fleet: new Map(),
       now: NOW,
     })
-    // last item active
-    expect(out).toContain('◉ <b>Bash</b> <code>ls</code>')
-    // earlier items plain
-    expect(out).toContain('● Read <code>a.ts</code>')
-    expect(out).toContain('● Read <code>b.ts</code>')
-    // last item is NOT plain
-    expect(out).not.toContain('● Bash <code>ls</code>')
+    // last item active — plain text, no <b>, no <code>, no tool prefix
+    expect(out).toContain('◉ ls')
+    expect(out).not.toContain('◉ <b>')
+    // earlier items — plain text only, no tool prefix
+    expect(out).toContain('● a.ts')
+    expect(out).toContain('● b.ts')
+    expect(out).not.toContain('Read <code>')
+    // No <code> wrapping anywhere on parent rows.
+    expect(out).not.toContain('<code>ls</code>')
+    expect(out).not.toContain('<code>a.ts</code>')
   })
 
   it('parent zone: when stage=done all bullets render as ● (no active marker)', () => {
@@ -136,8 +142,46 @@ describe('PR-C2: two-zone card snapshot extras', () => {
       fleet: new Map(),
       now: NOW,
     })
-    expect(out).toContain('● Read <code>a.ts</code>')
-    expect(out).toContain('● Bash <code>ls</code>')
+    expect(out).toContain('● a.ts')
+    expect(out).toContain('● ls')
     expect(out).not.toContain('◉')
+  })
+
+  it('parent zone: row with no label falls back to humanised tool name', () => {
+    const items = [
+      { tool: 'TodoWrite', label: '' },
+      { tool: 'Edit', label: '' },
+    ]
+    const out = renderTwoZoneCard({
+      state: st({ stage: 'run', turnStartedAt: NOW - 5000, items }),
+      fleet: new Map(),
+      now: NOW,
+    })
+    expect(out).toContain('● updating tasks')
+    expect(out).toContain('◉ editing file')
+  })
+
+  it('parent zone: row with no label on mcp tool uses mcpDisplayName', () => {
+    const items = [
+      { tool: 'mcp__switchroom-telegram__reply', label: '' },
+    ]
+    const out = renderTwoZoneCard({
+      state: st({ stage: 'run', turnStartedAt: NOW - 5000, items }),
+      fleet: new Map(),
+      now: NOW,
+    })
+    expect(out).toContain('◉ Telegram: reply')
+  })
+
+  it('parent zone: HTML in label is escaped (no raw <code> styling)', () => {
+    const items = [
+      { tool: 'Bash', label: 'echo <hi>' },
+    ]
+    const out = renderTwoZoneCard({
+      state: st({ stage: 'done', turnStartedAt: NOW - 5000, items }),
+      fleet: new Map(),
+      now: NOW,
+    })
+    expect(out).toContain('● echo &lt;hi&gt;')
   })
 })

--- a/telegram-plugin/tool-labels.ts
+++ b/telegram-plugin/tool-labels.ts
@@ -315,6 +315,53 @@ export function toolLabel(
  * labels, and otherwise capitalise the first letter and keep the rest
  * verbatim so unknown servers still render cleanly.
  */
+/**
+ * Public alias for `mcpBaseLabel` — the progress card uses this when an
+ * `mcp__*` tool fires with no human label so the row can still render
+ * something readable (e.g. "Telegram: reply") instead of the raw tool
+ * name.
+ */
+export function mcpDisplayName(tool: string): string {
+  return mcpBaseLabel(tool)
+}
+
+/**
+ * Human-readable fallback for a bare tool name when no label is
+ * available (TodoWrite, Task housekeeping, etc.). Returns the lowercased
+ * raw tool name when the tool isn't in the map.
+ */
+const TOOL_FALLBACK_LABELS: Record<string, string> = {
+  Bash: 'running command',
+  BashOutput: 'running command',
+  Edit: 'editing file',
+  Write: 'editing file',
+  NotebookEdit: 'editing file',
+  Read: 'reading file',
+  Grep: 'searching',
+  Glob: 'searching',
+  WebFetch: 'fetching',
+  WebSearch: 'searching the web',
+  Task: 'delegating',
+  Agent: 'delegating',
+  TodoWrite: 'updating tasks',
+  TaskCreate: 'updating tasks',
+  TaskUpdate: 'updating tasks',
+  TaskList: 'updating tasks',
+  TaskGet: 'updating tasks',
+  TaskStop: 'updating tasks',
+  TaskOutput: 'updating tasks',
+  Skill: 'running skill',
+  SlashCommand: 'running command',
+  KillShell: 'running command',
+  ToolSearch: 'searching',
+}
+
+export function toolFallbackLabel(tool: string): string {
+  if (!tool) return ''
+  if (TOOL_FALLBACK_LABELS[tool]) return TOOL_FALLBACK_LABELS[tool]
+  return tool.toLowerCase()
+}
+
 function mcpBaseLabel(tool: string): string {
   if (!tool.startsWith('mcp__')) return ''
   const parts = tool.slice('mcp__'.length).split('__')

--- a/telegram-plugin/two-zone-card.ts
+++ b/telegram-plugin/two-zone-card.ts
@@ -16,6 +16,7 @@ import type { FleetMember, FleetStatus } from './fleet-state.js'
 import { cap } from './fleet-state.js'
 import type { ProgressCardState, RenderOptions, TaskNum } from './progress-card.js'
 import { escapeHtml, formatDuration } from './card-format.js'
+import { mcpDisplayName, toolFallbackLabel } from './tool-labels.js'
 
 const PARENT_BULLET_CAP = 8
 const FLEET_ROW_CAP = 5
@@ -159,12 +160,20 @@ function renderParentZone(state: ProgressCardState): string {
   const lastIdx = visible.length - 1
   for (let i = 0; i < visible.length; i++) {
     const it = visible[i]
-    const tool = escapeHtml(it.tool || '')
-    const label = it.label ? ` <code>${escapeHtml(truncate(it.label, 80))}</code>` : ''
-    if (inFlight && i === lastIdx) {
-      lines.push(`◉ <b>${tool}</b>${label}`)
+    let text: string
+    if (it.label) {
+      text = escapeHtml(truncate(it.label, 80))
     } else {
-      lines.push(`● ${tool}${label}`)
+      const tool = it.tool || ''
+      const fallback = tool.startsWith('mcp__')
+        ? mcpDisplayName(tool) || toolFallbackLabel(tool)
+        : toolFallbackLabel(tool)
+      text = escapeHtml(fallback)
+    }
+    if (inFlight && i === lastIdx) {
+      lines.push(`◉ ${text}`)
+    } else {
+      lines.push(`● ${text}`)
     }
   }
   return lines.join('\n')


### PR DESCRIPTION
## Summary

Parent zone of the two-zone progress card now renders rows as bare human text. The raw tool name and the monospace `<code>` wrapping around the label are gone — the label IS the row.

When a tool emits no label (TodoWrite, Task housekeeping, etc.) we fall back to a humanised tool name from a small map in `tool-labels.ts`; `mcp__*` tools fall back to the existing "Server: action" form via a newly-exported `mcpDisplayName`.

The `◉` glyph alone signals the in-flight row — dropped the `<b>` on the prefix.

## Before / after

```
Before: ● Bash <code>Patch UML to guard hass.resources</code>
After:  ● Patch UML to guard hass.resources

Before: ◉ <b>Bash</b> <code>Reloading HA core</code>
After:  ◉ Reloading HA core

(no label, common tool)
After:  ● updating tasks

(no label, mcp tool)
After:  ● Telegram: reply
```

Label is HTML-escaped (it's now bare text in an HTML message). The truncate-to-80 cap stays.

## Test plan

- [x] `telegram-plugin/tests/two-zone-snapshot-extras.test.ts` updated and extended (label-present row, in-flight label row, no-label common-tool fallback, no-label mcp tool, HTML-escape).
- [x] `npx vitest run telegram-plugin/tests/two-zone-*` — all 40 tests green.
- [x] `npm run lint:tsc` clean.
- [x] Pre-existing failures on `main` in `tests/cli.issues.test.ts`, `tests/boot-self-test.test.ts`, `tests/run-hook.test.ts` are unrelated to this change.