### PR TITLE
feat(cli): `switchroom update` — one verb for the host-update flow (#918)

### DIFF
--- a/src/cli/update.test.ts
+++ b/src/cli/update.test.ts
@@ -1,0 +1,221 @@
+/**
+ * Unit tests for `switchroom update` (#918). Drives the planUpdate
+ * step builder + runUpdate dispatch with a fake runner so no real
+ * docker / git / bun is invoked.
+ */
+
+import { describe, it, expect } from "vitest";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { planUpdate, runUpdate, isGitCheckout } from "./update.js";
+
+function fakeRunner() {
+  const calls: Array<{ cmd: string; args: string[] }> = [];
+  let nextStatus = 0;
+  return {
+    calls,
+    setNextStatus(n: number) { nextStatus = n; },
+    fn: (cmd: string, args: string[]) => {
+      calls.push({ cmd, args });
+      const s = nextStatus;
+      nextStatus = 0;
+      return { status: s };
+    },
+  };
+}
+
+describe("planUpdate", () => {
+  it("produces 4 steps in default mode (no --rebuild)", () => {
+    const tmp = mkdtempSync(join(tmpdir(), "update-plan-"));
+    try {
+      const composePath = join(tmp, "docker-compose.yml");
+      writeFileSync(composePath, "services: {}\n");
+      const steps = planUpdate({ composePath });
+      expect(steps.map((s) => s.name)).toEqual([
+        "pull-images",
+        "apply-config",
+        "recreate-containers",
+        "doctor",
+      ]);
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("inserts the rebuild-source step when --rebuild is set", () => {
+    const tmp = mkdtempSync(join(tmpdir(), "update-rebuild-"));
+    try {
+      const composePath = join(tmp, "docker-compose.yml");
+      writeFileSync(composePath, "services: {}\n");
+      const steps = planUpdate({ composePath, rebuild: true });
+      expect(steps.map((s) => s.name)).toEqual([
+        "pull-images",
+        "rebuild-source",
+        "apply-config",
+        "recreate-containers",
+        "doctor",
+      ]);
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("skips pull-images with a clear reason when --skip-images is set", () => {
+    const tmp = mkdtempSync(join(tmpdir(), "update-skip-"));
+    try {
+      const composePath = join(tmp, "docker-compose.yml");
+      writeFileSync(composePath, "services: {}\n");
+      const steps = planUpdate({ composePath, skipImages: true });
+      const pull = steps.find((s) => s.name === "pull-images");
+      expect(pull?.skipReason).toContain("--skip-images");
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("skips pull-images with the right reason when compose file doesn't exist", () => {
+    const steps = planUpdate({ composePath: "/nonexistent/compose.yml" });
+    const pull = steps.find((s) => s.name === "pull-images");
+    expect(pull?.skipReason).toContain("compose file not found");
+    expect(pull?.skipReason).toContain("apply --compose-only");
+  });
+
+  it("skips recreate-containers when --skip-images and not --rebuild (nothing to recreate)", () => {
+    const steps = planUpdate({ skipImages: true });
+    const recreate = steps.find((s) => s.name === "recreate-containers");
+    expect(recreate?.skipReason).toContain("nothing to recreate");
+  });
+
+  it("does NOT skip recreate-containers when --rebuild is set, even with --skip-images", () => {
+    // Rebuild changes scaffolds/CLI, so containers may need to bounce
+    // even if image digests didn't change.
+    const tmp = mkdtempSync(join(tmpdir(), "update-rebuild-skipimg-"));
+    try {
+      const composePath = join(tmp, "docker-compose.yml");
+      writeFileSync(composePath, "services: {}\n");
+      const steps = planUpdate({
+        composePath,
+        skipImages: true,
+        rebuild: true,
+      });
+      const recreate = steps.find((s) => s.name === "recreate-containers");
+      expect(recreate?.skipReason).toBeUndefined();
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("runUpdate", () => {
+  it("dry-runs cleanly under --check, no runner calls", async () => {
+    const tmp = mkdtempSync(join(tmpdir(), "update-check-"));
+    try {
+      const composePath = join(tmp, "docker-compose.yml");
+      writeFileSync(composePath, "services: {}\n");
+      const out: string[] = [];
+      const runner = fakeRunner();
+      const code = await runUpdate({
+        check: true,
+        composePath,
+        stdout: (s) => out.push(s),
+        stderr: (s) => out.push(s),
+        runner: runner.fn,
+      });
+      expect(code).toBe(0);
+      expect(runner.calls).toHaveLength(0);
+      const joined = out.join("");
+      expect(joined).toMatch(/dry-run/);
+      expect(joined).toMatch(/pull-images/);
+      expect(joined).toMatch(/apply-config/);
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("runs the steps in order via the injected runner", async () => {
+    const tmp = mkdtempSync(join(tmpdir(), "update-run-"));
+    try {
+      const composePath = join(tmp, "docker-compose.yml");
+      writeFileSync(composePath, "services: {}\n");
+      const out: string[] = [];
+      const runner = fakeRunner();
+      const code = await runUpdate({
+        composePath,
+        stdout: (s) => out.push(s),
+        stderr: (s) => out.push(s),
+        runner: runner.fn,
+      });
+      expect(code).toBe(0);
+      // 4 calls: pull, apply, up, doctor. Identify each by its
+      // signature args (cmd + first non-script arg).
+      expect(runner.calls).toHaveLength(4);
+      // [0] docker compose ... pull
+      expect(runner.calls[0]?.cmd).toBe("docker");
+      expect(runner.calls[0]?.args).toContain("pull");
+      // [1] <execPath> <scriptPath> apply --non-interactive
+      expect(runner.calls[1]?.cmd).toBe(process.execPath);
+      expect(runner.calls[1]?.args).toContain("apply");
+      expect(runner.calls[1]?.args).toContain("--non-interactive");
+      // [2] docker compose ... up -d --remove-orphans
+      expect(runner.calls[2]?.cmd).toBe("docker");
+      expect(runner.calls[2]?.args).toContain("up");
+      expect(runner.calls[2]?.args).toContain("--remove-orphans");
+      // [3] <execPath> <scriptPath> doctor
+      expect(runner.calls[3]?.cmd).toBe(process.execPath);
+      expect(runner.calls[3]?.args).toContain("doctor");
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("fails fast on a step error and reports which step", async () => {
+    const tmp = mkdtempSync(join(tmpdir(), "update-fail-"));
+    try {
+      const composePath = join(tmp, "docker-compose.yml");
+      writeFileSync(composePath, "services: {}\n");
+      const out: string[] = [];
+      const runner = fakeRunner();
+      runner.setNextStatus(1); // first call (pull) fails
+      const code = await runUpdate({
+        composePath,
+        stdout: (s) => out.push(s),
+        stderr: (s) => out.push(s),
+        runner: runner.fn,
+      });
+      expect(code).toBe(1);
+      // Should NOT have proceeded to apply / up / doctor.
+      expect(runner.calls).toHaveLength(1);
+      expect(out.join("")).toMatch(/pull-images failed/);
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("isGitCheckout", () => {
+  it("returns true for a path under a directory containing .git", () => {
+    const tmp = mkdtempSync(join(tmpdir(), "git-detect-"));
+    try {
+      mkdirSync(join(tmp, ".git"), { recursive: true });
+      mkdirSync(join(tmp, "dist", "cli"), { recursive: true });
+      const scriptPath = join(tmp, "dist", "cli", "switchroom.js");
+      writeFileSync(scriptPath, "");
+      expect(isGitCheckout(scriptPath)).toBe(true);
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("returns false for a path with no .git ancestor", () => {
+    const tmp = mkdtempSync(join(tmpdir(), "no-git-detect-"));
+    try {
+      mkdirSync(join(tmp, "dist", "cli"), { recursive: true });
+      const scriptPath = join(tmp, "dist", "cli", "switchroom.js");
+      writeFileSync(scriptPath, "");
+      expect(isGitCheckout(scriptPath)).toBe(false);
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/cli/update.test.ts
+++ b/src/cli/update.test.ts
@@ -81,26 +81,32 @@ describe("planUpdate", () => {
     expect(pull?.skipReason).toContain("apply --compose-only");
   });
 
-  it("skips recreate-containers when --skip-images and not --rebuild (nothing to recreate)", () => {
+  it("never skips recreate-containers — even with --skip-images, apply may have changed compose (#923 reviewer)", () => {
     const steps = planUpdate({ skipImages: true });
     const recreate = steps.find((s) => s.name === "recreate-containers");
-    expect(recreate?.skipReason).toContain("nothing to recreate");
+    expect(recreate?.skipReason).toBeUndefined();
   });
+});
 
-  it("does NOT skip recreate-containers when --rebuild is set, even with --skip-images", () => {
-    // Rebuild changes scaffolds/CLI, so containers may need to bounce
-    // even if image digests didn't change.
-    const tmp = mkdtempSync(join(tmpdir(), "update-rebuild-skipimg-"));
+describe("--rebuild against a non-checkout install fails loudly (#923 reviewer)", () => {
+  it("rebuild-source step throws when scriptPath has no .git ancestor", () => {
+    const tmp = mkdtempSync(join(tmpdir(), "rebuild-no-git-"));
     try {
       const composePath = join(tmp, "docker-compose.yml");
       writeFileSync(composePath, "services: {}\n");
-      const steps = planUpdate({
-        composePath,
-        skipImages: true,
-        rebuild: true,
-      });
-      const recreate = steps.find((s) => s.name === "recreate-containers");
-      expect(recreate?.skipReason).toBeUndefined();
+      // Spoof argv[1] to a path with no .git ancestor for the duration
+      // of the plan() + run() calls.
+      const origArgv1 = process.argv[1];
+      process.argv[1] = join(tmp, "fake-installed-cli.js");
+      try {
+        const steps = planUpdate({ composePath, rebuild: true });
+        const rebuild = steps.find((s) => s.name === "rebuild-source");
+        expect(rebuild).toBeDefined();
+        expect(rebuild?.skipReason).toBeUndefined(); // not silently skipped
+        expect(() => rebuild!.run()).toThrow(/--rebuild requires a git checkout/);
+      } finally {
+        process.argv[1] = origArgv1;
+      }
     } finally {
       rmSync(tmp, { recursive: true, force: true });
     }

--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -1,61 +1,264 @@
 /**
- * `switchroom update` — removed in v0.7.
+ * `switchroom update` — bundle the host-update flow into one verb (#918).
  *
- * Replaced by the explicit operator-driven flow:
+ * Pre-#918 the operator was told to invoke five commands across two
+ * privilege levels:
  *
- *     docker compose -p switchroom -f ~/.switchroom/compose/docker-compose.yml pull
- *     switchroom apply
+ *     git pull
+ *     bun install
+ *     npm run build
+ *     sudo HOME=$HOME PATH=... bun /path/to/dist/cli/switchroom.js apply --non-interactive
  *     docker compose -p switchroom -f ~/.switchroom/compose/docker-compose.yml up -d
  *
- * This shim exists to keep v0.6 muscle memory + the v0.6 → v0.7 in-flight
- * upgrade path from hard-failing. It silently swallows the legacy flags
- * (`--force`, `--check`, `--no-restart`, `--resume`, `--phase`).
+ * Each had failure modes — the sudo invocation alone (#920) had three
+ * — and operators who didn't memorize the incantation got things half
+ * deployed. `update` runs them in order, with idempotent skip-if-fresh
+ * checks where possible and clean failure surfacing on each step.
  *
- * `--phase=post-build` is the one case where we exit 0 — that path is
- * invoked by an in-flight v0.6 upgrade self-reexec mid-replace; failing
- * there would leave the operator's fleet in a half-deployed state.
- * Every other invocation exits 1.
+ * Steps (in order):
+ *   1. Pull docker images (broker, kernel, agent) from GHCR.
+ *   2. (--rebuild only) git pull upstream main + bun install + npm run build.
+ *   3. switchroom apply (self-elevates via #920 if needed).
+ *   4. docker compose up -d --remove-orphans (recreates containers
+ *      whose image digest or compose entry changed).
+ *   5. switchroom doctor — surface any FAIL diagnostics post-bounce.
+ *
+ * Flags:
+ *   --check          dry-run; print the steps that would run, exit 0.
+ *   --skip-images    skip step 1 (offline mode).
+ *   --rebuild        run step 2 (source-checkout users; auto-skipped
+ *                    when not in a git repo).
+ *
+ * Legacy `--phase=post-build` is still accepted as a no-op so any
+ * in-flight v0.6 → v0.7 self-reexec path doesn't crash mid-flight.
  */
 import type { Command } from "commander";
 import chalk from "chalk";
+import { existsSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { join, dirname } from "node:path";
+import { homedir } from "node:os";
 
-const REMOVAL_MESSAGE = [
-  "switchroom update is removed in v0.7+.",
-  "Upgrade via:",
-  "  docker compose -p switchroom -f ~/.switchroom/compose/docker-compose.yml pull \\",
-  "    && switchroom apply \\",
-  "    && docker compose -p switchroom -f ~/.switchroom/compose/docker-compose.yml up -d",
-].join("\n");
+interface UpdateOptions {
+  check?: boolean;
+  skipImages?: boolean;
+  rebuild?: boolean;
+  /** Hidden / legacy flags — kept so v0.6-era invocations don't crash. */
+  phase?: string;
+  force?: boolean;
+  /** Compose-file override for tests. */
+  composePath?: string;
+  /** stdout/stderr writers for tests. */
+  stdout?: (s: string) => void;
+  stderr?: (s: string) => void;
+  /** Test seam — replace step.run with a fake. */
+  runner?: (cmd: string, args: string[]) => { status: number };
+}
+
+interface UpdateStep {
+  name: string;
+  description: string;
+  /** When true, step is skipped entirely (e.g. --skip-images). */
+  skipReason?: string;
+  /** Invoked when not in --check mode. Throws on failure. */
+  run: () => void;
+}
+
+const DEFAULT_COMPOSE_PATH = join(
+  homedir(),
+  ".switchroom",
+  "compose",
+  "docker-compose.yml",
+);
+
+/**
+ * Detect whether the running CLI lives inside a git checkout (so
+ * `--rebuild` is meaningful) or is an installed binary (where a git
+ * pull would be nonsensical).
+ */
+export function isGitCheckout(scriptPath: string): boolean {
+  let dir = dirname(scriptPath);
+  for (let i = 0; i < 10; i++) {
+    if (existsSync(join(dir, ".git"))) return true;
+    const parent = dirname(dir);
+    if (parent === dir) return false;
+    dir = parent;
+  }
+  return false;
+}
+
+/**
+ * Build the ordered list of update steps. Pure function — no side
+ * effects. The action handler iterates this list and either prints
+ * (--check) or executes (default).
+ */
+export function planUpdate(opts: UpdateOptions): UpdateStep[] {
+  const composePath = opts.composePath ?? DEFAULT_COMPOSE_PATH;
+  const runner = opts.runner ?? defaultRunner;
+  const steps: UpdateStep[] = [];
+
+  steps.push({
+    name: "pull-images",
+    description: "Pull broker / kernel / agent images from GHCR",
+    skipReason: opts.skipImages
+      ? "--skip-images flag set"
+      : !existsSync(composePath)
+        ? `compose file not found at ${composePath} (run \`switchroom apply --compose-only\` first)`
+        : undefined,
+    run: () => {
+      const r = runner("docker", [
+        "compose", "-p", "switchroom", "-f", composePath, "pull",
+      ]);
+      if (r.status !== 0) throw new Error("docker compose pull failed");
+    },
+  });
+
+  // Source-checkout step. Auto-skip when not in a git repo, so
+  // npm-installed users don't see a confusing "skipping git pull"
+  // line on every update.
+  const scriptPath = process.argv[1] ?? "";
+  const inCheckout = isGitCheckout(scriptPath);
+  if (opts.rebuild) {
+    steps.push({
+      name: "rebuild-source",
+      description: "git pull upstream main + bun install + npm run build",
+      skipReason: !inCheckout
+        ? "not in a git checkout (CLI is an installed binary)"
+        : undefined,
+      run: () => {
+        // CWD doesn't matter — git/bun/npm run from process.cwd().
+        // For `--rebuild` to mean anything, the operator should be
+        // invoking `update` from inside the checkout. We don't try to
+        // be clever about chdir.
+        const pull = runner("git", ["pull", "--ff-only", "upstream", "main"]);
+        if (pull.status !== 0) throw new Error("git pull failed");
+        const install = runner("bun", ["install"]);
+        if (install.status !== 0) throw new Error("bun install failed");
+        const build = runner("npm", ["run", "build"]);
+        if (build.status !== 0) throw new Error("npm run build failed");
+      },
+    });
+  }
+
+  steps.push({
+    name: "apply-config",
+    description: "switchroom apply — refresh per-agent scaffolds + compose",
+    run: () => {
+      // Re-exec ourselves to invoke the apply subcommand. apply will
+      // self-elevate via #920 if needed.
+      const r = runner(process.execPath, [
+        scriptPath,
+        "apply",
+        "--non-interactive",
+      ]);
+      if (r.status !== 0) throw new Error("switchroom apply failed");
+    },
+  });
+
+  steps.push({
+    name: "recreate-containers",
+    description:
+      "docker compose up -d --remove-orphans (recreates services with new images / compose)",
+    skipReason: opts.skipImages && !opts.rebuild
+      ? "no image or scaffold changes expected; nothing to recreate"
+      : undefined,
+    run: () => {
+      const r = runner("docker", [
+        "compose", "-p", "switchroom", "-f", composePath, "up", "-d",
+        "--remove-orphans",
+      ]);
+      if (r.status !== 0) throw new Error("docker compose up failed");
+    },
+  });
+
+  steps.push({
+    name: "doctor",
+    description: "switchroom doctor — surface post-bounce diagnostics",
+    run: () => {
+      // Doctor returns non-zero on findings; don't propagate that as
+      // an update failure (the update succeeded; the diagnostics are
+      // informational). Just print and continue.
+      runner(process.execPath, [scriptPath, "doctor"]);
+    },
+  });
+
+  return steps;
+}
+
+function defaultRunner(cmd: string, args: string[]): { status: number } {
+  const r = spawnSync(cmd, args, { stdio: "inherit" });
+  return { status: r.status ?? 1 };
+}
+
+async function runUpdate(opts: UpdateOptions): Promise<number> {
+  const stdout = opts.stdout ?? ((s) => process.stdout.write(s));
+  const stderr = opts.stderr ?? ((s) => process.stderr.write(s));
+  const steps = planUpdate(opts);
+
+  if (opts.check) {
+    stdout(chalk.bold("switchroom update --check (dry-run)\n\n"));
+    for (const step of steps) {
+      const status = step.skipReason
+        ? chalk.gray(`[skip] ${step.skipReason}`)
+        : chalk.green("[run]");
+      stdout(`  ${status} ${step.name} — ${step.description}\n`);
+    }
+    stdout("\nDry-run only; nothing was changed. Re-run without --check to apply.\n");
+    return 0;
+  }
+
+  for (const step of steps) {
+    if (step.skipReason) {
+      stdout(chalk.gray(`▸ ${step.name}: skipped (${step.skipReason})\n`));
+      continue;
+    }
+    stdout(chalk.bold(`▸ ${step.name}\n`));
+    try {
+      step.run();
+    } catch (err) {
+      stderr(
+        chalk.red(`✗ ${step.name} failed: ${(err as Error).message}\n`),
+      );
+      return 1;
+    }
+  }
+  stdout(chalk.green("\n✓ update complete\n"));
+  return 0;
+}
 
 export function registerUpdateCommand(program: Command): void {
   program
     .command("update")
     .description(
-      "[removed] Replaced by `docker compose pull && switchroom apply && docker compose up -d` (see message).",
+      "Update switchroom on this host: pull images, refresh scaffolds, recreate containers. Wraps the full `pull && apply && up -d` flow.",
     )
-    // Legacy flags — accepted and silently ignored so the v0.6 → v0.7
-    // self-reexec path doesn't crash on argv it no longer recognises.
-    .option("--force", "[no-op]")
-    .option("--check", "[no-op]")
-    .option("--no-restart", "[no-op]")
-    .option("--resume <file>", "[no-op]")
-    .option("--phase <phase>", "[no-op]")
-    .action(async (opts: { phase?: string }) => {
-      // The in-flight v0.6 → v0.7 self-reexec path arrives here with
-      // `--phase=post-build`. Failing in that window would leave the
-      // operator's fleet half-deployed. Exit 0 with a hint so the
-      // outer process keeps marching, and the operator finishes the
-      // upgrade by hand.
+    .option("--check", "Dry-run: print the steps that would execute, exit 0.")
+    .option("--skip-images", "Skip the docker image pull (offline mode).")
+    .option(
+      "--rebuild",
+      "Source-checkout users: also git pull + bun install + npm run build before applying. Auto-skipped when the CLI is an installed binary.",
+    )
+    // Legacy v0.6 flags — accepted as no-ops so a stale operator
+    // muscle-memory invocation doesn't crash. The --phase=post-build
+    // path was the in-flight v0.6→v0.7 self-reexec; that's dead now,
+    // exit 0 with a hint instead of trying to do anything.
+    .option("--force", "[legacy v0.6 no-op]")
+    .option("--no-restart", "[legacy v0.6 no-op]")
+    .option("--resume <file>", "[legacy v0.6 no-op]")
+    .option("--phase <phase>", "[legacy v0.6 no-op]")
+    .action(async (opts: UpdateOptions) => {
       if (opts.phase === "post-build") {
         console.warn(
           chalk.yellow(
-            "switchroom update --phase=post-build: upgrade-mode no longer supported. Restart manually with `docker compose ... up -d`.",
+            "switchroom update --phase=post-build: legacy v0.6 self-reexec path. " +
+            "v0.7+ handles this end-to-end via `update` proper; nothing to do.",
           ),
         );
         process.exit(0);
       }
-
-      console.error(chalk.red(REMOVAL_MESSAGE));
-      process.exit(1);
+      const code = await runUpdate(opts);
+      process.exit(code);
     });
 }
+
+export { runUpdate, defaultRunner, DEFAULT_COMPOSE_PATH };

--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -113,23 +113,29 @@ export function planUpdate(opts: UpdateOptions): UpdateStep[] {
     },
   });
 
-  // Source-checkout step. Auto-skip when not in a git repo, so
-  // npm-installed users don't see a confusing "skipping git pull"
-  // line on every update.
+  // Source-checkout step. Only added when --rebuild is explicit. If
+  // the user passed --rebuild but the CLI isn't running from a git
+  // checkout, the runUpdate dispatcher will fail loudly — the explicit
+  // flag is treated as a hard intent, not a hint we can quietly drop
+  // (#923 reviewer feedback).
   const scriptPath = process.argv[1] ?? "";
-  const inCheckout = isGitCheckout(scriptPath);
   if (opts.rebuild) {
     steps.push({
       name: "rebuild-source",
       description: "git pull upstream main + bun install + npm run build",
-      skipReason: !inCheckout
-        ? "not in a git checkout (CLI is an installed binary)"
-        : undefined,
       run: () => {
-        // CWD doesn't matter — git/bun/npm run from process.cwd().
-        // For `--rebuild` to mean anything, the operator should be
-        // invoking `update` from inside the checkout. We don't try to
-        // be clever about chdir.
+        if (!isGitCheckout(scriptPath)) {
+          throw new Error(
+            `--rebuild requires a git checkout, but the CLI is running ` +
+            `from ${scriptPath} which has no .git ancestor (looks like ` +
+            `an installed binary). Drop --rebuild or invoke from a ` +
+            `source checkout.`,
+          );
+        }
+        // CWD matters: git/bun/npm run from process.cwd(). Operator
+        // is expected to invoke `update --rebuild` from inside the
+        // checkout. We don't chdir on their behalf because they may
+        // have multiple worktrees and we shouldn't guess which.
         const pull = runner("git", ["pull", "--ff-only", "upstream", "main"]);
         if (pull.status !== 0) throw new Error("git pull failed");
         const install = runner("bun", ["install"]);
@@ -159,9 +165,12 @@ export function planUpdate(opts: UpdateOptions): UpdateStep[] {
     name: "recreate-containers",
     description:
       "docker compose up -d --remove-orphans (recreates services with new images / compose)",
-    skipReason: opts.skipImages && !opts.rebuild
-      ? "no image or scaffold changes expected; nothing to recreate"
-      : undefined,
+    // No skipReason: apply-config (the prior step) regenerates compose
+    // and per-agent scaffolds even with --skip-images. If the operator
+    // added/removed/renamed an agent and we skipped recreate, the
+    // running fleet would be out of sync with on-disk compose. Up-d
+    // is cheap and idempotent — if nothing changed it's a no-op
+    // (#923 reviewer feedback).
     run: () => {
       const r = runner("docker", [
         "compose", "-p", "switchroom", "-f", composePath, "up", "-d",


### PR DESCRIPTION
## Summary

Closes #918.

Pre-fix the operator was told to invoke five commands across two privilege levels to update switchroom on a host. Each had failure modes — the sudo invocation alone (#920) had three — and operators who didn't memorize the incantation got things half deployed. \`update\` bundles them with idempotent skip-if-fresh checks and clean per-step failure surfacing.

The pre-existing \`update\` shim (a v0.7 removed-stub) is replaced with the real verb. Legacy v0.6 flags (\`--force\`, \`--no-restart\`, \`--resume\`, \`--phase\`) remain accepted as no-ops so stale muscle-memory invocations don't crash; \`--phase=post-build\` still exits 0 to keep any in-flight v0.6→v0.7 self-reexec from breaking mid-flight.

## Steps (in order)

1. **pull-images** — \`docker compose pull\`
2. **rebuild-source** — \`git pull + bun install + npm run build\` (only with \`--rebuild\`; auto-skips when not in a git checkout)
3. **apply-config** — \`switchroom apply --non-interactive\` (self-elevates via #920 if needed)
4. **recreate-containers** — \`docker compose up -d --remove-orphans\`
5. **doctor** — \`switchroom doctor\` (informational; doesn't propagate non-zero)

## Flags

- \`--check\` — dry-run; print steps + their skip reasons, exit 0
- \`--skip-images\` — offline mode; skips image pull + container recreate
- \`--rebuild\` — source-checkout users; auto-skips when CLI is an installed binary

## Architecture

Pure-function \`planUpdate()\` builds the step list (no side effects); the \`runUpdate\` dispatcher iterates and either prints (\`--check\`) or runs. Tests inject a fake runner so no real docker / git / bun is invoked.

## Test plan
- [x] 11 new tests cover: plan shape (default vs \`--rebuild\` vs \`--skip-images\`), \`--check\` dry-run, in-order execution, fail-fast on a step error, isGitCheckout detection
- [x] \`npm run lint\` clean
- [x] All 11 tests pass
- [ ] Reviewer-agent verdict pending

## Companions

- Depends on #922 (apply self-elevate). update calls \`switchroom apply\` and benefits from auto-escalation when scaffold dirs need root.
- Sets up #919 (Telegram \`/update\`) — the bot command will invoke this CLI verb on the host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)