### PR TITLE
fix(boot-card): probes honest under Phase-4 docker; /status grows live health block

### DIFF
--- a/telegram-plugin/gateway/boot-card.ts
+++ b/telegram-plugin/gateway/boot-card.ts
@@ -41,7 +41,10 @@ import {
   probeGateway,
   probeQuota,
   probeHindsight,
-  probeCronTimers,
+  probeScheduler,
+  probeBroker,
+  probeKernel,
+  probeSkills,
   watchAgentProcess,
   AGENT_LIVE_WINDOW_MS,
   AGENT_LIVE_POLL_INTERVAL_MS,
@@ -89,7 +92,16 @@ export function resolvePersonaName(
 
 export type RestartReason = 'planned' | 'graceful' | 'crash' | 'fresh'
 
-export type ProbeKey = 'account' | 'agent' | 'gateway' | 'quota' | 'hindsight' | 'crons'
+export type ProbeKey =
+  | 'account'
+  | 'agent'
+  | 'gateway'
+  | 'quota'
+  | 'hindsight'
+  | 'scheduler'
+  | 'broker'
+  | 'kernel'
+  | 'skills'
 
 export type ProbeMap = Partial<Record<ProbeKey, ProbeResult | null>>
 
@@ -204,11 +216,15 @@ const PROBE_LABELS: Record<ProbeKey, string> = {
   gateway:   'Gateway',
   quota:     'Quota',
   hindsight: 'Hindsight',
-  crons:     'Crons',
+  scheduler: 'Scheduler',
+  broker:    'Broker',
+  kernel:    'Kernel',
+  skills:    'Skills',
 }
 
 const PROBE_KEYS: ReadonlyArray<ProbeKey> = [
-  'account', 'agent', 'gateway', 'quota', 'hindsight', 'crons',
+  'account', 'agent', 'gateway', 'quota', 'hindsight',
+  'scheduler', 'broker', 'kernel', 'skills',
 ]
 
 const REASON_EMOJI: Record<RestartReason, string> = {
@@ -413,7 +429,10 @@ export async function runAllProbes(opts: RunProbesOpts): Promise<ProbeMap> {
     probeGateway(opts.gatewayInfo).then(r => { probes.gateway = r }),
     probeQuota(claudeDir, opts.agentDir, opts.fetchImpl).then(r => { probes.quota = r }),
     probeHindsight(opts.bankName, opts.fetchImpl).then(r => { probes.hindsight = r }),
-    probeCronTimers(slug, { execFileImpl: opts.probeExecFileImpl, dockerMode: opts.dockerMode }).then(r => { probes.crons = r }),
+    probeScheduler(slug, { dockerMode: opts.dockerMode }).then(r => { probes.scheduler = r }),
+    probeBroker(undefined, { dockerMode: opts.dockerMode }).then(r => { probes.broker = r }),
+    probeKernel(undefined, { dockerMode: opts.dockerMode }).then(r => { probes.kernel = r }),
+    probeSkills(opts.agentDir).then(r => { probes.skills = r }),
   ])
 
   return probes

--- a/telegram-plugin/gateway/boot-probes.ts
+++ b/telegram-plugin/gateway/boot-probes.ts
@@ -930,111 +930,296 @@ export async function probeHindsight(
   })())
 }
 
-// ─── Probe: Cron timers ──────────────────────────────────────────────────────
+// ─── Probe: Scheduler (in-container agent-scheduler since Phase 4) ───────────
 
-interface SystemctlTimerEntry {
-  next?: string
-  left?: string
-  last?: string
-  unit?: string
-  activates?: string
-  passed?: string
+/**
+ * Default lock and audit-jsonl paths inside the agent container.
+ * Mirrored from src/agent-scheduler/index.ts:194-197 — kept in sync there.
+ */
+const SCHEDULER_LOCK_PATH_DEFAULT = '/state/agent/scheduler.lock'
+const SCHEDULER_JSONL_PATH_DEFAULT = '/state/agent/scheduler.jsonl'
+
+/**
+ * Filesystem injection point for the scheduler probe. Same shape as
+ * ProcFsImpl but read-only against arbitrary paths. Tests inject a
+ * synthetic fs to drive lockfile contents and jsonl tails without
+ * touching disk.
+ */
+export interface SchedulerFsImpl {
+  readFile: (path: string) => string
+  /** stat-mtime, ms-since-epoch. Used to age the audit jsonl. */
+  mtimeMs: (path: string) => number
+  exists: (path: string) => boolean
 }
 
-function parseTimerLeft(left: string | undefined): number | null {
-  if (!left) return null
-  // format: "1h 32min left" or "2min 5s left" or similar
-  let ms = 0
-  const h = left.match(/(\d+)h/)
-  const m = left.match(/(\d+)min/)
-  const s = left.match(/(\d+)s/)
-  if (h) ms += Number(h[1]) * 3600_000
-  if (m) ms += Number(m[1]) * 60_000
-  if (s) ms += Number(s[1]) * 1000
-  return ms > 0 ? ms : null
+const realSchedulerFs: SchedulerFsImpl = {
+  readFile: (p) => readFileSync(p, 'utf-8'),
+  mtimeMs: (p) => {
+    // `existsSync` shaped path keeps the probe defensive — caller checks
+    // exists() first. statSync is imported via the readdirSync chain.
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { statSync } = require('fs') as typeof import('fs')
+    return statSync(p).mtimeMs
+  },
+  exists: (p) => existsSync(p),
 }
 
-export async function probeCronTimers(
-  agentName: string,
+/**
+ * Probe the in-container agent-scheduler (cron-fold-in cutover, Phase 4
+ * — see CLAUDE.md "Cron-fold-in note"). Replaces the pre-Phase-4 probe
+ * that queried `systemctl --user list-timers switchroom-<agent>-cron-*`
+ * (those timers no longer exist) and the dockerMode short-circuit that
+ * lied with "managed by switchroom-cron" (that container was retired in
+ * PR #893).
+ *
+ * The scheduler is a sibling sidecar started by start.sh's
+ * _switchroom_supervise wrapper. It writes a pidfile-with-liveness lock
+ * at /state/agent/scheduler.lock (src/agent-scheduler/lock.ts) and an
+ * audit row per fire to /state/agent/scheduler.jsonl
+ * (src/agent-scheduler/index.ts:256, src/scheduler/audit.ts).
+ *
+ *   ok       — lockfile present, holder PID alive
+ *   degraded — lockfile present but PID dead (supervisor mid-restart, or
+ *              sched crashed and supervisor hasn't relaunched yet)
+ *   fail     — lockfile missing (sidecar never started or supervisor
+ *              gave up after restart-cap)
+ *
+ * Outside dockerMode the probe is silent (returns ok with "n/a"). Phase
+ * 4 deleted the host-side scheduler entirely; non-docker callers
+ * (legacy systemd installs, tests) have no scheduler to probe.
+ */
+export async function probeScheduler(
+  _agentName: string,
   opts: {
-    execFileImpl?: ExecFileFnType
-    /** When true, crons live in the `switchroom-cron` container and the
-     *  agent container has no docker.sock to query them. We surface that
-     *  the scheduler is managed externally rather than reporting fail
-     *  every boot for a non-issue. */
     dockerMode?: boolean
+    fs?: SchedulerFsImpl
+    lockPath?: string
+    jsonlPath?: string
+    /** Liveness check for the holder PID — defaults to process.kill(pid, 0). */
+    isAlive?: (pid: number) => boolean
+    now?: () => number
   } = {},
 ): Promise<ProbeResult> {
-  if (opts.dockerMode) {
-    return {
-      status: 'ok',
-      label: 'Crons',
-      detail: 'managed by switchroom-cron',
-    }
+  if (!opts.dockerMode) {
+    return { status: 'ok', label: 'Scheduler', detail: 'n/a (non-docker)' }
   }
-  const execFileFn: ExecFileFnType = opts.execFileImpl ?? execFile
-  return withTimeout('Crons', (async (): Promise<ProbeResult> => {
-    let stdout: string
-    try {
-      const result = await execFileFn('systemctl', [
-        '--user', 'list-timers',
-        `switchroom-${agentName}-cron-*`,
-        '--output=json',
-        '--all',
-      ])
-      stdout = result.stdout.trim()
-    } catch (err: unknown) {
-      // systemctl exits non-zero when no units match
-      const msg = (err as NodeJS.ErrnoException)?.message ?? String(err)
-      // child_process exec errors have `code` typed as string in
-      // NodeJS.ErrnoException, but at runtime it's numeric for shell
-      // exit codes. Stringify to avoid the type-system mismatch and
-      // the comparison "looks unintentional" warning.
-      if (msg.includes('No timers found') || String((err as NodeJS.ErrnoException)?.code) === '1') {
-        return { status: 'ok', label: 'Crons', detail: '0 timers' }
-      }
-      return { status: 'fail', label: 'Crons', detail: `systemctl failed: ${msg}` }
-    }
+  return withTimeout('Scheduler', (async (): Promise<ProbeResult> => {
+    const fs = opts.fs ?? realSchedulerFs
+    const lockPath = opts.lockPath ?? SCHEDULER_LOCK_PATH_DEFAULT
+    const jsonlPath = opts.jsonlPath ?? SCHEDULER_JSONL_PATH_DEFAULT
+    const now = opts.now ?? Date.now
+    const isAlive = opts.isAlive ?? ((pid: number) => {
+      try { process.kill(pid, 0); return true } catch { return false }
+    })
 
-    if (!stdout || stdout === '[]' || stdout.length === 0) {
-      return { status: 'ok', label: 'Crons', detail: '0 timers' }
+    if (!fs.exists(lockPath)) {
+      return { status: 'fail', label: 'Scheduler', detail: 'sidecar not running (no lockfile)' }
     }
-
-    let timers: SystemctlTimerEntry[] = []
+    let holderPid: number | null = null
     try {
-      timers = JSON.parse(stdout) as SystemctlTimerEntry[]
+      const raw = fs.readFile(lockPath).trim()
+      const parsed = Number.parseInt(raw, 10)
+      if (Number.isInteger(parsed) && parsed > 0) holderPid = parsed
     } catch {
-      // Fall back to line-count if JSON failed
-      const count = stdout.split('\n').filter(l => l.includes('cron')).length
-      return { status: 'ok', label: 'Crons', detail: `${count} timers` }
+      return { status: 'degraded', label: 'Scheduler', detail: 'lockfile unreadable' }
     }
-
-    if (!Array.isArray(timers) || timers.length === 0) {
-      return { status: 'ok', label: 'Crons', detail: '0 timers' }
+    if (holderPid == null) {
+      return { status: 'degraded', label: 'Scheduler', detail: 'lockfile contents invalid' }
     }
-
-    // Find the timer that fires soonest
-    let earliest: { name: string; leftMs: number } | null = null
-    for (const t of timers) {
-      const ms = parseTimerLeft(t.left)
-      const name = (t.unit ?? t.activates ?? '').replace(/^switchroom-[^-]+-cron-/, '').replace(/\.timer$/, '')
-      if (ms != null && (earliest == null || ms < earliest.leftMs)) {
-        earliest = { name, leftMs: ms }
+    if (!isAlive(holderPid)) {
+      return {
+        status: 'degraded',
+        label: 'Scheduler',
+        detail: `lock holder pid ${holderPid} not alive (supervisor restart in progress?)`,
       }
     }
 
-    const count = timers.length
-    if (!earliest) {
-      return { status: 'ok', label: 'Crons', detail: `${count} timers` }
+    // Sidecar is up. Add a freshness hint from scheduler.jsonl if present
+    // — gives the user signal that fires are actually happening, not just
+    // that the daemon is breathing. Absence is fine: a freshly booted
+    // agent or a 0-entry agent has no fires to report.
+    let detail = `running (pid ${holderPid})`
+    if (fs.exists(jsonlPath)) {
+      try {
+        const ageMs = now() - fs.mtimeMs(jsonlPath)
+        if (Number.isFinite(ageMs) && ageMs >= 0) {
+          detail += ` · last fire ${formatMs(ageMs)} ago`
+        }
+      } catch {
+        // mtime read failed — keep the basic detail; non-blocking.
+      }
     }
+    return { status: 'ok', label: 'Scheduler', detail }
+  })())
+}
 
-    const h = Math.floor(earliest.leftMs / 3600_000)
-    const m = Math.round((earliest.leftMs % 3600_000) / 60_000)
-    const timeStr = h > 0 ? `${h}h ${m}m` : `${m}m`
-    return {
-      status: 'ok',
-      label: 'Crons',
-      detail: `${count} timers · next: ${earliest.name} in ${timeStr}`,
+// ─── Probe: Vault broker / approval kernel reachability ──────────────────────
+
+/**
+ * Generic UDS-reachability probe used for both vault-broker and
+ * approval-kernel. Path-as-identity invariant (CLAUDE.md "Per-agent
+ * socket model") — bind paths are mounted into each agent container at
+ * /run/switchroom/{broker,kernel}/<agent>/sock. ENOENT means the
+ * compose volume isn't mounted (broker container down or no agent dir
+ * yet); ECONNREFUSED means the bind disappeared between us and the
+ * daemon (rare, broker shutdown removes the socket).
+ *
+ * Connect-test only — we do NOT send a wire request. The probe must not
+ * authenticate as the agent or do any vault/grant work; that's the
+ * agent's job. We just want to know "is something listening on this
+ * socket". Connection is closed immediately on success.
+ */
+async function probeUds(
+  label: string,
+  socketPath: string | undefined,
+  opts: { dockerMode?: boolean; connectImpl?: (path: string) => Promise<void> } = {},
+): Promise<ProbeResult> {
+  if (!opts.dockerMode) {
+    return { status: 'ok', label, detail: 'n/a (non-docker)' }
+  }
+  if (!socketPath) {
+    return { status: 'fail', label, detail: 'socket path not configured' }
+  }
+  return withTimeout(label, (async (): Promise<ProbeResult> => {
+    if (!opts.connectImpl) {
+      // Cheap pre-check: stat the file. Saves the connect round-trip on
+      // the common "broker container down → bind mount empty" case.
+      if (!existsSync(socketPath)) {
+        return { status: 'fail', label, detail: `socket missing: ${socketPath}` }
+      }
+    }
+    const connect = opts.connectImpl ?? defaultUdsConnect
+    try {
+      await connect(socketPath)
+      return { status: 'ok', label, detail: 'reachable' }
+    } catch (err: unknown) {
+      const code = (err as NodeJS.ErrnoException)?.code
+      const msg = (err as Error)?.message ?? String(err)
+      if (code === 'ENOENT') return { status: 'fail', label, detail: 'socket missing' }
+      if (code === 'ECONNREFUSED') return { status: 'fail', label, detail: 'connection refused' }
+      return { status: 'fail', label, detail: `connect failed: ${msg}` }
     }
   })())
+}
+
+/**
+ * Default UDS connect — opens a stream, then immediately closes it.
+ * Resolves on `connect` event, rejects on `error`. 1s connect timeout
+ * is plenty for a local socket (the per-probe timeout in withTimeout
+ * is the outer guard).
+ */
+function defaultUdsConnect(socketPath: string): Promise<void> {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const net = require('net') as typeof import('net')
+  return new Promise<void>((resolve, reject) => {
+    const sock = net.createConnection({ path: socketPath })
+    const t = setTimeout(() => {
+      sock.destroy()
+      reject(new Error('connect timeout'))
+    }, 1000)
+    sock.once('connect', () => {
+      clearTimeout(t)
+      sock.end()
+      resolve()
+    })
+    sock.once('error', (err) => {
+      clearTimeout(t)
+      sock.destroy()
+      reject(err)
+    })
+  })
+}
+
+export async function probeBroker(
+  socketPath?: string,
+  opts: { dockerMode?: boolean; connectImpl?: (path: string) => Promise<void> } = {},
+): Promise<ProbeResult> {
+  return probeUds('Broker', socketPath ?? process.env.SWITCHROOM_BROKER_SOCKET, opts)
+}
+
+export async function probeKernel(
+  socketPath?: string,
+  opts: { dockerMode?: boolean; connectImpl?: (path: string) => Promise<void> } = {},
+): Promise<ProbeResult> {
+  return probeUds('Kernel', socketPath ?? process.env.SWITCHROOM_KERNEL_SOCKET, opts)
+}
+
+// ─── Probe: Skills (symlink validity) ────────────────────────────────────────
+
+/**
+ * Validate that every entry under <agentDir>/.claude/skills/ resolves
+ * to a readable file. Skills are normally symlinks into the global pool
+ * `~/.switchroom/skills/` (src/agents/scaffold.ts:639); a renamed or
+ * deleted skill in the pool dangles silently — claude won't surface the
+ * skill, the user wonders why /<skill> doesn't work.
+ *
+ *   ok       — every entry resolves OR the dir doesn't exist (no skills
+ *              configured is a normal state, not a failure)
+ *   degraded — at least one symlink dangles; rendered detail names them
+ *              up to a cap so the row doesn't wrap forever
+ */
+export async function probeSkills(
+  agentDir: string,
+  opts: { fs?: SkillsFsImpl; maxNamesShown?: number } = {},
+): Promise<ProbeResult> {
+  return withTimeout('Skills', (async (): Promise<ProbeResult> => {
+    const fs = opts.fs ?? realSkillsFs
+    const max = opts.maxNamesShown ?? 3
+    const skillsDir = join(agentDir, '.claude', 'skills')
+    if (!fs.exists(skillsDir)) {
+      return { status: 'ok', label: 'Skills', detail: 'no skills dir' }
+    }
+    let entries: string[]
+    try {
+      entries = fs.readdir(skillsDir)
+    } catch {
+      return { status: 'degraded', label: 'Skills', detail: 'skills dir unreadable' }
+    }
+    if (entries.length === 0) {
+      return { status: 'ok', label: 'Skills', detail: '0 skills' }
+    }
+    const dangling: string[] = []
+    for (const name of entries) {
+      // Skills are dirs containing a SKILL.md (claude convention). The
+      // dangle case we worry about is a symlink whose target was
+      // removed — readability of <name>/SKILL.md is the simplest proxy
+      // and matches what claude itself would discover.
+      const skillPath = join(skillsDir, name)
+      if (!fs.exists(skillPath)) {
+        dangling.push(name)
+        continue
+      }
+      // Single-file skills exist (rare but allowed); accept them too.
+      const skillMd = join(skillPath, 'SKILL.md')
+      if (!fs.exists(skillMd) && !fs.exists(skillPath + '.md')) {
+        // Only flag as dangling if the entry IS a symlink (a real dir
+        // without SKILL.md is weird but not necessarily broken — could
+        // be an in-progress local skill). We have no symlink-test in
+        // SkillsFsImpl by design; conservatively don't flag as dangling.
+        // The user's main risk is removed-pool-target, which existsSync
+        // catches above.
+        continue
+      }
+    }
+    if (dangling.length === 0) {
+      return { status: 'ok', label: 'Skills', detail: `${entries.length} resolved` }
+    }
+    const named = dangling.slice(0, max).join(', ')
+    const more = dangling.length > max ? ` +${dangling.length - max} more` : ''
+    return {
+      status: 'degraded',
+      label: 'Skills',
+      detail: `${dangling.length}/${entries.length} dangling: ${named}${more}`,
+    }
+  })())
+}
+
+export interface SkillsFsImpl {
+  readdir: (p: string) => string[]
+  exists: (p: string) => boolean
+}
+
+const realSkillsFs: SkillsFsImpl = {
+  readdir: (p) => readdirSync(p),
+  exists: (p) => existsSync(p),
 }

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -153,7 +153,7 @@ import {
   resetSessionAckText as buildResetSessionAckText,
   TELEGRAM_BASE_COMMANDS,
   TELEGRAM_SWITCHROOM_COMMANDS,
-  type AgentMetadata, type AuthSummary,
+  type AgentMetadata, type AuthSummary, type StatusProbeRow,
 } from '../welcome-text.js'
 import {
   isContextExhaustionText,
@@ -6135,7 +6135,7 @@ function buildAgentAudit(agentName: string): AgentAudit | undefined {
 // to `switchroom agent list --json` and `switchroom auth status --json`.
 // Best-effort — any missing piece renders as a placeholder in the text
 // templates rather than blocking the reply.
-function buildAgentMetadata(agentName: string): AgentMetadata {
+async function buildAgentMetadata(agentName: string): Promise<AgentMetadata> {
   type AgentListResp = {
     agents: Array<{
       name: string; status: string; uptime: string;
@@ -6172,6 +6172,52 @@ function buildAgentMetadata(agentName: string): AgentMetadata {
     status: a?.status ?? null,
     auth: authSummary,
     audit: buildAgentAudit(agentName),
+    live: await buildLiveProbeRows(agentName),
+  }
+}
+
+/**
+ * Run the boot-card probe set on demand for `/status`. Same probes,
+ * different rendering contract: `/status` shows every row (silent-when-
+ * healthy is for the boot card; the user explicitly asked for current
+ * state here). Failures are swallowed per-probe via runAllProbes's
+ * Promise.allSettled, and we filter out anything we couldn't render so
+ * the reply doesn't break on a broken probe.
+ */
+async function buildLiveProbeRows(agentName: string): Promise<StatusProbeRow[]> {
+  try {
+    const { runAllProbes } = await import('./boot-card.js')
+    const agentDir = resolveAgentDirFromEnv()
+      ?? (process.env.TELEGRAM_STATE_DIR
+        ? require('path').dirname(process.env.TELEGRAM_STATE_DIR)
+        : '/tmp')
+    const probes = await runAllProbes({
+      agentName,
+      agentSlug: agentName,
+      version: formatBootVersion(),
+      agentDir,
+      gatewayInfo: { pid: process.pid, startedAtMs: GATEWAY_STARTED_AT_MS },
+      tmuxSupervisor: process.env.SWITCHROOM_TMUX_SUPERVISOR === '1',
+      dockerMode: process.env.SWITCHROOM_RUNTIME === 'docker',
+    })
+    const rows: StatusProbeRow[] = []
+    // Render order matches the boot card's PROBE_KEYS so the two
+    // surfaces tell the same story in the same order.
+    const order = ['account', 'agent', 'gateway', 'quota', 'hindsight',
+      'scheduler', 'broker', 'kernel', 'skills'] as const
+    for (const k of order) {
+      const r = probes[k]
+      if (!r) continue
+      rows.push({ status: r.status, label: r.label, detail: r.detail })
+    }
+    return rows
+  } catch (err: unknown) {
+    process.stderr.write(
+      `telegram gateway: /status: probe gathering failed: ${
+        (err as Error)?.message ?? String(err)
+      }\n`,
+    )
+    return []
   }
 }
 
@@ -6210,7 +6256,7 @@ bot.command('status', async ctx => {
   const from = ctx.from!
   if (access.allowFrom.includes(senderId)) {
     const userTag = from.username ? `@${from.username}` : senderId
-    const meta = buildAgentMetadata(getMyAgentName())
+    const meta = await buildAgentMetadata(getMyAgentName())
     await ctx.reply(buildStatusPairedText({ user: userTag, meta }), { parse_mode: 'HTML' })
     return
   }

--- a/telegram-plugin/tests/boot-card-probe-target.test.ts
+++ b/telegram-plugin/tests/boot-card-probe-target.test.ts
@@ -2,14 +2,19 @@
  * Tests for #309: boot card uses the agent slug (not display name) for
  * systemd unit probes.
  *
- * Root cause: probeAgentProcess and probeCronTimers were called with
- * opts.agentName (the persona display name, e.g. "Klanker") instead of
- * the lowercase slug ("klanker"). systemctl returns LoadState=not-found
- * for the capitalised name because unit files are always lowercase.
+ * Root cause: probeAgentProcess was called with opts.agentName (the
+ * persona display name, e.g. "Klanker") instead of the lowercase slug
+ * ("klanker"). systemctl returns LoadState=not-found for the
+ * capitalised name because unit files are always lowercase.
  *
  * Fix: RunProbesOpts.agentSlug carries the slug separately; runAllProbes
  * passes opts.agentSlug (falling back to opts.agentName for compat) to
- * both probeAgentProcess and probeCronTimers.
+ * probeAgentProcess.
+ *
+ * (Pre-Phase-4 this also covered probeCronTimers; that probe was
+ * replaced by probeScheduler when the singleton switchroom-cron
+ * container was retired and cron moved in-container — the slug now
+ * only matters for the systemd Agent probe.)
  */
 
 import { describe, it, expect } from 'vitest'
@@ -97,35 +102,6 @@ describe('#309: runAllProbes — slug vs display name for systemd calls', () => 
       const unitArg = agentProbeCall!.args.find(a => a.startsWith('switchroom-'))
       // Must use the slug, not the capitalised display name.
       expect(unitArg).toBe('switchroom-klanker.service')
-    } finally {
-      rmSync(tmpDir, { recursive: true })
-    }
-  })
-
-  it('probeCronTimers target is switchroom-<slug>-cron-*, not switchroom-<displayName>-cron-*', async () => {
-    const tmpDir = makeTmpAgentDir()
-    try {
-      const { fn: execFileMock, calls } = makeDispatchingExecFile('klanker')
-
-      await runAllProbes({
-        agentName: 'Klanker',
-        agentSlug: 'klanker',
-        version: 'v0.3.0',
-        agentDir: tmpDir,
-        gatewayInfo: { pid: 12345, startedAtMs: Date.now() },
-        fetchImpl: async () => new Response('', { status: 200 }),
-        settleWindowMs: 0,
-        agentLiveWindowMs: 0,
-        probeExecFileImpl: execFileMock,
-      })
-
-      // probeCronTimers calls: systemctl --user list-timers switchroom-<name>-cron-*
-      const cronProbeCall = calls.find(c =>
-        c.cmd === 'systemctl' && c.args.includes('list-timers'),
-      )
-      expect(cronProbeCall, 'probeCronTimers must call systemctl list-timers').toBeDefined()
-      const cronGlob = cronProbeCall!.args.find(a => a.includes('cron'))
-      expect(cronGlob).toBe('switchroom-klanker-cron-*')
     } finally {
       rmSync(tmpDir, { recursive: true })
     }

--- a/telegram-plugin/tests/boot-card-render.test.ts
+++ b/telegram-plugin/tests/boot-card-render.test.ts
@@ -94,27 +94,28 @@ describe('renderBootCard — degraded conditions', () => {
     expect(out).not.toContain('Agent</b>')
     expect(out).not.toContain('Gateway</b>')
     expect(out).not.toContain('Hindsight</b>')
-    expect(out).not.toContain('Crons</b>')
+    expect(out).not.toContain('Scheduler</b>')
   })
 
   it('orders probe rows in PROBE_KEYS canonical order regardless of object iteration', () => {
     // Insert in a non-canonical order; renderer must still output Account first,
-    // then Hindsight, then Crons (matching PROBE_KEYS).
+    // then Hindsight, then Scheduler (matching PROBE_KEYS — Phase 4 renamed
+    // crons → scheduler when the in-container agent-scheduler took over).
     const out = renderBootCard({
       agentName: 'a',
       version: 'v',
       probes: {
-        crons:     { status: 'fail',     label: 'Crons',     detail: 'bad' },
+        scheduler: { status: 'fail',     label: 'Scheduler', detail: 'sidecar not running' },
         hindsight: { status: 'fail',     label: 'Hindsight', detail: 'unreachable' },
         account:   { status: 'degraded', label: 'Account',   detail: 'expiring' },
       },
     })
     const accountIdx = out.indexOf('Account</b>')
     const hindsightIdx = out.indexOf('Hindsight</b>')
-    const cronsIdx = out.indexOf('Crons</b>')
+    const schedulerIdx = out.indexOf('Scheduler</b>')
     expect(accountIdx).toBeGreaterThan(-1)
     expect(hindsightIdx).toBeGreaterThan(accountIdx)
-    expect(cronsIdx).toBeGreaterThan(hindsightIdx)
+    expect(schedulerIdx).toBeGreaterThan(hindsightIdx)
   })
 
   it('crash + degraded probe = both rows render', () => {

--- a/telegram-plugin/tests/boot-probes.test.ts
+++ b/telegram-plugin/tests/boot-probes.test.ts
@@ -13,12 +13,17 @@ import { join } from 'path'
 
 import {
   probeAgentProcess,
-  probeCronTimers,
+  probeScheduler,
+  probeBroker,
+  probeKernel,
+  probeSkills,
   probeQuota,
   watchAgentProcess,
   findAgentProcessInContainer,
   uptimeMsForStarttime,
   type ProcFsImpl,
+  type SchedulerFsImpl,
+  type SkillsFsImpl,
 } from '../gateway/boot-probes.js'
 import { readQuotaCache, RATE_LIMIT_TTL_MS } from '../gateway/quota-cache.js'
 
@@ -455,7 +460,7 @@ describe('watchAgentProcess — #296: re-poll after window expiry', () => {
 
 // ── docker mode: skip systemctl, use /proc walk ───────────────────────────
 
-describe('probeAgentProcess / probeCronTimers — docker mode skips systemctl', () => {
+describe('probeAgentProcess — docker mode skips systemctl', () => {
   it('probeAgentProcess(dockerMode) returns the injected /proc result without execing', async () => {
     let execFileCalls = 0
     const execFileImpl: ExecFileFn = async () => {
@@ -522,20 +527,240 @@ describe('probeAgentProcess / probeCronTimers — docker mode skips systemctl', 
     expect(execFileCalls).toBe(0)
   })
 
-  it('probeCronTimers(dockerMode) returns ok-with-managed-externally without execing', async () => {
-    let execFileCalls = 0
-    const execFileImpl: ExecFileFn = async () => {
-      execFileCalls++
-      throw new Error('systemctl should never be called under dockerMode')
-    }
-    const result = await probeCronTimers('clerk', {
+})
+
+// ── probeScheduler — in-container agent-scheduler (Phase 4 cron-fold-in) ──
+
+function makeSchedulerFs(files: Record<string, { content?: string; mtimeMs?: number }>): SchedulerFsImpl {
+  return {
+    readFile: (p) => {
+      const f = files[p]
+      if (!f || f.content === undefined) throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
+      return f.content
+    },
+    mtimeMs: (p) => {
+      const f = files[p]
+      if (!f || f.mtimeMs === undefined) throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
+      return f.mtimeMs
+    },
+    exists: (p) => p in files,
+  }
+}
+
+describe('probeScheduler', () => {
+  it('returns ok n/a when not in dockerMode (Phase 4 deleted host-side scheduler)', async () => {
+    const result = await probeScheduler('clerk', { dockerMode: false })
+    expect(result.status).toBe('ok')
+    expect(result.label).toBe('Scheduler')
+    expect(result.detail).toContain('non-docker')
+  })
+
+  it('fails when lockfile is missing (sidecar never started or supervisor gave up)', async () => {
+    const fs = makeSchedulerFs({})
+    const result = await probeScheduler('clerk', {
       dockerMode: true,
-      execFileImpl: execFileImpl as never,
+      fs,
+      isAlive: () => true,
+    })
+    expect(result.status).toBe('fail')
+    expect(result.detail).toContain('no lockfile')
+  })
+
+  it('returns ok with last-fire age when lock is held by a live PID', async () => {
+    const lockPath = '/state/agent/scheduler.lock'
+    const jsonlPath = '/state/agent/scheduler.jsonl'
+    const now = 1_700_000_000_000
+    const fs = makeSchedulerFs({
+      [lockPath]: { content: '4242\n' },
+      [jsonlPath]: { content: '{}\n', mtimeMs: now - 5 * 60_000 },
+    })
+    const result = await probeScheduler('clerk', {
+      dockerMode: true,
+      fs,
+      isAlive: (pid) => pid === 4242,
+      now: () => now,
     })
     expect(result.status).toBe('ok')
-    expect(result.label).toBe('Crons')
-    expect(result.detail).toBe('managed by switchroom-cron')
-    expect(execFileCalls).toBe(0)
+    expect(result.detail).toContain('pid 4242')
+    expect(result.detail).toContain('last fire')
+  })
+
+  it('degraded when lockfile holder PID is not alive (mid-restart)', async () => {
+    const lockPath = '/state/agent/scheduler.lock'
+    const fs = makeSchedulerFs({
+      [lockPath]: { content: '99\n' },
+    })
+    const result = await probeScheduler('clerk', {
+      dockerMode: true,
+      fs,
+      isAlive: () => false,
+    })
+    expect(result.status).toBe('degraded')
+    expect(result.detail).toContain('pid 99 not alive')
+  })
+
+  it('degraded when lockfile contents are not a valid PID', async () => {
+    const lockPath = '/state/agent/scheduler.lock'
+    const fs = makeSchedulerFs({
+      [lockPath]: { content: 'garbage' },
+    })
+    const result = await probeScheduler('clerk', {
+      dockerMode: true,
+      fs,
+      isAlive: () => true,
+    })
+    expect(result.status).toBe('degraded')
+    expect(result.detail).toContain('invalid')
+  })
+
+  it('returns ok without freshness hint when scheduler.jsonl has never been written', async () => {
+    const lockPath = '/state/agent/scheduler.lock'
+    const fs = makeSchedulerFs({
+      [lockPath]: { content: '5555' },
+    })
+    const result = await probeScheduler('clerk', {
+      dockerMode: true,
+      fs,
+      isAlive: () => true,
+    })
+    expect(result.status).toBe('ok')
+    expect(result.detail).toContain('pid 5555')
+    expect(result.detail).not.toContain('last fire')
+  })
+})
+
+// ── probeBroker / probeKernel — UDS reachability ─────────────────────────
+
+describe('probeBroker / probeKernel', () => {
+  it('probeBroker returns ok n/a when not in dockerMode', async () => {
+    const result = await probeBroker('/some/path', { dockerMode: false })
+    expect(result.status).toBe('ok')
+    expect(result.detail).toContain('non-docker')
+  })
+
+  it('probeBroker fails when no socket path is configured', async () => {
+    const oldEnv = process.env.SWITCHROOM_BROKER_SOCKET
+    delete process.env.SWITCHROOM_BROKER_SOCKET
+    try {
+      const result = await probeBroker(undefined, { dockerMode: true })
+      expect(result.status).toBe('fail')
+      expect(result.detail).toContain('not configured')
+    } finally {
+      if (oldEnv !== undefined) process.env.SWITCHROOM_BROKER_SOCKET = oldEnv
+    }
+  })
+
+  it('probeBroker reports ok when connect resolves', async () => {
+    const result = await probeBroker('/run/switchroom/broker/clerk/sock', {
+      dockerMode: true,
+      connectImpl: async () => { /* connect ok */ },
+    })
+    expect(result.status).toBe('ok')
+    expect(result.label).toBe('Broker')
+    expect(result.detail).toBe('reachable')
+  })
+
+  it('probeBroker reports fail with ENOENT detail when socket missing', async () => {
+    const result = await probeBroker('/run/switchroom/broker/clerk/sock', {
+      dockerMode: true,
+      connectImpl: async () => {
+        const err = new Error('ENOENT') as NodeJS.ErrnoException
+        err.code = 'ENOENT'
+        throw err
+      },
+    })
+    expect(result.status).toBe('fail')
+    expect(result.detail).toContain('socket missing')
+  })
+
+  it('probeBroker reports fail with ECONNREFUSED detail when daemon down', async () => {
+    const result = await probeBroker('/run/switchroom/broker/clerk/sock', {
+      dockerMode: true,
+      connectImpl: async () => {
+        const err = new Error('ECONNREFUSED') as NodeJS.ErrnoException
+        err.code = 'ECONNREFUSED'
+        throw err
+      },
+    })
+    expect(result.status).toBe('fail')
+    expect(result.detail).toContain('connection refused')
+  })
+
+  it('probeKernel mirrors probeBroker shape with Kernel label', async () => {
+    const result = await probeKernel('/run/switchroom/kernel/clerk/sock', {
+      dockerMode: true,
+      connectImpl: async () => { /* connect ok */ },
+    })
+    expect(result.status).toBe('ok')
+    expect(result.label).toBe('Kernel')
+    expect(result.detail).toBe('reachable')
+  })
+})
+
+// ── probeSkills — symlink validity ───────────────────────────────────────
+
+function makeSkillsFs(entries: Record<string, string[]>, files: Set<string>): SkillsFsImpl {
+  return {
+    readdir: (p) => {
+      if (!(p in entries)) throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
+      return entries[p]
+    },
+    exists: (p) => files.has(p) || p in entries,
+  }
+}
+
+describe('probeSkills', () => {
+  const agentDir = '/state/agent'
+  const skillsDir = '/state/agent/.claude/skills'
+
+  it('returns ok when no skills dir exists (no skills configured is normal)', async () => {
+    const fs = makeSkillsFs({}, new Set())
+    const result = await probeSkills(agentDir, { fs })
+    expect(result.status).toBe('ok')
+    expect(result.detail).toContain('no skills dir')
+  })
+
+  it('returns ok with count when every skill resolves', async () => {
+    const fs = makeSkillsFs(
+      { [skillsDir]: ['simplify', 'review'] },
+      new Set([
+        `${skillsDir}/simplify`, `${skillsDir}/simplify/SKILL.md`,
+        `${skillsDir}/review`, `${skillsDir}/review/SKILL.md`,
+      ]),
+    )
+    const result = await probeSkills(agentDir, { fs })
+    expect(result.status).toBe('ok')
+    expect(result.detail).toContain('2 resolved')
+  })
+
+  it('degraded when at least one symlink dangles, names them up to cap', async () => {
+    const fs = makeSkillsFs(
+      { [skillsDir]: ['simplify', 'gone-skill', 'also-gone', 'and-this', 'review'] },
+      new Set([
+        `${skillsDir}/simplify`, `${skillsDir}/simplify/SKILL.md`,
+        `${skillsDir}/review`, `${skillsDir}/review/SKILL.md`,
+        // gone-skill, also-gone, and-this NOT in files set → dangling
+      ]),
+    )
+    const result = await probeSkills(agentDir, { fs, maxNamesShown: 2 })
+    expect(result.status).toBe('degraded')
+    expect(result.detail).toContain('3/5 dangling')
+    expect(result.detail).toContain('gone-skill')
+    expect(result.detail).toContain('also-gone')
+    expect(result.detail).toContain('+1 more')
+    expect(result.detail).not.toContain('and-this')
+  })
+
+  it('returns ok when entries dir is empty', async () => {
+    const fs = makeSkillsFs({ [skillsDir]: [] }, new Set([skillsDir]))
+    // Make exists() report true for the dir itself
+    const wrappedFs: SkillsFsImpl = {
+      readdir: fs.readdir,
+      exists: (p) => p === skillsDir || fs.exists(p),
+    }
+    const result = await probeSkills(agentDir, { fs: wrappedFs })
+    expect(result.status).toBe('ok')
+    expect(result.detail).toBe('0 skills')
   })
 })
 

--- a/telegram-plugin/tests/welcome-text.test.ts
+++ b/telegram-plugin/tests/welcome-text.test.ts
@@ -243,6 +243,63 @@ describe("statusPairedText", () => {
       expect(out).toContain("<b>Version</b>");
     });
   });
+
+  // Live probe block — `/status` shows EVERY probe (green and otherwise).
+  // This is the deliberate opposite of the boot card's silent-when-healthy
+  // contract: boot card = quiet ack, /status = dashboard.
+  describe("live health block", () => {
+    it("does NOT render a Health section when meta.live is undefined", () => {
+      const out = statusPairedText({ user: "@ken", meta });
+      expect(out).not.toContain("<b>Health</b>");
+    });
+
+    it("does NOT render a Health section when meta.live is empty array", () => {
+      const out = statusPairedText({ user: "@ken", meta: { ...meta, live: [] } });
+      expect(out).not.toContain("<b>Health</b>");
+    });
+
+    it("renders all probe rows including green ones", () => {
+      const live: AgentMetadata["live"] = [
+        { status: "ok",       label: "Account",   detail: "ken@x.com · Max · token 60d" },
+        { status: "ok",       label: "Broker",    detail: "reachable" },
+        { status: "degraded", label: "Skills",    detail: "1/5 dangling: foo" },
+        { status: "fail",     label: "Scheduler", detail: "sidecar not running" },
+      ];
+      const out = statusPairedText({ user: "@ken", meta: { ...meta, live } });
+      expect(out).toContain("<b>Health</b>");
+      expect(out).toContain("🟢 <b>Account</b>  ken@x.com · Max · token 60d");
+      expect(out).toContain("🟢 <b>Broker</b>  reachable");
+      expect(out).toContain("🟡 <b>Skills</b>  1/5 dangling: foo");
+      expect(out).toContain("🔴 <b>Scheduler</b>  sidecar not running");
+    });
+
+    it("renders Health section before the audit block", () => {
+      const live: AgentMetadata["live"] = [
+        { status: "ok", label: "Account", detail: "ok" },
+      ];
+      const audit = {
+        version: "v0.3.0", tools: "all", toolsDeny: null, skills: null,
+        limits: "idle 30m", channel: "switchroom", memoryBank: "x",
+      };
+      const out = statusPairedText({
+        user: "@ken",
+        meta: { ...meta, live, audit },
+      });
+      const healthIdx = out.indexOf("<b>Health</b>");
+      const versionIdx = out.indexOf("<b>Version</b>");
+      expect(healthIdx).toBeGreaterThan(-1);
+      expect(versionIdx).toBeGreaterThan(healthIdx);
+    });
+
+    it("escapes HTML in probe detail strings", () => {
+      const live: AgentMetadata["live"] = [
+        { status: "fail", label: "Skills", detail: "<script>alert(1)</script>" },
+      ];
+      const out = statusPairedText({ user: "@ken", meta: { ...meta, live } });
+      expect(out).not.toContain("<script>alert");
+      expect(out).toContain("&lt;script&gt;");
+    });
+  });
 });
 
 // Local alias for the audit shape — duplicates the AgentMetadata.audit

--- a/telegram-plugin/welcome-text.ts
+++ b/telegram-plugin/welcome-text.ts
@@ -48,6 +48,21 @@ export type AgentAudit = {
   memoryBank?: string;
 };
 
+/**
+ * One live probe row for the `/status` health block. Mirrors the
+ * `ProbeResult` shape used by the boot card without dragging the
+ * boot-probes module into welcome-text — keeps welcome-text dependency-
+ * free for unit tests.
+ */
+export type StatusProbeRow = {
+  /** ProbeStatus shape from boot-probes: ok / degraded / fail. */
+  status: 'ok' | 'degraded' | 'fail';
+  /** Display label, e.g. "Broker", "Scheduler". */
+  label: string;
+  /** Free-text detail, e.g. "running (pid 23) · last fire 4m ago". */
+  detail: string;
+};
+
 export type AgentMetadata = {
   agentName: string;
   model: string | null;
@@ -59,6 +74,13 @@ export type AgentMetadata = {
   auth: AuthSummary | null;
   /** Live audit details — present only when switchroom.yaml loaded cleanly. */
   audit?: AgentAudit;
+  /**
+   * Live probe results gathered at request time. Same probe set as the
+   * boot card. Unlike the boot card (silent-when-healthy), `/status`
+   * shows EVERY row including the green ones — the user explicitly
+   * asked for current state, so terseness loses to completeness here.
+   */
+  live?: StatusProbeRow[];
 };
 
 // Tiny escaper — duplicates the one in gateway.ts / server.ts so this
@@ -151,6 +173,12 @@ export function helpText(agentName: string): string {
  * Version. This is the on-demand reincarnation of the SessionStart
  * greeting card deleted in #142 PR 1.
  */
+const STATUS_DOT: Record<StatusProbeRow['status'], string> = {
+  ok: '🟢',
+  degraded: '🟡',
+  fail: '🔴',
+};
+
 export function statusPairedText(params: {
   user: string;
   meta: AgentMetadata;
@@ -163,6 +191,19 @@ export function statusPairedText(params: {
     `Auth: ${formatAuthLine(meta.auth)}`,
   ];
   if (meta.status) lines.push(`Status: <code>${escapeHtml(meta.status)}</code>${meta.uptime ? ` · up ${escapeHtml(meta.uptime)}` : ""}`);
+
+  // Live health block — every probe (green and otherwise) so the user
+  // can see at a glance what's working AND what isn't. This is the
+  // `/status`-specific opposite of the boot card's silent-when-healthy
+  // contract: the boot card is a quiet ack, /status is the dashboard.
+  if (meta.live && meta.live.length > 0) {
+    lines.push("");
+    lines.push("<b>Health</b>");
+    for (const row of meta.live) {
+      const dot = STATUS_DOT[row.status] ?? STATUS_DOT.fail;
+      lines.push(`${dot} <b>${escapeHtml(row.label)}</b>  ${escapeHtml(row.detail)}`);
+    }
+  }
 
   const audit = meta.audit;
   if (audit) {


### PR DESCRIPTION
## Summary

The boot card and `/status` had grown stale against the post-Phase-4 architecture. Three concrete disconnects + one coverage gap:

- **Crons probe was a lie.** `probeCronTimers(dockerMode)` returned ok with detail `"managed by switchroom-cron"` — but PRs #890–893 retired that singleton container; cron has been in-container as the `agent-scheduler` sidecar since. The non-docker path queried per-agent systemd timers that no longer exist either. Both paths reported green without checking anything real, so a crashed scheduler stayed silent.
- **No probe for vault-broker or approval-kernel.** Compose has bind-presence healthchecks (PR #898) but the gateway itself never queried either daemon. First `/vault` or `/approvals` call surfaced the failure to the user instead of the boot card.
- **Skills validated only against config, never against the filesystem.** A renamed/deleted skill in `~/.switchroom/skills/` dangles silently — claude won't discover it, user wonders why `/<skill>` doesn't work.
- **`/status` was missing live state.** It showed the configured audit (Profile/Tools/Skills/Limits/Channel/Memory) but no probe state — the user had no on-demand surface that named what was actually working right now.

## Changes

- Replace `probeCronTimers` with `probeScheduler`. Checks `/state/agent/scheduler.lock`, verifies the holder PID is alive (\`kill(pid, 0)\`), and adds a last-fire age hint from `scheduler.jsonl` mtime. Mirrors the lockfile semantics of `src/agent-scheduler/lock.ts`. Outside dockerMode returns `ok=n/a` (Phase 4 deleted the host-side scheduler entirely).
- Add `probeBroker` and `probeKernel` — UDS connect-test against the per-agent socket paths (path-as-identity invariant from `CLAUDE.md` and `src/vault/broker/peercred.ts`). \`ENOENT\` → fail with \`socket missing\`, \`ECONNREFUSED\` → fail with \`connection refused\`. Defaults read \`SWITCHROOM_BROKER_SOCKET\` / \`SWITCHROOM_KERNEL_SOCKET\` (set by compose, `src/agents/compose.ts:544-545`).
- Add `probeSkills`. Walks `<agentDir>/.claude/skills/` and reports any entry whose target is unreadable. Names up to 3 dangling skills inline so the row stays one mobile-line.
- Extend boot-card `PROBE_KEYS` / `PROBE_LABELS` with `scheduler`, `broker`, `kernel`, `skills`. **Silent-when-healthy contract preserved** — these probes only surface a row when degraded/fail. The boot-card design (#142 PR 1) was explicit on this and it stays.
- `/status` (Telegram) grows a `Health` section that renders **every** probe including the green ones. Same probe set as the boot card; opposite rendering contract — boot card stays the quiet ack, `/status` becomes the on-demand dashboard. \`buildAgentMetadata\` is now async and runs \`runAllProbes\` at request time.

## What's NOT in this PR

- An autoaccept-poll probe. autoaccept is a one-shot tail-watcher (first-run prompts only); its absence is non-fatal. Add as a follow-up if it shows up in field reports.
- A sidecar-aggregate probe. Gateway and scheduler are already covered individually; broker/kernel are external to the agent container.
- Reversing #142's silent-when-healthy contract on the boot card. The user confirmed they want the rich surface to live in `/status`, not the boot card.

## Test plan

- [x] \`npm run lint\` clean
- [x] \`npm test\` (vitest 5190 pass + targeted bun suite 154 pass — 7 boot-card/probe/welcome-text test files all green)
- [x] New unit tests for \`probeScheduler\` (5 cases: lockfile missing, holder alive with freshness hint, holder dead, invalid contents, no jsonl yet)
- [x] New unit tests for \`probeBroker\` / \`probeKernel\` (non-docker n/a, missing config, ok, ENOENT, ECONNREFUSED, kernel-mirrors-broker shape)
- [x] New unit tests for \`probeSkills\` (no dir, all-resolved, partial dangle with name cap, empty)
- [x] New welcome-text tests for the live health block (renders all rows, ordering vs audit, HTML escape, missing/empty cases)
- [x] Updated tests that pinned \`"managed by switchroom-cron"\` and the \`probeCronTimers\` slug-vs-displayName case (#309 cron half is obsolete; agent-process slug half is preserved)
- [ ] Manual smoke: restart an agent, confirm boot card stays the quiet ack on healthy boots and `/status` reply shows the new Health block (deferred — needs an authenticated agent to drive)

🤖 Generated with [Claude Code](https://claude.com/claude-code)