### PR TITLE
fix(uat): Driver.connect must call startUpdatesLoop() or no updates fire

### DIFF
--- a/telegram-plugin/uat/driver.ts
+++ b/telegram-plugin/uat/driver.ts
@@ -104,6 +104,14 @@ export class Driver {
     // session as authoritative and silently ignores ours.
     await this.client.importSession(this.opts.session, true);
     await this.client.connect();
+    // `connect()` opens the transport but does NOT start the updates
+    // dispatch loop — that's `start()`'s job. For a returning session
+    // (no interactive login) we have to call `startUpdatesLoop()`
+    // ourselves, otherwise `onNewMessage` / `onEditMessage` never
+    // fire and `observeMessages` silently waits forever. Symptom:
+    // `expectMessage` timing out even though the bot's reply has
+    // arrived in the chat (visible in Telegram).
+    await this.client.startUpdatesLoop();
   }
 
   async disconnect(): Promise<void> {

--- a/tests/uat-driver.test.ts
+++ b/tests/uat-driver.test.ts
@@ -40,6 +40,7 @@ class MockEmitter<T> {
 const mockClient = {
   importSession: vi.fn(async () => undefined),
   connect: vi.fn(async () => undefined),
+  startUpdatesLoop: vi.fn(async () => undefined),
   destroy: vi.fn(async () => undefined),
   sendText: vi.fn(async () => ({ id: 999 })),
   onNewMessage: new MockEmitter<unknown>(),
@@ -96,6 +97,26 @@ describe("Driver.connect", () => {
     const importOrder = mockClient.importSession.mock.invocationCallOrder[0];
     const connectOrder = mockClient.connect.mock.invocationCallOrder[0];
     expect(importOrder).toBeLessThan(connectOrder!);
+  });
+
+  it("calls startUpdatesLoop after connect so onNewMessage / onEditMessage fire for live updates", async () => {
+    // fails when: someone "simplifies" the connect chain by dropping
+    // the startUpdatesLoop call — `client.connect()` alone opens the
+    // transport but DOES NOT start dispatching incoming updates to
+    // the parsed emitters. Symptom is silent: messages arrive in
+    // Telegram (visible in the chat) but `observeMessages` never
+    // yields them, and `expectMessage` waits the full timeout. Took
+    // a debug session against a real bot reply to find the first
+    // time; this test exists so the second time is a unit-test
+    // failure on the PR, not a 90-second timeout in CI.
+    const driver = new Driver({ apiId: 1, apiHash: "h", session: "S" });
+    await driver.connect();
+    expect(mockClient.startUpdatesLoop).toHaveBeenCalledTimes(1);
+    const connectOrder = mockClient.connect.mock.invocationCallOrder[0];
+    const loopOrder = mockClient.startUpdatesLoop.mock.invocationCallOrder[0];
+    // Loop must start AFTER connect — calling startUpdatesLoop before
+    // there's a transport throws.
+    expect(connectOrder).toBeLessThan(loopOrder!);
   });
 });
 


### PR DESCRIPTION
## Summary

`Driver.connect()` was missing `client.startUpdatesLoop()`. With just `client.connect()`, mtcute opens the transport but doesn't dispatch incoming updates to the parsed emitters — `onNewMessage` / `onEditMessage` never fire, and `observeMessages` silently waits forever.

## Symptom

Smoke scenario `smoke-dm-reply.test.ts` timed out at 90s with:
```
expectMessage: no matching message in chat=8288144562 within 90000ms
```

…even though the bot's reply was visible in Telegram and logged on the agent side (`tg-post method=sendMessage chat=8248703757 status=ok`).

## Diagnosis

Walked a debug script through `client.onNewMessage.add(...)` against a live session. Without `startUpdatesLoop`: zero events for 30s. With it: bot's reply observed within seconds. Direct verification:

```
sent: id=67052 chat=8288144562
onEditMessage: chat.id=8288144562 sender.id=8248703757   ← driver's own send
onNewMessage: chat.id=8288144562 sender.id=8288144562 text="ack — uat-debug ... received ✅"
```

For interactive sessions, `client.start()` (used in `login.ts`) calls `startUpdatesLoop` internally. For a returning session — `importSession` + `connect` (the path we use in `Driver`) — it has to be called explicitly.

## Fix

One line in `Driver.connect()`:

```ts
await this.client.connect();
await this.client.startUpdatesLoop();   // ← was missing
```

## Test

New unit test in `tests/uat-driver.test.ts` pins the call order (connect → startUpdatesLoop), with a `// fails when:` comment documenting the silent-failure mode. With this, the next time someone "simplifies" the connect chain by dropping the loop call, the PR fails in unit tests rather than a 90-second CI timeout.

10/10 driver tests pass. `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)