### PR TITLE
feat(docker): pre-install Playwright + chromium in agent image

### DIFF
--- a/docker/Dockerfile.agent
+++ b/docker/Dockerfile.agent
@@ -85,6 +85,34 @@ RUN npm init -y >/dev/null \
  && npm install --omit=dev --build-from-source=false node-cron@^3.0.3
 WORKDIR /
 
+# Playwright — pre-baked for skills that use browser automation
+# (calendar / scrape / UI-test). Pre-this-bake, agents called
+# \`npx playwright\` which triggered an on-demand download of the
+# browser binaries into \`~/.cache/ms-playwright/\` per agent on
+# first call (~30s latency, plus N copies of ~150MB browsers across
+# the fleet). Baking it in:
+#
+#   - First call latency ~0s
+#   - One shared browser cache in image layer, not N per-agent caches
+#   - Version pin via image build, no per-agent npm @latest drift
+#
+# Major-version pin: the npm install resolves to the latest 1.x at
+# image build time; CI re-builds the image when a new patch lands.
+# Bumping the major requires CI to re-run \`playwright install
+# --with-deps\` in case browser-binary versions changed.
+#
+# \`--with-deps chromium\` installs the apt packages chromium needs
+# at runtime (libnss3, libatk1.0-0, libcups2 etc.). Firefox / Webkit
+# can be added per-agent via \`npx playwright install <browser>\`
+# without re-baking; chromium is the default because most skills
+# use it.
+#
+# Browser binaries land at \$PLAYWRIGHT_BROWSERS_PATH (image layer,
+# OS-independent) instead of \$HOME/.cache/.
+ENV PLAYWRIGHT_BROWSERS_PATH=/opt/playwright/browsers
+RUN npm install -g playwright@^1.49.0 \
+ && npx playwright install --with-deps chromium
+
 # tini handles zombies + signal forwarding. The actual command is
 # /state/agent/start.sh, which the scaffold renders into the bind-mount.
 ENTRYPOINT ["/usr/bin/tini", "--"]


### PR DESCRIPTION
## Why

Skills that use browser automation (calendar, scrape, UI-test) call `npx playwright`. Pre-this-bake, the first call from any agent triggered an on-demand download of the chromium binary into `~/.cache/ms-playwright/` — ~30s latency on first call, plus a copy of ~150MB browser binaries per agent (`$AGENTS × 150MB` across the fleet's home dirs).

Pre-baking moves the cost to image-build time and shares the cache across the fleet via a single image layer. Side benefit: pinning to `playwright@^1.49.0` in CI gives consistent browser version across all agents on a release; pre-bake, each agent's first call resolved `@latest` independently.

## Implementation

- `PLAYWRIGHT_BROWSERS_PATH=/opt/playwright/browsers` so the cache is in an image layer, not in per-agent HOME bind-mounts.
- `npx playwright install --with-deps chromium` pulls the apt packages chromium needs at runtime (libnss3, libatk1.0-0, libcups2 etc).
- Major-version pin (`1.x`); CI rebuilds the image whenever the package or browser binary changes.

Operators wanting Firefox / Webkit can `npx playwright install <browser>` from inside an agent — chromium is just the bake-in default.

## Test plan

- [x] `Dockerfile.agent` lints / builds in the dev path (manual: `docker build -f docker/Dockerfile.agent .` succeeds locally given a fresh base)
- [ ] CI build-dependents (agent) job: must pass with the new `RUN` layer
- [ ] Manual smoke (post-merge + post-update): from inside an agent, `npx playwright --version` returns immediately (no download), `npx playwright open https://example.com` (in headless mode) renders without an apt fault

## Out of scope

- Skills that need Firefox or Webkit by default — operators can install them per-agent without a Dockerfile change
- Replacing operator-managed browser caches in `~/.cache/ms-playwright/` — those are now redundant with the image cache; cleanup runbook can ride in a follow-up doc PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)