### PR TITLE
docs: v0.7 docker-only sweep + migration guide + CHANGELOG (PR-A4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,43 +1,29 @@
 # Changelog
 
-## v0.7.0 — BREAKING: lifecycle CLI consolidated to setup/apply
-
-The lifecycle surface now collapses to two verbs: `switchroom setup`
-(interactive wizard, run once) and `switchroom apply` (idempotent
-scaffold + compose-file generate, run any time switchroom.yaml changes).
+## v0.7.0 — Docker-only (BREAKING)
 
 **Breaking changes:**
+- `switchroom up`, `switchroom init` now deprecation aliases for `switchroom apply`. Removed in v0.8.
+- `switchroom update` replaced with deprecation shim that prints the docker upgrade recipe and exits 1.
+- `switchroom systemd` verb tree removed entirely.
+- `--legacy` flag on `switchroom up` removed; switchroom is docker-only on Linux now.
+- Forum-mode prompts removed from `switchroom setup`; default is per-agent DM bots.
 
-- `switchroom up` is removed. The thin shim that remains warns and
-  forwards to `switchroom apply`; slated for full removal in v0.8.
-- `switchroom init` is removed. Same shim treatment as `up`.
-- `switchroom update` is removed. The shim accepts and silently swallows
-  the legacy flags (`--force`, `--check`, `--no-restart`, `--resume`,
-  `--phase`) so a v0.6 → v0.7 in-flight self-reexec parses; every other
-  invocation prints the upgrade hint and exits 1.
-- `switchroom apply` does NOT shell out to `docker`. Operators run the
-  bring-up themselves so the CLI never has to second-guess docker
-  daemon, rootless mode, or sudo policy.
-- The interactive wizard no longer prompts for a Telegram forum group.
-  Per-agent bot DM-only is the default; the still-required
-  `telegram.forum_chat_id` schema field gets a sentinel "0" matching
-  the existing user-id sentinel pattern. Existing configs with a real
-  `forum_chat_id` keep working.
+**Adds:**
+- Static CLI binary distribution via GitHub releases + `install.sh`.
+- GHCR image publishing on tag push.
+- Compose generator includes top-level `name: switchroom` and absolute HOME paths.
+- Vault preflight + compose-v2 detection in `apply`.
+- UID alignment for bind-mounted agent state dirs (fail-hard by default; `--allow-unaligned` opt-out).
 
-**Migration (v0.6 → v0.7):**
+**Removes:**
+- `bin/bridge-watchdog.sh` — Docker `restart: unless-stopped` + per-service healthchecks supersede.
+- `src/agents/systemd.ts` and the entire systemd unit-template + reconcile machinery.
+- 5 unit-targeted test files; 4 watchdog integration tests.
 
-```sh
-cd ~/code/switchroom
-git pull
-bun install
-bun run build
-docker compose -p switchroom -f ~/.switchroom/compose/docker-compose.yml pull
-switchroom apply
-docker compose -p switchroom -f ~/.switchroom/compose/docker-compose.yml up -d
-```
+**Migration:** see [`docs/operators/migration-v0.7.md`](docs/operators/migration-v0.7.md).
 
-`switchroom update` keeps working through v0.7 as a deprecation shim
-that prints the same hint.
+**Scope:** Linux only. Mac (Docker Desktop) validation tracked as Phase 3.5.
 
 ## v0.6.0 — Docker substrate (Linux), single-host
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ So I built this.
 
 ## Architecture
 
-One long-running service per agent. Each agent runs the stock `claude` CLI — not a fork, not the Agents SDK, not a wrapped harness — authenticated directly with Anthropic via official OAuth. Switchroom is scaffolding and lifecycle around the CLI you'd run by hand: a Telegram bot, an approval broker, a vault broker, and either Docker Compose (default on Linux) or systemd + a watchdog (`--legacy`) for supervision. See [`docs/architecture.md`](docs/architecture.md) for the process model and how each layer maps to the `claude` CLI.
+One long-running service per agent. Each agent runs the stock `claude` CLI — not a fork, not the Agents SDK, not a wrapped harness — authenticated directly with Anthropic via official OAuth. Switchroom is scaffolding and lifecycle around the CLI you'd run by hand: a Telegram bot, an approval broker, a vault broker, and Docker Compose for supervision. See [`docs/architecture.md`](docs/architecture.md) for the process model and how each layer maps to the `claude` CLI.
 
 ```
 You (Telegram)
@@ -88,7 +88,7 @@ You (Telegram)
            ├─ SQLite history             ├─ Vault broker ◄────────┤   Drive MCP, Playwright MCP, …
            ├─ Card-events.jsonl audit    │   (cron secrets, IPC)  └─ scheduled tasks across reboots
            ├─ Emoji reactions            │
-           └─ Format conversion          └─ Compose restart (Docker) / watchdog (--legacy)
+           └─ Format conversion          └─ Docker Compose restart (unless-stopped)
 ```
 
 See [`docs/architecture.md`](docs/architecture.md) for the process model, IPC layout, supervisor choice, and how each layer maps to the `claude` CLI.
@@ -116,7 +116,7 @@ Each agent is a long-running service. They survive reboots, network drops, and y
 
 <p align="center"><img src="docs/diagrams/wake-audit-lifecycle.jpg" width="700" alt="Wake-audit lifecycle: kill, crash-pane snapshot, auto-restart, agent boots with SWITCHROOM_PENDING_TURN, acks with three options"></p>
 
-- **Auto-restart.** Under the default Docker runtime, agent containers come up with `restart: unless-stopped` so a crashed agent comes straight back. Under `--legacy` (systemd), a background watchdog keeps an eye on every agent for stuck turns, dead bridges, and runaway resource use; when it has to act, it captures a **crash pane snapshot** so you can see what the agent was looking at when it died, then auto-recovers with a full audit trail. No silent dropped work.
+- **Auto-restart.** Agent containers come up with `restart: unless-stopped`, and each service has a healthcheck — a crashed or wedged agent is brought back automatically. No silent dropped work.
 - **Resume protocol.** When an agent reboots mid-turn, `start.sh` exports `SWITCHROOM_PENDING_TURN=true` plus the original chat / message ids. The agent's first action on boot is to acknowledge the gap and ask the user how to proceed (start over, summarise and continue, or drop it).
 - **Wake-audit.** On every fresh boot the agent checks for owed replies, orphan sub-agents, and stale in-progress todos. If everything's clean it stays quiet. If it owed you a reply, it tells you.
 - **Token refresh.** Runs unattended for weeks via a `refresh-tick` daemon. Multi-account fallback pool kicks in when the active slot hits its quota window.
@@ -138,7 +138,7 @@ The wedge against OpenClaw and NanoClaw isn't the substrate — it's the stock `
 
 ## Install
 
-Runs on the box you already have. The supported production runtime is Linux + Docker (Ubuntu 24.04 LTS with 4GB RAM is the canonical target; other Linux distros work with minor tweaks). `switchroom apply` scaffolds every agent and writes a `docker-compose.yml` from your `switchroom.yaml`; you bring the fleet up yourself with `docker compose -p switchroom -f ~/.switchroom/compose/docker-compose.yml up -d`. The legacy systemd path is reached via the `switchroom agent` lifecycle verbs. macOS and Windows can run the fleet via Docker Desktop on a best-effort basis for development and demo use, but Linux is the only supported production target.
+Runs on the box you already have. The supported production runtime is Linux + Docker (Ubuntu 24.04 LTS with 4GB RAM is the canonical target; other Linux distros work with minor tweaks). `switchroom apply` scaffolds every agent and writes a `docker-compose.yml` from your `switchroom.yaml`; you bring the fleet up yourself with `docker compose -p switchroom -f ~/.switchroom/compose/docker-compose.yml up -d`. Linux is the only supported production target; macOS (Docker Desktop) is tracked as Phase 3.5 and not yet validated.
 
 > **Heads up on the package name.** The npm package was originally `switchroom-ai`. It's now just `switchroom`. The old name is deprecated and will stop receiving updates — `npm install -g switchroom` is the current path.
 
@@ -183,7 +183,8 @@ Then:
 switchroom setup                                        # interactive Telegram wiring
 switchroom agent create coach --profile health-coach    # scaffold your first agent
 switchroom auth login coach                             # link your Pro or Max session
-switchroom agent start coach                            # go
+switchroom apply                                        # write docker-compose.yml
+docker compose -p switchroom -f ~/.switchroom/compose/docker-compose.yml up -d
 ```
 
 After the last command you talk to the agent from Telegram. You don't touch the server again.
@@ -204,7 +205,7 @@ If you already have Telegram credentials in `~/.switchroom/switchroom.yaml`, ski
 ```bash
 switchroom agent create coach --profile health-coach
 switchroom auth login coach
-switchroom agent start coach
+switchroom apply && docker compose -p switchroom -f ~/.switchroom/compose/docker-compose.yml up -d
 ```
 
 ## Example configuration
@@ -251,7 +252,7 @@ See [docs/configuration.md](docs/configuration.md) for the full reference.
 
 ## Vault broker (cron secrets)
 
-Scheduled tasks run headless via `systemd --user` timers, so they can't prompt for the vault passphrase. The vault broker is a long-running user-level systemd unit that holds the vault decrypted in memory after a one-time interactive unlock. Cron tasks fetch the specific keys they declare via a unix socket. The passphrase never sits on disk.
+Scheduled tasks run headless inside the agent container, so they can't prompt for the vault passphrase. The vault broker is a long-running container (`switchroom-broker`) that holds the vault decrypted in memory after a one-time interactive unlock. Cron tasks fetch the specific keys they declare via a host-shared unix socket. The passphrase never sits on disk.
 
 **Declare per-cron secrets in `switchroom.yaml`:**
 
@@ -269,17 +270,18 @@ agents:
 **Bootstrap once per host:**
 
 ```bash
-switchroom apply                        # installs the broker systemd unit
+switchroom apply                        # writes broker into docker-compose.yml
+docker compose -p switchroom -f ~/.switchroom/compose/docker-compose.yml up -d switchroom-broker
 switchroom vault broker unlock          # prompt for passphrase, primes broker
 ```
 
 Or just run `switchroom vault get <key>` from a TTY. The broker offers to take the unlocked state with `[Y/n]` so you don't have to remember a separate unlock command.
 
-**Identity model.** On Linux, the broker reads `/proc/<pid>/cgroup` to find the connecting cron's systemd unit (`switchroom-<agent>-cron-<i>.service`). Cgroup membership is set by systemd as root and is unspoofable from userspace, so a compromised agent cannot pose as another agent's cron and read its keys. macOS and other platforms degrade to UID-only via the socket file mode 0600. Fine for desktop use, not recommended for production cron.
+**Identity model.** The broker reads `/proc/<pid>/cgroup` on the host to find the connecting cron's container (`switchroom-<agent>-scheduler` or `switchroom-<agent>`), which Docker sets unspoofably from userspace, so a compromised agent cannot pose as another agent's cron and read its keys. macOS (Docker Desktop) degrades to UID-only via the socket file mode 0600. Fine for desktop use, not recommended for production cron.
 
-The broker locks on `SIGTERM` (so a `restart` zeros the in-memory state) and on demand via `switchroom vault broker lock`. Use `switchroom vault get <key> --no-broker` to bypass and prompt locally.
+The broker locks on `SIGTERM` (so a container restart zeros the in-memory state) and on demand via `switchroom vault broker lock`. Use `switchroom vault get <key> --no-broker` to bypass and prompt locally.
 
-Unit installed at `~/.config/systemd/user/switchroom-vault-broker.service`.
+Broker socket lives at `~/.switchroom/vault-broker.sock` (host-mounted into every agent container).
 
 ### Auto-unlock on boot (opt-in)
 
@@ -313,7 +315,7 @@ switchroom agent reconcile <name|all>         # Re-apply switchroom.yaml (withou
 switchroom agent start|stop|restart <name>    # Lifecycle (with preflight)
 switchroom agent interrupt <name>             # Cancel in-flight turn without restarting
 switchroom agent rename <old> <new>           # Rename an agent slug (#168)
-switchroom agent destroy <name>               # Tear down systemd units + scaffold dir
+switchroom agent destroy <name>               # Remove from compose + scaffold dir
 switchroom agent attach <name>                # Interactive tmux session
 switchroom agent logs <name> [-f]             # View logs
 switchroom agent grant <name> <tool>          # Grant a tool permission
@@ -326,7 +328,7 @@ Profiles live in `profiles/` at the repo root. Bundled ones for `--profile`: `co
 `switchroom agent create <name> --profile <profile>` does two things in one step:
 
 1. Adds an entry to `switchroom.yaml` under `agents:` with `extends: <profile>` and a derived `topic_name` (capitalized agent name). Edit the yaml afterwards to change the topic name, emoji, tools, etc.
-2. Scaffolds the agent directory and installs the systemd unit (same as running `agent create` on an entry that already exists in yaml).
+2. Scaffolds the agent directory and registers the agent in `docker-compose.yml` on next `switchroom apply` (same as running `agent create` on an entry that already exists in yaml).
 
 If the agent is already in yaml, `--profile` must match the existing `extends:` value or it errors. If the yaml entry has no `extends:` and you pass `--profile`, the flag is written in additively with a warning. Running `agent create` with no `--profile` on a missing entry keeps the old "Agent not defined in switchroom.yaml" error, now with a hint to use `--profile`.
 

--- a/commands/start.md
+++ b/commands/start.md
@@ -1,5 +1,5 @@
 ---
-description: Start a switchroom agent (or all agents) via systemd
+description: Start a switchroom agent (or all agents) via Docker Compose
 argument-hint: "[agent-name]"
 allowed-tools: [Bash]
 ---
@@ -10,7 +10,7 @@ The user invoked: `/switchroom:start $ARGUMENTS`
 
 ## What to do
 
-If `$ARGUMENTS` names an agent, start only that one. If empty, start everything in the configured fleet. Both paths go through the canonical CLI — never poke `systemctl --user` directly unless the CLI is unavailable.
+If `$ARGUMENTS` names an agent, start only that one. If empty, start everything in the configured fleet. Both paths go through the canonical CLI — never poke `docker compose` directly unless the CLI is unavailable.
 
 ```bash
 # Single agent

--- a/docs/auto-unlock.md
+++ b/docs/auto-unlock.md
@@ -148,6 +148,6 @@ Three ways to recover:
 2. **Disable auto-unlock and unlock manually.** Run `switchroom vault
    broker disable-auto-unlock`, then `switchroom vault broker unlock`
    on every boot.
-3. **Inspect.** `journalctl --user -u switchroom-vault-broker.service
-   -e` will show the exact error class
+3. **Inspect.** `docker compose -p switchroom -f ~/.switchroom/compose/docker-compose.yml logs switchroom-broker --tail 100`
+   will show the exact error class
    (`tag-mismatch` / `format` / `io`).

--- a/docs/operators/install.md
+++ b/docs/operators/install.md
@@ -98,6 +98,6 @@ docker compose -p switchroom -f ~/.switchroom/compose/docker-compose.yml up -d
 
 ## Related
 
-- `runtime-mode.md` — Docker is the supported production runtime; the
-  legacy systemd path is reached via `switchroom agent` lifecycle verbs.
+- `runtime-mode.md` — Docker is the only supported runtime in v0.7+.
+- `migration-v0.7.md` — upgrading from the v0.6 systemd runtime.
 - `docs/proposed/docker-images.yml` — the GHCR build/push workflow.

--- a/docs/operators/migration-v0.7.md
+++ b/docs/operators/migration-v0.7.md
@@ -1,0 +1,143 @@
+# Migration: v0.6 → v0.7 (Docker-only)
+
+v0.7 removes the legacy systemd runtime. Every agent now runs as a
+Docker container under `docker compose`. The `switchroom systemd` verb
+tree is gone, `bin/bridge-watchdog.sh` is deleted, and `switchroom up`
+/ `switchroom init` / `switchroom update` survive only as deprecation
+shims (slated for removal in v0.8).
+
+This guide walks an existing v0.6 deployment to v0.7 with no fleet
+downtime beyond a normal restart.
+
+## Before you start
+
+- **Snapshot your config.** `cp -a ~/.switchroom ~/.switchroom.v0.6.bak`
+  — config, vault, agent state. Cheap insurance.
+- **Note what's running.** `switchroom agent list` (capture the output)
+  so you can compare after the migration.
+- **Confirm the host has compose v2.** `docker compose version` should
+  print `Docker Compose version v2.x`. If you only have the v1 plugin
+  (`docker-compose`), install the v2 plugin first — `apply` errors out
+  on v1.
+
+## Step 1 — Stop the systemd fleet
+
+```sh
+# Stop every per-agent unit, the watchdog, and the broker.
+systemctl --user stop 'switchroom-*.service' 'switchroom-*.timer' 2>/dev/null || true
+systemctl --user stop switchroom-vault-broker.service 2>/dev/null || true
+systemctl --user stop switchroom-watchdog.service 2>/dev/null || true
+
+# Disable so they don't fight the docker fleet on next boot.
+systemctl --user disable 'switchroom-*.service' 'switchroom-*.timer' 2>/dev/null || true
+systemctl --user disable switchroom-vault-broker.service 2>/dev/null || true
+systemctl --user disable switchroom-watchdog.service 2>/dev/null || true
+
+systemctl --user daemon-reload
+```
+
+The unit files stay on disk for now — Step 5 cleans them up after the
+docker fleet has been stable for 48 hours.
+
+## Step 2 — Update switchroom
+
+Pick whichever install path you originally used.
+
+**Source checkout:**
+
+```sh
+cd ~/code/switchroom
+git pull
+bun install
+bun run build
+```
+
+**Static binary:**
+
+```sh
+curl -fsSL https://github.com/switchroom/switchroom/raw/main/install.sh | sh
+```
+
+Verify:
+
+```sh
+switchroom --version    # should report 0.7.x
+```
+
+## Step 3 — Apply + bring the docker fleet up
+
+```sh
+switchroom apply
+docker compose -p switchroom -f ~/.switchroom/compose/docker-compose.yml pull
+docker compose -p switchroom -f ~/.switchroom/compose/docker-compose.yml up -d
+```
+
+`switchroom apply` runs the v0.7 preflights (compose-v2 detection,
+vault socket check, UID alignment for bind-mounted state dirs) before
+writing `~/.switchroom/compose/docker-compose.yml`. If the UID-alignment
+check fails (your agent state dirs are owned by a UID the container
+won't have), either fix the ownership or pass `--allow-unaligned` after
+reading the warning.
+
+If you used auto-unlock under v0.6, the vault broker re-unlocks itself
+inside its new container on first boot.
+
+## Step 4 — Verify
+
+```sh
+docker compose -p switchroom -f ~/.switchroom/compose/docker-compose.yml ps
+switchroom version
+switchroom agent list
+```
+
+Expect every previously-running agent to be in `Up (healthy)` state.
+`switchroom version` reports the same agent health summary it always
+did, but its data source is now `docker compose ps` rather than
+`systemctl`. Send a test message to one agent in Telegram to confirm
+end-to-end is alive.
+
+## Step 5 — Optional: remove dormant unit files
+
+After the docker fleet has been stable for ~48h:
+
+```sh
+rm -f ~/.config/systemd/user/switchroom-*.service
+rm -f ~/.config/systemd/user/switchroom-*.timer
+rm -f ~/.config/systemd/user/switchroom-watchdog.service
+rm -f ~/.config/systemd/user/switchroom-vault-broker.service
+systemctl --user daemon-reload
+```
+
+The CLI does not write these files in v0.7+; once removed, they don't
+come back.
+
+## Rollback
+
+If something breaks and you want back on v0.6:
+
+```sh
+# Stop the docker fleet.
+docker compose -p switchroom -f ~/.switchroom/compose/docker-compose.yml down
+
+# Restore the v0.6 config snapshot you took at the top of this doc.
+mv ~/.switchroom ~/.switchroom.v0.7.partial
+mv ~/.switchroom.v0.6.bak ~/.switchroom
+
+# Check out the v0.6 source (or reinstall the v0.6 binary release).
+cd ~/code/switchroom
+git checkout v0.6.0
+bun install && bun run build
+
+# Re-enable + start the v0.6 systemd units.
+switchroom apply        # v0.6 apply renders systemd units
+systemctl --user daemon-reload
+switchroom agent start
+```
+
+If you had not yet run Step 5, the v0.6 unit files are still on disk
+and will start cleanly. Otherwise `switchroom apply` (under v0.6) will
+re-render them.
+
+File any rollback needed as a v0.7 bug — the docker path is the
+supported runtime going forward and we want to know when it can't take
+the place of a v0.6 install.

--- a/docs/operators/runtime-mode.md
+++ b/docs/operators/runtime-mode.md
@@ -1,15 +1,9 @@
-# Runtime mode — Docker vs systemd
+# Runtime mode — Docker on Linux
 
-Switchroom can run its agent fleet in one of two runtimes:
-
-- **Docker** — each agent runs in its own container, brought up by a
-  generated `docker-compose.yml`. This is the supported production
-  runtime on Linux.
-- **systemd (legacy)** — each agent runs as a `switchroom-<name>` user
-  unit on the host. Reached via the `switchroom agent` lifecycle verbs
-  (`switchroom agent start`, `switchroom agent restart`, ...).
-
-## Docker
+Switchroom v0.7+ runs its agent fleet as Docker containers brought up by
+a generated `docker-compose.yml`. This is the only supported production
+runtime. The legacy systemd path was removed in v0.7 (see
+[`migration-v0.7.md`](./migration-v0.7.md)).
 
 ```sh
 switchroom apply
@@ -32,6 +26,5 @@ See [`install.md`](./install.md) for the operator install flow
 
 ## Production runtime declaration
 
-Linux is the only supported production runtime. macOS and Windows can
-run the fleet under Docker Desktop on a best-effort basis for development
-and demo use, but are not the supported production target.
+Linux is the only supported production runtime. macOS (Docker Desktop)
+is tracked as Phase 3.5 and not yet validated for production use.

--- a/skills/switchroom-architecture/SKILL.md
+++ b/skills/switchroom-architecture/SKILL.md
@@ -12,7 +12,7 @@ Switchroom is a multi-agent orchestrator built on Claude Code. It manages multip
 
 **One `switchroom.yaml` to rule them all.** All agents are configured from a single file using a three-layer cascade. See [cascade.md](cascade.md) for full merge semantics.
 
-**Agents as systemd services.** Each agent runs as a long-lived `claude` process managed by a systemd user service (`switchroom-<name>.service`). The `start.sh` script sets environment variables and execs into `claude`. Claude Code handles session persistence and tool execution.
+**Agents as Docker containers.** Each agent runs as a long-lived `claude` process inside its own container (`switchroom-<name>`), supervised by Docker Compose with `restart: unless-stopped` and a healthcheck. The `start.sh` script sets environment variables and execs into `claude`. Claude Code handles session persistence and tool execution.
 
 **Telegram as the primary interface.** The `switchroom-telegram` MCP plugin connects Claude Code to Telegram, providing 10 tools for message handling. See [telegram.md](telegram.md) for details.
 
@@ -46,12 +46,13 @@ Switchroom is a multi-agent orchestrator built on Claude Code. It manages multip
 ## Lifecycle
 
 1. `switchroom agent create <name>` — scaffold agent from switchroom.yaml
-2. `systemctl --user start switchroom-<name>` — start the process
-3. Claude Code boots, loads CLAUDE.md + skills + .mcp.json
-4. MCP servers connect (Hindsight, switchroom-telegram, others)
-5. Telegram plugin polls for messages
-6. User sends message → plugin fires `UserPromptSubmit` hook → Claude responds
-7. `switchroom agent reconcile <name>` — re-apply switchroom.yaml (no CLAUDE.md touch)
+2. `switchroom apply` — write `~/.switchroom/compose/docker-compose.yml`
+3. `docker compose -p switchroom -f ~/.switchroom/compose/docker-compose.yml up -d` — start the container
+4. Claude Code boots, loads CLAUDE.md + skills + .mcp.json
+5. MCP servers connect (Hindsight, switchroom-telegram, others)
+6. Telegram plugin polls for messages
+7. User sends message → plugin fires `UserPromptSubmit` hook → Claude responds
+8. `switchroom agent reconcile <name>` — re-apply switchroom.yaml (no CLAUDE.md touch)
 
 ## Deep dives
 

--- a/skills/switchroom-cli/SKILL.md
+++ b/skills/switchroom-cli/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: switchroom-cli
 description: "Run switchroom CLI operations on existing agents: logs, update, restart, version, config inspection, scheduled tasks, and Telegram plugin reference. Use when the user wants to: show logs (\"logs\", \"what happened\", \"check the journal\", \"why did it crash\"); update agents (\"update\", \"pull latest\", \"get new code\", \"upgrade\"); restart agents (\"restart\", \"reboot\", \"bounce\", \"kick\", \"it's stuck\"); check what's running (\"version\", \"what sha\", \"are agents up\", \"health summary\"); apply config changes (\"apply\", \"sync my config\", \"I just edited switchroom.yaml\"); inspect an agent's effective config (\"what model is X using\", \"how is <agent> configured\", \"show the cascade\"); list scheduled tasks (\"cron\", \"timers\", \"what runs automatically\", \"scheduled tasks\"); or ask about Telegram-plugin features (\"what MCP tools does the bot have\", \"how does reply work\"). Do NOT use for adding/removing agents (switchroom-manage), bootstrapping switchroom from scratch (switchroom-install), or \"something is broken\" diagnostics (switchroom-health).
-allowed-tools: Bash(switchroom *) Bash(systemctl --user *) Bash(journalctl *)
+allowed-tools: Bash(switchroom *) Bash(docker *) Bash(docker compose *)
 ---
 
 # Switchroom CLI operations
@@ -31,12 +31,12 @@ switchroom agent list
 
 ### Step 2 — Tail the logs
 
-Default is the last 20 lines. User can specify a number. Use the CLI if available; fall back to `journalctl` when it's not:
+Default is the last 20 lines. User can specify a number. Use the CLI if available; fall back to `docker compose logs` when it's not:
 
 ```bash
 switchroom agent logs <name> [--lines 50]
 # or, when switchroom CLI isn't reachable:
-journalctl --user -u switchroom-<name>.service -n 50 --no-pager
+docker compose -p switchroom -f ~/.switchroom/compose/docker-compose.yml logs --tail 50 switchroom-<name>
 ```
 
 ### Step 3 — Present output
@@ -64,8 +64,9 @@ docker compose -p switchroom -f ~/.switchroom/compose/docker-compose.yml up -d
 writes `~/.switchroom/compose/docker-compose.yml`. The CLI deliberately
 does not run `docker` for you — the operator owns the bring-up.
 
-The v0.6 `switchroom update` verb is removed in v0.7+; the legacy command
-still exists as a thin shim that prints this same upgrade hint.
+The v0.6 `switchroom update` verb is removed in v0.7+; calling it now
+prints this upgrade hint and exits 1. The shim is slated for full removal
+in v0.8.
 
 ---
 
@@ -234,8 +235,11 @@ List cron jobs and scheduled tasks.
 
 ### Step 1 — Show live timers
 
+Cron timers in v0.7+ run inside the per-agent scheduler container. Inspect
+its log to see fired jobs:
+
 ```bash
-systemctl --user list-timers --all | grep switchroom
+docker compose -p switchroom -f ~/.switchroom/compose/docker-compose.yml logs switchroom-<agent>-scheduler --tail 100
 ```
 
 ### Step 2 — Show declared schedule entries

--- a/skills/switchroom-health/SKILL.md
+++ b/skills/switchroom-health/SKILL.md
@@ -31,11 +31,11 @@ switchroom auth status 2>/dev/null || echo "FAIL: auth check failed"
 # and per-account health (healthy / quota-exhausted / expired / missing-refresh-token).
 switchroom auth account list 2>/dev/null || echo "INFO: no Anthropic accounts configured (legacy per-agent slot model in use)"
 
-# Check systemd units
-systemctl --user list-units "switchroom-*" --no-pager 2>/dev/null || echo "no switchroom systemd units"
+# Check docker-compose service health
+docker compose -p switchroom -f ~/.switchroom/compose/docker-compose.yml ps 2>/dev/null || echo "no switchroom docker fleet"
 
-# Check for failed units
-systemctl --user list-units "switchroom-*" --state=failed --no-pager 2>/dev/null
+# Check for unhealthy or exited containers
+docker compose -p switchroom -f ~/.switchroom/compose/docker-compose.yml ps --status exited --status unhealthy 2>/dev/null
 
 # Check MCP config exists for each agent
 for dir in ~/.switchroom/agents/*/; do
@@ -78,7 +78,7 @@ For each check, report:
 
 Group findings by category:
 1. **CLI & Auth** — switchroom installed, authenticated
-2. **Systemd units** — services running, no failed units
+2. **Docker fleet** — containers running, no unhealthy/exited services
 3. **Agent files** — start.sh, .mcp.json, settings.json present
 4. **Bot tokens** — Telegram credentials resolved
 5. **Memory backend** — Hindsight reachable
@@ -93,7 +93,7 @@ For common failures, give the exact fix:
 | Per-agent auth expired (slot model) | `switchroom auth login <agent>` |
 | Account expired (new model — `auth account list` shows red ✗) | `switchroom auth refresh-accounts` (one tick); if no refresh-token, the account needs re-adding |
 | Account quota-exhausted (yellow ⊘ in `auth account list`) | Auto-fallback handles it if the agent has multiple accounts; otherwise wait for the reset window or `switchroom auth enable <other-account> <agent>` |
-| Unit failed | `systemctl --user reset-failed switchroom-<name>`, then restart |
+| Container unhealthy | `docker compose -p switchroom -f ~/.switchroom/compose/docker-compose.yml restart switchroom-<name>` |
 | Missing .mcp.json | `switchroom apply` (full reconcile + rewrite compose; bring up via `docker compose ... up -d`) or `switchroom agent reconcile <name>` (targeted) |
 | Bot token unresolved | Check vault: `switchroom vault list` |
 | Memory unreachable | Check Hindsight MCP server is running |


### PR DESCRIPTION
## Summary

Pure-docs finale of the v0.7.0 docker-only series (builds on PR-A1 #840, PR-A2 #843, PR-A3 #845, PR-A3b #846).

Three commits:

1. **`docs: sweep README + operator docs for v0.7 docker-only reality`** — strip stale `--legacy` / systemd / bridge-watchdog / `switchroom update` references from operator-facing docs.
2. **`docs(operator): add migration guide for v0.6 → v0.7 cutover`** — new `docs/operators/migration-v0.7.md` with the stop-systemd / update / `apply` + `compose up` / verify / rollback recipe.
3. **`docs: CHANGELOG v0.7.0 BREAKING entry`** — replaces the partial in-flight v0.7 entry with the consolidated A1-A4 release notes.

## Files swept

- `README.md` — drop `--legacy` from architecture text + diagram, swap install/quick-start commands for `apply` + `docker compose up -d`, mark macOS as Phase 3.5 deferred, rewrite vault-broker section for the containerised broker, fix `agent destroy` description.
- `docs/operators/install.md` — fix Related list (point to migration guide instead of "legacy systemd via lifecycle verbs").
- `docs/operators/runtime-mode.md` — rewrite as docker-only; legacy systemd path called out as removed in v0.7 with pointer to the migration guide.
- `docs/auto-unlock.md` — `journalctl --user -u switchroom-vault-broker.service` → `docker compose ... logs switchroom-broker`.
- `skills/switchroom-cli/SKILL.md` — drop `systemctl/journalctl` from `allowed-tools`, fall back to `docker compose logs` instead of `journalctl`, replace `systemctl --user list-timers` with the per-agent scheduler container's logs.
- `skills/switchroom-health/SKILL.md` — replace systemd unit checks with `docker compose ps` health checks; update fix table.
- `skills/switchroom-architecture/SKILL.md` — agents are containers, not systemd services; lifecycle steps via `apply` + `docker compose up -d`.
- `commands/start.md` — start verb is `docker compose`, not systemd.

## New file

- `docs/operators/migration-v0.7.md` — operator migration guide.

## CHANGELOG

`v0.7.0` entry rewritten with the consolidated docker-only BREAKING notes covering A1-A4: CLI surface changes, static binary + GHCR publishing adds, `bin/bridge-watchdog.sh` + `src/agents/systemd.ts` removal, and a pointer to the migration guide.

## Test plan
- [ ] No code changes; vitest baseline should be unchanged.
- [ ] Render the migration guide on GitHub and skim for broken links / formatting.
- [ ] CHANGELOG renders cleanly at the top of the file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)