### PR TITLE
fix(vault): admin-agent grant-mgmt also bypasses the peercred gate

### DIFF
--- a/src/vault/broker/server.ts
+++ b/src/vault/broker/server.ts
@@ -1467,6 +1467,18 @@ export class VaultBroker {
       req.op === "list_grants" ||
       req.op === "revoke_grant";
     if (isGrantMgmtOp) {
+      // Decide trust upfront so both the agent-deny gate AND the
+      // peercred/cron gates below honour it. `isAdminAgent` is the
+      // admin-flagged-yaml path-as-identity equivalent of the
+      // operator socket: identity comes from the bound path
+      // (the per-agent socket is `/run/switchroom/broker/<name>/sock`),
+      // admin-ness comes from server-side config — never from the
+      // wire. Same trust posture as `isOperator`; bypasses peercred
+      // for the same reason.
+      const isAdminAgent =
+        agentName !== null &&
+        this.config?.agents?.[agentName]?.admin === true;
+      const trustedForGrantMgmt = isOperator || isAdminAgent;
       // Operator socket: trusted by path + 0600 chown; skip the cron-deny
       // and peercred-required gates below. Operator IS the operator-only
       // identity those gates were designed to verify. Audit logs reflect
@@ -1479,11 +1491,7 @@ export class VaultBroker {
         // grant-mgmt ops via their existing per-agent socket
         // (#1021 Design B). The agent already has operator-level
         // Telegram surface (`/agents`, `/vault`, `/restart`, etc.)
-        // so this is a consistent expansion. Path-as-identity is
-        // preserved: the agent name comes from the socket path,
-        // and admin-ness is read from server-side config — never
-        // from the wire.
-        const isAdminAgent = this.config?.agents?.[agentName]?.admin === true;
+        // so this is a consistent expansion.
         if (isAdminAgent) {
           // Fall through to grant-mgmt handlers below. Audit log
           // already carries the agent name + cgroup attribution.
@@ -1511,9 +1519,13 @@ export class VaultBroker {
           return;
         }
       }
-      // Operator socket bypasses both gates below — its identity is
-      // established by the bind path + 0600 chown, not peercred.
-      if (!isOperator) {
+      // Operator socket + admin agents bypass both gates below —
+      // their identity is established by the bind path + chown, not
+      // peercred. Per-agent (non-admin) connections that reach this
+      // point have already been rejected above; the only callers
+      // here are: (a) operator socket, (b) admin agent socket, or
+      // (c) some non-agent, non-operator path (legacy / dev mode).
+      if (!trustedForGrantMgmt) {
         const allowNonLinux = process.env.SWITCHROOM_BROKER_ALLOW_NON_LINUX === "1";
         if (peer === null && !allowNonLinux) {
           this.auditLogger.write({


### PR DESCRIPTION
## Summary

Live-validating PR #1022 against test-harness, the next gate after the agent-allowlist check rejected the admin agent connection with \`peercred unavailable; cannot verify operator identity\`. The second gate was unchanged from the operator-socket era and assumed only \`isOperator\` skipped peercred verification.

Admin agents have the same path-as-identity posture as the operator socket (name from bound path, admin-ness from server-side yaml, never from wire). Same trust → same gate bypass.

## Change

Hoist \`isAdminAgent\` into a \`trustedForGrantMgmt = isOperator || isAdminAgent\` constant; both the agent-deny gate AND the peercred/cron gate now consult it. ~20 LOC.

| Identity | Pre-#1022 | Post-#1022 | This PR |
|---|---|---|---|
| Operator socket | ✅ allowed | ✅ allowed | ✅ allowed |
| Admin agent socket | ❌ agent-deny | ❌ peercred-deny | ✅ allowed |
| Non-admin agent socket | ❌ agent-deny | ❌ agent-deny | ❌ agent-deny |
| Legacy / dev socket | (peercred gates apply) | (peercred gates apply) | (unchanged) |

## Test

The existing docker-integration denial test (\`tests/docker/phase2a-broker-ipc.test.ts:508\`) still pins the non-admin DENIED path. Test coverage for the admin allow path rolls in with the next phase2a fixture refresh.

\`npm run lint\` clean. End-to-end validation post-merge.

## Related

- #1022 (Design B base — this PR completes its bypass)
- #1021 / #1019 / #1012

DO NOT MERGE until a fresh reviewer process gives APPROVE per global CLAUDE.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)