### PR TITLE
fix(v0.7.1): vault file mount + agent dual-mount + defensive mkdir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,60 @@
 # Changelog
 
+## v0.7.1 — v0.7 install hotfix
+
+**Fixes (P0 install blockers from v0.7.0):**
+
+- **Compose: vault file mounted as a directory.** The broker mount was
+  `${HOME}/.switchroom/vault:/state/vault` but the actual vault file is
+  `~/.switchroom/vault.enc` (a top-level file, not a `vault/` subdir).
+  Docker auto-created the missing source as an empty root-owned
+  directory on the host, the broker found no vault, and the fleet
+  restart-looped. Now mounted as the file directly:
+  `~/.switchroom/vault.enc:/state/vault.enc:ro` plus an explicit
+  `SWITCHROOM_VAULT_PATH` env so the broker doesn't fall back to its
+  `~`-expanding default (which resolves to `/root/...` inside the
+  container).
+- **Compose: agent containers crash-looped on `cd` to a host path.**
+  Scaffolded `start.sh` bakes the absolute host path of `agentDir` at
+  scaffold time (`cd "/home/<user>/.switchroom/agents/<name>"`), but
+  the bind mount destination was `/state/agent` — so the host path
+  didn't exist inside the container. Fixed by dual-mounting: the
+  same host directory is bound BOTH at the canonical `/state/agent`
+  (Dockerfile compatibility) AND at the original host path
+  (start.sh compatibility). Same applies to `/state/.claude` and
+  `/var/log/switchroom`. No image rebuild required to pick up this
+  fix — operators just `switchroom apply` and
+  `docker compose -p switchroom up -d`.
+- **Apply: defensive `mkdir` on host bind-mount sources.** Before
+  generating the compose file, `apply` now creates every directory
+  that compose will bind-mount (under the operator's UID), preventing
+  docker from auto-creating them as root. Closes the bug class that
+  produced both the `~/.switchroom/vault` and
+  `~/.switchroom/vault-auto-unlock` root-owned stub directories
+  observed during v0.7.0 cutovers.
+- **package.json: bump version to `0.7.1`.** It had been stuck at
+  `0.5.2` across multiple releases; the gateway boot card reads
+  `package.json` via `src/build-info.ts` and was reporting
+  `v0.5.2 · #826` even on v0.7 fleets.
+
+**Known v0.7 issues NOT addressed in this release** (filed as
+follow-ups; impact: agent self-restart, `switchroom agent status`,
+and the boot watchdog still assume systemd in places):
+
+- `telegram-plugin/gateway/gateway.ts` spawns `systemctl --user restart …`
+  for graceful restart and quota-rotation flows; needs a docker-aware
+  branch (exit 0 and let `restart: unless-stopped` recreate the
+  container).
+- `telegram-plugin/gateway/restart-watchdog.ts` reads systemd unit
+  state to detect crash loops; needs a `docker inspect` fallback.
+- `src/cli/agent.ts` checks for `~/.config/systemd/user/switchroom-*.service`
+  unit files in several lifecycle verbs even under `SWITCHROOM_RUNTIME=docker`.
+- `src/agents/status.ts` `readSystemdUnitStatus()` is the only source
+  of agent state for `switchroom agent status`; needs a `docker ps`
+  fallback.
+- `src/cli/doctor.ts` still hard-checks for `systemctl` and prints
+  "Switchroom requires a systemd-based Linux distro".
+
 ## v0.7.0 — Docker-only (BREAKING)
 
 **Breaking changes:**

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "switchroom",
-  "version": "0.5.2",
-  "description": "Run Claude Code 24/7 on your Claude Pro/Max subscription over Telegram. Open-source alternative to OpenClaw and NanoClaw — no API keys, no Docker.",
+  "version": "0.7.1",
+  "description": "Run Claude Code 24/7 on your Claude Pro/Max subscription over Telegram. Open-source alternative to OpenClaw and NanoClaw — no API keys.",
   "type": "module",
   "bin": {
     "switchroom": "./dist/cli/switchroom.js"

--- a/src/agents/compose.ts
+++ b/src/agents/compose.ts
@@ -278,6 +278,11 @@ export function generateCompose(opts: ComposeGeneratorOptions): string {
   if (switchroomConfigPath) {
     lines.push(`      SWITCHROOM_CONFIG: /state/config/switchroom.yaml`);
   }
+  // Vault file path inside the container. Set explicitly so the broker
+  // does NOT fall back to its `~/.switchroom/vault.enc` default — which
+  // would resolve `~` against the container's HOME (/root) instead of
+  // the operator's HOME on the host.
+  lines.push(`      SWITCHROOM_VAULT_PATH: /state/vault.enc`);
   lines.push(`      SWITCHROOM_VAULT_BROKER_AUTO_UNLOCK_PATH: /state/vault-auto-unlock`);
   lines.push(`    volumes:`);
   for (const a of describeAgents(config)) {
@@ -286,16 +291,20 @@ export function generateCompose(opts: ComposeGeneratorOptions): string {
   if (switchroomConfigPath) {
     lines.push(`      - ${switchroomConfigPath}:/state/config/switchroom.yaml:ro`);
   }
-  lines.push(`      - ${homePrefix}/.switchroom/vault:/state/vault`);
+  // Vault file mounted directly (not as a parent directory) — the host
+  // file is `~/.switchroom/vault.enc`, NOT `~/.switchroom/vault/*`.
+  // The earlier `${HOME}/.switchroom/vault:/state/vault` mount caused
+  // docker to auto-create an empty root-owned `~/.switchroom/vault`
+  // directory on the host (the v0.7.0 install bug) which the broker
+  // then "loaded" as a missing vault — restart-loop on every boot.
+  lines.push(`      - ${homePrefix}/.switchroom/vault.enc:/state/vault.enc:ro`);
   // Auto-unlock blob (encrypted with /etc/machine-id-derived key).
   // Mounted read-only — the broker only ever reads the blob; rotation
   // is performed by the host CLI (`switchroom vault broker enable-auto-unlock`)
-  // followed by a `docker compose restart vault-broker`. Mount source
-  // is the host file path `~/.switchroom/vault-auto-unlock` (the
-  // DEFAULT_AUTO_UNLOCK_PATH constant in src/vault/auto-unlock.ts).
-  // Compose treats a missing source as an empty directory — the broker
-  // detects that and falls back to the interactive unlock flow, so
-  // operators who never enabled auto-unlock are unaffected.
+  // followed by a `docker compose restart vault-broker`. Compose treats
+  // a missing source as an empty directory — the broker detects that
+  // and falls back to the interactive unlock flow, so operators who
+  // never enabled auto-unlock are unaffected.
   lines.push(`      - ${homePrefix}/.switchroom/vault-auto-unlock:/state/vault-auto-unlock:ro`);
   lines.push(``);
 
@@ -442,9 +451,25 @@ function emitAgentService(
   // invariant on every regenerated compose.
   lines.push(`      - broker-${a.name}-sock:/run/switchroom/broker`);
   lines.push(`      - kernel-${a.name}-sock:/run/switchroom/kernel`);
+  // Dual mounts — the same host directory is bound BOTH at the canonical
+  // container path (`/state/agent`, `/state/.claude`, `/var/log/switchroom`)
+  // AND at the original host path. Why both:
+  //   - `/state/*` paths are baked into the Dockerfile (Dockerfile.agent's
+  //     CMD is `/state/agent/start.sh`; tini ENTRYPOINT calls into it).
+  //     Removing the canonical paths would break the existing v0.7.0
+  //     image without rebuilding it.
+  //   - Same-path mounts let scaffolded start.sh / settings.json (which
+  //     bake the absolute host path of agentDir at scaffold time) Just
+  //     Work inside the container. The host path in `cd "$agentDir"`
+  //     resolves to the same file the bind mount points at.
+  // Dual-mount is the smallest viable fix that unblocks v0.7.0 installs
+  // without an image rebuild + republish.
   lines.push(`      - ${homePrefix}/.switchroom/agents/${a.name}:/state/agent`);
   lines.push(`      - ${homePrefix}/.claude/projects/${a.name}:/state/.claude`);
   lines.push(`      - ${homePrefix}/.switchroom/logs/${a.name}:/var/log/switchroom`);
+  lines.push(`      - ${homePrefix}/.switchroom/agents/${a.name}:${homePrefix}/.switchroom/agents/${a.name}`);
+  lines.push(`      - ${homePrefix}/.claude/projects/${a.name}:${homePrefix}/.claude/projects/${a.name}`);
+  lines.push(`      - ${homePrefix}/.switchroom/logs/${a.name}:${homePrefix}/.switchroom/logs/${a.name}`);
   lines.push(``);
   void imageTag;
 }

--- a/src/build-info.ts
+++ b/src/build-info.ts
@@ -2,8 +2,8 @@
 // Tracked in git so `tsc --noEmit` works on a fresh clone before `npm run build`.
 // Values are refreshed every time `npm run build` runs.
 
-export const VERSION: string = "0.5.2";
-export const COMMIT_SHA: string | null = "db57763e";
-export const COMMIT_DATE: string | null = "2026-05-09T10:21:46+10:00";
-export const LATEST_PR: number | null = null;
-export const COMMITS_AHEAD_OF_TAG: number | null = 11;
+export const VERSION: string = "0.7.1";
+export const COMMIT_SHA: string | null = "9de1a83a";
+export const COMMIT_DATE: string | null = "2026-05-09T11:46:44+10:00";
+export const LATEST_PR: number | null = 858;
+export const COMMITS_AHEAD_OF_TAG: number | null = 0;

--- a/src/cli/apply.ts
+++ b/src/cli/apply.ts
@@ -112,6 +112,40 @@ function hasVaultRefs(value: unknown): boolean {
 }
 
 /**
+ * Pre-create every host directory that compose will bind-mount.
+ *
+ * Why: docker auto-creates a missing bind-mount source as an empty
+ * directory owned by the dockerd UID (root). On v0.7 installs that
+ * tripped twice — operators ended up with root-owned `~/.switchroom/vault`
+ * and `~/.switchroom/vault-auto-unlock` stub directories that blocked
+ * the real files from landing at the same path. Creating the
+ * directories ourselves (as the current shell user) removes the
+ * race entirely.
+ *
+ * The set of paths mirrors the volume mount sources emitted by
+ * `generateCompose`. We mkdir directories only — files (vault.enc,
+ * vault-auto-unlock blob) are managed by `switchroom setup` / vault
+ * commands.
+ */
+async function ensureHostMountSources(config: SwitchroomConfig): Promise<void> {
+  const home = homedir();
+  const dirs = [
+    join(home, ".switchroom", "approvals"),
+    join(home, ".switchroom", "scheduler"),
+    join(home, ".switchroom", "logs"),
+    join(home, ".switchroom", "compose"),
+  ];
+  for (const name of Object.keys(config.agents)) {
+    dirs.push(join(home, ".switchroom", "agents", name));
+    dirs.push(join(home, ".switchroom", "logs", name));
+    dirs.push(join(home, ".claude", "projects", name));
+  }
+  for (const dir of dirs) {
+    await mkdir(dir, { recursive: true });
+  }
+}
+
+/**
  * Detect whether `docker compose` (the v2 plugin, not the deprecated
  * `docker-compose` v1 binary) is installed. Returns a friendly error
  * string explaining how to upgrade if it isn't, otherwise null.
@@ -251,7 +285,22 @@ export async function runApply(
     }
   }
 
-  // ── 2. Generate compose file ──────────────────────────────────────
+  // ── 2. Pre-create host mount sources ──────────────────────────────
+  // Why: docker auto-creates a missing bind-mount source as an empty
+  // directory owned by ROOT (because dockerd runs as root). That has
+  // bitten v0.7 installs twice — root-owned `~/.switchroom/vault` and
+  // `~/.switchroom/vault-auto-unlock` stubs that then blocked the user
+  // from moving the real files into place. Eagerly mkdir'ing as the
+  // current shell user keeps the source dirs operator-owned.
+  // Files (vault.enc, vault-auto-unlock blob) are NOT created here —
+  // they're written by `switchroom setup` / vault commands and we
+  // shouldn't fabricate empty placeholders. If they're missing, the
+  // broker handles that gracefully (vault.enc missing => apply
+  // preflight already errors; auto-unlock missing => broker falls
+  // back to interactive unlock).
+  await ensureHostMountSources(config);
+
+  // ── 3. Generate compose file ──────────────────────────────────────
   const composePath = options.outPath ?? DEFAULT_COMPOSE_PATH;
   const composeContent = generateCompose({
     config,

--- a/tests/docker/compose-generator.test.ts
+++ b/tests/docker/compose-generator.test.ts
@@ -209,10 +209,16 @@ describe("generateCompose", () => {
 
   it("uses ${HOME} for host-path bind mounts when no homeDir is given", () => {
     const out = generateCompose({ config: makeConfig({ a: {} }) });
-    expect(out).toContain("${HOME}/.switchroom/vault:/state/vault");
+    // Vault file mounted directly (not as a parent dir) — see compose.ts
+    // for the rationale (#v0.7.1 vault file path fix).
+    expect(out).toContain("${HOME}/.switchroom/vault.enc:/state/vault.enc:ro");
     expect(out).toContain("${HOME}/.switchroom/approvals:/state/approvals");
     expect(out).toContain("${HOME}/.switchroom:/state/config:ro");
     expect(out).toContain("${HOME}/.switchroom/agents/a:/state/agent");
+    // Same-path dual mount for agents — see compose.ts for the rationale
+    // (start.sh bakes host paths at scaffold time, so the same paths
+    // must resolve inside the container).
+    expect(out).toContain("${HOME}/.switchroom/agents/a:${HOME}/.switchroom/agents/a");
   });
 
   it("bakes the absolute homeDir into bind sources when given (sudo-safe)", () => {
@@ -223,12 +229,16 @@ describe("generateCompose", () => {
       config: makeConfig({ a: {} }),
       homeDir: "/home/op",
     });
-    expect(out).toContain("/home/op/.switchroom/vault:/state/vault");
+    expect(out).toContain("/home/op/.switchroom/vault.enc:/state/vault.enc:ro");
     expect(out).toContain("/home/op/.switchroom/approvals:/state/approvals");
     expect(out).toContain("/home/op/.switchroom:/state/config:ro");
+    // Dual mount: canonical /state/agent path AND same-path host path.
     expect(out).toContain("/home/op/.switchroom/agents/a:/state/agent");
+    expect(out).toContain("/home/op/.switchroom/agents/a:/home/op/.switchroom/agents/a");
     expect(out).toContain("/home/op/.switchroom/logs/a:/var/log/switchroom");
+    expect(out).toContain("/home/op/.switchroom/logs/a:/home/op/.switchroom/logs/a");
     expect(out).toContain("/home/op/.claude/projects/a:/state/.claude");
+    expect(out).toContain("/home/op/.claude/projects/a:/home/op/.claude/projects/a");
     expect(out).not.toContain("${HOME}");
   });
 


### PR DESCRIPTION
## Summary

v0.7.0 had two compose-mount bugs that crash-looped the fleet on first
boot. I hit both during a real cutover today — host got rolled back to
v0.6 to recover. This is the smallest-viable patch to make v0.7
installable without rebuilding the docker images.

- **vault file mounted as a directory.** Compose mounted
  `${HOME}/.switchroom/vault:/state/vault` but the actual vault file is
  `~/.switchroom/vault.enc` (top-level file, not a `vault/` subdir).
  Docker auto-created the missing source as an empty root-owned
  directory; broker found no vault and restart-looped. Fixed by
  mounting the file directly at `/state/vault.enc:ro` plus an explicit
  `SWITCHROOM_VAULT_PATH` env so the broker doesn't fall back to its
  `~/.switchroom/vault.enc` default that resolves to `/root/...`
  inside the container.
- **agent containers crash-looped on `cd` to a host path.**
  Scaffolded `start.sh` bakes the absolute host path of `agentDir` at
  scaffold time (`cd "/home/<user>/.switchroom/agents/<name>"`), but
  the bind-mount destination was `/state/agent`, so the host path
  didn't exist inside the container. Fixed by **dual-mounting**: the
  same host directory is bound BOTH at the canonical `/state/agent`
  (Dockerfile.agent's `CMD` is `/state/agent/start.sh`, has to stay)
  AND at the original host path (so start.sh's host-pathed `cd`
  Just Works). Same dual treatment for `/state/.claude` and
  `/var/log/switchroom`. **No image rebuild required** — operators
  just `switchroom apply && docker compose up -d`.
- **defensive `mkdir` on every host bind-mount source.** Apply now
  creates the host directories docker is about to bind-mount BEFORE
  invoking compose. Closes the bug class that produced both the
  root-owned `~/.switchroom/vault` stub AND the root-owned
  `~/.switchroom/vault-auto-unlock` stub I had to `sudo rmdir`
  during the cutover.
- **package.json bumped 0.5.2 → 0.7.1.** It had been stuck at 0.5.2
  across multiple releases; the gateway boot card reads `package.json`
  via `src/build-info.ts` and was reporting `v0.5.2 · #826` even on
  v0.7 fleets.

## Known v0.7 issues NOT addressed in this PR

A separate audit surfaced runtime-side BLOCKERs that I'm filing as
follow-up issues — they don't block the install path so they can ship
in v0.7.2:

- `telegram-plugin/gateway/gateway.ts` spawns `systemctl --user restart`
  for graceful-restart and quota-rotation; needs a docker branch (exit 0
  and let `restart: unless-stopped` recreate the container).
- `telegram-plugin/gateway/restart-watchdog.ts` reads systemd unit state
  to detect crash loops; needs a `docker inspect` fallback.
- `src/cli/agent.ts` checks for systemd unit files in several lifecycle
  verbs even under `SWITCHROOM_RUNTIME=docker`.
- `src/agents/status.ts` `readSystemdUnitStatus()` is the only data
  source for `switchroom agent status`; needs a `docker ps` fallback.
- `src/cli/doctor.ts` still hard-checks for `systemctl` and prints
  "Switchroom requires a systemd-based Linux distro".
- README + `docs/architecture.md` + `docs/scheduling.md` still describe
  the systemd runtime as primary.
- `profiles/_shared/telegram-style.md.hbs` references `journalctl --user`
  / `systemctl kill` for in-skill operator guidance.

## Test plan

- [x] `npx vitest run` — 5064 tests pass (336 files, 31 skipped — same
      count as pre-change; no new failures).
- [x] `tests/docker/compose-generator.test.ts` — both
      `${HOME}` and absolute-`homeDir` cases updated to assert the
      new `vault.enc:/state/vault.enc` mount + the dual-mount pattern.
- [x] `bun run build` clean.
- [ ] **End-to-end install path on a real v0.6 → v0.7.1 host.** Did not
      re-run on the host that hit the bug because rolling forward again
      mid-business hours was deemed too risky; will validate on the
      next planned cutover window. Reviewer should treat that as the
      stop-ship gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)