### PR TITLE
fix(agent-scheduler): idle on empty schedule instead of exit-0 + restart-cap

### DIFF
--- a/src/agent-scheduler/index.ts
+++ b/src/agent-scheduler/index.ts
@@ -240,6 +240,16 @@ export async function main(): Promise<void> {
     // restart re-runs main() and re-reads config, so a future
     // `apply` that adds schedule entries gets picked up cleanly.
     setInterval(() => { /* idle */ }, 1 << 30);
+    // Release the lock cleanly on SIGTERM/SIGINT so a subsequent
+    // boot doesn't have to fall back to the stale-lock reclaim path
+    // in acquireLock. Only matters for log cleanliness — the reclaim
+    // path works either way (#895 boot-time freshness check).
+    const cleanup = (): never => {
+      releaseLock(lockPath);
+      process.exit(0);
+    };
+    process.once("SIGTERM", cleanup);
+    process.once("SIGINT", cleanup);
     return;
   }
 

--- a/src/agent-scheduler/index.ts
+++ b/src/agent-scheduler/index.ts
@@ -226,9 +226,21 @@ export async function main(): Promise<void> {
 
   if (entries.length === 0) {
     process.stdout.write(
-      `agent-scheduler: ${agentName} has no schedule entries — exiting cleanly\n`,
+      `agent-scheduler: ${agentName} has no schedule entries — idling ` +
+      `(re-checks on container restart)\n`,
     );
-    process.exit(0);
+    // Stay alive so start.sh's _switchroom_supervise restart-cap
+    // doesn't burn through 10 restarts and give up. An agent that
+    // legitimately has no cron is a perfectly normal state — most
+    // agents in a typical fleet don't have schedule blocks. The
+    // previous `process.exit(0)` produced 10 lines of noise per
+    // schedule-less agent in the supervisor log every container
+    // restart, then permanently wedged the supervisor for that
+    // agent. setInterval is enough to peg the event loop; container
+    // restart re-runs main() and re-reads config, so a future
+    // `apply` that adds schedule entries gets picked up cleanly.
+    setInterval(() => { /* idle */ }, 1 << 30);
+    return;
   }
 
   const sink: AuditSink = new JsonlAuditSink(resolve(jsonlPath));


### PR DESCRIPTION
## Summary

Pre-fix: an agent with no \`schedule:\` entries (typical — most agents in a fleet don't have cron) hit the empty-entries branch in \`main()\`, wrote \"no schedule entries — exiting cleanly\", and exited 0. start.sh's \`_switchroom_supervise\` respawned it; the cycle repeated until the 10-restart-in-60s cap fired and the supervisor permanently gave up.

**Two visible problems:**
1. Supervisor log produces 10 lines of \"no schedule entries\" + \"hit 10 restarts in <60s — giving up\" on every container restart for every schedule-less agent.
2. If the operator later edits the config to add a schedule entry and runs \`apply\`, the supervisor is already wedged — only a container restart re-arms it.

**Fix:** replace \`process.exit(0)\` with an indefinite \`setInterval\` that pegs the event loop. The process stays alive (no respawn), the supervisor sees a healthy long-running child (no restart-cap burn), and future \`apply\` runs that add entries get picked up on the next container restart.

Carried forward from PR #908's third sub-fix; #917 took the cascade-resolution half but left this part.

**Surfaced live** during the v0.7.7 update on a production host: 6 of 8 agents had no \`schedule:\` block and were spamming the supervisor log accordingly.

## Test plan

- [x] \`npm run lint\` clean
- [x] All 53 tests in \`src/agent-scheduler/\` pass
- [x] Will be visible end-to-end after merge: schedule-less agent containers should show a single \"idling\" line in the supervisor log instead of 10 restart attempts
- [ ] Reviewer-agent verdict pending

🤖 Generated with [Claude Code](https://claude.com/claude-code)