### PR TITLE
fix: progress card no longer freezes at ⚠ Stalled

### DIFF
--- a/src/build-info.ts
+++ b/src/build-info.ts
@@ -3,7 +3,7 @@
 // Values are refreshed every time `npm run build` runs.
 
 export const VERSION: string = "0.7.7";
-export const COMMIT_SHA: string | null = "a6861b34";
-export const COMMIT_DATE: string | null = "2026-05-10T08:17:51+10:00";
-export const LATEST_PR: number | null = 887;
-export const COMMITS_AHEAD_OF_TAG: number | null = 4;
+export const COMMIT_SHA: string | null = "5a33e6cb";
+export const COMMIT_DATE: string | null = "2026-05-10T08:31:23+10:00";
+export const LATEST_PR: number | null = 888;
+export const COMMITS_AHEAD_OF_TAG: number | null = 5;

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -10533,6 +10533,12 @@ void (async () => {
               onStall: (agentId, idleMs, description) => {
                 progressDriver?.onSubAgentStall(agentId, idleMs, description)
               },
+              // Symmetric to onStall: clear the ⚠ Stalled badge as soon
+              // as the watcher sees JSONL activity return, instead of
+              // waiting on the next render tick to recompute idle ms.
+              onUnstall: (agentId, description) => {
+                progressDriver?.onSubAgentUnstall?.(agentId, description)
+              },
               // #card-audit-log: symmetric sub_agent_finished surface.
               // The driver's per-chat shadow knows the parent turnKey and
               // the registry DB carries the background flag — combine them

--- a/telegram-plugin/progress-card-driver.ts
+++ b/telegram-plugin/progress-card-driver.ts
@@ -781,6 +781,18 @@ export interface ProgressDriver {
    */
   onSubAgentStall(agentId: string, idleMs: number, description: string): void
   /**
+   * Symmetric to `onSubAgentStall`. Fires when the watcher observes
+   * JSONL activity returning for a previously-stalled sub-agent. Forces
+   * a re-render so the ⚠ Stalled badge clears immediately, instead of
+   * waiting on the next heartbeat tick (which the diff-guard might
+   * suppress if no chat-level state otherwise changed). The render
+   * itself reads the now-current `sa.lastEventAt` (already bumped by
+   * the standard event path), so this method is purely a render-trigger.
+   *
+   * No-op if no card is currently tracking this `agentId`.
+   */
+  onSubAgentUnstall(agentId: string, description: string): void
+  /**
    * Test-only accessor exposing the driver's internal Maps so unit tests
    * can assert TTL eviction and outer-base-key cleanup actually drop
    * entries. Not part of the supported runtime API — gated behind the
@@ -2830,6 +2842,26 @@ export function createProgressDriver(config: ProgressDriverConfig): ProgressDriv
         lastSubAgentTickBucket.delete(cs.turnKey)
         // If the heartbeat isn't running (it would have been kept alive by
         // preserve-pending, but check defensively), start it.
+        if (chats.size > 0) startHeartbeatIfNeeded()
+        break
+      }
+    },
+
+    onSubAgentUnstall(agentId: string, _description: string) {
+      // Symmetric to onSubAgentStall: watcher saw JSONL activity return.
+      // The standard event path has already bumped sa.lastEventAt and
+      // (for tool events) flipped fleet member status stuck→running via
+      // applyToolUse. All this method needs to do is force a re-render
+      // so the ⚠ badge clears immediately — the diff-guard can otherwise
+      // suppress the heartbeat for several seconds if no chat-level
+      // state changed, which manifests as the badge lingering even
+      // though the underlying state is fresh.
+      for (const cs of chats.values()) {
+        if (!cs.state.subAgents.has(agentId)) continue
+        const sa = cs.state.subAgents.get(agentId)!
+        if (sa.state !== 'running') continue
+        lastHeartbeatBucket.delete(cs.turnKey)
+        lastSubAgentTickBucket.delete(cs.turnKey)
         if (chats.size > 0) startHeartbeatIfNeeded()
         break
       }

--- a/telegram-plugin/registry/subagents-schema.ts
+++ b/telegram-plugin/registry/subagents-schema.ts
@@ -24,6 +24,9 @@
  *
  * Status transitions:
  *   running → stalled     (via recordSubagentStall — no ended_at, may resume)
+ *   stalled → running     (via recordSubagentResume — JSONL activity returned
+ *                          before terminal; closes the resume edge the watcher
+ *                          documented but never wired)
  *   running → completed   (via recordSubagentEnd)
  *   running → failed      (via recordSubagentEnd)
  *   stalled → completed   (via recordSubagentEnd — terminal beats stalled)
@@ -137,6 +140,14 @@ export interface RecordSubagentStallArgs {
 export interface BumpSubagentActivityArgs {
   id: string
   ts: number
+}
+
+export interface RecordSubagentResumeArgs {
+  id: string
+  /** Wall-clock when the resume was observed. Not stored — last_activity_at
+   *  is updated separately by bumpSubagentActivity. Available for callers
+   *  that want to log it. */
+  resumedAt: number
 }
 
 export interface ReapStuckRunningArgs {
@@ -456,6 +467,32 @@ export function reapStuckRunningRows(
   }
 
   return { reaped: candidates.length, ids: candidates.map((r) => r.id) }
+}
+
+/**
+ * Reverse the stalled→running edge when JSONL activity returns. Mirror of
+ * `recordSubagentStall` for the resume direction the schema doc has always
+ * promised but the watcher never implemented (the cause of "card freezes
+ * at ⚠ Stalled even after sub-agent resumes / completes" — see
+ * subagent-watcher.ts checkStalls + bumpSubagentActivity).
+ *
+ * Idempotent + safe:
+ *   - Only flips rows where status is currently 'stalled'. A row that's
+ *     already 'running' is untouched (no-op UPDATE). A terminal row
+ *     ('completed' / 'failed') stays terminal — terminal beats both
+ *     stalled and running.
+ *   - No-ops gracefully if `id` is not found.
+ *   - last_activity_at is NOT touched here — callers separately call
+ *     bumpSubagentActivity for the activity bump on the same tick.
+ */
+export function recordSubagentResume(db: SqliteDatabase, args: RecordSubagentResumeArgs): void {
+  void args.resumedAt // available for log lines; not persisted (started_at + last_activity_at carry the timing)
+  db.prepare(`
+    UPDATE subagents
+    SET status = 'running'
+    WHERE id = ?
+      AND status = 'stalled'
+  `).run(args.id)
 }
 
 /**

--- a/telegram-plugin/registry/subagents.test.ts
+++ b/telegram-plugin/registry/subagents.test.ts
@@ -24,6 +24,7 @@ import {
   recordSubagentStart,
   recordSubagentEnd,
   recordSubagentStall,
+  recordSubagentResume,
   bumpSubagentActivity,
   getSubagent,
   reapStuckRunningRows,
@@ -226,6 +227,69 @@ describe('start → stall → end', () => {
     recordSubagentStall(db, { id: 'sa-007', stalledAt: 9999 })
     const row = getSubagent(db, 'sa-007')
     expect(row!.status).toBe('failed')
+    db.close()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Test 4b — recordSubagentResume (stalled → running edge)
+// ---------------------------------------------------------------------------
+//
+// The schema doc (subagents-schema.ts:26) has always promised
+// "running → stalled (may resume)" but the resume edge wasn't
+// implemented — leaving the registry stuck at 'stalled' even when
+// JSONL activity returned. recordSubagentResume closes that gap.
+
+describe('recordSubagentResume — stalled → running edge', () => {
+  it('flips a stalled row back to running', () => {
+    const db = openFreshSubagentsDbInMemory()
+    recordSubagentStart(db, { id: 'sa-r1', background: false, startedAt: 1000 })
+    recordSubagentStall(db, { id: 'sa-r1', stalledAt: 1500 })
+    expect(getSubagent(db, 'sa-r1')!.status).toBe('stalled')
+    recordSubagentResume(db, { id: 'sa-r1', resumedAt: 2000 })
+    const row = getSubagent(db, 'sa-r1')
+    expect(row!.status).toBe('running')
+    expect(row!.ended_at).toBeNull()
+    db.close()
+  })
+
+  it('is a no-op on a row that is already running', () => {
+    // Idempotency: the watcher fires resume on the first activity tick
+    // after a stall, but the same code path is also reached during
+    // normal activity bumps where stallNotified is already false. We
+    // never want a redundant resume to spuriously demote a row.
+    const db = openFreshSubagentsDbInMemory()
+    recordSubagentStart(db, { id: 'sa-r2', background: false, startedAt: 1000 })
+    recordSubagentResume(db, { id: 'sa-r2', resumedAt: 2000 })
+    expect(getSubagent(db, 'sa-r2')!.status).toBe('running')
+    db.close()
+  })
+
+  it('is a no-op on a completed row — terminal beats resume', () => {
+    const db = openFreshSubagentsDbInMemory()
+    recordSubagentStart(db, { id: 'sa-r3', background: false, startedAt: 1000 })
+    recordSubagentEnd(db, { id: 'sa-r3', endedAt: 2000, status: 'completed' })
+    recordSubagentResume(db, { id: 'sa-r3', resumedAt: 3000 })
+    const row = getSubagent(db, 'sa-r3')
+    expect(row!.status).toBe('completed')
+    expect(row!.ended_at).toBe(2000)
+    db.close()
+  })
+
+  it('is a no-op on a failed row', () => {
+    const db = openFreshSubagentsDbInMemory()
+    recordSubagentStart(db, { id: 'sa-r4', background: false, startedAt: 1000 })
+    recordSubagentEnd(db, { id: 'sa-r4', endedAt: 2000, status: 'failed' })
+    recordSubagentResume(db, { id: 'sa-r4', resumedAt: 3000 })
+    expect(getSubagent(db, 'sa-r4')!.status).toBe('failed')
+    db.close()
+  })
+
+  it('is a no-op on a missing row (graceful)', () => {
+    const db = openFreshSubagentsDbInMemory()
+    expect(() =>
+      recordSubagentResume(db, { id: 'sa-nope', resumedAt: 1000 }),
+    ).not.toThrow()
     db.close()
   })
 })

--- a/telegram-plugin/subagent-watcher.ts
+++ b/telegram-plugin/subagent-watcher.ts
@@ -43,7 +43,7 @@ import { homedir } from 'os'
 import { projectSubagentLine } from './session-tail.js'
 import { sanitiseToolArg } from './fleet-state.js'
 import { escapeHtml, truncate } from './card-format.js'
-import { bumpSubagentActivity, recordSubagentStall, recordSubagentEnd, reapStuckRunningRows } from './registry/subagents-schema.js'
+import { bumpSubagentActivity, recordSubagentStall, recordSubagentResume, recordSubagentEnd, reapStuckRunningRows } from './registry/subagents-schema.js'
 import { touchTurnActiveMarker } from './gateway/turn-active-marker.js'
 
 // ─── Types ───────────────────────────────────────────────────────────────────
@@ -119,10 +119,24 @@ export interface SubagentWatcherConfig {
    */
   rescanMs?: number
   /**
-   * How long without JSONL activity before a worker is considered stalled (ms).
-   * Default 60_000.
+   * How long without JSONL activity before a worker is considered stalled
+   * **once at least one tool has been used**. Default 60_000ms. Tool-call
+   * loops emit JSONL events frequently, so 60s of silence in that phase
+   * is a strong signal the sub-agent is stuck on a single tool.
    */
   stallThresholdMs?: number
+  /**
+   * Stall threshold (ms) used **before any tool has been used** —
+   * "silent synthesis" mode where the model is composing a response without
+   * emitting events yet. Long-running plan / synthesis sub-agents commonly
+   * spend 2-5 minutes in this state legitimately, so the active-loop
+   * threshold (60s) misfires. Default 300_000 (5 min).
+   *
+   * The watcher selects between this and `stallThresholdMs` per-entry
+   * based on `entry.toolCount`: 0 ⇒ silent synthesis, ≥1 ⇒ active loop.
+   * Both can be overridden for tests.
+   */
+  silentSynthesisStallThresholdMs?: number
   /**
    * Reaper TTL (ms): background rows in `status='running'` whose
    * `last_activity_at` (or `started_at` if liveness never wrote) is older
@@ -171,6 +185,18 @@ export interface SubagentWatcherConfig {
    * the same sub-agent across subsequent poll ticks.
    */
   onStall?: (agentId: string, idleMs: number, description: string) => void
+  /**
+   * Symmetric to `onStall`: fires when a previously-stalled sub-agent's
+   * JSONL grows again (text emission, tool use, turn_end — anything that
+   * moves last_activity_at). Wired to `progressDriver.onSubAgentUnstall`
+   * in gateway.ts so the pinned card clears the ⚠ Stalled badge as soon
+   * as activity resumes, instead of waiting on the next render tick.
+   *
+   * Each stall→resume cycle fires exactly once: the watcher resets
+   * `entry.stallNotified` on resume, so a sub-agent that stalls again
+   * later in the same lifetime is detected (and reported) again.
+   */
+  onUnstall?: (agentId: string, description: string) => void
   /**
    * Called exactly once per sub-agent when its watcher observes a terminal
    * transition (`done` or `failed`). Mirrors the existing `sub_agent_started`
@@ -226,6 +252,11 @@ export interface SubagentWatcherHandle {
 
 const DEFAULT_RESCAN_MS = 1000
 const DEFAULT_STALL_THRESHOLD_MS = 60_000
+/** Silent-synthesis threshold (no tools used yet). 5min covers plan /
+ *  research sub-agents that legitimately think for several minutes
+ *  before emitting their first event — the 60s active-loop threshold
+ *  misfires on those and freezes the card at ⚠. */
+const DEFAULT_SILENT_SYNTHESIS_STALL_THRESHOLD_MS = 300_000
 const DEFAULT_REAPER_TTL_MS = 60 * 60_000          // 1 hour
 const DEFAULT_REAPER_INTERVAL_MS = 15 * 60_000     // 15 minutes
 /**
@@ -338,6 +369,10 @@ function readSubTail(
   log?: (msg: string) => void,
   db?: SubagentLivenessDb | null,
   parentStateDir?: string | null,
+  /** Fires when the watcher observes JSONL activity returning for a
+   *  previously-stalled entry. Closes the resume edge the schema doc
+   *  has always promised. */
+  onUnstall?: (agentId: string, description: string) => void,
 ): void {
   try {
     const stat = fs.statSync(entry.filePath)
@@ -411,7 +446,39 @@ function readSubTail(
       if (!line) continue
       const events = projectSubagentLine(line, entry.agentId, startState)
       for (const ev of events) {
+        const idleSecBeforeBump = Math.round((now - entry.lastActivityAt) / 1000)
         entry.lastActivityAt = now
+        // Un-stall transition (#previously-missing). The schema doc
+        // promised "stalled → running (may resume)" but neither the
+        // in-memory `stallNotified` flag nor the DB `status` column was
+        // ever flipped back. That left the pinned card stuck at ⚠ until
+        // terminal completion, by which point the user had often
+        // already interrupted or redispatched. Reset both halves on the
+        // first activity tick after a stall + fire onUnstall for the
+        // driver to clear its render-time badge.
+        if (entry.stallNotified) {
+          entry.stallNotified = false
+          if (db != null) {
+            try {
+              const rowRef = db
+                .prepare('SELECT id FROM subagents WHERE jsonl_agent_id = ?')
+                .get(entry.agentId) as { id: string } | null
+              if (rowRef != null) {
+                recordSubagentResume(db, { id: rowRef.id, resumedAt: now })
+              }
+            } catch (dbErr) {
+              log?.(`subagent-watcher: resume DB write error ${entry.agentId}: ${(dbErr as Error).message}`)
+            }
+          }
+          if (onUnstall != null) {
+            try {
+              onUnstall(entry.agentId, entry.description)
+            } catch (cbErr) {
+              log?.(`subagent-watcher: onUnstall callback error ${entry.agentId}: ${(cbErr as Error).message}`)
+            }
+          }
+          log?.(`subagent-watcher: stall cleared for ${entry.agentId} (activity resumed after ${idleSecBeforeBump}s — re-arming detection)`)
+        }
         if (ev.kind === 'sub_agent_tool_use') {
           entry.toolCount++
           // P0 of #662: surface the most recent tool name + sanitised
@@ -467,6 +534,8 @@ function readSubTail(
 export function startSubagentWatcher(config: SubagentWatcherConfig): SubagentWatcherHandle {
   const agentDir = config.agentDir
   const stallThresholdMs = config.stallThresholdMs ?? DEFAULT_STALL_THRESHOLD_MS
+  const silentSynthesisStallThresholdMs =
+    config.silentSynthesisStallThresholdMs ?? DEFAULT_SILENT_SYNTHESIS_STALL_THRESHOLD_MS
   const reaperTtlMs = config.reaperTtlMs ?? DEFAULT_REAPER_TTL_MS
   const reaperIntervalMs = config.reaperIntervalMs ?? DEFAULT_REAPER_INTERVAL_MS
   const rescanMs = config.rescanMs ?? DEFAULT_RESCAN_MS
@@ -583,7 +652,7 @@ export function startSubagentWatcher(config: SubagentWatcherConfig): SubagentWat
     // Initial read
     readSubTail(entry, tail, n, (desc) => {
       log?.(`subagent-watcher: description updated for ${agentId}: ${desc}`)
-    }, fs, log, db, parentStateDir)
+    }, fs, log, db, parentStateDir, config.onUnstall)
 
     // If the JSONL already contained a turn_end at registration time
     // (file written-then-watched), fire the state-transition + completion
@@ -614,7 +683,7 @@ export function startSubagentWatcher(config: SubagentWatcherConfig): SubagentWat
         if (!entry || !t) return
         readSubTail(entry, t, nowFn(), (desc) => {
           log?.(`subagent-watcher: description updated for ${agentId}: ${desc}`)
-        }, fs, log, db, parentStateDir)
+        }, fs, log, db, parentStateDir, config.onUnstall)
         maybySendStateTransition(agentId)
       })
     } catch (err) {
@@ -731,7 +800,17 @@ export function startSubagentWatcher(config: SubagentWatcherConfig): SubagentWat
       if (entry.historical) continue
       if (entry.stallNotified) continue
       const idleMs = n - entry.lastActivityAt
-      if (idleMs >= stallThresholdMs) {
+      // Adaptive: a sub-agent that hasn't fired any tools yet is in
+      // "silent synthesis" mode (model thinking before its first emit).
+      // 60s is way too aggressive for plan / research sub-agents that
+      // legitimately spend 2-5 minutes composing before their first
+      // tool_use. Once tools have started, switch to the tighter loop
+      // threshold — frequent JSONL writes mean 60s of silence is a
+      // strong signal the sub-agent is genuinely stuck.
+      const threshold = entry.toolCount === 0
+        ? silentSynthesisStallThresholdMs
+        : stallThresholdMs
+      if (idleMs >= threshold) {
         entry.stallNotified = true
         const desc = escapeHtml(truncate(entry.description, 80))
         const idleSec = Math.floor(idleMs / 1000)
@@ -860,7 +939,7 @@ export function startSubagentWatcher(config: SubagentWatcherConfig): SubagentWat
       if (!tail) continue
       readSubTail(entry, tail, n, (desc) => {
         log?.(`subagent-watcher: description updated for ${agentId}: ${desc}`)
-      }, fs, log, db, parentStateDir)
+      }, fs, log, db, parentStateDir, config.onUnstall)
       maybySendStateTransition(agentId)
     }
 

--- a/telegram-plugin/tests/subagent-registry-bugs.test.ts
+++ b/telegram-plugin/tests/subagent-registry-bugs.test.ts
@@ -219,6 +219,11 @@ function makeHarnessWithDb(opts: {
     agentDir,
     sendNotification: (text) => notifications.push(text),
     stallThresholdMs,
+    // Mirror the active-loop threshold for fixtures with toolCount=0;
+    // tests that need the silent-synthesis vs active-loop distinction
+    // pass a separate value explicitly. See subagent-watcher.ts adaptive
+    // threshold logic.
+    silentSynthesisStallThresholdMs: stallThresholdMs,
     rescanMs: 500,
     now: () => currentTime,
     setInterval: (fn, ms) => {

--- a/telegram-plugin/tests/subagent-watcher-stall-notification.test.ts
+++ b/telegram-plugin/tests/subagent-watcher-stall-notification.test.ts
@@ -28,16 +28,19 @@ function subAgentUserMsg(promptText: string) {
 interface StallHarness {
   notifications: string[]
   stallCalls: Array<{ agentId: string; idleMs: number; description: string }>
+  unstallCalls: Array<{ agentId: string; description: string }>
   logs: string[]
   advance: (ms: number) => void
   watcher: ReturnType<typeof startSubagentWatcher>
   now: () => number
   fileContents: Map<string, Buffer>
+  jsonlPath: string
 }
 
 function makeStallHarness(opts: {
   agentDir?: string
   stallThresholdMs?: number
+  silentSynthesisStallThresholdMs?: number
   rescanMs?: number
   initialContent?: string
   agentId?: string
@@ -45,6 +48,7 @@ function makeStallHarness(opts: {
   const {
     agentDir = '/home/user/.switchroom/agents/myagent',
     stallThresholdMs = 60_000,
+    silentSynthesisStallThresholdMs,
     rescanMs = 500,
     agentId = 'test-stall-agent-01',
     initialContent,
@@ -53,6 +57,7 @@ function makeStallHarness(opts: {
   let currentTime = 1000
   const notifications: string[] = []
   const stallCalls: Array<{ agentId: string; idleMs: number; description: string }> = []
+  const unstallCalls: Array<{ agentId: string; description: string }> = []
   const logs: string[] = []
 
   // Build realistic path: <agentDir>/.claude/projects/<sanitized-cwd>/<sessionId>/subagents/
@@ -127,9 +132,16 @@ function makeStallHarness(opts: {
   const watcher = startSubagentWatcher({
     agentDir,
     stallThresholdMs,
+    // When the test doesn't explicitly distinguish the two thresholds,
+    // mirror them so existing fixtures (which have toolCount=0 and a
+    // simple "advance past 60s" model) keep working under the new
+    // adaptive logic. New tests pass an explicit value to exercise the
+    // silent-synthesis vs active-loop split.
+    silentSynthesisStallThresholdMs: silentSynthesisStallThresholdMs ?? stallThresholdMs,
     rescanMs,
     sendNotification: (text) => notifications.push(text),
     onStall: (id, idle, desc) => stallCalls.push({ agentId: id, idleMs: idle, description: desc }),
+    onUnstall: (id, desc) => unstallCalls.push({ agentId: id, description: desc }),
     now: () => currentTime,
     setInterval: (fn, ms) => {
       const ref = nextRef++
@@ -156,7 +168,7 @@ function makeStallHarness(opts: {
     }
   }
 
-  return { notifications, stallCalls, logs, advance, watcher, now: () => currentTime, fileContents }
+  return { notifications, stallCalls, unstallCalls, logs, advance, watcher, now: () => currentTime, fileContents, jsonlPath }
 }
 
 // ─── Tests ────────────────────────────────────────────────────────────────────
@@ -209,6 +221,97 @@ describe('subagent-watcher onStall callback (Option C, issue #393)', () => {
     // must prevent a second onStall call.
     advance(120_000)
     expect(stallCalls.length).toBe(countAfterFirstStall) // still exactly 1
+  })
+
+  // Test 11 (silent-synthesis): a sub-agent that hasn't fired any tools
+  // yet should NOT trip the stall detector at the active-loop threshold
+  // (60s) — it's almost certainly in long-form synthesis mode where the
+  // model is still composing its first emit. The silent-synthesis
+  // threshold (5min by default) is what gates that case. Pre-fix the
+  // single 60s threshold tripped on plan/research sub-agents that ran
+  // 2-3min legitimately, freezing the card at ⚠ until completion.
+  it('does NOT trip stall at 60s when toolCount=0 (silent synthesis adaptive threshold)', () => {
+    const agentId = 'stall-test-11'
+    const { stallCalls, advance, watcher } = makeStallHarness({
+      agentId,
+      stallThresholdMs: 60_000,
+      silentSynthesisStallThresholdMs: 300_000, // 5min
+      rescanMs: 500,
+    })
+    advance(500) // register
+    const entry = watcher.getRegistry().get(agentId)
+    if (entry) entry.historical = false
+    advance(120_000) // 2min idle, far past 60s but well under 5min
+    expect(stallCalls).toHaveLength(0)
+    advance(200_000) // total ~5min 20s — past silent-synthesis threshold
+    expect(stallCalls).toHaveLength(1)
+    expect(stallCalls[0].agentId).toBe(agentId)
+  })
+
+  // Test 12 (un-stall transition): once JSONL activity returns after a
+  // stall, the watcher must reset stallNotified, fire onUnstall, and
+  // re-arm so a subsequent stall detects again. Pre-fix none of those
+  // happened — the card stuck at ⚠ even when the sub-agent was clearly
+  // alive again.
+  it('fires onUnstall when activity returns after a stall and re-arms detection', () => {
+    const agentId = 'stall-test-12'
+    const { stallCalls, unstallCalls, advance, watcher, fileContents, jsonlPath } = makeStallHarness({
+      agentId,
+      // Force the active-loop threshold by giving the entry a tool right
+      // away (avoids the silent-synthesis adaptive path). We append a
+      // sub_agent_tool_use line in the initial content so toolCount > 0
+      // by the first activity bump.
+      stallThresholdMs: 60_000,
+      silentSynthesisStallThresholdMs: 60_000, // keep flat for this test
+      rescanMs: 500,
+      initialContent: buildJSONL(
+        subAgentUserMsg('background task'),
+        { type: 'assistant', message: { content: [{ type: 'tool_use', id: 'tool-A', name: 'Read', input: { path: '/x' } }] } },
+      ),
+    })
+    advance(500) // register + initial tail read (toolCount becomes 1)
+    const entry = watcher.getRegistry().get(agentId)
+    if (entry) entry.historical = false
+    advance(65_000) // cross 60s — stall fires
+    expect(stallCalls).toHaveLength(1)
+    expect(unstallCalls).toHaveLength(0)
+
+    // Append a fresh JSONL line — the sub-agent emits text, proving it's
+    // alive. The watcher should reset stallNotified, fire onUnstall, and
+    // re-arm so a *future* idle period can stall it again.
+    const existing = fileContents.get(jsonlPath) ?? Buffer.from('')
+    const resumeLine = JSON.stringify({ type: 'assistant', message: { content: [{ type: 'text', text: 'still alive' }] } }) + '\n'
+    fileContents.set(jsonlPath, Buffer.concat([existing, Buffer.from(resumeLine, 'utf-8')]))
+    advance(500) // poll picks up the new line
+
+    expect(unstallCalls).toHaveLength(1)
+    expect(unstallCalls[0].agentId).toBe(agentId)
+    // stallNotified must be re-armed: another idle window crosses
+    // threshold again and onStall fires a SECOND time.
+    advance(65_000)
+    expect(stallCalls).toHaveLength(2)
+  })
+
+  // Test 13 (un-stall + tool-loop adaptive): once tools have been used,
+  // a 60s gap correctly re-trips the stall detector. Sanity check that
+  // toolCount > 0 selects the active-loop threshold, not silent-synthesis.
+  it('uses 60s threshold once toolCount>0 (active-loop adaptive)', () => {
+    const agentId = 'stall-test-13'
+    const { stallCalls, advance, watcher } = makeStallHarness({
+      agentId,
+      stallThresholdMs: 60_000,
+      silentSynthesisStallThresholdMs: 600_000, // way out — 10min
+      rescanMs: 500,
+      initialContent: buildJSONL(
+        subAgentUserMsg('worker'),
+        { type: 'assistant', message: { content: [{ type: 'tool_use', id: 'tool-A', name: 'Read', input: {} }] } },
+      ),
+    })
+    advance(500) // register + tail (toolCount=1)
+    const entry = watcher.getRegistry().get(agentId)
+    if (entry) entry.historical = false
+    advance(65_000) // 65s of silence with tools active → stall
+    expect(stallCalls).toHaveLength(1)
   })
 
   // Test 10: onStall is NOT called for sub-agents already done/failed

--- a/telegram-plugin/tests/subagent-watcher.test.ts
+++ b/telegram-plugin/tests/subagent-watcher.test.ts
@@ -200,6 +200,11 @@ function makeHarness(opts: {
     agentDir,
     sendNotification: (text) => notifications.push(text),
     stallThresholdMs,
+    // Mirror the active-loop threshold so existing fixtures (which have
+    // toolCount=0 and use the simple "advance past N" model) keep
+    // working under the adaptive split. Tests that need the silent-
+    // synthesis vs active-loop distinction set both explicitly.
+    silentSynthesisStallThresholdMs: stallThresholdMs,
     rescanMs,
     now: () => currentTime,
     setInterval: (fn, ms) => {

--- a/telegram-plugin/tests/two-zone-card-header-phases.test.ts
+++ b/telegram-plugin/tests/two-zone-card-header-phases.test.ts
@@ -61,6 +61,16 @@ describe('phaseFor truth table', () => {
     ['parent-done + fg-failed + bg-running → Background, not Done', st({ stage: 'done' }), fleetOf(fm('a', 'failed'), fm('b', 'running', NOW)), { parentDone: true }, 'Background'],
     ['mixed terminal+stuck → not Done', st({ stage: 'run' }), fleetOf(fm('a', 'done'), fm('b', 'stuck', 0)), {}, 'Stalled'],
     ['reply tool fired AND fleet running → Background (parentDone)', st({ stage: 'done' }), fleetOf(fm('a', 'running', NOW)), { parentDone: true }, 'Background'],
+    // Regression: pre-fix the `[].every(...)` vacuous-truth at
+    // two-zone-card.ts fleetAllStuck would mark the fleet stalled the
+    // moment the last sub-agent finished while the parent was still
+    // running. Plan agents that completed in 2-3min showed ⚠ Stalled
+    // on the pinned card until the parent itself wrapped up. Now: zero
+    // running-or-stuck members in the fleet means we fall through to
+    // the default "Working…" instead.
+    ['regression: all fleet done + parent still running → Working… (was Stalled)', st({ stage: 'run' }), fleetOf(fm('a', 'done'), fm('b', 'done')), {}, 'Working…'],
+    ['regression: lone done sub-agent + parent still running → Working…', st({ stage: 'run' }), fleetOf(fm('a', 'done')), {}, 'Working…'],
+    ['regression: failed-only fleet + parent still running → Working… (was Stalled)', st({ stage: 'run' }), fleetOf(fm('a', 'failed')), {}, 'Working…'],
   ])('%s', (_name, state, fleet, opts, expectedLabel) => {
     const phase = phaseFor(state, fleet, NOW, opts as Record<string, unknown>)
     expect(phase.label).toBe(expectedLabel)

--- a/telegram-plugin/two-zone-card.ts
+++ b/telegram-plugin/two-zone-card.ts
@@ -87,7 +87,15 @@ export function phaseFor(
   if (stalledClose) return { icon: '⚠', label: 'Forced close' }
 
   const fleetRunning = anyFleetActive(fleet)
-  const fleetAllStuck = fleet.size > 0 && [...fleet.values()].filter((m) => m.status === 'running' || m.status === 'stuck').every((m) => isStuck(m, now))
+  // Stalled = "the only fleet members that could still make progress have
+  // gone idle past the threshold". An empty filtered list (every fleet
+  // member is already terminal) MUST NOT count as stalled — Array#every
+  // returns true vacuously on `[]`, which previously caused the card to
+  // freeze at ⚠ Stalled the moment the last sub-agent finished while the
+  // parent was still running. We require at least one running-or-stuck
+  // member before claiming the fleet is stalled.
+  const runningOrStuck = [...fleet.values()].filter((m) => m.status === 'running' || m.status === 'stuck')
+  const fleetAllStuck = runningOrStuck.length > 0 && runningOrStuck.every((m) => isStuck(m, now))
 
   // SilentEnd: parent terminated without a reply. Lifted above the
   // background/done branches so a still-running fleet can't mask it,
@@ -99,8 +107,11 @@ export function phaseFor(
   // Stalled: every running-or-stuck member is past the idle threshold.
   // Members already terminal (done/failed) are excluded from this check —
   // a fleet of [done, stuck] still surfaces as Stalled because the only
-  // member that could still make progress is no longer doing so.
-  if (fleet.size > 0 && fleetAllStuck && !parentDone) {
+  // member that could still make progress is no longer doing so. The
+  // `fleetAllStuck` calc itself guards against an empty filtered list
+  // (otherwise `[].every()` would lock the card at Stalled the moment
+  // the last sub-agent finished).
+  if (fleetAllStuck && !parentDone) {
     return { icon: '⚠', label: 'Stalled' }
   }
 


### PR DESCRIPTION
## Why

Pinned progress card shows fleet member as ⚠ Stalled even after the sub-agent completes successfully. Observed on a Plan agent that ran ~2:33 and returned normally; card stayed frozen at ⚠ until parent terminal. Erodes trust in the status surface and prompts users to interrupt or redispatch work that was completing fine.

## Root cause — three interacting bugs

### 1. Renderer vacuous-truth (the dominant cause)

`two-zone-card.ts:90` computed:
```ts
fleet.size > 0 && [...fleet.values()]
  .filter(m => m.status === 'running' || m.status === 'stuck')
  .every(m => isStuck(m, now))
```

When every fleet member finished, the filter returned `[]` and `[].every(...)` returns `true` vacuously. The Stalled branch fired the moment the last sub-agent transitioned to done while the parent was still running.

### 2. Watcher threshold too tight for silent synthesis

`subagent-watcher.ts:228` used a single 60s threshold for stall detection. Plan / research sub-agents that legitimately think for 2-5 minutes before emitting their first event tripped the detector, which produced the ⚠ stall row that the renderer bug then refused to clear.

### 3. No un-stall transition

`subagents-schema.ts:26` documented \`running → stalled (may resume)\` but the resume edge was never implemented. Once \`entry.stallNotified\` flipped to true the watcher never reset it, the DB row stayed at \`status='stalled'\`, and no callback notified the driver to clear the badge.

## What changed

| File | Change |
|---|---|
| \`telegram-plugin/two-zone-card.ts\` | Require ≥1 running-or-stuck member before declaring fleet stalled — kills the vacuous-truth path |
| \`telegram-plugin/subagent-watcher.ts\` | Adaptive threshold: 60s when \`toolCount > 0\`, 5 min when \`toolCount === 0\`. New \`silentSynthesisStallThresholdMs\` config. New \`onUnstall\` callback. Activity-bump path resets \`stallNotified\` + writes \`recordSubagentResume\` to DB + fires \`onUnstall\` |
| \`telegram-plugin/registry/subagents-schema.ts\` | New \`recordSubagentResume(db, args)\` — flips \`stalled→running\`, no-ops on terminal/running/missing. State machine doc updated |
| \`telegram-plugin/gateway/gateway.ts\` | Forwards \`onUnstall\` to \`progressDriver.onSubAgentUnstall\` |
| \`telegram-plugin/progress-card-driver.ts\` | New \`onSubAgentUnstall\` — mirrors \`onSubAgentStall\`, clears diff-guard buckets so the next heartbeat re-renders immediately rather than waiting on a chat-state change |

## Tests

- **two-zone-card-header-phases**: 3 new regression rows — all-fleet-done + parent-running → Working… (was Stalled), lone-done + parent-running → Working…, failed-only + parent-running → Working…. Existing 12 rows still green.
- **registry/subagents.test.ts**: 5 new cases for \`recordSubagentResume\` (flips stalled→running; no-op on running, completed, failed, or missing rows).
- **subagent-watcher-stall-notification**: 3 new cases — no trip at 60s when \`toolCount=0\` (silent synthesis); un-stall fires + re-arms; 60s threshold once \`toolCount>0\`.
- 3 pre-existing test harnesses updated to default \`silentSynthesisStallThresholdMs\` to \`stallThresholdMs\` so legacy fixtures (\`toolCount=0\`) keep working under the adaptive split.

### Verification

- [x] \`npm run lint\` — clean
- [x] \`bun test telegram-plugin/tests/\` — 3191 pass / 0 fail / 2 skip
- [x] \`npx vitest run\` — 4480 pass / 0 fail / 29 skip across 290 files
- [x] No production behavior change for sub-agents that complete in < 60s — the adaptive threshold only widens the window for silent synthesis

🤖 Generated with [Claude Code](https://claude.com/claude-code)