### PR TITLE
fix(boot-card): probeScheduler env overrides + settle-window softening

### DIFF
--- a/telegram-plugin/gateway/boot-probes.ts
+++ b/telegram-plugin/gateway/boot-probes.ts
@@ -940,6 +940,45 @@ const SCHEDULER_LOCK_PATH_DEFAULT = '/state/agent/scheduler.lock'
 const SCHEDULER_JSONL_PATH_DEFAULT = '/state/agent/scheduler.jsonl'
 
 /**
+ * How long after PID 1 started we treat a missing/dead scheduler as
+ * "still settling" rather than a hard fail. Boot-card already has its
+ * own 6 s settle window before probes run, so this only matters for
+ * /status hits during the first ~30 s of a container's life — long
+ * enough to cover supervisor + bun startup on a slow host without
+ * hiding a genuinely wedged scheduler.
+ */
+const SCHEDULER_FRESH_BOOT_MS = 30_000
+
+/**
+ * Read PID 1's start time inside the container (ms since epoch). Used
+ * to soften scheduler probe verdicts during the early-boot window.
+ * Mirrors `readContainerBootTimeMs` from src/agent-scheduler/lock.ts —
+ * we duplicate the small reader here rather than import across the
+ * src/telegram-plugin boundary, since the plugin is built standalone.
+ *
+ * Returns null on any /proc parse failure → caller skips the softening.
+ */
+function readContainerBootTimeMsForProbe(): number | null {
+  try {
+    const stat1 = readFileSync('/proc/1/stat', 'utf8')
+    const lastParen = stat1.lastIndexOf(')')
+    if (lastParen < 0) return null
+    const after = stat1.slice(lastParen + 1).trim().split(/\s+/)
+    const starttimeTicks = Number(after[19])
+    if (!Number.isFinite(starttimeTicks)) return null
+    const procStat = readFileSync('/proc/stat', 'utf8')
+    const btimeLine = procStat.split('\n').find((l) => l.startsWith('btime '))
+    if (!btimeLine) return null
+    const btimeSec = Number(btimeLine.split(/\s+/)[1])
+    if (!Number.isFinite(btimeSec)) return null
+    const CLK_TCK = 100
+    return (btimeSec + starttimeTicks / CLK_TCK) * 1000
+  } catch {
+    return null
+  }
+}
+
+/**
  * Filesystem injection point for the scheduler probe. Same shape as
  * ProcFsImpl but read-only against arbitrary paths. Tests inject a
  * synthetic fs to drive lockfile contents and jsonl tails without
@@ -993,11 +1032,24 @@ export async function probeScheduler(
   opts: {
     dockerMode?: boolean
     fs?: SchedulerFsImpl
+    /** Override the lockfile path. Defaults to env
+     *  `SWITCHROOM_AGENT_SCHEDULER_LOCK` (matches the override the
+     *  scheduler itself reads at src/agent-scheduler/index.ts:196), then
+     *  to `/state/agent/scheduler.lock`. */
     lockPath?: string
+    /** Override the audit-jsonl path. Defaults to env
+     *  `SWITCHROOM_AGENT_SCHEDULER_JSONL`, then to
+     *  `/state/agent/scheduler.jsonl` (mirrors index.ts:194). */
     jsonlPath?: string
     /** Liveness check for the holder PID — defaults to process.kill(pid, 0). */
     isAlive?: (pid: number) => boolean
     now?: () => number
+    /** Container PID-1 start time in ms since epoch. When set AND the
+     *  current time is within `SCHEDULER_FRESH_BOOT_MS` of it, scheduler
+     *  fail/degraded verdicts are softened to "still settling". Pass
+     *  `null` to disable the softening (e.g. unit tests pinning a hard
+     *  fail). Defaults to `readContainerBootTimeMsForProbe()`. */
+    containerBootTimeMs?: number | null
   } = {},
 ): Promise<ProbeResult> {
   if (!opts.dockerMode) {
@@ -1005,15 +1057,32 @@ export async function probeScheduler(
   }
   return withTimeout('Scheduler', (async (): Promise<ProbeResult> => {
     const fs = opts.fs ?? realSchedulerFs
-    const lockPath = opts.lockPath ?? SCHEDULER_LOCK_PATH_DEFAULT
-    const jsonlPath = opts.jsonlPath ?? SCHEDULER_JSONL_PATH_DEFAULT
+    const lockPath = opts.lockPath
+      ?? process.env.SWITCHROOM_AGENT_SCHEDULER_LOCK
+      ?? SCHEDULER_LOCK_PATH_DEFAULT
+    const jsonlPath = opts.jsonlPath
+      ?? process.env.SWITCHROOM_AGENT_SCHEDULER_JSONL
+      ?? SCHEDULER_JSONL_PATH_DEFAULT
     const now = opts.now ?? Date.now
     const isAlive = opts.isAlive ?? ((pid: number) => {
       try { process.kill(pid, 0); return true } catch { return false }
     })
+    const bootTimeMs = 'containerBootTimeMs' in opts
+      ? opts.containerBootTimeMs
+      : readContainerBootTimeMsForProbe()
+    const stillSettling = bootTimeMs != null
+      && (now() - bootTimeMs) < SCHEDULER_FRESH_BOOT_MS
+    const settlingNote = stillSettling ? ' (still settling)' : ''
 
     if (!fs.exists(lockPath)) {
-      return { status: 'fail', label: 'Scheduler', detail: 'sidecar not running (no lockfile)' }
+      // During the first ~30 s of a container's life, "no lockfile" is
+      // the supervisor + bun still starting up. /status hit at that
+      // moment shouldn't show 🔴 for a non-issue.
+      return {
+        status: stillSettling ? 'degraded' : 'fail',
+        label: 'Scheduler',
+        detail: `sidecar not running (no lockfile)${settlingNote}`,
+      }
     }
     let holderPid: number | null = null
     try {

--- a/telegram-plugin/tests/boot-probes.test.ts
+++ b/telegram-plugin/tests/boot-probes.test.ts
@@ -561,9 +561,94 @@ describe('probeScheduler', () => {
       dockerMode: true,
       fs,
       isAlive: () => true,
+      // Disable settle softening so the verdict is the hard fail —
+      // the "boot still settling" case is covered by the dedicated
+      // test below.
+      containerBootTimeMs: null,
     })
     expect(result.status).toBe('fail')
     expect(result.detail).toContain('no lockfile')
+  })
+
+  it('softens fail to degraded when container booted recently (still-settling window)', async () => {
+    // No lockfile, but container PID 1 started 5 s ago — the supervisor
+    // is still bringing the scheduler up. /status hit at this instant
+    // should NOT show 🔴 for a non-issue.
+    const now = 1_700_000_000_000
+    const fs = makeSchedulerFs({})
+    const result = await probeScheduler('clerk', {
+      dockerMode: true,
+      fs,
+      isAlive: () => true,
+      now: () => now,
+      containerBootTimeMs: now - 5_000,
+    })
+    expect(result.status).toBe('degraded')
+    expect(result.detail).toContain('still settling')
+  })
+
+  it('does NOT soften when container booted long ago (real wedge, not a flap)', async () => {
+    // Container has been up for an hour; missing lockfile is a real
+    // problem, not a settle window. Hard fail expected.
+    const now = 1_700_000_000_000
+    const fs = makeSchedulerFs({})
+    const result = await probeScheduler('clerk', {
+      dockerMode: true,
+      fs,
+      isAlive: () => true,
+      now: () => now,
+      containerBootTimeMs: now - 60 * 60_000,
+    })
+    expect(result.status).toBe('fail')
+    expect(result.detail).not.toContain('still settling')
+  })
+
+  it('honors SWITCHROOM_AGENT_SCHEDULER_LOCK env override', async () => {
+    const customLock = '/custom/sched.lock'
+    const fs = makeSchedulerFs({
+      [customLock]: { content: '1234' },
+    })
+    const oldEnv = process.env.SWITCHROOM_AGENT_SCHEDULER_LOCK
+    process.env.SWITCHROOM_AGENT_SCHEDULER_LOCK = customLock
+    try {
+      const result = await probeScheduler('clerk', {
+        dockerMode: true,
+        fs,
+        isAlive: (pid) => pid === 1234,
+        containerBootTimeMs: null,
+      })
+      expect(result.status).toBe('ok')
+      expect(result.detail).toContain('pid 1234')
+    } finally {
+      if (oldEnv === undefined) delete process.env.SWITCHROOM_AGENT_SCHEDULER_LOCK
+      else process.env.SWITCHROOM_AGENT_SCHEDULER_LOCK = oldEnv
+    }
+  })
+
+  it('honors SWITCHROOM_AGENT_SCHEDULER_JSONL env override for freshness hint', async () => {
+    const lockPath = '/state/agent/scheduler.lock'
+    const customJsonl = '/custom/audit.jsonl'
+    const now = 1_700_000_000_000
+    const fs = makeSchedulerFs({
+      [lockPath]: { content: '5555' },
+      [customJsonl]: { content: '{}\n', mtimeMs: now - 90_000 },
+    })
+    const oldEnv = process.env.SWITCHROOM_AGENT_SCHEDULER_JSONL
+    process.env.SWITCHROOM_AGENT_SCHEDULER_JSONL = customJsonl
+    try {
+      const result = await probeScheduler('clerk', {
+        dockerMode: true,
+        fs,
+        isAlive: () => true,
+        now: () => now,
+        containerBootTimeMs: null,
+      })
+      expect(result.status).toBe('ok')
+      expect(result.detail).toContain('last fire')
+    } finally {
+      if (oldEnv === undefined) delete process.env.SWITCHROOM_AGENT_SCHEDULER_JSONL
+      else process.env.SWITCHROOM_AGENT_SCHEDULER_JSONL = oldEnv
+    }
   })
 
   it('returns ok with last-fire age when lock is held by a live PID', async () => {


### PR DESCRIPTION
## Summary

Two non-blocking follow-ups from PR #925's reviewer:

1. **`probeScheduler` honors env-path overrides.** `SWITCHROOM_AGENT_SCHEDULER_LOCK` / `SWITCHROOM_AGENT_SCHEDULER_JSONL` are read from the env when no explicit path is passed, matching the scheduler's own override behavior (\`src/agent-scheduler/index.ts:194-197\`). Previously a non-default lock path was invisible to the probe — operator would see a false \`Scheduler  sidecar not running (no lockfile)\` row even with the scheduler running fine at the overridden path.

2. **Settle-window-aware fail → degraded mapping.** `/status` (no settle window) could surface a 🔴 row if hit during a brief supervisor flap or the first few seconds of a container's life — before the supervisor has forked the scheduler. \`probeScheduler\` now reads \`/proc/1/stat\` to compute the container's PID-1 start time, and downgrades the missing-lockfile fail → degraded with detail \"(still settling)\" within 30 s of boot. Same /proc parse logic as \`src/agent-scheduler/lock.ts:readContainerBootTimeMs\` (duplicated rather than imported across the src/telegram-plugin build boundary).

## Behavior

| Scenario | Before | After |
|----------|--------|-------|
| Container up 5 min, no lockfile | 🔴 fail | 🔴 fail (unchanged) |
| Container up 5 sec, no lockfile | 🔴 fail | 🟡 degraded \`(still settling)\` |
| Lock at custom env path, scheduler running | 🔴 fail false-alarm | 🟢 ok |

## Test plan

- [x] \`npm run lint\` clean
- [x] New unit tests: settle-window softens within 30s, doesn't soften beyond, env-override for both LOCK and JSONL paths
- [x] Existing \"no lockfile → fail\" test pinned with \`containerBootTimeMs: null\` so the hard-fail verdict stays deterministic
- [x] \`npm test\` (vitest 5202 pass, bun probes 128 pass — 2 vitest failures in \`src/cli/deprecated.test.ts\` are pre-existing on upstream/main, unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)