### PR TITLE
feat(uat): Driver.sendVoice + skipped voice-inbound scenario (#866 Phase 2f)

### DIFF
--- a/telegram-plugin/uat/driver.ts
+++ b/telegram-plugin/uat/driver.ts
@@ -18,7 +18,12 @@
  * production pattern).
  */
 
-import { MemoryStorage, TelegramClient, getMarkedPeerId } from "@mtcute/node";
+import {
+  MemoryStorage,
+  TelegramClient,
+  getMarkedPeerId,
+  InputMedia,
+} from "@mtcute/node";
 import type { Message } from "@mtcute/node";
 
 export interface DriverOptions {
@@ -484,17 +489,35 @@ export class Driver {
     return toObserved(msg, false);
   }
 
-  // -------- Deferred to #866 / Phase 2d --------
-
   /**
-   * TODO(#866): send a voice note. Needed for `voice-inbound.test.ts`.
+   * Send a voice note. Wraps mtcute's `sendMedia` + `InputMedia.voice`
+   * factory. The `oggPath` must be a path to an OGG/Opus audio file
+   * (Telegram only accepts that codec for voice notes); other audio
+   * formats render as a generic audio attachment and `voice_in`
+   * transcription on the bot side will skip them.
+   *
+   * Generating a fixture locally:
+   *   ffmpeg -f lavfi -i anullsrc=r=48000:cl=mono -t 1 \
+   *     -c:a libopus -b:a 32k tests/fixtures/voice/silence-1s.opus
+   *
+   * The scenario at `scenarios/voice-inbound-dm.test.ts` references
+   * a fixture path but is `describe.skip`'d until the fixture is
+   * committed (kept out of git to keep the repo small until needed).
    */
   async sendVoice(
-    _chatId: number,
-    _oggPath: string,
-    _opts?: SendTextOptions,
+    chatId: number,
+    oggPath: string,
+    opts?: SendTextOptions,
   ): Promise<{ messageId: number }> {
-    throw new Error("Driver.sendVoice not implemented (Phase 2d)");
+    const c = this.requireClient();
+    const replyTo = opts?.replyTo ?? opts?.messageThreadId;
+    const media = InputMedia.voice(oggPath);
+    const sent = await c.sendMedia(
+      chatId,
+      media,
+      replyTo ? { replyTo } : undefined,
+    );
+    return { messageId: sent.id };
   }
 
   private requireClient(): TelegramClient {

--- a/telegram-plugin/uat/scenarios/voice-inbound-dm.test.ts
+++ b/telegram-plugin/uat/scenarios/voice-inbound-dm.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Voice-inbound scenario — driver sends a voice note (OGG/Opus)
+ * to the test bot, gateway's `voice_in` skill transcribes it,
+ * bot replies with text.
+ *
+ * Part of: https://github.com/switchroom/switchroom/issues/866
+ *
+ * **Gated by fixture + bot config.** To unskip:
+ *
+ * 1. Generate a 1-second silent OGG/Opus fixture:
+ *
+ *    ```bash
+ *    mkdir -p telegram-plugin/uat/fixtures/voice
+ *    ffmpeg -f lavfi -i anullsrc=r=48000:cl=mono -t 1 \
+ *      -c:a libopus -b:a 32k \
+ *      telegram-plugin/uat/fixtures/voice/silence-1s.opus
+ *    ```
+ *
+ *    (Fixture is intentionally NOT committed to git — keep the repo
+ *    light. Generate locally before unskipping.)
+ *
+ * 2. Verify the test-harness agent has `voice_in` configured. The
+ *    default profile may not enable it; check `switchroom config
+ *    show test-harness` for `channels.telegram.voice_in.enabled`.
+ *
+ * 3. Remove the `describe.skip` below.
+ *
+ * Why skipped by default: voice transcription costs money per call
+ * (OpenAI/Whisper) and slow turns are expected — keeping this off
+ * the default UAT path until someone explicitly tests voice.
+ */
+
+import path from "node:path";
+import { existsSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import { spinUp } from "../harness.js";
+
+const FIXTURE = path.resolve(
+  __dirname,
+  "..",
+  "fixtures",
+  "voice",
+  "silence-1s.opus",
+);
+
+describe.skip("uat: voice-inbound DM round-trip", () => {
+  it("driver sends a voice note, bot transcribes + replies within 60s", async () => {
+    if (!existsSync(FIXTURE)) {
+      throw new Error(
+        `voice fixture not found at ${FIXTURE} — see scenario header to generate one`,
+      );
+    }
+    const sc = await spinUp({ agent: "test-harness" });
+    try {
+      await sc.driver.sendVoice(sc.botUserId, FIXTURE);
+      const reply = await sc.expectMessage(/.+/, {
+        from: "bot",
+        timeout: 60_000,
+      });
+      expect(reply.text.length).toBeGreaterThan(0);
+    } finally {
+      await sc.tearDown();
+    }
+  });
+});

--- a/tests/uat-driver.test.ts
+++ b/tests/uat-driver.test.ts
@@ -43,6 +43,7 @@ const mockClient = {
   startUpdatesLoop: vi.fn(async () => undefined),
   destroy: vi.fn(async () => undefined),
   sendText: vi.fn(async () => ({ id: 999 })),
+  sendMedia: vi.fn(async () => ({ id: 1234 })),
   getMessages: vi.fn(async (_chatId: number, _ids: number[]) => [null]),
   onNewMessage: new MockEmitter<unknown>(),
   onEditMessage: new MockEmitter<unknown>(),
@@ -79,6 +80,13 @@ vi.mock("@mtcute/node", () => ({
   MemoryStorage: class {},
   TelegramClient: TelegramClientCtor,
   getMarkedPeerId: getMarkedPeerIdImpl,
+  // Stand-in for mtcute's `InputMedia.voice(filePath)` factory.
+  // Production returns an `InputMediaVoice` object; tests just need
+  // to assert that the factory was called with the file path and
+  // that the result was handed to client.sendMedia.
+  InputMedia: {
+    voice: (file: string) => ({ __type: "InputMediaVoice", file }),
+  },
 }));
 
 let Driver: typeof DriverType;
@@ -683,5 +691,59 @@ describe("Driver.getMessage", () => {
     mockClient.getMessages.mockResolvedValueOnce([null]);
     const msg = await driver.getMessage(8288144562, 999);
     expect(msg).toBeNull();
+  });
+});
+
+describe("Driver.sendVoice", () => {
+  it("wraps sendMedia with an InputMedia.voice carrying the file path", async () => {
+    // fails when: a refactor switches to sending the OGG as a
+    // generic document — Telegram only renders OGG/Opus as a voice
+    // note when sent via inputMediaUploadedDocument with a voice
+    // attribute. mtcute's InputMedia.voice factory builds the
+    // right shape; bypassing it sends the file as an attachment
+    // instead, which the bot's voice_in skill ignores.
+    const driver = new Driver({ apiId: 1, apiHash: "h", session: "S" });
+    await driver.connect();
+    const sent = await driver.sendVoice(8288144562, "/tmp/silence.opus");
+    expect(mockClient.sendMedia).toHaveBeenCalledTimes(1);
+    const [chatId, media, params] = mockClient.sendMedia.mock.calls[0] as [
+      number,
+      { __type: string; file: string },
+      unknown,
+    ];
+    expect(chatId).toBe(8288144562);
+    expect(media.__type).toBe("InputMediaVoice");
+    expect(media.file).toBe("/tmp/silence.opus");
+    expect(params).toBeUndefined();
+    expect(sent.messageId).toBe(1234);
+  });
+
+  it("forwards messageThreadId via replyTo for forum-topic targeting", async () => {
+    // fails when: voice sends bypass the same threadId→replyTo
+    // routing that sendText uses — a forum-topic voice-inbound
+    // scenario would deliver the OGG into the supergroup's
+    // general topic instead of the test-scoped topic, polluting
+    // unrelated chats.
+    const driver = new Driver({ apiId: 1, apiHash: "h", session: "S" });
+    await driver.connect();
+    await driver.sendVoice(-1003852747971, "/tmp/silence.opus", {
+      messageThreadId: 200,
+    });
+    const [, , params] = mockClient.sendMedia.mock.calls[0] as [
+      number,
+      unknown,
+      { replyTo: number },
+    ];
+    expect(params.replyTo).toBe(200);
+  });
+
+  it("rejects voice sends before connect() with a clear error", async () => {
+    // fails when: the requireClient guard is dropped — a scenario
+    // that races a connect-failure would throw a TypeError on
+    // null client instead of the "call connect() first" pointer.
+    const driver = new Driver({ apiId: 1, apiHash: "h", session: "S" });
+    await expect(
+      driver.sendVoice(-100, "/tmp/x.opus"),
+    ).rejects.toThrow(/call connect/);
   });
 });


### PR DESCRIPTION
## Summary

Closes the "sendVoice" item from #866's deferred-to-2c list.

Code-only — the real-Telegram scenario stays \`describe.skip\`'d until an operator generates the OGG/Opus fixture locally (one-line ffmpeg in the scenario header).

## Driver

\`sendVoice(chatId, oggPath, opts)\` wraps mtcute's \`sendMedia\` + \`InputMedia.voice(oggPath)\`. Same \`messageThreadId → replyTo\` routing as \`sendText\` so forum-topic voice scenarios target correctly. JSDoc explains why OGG/Opus specifically — Telegram only renders voice notes for that codec; other audio falls back to generic attachment and \`voice_in\` skips it.

## Scenario

\`scenarios/voice-inbound-dm.test.ts\` is \`describe.skip\`'d. Header documents the unskip path: generate the fixture via \`ffmpeg -f lavfi -i anullsrc -t 1 -c:a libopus -b:a 32k …/silence-1s.opus\`, verify \`voice_in\` is enabled on test-harness, remove \`.skip\`. Fixture intentionally NOT committed.

## Tests

\`tests/uat-driver.test.ts\` +3: sendMedia wrapping shape, forum-topic replyTo routing, requireClient guard. The vi.mock surface gains an \`InputMedia.voice\` stand-in that emits a \`{ __type: "InputMediaVoice", file }\` marker — tests assert against this rather than recreating mtcute's real shape.

65/65 unit tests pass. \`npm run lint\` clean. The 4-scenario suite under \`test:uat\` reads as: 2 skipped (reactions-dm, voice-inbound-dm) + 2 expected-fail-on-missing-env (smoke, card); same fail profile as main.

DO NOT MERGE until a fresh reviewer process gives APPROVE per global CLAUDE.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)