### PR TITLE
fix(v0.7.6): in-container gateway daemon + telegram-plugin baking + docker-mode .mcp.json

### DIFF
--- a/docker/Dockerfile.agent
+++ b/docker/Dockerfile.agent
@@ -35,6 +35,28 @@ RUN mkdir -p /tmp/tmux-shared
 COPY dist/cli/autoaccept-poll.js /opt/switchroom/autoaccept-poll.js
 RUN chmod 0755 /opt/switchroom/autoaccept-poll.js
 
+# telegram-plugin: the MCP channel server claude spawns when invoked
+# with `--dangerously-load-development-channels server:switchroom-telegram`.
+# Resolved by bun via `bun run --cwd /opt/switchroom/telegram-plugin
+# --silent start` (see scaffold.ts:.mcp.json under SWITCHROOM_RUNTIME=docker).
+# The plugin needs three pieces:
+#   - dist/server.js     — the MCP entry (start.js falls back to source if
+#                          dist absent; the bake guarantees dist is present)
+#   - dist/gateway/      — the long-running gateway daemon that polls
+#                          Telegram and writes ~/.../telegram/gateway.sock;
+#                          spawned by start.sh as a sidecar
+#   - start.js           — entry shim that picks dist over source
+#   - package.json       — `bun run start` resolution
+# Under v0.6 systemd the plugin was reachable via the dev checkout path
+# (or npm-global install path on prod hosts); under v0.7 docker the
+# image is the source of truth, and `.mcp.json` points at the in-image
+# path. Without this COPY, the MCP sidecar exits at boot:
+#   "telegram channel: no gateway socket at <path>. Run `switchroom
+#    setup` to install the gateway daemon..."
+COPY telegram-plugin/dist /opt/switchroom/telegram-plugin/dist
+COPY telegram-plugin/start.js /opt/switchroom/telegram-plugin/start.js
+COPY telegram-plugin/package.json /opt/switchroom/telegram-plugin/package.json
+
 # tini handles zombies + signal forwarding. The actual command is
 # /state/agent/start.sh, which the scaffold renders into the bind-mount.
 ENTRYPOINT ["/usr/bin/tini", "--"]

--- a/profiles/_base/start.sh.hbs
+++ b/profiles/_base/start.sh.hbs
@@ -1,19 +1,25 @@
 #!/bin/bash
 # --- Docker-mode tmux supervisor (#793 §2 / v0.7.5) ---
 # Under v0.6 systemd the unit's ExecStart is `tmux new-session -d ...
-# bash -l start.sh` and ExecStartPost spawns autoaccept-poll on the
-# host — both pieces sit OUTSIDE the agent process. Under v0.7 docker
-# the container's CMD is start.sh directly under tini, with no tmux
-# wrapper and no host-side ExecStartPost. Without this preamble the
-# first-run dev-channels acknowledgement prompt blocks claude forever
-# (no autoaccept), and `switchroom agent attach` fails (no tmux server
-# inside the container for `tmux attach -t <name>` to find).
+# bash -l start.sh`, ExecStartPost spawns autoaccept-poll on the host,
+# and a sibling unit `switchroom-<name>-gateway.service` runs the
+# telegram-plugin gateway daemon — three pieces sitting OUTSIDE the
+# agent process. Under v0.7 docker the container's CMD is start.sh
+# directly under tini, with no tmux wrapper, no host-side
+# ExecStartPost, and no sibling gateway unit. Without this preamble
+# the first-run dev-channels acknowledgement prompt blocks claude
+# forever (no autoaccept), `switchroom agent attach` fails (no tmux
+# server with the expected socket name), and the telegram MCP sidecar
+# exits at boot with "no gateway socket; check `systemctl --user
+# status switchroom-telegram-gateway`" because the gateway daemon
+# isn't running anywhere.
 #
 # Fix: when we detect docker mode AND we're not already inside the
 # inner tmux pane (the SWITCHROOM_DOCKER_TMUX_INNER marker), spawn
-# autoaccept-poll as a sidecar then re-exec into tmux with this same
-# script as the inner command. Inside tmux the marker is set, so the
-# preamble is a no-op and the rest of the script runs normally.
+# the gateway daemon AND autoaccept-poll as supervised sidecars then
+# re-exec into tmux with this same script as the inner command.
+# Inside tmux the marker is set, so the preamble is a no-op and the
+# rest of the script runs normally.
 #
 # Socket name `switchroom-<agent>` and session name `<agent>` match
 # what `src/agents/autoaccept.ts:151` and
@@ -21,10 +27,63 @@
 # same one v0.6 systemd has always honored, just enforced inside the
 # container instead of by the host's user systemd manager.
 if [ "$SWITCHROOM_RUNTIME" = "docker" ] && [ -z "$SWITCHROOM_DOCKER_TMUX_INNER" ]; then
-  if [ -f /opt/switchroom/autoaccept-poll.js ] && command -v bun >/dev/null 2>&1; then
-    bun /opt/switchroom/autoaccept-poll.js "{{name}}" \
-      >> /var/log/switchroom/autoaccept.log 2>&1 &
+  # Hoist TELEGRAM_STATE_DIR up here so the gateway daemon (forked
+  # below) finds gateway.sock / gateway.pid.json / history.db at the
+  # same path the rest of start.sh + the MCP sidecar expects.
+  export TELEGRAM_STATE_DIR="{{agentDir}}/telegram"
+
+  # Tiny in-process supervisor: runs cmd in a respawn loop. Caps at
+  # 10 restarts in 60s before giving up — protects against tight
+  # crash loops that would otherwise burn CPU and obscure the root
+  # cause in logs. The sidecar's own structured logging is written
+  # directly to its log file; this wrapper only handles process
+  # lifecycle. Ampersand-backgrounded by callers below.
+  _switchroom_supervise() {
+    local _name="$1"; local _logfile="$2"; shift 2
+    local _restarts=0
+    local _window_start=$SECONDS
+    while true; do
+      "$@" >> "$_logfile" 2>&1
+      local _exit=$?
+      local _now=$SECONDS
+      if [ $((_now - _window_start)) -ge 60 ]; then
+        _restarts=0
+        _window_start=$_now
+      fi
+      _restarts=$((_restarts + 1))
+      echo "[supervise] $_name exited (status=$_exit, restart=$_restarts in $((_now - _window_start))s window)" >> "$_logfile"
+      if [ $_restarts -ge 10 ]; then
+        echo "[supervise] $_name hit 10 restarts in <60s — giving up" >> "$_logfile"
+        return 1
+      fi
+      sleep 1
+    done
+  }
+
+  # 1) Gateway daemon — the long-running Telegram bot client.
+  #    Polls Telegram, writes gateway.sock for the in-claude MCP
+  #    sidecar to bridge through. Mirrors the v0.6 sibling
+  #    switchroom-<name>-gateway.service unit. Talks to the broker
+  #    over SWITCHROOM_BROKER_SOCKET (set by compose) for the bot
+  #    token. Failure modes: vault locked → gateway boots, fails to
+  #    fetch token, exits non-zero, supervisor respawns; bot token
+  #    invalid → 401 from Telegram, gateway exits, same loop. The
+  #    cap avoids an infinite vault-locked respawn storm.
+  _gateway_bundle=/opt/switchroom/telegram-plugin/dist/gateway/gateway.js
+  if [ -f "$_gateway_bundle" ] && command -v bun >/dev/null 2>&1; then
+    _switchroom_supervise gateway /var/log/switchroom/gateway-supervisor.log \
+      bun "$_gateway_bundle" &
   fi
+
+  # 2) autoaccept-poll — first-run TUI prompt dispatcher. Single-shot
+  #    by design (exits cleanly after idle-timeout once prompts have
+  #    fired); supervisor's restart cap means a flaky autoaccept won't
+  #    masquerade as a tight loop.
+  if [ -f /opt/switchroom/autoaccept-poll.js ] && command -v bun >/dev/null 2>&1; then
+    _switchroom_supervise autoaccept /var/log/switchroom/autoaccept.log \
+      bun /opt/switchroom/autoaccept-poll.js "{{name}}" &
+  fi
+
   export SWITCHROOM_DOCKER_TMUX_INNER=1
   exec tmux -L "switchroom-{{name}}" \
     new-session -A -s "{{name}}" -x 400 -y 50 \

--- a/src/agents/compose.ts
+++ b/src/agents/compose.ts
@@ -406,7 +406,7 @@ export function generateCompose(opts: ComposeGeneratorOptions): string {
     if (a.strippedCaps.length > 0) {
       warn(`compose: stripping cap_add ${JSON.stringify(a.strippedCaps)} from agent "${a.name}" (Docker mode forbids capability extras; see RFC §security)`);
     }
-    emitAgentService(lines, a, imageTag, buildMode, buildContext, homePrefix);
+    emitAgentService(lines, a, imageTag, buildMode, buildContext, homePrefix, switchroomConfigPath);
   }
 
   // ── volumes ────────────────────────────────────────────────────────
@@ -427,6 +427,7 @@ function emitAgentService(
   buildMode: "pull" | "local",
   buildContext: string | undefined,
   homePrefix: string,
+  switchroomConfigPath: string | undefined,
 ): void {
   lines.push(`  agent-${a.name}:`);
   emitImageOrBuild(lines, "agent", imageTag, buildMode, buildContext);
@@ -495,6 +496,15 @@ function emitAgentService(
     SWITCHROOM_KERNEL_SOCKET: `/run/switchroom/kernel/${a.name}/sock`,
     SWITCHROOM_RUNTIME: "docker",
   };
+  // SWITCHROOM_CONFIG: the in-container telegram-plugin gateway daemon
+  // (forked as a sidecar by start.sh's docker preamble) shells out to
+  // the switchroom CLI for handoff / vault / topic operations and
+  // passes `--config $SWITCHROOM_CONFIG` so the in-container CLI finds
+  // the right yaml regardless of cwd. The yaml is bind-mounted below.
+  // Same env+mount pattern broker/kernel/scheduler already use.
+  if (switchroomConfigPath) {
+    env.SWITCHROOM_CONFIG = "/state/config/switchroom.yaml";
+  }
   for (const k of Object.keys(env).sort()) {
     lines.push(`      ${k}: ${JSON.stringify(env[k])}`);
   }
@@ -522,6 +532,13 @@ function emitAgentService(
   lines.push(`      - ${homePrefix}/.switchroom/logs/${a.name}:/var/log/switchroom`);
   lines.push(`      - ${homePrefix}/.switchroom/agents/${a.name}:${homePrefix}/.switchroom/agents/${a.name}`);
   lines.push(`      - ${homePrefix}/.claude/projects/${a.name}:${homePrefix}/.claude/projects/${a.name}`);
+  // switchroom.yaml file mount (read-only) — the in-container gateway
+  // daemon needs `--config $SWITCHROOM_CONFIG` to talk to the
+  // switchroom CLI for handoff / topic / vault grants. SWITCHROOM_CONFIG
+  // is set above; it points here.
+  if (switchroomConfigPath) {
+    lines.push(`      - ${switchroomConfigPath}:/state/config/switchroom.yaml:ro`);
+  }
   lines.push(`      - ${homePrefix}/.switchroom/logs/${a.name}:${homePrefix}/.switchroom/logs/${a.name}`);
   lines.push(``);
   void imageTag;

--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -1538,6 +1538,15 @@ Don't wait for a slash command. Don't ask permission. Memory work is table stake
   };
 }
 
+/**
+ * Path the v0.7 docker agent image bakes telegram-plugin into.
+ * Mirrors the `COPY telegram-plugin/...` block in `docker/Dockerfile.agent`.
+ * Used by `.mcp.json` generation in docker mode so the MCP server resolves
+ * inside the container regardless of where switchroom was installed on
+ * the host (npm-global, dev checkout, ad-hoc tarball).
+ */
+export const DOCKER_TELEGRAM_PLUGIN_PATH = "/opt/switchroom/telegram-plugin";
+
 export function scaffoldAgent(
   name: string,
   agentConfigRaw: AgentConfig,
@@ -1546,6 +1555,18 @@ export function scaffoldAgent(
   switchroomConfig?: SwitchroomConfig,
   userIdOverride?: string,
   switchroomConfigPath?: string,
+  /**
+   * v0.7+ docker-mode opt-in: when true, `.mcp.json` references the
+   * in-image telegram-plugin path (`/opt/switchroom/telegram-plugin`) and
+   * an in-image `switchroom` shim path; otherwise it resolves the host
+   * dev/install path the way it always has.
+   *
+   * Set by `src/cli/apply.ts` based on whether compose generation is
+   * happening (i.e. `switchroom apply` is being run as part of a docker
+   * fleet bring-up). Backwards-compatible: undefined / false preserves
+   * the v0.6 host-path behavior byte-for-byte.
+   */
+  dockerMode?: boolean,
 ): ScaffoldResult {
   // Apply the full cascade: global defaults → inline profile (from
   // `extends:`) → per-agent config. When switchroom.yaml has no `defaults:`
@@ -1810,11 +1831,27 @@ export function scaffoldAgent(
   if (usesSwitchroomTelegramPlugin(agentConfig)) {
     const mcpJsonPath = join(agentDir, ".mcp.json");
     if (!existsSync(mcpJsonPath)) {
-      const pluginDir = resolve(import.meta.dirname, "../../telegram-plugin");
-      const switchroomCliPath = resolveSwitchroomCliPath();
-      const resolvedConfigPath = switchroomConfigPath
-        ? resolve(switchroomConfigPath)
-        : resolve(process.cwd(), "switchroom.yaml");
+      // v0.7 docker mode: the agent image (Dockerfile.agent) COPYs the
+      // plugin to a stable in-image path and the running switchroom
+      // CLI is the npm-global one inside the image. Reference those —
+      // the host's repo checkout / npm-global install path is irrelevant
+      // inside the container and would resolve to a non-existent path.
+      // v0.6 systemd / non-docker mode: keep resolving against the host
+      // install layout.
+      const pluginDir = dockerMode
+        ? DOCKER_TELEGRAM_PLUGIN_PATH
+        : resolve(import.meta.dirname, "../../telegram-plugin");
+      const switchroomCliPath = dockerMode
+        ? "/usr/local/bin/switchroom"
+        : resolveSwitchroomCliPath();
+      // In docker, the in-container switchroom.yaml lives at the path
+      // compose bind-mounts it to (see compose.ts). In host mode, fall
+      // back to the existing logic.
+      const resolvedConfigPath = dockerMode
+        ? "/state/config/switchroom.yaml"
+        : (switchroomConfigPath
+            ? resolve(switchroomConfigPath)
+            : resolve(process.cwd(), "switchroom.yaml"));
 
       const mcpServers: Record<string, McpServerConfig> = {
         "switchroom-telegram": {
@@ -2312,6 +2349,15 @@ export interface ReconcileOptions {
    * as-is, ignoring template updates. Default false (regeneration is default).
    */
   preserveClaudeMd?: boolean;
+  /**
+   * v0.7+ docker-mode opt-in: when true, regenerated `.mcp.json` references
+   * the in-image telegram-plugin path (`/opt/switchroom/telegram-plugin`)
+   * and the in-image switchroom CLI; otherwise it resolves the host
+   * dev/install path the way it always has. Mirrors the same flag on
+   * `scaffoldAgent`. Set by `src/cli/apply.ts` based on whether docker
+   * compose is being generated.
+   */
+  dockerMode?: boolean;
 }
 
 /**
@@ -3241,11 +3287,19 @@ Don't wait for a slash command. Don't ask permission. Memory work is table stake
   // --- Reconcile .mcp.json (switchroom-telegram plugin agents only) ---
   if (usesSwitchroomTelegramPlugin(agentConfig)) {
     const mcpJsonPath = join(agentDir, ".mcp.json");
-    const pluginDir = resolve(import.meta.dirname, "../../telegram-plugin");
-    const switchroomCliPath = resolveSwitchroomCliPath();
-    const resolvedConfigPath = switchroomConfigPath
-      ? resolve(switchroomConfigPath)
-      : resolve(process.cwd(), "switchroom.yaml");
+    // Mirror the docker-mode branch in scaffoldAgent — keep both writers
+    // in sync so reconcile under docker emits the in-image paths.
+    const pluginDir = options.dockerMode
+      ? DOCKER_TELEGRAM_PLUGIN_PATH
+      : resolve(import.meta.dirname, "../../telegram-plugin");
+    const switchroomCliPath = options.dockerMode
+      ? "/usr/local/bin/switchroom"
+      : resolveSwitchroomCliPath();
+    const resolvedConfigPath = options.dockerMode
+      ? "/state/config/switchroom.yaml"
+      : (switchroomConfigPath
+          ? resolve(switchroomConfigPath)
+          : resolve(process.cwd(), "switchroom.yaml"));
 
     const mcpServers: Record<string, McpServerConfig> = {
       "switchroom-telegram": {

--- a/src/build-info.ts
+++ b/src/build-info.ts
@@ -3,7 +3,7 @@
 // Values are refreshed every time `npm run build` runs.
 
 export const VERSION: string = "0.7.3";
-export const COMMIT_SHA: string | null = "c88642de";
-export const COMMIT_DATE: string | null = "2026-05-09T17:28:20+10:00";
-export const LATEST_PR: number | null = 872;
-export const COMMITS_AHEAD_OF_TAG: number | null = 6;
+export const COMMIT_SHA: string | null = "93ab19c0";
+export const COMMIT_DATE: string | null = "2026-05-09T18:39:10+10:00";
+export const LATEST_PR: number | null = 874;
+export const COMMITS_AHEAD_OF_TAG: number | null = 8;

--- a/src/cli/agent.ts
+++ b/src/cli/agent.ts
@@ -546,6 +546,13 @@ export async function reconcileAndRestartAgent(
 
   // Reconcile first. If this throws, we stop here — never restart on
   // top of a broken config.
+  //
+  // dockerMode mirrors apply's behavior: when a compose file is present
+  // on the host (the host-shell signal `isDockerRuntime()` checks), the
+  // regenerated .mcp.json must reference the in-image telegram-plugin
+  // path, not the host's switchroom install. Otherwise reconcile would
+  // overwrite a working docker-mode .mcp.json with a host-mode one and
+  // break Telegram routing on the next agent restart.
   const result = deps.reconcileAgent(
     name,
     agentConfig,
@@ -553,6 +560,7 @@ export async function reconcileAndRestartAgent(
     config.telegram,
     config,
     configPath,
+    { dockerMode: isDockerRuntime() },
   );
 
   // v0.7: infra-unit regen no longer happens here. Compose-file drift
@@ -1445,7 +1453,7 @@ export function registerAgentCommand(program: Command): void {
               config.telegram,
               config,
               configPath,
-              { preserveClaudeMd: opts.preserveClaudeMd },
+              { preserveClaudeMd: opts.preserveClaudeMd, dockerMode: isDockerRuntime() },
             );
             // v0.7: infra-unit regen no longer runs here. Compose-file
             // drift is reconciled by `switchroom apply` + `docker compose
@@ -1635,6 +1643,7 @@ export function registerAgentCommand(program: Command): void {
           config.telegram,
           config,
           configPath,
+          { dockerMode: isDockerRuntime() },
         );
         if (result.changes.length > 0) {
           console.log(chalk.green(`  ${name}: reconciled (${result.changes.length} file(s))`));
@@ -1710,6 +1719,7 @@ export function registerAgentCommand(program: Command): void {
           config.telegram,
           config,
           configPath,
+          { dockerMode: isDockerRuntime() },
         );
         if (result.changes.length > 0) {
           console.log(chalk.green(`  ${name}: reconciled (${result.changes.length} file(s))`));

--- a/src/cli/apply.ts
+++ b/src/cli/apply.ts
@@ -248,6 +248,12 @@ export async function runApply(
   for (const name of agentNames) {
     const agentConfig = config.agents[name];
     try {
+      // apply ALWAYS generates a docker compose file (that's its whole
+      // job in v0.7+), so the rendered .mcp.json should reference the
+      // in-image telegram-plugin path the agent container will see, not
+      // the host's switchroom install path. Pass dockerMode=true here so
+      // a fresh user (no dev checkout, no host npm-global) gets a
+      // working agent on first compose-up.
       const result = scaffoldAgent(
         name,
         agentConfig,
@@ -256,6 +262,7 @@ export async function runApply(
         config,
         undefined,
         switchroomConfigPath,
+        true,
       );
       const detail =
         result.created.length > 0

--- a/tests/docker/compose-generator.test.ts
+++ b/tests/docker/compose-generator.test.ts
@@ -524,6 +524,37 @@ describe("generateCompose — switchroomConfigPath bind-mount (v0.7 P0 fix)", ()
     const sched = blockFor(out, "switchroom-cron");
     expect(sched).toMatch(/\.switchroom:\/state\/config:ro/);
   });
+
+  it("bind-mounts switchroom.yaml + sets SWITCHROOM_CONFIG on each agent (v0.7.6)", () => {
+    // The in-container telegram-plugin gateway sidecar shells out to
+    // the switchroom CLI for handoff / vault / topic operations and
+    // passes `--config $SWITCHROOM_CONFIG`. Without this mount the
+    // gateway boots, fails to resolve the config, and access-control
+    // checks default to deny.
+    const out = generateCompose({
+      config: makeConfig({ alice: {}, bob: {} }),
+      switchroomConfigPath: CONFIG,
+    });
+    const re = (a: string) =>
+      new RegExp(`  agent-${a}:[\\s\\S]*?(?=\\n  [a-z])`);
+    for (const a of ["alice", "bob"]) {
+      const block = re(a).exec(out)?.[0] ?? "";
+      expect(block, `${a} bind-mount`).toContain(
+        `${CONFIG}:/state/config/switchroom.yaml:ro`,
+      );
+      expect(block, `${a} env`).toMatch(
+        /SWITCHROOM_CONFIG:\s*"\/state\/config\/switchroom\.yaml"/,
+      );
+    }
+  });
+
+  it("back-compat: omitting switchroomConfigPath leaves agent without the mount", () => {
+    const out = generateCompose({ config: makeConfig({ alice: {} }) });
+    const re = /  agent-alice:[\s\S]*?(?=\n  [a-z])/;
+    const block = re.exec(out)?.[0] ?? "";
+    expect(block).not.toContain(":/state/config/switchroom.yaml");
+    expect(block).not.toMatch(/SWITCHROOM_CONFIG:/);
+  });
 });
 
 describe("generateCompose — buildMode (pull vs local)", () => {

--- a/tests/scaffold.test.ts
+++ b/tests/scaffold.test.ts
@@ -840,20 +840,69 @@ describe("scaffoldAgent — docker-mode tmux supervisor preamble (v0.7.5)", () =
     expect(startSh).toContain("export SWITCHROOM_DOCKER_TMUX_INNER=1");
   });
 
-  it("forks autoaccept-poll as a background sidecar before the tmux exec", () => {
+  it("forks autoaccept-poll under the bash supervisor before the tmux exec", () => {
     const config = makeAgentConfig({ topic_id: 1 });
     const result = scaffoldAgent("carol", config, tmpDir, telegramConfig);
     const startSh = readFileSync(join(result.agentDir, "start.sh"), "utf-8");
     // Path must match the COPY target in docker/Dockerfile.agent. Both
     // sides are pinned in tests so a Dockerfile rename surfaces here.
     expect(startSh).toContain("/opt/switchroom/autoaccept-poll.js");
-    expect(startSh).toContain('bun /opt/switchroom/autoaccept-poll.js "carol"');
-    // & at end ensures it's backgrounded — without it tmux exec never
-    // fires and claude never starts.
-    const autoacceptLine = startSh
-      .split("\n")
-      .find((l) => l.includes("autoaccept.log 2>&1 &"));
-    expect(autoacceptLine).toBeTruthy();
+    // v0.7.6: autoaccept now runs under _switchroom_supervise, which
+    // restarts it on crash up to a per-window cap. The supervisor
+    // line backgrounds with `&` and writes through the supervisor
+    // logfile (not the bare command's stdout).
+    expect(startSh).toMatch(
+      /_switchroom_supervise autoaccept \/var\/log\/switchroom\/autoaccept\.log[\s\S]*?bun \/opt\/switchroom\/autoaccept-poll\.js "carol" &/,
+    );
+  });
+
+  it("forks the gateway daemon under the bash supervisor (v0.7.6 P0)", () => {
+    // The MCP sidecar exits immediately at boot if no gateway daemon
+    // is running. v0.6 ran it as a sibling systemd unit; under v0.7
+    // docker the agent container runs the daemon as an in-process
+    // sidecar. Without this, claude boots fine but Telegram routing
+    // is dead end-to-end.
+    const config = makeAgentConfig({ topic_id: 1 });
+    const result = scaffoldAgent("eli", config, tmpDir, telegramConfig);
+    const startSh = readFileSync(join(result.agentDir, "start.sh"), "utf-8");
+    // Path must match the COPY target in docker/Dockerfile.agent.
+    expect(startSh).toContain(
+      "/opt/switchroom/telegram-plugin/dist/gateway/gateway.js",
+    );
+    expect(startSh).toMatch(
+      /_switchroom_supervise gateway \/var\/log\/switchroom\/gateway-supervisor\.log[\s\S]*?bun "\$_gateway_bundle" &/,
+    );
+  });
+
+  it("hoists TELEGRAM_STATE_DIR into the preamble so the gateway sidecar finds it", () => {
+    // The gateway looks at TELEGRAM_STATE_DIR for gateway.sock /
+    // gateway.pid.json / history.db. Without setting it BEFORE the
+    // sidecar fork, the gateway falls back to ~/.claude/channels/
+    // telegram which the MCP sidecar isn't watching.
+    const config = makeAgentConfig({ topic_id: 1 });
+    const result = scaffoldAgent("frank", config, tmpDir, telegramConfig);
+    const startSh = readFileSync(join(result.agentDir, "start.sh"), "utf-8");
+    const lines = startSh.split("\n");
+    const stateDirIdx = lines.findIndex((l) =>
+      l.includes(`TELEGRAM_STATE_DIR="${result.agentDir}/telegram"`),
+    );
+    const gatewayForkIdx = lines.findIndex((l) =>
+      l.includes("_switchroom_supervise gateway"),
+    );
+    expect(stateDirIdx).toBeGreaterThan(0);
+    expect(gatewayForkIdx).toBeGreaterThan(stateDirIdx);
+  });
+
+  it("supervisor caps restarts at 10 in 60s (avoids tight-loop CPU burn)", () => {
+    // Pin the cap shape so a future "make it 100" change forces a
+    // discussion: 10/60s is "give up after a clearly-broken
+    // first-minute" without making operators wait too long.
+    const config = makeAgentConfig({ topic_id: 1 });
+    const result = scaffoldAgent("greta", config, tmpDir, telegramConfig);
+    const startSh = readFileSync(join(result.agentDir, "start.sh"), "utf-8");
+    expect(startSh).toContain("_switchroom_supervise()");
+    expect(startSh).toContain("if [ $_restarts -ge 10 ]");
+    expect(startSh).toMatch(/if \[ \$\(\(_now - _window_start\)\) -ge 60 \]/);
   });
 
   it("re-execs into tmux with the v0.6-systemd socket+session contract", () => {
@@ -888,7 +937,7 @@ describe("scaffoldAgent — docker-mode tmux supervisor preamble (v0.7.5)", () =
     expect(bSh).toContain('new-session -A -s "eve-2"');
   });
 
-  it("Dockerfile.agent COPYs the bundle to the path start.sh references", () => {
+  it("Dockerfile.agent COPYs the autoaccept-poll bundle to the start.sh path", () => {
     // The two contracts have to stay paired: the start.sh preamble's
     // `bun /opt/switchroom/autoaccept-poll.js` invocation only resolves
     // because Dockerfile.agent COPYs the bundle into that exact path
@@ -904,6 +953,102 @@ describe("scaffoldAgent — docker-mode tmux supervisor preamble (v0.7.5)", () =
     expect(dockerfile).toMatch(
       /chmod 0755 \/opt\/switchroom\/autoaccept-poll\.js/,
     );
+  });
+
+  it("Dockerfile.agent COPYs the telegram-plugin bundle for the gateway sidecar (v0.7.6)", () => {
+    // start.sh forks `bun /opt/switchroom/telegram-plugin/dist/gateway/
+    // gateway.js`. That path resolves only because Dockerfile.agent
+    // bakes the plugin in. The MCP sidecar (claude-spawned) ALSO uses
+    // this path via .mcp.json's `--cwd`. A rename in either side
+    // breaks Telegram routing silently end-to-end.
+    const dockerfile = readFileSync(
+      resolve(__dirname, "..", "docker", "Dockerfile.agent"),
+      "utf-8",
+    );
+    expect(dockerfile).toContain(
+      "COPY telegram-plugin/dist /opt/switchroom/telegram-plugin/dist",
+    );
+    expect(dockerfile).toContain(
+      "COPY telegram-plugin/start.js /opt/switchroom/telegram-plugin/start.js",
+    );
+    expect(dockerfile).toContain(
+      "COPY telegram-plugin/package.json /opt/switchroom/telegram-plugin/package.json",
+    );
+  });
+});
+
+describe("scaffoldAgent — docker-mode .mcp.json (v0.7.6)", () => {
+  // The .mcp.json command paths are the third leg of the in-container
+  // telegram routing tripod (alongside Dockerfile.agent COPY and
+  // start.sh's docker preamble). When `dockerMode=true`, scaffold must
+  // emit the in-image paths so a fresh user with no host dev checkout
+  // and no host npm-global install gets a working agent on first
+  // compose-up.
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "switchroom-mcp-docker-"));
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("docker mode .mcp.json points --cwd at /opt/switchroom/telegram-plugin", () => {
+    const config = makeAgentConfig({ topic_id: 1 });
+    const result = scaffoldAgent(
+      "alice",
+      config,
+      tmpDir,
+      telegramConfig,
+      undefined,
+      undefined,
+      undefined,
+      true, // dockerMode
+    );
+    const mcp = JSON.parse(
+      readFileSync(join(result.agentDir, ".mcp.json"), "utf-8"),
+    ) as { mcpServers: Record<string, { args: string[]; env: Record<string, string> }> };
+    const args = mcp.mcpServers["switchroom-telegram"].args;
+    const cwdIdx = args.indexOf("--cwd");
+    expect(cwdIdx).toBeGreaterThan(-1);
+    expect(args[cwdIdx + 1]).toBe("/opt/switchroom/telegram-plugin");
+  });
+
+  it("docker mode .mcp.json points SWITCHROOM_CLI_PATH at the in-image binary", () => {
+    const config = makeAgentConfig({ topic_id: 1 });
+    const result = scaffoldAgent(
+      "bob",
+      config,
+      tmpDir,
+      telegramConfig,
+      undefined,
+      undefined,
+      undefined,
+      true,
+    );
+    const mcp = JSON.parse(
+      readFileSync(join(result.agentDir, ".mcp.json"), "utf-8"),
+    ) as { mcpServers: Record<string, { env: Record<string, string> }> };
+    const env = mcp.mcpServers["switchroom-telegram"].env;
+    expect(env.SWITCHROOM_CLI_PATH).toBe("/usr/local/bin/switchroom");
+    expect(env.SWITCHROOM_CONFIG).toBe("/state/config/switchroom.yaml");
+  });
+
+  it("non-docker mode preserves host-resolved paths (back-compat)", () => {
+    // Operators on v0.6 systemd / dev hosts still get the host
+    // pluginDir + host switchroomCliPath. Anything else would break
+    // existing fleets on reconcile.
+    const config = makeAgentConfig({ topic_id: 1 });
+    const result = scaffoldAgent("carol", config, tmpDir, telegramConfig);
+    const mcp = JSON.parse(
+      readFileSync(join(result.agentDir, ".mcp.json"), "utf-8"),
+    ) as { mcpServers: Record<string, { args: string[]; env: Record<string, string> }> };
+    const args = mcp.mcpServers["switchroom-telegram"].args;
+    const cwdIdx = args.indexOf("--cwd");
+    expect(args[cwdIdx + 1]).not.toBe("/opt/switchroom/telegram-plugin");
+    expect(mcp.mcpServers["switchroom-telegram"].env.SWITCHROOM_CLI_PATH)
+      .not.toBe("/usr/local/bin/switchroom");
   });
 });
 


### PR DESCRIPTION
## Summary
Closes the v0.7 docker-runtime gap that breaks every fresh user's first message. v0.6 ran the telegram-plugin gateway as a sibling systemd unit; v0.7 docker had neither the unit nor an in-container equivalent. MCP sidecar exited at boot:

```
telegram channel: no gateway socket at <path>. Run `switchroom setup` 
to install the gateway daemon, or check `systemctl --user status 
switchroom-telegram-gateway`. Exiting sidecar.
```

Three coupled fixes, can't ship apart:

1. **`docker/Dockerfile.agent` bakes the telegram-plugin bundle** at \`/opt/switchroom/telegram-plugin/\` — same pattern v0.7.5 used for autoaccept-poll. Cleans up host-path dependency.
2. **`scaffold.ts` + `apply.ts`/`agent.ts` emit docker-mode .mcp.json** via a new \`dockerMode?: boolean\` parameter. Points \`--cwd\` at the bake target, \`SWITCHROOM_CLI_PATH\` at the in-image binary, \`SWITCHROOM_CONFIG\` at the bind mount. Back-compat: undefined preserves byte-for-byte v0.6 host-path behavior.
3. **`start.sh.hbs` forks the gateway daemon as a supervised sidecar** under a small \`_switchroom_supervise\` bash helper (10 restarts in 60s cap). Hoists \`TELEGRAM_STATE_DIR\` into the preamble.

Plus **`compose.ts`** mounts switchroom.yaml + sets \`SWITCHROOM_CONFIG\` on each agent service so the gateway can shell out to the in-image switchroom CLI.

## Live verification
Cutover gymbro on this branch end-to-end:
- Process tree inside container: tini → tmux server+client → bash supervisors (×2) → gateway daemon (PID 10) + claude (PID 16) + MCP sidecar (PID 51, child of claude) bridging to gateway.sock.
- Gateway log: bot polling started, getMe + getChat + setMyCommands all OK, **boot card sent (msgId=1057)**.
- Autoaccept fired all three first-run prompts and exited cleanly.
- 0 container restarts. Vault auto-unlocked. Hindsight reachable.

## Test plan
- [x] \`vitest run\` — 5103 pass (was 5086). +9 new cases.
- [x] \`tsc --noEmit\` — only pre-existing \`deprecated.test.ts\` error.
- [x] Live cutover (above).
- [ ] Reviewer agent verdict.

## What this completes
v0.7.4 (broker), v0.7.5 (autoaccept), v0.7.6 (gateway daemon + plugin bake) together close the **P0** runtime gaps that any fresh user hits on first install. After this lands a fresh \`switchroom apply\` + \`docker compose up\` produces a working Telegram-routing fleet — the docker migration's actual headline behavior.

Outstanding (separate PRs, not blocking this one):
- v0.7.7: \`apply --only=<agent>\` for safe one-at-a-time migration.
- v0.7.7: \`docs/migration-v0.7.md\` reality-tested cutover playbook.
- CI: GHCR republish workflow on tag push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)