### PR TITLE
chore: release v0.7.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,47 @@
 # Changelog
 
+## v0.7.9 — broker socket env: canonical name + agent-perspective path
+
+Single-fix patch release for a regression discovered during the
+v0.7.8 deploy. The compose generator was emitting two stacked bugs
+in how the broker / kernel socket paths plumbed into agent
+containers, and an operator-side `VAULT-BROKER-DENIED: broker not
+running` error was the surface symptom even when the broker
+container was up, healthy, and listening.
+
+**Bug 1 — broker env var name drift (#947).** Compose emitted
+`SWITCHROOM_BROKER_SOCKET` into agent containers, but the broker
+*client* (`src/vault/broker/client.ts:293`) and the secret-guard
+hook (`telegram-plugin/hooks/secret-guard-pretool.mjs:36`) both
+read `SWITCHROOM_VAULT_BROKER_SOCK`. The set name was the broker
+*server*'s bind-path env (which is set inside the broker container,
+where the daemon needs it). Clients in agent containers silently
+fell through to the legacy `~/.switchroom/vault-broker.sock`
+fallback — a dangling symlink inside the container — and reported
+"broker not running" even when the broker was fine. Kernel side
+was already correct.
+
+**Bug 2 — wrong path value, both broker and kernel (#947).** Compose
+emitted `/run/switchroom/broker/<name>/sock` and `/run/switchroom/
+kernel/<name>/sock`, the per-agent subdir as seen by the broker /
+kernel containers. But the agent mounts the per-agent volume at
+`/run/switchroom/broker` and `/run/switchroom/kernel` directly
+(one level shallower than the broker / kernel see it), so inside
+the agent the actual sockets are at `/run/switchroom/broker/sock`
+and `/run/switchroom/kernel/sock`. Even with the right env name
+the value was a path that didn't exist inside the agent.
+
+**Operator impact.** Existing v0.7.8 fleets were running with the
+broken env — most workflows didn't notice because vault access
+goes through several routes and not all of them hit this lookup.
+The secret-guard hook (which gates tool calls that touch vault-
+ref'd keys) was the surface that consistently failed. Operators
+running `switchroom update` will pick up the new env vars
+automatically; agents will reconnect to the broker on the next
+request without further intervention.
+
+**No new features in this release** — only the regression fix.
+
 ## v0.7.8 — Phase 4 cron-fold-in, honest doctor, host-update CLI
 
 This release closes the v0.7 docker migration with the cron-fold-in

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "switchroom",
-  "version": "0.7.8",
+  "version": "0.7.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "switchroom",
-      "version": "0.7.8",
+      "version": "0.7.9",
       "license": "MIT",
       "workspaces": [
         "telegram-plugin"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "switchroom",
-  "version": "0.7.8",
+  "version": "0.7.9",
   "description": "Run Claude Code 24/7 on your Claude Pro/Max subscription over Telegram. Open-source alternative to OpenClaw and NanoClaw — no API keys.",
   "type": "module",
   "bin": {

--- a/src/build-info.ts
+++ b/src/build-info.ts
@@ -2,8 +2,8 @@
 // Tracked in git so `tsc --noEmit` works on a fresh clone before `npm run build`.
 // Values are refreshed every time `npm run build` runs.
 
-export const VERSION: string = "0.7.8";
-export const COMMIT_SHA: string | null = "5e6cc8cc";
-export const COMMIT_DATE: string | null = "2026-05-10T19:41:07+10:00";
-export const LATEST_PR: number | null = 945;
-export const COMMITS_AHEAD_OF_TAG: number | null = 39;
+export const VERSION: string = "0.7.9";
+export const COMMIT_SHA: string | null = "bd11c4a6";
+export const COMMIT_DATE: string | null = "2026-05-10T21:18:55+10:00";
+export const LATEST_PR: number | null = 947;
+export const COMMITS_AHEAD_OF_TAG: number | null = 1;


### PR DESCRIPTION
## v0.7.9 — broker socket env: canonical name + agent-perspective path

Single-fix patch release for the regression in v0.7.8's compose generator (#947). Existing v0.7.8 fleets had agents whose broker socket env var was wrong on two axes:

1. Wrong **name**: `SWITCHROOM_BROKER_SOCKET` (server-side bind env) instead of canonical client-side `SWITCHROOM_VAULT_BROKER_SOCK` — clients silently ignored the env.
2. Wrong **path**: broker's per-agent-subdir view, which doesn't exist inside the agent container.

Surfaced as `VAULT-BROKER-DENIED: broker not running` from the secret-guard hook (the tool-call gate that hits vault-ref'd keys).

Both fixed in #947 — this PR is just the version bump + CHANGELOG. Operators running `switchroom update` pick it up automatically; agents reconnect on the next request.

### Test plan

- [x] `npm run lint` clean
- [x] `npm test` (5232 vitest pass)
- [x] `package.json` + `package-lock.json` both at 0.7.9
- [x] `src/build-info.ts` auto-stamped to 0.7.9, COMMIT_SHA tracks bd11c4a6 (PR #947 merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)