### PR TITLE
feat(vault): tap-to-unlock-and-approve on vault_request_access cards

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -1395,6 +1395,20 @@ type PendingVaultOp =
   // Issue #969 P1a: user tapped "Rename" on a vault_request_save card;
   // the next message becomes the new key name for the staged save.
   | { kind: 'rename-vault-save'; stageId: string; startedAt: number }
+  // Issue #1012 Phase 2 follow-up: operator tapped Approve on a
+  // vault_request_access card without first unlocking the vault. The
+  // next message becomes the passphrase — we cache it, delete the
+  // passphrase message, and auto-resume the approval mint flow without
+  // making the operator tap Approve a second time. Mirrors the
+  // `passphrase-for-deferred` flow from #44.
+  | {
+      kind: 'passphrase-for-access-approve'
+      stageId: string
+      cardChatId: string
+      cardMessageId: number
+      senderId: string
+      startedAt: number
+    }
 const VAULT_INPUT_TTL_MS = 5 * 60 * 1000
 const pendingVaultOps = new Map<string, PendingVaultOp>()
 
@@ -5106,6 +5120,37 @@ async function handleInbound(
         vaultPassphraseCache.set(chat_id, { passphrase, expiresAt: Date.now() + VAULT_PASSPHRASE_TTL_MS })
         if (msgId != null) await deleteSensitiveMessage(chat_id, msgId, 'vault passphrase')
         await executeDeferredSecretSave(ctx, pendingVault.deferKey, passphrase, pendingVault.cardMessageId)
+      } else if (pendingVault.kind === 'passphrase-for-access-approve') {
+        // #1012 Phase 2 follow-up: operator tapped Approve on a
+        // vault_request_access card without first unlocking. We
+        // captured the next message as the passphrase, cache it,
+        // delete the chat copy, and resume the approve flow.
+        // Wrong passphrase surfaces via the broker's
+        // DENIED:passphrase-mismatch path and edits the card to the
+        // mint_grant-failed message (see performVaultAccessApproval).
+        const passphrase = text.trim()
+        if (!passphrase) {
+          await switchroomReply(ctx, 'Passphrase cannot be empty. Ask the agent to re-issue the request card.', { html: true })
+          return
+        }
+        vaultPassphraseCache.set(chat_id, { passphrase, expiresAt: Date.now() + VAULT_PASSPHRASE_TTL_MS })
+        if (msgId != null) await deleteSensitiveMessage(chat_id, msgId, 'vault passphrase')
+        const stagedAccess = pendingVaultRequestAccesses.get(pendingVault.stageId)
+        if (!stagedAccess) {
+          // Staged entry expired between tap and passphrase reply.
+          // The 10-min TTL is generous but not infinite; surface a
+          // clear next step.
+          await ctx.api
+            .editMessageText(
+              pendingVault.cardChatId,
+              pendingVault.cardMessageId,
+              `⌛ <i>Vault unlocked, but this access-request card expired before you replied. Ask the agent to re-issue.</i>`,
+              { parse_mode: 'HTML', reply_markup: { inline_keyboard: [] } },
+            )
+            .catch(() => {})
+          return
+        }
+        await performVaultAccessApproval(ctx, stagedAccess, pendingVault.stageId, pendingVault.senderId, passphrase)
       } else if (pendingVault.kind === 'grant-wizard' && pendingVault.awaitingCustomDuration) {
         // Issue #227: custom duration text reply for grant wizard
         const input = text.trim()
@@ -7962,6 +8007,86 @@ async function handleVaultRecentDenialCallback(ctx: Context, data: string): Prom
  * Same authorization gate as the recent-denials one-tap handler:
  * sender must be on the gateway's allowFrom list.
  */
+/**
+ * Mint the scoped grant + write the token file for an approved
+ * `vault_request_access` request. Factored out so both the direct
+ * approve-tap (passphrase already cached) and the
+ * `passphrase-for-access-approve` resume flow (passphrase captured
+ * via text-message intercept after tap-on-locked) drive identical
+ * minting behaviour. #1012 Phase 2 + follow-up.
+ */
+async function performVaultAccessApproval(
+  ctx: Context,
+  pending: PendingVaultRequestAccess,
+  stageId: string,
+  senderId: string,
+  passphrase: string,
+): Promise<void> {
+  const mintArgs: Parameters<typeof mintGrantViaBroker>[0] = {
+    agent: pending.agent,
+    keys: pending.scope === 'read' ? [pending.key] : [],
+    ttl_seconds: pending.ttl_seconds,
+    description: `auto-mint via vault_request_access (#1012, scope=${pending.scope}, by op ${senderId})`,
+    ...(pending.scope === 'write' ? { write_keys: [pending.key] } : {}),
+    passphrase,
+  }
+  const result = await mintGrantViaBroker(mintArgs)
+  if (result.kind === 'unreachable') {
+    await switchroomReply(ctx, `🔴 Broker unreachable: ${escapeHtmlForTg(result.msg)}`, { html: true })
+    return
+  }
+  if (result.kind === 'error') {
+    // Mint refused (most likely wrong passphrase). Drop the staged
+    // request so a re-attempt starts cleanly. The operator can ask
+    // the agent to re-issue, or the broker error message will tell
+    // them the next step.
+    pendingVaultRequestAccesses.delete(stageId)
+    if (pending.card_message_id != null) {
+      await ctx.api
+        .editMessageText(
+          pending.chat_id,
+          pending.card_message_id,
+          `<b>mint_grant failed:</b> ${escapeHtmlForTg(result.msg)}`,
+          { parse_mode: 'HTML', reply_markup: { inline_keyboard: [] } },
+        )
+        .catch(() => {})
+    }
+    return
+  }
+
+  const { token, id } = result
+  const tokenPath = join(homedir(), '.switchroom', 'agents', pending.agent, '.vault-token')
+  try {
+    mkdirSync(join(homedir(), '.switchroom', 'agents', pending.agent), { recursive: true })
+    writeFileSync(tokenPath, token, { mode: 0o600 })
+  } catch (err) {
+    await switchroomReply(
+      ctx,
+      `<b>Grant created (${escapeHtmlForTg(id)}) but token write failed:</b> ` +
+      `${escapeHtmlForTg(String(err))}\n` +
+      `<i>Recover with: <code>switchroom vault grant ${escapeHtmlForTg(pending.agent)} ` +
+      `--keys ${escapeHtmlForTg(pending.key)} --duration ${Math.round(pending.ttl_seconds / 86400)}d</code> on the host.</i>`,
+      { html: true },
+    )
+    return
+  }
+
+  pendingVaultRequestAccesses.delete(stageId)
+  if (pending.card_message_id != null) {
+    const days = Math.round(pending.ttl_seconds / 86400)
+    await ctx.api
+      .editMessageText(
+        pending.chat_id,
+        pending.card_message_id,
+        `✅ Granted <b>${escapeHtmlForTg(pending.agent)}</b> ${pending.scope} access to ` +
+        `<code>${escapeHtmlForTg(pending.key)}</code> for ${days}d. ` +
+        `(grant <code>${escapeHtmlForTg(id)}</code>)`,
+        { parse_mode: 'HTML', reply_markup: { inline_keyboard: [] } },
+      )
+      .catch(() => {})
+  }
+}
+
 async function handleVaultRequestAccessCallback(ctx: Context, data: string): Promise<void> {
   const senderId = String(ctx.from?.id ?? '')
   const access = loadAccess()
@@ -8009,86 +8134,42 @@ async function handleVaultRequestAccessCallback(ctx: Context, data: string): Pro
   }
 
   if (action === 'approve') {
-    await ctx.answerCallbackQuery({ text: '⏳ Minting grant…' }).catch(() => {})
-
-    // Attach the cached operator passphrase as broker attestation
-    // (#1012 Phase 2). Required when this handler runs in a NON-admin
-    // agent's gateway — the broker server-side allowlist (#1022) only
-    // trusts operator-socket and admin-agent paths for grant-mgmt
-    // ops. Passphrase attestation is the third trust posture, mirroring
-    // PUT (#969 P1a) — same shape, same threat surface.
-    //
-    // If the operator hasn't unlocked the vault in this chat yet,
-    // refuse before calling the broker: a non-admin agent's mint
-    // attempt without attestation would surface the same
-    // "agent-bound listeners cannot mint" error gymbro hit on the
-    // first run (screenshot in #1012 follow-up).
+    // Tap-to-unlock-and-approve: if the operator hasn't unlocked the
+    // vault in this chat yet, capture the passphrase via a pending op
+    // intercept and resume the approve flow automatically once it
+    // arrives — no second tap, no separate /vault unlock detour.
+    // Mirrors the `passphrase-for-deferred` flow from #44.
     const cached = vaultPassphraseCache.get(pending.chat_id)
     if (!cached || cached.expiresAt <= Date.now()) {
-      if (pending.card_message_id != null) {
-        await ctx.api
-          .editMessageText(
-            pending.chat_id,
-            pending.card_message_id,
-            `🔒 <b>Vault is locked.</b> Run <code>/vault unlock</code> (or any /vault command) in this chat to cache the passphrase, then ask the agent to re-issue the request card.\n\n` +
-            `<i>Approval needs operator-passphrase attestation — without it the broker refuses grant-mgmt from a non-admin agent.</i>`,
-            { parse_mode: 'HTML', reply_markup: { inline_keyboard: [] } },
-          )
+      if (pending.card_message_id == null) {
+        await ctx
+          .answerCallbackQuery({ text: 'Card missing — ask the agent to re-issue.' })
           .catch(() => {})
+        return
       }
-      pendingVaultRequestAccesses.delete(stageId)
-      return
-    }
-
-    const mintArgs: Parameters<typeof mintGrantViaBroker>[0] = {
-      agent: pending.agent,
-      keys: pending.scope === 'read' ? [pending.key] : [],
-      ttl_seconds: pending.ttl_seconds,
-      description: `auto-mint via vault_request_access (#1012, scope=${pending.scope}, by op ${senderId})`,
-      ...(pending.scope === 'write' ? { write_keys: [pending.key] } : {}),
-      passphrase: cached.passphrase,
-    }
-    const result = await mintGrantViaBroker(mintArgs)
-    if (result.kind === 'unreachable') {
-      await switchroomReply(ctx, `🔴 Broker unreachable: ${escapeHtmlForTg(result.msg)}`, { html: true })
-      return
-    }
-    if (result.kind === 'error') {
-      await switchroomReply(ctx, `<b>mint_grant failed:</b> ${escapeHtmlForTg(result.msg)}`, { html: true })
-      return
-    }
-
-    const { token, id } = result
-    const tokenPath = join(homedir(), '.switchroom', 'agents', pending.agent, '.vault-token')
-    try {
-      mkdirSync(join(homedir(), '.switchroom', 'agents', pending.agent), { recursive: true })
-      writeFileSync(tokenPath, token, { mode: 0o600 })
-    } catch (err) {
-      await switchroomReply(
-        ctx,
-        `<b>Grant created (${escapeHtmlForTg(id)}) but token write failed:</b> ` +
-        `${escapeHtmlForTg(String(err))}\n` +
-        `<i>Recover with: <code>switchroom vault grant ${escapeHtmlForTg(pending.agent)} ` +
-        `--keys ${escapeHtmlForTg(pending.key)} --duration ${Math.round(pending.ttl_seconds / 86400)}d</code> on the host.</i>`,
-        { html: true },
-      )
-      return
-    }
-
-    pendingVaultRequestAccesses.delete(stageId)
-    if (pending.card_message_id != null) {
-      const days = Math.round(pending.ttl_seconds / 86400)
+      pendingVaultOps.set(pending.chat_id, {
+        kind: 'passphrase-for-access-approve',
+        stageId,
+        cardChatId: pending.chat_id,
+        cardMessageId: pending.card_message_id,
+        senderId,
+        startedAt: Date.now(),
+      })
+      await ctx.answerCallbackQuery({ text: '🔐 Send your passphrase…' }).catch(() => {})
       await ctx.api
         .editMessageText(
           pending.chat_id,
           pending.card_message_id,
-          `✅ Granted <b>${escapeHtmlForTg(pending.agent)}</b> ${pending.scope} access to ` +
-          `<code>${escapeHtmlForTg(pending.key)}</code> for ${days}d. ` +
-          `(grant <code>${escapeHtmlForTg(id)}</code>)`,
+          `🔐 <b>Vault is locked.</b> Reply with your passphrase as your next message — we'll unlock, mint the grant for <b>${escapeHtmlForTg(pending.agent)}</b>, and delete the passphrase message in one step.\n\n` +
+          `<i>Mint authority stays operator-only: the broker only accepts the grant when the passphrase matches.</i>`,
           { parse_mode: 'HTML', reply_markup: { inline_keyboard: [] } },
         )
         .catch(() => {})
+      return
     }
+
+    await ctx.answerCallbackQuery({ text: '⏳ Minting grant…' }).catch(() => {})
+    await performVaultAccessApproval(ctx, pending, stageId, senderId, cached.passphrase)
     return
   }
 

--- a/telegram-plugin/tests/vault-request-access-tool.test.ts
+++ b/telegram-plugin/tests/vault-request-access-tool.test.ts
@@ -77,13 +77,21 @@ describe('vault_request_access (#1012)', () => {
     // grants DB directly. The broker is the single point of grant
     // issuance — bypassing it skips audit-log emission and breaks
     // the path-as-identity ACL contract.
-    const handlerBlock = gatewaySrc.split('async function handleVaultRequestAccessCallback')[1]?.split('async function handleVaultRequestSaveCallback')[0] ?? ''
-    expect(handlerBlock).toMatch(/mintGrantViaBroker/)
+    //
+    // The mint call lives in performVaultAccessApproval — the helper
+    // factored out so both the direct-approve path AND the
+    // tap-on-locked → passphrase-resume path drive identical minting
+    // (see telegram-plugin/tests/vault-request-access-unlock-resume.test.ts).
+    const mintHelperBlock =
+      gatewaySrc
+        .split('async function performVaultAccessApproval')[1]
+        ?.split('async function handleVaultRequestAccessCallback')[0] ?? ''
+    expect(mintHelperBlock).toMatch(/mintGrantViaBroker/)
     // Description string must carry the audit breadcrumb so post-hoc
     // forensics can tell agent-initiated grants apart from
     // operator-host-CLI grants and from /vault audit one-tap grants.
-    expect(handlerBlock).toMatch(/vault_request_access/)
-    expect(handlerBlock).toMatch(/#1012/)
+    expect(mintHelperBlock).toMatch(/vault_request_access/)
+    expect(mintHelperBlock).toMatch(/#1012/)
   })
 
   it('duration parser enforces the 90-day ceiling', () => {

--- a/telegram-plugin/tests/vault-request-access-unlock-resume.test.ts
+++ b/telegram-plugin/tests/vault-request-access-unlock-resume.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Contract pin for the tap-to-unlock-and-approve flow added on top of
+ * #1012 Phase 2 (#1030 broker passphrase-attested mint_grant).
+ *
+ * Before this PR: tapping Approve on a vault_request_access card
+ * without first unlocking the vault edited the card to "🔒 Vault is
+ * locked. Run /vault unlock... then ask the agent to re-issue." The
+ * operator had to (a) clear that card, (b) /vault unlock, (c) ask
+ * the agent to re-emit the request, (d) tap Approve again. Four steps
+ * for one decision.
+ *
+ * After this PR: the cache-miss tap keeps the card open, prompts for
+ * the passphrase as the next message, captures+caches it, deletes the
+ * passphrase message from chat, then auto-resumes the mint. One tap
+ * + one reply = one grant.
+ *
+ * Mirrors the `passphrase-for-deferred` flow from #44 (deferred-secret
+ * card's "🔓 Unlock vault & save"). Same idiom, same trust posture.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+const gatewaySrc = readFileSync(
+  resolve(__dirname, '..', 'gateway', 'gateway.ts'),
+  'utf-8',
+)
+
+describe('vault_request_access — tap-to-unlock-and-approve UX', () => {
+  it('declares the passphrase-for-access-approve PendingVaultOp variant', () => {
+    // fails when: the new PendingVaultOp kind is dropped. The
+    // resume flow leans on this discriminator — without it the
+    // text handler can't route the passphrase reply back to the
+    // staged request.
+    expect(gatewaySrc).toMatch(/kind:\s*['"]passphrase-for-access-approve['"]/)
+  })
+
+  it('Approve on a locked vault stages a passphrase prompt instead of clearing the card', () => {
+    // fails when: the cache-miss branch reverts to the old behaviour
+    // of editing the card to "ask the agent to re-issue." That UX
+    // is the four-step workaround we just replaced.
+    //
+    // Anchor: the approve-action block inside handleVaultRequestAccessCallback.
+    const approveBlock =
+      gatewaySrc.split('if (action === \'approve\')')[1]?.split('await ctx.answerCallbackQuery({ text: \'Unknown action\'')[0] ?? ''
+    expect(approveBlock).toMatch(/pendingVaultOps\.set/)
+    expect(approveBlock).toMatch(/passphrase-for-access-approve/)
+    // Card text must invite a passphrase reply, not punt to a
+    // /vault unlock detour.
+    expect(approveBlock).toMatch(/Reply with your passphrase/i)
+    // The "ask the agent to re-issue the request card" copy belonged
+    // to the pre-fix path. Should be gone from the cache-miss branch.
+    expect(approveBlock).not.toMatch(/ask the agent to re-issue the request card/)
+  })
+
+  it('passphrase intercept deletes the chat message and resumes mint', () => {
+    // fails when: the new pending-op handler stops calling
+    // deleteSensitiveMessage on the passphrase message OR stops
+    // routing into performVaultAccessApproval. Both are load-bearing:
+    //   - delete: prevents the passphrase from lingering in chat history
+    //   - resume: closes the "one decision" UX promise
+    //
+    // Anchor: the text-handler branch keyed on the new kind.
+    const handlerBlock =
+      gatewaySrc
+        .split("pendingVault.kind === 'passphrase-for-access-approve'")[1]
+        ?.split("pendingVault.kind === 'grant-wizard'")[0] ?? ''
+    expect(handlerBlock).toMatch(/deleteSensitiveMessage/)
+    expect(handlerBlock).toMatch(/performVaultAccessApproval/)
+    // Cache the passphrase so future operations in the same chat
+    // don't re-prompt within the TTL window.
+    expect(handlerBlock).toMatch(/vaultPassphraseCache\.set/)
+  })
+
+  it('expired-stage path edits the card cleanly, does not silently drop', () => {
+    // fails when: the resume path forgets to handle the edge case
+    // where the staged access entry's 10-min TTL elapsed between
+    // tap-on-locked and passphrase reply. Without this branch the
+    // operator types their passphrase, gets nothing visible back,
+    // and is confused about whether their secret leaked.
+    const handlerBlock =
+      gatewaySrc
+        .split("pendingVault.kind === 'passphrase-for-access-approve'")[1]
+        ?.split("pendingVault.kind === 'grant-wizard'")[0] ?? ''
+    expect(handlerBlock).toMatch(/expired before you replied|expired/)
+    expect(handlerBlock).toMatch(/editMessageText/)
+  })
+
+  it('mint failure (e.g. wrong passphrase) edits the card; does not silent-drop', () => {
+    // fails when: performVaultAccessApproval's error branch returns
+    // without editing the card. Without the edit, a wrong-passphrase
+    // attempt leaves the locked-vault prompt on screen forever and
+    // the operator can't tell whether the system saw their reply.
+    //
+    // Anchor: performVaultAccessApproval's `result.kind === 'error'`
+    // branch.
+    const mintHelper =
+      gatewaySrc.split('async function performVaultAccessApproval')[1]?.split('async function handleVaultRequestAccessCallback')[0] ?? ''
+    expect(mintHelper).toMatch(/result\.kind === 'error'/)
+    // After error: card edited AND pending entry dropped (no
+    // zombie staged request).
+    expect(mintHelper).toMatch(/editMessageText[\s\S]{0,400}mint_grant failed/)
+    expect(mintHelper).toMatch(/pendingVaultRequestAccesses\.delete/)
+  })
+})


### PR DESCRIPTION
## Summary

When the operator taps [✅ Approve] on a \`vault_request_access\` card without first having unlocked the vault, the card now prompts for the passphrase as the next message, captures + caches it, deletes the chat copy, and auto-resumes the mint. One tap + one reply = one grant.

## Why

Before this PR: cache-miss → card cleared with \"🔒 Vault is locked. Run \`/vault unlock\`... then ask the agent to re-issue.\" Four steps for one decision: clear card, \`/vault unlock\`, re-prompt agent, re-tap Approve. Today's gymbro retest hit this exact friction.

After this PR: mirrors the deferred-secret card's \"🔓 Unlock vault & save\" flow from #44 — same idiom, same trust posture, zero new threat surface.

## Implementation

- New \`PendingVaultOp\` variant: \`passphrase-for-access-approve\`.
- \`handleVaultRequestAccessCallback\`'s approve action sets up the pending-op intercept on cache-miss instead of clearing the card. Card text invites a passphrase reply.
- New helper \`performVaultAccessApproval\` owns the mint + token-write + card-edit body so the direct-approve and resume paths drive identical minting (DRY).
- Text handler's pending-op branch caches the passphrase, deletes the chat copy via \`deleteSensitiveMessage\`, looks up the staged access (handles the expired-between-tap-and-reply edge), and resumes via the helper.

## Threat model

Identical to #1030 (broker passphrase-attested \`mint_grant\`). The operator's passphrase IS the operator identity. Wrong passphrase fails closed at the broker (\`DENIED:passphrase-mismatch\`), which edits the card to \`mint_grant failed: …\` so the operator has clear next-step signal.

## Test plan

- [x] \`npm run lint\` — clean.
- [x] New \`telegram-plugin/tests/vault-request-access-unlock-resume.test.ts\` (5 cases): PendingVaultOp variant exists, cache-miss stages prompt instead of clearing, handler deletes + resumes, expired-stage cleanly edits, mint failure edits card.
- [x] Existing #1012 contract test updated to anchor on the new helper function.
- [x] \`npm test\` — only failures are pre-existing UAT-harness mocks (unrelated; confirmed via stash-pop diff).
- [ ] Post-merge: pull new agent image, repeat gymbro repro WITHOUT pre-unlocking — tap Approve → see passphrase prompt → reply → grant minted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)