### PR TITLE
fix(vault): allow '/' in vault-key regex so namespaced keys can use the approval card flow (#1047)

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -7973,7 +7973,11 @@ async function handleVaultRecentDenialCallback(ctx: Context, data: string): Prom
     await ctx.answerCallbackQuery({ text: 'Invalid agent name' }).catch(() => {})
     return
   }
-  if (!/^[A-Za-z0-9_.-]{1,200}$/.test(keyName)) {
+  // #1047: same canonical key shape as vault_request_save /
+  // vault_request_access — namespaced keys like `fatsecret/client_id`
+  // must round-trip through the /vault audit one-tap Allow flow too,
+  // not just the agent-initiated approval cards.
+  if (!VAULT_KEY_REGEX.test(keyName)) {
     await ctx.answerCallbackQuery({ text: 'Invalid key name' }).catch(() => {})
     return
   }

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -1349,6 +1349,17 @@ function rememberAgentButtonMeta(
 // Vault
 const vaultPassphraseCache = new Map<string, { passphrase: string; expiresAt: number }>()
 const VAULT_PASSPHRASE_TTL_MS = 30 * 60 * 1000
+/**
+ * Gateway-side guard on vault-key shape — UX gate, not a security
+ * boundary (the broker accepts any non-empty string per
+ * `src/vault/broker/protocol.ts:32`). Includes `/` so canonical
+ * namespaced keys like `fatsecret/client_id`, `mff/agent-private-key`,
+ * `microsoft/ken-tokens` are accepted in the vault_request_save /
+ * vault_request_access / [✏️ Rename] flows. See #1047.
+ */
+const VAULT_KEY_REGEX = /^[A-Za-z0-9_./-]{1,200}$/
+/** Human-readable label embedded in error messages and rename prompts. */
+const VAULT_KEY_REGEX_LABEL = "[A-Za-z0-9_./-]{1,200}"
 type PendingVaultOp =
   | { kind: 'passphrase'; op: 'list' | 'get' | 'delete' | 'set'; key?: string; startedAt: number }
   | { kind: 'value'; op: 'set'; key: string; passphrase: string; startedAt: number }
@@ -3543,10 +3554,13 @@ async function executeVaultRequestSave(args: Record<string, unknown>): Promise<{
 
   // Validate slug shape — vault keys must match a tight charset so the
   // host CLI hints render cleanly and reference resolution stays
-  // predictable. Same shape as `validateVaultKey` in the broker, kept
-  // local here to avoid pulling in the broker import.
-  if (!/^[A-Za-z0-9_.-]{1,200}$/.test(key)) {
-    throw new Error('vault_request_save: key must match [A-Za-z0-9_.-]{1,200}')
+  // predictable. Includes `/` so the canonical namespaced shape
+  // (`fatsecret/client_id`, `mff/agent-private-key`, ...) is
+  // accepted — issue #1047. The broker itself has no key regex
+  // (just `z.string().min(1)` in protocol.ts); this gateway-side
+  // gate is a UX guard, not a security boundary.
+  if (!VAULT_KEY_REGEX.test(key)) {
+    throw new Error(`vault_request_save: key must match ${VAULT_KEY_REGEX_LABEL}`)
   }
 
   const agentSlug = process.env.SWITCHROOM_AGENT_NAME || 'agent'
@@ -3629,8 +3643,8 @@ async function executeVaultRequestAccess(args: Record<string, unknown>): Promise
   if (!chat_id) throw new Error('vault_request_access: chat_id is required')
   const key = args.key as string
   if (!key || typeof key !== 'string') throw new Error('vault_request_access: key is required')
-  if (!/^[A-Za-z0-9_.-]{1,200}$/.test(key)) {
-    throw new Error('vault_request_access: key must match [A-Za-z0-9_.-]{1,200}')
+  if (!VAULT_KEY_REGEX.test(key)) {
+    throw new Error(`vault_request_access: key must match ${VAULT_KEY_REGEX_LABEL}`)
   }
   const scopeRaw = typeof args.scope === 'string' ? args.scope : 'read'
   if (scopeRaw !== 'read' && scopeRaw !== 'write') {
@@ -5182,10 +5196,10 @@ async function handleInbound(
           await switchroomReply(ctx, '⌛ That save card expired before you renamed. Ask the agent to re-issue.', { html: true })
           return
         }
-        if (!/^[A-Za-z0-9_.-]{1,200}$/.test(newKey)) {
+        if (!VAULT_KEY_REGEX.test(newKey)) {
           // Re-arm the pending state so the user can try again.
           pendingVaultOps.set(chat_id, { ...pendingVault, startedAt: Date.now() })
-          await switchroomReply(ctx, '⚠️ Key must match <code>[A-Za-z0-9_.-]</code> and be ≤ 200 chars. Send a different name.', { html: true })
+          await switchroomReply(ctx, `⚠️ Key must match <code>${VAULT_KEY_REGEX_LABEL}</code>. Send a different name.`, { html: true })
           return
         }
         staged.key = newKey

--- a/telegram-plugin/tests/vault-key-regex-allows-slash.test.ts
+++ b/telegram-plugin/tests/vault-key-regex-allows-slash.test.ts
@@ -83,6 +83,24 @@ describe("vault-key regex accepts canonical slash-namespaced keys (#1047)", () =
     ).toMatch(ACCEPTS_SLASH);
   });
 
+  it("/vault audit one-tap Allow callback validation includes '/' in the charclass", () => {
+    // Reviewer-caught oversight on #1049: the
+    // handleVaultRecentDenialCallback handler (#969 P2b) validates
+    // the keyName parsed from the inline-button callback_data with
+    // its own copy of the key regex. Without this site updated, the
+    // exact bug from #1047 — operator opens /vault audit on a
+    // denied `fatsecret/client_id`, taps [Allow] — would surface
+    // "Invalid key name" even though the agent-initiated card flow
+    // works.
+    const ix = gatewaySrc.indexOf("'Invalid key name'");
+    expect(ix, "could not find /vault audit Invalid key name error").toBeGreaterThan(0);
+    const window = gatewaySrc.slice(Math.max(0, ix - 400), ix);
+    expect(
+      window,
+      "/vault audit one-tap allow should accept '/' (e.g. fatsecret/client_id)",
+    ).toMatch(ACCEPTS_SLASH);
+  });
+
   it("user-facing rename error message names the slash as allowed", () => {
     // The visible error text guides the operator on what's allowed.
     // If we widened the regex but didn't update the message, the

--- a/telegram-plugin/tests/vault-key-regex-allows-slash.test.ts
+++ b/telegram-plugin/tests/vault-key-regex-allows-slash.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Contract pin for #1047 — the gateway's vault-key regex was stricter
+ * than the broker's, so canonical slash-namespaced keys like
+ * `fatsecret/client_id` couldn't be requested via the in-band
+ * approval card flow. Filed by gymbro after hitting
+ * VAULT-BROKER-DENIED on `fatsecret/client_id` and being unable to
+ * call `vault_request_access` because of the schema regex.
+ *
+ * Three call sites use the regex:
+ *   1. `vault_request_save` execute (telegram-plugin/gateway/gateway.ts ~3549)
+ *   2. `vault_request_access` execute (~3633)
+ *   3. The rename-the-staged-key text-message handler (~5185)
+ *
+ * All three must accept the canonical slash-namespaced shape used by
+ * production keys: `fatsecret/client_id`, `mff/agent-private-key`,
+ * `microsoft/ken-tokens`. The broker itself has no key-shape regex
+ * (just `z.string().min(1)` in protocol.ts), so the gateway should
+ * mirror that posture — accept what the broker accepts.
+ *
+ * This is a static-source pin — the regex literal must appear in the
+ * gateway source. A runtime test would need a full bot harness;
+ * static-source mirrors the convention used elsewhere in this file
+ * tree (see jtbd-talk-from-anywhere.test.ts, vault-request-access-tool.test.ts).
+ */
+
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const gatewaySrc = readFileSync(
+  resolve(__dirname, "..", "gateway", "gateway.ts"),
+  "utf-8",
+);
+
+/** The exported regex literal — what the gateway actually validates against. */
+function extractVaultKeyRegex(): RegExp {
+  // The shared constant declaration. Anchored on the `VAULT_KEY_REGEX
+  // = /` prefix and the `/` immediately before the line terminator
+  // (the regex has no flags). The source includes `/` inside the
+  // character class, so a greedy match up to end-of-line is the
+  // safe extraction strategy.
+  const m = gatewaySrc.match(/const\s+VAULT_KEY_REGEX\s*=\s*\/(.+)\/\s*$/m);
+  if (!m) throw new Error("VAULT_KEY_REGEX constant not found in gateway.ts");
+  return new RegExp(m[1]);
+}
+
+/** Either inline literal with `/`, OR a reference to VAULT_KEY_REGEX. */
+const ACCEPTS_SLASH = /\[A-Za-z0-9_(\/|\\\/|\.)+-\]|VAULT_KEY_REGEX/;
+
+describe("vault-key regex accepts canonical slash-namespaced keys (#1047)", () => {
+  it("vault_request_save validation includes '/' in the charclass", () => {
+    // Anchor on the unique error message so a refactor that moves
+    // the validation can still be located.
+    const ix = gatewaySrc.indexOf("vault_request_save: key must match");
+    expect(ix, "could not find vault_request_save key error message").toBeGreaterThan(0);
+    const window = gatewaySrc.slice(Math.max(0, ix - 400), ix);
+    expect(
+      window,
+      "vault_request_save validation should accept '/' (e.g. fatsecret/client_id)",
+    ).toMatch(ACCEPTS_SLASH);
+  });
+
+  it("vault_request_access validation includes '/' in the charclass", () => {
+    const ix = gatewaySrc.indexOf("vault_request_access: key must match");
+    expect(ix, "could not find vault_request_access key error message").toBeGreaterThan(0);
+    const window = gatewaySrc.slice(Math.max(0, ix - 400), ix);
+    expect(
+      window,
+      "vault_request_access validation should accept '/' (e.g. fatsecret/client_id)",
+    ).toMatch(ACCEPTS_SLASH);
+  });
+
+  it("rename-staged-key validation includes '/' in the charclass", () => {
+    // The rename handler for the [✏️ Rename] button on a
+    // vault_request_save card. If this stays strict, operators can't
+    // rename a staged key to a canonical namespaced form.
+    const ix = gatewaySrc.indexOf("Key must match");
+    expect(ix, "could not find rename validation error message").toBeGreaterThan(0);
+    const window = gatewaySrc.slice(Math.max(0, ix - 400), ix);
+    expect(
+      window,
+      "rename handler should accept '/' (e.g. fatsecret/client_id)",
+    ).toMatch(ACCEPTS_SLASH);
+  });
+
+  it("user-facing rename error message names the slash as allowed", () => {
+    // The visible error text guides the operator on what's allowed.
+    // If we widened the regex but didn't update the message, the
+    // operator is told `/` is disallowed even though it isn't.
+    // The VAULT_KEY_REGEX_LABEL string is the canonical user-visible
+    // hint and includes the `/` shape.
+    const m = gatewaySrc.match(/const\s+VAULT_KEY_REGEX_LABEL\s*=\s*"([^"]+)"/);
+    expect(m, "VAULT_KEY_REGEX_LABEL constant not found").not.toBeNull();
+    expect(m![1], "label must mention '/' as allowed").toMatch(/\//);
+  });
+});
+
+describe("vault-key regex: regression guards (the fix doesn't break the original shape)", () => {
+  // Anchored to the live VAULT_KEY_REGEX constant declaration so the
+  // test runs the same regex the gateway runs. A breaking refactor
+  // (typo, accidental tightening) fails loudly here.
+  const re = extractVaultKeyRegex();
+
+  it.each([
+    ["telegram_bot_token", true, "underscores + lowercase"],
+    ["MY_TOKEN", true, "uppercase + underscore"],
+    ["api.key", true, "dot namespace"],
+    ["fatsecret/client_id", true, "slash namespace (the bug)"],
+    ["fatsecret/credentials", true, "slash namespace"],
+    ["mff/agent-private-key", true, "slash namespace with hyphen"],
+    ["microsoft/ken-tokens", true, "slash namespace from issue"],
+    ["k", true, "single char"],
+    ["a".repeat(200), true, "max length"],
+    ["", false, "empty rejected"],
+    ["a".repeat(201), false, "over-length rejected"],
+    ["key with space", false, "space rejected"],
+    ['key"with"quotes', false, "quotes rejected"],
+    ["key\nwith\nnewlines", false, "newlines rejected"],
+  ] as const)("VAULT_KEY_REGEX: %s — should %s (%s)", (input, expected) => {
+    expect(re.test(input), `${JSON.stringify(input)} (${expected ? "accept" : "reject"})`).toBe(expected);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #1047 — filed by gymbro after hitting \`VAULT-BROKER-DENIED [DENIED]: key 'fatsecret/client_id' not in ACL\` and being unable to call \`vault_request_access(key=\"fatsecret/client_id\", ...)\` because the gateway's key regex rejected \`/\`.

## Root cause

The gateway's three vault-key validation sites used \`[A-Za-z0-9_.-]{1,200}\` — stricter than the broker. The broker has no key regex (just \`z.string().min(1)\` in \`src/vault/broker/protocol.ts:32\`), and the canonical production key shape uses \`/\` as a namespace separator: \`fatsecret/client_id\`, \`mff/agent-private-key\`, \`microsoft/ken-tokens\`. Gateway was lying about what's permitted.

## Fix

Factored out \`VAULT_KEY_REGEX = /^[A-Za-z0-9_./-]{1,200}$/\` + a matching \`VAULT_KEY_REGEX_LABEL\` so all three sites stay in sync:
- \`executeVaultRequestSave\`
- \`executeVaultRequestAccess\`
- The [✏️ Rename] text-message handler on a vault_request_save card

## Test plan

- [x] \`npm run lint\` — clean.
- [x] New \`telegram-plugin/tests/vault-key-regex-allows-slash.test.ts\` (18 cases): three call-site source pins, one user-facing-label check, 14 regex behavior cases (canonical namespaced keys accept, edge lengths, rejected shapes).
- [x] \`npm test\` — 5494/0 pass.
- [ ] Post-merge: rebuild + roll. From gymbro, call \`vault_request_access(key=\"fatsecret/client_id\", ...)\` — card should now render in DM instead of failing schema-validation.

## Out of scope

Purely a gateway-side UX gate. No broker changes, no protocol change. The validation is still strict enough to keep host-CLI hint output clean (no whitespace, no quotes), just no longer stricter than the broker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)