### PR TITLE
fix(uat): pin vitest.uat.config.ts root so test:uat discovers scenarios

### DIFF
--- a/vitest.uat.config.ts
+++ b/vitest.uat.config.ts
@@ -1,12 +1,22 @@
 import { defineConfig } from "vitest/config";
+import { fileURLToPath } from "node:url";
 
 /**
  * UAT-only vitest config (epic #863). Runs scenarios in
  * `telegram-plugin/uat/scenarios/`. Hits real Telegram, real Claude
  * — never on the default CI critical path. Invoke via
  * `bun run test:uat` from `telegram-plugin/`.
+ *
+ * `root` is pinned to the directory containing this config file
+ * (repo root), not vitest's cwd. Without this, running the script
+ * from `telegram-plugin/` (as `bun run test:uat` does) resolves
+ * the `include` glob against `telegram-plugin/`, so the pattern
+ * `telegram-plugin/uat/scenarios/**` ends up looking for
+ * `telegram-plugin/telegram-plugin/uat/scenarios/**` and matches
+ * nothing — "No test files found, exiting with code 1".
  */
 export default defineConfig({
+  root: fileURLToPath(new URL(".", import.meta.url)),
   test: {
     globals: true,
     environment: "node",


### PR DESCRIPTION
## Summary

`bun run test:uat` (which runs `vitest run --config ../vitest.uat.config.ts` from `telegram-plugin/`) was always exiting with `No test files found, exiting with code 1`. Root cause: vitest defaults to its cwd (`telegram-plugin/`) as the project root, then resolves `include: ["telegram-plugin/uat/scenarios/**/*.test.ts"]` against it → ends up looking for `telegram-plugin/telegram-plugin/uat/...` which matches nothing.

Fix: pin `root` to the config-file's directory (repo root) via `fileURLToPath(new URL(".", import.meta.url))`. The include glob then resolves correctly regardless of invocation cwd.

## Repro (pre-fix)

```
$ cd ~/code/switchroom/telegram-plugin
$ bun run test:uat
$ vitest run --config ../vitest.uat.config.ts
 RUN  v3.2.4 .../telegram-plugin
No test files found, exiting with code 1
include: telegram-plugin/uat/scenarios/**/*.test.ts
```

## Post-fix

```
$ bun run test:uat
$ vitest run --config ../vitest.uat.config.ts
 RUN  v3.2.4 .../switchroom

 ❯ telegram-plugin/uat/scenarios/smoke-dm-reply.test.ts (1 test | 1 failed)
   Test Files  1 failed (1)
   Tests  1 failed (1)
```

(The test fails on missing env vars in my worktree — expected; it confirms discovery + execution works.)

## Why nobody caught this

The scaffold landed in PR #868 (May 9) with the test config and a stub smoke scenario. The end-to-end runtime wasn't wired up until today (PRs #994 + #995 + #996 + several operator-side fixes), so the first `test:uat` invocation against a real working agent was the first time anyone ran the script for real.

## Verification

- `npx tsc --noEmit` clean.
- `bun run test:uat` from `telegram-plugin/` discovers the smoke scenario.
- `npm test` / `bun test` paths unaffected (they use `vitest.config.ts`, not `vitest.uat.config.ts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)