### PR TITLE
fix(scaffold): drop two dead settings keys

### DIFF
--- a/profiles/_base/settings.json.hbs
+++ b/profiles/_base/settings.json.hbs
@@ -1,15 +1,24 @@
+{{!--
+  Two keys deliberately omitted from this template (do not re-add):
+
+  * `skipDangerousModePermissionPrompt` — real key, but Claude Code IGNORES it
+    in project-level .claude/settings.json as a security measure (only user
+    or local scope is honored). It also belongs under `permissions.`, not
+    top-level. autoaccept (src/agents/autoaccept.ts) handles the prompt instead.
+
+  * `enabledPlugins` — managed-settings-only (org policy distribution), no
+    effect at user or project scope. Plugin selection is correctly driven
+    by CLI flags in profiles/_base/start.sh.hbs (--channels / --plugin-dir).
+
+  See https://code.claude.com/docs/en/settings for the settings reference.
+--}}
 {
   "permissions": {
     "allow": {{{json permissionAllow}}},
     "deny": {{{json toolsDeny}}}{{#if defaultModeAcceptEdits}},
     "defaultMode": "acceptEdits"{{/if}}
-  },
-  "enabledPlugins": {
-    "telegram@claude-plugins-official": {{#if useSwitchroomPlugin}}false{{else}}true{{/if}}
   }{{#if hindsightEnabled}},
   "autoMemoryEnabled": false{{/if}}{{#if mcpServers}},
   "mcpServers": {{{json mcpServers}}}
-  {{/if}}{{#if skipPermissionPrompt}},
-  "skipDangerousModePermissionPrompt": true
   {{/if}}
 }

--- a/profiles/_base/settings.json.hbs
+++ b/profiles/_base/settings.json.hbs
@@ -5,12 +5,18 @@
     in project-level .claude/settings.json as a security measure (only user
     or local scope is honored). It also belongs under `permissions.`, not
     top-level. autoaccept (src/agents/autoaccept.ts) handles the prompt instead.
+    See https://code.claude.com/docs/en/settings (permissions section).
 
-  * `enabledPlugins` — managed-settings-only (org policy distribution), no
-    effect at user or project scope. Plugin selection is correctly driven
-    by CLI flags in profiles/_base/start.sh.hbs (--channels / --plugin-dir).
+  * `enabledPlugins` — REDUNDANT, not nonfunctional. Plugin selection is
+    driven at the CLI by profiles/_base/start.sh.hbs (`--channels
+    plugin:telegram@claude-plugins-official` in vanilla mode, or
+    `--dangerously-load-development-channels server:switchroom-telegram` in
+    vendored-plugin mode). Re-adding an `enabledPlugins` block here would
+    work but duplicate state with the CLI flag and risk drift.
 
-  See https://code.claude.com/docs/en/settings for the settings reference.
+  A `settings_raw` block in switchroom.yaml CAN still inject either key via
+  the deep-merge escape hatch (src/config/merge.ts) — that's intentional
+  power-user territory, not a regression.
 --}}
 {
   "permissions": {

--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -1420,7 +1420,6 @@ function buildWorkspaceContext(args: BuildWorkspaceContextArgs): Record<string, 
     botToken: resolvedBotToken ?? rawBotToken,
     forumChatId: telegramConfig.forum_chat_id,
     dangerousMode: agentConfig.dangerous_mode === true,
-    skipPermissionPrompt: agentConfig.skip_permission_prompt === true,
     useSwitchroomPlugin: usesSwitchroomTelegramPlugin(agentConfig),
     useHotReloadStable: agentConfig.channels?.telegram?.hotReloadStable === true,
     hindsightEnabled: hindsightAutoRecallEnabled,
@@ -3170,6 +3169,15 @@ Don't wait for a slash command. Don't ask permission. Memory work is table stake
       }
     }
     delete settings[META_KEY];
+
+    // --- One-shot migration: retract dead settings keys that prior switchroom
+    // versions emitted from the hbs template. They were never tracked in
+    // _switchroomManagedRawKeys (template-emitted, not settings_raw-injected),
+    // so the loop above doesn't catch them on existing agents. Delete them
+    // explicitly. Safe to remove this block after a few releases.
+    // See settings.json.hbs header for why these keys are no-ops at project scope.
+    delete settings.enabledPlugins;
+    delete settings.skipDangerousModePermissionPrompt;
 
     // --- Phase 2: reconcile user hooks (replace, don't merge) ---
     //

--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -949,9 +949,7 @@ function buildHumanizerEnvVars(
 const SWITCHROOM_OWNED_SETTINGS_KEYS = new Set<string>([
   "permissions",
   "mcpServers",
-  "enabledPlugins",
   "autoMemoryEnabled",
-  "skipDangerousModePermissionPrompt",
   "hooks",
   "model",
 ]);

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -899,24 +899,23 @@ async function stepDangerousMode(
         const agentNames = Object.keys(config.agents);
 
         for (const name of agentNames) {
-          // Add dangerous_mode and skip_permission_prompt to each agent block
-          // Look for the agent's top-level key and add after it
+          // Add dangerous_mode to each agent block. (Prior versions also added
+          // skip_permission_prompt: true here — dropped as of the dead-settings
+          // cleanup since it's now a no-op; autoaccept handles the boot prompt.)
           const agentPattern = new RegExp(`(^  ${name}:\\s*\\n)`, "m");
           if (agentPattern.test(content)) {
-            // Check if dangerous_mode already exists for this agent
             const blockPattern = new RegExp(`^  ${name}:[\\s\\S]*?(?=^  [a-z]|\\Z)`, "m");
             const blockMatch = content.match(blockPattern);
             if (blockMatch && !blockMatch[0].includes("dangerous_mode")) {
               content = content.replace(
                 agentPattern,
-                `$1    dangerous_mode: true\n    skip_permission_prompt: true\n`,
+                `$1    dangerous_mode: true\n`,
               );
             }
           }
 
           // Also update the in-memory config
           config.agents[name].dangerous_mode = true;
-          config.agents[name].skip_permission_prompt = true;
         }
 
         writeFileSync(configPath, content, "utf-8");

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -1158,7 +1158,12 @@ export const AgentSchema = z.object({
   skip_permission_prompt: z
     .boolean()
     .optional()
-    .describe("If true, add skipDangerousModePermissionPrompt to settings.json"),
+    .describe(
+      "DEPRECATED no-op (accepted for backwards compatibility). Claude Code " +
+      "ignores skipDangerousModePermissionPrompt at project scope; autoaccept " +
+      "(src/agents/autoaccept.ts) handles the bypass-mode prompt instead. " +
+      "Safe to remove from switchroom.yaml.",
+    ),
   admin: z
     .boolean()
     .optional()

--- a/tests/scaffold.test.ts
+++ b/tests/scaffold.test.ts
@@ -1168,6 +1168,27 @@ describe("reconcileAgent", () => {
     expect(settings.permissions.allow).not.toContain("Write");
   });
 
+  it("retracts stale enabledPlugins / skipDangerousModePermissionPrompt on reconcile (one-shot migration)", () => {
+    // Pre-PR switchroom emitted both keys from settings.json.hbs to every
+    // scaffolded agent. They were never tracked in _switchroomManagedRawKeys
+    // (template-emitted, not settings_raw-injected), so the standard Phase-5
+    // retraction loop doesn't catch them. The one-shot migration in
+    // reconcileAgent must explicitly delete them.
+    const agentConfig = makeAgentConfig();
+    const scaffolded = scaffoldAgent("stale", agentConfig, tmpDir, telegramConfig);
+    const settingsPath = join(scaffolded.agentDir, ".claude", "settings.json");
+    const settings = JSON.parse(readFileSync(settingsPath, "utf-8"));
+    // Simulate a pre-PR agent: hand-inject both stale keys.
+    settings.enabledPlugins = { "telegram@claude-plugins-official": true };
+    settings.skipDangerousModePermissionPrompt = true;
+    writeFileSync(settingsPath, JSON.stringify(settings, null, 2), "utf-8");
+
+    reconcileAgent("stale", agentConfig, tmpDir, telegramConfig, buildSwitchroomConfig(agentConfig));
+    const reconciled = JSON.parse(readFileSync(settingsPath, "utf-8"));
+    expect(reconciled.enabledPlugins).toBeUndefined();
+    expect(reconciled.skipDangerousModePermissionPrompt).toBeUndefined();
+  });
+
   it("re-seeds workspace bootstrap files on reconcile (covers profile template additions)", () => {
     // Regression for Sprint 1 review finding #7: reconcileAgent did not
     // call seedWorkspaceBootstrapFiles, so new profile templates added

--- a/tests/scaffold.test.ts
+++ b/tests/scaffold.test.ts
@@ -541,8 +541,10 @@ describe("scaffoldAgent", () => {
     }
   });
 
-  it("never emits enabledPlugins — managed-settings-only, no effect at project scope", () => {
-    // Regression guard: plugin selection is driven by CLI flags in start.sh, not settings.json.
+  it("never emits enabledPlugins — redundant with start.sh CLI flag pathway", () => {
+    // Regression guard: plugin selection is driven by --channels / --plugin-dir
+    // in profiles/_base/start.sh.hbs. The settings.json block would work but
+    // duplicate state with the CLI flag and risk drift.
     const config = makeAgentConfig();
     const result = scaffoldAgent("no-enabled-plugins", config, tmpDir, telegramConfig);
     const settings = JSON.parse(

--- a/tests/scaffold.test.ts
+++ b/tests/scaffold.test.ts
@@ -527,24 +527,28 @@ describe("scaffoldAgent", () => {
     expect(startSh).not.toContain("--dangerously-skip-permissions");
   });
 
-  it("includes skipDangerousModePermissionPrompt when skip_permission_prompt is true", () => {
-    const config = makeAgentConfig({ skip_permission_prompt: true });
-    const result = scaffoldAgent("skip-prompt-agent", config, tmpDir, telegramConfig);
-    const settings = JSON.parse(
-      readFileSync(join(result.agentDir, ".claude", "settings.json"), "utf-8"),
-    );
-
-    expect(settings.skipDangerousModePermissionPrompt).toBe(true);
+  it("never emits skipDangerousModePermissionPrompt — Claude Code ignores it at project scope", () => {
+    // Regression guard: this key was emitted historically but Claude Code only
+    // honors it at user/local scope, never project. autoaccept handles the prompt.
+    for (const skip of [true, false, undefined]) {
+      const config = makeAgentConfig(skip === undefined ? {} : { skip_permission_prompt: skip });
+      const result = scaffoldAgent(`skip-${String(skip)}`, config, tmpDir, telegramConfig);
+      const settings = JSON.parse(
+        readFileSync(join(result.agentDir, ".claude", "settings.json"), "utf-8"),
+      );
+      expect(settings.skipDangerousModePermissionPrompt).toBeUndefined();
+      expect(settings.permissions?.skipDangerousModePermissionPrompt).toBeUndefined();
+    }
   });
 
-  it("does not include skipDangerousModePermissionPrompt by default", () => {
+  it("never emits enabledPlugins — managed-settings-only, no effect at project scope", () => {
+    // Regression guard: plugin selection is driven by CLI flags in start.sh, not settings.json.
     const config = makeAgentConfig();
-    const result = scaffoldAgent("default-prompt-agent", config, tmpDir, telegramConfig);
+    const result = scaffoldAgent("no-enabled-plugins", config, tmpDir, telegramConfig);
     const settings = JSON.parse(
       readFileSync(join(result.agentDir, ".claude", "settings.json"), "utf-8"),
     );
-
-    expect(settings.skipDangerousModePermissionPrompt).toBeUndefined();
+    expect(settings.enabledPlugins).toBeUndefined();
   });
 
   it("does not include switchroom-telegram MCP server in settings.json (it lives in .mcp.json)", () => {


### PR DESCRIPTION
## Summary

Two keys in `profiles/_base/settings.json.hbs` are written to every scaffolded agent's `.claude/settings.json` but have no effect there:

- **`skipDangerousModePermissionPrompt`** — real Claude Code key, but [ignored in project-level settings as a security measure](https://code.claude.com/docs/en/settings) (only user or local scope honored). Also wrong-nested (belongs under `permissions.`, we emit at top-level). `src/agents/autoaccept.ts` has been catching the boot prompt via the generic confirm regex; no behavior change from removal.
- **`enabledPlugins`** — REDUNDANT, not nonfunctional. The key IS valid at project scope per the docs ("What uses scopes" table at /en/settings; /en/discover-plugins notes project scope adds to `.claude/settings.json`). Plugin selection is already driven by `--channels` / `--plugin-dir` / `--dangerously-load-development-channels` flags in `profiles/_base/start.sh.hbs:506,508,512,514`. Keeping the settings.json block duplicates state and risks drift.

No user-visible behavior change.

## Changes

- Drop both blocks from `profiles/_base/settings.json.hbs`. Add a hbs-source-only comment explaining the (corrected) rationale so future reviewers don't re-add them. Note the `settings_raw` escape hatch can still inject either key intentionally.
- Remove both from `SWITCHROOM_OWNED_SETTINGS_KEYS` and `skipPermissionPrompt` from `buildSettingsTemplateVars` in `src/agents/scaffold.ts`.
- **One-shot migration retraction** in `reconcileAgent` (`src/agents/scaffold.ts` Phase-5+): explicitly `delete settings.enabledPlugins` / `delete settings.skipDangerousModePermissionPrompt`. The standard Phase-5 retraction loop is keyed on `_switchroomManagedRawKeys` (settings_raw injections), so template-emitted stale keys from prior versions wouldn't otherwise be retracted on existing agents. Safe to remove this block after a few releases.
- Mark `skip_permission_prompt` config field as DEPRECATED no-op in `src/config/schema.ts` describe text (accepted for backwards compatibility; users can safely remove it from `switchroom.yaml`).
- **Stop writing `skip_permission_prompt: true`** in `src/cli/setup.ts` during the dangerous-mode setup step — only `dangerous_mode: true` is written now. The deprecated field was being added to fresh yamls.
- New regression tests in `tests/scaffold.test.ts`:
  - **Scaffold path:** neither key is ever emitted at top-level or nested under `permissions`, for any value of `skip_permission_prompt`.
  - **Reconcile path:** hand-inject both stale keys into a scaffolded agent's settings.json, run reconcile, assert both are stripped.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `vitest run tests/scaffold.test.ts` — 167/167 (was 166; +1 reconcile regression)
- [x] `vitest run tests/reconcile-hooks-drift.test.ts` — 10/10
- [x] `vitest run tests/setup.test.ts` — 33/33
- [x] Manual: pre-PR agents get their stale `enabledPlugins` / `skipDangerousModePermissionPrompt` entries auto-stripped on next `switchroom apply` via the one-shot retraction.

## Non-blocking follow-ups

- Could add an explicit `autoaccept` PROMPTS rule matching Claude Code's `--dangerously-skip-permissions` startup warning, so the dangerous-mode boot path doesn't silently rely on the generic `Enter.{1,30}confirm` fallback. Not in scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)