### PR TITLE
feat(vault): admin agents get operator-socket access for grant management (#1019 Option 1)

### DIFF
--- a/src/agents/compose.ts
+++ b/src/agents/compose.ts
@@ -732,6 +732,23 @@ function emitAgentService(
   // `telegram-plugin/gateway/gateway.ts:514`.
   if (a.admin === true) {
     env.SWITCHROOM_AGENT_ADMIN = "true";
+    // SWITCHROOM_VAULT_BROKER_OPERATOR_SOCK + the mount below: lets
+    // grant-management ops (list_grants, mint_grant, revoke_grant)
+    // route through the broker's operator socket instead of the
+    // per-agent socket. Without this, `/vault audit <name>` from
+    // the bot's container can only see the agent's own scope and
+    // the broker rejects with "Grant management ops are operator-
+    // only; agent-bound listeners cannot mint, list, or revoke
+    // grants" (see src/vault/broker/server.ts:1493).
+    //
+    // Trust model: an admin-flagged agent already has operator-
+    // level Telegram surface (`/agents`, `/logs`, `/restart` etc.).
+    // Granting vault-grant management at the broker socket is a
+    // consistent expansion. Issue #1019 tracks options 2/3 for a
+    // narrower long-term design (read-only RPC on agent path, or a
+    // dedicated foreman-bot agent).
+    env.SWITCHROOM_VAULT_BROKER_OPERATOR_SOCK =
+      "/run/switchroom/broker/operator/sock";
   }
   for (const k of Object.keys(env).sort()) {
     lines.push(`      ${k}: ${JSON.stringify(env[k])}`);
@@ -742,6 +759,20 @@ function emitAgentService(
   // invariant on every regenerated compose.
   lines.push(`      - broker-${a.name}-sock:/run/switchroom/broker`);
   lines.push(`      - kernel-${a.name}-sock:/run/switchroom/kernel`);
+  if (a.admin === true) {
+    // Operator socket bind mount — pairs with the
+    // SWITCHROOM_VAULT_BROKER_OPERATOR_SOCK env above. The broker
+    // container binds the operator socket at
+    // `/run/switchroom/broker/operator/sock` inside ITS view (see
+    // the broker service block earlier in this file) and exposes it
+    // on the host via `${HOME}/.switchroom/broker-operator/sock`.
+    // Mounting the same host directory into admin agents lets
+    // grant-management ops route through the operator socket while
+    // vault get/set continue through the per-agent socket above.
+    lines.push(
+      `      - ${homePrefix}/.switchroom/broker-operator:/run/switchroom/broker/operator:ro`,
+    );
+  }
   // Dual mounts — the same host directory is bound BOTH at the canonical
   // container path (`/state/agent`, `/state/.claude`, `/var/log/switchroom`)
   // AND at the original host path. Why both:

--- a/src/vault/broker/client-prefer-operator-socket.test.ts
+++ b/src/vault/broker/client-prefer-operator-socket.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Tests for `preferOperatorSocket` — the helper that routes grant-
+ * management RPCs (list_grants / mint_grant / revoke_grant) through
+ * the operator socket when `SWITCHROOM_VAULT_BROKER_OPERATOR_SOCK` is
+ * set in env (i.e. on admin-flagged agents per #1019 Option 1's
+ * compose.ts mount).
+ *
+ * Without this rerouting, `/vault audit` on an admin agent fails
+ * with broker server's "Grant management ops are operator-only;
+ * agent-bound listeners cannot mint, list, or revoke grants"
+ * (`src/vault/broker/server.ts:1493`).
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { preferOperatorSocket } from "./client.js";
+
+const SAVED_ENV = {
+  operatorSock: process.env.SWITCHROOM_VAULT_BROKER_OPERATOR_SOCK,
+};
+
+beforeEach(() => {
+  delete process.env.SWITCHROOM_VAULT_BROKER_OPERATOR_SOCK;
+});
+
+afterEach(() => {
+  if (SAVED_ENV.operatorSock !== undefined) {
+    process.env.SWITCHROOM_VAULT_BROKER_OPERATOR_SOCK = SAVED_ENV.operatorSock;
+  } else {
+    delete process.env.SWITCHROOM_VAULT_BROKER_OPERATOR_SOCK;
+  }
+});
+
+describe("preferOperatorSocket", () => {
+  it("sets opts.socket from SWITCHROOM_VAULT_BROKER_OPERATOR_SOCK when env is set", () => {
+    // fails when: the env var stops being consulted — grant-mgmt
+    // RPCs from admin agents revert to the per-agent socket and
+    // get the "operator-only" rejection that #1019 Option 1 fixed.
+    process.env.SWITCHROOM_VAULT_BROKER_OPERATOR_SOCK =
+      "/run/switchroom/broker/operator/sock";
+    const result = preferOperatorSocket();
+    expect(result.socket).toBe("/run/switchroom/broker/operator/sock");
+  });
+
+  it("returns opts unchanged when env is NOT set (non-admin agents)", () => {
+    // fails when: the helper always returns a socket — non-admin
+    // agents would lose the runtime-aware default resolution
+    // (legacy host socket vs operator vs per-agent path) and
+    // their grant-mgmt calls would crash with an undefined path.
+    const result = preferOperatorSocket();
+    expect(result.socket).toBeUndefined();
+  });
+
+  it("respects an explicit caller-supplied opts.socket even when env IS set", () => {
+    // fails when: env unconditionally wins — tests + special-case
+    // host callers (e.g. a CLI that points at a specific test
+    // socket) lose control of routing. Explicit caller-pinning
+    // is a more specific signal than env, so it should win.
+    process.env.SWITCHROOM_VAULT_BROKER_OPERATOR_SOCK =
+      "/run/switchroom/broker/operator/sock";
+    const result = preferOperatorSocket({ socket: "/tmp/explicit-test.sock" });
+    expect(result.socket).toBe("/tmp/explicit-test.sock");
+  });
+
+  it("preserves other BrokerClientOpts fields when adding socket", () => {
+    // fails when: a refactor returns just `{ socket }` instead of
+    // spreading the caller's opts. The agent-token discovery
+    // (`agentSlug`) and timeout overrides would silently drop.
+    process.env.SWITCHROOM_VAULT_BROKER_OPERATOR_SOCK =
+      "/run/switchroom/broker/operator/sock";
+    const result = preferOperatorSocket({
+      timeoutMs: 5000,
+      agentSlug: "test-harness",
+    });
+    expect(result.socket).toBe("/run/switchroom/broker/operator/sock");
+    expect(result.timeoutMs).toBe(5000);
+    expect(result.agentSlug).toBe("test-harness");
+  });
+
+  it("handles undefined opts argument gracefully", () => {
+    // fails when: opts is unsafely destructured — most callers in
+    // the codebase invoke listGrantsViaBroker(agent) with no opts
+    // at all, so the helper must handle undefined cleanly.
+    process.env.SWITCHROOM_VAULT_BROKER_OPERATOR_SOCK =
+      "/run/switchroom/broker/operator/sock";
+    const result = preferOperatorSocket(undefined);
+    expect(result.socket).toBe("/run/switchroom/broker/operator/sock");
+  });
+});

--- a/src/vault/broker/client.ts
+++ b/src/vault/broker/client.ts
@@ -345,6 +345,35 @@ export function resolveBrokerSocketPath(opts?: BrokerClientOpts): string {
 }
 
 /**
+ * For grant-management RPCs (`mint_grant`, `list_grants`,
+ * `revoke_grant`), return a BrokerClientOpts that routes through the
+ * operator socket when `SWITCHROOM_VAULT_BROKER_OPERATOR_SOCK` is set
+ * — typically on admin-flagged agents (`admin: true` in switchroom.yaml,
+ * see `src/agents/compose.ts`).
+ *
+ * Without this rerouting, the broker rejects grant ops from agent-
+ * bound sockets with "Grant management ops are operator-only; agent-
+ * bound listeners cannot mint, list, or revoke grants"
+ * (`src/vault/broker/server.ts:1493`).
+ *
+ * Falls through to the caller's opts unchanged when the env isn't set
+ * — non-admin agents AND host CLI invocations keep their existing
+ * socket resolution.
+ *
+ * Issue #1019 tracks the wider design space (read-only RPC on agent
+ * path, dedicated foreman agent); this Option-1 implementation is
+ * the smallest change that unblocks `/vault audit` and #1012 testing.
+ */
+export function preferOperatorSocket(opts?: BrokerClientOpts): BrokerClientOpts {
+  const operatorEnv = process.env.SWITCHROOM_VAULT_BROKER_OPERATOR_SOCK;
+  if (!operatorEnv) return opts ?? {};
+  // Explicit caller-supplied socket wins — tests + special-case host
+  // callers can still pin a specific socket regardless of env.
+  if (opts?.socket) return opts;
+  return { ...(opts ?? {}), socket: operatorEnv };
+}
+
+/**
  * Result of a single RPC: either a parsed broker response, or an
  * "unreachable" status with a human-readable reason. Internal helper
  * — public API on top distinguishes denied vs not-found vs unreachable.
@@ -704,7 +733,7 @@ export async function mintGrantViaBroker(
       description: opts.description,
       ...(opts.write_keys !== undefined ? { write_keys: opts.write_keys } : {}),
     },
-    opts,
+    preferOperatorSocket(opts),
   );
   if (result.kind === "unreachable") return { kind: "unreachable", msg: result.msg };
   const resp = result.resp;
@@ -732,7 +761,7 @@ export async function listGrantsViaBroker(
   agent: string | undefined,
   opts?: BrokerClientOpts,
 ): Promise<ListGrantsResult> {
-  const result = await rpc({ v: 1, op: "list_grants", agent }, opts);
+  const result = await rpc({ v: 1, op: "list_grants", agent }, preferOperatorSocket(opts));
   if (result.kind === "unreachable") return { kind: "unreachable", msg: result.msg };
   const resp = result.resp;
   if (resp.ok && "grants" in resp) {
@@ -754,7 +783,7 @@ export async function revokeGrantViaBroker(
   id: string,
   opts?: BrokerClientOpts,
 ): Promise<RevokeGrantResult> {
-  const result = await rpc({ v: 1, op: "revoke_grant", id }, opts);
+  const result = await rpc({ v: 1, op: "revoke_grant", id }, preferOperatorSocket(opts));
   if (result.kind === "unreachable") return { kind: "unreachable", msg: result.msg };
   const resp = result.resp;
   if (resp.ok && "revoked" in resp) {

--- a/tests/docker/compose-generator.test.ts
+++ b/tests/docker/compose-generator.test.ts
@@ -626,6 +626,40 @@ describe("agent service env (Phase 2c F2 — IPC wiring)", () => {
     }
   });
 
+  it("mounts the operator broker socket + sets SWITCHROOM_VAULT_BROKER_OPERATOR_SOCK on admin agents", () => {
+    // fails when: the compose generator stops mounting the operator
+    // socket on admin-flagged agents, or stops setting the env var
+    // the broker client uses to route grant-management RPCs. Without
+    // either, `/vault audit` from an admin agent reverts to the
+    // pre-#1019 "Grant management ops are operator-only" rejection
+    // (see src/vault/broker/server.ts:1493). Pins both halves.
+    const out = generateCompose({
+      config: makeConfig({
+        alice: { admin: true },
+        bob: {},
+      }),
+    });
+    const aliceEnv = envBlockFor(out, "alice");
+    expect(aliceEnv).toMatch(
+      /SWITCHROOM_VAULT_BROKER_OPERATOR_SOCK:\s*"\/run\/switchroom\/broker\/operator\/sock"/,
+    );
+    // The volume mount lives outside the env block — grep for the
+    // bind line directly.
+    expect(out).toMatch(
+      /agent-alice:[\s\S]*?\.switchroom\/broker-operator:\/run\/switchroom\/broker\/operator:ro/,
+    );
+
+    // Non-admin agent must NOT get either — operator socket is the
+    // privileged surface, default agents stay isolated.
+    const bobEnv = envBlockFor(out, "bob");
+    expect(bobEnv).not.toMatch(/SWITCHROOM_VAULT_BROKER_OPERATOR_SOCK/);
+    // Confirm bob's block doesn't carry the bind: search the
+    // agent-bob section up to the next service.
+    expect(out).not.toMatch(
+      /agent-bob:[\s\S]*?broker-operator(?![\s\S]*?  agent-)/,
+    );
+  });
+
   it("surfaces yaml admin: true as SWITCHROOM_AGENT_ADMIN=true on the agent container", () => {
     // fails when: the compose generator stops propagating the
     // schema-level `admin: true` flag to the gateway's runtime env.


### PR DESCRIPTION
## Summary

\`/vault audit\` from an admin-flagged agent's bot was returning the placeholder "Grant management ops are operator-only; agent-bound listeners cannot mint, list, or revoke grants" because the per-agent broker socket can't serve cross-agent grant queries.

This PR implements **Option 1** from #1019: admin agents (\`admin: true\` in yaml) get the operator socket mounted read-only at \`/run/switchroom/broker/operator/\` plus a \`SWITCHROOM_VAULT_BROKER_OPERATOR_SOCK\` env var. Grant-management RPCs (\`list_grants\`, \`mint_grant\`, \`revoke_grant\`) route through the operator socket when the env is set. Vault get/set continue via the per-agent socket — only grant management is rerouted.

## Trust model

An admin-flagged agent already has operator-level Telegram surface (\`/agents\`, \`/logs\`, \`/restart\`, \`/grant\`, \`/update\`). Broker grant-management at the operator socket is a consistent expansion; the operator opts in by setting \`admin: true\` in switchroom.yaml.

Bigger redesigns are tracked as options 2/3 in #1019 (read-only RPC on agent path; dedicated foreman bot). This is the smallest-change unblocker for \`/vault audit\` and #1012 testing.

## Code changes

- \`src/agents/compose.ts\`: admin agents get the read-only operator-socket bind mount + the env var. Both gated on \`a.admin === true\`. Non-admin agents see no change.
- \`src/vault/broker/client.ts\`: new \`preferOperatorSocket(opts)\` helper. Each of the three grant-mgmt RPCs (\`listGrantsViaBroker\`, \`mintGrantViaBroker\`, \`revokeGrantViaBroker\`) passes opts through it. When the env is set: returns opts with \`.socket\` overridden to the operator path (preserves \`timeoutMs\`, \`agentSlug\`, etc.). When unset: opts unchanged. Caller-supplied explicit \`opts.socket\` always wins.

## Tests

- \`tests/docker/compose-generator.test.ts\` +1: admin agent gets BOTH the env var AND the bind mount; non-admin gets neither.
- \`src/vault/broker/client-prefer-operator-socket.test.ts\` +5 (new file): env-set / env-unset / caller-override / opts passthrough / undefined-opts. Each carries a \`// fails when:\` comment.

70/70 compose tests pass; 5/5 new client tests pass. \`npm run lint\` clean.

## Validation path

End-to-end \`/vault audit\` test needs the next agent image build (gateway.js is baked into the image at build time, not pulled at runtime). The docker-images workflow ships a new image on every push to main; will validate via the UAT harness once that lands.

## Related

- #1019 (Option 1)
- #1016 / #1017 / #1018 — sibling Docker-runtime ops bugs discovered in the same session
- #1012 — vault grant approval flow design; this PR unblocks UAT testing of it

DO NOT MERGE until a fresh reviewer process gives APPROVE per global CLAUDE.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)