### PR TITLE
fix(lifecycle): `restartAgent` uses `up -d --no-deps` not `restart` (#932)

### DIFF
--- a/src/agents/lifecycle.ts
+++ b/src/agents/lifecycle.ts
@@ -203,20 +203,34 @@ export function restartAgent(name: string, reason?: string): void {
   // the greeting card. Best-effort — if the dir is missing we swallow.
   if (reason) writeRestartReasonMarker(name, reason);
   try {
-    // `up -d --no-deps` not `restart` (#932). `restart` only stops +
-    // starts the existing container with its existing volume mounts;
-    // it does NOT recreate. So if `apply` regenerated the compose
-    // file with new bind-mounts (e.g. the #912 skills/credentials
-    // mounts; or future per-agent mounts not yet conceived),
-    // `restart` would leave the running container with the OLD
-    // mounts despite the on-disk compose having the new ones.
-    // `up -d --no-deps` detects the compose-entry diff and recreates
-    // when needed, no-ops when not. `--no-deps` prevents recreating
-    // sibling services (broker / kernel / other agents) that this
-    // restart shouldn't touch. The lesson is fresh from #857 / #916
-    // where the same primitive had to be swapped in test code for
-    // identical reasons.
-    dockerSync(composeArgs(["up", "-d", "--no-deps", serviceKey(name)]));
+    // `up -d --force-recreate --no-deps` not `restart` (#932). All
+    // three flags are load-bearing — DO NOT strip any without
+    // updating the surrounding callers:
+    //
+    // - `up -d` (vs `restart`): `restart` only stops + starts the
+    //   existing container with its EXISTING volume mounts; it does
+    //   NOT recreate. So if `apply` regenerated the compose with new
+    //   bind-mounts (e.g. #912's skills/credentials mounts), `restart`
+    //   leaves the container with the OLD mounts. Same lesson as
+    //   #857 / #916 where this got swapped in test code first.
+    //
+    // - `--force-recreate`: without it, `up -d` no-ops when the
+    //   compose entry is byte-identical (the common case after
+    //   scaffold-CONTENT changes — settings.json / .mcp.json /
+    //   start.sh / SOUL.md / CLAUDE.md — which the agent's bind-
+    //   mounted dir holds but the compose entry doesn't reference
+    //   per-file). claude reads those at process start, so picking
+    //   up edits requires a process bounce. Several callers depend
+    //   on this always-bounce semantics: auth.ts (restart after
+    //   token write), agent.ts grant/dangerous (restart after
+    //   reconcile), restart.ts (the canonical bounce-this-agent
+    //   verb). CLAUDE.md ~298 promises "restart is also a mini-
+    //   deploy of any scaffold changes" — that contract requires
+    //   --force-recreate. Caught by the #944 reviewer; keep this.
+    //
+    // - `--no-deps`: prevents recreating sibling services (broker /
+    //   kernel / other agents) that this restart shouldn't touch.
+    dockerSync(composeArgs(["up", "-d", "--force-recreate", "--no-deps", serviceKey(name)]));
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     throw new Error(`Failed to restart agent "${name}": ${message}`);

--- a/src/agents/lifecycle.ts
+++ b/src/agents/lifecycle.ts
@@ -203,7 +203,20 @@ export function restartAgent(name: string, reason?: string): void {
   // the greeting card. Best-effort — if the dir is missing we swallow.
   if (reason) writeRestartReasonMarker(name, reason);
   try {
-    dockerSync(composeArgs(["restart", serviceKey(name)]));
+    // `up -d --no-deps` not `restart` (#932). `restart` only stops +
+    // starts the existing container with its existing volume mounts;
+    // it does NOT recreate. So if `apply` regenerated the compose
+    // file with new bind-mounts (e.g. the #912 skills/credentials
+    // mounts; or future per-agent mounts not yet conceived),
+    // `restart` would leave the running container with the OLD
+    // mounts despite the on-disk compose having the new ones.
+    // `up -d --no-deps` detects the compose-entry diff and recreates
+    // when needed, no-ops when not. `--no-deps` prevents recreating
+    // sibling services (broker / kernel / other agents) that this
+    // restart shouldn't touch. The lesson is fresh from #857 / #916
+    // where the same primitive had to be swapped in test code for
+    // identical reasons.
+    dockerSync(composeArgs(["up", "-d", "--no-deps", serviceKey(name)]));
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     throw new Error(`Failed to restart agent "${name}": ${message}`);

--- a/tests/lifecycle-restart-reason.test.ts
+++ b/tests/lifecycle-restart-reason.test.ts
@@ -117,17 +117,19 @@ describe("lifecycle: restart-reason marker", () => {
   });
 });
 
-describe("lifecycle: restartAgent shellout shape (v0.7 PR-C1)", () => {
+describe("lifecycle: restartAgent shellout shape (v0.7 PR-C1, updated #932)", () => {
   // Under the docker runtime there's a single container per agent
   // (`switchroom-<name>`), not the systemd-era pair of agent + gateway
-  // services. The pre-#177 ordering concern is moot — a single
-  // `docker compose restart agent-<name>` cycles the whole container,
-  // which holds both the gateway and the claude REPL inside.
+  // services. Since #932 the call is `compose up -d --no-deps
+  // agent-<name>` (was `compose restart` pre-#932) so on-disk compose
+  // diffs are picked up via container recreation; --no-deps prevents
+  // disturbing sibling services (broker/kernel).
   //
   // This test pins that the source still routes restart through
   // docker compose with the expected project + service names, so a
-  // future re-edit can't silently revert to systemctl.
-  it("restartAgent's source uses `docker compose ... restart agent-<name>`", async () => {
+  // future re-edit can't silently revert to systemctl OR to plain
+  // `restart` (which would silently miss volume-mount changes).
+  it("restartAgent's source uses `docker compose ... up -d --no-deps agent-<name>` (#932)", async () => {
     const { readFileSync } = await import("node:fs");
     const { resolve, join: joinPath } = await import("node:path");
     const { fileURLToPath } = await import("node:url");
@@ -140,7 +142,12 @@ describe("lifecycle: restartAgent shellout shape (v0.7 PR-C1)", () => {
     expect(funcStart).toBeGreaterThan(0);
     const body = src.slice(funcStart, funcEnd);
 
-    expect(body).toMatch(/composeArgs\(\["restart", serviceKey\(name\)\]\)/);
+    expect(body).toMatch(
+      /composeArgs\(\["up", "-d", "--no-deps", serviceKey\(name\)\]\)/,
+    );
+    // Regression: must NOT silently revert to plain `restart` (would
+    // miss volume-mount diffs from `apply` — see #932 / #857 / #916).
+    expect(body).not.toMatch(/composeArgs\(\["restart"/);
     // No leftover systemctl calls in the restart path.
     expect(body).not.toMatch(/systemctl/);
   });

--- a/tests/lifecycle-restart-reason.test.ts
+++ b/tests/lifecycle-restart-reason.test.ts
@@ -143,11 +143,16 @@ describe("lifecycle: restartAgent shellout shape (v0.7 PR-C1, updated #932)", ()
     const body = src.slice(funcStart, funcEnd);
 
     expect(body).toMatch(
-      /composeArgs\(\["up", "-d", "--no-deps", serviceKey\(name\)\]\)/,
+      /composeArgs\(\["up", "-d", "--force-recreate", "--no-deps", serviceKey\(name\)\]\)/,
     );
-    // Regression: must NOT silently revert to plain `restart` (would
-    // miss volume-mount diffs from `apply` — see #932 / #857 / #916).
+    // Regression guards — must NOT silently revert to:
+    //   - plain `restart` (would miss volume-mount diffs from `apply`
+    //     — see #932 / #857 / #916)
+    //   - `up -d --no-deps` without --force-recreate (would no-op on
+    //     byte-identical compose, breaking auth.ts and grant flows
+    //     that depend on always-bounce — see #944 reviewer)
     expect(body).not.toMatch(/composeArgs\(\["restart"/);
+    expect(body).toMatch(/--force-recreate/);
     // No leftover systemctl calls in the restart path.
     expect(body).not.toMatch(/systemctl/);
   });

--- a/tests/lifecycle.docker.test.ts
+++ b/tests/lifecycle.docker.test.ts
@@ -115,11 +115,17 @@ describe("lifecycle (docker mode): start/stop/restart shellouts", () => {
     ]);
   });
 
-  it("restartAgent calls `compose up -d --no-deps agent-<name>` (#932)", () => {
-    // Was `compose restart` pre-#932 — swapped to `up -d --no-deps`
-    // so the recreate semantics pick up new volume mounts / compose-
-    // entry diffs (the same lesson learned in #857 / #916 for the
-    // test path). --no-deps prevents recreating sibling services.
+  it("restartAgent calls `compose up -d --force-recreate --no-deps agent-<name>` (#932)", () => {
+    // All three flags are load-bearing — see the doc-comment on
+    // restartAgent for why each one matters:
+    //   up -d            picks up volume-mount diffs (#857 / #916)
+    //   --force-recreate always bounces the process so scaffold-
+    //                    content edits (settings.json / start.sh /
+    //                    SOUL.md / .mcp.json) take effect — pre-PR
+    //                    `restart` always bounced; pre-#944-reviewer
+    //                    `up -d --no-deps` no-op'd on byte-identical
+    //                    compose, breaking auth.ts and grant flows.
+    //   --no-deps        leaves siblings (broker/kernel) untouched.
     const calls = recordingStub({ "compose up": () => "" });
     restartAgent("foo");
     expect(calls[0].args).toEqual([
@@ -130,6 +136,7 @@ describe("lifecycle (docker mode): start/stop/restart shellouts", () => {
       "/tmp/sw-test-compose.yml",
       "up",
       "-d",
+      "--force-recreate",
       "--no-deps",
       "agent-foo",
     ]);

--- a/tests/lifecycle.docker.test.ts
+++ b/tests/lifecycle.docker.test.ts
@@ -115,8 +115,12 @@ describe("lifecycle (docker mode): start/stop/restart shellouts", () => {
     ]);
   });
 
-  it("restartAgent calls `compose restart agent-<name>`", () => {
-    const calls = recordingStub({ "compose restart": () => "" });
+  it("restartAgent calls `compose up -d --no-deps agent-<name>` (#932)", () => {
+    // Was `compose restart` pre-#932 — swapped to `up -d --no-deps`
+    // so the recreate semantics pick up new volume mounts / compose-
+    // entry diffs (the same lesson learned in #857 / #916 for the
+    // test path). --no-deps prevents recreating sibling services.
+    const calls = recordingStub({ "compose up": () => "" });
     restartAgent("foo");
     expect(calls[0].args).toEqual([
       "compose",
@@ -124,7 +128,9 @@ describe("lifecycle (docker mode): start/stop/restart shellouts", () => {
       "switchroom",
       "-f",
       "/tmp/sw-test-compose.yml",
-      "restart",
+      "up",
+      "-d",
+      "--no-deps",
       "agent-foo",
     ]);
   });


### PR DESCRIPTION
## Summary

Closes #932.

Same lesson as PR #916 (test path) and #857 (production kernel-add): \`docker compose restart\` only stops + starts the existing container with its EXISTING volume mounts. It does NOT recreate. So if \`apply\` regenerated the compose with new bind-mounts (e.g. #912's skills/credentials mounts; or any future per-agent mount), a subsequent \`switchroom agent restart <name>\` would silently leave the running container with the OLD mounts despite the on-disk compose having the new ones.

**No active symptom today** — current per-agent volume mounts don't change between reconciles. But the post-merge reviewer flagged this as a footgun \"if/when they do\" and the lesson is fresh from the sister fixes. Defensive but cheap.

## Fix

Swap \`composeArgs([\"restart\", serviceKey(name)])\` → \`composeArgs([\"up\", \"-d\", \"--no-deps\", serviceKey(name)])\`. 

- \`up -d\` detects compose-entry diffs and recreates only when needed, no-ops when not.
- \`--no-deps\` prevents recreating sibling services (broker / kernel / other agents) that this restart shouldn't touch.

## Tests

Both touched test files updated:
- \`lifecycle.docker.test.ts\`: pin the new argv shape.
- \`lifecycle-restart-reason.test.ts\`: source-grep regression guard pins the new form AND adds a NOT-match against the old \`composeArgs([\"restart\", ...])\` form so a future re-edit can't silently revert (the same risk that motivated the original test).

## Test plan
- [x] \`npm run lint\` clean
- [x] All 25 lifecycle tests pass
- [ ] Reviewer-agent verdict pending

🤖 Generated with [Claude Code](https://claude.com/claude-code)