### PR TITLE
docs(profiles): describe handoff session-continuity, replace --continue references (#1078)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -31,7 +31,6 @@ The container's entrypoint is the agent's `start.sh`, run as PID 1's child under
 
 ```bash
 exec claude \
-  --continue \
   --dangerously-load-development-channels server:switchroom-telegram \
   --plugin-dir ~/.switchroom/agents/<agent>/plugins \
   --model claude-opus-4-7 \
@@ -40,17 +39,29 @@ exec claude \
 
 Key flags:
 
-- `--continue` — passed conditionally. Under `session_continuity.resume_mode: auto` (default), it's set only when the transcript exists, is under the configured size cap (default 2 MB), and is under 7 days old — so long-running agents pick up where they left off, but stale or oversized transcripts start fresh. Under `resume_mode: continue` it's always set; under `handoff` or `none` it's never set (the agent starts cold, optionally with a handoff briefing). See `profiles/_base/start.sh.hbs` for the exact logic.
+- `--continue` — **omitted by default.** As of switchroom #362, `session_continuity.resume_mode` defaults to `handoff`: every restart starts a fresh `claude` session and the prior session's context is reconstituted via a handoff briefing injected into `--append-system-prompt` (see "Session continuity model" below). Under `resume_mode: continue` `--continue` is always passed; under `auto` it's passed only when the latest JSONL transcript exists, is under the configured size cap (default 2 MB), and is under 7 days old; under `none` it's never passed and no handoff briefing is assembled. See `profiles/_base/start.sh.hbs` for the exact logic.
 - `--dangerously-load-development-channels server:switchroom-telegram` — loads the switchroom Telegram MCP as a development channel.
 - `--plugin-dir` — points at the agent's local plugin directory.
-- `--append-system-prompt` — injects the stable workspace bootstrap block (SOUL.md, AGENTS.md, TOOLS.md, etc.) at session start.
+- `--append-system-prompt` — injects the stable workspace bootstrap block (SOUL.md, AGENTS.md, TOOLS.md, etc.) plus, in `handoff` / `auto` mode, the assembled handoff briefing.
 
 Environment variables set before exec:
 
 - `CLAUDE_CONFIG_DIR` — pinned to `/agent/.claude/` (the agent's per-container config dir, host-mounted from `~/.switchroom/agents/<agent>/.claude/`). Fully isolates each agent's auth, settings, transcripts, and MCP config from every other agent and from the user's personal Claude setup.
 - `CLAUDE_CODE_OAUTH_TOKEN` — populated from the active slot or shared Anthropic account.
 
-This is an **interactive REPL**, not `claude -p`. The session is persistent and long-lived, conditionally resumed across container restarts via `--continue`.
+This is an **interactive REPL**, not `claude -p`. The session is persistent and long-lived; continuity across container restarts is provided by the switchroom layer (handoff briefing + Hindsight recall + Telegram history buffer), not by `--continue` (which is off by default).
+
+### Session continuity model
+
+Default mode is `handoff`. On a clean shutdown, the Stop hook runs `switchroom handoff <agent>` which summarizes the most recent session JSONL into `<agentDir>/.handoff.md`. On next boot, start.sh reads that file, plus a live briefing assembled by `handoff-briefing.sh` from recent Telegram messages / Hindsight recall / today's daily memory file (`<agentDir>/.handoff-briefing.md`), and merges both into `--append-system-prompt`. The fresh `claude` session wakes up already knowing what was going on without the cost or fragility of replaying a multi-MB transcript.
+
+Other state survives a restart through dedicated channels:
+
+- **`SWITCHROOM_PENDING_TURN`** — if the previous session was killed mid-turn (watchdog / SIGTERM / timeout), the gateway writes `<agentDir>/.pending-turn.env` and start.sh sources it into the new process. The agent reads it from CLAUDE.md and decides whether to acknowledge the interruption or silently continue.
+- **`.wake-audit-pending`** sentinel under `TELEGRAM_STATE_DIR` — dropped on every boot. The agent's first turn runs a three-signal check (owed reply / orphan sub-agents / open todos), surfaces findings, then `rm -f`s the sentinel.
+- **`SWITCHROOM_SESSION_MODE`** env (`continue` / `handoff` / `fresh` / `cold`) — exported for the SessionStart hook so the session-greeting card can render the correct "Session" row.
+
+The `/reset` and `/new` Telegram commands write a `.force-fresh-session` marker that start.sh consumes once to force a cold boot regardless of `resume_mode`.
 
 ### The gateway
 
@@ -93,14 +104,14 @@ The MCP child never makes direct HTTP calls to Telegram — all Telegram API cal
 ## Why two processes inside the container
 
 - **Survival across Claude restarts.** The gateway must stay alive when Claude exits (OOM, crash, scheduled compaction restart). If polling lived inside claude, every restart would drop the Telegram connection and lose in-flight messages.
-- **Message buffering.** The gateway's SQLite buffer holds inbound messages while claude is down. When claude restarts via `--continue`, the MCP child drains the buffer.
+- **Message buffering.** The gateway's SQLite buffer holds inbound messages while claude is down. When claude restarts (whether the new session is fresh-with-handoff or a `--continue` resume), the MCP child drains the buffer.
 - **Separation of concerns.** The gateway handles all Telegram I/O. Claude handles all inference. Neither needs to know the internals of the other.
 
 ---
 
 ## Where `claude -p` is (and isn't) used
 
-The main agent loop does **not** use `claude -p`. Agents run interactive (`--continue`).
+The main agent loop does **not** use `claude -p`. Agents run interactive — by default a fresh session per restart with handoff continuity (`--continue` is gated by `session_continuity.resume_mode`, which defaults to `handoff`).
 
 `claude -p` is used in exactly one place, short-lived and headless:
 

--- a/docs/session-optimization.md
+++ b/docs/session-optimization.md
@@ -16,24 +16,31 @@ Every turn includes fixed-cost components:
 
 Switchroom agents have three mechanisms that survive restarts and compaction:
 
-1. **Claude Code session** — `--continue` resumes the full conversation. Configurable freshness via `session.max_idle` and `session.max_turns` in switchroom.yaml.
+1. **Handoff briefing** — the default since switchroom #362. Every restart starts a **fresh** `claude` session; a compact summary of the prior session (written to `<agentDir>/.handoff.md` by the Stop hook) plus a live briefing assembled from recent Telegram messages, Hindsight recall, and today's daily memory file (`<agentDir>/.handoff-briefing.md`) is merged into `--append-system-prompt` so the new session wakes up oriented. The full transcript is *not* replayed.
 
-2. **Hindsight memory** — auto-retain fires every 10 turns, saving the full transcript to a semantic bank. Auto-recall fires every turn, bringing back relevant memories. Important facts survive compaction because they're stored externally.
+   To opt into transcript-replay continuity instead, set `session_continuity.resume_mode` per agent in switchroom.yaml:
 
-3. **Telegram history** — SQLite buffer of every inbound/outbound message. `get_recent_messages` lets the agent recover chat context after a restart.
+   - `handoff` — default. Fresh session every restart, briefing injected.
+   - `auto` — pass `--continue` only when the JSONL transcript exists, is under the size cap (`session_continuity.resume_max_bytes`, default 2 MB), and is fresher than `session.max_idle` (default 7 days).
+   - `continue` — always pass `--continue`. Flaky on large transcripts; only use if you know your sessions stay small.
+   - `none` — fresh every time, no briefing.
+
+2. **Hindsight memory** — auto-retain fires every 10 turns, saving the full transcript to a semantic bank. Auto-recall fires every turn, bringing back relevant memories. Important facts survive compaction and restart because they're stored externally.
+
+3. **Telegram history** — SQLite buffer of every inbound/outbound message. `get_recent_messages` lets the agent recover recent chat context after a restart, regardless of resume mode.
 
 ## Session Freshness Policy
 
-Configure automatic fresh-session boundaries in switchroom.yaml:
+`session.max_idle` and `session.max_turns` are the freshness knobs in switchroom.yaml:
 
 ```yaml
 defaults:
   session:
-    max_idle: 2h      # fresh session after 2h of inactivity
-    max_turns: 50     # fresh session after 50 user turns
+    max_idle: 2h      # under resume_mode: auto, force fresh after 2h of inactivity
+    max_turns: 50     # rotate to a fresh session after 50 user turns
 ```
 
-At startup, the agent checks the previous session's last-modified time and turn count. If either threshold is exceeded, it starts a fresh session instead of resuming. Hindsight auto-recall brings back relevant context automatically.
+In `auto` mode the boot check inspects the previous session's last-modified time and turn count and decides whether to pass `--continue`. In `handoff` mode (the default) every restart is fresh by construction; `session.max_idle` does not gate `--continue` because `--continue` is never passed. Hindsight auto-recall brings back relevant context regardless of mode.
 
 ## Sub-Agent Cost Optimization
 

--- a/profiles/default/CLAUDE.md.hbs
+++ b/profiles/default/CLAUDE.md.hbs
@@ -91,12 +91,17 @@ If no sub-agents are configured, do the work yourself.
 
 ## Session Continuity
 
-Your session resumes across restarts via `--continue`. After a restart:
-- Hindsight auto-recall brings back relevant memories from past sessions.
-- Use `get_recent_messages` to recover recent chat context if needed.
-- A config summary greeting is sent automatically — you don't need to announce yourself.
+By default, every restart starts a **fresh `claude` session** — the in-flight transcript is NOT carried over (`session_continuity.resume_mode: handoff`, the default since switchroom #362). Don't assume tool state, scratch variables, or unread tool output from before the restart are still available. What does survive:
 
-If you notice your context feels thin (after compaction or a fresh session), proactively recall from Hindsight before proceeding.
+- **Handoff briefing** — on a clean shutdown, the Stop hook writes a compact summary of the prior session to `.handoff.md`. On boot, start.sh injects it into your `--append-system-prompt` so you wake up already knowing what was going on. If the prior session crashed before the Stop hook fired, a live briefing is assembled from recent Telegram messages, Hindsight recall, and today's daily memory file (`.handoff-briefing.md`).
+- **Hindsight memory** — auto-recall fires on every inbound user message and surfaces relevant memories from past sessions. Long-term facts, decisions, and mental models live here, not in the transcript.
+- **Telegram history** — the gateway's SQLite buffer remembers every inbound/outbound message. Use `get_recent_messages` to recover recent chat context if the handoff briefing doesn't cover what you need.
+- **`SWITCHROOM_PENDING_TURN`** — if your previous session was killed mid-turn (watchdog, SIGTERM, timeout), start.sh exports this env var plus the chat/thread/last-user-message context. Acknowledge the interruption and ask for direction rather than silently resuming.
+- **`.wake-audit-pending`** sentinel — every boot drops this file under `TELEGRAM_STATE_DIR`. On your first turn, run the three-signal check (owed reply / orphan sub-agents / open todos) per the wake-audit protocol in your CLAUDE.md, then `rm -f` the sentinel.
+
+A config-summary greeting card is sent automatically by the SessionStart hook — you don't need to announce yourself. If your context feels thin (after compaction or any fresh session), proactively recall from Hindsight before proceeding.
+
+(Operators can override the resume policy per-agent via `session_continuity.resume_mode` in switchroom.yaml — `auto`, `continue`, `handoff`, or `none`. The default is `handoff`.)
 
 ## Tools
 {{#if tools}}


### PR DESCRIPTION
Closes #1078.

## Summary

Default `session_continuity.resume_mode` has been `handoff` since switchroom #362, but several doc surfaces still describe `--continue` as the session-resume mechanism. The most load-bearing offender is `profiles/default/CLAUDE.md.hbs:94` — the agent reads its own profile and is told a falsehood about how its session resumes.

## RCA — actual handoff model

What happens on restart (default `resume_mode: handoff`):

1. **Stop hook** writes `<agentDir>/.handoff.md` — LLM-summarized compact recap of the prior session JSONL. Invoked via `switchroom handoff <agent>` (`src/cli/handoff.ts` → `src/agents/handoff-summarizer.ts`). Best-effort; bounded 30s timeout; exits 0 on any failure so shutdown isn't blocked.
2. **start.sh** boots a **fresh `claude` session** (no `--continue`). Before exec:
   - Computes `SWITCHROOM_SESSION_MODE` (`continue` / `handoff` / `fresh` / `cold`) for the SessionStart hook to render the right "Session" row in the greeting card.
   - Sources `<agentDir>/.pending-turn.env` (written by the gateway when the previous turn was killed mid-flight) into env vars — `SWITCHROOM_PENDING_TURN=true`, chat/thread/last-user-msg ids, ended_via, started_at. Consumed-once via `rm -f`.
   - Drops `.wake-audit-pending` under `TELEGRAM_STATE_DIR` for the agent's first-turn three-signal check (owed reply / orphan sub-agents / open todos).
   - If `.handoff.md` is missing/empty, runs `switchroom handoff` as a synchronous 2s-capped fallback. In `handoff` mode it also runs `handoff-briefing.sh` to assemble a live briefing from recent Telegram messages / Hindsight recall / today's daily memory file into `.handoff-briefing.md`.
   - Merges both files into `APPEND_PROMPT` (briefing first, .handoff.md second; sub-prompt-cache-friendly ordering per the layering comment in start.sh).
   - Execs `claude --append-system-prompt "$APPEND_PROMPT" ...` (no `--continue`).
3. **Fresh claude session** wakes up with the briefing already in its system prompt and Hindsight auto-recall firing on every UserPromptSubmit. The Telegram gateway's SQLite buffer holds anything that came in while claude was down; `get_recent_messages` exposes it.

Other resume_mode values still work (`auto` / `continue` / `none`) — they're set per-agent in switchroom.yaml under `session_continuity.resume_mode`. Source of truth: `profiles/_base/start.sh.hbs:240-291`, default pinned in `src/agents/scaffold.ts:1547` and `:3033`.

`/reset` and `/new` write `<agentDir>/.force-fresh-session`; start.sh consumes it to force a cold boot regardless of resume_mode.

## Files changed

- **`profiles/default/CLAUDE.md.hbs`** — replaces the one-line `--continue` claim at line 94 with an accurate Session Continuity section: what survives (handoff briefing, Hindsight, Telegram history, SWITCHROOM_PENDING_TURN, wake-audit sentinel), what doesn't (tool state, scratch variables, unread tool output), and a pointer to switchroom.yaml for operators who want to override.
- **`docs/architecture.md`** — fixes the "`--continue` default: auto" claim at line 43 to "omitted by default; `resume_mode` defaults to `handoff`"; removes `--continue` from the inline `exec claude` example at lines 32-39 (matches actual default rendering); adds a "Session continuity model" subsection covering the full handoff lifecycle; refines the line 53 "interactive REPL" framing and line 103 "main agent loop" statement.
- **`docs/session-optimization.md`** — rewrites "Three Layers of Continuity" with handoff briefing as the default layer 1; documents all four resume_mode values; clarifies that `session.max_idle` only gates `--continue` in `auto` mode.

## Audit results (every occurrence considered)

Searched `git grep -i -- '--continue' '\bsession resumes\b' '\bresume.*session\b'` across `profiles/`, `docs/`, `reference/`, `README.md`, `CLAUDE.md`.

**Rewritten (3 files):**
- `profiles/default/CLAUDE.md.hbs:94`
- `docs/architecture.md:34, 43, 53, 96, 103`
- `docs/session-optimization.md:19, 25-36`

**Intentionally left alone:**
- `docs/vs-nanoclaw.md:33` — "Same `--continue` session semantics" lists upstream claude-CLI features Switchroom inherits. Correct: the flag exists and switchroom honors it under `resume_mode: continue` / `auto`.
- `docs/vs-openclaw.md:44` — same reasoning.
- `profiles/_base/start.sh.hbs:231-380` — this is the implementation. Comments accurately document each resume_mode branch with `handoff` flagged as default (line 244). Not stale.
- `profiles/_shared/telegram-style.md.hbs:80, 119` — references `--continue` respawns in the wake-audit-dedup context, which is accurate for `auto`/`continue` modes and harmless under `handoff`.
- `reference/idempotent-update-and-restart.md:99-103` — JTBD already advocates the new model ("Resume should be a feature of the switchroom layer ... not a side effect of `claude --continue` happening to succeed"). No update needed.
- `reference/give-each-agent-its-own-workspace.md:106, 127` — "session resumes" refers to filesystem worktree state, not the `--continue` flag.
- `reference/rfc-docker-multi-container.md:143, 149, 578, 760` — historical RFC; rewriting accepted RFCs is out of scope. Worth a follow-up doc-pass eventually but not this PR.
- `README.md:69` — "Resume across restarts with freshness gating and a wake-audit" is generic and accurate post-handoff.

## Test plan

- [x] `node` + `handlebars` round-trips `profiles/default/CLAUDE.md.hbs` with the `telegram-style` partial registered; renders cleanly to 27k chars; Session Continuity section visually inspected.
- [ ] Reviewer: skim the rewritten paragraph for accuracy — particularly the `SWITCHROOM_PENDING_TURN` and `.wake-audit-pending` claims, which I sourced from `profiles/_base/start.sh.hbs:336-386` and `profiles/_shared/telegram-style.md.hbs`.
- [ ] No code changes; no build/test impact expected.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>