### PR TITLE
docs(uat/SETUP): cross-reference operator papercuts (#999 #1001 #1002)

### DIFF
--- a/telegram-plugin/uat/SETUP.md
+++ b/telegram-plugin/uat/SETUP.md
@@ -156,6 +156,29 @@ switchroom agent status test-harness
 boots the container, runs a preflight. On success the agent is
 running and will reply to DMs from the driver user account.
 
+> **Known papercut — fix in #1001.** The wizard currently writes the
+> `--allow-from` user_id into `access.json` as a **number**; the
+> gateway requires it as a **string** and silently ignores DMs until
+> patched. Until #1001 lands, after `agent add` succeeds, edit the
+> file by hand (the file is owned by the per-agent UID; needs sudo):
+>
+> ```bash
+> sudo python3 -c "
+> import json
+> p = '/home/$USER/.switchroom/agents/test-harness/telegram/access.json'
+> d = json.load(open(p))
+> d['allowFrom'] = [str(x) for x in d['allowFrom']]
+> d['groups'] = {}   # see #1002: scaffold leaves a stray placeholder chat_id
+> json.dump(d, open(p, 'w'), indent=2)
+> "
+> ```
+
+> **Known papercut — fix in #1002.** The scaffold leaves a
+> placeholder `groups: {"-100…"}` entry pointing at a chat the bot
+> isn't in. The gateway probes it at boot and gets a 404 (noisy log,
+> not fatal). The `sudo python3` snippet above clears it; otherwise
+> ignore the `boot-probe-failed` log line.
+
 ### When this agent should be running
 
 - During UAT runs: yes. Scenarios fail with `expectMessage` timeouts
@@ -199,6 +222,16 @@ bun run test:uat
 
 unset TELEGRAM_API_HASH TELEGRAM_UAT_DRIVER_SESSION TELEGRAM_API_ID TELEGRAM_TEST_BOT_USERNAME
 ```
+
+> **Known papercut — fix in #999.** Each `vault get --no-broker` line
+> above relies on `$SWITCHROOM_VAULT_PASSPHRASE` being set in the env
+> because the vault CLI's passphrase prompt writes to stdout — which
+> `$(...)` captures into the env var, so the prompt is never shown to
+> the operator and the read fails silently. Setting
+> `SWITCHROOM_VAULT_PASSPHRASE` first sidesteps the prompt entirely.
+> If you forget, you'll see `Error: Passphrase cannot be empty` for
+> each line and `TELEGRAM_API_HASH=` will be empty, leading to a
+> later misleading "API ID invalid" from Telegram.
 
 The vault passphrase is unset BEFORE the tests run so a misbehaving
 scenario can't smuggle it into a chat message. The remaining env


### PR DESCRIPTION
## Summary

Documents three papercuts that blocked the first end-to-end UAT run today, with cross-references to the underlying bugs so the snippets can be collapsed back to \"see #N\" once each is fixed.

- **#999** — vault passphrase prompt on stdout swallowed by \`\$(...)\` substitution. Adds a note that \`SWITCHROOM_VAULT_PASSPHRASE\` must be set before the env-export block.
- **#1001** — \`agent add --allow-from <int>\` writes numeric \`allowFrom\`; gateway requires strings. Adds a sudo python3 one-liner to patch \`access.json\` post-creation.
- **#1002** — scaffold leaves a placeholder \`groups: {\"-100…\"}\` entry for DM-topology agents that 404s on boot. Cleared by the same patch snippet.

Docs-only — no code change, no test impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)