### PR TITLE
fix(broker,kernel): apply #988 socket.end fix to oversized-frame guards too

### DIFF
--- a/src/vault/approvals/kernel-server.ts
+++ b/src/vault/approvals/kernel-server.ts
@@ -202,8 +202,10 @@ function handleConnection(
   socket.on("data", (chunk: Buffer) => {
     buffer += chunk.toString("utf8");
     if (Buffer.byteLength(buffer, "utf8") > MAX_FRAME_BYTES) {
-      socket.write(encodeResponse(errorResponse("BAD_REQUEST", "Frame exceeds 64 KiB limit")));
-      socket.destroy();
+      // end(resp) not write(resp); destroy() — same race shape as
+      // #988's unlock-handler fix: destroy can drop the buffered
+      // response before the kernel flushes it to the peer.
+      socket.end(encodeResponse(errorResponse("BAD_REQUEST", "Frame exceeds 64 KiB limit")));
       return;
     }
     let nl: number;

--- a/src/vault/broker/server.ts
+++ b/src/vault/broker/server.ts
@@ -698,13 +698,15 @@ export class VaultBroker {
     socket.on("data", (chunk: Buffer) => {
       buffer += chunk.toString("utf8");
 
-      // Guard against oversized buffers (>64 KiB without a newline)
+      // Guard against oversized buffers (>64 KiB without a newline).
+      // `end(resp)` not `write(resp); destroy()` so the kernel flushes
+      // `resp` to the peer before FIN — same race shape as #988's
+      // unlock-handler fix.
       if (Buffer.byteLength(buffer, "utf8") > MAX_FRAME_BYTES) {
         const resp = encodeResponse(
           errorResponse("BAD_REQUEST", "Frame exceeds 64 KiB limit"),
         );
-        socket.write(resp);
-        socket.destroy();
+        socket.end(resp);
         return;
       }
 


### PR DESCRIPTION
Followup to #1045 — the reviewer flagged two remaining sites with the same write+destroy race pattern that #1045 fixed for the unlock handler:

- `src/vault/broker/server.ts:706` (data-socket >64KiB guard)
- `src/vault/approvals/kernel-server.ts:205` (kernel RPC >64KiB guard)

Both error-path responses now use `socket.end(resp)` (flushes then FIN-closes) instead of `socket.write(resp); socket.destroy()` (closes immediately, kernel can drop the buffered resp).

Narrower in practice than the unlock race (oversized frames are rare on these paths) but the bug shape is identical. Same #988 cross-reference in the comments.

47/47 tests pass (`server.test.ts` + `kernel.test.ts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)