### PR TITLE
fix(docker): bake switchroom CLI into agent image

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -366,10 +366,12 @@ contract" above. The pointers below are for *implementation*.)
   `profiles/_base/start.sh.hbs` (docker-mode preamble forks three
   supervised sidecars — telegram-plugin gateway, autoaccept-poll,
   agent-scheduler — then re-execs into tmux). `docker/Dockerfile.agent`
-  copies the bundles to `/opt/switchroom/{telegram-plugin/dist/,
-  autoaccept-poll.js, agent-scheduler/index.js}` and sets CMD to
-  `/state/agent/start.sh` under tini. `src/agents/compose.ts` emits
-  the env / volumes / caps and the broker/kernel healthchecks.
+  copies the bundles to `/opt/switchroom/{switchroom.js,
+  telegram-plugin/dist/, autoaccept-poll.js, agent-scheduler/index.js}`
+  (the CLI is symlinked onto PATH at `/usr/local/bin/switchroom` for the
+  gateway's shell-out path) and sets CMD to `/state/agent/start.sh`
+  under tini. `src/agents/compose.ts` emits the env / volumes / caps
+  and the broker/kernel healthchecks.
 - **"How does autoaccept dispatch first-run prompts?"** →
   `src/agents/autoaccept.ts` (tmux capture-pane + send-keys, regex
   prompts in `PROMPTS`). Bundle entry at `src/cli/autoaccept-poll.ts`.

--- a/docker/Dockerfile.agent
+++ b/docker/Dockerfile.agent
@@ -35,6 +35,20 @@ RUN mkdir -p /tmp/tmux-shared
 COPY dist/cli/autoaccept-poll.js /opt/switchroom/autoaccept-poll.js
 RUN chmod 0755 /opt/switchroom/autoaccept-poll.js
 
+# switchroom CLI bundle: the in-container telegram-plugin gateway sidecar
+# shells out to `switchroom <verb>` for /auth, /vault, /agent, /topics
+# and friends (see telegram-plugin/gateway/gateway.ts:switchroomExec). On
+# v0.6 systemd the host's installed CLI was on PATH; under v0.7+ docker
+# the agent container is its own filesystem and the host CLI isn't
+# reachable. Without this bake, every gateway shell-out hits ENOENT and
+# Telegram-driven `/auth add`, `/auth code`, `/auth list`, `/vault …`,
+# `/agent restart` (the post-fallback restart) all fail silently. The
+# bundle is self-contained (bun build --target node + bun shebang) and
+# bun is already in the base image, so a symlink onto PATH is enough.
+COPY dist/cli/switchroom.js /opt/switchroom/switchroom.js
+RUN chmod 0755 /opt/switchroom/switchroom.js \
+ && ln -s /opt/switchroom/switchroom.js /usr/local/bin/switchroom
+
 # telegram-plugin: the MCP channel server claude spawns when invoked
 # with `--dangerously-load-development-channels server:switchroom-telegram`.
 # Resolved by bun via `bun run --cwd /opt/switchroom/telegram-plugin

--- a/tests/docker/dockerfile-agent-bakes.test.ts
+++ b/tests/docker/dockerfile-agent-bakes.test.ts
@@ -1,0 +1,50 @@
+/**
+ * Pin the agent-image bake list. The in-container telegram-plugin gateway
+ * sidecar shells out to the switchroom CLI for /auth, /vault, /agent
+ * (post-fallback restart) and friends — see
+ * `telegram-plugin/gateway/gateway.ts:switchroomExec`. Under v0.6 systemd
+ * the host CLI was on PATH; under v0.7+ docker the agent container is
+ * its own filesystem, so the CLI bundle has to be baked into the image
+ * and symlinked onto PATH. Without it, every gateway shell-out hits
+ * ENOENT and Telegram-driven auth/vault flows fail silently.
+ */
+
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const dockerfile = readFileSync(resolve(root, "docker/Dockerfile.agent"), "utf8");
+
+describe("Dockerfile.agent bakes", () => {
+  it("bakes the switchroom CLI bundle", () => {
+    expect(dockerfile).toMatch(
+      /COPY\s+dist\/cli\/switchroom\.js\s+\/opt\/switchroom\/switchroom\.js/,
+    );
+  });
+
+  it("symlinks the CLI onto PATH at /usr/local/bin/switchroom", () => {
+    expect(dockerfile).toMatch(
+      /ln\s+-s\s+\/opt\/switchroom\/switchroom\.js\s+\/usr\/local\/bin\/switchroom/,
+    );
+  });
+
+  it("bakes the autoaccept-poll bundle", () => {
+    expect(dockerfile).toMatch(
+      /COPY\s+dist\/cli\/autoaccept-poll\.js\s+\/opt\/switchroom\/autoaccept-poll\.js/,
+    );
+  });
+
+  it("bakes the telegram-plugin dist tree", () => {
+    expect(dockerfile).toMatch(
+      /COPY\s+telegram-plugin\/dist\s+\/opt\/switchroom\/telegram-plugin\/dist/,
+    );
+  });
+
+  it("bakes the agent-scheduler bundle", () => {
+    expect(dockerfile).toMatch(
+      /COPY\s+dist\/agent-scheduler\/index\.js\s+\/opt\/switchroom\/agent-scheduler\/index\.js/,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

The in-container telegram-plugin gateway sidecar shells out to `switchroom <verb>` for `/auth`, `/vault`, `/agent` (post-fallback restart) and friends — see `telegram-plugin/gateway/gateway.ts:switchroomExec`. Under v0.6 systemd the host's CLI was on PATH; under v0.7+ docker the agent container is its own filesystem, so without baking the bundle every gateway shell-out hits ENOENT and Telegram-driven `/auth add`, `/auth code`, `/auth list`, `/vault …`, `/agent restart` silently fail.

Confirmed against a live container:

\`\`\`
\$ docker exec switchroom-reggie which switchroom
(nothing)
\$ docker exec switchroom-reggie ls /opt/switchroom/
autoaccept-poll.js
telegram-plugin
\`\`\`

This bakes \`dist/cli/switchroom.js\` (already a self-contained bun-targeted bundle with a \`#!/usr/bin/env bun\` shebang; bun is in the base image) into \`/opt/switchroom/switchroom.js\` and symlinks it onto PATH at \`/usr/local/bin/switchroom\`. Also adds a regex-pinned test so the bake list doesn't silently regress, and updates CLAUDE.md's bundle inventory.

## Test plan
- [x] \`npm run lint\` clean
- [x] New test \`tests/docker/dockerfile-agent-bakes.test.ts\` passes (5/5)
- [ ] Reviewer-agent: validate bake site + symlink target are correct
- [ ] Post-merge: rebuild agent image and verify \`docker exec switchroom-<name> switchroom --version\` works inside a freshly-restarted agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)