### PR TITLE
feat(telegram): recent-denials + one-tap allow on /vault audit (#969 P2b)

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -259,6 +259,7 @@ import { StagingMap } from '../secret-detect/staging.js'
 import { maskToken } from '../secret-detect/mask.js'
 import { defaultVaultWrite, defaultVaultList } from '../secret-detect/vault-write.js'
 import { parseVaultCliError, renderVaultCliError } from '../secret-detect/vault-error.js'
+import { recentDenialsFromAuditLog, type RecentDenial } from './recent-denials.js'
 import { detectSecrets } from '../secret-detect/index.js'
 import { classifyAdminGate } from '../admin-commands/index.js'
 import {
@@ -6326,6 +6327,31 @@ bot.use(async (ctx, next) => {
  * undefined so /status falls back to its previous (auth + uptime + agent
  * name) shape rather than blocking the reply.
  */
+/**
+ * Issue #969 P2b — read recent broker-denied vault accesses for an
+ * agent. Used by `/vault audit <agent>` to surface a one-tap
+ * "always allow" button per unique denied key, so the operator can
+ * fix a misconfigured cron without editing switchroom.yaml.
+ *
+ * Thin wrapper over the pure-functional parser in `./recent-denials.ts`
+ * which handles the actual parse + filter + group + sort logic and is
+ * unit-tested directly.
+ */
+function readRecentDenialsForAgent(
+  agentName: string,
+  windowMs: number,
+  limit: number,
+): RecentDenial[] {
+  try {
+    const auditPath = join(homedir(), '.switchroom', 'vault-audit.log')
+    if (!existsSync(auditPath)) return []
+    const raw = readFileSync(auditPath, 'utf8')
+    return recentDenialsFromAuditLog(raw, { agentName, windowMs, limit })
+  } catch {
+    return []
+  }
+}
+
 function buildAgentAudit(agentName: string): AgentAudit | undefined {
   try {
     const config = loadSwitchroomConfig()
@@ -7698,6 +7724,83 @@ function resolveAgentDirForName(agent: string): string | null {
  *   vrs:rename:<stageId>   — set up a pending-op intercept so the user's
  *                            next message is taken as a new key name.
  */
+/**
+ * Issue #969 P2b — handle a tap on the "🔓 Allow <key>" button posted by
+ * `/vault audit <agent>`'s Recent denials section. Mints a 30-day
+ * read-grant for the agent + key via the broker.
+ *
+ * The grant also unioning into the agent's existing token if one is
+ * already present is out of scope for this PR — the operator can
+ * re-mint with a wider key list if they want consolidation.
+ */
+async function handleVaultRecentDenialCallback(ctx: Context, data: string): Promise<void> {
+  const senderId = String(ctx.from?.id ?? '')
+  const access = loadAccess()
+  if (!access.allowFrom.includes(senderId)) {
+    await ctx.answerCallbackQuery({ text: 'Not authorized.' }).catch(() => {})
+    return
+  }
+  // vrd:<agent>:<key>  — parse, validate both halves against the strict
+  // slug regex before doing anything else.
+  const parts = data.split(':')
+  if (parts.length !== 3) {
+    await ctx.answerCallbackQuery({ text: 'Bad request' }).catch(() => {})
+    return
+  }
+  const [, agentName, keyName] = parts
+  if (!/^[a-z][a-z0-9-]{0,62}$/i.test(agentName)) {
+    await ctx.answerCallbackQuery({ text: 'Invalid agent name' }).catch(() => {})
+    return
+  }
+  if (!/^[A-Za-z0-9_.-]{1,200}$/.test(keyName)) {
+    await ctx.answerCallbackQuery({ text: 'Invalid key name' }).catch(() => {})
+    return
+  }
+  await ctx.answerCallbackQuery({ text: '⏳ Minting 30-day read grant…' }).catch(() => {})
+
+  const result = await mintGrantViaBroker({
+    agent: agentName,
+    keys: [keyName],
+    ttl_seconds: 30 * 24 * 60 * 60,
+    description: `auto-mint via /vault audit one-tap (#969 P2b)`,
+  })
+
+  if (result.kind === 'unreachable') {
+    await switchroomReply(ctx, `🔴 Broker unreachable: ${escapeHtmlForTg(result.msg)}`, { html: true })
+    return
+  }
+  if (result.kind === 'error') {
+    await switchroomReply(ctx, `<b>mint_grant failed:</b> ${escapeHtmlForTg(result.msg)}`, { html: true })
+    return
+  }
+  // Write the token to the agent's .vault-token file — same flow as the
+  // vault grant wizard. The agent restarts in the background pick up
+  // the new token via SWITCHROOM_AGENT_NAME on next CLI invocation.
+  const { token, id } = result
+  const tokenPath = join(homedir(), '.switchroom', 'agents', agentName, '.vault-token')
+  try {
+    mkdirSync(join(homedir(), '.switchroom', 'agents', agentName), { recursive: true })
+    writeFileSync(tokenPath, token, { mode: 0o600 })
+  } catch (err) {
+    await switchroomReply(
+      ctx,
+      `<b>Grant created (${escapeHtmlForTg(id)}) but token write failed:</b> ` +
+      `${escapeHtmlForTg(String(err))}\n` +
+      `<i>Recover with: <code>switchroom vault grant ${escapeHtmlForTg(agentName)} ` +
+      `--keys ${escapeHtmlForTg(keyName)} --duration 30d</code> on the host.</i>`,
+      { html: true },
+    )
+    return
+  }
+  await switchroomReply(
+    ctx,
+    `✅ Granted <b>${escapeHtmlForTg(agentName)}</b> read access to ` +
+    `<code>${escapeHtmlForTg(keyName)}</code> for 30 days. ` +
+    `(grant <code>${escapeHtmlForTg(id)}</code>)`,
+    { html: true },
+  )
+}
+
 async function handleVaultRequestSaveCallback(ctx: Context, data: string): Promise<void> {
   const senderId = String(ctx.from?.id ?? '')
   const access = loadAccess()
@@ -9071,13 +9174,51 @@ bot.command('vault', async ctx => {
       }
     }
     lines.push('')
+
+    // Issue #969 P2b — recent denials section + one-tap "always allow"
+    // button per unique denied key. Reads the broker's vault-audit.log
+    // and surfaces the latest unique keys the agent was denied access
+    // to. Tap a button → mint a 30-day read-grant for that key
+    // (extends the existing grant flow rather than reconciling YAML).
+    const denials = readRecentDenialsForAgent(targetAgent, 7 * 24 * 60 * 60 * 1000, 5)
+    const denialKeyboard = new InlineKeyboard()
+    if (denials.length > 0) {
+      lines.push('<b>Recent denials (last 7d):</b>')
+      for (const d of denials) {
+        const when = new Date(d.lastSeenMs).toISOString().slice(0, 16).replace('T', ' ')
+        lines.push(
+          `  <code>${escapeHtmlForTg(d.key)}</code> · ${d.count}× · last ${when}`,
+        )
+        // callback_data must stay ≤ 64 bytes. Format:
+        //   vrd:<agent>:<key>
+        // Agent + key combined are bounded by the slug regex (200 chars
+        // for key, ~64 for agent) but realistic combinations stay short.
+        // Truncate the label so the button text fits Telegram's 64-byte
+        // limit while still being readable.
+        const cb = `vrd:${targetAgent}:${d.key}`
+        if (cb.length <= 64) {
+          const label = d.key.length > 30 ? `🔓 Allow ${d.key.slice(0, 27)}…` : `🔓 Allow ${d.key}`
+          denialKeyboard.text(label, cb).row()
+        }
+      }
+      lines.push('')
+    }
+
     lines.push(
       `<i>Summary: ${readGrants.length} read grant${readGrants.length === 1 ? '' : 's'}, ` +
       `${writeGrants.length} write grant${writeGrants.length === 1 ? '' : 's'}, ` +
-      `${cronEntries.length} cron entr${cronEntries.length === 1 ? 'y' : 'ies'}.</i>`,
+      `${cronEntries.length} cron entr${cronEntries.length === 1 ? 'y' : 'ies'}, ` +
+      `${denials.length} recent denial${denials.length === 1 ? '' : 's'}.</i>`,
     )
 
-    await switchroomReply(ctx, lines.join('\n'), { html: true })
+    const chatIdAudit = String(ctx.chat!.id)
+    const threadIdAudit = resolveThreadId(chatIdAudit, ctx.message?.message_thread_id)
+    await ctx.reply(lines.join('\n'), {
+      parse_mode: 'HTML',
+      link_preview_options: { is_disabled: true },
+      ...(denials.length > 0 ? { reply_markup: denialKeyboard } : {}),
+      ...(threadIdAudit != null ? { message_thread_id: threadIdAudit } : {}),
+    })
     return
   }
 
@@ -9449,6 +9590,14 @@ bot.on('callback_query:data', async ctx => {
   // vrs:rename:<stageId>   — prompt for a new key name, then resume
   if (data.startsWith('vrs:')) {
     await handleVaultRequestSaveCallback(ctx, data)
+    return
+  }
+
+  // Issue #969 P2b: vault recent-denial one-tap approval.
+  //   vrd:<agent>:<key> — mint a 30-day read-grant for the agent + key
+  // Posted by /vault audit <agent> in the "Recent denials" section.
+  if (data.startsWith('vrd:')) {
+    await handleVaultRecentDenialCallback(ctx, data)
     return
   }
 

--- a/telegram-plugin/gateway/recent-denials.test.ts
+++ b/telegram-plugin/gateway/recent-denials.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Tests for the recent-denial scanner (#969 P2b).
+ */
+
+import { describe, it, expect } from "vitest";
+import { recentDenialsFromAuditLog } from "./recent-denials.js";
+
+// Anchor "now" in test runs so the windowing is reproducible.
+const NOW_MS = Date.parse("2026-05-11T12:00:00Z");
+
+function entry(o: Partial<{ ts: string; agent_name: string; key: string; result: string }>): string {
+  return JSON.stringify({
+    ts: o.ts,
+    op: "get",
+    caller: "pid:1234",
+    pid: 1234,
+    agent_name: o.agent_name,
+    key: o.key,
+    result: o.result ?? "denied:scope-allow",
+  });
+}
+
+describe("recentDenialsFromAuditLog", () => {
+  it("returns empty on empty log", () => {
+    expect(
+      recentDenialsFromAuditLog("", { agentName: "klanker", windowMs: 1000, limit: 5, nowMs: NOW_MS }),
+    ).toEqual([]);
+  });
+
+  it("filters to the target agent only", () => {
+    const log = [
+      entry({ ts: "2026-05-11T11:00:00Z", agent_name: "klanker", key: "k1", result: "denied:scope-allow" }),
+      entry({ ts: "2026-05-11T11:00:00Z", agent_name: "OTHER", key: "k2", result: "denied:scope-allow" }),
+    ].join("\n");
+    const r = recentDenialsFromAuditLog(log, { agentName: "klanker", windowMs: 24 * 3600 * 1000, limit: 5, nowMs: NOW_MS });
+    expect(r).toHaveLength(1);
+    expect(r[0].key).toBe("k1");
+  });
+
+  it("filters to denied results only (drops allowed)", () => {
+    const log = [
+      entry({ ts: "2026-05-11T11:00:00Z", agent_name: "klanker", key: "k1", result: "allowed" }),
+      entry({ ts: "2026-05-11T11:00:00Z", agent_name: "klanker", key: "k2", result: "denied:scope-allow" }),
+    ].join("\n");
+    const r = recentDenialsFromAuditLog(log, { agentName: "klanker", windowMs: 24 * 3600 * 1000, limit: 5, nowMs: NOW_MS });
+    expect(r.map((x) => x.key)).toEqual(["k2"]);
+  });
+
+  it("groups multiple denials for the same key into a count", () => {
+    const log = [
+      entry({ ts: "2026-05-11T10:00:00Z", agent_name: "klanker", key: "openai", result: "denied:scope-allow" }),
+      entry({ ts: "2026-05-11T11:00:00Z", agent_name: "klanker", key: "openai", result: "denied:scope-allow" }),
+      entry({ ts: "2026-05-11T11:30:00Z", agent_name: "klanker", key: "openai", result: "denied:scope-allow" }),
+    ].join("\n");
+    const r = recentDenialsFromAuditLog(log, { agentName: "klanker", windowMs: 24 * 3600 * 1000, limit: 5, nowMs: NOW_MS });
+    expect(r).toHaveLength(1);
+    expect(r[0]).toMatchObject({ key: "openai", count: 3 });
+    expect(r[0].lastSeenMs).toBe(Date.parse("2026-05-11T11:30:00Z"));
+  });
+
+  it("excludes entries older than the window", () => {
+    const log = [
+      entry({ ts: "2026-05-01T00:00:00Z", agent_name: "klanker", key: "stale" }), // > 7 days
+      entry({ ts: "2026-05-11T11:00:00Z", agent_name: "klanker", key: "fresh" }),
+    ].join("\n");
+    const r = recentDenialsFromAuditLog(log, { agentName: "klanker", windowMs: 7 * 24 * 3600 * 1000, limit: 5, nowMs: NOW_MS });
+    expect(r.map((x) => x.key)).toEqual(["fresh"]);
+  });
+
+  it("sorts newest first and applies limit", () => {
+    const log = [
+      entry({ ts: "2026-05-11T09:00:00Z", agent_name: "klanker", key: "a" }),
+      entry({ ts: "2026-05-11T10:00:00Z", agent_name: "klanker", key: "b" }),
+      entry({ ts: "2026-05-11T11:00:00Z", agent_name: "klanker", key: "c" }),
+      entry({ ts: "2026-05-11T11:30:00Z", agent_name: "klanker", key: "d" }),
+    ].join("\n");
+    const r = recentDenialsFromAuditLog(log, { agentName: "klanker", windowMs: 24 * 3600 * 1000, limit: 2, nowMs: NOW_MS });
+    expect(r.map((x) => x.key)).toEqual(["d", "c"]);
+  });
+
+  it("drops keys that don't match the safe slug regex", () => {
+    // Defensive: a tampered log line should not surface a button with
+    // injection-shaped data, even though Telegram callback_data is
+    // sanitized at render time too.
+    const log = [
+      entry({ ts: "2026-05-11T11:00:00Z", agent_name: "klanker", key: "../etc/passwd" }),
+      entry({ ts: "2026-05-11T11:00:00Z", agent_name: "klanker", key: "good_key" }),
+    ].join("\n");
+    const r = recentDenialsFromAuditLog(log, { agentName: "klanker", windowMs: 24 * 3600 * 1000, limit: 5, nowMs: NOW_MS });
+    expect(r.map((x) => x.key)).toEqual(["good_key"]);
+  });
+
+  it("ignores malformed JSON lines silently", () => {
+    const log = [
+      "not json",
+      "{trailing comma,}",
+      entry({ ts: "2026-05-11T11:00:00Z", agent_name: "klanker", key: "valid" }),
+    ].join("\n");
+    const r = recentDenialsFromAuditLog(log, { agentName: "klanker", windowMs: 24 * 3600 * 1000, limit: 5, nowMs: NOW_MS });
+    expect(r).toHaveLength(1);
+    expect(r[0].key).toBe("valid");
+  });
+});

--- a/telegram-plugin/gateway/recent-denials.ts
+++ b/telegram-plugin/gateway/recent-denials.ts
@@ -1,0 +1,77 @@
+/**
+ * Recent-denial scanner (issue #969 P2b).
+ *
+ * Parses the vault broker's NDJSON audit log to surface keys an agent
+ * was recently denied access to. Used by the Telegram gateway's
+ * `/vault audit <agent>` to render a one-tap "always allow" affordance
+ * for each unique denial — closing the loop where a cron schedule
+ * silently fails because `schedule[i].secrets[]` didn't list the key
+ * the skill ended up needing.
+ *
+ * Extracted out of gateway.ts so the parse + filter + group logic is
+ * unit-testable without spinning up a Telegram bot context.
+ */
+
+export interface RecentDenial {
+  /** The vault key that was denied. */
+  key: string;
+  /** How many times this (agent, key) tuple was denied in the window. */
+  count: number;
+  /** Most-recent denial timestamp, unix ms. */
+  lastSeenMs: number;
+}
+
+export interface RecentDenialsOpts {
+  agentName: string;
+  /** Time window, in ms, ending now. Entries older than this are dropped. */
+  windowMs: number;
+  /** Max number of unique-key denials to return (sorted newest-first). */
+  limit: number;
+  /** Optional "now" override for tests. */
+  nowMs?: number;
+}
+
+/**
+ * Parse a raw NDJSON audit log blob and return recent denials for one
+ * agent. Best-effort: bad lines are skipped silently.
+ *
+ * Pure-functional — caller does the file IO.
+ */
+export function recentDenialsFromAuditLog(
+  rawAuditLog: string,
+  opts: RecentDenialsOpts,
+): RecentDenial[] {
+  const now = opts.nowMs ?? Date.now();
+  const cutoffMs = now - opts.windowMs;
+  const grouped = new Map<string, { count: number; lastMs: number }>();
+  for (const line of rawAuditLog.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    let obj: Record<string, unknown>;
+    try {
+      obj = JSON.parse(trimmed) as Record<string, unknown>;
+    } catch {
+      continue;
+    }
+    if (typeof obj.agent_name !== "string" || obj.agent_name !== opts.agentName) continue;
+    if (typeof obj.result !== "string" || !obj.result.startsWith("denied")) continue;
+    if (typeof obj.key !== "string") continue;
+    const tsStr = typeof obj.ts === "string" ? obj.ts : null;
+    const tsMs = tsStr ? Date.parse(tsStr) : NaN;
+    if (!Number.isFinite(tsMs) || tsMs < cutoffMs) continue;
+    // Sanity-check the key shape — only the same charset accepted on
+    // the grant + audit flows. Defensive against a tampered log line.
+    if (!/^[A-Za-z0-9_.-]{1,200}$/.test(obj.key)) continue;
+    const prev = grouped.get(obj.key);
+    if (prev) {
+      prev.count += 1;
+      if (tsMs > prev.lastMs) prev.lastMs = tsMs;
+    } else {
+      grouped.set(obj.key, { count: 1, lastMs: tsMs });
+    }
+  }
+  return [...grouped.entries()]
+    .map(([key, v]) => ({ key, count: v.count, lastSeenMs: v.lastMs }))
+    .sort((a, b) => b.lastSeenMs - a.lastSeenMs)
+    .slice(0, opts.limit);
+}


### PR DESCRIPTION
## Summary

The cron-denial-loop closer. When a cron-fired skill hits a broker DENY today (key not in \`schedule[i].secrets[]\`, or no write-grant for a new key), the failure is silent in \`scheduler.jsonl\` — operators typically find out via \"the cron stopped working.\"

P2b surfaces those failures into the existing \`/vault audit <agent>\` card (from P2c #980) and gives the operator a **one-tap fix**:

\`\`\`
🔐 klanker — vault access
…existing sections (read grants, write grants, cron secrets)…

Recent denials (last 7d):
  openai_api_key · 3× · last 2026-05-11 10:30   [🔓 Allow openai_api_key]
  hindsight_key  · 1× · last 2026-05-10 14:15   [🔓 Allow hindsight_key]
\`\`\`

Tap → 30-day read-grant minted via broker (\`mintGrantViaBroker\`) and token written to \`~/.switchroom/agents/<agent>/.vault-token\`. Agent picks it up on next CLI invocation.

## Why grants instead of editing schedule.secrets[]?

1. Write-grants (P1b) already let agents rotate/create keys without touching \`schedule.secrets[]\`. Mirroring that for reads is consistent.
2. Editing switchroom.yaml from a Telegram tap requires careful YAML mutation + restart fan-out — riskier in scope. Grants are an overlay that doesn't touch source-of-truth config; operators can still pin reads into YAML manually.

## Files

- \`telegram-plugin/gateway/recent-denials.ts\` — new pure-functional parser; NDJSON in, sorted \`RecentDenial[]\` out. Defensive against malformed JSON, missing fields, stale entries, tampered slug shapes.
- \`telegram-plugin/gateway/gateway.ts\`:
  - \`readRecentDenialsForAgent()\` — thin file-IO wrapper
  - Extension to \`/vault audit\` branch — renders the section + inline keyboard
  - \`handleVaultRecentDenialCallback\` — \`vrd:<agent>:<key>\` handler with strict regex validation, auth gate, grant mint, token write

## Test plan

- [x] **8 unit tests** in \`recent-denials.test.ts\` — empty log, agent filter, denied-only filter, count grouping, window cutoff, newest-first + limit, slug-regex tampered-line defense, malformed-JSON tolerance.
- [x] Full \`vitest run\` — 5331 / 42 skipped / 0 fail.
- [x] \`tsc --noEmit\` clean.
- [x] Fresh-process reviewer — APPROVE.

## Closes the epic

#969 phases complete:
- P0a #971 (CLI structured errors)
- P0b #972 (gateway error rendering)
- P1a #975 (vault_request_save tool — closes #968)
- P1b #973 (write-grant capability)
- P2a #984 (durable approval-kernel schema)
- P2b (this PR — recent denials)
- P2c #980 (/vault audit unified view)
- P3 #982 (passphrase env deprecation + docs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)