### PR TITLE
fix(compose): mount switchroom.yaml into broker/kernel/scheduler containers (P0 v0.7 hotfix)

### DIFF
--- a/src/agents/compose.ts
+++ b/src/agents/compose.ts
@@ -127,6 +127,20 @@ export interface ComposeGeneratorOptions {
    * been updated yet (defaults to `${HOME}` interpolation).
    */
   homeDir?: string;
+  /**
+   * Absolute host path to the switchroom.yaml the operator wants the
+   * containerised broker / kernel / scheduler to load. Bind-mounted
+   * read-only into each of those services at /state/config/switchroom.yaml,
+   * with `SWITCHROOM_CONFIG=/state/config/switchroom.yaml` set so they
+   * skip the cwd auto-detect that doesn't exist inside the container.
+   *
+   * Without this, broker boots with `ConfigError: No switchroom.yaml found`
+   * and restart-loops — the v0.7 P0 install-path bug. Optional for
+   * back-compat; if omitted, broker / kernel get no config mount and
+   * scheduler keeps its legacy `~/.switchroom:/state/config:ro` directory
+   * mount (back-compat with pre-fix generated compose).
+   */
+  switchroomConfigPath?: string;
 }
 
 /** Resolve the image ref for one of the four service images. */
@@ -214,6 +228,7 @@ export function generateCompose(opts: ComposeGeneratorOptions): string {
   // preserves the older `${HOME}` shape for callers that haven't been
   // updated.
   const homePrefix = opts.homeDir ?? "${HOME}";
+  const switchroomConfigPath = opts.switchroomConfigPath;
   if (buildMode === "local" && !buildContext) {
     throw new Error(
       `compose: buildMode="local" requires buildContext (the absolute path to the switchroom checkout)`,
@@ -260,10 +275,16 @@ export function generateCompose(opts: ComposeGeneratorOptions): string {
   lines.push(`      - "CHOWN"`);
   lines.push(`      - "FOWNER"`);
   lines.push(`    environment:`);
+  if (switchroomConfigPath) {
+    lines.push(`      SWITCHROOM_CONFIG: /state/config/switchroom.yaml`);
+  }
   lines.push(`      SWITCHROOM_VAULT_BROKER_AUTO_UNLOCK_PATH: /state/vault-auto-unlock`);
   lines.push(`    volumes:`);
   for (const a of describeAgents(config)) {
     lines.push(`      - broker-${a.name}-sock:/run/switchroom/broker/${a.name}`);
+  }
+  if (switchroomConfigPath) {
+    lines.push(`      - ${switchroomConfigPath}:/state/config/switchroom.yaml:ro`);
   }
   lines.push(`      - ${homePrefix}/.switchroom/vault:/state/vault`);
   // Auto-unlock blob (encrypted with /etc/machine-id-derived key).
@@ -297,9 +318,16 @@ export function generateCompose(opts: ComposeGeneratorOptions): string {
   lines.push(`    cap_add:`);
   lines.push(`      - "CHOWN"`);
   lines.push(`      - "FOWNER"`);
+  if (switchroomConfigPath) {
+    lines.push(`    environment:`);
+    lines.push(`      SWITCHROOM_CONFIG: /state/config/switchroom.yaml`);
+  }
   lines.push(`    volumes:`);
   for (const a of describeAgents(config)) {
     lines.push(`      - kernel-${a.name}-sock:/run/switchroom/kernel/${a.name}`);
+  }
+  if (switchroomConfigPath) {
+    lines.push(`      - ${switchroomConfigPath}:/state/config/switchroom.yaml:ro`);
   }
   lines.push(`      - ${homePrefix}/.switchroom/approvals:/state/approvals`);
   lines.push(``);
@@ -323,7 +351,15 @@ export function generateCompose(opts: ComposeGeneratorOptions): string {
   // which is a write op against the daemon API. Read-only would
   // silently break dispatch with cryptic permission errors.
   lines.push(`      - /var/run/docker.sock:/var/run/docker.sock`);
-  lines.push(`      - ${homePrefix}/.switchroom:/state/config:ro`);
+  if (switchroomConfigPath) {
+    // Bind-mount the resolved config file directly so the scheduler
+    // boots regardless of where the operator keeps switchroom.yaml.
+    // Without this, scheduler only finds the file when it lives under
+    // ~/.switchroom/ — same install-path bug that bit the broker.
+    lines.push(`      - ${switchroomConfigPath}:/state/config/switchroom.yaml:ro`);
+  } else {
+    lines.push(`      - ${homePrefix}/.switchroom:/state/config:ro`);
+  }
   lines.push(`      - ${homePrefix}/.switchroom/scheduler:/state/scheduler`);
   lines.push(`    environment:`);
   lines.push(`      SWITCHROOM_CONFIG: /state/config/switchroom.yaml`);

--- a/src/cli/apply.ts
+++ b/src/cli/apply.ts
@@ -260,6 +260,11 @@ export async function runApply(
     // Bake the operator's HOME absolute path into volume sources at
     // apply time. Avoids `${HOME}` resolving to /root under sudo.
     homeDir: homedir(),
+    // Bind-mount the resolved switchroom.yaml directly into the broker,
+    // approval-kernel, and scheduler containers so they don't restart-loop
+    // on `ConfigError: No switchroom.yaml found` when the operator's
+    // config lives outside ~/.switchroom (v0.7 P0 install-path bug).
+    switchroomConfigPath,
   });
   await mkdir(dirname(composePath), { recursive: true });
   await writeFile(composePath, composeContent, {

--- a/tests/docker/compose-generator.test.ts
+++ b/tests/docker/compose-generator.test.ts
@@ -361,6 +361,64 @@ describe("agent service env (Phase 2c F2 — IPC wiring)", () => {
   });
 });
 
+describe("generateCompose — switchroomConfigPath bind-mount (v0.7 P0 fix)", () => {
+  // Regression: without the config bind-mount, the broker container boots
+  // with `ConfigError: No switchroom.yaml found` and restart-loops. The
+  // fix bind-mounts the resolved switchroom.yaml into broker, kernel, and
+  // scheduler at /state/config/switchroom.yaml, with SWITCHROOM_CONFIG
+  // pointing at it so the in-container loader skips its cwd auto-detect.
+  const CONFIG = "/home/op/switchroom.yaml";
+
+  function blockFor(yml: string, service: string): string {
+    const re = new RegExp(`  ${service}:[\\s\\S]*?(?=\\n  [a-z]|\\nvolumes:)`);
+    return re.exec(yml)?.[0] ?? "";
+  }
+
+  it("bind-mounts switchroom.yaml + sets SWITCHROOM_CONFIG on the broker", () => {
+    const out = generateCompose({
+      config: makeConfig({ a: {} }),
+      switchroomConfigPath: CONFIG,
+    });
+    const block = blockFor(out, "vault-broker");
+    expect(block).toContain(`${CONFIG}:/state/config/switchroom.yaml:ro`);
+    expect(block).toMatch(/SWITCHROOM_CONFIG:\s*\/state\/config\/switchroom\.yaml/);
+  });
+
+  it("bind-mounts switchroom.yaml + sets SWITCHROOM_CONFIG on the approval-kernel", () => {
+    const out = generateCompose({
+      config: makeConfig({ a: {} }),
+      switchroomConfigPath: CONFIG,
+    });
+    const block = blockFor(out, "approval-kernel");
+    expect(block).toContain(`${CONFIG}:/state/config/switchroom.yaml:ro`);
+    expect(block).toMatch(/SWITCHROOM_CONFIG:\s*\/state\/config\/switchroom\.yaml/);
+  });
+
+  it("bind-mounts switchroom.yaml as a file on the scheduler (not the dir)", () => {
+    const out = generateCompose({
+      config: makeConfig({ a: {} }),
+      switchroomConfigPath: CONFIG,
+    });
+    const block = blockFor(out, "switchroom-cron");
+    expect(block).toContain(`${CONFIG}:/state/config/switchroom.yaml:ro`);
+    // The legacy directory mount must be replaced when the explicit
+    // file path is provided, otherwise both compete for /state/config.
+    expect(block).not.toMatch(/\.switchroom:\/state\/config:ro/);
+    expect(block).toMatch(/SWITCHROOM_CONFIG:\s*\/state\/config\/switchroom\.yaml/);
+  });
+
+  it("back-compat: omitting switchroomConfigPath leaves broker/kernel without the mount", () => {
+    const out = generateCompose({ config: makeConfig({ a: {} }) });
+    const broker = blockFor(out, "vault-broker");
+    expect(broker).not.toContain(":/state/config/switchroom.yaml");
+    const kernel = blockFor(out, "approval-kernel");
+    expect(kernel).not.toContain(":/state/config/switchroom.yaml");
+    // Scheduler keeps its legacy directory mount in back-compat mode.
+    const sched = blockFor(out, "switchroom-cron");
+    expect(sched).toMatch(/\.switchroom:\/state\/config:ro/);
+  });
+});
+
 describe("generateCompose — buildMode (pull vs local)", () => {
   it("default mode emits ghcr.io image refs and no build: blocks", () => {
     const out = generateCompose({ config: makeConfig({ alice: {} }) });


### PR DESCRIPTION
## Bug

`switchroom apply && docker compose up -d` produces a broken broker that restart-loops with `ConfigError: No switchroom.yaml found`. PR-D2's e2e test caught it on the v0.7 install path. Blocks the v0.7 cutover.

## Root cause

`generateCompose()` only mounted `~/.switchroom:/state/config:ro` on the scheduler. The `vault-broker` and `approval-kernel` services had no config bind-mount and no `SWITCHROOM_CONFIG` env var, so when their `main()` called `loadConfig()` the loader's search path (`$SWITCHROOM_CONFIG` -> cwd -> `~/.switchroom/`) found nothing inside the container.

The scheduler ALSO broke whenever the operator's `switchroom.yaml` lived outside `~/.switchroom/` (e.g. checked into a project repo, or just `cwd`-only after `switchroom apply` in a fresh checkout) — its `~/.switchroom:/state/config:ro` directory mount silently resolves to an empty dir.

## Why Phase 2 broker tests didn't catch it

The Phase 2a/2b broker IPC tests hand-roll their own compose YAML and explicitly bind-mount `${configPath}:/state/config/switchroom.yaml:ro` with `SWITCHROOM_CONFIG=/state/config/switchroom.yaml` set (see `tests/docker/phase2a-broker-ipc.test.ts:250-251`). They never exercised `generateCompose()`'s output, so the install-path gap stayed invisible until PR-D2 went end-to-end.

## Fix

- Thread the resolved `switchroom.yaml` host path through `runApply` -> `generateCompose` as a new optional `switchroomConfigPath` option.
- Bind-mount that file read-only at `/state/config/switchroom.yaml` on broker, kernel, and scheduler.
- Set `SWITCHROOM_CONFIG=/state/config/switchroom.yaml` on broker and kernel (scheduler env already pointed at the same in-container path).
- Replace scheduler's `~/.switchroom:/state/config:ro` directory mount with the explicit file mount when `switchroomConfigPath` is provided, so scheduler also works when config lives outside `~/.switchroom/`. Back-compat path keeps the legacy directory mount when the option is omitted.
- Add a `generateCompose — switchroomConfigPath bind-mount (v0.7 P0 fix)` test block in `tests/docker/compose-generator.test.ts` asserting the mount + env on each of the three services, plus the back-compat shape.

## Validation

- `bun run build`: clean
- `npm run lint`: clean
- `bun run test:vitest`: 5027 passed; 2 failing files (`broker-ipc-race`, `per-agent-isolation`) — both pre-existing entries in `tests/.baseline-failures.txt`. No new failures introduced.

## Test plan

- [x] Unit: 4 new tests for broker / kernel / scheduler mount + env, plus back-compat assertion
- [x] Existing 36 compose-generator tests still pass
- [ ] Manual: `switchroom apply && docker compose up -d` against a fresh host (deferred to klanker)

🤖 Generated with [Claude Code](https://claude.com/claude-code)