### PR TITLE
fix(lifecycle): startAgent uses --force-recreate so env propagates after stop→edit→start (#1018)

### DIFF
--- a/src/agents/lifecycle.ts
+++ b/src/agents/lifecycle.ts
@@ -176,13 +176,18 @@ function containerExists(name: string): boolean {
 
 export function startAgent(name: string): void {
   try {
-    // If the container has never been created, `compose start` errors
-    // out — fall back to `up -d --no-deps` to bring it online.
-    if (containerExists(name)) {
-      dockerSync(composeArgs(["start", serviceKey(name)]));
-    } else {
-      dockerSync(composeArgs(["up", "-d", "--no-deps", serviceKey(name)]));
-    }
+    // Always `up -d --force-recreate --no-deps`. See restartAgent's
+    // comment for the rationale on each flag (#932 / #944). Same logic
+    // applies here: an operator running `agent start` after `agent
+    // stop` + a yaml edit + `apply` reasonably expects the new env
+    // block / mount changes to take effect. `compose start` (no
+    // recreate) silently reuses the existing container with its
+    // create-time env, which was the operator-reported symptom in
+    // #1018. Force-recreate covers both the "first ever boot" case
+    // (no existing container, recreate is a no-op cost) and the
+    // "stop → edit → start" case — the only cost is a fresh container
+    // spin-up (~1-2s), cheap relative to the surprise of stale env.
+    dockerSync(composeArgs(["up", "-d", "--force-recreate", "--no-deps", serviceKey(name)]));
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     throw new Error(`Failed to start agent "${name}": ${message}`);

--- a/tests/lifecycle.docker.test.ts
+++ b/tests/lifecycle.docker.test.ts
@@ -55,40 +55,18 @@ beforeEach(() => {
 });
 
 describe("lifecycle (docker mode): start/stop/restart shellouts", () => {
-  it("startAgent calls `compose start agent-<name>` when the container exists", () => {
+  it("startAgent calls `compose up -d --force-recreate --no-deps agent-<name>` (#1018)", () => {
+    // fails when: a refactor reverts startAgent to `compose start`
+    // (or `up -d` without `--force-recreate`). Either reintroduces
+    // #1018: a `stop → edit yaml → apply → start` round leaves the
+    // container with create-time env. The restartAgent test below
+    // pins the same flag-set for symmetry.
     const calls = recordingStub({
-      ps: () => "switchroom-foo\n",
-      "compose start": () => "",
-    });
-    startAgent("foo");
-    // First call: ps probe; second: compose start
-    expect(calls.length).toBe(2);
-    expect(calls[0].args).toEqual([
-      "ps",
-      "-a",
-      "--format",
-      "{{.Names}}",
-      "--filter",
-      "name=^switchroom-foo$",
-    ]);
-    expect(calls[1].args).toEqual([
-      "compose",
-      "-p",
-      "switchroom",
-      "-f",
-      "/tmp/sw-test-compose.yml",
-      "start",
-      "agent-foo",
-    ]);
-  });
-
-  it("startAgent falls back to `compose up -d --no-deps` when the container is missing", () => {
-    const calls = recordingStub({
-      ps: () => "", // no container
       "compose up": () => "",
     });
     startAgent("foo");
-    expect(calls[1].args).toEqual([
+    expect(calls.length).toBe(1);
+    expect(calls[0].args).toEqual([
       "compose",
       "-p",
       "switchroom",
@@ -96,6 +74,7 @@ describe("lifecycle (docker mode): start/stop/restart shellouts", () => {
       "/tmp/sw-test-compose.yml",
       "up",
       "-d",
+      "--force-recreate",
       "--no-deps",
       "agent-foo",
     ]);


### PR DESCRIPTION
Closes #1018.

`restartAgent` gained `--force-recreate` in #944, but `startAgent` kept the prior `compose start` (or `up -d --no-deps` fallback) which silently reuses the existing container's create-time env. So an operator running `stop → edit yaml → apply → start` saw the exact symptom the issue reports against restart: yaml change makes it into the compose file but never into the running container's env.

Aligning startAgent with restartAgent: always `up -d --force-recreate --no-deps`. Same flag rationale (cited inline at the new comment). Cost is ~1-2s for a recreate vs the surprise of stale env. The prior `containerExists()` branch is gone — `up -d` handles both "never created" and "exists, edit landed" cleanly.

Test pinning the new flag-set added with a #1018 reference so future refactors can't silently revert. All 15 `tests/lifecycle.docker.test.ts` cases pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)