### PR TITLE
feat(uat): observePins + expectPinnedCard + waitForCardPhase (#866 Phase 2c)

### DIFF
--- a/telegram-plugin/uat/assertions.ts
+++ b/telegram-plugin/uat/assertions.ts
@@ -213,41 +213,133 @@ export async function expectReaction(
   return trail;
 }
 
+export type CardPhase = "boot" | "working" | "done" | "error";
+
 export interface PinnedCardSnapshot {
+  chatId: number;
   messageId: number;
   text: string;
-  html?: string;
-  /** Production phase markers: `boot` | `working` | `done` | `error`. */
-  phase: string;
+  /** Detected phase, or `"unknown"` when the text doesn't match any marker. */
+  phase: CardPhase | "unknown";
 }
 
 /**
- * TODO(#866): wait for a pinned message to appear in
- * `chatId`/topic (the progress card). Resolves with a snapshot of
- * its current text/phase.
+ * Wait for a pinned message to appear in `chatId` (the progress
+ * card). Resolves with a snapshot of its current text + phase.
+ *
+ * Implementation:
+ * 1. Subscribe to `driver.observePins(chatId)`.
+ * 2. On the first pin event, fetch the message text via
+ *    `driver.getMessage` (the pin update carries only ids).
+ * 3. Return a snapshot with the parsed phase.
+ *
+ * Fast-turn note: the gateway's `progress_card.delay_ms` (default
+ * 45s) suppresses the card entirely for short turns. UAT runs
+ * against the standard-runtime test-harness agent will time out
+ * here unless the operator sets `delay_ms` to something small in
+ * `switchroom.yaml` under the agent's `channels.telegram` block.
  */
 export async function expectPinnedCard(
-  _driver: Driver,
-  _chatId: number,
-  _opts: PollOptions & { threadId?: number },
+  driver: Driver,
+  chatId: number,
+  opts: PollOptions & { threadId?: number },
 ): Promise<PinnedCardSnapshot> {
-  throw new Error("expectPinnedCard not implemented (Phase 2)");
+  void opts.threadId; // forum/topic routing rolls in with Phase 2d
+  const iter = driver.observePins(chatId)[Symbol.asyncIterator]();
+  const deadline = Date.now() + opts.timeout;
+  try {
+    while (Date.now() < deadline) {
+      const remaining = deadline - Date.now();
+      const next = await raceTimeout(iter.next(), remaining);
+      if (next === "timeout") break;
+      if (next.done === true) break;
+      const pin = next.value;
+      if (!pin.pinned) continue; // skip unpin events; we want pins
+      // Fetch the message body to compose the snapshot. If the
+      // message has been deleted in the gap between pin event and
+      // lookup, treat as a miss and keep waiting.
+      const msg = await driver.getMessage(chatId, pin.messageId).catch(() => null);
+      if (!msg) continue;
+      return {
+        chatId,
+        messageId: pin.messageId,
+        text: msg.text,
+        phase: detectPhase(msg.text),
+      };
+    }
+  } finally {
+    await iter.return?.();
+  }
+  throw new Error(
+    `expectPinnedCard: no pinned message in chat=${chatId} within ${opts.timeout}ms`,
+  );
 }
 
 /**
- * TODO(#866): wait for the pinned progress card to transition to
- * `phase`. The harness must read live edits, not just the snapshot
- * captured by `expectPinnedCard`.
+ * Wait for the pinned progress card to transition to `phase`.
+ *
+ * The gateway updates the card via `editMessage`, NOT by sending a
+ * new message. We observe edits via `driver.observeMessages` on
+ * the card's chat, filter to `msg.messageId === card.messageId`,
+ * and detect the target phase via the same regex set as
+ * `detectPhase`. If the snapshot we were handed is already at the
+ * target phase (e.g. a fast-turn scenario where the card was
+ * first-rendered straight at `done`), resolve immediately.
+ *
+ * The iterator yields a fresh `PinnedCardSnapshot` for each
+ * matching edit, so callers can chain phase transitions
+ * (`boot → working → done`) without re-subscribing.
  */
 export async function waitForCardPhase(
-  _driver: Driver,
-  _card: PinnedCardSnapshot,
-  _phase: "boot" | "working" | "done" | "error",
-  _opts: PollOptions,
+  driver: Driver,
+  card: PinnedCardSnapshot,
+  phase: CardPhase,
+  opts: PollOptions,
 ): Promise<PinnedCardSnapshot> {
-  throw new Error("waitForCardPhase not implemented (Phase 2)");
+  if (detectPhase(card.text) === phase) return card;
+  const iter = driver
+    .observeMessages(card.chatId)
+    [Symbol.asyncIterator]();
+  const deadline = Date.now() + opts.timeout;
+  try {
+    while (Date.now() < deadline) {
+      const remaining = deadline - Date.now();
+      const next = await raceTimeout(iter.next(), remaining);
+      if (next === "timeout") break;
+      if (next.done === true) break;
+      const msg = next.value;
+      if (msg.messageId !== card.messageId) continue;
+      const detected = detectPhase(msg.text);
+      if (detected === phase) {
+        return {
+          chatId: card.chatId,
+          messageId: card.messageId,
+          text: msg.text,
+          phase,
+        };
+      }
+    }
+  } finally {
+    await iter.return?.();
+  }
+  throw new Error(
+    `waitForCardPhase: card ${card.messageId} did not reach phase="${phase}" within ${opts.timeout}ms`,
+  );
 }
 
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
+/**
+ * Detect the progress card's phase from its rendered text.
+ *
+ * The actual card render (telegram-plugin/progress-card.ts) uses
+ * emoji markers: `✅` for done, `❌` for errors, `🤖` while the
+ * agent is working, `⏳` during the boot-card window. These markers
+ * are stable enough to key on for UAT — finer parsing (checklist
+ * items, sub-agent status) is out of scope.
+ */
+function detectPhase(text: string): CardPhase | "unknown" {
+  if (/✅|\bDone\b/i.test(text)) return "done";
+  if (/❌|\bFailed\b|\bError\b/i.test(text)) return "error";
+  if (/🤖|\bWorking\b/i.test(text)) return "working";
+  if (/⏳|\bStarting\b/i.test(text)) return "boot";
+  return "unknown";
 }

--- a/telegram-plugin/uat/assertions.ts
+++ b/telegram-plugin/uat/assertions.ts
@@ -296,7 +296,14 @@ export async function waitForCardPhase(
   phase: CardPhase,
   opts: PollOptions,
 ): Promise<PinnedCardSnapshot> {
-  if (detectPhase(card.text) === phase) return card;
+  if (detectPhase(card.text) === phase) {
+    // Refresh the phase field — the snapshot we were handed may
+    // have a stale `phase` from when the snapshot was captured
+    // (e.g. pin-time at "boot") even though the text has since
+    // been edited to a later phase. Returning the input as-is
+    // would surface that stale phase to the caller.
+    return { ...card, phase };
+  }
   const iter = driver
     .observeMessages(card.chatId)
     [Symbol.asyncIterator]();
@@ -342,4 +349,8 @@ function detectPhase(text: string): CardPhase | "unknown" {
   if (/🤖|\bWorking\b/i.test(text)) return "working";
   if (/⏳|\bStarting\b/i.test(text)) return "boot";
   return "unknown";
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }

--- a/telegram-plugin/uat/driver.ts
+++ b/telegram-plugin/uat/driver.ts
@@ -358,18 +358,103 @@ export class Driver {
     };
   }
 
-  // -------- Deferred to #866 / Phase 2c --------
-
   /**
-   * TODO(#866): subscribe to pin/unpin events on `chatId`/topic.
-   * Used for progress-card-lifecycle assertions.
+   * Subscribe to pin/unpin events on `chatId`. Used for
+   * progress-card-lifecycle assertions.
+   *
+   * mtcute doesn't expose a parsed event for `updatePinnedMessages`
+   * — it comes through raw. Same shape as `observeReactions`. The
+   * raw update carries `messages: number[]` (one or many msg ids
+   * pinned/unpinned in one batch) plus a `pinned?: boolean` flag.
+   *
+   * 1:1 DM peer filter: `peer._ === "peerUser" && peer.userId === chatId`.
+   * Forum/channel routing rolls in with Phase 2d.
    */
   observePins(
-    _chatId: number,
+    chatId: number,
     _opts?: { threadId?: number },
   ): AsyncIterable<ObservedPin> {
-    throw new Error("Driver.observePins not implemented (#866)");
+    const c = this.requireClient();
+    const queue: ObservedPin[] = [];
+    const waiters: Array<(p: IteratorResult<ObservedPin>) => void> = [];
+    let closed = false;
+
+    const dispatch = (p: ObservedPin): void => {
+      const w = waiters.shift();
+      if (w) w({ value: p, done: false });
+      else queue.push(p);
+    };
+
+    const onRaw = (info: { update: unknown }): void => {
+      const u = info.update as {
+        _: string;
+        pinned?: boolean;
+        peer?: { _: string; userId?: number };
+        messages?: number[];
+      };
+      if (u._ !== "updatePinnedMessages") return;
+      if (u.peer?._ !== "peerUser") return;
+      if (u.peer.userId !== chatId) return;
+      const ids = u.messages ?? [];
+      const pinned = u.pinned !== false; // default-true per TL (`pinned` omitted = pin)
+      const date = new Date();
+      for (const messageId of ids) {
+        dispatch({ chatId, messageId, pinned, date });
+      }
+    };
+
+    c.onRawUpdate.add(onRaw);
+
+    const close = (): void => {
+      if (closed) return;
+      closed = true;
+      c.onRawUpdate.remove(onRaw);
+      while (waiters.length > 0) {
+        waiters.shift()?.({ value: undefined as never, done: true });
+      }
+    };
+
+    return {
+      [Symbol.asyncIterator](): AsyncIterator<ObservedPin> {
+        return {
+          next(): Promise<IteratorResult<ObservedPin>> {
+            if (queue.length > 0) {
+              return Promise.resolve({ value: queue.shift()!, done: false });
+            }
+            if (closed) {
+              return Promise.resolve({ value: undefined as never, done: true });
+            }
+            return new Promise((resolve) => waiters.push(resolve));
+          },
+          return(): Promise<IteratorResult<ObservedPin>> {
+            close();
+            return Promise.resolve({ value: undefined as never, done: true });
+          },
+        };
+      },
+    };
   }
+
+  /**
+   * Fetch a single message by id. Used by `expectPinnedCard` to grab
+   * the card text once a pin event fires (the pin update carries
+   * just the id — content has to be looked up separately).
+   *
+   * Returns `null` when the message doesn't exist or has been
+   * deleted between the pin event and this lookup.
+   */
+  async getMessage(
+    chatId: number,
+    messageId: number,
+  ): Promise<ObservedMessage | null> {
+    const c = this.requireClient();
+    const results = await c.getMessages(chatId, [messageId]);
+    const msg = results[0];
+    if (!msg) return null;
+    return toObserved(msg, false);
+  }
+
+  // -------- Deferred to #866 / Phase 2d --------
 
   /**
    * TODO(#866): send a voice note. Needed for `voice-inbound.test.ts`.
@@ -379,7 +464,7 @@ export class Driver {
     _oggPath: string,
     _opts?: SendTextOptions,
   ): Promise<{ messageId: number }> {
-    throw new Error("Driver.sendVoice not implemented (#866)");
+    throw new Error("Driver.sendVoice not implemented (Phase 2d)");
   }
 
   private requireClient(): TelegramClient {

--- a/tests/uat-assertions.test.ts
+++ b/tests/uat-assertions.test.ts
@@ -10,11 +10,15 @@
 import { describe, expect, it } from "vitest";
 import {
   expectMessage,
+  expectPinnedCard,
   expectReaction,
+  waitForCardPhase,
+  type PinnedCardSnapshot,
 } from "../telegram-plugin/uat/assertions.js";
 import type {
   Driver,
   ObservedMessage,
+  ObservedPin,
   ObservedReaction,
 } from "../telegram-plugin/uat/driver.js";
 
@@ -277,5 +281,229 @@ describe("expectReaction: sequence matching", () => {
     ).rejects.toThrow();
     const elapsed = Date.now() - t0;
     expect(elapsed).toBeLessThan(500);
+  });
+});
+
+// ---------- Pinned-card scenarios ----------
+
+interface PinCardStubBehaviour {
+  pins?: ObservedPin[];
+  edits?: ObservedMessage[];
+  fetchById?: (id: number) => ObservedMessage | null;
+}
+
+function stubPinDriver(b: PinCardStubBehaviour): Driver {
+  return {
+    observePins(_chatId: number): AsyncIterable<ObservedPin> {
+      const items = b.pins ?? [];
+      let i = 0;
+      return {
+        [Symbol.asyncIterator](): AsyncIterator<ObservedPin> {
+          return {
+            next(): Promise<IteratorResult<ObservedPin>> {
+              if (i < items.length) {
+                return Promise.resolve({ value: items[i++]!, done: false });
+              }
+              return new Promise(() => {});
+            },
+            return(): Promise<IteratorResult<ObservedPin>> {
+              return Promise.resolve({ value: undefined as never, done: true });
+            },
+          };
+        },
+      };
+    },
+    observeMessages(_chatId: number): AsyncIterable<ObservedMessage> {
+      const items = b.edits ?? [];
+      let i = 0;
+      return {
+        [Symbol.asyncIterator](): AsyncIterator<ObservedMessage> {
+          return {
+            next(): Promise<IteratorResult<ObservedMessage>> {
+              if (i < items.length) {
+                return Promise.resolve({ value: items[i++]!, done: false });
+              }
+              return new Promise(() => {});
+            },
+            return(): Promise<IteratorResult<ObservedMessage>> {
+              return Promise.resolve({ value: undefined as never, done: true });
+            },
+          };
+        },
+      };
+    },
+    getMessage(_chatId: number, messageId: number): Promise<ObservedMessage | null> {
+      const fetched = b.fetchById?.(messageId) ?? null;
+      return Promise.resolve(fetched);
+    },
+  } as unknown as Driver;
+}
+
+function pin(messageId: number, pinned: boolean): ObservedPin {
+  return { chatId: 100, messageId, pinned, date: new Date() };
+}
+
+function fakeEdit(messageId: number, text: string): ObservedMessage {
+  return {
+    chatId: 100,
+    messageId,
+    text,
+    senderUserId: 555,
+    fromBot: true,
+    date: new Date(),
+    edited: true,
+  };
+}
+
+function fetchedMsg(messageId: number, text: string): ObservedMessage {
+  return {
+    chatId: 100,
+    messageId,
+    text,
+    senderUserId: 555,
+    fromBot: true,
+    date: new Date(),
+    edited: false,
+  };
+}
+
+describe("expectPinnedCard", () => {
+  it("returns a snapshot with parsed phase on first pinned event", async () => {
+    // fails when: the snapshot loses the chatId — waitForCardPhase
+    // needs it to subscribe to observeMessages, and dropping it
+    // would force callers to pass it again at every transition,
+    // re-introducing the kind of binding bug we just fixed with the
+    // sendDM closure capture.
+    const driver = stubPinDriver({
+      pins: [pin(42, true)],
+      fetchById: () => fetchedMsg(42, "⏳ Starting…"),
+    });
+    const snap = await expectPinnedCard(driver, 100, { timeout: 1000 });
+    expect(snap.chatId).toBe(100);
+    expect(snap.messageId).toBe(42);
+    expect(snap.phase).toBe("boot");
+    expect(snap.text).toContain("Starting");
+  });
+
+  it("skips unpin events and keeps waiting for the next pin", async () => {
+    // fails when: unpin events are treated as matches — the gateway
+    // does pin → unpin → re-pin during reflow; matching on the first
+    // unpin would surface a stale card text.
+    const driver = stubPinDriver({
+      pins: [pin(99, false), pin(42, true)],
+      fetchById: () => fetchedMsg(42, "🤖 Working…"),
+    });
+    const snap = await expectPinnedCard(driver, 100, { timeout: 1000 });
+    expect(snap.messageId).toBe(42);
+    expect(snap.phase).toBe("working");
+  });
+
+  it("keeps polling when getMessage returns null (race against delete)", async () => {
+    // fails when: a refactor treats null-result as a fatal error
+    // and aborts — a pin event then a quick edit-delete-edit cycle
+    // would crash the scenario instead of recovering on the next
+    // pin/edit.
+    let calls = 0;
+    const driver = stubPinDriver({
+      pins: [pin(42, true), pin(43, true)],
+      fetchById: (id) => {
+        calls++;
+        return id === 43 ? fetchedMsg(43, "✅ Done") : null;
+      },
+    });
+    const snap = await expectPinnedCard(driver, 100, { timeout: 1000 });
+    expect(snap.messageId).toBe(43);
+    expect(calls).toBe(2);
+  });
+
+  it("times out with a chat-id-bearing error when no pin arrives", async () => {
+    // fails when: the error message loses the chat_id, making CI
+    // flake reports ambiguous between "card never pinned" and "wrong
+    // chat being watched".
+    const driver = stubPinDriver({ pins: [] });
+    await expect(
+      expectPinnedCard(driver, 100, { timeout: 80 }),
+    ).rejects.toThrow(/chat=100.*80ms/);
+  });
+});
+
+describe("waitForCardPhase", () => {
+  function snap(phase: PinnedCardSnapshot["phase"], text: string): PinnedCardSnapshot {
+    return { chatId: 100, messageId: 42, text, phase };
+  }
+
+  it("resolves immediately when the input snapshot is already at the target phase", async () => {
+    // fails when: the fast-path early-return is removed — a scenario
+    // that observes the very first card-render at "done" (fast turn
+    // with delay_ms small) would re-subscribe to observeMessages and
+    // wait forever for an edit that never comes.
+    const driver = stubPinDriver({ edits: [] });
+    const result = await waitForCardPhase(driver, snap("done", "✅ Done"), "done", { timeout: 100 });
+    expect(result.phase).toBe("done");
+  });
+
+  it("matches the FIRST edit that detects the target phase", async () => {
+    // fails when: the matcher accumulates instead of short-circuits
+    // — long-running scenarios would skip the early "done" edit and
+    // race a later turn's "working" edit, returning the wrong card.
+    const driver = stubPinDriver({
+      edits: [
+        fakeEdit(42, "🤖 Working on item 1…"),
+        fakeEdit(42, "🤖 Working on item 2…"),
+        fakeEdit(42, "✅ Done — 2 items"),
+      ],
+    });
+    const result = await waitForCardPhase(driver, snap("boot", "⏳ Starting"), "done", { timeout: 1000 });
+    expect(result.phase).toBe("done");
+    expect(result.text).toContain("Done");
+  });
+
+  it("ignores edits to other messages in the chat (multi-card chats)", async () => {
+    // fails when: the messageId filter is dropped — a chat with two
+    // concurrent agents would interleave their card edits and the
+    // helper would resolve on the wrong agent's "done".
+    const driver = stubPinDriver({
+      edits: [
+        fakeEdit(99, "✅ Done — different card"),
+        fakeEdit(42, "✅ Done — our card"),
+      ],
+    });
+    const result = await waitForCardPhase(driver, snap("working", "🤖"), "done", { timeout: 1000 });
+    expect(result.messageId).toBe(42);
+    expect(result.text).toContain("our card");
+  });
+
+  it("times out with a message-id-bearing error when phase never lands", async () => {
+    // fails when: the error message loses the message_id, making
+    // a stuck-card report ambiguous about which card is misbehaving.
+    const driver = stubPinDriver({
+      edits: [fakeEdit(42, "🤖 Working forever…")],
+    });
+    await expect(
+      waitForCardPhase(driver, snap("working", "🤖"), "done", { timeout: 80 }),
+    ).rejects.toThrow(/card 42.*phase="done".*80ms/);
+  });
+});
+
+describe("detectPhase (via expectPinnedCard)", () => {
+  it("classifies ✅ → done, ❌ → error, 🤖 → working, ⏳ → boot", async () => {
+    // fails when: the phase regexes drift away from the production
+    // markers — would cause every UAT scenario that asserts a phase
+    // to either fail with "unknown" or grab the wrong phase.
+    const cases: Array<{ text: string; phase: string }> = [
+      { text: "✅ Done — 3 items", phase: "done" },
+      { text: "❌ Failed: timeout", phase: "error" },
+      { text: "🤖 Working on tool call…", phase: "working" },
+      { text: "⏳ Starting up…", phase: "boot" },
+      { text: "completely off-script text", phase: "unknown" },
+    ];
+    for (const { text, phase } of cases) {
+      const driver = stubPinDriver({
+        pins: [pin(1, true)],
+        fetchById: () => fetchedMsg(1, text),
+      });
+      const result = await expectPinnedCard(driver, 100, { timeout: 200 });
+      expect(result.phase).toBe(phase);
+    }
   });
 });

--- a/tests/uat-assertions.test.ts
+++ b/tests/uat-assertions.test.ts
@@ -442,6 +442,24 @@ describe("waitForCardPhase", () => {
     expect(result.phase).toBe("done");
   });
 
+  it("consults detectPhase(card.text), not card.phase — recovers from a stale snapshot.phase", async () => {
+    // fails when: someone refactors the fast-path to read
+    // `card.phase === phase` instead of re-running detectPhase over
+    // the text. A snapshot taken at pin-time has phase="boot" baked
+    // in, but the gateway can edit the card to "done" before the
+    // caller invokes waitForCardPhase; reading the stale `.phase`
+    // would force a useless second subscription and timeout. The
+    // current implementation correctly re-classifies from text.
+    const driver = stubPinDriver({ edits: [] });
+    const result = await waitForCardPhase(
+      driver,
+      snap("boot", "✅ Done — text already at done, phase field stale"),
+      "done",
+      { timeout: 100 },
+    );
+    expect(result.phase).toBe("done");
+  });
+
   it("matches the FIRST edit that detects the target phase", async () => {
     // fails when: the matcher accumulates instead of short-circuits
     // — long-running scenarios would skip the early "done" edit and

--- a/tests/uat-driver.test.ts
+++ b/tests/uat-driver.test.ts
@@ -43,6 +43,7 @@ const mockClient = {
   startUpdatesLoop: vi.fn(async () => undefined),
   destroy: vi.fn(async () => undefined),
   sendText: vi.fn(async () => ({ id: 999 })),
+  getMessages: vi.fn(async (_chatId: number, _ids: number[]) => [null]),
   onNewMessage: new MockEmitter<unknown>(),
   onEditMessage: new MockEmitter<unknown>(),
   onRawUpdate: new MockEmitter<unknown>(),
@@ -396,5 +397,127 @@ describe("Driver lifecycle", () => {
     // wondering what's wrong.
     const driver = new Driver({ apiId: 1, apiHash: "h", session: "S" });
     await expect(driver.sendText(-100, "x")).rejects.toThrow(/call connect/);
+  });
+});
+
+describe("Driver.observePins", () => {
+  function pinUpdate(opts: {
+    peerUserId: number;
+    msgIds: number[];
+    pinned?: boolean;
+  }): { update: unknown } {
+    return {
+      update: {
+        _: "updatePinnedMessages",
+        pinned: opts.pinned,
+        peer: { _: "peerUser", userId: opts.peerUserId },
+        messages: opts.msgIds,
+      },
+    };
+  }
+
+  it("yields one event per pinned messageId for a batched pin update", async () => {
+    // fails when: a refactor walks only msgIds[0] — the gateway can
+    // batch-pin a card + its boot header in one update; missing the
+    // second id would cause expectPinnedCard to wait forever on
+    // scenarios that pin > 1 message per turn.
+    const driver = new Driver({ apiId: 1, apiHash: "h", session: "S" });
+    await driver.connect();
+    const iter = driver.observePins(8288144562)[Symbol.asyncIterator]();
+    mockClient.onRawUpdate.emit(pinUpdate({
+      peerUserId: 8288144562,
+      msgIds: [101, 102],
+      pinned: true,
+    }));
+    const a = await iter.next();
+    const b = await iter.next();
+    expect((a.value as { messageId: number }).messageId).toBe(101);
+    expect((b.value as { messageId: number }).messageId).toBe(102);
+    expect((a.value as { pinned: boolean }).pinned).toBe(true);
+    await iter.return?.();
+  });
+
+  it("treats omitted `pinned` flag as pin (TL default-true), explicit false as unpin", async () => {
+    // fails when: the default flips — the TL says `pinned` defaults
+    // to true when omitted. If we default to false, every standalone
+    // pin update reads as an unpin and expectPinnedCard skips it.
+    const driver = new Driver({ apiId: 1, apiHash: "h", session: "S" });
+    await driver.connect();
+    const iter = driver.observePins(8288144562)[Symbol.asyncIterator]();
+    mockClient.onRawUpdate.emit(pinUpdate({ peerUserId: 8288144562, msgIds: [101] }));
+    mockClient.onRawUpdate.emit(pinUpdate({
+      peerUserId: 8288144562,
+      msgIds: [101],
+      pinned: false,
+    }));
+    const a = await iter.next();
+    const b = await iter.next();
+    expect((a.value as { pinned: boolean }).pinned).toBe(true);
+    expect((b.value as { pinned: boolean }).pinned).toBe(false);
+    await iter.return?.();
+  });
+
+  it("filters by chatId so cross-chat pins don't bleed into the iterator", async () => {
+    // fails when: peer.userId filtering moves to a downstream
+    // consumer — every chat the driver is in would flood the
+    // observer with unrelated pin events.
+    const driver = new Driver({ apiId: 1, apiHash: "h", session: "S" });
+    await driver.connect();
+    const iter = driver.observePins(8288144562)[Symbol.asyncIterator]();
+    mockClient.onRawUpdate.emit(pinUpdate({ peerUserId: 99, msgIds: [999] }));
+    mockClient.onRawUpdate.emit(pinUpdate({ peerUserId: 8288144562, msgIds: [101] }));
+    const first = await iter.next();
+    expect((first.value as { messageId: number }).messageId).toBe(101);
+    await iter.return?.();
+  });
+
+  it("removes the onRawUpdate listener on iterator return", async () => {
+    // fails when: cleanup is dropped — onRawUpdate is high-volume,
+    // a leaked listener accumulates handlers across scenarios.
+    const driver = new Driver({ apiId: 1, apiHash: "h", session: "S" });
+    await driver.connect();
+    expect(mockClient.onRawUpdate.size).toBe(0);
+    const iter = driver.observePins(8288144562)[Symbol.asyncIterator]();
+    expect(mockClient.onRawUpdate.size).toBe(1);
+    await iter.return?.();
+    expect(mockClient.onRawUpdate.size).toBe(0);
+  });
+});
+
+describe("Driver.getMessage", () => {
+  it("wraps getMessages with a single-id call and converts the result to ObservedMessage", async () => {
+    // fails when: a refactor passes the id as scalar rather than [id]
+    // — mtcute's `getMessages` accepts MaybeArray<number> and we want
+    // the array path so the result indexing is stable.
+    const driver = new Driver({ apiId: 1, apiHash: "h", session: "S" });
+    await driver.connect();
+    mockClient.getMessages.mockResolvedValueOnce([
+      {
+        id: 42,
+        text: "✅ Done",
+        date: new Date("2026-05-11T04:30:00Z"),
+        chat: { id: 8288144562 },
+        sender: { id: 8288144562, type: "user", isBot: true },
+        replyToMessage: undefined,
+      } as never,
+    ]);
+    const msg = await driver.getMessage(8288144562, 42);
+    expect(mockClient.getMessages).toHaveBeenCalledWith(8288144562, [42]);
+    expect(msg).not.toBeNull();
+    expect(msg?.messageId).toBe(42);
+    expect(msg?.text).toBe("✅ Done");
+    expect(msg?.fromBot).toBe(true);
+  });
+
+  it("returns null when the message has been deleted (mtcute returns null in that slot)", async () => {
+    // fails when: a refactor unwraps without checking null — scenarios
+    // that fetch right after a card-edit race could crash on a
+    // genuinely-deleted message; the contract is "return null, let
+    // caller poll".
+    const driver = new Driver({ apiId: 1, apiHash: "h", session: "S" });
+    await driver.connect();
+    mockClient.getMessages.mockResolvedValueOnce([null]);
+    const msg = await driver.getMessage(8288144562, 999);
+    expect(msg).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

Adds the progress-card lifecycle helpers on top of Phase 2b reactions.

**Code-only PR** — no real-Telegram scenario here because the gateway's `progress_card.delay_ms` defaults to 45s (fast-turn suppression), so any card-bearing scenario first needs the operator to tune that knob on the test-harness agent. Real-Telegram validation rolls into Phase 2d alongside that operator step + a long-turn scenario shape.

## Driver

- `observePins(chatId)` — parses raw `updatePinnedMessages` from `onRawUpdate`. Same shape as `observeReactions`. Pin events are batched (gateway can pin > 1 in one update), and `pinned` defaults to true per TL.
- `getMessage(chatId, messageId)` — wraps mtcute's `getMessages`; returns `ObservedMessage | null` so callers can handle the deleted-between-pin-and-lookup race.

## Assertions

- `PinnedCardSnapshot` gains `chatId` so `waitForCardPhase` can anchor its `observeMessages` subscription without re-passing the chat at every transition (same binding shape as `Scenario.sendDM`).
- `expectPinnedCard` — first pin event → fetch message → return snapshot with detected phase. Tolerates unpin→repin during reflow and deleted-during-race.
- `waitForCardPhase` — fast-path early-return when the input snapshot is already at target phase (common in fast-turn paths); else subscribes to `observeMessages` filtered to `card.messageId` and matches the first edit that classifies to the target phase.
- `detectPhase` — emoji-marker regex: `✅`/`Done` → done, `❌`/`Failed` → error, `🤖`/`Working` → working, `⏳`/`Starting` → boot. Falls back to `"unknown"`.

## Tests

- `tests/uat-driver.test.ts` +6
- `tests/uat-assertions.test.ts` +9

57/57 mocked-mtcute unit tests pass; `tsc --noEmit` clean. Each test carries a `// fails when:` comment per `telegram-plugin/tests/HARNESS.md`.

## Deferred to Phase 2d

- Real-Telegram progress-card scenario (needs `delay_ms` tuning).
- `sendVoice` + voice-inbound scenario.
- Forum-topic supergroup routing.

DO NOT MERGE until a fresh reviewer process gives APPROVE per global CLAUDE.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)