### PR TITLE
feat(uat): getKeyboard + pressButton — drive inline-keyboard vault UX (#866 Phase 2g; supports #1012)

### DIFF
--- a/telegram-plugin/uat/driver.ts
+++ b/telegram-plugin/uat/driver.ts
@@ -67,6 +67,30 @@ export interface ObservedMessage {
   edited: boolean;
 }
 
+export interface ObservedButton {
+  /** Visible label on the button. */
+  text: string;
+  /**
+   * Inline-callback button payload (Bot API `callback_data`). UTF-8
+   * decoded from the raw `Uint8Array` mtcute exposes. Undefined for
+   * URL buttons / web-app buttons / other non-callback button kinds.
+   */
+  callbackData?: string;
+  /** URL for `url` buttons; undefined for callback buttons. */
+  url?: string;
+}
+
+/**
+ * 2-D matrix of inline buttons, matching Bot API's
+ * `inline_keyboard: [[{text, callback_data}, ...], ...]`.
+ *
+ * Only `type === "inline"` keyboards are returned by `getKeyboard` —
+ * reply-keyboard / force-reply / hide markups aren't used by the
+ * gateway for vault UX flows and would require a separate driver
+ * surface (typing the reply instead of tapping).
+ */
+export type ObservedKeyboard = ObservedButton[][];
+
 export interface ObservedReaction {
   chatId: number;
   messageId: number;
@@ -487,6 +511,81 @@ export class Driver {
     const msg = results[0];
     if (!msg) return null;
     return toObserved(msg, false);
+  }
+
+  /**
+   * Fetch the inline keyboard attached to a bot message, if any.
+   * Returns `null` for messages without an inline_keyboard (or with
+   * a non-inline markup like force-reply).
+   *
+   * Used by vault UX scenarios that need to:
+   * 1. Drive the gateway-published vault save card, audit/allow flow,
+   *    or grant approval card (epic #1012).
+   * 2. Find the `[Allow]` / `[Save]` / `[Approve]` button to press by
+   *    its label, then pass `button.callbackData` to `pressButton`.
+   *
+   * Callback `data` is decoded from the raw `Uint8Array` to UTF-8
+   * string; the gateway always encodes callback_data as ASCII/UTF-8,
+   * so this matches Bot API consumers' view. URL buttons surface as
+   * `{ text, url }` with `callbackData: undefined`.
+   */
+  async getKeyboard(
+    chatId: number,
+    messageId: number,
+  ): Promise<ObservedKeyboard | null> {
+    const c = this.requireClient();
+    const results = await c.getMessages(chatId, [messageId]);
+    const msg = results[0] as { markup?: { type: string; buttons: unknown[][] } } | null;
+    if (!msg) return null;
+    const markup = msg.markup;
+    if (!markup || markup.type !== "inline") return null;
+    const decoder = new TextDecoder();
+    return markup.buttons.map((row) =>
+      row.map((b) => {
+        const btn = b as {
+          _: string;
+          text: string;
+          data?: Uint8Array;
+          url?: string;
+        };
+        const out: ObservedButton = { text: btn.text };
+        if (btn._ === "keyboardButtonCallback" && btn.data) {
+          out.callbackData = decoder.decode(btn.data);
+        }
+        if (btn._ === "keyboardButtonUrl" && btn.url) {
+          out.url = btn.url;
+        }
+        return out;
+      }),
+    );
+  }
+
+  /**
+   * Press an inline-keyboard callback button — the MTProto path that
+   * mirrors what tapping the button in the Telegram client does.
+   *
+   * The bot receives a `callback_query` update. Bot-side handlers
+   * (e.g. the gateway's vault-audit one-tap allow handler from
+   * #969 P2b, or the agent-grant-request flow proposed in #1012)
+   * fire as if a real operator tapped.
+   *
+   * Note: the driver user must be in the bot's admin allowlist for
+   * any admin-gated button (most `/vault` callbacks are admin-gated).
+   * The harness's `test-harness` agent already includes the driver
+   * via `--allow-from` at agent-add time, so admin actions work
+   * end-to-end out of the box.
+   */
+  async pressButton(
+    chatId: number,
+    messageId: number,
+    callbackData: string,
+  ): Promise<void> {
+    const c = this.requireClient();
+    await c.getCallbackAnswer({
+      chatId,
+      message: messageId,
+      data: callbackData,
+    });
   }
 
   /**

--- a/telegram-plugin/uat/scenarios/vault-audit-allow-dm.test.ts
+++ b/telegram-plugin/uat/scenarios/vault-audit-allow-dm.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Vault UX scenario — operator DMs `/vault audit`, taps `[Allow]`
+ * on a recent denial, agent re-attempts the vault read and succeeds.
+ *
+ * Part of: https://github.com/switchroom/switchroom/issues/866
+ * Exercises: #969 P2b one-tap allow flow.
+ *
+ * **Gated by operator setup.** To unskip:
+ *
+ * 1. **Driver must be admin on `test-harness`.** `agent add
+ *    --allow-from $DRIVER_UID` already includes the driver in
+ *    `access.json:allowFrom`. Confirm the `/vault` commands also
+ *    work — they may require an explicit `admin_chat_id` setting
+ *    in the agent's switchroom.yaml. Look for
+ *    "VAULT-AUDIT-FORBIDDEN" or similar in the gateway log when
+ *    the driver DMs `/vault audit`.
+ *
+ * 2. **Sacrificial vault keys for the test.** The scenario writes
+ *    and reads `uat-test-denial` under a deliberately empty
+ *    `--allow` scope so the agent's first read fails with
+ *    VAULT-BROKER-DENIED — that denial is what shows up in
+ *    `/vault audit`. Pre-create the key on the host:
+ *
+ *    ```bash
+ *    TMPF=$(mktemp) && printf '%s' 'sentinel-uat-value' > "$TMPF" && \
+ *      switchroom vault set uat-test-denial --file "$TMPF" \
+ *        --format string ; shred -u "$TMPF"
+ *    ```
+ *
+ *    The scenario then triggers a denial, taps Allow (scopes the
+ *    key to `test-harness`), and asserts the agent can now read it.
+ *    Cleanup at the end is operator-side: re-narrow the scope or
+ *    remove the key.
+ *
+ * 3. Remove the `describe.skip` below.
+ *
+ * Why skipped by default: the scenario mutates host vault state
+ * (broker ACL) — opt-in only.
+ */
+
+import { describe, expect, it } from "vitest";
+import { spinUp } from "../harness.js";
+
+describe.skip("uat: /vault audit one-tap allow", () => {
+  it("driver taps [Allow] on a recent denial; agent's next read succeeds", async () => {
+    const sc = await spinUp({ agent: "test-harness" });
+    try {
+      // 1. Trigger a denial by asking the agent to read a key the
+      //    agent isn't yet scoped for.
+      await sc.sendDM(
+        "Please run `switchroom vault get uat-test-denial` and tell me the value.",
+      );
+
+      // The bot's denial trace finishes the turn — wait for the
+      // turn-end message, then proceed to /vault audit.
+      await sc.expectMessage(/VAULT-BROKER-DENIED|denied|cannot/i, {
+        from: "bot",
+        timeout: 60_000,
+      });
+
+      // 2. DM /vault audit. The bot replies with a recent-denials
+      //    summary + inline [Allow] / [Deny] buttons per denied key.
+      await sc.sendDM("/vault audit");
+      const auditCard = await sc.expectMessage(/Recent denials|uat-test-denial/, {
+        from: "bot",
+        timeout: 30_000,
+      });
+
+      // 3. Find and press the [Allow] button.
+      const kb = await sc.driver.getKeyboard(sc.botUserId, auditCard.messageId);
+      expect(kb).not.toBeNull();
+      const allowButton = kb!
+        .flat()
+        .find(
+          (b) =>
+            b.callbackData !== undefined &&
+            /allow/i.test(b.text) &&
+            b.callbackData.includes("uat-test-denial"),
+        );
+      expect(allowButton).toBeDefined();
+      await sc.driver.pressButton(
+        sc.botUserId,
+        auditCard.messageId,
+        allowButton!.callbackData!,
+      );
+
+      // 4. Confirmation comes back via card edit; assert it lands.
+      //    (The gateway typically edits the audit card in-place to
+      //    show "allowed" status.)
+      await sc.expectMessage(/allowed|✓|scope updated/i, {
+        from: "bot",
+        timeout: 15_000,
+      });
+
+      // 5. Re-attempt the read. Should now succeed.
+      await sc.sendDM(
+        "Try `switchroom vault get uat-test-denial` again now.",
+      );
+      const success = await sc.expectMessage(/sentinel-uat-value/, {
+        from: "bot",
+        timeout: 60_000,
+      });
+      expect(success.text).toContain("sentinel-uat-value");
+    } finally {
+      await sc.tearDown();
+    }
+  });
+});

--- a/tests/uat-driver.test.ts
+++ b/tests/uat-driver.test.ts
@@ -45,6 +45,7 @@ const mockClient = {
   sendText: vi.fn(async () => ({ id: 999 })),
   sendMedia: vi.fn(async () => ({ id: 1234 })),
   getMessages: vi.fn(async (_chatId: number, _ids: number[]) => [null]),
+  getCallbackAnswer: vi.fn(async () => ({ message: "ok" })),
   onNewMessage: new MockEmitter<unknown>(),
   onEditMessage: new MockEmitter<unknown>(),
   onRawUpdate: new MockEmitter<unknown>(),
@@ -744,6 +745,142 @@ describe("Driver.sendVoice", () => {
     const driver = new Driver({ apiId: 1, apiHash: "h", session: "S" });
     await expect(
       driver.sendVoice(-100, "/tmp/x.opus"),
+    ).rejects.toThrow(/call connect/);
+  });
+});
+
+describe("Driver.getKeyboard", () => {
+  function fakeMsgWithKeyboard(buttons: Array<Array<{ _: string; text: string; data?: string; url?: string }>>): unknown {
+    return {
+      id: 42,
+      text: "Approve grant?",
+      date: new Date(),
+      chat: { id: 8288144562 },
+      sender: { id: 8288144562, type: "user", isBot: true },
+      markup: {
+        type: "inline",
+        buttons: buttons.map((row) =>
+          row.map((b) => {
+            const out: { _: string; text: string; data?: Uint8Array; url?: string } = {
+              _: b._,
+              text: b.text,
+            };
+            if (b.data) out.data = new TextEncoder().encode(b.data);
+            if (b.url) out.url = b.url;
+            return out;
+          }),
+        ),
+      },
+    };
+  }
+
+  it("parses inline keyboard buttons with UTF-8-decoded callback_data", async () => {
+    // fails when: a refactor swaps the decoding direction (Uint8Array
+    // → hex/base64 instead of UTF-8) — every vault-UX scenario that
+    // matches buttons by callback_data (e.g. "allow:agent=gymbro")
+    // would silently match nothing.
+    const driver = new Driver({ apiId: 1, apiHash: "h", session: "S" });
+    await driver.connect();
+    mockClient.getMessages.mockResolvedValueOnce([
+      fakeMsgWithKeyboard([
+        [
+          { _: "keyboardButtonCallback", text: "Allow", data: "allow:gymbro:fatsecret" },
+          { _: "keyboardButtonCallback", text: "Deny", data: "deny:gymbro:fatsecret" },
+        ],
+      ]) as never,
+    ]);
+    const kb = await driver.getKeyboard(8288144562, 42);
+    expect(kb).not.toBeNull();
+    expect(kb).toHaveLength(1);
+    expect(kb![0]).toHaveLength(2);
+    expect(kb![0]![0]).toEqual({
+      text: "Allow",
+      callbackData: "allow:gymbro:fatsecret",
+    });
+    expect(kb![0]![1]).toEqual({
+      text: "Deny",
+      callbackData: "deny:gymbro:fatsecret",
+    });
+  });
+
+  it("represents URL buttons with `url` set and `callbackData` omitted", async () => {
+    // fails when: URL buttons surface with bogus callbackData (e.g.
+    // the URL itself decoded as bytes). A scenario that tries to
+    // pressButton(callbackData=URL) would fail server-side with
+    // BUTTON_DATA_INVALID instead of falling back to opening the URL.
+    const driver = new Driver({ apiId: 1, apiHash: "h", session: "S" });
+    await driver.connect();
+    mockClient.getMessages.mockResolvedValueOnce([
+      fakeMsgWithKeyboard([
+        [{ _: "keyboardButtonUrl", text: "Open dashboard", url: "https://example.com" }],
+      ]) as never,
+    ]);
+    const kb = await driver.getKeyboard(8288144562, 42);
+    expect(kb![0]![0]).toEqual({
+      text: "Open dashboard",
+      url: "https://example.com",
+    });
+    expect(kb![0]![0]!.callbackData).toBeUndefined();
+  });
+
+  it("returns null for messages with no markup or non-inline markup", async () => {
+    // fails when: a refactor surfaces force-reply / reply-keyboard
+    // shapes as `ObservedKeyboard` — scenarios that expect inline
+    // buttons would press a "phantom" button that never existed on
+    // the wire.
+    const driver = new Driver({ apiId: 1, apiHash: "h", session: "S" });
+    await driver.connect();
+    mockClient.getMessages.mockResolvedValueOnce([
+      { id: 42, text: "no buttons", date: new Date(), chat: { id: 1 }, sender: { id: 1, type: "user", isBot: true }, markup: null } as never,
+    ]);
+    expect(await driver.getKeyboard(8288144562, 42)).toBeNull();
+
+    mockClient.getMessages.mockResolvedValueOnce([
+      {
+        id: 42, text: "force reply", date: new Date(),
+        chat: { id: 1 }, sender: { id: 1, type: "user", isBot: true },
+        markup: { type: "force_reply" },
+      } as never,
+    ]);
+    expect(await driver.getKeyboard(8288144562, 42)).toBeNull();
+  });
+
+  it("returns null when the message has been deleted", async () => {
+    // fails when: deleted-race recovery is dropped — scenarios that
+    // fetch a keyboard right after a card-edit-delete race would
+    // crash; the contract is "return null, let caller poll".
+    const driver = new Driver({ apiId: 1, apiHash: "h", session: "S" });
+    await driver.connect();
+    mockClient.getMessages.mockResolvedValueOnce([null]);
+    expect(await driver.getKeyboard(8288144562, 42)).toBeNull();
+  });
+});
+
+describe("Driver.pressButton", () => {
+  it("calls getCallbackAnswer with the chat+message+data triple", async () => {
+    // fails when: a refactor passes the callback_data as `Uint8Array`
+    // (instead of letting mtcute encode the string) — mtcute's
+    // getCallbackAnswer accepts both, but production code that
+    // assumes ASCII payloads would break for any future binary-
+    // callback_data button. The harness keeps it as a string for
+    // symmetry with how `getKeyboard` returns it.
+    const driver = new Driver({ apiId: 1, apiHash: "h", session: "S" });
+    await driver.connect();
+    await driver.pressButton(8288144562, 42, "allow:gymbro:fatsecret");
+    expect(mockClient.getCallbackAnswer).toHaveBeenCalledWith({
+      chatId: 8288144562,
+      message: 42,
+      data: "allow:gymbro:fatsecret",
+    });
+  });
+
+  it("rejects when called before connect()", async () => {
+    // fails when: the requireClient guard is dropped — same
+    // class of bug as sendText/sendVoice/getMessage before
+    // connect.
+    const driver = new Driver({ apiId: 1, apiHash: "h", session: "S" });
+    await expect(
+      driver.pressButton(8288144562, 42, "x"),
     ).rejects.toThrow(/call connect/);
   });
 });


### PR DESCRIPTION
## Summary

The harness drives text-only flows end-to-end today. Vault UX in Telegram is fundamentally inline-keyboard-driven (bot posts a card with [Allow]/[Deny] buttons → operator taps → bot acts on the callback). This PR adds the two missing driver primitives plus a stub scenario for the canonical case (\`/vault audit\` one-tap allow from #969 P2b).

Also unlocks #1012 (agent-initiated vault grant flow): once that ships, the scenario is ~5 lines on top of these primitives.

## Driver additions

- \`getKeyboard(chatId, messageId): Promise<ObservedKeyboard | null>\` — fetches the message, extracts \`msg.markup\` if it's \`type: "inline"\`, decodes each \`keyboardButtonCallback.data\` from raw \`Uint8Array\` to a UTF-8 string. Returns 2-D \`ObservedButton[][]\` or \`null\` for messages with no inline keyboard. URL buttons surface as \`{ text, url }\`.
- \`pressButton(chatId, messageId, callbackData): Promise<void>\` — wraps mtcute's \`getCallbackAnswer({chatId, message, data})\`. Same MTProto path as a real tap; bot sees a normal \`callback_query\` update.

## Scenario stub

\`scenarios/vault-audit-allow-dm.test.ts\` is \`describe.skip\`'d. Walks the full #969 P2b flow: trigger denial → \`/vault audit\` → press [Allow] → confirm → re-attempt read → succeed. Header documents the operator setup needed to unskip (sacrificial \`uat-test-denial\` key + admin gating verification).

## Tests

\`tests/uat-driver.test.ts\` +6: keyboard parsing (callback + URL buttons, UTF-8-decoded \`callbackData\`), null on missing/non-inline markup, null on deleted message, pressButton's \`getCallbackAnswer\` call shape, pre-connect guard.

34/34 driver tests pass; 71/71 across all UAT unit-test files. \`npm run lint\` clean. The 5-scenario \`test:uat\` suite reads as: 2 expected-fail on missing env (smoke, card), 3 skipped (reactions, voice, vault-audit); same fail profile as main.

DO NOT MERGE until a fresh reviewer process gives APPROVE per global CLAUDE.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)