### PR TITLE
feat(scheduler): Phase 1 — dispatchAsInbound primitive (no behaviour change)

### DIFF
--- a/docs/scheduling.md
+++ b/docs/scheduling.md
@@ -35,17 +35,13 @@ against the live agent container. The agent's MCP tools (Telegram, Vault, etc.) 
 | `model` | No | `claude-sonnet-4-6` | Model for this task |
 | `secrets` | No | `[]` | Vault keys this task may read via the broker. See [configuration.md#vault-broker-linux-only](configuration.md#vault-broker-linux-only). |
 
-> **`suppress_stdout` was removed in [#269](https://github.com/switchroom/switchroom/issues/269).** All cron tasks now route their Telegram message through the MCP `reply` tool — see below.
+> **`suppress_stdout` was removed in [#269](https://github.com/switchroom/switchroom/issues/269).** All cron tasks route their Telegram message through the MCP `reply` tool the agent already uses for interactive turns.
 
 ### How cron tasks deliver to Telegram
 
-Cron-scheduled tasks run as one-shot `claude -p` invocations with no live Telegram session. The cron script:
+Cron-scheduled tasks run as one-shot `claude -p` invocations with no live Telegram session. The scheduler executes the configured `prompt` directly — there is no shell-level prompt wrapping, no `HEARTBEAT_OK` sentinel, and no stdout redirection. If the task has something to say, the model calls `mcp__switchroom-telegram__reply` itself; the scheduler captures stdout only to populate the audit-log `output_summary` column.
 
-1. Wraps the configured `prompt` with delivery guidance instructing the model to call `mcp__switchroom-telegram__reply` with the chat ID and emit `HEARTBEAT_OK` to stdout.
-2. Executes `claude -p` with stdout routed to `/dev/null` so the discarded `HEARTBEAT_OK` (and any incidental model output) never reaches Telegram.
-3. The MCP `reply` tool applies the same markdown→HTML conversion, smart chunking, and sanitization as a live session — output renders identically regardless of trigger.
-
-If a cron task has nothing meaningful to say (data is dull, all signals nominal), the model emits `HEARTBEAT_OK` without calling `reply`. A silent heartbeat is correct behaviour, not an error — the user is not pinged unnecessarily.
+The MCP `reply` tool applies the same markdown→HTML conversion, smart chunking, and sanitization as a live session, so output renders identically regardless of trigger. If the task has nothing meaningful to deliver (data is dull, all signals nominal), the model can simply not call `reply` — a silent run is correct behaviour, not an error.
 
 This replaces the previous flow (raw `claude -p` stdout piped through `curl ... -d parse_mode=HTML`), which produced broken markdown rendering on phones (literal `**asterisks**`) and the duplicate-message bug tracked in [#251](https://github.com/switchroom/switchroom/issues/251).
 

--- a/src/scheduler/dispatch-inbound.test.ts
+++ b/src/scheduler/dispatch-inbound.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Unit tests for `dispatchAsInbound` — the Phase 1 cron-fire synthesis
+ * primitive. Pure function: builds an `InboundMessage` from a
+ * `SchedulerEntry` and hands it to a dispatcher. Phase 1 ships only
+ * this primitive; nothing calls it yet.
+ *
+ * The wire-shape source of truth is `validateGatewayMessage` in
+ * `telegram-plugin/bridge/ipc-client.ts` — the same validator the
+ * bridge uses to accept gateway→client messages on the live socket.
+ * Importing it here means the test fails the moment the bridge stops
+ * accepting our shape, not weeks later when an agent silently drops
+ * cron fires in production.
+ *
+ * (The handoff brief pointed at `validateClientMessage` in
+ * `gateway/ipc-server.ts:104-167`; that's the *client→gateway*
+ * validator, which doesn't recognise `type: "inbound"`. The
+ * gateway→client direction has its own validator and that's the one
+ * the bridge actually applies — so we exercise it here instead.)
+ */
+
+import { describe, it, expect } from "vitest";
+import { validateGatewayMessage } from "../../telegram-plugin/bridge/ipc-client.js";
+import {
+  dispatchAsInbound,
+  type InboundDispatcher,
+  type InboundMessageWire,
+  type SchedulerEntry,
+} from "./dispatch.js";
+
+const sampleEntry: SchedulerEntry = {
+  agent: "klanker",
+  scheduleIndex: 2,
+  cron: "0 8 * * 1-5",
+  prompt: "Morning briefing — calendar, blockers, top priorities",
+  promptKey: "abcdef012345",
+};
+
+function captureDispatcher(
+  responses: { delivered: boolean } = { delivered: true },
+): InboundDispatcher & {
+  calls: Array<{ agentName: string; msg: InboundMessageWire }>;
+} {
+  const calls: Array<{ agentName: string; msg: InboundMessageWire }> = [];
+  return {
+    calls,
+    sendToAgent(agentName, msg) {
+      calls.push({ agentName, msg });
+      return responses.delivered;
+    },
+  };
+}
+
+describe("dispatchAsInbound", () => {
+  it("synthesises an InboundMessage tagged with meta.source='cron'", () => {
+    const dispatcher = captureDispatcher();
+    const result = dispatchAsInbound(
+      sampleEntry,
+      { chatId: "-1001234567890", now: () => 1_700_000_000_000 },
+      dispatcher,
+    );
+
+    expect(result.delivered).toBe(true);
+    expect(dispatcher.calls).toHaveLength(1);
+    const { agentName, msg } = dispatcher.calls[0]!;
+    expect(agentName).toBe("klanker");
+    expect(msg.type).toBe("inbound");
+    expect(msg.chatId).toBe("-1001234567890");
+    expect(msg.text).toBe(sampleEntry.prompt);
+    expect(msg.user).toBe("cron");
+    expect(msg.userId).toBe(0);
+    expect(msg.ts).toBe(1_700_000_000_000);
+    expect(msg.messageId).toBe(1_700_000_000_000);
+    expect(msg.meta.source).toBe("cron");
+    expect(msg.meta.schedule_index).toBe("2");
+    expect(msg.meta.prompt_key).toBe("abcdef012345");
+  });
+
+  it("forwards the synthesised message verbatim in the result", () => {
+    const dispatcher = captureDispatcher();
+    const result = dispatchAsInbound(
+      sampleEntry,
+      { chatId: "c", now: () => 42 },
+      dispatcher,
+    );
+    expect(result.message).toEqual(dispatcher.calls[0]!.msg);
+  });
+
+  it("propagates threadId when given, omits the field when absent", () => {
+    const withThread = captureDispatcher();
+    dispatchAsInbound(
+      sampleEntry,
+      { chatId: "c", threadId: 7, now: () => 1 },
+      withThread,
+    );
+    expect(withThread.calls[0]!.msg.threadId).toBe(7);
+
+    const withoutThread = captureDispatcher();
+    dispatchAsInbound(sampleEntry, { chatId: "c", now: () => 1 }, withoutThread);
+    expect("threadId" in withoutThread.calls[0]!.msg).toBe(false);
+  });
+
+  it("returns delivered=false when no agent client is registered", () => {
+    const dispatcher = captureDispatcher({ delivered: false });
+    const result = dispatchAsInbound(
+      sampleEntry,
+      { chatId: "c", now: () => 1 },
+      dispatcher,
+    );
+    expect(result.delivered).toBe(false);
+    // The dispatcher is still called — Phase 2 in-agent cron will
+    // decide separately whether an undelivered fire goes to a queue
+    // or dead-letters into scheduler.jsonl.
+    expect(dispatcher.calls).toHaveLength(1);
+  });
+
+  it("defaults `ts` and `messageId` to Date.now() when no clock is injected", () => {
+    const dispatcher = captureDispatcher();
+    const before = Date.now();
+    dispatchAsInbound(sampleEntry, { chatId: "c" }, dispatcher);
+    const after = Date.now();
+    const ts = dispatcher.calls[0]!.msg.ts;
+    expect(ts).toBeGreaterThanOrEqual(before);
+    expect(ts).toBeLessThanOrEqual(after);
+    expect(dispatcher.calls[0]!.msg.messageId).toBe(ts);
+  });
+
+  it("survives a JSON wire round-trip with meta intact", () => {
+    const dispatcher = captureDispatcher();
+    dispatchAsInbound(
+      sampleEntry,
+      { chatId: "-100", threadId: 12, now: () => 1_700_000_000_000 },
+      dispatcher,
+    );
+    const original = dispatcher.calls[0]!.msg;
+    const wire = JSON.stringify(original) + "\n";
+    const parsed = JSON.parse(wire.trim()) as InboundMessageWire;
+    expect(parsed).toEqual(original);
+    expect(parsed.meta.source).toBe("cron");
+    expect(parsed.meta.schedule_index).toBe("2");
+    expect(parsed.meta.prompt_key).toBe("abcdef012345");
+  });
+
+  it("validates against the bridge's validateGatewayMessage", () => {
+    const dispatcher = captureDispatcher();
+    dispatchAsInbound(
+      sampleEntry,
+      { chatId: "-100", now: () => 1_700_000_000_000 },
+      dispatcher,
+    );
+    const wire = JSON.parse(JSON.stringify(dispatcher.calls[0]!.msg));
+    expect(validateGatewayMessage(wire)).toBe(true);
+  });
+});

--- a/src/scheduler/dispatch.ts
+++ b/src/scheduler/dispatch.ts
@@ -121,3 +121,122 @@ export async function dispatchEntry(
     finishedAt,
   };
 }
+
+// ───────────────────────────────────────────────────────────────────────
+//  Phase 1: in-band cron synthesis primitive (no behaviour change yet)
+// ───────────────────────────────────────────────────────────────────────
+//
+// The end-state for cron scheduling (see issue tracking the scheduler
+// fold-in work) is to retire the `switchroom-cron` singleton container
+// and run cron as a sibling of the gateway inside each agent container.
+// Fires are delivered to the agent as synthesized `InboundMessage`s
+// flowing the same path as Telegram messages and button-callback
+// injections (gateway.ts:5217, :8796, :9226), discriminated by
+// `meta.source = "cron"`. Reusing the existing envelope means the
+// agent transcript and Hindsight see cron fires as ordinary turns
+// tagged with `<channel source="cron">`, rather than as out-of-band
+// one-shot `claude -p` runs that vanish from session history.
+//
+// `dispatchAsInbound` is the synthesis primitive. Phase 1 only adds it
+// — nothing calls it yet. Phase 2 wires the in-agent scheduler.
+
+/**
+ * InboundMessage envelope, mirrored structurally from
+ * `telegram-plugin/gateway/ipc-protocol.ts` so this module can build
+ * one without crossing the src/ ↔ telegram-plugin/ tsconfig boundary.
+ *
+ * Keep this in sync with the source of truth — the bridge's
+ * `validateGatewayMessage` validator (`telegram-plugin/bridge/ipc-client.ts`)
+ * is what decides whether a wire-format message is accepted.
+ */
+export interface InboundMessageWire {
+  type: "inbound";
+  chatId: string;
+  threadId?: number;
+  messageId: number;
+  user: string;
+  userId: number;
+  ts: number;
+  text: string;
+  imagePath?: string;
+  attachment?: { fileId: string; mimeType: string; fileName?: string };
+  meta: Record<string, string>;
+}
+
+/**
+ * Minimum surface a dispatcher needs to deliver a synthesized inbound
+ * to a connected agent client. Matches the shape of the gateway's
+ * `IpcServer.sendToAgent` so a real gateway can be passed in directly,
+ * and tests can pass a capturing fake.
+ *
+ * Returns true when an agent client was registered for `agentName` and
+ * the message was written to its socket; false when the agent is not
+ * currently connected (the caller decides whether to drop, queue, or
+ * persist for replay-on-reconnect).
+ */
+export interface InboundDispatcher {
+  sendToAgent(agentName: string, msg: InboundMessageWire): boolean;
+}
+
+export interface InboundDispatchOptions {
+  /**
+   * Required: the chat the synthesized turn belongs to. The Phase 2
+   * in-agent scheduler resolves this from the agent's primary topic
+   * mapping; tests pass it directly.
+   */
+  chatId: string;
+  /** Optional Telegram topic / thread id when the chat has topics. */
+  threadId?: number;
+  /**
+   * Synthetic timestamp source. Defaulted to `Date.now()`; tests inject
+   * a fixed clock to make `messageId` and `ts` deterministic.
+   */
+  now?: () => number;
+}
+
+export interface InboundDispatchResult {
+  /** False when no agent client was registered for `entry.agent`. */
+  delivered: boolean;
+  /** The exact wire message handed to the dispatcher. */
+  message: InboundMessageWire;
+}
+
+/**
+ * Build an `InboundMessage` from a `SchedulerEntry` and hand it to the
+ * dispatcher. Pure synthesis — no clock, network, or filesystem unless
+ * the dispatcher does it. Phase 1 ships this primitive; Phase 2 wires
+ * it from the in-agent scheduler sibling.
+ *
+ * `meta.source = "cron"` is the only stable discriminator the bridge
+ * uses to render the turn as `<channel source="cron">`. `schedule_index`
+ * and `prompt_key` are carried for audit correlation against the
+ * scheduler.jsonl ledger Phase 2 introduces — both as strings, since
+ * `meta` is `Record<string, string>` on the wire.
+ */
+export function dispatchAsInbound(
+  entry: SchedulerEntry,
+  options: InboundDispatchOptions,
+  dispatcher: InboundDispatcher,
+): InboundDispatchResult {
+  const ts = (options.now ?? Date.now)();
+  const message: InboundMessageWire = {
+    type: "inbound",
+    chatId: options.chatId,
+    ...(options.threadId !== undefined ? { threadId: options.threadId } : {}),
+    // Synthetic id — cron fires don't have a Telegram message_id. The
+    // bridge only uses messageId for telegram_reply context, which is
+    // a no-op for cron-synthesized turns.
+    messageId: ts,
+    user: "cron",
+    userId: 0,
+    ts,
+    text: entry.prompt,
+    meta: {
+      source: "cron",
+      schedule_index: String(entry.scheduleIndex),
+      prompt_key: entry.promptKey,
+    },
+  };
+  const delivered = dispatcher.sendToAgent(entry.agent, message);
+  return { delivered, message };
+}


### PR DESCRIPTION
## Summary

Phase 1 of folding the singleton `switchroom-cron` container into per-agent sidecars. Adds a pure synthesis primitive that builds an `InboundMessage` from a `SchedulerEntry` and hands it to a dispatcher. **No behaviour change in this PR** — nothing calls `dispatchAsInbound` yet.

- `dispatchAsInbound(entry, options, dispatcher)` synthesises an `InboundMessage` tagged with `meta.source="cron"`, `meta.schedule_index`, `meta.prompt_key`. Reuses the existing envelope (the same shape `gateway.ts:5217`, `:8796`, `:9226` already produce for Telegram messages, button callbacks, and checklist events) so the bridge needs zero new code paths in Phase 2.
- 7 vitest cases covering structure, threadId pass-through, undelivered-agent path, default clock, JSON wire round-trip, and validation against the bridge's `validateGatewayMessage`.
- Fixes `docs/scheduling.md`: the previous "How cron tasks deliver to Telegram" section described a `HEARTBEAT_OK` sentinel + `> /dev/null` wrapper that doesn't exist in `dispatch.ts`. Doc now matches what the code actually does.

## Why

End state (tracked in the broader scheduler-fold-in handoff): retire `switchroom-cron` and run cron as a sibling of the gateway inside each agent container. Fires delivered to the agent through the same `InboundMessage` path Telegram already uses means cron-triggered turns appear in the agent transcript and Hindsight context as ordinary turns tagged `<channel source="cron">`, instead of disappearing into out-of-band one-shot `claude -p` runs that the agent has no awareness of.

This PR is the smallest possible step toward that — just the synthesis function — so each phase ships independently reviewable.

## Notes for the reviewer

- One handoff-brief reference correction noted in the test file: the brief pointed at `validateClientMessage` in `gateway/ipc-server.ts`; that's the *client→gateway* validator and doesn't recognise `type: "inbound"`. The synthesised message is gateway→client, so the test exercises `validateGatewayMessage` from `telegram-plugin/bridge/ipc-client.ts` instead. Same intent, correct validator.
- `InboundMessageWire` is a structural mirror of `telegram-plugin/gateway/ipc-protocol.ts:InboundMessage`. The doc-comment above it points at the source of truth. Phase 2's in-agent scheduler bundle (which will live somewhere reachable from telegram-plugin) can import the real type if/when convenient.

## Test plan

- [x] `npx vitest run src/scheduler/` — 8 passed, 1 skipped (existing audit-sqlite skip is unchanged)
- [x] `npm run lint` — clean (tsc + plugin-references)
- [ ] Reviewer agent: APPROVE / REQUEST_CHANGES / BLOCK on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)