### PR TITLE
fix(docker): bind-mount skills/credentials, tilde-path symlink, doctor scheduler check

### DIFF
--- a/profiles/_base/start.sh.hbs
+++ b/profiles/_base/start.sh.hbs
@@ -110,6 +110,22 @@ if [ "$SWITCHROOM_RUNTIME" = "docker" ] && [ -z "$SWITCHROOM_DOCKER_TMUX_INNER" 
     bash -l "$0"
 fi
 
+{{#if hostHomeQ}}
+# Host ~/.switchroom symlink (#910). Container HOME=/state/agent/home,
+# but operator yaml prompts (cron, hooks, ad-hoc tool calls) widely use
+# ~/.switchroom/skills/..., ~/.switchroom/credentials/..., and
+# ~/.switchroom/agents/<self>/... — those expand against $HOME inside the
+# container. Bind mounts land at the host's absolute path
+# (/home/<user>/.switchroom/...), not under HOME. Symlinking
+# $HOME/.switchroom → <host-home>/.switchroom makes tilde paths resolve
+# to the bind-mounted location. Idempotent: ln -sfn refreshes the link
+# without following an existing symlink. Guard refuses to clobber a
+# real directory at $HOME/.switchroom.
+if [ ! -e "$HOME/.switchroom" ] || [ -L "$HOME/.switchroom" ]; then
+  ln -sfn {{{hostHomeQ}}}/.switchroom "$HOME/.switchroom" 2>/dev/null || true
+fi
+{{/if}}
+
 export NVM_DIR="$HOME/.nvm"
 [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
 export PATH="$HOME/.bun/bin:$PATH"

--- a/src/agents/compose.ts
+++ b/src/agents/compose.ts
@@ -1,33 +1,30 @@
 /**
  * Docker Compose generator — Phase 1a.
  *
- * Turns the cascade-resolved switchroom.yaml into a byte-deterministic
- * docker-compose.yml. Mirrors what `installAllUnits()` does for systemd,
- * but for the Docker substrate (RFC §"Compose skeleton").
+ * Turns the cascade-resolved switchroom.yaml into a deterministic
+ * docker-compose.yml.
  *
- * Determinism is load-bearing: agents are emitted in sorted name order,
- * volumes alphabetised, env keys sorted. Two byte-identical inputs
- * MUST produce a byte-identical output (asserted by the snapshot tests
- * in tests/docker/compose-generator.test.ts).
+ * Determinism: agents are emitted in sorted name order, volumes
+ * alphabetised, env keys sorted. Two apply runs against the same
+ * inputs AND the same host filesystem state MUST produce a
+ * byte-identical output (asserted by the snapshot tests in
+ * tests/docker/compose-generator.test.ts). The host-filesystem
+ * caveat covers the optional skills/credentials bind mounts (#907)
+ * that we only emit when the source dirs actually exist — docker
+ * compose `up` hard-fails when a `:ro` bind source is missing.
  *
- * Identity model summary (RFC §"Container identity model"):
- *   - Each agent gets a deterministic UID in 10001..10999 derived from
- *     a stable hash of its name (allocateAgentUid()).
+ * Identity model:
+ *   - Each agent gets a deterministic UID in 10001..10999 derived
+ *     from a stable hash of its name (allocateAgentUid()).
  *   - Each agent's broker socket dir lives in its OWN named volume,
  *     mounted ONLY into that agent's container. Same for kernel.
  *   - The broker mounts every agent's socket dir under
  *     /run/switchroom/broker/<agent>; per-agent agents mount only
  *     their own dir under /run/switchroom/broker.
- *
- * What this module does NOT do:
- *   - Touch existing systemd code paths. The existing host-native
- *     install path (src/agents/systemd.ts) is unchanged.
- *   - Evaluate live runtime — that's the runtime detection in
- *     src/cli/agent.ts which calls this only when SWITCHROOM_RUNTIME
- *     is set to "docker".
  */
 
 import { createHash } from "node:crypto";
+import { existsSync } from "node:fs";
 import type { SwitchroomConfig, AgentConfig } from "../config/schema.js";
 import { resolveAgentConfig } from "../config/merge.js";
 
@@ -228,6 +225,11 @@ export function generateCompose(opts: ComposeGeneratorOptions): string {
   // preserves the older `${HOME}` shape for callers that haven't been
   // updated.
   const homePrefix = opts.homeDir ?? "${HOME}";
+  // For existsSync() decisions on optional bind-mount sources (#907):
+  // emission uses `homePrefix` (which may be the literal "${HOME}" so
+  // sudo-bake works), but the existsSync probe must use the real host
+  // home. Falls back to process.env.HOME when no homeDir is passed.
+  const hostHomeForChecks = opts.homeDir ?? process.env.HOME ?? "";
   const switchroomConfigPath = opts.switchroomConfigPath;
   if (buildMode === "local" && !buildContext) {
     throw new Error(
@@ -419,7 +421,7 @@ export function generateCompose(opts: ComposeGeneratorOptions): string {
     if (a.strippedCaps.length > 0) {
       warn(`compose: stripping cap_add ${JSON.stringify(a.strippedCaps)} from agent "${a.name}" (Docker mode forbids capability extras; see RFC §security)`);
     }
-    emitAgentService(lines, a, imageTag, buildMode, buildContext, homePrefix, switchroomConfigPath);
+    emitAgentService(lines, a, imageTag, buildMode, buildContext, homePrefix, hostHomeForChecks, switchroomConfigPath);
   }
 
   // ── volumes ────────────────────────────────────────────────────────
@@ -440,6 +442,7 @@ function emitAgentService(
   buildMode: "pull" | "local",
   buildContext: string | undefined,
   homePrefix: string,
+  hostHomeForChecks: string,
   switchroomConfigPath: string | undefined,
 ): void {
   lines.push(`  agent-${a.name}:`);
@@ -578,6 +581,21 @@ function emitAgentService(
   lines.push(`      - ${homePrefix}/.switchroom/logs/${a.name}:/var/log/switchroom`);
   lines.push(`      - ${homePrefix}/.switchroom/agents/${a.name}:${homePrefix}/.switchroom/agents/${a.name}`);
   lines.push(`      - ${homePrefix}/.claude/projects/${a.name}:${homePrefix}/.claude/projects/${a.name}`);
+  // Shared read-only bind mounts for skills + credentials (#907). Cron
+  // yaml prompts widely reference `~/.switchroom/skills/...` (calendar,
+  // mail, garmin, home-assistant) and `~/.switchroom/credentials/...`.
+  // Mounted at the operator's host path so absolute paths in scaffolded
+  // start.sh and yaml prompts Just Work; tilde resolution is fixed by
+  // start.sh.hbs's $HOME/.switchroom symlink (see #910). Conditional on
+  // existsSync because docker compose `up` hard-fails when a `:ro`
+  // source is missing — many operators keep all secrets in vault and
+  // never create a `credentials/` dir at all.
+  if (existsSync(`${hostHomeForChecks}/.switchroom/skills`)) {
+    lines.push(`      - ${homePrefix}/.switchroom/skills:${homePrefix}/.switchroom/skills:ro`);
+  }
+  if (existsSync(`${hostHomeForChecks}/.switchroom/credentials`)) {
+    lines.push(`      - ${homePrefix}/.switchroom/credentials:${homePrefix}/.switchroom/credentials:ro`);
+  }
   // switchroom.yaml file mount (read-only) — the in-container gateway
   // daemon needs `--config $SWITCHROOM_CONFIG` to talk to the
   // switchroom CLI for handoff / topic / vault grants. SWITCHROOM_CONFIG

--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -1434,6 +1434,10 @@ function buildWorkspaceContext(args: BuildWorkspaceContextArgs): Record<string, 
     switchroomConfigPathQ: switchroomConfigPath
       ? shellSingleQuote(resolve(switchroomConfigPath))
       : undefined,
+    // Host home — baked into start.sh.hbs's $HOME/.switchroom symlink
+    // (#910). When unset (e.g. tests with no HOME) the template's
+    // {{#if hostHomeQ}} guard renders the symlink block as a no-op.
+    hostHomeQ: process.env.HOME ? shellSingleQuote(process.env.HOME) : undefined,
     modelQ: shellSingleQuote(agentConfig.model ?? SWITCHROOM_DEFAULT_MAIN_MODEL),
     thinkingEffort: agentConfig.thinking_effort ?? SWITCHROOM_DEFAULT_THINKING_EFFORT,
     permissionMode: agentConfig.permission_mode,
@@ -2894,6 +2898,9 @@ export function reconcileAgent(
       hindsightRecallMaxMemories,
       hindsightRecallCacheTtlSecs,
       hindsightRecallMinOverlap,
+      // Mirror buildWorkspaceContext (#910): host home for the
+      // $HOME/.switchroom symlink in start.sh's docker preamble.
+      hostHomeQ: process.env.HOME ? shellSingleQuote(process.env.HOME) : undefined,
       modelQ: shellSingleQuote(agentConfig.model ?? SWITCHROOM_DEFAULT_MAIN_MODEL),
       thinkingEffort: agentConfig.thinking_effort ?? SWITCHROOM_DEFAULT_THINKING_EFFORT,
       permissionMode: agentConfig.permission_mode,

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -684,6 +684,50 @@ export async function checkTelegram(config: SwitchroomConfig): Promise<CheckResu
   return results;
 }
 
+/**
+ * Detect agents whose start.sh predates the Phase 4 cron-fold-in cutover
+ * (#893) — they lack the agent-scheduler supervisor block, so cron does
+ * not fire (#909, #911). Reads the host file directly; the bind mount
+ * makes it the same content the container sees.
+ *
+ * @internal exported for testing
+ */
+export function checkStartShStale(
+  agentName: string,
+  startShPath: string,
+): CheckResult {
+  const label = `${agentName}: start.sh scheduler block`;
+  if (!existsSync(startShPath)) {
+    return {
+      name: label,
+      status: "warn",
+      detail: `${startShPath} not found`,
+      fix: `Run \`switchroom apply\` to scaffold start.sh.`,
+    };
+  }
+  let content: string;
+  try {
+    content = readFileSync(startShPath, "utf-8");
+  } catch (err) {
+    return {
+      name: label,
+      status: "warn",
+      detail: `unreadable: ${(err as Error).message}`,
+    };
+  }
+  if (!content.includes("agent-scheduler")) {
+    return {
+      name: label,
+      status: "fail",
+      detail:
+        "missing agent-scheduler supervisor block — no crons will fire",
+      fix:
+        "Run `switchroom apply` to regenerate start.sh against the latest template, then `docker compose -p switchroom -f ~/.switchroom/compose/docker-compose.yml up -d` to restart.",
+    };
+  }
+  return { name: label, status: "ok", detail: "supervisor block present" };
+}
+
 function checkAgents(config: SwitchroomConfig, configPath: string): CheckResult[] {
   const results: CheckResult[] = [];
   const agentsDir = resolveAgentsDir(config);
@@ -703,6 +747,9 @@ function checkAgents(config: SwitchroomConfig, configPath: string): CheckResult[
       });
       continue;
     }
+
+    // 1b. start.sh has the post-Phase-4 scheduler supervisor block
+    results.push(checkStartShStale(name, join(agentDir, "start.sh")));
 
     // 2. Service status
     const status = statuses[name];

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -715,7 +715,11 @@ export function checkStartShStale(
       detail: `unreadable: ${(err as Error).message}`,
     };
   }
-  if (!content.includes("agent-scheduler")) {
+  // Match on the actual supervisor invocation, not the bare token —
+  // a comment like "# TODO: wire agent-scheduler" would otherwise
+  // falsely report "ok", and this check is the entire defense for
+  // the #911 silent-cron-loss class.
+  if (!/_switchroom_supervise\s+agent-scheduler\b/.test(content)) {
     return {
       name: label,
       status: "fail",

--- a/tests/docker/compose-generator.test.ts
+++ b/tests/docker/compose-generator.test.ts
@@ -273,6 +273,30 @@ describe("generateCompose", () => {
     }
   });
 
+  it("emits each mount independently when only one host dir exists (#907)", async () => {
+    // Vault-only operators commonly have populated skills/ but no
+    // filesystem credentials/ (everything via vault). The two
+    // existsSync probes must be independent — emitting one mount
+    // mustn't depend on the other being present.
+    const { mkdtempSync, mkdirSync, rmSync } = await import("node:fs");
+    const { tmpdir } = await import("node:os");
+    const { join } = await import("node:path");
+    const tmp = mkdtempSync(join(tmpdir(), "compose-asym-"));
+    mkdirSync(join(tmp, ".switchroom", "skills"), { recursive: true });
+    try {
+      const out = generateCompose({
+        config: makeConfig({ a: {} }),
+        homeDir: tmp,
+      });
+      expect(out).toContain(
+        `${tmp}/.switchroom/skills:${tmp}/.switchroom/skills:ro`,
+      );
+      expect(out).not.toContain(`${tmp}/.switchroom/credentials`);
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
   it("omits skills/credentials mounts when host dirs are absent (#907)", async () => {
     // docker compose `up` hard-fails if a `:ro` source path is missing.
     // Many operators keep all secrets in vault and never create

--- a/tests/docker/compose-generator.test.ts
+++ b/tests/docker/compose-generator.test.ts
@@ -250,6 +250,50 @@ describe("generateCompose", () => {
     expect(out).not.toContain("${HOME}");
   });
 
+  it("emits skills + credentials :ro mounts when host dirs exist (#907)", async () => {
+    const { mkdtempSync, mkdirSync, rmSync } = await import("node:fs");
+    const { tmpdir } = await import("node:os");
+    const { join } = await import("node:path");
+    const tmp = mkdtempSync(join(tmpdir(), "compose-mounts-"));
+    mkdirSync(join(tmp, ".switchroom", "skills"), { recursive: true });
+    mkdirSync(join(tmp, ".switchroom", "credentials"), { recursive: true });
+    try {
+      const out = generateCompose({
+        config: makeConfig({ a: {} }),
+        homeDir: tmp,
+      });
+      expect(out).toContain(
+        `${tmp}/.switchroom/skills:${tmp}/.switchroom/skills:ro`,
+      );
+      expect(out).toContain(
+        `${tmp}/.switchroom/credentials:${tmp}/.switchroom/credentials:ro`,
+      );
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("omits skills/credentials mounts when host dirs are absent (#907)", async () => {
+    // docker compose `up` hard-fails if a `:ro` source path is missing.
+    // Many operators keep all secrets in vault and never create
+    // `.switchroom/credentials/`; we must skip emission rather than
+    // refuse to generate compose at all.
+    const { mkdtempSync, rmSync } = await import("node:fs");
+    const { tmpdir } = await import("node:os");
+    const { join } = await import("node:path");
+    const tmp = mkdtempSync(join(tmpdir(), "compose-no-mounts-"));
+    try {
+      const out = generateCompose({
+        config: makeConfig({ a: {} }),
+        homeDir: tmp,
+      });
+      expect(out).not.toContain(`${tmp}/.switchroom/skills`);
+      expect(out).not.toContain(`${tmp}/.switchroom/credentials`);
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
   it("emits top-level project name 'switchroom' for collision protection", () => {
     // Belt-and-braces vs Coolify-managed (or other) compose stacks on
     // the same host. Pinning name: at file scope means

--- a/tests/doctor.test.ts
+++ b/tests/doctor.test.ts
@@ -12,6 +12,7 @@ import {
   checkDepsCacheWritable,
   checkSkillsPrerequisites,
   checkConfig,
+  checkStartShStale,
 } from "../src/cli/doctor.js";
 import { findConfigFile } from "../src/config/loader.js";
 import type { SwitchroomConfig } from "../src/config/schema.js";
@@ -487,5 +488,59 @@ describe("checkConfig — default subagents check", () => {
     expect(check!.status).toBe("warn");
     expect(check!.detail).toContain("no default subagents");
     expect(check!.fix).toContain("docs/sub-agents.md");
+  });
+});
+
+describe("checkStartShStale", () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = resolve(tmpdir(), `switchroom-doctor-startsh-${Date.now()}`);
+    mkdirSync(tempDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("warns when start.sh is missing entirely", () => {
+    const result = checkStartShStale("clerk", join(tempDir, "missing.sh"));
+    expect(result.status).toBe("warn");
+    expect(result.detail).toContain("not found");
+    expect(result.fix).toContain("switchroom apply");
+  });
+
+  it("fails when start.sh lacks the agent-scheduler supervisor block (#909)", () => {
+    // Hand-craft a pre-Phase-4 start.sh: gateway + autoaccept supervisors
+    // only, no agent-scheduler reference.
+    const startShPath = join(tempDir, "start.sh");
+    writeFileSync(
+      startShPath,
+      [
+        "#!/usr/bin/env bash",
+        "_switchroom_supervise gateway /var/log/switchroom/gateway.log bun gateway.js &",
+        "_switchroom_supervise autoaccept /var/log/switchroom/autoaccept.log bun autoaccept-poll.js &",
+        "exec tmux new-session -A -s clerk bash -l \"$0\"",
+      ].join("\n"),
+    );
+    const result = checkStartShStale("clerk", startShPath);
+    expect(result.status).toBe("fail");
+    expect(result.detail).toContain("agent-scheduler");
+    expect(result.fix).toContain("switchroom apply");
+    expect(result.fix).toContain("docker compose");
+  });
+
+  it("reports ok when the supervisor block is present", () => {
+    const startShPath = join(tempDir, "start.sh");
+    writeFileSync(
+      startShPath,
+      [
+        "#!/usr/bin/env bash",
+        "_switchroom_supervise agent-scheduler /var/log/switchroom/agent-scheduler.log \\",
+        "  bun /opt/switchroom/agent-scheduler/index.js &",
+      ].join("\n"),
+    );
+    const result = checkStartShStale("clerk", startShPath);
+    expect(result.status).toBe("ok");
   });
 });

--- a/tests/doctor.test.ts
+++ b/tests/doctor.test.ts
@@ -530,6 +530,24 @@ describe("checkStartShStale", () => {
     expect(result.fix).toContain("docker compose");
   });
 
+  it("fails when start.sh only mentions agent-scheduler in a comment (false-positive guard)", () => {
+    // Catches the loose-grep regression: a stale start.sh that
+    // happens to mention the token in a TODO/comment must still
+    // be diagnosed as broken — the supervisor invocation is what
+    // actually keeps cron alive.
+    const startShPath = join(tempDir, "start.sh");
+    writeFileSync(
+      startShPath,
+      [
+        "#!/usr/bin/env bash",
+        "# TODO: wire agent-scheduler post-upgrade",
+        "_switchroom_supervise gateway /var/log/switchroom/gateway.log bun gateway.js &",
+      ].join("\n"),
+    );
+    const result = checkStartShStale("clerk", startShPath);
+    expect(result.status).toBe("fail");
+  });
+
   it("reports ok when the supervisor block is present", () => {
     const startShPath = join(tempDir, "start.sh");
     writeFileSync(

--- a/tests/scaffold.test.ts
+++ b/tests/scaffold.test.ts
@@ -160,6 +160,42 @@ describe("scaffoldAgent", () => {
     expect(startSh).not.toContain("export SWITCHROOM_CONFIG=");
   });
 
+  it("start.sh symlinks $HOME/.switchroom to host home (#910 tilde-path fix)", () => {
+    // Container HOME=/state/agent/home (compose.ts) but operator yaml
+    // prompts widely use ~/.switchroom/skills/..., ~/.switchroom/
+    // credentials/..., etc. Without the symlink the tilde resolves to
+    // a path that doesn't exist inside the container.
+    const prevHome = process.env.HOME;
+    process.env.HOME = "/home/op";
+    try {
+      const config = makeAgentConfig();
+      const result = scaffoldAgent("tilde-agent", config, tmpDir, telegramConfig);
+      const startSh = readFileSync(join(result.agentDir, "start.sh"), "utf-8");
+      // Symlink target is the host home, link path is $HOME/.switchroom.
+      expect(startSh).toMatch(/ln -sfn '\/home\/op'\/\.switchroom "\$HOME\/\.switchroom"/);
+      // Idempotent guard refuses to clobber a real directory.
+      expect(startSh).toContain('[ ! -e "$HOME/.switchroom" ] || [ -L "$HOME/.switchroom" ]');
+    } finally {
+      if (prevHome === undefined) delete process.env.HOME;
+      else process.env.HOME = prevHome;
+    }
+  });
+
+  it("start.sh skips the symlink block when HOME is unset (test/non-host context)", () => {
+    const prevHome = process.env.HOME;
+    delete process.env.HOME;
+    try {
+      const config = makeAgentConfig();
+      const result = scaffoldAgent("no-home-agent", config, tmpDir, telegramConfig);
+      const startSh = readFileSync(join(result.agentDir, "start.sh"), "utf-8");
+      // Without hostHomeQ, the {{#if hostHomeQ}} guard renders nothing.
+      expect(startSh).not.toContain('"$HOME/.switchroom"');
+      expect(startSh).not.toContain("ln -sfn");
+    } finally {
+      if (prevHome !== undefined) process.env.HOME = prevHome;
+    }
+  });
+
   it("start.sh includes --effort flag when thinking_effort is set", () => {
     const config = makeAgentConfig({ thinking_effort: "xhigh" });
     const result = scaffoldAgent("effort-agent", config, tmpDir, telegramConfig);


### PR DESCRIPTION
## Summary

Three v0.7.x post-Docker-cutover regressions surfaced in production. Closes #907, #910, #911.

- **#907** — Agent containers were missing bind mounts for `~/.switchroom/skills/` and `~/.switchroom/credentials/`. All cron prompts that shell out to filesystem-resident skills (calendar, mail, garmin, home-assistant) failed; reconcile-time skill symlinks dangled inside the container; filesystem-resident credentials (`GARMIN_TOKEN_DIR`, `HA_SSH_KEY`, …) pointed at non-existent paths. Vault-backed secrets still worked because the broker socket was bound — that asymmetry was the smoking gun. Fix: emit both as `:ro` mounts, conditional on `existsSync` because `docker compose up` hard-fails on a missing `:ro` source and many operators keep all secrets in vault.

- **#910** — Container `HOME=/state/agent/home` (justified — numeric UID has no /etc/passwd entry, so default HOME breaks gh/git/pip), but operator yaml prompts widely use `~/.switchroom/...` paths that expand against `\$HOME` inside the container. Fix: `start.sh` now creates `\$HOME/.switchroom → <host-home>/.switchroom` symlink under the docker preamble (idempotent; refuses to clobber a real directory). New `hostHomeQ` template field plumbed through both `buildWorkspaceContext` and `reconcileAgent`.

- **#911** — Phase 4 cron-fold-in (#893) wired the `agent-scheduler` supervisor block into `start.sh.hbs`, but agents whose `start.sh` was scaffolded pre-cutover and never re-applied silently lose all cron delivery. Fix: new `checkStartShStale` doctor probe scans each agent's `start.sh` for the supervisor token and surfaces a concrete `apply` + compose-restart fix.

### JTBD / outcome

Serves the **always-on** outcome (cron delivers what the operator scheduled) and the **subscription-honest** outcome by extension (filesystem-resident credentials work alongside vault-backed ones). Passes the **defaults test** — fresh installs Just Work without the operator hand-mounting anything; **consistency test** — same `:ro` shape as the existing config-file mount.

### Determinism caveat

The compose snapshot guarantee is now contingent on host filesystem state (the optional bind-mount sources). Documented in the header comment of \`src/agents/compose.ts\`.

## Test plan

- [x] \`npm run lint\` clean
- [x] 7 new tests across compose-generator, scaffold, doctor — all pass (259/259 in touched files)
- [x] Full vitest suite: 35 failures match \`main\` baseline (all pre-existing, \`dist/\`-build-dependent); zero regressions introduced
- [ ] Reviewer-agent verdict pending

🤖 Generated with [Claude Code](https://claude.com/claude-code)