### PR TITLE
fix: three v0.6 → v0.7 migration bugs (start.sh regen, logs-dir chown, broker bind)

### DIFF
--- a/src/agents/scaffold.test.ts
+++ b/src/agents/scaffold.test.ts
@@ -57,6 +57,14 @@ describe("alignAgentUid", () => {
     vi.restoreAllMocks();
   });
 
+  // The agent state dir AND the per-agent log dir
+  // (~/.switchroom/logs/<name>) are both chowned to the agent UID. The
+  // log dir was added in #880 — without it, the in-container supervised
+  // gateway and autoaccept-poll sidecars exit silently because their
+  // log redirects (`>> /var/log/switchroom/...`) hit the bind-mounted
+  // root-owned dir as a non-root agent UID.
+  const expectedLogsDir = join(homedir(), ".switchroom", "logs", "agent");
+
   it("still runs recursive chown even when the top-level dir is already owned (subtree may be stale)", () => {
     // The previous behaviour was a fast-path no-op when statSync said the
     // top-level was already aligned. That hid stale uid 1000 entries
@@ -71,11 +79,11 @@ describe("alignAgentUid", () => {
     });
 
     expect(res.chowned).toBe(true);
-    expect(res.paths).toEqual(["/fake/state/agent"]);
+    expect(res.paths).toEqual(["/fake/state/agent", expectedLogsDir]);
     expect(mockedExecFileSync).toHaveBeenCalledTimes(1);
     const [bin, args] = mockedExecFileSync.mock.calls[0];
     expect(bin).toBe("chown");
-    expect(args).toEqual(["-R", "10042:10042", "/fake/state/agent"]);
+    expect(args).toEqual(["-R", "10042:10042", "/fake/state/agent", expectedLogsDir]);
   });
 
   it("tries unprivileged chown first, returns success when it works", () => {
@@ -91,7 +99,7 @@ describe("alignAgentUid", () => {
     expect(mockedExecFileSync).toHaveBeenCalledTimes(1);
     const [bin, args] = mockedExecFileSync.mock.calls[0];
     expect(bin).toBe("chown");
-    expect(args).toEqual(["-R", "10042:10042", "/fake/state/agent"]);
+    expect(args).toEqual(["-R", "10042:10042", "/fake/state/agent", expectedLogsDir]);
   });
 
   it("falls back to `sudo chown` when unprivileged chown fails (EPERM)", () => {
@@ -119,6 +127,7 @@ describe("alignAgentUid", () => {
       "-R",
       "10042:10042",
       "/fake/state/agent",
+      expectedLogsDir,
     ]);
   });
 
@@ -150,7 +159,7 @@ describe("alignAgentUid", () => {
     expect(mockedExecFileSync).not.toHaveBeenCalled();
   });
 
-  it("returns immediately with no paths when the agentDir does not exist", () => {
+  it("returns immediately with no paths when neither agentDir nor the logs dir exists", () => {
     mockedExistsSync.mockReturnValue(false);
 
     const res = alignAgentUid("agent", "/missing/agent", 10042, {
@@ -163,11 +172,30 @@ describe("alignAgentUid", () => {
     expect(mockedExecFileSync).not.toHaveBeenCalled();
   });
 
+  it("still chowns when only the logs dir exists (legacy state-only paths absent)", () => {
+    // existsSync returns true for /fake/state/agent (the call argument
+    // sequence in alignAgentUid is agentDir then logsDir).
+    mockedExistsSync.mockImplementation((p) => p !== "/fake/state/agent");
+    mockedStatSync.mockReturnValue({ uid: 1000, gid: 1000 } as never);
+    mockedExecFileSync.mockImplementationOnce(() => Buffer.from(""));
+
+    const res = alignAgentUid("agent", "/fake/state/agent", 10042, {
+      writeOut: () => {},
+      confirm: false,
+    });
+
+    expect(res.chowned).toBe(true);
+    expect(res.paths).toEqual([expectedLogsDir]);
+    const [bin, args] = mockedExecFileSync.mock.calls[0];
+    expect(bin).toBe("chown");
+    expect(args).toEqual(["-R", "10042:10042", expectedLogsDir]);
+  });
+
   // PR-D1 / v0.7 coverage gap #4 — when alignAgentUid actually shells
-  // chown, it must record the prior owner of the top-level dir to
+  // chown, it must record the prior owner of every top-level path to
   // ~/.switchroom/.uid-alignment.log so a future rollback can restore
   // exact ownership without guessing.
-  it("appends `<iso-ts> <dir> <prior-uid>:<prior-gid> -> <new>:<new>` to .uid-alignment.log when prior owner differs", () => {
+  it("appends one log line per top-level path whose prior owner differs from the target uid", () => {
     mockedStatSync.mockReturnValue({ uid: 1000, gid: 1000 } as never);
     mockedExecFileSync.mockImplementationOnce(() => Buffer.from(""));
 
@@ -176,14 +204,23 @@ describe("alignAgentUid", () => {
       confirm: false,
     });
 
-    expect(mockedAppendFileSync).toHaveBeenCalledOnce();
-    const [logPath, line] = mockedAppendFileSync.mock.calls[0]!;
-    expect(logPath).toBe(join(homedir(), ".switchroom", ".uid-alignment.log"));
-    expect(typeof line).toBe("string");
-    // Shape: <iso-ts> <dir> <prior-uid>:<prior-gid> -> <new>:<new>\n
-    expect(line as string).toMatch(
-      /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z \/fake\/state\/agent 1000:1000 -> 10042:10042\n$/,
-    );
+    // Two paths chowned (state dir + logs dir), so two audit lines.
+    expect(mockedAppendFileSync).toHaveBeenCalledTimes(2);
+    for (const call of mockedAppendFileSync.mock.calls) {
+      const [logPath, line] = call;
+      expect(logPath).toBe(join(homedir(), ".switchroom", ".uid-alignment.log"));
+      expect(typeof line).toBe("string");
+      // Shape: <iso-ts> <path> <prior-uid>:<prior-gid> -> <new>:<new>\n
+      expect(line as string).toMatch(
+        /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z \S+ 1000:1000 -> 10042:10042\n$/,
+      );
+    }
+    // One line per chowned path: state dir AND logs dir each appear.
+    const linesText = mockedAppendFileSync.mock.calls
+      .map((c) => c[1] as string)
+      .join("");
+    expect(linesText).toContain("/fake/state/agent");
+    expect(linesText).toContain(expectedLogsDir);
 
     // The log dir must be ensured ahead of the append (ENOENT-safe).
     expect(mockedMkdirSync).toHaveBeenCalledWith(

--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -108,38 +108,54 @@ export function alignAgentUid(
   opts: AlignAgentUidOptions = {},
 ): { chowned: boolean; paths: string[] } {
   const writeOut = opts.writeOut ?? ((s: string) => process.stdout.write(s));
+
+  // The agent state dir is the primary target. We also align the per-agent
+  // log dir (~/.switchroom/logs/<name>) — Dockerfile.agent creates
+  // /var/log/switchroom as root:root 0755, the compose volume mount
+  // inherits that ownership, and start.sh's docker-mode supervisor forks
+  // gateway and autoaccept-poll sidecars whose `>> /var/log/switchroom/*.log`
+  // redirects fail silently as the in-container agent UID. Without the
+  // log dir chowned to the agent UID, the sidecars exit immediately at
+  // boot and the agent comes up without autoaccept or the gateway daemon.
+  // See #880.
+  const logsDir = join(homedir(), ".switchroom", "logs", name);
   const paths: string[] = [];
   if (existsSync(agentDir)) paths.push(agentDir);
+  if (existsSync(logsDir)) paths.push(logsDir);
   if (paths.length === 0) return { chowned: false, paths: [] };
 
-  // No fast-path: a previous `apply` may have aligned the top-level dir
+  // No fast-path: a previous `apply` may have aligned the top-level dirs
   // while leaving stale uid 1000 entries deep in the subtree (e.g. the
   // operator dropped files in via sudo, or a v0.6 → v0.7 migration
   // chowned the root but skipped a child). `chown -R` is idempotent and
   // cheap, so we always run it. Pre-`chown` we record the prior owner of
-  // the top-level dir to ~/.switchroom/.uid-alignment.log so rollback
+  // each top-level path to ~/.switchroom/.uid-alignment.log so rollback
   // can restore precise ownership without guessing.
-  let priorUid: number | undefined;
-  let priorGid: number | undefined;
-  try {
-    const st = statSync(agentDir);
-    priorUid = st.uid;
-    priorGid = st.gid;
-  } catch { /* unreadable — skip the audit log entry */ }
+  const priors: Array<{ path: string; uid: number; gid: number } | { path: string; uid: undefined; gid: undefined }> = [];
+  for (const p of paths) {
+    try {
+      const st = statSync(p);
+      priors.push({ path: p, uid: st.uid, gid: st.gid });
+    } catch {
+      priors.push({ path: p, uid: undefined, gid: undefined });
+    }
+  }
 
   if (opts.dryRun) return { chowned: false, paths };
 
-  if (priorUid !== undefined && priorGid !== undefined && (priorUid !== uid || priorGid !== uid)) {
-    try {
-      const logPath = join(homedir(), ".switchroom", ".uid-alignment.log");
-      mkdirSync(join(homedir(), ".switchroom"), { recursive: true });
-      const ts = new Date().toISOString();
-      appendFileSync(
-        logPath,
-        `${ts} ${agentDir} ${priorUid}:${priorGid} -> ${uid}:${uid}\n`,
-      );
-    } catch { /* best-effort audit; never block alignment */ }
-  }
+  try {
+    const logPath = join(homedir(), ".switchroom", ".uid-alignment.log");
+    mkdirSync(join(homedir(), ".switchroom"), { recursive: true });
+    const ts = new Date().toISOString();
+    for (const prior of priors) {
+      if (prior.uid !== undefined && prior.gid !== undefined && (prior.uid !== uid || prior.gid !== uid)) {
+        appendFileSync(
+          logPath,
+          `${ts} ${prior.path} ${prior.uid}:${prior.gid} -> ${uid}:${uid}\n`,
+        );
+      }
+    }
+  } catch { /* best-effort audit; never block alignment */ }
 
   if (opts.confirm !== false && process.stdin.isTTY) {
     // Interactive prompt: explain why we're shelling sudo. We use
@@ -147,7 +163,7 @@ export function alignAgentUid(
     // appears on the operator's terminal.
     writeOut(
       chalk.gray(
-        `  · aligning ${name} state dir ownership to uid ${uid} (sudo chown)\n`,
+        `  · aligning ${name} state + log dir ownership to uid ${uid} (sudo chown)\n`,
       ),
     );
   }
@@ -156,7 +172,7 @@ export function alignAgentUid(
   try {
     // Recursive chown via shell — node's fs.chownSync isn't recursive
     // and rolling our own walk just to fall back to sudo is wasted code.
-    execFileSync("chown", ["-R", `${uid}:${uid}`, agentDir], {
+    execFileSync("chown", ["-R", `${uid}:${uid}`, ...paths], {
       stdio: ["ignore", "ignore", "pipe"],
     });
     return { chowned: true, paths };
@@ -169,13 +185,13 @@ export function alignAgentUid(
   }
 
   try {
-    execFileSync("sudo", ["chown", "-R", `${uid}:${uid}`, agentDir], {
+    execFileSync("sudo", ["chown", "-R", `${uid}:${uid}`, ...paths], {
       stdio: "inherit",
     });
     return { chowned: true, paths };
   } catch {
     throw new Error(
-      `alignAgentUid: sudo chown failed for ${agentDir} (target uid ${uid}). Run manually: sudo chown -R ${uid}:${uid} ${agentDir}`,
+      `alignAgentUid: sudo chown failed for ${paths.join(", ")} (target uid ${uid}). Run manually: sudo chown -R ${uid}:${uid} ${paths.join(" ")}`,
     );
   }
 }
@@ -1697,7 +1713,14 @@ export function scaffoldAgent(
   }
 
   // --- Render and write base templates ---
-  writeIfMissing(
+  // start.sh is purely template-driven (no user-merged sections), so it
+  // must be regenerated whenever the template changes. writeIfMissing
+  // would skip an existing file regardless of whether the template has
+  // since gained new content (e.g. v0.7.5 added the docker-mode tmux
+  // preamble — agents whose start.sh predated that release booted
+  // without the preamble after `apply --only=<name>` because the file
+  // already existed). See #879.
+  writeIfChanged(
     join(agentDir, "start.sh"),
     () => renderTemplate(join(basePath, "start.sh.hbs"), context),
     created,
@@ -3536,6 +3559,29 @@ function writeIfMissing(
     return;
   }
   writeFileSync(filePath, contentFn(), mode !== undefined ? { encoding: "utf-8", mode } : "utf-8");
+  created.push(filePath);
+}
+
+// Content-aware write for purely template-driven files (see #879).
+// Reads existing content, renders fresh, writes only when different.
+// Existing-and-changed counts as "created" for the caller's running
+// total — `apply`'s "N files created" line then truthfully reflects
+// that the file was rewritten, instead of silently reporting
+// "up to date" when the template has drifted.
+function writeIfChanged(
+  filePath: string,
+  contentFn: () => string,
+  created: string[],
+  skipped: string[],
+  mode?: number,
+): void {
+  const next = contentFn();
+  const prev = existsSync(filePath) ? readFileSync(filePath, "utf-8") : null;
+  if (prev === next) {
+    skipped.push(filePath);
+    return;
+  }
+  writeFileSync(filePath, next, mode !== undefined ? { encoding: "utf-8", mode } : "utf-8");
   created.push(filePath);
 }
 

--- a/src/vault/approvals/kernel-server.ts
+++ b/src/vault/approvals/kernel-server.ts
@@ -107,6 +107,19 @@ async function bindAgentSocket(
 ): Promise<AgentListener> {
   const dir = resolve(parentDir, agent);
   mkdirSync(dir, { recursive: true, mode: 0o700 });
+  // Reset the per-agent dir back to root:root 0700 BEFORE binding (#881).
+  // On a fresh container the dir is already root-owned (from the mkdir
+  // above) so chown is a no-op. On a restart where a previous instance
+  // left the dir chowned to the agent UID 10xxx mode 0700, a fresh
+  // kernel container — running root with cap_drop=ALL +
+  // cap_add=[CHOWN,FOWNER,DAC_READ_SEARCH] — does NOT hold
+  // CAP_DAC_OVERRIDE and cannot write into a 10xxx-owned 0700 dir.
+  // CAP_CHOWN is granted, so chown'ing the dir back to root succeeds
+  // regardless of its current owner. Pre-fix this manifested as
+  // "[kernel] listen error agent=<x>: Failed to listen at ..." for every
+  // agent on every container restart, with the unlinkSync below silently
+  // failing for the same DAC reason.
+  try { chownSync(dir, 0, 0); } catch { /* outside docker / no CAP_CHOWN */ }
   try { chmodSync(dir, 0o700); } catch { /* idempotent */ }
   // Chown the per-agent dir to the agent's UID so non-root agent
   // containers (running as user:<uid>:<uid> per compose) can traverse
@@ -123,13 +136,27 @@ async function bindAgentSocket(
   // root can no longer write into it (mode 0700 owned by 10116) and
   // bind() fails with EACCES. Order:
   //   1. mkdir with mode 0o700 under umask 0o077 (root-owned).
-  //   2. listen() — creates the socket file as root inside root-owned dir.
-  //   3. chown dir + sock to the agent UID (CAP_CHOWN granted).
-  //   4. chmod sock to 0o660 (FOWNER not strictly needed here since we
+  //   2. chown dir back to root (recovers from a previous run that left
+  //      it chowned to the agent UID — see #881).
+  //   3. listen() — creates the socket file as root inside root-owned dir.
+  //   4. chown dir + sock to the agent UID (CAP_CHOWN granted).
+  //   5. chmod sock to 0o660 (FOWNER not strictly needed here since we
   //      own the file, but the cap_add list includes it for the broker).
   const socketPath = resolve(dir, "sock");
   if (existsSync(socketPath)) {
-    try { unlinkSync(socketPath); } catch { /* ignore */ }
+    try {
+      unlinkSync(socketPath);
+    } catch (err) {
+      // Don't swallow silently (#881). Surface the path + errno so an
+      // operator chasing a "Failed to listen" can see *why* the stale
+      // socket couldn't be cleaned up. Continue to listen() either way:
+      // it will fail with the same root cause but the diagnostic
+      // breadcrumb is now in the log.
+      const msg = err instanceof Error ? err.message : String(err);
+      process.stderr.write(
+        `[kernel] could not unlink stale socket agent=${agent} sock=${socketPath}: ${msg}\n`,
+      );
+    }
   }
   return new Promise((resolveP, rejectP) => {
     const server = net.createServer((sock) => handleConnection(sock, agent, db));

--- a/src/vault/broker/server.ts
+++ b/src/vault/broker/server.ts
@@ -392,9 +392,39 @@ export class VaultBroker {
     }
 
     return new Promise((resolveP, rejectP) => {
-      // Remove stale socket if present (race-safe: parent dir 0700 by main).
+      // Reset the parent dir back to root:root 0700 BEFORE binding (#881).
+      // Subdir-shape paths like /run/switchroom/broker/<agent>/sock have
+      // a parent dir backed by a docker named volume; on a previous
+      // successful bind we chowned that dir to the agent UID 10xxx 0700
+      // (see post-listen chown below). On a fresh broker container — a
+      // common path during v0.6 → v0.7 cutover and on any compose-config
+      // change — root with cap_drop=ALL + cap_add=[CHOWN,FOWNER,
+      // DAC_READ_SEARCH] does NOT hold CAP_DAC_OVERRIDE and cannot
+      // unlink stale sockets or create new ones inside a 10xxx-owned
+      // 0700 dir. CAP_CHOWN succeeds regardless, so chown'ing the dir
+      // back to root recovers from the stale state.
+      if (abs.endsWith("/sock")) {
+        const dir = abs.slice(0, -"/sock".length);
+        if (existsSync(dir)) {
+          try { chownSync(dir, 0, 0); } catch { /* outside docker / no CAP_CHOWN */ }
+          try { chmodSync(dir, 0o700); } catch { /* idempotent */ }
+        }
+      }
+      // Remove stale socket if present.
       if (existsSync(abs)) {
-        try { unlinkSync(abs); } catch { /* ignore */ }
+        try {
+          unlinkSync(abs);
+        } catch (err) {
+          // Don't swallow silently (#881). Surface the path + errno so
+          // an operator chasing a "Failed to listen" can see *why* the
+          // stale socket couldn't be cleaned up. Continue to listen()
+          // either way: it will fail with the same root cause but the
+          // diagnostic breadcrumb is now in the log.
+          const msg = err instanceof Error ? err.message : String(err);
+          process.stderr.write(
+            `[vault-broker] could not unlink stale socket agent=${agentName} sock=${abs}: ${msg}\n`,
+          );
+        }
       }
       const server = net.createServer((sock) => {
         this._handleDataConnection(sock, abs, agentName);

--- a/tests/scaffold.regenerate-start-sh.test.ts
+++ b/tests/scaffold.regenerate-start-sh.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import {
+  mkdtempSync,
+  rmSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { scaffoldAgent } from "../src/agents/scaffold.js";
+import type { AgentConfig, SwitchroomConfig, TelegramConfig } from "../src/config/schema.js";
+
+// Regression for #879: scaffoldAgent must regenerate start.sh whenever
+// the rendered template content differs from what's on disk. The bug
+// was that scaffoldAgent used writeIfMissing for start.sh, so an
+// existing pre-template-change file was left in place. Operators
+// running `apply --only=<name>` after a release that modified the
+// start.sh template (e.g. v0.7.5 added the docker-mode tmux preamble)
+// silently kept the stale file.
+
+const telegramConfig: TelegramConfig = {
+  bot_token: "123456:ABC-DEF",
+  forum_chat_id: "-1001234567890",
+};
+
+function makeAgentConfig(overrides: Partial<AgentConfig> = {}): AgentConfig {
+  return {
+    extends: "default",
+    topic_name: "Test Topic",
+    schedule: [],
+    ...overrides,
+  } as AgentConfig;
+}
+
+function makeSwitchroomConfig(name: string, agentConfig: AgentConfig): SwitchroomConfig {
+  return {
+    switchroom: {
+      version: 1,
+      agents_dir: "~/.switchroom/agents",
+      skills_dir: "~/.switchroom/skills",
+    },
+    telegram: telegramConfig,
+    agents: { [name]: agentConfig },
+  };
+}
+
+describe("scaffoldAgent: start.sh content-aware regeneration (#879)", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "switchroom-regen-startsh-"));
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("rewrites an existing start.sh whose contents drift from the template", () => {
+    const name = "drifted-agent";
+    const config = makeAgentConfig();
+    const switchroomConfig = makeSwitchroomConfig(name, config);
+
+    const first = scaffoldAgent(name, config, tmpDir, telegramConfig, switchroomConfig);
+    const startShPath = join(first.agentDir, "start.sh");
+    const fresh = readFileSync(startShPath, "utf-8");
+    expect(first.created).toContain(startShPath);
+
+    // Simulate template drift: overwrite the rendered start.sh with
+    // pre-v0.7.5 stale content. A real operator would have a file
+    // missing the docker-mode tmux preamble; here we just clobber.
+    const stale = "#!/bin/bash\n# pre-v0.7.5 stale content — no preamble\nexec claude\n";
+    writeFileSync(startShPath, stale, "utf-8");
+    expect(readFileSync(startShPath, "utf-8")).toBe(stale);
+
+    // Re-scaffold with the same config. Pre-fix this was a no-op
+    // (writeIfMissing skipped the existing file). With the fix it
+    // detects content drift and rewrites.
+    const second = scaffoldAgent(name, config, tmpDir, telegramConfig, switchroomConfig);
+
+    expect(readFileSync(startShPath, "utf-8")).toBe(fresh);
+    expect(readFileSync(startShPath, "utf-8")).not.toBe(stale);
+    expect(second.created).toContain(startShPath);
+  });
+
+  it("does NOT rewrite an existing start.sh when content already matches the template", () => {
+    const name = "stable-agent";
+    const config = makeAgentConfig();
+    const switchroomConfig = makeSwitchroomConfig(name, config);
+
+    const first = scaffoldAgent(name, config, tmpDir, telegramConfig, switchroomConfig);
+    const startShPath = join(first.agentDir, "start.sh");
+
+    const second = scaffoldAgent(name, config, tmpDir, telegramConfig, switchroomConfig);
+
+    // Second pass sees identical content and reports start.sh as
+    // skipped, not created — preserves the "up to date" reporting
+    // for true no-op runs.
+    expect(second.created).not.toContain(startShPath);
+    expect(second.skipped).toContain(startShPath);
+  });
+});


### PR DESCRIPTION
## Summary

Three bugs surfaced during a real v0.6 → v0.7 production cutover on 2026-05-09 (8-agent fleet, GHCR images). Each silently breaks an agent boot or broker/kernel restart in a way the migration playbook doesn't warn about.

- **#879** — `apply --only=<name>` skipped updating an existing `start.sh`, so any agent whose `start.sh` predated the v0.7.5 docker-mode tmux preamble booted without the preamble (no tmux, no autoaccept, no gateway). Replaced `writeIfMissing` with a content-aware `writeIfChanged` mirroring what `reconcileAgent` already does.
- **#880** — `alignAgentUid` only chowned the agent state dir, not `~/.switchroom/logs/<name>/`. The log dir bind-mounts as `/var/log/switchroom` inside the agent and inherits the host's `root:root 0755`. Supervised gateway and autoaccept-poll sidecars couldn't write their log files, exited immediately, and start.sh exec'd into claude without sidecars. Now chowns both paths.
- **#881** — broker and kernel use `cap_drop:ALL + DAC_READ_SEARCH` (no `DAC_OVERRIDE`). After a successful bind they chown the per-agent socket dir to the agent UID 10xxx mode 0700, which is correct at runtime — but on container restart the new broker/kernel can't write into a dir it doesn't own. The existing `unlinkSync` swallowed EACCES, and `listen()` failed with a misleading "Failed to listen". Fix: pre-bind chown the dir back to root (CAP_CHOWN succeeds regardless of current owner). Also stop swallowing the unlink failure — log path + errno.

All three fixes are small and surgical. The bugs are low-frequency but extremely high-friction when hit (they masquerade as bind/permissions errors, send operators down the wrong diagnostic path).

## Test plan

- [x] `npm run lint` — clean
- [x] `npx vitest run` — 5109 pass / 31 skip / 0 new failures (6 pre-existing failures clear after `bun run build`)
- [x] `npm run test:bun` — 20 pre-existing failures (operator's real `~/.switchroom/vault-auto-unlock` blob bleeds into broker tests; identical failure count on canonical `main` — not caused by this PR)
- [x] New tests: `tests/scaffold.regenerate-start-sh.test.ts` (2 cases: drift detected and rewritten; no-op when content matches)
- [x] Updated tests: `src/agents/scaffold.test.ts` — alignAgentUid suite reflects the new logs-dir-included shape (10/10 pass)
- [ ] **Production validation:** the fixes correspond to real workarounds applied during today's cutover. The cutover succeeded with the workarounds; the fixes here remove the need for them on the next cutover.

## Operator workarounds removed

The migration playbook (`docs/operators/migration-v0.7.md`) currently doesn't warn about any of these. After this PR, the documented `apply --only=<name>` flow works as advertised. A doc update is intentionally out of scope here — once this lands, the playbook stops lying without needing edits.

## Notes for reviewer

- `#881` regression test is a docker integration concern (the bug only manifests under cap_drop). I tried to write a unit test but the broker's `socketPathToAgent` validator rejects non-`/run/switchroom/broker/...` paths, blocking a tmpdir-based unit test. The kernel's `bindAgentSocket` is private. Existing `tests/docker/phase2a-broker-ipc.test.ts` covers the docker happy path; the fix is well-commented inline. If a regression test is wanted, it'd need to extend phase2a with a stop-and-recreate cycle. Open to suggestions.
- `writeIfChanged` is in `src/agents/scaffold.ts` next to `writeIfMissing`; same signature, content-aware. Only used for `start.sh` in this PR (settings.json has user-merged sections so it can't switch).
- `alignAgentUid` API is unchanged — the logs dir is derived internally from `name`.

Closes #879, #880, #881.

🤖 Generated with [Claude Code](https://claude.com/claude-code)