### PR TITLE
fix(session_end): persist failed retains to pending-retains queue, drain on SessionStart (#1071)

### DIFF
--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -580,7 +580,98 @@ async function checkHindsight(config: SwitchroomConfig): Promise<CheckResult[]> 
     }
   }
 
+  // Pending-retains queue (#1071). When session_end's final retain
+  // fails it stashes the payload in ~/.hindsight/pending-retains/ so
+  // the next SessionStart can drain it. A non-empty queue is normal in
+  // flight, but persistent backlog (or any .dead markers) means
+  // operator attention.
+  results.push(checkPendingRetainsQueue());
+
   return results;
+}
+
+/**
+ * Probe ``~/.hindsight/pending-retains/`` and report:
+ *   ok    — directory missing or empty
+ *   warn  — entries present but none marked dead (will retry on next session)
+ *   fail  — at least one ``.dead`` marker (gave up after MAX_ATTEMPTS) OR
+ *           queue at/over the bounded cap (chronic backlog)
+ *
+ * Exported for unit testing.
+ * @internal
+ */
+export function checkPendingRetainsQueue(
+  dir?: string,
+): CheckResult {
+  // Same default as lib/pending.py: $HOME/.hindsight/pending-retains/.
+  const home = process.env.HOME ?? "";
+  const pendingDir =
+    dir
+    ?? process.env.HINDSIGHT_PENDING_DIR
+    ?? join(home, ".hindsight", "pending-retains");
+
+  if (!existsSync(pendingDir)) {
+    return {
+      name: "pending-retains queue",
+      status: "ok",
+      detail: "empty (no failed retains)",
+    };
+  }
+
+  let names: string[];
+  try {
+    names = readdirSync(pendingDir);
+  } catch (err) {
+    return {
+      name: "pending-retains queue",
+      status: "warn",
+      detail: `unreadable: ${(err as Error).message}`,
+    };
+  }
+
+  const pending = names.filter((n) => n.endsWith(".json"));
+  const dead = names.filter((n) => n.endsWith(".json.dead"));
+
+  // Keep in sync with MAX_ENTRIES in lib/pending.py.
+  const MAX_ENTRIES = 1000;
+
+  if (dead.length > 0) {
+    return {
+      name: "pending-retains queue",
+      status: "fail",
+      detail:
+        `${dead.length} dead entries (gave up after retries), ${pending.length} still queued`,
+      fix:
+        `Hindsight has been unreachable long enough that retries gave up. `
+        + `Inspect ~/.hindsight/pending-retains/*.json.dead, fix the upstream, `
+        + `then re-enqueue manually (rename .dead → .json) or discard.`,
+    };
+  }
+
+  if (pending.length >= MAX_ENTRIES) {
+    return {
+      name: "pending-retains queue",
+      status: "fail",
+      detail: `${pending.length} entries (queue at cap of ${MAX_ENTRIES}, dropping new failures)`,
+      fix:
+        `Chronic retain failures. Bring Hindsight up, run `
+        + `\`python3 ~/.claude/plugins/.../scripts/drain_pending.py\`, then re-check.`,
+    };
+  }
+
+  if (pending.length > 0) {
+    return {
+      name: "pending-retains queue",
+      status: "warn",
+      detail: `${pending.length} queued (will retry on next SessionStart)`,
+    };
+  }
+
+  return {
+    name: "pending-retains queue",
+    status: "ok",
+    detail: "empty (no failed retains)",
+  };
 }
 
 /**

--- a/tests/doctor.test.ts
+++ b/tests/doctor.test.ts
@@ -769,3 +769,59 @@ describe("checkLeakedHomeSwitchroom (#933)", () => {
     expect(r.fix).toContain("switchroom agent restart clerk");
   });
 });
+
+describe("checkPendingRetainsQueue (#1071)", () => {
+  let tempDir: string;
+  beforeEach(() => {
+    tempDir = resolve(tmpdir(), `switchroom-doctor-pending-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  });
+  afterEach(() => rmSync(tempDir, { recursive: true, force: true }));
+
+  it("returns ok when directory does not exist", async () => {
+    const { checkPendingRetainsQueue } = await import("../src/cli/doctor.js");
+    const r = checkPendingRetainsQueue(tempDir);
+    expect(r.status).toBe("ok");
+    expect(r.detail).toContain("empty");
+  });
+
+  it("returns ok when directory exists but is empty", async () => {
+    mkdirSync(tempDir, { recursive: true });
+    const { checkPendingRetainsQueue } = await import("../src/cli/doctor.js");
+    const r = checkPendingRetainsQueue(tempDir);
+    expect(r.status).toBe("ok");
+  });
+
+  it("returns warn when queued entries are present (no dead)", async () => {
+    mkdirSync(tempDir, { recursive: true });
+    writeFileSync(join(tempDir, "1000000000000-aaaaaaaaaaaa.json"), "{}");
+    writeFileSync(join(tempDir, "1000000000001-bbbbbbbbbbbb.json"), "{}");
+    const { checkPendingRetainsQueue } = await import("../src/cli/doctor.js");
+    const r = checkPendingRetainsQueue(tempDir);
+    expect(r.status).toBe("warn");
+    expect(r.detail).toContain("2 queued");
+  });
+
+  it("returns fail when at least one .dead marker exists", async () => {
+    mkdirSync(tempDir, { recursive: true });
+    writeFileSync(join(tempDir, "1000000000000-aaaaaaaaaaaa.json"), "{}");
+    writeFileSync(join(tempDir, "1000000000001-cccccccccccc.json.dead"), "{}");
+    const { checkPendingRetainsQueue } = await import("../src/cli/doctor.js");
+    const r = checkPendingRetainsQueue(tempDir);
+    expect(r.status).toBe("fail");
+    expect(r.detail).toContain("1 dead");
+    expect(r.fix).toContain("retries gave up");
+  });
+
+  it("returns fail when queue reaches the cap", async () => {
+    mkdirSync(tempDir, { recursive: true });
+    // We don't actually need 1000 files — the implementation reads
+    // length >= 1000. Mock by writing 1000 stubs (cheap, ~1 ms).
+    for (let i = 0; i < 1000; i++) {
+      writeFileSync(join(tempDir, `${1000000000000 + i}-x${i}.json`), "{}");
+    }
+    const { checkPendingRetainsQueue } = await import("../src/cli/doctor.js");
+    const r = checkPendingRetainsQueue(tempDir);
+    expect(r.status).toBe("fail");
+    expect(r.detail).toContain("queue at cap");
+  });
+});

--- a/vendor/hindsight-memory/scripts/drain_pending.py
+++ b/vendor/hindsight-memory/scripts/drain_pending.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+"""Drain ``~/.hindsight/pending-retains/``.
+
+SessionStart calls into ``drain()`` to retry any retain payloads that
+``session_end.py`` queued on failure (#1071). Each entry is retried up
+to ``MAX_ATTEMPTS`` (5) times; after that it's renamed to ``.dead`` so
+the queue no longer drains it but the operator can still inspect via
+``switchroom doctor``.
+
+Boundaries
+----------
+* Per-entry HTTP timeout: ``HINDSIGHT_DRAIN_TIMEOUT`` (default 5s).
+* Stall guard: if ``STALL_THRESHOLD`` (3) consecutive entries fail with
+  the same error class, we stop draining for this session — that's a
+  systemic outage, not a transient flake, and continuing would only
+  burn the SessionStart timeout budget. The remaining entries stay
+  queued for the next session.
+* Total wall-clock cap: ``HINDSIGHT_DRAIN_BUDGET_S`` (default 4s) so
+  drain never blocks SessionStart longer than the upstream
+  hook timeout permits.
+
+Standalone usage::
+
+    python3 drain_pending.py        # one-shot drain, prints summary
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import time
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from lib.client import HindsightClient
+from lib.config import debug_log, load_config
+from lib.pending import (
+    MAX_ATTEMPTS,
+    delete_entry,
+    iter_entries,
+    mark_dead,
+    update_attempt,
+)
+
+
+STALL_THRESHOLD = 3
+
+
+def _per_entry_timeout() -> int:
+    raw = os.environ.get("HINDSIGHT_DRAIN_TIMEOUT", "5")
+    try:
+        v = int(raw)
+        return max(1, v)
+    except ValueError:
+        return 5
+
+
+def _budget_seconds() -> float:
+    raw = os.environ.get("HINDSIGHT_DRAIN_BUDGET_S", "4")
+    try:
+        v = float(raw)
+        return max(0.5, v)
+    except ValueError:
+        return 4.0
+
+
+def _retry_one(entry: dict, timeout: int) -> None:
+    """POST a single queued retain. Raises on failure."""
+    client = HindsightClient(entry["api_url"], entry.get("api_token"))
+    client.retain(
+        bank_id=entry["bank_id"],
+        content=entry["content"],
+        document_id=entry.get("document_id", "conversation"),
+        context=entry.get("context"),
+        metadata=entry.get("metadata") or {},
+        tags=entry.get("tags"),
+        timeout=timeout,
+    )
+
+
+def drain(config: dict | None = None) -> dict:
+    """Walk the pending-retains directory and retry each entry.
+
+    Returns a summary dict::
+
+        {"drained": int,   # successful retries (entries deleted)
+         "retried": int,   # failures kept for next session
+         "dead":    int,   # entries promoted to .dead this run
+         "stalled": bool,  # stall guard tripped
+         "budget_exceeded": bool}
+    """
+    config = config or load_config()
+    timeout = _per_entry_timeout()
+    budget = _budget_seconds()
+    started = time.monotonic()
+
+    summary = {
+        "drained": 0,
+        "retried": 0,
+        "dead": 0,
+        "stalled": False,
+        "budget_exceeded": False,
+    }
+
+    entries = iter_entries()
+    if not entries:
+        debug_log(config, "drain_pending: queue empty")
+        return summary
+
+    debug_log(config, f"drain_pending: {len(entries)} entries to retry")
+
+    consecutive_failures = 0
+    last_error_class: str | None = None
+
+    for path, entry in entries:
+        if time.monotonic() - started > budget:
+            summary["budget_exceeded"] = True
+            debug_log(config, "drain_pending: total budget exceeded, stopping")
+            break
+
+        try:
+            _retry_one(entry, timeout=timeout)
+        except Exception as e:
+            err_class = type(e).__name__
+            if err_class == last_error_class:
+                consecutive_failures += 1
+            else:
+                consecutive_failures = 1
+                last_error_class = err_class
+
+            attempts = int(entry.get("attempt_count", 1))
+            if attempts >= MAX_ATTEMPTS:
+                marker = mark_dead(path, entry)
+                summary["dead"] += 1
+                print(
+                    f"[Hindsight] drain_pending: entry exceeded {MAX_ATTEMPTS} "
+                    f"attempts, marking dead at {marker} (last error: {err_class}: {e})",
+                    file=sys.stderr,
+                )
+            else:
+                update_attempt(path, entry, e)
+                summary["retried"] += 1
+                debug_log(
+                    config,
+                    f"drain_pending: retry {attempts}/{MAX_ATTEMPTS} failed for {path} ({err_class}: {e})",
+                )
+
+            if consecutive_failures >= STALL_THRESHOLD:
+                summary["stalled"] = True
+                print(
+                    f"[Hindsight] drain_pending: {consecutive_failures} consecutive "
+                    f"failures with {err_class}, stalling drain. Remaining entries "
+                    f"stay queued.",
+                    file=sys.stderr,
+                )
+                break
+            continue
+
+        # Success — delete the entry.
+        delete_entry(path)
+        summary["drained"] += 1
+        consecutive_failures = 0
+        last_error_class = None
+
+    return summary
+
+
+def main() -> int:
+    config = load_config()
+    summary = drain(config)
+    if summary["drained"] or summary["retried"] or summary["dead"]:
+        print(
+            f"[Hindsight] drain_pending: "
+            f"drained={summary['drained']} retried={summary['retried']} "
+            f"dead={summary['dead']} "
+            f"stalled={summary['stalled']} budget_exceeded={summary['budget_exceeded']}",
+            file=sys.stderr,
+        )
+    # Non-zero only when we promoted entries to .dead — that's the
+    # operator-visible signal. Plain retry-still-pending isn't an error,
+    # the next SessionStart picks them up.
+    return 1 if summary["dead"] else 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except Exception as e:
+        print(f"[Hindsight] drain_pending unexpected error: {e}", file=sys.stderr)
+        sys.exit(2)

--- a/vendor/hindsight-memory/scripts/lib/pending.py
+++ b/vendor/hindsight-memory/scripts/lib/pending.py
@@ -1,0 +1,218 @@
+"""Persistent queue for failed retain payloads.
+
+When a SessionEnd retain fails, the only on-disk record of the turn's
+memory is the just-closed transcript — and the agent thinks it was
+persisted. To prevent silent data loss (#1071), session_end.py
+serializes the *exact retain payload* it would have POSTed into
+``~/.hindsight/pending-retains/<unix-ms>-<short-uuid>.json``. The next
+SessionStart drains the directory: oldest first, success deletes,
+failure bumps an attempt counter (up to MAX_ATTEMPTS) and leaves the
+entry for the run after that.
+
+Layout
+------
+``~/.hindsight/pending-retains/`` (mode 0700, may contain sensitive
+memory payloads).
+
+Inside a Switchroom docker agent, ``$HOME`` is the agent UID's home
+inside the container, which is NOT a bind-mounted volume. The queue
+therefore survives session-to-session within a container's lifetime
+(the common case: claude session ends → container keeps running → next
+session drains) but NOT container recreate. That's deliberate: this is
+a rescue queue for transient retain failures, not a long-term DLQ.
+If the upstream is broken long enough that the agent container gets
+recreated, the operator has bigger problems and ``switchroom doctor``
+already surfaced the backlog.
+Each entry is a JSON file ``<unix-ms>-<short-uuid>.json`` containing::
+
+    {
+      "schema": 1,
+      "api_url":     "<resolved Hindsight URL at time of failure>",
+      "api_token":   "<bearer token or null>",
+      "bank_id":     "<derived bank id>",
+      "document_id": "<retain document id>",
+      "content":     "<formatted transcript>",
+      "context":     "<retainContext>",
+      "metadata":    {...},
+      "tags":        [...] or null,
+      "failed_at":   "<ISO-8601 UTC>",
+      "error_class": "<exception class name>",
+      "error_message": "<str(e)>",
+      "attempt_count": 1
+    }
+
+The file is written via ``write tmp + rename`` so concurrent agents
+sharing ``$HOME`` (legacy installs) never observe a half-written entry.
+
+Bounded directory
+-----------------
+``MAX_ENTRIES`` (1000) caps the queue. When full, ``enqueue()`` refuses
+the entry and returns ``None`` — the caller logs loudly and the operator
+is expected to drain manually. A chronically full queue means upstream
+is broken for a long time; piling on more entries doesn't help.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+import uuid
+from typing import Optional
+
+
+SCHEMA = 1
+MAX_ENTRIES = 1000
+MAX_ATTEMPTS = 5
+
+
+def pending_dir() -> str:
+    """Return the pending-retains directory path.
+
+    Override with ``HINDSIGHT_PENDING_DIR`` for tests. Default:
+    ``$HOME/.hindsight/pending-retains/``.
+    """
+    override = os.environ.get("HINDSIGHT_PENDING_DIR")
+    if override:
+        return override
+    return os.path.join(os.path.expanduser("~"), ".hindsight", "pending-retains")
+
+
+def _ensure_dir() -> str:
+    """Create the queue dir with mode 0700 if missing. Return its path."""
+    d = pending_dir()
+    if not os.path.isdir(d):
+        os.makedirs(d, mode=0o700, exist_ok=True)
+    else:
+        # Tighten perms if a previous run created it with looser bits.
+        try:
+            mode = os.stat(d).st_mode & 0o777
+            if mode != 0o700:
+                os.chmod(d, 0o700)
+        except OSError:
+            pass
+    return d
+
+
+def _list_entries(d: str) -> list[str]:
+    """Return sorted filenames (oldest first by lexicographic order on
+    the ``<unix-ms>-<uuid>.json`` filename pattern).
+    """
+    try:
+        names = [n for n in os.listdir(d) if n.endswith(".json")]
+    except FileNotFoundError:
+        return []
+    names.sort()
+    return names
+
+
+def count() -> int:
+    """Number of pending entries. Safe to call when dir doesn't exist."""
+    d = pending_dir()
+    return len(_list_entries(d))
+
+
+def enqueue(payload: dict, error: BaseException) -> Optional[str]:
+    """Persist a failed retain payload.
+
+    ``payload`` carries the exact arguments that would have gone to
+    ``client.retain()`` plus connection info (``api_url``, ``api_token``)
+    so the drainer can rebuild the client without re-resolving config.
+
+    Returns the absolute path of the written entry, or ``None`` if the
+    queue is full (``MAX_ENTRIES`` reached). Atomic: writes ``<name>.tmp``
+    then renames to ``<name>``.
+    """
+    d = _ensure_dir()
+    if len(_list_entries(d)) >= MAX_ENTRIES:
+        return None
+
+    entry = dict(payload)
+    entry["schema"] = SCHEMA
+    entry["failed_at"] = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+    entry["error_class"] = type(error).__name__
+    entry["error_message"] = str(error)
+    entry.setdefault("attempt_count", 1)
+
+    ts_ms = int(time.time() * 1000)
+    short_uuid = uuid.uuid4().hex[:12]
+    name = f"{ts_ms}-{short_uuid}.json"
+    final = os.path.join(d, name)
+    tmp = final + ".tmp"
+
+    with open(tmp, "w", encoding="utf-8") as f:
+        json.dump(entry, f, ensure_ascii=False)
+    os.chmod(tmp, 0o600)
+    os.rename(tmp, final)
+    return final
+
+
+def iter_entries() -> list[tuple[str, dict]]:
+    """Return ``[(path, entry_dict), ...]`` oldest first.
+
+    Unreadable / malformed files are skipped silently — the drainer
+    handles its own logging. We never crash the SessionStart hook on
+    a corrupt entry.
+    """
+    d = pending_dir()
+    out: list[tuple[str, dict]] = []
+    for name in _list_entries(d):
+        p = os.path.join(d, name)
+        try:
+            with open(p, encoding="utf-8") as f:
+                out.append((p, json.load(f)))
+        except (OSError, json.JSONDecodeError):
+            continue
+    return out
+
+
+def delete_entry(path: str) -> bool:
+    """Remove a queue entry. Returns True on success, False otherwise."""
+    try:
+        os.remove(path)
+        return True
+    except OSError:
+        return False
+
+
+def update_attempt(path: str, entry: dict, error: BaseException) -> bool:
+    """Persist an updated attempt count + error info back to ``path``.
+
+    Atomic: writes ``<path>.tmp`` then renames. Returns True on success.
+    """
+    entry["attempt_count"] = int(entry.get("attempt_count", 1)) + 1
+    entry["last_attempt_at"] = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+    entry["error_class"] = type(error).__name__
+    entry["error_message"] = str(error)
+    try:
+        tmp = path + ".tmp"
+        with open(tmp, "w", encoding="utf-8") as f:
+            json.dump(entry, f, ensure_ascii=False)
+        os.chmod(tmp, 0o600)
+        os.rename(tmp, path)
+        return True
+    except OSError:
+        return False
+
+
+def mark_dead(path: str, entry: dict) -> Optional[str]:
+    """Convert an entry that exceeded ``MAX_ATTEMPTS`` into a permanent
+    failure marker. Renames ``<path>`` to ``<path>.dead`` so the queue
+    no longer drains it but operators can still inspect.
+
+    Returns the marker path, or ``None`` if the rename failed.
+    """
+    entry["dead_at"] = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+    dead_path = path + ".dead"
+    try:
+        # Best-effort: write the final state first so the marker shows
+        # the death timestamp + last error.
+        tmp = path + ".tmp"
+        with open(tmp, "w", encoding="utf-8") as f:
+            json.dump(entry, f, ensure_ascii=False)
+        os.chmod(tmp, 0o600)
+        os.rename(tmp, path)
+        os.rename(path, dead_path)
+        return dead_path
+    except OSError:
+        return None

--- a/vendor/hindsight-memory/scripts/retain.py
+++ b/vendor/hindsight-memory/scripts/retain.py
@@ -69,12 +69,27 @@ def read_transcript(transcript_path: str) -> list:
     return messages
 
 
-def run_retain(hook_input: dict, force: bool = False) -> None:
+def run_retain(hook_input: dict, force: bool = False) -> dict:
+    """Run the auto-retain flow.
+
+    Returns a status dict::
+
+        {"status": "ok" | "skipped" | "failed",
+         "payload": {...},   # only when status == "failed"
+         "error":   Exception}  # only when status == "failed"
+
+    The ``payload`` field carries the exact arguments that were going to
+    be sent to ``client.retain()`` plus the resolved ``api_url`` /
+    ``api_token`` — sufficient to retry the call from a different
+    process (the SessionStart drainer, see ``drain_pending.py`` and
+    ``lib/pending.py``). ``status="skipped"`` is the normal early-exit
+    cases (auto-retain disabled, empty transcript, throttled chunk).
+    """
     config = load_config()
 
     if not config.get("autoRetain"):
         debug_log(config, "Auto-retain disabled, exiting")
-        return
+        return {"status": "skipped", "reason": "autoRetain disabled"}
 
     debug_log(config, f"Retain hook_input keys: {list(hook_input.keys())} force={force}")
 
@@ -85,7 +100,7 @@ def run_retain(hook_input: dict, force: bool = False) -> None:
     all_messages = read_transcript(transcript_path)
     if not all_messages:
         debug_log(config, "No messages in transcript, skipping retain")
-        return
+        return {"status": "skipped", "reason": "empty transcript"}
 
     debug_log(config, f"Read {len(all_messages)} messages from transcript")
 
@@ -101,7 +116,7 @@ def run_retain(hook_input: dict, force: bool = False) -> None:
         if turn_count % retain_every_n != 0:
             next_at = ((turn_count // retain_every_n) + 1) * retain_every_n
             debug_log(config, f"Turn {turn_count}/{retain_every_n}, skipping retain (next at turn {next_at})")
-            return
+            return {"status": "skipped", "reason": "throttled"}
 
     if retain_mode == "chunked" and retain_every_n > 1:
         # Sliding window: N turns + configured overlap
@@ -127,7 +142,7 @@ def run_retain(hook_input: dict, force: bool = False) -> None:
 
     if not transcript:
         debug_log(config, "Empty transcript after formatting, skipping retain")
-        return
+        return {"status": "skipped", "reason": "empty transcript after formatting"}
 
     # Resolve API URL
     def _dbg(*a):
@@ -137,14 +152,14 @@ def run_retain(hook_input: dict, force: bool = False) -> None:
         api_url = get_api_url(config, debug_fn=_dbg, allow_daemon_start=True)
     except RuntimeError as e:
         print(f"[Hindsight] {e}", file=sys.stderr)
-        return
+        return {"status": "failed", "error": e, "payload": None}
 
     api_token = config.get("hindsightApiToken")
     try:
         client = HindsightClient(api_url, api_token)
     except ValueError as e:
         print(f"[Hindsight] Invalid API URL: {e}", file=sys.stderr)
-        return
+        return {"status": "failed", "error": e, "payload": None}
 
     # Derive bank ID and ensure mission
     bank_id = derive_bank_id(hook_input, config)
@@ -216,20 +231,37 @@ def run_retain(hook_input: dict, force: bool = False) -> None:
     if tags:
         debug_log(config, f"Tags: {tags}")
 
+    # Build the full payload up-front so we can hand it to the pending-
+    # retains queue verbatim if the POST fails. The payload mirrors the
+    # client.retain() kwargs plus connection info (api_url, api_token)
+    # so the drainer can reconstruct the call from a different process.
+    payload = {
+        "api_url": api_url,
+        "api_token": api_token,
+        "bank_id": bank_id,
+        "content": transcript,
+        "document_id": document_id,
+        "context": config.get("retainContext", "claude-code"),
+        "metadata": metadata,
+        "tags": tags,
+    }
+
     # POST to Hindsight retain API
     try:
         response = client.retain(
             bank_id=bank_id,
             content=transcript,
             document_id=document_id,
-            context=config.get("retainContext", "claude-code"),
+            context=payload["context"],
             metadata=metadata,
             tags=tags,
             timeout=15,
         )
         debug_log(config, f"Retain response: {json.dumps(response)[:200]}")
+        return {"status": "ok", "response": response}
     except Exception as e:
         print(f"[Hindsight] Retain failed: {e}", file=sys.stderr)
+        return {"status": "failed", "error": e, "payload": payload}
 
 
 def main():

--- a/vendor/hindsight-memory/scripts/session_end.py
+++ b/vendor/hindsight-memory/scripts/session_end.py
@@ -1,10 +1,29 @@
 #!/usr/bin/env python3
-"""SessionEnd hook: daemon cleanup.
+"""SessionEnd hook: final retain + daemon cleanup.
 
-Fires once when a Claude Code session terminates. If the plugin
-auto-started a hindsight-embed daemon, this is where we stop it.
+Fires once when a Claude Code session terminates. Two jobs:
 
-Port of: Openclaw's service.stop() in index.js
+1. **Final retain.** Forces a retain pass so short sessions (fewer
+   turns than ``retainEveryNTurns``) still land on disk.
+2. **Daemon stop.** Tears down the auto-started hindsight-embed
+   daemon, if any.
+
+Silent data-loss guard (#1071)
+------------------------------
+Before this change the final retain would print its error to stderr
+and exit 0 — the operator sees nothing in journald (already noisy),
+the agent thinks the turn was saved, the *next* session can't recall
+the turn. Silent memory loss.
+
+Now: on retain failure we serialize the full retain payload to
+``~/.hindsight/pending-retains/<unix-ms>-<uuid>.json`` (see
+``lib/pending.py``) and exit non-zero so ``bin/run-hook.sh`` routes
+the failure through the ``switchroom issues`` sink (#424). The next
+SessionStart drains the queue (see ``drain_pending.py``).
+
+Pairs with #1070 (recall.py exit-code fix) — same threat class.
+
+Port of: Openclaw's service.stop() in index.js.
 """
 
 import json
@@ -15,9 +34,19 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 from lib.config import debug_log, load_config
 from lib.daemon import stop_daemon
+from lib.pending import MAX_ENTRIES, count as pending_count, enqueue as pending_enqueue
 
 
-def main():
+# Exit codes:
+#   0 — success (or retain skipped for benign reasons)
+#   1 — retain failed AND was queued to pending-retains (recoverable)
+#   2 — retain failed AND the queue rejected it (chronic backlog)
+EXIT_OK = 0
+EXIT_QUEUED = 1
+EXIT_DROPPED = 2
+
+
+def main() -> int:
     config = load_config()
 
     # Consume stdin
@@ -28,25 +57,66 @@ def main():
 
     debug_log(config, f"SessionEnd hook, reason: {hook_input.get('reason', 'unknown')}")
 
+    exit_code = EXIT_OK
+
     # Force a final retain before stopping the daemon — guarantees short sessions
     # (fewer turns than retainEveryNTurns) still land on disk.
     if config.get("autoRetain") and hook_input.get("transcript_path"):
         try:
             from retain import run_retain
-            run_retain(hook_input, force=True)
-        except Exception as e:
-            print(f"[Hindsight] SessionEnd final retain error: {e}", file=sys.stderr)
 
-    # Stop daemon if we started it
+            result = run_retain(hook_input, force=True) or {}
+        except Exception as e:
+            # Belt-and-braces — run_retain itself shouldn't raise, but
+            # if it does we treat it the same as a failed POST: queue
+            # what we can (nothing, since we have no payload) and exit
+            # non-zero so the issue sink picks it up.
+            print(f"[Hindsight] SessionEnd final retain error: {e}", file=sys.stderr)
+            result = {"status": "failed", "error": e, "payload": None}
+
+        if result.get("status") == "failed":
+            payload = result.get("payload")
+            err = result.get("error") or RuntimeError("unknown retain failure")
+            if payload:
+                queued = pending_enqueue(payload, err)
+                if queued is None:
+                    print(
+                        f"[Hindsight] pending-retains queue full ({MAX_ENTRIES} entries); "
+                        f"dropping this retain. Operator: drain manually, then run "
+                        f"`switchroom doctor`.",
+                        file=sys.stderr,
+                    )
+                    exit_code = EXIT_DROPPED
+                else:
+                    debug_log(config, f"SessionEnd retain queued to {queued} (pending={pending_count()})")
+                    print(
+                        f"[Hindsight] SessionEnd retain failed: queued to pending-retains "
+                        f"(error: {type(err).__name__}: {err}). Will retry on next "
+                        f"SessionStart.",
+                        file=sys.stderr,
+                    )
+                    exit_code = EXIT_QUEUED
+            else:
+                # No payload to queue — the failure happened before we
+                # finished building one (e.g. URL resolution).
+                exit_code = EXIT_QUEUED
+
+    # Stop daemon if we started it. Always runs, even on retain failure,
+    # so we don't leak a daemon process.
     def _dbg(*a):
         debug_log(config, *a)
 
     stop_daemon(config, debug_fn=_dbg)
+    return exit_code
 
 
 if __name__ == "__main__":
     try:
-        main()
+        sys.exit(main())
     except Exception as e:
         print(f"[Hindsight] SessionEnd error: {e}", file=sys.stderr)
-        sys.exit(0)
+        # Surface the unexpected failure to the issue sink rather than
+        # swallowing it (per #424). Stays non-zero in both debug and
+        # non-debug paths so the recall.py-style silent-failure trap
+        # (#1070) doesn't recur here.
+        sys.exit(2)

--- a/vendor/hindsight-memory/scripts/session_start.py
+++ b/vendor/hindsight-memory/scripts/session_start.py
@@ -46,10 +46,26 @@ def main():
         debug_log(config, f"Hindsight server reachable at {api_url}")
     except (RuntimeError, ValueError) as e:
         # Server not running — kick off background pre-start so it's ready
-        # by the time the first recall or retain hook fires.
+        # by the time the first recall or retain hook fires. Skip the
+        # drain here: with no server to talk to, every retry would just
+        # bump attempt counters and burn the SessionStart budget.
         debug_log(config, f"Hindsight not running, initiating background pre-start: {e}")
         prestart_daemon_background(config, debug_fn=_dbg)
         return
+
+    # Drain any retains that session_end.py queued on failure (#1071).
+    # Bounded by HINDSIGHT_DRAIN_BUDGET_S so a slow upstream can't pin
+    # the SessionStart hook. The drain is best-effort — failures stay
+    # queued for the next session, dead entries surface via
+    # `switchroom doctor`.
+    try:
+        from drain_pending import drain as drain_pending_retains
+
+        drain_pending_retains(config)
+    except Exception as e:
+        # Never let the drain break session start. Issue sink picks
+        # this up via run-hook.sh — see exit-code path in __main__.
+        debug_log(config, f"drain_pending unexpected error (ignored): {e}")
 
 
 if __name__ == "__main__":

--- a/vendor/hindsight-memory/tests/test_drain_pending.py
+++ b/vendor/hindsight-memory/tests/test_drain_pending.py
@@ -1,0 +1,192 @@
+"""Tests for drain_pending.drain() (#1071)."""
+
+import json
+import os
+import sys
+import tempfile
+import time
+import unittest
+import urllib.error
+from unittest.mock import patch
+
+SCRIPTS_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "scripts"))
+if SCRIPTS_DIR not in sys.path:
+    sys.path.insert(0, SCRIPTS_DIR)
+
+
+class FakeOk:
+    """Minimal urlopen() context-manager stand-in for a 200 OK."""
+
+    status = 200
+
+    def __init__(self, body: bytes = b'{"ok": true}'):
+        self._body = body
+
+    def read(self):
+        return self._body
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_):
+        return False
+
+
+def _seed_entry(pending_dir: str, document_id: str = "doc-x", attempt: int = 1) -> str:
+    os.makedirs(pending_dir, mode=0o700, exist_ok=True)
+    ts_ms = int(time.time() * 1000)
+    name = f"{ts_ms}-{document_id}.json"
+    path = os.path.join(pending_dir, name)
+    payload = {
+        "schema": 1,
+        "api_url": "http://fake:9077",
+        "api_token": None,
+        "bank_id": "bank-1",
+        "content": "user: hi\nassistant: hi back",
+        "document_id": document_id,
+        "context": "claude-code",
+        "metadata": {},
+        "tags": None,
+        "failed_at": "2026-05-12T00:00:00Z",
+        "error_class": "URLError",
+        "error_message": "Connection refused",
+        "attempt_count": attempt,
+    }
+    with open(path, "w") as f:
+        json.dump(payload, f)
+    return path
+
+
+class DrainPendingTest(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.mkdtemp(prefix="hindsight-drain-test-")
+        self._pending = os.path.join(self._tmp, "pending-retains")
+        # Each test resets modules so module-level config caching can't
+        # bleed across.
+        for n in ("drain_pending", "lib.pending"):
+            sys.modules.pop(n, None)
+        self._env = patch.dict(
+            os.environ,
+            {
+                "HINDSIGHT_PENDING_DIR": self._pending,
+                "HINDSIGHT_DRAIN_TIMEOUT": "2",
+                "HINDSIGHT_DRAIN_BUDGET_S": "60",
+            },
+            clear=False,
+        )
+        self._env.start()
+
+    def tearDown(self):
+        self._env.stop()
+        import shutil
+
+        shutil.rmtree(self._tmp, ignore_errors=True)
+        for n in ("drain_pending", "lib.pending"):
+            sys.modules.pop(n, None)
+
+    def test_drain_empty_queue_is_noop(self):
+        import drain_pending
+
+        summary = drain_pending.drain({})
+        self.assertEqual(summary["drained"], 0)
+        self.assertEqual(summary["retried"], 0)
+        self.assertEqual(summary["dead"], 0)
+        self.assertFalse(summary["stalled"])
+        self.assertFalse(summary["budget_exceeded"])
+
+    def test_drain_success_deletes_entry(self):
+        path = _seed_entry(self._pending)
+        import drain_pending
+
+        with patch("urllib.request.urlopen", return_value=FakeOk()):
+            summary = drain_pending.drain({})
+        self.assertEqual(summary["drained"], 1)
+        self.assertEqual(summary["retried"], 0)
+        self.assertFalse(os.path.exists(path))
+
+    def test_drain_failure_bumps_attempt_count(self):
+        path = _seed_entry(self._pending, attempt=1)
+        import drain_pending
+
+        def boom(*a, **kw):
+            raise urllib.error.URLError("still down")
+
+        with patch("urllib.request.urlopen", side_effect=boom):
+            summary = drain_pending.drain({})
+        # Single entry → consecutive_failures hits 1, threshold is 3,
+        # so we don't stall — but we only had one entry to try.
+        self.assertEqual(summary["drained"], 0)
+        self.assertEqual(summary["retried"], 1)
+        self.assertTrue(os.path.exists(path))
+        with open(path) as f:
+            entry = json.load(f)
+        self.assertEqual(entry["attempt_count"], 2)
+        self.assertIn("last_attempt_at", entry)
+
+    def test_drain_max_attempts_marks_dead(self):
+        from lib.pending import MAX_ATTEMPTS
+
+        path = _seed_entry(self._pending, attempt=MAX_ATTEMPTS)
+        import drain_pending
+
+        def boom(*a, **kw):
+            raise urllib.error.URLError("still down")
+
+        with patch("urllib.request.urlopen", side_effect=boom):
+            summary = drain_pending.drain({})
+        self.assertEqual(summary["dead"], 1)
+        self.assertFalse(os.path.exists(path))
+        self.assertTrue(os.path.exists(path + ".dead"))
+
+    def test_drain_stall_guard_stops_after_threshold(self):
+        # Seed 10 entries; with a same-error-class stream, the stall
+        # guard should trip at STALL_THRESHOLD (3) and leave the rest.
+        from drain_pending import STALL_THRESHOLD
+
+        for i in range(10):
+            _seed_entry(self._pending, document_id=f"doc-{i:02d}")
+
+        import drain_pending
+
+        def boom(*a, **kw):
+            raise urllib.error.URLError("permanent")
+
+        with patch("urllib.request.urlopen", side_effect=boom):
+            summary = drain_pending.drain({})
+
+        self.assertTrue(summary["stalled"])
+        self.assertEqual(summary["retried"], STALL_THRESHOLD)
+        self.assertEqual(summary["drained"], 0)
+        # 10 - STALL_THRESHOLD entries should remain untouched (still
+        # at attempt_count == 1)
+        remaining = [n for n in os.listdir(self._pending) if n.endswith(".json")]
+        self.assertEqual(len(remaining), 10)
+
+    def test_drain_mixed_success_failure(self):
+        # Three entries: server returns alternating ok/fail/ok.
+        _seed_entry(self._pending, document_id="doc-a")
+        time.sleep(0.005)
+        _seed_entry(self._pending, document_id="doc-b")
+        time.sleep(0.005)
+        _seed_entry(self._pending, document_id="doc-c")
+
+        call_idx = {"n": 0}
+
+        def maybe_ok(*a, **kw):
+            i = call_idx["n"]
+            call_idx["n"] += 1
+            if i == 1:
+                raise urllib.error.URLError("middle fail")
+            return FakeOk()
+
+        import drain_pending
+
+        with patch("urllib.request.urlopen", side_effect=maybe_ok):
+            summary = drain_pending.drain({})
+
+        self.assertEqual(summary["drained"], 2)
+        self.assertEqual(summary["retried"], 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/vendor/hindsight-memory/tests/test_pending.py
+++ b/vendor/hindsight-memory/tests/test_pending.py
@@ -1,0 +1,152 @@
+"""Tests for the pending-retains persistent queue (#1071)."""
+
+import json
+import os
+import sys
+import time
+import unittest
+from unittest.mock import patch
+
+SCRIPTS_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "scripts"))
+if SCRIPTS_DIR not in sys.path:
+    sys.path.insert(0, SCRIPTS_DIR)
+
+import lib.pending as pending_mod  # noqa: E402
+
+
+class PendingQueueTest(unittest.TestCase):
+    def setUp(self):
+        # Use a temp dir scoped per-test so concurrent runs don't
+        # collide. The module reads HINDSIGHT_PENDING_DIR on every call,
+        # not at import time — no reload needed.
+        import tempfile
+
+        self._tmp = tempfile.mkdtemp(prefix="hindsight-pending-test-")
+        self._dir = os.path.join(self._tmp, "pending-retains")
+        os.environ["HINDSIGHT_PENDING_DIR"] = self._dir
+
+    def tearDown(self):
+        import shutil
+
+        shutil.rmtree(self._tmp, ignore_errors=True)
+        os.environ.pop("HINDSIGHT_PENDING_DIR", None)
+
+    def _sample_payload(self, document_id: str = "doc-1") -> dict:
+        return {
+            "api_url": "http://fake:9077",
+            "api_token": None,
+            "bank_id": "test-bank",
+            "content": "user: hello\nassistant: hi",
+            "document_id": document_id,
+            "context": "claude-code",
+            "metadata": {"session_id": "sess-1"},
+            "tags": None,
+        }
+
+    def test_enqueue_creates_dir_with_mode_0700(self):
+        self.assertFalse(os.path.isdir(self._dir))
+        pending_mod.enqueue(self._sample_payload(), RuntimeError("boom"))
+        self.assertTrue(os.path.isdir(self._dir))
+        mode = os.stat(self._dir).st_mode & 0o777
+        self.assertEqual(mode, 0o700)
+
+    def test_enqueue_writes_payload_and_error_metadata(self):
+        path = pending_mod.enqueue(self._sample_payload(), ValueError("nope"))
+        self.assertIsNotNone(path)
+        self.assertTrue(os.path.isfile(path))
+        with open(path) as f:
+            entry = json.load(f)
+        self.assertEqual(entry["bank_id"], "test-bank")
+        self.assertEqual(entry["content"], "user: hello\nassistant: hi")
+        self.assertEqual(entry["document_id"], "doc-1")
+        self.assertEqual(entry["error_class"], "ValueError")
+        self.assertEqual(entry["error_message"], "nope")
+        self.assertEqual(entry["attempt_count"], 1)
+        self.assertIn("failed_at", entry)
+        self.assertEqual(entry["schema"], pending_mod.SCHEMA)
+
+    def test_enqueue_filename_is_unix_ms_uuid(self):
+        path = pending_mod.enqueue(self._sample_payload(), RuntimeError("boom"))
+        name = os.path.basename(path)
+        self.assertTrue(name.endswith(".json"))
+        head = name[: -len(".json")]
+        ts_part, uuid_part = head.split("-", 1)
+        self.assertTrue(ts_part.isdigit())
+        # Filename ts should be within 10 s of now
+        now_ms = int(time.time() * 1000)
+        self.assertLess(abs(now_ms - int(ts_part)), 10_000)
+        self.assertEqual(len(uuid_part), 12)
+
+    def test_enqueue_atomic_no_tmp_left_behind(self):
+        pending_mod.enqueue(self._sample_payload(), RuntimeError("boom"))
+        names = sorted(os.listdir(self._dir))
+        self.assertEqual(len(names), 1)
+        self.assertFalse(any(n.endswith(".tmp") for n in names))
+
+    def test_enqueue_returns_none_when_full(self):
+        # Pre-populate with MAX_ENTRIES dummy files.
+        os.makedirs(self._dir, mode=0o700)
+        for i in range(pending_mod.MAX_ENTRIES):
+            with open(os.path.join(self._dir, f"{i:013d}-aaaaaaaaaaaa.json"), "w") as f:
+                json.dump({"placeholder": True}, f)
+        result = pending_mod.enqueue(self._sample_payload(), RuntimeError("boom"))
+        self.assertIsNone(result)
+        # Count unchanged
+        self.assertEqual(pending_mod.count(), pending_mod.MAX_ENTRIES)
+
+    def test_iter_entries_ordered_oldest_first(self):
+        p1 = pending_mod.enqueue(self._sample_payload("doc-1"), RuntimeError("e1"))
+        time.sleep(0.005)
+        p2 = pending_mod.enqueue(self._sample_payload("doc-2"), RuntimeError("e2"))
+        time.sleep(0.005)
+        p3 = pending_mod.enqueue(self._sample_payload("doc-3"), RuntimeError("e3"))
+        entries = pending_mod.iter_entries()
+        paths = [e[0] for e in entries]
+        self.assertEqual(paths, [p1, p2, p3])
+
+    def test_iter_entries_skips_malformed(self):
+        os.makedirs(self._dir, mode=0o700)
+        # Good
+        good = pending_mod.enqueue(self._sample_payload(), RuntimeError("ok"))
+        # Bad (not JSON)
+        with open(os.path.join(self._dir, f"{int(time.time() * 1000) + 1}-bad.json"), "w") as f:
+            f.write("not json")
+        entries = pending_mod.iter_entries()
+        paths = [e[0] for e in entries]
+        self.assertIn(good, paths)
+        # The bad file is skipped, not raised
+        self.assertEqual(len(entries), 1)
+
+    def test_update_attempt_bumps_count_atomically(self):
+        path = pending_mod.enqueue(self._sample_payload(), RuntimeError("first"))
+        entries = pending_mod.iter_entries()
+        _, entry = entries[0]
+        self.assertEqual(entry["attempt_count"], 1)
+        ok = pending_mod.update_attempt(path, entry, RuntimeError("second"))
+        self.assertTrue(ok)
+        with open(path) as f:
+            reread = json.load(f)
+        self.assertEqual(reread["attempt_count"], 2)
+        self.assertEqual(reread["error_message"], "second")
+        self.assertIn("last_attempt_at", reread)
+
+    def test_mark_dead_renames_to_dot_dead(self):
+        path = pending_mod.enqueue(self._sample_payload(), RuntimeError("boom"))
+        entries = pending_mod.iter_entries()
+        _, entry = entries[0]
+        dead = pending_mod.mark_dead(path, entry)
+        self.assertTrue(dead.endswith(".dead"))
+        self.assertFalse(os.path.exists(path))
+        self.assertTrue(os.path.isfile(dead))
+        with open(dead) as f:
+            reread = json.load(f)
+        self.assertIn("dead_at", reread)
+        # iter_entries no longer surfaces .dead files
+        self.assertEqual(pending_mod.iter_entries(), [])
+
+    def test_count_safe_when_dir_missing(self):
+        self.assertEqual(pending_mod.count(), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/vendor/hindsight-memory/tests/test_session_end_pending.py
+++ b/vendor/hindsight-memory/tests/test_session_end_pending.py
@@ -1,0 +1,205 @@
+"""End-to-end tests for the session_end pending-queue path (#1071).
+
+Covers:
+  - retain success → queue stays empty, exit 0
+  - retain failure → exactly one entry written, payload faithful, exit non-zero
+  - daemon stop still runs even when retain fails
+"""
+
+import importlib
+import io
+import json
+import os
+import sys
+import tempfile
+import unittest
+import urllib.error
+from unittest.mock import patch
+
+SCRIPTS_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "scripts"))
+if SCRIPTS_DIR not in sys.path:
+    sys.path.insert(0, SCRIPTS_DIR)
+
+
+class FakeHTTPResponse:
+    """Minimal urlopen() stand-in (mirror of conftest.FakeHTTPResponse —
+    inlined so this module is importable under plain unittest)."""
+
+    def __init__(self, data: dict, status: int = 200):
+        self.status = status
+        self._data = json.dumps(data).encode()
+
+    def read(self):
+        return self._data
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_):
+        return False
+
+
+def _make_transcript(path: str) -> None:
+    """Minimal Claude-Code-format transcript that triggers a real retain."""
+    rows = [
+        {"type": "user", "message": {"role": "user", "content": "tell me a story"}},
+        {"type": "assistant", "message": {"role": "assistant", "content": "Once upon a time..."}},
+    ]
+    with open(path, "w") as f:
+        for r in rows:
+            f.write(json.dumps(r) + "\n")
+
+
+class SessionEndPendingTest(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.mkdtemp(prefix="hindsight-session-end-test-")
+        self._plugin_root = os.path.join(self._tmp, "plugin_root")
+        self._plugin_data = os.path.join(self._tmp, "plugin_data")
+        self._pending = os.path.join(self._tmp, "pending-retains")
+        self._home = os.path.join(self._tmp, "home")
+        os.makedirs(self._plugin_root)
+        os.makedirs(self._plugin_data)
+        os.makedirs(self._home)
+
+        # Settings — point at a fake URL the test can intercept.
+        settings = {
+            "autoRecall": False,
+            "autoRetain": True,
+            "retainEveryNTurns": 1,
+            "hindsightApiUrl": "http://fake-host:9077",
+            "bankId": "test-bank",
+        }
+        with open(os.path.join(self._plugin_root, "settings.json"), "w") as f:
+            json.dump(settings, f)
+
+        # Transcript that triggers retain.
+        self._transcript = os.path.join(self._tmp, "transcript.jsonl")
+        _make_transcript(self._transcript)
+
+        # Env setup.
+        self._env_patcher = patch.dict(
+            os.environ,
+            {
+                "CLAUDE_PLUGIN_ROOT": self._plugin_root,
+                "CLAUDE_PLUGIN_DATA": self._plugin_data,
+                "HINDSIGHT_PENDING_DIR": self._pending,
+                "HOME": self._home,
+            },
+            clear=False,
+        )
+        self._env_patcher.start()
+        # Strip any host HINDSIGHT_* env that would override settings.json.
+        for k in list(os.environ):
+            if k.startswith("HINDSIGHT_") and k not in (
+                "HINDSIGHT_PENDING_DIR",
+            ):
+                os.environ.pop(k, None)
+
+    def tearDown(self):
+        self._env_patcher.stop()
+        import shutil
+
+        shutil.rmtree(self._tmp, ignore_errors=True)
+
+    def _run_session_end(self, urlopen_side_effect):
+        """Invoke session_end.main() with the given urlopen side-effect.
+
+        Returns ``(exit_code, captured_stderr)``.
+        """
+        hook_input = {
+            "session_id": "sess-1",
+            "transcript_path": self._transcript,
+            "cwd": self._home,
+            "reason": "end",
+        }
+        stdin_data = io.StringIO(json.dumps(hook_input))
+        stderr_capture = io.StringIO()
+
+        # Force a fresh import — module-level state in session_end /
+        # retain / lib.* shouldn't leak between tests.
+        for mod_name in ("session_end", "retain", "lib.pending", "lib.daemon"):
+            sys.modules.pop(mod_name, None)
+
+        import session_end as session_end_mod  # noqa: WPS433
+
+        with (
+            patch("sys.stdin", stdin_data),
+            patch("sys.stderr", stderr_capture),
+            patch("urllib.request.urlopen", side_effect=urlopen_side_effect),
+            # daemon.stop_daemon is a no-op when we never started one,
+            # but stub it for hermetic-ness.
+            patch("session_end.stop_daemon", return_value=None),
+        ):
+            exit_code = session_end_mod.main()
+        return exit_code, stderr_capture.getvalue()
+
+    def test_successful_retain_leaves_queue_empty_and_exits_ok(self):
+        ok_response = FakeHTTPResponse({"items": [{"id": "abc"}]})
+        exit_code, _ = self._run_session_end(lambda *a, **kw: ok_response)
+        self.assertEqual(exit_code, 0)
+        # Queue should be empty (dir may not even exist)
+        if os.path.isdir(self._pending):
+            self.assertEqual([], os.listdir(self._pending))
+
+    def test_retain_http_failure_enqueues_payload_and_exits_nonzero(self):
+        # Raise an HTTPError on POST so retain.run_retain catches it
+        # and returns status=failed with payload.
+        def boom(*a, **kw):
+            raise urllib.error.URLError("Connection refused")
+
+        exit_code, stderr = self._run_session_end(boom)
+        # exit 1 == EXIT_QUEUED in session_end.py
+        self.assertEqual(exit_code, 1)
+        self.assertIn("queued to pending-retains", stderr)
+
+        # One entry in the queue
+        names = [n for n in os.listdir(self._pending) if n.endswith(".json")]
+        self.assertEqual(len(names), 1)
+
+        with open(os.path.join(self._pending, names[0])) as f:
+            entry = json.load(f)
+        self.assertEqual(entry["bank_id"], "test-bank")
+        self.assertEqual(entry["api_url"], "http://fake-host:9077")
+        self.assertIn("Once upon a time", entry["content"])
+        self.assertEqual(entry["attempt_count"], 1)
+        # error_class derives from the original urllib.error.URLError
+        self.assertIn("URLError", entry["error_class"])
+
+    def test_retain_failure_still_runs_daemon_stop(self):
+        def boom(*a, **kw):
+            raise urllib.error.URLError("nope")
+
+        # If session_end short-circuits before stop_daemon, this test
+        # catches the regression. We assert via a spy.
+        hook_input = {
+            "session_id": "sess-1",
+            "transcript_path": self._transcript,
+            "cwd": self._home,
+            "reason": "end",
+        }
+        stdin_data = io.StringIO(json.dumps(hook_input))
+        stderr_capture = io.StringIO()
+
+        for mod_name in ("session_end", "retain", "lib.pending", "lib.daemon"):
+            sys.modules.pop(mod_name, None)
+
+        import session_end as session_end_mod  # noqa: WPS433
+
+        call_log = {"stop_called": 0}
+
+        def fake_stop(config, debug_fn=None):
+            call_log["stop_called"] += 1
+
+        with (
+            patch("sys.stdin", stdin_data),
+            patch("sys.stderr", stderr_capture),
+            patch("urllib.request.urlopen", side_effect=boom),
+            patch("session_end.stop_daemon", side_effect=fake_stop),
+        ):
+            session_end_mod.main()
+
+        self.assertEqual(call_log["stop_called"], 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Closes #1071 (#472 finding #5, CRITICAL silent-data-loss).

Pre-fix, ``vendor/hindsight-memory/scripts/session_end.py`` printed retain failures to stderr and exited 0. The agent thought the final turn was saved; it wasn't; the next session couldn't recall it. Pure silent memory loss.

This change adds a persistent rescue queue at ``~/.hindsight/pending-retains/<unix-ms>-<uuid>.json`` (mode 0700) plus a SessionStart drainer. Pairs naturally with #1070 (recall.py exit-code fix) — same threat class (silent failure), complementary surfaces.

### What's new

- ``vendor/hindsight-memory/scripts/lib/pending.py`` — persistent queue: atomic ``write tmp + rename``, MAX_ENTRIES=1000 cap, attempt counter, ``.dead`` marker after MAX_ATTEMPTS=5.
- ``vendor/hindsight-memory/scripts/drain_pending.py`` — oldest-first drainer with HINDSIGHT_DRAIN_TIMEOUT (5s per entry), HINDSIGHT_DRAIN_BUDGET_S (4s total), and a 3-consecutive-failure stall guard so a broken upstream can't pin the SessionStart hook.
- ``session_end.py`` — on retain failure, enqueue the full retain payload (api_url, api_token, bank_id, content, document_id, context, metadata, tags) and ``exit 1``. ``exit 2`` when the queue is full. Both exits flow through ``bin/run-hook.sh`` into the #424 issue sink. Daemon stop still runs on the failure path so we don't leak the embed daemon.
- ``session_start.py`` — wires ``drain_pending.drain()`` in *after* the Hindsight reachability check (skip drain when server unreachable — no point retrying with no upstream).
- ``retain.py`` — now returns ``{"status": "ok"|"skipped"|"failed", "payload": ..., "error": ...}`` instead of None so session_end can capture the exact failed-call args without re-deriving them.
- ``src/cli/doctor.ts`` — new ``checkPendingRetainsQueue`` probe. **ok** when dir missing/empty, **warn** when entries are queued (will retry), **fail** when ``.dead`` markers exist or queue at cap.

### Layout (per ``lib/pending.py`` docstring)

Each entry: ``{schema, api_url, api_token, bank_id, content, document_id, context, metadata, tags, failed_at, error_class, error_message, attempt_count}``.

The queue lives under ``$HOME`` inside the docker agent, so it survives session-to-session within a container's lifetime (the common case) but not container recreate. That's deliberate — this is a rescue queue for transient retain failures, not a long-term DLQ. Long enough that the container restarts and ``switchroom doctor`` already surfaced the backlog.

## Test plan

- [x] ``vendor/hindsight-memory/tests/test_pending.py`` — 10 cases: dir creation 0700, atomic semantics, cap, ordering, attempt bump, dead marker.
- [x] ``vendor/hindsight-memory/tests/test_drain_pending.py`` — 6 cases: empty / success / failure / max-attempts-to-dead / stall guard / mixed.
- [x] ``vendor/hindsight-memory/tests/test_session_end_pending.py`` — 3 cases: ok path keeps queue empty + exits 0, HTTP failure enqueues + exits non-zero, daemon stop still runs on retain failure.
- [x] ``tests/doctor.test.ts`` — 5 new cases for the probe.
- [x] ``npm run lint`` clean.
- [x] ``npm run build`` clean.
- [x] ``npm run test:vitest`` — 5536 passed (3 pre-existing config failures unrelated to this change).
- [x] ``python3 -m pytest tests/`` in vendor/hindsight-memory — 172 passed (3 pre-existing failures in test_config.py around recallBudget default).

🤖 Generated with [Claude Code](https://claude.com/claude-code)