### PR TITLE
fix(progress-card): bg pending Agent spawn survives parent turn_end (RFC Phase 3 Bug 1)

### DIFF
--- a/telegram-plugin/progress-card.ts
+++ b/telegram-plugin/progress-card.ts
@@ -227,6 +227,16 @@ export interface PendingAgentSpawn {
   readonly subagentType?: string
   readonly promptText: string
   readonly startedAt: number
+  /**
+   * True when the parent emitted `Agent(run_in_background: true)`.
+   * Background sub-agents arrive AFTER the parent's `turn_end`, so
+   * background pending entries MUST survive the `turn_end` reducer's
+   * pending-spawn cleanup — otherwise the next `sub_agent_started`
+   * lands as an orphan with `pendingSpawns=0` (the live bug surfaced
+   * by `bg-sub-agent-dispatch-dm.test.ts`, see RFC Phase 2 §Bug 1
+   * in reference/sub-agent-visibility-rfc.md).
+   */
+  readonly runInBackground: boolean
 }
 
 export interface NarrativeStep {
@@ -559,7 +569,11 @@ export function reduce(
           process.stderr.write(`telegram gateway: progress-card: tool_use → agent correlation toolUseId=${event.toolUseId} agentId=${bestAgentId} (reverse-race adopt orphan)\n`)
         }
         if (!adopted) {
-          process.stderr.write(`telegram gateway: progress-card: tool_use → agent correlation toolUseId=${event.toolUseId} agentId=pending (awaiting sub_agent_started)\n`)
+          // Capture run_in_background flag — load-bearing for the
+          // turn_end pending-spawn preservation below. See
+          // PendingAgentSpawn.runInBackground JSDoc + RFC Phase 2 §Bug 1.
+          const runInBackground = event.input?.run_in_background === true
+          process.stderr.write(`telegram gateway: progress-card: tool_use → agent correlation toolUseId=${event.toolUseId} agentId=pending (awaiting sub_agent_started) bg=${runInBackground}\n`)
           const nextPending = new Map(pendingAgentSpawns)
           nextPending.set(event.toolUseId, {
             parentToolUseId: event.toolUseId,
@@ -567,6 +581,7 @@ export function reduce(
             subagentType,
             promptText,
             startedAt: now,
+            runInBackground,
           })
           pendingAgentSpawns = nextPending
         }
@@ -954,12 +969,26 @@ export function reduce(
       const narratives = state.narratives.map(n =>
         n.state === 'active' ? narrativeTransitionFromActive(n, subAgents) : n,
       )
+      // Preserve background pending spawns past turn_end. The
+      // parent's reply lands and turn_end fires in seconds, but the
+      // bg sub-agent's JSONL transcript appears later (worker takes
+      // its own startup time). Clearing pendingAgentSpawns wholesale
+      // here causes the eventual sub_agent_started to register as
+      // an orphan with `pendingSpawns=0` and isBackgroundDispatch=false,
+      // which then derails the header phase + defer-gate logic
+      // downstream. See RFC Phase 2 §Bug 1 in
+      // reference/sub-agent-visibility-rfc.md, surfaced by
+      // bg-sub-agent-dispatch-dm.test.ts.
+      const preservedPending = new Map<string, PendingAgentSpawn>()
+      for (const [k, v] of state.pendingAgentSpawns) {
+        if (v.runInBackground) preservedPending.set(k, v)
+      }
       return {
         ...state,
         items,
         narratives,
         subAgents,
-        pendingAgentSpawns: new Map(),
+        pendingAgentSpawns: preservedPending,
         stage: 'done',
         thinking: false,
         pendingPreamble: null,

--- a/telegram-plugin/tests/pending-bg-spawn-survives-turn-end.test.ts
+++ b/telegram-plugin/tests/pending-bg-spawn-survives-turn-end.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Regression gate for RFC Phase 2 §Bug 1
+ * (reference/sub-agent-visibility-rfc.md).
+ *
+ * Background sub-agents arrive AFTER the parent's `turn_end` event —
+ * the parent's reply lands in seconds, the bg worker takes longer to
+ * spin up its JSONL transcript. Before the fix, the reducer's
+ * `turn_end` case cleared `pendingAgentSpawns` wholesale; the eventual
+ * `sub_agent_started` then registered as an orphan with
+ * `pendingSpawns=0`, derailing both the `isBackgroundDispatch` flag
+ * AND the header-phase resolver downstream.
+ *
+ * After the fix: `turn_end` preserves entries whose `runInBackground`
+ * is true. Foreground entries are still cleared (no behaviour change
+ * for the common case).
+ *
+ * Surfaced by `telegram-plugin/uat/scenarios/
+ * bg-sub-agent-dispatch-dm.test.ts` running against real Telegram.
+ */
+
+import { describe, expect, it } from 'vitest'
+import { initialState, reduce } from '../progress-card.js'
+
+const NOW = 1_000_000
+
+function startedTurn(): ReturnType<typeof reduce> {
+  // Drive the reducer through `enqueue` → `text` so it's in a real
+  // post-`turn_start` state with `turnStartedAt` set. Direct
+  // construction of a state with a populated `pendingAgentSpawns`
+  // would bypass the tool_use code path we want to exercise.
+  let s = reduce(initialState(), {
+    kind: 'enqueue',
+    rawContent: 'test inbound',
+  }, NOW - 100)
+  s = reduce(s, { kind: 'text', text: 'starting work' }, NOW - 90)
+  return s
+}
+
+describe('reducer: turn_end pending-spawn preservation (RFC §Bug 1)', () => {
+  it('preserves a pending Agent(run_in_background:true) spawn across turn_end', () => {
+    let state = startedTurn()
+    state = reduce(state, {
+      kind: 'tool_use',
+      toolName: 'Agent',
+      toolUseId: 'tu-bg-1',
+      input: {
+        prompt: 'run a long background task',
+        description: 'bg worker',
+        subagent_type: 'general-purpose',
+        run_in_background: true,
+      },
+    }, NOW - 80)
+    expect(state.pendingAgentSpawns.size).toBe(1)
+    expect(state.pendingAgentSpawns.get('tu-bg-1')?.runInBackground).toBe(true)
+
+    state = reduce(state, { kind: 'turn_end', durationMs: 50 }, NOW)
+    // The bg pending spawn MUST survive. The corresponding
+    // sub_agent_started event will arrive later (worker has its own
+    // startup latency) and needs to match against this entry to be
+    // correlated rather than registered as an orphan.
+    expect(state.pendingAgentSpawns.size).toBe(1)
+    expect(state.pendingAgentSpawns.get('tu-bg-1')?.runInBackground).toBe(true)
+    expect(state.stage).toBe('done')
+  })
+
+  it('still clears foreground pending Agent spawns at turn_end (no regression)', () => {
+    let state = startedTurn()
+    state = reduce(state, {
+      kind: 'tool_use',
+      toolName: 'Agent',
+      toolUseId: 'tu-fg-1',
+      input: {
+        prompt: 'run a quick foreground task',
+        description: 'fg worker',
+        subagent_type: 'general-purpose',
+        run_in_background: false,
+      },
+    }, NOW - 80)
+    expect(state.pendingAgentSpawns.get('tu-fg-1')?.runInBackground).toBe(false)
+
+    state = reduce(state, { kind: 'turn_end', durationMs: 50 }, NOW)
+    // Foreground spawns SHOULD clear — if a foreground Agent's
+    // sub_agent_started never arrived during the turn, the pending
+    // entry is dead and shouldn't leak into the next turn.
+    expect(state.pendingAgentSpawns.size).toBe(0)
+  })
+
+  it('partial preservation: bg survives, fg clears, mixed map', () => {
+    let state = startedTurn()
+    state = reduce(state, {
+      kind: 'tool_use',
+      toolName: 'Agent',
+      toolUseId: 'tu-bg',
+      input: { prompt: 'bg', run_in_background: true },
+    }, NOW - 80)
+    state = reduce(state, {
+      kind: 'tool_use',
+      toolName: 'Agent',
+      toolUseId: 'tu-fg',
+      input: { prompt: 'fg', run_in_background: false },
+    }, NOW - 70)
+    expect(state.pendingAgentSpawns.size).toBe(2)
+
+    state = reduce(state, { kind: 'turn_end', durationMs: 50 }, NOW)
+    expect(state.pendingAgentSpawns.size).toBe(1)
+    expect(state.pendingAgentSpawns.has('tu-bg')).toBe(true)
+    expect(state.pendingAgentSpawns.has('tu-fg')).toBe(false)
+  })
+
+  it('Agent without explicit run_in_background defaults to foreground (cleared at turn_end)', () => {
+    let state = startedTurn()
+    state = reduce(state, {
+      kind: 'tool_use',
+      toolName: 'Agent',
+      toolUseId: 'tu-default',
+      input: {
+        prompt: 'no flag',
+        // run_in_background omitted — should default to false
+      },
+    }, NOW - 80)
+    expect(state.pendingAgentSpawns.get('tu-default')?.runInBackground).toBe(false)
+
+    state = reduce(state, { kind: 'turn_end', durationMs: 50 }, NOW)
+    expect(state.pendingAgentSpawns.size).toBe(0)
+  })
+
+  it('matches sub_agent_started arriving AFTER turn_end (end-to-end correlation)', () => {
+    let state = startedTurn()
+    state = reduce(state, {
+      kind: 'tool_use',
+      toolName: 'Agent',
+      toolUseId: 'tu-bg-correlate',
+      input: { prompt: 'bg correlate test', run_in_background: true },
+    }, NOW - 80)
+    // Parent turn ends BEFORE the bg worker's sub_agent_started fires.
+    state = reduce(state, { kind: 'turn_end', durationMs: 50 }, NOW)
+    expect(state.pendingAgentSpawns.size).toBe(1)
+
+    // Now the bg worker's sub_agent_started lands. It MUST find the
+    // preserved pending entry and correlate (NOT register as orphan).
+    state = reduce(state, {
+      kind: 'sub_agent_started',
+      agentId: 'agt-bg-correlated',
+      subagentType: 'general-purpose',
+      firstPromptText: 'bg correlate test',
+    }, NOW + 1_000)
+
+    const sub = state.subAgents.get('agt-bg-correlated')
+    expect(sub).toBeDefined()
+    // Correlation succeeded — parentToolUseId points back at the
+    // pending entry the bg dispatch left behind. Pre-fix this was
+    // null (orphan); post-fix it's 'tu-bg-correlate'.
+    expect(sub!.parentToolUseId).toBe('tu-bg-correlate')
+    // And the pending map is now empty — entry consumed by the match.
+    expect(state.pendingAgentSpawns.size).toBe(0)
+  })
+})


### PR DESCRIPTION
Phase 3 / Bug 1 from the sub-agent visibility RFC. Surfaced by the UAT scenario merged in #1056.

## The bug

`turn_end` reducer cleared `pendingAgentSpawns` wholesale. Background workers arrive AFTER the parent's turn ends, so their `sub_agent_started` event landed with `pendingSpawns=0` → registered as orphan → `isBackgroundDispatch: false` even though the parent's `Agent` tool_use had `run_in_background: true`.

Card transitioned to 🌀 Background only by accident (the deferred-completion gate defers on orphans separately). This is one half of the recurring "status?" UX failure in #709, #776, #782, #788.

## The fix

Three small changes in `telegram-plugin/progress-card.ts`:

1. `PendingAgentSpawn` gains `runInBackground: boolean`.
2. `tool_use` case captures the flag from `event.input?.run_in_background === true`.
3. `turn_end` filters pending spawns instead of wholesale-clearing — bg entries survive, foreground entries still clear.

## Tests

5 new cases in `pending-bg-spawn-survives-turn-end.test.ts`. The load-bearing one reproduces the production chronology (tool_use → turn_end → sub_agent_started AFTER turn_end) and proves correlation succeeds post-fix:

Before: `correlated=orphan pendingSpawns=0`
After: `correlated=yes parentToolUseId=tu-bg-correlate`

2817/2817 plugin tests pass.

## What's still red

Bug 2 (subagent-watcher row-not-in-DB) is the other half, in a parallel PR. Both need to land before the UAT scenario in #1056 can drop `.skip`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)