### PR TITLE
ci(buildkite): drop redundant telegram-plugin install so vi.mock("@mtcute/node") takes

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -114,9 +114,22 @@ steps:
       fi
       export PATH="$$HOME/.bun/bin:$$PATH"
       bun install --frozen-lockfile --prefer-offline --no-progress
-      # vitest also runs telegram-plugin/tests/*.test.ts (excluding bun-only
-      # history.test.ts) for cross-package coverage, so install plugin deps.
-      (cd telegram-plugin && bun install --frozen-lockfile --prefer-offline --no-progress)
+      # Note: do NOT separately `(cd telegram-plugin && bun install …)`.
+      # `telegram-plugin` is a workspace of the root (see /package.json
+      # "workspaces"), so the root install above already brings in its
+      # deps. A second install creates `telegram-plugin/node_modules/
+      # @mtcute/node` as a shadow path; Node-style resolution from
+      # `telegram-plugin/uat/driver.ts` then walks up to that closer
+      # copy instead of the hoisted one, while `tests/uat-driver.test.ts`
+      # resolves `@mtcute/node` to the hoisted root copy. They become
+      # two physically distinct modules — `vi.mock("@mtcute/node")`
+      # only intercepts the test's copy, the driver's import escapes
+      # the mock, and every Driver.connect() blows up with "Invalid
+      # session string" instead of being mocked. This step was hard-red
+      # on main for 10+ commits before the redundant install was
+      # removed; if you find yourself wanting to re-add it, the
+      # cross-package coverage it was supposedly enabling is already
+      # provided by the hoisted root install.
       # Build dist/ before tests. Several integration tests under tests/
       # (cli.issues.test.ts, run-hook.test.ts, boot-self-test.test.ts) shell
       # out to dist/cli/switchroom.js to exercise the same binary path


### PR DESCRIPTION
## Summary

The \`:vitest: Core tests\` step has been **hard-red on every main commit for the last 10+ PRs**. Root cause: a redundant \`(cd telegram-plugin && bun install …)\` after the root install. Because \`telegram-plugin\` is already a workspace of the root, the second install only adds a duplicate \`telegram-plugin/node_modules/@mtcute/node\` — which sits closer in module-resolution to \`telegram-plugin/uat/driver.ts\` than the hoisted root copy.

The result: \`tests/uat-driver.test.ts\` resolves \`@mtcute/node\` to the root copy, the driver resolves it to the plugin-local copy, they're two physically distinct modules, and \`vi.mock("@mtcute/node")\` only intercepts the test's copy. Every \`Driver.connect()\` call escapes the mock and blows up against the real mtcute parser with \`Invalid session string\`.

Why neither check-tree surfaced it: \`docker-e2e\` GHA workflow only runs \`vitest run tests/docker/\`, not the full Core suite. So the PR-level GitHub checks went green while buildkite stayed red on every merge to main.

## JTBD

[\`reference/principles.md\`](https://github.com/switchroom/switchroom/blob/main/reference/principles.md) §3 (Consistency) — the test-passing baseline should be one click, not "git CI is green but buildkite isn't, ignore that one." This restores parity.

## Test plan

- [x] Local vitest with the duplicate install removed: 5441 pass / 0 fail / 1 skip.
- [x] Local vitest with the duplicate install in place reproduces the failure (30 of 34 \`tests/uat-driver.test.ts\` cases fail with \`Invalid session string\`).
- [ ] Buildkite Core tests step expected to go green on this PR — the moment of truth.

## Principles check

- **Docs test:** ✅ — long inline warning comment explains why never to re-add the install.
- **Defaults test:** ✅ — no operator config touched.
- **Consistency test:** ✅ — buildkite + GHA tree of checks become consistently green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)