### PR TITLE
fix(compose): add healthchecks to vault-broker and approval-kernel

### DIFF
--- a/src/agents/compose.ts
+++ b/src/agents/compose.ts
@@ -262,6 +262,29 @@ export function generateCompose(opts: ComposeGeneratorOptions): string {
   lines.push(`      switchroom.role: "broker"`);
   lines.push(`      switchroom.fleet: "switchroom"`);
   lines.push(`    restart: unless-stopped`);
+  // Liveness probe — bind-presence. The broker creates per-agent
+  // socket directories at startup and binds `<dir>/sock` for each
+  // configured agent. If at least one bind has happened, the daemon
+  // is alive enough to take work; if every bind has gone away, the
+  // daemon is wedged or dead and `restart: unless-stopped` should
+  // recycle it. This catches the silent-down failure mode where the
+  // broker exits cleanly (compose then sees process-gone) AS WELL AS
+  // a hung daemon that's still holding the process slot but stopped
+  // listening.
+  //
+  // Trade-off: an empty fleet (no agents → no per-agent dirs → no
+  // sockets) reports unhealthy. Acceptable: a switchroom install
+  // without any agents has no business running the broker; an
+  // operator who's mid-install has minutes-scale exposure to this.
+  // We do NOT speak the broker's app protocol here — that requires
+  // peercred-checked auth and would generate audit-log noise on
+  // every healthcheck tick. Bind-presence is the right level.
+  lines.push(`    healthcheck:`);
+  lines.push(`      test: ["CMD-SHELL", "ls /run/switchroom/broker/*/sock 2>/dev/null | head -1 | grep -q ."]`);
+  lines.push(`      interval: 30s`);
+  lines.push(`      timeout: 5s`);
+  lines.push(`      retries: 3`);
+  lines.push(`      start_period: 20s`);
   lines.push(`    user: "0:0"`);
   lines.push(`    stop_grace_period: 10s`);
   lines.push(`    security_opt:`);
@@ -339,6 +362,16 @@ export function generateCompose(opts: ComposeGeneratorOptions): string {
   lines.push(`      switchroom.role: "kernel"`);
   lines.push(`      switchroom.fleet: "switchroom"`);
   lines.push(`    restart: unless-stopped`);
+  // Mirror the broker's bind-presence healthcheck — same failure-mode
+  // surface (kernel binds per-agent sockets at
+  // /run/switchroom/kernel/<agent>/sock; silently exits or hangs the
+  // same way) and same empty-fleet trade-off documented above.
+  lines.push(`    healthcheck:`);
+  lines.push(`      test: ["CMD-SHELL", "ls /run/switchroom/kernel/*/sock 2>/dev/null | head -1 | grep -q ."]`);
+  lines.push(`      interval: 30s`);
+  lines.push(`      timeout: 5s`);
+  lines.push(`      retries: 3`);
+  lines.push(`      start_period: 20s`);
   lines.push(`    user: "0:0"`);
   lines.push(`    stop_grace_period: 10s`);
   lines.push(`    security_opt:`);

--- a/tests/docker/compose-generator.test.ts
+++ b/tests/docker/compose-generator.test.ts
@@ -653,6 +653,69 @@ describe("describeAgents", () => {
   });
 });
 
+describe("singleton healthchecks (silent-down regression — see plans/singleton-healthchecks.md)", () => {
+  // The compose file used to emit `restart: unless-stopped` on every
+  // service with NO `healthcheck:` anywhere. Docker could only see
+  // "process running"; a hung-but-not-crashed broker or one that
+  // exited cleanly was invisible to `docker compose ps`. The fix is
+  // a bind-presence probe on each singleton — confirms at least one
+  // per-agent socket has been bound by the daemon.
+  //
+  // We pin the emitted block byte-for-byte so a future operator
+  // can't silently drop the probe with a refactor.
+  function blockFor(yml: string, service: string): string {
+    const re = new RegExp(`  ${service}:[\\s\\S]*?(?=\\n  [a-z]|\\nvolumes:|$)`);
+    return re.exec(yml)?.[0] ?? "";
+  }
+
+  it("emits a healthcheck on vault-broker", () => {
+    const out = generateCompose({ config: makeConfig({ alice: {} }) });
+    const block = blockFor(out, "vault-broker");
+    expect(block).toContain("healthcheck:");
+    // CMD-SHELL form — the probe is shell-piping `ls | head -1 | grep`
+    // and won't work as a bare exec list.
+    expect(block).toMatch(/test:\s*\[\s*"CMD-SHELL"\s*,/);
+    expect(block).toContain("/run/switchroom/broker/*/sock");
+    expect(block).toMatch(/interval:\s*30s/);
+    expect(block).toMatch(/timeout:\s*5s/);
+    expect(block).toMatch(/retries:\s*3/);
+    // start_period gives the broker time to bind its first socket
+    // before the probe starts firing — without it, the broker spends
+    // the first ~10s flagged unhealthy on every cold start.
+    expect(block).toMatch(/start_period:\s*20s/);
+  });
+
+  it("emits a healthcheck on approval-kernel mirroring the broker shape", () => {
+    const out = generateCompose({ config: makeConfig({ alice: {} }) });
+    const block = blockFor(out, "approval-kernel");
+    expect(block).toContain("healthcheck:");
+    expect(block).toMatch(/test:\s*\[\s*"CMD-SHELL"\s*,/);
+    expect(block).toContain("/run/switchroom/kernel/*/sock");
+    expect(block).toMatch(/interval:\s*30s/);
+    expect(block).toMatch(/timeout:\s*5s/);
+    expect(block).toMatch(/retries:\s*3/);
+    expect(block).toMatch(/start_period:\s*20s/);
+  });
+
+  it("does NOT emit healthchecks on agents (higher-fidelity signal lives in boot-card / tmux)", () => {
+    const out = generateCompose({ config: makeConfig({ alice: {}, bob: {} }) });
+    for (const a of ["alice", "bob"]) {
+      const block = blockFor(out, `agent-${a}`);
+      expect(block, `agent-${a} should have no healthcheck:`).not.toMatch(/^\s+healthcheck:/m);
+    }
+  });
+
+  it("probes use the per-agent socket path (path-as-identity invariant)", () => {
+    // The broker/kernel use socketPathToAgent(/run/switchroom/<svc>/<agent>/sock)
+    // for peer auth. The healthcheck must probe the same path shape so
+    // it actually exercises the binding code, not some sibling pidfile
+    // or status sentinel. Pin the exact glob.
+    const out = generateCompose({ config: makeConfig({ alice: {} }) });
+    expect(out).toContain(`"ls /run/switchroom/broker/*/sock 2>/dev/null | head -1 | grep -q ."`);
+    expect(out).toContain(`"ls /run/switchroom/kernel/*/sock 2>/dev/null | head -1 | grep -q ."`);
+  });
+});
+
 describe("Phase 4 cutover: agent-scheduler is default-on", () => {
   // Phase 3 used `experimental.inline_scheduler: true` + a per-agent
   // SWITCHROOM_INLINE_SCHEDULER=1 env emission to canary the in-agent


### PR DESCRIPTION
## Summary

Adds `healthcheck:` blocks to the two singletons. The compose file used to set `restart: unless-stopped` on every service but defined no healthcheck anywhere — Docker only saw "process running", and a hung-but-not-crashed broker (or one that exited cleanly) was invisible to `docker compose ps` and never restarted. Verified in production: a broker that was silently missing for hours.

## What changed

- `src/agents/compose.ts` — emits a `healthcheck:` block on `vault-broker` and `approval-kernel` with a bind-presence probe (`ls /run/switchroom/<svc>/*/sock`). Covers both clean-exit and wedged-bind failure modes.
- `tests/docker/compose-generator.test.ts` — 4 new cases pinning the emitted shape (presence, CMD-SHELL form, exact glob, four timing knobs, absence on agent services).

## What's NOT in scope

Per `~/plans/singleton-healthchecks.md`:

- **`switchroom-cron`** — N/A. Phase 4 of the cron-fold-in (PR #893) retired the singleton scheduler container. Cron runs in-container in every agent now; that's a different liveness story.
- **Agent containers** — boot card + tmux session are higher-fidelity signals than a Docker probe; a healthcheck would be noise.
- **CLI wrappers** — operators use `docker compose` natively here.

## Probe shape

```yaml
healthcheck:
  test: ["CMD-SHELL", "ls /run/switchroom/broker/*/sock 2>/dev/null | head -1 | grep -q ."]
  interval: 30s
  timeout: 5s
  retries: 3
  start_period: 20s
```

We do NOT speak the daemon's app protocol — that requires peercred-checked auth and would generate audit-log noise on every healthcheck tick. Bind-presence is the right level; matches the path-as-identity invariant the peer-auth code uses (see `src/vault/broker/peercred.ts`).

**Trade-off** (documented in the emit comment): an empty fleet (no agents → no per-agent dirs → no sockets) reports unhealthy. Acceptable — operators add agents within minutes of `switchroom setup`, and a no-agent broker has no work to do anyway.

## Test plan

- [x] `npm run lint` → clean
- [x] `npm run test:vitest` → 5161 passed, 41 skipped (full suite)
- [x] `npx vitest run tests/docker/compose-generator.test.ts` → 56/56
- [ ] Reviewer agent: APPROVE / REQUEST_CHANGES / BLOCK
- [ ] After `switchroom apply && docker compose -p switchroom -f ~/.switchroom/compose/docker-compose.yml up -d`, both services show `(healthy)` in `docker compose ps`. (Operator-side verification; not gated in CI.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)