### PR TITLE
chore: release v0.7.12

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "switchroom",
-  "version": "0.7.11",
+  "version": "0.7.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "switchroom",
-      "version": "0.7.11",
+      "version": "0.7.12",
       "license": "MIT",
       "workspaces": [
         "telegram-plugin"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "switchroom",
-  "version": "0.7.11",
+  "version": "0.7.12",
   "description": "Run Claude Code 24/7 on your Claude Pro/Max subscription over Telegram. Open-source alternative to OpenClaw and NanoClaw — no API keys.",
   "type": "module",
   "bin": {

--- a/src/build-info.ts
+++ b/src/build-info.ts
@@ -2,8 +2,8 @@
 // Tracked in git so `tsc --noEmit` works on a fresh clone before `npm run build`.
 // Values are refreshed every time `npm run build` runs.
 
-export const VERSION: string = "0.7.11";
-export const COMMIT_SHA: string | null = "27b38d37";
-export const COMMIT_DATE: string | null = "2026-05-10T23:39:11+10:00";
-export const LATEST_PR: number | null = 952;
+export const VERSION: string = "0.7.12";
+export const COMMIT_SHA: string | null = "f02f526c";
+export const COMMIT_DATE: string | null = "2026-05-11T04:23:13+10:00";
+export const LATEST_PR: number | null = 955;
 export const COMMITS_AHEAD_OF_TAG: number | null = 1;


### PR DESCRIPTION
## v0.7.12 — vault layout: dir-mount + atomic-rename + flock

The big one. Closes the EBUSY-on-rotation regression that's been blocking calendar (and any OAuth-shaped skill) all session. CHANGELOG entry already written in the underlying #955 — this PR is the version-bump.

### Closes

- **#951** asks 1 + 3 (write-capable broker path + auto-refresh-on-stale)
- **#952** end-to-end deployment (was DOA pre-this-release; #952 was the broker op:put feature)
- **#954** EBUSY-loop RCA (root cause: cross-fs single-file bind-mount)

### Test plan

- [x] `npm run lint` clean
- [x] `npm test` 5271 vitest pass + 5 broker drift-detection (bun) + 6 saveVault flock + 16 migration-helper tests
- [x] package.json + package-lock.json at 0.7.12
- [x] src/build-info.ts auto-stamped to 0.7.12, COMMIT_SHA tracks f02f526c (PR #955 merge)
- [x] State-E recovery message byte-for-byte fixture pinned in tests

### Migration story (also in CHANGELOG)

After `switchroom update` lands this:
- State A/D = no-op
- State B/C = silent auto-resolve
- State E = fatal with literal recovery recipe (rare)
- Backup tools that don't follow symlinks: update path to `~/.switchroom/vault/vault.enc` OR pass `--copy-links`/`-L`

🤖 Generated with [Claude Code](https://claude.com/claude-code)