### PR TITLE
feat: persistent agent HOME (Layer 1) + Tier 1 base packages

### DIFF
--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -14,29 +14,92 @@ FROM node:22-bookworm-slim
 ARG TARGETARCH
 RUN echo "switchroom/base building for arch=${TARGETARCH}" >&2
 
-# tini: PID 1 in agent containers (zombie reap + signal forward).
-# tmux: agent supervisor surface (#725).
-# bash, ca-certificates, procps: shell + curl trust + ps for diagnostics.
-# git: needed by claude tool calls + agent workflows.
-# sqlite3: kernel.db / scheduler.db / hindsight bank inspection.
-# openssh-client: claude bundle expects ssh-keygen for some flows.
-# python3: hindsight memory plugin's session_end.py / session_start.py
-#   hooks shell out to `python3` (defined in `.claude/hooks` for every
-#   scaffolded agent). Without it the SessionEnd hook errors on every
-#   turn end and claude exits — the v0.7.3 cutover crash-loop chain.
+# Tier 1 base packages — tools Claude reaches for in a meaningful
+# fraction of agent sessions, plus a small human-DX layer for
+# `switchroom agent attach`. Anything narrower belongs in a per-agent
+# image extension (Layer 2 / declarative `packages:` field).
+#
+# Existing rationale (kept for forensics):
+#   tini       — PID 1 in agent containers (zombie reap + signal forward)
+#   tmux       — agent supervisor surface (#725)
+#   bash, ca-certificates, procps — shell + TLS trust + ps
+#   git        — claude tool calls + agent workflows
+#   sqlite3    — kernel.db / scheduler.db / hindsight inspection
+#   openssh-client — claude bundle expects ssh-keygen
+#   curl       — also used by the bun installer below; keep above bun
+#   python3    — hindsight memory plugin's session_end.py /
+#                session_start.py hooks shell out to python3 (#v0.7.3)
+#
+# Tier 1 additions (Layer 1 / persistent-HOME PR):
+#   tzdata, wget               — timezone DB + alt downloader
+#   psmisc                     — pgrep / killall etc.
+#   python3-pip, python3-venv  — `pip install --user` now persists thanks
+#                                to Layer 1's per-agent HOME bind mount
+#   build-essential            — gcc + make for native pip/npm modules
+#   jq                         — JSON wrangling, every API debug task
+#   ripgrep                    — Claude's preferred grep
+#   fd-find                    — modern find (Debian installs as `fdfind`;
+#                                we add a /usr/local/bin/fd symlink so
+#                                Claude can call it under either name)
+#   tar/gzip/xz-utils/unzip/zip — archive handling baseline (unzip moved
+#                                from the bun block below to consolidate)
+#   less                       — pager (Claude pipes through this often)
+#   nano                       — minimal editor for human attach sessions
+#   tree, file                 — directory orientation + content sniffing
+#   dnsutils, iputils-ping,
+#   netcat-openbsd             — network connectivity debugging trio
 RUN apt-get update \
  && apt-get install -y --no-install-recommends \
       tini \
       tmux \
       bash \
       ca-certificates \
+      tzdata \
       procps \
+      psmisc \
       git \
       sqlite3 \
       openssh-client \
       curl \
+      wget \
       python3 \
+      python3-pip \
+      python3-venv \
+      build-essential \
+      jq \
+      ripgrep \
+      fd-find \
+      tar \
+      gzip \
+      xz-utils \
+      unzip \
+      zip \
+      less \
+      nano \
+      tree \
+      file \
+      dnsutils \
+      iputils-ping \
+      netcat-openbsd \
+ && ln -sf /usr/bin/fdfind /usr/local/bin/fd \
  && rm -rf /var/lib/apt/lists/*
+
+# GitHub CLI (`gh`) — promoted to Tier 1 because `gh auth login` is
+# table stakes once Layer 1's persistent HOME makes the credentials
+# survive container restart. Installed from the official cli.github.com
+# apt repo (the path GitHub themselves document at
+# cli.github.com/manual/installation). Keyring goes in
+# /usr/share/keyrings (modern Debian convention) rather than
+# apt-key (deprecated).
+RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+      -o /usr/share/keyrings/githubcli-archive-keyring.gpg \
+ && chmod 644 /usr/share/keyrings/githubcli-archive-keyring.gpg \
+ && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+      > /etc/apt/sources.list.d/github-cli.list \
+ && apt-get update \
+ && apt-get install -y --no-install-recommends gh \
+ && rm -rf /var/lib/apt/lists/* \
+ && gh --version >&2
 
 # Pin claude CLI version in the base image so every agent / scheduler
 # container resolves the SAME bundle. The version floats with the
@@ -66,10 +129,9 @@ RUN npm install -g @anthropic-ai/claude-code@latest \
 ARG BUN_VERSION=1.3.13
 ARG BUN_SHA256_X64=79c0771fa8b92c33aae41e15a0e0d307ea99d0e2f00317c71c6c53237a78e25a
 ARG BUN_SHA256_AARCH64=70bae41b3908b0a120e1e58c5c8af30e74afae3b8d11b0d3fdd8e787ddfb4b22
-RUN apt-get update \
- && apt-get install -y --no-install-recommends unzip \
- && rm -rf /var/lib/apt/lists/* \
- && ARCH="$(uname -m)" \
+# `unzip` is now installed in the Tier 1 apt block above; this RUN
+# only does the bun-specific download + verify + place steps.
+RUN ARCH="$(uname -m)" \
  && case "$ARCH" in \
       x86_64)   BUN_ARCH=x64;       BUN_SHA="${BUN_SHA256_X64}";;     \
       aarch64)  BUN_ARCH=aarch64;   BUN_SHA="${BUN_SHA256_AARCH64}";; \

--- a/profiles/_base/start.sh.hbs
+++ b/profiles/_base/start.sh.hbs
@@ -93,6 +93,12 @@ fi
 export NVM_DIR="$HOME/.nvm"
 [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
 export PATH="$HOME/.bun/bin:$PATH"
+# Layer 1 persistent-HOME PATH additions: user-space binary install dirs.
+# `pip install --user`, `npm install -g` (with NPM_CONFIG_PREFIX set in
+# compose.ts), `cargo install --root $HOME`, and manual `~/bin` drops
+# all land in these paths; survival across container restart is via the
+# /state/agent bind mount (HOME=/state/agent/home).
+export PATH="$HOME/.local/bin:$HOME/bin:$HOME/.npm-global/bin:$PATH"
 export CLAUDE_CONFIG_DIR="{{agentDir}}/.claude"
 unset CLAUDE_CODE_OAUTH_TOKEN
 if [ -f "$CLAUDE_CONFIG_DIR/.oauth-token" ]; then

--- a/src/agents/compose.ts
+++ b/src/agents/compose.ts
@@ -491,6 +491,21 @@ function emitAgentService(
   lines.push(`    environment:`);
   // env keys MUST be sorted for byte determinism.
   const env: Record<string, string> = {
+    // Per-agent persistent HOME — lives at ~/.switchroom/agents/<name>/home
+    // on the host (inside the existing /state/agent bind mount, no extra
+    // volume needed). The container's ImageConfig.User is a numeric UID
+    // with no /etc/passwd entry, so HOME defaults to "/" which is on the
+    // read-only root fs — every tool that writes to ~/.config, ~/.cache,
+    // ~/.local, ~/.gitconfig fails outright. Pointing HOME at the bind
+    // mount lets `gh auth login`, `git config --global`, `pip install
+    // --user`, shell history, ssh keys, and similar persist across
+    // container restarts.
+    HOME: "/state/agent/home",
+    // npm global installs (`npm install -g foo`) land here so they (a)
+    // don't fail on the read-only /usr/local prefix and (b) survive
+    // restart. PATH adjustment that puts this on the search path lives
+    // in profiles/_base/start.sh.hbs.
+    NPM_CONFIG_PREFIX: "/state/agent/home/.npm-global",
     SWITCHROOM_AGENT_NAME: a.name,
     SWITCHROOM_BROKER_SOCKET: `/run/switchroom/broker/${a.name}/sock`,
     SWITCHROOM_KERNEL_SOCKET: `/run/switchroom/kernel/${a.name}/sock`,

--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -1965,6 +1965,53 @@ export function scaffoldAgent(
   });
   ensureClaudeMdSymlinks(phase5WorkspaceDir, created);
 
+  // --- Persistent agent HOME (Layer 1) ---
+  // The container has read-only root + a numeric UID with no
+  // /etc/passwd entry, so HOME defaults to "/" — every tool that
+  // writes to ~/.config / ~/.cache / ~/.local fails outright.
+  // compose.ts sets HOME=/state/agent/home; this section creates that
+  // directory inside the existing /state/agent bind mount and seeds
+  // a minimal .bashrc / .profile so attached interactive shells get
+  // the same PATH/NPM env as start.sh sets for non-interactive
+  // children.
+  //
+  // All seeds are writeIfMissing — agents (and operators) can
+  // customize freely without losing changes on `switchroom apply`.
+  const persistentHomeDir = join(agentDir, "home");
+  mkdirSync(persistentHomeDir, { recursive: true });
+  for (const sub of [".local/bin", ".npm-global", "bin"]) {
+    mkdirSync(join(persistentHomeDir, sub), { recursive: true });
+  }
+  const homeEnvBlock = [
+    "# switchroom Layer 1: per-agent persistent HOME.",
+    "# These exports mirror profiles/_base/start.sh.hbs so attached",
+    "# interactive shells see the same PATH and npm-global prefix as",
+    "# the agent's non-interactive child processes.",
+    'export PATH="$HOME/.local/bin:$HOME/bin:$HOME/.npm-global/bin:$PATH"',
+    'export NPM_CONFIG_PREFIX="$HOME/.npm-global"',
+    "",
+  ].join("\n");
+  writeIfMissing(
+    join(persistentHomeDir, ".profile"),
+    () => homeEnvBlock,
+    created,
+    skipped,
+  );
+  writeIfMissing(
+    join(persistentHomeDir, ".bashrc"),
+    () =>
+      [
+        "# switchroom Layer 1: agent .bashrc.",
+        "# Defers to .profile for the env so login + non-login shells",
+        "# stay in lockstep. Edit freely — `switchroom apply` will not",
+        "# overwrite this file once it exists.",
+        '[ -f "$HOME/.profile" ] && . "$HOME/.profile"',
+        "",
+      ].join("\n"),
+    created,
+    skipped,
+  );
+
   // --- Initialize workspace as git repo (Phase 4) ---
   const workspaceDir = join(agentDir, "workspace");
   initWorkspaceGitRepo(workspaceDir, name);

--- a/src/build-info.ts
+++ b/src/build-info.ts
@@ -3,7 +3,7 @@
 // Values are refreshed every time `npm run build` runs.
 
 export const VERSION: string = "0.7.7";
-export const COMMIT_SHA: string | null = "86d9884a";
-export const COMMIT_DATE: string | null = "2026-05-10T02:02:30+10:00";
-export const LATEST_PR: number | null = 885;
-export const COMMITS_AHEAD_OF_TAG: number | null = 2;
+export const COMMIT_SHA: string | null = "d454642f";
+export const COMMIT_DATE: string | null = "2026-05-10T07:05:06+10:00";
+export const LATEST_PR: number | null = 886;
+export const COMMITS_AHEAD_OF_TAG: number | null = 3;

--- a/tests/docker/compose-generator.test.ts
+++ b/tests/docker/compose-generator.test.ts
@@ -388,6 +388,33 @@ describe("agent service env (Phase 2c F2 — IPC wiring)", () => {
       );
     }
   });
+
+  // Layer 1 (persistent agent HOME). The agent container runs as a
+  // numeric UID with no /etc/passwd entry; without HOME pointed at a
+  // writable dir, every tool that writes ~/.config / ~/.cache / ~/.local
+  // fails on the read-only root fs. compose.ts pins HOME inside the
+  // existing /state/agent bind mount so writes survive restart, and
+  // sets NPM_CONFIG_PREFIX so `npm install -g` lands under HOME instead
+  // of /usr/local (which is read-only).
+  it("sets HOME=/state/agent/home on each agent container", () => {
+    const out = generateCompose({
+      config: makeConfig({ alice: {}, bob: {} }),
+    });
+    for (const a of ["alice", "bob"]) {
+      const env = envBlockFor(out, a);
+      expect(env).toMatch(/HOME:\s*"\/state\/agent\/home"/);
+    }
+  });
+
+  it("sets NPM_CONFIG_PREFIX under HOME so npm -g installs persist", () => {
+    const out = generateCompose({
+      config: makeConfig({ alice: {} }),
+    });
+    const env = envBlockFor(out, "alice");
+    expect(env).toMatch(
+      /NPM_CONFIG_PREFIX:\s*"\/state\/agent\/home\/\.npm-global"/,
+    );
+  });
 });
 
 describe("agent service network (v0.7.4 — host networking)", () => {

--- a/tests/scaffold.persistent-home.test.ts
+++ b/tests/scaffold.persistent-home.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import {
+  mkdtempSync,
+  rmSync,
+  existsSync,
+  readFileSync,
+  writeFileSync,
+  statSync,
+} from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { scaffoldAgent } from "../src/agents/scaffold.js";
+import type {
+  AgentConfig,
+  SwitchroomConfig,
+  TelegramConfig,
+} from "../src/config/schema.js";
+
+/**
+ * Layer 1 — per-agent persistent HOME.
+ *
+ * compose.ts pins `HOME=/state/agent/home` on every agent container.
+ * scaffoldAgent must create the host-side directory backing that path
+ * (`<agentDir>/home/`) plus a few subdirs that keep PATH happy
+ * (`.local/bin`, `bin`, `.npm-global`) and seed minimal `.bashrc` /
+ * `.profile` so attached interactive shells see the same env that
+ * start.sh exports for non-interactive children.
+ *
+ * Crucial property: the seed is `writeIfMissing` — once the agent
+ * (or operator) edits .bashrc/.profile, a subsequent `switchroom
+ * apply` MUST NOT overwrite those edits. These tests pin both halves
+ * of that contract.
+ */
+
+const telegramConfig: TelegramConfig = {
+  bot_token: "123456:ABC-DEF",
+  forum_chat_id: "-1001234567890",
+};
+
+function makeAgentConfig(overrides: Partial<AgentConfig> = {}): AgentConfig {
+  return {
+    extends: "default",
+    topic_name: "Test Topic",
+    schedule: [],
+    ...overrides,
+  } as AgentConfig;
+}
+
+function makeSwitchroomConfig(
+  agentName: string,
+  agentConfig: AgentConfig,
+): SwitchroomConfig {
+  return {
+    switchroom: {
+      version: 1,
+      agents_dir: "~/.switchroom/agents",
+      skills_dir: "~/.switchroom/skills",
+    },
+    telegram: telegramConfig,
+    agents: {
+      [agentName]: agentConfig,
+    },
+  };
+}
+
+describe("scaffoldAgent — Layer 1 persistent HOME", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "switchroom-home-test-"));
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("creates <agentDir>/home/ with PATH-relevant subdirs", () => {
+    const cfg = makeAgentConfig();
+    const sw = makeSwitchroomConfig("alice", cfg);
+    const res = scaffoldAgent("alice", cfg, tmpDir, telegramConfig, sw);
+
+    const homeDir = join(res.agentDir, "home");
+    expect(existsSync(homeDir)).toBe(true);
+    expect(statSync(homeDir).isDirectory()).toBe(true);
+
+    // PATH (set in start.sh + .profile) prepends these. Subdirs must
+    // exist so `pip install --user`, `npm install -g`, and manual `~/bin`
+    // drops have somewhere to land without each tool having to mkdir
+    // first under a non-root UID.
+    for (const sub of [".local/bin", "bin", ".npm-global"]) {
+      const p = join(homeDir, sub);
+      expect(existsSync(p), `expected ${p} to exist`).toBe(true);
+      expect(statSync(p).isDirectory()).toBe(true);
+    }
+  });
+
+  it("seeds .profile with the PATH/NPM env block", () => {
+    const cfg = makeAgentConfig();
+    const sw = makeSwitchroomConfig("alice", cfg);
+    const res = scaffoldAgent("alice", cfg, tmpDir, telegramConfig, sw);
+
+    const profile = readFileSync(
+      join(res.agentDir, "home", ".profile"),
+      "utf-8",
+    );
+    expect(profile).toContain(
+      'export PATH="$HOME/.local/bin:$HOME/bin:$HOME/.npm-global/bin:$PATH"',
+    );
+    expect(profile).toContain(
+      'export NPM_CONFIG_PREFIX="$HOME/.npm-global"',
+    );
+  });
+
+  it("seeds .bashrc that defers to .profile (single source of truth)", () => {
+    const cfg = makeAgentConfig();
+    const sw = makeSwitchroomConfig("alice", cfg);
+    const res = scaffoldAgent("alice", cfg, tmpDir, telegramConfig, sw);
+
+    const bashrc = readFileSync(
+      join(res.agentDir, "home", ".bashrc"),
+      "utf-8",
+    );
+    // Bash's split between .profile (login shells) and .bashrc
+    // (interactive non-login) is a footgun if we duplicate env in both;
+    // .bashrc sources .profile so we keep one canonical block.
+    expect(bashrc).toContain('. "$HOME/.profile"');
+  });
+
+  it("does NOT overwrite existing .bashrc / .profile on subsequent scaffolds", () => {
+    const cfg = makeAgentConfig();
+    const sw = makeSwitchroomConfig("alice", cfg);
+
+    // First scaffold writes the seeds.
+    scaffoldAgent("alice", cfg, tmpDir, telegramConfig, sw);
+    const homeDir = join(tmpDir, "alice", "home");
+    const customProfile = "# operator-customized .profile\nexport FOO=bar\n";
+    const customBashrc = "# operator-customized .bashrc\nalias ll='ls -la'\n";
+    writeFileSync(join(homeDir, ".profile"), customProfile);
+    writeFileSync(join(homeDir, ".bashrc"), customBashrc);
+
+    // Second scaffold (idempotent reapply) MUST leave the operator
+    // edits intact — writeIfMissing skips the seed when the file
+    // exists. Otherwise every `switchroom apply` would clobber any
+    // shell-level customization the agent or operator ever made.
+    scaffoldAgent("alice", cfg, tmpDir, telegramConfig, sw);
+
+    expect(readFileSync(join(homeDir, ".profile"), "utf-8")).toBe(
+      customProfile,
+    );
+    expect(readFileSync(join(homeDir, ".bashrc"), "utf-8")).toBe(customBashrc);
+  });
+});


### PR DESCRIPTION
## Why

Agent containers ship with read-only root + a numeric UID that has no `/etc/passwd` entry, so `HOME` defaults to `/` and every write to `~/.config` / `~/.cache` / `~/.local` fails on the read-only root fs. Concretely today:

- `gh auth login` → ENOENT/EROFS
- `git config --global …` → can't write `~/.gitconfig`
- `pip install --user …` → can't write `~/.local`
- `npm install -g …` → can't write `/usr/local`
- shell history, ssh keys, dotfile customization → all wiped on every `docker compose restart`

This PR is **Layer 1** of the "long-lived chat" persistence model: a per-agent writable HOME inside the existing `/state/agent` bind mount.

## What changed

### Layer 1 wiring
- `compose.ts` — every agent service gets `HOME=/state/agent/home` and `NPM_CONFIG_PREFIX=/state/agent/home/.npm-global`. No new bind mount needed (it's inside the existing `/state/agent` mount → `~/.switchroom/agents/<name>/`).
- `scaffold.ts` — creates `<agentDir>/home/{.local/bin,bin,.npm-global}` on first scaffold; seeds `.profile` (PATH + NPM env block) and `.bashrc` (defers to `.profile`). Both seeds are `writeIfMissing` — operator/agent edits survive subsequent `switchroom apply` runs.
- `start.sh.hbs` — prepends `$HOME/.local/bin`, `$HOME/bin`, `$HOME/.npm-global/bin` to PATH so non-interactive children see the same paths as attached shells.

### Tier 1 base packages

Promoted into `switchroom/base` now that user-space installs persist:

| Package | Why |
|---|---|
| `gh` | `gh auth login` is now table-stakes (writes to `~/.config/gh/`) |
| `ripgrep` | Claude's preferred grep |
| `fd-find` | modern find; symlinked at `/usr/local/bin/fd` |
| `jq` | JSON wrangling, every API debug task |
| `wget` | alt downloader |
| `tzdata` | timezone DB |
| `psmisc` | pgrep / killall |
| `python3-pip`, `python3-venv` | `pip install --user` now persists |
| `build-essential` | gcc + make for native pip/npm modules |
| `tar/gzip/xz-utils/zip/unzip` | archive baseline (unzip moved up from bun block) |
| `less`, `nano` | pager + minimal editor |
| `tree`, `file` | orientation |
| `dnsutils`, `iputils-ping`, `netcat-openbsd` | network debug trio |

Decided against (Layer 2 territory): cloud CLIs (aws/gcloud/az), database clients (postgres/mysql), heavy languages (rust/go/java/ruby), `bat`/`htop` (human-DX, not Claude-DX).

## Image size impact

`switchroom/base` grows ~1.12 GB → ~1.64 GB multi-arch (~250 MB on a single-arch disk). ~150 MB of that is `build-essential`. Kept because native pip/npm modules (polars/pandas/numpy/sharp) are session-1 work for many agents and the cryptic compile failures are a worse UX than the size delta.

## Test plan

- [x] `npm run lint` clean
- [x] `npx vitest run tests/scaffold tests/docker/compose-generator src/agents/scaffold.test.ts` — 254 tests pass (4 new for persistent HOME, 2 new for compose env)
- [x] `bun test telegram-plugin/tests/` — 3185 pass, 0 fail
- [x] Base image builds (`docker build -f docker/Dockerfile.base ...`); every Tier 1 binary resolves inside a fresh container

### Verification on the box

After merge:
```bash
bun run build
# Rebuild base image (or wait for GHCR build-base CI to publish):
docker build -f docker/Dockerfile.base -t switchroom/base:latest .
switchroom apply  # regenerates compose with HOME env + creates home/ dirs
switchroom agent restart all
# Inside any agent's tmux:
docker exec switchroom-clerk bash -lc 'echo HOME=$HOME; cd $HOME && touch test && rm test && which gh rg jq fd'
gh auth login   # now writes to /state/agent/home/.config/gh/ → persists
```

## Out of scope

- Layer 2 (declarative per-agent `packages:` field, custom-built per-agent images) — separate, much bigger PR
- Disk quota / `du` summary in boot card for HOME usage — follow-up after we see real-world growth patterns
- `switchroom agent reset-home <name>` CLI command — defer until needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)