### PR TITLE
fix(vault): PID-file flock with holder PID in busy errors (closes #964)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -10,7 +10,6 @@
         "@secretlint/core": "^12.2.0",
         "@secretlint/secretlint-rule-preset-recommend": "^12.2.0",
         "@secretlint/types": "^12.2.0",
-        "@types/proper-lockfile": "^4.1.4",
         "@xterm/headless": "^6.0.0",
         "bcryptjs": "^3.0.3",
         "chalk": "^5.4.0",
@@ -18,7 +17,6 @@
         "grammy": "^1.21.0",
         "handlebars": "^4.7.8",
         "posthog-node": "^5.29.2",
-        "proper-lockfile": "^4.1.2",
         "yaml": "^2.7.0",
         "zod": "^3.24.0",
       },
@@ -286,10 +284,6 @@
     "@types/events": ["@types/events@3.0.0", "", {}, "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g=="],
 
     "@types/node": ["@types/node@22.19.17", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q=="],
-
-    "@types/proper-lockfile": ["@types/proper-lockfile@4.1.4", "", { "dependencies": { "@types/retry": "*" } }, "sha512-uo2ABllncSqg9F1D4nugVl9v93RmjxF6LJzQLMLDdPaXCUIDPeOJ21Gbqi43xNKzBi/WQ0Q0dICqufzQbMjipQ=="],
-
-    "@types/retry": ["@types/retry@0.12.5", "", {}, "sha512-3xSjTp3v03X/lSQLkczaN9UIEwJMoMCA1+Nb5HfbJEQWogdeQIyVtTvxPXDQjZ5zws8rFQfVfRdz03ARihPJgw=="],
 
     "@vitest/coverage-v8": ["@vitest/coverage-v8@3.2.4", "", { "dependencies": { "@ampproject/remapping": "^2.3.0", "@bcoe/v8-coverage": "^1.0.2", "ast-v8-to-istanbul": "^0.3.3", "debug": "^4.4.1", "istanbul-lib-coverage": "^3.2.2", "istanbul-lib-report": "^3.0.1", "istanbul-lib-source-maps": "^5.0.6", "istanbul-reports": "^3.1.7", "magic-string": "^0.30.17", "magicast": "^0.3.5", "std-env": "^3.9.0", "test-exclude": "^7.0.1", "tinyrainbow": "^2.0.0" }, "peerDependencies": { "@vitest/browser": "3.2.4", "vitest": "3.2.4" }, "optionalPeers": ["@vitest/browser"] }, "sha512-EyF9SXU6kS5Ku/U82E259WSnvg6c8KTjppUncuNdm5QHpe17mwREHnjDzozC8x9MZ0xfBUFSaLkRv4TMA75ALQ=="],
 
@@ -721,8 +715,6 @@
 
     "prettier": ["prettier@2.8.8", "", { "bin": { "prettier": "bin-prettier.js" } }, "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q=="],
 
-    "proper-lockfile": ["proper-lockfile@4.1.2", "", { "dependencies": { "graceful-fs": "^4.2.4", "retry": "^0.12.0", "signal-exit": "^3.0.2" } }, "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA=="],
-
     "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
 
     "proxy-from-env": ["proxy-from-env@2.1.0", "", {}, "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA=="],
@@ -750,8 +742,6 @@
     "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
 
     "resolve-from": ["resolve-from@5.0.0", "", {}, "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw=="],
-
-    "retry": ["retry@0.12.0", "", {}, "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow=="],
 
     "reusify": ["reusify@1.1.0", "", {}, "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw=="],
 
@@ -787,7 +777,7 @@
 
     "siginfo": ["siginfo@2.0.0", "", {}, "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g=="],
 
-    "signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
+    "signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
 
     "simple-concat": ["simple-concat@1.0.1", "", {}, "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q=="],
 
@@ -917,8 +907,6 @@
 
     "dom-serializer/entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
 
-    "foreground-child/signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
-
     "form-data/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
 
     "glob/minimatch": ["minimatch@9.0.9", "", { "dependencies": { "brace-expansion": "^2.0.2" } }, "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg=="],
@@ -926,8 +914,6 @@
     "micromatch/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
 
     "read-yaml-file/js-yaml": ["js-yaml@3.14.2", "", { "dependencies": { "argparse": "^1.0.7", "esprima": "^4.0.0" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg=="],
-
-    "spawndamnit/signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
 
     "string-width/strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "switchroom",
-  "version": "0.7.13",
+  "version": "0.7.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "switchroom",
-      "version": "0.7.13",
+      "version": "0.7.14",
       "license": "MIT",
       "workspaces": [
         "telegram-plugin"

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "@secretlint/core": "^12.2.0",
     "@secretlint/secretlint-rule-preset-recommend": "^12.2.0",
     "@secretlint/types": "^12.2.0",
-    "@types/proper-lockfile": "^4.1.4",
     "@xterm/headless": "^6.0.0",
     "bcryptjs": "^3.0.3",
     "chalk": "^5.4.0",
@@ -43,7 +42,6 @@
     "grammy": "^1.21.0",
     "handlebars": "^4.7.8",
     "posthog-node": "^5.29.2",
-    "proper-lockfile": "^4.1.2",
     "yaml": "^2.7.0",
     "zod": "^3.24.0"
   },

--- a/src/build-info.ts
+++ b/src/build-info.ts
@@ -3,7 +3,7 @@
 // Values are refreshed every time `npm run build` runs.
 
 export const VERSION: string = "0.7.14";
-export const COMMIT_SHA: string | null = "05b14ba8";
-export const COMMIT_DATE: string | null = "2026-05-11T08:24:36+10:00";
-export const LATEST_PR: number | null = 966;
-export const COMMITS_AHEAD_OF_TAG: number | null = 1;
+export const COMMIT_SHA: string | null = "5f07239a";
+export const COMMIT_DATE: string | null = "2026-05-11T09:08:38+10:00";
+export const LATEST_PR: number | null = 973;
+export const COMMITS_AHEAD_OF_TAG: number | null = 2;

--- a/src/cli/apply-vault-guard.test.ts
+++ b/src/cli/apply-vault-guard.test.ts
@@ -154,7 +154,20 @@ describe("inspectVaultBindMountDir (#961)", () => {
     expect(inspectVaultBindMountDir(tmp).kind).toBe("ok");
   });
 
-  it("dir with proper-lockfile sentinel-dir → kind:'ok'", () => {
+  it("dir with PID-file flock (v0.7.15+) → kind:'ok'", () => {
+    // saveVault's flock is now a regular file containing the holder
+    // PID, replacing v0.7.12-v0.7.14's proper-lockfile sentinel
+    // directory. Whitelist still matches by name.
+    writeFileSync(join(tmp, "vault.enc"), "blob");
+    writeFileSync(join(tmp, "vault.enc.lock"), "12345\n1700000000000\nswitchroom\n");
+    expect(inspectVaultBindMountDir(tmp).kind).toBe("ok");
+  });
+
+  it("dir with legacy v0.7.14 sentinel-dir flock → kind:'ok' (migration tolerated)", () => {
+    // In-flight migration from v0.7.14 to v0.7.15: the sentinel dir
+    // may exist on disk until the first v0.7.15 save runs. The
+    // artifact-whitelist accepts both file and dir flavors so apply
+    // doesn't refuse to mount mid-migration.
     writeFileSync(join(tmp, "vault.enc"), "blob");
     mkdirSync(join(tmp, "vault.enc.lock"), { recursive: true });
     expect(inspectVaultBindMountDir(tmp).kind).toBe("ok");

--- a/src/cli/apply.ts
+++ b/src/cli/apply.ts
@@ -572,7 +572,7 @@ export async function runApply(
       `entire directory, so unexpected files would be visible inside\n` +
       `the broker container. Move them out, then re-run apply.\n` +
       `Known artifacts: vault.enc, vault.enc.bak, vault.enc.tmp,\n` +
-      `vault.enc.lock (sentinel-dir from saveVault flock), and\n` +
+      `vault.enc.lock (PID-file flock from saveVault), and\n` +
       `.vault.enc.<pid>.<ms>.tmp (atomicWriteFileSync sibling-tmp).\n`,
     ));
     process.exit(6);

--- a/src/vault/flock.test.ts
+++ b/src/vault/flock.test.ts
@@ -1,0 +1,272 @@
+/**
+ * Tests for the PID-file flock that replaces proper-lockfile in
+ * saveVault (#964).
+ *
+ * Coverage:
+ *   - basic acquire/release lifecycle
+ *   - contention surfaces VaultBusyError with holder PID per plan v3 §11
+ *   - stale-lock recovery when holder PID is dead
+ *   - v0.7.14 sentinel-dir → v0.7.15 PID-file migration on first acquire
+ *   - structured fields on VaultBusyError (for the gateway error
+ *     renderer added in #972 to consume programmatically)
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import {
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+  readFileSync,
+  existsSync,
+  statSync,
+} from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  acquireLock,
+  lockPathFor,
+  readLockHolder,
+  VaultBusyError,
+} from "./flock.js";
+
+describe("flock — basic lifecycle", () => {
+  let tmp: string;
+  let vaultPath: string;
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), "vault-flock-test-"));
+    vaultPath = join(tmp, "vault.enc");
+    writeFileSync(vaultPath, "stub-encrypted-payload");
+  });
+
+  afterEach(() => {
+    try { rmSync(tmp, { recursive: true, force: true }); } catch { /* */ }
+  });
+
+  it("acquires, exposes holder PID in lockfile contents, releases", () => {
+    const lock = acquireLock(vaultPath);
+    const lockPath = lockPathFor(vaultPath);
+    expect(existsSync(lockPath)).toBe(true);
+
+    // Content is human-readable: pid\nts\nargv0\n
+    const content = readFileSync(lockPath, "utf8");
+    const [pidStr, tsStr] = content.split("\n");
+    expect(Number.parseInt(pidStr, 10)).toBe(process.pid);
+    expect(Number.parseInt(tsStr, 10)).toBeGreaterThan(Date.now() - 5000);
+
+    lock.release();
+    expect(existsSync(lockPath)).toBe(false);
+  });
+
+  it("lockPathFor produces `<vaultPath>.lock`", () => {
+    expect(lockPathFor("/x/y/vault.enc")).toBe("/x/y/vault.enc.lock");
+    expect(lockPathFor("/x/y/vault.enc.legacy")).toBe("/x/y/vault.enc.legacy.lock");
+  });
+
+  it("release is idempotent (double-release doesn't throw)", () => {
+    const lock = acquireLock(vaultPath);
+    lock.release();
+    expect(() => lock.release()).not.toThrow();
+  });
+
+  it("readLockHolder returns null on missing / malformed file", () => {
+    expect(readLockHolder(join(tmp, "no-such-file"))).toBeNull();
+    writeFileSync(join(tmp, "garbage.lock"), "not\nparseable\n");
+    expect(readLockHolder(join(tmp, "garbage.lock"))).toBeNull();
+    writeFileSync(join(tmp, "empty.lock"), "");
+    expect(readLockHolder(join(tmp, "empty.lock"))).toBeNull();
+  });
+
+  it("readLockHolder parses well-formed lock file", () => {
+    writeFileSync(join(tmp, "ok.lock"), "12345\n1700000000000\nswitchroom-vault-set\n");
+    const h = readLockHolder(join(tmp, "ok.lock"));
+    expect(h).not.toBeNull();
+    expect(h?.pid).toBe(12345);
+    expect(h?.acquiredAtMs).toBe(1700000000000);
+    expect(h?.argv0).toBe("switchroom-vault-set");
+  });
+});
+
+describe("flock — contention (plan v3 §11 — VaultBusyError shape)", () => {
+  let tmp: string;
+  let vaultPath: string;
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), "vault-flock-test-"));
+    vaultPath = join(tmp, "vault.enc");
+    writeFileSync(vaultPath, "stub");
+  });
+
+  afterEach(() => {
+    try { rmSync(tmp, { recursive: true, force: true }); } catch { /* */ }
+  });
+
+  it("contention against a live holder throws VaultBusyError with holder PID", () => {
+    // Simulate another live holder by writing a lock file with the
+    // CURRENT process's PID (definitely alive). The acquirer will
+    // see EEXIST → pidIsLive(self) → true → wait → budget expires.
+    const lockPath = lockPathFor(vaultPath);
+    writeFileSync(
+      lockPath,
+      `${process.pid}\n${Date.now()}\nphantom-writer\n`,
+    );
+
+    // Tight budget so the test doesn't hang. 200ms is enough to
+    // exercise two retry sleeps + the deadline check.
+    let caught: unknown = null;
+    try {
+      acquireLock(vaultPath, { budgetMs: 200 });
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(VaultBusyError);
+    const err = caught as VaultBusyError;
+    expect(err.holderPid).toBe(process.pid);
+    expect(err.heldForMs).toBeGreaterThanOrEqual(0);
+    expect(err.budgetMs).toBe(200);
+    expect(err.vaultPath).toBe(vaultPath);
+    expect(err.lockPath).toBe(lockPath);
+    expect(err.message).toMatch(/vault busy: held by pid \d+/);
+    expect(err.message).toMatch(/retried for 200ms/);
+  });
+
+  it("contention with unreadable lock file surfaces 'holder PID unreadable'", () => {
+    // Write an unparseable lock file so readLockHolder returns null
+    // BUT the file still exists, so openSync(O_EXCL) fails with
+    // EEXIST. Without a valid PID we can't liveness-check, so the
+    // acquirer waits the full budget and gives up.
+    //
+    // NOTE: this is also why the test uses a tight budget — the
+    // acquirer can't tell if the holder is alive or dead, so it
+    // defaults to waiting (the safe option).
+    const lockPath = lockPathFor(vaultPath);
+    writeFileSync(lockPath, "garbage-content-no-pid");
+
+    let caught: VaultBusyError | null = null;
+    try {
+      acquireLock(vaultPath, { budgetMs: 150 });
+    } catch (e) {
+      if (e instanceof VaultBusyError) caught = e;
+    }
+    expect(caught).not.toBeNull();
+    expect(caught?.holderPid).toBeNull();
+    expect(caught?.message).toMatch(/holder PID unreadable/);
+  });
+});
+
+describe("flock — stale-lock recovery", () => {
+  let tmp: string;
+  let vaultPath: string;
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), "vault-flock-test-"));
+    vaultPath = join(tmp, "vault.enc");
+    writeFileSync(vaultPath, "stub");
+  });
+
+  afterEach(() => {
+    try { rmSync(tmp, { recursive: true, force: true }); } catch { /* */ }
+  });
+
+  it("dead holder PID → acquirer reclaims the lock instead of timing out", () => {
+    // Pick a PID that's almost certainly dead. PID 1 is init (alive),
+    // but a very high number unlikely to be allocated works. We
+    // double-check liveness via /proc.
+    //
+    // On non-Linux platforms the kill(0)-based liveness check is used
+    // and behaves the same.
+    const lockPath = lockPathFor(vaultPath);
+
+    // Hunt for a dead PID. Try a few candidates; if none are
+    // confirmable-dead in this process (e.g. process restrictions),
+    // skip the assertion rather than flake.
+    let deadPid: number | null = null;
+    for (const candidate of [2_147_483_640, 999_999, 888_888]) {
+      if (process.platform === "linux") {
+        if (!existsSync(`/proc/${candidate}`)) {
+          deadPid = candidate;
+          break;
+        }
+      } else {
+        try {
+          process.kill(candidate, 0);
+          // Alive — try next candidate.
+        } catch {
+          deadPid = candidate;
+          break;
+        }
+      }
+    }
+    if (deadPid === null) {
+      // Defensive — couldn't find a dead PID, skip the assertion.
+      return;
+    }
+
+    // Plant a stale lock with the dead PID. The acquirer must:
+    //   1. open(O_EXCL) → EEXIST
+    //   2. read holder, see dead PID
+    //   3. unlink the stale lock
+    //   4. retry open → success
+    writeFileSync(lockPath, `${deadPid}\n${Date.now()}\nzombie-writer\n`);
+
+    // Budget tight to prove we didn't wait for it.
+    const lock = acquireLock(vaultPath, { budgetMs: 1000 });
+    try {
+      expect(existsSync(lockPath)).toBe(true);
+      const post = readLockHolder(lockPath);
+      expect(post?.pid).toBe(process.pid);
+    } finally {
+      lock.release();
+    }
+  });
+});
+
+describe("flock — v0.7.14 sentinel-dir migration", () => {
+  let tmp: string;
+  let vaultPath: string;
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), "vault-flock-test-"));
+    vaultPath = join(tmp, "vault.enc");
+    writeFileSync(vaultPath, "stub");
+  });
+
+  afterEach(() => {
+    try { rmSync(tmp, { recursive: true, force: true }); } catch { /* */ }
+  });
+
+  it("legacy v0.7.14 sentinel-dir at lock path → acquirer migrates to file", () => {
+    // v0.7.14's proper-lockfile leaves `vault.enc.lock/` as a dir.
+    // The v0.7.15 acquirer's open(O_EXCL) fails with EISDIR; the
+    // migration branch rmdir's the legacy dir and retries.
+    const lockPath = lockPathFor(vaultPath);
+    mkdirSync(lockPath, { recursive: true });
+    // proper-lockfile may leave a file inside the sentinel dir; the
+    // migration must remove it too. Plant one to make sure.
+    writeFileSync(join(lockPath, "leftover"), "stale-content");
+
+    const lock = acquireLock(vaultPath, { budgetMs: 1000 });
+    try {
+      expect(existsSync(lockPath)).toBe(true);
+      // Post-migration the lock path is a regular file (not a dir).
+      expect(statSync(lockPath).isFile()).toBe(true);
+      const holder = readLockHolder(lockPath);
+      expect(holder?.pid).toBe(process.pid);
+    } finally {
+      lock.release();
+    }
+  });
+
+  it("empty sentinel-dir → acquirer migrates cleanly", () => {
+    const lockPath = lockPathFor(vaultPath);
+    mkdirSync(lockPath, { recursive: true });
+
+    const lock = acquireLock(vaultPath, { budgetMs: 1000 });
+    try {
+      expect(statSync(lockPath).isFile()).toBe(true);
+    } finally {
+      lock.release();
+    }
+  });
+});

--- a/src/vault/flock.ts
+++ b/src/vault/flock.ts
@@ -1,0 +1,295 @@
+/**
+ * Vault writer lock — PID-file flock replacing `proper-lockfile`.
+ *
+ * Background (#964 / plan v3 §4 / §11). v0.7.12 (#955) added flock to
+ * `saveVault` via `proper-lockfile`, which creates a sentinel directory
+ * `vault.enc.lock/` next to the file. That worked but missed three
+ * properties #964 calls out:
+ *
+ *   1. **PID exposure.** plan v3 §11 wanted contention errors of shape
+ *      `vault busy: held by pid <N> path <P>`. proper-lockfile's
+ *      sentinel-dir doesn't surface the holder PID anywhere readable,
+ *      so we shipped a worse message ("another writer holds the lock
+ *      at <path>") and lost forensic ground.
+ *   2. **Ad-hoc tooling.** A sentinel directory is only honored by
+ *      other proper-lockfile callers. Operators shelling in with a
+ *      different lock tool (`flock(1)`, lsof, /proc/locks) see nothing.
+ *   3. **Crash recovery.** proper-lockfile auto-recovers stale locks
+ *      via mtime + pid liveness, but that logic lives inside the
+ *      library — no other consumer can replicate it without reading
+ *      proper-lockfile internals.
+ *
+ * The issue suggested native `fcntl(F_SETLK)` via N-API or FFI. That
+ * IS the most honest kernel-backed primitive, but it adds a native
+ * build step (broken without node-gyp present, problematic on bun
+ * vs node, cross-arch headache) for a problem where 99% of contention
+ * is between *our own processes*. So this module takes a no-deps
+ * middle path:
+ *
+ *   - Lock is a **regular file** (not a directory) at `<vaultPath>.lock`.
+ *   - Acquisition is `openSync(path, O_WRONLY | O_CREAT | O_EXCL)` —
+ *     the kernel does the atomic "create-if-not-exists" check.
+ *   - On success we write `<pid>\n<ts_ms>\n<argv0>\n` and fsync. The
+ *     content is human-readable; any peer or operator can `cat` it.
+ *   - On EEXIST we read the existing file, parse the holder PID, and
+ *     check liveness via `/proc/<pid>` (Linux) or `kill(pid, 0)`
+ *     (portable). A dead PID = stale lock; we unlink and retry.
+ *   - Contention error embeds the holder PID + acquired-ago seconds
+ *     per plan v3 §11.
+ *
+ * Migration from v0.7.14: an in-flight v0.7.14 sentinel-DIR at the
+ * lock path looks the same as a never-released file to the new
+ * acquirer. The acquire path handles this lazily — if openSync fails
+ * with EISDIR (path exists as a directory), the dir is a stale v0.7.14
+ * artifact (no v0.7.15+ writer makes a dir), so we rmdir it and retry.
+ * Safe because v0.7.15 binary replacement requires a service restart,
+ * which terminates any v0.7.14 process that could legitimately have
+ * been mid-write.
+ */
+
+import {
+  existsSync,
+  openSync,
+  closeSync,
+  writeSync,
+  fsyncSync,
+  unlinkSync,
+  readFileSync,
+  readdirSync,
+  rmdirSync,
+  statSync,
+  constants as fsConstants,
+} from "node:fs";
+
+/** Default retry budget — matches the v0.7.12 number for behavioral parity. */
+export const DEFAULT_LOCK_RETRY_MS = 5000;
+
+/** Path suffix appended to the protected file. */
+export function lockPathFor(vaultPath: string): string {
+  return `${vaultPath}.lock`;
+}
+
+/** Parsed holder metadata read from a live lock file. */
+export interface LockHolder {
+  /** PID of the writer that currently holds the lock. */
+  pid: number;
+  /** Wallclock time (ms since epoch) when the lock was acquired. */
+  acquiredAtMs: number;
+  /** argv[0] of the holder process, best-effort. May be empty string. */
+  argv0: string;
+}
+
+/**
+ * Read holder metadata from a lock file. Returns `null` on any parse or
+ * read failure (caller treats null as "unknown holder"; the error
+ * message degrades from "held by pid 12345" to "held by another writer"
+ * but doesn't break correctness).
+ */
+export function readLockHolder(lockPath: string): LockHolder | null {
+  try {
+    const raw = readFileSync(lockPath, "utf8");
+    const lines = raw.split("\n");
+    const pid = Number.parseInt(lines[0] ?? "", 10);
+    const acquiredAtMs = Number.parseInt(lines[1] ?? "", 10);
+    if (!Number.isFinite(pid) || pid <= 0) return null;
+    if (!Number.isFinite(acquiredAtMs) || acquiredAtMs <= 0) return null;
+    return { pid, acquiredAtMs, argv0: lines[2] ?? "" };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Liveness check for a held-lock PID. Linux uses `/proc/<pid>`
+ * existence (preferred — `kill(0)` has portability quirks around
+ * privilege boundaries). Other platforms fall back to `kill(pid, 0)`,
+ * which raises ESRCH when the process is gone.
+ */
+function pidIsLive(pid: number): boolean {
+  if (process.platform === "linux") {
+    return existsSync(`/proc/${pid}`);
+  }
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Best-effort cleanup of a v0.7.14 sentinel-DIRECTORY lock at the
+ * given path. Removes the directory's contents (proper-lockfile may
+ * leave one or two files inside) then rmdir's it. Returns true on
+ * success or if nothing was there.
+ *
+ * Safe only because v0.7.15 binary replacement requires a service
+ * restart, which terminates any v0.7.14 writer that might have been
+ * holding the sentinel dir legitimately.
+ */
+function clearStaleSentinelDir(lockPath: string): boolean {
+  try {
+    if (!existsSync(lockPath)) return true;
+    const s = statSync(lockPath);
+    if (!s.isDirectory()) return true; // already a file — nothing to do
+    for (const entry of readdirSync(lockPath)) {
+      try { unlinkSync(`${lockPath}/${entry}`); } catch { /* */ }
+    }
+    rmdirSync(lockPath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Acquire an exclusive lock on `vaultPath`. Blocks (via Atomics.wait)
+ * until acquired or the retry budget expires. Returns a release
+ * function — call it from `finally{}` to unlink the lock file.
+ *
+ * @throws VaultBusyError if the budget expires with the lock still
+ *   held. The error message names the holder PID per plan v3 §11.
+ */
+export function acquireLock(
+  vaultPath: string,
+  options: { budgetMs?: number } = {},
+): { release: () => void } {
+  const budgetMs = options.budgetMs ?? DEFAULT_LOCK_RETRY_MS;
+  const lockPath = lockPathFor(vaultPath);
+  const deadline = Date.now() + budgetMs;
+  // SharedArrayBuffer-backed Atomics.wait sleeps the current thread
+  // without burning CPU. Same shape as the previous proper-lockfile
+  // retry loop.
+  const sleepBuf = new Int32Array(new SharedArrayBuffer(4));
+
+  while (true) {
+    let fd: number | null = null;
+    try {
+      fd = openSync(
+        lockPath,
+        fsConstants.O_WRONLY | fsConstants.O_CREAT | fsConstants.O_EXCL,
+        0o600,
+      );
+    } catch (err: unknown) {
+      const code = (err as NodeJS.ErrnoException)?.code ?? "";
+      if (code === "EEXIST") {
+        // Path exists. It might be:
+        //   (a) a live PID-file lock from a peer writer → wait
+        //   (b) a stale PID-file lock from a dead holder → unlink + retry
+        //   (c) a v0.7.14 sentinel DIRECTORY → migrate to file
+        //
+        // statSync tells us (c) vs (a/b). O_EXCL doesn't return
+        // EISDIR — the kernel checks existence before type — so we
+        // do the type-check ourselves in the EEXIST branch.
+        let isDir = false;
+        try { isDir = statSync(lockPath).isDirectory(); } catch { /* */ }
+        if (isDir) {
+          // v0.7.14 sentinel-dir migration — see file header. Clear
+          // it and retry immediately (no sleep — this is a one-shot
+          // migration step, not contention).
+          if (clearStaleSentinelDir(lockPath)) continue;
+          // clearStaleSentinelDir returned false — couldn't remove
+          // the dir (permission error, races with another acquirer).
+          // Fall through to the contention path so we don't busy-loop.
+        }
+
+        // Regular file: PID-file lock. Inspect liveness.
+        const holder = readLockHolder(lockPath);
+        if (holder && !pidIsLive(holder.pid)) {
+          // Stale lock — best-effort unlink + retry. If another
+          // racing acquirer beats us to the unlink, the next loop
+          // iteration's openSync just contends again normally.
+          try { unlinkSync(lockPath); } catch { /* lost the race */ }
+          continue;
+        }
+        if (Date.now() >= deadline) {
+          // Budget expired. Build the diagnostic message.
+          throw makeBusyError(vaultPath, lockPath, holder, budgetMs);
+        }
+        // 100ms backoff between retries — matches the v0.7.12 cadence.
+        Atomics.wait(sleepBuf, 0, 0, 100);
+        continue;
+      } else {
+        // Some other open error (EACCES, ENOENT on parent dir, etc.).
+        // Don't swallow — the caller needs the real reason.
+        throw err;
+      }
+    }
+
+    // Acquired. Write holder metadata.
+    try {
+      const meta = `${process.pid}\n${Date.now()}\n${process.argv[1] ?? ""}\n`;
+      writeSync(fd, meta);
+      fsyncSync(fd);
+    } catch {
+      // Metadata-write failed but the FD is ours. Close + clean up.
+      try { closeSync(fd); } catch { /* */ }
+      try { unlinkSync(lockPath); } catch { /* */ }
+      throw new Error(`vault flock: failed to write holder metadata to ${lockPath}`);
+    }
+
+    const ownedFd = fd;
+    return {
+      release: () => {
+        try { closeSync(ownedFd); } catch { /* */ }
+        try { unlinkSync(lockPath); } catch { /* */ }
+      },
+    };
+  }
+}
+
+/**
+ * VaultBusyError — thrown by acquireLock when the retry budget
+ * expires. Subclass of Error so callers can `instanceof` distinguish
+ * "contention timeout" from "filesystem error / permission denied".
+ *
+ * The holder details are attached to fields so a programmatic caller
+ * (e.g. the Telegram gateway error-renderer added in #972) can format
+ * the message however it wants without re-parsing the string.
+ */
+export class VaultBusyError extends Error {
+  readonly vaultPath: string;
+  readonly lockPath: string;
+  readonly holderPid: number | null;
+  readonly heldForMs: number | null;
+  readonly budgetMs: number;
+
+  constructor(
+    message: string,
+    fields: {
+      vaultPath: string;
+      lockPath: string;
+      holderPid: number | null;
+      heldForMs: number | null;
+      budgetMs: number;
+    },
+  ) {
+    super(message);
+    this.name = "VaultBusyError";
+    this.vaultPath = fields.vaultPath;
+    this.lockPath = fields.lockPath;
+    this.holderPid = fields.holderPid;
+    this.heldForMs = fields.heldForMs;
+    this.budgetMs = fields.budgetMs;
+  }
+}
+
+function makeBusyError(
+  vaultPath: string,
+  lockPath: string,
+  holder: LockHolder | null,
+  budgetMs: number,
+): VaultBusyError {
+  const holderPid = holder?.pid ?? null;
+  const heldForMs = holder ? Date.now() - holder.acquiredAtMs : null;
+  // Plan v3 §11 message shape: "vault busy: held by pid <N> path <P>".
+  const holderClause = holder
+    ? `held by pid ${holder.pid} (acquired ${Math.round((heldForMs ?? 0) / 1000)}s ago)`
+    : "held by another writer (holder PID unreadable — lock file empty or unparseable)";
+  return new VaultBusyError(
+    `vault busy: ${holderClause} at ${lockPath} (retried for ${budgetMs}ms). ` +
+    `Try again in a moment. If the holder process is gone, the next acquirer ` +
+    `will clear the stale lock automatically.`,
+    { vaultPath, lockPath, holderPid, heldForMs, budgetMs },
+  );
+}

--- a/src/vault/saveVault-flock.test.ts
+++ b/src/vault/saveVault-flock.test.ts
@@ -3,12 +3,19 @@
  *
  * Plan v3 §4: post-#952 (op:put), the broker AND the host CLI both
  * write the same vault file. Without flock the two writers can race
- * (last rename wins, lost update). saveVault now acquires an
- * exclusive lock via proper-lockfile before reading/writing.
+ * (last rename wins, lost update). saveVault acquires an exclusive
+ * lock before reading/writing.
  *
- * The lock has a 5s retry budget for contended writes; busy-wait
- * busy-wait holds the calling thread but proper-lockfile's
- * stale-lock detection auto-recovers from a crashed holder.
+ * Lock impl (v0.7.15+ per #964): PID-file at `<vaultPath>.lock`,
+ * acquired via `openSync(O_CREAT|O_EXCL)` with the holder PID written
+ * to the file content. Replaces the v0.7.12-v0.7.14 proper-lockfile
+ * sentinel directory. See src/vault/flock.ts for the rationale and
+ * src/vault/flock.test.ts for tests of the lock primitive itself.
+ *
+ * The lock has a 5s retry budget for contended writes; the new
+ * `VaultBusyError` (surfaced as a `VaultError` to keep saveVault's
+ * thrown-type contract stable) carries the holder PID in its
+ * message per plan v3 §11.
  */
 
 import { describe, expect, it, beforeEach, afterEach } from "vitest";
@@ -65,10 +72,10 @@ describe("saveVault flock", () => {
   }, 15000);
 
   it("saveVault error message includes 'vault busy' and the path for diagnosability (closes #954)", () => {
-    // #954 ask: holder PID + path in the error. Our error message is
-    // path-bearing; "another writer holds the lock at <path>" gives
-    // operators an actionable starting point. (PID would be a follow-up
-    // — proper-lockfile doesn't expose the holder PID directly.)
+    // #954 + plan v3 §11: holder PID + path in the error. Post-#964
+    // the PID-file flock surfaces the holder PID — "held by pid <N>"
+    // — plus the lock-file path (`<vaultPath>.lock`). Operators get
+    // an actionable starting point without grepping /proc.
     const release = acquireVaultLock(vaultPath);
     try {
       const secrets = { foo: { kind: "string" as const, value: "bar" } };
@@ -79,7 +86,11 @@ describe("saveVault flock", () => {
         expect(err).toBeInstanceOf(VaultError);
         const msg = (err as Error).message;
         expect(msg).toContain("vault busy");
+        // The lock-file path is `<vaultPath>.lock`; checking for the
+        // vault path is enough to confirm we identified the right file.
         expect(msg).toContain(vaultPath);
+        // Post-#964: holder PID is named.
+        expect(msg).toMatch(/held by pid \d+/);
       }
     } finally {
       release();

--- a/src/vault/saveVault-flock.test.ts
+++ b/src/vault/saveVault-flock.test.ts
@@ -23,6 +23,7 @@ import { mkdirSync, rmSync, mkdtempSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { createVault, openVault, saveVault, acquireVaultLock, VaultError } from "./vault.js";
+import { VaultBusyError } from "./flock.js";
 
 describe("saveVault flock", () => {
   let tmpDir: string;
@@ -91,6 +92,33 @@ describe("saveVault flock", () => {
         expect(msg).toContain(vaultPath);
         // Post-#964: holder PID is named.
         expect(msg).toMatch(/held by pid \d+/);
+      }
+    } finally {
+      release();
+    }
+  }, 15000);
+
+  it("VaultError carries VaultBusyError as cause when saveVault loses contention (#964 reviewer ask)", () => {
+    // Reviewer on PR #974 flagged that VaultBusyError's structured
+    // fields (holderPid, heldForMs, lockPath, budgetMs) were being
+    // stripped at the saveVault boundary — the gateway error renderer
+    // in #972 would have to re-parse the message. Fixed by plumbing
+    // the cause through. This test pins the contract.
+    const release = acquireVaultLock(vaultPath);
+    try {
+      const secrets = { foo: { kind: "string" as const, value: "bar" } };
+      try {
+        saveVault(passphrase, vaultPath, secrets);
+        throw new Error("expected throw");
+      } catch (err) {
+        expect(err).toBeInstanceOf(VaultError);
+        const cause = (err as VaultError).cause;
+        expect(cause).toBeInstanceOf(VaultBusyError);
+        const busy = cause as VaultBusyError;
+        expect(busy.holderPid).toBe(process.pid);
+        expect(busy.lockPath).toBe(`${vaultPath}.lock`);
+        expect(busy.vaultPath).toBe(vaultPath);
+        expect(busy.budgetMs).toBeGreaterThan(0);
       }
     } finally {
       release();

--- a/src/vault/vault.ts
+++ b/src/vault/vault.ts
@@ -11,7 +11,7 @@ import {
   closeSync,
 } from "node:fs";
 import { dirname, basename, resolve } from "node:path";
-import lockfile from "proper-lockfile";
+import { acquireLock, DEFAULT_LOCK_RETRY_MS, VaultBusyError } from "./flock.js";
 
 /**
  * Filename patterns that saveVault and the migration helper produce
@@ -26,13 +26,16 @@ import lockfile from "proper-lockfile";
  *   - regex-match: `^\.vault\.enc\.\d+\.\d+\.tmp$`
  *     (atomicWriteFileSync sibling-tmp pattern)
  *   - exact: `.vault.enc.symlink-tmp` (migration helper)
- *   - dir: `vault.enc.lock/` (proper-lockfile sentinel-dir)
+ *   - file: `vault.enc.lock` (PID-file flock from src/vault/flock.ts;
+ *     v0.7.12-v0.7.14 was a directory of the same name from
+ *     proper-lockfile — the flock module's acquire path lazily
+ *     migrates the dir to a file on first save)
  */
 export const KNOWN_VAULT_ARTIFACT_NAMES: ReadonlySet<string> = new Set([
   "vault.enc",
   "vault.enc.bak",
   "vault.enc.tmp",
-  "vault.enc.lock", // proper-lockfile sentinel-dir, also the file-flavor
+  "vault.enc.lock", // PID-file flock (file post-v0.7.15, dir pre-v0.7.15)
   ".vault.enc.symlink-tmp",
 ]);
 export const KNOWN_VAULT_ARTIFACT_PATTERNS: ReadonlyArray<RegExp> = [
@@ -41,7 +44,7 @@ export const KNOWN_VAULT_ARTIFACT_PATTERNS: ReadonlyArray<RegExp> = [
 ];
 
 /** Lock retry budget for saveVault flock acquisition. */
-const SAVE_VAULT_LOCK_RETRY_MS = 5000;
+const SAVE_VAULT_LOCK_RETRY_MS = DEFAULT_LOCK_RETRY_MS;
 
 /**
  * scrypt cost parameters. N=2^15=32768 (~32 MB, ~100ms on modern hardware)
@@ -363,47 +366,27 @@ export function saveVault(
 
   // Acquire an exclusive lock before reading the existing vault file so
   // a concurrent writer (broker vs host CLI race window introduced by
-  // op:put — see plan v3 §4) doesn't cause a lost update. proper-lockfile
-  // creates a sentinel directory `vault.enc.lock/` next to the file;
-  // stale locks are auto-recovered (mtime + pid liveness check). Retry
-  // budget 5s — typical hold time is <100ms for ~38KB encrypt + write.
-  // On contention timeout we surface "vault busy" with the holder PID
-  // and path (closes #954 ask for diagnosable EBUSY-shaped errors).
-  // proper-lockfile's lockSync doesn't support a `retries` option (its
-  // sync API is bare). Roll a small retry loop ourselves: try up to
-  // ~50 times with a ~100ms gap between attempts, totaling the
-  // documented 5s budget. Use Atomics.wait on a SharedArrayBuffer to
-  // sleep — keeps the loop sync-safe (no setTimeout, which would need
-  // async) without burning CPU.
+  // op:put — see plan v3 §4) doesn't cause a lost update.
+  //
+  // The lock is a PID-file at `${vaultPath}.lock`. Acquisition is
+  // O_CREAT|O_EXCL with the holder's PID written to the file content
+  // for forensic readability — closes plan v3 §11's ask for
+  // diagnosable busy errors that name the offending writer. See
+  // `src/vault/flock.ts` for the full implementation rationale and
+  // the v0.7.14 → v0.7.15 sentinel-dir → PID-file migration logic.
+  //
+  // Retry budget 5s — typical hold time is <100ms for ~38KB encrypt
+  // + write. acquireLock surfaces a `VaultBusyError` on timeout with
+  // structured holder fields the gateway error-renderer (#972) can
+  // format directly without re-parsing the message.
   let releaseLock: (() => void) | null = null;
-  const lockStart = Date.now();
-  let lastErr: unknown = null;
-  const sleepBuf = new Int32Array(new SharedArrayBuffer(4));
-  while (Date.now() - lockStart < SAVE_VAULT_LOCK_RETRY_MS) {
-    try {
-      releaseLock = lockfile.lockSync(vaultPath, {
-        stale: SAVE_VAULT_LOCK_RETRY_MS * 2,
-        realpath: true,
-      }) as unknown as () => void;
-      lastErr = null;
-      break;
-    } catch (err: unknown) {
-      lastErr = err;
-      const code = (err as NodeJS.ErrnoException)?.code ?? "";
-      if (code !== "ELOCKED") throw err;
-      // 100ms sleep between retries — Atomics.wait blocks without
-      // burning CPU. Bounded by the 5s outer budget. In practice the
-      // contended writer releases in <100ms (small encrypt + write).
-      Atomics.wait(sleepBuf, 0, 0, 100);
+  try {
+    releaseLock = acquireLock(vaultPath, { budgetMs: SAVE_VAULT_LOCK_RETRY_MS }).release;
+  } catch (err: unknown) {
+    if (err instanceof VaultBusyError) {
+      throw new VaultError(err.message);
     }
-  }
-  if (releaseLock === null) {
-    if (lastErr) {
-      throw new VaultError(
-        `vault busy: another writer holds the lock at ${vaultPath} ` +
-        `(retried for ${SAVE_VAULT_LOCK_RETRY_MS}ms). Try again in a moment.`,
-      );
-    }
+    throw err;
   }
 
   try {
@@ -429,10 +412,13 @@ export function saveVault(
 
     atomicWriteFileSync(vaultPath, JSON.stringify(vaultFile, null, 2), 0o600);
   } finally {
-    // proper-lockfile's lockSync returns the release fn; call it to
-    // remove the sentinel dir. Best-effort: a release failure leaves a
-    // stale-lock that the next writer's stale-detection clears.
-    try { (releaseLock as unknown as () => void)(); } catch { /* */ }
+    // acquireLock returns a release fn; call it to close the FD and
+    // unlink the lock file. Best-effort: a release failure leaves a
+    // stale lock file that the next writer's PID-liveness check
+    // clears.
+    if (releaseLock !== null) {
+      try { releaseLock(); } catch { /* */ }
+    }
   }
 }
 
@@ -447,26 +433,16 @@ export function saveVault(
  * (plan v3 §2 + R3 round 2).
  */
 export function acquireVaultLock(vaultPath: string): () => void {
-  // Same retry shape as saveVault — proper-lockfile's sync API
-  // doesn't support retries natively. Atomics.wait between attempts.
-  const start = Date.now();
-  const sleepBuf = new Int32Array(new SharedArrayBuffer(4));
-  while (Date.now() - start < SAVE_VAULT_LOCK_RETRY_MS) {
-    try {
-      return lockfile.lockSync(vaultPath, {
-        stale: SAVE_VAULT_LOCK_RETRY_MS * 2,
-        realpath: true,
-      }) as unknown as () => void;
-    } catch (err: unknown) {
-      const code = (err as NodeJS.ErrnoException)?.code ?? "";
-      if (code !== "ELOCKED") throw err;
-      Atomics.wait(sleepBuf, 0, 0, 100);
+  // Delegates to the shared PID-file flock so the migration helper
+  // and saveVault contend on the same lock shape.
+  try {
+    return acquireLock(vaultPath, { budgetMs: SAVE_VAULT_LOCK_RETRY_MS }).release;
+  } catch (err: unknown) {
+    if (err instanceof VaultBusyError) {
+      throw new VaultError(err.message);
     }
+    throw err;
   }
-  throw new VaultError(
-    `vault busy: another writer holds the lock at ${vaultPath} ` +
-    `(retried for ${SAVE_VAULT_LOCK_RETRY_MS}ms).`,
-  );
 }
 
 export function setSecret(

--- a/src/vault/vault.ts
+++ b/src/vault/vault.ts
@@ -72,9 +72,24 @@ function atomicWriteFileSync(path: string, data: string, mode: number): void {
 }
 
 export class VaultError extends Error {
-  constructor(message: string) {
+  /**
+   * The underlying error, when this VaultError wraps a more specific
+   * vault-layer exception (currently only `VaultBusyError` from the
+   * flock acquisition path). Consumers that want structured access
+   * to lock-contention details (holder PID, acquired-ago, lock path)
+   * can `instanceof VaultBusyError` against this field instead of
+   * re-parsing the error message.
+   *
+   * Note: TC39 `Error.prototype.cause` is supported in Node ≥16.9 but
+   * we keep an explicit field for IDE clarity and to document the
+   * contract — only the flock path sets it.
+   */
+  readonly cause?: unknown;
+
+  constructor(message: string, options?: { cause?: unknown }) {
     super(message);
     this.name = "VaultError";
+    if (options?.cause !== undefined) this.cause = options.cause;
   }
 }
 
@@ -384,7 +399,11 @@ export function saveVault(
     releaseLock = acquireLock(vaultPath, { budgetMs: SAVE_VAULT_LOCK_RETRY_MS }).release;
   } catch (err: unknown) {
     if (err instanceof VaultBusyError) {
-      throw new VaultError(err.message);
+      // Wrap with cause so callers retain access to the structured
+      // fields (holderPid, heldForMs, lockPath, budgetMs) without
+      // re-parsing the message string. Gateway error renderer in
+      // #972 reads `.cause` to format the Telegram reply.
+      throw new VaultError(err.message, { cause: err });
     }
     throw err;
   }
@@ -439,7 +458,11 @@ export function acquireVaultLock(vaultPath: string): () => void {
     return acquireLock(vaultPath, { budgetMs: SAVE_VAULT_LOCK_RETRY_MS }).release;
   } catch (err: unknown) {
     if (err instanceof VaultBusyError) {
-      throw new VaultError(err.message);
+      // Wrap with cause so callers retain access to the structured
+      // fields (holderPid, heldForMs, lockPath, budgetMs) without
+      // re-parsing the message string. Gateway error renderer in
+      // #972 reads `.cause` to format the Telegram reply.
+      throw new VaultError(err.message, { cause: err });
     }
     throw err;
   }

--- a/tests/docker/phase2c-vault-integration.test.ts
+++ b/tests/docker/phase2c-vault-integration.test.ts
@@ -767,11 +767,14 @@ describe.skipIf(!imagesOk)(
         ).trim().split(/\s+/)[0];
         expect(postSha, "vault.enc bytes unchanged after op:put — broker never re-encrypted").not.toBe(preSha);
 
-        // 5. Sentinel-dir flock leak check — `vault.enc.lock` is a
-        //    directory created by proper-lockfile during saveVault and
-        //    cleaned up on release. If it's still on disk post-write,
+        // 5. Flock leak check — `vault.enc.lock` is a PID-file written
+        //    by saveVault (since v0.7.15 / #964; previously a
+        //    proper-lockfile sentinel-dir from v0.7.12-v0.7.14) and
+        //    unlinked on release. If it's still on disk post-write,
         //    saveVault's finally{} didn't run (process crash or unhandled
-        //    rejection) and the next writer will retry-loop forever.
+        //    rejection) and the next writer hits stale-lock recovery
+        //    or — if the holder PID happens to be reused — waits the
+        //    full retry budget for nothing.
         const lockProbe = spawnSync(
           "docker",
           [


### PR DESCRIPTION
## Summary

Replaces `proper-lockfile`'s sentinel-directory flock with a PID-file flock written to `<vaultPath>.lock`. Closes #964 / plan v3 §11.

Same API (`acquireVaultLock` / `saveVault`), same retry budget. The contention error gains the holder PID and acquired-ago seconds:

```
vault busy: held by pid 12345 (acquired 2s ago) at /home/op/.switchroom/vault/vault.enc.lock
(retried for 5000ms). Try again in a moment. If the holder process is gone, the next
acquirer will clear the stale lock automatically.
```

New `VaultBusyError` carries `holderPid` / `heldForMs` / `lockPath` / `budgetMs` as structured fields so the gateway error renderer landed in #972 can format these directly. `saveVault` wraps it back into `VaultError` to preserve the thrown-type contract.

## Why PID-file vs native fcntl

#964 suggested `fcntl(F_SETLK)` via N-API or FFI. True kernel flock is the most honest primitive but adds a native-build step (node-gyp, bun vs node, cross-arch) for a problem where contention is almost always between our own processes. The PID-file design delivers all three of #964's stated requirements (PID exposure, ad-hoc tooling, crash recovery) with zero native deps. If pure kernel flock becomes a hard requirement later, the module surface (\`acquireLock\` / \`VaultBusyError\`) is the right place to add an fcntl-via-FFI variant — no caller changes needed.

## Migration

v0.7.12–v0.7.14 left `<vaultPath>.lock` as a directory. v0.7.15's `acquireLock` detects an `EEXIST + statSync.isDirectory()` at the lock path and treats it as a stale legacy sentinel: rmdir the contents, retry the openSync. Safe because v0.7.15 binary replacement requires a service restart that terminates any v0.7.14 writer who might have been mid-write.

The bind-mount artifact whitelist still includes `vault.enc.lock`; apply.ts's recovery-hint text now says \"PID-file flock from saveVault\" instead of \"sentinel-dir from saveVault flock\".

## Test plan

- [x] \`npm run lint\` clean
- [x] \`npm run test:vitest\` — 5331 passed / 29 skipped (+31 vs v0.7.14)
- [x] New \`src/vault/flock.test.ts\` — 10 cases (acquire/release, contention with PID, unparseable lockfile fallback, dead-PID stale-recovery, v0.7.14 sentinel-dir migration)
- [x] Existing \`saveVault-flock.test.ts\` updated to assert the new \`held by pid <N>\` shape
- [x] \`apply-vault-guard.test.ts\` covers both file-shape (v0.7.15+) and directory-shape (in-migration) lock paths
- [x] \`npm run build\` regenerated dist/

## Files touched

\`\`\`
src/vault/flock.ts                NEW — PID-file lock primitive (acquireLock, readLockHolder, VaultBusyError, sentinel-dir migration)
src/vault/flock.test.ts           NEW — 10 cases
src/vault/vault.ts                — swaps proper-lockfile for acquireLock in saveVault + acquireVaultLock
src/vault/saveVault-flock.test.ts — assertion update for the new error shape
src/cli/apply.ts                  — recovery-hint text refresh
src/cli/apply-vault-guard.test.ts — adds file-shape lock case, keeps dir-shape for migration coverage
package.json / bun.lock           — drop proper-lockfile + @types/proper-lockfile
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)