### PR TITLE
chore(models): bump default opus to 4-7 across docs + schema + examples (#792)

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ memory:
   backend: hindsight
 
 defaults:
-  model: claude-opus-4-6   # or claude-sonnet-4-6, claude-haiku-4-5
+  model: claude-opus-4-7   # or claude-sonnet-4-6, claude-haiku-4-5
   tools: { allow: [all] }
   subagents:
     worker:
@@ -334,7 +334,7 @@ Profiles live in `profiles/` at the repo root. Bundled ones for `--profile`: `co
 
 If the agent is already in yaml, `--profile` must match the existing `extends:` value or it errors. If the yaml entry has no `extends:` and you pass `--profile`, the flag is written in additively with a warning. Running `agent create` with no `--profile` on a missing entry keeps the old "Agent not defined in switchroom.yaml" error, now with a hint to use `--profile`.
 
-Model aliases: the bare names `opus`, `sonnet`, `haiku` are accepted alongside the full IDs (`claude-opus-4-6`, `claude-sonnet-4-6`, `claude-haiku-4-5`). Use whichever reads cleaner in your config.
+Model aliases: the bare names `opus`, `sonnet`, `haiku` are accepted alongside the full IDs (`claude-opus-4-7`, `claude-sonnet-4-6`, `claude-haiku-4-5`). Use whichever reads cleaner in your config.
 
 ### Authentication (multi-account slot pool)
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -24,7 +24,7 @@ Each field type has specific merge behavior when values exist at multiple layers
 
 | Field | Cascade | Description |
 |-------|---------|-------------|
-| `model` | override | Claude model (`claude-opus-4-6`, `claude-sonnet-4-6`, `claude-haiku-4-5`). Haiku is the default for the handoff summarizer; agents typically use opus or sonnet. |
+| `model` | override | Claude model (`claude-opus-4-7`, `claude-sonnet-4-6`, `claude-haiku-4-5`). Haiku is the default for the handoff summarizer; agents typically use opus or sonnet. |
 | `extends` | — | Named profile to inherit from |
 | `tools.allow` / `tools.deny` | union | Tool permissions |
 | `soul` | per-field | Agent persona (name, style, boundaries) |

--- a/docs/session-optimization.md
+++ b/docs/session-optimization.md
@@ -41,7 +41,7 @@ Route implementation work to cheaper models via sub-agents:
 
 ```yaml
 defaults:
-  model: claude-opus-4-6
+  model: claude-opus-4-7
   subagents:
     worker:
       model: sonnet

--- a/examples/switchroom.yaml
+++ b/examples/switchroom.yaml
@@ -173,7 +173,7 @@ agents:
     topic_name: "Code"
     topic_emoji: "💻"
     extends: coder                      # inherits from inline profile above
-    model: claude-opus-4-6              # override defaults.model for this agent
+    model: claude-opus-4-7              # override defaults.model for this agent
     memory:
       collection: coding
     cli_args: ["--effort", "high"]      # escape hatch: extra exec claude flags

--- a/skills/switchroom-status/SKILL.md
+++ b/skills/switchroom-status/SKILL.md
@@ -58,7 +58,7 @@ assistant — running (2h 14m)
   model: claude-sonnet-4-6  collection: general
 
 dev — running (45m)
-  model: claude-opus-4-6  collection: coding
+  model: claude-opus-4-7  collection: coding
 
 coach — stopped
   last run: 3 days ago

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -26,7 +26,7 @@ export const ScheduleEntrySchema = z.object({
     .optional()
     .describe(
       "Model for this task. Defaults to claude-sonnet-4-6 (cheap, fast). " +
-      "Use claude-opus-4-6 for tasks needing complex reasoning.",
+      "Use claude-opus-4-7 for tasks needing complex reasoning.",
     ),
   secrets: z
     .array(z.string().regex(/^[a-zA-Z0-9_\-/]+$/, "Secret key names must contain only alphanumeric characters, underscores, hyphens, and forward slashes"))

--- a/tests/scaffold.test.ts
+++ b/tests/scaffold.test.ts
@@ -2044,7 +2044,7 @@ describe("scaffoldAgent with global defaults cascade", () => {
   });
 
   it("writes model override into settings.json when set", () => {
-    const agentConfig = makeAgentConfig({ model: "claude-opus-4-6" });
+    const agentConfig = makeAgentConfig({ model: "claude-opus-4-7" });
     const switchroomConfig: SwitchroomConfig = {
       switchroom: { version: 1, agents_dir: tmpDir },
       telegram: telegramConfig,
@@ -2062,10 +2062,10 @@ describe("scaffoldAgent with global defaults cascade", () => {
       readFileSync(join(result.agentDir, ".claude", "settings.json"), "utf-8"),
     );
 
-    expect(settings.model).toBe("claude-opus-4-6");
+    expect(settings.model).toBe("claude-opus-4-7");
     // And --model is appended to exec claude in start.sh
     const startSh = readFileSync(join(result.agentDir, "start.sh"), "utf-8");
-    expect(startSh).toContain("--model 'claude-opus-4-6'");
+    expect(startSh).toContain("--model 'claude-opus-4-7'");
   });
 
   it("exports user env vars in start.sh in declaration order", () => {
@@ -2799,7 +2799,7 @@ describe("scheduled task cron script generation", () => {
   it("uses the configured model when specified", () => {
     const agentConfig = makeAgentConfig({
       schedule: [
-        { cron: "0 9 * * *", prompt: "Important analysis", model: "claude-opus-4-6" },
+        { cron: "0 9 * * *", prompt: "Important analysis", model: "claude-opus-4-7" },
       ],
     });
     const result = scaffoldAgent(
@@ -2813,7 +2813,7 @@ describe("scheduled task cron script generation", () => {
       join(result.agentDir, "telegram", "cron-0.sh"),
       "utf-8",
     );
-    expect(content).toContain("claude-opus-4-6");
+    expect(content).toContain("claude-opus-4-7");
     expect(content).not.toContain("claude-sonnet-4-6");
   });
 
@@ -3508,7 +3508,7 @@ describe("scaffoldAgent with inline profiles (extends cascade)", () => {
   it("per-agent fields still win over inline profile fields", () => {
     const agentConfig = makeAgentConfig({
       extends: "coder",
-      model: "claude-opus-4-6",
+      model: "claude-opus-4-7",
     });
     const switchroomConfig: SwitchroomConfig = {
       switchroom: { version: 1, agents_dir: tmpDir },
@@ -3529,7 +3529,7 @@ describe("scaffoldAgent with inline profiles (extends cascade)", () => {
     const settings = JSON.parse(
       readFileSync(join(result.agentDir, ".claude", "settings.json"), "utf-8"),
     );
-    expect(settings.model).toBe("claude-opus-4-6");
+    expect(settings.model).toBe("claude-opus-4-7");
   });
 });
 


### PR DESCRIPTION
Fixes #792. Bumps user-facing `claude-opus-4-6` → `claude-opus-4-7` in docs, examples, schema doc-string, and test fixtures. Sonnet stays at 4-6, Haiku at 4-5 (per current model catalog). The CLI default constant in src/agents/scaffold.ts:409 stays on sonnet-4-6 because sonnet hasn't moved.