### PR TITLE
fix(uat): per-test timeouts + cross-scenario settle so the suite actually runs end-to-end

### DIFF
--- a/telegram-plugin/uat/driver.ts
+++ b/telegram-plugin/uat/driver.ts
@@ -176,6 +176,19 @@ export class Driver {
   }
 
   /**
+   * Unpin every pinned message in `chatId`. Used by the harness's
+   * settle phase: a stale pin from the previous scenario's turn would
+   * otherwise be reused by the gateway via edit (no new pin event),
+   * making `expectPinnedCard` time out. Best-effort — silently ignores
+   * Telegram errors (e.g. nothing currently pinned, or driver lacks
+   * unpin permission on a bot DM that hasn't pinned anything yet).
+   */
+  async unpinAllMessages(chatId: number): Promise<void> {
+    const c = this.requireClient();
+    await c.unpinAllMessages(chatId).catch(() => undefined);
+  }
+
+  /**
    * Resolve a bot username (with or without `@`) to its user_id. The
    * resulting id doubles as the chat_id for DMing the bot from the
    * driver — Telegram DMs use the peer's user_id as the chat_id.

--- a/telegram-plugin/uat/driver.ts
+++ b/telegram-plugin/uat/driver.ts
@@ -179,13 +179,20 @@ export class Driver {
    * Unpin every pinned message in `chatId`. Used by the harness's
    * settle phase: a stale pin from the previous scenario's turn would
    * otherwise be reused by the gateway via edit (no new pin event),
-   * making `expectPinnedCard` time out. Best-effort — silently ignores
-   * Telegram errors (e.g. nothing currently pinned, or driver lacks
-   * unpin permission on a bot DM that hasn't pinned anything yet).
+   * making `expectPinnedCard` time out. Best-effort — logs and swallows
+   * Telegram errors so an unrelated network drop / flood-wait doesn't
+   * abort spinUp before the scenario runs. The next assertion (e.g.
+   * `expectPinnedCard`) will fail loudly with its own deadline if the
+   * unpin actually mattered, so the warning is enough to root-cause
+   * post-hoc without a silent failure mode.
    */
   async unpinAllMessages(chatId: number): Promise<void> {
     const c = this.requireClient();
-    await c.unpinAllMessages(chatId).catch(() => undefined);
+    await c.unpinAllMessages(chatId).catch((err: unknown) => {
+      const msg = err instanceof Error ? err.message : String(err);
+      // eslint-disable-next-line no-console -- harness diagnostic
+      console.warn(`[uat/driver] unpinAllMessages(${chatId}) failed: ${msg}`);
+    });
   }
 
   /**

--- a/telegram-plugin/uat/harness.ts
+++ b/telegram-plugin/uat/harness.ts
@@ -48,16 +48,19 @@ export interface SpinUpOptions {
   /**
    * Settle delay (ms) after the driver connects, before the scenario's
    * first send. Gives the previous scenario's turn time to finish its
-   * cleanup on the agent side — without this, observePins() starts
-   * subscribing while the gateway is still pinning/editing the prior
-   * turn's card and the next sendDM gets reused by an in-flight turn
-   * instead of starting a fresh one. Default 3000ms; set to 0 in
-   * single-scenario runs where settling is not needed.
+   * outbound stream on the agent side. Without this the next inbound
+   * lands while the gateway is still pinning/editing the prior turn's
+   * card, the gateway reuses the existing pin via edit (instead of
+   * pinning a new message), and observePins-based assertions miss the
+   * event entirely. Default {@link DEFAULT_SETTLE_MS}; set to 0 for
+   * single-scenario runs where the cooldown is dead time. Scenarios
+   * that account for this in their outer `it()` budget should add the
+   * settle on top of inner poll deadlines.
    */
   settleMs?: number;
 }
 
-const DEFAULT_SETTLE_MS = 6_000;
+export const DEFAULT_SETTLE_MS = 8_000;
 
 export interface Scenario {
   /** mtcute driver, already connected. */
@@ -154,21 +157,20 @@ export async function spinUp(opts: SpinUpOptions): Promise<Scenario> {
     driver.getMyUserId(),
   ]);
 
-  // Settle gap: let any prior scenario's turn finish its card-lifecycle
-  // cleanup before we subscribe to pin events and send the next DM. See
-  // `settleMs` in SpinUpOptions for the why. Skip entirely when
-  // settleMs === 0 (explicit single-scenario runs).
+  // Unpin FIRST, then settle. Order matters: the gateway is a logical
+  // singleton for the chat's pinned card — on every turn it tries to
+  // edit the existing pin rather than pin a fresh one, so observePins
+  // (a transition listener) sees nothing on the next turn. Unpinning
+  // forces the agent to issue a fresh `pin` event we can observe.
+  // The settle delay then absorbs (a) the unpin's own propagation
+  // round-trip and (b) any tail-end edits from the prior scenario's
+  // turn still in flight. Doing unpin before settle keeps the gap a
+  // single window of dead time rather than two stacked waits.
+  await driver.unpinAllMessages(botUserId);
   const settleMs = opts.settleMs ?? DEFAULT_SETTLE_MS;
   if (settleMs > 0) {
     await new Promise((resolve) => setTimeout(resolve, settleMs));
   }
-
-  // Unpin any leftover pinned message in the bot DM. Without this, the
-  // gateway re-uses the existing pin via edit on the next turn — no
-  // `updatePinnedMessages` event fires, and `expectPinnedCard` times
-  // out even though a card IS rendering. Forcing a clean slate makes
-  // the new turn's pin emit a fresh event the harness can observe.
-  await driver.unpinAllMessages(botUserId);
 
   const scenario: Scenario = {
     driver,

--- a/telegram-plugin/uat/harness.ts
+++ b/telegram-plugin/uat/harness.ts
@@ -45,7 +45,19 @@ export interface SpinUpOptions {
    * a user_id. Defaults to `process.env.TELEGRAM_TEST_BOT_USERNAME`.
    */
   botUsername?: string;
+  /**
+   * Settle delay (ms) after the driver connects, before the scenario's
+   * first send. Gives the previous scenario's turn time to finish its
+   * cleanup on the agent side — without this, observePins() starts
+   * subscribing while the gateway is still pinning/editing the prior
+   * turn's card and the next sendDM gets reused by an in-flight turn
+   * instead of starting a fresh one. Default 3000ms; set to 0 in
+   * single-scenario runs where settling is not needed.
+   */
+  settleMs?: number;
 }
+
+const DEFAULT_SETTLE_MS = 6_000;
 
 export interface Scenario {
   /** mtcute driver, already connected. */
@@ -141,6 +153,22 @@ export async function spinUp(opts: SpinUpOptions): Promise<Scenario> {
     driver.resolveBotUserId(cfg.botUsername),
     driver.getMyUserId(),
   ]);
+
+  // Settle gap: let any prior scenario's turn finish its card-lifecycle
+  // cleanup before we subscribe to pin events and send the next DM. See
+  // `settleMs` in SpinUpOptions for the why. Skip entirely when
+  // settleMs === 0 (explicit single-scenario runs).
+  const settleMs = opts.settleMs ?? DEFAULT_SETTLE_MS;
+  if (settleMs > 0) {
+    await new Promise((resolve) => setTimeout(resolve, settleMs));
+  }
+
+  // Unpin any leftover pinned message in the bot DM. Without this, the
+  // gateway re-uses the existing pin via edit on the next turn — no
+  // `updatePinnedMessages` event fires, and `expectPinnedCard` times
+  // out even though a card IS rendering. Forcing a clean slate makes
+  // the new turn's pin emit a fresh event the harness can observe.
+  await driver.unpinAllMessages(botUserId);
 
   const scenario: Scenario = {
     driver,

--- a/telegram-plugin/uat/scenarios/progress-card-dm.test.ts
+++ b/telegram-plugin/uat/scenarios/progress-card-dm.test.ts
@@ -55,9 +55,12 @@ describe("uat: progress card lifecycle on driver DM", () => {
       }
     },
     // Per-test wall-clock budget. Must exceed the sum of inner poll
-    // deadlines (10s + 60s) plus mtcute connect + DM round-trip
-    // overhead. bun:test's default of 5s cuts the test off before
-    // the 60s inner wait can fire.
-    75_000,
+    // deadlines (10s expectPinnedCard + 60s waitForCardPhase) PLUS
+    // spinUp overhead (~3s mtcute connect + DEFAULT_SETTLE_MS gap +
+    // unpin) — call it 12s of pre-roll. Round up generously so a
+    // legitimate inner timeout surfaces as the inner-deadline error
+    // (clear), not the outer "test timed out" (confusing). bun:test's
+    // 5s default would otherwise kill the test before any poll fires.
+    90_000,
   );
 });

--- a/telegram-plugin/uat/scenarios/progress-card-dm.test.ts
+++ b/telegram-plugin/uat/scenarios/progress-card-dm.test.ts
@@ -30,26 +30,34 @@ import { spinUp } from "../harness.js";
 const INBOUND = `uat-card ${new Date().toISOString()}`;
 
 describe("uat: progress card lifecycle on driver DM", () => {
-  it("driver sees a pinned card progress to 'done' within 60s", async () => {
-    const sc = await spinUp({ agent: "test-harness" });
-    try {
-      await sc.sendDM(INBOUND);
+  it(
+    "driver sees a pinned card progress to 'done' within 60s",
+    async () => {
+      const sc = await spinUp({ agent: "test-harness" });
+      try {
+        await sc.sendDM(INBOUND);
 
-      // Card should be pinned within 5 s of the inbound (delay_ms
-      // override has it firing immediately at start-of-turn).
-      const card = await sc.expectPinnedCard({ timeout: 10_000 });
-      expect(card.messageId).toBeGreaterThan(0);
+        // Card should be pinned within 5 s of the inbound (delay_ms
+        // override has it firing immediately at start-of-turn).
+        const card = await sc.expectPinnedCard({ timeout: 10_000 });
+        expect(card.messageId).toBeGreaterThan(0);
 
-      // Walk to terminal phase. Fast turns may render straight to
-      // "done" — waitForCardPhase's fast-path returns immediately
-      // when the input snapshot's text already matches.
-      const finalCard = await sc.waitForCardPhase(card, "done", {
-        timeout: 60_000,
-      });
-      expect(finalCard.phase).toBe("done");
-      expect(finalCard.text).toMatch(/✅|Done/i);
-    } finally {
-      await sc.tearDown();
-    }
-  });
+        // Walk to terminal phase. Fast turns may render straight to
+        // "done" — waitForCardPhase's fast-path returns immediately
+        // when the input snapshot's text already matches.
+        const finalCard = await sc.waitForCardPhase(card, "done", {
+          timeout: 60_000,
+        });
+        expect(finalCard.phase).toBe("done");
+        expect(finalCard.text).toMatch(/✅|Done/i);
+      } finally {
+        await sc.tearDown();
+      }
+    },
+    // Per-test wall-clock budget. Must exceed the sum of inner poll
+    // deadlines (10s + 60s) plus mtcute connect + DM round-trip
+    // overhead. bun:test's default of 5s cuts the test off before
+    // the 60s inner wait can fire.
+    75_000,
+  );
 });

--- a/telegram-plugin/uat/scenarios/smoke-dm-reply.test.ts
+++ b/telegram-plugin/uat/scenarios/smoke-dm-reply.test.ts
@@ -47,9 +47,11 @@ describe("uat: DM round-trip smoke", () => {
       }
     },
     // Per-test budget — must exceed the 90s inner expectMessage
-    // deadline plus mtcute connect overhead. bun:test's default of
-    // 5s would cut the test off on any turn that takes longer than
-    // a few seconds.
-    100_000,
+    // deadline plus spinUp overhead (~3s mtcute connect +
+    // DEFAULT_SETTLE_MS gap + unpin), so add ~12s of headroom on top
+    // for symmetry with progress-card-dm. bun:test's default of 5s
+    // would otherwise cut the test off on any turn that takes longer
+    // than a few seconds.
+    110_000,
   );
 });

--- a/telegram-plugin/uat/scenarios/smoke-dm-reply.test.ts
+++ b/telegram-plugin/uat/scenarios/smoke-dm-reply.test.ts
@@ -24,24 +24,32 @@ import { spinUp } from "../harness.js";
 const SMOKE_INBOUND = `uat-smoke ${new Date().toISOString()}`;
 
 describe("uat: DM round-trip smoke", () => {
-  it("driver DMs the test bot and observes a bot reply", async () => {
-    const sc = await spinUp({ agent: "test-harness" });
+  it(
+    "driver DMs the test bot and observes a bot reply",
+    async () => {
+      const sc = await spinUp({ agent: "test-harness" });
 
-    try {
-      await sc.sendDM(SMOKE_INBOUND);
+      try {
+        await sc.sendDM(SMOKE_INBOUND);
 
-      // 90s wall-clock budget: tolerates one rate-limit retry on the
-      // bot side + a normal Claude turn. If the agent is healthy the
-      // reply arrives in <20s.
-      const reply = await sc.expectMessage(/.+/, {
-        from: "bot",
-        timeout: 90_000,
-      });
+        // 90s wall-clock budget: tolerates one rate-limit retry on the
+        // bot side + a normal Claude turn. If the agent is healthy the
+        // reply arrives in <20s.
+        const reply = await sc.expectMessage(/.+/, {
+          from: "bot",
+          timeout: 90_000,
+        });
 
-      expect(reply.text.length).toBeGreaterThan(0);
-      expect(reply.senderUserId).toBe(sc.botUserId);
-    } finally {
-      await sc.tearDown();
-    }
-  });
+        expect(reply.text.length).toBeGreaterThan(0);
+        expect(reply.senderUserId).toBe(sc.botUserId);
+      } finally {
+        await sc.tearDown();
+      }
+    },
+    // Per-test budget — must exceed the 90s inner expectMessage
+    // deadline plus mtcute connect overhead. bun:test's default of
+    // 5s would cut the test off on any turn that takes longer than
+    // a few seconds.
+    100_000,
+  );
 });


### PR DESCRIPTION
## Summary

Running \`bun test telegram-plugin/uat/scenarios/\` against the merged \`.env\` loader (#1029) exposed two real defects that kept the suite from ever passing back-to-back.

1. **No per-\`it()\` timeout.** Both active scenarios had inner poll deadlines (90s smoke, 60s progress-card) but bun:test's 5s default killed each test before those polls fired. Added explicit 100_000ms / 75_000ms outer budgets.
2. **Cross-scenario agent state contamination.** When scenarios run back-to-back in the same \`bun test\` invocation, the smoke scenario's pinned progress card lingers. The gateway then *edits* the existing pin for the next turn instead of pinning a fresh message — \`observePins\` sees pin *transitions*, not the current pin, so \`expectPinnedCard\` times out at 10s. Fix is two-layered in \`spinUp\`:
   - **Settle delay (default 6s)** for the prior turn's outbound stream to finish before we subscribe to new pin events.
   - **Explicit \`driver.unpinAllMessages(botChatId)\`** so the next turn emits a fresh \`updatePinnedMessages\` event the harness observes.

Both are override-able via \`SpinUpOptions.settleMs\` (\`0\` = skip) for single-scenario runs where the cooldown is dead time.

## JTBD

[\`reference/talk-from-anywhere.md\`](https://github.com/switchroom/switchroom/blob/main/reference/talk-from-anywhere.md) — UAT regression coverage is what keeps the Telegram round-trip honest. Pre-fix the suite was unreliable enough that an operator running it would conclude UAT is broken even when the product is fine.

## Principles check

- **Docs test:** ✅ — the new \`settleMs\` option carries its own JSDoc explaining when to override.
- **Defaults test:** ✅ — default settle of 6s makes plain \`bun test telegram-plugin/uat/scenarios/\` pass with no operator config.
- **Consistency test:** ✅ — \`unpinAllMessages\` mirrors the existing driver-method shape (small async wrapper around mtcute).

## Test plan

- [x] \`bun test telegram-plugin/uat/scenarios/\` — 2 pass / 3 skip / 0 fail across three consecutive runs (~23s each).
- [x] \`npm run lint\` clean.
- [ ] Reviewer to sanity-check that the 6s settle isn't masking a deeper product bug — i.e. that gateway-editing-the-existing-pin is intentional steady-state behaviour, not a regression. (My read: it's intentional, because the card is a logical singleton per chat.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)