### PR TITLE
feat(gateway): render structured vault-CLI errors with host hints (#969 P0b)

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -258,6 +258,7 @@ import { runPipeline } from '../secret-detect/pipeline.js'
 import { StagingMap } from '../secret-detect/staging.js'
 import { maskToken } from '../secret-detect/mask.js'
 import { defaultVaultWrite, defaultVaultList } from '../secret-detect/vault-write.js'
+import { parseVaultCliError, renderVaultCliError } from '../secret-detect/vault-error.js'
 import { detectSecrets } from '../secret-detect/index.js'
 import { classifyAdminGate } from '../admin-commands/index.js'
 import {
@@ -4871,7 +4872,15 @@ async function handleInbound(
         while (existing.has(slug)) slug = `${slugBase}_${n++}`
         const write = defaultVaultWrite(slug, staged.detection.matched_text, cached.passphrase)
         if (!write.ok) {
-          await switchroomReply(ctx, `<b>vault write failed:</b>\n${preBlock(write.output)}`, { html: true })
+          // Route P0a markers (#969) through the structured renderer so
+          // a "new key, needs operator approval" failure surfaces a
+          // host-CLI hint instead of a raw stderr blob.
+          const parsed = parseVaultCliError(write.output)
+          const rendered = renderVaultCliError(parsed, { verb: 'save', key: slug })
+          const body = rendered.suppressRaw
+            ? rendered.html
+            : `<b>vault write failed:</b>\n${preBlock(write.output)}`
+          await switchroomReply(ctx, body, { html: true })
           return
         }
         secretStaging.delete(staged.chat_id, staged.message_id)
@@ -5939,16 +5948,37 @@ function runVaultCli(args: string[], passphrase: string, stdinValue?: string): {
   }
 }
 
+/**
+ * Render a vault-CLI failure as Telegram HTML. Routes recognised P0a
+ * stderr markers (VAULT-SANDBOX-CONTEXT / VAULT-NEEDS-APPROVAL /
+ * VAULT-BROKER-UNREACHABLE / VAULT-BROKER-DENIED) through the structured
+ * renderer; falls back to a raw pre-block for anything else.
+ */
+function renderVaultOpFailure(
+  verbLabel: 'list' | 'get' | 'set' | 'delete',
+  cliOutput: string,
+  key: string | undefined,
+): string {
+  const parsed = parseVaultCliError(cliOutput)
+  // Map the gateway-internal op label onto the renderer's verb. 'delete'
+  // surfaces in the host hint as `switchroom vault remove <key>` (the
+  // canonical CLI name); 'list' has no key.
+  const verb = verbLabel === 'delete' ? 'remove' : verbLabel
+  const rendered = renderVaultCliError(parsed, { verb, key })
+  if (rendered.suppressRaw) return rendered.html
+  return `<b>vault ${verbLabel} failed:</b>\n${preBlock(cliOutput)}`
+}
+
 async function executeVaultOp(ctx: Context, chatId: string, op: 'list' | 'get' | 'set' | 'delete', key: string | undefined, passphrase: string, setValue: string | undefined): Promise<void> {
   if (op === 'list') {
     const r = runVaultCli(['list'], passphrase)
-    if (!r.ok) { await switchroomReply(ctx, `<b>vault list failed:</b>\n${preBlock(r.output)}`, { html: true }); return }
+    if (!r.ok) { await switchroomReply(ctx, renderVaultOpFailure('list', r.output, undefined), { html: true }); return }
     const keys = r.output.split('\n').filter(Boolean)
     if (keys.length === 0) { await switchroomReply(ctx, 'Vault is empty.', { html: true }) }
     else { await switchroomReply(ctx, `<b>Vault keys (${keys.length}):</b>\n${keys.map(k => `• <code>${escapeHtmlForTg(k)}</code>`).join('\n')}`, { html: true }) }
   } else if (op === 'get') {
     const r = runVaultCli(['get', key!], passphrase)
-    if (!r.ok) { await switchroomReply(ctx, `<b>vault get failed:</b>\n${preBlock(r.output)}`, { html: true }); return }
+    if (!r.ok) { await switchroomReply(ctx, renderVaultOpFailure('get', r.output, key), { html: true }); return }
     await switchroomReply(ctx, `<code>${escapeHtmlForTg(key!)}</code> =\n<code>${escapeHtmlForTg(r.output)}</code>`, { html: true })
   } else if (op === 'set') {
     if (setValue === undefined) {
@@ -5957,11 +5987,11 @@ async function executeVaultOp(ctx: Context, chatId: string, op: 'list' | 'get' |
       return
     }
     const r = runVaultCli(['set', key!], passphrase, setValue)
-    if (!r.ok) { await switchroomReply(ctx, `<b>vault set failed:</b>\n${preBlock(r.output)}`, { html: true }) }
+    if (!r.ok) { await switchroomReply(ctx, renderVaultOpFailure('set', r.output, key), { html: true }) }
     else { await switchroomReply(ctx, `✅ <code>${escapeHtmlForTg(key!)}</code> saved to vault.`, { html: true }) }
   } else if (op === 'delete') {
     const r = runVaultCli(['remove', key!], passphrase)
-    if (!r.ok) { await switchroomReply(ctx, `<b>vault delete failed:</b>\n${preBlock(r.output)}`, { html: true }) }
+    if (!r.ok) { await switchroomReply(ctx, renderVaultOpFailure('delete', r.output, key), { html: true }) }
     else { await switchroomReply(ctx, `✅ <code>${escapeHtmlForTg(key!)}</code> removed from vault.`, { html: true }) }
   }
 }
@@ -8087,13 +8117,26 @@ async function executeDeferredSecretSave(
 
   const write = defaultVaultWrite(slug, deferred.text, passphrase)
   if (!write.ok) {
-    // Keep the deferred entry so the user can retry by tapping again.
+    // Classify the failure via the structured stderr markers emitted by
+    // `switchroom vault` (issue #969 P0a). If it's a recognised marker,
+    // render a clean actionable message instead of dumping the raw
+    // "Vault file not found …" / "VAULT-NEEDS-APPROVAL …" blob the CLI
+    // emits — that was the misleading-error half of #968.
+    //
+    // Keep the deferred entry so the user can retry by tapping again
+    // once the underlying condition is fixed (broker started, host
+    // approval granted, etc.).
+    const parsed = parseVaultCliError(write.output)
+    const rendered = renderVaultCliError(parsed, { verb: "save", key: slug })
+    const body = rendered.suppressRaw
+      ? rendered.html
+      : `⚠️ vault write failed:\n<pre>${escapeHtmlForTg(write.output)}</pre>`
     if (cardMessageId != null) {
       await ctx.api
         .editMessageText(
           deferred.chat_id,
           cardMessageId,
-          `⚠️ vault write failed:\n<pre>${escapeHtmlForTg(write.output)}</pre>\n\nRe-tap to retry.`,
+          `${body}\n\nRe-tap to retry.`,
           {
             parse_mode: 'HTML',
             reply_markup: buildDeferredSecretKeyboard(deferKey).inline_keyboard.length > 0

--- a/telegram-plugin/secret-detect/vault-error.test.ts
+++ b/telegram-plugin/secret-detect/vault-error.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Tests for the vault-CLI error parser + renderer (issue #969 P0b).
+ */
+
+import { describe, it, expect } from "vitest";
+import { parseVaultCliError, renderVaultCliError } from "./vault-error.js";
+
+describe("parseVaultCliError", () => {
+  it("classifies VAULT-SANDBOX-CONTEXT", () => {
+    const stderr =
+      "VAULT-SANDBOX-CONTEXT: direct vault access is unavailable inside an " +
+      "agent sandbox. The vault file is not mounted into agent containers; " +
+      "only the broker socket is. Run 'switchroom vault init' on the host shell, " +
+      "or use a broker-supported operation.";
+    const err = parseVaultCliError(stderr);
+    expect(err.kind).toBe("sandbox_context");
+    // The hint contains 'switchroom vault init' — parser must skip it.
+    expect(err.key).toBeUndefined();
+  });
+
+  it("classifies VAULT-NEEDS-APPROVAL and extracts the affected key", () => {
+    const stderr =
+      "VAULT-NEEDS-APPROVAL [unknown_key]: secret 'telegram_bot_token_klanker_20260510' " +
+      "does not exist in the vault yet. Agents can rotate existing keys via " +
+      "the broker but cannot create new ones; this requires operator approval.";
+    const err = parseVaultCliError(stderr);
+    expect(err.kind).toBe("needs_approval");
+    expect(err.key).toBe("telegram_bot_token_klanker_20260510");
+  });
+
+  it("classifies VAULT-BROKER-UNREACHABLE", () => {
+    const stderr =
+      "VAULT-BROKER-UNREACHABLE: cannot reach vault broker " +
+      "(ENOENT: no such file or directory, connect '/run/switchroom/broker/sock'). " +
+      "From inside the agent sandbox, direct vault access is not possible.";
+    const err = parseVaultCliError(stderr);
+    expect(err.kind).toBe("broker_unreachable");
+  });
+
+  it("classifies VAULT-BROKER-DENIED and extracts the KEY (not the agent name)", () => {
+    // Regression test: the canonical stderr has TWO single-quoted
+    // tokens — the agent name and the key name. The parser must pick
+    // the key (anchored after "key '") so the rendered host hint
+    // suggests granting access to the right key.
+    const stderr =
+      "VAULT-BROKER-DENIED [DENIED]: agent 'klanker' is not in the allow list for key 'shared_token'";
+    const err = parseVaultCliError(stderr);
+    expect(err.kind).toBe("broker_denied");
+    expect(err.key).toBe("shared_token");
+  });
+
+  it("returns 'other' for unrecognised errors", () => {
+    const err = parseVaultCliError("Error: something broke\nstack trace …");
+    expect(err.kind).toBe("other");
+    expect(err.key).toBeUndefined();
+  });
+
+  it("handles empty / undefined stderr gracefully", () => {
+    expect(parseVaultCliError("").kind).toBe("other");
+    expect(parseVaultCliError(undefined as unknown as string).kind).toBe("other");
+  });
+});
+
+describe("renderVaultCliError", () => {
+  it("renders sandbox_context with a host-CLI suggestion", () => {
+    const out = renderVaultCliError(
+      { kind: "sandbox_context", original: "x" },
+      { verb: "set", key: "my_key" },
+    );
+    expect(out.suppressRaw).toBe(true);
+    expect(out.html).toContain("must run on the host");
+    expect(out.html).toContain("switchroom vault set my_key");
+  });
+
+  it("renders needs_approval with the affected key + host hint + P1a teaser", () => {
+    const out = renderVaultCliError(
+      { kind: "needs_approval", original: "x", key: "telegram_bot_token" },
+      { verb: "save" },
+    );
+    expect(out.suppressRaw).toBe(true);
+    expect(out.html).toContain("operator approval required");
+    expect(out.html).toContain("<code>telegram_bot_token</code>");
+    expect(out.html).toContain("switchroom vault set telegram_bot_token");
+    expect(out.html).toContain("P1a"); // forward-pointer to the upcoming flow
+  });
+
+  it("renders broker_unreachable with the status command", () => {
+    const out = renderVaultCliError(
+      { kind: "broker_unreachable", original: "x" },
+      { verb: "set" },
+    );
+    expect(out.suppressRaw).toBe(true);
+    expect(out.html).toContain("broker isn't reachable");
+    expect(out.html).toContain("switchroom vault broker status");
+  });
+
+  it("renders broker_denied with a grant command + key", () => {
+    const out = renderVaultCliError(
+      { kind: "broker_denied", original: "x", key: "shared_token" },
+      { verb: "set" },
+    );
+    expect(out.suppressRaw).toBe(true);
+    expect(out.html).toContain("refused the request");
+    expect(out.html).toContain("switchroom vault grant");
+    expect(out.html).toContain("shared_token");
+  });
+
+  it("prefers verbHint.key over parser-extracted key (verbHint wins for host suggestion)", () => {
+    // The gateway always knows the key the user asked for; rendering
+    // must use that over any heuristic extraction so a parser glitch
+    // can't surface the wrong key in the host command suggestion.
+    const out = renderVaultCliError(
+      { kind: "broker_denied", original: "x", key: "parser-extracted" },
+      { verb: "set", key: "gateway-supplied" },
+    );
+    expect(out.html).toContain("gateway-supplied");
+    expect(out.html).not.toContain("parser-extracted");
+  });
+
+  it("returns suppressRaw=false for 'other' so the gateway falls back to a raw pre-block", () => {
+    const out = renderVaultCliError({ kind: "other", original: "weird error" }, { verb: "set" });
+    expect(out.suppressRaw).toBe(false);
+    expect(out.html).toBe("");
+  });
+
+  it("escapes HTML special characters in the key", () => {
+    const out = renderVaultCliError(
+      { kind: "needs_approval", original: "x", key: "key<with>html" },
+      { verb: "save" },
+    );
+    expect(out.html).not.toContain("<with>");
+    expect(out.html).toContain("key&lt;with&gt;html");
+  });
+});

--- a/telegram-plugin/secret-detect/vault-error.ts
+++ b/telegram-plugin/secret-detect/vault-error.ts
@@ -1,0 +1,202 @@
+/**
+ * Vault CLI error classification (issue #969 P0b).
+ *
+ * `switchroom vault` emits stable stderr markers + exit codes when it
+ * detects a failure mode the Telegram gateway should surface with
+ * specific UX rather than a raw pre-block of error text. This module
+ * parses those markers (introduced in #971 / P0a) and translates them
+ * into a structured result the gateway can render against.
+ *
+ * Markers (from `src/cli/vault.ts`):
+ *
+ *   VAULT-SANDBOX-CONTEXT     (exit 7) — direct vault file IO is
+ *                                       unavailable inside an agent
+ *                                       container; the requested verb
+ *                                       has no broker equivalent.
+ *
+ *   VAULT-NEEDS-APPROVAL      (exit 5) — agent tried to write to a key
+ *                                       that doesn't exist yet. Broker
+ *                                       PUT cannot introduce new keys;
+ *                                       operator approval is required.
+ *                                       (P1a will wire up an inline
+ *                                       approval card; until then we
+ *                                       surface the host-CLI hint.)
+ *
+ *   VAULT-BROKER-UNREACHABLE  (exit 6) — broker socket missing/dead;
+ *                                       operator needs to inspect on
+ *                                       the host.
+ *
+ *   VAULT-BROKER-DENIED       (exit 2) — broker reachable but ACL or
+ *                                       grant refused; operator needs
+ *                                       to add an explicit grant.
+ */
+
+export type VaultCliErrorKind =
+  | "sandbox_context"
+  | "needs_approval"
+  | "broker_unreachable"
+  | "broker_denied"
+  | "other";
+
+export interface VaultCliError {
+  kind: VaultCliErrorKind;
+  /** The original stderr text (kept for fallback rendering / audit log). */
+  original: string;
+  /**
+   * Best-effort extraction of the affected key name, if surfaced by the
+   * marker. Used to compose host-CLI hints like
+   * `switchroom vault set <key>`.
+   */
+  key?: string;
+}
+
+const MARKER_TO_KIND: ReadonlyArray<readonly [string, VaultCliErrorKind]> = [
+  ["VAULT-SANDBOX-CONTEXT", "sandbox_context"],
+  ["VAULT-NEEDS-APPROVAL", "needs_approval"],
+  ["VAULT-BROKER-UNREACHABLE", "broker_unreachable"],
+  ["VAULT-BROKER-DENIED", "broker_denied"],
+];
+
+/**
+ * Classify a vault-CLI stderr blob into a structured error. Returns
+ * `kind: "other"` when no recognized marker is present — caller should
+ * fall back to a raw pre-block.
+ *
+ * Key extraction is marker-aware. The four markers don't all surface
+ * the key the same way:
+ *
+ *   VAULT-NEEDS-APPROVAL [unknown_key]: secret '<KEY>' does not …
+ *   VAULT-BROKER-DENIED  [<CODE>]: agent '<AGENT>' is not in the
+ *                          allow list for key '<KEY>'
+ *   VAULT-SANDBOX-CONTEXT: … 'switchroom vault set <KEY>' on the host.
+ *
+ * A naïve "first single-quoted token" regex would grab the agent name
+ * for broker_denied. Prefer the token after a `key '` anchor when the
+ * marker is broker_denied / needs_approval; for sandbox_context the
+ * gateway supplies the key directly via verbHint (extraction here is
+ * best-effort and may stay undefined).
+ */
+export function parseVaultCliError(stderr: string): VaultCliError {
+  const text = stderr ?? "";
+  for (const [marker, kind] of MARKER_TO_KIND) {
+    if (text.includes(marker)) {
+      const key = extractKey(text, kind);
+      return { kind, original: text, key };
+    }
+  }
+  return { kind: "other", original: text };
+}
+
+function extractKey(text: string, kind: VaultCliErrorKind): string | undefined {
+  // Prefer the explicit `key '<X>'` anchor when present — it's the
+  // unambiguous form used in broker_denied's stderr.
+  const anchored = text.match(/key '([A-Za-z0-9_.-]+)'/);
+  if (anchored) return anchored[1];
+
+  // needs_approval: `secret '<X>' does not …` is the canonical form;
+  // the only other quoted token in that message is the agent name in
+  // the suggestion clause (which is never present today, but guard
+  // against drift).
+  if (kind === "needs_approval") {
+    const m = text.match(/secret '([A-Za-z0-9_.-]+)'/);
+    if (m) return m[1];
+  }
+
+  // Fall back to first single-quoted token, skipping the
+  // `'switchroom vault …'` hint that sandbox_context emits.
+  const allQuoted = [...text.matchAll(/'([^']+)'/g)];
+  for (const m of allQuoted) {
+    const candidate = m[1];
+    if (candidate.includes("switchroom")) continue;
+    if (!/^[A-Za-z0-9_.-]+$/.test(candidate)) continue;
+    return candidate;
+  }
+  return undefined;
+}
+
+export interface VaultErrorRendering {
+  /** Telegram HTML message (no surrounding decoration). */
+  html: string;
+  /**
+   * When true, the gateway should NOT print the raw stderr blob — the
+   * rendered message already conveys the actionable next step. When
+   * false (kind="other"), the gateway should append the original
+   * output in a <pre> block as before.
+   */
+  suppressRaw: boolean;
+}
+
+function htmlEscape(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
+/**
+ * Compose the user-facing Telegram HTML for a parsed vault error.
+ *
+ * @param err       Result from parseVaultCliError.
+ * @param verbHint  Optional descriptor of the in-progress action used
+ *                  to compose the host-side command suggestion (e.g.
+ *                  "set", "remove", "init").
+ */
+export function renderVaultCliError(
+  err: VaultCliError,
+  verbHint: { verb: "set" | "get" | "list" | "init" | "remove" | "save"; key?: string } = { verb: "set" },
+): VaultErrorRendering {
+  // The gateway always knows which key the user was acting on for
+  // get/set/remove — prefer that over the parser's best-effort
+  // extraction so a renderer mistake can't surface the wrong key in
+  // the host command suggestion (e.g. an agent name from a
+  // broker_denied message). Fall back to parser extraction only when
+  // the gateway didn't pass a key (e.g. list).
+  const key = verbHint.key ?? err.key;
+  switch (err.kind) {
+    case "sandbox_context":
+      return {
+        suppressRaw: true,
+        html:
+          `⚠️ <b>This action must run on the host.</b>\n` +
+          `The vault file isn't mounted inside the agent sandbox; only ` +
+          `the broker socket is. Open a host shell and run:\n` +
+          `<pre>switchroom vault ${verbHint.verb}${key ? ` ${htmlEscape(key)}` : ""}</pre>`,
+      };
+    case "needs_approval":
+      return {
+        suppressRaw: true,
+        html:
+          `⚠️ <b>New vault key — operator approval required.</b>\n` +
+          (key
+            ? `The agent tried to save <code>${htmlEscape(key)}</code>, but `
+            : `The agent tried to save a new key, but `) +
+          `agents can only rotate existing keys via the broker; introducing ` +
+          `a new key needs an operator action.\n\n` +
+          `For now, run on a host shell:\n` +
+          `<pre>switchroom vault set${key ? ` ${htmlEscape(key)}` : " &lt;key&gt;"}</pre>\n` +
+          `<i>A one-tap approval card is on the way (#969 P1a).</i>`,
+      };
+    case "broker_unreachable":
+      return {
+        suppressRaw: true,
+        html:
+          `⚠️ <b>Vault broker isn't reachable.</b>\n` +
+          `From inside the agent sandbox there's no fallback path. ` +
+          `Operator can check on the host:\n` +
+          `<pre>switchroom vault broker status</pre>`,
+      };
+    case "broker_denied":
+      return {
+        suppressRaw: true,
+        html:
+          `⚠️ <b>Vault broker refused the request.</b>\n` +
+          (key
+            ? `The agent isn't authorized to access <code>${htmlEscape(key)}</code>. `
+            : `The agent isn't authorized to access this key. `) +
+          `Operator can grant access from a host shell:\n` +
+          `<pre>switchroom vault grant &lt;agent&gt; --keys ${key ? htmlEscape(key) : "&lt;key&gt;"}</pre>`,
+      };
+    case "other":
+      return { suppressRaw: false, html: "" };
+  }
+}


### PR DESCRIPTION
## Summary

- P0a (#971) made \`switchroom vault\` emit stable stderr markers + exit codes when run inside an agent sandbox. P0b consumes them in the Telegram gateway so the user-facing failure UX explains what to do instead of dumping a raw \"Vault file not found …\" or \"VAULT-NEEDS-APPROVAL …\" blob.
- Closes the misleading-error half of #968. The agent-initiated save-button flow (one-tap approval card) is the next workstream — P1a — and is referenced in the rendered message.

## Detail

New helper \`telegram-plugin/secret-detect/vault-error.ts\`:
- \`parseVaultCliError(stderr) → { kind, original, key? }\` — marker-aware key extraction (anchored \`key '<X>'\` form wins over agent-name false positives).
- \`renderVaultCliError(parsed, { verb, key }) → { html, suppressRaw }\` — verbHint.key wins over parser-extracted to keep host suggestions correct.

Per-marker rendering:

| Marker | UX |
|---|---|
| \`VAULT-SANDBOX-CONTEXT\` | \"⚠️ This action must run on the host.\" + \`<pre>switchroom vault &lt;verb&gt; &lt;key&gt;</pre>\` |
| \`VAULT-NEEDS-APPROVAL\` | \"⚠️ New vault key — operator approval required.\" + host CLI hint + forward-pointer to P1a's approval-card flow |
| \`VAULT-BROKER-UNREACHABLE\` | \"⚠️ Vault broker isn't reachable.\" + \`switchroom vault broker status\` |
| \`VAULT-BROKER-DENIED\` | \"⚠️ Vault broker refused the request.\" + \`switchroom vault grant &lt;agent&gt; --keys &lt;key&gt;\` |
| (unrecognised) | falls back to existing raw \`<pre>\` of stderr — no regression |

Gateway wiring (\`telegram-plugin/gateway/gateway.ts\`):
1. \`executeDeferredSecretSave\` — the exact #968 surface — replaces raw write.output pre-block with structured render. Re-tap retry preserved.
2. \`executeVaultOp\` — every \`/vault list|get|set|delete\` failure path routes through new \`renderVaultOpFailure\` helper.
3. The \`stash\`/\`rename\` secret-staging path — same treatment.

## Test plan

- [x] \`vitest run telegram-plugin/secret-detect/vault-error.test.ts\` — 13 tests, all pass. Locks in: kind classification, key-anchor extraction (regression test for the broker_denied false-positive), verbHint.key precedence, HTML escape, suppressRaw fallback contract.
- [x] \`vitest run\` — full suite passes (5319 / 29 skipped / 0 fail).
- [x] \`tsc --noEmit\` clean.
- [x] \`npm run build\` clean.
- [x] Fresh-process reviewer pass (separate session) — APPROVE.

## Refs

- Closes the misleading-error half of #968 (the one-tap save-card flow is P1a)
- Epic #969

🤖 Generated with [Claude Code](https://claude.com/claude-code)