### PR TITLE
fix: docker-aware startup health probes (no more "systemctl not found")

### DIFF
--- a/src/build-info.ts
+++ b/src/build-info.ts
@@ -3,7 +3,7 @@
 // Values are refreshed every time `npm run build` runs.
 
 export const VERSION: string = "0.7.7";
-export const COMMIT_SHA: string | null = "bbff7e9d";
-export const COMMIT_DATE: string | null = "2026-05-09T19:21:02+10:00";
-export const LATEST_PR: number | null = 877;
-export const COMMITS_AHEAD_OF_TAG: number | null = 0;
+export const COMMIT_SHA: string | null = "86d9884a";
+export const COMMIT_DATE: string | null = "2026-05-10T02:02:30+10:00";
+export const LATEST_PR: number | null = 885;
+export const COMMITS_AHEAD_OF_TAG: number | null = 2;

--- a/telegram-plugin/gateway/boot-card.ts
+++ b/telegram-plugin/gateway/boot-card.ts
@@ -390,6 +390,11 @@ export interface RunProbesOpts {
   /** When true, resolve the agent PID via cgroup walk instead of MainPID
    *  (which is the tmux server pid under tmux supervisor). */
   tmuxSupervisor?: boolean
+  /** When true, the gateway is running inside an agent docker container.
+   *  Probes that depend on systemctl (Agent, Crons) switch to /proc walks
+   *  and externally-managed surface text instead of execing systemctl
+   *  (which doesn't exist in the agent image). See `runtime-mode.ts`. */
+  dockerMode?: boolean
 }
 
 /** Run all six probes concurrently with their own per-probe timeouts.
@@ -404,11 +409,11 @@ export async function runAllProbes(opts: RunProbesOpts): Promise<ProbeMap> {
 
   await Promise.allSettled([
     probeAccount(opts.agentDir).then(r => { probes.account = r }),
-    probeAgentProcess(slug, { execFileImpl: opts.probeExecFileImpl, tmuxSupervisor: opts.tmuxSupervisor }).then(r => { probes.agent = r }),
+    probeAgentProcess(slug, { execFileImpl: opts.probeExecFileImpl, tmuxSupervisor: opts.tmuxSupervisor, dockerMode: opts.dockerMode }).then(r => { probes.agent = r }),
     probeGateway(opts.gatewayInfo).then(r => { probes.gateway = r }),
     probeQuota(claudeDir, opts.agentDir, opts.fetchImpl).then(r => { probes.quota = r }),
     probeHindsight(opts.bankName, opts.fetchImpl).then(r => { probes.hindsight = r }),
-    probeCronTimers(slug, { execFileImpl: opts.probeExecFileImpl }).then(r => { probes.crons = r }),
+    probeCronTimers(slug, { execFileImpl: opts.probeExecFileImpl, dockerMode: opts.dockerMode }).then(r => { probes.crons = r }),
   ])
 
   return probes
@@ -530,6 +535,7 @@ export async function startBootCard(
           sleepImpl: opts.agentLiveSleepImpl,
           execFileImpl: opts.agentLiveExecFileImpl,
           tmuxSupervisor: opts.tmuxSupervisor,
+          dockerMode: opts.dockerMode,
         })
 
         for await (const agentResult of watcher) {

--- a/telegram-plugin/gateway/boot-probes.ts
+++ b/telegram-plugin/gateway/boot-probes.ts
@@ -252,32 +252,45 @@ type ExecFileFnType = (
 ) => Promise<ExecFileResult>
 
 /**
+ * Filesystem injection point for the docker-mode /proc walk so tests can
+ * drive synthetic `/proc/<pid>/{comm,stat,status}` strings without
+ * touching the real host fs.
+ */
+export interface ProcFsImpl {
+  readdir: (path: string) => string[]
+  readFile: (path: string) => string
+}
+
+const realProcFs: ProcFsImpl = {
+  readdir: (p) => readdirSync(p),
+  readFile: (p) => readFileSync(p, 'utf-8'),
+}
+
+type AgentCandidate = {
+  pid: number
+  rssKb: number
+  comm: string
+  starttime: number
+}
+
+/**
  * Walk `/proc` from inside the current pid-namespace and pick the
  * heaviest claude/node process. Used for the docker-mode agent probe:
  * inside an agent container, we share the namespace with claude, so a
  * /proc walk replaces the systemctl-driven cgroup walk used under
  * systemd. Skips wrappers (tmux/expect/script/bash/sh) and our own
- * gateway PID.
+ * gateway PID. Exported for tests.
  */
-function findAgentProcessInContainer(): {
-  pid: number
-  comm: string
-  rssKb: number
-  starttime: number
-} | null {
+export function findAgentProcessInContainer(
+  fs: ProcFsImpl = realProcFs,
+): AgentCandidate | null {
   let entries: string[]
   try {
-    entries = readdirSync('/proc')
+    entries = fs.readdir('/proc')
   } catch {
     return null
   }
-  type Candidate = {
-    pid: number
-    rssKb: number
-    comm: string
-    starttime: number
-  }
-  const candidates: Candidate[] = []
+  const candidates: AgentCandidate[] = []
   for (const entry of entries) {
     if (!/^\d+$/.test(entry)) continue
     const pid = Number(entry)
@@ -285,13 +298,13 @@ function findAgentProcessInContainer(): {
     if (pid === process.pid) continue
     let comm = ''
     try {
-      comm = readFileSync(`/proc/${pid}/comm`, 'utf-8').trim()
+      comm = fs.readFile(`/proc/${pid}/comm`).trim()
     } catch {
       continue
     }
     let rssKb = 0
     try {
-      const status = readFileSync(`/proc/${pid}/status`, 'utf-8')
+      const status = fs.readFile(`/proc/${pid}/status`)
       const m = status.match(/^VmRSS:\s+(\d+)/m)
       if (m) rssKb = parseInt(m[1], 10) || 0
     } catch {
@@ -299,7 +312,7 @@ function findAgentProcessInContainer(): {
     }
     let starttime = 0
     try {
-      const stat = readFileSync(`/proc/${pid}/stat`, 'utf-8')
+      const stat = fs.readFile(`/proc/${pid}/stat`)
       // /proc/<pid>/stat format: pid (comm-with-parens) state ppid ...
       // field 22 (1-indexed) is starttime in clock ticks since boot.
       // comm can contain spaces/parens — use the LAST ')' as the
@@ -319,8 +332,8 @@ function findAgentProcessInContainer(): {
   }
   if (candidates.length === 0) return null
 
-  const isAgent = (c: Candidate): boolean => c.comm === 'claude'
-  const isWrapper = (c: Candidate): boolean =>
+  const isAgent = (c: AgentCandidate): boolean => c.comm === 'claude'
+  const isWrapper = (c: AgentCandidate): boolean =>
     c.comm === 'tmux' || c.comm.startsWith('tmux:') ||
     c.comm === 'expect' || c.comm === 'script' ||
     c.comm === 'bash' || c.comm === 'sh' ||
@@ -340,18 +353,22 @@ function findAgentProcessInContainer(): {
 }
 
 /**
- * Read the host /proc/uptime to derive the agent process's uptime from
- * its starttime (clock ticks since boot). Returns null on any failure.
+ * Read /proc/uptime to derive the agent process's uptime from its
+ * starttime (clock ticks since boot). Returns null on any failure.
+ *
+ * SC_CLK_TCK (the units of `starttime` in /proc/<pid>/stat) is a stable
+ * kernel ABI value, hardcoded to 100 on x86_64 across Debian/Ubuntu/
+ * Alpine/RHEL. If we ever ship on arm64 hosts where some kernels use
+ * 250, uptimes will look 2.5× too large and we'll revisit.
  */
-function uptimeMsForStarttime(starttimeTicks: number): number | null {
+export function uptimeMsForStarttime(
+  starttimeTicks: number,
+  fs: ProcFsImpl = realProcFs,
+): number | null {
   try {
-    const uptimeRaw = readFileSync('/proc/uptime', 'utf-8').trim()
+    const uptimeRaw = fs.readFile('/proc/uptime').trim()
     const bootUptimeSec = Number(uptimeRaw.split(/\s+/)[0])
     if (!Number.isFinite(bootUptimeSec) || bootUptimeSec <= 0) return null
-    // SC_CLK_TCK is conventionally 100 on Linux. We can't read it from
-    // node without an FFI, but every distro we ship on uses 100. If
-    // this ever changes we'll see suspiciously off uptimes; that's a
-    // cheap signal to revisit.
     const HZ = 100
     const procUptimeSec = bootUptimeSec - starttimeTicks / HZ
     if (procUptimeSec < 0) return null

--- a/telegram-plugin/gateway/boot-probes.ts
+++ b/telegram-plugin/gateway/boot-probes.ts
@@ -11,7 +11,7 @@
  * caller as a thrown error — only as ProbeResult{ status:'fail', ... }.
  */
 
-import { readFileSync, existsSync, mkdirSync, writeFileSync } from 'fs'
+import { readFileSync, readdirSync, existsSync, mkdirSync, writeFileSync } from 'fs'
 import { join } from 'path'
 import { execFile as execFileCb } from 'child_process'
 import { promisify } from 'util'
@@ -252,6 +252,131 @@ type ExecFileFnType = (
 ) => Promise<ExecFileResult>
 
 /**
+ * Walk `/proc` from inside the current pid-namespace and pick the
+ * heaviest claude/node process. Used for the docker-mode agent probe:
+ * inside an agent container, we share the namespace with claude, so a
+ * /proc walk replaces the systemctl-driven cgroup walk used under
+ * systemd. Skips wrappers (tmux/expect/script/bash/sh) and our own
+ * gateway PID.
+ */
+function findAgentProcessInContainer(): {
+  pid: number
+  comm: string
+  rssKb: number
+  starttime: number
+} | null {
+  let entries: string[]
+  try {
+    entries = readdirSync('/proc')
+  } catch {
+    return null
+  }
+  type Candidate = {
+    pid: number
+    rssKb: number
+    comm: string
+    starttime: number
+  }
+  const candidates: Candidate[] = []
+  for (const entry of entries) {
+    if (!/^\d+$/.test(entry)) continue
+    const pid = Number(entry)
+    if (!Number.isFinite(pid) || pid <= 0) continue
+    if (pid === process.pid) continue
+    let comm = ''
+    try {
+      comm = readFileSync(`/proc/${pid}/comm`, 'utf-8').trim()
+    } catch {
+      continue
+    }
+    let rssKb = 0
+    try {
+      const status = readFileSync(`/proc/${pid}/status`, 'utf-8')
+      const m = status.match(/^VmRSS:\s+(\d+)/m)
+      if (m) rssKb = parseInt(m[1], 10) || 0
+    } catch {
+      continue
+    }
+    let starttime = 0
+    try {
+      const stat = readFileSync(`/proc/${pid}/stat`, 'utf-8')
+      // /proc/<pid>/stat format: pid (comm-with-parens) state ppid ...
+      // field 22 (1-indexed) is starttime in clock ticks since boot.
+      // comm can contain spaces/parens — use the LAST ')' as the
+      // anchor so we tokenize the remainder safely.
+      const close = stat.lastIndexOf(')')
+      const tail = close >= 0 ? stat.slice(close + 2) : stat
+      const fields = tail.trim().split(/\s+/)
+      // After the "(comm)" group, the remaining fields are state, ppid,
+      // ... with starttime at index 19 (0-indexed) of `tail` because
+      // field 3 (state) is `tail[0]`.
+      const st = Number(fields[19])
+      if (Number.isFinite(st) && st > 0) starttime = st
+    } catch {
+      continue
+    }
+    candidates.push({ pid, rssKb, comm, starttime })
+  }
+  if (candidates.length === 0) return null
+
+  const isAgent = (c: Candidate): boolean => c.comm === 'claude'
+  const isWrapper = (c: Candidate): boolean =>
+    c.comm === 'tmux' || c.comm.startsWith('tmux:') ||
+    c.comm === 'expect' || c.comm === 'script' ||
+    c.comm === 'bash' || c.comm === 'sh' ||
+    c.comm === 'tini' || c.comm === 'sleep'
+
+  const claudeMatches = candidates.filter(isAgent)
+  if (claudeMatches.length > 0) {
+    claudeMatches.sort((a, b) => b.rssKb - a.rssKb)
+    return claudeMatches[0]
+  }
+  // No `claude` comm — fall back to heaviest non-wrapper node process.
+  const nodeMatches = candidates
+    .filter(c => c.comm === 'node' && !isWrapper(c))
+    .sort((a, b) => b.rssKb - a.rssKb)
+  if (nodeMatches.length > 0) return nodeMatches[0]
+  return null
+}
+
+/**
+ * Read the host /proc/uptime to derive the agent process's uptime from
+ * its starttime (clock ticks since boot). Returns null on any failure.
+ */
+function uptimeMsForStarttime(starttimeTicks: number): number | null {
+  try {
+    const uptimeRaw = readFileSync('/proc/uptime', 'utf-8').trim()
+    const bootUptimeSec = Number(uptimeRaw.split(/\s+/)[0])
+    if (!Number.isFinite(bootUptimeSec) || bootUptimeSec <= 0) return null
+    // SC_CLK_TCK is conventionally 100 on Linux. We can't read it from
+    // node without an FFI, but every distro we ship on uses 100. If
+    // this ever changes we'll see suspiciously off uptimes; that's a
+    // cheap signal to revisit.
+    const HZ = 100
+    const procUptimeSec = bootUptimeSec - starttimeTicks / HZ
+    if (procUptimeSec < 0) return null
+    return Math.round(procUptimeSec * 1000)
+  } catch {
+    return null
+  }
+}
+
+function probeAgentProcessDocker(): ProbeResult {
+  const found = findAgentProcessInContainer()
+  if (!found) {
+    return { status: 'fail', label: 'Agent', detail: 'claude process not found' }
+  }
+  const uptimeMs = uptimeMsForStarttime(found.starttime)
+  const mb = Math.round(found.rssKb / 1024)
+  const parts = [
+    `PID ${found.pid}`,
+    uptimeMs != null ? `up ${formatMs(uptimeMs)}` : '',
+    mb > 0 ? `${mb} MB` : '',
+  ].filter(Boolean)
+  return { status: 'ok', label: 'Agent', detail: parts.join(' · ') }
+}
+
+/**
  * Resolve the "real" agent PID under tmux supervisor by walking the
  * unit's cgroup and picking the heaviest-RSS claude/node process.
  *
@@ -371,8 +496,19 @@ export async function probeAgentProcess(
     /** When true, resolve PID via cgroup walk (heaviest claude/node) — under
      *  tmux supervisor MainPID is the tmux server (~2MB) which is misleading. */
     tmuxSupervisor?: boolean
+    /** When true, skip systemctl entirely. The gateway is running INSIDE the
+     *  agent container alongside claude, so we walk /proc directly. There's
+     *  no "service deactivating/activating" model under docker — claude is
+     *  either there or it isn't, so we return single-shot without retry. */
+    dockerMode?: boolean
+    /** Test override — defaults to the real probeAgentProcessDocker(). */
+    dockerProbeImpl?: () => ProbeResult
   } = {},
 ): Promise<ProbeResult> {
+  if (opts.dockerMode) {
+    const impl = opts.dockerProbeImpl ?? probeAgentProcessDocker
+    return withTimeout('Agent', Promise.resolve(impl()))
+  }
   const retryIntervalMs = opts.retryIntervalMs ?? AGENT_RETRY_INTERVAL_MS
   const retryMaxMs = opts.retryMaxMs ?? AGENT_RETRY_MAX_MS
   const sleep = opts.sleepImpl ?? ((ms: number) => new Promise(resolve => setTimeout(resolve, ms)))
@@ -469,8 +605,18 @@ export async function* watchAgentProcess(
     nowImpl?: () => number
     /** When true, resolve PID via cgroup walk (heaviest claude/node). */
     tmuxSupervisor?: boolean
+    /** When true, skip systemctl: yield once with the current /proc-derived
+     *  state and exit. Mirrors probeAgentProcess's docker-mode shortcut. */
+    dockerMode?: boolean
+    /** Test override — defaults to the real probeAgentProcessDocker(). */
+    dockerProbeImpl?: () => ProbeResult
   } = {},
 ): AsyncGenerator<ProbeResult> {
+  if (opts.dockerMode) {
+    const impl = opts.dockerProbeImpl ?? probeAgentProcessDocker
+    yield impl()
+    return
+  }
   const liveWindowMs = opts.liveWindowMs ?? AGENT_LIVE_WINDOW_MS
   const pollIntervalMs = opts.pollIntervalMs ?? AGENT_LIVE_POLL_INTERVAL_MS
   const followupRepollMs = opts.followupRepollMs ?? AGENT_LIVE_FOLLOWUP_REPOLL_MS
@@ -793,8 +939,22 @@ function parseTimerLeft(left: string | undefined): number | null {
 
 export async function probeCronTimers(
   agentName: string,
-  opts: { execFileImpl?: ExecFileFnType } = {},
+  opts: {
+    execFileImpl?: ExecFileFnType
+    /** When true, crons live in the `switchroom-cron` container and the
+     *  agent container has no docker.sock to query them. We surface that
+     *  the scheduler is managed externally rather than reporting fail
+     *  every boot for a non-issue. */
+    dockerMode?: boolean
+  } = {},
 ): Promise<ProbeResult> {
+  if (opts.dockerMode) {
+    return {
+      status: 'ok',
+      label: 'Crons',
+      detail: 'managed by switchroom-cron',
+    }
+  }
   const execFileFn: ExecFileFnType = opts.execFileImpl ?? execFile
   return withTimeout('Crons', (async (): Promise<ProbeResult> => {
     let stdout: string

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -10378,6 +10378,7 @@ void (async () => {
                       restartAgeMs: markerAgeMs,
                       loadAccounts: () => loadAccountsForBootCard(agentSlug),
                       tmuxSupervisor: process.env.SWITCHROOM_TMUX_SUPERVISOR === '1',
+                      dockerMode: process.env.SWITCHROOM_RUNTIME === 'docker',
                     }, ackMsgId)
                     activeBootCard = handle
                   } catch (err) {

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -2137,6 +2137,7 @@ const ipcServer: IpcServer = createIpcServer({
             restartAgeMs: markerAgeMs,
             loadAccounts: () => loadAccountsForBootCard(agentSlug),
             tmuxSupervisor: process.env.SWITCHROOM_TMUX_SUPERVISOR === '1',
+            dockerMode: process.env.SWITCHROOM_RUNTIME === 'docker',
           }, ackMsgId).then(handle => {
             activeBootCard = handle
           }).catch((err: Error) => {
@@ -10325,7 +10326,10 @@ void (async () => {
               const cleanMarkerStale = cleanMarker
                 ? !shouldSuppressRecoveryBanner(cleanMarker, nowMs, CLEAN_SHUTDOWN_MAX_AGE_MS)
                 : false
-              const detailParts: string[] = ['gateway crashed and was auto-restarted by systemd']
+              const supervisor = process.env.SWITCHROOM_RUNTIME === 'docker'
+                ? 'docker compose'
+                : 'systemd'
+              const detailParts: string[] = [`gateway crashed and was auto-restarted by ${supervisor}`]
               if (cleanMarker?.signal) detailParts.push(`prior signal=${cleanMarker.signal}`)
               if (cleanMarkerStale) detailParts.push('clean-shutdown marker stale')
               emitGatewayOperatorEvent({

--- a/telegram-plugin/tests/boot-probes.test.ts
+++ b/telegram-plugin/tests/boot-probes.test.ts
@@ -16,6 +16,9 @@ import {
   probeCronTimers,
   probeQuota,
   watchAgentProcess,
+  findAgentProcessInContainer,
+  uptimeMsForStarttime,
+  type ProcFsImpl,
 } from '../gateway/boot-probes.js'
 import { readQuotaCache, RATE_LIMIT_TTL_MS } from '../gateway/quota-cache.js'
 
@@ -531,8 +534,166 @@ describe('probeAgentProcess / probeCronTimers — docker mode skips systemctl', 
     })
     expect(result.status).toBe('ok')
     expect(result.label).toBe('Crons')
-    expect(result.detail).toContain('switchroom-cron')
+    expect(result.detail).toBe('managed by switchroom-cron')
     expect(execFileCalls).toBe(0)
+  })
+})
+
+// ── /proc parser unit tests (synthetic fs) ────────────────────────────────
+
+/** Build a /proc/<pid>/stat string for tests. */
+function makeStat(pid: number, comm: string, starttime: number): string {
+  // Layout: pid (comm) state ppid pgrp session tty_nr tpgid flags
+  //         minflt cminflt majflt cmajflt utime stime cutime cstime
+  //         priority nice num_threads itrealvalue starttime ...
+  // We need starttime at field 22 (1-indexed). Pad fields 4..21 with zeros.
+  const middle = new Array(18).fill('0').join(' ')
+  return `${pid} (${comm}) S ${middle} ${starttime} 0 0 0 0\n`
+}
+
+function makeProcFs(
+  procs: Array<{ pid: number; comm: string; rssKb: number; starttime: number }>,
+  extraFiles: Record<string, string> = {},
+): ProcFsImpl {
+  const files: Record<string, string> = { ...extraFiles }
+  const dirEntries = ['1', '2', 'self', 'uptime', 'meminfo']
+  for (const p of procs) {
+    files[`/proc/${p.pid}/comm`] = `${p.comm}\n`
+    files[`/proc/${p.pid}/status`] = `Name:\t${p.comm}\nVmRSS:\t  ${p.rssKb} kB\n`
+    files[`/proc/${p.pid}/stat`] = makeStat(p.pid, p.comm, p.starttime)
+    if (!dirEntries.includes(String(p.pid))) dirEntries.push(String(p.pid))
+  }
+  return {
+    readdir: (path: string) => {
+      if (path === '/proc') return dirEntries
+      throw new Error(`unexpected readdir: ${path}`)
+    },
+    readFile: (path: string) => {
+      if (path in files) return files[path]
+      throw new Error(`ENOENT: ${path}`)
+    },
+  }
+}
+
+describe('findAgentProcessInContainer — /proc parser', () => {
+  it('picks heaviest claude process across multiple candidates', () => {
+    const fs = makeProcFs([
+      { pid: 100, comm: 'claude', rssKb: 50_000, starttime: 1000 },
+      { pid: 101, comm: 'claude', rssKb: 200_000, starttime: 1100 },
+      { pid: 102, comm: 'bash',   rssKb: 5_000,   starttime: 900  },
+      { pid: 103, comm: 'tmux',   rssKb: 2_000,   starttime: 800  },
+    ])
+    const found = findAgentProcessInContainer(fs)
+    expect(found).not.toBeNull()
+    expect(found!.pid).toBe(101)
+    expect(found!.rssKb).toBe(200_000)
+    expect(found!.starttime).toBe(1100)
+  })
+
+  it('falls back to heaviest non-wrapper node when no claude exists', () => {
+    const fs = makeProcFs([
+      { pid: 200, comm: 'node', rssKb: 80_000, starttime: 500 },
+      { pid: 201, comm: 'node', rssKb: 30_000, starttime: 600 },
+      { pid: 202, comm: 'bash', rssKb: 5_000,  starttime: 400 },
+    ])
+    const found = findAgentProcessInContainer(fs)
+    expect(found!.pid).toBe(200)
+  })
+
+  it('returns null when only wrappers exist', () => {
+    const fs = makeProcFs([
+      { pid: 1,  comm: 'tini', rssKb: 500,  starttime: 100 },
+      { pid: 50, comm: 'bash', rssKb: 1000, starttime: 200 },
+      { pid: 51, comm: 'tmux', rssKb: 800,  starttime: 250 },
+    ])
+    const found = findAgentProcessInContainer(fs)
+    expect(found).toBeNull()
+  })
+
+  it('handles a comm containing parens via lastIndexOf(\")\")', () => {
+    // Tests are the only protection against off-by-one when comm is funky.
+    const procs = [{ pid: 300, comm: '(weird)comm', rssKb: 90_000, starttime: 1234 }]
+    const fs = makeProcFs(procs)
+    // Override stat with a path comm has parens — comm content goes inside (...)
+    // Note: the kernel actually wraps comm in single parens in /proc/<pid>/stat,
+    // so a comm of `(weird)comm` lands as `300 ((weird)comm) S ...` — making
+    // lastIndexOf the only safe parse anchor.
+    const fsWithFunky: ProcFsImpl = {
+      readdir: () => ['300', 'uptime'],
+      readFile: (path: string) => {
+        if (path === '/proc/300/comm') return '(weird)comm\n'
+        if (path === '/proc/300/status') return 'VmRSS:\t90000 kB\n'
+        if (path === '/proc/300/stat') return `300 ((weird)comm) S ${new Array(18).fill('0').join(' ')} 1234 0 0 0\n`
+        throw new Error(`ENOENT: ${path}`)
+      },
+    }
+    // Funky comm is neither 'claude' nor 'node', so it's filtered out.
+    expect(findAgentProcessInContainer(fsWithFunky)).toBeNull()
+    void fs; void procs
+  })
+
+  it('handles a claude comm with trailing parens correctly', () => {
+    const fs: ProcFsImpl = {
+      readdir: () => ['400', 'uptime'],
+      readFile: (path: string) => {
+        if (path === '/proc/400/comm') return 'claude\n'
+        if (path === '/proc/400/status') return 'VmRSS:\t  150000 kB\n'
+        // Use a `claude` comm followed by 18 zero pad fields then starttime=9999.
+        if (path === '/proc/400/stat') return `400 (claude) S ${new Array(18).fill('0').join(' ')} 9999 0 0 0\n`
+        throw new Error(`ENOENT: ${path}`)
+      },
+    }
+    const found = findAgentProcessInContainer(fs)
+    expect(found).not.toBeNull()
+    expect(found!.pid).toBe(400)
+    expect(found!.starttime).toBe(9999)
+    expect(found!.rssKb).toBe(150_000)
+  })
+
+  it('skips entries that fail to read', () => {
+    const fs: ProcFsImpl = {
+      readdir: () => ['1', '500'],
+      readFile: (path: string) => {
+        if (path === '/proc/500/comm') return 'claude\n'
+        if (path === '/proc/500/status') return 'VmRSS:\t10000 kB\n'
+        if (path === '/proc/500/stat') return `500 (claude) S ${new Array(18).fill('0').join(' ')} 7000 0 0 0\n`
+        throw new Error(`ENOENT: ${path}`) // PID 1 reads fail → skipped
+      },
+    }
+    const found = findAgentProcessInContainer(fs)
+    expect(found!.pid).toBe(500)
+  })
+})
+
+describe('uptimeMsForStarttime', () => {
+  it('computes uptime in ms from starttime ticks and /proc/uptime', () => {
+    const fs: ProcFsImpl = {
+      readdir: () => [],
+      readFile: (path: string) => {
+        if (path === '/proc/uptime') return '1234.56 1000.00\n'
+        throw new Error(`unexpected: ${path}`)
+      },
+    }
+    // boot uptime = 1234.56 s, starttime = 1000 ticks → 10 s in.
+    // Process uptime = 1234.56 - 10 = 1224.56 s = 1_224_560 ms.
+    expect(uptimeMsForStarttime(1000, fs)).toBe(1_224_560)
+  })
+
+  it('returns null if /proc/uptime is unreadable', () => {
+    const fs: ProcFsImpl = {
+      readdir: () => [],
+      readFile: () => { throw new Error('ENOENT') },
+    }
+    expect(uptimeMsForStarttime(1000, fs)).toBeNull()
+  })
+
+  it('returns null when computed uptime is negative', () => {
+    // starttime in the future relative to boot uptime → invalid.
+    const fs: ProcFsImpl = {
+      readdir: () => [],
+      readFile: () => '5.0 0.0\n',
+    }
+    expect(uptimeMsForStarttime(99999999, fs)).toBeNull()
   })
 })
 })

--- a/telegram-plugin/tests/boot-probes.test.ts
+++ b/telegram-plugin/tests/boot-probes.test.ts
@@ -13,6 +13,7 @@ import { join } from 'path'
 
 import {
   probeAgentProcess,
+  probeCronTimers,
   probeQuota,
   watchAgentProcess,
 } from '../gateway/boot-probes.js'
@@ -448,4 +449,90 @@ describe('watchAgentProcess — #296: re-poll after window expiry', () => {
     expect(yields[0].status).toBe('ok')
     expect(extraCalls).toBe(1) // only the initial probe; no follow-up
   })
+
+// ── docker mode: skip systemctl, use /proc walk ───────────────────────────
+
+describe('probeAgentProcess / probeCronTimers — docker mode skips systemctl', () => {
+  it('probeAgentProcess(dockerMode) returns the injected /proc result without execing', async () => {
+    let execFileCalls = 0
+    const execFileImpl: ExecFileFn = async () => {
+      execFileCalls++
+      throw new Error('systemctl should never be called under dockerMode')
+    }
+    const dockerProbeImpl = () => ({
+      status: 'ok' as const,
+      label: 'Agent',
+      detail: 'PID 42 · up 3.0s · 128 MB',
+    })
+    const result = await probeAgentProcess('clerk', {
+      dockerMode: true,
+      dockerProbeImpl,
+      execFileImpl: execFileImpl as never,
+      sleepImpl: noopSleep,
+      retryIntervalMs: 1,
+      retryMaxMs: 5,
+    })
+    expect(result.status).toBe('ok')
+    expect(result.label).toBe('Agent')
+    expect(result.detail).toBe('PID 42 · up 3.0s · 128 MB')
+    expect(execFileCalls).toBe(0)
+  })
+
+  it('probeAgentProcess(dockerMode) surfaces fail when no claude process found', async () => {
+    const dockerProbeImpl = () => ({
+      status: 'fail' as const,
+      label: 'Agent',
+      detail: 'claude process not found',
+    })
+    const result = await probeAgentProcess('clerk', {
+      dockerMode: true,
+      dockerProbeImpl,
+    })
+    expect(result.status).toBe('fail')
+    expect(result.detail).toBe('claude process not found')
+  })
+
+  it('watchAgentProcess(dockerMode) yields the /proc result once and exits', async () => {
+    let execFileCalls = 0
+    const execFileImpl: ExecFileFn = async () => {
+      execFileCalls++
+      return { stdout: '', stderr: '' }
+    }
+    const dockerProbeImpl = () => ({
+      status: 'ok' as const,
+      label: 'Agent',
+      detail: 'PID 42 · up 5.0s · 200 MB',
+    })
+    const yields: Array<{ status: string; detail: string }> = []
+    const gen = watchAgentProcess('clerk', {
+      dockerMode: true,
+      dockerProbeImpl,
+      execFileImpl: execFileImpl as never,
+      sleepImpl: noopSleep,
+      liveWindowMs: 1000,
+      pollIntervalMs: 10,
+      followupRepollMs: 0,
+    })
+    for await (const r of gen) yields.push({ status: r.status, detail: r.detail })
+    expect(yields).toHaveLength(1)
+    expect(yields[0].status).toBe('ok')
+    expect(execFileCalls).toBe(0)
+  })
+
+  it('probeCronTimers(dockerMode) returns ok-with-managed-externally without execing', async () => {
+    let execFileCalls = 0
+    const execFileImpl: ExecFileFn = async () => {
+      execFileCalls++
+      throw new Error('systemctl should never be called under dockerMode')
+    }
+    const result = await probeCronTimers('clerk', {
+      dockerMode: true,
+      execFileImpl: execFileImpl as never,
+    })
+    expect(result.status).toBe('ok')
+    expect(result.label).toBe('Crons')
+    expect(result.detail).toContain('switchroom-cron')
+    expect(execFileCalls).toBe(0)
+  })
+})
 })


### PR DESCRIPTION
## Why

The v0.7 boot card has been showing false-fail rows on every container
boot:

```
🔴 Agent   systemctl failed: Executable not found in $PATH: "systemctl"
🔴 Crons   systemctl failed: Executable not found in $PATH: "systemctl"
```

Plus the crash-recovery banner says "auto-restarted by systemd" even
though docker compose is the supervisor under v0.7+.

Root cause: `probeAgentProcess` and `probeCronTimers` shell out to
`systemctl --user` from inside the agent container, where systemctl
doesn't exist. Same env-var (`SWITCHROOM_RUNTIME=docker`) that already
gates the restart-watchdog and self-restart paths needs to gate these
two probes too.

## What changed

- `boot-probes.ts`
  - `probeAgentProcess` / `watchAgentProcess` accept `dockerMode`.
    Under docker, walk `/proc` inside the container and pick the
    heaviest-RSS `claude` (or non-wrapper `node`) process. Uptime from
    `/proc/<pid>/stat` starttime vs `/proc/uptime`. RSS from
    `/proc/<pid>/status`. Single-shot — there's no
    activating/deactivating model under docker.
  - `probeCronTimers` accepts `dockerMode`. Crons run in the
    `switchroom-cron` container and the agent container has no
    docker.sock; surface "managed by switchroom-cron" rather than
    failing every boot.
- `boot-card.ts` — `RunProbesOpts.dockerMode` plumbed through to all
  three probe call sites (initial run + live watcher).
- `gateway.ts` — both `startBootCard` invocations (boot + bridge-
  reconnect) pass `dockerMode: process.env.SWITCHROOM_RUNTIME ===
  'docker'`. Crash-recovery banner reads the same env to say "by
  docker compose" vs "by systemd".

## Out of scope (separate issues)

- Boot probe `400 Bad Request: chat not found`: bot was kicked from /
  never added to that chat id; the existing message already says "bot
  may not be a member" — config issue, not a code bug.
- Quota: HTTP 403: separate auth/Anthropic issue.

## Test plan

- [x] `npm run lint` clean
- [x] `bun test telegram-plugin/tests/` — 3176 pass, 0 fail (4 new
      tests covering docker-mode branches assert systemctl is never
      called)
- [x] Existing 18 systemd-mode probe tests still green — no behaviour
      change when `dockerMode` is unset

## Verification on the box

After merge:

1. `bun run build`
2. `switchroom apply` (regenerates compose if needed)
3. `switchroom agent restart all` — fresh boot card should show
   ✅ Agent · PID … · up …s · … MB
   ✅ Crons · managed by switchroom-cron
   instead of the two red `systemctl failed` rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)