### PR TITLE
fix(tests): docker phase tests must not clobber a live production fleet

### DIFF
--- a/src/agents/compose.ts
+++ b/src/agents/compose.ts
@@ -138,6 +138,33 @@ export interface ComposeGeneratorOptions {
    * mount (back-compat with pre-fix generated compose).
    */
   switchroomConfigPath?: string;
+  /**
+   * Prefix for `container_name:` values. Defaults to `"switchroom"` —
+   * production behavior is unchanged. Setting this to a unique
+   * per-test-run value (typical pattern: `phase1c-iso-${process.pid}`)
+   * lets phase tests bring up their own broker/kernel/agent fleet
+   * without colliding with the production singletons' fixed names on
+   * a shared host.
+   *
+   * Belt-and-braces with `productionFleetIsLive()` skipIf guards in
+   * `tests/docker/_prod-snapshot.ts`: even if a test forgets to skip
+   * on a host with a live fleet, the parametrized name means it
+   * creates `phase1c-iso-NNN-vault-broker` instead of clobbering
+   * `switchroom-vault-broker`. Closes the test/prod-clobber regression
+   * surfaced when PR #916 un-skipped the destructive docker phase
+   * tests.
+   *
+   * Affects three name slots:
+   *   `container_name: <prefix>-vault-broker`
+   *   `container_name: <prefix>-approval-kernel`
+   *   `container_name: <prefix>-<agent-name>` for each agent
+   *
+   * Does NOT affect compose project name (`name: switchroom` at file
+   * scope), service names (`vault-broker:`, `approval-kernel:`, the
+   * agent service keys), socket paths, or labels — those stay fixed
+   * because the runtime / operator UX depends on them.
+   */
+  containerNamePrefix?: string;
 }
 
 /** Resolve the image ref for one of the four service images. */
@@ -225,6 +252,12 @@ export function generateCompose(opts: ComposeGeneratorOptions): string {
   // preserves the older `${HOME}` shape for callers that haven't been
   // updated.
   const homePrefix = opts.homeDir ?? "${HOME}";
+  // Default container_name prefix matches the compose project name and
+  // every operator command in the docs (`docker exec -it switchroom-
+  // vault-broker ...`, `journalctl --user -u switchroom-vault-broker`).
+  // Tests override this so phase fleets get unique names that can't
+  // collide with a production install on the same host.
+  const containerNamePrefix = opts.containerNamePrefix ?? "switchroom";
   // For existsSync() decisions on optional bind-mount sources (#907):
   // emission uses `homePrefix` (which may be the literal "${HOME}" so
   // sudo-bake works), but the existsSync probe must use the real host
@@ -258,7 +291,7 @@ export function generateCompose(opts: ComposeGeneratorOptions): string {
   // ── vault-broker (singleton) ───────────────────────────────────────
   lines.push(`  vault-broker:`);
   emitImageOrBuild(lines, "broker", imageTag, buildMode, buildContext);
-  lines.push(`    container_name: switchroom-vault-broker`);
+  lines.push(`    container_name: ${containerNamePrefix}-vault-broker`);
   // Fleet labels for ad-hoc selection (e.g. `docker ps --filter label=switchroom.role=agent`).
   lines.push(`    labels:`);
   lines.push(`      switchroom.role: "broker"`);
@@ -359,7 +392,7 @@ export function generateCompose(opts: ComposeGeneratorOptions): string {
   // ── approval-kernel (singleton) ────────────────────────────────────
   lines.push(`  approval-kernel:`);
   emitImageOrBuild(lines, "kernel", imageTag, buildMode, buildContext);
-  lines.push(`    container_name: switchroom-approval-kernel`);
+  lines.push(`    container_name: ${containerNamePrefix}-approval-kernel`);
   lines.push(`    labels:`);
   lines.push(`      switchroom.role: "kernel"`);
   lines.push(`      switchroom.fleet: "switchroom"`);
@@ -421,7 +454,7 @@ export function generateCompose(opts: ComposeGeneratorOptions): string {
     if (a.strippedCaps.length > 0) {
       warn(`compose: stripping cap_add ${JSON.stringify(a.strippedCaps)} from agent "${a.name}" (Docker mode forbids capability extras; see RFC §security)`);
     }
-    emitAgentService(lines, a, imageTag, buildMode, buildContext, homePrefix, hostHomeForChecks, switchroomConfigPath);
+    emitAgentService(lines, a, imageTag, buildMode, buildContext, homePrefix, hostHomeForChecks, switchroomConfigPath, containerNamePrefix);
   }
 
   // ── volumes ────────────────────────────────────────────────────────
@@ -444,10 +477,11 @@ function emitAgentService(
   homePrefix: string,
   hostHomeForChecks: string,
   switchroomConfigPath: string | undefined,
+  containerNamePrefix: string,
 ): void {
   lines.push(`  agent-${a.name}:`);
   emitImageOrBuild(lines, "agent", imageTag, buildMode, buildContext);
-  lines.push(`    container_name: switchroom-${a.name}`);
+  lines.push(`    container_name: ${containerNamePrefix}-${a.name}`);
   lines.push(`    labels:`);
   lines.push(`      switchroom.role: "agent"`);
   lines.push(`      switchroom.fleet: "switchroom"`);

--- a/tests/docker/_prod-snapshot.ts
+++ b/tests/docker/_prod-snapshot.ts
@@ -96,3 +96,62 @@ function filterPhaseTestContainers(raw: string): string {
     .sort()
     .join("\n");
 }
+
+/**
+ * Probe whether a live switchroom production fleet is running on the
+ * host. The compose generator emits fixed `container_name:` values for
+ * the singletons (`switchroom-vault-broker`, `switchroom-approval-
+ * kernel`) — so a phase test that creates singletons under its own
+ * project name COLLIDES with those names and will either fail to start
+ * or, worse, clobber the production containers. PR #916 un-skipped
+ * `e2e.test.ts` + `per-agent-isolation.test.ts` + `broker-ipc-race.test
+ * .ts`; on 2026-05-10 that took the operator's klanker offline because
+ * those tests force-remove `switchroom-vault-broker` in their
+ * `beforeAll`.
+ *
+ * Detection is by the `switchroom.fleet=switchroom` label that the
+ * compose generator stamps on every production service
+ * (src/agents/compose.ts:264-265, 365-366, 459-460), NOT by container
+ * name — so a phase test running under a `switchroom-*` name is
+ * correctly NOT flagged. Returns true if at least one production
+ * singleton or agent is alive.
+ *
+ * Tests that destructively touch singleton names should
+ * `describe.skipIf(productionFleetIsLive())` at suite level, so a
+ * phase test never wrecks a live production fleet on a shared host.
+ * CI clean-room runs see no production fleet → tests proceed normally.
+ */
+export function productionFleetIsLive(): boolean {
+  try {
+    const out = execSync(
+      "docker ps --filter label=switchroom.fleet=switchroom --format '{{.Names}}'",
+      { stdio: ["ignore", "pipe", "pipe"] },
+    ).toString().trim();
+    return out.length > 0;
+  } catch {
+    // No docker, or sudo required and unavailable — fail closed:
+    // assume NO fleet so tests can still run on dev machines without
+    // docker access. The destructive operation will fail loudly later
+    // if docker is genuinely unreachable.
+    return false;
+  }
+}
+
+/**
+ * Hard guard for destructive phase-test setup. Throws when a live
+ * production fleet is detected. Belt to the
+ * `describe.skipIf(productionFleetIsLive())` braces — call from
+ * `beforeAll` so a future test that forgets the skipIf still bails out
+ * before the `docker rm -f switchroom-vault-broker` line.
+ */
+export function assertNoProductionFleet(): void {
+  if (productionFleetIsLive()) {
+    throw new Error(
+      "REFUSING TO RUN: a live switchroom production fleet was detected on this host " +
+      "(containers labeled switchroom.fleet=switchroom). This phase test would clobber " +
+      "the production singletons by name. Stop the production fleet with " +
+      "`docker compose -p switchroom down` before running this test, or run the suite " +
+      "on a host without a production switchroom install.",
+    );
+  }
+}

--- a/tests/docker/broker-ipc-race.test.ts
+++ b/tests/docker/broker-ipc-race.test.ts
@@ -59,8 +59,15 @@ import {
   safeLabelTeardown,
   mergeServiceEnv,
 } from "./_label-helpers.js";
+import { productionFleetIsLive, assertNoProductionFleet } from "./_prod-snapshot.js";
 
 const RUN_ID = newRunId();
+// See per-agent-isolation.test.ts:PROD_FLEET_LIVE — same prod-clobber
+// guard. This file ALSO reads `switchroom-vault-broker` /
+// `switchroom-approval-kernel` by their fixed names throughout the
+// test body, so running it on a host with a live production fleet
+// produces undefined cross-talk.
+const PROD_FLEET_LIVE = productionFleetIsLive();
 
 const TAG = "phase1b-test";
 // Phase 4 cron-fold-in cutover removed the singleton scheduler image.
@@ -130,7 +137,17 @@ function makeConfig(agents: string[]): SwitchroomConfig {
  *   - emit minimal switchroom.yaml inside a tmpfs the kernel/broker can read
  */
 function buildTestCompose(agents: string[], cfgPath: string): string {
-  let yml = generateCompose({ config: makeConfig(agents), imageTag: TAG });
+  // containerNamePrefix=PROJECT defends against the production-name
+  // collision regression (#916 un-skip → 2026-05-10 klanker incident).
+  // Emitted names become `phase1c-race-${pid}-vault-broker` etc., so
+  // even if a production fleet is up the test names cannot collide
+  // with `switchroom-vault-broker`. The describe.skipIf still gates
+  // the suite — this is the second layer.
+  let yml = generateCompose({
+    config: makeConfig(agents),
+    imageTag: TAG,
+    containerNamePrefix: PROJECT,
+  });
   // Rewrite registry refs to local tags. The compose generator points at
   // ghcr.io/switchroom/<image>:<tag>; for this test we want the locally
   // built switchroom/<image>:phase1b-test.
@@ -330,18 +347,25 @@ function releaseFleetLock(): void {
 
 beforeAll(() => {
   if (!imagesOk) return;
+  // Belt to the describe.skipIf(PROD_FLEET_LIVE) braces — refuse to
+  // run if a live production fleet is present (this test file ALSO
+  // reads/writes switchroom-vault-broker by fixed name).
+  assertNoProductionFleet();
   acquireFleetLock("/tmp/switchroom-docker-fleet.lock");
   composeDown(); // belt + braces
-  // Forcefully remove any leftover singletons from a sibling test file
-  // (per-agent-isolation) — they use fixed container_name: so projects
-  // collide. Scope: ONLY the singleton names this PR introduces.
+  // Force-remove any leftover *project-scoped* containers from a
+  // crashed prior run. ALL names here are prefixed with `${PROJECT}`,
+  // which is `phase1c-race-${process.pid}` — so this CANNOT touch
+  // `switchroom-vault-broker` or any other production container.
+  // Pre-fix this loop included production-named singletons and would
+  // clobber a live fleet (the 2026-05-10 klanker incident).
   for (const c of [
-    "switchroom-vault-broker",
-    "switchroom-approval-kernel",
-    "switchroom-alice",
-    "switchroom-bob",
-    "switchroom-carol",
-    "switchroom-newbie",
+    `${PROJECT}-vault-broker`,
+    `${PROJECT}-approval-kernel`,
+    `${PROJECT}-alice`,
+    `${PROJECT}-bob`,
+    `${PROJECT}-carol`,
+    `${PROJECT}-newbie`,
   ]) {
     try { execSync(`docker rm -f ${c}`, { stdio: "pipe" }); } catch { /* */ }
   }
@@ -399,7 +423,7 @@ afterAll(() => {
 // the container with the new volume) makes newbie's socket actually
 // bindable. The compose-fixture rot that previously masked this was
 // already addressed in PR-D3.
-describe.skipIf(!imagesOk)(
+describe.skipIf(!imagesOk || PROD_FLEET_LIVE)(
   "phase1c broker-IPC race — newbie agent online during sustained kernel IPC",
   () => {
     it(
@@ -413,7 +437,7 @@ describe.skipIf(!imagesOk)(
         const aliceSock = (() => {
           try {
             return execSync(
-              "docker exec switchroom-alice ls /run/switchroom/kernel/sock",
+              `docker exec ${PROJECT}-alice ls /run/switchroom/kernel/sock`,
             ).toString().trim();
           } catch (e) { return `MISSING (${(e as Error).message})`; }
         })();
@@ -421,16 +445,16 @@ describe.skipIf(!imagesOk)(
 
         // Snapshot RestartCount before any topology mutation.
         const startCounts = {
-          broker: getRestartCount("switchroom-vault-broker"),
-          kernel: getRestartCount("switchroom-approval-kernel"),
+          broker: getRestartCount(`${PROJECT}-vault-broker`),
+          kernel: getRestartCount(`${PROJECT}-approval-kernel`),
         };
         // Also capture the kernel container ID — the live-add procedure
         // recreates the kernel container (`docker compose up -d` picks
         // up the new kernel-newbie-sock volume mount), which resets
         // RestartCount to 0 on the new container. We assert recreation
         // by container-ID change instead of restart-count bump (#857).
-        const startKernelId = getContainerId("switchroom-approval-kernel");
-        const startBrokerId = getContainerId("switchroom-vault-broker");
+        const startKernelId = getContainerId(`${PROJECT}-approval-kernel`);
+        const startBrokerId = getContainerId(`${PROJECT}-vault-broker`);
 
         const results: Array<{ idx: number; ok: boolean; durationMs: number; err?: string }> = [];
         let newbieFirstReplyAt: number | null = null;
@@ -530,8 +554,8 @@ describe.skipIf(!imagesOk)(
         // disturbance (broker must still be untouched; the singleton
         // scheduler was retired in Phase 4 #893).
         const stabilityCounts = {
-          broker: getRestartCount("switchroom-vault-broker"),
-          kernel: getRestartCount("switchroom-approval-kernel"),
+          broker: getRestartCount(`${PROJECT}-vault-broker`),
+          kernel: getRestartCount(`${PROJECT}-approval-kernel`),
         };
 
         // Phase 3c F-#811 — split newbie-readiness from topology-stability.
@@ -577,13 +601,13 @@ describe.skipIf(!imagesOk)(
             while (Date.now() < deadline) {
               const probe = spawnSync(
                 "docker",
-                ["exec", "switchroom-newbie", "ls", "/run/switchroom/kernel/sock"],
+                ["exec", `${PROJECT}-newbie`, "ls", "/run/switchroom/kernel/sock"],
                 { encoding: "utf8", timeout: 4000 },
               );
               if (probe.status === 0 && probe.stdout.includes("/run/switchroom/kernel/sock")) {
                 // Socket bound — issue newbie's first real lookup against
                 // newbie's OWN kernel socket.
-                const r = kernelLookup("newbie", "switchroom-newbie");
+                const r = kernelLookup("newbie", `${PROJECT}-newbie`);
                 if (r.ok) {
                   newbieReadyAt = Date.now();
                   newbieReadyLatencyMs = newbieReadyAt - readinessStart;
@@ -598,8 +622,8 @@ describe.skipIf(!imagesOk)(
         }
 
         const endCounts = {
-          broker: getRestartCount("switchroom-vault-broker"),
-          kernel: getRestartCount("switchroom-approval-kernel"),
+          broker: getRestartCount(`${PROJECT}-vault-broker`),
+          kernel: getRestartCount(`${PROJECT}-approval-kernel`),
         };
 
         // Diagnostic line for vitest output
@@ -647,8 +671,8 @@ describe.skipIf(!imagesOk)(
         // Pre-#857 the test used `docker compose restart` and asserted
         // RestartCount+1; that didn't actually recreate the container,
         // so newbie's volume mount never appeared inside the kernel.
-        const endKernelId = getContainerId("switchroom-approval-kernel");
-        const endBrokerId = getContainerId("switchroom-vault-broker");
+        const endKernelId = getContainerId(`${PROJECT}-approval-kernel`);
+        const endBrokerId = getContainerId(`${PROJECT}-vault-broker`);
         expect(endBrokerId).toBe(startBrokerId);
         expect(endCounts.broker).toBe(startCounts.broker);
         expect(endKernelId).not.toBe(startKernelId);

--- a/tests/docker/compose-generator.test.ts
+++ b/tests/docker/compose-generator.test.ts
@@ -91,6 +91,36 @@ describe("generateCompose", () => {
     expect(out).toContain("container_name: switchroom-coach");
   });
 
+  it("defaults container_name prefix to 'switchroom' (production behavior)", () => {
+    const out = generateCompose({ config: makeConfig({ coach: {} }) });
+    expect(out).toContain("container_name: switchroom-vault-broker");
+    expect(out).toContain("container_name: switchroom-approval-kernel");
+    expect(out).toContain("container_name: switchroom-coach");
+  });
+
+  it("honors containerNamePrefix override (test prod-safety guard)", () => {
+    // Phase tests pass their own per-pid project name to keep singleton
+    // names from colliding with a live production fleet on a shared
+    // host. See tests/docker/_prod-snapshot.ts:productionFleetIsLive
+    // for the broader story.
+    const out = generateCompose({
+      config: makeConfig({ alice: {}, bob: {} }),
+      containerNamePrefix: "phase1c-iso-12345",
+    });
+    expect(out).toContain("container_name: phase1c-iso-12345-vault-broker");
+    expect(out).toContain("container_name: phase1c-iso-12345-approval-kernel");
+    expect(out).toContain("container_name: phase1c-iso-12345-alice");
+    expect(out).toContain("container_name: phase1c-iso-12345-bob");
+    // Prefix MUST NOT leak into compose project name, service keys,
+    // socket paths, or labels — those stay fixed on the production
+    // shape so operator tooling and runtime contracts don't drift.
+    expect(out).toContain("name: switchroom\n");
+    expect(out).toContain("  vault-broker:");
+    expect(out).toContain("  approval-kernel:");
+    expect(out).toContain("/run/switchroom/broker/alice/sock");
+    expect(out).toContain('switchroom.fleet: "switchroom"');
+  });
+
   it("emits agents in sorted order", () => {
     const out = generateCompose({ config: makeConfig({ zebra: {}, alpha: {}, mango: {} }) });
     const a = out.indexOf("agent-alpha:");

--- a/tests/docker/per-agent-isolation.test.ts
+++ b/tests/docker/per-agent-isolation.test.ts
@@ -51,8 +51,16 @@ import {
   safeLabelTeardown,
   mergeServiceEnv,
 } from "./_label-helpers.js";
+import { productionFleetIsLive, assertNoProductionFleet } from "./_prod-snapshot.js";
 
 const RUN_ID = newRunId();
+// Hard guard against the 2026-05-10 production-clobber incident: this
+// test's setup force-removes `switchroom-vault-broker` and
+// `switchroom-approval-kernel` by name (lines below), which collides
+// with a live production fleet on a shared host. Skip the suite
+// entirely when production singletons are detected. CI clean-room
+// runs see no fleet → tests proceed normally.
+const PROD_FLEET_LIVE = productionFleetIsLive();
 
 const TAG = "phase1b-test";
 // Phase 4 (#893) retired the singleton scheduler image. Listing it
@@ -144,7 +152,18 @@ function makeConfig(agents: string[]): SwitchroomConfig {
 /** Same compose-rewrite shape as the race test. Agents stay alive on
  *  a sleep loop so we can `docker exec` into them. */
 function buildTestCompose(agents: string[], cfgPath: string): string {
-  let yml = generateCompose({ config: makeConfig(agents), imageTag: TAG });
+  // containerNamePrefix=PROJECT defends against the production-name
+  // collision regression (PR #916 un-skipped this test on a host with
+  // a live production fleet → singletons clobbered). With the prefix,
+  // emitted names are `phase1c-iso-${pid}-vault-broker` etc., which
+  // can't collide with `switchroom-vault-broker` even if a production
+  // fleet is up. The describe.skipIf still gates the suite — this
+  // parametrization is the second layer.
+  let yml = generateCompose({
+    config: makeConfig(agents),
+    imageTag: TAG,
+    containerNamePrefix: PROJECT,
+  });
   // Generator emits ghcr.io/switchroom/switchroom-<name>:<tag>; locally
   // built test images are tagged switchroom/<name>:phase1b-test.
   yml = yml.replace(/ghcr\.io\/switchroom\/switchroom-/g, "switchroom/");
@@ -239,28 +258,34 @@ let ctx: FleetCtx | null = null;
 
 beforeAll(() => {
   if (!imagesOk) return;
+  // Belt to the describe.skipIf(PROD_FLEET_LIVE) braces below — if a
+  // future test forgets the skipIf, the throw here stops the
+  // destructive setup before the `docker rm -f switchroom-vault-broker`
+  // line wrecks production.
+  assertNoProductionFleet();
   // Belt-and-braces project-scoped down (does NOT touch other containers).
   try { execSync(`docker compose -p ${PROJECT} down -v --remove-orphans`, { stdio: "pipe" }); } catch { /* */ }
-  // Forcefully remove any leftover singletons from a sibling test file
-  // (race test) — they use fixed container_name: so projects collide.
-  // Scope: ONLY the switchroom singleton names this PR introduces.
-  // We do NOT touch unrelated containers on the host.
-  // Acquire a cross-fork lock — vitest runs test files in parallel
-  // forks, and both this file + broker-ipc-race.test.ts use the same
-  // `container_name:` from the shared compose generator. The lock is
-  // an atomic mkdir on a fixed path under /tmp; whichever fork claims
-  // it first gets to run; the other waits.
+  // Cross-fork lock — vitest runs test files in parallel forks, and
+  // both this file + broker-ipc-race.test.ts touch the same singleton
+  // container_name slots (under different prefixes since the prod-
+  // safety fix, but still benefit from serialised fleet bring-up).
   const LOCK_DIR = "/tmp/switchroom-docker-fleet.lock";
   acquireFleetLock(LOCK_DIR);
-  // Belt-and-braces: forcefully remove any leftover singletons.
+  // Force-remove any leftover *project-scoped* containers from a
+  // crashed prior run. ALL names here are prefixed with `${PROJECT}`,
+  // which is `phase1c-iso-${process.pid}` — so this CANNOT touch
+  // `switchroom-vault-broker` or any other production container.
+  // Pre-fix, this loop included the production-named singletons
+  // (`switchroom-vault-broker`, `switchroom-approval-kernel`) and
+  // would clobber a live production fleet on a shared host
+  // (the 2026-05-10 klanker incident).
   for (const c of [
-    "switchroom-vault-broker",
-    "switchroom-approval-kernel",
-    "switchroom-cron",
-    "switchroom-alice",
-    "switchroom-bob",
-    "switchroom-carol",
-    "switchroom-newbie",
+    `${PROJECT}-vault-broker`,
+    `${PROJECT}-approval-kernel`,
+    `${PROJECT}-alice`,
+    `${PROJECT}-bob`,
+    `${PROJECT}-carol`,
+    `${PROJECT}-newbie`,
   ]) {
     try { execSync(`docker rm -f ${c}`, { stdio: "pipe" }); } catch { /* */ }
   }
@@ -327,14 +352,14 @@ function dockerExec(c: string, cmd: string): { code: number; out: string } {
   return { code: r.status ?? -1, out: (r.stdout ?? "") + (r.stderr ?? "") };
 }
 
-describe.skipIf(!imagesOk)(
+describe.skipIf(!imagesOk || PROD_FLEET_LIVE)(
   "phase1c per-agent isolation — production-equivalent adversarial matrix",
   () => {
     it("agent-A cannot see agent-B's broker socket dir (compose discipline boundary)", () => {
       // From alice's container, /run/switchroom/broker/bob/sock should
       // not exist — the bob volume is NOT mounted into alice.
       const r = dockerExec(
-        "switchroom-alice",
+        `${PROJECT}-alice`,
         "ls /run/switchroom/broker/bob/sock 2>&1",
       );
       expect(r.code).not.toBe(0);
@@ -343,7 +368,7 @@ describe.skipIf(!imagesOk)(
 
     it("agent-A cannot see agent-B's kernel socket dir (compose discipline boundary)", () => {
       const r = dockerExec(
-        "switchroom-alice",
+        `${PROJECT}-alice`,
         "ls /run/switchroom/kernel/bob/sock 2>&1",
       );
       expect(r.code).not.toBe(0);

--- a/tests/docker/prod-snapshot.test.ts
+++ b/tests/docker/prod-snapshot.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Unit tests for the production-fleet detection helpers.
+ *
+ * These guard the destructive docker phase tests from clobbering a live
+ * production fleet on a shared host (the 2026-05-10 klanker incident).
+ * The helpers themselves are simple `docker ps --filter` wrappers, so
+ * the tests pin two things:
+ *
+ *   1. Detection is by `switchroom.fleet=switchroom` label, NOT by
+ *      container name. Tests that create containers under
+ *      `${PROJECT}-vault-broker` shapes don't false-positive.
+ *   2. `assertNoProductionFleet` throws (not returns) so a forgotten
+ *      `describe.skipIf` still bails out before destructive setup.
+ *
+ * No actual docker is invoked — `execSync` is shadowed via a local
+ * mock seam so the tests run in CI clean-rooms without a daemon.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// Module spy on node:child_process so we can drive execSync's response
+// without touching the real docker daemon. The helpers under test
+// `import { execSync } from "node:child_process"` so the mock applies
+// transparently.
+vi.mock("node:child_process", async () => {
+  const actual = await vi.importActual<typeof import("node:child_process")>(
+    "node:child_process",
+  );
+  return { ...actual, execSync: vi.fn() };
+});
+
+import { execSync } from "node:child_process";
+import {
+  productionFleetIsLive,
+  assertNoProductionFleet,
+} from "./_prod-snapshot.js";
+
+const mockExec = vi.mocked(execSync);
+
+beforeEach(() => {
+  mockExec.mockReset();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("productionFleetIsLive", () => {
+  it("returns true when docker ps reports at least one switchroom-fleet=switchroom container", () => {
+    mockExec.mockReturnValueOnce(
+      Buffer.from("switchroom-vault-broker\nswitchroom-klanker\n"),
+    );
+    expect(productionFleetIsLive()).toBe(true);
+    // Verify the filter is by LABEL, not by name pattern.
+    const cmd = String(mockExec.mock.calls[0][0]);
+    expect(cmd).toContain("--filter label=switchroom.fleet=switchroom");
+    expect(cmd).not.toContain("--filter name=");
+  });
+
+  it("returns false when docker ps returns empty", () => {
+    mockExec.mockReturnValueOnce(Buffer.from(""));
+    expect(productionFleetIsLive()).toBe(false);
+  });
+
+  it("returns false when docker ps returns whitespace-only", () => {
+    mockExec.mockReturnValueOnce(Buffer.from("\n  \n\t\n"));
+    expect(productionFleetIsLive()).toBe(false);
+  });
+
+  it("returns false when docker is unreachable (fail-closed)", () => {
+    mockExec.mockImplementationOnce(() => {
+      throw new Error("docker daemon not running");
+    });
+    // Fail-closed = assume NO fleet so dev machines without docker can
+    // still run the suite. The destructive op will fail loudly later
+    // if docker is genuinely needed.
+    expect(productionFleetIsLive()).toBe(false);
+  });
+});
+
+describe("assertNoProductionFleet", () => {
+  it("does NOT throw when no fleet is detected", () => {
+    mockExec.mockReturnValueOnce(Buffer.from(""));
+    expect(() => assertNoProductionFleet()).not.toThrow();
+  });
+
+  it("throws a clear error when production fleet is live", () => {
+    mockExec.mockReturnValueOnce(
+      Buffer.from("switchroom-vault-broker\nswitchroom-finn\n"),
+    );
+    expect(() => assertNoProductionFleet()).toThrow(/REFUSING TO RUN/);
+  });
+
+  it("error mentions the recovery command", () => {
+    mockExec.mockReturnValueOnce(Buffer.from("switchroom-vault-broker\n"));
+    expect(() => assertNoProductionFleet()).toThrow(
+      /docker compose -p switchroom down/,
+    );
+  });
+});

--- a/tests/docker/v0.7-install-e2e.test.ts
+++ b/tests/docker/v0.7-install-e2e.test.ts
@@ -64,6 +64,8 @@ import { newRunId, safeLabelTeardown } from "./_label-helpers.js";
 import {
   captureProdSnapshot,
   expectNoProdDrift,
+  productionFleetIsLive,
+  assertNoProductionFleet,
   type ProdSnapshot,
 } from "./_prod-snapshot.js";
 
@@ -164,6 +166,12 @@ function fixtureYaml(switchroomHome: string): string {
 
 beforeAll(() => {
   if (!enabled || !imagesOk) return;
+  // Belt to the SKIP_REASON braces — even if a future refactor drops
+  // the productionFleetIsLive() check from the skip computation, this
+  // throw stops the destructive setup before the apply+up step
+  // collides with `switchroom-vault-broker` / `switchroom-approval-
+  // kernel` singleton names from the production compose generator.
+  assertNoProductionFleet();
 
   const prodSnapshot = captureProdSnapshot();
 
@@ -249,7 +257,9 @@ const SKIP_REASON = !enabled
     ? "docker daemon unreachable"
     : !imagesOk
       ? "phase1b-test images not built — run `bash tests/docker/build-images.sh`"
-      : "";
+      : productionFleetIsLive()
+        ? "live switchroom production fleet detected on host — refusing to clobber singletons (run `docker compose -p switchroom down` first)"
+        : "";
 
 describe.skipIf(SKIP_REASON !== "")(
   "v0.7 install path — apply → compose up → assert healthy",


### PR DESCRIPTION
## The bug

On 2026-05-10 the operator's `klanker` agent reported \`VAULT-BROKER-DENIED: broker not running\`. \`docker ps --filter name=switchroom\` showed all 8 agents running but **no `switchroom-vault-broker` and no `switchroom-approval-kernel`** in the production compose project. \`dockerd\` event log told the story:

```
ep=switchroom-vault-broker net=phase1c-iso-3067927_default
ep=switchroom-vault-broker net=phase1c-race-3552415_default
ep=switchroom-approval-kernel net=phase1c-iso-3557045_default
...
```

— the **production** singletons being attached to **test** networks across the afternoon, then disappearing. The destructive phase tests un-skipped in PR #916 had been clobbering the production fleet on the operator's shared host.

Two architectural bugs combined:

1. `tests/docker/per-agent-isolation.test.ts:280-289` and `broker-ipc-race.test.ts:359-365` ran `docker rm -f switchroom-vault-broker` / `switchroom-approval-kernel` in their `beforeAll`. The comment said "we do not touch unrelated containers"; the names ARE the production singletons.
2. `src/agents/compose.ts:261,362` hardcoded `container_name: switchroom-vault-broker`. When tests brought up their own fleet under `project=phase1c-iso-${pid}`, the FIXED name collided with the live production container — the test's compose-down then took the singleton with it.

## Fix — two layers

### Layer 1: skipIf production-fleet detection

New helpers in `tests/docker/_prod-snapshot.ts`:

- `productionFleetIsLive()` — \`docker ps --filter label=switchroom.fleet=switchroom\`. **By LABEL, not by name** — so test containers under `${PROJECT}-vault-broker` shapes don't false-positive.
- `assertNoProductionFleet()` — throws with a clear "REFUSING TO RUN" message naming the recovery command (`docker compose -p switchroom down`).

Wired into the three destructive phase tests (`per-agent-isolation`, `broker-ipc-race`, `v0.7-install-e2e`) via `describe.skipIf(... || PROD_FLEET_LIVE)` AT SUITE LEVEL, plus an `assertNoProductionFleet()` belt in `beforeAll` so a future test that forgets the skipIf still bails before the destructive step.

### Layer 2: parametrize container_name in the compose generator

New `containerNamePrefix?: string` option on `ComposeGeneratorOptions`, defaults to `"switchroom"` — production callers (CLI \`apply\`, \`update\`, \`doctor\`) get the historical value with no change. Tests pass `containerNamePrefix: PROJECT` so emitted names become `phase1c-iso-NNN-vault-broker`, which **cannot collide** with `switchroom-vault-broker` even if a production fleet is up.

Compose project name (`name: switchroom`), service keys (`vault-broker:`, `approval-kernel:`, `agent-<name>:`), socket paths (`/run/switchroom/broker/<agent>/sock`), and labels are unchanged — those are runtime/operator-UX contracts.

`per-agent-isolation.test.ts` and `broker-ipc-race.test.ts` updated to:
- Pass `containerNamePrefix: PROJECT` to `generateCompose`
- Prefix every "force-remove leftover singleton" name with `${PROJECT}` so cleanup CANNOT touch production
- Prefix every fixed-name `docker exec` lookup with `${PROJECT}`

## Test plan

- [x] `npm run lint` clean
- [x] 9 new unit tests:
  - 7 in `tests/docker/prod-snapshot.test.ts` (label-not-name filter, empty/whitespace results, fail-closed on docker-down, throws on live fleet, error references recovery command)
  - 2 in `tests/docker/compose-generator.test.ts` (default prefix preserved; override changes ONLY container_name, not project/services/sockets/labels)
- [x] `npm test` — vitest 5204 pass, bun targeted suites green. The 2 pre-existing `src/cli/deprecated.test.ts` failures are unrelated (fail identically on upstream/main).
- [x] Manual confirm post-incident: brought broker + kernel back up via `docker compose -p switchroom up -d vault-broker approval-kernel`; both healthy; klanker `/vault` works again.

## Why two layers (belt + braces)

Either alone fixes the immediate bug:
- Layer 1 alone: tests skip on production hosts; CI clean-rooms still run them.
- Layer 2 alone: tests on production hosts run side-by-side without name collision.

But layer 2's reach into production code (compose generator) is bigger blast radius if it has a bug, while layer 1's `docker ps --filter` is locally testable. Together: layer 1 makes the regression impossible by skipping; layer 2 makes the architectural cause impossible by removing the name-collision. The operator asked for "super stable" — both layers ship together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)