### PR TITLE
feat(scheduler): Phase 3 — canary dual-run + mutual exclusion

### DIFF
--- a/src/agent-scheduler/index.ts
+++ b/src/agent-scheduler/index.ts
@@ -40,6 +40,7 @@ import {
   createInjectIpcClient,
   type InjectIpcClient,
 } from "./ipc-client.js";
+import { acquireLock, releaseLock } from "./lock.js";
 
 /**
  * Minimum node-cron-shaped surface — same as the host scheduler. The
@@ -191,6 +192,23 @@ export async function main(): Promise<void> {
     ?? join(stateDir, "gateway.sock");
   const jsonlPath = process.env.SWITCHROOM_AGENT_SCHEDULER_JSONL
     ?? "/state/agent/scheduler.jsonl";
+  const lockPath = process.env.SWITCHROOM_AGENT_SCHEDULER_LOCK
+    ?? "/state/agent/scheduler.lock";
+
+  // Phase 3 belt-and-braces dedup: refuse to start if another
+  // agent-scheduler is already running. start.sh's
+  // `_switchroom_supervise` only respawns after the previous instance
+  // exits, so this catches operator-launched second instances and
+  // mis-configured supervisors. Stale-lock detection lives in
+  // acquireLock — see the doc-comment there.
+  const lock = acquireLock(lockPath);
+  if (!lock.acquired) {
+    process.stderr.write(
+      `agent-scheduler: ${agentName} lock at ${lockPath} held by pid ` +
+      `${lock.holderPid ?? "unknown"} — exiting\n`,
+    );
+    process.exit(75); // EX_TEMPFAIL — the supervisor's restart cap handles repeated failures
+  }
 
   const config = loadConfig(configPath);
   const allEntries = collectScheduleEntries(config);
@@ -244,6 +262,7 @@ export async function main(): Promise<void> {
     for (const t of tasks) t.task.stop();
     sink.close();
     ipcClient.close();
+    releaseLock(lockPath);
     process.exit(0);
   };
   process.on("SIGTERM", shutdown);

--- a/src/agent-scheduler/lock.test.ts
+++ b/src/agent-scheduler/lock.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Unit tests for the agent-scheduler lockfile (Phase 3 dual-run dedup).
+ *
+ * Properties:
+ *   - first acquire creates the file with the calling pid
+ *   - second acquire while live returns acquired=false + holderPid
+ *   - second acquire after the holder exits removes the stale lock
+ *     and succeeds (one retry built in)
+ *   - release is idempotent (missing file is fine)
+ */
+
+import { afterEach, beforeEach, describe, it, expect } from "vitest";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { acquireLock, releaseLock } from "./lock.js";
+
+let tmp: string;
+
+beforeEach(() => {
+  tmp = mkdtempSync(join(tmpdir(), "agent-scheduler-lock-"));
+});
+
+afterEach(() => {
+  rmSync(tmp, { recursive: true, force: true });
+});
+
+describe("acquireLock / releaseLock", () => {
+  it("acquires when no lockfile exists and writes the calling pid", () => {
+    const path = join(tmp, "scheduler.lock");
+    const result = acquireLock(path, 12345);
+    expect(result.acquired).toBe(true);
+    expect(readFileSync(path, "utf8").trim()).toBe("12345");
+  });
+
+  it("refuses to acquire when held by a live process", () => {
+    const path = join(tmp, "scheduler.lock");
+    // The current test process IS alive — write our own pid in.
+    writeFileSync(path, String(process.pid));
+    const result = acquireLock(path);
+    expect(result.acquired).toBe(false);
+    expect(result.holderPid).toBe(process.pid);
+  });
+
+  it("clears a stale lock (PID no longer exists) and acquires on retry", () => {
+    const path = join(tmp, "scheduler.lock");
+    // Pick a pid that's almost certainly not alive — high enough to
+    // exceed any plausible recent fork, low enough to be valid.
+    // process.kill(pid, 0) raises ESRCH, which acquireLock treats
+    // as stale.
+    writeFileSync(path, "999999");
+    const result = acquireLock(path, 7777);
+    expect(result.acquired).toBe(true);
+    expect(readFileSync(path, "utf8").trim()).toBe("7777");
+  });
+
+  it("clears a garbage lockfile (non-numeric content) and acquires", () => {
+    const path = join(tmp, "scheduler.lock");
+    writeFileSync(path, "not-a-number\n");
+    const result = acquireLock(path, 4242);
+    expect(result.acquired).toBe(true);
+    expect(readFileSync(path, "utf8").trim()).toBe("4242");
+  });
+
+  it("creates the parent directory if missing", () => {
+    const path = join(tmp, "nested", "deeper", "scheduler.lock");
+    const result = acquireLock(path, 1);
+    expect(result.acquired).toBe(true);
+    expect(existsSync(path)).toBe(true);
+  });
+
+  it("releaseLock removes the file", () => {
+    const path = join(tmp, "scheduler.lock");
+    acquireLock(path, 1);
+    expect(existsSync(path)).toBe(true);
+    releaseLock(path);
+    expect(existsSync(path)).toBe(false);
+  });
+
+  it("releaseLock is idempotent (missing file is fine)", () => {
+    const path = join(tmp, "no-such.lock");
+    expect(() => releaseLock(path)).not.toThrow();
+  });
+});

--- a/src/agent-scheduler/lock.ts
+++ b/src/agent-scheduler/lock.ts
@@ -23,6 +23,29 @@
  * Lifecycle: caller invokes `acquire(path)` at startup; on graceful
  * shutdown calls `release(path)`. Hard kill (SIGKILL) leaves the
  * pidfile behind, but the next start's stale-PID detection clears it.
+ *
+ * Known limitation — PID reuse across container restarts. The lockfile
+ * lives on the bind-mounted /state/agent path so it survives a hard
+ * container kill. Inside an agent container PID density is low (tini=1,
+ * supervised siblings in single digits), so after SIGKILL leaves a
+ * pidfile pointing at, say, PID 23, the new container generation may
+ * have a sibling at PID 23 — `kill(23, 0)` succeeds, the new
+ * agent-scheduler exits with EX_TEMPFAIL, and the supervisor restarts
+ * it until something inside the container churns enough to free that
+ * PID. Bounded by the supervisor's restart-cap (10 in 60s), after
+ * which the supervisor gives up — and because the singleton has been
+ * filtered to skip this agent (mutual exclusion), cron tasks for it
+ * stop firing from EITHER path until the operator intervenes (e.g.
+ * `switchroom agent restart <name>` once, which clears the in-memory
+ * supervisor state).
+ *
+ * Phase 4 follow-up: add a boot-time freshness check by reading PID
+ * 1's start time from /proc/1/stat (field 22, starttime in clock-
+ * ticks since boot) plus btime from /proc/stat, and treat lockfiles
+ * older than that as stale regardless of PID liveness. Not done in
+ * Phase 3 because the post-cap missed-cron window is bounded by the
+ * canary observation period — by the time we'd hit it in production,
+ * Phase 4 will have shipped the fix or rolled back the canary.
  */
 
 import {

--- a/src/agent-scheduler/lock.ts
+++ b/src/agent-scheduler/lock.ts
@@ -1,0 +1,119 @@
+/**
+ * Pidfile-based lock for the in-agent scheduler. Belt-and-braces dedup
+ * — start.sh's `_switchroom_supervise` wrapper is structurally
+ * single-instance (it only respawns AFTER the previous process exits),
+ * so the lock is a safety net against an operator launching a second
+ * `bun /opt/switchroom/agent-scheduler/index.js` by hand.
+ *
+ * Why pidfile instead of flock(2):
+ *   - Node's stdlib has no portable flock binding. Going through a
+ *     native module (or fork-and-flock) for one safety check inflates
+ *     blast radius.
+ *   - The agent-scheduler always runs in a Linux container with a
+ *     local writable /state/agent — pidfile-with-liveness-check
+ *     covers every realistic failure mode (stale lock from a previous
+ *     hard kill, double-supervisor accident).
+ *
+ * The acquire flow uses O_CREAT|O_EXCL to make the create atomic. On
+ * EEXIST we read the holder PID and probe with `kill(pid, 0)`:
+ *   - process is alive → exit; the supervised parent will not respawn
+ *     a second instance because we exit non-zero with a stable code.
+ *   - process is dead → stale lock; remove and retry once.
+ *
+ * Lifecycle: caller invokes `acquire(path)` at startup; on graceful
+ * shutdown calls `release(path)`. Hard kill (SIGKILL) leaves the
+ * pidfile behind, but the next start's stale-PID detection clears it.
+ */
+
+import {
+  closeSync,
+  openSync,
+  readFileSync,
+  unlinkSync,
+  writeSync,
+  mkdirSync,
+} from "node:fs";
+import { dirname } from "node:path";
+
+export interface LockResult {
+  /** True when the caller now holds the lock. */
+  acquired: boolean;
+  /** When `acquired === false`, the live PID currently holding it. */
+  holderPid?: number;
+}
+
+/**
+ * Try to acquire the lockfile. Returns `{acquired: true}` on success.
+ * On contention, returns `{acquired: false, holderPid}` — the caller
+ * decides whether to exit or wait. The standard switchroom pattern is
+ * "exit with EX_TEMPFAIL (75)" so the supervisor's restart-cap kicks
+ * in instead of tight-looping.
+ *
+ * One stale-lock retry is built in: if the existing pidfile points at
+ * a process that's no longer alive, the lock is removed and we try
+ * once more. After that, we report contention (defensive — should
+ * never happen in practice, but the loop is bounded).
+ */
+export function acquireLock(
+  path: string,
+  pid: number = process.pid,
+): LockResult {
+  // mkdir -p the parent so a fresh /state/agent doesn't trip us up.
+  try { mkdirSync(dirname(path), { recursive: true, mode: 0o700 }); } catch {
+    // mkdir failures are surfaced by the open() that follows.
+  }
+  for (let attempt = 0; attempt < 2; attempt++) {
+    try {
+      const fd = openSync(path, "wx", 0o600);
+      try {
+        writeSync(fd, String(pid));
+      } finally {
+        closeSync(fd);
+      }
+      return { acquired: true };
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== "EEXIST") throw err;
+    }
+    // EEXIST — read the holder PID and probe.
+    let holderPid: number | undefined;
+    try {
+      const raw = readFileSync(path, "utf8").trim();
+      const parsed = Number.parseInt(raw, 10);
+      if (Number.isInteger(parsed) && parsed > 0) holderPid = parsed;
+    } catch {
+      // Unreadable pidfile is nonsense; remove and retry.
+      try { unlinkSync(path); } catch { /* nothing to do */ }
+      continue;
+    }
+    if (holderPid === undefined) {
+      try { unlinkSync(path); } catch { /* nothing to do */ }
+      continue;
+    }
+    // signal 0 = liveness probe (no signal sent, only checks
+    // existence + permission to send). ESRCH = no such pid.
+    try {
+      process.kill(holderPid, 0);
+      return { acquired: false, holderPid };
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "ESRCH") {
+        // Stale — remove and try the create one more time.
+        try { unlinkSync(path); } catch { /* nothing to do */ }
+        continue;
+      }
+      // EPERM means the PID exists but we can't signal it (different
+      // user). Treat as held — refusing is safer than colliding.
+      return { acquired: false, holderPid };
+    }
+  }
+  return { acquired: false };
+}
+
+/**
+ * Best-effort lock release. Idempotent: missing pidfile is fine.
+ * The caller is responsible for not removing a pidfile they don't
+ * own (we don't double-check the PID inside on release because the
+ * only legitimate caller is the same process that acquired it).
+ */
+export function releaseLock(path: string): void {
+  try { unlinkSync(path); } catch { /* nothing to do */ }
+}

--- a/src/agents/compose.ts
+++ b/src/agents/compose.ts
@@ -184,6 +184,16 @@ interface AgentServiceData {
   resources: ResourceDefaults;
   /** Capability extras the operator requested AND we stripped. */
   strippedCaps: string[];
+  /**
+   * Phase 3 canary flag. True when the cascade-resolved
+   * `experimental.inline_scheduler` is true — compose emits
+   * SWITCHROOM_INLINE_SCHEDULER=1 in the agent container's env so
+   * start.sh starts the in-container scheduler sibling, AND the
+   * singleton scheduler's collectScheduleEntries skips this agent
+   * (mutual exclusion: we never dual-fire). False (default) keeps
+   * the agent on the singleton dispatcher.
+   */
+  inlineScheduler: boolean;
 }
 
 /** Per-agent metadata exposed to doctor checks (and tests). */
@@ -196,8 +206,8 @@ export function describeAgents(config: SwitchroomConfig): AgentServiceData[] {
     const uid = allocateAgentUid(name);
     const resources = resolveResourceDefaults(name, profile);
     const strippedCaps = readStrippedCaps(agent);
-    out.push({ name, uid, profile, resources, strippedCaps });
-    void resolved;
+    const inlineScheduler = resolved.experimental?.inline_scheduler === true;
+    out.push({ name, uid, profile, resources, strippedCaps, inlineScheduler });
   }
   return out;
 }
@@ -537,6 +547,16 @@ function emitAgentService(
   // Same env+mount pattern broker/kernel/scheduler already use.
   if (switchroomConfigPath) {
     env.SWITCHROOM_CONFIG = "/state/config/switchroom.yaml";
+  }
+  // Phase 3 cron-fold-in canary. When experimental.inline_scheduler is
+  // true on this agent, set the env var so start.sh's third supervised
+  // sidecar (the agent-scheduler bundle, gated by the same env var)
+  // starts on boot. Mutual-exclusion with the singleton is enforced on
+  // the OTHER side: src/scheduler/index.ts:main() reads the same
+  // resolved config field and skips entries for agents where it's true,
+  // so we never dual-fire.
+  if (a.inlineScheduler) {
+    env.SWITCHROOM_INLINE_SCHEDULER = "1";
   }
   for (const k of Object.keys(env).sort()) {
     lines.push(`      ${k}: ${JSON.stringify(env[k])}`);

--- a/src/agents/compose.ts
+++ b/src/agents/compose.ts
@@ -552,9 +552,10 @@ function emitAgentService(
   // true on this agent, set the env var so start.sh's third supervised
   // sidecar (the agent-scheduler bundle, gated by the same env var)
   // starts on boot. Mutual-exclusion with the singleton is enforced on
-  // the OTHER side: src/scheduler/index.ts:main() reads the same
-  // resolved config field and skips entries for agents where it's true,
-  // so we never dual-fire.
+  // the OTHER side: src/scheduler/index.ts:main() calls
+  // `filterForSingleton(collectScheduleEntries(config), config)` to
+  // drop entries for inline-scheduled agents before registering its
+  // cron loop, so we never dual-fire.
   if (a.inlineScheduler) {
     env.SWITCHROOM_INLINE_SCHEDULER = "1";
   }

--- a/src/build-info.ts
+++ b/src/build-info.ts
@@ -3,7 +3,7 @@
 // Values are refreshed every time `npm run build` runs.
 
 export const VERSION: string = "0.7.7";
-export const COMMIT_SHA: string | null = "97a623f5";
-export const COMMIT_DATE: string | null = "2026-05-10T09:34:21+10:00";
-export const LATEST_PR: number | null = 891;
-export const COMMITS_AHEAD_OF_TAG: number | null = 8;
+export const COMMIT_SHA: string | null = "e249dd21";
+export const COMMIT_DATE: string | null = "2026-05-10T09:42:55+10:00";
+export const LATEST_PR: number | null = null;
+export const COMMITS_AHEAD_OF_TAG: number | null = 9;

--- a/src/build-info.ts
+++ b/src/build-info.ts
@@ -3,7 +3,7 @@
 // Values are refreshed every time `npm run build` runs.
 
 export const VERSION: string = "0.7.7";
-export const COMMIT_SHA: string | null = "3e7edccc";
-export const COMMIT_DATE: string | null = "2026-05-10T09:12:48+10:00";
-export const LATEST_PR: number | null = 890;
-export const COMMITS_AHEAD_OF_TAG: number | null = 7;
+export const COMMIT_SHA: string | null = "97a623f5";
+export const COMMIT_DATE: string | null = "2026-05-10T09:34:21+10:00";
+export const LATEST_PR: number | null = 891;
+export const COMMITS_AHEAD_OF_TAG: number | null = 8;

--- a/src/config/merge.ts
+++ b/src/config/merge.ts
@@ -583,6 +583,31 @@ export function mergeAgentConfig(
     merged.extra_stable_files = dedupe([...d, ...a]);
   }
 
+  // --- experimental: shallow per-key merge, agent wins ---
+  //
+  // The schema declares `experimental` at every cascade layer
+  // (defaults / profile / per-agent) and the descriptions promise
+  // "Cascades through defaults → profile → per-agent." Without an
+  // explicit clause here the merger silently dropped the defaults
+  // and profile layers — operators who set `experimental.*` at
+  // those layers got undefined behaviour at the resolved tip.
+  //
+  // Phase 3 cron-fold-in surfaced this for `inline_scheduler`: the
+  // canary toggle needs to survive the cascade so an operator can
+  // (a) flip it per-agent (ship today), and (b) flip it via
+  // defaults for Phase 4's cutover (no per-agent edit fanout).
+  // The same fix benefits `legacy_pty` and `legacy_autoaccept_expect`,
+  // both of which the schema already promised would cascade.
+  //
+  // Per-key (not deep) is the right shape — every existing field
+  // is a boolean. Agent wins on conflict, undefined values don't
+  // clobber.
+  if (defaults.experimental || merged.experimental) {
+    const d = defaults.experimental ?? {};
+    const a = merged.experimental ?? {};
+    merged.experimental = { ...d, ...a };
+  }
+
   return merged;
 }
 

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -875,6 +875,18 @@ const profileFields = {
           "Opt the autoaccept gateway back into the legacy expect-script behaviour " +
           "instead of the tmux send-keys path. Default: false.",
         ),
+      inline_scheduler: z
+        .boolean()
+        .optional()
+        .describe(
+          "Phase 3 canary flag for the cron-fold-in. When true, this agent's " +
+          "container starts an in-container scheduler sibling (gated by " +
+          "SWITCHROOM_INLINE_SCHEDULER=1, set automatically by compose) AND " +
+          "the singleton switchroom-cron container skips this agent's entries. " +
+          "The two paths are mutually exclusive — never dual-fired. Default: " +
+          "false (singleton remains the dispatcher). Phase 4 inverts the " +
+          "default and deletes the singleton.",
+        ),
     })
     .optional()
     .describe(
@@ -1294,6 +1306,18 @@ export const AgentSchema = z.object({
         .describe(
           "Opt the autoaccept gateway back into the legacy expect-script " +
           "behaviour instead of the tmux send-keys path. Default: false.",
+        ),
+      inline_scheduler: z
+        .boolean()
+        .optional()
+        .describe(
+          "Phase 3 canary flag for the cron-fold-in. When true, this agent's " +
+          "container starts an in-container scheduler sibling (gated by " +
+          "SWITCHROOM_INLINE_SCHEDULER=1, set automatically by compose) AND " +
+          "the singleton switchroom-cron container skips this agent's entries. " +
+          "The two paths are mutually exclusive — never dual-fired. Default: " +
+          "false (singleton remains the dispatcher). Phase 4 inverts the " +
+          "default and deletes the singleton.",
         ),
     })
     .optional()

--- a/src/scheduler/dispatch-singleton-filter.test.ts
+++ b/src/scheduler/dispatch-singleton-filter.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Phase 3 dual-run safety: the singleton scheduler must skip any
+ * agent whose cascade-resolved `experimental.inline_scheduler` is
+ * true. Mutual exclusion with the in-container scheduler — never
+ * dual-fire.
+ *
+ * Companion to `dispatch-inbound.test.ts` — both target small,
+ * pure helpers in `dispatch.ts`.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  collectScheduleEntries,
+  filterForSingleton,
+  inlineScheduledAgents,
+} from "./dispatch.js";
+import type { SwitchroomConfig } from "../config/schema.js";
+
+function makeConfig(agents: Record<string, {
+  schedule?: Array<{ cron: string; prompt: string; secrets?: string[] }>;
+  experimental?: { inline_scheduler?: boolean };
+  extends?: string;
+}>): SwitchroomConfig {
+  // Build a structurally complete SwitchroomConfig with the absolute
+  // minimum fields the helpers under test actually read. Cast through
+  // unknown to avoid restating the entire schema's required fields
+  // when only a slice of it is exercised.
+  const built = {
+    switchroom: { version: 1 as const, agents_dir: "/tmp", skills_dir: "/tmp" },
+    telegram: { bot_token: "x", forum_chat_id: "-1" },
+    agents: Object.fromEntries(
+      Object.entries(agents).map(([name, raw]) => [
+        name,
+        {
+          schedule: (raw.schedule ?? []).map((e) => ({ ...e, secrets: e.secrets ?? [] })),
+          experimental: raw.experimental,
+          ...(raw.extends ? { extends: raw.extends } : {}),
+        },
+      ]),
+    ),
+    profiles: {},
+    defaults: {},
+  };
+  return built as unknown as SwitchroomConfig;
+}
+
+describe("inlineScheduledAgents", () => {
+  it("returns the set of agents with experimental.inline_scheduler === true", () => {
+    const config = makeConfig({
+      alice: { experimental: { inline_scheduler: true } },
+      bob: {},
+      carol: { experimental: { inline_scheduler: false } },
+      dave: { experimental: { inline_scheduler: true } },
+    });
+    expect(inlineScheduledAgents(config)).toEqual(new Set(["alice", "dave"]));
+  });
+
+  it("returns an empty set when no agent has the flag", () => {
+    const config = makeConfig({
+      alice: {},
+      bob: { experimental: {} },
+    });
+    expect(inlineScheduledAgents(config).size).toBe(0);
+  });
+
+  it("treats a missing experimental block as inline=false (default)", () => {
+    const config = makeConfig({ alice: {} });
+    expect(inlineScheduledAgents(config).has("alice")).toBe(false);
+  });
+});
+
+describe("filterForSingleton", () => {
+  const sampleEntries = (config: SwitchroomConfig) => collectScheduleEntries(config);
+
+  it("returns entries unchanged when no agent is inline-scheduled", () => {
+    const config = makeConfig({
+      alice: { schedule: [{ cron: "0 8 * * *", prompt: "p1" }] },
+      bob: { schedule: [{ cron: "0 9 * * *", prompt: "p2" }] },
+    });
+    const all = sampleEntries(config);
+    expect(filterForSingleton(all, config)).toEqual(all);
+  });
+
+  it("drops entries for inline-scheduled agents and keeps the others", () => {
+    const config = makeConfig({
+      alice: {
+        schedule: [{ cron: "0 8 * * *", prompt: "alice-1" }],
+        experimental: { inline_scheduler: true },
+      },
+      bob: {
+        schedule: [
+          { cron: "0 9 * * *", prompt: "bob-1" },
+          { cron: "0 10 * * *", prompt: "bob-2" },
+        ],
+      },
+      carol: {
+        schedule: [{ cron: "0 11 * * *", prompt: "carol-1" }],
+        experimental: { inline_scheduler: true },
+      },
+    });
+    const all = sampleEntries(config);
+    expect(all).toHaveLength(4);
+    const filtered = filterForSingleton(all, config);
+    expect(filtered).toHaveLength(2);
+    expect(filtered.map((e) => e.agent)).toEqual(["bob", "bob"]);
+    expect(filtered.map((e) => e.prompt)).toEqual(["bob-1", "bob-2"]);
+  });
+
+  it("returns the original array when nothing is inline (no needless copy)", () => {
+    const config = makeConfig({
+      alice: { schedule: [{ cron: "0 8 * * *", prompt: "p" }] },
+    });
+    const all = sampleEntries(config);
+    expect(filterForSingleton(all, config)).toBe(all);
+  });
+});

--- a/src/scheduler/dispatch-singleton-filter.test.ts
+++ b/src/scheduler/dispatch-singleton-filter.test.ts
@@ -16,11 +16,15 @@ import {
 } from "./dispatch.js";
 import type { SwitchroomConfig } from "../config/schema.js";
 
-function makeConfig(agents: Record<string, {
-  schedule?: Array<{ cron: string; prompt: string; secrets?: string[] }>;
-  experimental?: { inline_scheduler?: boolean };
-  extends?: string;
-}>): SwitchroomConfig {
+function makeConfig(opts: {
+  agents: Record<string, {
+    schedule?: Array<{ cron: string; prompt: string; secrets?: string[] }>;
+    experimental?: { inline_scheduler?: boolean };
+    extends?: string;
+  }>;
+  defaults?: { experimental?: { inline_scheduler?: boolean } };
+  profiles?: Record<string, { experimental?: { inline_scheduler?: boolean } }>;
+}): SwitchroomConfig {
   // Build a structurally complete SwitchroomConfig with the absolute
   // minimum fields the helpers under test actually read. Cast through
   // unknown to avoid restating the entire schema's required fields
@@ -29,7 +33,7 @@ function makeConfig(agents: Record<string, {
     switchroom: { version: 1 as const, agents_dir: "/tmp", skills_dir: "/tmp" },
     telegram: { bot_token: "x", forum_chat_id: "-1" },
     agents: Object.fromEntries(
-      Object.entries(agents).map(([name, raw]) => [
+      Object.entries(opts.agents).map(([name, raw]) => [
         name,
         {
           schedule: (raw.schedule ?? []).map((e) => ({ ...e, secrets: e.secrets ?? [] })),
@@ -38,8 +42,8 @@ function makeConfig(agents: Record<string, {
         },
       ]),
     ),
-    profiles: {},
-    defaults: {},
+    profiles: opts.profiles ?? {},
+    defaults: opts.defaults ?? {},
   };
   return built as unknown as SwitchroomConfig;
 }
@@ -47,24 +51,28 @@ function makeConfig(agents: Record<string, {
 describe("inlineScheduledAgents", () => {
   it("returns the set of agents with experimental.inline_scheduler === true", () => {
     const config = makeConfig({
-      alice: { experimental: { inline_scheduler: true } },
-      bob: {},
-      carol: { experimental: { inline_scheduler: false } },
-      dave: { experimental: { inline_scheduler: true } },
+      agents: {
+        alice: { experimental: { inline_scheduler: true } },
+        bob: {},
+        carol: { experimental: { inline_scheduler: false } },
+        dave: { experimental: { inline_scheduler: true } },
+      },
     });
     expect(inlineScheduledAgents(config)).toEqual(new Set(["alice", "dave"]));
   });
 
   it("returns an empty set when no agent has the flag", () => {
     const config = makeConfig({
-      alice: {},
-      bob: { experimental: {} },
+      agents: {
+        alice: {},
+        bob: { experimental: {} },
+      },
     });
     expect(inlineScheduledAgents(config).size).toBe(0);
   });
 
   it("treats a missing experimental block as inline=false (default)", () => {
-    const config = makeConfig({ alice: {} });
+    const config = makeConfig({ agents: { alice: {} } });
     expect(inlineScheduledAgents(config).has("alice")).toBe(false);
   });
 });
@@ -74,8 +82,10 @@ describe("filterForSingleton", () => {
 
   it("returns entries unchanged when no agent is inline-scheduled", () => {
     const config = makeConfig({
-      alice: { schedule: [{ cron: "0 8 * * *", prompt: "p1" }] },
-      bob: { schedule: [{ cron: "0 9 * * *", prompt: "p2" }] },
+      agents: {
+        alice: { schedule: [{ cron: "0 8 * * *", prompt: "p1" }] },
+        bob: { schedule: [{ cron: "0 9 * * *", prompt: "p2" }] },
+      },
     });
     const all = sampleEntries(config);
     expect(filterForSingleton(all, config)).toEqual(all);
@@ -83,19 +93,21 @@ describe("filterForSingleton", () => {
 
   it("drops entries for inline-scheduled agents and keeps the others", () => {
     const config = makeConfig({
-      alice: {
-        schedule: [{ cron: "0 8 * * *", prompt: "alice-1" }],
-        experimental: { inline_scheduler: true },
-      },
-      bob: {
-        schedule: [
-          { cron: "0 9 * * *", prompt: "bob-1" },
-          { cron: "0 10 * * *", prompt: "bob-2" },
-        ],
-      },
-      carol: {
-        schedule: [{ cron: "0 11 * * *", prompt: "carol-1" }],
-        experimental: { inline_scheduler: true },
+      agents: {
+        alice: {
+          schedule: [{ cron: "0 8 * * *", prompt: "alice-1" }],
+          experimental: { inline_scheduler: true },
+        },
+        bob: {
+          schedule: [
+            { cron: "0 9 * * *", prompt: "bob-1" },
+            { cron: "0 10 * * *", prompt: "bob-2" },
+          ],
+        },
+        carol: {
+          schedule: [{ cron: "0 11 * * *", prompt: "carol-1" }],
+          experimental: { inline_scheduler: true },
+        },
       },
     });
     const all = sampleEntries(config);
@@ -108,9 +120,69 @@ describe("filterForSingleton", () => {
 
   it("returns the original array when nothing is inline (no needless copy)", () => {
     const config = makeConfig({
-      alice: { schedule: [{ cron: "0 8 * * *", prompt: "p" }] },
+      agents: { alice: { schedule: [{ cron: "0 8 * * *", prompt: "p" }] } },
     });
     const all = sampleEntries(config);
     expect(filterForSingleton(all, config)).toBe(all);
+  });
+});
+
+/**
+ * Cascade tests — `experimental.inline_scheduler` MUST cascade
+ * defaults → profile → per-agent (the schema doc-comment promises
+ * it; Phase 4's planned default-flip relies on it). These tests
+ * pin that promise. The merge clause that makes them pass lives
+ * in `src/config/merge.ts:mergeAgentConfig`'s experimental block.
+ */
+describe("inlineScheduledAgents — cascade behavior", () => {
+  it("cascades from defaults: a flag set in defaults flips every agent", () => {
+    const config = makeConfig({
+      defaults: { experimental: { inline_scheduler: true } },
+      agents: {
+        alice: { schedule: [{ cron: "0 8 * * *", prompt: "p" }] },
+        bob: { schedule: [{ cron: "0 9 * * *", prompt: "q" }] },
+      },
+    });
+    expect(inlineScheduledAgents(config)).toEqual(new Set(["alice", "bob"]));
+  });
+
+  it("per-agent override wins over defaults (false at agent unsets a true default)", () => {
+    const config = makeConfig({
+      defaults: { experimental: { inline_scheduler: true } },
+      agents: {
+        alice: { experimental: { inline_scheduler: false } },
+        bob: {},
+      },
+    });
+    // alice explicitly opts out; bob inherits the default true.
+    expect(inlineScheduledAgents(config)).toEqual(new Set(["bob"]));
+  });
+
+  it("cascades from a profile: extends + flag-on-profile flips the agent", () => {
+    const config = makeConfig({
+      profiles: {
+        canary_pool: { experimental: { inline_scheduler: true } },
+      },
+      agents: {
+        alice: { extends: "canary_pool" },
+        bob: {},
+      },
+    });
+    expect(inlineScheduledAgents(config)).toEqual(new Set(["alice"]));
+  });
+
+  it("per-agent override wins over profile (false at agent unsets a true profile)", () => {
+    const config = makeConfig({
+      profiles: {
+        canary_pool: { experimental: { inline_scheduler: true } },
+      },
+      agents: {
+        alice: {
+          extends: "canary_pool",
+          experimental: { inline_scheduler: false },
+        },
+      },
+    });
+    expect(inlineScheduledAgents(config).size).toBe(0);
   });
 });

--- a/src/scheduler/dispatch.ts
+++ b/src/scheduler/dispatch.ts
@@ -20,6 +20,7 @@
 
 import { spawn } from "node:child_process";
 import { createHash } from "node:crypto";
+import { resolveAgentConfig } from "../config/merge.js";
 import type { ScheduleEntry, SwitchroomConfig } from "../config/schema.js";
 
 export interface SchedulerEntry {
@@ -29,6 +30,53 @@ export interface SchedulerEntry {
   prompt: string;
   /** SHA-256 prefix of prompt — stable, non-reversible audit key. */
   promptKey: string;
+}
+
+/**
+ * Phase 3 cron-fold-in helper. Returns the set of agent names whose
+ * cascade-resolved `experimental.inline_scheduler` is true — these
+ * agents run an in-container scheduler sibling and the singleton
+ * MUST NOT also fire for them (mutual exclusion: never dual-fire).
+ *
+ * Pure function: no IO. The cascade is resolved here (defaults →
+ * profile → per-agent) so callers don't need to pre-merge.
+ */
+export function inlineScheduledAgents(
+  config: SwitchroomConfig,
+): Set<string> {
+  const out = new Set<string>();
+  const agentNames = Object.keys(config.agents);
+  for (const name of agentNames) {
+    const agent = config.agents[name];
+    if (!agent) continue;
+    const resolved = resolveAgentConfig(config.defaults, config.profiles, agent);
+    if (resolved.experimental?.inline_scheduler === true) {
+      out.add(name);
+    }
+  }
+  return out;
+}
+
+/**
+ * Filter to only the entries the singleton scheduler should fire.
+ * Drops entries for any agent whose cascade-resolved
+ * `experimental.inline_scheduler` is true — those fire from the
+ * in-container scheduler sibling instead. Phase 3 canary +
+ * dual-run safety net: prevents double-fires while one agent at
+ * a time gets flipped to inline-mode.
+ *
+ * Pure function: deterministic, no IO. The in-agent scheduler does
+ * NOT need to call this — start.sh only spawns it for agents whose
+ * compose env carries SWITCHROOM_INLINE_SCHEDULER=1, which is the
+ * same gate.
+ */
+export function filterForSingleton(
+  entries: SchedulerEntry[],
+  config: SwitchroomConfig,
+): SchedulerEntry[] {
+  const inline = inlineScheduledAgents(config);
+  if (inline.size === 0) return entries;
+  return entries.filter((e) => !inline.has(e.agent));
 }
 
 /**

--- a/src/scheduler/index.ts
+++ b/src/scheduler/index.ts
@@ -127,9 +127,21 @@ export async function main(): Promise<void> {
   const entries = filterForSingleton(allEntries, config);
   const skipped = allEntries.length - entries.length;
   if (skipped > 0) {
+    // Log the per-agent names too — Phase 3.4's audit-parity check
+    // correlates by (agent, schedule_index, prompt_key), and an
+    // operator pulling `docker logs switchroom-cron` should be able
+    // to confirm "yes the singleton skipped exactly the canary
+    // agents" without cross-referencing the YAML.
+    const skippedAgents = [
+      ...new Set(
+        allEntries
+          .filter((e) => !entries.includes(e))
+          .map((e) => e.agent),
+      ),
+    ].sort();
     process.stdout.write(
       `scheduler: skipping ${skipped} task(s) for inline-scheduled agents ` +
-      `(experimental.inline_scheduler=true)\n`,
+      `[${skippedAgents.join(", ")}] (experimental.inline_scheduler=true)\n`,
     );
   }
   const sink: AuditSink = pickSink({

--- a/src/scheduler/index.ts
+++ b/src/scheduler/index.ts
@@ -17,6 +17,7 @@ import {
   collectScheduleEntries,
   defaultExecRunner,
   dispatchEntry,
+  filterForSingleton,
   type SchedulerEntry,
 } from "./dispatch.js";
 import {
@@ -116,7 +117,21 @@ export async function main(): Promise<void> {
   const configPath = process.env.SWITCHROOM_CONFIG ?? "/state/config/switchroom.yaml";
   const dbPath = process.env.SWITCHROOM_SCHEDULER_DB ?? "/state/scheduler/scheduler.db.jsonl";
   const config = loadConfig(configPath);
-  const entries = collectScheduleEntries(config);
+  const allEntries = collectScheduleEntries(config);
+  // Phase 3 cron-fold-in dual-run safety: drop entries for agents
+  // whose cascade-resolved `experimental.inline_scheduler` is true.
+  // Those agents run an in-container scheduler sibling and we MUST
+  // NOT also fire for them from the singleton (mutual exclusion).
+  // Phase 4 deletes the singleton entirely; until then, the filter
+  // is what makes one-agent-at-a-time canary safe.
+  const entries = filterForSingleton(allEntries, config);
+  const skipped = allEntries.length - entries.length;
+  if (skipped > 0) {
+    process.stdout.write(
+      `scheduler: skipping ${skipped} task(s) for inline-scheduled agents ` +
+      `(experimental.inline_scheduler=true)\n`,
+    );
+  }
   const sink: AuditSink = pickSink({
     inMemory: process.env.SWITCHROOM_SCHEDULER_INMEMORY === "1",
     sqliteDbPath: process.env.SWITCHROOM_SCHEDULER_DB_PATH,

--- a/tests/docker/compose-generator.test.ts
+++ b/tests/docker/compose-generator.test.ts
@@ -656,3 +656,48 @@ describe("describeAgents", () => {
     }
   });
 });
+
+describe("Phase 3: inline_scheduler env emission", () => {
+  /**
+   * Build a config with a per-agent experimental.inline_scheduler flag.
+   * The makeConfig helper above doesn't model experimental, so we
+   * splice in the field after construction.
+   */
+  function configWithInline(agents: Record<string, boolean>): SwitchroomConfig {
+    const base = makeConfig(
+      Object.fromEntries(Object.keys(agents).map((n) => [n, {}])),
+    );
+    for (const [name, inline] of Object.entries(agents)) {
+      const a = base.agents[name] as unknown as Record<string, unknown>;
+      if (inline) a.experimental = { inline_scheduler: true };
+    }
+    return base;
+  }
+
+  it("emits SWITCHROOM_INLINE_SCHEDULER=1 ONLY for agents with the flag", () => {
+    const out = generateCompose({
+      config: configWithInline({ alice: true, bob: false }),
+    });
+    // Both agent service blocks exist — split so we can inspect each in
+    // isolation. The order is alphabetical (allocateAgentUid + sort).
+    const aliceBlock = out.split("agent-bob:")[0]!;
+    const bobBlock = out.split("agent-bob:")[1]!;
+    expect(aliceBlock).toContain('SWITCHROOM_INLINE_SCHEDULER: "1"');
+    expect(bobBlock).not.toContain("SWITCHROOM_INLINE_SCHEDULER");
+  });
+
+  it("does not emit the env var when no agent has the flag (back-compat)", () => {
+    const out = generateCompose({
+      config: configWithInline({ alice: false, bob: false }),
+    });
+    expect(out).not.toContain("SWITCHROOM_INLINE_SCHEDULER");
+  });
+
+  it("describeAgents surfaces inlineScheduler on each agent record", () => {
+    const agents = describeAgents(configWithInline({ alice: true, bob: false }));
+    const alice = agents.find((a) => a.name === "alice")!;
+    const bob = agents.find((a) => a.name === "bob")!;
+    expect(alice.inlineScheduler).toBe(true);
+    expect(bob.inlineScheduler).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Phase 3 of folding the singleton `switchroom-cron` container into per-agent sidecars. Wires the canary toggle that lets one agent at a time run on the in-container scheduler (Phase 2's gated sibling) while the rest stay on the singleton. **Mutual exclusion is enforced on both sides — the two paths never dual-fire for the same agent.**

## What's in this PR

**Schema** — `agents.<name>.experimental.inline_scheduler: bool`. Per-agent canary flag, cascades through defaults → profile → per-agent. Off by default; Phase 4 inverts.

**Compose** — `describeAgents` surfaces `inlineScheduler` on each record. `emitAgentService` adds `SWITCHROOM_INLINE_SCHEDULER=1` to the agent's env when the flag is set, so start.sh's Phase-2 sidecar starts on next `switchroom agent restart`.

**Singleton skip** — new `filterForSingleton(entries, config)` in `dispatch.ts` drops entries for inline-scheduled agents. `src/scheduler/index.ts:main()` calls it after `collectScheduleEntries` and logs the skipped count. The in-agent scheduler does NOT need to filter — start.sh only spawns it when the env var is set.

**Belt-and-braces lock** — `src/agent-scheduler/lock.ts` is a pidfile lock with stale-PID detection (`process.kill(pid, 0)` probe). Acquires at startup; releases on graceful shutdown. On contention, agent-scheduler exits with EX_TEMPFAIL (75) so start.sh's supervisor restart-cap kicks in rather than tight-looping. Pidfile (not flock(2)) because Node has no portable flock binding and the threat model is operator-second-launch, not kernel race.

## What stays unchanged

- `schedule:` YAML schema — user config is identical across all phases.
- Singleton compose block — Phase 4 deletes.
- Bridge — `meta.source=\"cron\"` still passes through; the renderer follow-up flagged in Phase 1 remains for Phase 4.

## Test plan

- [x] `npx vitest run src/agent-scheduler/ src/scheduler/ tests/docker/compose-generator.test.ts` → 50 passed, 1 skipped
- [x] `npm run lint` → clean
- [x] `npm run test:vitest` → 5170 passed, 31 skipped (full suite, +16 from Phase 2)
- [x] `npm run build` → all bundles emit cleanly
- [ ] Reviewer agent: APPROVE / REQUEST_CHANGES / BLOCK
- [ ] Operational: flip `experimental.inline_scheduler: true` on ONE canary agent + observe one week (audit parity, no missed/double fires)

## For the reviewer

Three design decisions worth a sanity check:

1. **Cascade-correctness of the filter.** `inlineScheduledAgents` calls `resolveAgentConfig` so defaults / profile flags inherit properly. Worth confirming the cascade is exercised — the test config sets the flag at the per-agent level only.

2. **Pidfile over flock(2).** Documented in `src/agent-scheduler/lock.ts`. Belt-and-braces dedup; the supervisor in start.sh is the structural single-instance guarantee. If you think portable flock is worth a native dep, flag it.

3. **Audit parity for Phase 3.4 observation.** Both paths emit a `DispatchResult` row. `exitCode` semantics differ (singleton: `claude -p` exit code; inline: 0/-1 delivery flag). Phase 1 review already accepted this — Phase 3.4's parity check is column-presence + non-error correlation by `(agent, schedule_index, prompt_key)`, not value equality on `exitCode` itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)