### PR TITLE
chore: release v0.7.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,53 @@
 # Changelog
 
+## v0.7.10 — `switchroom vault` CLI honors `SWITCHROOM_VAULT_BROKER_SOCK`
+
+Companion patch to v0.7.9. v0.7.9 fixed compose to emit
+`SWITCHROOM_VAULT_BROKER_SOCK` (canonical client-side env name) into
+agent containers, and verified the broker client + secret-guard hook
++ boot-card probe were all reading it. But the **`switchroom vault`
+CLI subcommands** had their own manual broker socket resolution that
+**skipped the env entirely** — going straight from
+`config.vault?.broker?.socket` to the legacy `~/.switchroom/vault-
+broker.sock` fallback (which is a dangling symlink inside an agent
+container, via the #910 home-symlink fix).
+
+Operator surface: clerk's calendar skill called `switchroom vault
+get microsoft/ken-tokens`, the CLI ignored the canonical env that
+v0.7.9 just set, fell through to the dangling fallback, and reported
+`VAULT-BROKER-DENIED: broker not running`. Direct broker IPC from
+the same container returned the token cleanly. The skill saw "no
+token" and refused to add the calendar item.
+
+**Fix (#949).** Five CLI files routed through the canonical
+`resolveBrokerSocketPath()` from `src/vault/broker/client.ts`:
+
+  - `src/cli/vault.ts` — vault get/list/put main surface
+  - `src/cli/vault-broker.ts` — broker management
+  - `src/cli/vault-doctor.ts` — vault doctor
+  - `src/cli/vault-grant.ts` — grant management
+  - `src/cli/vault-auto-unlock.ts` — auto-unlock setup
+
+Each pre-fix branch did `resolvePath(config?.vault?.broker?.socket
+?? "~/.switchroom/vault-broker.sock")`; post-fix uses
+`resolveBrokerSocketPath({ vaultBrokerSocket: ... })` which honors:
+
+  1. `opts.socket` (explicit caller override)
+  2. `SWITCHROOM_VAULT_BROKER_SOCK` env (compose-set; the regression
+     fix)
+  3. `opts.vaultBrokerSocket` (config-derived)
+  4. `~/.switchroom/vault-broker.sock` (legacy default)
+
+**Tests.** New `src/vault/broker/resolve-socket-path.test.ts` pins
+the precedence so a future refactor can't silently drop the env
+step again. 6 cases.
+
+**Operator impact.** Existing v0.7.9 fleets needed `switchroom
+update` to pick up the corrected compose env. v0.7.10's CLI fix
+takes effect inside agent containers automatically once the new
+agent image is pulled — the env is already in place from v0.7.9;
+this patch just makes the CLI read it.
+
 ## v0.7.9 — broker socket env: canonical name + agent-perspective path
 
 Single-fix patch release for a regression discovered during the

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "switchroom",
-  "version": "0.7.9",
+  "version": "0.7.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "switchroom",
-      "version": "0.7.9",
+      "version": "0.7.10",
       "license": "MIT",
       "workspaces": [
         "telegram-plugin"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "switchroom",
-  "version": "0.7.9",
+  "version": "0.7.10",
   "description": "Run Claude Code 24/7 on your Claude Pro/Max subscription over Telegram. Open-source alternative to OpenClaw and NanoClaw — no API keys.",
   "type": "module",
   "bin": {

--- a/src/build-info.ts
+++ b/src/build-info.ts
@@ -2,8 +2,8 @@
 // Tracked in git so `tsc --noEmit` works on a fresh clone before `npm run build`.
 // Values are refreshed every time `npm run build` runs.
 
-export const VERSION: string = "0.7.9";
-export const COMMIT_SHA: string | null = "bd11c4a6";
-export const COMMIT_DATE: string | null = "2026-05-10T21:18:55+10:00";
-export const LATEST_PR: number | null = 947;
+export const VERSION: string = "0.7.10";
+export const COMMIT_SHA: string | null = "1a092f93";
+export const COMMIT_DATE: string | null = "2026-05-10T22:15:33+10:00";
+export const LATEST_PR: number | null = 949;
 export const COMMITS_AHEAD_OF_TAG: number | null = 1;


### PR DESCRIPTION
## v0.7.10 — `switchroom vault` CLI honors `SWITCHROOM_VAULT_BROKER_SOCK`

Companion patch to v0.7.9. v0.7.9 fixed compose to emit the canonical client env name with the agent-perspective socket path, and the broker-client + secret-guard hook + boot-card probe all started reading it correctly. But the `switchroom vault` CLI subcommands had their own manual broker socket resolution that **skipped the env entirely**.

The bug fix landed in #949. This PR is just the version bump + CHANGELOG.

### Operator surface

Clerk's calendar skill (and any agent path that shells out to `switchroom vault get`) now successfully reads vault keys via the broker post-deploy. No more `VAULT-BROKER-DENIED: broker not running` while direct broker IPC works fine.

### Test plan

- [x] `npm run lint` clean
- [x] `npm test` (5232 vitest pass + 6 new precedence pins)
- [x] `package.json` + `package-lock.json` both at 0.7.10
- [x] `src/build-info.ts` auto-stamped to 0.7.10, COMMIT_SHA tracks 1a092f93 (PR #949 merge), LATEST_PR=949

🤖 Generated with [Claude Code](https://claude.com/claude-code)