### PR TITLE
fix(two-zone): replace ⏸ Background icon with 🌀 — ⏸ misreads as 'stopped' (#862)

### DIFF
--- a/telegram-plugin/tests/two-zone-card-fleet-row.test.ts
+++ b/telegram-plugin/tests/two-zone-card-fleet-row.test.ts
@@ -30,7 +30,7 @@ function fm(over: Partial<FleetMember>): FleetMember {
 describe('glyphForFleetStatus', () => {
   it('maps every status to a glyph', () => {
     expect(glyphForFleetStatus('running')).toBe('↻')
-    expect(glyphForFleetStatus('background')).toBe('⏸')
+    expect(glyphForFleetStatus('background')).toBe('🌀')
     expect(glyphForFleetStatus('done')).toBe('✓')
     expect(glyphForFleetStatus('failed')).toBe('✗')
     expect(glyphForFleetStatus('stuck')).toBe('⚠')

--- a/telegram-plugin/tests/two-zone-card-snapshot.test.ts
+++ b/telegram-plugin/tests/two-zone-card-snapshot.test.ts
@@ -123,10 +123,10 @@ describe('two-zone-card snapshots', () => {
       now: NOW,
     })
     expect(out).toBe(
-      '⏸ <b>Background</b> · ⏱ 01:30 · 🔧 17 · 🤖 2\n' +
+      '🌀 <b>Background</b> · ⏱ 01:30 · 🔧 17 · 🤖 2\n' +
       '\n' +
       '<b>FLEET (2)</b>\n' +
-      '⏸ background <code>bbbbbb</code> · 12t · Bash <code>long-job.sh</code> (1s ago)\n' +
+      '🌀 background <code>bbbbbb</code> · 12t · Bash <code>long-job.sh</code> (1s ago)\n' +
       '✓ worker <code>aaaaaa</code> · 5t · done 30s ago',
     )
   })

--- a/telegram-plugin/tests/two-zone-snapshot-extras.test.ts
+++ b/telegram-plugin/tests/two-zone-snapshot-extras.test.ts
@@ -68,7 +68,7 @@ describe('PR-C2: two-zone card snapshot extras', () => {
       '🙊 <b>Ended without reply</b> · ⏱ 00:30 · 🔧 7 · 🤖 1\n' +
       '\n' +
       '<b>FLEET (1)</b>\n' +
-      '⏸ background <code>aaaaaa</code> · 7t · Bash <code>long.sh</code> (2s ago)',
+      '🌀 background <code>aaaaaa</code> · 7t · Bash <code>long.sh</code> (2s ago)',
     )
   })
 

--- a/telegram-plugin/two-zone-card.ts
+++ b/telegram-plugin/two-zone-card.ts
@@ -115,9 +115,12 @@ export function phaseFor(
     return { icon: '⚠', label: 'Stalled' }
   }
 
-  // Background: parentDone but at least one fleet member still running
+  // Background: parentDone but at least one fleet member still running.
+  // Use 🌀 (spinning vortex), not ⏸ (pause). The card is actively working
+  // — sub-agents running, tools firing — and "pause" reads as "stopped,
+  // waiting for input." See #862 for the misread that motivated this.
   if (parentDone && fleetRunning) {
-    return { icon: '⏸', label: 'Background' }
+    return { icon: '🌀', label: 'Background' }
   }
 
   // Done: parent terminal + no fleet still running
@@ -237,7 +240,7 @@ export function formatLastActivity(m: FleetMember, now: number): string {
 export function glyphForFleetStatus(status: FleetStatus): string {
   switch (status) {
     case 'running': return '↻'
-    case 'background': return '⏸'
+    case 'background': return '🌀' // see #862: ⏸ misread as 'stopped'; background means actively-but-out-of-focus
     case 'done': return '✓'
     case 'failed': return '✗'
     case 'stuck': return '⚠'


### PR DESCRIPTION
Fixes #862. ⏸ pause glyph was being used for the 'parentDone but fleet still running' phase. Pause reads as 'stopped, waiting for input' — but the card is actively working (sub-agents firing tools). Swapping to 🌀 (spinning vortex) per issue's top-ranked suggestion. Same change on the fleet-row glyph. Snapshot tests updated; comments mentioning the old ⏸ in fleet-state.ts header + bg-agent-progress-card-757.test.ts header are pure history pointers and stay so future readers can find this PR.