### PR TITLE
fix(broker): persist vault audit log on host (#1025)

### DIFF
--- a/src/agents/compose.ts
+++ b/src/agents/compose.ts
@@ -488,6 +488,17 @@ export function generateCompose(opts: ComposeGeneratorOptions): string {
   // and falls back to the interactive unlock flow, so operators who
   // never enabled auto-unlock are unaffected.
   lines.push(`      - ${homePrefix}/.switchroom/vault-auto-unlock:/state/vault-auto-unlock:ro`);
+  // Audit log — bind-mount the host file into the broker so deny/
+  // allow events the broker writes land on the host fs. Without this
+  // mount the broker writes to `/root/.switchroom/vault-audit.log`
+  // inside the container (which evaporates on recreate and is
+  // unreachable to both the host CLI `switchroom vault audit` and
+  // the admin-agent :ro mount wired in #1024). The host file is
+  // pre-created at mode 0644 by `ensureHostMountSources()` so docker
+  // doesn't auto-create a directory at the source path. Writable
+  // because broker appends; broker runs as root with CAP_DAC_OVERRIDE
+  // so file ownership/mode doesn't gate the write path. See #1025.
+  lines.push(`      - ${homePrefix}/.switchroom/vault-audit.log:/root/.switchroom/vault-audit.log`);
   // /etc/machine-id passthrough — required so the broker can derive
   // the same machine-bound key the host's `enable-auto-unlock` used
   // to seal the auto-unlock blob. The agent base image (node:22-bookworm-slim)

--- a/src/cli/apply.ts
+++ b/src/cli/apply.ts
@@ -289,6 +289,20 @@ async function ensureHostMountSources(config: SwitchroomConfig): Promise<void> {
   if (!existsSync(autoUnlockPath)) {
     writeFileSync(autoUnlockPath, "", { mode: 0o600 });
   }
+
+  // vault-audit.log: same dir-vs-file race. The broker bind-mounts
+  // this file (see compose.ts broker volumes) so audit-log writes
+  // land on the host, not inside the ephemeral container fs where
+  // they'd be lost on recreate and invisible to the host CLI
+  // (`switchroom vault audit`) plus the admin-agent :ro mount
+  // wired up in #1024. Created mode 0644 because both readers
+  // (host operator + the agent UID inside admin agents) need
+  // access. Broker writes via root with CAP_DAC_OVERRIDE so
+  // mode doesn't matter on the write path.
+  const auditLogPath = join(home, ".switchroom", "vault-audit.log");
+  if (!existsSync(auditLogPath)) {
+    writeFileSync(auditLogPath, "", { mode: 0o644 });
+  }
 }
 
 /**

--- a/tests/docker/compose-generator.test.ts
+++ b/tests/docker/compose-generator.test.ts
@@ -471,6 +471,26 @@ describe("generateCompose", () => {
     expect(block).toMatch(/-\s+\/etc\/machine-id:\/etc\/machine-id:ro/);
   });
 
+  it("broker bind-mounts the host vault-audit.log onto /root/.switchroom/vault-audit.log (#1025)", () => {
+    // fails when: the broker writes its audit log to a container-local
+    // path that evaporates on recreate and is invisible to both the
+    // host CLI (`switchroom vault audit`) and the admin-agent :ro
+    // mount wired up by #1024. Broker resolves the log path via
+    // `os.homedir()` (`src/vault/broker/audit-log.ts:101`); broker
+    // runs as root so HOME=/root inside the container. Without this
+    // mount the host file never sees a single entry — exactly the
+    // failure mode #1024's Recent-denials section was meant to
+    // surface, masked by missing data. Mount is RW (not :ro) because
+    // the broker appends; `ensureHostMountSources()` in apply.ts
+    // pre-creates the source file so docker doesn't auto-create a
+    // directory at the mount path.
+    const out = generateCompose({ config: makeConfig({ a: {} }) });
+    const block = /vault-broker:[\s\S]*?(?=\n  [a-z])/.exec(out)?.[0] ?? "";
+    expect(block).toMatch(
+      /-\s+\$\{HOME\}\/\.switchroom\/vault-audit\.log:\/root\/\.switchroom\/vault-audit\.log(?!:ro)/,
+    );
+  });
+
   it("kernel keeps CHOWN + FOWNER (mirrors broker socket-ownership flow)", () => {
     const out = generateCompose({ config: makeConfig({ a: {} }) });
     const block = /approval-kernel:[\s\S]*?(?=\n  [a-z])/.exec(out)?.[0] ?? "";
@@ -662,13 +682,19 @@ describe("agent service env (Phase 2c F2 — IPC wiring)", () => {
     }
   });
 
-  it("skips the audit-log mount on fresh installs where the host log doesn't exist yet (no docker compose hard-fail)", async () => {
-    // fails when: the existsSync guard is dropped — docker compose
-    // `up` hard-fails when a `:ro` source path is missing. The
-    // audit log is created lazily by the broker on the first ACL
-    // decision; fresh installs (no denials ever fired) would then
-    // break the admin agent's container startup entirely. Same
-    // pattern as the skills/credentials mounts below.
+  it("skips the admin-agent audit-log mount on fresh installs where the host log doesn't exist yet (no docker compose hard-fail)", async () => {
+    // fails when: the existsSync guard on the AGENT-side :ro mount
+    // is dropped — docker compose `up` hard-fails when a `:ro`
+    // source path is missing. Before #1025 the audit log was created
+    // lazily by the broker on the first ACL decision, so a fresh
+    // install (no denials ever fired) could break admin agent
+    // startup. #1025 then made `ensureHostMountSources()` pre-create
+    // the file, which closes the timing window — but we keep the
+    // existsSync guard on the agent-side mount as belt-and-braces
+    // for the `compose-only-without-apply` codepath (tests, manual
+    // re-generation). The broker-side RW mount is intentionally
+    // unconditional: apply always pre-creates it, and the broker
+    // image already expects to write there.
     const { mkdtempSync, rmSync } = await import("node:fs");
     const { tmpdir } = await import("node:os");
     const { join } = await import("node:path");
@@ -679,7 +705,16 @@ describe("agent service env (Phase 2c F2 — IPC wiring)", () => {
         config: makeConfig({ alice: { admin: true } }),
         homeDir: tmp,
       });
-      expect(out).not.toContain("vault-audit.log");
+      // Agent-side :ro mount must NOT appear without the host file.
+      expect(out).not.toMatch(
+        /agent-alice:[\s\S]*?vault-audit\.log:\/state\/agent\/home\/\.switchroom\/vault-audit\.log:ro/,
+      );
+      // Broker-side RW mount IS still emitted (apply pre-creates the
+      // source). The broker depends on it for audit-log persistence
+      // across container recreate (#1025).
+      expect(out).toMatch(
+        /vault-broker:[\s\S]*?vault-audit\.log:\/root\/\.switchroom\/vault-audit\.log/,
+      );
     } finally {
       rmSync(tmp, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary

- Bind-mount `~/.switchroom/vault-audit.log` into the vault-broker container at `/root/.switchroom/vault-audit.log` (RW) so broker writes persist on the host.
- Pre-create the host file as mode 0644 in `ensureHostMountSources()` so docker doesn't auto-create a directory at the source path. Mirrors the existing `vault-auto-unlock` pattern.

## Why

Closes #1025. Without this mount the broker resolves its audit-log path via `os.homedir()` (audit-log.ts:101) — running as root, that lands at `/root/.switchroom/vault-audit.log` *inside the container*. That path evaporates on recreate and is invisible to:

- the host CLI (`switchroom vault audit`), and
- the admin-agent `:ro` mount wired up in #1024 — Recent-denials in `/vault audit` silently rendered "0 denials" regardless of how many had actually fired (the symptom that triggered #1025 from the gymbro screenshot).

Broker has `CAP_DAC_OVERRIDE` so ownership/mode don't gate the write path. Mount is unconditional on the broker side (apply pre-creates the source); the agent-side mount from #1024 keeps its `existsSync` guard for the compose-only-without-apply codepath.

## Test plan

- [x] `npm run lint` — clean.
- [x] `npm test` — 5433 pass.
- [x] New compose-generator test pins the broker mount line and rules out a `:ro` regression.
- [x] Existing #1024 fresh-install test updated: agent-side mount still skipped on fresh install, broker-side mount is now expected unconditionally.
- [ ] Post-merge: rebuild broker image (`switchroom apply --build-local` or pull GHCR), recreate broker, fire a denied vault op, verify `tail -n1 ~/.switchroom/vault-audit.log` on host has the entry and `/vault audit` Recent-denials shows it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)