### PR TITLE
Phase 1: UAT harness scaffold (#864 #865 #866)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -43,6 +43,7 @@
       "dependencies": {
         "@grammyjs/runner": "^2.0.3",
         "@modelcontextprotocol/sdk": "^1.0.0",
+        "@mtcute/node": "^0.27.0",
         "@secretlint/core": "^12.2.0",
         "@secretlint/secretlint-rule-preset-recommend": "^12.2.0",
         "@secretlint/types": "^12.2.0",
@@ -152,6 +153,14 @@
 
     "@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.7", "", { "os": "win32", "cpu": "x64" }, "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg=="],
 
+    "@fuman/io": ["@fuman/io@0.0.19", "", { "dependencies": { "@fuman/utils": "^0.0.19" } }, "sha512-B+2n3GVa9PCYMJ9xfsdXUlUV9yXO4gKLYfxm815PeJ+MGOw5TbEp166drRmBq1AtxVnP0efy6Oz9rYpKVODgow=="],
+
+    "@fuman/net": ["@fuman/net@0.0.19", "", { "dependencies": { "@fuman/io": "^0.0.19", "@fuman/utils": "^0.0.19" } }, "sha512-yISM+JcZEWBpBYn0v2mUY/Zst4SsicTRaVTvRkVhMiZhgMzdXalfvRwRV/vsgwwL31bntwowCTDW4iilCJLbXg=="],
+
+    "@fuman/node": ["@fuman/node@0.0.19", "", { "dependencies": { "@fuman/io": "^0.0.19", "@fuman/net": "^0.0.19", "@fuman/utils": "^0.0.19" }, "peerDependencies": { "ws": "^8.18.1" }, "optionalPeers": ["ws"] }, "sha512-1VNTBb47yrN5BzuXiP4t6An7mDPklH5N+vUtkeL3XATK+xWbtlQsSsU244T7iqGurmDpYrLM9kIUjdMFm8OhDw=="],
+
+    "@fuman/utils": ["@fuman/utils@0.0.19", "", {}, "sha512-4qVrZ9AjKYztLJsNr1Tp7kL48b22dvVLN1iVW+Me8ZSQ0ILN0qknoxjsczVPReF7+GDWgknNxR2l6ggrA4SZyw=="],
+
     "@grammyjs/runner": ["@grammyjs/runner@2.0.3", "", { "dependencies": { "abort-controller": "^3.0.0" }, "peerDependencies": { "grammy": "^1.13.1" } }, "sha512-nckmTs1dPWfVQteK9cxqxzE+0m1VRvluLWB8UgFzsjg62w3qthPJt0TYtJBEdG7OedvfQq4vnFAyE6iaMkR42A=="],
 
     "@grammyjs/types": ["@grammyjs/types@3.26.0", "", {}, "sha512-jlnyfxfev/2o68HlvAGRocAXgdPPX5QabG7jZlbqC2r9DZyWBfzTlg+nu3O3Fy4EhgLWu28hZ/8wr7DsNamP9A=="],
@@ -177,6 +186,22 @@
     "@manypkg/get-packages": ["@manypkg/get-packages@1.1.3", "", { "dependencies": { "@babel/runtime": "^7.5.5", "@changesets/types": "^4.0.1", "@manypkg/find-root": "^1.1.0", "fs-extra": "^8.1.0", "globby": "^11.0.0", "read-yaml-file": "^1.1.0" } }, "sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A=="],
 
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
+
+    "@mtcute/core": ["@mtcute/core@0.27.9", "", { "dependencies": { "@fuman/io": "0.0.19", "@fuman/net": "0.0.19", "@fuman/utils": "0.0.19", "@mtcute/file-id": "^0.27.8", "@mtcute/tl": "^221.0.0", "@mtcute/tl-runtime": "^0.24.3", "@types/events": "3.0.0", "long": "5.2.3" } }, "sha512-kbi/ml8H7Asnn5u1yQVRVl8CVZd03WU2Z4Sgd5d3RYqaoqRUA9wgUV9aEhq+bEgsvmnEr+PuwZ+/HKriXhtqlA=="],
+
+    "@mtcute/file-id": ["@mtcute/file-id@0.27.8", "", { "dependencies": { "@fuman/utils": "0.0.19", "@mtcute/tl-runtime": "^0.24.3", "long": "5.2.3" } }, "sha512-clwuBxVZKCSv65HMjxCx0zSnaZypAeNFy0pmnA0Uhvb9zvvB8lbd9Ig2BPieUkk/BbI+z8KZa0jvWOVe929Egw=="],
+
+    "@mtcute/html-parser": ["@mtcute/html-parser@0.27.9", "", { "dependencies": { "@mtcute/core": "^0.27.9", "htmlparser2": "^10.0.0", "long": "5.2.3" } }, "sha512-ojq7ah4rwkLWmZP0fZx4glnSA7D75fcrMBS1HsEf6/uyrWy/F74aDZWwdLMrL8EjSVS0JdMKbli+kow+49JPJA=="],
+
+    "@mtcute/markdown-parser": ["@mtcute/markdown-parser@0.27.9", "", { "dependencies": { "@mtcute/core": "^0.27.9", "long": "5.2.3" } }, "sha512-4roQapd+r3aZtP2BWeYbcPt6rhZUBv1Ua0CJfopGY25XlU3lEDYeqGrn0KuWYKr11dztEDo5M01IBmcyRqUlow=="],
+
+    "@mtcute/node": ["@mtcute/node@0.27.9", "", { "dependencies": { "@fuman/net": "0.0.19", "@fuman/node": "0.0.19", "@fuman/utils": "0.0.19", "@mtcute/core": "^0.27.9", "@mtcute/html-parser": "^0.27.9", "@mtcute/markdown-parser": "^0.27.9", "@mtcute/wasm": "^0.27.8", "better-sqlite3": "^12.4.1" } }, "sha512-Tflz5LRbTG5DE2rSUIRhLlBfey7ibhSQLTLTJD9nsoNpBeOG4ms/bc6VfBTQMHJytb8VCYQOHrXWZb9eYhWOPg=="],
+
+    "@mtcute/tl": ["@mtcute/tl@221.0.0", "", { "dependencies": { "long": "5.2.3" } }, "sha512-Wp01L9nznTMLl2s9rbKnzQ8pij72eF4HK2XIziOQoJXiObPKZxQdxvMj+C6l0ArxMFmpT0H0/3EL5RB7O6VPwg=="],
+
+    "@mtcute/tl-runtime": ["@mtcute/tl-runtime@0.24.3", "", { "dependencies": { "@fuman/utils": "0.0.15", "long": "5.2.3" } }, "sha512-61J3cgYgNOQT532GdIiuezRrSC7v6cc9MfvWv9GO27bRGf7JUKWVbFt4U0KzQ9Tp0J1uMOUfi1EbQKkYKacIKQ=="],
+
+    "@mtcute/wasm": ["@mtcute/wasm@0.27.8", "", {}, "sha512-3z1v1WtkAAW95l5t8LB3Ul+Y8dQNMez5YF16cHE3mAHX5RRrfgE+rgVk+wRQJHa24CugfuEEBSi6QpdZuTRBIw=="],
 
     "@nodelib/fs.scandir": ["@nodelib/fs.scandir@2.1.5", "", { "dependencies": { "@nodelib/fs.stat": "2.0.5", "run-parallel": "^1.1.9" } }, "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g=="],
 
@@ -256,6 +281,8 @@
 
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 
+    "@types/events": ["@types/events@3.0.0", "", {}, "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g=="],
+
     "@types/node": ["@types/node@22.19.17", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q=="],
 
     "@vitest/coverage-v8": ["@vitest/coverage-v8@3.2.4", "", { "dependencies": { "@ampproject/remapping": "^2.3.0", "@bcoe/v8-coverage": "^1.0.2", "ast-v8-to-istanbul": "^0.3.3", "debug": "^4.4.1", "istanbul-lib-coverage": "^3.2.2", "istanbul-lib-report": "^3.0.1", "istanbul-lib-source-maps": "^5.0.6", "istanbul-reports": "^3.1.7", "magic-string": "^0.30.17", "magicast": "^0.3.5", "std-env": "^3.9.0", "test-exclude": "^7.0.1", "tinyrainbow": "^2.0.0" }, "peerDependencies": { "@vitest/browser": "3.2.4", "vitest": "3.2.4" }, "optionalPeers": ["@vitest/browser"] }, "sha512-EyF9SXU6kS5Ku/U82E259WSnvg6c8KTjppUncuNdm5QHpe17mwREHnjDzozC8x9MZ0xfBUFSaLkRv4TMA75ALQ=="],
@@ -304,9 +331,17 @@
 
     "balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 
+    "base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
+
     "bcryptjs": ["bcryptjs@3.0.3", "", { "bin": { "bcrypt": "bin/bcrypt" } }, "sha512-GlF5wPWnSa/X5LKM1o0wz0suXIINz1iHRLvTS+sLyi7XPbe5ycmYI3DlZqVGZZtDgl4DmasFg7gOB3JYbphV5g=="],
 
     "better-path-resolve": ["better-path-resolve@1.0.0", "", { "dependencies": { "is-windows": "^1.0.0" } }, "sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g=="],
+
+    "better-sqlite3": ["better-sqlite3@12.9.0", "", { "dependencies": { "bindings": "^1.5.0", "prebuild-install": "^7.1.1" } }, "sha512-wqUv4Gm3toFpHDQmaKD4QhZm3g1DjUBI0yzS4UBl6lElUmXFYdTQmmEDpAFa5o8FiFiymURypEnfVHzILKaxqQ=="],
+
+    "bindings": ["bindings@1.5.0", "", { "dependencies": { "file-uri-to-path": "1.0.0" } }, "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ=="],
+
+    "bl": ["bl@4.1.0", "", { "dependencies": { "buffer": "^5.5.0", "inherits": "^2.0.4", "readable-stream": "^3.4.0" } }, "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w=="],
 
     "body-parser": ["body-parser@2.2.2", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^1.0.5", "debug": "^4.4.3", "http-errors": "^2.0.0", "iconv-lite": "^0.7.0", "on-finished": "^2.4.1", "qs": "^6.14.1", "raw-body": "^3.0.1", "type-is": "^2.0.1" } }, "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA=="],
 
@@ -315,6 +350,8 @@
     "brace-expansion": ["brace-expansion@5.0.5", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ=="],
 
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
+
+    "buffer": ["buffer@5.7.1", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.1.13" } }, "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ=="],
 
     "buildkite-test-collector": ["buildkite-test-collector@1.9.5", "", { "dependencies": { "axios": "^1.8.2", "dotenv": "^16.0.2", "request-spy": "^0.0.10", "strip-ansi": "^6.0.0", "uuid": "^8.3.2" } }, "sha512-xb1jLDKDEAI/FfJ2X/br2SfJviI7kH5PqPLn1PC5F+XRA95d0IxN7EcUH6PsEt21nZmmXFohyl4JpWRz8cCAeg=="],
 
@@ -335,6 +372,8 @@
     "chardet": ["chardet@2.1.1", "", {}, "sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ=="],
 
     "check-error": ["check-error@2.1.3", "", {}, "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA=="],
+
+    "chownr": ["chownr@1.1.4", "", {}, "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="],
 
     "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
 
@@ -358,7 +397,11 @@
 
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
+    "decompress-response": ["decompress-response@6.0.0", "", { "dependencies": { "mimic-response": "^3.1.0" } }, "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ=="],
+
     "deep-eql": ["deep-eql@5.0.2", "", {}, "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q=="],
+
+    "deep-extend": ["deep-extend@0.6.0", "", {}, "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="],
 
     "delayed-stream": ["delayed-stream@1.0.0", "", {}, "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="],
 
@@ -366,7 +409,17 @@
 
     "detect-indent": ["detect-indent@6.1.0", "", {}, "sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA=="],
 
+    "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
+
     "dir-glob": ["dir-glob@3.0.1", "", { "dependencies": { "path-type": "^4.0.0" } }, "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA=="],
+
+    "dom-serializer": ["dom-serializer@2.0.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.2", "entities": "^4.2.0" } }, "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg=="],
+
+    "domelementtype": ["domelementtype@2.3.0", "", {}, "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw=="],
+
+    "domhandler": ["domhandler@5.0.3", "", { "dependencies": { "domelementtype": "^2.3.0" } }, "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w=="],
+
+    "domutils": ["domutils@3.2.2", "", { "dependencies": { "dom-serializer": "^2.0.0", "domelementtype": "^2.3.0", "domhandler": "^5.0.3" } }, "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw=="],
 
     "dotenv": ["dotenv@16.6.1", "", {}, "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow=="],
 
@@ -380,7 +433,11 @@
 
     "encodeurl": ["encodeurl@2.0.0", "", {}, "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="],
 
+    "end-of-stream": ["end-of-stream@1.4.5", "", { "dependencies": { "once": "^1.4.0" } }, "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg=="],
+
     "enquirer": ["enquirer@2.4.1", "", { "dependencies": { "ansi-colors": "^4.1.1", "strip-ansi": "^6.0.1" } }, "sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ=="],
+
+    "entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
 
     "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
 
@@ -408,6 +465,8 @@
 
     "eventsource-parser": ["eventsource-parser@3.0.6", "", {}, "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg=="],
 
+    "expand-template": ["expand-template@2.0.3", "", {}, "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg=="],
+
     "expect-type": ["expect-type@1.3.0", "", {}, "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA=="],
 
     "express": ["express@5.2.1", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.1", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "depd": "^2.0.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw=="],
@@ -426,6 +485,8 @@
 
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
+    "file-uri-to-path": ["file-uri-to-path@1.0.0", "", {}, "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="],
+
     "fill-range": ["fill-range@7.1.1", "", { "dependencies": { "to-regex-range": "^5.0.1" } }, "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg=="],
 
     "finalhandler": ["finalhandler@2.1.1", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA=="],
@@ -442,6 +503,8 @@
 
     "fresh": ["fresh@2.0.0", "", {}, "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="],
 
+    "fs-constants": ["fs-constants@1.0.0", "", {}, "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="],
+
     "fs-extra": ["fs-extra@7.0.1", "", { "dependencies": { "graceful-fs": "^4.1.2", "jsonfile": "^4.0.0", "universalify": "^0.1.0" } }, "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw=="],
 
     "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
@@ -451,6 +514,8 @@
     "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
 
     "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
+
+    "github-from-package": ["github-from-package@0.0.0", "", {}, "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw=="],
 
     "glob": ["glob@10.5.0", "", { "dependencies": { "foreground-child": "^3.1.0", "jackspeak": "^3.1.2", "minimatch": "^9.0.4", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^1.11.1" }, "bin": { "glob": "dist/esm/bin.mjs" } }, "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg=="],
 
@@ -478,15 +543,21 @@
 
     "html-escaper": ["html-escaper@2.0.2", "", {}, "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg=="],
 
+    "htmlparser2": ["htmlparser2@10.1.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.3", "domutils": "^3.2.2", "entities": "^7.0.1" } }, "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ=="],
+
     "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
 
     "human-id": ["human-id@4.1.3", "", { "bin": { "human-id": "dist/cli.js" } }, "sha512-tsYlhAYpjCKa//8rXZ9DqKEawhPoSytweBC2eNvcaDK+57RZLHGqNs3PZTQO6yekLFSuvA6AlnAfrw1uBvtb+Q=="],
 
     "iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
 
+    "ieee754": ["ieee754@1.2.1", "", {}, "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="],
+
     "ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
 
     "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
+
+    "ini": ["ini@1.3.8", "", {}, "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="],
 
     "ip-address": ["ip-address@10.1.0", "", {}, "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q=="],
 
@@ -534,6 +605,8 @@
 
     "lodash.startcase": ["lodash.startcase@4.4.0", "", {}, "sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg=="],
 
+    "long": ["long@5.2.3", "", {}, "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q=="],
+
     "loupe": ["loupe@3.2.1", "", {}, "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ=="],
 
     "lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
@@ -558,11 +631,15 @@
 
     "mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
 
+    "mimic-response": ["mimic-response@3.1.0", "", {}, "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ=="],
+
     "minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
 
     "minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
 
     "minipass": ["minipass@7.1.3", "", {}, "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A=="],
+
+    "mkdirp-classic": ["mkdirp-classic@0.5.3", "", {}, "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="],
 
     "monkeypatch": ["monkeypatch@1.0.0", "", {}, "sha512-6tG0IrCUUIBuAspnbdmOAd+D/AptB/ya9JLujp88NIAuFuTGdGvCKtDkc6pwNOcIJ6nKLm3FjJlaCdx8vr3r2w=="],
 
@@ -572,9 +649,13 @@
 
     "nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
 
+    "napi-build-utils": ["napi-build-utils@2.0.0", "", {}, "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA=="],
+
     "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
 
     "neo-async": ["neo-async@2.6.2", "", {}, "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="],
+
+    "node-abi": ["node-abi@3.92.0", "", { "dependencies": { "semver": "^7.3.5" } }, "sha512-KdHvFWZjEKDf0cakgFjebl371GPsISX2oZHcuyKqM7DtogIsHrqKeLTo8wBHxaXRAQlY2PsPlZmfo+9ZCxEREQ=="],
 
     "node-fetch": ["node-fetch@2.7.0", "", { "dependencies": { "whatwg-url": "^5.0.0" }, "peerDependencies": { "encoding": "^0.1.0" }, "optionalPeers": ["encoding"] }, "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A=="],
 
@@ -630,11 +711,15 @@
 
     "posthog-node": ["posthog-node@5.29.2", "", { "dependencies": { "@posthog/core": "1.25.2" }, "peerDependencies": { "rxjs": "^7.0.0" }, "optionalPeers": ["rxjs"] }, "sha512-rI7kkF0XqDc0G1qjx+Hb4iuY9NAlL+XQNoGOpnEpRNTUcXvjY6WlsRGZ9m2whgc39emrrYdszi/YT8wZkr2xsg=="],
 
+    "prebuild-install": ["prebuild-install@7.1.3", "", { "dependencies": { "detect-libc": "^2.0.0", "expand-template": "^2.0.3", "github-from-package": "0.0.0", "minimist": "^1.2.3", "mkdirp-classic": "^0.5.3", "napi-build-utils": "^2.0.0", "node-abi": "^3.3.0", "pump": "^3.0.0", "rc": "^1.2.7", "simple-get": "^4.0.0", "tar-fs": "^2.0.0", "tunnel-agent": "^0.6.0" }, "bin": { "prebuild-install": "bin.js" } }, "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug=="],
+
     "prettier": ["prettier@2.8.8", "", { "bin": { "prettier": "bin-prettier.js" } }, "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q=="],
 
     "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
 
     "proxy-from-env": ["proxy-from-env@2.1.0", "", {}, "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA=="],
+
+    "pump": ["pump@3.0.4", "", { "dependencies": { "end-of-stream": "^1.1.0", "once": "^1.3.1" } }, "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA=="],
 
     "qs": ["qs@6.15.1", "", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg=="],
 
@@ -646,7 +731,11 @@
 
     "raw-body": ["raw-body@3.0.2", "", { "dependencies": { "bytes": "~3.1.2", "http-errors": "~2.0.1", "iconv-lite": "~0.7.0", "unpipe": "~1.0.0" } }, "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA=="],
 
+    "rc": ["rc@1.2.8", "", { "dependencies": { "deep-extend": "^0.6.0", "ini": "~1.3.0", "minimist": "^1.2.0", "strip-json-comments": "~2.0.1" }, "bin": { "rc": "./cli.js" } }, "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw=="],
+
     "read-yaml-file": ["read-yaml-file@1.1.0", "", { "dependencies": { "graceful-fs": "^4.1.5", "js-yaml": "^3.6.1", "pify": "^4.0.1", "strip-bom": "^3.0.0" } }, "sha512-VIMnQi/Z4HT2Fxuwg5KrY174U1VdUIASQVWXXyqtNRtxSr9IYkn1rsI6Tb6HsrHCmB7gVpNwX6JxPTHcH6IoTA=="],
+
+    "readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
 
     "request-spy": ["request-spy@0.0.10", "", { "dependencies": { "monkeypatch": "^1.0.0" } }, "sha512-va+4vLamK9Pwu/WJnJrQcTjCjYdIcl0KDKOKEkfvNmer4f+K+OhgbpU4DCiPyzBGnTpYXbrVLrnD8O5fS/cmKA=="],
 
@@ -661,6 +750,8 @@
     "router": ["router@2.2.0", "", { "dependencies": { "debug": "^4.4.0", "depd": "^2.0.0", "is-promise": "^4.0.0", "parseurl": "^1.3.3", "path-to-regexp": "^8.0.0" } }, "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ=="],
 
     "run-parallel": ["run-parallel@1.2.0", "", { "dependencies": { "queue-microtask": "^1.2.2" } }, "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA=="],
+
+    "safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
 
     "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
 
@@ -688,6 +779,10 @@
 
     "signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
 
+    "simple-concat": ["simple-concat@1.0.1", "", {}, "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q=="],
+
+    "simple-get": ["simple-get@4.0.1", "", { "dependencies": { "decompress-response": "^6.0.0", "once": "^1.3.1", "simple-concat": "^1.0.0" } }, "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA=="],
+
     "slash": ["slash@3.0.0", "", {}, "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q=="],
 
     "source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
@@ -708,17 +803,25 @@
 
     "string-width-cjs": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
+    "string_decoder": ["string_decoder@1.3.0", "", { "dependencies": { "safe-buffer": "~5.2.0" } }, "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA=="],
+
     "strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
     "strip-ansi-cjs": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
     "strip-bom": ["strip-bom@3.0.0", "", {}, "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA=="],
 
+    "strip-json-comments": ["strip-json-comments@2.0.1", "", {}, "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ=="],
+
     "strip-literal": ["strip-literal@3.1.0", "", { "dependencies": { "js-tokens": "^9.0.1" } }, "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg=="],
 
     "structured-source": ["structured-source@4.0.0", "", { "dependencies": { "boundary": "^2.0.0" } }, "sha512-qGzRFNJDjFieQkl/sVOI2dUjHKRyL9dAJi2gCPGJLbJHBIkyOHxjuocpIEfbLioX+qSJpvbYdT49/YCdMznKxA=="],
 
     "supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
+
+    "tar-fs": ["tar-fs@2.1.4", "", { "dependencies": { "chownr": "^1.1.1", "mkdirp-classic": "^0.5.2", "pump": "^3.0.0", "tar-stream": "^2.1.4" } }, "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ=="],
+
+    "tar-stream": ["tar-stream@2.2.0", "", { "dependencies": { "bl": "^4.0.3", "end-of-stream": "^1.4.1", "fs-constants": "^1.0.0", "inherits": "^2.0.3", "readable-stream": "^3.1.1" } }, "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ=="],
 
     "term-size": ["term-size@2.2.1", "", {}, "sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg=="],
 
@@ -742,6 +845,8 @@
 
     "tr46": ["tr46@0.0.3", "", {}, "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="],
 
+    "tunnel-agent": ["tunnel-agent@0.6.0", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w=="],
+
     "type-is": ["type-is@2.0.1", "", { "dependencies": { "content-type": "^1.0.5", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw=="],
 
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
@@ -753,6 +858,8 @@
     "universalify": ["universalify@0.1.2", "", {}, "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="],
 
     "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
+
+    "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
 
     "uuid": ["uuid@8.3.2", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="],
 
@@ -795,6 +902,10 @@
     "@manypkg/get-packages/@changesets/types": ["@changesets/types@4.1.0", "", {}, "sha512-LDQvVDv5Kb50ny2s25Fhm3d9QSZimsoUGBsUioj6MC3qbMUCuC8GPIvk/M6IvXx3lYhAs0lwWUQLb+VIEUCECw=="],
 
     "@manypkg/get-packages/fs-extra": ["fs-extra@8.1.0", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^4.0.0", "universalify": "^0.1.0" } }, "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g=="],
+
+    "@mtcute/tl-runtime/@fuman/utils": ["@fuman/utils@0.0.15", "", {}, "sha512-3H3WzkfG7iLKCa/yNV4s80lYD4yr5hgiNzU13ysLY2BcDqFjM08XGYuLd5wFVp4V8+DA/fe8gIDW96To/JwDyA=="],
+
+    "dom-serializer/entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
 
     "form-data/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
 

--- a/telegram-plugin/package.json
+++ b/telegram-plugin/package.json
@@ -19,11 +19,14 @@
     "start:source": "bun server.ts",
     "start:dist": "bun dist/server.js",
     "build": "node scripts/build.mjs",
-    "prepublishOnly": "npm run build"
+    "prepublishOnly": "npm run build",
+    "test:uat": "vitest run --config ../vitest.uat.config.ts",
+    "uat:login": "bun uat/login.ts"
   },
   "dependencies": {
     "@grammyjs/runner": "^2.0.3",
     "@modelcontextprotocol/sdk": "^1.0.0",
+    "@mtcute/node": "^0.27.0",
     "@secretlint/core": "^12.2.0",
     "@secretlint/secretlint-rule-preset-recommend": "^12.2.0",
     "@secretlint/types": "^12.2.0",

--- a/telegram-plugin/uat/SETUP.md
+++ b/telegram-plugin/uat/SETUP.md
@@ -1,0 +1,160 @@
+# UAT Harness — One-time Setup
+
+This is the operator runbook for bringing up the Telegram UAT harness
+introduced by epic [#863](https://github.com/switchroom/switchroom/issues/863).
+Phase 1 ships scaffolding only — every step in this file is a manual
+prerequisite that must be completed once before the first scenario can
+run against real Telegram.
+
+> ⚠️ **Security floor.** The mtcute *session string* this harness mints
+> is **bearer-equivalent to the driver Telegram user account**. Anyone
+> holding it can read every chat the user can read and impersonate them
+> in messages. Treat it with the same care as a long-lived OAuth refresh
+> token:
+>
+> - **Never** log it. **Never** echo it to a terminal. **Never** commit
+>   it. **Never** paste it into chat for "debugging."
+> - It lives in vault under key `telegram-uat-driver-session` and that
+>   is the only legitimate location.
+> - Same rules apply to `telegram-test-bot-token` (a normal bot token,
+>   but a bot the harness drives autonomously — leak = remote control).
+
+---
+
+## 1. BotFather: create the test bot
+
+1. Open `@BotFather` from the operator's Telegram account.
+2. `/newbot` → name (e.g. `Switchroom UAT`) → username (e.g.
+   `@switchroom_uat_bot`).
+3. Copy the HTTP API token BotFather returns.
+4. **Disable privacy mode** so the test bot sees all messages in groups,
+   not just commands: `/setprivacy` → select the bot → `Disable`.
+   (Privacy mode does not affect the driver's ability to read the bot —
+   bots cannot read other bots regardless. This is for the bot reading
+   the driver user.)
+5. Vault the token:
+   ```bash
+   switchroom vault set telegram-test-bot-token
+   # paste token at the prompt; do not pass via argv
+   ```
+6. Sanity check:
+   ```bash
+   TOKEN=$(switchroom vault get telegram-test-bot-token)
+   curl -s "https://api.telegram.org/bot${TOKEN}/getMe" | jq .ok
+   # expect: true
+   unset TOKEN
+   ```
+
+## 2. Create the test supergroup
+
+1. New Group → add the test bot + the driver user → "Upgrade to
+   supergroup" (Settings → Group Type, or just enable Topics; both
+   actions imply supergroup).
+2. Settings → **Topics: Enabled**.
+3. Settings → Administrators → promote both:
+   - test bot — needs at least: Manage Topics, Pin Messages, Delete
+     Messages.
+   - driver user — needs at least: Manage Topics (so per-scenario
+     topic creation works without the bot doing it).
+4. Note the chat id. Easiest: forward any message from the supergroup
+   to `@RawDataBot` and copy `forward_from_chat.id`. It will be
+   negative and ~13 digits (`-100…`).
+5. Stash the chat id under your shell profile or a UAT env file (NOT
+   in the repo):
+   ```bash
+   echo 'export SWITCHROOM_UAT_CHAT_ID=-1001234567890' >> ~/.config/switchroom/uat.env
+   ```
+
+## 3. Driver user: mint the mtcute session
+
+The mtcute MTProto driver runs as a **Telegram user account**, not a
+bot, because bots cannot read other bots' messages even with admin
+rights. ([Telegram Bots FAQ](https://core.telegram.org/bots/faq).)
+
+You will need:
+- An `api_id` and `api_hash` from <https://my.telegram.org/apps> (one
+  per developer; reusable across projects).
+- The driver user's phone number, the SMS/Telegram login code, and the
+  2FA password if set.
+
+Run:
+```bash
+cd telegram-plugin
+TELEGRAM_API_ID=12345 TELEGRAM_API_HASH=abcdef0123... bun run uat:login
+```
+
+The script prompts for phone, login code, and 2FA password on stdin,
+captures the session string in memory, and writes it to vault as
+`telegram-uat-driver-session`. It **never prints the session string
+to stdout or stderr** — if you see one in your scrollback, file an
+incident.
+
+## 4. 2FA / new-device re-login playbook
+
+mtcute session strings can get invalidated when:
+- The user changes/sets a 2FA password.
+- The user terminates the session from another client (Settings →
+  Devices → Active sessions → Terminate).
+- Telegram's anti-abuse heuristics decide the session is suspicious
+  (rare, but happens after long idle + IP change).
+
+When a scenario fails with `AUTH_KEY_UNREGISTERED`,
+`SESSION_REVOKED`, or `SESSION_PASSWORD_NEEDED`:
+
+1. Confirm via the Telegram app (Settings → Devices) that the prior
+   session is gone.
+2. Re-run `bun run uat:login` from the operator's machine.
+3. Enter the current 2FA password when prompted.
+4. The script overwrites the vault key. No other action required —
+   nothing caches the old string.
+
+If the driver account is locked entirely (e.g. SPAM_WAIT), only the
+account owner can resolve it via support@telegram.org. The harness has
+no recourse.
+
+## 5. Worktree-based agent install (NOT `switchroom agent add`)
+
+The UAT harness does **not** persistently install the test-harness
+agent through `switchroom agent add` (which writes a systemd unit + a
+persistent state dir — wrong shape for hermetic test runs). Instead,
+the harness `exec`s the agent as a child process per scenario with:
+
+- `STATE_DIR=$(mktemp -d)` — ephemeral; teardown rm-rfs it.
+- A unique `TELEGRAM_GATEWAY_PORT` (see port allocator note below).
+- `SWITCHROOM_AGENT_NAME=test-harness`.
+- The test bot token loaded from `telegram-test-bot-token`.
+
+The Phase 1 scaffold stubs this out in `harness.ts`; Phase 2 wires it
+end-to-end.
+
+## 6. Port allocator vs unix sockets
+
+Phase 1 commits to a **process-wide port allocator** (see
+`uat/port-allocator.ts`) rather than unix sockets. Rationale:
+
+- The gateway already speaks IP loopback to the bridge; switching to
+  unix sockets is a code change in `gateway/` we don't want bundled
+  with the UAT scaffold work.
+- Tests only ever run from one harness process, so a node-local
+  monotonic counter starting at a high ephemeral port (default 47000)
+  is enough to avoid collisions with the system + with sibling
+  scenarios in the same run.
+- The allocator also `bind()`s a probe socket and releases it before
+  returning, which catches "port already in use by another process"
+  before the agent boots and produces a confusing crash.
+
+If we ever want concurrent harness runs from CI, swap to unix sockets;
+the harness API takes a `transport` shape so it's a one-line change.
+
+## 7. Verification checklist before running scenarios
+
+- [ ] `switchroom vault get telegram-test-bot-token` returns a token.
+- [ ] `switchroom vault get telegram-uat-driver-session` returns a
+      session string (the command output may be redacted by the
+      vault — that's fine, you only need exit code 0).
+- [ ] `$SWITCHROOM_UAT_CHAT_ID` exported and is a negative int.
+- [ ] Test bot is admin in the supergroup.
+- [ ] Driver user is admin in the supergroup.
+- [ ] Topics enabled in the supergroup.
+
+When all six are checked, `bun run test:uat` is safe to run.

--- a/telegram-plugin/uat/assertions.ts
+++ b/telegram-plugin/uat/assertions.ts
@@ -1,0 +1,140 @@
+/**
+ * Eventual-assertion helpers for UAT scenarios.
+ *
+ * Issue: https://github.com/switchroom/switchroom/issues/866
+ *
+ * Real Telegram is eventually consistent across the bot API, MTProto,
+ * and CDN edges. Every assertion in a UAT scenario is a `waitFor`-
+ * shape: poll a predicate until it goes truthy or a deadline trips.
+ * Avoid `setTimeout(..., N); expect(...)` patterns at all cost.
+ */
+
+import type { Driver, ObservedMessage, ObservedReaction } from "./driver.js";
+
+export interface PollOptions {
+  /** Hard deadline; the predicate must resolve truthy before this. */
+  timeout: number;
+  /** Poll cadence in ms. Default 250ms. */
+  interval?: number;
+}
+
+/**
+ * Poll `predicate` every `interval` ms until it returns a truthy
+ * value, then resolve with that value. Reject when `timeout` ms
+ * elapse without success.
+ *
+ * The predicate may throw — exceptions are caught and treated as a
+ * "not yet" signal until the deadline. The last-seen exception is
+ * attached to the timeout error so flakes are debuggable.
+ */
+export async function pollUntil<T>(
+  predicate: () => Promise<T | undefined | null | false> | T | undefined | null | false,
+  opts: PollOptions,
+): Promise<T> {
+  const interval = opts.interval ?? 250;
+  const deadline = Date.now() + opts.timeout;
+  let lastError: unknown;
+
+  while (Date.now() < deadline) {
+    try {
+      const result = await predicate();
+      if (result) return result as T;
+    } catch (err) {
+      lastError = err;
+    }
+    const remaining = deadline - Date.now();
+    if (remaining <= 0) break;
+    await sleep(Math.min(interval, remaining));
+  }
+
+  const detail = lastError instanceof Error ? `: ${lastError.message}` : "";
+  throw new Error(`pollUntil: deadline exceeded after ${opts.timeout}ms${detail}`);
+}
+
+/**
+ * Sugar over `pollUntil` for the boolean-predicate case where the
+ * caller wants a clear assertion message.
+ */
+export async function expectEventually(
+  predicate: () => Promise<boolean> | boolean,
+  opts: PollOptions,
+  msg: string,
+): Promise<void> {
+  await pollUntil(async () => {
+    const ok = await predicate();
+    return ok || undefined;
+  }, opts).catch((err) => {
+    throw new Error(`expectEventually(${msg}): ${(err as Error).message}`);
+  });
+}
+
+// ---------- Phase 2 stubs ----------
+
+/**
+ * TODO(#866): wait for the bot to send a message in `chatId`/topic
+ * matching `match` (substring, regex, or predicate over the raw
+ * `ObservedMessage`). Returns the matched message.
+ */
+export async function expectMessage(
+  _driver: Driver,
+  _chatId: number,
+  _match: string | RegExp | ((m: ObservedMessage) => boolean),
+  _opts: PollOptions & { threadId?: number; from?: "bot" | "user" },
+): Promise<ObservedMessage> {
+  throw new Error("expectMessage not implemented (Phase 2)");
+}
+
+/**
+ * TODO(#866): wait for a reaction sequence on `messageId`. Each
+ * emoji in `sequence` must appear (add op) in order; intermediate
+ * other reactions are tolerated. Returns the full observed reaction
+ * trail.
+ */
+export async function expectReaction(
+  _driver: Driver,
+  _chatId: number,
+  _messageId: number,
+  _sequence: string[],
+  _opts: PollOptions,
+): Promise<ObservedReaction[]> {
+  throw new Error("expectReaction not implemented (Phase 2)");
+}
+
+export interface PinnedCardSnapshot {
+  messageId: number;
+  text: string;
+  html?: string;
+  /** Production phase markers: `boot` | `working` | `done` | `error`. */
+  phase: string;
+}
+
+/**
+ * TODO(#866): wait for a pinned message to appear in
+ * `chatId`/topic (the progress card). Resolves with a snapshot of
+ * its current text/phase.
+ */
+export async function expectPinnedCard(
+  _driver: Driver,
+  _chatId: number,
+  _opts: PollOptions & { threadId?: number },
+): Promise<PinnedCardSnapshot> {
+  throw new Error("expectPinnedCard not implemented (Phase 2)");
+}
+
+/**
+ * TODO(#866): wait for the pinned progress card to transition to
+ * `phase`. The harness must read live edits, not just the snapshot
+ * captured by `expectPinnedCard`.
+ */
+export async function waitForCardPhase(
+  _driver: Driver,
+  _card: PinnedCardSnapshot,
+  _phase: "boot" | "working" | "done" | "error",
+  _opts: PollOptions,
+): Promise<PinnedCardSnapshot> {
+  throw new Error("waitForCardPhase not implemented (Phase 2)");
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/telegram-plugin/uat/driver.ts
+++ b/telegram-plugin/uat/driver.ts
@@ -1,0 +1,174 @@
+/**
+ * mtcute-backed Telegram user-account driver for the UAT harness.
+ *
+ * Issue: https://github.com/switchroom/switchroom/issues/865
+ *
+ * The driver is a Telegram **user account** (not a bot) because bots
+ * cannot read other bots' messages even with privacy mode disabled
+ * and admin rights — see Telegram Bots FAQ. The driver sends fixture
+ * inbounds and observes everything the test bot emits.
+ *
+ * Phase 1: typed wrapper around mtcute with `connect` / `disconnect` /
+ * `sendText` implemented. `sendVoice`, `observeMessages`,
+ * `observeReactions`, `observePins` are stubs with TODO markers — they
+ * land in Phase 2 alongside the scenario catalog.
+ *
+ * Security: never log session strings, never log message bodies that
+ * might contain auth codes (see `auth-code-redact.ts` for the
+ * production pattern).
+ */
+
+import { TelegramClient } from "@mtcute/node";
+
+export interface DriverOptions {
+  /** Telegram developer credential — `api_id` from my.telegram.org. */
+  apiId: number;
+  /** Telegram developer credential — `api_hash` from my.telegram.org. */
+  apiHash: string;
+  /**
+   * Session string previously minted by `bun run uat:login` and
+   * stored in vault under `telegram-uat-driver-session`. Bearer-
+   * equivalent — never log.
+   */
+  session: string;
+}
+
+export interface SendTextOptions {
+  /** Forum topic id, when targeting a topic in a supergroup. */
+  messageThreadId?: number;
+  /** Reply-quote a specific earlier message id. */
+  replyTo?: number;
+}
+
+export interface ObservedMessage {
+  chatId: number;
+  messageId: number;
+  threadId?: number;
+  text: string;
+  /** raw HTML if the message was sent with `parse_mode: HTML`. */
+  html?: string;
+  fromBot: boolean;
+  date: Date;
+}
+
+export interface ObservedReaction {
+  chatId: number;
+  messageId: number;
+  emoji: string;
+  /** Reaction add (`+`) vs remove (`-`). */
+  op: "+" | "-";
+  date: Date;
+}
+
+export interface ObservedPin {
+  chatId: number;
+  messageId: number;
+  pinned: boolean;
+  date: Date;
+}
+
+/**
+ * Thin wrapper. Concrete mtcute use is intentionally narrow so the
+ * scenarios don't get tangled up in raw MTProto types.
+ */
+export class Driver {
+  private client: TelegramClient | null = null;
+
+  constructor(private readonly opts: DriverOptions) {}
+
+  async connect(): Promise<void> {
+    // mtcute v0.27 takes session via the `storage` option. For a
+    // string-session driver we'll use `@mtcute/core/utils.js`'s
+    // string-session-storage in Phase 2; Phase 1 just records the
+    // shape so the harness compiles.
+    // TODO(#865): wire StringSessionStorage from @mtcute/core/utils
+    // and feed `this.opts.session` through it.
+    this.client = new TelegramClient({
+      apiId: this.opts.apiId,
+      apiHash: this.opts.apiHash,
+    });
+    void this.opts.session;
+  }
+
+  async disconnect(): Promise<void> {
+    if (!this.client) return;
+    await this.client.destroy();
+    this.client = null;
+  }
+
+  async sendText(
+    chatId: number,
+    text: string,
+    opts?: SendTextOptions,
+  ): Promise<{ messageId: number }> {
+    const c = this.requireClient();
+    // mtcute exposes `sendText(peer, text, params)`. Forum topic
+    // targeting is via `params.replyTo` carrying a topic ref in
+    // newer mtcute; precise shape verified in Phase 2.
+    const sent = await c.sendText(chatId, text, {
+      replyTo: opts?.replyTo,
+    } as Parameters<TelegramClient["sendText"]>[2]);
+    void opts?.messageThreadId; // TODO(#865): topic routing in Phase 2
+    return { messageId: sent.id };
+  }
+
+  // -------- Phase 2 stubs --------
+
+  /**
+   * TODO(#865): send a voice note as the driver user. Needed for the
+   * `voice-inbound.test.ts` scenario. mtcute's `sendVoice` takes an
+   * OGG/Opus buffer or a path; we'll stage fixtures under
+   * `uat/fixtures/voice/`.
+   */
+  async sendVoice(
+    _chatId: number,
+    _oggPath: string,
+    _opts?: SendTextOptions,
+  ): Promise<{ messageId: number }> {
+    throw new Error("Driver.sendVoice not implemented (Phase 2)");
+  }
+
+  /**
+   * TODO(#865): subscribe to new + edited messages in `chatId`/topic.
+   * Returns an async iterable so scenarios can `for await` until a
+   * predicate matches. Should backfill via `getHistory(limit:50)` to
+   * catch messages that arrived between connect and observe-start.
+   */
+  observeMessages(
+    _chatId: number,
+    _opts?: { threadId?: number },
+  ): AsyncIterable<ObservedMessage> {
+    throw new Error("Driver.observeMessages not implemented (Phase 2)");
+  }
+
+  /**
+   * TODO(#865): subscribe to message-reaction updates. Note: mtcute
+   * delivers `updateMessageReactions` as a delta (full set after the
+   * change); the driver should compute add/remove ops vs the prior
+   * snapshot so scenarios can assert on the 👀→🤔→🔥→👍 sequence.
+   */
+  observeReactions(
+    _chatId: number,
+    _opts?: { messageId?: number },
+  ): AsyncIterable<ObservedReaction> {
+    throw new Error("Driver.observeReactions not implemented (Phase 2)");
+  }
+
+  /**
+   * TODO(#865): subscribe to pin/unpin events on `chatId`/topic.
+   * Used for progress-card-lifecycle assertions.
+   */
+  observePins(
+    _chatId: number,
+    _opts?: { threadId?: number },
+  ): AsyncIterable<ObservedPin> {
+    throw new Error("Driver.observePins not implemented (Phase 2)");
+  }
+
+  private requireClient(): TelegramClient {
+    if (!this.client) {
+      throw new Error("Driver not connected — call connect() first");
+    }
+    return this.client;
+  }
+}

--- a/telegram-plugin/uat/harness.ts
+++ b/telegram-plugin/uat/harness.ts
@@ -1,0 +1,161 @@
+/**
+ * Scenario harness for UAT runs.
+ *
+ * Issue: https://github.com/switchroom/switchroom/issues/866
+ *
+ * `spinUp({ agent, topic })` is the single entry point a scenario
+ * uses. Phase 1 ships the type shape + the lifecycle skeleton; the
+ * actual `child_process.spawn` of the agent under test is stubbed
+ * with TODO markers so the reviewer can see exactly where Phase 2
+ * lands.
+ */
+
+import { Driver } from "./driver.js";
+import {
+  expectMessage,
+  expectPinnedCard,
+  expectReaction,
+  waitForCardPhase,
+  type PollOptions,
+  type PinnedCardSnapshot,
+} from "./assertions.js";
+import { allocatePort } from "./port-allocator.js";
+
+export interface SpinUpOptions {
+  /** Agent name to install + run, e.g. `"clerk"`, `"test-harness"`. */
+  agent: string;
+  /**
+   * Forum topic slug for isolation. The harness creates the topic in
+   * the test supergroup and tears it down after the scenario.
+   */
+  topic: string;
+}
+
+export interface Scenario {
+  /** mtcute driver, already connected. */
+  driver: Driver;
+  /** Negative supergroup chat id; from `$SWITCHROOM_UAT_CHAT_ID`. */
+  chatId: number;
+  /** Topic id created for this scenario. */
+  threadId: number;
+
+  // Sugar over the assertion helpers, pre-bound to this scenario's
+  // chat + thread. Phase 1 returns a thin pass-through.
+  expectMessage: (
+    match: Parameters<typeof expectMessage>[2],
+    opts: PollOptions & { from?: "bot" | "user" },
+  ) => ReturnType<typeof expectMessage>;
+  expectReaction: (
+    messageId: number,
+    sequence: string[],
+    opts: PollOptions,
+  ) => ReturnType<typeof expectReaction>;
+  expectPinnedCard: (opts: PollOptions) => ReturnType<typeof expectPinnedCard>;
+  waitForCardPhase: (
+    card: PinnedCardSnapshot,
+    phase: "boot" | "working" | "done" | "error",
+    opts: PollOptions,
+  ) => ReturnType<typeof waitForCardPhase>;
+
+  /** Stop the agent process, delete the topic, disconnect the driver. */
+  tearDown: () => Promise<void>;
+}
+
+/**
+ * Spin up an isolated agent + scenario context.
+ *
+ * Phase 1: returns a stub Scenario whose tools throw helpful "not
+ * implemented" errors. The shape is correct so scenarios written
+ * against it will typecheck today and run for real once Phase 2
+ * lands.
+ */
+export async function spinUp(opts: SpinUpOptions): Promise<Scenario> {
+  // TODO(#866): resolve secrets from vault.
+  //   - `telegram-test-bot-token` for the agent under test
+  //   - `telegram-uat-driver-session` for the mtcute driver
+  //   - `TELEGRAM_API_ID` / `TELEGRAM_API_HASH` from env
+  // For now we throw early with a clear message so accidental runs
+  // before Phase 2 don't crash with confusing stack traces.
+  if (!process.env.SWITCHROOM_UAT_CHAT_ID) {
+    throw new Error(
+      "[uat/harness] SWITCHROOM_UAT_CHAT_ID is not set — see uat/SETUP.md §2",
+    );
+  }
+  const chatId = Number.parseInt(process.env.SWITCHROOM_UAT_CHAT_ID, 10);
+  if (!Number.isFinite(chatId) || chatId >= 0) {
+    throw new Error(
+      `[uat/harness] SWITCHROOM_UAT_CHAT_ID must be a negative supergroup id (got ${process.env.SWITCHROOM_UAT_CHAT_ID})`,
+    );
+  }
+
+  // TODO(#866): allocate gateway port + ephemeral STATE_DIR.
+  //   const port = await allocatePort();
+  //   const stateDir = await mkdtemp(join(tmpdir(), `uat-${opts.agent}-`));
+  //   process.env.STATE_DIR is per-process — we instead pass STATE_DIR
+  //   in the spawned child's env, never mutate ours.
+  const port = await allocatePort();
+  void port; // Phase 2: feed into agent child env
+
+  // TODO(#866): create the forum topic via Bot API
+  // (`createForumTopic`) using the test bot token; capture the
+  // returned `message_thread_id` and stash for tearDown's
+  // `deleteForumTopic`.
+  const threadId = -1; // sentinel; Phase 2 fills in
+
+  // TODO(#866): spawn the agent under test as a child process.
+  //   const child = spawn(process.execPath, [agentEntry], {
+  //     env: {
+  //       ...process.env,
+  //       STATE_DIR: stateDir,
+  //       TELEGRAM_GATEWAY_PORT: String(port),
+  //       SWITCHROOM_AGENT_NAME: opts.agent,
+  //       BOT_TOKEN: <vault: telegram-test-bot-token>,
+  //     },
+  //     stdio: ["ignore", "pipe", "pipe"],
+  //   });
+  //   await waitForGatewayReady(port, { timeout: 30_000 });
+
+  // TODO(#866): connect mtcute driver.
+  //   const driver = new Driver({ apiId, apiHash, session });
+  //   await driver.connect();
+  const driver = new Driver({
+    apiId: 0,
+    apiHash: "",
+    session: "<resolved-from-vault>",
+  });
+
+  const scenario: Scenario = {
+    driver,
+    chatId,
+    threadId,
+    expectMessage: (match, pollOpts) =>
+      expectMessage(driver, chatId, match, {
+        ...pollOpts,
+        threadId,
+      }),
+    expectReaction: (messageId, sequence, pollOpts) =>
+      expectReaction(driver, chatId, messageId, sequence, pollOpts),
+    expectPinnedCard: (pollOpts) =>
+      expectPinnedCard(driver, chatId, { ...pollOpts, threadId }),
+    waitForCardPhase: (card, phase, pollOpts) =>
+      waitForCardPhase(driver, card, phase, pollOpts),
+    tearDown: async () => {
+      // TODO(#866): SIGTERM child, await exit (or SIGKILL after 5s),
+      // delete forum topic, rm -rf state dir, disconnect driver.
+      await driver.disconnect().catch(() => {
+        /* idempotent */
+      });
+    },
+  };
+
+  // Phase 1 marker so accidental runs fail loudly instead of silently
+  // sending nothing.
+  void opts;
+  throw new Error(
+    "[uat/harness] spinUp is scaffolded but not wired (Phase 1 stub) — see TODO markers in uat/harness.ts",
+  );
+
+  // unreachable in Phase 1; left for shape:
+  // eslint-disable-next-line no-unreachable
+  return scenario;
+}

--- a/telegram-plugin/uat/login.ts
+++ b/telegram-plugin/uat/login.ts
@@ -1,0 +1,134 @@
+/**
+ * One-time interactive login script for the UAT mtcute driver.
+ *
+ * Issue: https://github.com/switchroom/switchroom/issues/865
+ *
+ * Run via `bun run uat:login` from telegram-plugin/. Prompts for
+ * phone, login code, and (optionally) 2FA password on stdin. Captures
+ * the session string in memory and writes it to vault under
+ * `telegram-uat-driver-session`. The session string is **never
+ * printed** — not to stdout, not to stderr, not to logs. If you see
+ * one in scrollback, file an incident.
+ *
+ * Required env:
+ *   TELEGRAM_API_ID    — from https://my.telegram.org/apps
+ *   TELEGRAM_API_HASH  — from https://my.telegram.org/apps
+ */
+
+import { spawn } from "node:child_process";
+import { createInterface } from "node:readline/promises";
+import { stdin as input, stdout as output } from "node:process";
+import { TelegramClient } from "@mtcute/node";
+
+const VAULT_KEY = "telegram-uat-driver-session";
+
+async function main(): Promise<void> {
+  const apiId = Number.parseInt(process.env.TELEGRAM_API_ID ?? "", 10);
+  const apiHash = process.env.TELEGRAM_API_HASH ?? "";
+  if (!Number.isFinite(apiId) || !apiHash) {
+    fail(
+      "TELEGRAM_API_ID and TELEGRAM_API_HASH must be set. See uat/SETUP.md §3.",
+    );
+  }
+
+  const rl = createInterface({ input, output, terminal: true });
+
+  // Confirm the operator understands the security posture before we
+  // mint a bearer-equivalent credential.
+  const ack = await rl.question(
+    [
+      "",
+      "About to mint a Telegram USER session string for the UAT driver.",
+      "This is bearer-equivalent to the user account. It will be stored",
+      "in vault under `" + VAULT_KEY + "` and NEVER printed.",
+      "",
+      "Type YES to proceed: ",
+    ].join("\n"),
+  );
+  if (ack.trim() !== "YES") {
+    fail("Aborted.");
+  }
+
+  const phone = (await rl.question("Phone number (E.164, e.g. +14155551234): ")).trim();
+  if (!phone.startsWith("+")) fail("Phone must start with '+'.");
+
+  const client = new TelegramClient({ apiId, apiHash });
+
+  // mtcute exposes a `start()` flow that takes async callbacks for
+  // each interactive step. Exact callback names may shift across
+  // versions — verify against the pinned mtcute version before first
+  // run.
+  await client.start({
+    phone: async () => phone,
+    code: async () =>
+      (await rl.question("Login code (from Telegram app or SMS): ")).trim(),
+    password: async () =>
+      (await rl.question("2FA password (leave blank if none): ")),
+  });
+
+  // TODO(#865): mtcute v0.27 exports sessions via the
+  // `@mtcute/core/utils.js` `StringSessionStorage` adapter; the
+  // exact call is `await client.exportSession()` only when that
+  // storage is configured, otherwise sessions live in the SQLite
+  // file at `client.session`. Phase 2 wires the string-session
+  // storage so this script can mint a string. For now we throw
+  // before producing a value so the operator never gets a half-
+  // baked session in vault.
+  const session: string = await Promise.reject(
+    new Error(
+      "uat:login: Phase 1 stub — Phase 2 wires StringSessionStorage. See uat/SETUP.md §3.",
+    ),
+  );
+
+  await client.destroy();
+  rl.close();
+
+  // Write to vault via the switchroom CLI's stdin path so the
+  // session never appears in argv (which would land in `ps` output).
+  await writeToVault(VAULT_KEY, session);
+
+  // Belt-and-suspenders: zero out the local copy.
+  scrub(session);
+
+  process.stdout.write(
+    `\nDone. Session stored in vault as \`${VAULT_KEY}\`.\n` +
+      "If you ever see the actual session string in your terminal, file an incident.\n",
+  );
+}
+
+function writeToVault(key: string, value: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const proc = spawn("switchroom", ["vault", "set", key], {
+      stdio: ["pipe", "inherit", "inherit"],
+    });
+    proc.on("error", reject);
+    proc.on("exit", (code) => {
+      if (code === 0) resolve();
+      else reject(new Error(`switchroom vault set exited ${code}`));
+    });
+    proc.stdin.end(value + "\n");
+  });
+}
+
+function scrub(_s: string): void {
+  // JS strings are immutable — best we can do is drop the reference
+  // and trust the GC. Documented here so a future hardening pass
+  // (e.g. SecureBuffer) has a hook.
+}
+
+function fail(msg: string): never {
+  process.stderr.write(`uat:login: ${msg}\n`);
+  process.exit(1);
+}
+
+main().catch((err) => {
+  // Defensive: if mtcute throws, the error MAY contain the session
+  // string in some adapters. Strip anything that looks like a base64
+  // blob > 64 chars before printing.
+  const sanitized = String(err?.message ?? err).replace(
+    /[A-Za-z0-9+/=_-]{64,}/g,
+    "<redacted>",
+  );
+  process.stderr.write(`uat:login failed: ${sanitized}\n`);
+  process.exit(1);
+});

--- a/telegram-plugin/uat/port-allocator.ts
+++ b/telegram-plugin/uat/port-allocator.ts
@@ -1,0 +1,71 @@
+/**
+ * Process-wide unique port allocator for the UAT harness.
+ *
+ * Why this exists: each scenario `spinUp`s an agent child process
+ * with its own gateway listening on `TELEGRAM_GATEWAY_PORT`. If two
+ * sibling scenarios race to pick a port we get silent collisions
+ * that masquerade as flaky assertions ("the bridge couldn't reach
+ * the gateway, so no replies showed up"). See SETUP.md §6 for the
+ * port-vs-unix-socket decision.
+ *
+ * The allocator is monotonic per process and probes the candidate
+ * by `bind()`ing a transient socket — catches the case where some
+ * other process on the host has stolen a port out of our range.
+ */
+
+import { createServer } from "node:net";
+
+const DEFAULT_BASE_PORT = 47000;
+const DEFAULT_MAX_PORT = 47999;
+
+let cursor = DEFAULT_BASE_PORT;
+
+/**
+ * Allocate the next free TCP port in the harness range.
+ *
+ * Throws if every port in [base, max] is taken — almost certainly
+ * means a previous run leaked agent processes. Recovery: `pkill -f
+ * test-harness-uat` and try again.
+ */
+export async function allocatePort(opts?: {
+  base?: number;
+  max?: number;
+}): Promise<number> {
+  const base = opts?.base ?? DEFAULT_BASE_PORT;
+  const max = opts?.max ?? DEFAULT_MAX_PORT;
+
+  if (cursor < base) cursor = base;
+
+  const start = cursor;
+  for (;;) {
+    const port = cursor;
+    cursor = cursor + 1 > max ? base : cursor + 1;
+
+    if (await isPortFree(port)) {
+      return port;
+    }
+
+    if (cursor === start) {
+      throw new Error(
+        `[uat/port-allocator] no free ports in [${base}, ${max}]; ` +
+          "likely leaked agent child processes — try `pkill -f test-harness-uat`",
+      );
+    }
+  }
+}
+
+/** Reset the allocator. Test-only. */
+export function _resetAllocatorForTests(): void {
+  cursor = DEFAULT_BASE_PORT;
+}
+
+function isPortFree(port: number): Promise<boolean> {
+  return new Promise((resolve) => {
+    const probe = createServer();
+    probe.once("error", () => resolve(false));
+    probe.once("listening", () => {
+      probe.close(() => resolve(true));
+    });
+    probe.listen(port, "127.0.0.1");
+  });
+}

--- a/telegram-plugin/uat/scenarios/smoke-clerk-reply.test.ts
+++ b/telegram-plugin/uat/scenarios/smoke-clerk-reply.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Smoke scenario — clerk replies to a simple text message.
+ *
+ * Part of: https://github.com/switchroom/switchroom/issues/866
+ *
+ * Phase 1 status: this file exercises the harness shape (typecheck-
+ * clean, reads as the canonical example) but will FAIL at runtime
+ * because `harness.spinUp` is stubbed. Phase 2 wires the real
+ * lifecycle and this becomes the first green UAT scenario.
+ *
+ * The shape mirrors the canonical scenario in epic #863 so reviewers
+ * can map directly between the design doc and the code.
+ */
+
+import { describe, it, expect } from "vitest";
+import { spinUp } from "../harness.js";
+
+describe("uat: clerk smoke", () => {
+  it("replies to a text message with the right reaction sequence + HTML reply", async () => {
+    const sc = await spinUp({ agent: "clerk", topic: "smoke-clerk-reply" });
+
+    try {
+      const sent = await sc.driver.sendText(
+        sc.chatId,
+        "summarize this short note",
+        { messageThreadId: sc.threadId },
+      );
+
+      // Status reactions should walk 👀 → 🤔 → 🔥 → 👍 on the inbound
+      // message within 30s on a healthy run.
+      await sc.expectReaction(
+        sent.messageId,
+        ["👀", "🤔", "🔥", "👍"],
+        { timeout: 30_000 },
+      );
+
+      // The progress card should be pinned within a few seconds.
+      const card = await sc.expectPinnedCard({ timeout: 5_000 });
+
+      // And ride to `done` within the model's normal turn budget.
+      const finalCard = await sc.waitForCardPhase(card, "done", {
+        timeout: 60_000,
+      });
+      expect(finalCard.text).toMatch(/Done|✅/);
+
+      // The actual reply prose lands as a fresh bot message, in HTML.
+      const reply = await sc.expectMessage(/./, {
+        from: "bot",
+        timeout: 60_000,
+      });
+      // Reviewer note: parse_mode isn't on the wire-level update;
+      // we proxy via "did the rendered HTML contain a `<` we
+      // recognize, or did markdown leak as plain `*`?". Phase 2
+      // will pick the right shape — left as a TODO so this file
+      // typechecks today.
+      expect(reply.text.length).toBeGreaterThan(0);
+    } finally {
+      await sc.tearDown();
+    }
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -60,6 +60,10 @@ export default defineConfig({
       // sessions. Their tests duplicate the canonical ones and run against
       // stale code — never discover them from the canonical repo.
       "**/.claude/worktrees/**",
+      // UAT harness scenarios (#863) hit real Telegram and must never run
+      // on the default test path. Invoke via `bun run test:uat` from
+      // telegram-plugin/.
+      "**/telegram-plugin/uat/**",
       "**/telegram-plugin/tests/history.test.ts",
       "**/telegram-plugin/tests/ipc-server-client.test.ts",
       "**/telegram-plugin/tests/ipc-server-race.test.ts",

--- a/vitest.uat.config.ts
+++ b/vitest.uat.config.ts
@@ -1,0 +1,29 @@
+import { defineConfig } from "vitest/config";
+
+/**
+ * UAT-only vitest config (epic #863). Runs scenarios in
+ * `telegram-plugin/uat/scenarios/`. Hits real Telegram, real Claude
+ * — never on the default CI critical path. Invoke via
+ * `bun run test:uat` from `telegram-plugin/`.
+ */
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: "node",
+    pool: "forks",
+    poolOptions: {
+      forks: {
+        // Sequential by default — Telegram rate limits are per-bot
+        // global. Phase 2 may revisit if topic-isolation lets us go
+        // wider safely.
+        maxForks: 1,
+        minForks: 1,
+      },
+    },
+    include: ["telegram-plugin/uat/scenarios/**/*.test.ts"],
+    // Eventual-assertion scenarios run long. Default vitest 5s
+    // would trip every assertion. 2 min ceiling per test.
+    testTimeout: 120_000,
+    hookTimeout: 60_000,
+  },
+});


### PR DESCRIPTION
## Summary

Phase 1 of epic #863 — Telegram test-bot UAT harness scaffolding. Code-only; no real Telegram interaction, no secrets, no live chat IDs.

## What's built

- `@mtcute/node ^0.27.0` added to `telegram-plugin/package.json`.
- `telegram-plugin/uat/` tree:
  - `SETUP.md` — operator runbook (BotFather, supergroup, mtcute login, 2FA re-login, security floor).
  - `driver.ts` — typed mtcute wrapper. `connect` / `disconnect` / `sendText` implemented.
  - `assertions.ts` — `pollUntil` + `expectEventually` implemented.
  - `harness.ts` — `spinUp()` Scenario shape; throws Phase 1 stub on call so accidental runs fail loudly.
  - `port-allocator.ts` — process-wide monotonic allocator with `bind()` probe. Chosen over unix sockets, see SETUP.md §6.
  - `login.ts` — `bun run uat:login` script skeleton. Never prints session string.
  - `scenarios/smoke-clerk-reply.test.ts` — canonical smoke shape; typechecks, runtime-fails until Phase 2.
- `vitest.uat.config.ts` — sequential, 2-min `testTimeout`, scoped to `telegram-plugin/uat/scenarios/**`.
- `vitest.config.ts` — excludes `**/telegram-plugin/uat/**` from default runs (UAT is opt-in).
- `telegram-plugin/package.json` — `test:uat` + `uat:login` scripts.

## What's stubbed (Phase 2)

- Real mtcute session wiring (StringSessionStorage adapter — `driver.ts` connect, `login.ts` exportSession).
- Forum-topic-aware `sendText` and observers (`observeMessages`, `observeReactions`, `observePins`).
- `sendVoice`.
- `expectMessage` / `expectReaction` / `expectPinnedCard` / `waitForCardPhase` against the live driver.
- `harness.spinUp` lifecycle: vault resolve, port allocate, ephemeral STATE_DIR, child-process spawn, gateway-ready wait, topic create/delete, teardown.

## What's blocked on Ken (manual prerequisites — #864, #865)

- Create test BotFather bot (`@switchroom_uat_bot` or similar); vault token as `telegram-test-bot-token`.
- Provision dedicated test supergroup with topics enabled; promote test bot + driver user to admin; capture chat id.
- Get `api_id` / `api_hash` from <https://my.telegram.org/apps>.
- Run `bun run uat:login` once (after Phase 2 wires StringSessionStorage) to vault `telegram-uat-driver-session`.

See `telegram-plugin/uat/SETUP.md` for the full runbook.

## Verification

- `npx tsc --noEmit -p tsconfig.json` clean.
- `npx tsc --noEmit` over `telegram-plugin/uat/**/*.ts` clean.
- Default vitest run does not pick up `uat/` (excluded).
- `bun install` in `telegram-plugin/` resolves @mtcute/node@0.27.9.

## Test plan

- [ ] Reviewer agent inspects branch `uat-harness-phase-1-scaffold` against `main`.
- [ ] Confirm no real secrets, tokens, or chat ids appear in any file.
- [ ] Confirm `bun test` (default) does not invoke any UAT scenario.
- [ ] Confirm `bun run test:uat` from `telegram-plugin/` discovers `smoke-clerk-reply.test.ts` (will fail at runtime with the Phase 1 stub message — that's expected).

DO NOT MERGE until a fresh reviewer process gives APPROVE per global CLAUDE.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)