### PR TITLE
fix(agent-scheduler): cronMatchesDate accepts node-cron name aliases (#896)

### DIFF
--- a/src/agent-scheduler/replay.test.ts
+++ b/src/agent-scheduler/replay.test.ts
@@ -19,6 +19,7 @@ import {
   cronMatchesDate,
   findMissedFires,
   matchField,
+  normalizeAliases,
   readRecentFires,
 } from "./replay.js";
 import type { DispatchResult } from "../scheduler/dispatch.js";
@@ -102,6 +103,60 @@ describe("cronMatchesDate", () => {
     expect(cronMatchesDate("0 8 * *", new Date())).toBe(false); // 4 fields
     expect(cronMatchesDate("0 8 * * 1-5 2024", new Date())).toBe(false); // 6 fields
     expect(cronMatchesDate("not-a-cron", new Date())).toBe(false);
+  });
+
+  // Name aliases (#896) — node-cron 3.x accepts these in month + dow
+  // fields. Replay must too or boot replay silently drops fires for
+  // any operator who wrote MON-FRI / JAN-DEC.
+  describe("name aliases (#896)", () => {
+    it("matches MON in dow against a Monday", () => {
+      const monday = new Date("2026-05-11T08:00:00"); // Monday
+      expect(cronMatchesDate("0 8 * * MON", monday)).toBe(true);
+      const tuesday = new Date("2026-05-12T08:00:00");
+      expect(cronMatchesDate("0 8 * * MON", tuesday)).toBe(false);
+    });
+
+    it("matches MON-FRI weekday range", () => {
+      const wed = new Date("2026-05-13T08:00:00");
+      const sat = new Date("2026-05-09T08:00:00");
+      expect(cronMatchesDate("0 8 * * MON-FRI", wed)).toBe(true);
+      expect(cronMatchesDate("0 8 * * MON-FRI", sat)).toBe(false);
+    });
+
+    it("matches JAN in month field", () => {
+      const jan = new Date("2026-01-15T08:00:00");
+      const feb = new Date("2026-02-15T08:00:00");
+      expect(cronMatchesDate("0 8 * JAN *", jan)).toBe(true);
+      expect(cronMatchesDate("0 8 * JAN *", feb)).toBe(false);
+    });
+
+    it("is case-insensitive", () => {
+      const monday = new Date("2026-05-11T08:00:00");
+      expect(cronMatchesDate("0 8 * * mon", monday)).toBe(true);
+      expect(cronMatchesDate("0 8 * * Mon", monday)).toBe(true);
+    });
+
+    it("accepts comma-lists of aliases", () => {
+      const monday = new Date("2026-05-11T08:00:00");
+      const sat = new Date("2026-05-09T08:00:00");
+      expect(cronMatchesDate("0 8 * * MON,WED,FRI", monday)).toBe(true);
+      expect(cronMatchesDate("0 8 * * MON,WED,FRI", sat)).toBe(false);
+    });
+
+    it("normalizeAliases is a no-op for already-numeric input", () => {
+      expect(normalizeAliases("1-5", "dow")).toBe("1-5");
+      expect(normalizeAliases("*", "month")).toBe("*");
+      expect(normalizeAliases("1,3,5", "dow")).toBe("1,3,5");
+    });
+
+    it("normalizeAliases leaves non-month/dow fields untouched", () => {
+      // Defensive: a stray alias in a minute/hour/dom field (operator
+      // typo) shouldn't get substituted — keep aliasing scoped to
+      // fields where node-cron actually accepts it.
+      expect(normalizeAliases("MON", "minute")).toBe("MON");
+      expect(normalizeAliases("MON", "hour")).toBe("MON");
+      expect(normalizeAliases("MON", "dom")).toBe("MON");
+    });
   });
 });
 

--- a/src/agent-scheduler/replay.test.ts
+++ b/src/agent-scheduler/replay.test.ts
@@ -157,6 +157,27 @@ describe("cronMatchesDate", () => {
       expect(normalizeAliases("MON", "hour")).toBe("MON");
       expect(normalizeAliases("MON", "dom")).toBe("MON");
     });
+
+    it("handles mixed alias + numeric forms in the same field", () => {
+      // The most likely user-written form to regress: half the field
+      // is named, half is numeric. Each letter-run substitutes
+      // independently, numerics pass through.
+      expect(normalizeAliases("MON,3,FRI", "dow")).toBe("1,3,5");
+      expect(normalizeAliases("1,WED,5", "dow")).toBe("1,3,5");
+      const monday = new Date("2026-05-11T08:00:00");
+      const wed = new Date("2026-05-13T08:00:00");
+      expect(cronMatchesDate("0 8 * * MON,3,FRI", monday)).toBe(true);
+      expect(cronMatchesDate("0 8 * * MON,3,FRI", wed)).toBe(true);
+    });
+
+    it("normalizes dow=7 (Sunday) chained after alias substitution", () => {
+      // Operator might write the literal '7' alongside aliases. The
+      // substitute-then-normalize-7 order (in cronMatchesDate) must
+      // not double-process: SUN already became 0; 7 also becomes 0.
+      expect(normalizeAliases("MON,7", "dow")).toBe("1,7");
+      const sun = new Date("2026-05-10T08:00:00");
+      expect(cronMatchesDate("0 8 * * MON,7", sun)).toBe(true);
+    });
   });
 });
 

--- a/src/agent-scheduler/replay.ts
+++ b/src/agent-scheduler/replay.ts
@@ -62,8 +62,16 @@ const DOW_ALIASES: Record<string, string> = {
 /**
  * Substitute month/dow name aliases (`JAN`, `MON`, etc.) with their
  * numeric equivalents. Operates on a single cron field; idempotent
- * for already-numeric input. Word-boundary regex so a stray `MON` in
- * a malformed expression doesn't cross-pollute adjacent characters.
+ * for already-numeric input. Letter-run regex so contiguous alpha
+ * tokens substitute as a unit and field separators (`-`, `,`, `/`)
+ * partition the runs cleanly — `MON-FRI` becomes `1-5`, not `1-FRI`.
+ *
+ * Known minor divergence from node-cron 3.x: `MON-FRI/2` expands to
+ * `1-5/2` here (matchPart steps from lo=1 yielding {1,3,5}), whereas
+ * node-cron's convert-expression emits {2,4}. Stepped weekday ranges
+ * with aliases are rare; operators who need them should write the
+ * numeric form. Filed as a known-quirk rather than a bug because
+ * Vixie cron's own behaviour is the {1,3,5} expansion.
  */
 export function normalizeAliases(field: string, kind: FieldKind): string {
   const map = kind === "month" ? MONTH_ALIASES : kind === "dow" ? DOW_ALIASES : null;

--- a/src/agent-scheduler/replay.ts
+++ b/src/agent-scheduler/replay.ts
@@ -47,6 +47,34 @@ const FIELD_RANGES: Record<FieldKind, [number, number]> = {
 };
 
 /**
+ * Name aliases node-cron 3.x accepts in month + day-of-week fields
+ * (#896). Case-insensitive. Substituted to numeric form before
+ * `matchField` runs, so the parser stays integer-only.
+ */
+const MONTH_ALIASES: Record<string, string> = {
+  JAN: "1", FEB: "2", MAR: "3", APR: "4", MAY: "5", JUN: "6",
+  JUL: "7", AUG: "8", SEP: "9", OCT: "10", NOV: "11", DEC: "12",
+};
+const DOW_ALIASES: Record<string, string> = {
+  SUN: "0", MON: "1", TUE: "2", WED: "3", THU: "4", FRI: "5", SAT: "6",
+};
+
+/**
+ * Substitute month/dow name aliases (`JAN`, `MON`, etc.) with their
+ * numeric equivalents. Operates on a single cron field; idempotent
+ * for already-numeric input. Word-boundary regex so a stray `MON` in
+ * a malformed expression doesn't cross-pollute adjacent characters.
+ */
+export function normalizeAliases(field: string, kind: FieldKind): string {
+  const map = kind === "month" ? MONTH_ALIASES : kind === "dow" ? DOW_ALIASES : null;
+  if (map == null) return field;
+  return field.replace(/[A-Za-z]+/g, (token) => {
+    const sub = map[token.toUpperCase()];
+    return sub ?? token;
+  });
+}
+
+/**
  * Returns true if `value` matches the cron field expression `field`.
  * Each field expression is a comma-separated list of parts; a value
  * matches the field iff it matches any part. Each part is one of:
@@ -112,13 +140,17 @@ function matchPart(part: string, value: number, min: number, max: number): boole
 export function cronMatchesDate(expr: string, date: Date): boolean {
   const fields = expr.trim().split(/\s+/);
   if (fields.length !== 5) return false;
-  const [mField, hField, domField, moField, dowFieldRaw] = fields as [
+  const [mField, hField, domField, moFieldRaw, dowFieldRaw] = fields as [
     string, string, string, string, string,
   ];
-  // Normalize 7 → 0 in dow before matching. Operators sometimes write
-  // `0` (Sun-Sat) and sometimes `7` (Sun-Sat-Sun); cron(5) accepts
-  // both.
-  const dowField = dowFieldRaw.replace(/\b7\b/g, "0");
+  // Substitute name aliases (JAN-DEC, SUN-SAT) before any other
+  // normalization. node-cron 3.x accepts these for live fires; the
+  // replay parser must too or boot replay is silently dropped (#896).
+  const moField = normalizeAliases(moFieldRaw, "month");
+  // Normalize 7 → 0 in dow AFTER alias substitution. Operators
+  // sometimes write `0` (Sun-Sat) and sometimes `7` (Sun-Sat-Sun);
+  // cron(5) accepts both.
+  const dowField = normalizeAliases(dowFieldRaw, "dow").replace(/\b7\b/g, "0");
 
   const minuteOk = matchField(mField, date.getMinutes(), "minute");
   const hourOk = matchField(hField, date.getHours(), "hour");


### PR DESCRIPTION
## Summary

Closes #896. Flagged as a minor nit by the Phase 4 reviewer (#893).

\`cronMatchesDate\` was integer-only — \`Number.parseInt(\"MON\", 10)\` returns NaN and the field-match returns false for any minute. So an operator who writes a perfectly valid \`0 8 * * MON-FRI\` gets correct live fires from node-cron but **zero boot-replay coverage** when the container restarts across a fire window. Silent dropped briefings.

**Fix:** pre-substitute month and day-of-week name aliases (JAN-DEC, SUN-SAT, case-insensitive) to numeric form before per-field matching. Word-boundary regex so a stray alias-shaped substring in a malformed expression doesn't cross-pollute. Aliasing is scoped to the month and dow fields only — node-cron doesn't accept aliases elsewhere and we shouldn't either (a stray \`MON\` in a minute-field expression remains a syntax error, not a value).

## Test plan

- [x] 7 new tests added (MON match/non-match, MON-FRI weekday range, JAN month, case-insensitivity, comma-list of aliases, already-numeric is no-op, scoped to month/dow fields only)
- [x] All 28 tests in \`replay.test.ts\` pass
- [x] \`npm run lint\` clean
- [ ] Reviewer-agent verdict pending

🤖 Generated with [Claude Code](https://claude.com/claude-code)