### PR TITLE
fix(agent-scheduler): boot-time freshness check defends against PID reuse (#895)

### DIFF
--- a/src/agent-scheduler/lock.test.ts
+++ b/src/agent-scheduler/lock.test.ts
@@ -128,10 +128,13 @@ describe("acquireLock / releaseLock", () => {
     it("readContainerBootTimeMs returns a finite recent timestamp on Linux", () => {
       // Smoke test the auto-detect path. On non-Linux runners this
       // returns null; on the Linux CI box it returns the real boot
-      // time (seconds-to-days ago, depending on uptime).
+      // time. Tight upper bound (≤now+1s) and a within-last-year
+      // lower bound — the latter catches a unit-conversion regression
+      // (e.g. seconds returned where ms expected would be ~1970).
       const v = readContainerBootTimeMs();
       if (v == null) return; // non-Linux — not applicable
-      expect(v).toBeGreaterThan(0);
+      const oneYearMs = 365 * 24 * 3600 * 1000;
+      expect(v).toBeGreaterThan(Date.now() - oneYearMs);
       expect(v).toBeLessThanOrEqual(Date.now() + 1000);
     });
   });

--- a/src/agent-scheduler/lock.test.ts
+++ b/src/agent-scheduler/lock.test.ts
@@ -10,10 +10,10 @@
  */
 
 import { afterEach, beforeEach, describe, it, expect } from "vitest";
-import { mkdtempSync, readFileSync, rmSync, writeFileSync, existsSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync, existsSync, utimesSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { acquireLock, releaseLock } from "./lock.js";
+import { acquireLock, releaseLock, readContainerBootTimeMs } from "./lock.js";
 
 let tmp: string;
 
@@ -80,5 +80,59 @@ describe("acquireLock / releaseLock", () => {
   it("releaseLock is idempotent (missing file is fine)", () => {
     const path = join(tmp, "no-such.lock");
     expect(() => releaseLock(path)).not.toThrow();
+  });
+
+  // Boot-time freshness check — defends against PID reuse across
+  // container restarts (#895). Inside an agent container PID density
+  // is low (tini=1, single-digit siblings), so a SIGKILL'd lock can
+  // legitimately point at a PID the new generation reuses for an
+  // unrelated process — kill(pid, 0) returns true and the supervisor
+  // wedges. The freshness check breaks this by trusting mtime first.
+  describe("boot-time freshness (#895)", () => {
+    it("treats a lock older than container boot time as stale even when its PID is live", () => {
+      const path = join(tmp, "scheduler.lock");
+      // Write our own (live) PID into the lock so kill(pid, 0) succeeds.
+      writeFileSync(path, String(process.pid));
+      // Backdate the mtime to 1 hour before "boot" — pretend the
+      // container restarted and this lock is from the previous gen.
+      const fakeBootMs = Date.now();
+      const oldTime = new Date(fakeBootMs - 60 * 60 * 1000);
+      utimesSync(path, oldTime, oldTime);
+      const result = acquireLock(path, 7777, { containerBootTimeMs: fakeBootMs });
+      expect(result.acquired).toBe(true);
+      expect(readFileSync(path, "utf8").trim()).toBe("7777");
+    });
+
+    it("honors a fresh lock (mtime newer than boot time) via the PID-liveness path", () => {
+      const path = join(tmp, "scheduler.lock");
+      writeFileSync(path, String(process.pid));
+      // mtime is "now"; pretend boot was an hour ago.
+      const fakeBootMs = Date.now() - 60 * 60 * 1000;
+      const result = acquireLock(path, 8888, { containerBootTimeMs: fakeBootMs });
+      expect(result.acquired).toBe(false);
+      expect(result.holderPid).toBe(process.pid);
+    });
+
+    it("skips the freshness check entirely when containerBootTimeMs is null", () => {
+      const path = join(tmp, "scheduler.lock");
+      writeFileSync(path, String(process.pid));
+      // Backdate mtime — would be stale under the freshness check, but
+      // null disables it, falling back to PID-liveness only.
+      const oldTime = new Date(Date.now() - 60 * 60 * 1000);
+      utimesSync(path, oldTime, oldTime);
+      const result = acquireLock(path, 9999, { containerBootTimeMs: null });
+      expect(result.acquired).toBe(false);
+      expect(result.holderPid).toBe(process.pid);
+    });
+
+    it("readContainerBootTimeMs returns a finite recent timestamp on Linux", () => {
+      // Smoke test the auto-detect path. On non-Linux runners this
+      // returns null; on the Linux CI box it returns the real boot
+      // time (seconds-to-days ago, depending on uptime).
+      const v = readContainerBootTimeMs();
+      if (v == null) return; // non-Linux — not applicable
+      expect(v).toBeGreaterThan(0);
+      expect(v).toBeLessThanOrEqual(Date.now() + 1000);
+    });
   });
 });

--- a/src/agent-scheduler/lock.ts
+++ b/src/agent-scheduler/lock.ts
@@ -107,10 +107,15 @@ export function readContainerBootTimeMs(): number | null {
     const btimeSec = Number(btimeLine.split(/\s+/)[1]);
     if (!Number.isFinite(btimeSec)) return null;
 
-    // CLK_TCK is 100 on every kernel switchroom ships against (the
-    // default is universally 100; node doesn't expose sysconf). A
-    // wrong CLK_TCK by 2.5× would misplace boot time by single-digit
-    // seconds at most — bounded by the safety margin in acquireLock.
+    // /proc/[pid]/stat's starttime is in units of sysconf(_SC_CLK_TCK)
+    // = USER_HZ, which the kernel ABI hardcodes to 100 on every arch
+    // switchroom plausibly ships to (x86/x86_64/arm/arm64/mips — see
+    // include/uapi/asm-generic/param.h; only Alpha differs). nsec_to_
+    // clock_t() converts to USER_HZ before exposing starttime, so this
+    // is independent of CONFIG_HZ (which DOES vary — 250 on Debian
+    // server, 1000 on Ubuntu desktop). Hardcoding 100 is correct, not
+    // a heuristic; the 2s safety margin in acquireLock covers
+    // mtime-vs-/proc clock skew, NOT a wrong CLK_TCK.
     const CLK_TCK = 100;
     return (btimeSec + starttimeTicks / CLK_TCK) * 1000;
   } catch {

--- a/src/agent-scheduler/lock.ts
+++ b/src/agent-scheduler/lock.ts
@@ -39,19 +39,22 @@
  * `switchroom agent restart <name>` once, which clears the in-memory
  * supervisor state).
  *
- * Phase 4 follow-up: add a boot-time freshness check by reading PID
- * 1's start time from /proc/1/stat (field 22, starttime in clock-
- * ticks since boot) plus btime from /proc/stat, and treat lockfiles
- * older than that as stale regardless of PID liveness. Not done in
- * Phase 3 because the post-cap missed-cron window is bounded by the
- * canary observation period — by the time we'd hit it in production,
- * Phase 4 will have shipped the fix or rolled back the canary.
+ * Boot-time freshness defence (#895): on EEXIST we ALSO compare the
+ * lockfile's mtime against this container's PID-1 start time (read
+ * from /proc/1/stat field 22 + /proc/stat btime). A pidfile whose
+ * mtime predates this container generation is stale regardless of
+ * what `kill(pid, 0)` says — the live PID is a coincident reuse, not
+ * the original holder. Without this check a SIGKILL'd lock can wedge
+ * the supervisor through 10 restart cycles before it gives up, and
+ * since Phase 4 (#893) deleted the singleton scheduler that path is
+ * the only delivery channel for cron.
  */
 
 import {
   closeSync,
   openSync,
   readFileSync,
+  statSync,
   unlinkSync,
   writeSync,
   mkdirSync,
@@ -64,6 +67,63 @@ export interface LockResult {
   /** When `acquired === false`, the live PID currently holding it. */
   holderPid?: number;
 }
+
+export interface AcquireLockOptions {
+  /**
+   * Container PID-1 start time in ms-since-epoch. When set, a
+   * lockfile whose mtime predates this is treated as stale (defends
+   * against PID reuse across container restarts — see #895). Defaults
+   * to `readContainerBootTimeMs()`. Pass `null` to disable the check
+   * (e.g. tests outside a container, or non-Linux deployments).
+   */
+  containerBootTimeMs?: number | null;
+}
+
+/**
+ * Compute when this container's PID 1 started (ms since epoch). Reads
+ * `/proc/1/stat` field 22 (starttime in clock ticks since system boot)
+ * + `/proc/stat` btime (system boot in seconds since epoch). Returns
+ * null when /proc is unavailable or fields don't parse — caller skips
+ * the freshness check rather than fail open.
+ */
+export function readContainerBootTimeMs(): number | null {
+  try {
+    // /proc/1/stat layout: pid (comm) state ppid ... where (comm) can
+    // contain spaces and parens. Split AFTER the last ')' so the comm
+    // doesn't poison field indexes.
+    const stat1 = readFileSync("/proc/1/stat", "utf8");
+    const lastParen = stat1.lastIndexOf(")");
+    if (lastParen < 0) return null;
+    const after = stat1.slice(lastParen + 1).trim().split(/\s+/);
+    // Field 22 = starttime (clock ticks since system boot). State is
+    // field 3 (index 0 of the post-comm split), so field 22 maps to
+    // index 19.
+    const starttimeTicks = Number(after[19]);
+    if (!Number.isFinite(starttimeTicks)) return null;
+
+    const procStat = readFileSync("/proc/stat", "utf8");
+    const btimeLine = procStat.split("\n").find((l) => l.startsWith("btime "));
+    if (!btimeLine) return null;
+    const btimeSec = Number(btimeLine.split(/\s+/)[1]);
+    if (!Number.isFinite(btimeSec)) return null;
+
+    // CLK_TCK is 100 on every kernel switchroom ships against (the
+    // default is universally 100; node doesn't expose sysconf). A
+    // wrong CLK_TCK by 2.5× would misplace boot time by single-digit
+    // seconds at most — bounded by the safety margin in acquireLock.
+    const CLK_TCK = 100;
+    return (btimeSec + starttimeTicks / CLK_TCK) * 1000;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Conservative margin for CLK_TCK uncertainty + clock skew between
+ * /proc and the lockfile's filesystem mtime. A lock written within
+ * ~2s of boot is treated as fresh either way.
+ */
+const FRESHNESS_MARGIN_MS = 2000;
 
 /**
  * Try to acquire the lockfile. Returns `{acquired: true}` on success.
@@ -80,7 +140,12 @@ export interface LockResult {
 export function acquireLock(
   path: string,
   pid: number = process.pid,
+  options: AcquireLockOptions = {},
 ): LockResult {
+  const bootTimeMs = "containerBootTimeMs" in options
+    ? options.containerBootTimeMs
+    : readContainerBootTimeMs();
+
   // mkdir -p the parent so a fresh /state/agent doesn't trip us up.
   try { mkdirSync(dirname(path), { recursive: true, mode: 0o700 }); } catch {
     // mkdir failures are surfaced by the open() that follows.
@@ -97,7 +162,24 @@ export function acquireLock(
     } catch (err) {
       if ((err as NodeJS.ErrnoException).code !== "EEXIST") throw err;
     }
-    // EEXIST — read the holder PID and probe.
+    // EEXIST — first check freshness vs container boot time (#895),
+    // THEN probe PID liveness. Boot-time precedes liveness because
+    // PID reuse across container generations can make a stale lock
+    // look live (low PID density inside a container — tini=1, single-
+    // digit siblings).
+    if (bootTimeMs != null) {
+      try {
+        const lockMtime = statSync(path).mtimeMs;
+        if (lockMtime < bootTimeMs - FRESHNESS_MARGIN_MS) {
+          try { unlinkSync(path); } catch { /* nothing to do */ }
+          continue;
+        }
+      } catch {
+        // statSync race (file disappeared between EEXIST and stat) —
+        // fall through; the next openSync will recover.
+      }
+    }
+    // Read the holder PID and probe with kill(pid, 0).
     let holderPid: number | undefined;
     try {
       const raw = readFileSync(path, "utf8").trim();


### PR DESCRIPTION
## Summary

Closes #895 — flagged as a non-blocking concern by the Phase 3 reviewer (#892), now load-bearing because Phase 4 (#893) deleted the singleton scheduler that used to act as a fallback delivery channel.

Inside an agent container PID density is low (tini=1, single-digit sibling supervisors). After a SIGKILL leaves a pidfile pointing at e.g. PID 23, the new container generation can legitimately have a sibling at PID 23 — \`kill(23, 0)\` returns true, the new agent-scheduler exits EX_TEMPFAIL, and start.sh's \`_switchroom_supervise\` cycles through its 10-restart cap before giving up. Cron silently dies for the affected agent until an operator runs \`switchroom agent restart <name>\`.

**Fix:** on EEXIST in \`acquireLock\`, compare the lockfile's mtime against this container's PID-1 start time (read via \`/proc/1/stat\` field 22 + \`/proc/stat\` btime) BEFORE the PID-liveness probe. A pidfile whose mtime predates this container generation is a previous-gen artifact regardless of what PID it names.

## API additions

- \`AcquireLockOptions.containerBootTimeMs?: number | null\` — defaults to autodetect. Pass \`null\` explicitly to disable (tests outside a container, non-Linux deployments).
- \`readContainerBootTimeMs()\` exported helper. Returns null on parse failure or non-Linux so callers can fall back gracefully.

Safety margin of 2s for CLK_TCK uncertainty + filesystem-vs-/proc clock skew. CLK_TCK is hardcoded to 100 (the universal Linux default; node doesn't expose \`sysconf(_SC_CLK_TCK)\`); a wrong-by-2.5× value would misplace boot time by single-digit seconds, well within the margin.

## Test plan
- [x] 4 new tests added (11/11 in \`lock.test.ts\` pass)
- [x] \`npm run lint\` clean
- [x] Full vitest delta vs \`main\`: 35 failures == 35 baseline failures (pre-existing, \`dist/\`-build-dependent); zero regressions
- [ ] Reviewer-agent verdict pending

🤖 Generated with [Claude Code](https://claude.com/claude-code)