### PR TITLE
fix(scheduler): collectScheduleEntries walks cascade-resolved config

### DIFF
--- a/src/scheduler/collect-entries.test.ts
+++ b/src/scheduler/collect-entries.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Cascade-resolution regression tests for `collectScheduleEntries`.
+ *
+ * The original implementation walked raw `config.agents[name].schedule`
+ * and silently dropped entries declared in `defaults.schedule` or in a
+ * profile's extends-chain. After Phase 4 (#893) deleted the singleton
+ * scheduler, that meant cron silently died for every agent whose
+ * schedule lived above the agent block in the cascade. These tests
+ * pin the cascade-aware behaviour so the regression can't return.
+ */
+
+import { describe, it, expect } from "vitest";
+import { collectScheduleEntries } from "./dispatch.js";
+import type { SwitchroomConfig } from "../config/schema.js";
+
+function configFromAgents(
+  agents: Record<string, Record<string, unknown>>,
+  extras: Partial<SwitchroomConfig> = {},
+): SwitchroomConfig {
+  return {
+    switchroom: {
+      version: 1,
+      agents_dir: "/tmp/agents",
+      skills_dir: "/tmp/skills",
+    },
+    telegram: { bot_token: "x", forum_chat_id: "-1001234567890" },
+    vault: { path: "/tmp/vault.enc" },
+    agents: agents as SwitchroomConfig["agents"],
+    ...extras,
+  } as SwitchroomConfig;
+}
+
+describe("collectScheduleEntries — cascade resolution", () => {
+  it("collects an agent-only schedule (baseline)", () => {
+    const cfg = configFromAgents({
+      alice: {
+        schedule: [
+          { cron: "0 8 * * *", prompt: "morning briefing" },
+        ],
+      },
+    });
+    const entries = collectScheduleEntries(cfg);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({
+      agent: "alice",
+      scheduleIndex: 0,
+      cron: "0 8 * * *",
+      prompt: "morning briefing",
+    });
+  });
+
+  it("collects schedule entries declared in defaults — the original silent-drop bug", () => {
+    const cfg = configFromAgents(
+      { alice: {} },
+      {
+        defaults: {
+          schedule: [
+            { cron: "0 9 * * *", prompt: "from defaults" },
+          ],
+        } as SwitchroomConfig["defaults"],
+      },
+    );
+    const entries = collectScheduleEntries(cfg);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]?.prompt).toBe("from defaults");
+    expect(entries[0]?.agent).toBe("alice");
+  });
+
+  it("collects schedule entries from a profile via extends:", () => {
+    const cfg = configFromAgents(
+      { alice: { extends: "ops" } },
+      {
+        profiles: {
+          ops: {
+            schedule: [
+              { cron: "*/5 * * * *", prompt: "from profile" },
+            ],
+          },
+        } as unknown as SwitchroomConfig["profiles"],
+      },
+    );
+    const entries = collectScheduleEntries(cfg);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]?.prompt).toBe("from profile");
+  });
+
+  it("concatenates defaults + profile + agent schedule entries in declared order", () => {
+    const cfg = configFromAgents(
+      {
+        alice: {
+          extends: "ops",
+          schedule: [{ cron: "0 17 * * *", prompt: "agent" }],
+        },
+      },
+      {
+        defaults: {
+          schedule: [{ cron: "0 8 * * *", prompt: "defaults" }],
+        } as SwitchroomConfig["defaults"],
+        profiles: {
+          ops: {
+            schedule: [{ cron: "0 12 * * *", prompt: "profile" }],
+          },
+        } as unknown as SwitchroomConfig["profiles"],
+      },
+    );
+    const entries = collectScheduleEntries(cfg);
+    expect(entries.map((e) => e.prompt)).toEqual([
+      "defaults",
+      "profile",
+      "agent",
+    ]);
+    // Index must be sequential 0..N across the merged list — replay
+    // semantics index off this number, so a re-ordering would change
+    // which audit row matches which entry.
+    expect(entries.map((e) => e.scheduleIndex)).toEqual([0, 1, 2]);
+  });
+
+  it("empty defaults + empty profile + empty agent yields no entries (no false positives)", () => {
+    const cfg = configFromAgents(
+      { alice: { extends: "ops" } },
+      {
+        defaults: {} as SwitchroomConfig["defaults"],
+        profiles: { ops: {} } as unknown as SwitchroomConfig["profiles"],
+      },
+    );
+    expect(collectScheduleEntries(cfg)).toEqual([]);
+  });
+});

--- a/src/scheduler/dispatch.ts
+++ b/src/scheduler/dispatch.ts
@@ -20,6 +20,7 @@
 
 import { createHash } from "node:crypto";
 import type { ScheduleEntry, SwitchroomConfig } from "../config/schema.js";
+import { resolveAgentConfig } from "../config/merge.js";
 
 export interface SchedulerEntry {
   agent: string;
@@ -31,8 +32,17 @@ export interface SchedulerEntry {
 }
 
 /**
- * Walk the resolved config and produce a flat list of (agent, index)
- * schedule entries that the cron loop registers. Pure function: no IO.
+ * Walk the cascade-resolved config and produce a flat list of (agent,
+ * index) schedule entries that the cron loop registers. Pure function:
+ * no IO.
+ *
+ * Cascade resolution is load-bearing — `schedule` is a `concatenate`
+ * cascade key (defaults.schedule + profile.schedule + agent.schedule).
+ * Walking raw `config.agents[name].schedule` (as the pre-fix code did)
+ * silently dropped entries declared in defaults or in a profile's
+ * extends-chain, leaving the in-agent scheduler with "no schedule
+ * entries" — which then triggered the start.sh supervisor's
+ * restart-cap and silently killed cron for the affected agent.
  *
  * Deterministic order: agents sorted by name, then schedule entries by
  * declared index. Important for snapshot tests of the audit log shape.
@@ -43,7 +53,10 @@ export function collectScheduleEntries(
   const out: SchedulerEntry[] = [];
   const agentNames = Object.keys(config.agents).sort();
   for (const agent of agentNames) {
-    const schedule: ScheduleEntry[] = config.agents[agent]?.schedule ?? [];
+    const raw = config.agents[agent];
+    if (!raw) continue;
+    const resolved = resolveAgentConfig(config.defaults, config.profiles, raw);
+    const schedule: ScheduleEntry[] = resolved.schedule ?? [];
     for (let i = 0; i < schedule.length; i++) {
       const entry = schedule[i]!;
       out.push({


### PR DESCRIPTION
## Summary

\`collectScheduleEntries\` walked raw \`config.agents[name].schedule\` and skipped entries declared in \`defaults.schedule\` or in a profile's extends-chain. \`schedule\` is a \`concatenate\` cascade key (defaults + profile + agent), but the helper bypassed the merge entirely. Result: the in-agent scheduler reports "no schedule entries" at boot, exits 0, the \`_switchroom_supervise\` wrapper burns its 10-restart-in-60s budget, and gives up. Since Phase 4 (#893) deleted the singleton scheduler that previously acted as a fallback, **cron silently dies for any agent whose schedule lives in defaults or in a profile**.

**Fix:** route each agent through \`resolveAgentConfig(defaults, profiles, raw)\` and read the resolved \`schedule\`. Same pure-function shape; same deterministic order (agents sorted by name, entries by index).

This **supersedes** the third fix in PR #908 (which had the right cascade analysis). The other two fixes in #908 (skills/credentials bind mounts, scaffold reachability check) are already addressed by the merged #912.

## Test plan

- [x] new \`src/scheduler/collect-entries.test.ts\` — 5 cases:
  - agent-only baseline
  - **defaults-only** (the silent-drop bug — pins the regression)
  - profile-only via \`extends:\`
  - all-three concatenated, in declared order, sequential indexes
  - all-empty cascade yields \`[]\` (no false positives)
- [x] \`npm run lint\` clean
- [x] All 12 tests in \`src/scheduler/\` pass
- [ ] Reviewer-agent verdict pending

🤖 Generated with [Claude Code](https://claude.com/claude-code)