### PR TITLE
feat(agents): SANDBOX primer in --append-system-prompt so agents recognise EROFS

### DIFF
--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -59,7 +59,7 @@ Your container has \`read_only: true\` rootfs. Most paths are read-only.
 - \`/\`, \`/opt\`, \`/usr\`, \`/etc\`, \`/bin\`, \`/lib\` — rootfs hardening.
 - \`~/.switchroom/skills/**\` — shared skill files; operator-owned.
 - \`~/.switchroom/credentials/**\` — secrets; immutable from your view.
-- \`~/.switchroom/switchroom.yaml\` — fleet config; operator-owned.
+- \`/state/config/switchroom.yaml\` — fleet config; operator-owned.
 
 ### When you hit "read-only file system" / EROFS
 

--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -21,6 +21,70 @@ import type { AgentConfig, QuotaConfig, SwitchroomConfig, TelegramConfig } from 
 
 // Repo root for referencing bin/ scripts in hooks
 const REPO_ROOT = resolve(import.meta.dirname, "../..");
+
+/**
+ * Primer the agent reads on every session boot so it knows it's running
+ * in a switchroom container with `read_only: true` rootfs and a fixed
+ * set of writable mounts. When the agent later hits an EROFS or
+ * "Read-only file system" error, this primer is what lets it produce a
+ * clear "I tried X, that's read-only because of <reason>; operator
+ * action needed" reply instead of either silently retrying or echoing
+ * the raw kernel error to the user.
+ *
+ * Kept in lockstep across the two `systemPromptAppendShellQuoted`
+ * call sites in this file — extracting to a top-level constant
+ * prevents drift the way the prior duplication of telegramGuidance +
+ * memoryGuidance did not.
+ *
+ * Why this string lives here and not in profiles/_base/*.hbs:
+ *   - The .hbs files are written to disk per-agent and operator-
+ *     editable; the sandbox primer is non-negotiable runtime context
+ *     and shouldn't get accidentally diverged per agent.
+ *   - Append-system-prompt is cache-friendly: same content every
+ *     session boot means the model's KV cache hits warm.
+ */
+const SANDBOX_GUIDANCE = `## Sandbox: you're running in a switchroom container
+
+Your container has \`read_only: true\` rootfs. Most paths are read-only.
+
+### Writable
+- \`/tmp\` — 256 MB tmpfs, ephemeral (gone on restart).
+- \`$HOME\` (\`/state/agent/home\`) — persistent across restarts. \`npm\`,
+  \`pip\`, \`git config --global\`, shell history, ssh keys all already
+  configured to write here (\`NPM_CONFIG_PREFIX\`, \`PIP_USER=1\`, etc).
+- \`/state/agent/**\` — your persistent agent dir.
+- \`/var/log/switchroom\` — your log dir.
+
+### Read-only (and why)
+- \`/\`, \`/opt\`, \`/usr\`, \`/etc\`, \`/bin\`, \`/lib\` — rootfs hardening.
+- \`~/.switchroom/skills/**\` — shared skill files; operator-owned.
+- \`~/.switchroom/credentials/**\` — secrets; immutable from your view.
+- \`~/.switchroom/switchroom.yaml\` — fleet config; operator-owned.
+
+### When you hit "read-only file system" / EROFS
+
+This is **the sandbox working as intended**, not a bug. Don't retry the
+same write. Don't apologise vaguely. Instead:
+
+1. Recognise the signal: \`EROFS\`, "Read-only file system", "permission
+   denied" on a path under \`/opt\`, \`/usr\`, \`/etc\`, or
+   \`~/.switchroom/{skills,credentials}\`.
+2. Tell the user in plain language what you tried and why the sandbox
+   blocked it.
+3. Suggest the right path: a writable alternative if your goal is
+   reachable that way, or explicit operator action otherwise.
+
+Example response shapes:
+
+- "I tried to edit \`~/.switchroom/skills/foo/script.sh\` — that's
+  mounted read-only from my view. **Operator action**: edit it on the
+  host, then \`switchroom apply\` to re-scaffold."
+- "I wanted to \`apt install <pkg>\`. My container's rootfs is read-only
+  and I'm not root. **Operator action**: add the package to
+  \`docker/Dockerfile.agent\` and rebuild the agent image."
+- "I tried to clone into \`/workspace\` — that path doesn't exist in my
+  sandbox. Cloning into \`$HOME/workspace\` instead."`;
+
 import { DEFAULT_PROFILE } from "../config/schema.js";
 import {
   resolveAgentConfig,
@@ -1510,7 +1574,7 @@ When the user asks "what do you know about X / me", "what do you remember about 
 Don't wait for a slash command. Don't ask permission. Memory work is table stakes, like a colleague who takes notes and remembers.`;
 
       if (useSwitchroomPlugin) {
-        const parts = [baseAppend, telegramGuidance, memoryGuidance].filter(s => s.length > 0);
+        const parts = [baseAppend, telegramGuidance, memoryGuidance, SANDBOX_GUIDANCE].filter(s => s.length > 0);
         const combined = parts.join('\n\n---\n\n');
         return shellSingleQuote(combined);
       }
@@ -3019,7 +3083,7 @@ When the user asks "what do you know about X / me", "what do you remember about 
 
 Don't wait for a slash command. Don't ask permission. Memory work is table stakes, like a colleague who takes notes and remembers.`;
         if (useSwitchroomPlugin) {
-          const parts = [baseAppend, telegramGuidance, memoryGuidance].filter(s => s.length > 0);
+          const parts = [baseAppend, telegramGuidance, memoryGuidance, SANDBOX_GUIDANCE].filter(s => s.length > 0);
           const combined = parts.join('\n\n---\n\n');
           return shellSingleQuote(combined);
         }

--- a/tests/scaffold.test.ts
+++ b/tests/scaffold.test.ts
@@ -2089,6 +2089,64 @@ describe("scaffoldAgent with global defaults cascade", () => {
     expect(startSh).toContain("export LOG_LEVEL='debug'");
   });
 
+  it("appends the sandbox primer to system prompt so agents recognise EROFS as the sandbox", () => {
+    // Closes the UX gap where agents hitting `EROFS` on a read-only mount
+    // would either silently retry or echo the raw kernel error to the
+    // user. The primer (top-level `SANDBOX_GUIDANCE` constant) names
+    // the writable mounts + tells the agent how to respond when it hits
+    // the boundary. Kept in lockstep across both
+    // `systemPromptAppendShellQuoted` call sites — this test would fail
+    // if either site forgets to include it after a future refactor.
+    const agentConfig = makeAgentConfig({});
+    const result = scaffoldAgent(
+      "sandbox-primer-agent",
+      agentConfig,
+      tmpDir,
+      telegramConfig,
+    );
+    const startSh = readFileSync(join(result.agentDir, "start.sh"), "utf-8");
+
+    // Load-bearing headings — drop these and the agent's reply
+    // template stops working. Substrings are chosen to NOT cross an
+    // ASCII apostrophe (POSIX single-quote wrapping splits the literal
+    // around apostrophes via the `'"'"'` idiom, so a substring spanning
+    // one wouldn't appear contiguously in start.sh).
+    expect(startSh).toContain("## Sandbox: you");
+    expect(startSh).toContain("running in a switchroom container");
+    // Writable paths the agent must know about
+    expect(startSh).toContain("$HOME");
+    expect(startSh).toContain("/state/agent/home");
+    expect(startSh).toContain("/tmp");
+    // Read-only paths + the operator-action framing
+    expect(startSh).toContain("read-only file system");
+    expect(startSh).toContain("Operator action");
+    // The primer must NOT leak when an agent doesn't use the switchroom
+    // telegram plugin (host-systemd legacy / non-telegram dispatches).
+    // The wrapping logic only includes the guidance when
+    // `useSwitchroomPlugin` is true; a regression there would attach
+    // the primer to agents whose telegram plumbing is different and
+    // confuse the model.
+  });
+
+  it("does NOT append sandbox primer for agents without the switchroom telegram plugin", () => {
+    const agentConfig = makeAgentConfig({
+      channels: {
+        telegram: {
+          plugin: "official",
+        },
+      },
+    });
+    const result = scaffoldAgent(
+      "sandbox-primer-skip-agent",
+      agentConfig,
+      tmpDir,
+      telegramConfig,
+    );
+    const startSh = readFileSync(join(result.agentDir, "start.sh"), "utf-8");
+    expect(startSh).not.toContain("## Sandbox: you");
+    expect(startSh).not.toContain("running in a switchroom container");
+  });
+
   it("escapes system_prompt_append via POSIX single-quote wrapping", () => {
     const agentConfig = makeAgentConfig({
       system_prompt_append:


### PR DESCRIPTION
## Summary
- Bakes a static sandbox primer into every scaffolded agent's `--append-system-prompt` (only when using the switchroom telegram plugin) so the agent knows its rootfs is `read_only: true`, which paths are writable, and how to phrase EROFS errors back to the operator (sandbox-as-intended + a concrete *Operator action* line).
- Lives in `src/agents/scaffold.ts` (the `SANDBOX_GUIDANCE` constant) rather than the per-agent `.hbs` template — non-negotiable runtime context that shouldn't drift per agent, and append-prompt caching stays warm because it's stable across boots.
- Layer 1 of the sandbox UX work. Layer 2 (a PostToolUse hook that detects EROFS in tool_response and appends an inline `[switchroom-sandbox-hint]` annotation) follows in a separate PR.

## Why
Multiple agents this week echoed raw `EROFS` / "read-only file system" errors back to users on Telegram, or retried the same write in a loop. They didn't know they were in a sandbox — the existing system prompt + workspace bootstrap don't name the mount layout. Primer closes that loop: name the writable + read-only paths, name the signal, give a response template.

Serves outcome #1 (visibility) and outcome #4 (always-on) from `reference/vision.md` — the agent's behaviour at the sandbox boundary becomes part of what the operator can *see and act on* from Telegram, instead of a stuck or noisy state.

## Test plan
- [x] `bun run test:vitest tests/scaffold.test.ts` — 168 passed (incl. two new sandbox tests).
- [x] `npm run lint` — clean.
- [x] Positive test asserts primer + writable paths + operator-action framing land in scaffolded start.sh.
- [x] Negative test asserts the primer does NOT attach for agents on `channels.telegram.plugin: official`.
- [ ] Smoke: scaffold a fresh agent, exec into the container, confirm `--append-system-prompt` argv contains the primer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)