### PR TITLE
fix: v0.7 P0 + P1 pre-tag fixes (vault paths, homeDir, alignAgentUid, install.sh, docs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,7 +293,7 @@ By default, the broker holds the unlocked state in memory only. Every restart (h
 switchroom vault broker enable-auto-unlock   # one-time setup, prompts for passphrase
 ```
 
-Done. The wizard prompts for your vault passphrase, encrypts it with AES-256-GCM keyed off `/etc/machine-id`, writes the result to `~/.config/switchroom/auto-unlock.bin` (mode 0600), flips `vault.broker.autoUnlock: true` in `switchroom.yaml`, restarts the broker, and verifies the vault came up unlocked. Every subsequent boot the broker reads + decrypts + unlocks itself.
+Done. The wizard prompts for your vault passphrase, encrypts it with AES-256-GCM keyed off `/etc/machine-id`, writes the result to `~/.switchroom/vault-auto-unlock` (mode 0600), flips `vault.broker.autoUnlock: true` in `switchroom.yaml`, restarts the broker, and verifies the vault came up unlocked. Every subsequent boot the broker reads + decrypts + unlocks itself.
 
 Disable with `switchroom vault broker disable-auto-unlock`.
 

--- a/docs/auto-unlock.md
+++ b/docs/auto-unlock.md
@@ -8,7 +8,7 @@ switchroom vault broker enable-auto-unlock
 
 You enter your vault passphrase once. Switchroom encrypts it with a key
 derived from `/etc/machine-id`, writes the result to
-`~/.config/switchroom/auto-unlock.bin` at mode 0600, flips
+`~/.switchroom/vault-auto-unlock` at mode 0600, flips
 `vault.broker.autoUnlock: true` in your `switchroom.yaml`, and restarts the
 broker. Done — every subsequent boot, the broker reads the file, decrypts,
 unlocks the vault, and your fleet comes back working without you typing
@@ -84,7 +84,7 @@ The broker stays running and lets you unlock interactively. Re-running
 ## How it works (file format)
 
 ```
-~/.config/switchroom/auto-unlock.bin   mode 0600
+~/.switchroom/vault-auto-unlock   mode 0600
 
   0       1     version (always 0x01)
   1       16    salt (random per-encryption)

--- a/docs/operators/migration-v0.7.md
+++ b/docs/operators/migration-v0.7.md
@@ -79,8 +79,20 @@ check fails (your agent state dirs are owned by a UID the container
 won't have), either fix the ownership or pass `--allow-unaligned` after
 reading the warning.
 
-If you used auto-unlock under v0.6, the vault broker re-unlocks itself
-inside its new container on first boot.
+If you used auto-unlock under v0.6, move the auto-unlock blob to its
+v0.7 path **before** running `switchroom apply` above (v0.7 changed the
+default location and the v0.6 file won't be picked up otherwise):
+
+```sh
+# v0.7 changed the auto-unlock blob path. If you used auto-unlock on v0.6:
+[ -f ~/.config/switchroom/auto-unlock.bin ] && \
+  mv ~/.config/switchroom/auto-unlock.bin ~/.switchroom/vault-auto-unlock
+```
+
+If you've moved the auto-unlock blob (above) the vault broker re-unlocks
+itself inside its new container on first boot. Otherwise you'll be
+prompted for the passphrase on first start; re-run
+`switchroom vault enable-auto-unlock` to restore unattended unlock.
 
 ## Step 4 — Verify
 

--- a/docs/operators/migration-v0.7.md
+++ b/docs/operators/migration-v0.7.md
@@ -119,6 +119,21 @@ If something breaks and you want back on v0.6:
 # Stop the docker fleet.
 docker compose -p switchroom -f ~/.switchroom/compose/docker-compose.yml down
 
+# Restore original UID ownership on agent state dirs. v0.7 apply chowns
+# each agent dir to its container UID (10xx range); v0.6 systemd units
+# run as your own UID and will refuse to read state owned by 10xx.
+# `apply` records the prior <uid>:<gid> per directory to the audit log
+# below — replay it in reverse so each dir gets its v0.6 owner back.
+# If the log is missing (fresh install or pre-PR-C2 v0.7), the
+# unconditional fallback restores everything to your shell user.
+if [ -f ~/.switchroom/.uid-alignment.log ]; then
+  # Each line: "<iso-ts> <agent-dir> <prior-uid>:<prior-gid> -> <new>".
+  awk '{print $2, $3}' ~/.switchroom/.uid-alignment.log \
+    | while read -r dir owner; do sudo chown -R "$owner" "$dir"; done
+else
+  sudo chown -R "$USER:$USER" ~/.switchroom/agents/
+fi
+
 # Restore the v0.6 config snapshot you took at the top of this doc.
 mv ~/.switchroom ~/.switchroom.v0.7.partial
 mv ~/.switchroom.v0.6.bak ~/.switchroom

--- a/install.sh
+++ b/install.sh
@@ -81,25 +81,11 @@ fi
 
 ok "Version: $version"
 
-# ---- GHCR auth advisory ----
-#
-# Switchroom container images live on ghcr.io. They're meant to be
-# public, but if you've forked or the org's visibility flipped, an
-# anonymous `docker pull` will return 401. Probe the public manifest
-# endpoint with a HEAD; if it 401s, print the gh-cli login recipe.
-# Don't fail — the static binary itself comes from GitHub Releases,
-# which doesn't need GHCR auth, so this is purely informational.
-ghcr_check_url="https://ghcr.io/v2/${REPO}/switchroom-base/manifests/latest"
-ghcr_status=$(curl -fsSL -o /dev/null -w '%{http_code}' -I "$ghcr_check_url" 2>/dev/null || echo "000")
-if [ "$ghcr_status" = "401" ] || [ "$ghcr_status" = "403" ]; then
-  warn "GHCR returned ${ghcr_status} for ${REPO}/switchroom-base — images may be private."
-  cat <<'GHCR'
-  If `docker compose pull` later returns 401, log in to ghcr.io first:
-    gh auth login --hostname github.com --scopes read:packages
-    gh auth token | docker login ghcr.io -u "$(gh api user -q .login)" --password-stdin
-  See docs/operators/install.md#ghcr-auth for details.
-GHCR
-fi
+# GHCR auth: anonymous `docker pull` against ghcr.io returns 401 even for
+# public images (the registry always wants a bearer token), so probing
+# from the installer was always going to flap or false-positive. We just
+# tell the user what to do if `docker compose pull` later fails — see the
+# "Next" block at the end of this script.
 
 # ---- download binary + checksums ----
 
@@ -201,6 +187,11 @@ Next:
 
 Note: the static binary bundles its runtime, but you still need the
 `claude` CLI installed (npm i -g @anthropic-ai/claude-code) to run agents.
+
+If `docker compose pull` later fails with 401 from ghcr.io, log in once:
+  gh auth login --hostname github.com --scopes read:packages
+  gh auth token | docker login ghcr.io -u "$(gh api user -q .login)" --password-stdin
+See docs/operators/install.md#ghcr-auth for details.
 
 Docs: https://switchroom.ai
 NEXT

--- a/src/agents/compose.ts
+++ b/src/agents/compose.ts
@@ -259,6 +259,8 @@ export function generateCompose(opts: ComposeGeneratorOptions): string {
   lines.push(`    cap_add:`);
   lines.push(`      - "CHOWN"`);
   lines.push(`      - "FOWNER"`);
+  lines.push(`    environment:`);
+  lines.push(`      SWITCHROOM_VAULT_BROKER_AUTO_UNLOCK_PATH: /state/vault-auto-unlock`);
   lines.push(`    volumes:`);
   for (const a of describeAgents(config)) {
     lines.push(`      - broker-${a.name}-sock:/run/switchroom/broker/${a.name}`);

--- a/src/agents/docker-fleet.ts
+++ b/src/agents/docker-fleet.ts
@@ -18,6 +18,7 @@
 
 import { resolve } from "node:path";
 import { mkdirSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
 import { execFileSync } from "node:child_process";
 import { generateCompose } from "./compose.js";
 import type { SwitchroomConfig } from "../config/schema.js";
@@ -79,9 +80,15 @@ export function bringUpAgentService(
 
   const compose =
     opts.generateComposeContent?.() ??
-    generateCompose({ config: opts.config });
+    // PR-A1 made compose interpolation use absolute HOME paths instead of
+    // ${HOME}; that fix requires threading homeDir through to
+    // generateCompose. Without it, sudo'd `agent add` would re-write
+    // compose.yml with /root/-rooted paths.
+    generateCompose({ config: opts.config, homeDir: homedir() });
   const composePath = resolve(composeDir, "docker-compose.yml");
-  writeFileSync(composePath, compose, { mode: 0o644 });
+  // 0o600 matches `switchroom apply` — compose can contain references to
+  // sockets/state under the operator's home and shouldn't be world-readable.
+  writeFileSync(composePath, compose, { mode: 0o600 });
 
   const dockerBin = opts.dockerBin ?? "docker";
   const stdio = opts.stdio ?? "inherit";

--- a/src/agents/scaffold.test.ts
+++ b/src/agents/scaffold.test.ts
@@ -49,16 +49,25 @@ describe("alignAgentUid", () => {
     vi.restoreAllMocks();
   });
 
-  it("is a no-op when the dir is already owned by the target uid (idempotent fast-path)", () => {
+  it("still runs recursive chown even when the top-level dir is already owned (subtree may be stale)", () => {
+    // The previous behaviour was a fast-path no-op when statSync said the
+    // top-level was already aligned. That hid stale uid 1000 entries
+    // sitting deeper in the subtree (e.g. files an operator dropped in
+    // via sudo). chown -R is idempotent + cheap, so we always run it.
     mockedStatSync.mockReturnValue({ uid: 10042, gid: 10042 } as never);
+    mockedExecFileSync.mockImplementationOnce(() => Buffer.from(""));
 
     const res = alignAgentUid("agent", "/fake/state/agent", 10042, {
       writeOut: () => {},
+      confirm: false,
     });
 
-    expect(res.chowned).toBe(false);
+    expect(res.chowned).toBe(true);
     expect(res.paths).toEqual(["/fake/state/agent"]);
-    expect(mockedExecFileSync).not.toHaveBeenCalled();
+    expect(mockedExecFileSync).toHaveBeenCalledTimes(1);
+    const [bin, args] = mockedExecFileSync.mock.calls[0];
+    expect(bin).toBe("chown");
+    expect(args).toEqual(["-R", "10042:10042", "/fake/state/agent"]);
   });
 
   it("tries unprivileged chown first, returns success when it works", () => {

--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -2,6 +2,7 @@ import {
   existsSync,
   mkdirSync,
   writeFileSync,
+  appendFileSync,
   readFileSync,
   chmodSync,
   symlinkSync,
@@ -12,6 +13,7 @@ import {
   lstatSync,
   readlinkSync,
 } from "node:fs";
+import { homedir } from "node:os";
 import { execSync, execFileSync } from "node:child_process";
 import { basename, join, resolve } from "node:path";
 import chalk from "chalk";
@@ -110,15 +112,34 @@ export function alignAgentUid(
   if (existsSync(agentDir)) paths.push(agentDir);
   if (paths.length === 0) return { chowned: false, paths: [] };
 
-  // Fast path: already correctly owned (idempotent re-runs).
+  // No fast-path: a previous `apply` may have aligned the top-level dir
+  // while leaving stale uid 1000 entries deep in the subtree (e.g. the
+  // operator dropped files in via sudo, or a v0.6 → v0.7 migration
+  // chowned the root but skipped a child). `chown -R` is idempotent and
+  // cheap, so we always run it. Pre-`chown` we record the prior owner of
+  // the top-level dir to ~/.switchroom/.uid-alignment.log so rollback
+  // can restore precise ownership without guessing.
+  let priorUid: number | undefined;
+  let priorGid: number | undefined;
   try {
     const st = statSync(agentDir);
-    if (st.uid === uid && st.gid === uid) {
-      return { chowned: false, paths };
-    }
-  } catch { /* fall through to chown */ }
+    priorUid = st.uid;
+    priorGid = st.gid;
+  } catch { /* unreadable — skip the audit log entry */ }
 
   if (opts.dryRun) return { chowned: false, paths };
+
+  if (priorUid !== undefined && priorGid !== undefined && (priorUid !== uid || priorGid !== uid)) {
+    try {
+      const logPath = join(homedir(), ".switchroom", ".uid-alignment.log");
+      mkdirSync(join(homedir(), ".switchroom"), { recursive: true });
+      const ts = new Date().toISOString();
+      appendFileSync(
+        logPath,
+        `${ts} ${agentDir} ${priorUid}:${priorGid} -> ${uid}:${uid}\n`,
+      );
+    } catch { /* best-effort audit; never block alignment */ }
+  }
 
   if (opts.confirm !== false && process.stdin.isTTY) {
     // Interactive prompt: explain why we're shelling sudo. We use

--- a/src/cli/apply.ts
+++ b/src/cli/apply.ts
@@ -276,7 +276,7 @@ export async function runApply(
   writeOut(
     `Bring the fleet up with:\n` +
       `  docker compose -p ${COMPOSE_PROJECT} -f ${composePath} pull && \\\n` +
-      `    docker compose -p ${COMPOSE_PROJECT} -f ${composePath} up -d\n`,
+      `    docker compose -p ${COMPOSE_PROJECT} -f ${composePath} up -d --remove-orphans\n`,
   );
   writeOut(
     chalk.gray(

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -801,7 +801,7 @@ async function stepAutoUnlock(
 
   const credPathRaw =
     config.vault?.broker?.autoUnlockCredentialPath ??
-    "~/.config/switchroom/auto-unlock.bin";
+    "~/.switchroom/vault-auto-unlock";
   const credPath = resolvePath(credPathRaw);
   if (config.vault?.broker?.autoUnlock === true && existsSync(credPath)) {
     console.log(chalk.green(`  ${STEP_DONE} Already configured (${credPath})`));

--- a/src/config/schema.test.ts
+++ b/src/config/schema.test.ts
@@ -102,7 +102,7 @@ describe("VaultConfigSchema.broker", () => {
       socket: "~/.switchroom/vault-broker.sock",
       enabled: true,
       autoUnlock: false,
-      autoUnlockCredentialPath: "~/.config/switchroom/auto-unlock.bin",
+      autoUnlockCredentialPath: "~/.switchroom/vault-auto-unlock",
     });
   });
 

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -1373,10 +1373,11 @@ export const VaultConfigSchema = z.object({
         "systemd-creds, no TPM. Run `switchroom vault broker " +
         "enable-auto-unlock` once to write the blob."
       ),
-      autoUnlockCredentialPath: z.string().default("~/.config/switchroom/auto-unlock.bin").describe(
+      autoUnlockCredentialPath: z.string().default("~/.switchroom/vault-auto-unlock").describe(
         "Path to the machine-bound auto-unlock blob (see " +
-        "src/vault/auto-unlock.ts for the format). Default lives under the " +
-        "user's switchroom config dir at mode 0600. Tilde-expansion happens " +
+        "src/vault/auto-unlock.ts for the format). Default lives under " +
+        "~/.switchroom so it can be bind-mounted into the vault-broker " +
+        "container by docker compose. Tilde-expansion happens " +
         "at read time."
       ),
     })

--- a/src/vault/auto-unlock.ts
+++ b/src/vault/auto-unlock.ts
@@ -221,8 +221,8 @@ export function readAutoUnlockFile(filePath: string): string {
 }
 
 /**
- * Default location for the auto-unlock blob. Picked so it doesn't collide
- * with systemd-creds' `~/.config/credstore.encrypted/` (different mechanism,
- * different file format) and lives under switchroom's own namespace.
+ * Default location for the auto-unlock blob. Lives under ~/.switchroom
+ * so it's co-located with other operator state and easily mounted into
+ * the broker container by the compose definition.
  */
-export const DEFAULT_AUTO_UNLOCK_PATH = "~/.config/switchroom/auto-unlock.bin";
+export const DEFAULT_AUTO_UNLOCK_PATH = "~/.switchroom/vault-auto-unlock";

--- a/src/vault/broker/server.ts
+++ b/src/vault/broker/server.ts
@@ -1459,8 +1459,10 @@ export class VaultBroker {
    * Sources, in order:
    *   1. The machine-bound auto-unlock blob written by
    *      `switchroom vault broker enable-auto-unlock` — default at
-   *      ~/.config/switchroom/auto-unlock.bin (configurable via
-   *      vault.broker.autoUnlockCredentialPath).
+   *      ~/.switchroom/vault-auto-unlock (configurable via
+   *      vault.broker.autoUnlockCredentialPath, or the
+   *      SWITCHROOM_VAULT_BROKER_AUTO_UNLOCK_PATH env var the
+   *      docker-compose vault-broker service injects).
    *   2. `$CREDENTIALS_DIRECTORY/vault-passphrase` — for power users who
    *      installed the broker as a system unit with systemd
    *      LoadCredentialEncrypted=. We don't ship that mode by default but
@@ -1472,7 +1474,7 @@ export class VaultBroker {
   }
 
   /**
-   * Read ~/.config/switchroom/auto-unlock.bin (or configured path), decrypt
+   * Read ~/.switchroom/vault-auto-unlock (or configured/env path), decrypt
    * with the key derived from /etc/machine-id + the per-file salt, push the
    * passphrase into unlockFromPassphrase. Returns true if we attempted —
    * regardless of success — so the caller knows whether to try other paths.
@@ -1480,8 +1482,18 @@ export class VaultBroker {
    * Returns false only when auto-unlock is not configured (file path absent).
    */
   private _tryAutoUnlockFromMachineBoundFile(): boolean {
+    // Resolution order:
+    //   1. SWITCHROOM_VAULT_BROKER_AUTO_UNLOCK_PATH env var — set by the
+    //      docker-compose vault-broker service so the in-container path
+    //      (`/state/vault-auto-unlock`) overrides the host-shaped default
+    //      that wouldn't resolve inside the container.
+    //   2. config.vault.broker.autoUnlockCredentialPath — operator override.
+    //   3. DEFAULT_AUTO_UNLOCK_PATH — the canonical host location.
+    const envPath = process.env.SWITCHROOM_VAULT_BROKER_AUTO_UNLOCK_PATH;
     const configuredPath =
-      this.config?.vault?.broker?.autoUnlockCredentialPath ?? DEFAULT_AUTO_UNLOCK_PATH;
+      (envPath && envPath.length > 0 ? envPath : undefined) ??
+      this.config?.vault?.broker?.autoUnlockCredentialPath ??
+      DEFAULT_AUTO_UNLOCK_PATH;
     const filePath = resolvePath(configuredPath);
     if (!existsSync(filePath)) return false;
 


### PR DESCRIPTION
## Summary

Bundle of 6 small P0 + P1 fixes from the v0.7 pre-tag review (PR-C2).

- **P0 vault auto-unlock blob path mismatch** — broker default resolved to `/root/.config/switchroom/auto-unlock.bin` inside the container, but compose mounted at `/state/vault-auto-unlock`. Auto-unlock silently fell through to interactive. Fixed by (a) moving `DEFAULT_AUTO_UNLOCK_PATH` to `~/.switchroom/vault-auto-unlock` so the host write path matches the bind-mount source, and (b) honouring `SWITCHROOM_VAULT_BROKER_AUTO_UNLOCK_PATH` env in the broker (compose injects `/state/vault-auto-unlock`).
- **P0 `bringUpAgentService` regenerated compose without `homeDir`** — sudo'd `agent add` re-wrote `compose.yml` with `${HOME}` interpolating to `/root`. Threaded `homedir()` through and tightened the write mode to `0o600` to match `apply`.
- **P1 `install.sh` GHCR probe** — duplicated `/switchroom/` in URL, and anonymous HEAD against ghcr.io always 401s anyway. Dropped the probe; appended the gh-cli login recipe to the Next-steps block so it's always visible.
- **P1 `alignAgentUid` fast-path** — only inspected the top-level dir, missing stale uid 1000 entries deeper in the subtree. Always run `chown -R` (idempotent + cheap), and record prior `<uid>:<gid>` per dir to `~/.switchroom/.uid-alignment.log` for precise rollback.
- **P1 `apply` next-step hint** — added `--remove-orphans` to the suggested `compose up` so removed agents get cleaned up.
- **P1 migration doc rollback** — added a step that replays `.uid-alignment.log` (with a fallback `chown -R $USER:$USER`) so v0.6 systemd can re-read state owned by 10xx UIDs.

## Test plan

- [x] `bun run build` — clean.
- [x] `npm run lint` — clean.
- [x] `bun run test:vitest` — 5005 passed / 38 skipped, 0 failures (strict subset of `tests/.baseline-failures.txt`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)