### PR TITLE
feat(uat): unskip progress-card scenario; skip reactions-dm (mutex)

### DIFF
--- a/telegram-plugin/uat/scenarios/progress-card-dm.test.ts
+++ b/telegram-plugin/uat/scenarios/progress-card-dm.test.ts
@@ -29,7 +29,7 @@ import { spinUp } from "../harness.js";
 
 const INBOUND = `uat-card ${new Date().toISOString()}`;
 
-describe.skip("uat: progress card lifecycle on driver DM", () => {
+describe("uat: progress card lifecycle on driver DM", () => {
   it("driver sees a pinned card progress to 'done' within 60s", async () => {
     const sc = await spinUp({ agent: "test-harness" });
     try {

--- a/telegram-plugin/uat/scenarios/reactions-dm.test.ts
+++ b/telegram-plugin/uat/scenarios/reactions-dm.test.ts
@@ -22,7 +22,17 @@ import { spinUp } from "../harness.js";
 
 const INBOUND = `uat-reactions ${new Date().toISOString()}`;
 
-describe("uat: bot reacts to driver DM with terminal status emoji", () => {
+// SKIPPED: this scenario depends on the gateway's "fast-turn"
+// path that emits status-emoji reactions on the inbound. When
+// the progress card is active (test-harness now sets
+// `progress_card.delay_ms: 1000` so the card-lifecycle scenario
+// can fire — see SETUP.md §5 and `progress-card-dm.test.ts`), the
+// gateway renders the card INSTEAD of reactions, not in addition.
+//
+// Two-agent split (a `test-harness-fast` with default delay_ms +
+// the existing `test-harness` for card scenarios) would let both
+// be green at the same time. Tracked for Phase 2e.
+describe.skip("uat: bot reacts to driver DM with terminal status emoji", () => {
   it("driver sees 👍 (done) appear on its inbound within 90s", async () => {
     const sc = await spinUp({ agent: "test-harness" });
     try {


### PR DESCRIPTION
## Summary

The gateway emits **either** status-emoji reactions on the inbound **or** a pinned progress card on each turn, not both. The mutex is controlled by \`channels.telegram.progress_card.delay_ms\` on the agent:

| delay_ms | Behaviour | Validated scenario |
|---|---|---|
| 45000 (default) | Fast turns finish before the timer; card suppressed; reactions emitted | \`reactions-dm.test.ts\` (per #1004) |
| 1000 | Card fires on every turn; reactions skipped | \`progress-card-dm.test.ts\` (this PR) |

The operator set \`delay_ms: 1000\` on \`test-harness\` per SETUP.md §5 (the override doc landed in #1008). With that in place, the card scenario is now end-to-end validated against real Telegram and unskipped.

## End-to-end results (against live test-harness, post-config change)

\`\`\`
 ↓ reactions-dm.test.ts (1 test | 1 skipped)
 ✓ progress-card-dm.test.ts (1 test) 7988ms
 ✓ smoke-dm-reply.test.ts (1 test) 3082ms
 Test Files  2 passed | 1 skipped (3)
 Tests       2 passed | 1 skipped (3)
\`\`\`

## Why reactions-dm goes the other way

There's no per-turn fallback path emitting reactions when the card is active — confirmed by inspecting \`/var/log/switchroom/gateway-supervisor.log\` during the card run: zero \`setMessageReaction\` calls. So a single agent can't validate both signals in the same suite.

Phase 2e backlog: add a \`test-harness-fast\` agent with default 45 s \`delay_ms\` so reactions-dm can run alongside card scenarios. Small operator change, no code rewrite. Until then, reactions-dm is recorded as "validated in #1004 under default config; skipped here so the card scenario can run".

## Verification

- \`bun run test:uat\` from \`telegram-plugin/\` against live test-harness: 2 passed, 1 skipped. Total 12.48s.
- \`npm run lint\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)