### PR TITLE
fix(v0.7.4): python3 in base image + tty/stdin_open on agent containers

### DIFF
--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -20,6 +20,10 @@ RUN echo "switchroom/base building for arch=${TARGETARCH}" >&2
 # git: needed by claude tool calls + agent workflows.
 # sqlite3: kernel.db / scheduler.db / hindsight bank inspection.
 # openssh-client: claude bundle expects ssh-keygen for some flows.
+# python3: hindsight memory plugin's session_end.py / session_start.py
+#   hooks shell out to `python3` (defined in `.claude/hooks` for every
+#   scaffolded agent). Without it the SessionEnd hook errors on every
+#   turn end and claude exits — the v0.7.3 cutover crash-loop chain.
 RUN apt-get update \
  && apt-get install -y --no-install-recommends \
       tini \
@@ -31,6 +35,7 @@ RUN apt-get update \
       sqlite3 \
       openssh-client \
       curl \
+      python3 \
  && rm -rf /var/lib/apt/lists/*
 
 # Pin claude CLI version in the base image so every agent / scheduler

--- a/src/agents/compose.ts
+++ b/src/agents/compose.ts
@@ -457,6 +457,17 @@ function emitAgentService(
   lines.push(`    network_mode: host`);
   lines.push(`    restart: unless-stopped`);
   lines.push(`    init: false`);
+  // PTY allocation — claude's interactive mode requires a TTY at stdin
+  // (the alt-screen UI, autoaccept-poll keystrokes, and the `--print`
+  // fallback's stdin check). Without these the container boots, claude
+  // detects "no TTY → fall back to --print", immediately errors
+  // "Input must be provided either through stdin or as a prompt
+  // argument when using --print", tini exits, and the container
+  // restarts forever. Equivalent to `docker run -it`. v0.6's systemd
+  // path got the PTY for free via the tmux ExecStart wrapper; under
+  // docker we ask compose for it directly.
+  lines.push(`    tty: true`);
+  lines.push(`    stdin_open: true`);
   lines.push(`    stop_grace_period: 45s`);
   lines.push(`    user: "${a.uid}:${a.uid}"`);
   lines.push(`    mem_limit: ${a.resources.memLimit}`);

--- a/src/build-info.ts
+++ b/src/build-info.ts
@@ -3,7 +3,7 @@
 // Values are refreshed every time `npm run build` runs.
 
 export const VERSION: string = "0.7.3";
-export const COMMIT_SHA: string | null = "48d4157c";
-export const COMMIT_DATE: string | null = "2026-05-09T16:30:39+10:00";
-export const LATEST_PR: number | null = 871;
-export const COMMITS_AHEAD_OF_TAG: number | null = 5;
+export const COMMIT_SHA: string | null = "c88642de";
+export const COMMIT_DATE: string | null = "2026-05-09T17:28:20+10:00";
+export const LATEST_PR: number | null = 872;
+export const COMMITS_AHEAD_OF_TAG: number | null = 6;

--- a/tests/docker/compose-generator.test.ts
+++ b/tests/docker/compose-generator.test.ts
@@ -434,6 +434,40 @@ describe("agent service network (v0.7.4 — host networking)", () => {
   });
 });
 
+describe("agent service tty (v0.7.4 — claude interactive mode)", () => {
+  // Without tty + stdin_open, claude detects no-TTY at boot and falls
+  // back to --print mode, which then errors "Input must be provided
+  // either through stdin or as a prompt argument when using --print"
+  // because start.sh exec's claude with no stdin pipe. Container
+  // crash-loops forever. v0.6's systemd path got the PTY via the
+  // tmux ExecStart wrapper; under docker we ask compose for it.
+  it("emits tty: true and stdin_open: true on every agent service", () => {
+    const out = generateCompose({
+      config: makeConfig({ alice: {}, bob: {} }),
+    });
+    for (const a of ["alice", "bob"]) {
+      const re = new RegExp(`  agent-${a}:[\\s\\S]*?(?=\\n  [a-z])`);
+      const block = re.exec(out)?.[0] ?? "";
+      expect(block, `${a} block`).toMatch(/tty:\s*true/);
+      expect(block, `${a} block`).toMatch(/stdin_open:\s*true/);
+    }
+  });
+
+  it("does NOT emit tty / stdin_open on broker / kernel / scheduler", () => {
+    // Singletons run a long-lived server loop with no stdin reads;
+    // forcing a TTY would just waste a fd.
+    const out = generateCompose({
+      config: makeConfig({ a: {} }),
+    });
+    for (const svc of ["vault-broker", "approval-kernel", "switchroom-cron"]) {
+      const re = new RegExp(`  ${svc}:[\\s\\S]*?(?=\\n  [a-z]|\\nvolumes:)`);
+      const block = re.exec(out)?.[0] ?? "";
+      expect(block, `${svc} block`).not.toMatch(/^\s+tty:\s*true/m);
+      expect(block, `${svc} block`).not.toMatch(/^\s+stdin_open:\s*true/m);
+    }
+  });
+});
+
 describe("generateCompose — switchroomConfigPath bind-mount (v0.7 P0 fix)", () => {
   // Regression: without the config bind-mount, the broker container boots
   // with `ConfigError: No switchroom.yaml found` and restart-loops. The


### PR DESCRIPTION
## Summary
Two crash-loop fixes that surfaced when bringing up a single agent on docker after #872 landed:

1. **`python3` in `docker/Dockerfile.base`** — the hindsight memory plugin's `session_end.py` / `session_start.py` hooks (auto-installed for every scaffolded agent) shell out to `python3`. Without it every turn-end errored \`SessionEnd hook ... failed: /bin/sh: 1: python3: not found\`.
2. **`tty: true` + `stdin_open: true` on agent compose services** — without these, claude detects no-TTY at boot, falls back to `--print` mode, errors \`Input must be provided either through stdin or as a prompt argument when using --print\`, exits, and tini restarts the container in a loop.

## Verification
Live cutover of one agent (gymbro) on the v0.7.4-merged code:
- Before: 8 restarts in 90s (the two crash-loop chains above).
- After: 0 restarts in 30s+. `claude --version` running (PID 677722), gateway polling Telegram (\`tg-post method=getUpdates ... status=ok\`), vault auto-unlocked via /etc/machine-id-bound blob, hindsight reachable via `network_mode: host`.

## Test plan
- [x] `vitest run tests/docker/compose-generator.test.ts` — 47/47 pass (was 45). +2 cases (tty + stdin_open on agents but NOT singletons).
- [x] `tsc --noEmit` — only pre-existing `deprecated.test.ts` error.
- [x] Live agent cutover, see Verification.
- [ ] Reviewer agent verdict.

## Risk
- `python3` adds ~30MB to the base image. Acceptable — the hooks need it and it's a hard requirement, not a nicety.
- `tty: true` is the standard pattern for interactive container processes. No change to security posture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)