### PR TITLE
feat: UX polish — GHCR auth + Sequoia + static-binary regression (v0.7 PR-B)

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,8 @@ Replace `switchroom-linux-amd64` with `switchroom-linux-arm64`, `switchroom-maco
 
 **macOS Gatekeeper note.** Releases are not yet Apple-code-signed. After installing on macOS you may need to clear the quarantine xattr so the binary will run: `xattr -d com.apple.quarantine /usr/local/bin/switchroom`. The `install.sh` one-liner handles this automatically.
 
+**Mac (Sequoia+) one-time.** macOS 15 adds a second-stage notarization check that the `xattr` strip alone does not bypass — you may still see a Gatekeeper "cannot verify the developer" dialog the first time you run `switchroom`. `install.sh` attempts `sudo spctl --add /usr/local/bin/switchroom` automatically (best-effort, ignored if sudo isn't available). If the dialog still fires, run that `spctl --add` manually, or open System Settings → Privacy & Security → "Open Anyway" once.
+
 Then:
 
 ```bash

--- a/docs/operators/install.md
+++ b/docs/operators/install.md
@@ -96,6 +96,31 @@ docker compose -p switchroom -f ~/.switchroom/compose/docker-compose.yml up -d
   `depends_on` healthcheck. Inspect with `docker compose -p switchroom
   ps` in another terminal.
 
+<a id="ghcr-auth"></a>
+## GHCR auth
+
+Switchroom's container images are intended to be public on
+`ghcr.io/switchroom/...`. If you've forked the repo, or if the org's
+package visibility is set to private, anonymous `docker pull` will
+return `401 Unauthorized`. The fix is to authenticate Docker against
+GHCR with a personal access token that has `read:packages` scope. The
+easiest path uses the GitHub CLI:
+
+```sh
+# Mint a token with read:packages scope (interactive, one-time).
+gh auth login --hostname github.com --scopes read:packages
+
+# Hand the token to docker. -u must be your GitHub username.
+gh auth token | docker login ghcr.io -u "$(gh api user -q .login)" --password-stdin
+```
+
+Subsequent `docker compose pull` calls will reuse the credential cached
+in `~/.docker/config.json`. To clear it: `docker logout ghcr.io`.
+
+If you don't have `gh` available, mint a classic PAT via the GitHub
+web UI (Settings → Developer settings → Personal access tokens →
+`read:packages`) and pipe it into `docker login ghcr.io -u <user> --password-stdin` directly.
+
 ## Related
 
 - `runtime-mode.md` — Docker is the only supported runtime in v0.7+.

--- a/install.sh
+++ b/install.sh
@@ -170,6 +170,18 @@ if [ "$platform" = "macos" ] && have xattr; then
   xattr -d com.apple.quarantine "$target" 2>/dev/null || true
 fi
 
+# Sequoia (macOS 15+) adds a notarization re-check that survives the
+# xattr strip — the OS still prompts on first run. Best-effort whitelist
+# the binary with spctl so it's allowed without the dialog. Requires
+# admin / sudo and is silently no-op'd if either is unavailable.
+if [ "$platform" = "macos" ] && have spctl; then
+  if [ -w "$(dirname "$target")" ]; then
+    spctl --add "$target" 2>/dev/null || true
+  elif have sudo; then
+    sudo spctl --add "$target" 2>/dev/null || true
+  fi
+fi
+
 ok "Installed switchroom to $target"
 
 # ---- verify ----

--- a/install.sh
+++ b/install.sh
@@ -81,6 +81,26 @@ fi
 
 ok "Version: $version"
 
+# ---- GHCR auth advisory ----
+#
+# Switchroom container images live on ghcr.io. They're meant to be
+# public, but if you've forked or the org's visibility flipped, an
+# anonymous `docker pull` will return 401. Probe the public manifest
+# endpoint with a HEAD; if it 401s, print the gh-cli login recipe.
+# Don't fail — the static binary itself comes from GitHub Releases,
+# which doesn't need GHCR auth, so this is purely informational.
+ghcr_check_url="https://ghcr.io/v2/${REPO}/switchroom-base/manifests/latest"
+ghcr_status=$(curl -fsSL -o /dev/null -w '%{http_code}' -I "$ghcr_check_url" 2>/dev/null || echo "000")
+if [ "$ghcr_status" = "401" ] || [ "$ghcr_status" = "403" ]; then
+  warn "GHCR returned ${ghcr_status} for ${REPO}/switchroom-base — images may be private."
+  cat <<'GHCR'
+  If `docker compose pull` later returns 401, log in to ghcr.io first:
+    gh auth login --hostname github.com --scopes read:packages
+    gh auth token | docker login ghcr.io -u "$(gh api user -q .login)" --password-stdin
+  See docs/operators/install.md#ghcr-auth for details.
+GHCR
+fi
+
 # ---- download binary + checksums ----
 
 base_url="https://github.com/${REPO}/releases/download/${version}"

--- a/src/build-info.ts
+++ b/src/build-info.ts
@@ -3,7 +3,7 @@
 // Values are refreshed every time `npm run build` runs.
 
 export const VERSION: string = "0.5.2";
-export const COMMIT_SHA: string | null = "85e7454a";
-export const COMMIT_DATE: string | null = "2026-05-09T09:18:15+10:00";
+export const COMMIT_SHA: string | null = "db57763e";
+export const COMMIT_DATE: string | null = "2026-05-09T10:21:46+10:00";
 export const LATEST_PR: number | null = null;
-export const COMMITS_AHEAD_OF_TAG: number | null = 7;
+export const COMMITS_AHEAD_OF_TAG: number | null = 11;

--- a/src/cli/apply.ts
+++ b/src/cli/apply.ts
@@ -17,8 +17,21 @@
  */
 import type { Command } from "commander";
 import chalk from "chalk";
-import { copyFileSync, existsSync } from "node:fs";
+import { copyFileSync, existsSync, writeFileSync } from "node:fs";
 import { mkdir, writeFile } from "node:fs/promises";
+// Embed example configs as text imports so they survive `bun build --compile`.
+// `import.meta.dirname` resolves to `/$bunfs/root` inside a compiled binary,
+// which means resolve(import.meta.dirname, "../../examples/...") points at a
+// path that doesn't exist on the host — apply --example would fail with
+// ENOENT. Text imports are bundled into the binary at compile time.
+import switchroomExample from "../../examples/switchroom.yaml" with { type: "text" };
+import minimalExample from "../../examples/minimal.yaml" with { type: "text" };
+
+/** Embedded example configs, keyed by name. Mirrors files under examples/. */
+const EMBEDDED_EXAMPLES: Record<string, string> = {
+  switchroom: switchroomExample,
+  minimal: minimalExample,
+};
 import { dirname, join, resolve } from "node:path";
 import { homedir } from "node:os";
 import { execFileSync } from "node:child_process";
@@ -296,17 +309,8 @@ function copyExampleConfig(name: string): void {
       `Invalid example name: ${name} (must match /^[a-z0-9_-]+$/)`,
     );
   }
-  const exampleFile = resolve(
-    import.meta.dirname,
-    `../../examples/${name}.yaml`,
-  );
-  const dest = resolve(process.cwd(), "switchroom.yaml");
 
-  if (!existsSync(exampleFile)) {
-    throw new Error(
-      `Example config not found: ${name}.yaml (available: switchroom, minimal)`,
-    );
-  }
+  const dest = resolve(process.cwd(), "switchroom.yaml");
 
   if (existsSync(dest)) {
     console.error(
@@ -317,6 +321,26 @@ function copyExampleConfig(name: string): void {
     return;
   }
 
+  // Prefer embedded examples (works under both `bun run` and `bun build
+  // --compile`). Fall back to disk lookup so contributors can add new
+  // examples in-tree without rebuilding — only relevant in dev because
+  // the compiled binary's `import.meta.dirname` is the bunfs virtual root.
+  const embedded = EMBEDDED_EXAMPLES[name];
+  if (embedded !== undefined) {
+    writeFileSync(dest, embedded, { encoding: "utf8" });
+    console.log(chalk.green(`Copied ${name}.yaml -> switchroom.yaml`));
+    return;
+  }
+
+  const exampleFile = resolve(
+    import.meta.dirname,
+    `../../examples/${name}.yaml`,
+  );
+  if (!existsSync(exampleFile)) {
+    throw new Error(
+      `Example config not found: ${name}.yaml (available: ${Object.keys(EMBEDDED_EXAMPLES).join(", ")})`,
+    );
+  }
   copyFileSync(exampleFile, dest);
   console.log(chalk.green(`Copied ${name}.yaml -> switchroom.yaml`));
 }

--- a/src/cli/apply.ts
+++ b/src/cli/apply.ts
@@ -265,6 +265,11 @@ export async function runApply(
       `  docker compose -p ${COMPOSE_PROJECT} -f ${composePath} pull && \\\n` +
       `    docker compose -p ${COMPOSE_PROJECT} -f ${composePath} up -d\n`,
   );
+  writeOut(
+    chalk.gray(
+      `  (If pull returns 401, login to ghcr.io first: see docs/operators/install.md#ghcr-auth)\n`,
+    ),
+  );
 
   writeOut(
     chalk.bold(

--- a/tests/install/static-binary.test.ts
+++ b/tests/install/static-binary.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Regression: `switchroom apply --example <name>` must work in the
+ * compiled static binary. `import.meta.dirname` resolves to the bunfs
+ * virtual root inside `bun build --compile` output, so the legacy
+ * `resolve(import.meta.dirname, "../../examples/...")` path was an
+ * ENOENT on the host. Examples are now embedded via text imports —
+ * this test rebuilds the CLI as a static binary in a tmpdir, runs
+ * `apply --example switchroom`, and asserts the example landed.
+ *
+ * Skipped automatically when `bun` itself isn't on PATH (CI workers
+ * without the bun toolchain) or when the `BUN_BUILD_COMPILE_SKIP` env
+ * var is set (sandbox where compile is too heavy).
+ */
+import { describe, it, expect } from "vitest";
+import { execFileSync, spawnSync } from "node:child_process";
+import { mkdtempSync, writeFileSync, existsSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+const REPO_ROOT = resolve(__dirname, "../..");
+
+function bunAvailable(): boolean {
+  if (process.env.BUN_BUILD_COMPILE_SKIP) return false;
+  try {
+    execFileSync("bun", ["--version"], { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+describe("static binary — import.meta.dirname regression", () => {
+  it.skipIf(!bunAvailable())(
+    "apply --example switchroom works inside a `bun build --compile` artifact",
+    () => {
+      const tmp = mkdtempSync(join(tmpdir(), "switchroom-static-"));
+      const binPath = join(tmp, "switchroom-bin");
+
+      // Compile the CLI into a single static binary. Mirrors the
+      // production `package.json` build:cli target but stripped down
+      // (no --target / --minify so the build is fast).
+      const compile = spawnSync(
+        "bun",
+        [
+          "build",
+          "--compile",
+          resolve(REPO_ROOT, "bin/switchroom.ts"),
+          "--outfile",
+          binPath,
+        ],
+        { cwd: REPO_ROOT, encoding: "utf8" },
+      );
+      if (compile.status !== 0) {
+        throw new Error(
+          `bun build --compile failed:\nstdout: ${compile.stdout}\nstderr: ${compile.stderr}`,
+        );
+      }
+      expect(existsSync(binPath)).toBe(true);
+
+      // Need a writable home + cwd so apply doesn't blow up writing
+      // the compose file or hitting the agents-dir.
+      const fakeHome = join(tmp, "home");
+      const cwd = join(tmp, "work");
+      const env = {
+        ...process.env,
+        HOME: fakeHome,
+        // Skip docker-compose-v2 preflight; we only care that the
+        // example-copy step succeeds.
+        SWITCHROOM_SKIP_PREFLIGHT: "1",
+      };
+      execFileSync("mkdir", ["-p", fakeHome, cwd]);
+
+      // Run `apply --example switchroom` — but we don't actually want
+      // apply itself to run (it'd shell out to docker preflight). The
+      // copyExampleConfig() step runs BEFORE config load, so even a
+      // failed apply leaves switchroom.yaml on disk. Capture output
+      // for diagnostics.
+      const run = spawnSync(binPath, ["apply", "--example", "switchroom"], {
+        cwd,
+        env,
+        encoding: "utf8",
+        timeout: 30_000,
+      });
+
+      // The example copy must have succeeded regardless of apply's
+      // overall exit status. The pre-fix bug surfaced as:
+      //   "Example config not found: switchroom.yaml (available: ...)"
+      // ...which would NOT leave the file on disk.
+      const dest = join(cwd, "switchroom.yaml");
+      expect(
+        existsSync(dest),
+        `Expected switchroom.yaml at ${dest}.\nstdout: ${run.stdout}\nstderr: ${run.stderr}`,
+      ).toBe(true);
+
+      const contents = readFileSync(dest, "utf8");
+      // Sanity: the embedded example is non-empty and looks like YAML.
+      expect(contents.length).toBeGreaterThan(50);
+      expect(contents).toMatch(/agents\s*:/);
+    },
+    120_000,
+  );
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -17,6 +17,10 @@ if (process.env.BUILDKITE_ANALYTICS_TOKEN) {
 const VITEST_MAX_FORKS = Number(process.env.VITEST_MAX_FORKS ?? 4);
 
 export default defineConfig({
+  // Treat .yaml as a static asset so `import x from "./foo.yaml" with
+  // { type: "text" }` works under Vite/vitest. Bun's compile-time text
+  // imports already handle this; this line keeps vitest aligned.
+  assetsInclude: ["**/*.yaml"],
   test: {
     globals: true,
     environment: "node",


### PR DESCRIPTION
v0.7 PR-B — three small UX polish items deferred from the pre-cutover review. Branched off `upstream/main` at e0476147.

## Items

### 1. GHCR auth handling (#7)
- `install.sh`: HEAD-probes `ghcr.io/switchroom/switchroom-base` before downloading; on a 401/403 prints the `gh auth login` + `docker login ghcr.io` recipe so operators don't hit a silent `docker pull` failure later. Non-fatal.
- `src/cli/apply.ts`: appends a one-line note to the bring-up hint pointing at the new docs anchor.
- `docs/operators/install.md`: new `#ghcr-auth` section with the gh-cli path and a manual classic-PAT fallback.

### 2. macOS Sequoia Gatekeeper (#13)
- `install.sh`: best-effort `spctl --add` after the `xattr -d com.apple.quarantine` strip. Sequoia's second-stage notarization check survives the xattr alone. Failures (no sudo, missing spctl) are silently ignored.
- README install section: new "Mac (Sequoia+) one-time" note explaining the manual `spctl --add` and the System Settings → Privacy & Security → "Open Anyway" fallback.

### 3. Static-binary `import.meta.dirname` regression (#14)
- **Confirmed broken.** Inside `bun build --compile` artifacts, `import.meta.dirname` resolves to `/$bunfs/root` (bun's virtual fs root), so `resolve(import.meta.dirname, "../../examples/<name>.yaml")` pointed at a host path that didn't exist. `switchroom apply --example switchroom` from the static binary failed with `Example config not found`.
- Fix: embed both example YAMLs via Bun text imports (`with { type: "text" }`); they're bundled into the compiled binary at build time. Disk-path fallback retained for in-tree dev so contributors adding new examples don't need a rebuild.
- New regression test `tests/install/static-binary.test.ts`: compiles the CLI into a tmpdir, runs `apply --example switchroom`, asserts the file lands. Auto-skips if `bun` isn't on PATH.
- `vitest.config.ts`: `assetsInclude: ["**/*.yaml"]` so the text imports parse cleanly under Vite.

## Validation
- `bun run build` clean.
- `npm run lint` clean.
- `bun run test:vitest` — no FAILs introduced (baseline subset preserved).
- `bash -n install.sh` clean (shellcheck not available on this host).

## Commits
1. `feat(install): GHCR auth probe + apply hint + docs section`
2. `feat(install): macOS Sequoia spctl whitelist + README note`
3. `test(install): static-binary import.meta.dirname regression + fix`