### PR TITLE
fix(scaffold,docker): bake hooks into agent image + scaffold uses in-image paths (RFC Phase 3 Bug 3)

### DIFF
--- a/docker/Dockerfile.agent
+++ b/docker/Dockerfile.agent
@@ -70,6 +70,23 @@ RUN chmod 0755 /opt/switchroom/switchroom.js \
 COPY telegram-plugin/dist /opt/switchroom/telegram-plugin/dist
 COPY telegram-plugin/start.js /opt/switchroom/telegram-plugin/start.js
 COPY telegram-plugin/package.json /opt/switchroom/telegram-plugin/package.json
+# Hooks (PreToolUse / PostToolUse / Stop / UserPromptSubmit) — Claude Code
+# spawns these as child processes whenever the corresponding hook fires
+# (see `<agentDir>/.claude/settings.json` `hooks` block, scaffolded by
+# `src/agents/scaffold.ts:buildSettingsHooksBlock`). Pre-this-bake the
+# scaffolded paths pointed at the operator's host repo checkout, which
+# doesn't exist inside the container — Claude Code silently skipped them
+# and the bg-sub-agent tracking, secret-redaction, tool-label, and silent-
+# end paths all went dark in docker mode. Surfaced by RFC Phase 3 §Bug 3
+# (reference/sub-agent-visibility-rfc.md); confirmed via the test-harness
+# registry.db being a 4096-byte file with zero tables.
+COPY telegram-plugin/hooks /opt/switchroom/telegram-plugin/hooks
+COPY bin/run-hook.sh /opt/switchroom/bin/run-hook.sh
+COPY bin/timezone-hook.sh /opt/switchroom/bin/timezone-hook.sh
+COPY bin/user-profile-refresh-hook.sh /opt/switchroom/bin/user-profile-refresh-hook.sh
+COPY bin/workspace-stable-hook.sh /opt/switchroom/bin/workspace-stable-hook.sh
+COPY bin/workspace-dynamic-hook.sh /opt/switchroom/bin/workspace-dynamic-hook.sh
+RUN chmod +x /opt/switchroom/bin/*.sh
 
 # Phase 2 cron-fold-in: the in-agent scheduler bundle plus its node-cron
 # runtime dep. Started by start.sh as a third supervised sidecar (after

--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -1567,6 +1567,25 @@ Don't wait for a slash command. Don't ask permission. Memory work is table stake
  */
 export const DOCKER_TELEGRAM_PLUGIN_PATH = "/opt/switchroom/telegram-plugin";
 
+/**
+ * In-image path where Dockerfile.agent COPYs `telegram-plugin/hooks/*.mjs`.
+ * Claude Code spawns hooks as child processes from the path written into
+ * `settings.json.hooks` at scaffold time; pre-Bug-3 the scaffold emitted
+ * the operator's host repo path here, which doesn't exist inside the
+ * container — hooks silently never ran (RFC Phase 3 §Bug 3 in
+ * reference/sub-agent-visibility-rfc.md).
+ */
+export const DOCKER_HOOKS_PATH = `${DOCKER_TELEGRAM_PLUGIN_PATH}/hooks`;
+
+/**
+ * In-image path where Dockerfile.agent COPYs the `bin/*-hook.sh` family
+ * (run-hook.sh, timezone-hook.sh, workspace-stable-hook.sh,
+ * workspace-dynamic-hook.sh, user-profile-refresh-hook.sh). Same
+ * rationale as DOCKER_HOOKS_PATH — these are invoked from the
+ * scaffolded settings.json hooks block.
+ */
+export const DOCKER_BIN_PATH = "/opt/switchroom/bin";
+
 export function scaffoldAgent(
   name: string,
   agentConfigRaw: AgentConfig,
@@ -2448,7 +2467,13 @@ export function buildSettingsHooksBlock(p: HooksBlockParams): Record<string, unk
   // in the issue sink (#425) and on the Telegram issues card (#428).
   // The wrapper preserves the original exit code, so claude code's
   // hook contract (decision: block, etc.) is unchanged.
-  const wrapper = `bash "${join(REPO_ROOT, "bin", "run-hook.sh")}"`;
+  //
+  // Path is the docker-baked location. The scaffold runs on the host but
+  // settings.json is consumed inside the agent container — referencing
+  // the host repo checkout would silently fail (RFC §Bug 3). Mirrors
+  // the `.mcp.json` plugin path which already uses DOCKER_TELEGRAM_PLUGIN_PATH
+  // for the same reason.
+  const wrapper = `bash "${join(DOCKER_BIN_PATH, "run-hook.sh")}"`;
   const wrap = (source: string, command: string): string =>
     `${wrapper} ${shellSingleQuote(source)} ${command}`;
 
@@ -2474,7 +2499,7 @@ export function buildSettingsHooksBlock(p: HooksBlockParams): Record<string, unk
       type: "command",
       command: wrap(
         "hook:user-profile-refresh",
-        `bash "${join(REPO_ROOT, "bin", "user-profile-refresh-hook.sh")}"`,
+        `bash "${join(DOCKER_BIN_PATH, "user-profile-refresh-hook.sh")}"`,
       ),
       timeout: 10,
       async: true,
@@ -2485,7 +2510,7 @@ export function buildSettingsHooksBlock(p: HooksBlockParams): Record<string, unk
       type: "command",
       command: wrap(
         "hook:secret-scrub-stop",
-        `node "${join(REPO_ROOT, "telegram-plugin", "hooks", "secret-scrub-stop.mjs")}"`,
+        `node "${join(DOCKER_HOOKS_PATH, "secret-scrub-stop.mjs")}"`,
       ),
       timeout: 15,
       async: true,
@@ -2494,7 +2519,7 @@ export function buildSettingsHooksBlock(p: HooksBlockParams): Record<string, unk
       type: "command",
       command: wrap(
         "hook:silent-end-interrupt-stop",
-        `node "${join(REPO_ROOT, "telegram-plugin", "hooks", "silent-end-interrupt-stop.mjs")}"`,
+        `node "${join(DOCKER_HOOKS_PATH, "silent-end-interrupt-stop.mjs")}"`,
       ),
       timeout: 5,
       async: false,
@@ -2505,7 +2530,7 @@ export function buildSettingsHooksBlock(p: HooksBlockParams): Record<string, unk
       type: "command",
       command: wrap(
         "hook:tool-label-stop",
-        `node "${join(REPO_ROOT, "telegram-plugin", "hooks", "tool-label-stop.mjs")}"`,
+        `node "${join(DOCKER_HOOKS_PATH, "tool-label-stop.mjs")}"`,
       ),
       timeout: 5,
       async: true,
@@ -2522,7 +2547,7 @@ export function buildSettingsHooksBlock(p: HooksBlockParams): Record<string, unk
               type: "command",
               command: wrap(
                 "hook:secret-guard-pretool",
-                `node "${join(REPO_ROOT, "telegram-plugin", "hooks", "secret-guard-pretool.mjs")}"`,
+                `node "${join(DOCKER_HOOKS_PATH, "secret-guard-pretool.mjs")}"`,
               ),
               timeout: 10,
             },
@@ -2539,7 +2564,7 @@ export function buildSettingsHooksBlock(p: HooksBlockParams): Record<string, unk
               type: "command",
               command: wrap(
                 "hook:subagent-tracker-pretool",
-                `node "${join(REPO_ROOT, "telegram-plugin", "hooks", "subagent-tracker-pretool.mjs")}"`,
+                `node "${join(DOCKER_HOOKS_PATH, "subagent-tracker-pretool.mjs")}"`,
               ),
               timeout: 10,
             },
@@ -2554,7 +2579,7 @@ export function buildSettingsHooksBlock(p: HooksBlockParams): Record<string, unk
               type: "command",
               command: wrap(
                 "hook:tool-label-pretool",
-                `node "${join(REPO_ROOT, "telegram-plugin", "hooks", "tool-label-pretool.mjs")}"`,
+                `node "${join(DOCKER_HOOKS_PATH, "tool-label-pretool.mjs")}"`,
               ),
               timeout: 5,
             },
@@ -2577,7 +2602,7 @@ export function buildSettingsHooksBlock(p: HooksBlockParams): Record<string, unk
               type: "command",
               command: wrap(
                 "hook:subagent-tracker-posttool",
-                `node "${join(REPO_ROOT, "telegram-plugin", "hooks", "subagent-tracker-posttool.mjs")}"`,
+                `node "${join(DOCKER_HOOKS_PATH, "subagent-tracker-posttool.mjs")}"`,
               ),
               timeout: 10,
             },
@@ -2597,7 +2622,7 @@ export function buildSettingsHooksBlock(p: HooksBlockParams): Record<string, unk
                 type: "command",
                 command: wrap(
                   "hook:workspace-stable",
-                  `bash "${join(REPO_ROOT, "bin", "workspace-stable-hook.sh")}"`,
+                  `bash "${join(DOCKER_BIN_PATH, "workspace-stable-hook.sh")}"`,
                 ),
                 timeout: 6,
               },
@@ -2611,7 +2636,7 @@ export function buildSettingsHooksBlock(p: HooksBlockParams): Record<string, unk
           type: "command",
           command: wrap(
             "hook:workspace-dynamic",
-            `bash "${join(REPO_ROOT, "bin", "workspace-dynamic-hook.sh")}"`,
+            `bash "${join(DOCKER_BIN_PATH, "workspace-dynamic-hook.sh")}"`,
           ),
           timeout: 5,
         },
@@ -2623,7 +2648,7 @@ export function buildSettingsHooksBlock(p: HooksBlockParams): Record<string, unk
           type: "command",
           command: wrap(
             "hook:timezone",
-            `bash "${join(REPO_ROOT, "bin", "timezone-hook.sh")}"`,
+            `bash "${join(DOCKER_BIN_PATH, "timezone-hook.sh")}"`,
           ),
           timeout: 3,
         },


### PR DESCRIPTION
Phase 3 / Bug 3 from the sub-agent visibility RFC. **The actual blocker** for bg-sub-agent visibility working in docker mode — Bug 1 (#1057) and Bug 2 (#1059) were both correct but neither could deliver value alone.

## The bug

`buildSettingsHooksBlock` in `src/agents/scaffold.ts` emitted hook commands with the host repo path (`/home/<op>/code/switchroom/telegram-plugin/hooks/...`). Inside docker the path doesn't exist — `Dockerfile.agent` COPYs only `telegram-plugin/{dist,start.js,package.json}`, not `hooks/` or the `bin/*-hook.sh` family. Claude Code silently skips hook commands whose binary is missing.

Effect: bg-sub-agent tracking, secret-redaction, tool-label preprocessor, silent-end Stop hook, workspace-dynamic UserPromptSubmit, timezone, user-profile refresh — **none of these fired in docker mode**. Confirmed by inspecting test-harness's registry.db: 4096 bytes, zero tables, despite hundreds of Agent dispatches.

## The fix

Two parts, paired:

**`docker/Dockerfile.agent`** — adds COPY for `telegram-plugin/hooks` → `/opt/switchroom/telegram-plugin/hooks` plus the 5 `bin/*-hook.sh` files → `/opt/switchroom/bin/` (chmod +x). ~50KB of files total, no build step.

**`src/agents/scaffold.ts`** — adds two new exported constants:
- `DOCKER_HOOKS_PATH = "/opt/switchroom/telegram-plugin/hooks"`
- `DOCKER_BIN_PATH = "/opt/switchroom/bin"`

`buildSettingsHooksBlock` swaps the `REPO_ROOT`-based joins for these. Mirrors the existing `.mcp.json` plugin path which already uses `DOCKER_TELEGRAM_PLUGIN_PATH` unconditionally for the same reason.

## Why no test changes

Scaffold tests pin hook NAMES and ORDERING in the hooks block, not the path prefix. The 166 scaffold tests pass without modification.

## Validation path post-merge

1. `docker-images` workflow builds + publishes new agent image.
2. Operator runs `switchroom update` → compose pulls + recreates → settings.json regenerated with docker paths.
3. Next Agent dispatch fires the pretool hook → row lands in `<agentDir>/telegram/registry.db`.
4. `bg-sub-agent-dispatch-dm.test.ts` (#1056) goes green → drop `.skip` + close #709 / #776 / #782 / #788.

## Together with #1057 + #1059

All three need to be merged + image rebuilt + apply re-run before the bg-sub-agent visibility contract is honored end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)