### PR TITLE
docs+test(uat): progress-card scenario skeleton + delay_ms operator note

### DIFF
--- a/telegram-plugin/uat/SETUP.md
+++ b/telegram-plugin/uat/SETUP.md
@@ -200,6 +200,39 @@ switchroom agent start test-harness
 Phase 2b adds per-scenario state-dir scoping so this becomes
 automatic.
 
+### Optional: force progress-card on every turn (Phase 2c+ card scenarios)
+
+The gateway's `progress_card.delay_ms` defaults to 45 s, so short DM
+turns (most of UAT) never trigger the pinned card and the card-
+lifecycle scenarios (`progress-card-dm.test.ts`) skip themselves.
+To unskip — and validate `expectPinnedCard` / `waitForCardPhase`
+against real Telegram — override the delay on `test-harness` only:
+
+Edit `~/.switchroom/switchroom.yaml`, find the `test-harness:`
+block, and add the highlighted lines:
+
+```yaml
+  test-harness:
+    extends: default
+    topic_name: Test Harness
+    channels:
+      telegram:
+        progress_card:
+          delay_ms: 1000     # short — make every turn flash a card
+```
+
+Then apply + restart:
+
+```bash
+switchroom apply
+switchroom agent restart test-harness
+```
+
+Production agents keep the 45 s default; this override is test-only.
+Once configured, unskip the card scenario by changing
+`describe.skip(...)` → `describe(...)` in
+`scenarios/progress-card-dm.test.ts`.
+
 ## 6. Running scenarios — env setup
 
 The harness reads four env vars at `spinUp()` time. Source them from

--- a/telegram-plugin/uat/scenarios/progress-card-dm.test.ts
+++ b/telegram-plugin/uat/scenarios/progress-card-dm.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Progress-card lifecycle scenario — driver DMs the test bot, the
+ * gateway pins a status card, edits it through phases, and finalizes
+ * at "done".
+ *
+ * Part of: https://github.com/switchroom/switchroom/issues/866
+ *
+ * **Gated by operator config.** The gateway's
+ * `progress_card.delay_ms` defaults to 45 s, so short DM turns
+ * (most of UAT) never trigger the pinned card. To unskip this
+ * scenario, set the override on `test-harness` in
+ * `~/.switchroom/switchroom.yaml`:
+ *
+ *   test-harness:
+ *     channels:
+ *       telegram:
+ *         progress_card:
+ *           delay_ms: 1000
+ *
+ * Then `switchroom apply && switchroom agent restart test-harness`,
+ * and remove the `.skip` below. See `uat/SETUP.md` §5 for the full
+ * runbook.
+ *
+ * Requires the same env as `smoke-dm-reply.test.ts` (see SETUP.md §6).
+ */
+
+import { describe, expect, it } from "vitest";
+import { spinUp } from "../harness.js";
+
+const INBOUND = `uat-card ${new Date().toISOString()}`;
+
+describe.skip("uat: progress card lifecycle on driver DM", () => {
+  it("driver sees a pinned card progress to 'done' within 60s", async () => {
+    const sc = await spinUp({ agent: "test-harness" });
+    try {
+      await sc.sendDM(INBOUND);
+
+      // Card should be pinned within 5 s of the inbound (delay_ms
+      // override has it firing immediately at start-of-turn).
+      const card = await sc.expectPinnedCard({ timeout: 10_000 });
+      expect(card.messageId).toBeGreaterThan(0);
+
+      // Walk to terminal phase. Fast turns may render straight to
+      // "done" — waitForCardPhase's fast-path returns immediately
+      // when the input snapshot's text already matches.
+      const finalCard = await sc.waitForCardPhase(card, "done", {
+        timeout: 60_000,
+      });
+      expect(finalCard.phase).toBe("done");
+      expect(finalCard.text).toMatch(/✅|Done/i);
+    } finally {
+      await sc.tearDown();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Phase 2c (#1006) shipped the progress-card helpers but no real-Telegram scenario, because the gateway's default 45 s \`progress_card.delay_ms\` suppresses the card on the fast turns that dominate DM scenarios.

This PR lands the scenario *designed but skipped* plus a SETUP.md runbook step for the operator config that unskips it.

## Files

- \`telegram-plugin/uat/scenarios/progress-card-dm.test.ts\` — \`describe.skip\` scenario. Driver DMs the bot → expects pinned card within 10 s → walks to terminal \`done\` within 60 s.
- \`telegram-plugin/uat/SETUP.md\` — new "Optional: force progress-card on every turn" sub-section under §5: yaml override (\`delay_ms: 1000\`), \`switchroom apply\` + \`agent restart test-harness\`, and where to unskip.

## Why skipped

The agent's \`progress_card.delay_ms\` lives in \`~/.switchroom/switchroom.yaml\` — an operator-owned file outside the project worktree. Shipping the scenario in skip form keeps the design intent on main and gives the operator a single-line action (delete \`.skip\`) once they flip the config.

## Verification

\`npm run lint\` clean. No code changes — just one new test file (skipped) + SETUP.md additions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)