### PR TITLE
docs+feat(vault): deprecate SWITCHROOM_VAULT_PASSPHRASE in sandbox + canonical-pattern docs (#969 P3)

### DIFF
--- a/docs/vault-security.md
+++ b/docs/vault-security.md
@@ -26,13 +26,13 @@ an optional expiry:
 
 ```bash
 # Read-only access to two named keys, 30-day expiry
-switchroom vault grant clerk --keys google_cal_refresh_token,google_cal_access_token --duration 30d
+switchroom vault grant clerk --keys google-cal-refresh-token,google-cal-access-token --duration 30d
 
 # Write access to any key matching a glob (issue #969 P1b)
-switchroom vault grant clerk --write 'google_cal_access_token' --duration 30d
+switchroom vault grant clerk --write 'google-cal-access-token' --duration 30d
 
 # Combined: read + rotate the same key
-switchroom vault grant clerk --keys google_cal_refresh_token --write google_cal_access_token --duration 30d
+switchroom vault grant clerk --keys google-cal-refresh-token --write google-cal-access-token --duration 30d
 ```
 
 The token is written to `~/.switchroom/agents/<agent>/.vault-token` (mode 0600).

--- a/docs/vault-security.md
+++ b/docs/vault-security.md
@@ -1,0 +1,137 @@
+# Vault security model
+
+How agents and operators access vault secrets, and which path to use when.
+
+This document is the canonical reference. Skill authors and operators reading
+this should leave with a clear answer for "I'm in situation X — which auth path
+do I use, and what do I have to set up?"
+
+## Three auth paths
+
+The vault broker accepts three distinct authorization paths for read (`get` /
+`list`) and write (`put`). Each is appropriate in different contexts:
+
+| Path                       | Read         | Write (rotate) | Write (new key) | Where it runs        |
+|----------------------------|--------------|----------------|-----------------|----------------------|
+| Capability grant (token)   | ✅           | ✅ (write-grant)| ✅ (write-grant) | Agents, cron, scripts |
+| Path-as-identity (UDS)     | ✅ (cron ACL)| ✅             | ❌              | Agents, cron         |
+| Operator passphrase        | ✅           | ✅             | ✅              | Operator on host, gateway |
+
+### 1. Capability grant (`switchroom vault grant`)
+
+The canonical path for **autonomous agents** and **scheduled jobs**.
+
+The operator mints a token once, with a tightly-scoped set of allowed keys and
+an optional expiry:
+
+```bash
+# Read-only access to two named keys, 30-day expiry
+switchroom vault grant clerk --keys google_cal_refresh_token,google_cal_access_token --duration 30d
+
+# Write access to any key matching a glob (issue #969 P1b)
+switchroom vault grant clerk --write 'google_cal_access_token' --duration 30d
+
+# Combined: read + rotate the same key
+switchroom vault grant clerk --keys google_cal_refresh_token --write google_cal_access_token --duration 30d
+```
+
+The token is written to `~/.switchroom/agents/<agent>/.vault-token` (mode 0600).
+The broker client reads it automatically when the calling process sets
+`SWITCHROOM_AGENT_NAME=<agent>` (compose does this for agent containers).
+
+A grant is the **whole authorization story**: no passphrase needed, no env
+var, no host shell. The cron unit / skill script just calls `switchroom vault
+get <key>` or `switchroom vault set <key>` and the broker checks the token.
+
+Audit log entries for grant-based access carry `method:"grant"` and the
+`grant_id` so revocations can be traced back to the operator action that
+minted them.
+
+### 2. Path-as-identity
+
+The legacy cron path. Per-agent UDS sockets at
+`/run/switchroom/broker/<agent>/sock` are chowned to the agent's UID, and the
+broker parses the agent name from the bind path. Schedule-declared secrets
+(`agents.<agent>.schedule[i].secrets[]` in switchroom.yaml) gate access.
+
+Use this when:
+- Cron-fired tasks need a fixed set of secrets known at deploy time.
+- You want the secret allowlist in version control alongside the cron schedule.
+
+Does NOT allow new-key creation. Agents can rotate (write) keys they can
+already read.
+
+### 3. Operator passphrase
+
+The path for **operator-driven actions** from a host shell or the Telegram
+gateway. The broker is unlocked once (auto-unlock from `/etc/machine-id`, or
+interactively via `switchroom vault broker unlock`); after that, it holds the
+passphrase in memory so it can re-encrypt on writes.
+
+Two surface forms:
+
+- **`switchroom vault set <key>`** run interactively on the host with the
+  passphrase typed at the prompt (or set via `SWITCHROOM_VAULT_PASSPHRASE`).
+  Direct file IO; the broker is bypassed.
+- **Broker passphrase attestation** (issue #969 P1a). The Telegram gateway
+  forwards the operator's passphrase as a `passphrase` field on the PUT
+  request when the user taps an approval card (`vault_request_save`). The
+  broker validates against its loaded passphrase and authorizes the call as
+  operator-attested. This is what powers the one-tap save-from-Telegram flow.
+
+Audit log entries for passphrase-attested writes carry `method:"passphrase"`.
+
+## Decision flow
+
+```
+Is this an autonomous agent or scheduled job?
+├─ Yes → use a capability grant.
+│        (operator mints once with `vault grant`; agent / cron carries it
+│         transparently via .vault-token).
+│
+├─ No, this is the operator at a host shell.
+│        → use `switchroom vault set <key>` directly (the broker daemon
+│          stays out of the way for first-time provisioning).
+│
+└─ No, this is a Telegram-driven flow.
+         → use the `vault_request_save` MCP tool (#969 P1a). The user
+           taps an approval card; the gateway runs the write under
+           operator-passphrase attestation.
+```
+
+## Deprecation note: `SWITCHROOM_VAULT_PASSPHRASE` env var
+
+Some legacy skills document `SWITCHROOM_VAULT_PASSPHRASE` as a prerequisite —
+exported so the CLI can decrypt the vault directly without prompting. **This
+is the wrong pattern for agent-side skills** going forward:
+
+- It puts the master passphrase in every agent process's environment, where
+  any subprocess can read it via `/proc/<pid>/environ`. Agents launch many
+  subprocesses (claude, MCP servers, skill scripts).
+- It bypasses the broker's audit log entirely — accesses are invisible to
+  `vault audit log`.
+- It defeats the ACL model: a grant scoped to two keys is meaningless if the
+  caller also has the master passphrase.
+
+Migration:
+1. Operator: `switchroom vault grant <agent> --keys <X,Y> [--write <Z>] --duration <ttl>`.
+2. Remove `SWITCHROOM_VAULT_PASSPHRASE` from the skill's host prerequisites.
+3. Ensure the agent's `SWITCHROOM_AGENT_NAME` env is set (compose does this
+   automatically; standalone scripts must set it).
+4. The CLI's `vault get` / `vault set` will pick up `~/.switchroom/agents/
+   <agent>/.vault-token` transparently.
+
+`SWITCHROOM_VAULT_PASSPHRASE` is still honoured for backwards compatibility
+and for operator-host workflows (vault doctor, vault sweep, setup wizard).
+A runtime deprecation warning is emitted when the env var is consumed inside
+an agent sandbox (`SWITCHROOM_RUNTIME=docker`) where a grant should be used
+instead.
+
+## See also
+
+- `src/vault/broker/server.ts` — the broker's PUT/GET handlers and the order
+  in which auth paths are tried.
+- `src/vault/grants.ts` — grant schema, `validateGrant` / `validateGrantForWrite`.
+- `telegram-plugin/gateway/gateway.ts` — the `vault_request_save` tool +
+  `vrs:` callback flow.
+- Issue #968, epic #969 — the original gap that motivated P0–P3.

--- a/skills/token-helpers/SKILL.md
+++ b/skills/token-helpers/SKILL.md
@@ -65,7 +65,30 @@ Other env:
 - `curl`
 - `jq`
 - `switchroom` on `PATH` (or pass `SWITCHROOM_CLI`)
-- `SWITCHROOM_VAULT_PASSPHRASE` exported so the CLI can unlock the vault non-interactively
+
+### Vault authentication
+
+**Canonical: capability grant.** The CLI authenticates to the broker via the
+agent's capability token at `~/.switchroom/agents/<agent>/.vault-token` (mode
+0600). Mint once with:
+
+```bash
+switchroom vault grant <agent> \
+  --keys google-cal-refresh-token,google-cal-client-id,google-cal-client-secret \
+  --write google-cal-access-token \
+  --duration 30d
+```
+
+The agent container's compose env sets `SWITCHROOM_AGENT_NAME` automatically;
+standalone scripts must set it. The CLI reads the token transparently and
+forwards it on every `get` / `set` call. See `docs/vault-security.md` for the
+full model.
+
+**Legacy: `SWITCHROOM_VAULT_PASSPHRASE`** (deprecated for agent-side use,
+still honoured). Setting this env var puts the master passphrase in every
+subprocess's environment, defeats the ACL model, and bypasses the broker's
+audit log. A runtime deprecation warning is emitted when the env var is
+consumed inside an agent sandbox.
 
 ## Exit codes
 

--- a/src/cli/vault-passphrase-deprecation.test.ts
+++ b/src/cli/vault-passphrase-deprecation.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Tests for the SWITCHROOM_VAULT_PASSPHRASE deprecation warning (#969 P3).
+ *
+ * The env var path is still honoured (backwards compatibility AND the
+ * canonical gateway-passphrase-attestation flow from P1a). The deprecation
+ * warning targets the anti-pattern where a SKILL bakes the master
+ * passphrase into the agent's environment.
+ *
+ * The hook fires on every `switchroom vault <subcommand>` invocation
+ * BEFORE the subcommand runs — via commander's `preAction` lifecycle
+ * hook on the parent `vault` command. The check runs once per process
+ * (in case a long-running gateway invocation re-enters), and only when
+ * SWITCHROOM_RUNTIME=docker (sandbox context).
+ */
+
+import { describe, expect, it } from "vitest";
+import { spawnSync } from "node:child_process";
+import * as path from "node:path";
+import * as os from "node:os";
+import * as fs from "node:fs";
+
+const REPO_ROOT = path.resolve(__dirname, "../..");
+const CLI_ENTRY = path.join(REPO_ROOT, "bin/switchroom.ts");
+
+function runCli(
+  args: string[],
+  env: Record<string, string | undefined> = {},
+): { stdout: string; stderr: string; status: number | null } {
+  const result = spawnSync("bun", [CLI_ENTRY, ...args], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      HOME: fs.mkdtempSync(path.join(os.tmpdir(), "vault-deprecate-test-")),
+      ...env,
+    },
+    timeout: 15000,
+  });
+  return {
+    stdout: result.stdout ?? "",
+    stderr: result.stderr ?? "",
+    status: result.status,
+  };
+}
+
+describe("SWITCHROOM_VAULT_PASSPHRASE deprecation (#969 P3)", () => {
+  it("emits VAULT-DEPRECATION-WARNING when env var is set inside sandbox", () => {
+    const r = runCli(["vault", "list"], {
+      SWITCHROOM_RUNTIME: "docker",
+      SWITCHROOM_VAULT_PASSPHRASE: "anything",
+      SWITCHROOM_VAULT_BROKER_SOCK: "/tmp/not-a-real-socket-for-deprecation-test",
+    });
+    expect(r.stderr).toContain("VAULT-DEPRECATION-WARNING");
+    // The warning's nudge to migrate must include both the docs pointer
+    // and the canonical mint command — operators reading the warning
+    // should be able to act on it immediately.
+    expect(r.stderr).toContain("docs/vault-security.md");
+    expect(r.stderr).toContain("switchroom vault grant");
+  });
+
+  it("does NOT warn on host context (no SWITCHROOM_RUNTIME)", () => {
+    const r = runCli(["vault", "list"], {
+      SWITCHROOM_RUNTIME: undefined,
+      SWITCHROOM_VAULT_PASSPHRASE: "anything",
+    });
+    expect(r.stderr).not.toContain("VAULT-DEPRECATION-WARNING");
+  });
+
+  it("does NOT warn when env var is absent", () => {
+    const r = runCli(["vault", "list"], {
+      SWITCHROOM_RUNTIME: "docker",
+      SWITCHROOM_VAULT_PASSPHRASE: undefined,
+      SWITCHROOM_VAULT_BROKER_SOCK: "/tmp/not-a-real-socket-for-deprecation-test",
+    });
+    expect(r.stderr).not.toContain("VAULT-DEPRECATION-WARNING");
+  });
+
+  it("respects SWITCHROOM_NO_VAULT_DEPRECATION_WARNING=1 escape hatch", () => {
+    const r = runCli(["vault", "list"], {
+      SWITCHROOM_RUNTIME: "docker",
+      SWITCHROOM_VAULT_PASSPHRASE: "anything",
+      SWITCHROOM_NO_VAULT_DEPRECATION_WARNING: "1",
+      SWITCHROOM_VAULT_BROKER_SOCK: "/tmp/not-a-real-socket-for-deprecation-test",
+    });
+    expect(r.stderr).not.toContain("VAULT-DEPRECATION-WARNING");
+  });
+});

--- a/src/cli/vault.ts
+++ b/src/cli/vault.ts
@@ -152,6 +152,45 @@ function readStdinToEnd(): Promise<string> {
   });
 }
 
+/**
+ * Issue #969 P3: emit a one-shot deprecation warning when
+ * `SWITCHROOM_VAULT_PASSPHRASE` is set inside an agent sandbox. The env
+ * var is still honoured for backwards compatibility AND for the
+ * canonical gateway-passphrase-attestation flow (P1a) — both legitimate.
+ * The warning targets the anti-pattern where a SKILL script bakes the
+ * master passphrase into the agent's environment.
+ *
+ * Heuristic for distinguishing the two: the gateway invokes the CLI
+ * with the env var set on a per-spawn basis AND the wider sandbox
+ * shell does not have it exported. The legitimate gateway flow never
+ * enters this codepath under normal sandbox boot because the env is
+ * only on the spawned subprocess, not the agent's interactive shell
+ * environment. A skill script that runs `switchroom vault get` after
+ * `export SWITCHROOM_VAULT_PASSPHRASE=...` WILL hit it — which is
+ * exactly what we want.
+ *
+ * Emitting the warning is therefore safe to put at vault CLI entry:
+ * even if it fires on a legitimate gateway-spawned subprocess, it's
+ * one-shot, goes to stderr (not stdout), and gateway error handling
+ * already separates these streams.
+ */
+let _passphraseEnvDeprecationWarned = false;
+function maybeWarnPassphraseEnvDeprecation(): void {
+  if (_passphraseEnvDeprecationWarned) return;
+  if (process.env.SWITCHROOM_VAULT_PASSPHRASE === undefined) return;
+  if (!isSandboxContext()) return;
+  if (process.env.SWITCHROOM_NO_VAULT_DEPRECATION_WARNING === "1") return;
+  _passphraseEnvDeprecationWarned = true;
+  process.stderr.write(
+    `VAULT-DEPRECATION-WARNING: SWITCHROOM_VAULT_PASSPHRASE is set inside ` +
+    `an agent sandbox. Skills should authenticate via a capability grant ` +
+    `(\`switchroom vault grant <agent> --keys ... [--write ...]\`) instead — ` +
+    `the master passphrase in process env defeats the ACL model and ` +
+    `bypasses the broker audit log. See docs/vault-security.md. ` +
+    `(Set SWITCHROOM_NO_VAULT_DEPRECATION_WARNING=1 to silence.)\n`
+  );
+}
+
 async function getPassphrase(confirm = false): Promise<string> {
   // Check env var first
   const envPassphrase = process.env.SWITCHROOM_VAULT_PASSPHRASE;
@@ -195,7 +234,13 @@ function conversionHint(stored: VaultFormatHint, expected: VaultFormatHint): str
 export function registerVaultCommand(program: Command): void {
   const vault = program
     .command("vault")
-    .description("Manage encrypted secrets vault");
+    .description("Manage encrypted secrets vault")
+    .hook("preAction", () => {
+      // Fire the env-var deprecation check once per CLI invocation, BEFORE
+      // any subcommand runs. Catches the legacy skill pattern of exporting
+      // SWITCHROOM_VAULT_PASSPHRASE in the agent environment. (#969 P3)
+      maybeWarnPassphraseEnvDeprecation();
+    });
 
   vault
     .command("init")

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -6101,7 +6101,16 @@ async function runSwitchroomAuthCommand(ctx: Context, args: string[], label: str
 }
 
 function runVaultCli(args: string[], passphrase: string, stdinValue?: string): { ok: boolean; output: string } {
-  const env = { ...process.env, SWITCHROOM_VAULT_PASSPHRASE: passphrase }
+  // Suppress the #969 P3 deprecation warning on this per-spawn
+  // invocation. The gateway forwarding the operator's passphrase to
+  // the CLI (which in turn forwards it to the broker as the canonical
+  // P1a passphrase-attestation) is intended; without this silencer the
+  // warning would surface in error pre-blocks shown to the user.
+  const env = {
+    ...process.env,
+    SWITCHROOM_VAULT_PASSPHRASE: passphrase,
+    SWITCHROOM_NO_VAULT_DEPRECATION_WARNING: '1',
+  }
   try {
     let result: string
     if (stdinValue !== undefined) {

--- a/telegram-plugin/secret-detect/vault-write.ts
+++ b/telegram-plugin/secret-detect/vault-write.ts
@@ -25,7 +25,13 @@ export type VaultWriteFn = (
 export type VaultListFn = (passphrase: string) => { ok: boolean; keys: string[] }
 
 export const defaultVaultWrite: VaultWriteFn = (slug, value, passphrase) => {
-  const env = { ...process.env, SWITCHROOM_VAULT_PASSPHRASE: passphrase }
+  // Suppress the #969 P3 deprecation warning — the gateway forwarding
+  // the operator's passphrase per-spawn is the canonical P1a flow.
+  const env = {
+    ...process.env,
+    SWITCHROOM_VAULT_PASSPHRASE: passphrase,
+    SWITCHROOM_NO_VAULT_DEPRECATION_WARNING: '1',
+  }
   try {
     const result = execFileSync(
       process.env.SWITCHROOM_CLI_PATH ?? 'switchroom',
@@ -41,7 +47,13 @@ export const defaultVaultWrite: VaultWriteFn = (slug, value, passphrase) => {
 }
 
 export const defaultVaultList: VaultListFn = (passphrase) => {
-  const env = { ...process.env, SWITCHROOM_VAULT_PASSPHRASE: passphrase }
+  // Suppress the #969 P3 deprecation warning — the gateway forwarding
+  // the operator's passphrase per-spawn is the canonical P1a flow.
+  const env = {
+    ...process.env,
+    SWITCHROOM_VAULT_PASSPHRASE: passphrase,
+    SWITCHROOM_NO_VAULT_DEPRECATION_WARNING: '1',
+  }
   try {
     const result = execFileSync(
       process.env.SWITCHROOM_CLI_PATH ?? 'switchroom',


### PR DESCRIPTION
## Summary

Targets a specific anti-pattern: skills that export the master passphrase into the agent's environment, defeating the ACL model and bypassing the broker's audit log. The env var path remains honoured for backwards compatibility AND for the canonical gateway-passphrase-attestation flow (#969 P1a).

Three pieces:

1. **\`docs/vault-security.md\`** — new canonical reference. Three auth paths (capability grant, path-as-identity, operator passphrase), a decision flow, migration notes.
2. **Runtime warning** at \`vault\` CLI preAction. One-shot per process. Fires only when env var set AND \`SWITCHROOM_RUNTIME=docker\` AND escape hatch unset. Stderr only. Message includes the canonical mint command and docs pointer.
3. **\`skills/token-helpers/SKILL.md\`** updated — the one in-tree skill that documented the env var prereq now advertises capability grants first.

## Review nits addressed

- Reviewer flagged that the gateway's per-spawn \`switchroom vault\` invocations would trigger the warning (canonical P1a flow). Fixed by setting \`SWITCHROOM_NO_VAULT_DEPRECATION_WARNING=1\` in \`runVaultCli\` and \`defaultVaultWrite\` / \`defaultVaultList\`.
- Reviewer flagged underscore/hyphen mismatch between docs and SKILL.md. Aligned docs to hyphens (matches the existing skill).

## Test plan

- [x] 4 new tests in \`src/cli/vault-passphrase-deprecation.test.ts\` — sandbox+env emits warning; host no warning; env unset no warning; escape hatch silences.
- [x] Full \`vitest run\` — 5336 / 29 skipped / 0 fail.
- [x] \`tsc --noEmit\` clean.
- [x] Fresh-process reviewer — APPROVE.

## Refs

- Epic #969 — P3 complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)