### PR TITLE
sec(repo): migration script + doctor probe for clerk-export (#1072)

### DIFF
--- a/scripts/migrate-clerk-export-to-vault.sh
+++ b/scripts/migrate-clerk-export-to-vault.sh
@@ -26,14 +26,38 @@
 #      clerk-export/config/secrets.json
 #      clerk-export/identity/USER.md
 #
-# The tarball (if present) is stored as a single binary blob under:
-#   clerk-export/_bundle.tar.gz
+# The tarball (if present) is stored as a base64-encoded blob under:
+#   clerk-export/_bundle.tar.gz.b64
+#
+# Why base64 for the tarball: `switchroom vault set --file` reads as
+# UTF-8 (src/cli/vault.ts:475), which replaces invalid byte sequences
+# with U+FFFD and silently corrupts binary input. Base64 sidesteps
+# this entirely. Tracked as a follow-up against the vault CLI; for
+# now the script handles binary itself. See PR #1084.
+#
+# Avoiding repeated passphrase prompts
+# ------------------------------------
+# Each `switchroom vault {set,get,remove}` opens the vault, which means
+# one prompt per file unless the operator either
+#
+#   (a) exports SWITCHROOM_VAULT_PASSPHRASE before running, OR
+#   (b) ensures the vault broker is unlocked (`switchroom vault broker
+#       status` exits 0 → unlocked, 1 → locked, 2 → not running).
+#
+# The script refuses to run if neither is true, surfacing the file
+# count up-front so the operator can decide whether to pre-unlock.
+#
+# Verification
+# ------------
+# Every write is round-tripped (read back, hashed, compared to source)
+# BEFORE the deletion prompt. Any single-file mismatch aborts with the
+# offending key and skips deletion entirely. `vault list` proves
+# presence; round-trip hashing proves byte fidelity.
 #
 # Prerequisites
 # -------------
 #   - switchroom CLI on PATH (`switchroom --version` works)
-#   - Vault unlocked (`switchroom vault list` returns without
-#     prompting, OR you're prepared to type the passphrase once)
+#   - Vault unlocked via env var OR broker (enforced; see above)
 #   - Run from the repo root (where ./clerk-export/ lives)
 #
 # Usage
@@ -43,8 +67,10 @@
 # Exit codes
 # ----------
 #   0  success — all files migrated + (optionally) deleted
-#   1  precondition failed (missing CLI, missing dir, vault locked)
-#   2  one or more `vault set` calls failed; nothing deleted
+#   1  precondition failed (missing CLI, missing dir, vault locked,
+#      sentinel write/read mismatch, etc.)
+#   2  one or more `vault set` or round-trip hash checks failed;
+#      nothing deleted
 #
 
 set -euo pipefail
@@ -54,6 +80,8 @@ set -euo pipefail
 EXPORT_DIR="${EXPORT_DIR:-./clerk-export}"
 TARBALL="${TARBALL:-./clerk-export-with-secrets.tar.gz}"
 KEY_PREFIX="${KEY_PREFIX:-clerk-export}"
+BUNDLE_KEY="${KEY_PREFIX}/_bundle.tar.gz.b64"
+PROBE_KEY="${KEY_PREFIX}/__migration_probe"
 
 if ! command -v switchroom >/dev/null 2>&1; then
   echo "error: switchroom CLI not found on PATH" >&2
@@ -61,23 +89,20 @@ if ! command -v switchroom >/dev/null 2>&1; then
   exit 1
 fi
 
+for tool in sha256sum base64; do
+  if ! command -v "$tool" >/dev/null 2>&1; then
+    echo "error: required tool '$tool' not found on PATH" >&2
+    exit 1
+  fi
+done
+
 if [ ! -d "$EXPORT_DIR" ] && [ ! -f "$TARBALL" ]; then
   echo "nothing to migrate: neither $EXPORT_DIR nor $TARBALL exists" >&2
   echo "(if you've already migrated, the doctor probe should now pass)" >&2
   exit 0
 fi
 
-# Probe vault — `vault list` is the cheapest way to confirm the vault
-# is reachable and unlocked. We discard output but capture the exit.
-echo "→ probing vault (this may prompt for passphrase)..."
-if ! switchroom vault list >/dev/null; then
-  echo "error: 'switchroom vault list' failed — vault locked or misconfigured" >&2
-  echo "       unlock with 'switchroom vault broker unlock' first" >&2
-  exit 1
-fi
-echo "  ✓ vault reachable"
-
-# ─── Enumerate files ────────────────────────────────────────────────
+# ─── Enumerate files (early — so the prompt-count message is accurate) ──
 
 declare -a FILES=()
 if [ -d "$EXPORT_DIR" ]; then
@@ -98,6 +123,65 @@ if [ "$TOTAL" -eq 0 ]; then
   exit 0
 fi
 
+# Each file triggers ≥3 vault opens (set + get for verify + final
+# remove of the probe doesn't count). Without unlock, that's ≥2×TOTAL
+# passphrase prompts — refuse with a clear remedy.
+PROMPT_BUDGET=$((TOTAL * 2 + 2))
+
+vault_unlocked=0
+if [ -n "${SWITCHROOM_VAULT_PASSPHRASE:-}" ]; then
+  vault_unlocked=1
+else
+  # `switchroom vault broker status` exits 0=unlocked, 1=locked,
+  # 2=not running. We only proceed on 0.
+  if switchroom vault broker status >/dev/null 2>&1; then
+    vault_unlocked=1
+  fi
+fi
+
+if [ "$vault_unlocked" -ne 1 ]; then
+  echo "error: vault is locked and SWITCHROOM_VAULT_PASSPHRASE is not set" >&2
+  echo "" >&2
+  echo "       This script performs ~${PROMPT_BUDGET} vault operations across" >&2
+  echo "       ${TOTAL} item(s) — you would be prompted for the passphrase" >&2
+  echo "       on every call. Refusing to run." >&2
+  echo "" >&2
+  echo "       Pick one before re-running:" >&2
+  echo "         (a) export SWITCHROOM_VAULT_PASSPHRASE='...'" >&2
+  echo "         (b) switchroom vault broker unlock" >&2
+  echo "" >&2
+  exit 1
+fi
+
+echo "→ vault accessible (broker unlocked or SWITCHROOM_VAULT_PASSPHRASE set)"
+
+# Sentinel probe — `vault list` succeeding doesn't prove the passphrase
+# is correct for subsequent writes (an empty/lock-skip vault would
+# happily list zero keys). Round-trip a known value through set→get→
+# remove so a wrong passphrase or broken broker fails BEFORE we touch
+# real data.
+echo "→ running sentinel probe at ${PROBE_KEY}..."
+SENTINEL_VALUE="migration-probe-$$-$(date +%s)"
+if ! printf '%s' "$SENTINEL_VALUE" | switchroom vault set "$PROBE_KEY" >/dev/null; then
+  echo "error: sentinel probe write failed — vault may be misconfigured" >&2
+  exit 1
+fi
+PROBE_READ="$(switchroom vault get "$PROBE_KEY" 2>/dev/null || true)"
+# `vault get` console.log()s the value with a trailing newline. Strip it.
+PROBE_READ="${PROBE_READ%$'\n'}"
+if [ "$PROBE_READ" != "$SENTINEL_VALUE" ]; then
+  echo "error: sentinel probe round-trip mismatch — refusing to migrate" >&2
+  echo "       expected: $SENTINEL_VALUE" >&2
+  echo "       got:      $PROBE_READ" >&2
+  # Best-effort cleanup of the probe key.
+  switchroom vault remove "$PROBE_KEY" >/dev/null 2>&1 || true
+  exit 1
+fi
+if ! switchroom vault remove "$PROBE_KEY" >/dev/null 2>&1; then
+  echo "warn: failed to remove sentinel probe ${PROBE_KEY} — please remove manually" >&2
+fi
+echo "  ✓ sentinel probe round-tripped cleanly"
+
 echo "→ found $TOTAL item(s) to migrate"
 echo "    $EXPORT_DIR/: ${#FILES[@]} file(s)"
 if [ "$TARBALL_PRESENT" -eq 1 ]; then
@@ -105,17 +189,40 @@ if [ "$TARBALL_PRESENT" -eq 1 ]; then
 fi
 echo
 
-# ─── Migrate ────────────────────────────────────────────────────────
+# ─── Migrate (text via --file, binary via base64) ───────────────────
 
 declare -a KEYS=()
+# Parallel array — for each KEYS[i], SOURCES[i] is the on-disk path and
+# MODES[i] is "text" or "base64". Used by the verify pass.
+declare -a SOURCES=()
+declare -a MODES=()
 FAILURES=0
 
-migrate_file() {
+migrate_text_file() {
   local path="$1"
   local key="$2"
-  echo "  → $key"
+  echo "  → $key  (text)"
   if switchroom vault set "$key" --file "$path"; then
     KEYS+=("$key")
+    SOURCES+=("$path")
+    MODES+=("text")
+  else
+    echo "    ✗ failed to set $key" >&2
+    FAILURES=$((FAILURES + 1))
+  fi
+}
+
+migrate_binary_file() {
+  local path="$1"
+  local key="$2"
+  echo "  → $key  (base64-encoded binary)"
+  # Pipe base64 of the file into `vault set` via stdin. The CLI's
+  # non-TTY branch (src/cli/vault.ts:481) slurps stdin verbatim, so
+  # this preserves the encoded value byte-for-byte.
+  if base64 -w0 < "$path" | switchroom vault set "$key" >/dev/null; then
+    KEYS+=("$key")
+    SOURCES+=("$path")
+    MODES+=("base64")
   else
     echo "    ✗ failed to set $key" >&2
     FAILURES=$((FAILURES + 1))
@@ -128,16 +235,14 @@ for f in "${FILES[@]}"; do
   # clerk-export/credentials/foo
   rel="${f#"$EXPORT_DIR"/}"
   key="$KEY_PREFIX/$rel"
-  migrate_file "$f" "$key"
+  migrate_text_file "$f" "$key"
 done
 
 if [ "$TARBALL_PRESENT" -eq 1 ]; then
-  migrate_file "$TARBALL" "$KEY_PREFIX/_bundle.tar.gz"
+  migrate_binary_file "$TARBALL" "$BUNDLE_KEY"
 fi
 
 echo
-
-# ─── Verify ─────────────────────────────────────────────────────────
 
 if [ "$FAILURES" -ne 0 ]; then
   echo "error: $FAILURES item(s) failed to migrate — nothing deleted" >&2
@@ -145,8 +250,9 @@ if [ "$FAILURES" -ne 0 ]; then
   exit 2
 fi
 
+# ─── Verify: presence + round-trip hash ─────────────────────────────
+
 echo "→ verifying all keys are present in the vault..."
-# `vault list` is line-per-key; grep -Fx for exact match per key.
 LIVE_KEYS="$(switchroom vault list)"
 MISSING=0
 for k in "${KEYS[@]}"; do
@@ -162,6 +268,41 @@ if [ "$MISSING" -ne 0 ]; then
 fi
 
 echo "  ✓ all ${#KEYS[@]} key(s) present"
+
+echo "→ round-trip hash check (vault get | sha256sum == source sha256sum)..."
+MISMATCH=0
+for i in "${!KEYS[@]}"; do
+  k="${KEYS[$i]}"
+  src="${SOURCES[$i]}"
+  mode="${MODES[$i]}"
+
+  src_hash="$(sha256sum < "$src" | awk '{print $1}')"
+
+  # `vault get` console.log()s the value + trailing newline; `head -c -1`
+  # strips that one byte so the comparison is against the bytes we wrote.
+  if [ "$mode" = "text" ]; then
+    got_hash="$(switchroom vault get "$k" 2>/dev/null | head -c -1 | sha256sum | awk '{print $1}')"
+  else
+    # base64 mode: strip trailing newline, base64-decode, then hash.
+    got_hash="$(switchroom vault get "$k" 2>/dev/null | head -c -1 | base64 -d | sha256sum | awk '{print $1}')"
+  fi
+
+  if [ "$src_hash" != "$got_hash" ]; then
+    echo "  ✗ hash mismatch for $k" >&2
+    echo "      source:   $src_hash  ($src)" >&2
+    echo "      vault:    $got_hash" >&2
+    MISMATCH=$((MISMATCH + 1))
+  fi
+done
+
+if [ "$MISMATCH" -ne 0 ]; then
+  echo "error: $MISMATCH key(s) failed round-trip verification — nothing deleted" >&2
+  echo "       the on-disk copies remain intact. Inspect the mismatches" >&2
+  echo "       (likely a binary-as-text corruption — see PR #1084)." >&2
+  exit 2
+fi
+
+echo "  ✓ all ${#KEYS[@]} key(s) verified byte-for-byte"
 echo
 
 # ─── Delete on-disk copies (prompted) ───────────────────────────────
@@ -180,6 +321,15 @@ case "$REPLY" in
     exit 0
     ;;
 esac
+
+# TOCTOU acknowledgement: between the verify pass above and the deletes
+# below, an attacker with local write access to $EXPORT_DIR or $TARBALL
+# could mutate the on-disk copies — we'd then delete tampered files
+# whose contents no longer match what's now in the vault. This is an
+# operator-local script run interactively from the repo root; the
+# practical risk is negligible. Re-verifying inside the deletion block
+# would only narrow, not close, the window. Calling it out so a future
+# reader doesn't mistake the gap for an oversight.
 
 # Prefer `trash` (recoverable) over `rm` (irrecoverable) when available.
 if command -v trash >/dev/null 2>&1; then

--- a/scripts/migrate-clerk-export-to-vault.sh
+++ b/scripts/migrate-clerk-export-to-vault.sh
@@ -1,0 +1,201 @@
+#!/usr/bin/env bash
+#
+# migrate-clerk-export-to-vault.sh — one-shot operator script for #1072.
+#
+# Moves the contents of ./clerk-export/ (and the sealed bundle
+# ./clerk-export-with-secrets.tar.gz, if present) into the switchroom
+# vault, then offers to delete the on-disk copies.
+#
+# Why this script exists
+# ----------------------
+# The OpenClaw export bundle carries real secrets and has been sitting
+# in the repo root since the initial migration. It's gitignored, so it
+# can never be committed — but it's still readable by any backup tool,
+# grep, file-share workflow, or "upload my repo" agent that scans the
+# tree. The fix is to migrate the contents into the vault (encrypted at
+# rest, gated by passphrase + broker ACL) and delete the on-disk copy.
+#
+# The PR that adds this script does NOT delete anything. The operator
+# (you) runs the script when ready, on the host that owns the vault.
+#
+# Vault key scheme
+# ----------------
+#   clerk-export/<relative-path-with-slashes-preserved>
+#
+# e.g. clerk-export/credentials/files/notion-token
+#      clerk-export/config/secrets.json
+#      clerk-export/identity/USER.md
+#
+# The tarball (if present) is stored as a single binary blob under:
+#   clerk-export/_bundle.tar.gz
+#
+# Prerequisites
+# -------------
+#   - switchroom CLI on PATH (`switchroom --version` works)
+#   - Vault unlocked (`switchroom vault list` returns without
+#     prompting, OR you're prepared to type the passphrase once)
+#   - Run from the repo root (where ./clerk-export/ lives)
+#
+# Usage
+# -----
+#   ./scripts/migrate-clerk-export-to-vault.sh
+#
+# Exit codes
+# ----------
+#   0  success — all files migrated + (optionally) deleted
+#   1  precondition failed (missing CLI, missing dir, vault locked)
+#   2  one or more `vault set` calls failed; nothing deleted
+#
+
+set -euo pipefail
+
+# ─── Preconditions ──────────────────────────────────────────────────
+
+EXPORT_DIR="${EXPORT_DIR:-./clerk-export}"
+TARBALL="${TARBALL:-./clerk-export-with-secrets.tar.gz}"
+KEY_PREFIX="${KEY_PREFIX:-clerk-export}"
+
+if ! command -v switchroom >/dev/null 2>&1; then
+  echo "error: switchroom CLI not found on PATH" >&2
+  echo "       install it or add ~/.bun/bin to PATH" >&2
+  exit 1
+fi
+
+if [ ! -d "$EXPORT_DIR" ] && [ ! -f "$TARBALL" ]; then
+  echo "nothing to migrate: neither $EXPORT_DIR nor $TARBALL exists" >&2
+  echo "(if you've already migrated, the doctor probe should now pass)" >&2
+  exit 0
+fi
+
+# Probe vault — `vault list` is the cheapest way to confirm the vault
+# is reachable and unlocked. We discard output but capture the exit.
+echo "→ probing vault (this may prompt for passphrase)..."
+if ! switchroom vault list >/dev/null; then
+  echo "error: 'switchroom vault list' failed — vault locked or misconfigured" >&2
+  echo "       unlock with 'switchroom vault broker unlock' first" >&2
+  exit 1
+fi
+echo "  ✓ vault reachable"
+
+# ─── Enumerate files ────────────────────────────────────────────────
+
+declare -a FILES=()
+if [ -d "$EXPORT_DIR" ]; then
+  # -print0 / read -d '' so paths with spaces or newlines survive.
+  while IFS= read -r -d '' f; do
+    FILES+=("$f")
+  done < <(find "$EXPORT_DIR" -type f -print0)
+fi
+
+TARBALL_PRESENT=0
+if [ -f "$TARBALL" ]; then
+  TARBALL_PRESENT=1
+fi
+
+TOTAL=$((${#FILES[@]} + TARBALL_PRESENT))
+if [ "$TOTAL" -eq 0 ]; then
+  echo "nothing to migrate: $EXPORT_DIR is empty and no tarball"
+  exit 0
+fi
+
+echo "→ found $TOTAL item(s) to migrate"
+echo "    $EXPORT_DIR/: ${#FILES[@]} file(s)"
+if [ "$TARBALL_PRESENT" -eq 1 ]; then
+  echo "    $TARBALL: 1 tarball"
+fi
+echo
+
+# ─── Migrate ────────────────────────────────────────────────────────
+
+declare -a KEYS=()
+FAILURES=0
+
+migrate_file() {
+  local path="$1"
+  local key="$2"
+  echo "  → $key"
+  if switchroom vault set "$key" --file "$path"; then
+    KEYS+=("$key")
+  else
+    echo "    ✗ failed to set $key" >&2
+    FAILURES=$((FAILURES + 1))
+  fi
+}
+
+for f in "${FILES[@]}"; do
+  # Strip the leading "./clerk-export/" — but keep the bundle prefix
+  # in the vault key. e.g. ./clerk-export/credentials/foo →
+  # clerk-export/credentials/foo
+  rel="${f#"$EXPORT_DIR"/}"
+  key="$KEY_PREFIX/$rel"
+  migrate_file "$f" "$key"
+done
+
+if [ "$TARBALL_PRESENT" -eq 1 ]; then
+  migrate_file "$TARBALL" "$KEY_PREFIX/_bundle.tar.gz"
+fi
+
+echo
+
+# ─── Verify ─────────────────────────────────────────────────────────
+
+if [ "$FAILURES" -ne 0 ]; then
+  echo "error: $FAILURES item(s) failed to migrate — nothing deleted" >&2
+  echo "       inspect the errors above, fix, re-run" >&2
+  exit 2
+fi
+
+echo "→ verifying all keys are present in the vault..."
+# `vault list` is line-per-key; grep -Fx for exact match per key.
+LIVE_KEYS="$(switchroom vault list)"
+MISSING=0
+for k in "${KEYS[@]}"; do
+  if ! printf '%s\n' "$LIVE_KEYS" | grep -Fxq "$k"; then
+    echo "  ✗ missing from vault: $k" >&2
+    MISSING=$((MISSING + 1))
+  fi
+done
+
+if [ "$MISSING" -ne 0 ]; then
+  echo "error: $MISSING key(s) missing from vault list — nothing deleted" >&2
+  exit 2
+fi
+
+echo "  ✓ all ${#KEYS[@]} key(s) present"
+echo
+
+# ─── Delete on-disk copies (prompted) ───────────────────────────────
+
+echo "All ${#KEYS[@]} item(s) migrated to vault under prefix '$KEY_PREFIX/'."
+printf "Delete on-disk copies (%s and %s)? [y/N] " "$EXPORT_DIR" "$TARBALL"
+read -r REPLY
+case "$REPLY" in
+  [yY]|[yY][eE][sS])
+    ;;
+  *)
+    echo "skipped deletion — on-disk copies remain at:"
+    [ -d "$EXPORT_DIR" ] && echo "    $EXPORT_DIR"
+    [ -f "$TARBALL" ]    && echo "    $TARBALL"
+    echo "(re-run this script or remove them manually when ready)"
+    exit 0
+    ;;
+esac
+
+# Prefer `trash` (recoverable) over `rm` (irrecoverable) when available.
+if command -v trash >/dev/null 2>&1; then
+  RM="trash"
+else
+  RM="rm -rf"
+fi
+
+if [ -d "$EXPORT_DIR" ]; then
+  echo "  → $RM $EXPORT_DIR"
+  $RM "$EXPORT_DIR"
+fi
+if [ -f "$TARBALL" ]; then
+  echo "  → $RM $TARBALL"
+  $RM "$TARBALL"
+fi
+
+echo
+echo "✓ migration complete. 'switchroom doctor' should now show repo hygiene OK."

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -912,6 +912,113 @@ export function checkLeakedHomeSwitchroom(
   };
 }
 
+/**
+ * Hygiene probe for the switchroom git checkout itself (#1072).
+ *
+ * The original OpenClaw export bundle (`clerk-export/`) and its tarball
+ * carry real secrets. They're gitignored, so they can't reach a commit,
+ * but they sit on disk in the repo root and are exposed to any tool that
+ * scans the working tree (backups, grep, "send my repo to X" workflows).
+ *
+ * The proper fix is to migrate the bundle into the vault and delete the
+ * on-disk copies (see `scripts/migrate-clerk-export-to-vault.sh`). This
+ * check surfaces the residual on-disk state so an operator who skipped
+ * the migration script — or restored an old worktree — sees a clear
+ * warning.
+ *
+ * Scope: only meaningful when doctor runs from inside a switchroom
+ * checkout. The caller is expected to skip this section if `repoRoot`
+ * isn't a switchroom repo.
+ */
+export function checkRepoHygiene(repoRoot: string): CheckResult[] {
+  const results: CheckResult[] = [];
+
+  // 1. Directory: `clerk-export/`
+  const exportDir = join(repoRoot, "clerk-export");
+  if (existsSync(exportDir)) {
+    results.push({
+      name: "repo hygiene: clerk-export/ on disk (#1072)",
+      status: "warn",
+      detail:
+        `${exportDir} contains real secrets exported from OpenClaw. ` +
+        `Gitignored, so it can't be committed, but it's still readable ` +
+        `by any tool that scans the working tree.`,
+      fix:
+        `Run scripts/migrate-clerk-export-to-vault.sh to move the bundle ` +
+        `into the vault, then delete the on-disk copy.`,
+    });
+  }
+
+  // 2. Tarball: known name + glob for any *-with-secrets*.tar.gz at repo root
+  const knownTarball = join(repoRoot, "clerk-export-with-secrets.tar.gz");
+  if (existsSync(knownTarball)) {
+    results.push({
+      name: "repo hygiene: clerk-export-with-secrets.tar.gz on disk (#1072)",
+      status: "warn",
+      detail:
+        `${knownTarball} is a sealed copy of the OpenClaw secret bundle. ` +
+        `Gitignored, but persists on disk.`,
+      fix:
+        `Run scripts/migrate-clerk-export-to-vault.sh (handles the tarball ` +
+        `too) then 'trash' or 'rm' the file.`,
+    });
+  }
+
+  // 3. Glob: any *-with-secrets*.tar.gz at repo root that wasn't the known one
+  try {
+    const entries = readdirSync(repoRoot);
+    for (const name of entries) {
+      if (name === "clerk-export-with-secrets.tar.gz") continue; // already reported
+      if (/-with-secrets.*\.tar\.gz$/i.test(name)) {
+        results.push({
+          name: `repo hygiene: ${name} on disk (#1072)`,
+          status: "warn",
+          detail:
+            `${join(repoRoot, name)} matches the *-with-secrets*.tar.gz ` +
+            `pattern. Likely contains real credentials.`,
+          fix:
+            `Inspect, migrate any secrets into the vault, then delete the ` +
+            `archive.`,
+        });
+      }
+    }
+  } catch {
+    // Unreadable repo root — surface as a warning rather than crash.
+    results.push({
+      name: "repo hygiene: scan failed (#1072)",
+      status: "warn",
+      detail: `could not enumerate ${repoRoot} for *-with-secrets*.tar.gz`,
+    });
+  }
+
+  if (results.length === 0) {
+    results.push({
+      name: "repo hygiene: clerk-export bundle (#1072)",
+      status: "ok",
+      detail: "no clerk-export/ or *-with-secrets*.tar.gz at repo root",
+    });
+  }
+
+  return results;
+}
+
+/**
+ * Heuristic: does this directory look like a switchroom git checkout?
+ * Used to gate `checkRepoHygiene` so doctor running from a random cwd
+ * on a non-developer host doesn't emit a noisy "ok" line.
+ */
+export function isSwitchroomCheckout(dir: string): boolean {
+  try {
+    if (!existsSync(join(dir, ".git"))) return false;
+    const pkgPath = join(dir, "package.json");
+    if (!existsSync(pkgPath)) return false;
+    const pkg = JSON.parse(readFileSync(pkgPath, "utf-8")) as { name?: string };
+    return pkg.name === "switchroom";
+  } catch {
+    return false;
+  }
+}
+
 export function checkAgents(config: SwitchroomConfig, configPath: string): CheckResult[] {
   const results: CheckResult[] = [];
   const agentsDir = resolveAgentsDir(config);
@@ -1738,6 +1845,17 @@ export function registerDoctorCommand(program: Command): void {
           { title: "Docker (Phase 1a)", results: runDockerSection(config) },
           { title: "MFF Skill", results: await checkMff(passphrase, vaultPath) },
         ];
+
+        // Repo Hygiene (#1072): only when doctor runs from a switchroom
+        // checkout. On a consumer host this section is silent — the
+        // probe is for the developer/operator who has the source tree.
+        const cwd = process.cwd();
+        if (isSwitchroomCheckout(cwd)) {
+          sections.push({
+            title: "Repo Hygiene",
+            results: checkRepoHygiene(cwd),
+          });
+        }
 
         if (opts.json) {
           console.log(

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -969,7 +969,13 @@ export function checkRepoHygiene(repoRoot: string): CheckResult[] {
     const entries = readdirSync(repoRoot);
     for (const name of entries) {
       if (name === "clerk-export-with-secrets.tar.gz") continue; // already reported
-      if (/-with-secrets.*\.tar\.gz$/i.test(name)) {
+      // `[^/]*` rather than `.*` — `readdirSync` always returns
+      // basenames (no path separators) so the two are functionally
+      // equivalent today, but pinning out `/` makes the intent
+      // obvious and forecloses the false-positive shape (`weird-
+      // with-secrets/anything.tar.gz` as a single readdir entry)
+      // if this regex ever migrates to a non-`readdirSync` caller.
+      if (/-with-secrets[^/]*\.tar\.gz$/i.test(name)) {
         results.push({
           name: `repo hygiene: ${name} on disk (#1072)`,
           status: "warn",

--- a/tests/doctor.repo-hygiene.test.ts
+++ b/tests/doctor.repo-hygiene.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Tests for the Repo Hygiene doctor probe (#1072).
+ *
+ * Threat model: clerk-export/ and *-with-secrets*.tar.gz are gitignored
+ * but persist on disk in the repo root after the OpenClaw migration. The
+ * probe surfaces residual state so an operator who skipped the migration
+ * script sees a warning instead of silent exposure.
+ */
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  checkRepoHygiene,
+  isSwitchroomCheckout,
+} from "../src/cli/doctor.js";
+
+describe("checkRepoHygiene (#1072)", () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = resolve(tmpdir(), `switchroom-doctor-hygiene-${Date.now()}-${Math.random()}`);
+    mkdirSync(tempDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("returns ok when the repo root is clean", () => {
+    const results = checkRepoHygiene(tempDir);
+    expect(results).toHaveLength(1);
+    expect(results[0].status).toBe("ok");
+    expect(results[0].name).toMatch(/#1072/);
+  });
+
+  it("warns when clerk-export/ exists", () => {
+    mkdirSync(join(tempDir, "clerk-export"));
+    writeFileSync(join(tempDir, "clerk-export", "MANIFEST.md"), "secrets");
+    const results = checkRepoHygiene(tempDir);
+    const exportWarning = results.find((r) => r.name.includes("clerk-export/ on disk"));
+    expect(exportWarning).toBeDefined();
+    expect(exportWarning?.status).toBe("warn");
+    expect(exportWarning?.fix).toMatch(/migrate-clerk-export-to-vault\.sh/);
+  });
+
+  it("warns when clerk-export-with-secrets.tar.gz exists", () => {
+    writeFileSync(join(tempDir, "clerk-export-with-secrets.tar.gz"), "fake");
+    const results = checkRepoHygiene(tempDir);
+    const tarballWarning = results.find((r) =>
+      r.name.includes("clerk-export-with-secrets.tar.gz")
+    );
+    expect(tarballWarning).toBeDefined();
+    expect(tarballWarning?.status).toBe("warn");
+  });
+
+  it("warns on any *-with-secrets*.tar.gz pattern (not just clerk-export)", () => {
+    writeFileSync(join(tempDir, "myproject-with-secrets-2026.tar.gz"), "fake");
+    const results = checkRepoHygiene(tempDir);
+    const generic = results.find((r) =>
+      r.name.includes("myproject-with-secrets-2026.tar.gz")
+    );
+    expect(generic).toBeDefined();
+    expect(generic?.status).toBe("warn");
+  });
+
+  it("does not double-report the known tarball under the glob rule", () => {
+    writeFileSync(join(tempDir, "clerk-export-with-secrets.tar.gz"), "fake");
+    const results = checkRepoHygiene(tempDir);
+    // Only one warning, not two.
+    const matching = results.filter((r) =>
+      r.name.includes("clerk-export-with-secrets.tar.gz")
+    );
+    expect(matching).toHaveLength(1);
+  });
+
+  it("reports all three when all are present", () => {
+    mkdirSync(join(tempDir, "clerk-export"));
+    writeFileSync(join(tempDir, "clerk-export-with-secrets.tar.gz"), "fake");
+    writeFileSync(join(tempDir, "backup-with-secrets.tar.gz"), "fake");
+    const results = checkRepoHygiene(tempDir);
+    // 3 warnings, no "ok" placeholder.
+    expect(results.filter((r) => r.status === "warn")).toHaveLength(3);
+    expect(results.find((r) => r.status === "ok")).toBeUndefined();
+  });
+
+  it("returns clean ok when sibling files exist that don't match the pattern", () => {
+    writeFileSync(join(tempDir, "README.md"), "");
+    writeFileSync(join(tempDir, "package.json"), "{}");
+    writeFileSync(join(tempDir, "backup.tar.gz"), ""); // no "-with-secrets" — fine
+    const results = checkRepoHygiene(tempDir);
+    expect(results).toHaveLength(1);
+    expect(results[0].status).toBe("ok");
+  });
+});
+
+describe("isSwitchroomCheckout (#1072)", () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = resolve(tmpdir(), `switchroom-doctor-checkout-${Date.now()}-${Math.random()}`);
+    mkdirSync(tempDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("returns false for an empty directory", () => {
+    expect(isSwitchroomCheckout(tempDir)).toBe(false);
+  });
+
+  it("returns false when .git is present but package.json is missing", () => {
+    mkdirSync(join(tempDir, ".git"));
+    expect(isSwitchroomCheckout(tempDir)).toBe(false);
+  });
+
+  it("returns false when package.json has a different name", () => {
+    mkdirSync(join(tempDir, ".git"));
+    writeFileSync(join(tempDir, "package.json"), JSON.stringify({ name: "other-project" }));
+    expect(isSwitchroomCheckout(tempDir)).toBe(false);
+  });
+
+  it("returns true for a switchroom checkout", () => {
+    mkdirSync(join(tempDir, ".git"));
+    writeFileSync(join(tempDir, "package.json"), JSON.stringify({ name: "switchroom" }));
+    expect(isSwitchroomCheckout(tempDir)).toBe(true);
+  });
+
+  it("returns false when package.json is malformed", () => {
+    mkdirSync(join(tempDir, ".git"));
+    writeFileSync(join(tempDir, "package.json"), "{ not json");
+    expect(isSwitchroomCheckout(tempDir)).toBe(false);
+  });
+});

--- a/tests/doctor.repo-hygiene.test.ts
+++ b/tests/doctor.repo-hygiene.test.ts
@@ -64,6 +64,39 @@ describe("checkRepoHygiene (#1072)", () => {
     expect(generic?.status).toBe("warn");
   });
 
+  // Regression: the pre-fix regex was `/-with-secrets.*\.tar\.gz$/i` with
+  // an unescaped `.` (matches ANY single char). The tightened pattern is
+  // `[^/]*` instead of `.*`. These cases lock the intended boundary so a
+  // future "simplify" pass can't loosen it without a test failure.
+  it("matches the canonical false-positive shapes that motivated the regex", () => {
+    // The shapes that SHOULD match — all real candidates for an
+    // operator-leaked archive.
+    const matchers = [
+      "anything-with-secrets.tar.gz", // bare boundary
+      "x-with-secrets.tar.gz",
+      "weird-with-secretsZ.tar.gz", // single non-separator after the suffix
+      "Aaa-with-secrets-2026-q4.tar.gz",
+    ];
+    for (const name of matchers) {
+      writeFileSync(join(tempDir, name), "fake");
+    }
+    const results = checkRepoHygiene(tempDir);
+    for (const name of matchers) {
+      const hit = results.find((r) => r.name.includes(name));
+      expect(hit, `expected warning for ${name}`).toBeDefined();
+      expect(hit?.status).toBe("warn");
+    }
+  });
+
+  it("ignores filenames that don't end with .tar.gz even when they contain '-with-secrets'", () => {
+    writeFileSync(join(tempDir, "notes-with-secrets.txt"), "x");
+    writeFileSync(join(tempDir, "with-secrets.zip"), "x");
+    writeFileSync(join(tempDir, "x-with-secrets.tar"), "x"); // missing .gz
+    const results = checkRepoHygiene(tempDir);
+    expect(results).toHaveLength(1);
+    expect(results[0].status).toBe("ok");
+  });
+
   it("does not double-report the known tarball under the glob rule", () => {
     writeFileSync(join(tempDir, "clerk-export-with-secrets.tar.gz"), "fake");
     const results = checkRepoHygiene(tempDir);


### PR DESCRIPTION
## Threat model

`clerk-export/` and `clerk-export-with-secrets.tar.gz` carry real OpenClaw secrets and sit in the repo root. They're gitignored, so they can't be committed, but they persist on disk and are exposed to:

- backup tooling that scans the working tree
- grep / ripgrep / "agent-reads-the-repo" workflows
- accidental tarball-and-share operations
- restored worktrees that miss the gitignore context

**Git history audit (clean — proceeded with PR):**

```
git log --all --diff-filter=A -- 'clerk-export/*'                # → empty
git log --all -- 'clerk-export-with-secrets.tar.gz'              # → empty
git log --all -S 'clerk-export' --oneline                        # → docs + .gitignore only
```

No commit ever tracked the file content. Only `.gitignore`, `CLAUDE.md`, and one docs file mention the string. No history rewrite needed.

## What's in this PR

**1. `scripts/migrate-clerk-export-to-vault.sh`** — one-shot operator script.

- Walks `./clerk-export/` recursively, stores each file under vault key `clerk-export/<relpath>` (e.g. `clerk-export/credentials/files/notion-token`).
- Stores `clerk-export-with-secrets.tar.gz` as a binary blob under `clerk-export/_bundle.tar.gz`.
- Probes `switchroom vault list` first — aborts if the vault is locked.
- After every `vault set`, verifies the key is present via `vault list` before offering deletion.
- Prompts `[y/N]` before deletion; uses `trash` over `rm -rf` when available.
- Exit codes: 0 = success, 1 = precondition fail, 2 = migration fail (nothing deleted).

**2. `checkRepoHygiene()` doctor probe** (`src/cli/doctor.ts`).

- Warns on `clerk-export/`, on `clerk-export-with-secrets.tar.gz`, and on any `*-with-secrets*.tar.gz` pattern at the repo root.
- Gated by `isSwitchroomCheckout()` (checks for `.git/` + `package.json` with `name: "switchroom"`) so it only runs when doctor is invoked from inside a switchroom git checkout. Silent on consumer hosts.
- Surfaces a clear `fix:` hint pointing at the migration script.

**3. Tests** — `tests/doctor.repo-hygiene.test.ts`, 12 tests covering: clean dir, each of three warning paths, double-report dedup, all-three-present, isSwitchroomCheckout heuristic edge cases.

## Operator action required

This PR does **not** delete files itself — the secrets are operator-owned and the canonical copy lives only on the operator's host. After merge:

1. `cd ~/code/switchroom`
2. `./scripts/migrate-clerk-export-to-vault.sh`
3. Confirm the prompt
4. `switchroom doctor` → "Repo Hygiene" section should now show `ok`

## Defense check

`git grep -i clerk-export` returns 4 hits, all of them in `.gitignore` / `CLAUDE.md` / `docs/REVIEW-2026-05-02.md`. No live code references — the agent scaffold (`src/agents/scaffold.ts`) and all other runtime paths are clean.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run test:vitest tests/doctor.repo-hygiene.test.ts` — 12/12 pass
- [x] `npm run test:vitest tests/doctor.test.ts` — 48/48 (no regression)
- [x] `npm run build` — clean
- [x] `bash -n scripts/migrate-clerk-export-to-vault.sh` — syntax OK (shellcheck not installed on this host)
- [ ] Operator: run `./scripts/migrate-clerk-export-to-vault.sh` on the host with the live bundle
- [ ] Operator: verify `switchroom doctor` Repo Hygiene section shows `ok` post-migration