### PR TITLE
fix(progress-card): tool_result preserves bg pending Agent spawn (RFC §Bug 5)

### DIFF
--- a/telegram-plugin/progress-card.ts
+++ b/telegram-plugin/progress-card.ts
@@ -697,9 +697,21 @@ export function reduce(
             break
           }
         }
-        if (pendingAgentSpawns.has(event.toolUseId)) {
+        // For background dispatches, the Agent tool returns IMMEDIATELY
+        // after spawning — tool_result fires before the worker writes
+        // its JSONL, so the corresponding sub_agent_started arrives
+        // LATER. Deleting the pending entry on tool_result would strand
+        // that future event as an orphan with pendingSpawns=0 (same
+        // root-cause family as #1057 / RFC Bug 1, different reducer
+        // case). Preserve bg entries; clear foreground ones — they
+        // HAD their chance to correlate during the turn.
+        //
+        // See `pending-bg-spawn-survives-turn-end.test.ts` for the
+        // foreground/background-distinction regression gate.
+        const pendingEntry = pendingAgentSpawns.get(event.toolUseId ?? "")
+        if (pendingEntry && !pendingEntry.runInBackground) {
           const next = new Map(pendingAgentSpawns)
-          next.delete(event.toolUseId)
+          next.delete(event.toolUseId!)
           pendingAgentSpawns = next
         }
       }

--- a/telegram-plugin/tests/pending-bg-spawn-survives-turn-end.test.ts
+++ b/telegram-plugin/tests/pending-bg-spawn-survives-turn-end.test.ts
@@ -155,3 +155,96 @@ describe('reducer: turn_end pending-spawn preservation (RFC §Bug 1)', () => {
     expect(state.pendingAgentSpawns.size).toBe(0)
   })
 })
+
+describe('reducer: tool_result preserves bg pending spawn (RFC §Bug 5)', () => {
+  // The Agent tool with `run_in_background:true` returns IMMEDIATELY
+  // (the dispatch is the result). So the chronology is:
+  //   tool_use(bg)  → pending entry added (runInBackground:true)
+  //   tool_result   → ← THIS deleted the pending entry pre-fix
+  //   turn_end      → Bug 1 fix preserves bg entries here
+  //   sub_agent_started — late, after worker JSONL appears
+  //
+  // The Bug 1 fix only addressed the turn_end deletion. The earlier
+  // tool_result deletion still stranded bg entries before turn_end
+  // could even preserve them. Production trace:
+  //   `correlated=orphan pendingSpawns=0` despite `bg=true` at
+  //   tool_use time.
+
+  it('tool_result for a bg Agent dispatch DOES NOT delete the pending entry', () => {
+    let state = startedTurn()
+    state = reduce(state, {
+      kind: 'tool_use',
+      toolName: 'Agent',
+      toolUseId: 'tu-bg-result',
+      input: { prompt: 'bg', run_in_background: true },
+    }, NOW - 80)
+    expect(state.pendingAgentSpawns.get('tu-bg-result')?.runInBackground).toBe(true)
+
+    state = reduce(state, {
+      kind: 'tool_result',
+      toolUseId: 'tu-bg-result',
+      isError: false,
+    }, NOW - 70)
+
+    // Bg pending entry MUST survive tool_result so the eventual
+    // sub_agent_started can still correlate.
+    expect(state.pendingAgentSpawns.size).toBe(1)
+    expect(state.pendingAgentSpawns.has('tu-bg-result')).toBe(true)
+  })
+
+  it('tool_result for a FOREGROUND Agent dispatch still deletes the pending entry (no regression)', () => {
+    let state = startedTurn()
+    state = reduce(state, {
+      kind: 'tool_use',
+      toolName: 'Agent',
+      toolUseId: 'tu-fg-result',
+      input: { prompt: 'fg', run_in_background: false },
+    }, NOW - 80)
+    expect(state.pendingAgentSpawns.size).toBe(1)
+
+    state = reduce(state, {
+      kind: 'tool_result',
+      toolUseId: 'tu-fg-result',
+      isError: false,
+    }, NOW - 70)
+
+    // Foreground spawn that never produced a sub_agent_started during
+    // its tool_use → tool_result window is dead. Clean up the pending
+    // entry so it doesn't leak forward.
+    expect(state.pendingAgentSpawns.size).toBe(0)
+  })
+
+  it('end-to-end: tool_use(bg) → tool_result → turn_end → late sub_agent_started correlates', () => {
+    // The full production chronology this bug bit. Surfaced in
+    // bg-sub-agent-dispatch-dm.test.ts running live against Telegram.
+    let state = startedTurn()
+    state = reduce(state, {
+      kind: 'tool_use',
+      toolName: 'Agent',
+      toolUseId: 'tu-bg-e2e',
+      input: { prompt: 'bg e2e test', run_in_background: true },
+    }, NOW - 80)
+    state = reduce(state, {
+      kind: 'tool_result',
+      toolUseId: 'tu-bg-e2e',
+      isError: false,
+    }, NOW - 60)
+    state = reduce(state, { kind: 'turn_end', durationMs: 30 }, NOW)
+    // Pending entry MUST still be alive at this point — tool_result
+    // preserved it (Bug 5 fix), turn_end preserved it (Bug 1 fix).
+    expect(state.pendingAgentSpawns.size).toBe(1)
+    expect(state.pendingAgentSpawns.has('tu-bg-e2e')).toBe(true)
+
+    state = reduce(state, {
+      kind: 'sub_agent_started',
+      agentId: 'agt-bg-e2e',
+      subagentType: 'general-purpose',
+      firstPromptText: 'bg e2e test',
+    }, NOW + 5_000)
+
+    const sub = state.subAgents.get('agt-bg-e2e')
+    expect(sub).toBeDefined()
+    expect(sub!.parentToolUseId).toBe('tu-bg-e2e')
+    expect(state.pendingAgentSpawns.size).toBe(0)
+  })
+})


### PR DESCRIPTION
Same root-cause family as #1057 (Bug 1), different reducer case. `Agent(run_in_background:true)` returns IMMEDIATELY after spawning — so `tool_result` fires BEFORE the worker writes its JSONL and emits `sub_agent_started`. Pre-fix, `tool_result` deleted the pending entry; the late `sub_agent_started` then registered as orphan with `pendingSpawns=0` even though `bg=true` at tool_use time.

Production trace from the live UAT scenario run after Bugs 1–4 landed:

```
tool_use → agent correlation toolUseId=toolu_… agentId=pending (awaiting sub_agent_started) bg=true
...
sub_agent_started agentId=… correlated=orphan pendingSpawns=0
```

The Bug 1 fix only preserved bg entries across `turn_end`; this PR preserves them across `tool_result` too. Foreground entries still clear on tool_result (no regression).

## Tests

3 new cases in `pending-bg-spawn-survives-turn-end.test.ts`:
- bg tool_result preserves
- fg tool_result still deletes
- end-to-end chronology reproducing the production trace

8/8 pass.

## Together with prior Phase 3 PRs

This is the final missing piece. After this lands + image rebuild + apply, the bg UAT scenario should hit `correlated=yes` and close #709 / #776 / #782 / #788.

🤖 Generated with [Claude Code](https://claude.com/claude-code)