### PR TITLE
test(jtbd): pin the talk-to-agents-from-anywhere contract as executable tests

### DIFF
--- a/tests/jtbd-talk-from-anywhere.test.ts
+++ b/tests/jtbd-talk-from-anywhere.test.ts
@@ -183,21 +183,42 @@ describe("JTBD/talk-from-anywhere — no live code path tells the operator to le
     expect(gatewaySrcWithoutAllowedPunts()).not.toMatch(/Phase \d[a-z]? will wire/i);
   });
 
-  it("no headline error punts to 'on the host'", () => {
+  it("no headline-error closer punts to 'on the host'", () => {
     // The `on the host` substring shows up in legitimate edge-recovery
     // messages (token-write failed AFTER mint succeeded) where the
-    // operator genuinely has a host-side recovery option. Those reads
+    // operator genuinely has a host-side recovery option. Those read
     // as a fallback, not a headline.
     //
     // The anti-pattern is the HEADLINE form — the first thing the
-    // operator sees on a fresh error. Match the trailing "</i>" form
-    // that the vault renderer / fallback message uses for the
-    // closer line of an error card.
+    // operator sees on a fresh error. Match the trailing-italic closer
+    // pattern (`on the host.</i>` or `on the host shell.</i>`) since
+    // that's how renderer / fallback strings sign off a card.
+    //
+    // Caveat: this guard only catches the *closer* form. A future
+    // regression that buries "on the host" in mid-sentence headline
+    // text would slip through. Two known existing matches are inside
+    // recovery-tip <i> fallbacks (gateway.ts:7941, 8046) — those use
+    // the same closer shape and remain in the allowlist via context
+    // (they're triggered by token-write-failure-after-mint, not
+    // displayed as a primary error).
     const body = gatewaySrcWithoutAllowedPunts();
-    // Match strings like "on the host.</i>" or "on the host shell" as
-    // the closer of an error message. The bare "on the host" inside a
-    // recovery-tip parenthetical is allowed.
-    expect(body).not.toMatch(/on the host shell\b/);
+    // Strip the two known fallback patterns (token-write-fail recovery
+    // tips, NOT headline errors) so the test guards genuinely new
+    // regressions.
+    const RECOVERY_FALLBACK_PATTERNS = [
+      // Recent-denials one-tap (gateway.ts:7937-7941)
+      /Recover with:.*?on the host\.<\/i>/gs,
+      // vault_request_access (gateway.ts:8042-8046)
+      /Recover with:.*?on the host\.<\/i>/gs,
+    ];
+    let stripped = body;
+    for (const pat of RECOVERY_FALLBACK_PATTERNS) {
+      stripped = stripped.replace(pat, "");
+    }
+    // After stripping documented recovery fallbacks, the closer pattern
+    // should NOT appear anywhere.
+    expect(stripped).not.toMatch(/on the host shell\b/);
+    expect(stripped).not.toMatch(/on the host\.<\/i>/);
   });
 });
 
@@ -335,6 +356,10 @@ describe("Vision/multi-agent fleet — discoverability of admin actions", () => 
     // reads. If it doesn't say "call me when you hit VAULT-BROKER-DENIED,"
     // the agent will hold on and surface a useless `VAULT-BROKER-DENIED`
     // wall-of-text to the operator instead of asking for help.
-    expect(bridgeSrc).toMatch(/VAULT-BROKER-DENIED|vault_request_access[\s\S]{0,200}denied/i);
+    // Anchor: extract the vault_request_access tool's own description
+    // block (not the entire file) so a 'denied' reference in some other
+    // schema doesn't satisfy this test by accident.
+    const accessBlock = bridgeSrc.split("name: 'vault_request_access'")[1]?.split("name: '")[0] ?? "";
+    expect(accessBlock).toMatch(/VAULT-BROKER-DENIED|denied/i);
   });
 });

--- a/tests/jtbd-talk-from-anywhere.test.ts
+++ b/tests/jtbd-talk-from-anywhere.test.ts
@@ -1,0 +1,340 @@
+/**
+ * JTBD contract tests for `reference/talk-to-agents-from-anywhere.md`.
+ *
+ * The JTBD's load-bearing line:
+ *
+ *   "Everything the user needs to steer, inspect, correct, or pause
+ *    their agents has to be reachable from a phone with one hand. If
+ *    a capability only exists on the desktop, the user is tethered,
+ *    and the product stops being theirs."
+ *
+ * Every test in this file pins one signal-it's-working from the JTBD,
+ * or rules out one named anti-pattern. Failing means we still have a
+ * "punt to terminal" somewhere in the live product. The tests get
+ * closed one at a time in follow-up PRs; the PR description for each
+ * follow-up should cite which test it makes green.
+ *
+ * **Status convention.** Tests are split into two kinds:
+ *
+ *   1. **Live regression guards** — plain `it()`. Today's contract;
+ *      passing today. A future change that breaks one of these has
+ *      *regressed* the JTBD.
+ *
+ *   2. **Punch-list items** — `it.skip()`. Today's gap; failing today.
+ *      Each is closed by a dedicated follow-up PR that (a) removes
+ *      the `.skip` and (b) makes the test pass. PR body should cite
+ *      which gap it closes.
+ *
+ * Don't make a `.skip` green by editing the test. Change the product
+ * to match, then unskip.
+ *
+ * Cross-cutting product checks:
+ *   - Principle 1 (docs test): error messages tell user what to do next.
+ *   - Principle 3 (consistency): same approval-card shape across features.
+ *   - Vision outcome 4 (always-on): "Anywhere your phone has signal,
+ *     your fleet is reachable."
+ *
+ * Read the JTBD before adding/removing a test here.
+ */
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, it, expect } from "vitest";
+
+const REPO_ROOT = resolve(__dirname, "..");
+
+const vaultErrorSrc = readFileSync(
+  resolve(REPO_ROOT, "telegram-plugin/secret-detect/vault-error.ts"),
+  "utf-8",
+);
+const gatewaySrc = readFileSync(
+  resolve(REPO_ROOT, "telegram-plugin/gateway/gateway.ts"),
+  "utf-8",
+);
+const bridgeSrc = readFileSync(
+  resolve(REPO_ROOT, "telegram-plugin/bridge/bridge.ts"),
+  "utf-8",
+);
+
+// ── Helpers ─────────────────────────────────────────────────────────────
+
+/** Extract a single rendering case block from vault-error.ts switch arm. */
+function extractRenderCase(kind: string): string {
+  const cases = [
+    "sandbox_context",
+    "needs_approval",
+    "broker_unreachable",
+    "broker_denied",
+    "other",
+  ];
+  const idx = cases.indexOf(kind);
+  if (idx < 0) throw new Error(`unknown kind: ${kind}`);
+  const next = cases[idx + 1];
+  const start = vaultErrorSrc.indexOf(`case "${kind}":`);
+  if (start < 0) throw new Error(`case "${kind}" not found in vault-error.ts`);
+  const end = next
+    ? vaultErrorSrc.indexOf(`case "${next}":`, start)
+    : vaultErrorSrc.length;
+  return vaultErrorSrc.slice(start, end > 0 ? end : vaultErrorSrc.length);
+}
+
+// ── JTBD signal: error messages tell the user what to do *in Telegram* ──
+
+describe("JTBD/talk-from-anywhere — error renderers point to in-Telegram next-steps", () => {
+  it.skip("VAULT-BROKER-DENIED mentions the Telegram-native grant flow, not just the host CLI", () => {
+    // Signs it's working: "A short reply should be enough to course-correct."
+    // Principle 1: "When something fails, does the error tell the user what to do next?"
+    //
+    // Today (vault-error.ts:189-198): renderer ends with
+    //   "Operator can grant access from a host shell:
+    //    switchroom vault grant <agent> --keys <key>"
+    //
+    // This is the gymbro screenshot. The Telegram-native paths exist
+    // — /vault audit <agent> one-tap allow (#969 P2b), and the agent
+    // can call vault_request_access (#1012). The renderer just hasn't
+    // been told.
+    const block = extractRenderCase("broker_denied");
+    expect(block).toMatch(/vault_request_access|\/vault audit/);
+  });
+
+  it.skip("VAULT-NEEDS-APPROVAL renderer drops the 'card is on the way' stub and points to the live tool", () => {
+    // Principle 1: error tells the user what to do next.
+    //
+    // Today (vault-error.ts:167-178): renderer contains the literal
+    // comment "A one-tap approval card is on the way (#969 P1a)."
+    // That card shipped months ago — `vault_request_save`. The
+    // renderer is lying.
+    const block = extractRenderCase("needs_approval");
+    expect(block, "should not say 'on the way' for a shipped feature").not.toMatch(/on the way/i);
+    expect(block, "should reference the live vault_request_save tool").toMatch(/vault_request_save/);
+  });
+
+  it.skip("VAULT-BROKER-UNREACHABLE surfaces a Telegram-reachable recovery action", () => {
+    // Vision outcome 4: "Anywhere your phone has signal, your fleet
+    // is reachable."
+    //
+    // Today (vault-error.ts:182-186): "Operator can check on the host:
+    // switchroom vault broker status." Full stop. The mobile-only
+    // operator has nothing.
+    //
+    // Closing this test requires building /vault broker {status,restart}
+    // as admin verbs that proxy through to the host. Until then this
+    // test stays red, marking the unbuilt surface.
+    const block = extractRenderCase("broker_unreachable");
+    expect(block).toMatch(/\/vault broker/);
+  });
+
+  it.skip("VAULT-SANDBOX-CONTEXT points at the in-Telegram alternative for the relevant verb", () => {
+    // Anti-pattern: "A mobile experience that's really a web view of
+    // the desktop UI."
+    //
+    // Today (vault-error.ts:155-163): "Open a host shell and run
+    // `switchroom vault <verb>`." Verbs that hit this:
+    //   - set    → vault_request_save (shipped, #969 P1a)
+    //   - get    → /vault get (shipped)
+    //   - list   → /vault list (shipped)
+    //   - remove → no Telegram equivalent yet
+    //   - init   → terminal-only (one-time bootstrap, acceptable)
+    //
+    // The renderer should drop the host-shell punt and route to the
+    // shipped Telegram path. "init" is the only legitimate edge — and
+    // even that should say "this is a one-time host-shell setup," not
+    // pretend it's the operator's job to know that.
+    const block = extractRenderCase("sandbox_context");
+    expect(block, "no blanket 'open a host shell' directive").not.toMatch(/Open a host shell/);
+    expect(block).toMatch(/vault_request_save|\/vault (get|list|delete)/);
+  });
+});
+
+// ── Anti-pattern check: live gateway never tells the user "go to a terminal" ──
+
+describe("JTBD/talk-from-anywhere — no live code path tells the operator to leave Telegram", () => {
+  // Allowed exceptions (real infra gaps, tracked separately):
+  //   - #926: `/update apply` on docker installs needs host-side daemon;
+  //     until then the renderer legitimately points at the host CLI.
+  //
+  // Add to this list ONLY if there's a tracked issue explaining why no
+  // Telegram-native path is possible. Default answer is no exception.
+  const ALLOWED_HOST_PUNTS = [
+    "run <code>switchroom update</code> from the", // #926 host-side update daemon
+  ];
+
+  function gatewaySrcWithoutAllowedPunts(): string {
+    let src = gatewaySrc;
+    for (const allowed of ALLOWED_HOST_PUNTS) {
+      src = src.split(allowed).join("");
+    }
+    return src;
+  }
+
+  it.skip("no string says 'run in terminal' anywhere in the live gateway", () => {
+    // Today (gateway.ts:8980): "Phase 4c will wire ${action} buttons.
+    // Until then, run in terminal: switchroom auth use ..."
+    //
+    // Anti-pattern: tells the operator the product is incomplete AND
+    // shoves them to the desktop. Two failures in one sentence.
+    expect(gatewaySrcWithoutAllowedPunts()).not.toMatch(/run in terminal/i);
+  });
+
+  it.skip("no string says 'Phase Nx will wire …' as a feature stub", () => {
+    // Principle 2 (defaults test): "Does this work with zero
+    // configuration?" Stub callbacks that promise future work fail.
+    // Either ship the button or remove the button.
+    expect(gatewaySrcWithoutAllowedPunts()).not.toMatch(/Phase \d[a-z]? will wire/i);
+  });
+
+  it("no headline error punts to 'on the host'", () => {
+    // The `on the host` substring shows up in legitimate edge-recovery
+    // messages (token-write failed AFTER mint succeeded) where the
+    // operator genuinely has a host-side recovery option. Those reads
+    // as a fallback, not a headline.
+    //
+    // The anti-pattern is the HEADLINE form — the first thing the
+    // operator sees on a fresh error. Match the trailing "</i>" form
+    // that the vault renderer / fallback message uses for the
+    // closer line of an error card.
+    const body = gatewaySrcWithoutAllowedPunts();
+    // Match strings like "on the host.</i>" or "on the host shell" as
+    // the closer of an error message. The bare "on the host" inside a
+    // recovery-tip parenthetical is allowed.
+    expect(body).not.toMatch(/on the host shell\b/);
+  });
+});
+
+// ── JTBD signal: every fleet-mutation has a Telegram-native shape ──
+
+describe("JTBD/talk-from-anywhere — every fleet-mutation has a Telegram-native command", () => {
+  // Each test below is the operator's "I should be able to do this from
+  // my phone" mapped to a bot.command() existence check. Failing means
+  // the command isn't built. Closing each requires its own PR.
+  //
+  // Why command-existence-checks here instead of behaviour tests? At this
+  // stage the contract is "this verb should exist." Behavioural tests
+  // come with each implementation PR.
+
+  it.skip("/agent remove — operator can drop an agent from their phone", () => {
+    // Vision outcome 2: multi-agent fleet, specialists not generalists.
+    // Fleet curation is a daily op. Today: switchroom agent destroy
+    // (CLI only).
+    expect(gatewaySrc).toMatch(/bot\.command\(['"]agent[-_ ]?remove['"]/);
+  });
+
+  it.skip("/agent admin <name> on|off — operator can grant admin verbs to an agent without SSH", () => {
+    // Bootstrap chicken-and-egg: a fresh switchroom has NO admin agents,
+    // so the user must SSH to flip the first one. This is the literal
+    // "If a capability only exists on the desktop" failure mode the
+    // JTBD names.
+    expect(gatewaySrc).toMatch(/bot\.command\(['"]agent[-_ ]?admin['"]/);
+  });
+
+  it.skip("/auth slot management is fully wired (no Phase 4c stub)", () => {
+    // Vision outcome 3: subscription-honest. Operator manages auth
+    // slots; switching the active slot today requires SSH.
+    expect(gatewaySrc).not.toMatch(/Phase 4c will wire/);
+  });
+
+  it.skip("/vault broker {status,restart} — operator can recover a dead broker", () => {
+    // Vision outcome 4 (always-on): "Crashed agents auto-recover with
+    // an audit trail. The fleet comes back on its own."
+    //
+    // The broker isn't an agent and doesn't auto-recover — when it
+    // gets stuck (locked, OOM-killed, etc.) the operator needs a
+    // hand. Today that hand is a terminal. Operator on the train
+    // sees their fleet go silent and can do nothing.
+    expect(gatewaySrc).toMatch(/vault broker (status|restart)/);
+  });
+
+  it.skip("/vault passphrase rotate — passphrase rotation works from Telegram", () => {
+    // Operator hygiene. Shell-only today.
+    // (Acceptable to phrase as `/vault rotate-passphrase` — the test
+    // matches either.)
+    expect(gatewaySrc).toMatch(/passphrase[-_ ]?rotate|rotate[-_ ]?passphrase/);
+  });
+});
+
+// ── Principle 3 (consistency): approval cards share the same shape ──
+
+describe("Principles/consistency — every operator approval card uses the same shape", () => {
+  it("every fleet-mutation approval flow uses ✅/🚫 button pair (one mind built this)", () => {
+    // "When you learn how one part works, you've learned how the rest
+    // works." Three approval flows exist:
+    //
+    //   - vault_request_save (#969 P1a) — ✅ Save once / 🚫 Discard
+    //   - vault_request_access (#1012 Phase 1) — ✅ Approve / 🚫 Deny
+    //   - /vault audit Recent denials (#969 P2b) — 🔓 Allow <key> (drift!)
+    //
+    // The third one uses 🔓 instead of ✅. That's the consistency-test
+    // failure: same operation, different emoji. Either standardise on
+    // ✅ for all confirm buttons, or document why /vault audit is
+    // different.
+    const approveButtons = gatewaySrc.match(/text:\s*['"`]✅[^'"`]+['"`]/g) ?? [];
+    const denyButtons = gatewaySrc.match(/text:\s*['"`]🚫[^'"`]+['"`]/g) ?? [];
+    // ✅ confirm buttons: at least 3 (save, access, recent-denial)
+    expect(approveButtons.length, "≥3 ✅ confirm buttons across approval flows").toBeGreaterThanOrEqual(3);
+    // 🚫 deny buttons: at least 2 (save discard, access deny)
+    expect(denyButtons.length, "≥2 🚫 cancel buttons across approval flows").toBeGreaterThanOrEqual(2);
+  });
+
+  it("every callback prefix is documented at the dispatcher (single source of truth)", () => {
+    // Today the gateway has a callback dispatcher around `data.startsWith(...)`
+    // with comments explaining each prefix. New prefixes that land
+    // without a comment are a consistency miss — future maintainers
+    // hit a `data.startsWith('xyz:')` line with no idea what it does.
+    //
+    // Test: every prefix used in a callback_data string MUST appear in
+    // the dispatcher block at the bottom of gateway.ts. Stub for now —
+    // the dispatcher list is hand-maintained, so this test is more
+    // a documentation invariant than a hard contract.
+    const prefixUses = new Set<string>();
+    for (const m of gatewaySrc.matchAll(/callback_data:\s*[`'"]([a-z]+):/gi)) {
+      prefixUses.add(m[1]!);
+    }
+    // Expected set as of #1012 Phase 1.
+    const expectedPrefixes = ["vrs", "vra", "vrd", "vd", "vg", "op"];
+    for (const p of expectedPrefixes) {
+      expect(
+        gatewaySrc,
+        `dispatcher should document the '${p}:' callback prefix at its startsWith branch`,
+      ).toMatch(new RegExp(`data\\.startsWith\\(['"\`]${p}:['"\`]\\)`));
+    }
+    // No surprise prefixes — any new one introduced without updating
+    // this list flags as a contract drift.
+    for (const p of prefixUses) {
+      // 'aq:' is the ask_user callback decoder; not a startsWith branch.
+      // Add other known exceptions here with a reason.
+      if (p === "aq") continue;
+      expect(
+        expectedPrefixes,
+        `new callback prefix '${p}:' — update jtbd-talk-from-anywhere.test.ts expectedPrefixes`,
+      ).toContain(p);
+    }
+  });
+});
+
+// ── Vision outcome 2 (multi-agent fleet): admin gating is discoverable ──
+
+describe("Vision/multi-agent fleet — discoverability of admin actions", () => {
+  it.skip("/help or /vault help mentions /vault audit and the agent vault_request_access tool", () => {
+    // Anti-pattern: "Relying on a dashboard the user has to open to see
+    // state." Sibling: relying on the user to know which tool/command
+    // exists. The bot's own help text should advertise the operator's
+    // fleet-management surface.
+    //
+    // Today: /vault help (gateway.ts:9314-9328) lists unlock/lock/set/
+    // get/delete/grant/grants/audit/status. Good for /vault. But /help
+    // (the top-level) is silent on the admin surface — a new operator
+    // discovers /vault audit only by typing /vault. Add a discoverability
+    // line to /help.
+    const helpBlock = gatewaySrc.split("bot.command('help'")[1]?.split("bot.command('")[0] ?? "";
+    expect(helpBlock, "/help should mention /vault audit for admin operators").toMatch(/\/vault audit/);
+  });
+
+  it("vault_request_access tool description tells the agent when to call it (#1012)", () => {
+    // Principle 1: "Does the CLI / Telegram surface explain the *why*,
+    // not just the *what*?" The MCP tool description is what the agent
+    // reads. If it doesn't say "call me when you hit VAULT-BROKER-DENIED,"
+    // the agent will hold on and surface a useless `VAULT-BROKER-DENIED`
+    // wall-of-text to the operator instead of asking for help.
+    expect(bridgeSrc).toMatch(/VAULT-BROKER-DENIED|vault_request_access[\s\S]{0,200}denied/i);
+  });
+});


### PR DESCRIPTION
## Summary

Adds \`tests/jtbd-talk-from-anywhere.test.ts\` — 16 contract tests that encode the JTBD signals from \`reference/talk-to-agents-from-anywhere.md\` as executable checks. Sets the scope and direction for the operator-mobile-UX work; each \`.skip\` is the rationale for a follow-up PR.

## Why

The phone-only operator JTBD is the single load-bearing JTBD for everything we've been shipping recently (#969 P1a, P2b, #1012 Phase 1, #1024–#1026). Every \"go run \`switchroom foo\` on the host\" string in the live product violates this JTBD's named anti-patterns:

> *"Everything the user needs to steer, inspect, correct, or pause their agents has to be reachable from a phone with one hand. If a capability only exists on the desktop, the user is tethered, and the product stops being theirs."*

Today we have ~12 places that still force a terminal. This PR makes that list executable, not aspirational.

## What's in the file

- **4 live regression guards** (\`it()\`) — contracts that hold today. Future PRs that regress them must explicitly turn them off.
  - approval cards use ✅ / 🚫 button pair across the three known approval flows
  - dispatcher documents every callback prefix
  - no \"on the host\" trailing the closer of a headline error message
  - \`vault_request_access\` MCP tool description tells the agent when to call it

- **12 punch-list items** (\`.skip\`) — gaps captured as tests. Each is the contract a follow-up PR's verdict will be measured against. Grouped:
  - **Vault error renderers** (4 tests): \`vault-error.ts\` still says \"run \`switchroom vault grant\` on the host\" for VAULT-BROKER-DENIED and friends. Text-only fix; closes the gymbro screenshot literally.
  - **Live gateway anti-patterns** (2 tests): no \"run in terminal\" stub, no \"Phase Nx will wire\" promise.
  - **Missing Telegram-native verbs** (5 tests): \`/agent remove\`, \`/agent admin\`, \`/auth\` slot management without the Phase 4c stub, \`/vault broker {status,restart}\`, \`/vault passphrase rotate\`.
  - **Discoverability** (1 test): \`/help\` should mention \`/vault audit\` so operators discover the admin surface.

## Test plan

- [x] \`npm run lint\` — clean.
- [x] \`npx vitest run tests/jtbd-talk-from-anywhere.test.ts\` — 4 pass + 12 skip (skips intentional; they're the punch list).
- [x] No baseline tests broken (this PR adds one new file).

## Status convention (in-file docstring)

Each \`.skip\` is unskipped by exactly one follow-up PR — the one that closes the gap. Don't unskip without changing the product. Don't \"fix\" a test by editing the assertion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)