### PR TITLE
refactor(uat): dedupe raceTimeoutR into raceTimeout (PR #1004 follow-up)

### DIFF
--- a/telegram-plugin/uat/assertions.ts
+++ b/telegram-plugin/uat/assertions.ts
@@ -190,7 +190,7 @@ export async function expectReaction(
   try {
     while (Date.now() < deadline && cursor < sequence.length) {
       const remaining = deadline - Date.now();
-      const next = await raceTimeoutR(iter.next(), remaining);
+      const next = await raceTimeout(iter.next(), remaining);
       if (next === "timeout") break;
       if (next.done === true) break;
       const r = next.value;
@@ -211,20 +211,6 @@ export async function expectReaction(
     );
   }
   return trail;
-}
-
-function raceTimeoutR<T>(p: Promise<T>, ms: number): Promise<T | "timeout"> {
-  if (ms <= 0) return Promise.resolve("timeout");
-  return new Promise<T | "timeout">((resolve) => {
-    const t = setTimeout(() => resolve("timeout"), ms);
-    p.then((v) => {
-      clearTimeout(t);
-      resolve(v);
-    }).catch(() => {
-      clearTimeout(t);
-      resolve("timeout");
-    });
-  });
 }
 
 export interface PinnedCardSnapshot {


### PR DESCRIPTION
Reviewer flagged on #1004: \`raceTimeoutR\` in \`assertions.ts\` was a byte-identical copy of \`raceTimeout\`, introduced when expectReaction landed alongside expectMessage and the two were authored as separate paths. Collapse to one helper.

No behaviour change. 13/13 \`tests/uat-assertions.test.ts\` still pass. \`tsc --noEmit\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)