### PR TITLE
docs: replace stale systemctl/journalctl refs (closes #848)

### DIFF
--- a/docs/scheduling.md
+++ b/docs/scheduling.md
@@ -1,6 +1,6 @@
 # Scheduled Tasks
 
-Switchroom runs scheduled tasks as **systemd user timers** — reliable, OS-level, survive reboots and session crashes. Each task fires a one-shot `claude -p` call with the configured model and sends output to Telegram.
+Switchroom runs scheduled tasks via the **`scheduler` container** — a singleton cron service in the docker fleet that dispatches one-shot `claude -p` calls into each agent container at the configured times and sends output to Telegram. Surviving host reboots is handled by docker's restart policy.
 
 ## Quick Start
 
@@ -14,20 +14,17 @@ defaults:
       model: claude-opus-4-6    # override for important tasks
 ```
 
-Run `switchroom agent create <name>` or `switchroom agent reconcile <name>` to install the timers.
+Run `switchroom agent create <name>` or `switchroom agent reconcile <name>` to register the schedule entries with the scheduler.
 
 ## How It Works
 
-For each schedule entry, switchroom generates:
+The `scheduler` container reads each agent's `schedule:` block from `~/.switchroom/switchroom.yaml` (and the cascade), converts every `cron:` expression to a `node-cron` schedule, and at fire time runs:
 
-1. **`telegram/cron-N.sh`** — self-contained bash script that:
-   - Sources nvm (so `claude` is on PATH)
-   - Runs `claude -p "prompt" --model <model> --no-session-persistence`
-   - Sends the output to your Telegram DM via curl
+```
+docker exec agent-<name> claude -p "<prompt>" --model <model> --no-session-persistence
+```
 
-2. **`switchroom-<agent>-cron-N.timer`** — systemd timer with `OnCalendar` converted from the cron expression
-
-3. **`switchroom-<agent>-cron-N.service`** — systemd oneshot service that runs the script
+against the live agent container. The agent's MCP tools (Telegram, Vault, etc.) are wired the same way they are for an interactive turn, so the dispatched task can call `mcp__switchroom-telegram__reply` directly. The scheduler itself never sees secret values — the agent resolves any vault refs through the broker socket.
 
 ## Configuration
 
@@ -108,27 +105,27 @@ Scheduled tasks are **not** part of the running agent session. They:
 
 This means a scheduled task won't see the agent's conversation history or Hindsight memories. It's a clean, isolated execution — ideal for briefings, reminders, and periodic checks.
 
-## Managing Timers
+## Managing the Scheduler
 
 ```bash
-# List all active timers
-systemctl --user list-timers "switchroom-*"
+# Confirm the scheduler container is running
+docker compose -p switchroom -f ~/.switchroom/compose/docker-compose.yml ps scheduler
 
-# Check a specific timer
-systemctl --user status switchroom-assistant-cron-0.timer
+# Tail the scheduler's fire log (which task fired when, exit codes)
+docker compose -p switchroom -f ~/.switchroom/compose/docker-compose.yml logs -f scheduler
 
-# Manually trigger a scheduled task
-systemctl --user start switchroom-assistant-cron-0.service
+# Manually trigger a scheduled task by dispatching it directly into the agent
+docker exec agent-<name> claude -p "<prompt>" --model claude-sonnet-4-6 --no-session-persistence
 
-# View output from the last run
-journalctl --user -u switchroom-assistant-cron-0.service --no-pager -n 20
+# Restart the scheduler (e.g. after editing switchroom.yaml + reconciling)
+docker compose -p switchroom -f ~/.switchroom/compose/docker-compose.yml restart scheduler
 ```
 
 ## Comparison with Claude Code's Native Scheduling
 
-| | Switchroom (systemd timers) | Claude Code CronCreate | Claude Code Desktop |
+| | Switchroom (scheduler container) | Claude Code CronCreate | Claude Code Desktop |
 |---|---|---|---|
-| **Survives restart** | Yes (OS-level) | No (session-scoped) | Yes (app must be open) |
+| **Survives restart** | Yes (docker `restart: unless-stopped`) | No (session-scoped) | Yes (app must be open) |
 | **Headless** | Yes | Yes | No (Desktop app only) |
 | **Model selection** | Per-task | Inherits session | Per-task |
 | **Context isolation** | Fully isolated | Shares session | Isolated |

--- a/docs/tmux-supervisor-fanout.md
+++ b/docs/tmux-supervisor-fanout.md
@@ -25,7 +25,7 @@ agents:
 Then reconcile + restart that one agent:
 
 ```bash
-switchroom systemd reconcile myagent
+switchroom agent reconcile myagent
 switchroom agent restart myagent
 ```
 
@@ -63,16 +63,17 @@ update configs at your convenience but don't leave it forever.
 
 ## How to verify which supervisor an agent is on
 
+Read the resolved config — `experimental.legacy_pty` is the source of truth:
+
 ```bash
-systemctl --user cat switchroom-<name>.service | grep ^ExecStart=
-# default:  ExecStart=/usr/bin/tmux -L switchroom-<name> ...
-# legacy:   ExecStart=/usr/bin/script -qfc ...
+switchroom config show <name> | grep -A1 experimental
+# default:  legacy_pty: false  (or absent)
+# legacy:   legacy_pty: true
 ```
 
-Or check the unit type:
+Or inspect what the agent container is actually running — under the tmux supervisor the entrypoint launches `tmux -L switchroom-<name>`; under `legacy_pty: true` it falls back to `script -qfc`:
 
 ```bash
-systemctl --user show switchroom-<name>.service -p Type
-# default:  Type=forking
-# legacy:   Type=simple
+docker inspect agent-<name> --format '{{.Config.Cmd}} {{.Config.Entrypoint}}'
+docker compose -p switchroom -f ~/.switchroom/compose/docker-compose.yml logs agent-<name> | head -5
 ```


### PR DESCRIPTION
## Summary

Closes #848. Six `systemctl --user` / `journalctl --user` commands left over from the pre-v0.7 systemd era still lived in `docs/`, misleading operators copy-pasting from the docs after the docker-only migration. Replaced with the canonical `docker compose -p switchroom -f ~/.switchroom/compose/docker-compose.yml ...` shape and tightened nearby framing that still claimed systemd was the implementation.

## Lines fixed

`docs/scheduling.md`
- L3 (intro) — "systemd user timers" → "the scheduler container"
- L20-30 (How It Works) — replaced 3-bullet unit-file description with the actual scheduler-container dispatch model (`docker exec agent-<name> claude -p ...`)
- L113-124 (Managing Timers) — 4 stale commands replaced with `docker compose ps/logs/restart scheduler` + `docker exec` for manual fire
- L126-128 (Comparison table) — column header + restart row now describe `restart: unless-stopped` instead of "OS-level"

`docs/tmux-supervisor-fanout.md`
- L67 — `systemctl --user cat ...` → `switchroom config show <name>` + `docker inspect agent-<name>`
- L75 — `systemctl --user show ... -p Type` removed; the unit-type distinction is gone in docker mode
- L28 (drive-by) — `switchroom systemd reconcile` → `switchroom agent reconcile` (the `systemd` verb was removed in v0.7)

## Out of scope (left for future sweep)

- The "Independence from Agent Sessions" bullet "Fire even if the agent is down" is now arguably wrong (a stopped container can't be `docker exec`'d into) — phrasing tweak rather than command swap.
- `tmux-supervisor-fanout.md` L32-34 still describes systemd unit re-rendering and `Environment=` drops — accurate translation needs a small rewrite, not a one-line edit.
- `docs/vault.md`, `docs/vault-broker.md`, `docs/architecture.md`, `docs/configuration.md`, `docs/rfcs/approval-kernel.md` reference `switchroom-*-cron-N.service` cgroup names — those are architectural descriptions that may still apply in spirit; left alone here.

## Test plan
- [x] Pure docs change — no code paths touched.
- [x] `bun run test:vitest` baseline = 36 failed pre-existing; on branch = 35 failed (unchanged / flaky, no new failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)