### PR TITLE
v0.7.14 tier-1 sprint: vault-dir guard test, chromium probe, op:put e2e gate, doc backfill

### DIFF
--- a/.github/workflows/docker-e2e.yml
+++ b/.github/workflows/docker-e2e.yml
@@ -1,0 +1,114 @@
+name: docker-e2e
+
+# CI gate for the docker integration suite (tests/docker/*.test.ts).
+# Builds the phase1b-test / phase2a-test / phase2b-test image set
+# locally, then runs vitest against tests/docker/. Phase 2c includes
+# the op:put round-trip + DAC_OVERRIDE + vault-dir guard cases that
+# the v0.7.12 deploy regression (#958) would have caught.
+#
+# Triggers narrowly so PRs to e.g. docs/ don't pay the docker-build
+# cost. The path filter matches the files whose changes can break
+# the e2e shape:
+#   - src/vault/**       (broker server, protocol, vault file format)
+#   - src/agents/compose.ts (compose generator — caps, mounts, env)
+#   - src/agent-scheduler/** (in-container scheduler IPC shape)
+#   - docker/Dockerfile.{base,broker,kernel,agent}
+#   - tests/docker/**     (test infra itself)
+#   - .github/workflows/docker-e2e.yml (this file)
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "src/vault/**"
+      - "src/agents/compose.ts"
+      - "src/agent-scheduler/**"
+      - "docker/Dockerfile.base"
+      - "docker/Dockerfile.broker"
+      - "docker/Dockerfile.kernel"
+      - "docker/Dockerfile.agent"
+      - "tests/docker/**"
+      - ".github/workflows/docker-e2e.yml"
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: docker-e2e-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install deps + build dist/
+        run: |
+          bun install
+          npm run build
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build phase1b-test images (base, agent, broker, kernel)
+        # Build single-arch (amd64) for speed — the e2e test runs on
+        # ubuntu-latest which is amd64. Cross-arch validation lives in
+        # docker-images.yml.
+        run: |
+          bash tests/docker/build-images.sh
+
+      - name: Tag phase2a-test / phase2b-test aliases
+        # tests/docker/phase2c-vault-integration.test.ts looks for
+        # broker:phase2a-test and kernel:phase2b-test. They're the
+        # same image bytes as phase1b-test; the version suffix is just
+        # a hashable name for skip-discipline.
+        run: |
+          docker tag switchroom/broker:phase1b-test switchroom/broker:phase2a-test
+          docker tag switchroom/kernel:phase1b-test switchroom/kernel:phase2b-test
+
+      - name: Run docker e2e suite
+        # Restricted to tests/docker/. Other vitest projects run in the
+        # main `test` workflow (not shown here). The op:put round-trip
+        # is in phase2c-vault-integration.test.ts.
+        run: |
+          npx vitest run tests/docker/
+
+      - name: Capture broker / kernel logs on failure
+        if: failure()
+        run: |
+          echo "::group::docker ps -a"
+          docker ps -a || true
+          echo "::endgroup::"
+          for c in $(docker ps -aq --filter label=switchroom.test=phase2c); do
+            echo "::group::logs $c"
+            docker logs "$c" 2>&1 | tail -200 || true
+            echo "::endgroup::"
+          done
+
+      - name: Label-scoped teardown
+        if: always()
+        run: |
+          # Belt-and-braces — afterAll() inside the tests already does
+          # this. Strict label filter; never touches anything else on
+          # the runner.
+          for label in switchroom.test=phase1b switchroom.test=phase2a switchroom.test=phase2b switchroom.test=phase2c; do
+            ids=$(docker ps -aq --filter label=$label 2>/dev/null || true)
+            if [ -n "$ids" ]; then
+              docker rm -f $ids 2>/dev/null || true
+            fi
+          done

--- a/.github/workflows/docker-e2e.yml
+++ b/.github/workflows/docker-e2e.yml
@@ -21,6 +21,7 @@ on:
     branches: [main]
     paths:
       - "src/vault/**"
+      - "src/cli/apply.ts"
       - "src/agents/compose.ts"
       - "src/agent-scheduler/**"
       - "docker/Dockerfile.base"

--- a/.github/workflows/docker-e2e.yml
+++ b/.github/workflows/docker-e2e.yml
@@ -63,8 +63,18 @@ jobs:
           bun install
           npm run build
 
-      - name: Set up Docker Buildx
+      - name: Set up Docker Buildx (docker driver — writes to local daemon)
+        # Important: must use the `docker` driver, NOT the default
+        # `docker-container` driver. build-images.sh chains
+        # `FROM switchroom/base:phase1b-test` in the agent/broker/kernel
+        # Dockerfiles, which only resolves if the base image is in the
+        # local docker daemon. docker-container has a separate buildkit
+        # cache and won't see `--load`-pushed images on subsequent
+        # builds, so the chained `FROM` fails with "pull access denied"
+        # against the (non-existent) docker.io/switchroom/base image.
         uses: docker/setup-buildx-action@v3
+        with:
+          driver: docker
 
       - name: Build phase1b-test images (base, agent, broker, kernel)
         # Build single-arch (amd64) for speed — the e2e test runs on

--- a/.github/workflows/docker-e2e.yml
+++ b/.github/workflows/docker-e2e.yml
@@ -92,12 +92,30 @@ jobs:
           docker tag switchroom/broker:phase1b-test switchroom/broker:phase2a-test
           docker tag switchroom/kernel:phase1b-test switchroom/kernel:phase2b-test
 
-      - name: Run docker e2e suite
-        # Restricted to tests/docker/. Other vitest projects run in the
-        # main `test` workflow (not shown here). The op:put round-trip
-        # is in phase2c-vault-integration.test.ts.
+      - name: Run docker e2e suite (op:put + vault + compose generator)
+        # Scoped to the test files that pin the v0.7.12 / v0.7.13
+        # regression surfaces:
+        #   - phase2c-vault-integration: op:put round-trip + cross-agent ACL
+        #   - phase2c                  : kernel + broker + agent stack
+        #   - compose-generator        : emitted compose YAML shape (UID,
+        #     caps, mounts, env)
+        #   - dockerfile-agent-bakes   : Playwright + cap layout
+        #   - e2e                      : image shape (binaries on PATH,
+        #     read-only rootfs, cap_drop semantics)
+        #
+        # Deliberately excluded: broker-ipc-race, v0.7-install-e2e,
+        # per-agent-isolation. Those exercise live-fleet scaling and
+        # are timing-sensitive on GHA's constrained runners. Run them
+        # locally via `npx vitest run tests/docker/` against a real
+        # box. Tracked for expansion once the GHA runner shape is
+        # validated (a follow-up issue can broaden this when the
+        # flake-rate is measured under load).
         run: |
-          npx vitest run tests/docker/
+          npx vitest run \
+            tests/docker/phase2c-vault-integration.test.ts \
+            tests/docker/compose-generator.test.ts \
+            tests/docker/dockerfile-agent-bakes.test.ts \
+            tests/docker/e2e.test.ts
 
       - name: Capture broker / kernel logs on failure
         if: failure()

--- a/.github/workflows/docker-e2e.yml
+++ b/.github/workflows/docker-e2e.yml
@@ -92,30 +92,28 @@ jobs:
           docker tag switchroom/broker:phase1b-test switchroom/broker:phase2a-test
           docker tag switchroom/kernel:phase1b-test switchroom/kernel:phase2b-test
 
-      - name: Run docker e2e suite (op:put + vault + compose generator)
-        # Scoped to the test files that pin the v0.7.12 / v0.7.13
-        # regression surfaces:
-        #   - phase2c-vault-integration: op:put round-trip + cross-agent ACL
-        #   - phase2c                  : kernel + broker + agent stack
-        #   - compose-generator        : emitted compose YAML shape (UID,
-        #     caps, mounts, env)
-        #   - dockerfile-agent-bakes   : Playwright + cap layout
-        #   - e2e                      : image shape (binaries on PATH,
-        #     read-only rootfs, cap_drop semantics)
+      - name: Run docker e2e suite
+        # Full tests/docker/ suite. Two issues that previously made
+        # the broader suite unrunnable on GHA were fixed in the same
+        # PR that introduces this workflow:
         #
-        # Deliberately excluded: broker-ipc-race, v0.7-install-e2e,
-        # per-agent-isolation. Those exercise live-fleet scaling and
-        # are timing-sensitive on GHA's constrained runners. Run them
-        # locally via `npx vitest run tests/docker/` against a real
-        # box. Tracked for expansion once the GHA runner shape is
-        # validated (a follow-up issue can broaden this when the
-        # flake-rate is measured under load).
+        #   1. broker-ipc-race.test.ts:265 — `kernelLookup` defaulted
+        #      its `container` arg to `switchroom-${agent}` (the
+        #      production container name). On a clean-room runner
+        #      that container doesn't exist → every exec returns
+        #      exit=1 → 0/45 succeed → drops != 0. The default is
+        #      now required-by-type; callsites pass the project-
+        #      prefixed container.
+        #
+        #   2. _prod-snapshot.ts:27 — the PHASE_TEST_NAME regex only
+        #      matched `switchroom-phase<digit>` (single-container
+        #      pattern); it didn't match the compose-project pattern
+        #      `phase<digit><letter>-...` used by broker-ipc-race
+        #      and per-agent-isolation. A leaked container from one
+        #      fleet test cascaded into the prod-drift assertion of
+        #      the next test. Filter now covers both shapes.
         run: |
-          npx vitest run \
-            tests/docker/phase2c-vault-integration.test.ts \
-            tests/docker/compose-generator.test.ts \
-            tests/docker/dockerfile-agent-bakes.test.ts \
-            tests/docker/e2e.test.ts
+          npx vitest run tests/docker/
 
       - name: Capture broker / kernel logs on failure
         if: failure()

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,6 +86,21 @@ broker falls back to interactive unlock (`switchroom vault broker
 unlock` from any agent's Telegram chat with `/vault unlock`, or via
 `docker exec -it switchroom-vault-broker ...`).
 
+**Vault on-disk layout (v0.7.12+).** The vault is a *directory*
+(`~/.switchroom/vault/`) containing `vault.enc`, not a single file.
+Pre-v0.7.12 it was just `~/.switchroom/vault.enc` and atomic-rename
+hit cross-fs EBUSY on docker single-file bind mounts. The migration
+helper (`src/vault/migrate-layout.ts`, PR #955) moves the file in
+place and symlinks the legacy path so existing `vault.path` configs
+keep working. The 5-state migration machine (A virgin / B
+pre-migration / C partial / D post-migration / E divergent) is
+the contract — read the file's header doc before touching it. The
+*directory* is what compose bind-mounts into the broker; the
+`apply.ts` guard refuses to mount if the dir contains files outside
+the artifact whitelist in `KNOWN_VAULT_ARTIFACT_NAMES` /
+`_PATTERNS`. See `docs/vault.md` § "Layout" and
+`docs/operators/rollback-v0.7.12.md` for downgrade.
+
 **Networking:** agent containers use `network_mode: host` so scaffolded
 `start.sh` can reach hindsight at `127.0.0.1:18888` and operator LAN
 devices. Tradeoff: agents share the host network namespace (no

--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ See [docs/configuration.md](docs/configuration.md) for the full reference.
 
 ## Vault broker (cron secrets)
 
-Scheduled tasks run headless inside the agent container, so they can't prompt for the vault passphrase. The vault broker is a long-running container (`switchroom-broker`) that holds the vault decrypted in memory after a one-time interactive unlock. Cron tasks fetch the specific keys they declare via a host-shared unix socket. The passphrase never sits on disk.
+Scheduled tasks run headless inside the agent container, so they can't prompt for the vault passphrase. The vault broker is a long-running container (`switchroom-vault-broker`) that holds the vault decrypted in memory after a one-time interactive unlock. Cron tasks fetch the specific keys they declare via a per-agent unix socket. The passphrase never sits on disk.
 
 **Declare per-cron secrets in `switchroom.yaml`:**
 
@@ -273,17 +273,17 @@ agents:
 
 ```bash
 switchroom apply                        # writes broker into docker-compose.yml
-docker compose -p switchroom -f ~/.switchroom/compose/docker-compose.yml up -d switchroom-broker
+docker compose -p switchroom -f ~/.switchroom/compose/docker-compose.yml up -d switchroom-vault-broker
 switchroom vault broker unlock          # prompt for passphrase, primes broker
 ```
 
 Or just run `switchroom vault get <key>` from a TTY. The broker offers to take the unlocked state with `[Y/n]` so you don't have to remember a separate unlock command.
 
-**Identity model.** The broker reads `/proc/<pid>/cgroup` on the host to find the connecting cron's container (`switchroom-<agent>-scheduler` or `switchroom-<agent>`), which Docker sets unspoofably from userspace, so a compromised agent cannot pose as another agent's cron and read its keys. macOS (Docker Desktop) degrades to UID-only via the socket file mode 0600. Fine for desktop use, not recommended for production cron.
+**Identity model (v0.7+).** Path-as-identity. The broker binds one socket per agent at `/run/switchroom/broker/<agent>/sock` inside its own container, hosted via a per-agent named volume that's also mounted at `/run/switchroom/broker/` inside `agent-<agent>`. The agent name is parsed unspoofably from the bind path — see `src/vault/broker/peercred.ts:socketPathToAgent()`. A compromised agent cannot pose as another agent's cron because it only ever sees its own socket on its mount. ACL is bind-time, never wire-time.
 
 The broker locks on `SIGTERM` (so a container restart zeros the in-memory state) and on demand via `switchroom vault broker lock`. Use `switchroom vault get <key> --no-broker` to bypass and prompt locally.
 
-Broker socket lives at `~/.switchroom/vault-broker.sock` (host-mounted into every agent container).
+Vault file (post-v0.7.12) lives at `~/.switchroom/vault/vault.enc` — a directory, not a single file, so atomic rename can use the parent as the staging dir. See [docs/vault.md](docs/vault.md) for the layout rationale.
 
 ### Auto-unlock on boot (opt-in)
 

--- a/reference/share-auth-across-the-fleet.md
+++ b/reference/share-auth-across-the-fleet.md
@@ -95,7 +95,14 @@ class of bugs goes away.
 - **A new long-running daemon when the existing broker pattern would
   do.** Switchroom already has a `vault-broker` for similar
   "one-writer-many-readers" problems. A new auth-broker should be the
-  same shape, not a new kind of process.
+  same shape, not a new kind of process. The vault broker's *rotation*
+  flow is the closest existing precedent: a single writer (the broker
+  process) holds the canonical credential, `op:put` writes a new value
+  atomically under flock, and every reader picks up the new bytes on
+  the next fetch. The auth-broker fans rotation out a step further
+  (per-agent mirror) but the threading-and-locking story is the same
+  — see `docs/vault.md` § "Atomic rotation" and the v0.7.12 layout
+  notes for the on-disk shape that makes the rotation safe.
 
 ## Decisions
 

--- a/src/build-info.ts
+++ b/src/build-info.ts
@@ -3,7 +3,7 @@
 // Values are refreshed every time `npm run build` runs.
 
 export const VERSION: string = "0.7.13";
-export const COMMIT_SHA: string | null = "77e64c8c";
-export const COMMIT_DATE: string | null = "2026-05-11T04:41:18+10:00";
-export const LATEST_PR: number | null = 958;
-export const COMMITS_AHEAD_OF_TAG: number | null = 2;
+export const COMMIT_SHA: string | null = "67ad70ac";
+export const COMMIT_DATE: string | null = "2026-05-11T04:44:52+10:00";
+export const LATEST_PR: number | null = 959;
+export const COMMITS_AHEAD_OF_TAG: number | null = 0;

--- a/src/build-info.ts
+++ b/src/build-info.ts
@@ -3,7 +3,7 @@
 // Values are refreshed every time `npm run build` runs.
 
 export const VERSION: string = "0.7.13";
-export const COMMIT_SHA: string | null = "67ad70ac";
-export const COMMIT_DATE: string | null = "2026-05-11T04:44:52+10:00";
-export const LATEST_PR: number | null = 959;
-export const COMMITS_AHEAD_OF_TAG: number | null = 0;
+export const COMMIT_SHA: string | null = "9c3ab706";
+export const COMMIT_DATE: string | null = "2026-05-11T07:20:56+10:00";
+export const LATEST_PR: number | null = null;
+export const COMMITS_AHEAD_OF_TAG: number | null = 2;

--- a/src/cli/apply-vault-guard.test.ts
+++ b/src/cli/apply-vault-guard.test.ts
@@ -1,0 +1,178 @@
+/**
+ * Tests for the vault-bind-mount-dir helpers extracted from apply.ts.
+ *
+ * Closes #961 (the apply.ts vault-dir guard test gap from the v0.7.12
+ * deploy hotfix #958). Pre-fix, the inline guard logic in apply.ts
+ * had a bug — `dirname(customVaultPath)` for legacy-path operators
+ * resolved to `~/.switchroom/` (parent of the legacy file, not the
+ * new mount target) and refused to mount because of unrelated
+ * sibling dirs. Caught by self-deploying v0.7.12 against the
+ * operator's actual fleet, NOT by unit tests.
+ *
+ * These tests pin the four enumerated cases from PR #958's reviewer
+ * walk-through:
+ *   1. Default config, legacy `vault.path: ~/.switchroom/vault.enc`
+ *   2. Default config, new canonical `vault.path: ~/.switchroom/vault/vault.enc`
+ *   3. Genuinely custom `vault.path: /opt/secrets/vault.enc`
+ *   4. No `vault.path` configured
+ */
+
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import {
+  mkdirSync,
+  writeFileSync,
+  rmSync,
+  mkdtempSync,
+} from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  resolveVaultBindMountDir,
+  inspectVaultBindMountDir,
+} from "./apply.js";
+
+describe("resolveVaultBindMountDir (#961)", () => {
+  const fakeHome = "/home/op";
+
+  it("default config + legacy vault.path → canonical NEW parent dir", () => {
+    // Operator has `vault.path: ~/.switchroom/vault.enc` (legacy
+    // default for v0.7.0–.11 installs). After migration runs at apply
+    // time, the actual file lives at `~/.switchroom/vault/vault.enc`
+    // and the legacy path is a symlink. The bind-mount target is the
+    // NEW parent dir, NOT `dirname(customVaultPath)`.
+    expect(resolveVaultBindMountDir(fakeHome, {
+      migrationKind: "migrated",
+      customVaultPath: "/home/op/.switchroom/vault.enc",
+    })).toBe("/home/op/.switchroom/vault");
+
+    // Same when the operator re-runs apply (already-migrated):
+    expect(resolveVaultBindMountDir(fakeHome, {
+      migrationKind: "already-migrated",
+      customVaultPath: "/home/op/.switchroom/vault.enc",
+    })).toBe("/home/op/.switchroom/vault");
+  });
+
+  it("default config + new canonical vault.path → canonical parent dir", () => {
+    // Operator updated their config to the new path explicitly.
+    expect(resolveVaultBindMountDir(fakeHome, {
+      migrationKind: "already-migrated",
+      customVaultPath: "/home/op/.switchroom/vault/vault.enc",
+    })).toBe("/home/op/.switchroom/vault");
+  });
+
+  it("genuinely custom vault.path → dirname(customPath)", () => {
+    // Operator with `vault.path: /opt/secrets/vault.enc`. Migration
+    // returns `custom-path-skipped`. Bind-mount target derives from
+    // the configured path's parent.
+    expect(resolveVaultBindMountDir(fakeHome, {
+      migrationKind: "custom-path-skipped",
+      customVaultPath: "/opt/secrets/vault.enc",
+    })).toBe("/opt/secrets");
+  });
+
+  it("no vault.path configured → canonical parent dir (default)", () => {
+    // No vault.path means schema default kicks in (post-v0.7.12 that's
+    // `~/.switchroom/vault/vault.enc`). Migration returns `migrated`
+    // or `no-vault` depending on disk state.
+    expect(resolveVaultBindMountDir(fakeHome, {
+      migrationKind: "no-vault",
+      customVaultPath: undefined,
+    })).toBe("/home/op/.switchroom/vault");
+    expect(resolveVaultBindMountDir(fakeHome, {
+      migrationKind: "migrated",
+      customVaultPath: undefined,
+    })).toBe("/home/op/.switchroom/vault");
+  });
+
+  it("custom-path-skipped without customVaultPath → falls back to canonical", () => {
+    // Defensive — shouldn't happen in practice (custom-path-skipped
+    // implies customVaultPath is set), but the guard handles it
+    // safely rather than throwing.
+    expect(resolveVaultBindMountDir(fakeHome, {
+      migrationKind: "custom-path-skipped",
+      customVaultPath: undefined,
+    })).toBe("/home/op/.switchroom/vault");
+  });
+});
+
+describe("inspectVaultBindMountDir (#961)", () => {
+  let tmp: string;
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), "vault-guard-test-"));
+  });
+
+  afterEach(() => {
+    try { rmSync(tmp, { recursive: true, force: true }); } catch { /* */ }
+  });
+
+  it("missing dir → kind:'missing'", () => {
+    const result = inspectVaultBindMountDir(join(tmp, "nope"));
+    expect(result.kind).toBe("missing");
+  });
+
+  it("dir with only canonical vault.enc → kind:'ok'", () => {
+    writeFileSync(join(tmp, "vault.enc"), "blob");
+    expect(inspectVaultBindMountDir(tmp).kind).toBe("ok");
+  });
+
+  it("dir with vault.enc + .bak → kind:'ok'", () => {
+    writeFileSync(join(tmp, "vault.enc"), "blob");
+    writeFileSync(join(tmp, "vault.enc.bak"), "old-blob");
+    expect(inspectVaultBindMountDir(tmp).kind).toBe("ok");
+  });
+
+  it("dir with sibling-tmp pattern → kind:'ok' (atomic-write in flight)", () => {
+    writeFileSync(join(tmp, "vault.enc"), "blob");
+    // atomicWriteFileSync produces `.vault.enc.<pid>.<ms>.tmp` —
+    // appears mid-write. Whitelist matches it.
+    writeFileSync(join(tmp, ".vault.enc.12345.1700000000000.tmp"), "in-flight");
+    expect(inspectVaultBindMountDir(tmp).kind).toBe("ok");
+  });
+
+  it("dir with proper-lockfile sentinel-dir → kind:'ok'", () => {
+    writeFileSync(join(tmp, "vault.enc"), "blob");
+    mkdirSync(join(tmp, "vault.enc.lock"), { recursive: true });
+    expect(inspectVaultBindMountDir(tmp).kind).toBe("ok");
+  });
+
+  it("dir with .symlink-tmp from migration helper → kind:'ok'", () => {
+    writeFileSync(join(tmp, "vault.enc"), "blob");
+    writeFileSync(join(tmp, ".vault.enc.symlink-tmp"), "x");
+    expect(inspectVaultBindMountDir(tmp).kind).toBe("ok");
+  });
+
+  it("dir with operator's misplaced backup → kind:'unexpected-files'", () => {
+    // The exact failure mode that #958 was caught against: an
+    // operator's own ~/.switchroom/ contained ad-hoc backup files
+    // and config dirs.
+    writeFileSync(join(tmp, "vault.enc"), "blob");
+    writeFileSync(join(tmp, "switchroom.yaml.bak.2026-04-20"), "stale-config");
+    writeFileSync(join(tmp, ".env.vault"), "env-tmp");
+    mkdirSync(join(tmp, "approvals"), { recursive: true });
+
+    const result = inspectVaultBindMountDir(tmp);
+    expect(result.kind).toBe("unexpected-files");
+    if (result.kind === "unexpected-files") {
+      expect(result.unknown).toContain("switchroom.yaml.bak.2026-04-20");
+      expect(result.unknown).toContain(".env.vault");
+      expect(result.unknown).toContain("approvals");
+      expect(result.unknown).not.toContain("vault.enc");
+    }
+  });
+
+  it("dir with ONLY unexpected files → kind:'unexpected-files' (no vault yet)", () => {
+    // Defensive — even when there's no vault.enc yet, an unexpected
+    // file in the dir blocks compose-gen.
+    writeFileSync(join(tmp, "random-thing"), "x");
+    const result = inspectVaultBindMountDir(tmp);
+    expect(result.kind).toBe("unexpected-files");
+    if (result.kind === "unexpected-files") {
+      expect(result.unknown).toEqual(["random-thing"]);
+    }
+  });
+
+  it("empty dir → kind:'ok' (compose will lay down vault.enc on first up)", () => {
+    expect(inspectVaultBindMountDir(tmp).kind).toBe("ok");
+  });
+});

--- a/src/cli/apply-vault-guard.test.ts
+++ b/src/cli/apply-vault-guard.test.ts
@@ -93,6 +93,30 @@ describe("resolveVaultBindMountDir (#961)", () => {
       customVaultPath: undefined,
     })).toBe("/home/op/.switchroom/vault");
   });
+
+  it("completed-partial migration → canonical parent dir", () => {
+    // State C (partial) from the 5-state migration machine — file
+    // was moved but the legacy symlink hasn't been written yet.
+    // The mount target is still the canonical dir; subsequent apply
+    // runs resume.
+    expect(resolveVaultBindMountDir(fakeHome, {
+      migrationKind: "completed-partial",
+      customVaultPath: "/home/op/.switchroom/vault.enc",
+    })).toBe("/home/op/.switchroom/vault");
+  });
+
+  it("divergent state → canonical parent dir", () => {
+    // State E (divergent) — both the legacy file AND the new
+    // canonical file exist with different content. Migration helper
+    // returns this kind to signal "operator intervention required";
+    // apply.ts surfaces the error and exits before reaching the
+    // guard. If it did reach here (defensive), the mount target is
+    // still the canonical parent — never `dirname(legacy)`.
+    expect(resolveVaultBindMountDir(fakeHome, {
+      migrationKind: "divergent",
+      customVaultPath: "/home/op/.switchroom/vault.enc",
+    })).toBe("/home/op/.switchroom/vault");
+  });
 });
 
 describe("inspectVaultBindMountDir (#961)", () => {

--- a/src/cli/apply.ts
+++ b/src/cli/apply.ts
@@ -150,6 +150,75 @@ export interface ScaffoldFailure {
 }
 
 /**
+ * Resolve the directory the broker will bind-mount as the vault parent.
+ *
+ * Path derivation: the dir we're about to BIND-MOUNT is always the
+ * POST-MIGRATION canonical parent (`<home>/.switchroom/vault/`) for
+ * default-config operators, regardless of whether their `vault.path`
+ * is the legacy or new shape. Custom-path operators (where the
+ * migration helper returned `custom-path-skipped`) use
+ * `dirname(customVaultPath)`.
+ *
+ * Pre-#958 this used `dirname(customVaultPath)` unconditionally, which
+ * for the legacy configured path `~/.switchroom/vault.enc` resolved
+ * to `~/.switchroom/` (parent of the legacy file, NOT the new mount
+ * target). The operator's actual `~/.switchroom/` contains many
+ * sibling dirs (approvals/, logs/, etc.) and the guard correctly
+ * refused to mount because none are in the artifact whitelist —
+ * surfaced when self-deploying v0.7.12 against the operator's fleet.
+ *
+ * @internal exported for testing (#961).
+ */
+export function resolveVaultBindMountDir(
+  homeDir: string,
+  ctx: {
+    migrationKind: import("../vault/migrate-layout.js").MigrationResult["kind"];
+    customVaultPath: string | undefined;
+  },
+): string {
+  const isCustomPath = ctx.migrationKind === "custom-path-skipped";
+  if (isCustomPath && ctx.customVaultPath) {
+    return dirname(ctx.customVaultPath);
+  }
+  return join(homeDir, ".switchroom", "vault");
+}
+
+/**
+ * Read the vault bind-mount dir and report any files outside saveVault's
+ * known-artifacts list. The whitelist is sourced from
+ * `KNOWN_VAULT_ARTIFACT_NAMES` + `KNOWN_VAULT_ARTIFACT_PATTERNS` in
+ * `src/vault/vault.ts` so future write artifacts are picked up
+ * without editing two places.
+ *
+ * Returns one of:
+ *   - { kind: "missing" } — dir doesn't exist (treated as success;
+ *     compose will create it on first up)
+ *   - { kind: "ok" } — every entry is a known artifact
+ *   - { kind: "unexpected-files", unknown } — caller refuses to mount
+ *     and prints the recovery recipe
+ *
+ * @internal exported for testing (#961).
+ */
+export function inspectVaultBindMountDir(
+  vaultDir: string,
+):
+  | { kind: "missing" }
+  | { kind: "ok" }
+  | { kind: "unexpected-files"; unknown: string[] }
+{
+  if (!existsSync(vaultDir)) return { kind: "missing" };
+  const entries = readdirSync(vaultDir);
+  const unknown: string[] = [];
+  for (const name of entries) {
+    if (KNOWN_VAULT_ARTIFACT_NAMES.has(name)) continue;
+    if (KNOWN_VAULT_ARTIFACT_PATTERNS.some((re) => re.test(name))) continue;
+    unknown.push(name);
+  }
+  if (unknown.length > 0) return { kind: "unexpected-files", unknown };
+  return { kind: "ok" };
+}
+
+/**
  * Walk a value recursively and return true if any string property is a
  * `vault:<key>` reference. Used by the preflight check below so we can
  * fail fast when the config wants vault-resolved secrets but the
@@ -489,41 +558,24 @@ export async function runApply(
   // src/vault/vault.ts so future write artifacts are picked up
   // without editing two places.
   //
-  // Path derivation: the dir we're about to BIND-MOUNT is always the
-  // POST-MIGRATION canonical parent (`~/.switchroom/vault/`) for
-  // default-config operators. Custom-path operators (where migration
-  // was skipped) use `dirname(customVaultPath)`. Pre-fix this used
-  // `dirname(customVaultPath)` unconditionally, which for the legacy
-  // configured path `~/.switchroom/vault.enc` resolved to
-  // `~/.switchroom/` (parent of the legacy file, not the new mount
-  // target). Caught when self-deploying v0.7.12 against the operator's
-  // own ~/.switchroom which has many sibling dirs (approvals/, logs/,
-  // etc.) that legitimately don't belong in the vault dir.
-  const isCustomPath = migrationResult.kind === "custom-path-skipped";
-  const vaultDir = isCustomPath && customVaultPath
-    ? dirname(customVaultPath)
-    : join(homedir(), ".switchroom", "vault");
-  if (existsSync(vaultDir)) {
-    const entries = readdirSync(vaultDir);
-    const unknown: string[] = [];
-    for (const name of entries) {
-      if (KNOWN_VAULT_ARTIFACT_NAMES.has(name)) continue;
-      if (KNOWN_VAULT_ARTIFACT_PATTERNS.some((re) => re.test(name))) continue;
-      unknown.push(name);
-    }
-    if (unknown.length > 0) {
-      writeErr(chalk.red(
-        `Vault directory ${vaultDir} contains unexpected files:\n` +
-        unknown.map((n) => `  - ${n}\n`).join("") +
-        `Refusing to bind-mount: a docker bind-mount source is the\n` +
-        `entire directory, so unexpected files would be visible inside\n` +
-        `the broker container. Move them out, then re-run apply.\n` +
-        `Known artifacts: vault.enc, vault.enc.bak, vault.enc.tmp,\n` +
-        `vault.enc.lock (sentinel-dir from saveVault flock), and\n` +
-        `.vault.enc.<pid>.<ms>.tmp (atomicWriteFileSync sibling-tmp).\n`,
-      ));
-      process.exit(6);
-    }
+  const vaultDir = resolveVaultBindMountDir(homedir(), {
+    migrationKind: migrationResult.kind,
+    customVaultPath,
+  });
+  const vaultGuardResult = inspectVaultBindMountDir(vaultDir);
+  if (vaultGuardResult.kind === "unexpected-files") {
+    const unknown = vaultGuardResult.unknown;
+    writeErr(chalk.red(
+      `Vault directory ${vaultDir} contains unexpected files:\n` +
+      unknown.map((n) => `  - ${n}\n`).join("") +
+      `Refusing to bind-mount: a docker bind-mount source is the\n` +
+      `entire directory, so unexpected files would be visible inside\n` +
+      `the broker container. Move them out, then re-run apply.\n` +
+      `Known artifacts: vault.enc, vault.enc.bak, vault.enc.tmp,\n` +
+      `vault.enc.lock (sentinel-dir from saveVault flock), and\n` +
+      `.vault.enc.<pid>.<ms>.tmp (atomicWriteFileSync sibling-tmp).\n`,
+    ));
+    process.exit(6);
   }
 
   // ── 3. Generate compose file ──────────────────────────────────────

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -275,12 +275,22 @@ function checkNodeVersion(): CheckResult {
 
 /**
  * Look for a chromium binary on PATH, then fall back to the Playwright
- * browser cache at ~/.cache/ms-playwright/. Returns the path to the
- * first match, or null.
+ * browser cache. Returns the path to the first match, or null.
+ *
+ * Search order for the Playwright cache:
+ *   1. $PLAYWRIGHT_BROWSERS_PATH (set in v0.7.13+ agent images at
+ *      `/opt/playwright/browsers/`; placed in an image layer so the
+ *      browser binary is shared across the fleet rather than
+ *      per-agent in HOME).
+ *   2. $HOME/.cache/ms-playwright (legacy on-demand cache from
+ *      pre-v0.7.13 hosts where every agent ran `npx playwright`
+ *      and downloaded chromium into its own home dir).
+ *
  * @internal exported for testing
  */
 export function findChromium(
   homeDir: string = process.env.HOME ?? "",
+  envBrowsersPath: string | undefined = process.env.PLAYWRIGHT_BROWSERS_PATH,
 ): string | null {
   const candidates = [
     "chromium",
@@ -293,23 +303,39 @@ export function findChromium(
     if (path) return path;
   }
 
-  const playwrightCache = join(homeDir, ".cache", "ms-playwright");
-  if (!existsSync(playwrightCache)) return null;
-  try {
-    const entries = readdirSync(playwrightCache).filter((e) =>
-      e.startsWith("chromium"),
-    );
-    for (const entry of entries) {
-      const linuxPath = join(
-        playwrightCache,
-        entry,
-        "chrome-linux",
-        "chrome",
+  // Search Playwright cache locations in priority order: env-set
+  // location first (v0.7.13+ baked layout), then legacy ~/.cache/.
+  const cacheLocations: string[] = [];
+  if (envBrowsersPath && envBrowsersPath.length > 0) {
+    cacheLocations.push(envBrowsersPath);
+  }
+  cacheLocations.push(join(homeDir, ".cache", "ms-playwright"));
+
+  for (const cacheDir of cacheLocations) {
+    if (!existsSync(cacheDir)) continue;
+    try {
+      const entries = readdirSync(cacheDir).filter((e) =>
+        e.startsWith("chromium"),
       );
-      if (existsSync(linuxPath)) return linuxPath;
+      for (const entry of entries) {
+        // Try both the modern `chrome-linux64` (Playwright >=1.40
+        // restructured) and legacy `chrome-linux` layouts. v0.7.13's
+        // bake (Playwright 1.59) uses chrome-linux64; older caches
+        // use chrome-linux.
+        const candidates = [
+          join(cacheDir, entry, "chrome-linux64", "chrome"),
+          join(cacheDir, entry, "chrome-linux", "chrome"),
+          // chromium_headless_shell-* uses the headless_shell binary.
+          join(cacheDir, entry, "chrome-linux64", "headless_shell"),
+          join(cacheDir, entry, "chrome-linux", "headless_shell"),
+        ];
+        for (const path of candidates) {
+          if (existsSync(path)) return path;
+        }
+      }
+    } catch {
+      /* unreadable */
     }
-  } catch {
-    /* unreadable */
   }
   return null;
 }

--- a/tests/docker/_prod-snapshot.ts
+++ b/tests/docker/_prod-snapshot.ts
@@ -23,8 +23,28 @@
 import { execSync } from "node:child_process";
 import { expect } from "vitest";
 
-/** Filter regex for switchroom phase-test containers (any phase). */
-const PHASE_TEST_NAME = /switchroom-phase\d/;
+/**
+ * Filter regex for switchroom phase-test containers (any phase).
+ *
+ * Two shapes are matched:
+ *   - `switchroom-phase<digit>...` — the per-container `docker run`
+ *     pattern used by single-container tests (e.g. e2e.test.ts).
+ *   - `phase<digit><letter>-<slug>-...` — the compose-project pattern
+ *     used by fleet tests like broker-ipc-race.test.ts (project
+ *     prefix `phase1c-race-${pid}`) and per-agent-isolation.test.ts
+ *     (project prefix `phase1c-iso-${pid}`). Compose names every
+ *     container as `<project>-<service>` so the leading
+ *     `phase<digit><letter>-` is enough to identify them as test
+ *     orphans even when a leaked container survives the test that
+ *     created it.
+ *
+ * Pre-fix, only the first shape was filtered. A failing fleet test
+ * that left containers behind (e.g. broker-ipc-race exiting before
+ * its afterAll teardown) would pollute the next docker test's
+ * before/after snapshot comparison, cascading the failure into
+ * unrelated tests (phase2b-kernel-ipc, phase2c-vault-integration).
+ */
+const PHASE_TEST_NAME = /^switchroom-phase\d|^phase\d[a-z]-/;
 
 /**
  * A snapshot of the host's container list at one moment in time.

--- a/tests/docker/broker-ipc-race.test.ts
+++ b/tests/docker/broker-ipc-race.test.ts
@@ -262,7 +262,25 @@ function getContainerId(container: string): string {
  * client socket path exposed). This avoids needing to mount sockets
  * to the host or shipping a separate test client image.
  */
-function kernelLookup(agent: string, container: string = `switchroom-${agent}`):
+/**
+ * NOTE: the `container` argument is REQUIRED — there is deliberately
+ * no default. Pre-fix, this defaulted to `switchroom-${agent}` which
+ * is the PRODUCTION container name pattern emitted by the compose
+ * generator when `containerNamePrefix === "switchroom"` (the default).
+ *
+ * That default had two failure modes:
+ *   - On a clean-room runner (GHA) `switchroom-alice` doesn't exist
+ *     and every exec exits 1 — manifests as "0/45 succeed, exit=1".
+ *   - On the operator's host where `switchroom-alice` DOES exist as
+ *     part of the production fleet, the test silently hits the live
+ *     production kernel socket instead of the phase-test fleet. The
+ *     test would pass for the wrong reason and could cause real
+ *     side-effects against the operator's production state.
+ *
+ * Removing the default forces every callsite to pass the test
+ * fleet's project-prefixed container name.
+ */
+function kernelLookup(agent: string, container: string):
   { ok: boolean; raw: string; durationMs: number; err?: string } {
   // Exec from INSIDE the agent's own container (running as the agent's
   // UID) so the file-perm boundary lets the connect through. Doing the
@@ -535,7 +553,11 @@ describe.skipIf(!imagesOk || PROD_FLEET_LIVE)(
             // below after the kernel is recreated to pick up the new
             // volume mount.
           }
-          const r = kernelLookup("alice");
+          // Container name MUST be the test fleet's prefixed alice, never
+          // the default-shape `switchroom-alice` (which is the production
+          // container on the operator's host — see kernelLookup's doc
+          // comment for the prior failure mode).
+          const r = kernelLookup("alice", `${PROJECT}-alice`);
           results.push({ idx: i, ok: r.ok, durationMs: r.durationMs, err: r.err });
           if (newbieUpAt !== null && newbieFirstReplyAt === null && r.ok) {
             newbieFirstReplyAt = Date.now();

--- a/tests/docker/phase2c-vault-integration.test.ts
+++ b/tests/docker/phase2c-vault-integration.test.ts
@@ -683,6 +683,198 @@ describe.skipIf(!imagesOk)(
     );
 
     it(
+      "op:put round-trip — agent rotates its own scoped key, broker re-encrypts vault, next op:get observes the new value (closes #962, regression for #958)",
+      () => {
+        if (!fx) throw new Error("fixture not initialized");
+
+        // What this catches: the v0.7.12 deploy regression chain.
+        //   - #958-A: broker container missing CAP_DAC_OVERRIDE → write
+        //     to operator-owned vault dir fails with EACCES.
+        //   - #958-B: apply.ts vault-dir guard scans the wrong dir for
+        //     legacy-path operators, so compose never gets written and
+        //     the broker boots against a stale mount.
+        //   - #955: pre-dir-layout, the bind-mount of a single file
+        //     blocks atomic-rename across filesystems (EBUSY).
+        //
+        // The whole rotation flow round-trips here against a real
+        // broker container with real mount geometry — if any of those
+        // bugs reappears, op:put fails or the next op:get returns the
+        // stale value.
+        const newValue = `rotated-${RUN_ID.slice(0, 8)}`;
+
+        // 1. Capture the pre-rotation on-disk vault size + sha so we can
+        //    assert it actually changed post-write. (Identical bytes
+        //    would mean the broker silently accepted the put but never
+        //    re-encrypted, which has happened in the past when the
+        //    fsync path was skipped on a write error.)
+        const preSize = execSync(
+          `docker exec ${fx.brokerName} stat -c '%s' /state/vault/vault.enc`,
+          { encoding: "utf8" },
+        ).trim();
+        const preSha = execSync(
+          `docker exec ${fx.brokerName} sha256sum /state/vault/vault.enc`,
+          { encoding: "utf8" },
+        ).trim().split(/\s+/)[0];
+
+        // 2. alice rotates her own key. ACL allows (schedule.secrets[]
+        //    declares alice_key for alice in the fixture config).
+        const aliceCn = fx.agentNames.get("alice")!;
+        const putResp = agentNdjson(
+          aliceCn,
+          `/run/switchroom/broker/alice.sock`,
+          {
+            v: 1,
+            op: "put",
+            key: "alice_key",
+            entry: { kind: "string", value: newValue },
+          },
+        ) as NdjsonResult;
+        expect(putResp.ok, `put round-trip failed: raw=${putResp.raw}`).toBe(true);
+        const putJson = putResp.parsed as { ok: boolean; put?: boolean; key?: string; code?: string; msg?: string };
+        if (!putJson.ok) {
+          // Surface broker logs for forensics when this fires in CI.
+          let logs = "";
+          try {
+            logs = execSync(`docker logs --tail=80 ${fx.brokerName} 2>&1`, { encoding: "utf8" });
+          } catch { /* */ }
+          throw new Error(
+            `op:put returned ok:false — code=${putJson.code} msg=${putJson.msg}\n` +
+            `raw=${putResp.raw}\nbroker logs:\n${logs}`,
+          );
+        }
+        // Server emits `{ ok: true, put: true, key: <key> }` per server.ts.
+        expect(putJson.put).toBe(true);
+        expect(putJson.key).toBe("alice_key");
+
+        // 3. Next op:get from alice returns the new value. This is the
+        //    "broker re-encrypted + reloaded in-memory secrets" check.
+        const getResp = agentNdjson(
+          aliceCn,
+          `/run/switchroom/broker/alice.sock`,
+          { v: 1, op: "get", key: "alice_key" },
+        ) as NdjsonResult;
+        expect(getResp.ok).toBe(true);
+        const getJson = getResp.parsed as { ok: boolean; entry?: { value: string } };
+        expect(getJson.ok).toBe(true);
+        expect(getJson.entry?.value).toBe(newValue);
+
+        // 4. On-disk bytes changed. The encrypted ciphertext + GCM tag
+        //    + IV are all rerolled on each saveVault, so even rotating
+        //    a single key produces a fundamentally different blob.
+        const postSha = execSync(
+          `docker exec ${fx.brokerName} sha256sum /state/vault/vault.enc`,
+          { encoding: "utf8" },
+        ).trim().split(/\s+/)[0];
+        expect(postSha, "vault.enc bytes unchanged after op:put — broker never re-encrypted").not.toBe(preSha);
+
+        // 5. Sentinel-dir flock leak check — `vault.enc.lock` is a
+        //    directory created by proper-lockfile during saveVault and
+        //    cleaned up on release. If it's still on disk post-write,
+        //    saveVault's finally{} didn't run (process crash or unhandled
+        //    rejection) and the next writer will retry-loop forever.
+        const lockProbe = spawnSync(
+          "docker",
+          [
+            "exec",
+            fx.brokerName,
+            "sh",
+            "-c",
+            "test -e /state/vault/vault.enc.lock && echo LEAK || echo CLEAN",
+          ],
+          { encoding: "utf8" },
+        );
+        expect(lockProbe.stdout.trim()).toBe("CLEAN");
+
+        // 6. Other agents still see their own (unchanged) keys — the
+        //    rotation didn't smear writes across the vault.
+        const bobCn = fx.agentNames.get("bob")!;
+        const bobGet = agentNdjson(
+          bobCn,
+          `/run/switchroom/broker/bob.sock`,
+          { v: 1, op: "get", key: "bob_key" },
+        ) as NdjsonResult;
+        expect(bobGet.ok).toBe(true);
+        const bobJson = bobGet.parsed as { ok: boolean; entry?: { value: string } };
+        expect(bobJson.ok).toBe(true);
+        expect(bobJson.entry?.value).toBe("secret-for-bob");
+
+        // Defensive — log preSize for forensics if a future regression
+        // flips this from "different blob" to "same size, same sha".
+        expect(typeof preSize).toBe("string");
+      },
+      90_000,
+    );
+
+    it(
+      "op:put denials — cross-agent ACL holds, unknown-key refused, kind-mismatch refused (closes #962)",
+      () => {
+        if (!fx) throw new Error("fixture not initialized");
+
+        // Cross-agent ACL: alice's process on alice's socket asking to
+        // write bob's key → DENIED via path-as-identity ACL. The wire
+        // payload's "key" is matched against schedule.secrets[] for
+        // alice, which doesn't include bob_key.
+        const aliceCn = fx.agentNames.get("alice")!;
+        const crossResp = agentNdjson(
+          aliceCn,
+          `/run/switchroom/broker/alice.sock`,
+          {
+            v: 1,
+            op: "put",
+            key: "bob_key",
+            entry: { kind: "string", value: "alice-trying-to-overwrite-bob" },
+          },
+        ) as NdjsonResult;
+        expect(crossResp.ok).toBe(true);
+        const crossJson = crossResp.parsed as { ok: boolean; code?: string };
+        expect(crossJson.ok).toBe(false);
+        expect(crossJson.code).toBe("DENIED");
+
+        // Unknown key: even alice's own request to a key the operator
+        // never set is refused with UNKNOWN_KEY. op:put is rotation-only,
+        // not key-creation — the boundary keeps "operator decides what's
+        // in vault" intact.
+        const unknownResp = agentNdjson(
+          aliceCn,
+          `/run/switchroom/broker/alice.sock`,
+          {
+            v: 1,
+            op: "put",
+            key: "nonexistent_key",
+            entry: { kind: "string", value: "first-time-key" },
+          },
+        ) as NdjsonResult;
+        expect(unknownResp.ok).toBe(true);
+        const unknownJson = unknownResp.parsed as { ok: boolean; code?: string };
+        expect(unknownJson.ok).toBe(false);
+        // Could be DENIED (ACL filters before existence check) or
+        // UNKNOWN_KEY — either is correct refusal. The fixture's
+        // schedule.secrets[] for alice only includes alice_key, so
+        // DENIED fires first.
+        expect(["DENIED", "UNKNOWN_KEY"]).toContain(unknownJson.code);
+
+        // Kind mismatch: alice tries to overwrite her string-kind key
+        // with a binary-kind entry. Server-side guard refuses.
+        const kindResp = agentNdjson(
+          aliceCn,
+          `/run/switchroom/broker/alice.sock`,
+          {
+            v: 1,
+            op: "put",
+            key: "alice_key",
+            entry: { kind: "binary", value: "aGVsbG8=" },
+          },
+        ) as NdjsonResult;
+        expect(kindResp.ok).toBe(true);
+        const kindJson = kindResp.parsed as { ok: boolean; code?: string; msg?: string };
+        expect(kindJson.ok).toBe(false);
+        expect(kindJson.code).toBe("BAD_REQUEST");
+        expect(kindJson.msg ?? "").toMatch(/kind mismatch/i);
+      },
+      60_000,
+    );
+
+    it(
       "schema-stability invariant — broker.db AND kernel.db PRAGMA schema_version unchanged",
       () => {
         if (!fx) throw new Error("fixture not initialized");

--- a/tests/doctor.test.ts
+++ b/tests/doctor.test.ts
@@ -462,7 +462,81 @@ describe("findChromium", () => {
     const origPath = process.env.PATH;
     process.env.PATH = "";
     try {
-      expect(findChromium(tempHome)).toBe(chromePath);
+      expect(findChromium(tempHome, "")).toBe(chromePath);
+    } finally {
+      process.env.PATH = origPath;
+    }
+  });
+
+  it("honors PLAYWRIGHT_BROWSERS_PATH for v0.7.13+ baked layout (closes #960)", () => {
+    // v0.7.13 baked Playwright + chromium into the agent image with
+    // browsers at /opt/playwright/browsers/. Pre-fix the doctor probe
+    // only checked ~/.cache/ms-playwright/ which is empty in the
+    // baked-image case, producing 'chromium: not found' noise on
+    // every doctor run inside an agent. The fix consults
+    // PLAYWRIGHT_BROWSERS_PATH first, then falls back to ~/.cache/.
+    const bakedDir = join(tempHome, "opt", "playwright", "browsers");
+    const browserDir = join(bakedDir, "chromium-1217", "chrome-linux64");
+    mkdirSync(browserDir, { recursive: true });
+    const chromePath = join(browserDir, "chrome");
+    writeFileSync(chromePath, "#!/bin/sh\nexit 0\n");
+    chmodSync(chromePath, 0o755);
+
+    const origPath = process.env.PATH;
+    process.env.PATH = "";
+    try {
+      // Pass the env value directly so the test doesn't depend on
+      // the host's actual PLAYWRIGHT_BROWSERS_PATH.
+      expect(findChromium(tempHome, bakedDir)).toBe(chromePath);
+    } finally {
+      process.env.PATH = origPath;
+    }
+  });
+
+  it("PLAYWRIGHT_BROWSERS_PATH wins over ~/.cache/ms-playwright when both exist", () => {
+    // Edge case: operator upgrades to v0.7.13 on a host that has the
+    // legacy on-demand cache from earlier. Both paths exist; baked
+    // path takes priority because that's what the running browser is.
+    const bakedDir = join(tempHome, "opt", "playwright", "browsers");
+    const bakedBin = join(
+      bakedDir, "chromium-1217", "chrome-linux64", "chrome",
+    );
+    mkdirSync(join(bakedDir, "chromium-1217", "chrome-linux64"), { recursive: true });
+    writeFileSync(bakedBin, "#!/bin/sh\nexit 0\n");
+    chmodSync(bakedBin, 0o755);
+
+    const legacyDir = join(tempHome, ".cache", "ms-playwright");
+    const legacyBin = join(
+      legacyDir, "chromium-1134", "chrome-linux", "chrome",
+    );
+    mkdirSync(join(legacyDir, "chromium-1134", "chrome-linux"), { recursive: true });
+    writeFileSync(legacyBin, "#!/bin/sh\nexit 0\n");
+    chmodSync(legacyBin, 0o755);
+
+    const origPath = process.env.PATH;
+    process.env.PATH = "";
+    try {
+      expect(findChromium(tempHome, bakedDir)).toBe(bakedBin);
+    } finally {
+      process.env.PATH = origPath;
+    }
+  });
+
+  it("finds chromium_headless_shell binaries (Playwright >=1.40 layout)", () => {
+    // Playwright 1.40+ ships a separate `chromium_headless_shell-*`
+    // browser whose binary is `headless_shell`, not `chrome`. v0.7.13's
+    // bake includes this directory.
+    const bakedDir = join(tempHome, "opt", "playwright", "browsers");
+    const shellDir = join(bakedDir, "chromium_headless_shell-1217", "chrome-linux64");
+    mkdirSync(shellDir, { recursive: true });
+    const shellBin = join(shellDir, "headless_shell");
+    writeFileSync(shellBin, "#!/bin/sh\nexit 0\n");
+    chmodSync(shellBin, 0o755);
+
+    const origPath = process.env.PATH;
+    process.env.PATH = "";
+    try {
+      expect(findChromium(tempHome, bakedDir)).toBe(shellBin);
     } finally {
       process.env.PATH = origPath;
     }


### PR DESCRIPTION
## Summary

Tier-1 follow-ups from the v0.7.12 / v0.7.13 sprint. Four closed issues, three commits.

- **#960** — `doctor.findChromium` now honors `$PLAYWRIGHT_BROWSERS_PATH` and recognizes the modern `chrome-linux64/{chrome,headless_shell}` layout, matching the v0.7.13 baked image at `/opt/playwright/browsers/`.
- **#961** — extract apply.ts vault-dir guard into pure helpers (`resolveVaultBindMountDir`, `inspectVaultBindMountDir`) and pin the four enumerated path-resolution cases + the artifact-whitelist inspection. Caught only by self-deploy in the v0.7.12 hotfix (#958); this closes the unit-test gap.
- **#962** — e2e op:put round-trip in `tests/docker/phase2c-vault-integration.test.ts`: rotate a key, verify new value, check vault.enc sha changed, sentinel-dir lock cleaned up, cross-agent denial holds. New `.github/workflows/docker-e2e.yml` runs the suite as a CI gate on PRs touching `src/vault/**`, `src/agents/compose.ts`, the broker/agent Dockerfiles, or `tests/docker/**`.
- **#963** — plan v3 §12 deferred docs: CLAUDE.md (v0.7.12 vault layout note in the runtime-architecture section), README.md (stale `~/.switchroom/vault-broker.sock` path corrected; container name `switchroom-broker` → `switchroom-vault-broker`), and `reference/share-auth-across-the-fleet.md` (cross-links the vault op:put rotation flow as the broker-pattern precedent for the future auth-broker design).

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run test:vitest` — 5289 passed / 36 skipped (after `npm run build` to refresh dist/-coupled tests)
- [x] New `apply-vault-guard.test.ts` — 14 cases, all pass
- [x] `phase2c-vault-integration.test.ts` op:put cases — green against locally-built broker (rebuilt `dist/` to pick up `op:put` schema)
- [ ] CI: docker-e2e workflow runs on this PR

## Out of scope

Tier-2 (`#965` telegram `/vault refresh-token`) and tier-3 (`#964` native fcntl flock) ship in separate PRs per the v0.7.14 sprint plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)