### PR TITLE
fix(vault): forward capability token on broker get so freshly-minted grants actually work (#1053)

### DIFF
--- a/src/cli/vault.ts
+++ b/src/cli/vault.ts
@@ -731,8 +731,21 @@ export function registerVaultCommand(program: Command): void {
             }
           }
 
-          // Broker is unlocked — request the key
-          const result = await getViaBrokerStructured(key, brokerOpts);
+          // Broker is unlocked — request the key.
+          // Issue #1053: include the agent's capability token so the
+          // broker's grant path (server.ts:994-1028) can bypass the
+          // peercred ACL check. Mirror the `vault set` path above
+          // (line 401-402) which has done this since #969 P1b.
+          // Without this, a freshly-minted grant (Telegram approval
+          // card) writes a token file the CLI then ignores —
+          // subsequent `vault get` still gets DENIED on the
+          // peercred ACL even though the operator just approved.
+          const getAgentSlug = process.env.SWITCHROOM_AGENT_NAME;
+          const getToken = getAgentSlug ? readVaultTokenFile(getAgentSlug) ?? undefined : undefined;
+          const result = await getViaBrokerStructured(key, {
+            ...brokerOpts,
+            ...(getToken ? { token: getToken } : {}),
+          });
 
           if (result.kind === "ok") {
             const entry = result.entry;

--- a/src/vault/broker/client-get-token.test.ts
+++ b/src/vault/broker/client-get-token.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Regression tests for #1053: `getViaBrokerStructured` must forward
+ * the agent's capability token in the wire payload.
+ *
+ * Pre-fix: an agent with a freshly-minted grant (via Telegram
+ * approval card flow) had its `.vault-token` file written, but the
+ * CLI's `switchroom vault get` and the cascade's vault-reference
+ * resolver both used `getViaBrokerStructured(key, opts)` without
+ * forwarding the token. The broker's grant code path
+ * (server.ts:994-1028) was therefore never invoked — every get
+ * fell through to the peercred ACL, which still denied the key.
+ *
+ * Net effect (from gymbro): Telegram approval card → operator
+ * passphrase → broker mints token → `.vault-token` written → agent
+ * runs `switchroom vault get fatsecret/client_id` → broker returns
+ * VAULT-BROKER-DENIED: not in ACL. The approval flow looked like
+ * it worked but the agent could still not read the key.
+ *
+ * Post-fix: getViaBrokerStructured accepts `token` on its opts and
+ * forwards it on the wire. Broker validates via validateGrant and
+ * bypasses ACL when the grant authorizes the key.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import * as net from "node:net";
+import * as os from "node:os";
+import * as path from "node:path";
+import * as fs from "node:fs";
+import { getViaBrokerStructured, putViaBroker } from "./client.js";
+import {
+  encodeResponse,
+  errorResponse,
+  entryResponse,
+  type BrokerRequest,
+} from "./protocol.js";
+
+/**
+ * Fake broker that records every inbound request and replies with a
+ * canned response. Lets us assert what the client puts on the wire
+ * without spinning up the full broker.
+ */
+function startFakeBroker(handler: (req: BrokerRequest) => unknown) {
+  let socketPath: string;
+  let tmpDir: string;
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "broker-client-token-"));
+  socketPath = path.join(tmpDir, "fake.sock");
+
+  const requests: BrokerRequest[] = [];
+  const server = net.createServer((socket) => {
+    let buf = "";
+    socket.on("data", (chunk) => {
+      buf += chunk.toString("utf8");
+      let idx: number;
+      while ((idx = buf.indexOf("\n")) !== -1) {
+        const line = buf.slice(0, idx);
+        buf = buf.slice(idx + 1);
+        try {
+          const req = JSON.parse(line) as BrokerRequest;
+          requests.push(req);
+          const resp = handler(req);
+          socket.write(encodeResponse(resp as never));
+          socket.end();
+        } catch (e) {
+          socket.write(encodeResponse(errorResponse("INTERNAL", String(e))));
+          socket.end();
+        }
+      }
+    });
+  });
+  return new Promise<{
+    socketPath: string;
+    requests: BrokerRequest[];
+    stop: () => Promise<void>;
+  }>((resolve) => {
+    server.listen(socketPath, () => {
+      resolve({
+        socketPath,
+        requests,
+        stop: () =>
+          new Promise<void>((r) => {
+            server.close(() => {
+              try {
+                fs.rmSync(tmpDir, { recursive: true, force: true });
+              } catch {
+                /* ignore */
+              }
+              r();
+            });
+          }),
+      });
+    });
+  });
+}
+
+describe("getViaBrokerStructured: forwards capability token (#1053)", () => {
+  let broker: Awaited<ReturnType<typeof startFakeBroker>>;
+
+  beforeEach(async () => {
+    broker = await startFakeBroker((req) => {
+      if (req.op === "get") {
+        return entryResponse({ kind: "string", value: `value-of-${req.key}` });
+      }
+      return errorResponse("BAD_REQUEST", `unhandled op: ${req.op}`);
+    });
+  });
+
+  afterEach(async () => {
+    await broker.stop();
+  });
+
+  it("includes `token` on the wire when opts.token is set", async () => {
+    // fails when: the CLI's `vault get` writes the token file (after
+    // a Telegram approval card mint) but the wire payload doesn't
+    // carry it — the broker's grant path is unreachable and the
+    // agent gets DENIED on the peercred ACL anyway. This was the
+    // gymbro bug class.
+    const result = await getViaBrokerStructured("fatsecret/client_id", {
+      socket: broker.socketPath,
+      token: "vg_abc123.deadbeefcafe",
+    });
+    expect(result.kind).toBe("ok");
+    expect(broker.requests).toHaveLength(1);
+    const req = broker.requests[0]!;
+    expect(req.op).toBe("get");
+    expect((req as { key: string }).key).toBe("fatsecret/client_id");
+    expect((req as { token?: string }).token).toBe("vg_abc123.deadbeefcafe");
+  });
+
+  it("omits `token` when no token is provided (back-compat with peercred-only get)", async () => {
+    // The legacy path-as-identity / peercred get still works for
+    // agents that don't have a grant yet. The token field should be
+    // absent from the wire entirely (not "" / not null) so a
+    // forward-compat broker parser doesn't accidentally hit the
+    // grant-validation branch on a null/empty token.
+    const result = await getViaBrokerStructured("legacy_key", {
+      socket: broker.socketPath,
+    });
+    expect(result.kind).toBe("ok");
+    expect(broker.requests).toHaveLength(1);
+    const req = broker.requests[0]!;
+    expect("token" in req).toBe(false);
+  });
+
+  it("regression: putViaBroker still forwards token + passphrase (sanity, no behaviour change here)", async () => {
+    // Sanity guard so a future refactor of the put helper doesn't
+    // drop the token alongside this PR's get-side change.
+    await broker.stop();
+    broker = await startFakeBroker((req) => {
+      if (req.op === "put") {
+        return { ok: true, put: true, key: (req as { key: string }).key };
+      }
+      return errorResponse("BAD_REQUEST", `unhandled op: ${req.op}`);
+    });
+    const result = await putViaBroker(
+      "k",
+      { kind: "string", value: "v" },
+      { socket: broker.socketPath, token: "vg_xyz.beef", passphrase: "operator-pass" },
+    );
+    expect(result.kind).toBe("ok");
+    const req = broker.requests[0]!;
+    expect((req as { token?: string }).token).toBe("vg_xyz.beef");
+    expect((req as { passphrase?: string }).passphrase).toBe("operator-pass");
+  });
+});

--- a/src/vault/broker/client.ts
+++ b/src/vault/broker/client.ts
@@ -460,9 +460,21 @@ async function rpc(
  */
 export async function getViaBrokerStructured(
   key: string,
-  opts?: BrokerClientOpts,
+  opts?: BrokerClientOpts & { token?: string },
 ): Promise<GetResult> {
-  const result = await rpc({ v: 1, op: "get", key }, opts);
+  // Include the token in the wire payload only when present. The
+  // broker validates via validateGrant (server.ts:994-1028) — when
+  // the grant authorizes read for this key, the broker bypasses
+  // path-as-identity ACL. Issue #1053: the CLI's `vault get` path
+  // wasn't forwarding the token, so freshly-minted grants via the
+  // Telegram approval card flow had no effect — the get still
+  // got denied on the peercred ACL. Mirrors the `putViaBroker`
+  // shape that has supported `token` since #969 P1b.
+  const token = opts?.token;
+  const result = await rpc(
+    { v: 1, op: "get", key, ...(token ? { token } : {}) },
+    opts,
+  );
   if (result.kind === "unreachable") {
     return { kind: "unreachable", msg: result.msg };
   }

--- a/src/vault/resolver.ts
+++ b/src/vault/resolver.ts
@@ -17,6 +17,7 @@ import { resolvePath } from "../config/loader.js";
 import {
   getViaBrokerStructured,
   resolveBrokerSocketPath,
+  readVaultTokenFile,
   type BrokerClientOpts,
 } from "./broker/client.js";
 
@@ -317,8 +318,19 @@ export async function resolveVaultReferencesViaBroker(
   let sawLocked = false;
   let sawNotFound = false;
 
+  // #1053: forward the agent's capability token so the broker can
+  // bypass the peercred ACL on grant-authorized keys. Without this,
+  // freshly-minted grants via the Telegram approval card flow had
+  // no effect on cascade-time `vault:<key>` resolution either —
+  // same bug class as the CLI `vault get` path.
+  const resolverAgentSlug = process.env.SWITCHROOM_AGENT_NAME;
+  const resolverToken = resolverAgentSlug
+    ? readVaultTokenFile(resolverAgentSlug) ?? undefined
+    : undefined;
+  const optsWithToken = resolverToken ? { ...opts, token: resolverToken } : opts;
+
   for (const key of refs) {
-    const result = await getViaBrokerStructured(key, opts);
+    const result = await getViaBrokerStructured(key, optsWithToken);
     if (result.kind === "ok") {
       brokerSecrets[key] = result.entry;
     } else if (result.kind === "unreachable") {

--- a/telegram-plugin/uat/scenarios/vault-request-access-end-to-end-dm.test.ts
+++ b/telegram-plugin/uat/scenarios/vault-request-access-end-to-end-dm.test.ts
@@ -1,0 +1,158 @@
+/**
+ * End-to-end UAT scenario for the agent-initiated vault_request_access
+ * flow — closes the test-coverage gap that allowed #1053 to ship.
+ *
+ * #1053: an agent called `vault_request_access`, operator approved,
+ * passphrase was entered, broker minted a grant token and wrote it
+ * to `.vault-token` — BUT the agent's subsequent `vault get` still
+ * returned VAULT-BROKER-DENIED because the CLI's get path didn't
+ * forward the token. Every unit test passed (gateway, broker, CLI
+ * each looked right in isolation) but the integration was broken.
+ *
+ * The lesson the operator drew: "test and prevent these kinds of
+ * things using the full telegram test bot." This scenario is that
+ * test — it round-trips through real Telegram, real broker, real
+ * agent, asserting the final state (vault get succeeds) rather
+ * than any single component's contract.
+ *
+ * Sibling: `vault-audit-allow-dm.test.ts` exercises the OPERATOR-
+ * initiated path (operator opens /vault audit, taps Allow on a
+ * recent denial). This scenario exercises the AGENT-initiated path
+ * (agent calls vault_request_access, operator approves the card
+ * the agent's tool emitted) — a different gateway handler
+ * (handleVaultRequestAccessCallback vs handleVaultRecentDenialCallback)
+ * but the same broker token-writing + grant-validation backend.
+ *
+ * **Skipped by default.** To unskip:
+ *
+ * 1. Standard UAT preflight (`uat/SETUP.md` §5-6) — test-harness
+ *    agent live, driver session auth'd, env vars set.
+ *
+ * 2. **Operator passphrase visibility.** The scenario must enter
+ *    the operator's vault passphrase in chat as part of the
+ *    approve flow. Set `TELEGRAM_UAT_VAULT_PASSPHRASE` in the
+ *    env so the scenario can send it. The gateway deletes the
+ *    passphrase message from chat history immediately after
+ *    caching it (see `deleteSensitiveMessage` in gateway.ts) so
+ *    no plaintext lingers.
+ *
+ * 3. **Sacrificial vault key.** Same convention as the
+ *    `/vault audit` scenario — pre-create a key the harness can
+ *    request. Suggested:
+ *
+ *    ```bash
+ *    TMPF=$(mktemp) && printf '%s' 'sentinel-1053-value' > "$TMPF" && \
+ *      switchroom vault set uat/req-access-target --file "$TMPF" \
+ *        --format string ; shred -u "$TMPF"
+ *    ```
+ *
+ *    Slash-namespaced shape on purpose — also exercises #1047
+ *    (vault-key regex allowing '/').
+ *
+ * 4. Remove `describe.skip` below.
+ *
+ * Why skipped: mutates host vault state (mints a 30-day grant on
+ * test-harness) — opt-in only. Cleanup is operator-side
+ * (`switchroom vault revoke <grant-id>` after the run).
+ */
+
+import { describe, expect, it } from "vitest";
+import { spinUp } from "../harness.js";
+
+const SENTINEL_VALUE = "sentinel-1053-value";
+const TARGET_KEY = "uat/req-access-target";
+
+describe.skip("uat: vault_request_access end-to-end (#1053 regression)", () => {
+  it(
+    "agent calls tool → operator approves + enters passphrase → agent reads the value",
+    async () => {
+      const operatorPassphrase = process.env.TELEGRAM_UAT_VAULT_PASSPHRASE;
+      if (!operatorPassphrase) {
+        throw new Error(
+          "TELEGRAM_UAT_VAULT_PASSPHRASE must be set in env for this scenario " +
+          "(see SETUP.md). The scenario sends it via DM as part of the approve " +
+          "flow; the gateway deletes the message immediately after caching.",
+        );
+      }
+      const sc = await spinUp({ agent: "test-harness" });
+      try {
+        // 1. Tell the agent to call the MCP tool. The agent's reply
+        //    is what fires the approval card — we don't fire it
+        //    from the driver side because the WHOLE POINT is to
+        //    cover the agent → gateway → broker → token-file
+        //    → agent path.
+        await sc.sendDM(
+          `Please call your vault_request_access MCP tool with ` +
+          `key="${TARGET_KEY}", scope="read", reason="UAT regression for #1053". ` +
+          `Then attempt to read the key once the operator confirms.`,
+        );
+
+        // 2. Wait for the bot's approval card. Anchor on the
+        //    headline emoji + tool-specific copy.
+        const card = await sc.expectMessage(/🔐.*wants vault access/, {
+          from: "bot",
+          timeout: 60_000,
+        });
+
+        // 3. Confirm the card carries the right inline keyboard.
+        //    Locate the [✅ Approve] button.
+        const kb = await sc.driver.getKeyboard(sc.botUserId, card.messageId);
+        expect(kb).not.toBeNull();
+        const approveButton = kb!
+          .flat()
+          .find((b) => b.callbackData !== undefined && /approve/i.test(b.text));
+        expect(approveButton, "card should have an [✅ Approve] button").toBeDefined();
+
+        // 4. Tap Approve. With no cached passphrase yet, the gateway
+        //    edits the card to prompt for the passphrase as the
+        //    next message (vault_request_access tap-to-unlock flow
+        //    from #1012 Phase 2 / #1034).
+        await sc.driver.pressButton(
+          sc.botUserId,
+          card.messageId,
+          approveButton!.callbackData!,
+        );
+        await sc.expectMessage(/Vault is locked.*Reply with your passphrase/, {
+          from: "bot",
+          timeout: 15_000,
+        });
+
+        // 5. Send the passphrase. Gateway caches it, deletes the
+        //    chat message via deleteSensitiveMessage, then auto-
+        //    resumes the mint flow. Card edits to the "Granted"
+        //    state when the broker accepts the attestation.
+        await sc.sendDM(operatorPassphrase);
+        await sc.expectMessage(/Granted.*read access/, {
+          from: "bot",
+          timeout: 30_000,
+        });
+
+        // 6. THE LOAD-BEARING ASSERTION FOR #1053: ask the agent
+        //    to fetch the key. The agent's `switchroom vault get`
+        //    MUST forward the freshly-minted token. If it doesn't
+        //    (the pre-#1053-fix state), the broker denies on the
+        //    peercred ACL and the agent reports VAULT-BROKER-DENIED.
+        //    Post-fix: the get succeeds and returns the sentinel
+        //    value the operator pre-staged.
+        await sc.sendDM(
+          `Now run: switchroom vault get ${TARGET_KEY} — and tell me ` +
+          `exactly what the command printed (including any error markers).`,
+        );
+        const replyAfterGet = await sc.expectMessage(
+          new RegExp(SENTINEL_VALUE),
+          { from: "bot", timeout: 60_000 },
+        );
+        expect(replyAfterGet.text).toContain(SENTINEL_VALUE);
+        // The bot's reply MUST NOT contain the denial marker. This
+        // is the regression guard: a future bug that reintroduces
+        // the silent token-drop would surface VAULT-BROKER-DENIED
+        // alongside the value (or instead of it).
+        expect(replyAfterGet.text).not.toMatch(/VAULT-BROKER-DENIED/);
+      } finally {
+        await sc.tearDown();
+      }
+    },
+    300_000, // 5 min — covers card render + Approve tap + passphrase
+             // round-trip + grant mint + agent's next turn + vault get.
+  );
+});

--- a/tests/cli-vault-get-token-wiring.test.ts
+++ b/tests/cli-vault-get-token-wiring.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Static-source guard pinning that the CLI's `vault get` and the
+ * cascade-time vault-reference resolver BOTH read the capability
+ * token file and forward it via `getViaBrokerStructured`.
+ *
+ * Lives at the integration-shape layer that the unit-level test
+ * `src/vault/broker/client-get-token.test.ts` can't reach: the
+ * client unit test proves the wire payload is correct when the
+ * caller passes a token, but it can't catch the case where the
+ * caller never bothers to read the token in the first place —
+ * which is exactly how #1053 got past code review.
+ *
+ * This file pins the call-site wiring. If a future refactor moves
+ * `vault get` to a different code path that forgets to read the
+ * token file, this test fails loudly with a recognizable message
+ * pointing at the regression class.
+ */
+
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const REPO_ROOT = resolve(__dirname, "..");
+
+describe("vault get CLI forwards the agent's capability token (#1053 regression guard)", () => {
+  const cliSrc = readFileSync(resolve(REPO_ROOT, "src/cli/vault.ts"), "utf-8");
+
+  it("the get-via-broker call site reads the agent's token file", () => {
+    // Locate the broker get call by anchor; the surrounding window
+    // MUST mention readVaultTokenFile.
+    const ix = cliSrc.indexOf("getViaBrokerStructured(");
+    expect(ix, "expected getViaBrokerStructured call site in src/cli/vault.ts").toBeGreaterThan(0);
+    const window = cliSrc.slice(Math.max(0, ix - 600), ix + 200);
+    // The call must be preceded by a token read.
+    expect(
+      window,
+      "vault get's broker-call site must read the agent's .vault-token (readVaultTokenFile) — see #1053",
+    ).toMatch(/readVaultTokenFile/);
+    // And the resolved token must be passed on the call.
+    expect(
+      window,
+      "vault get's broker-call site must forward the token in opts (e.g. token: getToken)",
+    ).toMatch(/token:\s*(getToken|token)/);
+  });
+});
+
+describe("vault-reference resolver forwards the agent's capability token (#1053 regression guard)", () => {
+  const resolverSrc = readFileSync(
+    resolve(REPO_ROOT, "src/vault/resolver.ts"),
+    "utf-8",
+  );
+
+  it("the cascade-time resolver reads the token before its per-key loop", () => {
+    const ix = resolverSrc.indexOf("getViaBrokerStructured(");
+    expect(ix, "expected getViaBrokerStructured call site in src/vault/resolver.ts").toBeGreaterThan(0);
+    const window = resolverSrc.slice(Math.max(0, ix - 600), ix + 100);
+    // Resolver must read SWITCHROOM_AGENT_NAME and the token file
+    // (mirrors the CLI path); without this, agents that need
+    // grant-authorized cascade refs at startup hit the same #1053
+    // class of bug.
+    expect(window).toMatch(/SWITCHROOM_AGENT_NAME/);
+    expect(window).toMatch(/readVaultTokenFile/);
+    expect(window).toMatch(/token/);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #1053 — the operator-approved \`vault_request_access\` flow looked like it worked but the agent still couldn't read the key.

## Root cause

\`getViaBrokerStructured\` in \`src/vault/broker/client.ts\` sent \`{v:1, op:\"get\", key}\` with no token. The broker's grant-validation path (\`server.ts:994-1028\`) was therefore never invoked — every get fell through to the peercred ACL, which denied the freshly-granted key.

The CLI's \`vault set\` path has read + forwarded the token since #969 P1b. The \`vault get\` path drifted out of sync.

## Fix (three small changes)

- **\`src/vault/broker/client.ts\`** — extend \`getViaBrokerStructured\`'s opts to accept \`token?: string\` and forward it on the wire. Mirrors \`putViaBroker\`'s shape.
- **\`src/cli/vault.ts:735\`** — read \`readVaultTokenFile(SWITCHROOM_AGENT_NAME)\` and pass through. Mirrors the set-path at line 401-402.
- **\`src/vault/resolver.ts:321\`** — same omission in the cascade-time \`vault:<key>\` reference resolver. Same fix.

## Test plan

- [x] \`npm run lint\` — clean.
- [x] New \`src/vault/broker/client-get-token.test.ts\` (3 cases). Uses a fake broker that records inbound wire requests; asserts token forwarded when set, absent when not, plus a regression guard that \`putViaBroker\` still forwards token + passphrase.
- [x] \`npm test\` — 5505/0 pass.
- [ ] Post-merge dogfood: pull new agent image, repeat the gymbro repro from #1053 — call \`vault_request_access\` for \`fatsecret/client_id\`, tap Approve, enter passphrase, then run \`switchroom vault get fatsecret/client_id\` from the agent. Should print the value, not VAULT-BROKER-DENIED.

## Out of scope

- **#1051** (concurrent approval cards collapse passphrase prompt) — independent bug; needs cached-passphrase-window logic.
- **#1052** (agent auto-resume after grant lands) — independent bug; needs synthetic channel event from broker → agent gateway.

The reporter flagged #1053 as the blocker behind both — agreed; this is the load-bearing fix. Without it, fixing #1051 and #1052 doesn't help because the agent still can't read the key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)