### PR TITLE
fix: two more v0.6 → v0.7 cutover bugs (.mcp.json regen + gateway boot mutex)

### DIFF
--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -1853,58 +1853,64 @@ export function scaffoldAgent(
   // so the enhanced Telegram plugin can be launched as a dev channel.
   if (usesSwitchroomTelegramPlugin(agentConfig)) {
     const mcpJsonPath = join(agentDir, ".mcp.json");
-    if (!existsSync(mcpJsonPath)) {
-      // v0.7 docker mode: the agent image (Dockerfile.agent) COPYs the
-      // plugin to a stable in-image path and the running switchroom
-      // CLI is the npm-global one inside the image. Reference those —
-      // the host's repo checkout / npm-global install path is irrelevant
-      // inside the container and would resolve to a non-existent path.
-      // v0.6 systemd / non-docker mode: keep resolving against the host
-      // install layout.
-      const pluginDir = dockerMode
-        ? DOCKER_TELEGRAM_PLUGIN_PATH
-        : resolve(import.meta.dirname, "../../telegram-plugin");
-      const switchroomCliPath = dockerMode
-        ? "/usr/local/bin/switchroom"
-        : resolveSwitchroomCliPath();
-      // In docker, the in-container switchroom.yaml lives at the path
-      // compose bind-mounts it to (see compose.ts). In host mode, fall
-      // back to the existing logic.
-      const resolvedConfigPath = dockerMode
-        ? "/state/config/switchroom.yaml"
-        : (switchroomConfigPath
-            ? resolve(switchroomConfigPath)
-            : resolve(process.cwd(), "switchroom.yaml"));
+    // v0.7 docker mode: the agent image (Dockerfile.agent) COPYs the
+    // plugin to a stable in-image path and the running switchroom
+    // CLI is the npm-global one inside the image. Reference those —
+    // the host's repo checkout / npm-global install path is irrelevant
+    // inside the container and would resolve to a non-existent path.
+    // v0.6 systemd / non-docker mode: keep resolving against the host
+    // install layout.
+    const pluginDir = dockerMode
+      ? DOCKER_TELEGRAM_PLUGIN_PATH
+      : resolve(import.meta.dirname, "../../telegram-plugin");
+    const switchroomCliPath = dockerMode
+      ? "/usr/local/bin/switchroom"
+      : resolveSwitchroomCliPath();
+    // In docker, the in-container switchroom.yaml lives at the path
+    // compose bind-mounts it to (see compose.ts). In host mode, fall
+    // back to the existing logic.
+    const resolvedConfigPath = dockerMode
+      ? "/state/config/switchroom.yaml"
+      : (switchroomConfigPath
+          ? resolve(switchroomConfigPath)
+          : resolve(process.cwd(), "switchroom.yaml"));
 
-      const mcpServers: Record<string, McpServerConfig> = {
-        "switchroom-telegram": {
-          command: "bun",
-          args: ["run", "--cwd", pluginDir, "--shell=bun", "--silent", "start"],
-          env: {
-            TELEGRAM_STATE_DIR: join(agentDir, "telegram"),
-            SWITCHROOM_CONFIG: resolvedConfigPath,
-            SWITCHROOM_CLI_PATH: switchroomCliPath,
-          },
+    const mcpServers: Record<string, McpServerConfig> = {
+      "switchroom-telegram": {
+        command: "bun",
+        args: ["run", "--cwd", pluginDir, "--shell=bun", "--silent", "start"],
+        env: {
+          TELEGRAM_STATE_DIR: join(agentDir, "telegram"),
+          SWITCHROOM_CONFIG: resolvedConfigPath,
+          SWITCHROOM_CLI_PATH: switchroomCliPath,
         },
-      };
+      },
+    };
 
-      // Add hindsight memory MCP if configured
-      if (hindsightEnabled && switchroomConfig) {
-        const hindsightEntry = getHindsightSettingsEntry(name, switchroomConfig);
-        if (hindsightEntry) {
-          mcpServers[hindsightEntry.key] = hindsightEntry.value;
-        }
+    // Add hindsight memory MCP if configured
+    if (hindsightEnabled && switchroomConfig) {
+      const hindsightEntry = getHindsightSettingsEntry(name, switchroomConfig);
+      if (hindsightEntry) {
+        mcpServers[hindsightEntry.key] = hindsightEntry.value;
       }
-
-      const mcpJson = { mcpServers };
-
-      writeFileSync(
-        mcpJsonPath,
-        JSON.stringify(mcpJson, null, 2) + "\n",
-        { encoding: "utf-8", mode: 0o600 },
-      );
-      created.push(mcpJsonPath);
     }
+
+    // .mcp.json is purely template-driven (every field is a deterministic
+    // function of dockerMode + the resolved CLI/plugin paths + the
+    // configured MCP set). Use writeIfChanged so that a stale file from a
+    // pre-v0.7.6 release — when the plugin path resolution was different —
+    // is rewritten on the next `switchroom apply`. writeIfMissing left
+    // these stale, which is what bit 7 of 8 agents in the v0.6 → v0.7
+    // cutover (#883): claude couldn't spawn the MCP plugin because the
+    // host repo path baked into the old `.mcp.json` doesn't exist inside
+    // the agent container.
+    writeIfChanged(
+      mcpJsonPath,
+      () => JSON.stringify({ mcpServers }, null, 2) + "\n",
+      created,
+      skipped,
+      0o600,
+    );
   }
 
   // --- Render template-specific files ---

--- a/telegram-plugin/gateway/startup-mutex.ts
+++ b/telegram-plugin/gateway/startup-mutex.ts
@@ -27,6 +27,29 @@
  * Releases happen on shutdown (SIGTERM/SIGINT/uncaught error) by
  * unlinking the canonical path. We log every state transition; do NOT
  * silently swallow filesystem errors.
+ *
+ * Container/PID-namespace correctness (#884):
+ * -------------------------------------------
+ * Under v0.7 docker each agent runs in its own PID namespace. The
+ * gateway PID written to disk inside the previous container instance
+ * is meaningless in the new container — PID 10 in container A and
+ * PID 10 in container B are unrelated processes. `process.kill(pid, 0)`
+ * happily reports "alive" because the PID number is reused by an
+ * unrelated current-container process (tini's child, autoaccept-poll,
+ * etc.), and the new gateway aborts with `another_gateway_is_live`.
+ *
+ * Fix: stamp every record with a `bootId` derived from PID 1's
+ * `starttime` (clock ticks since system boot, field 22 in /proc/1/stat).
+ * Inside a container, PID 1 is tini and its starttime is the container's
+ * start instant — survives PID recycling within the namespace, but
+ * differs from any other container's PID 1 starttime. On bare metal
+ * PID 1 is systemd/init; the field still uniquely identifies the host
+ * boot. The PID-liveness check is now gated on bootId match: same boot
+ * → trust kill(pid,0); different boot → record is stale regardless.
+ *
+ * Records written by older versions have no `bootId`. We treat those as
+ * "unknown boot" and fall back to the legacy kill-based check — same
+ * behavior as before this fix, so the upgrade path is one-way safe.
  */
 import {
   link as linkAsync,
@@ -34,10 +57,48 @@ import {
   writeFile as writeFileAsync,
   readFile as readFileAsync,
 } from "node:fs/promises";
+import { readFileSync } from "node:fs";
 
 export interface MutexRecord {
   pid: number;
   startedAtMs: number;
+  /**
+   * Identifier of the OS/container boot during which this record was
+   * written. See "Container/PID-namespace correctness" in the file
+   * header. Optional for backwards compatibility with records written
+   * by pre-#884 gateway versions.
+   */
+  bootId?: string;
+}
+
+/**
+ * Read PID 1's start-time-in-clock-ticks from /proc/1/stat (field 22).
+ *
+ * Inside a docker container the PID-1 starttime is tied to the
+ * container instance and survives PID recycling but differs across
+ * container recreations. On bare metal it identifies the host boot.
+ * Returns `null` outside Linux or when /proc/1/stat is unreadable —
+ * callers fall back to legacy PID-only checks in that case.
+ *
+ * The 22nd field (`starttime`) appears AFTER the `comm` field which
+ * is wrapped in parentheses and may contain spaces/parens itself, so
+ * we slice past the LAST `)` before splitting on whitespace.
+ */
+export function readCurrentBootId(): string | null {
+  try {
+    const stat = readFileSync("/proc/1/stat", "utf-8");
+    const lastParen = stat.lastIndexOf(")");
+    if (lastParen < 0) return null;
+    const tail = stat.slice(lastParen + 1).trim();
+    const fields = tail.split(/\s+/);
+    // Field index in the post-comm tail: original fields 3..N → tail[0..]
+    // starttime is original field 22, so tail index 22 - 3 = 19.
+    const starttime = fields[19];
+    if (!starttime || !/^\d+$/.test(starttime)) return null;
+    return `pid1:${starttime}`;
+  } catch {
+    return null;
+  }
 }
 
 export type AcquireOutcome =
@@ -63,6 +124,14 @@ export interface AcquireOptions {
    * Injectable so tests can simulate dead/alive PIDs without forking.
    */
   isPidAlive?: (pid: number) => boolean;
+  /**
+   * Override for "what boot are we in right now". Defaults to
+   * `readCurrentBootId()`. Injectable so tests can simulate
+   * container-restart scenarios without recreating containers.
+   * `null` disables the bootId gate (treats all records as
+   * same-boot — the legacy pre-#884 behavior).
+   */
+  currentBootId?: string | null;
   /**
    * Logger. Defaults to process.stderr.write. Lines are pre-formatted
    * with the `telegram gateway:` prefix to match journalctl style.
@@ -114,7 +183,11 @@ async function tryReadRecord(path: string): Promise<MutexRecord | null> {
       Number.isFinite(parsed.pid) &&
       Number.isFinite(parsed.startedAtMs)
     ) {
-      return { pid: parsed.pid, startedAtMs: parsed.startedAtMs };
+      const out: MutexRecord = { pid: parsed.pid, startedAtMs: parsed.startedAtMs };
+      if (typeof parsed.bootId === "string" && parsed.bootId.length > 0) {
+        out.bootId = parsed.bootId;
+      }
+      return out;
     }
     return null;
   } catch {
@@ -139,8 +212,18 @@ export async function acquireStartupLock(
   const { path, record, agentName } = opts;
   const agentTag = fmtAgent(agentName);
 
+  // Resolve the current bootId. `undefined` in opts means "use the
+  // process default"; an explicit `null` opts out (legacy behavior).
+  const currentBootId =
+    opts.currentBootId === undefined ? readCurrentBootId() : opts.currentBootId;
+
+  // Stamp our own record with the bootId so future boots know whether
+  // we belong to the same container/host as them. Don't mutate the
+  // caller's record object.
+  const recordToWrite: MutexRecord =
+    currentBootId != null ? { ...record, bootId: currentBootId } : { ...record };
   const tmp = tmpPath(path, record.pid);
-  const payload = JSON.stringify(record);
+  const payload = JSON.stringify(recordToWrite);
 
   // Write the tmp file first. If this throws, the canonical isn't
   // touched — caller can retry on a fresh boot.
@@ -184,6 +267,31 @@ export async function acquireStartupLock(
           `telegram gateway: boot.lock_corrupt_recovered path=${path}${agentTag}`,
         );
         await unlinkAsync(path).catch(() => {});
+        continue;
+      }
+
+      // Boot/PID-namespace gate (#884). If the holder record carries a
+      // bootId AND it doesn't match ours, the holder PID is from a
+      // different container/host boot and `kill(pid, 0)` against it is
+      // meaningless — same PID number could be a live unrelated process
+      // in our namespace. Skip the kill check, treat as stale, recover.
+      // If either side has no bootId we fall back to the legacy PID
+      // check (preserves pre-#884 behavior for non-Linux dev/test runs
+      // and for upgrades from records that pre-date the bootId field).
+      const bootMismatch =
+        currentBootId != null && holder.bootId != null && holder.bootId !== currentBootId;
+
+      if (bootMismatch) {
+        log(
+          `telegram gateway: boot.lock_stale_recovered_boot_mismatch prior_pid=${holder.pid} prior_started_at=${new Date(
+            holder.startedAtMs,
+          ).toISOString()} prior_boot=${holder.bootId} current_boot=${currentBootId}${agentTag}`,
+        );
+        await unlinkAsync(path).catch((unlinkErr: unknown) => {
+          const code = (unlinkErr as NodeJS.ErrnoException).code;
+          if (code !== "ENOENT") throw unlinkErr;
+        });
+        recoveredFrom = holder;
         continue;
       }
 

--- a/telegram-plugin/tests/gateway-startup-mutex.test.ts
+++ b/telegram-plugin/tests/gateway-startup-mutex.test.ts
@@ -166,6 +166,108 @@ describe("acquireStartupLock", () => {
     expect(acquired).toContain(`pid=${ourPid}`);
   });
 
+  it("(c.boot-id) auto-recovers a lock from a different boot, even if the recorded PID number is alive (#884)", async () => {
+    // Reproduces the v0.7 docker container-restart bug: the previous
+    // gateway lived in a now-gone container's PID namespace and was
+    // PID 10. The new container's PID 10 is some unrelated process
+    // (autoaccept-poll, tini's child, etc.). isPidAlive(10) reports
+    // alive, but the holder isn't actually the gateway — it's a stale
+    // record from a different boot. Pre-#884 this caused the new
+    // gateway to report blocked, retry 10x, then exit non-zero with
+    // "another_gateway_is_live" — leaving the agent without a
+    // gateway daemon.
+    const { dir, path } = tmpLockPath();
+    cleanups.push(dir);
+    const collidingPid = 10;
+    const stale = { ...makeRecord(collidingPid, Date.now() - 5_000_000), bootId: "pid1:111111111" };
+    writeFileSync(path, JSON.stringify(stale), "utf-8");
+
+    const { lines, log } = noopLog();
+    const result = await acquireStartupLock({
+      path,
+      record: makeRecord(99999),
+      // Inject a DIFFERENT current bootId (this is what readCurrentBootId
+      // would return inside a fresh container).
+      currentBootId: "pid1:222222222",
+      // Crucially: report the holder PID as ALIVE — the bug was that the
+      // PID number is reused by an unrelated current-namespace process.
+      isPidAlive: () => true,
+      log,
+      agentName: "test-agent",
+    });
+
+    expect(result.status).toBe("acquired");
+    if (result.status !== "acquired") throw new Error("unreachable");
+    expect(result.recoveredFrom).toBeDefined();
+    expect(result.recoveredFrom?.pid).toBe(collidingPid);
+    expect(result.recoveredFrom?.bootId).toBe("pid1:111111111");
+
+    // Our record should now own the file AND carry the new bootId so
+    // future boots can apply the same gate.
+    const onDisk = JSON.parse(readFileSync(path, "utf-8")) as MutexRecord;
+    expect(onDisk.pid).toBe(99999);
+    expect(onDisk.bootId).toBe("pid1:222222222");
+
+    const recovered = lines.find((l) => l.includes("boot.lock_stale_recovered_boot_mismatch"));
+    expect(recovered).toBeDefined();
+    expect(recovered).toContain(`prior_pid=${collidingPid}`);
+    expect(recovered).toContain("prior_boot=pid1:111111111");
+    expect(recovered).toContain("current_boot=pid1:222222222");
+
+    // Should NOT have logged boot.lock_blocked — that's the bug we're
+    // pinning against.
+    const blocked = lines.find((l) => l.includes("boot.lock_blocked"));
+    expect(blocked).toBeUndefined();
+  });
+
+  it("(c.legacy-record) falls back to PID check when the existing record predates the bootId field", async () => {
+    // Records written by pre-#884 gateways have no bootId. We must
+    // preserve the legacy kill-based check for those — otherwise an
+    // upgrade would treat every legacy live holder as stale and
+    // potentially clobber a working sibling.
+    const { dir, path } = tmpLockPath();
+    cleanups.push(dir);
+    const livePid = 12345;
+    const legacy = makeRecord(livePid, Date.now() - 5000); // no bootId
+    writeFileSync(path, JSON.stringify(legacy), "utf-8");
+
+    const { log } = noopLog();
+    const result = await acquireStartupLock({
+      path,
+      record: makeRecord(99999),
+      currentBootId: "pid1:any",
+      isPidAlive: (pid) => pid === livePid,
+      log,
+      agentName: "test-agent",
+    });
+
+    expect(result.status).toBe("blocked");
+  });
+
+  it("(c.same-boot) treats matching bootId as same-boot and trusts the PID check", async () => {
+    // Within the same container/host boot, the PID-namespace recycling
+    // problem doesn't exist. A holder record with the same bootId as
+    // ours should be evaluated by isPidAlive verbatim — both for blocked
+    // (live holder) and stale-recovered (dead holder) outcomes.
+    const { dir, path } = tmpLockPath();
+    cleanups.push(dir);
+    const livePid = 12345;
+    const sameBoot = { ...makeRecord(livePid, Date.now() - 5000), bootId: "pid1:same" };
+    writeFileSync(path, JSON.stringify(sameBoot), "utf-8");
+
+    const { log } = noopLog();
+    const result = await acquireStartupLock({
+      path,
+      record: makeRecord(99999),
+      currentBootId: "pid1:same",
+      isPidAlive: (pid) => pid === livePid,
+      log,
+      agentName: "test-agent",
+    });
+
+    expect(result.status).toBe("blocked");
+  });
+
   it("(c.bonus) double-acquire by the SAME process does NOT corrupt state", async () => {
     // Defensive: if the boot path somehow runs acquireStartupLock twice
     // in the same process, we should detect ourselves as the holder and

--- a/tests/scaffold.regenerate-mcp-json.test.ts
+++ b/tests/scaffold.regenerate-mcp-json.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import {
+  mkdtempSync,
+  rmSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { scaffoldAgent } from "../src/agents/scaffold.js";
+import type { AgentConfig, SwitchroomConfig, TelegramConfig } from "../src/config/schema.js";
+
+// Regression for #883: scaffoldAgent must regenerate .mcp.json whenever
+// the rendered content differs from what's on disk. The bug was that
+// scaffoldAgent gated `.mcp.json` writes on `if (!existsSync(...))`, so
+// the v0.7.6 fix that switched docker-mode plugin paths from the host
+// repo to /opt/switchroom/telegram-plugin never reached agents whose
+// `.mcp.json` already existed from a pre-v0.7.6 scaffold. Result: 7 of
+// 8 agents in the v0.6 → v0.7 cutover had host-path `--cwd` baked into
+// .mcp.json — claude couldn't spawn the MCP plugin, no bridge connected,
+// every Telegram message got "⏳ Agent is restarting…" forever.
+
+const telegramConfig: TelegramConfig = {
+  bot_token: "123456:ABC-DEF",
+  forum_chat_id: "-1001234567890",
+};
+
+function makeAgentConfig(overrides: Partial<AgentConfig> = {}): AgentConfig {
+  return {
+    extends: "default",
+    topic_name: "Test Topic",
+    schedule: [],
+    ...overrides,
+  } as AgentConfig;
+}
+
+function makeSwitchroomConfig(name: string, agentConfig: AgentConfig): SwitchroomConfig {
+  return {
+    switchroom: {
+      version: 1,
+      agents_dir: "~/.switchroom/agents",
+      skills_dir: "~/.switchroom/skills",
+    },
+    telegram: telegramConfig,
+    agents: { [name]: agentConfig },
+  };
+}
+
+describe("scaffoldAgent: .mcp.json content-aware regeneration (#883)", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "switchroom-regen-mcpjson-"));
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("rewrites an existing .mcp.json whose contents drift from the template", () => {
+    const name = "drifted-mcp";
+    const config = makeAgentConfig();
+    const switchroomConfig = makeSwitchroomConfig(name, config);
+
+    const first = scaffoldAgent(name, config, tmpDir, telegramConfig, switchroomConfig);
+    const mcpPath = join(first.agentDir, ".mcp.json");
+    const fresh = readFileSync(mcpPath, "utf-8");
+    expect(first.created).toContain(mcpPath);
+    expect(fresh).toContain('"switchroom-telegram"');
+
+    // Simulate a stale .mcp.json from a pre-v0.7.6 scaffold where the
+    // plugin path was the host repo path, not the in-image baked path.
+    const stale = JSON.stringify({
+      mcpServers: {
+        "switchroom-telegram": {
+          command: "bun",
+          args: ["run", "--cwd", "/home/legacy/host/path/telegram-plugin", "--shell=bun", "--silent", "start"],
+          env: {},
+        },
+      },
+    }, null, 2) + "\n";
+    writeFileSync(mcpPath, stale, "utf-8");
+    expect(readFileSync(mcpPath, "utf-8")).toBe(stale);
+
+    // Re-scaffold with same config. Pre-fix this was a no-op (the
+    // existsSync guard skipped the existing file). Post-fix it detects
+    // content drift and rewrites with the current template output.
+    const second = scaffoldAgent(name, config, tmpDir, telegramConfig, switchroomConfig);
+
+    const after = readFileSync(mcpPath, "utf-8");
+    expect(after).toBe(fresh);
+    expect(after).not.toContain("/home/legacy/host/path");
+    expect(second.created).toContain(mcpPath);
+  });
+
+  it("does NOT rewrite an existing .mcp.json when content already matches", () => {
+    const name = "stable-mcp";
+    const config = makeAgentConfig();
+    const switchroomConfig = makeSwitchroomConfig(name, config);
+
+    const first = scaffoldAgent(name, config, tmpDir, telegramConfig, switchroomConfig);
+    const mcpPath = join(first.agentDir, ".mcp.json");
+
+    const second = scaffoldAgent(name, config, tmpDir, telegramConfig, switchroomConfig);
+    expect(second.created).not.toContain(mcpPath);
+    expect(second.skipped).toContain(mcpPath);
+  });
+});


### PR DESCRIPTION
## Summary

Two follow-on bugs from the same v0.6 → v0.7 cutover that turned up #879/#880/#881 (closed by #882). After the platform cleanly came up on docker, **every agent except gymbro silently replied "⏳ Agent is restarting…" to every Telegram message, forever**. Two distinct bugs in series.

- **#883 — `apply` skips updating existing `.mcp.json`.** Same `writeIfMissing` shape as #879, for a different file. PR #875's v0.7.6 fix that switched docker-mode plugin paths to the in-image baked location never reached 7 of 8 agents because the `.mcp.json` write was gated on `if (!existsSync(...))`. Fix: same `writeIfChanged` helper introduced in #882.
- **#884 — Gateway boot mutex misfires on container restart.** `process.kill(pid, 0)` is meaningless across PID namespaces; the previous gateway's PID 10 lives in a now-gone container, while PID 10 in the new container is some unrelated current-namespace process (autoaccept-poll, etc.). The new gateway sees the recycled PID, concludes the lock is held, aborts. Fix: stamp records with a `bootId` derived from PID 1's `starttime` (`/proc/1/stat` field 22) — inside a container PID 1 is tini and its starttime uniquely identifies the instance.

Both fixes are small. Both have unit-test coverage that pins the symptom shape — a `.mcp.json` whose contents drift from the template gets rewritten; a stale lock record whose `bootId` doesn't match the current container is auto-recovered even when the recorded PID number happens to be live.

## Test plan

- [x] `npx vitest run tests/scaffold.regenerate-mcp-json.test.ts tests/scaffold.regenerate-start-sh.test.ts src/agents/scaffold.test.ts` — 14 pass
- [x] `bun test telegram-plugin/tests/gateway-startup-mutex.test.ts` — 10 pass (3 new: boot-mismatch recovery, legacy-record fallback, same-boot trust)
- [x] `bun run build` — clean
- [ ] Lint failed locally on a tsc-resolution edge case in the worktree's symlinked `node_modules` (UAT files importing `@mtcute/node`); doesn't reproduce in canonical checkout. CI runs the same check, so I'm relying on it. My changes don't touch UAT files.
- [x] **Production validation:** corresponds to manual workarounds applied during today's cutover. The fleet is currently running with the workarounds; the fixes here remove the need for them on the next cutover.

## Notes

- `bootId` shape is `pid1:<starttime>` (e.g. `pid1:1234567890`). Linux-only; falls back to legacy PID-only behavior on macOS / non-/proc systems. The fallback also kicks in when reading a record written by a pre-#884 gateway, so upgrades are one-way safe.
- The `currentBootId` option on `acquireStartupLock` is injectable to make tests deterministic without recreating containers.
- I added one `lock_stale_recovered_boot_mismatch` log line so an operator grepping journalctl can tell the difference between a recovered legacy stale lock and a recovered boot-mismatch lock.

## Out-of-scope (worth flagging)

While debugging these I also noticed:

1. **MCP-trust prompt regex** at `src/agents/autoaccept.ts:116` (`/Use this and all future MCP servers/`) didn't match anything claude actually showed for a freshly regenerated `.mcp.json`; autoaccept logged `fired=(none)` for the MCP step on every agent. Either claude code v2.1.x changed the wording, or the prompt appeared and disappeared inside autoaccept-poll's idle-timeout window. Workaround for now: pre-populate `enabledMcpjsonServers: ["switchroom-telegram"]` in `.claude/.claude.json` via a post-scaffold hook. Worth verifying separately and filing as its own issue.
2. **`HOME=/` inside the agent container** leads to `PATH=//.bun/bin:...` (cosmetic — bun is also in `/usr/local/bin`).
3. After `apply --only` chowns the agent state dir to UID 10xxx, **subsequent host-shell `apply` runs fail with EACCES** until manually `sudo chown -R kenthompson` back. The migration playbook should call this out.

Closes #883, #884.

🤖 Generated with [Claude Code](https://claude.com/claude-code)