### PR TITLE
fix: Layer 1 follow-ups — pip works, agent UID resolves, e2e coverage

### DIFF
--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -144,6 +144,37 @@ RUN ARCH="$(uname -m)" \
  && rm -rf /tmp/bun /tmp/bun.zip \
  && bun --version >&2
 
+# Pre-seed /etc/passwd + /etc/group entries for the entire allocator
+# UID range (10001..10999 — see src/agents/compose.ts:AGENT_UID_MIN/MAX
+# and allocateAgentUid). Without these, a container running as one of
+# those UIDs has no passwd entry, which:
+#
+#   - `whoami` fails with "cannot find name for user ID NNN"
+#   - `id` shows uid=NNN with no name; `groups` is empty
+#   - Python's `pwd.getpwuid()` and `getpass.getuser()` raise KeyError
+#     (breaks `pip`, several stdlib paths, and tools that use them)
+#   - `git` warns "Author identity unknown" and (worse) some git
+#     subcommands silently use a fabricated email like agent@hostname
+#   - SSH from the container fails to map the UID to a username,
+#     surfacing as "no user" errors against some servers
+#
+# Runtime fixes (writing to /etc/passwd from start.sh) are blocked by
+# the read-only root fs that Layer 1 deliberately preserves; nss_wrapper
+# adds an LD_PRELOAD dependency we don't want. Baking 999 entries at
+# image-build time costs ~50 KB total and zero runtime cost.
+#
+# Each entry maps to HOME=/state/agent/home and shell=/bin/bash to match
+# the compose-generated env. The `name` column is `agent<UID>` so the
+# username never needs lookup ergonomics — operators always identify
+# agents by container name (`switchroom-<slug>`), not username.
+RUN set -eu \
+ && for uid in $(seq 10001 10999); do \
+      printf 'agent%s:x:%s:%s:switchroom agent:/state/agent/home:/bin/bash\n' "$uid" "$uid" "$uid" >> /etc/passwd; \
+      printf 'agent%s:x:%s:\n' "$uid" "$uid" >> /etc/group; \
+    done \
+ && chmod 644 /etc/passwd /etc/group \
+ && tail -n 1 /etc/passwd >&2
+
 # Default workdir; overridden by per-image Dockerfile if needed.
 WORKDIR /opt/switchroom
 

--- a/src/agents/compose.ts
+++ b/src/agents/compose.ts
@@ -506,6 +506,24 @@ function emitAgentService(
     // restart. PATH adjustment that puts this on the search path lives
     // in profiles/_base/start.sh.hbs.
     NPM_CONFIG_PREFIX: "/state/agent/home/.npm-global",
+    // Make `pip install foo` Just Work for agents. Two env vars:
+    //   PIP_USER=1                 — install to ~/.local (writable +
+    //                                persistent via Layer 1) instead of
+    //                                /usr/local site-packages (read-only).
+    //   PIP_BREAK_SYSTEM_PACKAGES=1 — Debian 12 marks the system Python
+    //                                as PEP 668 "externally-managed",
+    //                                so pip refuses even `pip install
+    //                                --user` by default with a confusing
+    //                                "externally-managed-environment"
+    //                                error. The override is explicit +
+    //                                visible in `printenv`.
+    // Without both, an agent's first `pip install polars / pandas /
+    // numpy / claude-sdk` fails with either that error or "Read-only
+    // file system" — neither recoverable from a tool-call retry loop.
+    // With both, packages land in ~/.local/lib and survive container
+    // restart via the /state/agent bind mount.
+    PIP_BREAK_SYSTEM_PACKAGES: "1",
+    PIP_USER: "1",
     SWITCHROOM_AGENT_NAME: a.name,
     SWITCHROOM_BROKER_SOCKET: `/run/switchroom/broker/${a.name}/sock`,
     SWITCHROOM_KERNEL_SOCKET: `/run/switchroom/kernel/${a.name}/sock`,

--- a/src/build-info.ts
+++ b/src/build-info.ts
@@ -3,7 +3,7 @@
 // Values are refreshed every time `npm run build` runs.
 
 export const VERSION: string = "0.7.7";
-export const COMMIT_SHA: string | null = "d454642f";
-export const COMMIT_DATE: string | null = "2026-05-10T07:05:06+10:00";
-export const LATEST_PR: number | null = 886;
-export const COMMITS_AHEAD_OF_TAG: number | null = 3;
+export const COMMIT_SHA: string | null = "a6861b34";
+export const COMMIT_DATE: string | null = "2026-05-10T08:17:51+10:00";
+export const LATEST_PR: number | null = 887;
+export const COMMITS_AHEAD_OF_TAG: number | null = 4;

--- a/tests/docker/compose-generator.test.ts
+++ b/tests/docker/compose-generator.test.ts
@@ -415,6 +415,23 @@ describe("agent service env (Phase 2c F2 — IPC wiring)", () => {
       /NPM_CONFIG_PREFIX:\s*"\/state\/agent\/home\/\.npm-global"/,
     );
   });
+
+  // Layer 1 followup: PEP 668. Debian 12's system Python is marked
+  // externally-managed, which makes `pip install --user foo` refuse
+  // even though Layer 1 made ~/.local writable. Both env vars together
+  // route writes to ~/.local (PIP_USER) and override the PEP 668 guard
+  // (PIP_BREAK_SYSTEM_PACKAGES). Without both, an agent's first
+  // `pip install` fails opaquely inside a tool-call retry loop.
+  it("sets PIP_USER + PIP_BREAK_SYSTEM_PACKAGES so `pip install foo` lands in ~/.local", () => {
+    const out = generateCompose({
+      config: makeConfig({ alice: {}, bob: {} }),
+    });
+    for (const a of ["alice", "bob"]) {
+      const env = envBlockFor(out, a);
+      expect(env).toMatch(/PIP_USER:\s*"1"/);
+      expect(env).toMatch(/PIP_BREAK_SYSTEM_PACKAGES:\s*"1"/);
+    }
+  });
 });
 
 describe("agent service network (v0.7.4 — host networking)", () => {

--- a/tests/docker/e2e.test.ts
+++ b/tests/docker/e2e.test.ts
@@ -238,6 +238,78 @@ describe.skipIf(!dockerOk || !allImagesPresent)(
       expect(`${r.stderr}${r.stdout}`).toMatch(/read-only file system/i);
     });
 
+    it("base image resolves an agent UID via /etc/passwd (whoami / id / pwd.getpwuid all work)", () => {
+      // Layer 1 followup: agent containers run with UIDs 10001..10999 from
+      // src/agents/compose.ts:allocateAgentUid. Without /etc/passwd entries
+      // for that range, whoami fails, getpass.getuser() raises KeyError, and
+      // git complains about unknown identity. The base Dockerfile bakes
+      // 999 entries; this test pins both ends of the range plus the middle.
+      for (const uid of [10001, 10500, 10999]) {
+        const r = spawnSync(
+          "docker",
+          [
+            "run", "--rm", ...LABELS_ARGV,
+            "--user", String(uid),
+            "--entrypoint", "sh", IMAGES.base, "-c",
+            // whoami exits non-zero if no passwd entry; getent passwd
+            // confirms the entry shape. Use a fully-shell-quoted body so
+            // neither the host shell nor the JS template literal mangles
+            // the substitution.
+            `whoami && getent passwd ${uid} && python3 -c 'import pwd; print(pwd.getpwuid(${uid}).pw_name)'`,
+          ],
+          { encoding: "utf8" },
+        );
+        expect(r.status, `uid=${uid} stderr=${r.stderr}`).toBe(0);
+        expect(r.stdout).toContain(`agent${uid}`);
+      }
+    });
+
+    it("agent image gives uid 10001 a writable HOME at /state/agent/home (Layer 1)", () => {
+      // The whole point of Layer 1: HOME points inside the bind-mount
+      // root rather than the read-only "/" that an unmapped UID gets by
+      // default. We can't test the bind mount in isolation here (this
+      // test runs the bare image, not via compose), so we mount a tmpfs
+      // at /state/agent and confirm HOME=$path-on-tmpfs is writable
+      // when set in env. Compose itself is exercised by the
+      // compose-generator tests; this asserts the *image* end of the
+      // contract — that an unmapped UID + read-only root + an explicit
+      // HOME env still produces a write-capable shell.
+      const r = spawnSync(
+        "docker",
+        [
+          "run", "--rm", ...LABELS_ARGV,
+          "--read-only",
+          "--user", "10001",
+          "--tmpfs", "/state/agent:rw,uid=10001,mode=755",
+          "--tmpfs", "/tmp:rw,size=16m,mode=1777",
+          "-e", "HOME=/state/agent/home",
+          "--entrypoint", "sh", IMAGES.agent, "-c",
+          'mkdir -p "$HOME" && touch "$HOME/.gitconfig" && echo OK',
+        ],
+        { encoding: "utf8" },
+      );
+      expect(r.status, `stderr=${r.stderr} stdout=${r.stdout}`).toBe(0);
+      expect(r.stdout).toContain("OK");
+    });
+
+    it("base image has Tier 1 tools on PATH (gh, ripgrep, fd, jq, pip, git, less, nano)", () => {
+      // Pin the Tier 1 list — anything missing here is a regression in
+      // docker/Dockerfile.base. These are the tools Claude reaches for
+      // in the first 10 turns of a typical session; failing to install
+      // them in base forces every agent to wait 30+s on apt-get on
+      // first use, which torpedoes the boot-card "ready" promise.
+      const r = spawnSync(
+        "docker",
+        [
+          "run", "--rm", ...LABELS_ARGV, "--entrypoint", "sh", IMAGES.base, "-c",
+          'for c in gh rg fd jq pip3 git less nano dig ping nc tree file; do command -v "$c" || echo "MISSING:$c"; done',
+        ],
+        { encoding: "utf8" },
+      );
+      expect(r.status, `stderr=${r.stderr}`).toBe(0);
+      expect(r.stdout).not.toMatch(/^MISSING:/m);
+    });
+
     it("agent image with cap_drop=ALL blocks mount (mount -t tmpfs → EPERM)", () => {
       const r = spawnSync(
         "docker",


### PR DESCRIPTION
## Why

Three follow-ups from #887's reviewer notes — each closes a real friction point that would surface as a confusing tool-call failure on the box.

## What changed

### 1. \`pip install foo\` Just Works (PEP 668)

Debian 12 marks system Python as PEP 668 \"externally-managed\" — pip refuses even \`pip install --user\` with a confusing error. Layer 1 made \`~/.local\` writable, but agents trying their first \`pip install polars/pandas/numpy\` still hit the wall.

\`compose.ts\` now sets:
- \`PIP_USER=1\` — install to \`~/.local\` (persistent via Layer 1)
- \`PIP_BREAK_SYSTEM_PACKAGES=1\` — opt out of PEP 668 explicitly (loud, visible in \`printenv\`, no marker-file deletion)

### 2. \`/etc/passwd\` entries for the agent UID range

Agent UIDs 10001..10999 had no passwd entries:
- \`whoami\` → \"cannot find name for user ID NNN\"
- \`pwd.getpwuid()\` → KeyError (breaks pip + several stdlib paths)
- \`git\` → \"Author identity unknown\" / fabricated emails
- \`ssh\` → some servers reject \"no user\"

\`Dockerfile.base\` now bakes 999 passwd + group entries at image build (\`agent<UID>\` → \`HOME=/state/agent/home\`, \`shell=/bin/bash\`). ~50 KB total. Runtime \`/etc/passwd\` writes blocked by the read-only root we deliberately preserved; \`nss_wrapper\` would add an LD_PRELOAD dependency. Baking is simplest.

Verified post-build:
\`\`\`
uid=10500 name=agent10500 home=/state/agent/home
getent passwd 10001 → agent10001:x:10001:10001:switchroom agent:/state/agent/home:/bin/bash
python3 -c 'import pwd; print(pwd.getpwuid(10500).pw_name)' → agent10500
\`\`\`

### 3. e2e coverage for the HOME contract

Three new tests in \`tests/docker/e2e.test.ts\`:
- Agent UID resolves at both ends + middle of range (10001 / 10500 / 10999) via \`whoami\` + \`getent\` + \`pwd.getpwuid\`
- Read-only root + uid=10001 + \`HOME\` env still permits \`touch ~/.gitconfig\` (the original Layer 1 failure mode)
- Base image has every Tier 1 binary on PATH (regression cover for the Dockerfile apt block)

Plus a 4th compose-generator test pinning the new pip env vars.

## Test plan

- [x] \`npm run lint\` clean
- [x] \`bun test telegram-plugin/tests/\` — 3185 pass
- [x] \`npx vitest run tests/scaffold tests/docker\` — 290 pass / 15 skipped
- [x] \`npx vitest run tests/docker/e2e.test.ts\` against locally-built \`phase1b-test\` images — 8 pass / 1 sentinel skip
- [x] Manual smoke against the rebuilt base image confirmed all three followups

### Verification on the box

\`\`\`bash
bun run build
docker pull ghcr.io/switchroom/switchroom-base:latest  # or rebuild locally
switchroom apply
switchroom agent restart all
docker exec switchroom-clerk bash -lc '
  echo \"whoami: \$(whoami)\"
  pip install --quiet requests && python3 -c \"import requests; print(requests.__version__)\"
  git config --global user.email me@example.com && git config --get user.email
'
\`\`\`

Each line should now print without errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)