### PR TITLE
test(v0.7): close coverage gaps for orchestrators + bringUp + scaffold log + deprecated shims (PR-D1)

### DIFF
--- a/src/agents/create-orchestrator.test.ts
+++ b/src/agents/create-orchestrator.test.ts
@@ -1,0 +1,293 @@
+/**
+ * Tests for {@link createAgent} — happy-path, rollback-on-failure, and
+ * idempotent re-run behaviour. PR-D1 / v0.7 coverage gap #1.
+ *
+ * createAgent is heavily I/O-coupled (yaml writes, scaffold-on-disk,
+ * Telegram getMe network round-trip, OAuth tmux session). We mock every
+ * external boundary so the tests exercise the orchestrator's sequencing
+ * + rollback bookkeeping without touching the real filesystem, network,
+ * or systemd. The yaml + agent-dir mutations are tracked in tmpdirs so
+ * we can assert the rollback actually unwound them.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, mkdirSync, writeFileSync, existsSync, rmSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+vi.mock("./scaffold.js", () => ({
+  scaffoldAgent: vi.fn(),
+  reconcileAgent: vi.fn(),
+}));
+
+vi.mock("./profiles.js", () => ({
+  listAvailableProfiles: vi.fn(() => ["default", "general", "health-coach"]),
+}));
+
+vi.mock("./lifecycle.js", () => ({
+  startAgent: vi.fn(),
+  stopAgent: vi.fn(),
+}));
+
+vi.mock("../auth/manager.js", () => ({
+  startAuthSession: vi.fn(),
+  submitAuthCode: vi.fn(),
+}));
+
+vi.mock("../setup/telegram-api.js", () => ({
+  validateBotToken: vi.fn().mockResolvedValue({ id: 1, is_bot: true, username: "ken_bot" }),
+  validateBotTokenMatchesAgent: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("../setup/onboarding.js", () => ({
+  writeAgentEnv: vi.fn(),
+}));
+
+import { createAgent } from "./create-orchestrator.js";
+import { scaffoldAgent } from "./scaffold.js";
+import { startAuthSession } from "../auth/manager.js";
+import { writeAgentEnv } from "../setup/onboarding.js";
+import { validateBotTokenMatchesAgent } from "../setup/telegram-api.js";
+
+function makeWorkspace(): { configPath: string; agentsDir: string; cleanup: () => void } {
+  const root = mkdtempSync(join(tmpdir(), "create-orch-"));
+  const agentsDir = join(root, "agents");
+  mkdirSync(agentsDir, { recursive: true });
+  const configPath = join(root, "switchroom.yaml");
+  writeFileSync(
+    configPath,
+    [
+      "switchroom:",
+      "  version: 1",
+      `  agents_dir: ${agentsDir}`,
+      "telegram:",
+      "  bot_token: \"vault:telegram-bot-token\"",
+      "  forum_chat_id: \"-1001234567890\"",
+      "agents: {}",
+      "",
+    ].join("\n"),
+  );
+  return {
+    configPath,
+    agentsDir,
+    cleanup: () => rmSync(root, { recursive: true, force: true }),
+  };
+}
+
+describe("createAgent", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (validateBotTokenMatchesAgent as any).mockResolvedValue(undefined);
+    (startAuthSession as any).mockReturnValue({
+      loginUrl: "https://login.example/code",
+      sessionName: "auth-bot-1",
+    });
+    // scaffoldAgent must create the agentDir on disk so the rollback can
+    // remove it (tests assert dir-exists before/after rollback).
+    (scaffoldAgent as any).mockImplementation(
+      (_name: string, _cfg: unknown, agentsDir: string, _tg: unknown, _config: unknown, _slot: unknown, _configPath?: string) => {
+        const name = _name as string;
+        mkdirSync(join(agentsDir, name), { recursive: true });
+      },
+    );
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("happy path: validates token, writes yaml entry, scaffolds, writes env, starts auth", async () => {
+    const ws = makeWorkspace();
+    try {
+      const result = await createAgent({
+        name: "bot",
+        profile: "general",
+        telegramBotToken: "fake:token",
+        configPath: ws.configPath,
+      });
+
+      expect(validateBotTokenMatchesAgent).toHaveBeenCalledWith("fake:token", "bot");
+      expect(scaffoldAgent).toHaveBeenCalledOnce();
+      expect(writeAgentEnv).toHaveBeenCalledWith(
+        join(ws.agentsDir, "bot"),
+        "fake:token",
+      );
+      expect(startAuthSession).toHaveBeenCalledOnce();
+      expect(result.loginUrl).toBe("https://login.example/code");
+      expect(result.sessionName).toBe("auth-bot-1");
+      expect(result.agentDir).toBe(resolve(ws.agentsDir, "bot"));
+
+      // yaml entry written
+      const yamlBody = readFileSync(ws.configPath, "utf-8");
+      expect(yamlBody).toMatch(/\bbot:/);
+      // agent dir from scaffoldAgent mock is on disk
+      expect(existsSync(join(ws.agentsDir, "bot"))).toBe(true);
+    } finally {
+      ws.cleanup();
+    }
+  });
+
+  it("rollback-on-failure: when startAuthSession throws and rollbackOnFail=true, yaml entry + agent dir are reverted", async () => {
+    const ws = makeWorkspace();
+    try {
+      (startAuthSession as any).mockImplementation(() => {
+        throw new Error("auth tmux failed");
+      });
+
+      await expect(
+        createAgent({
+          name: "bot",
+          profile: "general",
+          telegramBotToken: "fake:token",
+          configPath: ws.configPath,
+          rollbackOnFail: true,
+        }),
+      ).rejects.toThrow(/auth tmux failed/);
+
+      // yaml rolled back: bot entry removed
+      const yamlBody = readFileSync(ws.configPath, "utf-8");
+      expect(yamlBody).not.toMatch(/\bbot:/);
+      // agent dir cleaned up
+      expect(existsSync(join(ws.agentsDir, "bot"))).toBe(false);
+    } finally {
+      ws.cleanup();
+    }
+  });
+
+  it("rollback-on-failure: when rollbackOnFail=false, side-effects remain for retry", async () => {
+    const ws = makeWorkspace();
+    try {
+      (startAuthSession as any).mockImplementation(() => {
+        throw new Error("auth tmux failed");
+      });
+
+      await expect(
+        createAgent({
+          name: "bot",
+          profile: "general",
+          telegramBotToken: "fake:token",
+          configPath: ws.configPath,
+          rollbackOnFail: false,
+        }),
+      ).rejects.toThrow(/auth tmux failed/);
+
+      // yaml entry is preserved so the operator can retry
+      const yamlBody = readFileSync(ws.configPath, "utf-8");
+      expect(yamlBody).toMatch(/\bbot:/);
+      expect(existsSync(join(ws.agentsDir, "bot"))).toBe(true);
+    } finally {
+      ws.cleanup();
+    }
+  });
+
+  it("idempotent re-run: invoking with the same profile when the agent is already in yaml succeeds without throwing", async () => {
+    const ws = makeWorkspace();
+    try {
+      // First run — populates yaml + scaffolds
+      await createAgent({
+        name: "bot",
+        profile: "general",
+        telegramBotToken: "fake:token",
+        configPath: ws.configPath,
+      });
+      const callsAfterFirst = (scaffoldAgent as any).mock.calls.length;
+
+      // Second run with same profile must not throw and must reuse the existing entry
+      await expect(
+        createAgent({
+          name: "bot",
+          profile: "general",
+          telegramBotToken: "fake:token",
+          configPath: ws.configPath,
+        }),
+      ).resolves.toMatchObject({ sessionName: "auth-bot-1" });
+
+      expect((scaffoldAgent as any).mock.calls.length).toBeGreaterThan(callsAfterFirst);
+    } finally {
+      ws.cleanup();
+    }
+  });
+
+  it("rejects re-run with a different profile (would mutate extends silently)", async () => {
+    const ws = makeWorkspace();
+    try {
+      await createAgent({
+        name: "bot",
+        profile: "general",
+        telegramBotToken: "fake:token",
+        configPath: ws.configPath,
+      });
+
+      await expect(
+        createAgent({
+          name: "bot",
+          profile: "health-coach",
+          telegramBotToken: "fake:token",
+          configPath: ws.configPath,
+        }),
+      ).rejects.toThrow(/already configured with profile "general"/);
+    } finally {
+      ws.cleanup();
+    }
+  });
+
+  it("rejects invalid agent name slugs before any disk writes", async () => {
+    const ws = makeWorkspace();
+    try {
+      await expect(
+        createAgent({
+          name: "BadName!",
+          profile: "general",
+          telegramBotToken: "fake:token",
+          configPath: ws.configPath,
+        }),
+      ).rejects.toThrow(/Invalid agent name/);
+      expect(scaffoldAgent).not.toHaveBeenCalled();
+      expect(validateBotTokenMatchesAgent).not.toHaveBeenCalled();
+    } finally {
+      ws.cleanup();
+    }
+  });
+
+  it("rejects unknown profile before token validation or disk writes", async () => {
+    const ws = makeWorkspace();
+    try {
+      await expect(
+        createAgent({
+          name: "bot",
+          profile: "no-such-profile",
+          telegramBotToken: "fake:token",
+          configPath: ws.configPath,
+        }),
+      ).rejects.toThrow(/Unknown profile/);
+      expect(validateBotTokenMatchesAgent).not.toHaveBeenCalled();
+      expect(scaffoldAgent).not.toHaveBeenCalled();
+    } finally {
+      ws.cleanup();
+    }
+  });
+
+  it("bot-token validation failure aborts before any yaml/scaffold work", async () => {
+    const ws = makeWorkspace();
+    try {
+      (validateBotTokenMatchesAgent as any).mockRejectedValueOnce(
+        new Error("Telegram getMe rejected"),
+      );
+
+      await expect(
+        createAgent({
+          name: "bot",
+          profile: "general",
+          telegramBotToken: "broken:token",
+          configPath: ws.configPath,
+        }),
+      ).rejects.toThrow(/Bot token validation failed/);
+
+      expect(scaffoldAgent).not.toHaveBeenCalled();
+      const yamlBody = readFileSync(ws.configPath, "utf-8");
+      expect(yamlBody).not.toMatch(/\bbot:/);
+    } finally {
+      ws.cleanup();
+    }
+  });
+});

--- a/src/agents/docker-fleet.test.ts
+++ b/src/agents/docker-fleet.test.ts
@@ -1,0 +1,179 @@
+/**
+ * Tests for {@link bringUpAgentService} — the helper that owns the
+ * "regenerate compose, persist, `docker compose up -d --no-deps
+ * agent-<name>`" sequence used by `switchroom agent add` (Phase 3a/3b)
+ * and the in-flight bring-up path. PR-D1 / v0.7 coverage gap #2.
+ *
+ * We mock the compose generator (so we don't need a fully-formed config),
+ * intercept `node:child_process.execFileSync` to assert the docker argv,
+ * and write to a tmpdir to verify the on-disk compose path + file mode.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mkdtempSync, statSync, readFileSync, existsSync } from "node:fs";
+import { tmpdir, homedir } from "node:os";
+import { join, resolve } from "node:path";
+
+vi.mock("./compose.js", () => ({
+  generateCompose: vi.fn(),
+}));
+
+vi.mock("node:child_process", async () => {
+  const actual = await vi.importActual<typeof import("node:child_process")>("node:child_process");
+  return {
+    ...actual,
+    execFileSync: vi.fn(),
+  };
+});
+
+import { bringUpAgentService, resolveSwitchroomHome } from "./docker-fleet.js";
+import { generateCompose } from "./compose.js";
+import { execFileSync } from "node:child_process";
+import type { SwitchroomConfig } from "../config/schema.js";
+
+const STUB_CONFIG = {
+  switchroom: { agents_dir: "/tmp/agents" },
+  agents: { bot: { extends: "general" } },
+} as unknown as SwitchroomConfig;
+
+const STUB_COMPOSE_YAML = "services:\n  agent-bot:\n    image: stub\n";
+
+describe("bringUpAgentService", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (generateCompose as any).mockReturnValue(STUB_COMPOSE_YAML);
+  });
+
+  it("writes compose YAML to <home>/compose/docker-compose.yml with mode 0o600", () => {
+    const home = mkdtempSync(join(tmpdir(), "docker-fleet-"));
+    (execFileSync as any).mockReturnValue(Buffer.from(""));
+
+    const result = bringUpAgentService({
+      config: STUB_CONFIG,
+      agentName: "bot",
+      switchroomHome: home,
+      stdio: "ignore",
+    });
+
+    const expectedPath = resolve(home, "compose", "docker-compose.yml");
+    expect(result.composePath).toBe(expectedPath);
+    expect(existsSync(expectedPath)).toBe(true);
+    expect(readFileSync(expectedPath, "utf-8")).toBe(STUB_COMPOSE_YAML);
+
+    const mode = statSync(expectedPath).mode & 0o777;
+    expect(mode).toBe(0o600);
+  });
+
+  it("calls generateCompose with homeDir = os.homedir() (PR-A1 fix)", () => {
+    const home = mkdtempSync(join(tmpdir(), "docker-fleet-"));
+    (execFileSync as any).mockReturnValue(Buffer.from(""));
+
+    bringUpAgentService({
+      config: STUB_CONFIG,
+      agentName: "bot",
+      switchroomHome: home,
+      stdio: "ignore",
+    });
+
+    expect(generateCompose).toHaveBeenCalledWith({
+      config: STUB_CONFIG,
+      homeDir: homedir(),
+    });
+  });
+
+  it("shells out `docker compose -f <path> up -d --no-deps agent-<name>` with exact argv", () => {
+    const home = mkdtempSync(join(tmpdir(), "docker-fleet-"));
+    (execFileSync as any).mockReturnValue(Buffer.from(""));
+
+    bringUpAgentService({
+      config: STUB_CONFIG,
+      agentName: "bot",
+      switchroomHome: home,
+      stdio: "ignore",
+    });
+
+    expect(execFileSync).toHaveBeenCalledTimes(1);
+    const [bin, args, opts] = (execFileSync as any).mock.calls[0];
+    expect(bin).toBe("docker");
+    expect(args).toEqual([
+      "compose",
+      "-f",
+      resolve(home, "compose", "docker-compose.yml"),
+      "up",
+      "-d",
+      "--no-deps",
+      "agent-bot",
+    ]);
+    expect(opts.stdio).toBe("ignore");
+  });
+
+  it("respects custom dockerBin override (tests can substitute a wrapper)", () => {
+    const home = mkdtempSync(join(tmpdir(), "docker-fleet-"));
+    (execFileSync as any).mockReturnValue(Buffer.from(""));
+
+    bringUpAgentService({
+      config: STUB_CONFIG,
+      agentName: "bot",
+      switchroomHome: home,
+      dockerBin: "/usr/local/bin/podman",
+      stdio: "ignore",
+    });
+
+    const [bin] = (execFileSync as any).mock.calls[0];
+    expect(bin).toBe("/usr/local/bin/podman");
+  });
+
+  it("uses the injected generateComposeContent override when supplied (skips real generator)", () => {
+    const home = mkdtempSync(join(tmpdir(), "docker-fleet-"));
+    (execFileSync as any).mockReturnValue(Buffer.from(""));
+    const customCompose = "services: {}\n";
+
+    bringUpAgentService({
+      config: STUB_CONFIG,
+      agentName: "bot",
+      switchroomHome: home,
+      generateComposeContent: () => customCompose,
+      stdio: "ignore",
+    });
+
+    expect(generateCompose).not.toHaveBeenCalled();
+    const composePath = resolve(home, "compose", "docker-compose.yml");
+    expect(readFileSync(composePath, "utf-8")).toBe(customCompose);
+  });
+
+  it("propagates docker failure as an error from execFileSync", () => {
+    const home = mkdtempSync(join(tmpdir(), "docker-fleet-"));
+    (execFileSync as any).mockImplementation(() => {
+      const e = new Error("docker compose up failed: image pull error") as Error & { status: number };
+      e.status = 1;
+      throw e;
+    });
+
+    expect(() =>
+      bringUpAgentService({
+        config: STUB_CONFIG,
+        agentName: "bot",
+        switchroomHome: home,
+        stdio: "ignore",
+      }),
+    ).toThrow(/docker compose up failed/);
+
+    // The compose file MUST still have been persisted before the docker
+    // shellout — that's what makes a retry possible.
+    expect(existsSync(resolve(home, "compose", "docker-compose.yml"))).toBe(true);
+  });
+});
+
+describe("resolveSwitchroomHome", () => {
+  beforeEach(() => {
+    delete process.env.SWITCHROOM_HOME;
+  });
+
+  it("explicit > env > HOME-derived precedence", () => {
+    expect(resolveSwitchroomHome("/explicit")).toBe("/explicit");
+    process.env.SWITCHROOM_HOME = "/from-env";
+    expect(resolveSwitchroomHome()).toBe("/from-env");
+    delete process.env.SWITCHROOM_HOME;
+    expect(resolveSwitchroomHome()).toBe(resolve(process.env.HOME ?? "", ".switchroom"));
+  });
+});

--- a/src/agents/rename-orchestrator.test.ts
+++ b/src/agents/rename-orchestrator.test.ts
@@ -1,0 +1,245 @@
+/**
+ * Tests for {@link renameAgent} — happy-path rename, rollback when a
+ * mid-flight step throws, and the guard against renaming to an
+ * existing slug. PR-D1 / v0.7 coverage gap #1.
+ *
+ * The orchestrator exposes a thick `RenameAgentDeps` injection seam
+ * (loadConfig, stopAgent/startAgent, copyDir/removeDir/snapshotDir,
+ * vault open/save, reconcile). We exploit it: every external boundary
+ * is a vi.fn(), and we assert the rollback unwinds in reverse order
+ * when reconcile throws.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mkdtempSync, mkdirSync, writeFileSync, existsSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { renameAgent } from "./rename-orchestrator.js";
+import type { RenameAgentDeps } from "./rename-orchestrator.js";
+import type { SwitchroomConfig } from "../config/schema.js";
+
+function makeWorkspace(opts: { agents: string[] }): {
+  configPath: string;
+  agentsDir: string;
+} {
+  const root = mkdtempSync(join(tmpdir(), "rename-orch-"));
+  const agentsDir = join(root, "agents");
+  mkdirSync(agentsDir, { recursive: true });
+  for (const name of opts.agents) {
+    mkdirSync(join(agentsDir, name), { recursive: true });
+    writeFileSync(join(agentsDir, name, "marker.txt"), name);
+  }
+  const cfgPath = join(root, "switchroom.yaml");
+  // Use full block mapping so renameAgentInConfig (which reads the file
+  // directly with YAML.parseDocument) can find and rewrite the entry.
+  const lines = ["agents:"];
+  for (const name of opts.agents) {
+    lines.push(`  ${name}:`);
+    lines.push(`    extends: general`);
+    lines.push(`    topic_name: ${name[0]!.toUpperCase()}${name.slice(1)}`);
+  }
+  lines.push("");
+  writeFileSync(cfgPath, lines.join("\n"));
+  return { configPath: cfgPath, agentsDir };
+}
+
+function makeConfig(agentsDir: string, agents: string[]): SwitchroomConfig {
+  const agentEntries: Record<string, unknown> = {};
+  for (const n of agents) {
+    agentEntries[n] = { extends: "general", topic_name: n };
+  }
+  return {
+    switchroom: { agents_dir: agentsDir },
+    agents: agentEntries,
+    telegram: { forum_chat_id: "0" },
+    defaults: {},
+  } as unknown as SwitchroomConfig;
+}
+
+function makeDeps(
+  ws: { agentsDir: string; configPath?: string },
+  agentsAtLoad: string[],
+  overrides: Partial<RenameAgentDeps> = {},
+): RenameAgentDeps {
+  // Default loadConfig re-derives the agent list from the on-disk yaml
+  // each call, so a yaml mutation between calls (rename → reload) is
+  // observed correctly without per-test wiring.
+  const loadFromDisk = (cfgPath: string): SwitchroomConfig => {
+    if (!ws.configPath || !existsSync(ws.configPath)) {
+      return makeConfig(ws.agentsDir, agentsAtLoad);
+    }
+    void cfgPath;
+    const body = readFileSync(ws.configPath, "utf-8");
+    const matches = Array.from(body.matchAll(/^ {2}([a-z0-9][a-z0-9_-]*):/gm)).map((m) => m[1]!);
+    return makeConfig(ws.agentsDir, matches.length > 0 ? matches : agentsAtLoad);
+  };
+  return {
+    loadConfig: vi.fn((p: string) => loadFromDisk(p)),
+    resolveAgentsDir: vi.fn(() => ws.agentsDir),
+    stopAgent: vi.fn(),
+    startAgent: vi.fn(),
+    reconcileAgent: vi.fn(() => ({ changes: ["wrote .mcp.json"] })) as unknown as RenameAgentDeps["reconcileAgent"],
+    usesSwitchroomTelegramPlugin: vi.fn(() => true) as unknown as RenameAgentDeps["usesSwitchroomTelegramPlugin"],
+    resolveAgentConfig: vi.fn() as unknown as RenameAgentDeps["resolveAgentConfig"],
+    resolveTimezone: vi.fn() as unknown as RenameAgentDeps["resolveTimezone"],
+    snapshotDir: vi.fn((src: string) => `${src}.snap`),
+    copyDir: vi.fn((src: string, dst: string) => {
+      if (existsSync(src)) {
+        mkdirSync(dst, { recursive: true });
+        writeFileSync(
+          join(dst, "marker.txt"),
+          existsSync(join(src, "marker.txt"))
+            ? readFileSync(join(src, "marker.txt"), "utf-8")
+            : "",
+        );
+      } else {
+        mkdirSync(dst, { recursive: true });
+      }
+    }),
+    removeDir: vi.fn((p: string) => {
+      // Real removal so subsequent existsSync checks are accurate.
+      const fs = require("node:fs") as typeof import("node:fs");
+      try { fs.rmSync(p, { recursive: true, force: true }); } catch { /* */ }
+    }),
+    existsSync: (p: string) => existsSync(p),
+    readFileSync: (p: string, enc: BufferEncoding) => readFileSync(p, enc),
+    resolveVaultPath: vi.fn(() => "/dev/null/vault.enc"),
+    ...overrides,
+  };
+}
+
+describe("renameAgent", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    delete process.env.SWITCHROOM_VAULT_PASSPHRASE;
+  });
+
+  it("happy path: stops old, copies dir, updates yaml, reconciles, starts new", async () => {
+    const ws = makeWorkspace({ agents: ["fin"] });
+    const deps = makeDeps({ ...ws }, ["fin"]);
+
+    const result = await renameAgent(
+      { oldName: "fin", newName: "finn", configPath: ws.configPath },
+      deps,
+    );
+
+    expect(deps.stopAgent).toHaveBeenCalledWith("fin");
+    expect(deps.copyDir).toHaveBeenCalledWith(
+      join(ws.agentsDir, "fin"),
+      join(ws.agentsDir, "finn"),
+    );
+    expect(deps.reconcileAgent).toHaveBeenCalledOnce();
+    expect(deps.startAgent).toHaveBeenLastCalledWith("finn");
+
+    // yaml updated atomically: old key gone, new key present
+    const yamlBody = readFileSync(ws.configPath, "utf-8");
+    expect(yamlBody).toMatch(/\bfinn:/);
+    expect(yamlBody).not.toMatch(/^ {2}fin:/m);
+
+    expect(result.agentDir).toBe(join(ws.agentsDir, "finn"));
+    expect(result.reconcileChanges).toEqual(["wrote .mcp.json"]);
+  });
+
+  it("rollback: when reconcile throws, yaml is reverted and old agent dir is restored from snapshot", async () => {
+    const ws = makeWorkspace({ agents: ["fin"] });
+    let loadCount = 0;
+    const deps = makeDeps(ws, ["fin"], {
+      // First load returns just `fin`, post-yaml-update load returns `finn`.
+      loadConfig: vi.fn(() => {
+        loadCount += 1;
+        return makeConfig(ws.agentsDir, loadCount === 1 ? ["fin"] : ["finn"]);
+      }),
+      reconcileAgent: vi.fn(() => {
+        throw new Error("reconcile blew up: missing template");
+      }) as unknown as RenameAgentDeps["reconcileAgent"],
+    });
+
+    await expect(
+      renameAgent({ oldName: "fin", newName: "finn", configPath: ws.configPath }, deps),
+    ).rejects.toThrow(/reconcile blew up/);
+
+    // yaml rolled back: fin restored, finn gone
+    const yamlBody = readFileSync(ws.configPath, "utf-8");
+    expect(yamlBody).toMatch(/\bfin:/);
+    expect(yamlBody).not.toMatch(/\bfinn:/);
+
+    // dir restore: fin path back, finn path removed
+    expect(existsSync(join(ws.agentsDir, "fin"))).toBe(true);
+    expect(existsSync(join(ws.agentsDir, "finn"))).toBe(false);
+
+    // Best-effort restart of the old agent was attempted
+    expect(deps.startAgent).toHaveBeenCalledWith("fin");
+  });
+
+  it("guard: rejects rename when new name already exists in switchroom.yaml", async () => {
+    const ws = makeWorkspace({ agents: ["fin", "finn"] });
+    const deps = makeDeps(ws, ["fin", "finn"]);
+
+    await expect(
+      renameAgent({ oldName: "fin", newName: "finn", configPath: ws.configPath }, deps),
+    ).rejects.toThrow(/already defined in switchroom\.yaml/);
+
+    // No side-effects: stopAgent must NOT have been called for "fin"
+    expect(deps.stopAgent).not.toHaveBeenCalled();
+    expect(deps.copyDir).not.toHaveBeenCalled();
+  });
+
+  it("guard: rejects rename when target agent dir already exists on disk (no yaml entry yet)", async () => {
+    const ws = makeWorkspace({ agents: ["fin"] });
+    // Pre-create the target dir (operator partial-recovered) but NOT the yaml entry
+    mkdirSync(join(ws.agentsDir, "finn"), { recursive: true });
+    const deps = makeDeps({ ...ws }, ["fin"]);
+
+    await expect(
+      renameAgent({ oldName: "fin", newName: "finn", configPath: ws.configPath }, deps),
+    ).rejects.toThrow(/Directory already exists at target path/);
+
+    expect(deps.copyDir).not.toHaveBeenCalled();
+  });
+
+  it("guard: rejects identical old/new names", async () => {
+    const ws = makeWorkspace({ agents: ["fin"] });
+    const deps = makeDeps({ ...ws }, ["fin"]);
+
+    await expect(
+      renameAgent({ oldName: "fin", newName: "fin", configPath: ws.configPath }, deps),
+    ).rejects.toThrow(/Old and new names are the same/);
+  });
+
+  it("guard: rejects invalid new-name slug before any work", async () => {
+    const ws = makeWorkspace({ agents: ["fin"] });
+    const deps = makeDeps({ ...ws }, ["fin"]);
+
+    await expect(
+      renameAgent({ oldName: "fin", newName: "BadName!", configPath: ws.configPath }, deps),
+    ).rejects.toThrow(/Invalid new agent name/);
+
+    expect(deps.loadConfig).not.toHaveBeenCalled();
+  });
+
+  it("guard: rejects when old agent isn't in switchroom.yaml", async () => {
+    const ws = makeWorkspace({ agents: ["fin"] });
+    const deps = makeDeps({ ...ws }, ["fin"]);
+
+    await expect(
+      renameAgent({ oldName: "ghost", newName: "spectre", configPath: ws.configPath }, deps),
+    ).rejects.toThrow(/not defined in switchroom\.yaml/);
+  });
+
+  it("hindsight=preserve (default) is a no-op; unsupported modes throw", async () => {
+    const ws = makeWorkspace({ agents: ["fin"] });
+    const deps = makeDeps({ ...ws }, ["fin"]);
+
+    await expect(
+      renameAgent(
+        {
+          oldName: "fin",
+          newName: "finn",
+          configPath: ws.configPath,
+          hindsightMode: "migrate" as never,
+        },
+        deps,
+      ),
+    ).rejects.toThrow(/Unsupported --hindsight mode/);
+  });
+});

--- a/src/agents/scaffold.test.ts
+++ b/src/agents/scaffold.test.ts
@@ -25,23 +25,31 @@ vi.mock("node:fs", async () => {
     ...actual,
     existsSync: vi.fn(() => true),
     statSync: vi.fn(),
+    appendFileSync: vi.fn(),
+    mkdirSync: vi.fn(),
   };
 });
 
 // Imports MUST come after vi.mock so the mocks are applied.
 import { execFileSync } from "node:child_process";
-import { existsSync, statSync } from "node:fs";
+import { existsSync, statSync, appendFileSync, mkdirSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
 import { alignAgentUid } from "./scaffold.js";
 
 const mockedExecFileSync = vi.mocked(execFileSync);
 const mockedExistsSync = vi.mocked(existsSync);
 const mockedStatSync = vi.mocked(statSync);
+const mockedAppendFileSync = vi.mocked(appendFileSync);
+const mockedMkdirSync = vi.mocked(mkdirSync);
 
 describe("alignAgentUid", () => {
   beforeEach(() => {
     mockedExecFileSync.mockReset();
     mockedExistsSync.mockReset();
     mockedStatSync.mockReset();
+    mockedAppendFileSync.mockReset();
+    mockedMkdirSync.mockReset();
     mockedExistsSync.mockReturnValue(true);
   });
 
@@ -153,5 +161,62 @@ describe("alignAgentUid", () => {
     expect(res.chowned).toBe(false);
     expect(res.paths).toEqual([]);
     expect(mockedExecFileSync).not.toHaveBeenCalled();
+  });
+
+  // PR-D1 / v0.7 coverage gap #4 — when alignAgentUid actually shells
+  // chown, it must record the prior owner of the top-level dir to
+  // ~/.switchroom/.uid-alignment.log so a future rollback can restore
+  // exact ownership without guessing.
+  it("appends `<iso-ts> <dir> <prior-uid>:<prior-gid> -> <new>:<new>` to .uid-alignment.log when prior owner differs", () => {
+    mockedStatSync.mockReturnValue({ uid: 1000, gid: 1000 } as never);
+    mockedExecFileSync.mockImplementationOnce(() => Buffer.from(""));
+
+    alignAgentUid("agent", "/fake/state/agent", 10042, {
+      writeOut: () => {},
+      confirm: false,
+    });
+
+    expect(mockedAppendFileSync).toHaveBeenCalledOnce();
+    const [logPath, line] = mockedAppendFileSync.mock.calls[0]!;
+    expect(logPath).toBe(join(homedir(), ".switchroom", ".uid-alignment.log"));
+    expect(typeof line).toBe("string");
+    // Shape: <iso-ts> <dir> <prior-uid>:<prior-gid> -> <new>:<new>\n
+    expect(line as string).toMatch(
+      /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z \/fake\/state\/agent 1000:1000 -> 10042:10042\n$/,
+    );
+
+    // The log dir must be ensured ahead of the append (ENOENT-safe).
+    expect(mockedMkdirSync).toHaveBeenCalledWith(
+      join(homedir(), ".switchroom"),
+      expect.objectContaining({ recursive: true }),
+    );
+  });
+
+  it("does NOT append a log line when prior owner already matches the target uid (no work to record)", () => {
+    mockedStatSync.mockReturnValue({ uid: 10042, gid: 10042 } as never);
+    mockedExecFileSync.mockImplementationOnce(() => Buffer.from(""));
+
+    alignAgentUid("agent", "/fake/state/agent", 10042, {
+      writeOut: () => {},
+      confirm: false,
+    });
+
+    expect(mockedAppendFileSync).not.toHaveBeenCalled();
+  });
+
+  it("appendFileSync failures never block the chown (best-effort audit)", () => {
+    mockedStatSync.mockReturnValue({ uid: 1000, gid: 1000 } as never);
+    mockedAppendFileSync.mockImplementation(() => {
+      throw new Error("ENOSPC: disk full");
+    });
+    mockedExecFileSync.mockImplementationOnce(() => Buffer.from(""));
+
+    const res = alignAgentUid("agent", "/fake/state/agent", 10042, {
+      writeOut: () => {},
+      confirm: false,
+    });
+
+    expect(res.chowned).toBe(true);
+    expect(mockedExecFileSync).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/cli/deprecated.test.ts
+++ b/src/cli/deprecated.test.ts
@@ -1,6 +1,27 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { Command } from "commander";
 import { registerUpCommand, registerInitCommand } from "./deprecated.js";
+import { registerUpdateCommand } from "./update.js";
+
+vi.mock("./apply.js", () => ({
+  runApply: vi.fn().mockResolvedValue({ composePath: "/tmp/dc.yml", composeBytes: 10 }),
+}));
+
+vi.mock("../config/loader.js", async () => {
+  const actual = await vi.importActual<typeof import("../config/loader.js")>("../config/loader.js");
+  return {
+    ...actual,
+    loadConfig: vi.fn(() => ({
+      switchroom: { agents_dir: "/tmp/agents" },
+      agents: {},
+      telegram: { forum_chat_id: "0" },
+      defaults: {},
+    })),
+    findConfigFile: vi.fn(() => "/tmp/switchroom.yaml"),
+  };
+});
+
+import { runApply } from "./apply.js";
 
 /**
  * Smoke tests — make sure the deprecation shims register cleanly and
@@ -32,5 +53,109 @@ describe("deprecation shims", () => {
     expect(flags).toContain("--build-local");
     expect(flags).toContain("--out");
     expect(init!.description()).toMatch(/deprecated/i);
+  });
+});
+
+// ─── PR-D1 / v0.7 coverage gap #5 ────────────────────────────────────────────
+// Exit-code + delegation assertions for the deprecation shims.
+
+describe("`up` and `init` delegate to runApply with a yellow deprecation warning", () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+  let errSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+    errSpy.mockRestore();
+  });
+
+  it("`up` prints a yellow `deprecated` warning and forwards to runApply", async () => {
+    const program = new Command();
+    program.exitOverride();
+    registerUpCommand(program);
+    await program.parseAsync(["node", "switchroom", "up"]);
+
+    // Warning printed (chalk yellow leaves the text intact)
+    expect(warnSpy).toHaveBeenCalled();
+    const banner = warnSpy.mock.calls.map((c) => String(c[0])).join("\n");
+    expect(banner).toMatch(/switchroom up is deprecated/);
+    expect(banner).toMatch(/use `switchroom apply`/);
+    expect(runApply).toHaveBeenCalledOnce();
+  });
+
+  it("`init` prints a yellow `deprecated` warning and forwards to runApply, threading --example", async () => {
+    const program = new Command();
+    program.exitOverride();
+    registerInitCommand(program);
+    await program.parseAsync(["node", "switchroom", "init", "--example", "minimal"]);
+
+    expect(warnSpy.mock.calls.map((c) => String(c[0])).join("\n")).toMatch(
+      /switchroom init is deprecated/,
+    );
+    expect(runApply).toHaveBeenCalledOnce();
+    const applyCall = (runApply as any).mock.calls[0]!;
+    // Second arg is the apply opts; we threaded --example through.
+    expect(applyCall[1]).toMatchObject({ example: "minimal" });
+  });
+});
+
+describe("`update` removed-shim exit codes", () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+  let errSpy: ReturnType<typeof vi.spyOn>;
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    exitSpy = vi.spyOn(process, "exit").mockImplementation(((_code?: number) => {
+      throw new Error(`__exit_${_code ?? 0}`);
+    }) as never);
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+    errSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+
+  it("`update` (no flags) exits 1 with the docker recipe in stderr", async () => {
+    const program = new Command();
+    program.exitOverride();
+    registerUpdateCommand(program);
+
+    await expect(program.parseAsync(["node", "switchroom", "update"])).rejects.toThrow(
+      /__exit_1/,
+    );
+
+    const errBanner = errSpy.mock.calls.map((c) => String(c[0])).join("\n");
+    expect(errBanner).toMatch(/switchroom update is removed in v0\.7/);
+    expect(errBanner).toMatch(/docker compose .* pull/);
+    expect(errBanner).toMatch(/switchroom apply/);
+    expect(errBanner).toMatch(/docker compose .* up -d/);
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it("`update --phase=post-build` exits 0 with the `no longer supported, restart manually` notice", async () => {
+    const program = new Command();
+    program.exitOverride();
+    registerUpdateCommand(program);
+
+    await expect(
+      program.parseAsync(["node", "switchroom", "update", "--phase", "post-build"]),
+    ).rejects.toThrow(/__exit_0/);
+
+    const warnBanner = warnSpy.mock.calls.map((c) => String(c[0])).join("\n");
+    expect(warnBanner).toMatch(/post-build/);
+    expect(warnBanner).toMatch(/no longer supported/);
+    expect(warnBanner).toMatch(/Restart manually/);
+    expect(exitSpy).toHaveBeenCalledWith(0);
+    // Crucially, the red error banner must NOT have fired in this branch.
+    expect(errSpy).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

Tests-only PR. Closes four v0.7 test-coverage gaps surfaced by the coverage audit. Zero production-code changes.

## Gaps closed

- **Gap #1 — `create-orchestrator` end-to-end with rollback** (`src/agents/create-orchestrator.test.ts`, +293 lines, 8 tests)
  - happy path: token validate → yaml entry → scaffold → env → auth-session
  - rollback-on-failure: yaml entry + agent dir reverted when `startAuthSession` throws and `rollbackOnFail=true`
  - rollback-on-failure: side-effects preserved when `rollbackOnFail=false` (retry path)
  - idempotent re-run: re-invoke with same profile succeeds
  - guard: re-run with different profile rejected (would mutate extends silently)
  - guard: invalid slug + unknown profile + bot-token validation failure all abort before any disk writes

- **Gap #1 — `rename-orchestrator` end-to-end with rollback** (`src/agents/rename-orchestrator.test.ts`, +245 lines, 8 tests)
  - happy path: stop/copy/yaml/reconcile/start sequence end-to-end
  - rollback: yaml reverted + dir restored from snapshot + best-effort restart of old agent when reconcile throws
  - guard: rejects rename when target name already in yaml
  - guard: rejects when target dir already exists on disk (operator partial-recovery)
  - guard: identical old/new name + invalid new-name slug + missing source agent
  - guard: unsupported `--hindsight` mode rejected loudly
  - All external boundaries injected via the existing `RenameAgentDeps` seam

- **Gap #2 — `bringUpAgentService` unit** (`src/agents/docker-fleet.test.ts`, +179 lines, 7 tests)
  - asserts compose-write happens with `homeDir: homedir()` (PR-A1 fix)
  - asserts file mode `0o600` on the persisted compose YAML
  - asserts exact docker shellout argv: `docker compose -f <path> up -d --no-deps agent-<name>`
  - asserts docker failure path propagates the error (compose file still written for retry)
  - covers `dockerBin` override + `generateComposeContent` injection + `resolveSwitchroomHome` precedence

- **Gap #4 — `scaffold.ts` prior-UID-logged-for-rollback** (`src/agents/scaffold.test.ts`, +60 lines, 3 new tests)
  - asserts `~/.switchroom/.uid-alignment.log` gets `<iso-ts> <dir> <prior-uid>:<prior-gid> -> <new>:<new>` line appended when `alignAgentUid` chowns
  - asserts no log line written when prior owner already matches target
  - asserts `appendFileSync` failures never block the chown (best-effort audit)

- **Gap #5 — `deprecated.ts` exit-code assertions** (`src/cli/deprecated.test.ts`, +132 lines, 4 new tests)
  - `update` (no flags) exits 1 with the docker recipe in stderr
  - `update --phase=post-build` exits 0 with `no longer supported, restart manually` notice
  - `up` and `init` print yellow deprecation warning + delegate to `runApply` (verified via spy + `--example` threading)

## Validation

- `bun run build` — green
- `npm run lint` — clean
- `bun run test:vitest 2>&1 | grep '^ FAIL '` — strict subset of `tests/.baseline-failures.txt` (only the two pre-existing docker/* baseline failures remain, both unrelated to this PR)

## Test plan

- [x] `bun run test:vitest src/agents/create-orchestrator.test.ts` — 8/8 pass
- [x] `bun run test:vitest src/agents/rename-orchestrator.test.ts` — 8/8 pass
- [x] `bun run test:vitest src/agents/docker-fleet.test.ts` — 7/7 pass
- [x] `bun run test:vitest src/agents/scaffold.test.ts` — 9/9 pass (3 new + 6 existing)
- [x] `bun run test:vitest src/cli/deprecated.test.ts` — 6/6 pass (4 new + 2 existing)