### PR TITLE
test(vault-broker): pin auto-unlock machine-bound path so suite is hermetic on operator machines

### DIFF
--- a/src/vault/broker/auto-unlock.test.ts
+++ b/src/vault/broker/auto-unlock.test.ts
@@ -91,6 +91,7 @@ describe("_tryAutoUnlockFromCredentials", () => {
   // Save/restore env vars touched across tests
   let prevCredsDir: string | undefined;
   let prevNonLinux: string | undefined;
+  let prevAutoUnlockPath: string | undefined;
 
   beforeEach(() => {
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "auto-unlock-test-"));
@@ -103,8 +104,23 @@ describe("_tryAutoUnlockFromCredentials", () => {
 
     prevCredsDir = process.env.CREDENTIALS_DIRECTORY;
     prevNonLinux = process.env.SWITCHROOM_BROKER_ALLOW_NON_LINUX;
+    prevAutoUnlockPath = process.env.SWITCHROOM_VAULT_BROKER_AUTO_UNLOCK_PATH;
     // Silence stderr noise from auto-unlock log lines
     process.env.SWITCHROOM_BROKER_ALLOW_NON_LINUX = "1";
+    // Pin the machine-bound auto-unlock path inside the test's tmpDir so
+    // the broker's `_tryAutoUnlockFromMachineBoundFile()` short-circuits
+    // (file doesn't exist) and falls through to the systemd-credentials
+    // path that this suite is actually exercising. Without this, on an
+    // operator's machine where `~/.switchroom/vault-auto-unlock` IS
+    // present, the broker reads the OPERATOR'S real blob, decrypts it
+    // with the host's machine-id, applies the operator's real
+    // passphrase to the test's fixture vault, and fails with a
+    // misleading "vault rejected the passphrase" — case 2 was hard-red
+    // on every developer machine running this suite for that reason.
+    process.env.SWITCHROOM_VAULT_BROKER_AUTO_UNLOCK_PATH = path.join(
+      tmpDir,
+      "vault-auto-unlock-nonexistent",
+    );
   });
 
   afterEach(() => {
@@ -123,6 +139,11 @@ describe("_tryAutoUnlockFromCredentials", () => {
       delete process.env.SWITCHROOM_BROKER_ALLOW_NON_LINUX;
     } else {
       process.env.SWITCHROOM_BROKER_ALLOW_NON_LINUX = prevNonLinux;
+    }
+    if (prevAutoUnlockPath === undefined) {
+      delete process.env.SWITCHROOM_VAULT_BROKER_AUTO_UNLOCK_PATH;
+    } else {
+      process.env.SWITCHROOM_VAULT_BROKER_AUTO_UNLOCK_PATH = prevAutoUnlockPath;
     }
   });
 


### PR DESCRIPTION
## Summary

\`src/vault/broker/auto-unlock.test.ts\` case 2 has been hard-red on every developer machine where vault auto-unlock is enabled (i.e. every v0.7+ install). The test's \`beforeEach\` creates a hermetic fixture vault with a known \`FIXTURE_PASSPHRASE\`, but the broker's \`_tryAutoUnlockFromMachineBoundFile()\` short-circuits before \`_tryAutoUnlockFromSystemdCredentials\` runs — and \`DEFAULT_AUTO_UNLOCK_PATH\` resolves to \`~/.switchroom/vault-auto-unlock\`, which on an operator's machine is the OPERATOR'S real auto-unlock blob. The broker decrypts it with the host machine-id, applies the operator's REAL passphrase to the test's fixture vault, and fails with a misleading "vault rejected the passphrase".

Fix: in \`beforeEach\`, set \`SWITCHROOM_VAULT_BROKER_AUTO_UNLOCK_PATH\` to a tmpDir-relative non-existent path. The broker's resolution order honors the env var first, finds nothing, returns false, and falls through to \`_tryAutoUnlockFromSystemdCredentials\` — which is the path this suite is actually exercising. \`afterEach\` restores the prior value.

## Why this wasn't gating CI

GHA \`docker-e2e\` workflow only runs vitest (not bun test). \`src/vault/broker/auto-unlock.test.ts\` is in \`test:bun\` because it imports \`bun:sqlite\` transitively. So the failure has been silent in CI tree-of-checks but visible every time anyone runs \`npm run test:bun\` locally.

## Test plan

- [x] \`bun test src/vault/broker/auto-unlock.test.ts\` → 4 pass / 0 fail (was 3 pass / 1 fail).
- [x] \`npm run lint\` clean.

## Principles check

- **Docs test:** ✅ — beforeEach now has a comment explaining the resolution-order rationale.
- **Defaults test:** ✅ — test-only change, no production behaviour touched.
- **Consistency test:** ✅ — matches the existing env-restore pattern for CREDENTIALS_DIRECTORY and SWITCHROOM_BROKER_ALLOW_NON_LINUX in the same file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)