### PR TITLE
fix(docker): mount skills+credentials, repair scheduler cascade

### DIFF
--- a/src/agent-scheduler/index.ts
+++ b/src/agent-scheduler/index.ts
@@ -178,6 +178,22 @@ export function resolveChannelTarget(
   };
 }
 
+/**
+ * Park the process indefinitely without exiting. Used by main() when the
+ * config is unusable (missing forum chat or zero resolved entries) — see
+ * #907 root cause: exiting in those cases burns the start.sh supervisor's
+ * restart budget and the scheduler silently disappears. Wakes on SIGTERM
+ * so container shutdown still proceeds cleanly.
+ */
+async function idle(): Promise<void> {
+  await new Promise<void>((resolve) => {
+    const onSignal = () => resolve();
+    process.on("SIGTERM", onSignal);
+    process.on("SIGINT", onSignal);
+  });
+  process.exit(0);
+}
+
 export async function main(): Promise<void> {
   const agentName = process.env.SWITCHROOM_AGENT_NAME;
   if (!agentName) {
@@ -215,20 +231,45 @@ export async function main(): Promise<void> {
   const allEntries = collectScheduleEntries(config);
   const entries = allEntries.filter((e) => e.agent === agentName);
 
+  // Startup self-check (#907 regression visibility): always log the
+  // registered timer set up-front. Before this, a silent "0 entries
+  // resolved" looked identical to "scheduler running fine but no fires
+  // are due" — the May 8 cutover regression went unnoticed for two days
+  // for exactly this reason. Now the log line names every entry's cron
+  // expression so an operator can grep `agent-scheduler.log` and see
+  // immediately whether the cascade resolved their schedule at all.
+  const summary = entries.length === 0
+    ? "(none)"
+    : entries
+        .map((e) => `[idx=${e.scheduleIndex} cron="${e.cron}" key=${e.promptKey}]`)
+        .join(" ");
+  process.stdout.write(
+    `agent-scheduler: ${agentName} startup self-check — ` +
+    `${entries.length} entry(ies) resolved from ${configPath}: ${summary}\n`,
+  );
+
   const channel = resolveChannelTarget(config, agentName);
   if (channel === null) {
     process.stderr.write(
       `agent-scheduler: ${agentName} has no resolvable chat target ` +
-      `(missing telegram.forum_chat_id) — exiting\n`,
+      `(missing telegram.forum_chat_id) — sleeping (no exit, avoid supervisor restart-burn)\n`,
     );
-    process.exit(78); // EX_CONFIG
+    // Idle-sleep instead of exit. Exiting non-zero would burn the
+    // start.sh supervisor's 10-restart-in-60s budget and the scheduler
+    // would silently disappear — exactly the #907 failure mode. An
+    // idle process is observable (`ps` shows it) and recovers on the
+    // next container restart after the operator fixes the config.
+    await idle();
+    return;
   }
 
   if (entries.length === 0) {
     process.stdout.write(
-      `agent-scheduler: ${agentName} has no schedule entries — exiting cleanly\n`,
+      `agent-scheduler: ${agentName} has no schedule entries — sleeping ` +
+      `(no exit, avoid supervisor restart-burn)\n`,
     );
-    process.exit(0);
+    await idle();
+    return;
   }
 
   const sink: AuditSink = new JsonlAuditSink(resolve(jsonlPath));

--- a/src/agents/compose.ts
+++ b/src/agents/compose.ts
@@ -586,6 +586,20 @@ function emitAgentService(
     lines.push(`      - ${switchroomConfigPath}:/state/config/switchroom.yaml:ro`);
   }
   lines.push(`      - ${homePrefix}/.switchroom/logs/${a.name}:${homePrefix}/.switchroom/logs/${a.name}`);
+  // Shared host directories the agent needs read-only access to. Without
+  // these the v0.6 → v0.7 cutover broke any prompt that shells out to a
+  // bundled skill script (e.g. `python3 ~/.switchroom/skills/calendar/...`)
+  // or reads filesystem-resident credentials (Garmin token dir, HA SSH
+  // key). Vault-resident secrets continued working because the broker
+  // socket is bound; the asymmetry was the smoking gun in #907.
+  //
+  // Both paths are bind-mounted at their canonical host path so absolute
+  // paths baked into prompts / env vars (GARMIN_TOKEN_DIR, HA_SSH_KEY,
+  // skill symlink targets under .claude/skills/) resolve identically
+  // inside the container as they do on the host. Read-only — agents
+  // never write to either pool.
+  lines.push(`      - ${homePrefix}/.switchroom/skills:${homePrefix}/.switchroom/skills:ro`);
+  lines.push(`      - ${homePrefix}/.switchroom/credentials:${homePrefix}/.switchroom/credentials:ro`);
   lines.push(``);
   void imageTag;
 }

--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -700,6 +700,20 @@ function syncGlobalSkills(
     }
     try {
       symlinkSync(src, dest);
+      // Container-aware sanity (#907): the symlink target is an absolute
+      // host path that must also be reachable inside the agent container.
+      // Compose now bind-mounts ~/.switchroom/skills at the same host
+      // path so the link resolves identically in both worlds. Verify the
+      // target is readable post-create — a broken link surfaces here as
+      // a loud warning rather than a silent skill-missing failure
+      // discovered only when a cron prompt fires inside the sandbox.
+      if (!existsSync(dest)) {
+        console.warn(
+          `  WARNING: skill "${name}" symlink dangles after create ` +
+          `(src=${src} dest=${dest}). Skill will appear missing inside ` +
+          `the agent container.`,
+        );
+      }
     } catch (err) {
       console.warn(
         `  WARNING: failed to symlink skill "${name}": ${(err as Error).message}`,

--- a/src/scheduler/collect-entries.test.ts
+++ b/src/scheduler/collect-entries.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Regression test for #907 — `collectScheduleEntries` must walk the
+ * cascade-resolved agent config so schedule entries declared in
+ * `defaults.schedule` or in an `extends:` profile are visible to the
+ * in-agent scheduler. Walking the raw `config.agents[name].schedule`
+ * skipped them, the agent-scheduler exited with "no schedule entries",
+ * the supervisor burned its restart budget, and fires silently stopped.
+ */
+
+import { describe, it, expect } from "vitest";
+import { collectScheduleEntries } from "./dispatch.js";
+import type { SwitchroomConfig } from "../config/schema.js";
+
+describe("collectScheduleEntries — cascade resolution (#907)", () => {
+  it("merges defaults.schedule into every agent's resolved entries", () => {
+    const config = {
+      switchroom: { version: 1 },
+      defaults: {
+        schedule: [
+          { cron: "0 8 * * *", prompt: "morning briefing" },
+        ],
+      },
+      profiles: {},
+      agents: {
+        klanker: {},
+      },
+    } as unknown as SwitchroomConfig;
+
+    const entries = collectScheduleEntries(config);
+    expect(entries.length).toBe(1);
+    expect(entries[0]!.agent).toBe("klanker");
+    expect(entries[0]!.cron).toBe("0 8 * * *");
+    expect(entries[0]!.prompt).toBe("morning briefing");
+  });
+
+  it("preserves agent-level schedule entries when defaults has none", () => {
+    const config = {
+      switchroom: { version: 1 },
+      defaults: {},
+      profiles: {},
+      agents: {
+        klanker: {
+          schedule: [{ cron: "*/15 * * * *", prompt: "heartbeat" }],
+        },
+      },
+    } as unknown as SwitchroomConfig;
+
+    const entries = collectScheduleEntries(config);
+    expect(entries.length).toBe(1);
+    expect(entries[0]!.cron).toBe("*/15 * * * *");
+  });
+
+  it("concatenates defaults.schedule before agent.schedule (cascade order)", () => {
+    const config = {
+      switchroom: { version: 1 },
+      defaults: {
+        schedule: [{ cron: "0 8 * * *", prompt: "a" }],
+      },
+      profiles: {},
+      agents: {
+        klanker: {
+          schedule: [{ cron: "0 18 * * *", prompt: "b" }],
+        },
+      },
+    } as unknown as SwitchroomConfig;
+
+    const entries = collectScheduleEntries(config);
+    expect(entries.map((e) => e.prompt)).toEqual(["a", "b"]);
+  });
+});

--- a/src/scheduler/dispatch.ts
+++ b/src/scheduler/dispatch.ts
@@ -20,6 +20,7 @@
 
 import { createHash } from "node:crypto";
 import type { ScheduleEntry, SwitchroomConfig } from "../config/schema.js";
+import { resolveAgentConfig } from "../config/merge.js";
 
 export interface SchedulerEntry {
   agent: string;
@@ -43,7 +44,19 @@ export function collectScheduleEntries(
   const out: SchedulerEntry[] = [];
   const agentNames = Object.keys(config.agents).sort();
   for (const agent of agentNames) {
-    const schedule: ScheduleEntry[] = config.agents[agent]?.schedule ?? [];
+    // #907 root cause: resolve through the cascade so schedule entries
+    // declared in `defaults.schedule` or in a profile's `extends`-chain
+    // are visible to the in-agent scheduler. Walking the raw
+    // `config.agents[name].schedule` skipped them entirely, so
+    // collectScheduleEntries returned 0 for every agent that inherited
+    // its cron from a profile, the agent-scheduler exited 0 with "no
+    // schedule entries — exiting cleanly", and the start.sh supervisor
+    // burned its 10-restarts-in-60s budget then gave up. From the
+    // operator's perspective: scheduler vanished, no fires.
+    const agentDef = config.agents[agent];
+    if (!agentDef) continue;
+    const resolved = resolveAgentConfig(config.defaults, config.profiles, agentDef);
+    const schedule: ScheduleEntry[] = resolved.schedule ?? [];
     for (let i = 0; i < schedule.length; i++) {
       const entry = schedule[i]!;
       out.push({

--- a/tests/docker/compose-generator.test.ts
+++ b/tests/docker/compose-generator.test.ts
@@ -247,6 +247,11 @@ describe("generateCompose", () => {
     expect(out).toContain("/home/op/.switchroom/logs/a:/home/op/.switchroom/logs/a");
     expect(out).toContain("/home/op/.claude/projects/a:/state/.claude");
     expect(out).toContain("/home/op/.claude/projects/a:/home/op/.claude/projects/a");
+    // Shared pools (#907): skills + credentials bind-mounted read-only at
+    // their canonical host paths so prompts and env vars resolve identically
+    // inside the container.
+    expect(out).toContain("/home/op/.switchroom/skills:/home/op/.switchroom/skills:ro");
+    expect(out).toContain("/home/op/.switchroom/credentials:/home/op/.switchroom/credentials:ro");
     expect(out).not.toContain("${HOME}");
   });
 


### PR DESCRIPTION
## Summary

Closes #907 — three regressions from the systemd → docker cutover, fixed in one cohesive PR.

**1. Missing bind-mounts in agent container template** (`src/agents/compose.ts`)
Add ro bind-mounts for `~/.switchroom/skills/` and `~/.switchroom/credentials/` at their canonical host paths. Skill scripts (`python3 ~/.switchroom/skills/<x>/scripts/...`) and filesystem-resident credentials (`GARMIN_TOKEN_DIR`, `HA_SSH_KEY`) now resolve identically inside the container as on the host. Mirrors the existing dual-mount pattern used for `agents/`, `logs/`, `.claude/projects/`. Test added in `tests/docker/compose-generator.test.ts`.

**2. Reconcile-time symlink reachability assert** (`src/agents/scaffold.ts`)
With (1) fixed, `<agentDir>/.claude/skills/<name>` symlinks targeting `<skills_dir>/<name>` resolve in-container. Add a post-create `existsSync(dest)` check so any future regression surfaces as a loud reconcile-time warning rather than a silent skill-missing failure when a cron prompt fires inside the sandbox.

**3. Scheduler stopped firing post-cutover — root cause + visibility** (`src/scheduler/dispatch.ts`, `src/agent-scheduler/index.ts`)
- **Root cause**: `collectScheduleEntries` walked the raw `config.agents[name].schedule` and skipped entries declared in `defaults.schedule` or in a profile's `extends`-chain. The in-agent scheduler then exited 0 with "no schedule entries", and the start.sh supervisor burned its 10-restart-in-60s budget then gave up. Fix: route through `resolveAgentConfig` so the cascade is applied.
- **Visibility**: startup self-check log now always names every resolved entry's cron expression, so the regression would have been visible by `grep agent-scheduler.log` rather than silent.
- **Restart-burn guard**: when the config legitimately yields zero entries or no chat target, idle-sleep instead of exit-0 so the supervisor keeps the process alive (observable in `ps`) and recovers on the next container restart.

Regression test added in `src/scheduler/collect-entries.test.ts`.

## Test plan

- [x] `bun test src/scheduler src/agent-scheduler tests/docker/compose-generator.test.ts` — 107 pass, 1 pre-existing fail and 2 pre-existing harness errors unrelated to this PR (verified by stashing changes and re-running)
- [x] New regression tests pass for cascade-resolution and skills/credentials mounts
- [ ] Operator: verify `agent-scheduler.log` shows the new startup self-check line on next gymbro restart
- [ ] Operator: verify `ls /home/<user>/.switchroom/skills` works inside an agent container after `switchroom apply`

## Deferred / follow-ups

None — all three regressions are fixed end-to-end. Future hardening (out of scope): a doctor-check that asserts both new bind mounts are present in the generated compose, mirroring `checkAgentSocketMounts`.