### PR TITLE
fix(v0.7.5): in-container tmux supervisor for autoaccept + attach

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,11 +9,81 @@ there.
 Switchroom is a Telegram plugin + agent lifecycle layer sitting on top of
 the unmodified `claude` CLI. Users run Claude Code agents 24/7 on a Linux
 box, talk to them from Telegram, and authenticate with their Claude
-Pro/Max subscription via OAuth (no API keys, no Docker, no custom
-runtime). The headline feature is a live **progress card** that pins into
+Pro/Max subscription via OAuth (no API keys, no custom runtime around
+claude). The headline feature is a live **progress card** that pins into
 each Telegram topic while an agent works.
 
+**v0.7+ ships agents in Docker containers** — one per agent, plus three
+shared singletons (`vault-broker`, `approval-kernel`, `switchroom-cron`)
+brought up by `docker compose`. v0.6 was systemd-user units; v0.7 is the
+docker migration. The `claude` CLI runs unmodified inside each agent
+container — Docker is for *distribution and isolation*, not a custom
+runtime around claude (the vision's "no Docker-as-runtime" line in
+`reference/vision.md` is preserved).
+
 See `README.md` for the user-facing description.
+
+## v0.7 runtime architecture (read this before touching docker/compose/broker code)
+
+```
+                  ┌─ vault-broker (root, cap_drop=ALL + CHOWN/FOWNER/DAC_READ_SEARCH)
+                  │    /etc/machine-id mount → auto-unlock derives AES key
+                  │    binds /run/switchroom/broker/<agent>/sock per agent (chowned to UID)
+                  │
+docker compose ───┼─ approval-kernel (root, mirror of broker socket model)
+project=switchroom│    binds /run/switchroom/kernel/<agent>/sock per agent
+                  │
+                  ├─ switchroom-cron (scheduler, mounts /var/run/docker.sock RW)
+                  │
+                  └─ agent-<name> ✕ N (per-agent UID 10001-10999, network_mode: host)
+                       tini → start.sh → tmux server+client → bash → claude
+                                              ↑ autoaccept-poll sidecar (sibling to tmux)
+```
+
+**Agent container process tree** (since v0.7.5): `tini` is PID 1.
+`start.sh` runs as tini's child. When `SWITCHROOM_RUNTIME=docker` is set
+(by compose) and `SWITCHROOM_DOCKER_TMUX_INNER` is unset (top-level
+entry), start.sh forks `bun /opt/switchroom/autoaccept-poll.js <name>`
+as a sidecar then `exec`s into `tmux -L switchroom-<name>
+new-session -A -s <name> bash -l "$0"` — the same script re-enters
+inside tmux with the inner-marker set, skips the wrapper, and runs
+claude. autoaccept-poll uses `tmux capture-pane / send-keys` against
+the same socket+session names to dispatch first-run prompts (dev-channels
+acknowledge, MCP trust, theme picker). v0.6's systemd ExecStart wraps
+the same way; v0.7 just enforces the contract inside the container.
+
+**Why both halves matter:** without tmux, autoaccept can't reach claude
+(it talks tmux), `switchroom agent attach` can't connect (it does
+`docker exec -it ... tmux attach -t <name>`), and `! interrupt`
+(`tmux send-keys C-c`) has nowhere to send. The contract is "tmux
+socket `switchroom-<name>` + session `<name>` lives inside the agent
+container" — pinned in `src/agents/autoaccept.ts:151`,
+`src/agents/lifecycle.ts:attachAgent`, and `profiles/_base/start.sh.hbs`.
+
+**Per-agent socket model:** compose mounts named volume
+`broker-<name>-sock` at `/run/switchroom/broker/<name>` inside the
+broker AND at `/run/switchroom/broker` inside agent-<name>. Broker
+enumerates subdirs at `/run/switchroom/broker/`, binds a socket at
+`<subdir>/sock`, chowns it to the agent UID (CAP_CHOWN granted) so a
+non-root agent container can connect. Path-as-identity invariant: agent
+name is parsed from the bind path via `socketPathToAgent` — never from
+a wire payload. Same shape for approval-kernel.
+
+**Vault auto-unlock:** machine-bound — broker derives an AES key from
+`/etc/machine-id` (host-mounted into the broker container) and decrypts
+the `vault-auto-unlock` blob on boot. Operator runs `switchroom vault
+broker enable-auto-unlock` once on the host to write the blob; rotation
+is via the same CLI. If the blob is missing or fails to decrypt, the
+broker falls back to interactive unlock (`switchroom vault broker
+unlock` from any agent's Telegram chat with `/vault unlock`, or via
+`docker exec -it switchroom-vault-broker ...`).
+
+**Networking:** agent containers use `network_mode: host` so scaffolded
+`start.sh` can reach hindsight at `127.0.0.1:18888` and operator LAN
+devices unchanged from v0.6. Tradeoff: agents share the host network
+namespace (no inter-agent isolation). The trust model already assumed
+shared-host operation. Future work: an opt-in strict-isolation mode
+with `extra_hosts: host.docker.internal`.
 
 ## Docker test discipline (HARD RULES)
 
@@ -76,14 +146,23 @@ Anything else is out of scope, however clever.
 ```
 src/                    TypeScript source for the `switchroom` CLI
   agents/               Agent scaffolding, lifecycle, workspace bootstrap
+                        compose.ts — generates ~/.switchroom/compose/docker-compose.yml
+                        scaffold.ts — renders start.sh, settings.json, .mcp.json per agent
+                        autoaccept.ts — tmux capture-pane / send-keys first-run dispatcher
+                        lifecycle.ts — start/stop/restart/status/attach (docker + systemd dual-path)
   auth/                 OAuth + multi-account slot pool (accounts.ts, manager.ts)
   cli/                  One file per top-level CLI verb (auth, agent,
                         workspace, debug, memory, topics, vault, ...)
+                        autoaccept-poll.ts — bun-runnable bundle baked into agent image
   config/               YAML loader + three-layer cascade (defaults → profiles → agents)
   memory/               Hindsight memory integration
+  runtime-mode.ts       isDockerRuntime() — v0.7.3 unified host-shell + in-container detection
   setup/                Interactive `switchroom setup` wizard
   telegram/             Shared telegram helpers used by the CLI
   vault/                AES-256-GCM encrypted secrets store
+    broker/             Long-lived UDS daemon (server.ts, client.ts, peercred.ts)
+                        Per-agent sockets at /run/switchroom/broker/<name>/sock
+    approvals/          approval-kernel — per-agent UDS for approval/grant flows
   web/                  Web dashboard
 
 telegram-plugin/        The enhanced MCP Telegram plugin (own Bun tests)
@@ -94,17 +173,31 @@ telegram-plugin/        The enhanced MCP Telegram plugin (own Bun tests)
   auto-fallback.ts      Quota-exhaustion auto-fallback
   tests/                Bun tests
 
+docker/                 Dockerfiles (base, agent, broker, kernel, scheduler).
+                        Built via `--build-local` flag on `switchroom apply`,
+                        OR pulled from GHCR (`ghcr.io/switchroom/switchroom-*:latest`).
 profiles/               Built-in agent profiles (CLAUDE.md.hbs + SOUL.md.hbs)
+                        _base/start.sh.hbs is the agent entry script template
+                        (includes the docker-mode tmux preamble, since v0.7.5).
 skills/                 Bundled Claude Code skills (symlinked into agents)
 docs/                   User-facing docs
 reference/              Design contract — vision.md, principles.md,
                         and outcome-focused JTBDs (*.md)
 scripts/                Build + release helpers
 tests/                  Vitest suite for src/
+  docker/               Docker-specific tests (compose generator, broker IPC,
+                        per-agent isolation, e2e). Use `switchroom.test=<phase>`
+                        labels — see "Docker test discipline" above.
 ```
 
 Agent scaffolds are written **outside** this repo (default
 `~/.switchroom/agents/<name>/`) — never commit per-user agent state here.
+
+The generated compose file at `~/.switchroom/compose/docker-compose.yml`
+doubles as a runtime-mode signal: `isDockerRuntime()` (`src/runtime-mode.ts`)
+returns true if either the file exists OR `SWITCHROOM_RUNTIME=docker` is
+set (the env-var path is for in-container code; the file path is for
+host-shell CLI invocations).
 
 ## Commands
 
@@ -241,3 +334,27 @@ contract" above. The pointers below are for *implementation*.)
 - **"What can I inspect at runtime?"** → `switchroom debug turn <agent>`
   dumps exact prompt layering; `switchroom workspace render <agent>`
   prints the bootstrap block.
+- **"How is the docker compose file generated?"** →
+  `src/agents/compose.ts:generateCompose()`. Tests pin every emitted
+  field at `tests/docker/compose-generator.test.ts`. UID allocation is
+  `allocateAgentUid()` (deterministic hash → 10001-10999).
+- **"How does the broker authenticate agents?"** → path-as-identity:
+  `src/vault/broker/peercred.ts:socketPathToAgent()` parses the bind
+  path. Two canonical shapes: flat `<agent>.sock` (legacy / tests) and
+  subdir `<agent>/sock` (what compose emits). ACL is bind-time, never
+  wire-time.
+- **"How does an agent boot inside a container?"** →
+  `profiles/_base/start.sh.hbs` (the docker-mode preamble at the top
+  forks autoaccept-poll + re-execs into tmux), `docker/Dockerfile.agent`
+  (CMD = `/state/agent/start.sh` under tini ENTRYPOINT, COPYs
+  autoaccept-poll bundle to `/opt/switchroom/`), `src/agents/compose.ts`
+  for the env / volumes / caps.
+- **"How does autoaccept dispatch first-run prompts?"** →
+  `src/agents/autoaccept.ts` (tmux capture-pane + send-keys, regex
+  prompts in `PROMPTS`). Bundle entry at `src/cli/autoaccept-poll.ts`.
+  Same code runs under v0.6 systemd (host-side) and v0.7 docker
+  (in-container sidecar) — only the supervisor location changed.
+- **"Why does a host-shell `switchroom agent list` differ from
+  inside a container?"** → `src/runtime-mode.ts:isDockerRuntime()`.
+  Both signals (env var + compose-file presence) flip the answer.
+  Doctor / status / lifecycle all branch on this single helper.

--- a/docker/Dockerfile.agent
+++ b/docker/Dockerfile.agent
@@ -22,6 +22,19 @@ RUN mkdir -p /state/agent /state/.claude /var/log/switchroom \
 # the compose `user:` directive at runtime.
 RUN mkdir -p /tmp/tmux-shared
 
+# autoaccept-poll bundle: a small bun-runnable JS that uses
+# `tmux capture-pane / send-keys` to dispatch keystrokes for first-run
+# claude TUI prompts (theme picker, MCP trust, dev-channels
+# acknowledgement, API provider picker). Under v0.6 systemd this was
+# spawned as ExecStartPost on the host; under v0.7 docker the agent
+# runs claude inside an in-container tmux (see start.sh's docker
+# preamble) and start.sh forks autoaccept-poll as a sidecar. Bake the
+# self-contained bundle into the image so start.sh has a stable path
+# (`/opt/switchroom/autoaccept-poll.js`) to invoke regardless of
+# operator install layout.
+COPY dist/cli/autoaccept-poll.js /opt/switchroom/autoaccept-poll.js
+RUN chmod 0755 /opt/switchroom/autoaccept-poll.js
+
 # tini handles zombies + signal forwarding. The actual command is
 # /state/agent/start.sh, which the scaffold renders into the bind-mount.
 ENTRYPOINT ["/usr/bin/tini", "--"]

--- a/profiles/_base/start.sh.hbs
+++ b/profiles/_base/start.sh.hbs
@@ -1,4 +1,36 @@
 #!/bin/bash
+# --- Docker-mode tmux supervisor (#793 §2 / v0.7.5) ---
+# Under v0.6 systemd the unit's ExecStart is `tmux new-session -d ...
+# bash -l start.sh` and ExecStartPost spawns autoaccept-poll on the
+# host — both pieces sit OUTSIDE the agent process. Under v0.7 docker
+# the container's CMD is start.sh directly under tini, with no tmux
+# wrapper and no host-side ExecStartPost. Without this preamble the
+# first-run dev-channels acknowledgement prompt blocks claude forever
+# (no autoaccept), and `switchroom agent attach` fails (no tmux server
+# inside the container for `tmux attach -t <name>` to find).
+#
+# Fix: when we detect docker mode AND we're not already inside the
+# inner tmux pane (the SWITCHROOM_DOCKER_TMUX_INNER marker), spawn
+# autoaccept-poll as a sidecar then re-exec into tmux with this same
+# script as the inner command. Inside tmux the marker is set, so the
+# preamble is a no-op and the rest of the script runs normally.
+#
+# Socket name `switchroom-<agent>` and session name `<agent>` match
+# what `src/agents/autoaccept.ts:151` and
+# `src/agents/lifecycle.ts:attachAgent` expect — the contract is the
+# same one v0.6 systemd has always honored, just enforced inside the
+# container instead of by the host's user systemd manager.
+if [ "$SWITCHROOM_RUNTIME" = "docker" ] && [ -z "$SWITCHROOM_DOCKER_TMUX_INNER" ]; then
+  if [ -f /opt/switchroom/autoaccept-poll.js ] && command -v bun >/dev/null 2>&1; then
+    bun /opt/switchroom/autoaccept-poll.js "{{name}}" \
+      >> /var/log/switchroom/autoaccept.log 2>&1 &
+  fi
+  export SWITCHROOM_DOCKER_TMUX_INNER=1
+  exec tmux -L "switchroom-{{name}}" \
+    new-session -A -s "{{name}}" -x 400 -y 50 \
+    bash -l "$0"
+fi
+
 export NVM_DIR="$HOME/.nvm"
 [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
 export PATH="$HOME/.bun/bin:$PATH"

--- a/tests/scaffold.test.ts
+++ b/tests/scaffold.test.ts
@@ -799,6 +799,114 @@ describe("scaffoldAgent", () => {
   });
 });
 
+describe("scaffoldAgent — docker-mode tmux supervisor preamble (v0.7.5)", () => {
+  // Under v0.7 docker, the agent container's CMD is start.sh under tini
+  // with no host-side tmux wrapper or ExecStartPost autoaccept. Without
+  // this preamble: claude blocks forever on the dev-channels acknowledge
+  // prompt (no autoaccept inside the container) and `switchroom agent
+  // attach` fails (no tmux server inside the container with the expected
+  // socket name). The preamble is gated on SWITCHROOM_RUNTIME=docker so
+  // the systemd path is unchanged byte-for-byte.
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "switchroom-docker-tmux-"));
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("renders the SWITCHROOM_RUNTIME=docker gate at the top of start.sh", () => {
+    const config = makeAgentConfig({ topic_id: 1 });
+    const result = scaffoldAgent("alice", config, tmpDir, telegramConfig);
+    const startSh = readFileSync(join(result.agentDir, "start.sh"), "utf-8");
+    // Must come BEFORE the env-var setup so we re-exec into tmux before
+    // doing redundant work (handoff load, hindsight wait-loop, etc).
+    const preambleIdx = startSh.indexOf('"$SWITCHROOM_RUNTIME" = "docker"');
+    const envIdx = startSh.indexOf('NVM_DIR="$HOME/.nvm"');
+    expect(preambleIdx).toBeGreaterThan(0);
+    expect(envIdx).toBeGreaterThan(preambleIdx);
+  });
+
+  it("guards re-entry with the SWITCHROOM_DOCKER_TMUX_INNER marker", () => {
+    // Without the inner-marker check the script would tmux-recurse
+    // forever — first invocation re-execs into tmux, the inner script
+    // runs again under tmux and would re-exec into another tmux, ...
+    const config = makeAgentConfig({ topic_id: 1 });
+    const result = scaffoldAgent("bob", config, tmpDir, telegramConfig);
+    const startSh = readFileSync(join(result.agentDir, "start.sh"), "utf-8");
+    expect(startSh).toContain('-z "$SWITCHROOM_DOCKER_TMUX_INNER"');
+    expect(startSh).toContain("export SWITCHROOM_DOCKER_TMUX_INNER=1");
+  });
+
+  it("forks autoaccept-poll as a background sidecar before the tmux exec", () => {
+    const config = makeAgentConfig({ topic_id: 1 });
+    const result = scaffoldAgent("carol", config, tmpDir, telegramConfig);
+    const startSh = readFileSync(join(result.agentDir, "start.sh"), "utf-8");
+    // Path must match the COPY target in docker/Dockerfile.agent. Both
+    // sides are pinned in tests so a Dockerfile rename surfaces here.
+    expect(startSh).toContain("/opt/switchroom/autoaccept-poll.js");
+    expect(startSh).toContain('bun /opt/switchroom/autoaccept-poll.js "carol"');
+    // & at end ensures it's backgrounded — without it tmux exec never
+    // fires and claude never starts.
+    const autoacceptLine = startSh
+      .split("\n")
+      .find((l) => l.includes("autoaccept.log 2>&1 &"));
+    expect(autoacceptLine).toBeTruthy();
+  });
+
+  it("re-execs into tmux with the v0.6-systemd socket+session contract", () => {
+    // src/agents/autoaccept.ts:151 hardcodes socket
+    // `switchroom-${agentName}` and src/agents/lifecycle.ts:attachAgent
+    // does `docker exec -it ... tmux -L switchroom-<name> attach -t <name>`.
+    // Both contracts are met from the inside-the-container side here.
+    const config = makeAgentConfig({ topic_id: 1 });
+    const result = scaffoldAgent("dave", config, tmpDir, telegramConfig);
+    const startSh = readFileSync(join(result.agentDir, "start.sh"), "utf-8");
+    expect(startSh).toMatch(/exec tmux -L "switchroom-dave"/);
+    expect(startSh).toMatch(/new-session -A -s "dave"/);
+  });
+
+  it("preamble interpolates the agent name consistently across the three call sites", () => {
+    // Three places interpolate `{{name}}` in the preamble: the
+    // autoaccept-poll bun arg, the tmux socket name (-L), and the tmux
+    // session name (-s). All three must agree — drift between them
+    // would break the autoaccept contract or the attach contract.
+    const a = scaffoldAgent("eve", makeAgentConfig({ topic_id: 1 }), tmpDir, telegramConfig);
+    const b = scaffoldAgent("eve-2", makeAgentConfig({ topic_id: 2 }), tmpDir, telegramConfig);
+    const aSh = readFileSync(join(a.agentDir, "start.sh"), "utf-8");
+    const bSh = readFileSync(join(b.agentDir, "start.sh"), "utf-8");
+
+    expect(aSh).toContain('bun /opt/switchroom/autoaccept-poll.js "eve"');
+    expect(aSh).toContain('exec tmux -L "switchroom-eve"');
+    expect(aSh).toContain('new-session -A -s "eve"');
+
+    // Non-trivial name (with a hyphen) survives interpolation byte-for-byte.
+    expect(bSh).toContain('bun /opt/switchroom/autoaccept-poll.js "eve-2"');
+    expect(bSh).toContain('exec tmux -L "switchroom-eve-2"');
+    expect(bSh).toContain('new-session -A -s "eve-2"');
+  });
+
+  it("Dockerfile.agent COPYs the bundle to the path start.sh references", () => {
+    // The two contracts have to stay paired: the start.sh preamble's
+    // `bun /opt/switchroom/autoaccept-poll.js` invocation only resolves
+    // because Dockerfile.agent COPYs the bundle into that exact path
+    // at image build time. A rename in either file silently breaks
+    // autoaccept, so pin both halves here.
+    const dockerfile = readFileSync(
+      resolve(__dirname, "..", "docker", "Dockerfile.agent"),
+      "utf-8",
+    );
+    expect(dockerfile).toContain(
+      "COPY dist/cli/autoaccept-poll.js /opt/switchroom/autoaccept-poll.js",
+    );
+    expect(dockerfile).toMatch(
+      /chmod 0755 \/opt\/switchroom\/autoaccept-poll\.js/,
+    );
+  });
+});
+
 describe("reconcileAgent", () => {
   let tmpDir: string;
 


### PR DESCRIPTION
## Summary
Closes the v0.7 docker design's autoaccept gap that's been silently breaking every fresh agent boot under docker. Epic #793 §2 explicitly calls for tmux-supervised agent runtime under docker, matching v0.6 systemd semantics. The v0.7 migration PRs landed compose generation, lifecycle dockerization, broker IPC, watchdog — but never wired tmux into the agent container. Without it: claude blocks forever on the first-run \`--dangerously-load-development-channels\` acknowledge prompt (no autoaccept inside container); \`switchroom agent attach\` is broken (no tmux server for it to docker-exec into); \`! interrupt\` has nowhere to send.

## Two halves, one contract
1. \`docker/Dockerfile.agent\` COPYs \`dist/cli/autoaccept-poll.js\` to \`/opt/switchroom/autoaccept-poll.js\` so start.sh has a stable in-image path.
2. \`profiles/_base/start.sh.hbs\` gets a docker-mode preamble at the top: when \`SWITCHROOM_RUNTIME=docker\` and the inner-marker \`SWITCHROOM_DOCKER_TMUX_INNER\` is unset, fork autoaccept-poll as a sidecar then \`exec tmux -L switchroom-<name> new-session -A -s <name> bash -l "$0"\`. The same script re-enters under tmux with the marker set, skips the wrapper, runs claude.

Socket+session names match what \`src/agents/autoaccept.ts:151\` and \`src/agents/lifecycle.ts:attachAgent\` already expect — this PR just makes the agent container honor the contract v0.6 has always honored, enforced inside the container instead of by the host's user systemd manager.

The systemd path is unchanged byte-for-byte — preamble is gated on \`SWITCHROOM_RUNTIME=docker\` which only the compose generator sets.

## Live verification
Cut over one agent (gymbro) on this branch end-to-end:
- Process tree inside container: \`tini → tmux server + tmux client → bash → claude\` (v0.6 systemd shape).
- autoaccept-poll log: \`fired dev-channels-loading,dev-channels-local,enter-to-confirm\` then clean idle-timeout.
- 0 container restarts, claude alive, gateway polling Telegram (\`tg-post method=getUpdates ... status=ok\`), vault auto-unlocked via v0.7.4 machine-id broker, hindsight reachable via \`network_mode: host\`.

## Test plan
- [x] \`vitest run tests/scaffold.test.ts\` — 158/158 pass. +5 new cases under "docker-mode tmux supervisor preamble" pinning the gate, re-entry marker, autoaccept fork, tmux socket+session contract, name interpolation, and the Dockerfile.agent COPY.
- [x] Full \`vitest run\` — no regressions vs upstream/main.
- [x] \`tsc --noEmit\` — only the pre-existing \`deprecated.test.ts\` error.
- [x] Live cutover (see above).
- [ ] Reviewer agent verdict.

## CLAUDE.md
This PR also updates CLAUDE.md with the v0.7 runtime architecture (process tree, broker/kernel topology, per-agent socket model, auto-unlock chain, host networking tradeoff) and refreshed "Where to look first" pointers — the previous version still said "no Docker" in the project description.

## JTBD this serves
Always-on (#4 in vision.md): an agent that crash-loops on every fresh boot isn't always-on, it's never-on. This restores the v0.6 always-on contract under v0.7 docker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)