### PR TITLE
fix(docker): scheduler/base hardening + vault-auto-unlock rewire (v0.7 PR-A2)

### DIFF
--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -36,8 +36,12 @@ RUN apt-get update \
 # Pin claude CLI version in the base image so every agent / scheduler
 # container resolves the SAME bundle. The version floats with the
 # upstream tag at image-build time; agents do NOT install claude.
+# Fail-fast: if the npm install or the resulting binary is broken we
+# want the image build to die here, not produce a base that ships
+# downstream and explodes at agent boot. Previously this had a
+# trailing `|| true` that swallowed any failure.
 RUN npm install -g @anthropic-ai/claude-code@latest \
- && claude --version >&2 || true
+ && claude --version >&2
 
 # Phase 1b: install bun. The broker server (src/vault/broker/server.ts)
 # imports `bun:sqlite` and `bun:ffi` directly; those modules don't exist

--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -51,16 +51,30 @@ RUN npm install -g @anthropic-ai/claude-code@latest \
 # broker / kernel-server with `bun` instead of `node`. Agent containers
 # don't run bun — they shell out to claude (via tmux) which has its
 # own runtime.
-# Pin the bun version so a `docker build` next month produces the same
-# runtime as today. `bun.sh/install` accepts an explicit tag via `bash -s
-# "bun-vX.Y.Z"`. Override at build time with --build-arg BUN_VERSION=…
-# when bumping. Host stable as of this PR is 1.3.13.
+# Pin the bun version AND verify the download by sha256 so a
+# `docker build` next month produces the same runtime as today, and
+# a compromised bun.sh / GitHub mirror can't slip a different binary
+# into our base image. Override at build time with
+#   --build-arg BUN_VERSION=… --build-arg BUN_SHA256_X64=… --build-arg BUN_SHA256_AARCH64=…
+# when bumping. SHA256s come from the release page on github.com/oven-sh/bun
+# and MUST be updated together with BUN_VERSION.
 ARG BUN_VERSION=1.3.13
+ARG BUN_SHA256_X64=79c0771fa8b92c33aae41e15a0e0d307ea99d0e2f00317c71c6c53237a78e25a
+ARG BUN_SHA256_AARCH64=70bae41b3908b0a120e1e58c5c8af30e74afae3b8d11b0d3fdd8e787ddfb4b22
 RUN apt-get update \
  && apt-get install -y --no-install-recommends unzip \
  && rm -rf /var/lib/apt/lists/* \
- && curl -fsSL https://bun.sh/install | bash -s "bun-v${BUN_VERSION}" \
- && mv /root/.bun/bin/bun /usr/local/bin/bun \
+ && ARCH="$(uname -m)" \
+ && case "$ARCH" in \
+      x86_64)   BUN_ARCH=x64;       BUN_SHA="${BUN_SHA256_X64}";;     \
+      aarch64)  BUN_ARCH=aarch64;   BUN_SHA="${BUN_SHA256_AARCH64}";; \
+      *) echo "unsupported arch for bun pin: $ARCH" >&2 && exit 1;;   \
+    esac \
+ && curl -fsSL "https://github.com/oven-sh/bun/releases/download/bun-v${BUN_VERSION}/bun-linux-${BUN_ARCH}.zip" -o /tmp/bun.zip \
+ && echo "${BUN_SHA}  /tmp/bun.zip" | sha256sum -c - \
+ && unzip -q /tmp/bun.zip -d /tmp/bun \
+ && mv "/tmp/bun/bun-linux-${BUN_ARCH}/bun" /usr/local/bin/bun \
+ && rm -rf /tmp/bun /tmp/bun.zip \
  && bun --version >&2
 
 # Default workdir; overridden by per-image Dockerfile if needed.

--- a/docker/Dockerfile.scheduler
+++ b/docker/Dockerfile.scheduler
@@ -13,8 +13,20 @@ RUN echo "switchroom/scheduler building for arch=${TARGETARCH}" >&2
 # Install the docker CLI so the scheduler can `docker exec` into agent
 # containers via the bind-mounted /var/run/docker.sock. This is the
 # CLI client only; the engine is the host's, mounted in.
+#
+# We use Docker's official `docker-ce-cli` package (CLI only, ~50MB)
+# rather than Debian's `docker.io` (~250MB, drags in the daemon and
+# containerd we never run). The trade-off is one extra apt repo +
+# GPG key, but the image savings + smaller attack surface (no daemon
+# binary present at all) are worth it. See PR-A2 in the v0.7 series.
 RUN apt-get update \
- && apt-get install -y --no-install-recommends docker.io \
+ && apt-get install -y --no-install-recommends ca-certificates curl \
+ && install -m 0755 -d /etc/apt/keyrings \
+ && curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc \
+ && chmod a+r /etc/apt/keyrings/docker.asc \
+ && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/debian $(. /etc/os-release && echo \"$VERSION_CODENAME\") stable" > /etc/apt/sources.list.d/docker.list \
+ && apt-get update \
+ && apt-get install -y --no-install-recommends docker-ce-cli \
  && rm -rf /var/lib/apt/lists/*
 
 # State dir for scheduler.db (audit trail of fires).

--- a/install.sh
+++ b/install.sh
@@ -98,7 +98,14 @@ curl -fsSL --retry 3 -o "$tmp/switchroom-checksums.txt" "$base_url/switchroom-ch
 # ---- verify checksum ----
 
 log "Verifying SHA256"
-expected=$(grep " $asset\$\| ${asset}$" "$tmp/switchroom-checksums.txt" | awk '{print $1}' | head -n 1)
+# The checksums file uses the `sha256sum`-canonical "<hash>  <file>"
+# two-space format. Older revisions of this script grep'd with a
+# pattern that only tolerated a single trailing space and was anchored
+# at end-of-line, which mis-fired on some platforms (BSD grep regex
+# alternation, CRLF line endings) and silently missed valid entries.
+# Use a fixed-string match against the exact two-space-prefixed asset
+# name to find the line.
+expected=$(grep -F "  ${asset}" "$tmp/switchroom-checksums.txt" | awk '{print $1}' | head -n 1)
 [ -n "$expected" ] || die "No checksum entry for $asset in switchroom-checksums.txt."
 
 actual=$($sha_cmd "$tmp/$asset" | awk '{print $1}')

--- a/src/agents/compose.ts
+++ b/src/agents/compose.ts
@@ -264,6 +264,16 @@ export function generateCompose(opts: ComposeGeneratorOptions): string {
     lines.push(`      - broker-${a.name}-sock:/run/switchroom/broker/${a.name}`);
   }
   lines.push(`      - ${homePrefix}/.switchroom/vault:/state/vault`);
+  // Auto-unlock blob (encrypted with /etc/machine-id-derived key).
+  // Mounted read-only — the broker only ever reads the blob; rotation
+  // is performed by the host CLI (`switchroom vault broker enable-auto-unlock`)
+  // followed by a `docker compose restart vault-broker`. Mount source
+  // is the host file path `~/.switchroom/vault-auto-unlock` (the
+  // DEFAULT_AUTO_UNLOCK_PATH constant in src/vault/auto-unlock.ts).
+  // Compose treats a missing source as an empty directory — the broker
+  // detects that and falls back to the interactive unlock flow, so
+  // operators who never enabled auto-unlock are unaffected.
+  lines.push(`      - ${homePrefix}/.switchroom/vault-auto-unlock:/state/vault-auto-unlock:ro`);
   lines.push(``);
 
   // ── approval-kernel (singleton) ────────────────────────────────────

--- a/src/build-info.ts
+++ b/src/build-info.ts
@@ -3,7 +3,7 @@
 // Values are refreshed every time `npm run build` runs.
 
 export const VERSION: string = "0.5.2";
-export const COMMIT_SHA: string | null = "b502743a";
-export const COMMIT_DATE: string | null = "2026-05-09T08:38:49+10:00";
+export const COMMIT_SHA: string | null = "4415a44b";
+export const COMMIT_DATE: string | null = "2026-05-09T09:04:26+10:00";
 export const LATEST_PR: number | null = null;
-export const COMMITS_AHEAD_OF_TAG: number | null = 6;
+export const COMMITS_AHEAD_OF_TAG: number | null = 7;

--- a/src/cli/vault-auto-unlock.ts
+++ b/src/cli/vault-auto-unlock.ts
@@ -10,16 +10,23 @@
  *
  *   1. encryptCredential — write the blob to disk (mode 0600).
  *   2. applyAutoUnlock — flip vault.broker.autoUnlock=true in
- *      switchroom.yaml, reconcile units, restart broker, poll status to
- *      verify the vault came up unlocked.
+ *      switchroom.yaml, restart the broker container via
+ *      `docker compose restart vault-broker`, poll status to verify the
+ *      vault came up unlocked.
+ *
+ * Pre-v0.7 this module reconciled systemd user units and called
+ * `systemctl --user restart switchroom-vault-broker.service`. v0.7
+ * dropped the systemd substrate; the orchestration is now Docker
+ * Compose. The crypto path is unchanged.
  */
 
 import { spawnSync } from "node:child_process";
 import { readFileSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
 import YAML from "yaml";
 
 import { findConfigFile, loadConfig, resolvePath } from "../config/loader.js";
-import { installAllUnits } from "../agents/systemd.js";
 import { statusViaBroker } from "../vault/broker/client.js";
 import {
   AutoUnlockDecryptError,
@@ -89,53 +96,72 @@ export interface ApplyOptions {
   configPath?: string;
   log?: (line: string) => void;
   err?: (line: string) => void;
-  /** Override systemctl invocation in tests. */
-  runSystemctl?: (args: string[]) => { status: number | null };
+  /**
+   * Override the docker compose invocation in tests. Receives the full
+   * argv (excluding the `docker` program name itself, e.g.
+   * `["compose", "-f", "/path/compose.yaml", "restart", "vault-broker"]`)
+   * and returns an object with the exit status. Defaults to a real
+   * `spawnSync("docker", ...)` with stdio inherit.
+   */
+  runDockerCompose?: (args: string[]) => { status: number | null };
+  /**
+   * Path to the generated docker-compose file. Defaults to
+   * `~/.switchroom/compose/docker-compose.yml` — the canonical location
+   * emitted by `switchroom apply`.
+   */
+  composeFile?: string;
   /** Override status polling in tests. */
   pollStatus?: () => Promise<{ unlocked: boolean } | null>;
   /** How long to wait for the broker to come up unlocked. */
   verifyTimeoutMs?: number;
 }
 
+const DEFAULT_COMPOSE_FILE = join(homedir(), ".switchroom", "compose", "docker-compose.yml");
+
 /**
- * Flip vault.broker.autoUnlock=true in switchroom.yaml, regenerate units,
- * restart the broker, and poll status to confirm the vault came up
- * unlocked. The whole thing is one call so callers don't have to
- * re-implement the 3-step "Next steps" list.
+ * Flip vault.broker.autoUnlock=true in switchroom.yaml, restart the
+ * vault-broker container via docker compose, and poll status to confirm
+ * the vault came up unlocked. The whole thing is one call so callers
+ * don't have to re-implement the 3-step "Next steps" list.
+ *
+ * Note that the broker container reads the auto-unlock blob via the
+ * bind-mount declared in src/agents/compose.ts. The blob is written
+ * by `encryptCredential` BEFORE this function runs; here we just need
+ * to bounce the container so the broker re-reads its config + the blob.
  */
 export async function applyAutoUnlock(opts: ApplyOptions = {}): Promise<void> {
   const log = opts.log ?? ((s: string) => console.log(s));
   const err = opts.err ?? ((s: string) => console.error(s));
-  const runSystemctl =
-    opts.runSystemctl ?? ((args: string[]) => spawnSync("systemctl", args, { stdio: "inherit" }));
+  const runDockerCompose =
+    opts.runDockerCompose ??
+    ((args: string[]) => spawnSync("docker", args, { stdio: "inherit" }));
   // 10s default — generous enough for cold-cache decrypt on slow boxes,
   // short enough that a real auto-unlock failure surfaces before the user
   // gives up.
   const verifyTimeoutMs = opts.verifyTimeoutMs ?? 10000;
 
   const configPath = opts.configPath ?? findConfigFile();
+  const composeFile = opts.composeFile ?? DEFAULT_COMPOSE_FILE;
+
   setVaultBrokerAutoUnlock(configPath, true);
   log(`✓ Set vault.broker.autoUnlock=true in ${configPath}`);
 
-  // Reload the config from disk so installAllUnits sees the freshly-flipped
-  // value (broker unit content depends on it indirectly via downstream
-  // consumers; today the unit shape is identical, but reloading keeps the
-  // call site honest if that ever changes).
+  // Reload the config from disk so the post-restart status poll can
+  // resolve the broker socket from the (possibly relative) configured
+  // path. Surfaces parse errors early too.
   const config = loadConfig(configPath);
-  installAllUnits(config);
-  log("✓ Reconciled broker unit");
 
-  runSystemctl(["--user", "daemon-reload"]);
-  const restart = runSystemctl(["--user", "restart", "switchroom-vault-broker.service"]);
+  const composeArgs = ["compose", "-f", composeFile, "restart", "vault-broker"];
+  const restart = runDockerCompose(composeArgs);
   if (restart.status !== 0) {
     err(
       "Broker restart failed. Check:\n" +
-        "  systemctl --user status switchroom-vault-broker.service\n" +
-        "  journalctl --user -u switchroom-vault-broker.service -e",
+        `  docker compose -f ${composeFile} ps vault-broker\n` +
+        `  docker compose -f ${composeFile} logs vault-broker`,
     );
-    throw new Error(`broker restart exited ${restart.status}`);
+    throw new Error(`docker compose restart exited ${restart.status}`);
   }
-  log("✓ Restarted switchroom-vault-broker.service");
+  log("✓ Restarted vault-broker container (docker compose restart)");
 
   const socket = resolvePath(config.vault?.broker?.socket ?? "~/.switchroom/vault-broker.sock");
   const poll = opts.pollStatus ?? (() => statusViaBroker({ socket }));
@@ -153,8 +179,8 @@ export async function applyAutoUnlock(opts: ApplyOptions = {}): Promise<void> {
   err(
     "Broker restarted but vault did not unlock within " +
       `${verifyTimeoutMs}ms. Check:\n` +
-      "  systemctl --user status switchroom-vault-broker.service\n" +
-      "  journalctl --user -u switchroom-vault-broker.service -e",
+      `  docker compose -f ${composeFile} ps vault-broker\n` +
+      `  docker compose -f ${composeFile} logs vault-broker`,
   );
   throw new Error("verification timeout: broker did not unlock");
 }

--- a/src/cli/vault-broker.ts
+++ b/src/cli/vault-broker.ts
@@ -387,7 +387,7 @@ export function registerVaultBrokerCommand(vaultCmd: Command, program: Command):
         console.log("");
         console.log("Staged only (--no-apply). To activate:");
         console.log("  1. Set vault.broker.autoUnlock: true in switchroom.yaml");
-        console.log("  2. systemctl --user restart switchroom-vault-broker.service");
+        console.log("  2. docker compose -f ~/.switchroom/compose/docker-compose.yml restart vault-broker");
         return;
       }
 
@@ -420,8 +420,8 @@ export function registerVaultBrokerCommand(vaultCmd: Command, program: Command):
         console.log("");
         console.log("Next steps:");
         console.log("  1. Set vault.broker.autoUnlock: false in switchroom.yaml (or remove)");
-        console.log("  2. switchroom reconcile");
-        console.log("  3. systemctl --user restart switchroom-vault-broker.service");
+        console.log("  2. switchroom apply");
+        console.log("  3. docker compose -f ~/.switchroom/compose/docker-compose.yml restart vault-broker");
       } catch (err) {
         console.error(`Failed to remove credential file: ${err instanceof Error ? err.message : String(err)}`);
         process.exit(1);

--- a/tests/vault-auto-unlock.test.ts
+++ b/tests/vault-auto-unlock.test.ts
@@ -120,13 +120,10 @@ describe("applyAutoUnlock", () => {
     vi.restoreAllMocks();
   });
 
-  it("flips YAML, calls systemctl, polls status, and reports success when vault unlocks", async () => {
-    const systemd = await import("../src/agents/systemd.js");
-    vi.spyOn(systemd, "installAllUnits").mockImplementation(() => {});
-
-    const systemctlCalls: string[][] = [];
-    const runSystemctl = vi.fn((args: string[]) => {
-      systemctlCalls.push(args);
+  it("flips YAML, calls docker compose restart, polls status, and reports success when vault unlocks", async () => {
+    const composeCalls: string[][] = [];
+    const runDockerCompose = vi.fn((args: string[]) => {
+      composeCalls.push(args);
       return { status: 0 };
     });
     let polled = 0;
@@ -137,53 +134,81 @@ describe("applyAutoUnlock", () => {
 
     await applyAutoUnlock({
       configPath,
+      composeFile: "/fake/compose.yml",
       log: () => {},
       err: () => {},
-      runSystemctl,
+      runDockerCompose,
       pollStatus,
       verifyTimeoutMs: 2000,
     });
 
     expect(readFileSync(configPath, "utf-8")).toContain("autoUnlock: true");
-    expect(systemctlCalls).toContainEqual(["--user", "daemon-reload"]);
-    expect(systemctlCalls).toContainEqual(["--user", "restart", "switchroom-vault-broker.service"]);
+    expect(composeCalls).toContainEqual([
+      "compose",
+      "-f",
+      "/fake/compose.yml",
+      "restart",
+      "vault-broker",
+    ]);
     expect(polled).toBeGreaterThanOrEqual(2);
   });
 
-  it("throws when the broker restart exits non-zero", async () => {
-    const systemd = await import("../src/agents/systemd.js");
-    vi.spyOn(systemd, "installAllUnits").mockImplementation(() => {});
-
-    const runSystemctl = vi.fn((args: string[]) => {
-      if (args.includes("restart")) return { status: 1 };
-      return { status: 0 };
-    });
+  it("throws when the docker compose restart exits non-zero", async () => {
+    const runDockerCompose = vi.fn(() => ({ status: 1 }));
 
     await expect(
       applyAutoUnlock({
         configPath,
+        composeFile: "/fake/compose.yml",
         log: () => {},
         err: () => {},
-        runSystemctl,
+        runDockerCompose,
         pollStatus: async () => ({ unlocked: false }),
         verifyTimeoutMs: 500,
       }),
-    ).rejects.toThrow(/broker restart exited 1/);
+    ).rejects.toThrow(/docker compose restart exited 1/);
   });
 
   it("throws when verify-poll times out", async () => {
-    const systemd = await import("../src/agents/systemd.js");
-    vi.spyOn(systemd, "installAllUnits").mockImplementation(() => {});
-
     await expect(
       applyAutoUnlock({
         configPath,
+        composeFile: "/fake/compose.yml",
         log: () => {},
         err: () => {},
-        runSystemctl: () => ({ status: 0 }),
+        runDockerCompose: () => ({ status: 0 }),
         pollStatus: async () => ({ unlocked: false }),
         verifyTimeoutMs: 500,
       }),
     ).rejects.toThrow(/verification timeout/);
+  });
+
+  it("invokes docker (not systemctl) with the configured compose file", async () => {
+    const seen: string[][] = [];
+    const runDockerCompose = vi.fn((args: string[]) => {
+      seen.push(args);
+      return { status: 0 };
+    });
+
+    await applyAutoUnlock({
+      configPath,
+      composeFile: "/etc/switchroom/compose.yml",
+      log: () => {},
+      err: () => {},
+      runDockerCompose,
+      pollStatus: async () => ({ unlocked: true }),
+      verifyTimeoutMs: 2000,
+    });
+
+    // The first (and only) call must be the compose restart with the
+    // exact compose-file path the caller passed in.
+    expect(seen.length).toBe(1);
+    expect(seen[0]).toEqual([
+      "compose",
+      "-f",
+      "/etc/switchroom/compose.yml",
+      "restart",
+      "vault-broker",
+    ]);
   });
 });


### PR DESCRIPTION
## Scope

Second slice of the v0.7.0 release series. Builds on PR-A1 (#840, merged at `d9cbbe26`). Five commits, no overlap with A1's surface:

1. **`fix(docker): scheduler uses docker-ce-cli not docker.io`** — replace Debian's ~250MB `docker.io` package (which drags in the daemon + containerd we never run) with Docker's official `docker-ce-cli` (~50MB CLI-only). One extra apt repo + GPG key during build. Smaller image, smaller attack surface (no daemon binary present at all).
2. **`fix(docker): claude install fail-fast, no || true`** — drop the trailing `|| true` on `claude --version` in `Dockerfile.base` so a busted npm install of `@anthropic-ai/claude-code` fails the base build instead of silently shipping a broken bundle downstream.
3. **`fix(docker): pin + checksum bun installer`** — replace `curl https://bun.sh/install | bash` with a pinned-version download from GitHub plus per-arch sha256 verification (x64 + aarch64). Bumping bun now requires updating `BUN_VERSION` and `BUN_SHA256_*` together; mismatches fail the build.
4. **`fix(install.sh): correct sha256sum grep pattern`** — the previous regex matched only single-trailing-space lines and was anchored at end-of-line; on hosts with CRLF endings or BSD grep alternation quirks the lookup silently failed and the installer aborted with "No checksum entry" on a valid checksums file. Switched to a fixed-string two-space-prefixed match (`grep -F`).
5. **`refactor(vault-auto-unlock): replace systemctl with docker compose restart`** — the v0.7 substrate is Docker; rewire `applyAutoUnlock` so `switchroom vault broker enable-auto-unlock` (and the equivalent setup-wizard step) bounce the broker via `docker compose -f <compose-file> restart vault-broker` instead of `systemctl --user restart`. The encrypted blob is now bind-mounted from `~/.switchroom/vault-auto-unlock` into the broker container at `/state/vault-auto-unlock:ro`. The crypto path is unchanged.

## Depends on

- PR-A1 #840 (compose + scaffold + apply blockers) — already merged. This branch is cut from `upstream/main` at `d9cbbe26` and inherits the new `tests/.baseline-failures.txt` contract.

## Deferred to PR-A3

The legacy `src/agents/systemd.ts` module (and its `installAllUnits` export) remains in the tree, just no longer referenced from the auto-unlock path. PR-A3 will delete the systemd module wholesale along with the rest of the host-native install surface — keeping it as a separate slice keeps the diff legible.

## Validation

- `bun run build` — green on every commit.
- `npm run lint` (tsc --noEmit + plugin-references) — clean.
- `bun run test:vitest` — failing test set (`tests/docker/broker-ipc-race.test.ts`, `tests/docker/per-agent-isolation.test.ts`) is a strict subset of the baseline declared by PR-A1 in `tests/.baseline-failures.txt`. No new failures introduced.
- New test coverage for the docker-compose-restart flow in `tests/vault-auto-unlock.test.ts` (4 cases: success, restart non-zero, verify-poll timeout, exact-argv assertion).

## Test plan

- [ ] Build the scheduler image locally — confirm <100MB (vs ~250MB baseline).
- [ ] Build the base image locally — confirm `BUN_SHA256` mismatch (e.g. `--build-arg BUN_VERSION=1.3.13 --build-arg BUN_SHA256_X64=000…`) fails the build deterministically.
- [ ] On a host with a stale `~/.switchroom/vault-auto-unlock` blob, run `switchroom vault broker enable-auto-unlock` — confirm `docker compose ... restart vault-broker` is invoked and the broker comes up unlocked.
- [ ] Run `install.sh` in a fresh shell against a release with the canonical two-space-format checksums file — confirm verify passes.