### PR TITLE
feat(vault): auto-resume agent task after vault_request_access approval (#1052)

### DIFF
--- a/telegram-plugin/bridge/bridge.ts
+++ b/telegram-plugin/bridge/bridge.ts
@@ -421,7 +421,7 @@ const TOOL_SCHEMAS = [
   {
     name: 'vault_request_access',
     description:
-      'Ask the operator (via Telegram approval card) to grant this agent read or write access to a vault key it does not yet have. Use this when you hit `VAULT-BROKER-DENIED` or when you know upfront that an upcoming task needs a key you lack. Renders a [Approve] [Deny] card; on approve, the broker mints a scoped grant token and writes it to the agent\'s `.vault-token` file — your next vault read will succeed without intervention. You CANNOT mint or self-elevate; only the operator can tap Approve. Wait for confirmation before retrying the vault op. Do NOT call this for keys you already have access to (use the normal `vault:<key>` reference) and do NOT spam-request (the operator sees every card).',
+      'Ask the operator (via Telegram approval card) to grant this agent read or write access to a vault key it does not yet have. Use this when you hit `VAULT-BROKER-DENIED` or when you know upfront that an upcoming task needs a key you lack. Renders a [Approve] [Deny] card; on approve, the broker mints a scoped grant token and writes it to the agent\'s `.vault-token` file. You CANNOT mint or self-elevate; only the operator can tap Approve. After firing this tool, END YOUR TURN cleanly — the gateway will inject a fresh inbound message (with `<channel source="vault_grant_approved">`) when the operator approves, kicking off a new turn where you can resume the original task. Do NOT call this for keys you already have access to (use the normal `vault:<key>` reference) and do NOT spam-request (the operator sees every card).',
     inputSchema: {
       type: 'object',
       properties: {

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -8192,6 +8192,53 @@ async function performVaultAccessApproval(
       )
       .catch(() => {})
   }
+
+  // #1052: deliver a synthetic inbound message back to the agent so
+  // the task that fired vault_request_access auto-resumes — without
+  // this, the agent's turn ended after the tool call ("waiting for
+  // approval") and the operator has to send a fresh message to kick
+  // it back into action.
+  //
+  // Uses the existing inject_inbound primitive (cron's pattern from
+  // dispatch.ts:180-206). The bridge sees a normal channel event,
+  // renders it as `<channel source="vault_grant_approved">`, and the
+  // agent starts a new turn with the context that the operator just
+  // approved.
+  //
+  // The synthetic message text is concise + actionable so the agent
+  // knows (a) which key was approved, (b) at what scope, (c) what to
+  // do next. Meta carries the structured fields for forensics + for
+  // future filters that want to suppress these in the chat tail.
+  const grantedSyntheticTs = Date.now()
+  const synthetic: InboundMessage = {
+    type: 'inbound',
+    chatId: pending.chat_id,
+    messageId: grantedSyntheticTs, // synthetic — no Telegram message id exists
+    user: 'vault-broker',
+    userId: 0,
+    ts: grantedSyntheticTs,
+    text:
+      `✅ Operator approved your vault access request for ` +
+      `\`${pending.key}\` (scope=${pending.scope}, ` +
+      `${Math.round(pending.ttl_seconds / 86400)}d, grant=${id}). ` +
+      `The token has been written. Please resume the task that was ` +
+      `waiting on this credential — fetch via the usual switchroom vault ` +
+      `get path.`,
+    meta: {
+      source: 'vault_grant_approved',
+      agent: pending.agent,
+      key: pending.key,
+      scope: pending.scope,
+      grant_id: id,
+      stage_id: stageId,
+      operator_id: senderId,
+    },
+  }
+  const delivered = ipcServer.sendToAgent(pending.agent, synthetic)
+  process.stderr.write(
+    `telegram gateway: vault_grant_approved injection agent=${pending.agent} ` +
+    `key=${pending.key} stage=${stageId} delivered=${delivered}\n`,
+  )
 }
 
 async function handleVaultRequestAccessCallback(ctx: Context, data: string): Promise<void> {

--- a/telegram-plugin/tests/vault-grant-auto-resume.test.ts
+++ b/telegram-plugin/tests/vault-grant-auto-resume.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Contract pin for #1052 — agent auto-resumes after operator approves
+ * a vault_request_access card.
+ *
+ * Pre-fix: agent called vault_request_access → tool returned ack →
+ * agent's turn ended ("waiting for approval"). Operator approved later
+ * → grant minted → BUT the agent did nothing because its turn was
+ * already over. Operator had to send a fresh message to kick the
+ * agent back into action.
+ *
+ * Fix: after successful mint (via passphrase-attestation broker call
+ * + token-write), the gateway injects a synthetic InboundMessage into
+ * the agent's bridge via `ipcServer.sendToAgent`. The bridge sees it
+ * as a normal channel event (with meta.source="vault_grant_approved"
+ * for distinct rendering) and starts a new turn. Re-uses the existing
+ * inject_inbound primitive that cron has used since #890+.
+ *
+ * This file pins the call site so a future refactor can't quietly
+ * drop the injection.
+ */
+
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const gatewaySrc = readFileSync(
+  resolve(__dirname, "..", "gateway", "gateway.ts"),
+  "utf-8",
+);
+
+function extractPerformBlock(): string {
+  const start = gatewaySrc.indexOf("async function performVaultAccessApproval");
+  if (start < 0) throw new Error("performVaultAccessApproval not found");
+  const restAfter = gatewaySrc.slice(start + 1);
+  const endRel = restAfter.indexOf("\nasync function ");
+  return gatewaySrc.slice(start, start + 1 + (endRel >= 0 ? endRel : restAfter.length));
+}
+
+describe("performVaultAccessApproval injects a synthetic inbound on success (#1052)", () => {
+  const block = extractPerformBlock();
+
+  it("calls ipcServer.sendToAgent AFTER successful mint + token-write", () => {
+    // fails when: the auto-resume injection gets dropped. Pre-fix
+    // operator had to message the agent again to resume the task —
+    // the injection is the load-bearing wiring.
+    expect(block, "missing ipcServer.sendToAgent call").toMatch(/ipcServer\.sendToAgent\(/);
+    // Must run AFTER the mint-success path (i.e., after the
+    // `result.kind === 'error'` early-return guard).
+    const errorReturn = block.indexOf("result.kind === 'error'");
+    const sendIdx = block.indexOf("ipcServer.sendToAgent(");
+    expect(errorReturn).toBeGreaterThan(0);
+    expect(sendIdx, "sendToAgent must come AFTER the error-return early exit").toBeGreaterThan(errorReturn);
+  });
+
+  it("synthetic inbound carries meta.source = 'vault_grant_approved'", () => {
+    // fails when: the source marker is missing or different — the
+    // bridge uses meta.source to render `<channel source="...">`,
+    // and the agent's system prompt may filter on this. Pinning the
+    // string so future renders stay consistent.
+    expect(block).toMatch(/source:\s*['"]vault_grant_approved['"]/);
+  });
+
+  it("synthetic inbound carries the structured meta forensics need", () => {
+    // The meta carries fields the post-hoc audit / agent filter use:
+    // agent, key, scope, grant_id, stage_id, operator_id.
+    const metaBlock = block.split("meta: {")[1]?.split("}")[0] ?? "";
+    expect(metaBlock).toMatch(/\bagent\b/);
+    expect(metaBlock).toMatch(/\bkey\b/);
+    expect(metaBlock).toMatch(/\bscope\b/);
+    expect(metaBlock).toMatch(/grant_id/);
+    expect(metaBlock).toMatch(/stage_id/);
+    expect(metaBlock).toMatch(/operator_id/);
+  });
+
+  it("user/userId identifies the synthetic source as the vault broker", () => {
+    // The bridge surfaces `user` in the channel tag the agent sees.
+    // Should be 'vault-broker' (or similar marker), not a real user
+    // name. userId=0 because no real Telegram user authored it.
+    expect(block).toMatch(/user:\s*['"]vault-broker['"]/);
+    expect(block).toMatch(/userId:\s*0/);
+  });
+
+  it("logs delivery outcome to stderr for forensics", () => {
+    // Mirrors the cron inject_inbound logging at gateway.ts:2470 so
+    // ops can confirm an injection actually delivered (vs the agent's
+    // bridge being down).
+    expect(block).toMatch(/vault_grant_approved injection[\s\S]*delivered/);
+  });
+});

--- a/telegram-plugin/uat/scenarios/vault-grant-auto-resume-dm.test.ts
+++ b/telegram-plugin/uat/scenarios/vault-grant-auto-resume-dm.test.ts
@@ -1,0 +1,121 @@
+/**
+ * End-to-end UAT scenario for #1052 — agent auto-resumes its task
+ * after operator approves a vault_request_access card.
+ *
+ * Pre-fix: agent fired vault_request_access → ended its turn → operator
+ * approved later → grant minted → agent did nothing further until
+ * operator messaged again. Operator had to manually nudge the agent
+ * to resume work the agent itself had flagged.
+ *
+ * Fix: gateway injects a synthetic InboundMessage after successful
+ * mint (via the existing inject_inbound IPC primitive cron uses).
+ * Agent's bridge receives the channel event, starts a new turn, and
+ * resumes the task.
+ *
+ * Load-bearing assertion: after the operator's passphrase reply +
+ * "Granted" card edit, the DRIVER sees a NEW bot turn (a substantive
+ * reply that uses the just-granted key) WITHOUT the driver sending
+ * any further message.
+ *
+ * **Skipped by default.** To unskip:
+ *
+ * 1. Standard UAT preflight (`uat/SETUP.md` §5-6).
+ * 2. `TELEGRAM_UAT_VAULT_PASSPHRASE` set in env.
+ * 3. Pre-create a sacrificial vault key:
+ *
+ *    ```bash
+ *    TMPF=$(mktemp) && printf '%s' 'sentinel-1052-value' > "$TMPF" && \
+ *      switchroom vault set uat/auto-resume-key --file "$TMPF" \
+ *        --format string ; shred -u "$TMPF"
+ *    ```
+ *
+ * 4. Remove `describe.skip` below.
+ *
+ * Why skipped: mutates vault state. Cleanup is operator-side post-run.
+ */
+
+import { describe, expect, it } from "vitest";
+import { spinUp } from "../harness.js";
+
+const KEY = "uat/auto-resume-key";
+const SENTINEL = "sentinel-1052-value";
+
+describe.skip("uat: agent auto-resumes after vault grant approval (#1052)", () => {
+  it(
+    "agent fires card, operator approves, agent emits new turn WITHOUT a nudge",
+    async () => {
+      const passphrase = process.env.TELEGRAM_UAT_VAULT_PASSPHRASE;
+      if (!passphrase) {
+        throw new Error(
+          "TELEGRAM_UAT_VAULT_PASSPHRASE must be set in env (see uat/SETUP.md).",
+        );
+      }
+      const sc = await spinUp({ agent: "test-harness" });
+      try {
+        // 1. Ask the agent to fetch the key — it'll hit DENIED first,
+        //    fire vault_request_access, then end its turn.
+        await sc.sendDM(
+          `Please run \`switchroom vault get ${KEY}\`. If you get ` +
+          `VAULT-BROKER-DENIED, call your vault_request_access MCP tool ` +
+          `for that key (read, 30d, reason "UAT for #1052 auto-resume"), ` +
+          `END YOUR TURN cleanly, and when the operator approves you should ` +
+          `automatically resume by re-running the vault get and reporting ` +
+          `the value.`,
+        );
+
+        // 2. Wait for the approval card.
+        const card = await sc.expectMessage(/🔐.*wants vault access/, {
+          from: "bot",
+          timeout: 120_000,
+        });
+        const kb = await sc.driver.getKeyboard(sc.botUserId, card.messageId);
+        const approveButton = kb!
+          .flat()
+          .find((b) => b.callbackData !== undefined && /approve/i.test(b.text));
+        expect(approveButton).toBeDefined();
+
+        // 3. Tap Approve. Triggers passphrase prompt.
+        await sc.driver.pressButton(sc.botUserId, card.messageId, approveButton!.callbackData!);
+        await sc.expectMessage(/Vault is locked.*Reply with your passphrase/, {
+          from: "bot",
+          timeout: 15_000,
+        });
+
+        // 4. Send passphrase. Card edits to "Granted ...".
+        const lastDriverMsg = await sc.sendDM(passphrase);
+        const lastDriverMsgId = lastDriverMsg.messageId;
+        await sc.expectMessage(/Granted.*read access/, {
+          from: "bot",
+          timeout: 30_000,
+        });
+
+        // 5. THE LOAD-BEARING #1052 ASSERTION: the agent should
+        //    auto-resume WITHOUT the driver sending another message.
+        //    We wait for a substantive bot reply containing the
+        //    sentinel value, OR matching the auto-resume channel
+        //    source marker the gateway stamps.
+        //
+        //    Pre-fix: this assertion times out (no synthetic
+        //    injection → agent's bridge never received a new turn
+        //    → agent stayed idle).
+        //
+        //    Post-fix: the gateway's ipcServer.sendToAgent fires a
+        //    synthetic inbound with meta.source="vault_grant_approved".
+        //    The agent's bridge starts a new turn, re-runs vault get,
+        //    and reports the value.
+        const autoResumeReply = await sc.expectMessage(
+          new RegExp(SENTINEL),
+          { from: "bot", timeout: 180_000 },
+        );
+        expect(autoResumeReply.text).toContain(SENTINEL);
+        expect(
+          autoResumeReply.messageId,
+          "auto-resume reply must be a NEW message, not the granted-card edit",
+        ).toBeGreaterThan(lastDriverMsgId);
+      } finally {
+        await sc.tearDown();
+      }
+    },
+    420_000,
+  );
+});


### PR DESCRIPTION
## Summary

Closes #1052. Combined with the prior PRs (#1030, #1034, #1051, #1053), closes the parent epic #1012.

**Before:** agent called vault_request_access → tool ack → agent's turn ended (\"waiting for approval\"). Operator approved later → grant minted → agent did nothing further. Operator had to nudge.

**After:** gateway uses the existing \`inject_inbound\` IPC primitive (cron's pattern since Phase 4 fold-in) to deliver a synthetic InboundMessage to the agent's bridge after successful mint. Bridge renders \`<channel source=\"vault_grant_approved\">\` and the agent starts a new turn with full context that the operator just approved.

## Implementation

- \`gateway.ts:performVaultAccessApproval\` — after success-path token write, build a synthetic InboundMessage (chat_id = original card chat, user = 'vault-broker', text = \"✅ Operator approved... Resume the task...\", meta = { source, agent, key, scope, grant_id, stage_id, operator_id }) and call \`ipcServer.sendToAgent(pending.agent, synthetic)\`. Logs delivery to stderr for forensics.
- \`bridge.ts\` — vault_request_access tool description updated: agent should END ITS TURN cleanly after firing; the gateway will deliver a fresh inbound when the operator approves.

## Tests

- New \`telegram-plugin/tests/vault-grant-auto-resume.test.ts\` (5 cases) — static-source contract on the injection wiring (call exists, lands AFTER error-return, carries \`source=vault_grant_approved\`, structured meta fields, user=vault-broker, stderr log).
- New \`telegram-plugin/uat/scenarios/vault-grant-auto-resume-dm.test.ts\` (\`.skip\`) — end-to-end Telegram round-trip. THE LOAD-BEARING ASSERTION: after operator passphrase, a new bot turn appears with the vault value WITHOUT the driver sending another message.

## Closes #1012 epic

Full Telegram-mediated vault ACL approval flow now lands:
- agent hits VAULT-BROKER-DENIED → fires vault_request_access (#1027/#1012 Phase 1)
- approval card with [✅ Approve] / [🚫 Deny] in operator DM (#1027/#1012 Phase 1)
- tap-to-unlock-and-approve if no cached passphrase (#1034)
- broker mints via passphrase-attestation (#1030/#1012 Phase 2)
- grant covers union of all prior approvals (#1051)
- agent reads via forwarded token (#1053)
- agent auto-resumes the original task (#1052 — this PR)

No operator host shell needed end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)