### PR TITLE
fix(two-zone): humanize last-tool verb on fleet row + drop raw arg (#861)

### DIFF
--- a/telegram-plugin/tests/two-zone-card-fleet-row.test.ts
+++ b/telegram-plugin/tests/two-zone-card-fleet-row.test.ts
@@ -59,14 +59,15 @@ describe('renderFleetRow', () => {
     expect(out).not.toContain('abcdef0')
   })
 
-  it('renders running with last tool + age', () => {
+  it('renders running with humanized last-tool phrase + age (#861)', () => {
     const out = renderFleetRow(fm({
       lastActivityAt: NOW - 5000,
       lastTool: { name: 'Read', sanitisedArg: 'file.ts' },
       toolCount: 3,
     }), NOW)
-    expect(out).toContain('Read')
-    expect(out).toContain('file.ts')
+    expect(out).toContain('Reading file')
+    // Raw arg is intentionally NOT in the rendered row (#861).
+    expect(out).not.toContain('file.ts')
     expect(out).toContain('5s ago')
     expect(out).toContain('3t')
     expect(out.startsWith('↻')).toBe(true)

--- a/telegram-plugin/tests/two-zone-card-sanitise.test.ts
+++ b/telegram-plugin/tests/two-zone-card-sanitise.test.ts
@@ -38,21 +38,33 @@ function fm(over: Partial<FleetMember>): FleetMember {
 }
 
 describe('two-zone-card sanitise', () => {
-  it('does not contain raw absolute path under /etc/secrets', () => {
+  // Post-#861 the fleet row no longer renders the sanitisedArg at all
+  // (the row shows a humanized verb phrase like "Reading file" or
+  // "Running command" instead). These tests collapse to a stronger
+  // assertion: the renderer can't leak secret paths/bearer tokens no
+  // matter what shape the sanitisedArg takes, because that field
+  // doesn't reach the output.
+  it('does not contain raw absolute path even if sanitisedArg leaked one (defense-in-depth)', () => {
     const fleet = new Map([['a', fm({
-      lastTool: { name: 'Read', sanitisedArg: 'foo.key' }, // already sanitised by fleet-state
+      // Deliberately pass an *un*sanitised value here to assert the
+      // renderer can't be tricked into leaking it.
+      lastTool: { name: 'Read', sanitisedArg: '/etc/secrets/foo.key' },
     })]])
     const out = renderTwoZoneCard({ state: baseState, fleet, now: 2000 })
     expect(out).not.toContain('/etc/secrets')
-    expect(out).toContain('foo.key')
+    expect(out).not.toContain('foo.key')
+    // The row should still surface that *some* file read happened.
+    expect(out).toContain('Reading file')
   })
 
-  it('does not contain bearer-shaped tokens (sanitised upstream)', () => {
+  it('does not contain bearer-shaped tokens even if sanitisedArg leaked one', () => {
     const fleet = new Map([['a', fm({
-      lastTool: { name: 'Bash', sanitisedArg: 'curl -H "Authorization: [redacted]" https://api' },
+      lastTool: { name: 'Bash', sanitisedArg: 'curl -H "Authorization: Bearer abc123def456ghi789jkl" https://api' },
     })]])
     const out = renderTwoZoneCard({ state: baseState, fleet, now: 2000 })
-    expect(out).toContain('[redacted]')
     expect(out).not.toMatch(/Bearer\s+[A-Za-z0-9]{16,}/)
+    expect(out).not.toContain('abc123def456ghi789jkl')
+    // The row should still surface that *some* command ran.
+    expect(out).toContain('Running command')
   })
 })

--- a/telegram-plugin/tests/two-zone-card-snapshot.test.ts
+++ b/telegram-plugin/tests/two-zone-card-snapshot.test.ts
@@ -68,7 +68,7 @@ describe('two-zone-card snapshots', () => {
       '⚙️ <b>Working…</b> · ⏱ 00:30 · 🔧 14 · 🤖 3\n' +
       '\n' +
       '<b>FLEET (3)</b>\n' +
-      '↻ researcher <code>aaaaaa</code> · 4t · Grep <code>TODO</code> (2s ago)\n' +
+      '↻ researcher <code>aaaaaa</code> · 4t · Searching files (2s ago)\n' +
       '✓ worker <code>bbbbbb</code> · 8t · done 10s ago\n' +
       '⚠ reviewer <code>cccccc</code> · 2t · idle 1m10s ago',
     )
@@ -126,7 +126,7 @@ describe('two-zone-card snapshots', () => {
       '🌀 <b>Background</b> · ⏱ 01:30 · 🔧 17 · 🤖 2\n' +
       '\n' +
       '<b>FLEET (2)</b>\n' +
-      '🌀 background <code>bbbbbb</code> · 12t · Bash <code>long-job.sh</code> (1s ago)\n' +
+      '🌀 background <code>bbbbbb</code> · 12t · Running command (1s ago)\n' +
       '✓ worker <code>aaaaaa</code> · 5t · done 30s ago',
     )
   })

--- a/telegram-plugin/tests/two-zone-snapshot-extras.test.ts
+++ b/telegram-plugin/tests/two-zone-snapshot-extras.test.ts
@@ -68,7 +68,7 @@ describe('PR-C2: two-zone card snapshot extras', () => {
       '🙊 <b>Ended without reply</b> · ⏱ 00:30 · 🔧 7 · 🤖 1\n' +
       '\n' +
       '<b>FLEET (1)</b>\n' +
-      '🌀 background <code>aaaaaa</code> · 7t · Bash <code>long.sh</code> (2s ago)',
+      '🌀 background <code>aaaaaa</code> · 7t · Running command (2s ago)',
     )
   })
 

--- a/telegram-plugin/two-zone-card.ts
+++ b/telegram-plugin/two-zone-card.ts
@@ -214,6 +214,58 @@ export function renderFleetRow(m: FleetMember, now: number): string {
   return `${glyph} ${role} <code>${id6}</code> · ${tools} · ${activity}`
 }
 
+/**
+ * Map a raw Claude Code tool name to a human-readable verb phrase for
+ * the fleet row. See #861 — the prior rendering leaked raw shell
+ * commands and tool-name + truncated-arg blobs into the status card,
+ * which read as terminal log spew rather than "what is the agent
+ * doing." The phrases here are intentionally short (≤22 chars) so a
+ * mobile-width fleet row stays one line.
+ *
+ * Future improvement (#861 ideal): wire the preamble field through
+ * fleet-state so a model-emitted "Searching for typing handlers"
+ * preceding the tool_use beats the generic phrase. That requires
+ * adding `preamble` to FleetMember and threading it through
+ * applyToolUse — bigger change, tracked separately.
+ */
+export function humanizeToolName(toolName: string): string {
+  switch (toolName) {
+    case 'Bash':
+    case 'BashOutput':
+      return 'Running command'
+    case 'KillShell':
+      return 'Killing shell'
+    case 'Read':
+      return 'Reading file'
+    case 'Write':
+    case 'Edit':
+    case 'NotebookEdit':
+      return 'Editing file'
+    case 'Glob':
+    case 'Grep':
+      return 'Searching files'
+    case 'WebFetch':
+      return 'Fetching URL'
+    case 'WebSearch':
+      return 'Searching the web'
+    case 'Task':
+    case 'Agent':
+      return 'Sub-agent'
+    case 'TodoWrite':
+      return 'Updating todos'
+    case 'AskUserQuestion':
+      return 'Asking user'
+    case 'ExitPlanMode':
+      return 'Exiting plan'
+    default:
+      // Unknown tool — keep the name (escaped) so a brand-new tool
+      // shows something rather than disappearing. Surface as
+      // "Using <Name>" instead of bare "<Name>" so the human-language
+      // pattern is preserved.
+      return `Using ${escapeHtml(toolName)}`
+  }
+}
+
 export function formatLastActivity(m: FleetMember, now: number): string {
   // Terminal states show "<status> <relative-time>"
   if (m.terminalAt != null) {
@@ -225,16 +277,19 @@ export function formatLastActivity(m: FleetMember, now: number): string {
     const idle = formatRelativeTime(Math.max(0, now - m.lastActivityAt))
     return `idle ${idle}`
   }
-  // Running — show last tool + age
+  // Running — show humanized tool descriptor + age. Pre-#861 this
+  // surfaced the raw tool name + truncated command (e.g. `Bash cd
+  // /home/… && gre…`); the issue documents how that reads as
+  // terminal log spew rather than a status update. Raw arg is
+  // dropped on purpose — it's never short enough to be useful on
+  // mobile and the agent-id chip + token-count already disambiguate
+  // between concurrent sub-agents.
   if (m.lastTool == null) {
     const age = formatRelativeTime(Math.max(0, now - m.lastActivityAt))
     return `started ${age}`
   }
   const age = formatRelativeTime(Math.max(0, now - m.lastActivityAt))
-  const arg = m.lastTool.sanitisedArg
-    ? ` <code>${escapeHtml(truncate(m.lastTool.sanitisedArg, 60))}</code>`
-    : ''
-  return `${escapeHtml(m.lastTool.name)}${arg} (${age})`
+  return `${humanizeToolName(m.lastTool.name)} (${age})`
 }
 
 export function glyphForFleetStatus(status: FleetStatus): string {


### PR DESCRIPTION
Closes #861. The fleet zone of the parent's progress card was rendering raw tool calls (`Bash cd /home/… && gre…`) which read as terminal log spew rather than "what is the agent doing."

Adds `humanizeToolName` mapper returning short human-language phrases (`Bash → "Running command", Grep/Glob → "Searching files", Read → "Reading file", Edit/Write → "Editing file", WebFetch → "Fetching URL"`, etc.). `formatLastActivity` uses the phrase and drops the raw arg.

## Side-effect security win

The sanitisedArg field no longer reaches the rendered output. Even if upstream `sanitiseToolArg` ever leaks a secret path or bearer token, the renderer can't surface it. The sanitise tests are now stronger: they pass *unsanitised* values and assert the output still can't leak.

## Out of scope

Plumbing the model-emitted preamble ("Searching for typing handlers") through FleetMember so a preamble beats the generic phrase. That's a fleet-state schema change; the issue mentions it as the ideal but accepts the humanized-phrase fallback as the minimum.

## Test plan

- [x] Snapshot tests updated: two-zone-card-snapshot.test.ts, two-zone-snapshot-extras.test.ts, two-zone-card-fleet-row.test.ts, two-zone-card-sanitise.test.ts.
- [x] 2793/2793 telegram-plugin tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)