### PR TITLE
fix(compose): surface yaml admin: true as SWITCHROOM_AGENT_ADMIN env var

### DIFF
--- a/src/agents/compose.ts
+++ b/src/agents/compose.ts
@@ -245,6 +245,13 @@ interface AgentServiceData {
   resources: ResourceDefaults;
   /** Capability extras the operator requested AND we stripped. */
   strippedCaps: string[];
+  /**
+   * Yaml-level `admin: true` flag — when set, surfaces as
+   * `SWITCHROOM_AGENT_ADMIN=true` on the agent container so the
+   * gateway permits admin slash commands (`/vault`, `/agents`,
+   * `/logs`, `/grant`, `/update` etc). Default false.
+   */
+  admin: boolean;
 }
 
 /** Per-agent metadata exposed to doctor checks (and tests). */
@@ -257,7 +264,14 @@ export function describeAgents(config: SwitchroomConfig): AgentServiceData[] {
     const uid = allocateAgentUid(name);
     const resources = resolveResourceDefaults(name, profile);
     const strippedCaps = readStrippedCaps(agent);
-    out.push({ name, uid, profile, resources, strippedCaps });
+    out.push({
+      name,
+      uid,
+      profile,
+      resources,
+      strippedCaps,
+      admin: agent.admin === true,
+    });
     void resolved;
   }
   return out;
@@ -710,6 +724,14 @@ function emitAgentService(
   // Same env+mount pattern broker/kernel/scheduler already use.
   if (switchroomConfigPath) {
     env.SWITCHROOM_CONFIG = "/state/config/switchroom.yaml";
+  }
+  // SWITCHROOM_AGENT_ADMIN: gateway gates `/agents`, `/logs`, `/grant`,
+  // `/vault`, `/update` etc. on this env var being `"true"`. The agent
+  // schema's `admin: true` flag must surface here — otherwise the
+  // yaml field is silently a no-op. The gateway reads it at
+  // `telegram-plugin/gateway/gateway.ts:514`.
+  if (a.admin === true) {
+    env.SWITCHROOM_AGENT_ADMIN = "true";
   }
   for (const k of Object.keys(env).sort()) {
     lines.push(`      ${k}: ${JSON.stringify(env[k])}`);

--- a/tests/docker/compose-generator.test.ts
+++ b/tests/docker/compose-generator.test.ts
@@ -30,7 +30,7 @@ import {
 } from "../../src/agents/compose.js";
 import type { SwitchroomConfig } from "../../src/config/schema.js";
 
-function makeConfig(agents: Record<string, { extends?: string; settings_raw?: Record<string, unknown> }>): SwitchroomConfig {
+function makeConfig(agents: Record<string, { extends?: string; settings_raw?: Record<string, unknown>; admin?: boolean }>): SwitchroomConfig {
   return {
     switchroom: { version: 1, agents_dir: "~/.switchroom/agents", skills_dir: "~/.switchroom/skills" },
     telegram: { bot_token: "x" },
@@ -42,6 +42,7 @@ function makeConfig(agents: Record<string, { extends?: string; settings_raw?: Re
         {
           extends: cfg.extends,
           settings_raw: cfg.settings_raw,
+          admin: cfg.admin,
           schedule: [],
           tools: { allow: [], deny: [] },
           hooks: undefined,
@@ -623,6 +624,29 @@ describe("agent service env (Phase 2c F2 — IPC wiring)", () => {
         new RegExp(`SWITCHROOM_AGENT_NAME:\\s*"${a}"`),
       );
     }
+  });
+
+  it("surfaces yaml admin: true as SWITCHROOM_AGENT_ADMIN=true on the agent container", () => {
+    // fails when: the compose generator stops propagating the
+    // schema-level `admin: true` flag to the gateway's runtime env.
+    // The gateway gates `/vault`, `/agents`, `/logs`, `/grant`,
+    // `/update` etc. on `SWITCHROOM_AGENT_ADMIN === "true"`
+    // (telegram-plugin/gateway/gateway.ts:514). Without this
+    // propagation the yaml field is silently a no-op — the
+    // operator sets `admin: true`, restarts, and the bot still
+    // rejects `/vault` with "this agent isn't admin-flagged".
+    // Discovered while setting up the UAT harness's
+    // `test-harness` agent for vault-UX scenarios.
+    const out = generateCompose({
+      config: makeConfig({
+        alice: { admin: true },
+        bob: {},
+      }),
+    });
+    const aliceEnv = envBlockFor(out, "alice");
+    const bobEnv = envBlockFor(out, "bob");
+    expect(aliceEnv).toMatch(/SWITCHROOM_AGENT_ADMIN:\s*"true"/);
+    expect(bobEnv).not.toMatch(/SWITCHROOM_AGENT_ADMIN/);
   });
 
   // Layer 1 (persistent agent HOME). The agent container runs as a


### PR DESCRIPTION
## Summary

\`admin: true\` in switchroom.yaml was silently a no-op on Docker hosts. The schema declares it; the gateway gates admin slash commands (\`/vault\`, \`/agents\`, \`/logs\`, \`/grant\`, \`/update\`) on \`SWITCHROOM_AGENT_ADMIN === "true"\`; the Docker compose generator never set the env var. The gateway comment points at \`generateGatewayUnit\` — the retired systemd path.

## Repro

1. Add \`admin: true\` to an agent in switchroom.yaml.
2. \`switchroom apply && switchroom agent restart <name>\`.
3. DM \`/vault audit\` to the bot.
4. Bot rejects: "⚠️ /vault is an admin command — this agent (NAME) isn't admin-flagged. ... set admin: true for this agent in switchroom.yaml."

…despite admin: true being set.

## Fix

\`describeAgents\` reads \`agent.admin === true\` and \`AgentServiceData.admin\` propagates to the per-agent env block (\`compose.ts:712\`). Env var is OMITTED entirely when admin is false/undefined.

## Test

\`tests/docker/compose-generator.test.ts\` +1: pins both directions (admin=true → env present; admin=undefined → env absent). \`// fails when:\` comment ties to the live UAT-blocked symptom.

69/69 compose-generator tests pass; \`npm run lint\` clean.

## Operator-side dependency

Fix only takes effect on freshly-recreated containers. Existing containers need \`docker compose up -d --force-recreate <service>\` to pick up the env. \`switchroom agent restart\` doesn't \`--force-recreate\` by default (a separate small bug I'm filing).

## Discovered while

Setting up the \`test-harness\` UAT agent for vault-UX scenarios (#866 Phase 2g / #1015 follow-up). The agent had \`admin: true\` in yaml but \`/vault audit\` was rejected — diagnosed by inspecting the container env and tracing back to the missing propagation in \`compose.ts\`.

DO NOT MERGE until a fresh reviewer process gives APPROVE per global CLAUDE.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)