### PR TITLE
fix(compose): parametrize switchroom.fleet label so phase tests don't false-positive each other

### DIFF
--- a/src/agents/compose.ts
+++ b/src/agents/compose.ts
@@ -154,15 +154,24 @@ export interface ComposeGeneratorOptions {
    * surfaced when PR #916 un-skipped the destructive docker phase
    * tests.
    *
-   * Affects three name slots:
+   * Affects four slots:
    *   `container_name: <prefix>-vault-broker`
    *   `container_name: <prefix>-approval-kernel`
    *   `container_name: <prefix>-<agent-name>` for each agent
+   *   `switchroom.fleet: "<prefix>"` label on every service
+   *
+   * The fleet label parametrization (added 2026-05-10 follow-up to PR
+   * #939) lets `productionFleetIsLive()` distinguish a live production
+   * fleet from a sibling phase test's fleet running in a parallel
+   * vitest fork — the detection filter is `label=switchroom.fleet=
+   * switchroom`, which now matches ONLY production. Without this, a
+   * phase fleet from one fork looked like production to another fork
+   * and produced spurious skip-with-"production-detected" reasons.
    *
    * Does NOT affect compose project name (`name: switchroom` at file
    * scope), service names (`vault-broker:`, `approval-kernel:`, the
-   * agent service keys), socket paths, or labels — those stay fixed
-   * because the runtime / operator UX depends on them.
+   * agent service keys), or socket paths — those stay fixed because
+   * the runtime / operator UX depends on them.
    */
   containerNamePrefix?: string;
 }
@@ -295,7 +304,7 @@ export function generateCompose(opts: ComposeGeneratorOptions): string {
   // Fleet labels for ad-hoc selection (e.g. `docker ps --filter label=switchroom.role=agent`).
   lines.push(`    labels:`);
   lines.push(`      switchroom.role: "broker"`);
-  lines.push(`      switchroom.fleet: "switchroom"`);
+  lines.push(`      switchroom.fleet: "${containerNamePrefix}"`);
   lines.push(`    restart: unless-stopped`);
   // Liveness probe — bind-presence. The broker creates per-agent
   // socket directories at startup and binds `<dir>/sock` for each
@@ -395,7 +404,7 @@ export function generateCompose(opts: ComposeGeneratorOptions): string {
   lines.push(`    container_name: ${containerNamePrefix}-approval-kernel`);
   lines.push(`    labels:`);
   lines.push(`      switchroom.role: "kernel"`);
-  lines.push(`      switchroom.fleet: "switchroom"`);
+  lines.push(`      switchroom.fleet: "${containerNamePrefix}"`);
   lines.push(`    restart: unless-stopped`);
   // Mirror the broker's bind-presence healthcheck — same failure-mode
   // surface (kernel binds per-agent sockets at
@@ -484,7 +493,7 @@ function emitAgentService(
   lines.push(`    container_name: ${containerNamePrefix}-${a.name}`);
   lines.push(`    labels:`);
   lines.push(`      switchroom.role: "agent"`);
-  lines.push(`      switchroom.fleet: "switchroom"`);
+  lines.push(`      switchroom.fleet: "${containerNamePrefix}"`);
   lines.push(`      switchroom.agent: "${a.name}"`);
   // Share the host's network namespace.
   //

--- a/tests/docker/_prod-snapshot.ts
+++ b/tests/docker/_prod-snapshot.ts
@@ -109,12 +109,18 @@ function filterPhaseTestContainers(raw: string): string {
  * those tests force-remove `switchroom-vault-broker` in their
  * `beforeAll`.
  *
- * Detection is by the `switchroom.fleet=switchroom` label that the
- * compose generator stamps on every production service
- * (src/agents/compose.ts:264-265, 365-366, 459-460), NOT by container
- * name — so a phase test running under a `switchroom-*` name is
- * correctly NOT flagged. Returns true if at least one production
- * singleton or agent is alive.
+ * Detection is by the `switchroom.fleet=switchroom` label, NOT by
+ * container name. The compose generator stamps the fleet label with
+ * the value of `containerNamePrefix` (defaults `"switchroom"` for
+ * production, parametrized to the test PROJECT name for phase tests
+ * — see `src/agents/compose.ts:ComposeGeneratorOptions
+ * .containerNamePrefix`). So a phase test running in one vitest fork
+ * carries `switchroom.fleet=phase1c-iso-NNN` and is NOT flagged by
+ * another fork's `productionFleetIsLive()` — closing the parallel-
+ * fork false-positive PR #939's reviewer flagged.
+ *
+ * Returns true if at least one container with `switchroom.fleet=
+ * switchroom` is alive.
  *
  * Tests that destructively touch singleton names should
  * `describe.skipIf(productionFleetIsLive())` at suite level, so a

--- a/tests/docker/compose-generator.test.ts
+++ b/tests/docker/compose-generator.test.ts
@@ -112,13 +112,29 @@ describe("generateCompose", () => {
     expect(out).toContain("container_name: phase1c-iso-12345-alice");
     expect(out).toContain("container_name: phase1c-iso-12345-bob");
     // Prefix MUST NOT leak into compose project name, service keys,
-    // socket paths, or labels — those stay fixed on the production
-    // shape so operator tooling and runtime contracts don't drift.
+    // or socket paths — those stay fixed on the production shape so
+    // operator tooling and runtime contracts don't drift.
     expect(out).toContain("name: switchroom\n");
     expect(out).toContain("  vault-broker:");
     expect(out).toContain("  approval-kernel:");
     expect(out).toContain("/run/switchroom/broker/alice/sock");
-    expect(out).toContain('switchroom.fleet: "switchroom"');
+    // The fleet label IS parametrized (PR #939 follow-up): test
+    // fleets carry switchroom.fleet=<prefix>, so a parallel vitest
+    // fork's productionFleetIsLive() filter on switchroom.fleet=
+    // switchroom doesn't false-positive on a sibling test fleet.
+    expect(out).toContain('switchroom.fleet: "phase1c-iso-12345"');
+    expect(out).not.toContain('switchroom.fleet: "switchroom"');
+  });
+
+  it("default containerNamePrefix preserves the production fleet label", () => {
+    // Critical for productionFleetIsLive() to keep working: the
+    // default-emit path MUST still stamp `switchroom.fleet=switchroom`
+    // on every service so `docker ps --filter
+    // label=switchroom.fleet=switchroom` finds them.
+    const out = generateCompose({ config: makeConfig({ coach: {} }) });
+    // One label line per service: broker + kernel + 1 agent = 3.
+    const matches = out.match(/switchroom\.fleet: "switchroom"/g) ?? [];
+    expect(matches.length).toBe(3);
   });
 
   it("emits agents in sorted order", () => {

--- a/tests/docker/prod-snapshot.test.ts
+++ b/tests/docker/prod-snapshot.test.ts
@@ -67,6 +67,23 @@ describe("productionFleetIsLive", () => {
     expect(productionFleetIsLive()).toBe(false);
   });
 
+  it("filter value is exactly 'switchroom' — does not match parametrized test fleets", () => {
+    // Regression test for PR #939's reviewer note: phase tests in
+    // parallel vitest forks emit containers labeled
+    // switchroom.fleet=<PROJECT> (e.g. phase1c-iso-12345). The
+    // production filter must be the LITERAL string 'switchroom' so it
+    // matches ONLY production containers, not sibling-fork test
+    // fleets. Docker label filters are equality, not prefix — so as
+    // long as we filter on exactly 'switchroom', a label of
+    // 'phase1c-iso-12345' is correctly excluded by the daemon.
+    mockExec.mockReturnValueOnce(Buffer.from(""));
+    productionFleetIsLive();
+    const cmd = String(mockExec.mock.calls[0][0]);
+    // Anchor the filter value on both sides to catch any future
+    // refactor that adds a wildcard or prefix-match shape.
+    expect(cmd).toMatch(/--filter label=switchroom\.fleet=switchroom(?=\s|$|'|")/);
+  });
+
   it("returns false when docker is unreachable (fail-closed)", () => {
     mockExec.mockImplementationOnce(() => {
       throw new Error("docker daemon not running");


### PR DESCRIPTION
## Follow-up to PR #939

The reviewer on #939 flagged a latent flake: the `switchroom.fleet: \"switchroom\"` label was hardcoded across all three service emissions in `src/agents/compose.ts`. Phase tests in parallel vitest forks brought up their own fleets carrying the SAME label as production. Combined with module-load-time `productionFleetIsLive()` evaluation, this enabled a race:

1. Fork A's `beforeAll` brings up its test fleet (label=switchroom)
2. Fork B's test module loads → `const PROD_FLEET_LIVE = productionFleetIsLive()` → sees A's fleet → returns true
3. Fork B's suite skips with reason \"live switchroom production fleet detected on host\"

**Not a prod-safety hole** — fail mode is \"skip too eagerly,\" never \"clobber production.\" But left unaddressed, CI would intermittently skip whichever phase test happened to load second.

## Fix

Thread `containerNamePrefix` into all three `switchroom.fleet` label emissions in `src/agents/compose.ts` (broker:298, kernel:398, agent:487 — all now `switchroom.fleet: \"\${containerNamePrefix}\"`). Production callers default to `\"switchroom\"` → no behavior change. Phase tests pass `containerNamePrefix: PROJECT` (already wired in PR #939) and now emit `switchroom.fleet: \"phase1c-iso-NNN\"` etc., so a parallel fork's `--filter label=switchroom.fleet=switchroom` matches **only** production.

Docker label filters are equality, not pattern — so `--filter label=switchroom.fleet=switchroom` cannot accidentally match `switchroom.fleet=phase1c-iso-NNN`. The fix is correct by daemon semantics; the regression test pins it.

## Test plan

- [x] `npm run lint` clean
- [x] `npm test` (vitest 5213/5213 pass — even the pre-existing `src/cli/deprecated.test.ts` failures cleared on this fresh build)
- [x] New regression test in `prod-snapshot.test.ts` — pins that the filter value is the literal string `\"switchroom\"` with anchored boundaries on both sides. Catches any future refactor that adds a prefix-match or wildcard shape.
- [x] New pin in `compose-generator.test.ts` — under override, label becomes `switchroom.fleet: \"phase1c-iso-12345\"` AND the production label is GONE.
- [x] New pin in `compose-generator.test.ts` — under default (no override), 3 services × 1 `switchroom.fleet: \"switchroom\"` line each (count = 3).
- [x] Updated existing override test no longer asserts the production label leaks into the override path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)