### PR TITLE
fix(hooks): subagent-tracker hooks consult TELEGRAM_STATE_DIR so rows reach the registry (RFC Phase 3 Bug 2)

### DIFF
--- a/telegram-plugin/hooks/subagent-tracker-posttool.mjs
+++ b/telegram-plugin/hooks/subagent-tracker-posttool.mjs
@@ -11,7 +11,13 @@
  * block the tool response.
  *
  * DB location: <agentDir>/telegram/registry.db
- *   agentDir = SWITCHROOM_AGENT_DIR env var, falling back to process.cwd()
+ *   agentDir lookup (first hit wins):
+ *     1. SWITCHROOM_AGENT_DIR env var (explicit override, mainly used in tests)
+ *     2. TELEGRAM_STATE_DIR with `/telegram` suffix stripped — the canonical
+ *        env var start.sh exports on every switchroom agent. See the
+ *        sibling pretool hook docblock for why this lookup matters (without
+ *        it the hook used to write to a registry.db nobody read).
+ *     3. process.cwd() (legacy fallback for ad-hoc invocations).
  *
  * Performance: the actual DB write is deferred via setImmediate (Node 22+
  * node:sqlite path) or non-blocking spawn (CLI fallback) so the hook returns
@@ -268,7 +274,18 @@ function main() {
   const id = event.tool_use_id ?? null
   if (!id) process.exit(0)
 
-  const agentDir = process.env.SWITCHROOM_AGENT_DIR ?? process.cwd()
+  // Same agent-dir resolution as the pretool hook (Bug 2 fix). Without
+  // the TELEGRAM_STATE_DIR derivation the posttool would write the
+  // `ended_at` row to a registry.db nobody reads, even though the row
+  // was originally inserted by the pretool hook that DID write to the
+  // correct DB (after this PR). Keep the two hooks in lock-step.
+  const stateDir = process.env.TELEGRAM_STATE_DIR
+  const derivedFromStateDir = stateDir && stateDir.endsWith('/telegram')
+    ? stateDir.slice(0, -'/telegram'.length)
+    : null
+  const agentDir = process.env.SWITCHROOM_AGENT_DIR
+    ?? derivedFromStateDir
+    ?? process.cwd()
   const dbPath = join(agentDir, 'telegram', 'registry.db')
 
   // If DB doesn't exist yet, nothing to update

--- a/telegram-plugin/hooks/subagent-tracker-pretool.mjs
+++ b/telegram-plugin/hooks/subagent-tracker-pretool.mjs
@@ -11,7 +11,17 @@
  * block the tool call.
  *
  * DB location: <agentDir>/telegram/registry.db
- *   agentDir = SWITCHROOM_AGENT_DIR env var, falling back to process.cwd()
+ *   agentDir lookup (first hit wins):
+ *     1. SWITCHROOM_AGENT_DIR env var (explicit override, mainly used in tests)
+ *     2. TELEGRAM_STATE_DIR with `/telegram` suffix stripped — the canonical
+ *        env var start.sh exports for every switchroom agent (and the same
+ *        path the gateway + watcher resolve their DB through). Without this
+ *        the hook used to fall through to process.cwd() in production,
+ *        writing to a registry.db nobody read, leaving every bg sub-agent
+ *        invisible to the watcher. Surfaced by
+ *        bg-sub-agent-dispatch-dm.test.ts; see RFC Phase 2 §Bug 2 in
+ *        reference/sub-agent-visibility-rfc.md.
+ *     3. process.cwd() (legacy fallback for ad-hoc invocations).
  *
  * Performance: the actual DB write is deferred via setImmediate (Node 22+
  * node:sqlite path) or a non-blocking spawn (CLI fallback) so the hook
@@ -223,7 +233,17 @@ function main() {
   // misroute).
   if (event.tool_name !== 'Agent' && event.tool_name !== 'Task') process.exit(0)
 
-  const agentDir = process.env.SWITCHROOM_AGENT_DIR ?? process.cwd()
+  // Resolve agent dir: explicit env override → derive from TELEGRAM_STATE_DIR
+  // (start.sh exports this on every agent) → cwd fallback. The middle case
+  // is the production path; without it the hook silently wrote to a
+  // registry.db nobody read (#709 / #776 / #782 / #788 Bug 2).
+  const stateDir = process.env.TELEGRAM_STATE_DIR
+  const derivedFromStateDir = stateDir && stateDir.endsWith('/telegram')
+    ? stateDir.slice(0, -'/telegram'.length)
+    : null
+  const agentDir = process.env.SWITCHROOM_AGENT_DIR
+    ?? derivedFromStateDir
+    ?? process.cwd()
   const telegramDir = join(agentDir, 'telegram')
   const dbPath = join(telegramDir, 'registry.db')
 

--- a/telegram-plugin/tests/subagent-tracker-hooks.test.ts
+++ b/telegram-plugin/tests/subagent-tracker-hooks.test.ts
@@ -211,3 +211,110 @@ describe('subagent-tracker-posttool', () => {
     expect(row?.status).toBe('failed')
   })
 })
+
+describe('agent-dir resolution (RFC §Bug 2)', () => {
+  // The hooks used to look only at SWITCHROOM_AGENT_DIR and then cwd.
+  // In production neither matched the path the gateway + watcher used,
+  // so rows were written to a registry.db nobody read. The fix adds
+  // TELEGRAM_STATE_DIR (the env var start.sh exports for every agent)
+  // as a middle lookup. These tests pin the precedence + the legacy
+  // fallback so a future refactor can't silently revert.
+
+  function runWith(scriptPath: string, event: object, env: Record<string, string | undefined>) {
+    const finalEnv: Record<string, string> = { ...process.env } as Record<string, string>
+    // Clear the inherited overrides; we want a clean baseline.
+    delete finalEnv.SWITCHROOM_AGENT_DIR
+    delete finalEnv.TELEGRAM_STATE_DIR
+    for (const [k, v] of Object.entries(env)) {
+      if (v === undefined) delete finalEnv[k]
+      else finalEnv[k] = v
+    }
+    return spawnSync(process.execPath, [scriptPath], {
+      input: JSON.stringify(event),
+      encoding: 'utf8',
+      env: finalEnv,
+      timeout: 15_000,
+    })
+  }
+
+  const baseEvent = {
+    session_id: 's',
+    tool_name: 'Agent',
+    tool_use_id: 'toolu_envtest1',
+    tool_input: { subagent_type: 'w', description: 'd', run_in_background: true },
+  }
+
+  it('pretool prefers SWITCHROOM_AGENT_DIR over TELEGRAM_STATE_DIR', () => {
+    const explicit = mkdtempSync(join(tmpdir(), 'agent-dir-explicit-'))
+    const stateDirParent = mkdtempSync(join(tmpdir(), 'state-dir-parent-'))
+    mkdirSync(join(explicit, 'telegram'), { recursive: true })
+    mkdirSync(join(stateDirParent, 'telegram'), { recursive: true })
+    try {
+      const result = runWith(PRETOOL_SCRIPT, baseEvent, {
+        SWITCHROOM_AGENT_DIR: explicit,
+        TELEGRAM_STATE_DIR: join(stateDirParent, 'telegram'),
+      })
+      expect(result.status).toBe(0)
+      // Row landed in the EXPLICIT location, not the state-dir-derived one.
+      const explicitDb = join(explicit, 'telegram', 'registry.db')
+      const stateDirDb = join(stateDirParent, 'telegram', 'registry.db')
+      expect(Bun.file(explicitDb).size).toBeGreaterThan(0)
+      expect(Bun.file(stateDirDb).size).toBe(0)
+    } finally {
+      try { rmSync(explicit, { recursive: true }) } catch { /* */ }
+      try { rmSync(stateDirParent, { recursive: true }) } catch { /* */ }
+    }
+  })
+
+  it('pretool derives agentDir from TELEGRAM_STATE_DIR when SWITCHROOM_AGENT_DIR is unset (the production path)', () => {
+    const stateDirParent = mkdtempSync(join(tmpdir(), 'state-dir-only-'))
+    mkdirSync(join(stateDirParent, 'telegram'), { recursive: true })
+    try {
+      const result = runWith(PRETOOL_SCRIPT, baseEvent, {
+        TELEGRAM_STATE_DIR: join(stateDirParent, 'telegram'),
+      })
+      expect(result.status).toBe(0)
+      const dbPath = join(stateDirParent, 'telegram', 'registry.db')
+      expect(Bun.file(dbPath).size).toBeGreaterThan(0)
+      // Row landed in the state-dir-derived location.
+      const { Database } = require('bun:sqlite') as { Database: new (p: string) => {
+        prepare(sql: string): { get(...params: unknown[]): unknown }
+      } }
+      const db = new Database(dbPath)
+      const row = db.prepare('SELECT id FROM subagents WHERE id = ?').get('toolu_envtest1') as
+        | { id: string } | undefined
+      expect(row?.id).toBe('toolu_envtest1')
+    } finally {
+      try { rmSync(stateDirParent, { recursive: true }) } catch { /* */ }
+    }
+  })
+
+  it('pretool ignores TELEGRAM_STATE_DIR that does NOT end in /telegram (defensive)', () => {
+    // If TELEGRAM_STATE_DIR ever drifts to a non-canonical shape, the
+    // hook should NOT silently use it — falling through to cwd is the
+    // safer behaviour (you'll notice the wrong location quickly).
+    const weirdDir = mkdtempSync(join(tmpdir(), 'state-dir-weird-'))
+    const cwdDir = mkdtempSync(join(tmpdir(), 'cwd-dir-'))
+    mkdirSync(join(cwdDir, 'telegram'), { recursive: true })
+    try {
+      const result = spawnSync(process.execPath, [PRETOOL_SCRIPT], {
+        input: JSON.stringify(baseEvent),
+        encoding: 'utf8',
+        cwd: cwdDir,
+        env: {
+          ...process.env,
+          SWITCHROOM_AGENT_DIR: undefined as unknown as string,
+          TELEGRAM_STATE_DIR: weirdDir, // does NOT end in /telegram
+        } as Record<string, string>,
+        timeout: 15_000,
+      })
+      expect(result.status).toBe(0)
+      // Fell through to cwd, NOT the weird TELEGRAM_STATE_DIR.
+      const cwdDb = join(cwdDir, 'telegram', 'registry.db')
+      expect(Bun.file(cwdDb).size).toBeGreaterThan(0)
+    } finally {
+      try { rmSync(weirdDir, { recursive: true }) } catch { /* */ }
+      try { rmSync(cwdDir, { recursive: true }) } catch { /* */ }
+    }
+  })
+})


### PR DESCRIPTION
Phase 3 / Bug 2 from the sub-agent visibility RFC. Surfaced by the UAT scenario merged in #1056. Parallel to #1057 (Bug 1).

## The bug

`subagent-tracker-pretool.mjs` and `subagent-tracker-posttool.mjs` resolved their target DB path as:

```
agentDir = process.env.SWITCHROOM_AGENT_DIR ?? process.cwd()
```

`SWITCHROOM_AGENT_DIR` is set in tests but NOT in production. So the hooks fell through to `process.cwd()` — which inside a docker agent container is the workspace dir, NOT the agent dir. Hooks wrote to `<workspace>/telegram/registry.db` while the gateway + subagent-watcher both read from `<agentDir>/telegram/registry.db` (via TELEGRAM_STATE_DIR, which start.sh DOES export).

Net effect: every Agent dispatch's row was written to a registry.db nobody read. The watcher's `liveness skip … — row not in DB yet (Phase 2 Pre hook pending)` log was misleading — the hook HAD fired, but to a separate DB. Confirmed by inspecting the test-harness's real registry.db: 4096 bytes, zero tables.

## The fix

Both hooks gain a middle lookup step:

1. `SWITCHROOM_AGENT_DIR` (explicit override — test-only)
2. Derive from `TELEGRAM_STATE_DIR` by stripping trailing `/telegram` (production path)
3. `process.cwd()` (legacy fallback)

The `/telegram` suffix gate makes the derivation defensive — if TELEGRAM_STATE_DIR drifts to a non-canonical shape, hook falls through to cwd rather than silently writing to a wrong location.

## Tests

3 new cases pin the precedence + the defensive fallback. 7/7 hook tests pass.

## Together with #1057

Both fixes are needed before `bg-sub-agent-dispatch-dm.test.ts` can drop `.skip`. They're independent — can land in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)