### PR TITLE
fix: four UAT-setup papercuts (closes #999/#1000/#1001/#1002)

### DIFF
--- a/src/agents/add-orchestrator.test.ts
+++ b/src/agents/add-orchestrator.test.ts
@@ -856,6 +856,7 @@ describe("addAgent — forum topology (#543 acceptance)", () => {
       "777",
       "-1001234567890",
       42,
+      { dmOnly: false },
     );
     // The mock captured the right shape — verify it on disk too.
     const fs = require("node:fs") as typeof import("node:fs");
@@ -901,6 +902,7 @@ describe("addAgent — forum topology (#543 acceptance)", () => {
       "888",
       "-1009999999999",
       undefined,
+      { dmOnly: false },
     );
   });
 
@@ -942,6 +944,7 @@ describe("addAgent — forum topology (#543 acceptance)", () => {
       "555",
       "",
       undefined,
+      { dmOnly: true },
     );
   });
 });

--- a/src/agents/add-orchestrator.ts
+++ b/src/agents/add-orchestrator.ts
@@ -356,15 +356,19 @@ export async function addAgent(opts: AddAgentOpts): Promise<AddAgentResult> {
   }
 
   // ── Step 5b: write access.json ───────────────────────────────────────────
-  // DM mode: only the per-user `allowFrom` matters; the `groups` block is
-  // written with an empty key and ignored by the gateway.
+  // DM mode: only the per-user `allowFrom` matters; passing `dmOnly: true`
+  // tells writeAccessJson to omit the `groups` block entirely so the
+  // gateway's boot probe doesn't 404 on a synthetic empty-string chat id
+  // (#1002).
   // Forum mode: the operator supplied --forum-chat-id, which becomes the
   // group key, and (optionally) --topic-id which scopes the policy to a
   // single forum topic.
   const agentDir = created.agentDir;
   const forumChatId = opts.topology === "forum" ? (opts.forumChatId ?? "") : "";
   const forumTopicId = opts.topology === "forum" ? opts.forumTopicId : undefined;
-  writeAccessJson(agentDir, userId, forumChatId, forumTopicId);
+  writeAccessJson(agentDir, userId, forumChatId, forumTopicId, {
+    dmOnly: opts.topology === "dm",
+  });
   log(
     `[5/6] Wrote access.json (allowFrom=[${userId}]` +
       (opts.topology === "forum"

--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -3603,7 +3603,12 @@ function buildAccessJson(
   resolvedTopicId?: number,
   userId?: string,
 ): string {
-  const allowFrom = userId ? [userId] : [];
+  // Issue #1001: defensive String() coercion so a numeric userId from a
+  // legacy `~/.switchroom/user.json` (saveUserConfig is typed `string`
+  // but TS can't enforce at runtime) doesn't land an unquoted JSON
+  // number in allowFrom (which the gateway then rejects as "non-string
+  // entries — treating as empty").
+  const allowFrom = userId ? [String(userId)] : [];
   if (allowFrom.length === 0) {
     console.warn(
       "  WARNING: No user ID available for access.json allowFrom. " +
@@ -3614,14 +3619,23 @@ function buildAccessJson(
     dmPolicy: "allowlist",
     allowFrom,
   };
-  // DM-only bots opt out of inheriting the global forum_chat_id into the
-  // access list. Without this, the boot probe sweeps a chat the bot isn't
-  // a member of and emits a noisy "boot-probe-failed: 400 chat not found"
-  // every restart (plus a misleading user-facing notification). See the
-  // schema doc on `dm_only` for the design rationale.
-  if (!agentConfig.dm_only) {
+  // DM-only bots opt out of inheriting the global forum_chat_id into
+  // the access list. Without this, the boot probe sweeps a chat the
+  // bot isn't a member of and emits a noisy "boot-probe-failed: 400
+  // chat not found" every restart (plus a misleading user-facing
+  // notification). See the schema doc on `dm_only` for the design
+  // rationale.
+  //
+  // Issue #1002: also skip when the resolved forum chat id is the
+  // empty string or the v0.7 sentinel "0" — those are the values
+  // `switchroom agent add --topology dm` emits when no real forum
+  // chat is in scope, and the bug surfaced as a spurious 404 on every
+  // fresh DM-topology agent.
+  const forumChatId = telegramConfig.forum_chat_id;
+  const hasRealForumChat = forumChatId !== "" && forumChatId !== "0";
+  if (!agentConfig.dm_only && hasRealForumChat) {
     access.groups = {
-      [telegramConfig.forum_chat_id]: {
+      [forumChatId]: {
         requireMention: false,
         allowFrom,
       },

--- a/src/cli/vault-prompt-stderr.test.ts
+++ b/src/cli/vault-prompt-stderr.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Test for #999 — vault passphrase prompt must write to stderr so the
+ * common `$(switchroom vault get --no-broker <key>)` capture pattern
+ * doesn't silently consume it into the operator's variable.
+ *
+ * Exercise: spawn the CLI with no stdin (no TTY, no env passphrase),
+ * capture stdout and stderr separately, assert the prompt landed on
+ * stderr and stdout is clean.
+ */
+
+import { describe, it, expect } from "vitest";
+import { spawnSync } from "node:child_process";
+import * as path from "node:path";
+import * as os from "node:os";
+import * as fs from "node:fs";
+
+const REPO_ROOT = path.resolve(__dirname, "../..");
+const CLI_ENTRY = path.join(REPO_ROOT, "bin/switchroom.ts");
+
+describe("vault passphrase prompt → stderr (#999)", () => {
+  it("vault get --no-broker prompt does NOT appear on stdout", () => {
+    // Use a tmp HOME so we don't poke the operator's real vault, and
+    // a tmp vault path so the read attempt fails predictably AFTER the
+    // prompt step.
+    const tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), "vault-prompt-test-"));
+    const r = spawnSync(
+      "bun",
+      [CLI_ENTRY, "vault", "get", "--no-broker", "some_key"],
+      {
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          HOME: tmpHome,
+          // Explicitly unset so getPassphrase() reaches promptLine.
+          SWITCHROOM_VAULT_PASSPHRASE: undefined,
+          // Defeat the P0a sandbox guard (this test runs in host context).
+          SWITCHROOM_RUNTIME: undefined,
+        },
+        // No stdin → readline sees EOF on stdin; the prompt is still
+        // emitted by createInterface before EOF closes the read.
+        input: "",
+        timeout: 15000,
+      },
+    );
+
+    // The prompt text — whatever its exact wording — must NOT land on
+    // stdout (which a `$(...)` capture would slurp into the operator's
+    // variable). Pre-fix `process.stdout.write(prompt)` violated this.
+    expect(r.stdout).not.toContain("Vault passphrase");
+    expect(r.stdout).not.toContain("passphrase");
+
+    // stderr is where the prompt + error messages now go. The exact
+    // message depends on which guard fires first (no vault file →
+    // VaultError, or empty passphrase → "Passphrase cannot be empty").
+    // Either way, the user-visible bit is on stderr.
+    expect(r.stderr.length).toBeGreaterThan(0);
+  });
+});

--- a/src/cli/vault.ts
+++ b/src/cli/vault.ts
@@ -89,14 +89,19 @@ function getVaultPath(configPath?: string): string {
 
 function promptLine(prompt: string, hidden = false): Promise<string> {
   return new Promise((resolve, reject) => {
+    // Issue #999: interactive prompts go to stderr, not stdout. Stdout
+    // is reserved for the actual secret payload (which the caller is
+    // capturing via `$(switchroom vault get ...)`); piping the prompt
+    // there silently consumed it, producing "Passphrase cannot be empty"
+    // with no visible prompt and a missing value in the captured var.
     const rl = createInterface({
       input: process.stdin,
-      output: process.stdout,
+      output: process.stderr,
     });
 
     if (hidden && process.stdin.isTTY) {
       // Disable echo for hidden input
-      process.stdout.write(prompt);
+      process.stderr.write(prompt);
       const stdin = process.stdin;
       stdin.setRawMode(true);
       stdin.resume();
@@ -108,14 +113,14 @@ function promptLine(prompt: string, hidden = false): Promise<string> {
           stdin.setRawMode(false);
           stdin.removeListener("data", onData);
           rl.close();
-          process.stdout.write("\n");
+          process.stderr.write("\n");
           resolve(input);
         } else if (char === "\u0003") {
           // Ctrl+C
           stdin.setRawMode(false);
           stdin.removeListener("data", onData);
           rl.close();
-          process.stdout.write("\n");
+          process.stderr.write("\n");
           reject(new Error("Aborted"));
         } else if (char === "\u007F" || char === "\b") {
           // Backspace

--- a/src/setup/access-json-build.test.ts
+++ b/src/setup/access-json-build.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Tests for `buildAccessJson` in setup/onboarding.ts.
+ *
+ * Covers issues #1001 (numeric userId must serialise as a string) and
+ * #1002 (DM topology / empty-or-sentinel forum chat id must omit the
+ * groups block).
+ */
+
+import { describe, it, expect } from "vitest";
+import { buildAccessJson } from "./onboarding.js";
+
+function parse(s: string): {
+  allowFrom: unknown;
+  groups?: Record<string, unknown>;
+  dmPolicy: string;
+} {
+  return JSON.parse(s);
+}
+
+describe("buildAccessJson — userId coercion (#1001)", () => {
+  it("string userId lands as a quoted string in allowFrom", () => {
+    const j = parse(buildAccessJson("8248703757", "-100123", undefined));
+    expect(j.allowFrom).toEqual(["8248703757"]);
+    expect(typeof (j.allowFrom as unknown[])[0]).toBe("string");
+  });
+
+  it("numeric userId (typed-out from a legacy user.json) is coerced to string", () => {
+    // Defensive coercion: the type says `string` but TS can't enforce at
+    // runtime, and the gateway rejects unquoted JSON numbers as
+    // 'non-string entries'.
+    const j = parse(buildAccessJson(8248703757 as unknown as string, "-100123", undefined));
+    expect(j.allowFrom).toEqual(["8248703757"]);
+    expect(typeof (j.allowFrom as unknown[])[0]).toBe("string");
+  });
+});
+
+describe("buildAccessJson — groups gating (#1002)", () => {
+  it("DM-topology (dmOnly:true) omits the groups block entirely", () => {
+    const j = parse(buildAccessJson("12345", "-100abc", undefined, { dmOnly: true }));
+    expect(j.groups).toBeUndefined();
+  });
+
+  it("empty forumChatId omits the groups block (no synthetic empty-key entry)", () => {
+    // Pre-fix: this produced groups: { "": { ... } } which the gateway
+    // boot-probe 404s on. Post-fix: skip the block when forum chat id
+    // is not a real value.
+    const j = parse(buildAccessJson("12345", "", undefined));
+    expect(j.groups).toBeUndefined();
+  });
+
+  it('sentinel "0" forumChatId also omits the groups block', () => {
+    // v0.7 setup writes "0" as a placeholder for "no forum configured".
+    // It's not a real chat id; don't pin it into the access list.
+    const j = parse(buildAccessJson("12345", "0", undefined));
+    expect(j.groups).toBeUndefined();
+  });
+
+  it("real forumChatId + non-dmOnly emits the groups entry as before", () => {
+    const j = parse(buildAccessJson("12345", "-1001234567890", undefined));
+    expect(j.groups).toEqual({
+      "-1001234567890": { requireMention: false, allowFrom: [] },
+    });
+  });
+});

--- a/src/setup/onboarding.ts
+++ b/src/setup/onboarding.ts
@@ -88,11 +88,22 @@ export function buildAccessJson(
   topicId?: number,
   opts: { dmOnly?: boolean } = {},
 ): string {
+  // Issue #1001: defensive String() coercion so a numeric userId from a
+  // legacy `~/.switchroom/user.json` or a buggy caller can't land an
+  // unquoted JSON number in allowFrom (which the gateway then rejects
+  // as "non-string entries — treating as empty").
   const access: Record<string, unknown> = {
     dmPolicy: "allowlist",
-    allowFrom: [userId],
+    allowFrom: [String(userId)],
   };
-  if (!opts.dmOnly) {
+  // Issue #1002: when no real forum chat ID is in scope (DM topology,
+  // or the v0.7 sentinel "0"), don't write a groups entry at all —
+  // an empty-string or sentinel-id key triggers the gateway's boot
+  // probe which then 404s and logs an unhandled rejection. `dmOnly`
+  // is the explicit signal; the empty/sentinel guard catches the
+  // implicit case where the operator skipped passing a chat id.
+  const hasRealForumChat = forumChatId !== "" && forumChatId !== "0";
+  if (!opts.dmOnly && hasRealForumChat) {
     access.groups = {
       [forumChatId]: {
         requireMention: false,

--- a/src/vault/symlink-preserve.test.ts
+++ b/src/vault/symlink-preserve.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Test for #1000 — `vault set --no-broker` must preserve a symlinked
+ * vault path rather than replacing the symlink with a regular file.
+ *
+ * Reproduces the v0.7.12+ layout where `~/.switchroom/vault.enc` is a
+ * symlink to `~/.switchroom/vault/vault.enc`, then exercises a write
+ * through the symlinked path. Pre-fix the rename targeted the symlink
+ * itself (replacing it); post-fix it follows the link and targets the
+ * underlying file.
+ */
+
+import { describe, it, expect } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { createVault, setStringSecret, openVault } from "./vault.js";
+
+const PASSPHRASE = "symlink-preserve-test-pass";
+
+describe("saveVault — symlink preservation (#1000)", () => {
+  it("writing through a symlinked vault path preserves the symlink", () => {
+    // Set up the canonical v0.7.12+ layout: symlink at the legacy path,
+    // real file at the new path.
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "vault-symlink-"));
+    const vaultDir = path.join(tmpDir, "vault");
+    fs.mkdirSync(vaultDir, { recursive: true });
+
+    const realPath = path.join(vaultDir, "vault.enc");
+    const linkPath = path.join(tmpDir, "vault.enc");
+
+    createVault(PASSPHRASE, realPath);
+    fs.symlinkSync("vault/vault.enc", linkPath);
+
+    // Sanity: the layout we expect.
+    expect(fs.lstatSync(linkPath).isSymbolicLink()).toBe(true);
+    expect(fs.lstatSync(realPath).isFile()).toBe(true);
+
+    // Write a secret through the SYMLINK path.
+    setStringSecret(PASSPHRASE, linkPath, "shared_token", "fresh-value");
+
+    // The symlink must STILL be a symlink (pre-fix it became a regular file).
+    expect(fs.lstatSync(linkPath).isSymbolicLink()).toBe(true);
+    // And the real file at the target must have been updated.
+    expect(fs.lstatSync(realPath).isFile()).toBe(true);
+
+    // Read back through either path — both must see the new secret.
+    const viaLink = openVault(PASSPHRASE, linkPath);
+    const viaReal = openVault(PASSPHRASE, realPath);
+    expect(viaLink.shared_token).toBeDefined();
+    expect(viaReal.shared_token).toBeDefined();
+    if (viaLink.shared_token?.kind === "string") {
+      expect(viaLink.shared_token.value).toBe("fresh-value");
+    }
+    if (viaReal.shared_token?.kind === "string") {
+      expect(viaReal.shared_token.value).toBe("fresh-value");
+    }
+
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("non-symlinked vault path is unaffected (regression guard)", () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "vault-plain-"));
+    const vaultPath = path.join(tmpDir, "vault.enc");
+    createVault(PASSPHRASE, vaultPath);
+
+    setStringSecret(PASSPHRASE, vaultPath, "shared_token", "v1");
+    expect(fs.lstatSync(vaultPath).isFile()).toBe(true);
+
+    setStringSecret(PASSPHRASE, vaultPath, "shared_token", "v2");
+    const opened = openVault(PASSPHRASE, vaultPath);
+    if (opened.shared_token?.kind === "string") {
+      expect(opened.shared_token.value).toBe("v2");
+    }
+
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+});

--- a/src/vault/vault.ts
+++ b/src/vault/vault.ts
@@ -9,6 +9,8 @@ import {
   fsyncSync,
   openSync,
   closeSync,
+  lstatSync,
+  realpathSync,
 } from "node:fs";
 import { dirname, basename, resolve } from "node:path";
 import { acquireLock, DEFAULT_LOCK_RETRY_MS, VaultBusyError } from "./flock.js";
@@ -60,11 +62,30 @@ const SCRYPT_MAXMEM = 128 * 1024 * 1024; // 128 MB
 function atomicWriteFileSync(path: string, data: string, mode: number): void {
   // Write to a sibling temp file then rename. Rename is atomic on the same
   // filesystem, which guarantees readers never see a half-written vault.
-  const dir = dirname(resolve(path));
-  const tmp = resolve(dir, `.${basename(path)}.${process.pid}.${Date.now()}.tmp`);
+  //
+  // Issue #1000: when `path` is a symlink (the v0.7.12+ layout has
+  // `~/.switchroom/vault.enc -> vault/vault.enc`), a naive `renameSync(tmp,
+  // path)` REPLACES the symlink with a regular file, leaving the directory
+  // entry orphaned and stale. The broker keeps reading the (untouched)
+  // target file, so writes silently don't reach it; the next
+  // `switchroom apply` then trips the divergence guard. Resolve the
+  // symlink first so the rename targets the underlying file, preserving
+  // the layout invariant.
+  let effectivePath = path;
+  try {
+    if (existsSync(path) && lstatSync(path).isSymbolicLink()) {
+      effectivePath = realpathSync(path);
+    }
+  } catch {
+    // Best-effort introspection: if we can't lstat/realpath (perm
+    // error, race, target missing), fall back to the path as given.
+    // The downstream write will surface the real failure.
+  }
+  const dir = dirname(resolve(effectivePath));
+  const tmp = resolve(dir, `.${basename(effectivePath)}.${process.pid}.${Date.now()}.tmp`);
   try {
     writeFileSync(tmp, data, { encoding: "utf8", mode });
-    renameSync(tmp, path);
+    renameSync(tmp, effectivePath);
   } catch (err) {
     try { if (existsSync(tmp)) unlinkSync(tmp); } catch {}
     throw err;


### PR DESCRIPTION
Replaces #1007 — rebased onto current upstream/main (which now has #1005's assertions.ts dedupe) and the stray stash-pop artifact removed.

Four small, independent fixes bundled. Each closes a distinct issue; bundled because no single fix exceeds ~15 LOC and all live in the operator-onboarding path.

### #999 — vault passphrase prompt to stderr (was stdout)
\`switchroom vault get --no-broker <key>\` is canonically called via \`\$(...)\` substitution. Pre-fix the passphrase prompt wrote to stdout → captured by subshell → operator saw nothing → \"Passphrase cannot be empty\".

### #1000 — vault saveVault preserves symlinked layout
v0.7.12+ has \`~/.switchroom/vault.enc -> vault/vault.enc\`. Pre-fix \`renameSync\` replaced the symlink with a regular file; broker kept reading the (untouched) target. \`lstat\` → \`realpathSync\` resolves before rename; atomic-rename semantics preserved (tmp stays in the resolved file's directory).

### #1001 — allowFrom entries always strings
Both \`buildAccessJson\` writers (\`onboarding.ts\` and \`scaffold.ts\`) now \`String(userId)\` defensively. Gateway rejects numeric \`allowFrom\` entries as 'non-string'.

### #1002 — DM-topology agents omit the groups block
Pre-fix DM agents got a groups entry the bot wasn't in → 404 boot-probe every restart. Fixed in three places: orchestrator passes \`dmOnly: opts.topology === 'dm'\`; both \`buildAccessJson\` writers skip groups on \`dmOnly\` OR empty/sentinel chat id.

## Test plan
- [x] 9 new unit tests across 3 files — all pass
- [x] \`tsc --noEmit\` clean
- [x] \`npm run build\` clean
- [x] Fresh-process reviewer pass — APPROVE (after I reverted the stash-pop artifact)

## Refs
Closes #999, #1000, #1001, #1002.

🤖 Generated with [Claude Code](https://claude.com/claude-code)