### PR TITLE
fix(doctor): EACCES on per-agent state files renders as warn, not as "not authenticated" / "missing"

### DIFF
--- a/src/auth/manager.ts
+++ b/src/auth/manager.ts
@@ -41,6 +41,20 @@ export interface AuthStatus {
   rateLimitTier?: string;
   source?: "credentials" | "oauth-token";
   pendingAuth?: boolean;
+  /**
+   * True when the credential / oauth-token files exist on disk but the
+   * current process can't open(2) them (EACCES). Typical case: per-
+   * agent state files are mode 0600 owned by the agent UID
+   * (compose.ts allocates 10001-10999), and the host operator running
+   * `switchroom doctor` is a different UID. Agent state is almost
+   * certainly fine; the host just can't verify.
+   *
+   * Doctor renders `inaccessible: true` as `warn` ("auth state owned
+   * by agent UID — unverifiable from host") instead of `fail` ("not
+   * authenticated"), which was the 2026-05-10 false-positive that
+   * polluted the post-deploy doctor across all 8 agents.
+   */
+  inaccessible?: boolean;
 }
 
 interface CredentialsFile {
@@ -246,6 +260,38 @@ function readOAuthToken(agentDir: string): string | null {
   } catch {
     return null;
   }
+}
+
+/**
+ * Detect whether the agent's auth state files exist on disk but are
+ * unreadable from the current process (EACCES). Per-agent state is
+ * mode 0600 owned by an agent-specific UID (compose.ts allocates
+ * 10001-10999); when `switchroom doctor` runs as the host operator
+ * the open(2) fails with EACCES even though the agent itself reads
+ * the file fine. Pre-fix this manifested as a per-agent "not
+ * authenticated" fail row on every host-side doctor run (the 2026-
+ * 05-10 false-positive that polluted the post-deploy doctor across
+ * all 8 agents).
+ *
+ * Returns true if EITHER credentials.json or .oauth-token is present
+ * but unreadable. ENOENT (genuinely missing) is NOT treated as
+ * inaccessible — that's a real "not authenticated" state.
+ */
+function authFilesAreInaccessible(agentDir: string): boolean {
+  const probes = [credentialsPath(agentDir), oauthTokenPath(agentDir)];
+  for (const p of probes) {
+    if (!existsSync(p)) continue;
+    try {
+      readFileSync(p, "utf-8");
+    } catch (err: unknown) {
+      const code = (err as NodeJS.ErrnoException)?.code;
+      if (code === "EACCES" || code === "EPERM") return true;
+      // Any other error (corrupted file, FS issue) is a different
+      // problem; let the existing flow fall through to "not
+      // authenticated" rather than masking it as inaccessible.
+    }
+  }
+  return false;
 }
 
 /**
@@ -517,7 +563,14 @@ export function getAuthStatus(name: string, agentDir: string): AuthStatus {
   }
 
   if (!creds?.accessToken) {
-    return { authenticated: false, pendingAuth };
+    // Distinguish "credentials genuinely missing" (real not-authenticated
+    // state) from "credentials present on disk but unreadable from this
+    // UID" (host-side doctor false-positive — agent state is fine).
+    return {
+      authenticated: false,
+      pendingAuth,
+      ...(authFilesAreInaccessible(agentDir) ? { inaccessible: true } : {}),
+    };
   }
 
   const expiresAt = creds.expiresAt;

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -558,19 +558,85 @@ async function checkHindsight(config: SwitchroomConfig): Promise<CheckResult[]> 
 }
 
 /**
+ * Classify a filesystem read error so doctor checks can distinguish
+ * "file genuinely missing" (ENOENT — usually a real config bug worth a
+ * red row) from "file present but the doctor process can't read it"
+ * (EACCES — the doctor is running as the host operator UID, but
+ * per-agent state files are mode 0600 owned by the agent UID
+ * (compose.ts:580ish, agentUid 10001-10999); the agent runtime reads
+ * them just fine, the doctor just can't verify from the host). Pre-fix,
+ * the EACCES path produced a false "missing" fail per agent on every
+ * `switchroom doctor` run on a multi-agent host.
+ * @internal exported for testing
+ */
+export type ReadErrorKind = "enoent" | "eacces" | "other";
+export function classifyReadError(err: unknown): ReadErrorKind {
+  const code = (err as NodeJS.ErrnoException)?.code;
+  if (code === "ENOENT") return "enoent";
+  if (code === "EACCES" || code === "EPERM") return "eacces";
+  return "other";
+}
+
+/**
+ * Result of a host-side read attempt against per-agent state files.
+ * Callers branch on `kind` to render an honest doctor row.
+ *
+ *   ok       — got the content
+ *   enoent   — file is missing (real failure most of the time)
+ *   eacces   — file is there but unreadable from this UID
+ *              (typical when doctor runs as host operator and the
+ *              file is owned by a per-agent UID); agent state likely
+ *              fine; render as `warn`, not `fail`
+ *   other    — anything else (corrupted FS, etc.); rare
+ */
+export type FileReadResult =
+  | { kind: "ok"; content: string }
+  | { kind: "enoent" }
+  | { kind: "eacces"; error: string }
+  | { kind: "other"; error: string };
+
+export function tryReadHostFile(path: string): FileReadResult {
+  try {
+    return { kind: "ok", content: readFileSync(path, "utf-8") };
+  } catch (err: unknown) {
+    const kind = classifyReadError(err);
+    const error = (err as Error)?.message ?? String(err);
+    if (kind === "enoent") return { kind: "enoent" };
+    if (kind === "eacces") return { kind: "eacces", error };
+    return { kind: "other", error };
+  }
+}
+
+/**
  * Parse a simple KEY=VALUE env file. Quotes around values are stripped.
  * Lines starting with `#` and blank lines are ignored.
+ *
+ * Returns an empty object on ANY read error — callers that need to
+ * distinguish ENOENT (real missing) from EACCES (host-perm) should use
+ * `tryReadHostFile()` directly instead.
  * @internal exported for testing
  */
 export function parseEnvFile(path: string): Record<string, string> {
-  const out: Record<string, string> = {};
-  if (!existsSync(path)) return out;
+  if (!existsSync(path)) return {};
   let content: string;
   try {
     content = readFileSync(path, "utf-8");
   } catch {
-    return out;
+    return {};
   }
+  return parseSimpleEnv(content);
+}
+
+/**
+ * Parse pre-read env-file content (KEY=VALUE per line; quotes stripped;
+ * `#`-comments and blanks ignored). Extracted from parseEnvFile so
+ * callers that already have the content (because they read the file
+ * via tryReadHostFile to distinguish EACCES from ENOENT) don't have
+ * to re-read it.
+ * @internal exported for testing
+ */
+export function parseSimpleEnv(content: string): Record<string, string> {
+  const out: Record<string, string> = {};
   for (const line of content.split("\n")) {
     const trimmed = line.trim();
     if (!trimmed || trimmed.startsWith("#")) continue;
@@ -638,13 +704,31 @@ export async function checkTelegram(config: SwitchroomConfig): Promise<CheckResu
     const plugin = agentConfig.channels?.telegram?.plugin ?? "switchroom";
     if (plugin !== "switchroom") continue;
     const envPath = join(agentsDir, name, "telegram", ".env");
-    const env = parseEnvFile(envPath);
+    const read = tryReadHostFile(envPath);
+    if (read.kind === "eacces") {
+      // The .env file is mode 0600 owned by the per-agent UID; doctor
+      // running as the host operator can't open(2) it. The agent
+      // process itself reads it fine. Surface this as a warn with
+      // honest detail rather than a false "TELEGRAM_BOT_TOKEN missing"
+      // fail (the 2026-05-10 false-positive that polluted the post-
+      // deploy doctor across all 8 agents).
+      results.push({
+        name: `${name}: bot token`,
+        status: "warn",
+        detail: `unreadable from host (${read.error}) — agent reads it fine; cannot verify TELEGRAM_BOT_TOKEN from operator UID`,
+      });
+      continue;
+    }
+    const env = read.kind === "ok" ? parseSimpleEnv(read.content) : {};
     const token = env.TELEGRAM_BOT_TOKEN;
     if (!token) {
       results.push({
         name: `${name}: bot token`,
         status: "fail",
-        detail: `TELEGRAM_BOT_TOKEN missing from ${envPath}`,
+        detail:
+          read.kind === "enoent"
+            ? `TELEGRAM_BOT_TOKEN missing from ${envPath} (file does not exist)`
+            : `TELEGRAM_BOT_TOKEN missing from ${envPath}`,
         fix: `Run \`switchroom agent reconcile ${name}\` and ensure the vault contains telegram_bot_token`,
       });
       continue;
@@ -855,14 +939,28 @@ export function checkAgents(config: SwitchroomConfig, configPath: string): Check
     // 3. Auth
     const auth = authStatuses[name];
     if (!auth?.authenticated) {
-      results.push({
-        name: `${name}: auth`,
-        status: "fail",
-        detail: auth?.pendingAuth
-          ? "pending (auth flow in progress)"
-          : "not authenticated",
-        fix: `Run \`switchroom auth login ${name}\` and complete the OAuth flow`,
-      });
+      if (auth?.inaccessible) {
+        // Per-agent credentials exist but the doctor process can't
+        // open(2) them (UID mismatch — host operator vs. agent UID).
+        // Agent state is almost certainly fine; the host just can't
+        // verify. Render as warn with honest detail rather than the
+        // false "not authenticated" fail that pre-fix polluted the
+        // post-deploy doctor across the full fleet (2026-05-10).
+        results.push({
+          name: `${name}: auth`,
+          status: "warn",
+          detail: "auth state owned by agent UID — unverifiable from host (agent reads it fine)",
+        });
+      } else {
+        results.push({
+          name: `${name}: auth`,
+          status: "fail",
+          detail: auth?.pendingAuth
+            ? "pending (auth flow in progress)"
+            : "not authenticated",
+          fix: `Run \`switchroom auth login ${name}\` and complete the OAuth flow`,
+        });
+      }
     } else {
       // Rich auth detail: plan · expires in · rate-limit tier
       const parts: string[] = [];

--- a/tests/auth.status-settling.test.ts
+++ b/tests/auth.status-settling.test.ts
@@ -71,6 +71,47 @@ describe("auth status settling (#171 / #176)", () => {
     // Guard: no slot, no legacy file — must NOT return authenticated.
     const status = getAuthStatus("empty-agent", tempDir);
     expect(status.authenticated).toBe(false);
+    // Must NOT mark inaccessible — the file genuinely isn't there
+    // (ENOENT, not EACCES). Inaccessible is reserved for "file
+    // present but unreadable from this UID" — see the EACCES test
+    // below.
+    expect(status.inaccessible).toBeUndefined();
+  });
+
+  it("flags inaccessible=true when credentials/token files exist but are unreadable from this UID (EACCES)", async () => {
+    // Reproduce the 2026-05-10 doctor false-positive: per-agent
+    // state files are mode 0600 owned by the agent UID
+    // (compose.ts allocates 10001-10999), and `switchroom doctor`
+    // running as the host operator can't open(2) them. Pre-fix
+    // getAuthStatus saw the file via existsSync, failed to
+    // readFileSync (EACCES), and returned authenticated=false —
+    // looking identical to the genuine "not authenticated" state.
+    //
+    // The fix: surface an `inaccessible: true` flag so the doctor
+    // can render warn + honest detail instead of fail + "not
+    // authenticated".
+    //
+    // We simulate UID-mismatch with chmod 0o000 (no perms for
+    // anyone), which produces EACCES on read. existsSync still
+    // returns true.
+    const { chmodSync } = await import("node:fs");
+    const claudeDir = resolve(tempDir, ".claude");
+    const credPath = resolve(claudeDir, ".credentials.json");
+    writeFileSync(credPath, JSON.stringify({
+      claudeAiOauth: {
+        accessToken: "sk-ant-faux",
+        expiresAt: Date.now() + 365 * 24 * 60 * 60_000,
+        subscriptionType: "max",
+      },
+    }), { mode: 0o600 });
+    chmodSync(credPath, 0o000);
+    try {
+      const status = getAuthStatus("eacces-agent", tempDir);
+      expect(status.authenticated).toBe(false);
+      expect(status.inaccessible).toBe(true);
+    } finally {
+      chmodSync(credPath, 0o600);
+    }
   });
 
   it("returns authenticated=false when slot token exists but active marker is absent", () => {

--- a/tests/doctor.test.ts
+++ b/tests/doctor.test.ts
@@ -17,6 +17,61 @@ import {
 import { findConfigFile } from "../src/config/loader.js";
 import type { SwitchroomConfig } from "../src/config/schema.js";
 
+describe("classifyReadError + tryReadHostFile", () => {
+  let tempDir: string;
+  beforeEach(() => {
+    tempDir = resolve(tmpdir(), `switchroom-doctor-readerr-${Date.now()}`);
+    mkdirSync(tempDir, { recursive: true });
+  });
+  afterEach(() => rmSync(tempDir, { recursive: true, force: true }));
+
+  it("classifies ENOENT correctly", async () => {
+    const { classifyReadError } = await import("../src/cli/doctor.js");
+    expect(classifyReadError({ code: "ENOENT" } as NodeJS.ErrnoException)).toBe("enoent");
+  });
+
+  it("classifies EACCES and EPERM as eacces", async () => {
+    const { classifyReadError } = await import("../src/cli/doctor.js");
+    expect(classifyReadError({ code: "EACCES" } as NodeJS.ErrnoException)).toBe("eacces");
+    expect(classifyReadError({ code: "EPERM" } as NodeJS.ErrnoException)).toBe("eacces");
+  });
+
+  it("classifies unknown codes as other", async () => {
+    const { classifyReadError } = await import("../src/cli/doctor.js");
+    expect(classifyReadError({ code: "EBUSY" } as NodeJS.ErrnoException)).toBe("other");
+    expect(classifyReadError(new Error("totally generic"))).toBe("other");
+  });
+
+  it("tryReadHostFile returns ok with content when readable", async () => {
+    const { tryReadHostFile } = await import("../src/cli/doctor.js");
+    const path = join(tempDir, "ok.txt");
+    writeFileSync(path, "hello\n");
+    const result = tryReadHostFile(path);
+    expect(result.kind).toBe("ok");
+    if (result.kind === "ok") expect(result.content).toBe("hello\n");
+  });
+
+  it("tryReadHostFile returns enoent when file is missing", async () => {
+    const { tryReadHostFile } = await import("../src/cli/doctor.js");
+    const result = tryReadHostFile(join(tempDir, "nope.txt"));
+    expect(result.kind).toBe("enoent");
+  });
+
+  it("tryReadHostFile returns eacces when file exists but is unreadable", async () => {
+    const { tryReadHostFile } = await import("../src/cli/doctor.js");
+    const path = join(tempDir, "secret.txt");
+    writeFileSync(path, "x");
+    chmodSync(path, 0o000);
+    try {
+      const result = tryReadHostFile(path);
+      expect(result.kind).toBe("eacces");
+      if (result.kind === "eacces") expect(result.error).toMatch(/EACCES|permission/i);
+    } finally {
+      chmodSync(path, 0o600);
+    }
+  });
+});
+
 describe("parseEnvFile", () => {
   let tempDir: string;
 
@@ -247,6 +302,35 @@ describe("checkTelegram", () => {
       makeConfig({ other: { plugin: "none" } }),
     );
     expect(results).toHaveLength(0);
+  });
+
+  it("reports warn (not fail) when .env exists but is unreadable from host UID (EACCES)", async () => {
+    // Per-agent state files are mode 0600 owned by the agent UID
+    // (compose.ts allocates 10001-10999); when `switchroom doctor`
+    // runs as the host operator, open(2) fails with EACCES even
+    // though the agent itself reads the file fine. Pre-fix this
+    // produced a false "TELEGRAM_BOT_TOKEN missing" fail per agent
+    // — the 2026-05-10 post-deploy doctor false-positive.
+    //
+    // Simulate by writing the file with mode 0000 (so existsSync
+    // still returns true but readFileSync throws EACCES).
+    writeAgentEnv("assistant", "123:ABC");
+    const envPath = join(tempDir, "assistant", "telegram", ".env");
+    chmodSync(envPath, 0o000);
+    try {
+      const results = await checkTelegram(
+        makeConfig({ assistant: { plugin: "switchroom" } }),
+      );
+      expect(results).toHaveLength(1);
+      expect(results[0].status).toBe("warn");
+      expect(results[0].detail).toContain("unreadable from host");
+      expect(results[0].detail).toContain("agent reads it fine");
+      // Crucially: the row must NOT claim TELEGRAM_BOT_TOKEN is "missing".
+      expect(results[0].detail).not.toContain("missing");
+    } finally {
+      // Restore so afterEach's rmSync can clean up.
+      chmodSync(envPath, 0o600);
+    }
   });
 
   it("dedupes tokens across multiple agents sharing one bot", async () => {


### PR DESCRIPTION
## The bug

Today's `switchroom doctor` run, post-deploy, produced 16 fail rows that didn't reflect any real failure:

```
✗ clerk: bot token  (TELEGRAM_BOT_TOKEN missing from .../telegram/.env)
✗ klanker: bot token (TELEGRAM_BOT_TOKEN missing from .../telegram/.env)
... × 8 agents
✗ clerk: auth       (not authenticated)
✗ klanker: auth     (not authenticated)
... × 8 agents
```

The agents were running, serving, and authenticated — verified via `docker exec` showing `TELEGRAM_BOT_TOKEN=...` in `.env` and a valid OAuth token meta with `expiresAt: 2027-04-09`.

Root cause: per-agent state files are mode `0600` owned by the agent UID (`src/agents/compose.ts` allocates `10001-10999`). `switchroom doctor` runs as the host operator UID. `existsSync(path)` returns true; `readFileSync(path)` throws `EACCES`. Pre-fix the checks silently swallowed the error and reported \"missing\" / \"not authenticated\" — same shape as a genuine config bug. **16 false-positive fails buried any real failure** in the same noise.

## Fix

### `src/cli/doctor.ts`

- New `tryReadHostFile()` returns `{kind: 'ok' | 'enoent' | 'eacces' | 'other'}` so callers can render honest detail.
- New `classifyReadError()` distinguishes ENOENT, EACCES (+ EPERM), and other.
- `checkTelegram` branches on EACCES → `warn` (\"unreadable from host — agent reads it fine; cannot verify TELEGRAM_BOT_TOKEN from operator UID\") instead of `fail`.
- ENOENT path still produces fail with `(file does not exist)` suffix — operators with a genuinely broken `.env` (vault never reconciled) get the same actionable error as before.

### `src/auth/manager.ts`

- `AuthStatus` grows an optional `inaccessible: boolean` flag.
- New `authFilesAreInaccessible(agentDir)` probes credentials.json + .oauth-token and returns true on EACCES.
- `getAuthStatus`'s unauthenticated return path sets `inaccessible: true` when the files exist but are unreadable.

### `src/cli/doctor.ts` auth check

- When `auth.inaccessible` is true → render `warn` (\"auth state owned by agent UID — unverifiable from host\") instead of `fail` (\"not authenticated\").
- The fix recipe is dropped because there's nothing for the operator to fix — the agent works.

## What's NOT changed

- Agent runtime: those processes read the files using their own UID. This is a pure host-doctor rendering improvement.
- Genuine ENOENT path: `(file does not exist)` suffix added to the detail string, but still `fail`.
- Other doctor checks: only the two that actually-currently-false-positive on a multi-agent host got the treatment. Other checks already use `existsSync`-then-fail patterns (e.g. start.sh scheduler block) which already emit `!` warn instead of `✗`.

## Test plan

- [x] `npm run lint` clean
- [x] `npm test` — vitest 5232/5232 pass (50 in the touched files)
- [x] 5 new cases for `classifyReadError` / `tryReadHostFile` (ENOENT / EACCES / EPERM / other / ok)
- [x] New: bot-token check renders `warn` (not `fail`) when `.env` is mode `0o000` (simulating UID-mismatch on a single-user test machine)
- [x] New: `getAuthStatus` flags `inaccessible: true` when credentials exist but are mode `0o000`
- [x] Existing \"no token at all\" test expanded to assert `inaccessible` is undefined (real ENOENT — must NOT be confused with EACCES)

## Real-world verification

After this fix lands and the host rebuilds/redeploys, the post-deploy doctor for the operator's 8-agent fleet should drop the 8 false-positive bot-token fails and 8 false-positive auth fails, leaving only the genuine warnings (mission config gaps, MFF skill optional probes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)