### PR TITLE
docs: comprehensive v0.7 sweep — README + operator docs + JTBD + skills

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -189,8 +189,10 @@ your work affects the CLI, the telegram-plugin, or scaffolded assets,
 expect a `switchroom agent restart all` to be part of verification.
 
 Since PR #59, `switchroom agent restart` always runs reconcile first
-(regenerating systemd units + daemon-reload if changed). So a restart is
-also a mini-deploy of any scaffold changes.
+(regenerating the per-agent scaffold + the compose file if changed). So
+a restart is also a mini-deploy of any scaffold changes — under the
+hood it re-emits `~/.switchroom/compose/docker-compose.yml` and bounces
+the affected container(s) via `docker compose up -d`.
 
 ### Install paths
 

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ The wedge against OpenClaw and NanoClaw isn't the substrate — it's the stock `
 
 ## Install
 
-Runs on the box you already have. The supported production runtime is Linux + Docker (Ubuntu 24.04 LTS with 4GB RAM is the canonical target; other Linux distros work with minor tweaks). `switchroom apply` scaffolds every agent and writes a `docker-compose.yml` from your `switchroom.yaml`; you bring the fleet up yourself with `docker compose -p switchroom -f ~/.switchroom/compose/docker-compose.yml up -d`. Linux is the only supported production target; macOS (Docker Desktop) is tracked as Phase 3.5 and not yet validated.
+Runs on the box you already have. The supported production runtime is Linux + Docker (Ubuntu 24.04 LTS with 4GB RAM is the canonical target; other Linux distros work with minor tweaks). `switchroom apply` scaffolds every agent and writes a `docker-compose.yml` from your `switchroom.yaml`; you bring the fleet up yourself with `docker compose -p switchroom -f ~/.switchroom/compose/docker-compose.yml up -d`. Five published images on GHCR (`switchroom-base`, `switchroom-agent`, `switchroom-broker`, `switchroom-kernel`, `switchroom-scheduler`) — no `docker build` on the operator's host. macOS (Docker Desktop) works for development but is not yet release-validated.
 
 > **Heads up on the package name.** The npm package was originally `switchroom-ai`. It's now just `switchroom`. The old name is deprecated and will stop receiving updates — `npm install -g switchroom` is the current path.
 
@@ -217,8 +217,8 @@ switchroom:
   version: 1
 
 telegram:
+  # Per-agent bot token (DM-only by default).
   bot_token: "vault:telegram-bot-token"
-  forum_chat_id: "-1001234567890"
 
 memory:
   backend: hindsight
@@ -421,7 +421,7 @@ Overlay entries win on collision with built-in defaults. Unknown files that appe
 | **[Vault](docs/vault.md)** | Architecture, per-cron secrets, ACL, audit log, threat model |
 | **[Telegram Plugin](docs/telegram-plugin.md)** | Progress cards, 15 MCP tools, native checklists, sticker aliases, voice-in |
 | **[Sub-Agents](docs/sub-agents.md)** | Model routing, delegation patterns, frontmatter spec |
-| **[Scheduling](docs/scheduling.md)** | Cron tasks, systemd timers, model selection |
+| **[Scheduling](docs/scheduling.md)** | Cron tasks (per-agent scheduler container), model selection |
 | **[Session Management](docs/session-optimization.md)** | Continuity, compaction, freshness policy |
 | **[OpenClaw alternative](docs/vs-openclaw.md)** | Switchroom vs OpenClaw |
 | **[NanoClaw alternative](docs/vs-nanoclaw.md)** | Switchroom vs NanoClaw |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,27 +2,32 @@
 
 ## The short version
 
-One Claude Code REPL per agent, dressed up with systemd and a Telegram bot. Each agent is an unmodified `claude` CLI process running interactively under systemd, with a separate long-lived gateway process that owns the Telegram connection. Everything else — memory, MCP tools, scheduling — layers on top of that pair.
+One Claude Code REPL per agent, dressed up with Docker Compose and a Telegram bot. Each agent is an unmodified `claude` CLI process running interactively inside its own container, with a separate long-lived gateway process that owns the Telegram connection. Everything else — memory, MCP tools, scheduling — layers on top of that pair.
+
+The v0.7+ runtime is Docker on Linux. The legacy systemd path was removed in v0.7 (see [`operators/migration-v0.7.md`](operators/migration-v0.7.md)).
 
 ---
 
-## Per-agent process model (two systemd units)
+## Per-agent process model (containers)
 
-### `switchroom-<agent>.service` — the brain
+A switchroom fleet is a small set of containers wired together by a generated `docker-compose.yml` (`~/.switchroom/compose/docker-compose.yml`). Five published images on GHCR cover the whole stack:
 
-Runs the Claude Code CLI session. The unit's `ExecStart` is:
+- `ghcr.io/switchroom/switchroom-base` — shared base layer
+- `ghcr.io/switchroom/switchroom-agent` — the per-agent claude REPL
+- `ghcr.io/switchroom/switchroom-broker` — vault broker (cron secrets)
+- `ghcr.io/switchroom/switchroom-kernel` — approval kernel
+- `ghcr.io/switchroom/switchroom-scheduler` — per-agent cron container
 
-```
-/usr/bin/script -qfc "/usr/bin/expect -f bin/autoaccept.exp ~/.switchroom/agents/<agent>/start.sh" <logFile>
-```
+Per agent, compose brings up:
 
-The layers:
+- `switchroom-<agent>` — the agent container (claude REPL + gateway + telegram MCP, single-spine process tree under `tini` as PID 1).
+- `switchroom-<agent>-scheduler` — cron container for that agent's scheduled tasks.
 
-- **`script`** — allocates a PTY and writes a full-fidelity terminal log. Required because `claude` expects an interactive terminal; also enables log-based token-detection during auth.
-- **`expect`** (via `bin/autoaccept.exp`) — handles the one-time TUI dialogs Claude Code shows on first run (theme picker, trust-folder prompt, `--dangerously-load-development-channels` acknowledgement) so headless systemd launches don't block on keyboard input. It does NOT auto-accept per-tool permission prompts — those still route through the Telegram inline-button approval flow when the agent hits one mid-turn. `expect` then launches `/bin/bash -l start.sh` internally.
-- **`start.sh`** — thin wrapper that sets environment variables, then `exec`s the `claude` binary.
+Plus one shared service per host: `switchroom-broker` (vault). All containers run with `restart: unless-stopped` and a healthcheck. Compose is the supervisor — a crashed agent is brought back automatically.
 
-`start.sh` invokes claude with flags like:
+### Inside the agent container
+
+The container's entrypoint is the agent's `start.sh`, run as PID 1's child under `tini`. `start.sh` invokes claude with flags like:
 
 ```bash
 exec claude \
@@ -36,28 +41,28 @@ exec claude \
 Key flags:
 
 - `--continue` — passed conditionally. Under `session_continuity.resume_mode: auto` (default), it's set only when the transcript exists, is under the configured size cap (default 2 MB), and is under 7 days old — so long-running agents pick up where they left off, but stale or oversized transcripts start fresh. Under `resume_mode: continue` it's always set; under `handoff` or `none` it's never set (the agent starts cold, optionally with a handoff briefing). See `profiles/_base/start.sh.hbs` for the exact logic.
-- `--dangerously-load-development-channels server:switchroom-telegram` — loads the switchroom Telegram MCP as a development channel. Operators can swap this for `--channels plugin:telegram@claude-plugins-official` per-agent.
+- `--dangerously-load-development-channels server:switchroom-telegram` — loads the switchroom Telegram MCP as a development channel.
 - `--plugin-dir` — points at the agent's local plugin directory.
 - `--append-system-prompt` — injects the stable workspace bootstrap block (SOUL.md, AGENTS.md, TOOLS.md, etc.) at session start.
 
 Environment variables set before exec:
 
-- `CLAUDE_CONFIG_DIR` — pinned to `~/.switchroom/agents/<agent>/.claude/`. Fully isolates each agent's auth, settings, transcripts, and MCP config from every other agent and from the user's personal Claude setup.
-- `CLAUDE_CODE_OAUTH_TOKEN` — populated from the active slot file (`accounts/<slot>/.oauth-token`) for multi-account rotation. Claude Code reads this env var and uses it in place of the credentials file when set.
+- `CLAUDE_CONFIG_DIR` — pinned to `/agent/.claude/` (the agent's per-container config dir, host-mounted from `~/.switchroom/agents/<agent>/.claude/`). Fully isolates each agent's auth, settings, transcripts, and MCP config from every other agent and from the user's personal Claude setup.
+- `CLAUDE_CODE_OAUTH_TOKEN` — populated from the active slot or shared Anthropic account.
 
-This is an **interactive REPL**, not `claude -p`. The session is persistent and long-lived, conditionally resumed across restarts via `--continue` (see flag description above).
+This is an **interactive REPL**, not `claude -p`. The session is persistent and long-lived, conditionally resumed across container restarts via `--continue`.
 
-### `switchroom-<agent>-gateway.service` — the mouth
+### The gateway
 
-A Bun process running `telegram-plugin/gateway/gateway.ts`. Responsibilities:
+A Bun process (`telegram-plugin/gateway/gateway.ts`) runs alongside the claude REPL inside the same agent container. Responsibilities:
 
 - Owns the Telegram Bot API polling loop (long-poll, persistent connection)
-- Listens on a Unix domain socket at `~/.switchroom/agents/<agent>/telegram/gateway.sock`
+- Listens on a Unix domain socket at `/agent/telegram/gateway.sock`
 - Buffers inbound Telegram messages in SQLite while Claude is down or restarting
 - Handles auth gating (`access.json`), admin commands, permission prompts forwarded from claude, and progress card lifecycle
 - Routes outbound messages from the switchroom-telegram MCP back to Telegram
 
-The gateway is intentionally decoupled from the Claude process so that Telegram connectivity survives Claude crashes, OOM kills, and scheduled restarts.
+The gateway is intentionally decoupled from the Claude process so that Telegram connectivity survives Claude crashes, OOM kills, and scheduled restarts inside the container.
 
 ---
 
@@ -81,15 +86,15 @@ Outbound path:
     -> message delivered to user
 ```
 
-The MCP child never makes direct HTTP calls to Telegram — all Telegram API calls go through the gateway. This keeps the socket boundary clean and lets the gateway handle rate limiting, error retry, and message buffering in one place.
+The MCP child never makes direct HTTP calls to Telegram — all Telegram API calls go through the gateway.
 
 ---
 
-## Why two processes
+## Why two processes inside the container
 
 - **Survival across Claude restarts.** The gateway must stay alive when Claude exits (OOM, crash, scheduled compaction restart). If polling lived inside claude, every restart would drop the Telegram connection and lose in-flight messages.
-- **Message buffering.** The gateway's SQLite buffer holds inbound messages while claude is down. When claude restarts via `--continue`, the MCP child drains the buffer and presents the queued messages as a new turn.
-- **Separation of concerns.** The gateway handles all Telegram I/O (polling, rate limits, retries, bot-API quirks). Claude handles all inference. Neither needs to know the internals of the other.
+- **Message buffering.** The gateway's SQLite buffer holds inbound messages while claude is down. When claude restarts via `--continue`, the MCP child drains the buffer.
+- **Separation of concerns.** The gateway handles all Telegram I/O. Claude handles all inference. Neither needs to know the internals of the other.
 
 ---
 
@@ -99,22 +104,24 @@ The main agent loop does **not** use `claude -p`. Agents run interactive (`--con
 
 `claude -p` is used in exactly two places, both short-lived and headless:
 
-- **Scheduled cron tasks** (`src/agents/scaffold.ts` ~L1150) — one-shot prompts fired by systemd timers. Exit on completion.
-- **Handoff summarization** (`src/agents/handoff-summarizer.ts` ~L297) — generates a cross-session handoff summary on demand. Exit on completion.
-
-Neither use case is affected by any rumored deprecation of `-p` in a meaningful way — they are genuinely one-shot, not persistent sessions dressed up as headless.
+- **Scheduled cron tasks** — one-shot prompts fired by the scheduler container. Exit on completion.
+- **Handoff summarization** (`src/agents/handoff-summarizer.ts`) — generates a cross-session handoff summary on demand. Exit on completion.
 
 ---
 
 ## Other moving parts
 
-**Hindsight** — runs as a Docker container (`ghcr.io/vectorize-io/hindsight:latest`) exposing its API on `localhost:18888` (port mapping `127.0.0.1:18888 → 8888/tcp`; also exposes `127.0.0.1:19999 → 9999/tcp`). It's mounted into each agent's `claude` process as an MCP plugin (`--plugin-dir .claude/plugins/hindsight-memory`), so every agent shares the same long-term memory backend while keeping its own bank. Deployment mechanism (Docker) is independent of switchroom itself — switchroom only wires the MCP plugin into each agent's `claude` invocation. Provides semantic memory, knowledge graph, entity resolution, and directives.
+**Vault broker (`switchroom-broker`)** — a long-running container holding the vault decrypted in memory after a one-time interactive unlock (`switchroom vault broker unlock`, or auto-unlock on boot). Cron tasks fetch declared keys via a host-shared unix socket. Container identity is asserted from the listening socket path (`/run/switchroom/broker/<agent>/sock`), not from cgroup parsing — broker-controlled input the agent cannot influence. See [`vault-broker.md`](vault-broker.md).
 
-**Foreman** — an optional always-on admin bot (`telegram-plugin/foreman/foreman.ts`) that provides fleet-wide visibility and lifecycle control over a separate Telegram bot token. Does not run Claude inference. Talks to the `switchroom` CLI directly for status, logs, restart, and create operations. Gated by `access.json` sender allowlists.
+**Approval kernel (`switchroom-kernel`)** — out-of-process broker that gates every tool call against the per-agent allowlist; pending grants surface as inline Telegram cards. The agent never decides its own permissions; it asks and waits.
 
-**Per-agent `.claude/`** — each agent has a fully isolated Claude config directory at `~/.switchroom/agents/<agent>/.claude/`. Separate auth credentials, separate `settings.json`, separate plugin config, separate transcript store. No agent can see or affect another agent's config.
+**Hindsight** — runs as a separate Docker container (`ghcr.io/vectorize-io/hindsight:latest`) exposing its API on `localhost:18888`. Mounted into each agent's `claude` process as an MCP plugin. Provides semantic memory, knowledge graph, entity resolution, and directives.
 
-**Config cascade** — agent config is resolved at reconcile time from `switchroom.yaml`: global defaults, then profile (`extends:`), then per-agent overrides. The rendered config is written into the agent's directory. Changing one line in `switchroom.yaml` and running `switchroom agent reconcile <agent>` propagates the change.
+**Per-agent `.claude/`** — each agent has a fully isolated Claude config directory at `~/.switchroom/agents/<agent>/.claude/` on the host, bind-mounted into the container at `/agent/.claude/`. Separate auth credentials, separate `settings.json`, separate plugin config, separate transcript store.
+
+**Config cascade** — agent config is resolved at apply time from `switchroom.yaml`: global defaults, then profile (`extends:`), then per-agent overrides. The rendered config is written into the agent's directory and the compose file is re-emitted. `switchroom apply` is the canonical reconcile.
+
+**Foreman** — an optional always-on admin bot (`telegram-plugin/foreman/foreman.ts`) over a separate Telegram bot token. Talks to the `switchroom` CLI directly for status, logs, restart, and create operations. Gated by `access.json` sender allowlists.
 
 ---
 

--- a/docs/operators/install.md
+++ b/docs/operators/install.md
@@ -9,26 +9,31 @@ fleet up via `docker compose`. No `docker build` on the operator's host.
 
 - Linux (Ubuntu 24.04 LTS canonical; other distros work).
 - Docker Engine 24+ with the compose v2 plugin (`docker compose ...`).
-- Bun (used for the `switchroom` CLI itself — the agent runtime is in
-  containers, but the CLI runs on the host).
+- The `claude` CLI on the host (`npm i -g @anthropic-ai/claude-code`,
+  Node 20.11+) for OAuth login. The agent runtime itself ships in
+  containers — the host only needs `claude` for `switchroom auth login`.
 
-## Install
+## Install — one-liner (recommended)
 
 ```sh
-# 1. Get the source (the CLI ships from this repo).
-git clone https://github.com/switchroom/switchroom.git ~/code/switchroom
-cd ~/code/switchroom
-bun install
-bun run build
+curl -fsSL https://github.com/switchroom/switchroom/raw/main/install.sh | sh
+```
 
-# 2. Generate per-host config + first-run wiring.
-switchroom setup           # interactive wizard
+This drops a self-contained `switchroom` binary in `/usr/local/bin`
+(falls back to `~/.local/bin` if the former isn't writable). No `bun`,
+no `node`, no source checkout required on the host. The binary is the
+operator CLI; the agent runtime is pulled from GHCR by Docker.
 
-# 3. Apply the config: scaffold agents + write docker-compose.yml.
-#    Writes ~/.switchroom/compose/docker-compose.yml.
+Then bring up your fleet:
+
+```sh
+# 1. Interactive first-time wiring (Telegram bot token, vault, first agent).
+switchroom setup
+
+# 2. Scaffold agents + write ~/.switchroom/compose/docker-compose.yml.
 switchroom apply
 
-# 4. Bring the fleet up yourself with docker compose.
+# 3. Bring the fleet up.
 docker compose -p switchroom -f ~/.switchroom/compose/docker-compose.yml pull
 docker compose -p switchroom -f ~/.switchroom/compose/docker-compose.yml up -d
 ```
@@ -36,6 +41,21 @@ docker compose -p switchroom -f ~/.switchroom/compose/docker-compose.yml up -d
 `switchroom apply` only scaffolds + writes the compose file — it does
 not call `docker`. Operators control the bring-up so the CLI never has
 to second-guess your docker setup, daemon socket, or rootless config.
+
+## Install — from source (development)
+
+If you're hacking on switchroom itself, install from a checkout instead:
+
+```sh
+git clone https://github.com/switchroom/switchroom.git ~/code/switchroom
+cd ~/code/switchroom
+bun install
+bun run build
+bun link               # adds the dev `switchroom` to PATH
+switchroom setup
+switchroom apply
+docker compose -p switchroom -f ~/.switchroom/compose/docker-compose.yml up -d
+```
 
 ## Image refs
 
@@ -72,6 +92,18 @@ compose. Pass `--build` to `docker compose up` to actually rebuild. The
 production path (no flag) is unaffected.
 
 ## Upgrading
+
+For the static-binary install, re-run the installer to pick up a newer
+release, then re-apply + pull + up:
+
+```sh
+curl -fsSL https://github.com/switchroom/switchroom/raw/main/install.sh | sh
+switchroom apply
+docker compose -p switchroom -f ~/.switchroom/compose/docker-compose.yml pull
+docker compose -p switchroom -f ~/.switchroom/compose/docker-compose.yml up -d
+```
+
+For the source install:
 
 ```sh
 cd ~/code/switchroom

--- a/docs/operators/runtime-mode.md
+++ b/docs/operators/runtime-mode.md
@@ -5,26 +5,19 @@ a generated `docker-compose.yml`. This is the only supported production
 runtime. The legacy systemd path was removed in v0.7 (see
 [`migration-v0.7.md`](./migration-v0.7.md)).
 
+Three commands cover the full lifecycle:
+
 ```sh
 switchroom apply
 docker compose -p switchroom -f ~/.switchroom/compose/docker-compose.yml pull
-docker compose -p switchroom -f ~/.switchroom/compose/docker-compose.yml up -d
+docker compose -p switchroom -f ~/.switchroom/compose/docker-compose.yml up -d --remove-orphans
 ```
 
 `switchroom apply` scaffolds every agent and writes the compose file
 derived from your `switchroom.yaml`. The CLI deliberately does not call
 `docker` for you — operators control the bring-up.
 
-## Installing from GHCR
-
-The Docker runtime pulls its 5 fleet images from
-`ghcr.io/switchroom/switchroom-{base,agent,broker,kernel,scheduler}`.
-See [`install.md`](./install.md) for the operator install flow
-(`git clone` + `bun install` + `switchroom setup` + `switchroom apply` +
-`docker compose ... up -d`), upgrade procedure, and the dev-time
-`--build-local` mode.
-
-## Production runtime declaration
-
-Linux is the only supported production runtime. macOS (Docker Desktop)
-is tracked as Phase 3.5 and not yet validated for production use.
+See [`install.md`](./install.md) for the full operator install flow
+(curl one-liner, prerequisites, GHCR auth, dev-time `--build-local`
+mode, upgrade procedure). Linux is the only release-validated production
+target; macOS (Docker Desktop) is supported for development.

--- a/docs/vault-broker.md
+++ b/docs/vault-broker.md
@@ -1,11 +1,20 @@
 # Vault Broker — ACL model and access guide
 
+> **v0.7 note.** Under v0.7+ the broker runs as the `switchroom-broker`
+> container and authenticates connecting clients by the socket path the
+> connection arrived on (`/run/switchroom/broker/<agent>/sock`,
+> broker-controlled per-agent socket), not by parsing systemd cgroups.
+> The terms "cron unit" / "systemd unit" / cgroup parsing below describe
+> the v0.6 host-native broker; the ACL contract — "only declared cron
+> secrets, only the cron caller for that agent" — is identical, and the
+> per-agent `secrets:` allowlist still drives what each cron can read.
+
 ## What is the vault broker?
 
-The vault broker is a per-user daemon that holds the decrypted vault in memory
-and serves secrets to authorised **switchroom cron units** over a Unix socket
-(`~/.switchroom/vault-broker.sock`).  It avoids re-prompting for the vault
-passphrase on every scheduled run.
+The vault broker is a per-host daemon that holds the decrypted vault in
+memory and serves secrets to authorised **switchroom scheduler containers**
+over a Unix socket. It avoids re-prompting for the vault passphrase on
+every scheduled run.
 
 The broker is **not** a general-purpose secret server.  It only serves callers
 it can positively identify as a switchroom cron unit — it does not serve

--- a/reference/give-each-agent-its-own-workspace.md
+++ b/reference/give-each-agent-its-own-workspace.md
@@ -92,7 +92,7 @@ doesn't have to:
    Removed when the agent is removed.
 3. **Per-agent long-lived branch.** `agent/<agent-name>/main`, where
    `<agent-name>` is the agent's id from `switchroom.yaml` (the same id
-   used in directory names and systemd units, e.g. `clerk`, `klanker`).
+   used in directory names and compose service names, e.g. `clerk`, `klanker`).
    Fast-forwarded to `upstream/main` on session start when the worktree
    is clean. Task work happens on transient branches off that branch.
 4. **Repos declared in `switchroom.yaml`.** An agent's manifest lists
@@ -117,7 +117,7 @@ doesn't have to:
    Don't try to share.
 10. **Lifecycle is part of `agent restart`.** Worktree provisioning,
     ff-when-clean, and stale-branch cleanup happen as part of the
-    `restart = reconcile + restart` contract — same as systemd unit
+    `restart = reconcile + restart` contract — same as compose-file
     rendering. No new manual command.
 
 ## What this enables

--- a/reference/idempotent-update-and-restart.md
+++ b/reference/idempotent-update-and-restart.md
@@ -1,17 +1,18 @@
 ---
 job: update switchroom and trust that everything is actually running the new version, no manual checks
-outcome: After `switchroom update` finishes, the entire stack — runtime, CLI, gateway, agents, MCP servers, memory backend, vault broker — is at the version switchroom declared and tested as a unit. After any restart, the agent comes back with fresh code, fresh MCP servers, fresh settings, and intact context (recent messages, memory, today's plan). The user does not lose their thread.
+outcome: After the upgrade flow finishes (`switchroom apply` + `docker compose pull` + `docker compose up -d --remove-orphans`), the entire stack — CLI, agent containers, broker, kernel, scheduler, MCP servers, memory backend — is at the version switchroom declared and tested as a unit. After any restart, the agent comes back with fresh code, fresh MCP servers, fresh settings, and intact context (recent messages, memory, today's plan). The user does not lose their thread.
 stakes: If `update` quietly leaves stale processes running, the user thinks they're talking to a new agent and they're talking to last week's. Bugs come back from the dead. New features advertised in the changelog don't actually load. The user loses faith that the version reported by the CLI matches reality. Updates become a thing to dread.
 ---
 
 # The job
 
-The user runs `switchroom update`. Maybe they're picking up a bug fix.
-Maybe a dependency security advisory landed. Maybe a new feature shipped.
-The job is for the next agent reply to be backed by the new version of
-*everything* — without the user having to know which processes survive a
-restart, which dependencies are pinned where, or which systemd unit
-secretly held a stale handle.
+The user runs the upgrade flow (`switchroom apply` + `docker compose
+pull` + `docker compose up -d --remove-orphans`). Maybe they're picking
+up a bug fix. Maybe a dependency security advisory landed. Maybe a new
+feature shipped. The job is for the next agent reply to be backed by
+the new version of *everything* — without the user having to know which
+processes survive a restart, which dependencies are pinned where, or
+which container secretly held a stale handle.
 
 The same is true for restarts. When a unit restarts, the agent should
 come back as a fresh process with current settings, not a zombie of
@@ -20,24 +21,25 @@ happening before — recent messages, the user's current goal, today's
 calendar — not as an amnesiac who needs to be re-briefed.
 
 The pattern is: **switchroom is a release**, not a moving target. A
-version of switchroom pins a tested matrix of bun, node, claude CLI,
-playwright/mcp, hindsight, vault broker, and every other moving piece.
-`update` brings every piece to its declared version, in lockstep. No
-piece moves on its own.
+version of switchroom pins a tested matrix of agent / broker / kernel /
+scheduler images, the claude CLI baked into the agent image, playwright/mcp,
+hindsight, and every other moving piece. The upgrade flow brings every
+piece to its declared version, in lockstep, by pulling the matched set
+of GHCR images. No piece moves on its own.
 
 ## Signs it's working
 
-- `switchroom update` finishes; the user sends a message; the agent's
+- The upgrade flow finishes; the user sends a message; the agent's
   next reply is backed by the new code without further intervention.
-  No manual `systemctl restart`, no `bun install`, no "have you tried
+  No manual `docker restart`, no `bun install`, no "have you tried
   restarting claude?" exchange.
 - The version reported by the CLI matches the version actually loaded
   into every running process. `switchroom doctor` confirms with a
   green check.
-- A user can re-run `switchroom update` and `switchroom agent restart`
-  any number of times, in any order, and end up in the same valid
-  state every time. No accumulating side effects. No "if you did X,
-  now you have to do Y to fix it."
+- A user can re-run `switchroom apply` + `docker compose up -d` and
+  `switchroom agent restart` any number of times, in any order, and
+  end up in the same valid state every time. No accumulating side
+  effects. No "if you did X, now you have to do Y to fix it."
 - After a restart, the agent's first response demonstrates it knows
   what was happening — references the user's last message, today's
   calendar, an in-flight task — without being prompted.
@@ -59,18 +61,18 @@ piece moves on its own.
   apparently didn't ship. New tools don't appear in the agent's
   toolbox. The "version" the CLI reports has decoupled from what's
   actually running.
-- A restart "succeeds" (systemd reports active) but the underlying
-  agent process didn't actually exit. PIDs from before the restart
-  are still alive. Settings changes don't take effect until the user
-  manually kills the process.
+- A restart "succeeds" (compose reports the container as running) but
+  the underlying agent process inside the container didn't actually
+  exit. PIDs from before the restart are still alive. Settings changes
+  don't take effect until the user manually bounces the container.
 - `update` overwrites a runtime version (e.g. claude CLI) by silently
   pulling `@latest` from a registry, picking up whatever shipped
   today regardless of whether the rest of the stack has been tested
   with that version.
 - The user has to keep a mental model of which dependency goes through
-  which channel. "claude is a global bun package, but bun itself I
-  installed via curl, and the vault broker is a separate systemd unit
-  that update doesn't touch."
+  which channel. "claude is baked into the agent image, but the broker
+  is a separate container, and the operator-host CLI is a static binary
+  that the upgrade doesn't touch."
 - A second `update` or `restart` after the first exposes new failure
   modes — implies the first run left the system in an in-between
   state.
@@ -83,8 +85,10 @@ piece moves on its own.
 
 ## What the user needs from the surface
 
-- One command (`switchroom update`) that does the right thing for the
-  whole stack. Not a runbook of three commands and two README links.
+- A small, fixed set of commands (`switchroom apply`, `docker compose
+  pull`, `docker compose up -d --remove-orphans`) that do the right
+  thing for the whole stack. Not a runbook of ten commands and two
+  README links.
 - A clear failure mode if the update can't finish cleanly. "Stopped at
   step X because Y failed; nothing was applied" beats "applied half,
   please figure out the rest yourself".
@@ -105,20 +109,21 @@ piece moves on its own.
 
 ### Update lands a security patch
 
-The user reads about a CVE in a transitive dependency. They run
-`switchroom update`. The CLI reports the new switchroom version, runs
-`bun upgrade`, bumps claude CLI to the pinned version, reinstalls the
-plugin, restarts the vault broker, and rolls each agent — gateway and
-claude process both bouncing. After it finishes, every running process
-is on the new version. The user sends "ping" and the agent replies
-within seconds, demonstrating it picked up the change without being
-asked. `switchroom doctor` reports no drift.
+The user reads about a CVE in a transitive dependency. They re-run the
+installer for a newer switchroom binary, then `switchroom apply`,
+`docker compose pull`, `docker compose up -d --remove-orphans`. Pull
+fetches the matched set of GHCR images at the new release tag; the
+rolling `up -d` replaces each agent + scheduler + broker container in
+turn. After it finishes, every container is on the new version. The
+user sends "ping" and the agent replies within seconds, demonstrating
+it picked up the change without being asked. `switchroom doctor`
+reports no drift.
 
 ### A restart in the middle of a busy thread
 
 The user has been mid-conversation about a legal letter, with several
-attachments shared. The agent restarts (systemd reschedule, host
-reboot, manual `agent restart`). The agent's first reply after coming
+attachments shared. The agent restarts (compose health-check bounce,
+host reboot, manual `agent restart`). The agent's first reply after coming
 back acknowledges where the thread was — references the legal letter,
 the deadline, what was already drafted — without the user having to
 paste it all back in.
@@ -135,10 +140,10 @@ on demand.
 
 ### Stale dependency exposed at update time
 
-The user installed claude CLI manually six months ago and forgot. They
-run `switchroom update`. Switchroom detects the installed claude
-version is ahead of the pinned version for this switchroom release,
-flags the drift, and either re-pins to the tested version or refuses
-to proceed pending user confirmation. Either way the user knows
-*before* sending their next message — not after the agent gives a
-weird answer that turns out to be a bug fixed in the pinned version.
+The user installed claude CLI manually on the host six months ago and
+forgot. (The host claude is only used for `switchroom auth login`; the
+agent itself runs the claude baked into the agent image.) `switchroom
+doctor` detects the host's claude is far behind the version baked into
+the running agent image, flags the drift as informational, and offers a
+one-liner to upgrade the host CLI. Either way the user knows *before*
+their next OAuth login fails or behaves oddly.

--- a/reference/principles.md
+++ b/reference/principles.md
@@ -86,8 +86,9 @@ is work. Give them the working thing first. Let them tinker later.
   with the `default` profile, a working bot, working memory, and the
   first agent already responding in Telegram before the user reads
   anything.
-- ❌ **Bad:** `switchroom init` writes a blank `switchroom.yaml` and
-  tells the user to read `docs/configuration.md` before proceeding.
+- ❌ **Bad:** A bare `switchroom apply` against a blank `switchroom.yaml`
+  with no first agent, telling the user to read `docs/configuration.md`
+  before proceeding.
 
 - ✅ **Good:** Playwright MCP is wired by default; opt out with
   `mcp_servers: { playwright: false }`. Progress cards on by default
@@ -101,11 +102,12 @@ is work. Give them the working thing first. Let them tinker later.
 - ❌ **Bad:** Each new agent requires copying ten files of boilerplate
   before it boots.
 
-- ✅ **Good:** `switchroom update` upgrades the CLI, reconciles each
-  agent's runtime, restarts each agent + gateway, and reports done.
-  One command, idempotent.
-- ❌ **Bad:** "Run `bun run build`, then `systemctl --user
-  daemon-reload`, then restart each agent yourself."
+- ✅ **Good:** The upgrade flow — `switchroom apply` to reconcile,
+  `docker compose pull` to fetch new images, `docker compose up -d
+  --remove-orphans` to roll the fleet — is three lines, idempotent,
+  and the same on every host.
+- ❌ **Bad:** "Run `bun run build`, then bounce each container by hand,
+  then re-render the compose file, then…"
 
 - ✅ **Good:** Sensible default skills on each profile (health-coach
   ships with `check-in` and `weekly-review`); operator skills

--- a/reference/rfc-docker-multi-container.md
+++ b/reference/rfc-docker-multi-container.md
@@ -8,7 +8,26 @@ source: research output for issue #793, "Option 3" of the comparison
 
 # RFC: one container per agent, docker compose for the fleet
 
-## Status (post-v0.6)
+## Status — shipped in v0.7
+
+This RFC is **shipped**. v0.7.0 is the docker-only release: the legacy
+systemd path was removed, `bin/bridge-watchdog.sh` was retired (compose
+healthchecks + `restart: unless-stopped` self-heal), and the `switchroom
+up` / `switchroom init` / `switchroom update` / `switchroom systemd`
+verbs are gone. The v0.7 install path is `curl ... install.sh | sh`,
+then `switchroom setup`, then `switchroom apply && docker compose pull
+&& docker compose up -d --remove-orphans`. Five published GHCR images
+(`switchroom-base`, `switchroom-agent`, `switchroom-broker`,
+`switchroom-kernel`, `switchroom-scheduler`) — no `docker build` on the
+operator's host.
+
+The body below is preserved as the historical design record. Phase
+labels reference earlier PRs; status notes inside individual phases
+describe what landed at the time of the RFC's last edit, not the
+current state of the codebase. For the current operator surface see
+`docs/operators/install.md` and `docs/architecture.md`.
+
+## Status (post-v0.6, historical)
 
 - **Phase 0** (peercred spike) — shipped (#801).
 - **Phase 1** (compose generator + per-agent containers) — shipped (#802, #804, #807).

--- a/reference/share-auth-across-the-fleet.md
+++ b/reference/share-auth-across-the-fleet.md
@@ -129,8 +129,8 @@ user doesn't have to:
    by the broker, not by claude. No symlinks. No bind mounts. Just an
    atomic-write copy whose only writer is `switchroom-auth-broker`.
 
-4. **`switchroom-auth-broker` is the only writer.** A new systemd user
-   service in the same shape as `vault-broker`. Owns:
+4. **`switchroom-auth-broker` is the only writer.** A long-running
+   container in the same shape as `switchroom-broker` (vault). Owns:
    - the global `~/.switchroom/accounts/<label>/credentials.json` files,
    - the OAuth refresh loop (one POST per account, regardless of how
      many agents use it),

--- a/skills/switchroom-install/SKILL.md
+++ b/skills/switchroom-install/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: switchroom-install
-description: Install switchroom and its dependencies (bun, node, docker, tmux, claude CLI) on a fresh machine. Use for onboarding and first-time setup — when the user says 'install switchroom on this machine', 'set up switchroom for the first time', 'bootstrap switchroom from scratch', 'get switchroom running', 'how do I get started with switchroom', "I'm new to switchroom, where do I begin", or asks about switchroom dependencies or prerequisites. This is the onboarding entry point, not for managing existing agents.
+description: Install switchroom and its dependencies (docker, claude CLI, switchroom binary) on a fresh machine. Use for onboarding and first-time setup — when the user says 'install switchroom on this machine', 'set up switchroom for the first time', 'bootstrap switchroom from scratch', 'get switchroom running', 'how do I get started with switchroom', "I'm new to switchroom, where do I begin", or asks about switchroom dependencies or prerequisites. This is the onboarding entry point, not for managing existing agents.
 ---
 
 # Install Switchroom
 
 When the user asks to install, set up, bootstrap, or get started with switchroom — or when they're new to switchroom and want to know where to begin — walk them through this flow. Switchroom turns a Linux server + their Claude Pro/Max subscription into always-on Claude Code agents reachable from Telegram.
 
-Switchroom's dependencies are: **bun** (TypeScript runtime), **node** 22+ (via nvm), **docker** (for plugins), **tmux** (for agent sessions), and the **claude** Code CLI (authenticates against Claude Pro/Max). Always enumerate these explicitly when the user asks about dependencies or prerequisites.
+Switchroom v0.7+ ships as a self-contained static binary (no host bun or node runtime required) and runs the agent fleet in Docker containers pulled from GHCR. The two host dependencies are: **docker** (engine 24+ with the compose v2 plugin) and the **claude** Code CLI (used for OAuth login against your Pro/Max subscription).
 
 ## Step 0 — Detect existing install
 
@@ -17,11 +17,11 @@ Before doing anything, check whether switchroom is already installed:
 command -v switchroom && switchroom --version 2>/dev/null
 ```
 
-If switchroom is present, tell the user it's already installed and then — regardless — run the dependency audit in Step 2 so they see the state of **bun**, **node**, **docker**, **tmux**, and **claude**. Users who ask "install switchroom and its dependencies" want to see the dependency inventory even when switchroom itself is already installed. After the audit, offer `switchroom setup` (re-run the wizard), `switchroom doctor` (diagnose), or `switchroom agent list` (see what's running). Do not reinstall switchroom itself without explicit confirmation.
+If switchroom is present, tell the user it's already installed and then — regardless — run the dependency audit in Step 2 so they see the state of **docker** and **claude**. After the audit, offer `switchroom setup` (re-run the wizard), `switchroom doctor` (diagnose), or `switchroom agent list` (see what's running). Do not reinstall switchroom itself without explicit confirmation.
 
 ## Step 1 — Verify prerequisites
 
-Switchroom requires Ubuntu 24.04 LTS (or compatible Debian-based Linux) with ≥4GB RAM. Check:
+Switchroom requires Linux with Docker (Ubuntu 24.04 LTS canonical; ≥4GB RAM):
 
 ```bash
 . /etc/os-release && echo "$PRETTY_NAME"
@@ -29,56 +29,40 @@ free -h | awk '/^Mem:/ {print $2}'
 uname -m
 ```
 
-If the user is on macOS or Windows, stop and explain: switchroom runs on Linux servers (typically a $6/mo VPS). Point them at the README's "Quick Start" — they'll want to provision a Linux box first.
+If the user is on macOS or Windows, stop and explain: switchroom's release-validated production runtime is Linux. macOS (Docker Desktop) works for development but isn't yet release-gated. Windows users need WSL2.
 
-## Step 2 — Install system dependencies
+## Step 2 — Install host dependencies
 
 Only install what's missing. Check each first:
 
 ```bash
-# System packages
-for pkg in tmux expect docker.io; do
-  dpkg -s "$pkg" >/dev/null 2>&1 || echo "MISSING: $pkg"
-done
+# Docker
+command -v docker || echo "MISSING: docker"
+docker compose version >/dev/null 2>&1 || echo "MISSING: docker compose v2"
 
-# Bun
-command -v bun || echo "MISSING: bun"
-
-# Node 22+ (via nvm)
-node -v 2>/dev/null || echo "MISSING: node"
-
-# Claude Code CLI
+# Claude Code CLI (needed for switchroom auth login)
 command -v claude || echo "MISSING: claude"
 ```
 
-For anything missing, run the corresponding install step:
+For anything missing:
 
 ```bash
-# apt packages
-sudo apt update && sudo apt install -y tmux expect docker.io
+# Docker (Ubuntu/Debian)
+sudo apt update && sudo apt install -y docker.io docker-compose-plugin
+sudo usermod -aG docker "$USER"   # log out/in or `newgrp docker` to apply
 
-# bun
-curl -fsSL https://bun.sh/install | bash
-
-# nvm + node 22
-curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh | bash
-source ~/.bashrc
-nvm install 22
-
-# claude code
+# Claude Code CLI (needs Node 20.11+)
 npm install -g @anthropic-ai/claude-code
-
-# docker group (user needs to log out/in or newgrp)
-sudo usermod -aG docker "$USER"
 ```
 
 **Important:** After `usermod -aG docker`, the user needs a new shell for group membership to apply. Mention this explicitly.
 
-## Step 3 — Clone and build switchroom
+## Step 3 — Install the switchroom binary
+
+The recommended path is the static-binary one-liner — auto-detects platform/arch, downloads the matching pre-built binary from the latest GitHub release, verifies its SHA256, and installs to `/usr/local/bin` (or `~/.local/bin` if not writable):
 
 ```bash
-git clone https://github.com/mekenthompson/switchroom.git ~/code/switchroom
-cd ~/code/switchroom && bun install && bun link
+curl -fsSL https://github.com/switchroom/switchroom/raw/main/install.sh | sh
 ```
 
 Verify:
@@ -87,15 +71,27 @@ Verify:
 switchroom --version
 ```
 
+(For development against a source checkout, `git clone` + `bun install` + `bun link` still works — see `docs/operators/install.md`. Don't suggest the source path for first-time users.)
+
 ## Step 4 — Run setup wizard
 
-`switchroom setup` is an interactive wizard that configures the Telegram bot token, forum chat, and first agent. **It requires a terminal the user controls** — if you're running inside an agent session, you cannot drive it yourself. Tell the user:
+`switchroom setup` is an interactive wizard that wires the operator's Telegram bot token, sets up the vault, and scaffolds a first agent. DM-only by default — no forum chat ID required up front. **It requires a terminal the user controls** — if you're running inside an agent session, you cannot drive it yourself. Tell the user:
 
 > Run `switchroom setup` in your own terminal. It'll ask for your Telegram bot token and walk you through creating your first agent. Come back when it finishes and I can verify with `switchroom doctor`.
 
-## Step 5 — Verify
+## Step 5 — Apply and bring up the fleet
 
-After `switchroom setup` completes:
+After `switchroom setup` completes, three commands take you from config to a running fleet:
+
+```bash
+switchroom apply
+docker compose -p switchroom -f ~/.switchroom/compose/docker-compose.yml pull
+docker compose -p switchroom -f ~/.switchroom/compose/docker-compose.yml up -d --remove-orphans
+```
+
+`switchroom apply` reconciles every agent declared in `switchroom.yaml` and writes `~/.switchroom/compose/docker-compose.yml`. The CLI deliberately does not run `docker` for you — operators own the bring-up. The first `pull` fetches the 5 GHCR images (~1-2 GB total); subsequent pulls are layer-only.
+
+## Step 6 — Verify
 
 ```bash
 switchroom doctor
@@ -112,5 +108,6 @@ Once the first agent is up and authenticated, the user can promote that agent's 
 
 - **Do not** run `switchroom setup` non-interactively or pipe input to it — it's designed for a human.
 - **Do not** edit `~/.switchroom/vault.enc` or any file under `~/.switchroom/` directly. Use the CLI.
-- **Do not** install switchroom system-wide (no `sudo npm install -g switchroom`). Switchroom is a bun-linked binary from a user-owned checkout.
+- **Do not** run `docker build` on the operator's host. The 5 fleet images are published on GHCR; `switchroom apply` writes a compose file that pulls them.
+- **Do not** suggest the legacy `switchroom up` / `switchroom init` / `switchroom update` verbs — they were removed in v0.7. The current flow is `switchroom apply && docker compose pull && docker compose up -d`.
 - **Do not** reinstall over an existing install without asking. If the user wants a clean slate, have them run `switchroom uninstall` first (or confirm they want to blow away `~/.switchroom/`).

--- a/skills/switchroom-manage/SKILL.md
+++ b/skills/switchroom-manage/SKILL.md
@@ -30,7 +30,7 @@ When the user invokes `/switchroom` or asks to add, create, remove, reinstall, r
 
 ### Add / create a new agent
 
-When the user says "add a new agent", "add an agent to my switchroom setup", or "create a new agent", ask for a name (if not provided) and run `switchroom agent create <name>`. This scaffolds the agent directory, installs systemd timers, and wires it into the config cascade.
+When the user says "add a new agent", "add an agent to my switchroom setup", or "create a new agent", ask for a name (if not provided) and run `switchroom agent create <name>`. This scaffolds the agent directory and wires it into the config cascade. Follow up with `switchroom apply` and `docker compose -p switchroom -f ~/.switchroom/compose/docker-compose.yml up -d` to materialise the new agent + scheduler containers.
 
 ### Reinstall / reprovision agents
 

--- a/skills/switchroom-status/SKILL.md
+++ b/skills/switchroom-status/SKILL.md
@@ -29,7 +29,7 @@ If that succeeds, parse the output and present the running agent list with full 
 
 When you have real output, for each agent show:
 - **Name** and topic
-- **Status**: running / stopped / error (from systemd unit state)
+- **Status**: running / stopped / error (from the docker-compose container state)
 - **Uptime**: how long it's been running (for running agents, always include the word "uptime" and the duration)
 - **Model**: which Claude model it's using
 - **Memory**: Hindsight collection name (if configured)


### PR DESCRIPTION
## Summary

Round of follow-up doc cleanups across the repo to bring everything in line with the v0.7 docker-only reality (the lifecycle verbs `switchroom up`/`init`/`update`/`systemd` are gone; the install path is `curl install.sh | sh` then `switchroom setup` then `switchroom apply && docker compose pull && docker compose up -d --remove-orphans`; agents run as containers, not systemd units).

Files swept (14):

- \`README.md\` — listed all 5 GHCR images, dropped \`forum_chat_id\` from the example, dropped the residual "Linux-only Phase 3.5" caveat, fixed scheduling description.
- \`docs/architecture.md\` — full rewrite for the docker substrate.
- \`docs/operators/install.md\` — leads with the curl one-liner; source-checkout install moved under "From source (development)".
- \`docs/operators/runtime-mode.md\` — thinned to a pointer at \`install.md\`.
- \`docs/vault-broker.md\` — added v0.7 note explaining socket-path identity replaces systemd-cgroup peercred. Body retained as v0.6 context.
- \`CLAUDE.md\` — restart blurb references compose, not systemd units.
- \`skills/switchroom-install/SKILL.md\` — rewritten around the static-binary one-liner + 3-command apply/pull/up flow + DM-only setup.
- \`skills/switchroom-status/SKILL.md\` — container state, not systemd unit state.
- \`skills/switchroom-manage/SKILL.md\` — agent create no longer "installs systemd timers".
- \`reference/principles.md\` — examples updated from \`switchroom init\` / \`switchroom update\` to \`switchroom apply\` + compose flow.
- \`reference/idempotent-update-and-restart.md\` — JTBD outcomes / signs / worked examples rephrased around \`switchroom apply\` + \`docker compose pull\` + \`up -d --remove-orphans\`.
- \`reference/give-each-agent-its-own-workspace.md\` — "systemd units" → "compose service names".
- \`reference/share-auth-across-the-fleet.md\` — auth broker described as a long-running container.
- \`reference/rfc-docker-multi-container.md\` — added v0.7-shipped status block at the top; preserved historical body.

## Out of scope

- \`docs/configuration.md\` — keeps systemd references in the broker comparison section because they're useful as historical/comparison context. The v0.7 broker note in \`vault-broker.md\` covers the divergence.
- \`docs/auto-unlock.md\`, \`docs/posthog.md\`, \`docs/compliance-attestation.md\` — systemd refs there are accurate (they describe the actual host \`/etc/machine-id\` mechanism, the action-boundary instrumentation pattern, and the compliance scope respectively).
- \`reference/rfc-docker-multi-container.md\` body — preserved verbatim as the historical design record.

## Test plan

- [ ] \`docs/operators/install.md\` reads cleanly top-to-bottom on the rendered PR diff.
- [ ] \`docs/architecture.md\` matches the actual containers brought up by \`switchroom apply\` on a fresh box.
- [ ] No remaining references to \`switchroom up\` / \`switchroom init\` / \`switchroom update\` outside the historical RFC and the install skill's "do not suggest" list.
- [ ] Skills sweep: \`switchroom-install\` walks a brand-new operator from zero to a running agent in three CLI invocations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)