### PR TITLE
fix(cli): vault subcommands use canonical resolveBrokerSocketPath (honor SWITCHROOM_VAULT_BROKER_SOCK env)

### DIFF
--- a/src/cli/vault-auto-unlock.ts
+++ b/src/cli/vault-auto-unlock.ts
@@ -27,7 +27,7 @@ import { join } from "node:path";
 import YAML from "yaml";
 
 import { findConfigFile, loadConfig, resolvePath } from "../config/loader.js";
-import { statusViaBroker } from "../vault/broker/client.js";
+import { statusViaBroker, resolveBrokerSocketPath } from "../vault/broker/client.js";
 import {
   AutoUnlockDecryptError,
   DEFAULT_AUTO_UNLOCK_PATH,
@@ -163,7 +163,13 @@ export async function applyAutoUnlock(opts: ApplyOptions = {}): Promise<void> {
   }
   log("✓ Restarted vault-broker container (docker compose restart)");
 
-  const socket = resolvePath(config.vault?.broker?.socket ?? "~/.switchroom/vault-broker.sock");
+  // Canonical resolver — env first, then config, then legacy fallback.
+  // Same shape as the other vault CLI files post-fix.
+  const socket = resolveBrokerSocketPath({
+    vaultBrokerSocket: config.vault?.broker?.socket
+      ? resolvePath(config.vault.broker.socket)
+      : undefined,
+  });
   const poll = opts.pollStatus ?? (() => statusViaBroker({ socket }));
 
   const deadline = Date.now() + verifyTimeoutMs;

--- a/src/cli/vault-broker.ts
+++ b/src/cli/vault-broker.ts
@@ -40,11 +40,24 @@ const DEFAULT_PID_FILE = "~/.switchroom/vault-broker.pid";
 const DEFAULT_SOCKET_PATH = "~/.switchroom/vault-broker.sock";
 
 function getSocketPath(configPath?: string): string {
+  // Use the canonical resolver — honors `SWITCHROOM_VAULT_BROKER_SOCK`
+  // env first, then `vault.broker.socket` config, then the legacy
+  // `~/.switchroom/vault-broker.sock` fallback. Same fix as the other
+  // vault CLI files: pre-fix this skipped the env entirely so
+  // `switchroom vault broker status` from inside an agent container
+  // saw the dangling-symlink fallback and reported the broker as
+  // unreachable even when it was fine on the canonical path.
   try {
     const config = loadConfig(configPath);
-    return resolvePath(config.vault?.broker?.socket ?? DEFAULT_SOCKET_PATH);
+    return resolveBrokerSocketPath({
+      vaultBrokerSocket: config.vault?.broker?.socket
+        ? resolvePath(config.vault.broker.socket)
+        : resolvePath(DEFAULT_SOCKET_PATH),
+    });
   } catch {
-    return resolvePath(DEFAULT_SOCKET_PATH);
+    return resolveBrokerSocketPath({
+      vaultBrokerSocket: resolvePath(DEFAULT_SOCKET_PATH),
+    });
   }
 }
 

--- a/src/cli/vault-doctor.ts
+++ b/src/cli/vault-doctor.ts
@@ -22,7 +22,7 @@ import { existsSync } from "node:fs";
 import { analyseVaultHealth, type Diagnostic, type DiagnosticLevel } from "../vault/doctor.js";
 import { openVault, VaultError } from "../vault/vault.js";
 import { loadConfig, resolvePath } from "../config/loader.js";
-import { statusViaBroker } from "../vault/broker/client.js";
+import { statusViaBroker, resolveBrokerSocketPath } from "../vault/broker/client.js";
 
 function levelGlyph(level: DiagnosticLevel): string {
   switch (level) {
@@ -140,9 +140,16 @@ export function registerVaultDoctorCommand(vault: Command, program: Command): vo
       let brokerRunning: boolean | undefined = undefined;
 
       if (brokerConfigured) {
-        const socketPath = resolvePath(
-          config.vault?.broker?.socket ?? "~/.switchroom/vault-broker.sock"
-        );
+        // Use the canonical resolver — honors SWITCHROOM_VAULT_BROKER_SOCK
+        // env (set by compose into agent containers). Pre-fix this read
+        // only the config + legacy fallback, which inside an agent
+        // container resolved to a dangling symlink → "broker not running"
+        // false-positive on every `switchroom vault doctor` invocation.
+        const socketPath = resolveBrokerSocketPath({
+          vaultBrokerSocket: config.vault?.broker?.socket
+            ? resolvePath(config.vault.broker.socket)
+            : undefined,
+        });
         const status = await statusViaBroker({ socket: socketPath, timeoutMs: 1500 });
         brokerRunning = status !== null;
       }

--- a/src/cli/vault-grant.ts
+++ b/src/cli/vault-grant.ts
@@ -27,6 +27,7 @@ import {
   mintGrantViaBroker,
   listGrantsViaBroker,
   revokeGrantViaBroker,
+  resolveBrokerSocketPath,
   type BrokerClientOpts,
 } from "../vault/broker/client.js";
 import type { GrantMeta } from "../vault/broker/protocol.js";
@@ -63,14 +64,20 @@ function parseDuration(raw: string): number | null {
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
 function getBrokerOpts(configPath?: string): BrokerClientOpts {
+  // Use the canonical resolver — honors SWITCHROOM_VAULT_BROKER_SOCK
+  // env (set by compose). Same fix as the other vault CLI files. Pre-
+  // fix this read only config + legacy fallback, missing the env var
+  // every other broker client honors.
   try {
     const config = loadConfig(configPath);
-    const socket = resolvePath(
-      config.vault?.broker?.socket ?? "~/.switchroom/vault-broker.sock",
-    );
+    const socket = resolveBrokerSocketPath({
+      vaultBrokerSocket: config.vault?.broker?.socket
+        ? resolvePath(config.vault.broker.socket)
+        : undefined,
+    });
     return { socket };
   } catch {
-    return { socket: resolvePath("~/.switchroom/vault-broker.sock") };
+    return { socket: resolveBrokerSocketPath() };
   }
 }
 

--- a/src/cli/vault.ts
+++ b/src/cli/vault.ts
@@ -405,12 +405,27 @@ export function registerVaultCommand(program: Command): void {
 
       // ── Broker routing ──────────────────────────────────────────────────
       if (useBroker) {
+        // Use the canonical resolver — honors `SWITCHROOM_VAULT_BROKER_SOCK`
+        // env first (set by compose into agent containers), then config
+        // `vault.broker.socket`, then `~/.switchroom/vault-broker.sock`
+        // legacy fallback. Pre-fix this CLI skipped the env entirely and
+        // jumped straight to config → legacy fallback. Inside an agent
+        // container the legacy fallback `~/.switchroom/vault-broker.sock`
+        // is a dangling symlink (via the #910 home-symlink fix), so the
+        // CLI reported "broker not running" even when the broker WAS
+        // reachable on the canonical env path. Surfaced 2026-05-10 as
+        // clerk's calendar skill failing every `switchroom vault get`
+        // even though direct broker IPC worked fine.
         let brokerSocket: string | undefined;
         try {
           const config = loadConfig(parentOpts.config);
-          brokerSocket = resolvePath(config.vault?.broker?.socket ?? "~/.switchroom/vault-broker.sock");
+          brokerSocket = resolveBrokerSocketPath({
+            vaultBrokerSocket: config.vault?.broker?.socket
+              ? resolvePath(config.vault.broker.socket)
+              : undefined,
+          });
         } catch {
-          brokerSocket = resolvePath("~/.switchroom/vault-broker.sock");
+          brokerSocket = resolveBrokerSocketPath();
         }
 
         const brokerOpts = { socket: brokerSocket };

--- a/src/vault/broker/resolve-socket-path.test.ts
+++ b/src/vault/broker/resolve-socket-path.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Tests for `resolveBrokerSocketPath` — the canonical broker socket
+ * resolver shared by every broker client (CLI, secret-guard hook,
+ * boot-card probeBroker).
+ *
+ * The resolver's precedence order is documented at the top of
+ * `client.ts` and load-bearing for the multi-container deploy:
+ *
+ *   1. opts.socket      — explicit caller override
+ *   2. SWITCHROOM_VAULT_BROKER_SOCK env — set by compose into agents
+ *   3. opts.vaultBrokerSocket — config-derived path
+ *   4. ~/.switchroom/vault-broker.sock — legacy default
+ *
+ * Pre-fix the CLI (`src/cli/vault.ts`, `vault-broker.ts`,
+ * `vault-doctor.ts`, `vault-grant.ts`, `vault-auto-unlock.ts`) all
+ * skipped step 2 entirely and went straight from caller-override to
+ * config-or-legacy. Inside agent containers — where the env is set
+ * but the legacy path is a dangling symlink (#910) — that meant the
+ * CLI saw "broker not running" even when the broker was reachable
+ * via the canonical env path. The 2026-05-10 incident: clerk's
+ * calendar skill failing every `switchroom vault get` while the
+ * broker WAS reachable on `/run/switchroom/broker/sock` per the env
+ * var.
+ *
+ * These tests pin the precedence so a future refactor that drops the
+ * env step (or reorders it) breaks the test rather than the agent
+ * fleet.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { resolveBrokerSocketPath } from "./client.js";
+
+const ENV_KEY = "SWITCHROOM_VAULT_BROKER_SOCK";
+const LEGACY_DEFAULT = join(homedir(), ".switchroom", "vault-broker.sock");
+
+describe("resolveBrokerSocketPath", () => {
+  let savedEnv: string | undefined;
+
+  beforeEach(() => {
+    savedEnv = process.env[ENV_KEY];
+    delete process.env[ENV_KEY];
+  });
+
+  afterEach(() => {
+    if (savedEnv === undefined) delete process.env[ENV_KEY];
+    else process.env[ENV_KEY] = savedEnv;
+  });
+
+  it("opts.socket wins over everything else", () => {
+    process.env[ENV_KEY] = "/from-env";
+    const result = resolveBrokerSocketPath({
+      socket: "/from-opts",
+      vaultBrokerSocket: "/from-config",
+    });
+    expect(result).toBe("/from-opts");
+  });
+
+  it("env wins over config and legacy default (the regression fix)", () => {
+    // The 2026-05-10 incident's root cause was every CLI helper
+    // skipping this step. Pin it.
+    process.env[ENV_KEY] = "/run/switchroom/broker/sock";
+    const result = resolveBrokerSocketPath({
+      vaultBrokerSocket: "/from-config",
+    });
+    expect(result).toBe("/run/switchroom/broker/sock");
+  });
+
+  it("config wins over the legacy default when env is unset", () => {
+    const result = resolveBrokerSocketPath({
+      vaultBrokerSocket: "/from-config",
+    });
+    expect(result).toBe("/from-config");
+  });
+
+  it("falls back to ~/.switchroom/vault-broker.sock when nothing else is set", () => {
+    const result = resolveBrokerSocketPath();
+    expect(result).toBe(LEGACY_DEFAULT);
+  });
+
+  it("treats empty SWITCHROOM_VAULT_BROKER_SOCK env as unset", () => {
+    process.env[ENV_KEY] = "";
+    const result = resolveBrokerSocketPath({ vaultBrokerSocket: "/from-config" });
+    expect(result).toBe("/from-config");
+  });
+
+  it("undefined opts works (zero-arg call from CLI helpers)", () => {
+    process.env[ENV_KEY] = "/from-env";
+    const result = resolveBrokerSocketPath();
+    expect(result).toBe("/from-env");
+  });
+});


### PR DESCRIPTION
## The bug — v0.7.9 fixed half the problem

PR #947 / v0.7.9 fixed compose to emit `SWITCHROOM_VAULT_BROKER_SOCK` (canonical client-side env) into agent containers with the agent-perspective socket path. Verified the broker-client + secret-guard hook + boot-card probeBroker were all reading the right value.

But the **`switchroom vault` CLI subcommands** were a separate code path that I missed. Every one of them had its own manual broker socket resolution that **skipped the env entirely**:

```ts
// pre-fix shape, repeated across 5 CLI files
brokerSocket = resolvePath(config.vault?.broker?.socket ?? "~/.switchroom/vault-broker.sock");
```

Inside an agent container, `~/.switchroom/vault-broker.sock` is a dangling symlink (the host-symlink fix from #910 makes `~/.switchroom` point to the host home, which doesn't exist inside the container). So the CLI saw "broker not running" on every call — even when the broker was reachable on the canonical path.

## Operator surface

The screenshot from clerk earlier today: `switchroom vault get microsoft/ken-tokens` from clerk's calendar skill fails with `VAULT-BROKER-DENIED: broker not running`, even though direct broker IPC (`nc -U $SWITCHROOM_VAULT_BROKER_SOCK`) from the same container returns the MS Graph token cleanly. The skill never gets the token. Calendar items never get added.

## Fix

Five CLI files updated to use `resolveBrokerSocketPath()` from the broker client (the same resolver that secret-guard hook and boot-card probeBroker use):

- `src/cli/vault.ts` — vault get/list/put main surface
- `src/cli/vault-broker.ts` — broker management commands
- `src/cli/vault-doctor.ts` — vault doctor
- `src/cli/vault-grant.ts` — grant management
- `src/cli/vault-auto-unlock.ts` — auto-unlock setup

Each pre-fix branch did:

```ts
resolvePath(config.vault?.broker?.socket ?? "~/.switchroom/vault-broker.sock")
```

Post-fix:

```ts
resolveBrokerSocketPath({
  vaultBrokerSocket: config.vault?.broker?.socket
    ? resolvePath(config.vault.broker.socket)
    : undefined,
})
```

Honors the documented precedence: `opts.socket` → env → `opts.vaultBrokerSocket` → legacy default.

## Test plan

- [x] `npm run lint` clean
- [x] `npm test` — 5232/5232 vitest pass
- [x] **New** `src/vault/broker/resolve-socket-path.test.ts` — 6 cases pin the precedence: opts.socket wins; env wins over config; config wins over legacy; legacy as last-resort default; empty env treated as unset; zero-arg call works
- [x] Manual smoke (deferred until merge): from inside klanker, `switchroom vault get` should work via broker without the dangling-fallback fail. Will verify post-deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)