### PR TITLE
fix: agent list active on host-shell systemd fleets + manifest drift

### DIFF
--- a/dependencies.json
+++ b/dependencies.json
@@ -1,12 +1,12 @@
 {
-  "switchroom_version": "0.4.0",
-  "tested_at": "2026-04-30T19:35:00+10:00",
+  "switchroom_version": "0.7.3",
+  "tested_at": "2026-05-09T16:30:00+10:00",
   "runtime": {
-    "bun": "1.3.11",
+    "bun": "1.3.13",
     "node": "22.22.2"
   },
   "claude": {
-    "cli": "2.1.123"
+    "cli": "2.1.137"
   },
   "playwright_mcp": "0.0.71",
   "hindsight": {

--- a/src/agents/lifecycle.ts
+++ b/src/agents/lifecycle.ts
@@ -8,6 +8,8 @@ import { resolveAgentConfig } from "../config/merge.js";
 import { loadConfig } from "../config/loader.js";
 import { sendAgentInterrupt } from "./tmux.js";
 import { resolveSwitchroomHome } from "./docker-fleet.js";
+import { isDockerRuntime } from "../runtime-mode.js";
+import { readSystemdUnit } from "./status.js";
 
 /**
  * Resolve the per-agent gateway clean-shutdown marker path.
@@ -509,7 +511,32 @@ export function resolveAgentPid(name: string): number {
  * the systemd-era signature; under docker we ignore it (the pid we
  * return is always the container's PID 1).
  */
+function getAgentStatusSystemd(name: string): AgentStatus {
+  const info = readSystemdUnit(`switchroom-${name}`);
+  return {
+    active: info.active === "active" ? "active" : info.active || "inactive",
+    uptime:
+      info.activeEnterTs !== null
+        ? new Date(info.activeEnterTs).toISOString()
+        : null,
+    memory: null,
+    pid: info.pid,
+  };
+}
+
 export function getAgentStatus(name: string, _tmuxSupervisor = true): AgentStatus {
+  // Host-shell + systemd fleet: v0.7 PR-C1 rewrote this function as
+  // docker-only, so on a fleet that hasn't been migrated yet (no compose
+  // file present, no SWITCHROOM_RUNTIME=docker env var) every `docker
+  // inspect` throws and the caller — `switchroom agent list` —
+  // reports every agent as "inactive" even when systemd shows them
+  // running. Mirror the runtime branch that v0.7.3 added in
+  // `defaultStatusInputs` so the list matches reality on systemd hosts
+  // until they cut over.
+  if (!isDockerRuntime()) {
+    return getAgentStatusSystemd(name);
+  }
+
   const cn = containerName(name);
 
   let active = "inactive";

--- a/src/build-info.ts
+++ b/src/build-info.ts
@@ -3,7 +3,7 @@
 // Values are refreshed every time `npm run build` runs.
 
 export const VERSION: string = "0.7.3";
-export const COMMIT_SHA: string | null = "896f5bb9";
-export const COMMIT_DATE: string | null = "2026-05-09T13:54:55+10:00";
-export const LATEST_PR: number | null = 868;
-export const COMMITS_AHEAD_OF_TAG: number | null = 3;
+export const COMMIT_SHA: string | null = "03778242";
+export const COMMIT_DATE: string | null = "2026-05-09T14:14:07+10:00";
+export const LATEST_PR: number | null = 870;
+export const COMMITS_AHEAD_OF_TAG: number | null = 4;


### PR DESCRIPTION
## Summary
- `getAgentStatus()` now branches on `isDockerRuntime()` — on a host that hasn't migrated to docker (no compose file present, no `SWITCHROOM_RUNTIME=docker`), `switchroom agent list` was reporting all agents `inactive` despite systemd showing them running. The function had been rewritten as docker-only in v0.7 PR-C1; v0.7.3 added the host-shell branch to `defaultStatusInputs` but missed this callsite.
- Bumps `dependencies.json` to current installed versions (bun 1.3.13, claude 2.1.137, switchroom 0.7.3) so doctor stops emitting stale drift warnings.

## Motivation
On the maintainer's dev host the live fleet still runs under systemd. `switchroom agent list` was unusable as ground truth — every agent showed `inactive` while `systemctl --user list-units 'switchroom*'` showed all 8 agents `active running`. This blocks pre-cutover validation before migrating to docker. Same root cause class as the v0.7.3 fix (host-shell detection); just a missed callsite.

## Test plan
- [x] `switchroom agent list` against an 8-agent systemd fleet: 8/8 active with correct uptimes (was 0/8).
- [x] `vitest src/runtime-mode.test.ts src/agents/status-runtime.test.ts tests/manifest.test.ts` — 26 pass.
- [x] No new tsc errors (1 pre-existing in `src/cli/deprecated.test.ts`, unchanged).
- [ ] Reviewer agent verdict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)