### PR TITLE
feat(telegram): `/update` — operator-side host update via Telegram (#919)

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -6421,6 +6421,69 @@ async function handleNewOrResetCommand(ctx: Context, kind: 'new' | 'reset'): Pro
 bot.command('new', async ctx => handleNewOrResetCommand(ctx, 'new'))
 bot.command('reset', async ctx => handleNewOrResetCommand(ctx, 'reset'))
 
+// /update — host update from Telegram (#919). Default = dry-run plan
+// (`switchroom update --check`); explicit `apply` triggers the real
+// thing via spawnSwitchroomDetached so the gateway can be killed
+// mid-flight by the recreate-containers step without orphaning the
+// update. Admin-gated via ADMIN_COMMAND_NAMES.
+bot.command('update', async ctx => {
+  if (!isAuthorizedSender(ctx)) return
+  const arg = ctx.match?.trim() || ''
+  if (arg === '' || arg === 'check' || arg === '--check') {
+    await runSwitchroomCommand(ctx, ['update', '--check'], 'update --check')
+    await switchroomReply(
+      ctx,
+      'Reply with <code>/update apply</code> to execute, or <code>/update apply --skip-images</code> to skip the image pull.',
+      { html: true },
+    )
+    return
+  }
+  // Parse `apply` (with optional --skip-images / --rebuild passthrough).
+  // `/update apply` and `/update apply --skip-images` are the supported
+  // forms; everything else surfaces a usage hint.
+  const tokens = arg.split(/\s+/)
+  if (tokens[0] !== 'apply' && tokens[0] !== '--apply') {
+    await switchroomReply(
+      ctx,
+      'Usage: <code>/update</code> (dry-run) or <code>/update apply [--skip-images] [--rebuild]</code>',
+      { html: true },
+    )
+    return
+  }
+  // Whitelist passthrough flags. Anything outside the allowlist is
+  // refused — operators should not be able to inject arbitrary CLI
+  // args via Telegram (defense in depth even though admin-gated).
+  const ALLOWED_FLAGS = new Set(['--skip-images', '--rebuild'])
+  const passthrough = tokens.slice(1)
+  for (const tok of passthrough) {
+    if (!ALLOWED_FLAGS.has(tok)) {
+      await switchroomReply(
+        ctx,
+        `Refusing to pass unknown flag: <code>${escapeHtmlForTg(tok)}</code>. ` +
+        `Allowed: <code>--skip-images</code>, <code>--rebuild</code>.`,
+        { html: true },
+      )
+      return
+    }
+  }
+  const chatId = String(ctx.chat!.id)
+  const threadId = resolveThreadId(chatId, ctx.message?.message_thread_id)
+  await switchroomReply(
+    ctx,
+    `🚀 <b>update started</b> — running ${[
+      '<code>switchroom update</code>',
+      ...passthrough.map((t) => `<code>${escapeHtmlForTg(t)}</code>`),
+    ].join(' ')}\n` +
+    `\nThe gateway will restart as part of the recreate step; watch ` +
+    `for the post-restart greeting card to confirm completion.`,
+    { html: true },
+  )
+  spawnSwitchroomDetached(
+    ['update', ...passthrough],
+    notifyDetachedFailure(chatId, threadId ?? null, 'update'),
+  )
+})
+
 // ─── /approve, /deny, /pending ────────────────────────────────────────────
 // Slash-command alternatives to the inline-button approval flow (useful for
 // desktop-only sessions and power-users). Share pendingPermissions state

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -6466,18 +6466,69 @@ bot.command('update', async ctx => {
       return
     }
   }
+  // Debounce vs concurrent self-restart commands (/restart, /new, /reset
+  // and other /update). Reading + writing the SAME restart marker means
+  // a double-tap of /update apply is rejected, AND a /restart fired
+  // mid-update is rejected (and vice versa). 15s window matches the
+  // /restart handler.
+  const existing = readRestartMarker()
+  if (existing && Date.now() - existing.ts < 15_000) {
+    await switchroomReply(
+      ctx,
+      `⏳ Self-restart already in progress (started ${Math.round(
+        (Date.now() - existing.ts) / 1000,
+      )}s ago) — ignoring duplicate.`,
+      { html: true },
+    )
+    return
+  }
   const chatId = String(ctx.chat!.id)
   const threadId = resolveThreadId(chatId, ctx.message?.message_thread_id)
-  await switchroomReply(
-    ctx,
+  // Send the ack and capture its message_id so the post-restart
+  // greeting card can edit/reply into the same message. Mirrors the
+  // /restart handler (gateway.ts ~6273) so the boot-card lookup
+  // (gateway.ts ~10393) finds chat_id + ack_message_id in the marker.
+  const ackText =
     `🚀 <b>update started</b> — running ${[
       '<code>switchroom update</code>',
       ...passthrough.map((t) => `<code>${escapeHtmlForTg(t)}</code>`),
     ].join(' ')}\n` +
     `\nThe gateway will restart as part of the recreate step; watch ` +
-    `for the post-restart greeting card to confirm completion.`,
-    { html: true },
-  )
+    `for the post-restart greeting card to confirm completion.`
+  let ackId: number | null = null
+  try {
+    const sent = await lockedBot.api.sendMessage(chatId, ackText, {
+      parse_mode: 'HTML',
+      link_preview_options: { is_disabled: true },
+      ...(threadId != null ? { message_thread_id: threadId } : {}),
+    })
+    ackId = sent.message_id
+    if (HISTORY_ENABLED) {
+      try {
+        recordOutbound({
+          chat_id: chatId,
+          thread_id: threadId ?? null,
+          message_ids: [sent.message_id],
+          texts: [`🚀 update started`],
+          attachment_kinds: [],
+        })
+      } catch {}
+    }
+  } catch {}
+  writeRestartMarker({
+    chat_id: chatId,
+    thread_id: threadId ?? null,
+    ack_message_id: ackId,
+    ts: Date.now(),
+  })
+  // Reason banner for the post-restart greeting card. Without this the
+  // banner falls back to whatever the CLI's clean-shutdown marker
+  // stamped — usually 'unknown' or a docker-compose-restart string.
+  stampUserRestartReason('user: /update from chat')
+  // Unpin progress cards + clear active reactions before we die. The
+  // pinned-progress-card surface is the headline feature per CLAUDE.md;
+  // leaving one pinned across the recreate would surprise the operator.
+  await sweepBeforeSelfRestart()
   spawnSwitchroomDetached(
     ['update', ...passthrough],
     notifyDetachedFailure(chatId, threadId ?? null, 'update'),

--- a/telegram-plugin/welcome-text.ts
+++ b/telegram-plugin/welcome-text.ts
@@ -312,7 +312,7 @@ export function switchroomHelpText(agentName: string): string {
     `<code>/memory &lt;query&gt;</code> — search agent memory`,
     ``,
     `<b>Fleet management</b>`,
-    `<code>/update</code> — pull latest code, reconcile, restart everything`,
+    `<code>/update</code> — dry-run plan; <code>/update apply</code> — actually pull images, reconcile, restart`,
     `<code>/restart [name|all]</code> — bounce agent (drains in-flight turn by default)`,
     `<code>/version</code> — show versions + running agent health summary`,
     ``,
@@ -336,7 +336,7 @@ export function switchroomHelpText(agentName: string): string {
     `<code>/inject &lt;slash&gt;</code> — inject a Claude Code REPL slash command (e.g. <code>/inject /cost</code>; allowlisted)`,
     `<code>/commands</code> — this help`,
     ``,
-    `<i>Tip: <code>/update</code> picks up new code; <code>/restart</code> bounces a stuck agent; <code>/version</code> checks what's running.</i>`,
+    `<i>Tip: <code>/update</code> shows the plan; <code>/update apply</code> executes it; <code>/restart</code> bounces a stuck agent; <code>/version</code> checks what's running.</i>`,
   ].join("\n");
 }
 


### PR DESCRIPTION
## Summary

Closes #919.

Operator on the train wants to push a bugfix that just merged. Pre-fix they had to SSH in and remember the five-command incantation. Now they tap \`/update\` from their phone.

## Behavior

- \`/update\` (no args) — runs \`switchroom update --check\`, posts the formatted dry-run plan as a Telegram pre-block, with a hint about the \`apply\` form.
- \`/update apply\` — spawns \`switchroom update\` detached so the recreate-containers step (which kills this very gateway) doesn't orphan the update mid-flight. \`notifyDetachedFailure\` surfaces any fast-fail back to the chat.
- \`/update apply --skip-images\` and \`/update apply --rebuild\` are passed through to the CLI verb.

## Defense in depth

- Admin-gated via the existing \`ADMIN_COMMAND_NAMES\` allowlist (no behaviour change there — \`update\` was already in the set).
- Inside the handler, an explicit flag allowlist refuses any unknown token to prevent argv injection through the chat surface.

## Help text

Updated the \`/commands\` help text + tip line in \`welcome-text.ts\` to surface the new dry-run-by-default UX:

\`\`\`
/update — dry-run plan; /update apply — actually pull images, reconcile, restart
\`\`\`

## Companions

- #918 (\`switchroom update\` CLI verb) — what this command invokes
- #920 (\`apply\` self-elevate) — what \`switchroom update\` calls into for the per-agent scaffold refresh

## Test plan
- [x] \`npm run lint\` clean
- [x] Telegram-plugin test delta vs main: 32 failures match the pre-existing baseline (all dist/-build-dependent)
- [x] Manual eyeball: ADMIN_COMMAND_NAMES already lists \`update\`, so admin gating is wired automatically. \`runSwitchroomCommand\` and \`spawnSwitchroomDetached\` are battle-tested helpers used by 8+ sibling commands
- [ ] Reviewer-agent verdict pending

## Out of scope (future)

- Inline \`[Apply]\` / \`[Cancel]\` button on the dry-run plan instead of requiring the operator to type \`apply\` (would be a nice UX upgrade; deferred for v1)
- 2FA via the vault Telegram-2FA flow (#205) — \`update\` is already admin-gated, but a destructive op might warrant the extra ceremony
- Per-host concurrency lock to prevent two operators from invoking \`/update apply\` simultaneously
- \`/update --rollback\` to step back to the prior commit + image digests

🤖 Generated with [Claude Code](https://claude.com/claude-code)