### PR TITLE
fix(uat): escape `*/` in vault-request-access-concurrent-dm JSDoc (#1058 followup)

### DIFF
--- a/telegram-plugin/uat/scenarios/vault-request-access-concurrent-dm.test.ts
+++ b/telegram-plugin/uat/scenarios/vault-request-access-concurrent-dm.test.ts
@@ -29,7 +29,7 @@
  *
  *    ```bash
  *    for k in uat/concurrent-a uat/concurrent-b ; do
- *      TMPF=$(mktemp); printf '%s' "sentinel-${k##*/}" > "$TMPF"
+ *      TMPF=$(mktemp); printf '%s' "sentinel-$(basename "$k")" > "$TMPF"
  *      switchroom vault set "$k" --file "$TMPF" --format string
  *      shred -u "$TMPF"
  *    done


### PR DESCRIPTION
## Summary

One-line fix for a parse error in the UAT scenario I shipped in #1058.

A bash parameter expansion `${k##*/}` inside the scenario's JSDoc setup-instructions broke esbuild's transform — the `*/` inside the bash literal closes the JSDoc comment prematurely:

```
Transform failed with 1 error:
.../vault-request-access-concurrent-dm.test.ts:32:53: ERROR: Unexpected "}"
```

The error only surfaces when vitest's UAT runner picks up the file for transform (running `bun run test:uat`). Caught while running a rollout-verification probe against the freshly-deployed image stack.

Fix: rewrite the bash snippet to use `$(basename "$k")` instead of `${k##*/}` — same result, no `*/` in the JSDoc.

## Test plan

- [x] `npm run lint` — clean.
- [x] `npm test` — 5524/0 pass.
- [x] `bun run test:uat` — file now transforms cleanly; existing live scenarios (smoke, progress-card) run and pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)