### PR TITLE
feat(vault): teach agents to discover & request vault grants on denial

### DIFF
--- a/profiles/_shared/vault-protocol.md.hbs
+++ b/profiles/_shared/vault-protocol.md.hbs
@@ -1,0 +1,68 @@
+<!--
+  Switchroom-managed: vault protocol.
+  Rendered automatically by `switchroom apply` / `agent reconcile` from
+  profiles/_shared/vault-protocol.md.hbs. Edit there — hand-edits to
+  this section will be overwritten on next reconcile. To add agent-
+  specific guidance, put it in workspace/CLAUDE.custom.md (sidecar).
+-->
+
+## Vault & secrets
+
+Secrets (API keys, tokens, credentials) live in the encrypted vault.
+You read them via the vault-broker — never via direct file IO, never
+from an env file on disk, never by asking the operator to paste them
+into chat.
+
+### The reference syntax
+
+In `switchroom.yaml` and config files, secrets are referenced as
+`vault:<key>` (e.g. `vault:fatsecret/client_id`). The cascade resolver
+expands those at startup. In a shell script, fetch with:
+
+```bash
+switchroom vault get <key>
+```
+
+The CLI tries the broker first. From inside this agent, that's the
+only path that can work — the vault file itself is not mounted into
+the container.
+
+### When you hit `VAULT-BROKER-DENIED`
+
+You don't have a grant for that key yet. Recovery depends on whether
+there's an operator in the loop:
+
+- **Interactive context** (you're handling an inbound chat message,
+  i.e. you have a `chat_id` available): call the
+  `vault_request_access` MCP tool with `key='<key>'`, `scope='read'`,
+  and a one-line `reason`. This renders a `[✅ Approve] [🚫 Deny]`
+  card in the chat. After firing the tool, **end your turn cleanly** —
+  the gateway will inject a fresh inbound (`<channel source="vault_grant_approved">`)
+  when the operator approves, kicking off a new turn where you can
+  resume the task.
+
+- **Non-interactive context** (cron fire, `meta.source="cron"`, no
+  operator chat): do **not** spam approval cards into an empty topic.
+  Log the missing capability in your output, degrade gracefully
+  (clearly-marked estimates / a "skipped — needs vault grant" status
+  / etc.), and continue. The operator will see the gap in your next
+  interactive turn and can grant access then.
+
+### What never works from inside the agent
+
+- `switchroom vault get --no-broker <key>` — the vault file isn't
+  mounted; this exits with `VAULT-SANDBOX-CONTEXT`. The flag exists
+  for the operator on the host, not for you.
+- Reading a credentials env file from disk (e.g.
+  `~/.switchroom/credentials/<service>.env`). If you see code that
+  does this, treat it as a bug to fix, not a fallback to rely on —
+  unencrypted secrets on disk defeat the whole vault model.
+- Asking the operator to paste the secret into Telegram. The secret-
+  scrub hooks will redact it, and you've leaked it to chat history
+  along the way. Always use the `vault_request_access` flow.
+
+### Hint: the deny stderr tells you the exact recovery
+
+The CLI emits a marker + actionable hint on every vault failure. Read
+the **second line** — it names the right tool for your situation,
+sandbox-aware. Trust it instead of guessing.

--- a/src/agents/profiles.test.ts
+++ b/src/agents/profiles.test.ts
@@ -3,7 +3,12 @@ import { sep as pathSep, resolve } from "node:path";
 import { mkdtempSync, mkdirSync, symlinkSync, writeFileSync, rmSync, readFileSync, existsSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { getProfilePath, listAvailableProfiles, renderProfileClaudeTemplate } from "./profiles.js";
+import {
+  getProfilePath,
+  listAvailableProfiles,
+  renderProfileClaudeTemplate,
+  renderVaultProtocolFragment,
+} from "./profiles.js";
 
 describe("getProfilePath", () => {
   it("resolves a real profile that exists on disk", () => {
@@ -200,5 +205,60 @@ describe("telegram-style partial — status? RCA-offer guidance (#162)", () => {
     // immediately on every "status?".
     expect(partial.toLowerCase()).toContain("auto-file");
     expect(partial.toLowerCase()).toContain("offer-then-confirm");
+  });
+});
+
+describe("vault-protocol partial — agent vault discovery (#gymbro-fallback)", () => {
+  // Background: gymbro hit VAULT-BROKER-DENIED on fatsecret/* and
+  // silently fell back to estimates because it didn't know
+  // `vault_request_access` existed. Every agent must inherit this
+  // protocol deterministically — the partial is what teaches it.
+
+  it("tells the agent to call vault_request_access on broker denial", () => {
+    const fragment = renderVaultProtocolFragment();
+    expect(fragment).toContain("vault_request_access");
+    expect(fragment).toContain("VAULT-BROKER-DENIED");
+  });
+
+  it("branches on interactive vs cron context (don't spam approval cards)", () => {
+    // The whole reason the rule isn't "always request" is the cron
+    // case: a 3am fire shouldn't surface an approval card to a
+    // sleeping operator. The fragment must explicitly call this out.
+    const fragment = renderVaultProtocolFragment();
+    expect(fragment.toLowerCase()).toMatch(/interactive/);
+    expect(fragment.toLowerCase()).toMatch(/cron|non-interactive/);
+    expect(fragment.toLowerCase()).toMatch(/degrade|skip/);
+  });
+
+  it("forbids the --no-broker fallback (which can't work from a sandbox)", () => {
+    // The historical CLI hint pointed agents at `--no-broker`. That
+    // hint was wrong for an agent — the vault file isn't mounted, so
+    // --no-broker just hits VAULT-SANDBOX-CONTEXT. The fragment must
+    // explicitly tell the agent not to retry that way.
+    const fragment = renderVaultProtocolFragment();
+    expect(fragment).toContain("--no-broker");
+    expect(fragment.toLowerCase()).toMatch(/(do not|never|don't)[^.]*--no-broker|--no-broker[^.]*(does not|doesn't|can't|never)/);
+  });
+
+  it("forbids env-file fallbacks for secrets", () => {
+    // Pre-fix gymbro's food-log skill had a `~/.switchroom/credentials/
+    // fatsecret.env` fallback, justified by "main agent has no broker
+    // socket" — false in the per-agent socket model. The fragment
+    // forbids this anti-pattern.
+    const fragment = renderVaultProtocolFragment();
+    expect(fragment.toLowerCase()).toMatch(/env file|credentials.*\.env|env-file/);
+  });
+
+  it("forbids asking the operator to paste secrets into Telegram", () => {
+    // Mid-conversation "send me the API key" defeats the whole vault
+    // model and leaks the secret into chat history (even with
+    // secret-scrub hooks running).
+    const fragment = renderVaultProtocolFragment();
+    expect(fragment.toLowerCase()).toMatch(/paste|chat history|telegram/);
+  });
+
+  it("is non-empty (file present and rendered)", () => {
+    const fragment = renderVaultProtocolFragment();
+    expect(fragment.length).toBeGreaterThan(200);
   });
 });

--- a/src/agents/profiles.ts
+++ b/src/agents/profiles.ts
@@ -171,12 +171,34 @@ Handlebars.registerHelper("isNumber", (value: unknown) => {
 // The _shared/ directory is underscore-prefixed (like _base/) and is not
 // listed by listAvailableProfiles() — it's framework-internal.
 const SHARED_FRAGMENTS_DIR = resolve(PROFILES_ROOT, "_shared");
-const SHARED_FRAGMENTS = ["telegram-style"] as const;
+const SHARED_FRAGMENTS = ["telegram-style", "vault-protocol"] as const;
 for (const name of SHARED_FRAGMENTS) {
   const fragPath = join(SHARED_FRAGMENTS_DIR, `${name}.md.hbs`);
   if (existsSync(fragPath)) {
     Handlebars.registerPartial(name, readFileSync(fragPath, "utf-8"));
   }
+}
+
+/**
+ * Render the vault-protocol fragment standalone for unconditional
+ * append to every agent's CLAUDE.md. Unlike `telegram-style` (which
+ * profiles opt into via `{{> telegram-style}}`), vault-protocol is
+ * load-bearing safety guidance — every agent gets it, regardless of
+ * whether their profile template remembered to include the partial.
+ *
+ * Returns the rendered Markdown, or an empty string if the fragment
+ * file is missing (e.g. partial install).
+ */
+export function renderVaultProtocolFragment(
+  context: Record<string, unknown> = {},
+  /** Override the profiles root; used by tests. */
+  profilesRoot: string = PROFILES_ROOT,
+): string {
+  const fragPath = join(resolve(profilesRoot, "_shared"), "vault-protocol.md.hbs");
+  if (!existsSync(fragPath)) return "";
+  const source = readFileSync(fragPath, "utf-8");
+  const template = Handlebars.compile(source, { noEscape: true });
+  return template(context).trimEnd();
 }
 
 /**

--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -35,6 +35,7 @@ import {
   renderTemplate,
   copyProfileSkills,
   renderProfileClaudeTemplate,
+  renderVaultProtocolFragment,
 } from "./profiles.js";
 import { getHindsightSettingsEntry, getBuiltinDefaultMcpEntries } from "../memory/scaffold-integration.js";
 import { reconcileAgentDefaultSkills } from "./reconcile-default-skills.js";
@@ -1919,6 +1920,17 @@ export function scaffoldAgent(
         join(agentDir, dest),
         () => {
           let rendered = renderTemplate(srcPath, context);
+          // Append the switchroom-managed vault protocol section. Every
+          // agent gets it regardless of profile — it's load-bearing
+          // safety guidance (how to handle VAULT-BROKER-DENIED, when to
+          // call vault_request_access, why --no-broker can't work from
+          // inside the sandbox). Reconcile re-applies it on every run.
+          if (dest === "CLAUDE.md") {
+            const vaultProtocol = renderVaultProtocolFragment(context);
+            if (vaultProtocol) {
+              rendered = rendered.trimEnd() + "\n\n" + vaultProtocol + "\n";
+            }
+          }
           // Phase 5: append claude_md_raw escape hatch on initial
           // scaffold. CLAUDE.md is user-protected afterwards so the
           // hatch is one-shot — users who edit CLAUDE.md after scaffold
@@ -3068,8 +3080,15 @@ Don't wait for a slash command. Don't ask permission. Memory work is table stake
         useSwitchroomPlugin: usesSwitchroomTelegramPlugin(agentConfig),
       };
 
-      // Render template + compose with sidecar
-      const rendered = renderTemplate(claudeMdSrc, claudeContext);
+      // Render template, then append the switchroom-managed vault
+      // protocol section (every agent gets it; reconcile re-applies on
+      // every run so updates to the fragment propagate without touching
+      // per-profile templates), then compose with the user sidecar.
+      let rendered = renderTemplate(claudeMdSrc, claudeContext);
+      const vaultProtocol = renderVaultProtocolFragment(claudeContext);
+      if (vaultProtocol) {
+        rendered = rendered.trimEnd() + "\n\n" + vaultProtocol + "\n";
+      }
       let composed = composeWithSidecar(rendered, claudeCustomPath);
 
       // Legacy claude_md_raw still appends after sidecar (one-shot escape hatch)

--- a/src/cli/vault.ts
+++ b/src/cli/vault.ts
@@ -78,6 +78,58 @@ function refuseSandboxDirectAccess(verbHint: string): never {
   process.exit(VAULT_EXIT_SANDBOX_CONTEXT);
 }
 
+/**
+ * Sandbox-aware recovery hint for the three broker failure modes
+ * (denied / locked / unreachable). The same `--no-broker` hint that
+ * works for an operator on the host is actively misleading inside an
+ * agent: the vault file isn't mounted, so `--no-broker` would just
+ * fall into `refuseSandboxDirectAccess`. Worse, the agent reads this
+ * hint as instruction and gives up ("I'm sandboxed") instead of
+ * calling the `vault_request_access` MCP tool that actually exists
+ * to recover.
+ *
+ * In sandbox context, point at the tool that can recover the
+ * situation. On the host, keep the historical `--no-broker` hint.
+ */
+function recoveryHint(
+  situation: "denied" | "locked" | "unreachable",
+  key?: string,
+): string {
+  if (!isSandboxContext()) {
+    const keyArg = key ? ` ${key}` : "";
+    return `Hint: run 'switchroom vault get --no-broker${keyArg}' for interactive (non-cron) access.`;
+  }
+  // Inside an agent. The vault.enc file isn't mounted; `--no-broker`
+  // can't work. Tell the agent what *can* work.
+  switch (situation) {
+    case "denied":
+      return (
+        `Hint: this agent has no grant for ${key ? `'${key}'` : "this key"}. ` +
+        `Call the \`vault_request_access\` MCP tool ` +
+        `(key=${key ? `'${key}'` : "'<key>'"}, scope='read') ` +
+        `to ask the operator for access via a Telegram approval card. ` +
+        `Do NOT retry with --no-broker — the vault file is not mounted ` +
+        `into agent containers.`
+      );
+    case "locked":
+      return (
+        `Hint: the broker is locked. Ask the operator to unlock it ` +
+        `(\`/vault unlock\` in this chat, or ` +
+        `\`switchroom vault broker unlock\` on the host). ` +
+        `Do NOT retry with --no-broker — the vault file is not mounted ` +
+        `into agent containers.`
+      );
+    case "unreachable":
+      return (
+        `Hint: the broker is unreachable. Ask the operator to check it ` +
+        `(\`switchroom vault broker status\` on the host; if wedged, ` +
+        `\`docker compose -p switchroom restart vault-broker\`). ` +
+        `Do NOT retry with --no-broker — the vault file is not mounted ` +
+        `into agent containers.`
+      );
+  }
+}
+
 function getVaultPath(configPath?: string): string {
   try {
     const config = loadConfig(configPath);
@@ -724,8 +776,8 @@ export function registerVaultCommand(program: Command): void {
               // Non-TTY + broker locked: write a clearly-prefixed error to
               // stderr so agents/scripts surfacing captured output can grep it.
               process.stderr.write(
-                `VAULT-BROKER-DENIED: broker locked and stdin is not a TTY; ` +
-                `use 'switchroom vault get --no-broker' for interactive access\n`
+                `VAULT-BROKER-DENIED: broker locked and stdin is not a TTY.\n` +
+                `${recoveryHint("locked", key)}\n`
               );
               process.exit(3);
             }
@@ -785,7 +837,7 @@ export function registerVaultCommand(program: Command): void {
               // message isn't surfaced in their UI.
               process.stderr.write(
                 `VAULT-BROKER-DENIED [${result.code}]: ${result.msg}\n` +
-                `Hint: run 'switchroom vault get --no-broker ${key}' for interactive (non-cron) access.\n`
+                `${recoveryHint("denied", key)}\n`
               );
               process.exit(2);
             }
@@ -807,8 +859,8 @@ export function registerVaultCommand(program: Command): void {
         // Broker not reachable
         if (!process.stdin.isTTY && !process.env.SWITCHROOM_VAULT_PASSPHRASE) {
           process.stderr.write(
-            `VAULT-BROKER-DENIED: broker not running and stdin is not a TTY; ` +
-            `use 'switchroom vault get --no-broker ${key}' for interactive access\n`
+            `VAULT-BROKER-DENIED: broker not running and stdin is not a TTY.\n` +
+            `${recoveryHint("unreachable", key)}\n`
           );
           process.exit(1);
         }

--- a/tests/scaffold.persona.test.ts
+++ b/tests/scaffold.persona.test.ts
@@ -114,9 +114,17 @@ describe("scaffoldAgent — persona (Phase 2)", () => {
     // lifecycle additions in #557 (wake-audit + restart-visibility);
     // raised again 24000 → 26000 for the phone-first-UX epic #572
     // (`!` interrupt marker, voice transcripts, sticker/GIF persona
-    // guidance, Telegraph long-reply auto-publish). Each block is
-    // load-bearing — the agent needs them to use the new MCP tools
-    // correctly. Future bumps should justify themselves similarly.
-    expect(claudeMd.length).toBeLessThan(26000); // generous cap; target is lean but not 3KB
+    // guidance, Telegraph long-reply auto-publish); cap had already
+    // drifted to ~27.3KB on upstream/main from incremental persona /
+    // skill / handoff edits before the bump below. Raised again
+    // 26000 → 32000 for the unconditional vault-protocol fragment
+    // appended to every agent's CLAUDE.md (~2.9KB; teaches the agent
+    // when to call vault_request_access, when to degrade gracefully
+    // in cron context, and why --no-broker / env-file fallbacks can't
+    // work from inside a sandbox — RCA: gymbro silently fell back to
+    // estimates on VAULT-BROKER-DENIED instead of requesting a grant).
+    // Each block is load-bearing. Future bumps should justify themselves
+    // similarly.
+    expect(claudeMd.length).toBeLessThan(32000); // generous cap; target is lean but not 3KB
   });
 });

--- a/tests/vault.test.ts
+++ b/tests/vault.test.ts
@@ -815,4 +815,29 @@ describe("broker-denied error message format", () => {
     ) as string;
     expect(src).toContain("VAULT-FORMAT-MISMATCH");
   });
+
+  it("deny-hint points agents at vault_request_access, not --no-broker (#gymbro-fallback)", () => {
+    // Pre-fix: stderr on VAULT-BROKER-DENIED told the agent to retry
+    // with `--no-broker`, which can never work from inside a sandbox
+    // (the vault file isn't mounted). The agent then gave up
+    // ("I'm sandboxed") instead of calling the MCP tool that exists
+    // for exactly this case. Post-fix: stderr branches on
+    // isSandboxContext() and names vault_request_access.
+    const src = require("node:fs").readFileSync(
+      require("node:path").join(
+        require("node:url").fileURLToPath(new URL("../src/cli/vault.ts", import.meta.url))
+      ),
+      "utf8"
+    ) as string;
+    // The sandbox-aware helper exists.
+    expect(src).toMatch(/function recoveryHint/);
+    // It names the MCP tool.
+    expect(src).toContain("vault_request_access");
+    // It explicitly warns agents off --no-broker.
+    expect(src).toMatch(/Do NOT retry with --no-broker/);
+    // The three deny paths still use the helper (one call per path).
+    const helperCalls = (src.match(/recoveryHint\(/g) ?? []).length;
+    // 1 definition + 3 call sites = 4 occurrences in source.
+    expect(helperCalls).toBeGreaterThanOrEqual(4);
+  });
 });


### PR DESCRIPTION
## Summary

Closes the gap that made gymbro silently fall back to estimates when it hit `VAULT-BROKER-DENIED` on `fatsecret/*` credentials instead of calling the `vault_request_access` MCP tool that exists for exactly this case.

- **`src/cli/vault.ts`** — new `recoveryHint(situation, key)` helper branches on `isSandboxContext()`. From inside an agent, the three broker-failure paths (denied / locked / unreachable) name the recovery that *can* work from inside the container and explicitly warn off `--no-broker` (vault.enc isn't mounted there). On the host, the historical hint is preserved.
- **`profiles/_shared/vault-protocol.md.hbs`** — new shared fragment (~3KB), appended to every scaffolded agent's CLAUDE.md unconditionally (initial scaffold + every reconcile, mirroring `composeWithSidecar`). Covers `vault:<key>` syntax, when to call `vault_request_access` (interactive context only — explicit cron branch says degrade gracefully so cron fires don't spam approval cards into empty topics), why `--no-broker` / env-file / paste-to-Telegram fallbacks can't work.
- **`src/agents/profiles.ts`** — registers `vault-protocol` as a shared Handlebars partial AND exposes `renderVaultProtocolFragment()` for the unconditional append in scaffold.

## RCA

Gymbro chat showed two adjacent failures:
1. CLI told the agent to retry with `--no-broker`, which from a sandbox just exits `VAULT-SANDBOX-CONTEXT`. The agent read "I'm sandboxed" and gave up.
2. No CLAUDE.md guidance taught it `vault_request_access` exists. Profile templates reference `vault get`; nothing said "on DENIED, call the tool; in cron, degrade."

Both gaps are now closed.

## Design contract review (vision / principles / JTBDs)

| Lens | Verdict |
|---|---|
| Vision outcome 1 (Visibility) | ✅ Replaces silent fallback with a visible approval card |
| Principle 1 ("if they need the docs, we've failed") | ✅ Old `--no-broker` hint was literally the ❌ example in `principles.md`; new hint is the ✅ shape |
| Principle 2 (defaults) | ✅ Vault-aware behaviour ships to every new agent on `switchroom apply` |
| Principle 3 (consistency) | ✅ Mirrors the existing `composeWithSidecar` + shared-partial pattern |
| JTBD/know-what-my-agent-is-doing | ✅ Gymbro transcript was the motivating failure |
| JTBD/survive-reboots-and-real-life | ✅ Cron branch preserves silent degradation when no operator is in the loop |

## Test plan

- [x] `npm run lint` clean (tsc strict + plugin-references)
- [x] `npm run build` clean
- [x] `npx vitest run src/agents/profiles.test.ts tests/vault.test.ts tests/scaffold.persona.test.ts` — all green, including 6 new tests on the vault-protocol partial and the recoveryHint helper
- [x] `npm run test:bun` — 640 pass / 0 fail
- [ ] After merge: operator-side cleanup on gymbro — `switchroom agent reconcile gymbro` picks up the new CLAUDE.md fragment, mint a `fatsecret/credentials` grant, deprecate the stale `~/.switchroom/credentials/fatsecret.env` fallback in the per-agent `food-log` skill

Pre-existing test failures (NOT introduced here):
- 30 in `tests/uat-driver.test.ts` — mtcute session-string fixture is invalid in my local env. Reproduces on clean upstream/main with no patch applied.
- `tests/scaffold.persona.test.ts` was already failing at 27284 bytes (cap 26000) before this PR; bumped to 32000 with a comment that explains both the pre-existing drift and the +2.9KB vault-protocol fragment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)