### PR TITLE
feat(telegram): handle 13 previously-silent inbound message types (#1077)

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -10786,6 +10786,269 @@ bot.on('message:animation', async ctx => {
   })
 })
 
+// ─── Previously-silent inbound types (#1077) ─────────────────────────────
+// Telegram emits a dozen more `message:*` types that earlier versions of
+// this gateway never registered handlers for. The user would send a
+// contact / location / poll / etc., the gateway would log nothing, the
+// agent would never see the message, and the user would get zero
+// acknowledgement. Each type below now has an explicit decision:
+//
+//   forward         — build a descriptive envelope + flow through
+//                     handleInbound (gate + ack 👀 + bridge IPC).
+//   log-only ack    — gate, react 👀, log; agent is not bothered.
+//   log-only DENY   — refuse with a polite reply, never forward.
+//
+// Decision matrix (see issue #1077):
+//
+//   contact            forward          meaningful user intent
+//   location           forward          agent might map / lookup
+//   venue              forward          same shape as location
+//   poll               forward          could be feedback / polling agent
+//   web_app_data       forward          mini-app result; agent consumes
+//   users_shared       forward          explicit user-share request
+//   chat_shared        forward          same
+//   dice               ack-only         low-info — agent isn't a die
+//   game               ack-only         we aren't a game host
+//   story              ack-only         stories are FYI
+//   paid_media         ack-only + WARN  money flow — operator review
+//   successful_payment ack-only + WARN  money flow — operator review
+//   passport_data      DENY             regulated identity data, unsupported
+//
+// Every handler is wrapped in try/catch so a malformed Telegram payload
+// can never tear down the gateway dispatcher.
+
+/**
+ * Gate + 👀-react path for inbound types we acknowledge but don't
+ * forward to the agent. Mirrors the gate/drop/pair branches that
+ * handleInbound takes, but skips the IPC broadcast.
+ */
+async function handleAckOnly(
+  ctx: Context,
+  kind: string,
+  opts: { emoji?: string; warn?: boolean } = {},
+): Promise<void> {
+  try {
+    const result = gate(ctx)
+    if (result.action === 'drop') return
+    if (result.action === 'pair') {
+      const lead = result.isResend ? 'Still pending' : 'Pairing required'
+      await ctx.reply(`${lead} — run in Claude Code:\n\n/telegram:access pair ${result.code}`).catch(() => {})
+      return
+    }
+    const chat_id = String(ctx.chat!.id)
+    const msgId = ctx.message?.message_id
+    if (msgId != null) {
+      void bot.api.setMessageReaction(chat_id, msgId, [
+        { type: 'emoji', emoji: (opts.emoji ?? '👀') as ReactionTypeEmoji['emoji'] },
+      ]).catch(() => {})
+    }
+    const prefix = opts.warn ? 'WARN ' : ''
+    process.stderr.write(`telegram gateway: ${prefix}inbound ${kind} ack-only chat_id=${chat_id} from=${ctx.from?.id ?? '?'}\n`)
+  } catch (err) {
+    process.stderr.write(`telegram gateway: ack-only handler error (${kind}): ${(err as Error).message}\n`)
+  }
+}
+
+/**
+ * Polite refusal for inbound types we explicitly do not support
+ * (passport_data). Sends a reply, NEVER forwards to the agent.
+ */
+async function handleRefusal(
+  ctx: Context,
+  kind: string,
+  refusalText: string,
+): Promise<void> {
+  try {
+    const result = gate(ctx)
+    if (result.action === 'drop') return
+    if (result.action === 'pair') {
+      // Pre-pair senders don't get the refusal either — same drop path
+      // as any other unauthorized inbound.
+      return
+    }
+    const chat_id = String(ctx.chat!.id)
+    const msgId = ctx.message?.message_id
+    const messageThreadId = ctx.message?.message_thread_id
+    if (msgId != null) {
+      void bot.api.setMessageReaction(chat_id, msgId, [
+        { type: 'emoji', emoji: '🚫' as ReactionTypeEmoji['emoji'] },
+      ]).catch(() => {})
+    }
+    await bot.api.sendMessage(
+      chat_id,
+      refusalText,
+      messageThreadId != null ? { message_thread_id: messageThreadId } : {},
+    ).catch(() => {})
+    // Loud stderr: this category gets monitored. A passport_data inbound
+    // is unusual enough to warrant operator attention.
+    process.stderr.write(
+      `telegram gateway: SECURITY inbound ${kind} REFUSED chat_id=${chat_id} from=${ctx.from?.id ?? '?'} — agent never saw payload\n`,
+    )
+  } catch (err) {
+    process.stderr.write(`telegram gateway: refusal handler error (${kind}): ${(err as Error).message}\n`)
+  }
+}
+
+bot.on('message:contact', async ctx => {
+  try {
+    const c = ctx.message.contact
+    const phone = safeName(c.phone_number) ?? '?'
+    const first = safeName(c.first_name) ?? ''
+    const last = safeName(c.last_name) ?? ''
+    const name = [first, last].filter(Boolean).join(' ') || '?'
+    const userIdPart = c.user_id != null ? ` user_id=${c.user_id}` : ''
+    const text = `(contact: name="${name}" phone="${phone}"${userIdPart})`
+    process.stderr.write(`telegram gateway: inbound contact from chat=${ctx.chat?.id ?? '?'}\n`)
+    await handleInbound(ctx, text, undefined)
+  } catch (err) {
+    process.stderr.write(`telegram gateway: contact handler error: ${(err as Error).message}\n`)
+  }
+})
+
+bot.on('message:location', async ctx => {
+  try {
+    const loc = ctx.message.location
+    const lat = typeof loc.latitude === 'number' ? loc.latitude.toFixed(6) : '?'
+    const lon = typeof loc.longitude === 'number' ? loc.longitude.toFixed(6) : '?'
+    const live = (loc as { live_period?: number }).live_period != null
+      ? ` live_period=${(loc as { live_period?: number }).live_period}s`
+      : ''
+    const text = `(location: lat=${lat} lon=${lon}${live})`
+    process.stderr.write(`telegram gateway: inbound location from chat=${ctx.chat?.id ?? '?'}\n`)
+    await handleInbound(ctx, text, undefined)
+  } catch (err) {
+    process.stderr.write(`telegram gateway: location handler error: ${(err as Error).message}\n`)
+  }
+})
+
+bot.on('message:venue', async ctx => {
+  try {
+    const v = ctx.message.venue
+    const title = safeName(v.title) ?? '?'
+    const address = safeName(v.address) ?? '?'
+    const lat = typeof v.location?.latitude === 'number' ? v.location.latitude.toFixed(6) : '?'
+    const lon = typeof v.location?.longitude === 'number' ? v.location.longitude.toFixed(6) : '?'
+    const text = `(venue: title="${title}" address="${address}" lat=${lat} lon=${lon})`
+    process.stderr.write(`telegram gateway: inbound venue from chat=${ctx.chat?.id ?? '?'}\n`)
+    await handleInbound(ctx, text, undefined)
+  } catch (err) {
+    process.stderr.write(`telegram gateway: venue handler error: ${(err as Error).message}\n`)
+  }
+})
+
+bot.on('message:poll', async ctx => {
+  try {
+    const p = ctx.message.poll
+    const q = safeName(p.question) ?? '?'
+    const optsCount = Array.isArray(p.options) ? p.options.length : 0
+    const optsList = Array.isArray(p.options)
+      ? p.options.slice(0, 10).map(o => safeName((o as { text?: string }).text) ?? '?').join(' | ')
+      : ''
+    const anon = p.is_anonymous ? ' anonymous' : ''
+    const text = `(poll: question="${q}" options=${optsCount}${anon}${optsList ? ` choices=[${optsList}]` : ''})`
+    process.stderr.write(`telegram gateway: inbound poll from chat=${ctx.chat?.id ?? '?'}\n`)
+    await handleInbound(ctx, text, undefined)
+  } catch (err) {
+    process.stderr.write(`telegram gateway: poll handler error: ${(err as Error).message}\n`)
+  }
+})
+
+bot.on('message:web_app_data', async ctx => {
+  try {
+    const w = ctx.message.web_app_data
+    // web_app_data.data is arbitrary user-supplied string from the
+    // mini-app — pass it through but cap length so a malicious mini-app
+    // can't blast the agent with multi-MB payloads.
+    const raw = typeof w.data === 'string' ? w.data : ''
+    const data = raw.length > 4096 ? raw.slice(0, 4096) + '…(truncated)' : raw
+    const button = safeName(w.button_text) ?? '?'
+    const text = `(web_app_data: button="${button}" data=${JSON.stringify(data)})`
+    process.stderr.write(`telegram gateway: inbound web_app_data from chat=${ctx.chat?.id ?? '?'} button="${button}" bytes=${raw.length}\n`)
+    await handleInbound(ctx, text, undefined)
+  } catch (err) {
+    process.stderr.write(`telegram gateway: web_app_data handler error: ${(err as Error).message}\n`)
+  }
+})
+
+bot.on('message:users_shared', async ctx => {
+  try {
+    const u = ctx.message.users_shared
+    const users = Array.isArray(u.users) ? u.users : []
+    const ids = users.map(usr => String((usr as { user_id?: number }).user_id ?? '?')).join(',')
+    const text = `(users_shared: request_id=${u.request_id ?? '?'} user_ids=[${ids}] count=${users.length})`
+    process.stderr.write(`telegram gateway: inbound users_shared from chat=${ctx.chat?.id ?? '?'} count=${users.length}\n`)
+    await handleInbound(ctx, text, undefined)
+  } catch (err) {
+    process.stderr.write(`telegram gateway: users_shared handler error: ${(err as Error).message}\n`)
+  }
+})
+
+bot.on('message:chat_shared', async ctx => {
+  try {
+    const c = ctx.message.chat_shared
+    const title = safeName((c as { title?: string }).title) ?? ''
+    const titlePart = title ? ` title="${title}"` : ''
+    const text = `(chat_shared: request_id=${c.request_id ?? '?'} chat_id=${c.chat_id ?? '?'}${titlePart})`
+    process.stderr.write(`telegram gateway: inbound chat_shared from chat=${ctx.chat?.id ?? '?'} shared_chat_id=${c.chat_id ?? '?'}\n`)
+    await handleInbound(ctx, text, undefined)
+  } catch (err) {
+    process.stderr.write(`telegram gateway: chat_shared handler error: ${(err as Error).message}\n`)
+  }
+})
+
+bot.on('message:dice', async ctx => {
+  process.stderr.write(`telegram gateway: inbound dice from chat=${ctx.chat?.id ?? '?'}\n`)
+  await handleAckOnly(ctx, 'dice', { emoji: '🎲' })
+})
+
+bot.on('message:game', async ctx => {
+  process.stderr.write(`telegram gateway: inbound game from chat=${ctx.chat?.id ?? '?'}\n`)
+  await handleAckOnly(ctx, 'game')
+})
+
+bot.on('message:story', async ctx => {
+  process.stderr.write(`telegram gateway: inbound story from chat=${ctx.chat?.id ?? '?'}\n`)
+  await handleAckOnly(ctx, 'story')
+})
+
+bot.on('message:paid_media', async ctx => {
+  process.stderr.write(`telegram gateway: inbound paid_media from chat=${ctx.chat?.id ?? '?'}\n`)
+  await handleAckOnly(ctx, 'paid_media', { warn: true })
+})
+
+bot.on('message:successful_payment', async ctx => {
+  // Money has changed hands — log loudly with the structured fields a
+  // reconciliation script would want. Do NOT forward to the agent; an
+  // LLM should not be in the loop for confirming receipts.
+  try {
+    const p = ctx.message.successful_payment
+    process.stderr.write(
+      `telegram gateway: inbound successful_payment from chat=${ctx.chat?.id ?? '?'} ` +
+      `currency=${p.currency ?? '?'} total_amount=${p.total_amount ?? '?'} ` +
+      `payload="${safeName(p.invoice_payload) ?? ''}" ` +
+      `provider_charge=${safeName(p.provider_payment_charge_id) ?? '?'} ` +
+      `telegram_charge=${safeName(p.telegram_payment_charge_id) ?? '?'}\n`,
+    )
+  } catch (err) {
+    process.stderr.write(`telegram gateway: successful_payment log failed: ${(err as Error).message}\n`)
+  }
+  await handleAckOnly(ctx, 'successful_payment', { warn: true })
+})
+
+bot.on('message:passport_data', async ctx => {
+  // Telegram Passport is a regulated identity-document flow. Forwarding
+  // the encrypted credentials to an LLM-driven agent would be reckless;
+  // we explicitly refuse to handle it and tell the user so they can
+  // route via the proper channel. Logged at SECURITY level so operators
+  // can see if a passport_data inbound ever lands here (an outlier worth
+  // investigating).
+  await handleRefusal(
+    ctx,
+    'passport_data',
+    "Sorry, I don't handle Telegram Passport data. Please share identity documents through a supported channel — your agent does not process encrypted Passport payloads.",
+  )
+})
+
 // ─── Checklist service message handlers ──────────────────────────────────
 // Telegram emits `checklist_tasks_done` and `checklist_tasks_added` service
 // messages when users tick or add tasks in a native checklist. These arrive

--- a/telegram-plugin/tests/inbound-message-types.test.ts
+++ b/telegram-plugin/tests/inbound-message-types.test.ts
@@ -1,0 +1,267 @@
+/**
+ * Structural tests for the 13 previously-silent inbound message types
+ * registered on `bot.on('message:<type>')` in the gateway (#1077).
+ *
+ * Why structural: gateway/gateway.ts wires every handler inline against
+ * the live `bot` instance — none of these closures are exported, so a
+ * functional invocation would require booting the full grammy runtime
+ * against a real or mocked Bot API. The existing gateway test suite
+ * settled on file-level grep assertions (see
+ * `gateway-secret-detect.test.ts`) for exactly this reason: cheap,
+ * deterministic, and they catch the regression we actually care about
+ * — a future hand mistakenly deleting a handler or skipping the
+ * gate/ack call that gives the user feedback.
+ *
+ * Decision matrix being enforced here (issue #1077):
+ *
+ *   forward         → contact, location, venue, poll, web_app_data,
+ *                     users_shared, chat_shared
+ *   ack-only        → dice, game, story, paid_media, successful_payment
+ *   refuse (DENY)   → passport_data
+ *
+ * The contract per-type:
+ *   - A `bot.on('message:<type>', …)` registration exists.
+ *   - Forwarding handlers call `handleInbound(`.
+ *   - Ack-only handlers call `handleAckOnly(`.
+ *   - The refusal handler calls `handleRefusal(` and does NOT call
+ *     `handleInbound(` (passport data must never reach the agent).
+ *   - Every handler logs a stderr line so operators can see the
+ *     event landed.
+ *   - Every handler is wrapped in try/catch (or delegates to a helper
+ *     that is) so a malformed payload cannot tear down the dispatcher.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+
+const SRC = readFileSync(
+  new URL('../gateway/gateway.ts', import.meta.url),
+  'utf8',
+)
+
+// ─── Helpers ─────────────────────────────────────────────────────────────
+
+/**
+ * Extract the body of a `bot.on('message:<kind>', …)` handler. Returns
+ * the substring from the `bot.on(` line up to the matching closing
+ * `})` at the outer scope. Good enough for grepping — not a full
+ * AST parse.
+ */
+function handlerBody(kind: string): string {
+  const needle = `bot.on('message:${kind}'`
+  const start = SRC.indexOf(needle)
+  expect(start, `handler bot.on('message:${kind}') not found`).toBeGreaterThan(0)
+  // Find the matching close — naive depth count of {/} from the first `{`.
+  const firstBrace = SRC.indexOf('{', start)
+  let depth = 0
+  for (let i = firstBrace; i < SRC.length; i++) {
+    const c = SRC[i]
+    if (c === '{') depth++
+    else if (c === '}') {
+      depth--
+      if (depth === 0) return SRC.slice(start, i + 1)
+    }
+  }
+  throw new Error(`could not find end of handler ${kind}`)
+}
+
+// ─── Registration completeness ───────────────────────────────────────────
+
+const ALL_KINDS = [
+  'contact',
+  'location',
+  'venue',
+  'dice',
+  'poll',
+  'game',
+  'story',
+  'paid_media',
+  'successful_payment',
+  'passport_data',
+  'web_app_data',
+  'users_shared',
+  'chat_shared',
+] as const
+
+describe('inbound message-type handlers: registration', () => {
+  for (const kind of ALL_KINDS) {
+    it(`registers a bot.on('message:${kind}') handler`, () => {
+      expect(SRC).toContain(`bot.on('message:${kind}'`)
+    })
+  }
+})
+
+// ─── Forwarding handlers ─────────────────────────────────────────────────
+
+const FORWARDING = [
+  'contact',
+  'location',
+  'venue',
+  'poll',
+  'web_app_data',
+  'users_shared',
+  'chat_shared',
+] as const
+
+describe('inbound message-type handlers: forwarding decisions', () => {
+  for (const kind of FORWARDING) {
+    it(`${kind} forwards via handleInbound and logs to stderr`, () => {
+      const body = handlerBody(kind)
+      expect(body).toMatch(/handleInbound\(ctx,/)
+      expect(body).toMatch(/process\.stderr\.write/)
+      // Must not divert to the ack-only path — that would silently
+      // hide the payload from the agent.
+      expect(body).not.toMatch(/handleAckOnly\(/)
+      expect(body).not.toMatch(/handleRefusal\(/)
+    })
+  }
+
+  it('forwarding envelopes describe the payload kind in the text', () => {
+    // Each handler builds a `(<kind>: …)` text envelope so the agent
+    // sees what category of payload arrived without having to decode
+    // the meta block.
+    expect(handlerBody('contact')).toContain('(contact:')
+    expect(handlerBody('location')).toContain('(location:')
+    expect(handlerBody('venue')).toContain('(venue:')
+    expect(handlerBody('poll')).toContain('(poll:')
+    expect(handlerBody('web_app_data')).toContain('(web_app_data:')
+    expect(handlerBody('users_shared')).toContain('(users_shared:')
+    expect(handlerBody('chat_shared')).toContain('(chat_shared:')
+  })
+
+  it('web_app_data caps untrusted payload length before forwarding', () => {
+    // web_app_data.data is arbitrary mini-app output — a malicious
+    // mini-app could otherwise flood the agent. Same defence as #553
+    // applied to text coalescing.
+    const body = handlerBody('web_app_data')
+    expect(body).toMatch(/slice\(0,\s*4096\)/)
+    expect(body).toMatch(/truncated/)
+  })
+})
+
+// ─── Ack-only handlers ───────────────────────────────────────────────────
+
+const ACK_ONLY = ['dice', 'game', 'story', 'paid_media', 'successful_payment'] as const
+
+describe('inbound message-type handlers: ack-only decisions', () => {
+  for (const kind of ACK_ONLY) {
+    it(`${kind} uses handleAckOnly (no forward to agent)`, () => {
+      const body = handlerBody(kind)
+      expect(body).toMatch(/handleAckOnly\(/)
+      expect(body).toMatch(/process\.stderr\.write/)
+      // Ack-only must NOT call handleInbound — the whole point is
+      // we don't bother the agent for these.
+      expect(body).not.toMatch(/handleInbound\(/)
+      // Nor should it pretend to refuse.
+      expect(body).not.toMatch(/handleRefusal\(/)
+    })
+  }
+
+  it('dice uses a 🎲 reaction for situational feedback', () => {
+    expect(handlerBody('dice')).toContain("emoji: '🎲'")
+  })
+
+  it('paid_media and successful_payment are marked warn:true', () => {
+    expect(handlerBody('paid_media')).toMatch(/warn:\s*true/)
+    expect(handlerBody('successful_payment')).toMatch(/warn:\s*true/)
+  })
+
+  it('successful_payment logs the structured payment fields', () => {
+    // Money-flow events need a reconciliation-friendly stderr line.
+    const body = handlerBody('successful_payment')
+    expect(body).toContain('currency=')
+    expect(body).toContain('total_amount=')
+    expect(body).toContain('telegram_charge=')
+  })
+})
+
+// ─── Refusal handler ─────────────────────────────────────────────────────
+
+describe('inbound message-type handlers: passport_data refusal', () => {
+  it('passport_data uses handleRefusal and NEVER calls handleInbound', () => {
+    const body = handlerBody('passport_data')
+    expect(body).toMatch(/handleRefusal\(/)
+    // Critical: passport data is regulated identity material. Even a
+    // diagnostic forward path would leak it onto the agent's wire.
+    expect(body).not.toMatch(/handleInbound\(/)
+    expect(body).not.toMatch(/ipcServer\.broadcast/)
+  })
+
+  it('passport_data refusal text mentions Telegram Passport', () => {
+    // The user gets a polite explanation so they don't think the
+    // message was simply dropped on the floor.
+    const body = handlerBody('passport_data')
+    expect(body).toMatch(/Telegram Passport/)
+  })
+})
+
+// ─── Shared helper invariants ────────────────────────────────────────────
+
+describe('inbound message-type helpers: handleAckOnly + handleRefusal', () => {
+  it('handleAckOnly is declared and gates before reacting', () => {
+    // The function must consult gate() so non-allowlisted senders
+    // don't get a reaction (which would confirm the bot exists to
+    // a stranger).
+    expect(SRC).toMatch(/async function handleAckOnly\(/)
+    const fnStart = SRC.indexOf('async function handleAckOnly(')
+    const fnSlice = SRC.slice(fnStart, fnStart + 2000)
+    expect(fnSlice).toContain('gate(ctx)')
+    expect(fnSlice).toContain('setMessageReaction')
+  })
+
+  it('handleAckOnly drops non-allowlisted senders silently', () => {
+    const fnStart = SRC.indexOf('async function handleAckOnly(')
+    const fnSlice = SRC.slice(fnStart, fnStart + 2000)
+    expect(fnSlice).toMatch(/action === 'drop'/)
+  })
+
+  it('handleAckOnly is wrapped in try/catch', () => {
+    const fnStart = SRC.indexOf('async function handleAckOnly(')
+    const fnSlice = SRC.slice(fnStart, fnStart + 2000)
+    expect(fnSlice).toMatch(/try\s*\{/)
+    expect(fnSlice).toMatch(/catch\s*\(/)
+  })
+
+  it('handleRefusal is declared and sends a reply via sendMessage', () => {
+    expect(SRC).toMatch(/async function handleRefusal\(/)
+    const fnStart = SRC.indexOf('async function handleRefusal(')
+    const fnSlice = SRC.slice(fnStart, fnStart + 2000)
+    expect(fnSlice).toContain('gate(ctx)')
+    expect(fnSlice).toContain('sendMessage')
+    // SECURITY-tagged log line so operators see the refusal in
+    // their stderr scrape.
+    expect(fnSlice).toMatch(/SECURITY/)
+  })
+
+  it('handleRefusal sits behind the gate (no leak to strangers)', () => {
+    // Mirrors handleAckOnly — we don't even confirm the bot exists
+    // to a sender who isn't allowlisted.
+    const fnStart = SRC.indexOf('async function handleRefusal(')
+    const fnSlice = SRC.slice(fnStart, fnStart + 2000)
+    expect(fnSlice).toMatch(/action === 'drop'/)
+  })
+})
+
+// ─── Decision-matrix completeness ────────────────────────────────────────
+
+describe('inbound message-type decisions cover all 13 types from #1077', () => {
+  it('every kind in the matrix has exactly one decision', () => {
+    const forwardSet = new Set<string>(FORWARDING)
+    const ackSet = new Set<string>(ACK_ONLY)
+    const refusalSet = new Set<string>(['passport_data'])
+    for (const kind of ALL_KINDS) {
+      const inForward = forwardSet.has(kind)
+      const inAck = ackSet.has(kind)
+      const inRefusal = refusalSet.has(kind)
+      const count = Number(inForward) + Number(inAck) + Number(inRefusal)
+      expect(count, `${kind} should appear in exactly one bucket, got ${count}`).toBe(1)
+    }
+  })
+
+  it('matrix totals: 7 forward, 5 ack-only, 1 refuse', () => {
+    expect(FORWARDING.length).toBe(7)
+    expect(ACK_ONLY.length).toBe(5)
+    // All 13 covered, no extras dropped.
+    expect(FORWARDING.length + ACK_ONLY.length + 1).toBe(ALL_KINDS.length)
+  })
+})

--- a/telegram-plugin/uat/driver.ts
+++ b/telegram-plugin/uat/driver.ts
@@ -639,6 +639,27 @@ export class Driver {
     return { messageId: sent.id };
   }
 
+  /**
+   * Send a geolocation point. Used by the UAT location-inbound scenario
+   * to exercise the gateway's `message:location` handler (#1077).
+   */
+  async sendLocation(
+    chatId: number,
+    latitude: number,
+    longitude: number,
+    opts?: SendTextOptions,
+  ): Promise<{ messageId: number }> {
+    const c = this.requireClient();
+    const replyTo = opts?.replyTo ?? opts?.messageThreadId;
+    const media = InputMedia.geo(latitude, longitude);
+    const sent = await c.sendMedia(
+      chatId,
+      media,
+      replyTo ? { replyTo } : undefined,
+    );
+    return { messageId: sent.id };
+  }
+
   private requireClient(): TelegramClient {
     if (!this.client) {
       throw new Error("Driver not connected — call connect() first");

--- a/telegram-plugin/uat/scenarios/location-inbound-dm.test.ts
+++ b/telegram-plugin/uat/scenarios/location-inbound-dm.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Location-inbound scenario — driver shares a geolocation with the
+ * test bot. Exercises the new `message:location` handler from #1077
+ * end-to-end: gateway parses the lat/lon, builds a `(location: …)`
+ * envelope, forwards to the agent, agent replies.
+ *
+ * Requires the same env as `smoke-dm-reply.test.ts` (see
+ * `uat/SETUP.md` §6).
+ *
+ * Coordinates are intentionally a well-known landmark (Sydney Opera
+ * House) so a failure trace makes "what was shared" obvious — and so
+ * a chatbot persona has something semantically grounded to respond to,
+ * which makes the bot's reply check more meaningful than asserting
+ * `.+`. We still tolerate ANY reply text — the goal is to prove the
+ * gateway forwarded the location, not to grade the agent's geography.
+ *
+ * Other 12 inbound types from #1077 are covered structurally in
+ * `tests/inbound-message-types.test.ts`. End-to-end UAT for them
+ * (contact, venue, dice, poll, web_app_data, users_shared,
+ * chat_shared, dice, game, story, paid_media, successful_payment,
+ * passport_data) is deferred — most require either a custom bot
+ * setup (mini-app, payments provider) or a Telegram client gesture
+ * (story share, dice roll) that the mtcute driver does not script
+ * cleanly enough to be worth the brittleness.
+ */
+
+import { describe, it, expect } from "vitest";
+import { spinUp } from "../harness.js";
+
+// Sydney Opera House — recognizable, non-sensitive, stable across runs.
+const SYDNEY_OPERA_HOUSE_LAT = -33.8568;
+const SYDNEY_OPERA_HOUSE_LON = 151.2153;
+
+describe("uat: location-inbound DM round-trip", () => {
+  it(
+    "driver shares a geolocation, bot replies within 90s",
+    async () => {
+      const sc = await spinUp({ agent: "test-harness" });
+
+      try {
+        await sc.driver.sendLocation(
+          sc.botUserId,
+          SYDNEY_OPERA_HOUSE_LAT,
+          SYDNEY_OPERA_HOUSE_LON,
+        );
+
+        // Same budget as smoke-dm-reply: 90s tolerates the gateway's
+        // coalescing window + one normal Claude turn. A healthy agent
+        // replies in <20s.
+        const reply = await sc.expectMessage(/.+/, {
+          from: "bot",
+          timeout: 90_000,
+        });
+
+        expect(reply.text.length).toBeGreaterThan(0);
+        expect(reply.senderUserId).toBe(sc.botUserId);
+      } finally {
+        await sc.tearDown();
+      }
+    },
+    // Mirrors smoke-dm-reply's 110s outer budget — must exceed the
+    // 90s inner deadline plus spinUp overhead.
+    110_000,
+  );
+});


### PR DESCRIPTION
## Summary

Closes #1077. The gateway's `bot.on('message:*')` enumeration registered handlers for text/photo/voice/video/document/audio/animation/sticker but silently dropped 13 other types — the user would send a contact / location / poll / etc., the gateway logged nothing, the agent never saw the message, and the user got zero acknowledgement.

This PR adds an explicit handler per type with a documented decision.

## Decision matrix

| Type | Decision | Why |
|---|---|---|
| `contact` | forward | Meaningful user intent — agent could store/route |
| `location` | forward | Agent might map / lookup |
| `venue` | forward | Same shape as location |
| `poll` | forward | Could be feedback / polling agent |
| `web_app_data` | forward (cap 4096B) | Mini-app result; agent consumes |
| `users_shared` | forward | Explicit user-share request |
| `chat_shared` | forward | Same |
| `dice` | ack-only (🎲) | Low-information; agent isn't a die |
| `game` | ack-only (👀) | We aren't a game host |
| `story` | ack-only (👀) | Stories are FYI |
| `paid_media` | ack-only + WARN log | Money flow — operator review |
| `successful_payment` | ack-only + WARN log + structured fields | Money flow — agent shouldn't confirm receipts |
| `passport_data` | REFUSE (🚫 + polite reply) | Regulated identity data; explicitly out of scope |

**Totals: 7 forward / 5 ack-only / 1 refuse.**

Two shared helpers carry the contract:
- `handleAckOnly(ctx, kind, {emoji, warn})` — gates through `access.allowFrom`, reacts with 👀 (or override), logs to stderr. No IPC broadcast — the agent is not bothered.
- `handleRefusal(ctx, kind, refusalText)` — gates, reacts 🚫, sends a polite reply, logs at `SECURITY` level. **Never** calls `handleInbound` or `ipcServer.broadcast` — passport data must not reach the agent under any circumstance.

Every handler is wrapped in try/catch so a malformed Telegram payload cannot tear down the dispatcher. Forwarded types build a self-describing `(<kind>: …)` text envelope so the agent gets a readable message without having to decode meta fields. `web_app_data.data` is capped at 4096 bytes because it's arbitrary mini-app output and shouldn't be a DoS vector.

## Test plan

- [x] `telegram-plugin/tests/inbound-message-types.test.ts` — 39 structural tests covering registration, helper invocation, decision-matrix completeness, and the passport_data isolation invariant (never calls `handleInbound`, never broadcasts to bridge).
- [x] `telegram-plugin/uat/scenarios/location-inbound-dm.test.ts` — end-to-end UAT for the location forward path; added `Driver.sendLocation` so mtcute can script the gesture.
- [x] `npm run lint` clean
- [x] `npm run build` clean
- [x] `npm run test:bun` — 640 pass, 2 skip, 0 fail
- [x] `npm run test:vitest` — only failure is the pre-existing `scaffold.persona.test.ts` "CLAUDE.md <16KB" assertion (confirmed failing on clean `upstream/main`, unrelated to this PR)
- [ ] UAT scenarios run in CI when the harness env is configured (gated by `TELEGRAM_API_ID` / `TELEGRAM_UAT_DRIVER_SESSION`).

UAT for the other 12 types is intentionally deferred — most require a mini-app, payments provider, or non-scriptable client gesture (dice roll, story share). The structural coverage in `inbound-message-types.test.ts` is the safety net for those.

Rebased on top of #1067 (currentTurn-atom singleton refactor) — no conflicts; new handlers live in the same `bot.on('message:*')` block but well below the lines #1067 touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)