### PR TITLE
fix(approvals): namespace deferred-secret scope as vault:secret:<slug> (#832)

### DIFF
--- a/src/vault/approvals/vd-unlock-dual-dispatch.test.ts
+++ b/src/vault/approvals/vd-unlock-dual-dispatch.test.ts
@@ -30,7 +30,7 @@ import {
 } from "./kernel.js";
 
 const AGENT_UNIT = "switchroom-klanker.service";
-const SCOPE = "secret:openai_api_key";
+const SCOPE = "vault:secret:openai_api_key";
 const ACTION = "unlock";
 const APPROVER_SET = ["12345"];
 
@@ -216,7 +216,7 @@ describe("vd:unlock dual-dispatch (Phase 1 migration)", () => {
     });
     const nonce = consumeNonce(db, req.request_id);
     expect(nonce).not.toBeNull();
-    expect(nonce!.scope.startsWith("secret:")).toBe(true);
+    expect(nonce!.scope.startsWith("vault:secret:")).toBe(true);
     expect(nonce!.action).toBe("unlock");
     expect(nonce!.agent_unit).toBe(AGENT_UNIT);
   });

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -1539,7 +1539,7 @@ async function mintDeferredSecretKernelRequest(
   try {
     const r = await approvalRequest({
       agent_unit: `switchroom-${agentName}.service`,
-      scope: `secret:${slug}`,
+      scope: `vault:secret:${slug}`,
       action: 'unlock',
       approver_set: approverSet,
       why: 'Unlock vault to save a deferred secret detected in chat.',


### PR DESCRIPTION
Fixes #832. Renames the deferred-secret kernel scope from `secret:<slug>` to `vault:secret:<slug>` for symmetry with Drive's `doc:gdrive:**` and future `vault:grant:*`. Two-line change per the issue scope: gateway.ts:1542 (the only production emitter) + the SCOPE constant and prefix assertion in vd-unlock-dual-dispatch.test.ts. Kernel-internal tests that use bare `secret:` as a literal fixture stay untouched — they test storage, not emission convention.