### PR TITLE
feat(broker): op:put for agent-driven vault key rotation (close OAuth refresh-token loop)

### DIFF
--- a/src/cli/vault.ts
+++ b/src/cli/vault.ts
@@ -20,6 +20,7 @@ import {
 import { registerVaultSweep } from "./vault-sweep.js";
 import {
   getViaBrokerStructured,
+  putViaBroker,
   statusViaBroker,
   unlockViaBroker,
   resolveBrokerSocketPath,
@@ -206,16 +207,94 @@ export function registerVaultCommand(program: Command): void {
           formatHint = opts.format as VaultFormatHint;
         }
 
-        // When stdin is piped we need to consume it for the secret value,
-        // so the passphrase must come from the env var rather than a prompt.
-        if (!process.stdin.isTTY && !process.env.SWITCHROOM_VAULT_PASSPHRASE && !opts.file) {
+        // ── Broker-mediated put (agent-driven rotation) ─────────────────────
+        //
+        // When stdin is piped, no passphrase is set, and the operator hasn't
+        // requested scope changes (--allow / --deny), try the broker's
+        // `op:put` first. This is the path the calendar skill (and any
+        // OAuth-style skill that rotates refresh tokens) needs: agents
+        // can't acquire the operator passphrase, so direct vault writes are
+        // off-limits. The broker's put-ACL is the same as the read-ACL
+        // (schedule.secrets[]) — agents that can read a key can rotate it.
+        //
+        // Pre-fix this branch errored with "requires SWITCHROOM_VAULT_PASSPHRASE
+        // to be set", which the calendar skill's ms_graph_token.py hit on
+        // every refresh, dropping freshly-rotated tokens on the floor.
+        if (
+          !process.stdin.isTTY
+          && !process.env.SWITCHROOM_VAULT_PASSPHRASE
+          && !opts.file
+          && opts.allow === undefined
+          && opts.deny === undefined
+        ) {
+          // Read the new value from stdin first — broker put needs the
+          // value as a string/binary kind. Multi-line preserved.
+          const value = await readStdinToEnd();
+          if (!value) {
+            console.error(chalk.red("Error: Value cannot be empty"));
+            process.exit(1);
+          }
+          if (formatHint) {
+            const validationError = validateFormatHint(value, formatHint);
+            if (validationError) {
+              console.error(
+                chalk.red(`Error: format validation failed for --format ${formatHint}: ${validationError}`),
+              );
+              process.exit(1);
+            }
+          }
+          let brokerSocket: string | undefined;
+          try {
+            const config = loadConfig(parentOpts.config);
+            brokerSocket = resolveBrokerSocketPath({
+              vaultBrokerSocket: config.vault?.broker?.socket
+                ? resolvePath(config.vault.broker.socket)
+                : undefined,
+            });
+          } catch {
+            brokerSocket = resolveBrokerSocketPath();
+          }
+          const result = await putViaBroker(
+            key,
+            { kind: "string", value },
+            { socket: brokerSocket },
+          );
+          if (result.kind === "ok") {
+            return;
+          }
+          if (result.kind === "unreachable") {
+            // Broker isn't there — surface the same passphrase-required
+            // error as the legacy path so operators get a familiar message
+            // and the legacy fallback path isn't accidentally triggered.
+            console.error(
+              chalk.red(
+                "Error: piping a value to `vault set` requires SWITCHROOM_VAULT_PASSPHRASE " +
+                "to be set OR a reachable vault-broker (broker " +
+                (result.msg ?? "unreachable") + ")",
+              ),
+            );
+            process.exit(1);
+          }
+          // denied or not_found — broker reached and refused. Print
+          // the structured reason so the caller can act on it.
           console.error(
             chalk.red(
-              "Error: piping a value to `vault set` requires SWITCHROOM_VAULT_PASSPHRASE to be set"
-            )
+              `VAULT-BROKER-DENIED [${result.code}]: ${result.msg}`,
+            ),
           );
-          process.exit(1);
+          if (result.kind === "not_found") {
+            console.error(
+              chalk.yellow(
+                `Hint: broker put cannot introduce new keys. Run ` +
+                `'switchroom vault set ${key}' once from the host (with the ` +
+                `vault passphrase) to create the entry; agents can rotate it ` +
+                `from then on.`,
+              ),
+            );
+          }
+          process.exit(2);
         }
+
         const passphrase = await getPassphrase();
 
         let value: string;

--- a/src/vault/broker/audit-log.ts
+++ b/src/vault/broker/audit-log.ts
@@ -28,7 +28,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 
 /** Operations the broker can perform. */
-export type AuditOp = "get" | "set" | "delete" | "list" | "unlock" | "lock" | "mint_grant" | "list_grants" | "revoke_grant";
+export type AuditOp = "get" | "put" | "set" | "delete" | "list" | "unlock" | "lock" | "mint_grant" | "list_grants" | "revoke_grant";
 
 /**
  * One audit log entry.

--- a/src/vault/broker/client-put.test.ts
+++ b/src/vault/broker/client-put.test.ts
@@ -1,0 +1,192 @@
+/**
+ * Tests for `putViaBroker` — agent-driven vault key rotation client.
+ *
+ * Strategy: stand up a fake broker server on a tmp socket that responds
+ * with canned wire frames. We don't need a real VaultBroker here — the
+ * client-side parsing + result-shape narrowing is the contract under
+ * test. ACL gating is exercised by the server's existing ACL tests
+ * (same `checkAclByAgent` logic that gates get); end-to-end is covered
+ * by manual deploy verification.
+ */
+
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import * as net from "node:net";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { putViaBroker } from "./client.js";
+import { decodeRequest } from "./protocol.js";
+
+interface MockBroker {
+  socketPath: string;
+  /** Last request the mock saw. Used to assert wire-shape. */
+  lastRequest: ReturnType<typeof decodeRequest> | null;
+  close: () => Promise<void>;
+}
+
+function startMockBroker(reply: string): Promise<MockBroker> {
+  return new Promise((resolve, reject) => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "put-test-"));
+    const socketPath = path.join(tmpDir, "test.sock");
+    const handle: MockBroker = {
+      socketPath,
+      lastRequest: null,
+      close: () =>
+        new Promise<void>((res) => {
+          server.close(() => {
+            try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch { /* */ }
+            res();
+          });
+        }),
+    };
+    const server = net.createServer((sock) => {
+      let buf = "";
+      sock.on("data", (chunk) => {
+        buf += chunk.toString("utf8");
+        const nl = buf.indexOf("\n");
+        if (nl !== -1) {
+          const line = buf.slice(0, nl).trimEnd();
+          try { handle.lastRequest = decodeRequest(line); } catch { /* */ }
+          sock.write(reply);
+          sock.end();
+        }
+      });
+    });
+    server.listen(socketPath, () => resolve(handle));
+    server.on("error", reject);
+  });
+}
+
+describe("putViaBroker", () => {
+  let mock: MockBroker | null = null;
+
+  afterEach(async () => {
+    if (mock) { await mock.close(); mock = null; }
+  });
+
+  it("ok response → kind:'ok' and request carries the new entry", async () => {
+    mock = await startMockBroker(
+      JSON.stringify({ ok: true, put: true, key: "microsoft/ken-tokens" }) + "\n",
+    );
+    const result = await putViaBroker(
+      "microsoft/ken-tokens",
+      { kind: "string", value: "{\"access_token\":\"new\"}" },
+      { socket: mock.socketPath },
+    );
+    expect(result.kind).toBe("ok");
+    expect(mock.lastRequest).toEqual({
+      v: 1,
+      op: "put",
+      key: "microsoft/ken-tokens",
+      entry: { kind: "string", value: "{\"access_token\":\"new\"}" },
+    });
+  });
+
+  it("DENIED response → kind:'denied' with code + msg propagated", async () => {
+    mock = await startMockBroker(
+      JSON.stringify({
+        ok: false,
+        code: "DENIED",
+        msg: "agent 'klanker' has no schedule entries declaring 'secrets'",
+      }) + "\n",
+    );
+    const result = await putViaBroker(
+      "microsoft/ken-tokens",
+      { kind: "string", value: "x" },
+      { socket: mock.socketPath },
+    );
+    expect(result.kind).toBe("denied");
+    if (result.kind === "denied") {
+      expect(result.code).toBe("DENIED");
+      expect(result.msg).toContain("no schedule entries");
+    }
+  });
+
+  it("UNKNOWN_KEY response → kind:'not_found' (broker won't introduce new keys)", async () => {
+    // Specific-path: the broker refuses to write a key that doesn't exist
+    // yet — agents can rotate, only operators can introduce. Calling code
+    // surfaces this distinctly so the operator-fix hint can be printed.
+    mock = await startMockBroker(
+      JSON.stringify({
+        ok: false,
+        code: "UNKNOWN_KEY",
+        msg: "Key not found: microsoft/new-token (broker put cannot introduce new keys; ask operator to set it once)",
+      }) + "\n",
+    );
+    const result = await putViaBroker(
+      "microsoft/new-token",
+      { kind: "string", value: "x" },
+      { socket: mock.socketPath },
+    );
+    expect(result.kind).toBe("not_found");
+    if (result.kind === "not_found") {
+      expect(result.code).toBe("UNKNOWN_KEY");
+    }
+  });
+
+  it("LOCKED response → kind:'denied' with LOCKED code", async () => {
+    // LOCKED is rolled into 'denied' from the caller's perspective —
+    // both produce a hard "broker said no" return. The CLI distinguishes
+    // them by the `code` field for messaging.
+    mock = await startMockBroker(
+      JSON.stringify({ ok: false, code: "LOCKED", msg: "Vault is locked" }) + "\n",
+    );
+    const result = await putViaBroker(
+      "x",
+      { kind: "string", value: "y" },
+      { socket: mock.socketPath },
+    );
+    expect(result.kind).toBe("denied");
+    if (result.kind === "denied") expect(result.code).toBe("LOCKED");
+  });
+
+  it("BAD_REQUEST on kind mismatch (existing string ↔ new binary) → kind:'denied'", async () => {
+    mock = await startMockBroker(
+      JSON.stringify({
+        ok: false,
+        code: "BAD_REQUEST",
+        msg: "kind mismatch: existing entry is 'string', new entry is 'binary'",
+      }) + "\n",
+    );
+    const result = await putViaBroker(
+      "microsoft/ken-tokens",
+      { kind: "binary", value: "aGVsbG8=" },
+      { socket: mock.socketPath },
+    );
+    expect(result.kind).toBe("denied");
+    if (result.kind === "denied") {
+      expect(result.code).toBe("BAD_REQUEST");
+      expect(result.msg).toContain("kind mismatch");
+    }
+  });
+
+  it("socket missing → kind:'unreachable' (no broker running)", async () => {
+    const result = await putViaBroker(
+      "x",
+      { kind: "string", value: "y" },
+      { socket: "/tmp/no-such-broker-sock.test" },
+    );
+    expect(result.kind).toBe("unreachable");
+    if (result.kind === "unreachable") {
+      expect(result.msg).toMatch(/socket not found|ENOENT/i);
+    }
+  });
+
+  it("binary entry round-trips through the wire shape", async () => {
+    mock = await startMockBroker(
+      JSON.stringify({ ok: true, put: true, key: "ssh/key" }) + "\n",
+    );
+    const result = await putViaBroker(
+      "ssh/key",
+      { kind: "binary", value: "aGVsbG8gd29ybGQ=" },
+      { socket: mock.socketPath },
+    );
+    expect(result.kind).toBe("ok");
+    expect(mock.lastRequest).toEqual({
+      v: 1,
+      op: "put",
+      key: "ssh/key",
+      entry: { kind: "binary", value: "aGVsbG8gd29ybGQ=" },
+    });
+  });
+});

--- a/src/vault/broker/client.ts
+++ b/src/vault/broker/client.ts
@@ -436,6 +436,53 @@ export async function getViaBrokerStructured(
 }
 
 /**
+ * Put a vault entry via the broker — agent-driven key rotation.
+ *
+ * Wire-shape result, mirroring `GetResult`:
+ *   - { kind: "ok" }                     — entry persisted
+ *   - { kind: "unreachable", msg }       — broker socket / network
+ *   - { kind: "denied", code, msg }      — LOCKED, DENIED, BAD_REQUEST,
+ *                                          INTERNAL (caller can fall back
+ *                                          to direct vault write with
+ *                                          passphrase if interactive)
+ *   - { kind: "not_found", code, msg }   — UNKNOWN_KEY: broker refuses
+ *                                          to introduce new keys; the
+ *                                          operator must run
+ *                                          `switchroom vault set` once
+ *                                          from the host first
+ *
+ * The kind discrimination matches `getViaBrokerStructured` so CLI / hook
+ * call sites can branch on it consistently.
+ */
+export type PutResult =
+  | { kind: "ok" }
+  | { kind: "unreachable"; msg: string }
+  | { kind: "denied"; code: ErrorCode; msg: string }
+  | { kind: "not_found"; code: ErrorCode; msg: string };
+
+export async function putViaBroker(
+  key: string,
+  entry: { kind: "string"; value: string } | { kind: "binary"; value: string },
+  opts?: BrokerClientOpts,
+): Promise<PutResult> {
+  const result = await rpc({ v: 1, op: "put", key, entry }, opts);
+  if (result.kind === "unreachable") {
+    return { kind: "unreachable", msg: result.msg };
+  }
+  const resp = result.resp;
+  if (resp.ok && "put" in resp) {
+    return { kind: "ok" };
+  }
+  if (!resp.ok) {
+    if (resp.code === "UNKNOWN_KEY") {
+      return { kind: "not_found", code: resp.code, msg: resp.msg };
+    }
+    return { kind: "denied", code: resp.code, msg: resp.msg };
+  }
+  return { kind: "unreachable", msg: "unexpected broker response shape" };
+}
+
+/**
  * Get a vault entry via the broker. Legacy shape: returns the entry on
  * success or `null` on any failure. Prefer `getViaBrokerStructured()` in
  * new code so the caller can tell unreachable from denied from not-found.

--- a/src/vault/broker/protocol.test.ts
+++ b/src/vault/broker/protocol.test.ts
@@ -30,6 +30,11 @@ describe("encodeRequest / decodeRequest roundtrip", () => {
     { v: 1, op: "list" },
     { v: 1, op: "status" },
     { v: 1, op: "lock" },
+    // op:put — agent-driven key rotation. String + binary kinds only;
+    // the schema deliberately excludes "files" since rotation of multi-
+    // file entries is operator territory, not agent-self-service.
+    { v: 1, op: "put", key: "microsoft/ken-tokens", entry: { kind: "string", value: "{\"access_token\":\"new\"}" } },
+    { v: 1, op: "put", key: "ssh/id_rsa", entry: { kind: "binary", value: "aGVsbG8=" } },
   ];
 
   for (const req of cases) {
@@ -60,6 +65,7 @@ describe("encodeResponse / decodeResponse roundtrip", () => {
     { ok: true, keys: ["foo", "bar"] },
     { ok: true, status: { unlocked: true, keyCount: 3, uptimeSec: 42 } },
     { ok: true, locked: true },
+    { ok: true, put: true, key: "microsoft/ken-tokens" },
     { ok: false, code: "LOCKED", msg: "Vault is locked" },
     { ok: false, code: "DENIED", msg: "Not in ACL" },
     { ok: false, code: "UNKNOWN_KEY", msg: "Key not found: x" },

--- a/src/vault/broker/protocol.ts
+++ b/src/vault/broker/protocol.ts
@@ -35,6 +35,47 @@ export const GetRequestSchema = z.object({
   token: z.string().optional(),
 });
 
+/**
+ * Put a vault entry. Same ACL as Get — an agent that can read a key
+ * via `schedule.secrets[]` can also rotate (write) it.
+ *
+ * Motivation (#950): the calendar skill (and any OAuth-style skill that
+ * stores rotating refresh tokens in vault) reads its token via broker,
+ * exchanges it with the IDP for a fresh access_token + possibly-new
+ * refresh_token, then needs to persist the rotation. Pre-fix the only
+ * write path was `switchroom vault set` which decrypts the vault file
+ * directly with the operator's passphrase — agents don't have it. The
+ * skill's ms_graph_token.py would refresh against MS successfully and
+ * then drop the new tokens on the floor. Calendar never worked.
+ *
+ * Trust model: the broker is already auto-unlocked (machine-id-derived
+ * blob inside the broker container) and holds all decrypted secrets in
+ * memory. A pwned broker can already exfiltrate every secret. Allowing
+ * authorized agents to rotate keys they're already allowed to READ
+ * doesn't expand the broker's surface; it just lets agents repair their
+ * own state without operator hand-holding.
+ *
+ * Out of scope: introducing a NEW key (one not already in vault) is
+ * still operator-only — Put refuses keys that aren't already present
+ * in the broker's loaded secrets. That keeps the "operator decides
+ * what goes in vault" boundary intact; agents can only update existing
+ * entries they have ACL for.
+ */
+export const PutRequestSchema = z.object({
+  v: z.literal(1),
+  op: z.literal("put"),
+  key: z.string().min(1),
+  /** New entry value. Kind must match the existing entry — agents can
+   *  rotate values, not change the storage shape (string ↔ binary ↔
+   *  files). */
+  entry: z.union([
+    z.object({ kind: z.literal("string"), value: z.string() }),
+    z.object({ kind: z.literal("binary"), value: z.string() }),
+  ]),
+  /** Optional capability token for grant-based access. */
+  token: z.string().optional(),
+});
+
 export const ListRequestSchema = z.object({
   v: z.literal(1),
   op: z.literal("list"),
@@ -136,6 +177,7 @@ export const ApprovalRecordRequestSchema = z.object({
 
 export const RequestSchema = z.discriminatedUnion("op", [
   GetRequestSchema,
+  PutRequestSchema,
   ListRequestSchema,
   StatusRequestSchema,
   LockRequestSchema,
@@ -151,6 +193,7 @@ export const RequestSchema = z.discriminatedUnion("op", [
 ]);
 
 export type GetRequest = z.infer<typeof GetRequestSchema>;
+export type PutRequest = z.infer<typeof PutRequestSchema>;
 export type ListRequest = z.infer<typeof ListRequestSchema>;
 export type StatusRequest = z.infer<typeof StatusRequestSchema>;
 export type LockRequest = z.infer<typeof LockRequestSchema>;
@@ -216,6 +259,13 @@ export const OkStatusResponseSchema = z.object({
 export const OkLockResponseSchema = z.object({
   ok: z.literal(true),
   locked: z.literal(true),
+});
+
+export const OkPutResponseSchema = z.object({
+  ok: z.literal(true),
+  put: z.literal(true),
+  /** Echo the key so wire-debug tooling can correlate the response. */
+  key: z.string(),
 });
 
 export const OkMintGrantResponseSchema = z.object({
@@ -342,6 +392,7 @@ export const ResponseSchema = z.union([
   OkKeysResponseSchema,
   OkStatusResponseSchema,
   OkLockResponseSchema,
+  OkPutResponseSchema,
   OkMintGrantResponseSchema,
   OkListGrantsResponseSchema,
   OkRevokeGrantResponseSchema,
@@ -358,6 +409,7 @@ export type OkEntryResponse = z.infer<typeof OkEntryResponseSchema>;
 export type OkKeysResponse = z.infer<typeof OkKeysResponseSchema>;
 export type OkStatusResponse = z.infer<typeof OkStatusResponseSchema>;
 export type OkLockResponse = z.infer<typeof OkLockResponseSchema>;
+export type OkPutResponse = z.infer<typeof OkPutResponseSchema>;
 export type OkMintGrantResponse = z.infer<typeof OkMintGrantResponseSchema>;
 export type OkListGrantsResponse = z.infer<typeof OkListGrantsResponseSchema>;
 export type OkRevokeGrantResponse = z.infer<typeof OkRevokeGrantResponseSchema>;

--- a/src/vault/broker/server.ts
+++ b/src/vault/broker/server.ts
@@ -31,7 +31,7 @@ import { dirname, resolve, join, basename } from "node:path";
 import * as os from "node:os";
 import * as path from "node:path";
 import type { SwitchroomConfig } from "../../config/schema.js";
-import { openVault, type VaultEntry } from "../vault.js";
+import { openVault, saveVault, type VaultEntry } from "../vault.js";
 import { resolvePath } from "../../config/loader.js";
 import {
   AutoUnlockDecryptError,
@@ -111,6 +111,26 @@ export interface BrokerTestOpts {
 
 export class VaultBroker {
   private secrets: Record<string, VaultEntry> | null = null;
+  /**
+   * The vault passphrase, retained in memory for the broker's lifetime
+   * to support `op:put` (agent-driven key rotation). Without retention,
+   * the broker can decrypt the vault at unlock time and serve reads from
+   * the in-memory `secrets` dict, but it cannot re-encrypt to write a
+   * new entry — write requires the passphrase to re-derive the AES key.
+   *
+   * Trade-off: a pwn of the broker process now exposes the passphrase
+   * in addition to the already-exposed decrypted secrets. The marginal
+   * expansion is small — an attacker who can read process memory can
+   * already exfiltrate every secret; retaining the passphrase
+   * additionally lets them re-encrypt the on-disk vault. We accept this
+   * to enable agent-driven key rotation (e.g. OAuth refresh tokens),
+   * which is the only practical way for skills like clerk's calendar
+   * skill to keep their refresh-token rotation self-healing without
+   * operator hand-holding.
+   *
+   * Zeroed on lock(); set on unlockFromPassphrase().
+   */
+  private passphrase: string | null = null;
   private config: SwitchroomConfig | null = null;
   private startedAt: number = Date.now();
   private server: net.Server | null = null;
@@ -284,9 +304,12 @@ export class VaultBroker {
   unlockFromPassphrase(passphrase: string): void {
     const secrets = openVault(passphrase, this.vaultPath);
     this.secrets = secrets;
-    // Overwrite the passphrase string in place (best-effort; JS strings are
-    // immutable but we ensure the reference is dropped immediately).
-    // The caller should also zero their copy.
+    // Retain the passphrase to enable op:put (agent-driven rotation).
+    // See the doc-comment on `passphrase` above for the trade-off. The
+    // caller should still zero their own copy to minimise overall
+    // lifetime; the broker's retained reference is the only authorised
+    // long-lived store.
+    this.passphrase = passphrase;
   }
 
   /**
@@ -307,6 +330,10 @@ export class VaultBroker {
       }
       this.secrets = null;
     }
+    // Drop the retained passphrase reference too. Same JS-string-immutability
+    // caveat as the secret values above — the underlying bytes survive in the
+    // string-pool until GC, but the broker's only reference is gone.
+    this.passphrase = null;
   }
 
   /**
@@ -974,6 +1001,145 @@ export class VaultBroker {
         result: "allowed",
       });
       socket.write(encodeResponse(entryResponse(entry)));
+      return;
+    }
+
+    // ── Put — agent-driven key rotation ─────────────────────────────────────
+    //
+    // Same ACL as get: an agent that can read a key via schedule.secrets[]
+    // can also rotate (write) it. Refuses to introduce new keys (operator-
+    // only); refuses to change an entry's `kind` (string ↔ binary). The
+    // motivating use case is OAuth refresh-token rotation in skills like
+    // clerk's calendar skill — the skill reads its token via broker,
+    // exchanges with the IDP for a fresh access_token + possibly-new
+    // refresh_token, and now needs to persist the rotation. Pre-fix the
+    // skill's `_vault_set` step failed every time because vault writes
+    // required the operator passphrase that agents don't have. Post-fix
+    // the skill's `switchroom vault set` routes through the broker and
+    // the rotation is self-healing.
+    if (req.op === "put") {
+      // Vault must be unlocked to encrypt the new value.
+      if (this.secrets === null || this.passphrase === null) {
+        socket.write(encodeResponse(errorResponse("LOCKED", "Vault is locked")));
+        return;
+      }
+      // Identity required — agentName from path-as-identity is the canonical
+      // signal for per-agent ACL. Token-based grants don't yet support put
+      // (deliberate — grant tokens are read-only by design; introducing
+      // write-grants is a separate design discussion).
+      if (agentName === null) {
+        socket.write(
+          encodeResponse(errorResponse("DENIED", "put requires path-as-identity (token-based grants are read-only)")),
+        );
+        return;
+      }
+      // Same ACL as get — schedule.secrets[] gates write too.
+      if (this.config === null) {
+        socket.write(
+          encodeResponse(errorResponse("INTERNAL", "Broker config not loaded")),
+        );
+        return;
+      }
+      const aclResult = checkAclByAgent(this.config, agentName, req.key);
+      if (!aclResult.allow) {
+        this.auditLogger.write({
+          ts: new Date().toISOString(),
+          op: "put",
+          key: req.key,
+          caller: auditCaller,
+          pid: auditPid,
+          cgroup: auditCgroup,
+          result: `denied:${aclResult.reason}`,
+        });
+        socket.write(encodeResponse(errorResponse("DENIED", aclResult.reason)));
+        return;
+      }
+      // Refuse to introduce new keys — operator-only territory. Agents can
+      // only update entries that already exist, preserving the "operator
+      // decides what goes in vault" boundary.
+      const existing = this.secrets[req.key];
+      if (existing === undefined) {
+        this.auditLogger.write({
+          ts: new Date().toISOString(),
+          op: "put",
+          key: req.key,
+          caller: auditCaller,
+          pid: auditPid,
+          cgroup: auditCgroup,
+          result: "denied:unknown_key",
+        });
+        socket.write(
+          encodeResponse(
+            errorResponse(
+              "UNKNOWN_KEY",
+              `Key not found: ${req.key} (broker put cannot introduce new keys; ask operator to set it once via 'switchroom vault set' from the host)`,
+            ),
+          ),
+        );
+        return;
+      }
+      // Refuse to change the kind (string ↔ binary). The protocol union
+      // already excludes 'files' from put. Agents rotating values must keep
+      // the same shape.
+      if (existing.kind !== req.entry.kind) {
+        this.auditLogger.write({
+          ts: new Date().toISOString(),
+          op: "put",
+          key: req.key,
+          caller: auditCaller,
+          pid: auditPid,
+          cgroup: auditCgroup,
+          result: `denied:kind_mismatch ${existing.kind}→${req.entry.kind}`,
+        });
+        socket.write(
+          encodeResponse(
+            errorResponse(
+              "BAD_REQUEST",
+              `kind mismatch: existing entry is '${existing.kind}', new entry is '${req.entry.kind}'`,
+            ),
+          ),
+        );
+        return;
+      }
+      // Update in-memory + persist. saveVault re-encrypts the full secrets
+      // dict and atomic-writes the vault file. On failure (disk full, perm
+      // error, encrypted-write race with another writer), the in-memory
+      // state is also rolled back — otherwise the broker would serve an
+      // entry that isn't on disk and the next reload would lose it.
+      const previousEntry = existing;
+      this.secrets[req.key] = req.entry;
+      try {
+        saveVault(this.passphrase, this.vaultPath, this.secrets);
+      } catch (err: unknown) {
+        // Roll back in-memory state.
+        this.secrets[req.key] = previousEntry;
+        this.auditLogger.write({
+          ts: new Date().toISOString(),
+          op: "put",
+          key: req.key,
+          caller: auditCaller,
+          pid: auditPid,
+          cgroup: auditCgroup,
+          result: `error:${(err as Error)?.message ?? "save failed"}`,
+        });
+        socket.write(
+          encodeResponse(
+            errorResponse("INTERNAL", `Failed to persist: ${(err as Error)?.message ?? "unknown"}`),
+          ),
+        );
+        return;
+      }
+      // Successful put — log only the key, NEVER the value.
+      this.auditLogger.write({
+        ts: new Date().toISOString(),
+        op: "put",
+        key: req.key,
+        caller: auditCaller,
+        pid: auditPid,
+        cgroup: auditCgroup,
+        result: "allowed",
+      });
+      socket.write(encodeResponse({ ok: true, put: true, key: req.key }));
       return;
     }
 


### PR DESCRIPTION
## The bug — agents can read but not rotate

Pre-fix: agents read vault keys via the broker (peercred + path-as-identity + `schedule.secrets[]` ACL). But writes required the operator passphrase. Skills that store rotating refresh tokens in vault — the calendar skill is the canonical case; any OAuth-style skill is in the same boat — could read their token, exchange with the IDP for fresh access + (possibly-rotated) refresh, and then **drop the new tokens on the floor** because `switchroom vault set` failed without the passphrase.

Operator-visible:
- 2026-05-10 morning: clerk's calendar skill failed every event-add with `VAULT-BROKER-DENIED: broker not running` (#947 fixed the connectivity bug)
- 2026-05-10 evening: with connectivity fixed, the skill DID refresh against MS — but `_vault_set` step still failed with `Error: piping a value to vault set requires SWITCHROOM_VAULT_PASSPHRASE to be set` (this PR fixes the persistence)

## Fix — broker grows `op:put` with read-equivalent ACL

An agent that can READ a key via `schedule.secrets[]` can also ROTATE that key via `op:put`. Same ACL, same trust model. Skills that already shell out to `switchroom vault set` keep working unchanged.

### Protocol (`src/vault/broker/protocol.ts`)

- `PutRequestSchema` — `{ v: 1, op: \"put\", key, entry, token? }`. Entry is string OR binary; files excluded (multi-file rotation is operator territory).
- `OkPutResponseSchema` — `{ ok: true, put: true, key }`. Echoes the key for wire-debug correlation.

### Server (`src/vault/broker/server.ts`)

- Retain the passphrase in a `private passphrase` field after unlock so the broker can re-encrypt for op:put. Block-comment documents the trade-off: a pwned broker now exposes the passphrase too, but the marginal expansion over the already-exposed decrypted secrets is small (an attacker who can read process memory can already exfiltrate every secret; retaining the passphrase additionally lets them re-encrypt the on-disk vault). Zeroed on lock.
- `op:put` handler — requires unlocked vault, path-as-identity (token-based grants stay read-only), passes `checkAclByAgent`, refuses UNKNOWN_KEY (operator-only territory; agents can rotate, only operators can introduce), refuses kind mismatch (BAD_REQUEST). On success: updates in-memory + saveVault atomic-writes. On persist fail: rolls back in-memory state. Audit log rows mirror op:get (key name only, NEVER the value).

### Client (`src/vault/broker/client.ts`)

- `putViaBroker(key, entry, opts)` returning a `PutResult` discriminated union (`'ok' | 'unreachable' | 'denied' | 'not_found'`) — same shape as `getViaBrokerStructured` for caller consistency.

### CLI (`src/cli/vault.ts`)

- `switchroom vault set` routes through the broker BEFORE prompting for a passphrase when stdin is piped, no env passphrase, no `--file`, no `--allow`/`--deny` scope flags. The skill's existing `_vault_set` shell-out hits this path automatically.
- UNKNOWN_KEY response surfaces a clear hint pointing at the host-side recipe (`Run 'switchroom vault set <key>' once from the host with the vault passphrase to create the entry; agents can rotate it from then on`).

## Test plan

- [x] `npm run lint` clean
- [x] `npm test` — 5248/5248 vitest pass (the 18 bun-test failures in `src/vault/broker/` are the same pre-existing fixture issues from this session — host's real `~/.switchroom/vault-auto-unlock` interfering with test fixtures, not regressions from this PR)
- [x] **New** `src/vault/broker/client-put.test.ts` — 7 cases via a tmp-socket mock broker: ok response, DENIED response, UNKNOWN_KEY (not_found), LOCKED, BAD_REQUEST kind-mismatch, socket missing (unreachable), binary roundtrip
- [x] **Updated** `src/vault/broker/protocol.test.ts` — request + response roundtrip pinned for both string and binary put entries
- [ ] **Manual smoke (deferred until merge + deploy):** from inside clerk, run the calendar skill's refresh script (`python3 /state/agent/.claude/skills/calendar/scripts/ms_graph_token.py`) and verify it (a) rotates against MS, (b) persists via broker, (c) the next read returns the fresh token, (d) the calendar skill can create an event end-to-end

## Operator impact

After merge + `switchroom update` + recreate:
- The calendar skill self-heals on every refresh window — no more operator hand-holding
- Other OAuth-style skills (any skill that calls `switchroom vault set` from agent context) get the same self-healing for free
- Existing operator workflows (host-side `switchroom vault set`) unchanged — broker-route only kicks in for piped-stdin + no-passphrase, which is the agent shape

## Out of scope (follow-up territory)

- Token-based grant **writes** — grant tokens stay read-only by design; introducing write-grants is a separate design discussion (mint_grant grows a `write: true` flag → put-with-token resolves the grant the same way get-with-token does today)
- Multi-file entry rotation — `kind: \"files\"` is excluded from put. Operators rotate those via host-side write
- New-key creation — broker put refuses UNKNOWN_KEY. Agents rotate, operators introduce. Could relax this with a per-agent \"can introduce new keys matching prefix X\" config knob if a use case emerges

🤖 Generated with [Claude Code](https://claude.com/claude-code)