### PR TITLE
test(flock): unit-test /proc/pid/stat comm-field-with-')' parsing (closes #989; #977/#978 already done in #987)

### DIFF
--- a/src/vault/flock.test.ts
+++ b/src/vault/flock.test.ts
@@ -27,6 +27,7 @@ import { tmpdir } from "node:os";
 import {
   acquireLock,
   lockPathFor,
+  parseProcStartTimeMs,
   readLockHolder,
   VaultBusyError,
 } from "./flock.js";
@@ -397,5 +398,74 @@ describe("flock — v0.7.14 sentinel-dir migration", () => {
     } finally {
       lock.release();
     }
+  });
+});
+
+describe("parseProcStartTimeMs — comm-field-with-')' parsing (closes #989)", () => {
+  // We feed concrete fixtures so the test doesn't depend on /proc.
+  // `now` is anchored so the sanity-window check passes deterministically.
+  // Boot = 1700000000 (epoch sec, 2023-11-14). starttime ticks = 100 → 1s
+  // post-boot → start = 1700000001000ms. `now` = boot + 60s.
+  const BOOT_EPOCH_SEC = 1_700_000_000;
+  const STARTTIME_TICKS = 100; // 1s past boot at USER_HZ=100
+  const NOW_EPOCH_MS = (BOOT_EPOCH_SEC + 60) * 1000;
+  const PROC_STAT = [
+    "cpu  100 200 300 400",
+    `btime ${BOOT_EPOCH_SEC}`,
+    "processes 12345",
+  ].join("\n");
+
+  // Build a /proc/<pid>/stat line where the comm field is in parens.
+  // We need fields 1..22 (1-indexed). Most fields are placeholders.
+  function makeStatLine(pid: number, comm: string): string {
+    // field 1: pid; field 2: (comm); field 3: state; field 4..21: zeros
+    // field 22: starttime.
+    const filler = Array.from({ length: 18 }, () => "0").join(" ");
+    return `${pid} (${comm}) S ${filler} ${STARTTIME_TICKS} 0 0 0 0 0 0 0 0 0 0\n`;
+  }
+
+  it("parses cleanly when comm contains no parens", () => {
+    const stat = makeStatLine(1234, "bash");
+    const result = parseProcStartTimeMs(stat, PROC_STAT, NOW_EPOCH_MS);
+    expect(result).toBe((BOOT_EPOCH_SEC + 1) * 1000);
+  });
+
+  it("parses correctly when comm contains literal `)` characters (e.g. evil)name)", () => {
+    // The canonical adversarial case the issue calls out: a process
+    // name containing `)` would break a naive `indexOf(")")` parser
+    // but lastIndexOf(")") handles it correctly.
+    const stat = makeStatLine(1234, "evil)name");
+    const result = parseProcStartTimeMs(stat, PROC_STAT, NOW_EPOCH_MS);
+    expect(result).toBe((BOOT_EPOCH_SEC + 1) * 1000);
+  });
+
+  it("parses correctly when comm contains multiple `)` characters", () => {
+    const stat = makeStatLine(1234, "a)b)c)d)");
+    const result = parseProcStartTimeMs(stat, PROC_STAT, NOW_EPOCH_MS);
+    expect(result).toBe((BOOT_EPOCH_SEC + 1) * 1000);
+  });
+
+  it("parses correctly when comm contains literal space + `)`", () => {
+    const stat = makeStatLine(1234, "weird name) here");
+    const result = parseProcStartTimeMs(stat, PROC_STAT, NOW_EPOCH_MS);
+    expect(result).toBe((BOOT_EPOCH_SEC + 1) * 1000);
+  });
+
+  it("returns null when stat line has no `)` at all (impossible in real /proc but defensive)", () => {
+    expect(parseProcStartTimeMs("1234 bashS 0 0", PROC_STAT, NOW_EPOCH_MS)).toBeNull();
+  });
+
+  it("returns null when /proc/stat lacks btime", () => {
+    const stat = makeStatLine(1234, "bash");
+    expect(parseProcStartTimeMs(stat, "cpu  1 2 3 4\n", NOW_EPOCH_MS)).toBeNull();
+  });
+
+  it("returns null when starttime is outside the sanity window (USER_HZ drift / impostor)", () => {
+    // 100 ticks past boot = 1s past boot, but with USER_HZ=100 and
+    // starttime=1_000_000 ticks (10_000s = ~2.7h) the start would
+    // fall in the future relative to our pinned now (boot + 60s).
+    const filler = Array.from({ length: 18 }, () => "0").join(" ");
+    const stat = `1234 (bash) S ${filler} 1000000 0 0 0 0 0 0 0 0 0 0\n`;
+    expect(parseProcStartTimeMs(stat, PROC_STAT, NOW_EPOCH_MS)).toBeNull();
   });
 });

--- a/src/vault/flock.ts
+++ b/src/vault/flock.ts
@@ -131,51 +131,72 @@ function pidIsLive(pid: number): boolean {
  * if the running process started AFTER the lock was acquired, the
  * PID was reused and the lock is stale. Closes #976.
  */
+/**
+ * Pure parser for /proc/<pid>/stat — split out from {@link pidStartTimeMs}
+ * so the regression cases (notably comm fields containing literal `)`,
+ * see #989) can be unit-tested without mocking the filesystem.
+ *
+ * Returns the process start time in epoch-milliseconds, or null if
+ * either input is malformed / outside the sanity window.
+ *
+ * @param statLine    The raw single line read from /proc/<pid>/stat.
+ * @param procStat    The raw contents of /proc/stat (we need the `btime` line).
+ * @param now         Current epoch-ms — accepted as a param so tests don't depend on wall-clock.
+ */
+export function parseProcStartTimeMs(
+  statLine: string,
+  procStat: string,
+  now: number,
+): number | null {
+  // The comm field (field 2 of /proc/<pid>/stat) is wrapped in parens
+  // and can contain any byte except null — including literal `)`. The
+  // canonical way to skip it is `lastIndexOf(")")` because the comm
+  // string is guaranteed to be followed by ` <state> …`, and `state`
+  // is one of " RSDZTtWXxKWPI" — none of which contain `)`. So the
+  // LAST `)` in the line always terminates the comm field.
+  const tailStart = statLine.lastIndexOf(")");
+  if (tailStart < 0) return null;
+  const tokens = statLine.slice(tailStart + 1).trim().split(/\s+/);
+  // After the closing `)`, the next field is `state` (index 0 of
+  // tokens, which corresponds to field 3 of /proc/<pid>/stat).
+  // starttime is field 22, so index 22 - 3 = 19.
+  const starttimeTicks = Number.parseInt(tokens[19] ?? "", 10);
+  if (!Number.isFinite(starttimeTicks)) return null;
+
+  // Boot wallclock (seconds since epoch) — `btime` in /proc/stat.
+  const btimeMatch = procStat.match(/^btime\s+(\d+)/m);
+  if (!btimeMatch) return null;
+  const bootEpochSec = Number.parseInt(btimeMatch[1], 10);
+  if (!Number.isFinite(bootEpochSec)) return null;
+
+  // USER_HZ (clock ticks per second). On Linux this is almost always
+  // 100 (`getconf CLK_TCK`); we can't read it from /proc directly
+  // but the constant has been 100 on every common distro for 20+
+  // years. If this ever changes we surface "unknown start time" by
+  // returning null via the sanity check below rather than computing
+  // a wrong answer.
+  const USER_HZ = 100;
+  const startEpochMs = bootEpochSec * 1000 + (starttimeTicks / USER_HZ) * 1000;
+
+  // Sanity range: process start must be between boot time and now
+  // (with a 5s slop for clock skew / leap-second weirdness). A
+  // result outside that band suggests USER_HZ drift, parsing bug,
+  // or a /proc impostor — return null and let the caller fall
+  // back to the conservative "treat as live" path.
+  const bootEpochMs = bootEpochSec * 1000;
+  const SLOP_MS = 5000;
+  if (startEpochMs < bootEpochMs - SLOP_MS || startEpochMs > now + SLOP_MS) {
+    return null;
+  }
+  return Math.floor(startEpochMs);
+}
+
 function pidStartTimeMs(pid: number): number | null {
   if (process.platform !== "linux") return null;
   try {
-    // /proc/<pid>/stat is one line. The comm field (field 2) is
-    // wrapped in parens and can contain spaces, so split on the
-    // closing `)` and parse the remaining whitespace-separated
-    // tokens. Field 22 (starttime) is index 19 of the post-`)` split.
-    const raw = readFileSync(`/proc/${pid}/stat`, "utf8");
-    const tailStart = raw.lastIndexOf(")");
-    if (tailStart < 0) return null;
-    const tokens = raw.slice(tailStart + 1).trim().split(/\s+/);
-    // After the closing `)`, the next field is `state` (index 0 of
-    // tokens, which corresponds to field 3 of /proc/<pid>/stat).
-    // starttime is field 22, so index 22 - 3 = 19.
-    const starttimeTicks = Number.parseInt(tokens[19] ?? "", 10);
-    if (!Number.isFinite(starttimeTicks)) return null;
-
-    // Boot wallclock (seconds since epoch) — `btime` in /proc/stat.
+    const statLine = readFileSync(`/proc/${pid}/stat`, "utf8");
     const procStat = readFileSync("/proc/stat", "utf8");
-    const btimeMatch = procStat.match(/^btime\s+(\d+)/m);
-    if (!btimeMatch) return null;
-    const bootEpochSec = Number.parseInt(btimeMatch[1], 10);
-    if (!Number.isFinite(bootEpochSec)) return null;
-
-    // USER_HZ (clock ticks per second). On Linux this is almost always
-    // 100 (`getconf CLK_TCK`); we can't read it from /proc directly
-    // but the constant has been 100 on every common distro for 20+
-    // years. If this ever changes we surface "unknown start time" by
-    // returning null via the sanity check below rather than computing
-    // a wrong answer.
-    const USER_HZ = 100;
-    const startEpochMs = bootEpochSec * 1000 + (starttimeTicks / USER_HZ) * 1000;
-
-    // Sanity range: process start must be between boot time and now
-    // (with a 5s slop for clock skew / leap-second weirdness). A
-    // result outside that band suggests USER_HZ drift, parsing bug,
-    // or a /proc impostor — return null and let the caller fall
-    // back to the conservative "treat as live" path.
-    const now = Date.now();
-    const bootEpochMs = bootEpochSec * 1000;
-    const SLOP_MS = 5000;
-    if (startEpochMs < bootEpochMs - SLOP_MS || startEpochMs > now + SLOP_MS) {
-      return null;
-    }
-    return Math.floor(startEpochMs);
+    return parseProcStartTimeMs(statLine, procStat, Date.now());
   } catch {
     return null;
   }


### PR DESCRIPTION
Closes #989. Also confirms #977 and #978 are already addressed in #987.

## #989 (this PR)
Extracts the /proc/<pid>/stat parsing out of `pidStartTimeMs` into a pure `parseProcStartTimeMs(statLine, procStat, now)` helper so the adversarial cases can be unit-tested without mocking fs. 7 new cases:

- normal comm field
- comm with single literal `)` (`evil)name` — the canonical adversarial case)
- comm with multiple `)`
- comm with space + `)`
- stat line missing `)` entirely (defensive null)
- /proc/stat lacking `btime` (null)
- USER_HZ drift / starttime past sanity window (null)

The parser was already correct (uses `lastIndexOf(")")` which handles arbitrary comm content) — this PR locks in that correctness.

## #977 and #978 — already done in #987

While preparing this PR I checked the cited gaps and they're both closed by #987 (the original PR's auto-close keyword formatting must have missed them):

- **#977** (unparseable + mtime-stale): `src/vault/flock.ts:373` has the `isUnparseableAndOld` branch; `src/vault/flock.test.ts:160` has the regression case.
- **#978** (worker_threads concurrent acquirer test): `src/vault/flock-concurrent.test.ts` is the dedicated file with that coverage.

Suggesting both issues are closed alongside #989 once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)