### PR TITLE
fix(test): kernel readiness after live agent-add — `up -d` not `restart` (#857)

### DIFF
--- a/tests/docker/broker-ipc-race.test.ts
+++ b/tests/docker/broker-ipc-race.test.ts
@@ -233,6 +233,12 @@ function getRestartCount(container: string): number {
   } catch { return -1; }
 }
 
+function getContainerId(container: string): string {
+  try {
+    return execSync(`docker inspect -f '{{.Id}}' ${container}`).toString().trim();
+  } catch { return ""; }
+}
+
 /**
  * Run an `approval_lookup` against kernel by execing a tiny inline
  * client inside the kernel container itself (which has bun + the
@@ -386,20 +392,18 @@ afterAll(() => {
   releaseFleetLock();
 }, 60_000);
 
-// Gated behind SWITCHROOM_PHASE1C_RACE=1 in addition to image presence.
-// The "newbie ready after live add" sub-assertion is currently flaky on
-// some kernels — `kernelLookup("newbie")` does not return ok within the
-// 30s socket-bind deadline even when the socket exists. Triaged in
-// PR-D3 as a product/timing question separate from the compose-fixture
-// rot that previously masked it (filed as follow-up). Compose YAML
-// generation IS now exercised by the per-agent-isolation suite which
-// shares the same fixture path; if that goes red, this needs to too.
-const raceOptIn = process.env.SWITCHROOM_PHASE1C_RACE === "1";
-describe.skipIf(!imagesOk || !raceOptIn)(
+// Ungated post-#857: the newbie-readiness assertion was flaky because
+// the test used `docker compose restart approval-kernel`, which does
+// NOT pick up the new kernel-newbie-sock volume mount. Switching to
+// `up -d approval-kernel` (which detects the compose diff and recreates
+// the container with the new volume) makes newbie's socket actually
+// bindable. The compose-fixture rot that previously masked this was
+// already addressed in PR-D3.
+describe.skipIf(!imagesOk)(
   "phase1c broker-IPC race — newbie agent online during sustained kernel IPC",
   () => {
     it(
-      "45 requests succeed, 0 broker/kernel/scheduler restarts, newbie reaches first reply within 60s",
+      "45 requests succeed, broker stays untouched across live add, newbie reaches first reply within 60s",
       async () => {
         if (!ctx) throw new Error("ctx not initialized");
         // Sanity: alice's container can see its own kernel sock at the
@@ -420,6 +424,13 @@ describe.skipIf(!imagesOk || !raceOptIn)(
           broker: getRestartCount("switchroom-vault-broker"),
           kernel: getRestartCount("switchroom-approval-kernel"),
         };
+        // Also capture the kernel container ID — the live-add procedure
+        // recreates the kernel container (`docker compose up -d` picks
+        // up the new kernel-newbie-sock volume mount), which resets
+        // RestartCount to 0 on the new container. We assert recreation
+        // by container-ID change instead of restart-count bump (#857).
+        const startKernelId = getContainerId("switchroom-approval-kernel");
+        const startBrokerId = getContainerId("switchroom-vault-broker");
 
         const results: Array<{ idx: number; ok: boolean; durationMs: number; err?: string }> = [];
         let newbieFirstReplyAt: number | null = null;
@@ -514,8 +525,9 @@ describe.skipIf(!imagesOk || !raceOptIn)(
         const drops = TOTAL_REQUESTS - ok;
 
         // Topology-stability snapshot — captured BEFORE the kernel
-        // restart-after-add step below, since that step is a deliberate
-        // bump (broker/scheduler must still be restartless).
+        // recreation step below, since that step is a deliberate
+        // disturbance (broker must still be untouched; the singleton
+        // scheduler was retired in Phase 4 #893).
         const stabilityCounts = {
           broker: getRestartCount("switchroom-vault-broker"),
           kernel: getRestartCount("switchroom-approval-kernel"),
@@ -541,8 +553,20 @@ describe.skipIf(!imagesOk || !raceOptIn)(
         if (newbieUpAt !== null) {
           const readinessStart = Date.now();
           try {
+            // #857 fix: `docker compose restart` does NOT recreate the
+            // container — it just stops + starts the existing one with
+            // its existing volume mounts. The kernel's enumeration of
+            // per-agent socket dirs (`readdirSync(/run/switchroom/kernel)`
+            // in kernel-server.ts:bootstrap) is gated by what's actually
+            // mounted into the container at create time. compose2 added
+            // a `kernel-newbie-sock` named volume to approval-kernel's
+            // volumes list; only `up -d` (which detects the config diff
+            // and recreates) picks that up. With `restart`, newbie's
+            // subdir never appears in the kernel's view, the kernel
+            // never binds newbie's socket, and the polling loop times
+            // out after 30s — exactly the symptom the issue described.
             execSync(
-              `docker compose -p ${PROJECT} -f ${ctx.composePath} restart approval-kernel`,
+              `docker compose -p ${PROJECT} -f ${ctx.composePath} up -d approval-kernel`,
               { stdio: "pipe", cwd: ctx.workdir },
             );
             // Give kernel up to 30s to bind newbie's per-agent socket.
@@ -599,27 +623,32 @@ describe.skipIf(!imagesOk || !raceOptIn)(
         // ── Topology stability ────────────────────────────────────────
         // Assertion 1: zero IPC drops on alice's pre-existing socket.
         expect(drops).toBe(0);
-        // Assertion 2: broker / kernel / scheduler RestartCount unchanged
-        // across the agent-add window itself (kernel restart-after-add
-        // is a separate, deliberate step measured below).
+        // Assertion 2: broker + kernel RestartCount unchanged across
+        // the agent-add window itself (kernel recreation is a separate,
+        // deliberate step measured below). Singleton scheduler is gone
+        // since Phase 4 (#893).
         expect(stabilityCounts.broker).toBe(startCounts.broker);
         expect(stabilityCounts.kernel).toBe(startCounts.kernel);
-        expect(stabilityCounts.scheduler).toBe(startCounts.scheduler);
 
         // ── Newbie readiness ──────────────────────────────────────────
         // Assertion 3a: newbie reached "own socket bound + first lookup
-        // answered" within the budget. This requires the kernel
-        // restart-after-add — broker + scheduler MUST stay restartless.
+        // answered" within the budget. This requires kernel recreation
+        // with the new volume mount — broker MUST stay untouched.
         expect(newbieUpAt).not.toBeNull();
         expect(newbieReadyAt).not.toBeNull();
         expect(newbieReadyLatencyMs).not.toBeNull();
         expect(newbieReadyLatencyMs!).toBeLessThan(NEWBIE_FIRST_REPLY_BUDGET_MS);
-        // Assertion 3b: broker + scheduler RestartCount STILL unchanged
-        // even after the kernel restart. Kernel is allowed to bump by
-        // exactly 1 (the deliberate restart-after-add).
+        // Assertion 3b: kernel was recreated (container ID changed) so
+        // it picked up the new kernel-newbie-sock volume; broker was
+        // NOT touched (container ID unchanged + RestartCount stable).
+        // Pre-#857 the test used `docker compose restart` and asserted
+        // RestartCount+1; that didn't actually recreate the container,
+        // so newbie's volume mount never appeared inside the kernel.
+        const endKernelId = getContainerId("switchroom-approval-kernel");
+        const endBrokerId = getContainerId("switchroom-vault-broker");
+        expect(endBrokerId).toBe(startBrokerId);
         expect(endCounts.broker).toBe(startCounts.broker);
-        expect(endCounts.scheduler).toBe(startCounts.scheduler);
-        expect(endCounts.kernel).toBe(startCounts.kernel + 1);
+        expect(endKernelId).not.toBe(startKernelId);
       },
       LONG_MODE ? 240_000 : 120_000,
     );

--- a/tests/docker/broker-ipc-race.test.ts
+++ b/tests/docker/broker-ipc-race.test.ts
@@ -505,10 +505,11 @@ describe.skipIf(!imagesOk)(
               // count stability.
               process.stderr.write(`[race-test] newbie up failed: ${(e as Error).message}\n`);
             }
-            // Treat first SUCCESSFUL request after up-d as "newbie first reply"
-            // proxy, since newbie's own kernel socket isn't bound by the
-            // existing kernel container (kernel is restartless here).
-            // (Documented limitation.)
+            // Track first SUCCESSFUL alice lookup post-add as a topology-
+            // stability proxy (proves the live add didn't disturb existing
+            // sockets). Newbie's own readiness is asserted separately
+            // below after the kernel is recreated to pick up the new
+            // volume mount.
           }
           const r = kernelLookup("alice");
           results.push({ idx: i, ok: r.ok, durationMs: r.durationMs, err: r.err });
@@ -535,19 +536,21 @@ describe.skipIf(!imagesOk)(
 
         // Phase 3c F-#811 — split newbie-readiness from topology-stability.
         //
-        // Topology stability (existing assertions): broker/scheduler/kernel
+        // Topology stability (existing assertions): broker + kernel
         // RestartCount unchanged across the agent-add window. The original
-        // test conflated "first SUCCESSFUL alice lookup after newbie up" with
-        // "newbie is ready" — those are different things. Alice's IPC running
-        // through alice's pre-existing socket only proves the topology change
-        // didn't disrupt the existing fleet.
+        // test conflated "first SUCCESSFUL alice lookup after newbie up"
+        // with "newbie is ready" — those are different things. Alice's
+        // IPC running through alice's pre-existing socket only proves the
+        // topology change didn't disrupt the existing fleet.
         //
-        // Newbie readiness (new): newbie's OWN kernel socket is bound and
-        // newbie's first lookup against newbie's socket succeeds. The kernel
-        // server enumerates agents from the config + filesystem at boot, so
-        // it MUST be restarted after newbie's compose entry is added for its
-        // socket to exist. Broker + scheduler stay restartless — kernel
-        // RestartCount is allowed to bump by exactly 1.
+        // Newbie readiness (#857): newbie's OWN kernel socket is bound
+        // and newbie's first lookup against newbie's socket succeeds.
+        // The kernel-server enumerates agents from per-agent socket dirs
+        // mounted in at container-create time. So the kernel container
+        // must be RECREATED (not merely restarted) after newbie's compose
+        // entry is added — `up -d approval-kernel` does this; `restart`
+        // does NOT. Broker stays untouched. Singleton scheduler is gone
+        // since Phase 4 (#893).
         let newbieReadyAt: number | null = null;
         let newbieReadyLatencyMs: number | null = null;
         if (newbieUpAt !== null) {

--- a/tests/docker/build-images.sh
+++ b/tests/docker/build-images.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
-# Phase 1b helper — build all 5 images locally with the :phase1b-test tag
-# so tests/docker/e2e.test.ts can find them. CI does the same via the
-# multi-arch workflow at .github/workflows/docker-images.yml.
+# Phase 1b helper — build the docker images locally with the :phase1b-test
+# tag so tests/docker/e2e.test.ts and friends can find them. CI does the
+# same via the multi-arch workflow at .github/workflows/docker-images.yml.
+# Phase 4 (#893) retired the singleton scheduler image; this script
+# tracks that.
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
@@ -13,7 +15,7 @@ echo "[build-images] running npm build (emits dist/ bundles required by COPY dir
 echo "[build-images] base"
 docker buildx build -t "switchroom/base:${TAG}" -f "$ROOT/docker/Dockerfile.base" --load "$ROOT"
 
-for img in agent broker kernel scheduler; do
+for img in agent broker kernel; do
   echo "[build-images] ${img}"
   docker buildx build \
     --build-arg "BASE_IMAGE=switchroom/base:${TAG}" \

--- a/tests/docker/e2e.test.ts
+++ b/tests/docker/e2e.test.ts
@@ -200,20 +200,9 @@ describe.skipIf(!dockerOk || !allImagesPresent)(
       }
     });
 
-    it("scheduler image's bundled index.js loads under node and better-sqlite3 prebuilt opens an in-memory DB", () => {
-      const script = [
-        `const Database = require('better-sqlite3');`,
-        `const db = new Database(':memory:');`,
-        `db.exec('CREATE TABLE t(x INTEGER)');`,
-        `db.prepare('INSERT INTO t VALUES (?)').run(7);`,
-        `const row = db.prepare('SELECT x FROM t').get();`,
-        `console.log('sqlite_ok=' + row.x);`,
-      ].join("");
-      const out = execSync(
-        `docker run --rm ${LABELS} --entrypoint node ${IMAGES.scheduler} -e ${JSON.stringify(script)}`,
-      ).toString();
-      expect(out.trim()).toBe("sqlite_ok=7");
-    });
+    // scheduler-image test removed in #893 (Phase 4 cron-fold-in
+    // cutover). better-sqlite3 prebuilt-binary loading is now exercised
+    // inside the agent image via the bundled agent-scheduler sidecar.
 
     it("agent image enforces read-only rootfs (touch /etc/passwd → EROFS)", () => {
       const r = spawnSync(

--- a/tests/docker/e2e.test.ts
+++ b/tests/docker/e2e.test.ts
@@ -56,7 +56,9 @@ const IMAGES = {
   agent: `switchroom/agent:${TAG}`,
   broker: `switchroom/broker:${TAG}`,
   kernel: `switchroom/kernel:${TAG}`,
-  scheduler: `switchroom/scheduler:${TAG}`,
+  // Phase 4 (#893) retired the singleton scheduler image. Keeping it
+  // here would make `imagesOk` false in any environment that doesn't
+  // build the (now-deleted) image, silently skipping this whole suite.
 };
 
 function hasDocker(): boolean {

--- a/tests/docker/per-agent-isolation.test.ts
+++ b/tests/docker/per-agent-isolation.test.ts
@@ -153,7 +153,6 @@ function buildTestCompose(agents: string[], cfgPath: string): string {
     .replace(/- \$\{HOME\}\/\.switchroom\/vault:\/state\/vault\b/g, "- vault-state:/state/vault")
     .replace(/- \$\{HOME\}\/\.switchroom\/approvals:\/state\/approvals\b/g, "- approvals-state:/state/approvals")
     .replace(/- \$\{HOME\}\/\.switchroom:\/state\/config:ro\b/g, `- ${cfgPath}:/state/config/switchroom.yaml:ro`)
-    .replace(/- \$\{HOME\}\/\.switchroom\/scheduler:\/state\/scheduler\b/g, "- scheduler-state:/state/scheduler")
     .replace(/- \$\{HOME\}\/\.switchroom\/agents\/[^:]+:\/state\/agent\b/g, "- agent-state:/state/agent")
     .replace(/- \$\{HOME\}\/\.claude\/projects\/[^:]+:\/state\/\.claude\b/g, "- claude-state:/state/.claude");
   for (const a of agents) {
@@ -172,7 +171,7 @@ function buildTestCompose(agents: string[], cfgPath: string): string {
   ]);
   yml = yml.replace(/(  vault-broker:[\s\S]*?volumes:\n)/, `$1      - ${cfgPath}:/state/config/switchroom.yaml:ro\n`);
   yml = yml.replace(/(  approval-kernel:[\s\S]*?volumes:\n)/, `$1      - ${cfgPath}:/state/config/switchroom.yaml:ro\n`);
-  yml += "  vault-state:\n  approvals-state:\n  scheduler-state:\n  agent-state:\n  claude-state:\n";
+  yml += "  vault-state:\n  approvals-state:\n  agent-state:\n  claude-state:\n";
   // CLAUDE.md HARD RULES: every test container carries the
   // `switchroom.test=phase1c` label + per-run UUID. Note this fires
   // before appendAdversarialServices() so we re-inject after that

--- a/tests/docker/per-agent-isolation.test.ts
+++ b/tests/docker/per-agent-isolation.test.ts
@@ -55,7 +55,10 @@ import {
 const RUN_ID = newRunId();
 
 const TAG = "phase1b-test";
-const IMAGES = ["base", "agent", "broker", "kernel", "scheduler"].map(
+// Phase 4 (#893) retired the singleton scheduler image. Listing it
+// here would make `imagesOk` false in any environment that doesn't
+// build the (now-deleted) image, silently skipping the whole suite.
+const IMAGES = ["base", "agent", "broker", "kernel"].map(
   (n) => `switchroom/${n}:${TAG}`,
 );
 const PROJECT = `phase1c-iso-${process.pid}`;


### PR DESCRIPTION
## Summary

Closes #857. Linked to #811.

The \`tests/docker/broker-ipc-race.test.ts\` newbie-ready-after-live-add assertion was gated behind \`SWITCHROOM_PHASE1C_RACE=1\` because the kernel container didn't reply to vault lookups within 30s after a fresh agent was added live. **Root cause:** the test used \`docker compose restart approval-kernel\`, which stops + starts the existing container with its EXISTING volume mounts. The kernel's per-agent socket enumeration (\`readdirSync(/run/switchroom/kernel)\` in \`bootstrap()\`) is gated by what's actually mounted at create time. The regenerated compose added a \`kernel-newbie-sock\` named volume to approval-kernel's volumes list — only \`up -d\` (which detects the config diff and recreates) picks that up. With \`restart\`, newbie's subdir never appeared in the kernel's view, the kernel never bound newbie's socket, and the polling loop timed out.

## Fix

- \`restart approval-kernel\` → \`up -d approval-kernel\` (compose detects the volume-list diff and recreates).
- The recreation resets kernel RestartCount to 0 on the new container, so \`endCounts.kernel === startCounts.kernel + 1\` no longer applies. Replaced with a container-ID-changed check that proves recreation happened, plus an explicit broker-container-ID-unchanged check that proves broker was NOT disturbed.
- Drop the singleton scheduler restart-count assertion (Phase 4 #893 retired the singleton).
- Drop the \`SWITCHROOM_PHASE1C_RACE=1\` gate.

**Drive-by:** drop the \`scheduler\` entry from \`tests/docker/build-images.sh\` (Phase 4 retired \`Dockerfile.scheduler\` — same cleanup class as #899 which already merged for the CI build matrix).

## Test plan

- [x] \`bash tests/docker/build-images.sh\` — clean build of 4 images (no scheduler)
- [x] \`npx vitest run tests/docker/broker-ipc-race.test.ts\` — passes locally
  - 45/45 requests succeed, 0 drops
  - newbie_ready_latency_ms = **1578ms** (vs the 30s timeout that was failing pre-fix)
  - broker container ID unchanged across the live-add window
  - kernel container ID changed (proves recreation picked up the new volume)
- [x] \`npm run lint\` clean
- [ ] Reviewer-agent verdict pending

🤖 Generated with [Claude Code](https://claude.com/claude-code)