### PR TITLE
fix(vault): v0.7.12 deploy hotfix — DAC_OVERRIDE + correct vault-dir guard path

### DIFF
--- a/src/agents/compose.ts
+++ b/src/agents/compose.ts
@@ -349,12 +349,24 @@ export function generateCompose(opts: ComposeGeneratorOptions): string {
   //    boots, hits "Permission denied" on `/state/vault-auto-unlock`,
   //    logs `auto-unlock decrypt failed (io)`, and falls back to
   //    interactive unlock — i.e. auto-unlock is silently broken under
-  //    docker. Read-only is enough; we don't need DAC_OVERRIDE which
-  //    would also bypass write checks.
+  //    docker.
+  //  - DAC_OVERRIDE: bypass DAC checks for WRITE access to the vault
+  //    dir (post-v0.7.12 op:put rotation). Without it, broker can
+  //    READ the operator-owned vault dir (DAC_READ_SEARCH) but
+  //    rejects mkdir/write into it because the host dir is mode 0700
+  //    owned by the operator UID and the broker's container-root UID
+  //    isn't recognized as the owner. Caught when self-deploying
+  //    v0.7.12 against the operator's fleet: ms_graph_token.py
+  //    succeeded reading the token but EACCES'd on writing the
+  //    rotated value via `op:put`. The cap is consistent with the
+  //    broker's existing trust posture (it already holds the
+  //    passphrase + decrypted secrets in memory; allowing write is
+  //    not an expansion of access, just of operations).
   lines.push(`    cap_add:`);
   lines.push(`      - "CHOWN"`);
   lines.push(`      - "FOWNER"`);
   lines.push(`      - "DAC_READ_SEARCH"`);
+  lines.push(`      - "DAC_OVERRIDE"`);
   lines.push(`    environment:`);
   if (switchroomConfigPath) {
     lines.push(`      SWITCHROOM_CONFIG: /state/config/switchroom.yaml`);

--- a/src/cli/apply.ts
+++ b/src/cli/apply.ts
@@ -488,7 +488,19 @@ export async function runApply(
   // KNOWN_VAULT_ARTIFACT_NAMES + KNOWN_VAULT_ARTIFACT_PATTERNS in
   // src/vault/vault.ts so future write artifacts are picked up
   // without editing two places.
-  const vaultDir = customVaultPath
+  //
+  // Path derivation: the dir we're about to BIND-MOUNT is always the
+  // POST-MIGRATION canonical parent (`~/.switchroom/vault/`) for
+  // default-config operators. Custom-path operators (where migration
+  // was skipped) use `dirname(customVaultPath)`. Pre-fix this used
+  // `dirname(customVaultPath)` unconditionally, which for the legacy
+  // configured path `~/.switchroom/vault.enc` resolved to
+  // `~/.switchroom/` (parent of the legacy file, not the new mount
+  // target). Caught when self-deploying v0.7.12 against the operator's
+  // own ~/.switchroom which has many sibling dirs (approvals/, logs/,
+  // etc.) that legitimately don't belong in the vault dir.
+  const isCustomPath = migrationResult.kind === "custom-path-skipped";
+  const vaultDir = isCustomPath && customVaultPath
     ? dirname(customVaultPath)
     : join(homedir(), ".switchroom", "vault");
   if (existsSync(vaultDir)) {

--- a/tests/docker/compose-generator.test.ts
+++ b/tests/docker/compose-generator.test.ts
@@ -447,6 +447,19 @@ describe("generateCompose", () => {
     expect(block).toContain("DAC_READ_SEARCH");
   });
 
+  it("broker adds DAC_OVERRIDE so op:put can write to the host-owned vault dir (v0.7.13)", () => {
+    // Without this cap, broker can READ the vault dir (DAC_READ_SEARCH)
+    // but rejects mkdir + write into it. Surfaced post-v0.7.12 deploy
+    // as `EACCES: permission denied, mkdir '/state/vault/vault.enc.lock'`
+    // when ms_graph_token.py's broker put attempted the saveVault flock
+    // sentinel-dir. The host vault dir is mode 0700 owned by the
+    // operator UID; broker runs as container-root which doesn't bypass
+    // perms under cap_drop ALL without DAC_OVERRIDE.
+    const out = generateCompose({ config: makeConfig({ a: {} }) });
+    const block = /vault-broker:[\s\S]*?(?=\n  [a-z])/.exec(out)?.[0] ?? "";
+    expect(block).toContain("DAC_OVERRIDE");
+  });
+
   it("broker mounts /etc/machine-id so auto-unlock key derivation matches host (v0.7.4)", () => {
     // The auto-unlock blob is sealed with an AES key derived from the
     // host's /etc/machine-id. Without passing it through, the broker


### PR DESCRIPTION
## Two bugs caught when self-deploying v0.7.12 against the operator's fleet

### Bug 1 — vault-dir contents guard scanned the wrong directory

`apply.ts` used `dirname(customVaultPath)` to derive the dir to scan against `KNOWN_VAULT_ARTIFACT_NAMES`. For operators whose configured `vault.path` was the legacy `~/.switchroom/vault.enc`, `customVaultPath` resolved to that path, so `dirname` returned `~/.switchroom` — the parent of the LEGACY file, NOT the new bind-mount target.

The operator's actual `~/.switchroom/` contains many sibling dirs (`approvals/`, `web-token/`, `worktrees/`, `vault-grants.db-wal`, `switchroom.yaml.bak.2026-04-20`, `.env.vault`, etc.) and the guard correctly refused to mount because none of those are in the artifact whitelist.

**Fix:** only use `dirname(customVaultPath)` for genuinely custom paths (state `custom-path-skipped`). For default-config operators (whose `customVaultPath` might be the legacy path), the bind-mount target is always the new canonical `~/.switchroom/vault/` parent — derive that explicitly.

### Bug 2 — broker couldn't WRITE to the host-owned vault dir

`cap_drop: ALL` strips DAC_OVERRIDE. Without it, container-root (broker runs as uid 0) can READ via `DAC_READ_SEARCH` (kept since v0.7.4) but rejects mkdir + write because the host vault dir is mode `0700` owned by the operator UID, not container-root's matching UID.

**Surface:** `ms_graph_token.py`'s broker put step `EACCES`d on `mkdir '/state/vault/vault.enc.lock'` (the `saveVault` flock sentinel-dir).

**Fix:** add `DAC_OVERRIDE` to broker `cap_add`. Trust posture is consistent — broker already holds the passphrase + decrypted secrets in memory; allowing write capability is not an expansion of access, just of operations.

## Test plan

- [x] `npm run lint` clean
- [x] **65/65** compose-generator tests pass (1 new pinning DAC_OVERRIDE in the broker cap_add block)
- [x] **5271/5271** vitest pass
- [x] **End-to-end deploy verified:** rebuilt locally, redeployed broker via `up -d --force-recreate vault-broker`, ran `ms_graph_token.py` from inside clerk → token rotated → broker persisted via op:put → re-read returns fresh token → `MS Graph /me` returns 200 with `upn: ken.thompson@outlook.com.au`
- [x] **Calendar event created end-to-end** — ran `calendar.py create-event` for "Year 4 Camp — Mabel" 19-21 May at Toolangi Camp; MS Graph returned the event JSON with the expected attendees + organizer.

## Issues

- Closes the v0.7.12 deploy regression discovered post-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)