### PR TITLE
fix(compose): mount vault-audit.log into admin agents for /vault audit Recent-denials

### DIFF
--- a/src/agents/compose.ts
+++ b/src/agents/compose.ts
@@ -752,6 +752,31 @@ function emitAgentService(
   // invariant on every regenerated compose.
   lines.push(`      - broker-${a.name}-sock:/run/switchroom/broker`);
   lines.push(`      - kernel-${a.name}-sock:/run/switchroom/kernel`);
+  if (a.admin === true) {
+    // Admin agents need read access to the host operator's vault
+    // audit log so the bot's `/vault audit <agent>` Recent-denials
+    // section (#969 P2b) can render. The bot reads from
+    // `${HOME}/.switchroom/vault-audit.log` (homedir-relative); the
+    // agent container's HOME is `/state/agent/home`, so the host
+    // file gets mounted there as a read-only file bind. Non-admin
+    // agents stay isolated.
+    //
+    // The bot only consumes this for read-only rendering; the
+    // broker is the sole writer (running in its own container with
+    // its own append-only access). Mounting :ro protects the file
+    // even from a fully-compromised admin agent.
+    //
+    // Gated on `existsSync` because the audit log is created lazily
+    // by the broker on the first ACL decision — fresh installs may
+    // not have it yet, and docker compose `up` hard-fails when a
+    // `:ro` source is missing (same pattern as the skills /
+    // credentials mounts below).
+    if (existsSync(`${hostHomeForChecks}/.switchroom/vault-audit.log`)) {
+      lines.push(
+        `      - ${homePrefix}/.switchroom/vault-audit.log:/state/agent/home/.switchroom/vault-audit.log:ro`,
+      );
+    }
+  }
   // Dual mounts — the same host directory is bound BOTH at the canonical
   // container path (`/state/agent`, `/state/.claude`, `/var/log/switchroom`)
   // AND at the original host path. Why both:

--- a/tests/docker/compose-generator.test.ts
+++ b/tests/docker/compose-generator.test.ts
@@ -626,6 +626,65 @@ describe("agent service env (Phase 2c F2 — IPC wiring)", () => {
     }
   });
 
+  it("admin agents get a read-only vault-audit.log mount when the host log exists", async () => {
+    // fails when: the audit-log mount is dropped from admin agent
+    // compose. The bot in the admin agent container reads
+    // `${HOME}/.switchroom/vault-audit.log` (telegram-plugin/
+    // gateway/gateway.ts:6346 — `readRecentDenialsForAgent`).
+    // Container HOME is `/state/agent/home`, so the host audit log
+    // must be mounted there. Without the mount, the bot silently
+    // returns 0 recent denials regardless of how many actually
+    // fired, breaking the /vault audit one-tap allow UX from #969 P2b.
+    const { mkdtempSync, mkdirSync, writeFileSync, rmSync } = await import("node:fs");
+    const { tmpdir } = await import("node:os");
+    const { join } = await import("node:path");
+    const tmp = mkdtempSync(join(tmpdir(), "compose-audit-mount-"));
+    try {
+      mkdirSync(join(tmp, ".switchroom"), { recursive: true });
+      writeFileSync(join(tmp, ".switchroom", "vault-audit.log"), "");
+      const out = generateCompose({
+        config: makeConfig({
+          alice: { admin: true },
+          bob: {},
+        }),
+        homeDir: tmp,
+      });
+      expect(out).toMatch(
+        /agent-alice:[\s\S]*?\.switchroom\/vault-audit\.log:\/state\/agent\/home\/\.switchroom\/vault-audit\.log:ro/,
+      );
+      // Non-admin gets no host audit-log mount — operator state is
+      // not exposed to ordinary agents.
+      expect(out).not.toMatch(
+        /agent-bob:[\s\S]*?vault-audit\.log(?![\s\S]*?  (?:agent|vault|approval|kernel))/,
+      );
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("skips the audit-log mount on fresh installs where the host log doesn't exist yet (no docker compose hard-fail)", async () => {
+    // fails when: the existsSync guard is dropped — docker compose
+    // `up` hard-fails when a `:ro` source path is missing. The
+    // audit log is created lazily by the broker on the first ACL
+    // decision; fresh installs (no denials ever fired) would then
+    // break the admin agent's container startup entirely. Same
+    // pattern as the skills/credentials mounts below.
+    const { mkdtempSync, rmSync } = await import("node:fs");
+    const { tmpdir } = await import("node:os");
+    const { join } = await import("node:path");
+    const tmp = mkdtempSync(join(tmpdir(), "compose-audit-fresh-"));
+    try {
+      // No vault-audit.log created — simulates fresh install.
+      const out = generateCompose({
+        config: makeConfig({ alice: { admin: true } }),
+        homeDir: tmp,
+      });
+      expect(out).not.toContain("vault-audit.log");
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
   it("admin agents get NO operator-socket mount or routing env (#1021 Design B handles grant-mgmt server-side)", () => {
     // fails when: a refactor re-introduces the pre-#1021 attempt of
     // mounting the operator socket directly into admin agents. That


### PR DESCRIPTION
## Summary

Validating PR #1023 live: \`/vault audit test-harness\` now renders correctly (no "operator-only" or "peercred unavailable"), but Recent-denials returns 0 entries even after a real broker denial fires.

Cause: the bot reads \`\${HOME}/.switchroom/vault-audit.log\` (\`gateway.ts:6346\`). Inside the agent container HOME=\`/state/agent/home\`, so the bot looks at a path that doesn't exist. The audit log lives on the host at \`~/.switchroom/vault-audit.log\`.

## Fix

For \`admin: true\` agents, mount the host audit log read-only at the bot-expected path:

\`\`\`yaml
- \${HOME}/.switchroom/vault-audit.log:/state/agent/home/.switchroom/vault-audit.log:ro
\`\`\`

Non-admin agents stay isolated. The :ro mount protects the file from a compromised admin agent — the broker is the sole writer.

## Test

71/71 compose tests pass; \`npm run lint\` clean. New test pins:
- admin agent gets the audit-log bind mount
- non-admin agent gets no audit-log mount

## Operator path

\`switchroom apply\` regenerates compose; existing operators only need \`switchroom agent restart test-harness --force\` (no agent image rebuild required — pure volume mount).

## Cascade

This is the 4th gate the bot hits when doing admin work from inside the agent sandbox: 1) /vault admin command gate (#1016), 2) per-agent grant-mgmt deny (#1022), 3) peercred gate (#1023), 4) audit-log read access (this PR). Long-term the right architecture is a dedicated foreman bot agent (#1019 Option 3). Tonight's fixes are the minimum-viable unblock for harness testing.

DO NOT MERGE until a fresh reviewer process gives APPROVE per global CLAUDE.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)