### PR TITLE
boot-card: degraded rows carry actionable next-step hints

### DIFF
--- a/telegram-plugin/gateway/boot-card.ts
+++ b/telegram-plugin/gateway/boot-card.ts
@@ -279,6 +279,18 @@ export interface RenderBootCardOpts {
  * user only needs to know the agent came back up. Anything red catches
  * the eye; everything else stays out of the way.
  */
+/**
+ * Render a probe's `nextStep` hint as Telegram HTML. The hint is
+ * authored as plain text with backtick-quoted commands (one shell idiom
+ * across the codebase — search "Run `switchroom"). We translate those
+ * to <code> spans and escape everything else, so commands stay tap-to-
+ * copy on mobile without bleeding raw HTML through.
+ */
+function renderNextStep(text: string): string {
+  const parts = text.split('`')
+  return parts.map((p, i) => (i % 2 === 0 ? escapeHtml(p) : `<code>${escapeHtml(p)}</code>`)).join('')
+}
+
 export function renderBootCard(opts: RenderBootCardOpts): string {
   const { agentName, version, probes, restartReason, restartAgeMs } = opts
   const ackEmoji = restartReason ? REASON_EMOJI[restartReason] : '✅'
@@ -295,10 +307,16 @@ export function renderBootCard(opts: RenderBootCardOpts): string {
       ? ` · ${(restartAgeMs / 1000).toFixed(1)}s ago`
       : ''
     degradedRows.push(`⚠️ <b>Restart</b>  ${escapeHtml(REASON_LABEL.crash)}${ageStr}`)
+    // Principle 1: every failure carries its next step. The crash row
+    // tells the user how to inspect why.
+    degradedRows.push(`    ↳ Tail logs: <code>journalctl --user -u switchroom-${escapeHtml(agentName)} -n 100</code>`)
   }
 
   // Probe rows — only those that surfaced as degraded/fail. Healthy
-  // (`ok`) probes don't render at all.
+  // (`ok`) probes don't render at all. When a probe carries a nextStep,
+  // it renders as an indented continuation line beneath the row — see
+  // `reference/principles.md` principle 1 ("If they need the docs, we've
+  // failed"): every failure surface tells the user what to run.
   if (probes) {
     for (const key of PROBE_KEYS) {
       const r = probes[key]
@@ -306,6 +324,9 @@ export function renderBootCard(opts: RenderBootCardOpts): string {
       if (r.status === 'ok') continue
       const dot = DOT[r.status] ?? DOT.fail
       degradedRows.push(`${dot} <b>${PROBE_LABELS[key]}</b>  ${escapeHtml(r.detail)}`)
+      if (r.nextStep) {
+        degradedRows.push(`    ↳ ${renderNextStep(r.nextStep)}`)
+      }
     }
   }
 
@@ -432,7 +453,7 @@ export async function runAllProbes(opts: RunProbesOpts): Promise<ProbeMap> {
     probeScheduler(slug, { dockerMode: opts.dockerMode }).then(r => { probes.scheduler = r }),
     probeBroker(undefined, { dockerMode: opts.dockerMode }).then(r => { probes.broker = r }),
     probeKernel(undefined, { dockerMode: opts.dockerMode }).then(r => { probes.kernel = r }),
-    probeSkills(opts.agentDir).then(r => { probes.skills = r }),
+    probeSkills(opts.agentDir, { agentName: opts.agentSlug ?? opts.agentName }).then(r => { probes.skills = r }),
   ])
 
   return probes

--- a/telegram-plugin/gateway/boot-card.ts
+++ b/telegram-plugin/gateway/boot-card.ts
@@ -243,6 +243,10 @@ const REASON_LABEL: Record<RestartReason, string> = {
 
 export interface RenderBootCardOpts {
   agentName: string
+  /** Lowercase slug used for systemd unit names. Falls back to
+   *  `agentName` when omitted — matches the same fallback used by
+   *  `runAllProbes` for systemd targets. */
+  agentSlug?: string
   /** Pre-formatted version string, e.g. "v0.3.0+44" or "v0.3.0 · #143 · 2h ago". */
   version: string
   /** Probe results (only present after the settle window). When absent or
@@ -288,11 +292,16 @@ export interface RenderBootCardOpts {
  */
 function renderNextStep(text: string): string {
   const parts = text.split('`')
+  // Odd-count backticks means an unterminated <code> span — fall back to
+  // plain-escaped text rather than rendering the trailing tail inside a
+  // code block. Author error, not user-input, but defensive is cheap.
+  if (parts.length % 2 === 0) return escapeHtml(text)
   return parts.map((p, i) => (i % 2 === 0 ? escapeHtml(p) : `<code>${escapeHtml(p)}</code>`)).join('')
 }
 
 export function renderBootCard(opts: RenderBootCardOpts): string {
   const { agentName, version, probes, restartReason, restartAgeMs } = opts
+  const agentSlug = opts.agentSlug ?? agentName
   const ackEmoji = restartReason ? REASON_EMOJI[restartReason] : '✅'
   const ack = `${ackEmoji} <b>${escapeHtml(agentName)}</b> back up · ${escapeHtml(version)}`
 
@@ -309,7 +318,7 @@ export function renderBootCard(opts: RenderBootCardOpts): string {
     degradedRows.push(`⚠️ <b>Restart</b>  ${escapeHtml(REASON_LABEL.crash)}${ageStr}`)
     // Principle 1: every failure carries its next step. The crash row
     // tells the user how to inspect why.
-    degradedRows.push(`    ↳ Tail logs: <code>journalctl --user -u switchroom-${escapeHtml(agentName)} -n 100</code>`)
+    degradedRows.push(`    ↳ Tail logs: <code>journalctl --user -u switchroom-${escapeHtml(agentSlug)} -n 100</code>`)
   }
 
   // Probe rows — only those that surfaced as degraded/fail. Healthy
@@ -482,6 +491,7 @@ export async function startBootCard(
   // confirmation that the agent is back without waiting on probes.
   const ackText = renderBootCard({
     agentName: opts.agentName,
+    agentSlug: opts.agentSlug,
     version: opts.version,
     restartReason: opts.restartReason,
     restartAgeMs: opts.restartAgeMs,
@@ -538,6 +548,7 @@ export async function startBootCard(
         // Render with current probe state and edit if anything changed.
         let currentText = renderBootCard({
           agentName: opts.agentName,
+          agentSlug: opts.agentSlug,
           version: opts.version,
           probes,
           restartReason: opts.restartReason,
@@ -584,6 +595,7 @@ export async function startBootCard(
           const updatedProbes: ProbeMap = { ...probes, agent: agentResult }
           const updatedText = renderBootCard({
             agentName: opts.agentName,
+            agentSlug: opts.agentSlug,
             version: opts.version,
             probes: updatedProbes,
             restartReason: opts.restartReason,

--- a/telegram-plugin/gateway/boot-card.ts
+++ b/telegram-plugin/gateway/boot-card.ts
@@ -454,7 +454,7 @@ export async function runAllProbes(opts: RunProbesOpts): Promise<ProbeMap> {
   const slug = opts.agentSlug ?? opts.agentName
 
   await Promise.allSettled([
-    probeAccount(opts.agentDir).then(r => { probes.account = r }),
+    probeAccount(opts.agentDir, { agentName: opts.agentSlug ?? opts.agentName }).then(r => { probes.account = r }),
     probeAgentProcess(slug, { execFileImpl: opts.probeExecFileImpl, tmuxSupervisor: opts.tmuxSupervisor, dockerMode: opts.dockerMode }).then(r => { probes.agent = r }),
     probeGateway(opts.gatewayInfo).then(r => { probes.gateway = r }),
     probeQuota(claudeDir, opts.agentDir, opts.fetchImpl).then(r => { probes.quota = r }),

--- a/telegram-plugin/gateway/boot-probes.ts
+++ b/telegram-plugin/gateway/boot-probes.ts
@@ -28,6 +28,13 @@ export interface ProbeResult {
   status: ProbeStatus
   label: string
   detail: string
+  /** Plain-text remediation hint shown beneath the degraded row in the
+   *  boot card. Per `reference/principles.md` principle 1, every failure
+   *  should tell the user what to do next — naming the failure without a
+   *  next step is the explicit ❌ Bad pattern. Omitted on ok rows (they
+   *  don't render) and on degraded rows where no actionable hint exists.
+   */
+  nextStep?: string
   /** True when a 429 caused the probe to skip the live check. Used by
    *  writeQuotaCache to select the short RATE_LIMIT_TTL_MS instead of the
    *  default 5-min TTL. Keying off this boolean avoids matching on the
@@ -125,7 +132,12 @@ export async function probeAccount(agentDir: string): Promise<ProbeResult> {
 
     const acc = cfg.oauthAccount
     if (!acc?.emailAddress) {
-      return { status: 'degraded', label: 'Account', detail: 'not signed in' }
+      return {
+        status: 'degraded',
+        label: 'Account',
+        detail: 'not signed in',
+        nextStep: 'Run `switchroom auth login <agent>` to start the OAuth flow',
+      }
     }
 
     const plan = mapPlan(acc.billingType, acc.hasExtraUsageEnabled)
@@ -154,10 +166,16 @@ export async function probeAccount(agentDir: string): Promise<ProbeResult> {
       }
     }
 
+    const nextStep = status === 'fail'
+      ? 'OAuth token expired. Run `switchroom auth login <agent>` to re-authenticate.'
+      : status === 'degraded'
+        ? 'Token expiring soon. Run `switchroom auth login <agent>` before it lapses.'
+        : undefined
     return {
       status,
       label: 'Account',
       detail: `${acc.emailAddress} · ${plan}${tokenStr}`,
+      ...(nextStep ? { nextStep } : {}),
     }
   })())
 }
@@ -1236,7 +1254,7 @@ export async function probeKernel(
  */
 export async function probeSkills(
   agentDir: string,
-  opts: { fs?: SkillsFsImpl; maxNamesShown?: number } = {},
+  opts: { fs?: SkillsFsImpl; maxNamesShown?: number; agentName?: string } = {},
 ): Promise<ProbeResult> {
   return withTimeout('Skills', (async (): Promise<ProbeResult> => {
     const fs = opts.fs ?? realSkillsFs
@@ -1282,10 +1300,12 @@ export async function probeSkills(
     }
     const named = dangling.slice(0, max).join(', ')
     const more = dangling.length > max ? ` +${dangling.length - max} more` : ''
+    const reconcileTarget = opts.agentName ? ` ${opts.agentName}` : ''
     return {
       status: 'degraded',
       label: 'Skills',
       detail: `${dangling.length}/${entries.length} dangling: ${named}${more}`,
+      nextStep: `Run \`switchroom agent reconcile${reconcileTarget}\` to rebuild symlinks, or remove unused entries from switchroom.yaml`,
     }
   })())
 }

--- a/telegram-plugin/gateway/boot-probes.ts
+++ b/telegram-plugin/gateway/boot-probes.ts
@@ -167,9 +167,9 @@ export async function probeAccount(agentDir: string): Promise<ProbeResult> {
     }
 
     const nextStep = status === 'fail'
-      ? 'OAuth token expired. Run `switchroom auth login <agent>` to re-authenticate.'
+      ? 'OAuth token expired — run `switchroom auth login <agent>` to re-authenticate'
       : status === 'degraded'
-        ? 'Token expiring soon. Run `switchroom auth login <agent>` before it lapses.'
+        ? 'Token expiring soon — run `switchroom auth login <agent>` before it lapses'
         : undefined
     return {
       status,

--- a/telegram-plugin/gateway/boot-probes.ts
+++ b/telegram-plugin/gateway/boot-probes.ts
@@ -118,10 +118,18 @@ const TOKEN_EXPIRING_SOON_DAYS = 7
  * Read account info from the agent's .claude.json.
  * agentDir: e.g. /home/user/.switchroom/agents/clerk
  */
-export async function probeAccount(agentDir: string): Promise<ProbeResult> {
+export async function probeAccount(
+  agentDir: string,
+  opts: { agentName?: string } = {},
+): Promise<ProbeResult> {
   return withTimeout('Account', (async (): Promise<ProbeResult> => {
     const claudeDir = join(agentDir, '.claude')
     const claudeJsonPath = join(claudeDir, '.claude.json')
+    // Fall back to the literal placeholder only when no agentName is plumbed
+    // through — the renderer's <code> escape will keep that safe in Telegram
+    // HTML, but real call sites should always pass the name so users can
+    // tap-to-copy a working command.
+    const agentRef = opts.agentName ?? '<agent>'
     let cfg: ClaudeJson = {}
     try {
       const raw = readFileSync(claudeJsonPath, 'utf8')
@@ -136,7 +144,7 @@ export async function probeAccount(agentDir: string): Promise<ProbeResult> {
         status: 'degraded',
         label: 'Account',
         detail: 'not signed in',
-        nextStep: 'Run `switchroom auth login <agent>` to start the OAuth flow',
+        nextStep: `Run \`switchroom auth login ${agentRef}\` to start the OAuth flow`,
       }
     }
 
@@ -167,9 +175,9 @@ export async function probeAccount(agentDir: string): Promise<ProbeResult> {
     }
 
     const nextStep = status === 'fail'
-      ? 'OAuth token expired — run `switchroom auth login <agent>` to re-authenticate'
+      ? `OAuth token expired — run \`switchroom auth login ${agentRef}\` to re-authenticate`
       : status === 'degraded'
-        ? 'Token expiring soon — run `switchroom auth login <agent>` before it lapses'
+        ? `Token expiring soon — run \`switchroom auth login ${agentRef}\` before it lapses`
         : undefined
     return {
       status,

--- a/telegram-plugin/tests/boot-card-render.test.ts
+++ b/telegram-plugin/tests/boot-card-render.test.ts
@@ -135,6 +135,50 @@ describe('renderBootCard — degraded conditions', () => {
     expect(out).toContain('🟡 <b>Account</b>  expiring')
   })
 
+  it('renders nextStep as an indented continuation line beneath a degraded row', () => {
+    // Principle 1 ("If they need the docs, we've failed"): every degraded
+    // probe should surface its remediation inline. Plain backticks in the
+    // nextStep get translated to <code> spans so the command stays tap-to-
+    // copy on mobile.
+    const out = renderBootCard({
+      agentName: 'lawgpt',
+      version: 'v0.7.16',
+      probes: {
+        skills: {
+          status: 'degraded',
+          label: 'Skills',
+          detail: '10/10 dangling: a, b, c +7 more',
+          nextStep: 'Run `switchroom agent reconcile lawgpt` to rebuild symlinks',
+        },
+      },
+    })
+    expect(out).toContain('🟡 <b>Skills</b>  10/10 dangling')
+    expect(out).toContain('    ↳ Run <code>switchroom agent reconcile lawgpt</code> to rebuild symlinks')
+  })
+
+  it('crash row carries a tail-logs next-step', () => {
+    const out = renderBootCard({
+      agentName: 'lawgpt',
+      version: 'v0.7.16',
+      restartReason: 'crash',
+      restartAgeMs: 6_100,
+    })
+    expect(out).toContain('⚠️ <b>Restart</b>  crash recovery · 6.1s ago')
+    expect(out).toContain('↳ Tail logs: <code>journalctl --user -u switchroom-lawgpt -n 100</code>')
+  })
+
+  it('degraded rows without nextStep render unchanged (backwards compat)', () => {
+    const out = renderBootCard({
+      agentName: 'a',
+      version: 'v',
+      probes: {
+        quota: { status: 'fail', label: 'Quota', detail: 'rate limited' },
+      },
+    })
+    expect(out).toContain('🔴 <b>Quota</b>  rate limited')
+    expect(out).not.toContain('↳')
+  })
+
   it('null probe entries are skipped (defensive against partial probe maps)', () => {
     const out = renderBootCard({
       agentName: 'a',

--- a/telegram-plugin/tests/boot-card-render.test.ts
+++ b/telegram-plugin/tests/boot-card-render.test.ts
@@ -167,6 +167,51 @@ describe('renderBootCard — degraded conditions', () => {
     expect(out).toContain('↳ Tail logs: <code>journalctl --user -u switchroom-lawgpt -n 100</code>')
   })
 
+  it('crash row uses agentSlug for the systemd unit when provided', () => {
+    const out = renderBootCard({
+      agentName: 'LawGPT',
+      agentSlug: 'lawgpt',
+      version: 'v1',
+      restartReason: 'crash',
+    })
+    expect(out).toContain('switchroom-lawgpt')
+    expect(out).not.toContain('switchroom-LawGPT')
+  })
+
+  it('renderNextStep escapes HTML inside backtick-quoted commands', () => {
+    const out = renderBootCard({
+      agentName: 'a',
+      version: 'v',
+      probes: {
+        account: {
+          status: 'fail',
+          label: 'Account',
+          detail: 'expired',
+          nextStep: 'Run `foo <bar> "baz"` to fix',
+        },
+      },
+    })
+    expect(out).toContain('<code>foo &lt;bar&gt; &quot;baz&quot;</code>')
+    expect(out).not.toContain('<bar>')
+  })
+
+  it('unpaired backticks in nextStep fall back to plain escaped text', () => {
+    const out = renderBootCard({
+      agentName: 'a',
+      version: 'v',
+      probes: {
+        account: {
+          status: 'fail',
+          label: 'Account',
+          detail: 'expired',
+          nextStep: 'Run `switchroom foo to fix',
+        },
+      },
+    })
+    expect(out).toContain('↳ Run `switchroom foo to fix')
+    expect(out).not.toContain('<code>')
+  })
+
   it('degraded rows without nextStep render unchanged (backwards compat)', () => {
     const out = renderBootCard({
       agentName: 'a',

--- a/telegram-plugin/tests/boot-card-render.test.ts
+++ b/telegram-plugin/tests/boot-card-render.test.ts
@@ -187,11 +187,11 @@ describe('renderBootCard — degraded conditions', () => {
           status: 'fail',
           label: 'Account',
           detail: 'expired',
-          nextStep: 'Run `foo <bar> "baz"` to fix',
+          nextStep: 'Run `foo <bar> & baz` to fix',
         },
       },
     })
-    expect(out).toContain('<code>foo &lt;bar&gt; &quot;baz&quot;</code>')
+    expect(out).toContain('<code>foo &lt;bar&gt; &amp; baz</code>')
     expect(out).not.toContain('<bar>')
   })
 

--- a/telegram-plugin/tests/boot-probes.test.ts
+++ b/telegram-plugin/tests/boot-probes.test.ts
@@ -7,11 +7,12 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'bun:test'
-import { mkdtempSync, rmSync } from 'fs'
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from 'fs'
 import { tmpdir } from 'os'
 import { join } from 'path'
 
 import {
+  probeAccount,
   probeAgentProcess,
   probeScheduler,
   probeBroker,
@@ -852,6 +853,67 @@ describe('probeSkills', () => {
     const result = await probeSkills(agentDir, { fs: wrappedFs })
     expect(result.status).toBe('ok')
     expect(result.detail).toBe('0 skills')
+  })
+})
+
+// ── probeAccount nextStep interpolation (PR #1081 reviewer follow-up) ─────
+
+describe('probeAccount — nextStep agent-name interpolation', () => {
+  let tmpDir: string
+
+  function setupAgentDir(claudeJson: Record<string, unknown>, tokenMeta?: { expiresAt: number }): string {
+    const agentDir = mkdtempSync(join(tmpdir(), 'probe-account-'))
+    const claudeDir = join(agentDir, '.claude')
+    mkdirSync(claudeDir, { recursive: true })
+    writeFileSync(join(claudeDir, '.claude.json'), JSON.stringify(claudeJson))
+    if (tokenMeta) {
+      writeFileSync(join(claudeDir, '.oauth-token.meta.json'), JSON.stringify(tokenMeta))
+    }
+    return agentDir
+  }
+
+  afterEach(() => {
+    if (tmpDir) {
+      try { rmSync(tmpDir, { recursive: true, force: true }) } catch {}
+    }
+  })
+
+  it('not-signed-in hint interpolates agentName instead of <agent>', async () => {
+    tmpDir = setupAgentDir({})
+    const result = await probeAccount(tmpDir, { agentName: 'finn' })
+    expect(result.status).toBe('degraded')
+    expect(result.detail).toBe('not signed in')
+    expect(result.nextStep).toBeDefined()
+    expect(result.nextStep).toContain('switchroom auth login finn')
+    expect(result.nextStep).not.toContain('<agent>')
+  })
+
+  it('expired-token hint interpolates agentName', async () => {
+    tmpDir = setupAgentDir(
+      { oauthAccount: { emailAddress: 'me@example.com', billingType: 'max' } },
+      { expiresAt: Date.now() - 86_400_000 }, // expired yesterday
+    )
+    const result = await probeAccount(tmpDir, { agentName: 'klanker' })
+    expect(result.status).toBe('fail')
+    expect(result.nextStep).toContain('switchroom auth login klanker')
+    expect(result.nextStep).not.toContain('<agent>')
+  })
+
+  it('expiring-soon hint interpolates agentName', async () => {
+    tmpDir = setupAgentDir(
+      { oauthAccount: { emailAddress: 'me@example.com', billingType: 'max' } },
+      { expiresAt: Date.now() + 3 * 86_400_000 }, // 3 days left (< 7)
+    )
+    const result = await probeAccount(tmpDir, { agentName: 'lawgpt' })
+    expect(result.status).toBe('degraded')
+    expect(result.nextStep).toContain('switchroom auth login lawgpt')
+    expect(result.nextStep).not.toContain('<agent>')
+  })
+
+  it('falls back to <agent> placeholder when no agentName provided (backwards-compat)', async () => {
+    tmpDir = setupAgentDir({})
+    const result = await probeAccount(tmpDir)
+    expect(result.nextStep).toContain('<agent>')
   })
 })
 


### PR DESCRIPTION
## Summary

- Adds optional `nextStep?: string` to `ProbeResult`; renderer emits it as an indented continuation line beneath each degraded row with backtick-quoted commands translated to `<code>` for tap-to-copy
- Populates `nextStep` on `probeSkills` (dangling) and `probeAccount` (not signed in / token expiring / expired); `probeSkills` now takes an optional `agentName` so the hint names the reconcile target
- Crash-restart row in `renderBootCard` gains a "tail logs" next-step pointing at the agent's systemd journal

## Why

Per `reference/principles.md` principle 1 ("If they need the docs, we've failed"), every failure surface should tell the user what to run next. The previous boot card named the failure (e.g. \"Skills 10/10 dangling: foo, bar, baz +7 more\") with **no remediation** — the explicit ❌ Bad pattern called out in the principle doc itself:

> ✅ Good: progress card shows *\"⚠ skill `weekly-review` failed: missing `hindsight` MCP. Run `switchroom agent reconcile coach` to repair.\"*
> ❌ Bad: progress card shows `❌ Error` with no next step and a pointer to \"check the agent logs.\"

The JTBD in `reference/restart-and-know-what-im-running.md` explicitly requires the clean-boot ack stays (*\"If nothing changed, the user still gets a light acknowledgement\"*) — silent respawn is a named anti-pattern — so this PR keeps that and only adds remediation to the degraded rows.

## Compatibility

Additive: `nextStep` is optional. Rows without it render unchanged. No behavior change for clean boots.

## Test plan

- [x] New tests in `boot-card-render.test.ts`:
  - dangling-skills row + nextStep renders with `<code>` for the command
  - crash row carries the tail-logs hint
  - degraded row without nextStep renders unchanged (backwards compat)
- [ ] Verify on a real boot of a misconfigured agent (e.g. lawgpt with dangling skills) that the row now reads:
  ```
  🟡 Skills  10/10 dangling: switchroom-status, switchroom-health, skill-creator +7 more
      ↳ Run `switchroom agent reconcile lawgpt` to rebuild symlinks, or remove unused entries from switchroom.yaml
  ```

## Follow-up

Cross-boot dedup of degraded rows (don't re-fire the same `(agent, probe, detail-fingerprint)` every restart until state changes) is a separate concern — will file as its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)