### PR TITLE
fix(cli): vault-broker socket resolution honors env var first, ignores schema default (RFC §Bug 4)

### DIFF
--- a/src/cli/agent-vault-preflight.test.ts
+++ b/src/cli/agent-vault-preflight.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import type { SwitchroomConfig } from "../config/schema.js";
 import type { BrokerStatus } from "../vault/broker/protocol.js";
 import {
@@ -7,6 +7,7 @@ import {
   effectiveBotToken,
   formatLockedRefusal,
   formatLockedRefusalBulk,
+  resolvePreflightSocket,
 } from "./agent-vault-preflight.js";
 
 function mkConfig(opts: {
@@ -147,5 +148,57 @@ describe("formatLockedRefusalBulk", () => {
     expect(m).toContain("foo");
     expect(m).toContain("bar");
     expect(m).toContain("--force-locked");
+  });
+});
+
+describe("resolvePreflightSocket — env > config > default (#1062 Bug 4)", () => {
+  const prev = process.env.SWITCHROOM_VAULT_BROKER_SOCK;
+  afterEach(() => {
+    if (prev === undefined) delete process.env.SWITCHROOM_VAULT_BROKER_SOCK;
+    else process.env.SWITCHROOM_VAULT_BROKER_SOCK = prev;
+  });
+
+  function withSocket(socket?: string): SwitchroomConfig {
+    const base = mkConfig({ agents: { foo: { bot_token: "vault:foo" } } });
+    if (socket === undefined) return base;
+    return {
+      ...base,
+      vault: {
+        path: "~/.switchroom/vault.enc",
+        broker: { enabled: true, socket },
+      },
+    } as SwitchroomConfig;
+  }
+
+  it("env var wins over explicit config value", () => {
+    process.env.SWITCHROOM_VAULT_BROKER_SOCK = "/tmp/from-env.sock";
+    const got = resolvePreflightSocket(withSocket("/tmp/from-config.sock"));
+    expect(got).toBe("/tmp/from-env.sock");
+  });
+
+  it("explicit config value used when env unset", () => {
+    delete process.env.SWITCHROOM_VAULT_BROKER_SOCK;
+    const got = resolvePreflightSocket(withSocket("/tmp/from-config.sock"));
+    expect(got).toBe("/tmp/from-config.sock");
+  });
+
+  it("Zod schema default in config does NOT count as explicit (returns undefined → fall through)", () => {
+    // This is the load-bearing case. Before the fix, the schema's
+    // default of "~/.switchroom/vault-broker.sock" appeared identical
+    // to an operator override, masking the env var and routing the
+    // preflight at a legacy socket nobody was listening on. Returning
+    // undefined here lets statusViaBroker pick the runtime default
+    // (operator socket under docker).
+    delete process.env.SWITCHROOM_VAULT_BROKER_SOCK;
+    const got = resolvePreflightSocket(
+      withSocket("~/.switchroom/vault-broker.sock"),
+    );
+    expect(got).toBeUndefined();
+  });
+
+  it("config without vault.broker.socket field → undefined", () => {
+    delete process.env.SWITCHROOM_VAULT_BROKER_SOCK;
+    const got = resolvePreflightSocket(withSocket(undefined));
+    expect(got).toBeUndefined();
   });
 });

--- a/src/cli/agent-vault-preflight.ts
+++ b/src/cli/agent-vault-preflight.ts
@@ -19,6 +19,35 @@ import { isVaultReference } from "../vault/resolver.js";
 import { statusViaBroker } from "../vault/broker/client.js";
 import type { BrokerStatus } from "../vault/broker/protocol.js";
 import { isDockerRuntime } from "../runtime-mode.js";
+import { resolvePath } from "../config/loader.js";
+
+/**
+ * Must mirror `src/config/schema.ts:vault.broker.socket` default.
+ * See `src/cli/vault-broker.ts:SCHEMA_DEFAULT_SOCKET` for the same
+ * sentinel — keep them in sync if the schema default ever changes.
+ */
+const SCHEMA_DEFAULT_SOCKET = "~/.switchroom/vault-broker.sock";
+
+/**
+ * Pick the broker socket the preflight should consult. Mirrors
+ * `src/cli/vault-broker.ts:getSocketPath` precedence: env var first,
+ * config `vault.broker.socket` only when explicitly set (not the
+ * schema default), runtime-aware default last. Pre-fix the preflight
+ * always used `statusViaBroker()` with no socket argument — its
+ * default resolution on the host ignores config AND ignores the env
+ * var in some shapes, so a docker-mode operator with an unlocked
+ * broker hit a phantom "broker unreachable" refusal on every restart.
+ * See RFC §Bug 4.
+ */
+export function resolvePreflightSocket(config: SwitchroomConfig): string | undefined {
+  const env = process.env.SWITCHROOM_VAULT_BROKER_SOCK;
+  if (env) return resolvePath(env);
+  const raw = config.vault?.broker?.socket;
+  if (typeof raw === "string" && raw !== SCHEMA_DEFAULT_SOCKET) {
+    return resolvePath(raw);
+  }
+  return undefined; // let statusViaBroker fall back to its runtime default
+}
 
 export type VaultPreflightVerdict =
   | { kind: "ok" }
@@ -57,7 +86,8 @@ export async function checkVaultPreflight(
   if (!token) return { kind: "skip", reason: "no-token" };
   if (!isVaultReference(token)) return { kind: "skip", reason: "plaintext-token" };
 
-  const fetch = deps.status ?? (() => statusViaBroker());
+  const socket = resolvePreflightSocket(config);
+  const fetch = deps.status ?? (() => statusViaBroker(socket ? { socket } : undefined));
   const status = await fetch();
   if (status === null) {
     // Broker unreachable. We can't verify; treat as locked.
@@ -93,7 +123,8 @@ export async function checkVaultPreflightBulk(
     return { blocked: [], reachable: true };
   }
 
-  const fetch = deps.status ?? (() => statusViaBroker());
+  const socket = resolvePreflightSocket(config);
+  const fetch = deps.status ?? (() => statusViaBroker(socket ? { socket } : undefined));
   const status = await fetch();
   if (status === null) {
     return {

--- a/src/cli/vault-broker.ts
+++ b/src/cli/vault-broker.ts
@@ -46,17 +46,32 @@ const DEFAULT_PID_FILE = "~/.switchroom/vault-broker.pid";
 const LEGACY_SOCKET_PATH = "~/.switchroom/vault-broker.sock";
 
 function getSocketPath(configPath?: string): string {
-  // Use the canonical resolver — honors `SWITCHROOM_VAULT_BROKER_SOCK`
-  // env first, then `vault.broker.socket` config, then the legacy
-  // `~/.switchroom/vault-broker.sock` fallback. Same fix as the other
-  // vault CLI files: pre-fix this skipped the env entirely so
-  // `switchroom vault broker status` from inside an agent container
-  // saw the dangling-symlink fallback and reported the broker as
-  // unreachable even when it was fine on the canonical path.
+  // Canonical resolution order (#1062 / RFC Bug 4):
+  //   1. SWITCHROOM_VAULT_BROKER_SOCK env var — always wins.
+  //   2. `vault.broker.socket` from yaml — BUT only when the operator
+  //      actually set it. The Zod schema defaults this to
+  //      `~/.switchroom/vault-broker.sock`, so a bare
+  //      `if (config.vault?.broker?.socket !== undefined)` check was
+  //      always true even on hosts with no explicit override, masking
+  //      the env var and routing connections to the legacy socket that
+  //      has no listener in docker mode. We detect "operator set this
+  //      explicitly" by comparing against the schema's default string.
+  //   3. Runtime-aware default — operator socket under Docker, legacy
+  //      under v0.6 systemd. Delegated to `resolveBrokerSocketPath`.
+  //
+  // The pre-fix shape pointed `switchroom vault broker status` (and the
+  // restart preflight) at the legacy host path even when a docker-mode
+  // operator had `SWITCHROOM_VAULT_BROKER_SOCK` exported — false
+  // "broker unreachable" reports were the symptom. See
+  // reference/sub-agent-visibility-rfc.md §Bug 4 for the full trace.
+  const env = process.env.SWITCHROOM_VAULT_BROKER_SOCK;
+  if (env) return resolvePath(env);
+
   try {
     const config = loadConfig(configPath);
-    if (config.vault?.broker?.socket !== undefined) {
-      return resolvePath(config.vault.broker.socket);
+    const raw = config.vault?.broker?.socket;
+    if (typeof raw === "string" && raw !== SCHEMA_DEFAULT_SOCKET) {
+      return resolvePath(raw);
     }
   } catch {
     // Config load failure — defer to the resolver below.
@@ -66,6 +81,15 @@ function getSocketPath(configPath?: string): string {
   // installs keep getting the legacy socket. See client.ts.
   return resolveBrokerSocketPath();
 }
+
+/**
+ * Must mirror the default declared in `src/config/schema.ts` for the
+ * `vault.broker.socket` field. The Zod schema applies this default
+ * whenever the operator's yaml omits the field, so we use it to
+ * distinguish "operator set this explicitly" from "schema filled
+ * this in for us." If the schema default changes, change this too.
+ */
+const SCHEMA_DEFAULT_SOCKET = "~/.switchroom/vault-broker.sock";
 
 function getConfigPath(configPath?: string): string | undefined {
   return configPath;


### PR DESCRIPTION
Discovered while validating the Phase 3 sub-agent visibility fixes against a real docker test-harness. `vault broker status` reported `running:false` and `agent restart` refused with "broker unreachable" — both phantom, the broker was alive and unlocked on the operator socket.

## Root cause

`src/config/schema.ts:1369` defaults `vault.broker.socket` to `~/.switchroom/vault-broker.sock`. Zod fills the field on every config load, so `config.vault.broker.socket !== undefined` is **always true**, masking the env-var fallback in two consumers:

1. `getSocketPath` (vault-broker CLI verbs) — docs say "env first" but code checked config first.
2. `checkVaultPreflight` (agent restart) — called `statusViaBroker()` with no opts; the host shell's runtime-aware default routes to the legacy socket.

## Fix

Both files now follow env > explicit-config > runtime-default, with a `SCHEMA_DEFAULT_SOCKET` sentinel that treats the schema default as "no explicit override."

## Tests

4 new cases in `agent-vault-preflight.test.ts` pinning the precedence:
- env wins over explicit config
- explicit config used when env unset
- schema-default value treated as undefined (the load-bearing case)
- missing field treated as undefined

18/18 preflight tests pass.

## After this lands

Operators on docker mode get `vault broker status` and `agent restart` working correctly without needing an explicit `vault.broker.socket` in yaml or an exported env var — the docker-mode default just works. Unblocks the final step of the sub-agent visibility validation (#709 / #776 / #782 / #788).

🤖 Generated with [Claude Code](https://claude.com/claude-code)