### PR TITLE
fix(compose): broker/kernel socket env vars use canonical names + agent-perspective paths

### DIFF
--- a/profiles/_base/start.sh.hbs
+++ b/profiles/_base/start.sh.hbs
@@ -64,7 +64,7 @@ if [ "$SWITCHROOM_RUNTIME" = "docker" ] && [ -z "$SWITCHROOM_DOCKER_TMUX_INNER" 
   #    Polls Telegram, writes gateway.sock for the in-claude MCP
   #    sidecar to bridge through. Mirrors the v0.6 sibling
   #    switchroom-<name>-gateway.service unit. Talks to the broker
-  #    over SWITCHROOM_BROKER_SOCKET (set by compose) for the bot
+  #    over SWITCHROOM_VAULT_BROKER_SOCK (set by compose) for the bot
   #    token. Failure modes: vault locked → gateway boots, fails to
   #    fetch token, exits non-zero, supervisor respawns; bot token
   #    invalid → 401 from Telegram, gateway exits, same loop. The

--- a/src/agents/compose.ts
+++ b/src/agents/compose.ts
@@ -584,8 +584,35 @@ function emitAgentService(
     PIP_BREAK_SYSTEM_PACKAGES: "1",
     PIP_USER: "1",
     SWITCHROOM_AGENT_NAME: a.name,
-    SWITCHROOM_BROKER_SOCKET: `/run/switchroom/broker/${a.name}/sock`,
-    SWITCHROOM_KERNEL_SOCKET: `/run/switchroom/kernel/${a.name}/sock`,
+    // Broker / kernel socket paths inside the agent container. The
+    // per-agent volume is mounted at `/run/switchroom/broker` (and
+    // `/run/switchroom/kernel`) — directly at the parent dir, NOT
+    // at the broker-side `/run/switchroom/broker/<agent>` subdir
+    // (compose.ts:370 vs compose.ts:607). So from inside the agent
+    // the socket is at `/run/switchroom/broker/sock`, one level
+    // shallower than the broker container sees it.
+    //
+    // Two pre-fix bugs were stacked:
+    //   1. The path values here were `/run/switchroom/broker/<name>
+    //      /sock` — the broker's view, which does not exist inside
+    //      the agent container at all.
+    //   2. The broker env NAME was `SWITCHROOM_BROKER_SOCKET` — but
+    //      the broker CLIENT (`src/vault/broker/client.ts:293`) and
+    //      the secret-guard hook (`telegram-plugin/hooks/secret-
+    //      guard-pretool.mjs:36`) both read
+    //      `SWITCHROOM_VAULT_BROKER_SOCK`. So clients silently fell
+    //      through to the `~/.switchroom/vault-broker.sock` legacy
+    //      fallback (a dangling symlink inside the container) and
+    //      reported "broker not running" even when the broker was
+    //      up and the socket was bound at the correct in-container
+    //      path. Operator-visible on 2026-05-10 as klanker's
+    //      "VAULT-BROKER-DENIED" after the test-clobber incident
+    //      restored the broker container.
+    // Kernel side already used the correct env name (matches
+    // `src/vault/approvals/client.ts:60`) but had the same wrong
+    // path value. Both fixed here.
+    SWITCHROOM_VAULT_BROKER_SOCK: `/run/switchroom/broker/sock`,
+    SWITCHROOM_KERNEL_SOCKET: `/run/switchroom/kernel/sock`,
     SWITCHROOM_RUNTIME: "docker",
   };
   // SWITCHROOM_CONFIG: the in-container telegram-plugin gateway daemon

--- a/telegram-plugin/gateway/boot-probes.ts
+++ b/telegram-plugin/gateway/boot-probes.ts
@@ -1203,7 +1203,14 @@ export async function probeBroker(
   socketPath?: string,
   opts: { dockerMode?: boolean; connectImpl?: (path: string) => Promise<void> } = {},
 ): Promise<ProbeResult> {
-  return probeUds('Broker', socketPath ?? process.env.SWITCHROOM_BROKER_SOCKET, opts)
+  // SWITCHROOM_VAULT_BROKER_SOCK is the canonical client-side env name
+  // — matches what src/vault/broker/client.ts:293 and the secret-guard
+  // hook (telegram-plugin/hooks/secret-guard-pretool.mjs:36) read.
+  // The broker SERVER reads SWITCHROOM_BROKER_SOCKET as its bind-path
+  // env (in the broker container only). Pre-fix the probe + compose
+  // both used SWITCHROOM_BROKER_SOCKET in the agent container — wrong
+  // name, fell through to dangling-symlink fallback, false-failed.
+  return probeUds('Broker', socketPath ?? process.env.SWITCHROOM_VAULT_BROKER_SOCK, opts)
 }
 
 export async function probeKernel(

--- a/telegram-plugin/tests/boot-probes.test.ts
+++ b/telegram-plugin/tests/boot-probes.test.ts
@@ -724,14 +724,20 @@ describe('probeBroker / probeKernel', () => {
   })
 
   it('probeBroker fails when no socket path is configured', async () => {
-    const oldEnv = process.env.SWITCHROOM_BROKER_SOCKET
-    delete process.env.SWITCHROOM_BROKER_SOCKET
+    // SWITCHROOM_VAULT_BROKER_SOCK is the canonical client-side env
+    // var, matches what src/vault/broker/client.ts and the
+    // secret-guard hook read. (Pre-fix the probe used the wrong name
+    // SWITCHROOM_BROKER_SOCKET — the broker server's bind-path env —
+    // which compose was setting in agent containers but no client
+    // ever read.)
+    const oldEnv = process.env.SWITCHROOM_VAULT_BROKER_SOCK
+    delete process.env.SWITCHROOM_VAULT_BROKER_SOCK
     try {
       const result = await probeBroker(undefined, { dockerMode: true })
       expect(result.status).toBe('fail')
       expect(result.detail).toContain('not configured')
     } finally {
-      if (oldEnv !== undefined) process.env.SWITCHROOM_BROKER_SOCKET = oldEnv
+      if (oldEnv !== undefined) process.env.SWITCHROOM_VAULT_BROKER_SOCK = oldEnv
     }
   })
 

--- a/tests/docker/compose-generator.test.ts
+++ b/tests/docker/compose-generator.test.ts
@@ -117,7 +117,12 @@ describe("generateCompose", () => {
     expect(out).toContain("name: switchroom\n");
     expect(out).toContain("  vault-broker:");
     expect(out).toContain("  approval-kernel:");
-    expect(out).toContain("/run/switchroom/broker/alice/sock");
+    // Per-agent broker volume mount on the broker side stays
+    // `/run/switchroom/broker/<agent>` regardless of the
+    // containerNamePrefix — it's the broker's view, not a name. The
+    // per-agent socket file (`<dir>/sock`) is created by the broker at
+    // runtime, not emitted into the compose YAML.
+    expect(out).toContain("broker-alice-sock:/run/switchroom/broker/alice");
     // The fleet label IS parametrized (PR #939 follow-up): test
     // fleets carry switchroom.fleet=<prefix>, so a parallel vitest
     // fork's productionFleetIsLive() filter on switchroom.fleet=
@@ -479,30 +484,54 @@ describe("agent service env (Phase 2c F2 — IPC wiring)", () => {
     }
   });
 
-  it("sets SWITCHROOM_KERNEL_SOCKET to the per-agent kernel-server bind path", () => {
+  it("sets SWITCHROOM_KERNEL_SOCKET to the agent-perspective socket path", () => {
+    // The agent mounts `kernel-<name>-sock` at `/run/switchroom/kernel`
+    // (compose.ts line ~608 — directly at the parent dir, not at a
+    // per-agent subdir). So the kernel socket inside the agent is at
+    // `/run/switchroom/kernel/sock`, not `/run/switchroom/kernel/
+    // <name>/sock` (which is the kernel CONTAINER's view). Pre-fix
+    // the env value was the kernel-side path → didn't exist inside
+    // the agent → client fell through to the legacy fallback.
     const out = generateCompose({
       config: makeConfig({ alice: {}, bob: {} }),
     });
     for (const a of ["alice", "bob"]) {
       const env = envBlockFor(out, a);
       expect(env).toMatch(
-        new RegExp(
-          `SWITCHROOM_KERNEL_SOCKET:\\s*"/run/switchroom/kernel/${a}/sock"`,
-        ),
+        /SWITCHROOM_KERNEL_SOCKET:\s*"\/run\/switchroom\/kernel\/sock"/,
+      );
+      // Pin the regression: the per-agent-subdir form is the kernel-
+      // side bind path, NOT what should land in agent env.
+      expect(env).not.toMatch(
+        new RegExp(`SWITCHROOM_KERNEL_SOCKET:\\s*"/run/switchroom/kernel/${a}/sock"`),
       );
     }
   });
 
-  it("sets SWITCHROOM_BROKER_SOCKET to the per-agent broker-server bind path", () => {
+  it("sets SWITCHROOM_VAULT_BROKER_SOCK (canonical name) to the agent-perspective path", () => {
+    // The compose generator pre-fix emitted `SWITCHROOM_BROKER_SOCKET`
+    // (the broker SERVER's bind-path env), which the broker CLIENT
+    // (`src/vault/broker/client.ts:293`) and the secret-guard hook
+    // (`telegram-plugin/hooks/secret-guard-pretool.mjs:36`) do NOT
+    // read — they read `SWITCHROOM_VAULT_BROKER_SOCK`. So the env var
+    // was set but ignored. Plus the value was the broker's view of
+    // the per-agent subdir, which doesn't exist inside the agent
+    // container. Both fixed: canonical name + agent-perspective path.
+    // Surfaced as klanker's "VAULT-BROKER-DENIED" on 2026-05-10.
     const out = generateCompose({
       config: makeConfig({ alice: {}, bob: {} }),
     });
     for (const a of ["alice", "bob"]) {
       const env = envBlockFor(out, a);
       expect(env).toMatch(
-        new RegExp(
-          `SWITCHROOM_BROKER_SOCKET:\\s*"/run/switchroom/broker/${a}/sock"`,
-        ),
+        /SWITCHROOM_VAULT_BROKER_SOCK:\s*"\/run\/switchroom\/broker\/sock"/,
+      );
+      // Regression pins:
+      //   1. The wrong NAME (server-side env) is no longer set.
+      //   2. The wrong PATH (broker's per-agent-subdir view) is gone.
+      expect(env).not.toMatch(/SWITCHROOM_BROKER_SOCKET:/);
+      expect(env).not.toMatch(
+        new RegExp(`/run/switchroom/broker/${a}/sock`),
       );
     }
   });


### PR DESCRIPTION
## The bug

When investigating "is vault broker running?" post-v0.7.8-deploy I traced klanker's earlier `VAULT-BROKER-DENIED: broker not running` to the actual cause: the broker WAS running, but the env-var plumbing into the agent containers was wrong on two axes.

### Bug 1 — env var name drift (broker side only)

Compose emitted `SWITCHROOM_BROKER_SOCKET` into agent containers. But:

| Reader | Env var read |
|---|---|
| `src/vault/broker/client.ts:293` (broker client) | `SWITCHROOM_VAULT_BROKER_SOCK` |
| `telegram-plugin/hooks/secret-guard-pretool.mjs:36` | `SWITCHROOM_VAULT_BROKER_SOCK` |
| `src/vault/broker/server.ts:1698` (broker server, in-broker-container) | `SWITCHROOM_BROKER_SOCKET` |
| `src/agents/compose.ts:587` (compose generator emits) | **`SWITCHROOM_BROKER_SOCKET`** ← wrong |

`SWITCHROOM_BROKER_SOCKET` is the broker SERVER's bind-path env — set inside the broker container so the daemon knows where to listen. Compose was setting that name in agent containers, where no client reads it. The intended canonical client-side env is `SWITCHROOM_VAULT_BROKER_SOCK`.

Kernel side was already correct (`SWITCHROOM_KERNEL_SOCKET` matches what `src/vault/approvals/client.ts:60` reads).

### Bug 2 — wrong path value (broker AND kernel)

Compose emitted `/run/switchroom/broker/<name>/sock` and `/run/switchroom/kernel/<name>/sock`. That's the per-agent subdir as seen by the broker / kernel containers (`compose.ts:370, 446`). But the agent mounts the per-agent volume at `/run/switchroom/broker` and `/run/switchroom/kernel` directly (`compose.ts:607-608`), one level shallower. So inside the agent the actual socket paths are `/run/switchroom/broker/sock` and `/run/switchroom/kernel/sock`.

Even if the broker name had been right, the value still pointed at a path that doesn't exist inside the agent container.

## Fix

- **`src/agents/compose.ts`**: emit `SWITCHROOM_VAULT_BROKER_SOCK` (canonical client name) with value `/run/switchroom/broker/sock` (agent-perspective). Kernel keeps its env name; gets the agent-perspective `/run/switchroom/kernel/sock` value.
- **`telegram-plugin/gateway/boot-probes.ts`**: `probeBroker` reads the canonical `SWITCHROOM_VAULT_BROKER_SOCK` (was reading the same wrong name as compose — that's why the probe didn't catch it).
- **`profiles/_base/start.sh.hbs`**: stale doc-comment fixed.

## Test plan

- [x] `npm run lint` clean
- [x] `npm test` — 5232/5232 vitest pass + targeted bun suites green
- [x] **New regression pins** in `compose-generator.test.ts`:
  - `SWITCHROOM_VAULT_BROKER_SOCK` (canonical) emitted with value `/run/switchroom/broker/sock`
  - `SWITCHROOM_BROKER_SOCKET` (server-side env, no longer leaks into agent env) is NOT emitted
  - Agent env doesn't contain the per-agent-subdir path `/run/switchroom/broker/<name>/sock`
  - Mirror checks for kernel side
- [x] **Updated** `boot-probes.test.ts` — `probeBroker` test saves/restores the canonical env name
- [x] **Updated** prod-safety-prefix test from PR #939 — its broad check that `/run/switchroom/broker/alice/sock` appears in compose output was relying on the env value pre-fix; post-fix only the volume-mount line carries the broker-side per-agent path. Assertion narrowed to that line.

## Operator impact

Existing agents need a re-apply to pick up the new env vars. The `switchroom update` flow handles this automatically (`apply` regenerates compose, `up -d --remove-orphans` recreates agents with the new env).

🤖 Generated with [Claude Code](https://claude.com/claude-code)