### PR TITLE
fix(apply.test): sandbox HOME so migration check is env-independent

### DIFF
--- a/src/cli/apply.test.ts
+++ b/src/cli/apply.test.ts
@@ -30,6 +30,28 @@ function makeStubConfig(agentsDir: string): SwitchroomConfig {
 }
 
 describe("runApply", () => {
+  // Sandbox HOME so the apply orchestrator's vault-layout migration check
+  // (`migrateVaultLayout(homedir(), …)`) doesn't poke the real
+  // ~/.switchroom/vault/ on the test host. Without this, every test on a
+  // box where vault layout has already migrated to v0.7.12+ (the post-
+  // migration "state D" layout) sees the real symlink + vault file and
+  // can flip the migration classifier into "divergent" → process.exit(4).
+  // Pre-fix this was an env-dependent flake.
+  let _origHome: string | undefined;
+  let _homeSandbox: string | undefined;
+  beforeEach(async () => {
+    _origHome = process.env.HOME;
+    _homeSandbox = await mkdtemp(join(tmpdir(), "switchroom-apply-home-"));
+    process.env.HOME = _homeSandbox;
+  });
+  afterEach(() => {
+    if (_origHome !== undefined) {
+      process.env.HOME = _origHome;
+    } else {
+      delete process.env.HOME;
+    }
+  });
+
   it("writes the compose YAML to the requested path", async () => {
     const dir = await mkdtemp(join(tmpdir(), "switchroom-apply-test-"));
     const outPath = join(dir, "nested", "docker-compose.yml");


### PR DESCRIPTION
Pre-existing flake on `src/cli/apply.test.ts` — runApply probes the real `~/.switchroom/vault/` to detect migration state, which on any deployed switchroom box (post-v0.7.12 layout) trips into 'divergent' → `process.exit(4)` and fails 7 of 15 tests. Verified the same 7 failures exist on the v0.7.15 tag.

Fix: `beforeEach/afterEach` set `process.env.HOME` to a fresh tmp dir, so `homedir()` reads the sandbox instead of the real one. All 15 tests now pass on this box.

Test-only change, no production code modified.

Blocking the v0.7.16 npm publish until this lands so `prepublishOnly` passes cleanly.