### PR TITLE
feat(scheduler): Phase 2 — in-agent scheduler sibling (gated, opt-in)

### DIFF
--- a/docker/Dockerfile.agent
+++ b/docker/Dockerfile.agent
@@ -57,6 +57,20 @@ COPY telegram-plugin/dist /opt/switchroom/telegram-plugin/dist
 COPY telegram-plugin/start.js /opt/switchroom/telegram-plugin/start.js
 COPY telegram-plugin/package.json /opt/switchroom/telegram-plugin/package.json
 
+# Phase 2 cron-fold-in: the in-agent scheduler bundle plus its node-cron
+# runtime dep. Started by start.sh as a third supervised sidecar (after
+# gateway + autoaccept-poll) only when SWITCHROOM_INLINE_SCHEDULER=1 —
+# off by default until Phase 4 cuts the singleton over. Bundle is built
+# by scripts/build.mjs with --external node-cron, so the image must
+# provide it. node-cron is pure JS (no native compilation), so install
+# is fast and arch-independent.
+COPY dist/agent-scheduler/index.js /opt/switchroom/agent-scheduler/index.js
+WORKDIR /opt/switchroom/agent-scheduler
+RUN npm init -y >/dev/null \
+ && node -e "const fs=require('fs');const p=JSON.parse(fs.readFileSync('package.json'));p.type='module';fs.writeFileSync('package.json',JSON.stringify(p,null,2));" \
+ && npm install --omit=dev --build-from-source=false node-cron@^3.0.3
+WORKDIR /
+
 # tini handles zombies + signal forwarding. The actual command is
 # /state/agent/start.sh, which the scaffold renders into the bind-mount.
 ENTRYPOINT ["/usr/bin/tini", "--"]

--- a/profiles/_base/start.sh.hbs
+++ b/profiles/_base/start.sh.hbs
@@ -84,6 +84,23 @@ if [ "$SWITCHROOM_RUNTIME" = "docker" ] && [ -z "$SWITCHROOM_DOCKER_TMUX_INNER" 
       bun /opt/switchroom/autoaccept-poll.js "{{name}}" &
   fi
 
+  # 3) agent-scheduler (Phase 2 cron-fold-in, opt-in via env).
+  #    Long-running. Replaces the singleton switchroom-cron container
+  #    once SWITCHROOM_INLINE_SCHEDULER=1 is set per agent (Phase 3
+  #    canary) and then defaulted on (Phase 4). Running as a sibling
+  #    of the gateway means cron fires arrive in this agent's
+  #    transcript through the SAME inbound path as Telegram messages
+  #    — synthesized turns tagged meta.source="cron". The bundle
+  #    connects to the gateway socket above, so the gateway must be
+  #    up before fires can deliver; the supervisor's respawn loop
+  #    handles the early-boot race naturally.
+  if [ "$SWITCHROOM_INLINE_SCHEDULER" = "1" ] \
+     && [ -f /opt/switchroom/agent-scheduler/index.js ] \
+     && command -v bun >/dev/null 2>&1; then
+    _switchroom_supervise agent-scheduler /var/log/switchroom/agent-scheduler.log \
+      bun /opt/switchroom/agent-scheduler/index.js &
+  fi
+
   export SWITCHROOM_DOCKER_TMUX_INNER=1
   exec tmux -L "switchroom-{{name}}" \
     new-session -A -s "{{name}}" -x 400 -y 50 \

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -163,6 +163,13 @@ const serverEntries = [
   // the image runs the bundle under `bun`.
   { src: "src/vault/approvals/kernel-server.ts", out: "dist/vault/approvals/kernel-server.js" },
   { src: "src/scheduler/index.ts", out: "dist/scheduler/index.js" },
+  // Phase 2 cron-fold-in: in-agent scheduler sibling. Baked into the
+  // agent image at /opt/switchroom/agent-scheduler/index.js and started
+  // by start.sh under SWITCHROOM_INLINE_SCHEDULER=1. Same external/build
+  // discipline as the host scheduler bundle — node-cron is npm-installed
+  // inside the agent image (docker/Dockerfile.agent) so the prebuilt
+  // binary lines up with the linux/glibc runtime.
+  { src: "src/agent-scheduler/index.ts", out: "dist/agent-scheduler/index.js" },
 ];
 for (const entry of serverEntries) {
   const srcAbs = resolve(root, entry.src);

--- a/src/agent-scheduler/index.test.ts
+++ b/src/agent-scheduler/index.test.ts
@@ -1,0 +1,237 @@
+/**
+ * Unit tests for the in-agent scheduler sibling. Drives the cron-fire
+ * path with fakes for cron + dispatcher + audit sink, asserting:
+ *   - the dispatcher receives a correctly-shaped InboundMessageWire
+ *   - audit rows mirror the host scheduler's DispatchResult shape
+ *     (Phase 3 audit-parity check depends on this)
+ *   - delivered=false maps to exit_code=-1, dispatcher errors are
+ *     caught and audited (the cron loop must never crash on a fire)
+ *   - resolveChannelTarget reads the config cascade correctly
+ */
+
+import { describe, it, expect } from "vitest";
+import { InMemoryAuditSink } from "../scheduler/audit.js";
+import type {
+  InboundDispatcher,
+  InboundMessageWire,
+  SchedulerEntry,
+} from "../scheduler/dispatch.js";
+import {
+  registerAgentSchedule,
+  resolveChannelTarget,
+  type CronLib,
+} from "./index.js";
+
+function fakeCron(): CronLib & { fire: (idx: number) => Promise<void>; tasks: Array<() => void | Promise<void>>; stops: number } {
+  const handlers: Array<() => void | Promise<void>> = [];
+  let stops = 0;
+  return {
+    schedule(_expr, h) {
+      handlers.push(h);
+      return { stop: () => { stops += 1; } };
+    },
+    async fire(idx) {
+      const h = handlers[idx];
+      if (!h) throw new Error(`no handler at idx=${idx}`);
+      await h();
+    },
+    get tasks() { return handlers; },
+    get stops() { return stops; },
+  };
+}
+
+function captureDispatcher(opts: { delivered?: boolean; throwOnce?: Error } = {}): InboundDispatcher & {
+  calls: Array<{ agent: string; msg: InboundMessageWire }>;
+} {
+  let firstCall = true;
+  const calls: Array<{ agent: string; msg: InboundMessageWire }> = [];
+  return {
+    calls,
+    sendToAgent(agent, msg) {
+      if (firstCall && opts.throwOnce) {
+        firstCall = false;
+        throw opts.throwOnce;
+      }
+      firstCall = false;
+      calls.push({ agent, msg });
+      return opts.delivered ?? true;
+    },
+  };
+}
+
+const sampleEntries: SchedulerEntry[] = [
+  {
+    agent: "klanker",
+    scheduleIndex: 0,
+    cron: "0 8 * * 1-5",
+    prompt: "Morning briefing",
+    promptKey: "abc123",
+  },
+  {
+    agent: "klanker",
+    scheduleIndex: 1,
+    cron: "0 20 * * 0",
+    prompt: "Weekly review",
+    promptKey: "def456",
+  },
+];
+
+describe("registerAgentSchedule", () => {
+  it("registers one cron task per entry and returns stop handles", () => {
+    const cron = fakeCron();
+    const sink = new InMemoryAuditSink();
+    const dispatcher = captureDispatcher();
+    const tasks = registerAgentSchedule({
+      entries: sampleEntries,
+      channel: { chatId: "-100", threadId: 7 },
+      sink,
+      cronLib: cron,
+      dispatcher,
+      now: () => 1_700_000_000_000,
+    });
+    expect(tasks).toHaveLength(2);
+    expect(cron.tasks).toHaveLength(2);
+    tasks[0]!.task.stop();
+    tasks[1]!.task.stop();
+    expect(cron.stops).toBe(2);
+  });
+
+  it("on fire, sends inject_inbound carrying meta.source='cron' and audits exit_code=0", async () => {
+    const cron = fakeCron();
+    const sink = new InMemoryAuditSink();
+    const dispatcher = captureDispatcher({ delivered: true });
+    registerAgentSchedule({
+      entries: sampleEntries,
+      channel: { chatId: "-100", threadId: 7 },
+      sink,
+      cronLib: cron,
+      dispatcher,
+      now: () => 1_700_000_000_000,
+    });
+
+    await cron.fire(0);
+
+    expect(dispatcher.calls).toHaveLength(1);
+    const sent = dispatcher.calls[0]!;
+    expect(sent.agent).toBe("klanker");
+    expect(sent.msg.type).toBe("inbound");
+    expect(sent.msg.chatId).toBe("-100");
+    expect(sent.msg.threadId).toBe(7);
+    expect(sent.msg.text).toBe("Morning briefing");
+    expect(sent.msg.meta.source).toBe("cron");
+    expect(sent.msg.meta.schedule_index).toBe("0");
+    expect(sent.msg.meta.prompt_key).toBe("abc123");
+
+    expect(sink.fires).toHaveLength(1);
+    const audit = sink.fires[0]!;
+    expect(audit.agent).toBe("klanker");
+    expect(audit.scheduleIndex).toBe(0);
+    expect(audit.promptKey).toBe("abc123");
+    expect(audit.exitCode).toBe(0);
+    expect(audit.outputSummary).toContain("delivered");
+    expect(audit.startedAt).toBe(1_700_000_000_000);
+    expect(audit.finishedAt).toBe(1_700_000_000_000);
+  });
+
+  it("when the dispatcher reports undelivered, audits exit_code=-1 with a 'no agent client' summary", async () => {
+    const cron = fakeCron();
+    const sink = new InMemoryAuditSink();
+    const dispatcher = captureDispatcher({ delivered: false });
+    registerAgentSchedule({
+      entries: sampleEntries,
+      channel: { chatId: "-100" },
+      sink,
+      cronLib: cron,
+      dispatcher,
+      now: () => 1,
+    });
+
+    await cron.fire(1);
+
+    expect(sink.fires).toHaveLength(1);
+    expect(sink.fires[0]!.exitCode).toBe(-1);
+    expect(sink.fires[0]!.outputSummary).toContain("no agent client");
+    expect(sink.fires[0]!.scheduleIndex).toBe(1);
+    expect(sink.fires[0]!.promptKey).toBe("def456");
+  });
+
+  it("when the dispatcher throws, the audit row carries the error and the cron loop survives", async () => {
+    const cron = fakeCron();
+    const sink = new InMemoryAuditSink();
+    const dispatcher = captureDispatcher({ throwOnce: new Error("EPIPE") });
+    registerAgentSchedule({
+      entries: sampleEntries,
+      channel: { chatId: "-100" },
+      sink,
+      cronLib: cron,
+      dispatcher,
+      now: () => 7,
+    });
+
+    // First fire throws; second should still succeed.
+    await cron.fire(0);
+    await cron.fire(0);
+
+    expect(sink.fires).toHaveLength(2);
+    expect(sink.fires[0]!.exitCode).toBe(-1);
+    expect(sink.fires[0]!.outputSummary).toContain("EPIPE");
+    expect(sink.fires[1]!.exitCode).toBe(0);
+  });
+
+  it("omits threadId when the channel target has no topic (e.g. DM-style chat)", async () => {
+    const cron = fakeCron();
+    const sink = new InMemoryAuditSink();
+    const dispatcher = captureDispatcher();
+    registerAgentSchedule({
+      entries: [sampleEntries[0]!],
+      channel: { chatId: "-100" },
+      sink,
+      cronLib: cron,
+      dispatcher,
+      now: () => 1,
+    });
+    await cron.fire(0);
+    const sent = dispatcher.calls[0]!;
+    expect("threadId" in sent.msg).toBe(false);
+  });
+});
+
+describe("resolveChannelTarget", () => {
+  it("reads forum_chat_id from telegram + topic_id from the agent block", () => {
+    const config = {
+      telegram: { forum_chat_id: "-1001234567890" },
+      agents: { klanker: { topic_id: 42 } },
+    } as unknown as Parameters<typeof resolveChannelTarget>[0];
+    expect(resolveChannelTarget(config, "klanker")).toEqual({
+      chatId: "-1001234567890",
+      threadId: 42,
+    });
+  });
+
+  it("returns null when forum_chat_id is missing", () => {
+    const config = {
+      telegram: undefined,
+      agents: { klanker: { topic_id: 42 } },
+    } as unknown as Parameters<typeof resolveChannelTarget>[0];
+    expect(resolveChannelTarget(config, "klanker")).toBeNull();
+  });
+
+  it("returns chatId without threadId when the agent has no topic_id", () => {
+    const config = {
+      telegram: { forum_chat_id: "-100" },
+      agents: { klanker: {} },
+    } as unknown as Parameters<typeof resolveChannelTarget>[0];
+    const result = resolveChannelTarget(config, "klanker");
+    expect(result).not.toBeNull();
+    expect(result!.chatId).toBe("-100");
+    expect("threadId" in result!).toBe(false);
+  });
+
+  it("returns chatId without threadId when the agent is missing entirely", () => {
+    const config = {
+      telegram: { forum_chat_id: "-100" },
+      agents: {},
+    } as unknown as Parameters<typeof resolveChannelTarget>[0];
+    expect(resolveChannelTarget(config, "ghost")).toEqual({ chatId: "-100" });
+  });
+});

--- a/src/agent-scheduler/index.ts
+++ b/src/agent-scheduler/index.ts
@@ -1,0 +1,267 @@
+/**
+ * In-agent scheduler sibling — Phase 2 of the cron-fold-in.
+ *
+ * Runs as a process inside each agent container, supervised by
+ * start.sh's `_switchroom_supervise` wrapper, gated behind
+ * `SWITCHROOM_INLINE_SCHEDULER=1`. Reads the agent's own schedule
+ * entries from the bind-mounted switchroom.yaml, registers each
+ * with node-cron, and on fire sends an `inject_inbound` envelope
+ * to the local gateway (which forwards it to the bridge as a
+ * synthesized turn tagged `meta.source="cron"`).
+ *
+ * Why a separate entry from `src/scheduler/index.ts`:
+ *   - The host-side singleton scheduler dispatches via `docker
+ *     exec switchroom-<name> claude -p`. It needs the docker.sock
+ *     and lives outside any agent.
+ *   - The in-agent sibling dispatches via the gateway's IPC. It
+ *     has no docker.sock, no docker CLI, and only ever fires for
+ *     ONE agent (its own).
+ *   Two dispatch transports → two separate entry points. Phase 4
+ *   deletes the host-side bundle entirely.
+ *
+ * Audit: writes one JSONL row per fire to `/state/agent/scheduler.jsonl`
+ * (under the agent's own bind mount, never shared across agents).
+ * The shape mirrors `DispatchResult` from `src/scheduler/dispatch.ts`
+ * so Phase 3's audit-parity check can compare per-agent JSONL rows
+ * against the singleton's SQLite rows column-for-column.
+ */
+
+import { resolve, join } from "node:path";
+import { loadConfig } from "../config/loader.js";
+import {
+  collectScheduleEntries,
+  dispatchAsInbound,
+  type InboundDispatcher,
+  type InboundMessageWire,
+  type SchedulerEntry,
+} from "../scheduler/dispatch.js";
+import { JsonlAuditSink, type AuditSink } from "../scheduler/audit.js";
+import {
+  createInjectIpcClient,
+  type InjectIpcClient,
+} from "./ipc-client.js";
+
+/**
+ * Minimum node-cron-shaped surface — same as the host scheduler. The
+ * package is installed inside the agent image (Phase 2 Dockerfile
+ * change) and resolved at runtime; tests inject their own.
+ */
+export interface CronLib {
+  schedule(
+    expr: string,
+    handler: () => void | Promise<void>,
+  ): { stop(): void };
+}
+
+/**
+ * The fields the in-agent scheduler knows about its target chat at
+ * registration time. The forum_chat_id is global (one per fleet);
+ * threadId is the agent's own topic in that forum.
+ */
+export interface AgentChannelTarget {
+  chatId: string;
+  threadId?: number;
+}
+
+export interface RegisterOptions {
+  /** Already-filtered to a single agent's entries. */
+  entries: SchedulerEntry[];
+  channel: AgentChannelTarget;
+  sink: AuditSink;
+  cronLib: CronLib;
+  /** Sends one inject_inbound per fire. */
+  dispatcher: InboundDispatcher;
+  /** Replaceable for tests. */
+  now?: () => number;
+}
+
+export interface RegisteredTask {
+  entry: SchedulerEntry;
+  task: { stop: () => void };
+}
+
+/**
+ * Register every entry with node-cron. Returns the live tasks so the
+ * caller can stop them on shutdown. Pure-ish: side effects are limited
+ * to `dispatcher.sendToAgent` (the IPC write) and `sink.recordFire`
+ * (the JSONL append).
+ */
+export function registerAgentSchedule(opts: RegisterOptions): RegisteredTask[] {
+  const tasks: RegisteredTask[] = [];
+  const now = opts.now ?? Date.now;
+  for (const entry of opts.entries) {
+    const task = opts.cronLib.schedule(entry.cron, () => {
+      const startedAt = now();
+      let delivered = false;
+      let summary = "";
+      try {
+        const result = dispatchAsInbound(
+          entry,
+          { chatId: opts.channel.chatId, threadId: opts.channel.threadId, now },
+          opts.dispatcher,
+        );
+        delivered = result.delivered;
+        summary = delivered
+          ? "delivered to bridge via gateway"
+          : "no agent client connected — fire dropped";
+      } catch (err) {
+        summary = `dispatch error: ${(err as Error).message}`.slice(0, 200);
+      }
+      const finishedAt = now();
+      // Mirror the shape host-side dispatch.ts:DispatchResult emits so
+      // Phase 3 audit parity is a field-for-field equality check.
+      // exit_code semantics for the IPC path:
+      //   0 — bytes accepted by the local gateway socket (best signal)
+      //  -1 — gateway not connected, or wire write failed
+      opts.sink.recordFire({
+        agent: entry.agent,
+        scheduleIndex: entry.scheduleIndex,
+        promptKey: entry.promptKey,
+        exitCode: delivered ? 0 : -1,
+        outputSummary: summary,
+        startedAt,
+        finishedAt,
+      });
+    });
+    tasks.push({ entry, task });
+  }
+  return tasks;
+}
+
+/**
+ * Build an `InboundDispatcher` backed by a local IPC client that
+ * writes `inject_inbound` envelopes to the gateway. Tests pass a
+ * capturing dispatcher directly to `registerAgentSchedule` and skip
+ * this adapter.
+ */
+export function ipcDispatcher(client: InjectIpcClient): InboundDispatcher {
+  return {
+    sendToAgent(agentName: string, inbound: InboundMessageWire): boolean {
+      // The wire envelope wraps the InboundMessage so the gateway's
+      // validateClientMessage validates it as a client→gateway
+      // message rather than impersonating a gateway→client one.
+      return client.sendInjectInbound({
+        type: "inject_inbound",
+        agentName,
+        // dispatchAsInbound builds an InboundMessageWire, which is a
+        // structural mirror of telegram-plugin's InboundMessage —
+        // the cast is a no-op at runtime.
+        inbound: inbound as unknown as Parameters<
+          InjectIpcClient["sendInjectInbound"]
+        >[0]["inbound"],
+      });
+    },
+  };
+}
+
+/**
+ * Resolve the chat target for the in-agent scheduler from the
+ * cascade-resolved config: the forum chat ID is global; the agent's
+ * topic ID is per-agent (auto-populated by `switchroom topics sync`).
+ *
+ * Returns null when the agent has no configured topic — the scheduler
+ * exits with a clear error rather than silently misrouting fires.
+ */
+export function resolveChannelTarget(
+  config: ReturnType<typeof loadConfig>,
+  agentName: string,
+): AgentChannelTarget | null {
+  const forumChatId = config.telegram?.forum_chat_id;
+  if (typeof forumChatId !== "string" || forumChatId.length === 0) return null;
+  const agent = config.agents?.[agentName];
+  const threadId = agent?.topic_id;
+  return {
+    chatId: forumChatId,
+    ...(typeof threadId === "number" ? { threadId } : {}),
+  };
+}
+
+export async function main(): Promise<void> {
+  const agentName = process.env.SWITCHROOM_AGENT_NAME;
+  if (!agentName) {
+    process.stderr.write(
+      "agent-scheduler: SWITCHROOM_AGENT_NAME is required\n",
+    );
+    process.exit(64); // EX_USAGE
+  }
+
+  const configPath = process.env.SWITCHROOM_CONFIG ?? "/state/config/switchroom.yaml";
+  const stateDir = process.env.TELEGRAM_STATE_DIR ?? "/state/agent/telegram";
+  const socketPath = process.env.SWITCHROOM_GATEWAY_SOCKET
+    ?? join(stateDir, "gateway.sock");
+  const jsonlPath = process.env.SWITCHROOM_AGENT_SCHEDULER_JSONL
+    ?? "/state/agent/scheduler.jsonl";
+
+  const config = loadConfig(configPath);
+  const allEntries = collectScheduleEntries(config);
+  const entries = allEntries.filter((e) => e.agent === agentName);
+
+  const channel = resolveChannelTarget(config, agentName);
+  if (channel === null) {
+    process.stderr.write(
+      `agent-scheduler: ${agentName} has no resolvable chat target ` +
+      `(missing telegram.forum_chat_id) — exiting\n`,
+    );
+    process.exit(78); // EX_CONFIG
+  }
+
+  if (entries.length === 0) {
+    process.stdout.write(
+      `agent-scheduler: ${agentName} has no schedule entries — exiting cleanly\n`,
+    );
+    process.exit(0);
+  }
+
+  const sink: AuditSink = new JsonlAuditSink(resolve(jsonlPath));
+  const ipcClient = createInjectIpcClient({
+    socketPath,
+    log: (m) => process.stderr.write(`agent-scheduler: ${m}\n`),
+  });
+  const dispatcher = ipcDispatcher(ipcClient);
+
+  // Lazy-resolve node-cron at runtime — it's installed inside the
+  // agent image (docker/Dockerfile.agent) and not pulled in as a
+  // top-level switchroom dep so the host-side install footprint is
+  // unchanged.
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const cronLib = require("node-cron") as CronLib;
+
+  const tasks = registerAgentSchedule({
+    entries,
+    channel,
+    sink,
+    cronLib,
+    dispatcher,
+  });
+
+  process.stdout.write(
+    `agent-scheduler: ${agentName} registered ${tasks.length} task(s); ` +
+    `chat=${channel.chatId} thread=${channel.threadId ?? "(none)"} ` +
+    `socket=${socketPath} jsonl=${jsonlPath}\n`,
+  );
+
+  const shutdown = () => {
+    for (const t of tasks) t.task.stop();
+    sink.close();
+    ipcClient.close();
+    process.exit(0);
+  };
+  process.on("SIGTERM", shutdown);
+  process.on("SIGINT", shutdown);
+}
+
+// Entry guard — only run main() when invoked as the agent-scheduler
+// bundle. Same shape as src/scheduler/index.ts so vitest imports of
+// helpers (registerAgentSchedule, ipcDispatcher, resolveChannelTarget)
+// don't accidentally trigger main().
+if (
+  import.meta.url === `file://${process.argv[1]}` &&
+  /(?:^|[/\\])agent-scheduler[/\\]index\.(?:js|ts)$/.test(process.argv[1] ?? "")
+) {
+  main().catch((err) => {
+    process.stderr.write(
+      `agent-scheduler fatal: ${err instanceof Error ? err.stack : err}\n`,
+    );
+    process.exit(1);
+  });
+}

--- a/src/agent-scheduler/ipc-client.test.ts
+++ b/src/agent-scheduler/ipc-client.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Unit tests for the agent-scheduler IPC client. Uses an injectable
+ * `_connect` to simulate the gateway socket without binding a real
+ * Unix socket — that's covered separately by the integration suite.
+ *
+ * Properties exercised:
+ *   - sendInjectInbound returns false before connect, true after
+ *   - the wire format is one NDJSON line per message
+ *   - close() prevents further reconnect attempts
+ */
+
+import { describe, it, expect } from "vitest";
+import { EventEmitter } from "node:events";
+import type { Socket } from "node:net";
+import { createInjectIpcClient } from "./ipc-client.js";
+import type { InjectInboundMessage } from "../../telegram-plugin/gateway/ipc-protocol.js";
+
+class FakeSocket extends EventEmitter {
+  public writes: string[] = [];
+  public ended = false;
+  public destroyed = false;
+  write(data: string | Uint8Array): boolean {
+    this.writes.push(typeof data === "string" ? data : Buffer.from(data).toString("utf8"));
+    return true;
+  }
+  end(): void {
+    this.ended = true;
+    setImmediate(() => this.emit("close"));
+  }
+  destroy(): void {
+    this.destroyed = true;
+    setImmediate(() => this.emit("close"));
+  }
+}
+
+function sampleMsg(): InjectInboundMessage {
+  return {
+    type: "inject_inbound",
+    agentName: "klanker",
+    inbound: {
+      type: "inbound",
+      chatId: "-100",
+      messageId: 1,
+      user: "cron",
+      userId: 0,
+      ts: 1,
+      text: "hi",
+      meta: { source: "cron", schedule_index: "0", prompt_key: "abc" },
+    },
+  };
+}
+
+async function tick(): Promise<void> {
+  // Two macrotask hops — setImmediate (used by the client to defer
+  // the initial connect) + EventEmitter sync emit.
+  await new Promise<void>((res) => setImmediate(res));
+  await new Promise<void>((res) => setImmediate(res));
+}
+
+describe("createInjectIpcClient", () => {
+  it("returns false before the connect event fires, true once connected", async () => {
+    const fake = new FakeSocket();
+    const client = createInjectIpcClient({
+      socketPath: "/fake.sock",
+      _connect: () => fake as unknown as Socket,
+    });
+    expect(client.isConnected()).toBe(false);
+    expect(client.sendInjectInbound(sampleMsg())).toBe(false);
+
+    await tick();
+    fake.emit("connect");
+
+    expect(client.isConnected()).toBe(true);
+    expect(client.sendInjectInbound(sampleMsg())).toBe(true);
+    expect(fake.writes).toHaveLength(1);
+    const wire = fake.writes[0]!;
+    expect(wire.endsWith("\n")).toBe(true);
+    const parsed = JSON.parse(wire.trim());
+    expect(parsed.type).toBe("inject_inbound");
+    expect(parsed.agentName).toBe("klanker");
+    expect(parsed.inbound.meta.source).toBe("cron");
+
+    client.close();
+  });
+
+  it("close() prevents further reconnect attempts", async () => {
+    let connectCalls = 0;
+    const factory = () => {
+      connectCalls += 1;
+      const s = new FakeSocket();
+      // Never emit 'connect'; close immediately.
+      setImmediate(() => s.emit("close"));
+      return s as unknown as Socket;
+    };
+    const client = createInjectIpcClient({
+      socketPath: "/fake.sock",
+      reconnectDelayMs: 1,
+      maxReconnectDelayMs: 1,
+      connectTimeoutMs: 10_000,
+      _connect: factory,
+    });
+    await tick();
+    // First attempt fired; close before reconnect timer runs.
+    expect(connectCalls).toBe(1);
+    client.close();
+    await new Promise<void>((res) => setTimeout(res, 5));
+    // close should have prevented the reconnect from firing.
+    expect(connectCalls).toBe(1);
+    expect(client.isConnected()).toBe(false);
+  });
+
+  it("after a connected socket closes, the client schedules a reconnect", async () => {
+    const sockets: FakeSocket[] = [];
+    const factory = () => {
+      const s = new FakeSocket();
+      sockets.push(s);
+      return s as unknown as Socket;
+    };
+    const client = createInjectIpcClient({
+      socketPath: "/fake.sock",
+      reconnectDelayMs: 1,
+      maxReconnectDelayMs: 1,
+      _connect: factory,
+    });
+    await tick();
+    sockets[0]!.emit("connect");
+    expect(client.isConnected()).toBe(true);
+    sockets[0]!.emit("close");
+    expect(client.isConnected()).toBe(false);
+    // Wait for reconnect timer.
+    await new Promise<void>((res) => setTimeout(res, 5));
+    expect(sockets.length).toBeGreaterThanOrEqual(2);
+    client.close();
+  });
+});

--- a/src/agent-scheduler/ipc-client.ts
+++ b/src/agent-scheduler/ipc-client.ts
@@ -1,0 +1,174 @@
+/**
+ * Minimal IPC client used by the in-agent scheduler sibling
+ * (Phase 2 cron-fold-in) to send `inject_inbound` messages to the
+ * agent's gateway. Deliberately separate from the bridge's
+ * `telegram-plugin/bridge/ipc-client.ts` — the scheduler does NOT
+ * need heartbeats, tool-call RPC, permission-event handling, the
+ * liveness file, or the inbound/permission/status receive loop.
+ * It just needs to write NDJSON `inject_inbound` envelopes to the
+ * gateway socket and reconnect when the socket goes away.
+ *
+ * Uses `node:net` (works under both node and bun) so the bundled
+ * agent-scheduler runs identically inside the agent container
+ * regardless of which runtime supervises it.
+ *
+ * Trust model: the gateway socket lives at a per-agent path inside
+ * the agent container (default `${TELEGRAM_STATE_DIR}/gateway.sock`,
+ * overridable via `SWITCHROOM_GATEWAY_SOCKET`). Only processes
+ * inside this container's network namespace can connect — the
+ * scheduler runs as a sibling of the gateway under the same agent
+ * UID, so peer authentication is the container boundary itself.
+ */
+
+import { createConnection, type Socket } from "node:net";
+import type { InjectInboundMessage } from "../../telegram-plugin/gateway/ipc-protocol.js";
+
+export interface InjectIpcClientOptions {
+  socketPath: string;
+  /** Initial reconnect delay in ms; doubles up to maxReconnectDelayMs. */
+  reconnectDelayMs?: number;
+  maxReconnectDelayMs?: number;
+  /**
+   * Connect attempt timeout in ms. Default 5_000. The gateway boots in
+   * the same container's start.sh preamble; if it isn't up after 5s,
+   * it's not coming up on its own — the supervisor wrapper around the
+   * scheduler will respawn the whole process.
+   */
+  connectTimeoutMs?: number;
+  log?: (msg: string) => void;
+  /**
+   * Test seam — replace `createConnection`. Default uses node:net.
+   * Tests pass a fake that returns a Socket-shaped object with
+   * `.write`, `.end`, and the `connect` / `close` / `error` events.
+   */
+  _connect?: (socketPath: string) => Socket;
+}
+
+export interface InjectIpcClient {
+  /**
+   * Send an inject_inbound envelope. Returns true if the bytes were
+   * accepted by the local socket (which is the strongest delivery
+   * signal a fire-and-forget client gets); false when not connected
+   * or the write fails.
+   */
+  sendInjectInbound(msg: InjectInboundMessage): boolean;
+  isConnected(): boolean;
+  close(): void;
+}
+
+export function createInjectIpcClient(
+  options: InjectIpcClientOptions,
+): InjectIpcClient {
+  const {
+    socketPath,
+    reconnectDelayMs = 1_000,
+    maxReconnectDelayMs = 30_000,
+    connectTimeoutMs = 5_000,
+    log = () => {},
+    _connect = (path) => createConnection(path),
+  } = options;
+
+  let socket: Socket | null = null;
+  let connected = false;
+  let closed = false;
+  let currentDelay = reconnectDelayMs;
+  let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  let connectTimeoutTimer: ReturnType<typeof setTimeout> | null = null;
+
+  function clearConnectTimeout(): void {
+    if (connectTimeoutTimer !== null) {
+      clearTimeout(connectTimeoutTimer);
+      connectTimeoutTimer = null;
+    }
+  }
+
+  function clearReconnectTimer(): void {
+    if (reconnectTimer !== null) {
+      clearTimeout(reconnectTimer);
+      reconnectTimer = null;
+    }
+  }
+
+  function scheduleReconnect(): void {
+    if (closed) return;
+    log(`scheduler ipc: reconnecting in ${currentDelay}ms`);
+    reconnectTimer = setTimeout(() => {
+      reconnectTimer = null;
+      if (!closed) connect();
+    }, currentDelay);
+    currentDelay = Math.min(currentDelay * 2, maxReconnectDelayMs);
+  }
+
+  function onClose(): void {
+    clearConnectTimeout();
+    connected = false;
+    socket = null;
+    if (!closed) scheduleReconnect();
+  }
+
+  function connect(): void {
+    if (closed) return;
+    let s: Socket;
+    try {
+      s = _connect(socketPath);
+    } catch (err) {
+      log(`scheduler ipc: connect threw: ${(err as Error).message}`);
+      scheduleReconnect();
+      return;
+    }
+    socket = s;
+
+    connectTimeoutTimer = setTimeout(() => {
+      connectTimeoutTimer = null;
+      if (!connected) {
+        log(`scheduler ipc: connect timeout after ${connectTimeoutMs}ms`);
+        try { s.destroy(); } catch { /* nothing to do */ }
+      }
+    }, connectTimeoutMs);
+
+    s.on("connect", () => {
+      clearConnectTimeout();
+      connected = true;
+      currentDelay = reconnectDelayMs;
+      log(`scheduler ipc: connected to ${socketPath}`);
+    });
+    s.on("close", () => onClose());
+    s.on("error", (err) => {
+      log(`scheduler ipc: socket error: ${err.message}`);
+      // 'close' fires after 'error', so onClose handles reconnect.
+    });
+    // The scheduler doesn't process inbound bytes — drain any to keep
+    // the kernel buffer from filling. The gateway never replies to
+    // inject_inbound, so this is just defence in depth.
+    s.on("data", () => { /* discard */ });
+  }
+
+  // Kick off the first connect attempt asynchronously so the caller
+  // can install the cron handlers before the connection goes live.
+  setImmediate(connect);
+
+  return {
+    sendInjectInbound(msg: InjectInboundMessage): boolean {
+      if (!socket || !connected) return false;
+      try {
+        return socket.write(JSON.stringify(msg) + "\n");
+      } catch (err) {
+        log(`scheduler ipc: write failed: ${(err as Error).message}`);
+        return false;
+      }
+    },
+    isConnected(): boolean {
+      return connected;
+    },
+    close(): void {
+      closed = true;
+      clearReconnectTimer();
+      clearConnectTimeout();
+      if (socket) {
+        try { socket.end(); } catch { /* nothing to do */ }
+        socket = null;
+      }
+      connected = false;
+    },
+  };
+}

--- a/src/build-info.ts
+++ b/src/build-info.ts
@@ -3,7 +3,7 @@
 // Values are refreshed every time `npm run build` runs.
 
 export const VERSION: string = "0.7.7";
-export const COMMIT_SHA: string | null = "5a33e6cb";
-export const COMMIT_DATE: string | null = "2026-05-10T08:31:23+10:00";
-export const LATEST_PR: number | null = 888;
-export const COMMITS_AHEAD_OF_TAG: number | null = 5;
+export const COMMIT_SHA: string | null = "3e7edccc";
+export const COMMIT_DATE: string | null = "2026-05-10T09:12:48+10:00";
+export const LATEST_PR: number | null = 890;
+export const COMMITS_AHEAD_OF_TAG: number | null = 7;

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -230,6 +230,7 @@ import type {
   OperatorEventForward,
   PtyPartialForward,
   InboundMessage,
+  InjectInboundMessage,
 } from './ipc-protocol.js'
 import { writePidFile, clearPidFile } from './pid-file.js'
 import { acquireStartupLock, releaseStartupLock } from './startup-mutex.js'
@@ -2331,6 +2332,31 @@ const ipcServer: IpcServer = createIpcServer({
    */
   onPtyPartial(_client: IpcClient, msg: PtyPartialForward) {
     handlePtyPartial(msg.text)
+  },
+
+  /**
+   * Phase 2 cron-fold-in: forward a synthesized inbound from the
+   * in-agent scheduler sibling to the registered bridge for the
+   * named agent. The wrapped `inbound` envelope is shipped verbatim
+   * — the in-agent scheduler is the synthesis authority (it runs
+   * `dispatchAsInbound` from `src/scheduler/dispatch.ts` to build
+   * the message). The gateway only validates wire shape (handled
+   * in ipc-server.ts:validateClientMessage) and routes.
+   *
+   * Logs every fire so an operator can correlate the agent's
+   * transcript turn against the scheduler's audit row by `prompt_key`.
+   */
+  onInjectInbound(_client: IpcClient, msg: InjectInboundMessage) {
+    const promptKey = typeof msg.inbound.meta?.prompt_key === 'string'
+      ? msg.inbound.meta.prompt_key
+      : 'unknown'
+    const source = typeof msg.inbound.meta?.source === 'string'
+      ? msg.inbound.meta.source
+      : 'unknown'
+    const delivered = ipcServer.sendToAgent(msg.agentName, msg.inbound)
+    process.stderr.write(
+      `telegram gateway: inject_inbound agent=${msg.agentName} source=${source} prompt_key=${promptKey} delivered=${delivered}\n`,
+    )
   },
 
   log: (msg) => process.stderr.write(`telegram gateway: ipc — ${msg}\n`),

--- a/telegram-plugin/gateway/ipc-protocol.ts
+++ b/telegram-plugin/gateway/ipc-protocol.ts
@@ -139,6 +139,38 @@ export interface UpdatePlaceholderMessage {
   text: string;
 }
 
+/**
+ * Phase 2 cron-fold-in: a privileged client (the in-agent scheduler
+ * sibling, supervised by start.sh under SWITCHROOM_INLINE_SCHEDULER=1)
+ * sends this to the gateway to inject a synthesized turn into the
+ * agent's bridge. The gateway forwards the embedded `inbound` envelope
+ * verbatim via `ipcServer.sendToAgent(agentName, inbound)`.
+ *
+ * Why a separate envelope rather than a direct inbound on the wire:
+ *   1. ClientToGateway and GatewayToClient are distinct directions.
+ *      A client cannot send a `type: "inbound"` message — that's a
+ *      gateway→client envelope. The bridge's validateGatewayMessage
+ *      is its security boundary, and the gateway's validateClientMessage
+ *      is the parallel boundary on this side. Wrapping in
+ *      `inject_inbound` keeps both validators sharp on their own
+ *      direction.
+ *   2. The gateway is *deciding* to forward — a future scope check
+ *      (e.g., reject inbounds whose `meta.source` is not in a known
+ *      set, rate-limit per sender) lives naturally at the gateway.
+ *
+ * Trust model: the gateway socket lives at a per-agent path inside
+ * the agent container; only processes inside that container can
+ * connect. `inject_inbound` is therefore as trusted as any other
+ * process running under that agent's UID.
+ */
+export interface InjectInboundMessage {
+  type: "inject_inbound";
+  /** Target agent name — the gateway routes via sendToAgent. */
+  agentName: string;
+  /** Forwarded verbatim to the bridge as a `type: "inbound"` envelope. */
+  inbound: InboundMessage;
+}
+
 export type ClientToGateway =
   | RegisterMessage
   | ToolCallMessage
@@ -148,4 +180,5 @@ export type ClientToGateway =
   | ScheduleRestartMessage
   | OperatorEventForward
   | PtyPartialForward
-  | UpdatePlaceholderMessage;
+  | UpdatePlaceholderMessage
+  | InjectInboundMessage;

--- a/telegram-plugin/gateway/ipc-server.ts
+++ b/telegram-plugin/gateway/ipc-server.ts
@@ -3,6 +3,7 @@ import type {
   ClientToGateway,
   GatewayToClient,
   HeartbeatMessage,
+  InjectInboundMessage,
   OperatorEventForward,
   PermissionRequestForward,
   PtyPartialForward,
@@ -30,6 +31,15 @@ export interface IpcServerOptions {
    * messages will be silently dropped at dispatch.
    */
   onPtyPartial?: (client: IpcClient, msg: PtyPartialForward) => void;
+  /**
+   * Phase 2 cron-fold-in: invoked when a privileged in-container client
+   * (the agent-scheduler sibling) asks the gateway to forward a
+   * synthesized InboundMessage to a registered bridge. The handler is
+   * expected to call `ipcServer.sendToAgent(msg.agentName, msg.inbound)`
+   * (or its own equivalent). Optional: gateways that don't run the
+   * inline scheduler simply ignore inject_inbound messages.
+   */
+  onInjectInbound?: (client: IpcClient, msg: InjectInboundMessage) => void;
   log?: (msg: string) => void;
   /**
    * How long (in ms) to wait without a heartbeat before force-closing the
@@ -161,6 +171,27 @@ export function validateClientMessage(msg: unknown): msg is ClientToGateway {
       // ipc-protocol.ts for context.
       return typeof m.chatId === "string" && (m.chatId as string).length > 0
         && typeof m.text === "string" && (m.text as string).length <= 8192;
+    case "inject_inbound": {
+      // Phase 2 cron-fold-in. The wrapped `inbound` is forwarded
+      // verbatim to the bridge as a `type: "inbound"` envelope, so
+      // we validate the same fields the bridge's
+      // validateGatewayMessage cares about (`chatId`, `text`) plus
+      // the basic structural shape every InboundMessage carries.
+      if (typeof m.agentName !== "string"
+        || !AGENT_NAME_RE.test(m.agentName as string)) return false;
+      if (typeof m.inbound !== "object" || m.inbound === null) return false;
+      const inb = m.inbound as Record<string, unknown>;
+      return inb.type === "inbound"
+        && typeof inb.chatId === "string"
+        && (inb.chatId as string).length > 0
+        && typeof inb.text === "string"
+        && typeof inb.messageId === "number"
+        && typeof inb.user === "string"
+        && typeof inb.userId === "number"
+        && typeof inb.ts === "number"
+        && typeof inb.meta === "object"
+        && inb.meta !== null;
+    }
     default:
       return false;
   }
@@ -178,6 +209,7 @@ export function createIpcServer(options: IpcServerOptions): IpcServer {
     onScheduleRestart,
     onOperatorEvent,
     onPtyPartial,
+    onInjectInbound,
     log = () => {},
     heartbeatTimeoutMs = 30_000,
   } = options;
@@ -262,6 +294,9 @@ export function createIpcServer(options: IpcServerOptions): IpcServer {
         break;
       case "pty_partial":
         if (onPtyPartial) onPtyPartial(client, msg as PtyPartialForward);
+        break;
+      case "inject_inbound":
+        if (onInjectInbound) onInjectInbound(client, msg as InjectInboundMessage);
         break;
       case "update_placeholder":
         // Legacy recall.py IPC — placeholder UX was removed in #553 PR 5.

--- a/telegram-plugin/tests/ipc-server-validate-inject-inbound.test.ts
+++ b/telegram-plugin/tests/ipc-server-validate-inject-inbound.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Validation contract for the Phase 2 cron-fold-in `inject_inbound`
+ * IPC message — the wire envelope the in-agent scheduler sibling
+ * uses to ask the gateway to forward a synthesized InboundMessage to
+ * a registered bridge.
+ *
+ * The gateway's `validateClientMessage` is the security boundary on
+ * the client→gateway direction. The wrapped `inbound` payload is
+ * forwarded verbatim to the bridge as a `type: "inbound"` envelope —
+ * the bridge's validateGatewayMessage runs on the other end and is
+ * lenient (only checks `chatId` + `text`), so this validator carries
+ * the structural checks the bridge silently relies on.
+ *
+ * Companion to ipc-server-validate-{operator,pty-partial,update-placeholder}.test.ts.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { validateClientMessage } from '../gateway/ipc-server.js'
+
+function baseInbound() {
+  return {
+    type: 'inbound' as const,
+    chatId: '-1001234567890',
+    messageId: 1_700_000_000_000,
+    user: 'cron',
+    userId: 0,
+    ts: 1_700_000_000_000,
+    text: 'Morning briefing',
+    meta: {
+      source: 'cron',
+      schedule_index: '0',
+      prompt_key: 'abcdef012345',
+    },
+  }
+}
+
+function base() {
+  return {
+    type: 'inject_inbound' as const,
+    agentName: 'klanker',
+    inbound: baseInbound(),
+  }
+}
+
+describe('validateClientMessage — inject_inbound', () => {
+  it('accepts a well-formed cron fire', () => {
+    expect(validateClientMessage(base())).toBe(true)
+  })
+
+  it('rejects when agentName is missing or malformed', () => {
+    const noName = { ...base() } as Record<string, unknown>
+    delete noName.agentName
+    expect(validateClientMessage(noName)).toBe(false)
+    expect(validateClientMessage({ ...base(), agentName: '' })).toBe(false)
+    // Same regex as register/heartbeat — uppercase rejected.
+    expect(validateClientMessage({ ...base(), agentName: 'Klanker' })).toBe(false)
+    // Path traversal / shell metacharacters rejected.
+    expect(validateClientMessage({ ...base(), agentName: '../etc/passwd' })).toBe(false)
+    expect(validateClientMessage({ ...base(), agentName: 'a$(rm -rf)' })).toBe(false)
+    expect(validateClientMessage({ ...base(), agentName: 42 })).toBe(false)
+  })
+
+  it('rejects when inbound is not an object', () => {
+    expect(validateClientMessage({ ...base(), inbound: null })).toBe(false)
+    expect(validateClientMessage({ ...base(), inbound: 'string' })).toBe(false)
+    expect(validateClientMessage({ ...base(), inbound: 42 })).toBe(false)
+    const noInbound = { ...base() } as Record<string, unknown>
+    delete noInbound.inbound
+    expect(validateClientMessage(noInbound)).toBe(false)
+  })
+
+  it("requires inbound.type === 'inbound'", () => {
+    expect(validateClientMessage({
+      ...base(),
+      inbound: { ...baseInbound(), type: 'permission' },
+    })).toBe(false)
+    expect(validateClientMessage({
+      ...base(),
+      inbound: { ...baseInbound(), type: 'Inbound' },
+    })).toBe(false)
+  })
+
+  it('requires non-empty inbound.chatId (string) and string inbound.text', () => {
+    expect(validateClientMessage({
+      ...base(),
+      inbound: { ...baseInbound(), chatId: '' },
+    })).toBe(false)
+    expect(validateClientMessage({
+      ...base(),
+      inbound: { ...baseInbound(), chatId: 42 },
+    })).toBe(false)
+    expect(validateClientMessage({
+      ...base(),
+      inbound: { ...baseInbound(), text: 42 },
+    })).toBe(false)
+  })
+
+  it('requires numeric messageId, userId, ts (the bridge does not coerce)', () => {
+    expect(validateClientMessage({
+      ...base(),
+      inbound: { ...baseInbound(), messageId: '0' },
+    })).toBe(false)
+    expect(validateClientMessage({
+      ...base(),
+      inbound: { ...baseInbound(), userId: '0' },
+    })).toBe(false)
+    expect(validateClientMessage({
+      ...base(),
+      inbound: { ...baseInbound(), ts: '0' },
+    })).toBe(false)
+  })
+
+  it('requires meta to be an object (Record<string, string> on the wire)', () => {
+    expect(validateClientMessage({
+      ...base(),
+      inbound: { ...baseInbound(), meta: null },
+    })).toBe(false)
+    const noMeta = { ...baseInbound() } as Record<string, unknown>
+    delete noMeta.meta
+    expect(validateClientMessage({ ...base(), inbound: noMeta })).toBe(false)
+    // Empty meta is acceptable — the gateway doesn't enforce specific keys
+    // here; meta.source filtering is policy that lives at the handler.
+    expect(validateClientMessage({
+      ...base(),
+      inbound: { ...baseInbound(), meta: {} },
+    })).toBe(true)
+  })
+
+  it('rejects unknown type aliases that look similar', () => {
+    expect(validateClientMessage({ ...base(), type: 'inject_inbounds' })).toBe(false)
+    expect(validateClientMessage({ ...base(), type: 'inject-inbound' })).toBe(false)
+    expect(validateClientMessage({ ...base(), type: 'inbound' })).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary

Phase 2 of folding the singleton `switchroom-cron` container into per-agent sidecars. Adds the in-container infrastructure but leaves it **opt-in via `SWITCHROOM_INLINE_SCHEDULER=1`** — the host-side singleton still runs and is the active dispatcher. Phase 3 adds the canary flag + dual-run dedup; Phase 4 deletes the singleton.

## What's in this PR

**Wire protocol (telegram-plugin/gateway/)**
- New `inject_inbound` ClientToGateway message wrapping an `InboundMessage`. Required because the in-agent scheduler is a *client* of the gateway and cannot emit `type: "inbound"` directly (that's a gateway→client envelope).
- `validateClientMessage` gains a tight schema check on the wrapped inbound — covers the structural fields the bridge's `validateGatewayMessage` silently relies on but doesn't re-validate.
- gateway.ts `onInjectInbound` logs every fire (agent + source + prompt_key + delivered).

**Agent-scheduler (`src/agent-scheduler/`)**
- `index.ts` — `registerAgentSchedule` + `main()`. Filters by `SWITCHROOM_AGENT_NAME`, registers entries with node-cron, on fire calls `dispatchAsInbound` (Phase 1) and sends `inject_inbound`.
- `ipc-client.ts` — minimal NDJSON-over-unix-socket client (node:net). No heartbeats, no receive loop — just connect + write + auto-reconnect.
- 12 unit cases across 2 test files: cron path, delivered=false → exit_code=-1, dispatcher-throws survives next fire, channel resolution, IPC reconnect, close() prevents reconnects.

**Audit shape mirrors host-side `DispatchResult`** so Phase 3's audit-parity check is a column-for-column equality. `exit_code` semantics: `0` = bytes accepted by local gateway socket; `-1` = gateway not connected / write failed / dispatcher threw.

**Container integration**
- `docker/Dockerfile.agent` — copies `dist/agent-scheduler/index.js` and `npm install node-cron@^3.0.3` at the same path.
- `profiles/_base/start.sh.hbs` — third `_switchroom_supervise` block (after gateway + autoaccept-poll), gated by `SWITCHROOM_INLINE_SCHEDULER=1`.
- `scripts/build.mjs` — adds the bundle entry with `--external node-cron`.

## What stays unchanged

- `compose.ts` — the `switchroom-cron` singleton block is untouched. Phase 3 adds the env-var dispatch filter; Phase 4 deletes it.
- `schedule:` YAML — user-facing config is unchanged across all four phases.
- Bridge code — same `InboundMessage` envelope. `meta.source="cron"` passes through; the rendering hard-codes `source="switchroom-telegram"` today (small follow-up flagged by the Phase 1 reviewer; not on the cutover critical path).

## Test plan

- [x] `npx vitest run src/agent-scheduler/ src/scheduler/ telegram-plugin/tests/ipc-server-validate-inject-inbound.test.ts` → 28 passed, 1 skipped
- [x] `npm run lint` → clean
- [x] `npm run test:vitest` → 5154 passed, 31 skipped (full suite)
- [x] `npm run build` → `dist/agent-scheduler/index.js` emits (412 KB, 89 modules)
- [x] `npm run test:bun` → 20 pre-existing vault-broker env failures (also fail on `main`; unrelated to this PR)
- [ ] Reviewer agent: APPROVE / REQUEST_CHANGES / BLOCK

## For the reviewer

Two design decisions worth confirming:
1. **Wrapped envelope vs. shared inbound.** The Phase 1 brief said "do not invent a cron-fire type" — this PR doesn't (the bridge still gets a plain `InboundMessage`). What's new is the *client→gateway* wire shape (`inject_inbound`), which is required because client→gateway and gateway→client are distinct directions in the validator. See the doc-comment on `InjectInboundMessage` in `ipc-protocol.ts` for the full reasoning.
2. **Audit shape parity.** The in-agent scheduler writes a `DispatchResult` row that's structurally identical to the singleton's, with `exitCode` repurposed to mean "delivered to gateway socket" rather than "claude -p exit code". Phase 3 needs this to be a one-to-one comparison.

🤖 Generated with [Claude Code](https://claude.com/claude-code)