### PR TITLE
feat(v0.7.7): apply --only=<agent> + reality-tested migration playbook

### DIFF
--- a/docs/operators/migration-v0.7.md
+++ b/docs/operators/migration-v0.7.md
@@ -38,9 +38,10 @@ will make the migration fail in subtle ways if skipped.
 
   This writes `~/.switchroom/vault-auto-unlock` (a 60-byte file
   AES-encrypted with `/etc/machine-id`) and survives v0.6 → v0.7
-  unchanged. Mode 0644 is required so root-in-container can read it
-  (the broker has `DAC_READ_SEARCH`, but the host file mode is the
-  ultimate gate).
+  unchanged. The blob ships at mode 0600 (operator-owned). v0.7.4+
+  grants `DAC_READ_SEARCH` to the broker container so root-in-broker
+  can read 0600 operator-owned files without `DAC_OVERRIDE`; do not
+  loosen the file mode.
 
 - **Decide cutover mode: all-at-once or one-at-a-time.** v0.7 `apply`
   chowns every agent's state dir to its per-agent UID (10001-10999)

--- a/docs/operators/migration-v0.7.md
+++ b/docs/operators/migration-v0.7.md
@@ -6,19 +6,59 @@ tree is gone, `bin/bridge-watchdog.sh` is deleted, and `switchroom up`
 / `switchroom init` / `switchroom update` survive only as deprecation
 shims (slated for removal in v0.8).
 
-This guide walks an existing v0.6 deployment to v0.7 with no fleet
-downtime beyond a normal restart.
+This guide walks an existing v0.6 deployment to v0.7. Read all of
+"Before you start" — three of those preconditions look optional but
+will make the migration fail in subtle ways if skipped.
 
 ## Before you start
 
-- **Snapshot your config.** `cp -a ~/.switchroom ~/.switchroom.v0.6.bak`
-  — config, vault, agent state. Cheap insurance.
+- **Snapshot everything.** `cp -a ~/.switchroom ~/.switchroom.v0.6.bak`
+  — config, vault, agent state. Also save your systemd units:
+  `cp -a ~/.config/systemd/user ~/.config/systemd-user.v0.6.bak`.
+  These are your rollback path. Cheap insurance.
+
 - **Note what's running.** `switchroom agent list` (capture the output)
   so you can compare after the migration.
+
 - **Confirm the host has compose v2.** `docker compose version` should
   print `Docker Compose version v2.x`. If you only have the v1 plugin
   (`docker-compose`), install the v2 plugin first — `apply` errors out
   on v1.
+
+- **Enable vault auto-unlock BEFORE Step 3.** v0.7's broker runs in a
+  container with `cap_drop: ALL` plus `CHOWN/FOWNER/DAC_READ_SEARCH`
+  and reads `/etc/machine-id` to derive the AES unlock key. Without an
+  auto-unlock blob, the broker boots locked, agents can't fetch their
+  bot tokens, and the whole fleet sits idle waiting for an interactive
+  unlock that has no terminal. Run:
+
+  ```sh
+  switchroom vault broker enable-auto-unlock
+  ```
+
+  This writes `~/.switchroom/vault-auto-unlock` (a 60-byte file
+  AES-encrypted with `/etc/machine-id`) and survives v0.6 → v0.7
+  unchanged. Mode 0644 is required so root-in-container can read it
+  (the broker has `DAC_READ_SEARCH`, but the host file mode is the
+  ultimate gate).
+
+- **Decide cutover mode: all-at-once or one-at-a-time.** v0.7 `apply`
+  chowns every agent's state dir to its per-agent UID (10001-10999)
+  for the bind-mount to be writable from inside the container. If
+  systemd v0.6 agents are still running, the chown breaks them
+  silently — they keep running on FDs they already opened, but the
+  next restart fails because user 1000 (your shell) can no longer
+  read their `start.sh`.
+
+  Pick one:
+    - **All-at-once:** stop the entire systemd fleet (Step 1), `apply`
+      everything, bring the docker fleet up. Brief total outage.
+    - **One-at-a-time:** for each agent, stop its systemd units, run
+      `switchroom apply --only=<name>`, bring up that one container,
+      validate, repeat. Other agents stay on systemd until they're
+      cut over. **The "all-at-once" failure mode is silent and
+      fragile; use `--only=<name>` if your fleet has more than 2-3
+      agents.**
 
 ## Step 1 — Stop the systemd fleet
 
@@ -66,10 +106,31 @@ switchroom --version    # should report 0.7.x
 
 ## Step 3 — Apply + bring the docker fleet up
 
+### All-at-once
+
 ```sh
 switchroom apply
 docker compose -p switchroom -f ~/.switchroom/compose/docker-compose.yml pull
 docker compose -p switchroom -f ~/.switchroom/compose/docker-compose.yml up -d
+```
+
+### One-at-a-time (recommended for fleets > 2 agents)
+
+```sh
+# For EACH agent, in turn:
+AGENT=alice
+systemctl --user stop switchroom-${AGENT} switchroom-${AGENT}-gateway
+switchroom apply --only=${AGENT}
+docker compose -p switchroom -f ~/.switchroom/compose/docker-compose.yml \
+  up -d vault-broker approval-kernel agent-${AGENT}
+# (broker + kernel are idempotent; up -d won't restart them once running)
+
+# Validate this agent before moving to the next:
+docker compose -p switchroom -f ~/.switchroom/compose/docker-compose.yml \
+  logs --tail 30 agent-${AGENT}
+# Send a Telegram message to the agent and confirm a reply.
+
+# Then repeat with AGENT=bob, etc.
 ```
 
 `switchroom apply` runs the v0.7 preflights (compose-v2 detection,
@@ -78,6 +139,8 @@ writing `~/.switchroom/compose/docker-compose.yml`. If the UID-alignment
 check fails (your agent state dirs are owned by a UID the container
 won't have), either fix the ownership or pass `--allow-unaligned` after
 reading the warning.
+
+### Auto-unlock blob path
 
 If you used auto-unlock under v0.6, move the auto-unlock blob to its
 v0.7 path **before** running `switchroom apply` above (v0.7 changed the
@@ -90,9 +153,30 @@ default location and the v0.6 file won't be picked up otherwise):
 ```
 
 If you've moved the auto-unlock blob (above) the vault broker re-unlocks
-itself inside its new container on first boot. Otherwise you'll be
-prompted for the passphrase on first start; re-run
-`switchroom vault enable-auto-unlock` to restore unattended unlock.
+itself inside its new container on first boot. If you haven't yet
+enabled auto-unlock, re-run `switchroom vault broker enable-auto-unlock`
+**now** — without it, the broker container boots locked and the fleet
+can't start (see "Before you start" preconditions above).
+
+### Image source: pulled (default) or built locally
+
+`switchroom apply` writes a compose file that pulls the agent / broker
+/ kernel / scheduler images from `ghcr.io/switchroom/*:latest`. If you
+want to validate this branch's fixes before the canonical CI republishes
+the GHCR images (the v0.7.6 fix bakes the telegram-plugin bundle into
+the agent image; older `latest` tags don't have it), pass `--build-local`
+so compose builds from your in-tree Dockerfiles:
+
+```sh
+switchroom apply --build-local
+docker compose -p switchroom -f ~/.switchroom/compose/docker-compose.yml \
+  build vault-broker approval-kernel agent-${AGENT}
+docker compose -p switchroom -f ~/.switchroom/compose/docker-compose.yml \
+  up -d vault-broker approval-kernel agent-${AGENT}
+```
+
+Use `--build-local` on the maintainer's host until ghcr.io is refreshed;
+once the v0.7.6+ images are republished, drop the flag.
 
 ## Step 4 — Verify
 

--- a/src/build-info.ts
+++ b/src/build-info.ts
@@ -3,7 +3,7 @@
 // Values are refreshed every time `npm run build` runs.
 
 export const VERSION: string = "0.7.3";
-export const COMMIT_SHA: string | null = "93ab19c0";
-export const COMMIT_DATE: string | null = "2026-05-09T18:39:10+10:00";
-export const LATEST_PR: number | null = 874;
-export const COMMITS_AHEAD_OF_TAG: number | null = 8;
+export const COMMIT_SHA: string | null = "ed4ed823";
+export const COMMIT_DATE: string | null = "2026-05-09T18:58:46+10:00";
+export const LATEST_PR: number | null = 875;
+export const COMMITS_AHEAD_OF_TAG: number | null = 9;

--- a/src/cli/apply.test.ts
+++ b/src/cli/apply.test.ts
@@ -162,4 +162,97 @@ describe("runApply", () => {
     expect(res.agentsTotal).toBe(1);
     expect(res.composePath).toBe(outPath);
   });
+
+  describe("--only=<agent> (v0.7.7 — one-at-a-time cutover)", () => {
+    // The full v0.6 → v0.7 cutover chowns every agent's state dir to a
+    // per-agent UID; that breaks the systemd-managed siblings until
+    // they're stopped. --only=<name> scopes scaffold + chown to one
+    // agent so siblings keep running while operators migrate piecemeal.
+    function multiAgentConfig(agentsDir: string): SwitchroomConfig {
+      return {
+        agents: {
+          alice: { profile: "engineer", claudeAccount: "default" },
+          bob: { profile: "engineer", claudeAccount: "default" },
+          carol: { profile: "engineer", claudeAccount: "default" },
+        },
+        profiles: {},
+        defaults: {},
+        switchroom: { agents_dir: agentsDir },
+        telegram: { forum_chat_id: "0" },
+      } as unknown as SwitchroomConfig;
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let scaffoldSpy: any;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let alignSpy: any;
+
+    beforeEach(() => {
+      scaffoldSpy = vi
+        .spyOn(scaffoldModule, "scaffoldAgent")
+        .mockImplementation(() => ({ created: [] }) as never);
+      alignSpy = vi
+        .spyOn(scaffoldModule, "alignAgentUid")
+        .mockImplementation(() => ({ chowned: true, paths: [] }));
+    });
+
+    afterEach(() => {
+      scaffoldSpy.mockRestore();
+      alignSpy.mockRestore();
+    });
+
+    it("scaffolds + aligns only the named agent (siblings untouched)", async () => {
+      const dir = await mkdtemp(join(tmpdir(), "switchroom-apply-only-"));
+      const outPath = join(dir, "docker-compose.yml");
+
+      await runApply(
+        multiAgentConfig(join(dir, "agents")),
+        { outPath, only: "bob", nonInteractive: true },
+        { writeOut: () => {}, writeErr: () => {} },
+      );
+
+      // Only `bob` got scaffolded + aligned — alice and carol are
+      // still on whatever state they had before (presumably v0.6 systemd).
+      expect(scaffoldSpy).toHaveBeenCalledTimes(1);
+      expect(scaffoldSpy.mock.calls[0]![0]).toBe("bob");
+      expect(alignSpy).toHaveBeenCalledTimes(1);
+      expect(alignSpy.mock.calls[0]![0]).toBe("bob");
+    });
+
+    it("regenerates compose for the FULL fleet even with --only", async () => {
+      // Compose still needs every agent in YAML for the broker/kernel
+      // per-agent socket volumes to be emitted. Otherwise --only=alice
+      // would silently strip bob/carol from the compose and break their
+      // post-cutover sockets.
+      const dir = await mkdtemp(join(tmpdir(), "switchroom-apply-only-"));
+      const outPath = join(dir, "docker-compose.yml");
+
+      const res = await runApply(
+        multiAgentConfig(join(dir, "agents")),
+        { outPath, only: "alice", nonInteractive: true },
+        { writeOut: () => {}, writeErr: () => {} },
+      );
+
+      const composeYml = await readFile(outPath, "utf-8");
+      // All three agent services in the compose, regardless of --only.
+      expect(composeYml).toMatch(/agent-alice:/);
+      expect(composeYml).toMatch(/agent-bob:/);
+      expect(composeYml).toMatch(/agent-carol:/);
+      // agentsTotal still reflects the YAML, not the --only narrow.
+      expect(res.agentsTotal).toBe(3);
+    });
+
+    it("rejects --only=<unknown-name> with an actionable error", async () => {
+      const dir = await mkdtemp(join(tmpdir(), "switchroom-apply-only-"));
+      const outPath = join(dir, "docker-compose.yml");
+
+      await expect(
+        runApply(
+          multiAgentConfig(join(dir, "agents")),
+          { outPath, only: "frank", nonInteractive: true },
+          { writeOut: () => {}, writeErr: () => {} },
+        ),
+      ).rejects.toThrow(/--only=frank.*no such agent/);
+    });
+  });
 });

--- a/src/cli/apply.ts
+++ b/src/cli/apply.ts
@@ -406,7 +406,7 @@ export async function runApply(
 
   writeOut(
     chalk.bold(
-      `\nDone. Scaffolded ${scaffolded}/${agentNames.length} agents.\n`,
+      `\nDone. Scaffolded ${scaffolded}/${allAgentNames.length} agents.\n`,
     ),
   );
 

--- a/src/cli/apply.ts
+++ b/src/cli/apply.ts
@@ -80,6 +80,25 @@ export interface ApplyOptions {
    * unless the operator opts into the unsafe path.
    */
   allowUnaligned?: boolean;
+  /**
+   * Restrict apply to a single agent — scaffold + UID-align ONLY this
+   * agent's state dir, leaving every other agent untouched. Compose is
+   * still regenerated for the full fleet so the singletons (broker,
+   * kernel, scheduler) match yaml; we just don't touch the other agents'
+   * state dirs.
+   *
+   * Why: a v0.6 → v0.7 cutover that aligns every agent's UID at once
+   * will break every agent that's currently running under systemd —
+   * systemd-user is uid 1000; the post-align dirs are owned by per-agent
+   * UIDs (10001-10999), which kenthompson can no longer execute or
+   * write to. The fleet-wide chown is correct after a clean stop, but
+   * during a partial cutover where other agents are still systemd-managed,
+   * `--only=<name>` is the safe one-at-a-time path.
+   *
+   * The migration playbook is: stop systemd <name>, `apply --only=<name>`,
+   * compose-up <name>, validate, repeat for next agent.
+   */
+  only?: string;
 }
 
 export interface ApplyDeps {
@@ -235,9 +254,31 @@ export async function runApply(
   runApplyPreflight(config);
 
   const agentsDir = resolveAgentsDir(config);
-  const agentNames = Object.keys(config.agents);
+  const allAgentNames = Object.keys(config.agents);
+
+  // --only=<name> narrows the scaffold+align loop to a single agent.
+  // Compose generation still walks the FULL fleet (all 8 agents are in
+  // the YAML; the singletons need to know about each named agent for
+  // the per-agent socket volumes). Only the per-agent state-dir touches
+  // are scoped.
+  if (options.only !== undefined && !allAgentNames.includes(options.only)) {
+    throw new Error(
+      `apply --only=${options.only}: no such agent in switchroom.yaml. ` +
+      `Defined agents: ${allAgentNames.join(", ")}.`,
+    );
+  }
+  const agentNames =
+    options.only !== undefined ? [options.only] : allAgentNames;
 
   writeOut(chalk.bold("\nApplying switchroom config...\n"));
+  if (options.only !== undefined) {
+    writeOut(
+      chalk.gray(
+        `  (--only=${options.only}: scaffolding/aligning this agent only; ` +
+        `compose still covers all ${allAgentNames.length})\n`,
+      ),
+    );
+  }
 
   // ── 1. Scaffold each agent ────────────────────────────────────────
   let scaffolded = 0;
@@ -371,7 +412,7 @@ export async function runApply(
 
   return {
     scaffolded,
-    agentsTotal: agentNames.length,
+    agentsTotal: allAgentNames.length,
     composePath,
     composeBytes,
   };
@@ -450,6 +491,10 @@ export function registerApplyCommand(program: Command): void {
       "--allow-unaligned",
       "Treat UID-alignment chown failures as warnings instead of hard errors. Unsafe: an unaligned state dir will break the agent on first write. Use only if you know you'll fix ownership out-of-band.",
     )
+    .option(
+      "--only <agent>",
+      "Restrict scaffold + UID-alignment to a single agent (compose still covers the full fleet). Use during a v0.6 → v0.7 cutover to migrate agents one at a time without breaking the systemd-managed siblings.",
+    )
     .action(
       async (opts: {
         buildLocal?: boolean | string;
@@ -457,6 +502,7 @@ export function registerApplyCommand(program: Command): void {
         example?: string;
         nonInteractive?: boolean;
         allowUnaligned?: boolean;
+        only?: string;
       }) => {
         try {
           if (opts.example) {
@@ -483,6 +529,7 @@ export function registerApplyCommand(program: Command): void {
               example: opts.example,
               nonInteractive: opts.nonInteractive ?? false,
               allowUnaligned: opts.allowUnaligned ?? false,
+              only: opts.only,
             },
             {},
             switchroomConfigPath,


### PR DESCRIPTION
## Summary
Two operator-facing follow-ons after v0.7.4–7.6 closed the runtime gaps:

1. **`switchroom apply --only=<agent>`** — scopes scaffold + UID-align to one agent; compose still walks the FULL fleet (singletons need every name in YAML for per-agent socket volumes). Lets operators migrate fleets piecemeal without breaking systemd-running siblings.
2. **`docs/operators/migration-v0.7.md`** rewrite — auto-unlock now flagged as a hard precondition (was optional), all-at-once vs one-at-a-time cutover documented with the new flag, image-source choice (\`pull\` vs \`--build-local\`) explained, snapshot step expanded to include systemd unit files.

## Why
Both surfaced from a real v0.6 → v0.7 cutover this week:
- Auto-unlock missing → broker boots locked → fleet idle → operator confused.
- All-at-once chown with siblings running → siblings break silently on next restart.

## Test plan
- [x] \`vitest run src/cli/apply.test.ts\` — 9/9 pass (3 new \`--only\` cases).
- [x] \`vitest run\` — 5106 pass.
- [x] \`tsc --noEmit\` — only pre-existing \`deprecated.test.ts\` error.
- [ ] Reviewer agent verdict.

## Risk
- \`--only\` is purely additive; default behavior unchanged.
- Doc-only changes for the migration playbook.

## What this completes
With v0.7.4 (broker), v0.7.5 (autoaccept), v0.7.6 (gateway daemon + plugin bake), and now v0.7.7 (\`--only\` + docs), every P0/P1 gap from \"what's needed for any user to install v0.7\" is closed. Outstanding: a release decision (tag + npm publish) — not engineering, not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)