### PR TITLE
feat(uat): observeReactions + expectReaction for status-emoji scenarios (#866 Phase 2b)

### DIFF
--- a/telegram-plugin/uat/assertions.ts
+++ b/telegram-plugin/uat/assertions.ts
@@ -153,19 +153,78 @@ function raceTimeout<T>(p: Promise<T>, ms: number): Promise<T | "timeout"> {
 // ---------- Phase 2b stubs (deferred to follow-up PR) ----------
 
 /**
- * TODO(#866): wait for a reaction sequence on `messageId`. Each
- * emoji in `sequence` must appear (add op) in order; intermediate
- * other reactions are tolerated. Returns the full observed reaction
- * trail.
+ * Wait for a reaction `sequence` on `messageId` in `chatId`. Each
+ * emoji must appear (as an add `+` op) in the order given;
+ * intermediate add/remove ops for other emojis are tolerated.
+ *
+ * Returns the full observed trail (every add/remove seen up to and
+ * including the final match) so scenarios can do follow-up
+ * assertions on the order or count.
+ *
+ * Production note: the gateway calls `setMessageReaction` which
+ * REPLACES the prior emoji (not adds-in-addition-to). So an
+ * 👀 → 🤔 transition emits `-👀` and `+🤔` in the same observation
+ * window. This helper only watches the `+` ops, so the
+ * gateway-replace pattern reads as a clean sequence.
+ *
+ * Fast-turn note: turns shorter than the gateway's
+ * `progress-card initialDelayMs` may collapse intermediate
+ * reactions — you might only see 👀 and 👍. The sequence-match
+ * tolerates this: every emoji in `sequence` must appear in order,
+ * but we don't require it to be the ONLY emojis added.
  */
 export async function expectReaction(
-  _driver: Driver,
-  _chatId: number,
-  _messageId: number,
-  _sequence: string[],
-  _opts: PollOptions,
+  driver: Driver,
+  chatId: number,
+  messageId: number,
+  sequence: string[],
+  opts: PollOptions,
 ): Promise<ObservedReaction[]> {
-  throw new Error("expectReaction not implemented (Phase 2)");
+  if (sequence.length === 0) {
+    throw new Error("expectReaction: sequence must be non-empty");
+  }
+  const trail: ObservedReaction[] = [];
+  const iter = driver.observeReactions(chatId, { messageId })[Symbol.asyncIterator]();
+  const deadline = Date.now() + opts.timeout;
+  let cursor = 0;
+  try {
+    while (Date.now() < deadline && cursor < sequence.length) {
+      const remaining = deadline - Date.now();
+      const next = await raceTimeoutR(iter.next(), remaining);
+      if (next === "timeout") break;
+      if (next.done === true) break;
+      const r = next.value;
+      trail.push(r);
+      if (r.op === "+" && r.emoji === sequence[cursor]) {
+        cursor++;
+      }
+    }
+  } finally {
+    await iter.return?.();
+  }
+  if (cursor < sequence.length) {
+    throw new Error(
+      `expectReaction: saw ${cursor}/${sequence.length} expected emoji ` +
+        `(missing ${sequence.slice(cursor).map((e) => JSON.stringify(e)).join(", ")}) ` +
+        `on chat=${chatId} msg=${messageId} within ${opts.timeout}ms ` +
+        `(observed ops: ${trail.map((t) => `${t.op}${t.emoji}`).join(" ")})`,
+    );
+  }
+  return trail;
+}
+
+function raceTimeoutR<T>(p: Promise<T>, ms: number): Promise<T | "timeout"> {
+  if (ms <= 0) return Promise.resolve("timeout");
+  return new Promise<T | "timeout">((resolve) => {
+    const t = setTimeout(() => resolve("timeout"), ms);
+    p.then((v) => {
+      clearTimeout(t);
+      resolve(v);
+    }).catch(() => {
+      clearTimeout(t);
+      resolve("timeout");
+    });
+  });
 }
 
 export interface PinnedCardSnapshot {

--- a/telegram-plugin/uat/driver.ts
+++ b/telegram-plugin/uat/driver.ts
@@ -240,22 +240,125 @@ export class Driver {
     };
   }
 
-  // -------- Deferred to #866 / Phase 2b --------
-
   /**
-   * TODO(#866): subscribe to message-reaction updates. mtcute delivers
-   * `updateMessageReactions` via the raw update stream; the driver
-   * should compute add/remove ops vs the prior snapshot so scenarios
-   * can assert on the 👀→🤔→🔥→👍 sequence. Held out of #865 because
-   * mtcute's user-account reaction parsing has rougher edges than
-   * `onNewMessage` and benefits from a dedicated PR + test.
+   * Subscribe to message-reaction add/remove ops in `chatId` (and
+   * optionally on a specific `messageId`).
+   *
+   * Implementation notes:
+   *
+   * - mtcute parses `updateBotMessageReaction` for bot accounts; for
+   *   USER accounts (the driver) we have to handle the raw
+   *   `updateMessageReactions` ourselves via `onRawUpdate`. The TL
+   *   carries the full new reaction set, not a delta — we diff
+   *   against the prior set we've cached for the same `msgId` to
+   *   emit add (`+`) / remove (`-`) ops.
+   *
+   * - For 1:1 DMs the update's `peer` is `peerUser` carrying the
+   *   OTHER party's user_id (the bot). Filtering by
+   *   `peer.userId === chatId` matches the driver-side convention
+   *   where `chatId === botUserId`.
+   *
+   * - Reactions are emitted only when they CHANGE. The initial
+   *   reaction-add fires as `op: "+"`; a follow-up
+   *   `setMessageReaction` that REPLACES the prior emoji emits `-`
+   *   for the old + `+` for the new.
+   *
+   * - Custom emojis (`reactionCustomEmoji`) are skipped — scenarios
+   *   that need them aren't in scope and parsing them would require
+   *   resolving the document id to an alias.
    */
   observeReactions(
-    _chatId: number,
-    _opts?: { messageId?: number },
+    chatId: number,
+    opts?: { messageId?: number },
   ): AsyncIterable<ObservedReaction> {
-    throw new Error("Driver.observeReactions not implemented (#866)");
+    const c = this.requireClient();
+    const targetMsgId = opts?.messageId;
+    const queue: ObservedReaction[] = [];
+    const waiters: Array<(m: IteratorResult<ObservedReaction>) => void> = [];
+    let closed = false;
+    const prior = new Map<number, Set<string>>();
+
+    const dispatch = (r: ObservedReaction): void => {
+      const w = waiters.shift();
+      if (w) w({ value: r, done: false });
+      else queue.push(r);
+    };
+
+    const onRaw = (info: { update: unknown }): void => {
+      const u = info.update as {
+        _: string;
+        peer?: { _: string; userId?: number };
+        msgId?: number;
+        reactions?: {
+          results?: Array<{
+            reaction: { _: string; emoticon?: string };
+          }>;
+        };
+      };
+      if (u._ !== "updateMessageReactions") return;
+      if (u.peer?._ !== "peerUser") return;
+      if (u.peer.userId !== chatId) return;
+      const msgId = u.msgId;
+      if (typeof msgId !== "number") return;
+      if (targetMsgId !== undefined && msgId !== targetMsgId) return;
+
+      const now = new Set<string>();
+      for (const rc of u.reactions?.results ?? []) {
+        if (
+          rc.reaction?._ === "reactionEmoji" &&
+          typeof rc.reaction.emoticon === "string"
+        ) {
+          now.add(rc.reaction.emoticon);
+        }
+      }
+      const before = prior.get(msgId) ?? new Set<string>();
+      const date = new Date();
+      for (const e of now) {
+        if (!before.has(e)) {
+          dispatch({ chatId, messageId: msgId, emoji: e, op: "+", date });
+        }
+      }
+      for (const e of before) {
+        if (!now.has(e)) {
+          dispatch({ chatId, messageId: msgId, emoji: e, op: "-", date });
+        }
+      }
+      prior.set(msgId, now);
+    };
+
+    c.onRawUpdate.add(onRaw);
+
+    const close = (): void => {
+      if (closed) return;
+      closed = true;
+      c.onRawUpdate.remove(onRaw);
+      while (waiters.length > 0) {
+        waiters.shift()?.({ value: undefined as never, done: true });
+      }
+    };
+
+    return {
+      [Symbol.asyncIterator](): AsyncIterator<ObservedReaction> {
+        return {
+          next(): Promise<IteratorResult<ObservedReaction>> {
+            if (queue.length > 0) {
+              return Promise.resolve({ value: queue.shift()!, done: false });
+            }
+            if (closed) {
+              return Promise.resolve({ value: undefined as never, done: true });
+            }
+            return new Promise((resolve) => waiters.push(resolve));
+          },
+          return(): Promise<IteratorResult<ObservedReaction>> {
+            close();
+            return Promise.resolve({ value: undefined as never, done: true });
+          },
+        };
+      },
+    };
   }
+
+  // -------- Deferred to #866 / Phase 2c --------
 
   /**
    * TODO(#866): subscribe to pin/unpin events on `chatId`/topic.

--- a/telegram-plugin/uat/scenarios/reactions-dm.test.ts
+++ b/telegram-plugin/uat/scenarios/reactions-dm.test.ts
@@ -1,0 +1,43 @@
+/**
+ * Reaction-sequence scenario — driver DMs the test bot, bot reacts
+ * to the inbound message with the gateway's status emoji sequence.
+ *
+ * Part of: https://github.com/switchroom/switchroom/issues/866
+ *
+ * The gateway emits reactions in order via `setMessageReaction`,
+ * which REPLACES the prior emoji on each call. For fast turns
+ * (< the progress-card `initialDelayMs` of 45s), intermediate
+ * reactions may collapse — typically the terminal `👍` is what
+ * lands. This scenario only asserts on the terminal emoji because
+ * that's the one observable in fast-turn DMs without artificial
+ * delay; the full 👀→🤔→🔥→👍 sequence is a Phase 2c target
+ * with a long-turn scenario.
+ *
+ * Requires the same env as `smoke-dm-reply.test.ts` (see
+ * `uat/SETUP.md` §6).
+ */
+
+import { describe, it, expect } from "vitest";
+import { spinUp } from "../harness.js";
+
+const INBOUND = `uat-reactions ${new Date().toISOString()}`;
+
+describe("uat: bot reacts to driver DM with terminal status emoji", () => {
+  it("driver sees 👍 (done) appear on its inbound within 90s", async () => {
+    const sc = await spinUp({ agent: "test-harness" });
+    try {
+      const sent = await sc.sendDM(INBOUND);
+      const trail = await sc.expectReaction(
+        sent.messageId,
+        ["👍"],
+        { timeout: 90_000 },
+      );
+      // The trail captures everything observed; surface the last add
+      // so a failure dump shows the actual emoji set.
+      const lastAdd = [...trail].reverse().find((t) => t.op === "+");
+      expect(lastAdd?.emoji).toBe("👍");
+    } finally {
+      await sc.tearDown();
+    }
+  });
+});

--- a/tests/uat-assertions.test.ts
+++ b/tests/uat-assertions.test.ts
@@ -8,10 +8,14 @@
  */
 
 import { describe, expect, it } from "vitest";
-import { expectMessage } from "../telegram-plugin/uat/assertions.js";
+import {
+  expectMessage,
+  expectReaction,
+} from "../telegram-plugin/uat/assertions.js";
 import type {
   Driver,
   ObservedMessage,
+  ObservedReaction,
 } from "../telegram-plugin/uat/driver.js";
 
 /**
@@ -153,6 +157,123 @@ describe("expectMessage: timeout", () => {
     const t0 = Date.now();
     await expect(
       expectMessage(driver, -100, /./, { timeout: 80 }),
+    ).rejects.toThrow();
+    const elapsed = Date.now() - t0;
+    expect(elapsed).toBeLessThan(500);
+  });
+});
+
+function stubReactionDriver(reactions: ObservedReaction[]): Driver {
+  return {
+    observeReactions(_chatId: number, _opts?: { messageId?: number }): AsyncIterable<ObservedReaction> {
+      let i = 0;
+      return {
+        [Symbol.asyncIterator](): AsyncIterator<ObservedReaction> {
+          return {
+            next(): Promise<IteratorResult<ObservedReaction>> {
+              if (i < reactions.length) {
+                return Promise.resolve({ value: reactions[i++]!, done: false });
+              }
+              return new Promise(() => {});
+            },
+            return(): Promise<IteratorResult<ObservedReaction>> {
+              return Promise.resolve({ value: undefined as never, done: true });
+            },
+          };
+        },
+      };
+    },
+  } as unknown as Driver;
+}
+
+function rx(emoji: string, op: "+" | "-"): ObservedReaction {
+  return { chatId: 100, messageId: 5, emoji, op, date: new Date() };
+}
+
+describe("expectReaction: sequence matching", () => {
+  it("matches an in-order add sequence", async () => {
+    // fails when: the cursor-advance logic is dropped — observing
+    // [+👀, +🤔, +🔥, +👍] would only advance once and the helper
+    // would time out claiming we saw 1/4. This is the foundational
+    // shape: each emoji in `sequence` must appear in order.
+    const trail = await expectReaction(
+      stubReactionDriver([rx("👀", "+"), rx("🤔", "+"), rx("🔥", "+"), rx("👍", "+")]),
+      100,
+      5,
+      ["👀", "🤔", "🔥", "👍"],
+      { timeout: 1000 },
+    );
+    expect(trail).toHaveLength(4);
+    expect(trail.every((t) => t.op === "+")).toBe(true);
+  });
+
+  it("tolerates intermediate -remove ops (gateway's setMessageReaction REPLACES)", async () => {
+    // fails when: the matcher accidentally counts `-` ops toward the
+    // sequence — the gateway emits `-old +new` on every replace, so
+    // for a fast-turn 👀→👍 trail we see [+👀, +👍, -👀]; if `-👀`
+    // counted, the cursor would mis-advance and the sequence would
+    // be considered already-complete.
+    const trail = await expectReaction(
+      stubReactionDriver([rx("👀", "+"), rx("👍", "+"), rx("👀", "-")]),
+      100,
+      5,
+      ["👀", "👍"],
+      { timeout: 1000 },
+    );
+    expect(trail.filter((t) => t.op === "+").map((t) => t.emoji)).toEqual(["👀", "👍"]);
+  });
+
+  it("tolerates intermediate other-emoji adds (extra reactions don't break the match)", async () => {
+    // fails when: scenarios that share the chat with concurrent
+    // activity (a human reacting to the same message, future
+    // multi-driver tests) flake because the unrelated reaction
+    // collides with the sequence cursor.
+    const trail = await expectReaction(
+      stubReactionDriver([rx("👀", "+"), rx("💩", "+"), rx("👍", "+")]),
+      100,
+      5,
+      ["👀", "👍"],
+      { timeout: 1000 },
+    );
+    expect(trail).toHaveLength(3);
+  });
+
+  it("times out with a useful error mentioning the missing emoji + observed trail", async () => {
+    // fails when: the timeout error loses the trail summary — a CI
+    // flake report would say "missing 👍" without any indication
+    // that the bot DID set 👀 and 🤔 first, which would change the
+    // debugging direction from "gateway broken" to "fast-turn
+    // suppression collapsing 🔥 and 👍".
+    await expect(
+      expectReaction(
+        stubReactionDriver([rx("👀", "+"), rx("🤔", "+")]),
+        100,
+        5,
+        ["👀", "🤔", "🔥", "👍"],
+        { timeout: 80 },
+      ),
+    ).rejects.toThrow(/2\/4.*missing.*"🔥".*"👍".*\+👀.*\+🤔/s);
+  });
+
+  it("rejects an empty sequence", async () => {
+    // fails when: the empty-guard is dropped — a scenario that
+    // accidentally passes [] would silently "succeed" without
+    // observing anything, lulling the author into false confidence.
+    await expect(
+      expectReaction(stubReactionDriver([]), 100, 5, [], { timeout: 100 }),
+    ).rejects.toThrow(/non-empty/);
+  });
+
+  it("doesn't hang past the deadline on a silent stream", async () => {
+    // fails when: the inner iter.next() isn't raced against the
+    // deadline — silent reaction stream would hang the test runner
+    // until vitest's per-test timeout fires.
+    const t0 = Date.now();
+    await expect(
+      expectReaction(
+        stubReactionDriver([]),
+        100, 5, ["👀"], { timeout: 80 },
+      ),
     ).rejects.toThrow();
     const elapsed = Date.now() - t0;
     expect(elapsed).toBeLessThan(500);

--- a/tests/uat-driver.test.ts
+++ b/tests/uat-driver.test.ts
@@ -45,6 +45,7 @@ const mockClient = {
   sendText: vi.fn(async () => ({ id: 999 })),
   onNewMessage: new MockEmitter<unknown>(),
   onEditMessage: new MockEmitter<unknown>(),
+  onRawUpdate: new MockEmitter<unknown>(),
 };
 
 const TelegramClientCtor = vi.fn().mockImplementation(() => mockClient);
@@ -60,6 +61,7 @@ beforeEach(async () => {
   vi.clearAllMocks();
   mockClient.onNewMessage = new MockEmitter<unknown>();
   mockClient.onEditMessage = new MockEmitter<unknown>();
+  mockClient.onRawUpdate = new MockEmitter<unknown>();
   Driver = (await import("../telegram-plugin/uat/driver.js")).Driver;
 });
 
@@ -242,6 +244,137 @@ describe("Driver.observeMessages", () => {
 
     const after = await iter.next();
     expect(after.done).toBe(true);
+  });
+});
+
+describe("Driver.observeReactions", () => {
+  // Helper — build a raw `updateMessageReactions` shape.
+  function rxUpdate(opts: {
+    peerUserId: number;
+    msgId: number;
+    emojis: string[];
+  }): { update: unknown } {
+    return {
+      update: {
+        _: "updateMessageReactions",
+        peer: { _: "peerUser", userId: opts.peerUserId },
+        msgId: opts.msgId,
+        reactions: {
+          results: opts.emojis.map((e) => ({
+            reaction: { _: "reactionEmoji", emoticon: e },
+          })),
+        },
+      },
+    };
+  }
+
+  it("emits a `+emoji` op on first reaction", async () => {
+    // fails when: the prior-set diff logic loses its initial empty
+    // baseline — first reaction wouldn't be classified as "new" and
+    // expectReaction would time out on the very first emoji.
+    const driver = new Driver({ apiId: 1, apiHash: "h", session: "S" });
+    await driver.connect();
+    const iter = driver.observeReactions(8288144562, { messageId: 67050 })[Symbol.asyncIterator]();
+    mockClient.onRawUpdate.emit(rxUpdate({
+      peerUserId: 8288144562,
+      msgId: 67050,
+      emojis: ["👀"],
+    }));
+    const first = await iter.next();
+    expect(first.done).toBe(false);
+    const r = first.value as { emoji: string; op: string };
+    expect(r.emoji).toBe("👀");
+    expect(r.op).toBe("+");
+    await iter.return?.();
+  });
+
+  it("computes -old +new when setMessageReaction replaces the prior emoji", async () => {
+    // fails when: the diff direction inverts (would emit -new instead
+    // of -old) or the prior set isn't updated, producing duplicate
+    // emissions on the next call. Pins the gateway's actual
+    // call pattern: setMessageReaction REPLACES, doesn't add.
+    const driver = new Driver({ apiId: 1, apiHash: "h", session: "S" });
+    await driver.connect();
+    const iter = driver.observeReactions(8288144562, { messageId: 67050 })[Symbol.asyncIterator]();
+    mockClient.onRawUpdate.emit(rxUpdate({
+      peerUserId: 8288144562, msgId: 67050, emojis: ["👀"],
+    }));
+    mockClient.onRawUpdate.emit(rxUpdate({
+      peerUserId: 8288144562, msgId: 67050, emojis: ["👍"],
+    }));
+    // Order: +👀, then on the replace event +👍 + -👀 (order of those
+    // last two doesn't matter, but both must come through).
+    const ops: Array<{ emoji: string; op: string }> = [];
+    for (let i = 0; i < 3; i++) {
+      const n = await iter.next();
+      if (n.done) break;
+      const v = n.value as { emoji: string; op: string };
+      ops.push({ emoji: v.emoji, op: v.op });
+    }
+    expect(ops).toEqual(expect.arrayContaining([
+      { emoji: "👀", op: "+" },
+      { emoji: "👍", op: "+" },
+      { emoji: "👀", op: "-" },
+    ]));
+    await iter.return?.();
+  });
+
+  it("filters out updates for the wrong chat or message", async () => {
+    // fails when: the chat/msg filter widens — scenarios would see
+    // reactions from every chat the driver is part of, flooding the
+    // queue and likely matching unrelated emoji shapes by accident.
+    const driver = new Driver({ apiId: 1, apiHash: "h", session: "S" });
+    await driver.connect();
+    const iter = driver.observeReactions(8288144562, { messageId: 67050 })[Symbol.asyncIterator]();
+    mockClient.onRawUpdate.emit(rxUpdate({ peerUserId: 99, msgId: 67050, emojis: ["💩"] }));
+    mockClient.onRawUpdate.emit(rxUpdate({ peerUserId: 8288144562, msgId: 1, emojis: ["💩"] }));
+    mockClient.onRawUpdate.emit(rxUpdate({ peerUserId: 8288144562, msgId: 67050, emojis: ["👀"] }));
+    const first = await iter.next();
+    const r = first.value as { emoji: string };
+    expect(r.emoji).toBe("👀");
+    await iter.return?.();
+  });
+
+  it("skips custom-emoji reactions (out of scope for Phase 2b)", async () => {
+    // fails when: someone adds support for `reactionCustomEmoji`
+    // without resolving the document_id to an alias. Custom emojis
+    // would leak through as opaque "documentId=..." strings and break
+    // expectReaction's exact-match.
+    const driver = new Driver({ apiId: 1, apiHash: "h", session: "S" });
+    await driver.connect();
+    const iter = driver.observeReactions(8288144562, { messageId: 67050 })[Symbol.asyncIterator]();
+    mockClient.onRawUpdate.emit({
+      update: {
+        _: "updateMessageReactions",
+        peer: { _: "peerUser", userId: 8288144562 },
+        msgId: 67050,
+        reactions: {
+          results: [
+            { reaction: { _: "reactionCustomEmoji", documentId: { high: 0, low: 1 } } },
+            { reaction: { _: "reactionEmoji", emoticon: "👀" } },
+          ],
+        },
+      },
+    });
+    const first = await iter.next();
+    const r = first.value as { emoji: string };
+    expect(r.emoji).toBe("👀"); // custom emoji silently skipped
+    await iter.return?.();
+  });
+
+  it("removes its onRawUpdate listener on iterator return", async () => {
+    // fails when: cleanup is dropped — `onRawUpdate` listeners
+    // accumulate across scenarios. Unlike `onNewMessage`, the raw
+    // update fires for EVERY Telegram event the driver receives
+    // (typing, presence, etc.), so a leaked listener is much
+    // louder than for the message observer.
+    const driver = new Driver({ apiId: 1, apiHash: "h", session: "S" });
+    await driver.connect();
+    expect(mockClient.onRawUpdate.size).toBe(0);
+    const iter = driver.observeReactions(8288144562)[Symbol.asyncIterator]();
+    expect(mockClient.onRawUpdate.size).toBe(1);
+    await iter.return?.();
+    expect(mockClient.onRawUpdate.size).toBe(0);
   });
 });
 


### PR DESCRIPTION
## Summary

Wires real `Driver.observeReactions` and `expectReaction` on top of the DM round-trip lifecycle shipped in #995. Reactions are the most observable side-effect the gateway emits per turn (more reliable than the pinned progress card, which is suppressed for fast turns under 45s), so they're the natural Phase 2b shape.

## How it works

- mtcute parses `updateBotMessageReaction` for **bot accounts**; the driver is a **user account**, so the parsed update never fires. The raw `updateMessageReactions` carries the *full new reaction set*, not a delta — `observeReactions` hooks `onRawUpdate`, diffs against a per-`(chatId, msgId)` cached snapshot, and emits add (`+`) / remove (`-`) ops per emoji.
- For 1:1 DMs the update's `peer._` is `peerUser` carrying the OTHER party's user_id (the bot). Filter by `peer.userId === chatId` matches the driver-side convention where `chatId === botUserId`.
- Custom emojis (`reactionCustomEmoji`) are silently skipped — they'd need document_id-to-alias resolution and aren't in scope for the gateway's `👀 🤔 🔥 👍`.
- `expectReaction(driver, chatId, messageId, sequence, opts)` walks the observation stream, advancing a cursor on each `+` op that matches the next expected emoji. Intermediate `-` ops (from the gateway's `setMessageReaction`-as-REPLACE pattern) and unrelated `+` ops are tolerated. Timeout error surfaces the full observed trail.

## New scenario

`scenarios/reactions-dm.test.ts` — driver DMs the bot, expects `👍` within 90s. Asserts on just the terminal emoji because fast-turn suppression often collapses 🤔/🔥.

## Deferred to Phase 2c

- `observePins` / `expectPinnedCard` / `waitForCardPhase` — pin observation requires raw `updatePinnedMessages` parsing; progress-card scenarios need a long-turn shape to bypass fast-turn suppression.
- `sendVoice` (voice-inbound scenario).
- Forum-topic supergroup support.

Throwing stubs unchanged in `driver.ts` / `assertions.ts` so scenarios calling those still fail fast.

## Tests

- `tests/uat-driver.test.ts` +5
- `tests/uat-assertions.test.ts` +6

42/42 mocked-mtcute unit tests pass. `tsc --noEmit` clean. Each test carries a `// fails when:` comment per `telegram-plugin/tests/HARNESS.md`.

## Verification

- `npx vitest run tests/uat-*.test.ts` → 42 passed
- `bun test` from `telegram-plugin/` → same fail profile as main (2 scenario stubs fail on missing env vars, expected)

DO NOT MERGE until a fresh reviewer process gives APPROVE per global CLAUDE.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)