### PR TITLE
feat(vault): agent-initiated ACL request via Telegram approval card (#1012 Phase 1)

### DIFF
--- a/telegram-plugin/bridge/bridge.ts
+++ b/telegram-plugin/bridge/bridge.ts
@@ -418,6 +418,23 @@ const TOOL_SCHEMAS = [
       required: ['chat_id', 'key', 'value'],
     },
   },
+  {
+    name: 'vault_request_access',
+    description:
+      'Ask the operator (via Telegram approval card) to grant this agent read or write access to a vault key it does not yet have. Use this when you hit `VAULT-BROKER-DENIED` or when you know upfront that an upcoming task needs a key you lack. Renders a [Approve] [Deny] card; on approve, the broker mints a scoped grant token and writes it to the agent\'s `.vault-token` file — your next vault read will succeed without intervention. You CANNOT mint or self-elevate; only the operator can tap Approve. Wait for confirmation before retrying the vault op. Do NOT call this for keys you already have access to (use the normal `vault:<key>` reference) and do NOT spam-request (the operator sees every card).',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        chat_id: { type: 'string', description: 'Chat to render the approval card in (use the chat_id of the user message that triggered the workflow).' },
+        key: { type: 'string', description: 'Vault key the agent wants access to (matches the key shown in the VAULT-BROKER-DENIED error, e.g. `fatsecret/credentials`).' },
+        scope: { type: 'string', enum: ['read', 'write'], description: 'Access scope: "read" (default) for `vault:<key>` references; "write" if the agent needs to put new values.' },
+        reason: { type: 'string', description: 'Short human-readable rationale rendered on the card (e.g. "to look up today\'s food log entries"). Helps the operator decide.' },
+        duration: { type: 'string', description: 'Requested grant TTL, like "30d" or "12h". Default 30d, capped at 90d. Beyond 90d the operator should use the host CLI explicitly.' },
+        message_thread_id: { type: 'string', description: 'Forum topic thread ID. Auto-applied from the last inbound message if not specified.' },
+      },
+      required: ['chat_id', 'key'],
+    },
+  },
 ]
 
 mcp.setRequestHandler(ListToolsRequestSchema, async () => ({ tools: TOOL_SCHEMAS }))

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -1466,6 +1466,47 @@ function sweepPendingVaultRequestSaves(): void {
 }
 
 /**
+ * Issue #1012 — agent-initiated vault ACL request. The agent calls
+ * `vault_request_access` when it hits VAULT-BROKER-DENIED (or
+ * preemptively, when it knows it'll need a key it doesn't yet have).
+ * The card carries [Approve] / [Deny] inline buttons; only the
+ * operator can mint the grant (same authorization gate as the
+ * existing /vault audit one-tap allow flow). The agent never sees
+ * the grant token directly — `mintGrantViaBroker` writes it to the
+ * agent's `.vault-token` file, which the agent's CLI reads on the
+ * next vault request.
+ *
+ * Mirrors PendingVaultRequestSave above (#969 P1a). No secret
+ * material is staged here — only the request metadata.
+ */
+interface PendingVaultRequestAccess {
+  /** Agent that initiated the request (process.env.SWITCHROOM_AGENT_NAME). */
+  agent: string
+  /** Chat the card was rendered into; edited on tap. */
+  chat_id: string
+  /** Card message id (filled in after we send the card). */
+  card_message_id?: number
+  /** Vault key the agent wants to read. */
+  key: string
+  /** 'read' (default) or 'write'. */
+  scope: 'read' | 'write'
+  /** Optional rationale the agent supplied; rendered on the card. */
+  reason?: string
+  /** Grant TTL in seconds (max 90 days; null = never, refused). */
+  ttl_seconds: number
+  /** Unix-ms timestamp; entries are reaped after VAULT_REQUEST_ACCESS_TTL_MS. */
+  staged_at: number
+}
+const pendingVaultRequestAccesses = new Map<string, PendingVaultRequestAccess>()
+const VAULT_REQUEST_ACCESS_TTL_MS = 10 * 60 * 1000
+function sweepPendingVaultRequestAccesses(): void {
+  const cutoff = Date.now() - VAULT_REQUEST_ACCESS_TTL_MS
+  for (const [k, v] of pendingVaultRequestAccesses) {
+    if (v.staged_at < cutoff) pendingVaultRequestAccesses.delete(k)
+  }
+}
+
+/**
  * Mint an approval-kernel decision row for a deferred-secret card
  * (MIGRATION.md §1). Best-effort: if the kernel/broker is unreachable, we
  * return null and the caller proceeds with the legacy-only path so the
@@ -2413,6 +2454,7 @@ const ALLOWED_TOOLS = new Set([
   'ask_user',
   'send_sticker', 'send_gif',
   'vault_request_save',
+  'vault_request_access',
 ])
 
 async function executeToolCall(tool: string, args: Record<string, unknown>): Promise<unknown> {
@@ -2454,6 +2496,8 @@ async function executeToolCall(tool: string, args: Record<string, unknown>): Pro
       return executeSendGif(args)
     case 'vault_request_save':
       return executeVaultRequestSave(args)
+    case 'vault_request_access':
+      return executeVaultRequestAccess(args)
     default:
       throw new Error(`unknown tool: ${tool}`)
   }
@@ -3523,6 +3567,113 @@ async function executeVaultRequestSave(args: Record<string, unknown>): Promise<{
       {
         type: 'text',
         text: `vault_request_save: card sent (stage_id=${stageId}, key=${key}). The user must tap a button before the secret is persisted; do not assume success until you see the user's next message confirming the outcome.`,
+      },
+    ],
+  }
+}
+
+/**
+ * Issue #1012 — render the agent-initiated ACL request approval card.
+ * Same visual language as the recent-denials one-tap allow (#969 P2b)
+ * but with the agent's own reason and an explicit [Deny] path.
+ */
+function buildVaultRequestAccessKeyboard(stageId: string): { inline_keyboard: Array<Array<{ text: string; callback_data: string }>> } {
+  return {
+    inline_keyboard: [
+      [
+        { text: '✅ Approve', callback_data: `vra:approve:${stageId}` },
+        { text: '🚫 Deny', callback_data: `vra:deny:${stageId}` },
+      ],
+    ],
+  }
+}
+
+function renderVaultRequestAccessCard(req: PendingVaultRequestAccess): string {
+  const lines: string[] = []
+  const scopeLabel = req.scope === 'write' ? 'write' : 'read'
+  const days = Math.round(req.ttl_seconds / 86400)
+  const durationLabel = days >= 1 ? `${days}d` : `${Math.round(req.ttl_seconds / 3600)}h`
+  lines.push(`🔐 <b>${escapeHtmlForTg(req.agent)}</b> wants vault access`)
+  lines.push(`key: <code>${escapeHtmlForTg(req.key)}</code>`)
+  lines.push(`scope: <code>${scopeLabel}</code> · duration: <code>${durationLabel}</code>`)
+  if (req.reason && req.reason.length > 0) {
+    lines.push(`why: <i>${escapeHtmlForTg(req.reason)}</i>`)
+  }
+  lines.push('')
+  lines.push(`<i>Tap Approve to mint a scoped grant token (same flow as <code>switchroom vault grant</code>). Tap Deny to refuse — the agent will receive a denial result.</i>`)
+  return lines.join('\n')
+}
+
+/**
+ * `vault_request_access` tool — agent surfaces an approval card asking
+ * the operator to grant a vault ACL it doesn't yet have. See #1012.
+ * Auth boundary: only operators on the gateway allowFrom list can tap;
+ * the agent itself can only REQUEST.
+ */
+async function executeVaultRequestAccess(args: Record<string, unknown>): Promise<{ content: Array<{ type: string; text: string }> }> {
+  const chat_id = args.chat_id as string
+  if (!chat_id) throw new Error('vault_request_access: chat_id is required')
+  const key = args.key as string
+  if (!key || typeof key !== 'string') throw new Error('vault_request_access: key is required')
+  if (!/^[A-Za-z0-9_.-]{1,200}$/.test(key)) {
+    throw new Error('vault_request_access: key must match [A-Za-z0-9_.-]{1,200}')
+  }
+  const scopeRaw = typeof args.scope === 'string' ? args.scope : 'read'
+  if (scopeRaw !== 'read' && scopeRaw !== 'write') {
+    throw new Error('vault_request_access: scope must be "read" or "write"')
+  }
+  const reason = typeof args.reason === 'string' ? args.reason : undefined
+  // Duration: accept a "30d" / "12h" string from the agent OR default
+  // to 30 days. Cap at 90 days — beyond that the operator should use
+  // the host CLI and pick the lifetime explicitly. Refuse "never"
+  // requests outright; agent-initiated grants must have a sunset.
+  let ttl_seconds = 30 * 24 * 60 * 60
+  const durRaw = args.duration
+  if (typeof durRaw === 'string' && durRaw.length > 0) {
+    const m = durRaw.match(/^(\d+)([dh])$/)
+    if (!m) {
+      throw new Error('vault_request_access: duration must look like "30d" or "12h"')
+    }
+    const n = Number(m[1])
+    const unit = m[2]
+    const parsed = unit === 'd' ? n * 86400 : n * 3600
+    const NINETY_DAYS = 90 * 86400
+    if (parsed <= 0 || parsed > NINETY_DAYS) {
+      throw new Error('vault_request_access: duration must be > 0 and <= 90d')
+    }
+    ttl_seconds = parsed
+  }
+  assertAllowedChat(chat_id)
+
+  const agentSlug = process.env.SWITCHROOM_AGENT_NAME || 'agent'
+
+  const stageId = randomBytes(4).toString('hex')
+  const pending: PendingVaultRequestAccess = {
+    agent: agentSlug,
+    chat_id,
+    key,
+    scope: scopeRaw,
+    reason,
+    ttl_seconds,
+    staged_at: Date.now(),
+  }
+  pendingVaultRequestAccesses.set(stageId, pending)
+  sweepPendingVaultRequestAccesses()
+
+  const text = renderVaultRequestAccessCard(pending)
+  const threadId = args.message_thread_id != null ? Number(args.message_thread_id) : undefined
+  const sent = await lockedBot.api.sendMessage(chat_id, text, {
+    parse_mode: 'HTML',
+    reply_markup: buildVaultRequestAccessKeyboard(stageId),
+    ...(threadId != null && Number.isFinite(threadId) ? { message_thread_id: threadId } : {}),
+  })
+  pending.card_message_id = sent.message_id
+
+  return {
+    content: [
+      {
+        type: 'text',
+        text: `vault_request_access: card sent (stage_id=${stageId}, key=${key}, scope=${scopeRaw}). Wait for the operator to tap Approve or Deny — do not retry the vault read until you see a confirmation message. If the card times out (10 min) you can re-request.`,
       },
     ],
   }
@@ -7801,6 +7952,123 @@ async function handleVaultRecentDenialCallback(ctx: Context, data: string): Prom
   )
 }
 
+/**
+ * Issue #1012 — handle a tap on the vault_request_access approval card.
+ *   vra:approve:<stageId> — mint a scoped grant token via the broker,
+ *                           write the token to the agent's
+ *                           `.vault-token` file, edit card to success.
+ *   vra:deny:<stageId>    — drop the staged request, edit card to denied.
+ *
+ * Same authorization gate as the recent-denials one-tap handler:
+ * sender must be on the gateway's allowFrom list.
+ */
+async function handleVaultRequestAccessCallback(ctx: Context, data: string): Promise<void> {
+  const senderId = String(ctx.from?.id ?? '')
+  const access = loadAccess()
+  if (!access.allowFrom.includes(senderId)) {
+    await ctx.answerCallbackQuery({ text: 'Not authorized.' }).catch(() => {})
+    return
+  }
+  const parts = data.split(':')
+  if (parts.length < 3) {
+    await ctx.answerCallbackQuery({ text: 'Bad request' }).catch(() => {})
+    return
+  }
+  const action = parts[1]
+  const stageId = parts.slice(2).join(':')
+  const pending = pendingVaultRequestAccesses.get(stageId)
+  if (!pending) {
+    await ctx.answerCallbackQuery({ text: 'Card expired — ask the agent to re-request.' }).catch(() => {})
+    if (ctx.callbackQuery?.message) {
+      await ctx.api
+        .editMessageText(
+          ctx.callbackQuery.message.chat.id,
+          ctx.callbackQuery.message.message_id,
+          '⌛ <i>This access-request card expired before you tapped. Ask the agent to re-issue if the need still stands.</i>',
+          { parse_mode: 'HTML', reply_markup: { inline_keyboard: [] } },
+        )
+        .catch(() => {})
+    }
+    return
+  }
+
+  if (action === 'deny') {
+    pendingVaultRequestAccesses.delete(stageId)
+    await ctx.answerCallbackQuery({ text: '🚫 Denied' }).catch(() => {})
+    if (pending.card_message_id != null) {
+      await ctx.api
+        .editMessageText(
+          pending.chat_id,
+          pending.card_message_id,
+          `🚫 <i>Denied. <b>${escapeHtmlForTg(pending.agent)}</b> will not get access to <code>${escapeHtmlForTg(pending.key)}</code>.</i>`,
+          { parse_mode: 'HTML', reply_markup: { inline_keyboard: [] } },
+        )
+        .catch(() => {})
+    }
+    return
+  }
+
+  if (action === 'approve') {
+    await ctx.answerCallbackQuery({ text: '⏳ Minting grant…' }).catch(() => {})
+
+    // Mirror the recent-denials handler (#969 P2b): mint via broker
+    // with the operator's intent (operator socket = capability),
+    // then write the token to the agent's `.vault-token` file so
+    // the agent's next CLI invocation picks it up.
+    const mintArgs: Parameters<typeof mintGrantViaBroker>[0] = {
+      agent: pending.agent,
+      keys: pending.scope === 'read' ? [pending.key] : [],
+      ttl_seconds: pending.ttl_seconds,
+      description: `auto-mint via vault_request_access (#1012, scope=${pending.scope}, by op ${senderId})`,
+      ...(pending.scope === 'write' ? { write_keys: [pending.key] } : {}),
+    }
+    const result = await mintGrantViaBroker(mintArgs)
+    if (result.kind === 'unreachable') {
+      await switchroomReply(ctx, `🔴 Broker unreachable: ${escapeHtmlForTg(result.msg)}`, { html: true })
+      return
+    }
+    if (result.kind === 'error') {
+      await switchroomReply(ctx, `<b>mint_grant failed:</b> ${escapeHtmlForTg(result.msg)}`, { html: true })
+      return
+    }
+
+    const { token, id } = result
+    const tokenPath = join(homedir(), '.switchroom', 'agents', pending.agent, '.vault-token')
+    try {
+      mkdirSync(join(homedir(), '.switchroom', 'agents', pending.agent), { recursive: true })
+      writeFileSync(tokenPath, token, { mode: 0o600 })
+    } catch (err) {
+      await switchroomReply(
+        ctx,
+        `<b>Grant created (${escapeHtmlForTg(id)}) but token write failed:</b> ` +
+        `${escapeHtmlForTg(String(err))}\n` +
+        `<i>Recover with: <code>switchroom vault grant ${escapeHtmlForTg(pending.agent)} ` +
+        `--keys ${escapeHtmlForTg(pending.key)} --duration ${Math.round(pending.ttl_seconds / 86400)}d</code> on the host.</i>`,
+        { html: true },
+      )
+      return
+    }
+
+    pendingVaultRequestAccesses.delete(stageId)
+    if (pending.card_message_id != null) {
+      const days = Math.round(pending.ttl_seconds / 86400)
+      await ctx.api
+        .editMessageText(
+          pending.chat_id,
+          pending.card_message_id,
+          `✅ Granted <b>${escapeHtmlForTg(pending.agent)}</b> ${pending.scope} access to ` +
+          `<code>${escapeHtmlForTg(pending.key)}</code> for ${days}d. ` +
+          `(grant <code>${escapeHtmlForTg(id)}</code>)`,
+          { parse_mode: 'HTML', reply_markup: { inline_keyboard: [] } },
+        )
+        .catch(() => {})
+    }
+    return
+  }
+
+  await ctx.answerCallbackQuery({ text: 'Unknown action' }).catch(() => {})
+}
+
 async function handleVaultRequestSaveCallback(ctx: Context, data: string): Promise<void> {
   const senderId = String(ctx.from?.id ?? '')
   const access = loadAccess()
@@ -9590,6 +9858,14 @@ bot.on('callback_query:data', async ctx => {
   // vrs:rename:<stageId>   — prompt for a new key name, then resume
   if (data.startsWith('vrs:')) {
     await handleVaultRequestSaveCallback(ctx, data)
+    return
+  }
+
+  // Issue #1012: agent-initiated vault ACL request approval card.
+  // vra:approve:<stageId> — mint scoped grant via broker, write token
+  // vra:deny:<stageId>    — refuse, edit card to denied
+  if (data.startsWith('vra:')) {
+    await handleVaultRequestAccessCallback(ctx, data)
     return
   }
 

--- a/telegram-plugin/tests/vault-request-access-tool.test.ts
+++ b/telegram-plugin/tests/vault-request-access-tool.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Pin the agent-initiated vault ACL request flow shipped in #1012.
+ *
+ * Regressions guarded here:
+ *   1. `vault_request_access` MCP tool dropping from bridge.ts schema
+ *      (the agent would lose the tool with no compile-time signal).
+ *   2. `vault_request_access` missing from the gateway's ALLOWED_TOOLS
+ *      set (bridge would emit it but gateway would 403 with
+ *      `tool not allowed`).
+ *   3. The `vra:` callback prefix losing its dispatcher branch (taps
+ *      on [Approve] / [Deny] silently fall through to the trailing
+ *      "unknown callback" arm).
+ *   4. The 90-day TTL ceiling and `read|write` scope shape — both are
+ *      part of the threat model (agents can't request perpetual or
+ *      undefined-scope grants).
+ */
+
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+const bridgeSrc = readFileSync(
+  resolve(__dirname, '..', 'bridge', 'bridge.ts'),
+  'utf-8',
+)
+const gatewaySrc = readFileSync(
+  resolve(__dirname, '..', 'gateway', 'gateway.ts'),
+  'utf-8',
+)
+
+describe('vault_request_access (#1012)', () => {
+  it('bridge advertises the tool to MCP clients', () => {
+    // fails when: the schema is removed from TOOL_SCHEMAS — agents
+    // running the new tool will hit a generic "unknown tool" path
+    // before they ever see the gateway.
+    expect(bridgeSrc).toContain("name: 'vault_request_access'")
+  })
+
+  it('bridge schema declares the threat-model-critical fields', () => {
+    // fails when: a refactor drops `scope` (defaults to read) or
+    // `duration` (caps requested TTL at 90d). Both gates are part of
+    // the agent-can-only-request-not-mint boundary described in #1012.
+    const block = bridgeSrc.split("name: 'vault_request_access'")[1]?.split("name: '")[0] ?? ''
+    expect(block).toContain("'read'")
+    expect(block).toContain("'write'")
+    expect(block).toMatch(/duration/)
+    // Required fields: chat_id + key. Value is NOT required (this is
+    // an access request, not a save — the agent doesn't have the
+    // value, it wants permission to read it).
+    expect(block).toMatch(/required:\s*\[\s*'chat_id',\s*'key'\s*\]/)
+  })
+
+  it('gateway accepts vault_request_access in ALLOWED_TOOLS', () => {
+    // fails when: the ALLOWED_TOOLS set is touched and the entry
+    // gets dropped. Bridge would forward the call and the gateway
+    // would reject with `tool not allowed`.
+    expect(gatewaySrc).toMatch(/ALLOWED_TOOLS[\s\S]*?'vault_request_access'/)
+  })
+
+  it('gateway routes vault_request_access in executeToolCall', () => {
+    // fails when: the switch arm is dropped. Tool would be accepted
+    // by ALLOWED_TOOLS but fall through to the `unknown tool` branch.
+    expect(gatewaySrc).toMatch(/case\s+'vault_request_access':\s*\n\s*return\s+executeVaultRequestAccess/)
+  })
+
+  it('gateway dispatches vra: callback prefix', () => {
+    // fails when: the callback_query dispatcher loses the `vra:`
+    // branch. Operator taps on [Approve] / [Deny] would fall to the
+    // catch-all "unknown callback" path and the card would stay
+    // open forever.
+    expect(gatewaySrc).toMatch(/data\.startsWith\('vra:'\)/)
+    expect(gatewaySrc).toMatch(/handleVaultRequestAccessCallback/)
+  })
+
+  it('approve handler mints via broker (not direct grants.db write)', () => {
+    // fails when: someone tries to short-circuit by writing to the
+    // grants DB directly. The broker is the single point of grant
+    // issuance — bypassing it skips audit-log emission and breaks
+    // the path-as-identity ACL contract.
+    const handlerBlock = gatewaySrc.split('async function handleVaultRequestAccessCallback')[1]?.split('async function handleVaultRequestSaveCallback')[0] ?? ''
+    expect(handlerBlock).toMatch(/mintGrantViaBroker/)
+    // Description string must carry the audit breadcrumb so post-hoc
+    // forensics can tell agent-initiated grants apart from
+    // operator-host-CLI grants and from /vault audit one-tap grants.
+    expect(handlerBlock).toMatch(/vault_request_access/)
+    expect(handlerBlock).toMatch(/#1012/)
+  })
+
+  it('duration parser enforces the 90-day ceiling', () => {
+    // fails when: the cap is removed or widened without a corresponding
+    // doc/threat-model update. Agent-initiated grants must have a
+    // finite sunset; "never" must be refused outright.
+    const execBlock = gatewaySrc.split('async function executeVaultRequestAccess')[1]?.split('async function ')[0] ?? ''
+    expect(execBlock).toMatch(/NINETY_DAYS/)
+    expect(execBlock).toMatch(/90\s*\*\s*86400/)
+  })
+
+  it('approve handler is gated on the operator allowFrom list', () => {
+    // fails when: the access check is dropped. Without this gate any
+    // chat member could approve a grant — breaks the operator-only
+    // mint authority that's load-bearing for #1012's threat model.
+    const handlerBlock = gatewaySrc.split('async function handleVaultRequestAccessCallback')[1]?.split('async function handleVaultRequestSaveCallback')[0] ?? ''
+    expect(handlerBlock).toMatch(/loadAccess\(\)/)
+    expect(handlerBlock).toMatch(/allowFrom\.includes/)
+  })
+})


### PR DESCRIPTION
## Summary

- New MCP tool \`vault_request_access\` (sibling of \`vault_request_save\` from #969 P1a). The agent calls it when it hits \`VAULT-BROKER-DENIED\` or knows it'll need a key it doesn't have.
- Renders a \`🔐 <agent> wants vault access\` card with [✅ Approve] / [🚫 Deny] in the operator chat. Card auto-expires after 10 min.
- On [Approve], the gateway mints a scoped grant via \`mintGrantViaBroker\` (same path as the /vault audit one-tap allow flow from #969 P2b) and writes the token to \`~/.switchroom/agents/<agent>/.vault-token\`. The agent's next vault read just works.
- On [Deny], card edits to denied and no token is written.

## Why this is the right shape

The infrastructure was already 90% there:
- The broker already supports live grant minting via the operator socket — no broker restart needed.
- The recent-denials one-tap allow flow (#969 P2b) already mints + writes the token file from the gateway.
- The \`vault_request_save\` flow (#969 P1a) already proves the agent → operator approval-card pattern works for vault-touching ops.

Phase 1 connects the dots: it lets the AGENT initiate the request instead of the operator having to find the denial first in \`/vault audit\`.

## Threat model

- Agents can only **request** — never approve. The [Approve] callback is gated on the gateway's allowFrom operator list (same gate as the /vault audit one-tap handler).
- Agent-requested TTL is capped at 90 days; \"never\" is refused. The operator should use the host CLI for perpetual grants.
- Card carries: agent name, key, scope (read/write), duration, agent-supplied reason. Audit-log description includes \`#1012, scope=<>, by op <senderId>\` so post-hoc forensics can tell agent-initiated grants apart from operator-CLI grants and one-tap grants.
- No secret material is staged in gateway memory (this is an access request, not a save — the agent doesn't have the value).

## Out of scope (follow-ups)

- **Auto-detection of \`VAULT-BROKER-DENIED\`**: today the agent must explicitly call \`vault_request_access\`. The bot already parses denial markers (\`recent-denials.ts\` from #969 P2c); a follow-up can hook the same parser to auto-post a request card without the agent emitting the tool call.
- **Rate-limit per agent** (5 outstanding requests max in #1012's threat model): not blocking; can land as a follow-up. Currently bounded only by the 10-min TTL on staged requests.

## Test plan

- [x] \`npm run lint\` — clean.
- [x] \`npm run test:vitest\` — 5411 pass + new test (8 cases). Pre-existing 30 UAT-driver mtcute-mock failures are unrelated (confirmed with stash-pop diff).
- [x] New test pins: tool schema in bridge, ALLOWED_TOOLS membership, executeToolCall arm, \`vra:\` dispatcher branch, 90-day TTL ceiling, operator-allowlist gate.
- [ ] Post-merge dogfood: deploy to test-harness agent; have it call \`vault_request_access\` with a known-denied key; tap [Approve] in DM; verify token file lands and the next get works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)