### PR TITLE
fix(agent-add): thread --bot-username through to second bot-token validation

### DIFF
--- a/src/agents/add-orchestrator.ts
+++ b/src/agents/add-orchestrator.ts
@@ -273,12 +273,20 @@ export async function addAgent(opts: AddAgentOpts): Promise<AddAgentResult> {
   log(`\n[1/6] Scaffolding agent "${opts.name}" (profile=${resolvedProfile}, topology=${opts.topology})`);
 
   // ── Step 2: scaffold + auth session ──────────────────────────────────────
+  // `botUsername` is threaded through so the second bot-token validation
+  // (inside createAgent) uses exact-equality against the operator-declared
+  // username when the bot is intentionally named without the slug. Without
+  // this passthrough, `--bot-username` is honoured by the BotFather
+  // walkthrough above but rejected by the slug-contains check inside
+  // createAgent — making `--bot-username` (and `--loose`) silently
+  // ineffective for the use case they were added for.
   const created = await createAgent({
     name: opts.name,
     profile: resolvedProfile,
     telegramBotToken: resolvedBotToken,
     configPath: opts.configPath,
     rollbackOnFail: true,
+    botUsername: opts.botUsername,
   });
 
   // ── Step 2b: prune bundled skills the operator dropped ───────────────────

--- a/src/agents/create-orchestrator.test.ts
+++ b/src/agents/create-orchestrator.test.ts
@@ -106,7 +106,14 @@ describe("createAgent", () => {
         configPath: ws.configPath,
       });
 
-      expect(validateBotTokenMatchesAgent).toHaveBeenCalledWith("fake:token", "bot");
+      // Third arg is the optional `botUsername` (used by `--bot-username`
+      // exact-match path). Default path = `undefined` so the slug-contains
+      // assertion in validateBotTokenMatchesAgent kicks in.
+      expect(validateBotTokenMatchesAgent).toHaveBeenCalledWith(
+        "fake:token",
+        "bot",
+        undefined,
+      );
       expect(scaffoldAgent).toHaveBeenCalledOnce();
       expect(writeAgentEnv).toHaveBeenCalledWith(
         join(ws.agentsDir, "bot"),
@@ -286,6 +293,35 @@ describe("createAgent", () => {
       expect(scaffoldAgent).not.toHaveBeenCalled();
       const yamlBody = readFileSync(ws.configPath, "utf-8");
       expect(yamlBody).not.toMatch(/\bbot:/);
+    } finally {
+      ws.cleanup();
+    }
+  });
+
+  it("forwards botUsername to validateBotTokenMatchesAgent so --bot-username actually swaps slug-contains for exact-match", async () => {
+    // fails when: a refactor drops the botUsername passthrough — the
+    // `switchroom agent add --bot-username` flag is silently honoured
+    // by the BotFather walkthrough's first validation but then
+    // rejected by the slug-contains check inside createAgent. This is
+    // the exact bug that blocked UAT setup (#866 follow-up): agent
+    // `test-harness` paired with bot `meken_switchroom_test_bot`
+    // cannot pass slug-contains, and the operator's `--bot-username`
+    // override was being silently discarded here.
+    const ws = makeWorkspace();
+    try {
+      await createAgent({
+        name: "test-harness",
+        profile: "general",
+        telegramBotToken: "fake:token",
+        configPath: ws.configPath,
+        botUsername: "meken_switchroom_test_bot",
+      });
+
+      expect(validateBotTokenMatchesAgent).toHaveBeenCalledWith(
+        "fake:token",
+        "test-harness",
+        "meken_switchroom_test_bot",
+      );
     } finally {
       ws.cleanup();
     }

--- a/src/agents/create-orchestrator.ts
+++ b/src/agents/create-orchestrator.ts
@@ -54,6 +54,19 @@ export interface CreateAgentOpts {
    * Default: false (leave artefacts for retry).
    */
   rollbackOnFail?: boolean;
+  /**
+   * Optional explicit bot username for exact-equality validation. Use when
+   * the bot's username deliberately doesn't contain the agent slug (e.g.
+   * UAT setup uses `meken_switchroom_test_bot` for agent `test-harness`).
+   * When set, the slug-in-username assertion is replaced by an exact
+   * match against this username; mismatch still fails.
+   *
+   * Threaded through from `switchroom agent add --bot-username` via
+   * `add-orchestrator.ts`. Without this passthrough, the CLI flag is
+   * silently ignored at this second validation step and the slug check
+   * rejects mismatched names even with `--loose`.
+   */
+  botUsername?: string;
 }
 
 export interface CreationResult {
@@ -115,6 +128,7 @@ export async function createAgent(
     telegramBotToken,
     configPath: configPathOpt,
     rollbackOnFail = false,
+    botUsername,
   } = opts;
 
   // ── Step 0: Validate name slug (before any disk writes) ───────────────────
@@ -135,14 +149,17 @@ export async function createAgent(
 
   // ── Step 2: Validate bot token and assert username matches agent slug ────
   // Uses getMe to verify the token is valid AND that the returned username
-  // contains the agent slug — catches copy-paste mistakes like writing
-  // clerk's token into finn's .env before any disk writes occur.
-  await validateBotTokenMatchesAgent(telegramBotToken, name).catch((err: Error) => {
-    throw new Error(
-      `Bot token validation failed — check the token and try again. ` +
-        `(${err.message})`,
-    );
-  });
+  // matches what the operator expects — either by slug-substring (default)
+  // or by exact equality when `botUsername` is supplied (the `--bot-username`
+  // path used when the bot is intentionally named without the slug).
+  await validateBotTokenMatchesAgent(telegramBotToken, name, botUsername).catch(
+    (err: Error) => {
+      throw new Error(
+        `Bot token validation failed — check the token and try again. ` +
+          `(${err.message})`,
+      );
+    },
+  );
 
   // ── Step 3: Determine configPath and ensure agent in yaml ─────────────────
   const configPath =


### PR DESCRIPTION
## Summary

`switchroom agent add --bot-username <X>` was silently ignored at the second bot-token validation inside `createAgent`. The BotFather walkthrough at the top of `add-orchestrator.ts` correctly honoured the override (exact-match), but `createAgent` then ran its own `validateBotTokenMatchesAgent(token, name)` call — no third arg — which fell back to the slug-contains check and rejected anything where the bot username didn't contain the agent slug.

## Repro

```
SWITCHROOM_BOT_TOKEN=<token-for-@meken_switchroom_test_bot> \
  switchroom agent add test-harness \
    --profile default \
    --topology dm \
    --bot-username meken_switchroom_test_bot \
    --loose \
    --allow-from $UID
```

Walkthrough prints `Bot token validated for @meken_switchroom_test_bot` (slug-bypass honoured by walkthrough). Then:

```
agent add failed: Bot token validation failed — check the token and try again.
  (agent "test-harness" bot_token resolves to @meken_switchroom_test_bot
   — expected username to contain "test-harness". ...)
```

The `--loose` flag is unrelated to this validation; it controls warn-vs-throw in the walkthrough only.

## Fix

- `CreateAgentOpts` gains optional `botUsername`.
- `createAgent` passes it as the 3rd arg to `validateBotTokenMatchesAgent` (which already short-circuits to exact-match when the 3rd arg is set — see `src/setup/telegram-api.ts:assertBotUsernameMatchesAgent`).
- `add-orchestrator.ts:createAgent({...})` forwards `opts.botUsername`.

## Tests

- New test in `create-orchestrator.test.ts` pins the passthrough.
- Existing happy-path test updated to expect the new (undefined) 3rd arg.
- 9/9 create-orchestrator + 29/29 add-orchestrator tests pass; `tsc --noEmit` clean.

## Discovered while

Setting up the test-harness agent for the UAT smoke loop (#866 Phase 2a follow-up). The bot is `@meken_switchroom_test_bot` (vendored Telegram bot for UAT); the agent is `test-harness` (must match the `--allow test-harness` vault scope on `telegram-test-bot-token` and the 3 other UAT vault keys, so renaming the agent isn't an option).

🤖 Generated with [Claude Code](https://claude.com/claude-code)