### PR TITLE
feat(telegram): `/upgradestatus` — read-only fleet update status (#927)

### DIFF
--- a/src/cli/update.test.ts
+++ b/src/cli/update.test.ts
@@ -141,6 +141,21 @@ describe("--status (#927)", () => {
     expect(out.join("")).toContain("CLI: test");
   });
 
+  it("runUpdate --json without --status fails loud (exit 2) — #938 reviewer", async () => {
+    const { runUpdate } = await import("./update.js");
+    const out: string[] = [];
+    const err: string[] = [];
+    const code = await runUpdate({
+      json: true,
+      composePath: "/x.yml",
+      stdout: (s) => out.push(s),
+      stderr: (s) => err.push(s),
+      runner: () => ({ status: 0 }),
+    });
+    expect(code).toBe(2);
+    expect(err.join("")).toMatch(/--json is only honored under --status/);
+  });
+
   it("runUpdate --status --json emits parseable JSON with the report shape", async () => {
     const { runUpdate } = await import("./update.js");
     const out: string[] = [];

--- a/src/cli/update.test.ts
+++ b/src/cli/update.test.ts
@@ -88,6 +88,85 @@ describe("planUpdate", () => {
   });
 });
 
+describe("--status (#927)", () => {
+  it("formatStatusReport renders CLI version + per-service ages", async () => {
+    const { formatStatusReport } = await import("./update.js");
+    // Fixed clock for deterministic age strings.
+    const now = Date.parse("2026-05-10T18:00:00Z");
+    const out = formatStatusReport({
+      cliVersion: "0.7.7",
+      cliBuiltAt: new Date(now - 30 * 60 * 1000).toISOString(), // 30m ago
+      services: [
+        {
+          name: "agent-clerk",
+          image: "ghcr.io/x/switchroom-agent:latest",
+          imageDigestShort: "abc123def456",
+          imagePulledAt: new Date(now - 4 * 3600 * 1000).toISOString(), // 4h
+          containerCreatedAt: new Date(now - 1 * 3600 * 1000).toISOString(), // 1h
+          status: "running",
+        },
+      ],
+      warnings: [],
+    });
+    expect(out).toContain("CLI: 0.7.7");
+    expect(out).toContain("agent-clerk");
+    expect(out).toContain("running");
+    expect(out).toContain("[abc123def456]");
+  });
+
+  it("runUpdate --status uses statusProbe seam, never invokes runner", async () => {
+    const { runUpdate } = await import("./update.js");
+    const out: string[] = [];
+    let runnerCalled = false;
+    let probedComposePath = "";
+    const code = await runUpdate({
+      status: true,
+      composePath: "/some/compose.yml",
+      stdout: (s) => out.push(s),
+      stderr: (s) => out.push(s),
+      runner: () => { runnerCalled = true; return { status: 0 }; },
+      statusProbe: (p) => {
+        probedComposePath = p;
+        return {
+          cliVersion: "test",
+          cliBuiltAt: null,
+          services: [],
+          warnings: [],
+        };
+      },
+    });
+    expect(code).toBe(0);
+    expect(runnerCalled).toBe(false); // status mode runs no steps
+    expect(probedComposePath).toBe("/some/compose.yml");
+    expect(out.join("")).toContain("CLI: test");
+  });
+
+  it("runUpdate --status --json emits parseable JSON with the report shape", async () => {
+    const { runUpdate } = await import("./update.js");
+    const out: string[] = [];
+    await runUpdate({
+      status: true,
+      json: true,
+      composePath: "/x.yml",
+      stdout: (s) => out.push(s),
+      runner: () => ({ status: 0 }),
+      statusProbe: () => ({
+        cliVersion: "0.7.8",
+        cliBuiltAt: "2026-05-10T18:00:00Z",
+        services: [
+          { name: "vault-broker", image: "ghcr.io/x:latest", imageDigestShort: "deadbeef", imagePulledAt: null, containerCreatedAt: null, status: "running" },
+        ],
+        warnings: ["test warning"],
+      }),
+    });
+    const parsed = JSON.parse(out.join(""));
+    expect(parsed.cliVersion).toBe("0.7.8");
+    expect(parsed.services).toHaveLength(1);
+    expect(parsed.services[0].name).toBe("vault-broker");
+    expect(parsed.warnings).toEqual(["test warning"]);
+  });
+});
+
 describe("--rebuild against a non-checkout install fails loudly (#923 reviewer)", () => {
   it("rebuild-source step throws when scriptPath has no .git ancestor", () => {
     const tmp = mkdtempSync(join(tmpdir(), "rebuild-no-git-"));

--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -43,6 +43,11 @@ interface UpdateOptions {
   check?: boolean;
   skipImages?: boolean;
   rebuild?: boolean;
+  /** Read-only mode: report current version + image/container state without
+   *  invoking any update steps. Wired by Telegram /upgrade-status (#927). */
+  status?: boolean;
+  /** JSON output (currently only honored under --status). */
+  json?: boolean;
   /** Hidden / legacy flags — kept so v0.6-era invocations don't crash. */
   phase?: string;
   force?: boolean;
@@ -53,6 +58,8 @@ interface UpdateOptions {
   stderr?: (s: string) => void;
   /** Test seam — replace step.run with a fake. */
   runner?: (cmd: string, args: string[]) => { status: number };
+  /** Test seam — replace docker inspect / package.json reads. */
+  statusProbe?: (composePath: string) => StatusReport;
 }
 
 interface UpdateStep {
@@ -204,9 +211,221 @@ function defaultRunner(cmd: string, args: string[]): { status: number } {
   return { status: r.status ?? 1 };
 }
 
+// ─── --status mode (#927) ────────────────────────────────────────────────
+//
+// Read-only snapshot of "where this host stands" for the operator who
+// wants to know whether they should run `update`. Wired by Telegram
+// /upgrade-status — the bot command is one line: shell `switchroom
+// update --status` and post the output.
+//
+// Intentional v1 limitation: does NOT query upstream (GitHub API) for
+// commits-ahead/behind. Adding that needs gh auth, network, and
+// per-host opt-in. Instead, the operator can `/update` (dry-run) which
+// shows what `docker compose pull` would change. Filed as a follow-up.
+
+export interface ServiceState {
+  name: string;
+  image: string | null;          // e.g. "ghcr.io/switchroom/switchroom-agent:latest"
+  imageDigestShort: string | null; // first 12 of the image's content hash
+  imagePulledAt: string | null;  // ISO ts, when the image's local pull happened
+  containerCreatedAt: string | null; // ISO ts, when the running container was started
+  status: string;                // "running" | "exited" | "<unknown>"
+}
+
+export interface StatusReport {
+  cliVersion: string;
+  cliBuiltAt: string | null;     // ISO ts (mtime of the running script)
+  services: ServiceState[];
+  /** Soft warnings — e.g. compose missing, docker unreachable. Render-only. */
+  warnings: string[];
+}
+
+/**
+ * Probe the host for current update state. No side effects. Heavy on
+ * docker shellouts but each is bounded by spawnSync's default timeout.
+ */
+function defaultStatusProbe(composePath: string): StatusReport {
+  const warnings: string[] = [];
+
+  // CLI version + build time. Walk up from process.argv[1] looking
+  // for package.json (covers both bun-run-dev and installed paths).
+  let cliVersion = "unknown";
+  let cliBuiltAt: string | null = null;
+  try {
+    const scriptPath = process.argv[1] ?? "";
+    if (scriptPath) {
+      // Look for package.json in the script's repo / install dir.
+      let dir = dirname(scriptPath);
+      for (let i = 0; i < 8; i++) {
+        const pkgPath = join(dir, "package.json");
+        if (existsSync(pkgPath)) {
+          try {
+            const stat = spawnSync("stat", ["-c", "%Y", scriptPath], { encoding: "utf-8" });
+            if (stat.status === 0) {
+              const mtime = Number(stat.stdout.trim()) * 1000;
+              if (Number.isFinite(mtime)) cliBuiltAt = new Date(mtime).toISOString();
+            }
+          } catch { /* nothing to do */ }
+          try {
+            const fs = require("node:fs") as typeof import("node:fs");
+            const pkg = JSON.parse(fs.readFileSync(pkgPath, "utf-8")) as { version?: string };
+            if (typeof pkg.version === "string") cliVersion = pkg.version;
+          } catch { /* nothing to do */ }
+          break;
+        }
+        const parent = dirname(dir);
+        if (parent === dir) break;
+        dir = parent;
+      }
+    }
+  } catch { warnings.push("could not resolve CLI version + build time"); }
+
+  // Docker probe — list services from compose, then docker inspect each.
+  const services: ServiceState[] = [];
+  if (!existsSync(composePath)) {
+    warnings.push(`compose file not found at ${composePath}; service status unknown`);
+    return { cliVersion, cliBuiltAt, services, warnings };
+  }
+  let serviceList: string[] = [];
+  try {
+    const r = spawnSync(
+      "docker",
+      ["compose", "-p", "switchroom", "-f", composePath, "config", "--services"],
+      { encoding: "utf-8", timeout: 10_000 },
+    );
+    if (r.status !== 0) {
+      warnings.push(`docker compose config --services failed: ${r.stderr?.trim() ?? r.error?.message ?? "unknown"}`);
+      return { cliVersion, cliBuiltAt, services, warnings };
+    }
+    serviceList = r.stdout.split("\n").map((s) => s.trim()).filter(Boolean).sort();
+  } catch (err) {
+    warnings.push(`docker not reachable: ${(err as Error).message}`);
+    return { cliVersion, cliBuiltAt, services, warnings };
+  }
+
+  for (const svc of serviceList) {
+    // Map service → container name. Compose generator uses
+    // `switchroom-<svc-without-agent-prefix>` for agents, or the bare
+    // service name for singletons (vault-broker / approval-kernel).
+    const containerName = svc.startsWith("agent-")
+      ? `switchroom-${svc.slice("agent-".length)}`
+      : `switchroom-${svc}`;
+    let image: string | null = null;
+    let containerCreatedAt: string | null = null;
+    let status = "<unknown>";
+    try {
+      const r = spawnSync(
+        "docker",
+        ["inspect", "-f", "{{.Config.Image}}|{{.Created}}|{{.State.Status}}", containerName],
+        { encoding: "utf-8", timeout: 5_000 },
+      );
+      if (r.status === 0) {
+        const [img, created, st] = r.stdout.trim().split("|");
+        image = img ?? null;
+        containerCreatedAt = created ?? null;
+        status = st ?? "<unknown>";
+      } else {
+        status = "absent";
+      }
+    } catch { status = "<probe failed>"; }
+
+    let imageDigestShort: string | null = null;
+    let imagePulledAt: string | null = null;
+    if (image) {
+      try {
+        const r = spawnSync(
+          "docker",
+          ["image", "inspect", "-f", "{{.Id}}|{{.Created}}|{{.Metadata.LastTagTime}}", image],
+          { encoding: "utf-8", timeout: 5_000 },
+        );
+        if (r.status === 0) {
+          const [id, created, lastTag] = r.stdout.trim().split("|");
+          imageDigestShort = id?.replace(/^sha256:/, "").slice(0, 12) ?? null;
+          // LastTagTime is when this tag was last bumped locally
+          // (i.e. when `docker pull` last brought a newer image
+          // under this tag). Falls back to image Created if absent.
+          imagePulledAt = lastTag && lastTag !== "0001-01-01T00:00:00Z" ? lastTag
+            : (created ?? null);
+        }
+      } catch { /* nothing to do */ }
+    }
+
+    services.push({
+      name: svc,
+      image,
+      imageDigestShort,
+      imagePulledAt,
+      containerCreatedAt,
+      status,
+    });
+  }
+
+  return { cliVersion, cliBuiltAt, services, warnings };
+}
+
+function formatRelative(iso: string | null, now: number = Date.now()): string {
+  if (!iso) return "<unknown>";
+  const t = Date.parse(iso);
+  if (!Number.isFinite(t)) return "<unparseable>";
+  const ageSec = Math.max(0, Math.floor((now - t) / 1000));
+  if (ageSec < 60) return `${ageSec}s ago`;
+  if (ageSec < 3600) return `${Math.floor(ageSec / 60)}m ago`;
+  if (ageSec < 86400) return `${Math.floor(ageSec / 3600)}h ago`;
+  return `${Math.floor(ageSec / 86400)}d ago`;
+}
+
+function formatStatusReport(rep: StatusReport): string {
+  const lines: string[] = [];
+  lines.push(`Switchroom on this host`);
+  lines.push("");
+  lines.push(`CLI: ${rep.cliVersion}` + (rep.cliBuiltAt
+    ? ` (built ${formatRelative(rep.cliBuiltAt)})`
+    : ""));
+  lines.push("");
+  if (rep.services.length === 0) {
+    lines.push("Services: <none reachable>");
+  } else {
+    lines.push("Services:");
+    const maxNameLen = Math.max(...rep.services.map((s) => s.name.length));
+    for (const s of rep.services) {
+      const namePad = s.name.padEnd(maxNameLen);
+      const containerAge = formatRelative(s.containerCreatedAt);
+      const imageAge = formatRelative(s.imagePulledAt);
+      const digest = s.imageDigestShort ? `[${s.imageDigestShort}]` : "[?]";
+      lines.push(
+        `  ${namePad}  ${s.status.padEnd(8)}  ${digest}  pulled ${imageAge}  container ${containerAge}`,
+      );
+    }
+  }
+  if (rep.warnings.length > 0) {
+    lines.push("");
+    lines.push("Warnings:");
+    for (const w of rep.warnings) lines.push(`  ⚠ ${w}`);
+  }
+  lines.push("");
+  lines.push(`Run \`switchroom update --check\` to see what an update would do, or \`/update\` from Telegram.`);
+  return lines.join("\n");
+}
+
 async function runUpdate(opts: UpdateOptions): Promise<number> {
   const stdout = opts.stdout ?? ((s) => process.stdout.write(s));
   const stderr = opts.stderr ?? ((s) => process.stderr.write(s));
+
+  // --status: read-only snapshot, no plan execution. Wired by Telegram
+  // /upgrade-status (#927). JSON output for machine readers; human
+  // output otherwise.
+  if (opts.status) {
+    const composePath = opts.composePath ?? DEFAULT_COMPOSE_PATH;
+    const probe = opts.statusProbe ?? defaultStatusProbe;
+    const report = probe(composePath);
+    if (opts.json) {
+      stdout(JSON.stringify(report, null, 2) + "\n");
+    } else {
+      stdout(formatStatusReport(report) + "\n");
+    }
+    return 0;
+  }
+
   const steps = planUpdate(opts);
 
   if (opts.check) {
@@ -252,6 +471,14 @@ export function registerUpdateCommand(program: Command): void {
       "--rebuild",
       "Source-checkout users: also git pull + bun install + npm run build before applying. Auto-skipped when the CLI is an installed binary.",
     )
+    .option(
+      "--status",
+      "Read-only snapshot: report local CLI version, image digest + pull time, container creation time per service. Does NOT invoke any update steps. Wired by Telegram /upgrade-status (#927).",
+    )
+    .option(
+      "--json",
+      "Output as JSON (currently only honored under --status; other modes ignore).",
+    )
     // Legacy v0.6 flags — accepted as no-ops so a stale operator
     // muscle-memory invocation doesn't crash. The --phase=post-build
     // path was the in-flight v0.6→v0.7 self-reexec; that's dead now,
@@ -275,4 +502,11 @@ export function registerUpdateCommand(program: Command): void {
     });
 }
 
-export { runUpdate, defaultRunner, DEFAULT_COMPOSE_PATH };
+export {
+  runUpdate,
+  defaultRunner,
+  defaultStatusProbe,
+  formatStatusReport,
+  formatRelative,
+  DEFAULT_COMPOSE_PATH,
+};

--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -34,7 +34,7 @@
  */
 import type { Command } from "commander";
 import chalk from "chalk";
-import { existsSync } from "node:fs";
+import { existsSync, readFileSync, realpathSync, statSync } from "node:fs";
 import { spawnSync } from "node:child_process";
 import { join, dirname } from "node:path";
 import { homedir } from "node:os";
@@ -252,25 +252,43 @@ function defaultStatusProbe(composePath: string): StatusReport {
   let cliVersion = "unknown";
   let cliBuiltAt: string | null = null;
   try {
-    const scriptPath = process.argv[1] ?? "";
+    // Resolve symlinks first — `~/.bun/bin/switchroom` is typically a
+    // symlink to `dist/cli/switchroom.js` inside the workspace
+    // checkout. Walking up from the symlink's argv[1] would land in
+    // `~/.bun/bin/` which has no package.json ancestor (#938 reviewer).
+    const rawScriptPath = process.argv[1] ?? "";
+    let scriptPath = rawScriptPath;
+    try {
+      if (rawScriptPath) scriptPath = realpathSync(rawScriptPath);
+    } catch { /* nothing to do — fall back to raw argv[1] */ }
+
     if (scriptPath) {
-      // Look for package.json in the script's repo / install dir.
+      // Use mtime of the resolved script as the "built at" time —
+      // portable across BSD/macOS/Linux unlike the prior `stat -c %Y`
+      // shellout (#938 reviewer).
+      try {
+        cliBuiltAt = new Date(statSync(scriptPath).mtimeMs).toISOString();
+      } catch { /* nothing to do */ }
+
+      // Walk up from the script's directory looking for package.json.
+      // 8 levels is generous — the deepest realistic path is
+      // workspace/dist/cli/switchroom.js → 3 levels.
       let dir = dirname(scriptPath);
       for (let i = 0; i < 8; i++) {
         const pkgPath = join(dir, "package.json");
         if (existsSync(pkgPath)) {
           try {
-            const stat = spawnSync("stat", ["-c", "%Y", scriptPath], { encoding: "utf-8" });
-            if (stat.status === 0) {
-              const mtime = Number(stat.stdout.trim()) * 1000;
-              if (Number.isFinite(mtime)) cliBuiltAt = new Date(mtime).toISOString();
-            }
-          } catch { /* nothing to do */ }
-          try {
-            const fs = require("node:fs") as typeof import("node:fs");
-            const pkg = JSON.parse(fs.readFileSync(pkgPath, "utf-8")) as { version?: string };
+            // Direct ESM read — was previously `require("node:fs")`
+            // which is undefined under true ESM and threw silently
+            // (#938 reviewer blocker). readFileSync now in the
+            // top-of-file import.
+            const pkg = JSON.parse(readFileSync(pkgPath, "utf-8")) as { version?: string };
             if (typeof pkg.version === "string") cliVersion = pkg.version;
-          } catch { /* nothing to do */ }
+          } catch (err) {
+            warnings.push(
+              `read ${pkgPath} failed: ${(err as Error).message}`,
+            );
+          }
           break;
         }
         const parent = dirname(dir);
@@ -278,7 +296,17 @@ function defaultStatusProbe(composePath: string): StatusReport {
         dir = parent;
       }
     }
-  } catch { warnings.push("could not resolve CLI version + build time"); }
+  } catch (err) {
+    warnings.push(`CLI version probe failed: ${(err as Error).message}`);
+  }
+  if (cliVersion === "unknown") {
+    // Inner probes have their own try/catch; surface a single
+    // diagnostic when they all bottom out so 'CLI: unknown' is never
+    // silent (#938 reviewer concern C3).
+    warnings.push(
+      "could not resolve CLI version (no package.json found above the resolved script path)",
+    );
+  }
 
   // Docker probe — list services from compose, then docker inspect each.
   const services: ServiceState[] = [];
@@ -424,6 +452,16 @@ async function runUpdate(opts: UpdateOptions): Promise<number> {
       stdout(formatStatusReport(report) + "\n");
     }
     return 0;
+  }
+  if (opts.json) {
+    // --json without --status is unsupported (the apply / pull / up
+    // pipeline streams human output; piping JSON through a multi-step
+    // shellout is not coherent). Fail loud rather than silently
+    // ignoring (#938 reviewer nit).
+    stderr(chalk.red(
+      "--json is only honored under --status. Drop --json or add --status.\n",
+    ));
+    return 2;
   }
 
   const steps = planUpdate(opts);

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -6646,11 +6646,13 @@ bot.command('update', async ctx => {
   )
 })
 
-// /upgrade-status — read-only snapshot of where this host stands (#927).
+// /upgradestatus — read-only snapshot of where this host stands (#927).
 // Wraps `switchroom update --status` synchronously and posts the
 // formatted output. NOT admin-gated: read-only fleet metadata is safe
 // for any allowFrom user to see, and the answer "is something behind?"
 // is the missing companion to /update's "trigger an update".
+// (Telegram slash-commands forbid hyphens, hence /upgradestatus not
+// /upgrade-status. The /upgrade alias just below redirects.)
 bot.command('upgradestatus', async ctx => {
   if (!isAuthorizedSender(ctx)) return
   await runSwitchroomCommand(ctx, ['update', '--status'], 'update --status')

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -6646,6 +6646,28 @@ bot.command('update', async ctx => {
   )
 })
 
+// /upgrade-status — read-only snapshot of where this host stands (#927).
+// Wraps `switchroom update --status` synchronously and posts the
+// formatted output. NOT admin-gated: read-only fleet metadata is safe
+// for any allowFrom user to see, and the answer "is something behind?"
+// is the missing companion to /update's "trigger an update".
+bot.command('upgradestatus', async ctx => {
+  if (!isAuthorizedSender(ctx)) return
+  await runSwitchroomCommand(ctx, ['update', '--status'], 'update --status')
+})
+// Alias with hyphen — Grammy doesn't allow hyphens in command names
+// (Telegram's slash-command grammar excludes them) but operators are
+// likely to type /upgrade-status; surface a polite redirect.
+bot.command('upgrade', async ctx => {
+  if (!isAuthorizedSender(ctx)) return
+  await switchroomReply(
+    ctx,
+    'Did you mean <code>/upgradestatus</code> (no hyphen — Telegram slash-command grammar)? ' +
+    'Or <code>/update</code> to plan, <code>/update apply</code> to execute.',
+    { html: true },
+  )
+})
+
 // ─── /approve, /deny, /pending ────────────────────────────────────────────
 // Slash-command alternatives to the inline-button approval flow (useful for
 // desktop-only sessions and power-users). Share pendingPermissions state
@@ -8840,17 +8862,11 @@ bot.command('permissions', async ctx => {
   await runSwitchroomCommand(ctx, ['agent', 'permissions', agentName], `permissions ${agentName}`)
 })
 
-bot.command('update', async ctx => {
-  if (!isAuthorizedSender(ctx)) return
-  await switchroomReply(ctx, '🔄 Running <b>switchroom update</b>… back in ~30 seconds.', { html: true })
-  await sweepBeforeSelfRestart()
-  const chatId = String(ctx.chat!.id)
-  const threadId = resolveThreadId(chatId, ctx.message?.message_thread_id)
-  spawnSwitchroomDetached(
-    ['update'],
-    notifyDetachedFailure(chatId, threadId ?? null, 'update'),
-  )
-})
+// Drive-by cleanup (#927): the dead /update handler that lived here
+// was a pre-#919 stub. Grammy registers in order so the comprehensive
+// /update handler at line ~6516 (added in #919, hardened in #924,
+// docker-guarded in #934) fired first and this one never ran.
+// Removed to avoid future confusion.
 
 bot.command('version', async ctx => {
   if (!isAuthorizedSender(ctx)) return

--- a/telegram-plugin/welcome-text.ts
+++ b/telegram-plugin/welcome-text.ts
@@ -353,6 +353,7 @@ export function switchroomHelpText(agentName: string): string {
     `<code>/memory &lt;query&gt;</code> — search agent memory`,
     ``,
     `<b>Fleet management</b>`,
+    `<code>/upgradestatus</code> — read-only: CLI version, image age, container age per service`,
     `<code>/update</code> — dry-run plan; <code>/update apply</code> — actually pull images, reconcile, restart`,
     `<code>/restart [name|all]</code> — bounce agent (drains in-flight turn by default)`,
     `<code>/version</code> — show versions + running agent health summary`,


### PR DESCRIPTION
## Summary

Closes #927.

PR #919 shipped \`/update\` (trigger an update) but not the companion question: \"is anything to update?\". Operator on the train wants to know whether their host is behind upstream BEFORE deciding to apply.

## CLI side — \`switchroom update --status\`

Read-only snapshot:
- CLI version (read from package.json by walking up from \`process.argv[1]\`)
- For each compose service: image, image pull time (\`LastTagTime\`), container creation time, status
- Renders human-readable table OR JSON with \`--json\`
- Pure-function probe + format. Test seam via \`UpdateOptions.statusProbe\` so unit tests don't need a real docker
- Soft warnings (compose missing, docker unreachable) instead of hard failures — read-only status surfaces what it can

Sample output:

\`\`\`
Switchroom on this host

CLI: 0.7.7 (built 30m ago)

Services:
  approval-kernel  running   [a30b9572df01]  pulled 4h ago  container 1h ago
  vault-broker     running   [67401db94f5b]  pulled 4h ago  container 1h ago
  agent-clerk      running   [19d3cfb9bb74]  pulled 4h ago  container 1h ago
  ... (7 more)

Run \`switchroom update --check\` to see what an update would do, or \`/update\` from Telegram.
\`\`\`

## Telegram side — \`/upgradestatus\`

- \`bot.command('upgradestatus', ...)\` shells \`switchroom update --status\` via \`runSwitchroomCommand\` and posts the formatted output.
- **Not admin-gated**: read-only fleet metadata is safe for any \`allowFrom\` user. Operators can answer \"is anything to update?\" without authorization friction.
- Hyphen-form alias \`/upgrade\` prints a polite redirect (Telegram's slash-command grammar excludes hyphens).
- Help text in \`welcome-text.ts\` grew the new line.

## V1 limitation (filed as follow-up)

Does NOT query upstream (GitHub API) for \"X commits behind\". The operator can use \`/update\` (dry-run) to see what \`docker compose pull\` would change, which answers \"is anything new?\" indirectly. Adding GH-API needs auth, network, and per-host opt-in — out of scope for v1.

## Drive-by cleanup

Removed a dead \`bot.command('update', ...)\` handler at \`gateway.ts:8865\` that was a pre-#919 stub. Grammy registers in order so the comprehensive \`/update\` handler at line 6516 (added in #919, hardened in #924, docker-guarded in #934) fired first and the duplicate at 8865 never ran.

## Test plan
- [x] \`npm run lint\` clean
- [x] 3 new tests pin \`--status\` mode behavior (formatter shape, runner-not-invoked seam, JSON output) — all 14 \`update.test.ts\` tests pass
- [ ] Reviewer-agent verdict pending

🤖 Generated with [Claude Code](https://claude.com/claude-code)