### PR TITLE
fix(v0.7.4): broker caps + machine-id + per-agent socket subdirs + agent host network

### DIFF
--- a/src/agents/compose.ts
+++ b/src/agents/compose.ts
@@ -268,12 +268,26 @@ export function generateCompose(opts: ComposeGeneratorOptions): string {
   lines.push(`      - "no-new-privileges:true"`);
   lines.push(`    cap_drop:`);
   lines.push(`      - "ALL"`);
-  // Broker needs CHOWN + FOWNER to take ownership of per-agent socket
-  // dirs (created at startup) and chmod sockets to 0660 owned by the
-  // agent's UID. Everything else stays dropped.
+  // Broker needs:
+  //  - CHOWN + FOWNER: take ownership of per-agent socket dirs
+  //    (created at startup) and chmod sockets to 0660 owned by the
+  //    agent's UID.
+  //  - DAC_READ_SEARCH: bypass DAC checks to read the operator-owned
+  //    vault files. Broker runs as UID 0 so it can chown sockets, but
+  //    `cap_drop: ALL` strips DAC_OVERRIDE / DAC_READ_SEARCH — without
+  //    re-adding it, root can't read 0600 files owned by the operator's
+  //    UID (which is what `setup` writes for vault.enc and
+  //    `enable-auto-unlock` writes for vault-auto-unlock). Verified
+  //    against a v0.7.3 test cutover: without this cap the broker
+  //    boots, hits "Permission denied" on `/state/vault-auto-unlock`,
+  //    logs `auto-unlock decrypt failed (io)`, and falls back to
+  //    interactive unlock — i.e. auto-unlock is silently broken under
+  //    docker. Read-only is enough; we don't need DAC_OVERRIDE which
+  //    would also bypass write checks.
   lines.push(`    cap_add:`);
   lines.push(`      - "CHOWN"`);
   lines.push(`      - "FOWNER"`);
+  lines.push(`      - "DAC_READ_SEARCH"`);
   lines.push(`    environment:`);
   if (switchroomConfigPath) {
     lines.push(`      SWITCHROOM_CONFIG: /state/config/switchroom.yaml`);
@@ -306,6 +320,15 @@ export function generateCompose(opts: ComposeGeneratorOptions): string {
   // and falls back to the interactive unlock flow, so operators who
   // never enabled auto-unlock are unaffected.
   lines.push(`      - ${homePrefix}/.switchroom/vault-auto-unlock:/state/vault-auto-unlock:ro`);
+  // /etc/machine-id passthrough — required so the broker can derive
+  // the same machine-bound key the host's `enable-auto-unlock` used
+  // to seal the auto-unlock blob. The agent base image (node:22-bookworm-slim)
+  // ships without /etc/machine-id; without this mount the broker
+  // errors out "Cannot derive machine-bound key: neither /etc/machine-id
+  // nor /var/lib/dbus/machine-id is readable" and falls back to
+  // interactive unlock. Mount the FILE (not the /etc dir) so we don't
+  // shadow the rest of /etc inside the broker image.
+  lines.push(`      - /etc/machine-id:/etc/machine-id:ro`);
   lines.push(``);
 
   // ── approval-kernel (singleton) ────────────────────────────────────
@@ -408,11 +431,30 @@ function emitAgentService(
   lines.push(`  agent-${a.name}:`);
   emitImageOrBuild(lines, "agent", imageTag, buildMode, buildContext);
   lines.push(`    container_name: switchroom-${a.name}`);
-  lines.push(`    hostname: ${a.name}`);
   lines.push(`    labels:`);
   lines.push(`      switchroom.role: "agent"`);
   lines.push(`      switchroom.fleet: "switchroom"`);
   lines.push(`      switchroom.agent: "${a.name}"`);
+  // Share the host's network namespace.
+  //
+  // Scaffolded `start.sh` and the env baked into it reach a number of
+  // host-local endpoints by their host-side address: Hindsight at
+  // 127.0.0.1:18888 (host-loopback), the operator's LAN devices for
+  // user-declared env vars (HA at 192.168.x.x, NAS, smart-home gear),
+  // and the host's resolver for any DNS. With the default bridge
+  // network those are unreachable from inside the container —
+  // `127.0.0.1` is the container's own loopback, and the LAN is on the
+  // host side of the bridge. v0.7.0 → v0.7.3 emitted no network config
+  // and the agent silently failed: hindsight wait-loop timed out, MCP
+  // servers errored at startup, telegram polling never began.
+  // `network_mode: host` puts the agent on the host's network stack —
+  // identical semantics to the v0.6 systemd-era model. Tradeoff:
+  // network isolation between agents goes away (they can reach each
+  // other and any host service), but the previous trust model already
+  // assumed shared-host operation. Future work: a strict-isolation
+  // mode that puts agents on a custom network and routes hindsight
+  // through an explicit `extra_hosts` entry for `host.docker.internal`.
+  lines.push(`    network_mode: host`);
   lines.push(`    restart: unless-stopped`);
   lines.push(`    init: false`);
   lines.push(`    stop_grace_period: 45s`);

--- a/src/build-info.ts
+++ b/src/build-info.ts
@@ -3,7 +3,7 @@
 // Values are refreshed every time `npm run build` runs.
 
 export const VERSION: string = "0.7.3";
-export const COMMIT_SHA: string | null = "03778242";
-export const COMMIT_DATE: string | null = "2026-05-09T14:14:07+10:00";
-export const LATEST_PR: number | null = 870;
-export const COMMITS_AHEAD_OF_TAG: number | null = 4;
+export const COMMIT_SHA: string | null = "48d4157c";
+export const COMMIT_DATE: string | null = "2026-05-09T16:30:39+10:00";
+export const LATEST_PR: number | null = 871;
+export const COMMITS_AHEAD_OF_TAG: number | null = 5;

--- a/src/vault/broker/peercred-socket-path.test.ts
+++ b/src/vault/broker/peercred-socket-path.test.ts
@@ -50,6 +50,42 @@ describe("socketPathToAgent", () => {
     expect(socketPathToAgent("/run/switchroom/broker/_alice.sock")).toBeNull();
   });
 
+  describe("subdir form (v0.7.4 — per-agent volume mounts)", () => {
+    // The compose generator mounts each per-agent named volume at
+    // /run/switchroom/broker/<agent>, exposing a single `sock` file.
+    // socketPathToAgent must accept that shape so bindAgentSocket can
+    // accept the path as-is (no path rewriting at the call site).
+    it("returns the agent name for /run/switchroom/broker/<agent>/sock", () => {
+      expect(socketPathToAgent("/run/switchroom/broker/alice/sock")).toBe("alice");
+      expect(socketPathToAgent("/run/switchroom/broker/bob/sock")).toBe("bob");
+    });
+
+    it("supports hyphens, underscores, and digits in subdir form too", () => {
+      expect(socketPathToAgent("/run/switchroom/broker/agent-1/sock")).toBe("agent-1");
+      expect(socketPathToAgent("/run/switchroom/broker/my_agent/sock")).toBe("my_agent");
+      expect(socketPathToAgent("/run/switchroom/broker/agent42/sock")).toBe("agent42");
+    });
+
+    it("still rejects non-canonical shapes that look subdir-ish", () => {
+      // Wrong inner filename
+      expect(socketPathToAgent("/run/switchroom/broker/alice/socket")).toBeNull();
+      expect(socketPathToAgent("/run/switchroom/broker/alice/sock.bak")).toBeNull();
+      // Extra path segments
+      expect(socketPathToAgent("/run/switchroom/broker/alice/sub/sock")).toBeNull();
+      // Wrong parent
+      expect(socketPathToAgent("/run/switchroom/kernel/alice/sock")).toBeNull();
+      // Path-traversal in the agent slot
+      expect(socketPathToAgent("/run/switchroom/broker/../etc/sock")).toBeNull();
+      // Empty agent name
+      expect(socketPathToAgent("/run/switchroom/broker//sock")).toBeNull();
+    });
+
+    it("rejects subdir form agent names beginning with non-alphanumeric chars", () => {
+      expect(socketPathToAgent("/run/switchroom/broker/-alice/sock")).toBeNull();
+      expect(socketPathToAgent("/run/switchroom/broker/_alice/sock")).toBeNull();
+    });
+  });
+
   it("returns null for non-string input", () => {
     // @ts-expect-error — runtime guard for type-confused callers
     expect(socketPathToAgent(undefined)).toBeNull();

--- a/src/vault/broker/peercred.ts
+++ b/src/vault/broker/peercred.ts
@@ -42,29 +42,43 @@ import { getPeerCred } from "./peercred-ffi.js";
  *
  * The Phase 2a Docker migration moves agent identity off of cgroup/systemd-
  * unit inspection (which only works on Linux + systemd-user) and onto the
- * socket path itself. Each agent's compose service mounts a per-agent named
- * volume at /run/switchroom/broker, exposing exactly one socket file:
+ * socket path itself. Two canonical shapes are accepted:
  *
- *     /run/switchroom/broker/<agent>.sock
+ *   (a) /run/switchroom/broker/<agent>.sock          (flat sibling files)
+ *   (b) /run/switchroom/broker/<agent>/sock          (per-agent subdir)
  *
- * The broker container sees those mount points as siblings under
- * /run/switchroom/broker/ and binds one listener per file. The listener's
- * own bind-time socketPath is the trusted source-of-truth for the calling
- * agent's identity — no wire-payload field, no peercred lookup, no cgroup
- * inspection can override it. Same pattern as kernel-server.ts.
+ * (b) is the layout the v0.7 compose generator emits: each agent's
+ * `broker-<name>-sock` named volume mounts at
+ * `/run/switchroom/broker/<name>` inside the broker container and at
+ * `/run/switchroom/broker` inside the agent — so the same `sock` file
+ * is at `<subdir>/sock` from the broker's POV and at `sock` from the
+ * agent's POV (after the agent reaches it via its env-var path
+ * `/run/switchroom/broker/<name>/sock`, which collapses to
+ * `<volume root>/sock` once you account for the agent's own mount).
+ * Same pattern as `kernel-server.ts`. Shape (a) is preserved for tests
+ * and any setups that pre-create flat socket files.
+ *
+ * The listener's own bind-time socketPath is the trusted source-of-truth
+ * for the calling agent's identity — no wire-payload field, no peercred
+ * lookup, no cgroup inspection can override it.
  *
  * SO_PEERCRED is still captured (when available) and goes into the audit
  * row as informational `peer_uid`, but it does NOT gate ACL.
  *
- * Returns the parsed agent name on a path matching the canonical shape;
- * returns null otherwise (caller treats null as "unidentified" → DENIED).
+ * Returns the parsed agent name on a path matching one of the canonical
+ * shapes; returns null otherwise (caller treats null as "unidentified"
+ * → DENIED).
  */
 const SOCKET_PATH_AGENT_RE =
   /^\/run\/switchroom\/broker\/([a-zA-Z0-9][a-zA-Z0-9_-]*)\.sock$/;
+const SOCKET_PATH_AGENT_SUBDIR_RE =
+  /^\/run\/switchroom\/broker\/([a-zA-Z0-9][a-zA-Z0-9_-]*)\/sock$/;
 
 export function socketPathToAgent(socketPath: string): string | null {
   if (typeof socketPath !== "string" || socketPath.length === 0) return null;
-  const m = socketPath.match(SOCKET_PATH_AGENT_RE);
+  const m =
+    socketPath.match(SOCKET_PATH_AGENT_RE) ??
+    socketPath.match(SOCKET_PATH_AGENT_SUBDIR_RE);
   if (!m) return null;
   return m[1];
 }

--- a/src/vault/broker/server.ts
+++ b/src/vault/broker/server.ts
@@ -25,7 +25,8 @@
  */
 
 import * as net from "node:net";
-import { mkdirSync, chmodSync, existsSync, readFileSync, readdirSync, statSync, unlinkSync, writeFileSync, renameSync } from "node:fs";
+import { mkdirSync, chmodSync, chownSync, existsSync, readFileSync, readdirSync, statSync, unlinkSync, writeFileSync, renameSync } from "node:fs";
+import { allocateAgentUid } from "../../agents/compose.js";
 import { dirname, resolve, join, basename } from "node:path";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -401,6 +402,27 @@ export class VaultBroker {
       server.on("error", (err) => rejectP(err));
       server.listen(abs, () => {
         try { chmodSync(abs, 0o660); } catch { /* ignore */ }
+        // Chown the socket (and, for subdir-shape paths, the parent dir
+        // mount point) to the agent UID so a non-root agent container
+        // — running as `user: <uid>:<uid>` per compose — can connect.
+        // The broker runs root-in-container with cap_drop=ALL +
+        // cap_add=[CHOWN, FOWNER, DAC_READ_SEARCH], so chown succeeds
+        // here. Mirrors `kernel-server.ts:bindAgentSocket`. Order
+        // matters: chown AFTER listen() so root could write into the
+        // (still-root-owned) parent dir to create the socket node.
+        // Errors swallowed for non-docker dev/test runs where CAP_CHOWN
+        // isn't held (callers run as the same UID as agents).
+        try {
+          const uid = allocateAgentUid(agentName);
+          try { chownSync(abs, uid, uid); } catch { /* see above */ }
+          if (abs.endsWith("/sock")) {
+            const dir = abs.slice(0, -"/sock".length);
+            try { chownSync(dir, uid, uid); } catch { /* see above */ }
+          }
+        } catch {
+          // allocateAgentUid is deterministic and pure; swallow only to
+          // protect the listen() callback from any unexpected throw.
+        }
         this.agentServers.set(abs, { server, agentName });
         resolveP(agentName);
       });
@@ -1651,27 +1673,48 @@ export async function main(): Promise<void> {
   const vaultPath = process.env.SWITCHROOM_VAULT_PATH;
 
   // Phase 2a — enumerate per-agent socket targets that compose mounted in.
-  // We expect entries to appear as either:
+  // We accept two shapes (matching the kernel and the patterns
+  // socketPathToAgent() vets):
   //   (a) regular files named <agent>.sock — pre-created by compose
-  //   (b) directories named <agent> with a `sock` file inside (kernel-style)
-  //   (c) nothing (named volumes that resolve to empty dirs) — in this case
-  //       we fall through to legacy single-socket mode.
-  // For Phase 2a we standardize on (a): compose mounts a named volume
-  // `vault-broker-<agent>-sock` at /run/switchroom/broker, and the agent
-  // container's start.sh expects the file at /run/switchroom/vault/sock
-  // by symlink. The broker's job here is just to bind exactly one
-  // listener per <agent>.sock target it sees.
+  //   (b) directories named <agent> (per-agent named-volume mount points);
+  //       we bind a socket at `<dir>/sock`. This is what the v0.7 compose
+  //       generator emits — `broker-<name>-sock` mounts at
+  //       `/run/switchroom/broker/<name>` inside the broker, and the agent
+  //       sees the same file via its `/run/switchroom/broker` mount of
+  //       the same volume, accessed by its env path
+  //       `/run/switchroom/broker/<name>/sock`.
+  //   (c) nothing (named volumes that resolve to empty dirs without the
+  //       per-agent subdir mounts) — fall through to legacy single-socket.
+  // The agent name is always derived from the socket path (not from a
+  // wire-payload field) via socketPathToAgent(), so both shapes preserve
+  // the path-as-identity invariant.
   let perAgentTargets: string[] = [];
   try {
     if (existsSync(perAgentDir)) {
-      perAgentTargets = readdirSync(perAgentDir)
-        .filter((name) => name.endsWith(".sock") && !name.startsWith("."))
-        .map((name) => resolve(perAgentDir, name))
-        .filter((p) => {
-          // Each entry must parse as <agent>.sock (no traversal, no
-          // weird shapes). We trust socketPathToAgent() to vet shape.
-          return socketPathToAgent(p) !== null;
-        })
+      const entries = readdirSync(perAgentDir, { withFileTypes: true });
+      const flat: string[] = [];
+      const subdirs: string[] = [];
+      for (const e of entries) {
+        if (e.name.startsWith(".")) continue;
+        // (a) flat file
+        if (
+          (e.isFile() || e.isSocket()) &&
+          e.name.endsWith(".sock")
+        ) {
+          flat.push(resolve(perAgentDir, e.name));
+          continue;
+        }
+        // (b) per-agent subdir — bind <subdir>/sock if the subdir name
+        // parses as a valid agent identifier.
+        if (e.isDirectory()) {
+          const candidate = resolve(perAgentDir, e.name, "sock");
+          if (socketPathToAgent(candidate) !== null) {
+            subdirs.push(candidate);
+          }
+        }
+      }
+      perAgentTargets = [...flat, ...subdirs]
+        .filter((p) => socketPathToAgent(p) !== null)
         .sort();
     }
   } catch (err) {

--- a/tests/docker/compose-generator.test.ts
+++ b/tests/docker/compose-generator.test.ts
@@ -289,6 +289,25 @@ describe("generateCompose", () => {
     expect(block).toContain("FOWNER");
   });
 
+  it("broker adds DAC_READ_SEARCH so root can read host-owned vault files (v0.7.4)", () => {
+    // Without this cap the broker boots, fails to read
+    // /state/vault-auto-unlock (mode 0600 owned by host UID), and silently
+    // falls back to interactive unlock. Verified against a v0.7.3 cutover.
+    const out = generateCompose({ config: makeConfig({ a: {} }) });
+    const block = /vault-broker:[\s\S]*?(?=\n  [a-z])/.exec(out)?.[0] ?? "";
+    expect(block).toContain("DAC_READ_SEARCH");
+  });
+
+  it("broker mounts /etc/machine-id so auto-unlock key derivation matches host (v0.7.4)", () => {
+    // The auto-unlock blob is sealed with an AES key derived from the
+    // host's /etc/machine-id. Without passing it through, the broker
+    // image (no /etc/machine-id baked in) errors "Cannot derive
+    // machine-bound key" and falls back to interactive unlock.
+    const out = generateCompose({ config: makeConfig({ a: {} }) });
+    const block = /vault-broker:[\s\S]*?(?=\n  [a-z])/.exec(out)?.[0] ?? "";
+    expect(block).toMatch(/-\s+\/etc\/machine-id:\/etc\/machine-id:ro/);
+  });
+
   it("kernel keeps CHOWN + FOWNER (mirrors broker socket-ownership flow)", () => {
     const out = generateCompose({ config: makeConfig({ a: {} }) });
     const block = /approval-kernel:[\s\S]*?(?=\n  [a-z])/.exec(out)?.[0] ?? "";
@@ -367,6 +386,50 @@ describe("agent service env (Phase 2c F2 — IPC wiring)", () => {
       expect(env).toMatch(
         new RegExp(`SWITCHROOM_AGENT_NAME:\\s*"${a}"`),
       );
+    }
+  });
+});
+
+describe("agent service network (v0.7.4 — host networking)", () => {
+  // Scaffolded start.sh hard-codes host-loopback URLs (e.g.
+  // http://127.0.0.1:18888 for hindsight) and operator LAN IPs (HA,
+  // smart-home gear). The default bridge network reaches none of those.
+  // network_mode: host puts the agent on the host's network namespace,
+  // matching the v0.6 systemd-era behavior so existing scaffolds Just
+  // Work without a regen of every start.sh / settings.json.
+  it("emits network_mode: host on every agent service", () => {
+    const out = generateCompose({
+      config: makeConfig({ alice: {}, bob: {} }),
+    });
+    for (const a of ["alice", "bob"]) {
+      const re = new RegExp(`  agent-${a}:[\\s\\S]*?(?=\\n  [a-z])`);
+      const block = re.exec(out)?.[0] ?? "";
+      expect(block, `${a} block`).toMatch(/network_mode:\s*host/);
+    }
+  });
+
+  it("does NOT emit network_mode: host on broker / kernel / scheduler", () => {
+    // Only agents need host networking — the singletons talk via UDS
+    // (broker, kernel) or to the docker daemon socket (scheduler).
+    const out = generateCompose({
+      config: makeConfig({ a: {} }),
+    });
+    for (const svc of ["vault-broker", "approval-kernel", "switchroom-cron"]) {
+      const re = new RegExp(`  ${svc}:[\\s\\S]*?(?=\\n  [a-z]|\\nvolumes:)`);
+      const block = re.exec(out)?.[0] ?? "";
+      expect(block, `${svc} block`).not.toMatch(/network_mode:\s*host/);
+    }
+  });
+
+  it("drops `hostname:` on agents (incompatible with network_mode: host)", () => {
+    // docker emits a warning when both are set; cleaner to just not emit.
+    const out = generateCompose({
+      config: makeConfig({ alice: {}, bob: {} }),
+    });
+    for (const a of ["alice", "bob"]) {
+      const re = new RegExp(`  agent-${a}:[\\s\\S]*?(?=\\n  [a-z])`);
+      const block = re.exec(out)?.[0] ?? "";
+      expect(block, `${a} block`).not.toMatch(/^\s+hostname:/m);
     }
   });
 });

--- a/tests/lifecycle.docker.test.ts
+++ b/tests/lifecycle.docker.test.ts
@@ -52,6 +52,11 @@ beforeEach(() => {
   mockedExec.mockReset();
   // Pin a deterministic compose path so we can assert argv shape.
   process.env.SWITCHROOM_COMPOSE_FILE = "/tmp/sw-test-compose.yml";
+  // Force docker runtime mode for the whole suite. Without this,
+  // getAgentStatus()'s host-shell branch (added in v0.7.3 PR #871)
+  // calls readSystemdUnit and returns "inactive" — defeating the
+  // point of these tests, which exercise the docker `inspect` path.
+  process.env.SWITCHROOM_RUNTIME = "docker";
 });
 
 describe("lifecycle (docker mode): start/stop/restart shellouts", () => {

--- a/tests/lifecycle.interrupt.test.ts
+++ b/tests/lifecycle.interrupt.test.ts
@@ -73,6 +73,13 @@ describe("interruptAgent dual-path", () => {
   beforeEach(() => {
     mockedExec.mockReset();
     mockedSendInterrupt.mockReset();
+    // interruptAgent calls getAgentStatus to read the running PID.
+    // Post v0.7.3 #871, getAgentStatus host-shell branch goes through
+    // readSystemdUnit (which the test stubs as a docker-aware
+    // `compose exec` path). Force docker mode so the docker `inspect`
+    // branch fires — otherwise status.pid is null and interruptAgent
+    // bails before exercising the dual-path under test.
+    process.env.SWITCHROOM_RUNTIME = "docker";
   });
 
   it("tmux-supervised agent: prefers tmux send-keys; does NOT fire systemctl kill on success", () => {


### PR DESCRIPTION
## Summary
Four end-to-end docker-cutover blockers, each tiny on its own, together unblock the v0.7 migration:

1. **Broker DAC** — re-add `DAC_READ_SEARCH` so root-in-broker can read 0600 vault files (host UID-owned).
2. **Auto-unlock machine-id** — bind-mount `/etc/machine-id` so the AES key derivation in the broker matches what `enable-auto-unlock` produced on the host.
3. **Per-agent socket subdirs** — accept `/run/switchroom/broker/<agent>/sock` (the shape compose actually emits, matching the working kernel pattern); chown sock + dir to agent UID after listen.
4. **Agent host networking** — `network_mode: host` so scaffolded `start.sh` reaches hindsight at `127.0.0.1:18888` and operator LAN devices.

Each is documented inline with the reason it broke v0.7.3.

## Motivation
Verified against a v0.7.3 cutover attempt on a real fleet today: broker boots → silent auto-unlock failure → fall through to interactive unlock; even after manual unlock, agent containers can't reach broker (subdir mismatch) or hindsight (no host net) and never start polling Telegram. Reverted to systemd; this PR fixes the underlying causes.

## Test plan
- [x] `vitest run` — 5086 pass (was 5078). 8 new test cases (3 compose, 5 peercred subdir).
- [x] `bun test` — identical pass/fail count to upstream/main HEAD (527 pass / 20 fail; the 20 are pre-existing vault broker flakes, unchanged).
- [x] `tsc --noEmit` — only the pre-existing `deprecated.test.ts` error from upstream.
- [ ] **End-to-end**: re-cutover one live agent (gymbro) on this branch — pending merge so canonical compose + agent images include the fix.
- [ ] Reviewer agent verdict.

## Risk
- `network_mode: host` is a real semantic change — agents now share the host network namespace. The trust model already assumes shared-host operation (agents run as the operator's-tied UIDs, read host-mounted state). Future work: an opt-in strict-isolation mode that uses `extra_hosts: host.docker.internal` and rewrites scaffold URLs.
- Subdir socket form is additive: flat-form callers still work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)