### PR TITLE
fix(vault): grant-key union + pending-op queue so concurrent vault_request_access approvals don't strand prior grants (#1051)

### DIFF
--- a/src/vault/broker/client.ts
+++ b/src/vault/broker/client.ts
@@ -748,12 +748,25 @@ export type ListGrantsResult =
 
 /**
  * List active grants via the broker, optionally filtered by agent.
+ *
+ * Accepts an optional `passphrase` for operator-attested listing from
+ * a non-admin agent socket (#1051 — the grant-union flow needs read
+ * access to existing grants before minting a unioned one).
  */
 export async function listGrantsViaBroker(
   agent: string | undefined,
-  opts?: BrokerClientOpts,
+  opts?: BrokerClientOpts & { passphrase?: string },
 ): Promise<ListGrantsResult> {
-  const result = await rpc({ v: 1, op: "list_grants", agent }, opts);
+  const passphrase = opts?.passphrase;
+  const result = await rpc(
+    {
+      v: 1,
+      op: "list_grants",
+      agent,
+      ...(passphrase ? { passphrase } : {}),
+    },
+    opts,
+  );
   if (result.kind === "unreachable") return { kind: "unreachable", msg: result.msg };
   const resp = result.resp;
   if (resp.ok && "grants" in resp) {

--- a/src/vault/broker/protocol.ts
+++ b/src/vault/broker/protocol.ts
@@ -131,6 +131,16 @@ export const ListGrantsRequestSchema = z.object({
   v: z.literal(1),
   op: z.literal("list_grants"),
   agent: z.string().optional(),
+  /**
+   * Optional operator-passphrase attestation (#1051). Same trust
+   * posture as the mint_grant attestation field (#1012 Phase 2).
+   * list_grants needs to be reachable from non-admin agent gateways
+   * so the grant-union flow can read the agent's existing keys
+   * before minting a unioned grant. Read-only — adds no security
+   * regression vs the mint_grant path that's already
+   * operator-attested.
+   */
+  passphrase: z.string().optional(),
 });
 
 export const RevokeGrantRequestSchema = z.object({

--- a/src/vault/broker/server-mint-grant-passphrase-attest.test.ts
+++ b/src/vault/broker/server-mint-grant-passphrase-attest.test.ts
@@ -248,19 +248,83 @@ describe("VaultBroker: mint_grant passphrase attestation (#1012 Phase 2)", () =>
     expect(mismatch?.method).toBe("passphrase");
   });
 
-  // ── Scope limit: only mint_grant accepts passphrase attestation ─────
+  // ── Scope: mint_grant + list_grants accept passphrase attestation ──
+  //
+  // 2026-05-12 (#1051): list_grants attestation enabled so the gateway
+  // can read existing grants before minting a unioned one — without
+  // it, the second Approve card on a non-admin agent silently strands
+  // the prior .vault-token. Read-only op, same operator-attested
+  // trust posture as mint_grant. revoke_grant stays admin-only.
 
-  it("list_grants from a non-admin agent is still DENIED (operator-only)", async () => {
-    // Scope discipline: the agent → operator approval flow only needs
-    // MINT. Listing and revoking grants is operator-side audit work
-    // and stays admin-agent-only. Pinning this so a future refactor
-    // that extends attestation to list/revoke has to consciously
-    // widen the threat surface (and add the corresponding zod schema
-    // fields).
+  it("list_grants from a non-admin agent without passphrase: still DENIED", async () => {
+    // The base agent-deny gate still applies when no attestation is
+    // presented. Only the operator-attested path is widened.
     const resp = await rpc(socketPath, {
       v: 1,
       op: "list_grants",
       agent: "gymbro",
+    });
+    expect(resp.ok).toBe(false);
+    if (!resp.ok) {
+      expect(resp.code).toBe("DENIED");
+    }
+  });
+
+  it("list_grants from a non-admin agent WITH correct passphrase: ALLOWED (#1051)", async () => {
+    // Before minting a unioned grant on the second Approve, the
+    // gateway needs to list existing grants for the agent — this is
+    // the read-only attestation path that makes that possible.
+    // First seed two grants so the response isn't empty.
+    await rpc(socketPath, {
+      v: 1,
+      op: "mint_grant",
+      agent: "gymbro",
+      keys: ["fatsecret/client_id"],
+      ttl_seconds: 30 * 86400,
+      passphrase: TEST_PASSPHRASE,
+    });
+    const resp = await rpc(socketPath, {
+      v: 1,
+      op: "list_grants",
+      agent: "gymbro",
+      passphrase: TEST_PASSPHRASE,
+    });
+    expect(resp.ok).toBe(true);
+    if (resp.ok && "grants" in resp) {
+      // Find a non-revoked, non-expired grant covering fatsecret/client_id.
+      const found = resp.grants.find(
+        (g) => g.agent_slug === "gymbro" && g.key_allow.includes("fatsecret/client_id"),
+      );
+      expect(found, "expected the gymbro fatsecret/client_id grant to be listed").toBeDefined();
+    }
+  });
+
+  it("list_grants with WRONG passphrase: DENIED with passphrase-mismatch (no fall-through)", async () => {
+    // Same fail-closed shape as the mint_grant mismatch — the caller
+    // explicitly asserted operator identity, so we surface the
+    // mismatch clearly rather than silently falling through to the
+    // agent-deny gate.
+    const resp = await rpc(socketPath, {
+      v: 1,
+      op: "list_grants",
+      agent: "gymbro",
+      passphrase: "WRONG-PASSPHRASE",
+    });
+    expect(resp.ok).toBe(false);
+    if (!resp.ok) {
+      expect(resp.code).toBe("DENIED");
+      expect(resp.msg).toMatch(/does not match/);
+    }
+  });
+
+  it("revoke_grant still requires admin agent (scope discipline)", async () => {
+    // revoke is destructive — keep it admin-only for now. The
+    // grant-union flow doesn't need revoke (old grants age out via
+    // TTL); a future PR can extend if needed.
+    const resp = await rpc(socketPath, {
+      v: 1,
+      op: "revoke_grant",
+      id: "vg_doesnotexist",
     });
     expect(resp.ok).toBe(false);
     if (!resp.ok) {

--- a/src/vault/broker/server.ts
+++ b/src/vault/broker/server.ts
@@ -1523,7 +1523,13 @@ export class VaultBroker {
       // instead of silently falling through to other auth paths).
       let mintPassphraseAttested = false;
       if (
-        req.op === "mint_grant" &&
+        // #1051: also covers list_grants. The grant-union flow needs
+        // to read existing grants before minting a unioned one;
+        // without this the gateway can't see the prior key list and
+        // each fresh mint silently strands the previous .vault-token.
+        // Read-only — adds no security regression vs the mint_grant
+        // attestation that already exists for the same caller.
+        (req.op === "mint_grant" || req.op === "list_grants") &&
         (req as { passphrase?: string }).passphrase !== undefined &&
         (req as { passphrase?: string }).passphrase !== ""
       ) {

--- a/src/vault/broker/server.ts
+++ b/src/vault/broker/server.ts
@@ -1492,6 +1492,11 @@ export class VaultBroker {
       req.op === "mint_grant" ||
       req.op === "list_grants" ||
       req.op === "revoke_grant";
+    // Hoisted from the isGrantMgmtOp block so the per-op handlers
+    // (list_grants at ~line 1765, mint_grant at ~line 1670) can also
+    // see the attestation flag. Used for `method=passphrase` audit
+    // attribution on the per-op success rows (#1058 reviewer Q10).
+    let mintPassphraseAttested = false;
     if (isGrantMgmtOp) {
       // Decide trust upfront so both the agent-deny gate AND the
       // peercred/cron gates below honour it. `isAdminAgent` is the
@@ -1521,7 +1526,8 @@ export class VaultBroker {
       // Wrong passphrase explicitly supplied → fail closed (mirrors
       // the PUT path at line 1206-1234 so the failure surfaces clearly
       // instead of silently falling through to other auth paths).
-      let mintPassphraseAttested = false;
+      // (`mintPassphraseAttested` is declared outside this block —
+      // see the hoist comment above the `if (isGrantMgmtOp)`.)
       if (
         // #1051: also covers list_grants. The grant-union flow needs
         // to read existing grants before minting a unioned one;
@@ -1764,6 +1770,11 @@ export class VaultBroker {
 
     if (req.op === "list_grants") {
       const grants = listGrants(this.grantsDb, req.agent);
+      // Reviewer-flagged on #1058 (Q10): stamp `method=passphrase` on
+      // the operation row when the request was operator-attested, so
+      // forensics has the same attribution on the actual list op as
+      // on the gate-allow row above. Without this the attestation is
+      // recorded but the per-op evidence reads as ambiguous.
       this.auditLogger.write({
         ts: new Date().toISOString(),
         op: "list_grants",
@@ -1771,6 +1782,7 @@ export class VaultBroker {
         pid: auditPid,
         cgroup: auditCgroup,
         result: `allowed:${grants.length}`,
+        ...(mintPassphraseAttested ? { method: "passphrase" as const } : {}),
       });
       // Strip revoked_at before sending (not part of the GrantMeta wire schema)
       const grantMetas = grants.map(({ id, agent_slug, key_allow, write_allow, expires_at, created_at, description }) => ({

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -8096,7 +8096,17 @@ async function performVaultAccessApproval(
       // created_at desc for stability.
       const active = list.grants
         .filter((g) => g.expires_at === null || g.expires_at > now)
-        .sort((a, b) => (b.created_at ?? 0) - (a.created_at ?? 0));
+        // Reviewer-flagged on #1058 (Q4): `created_at` is
+        // seconds-granularity, so two grants minted in the same
+        // wall-clock second tie. Secondary sort by `id` (vg_<6hex>)
+        // makes the ordering stable so item 2's drain reliably picks
+        // up item 1's just-minted grant rather than an unrelated
+        // same-second grant.
+        .sort((a, b) => {
+          const dt = (b.created_at ?? 0) - (a.created_at ?? 0);
+          if (dt !== 0) return dt;
+          return b.id.localeCompare(a.id);
+        });
       if (active.length > 0) {
         existingReadKeys = active[0]!.key_allow ?? [];
         existingWriteKeys = active[0]!.write_allow ?? [];

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -1412,12 +1412,21 @@ type PendingVaultOp =
   // passphrase message, and auto-resume the approval mint flow without
   // making the operator tap Approve a second time. Mirrors the
   // `passphrase-for-deferred` flow from #44.
+  //
+  // #1051: `items` is a queue so concurrent Approve taps (operator
+  // taps card 2 before typing passphrase for card 1) don't strand
+  // earlier stages. On passphrase reply we process all queued items
+  // sequentially. Each item carries its own stageId + card refs;
+  // they're all in the same chat by construction (pendingVaultOps
+  // map is keyed by chat_id).
   | {
       kind: 'passphrase-for-access-approve'
-      stageId: string
-      cardChatId: string
-      cardMessageId: number
-      senderId: string
+      items: Array<{
+        stageId: string
+        cardChatId: string
+        cardMessageId: number
+        senderId: string
+      }>
       startedAt: number
     }
 const VAULT_INPUT_TTL_MS = 5 * 60 * 1000
@@ -5135,12 +5144,14 @@ async function handleInbound(
         if (msgId != null) await deleteSensitiveMessage(chat_id, msgId, 'vault passphrase')
         await executeDeferredSecretSave(ctx, pendingVault.deferKey, passphrase, pendingVault.cardMessageId)
       } else if (pendingVault.kind === 'passphrase-for-access-approve') {
-        // #1012 Phase 2 follow-up: operator tapped Approve on a
-        // vault_request_access card without first unlocking. We
-        // captured the next message as the passphrase, cache it,
-        // delete the chat copy, and resume the approve flow.
-        // Wrong passphrase surfaces via the broker's
-        // DENIED:passphrase-mismatch path and edits the card to the
+        // #1012 Phase 2 follow-up + #1051: operator tapped Approve on
+        // one or more vault_request_access cards without first
+        // unlocking. We captured the next message as the passphrase,
+        // cache it, delete the chat copy, and resume the approve
+        // flow for EVERY queued stage (#1051 — without the queue, a
+        // concurrent second tap orphaned the first stage). Wrong
+        // passphrase surfaces via the broker's
+        // DENIED:passphrase-mismatch path and edits each card to the
         // mint_grant-failed message (see performVaultAccessApproval).
         const passphrase = text.trim()
         if (!passphrase) {
@@ -5149,22 +5160,30 @@ async function handleInbound(
         }
         vaultPassphraseCache.set(chat_id, { passphrase, expiresAt: Date.now() + VAULT_PASSPHRASE_TTL_MS })
         if (msgId != null) await deleteSensitiveMessage(chat_id, msgId, 'vault passphrase')
-        const stagedAccess = pendingVaultRequestAccesses.get(pendingVault.stageId)
-        if (!stagedAccess) {
-          // Staged entry expired between tap and passphrase reply.
-          // The 10-min TTL is generous but not infinite; surface a
-          // clear next step.
-          await ctx.api
-            .editMessageText(
-              pendingVault.cardChatId,
-              pendingVault.cardMessageId,
-              `⌛ <i>Vault unlocked, but this access-request card expired before you replied. Ask the agent to re-issue.</i>`,
-              { parse_mode: 'HTML', reply_markup: { inline_keyboard: [] } },
-            )
-            .catch(() => {})
-          return
+        // Drain the queued items SEQUENTIALLY. The grant-union step
+        // inside performVaultAccessApproval lists existing grants
+        // before minting; sequential processing means the union
+        // grows monotonically (item 1 mints grant for [keyA]; item 2
+        // lists, finds [keyA], unions with keyB → mints [keyA, keyB]).
+        // Parallel processing would race on the list-and-merge.
+        for (const item of pendingVault.items) {
+          const stagedAccess = pendingVaultRequestAccesses.get(item.stageId)
+          if (!stagedAccess) {
+            // Stage expired or denied between tap and passphrase reply.
+            // Edit its card to a clean explanation; don't break the
+            // loop (sibling cards may still be valid).
+            await ctx.api
+              .editMessageText(
+                item.cardChatId,
+                item.cardMessageId,
+                `⌛ <i>Vault unlocked, but this access-request card expired or was denied before you replied. Ask the agent to re-issue if still needed.</i>`,
+                { parse_mode: 'HTML', reply_markup: { inline_keyboard: [] } },
+              )
+              .catch(() => {})
+            continue
+          }
+          await performVaultAccessApproval(ctx, stagedAccess, item.stageId, item.senderId, passphrase)
         }
-        await performVaultAccessApproval(ctx, stagedAccess, pendingVault.stageId, pendingVault.senderId, passphrase)
       } else if (pendingVault.kind === 'grant-wizard' && pendingVault.awaitingCustomDuration) {
         // Issue #227: custom duration text reply for grant wizard
         const input = text.trim()
@@ -8051,12 +8070,61 @@ async function performVaultAccessApproval(
   senderId: string,
   passphrase: string,
 ): Promise<void> {
+  // #1051: union the new key with the agent's existing active grant
+  // before minting. Without this, each fresh Approve OVERWRITES the
+  // agent's `.vault-token` file with a single-key grant — the
+  // previous approval's grant is still in the broker DB but the
+  // agent can no longer authenticate against it (the CLI reads the
+  // file's current token, the broker validates it, sees the new key
+  // isn't in the OLD grant's key_allow, and denies).
+  //
+  // Solution: list the agent's existing non-expired grants
+  // (passphrase-attested per #1051's broker-side gate widening),
+  // find the active read-grant (most recent non-revoked,
+  // non-expired), and pass its keys ∪ new_key as `keys` to the
+  // mint call. Old grant ages out via TTL — no explicit revoke
+  // needed.
+  let existingReadKeys: string[] = [];
+  let existingWriteKeys: string[] = [];
+  if (pending.scope === 'read' || pending.scope === 'write') {
+    const list = await listGrantsViaBroker(pending.agent, { passphrase });
+    if (list.kind === 'ok') {
+      const now = Math.floor(Date.now() / 1000);
+      // Prefer the MOST RECENT non-revoked, non-expired grant. The
+      // broker's listGrants returns ALL non-revoked, but we still
+      // filter expires_at locally as defence-in-depth + sort by
+      // created_at desc for stability.
+      const active = list.grants
+        .filter((g) => g.expires_at === null || g.expires_at > now)
+        .sort((a, b) => (b.created_at ?? 0) - (a.created_at ?? 0));
+      if (active.length > 0) {
+        existingReadKeys = active[0]!.key_allow ?? [];
+        existingWriteKeys = active[0]!.write_allow ?? [];
+      }
+    }
+    // If list fails (broker unreachable / error), proceed without
+    // union — better to mint a single-key grant than fail closed
+    // entirely. The agent loses the prior coverage in that edge
+    // case, same as today, but the new key is granted.
+  }
+
+  // Compute the unioned key sets. Use Set to dedupe.
+  const readKeys = new Set<string>(existingReadKeys);
+  const writeKeys = new Set<string>(existingWriteKeys);
+  if (pending.scope === 'read') readKeys.add(pending.key);
+  if (pending.scope === 'write') writeKeys.add(pending.key);
+
   const mintArgs: Parameters<typeof mintGrantViaBroker>[0] = {
     agent: pending.agent,
-    keys: pending.scope === 'read' ? [pending.key] : [],
+    keys: Array.from(readKeys),
     ttl_seconds: pending.ttl_seconds,
-    description: `auto-mint via vault_request_access (#1012, scope=${pending.scope}, by op ${senderId})`,
-    ...(pending.scope === 'write' ? { write_keys: [pending.key] } : {}),
+    description:
+      `auto-mint via vault_request_access (#1012, scope=${pending.scope}, by op ${senderId}` +
+      (existingReadKeys.length + existingWriteKeys.length > 0
+        ? `, unioned with prior grant`
+        : ``) +
+      `)`,
+    ...(writeKeys.size > 0 ? { write_keys: Array.from(writeKeys) } : {}),
     passphrase,
   }
   const result = await mintGrantViaBroker(mintArgs)
@@ -8176,21 +8244,43 @@ async function handleVaultRequestAccessCallback(ctx: Context, data: string): Pro
           .catch(() => {})
         return
       }
-      pendingVaultOps.set(pending.chat_id, {
-        kind: 'passphrase-for-access-approve',
+      // #1051: if there's ALREADY a passphrase-for-access-approve
+      // pending op for this chat (operator tapped Approve on a
+      // sibling card before typing the passphrase), APPEND this
+      // stage to the existing queue instead of overwriting. When
+      // the passphrase reply lands the text-handler drains every
+      // queued stage — both cards get their grant minted off one
+      // passphrase entry. Without this, the second Approve tap
+      // orphans the first stage.
+      const existing = pendingVaultOps.get(pending.chat_id)
+      const newItem = {
         stageId,
         cardChatId: pending.chat_id,
         cardMessageId: pending.card_message_id,
         senderId,
-        startedAt: Date.now(),
+      }
+      const items =
+        existing?.kind === 'passphrase-for-access-approve'
+          ? [...existing.items.filter((it) => it.stageId !== stageId), newItem]
+          : [newItem]
+      pendingVaultOps.set(pending.chat_id, {
+        kind: 'passphrase-for-access-approve',
+        items,
+        startedAt: existing?.kind === 'passphrase-for-access-approve' ? existing.startedAt : Date.now(),
       })
-      await ctx.answerCallbackQuery({ text: '🔐 Send your passphrase…' }).catch(() => {})
+      // Card text differs slightly when joining an existing batch so
+      // the operator isn't confused by two "Reply with passphrase"
+      // cards open at once.
+      const joiningBatch = items.length > 1
+      await ctx.answerCallbackQuery({ text: joiningBatch ? `🔐 Queued — one passphrase covers ${items.length} cards` : '🔐 Send your passphrase…' }).catch(() => {})
       await ctx.api
         .editMessageText(
           pending.chat_id,
           pending.card_message_id,
-          `🔐 <b>Vault is locked.</b> Reply with your passphrase as your next message — we'll unlock, mint the grant for <b>${escapeHtmlForTg(pending.agent)}</b>, and delete the passphrase message in one step.\n\n` +
-          `<i>Mint authority stays operator-only: the broker only accepts the grant when the passphrase matches.</i>`,
+          joiningBatch
+            ? `🔐 <b>Queued behind an earlier card.</b> Type your passphrase as your next message — it covers <b>${items.length}</b> pending approvals in this chat (one entry mints all grants, no re-type per card).`
+            : `🔐 <b>Vault is locked.</b> Reply with your passphrase as your next message — we'll unlock, mint the grant for <b>${escapeHtmlForTg(pending.agent)}</b>, and delete the passphrase message in one step.\n\n` +
+              `<i>Mint authority stays operator-only: the broker only accepts the grant when the passphrase matches.</i>`,
           { parse_mode: 'HTML', reply_markup: { inline_keyboard: [] } },
         )
         .catch(() => {})

--- a/telegram-plugin/tests/vault-grant-union.test.ts
+++ b/telegram-plugin/tests/vault-grant-union.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Static-source contract pin for the grant-union behavior shipped to
+ * fix #1051's silent-token-overwrite bug class.
+ *
+ * The bug: when an operator approved a vault_request_access card for
+ * key A and then later approved a second card for key B, the second
+ * mint OVERWROTE the agent's `.vault-token` file with a single-key
+ * grant. Both grants existed in the broker DB but the agent could
+ * only authenticate against the most-recent one — `vault get keyA`
+ * after the second approval returned VAULT-BROKER-DENIED.
+ *
+ * Fix: before minting, the gateway lists the agent's existing
+ * non-expired grants (using the new passphrase-attested list_grants
+ * path) and unions their keys with the new key. The fresh grant
+ * covers OLD ∪ NEW; the old grant ages out via TTL.
+ *
+ * This file pins the wiring at the call site so a future refactor
+ * can't silently drop the union step.
+ */
+
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const gatewaySrc = readFileSync(
+  resolve(__dirname, "..", "gateway", "gateway.ts"),
+  "utf-8",
+);
+
+function extractPerformBlock(): string {
+  const start = gatewaySrc.indexOf("async function performVaultAccessApproval");
+  if (start < 0) throw new Error("performVaultAccessApproval not found");
+  // Bound the block by the next top-level `async function` keyword.
+  const restAfter = gatewaySrc.slice(start + 1);
+  const endRel = restAfter.indexOf("\nasync function ");
+  return gatewaySrc.slice(start, start + 1 + (endRel >= 0 ? endRel : restAfter.length));
+}
+
+describe("performVaultAccessApproval unions keys with the agent's existing grant (#1051)", () => {
+  const block = extractPerformBlock();
+
+  it("calls listGrantsViaBroker BEFORE mintGrantViaBroker", () => {
+    // fails when: a refactor drops the list step. Without it the
+    // mint covers only [pending.key] and OVERWRITES the agent's
+    // .vault-token, stranding the previous approval's grant from
+    // the agent's perspective.
+    const listIdx = block.indexOf("listGrantsViaBroker(");
+    const mintIdx = block.indexOf("mintGrantViaBroker(");
+    expect(listIdx, "listGrantsViaBroker call missing in performVaultAccessApproval").toBeGreaterThan(0);
+    expect(mintIdx, "mintGrantViaBroker call missing").toBeGreaterThan(0);
+    expect(listIdx, "list MUST happen BEFORE mint").toBeLessThan(mintIdx);
+  });
+
+  it("forwards the operator passphrase to listGrantsViaBroker (attestation)", () => {
+    // The non-admin agent socket needs operator-passphrase attestation
+    // to call list_grants (#1051's broker-side gate widening). Without
+    // forwarding the passphrase, the list call gets DENIED and the
+    // gateway falls back to single-key mint — silent regression to
+    // the pre-fix behavior.
+    const listMatch = block.match(/listGrantsViaBroker\([^)]+\)/);
+    expect(listMatch, "listGrantsViaBroker call shape").not.toBeNull();
+    expect(listMatch![0], "passphrase MUST be forwarded for attestation").toMatch(/passphrase/);
+  });
+
+  it("unions existing key_allow with the new key before minting", () => {
+    // Pin the union semantics. The mint call must pass a Set-like
+    // union of existing keys + new key, not just [pending.key].
+    expect(block).toMatch(/key_allow/);
+    expect(block).toMatch(/new Set/);
+    // The Set MUST be seeded from the existing grant's keys.
+    expect(block).toMatch(/existingReadKeys|active\[0\]/);
+  });
+
+  it("includes write_allow union for write-scope requests", () => {
+    // Mirror the read-side union for write scope.
+    expect(block).toMatch(/write_allow/);
+    expect(block).toMatch(/writeKeys\.add|writeKeys\.size/);
+  });
+
+  it("concurrent Approve taps queue into a single pending-op (#1051)", () => {
+    // Without the queue, a second Approve tap before the operator
+    // types their passphrase OVERWRITES the first stage's pending
+    // op — the first card's grant never mints. The new shape has
+    // `items: [...]` so a second tap APPENDS, and the text-handler
+    // drains every queued stage off one passphrase entry.
+    //
+    // Anchor on the producer site inside handleVaultRequestAccessCallback.
+    const callbackHandler =
+      gatewaySrc
+        .split("async function handleVaultRequestAccessCallback")[1]
+        ?.split("\nasync function ")[0] ?? "";
+    // The producer reads any existing pending op, and APPENDS to
+    // items[] rather than overwriting.
+    expect(callbackHandler).toMatch(/pendingVaultOps\.get\(pending\.chat_id\)/);
+    // `items` declared (either as `items: [...]` literal or `const items = ...`).
+    expect(callbackHandler).toMatch(/\bitems\b/);
+    expect(callbackHandler).toMatch(/passphrase-for-access-approve/);
+
+    // The consumer (text-handler) loops over items. Anchor on the
+    // unique consumer code (the `else if` branch that handles a
+    // passphrase reply), not the type-discriminator string itself —
+    // the latter appears in the PendingVaultOp type definition too,
+    // so a naive split lands on the wrong slice.
+    const textHandlerIdx = gatewaySrc.indexOf("else if (pendingVault.kind === 'passphrase-for-access-approve')");
+    expect(textHandlerIdx, "text-handler consumer branch not found").toBeGreaterThan(0);
+    const textHandler = gatewaySrc.slice(textHandlerIdx, textHandlerIdx + 3000);
+    expect(textHandler, "text-handler MUST iterate items").toMatch(/for\s*\(\s*const\s+item\s+of\s+pendingVault\.items/);
+    // Each iteration looks up the staged access (sibling-stage may
+    // have been denied / expired between tap and passphrase reply).
+    expect(textHandler).toMatch(/pendingVaultRequestAccesses\.get\(item\.stageId\)/);
+  });
+
+  it("gracefully proceeds with single-key mint when listGrants fails", () => {
+    // Non-blocker: if listGrants returns unreachable/error, the
+    // gateway should STILL mint the new grant (without union) so
+    // the operator's tap-to-approve doesn't get blocked on a
+    // transient broker issue. Documented intent.
+    expect(block).toMatch(/list\.kind === 'ok'/);
+    // A comment explaining the fallback behavior must be present so
+    // a future reader knows the gracefully-degraded path is
+    // intentional.
+    // The comment is split across multiple // lines, so collapse
+    // whitespace + comment prefixes before matching.
+    const flattened = block.replace(/\n\s*\/\/\s*/g, " ");
+    expect(flattened).toMatch(/(without union|edge case|fall.?back|fail closed|degrade)/i);
+  });
+});

--- a/telegram-plugin/uat/scenarios/vault-request-access-concurrent-dm.test.ts
+++ b/telegram-plugin/uat/scenarios/vault-request-access-concurrent-dm.test.ts
@@ -1,0 +1,161 @@
+/**
+ * End-to-end UAT scenario for the #1051 fix — concurrent
+ * vault_request_access cards must BOTH end up readable by the agent.
+ *
+ * #1051 had two failure modes:
+ *   (a) `.vault-token` overwrite — each new grant strands the prior
+ *       (agent can read only the most-recently-approved key).
+ *   (b) pending-op race — second Approve tap before first passphrase
+ *       reply orphans the first stage entirely (no second grant
+ *       even minted).
+ *
+ * Both fixed by the gateway-side grant-union path: list existing
+ * grants → union keys → mint a consolidated grant. PLUS the
+ * pending-op shape extended to a queue so concurrent taps don't
+ * overwrite.
+ *
+ * This scenario covers (a) — the most-likely real-world repro
+ * (gymbro fires two cards back-to-back; operator approves both
+ * sequentially). Covering (b) cleanly needs precise tap-timing
+ * that's harder to script — the static-source test
+ * `telegram-plugin/tests/vault-grant-union.test.ts` pins it at the
+ * code level instead.
+ *
+ * **Skipped by default.** To unskip:
+ *
+ * 1. Standard UAT preflight (`uat/SETUP.md` §5-6).
+ * 2. `TELEGRAM_UAT_VAULT_PASSPHRASE` set in env.
+ * 3. Pre-create two sacrificial vault keys:
+ *
+ *    ```bash
+ *    for k in uat/concurrent-a uat/concurrent-b ; do
+ *      TMPF=$(mktemp); printf '%s' "sentinel-${k##*/}" > "$TMPF"
+ *      switchroom vault set "$k" --file "$TMPF" --format string
+ *      shred -u "$TMPF"
+ *    done
+ *    ```
+ *
+ * 4. Remove `describe.skip` below.
+ *
+ * Why skipped: mutates vault state (mints a grant covering both keys
+ * on test-harness). Cleanup is operator-side post-run.
+ */
+
+import { describe, expect, it } from "vitest";
+import { spinUp } from "../harness.js";
+
+const KEY_A = "uat/concurrent-a";
+const KEY_B = "uat/concurrent-b";
+const SENTINEL_A = "sentinel-concurrent-a";
+const SENTINEL_B = "sentinel-concurrent-b";
+
+describe.skip("uat: concurrent vault_request_access approvals — both grants survive (#1051)", () => {
+  it(
+    "agent fires two cards back-to-back, operator approves both → agent can read both keys",
+    async () => {
+      const passphrase = process.env.TELEGRAM_UAT_VAULT_PASSPHRASE;
+      if (!passphrase) {
+        throw new Error(
+          "TELEGRAM_UAT_VAULT_PASSPHRASE must be set in env (see uat/SETUP.md).",
+        );
+      }
+      const sc = await spinUp({ agent: "test-harness" });
+      try {
+        // 1. Tell the agent to fire TWO vault_request_access calls
+        //    in the same turn for two distinct keys. The natural way
+        //    to express this is one prompt that describes both
+        //    needs; the agent then makes both tool calls.
+        await sc.sendDM(
+          `Please call your vault_request_access MCP tool TWICE — ` +
+          `once for key="${KEY_A}" and once for key="${KEY_B}" — ` +
+          `both scope="read", both reason="UAT for #1051 concurrent". ` +
+          `Then attempt to read BOTH keys via switchroom vault get and ` +
+          `print the values in your reply.`,
+        );
+
+        // 2. Wait for the FIRST approval card.
+        const cardA = await sc.expectMessage(
+          new RegExp(`🔐.*wants vault access[\\s\\S]*${KEY_A.replace("/", "\\/")}`),
+          { from: "bot", timeout: 90_000 },
+        );
+        const cardB = await sc.expectMessage(
+          new RegExp(`🔐.*wants vault access[\\s\\S]*${KEY_B.replace("/", "\\/")}`),
+          { from: "bot", timeout: 30_000 },
+        );
+
+        // 3. Tap Approve on card A.
+        const kbA = await sc.driver.getKeyboard(sc.botUserId, cardA.messageId);
+        const approveA = kbA!
+          .flat()
+          .find((b) => b.callbackData !== undefined && /approve/i.test(b.text));
+        expect(approveA).toBeDefined();
+        await sc.driver.pressButton(sc.botUserId, cardA.messageId, approveA!.callbackData!);
+
+        // Wait for the passphrase prompt on card A.
+        await sc.expectMessage(/Vault is locked.*Reply with your passphrase/, {
+          from: "bot",
+          timeout: 15_000,
+        });
+
+        // 4. Tap Approve on card B BEFORE typing the passphrase.
+        //    This exercises the pending-op queueing path (bug B).
+        //    The card should edit to "Queued behind an earlier card."
+        const kbB = await sc.driver.getKeyboard(sc.botUserId, cardB.messageId);
+        const approveB = kbB!
+          .flat()
+          .find((b) => b.callbackData !== undefined && /approve/i.test(b.text));
+        expect(approveB).toBeDefined();
+        await sc.driver.pressButton(sc.botUserId, cardB.messageId, approveB!.callbackData!);
+        await sc.expectMessage(/Queued behind an earlier card|Queued.*one passphrase/i, {
+          from: "bot",
+          timeout: 15_000,
+        });
+
+        // 5. Send passphrase. Gateway drains the queue, mints a
+        //    unioned grant for {KEY_A, KEY_B}, writes a single
+        //    .vault-token. BOTH cards edit to "Granted".
+        await sc.sendDM(passphrase);
+        await sc.expectMessage(new RegExp(`Granted[\\s\\S]*${KEY_A.replace("/", "\\/")}`), {
+          from: "bot",
+          timeout: 30_000,
+        });
+        await sc.expectMessage(new RegExp(`Granted[\\s\\S]*${KEY_B.replace("/", "\\/")}`), {
+          from: "bot",
+          timeout: 30_000,
+        });
+
+        // 6. Ask the agent to read BOTH keys. The load-bearing
+        //    assertion: pre-fix, the agent could only read ONE
+        //    (.vault-token had been overwritten with the second
+        //    grant's token, which only covered KEY_B). Post-fix,
+        //    the agent has a single token whose grant covers
+        //    BOTH keys, so BOTH gets succeed.
+        await sc.sendDM(
+          `Now run: switchroom vault get ${KEY_A} && switchroom vault get ${KEY_B} ` +
+          `— and paste the output verbatim. Include any error markers if either fails.`,
+        );
+        const finalReply = await sc.expectMessage(
+          new RegExp(SENTINEL_A),
+          { from: "bot", timeout: 90_000 },
+        );
+        expect(
+          finalReply.text,
+          `agent must read KEY_A — pre-fix this was the SECOND grant's key and would have succeeded; the union now covers it`,
+        ).toContain(SENTINEL_A);
+        expect(
+          finalReply.text,
+          `agent must read KEY_B — pre-fix this would have FAILED with VAULT-BROKER-DENIED because .vault-token was overwritten`,
+        ).toContain(SENTINEL_B);
+        expect(
+          finalReply.text,
+          `neither key should denied`,
+        ).not.toMatch(/VAULT-BROKER-DENIED/);
+      } finally {
+        await sc.tearDown();
+      }
+    },
+    420_000, // 7 min — covers two cards rendering + two approves +
+             //         passphrase round-trip + drain queue + two
+             //         mints + two vault gets.
+  );
+});


### PR DESCRIPTION
## Summary

Closes #1051. Two real bugs both surface as \"agent can only read the most-recently-approved key\" after multiple Approve cards.

### Bug A — \`.vault-token\` overwrite (load-bearing)
Each fresh Approve mints a new single-key grant and OVERWRITES the agent's token file. Both grants exist in the broker DB, but the agent can only authenticate against the most-recent — which doesn't cover the FIRST approved key.

**Fix:** before minting, the gateway lists existing grants (passphrase-attested via a small broker-side widening — list_grants joins mint_grant in the attestation gate from #1030) and UNIONS their keys with the new key. Old grant ages out via TTL.

### Bug B — pending-op race
Second Approve before typing passphrase for the first orphans the first stage.

**Fix:** \`pendingVaultOps[chat_id]\` shape extended to a queue (\`items: Array<{...}>\`). Second tap APPENDS. Text-handler drains the queue sequentially when passphrase reply lands. Card 2 edits to \"Queued behind an earlier card — one passphrase covers N pending approvals.\"

## Test plan

- [x] \`npm run lint\` — clean.
- [x] \`bun test src/vault/broker/server-mint-grant-passphrase-attest.test.ts\` — 7/7 (4 → 7, adding list_grants attestation paths + revoke scope-discipline guard).
- [x] \`npx vitest run telegram-plugin/tests/vault-grant-union.test.ts\` — 6/6 new (union semantics + queueing producer/consumer + graceful-degradation).
- [x] \`npm test\` — 5514/0.
- [x] New \`telegram-plugin/uat/scenarios/vault-request-access-concurrent-dm.test.ts\` (\`describe.skip\`) — full Telegram round-trip with two cards. Pinned the load-bearing assertion as agent reads BOTH keys without VAULT-BROKER-DENIED.
- [ ] Post-merge dogfood: pull image, run gymbro repro with two keys, confirm both readable.

## Sibling

- **#1052** (agent doesn't auto-resume after grant lands) — independent. Follow-up PR coming.
- **#1012** (parent epic) — close after #1052 ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)