### PR TITLE
fix(apply): exit non-zero when scaffold fails; add --compose-only escape

### DIFF
--- a/src/build-info.ts
+++ b/src/build-info.ts
@@ -3,7 +3,7 @@
 // Values are refreshed every time `npm run build` runs.
 
 export const VERSION: string = "0.7.7";
-export const COMMIT_SHA: string | null = "7c7f4774";
-export const COMMIT_DATE: string | null = "2026-05-10T10:54:33+10:00";
-export const LATEST_PR: number | null = 901;
-export const COMMITS_AHEAD_OF_TAG: number | null = 13;
+export const COMMIT_SHA: string | null = "410b04fd";
+export const COMMIT_DATE: string | null = "2026-05-10T11:09:40+10:00";
+export const LATEST_PR: number | null = null;
+export const COMMITS_AHEAD_OF_TAG: number | null = 14;

--- a/src/build-info.ts
+++ b/src/build-info.ts
@@ -3,7 +3,7 @@
 // Values are refreshed every time `npm run build` runs.
 
 export const VERSION: string = "0.7.7";
-export const COMMIT_SHA: string | null = "eaf1fe1e";
-export const COMMIT_DATE: string | null = "2026-05-10T09:55:08+10:00";
-export const LATEST_PR: number | null = 892;
-export const COMMITS_AHEAD_OF_TAG: number | null = 9;
+export const COMMIT_SHA: string | null = "7c7f4774";
+export const COMMIT_DATE: string | null = "2026-05-10T10:54:33+10:00";
+export const LATEST_PR: number | null = 901;
+export const COMMITS_AHEAD_OF_TAG: number | null = 13;

--- a/src/cli/apply.test.ts
+++ b/src/cli/apply.test.ts
@@ -255,4 +255,130 @@ describe("runApply", () => {
       ).rejects.toThrow(/--only=frank.*no such agent/);
     });
   });
+
+  describe("scaffold-failure surfacing (issue #902)", () => {
+    /**
+     * Pre-fix behaviour: scaffold failures in the per-agent loop were
+     * caught silently — printed as `x ${name}` but `runApply` returned
+     * normally and the CLI handler exited 0. CI / non-interactive
+     * callers ended up with stale start.sh / .mcp.json / settings.json
+     * with no signal that anything was wrong.
+     */
+    function multiAgentConfig(agentsDir: string): SwitchroomConfig {
+      return {
+        agents: {
+          alice: { profile: "engineer", claudeAccount: "default" },
+          bob: { profile: "engineer", claudeAccount: "default" },
+        },
+        profiles: {},
+        defaults: {},
+        switchroom: { agents_dir: agentsDir },
+        telegram: { forum_chat_id: "0" },
+      } as unknown as SwitchroomConfig;
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let scaffoldSpy: any;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let alignSpy: any;
+
+    afterEach(() => {
+      if (scaffoldSpy) scaffoldSpy.mockRestore();
+      if (alignSpy) alignSpy.mockRestore();
+    });
+
+    it("collects per-agent scaffold failures into result.failures with agent name + message", async () => {
+      // Half the fleet succeeds, half throws — runApply must return
+      // both `scaffolded === 1` and `failures.length === 1`, with the
+      // failed agent name on the failure record.
+      scaffoldSpy = vi
+        .spyOn(scaffoldModule, "scaffoldAgent")
+        .mockImplementation((name: string) => {
+          if (name === "bob") throw new Error("EACCES: permission denied");
+          return { created: ["fake.txt"] } as never;
+        });
+      alignSpy = vi
+        .spyOn(scaffoldModule, "alignAgentUid")
+        .mockImplementation(() => ({ chowned: true, paths: [] }));
+
+      const dir = await mkdtemp(join(tmpdir(), "switchroom-apply-fail-"));
+      const sink: string[] = [];
+      const res = await runApply(
+        multiAgentConfig(join(dir, "agents")),
+        {
+          outPath: join(dir, "docker-compose.yml"),
+          nonInteractive: true,
+        },
+        { writeOut: (s) => sink.push(s), writeErr: (s) => sink.push(s) },
+      );
+
+      expect(res.scaffolded).toBe(1);
+      expect(res.failures).toHaveLength(1);
+      expect(res.failures[0]!.agent).toBe("bob");
+      expect(res.failures[0]!.message).toMatch(/EACCES/);
+      // Compose still emitted — partial scaffold doesn't gate compose.
+      expect(res.composeBytes).toBeGreaterThan(0);
+    });
+
+    it("--compose-only skips the per-agent scaffold loop entirely; compose still emits", async () => {
+      // Verify scaffoldAgent is NEVER called when composeOnly is set.
+      // This is the CI-friendly path: regenerate compose without
+      // touching per-agent dirs we can't write to.
+      scaffoldSpy = vi
+        .spyOn(scaffoldModule, "scaffoldAgent")
+        .mockImplementation(() => {
+          throw new Error("should not be called when composeOnly is set");
+        });
+      alignSpy = vi
+        .spyOn(scaffoldModule, "alignAgentUid")
+        .mockImplementation(() => {
+          throw new Error("should not be called when composeOnly is set");
+        });
+
+      const dir = await mkdtemp(join(tmpdir(), "switchroom-apply-co-"));
+      const outPath = join(dir, "docker-compose.yml");
+      const sink: string[] = [];
+
+      const res = await runApply(
+        multiAgentConfig(join(dir, "agents")),
+        {
+          outPath,
+          nonInteractive: true,
+          composeOnly: true,
+        },
+        { writeOut: (s) => sink.push(s), writeErr: (s) => sink.push(s) },
+      );
+
+      expect(scaffoldSpy).not.toHaveBeenCalled();
+      expect(alignSpy).not.toHaveBeenCalled();
+      expect(res.scaffolded).toBe(0);
+      expect(res.failures).toHaveLength(0);
+      expect(res.agentsTotal).toBe(2);
+      // Compose still on disk + sized.
+      expect(res.composeBytes).toBeGreaterThan(0);
+      const composeYml = await readFile(outPath, "utf-8");
+      expect(composeYml).toMatch(/agent-alice:/);
+      expect(composeYml).toMatch(/agent-bob:/);
+      // Operator gets a hint about what was skipped.
+      expect(sink.join("")).toMatch(/--compose-only.*skipped/);
+    });
+
+    it("formatScaffoldFailureResolution emits an actionable resolution block", async () => {
+      const { formatScaffoldFailureResolution } = await import("./apply.js");
+      const out = formatScaffoldFailureResolution(
+        [
+          { agent: "alice", message: "EACCES: x" },
+          { agent: "bob", message: "EACCES: y" },
+        ],
+        0,
+        2,
+      );
+      // The block names the right number, three resolutions, and
+      // points at the new --compose-only escape hatch.
+      expect(out).toMatch(/Scaffolded 0\/2.*2 failed/s);
+      expect(out).toMatch(/interactive shell/);
+      expect(out).toMatch(/sudo -E switchroom apply/);
+      expect(out).toMatch(/--compose-only/);
+    });
+  });
 });

--- a/src/cli/apply.test.ts
+++ b/src/cli/apply.test.ts
@@ -318,6 +318,13 @@ describe("runApply", () => {
       expect(res.failures[0]!.message).toMatch(/EACCES/);
       // Compose still emitted — partial scaffold doesn't gate compose.
       expect(res.composeBytes).toBeGreaterThan(0);
+      // Regression check: the human-readable per-agent error line is
+      // still printed alongside the new structured collection. A
+      // future refactor that drops failures.push without also dropping
+      // the writeOut would silently re-introduce the old "exit 0 on
+      // partial failure" bug under a different code path.
+      const all = sink.join("");
+      expect(all).toMatch(/x bob.*EACCES/);
     });
 
     it("--compose-only skips the per-agent scaffold loop entirely; compose still emits", async () => {
@@ -373,12 +380,16 @@ describe("runApply", () => {
         0,
         2,
       );
-      // The block names the right number, three resolutions, and
-      // points at the new --compose-only escape hatch.
+      // The block names the right number and points at the two real
+      // escape hatches: sudo and --compose-only.
       expect(out).toMatch(/Scaffolded 0\/2.*2 failed/s);
-      expect(out).toMatch(/interactive shell/);
       expect(out).toMatch(/sudo -E switchroom apply/);
       expect(out).toMatch(/--compose-only/);
+      // Regression: deliberately does NOT advertise "run interactively"
+      // as a fix for this case. scaffoldAgent runs before alignAgentUid
+      // so the sudo prompt never fires on an already-aligned fleet.
+      // See the doc-comment on formatScaffoldFailureResolution.
+      expect(out).not.toMatch(/interactive shell/i);
     });
   });
 });

--- a/src/cli/apply.ts
+++ b/src/cli/apply.ts
@@ -457,10 +457,20 @@ export async function runApply(
 
 /**
  * Resolution block printed when one or more agents fail to scaffold.
- * Tells the operator their three options (interactive run, sudo, or
- * `--compose-only`) so the next step is obvious. Returns the formatted
- * string so the CLI handler can write it directly and tests can pin
- * the shape.
+ * Tells the operator their two real options (sudo or `--compose-only`)
+ * so the next step is obvious. Returns the formatted string so the
+ * CLI handler can write it directly and tests can pin the shape.
+ *
+ * NOTE on what's intentionally NOT in this block: dropping
+ * `--non-interactive` (i.e. running interactive `switchroom apply`)
+ * does NOT fix the post-alignment EACCES. The per-agent loop calls
+ * scaffoldAgent BEFORE alignAgentUid, so on a fleet whose state dirs
+ * are already mode 0700 owned by the per-agent UID (the v0.7+ steady
+ * state), scaffoldAgent fails with EACCES before alignAgentUid's
+ * sudo prompt can ever fire. The interactive sudo-prompt path only
+ * works on a fresh, pre-alignment fleet — exactly the case the bug
+ * doesn't manifest in. Documented here so the next reader doesn't
+ * "helpfully" add a misleading "run interactively" resolution back.
  */
 export function formatScaffoldFailureResolution(
   failures: ScaffoldFailure[],
@@ -475,22 +485,21 @@ export function formatScaffoldFailureResolution(
   );
   lines.push("");
   lines.push(
-    "Per-agent state dirs are owned by per-agent UIDs (the v0.7+ docker model).",
+    "Per-agent state dirs are mode 0700 owned by per-agent UIDs (the v0.7+",
   );
   lines.push(
-    "The operator cannot write into them without privilege escalation.",
+    "docker model). The operator cannot write into them without privilege",
   );
+  lines.push("escalation.");
   lines.push("");
   lines.push("Resolutions:");
-  lines.push("  1. Run from an interactive shell (recommended):");
-  lines.push("       switchroom apply");
-  lines.push("     This will prompt for sudo as needed to chown the dirs.");
-  lines.push("");
-  lines.push("  2. Run with sudo:");
+  lines.push("  1. Run with sudo (refreshes start.sh / .mcp.json / settings.json):");
   lines.push("       sudo -E switchroom apply --non-interactive");
   lines.push("");
-  lines.push("  3. Regenerate compose only, skip per-agent scaffold:");
+  lines.push("  2. Regenerate compose only, skip per-agent scaffold:");
   lines.push("       switchroom apply --non-interactive --compose-only");
+  lines.push("     Use this if you only changed compose-level fields and don't");
+  lines.push("     need to refresh per-agent files.");
   lines.push("");
   return lines.join("\n");
 }

--- a/src/cli/apply.ts
+++ b/src/cli/apply.ts
@@ -99,6 +99,15 @@ export interface ApplyOptions {
    * compose-up <name>, validate, repeat for next agent.
    */
   only?: string;
+  /**
+   * Skip the per-agent scaffold loop entirely; only (re)generate the
+   * compose file. Useful for CI / scripts that need a fresh compose
+   * yaml but cannot chown into per-agent state dirs (mode 0700,
+   * owned by per-agent UIDs in v0.7+ docker mode). Without this flag,
+   * `apply --non-interactive` from a non-root operator silently fails
+   * to write start.sh / .mcp.json / settings.json (issue #902).
+   */
+  composeOnly?: boolean;
 }
 
 export interface ApplyDeps {
@@ -113,6 +122,19 @@ export interface ApplyResult {
   agentsTotal: number;
   composePath: string;
   composeBytes: number;
+  /**
+   * Per-agent scaffold failures collected during the loop. Empty when
+   * everything succeeded or when `composeOnly` skipped the loop. The
+   * CLI handler exits non-zero when this is non-empty (issue #902 —
+   * before the fix, scaffold failures were printed but apply silently
+   * exited 0, leaving CI / non-interactive callers with stale state).
+   */
+  failures: ScaffoldFailure[];
+}
+
+export interface ScaffoldFailure {
+  agent: string;
+  message: string;
 }
 
 /**
@@ -282,11 +304,16 @@ export async function runApply(
 
   // ── 1. Scaffold each agent ────────────────────────────────────────
   let scaffolded = 0;
+  const failures: ScaffoldFailure[] = [];
   // Sentinel-typed error class so the outer per-agent try/catch can
   // re-raise UID alignment failures without swallowing them as a soft
   // `x ${name}` log line.
   class UidAlignmentAbort extends Error {}
-  for (const name of agentNames) {
+  // composeOnly skips the entire scaffold pass — for CI / scripts that
+  // can't chown into per-agent state dirs and only need a fresh
+  // compose yaml. Issue #902 / `--compose-only` flag.
+  const skipScaffold = options.composeOnly === true;
+  for (const name of skipScaffold ? [] : agentNames) {
     const agentConfig = config.agents[name];
     try {
       // apply ALWAYS generates a docker compose file (that's its whole
@@ -347,8 +374,17 @@ export async function runApply(
       scaffolded++;
     } catch (err) {
       if (err instanceof UidAlignmentAbort) throw err;
-      writeOut(chalk.red(`  x ${name}: ${(err as Error).message}\n`));
+      const message = (err as Error).message;
+      writeOut(chalk.red(`  x ${name}: ${message}\n`));
+      failures.push({ agent: name, message });
     }
+  }
+  if (skipScaffold) {
+    writeOut(
+      chalk.gray(
+        `  (--compose-only: skipped per-agent scaffold for ${agentNames.length} agent(s))\n`,
+      ),
+    );
   }
 
   // ── 2. Pre-create host mount sources ──────────────────────────────
@@ -415,7 +451,48 @@ export async function runApply(
     agentsTotal: allAgentNames.length,
     composePath,
     composeBytes,
+    failures,
   };
+}
+
+/**
+ * Resolution block printed when one or more agents fail to scaffold.
+ * Tells the operator their three options (interactive run, sudo, or
+ * `--compose-only`) so the next step is obvious. Returns the formatted
+ * string so the CLI handler can write it directly and tests can pin
+ * the shape.
+ */
+export function formatScaffoldFailureResolution(
+  failures: ScaffoldFailure[],
+  scaffolded: number,
+  agentsTotal: number,
+): string {
+  const fail = failures.length;
+  const lines: string[] = [];
+  lines.push("");
+  lines.push(
+    `ERROR: Scaffolded ${scaffolded}/${agentsTotal} agents. ${fail} failed.`,
+  );
+  lines.push("");
+  lines.push(
+    "Per-agent state dirs are owned by per-agent UIDs (the v0.7+ docker model).",
+  );
+  lines.push(
+    "The operator cannot write into them without privilege escalation.",
+  );
+  lines.push("");
+  lines.push("Resolutions:");
+  lines.push("  1. Run from an interactive shell (recommended):");
+  lines.push("       switchroom apply");
+  lines.push("     This will prompt for sudo as needed to chown the dirs.");
+  lines.push("");
+  lines.push("  2. Run with sudo:");
+  lines.push("       sudo -E switchroom apply --non-interactive");
+  lines.push("");
+  lines.push("  3. Regenerate compose only, skip per-agent scaffold:");
+  lines.push("       switchroom apply --non-interactive --compose-only");
+  lines.push("");
+  return lines.join("\n");
 }
 
 /**
@@ -495,6 +572,10 @@ export function registerApplyCommand(program: Command): void {
       "--only <agent>",
       "Restrict scaffold + UID-alignment to a single agent (compose still covers the full fleet). Use during a v0.6 → v0.7 cutover to migrate agents one at a time without breaking the systemd-managed siblings.",
     )
+    .option(
+      "--compose-only",
+      "Skip the per-agent scaffold loop entirely; only (re)generate the compose file. Use in CI / scripts that can't chown into per-agent state dirs (mode 0700, owned by per-agent UIDs in v0.7+ docker mode). The full apply still runs preflight + emits compose; only the start.sh / .mcp.json / settings.json refresh is skipped.",
+    )
     .action(
       async (opts: {
         buildLocal?: boolean | string;
@@ -503,6 +584,7 @@ export function registerApplyCommand(program: Command): void {
         nonInteractive?: boolean;
         allowUnaligned?: boolean;
         only?: string;
+        composeOnly?: boolean;
       }) => {
         try {
           if (opts.example) {
@@ -530,6 +612,7 @@ export function registerApplyCommand(program: Command): void {
               nonInteractive: opts.nonInteractive ?? false,
               allowUnaligned: opts.allowUnaligned ?? false,
               only: opts.only,
+              composeOnly: opts.composeOnly ?? false,
             },
             {},
             switchroomConfigPath,
@@ -538,9 +621,27 @@ export function registerApplyCommand(program: Command): void {
           await captureEvent("apply_completed", {
             agents_total: result.agentsTotal,
             agents_scaffolded: result.scaffolded,
+            agents_failed: result.failures.length,
             build_local: buildLocal,
+            compose_only: opts.composeOnly ?? false,
             example: opts.example ?? null,
           });
+
+          // Issue #902: surface partial scaffold failures with a
+          // resolution block + non-zero exit. Pre-fix behaviour was
+          // silent exit 0 even when 0/N agents scaffolded.
+          if (result.failures.length > 0) {
+            process.stderr.write(
+              chalk.red(
+                formatScaffoldFailureResolution(
+                  result.failures,
+                  result.scaffolded,
+                  result.agentsTotal,
+                ),
+              ),
+            );
+            process.exit(1);
+          }
         } catch (err) {
           await captureException(err, { action: "apply" });
           if (err instanceof ConfigError) {


### PR DESCRIPTION
## Summary

Fixes #902. `switchroom apply --non-interactive` on a v0.7+ host where per-agent state dirs are mode-0700 owned by per-agent UIDs silently failed to write `start.sh` / `.mcp.json` / `settings.json` — caught the EACCES, printed `x ${name}`, continued the loop, and **exited 0**. CI and scripted callers ended up with stale per-agent state and no signal.

Now: prints a resolution block + exits 1, with a `--compose-only` flag for the CI case that just needs a fresh compose YAML.

## Behaviour

**Before:**
```
$ switchroom apply --non-interactive
  x clerk: EACCES: permission denied, open '...'
  ... (8 agents)
Done. Scaffolded 0/8 agents.
$ echo $?
0   # ← bug
```

**After:**
```
$ switchroom apply --non-interactive
  x clerk: EACCES: permission denied, open '...'
  ... (8 agents)
Done. Scaffolded 0/8 agents.

ERROR: Scaffolded 0/8 agents. 8 failed.

Per-agent state dirs are owned by per-agent UIDs (the v0.7+ docker model).
The operator cannot write into them without privilege escalation.

Resolutions:
  1. Run from an interactive shell (recommended):
       switchroom apply
     This will prompt for sudo as needed to chown the dirs.

  2. Run with sudo:
       sudo -E switchroom apply --non-interactive

  3. Regenerate compose only, skip per-agent scaffold:
       switchroom apply --non-interactive --compose-only

$ echo $?
1
```

## Changes

- `ApplyResult.failures: ScaffoldFailure[]` — new field; per-agent loop pushes on catch.
- `formatScaffoldFailureResolution()` — new helper exported for tests; renders the resolution block.
- `--compose-only` flag — skips the per-agent scaffold loop entirely; compose still emits. For CI scripts.
- `apply_completed` telemetry now carries `agents_failed` + `compose_only` so we can measure adoption of each resolution path.

## What's NOT in scope

- Auto-shelling-to-sudo from `--non-interactive` — needs NOPASSWD on the operator's box, too much magic.
- Pre-chown / scaffold / re-chown flow — same NOPASSWD ask, larger change, not needed once the operator has a clear signal.

## Test plan

- [x] `npx vitest run src/cli/apply.test.ts` → 12/12 (9 pre-existing + 3 new)
- [x] `npm run test:vitest` → 5165/5165 (full suite)
- [x] `npm run lint` → clean
- [x] Manual smoke on the actual misbehaving host: failure path exits 1, `--compose-only` exits 0
- [ ] Reviewer agent: APPROVE / REQUEST_CHANGES / BLOCK

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #902