### PR TITLE
feat(agent-list): scheduler-state column distinguishes active/idle/wedged (#931)

### DIFF
--- a/src/agents/scheduler-state.test.ts
+++ b/src/agents/scheduler-state.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Unit tests for getSchedulerState (#931).
+ */
+
+import { describe, it, expect } from "vitest";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { getSchedulerState, formatSchedulerState } from "./scheduler-state.js";
+
+function withTempLogs(
+  agent: string,
+  log: string,
+  fn: (logsDir: string) => void,
+): void {
+  const dir = mkdtempSync(join(tmpdir(), "sched-state-"));
+  try {
+    mkdirSync(join(dir, agent), { recursive: true });
+    writeFileSync(join(dir, agent, "agent-scheduler.log"), log);
+    fn(dir);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+describe("getSchedulerState", () => {
+  it("returns active with task count when log shows registered N task(s)", () => {
+    withTempLogs(
+      "clerk",
+      "agent-scheduler: clerk registered 5 task(s); chat=-1003 ...\n",
+      (dir) => {
+        expect(getSchedulerState("clerk", dir)).toEqual({
+          kind: "active",
+          tasks: 5,
+        });
+      },
+    );
+  });
+
+  it("returns idle when log shows no schedule entries — idling", () => {
+    withTempLogs(
+      "finn",
+      "agent-scheduler: finn has no schedule entries — idling (re-checks on container restart)\n",
+      (dir) => {
+        expect(getSchedulerState("finn", dir)).toEqual({ kind: "idle" });
+      },
+    );
+  });
+
+  it("returns wedged when log shows the supervisor restart-cap (legacy)", () => {
+    withTempLogs(
+      "old",
+      "[supervise] agent-scheduler hit 10 restarts in <60s — giving up\n",
+      (dir) => {
+        expect(getSchedulerState("old", dir)).toEqual({ kind: "wedged" });
+      },
+    );
+  });
+
+  it("returns the most recent state line when log has historical noise above it", () => {
+    // Realistic: the log accumulates restart cycles + scheduler ipc
+    // reconnects; the bottom-up scan must pick the most recent
+    // state, not the first one we see.
+    const log = [
+      "agent-scheduler: clerk has no schedule entries — idling (re-checks on container restart)",
+      "[supervise] agent-scheduler exited (status=0, restart=10 in 12s window)",
+      "[supervise] agent-scheduler hit 10 restarts in <60s — giving up",
+      "agent-scheduler: clerk registered 5 task(s); chat=-1003 ...",
+      "agent-scheduler: scheduler ipc: connected to ...",
+      "",
+    ].join("\n");
+    withTempLogs("clerk", log, (dir) => {
+      expect(getSchedulerState("clerk", dir)).toEqual({
+        kind: "active",
+        tasks: 5,
+      });
+    });
+  });
+
+  it("returns unknown when the log file doesn't exist", () => {
+    const dir = mkdtempSync(join(tmpdir(), "sched-state-missing-"));
+    try {
+      const r = getSchedulerState("ghost", dir);
+      expect(r.kind).toBe("unknown");
+      if (r.kind === "unknown") expect(r.reason).toMatch(/not readable/);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("returns unknown when log exists but has no state line", () => {
+    withTempLogs(
+      "x",
+      "agent-scheduler: scheduler ipc: reconnecting in 1000ms\n",
+      (dir) => {
+        const r = getSchedulerState("x", dir);
+        expect(r.kind).toBe("unknown");
+        if (r.kind === "unknown") expect(r.reason).toMatch(/no state line/);
+      },
+    );
+  });
+});
+
+describe("formatSchedulerState", () => {
+  it("singular vs plural task count", () => {
+    expect(formatSchedulerState({ kind: "active", tasks: 1 })).toBe("1 task");
+    expect(formatSchedulerState({ kind: "active", tasks: 5 })).toBe("5 tasks");
+  });
+
+  it("idle / wedged / unknown", () => {
+    expect(formatSchedulerState({ kind: "idle" })).toBe("idle");
+    expect(formatSchedulerState({ kind: "wedged" })).toBe("wedged");
+    expect(formatSchedulerState({ kind: "unknown", reason: "x" })).toBe("?");
+  });
+});

--- a/src/agents/scheduler-state.ts
+++ b/src/agents/scheduler-state.ts
@@ -1,0 +1,95 @@
+/**
+ * Scheduler-state probe (#931) — distinguishes scheduler-active
+ * (registered N tasks) from scheduler-idle (no schedule entries) by
+ * tail-reading agent-scheduler.log.
+ *
+ * Pre-#931, `switchroom agent status` and `switchroom agent list`
+ * reported the same string for both states, so the operator had to
+ * `docker logs <agent>` and grep to confirm scheduler health on a
+ * fleet of N agents — friction that grows linearly with fleet size.
+ *
+ * Cheap log-tail-parse implementation (per the issue's "cheap version
+ * vs JSON state file" choice). The log lines are stable since #921 /
+ * #917 / #911:
+ *   - active:  "agent-scheduler: <name> registered N task(s); ..."
+ *   - idle:    "agent-scheduler: <name> has no schedule entries — idling ..."
+ *   - wedged:  "[supervise] agent-scheduler hit 10 restarts in <60s — giving up"
+ *               (legacy, pre-#921; surfaced for diagnosis on stale fleets)
+ */
+
+import { closeSync, openSync, readSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+export type SchedulerState =
+  | { kind: "active"; tasks: number }
+  | { kind: "idle" }
+  | { kind: "wedged" }
+  | { kind: "unknown"; reason: string };
+
+/**
+ * Returns the most-recent scheduler-state line for the named agent.
+ * Tail-reads up to the last 64KB of the log to keep the cost bounded
+ * for long-running fleets — state lines fire on every container
+ * restart so the most recent is always near the end.
+ */
+export function getSchedulerState(
+  agentName: string,
+  logsDir: string,
+): SchedulerState {
+  const path = join(logsDir, agentName, "agent-scheduler.log");
+  let buf: string;
+  try {
+    const stat = statSync(path);
+    if (stat.size === 0) return { kind: "unknown", reason: "log empty" };
+    // Read up to the last 64KB. State lines are <300 bytes each and
+    // fire ≤1× per container restart so this is plenty of slack.
+    // ESM-safe: top-of-file imports, not require() — see #938 reviewer.
+    const fd = openSync(path, "r");
+    try {
+      const chunkSize = Math.min(65536, stat.size);
+      const chunk = Buffer.alloc(chunkSize);
+      readSync(fd, chunk, 0, chunkSize, stat.size - chunkSize);
+      buf = chunk.toString("utf-8");
+    } finally {
+      closeSync(fd);
+    }
+  } catch (err) {
+    return {
+      kind: "unknown",
+      reason: `log not readable: ${(err as Error).message}`,
+    };
+  }
+
+  // Scan lines bottom-up; first state-line wins.
+  const lines = buf.split("\n");
+  for (let i = lines.length - 1; i >= 0; i--) {
+    const line = lines[i] ?? "";
+    if (!line) continue;
+
+    if (line.includes("hit 10 restarts in <60s")) {
+      return { kind: "wedged" };
+    }
+    if (line.includes("has no schedule entries — idling")) {
+      return { kind: "idle" };
+    }
+    const m = line.match(/registered (\d+) task\(s\)/);
+    if (m) {
+      const n = Number(m[1]);
+      if (Number.isFinite(n)) return { kind: "active", tasks: n };
+    }
+  }
+  return { kind: "unknown", reason: "no state line in log tail" };
+}
+
+/**
+ * Pretty-print a SchedulerState for the `agent list` table column
+ * and `agent status` line. Kept short so it fits in narrow terminals.
+ */
+export function formatSchedulerState(state: SchedulerState): string {
+  switch (state.kind) {
+    case "active": return `${state.tasks} task${state.tasks === 1 ? "" : "s"}`;
+    case "idle":   return "idle";
+    case "wedged": return "wedged";
+    case "unknown": return `?`;
+  }
+}

--- a/src/agents/scheduler-state.ts
+++ b/src/agents/scheduler-state.ts
@@ -20,6 +20,11 @@
 import { closeSync, openSync, readSync, statSync } from "node:fs";
 import { join } from "node:path";
 
+/**
+ * Stable contract: branch on `kind` only — `reason` is diagnostic-
+ * only free-form text intended for operator debugging, NOT for
+ * downstream consumers to parse.
+ */
 export type SchedulerState =
   | { kind: "active"; tasks: number }
   | { kind: "idle" }
@@ -48,8 +53,11 @@ export function getSchedulerState(
     try {
       const chunkSize = Math.min(65536, stat.size);
       const chunk = Buffer.alloc(chunkSize);
-      readSync(fd, chunk, 0, chunkSize, stat.size - chunkSize);
-      buf = chunk.toString("utf-8");
+      // Slice to bytesRead before toString — protects against a
+      // truncate-during-read race that would otherwise leave NUL bytes
+      // in the parsed string (#942 reviewer nit).
+      const bytesRead = readSync(fd, chunk, 0, chunkSize, stat.size - chunkSize);
+      buf = chunk.subarray(0, bytesRead).toString("utf-8");
     } finally {
       closeSync(fd);
     }

--- a/src/cli/agent.ts
+++ b/src/cli/agent.ts
@@ -1,7 +1,9 @@
 import type { Command } from "commander";
 import chalk from "chalk";
-import { resolve } from "node:path";
+import { join, resolve } from "node:path";
 import { rmSync, existsSync, readFileSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { getSchedulerState, formatSchedulerState } from "../agents/scheduler-state.js";
 import YAML from "yaml";
 import { resolveAgentsDir, loadConfig } from "../config/loader.js";
 import type { SwitchroomConfig } from "../config/schema.js";
@@ -603,10 +605,21 @@ export function registerAgentCommand(program: Command): void {
           return;
         }
 
+        // Per-agent scheduler state — distinguishes "5 tasks" from
+        // "idle (no schedule entries)" from "wedged" (#931). Cheap
+        // log-tail-parse against ~/.switchroom/logs/<agent>/agent-
+        // scheduler.log so the operator doesn't have to docker-logs
+        // each agent to confirm cron health.
+        const logsDir = join(homedir(), ".switchroom", "logs");
+        const schedulerStates = Object.fromEntries(
+          agentNames.map((n) => [n, getSchedulerState(n, logsDir)] as const),
+        );
+
         if (opts.json) {
           const data = agentNames.map((name) => {
             const agentConfig = config.agents[name];
             const status = statuses[name];
+            const sched = schedulerStates[name];
             return {
               name,
               status: status?.active ?? "unknown",
@@ -614,18 +627,20 @@ export function registerAgentCommand(program: Command): void {
               extends: agentConfig.extends ?? "default",
               topic_name: agentConfig.topic_name,
               topic_emoji: agentConfig.topic_emoji,
+              scheduler: sched, // {kind:'active',tasks:N} | {kind:'idle'} | etc.
             };
           });
           console.log(JSON.stringify({ agents: data }, null, 2));
           return;
         }
 
-        const headers = ["Name", "Status", "Uptime", "Template", "Topic"];
-        const widths = [16, 10, 12, 15, 20];
+        const headers = ["Name", "Status", "Uptime", "Template", "Scheduler", "Topic"];
+        const widths = [16, 10, 12, 15, 12, 20];
 
         const rows = agentNames.map((name) => {
           const agentConfig = config.agents[name];
           const status = statuses[name];
+          const sched = schedulerStates[name];
           const topicDisplay = [
             agentConfig.topic_name,
             agentConfig.topic_emoji,
@@ -638,6 +653,7 @@ export function registerAgentCommand(program: Command): void {
             statusColor(status?.active ?? "unknown"),
             formatUptime(status?.uptime ?? null),
             agentConfig.extends ?? "default",
+            sched ? formatSchedulerState(sched) : "?",
             topicDisplay,
           ];
         });


### PR DESCRIPTION
## Summary

Closes #931.

Pre-fix: \`switchroom agent list\` reported the same string for two different scheduler states. To distinguish, the operator had to \`docker logs <agent>\` and grep — friction that grows linearly with fleet size.

## Fix

\`getSchedulerState(agent, logsDir)\` helper tail-reads the last 64KB of \`~/.switchroom/logs/<agent>/agent-scheduler.log\`, scans bottom-up for the most recent state line, returns one of:

| State | Match |
|---|---|
| \`{kind:\"active\", tasks:N}\` | \"registered N task(s)\" |
| \`{kind:\"idle\"}\` | \"no schedule entries — idling\" (#921) |
| \`{kind:\"wedged\"}\` | \"hit 10 restarts in <60s — giving up\" (legacy pre-#921) |
| \`{kind:\"unknown\", reason}\` | log absent / no state line / read fail |

\`switchroom agent list\` grew a Scheduler column. JSON output also gets a structured \`scheduler\` field.

Sample output:

\`\`\`
  Name              Status      Uptime        Template         Scheduler     Topic
  clerk             active      29s           default          5 tasks       DM 💬
  klanker           active      29s           default          idle          DM 🔧
  gymbro            active      29s           default          6 tasks       DM 💪
  finn              active      29s           default          idle          DM 💰
  ...
\`\`\`

## Approach

Cheap log-tail-parse (per the issue's choice between log-tail vs JSON-state-file). No new filesystem writes; read-only against existing logs. Bounded cost: state lines are <300 bytes and fire ≤1× per container restart, so 64KB tail is plenty of slack.

ESM-safe top-of-file imports per the #938 reviewer pattern (no \`require()\` inside the module).

## Test plan
- [x] \`npm run lint\` clean
- [x] 8 new tests cover all five states + the most-recent-wins bottom-up scan with realistic interleaved log content
- [ ] Reviewer-agent verdict pending

🤖 Generated with [Claude Code](https://claude.com/claude-code)