### PR TITLE
fix(recall): exit 2 on uncaught error so issue-sink captures memory outages (#1070)

### DIFF
--- a/src/build-info.ts
+++ b/src/build-info.ts
@@ -3,7 +3,7 @@
 // Values are refreshed every time `npm run build` runs.
 
 export const VERSION: string = "0.7.16";
-export const COMMIT_SHA: string | null = "a6d3e0ce";
-export const COMMIT_DATE: string | null = "2026-05-12T05:28:57+10:00";
-export const LATEST_PR: number | null = null;
-export const COMMITS_AHEAD_OF_TAG: number | null = 34;
+export const COMMIT_SHA: string | null = "309644fd";
+export const COMMIT_DATE: string | null = "2026-05-12T10:59:43+10:00";
+export const LATEST_PR: number | null = 1070;
+export const COMMITS_AHEAD_OF_TAG: number | null = 60;

--- a/vendor/hindsight-memory/scripts/recall.py
+++ b/vendor/hindsight-memory/scripts/recall.py
@@ -21,14 +21,22 @@ Flow:
 Exit codes:
   0 — normal success (incl. graceful in-flight errors like recall API
       timeouts where we still produce a valid hookSpecificOutput).
-  2 — uncaught exception in non-debug mode. Switchroom #1070: the
-      wrapper (bin/run-hook.sh) reads this as a failure and records
-      an issue via the #424 issue-sink, so silent memory outages
-      surface to the operator instead of looking like "no memories
-      found". Stdout is left empty (same shape as the no-memories
-      success path) so the agent's prompt assembly still works.
-  2 — debug mode any error (unchanged — surfaces to Claude per
-      Claude Code hook contract).
+  0 — uncaught exception in non-debug mode. Switchroom #1070 (redo,
+      after #1085 review): recall.py is registered as a DIRECT Claude
+      Code plugin hook (`vendor/hindsight-memory/hooks/hooks.json`),
+      NOT wrapped by `bin/run-hook.sh`. Per Claude Code's
+      UserPromptSubmit hook contract, exit 2 BLOCKS the user's
+      prompt and surfaces stderr to the user — so a hindsight outage
+      would block every turn. We instead exit 0 (agent prompt
+      assembly proceeds with no memories), emit a bounded stderr
+      line for journald, and shell out directly to `switchroom
+      issues record` so the #424 issue-sink still captures the
+      failure on the operator's issues card. The subprocess call
+      is fault-tolerant — if it fails for any reason, we still
+      exit 0 with the safe stdout shape.
+  2 — debug mode any error. HINDSIGHT_DEBUG=1 operators are
+      live-debugging and want maximum signal — full traceback to
+      stderr and non-zero exit. Existing behaviour.
 """
 
 import hashlib
@@ -720,33 +728,127 @@ def main():
     json.dump(output, sys.stdout)
 
 
+def _redact_secrets(text: str) -> str:
+    """Best-effort inline scrub for the obvious leak shapes that show
+    up in HTTP error messages (`lib/client.py:73` formats the URL into
+    the RuntimeError, and the URL may include query-string credentials).
+
+    We don't have a python-callable bridge to the TS `secret-detect`
+    module, so this is a small regex pass covering:
+      * Authorization: Bearer <token>
+      * ?key=val and &key=val for keys matching token|key|secret|auth
+      * x-api-key: <value> header shape
+
+    Bounded by `re` (anchored, no catastrophic alternation) so this is
+    safe to run on a 400-char input. Returns `text` unchanged if no
+    matches; on regex-engine error, falls back to returning the raw
+    text — redaction is best-effort, not a security boundary, and the
+    server-side detail handler (#1069) re-scans before persistence.
+    """
+    import re
+
+    try:
+        # Bearer tokens — case-insensitive
+        text = re.sub(
+            r"(?i)(bearer\s+)[A-Za-z0-9._\-]{8,}",
+            r"\1<redacted>",
+            text,
+        )
+        # x-api-key / api-key header values
+        text = re.sub(
+            r"(?i)(x?-?api[-_]?key\s*[:=]\s*)([A-Za-z0-9._\-]{8,})",
+            r"\1<redacted>",
+            text,
+        )
+        # Query-string credentials: ?token=…, &api_key=…, ?secret=…
+        text = re.sub(
+            r"(?i)([?&](?:[a-z0-9_\-]*?(?:token|key|secret|auth|password|pass)"
+            r"[a-z0-9_\-]*?)=)([^&\s]{4,})",
+            r"\1<redacted>",
+            text,
+        )
+        return text
+    except Exception:
+        return text
+
+
+def _record_issue_safely(detail: str, class_name: str) -> None:
+    """Fire-and-forget call into `switchroom issues record`. Bounded by
+    timeout; never raises. The agent's responsiveness on a hindsight
+    outage depends on this NOT propagating any failure.
+    """
+    import subprocess
+
+    try:
+        subprocess.run(
+            [
+                "switchroom",
+                "issues",
+                "record",
+                "--severity",
+                "warn",
+                "--source",
+                "hindsight.recall",
+                "--code",
+                "recall_failed",
+                "--summary",
+                f"Hindsight recall failed: {class_name}",
+                "--detail-stdin",
+                "--quiet",
+            ],
+            input=detail,
+            text=True,
+            timeout=5,
+            check=False,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+    except Exception:
+        # Hard swallow. The agent stays responsive even if the issue
+        # sink is wedged, missing, or the CLI isn't on PATH. The stderr
+        # line above is the operator's only signal in that case.
+        pass
+
+
 if __name__ == "__main__":
     try:
         main()
     except Exception as e:
-        # Switchroom #1070 — surface uncaught recall failures to the
-        # #424 issue-sink instead of silently degrading to an empty
-        # memory block. The wrapper (bin/run-hook.sh) treats any
-        # non-zero exit as a hook failure and calls `switchroom issues
-        # record`, which surfaces on the operator's issues card.
+        # Switchroom #1070 (redo per #1085 review).
         #
-        # Bound the stderr line to class + message (truncated). The
-        # full traceback is gated behind the existing debug flag so
-        # we don't leak prompt/state contents into journald
-        # unredacted (#1069's threat model).
+        # recall.py is a DIRECT Claude Code plugin hook (see
+        # vendor/hindsight-memory/hooks/hooks.json). It is NOT wrapped
+        # by bin/run-hook.sh, so the `non-zero exit → record_failure`
+        # pipeline does NOT apply here. Per Claude Code's hook
+        # contract, exit 2 on UserPromptSubmit BLOCKS the user's
+        # prompt and surfaces stderr to them — which would turn a
+        # hindsight outage into "every turn blocked".
+        #
+        # Correct posture: exit 0 with the same safe-empty stdout
+        # shape as the no-memories success path (recall.py line ~660
+        # — `return` with no JSON dumped), so the agent's prompt
+        # assembly proceeds with no memories. Then shell out directly
+        # to `switchroom issues record` so the operator still sees
+        # the failure on their issues card. The subprocess call is
+        # fault-tolerant; if it fails for any reason the agent still
+        # stays responsive.
+        #
+        # Debug mode (HINDSIGHT_DEBUG=1) keeps the legacy posture —
+        # traceback + exit 2 — because live-debugging operators want
+        # maximum signal and have opted in.
         _msg = str(e)
         if len(_msg) > 400:
             _msg = _msg[:400] + "…"
+        _msg = _redact_secrets(_msg)
+        _class = type(e).__name__
+        _detail = f"{_class}: {_msg}"
         print(
-            f"[Hindsight] Unexpected error in recall: "
-            f"{type(e).__name__}: {_msg}",
+            f"[Hindsight] Unexpected error in recall: {_detail}",
             file=sys.stderr,
         )
-        # Try to read the debug flag to decide on traceback verbosity
-        # AND on the legacy debug-mode exit code (which is also 2,
-        # but operators rely on the existing behaviour shape — don't
-        # change it for them). Both paths now exit non-zero so the
-        # issue-sink captures memory outages either way.
+
+        # Decide on debug-branch behaviour. load_config may itself be
+        # what failed in main() (it's called early), so guard.
         _is_debug = False
         try:
             from lib.config import load_config
@@ -754,13 +856,18 @@ if __name__ == "__main__":
             _is_debug = bool(load_config().get("debug"))
         except Exception:
             pass
+
         if _is_debug:
             import traceback
 
             traceback.print_exc(file=sys.stderr)
-        # Stdout is left empty here (same shape as the no-memories
-        # success path on line ~651). The agent's prompt assembly
-        # treats absence of additionalContext as "no recall this
-        # turn" and proceeds. The non-zero exit is what wakes up the
-        # issue-sink.
-        sys.exit(2)
+            # Debug-mode exit 2 is intentional and unchanged —
+            # operators with HINDSIGHT_DEBUG=1 are chasing a broken
+            # recall and want the hook to surface its failure.
+            sys.exit(2)
+
+        # Non-debug: route the failure to the issue-sink, then exit
+        # 0 with no stdout (agent's prompt assembly treats absent
+        # additionalContext as "no recall this turn").
+        _record_issue_safely(_detail, _class)
+        sys.exit(0)

--- a/vendor/hindsight-memory/scripts/recall.py
+++ b/vendor/hindsight-memory/scripts/recall.py
@@ -19,7 +19,16 @@ Flow:
  11. Save last recall to state (for PostCompact re-injection)
 
 Exit codes:
-  0 — always (graceful degradation on any error)
+  0 — normal success (incl. graceful in-flight errors like recall API
+      timeouts where we still produce a valid hookSpecificOutput).
+  2 — uncaught exception in non-debug mode. Switchroom #1070: the
+      wrapper (bin/run-hook.sh) reads this as a failure and records
+      an issue via the #424 issue-sink, so silent memory outages
+      surface to the operator instead of looking like "no memories
+      found". Stdout is left empty (same shape as the no-memories
+      success path) so the agent's prompt assembly still works.
+  2 — debug mode any error (unchanged — surfaces to Claude per
+      Claude Code hook contract).
 """
 
 import hashlib
@@ -715,11 +724,43 @@ if __name__ == "__main__":
     try:
         main()
     except Exception as e:
-        print(f"[Hindsight] Unexpected error in recall: {e}", file=sys.stderr)
-        # Exit 2 in debug mode surfaces errors to Claude; 0 degrades silently
+        # Switchroom #1070 — surface uncaught recall failures to the
+        # #424 issue-sink instead of silently degrading to an empty
+        # memory block. The wrapper (bin/run-hook.sh) treats any
+        # non-zero exit as a hook failure and calls `switchroom issues
+        # record`, which surfaces on the operator's issues card.
+        #
+        # Bound the stderr line to class + message (truncated). The
+        # full traceback is gated behind the existing debug flag so
+        # we don't leak prompt/state contents into journald
+        # unredacted (#1069's threat model).
+        _msg = str(e)
+        if len(_msg) > 400:
+            _msg = _msg[:400] + "…"
+        print(
+            f"[Hindsight] Unexpected error in recall: "
+            f"{type(e).__name__}: {_msg}",
+            file=sys.stderr,
+        )
+        # Try to read the debug flag to decide on traceback verbosity
+        # AND on the legacy debug-mode exit code (which is also 2,
+        # but operators rely on the existing behaviour shape — don't
+        # change it for them). Both paths now exit non-zero so the
+        # issue-sink captures memory outages either way.
+        _is_debug = False
         try:
             from lib.config import load_config
 
-            sys.exit(2 if load_config().get("debug") else 0)
+            _is_debug = bool(load_config().get("debug"))
         except Exception:
-            sys.exit(0)
+            pass
+        if _is_debug:
+            import traceback
+
+            traceback.print_exc(file=sys.stderr)
+        # Stdout is left empty here (same shape as the no-memories
+        # success path on line ~651). The agent's prompt assembly
+        # treats absence of additionalContext as "no recall this
+        # turn" and proceeds. The non-zero exit is what wakes up the
+        # issue-sink.
+        sys.exit(2)

--- a/vendor/hindsight-memory/tests/test_recall_exit_codes.py
+++ b/vendor/hindsight-memory/tests/test_recall_exit_codes.py
@@ -1,22 +1,38 @@
 """Exit-code contract for recall.py's top-level exception handler.
 
-Switchroom #1070. Before this fix, an uncaught exception in the
-``__main__`` block exited 0 in non-debug mode — so ``bin/run-hook.sh``
-saw a successful run and the #424 issue-sink never captured the
-silent memory outage. The agent's ``<hindsight_memories>`` block
-silently went empty.
+Switchroom #1070 (redo per #1085 review feedback).
 
-The contract these tests pin:
+The original fix changed non-debug uncaught exceptions to exit 2,
+assuming `bin/run-hook.sh`'s `record_failure` path would fire. But
+recall.py is registered as a DIRECT Claude Code plugin hook
+(`vendor/hindsight-memory/hooks/hooks.json`), not wrapped. Per Claude
+Code's `UserPromptSubmit` hook contract, exit 2 blocks the user's
+prompt and surfaces stderr to them — so a hindsight outage would
+block every turn.
 
-* Non-debug uncaught exception → exit code 2, empty stdout, stderr
-  contains the exception class + message but NOT a full traceback.
-* Debug uncaught exception → exit code 2 still (unchanged), stderr
-  carries the traceback for live debugging.
+The corrected contract pinned by these tests:
 
-The fault is injected by monkey-patching ``lib.config.load_config``
-to raise inside ``main()``, which propagates to the top-level
-handler. We run the script as a subprocess so the real
-``if __name__ == '__main__':`` block executes.
+* Non-debug uncaught exception → exit code 0 (agent stays responsive),
+  empty stdout (matches the no-memories success-path shape), stderr
+  carrying the class + message but NOT a traceback, AND a synchronous
+  shell-out to `switchroom issues record --severity warn --source
+  hindsight.recall --code recall_failed ...` so the #424 issue-sink
+  still captures the outage.
+* The shell-out is fault-tolerant: if the `switchroom` binary is
+  missing, hangs, or exits non-zero, recall.py still exits 0 with the
+  safe stdout shape.
+* Stderr / issue-sink detail are passed through an inline secret
+  redactor (bearer tokens, ?token=…/&api_key=… query-string creds,
+  x-api-key headers) so credentials leaking out of `lib/client.py:73`'s
+  `RuntimeError(f"HTTP {e.code} from {url}: ...")` don't land in
+  journald or the issues store.
+* Debug uncaught exception (HINDSIGHT_DEBUG=1) → exit code 2 with
+  full traceback. Unchanged — live-debugging operators opt in.
+
+The fault is injected by monkey-patching a helper called during
+``main()`` so the top-level except handler fires. We run the script
+as a subprocess so the real ``if __name__ == '__main__':`` block
+executes.
 """
 
 import json
@@ -36,6 +52,7 @@ def _run_recall_with_injected_fault(
     tmp_path,
     debug=False,
     fault_message="boom: simulated fault",
+    switchroom_shim=None,
 ):
     """Run recall.py as a subprocess after injecting a fault into a
     lib helper called *during* main() so the top-level except handler
@@ -44,6 +61,11 @@ def _run_recall_with_injected_fault(
     crucially does NOT touch lib.config — so the handler's own
     ``load_config()`` call (used to decide on traceback verbosity)
     still works.
+
+    ``switchroom_shim`` (optional) is shell script content; if
+    provided, a `switchroom` executable with that content is prepended
+    to PATH so the handler's subprocess call resolves to it instead
+    of (or instead of failing to find) the real CLI.
 
     Returns the CompletedProcess.
     """
@@ -80,39 +102,73 @@ def _run_recall_with_injected_fault(
     if debug:
         env["HINDSIGHT_DEBUG"] = "1"
 
+    # Path manipulation for the switchroom shim. We always isolate
+    # PATH so the test doesn't accidentally invoke a real `switchroom`
+    # on the host — that would write to a real state dir.
+    bindir = tmp_path / "bin"
+    bindir.mkdir(exist_ok=True)
+    if switchroom_shim is not None:
+        sw = bindir / "switchroom"
+        sw.write_text(switchroom_shim)
+        sw.chmod(0o755)
+    # Keep system path elements for /usr/bin/env etc., but put our
+    # bindir FIRST so any shim wins.
+    env["PATH"] = f"{bindir}:{env.get('PATH', '/usr/bin:/bin')}"
+
     proc = subprocess.run(
         [sys.executable, str(shim)],
         input=json.dumps({"prompt": "anything", "session_id": "s"}),
         capture_output=True,
         text=True,
         env=env,
-        timeout=10,
+        timeout=15,
     )
     return proc
 
 
+# Default recording shim: writes argv (NUL-separated) + stdin into a
+# file under $SHIM_RECORD so the test can assert call shape. Exit 0.
+_RECORDING_SHIM = textwrap.dedent(
+    """\
+    #!/usr/bin/env bash
+    set -u
+    out="${SHIM_RECORD:-/tmp/sw-shim-record}"
+    {
+      for a in "$@"; do printf '%s\\0' "$a"; done
+      printf -- '---STDIN---\\n'
+      cat
+    } > "$out"
+    exit 0
+    """
+)
+
+
 class TestRecallExitCodes:
-    def test_nondebug_uncaught_exits_two(self, tmp_path):
-        """The headline contract: non-debug uncaught → exit 2 so the
-        wrapper's record_failure path fires."""
+    def test_nondebug_uncaught_exits_zero(self, tmp_path):
+        """Headline contract: a hindsight outage must NOT block the
+        user's prompt. exit 0 → Claude Code accepts the empty
+        additionalContext and proceeds with normal turn handling."""
         proc = _run_recall_with_injected_fault(tmp_path, debug=False)
-        assert proc.returncode == 2, (
-            f"expected exit 2, got {proc.returncode}; "
+        assert proc.returncode == 0, (
+            f"expected exit 0, got {proc.returncode}; "
             f"stderr={proc.stderr!r}"
         )
 
-    def test_nondebug_stdout_is_safe_empty(self, tmp_path):
-        """Stdout must be empty (matches the no-memories success
-        shape) so the agent's prompt assembly doesn't try to parse
-        an error message as JSON."""
+    def test_nondebug_stdout_is_empty_memory_shape(self, tmp_path):
+        """Stdout must match the no-memories success-path shape. In
+        recall.py that path is a bare `return` with nothing dumped
+        to stdout (see line ~660 — the `if not directives_block and
+        not memories_block: return` branch). So stdout must be the
+        empty string."""
         proc = _run_recall_with_injected_fault(tmp_path, debug=False)
-        assert proc.stdout.strip() == "", (
+        assert proc.stdout == "", (
             f"expected empty stdout, got {proc.stdout!r}"
         )
 
     def test_nondebug_stderr_includes_class_and_message(self, tmp_path):
-        """The wrapper attaches the last ~60 lines of stderr to the
-        recorded issue, so the class + message must be present."""
+        """Operators reading journald need the class + message to
+        understand what broke. The full traceback stays gated behind
+        HINDSIGHT_DEBUG=1."""
         proc = _run_recall_with_injected_fault(
             tmp_path, debug=False, fault_message="kaboom-1070"
         )
@@ -132,18 +188,138 @@ class TestRecallExitCodes:
             f"non-debug stderr leaked traceback: {proc.stderr!r}"
         )
 
-    def test_debug_includes_traceback(self, tmp_path):
-        """In debug mode, the traceback is allowed — operators run
-        with HINDSIGHT_DEBUG=1 explicitly when they're chasing a
-        broken recall and need the full stack."""
+    def test_nondebug_invokes_issues_record_subprocess(self, tmp_path):
+        """The substitute for the wrapper's record_failure path:
+        recall.py must shell out to `switchroom issues record` itself.
+        Assert the call argv shape via a recording shim on PATH."""
+        record_path = tmp_path / "shim_record.txt"
+        env_override_shim = _RECORDING_SHIM.replace(
+            '${SHIM_RECORD:-/tmp/sw-shim-record}', str(record_path)
+        )
+        proc = _run_recall_with_injected_fault(
+            tmp_path,
+            debug=False,
+            fault_message="kaboom-call-shape",
+            switchroom_shim=env_override_shim,
+        )
+        assert proc.returncode == 0
+        assert record_path.exists(), (
+            f"switchroom shim was not invoked; stderr={proc.stderr!r}"
+        )
+        raw = record_path.read_bytes()
+        head, _, tail = raw.partition(b"---STDIN---\n")
+        argv = [a.decode() for a in head.split(b"\x00") if a]
+        # Expected verb chain
+        assert argv[0:3] == ["issues", "record", "--severity"], argv
+        assert "warn" in argv
+        assert "--source" in argv
+        assert "hindsight.recall" in argv
+        assert "--code" in argv
+        assert "recall_failed" in argv
+        assert "--summary" in argv
+        # Summary contains the class
+        assert any(
+            "Hindsight recall failed: RuntimeError" in a for a in argv
+        ), argv
+        assert "--detail-stdin" in argv
+        assert "--quiet" in argv
+        # Stdin carries class + message
+        stdin_payload = tail.decode()
+        assert "RuntimeError" in stdin_payload
+        assert "kaboom-call-shape" in stdin_payload
+
+    def test_nondebug_issues_record_failure_does_not_propagate(self, tmp_path):
+        """If the shim exits non-zero (or the binary is missing or
+        hangs), recall.py must still exit 0 with the safe stdout
+        shape. The agent's responsiveness on a hindsight outage MUST
+        NOT depend on the issue sink also working."""
+        failing_shim = "#!/usr/bin/env bash\nexit 17\n"
+        proc = _run_recall_with_injected_fault(
+            tmp_path, debug=False, switchroom_shim=failing_shim
+        )
+        assert proc.returncode == 0, (
+            f"shim failure leaked through; rc={proc.returncode} "
+            f"stderr={proc.stderr!r}"
+        )
+        assert proc.stdout == ""
+
+    def test_nondebug_missing_switchroom_binary_does_not_propagate(self, tmp_path):
+        """The other failure mode: the binary isn't on PATH at all.
+        FileNotFoundError must be swallowed; agent still exits 0."""
+        # Empty bindir, no shim. PATH will only contain our empty
+        # bindir + system paths; system paths shouldn't have a
+        # `switchroom` on a test runner (and even if they do, the
+        # important thing is exit 0).
+        proc = _run_recall_with_injected_fault(
+            tmp_path, debug=False, switchroom_shim=None
+        )
+        # We can't assert the shim wasn't called (we didn't install
+        # one) but we CAN assert recall.py still exits 0.
+        assert proc.returncode == 0, (
+            f"missing-binary path leaked; rc={proc.returncode} "
+            f"stderr={proc.stderr!r}"
+        )
+
+    def test_nondebug_redacts_token_in_message(self, tmp_path):
+        """Exception messages from `lib/client.py:73` interpolate the
+        request URL into a RuntimeError; that URL may carry
+        `?api_key=...` or `Authorization: Bearer ...` in the body
+        echo. The redactor must scrub these from BOTH stderr and the
+        issues-record stdin payload.
+
+        Per repo convention (CLAUDE.md "Secrets in tests"), the
+        token-shaped fixture is built by string concatenation so the
+        source file never contains a contiguous secret-looking blob.
+        """
+        # Construct a fake token at runtime
+        fake_token = "sk" + "-" + "ant" + "-" + "a" * 40
+        fault_msg = (
+            "HTTP 401 from https://api.example.com/recall"
+            f"?api_key={fake_token}: unauthorized"
+        )
+        record_path = tmp_path / "shim_record.txt"
+        env_override_shim = _RECORDING_SHIM.replace(
+            '${SHIM_RECORD:-/tmp/sw-shim-record}', str(record_path)
+        )
+        proc = _run_recall_with_injected_fault(
+            tmp_path,
+            debug=False,
+            fault_message=fault_msg,
+            switchroom_shim=env_override_shim,
+        )
+        assert proc.returncode == 0
+        assert fake_token not in proc.stderr, (
+            f"token leaked to stderr: {proc.stderr!r}"
+        )
+        assert record_path.exists()
+        payload = record_path.read_bytes().decode("utf-8", errors="replace")
+        assert fake_token not in payload, (
+            f"token leaked to issues-record payload: {payload!r}"
+        )
+
+    def test_nondebug_redacts_bearer_in_message(self, tmp_path):
+        """Bearer-token shape is the other common leak vector."""
+        fake_bearer = "abcdef" + "0123456789" * 4
+        fault_msg = f"HTTP 401: Authorization: Bearer {fake_bearer} rejected"
+        proc = _run_recall_with_injected_fault(
+            tmp_path,
+            debug=False,
+            fault_message=fault_msg,
+            switchroom_shim=_RECORDING_SHIM,
+        )
+        assert proc.returncode == 0
+        assert fake_bearer not in proc.stderr, (
+            f"bearer leaked to stderr: {proc.stderr!r}"
+        )
+
+    def test_debug_exits_two_with_traceback(self, tmp_path):
+        """In debug mode, the traceback is allowed AND we exit 2.
+        Unchanged from the existing debug-branch behaviour."""
         proc = _run_recall_with_injected_fault(tmp_path, debug=True)
+        assert proc.returncode == 2, (
+            f"expected exit 2 in debug, got {proc.returncode}; "
+            f"stderr={proc.stderr!r}"
+        )
         assert "Traceback (most recent call last)" in proc.stderr, (
             f"debug stderr missing traceback: {proc.stderr!r}"
         )
-
-    def test_debug_still_exits_nonzero(self, tmp_path):
-        """Debug mode previously exited 2; we preserve that so
-        live-debugging operators see the same exit code shape they
-        always have."""
-        proc = _run_recall_with_injected_fault(tmp_path, debug=True)
-        assert proc.returncode == 2

--- a/vendor/hindsight-memory/tests/test_recall_exit_codes.py
+++ b/vendor/hindsight-memory/tests/test_recall_exit_codes.py
@@ -1,0 +1,149 @@
+"""Exit-code contract for recall.py's top-level exception handler.
+
+Switchroom #1070. Before this fix, an uncaught exception in the
+``__main__`` block exited 0 in non-debug mode — so ``bin/run-hook.sh``
+saw a successful run and the #424 issue-sink never captured the
+silent memory outage. The agent's ``<hindsight_memories>`` block
+silently went empty.
+
+The contract these tests pin:
+
+* Non-debug uncaught exception → exit code 2, empty stdout, stderr
+  contains the exception class + message but NOT a full traceback.
+* Debug uncaught exception → exit code 2 still (unchanged), stderr
+  carries the traceback for live debugging.
+
+The fault is injected by monkey-patching ``lib.config.load_config``
+to raise inside ``main()``, which propagates to the top-level
+handler. We run the script as a subprocess so the real
+``if __name__ == '__main__':`` block executes.
+"""
+
+import json
+import os
+import subprocess
+import sys
+import textwrap
+
+
+SCRIPTS_DIR = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..", "scripts")
+)
+RECALL_PY = os.path.join(SCRIPTS_DIR, "recall.py")
+
+
+def _run_recall_with_injected_fault(
+    tmp_path,
+    debug=False,
+    fault_message="boom: simulated fault",
+):
+    """Run recall.py as a subprocess after injecting a fault into a
+    lib helper called *during* main() so the top-level except handler
+    fires. We target ``lib.gateway_ipc.extract_chat_id_from_prompt``
+    because it's called unconditionally in the recall flow and
+    crucially does NOT touch lib.config — so the handler's own
+    ``load_config()`` call (used to decide on traceback verbosity)
+    still works.
+
+    Returns the CompletedProcess.
+    """
+    shim = tmp_path / "fault_shim.py"
+    shim.write_text(
+        textwrap.dedent(
+            f"""\
+            import sys, os, runpy
+            sys.path.insert(0, {SCRIPTS_DIR!r})
+            from lib import gateway_ipc as _gw
+
+            def _boom(*a, **kw):
+                raise RuntimeError({fault_message!r})
+
+            _gw.extract_chat_id_from_prompt = _boom
+
+            # Run recall.py as __main__ so the top-level try/except
+            # block executes exactly as it does in production.
+            runpy.run_path({RECALL_PY!r}, run_name="__main__")
+            """
+        )
+    )
+
+    env = os.environ.copy()
+    # Strip any real HINDSIGHT_* / CLAUDE_PLUGIN_* env that might bleed in
+    for key in list(env):
+        if key.startswith(("HINDSIGHT_", "CLAUDE_PLUGIN_")):
+            env.pop(key, None)
+    env["HOME"] = str(tmp_path)
+    env["CLAUDE_PLUGIN_ROOT"] = str(tmp_path / "plugin_root")
+    env["CLAUDE_PLUGIN_DATA"] = str(tmp_path / "plugin_data")
+    (tmp_path / "plugin_root").mkdir(exist_ok=True)
+    (tmp_path / "plugin_data").mkdir(exist_ok=True)
+    if debug:
+        env["HINDSIGHT_DEBUG"] = "1"
+
+    proc = subprocess.run(
+        [sys.executable, str(shim)],
+        input=json.dumps({"prompt": "anything", "session_id": "s"}),
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=10,
+    )
+    return proc
+
+
+class TestRecallExitCodes:
+    def test_nondebug_uncaught_exits_two(self, tmp_path):
+        """The headline contract: non-debug uncaught → exit 2 so the
+        wrapper's record_failure path fires."""
+        proc = _run_recall_with_injected_fault(tmp_path, debug=False)
+        assert proc.returncode == 2, (
+            f"expected exit 2, got {proc.returncode}; "
+            f"stderr={proc.stderr!r}"
+        )
+
+    def test_nondebug_stdout_is_safe_empty(self, tmp_path):
+        """Stdout must be empty (matches the no-memories success
+        shape) so the agent's prompt assembly doesn't try to parse
+        an error message as JSON."""
+        proc = _run_recall_with_injected_fault(tmp_path, debug=False)
+        assert proc.stdout.strip() == "", (
+            f"expected empty stdout, got {proc.stdout!r}"
+        )
+
+    def test_nondebug_stderr_includes_class_and_message(self, tmp_path):
+        """The wrapper attaches the last ~60 lines of stderr to the
+        recorded issue, so the class + message must be present."""
+        proc = _run_recall_with_injected_fault(
+            tmp_path, debug=False, fault_message="kaboom-1070"
+        )
+        assert "RuntimeError" in proc.stderr
+        assert "kaboom-1070" in proc.stderr
+        assert "Unexpected error in recall" in proc.stderr
+
+    def test_nondebug_stderr_omits_traceback(self, tmp_path):
+        """#1069 threat model: don't dump tracebacks (which may
+        include local-variable repr in some frames or framework
+        internals) to unredacted stderr unless debug mode is on."""
+        proc = _run_recall_with_injected_fault(tmp_path, debug=False)
+        # The Python traceback module emits "Traceback (most recent
+        # call last):" as the first line. Its absence is the cheap,
+        # unambiguous check.
+        assert "Traceback (most recent call last)" not in proc.stderr, (
+            f"non-debug stderr leaked traceback: {proc.stderr!r}"
+        )
+
+    def test_debug_includes_traceback(self, tmp_path):
+        """In debug mode, the traceback is allowed — operators run
+        with HINDSIGHT_DEBUG=1 explicitly when they're chasing a
+        broken recall and need the full stack."""
+        proc = _run_recall_with_injected_fault(tmp_path, debug=True)
+        assert "Traceback (most recent call last)" in proc.stderr, (
+            f"debug stderr missing traceback: {proc.stderr!r}"
+        )
+
+    def test_debug_still_exits_nonzero(self, tmp_path):
+        """Debug mode previously exited 2; we preserve that so
+        live-debugging operators see the same exit code shape they
+        always have."""
+        proc = _run_recall_with_injected_fault(tmp_path, debug=True)
+        assert proc.returncode == 2


### PR DESCRIPTION
## Summary

Closes #1070. CRITICAL silent-failure: an uncaught exception in `vendor/hindsight-memory/scripts/recall.py`'s `__main__` block exited 0 in the non-debug path. `bin/run-hook.sh` (the #424 issue-sink wrapper) reads exit 0 as success, so a broken recall silently produced an empty `<hindsight_memories>` block and never surfaced on the operator's issues card. This violates the #424 Phase-0 invariant: hook failures must be surface-able.

## Change

- **Non-debug exit code: 0 → 2.** Distinct from 1 so the failure mode is greppable in production logs. The wrapper's `record_failure` now fires and writes to `issues.jsonl`.
- **Stderr is bounded** to `type(e).__name__: <message truncated to 400 chars>`. Full traceback is gated behind the existing `HINDSIGHT_DEBUG=1` flag (preserves #1069's redaction posture — no local-variable repr leaking into unredacted journald).
- **Stdout is left empty** on the failure path. Same shape as the no-memories success branch (line ~651) so the agent's prompt assembly proceeds as "no recall this turn" rather than trying to parse an error blob.
- **Debug-mode behaviour preserved.** Still exits 2, still prints the diagnostic — operators chasing live recall breakage keep their existing contract — but now also includes the full traceback when `HINDSIGHT_DEBUG=1`.

## Test plan

New `vendor/hindsight-memory/tests/test_recall_exit_codes.py` runs `recall.py` as a subprocess (so the real `__main__` block executes) with a fault injected at `lib.gateway_ipc.extract_chat_id_from_prompt`. Asserts:

- [x] non-debug uncaught → exit 2
- [x] non-debug stdout is empty (safe fallback shape)
- [x] non-debug stderr contains class + message
- [x] non-debug stderr does NOT contain `Traceback (most recent call last)` (#1069 leak guard)
- [x] debug stderr DOES contain the traceback
- [x] debug still exits 2

All 6 pass. Vendor suite: 146 passed, 3 pre-existing failures in `test_config.py` (recallBudget default `mid` → `low` from #470, unrelated to this change).

Switchroom side:
- [x] `npm run build`
- [x] `npm run lint`
- [x] `npm run test:vitest` (UAT-driver telegram-session failures unrelated)
- [x] `npm run test:bun` (640 pass / 2 skip)
- [x] `tests/run-hook.test.ts` re-run cleanly (13/13)

## Vendor sync note

`vendor/hindsight-memory/` has no sync script in this repo (`scripts/` and root inspected; recent history shows direct switchroom commits modifying the vendor — #475, #432, #424, #303, #470). Edited in place. No upstream `vectorize-io/hindsight` PR required for this switchroom-specific fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)