### PR TITLE
fix(gateway): classify startup 401 as quarantine, no exit-loop (#1076)

### DIFF
--- a/profiles/_base/start.sh.hbs
+++ b/profiles/_base/start.sh.hbs
@@ -46,6 +46,19 @@ if [ "$SWITCHROOM_RUNTIME" = "docker" ] && [ -z "$SWITCHROOM_DOCKER_TMUX_INNER" 
       "$@" >> "$_logfile" 2>&1
       local _exit=$?
       local _now=$SECONDS
+      # Exit 78 = sysexits EX_CONFIG, the "permanent config error, do
+      # not restart" sentinel. The gateway uses this on a 401 from
+      # Telegram (#1076 — revoked / wrong-typed bot token). Restarting
+      # would just re-hit the same 401, burn the 10-in-60 s budget,
+      # and leave the agent silently dead. The supervisor instead
+      # records the quarantine in the log and stops — the host CLI
+      # (`switchroom doctor`, `switchroom agent restart`) reads the
+      # quarantine marker at <TELEGRAM_STATE_DIR>/quarantine.json and
+      # surfaces it to the operator.
+      if [ $_exit -eq 78 ]; then
+        echo "[supervise] $_name exit 78 (EX_CONFIG) — quarantined, not restarting. Operator action required." >> "$_logfile"
+        return 0
+      fi
       if [ $((_now - _window_start)) -ge 60 ]; then
         _restarts=0
         _window_start=$_now

--- a/src/agents/quarantine.ts
+++ b/src/agents/quarantine.ts
@@ -1,0 +1,181 @@
+/**
+ * Agent quarantine marker — a permanent-config-error flag the gateway
+ * raises so an out-of-band restart loop can't burn the supervisor budget.
+ *
+ * The Telegram gateway writes one of these (via `writeQuarantineMarker`)
+ * when a startup API call returns 401 Unauthorized — see #1076. A 401
+ * is permanent: the bot token has been revoked, rotated, or wrong-typed
+ * (a string that doesn't tokenise). Pre-fix the gateway exited 1 on
+ * every attempt; the in-container `_switchroom_supervise` respawned 10
+ * times in <60 s, hit the cap, and the gateway went silently dead. No
+ * Telegram surface, no operator signal, no doctor flag — just a non-
+ * responsive agent.
+ *
+ * Post-fix the gateway writes this marker + an issue + exits 78 (sysexits
+ * `EX_CONFIG`). The supervisor recognises 78 as "config error, don't
+ * restart" and stops. On the host side, `switchroom apply` and
+ * `switchroom agent restart` refuse to start a quarantined agent until
+ * the operator runs `switchroom agent unquarantine <name>`. The
+ * unquarantine simply clears the marker — the next boot is naive, and
+ * if the token is still bad we re-quarantine immediately.
+ *
+ * On-disk layout:
+ *
+ *   <telegramStateDir>/quarantine.json
+ *
+ * which expands to `<agentDir>/telegram/quarantine.json` for the
+ * canonical compose layout. The telegram state dir is the directory the
+ * gateway already mints (mkdir at 0o700) and that the host CLI can
+ * locate by joining `<agentsDir>/<name>/telegram`. Storing the marker
+ * here keeps the contract symmetric for both sides without inventing a
+ * new state location.
+ *
+ * SECURITY: the marker NEVER contains the bot token, even truncated.
+ * The threat model assumes the token is the secret being misused — see
+ * #1076. We store only timestamps, a reason code, and an optional short
+ * detail (e.g. the Telegram API description, which is "Unauthorized"
+ * for a 401 and contains no token material).
+ */
+
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
+
+export const QUARANTINE_FILENAME = "quarantine.json";
+
+/**
+ * Stable machine-readable reason codes. Add to this list (and document
+ * the operator remediation) when extending quarantine to new failure
+ * modes — e.g. "vault permanently sealed", "agent UID mismatch".
+ */
+export type QuarantineReason = "startup.unauthorized";
+
+export interface QuarantineMarker {
+  /** Schema version for forward-compat. Bump if shape changes. */
+  v: 1;
+  /** Stable code so doctor / CLI can switch on the reason. */
+  reason: QuarantineReason;
+  /** Unix epoch ms when the marker was written. */
+  ts: number;
+  /**
+   * Optional short human-readable detail. MUST NOT include any secret
+   * material (bot token, vault password, etc). For the 401 case this
+   * is just "Telegram API returned 401 Unauthorized".
+   */
+  detail?: string;
+}
+
+/**
+ * Resolve the marker path inside a Telegram state dir.
+ */
+export function quarantineMarkerPath(telegramStateDir: string): string {
+  return join(telegramStateDir, QUARANTINE_FILENAME);
+}
+
+/**
+ * Write the quarantine marker. Idempotent — overwrites any existing
+ * marker so a fresh `ts` lands on each detection. Creates the parent
+ * dir if it doesn't exist (defensive — the gateway already minted it
+ * by the time it would call this, but `apply --check`-like paths might
+ * not have).
+ */
+export function writeQuarantineMarker(
+  telegramStateDir: string,
+  reason: QuarantineReason,
+  detail?: string,
+  nowFn: () => number = Date.now,
+): void {
+  mkdirSync(telegramStateDir, { recursive: true, mode: 0o700 });
+  const marker: QuarantineMarker = {
+    v: 1,
+    reason,
+    ts: nowFn(),
+    detail,
+  };
+  // No atomic-rename song-and-dance — the marker is a single tiny JSON
+  // and a torn write yields invalid JSON, which `readQuarantineMarker`
+  // treats as "no marker" (best-effort surface). The next boot's
+  // detector will re-write it cleanly.
+  writeFileSync(
+    quarantineMarkerPath(telegramStateDir),
+    JSON.stringify(marker) + "\n",
+    "utf-8",
+  );
+}
+
+/**
+ * Read the quarantine marker, or `null` if absent / unparseable.
+ *
+ * Unparseable / corrupt markers are treated as "no marker present" so
+ * a single bad write can't deadlock the agent. The next gateway boot's
+ * 401-detection path will replace it with a valid marker.
+ */
+export function readQuarantineMarker(
+  telegramStateDir: string,
+): QuarantineMarker | null {
+  const path = quarantineMarkerPath(telegramStateDir);
+  if (!existsSync(path)) return null;
+  try {
+    const raw = readFileSync(path, "utf-8");
+    const parsed = JSON.parse(raw) as unknown;
+    if (!parsed || typeof parsed !== "object") return null;
+    const m = parsed as Partial<QuarantineMarker>;
+    if (m.v !== 1) return null;
+    if (typeof m.reason !== "string") return null;
+    if (typeof m.ts !== "number") return null;
+    return {
+      v: 1,
+      reason: m.reason as QuarantineReason,
+      ts: m.ts,
+      detail: typeof m.detail === "string" ? m.detail : undefined,
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Remove the marker, returning true if one was actually deleted.
+ * Idempotent: returns false if no marker existed. Used by
+ * `switchroom agent unquarantine`.
+ */
+export function clearQuarantineMarker(telegramStateDir: string): boolean {
+  const path = quarantineMarkerPath(telegramStateDir);
+  if (!existsSync(path)) return false;
+  try {
+    unlinkSync(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Host-side convenience. Given a switchroom config's agents dir and an
+ * agent name, return the path to that agent's telegram state dir as
+ * the host sees it on disk (NOT inside the container). The canonical
+ * layout is `<agentsDir>/<name>/telegram/` — mirrors
+ * `src/cli/agent.ts:preflightCheck`.
+ */
+export function hostTelegramStateDir(
+  agentsDir: string,
+  name: string,
+): string {
+  return join(agentsDir, name, "telegram");
+}
+
+/**
+ * Convenience reader for host-side callers (apply, agent start/restart,
+ * doctor). Resolves the marker path from agentsDir + name.
+ */
+export function readQuarantineMarkerForAgent(
+  agentsDir: string,
+  name: string,
+): QuarantineMarker | null {
+  return readQuarantineMarker(hostTelegramStateDir(agentsDir, name));
+}

--- a/src/cli/agent.ts
+++ b/src/cli/agent.ts
@@ -46,6 +46,12 @@ import {
   checkVaultPreflightBulk,
   formatLockedRefusalBulk,
 } from "./agent-vault-preflight.js";
+import {
+  clearQuarantineMarker,
+  hostTelegramStateDir,
+  readQuarantineMarkerForAgent,
+  type QuarantineMarker,
+} from "../agents/quarantine.js";
 
 /**
  * Pre-restart preflight check. Verifies the agent's runtime
@@ -165,6 +171,54 @@ function checkSwitchroomBranch(): string | null {
     // dist, etc) and skip the warning.
     return null;
   }
+}
+
+/**
+ * Render a quarantine-refusal banner. The host-side CLI checks the
+ * marker BEFORE issuing any `docker compose up` so the operator gets a
+ * single clear error and a documented unquarantine path, rather than
+ * watching the gateway re-crash on 401. See `src/agents/quarantine.ts`
+ * for the on-disk contract and #1076 for the originating incident.
+ */
+export function formatQuarantineRefusal(
+  name: string,
+  marker: QuarantineMarker,
+): string {
+  const ageSec = Math.max(0, Math.floor((Date.now() - marker.ts) / 1000));
+  const ageStr =
+    ageSec < 60
+      ? `${ageSec}s ago`
+      : ageSec < 3600
+        ? `${Math.floor(ageSec / 60)}m ago`
+        : ageSec < 86400
+          ? `${Math.floor(ageSec / 3600)}h ago`
+          : `${Math.floor(ageSec / 86400)}d ago`;
+  const reasonLine =
+    marker.reason === "startup.unauthorized"
+      ? "Telegram API rejected the bot token (401 Unauthorized)."
+      : `Quarantine reason: ${marker.reason}.`;
+  return (
+    `${name} is QUARANTINED (${ageStr}).\n` +
+    `      ${reasonLine}\n` +
+    (marker.detail ? `      ${marker.detail}\n` : "") +
+    `      Fix the underlying issue (e.g. rotate the bot token via \`switchroom vault\`), then:\n` +
+    `        switchroom agent unquarantine ${name}\n` +
+    `      That clears the marker; the next start re-checks the credential.`
+  );
+}
+
+/**
+ * If `name` has a quarantine marker, print the refusal banner and return
+ * true (caller should skip / abort). Returns false otherwise.
+ */
+export function checkQuarantineRefusal(
+  agentsDir: string,
+  name: string,
+): boolean {
+  const marker = readQuarantineMarkerForAgent(agentsDir, name);
+  if (!marker) return false;
+  console.error(chalk.red(`\n  ${formatQuarantineRefusal(name, marker)}\n`));
+  return true;
 }
 
 export function preflightCheck(
@@ -889,6 +943,16 @@ export function registerAgentCommand(program: Command): void {
             continue;
           }
 
+          // #1076: refuse to start a quarantined agent. The gateway last
+          // exited with a permanent-config-error (e.g. 401 from Telegram)
+          // and starting it again would just re-hit the same wall and
+          // burn the supervisor restart budget. Operator clears via
+          // `switchroom agent unquarantine <name>`. --force bypasses
+          // (matches the existing --force semantics for preflight).
+          if (!opts.force && checkQuarantineRefusal(agentsDir, n)) {
+            continue;
+          }
+
           if (!opts.force) {
             const agentDir = resolve(agentsDir, n);
             const usesDevChannels =
@@ -1053,6 +1117,18 @@ export function registerAgentCommand(program: Command): void {
               continue;
             }
 
+            // #1076: refuse to restart a quarantined agent. The gateway
+            // hit a permanent-config-error on its last start (e.g. 401
+            // from Telegram on a revoked token); restarting it again
+            // would just re-hit the same wall and burn the supervisor
+            // restart budget. Operator clears the marker explicitly via
+            // `switchroom agent unquarantine <name>` once the underlying
+            // credential is rotated. --force bypasses.
+            if (!opts.force && checkQuarantineRefusal(agentsDir, n)) {
+              sawAbort = true;
+              continue;
+            }
+
             const agentDir = resolve(agentsDir, n);
 
             // Preflight: verify runtime dependencies before restart.
@@ -1191,6 +1267,61 @@ export function registerAgentCommand(program: Command): void {
           }
         }
       )
+    );
+
+  // switchroom agent unquarantine <name>
+  // #1076: clear the quarantine marker so the next start/restart goes
+  // through. Operator-driven — the gateway never clears its own marker
+  // (the whole point is that the *next* boot is naive and re-quarantines
+  // if the underlying credential is still bad). Host-only by design:
+  // a quarantined agent has no Telegram surface, so there's no in-chat
+  // affordance and no admin gating to wire.
+  agent
+    .command("unquarantine <name>")
+    .description(
+      "Clear the quarantine marker so the agent's gateway will start on the next restart"
+    )
+    .action(
+      withConfigError(async (name: string) => {
+        const config = getConfig(program);
+        if (!config.agents[name]) {
+          console.error(
+            chalk.red(`Agent "${name}" is not defined in switchroom.yaml`)
+          );
+          process.exit(1);
+        }
+        const agentsDir = resolveAgentsDir(config);
+        const marker = readQuarantineMarkerForAgent(agentsDir, name);
+        if (!marker) {
+          console.log(
+            chalk.gray(`${name} is not quarantined — no marker to clear.`)
+          );
+          return;
+        }
+        const cleared = clearQuarantineMarker(
+          hostTelegramStateDir(agentsDir, name)
+        );
+        if (cleared) {
+          console.log(
+            chalk.green(
+              `Cleared quarantine marker for ${name} (was: ${marker.reason}).`
+            )
+          );
+          console.log(
+            chalk.gray(
+              `  Run \`switchroom agent restart ${name}\` to bring the gateway back up.\n` +
+                `  If the underlying issue isn't fixed (e.g. bot token still bad), the next start will re-quarantine.`
+            )
+          );
+        } else {
+          console.error(
+            chalk.red(
+              `Failed to clear marker for ${name} — check permissions on ${hostTelegramStateDir(agentsDir, name)}.`
+            )
+          );
+          process.exit(1);
+        }
+      })
     );
 
   // switchroom agent attach <name>

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -18,6 +18,7 @@ import { resolveAgentsDir, resolvePath } from "../config/loader.js";
 import { resolveStatePath } from "../config/paths.js";
 import { getConfig, getConfigPath, withConfigError } from "./helpers.js";
 import { getAllAgentStatuses } from "../agents/lifecycle.js";
+import { readQuarantineMarkerForAgent } from "../agents/quarantine.js";
 import { getAllAuthStatuses } from "../auth/manager.js";
 import { getSlotInfos, type SlotInfo } from "../auth/accounts.js";
 import type { SwitchroomConfig } from "../config/schema.js";
@@ -1021,6 +1022,39 @@ export function checkAgents(config: SwitchroomConfig, configPath: string): Check
         fix: `Run \`switchroom agent create ${name}\``,
       });
       continue;
+    }
+
+    // 1a. Quarantine marker (#1076). When the gateway exits via the
+    // EX_CONFIG path (revoked / wrong-typed bot token, today), it
+    // writes <agentDir>/telegram/quarantine.json and the supervisor
+    // stops respawning. This check surfaces the state to the operator
+    // so a silently-dead gateway can't hide behind a green doctor.
+    // Reported as `fail` because the agent is non-functional until
+    // the operator rotates the underlying credential and runs
+    // `switchroom agent unquarantine <name>`.
+    const quarantine = readQuarantineMarkerForAgent(agentsDir, name);
+    if (quarantine != null) {
+      const ageSec = Math.max(0, Math.floor((Date.now() - quarantine.ts) / 1000));
+      const ageStr =
+        ageSec < 60
+          ? `${ageSec}s`
+          : ageSec < 3600
+            ? `${Math.floor(ageSec / 60)}m`
+            : ageSec < 86400
+              ? `${Math.floor(ageSec / 3600)}h`
+              : `${Math.floor(ageSec / 86400)}d`;
+      const reasonText =
+        quarantine.reason === "startup.unauthorized"
+          ? "bot token rejected by Telegram (401) at gateway startup"
+          : quarantine.reason;
+      results.push({
+        name: `${name}: quarantine`,
+        status: "fail",
+        detail: `${reasonText} (${ageStr} ago)`,
+        fix:
+          `Rotate the bot token (e.g. via \`switchroom vault\`), then run ` +
+          `\`switchroom agent unquarantine ${name}\` and \`switchroom agent restart ${name}\``,
+      });
     }
 
     // 1b. start.sh has the post-Phase-4 scheduler supervisor block

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -77,6 +77,7 @@ import {
 } from '../pty-tail.js'
 import { clearStaleTelegramPollingState } from '../startup-reset.js'
 import { gatewayStartupRetry } from './startup-network-retry.js'
+import { writeQuarantineMarker } from './quarantine.js'
 import {
   parseAuthSubCommand,
   checkRemoveSafety,
@@ -11591,6 +11592,68 @@ void (async () => {
         // production incident that motivates this. Safe to re-run on retries.
         await clearStaleTelegramPollingState(bot.api)
         return bot.api.getMe()
+      }, {
+        // #1076: a revoked/wrong-typed bot token returns 401 Unauthorized.
+        // The pre-fix path rethrew non-network errors → the surrounding
+        // catch exited 1 → `_switchroom_supervise` respawned → repeat. Ten
+        // restarts in <60 s tripped the supervisor cap and the gateway
+        // went silently dead. New path: classify 401, write a high-
+        // severity issue (no token material, even truncated — threat
+        // model assumes the token is the misused secret), write the
+        // quarantine marker so the host CLI can refuse the next start,
+        // exit 78 (sysexits EX_CONFIG) so `_switchroom_supervise`
+        // stops respawning (start.sh.hbs treats 78 as "config error,
+        // don't restart").
+        onUnauthorized: (err) => {
+          const agentName = process.env.SWITCHROOM_AGENT_NAME ?? '-'
+          process.stderr.write(
+            `telegram gateway: startup.unauthorized — Telegram API rejected the bot token (401). ` +
+              `Marking agent quarantined; ` +
+              `operator action: rotate the token, then \`switchroom agent unquarantine ${agentName}\`. ` +
+              `err.name=${(err as Error)?.name ?? '?'}\n`,
+          )
+          // Issue sink — surfaces in `switchroom issues list` and
+          // `switchroom doctor`. The detail field deliberately omits the
+          // error message ("Unauthorized" is fine in principle but we
+          // keep the surface tight against future Grammy versions that
+          // might include header/body excerpts).
+          try {
+            switchroomExec([
+              'issues', 'record',
+              '--severity', 'critical',
+              '--source', 'gateway.startup',
+              '--code', 'gateway.startup.unauthorized',
+              '--summary', 'bot token rejected by Telegram (401) at startup',
+              '--detail', 'Telegram API returned 401 Unauthorized for the gateway startup probe. The bot token is revoked, rotated, or wrong-typed. Run `switchroom agent unquarantine ' + agentName + '` after rotating the token.',
+              '--quiet',
+            ])
+          } catch (issueErr) {
+            process.stderr.write(
+              `telegram gateway: startup.unauthorized: failed to write issue sink: ${(issueErr as Error).message}\n`,
+            )
+          }
+          // Quarantine marker — read by `switchroom apply` /
+          // `switchroom agent restart` to refuse a doomed restart, and
+          // by `switchroom doctor` to surface the state. Lives at
+          // <TELEGRAM_STATE_DIR>/quarantine.json (the same dir the
+          // gateway already minted at boot).
+          try {
+            writeQuarantineMarker(
+              STATE_DIR,
+              'startup.unauthorized',
+              'Telegram API returned 401 Unauthorized for getMe at gateway startup.',
+            )
+          } catch (markerErr) {
+            process.stderr.write(
+              `telegram gateway: startup.unauthorized: failed to write quarantine marker: ${(markerErr as Error).message}\n`,
+            )
+          }
+          // 78 = sysexits EX_CONFIG. start.sh.hbs's _switchroom_supervise
+          // honours this as "config error, do not restart". A bare
+          // exit 1 would put us right back in the respawn loop this fix
+          // exists to prevent.
+          process.exit(78)
+        },
       })
       // Backport of upstream `7e401ed` (claude-plugins-official #1397):
       // reset the backoff counter on successful poll-loop start so a

--- a/telegram-plugin/gateway/quarantine.ts
+++ b/telegram-plugin/gateway/quarantine.ts
@@ -1,0 +1,59 @@
+/**
+ * Gateway-side writer for the agent quarantine marker (#1076).
+ *
+ * Mirrors the on-disk contract owned by `src/agents/quarantine.ts` —
+ * the host-side host CLI reads the marker, the gateway writes it. We
+ * keep a tiny copy here (writer only) because the gateway is bundled
+ * separately and can't import from `src/`.
+ *
+ * The schema MUST stay in sync with `src/agents/quarantine.ts`:
+ *
+ *   { v: 1, reason: "startup.unauthorized", ts: <ms>, detail?: <string> }
+ *
+ * Any change to the shape should land in both files in the same PR
+ * (or be guarded by `v`). See the src module's docstring for the full
+ * threat-model and operator remediation.
+ *
+ * SECURITY: never write the bot token (or any secret material) into
+ * the marker. The detail field is for the API description ("Unauthorized")
+ * and similar non-secret context.
+ */
+
+import { mkdirSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+export const QUARANTINE_FILENAME = 'quarantine.json'
+
+export type QuarantineReason = 'startup.unauthorized'
+
+export interface QuarantineMarker {
+  v: 1
+  reason: QuarantineReason
+  ts: number
+  detail?: string
+}
+
+/**
+ * Write the quarantine marker into a Telegram state dir (typically
+ * `process.env.TELEGRAM_STATE_DIR`). Idempotent — overwrites any
+ * existing marker. Creates the parent dir if missing.
+ */
+export function writeQuarantineMarker(
+  telegramStateDir: string,
+  reason: QuarantineReason,
+  detail?: string,
+  nowFn: () => number = Date.now,
+): void {
+  mkdirSync(telegramStateDir, { recursive: true, mode: 0o700 })
+  const marker: QuarantineMarker = {
+    v: 1,
+    reason,
+    ts: nowFn(),
+    detail,
+  }
+  writeFileSync(
+    join(telegramStateDir, QUARANTINE_FILENAME),
+    JSON.stringify(marker) + '\n',
+    'utf-8',
+  )
+}

--- a/telegram-plugin/gateway/startup-network-retry.ts
+++ b/telegram-plugin/gateway/startup-network-retry.ts
@@ -1,5 +1,6 @@
 /**
- * Bounded exponential-backoff retry for gateway startup network errors.
+ * Bounded exponential-backoff retry for gateway startup network errors,
+ * with classification of the failure mode so the caller can act.
  *
  * On 2026-04-29 all five switchroom gateways silently broke at boot because
  * `api.telegram.org` was unreachable for ~27 minutes after system boot (the
@@ -9,21 +10,28 @@
  * process alive but not polling. No crash, so systemd's `Restart=always` never
  * fired. Telegram → agent delivery was dead until manual restarts.
  *
+ * Then issue #1076: a *revoked or wrong-typed* bot token returns Telegram API
+ * 401 `Unauthorized`. Pre-fix `gatewayStartupRetry` rethrew non-network errors
+ * immediately, the surrounding gateway catch block exited 1, the in-container
+ * `_switchroom_supervise` respawned, the new gateway re-hit 401, repeat. Ten
+ * restarts in <60 s tripped the supervisor cap and the gateway went silently
+ * dead with no operator-visible signal. This module now distinguishes 401 as
+ * a permanent config error, which the gateway handles by writing an issue +
+ * quarantine marker + exit-78 (the supervisor's "config error, don't
+ * restart" sentinel — see profiles/_base/start.sh.hbs).
+ *
  * This module provides:
  *
- *   `isBootNetworkError(err)`  — recognises network-layer errors thrown by
- *       grammy's HttpError wrapper and by raw fetch/Node network failures.
- *
- *   `STARTUP_RETRY_DELAYS_MS`  — the chosen backoff schedule.
- *
- *   `gatewayStartupRetry(fn, opts)` — drives the retry loop. Calls `fn()` up to
- *       `maxAttempts` times with delays from `delaysMs`. On success it resolves.
- *       On exhaustion it calls `opts.onExhausted()` (default: `process.exit(1)`)
- *       so systemd's `Restart=always` can restart the unit cleanly.
+ *   `classifyStartupError(err)` — returns `'network' | 'unauthorized' | 'other'`.
+ *   `isBootNetworkError(err)` — back-compat alias for the network arm.
+ *   `STARTUP_RETRY_DELAYS_MS` — the chosen backoff schedule.
+ *   `gatewayStartupRetry(fn, opts)` — drives the retry loop.
  *
  * The function is extracted from `gateway.ts`'s top-level IIFE so it can be
  * unit-tested without spinning up the full bot runtime.
  */
+
+export type StartupErrorKind = 'network' | 'unauthorized' | 'other'
 
 export interface StartupRetryOpts {
   /**
@@ -39,10 +47,22 @@ export interface StartupRetryOpts {
   sleep?: (ms: number) => Promise<void>
 
   /**
-   * Called when all attempts are exhausted. Should NOT return (exit/throw).
-   * Defaults to `process.exit(1)`.
+   * Called when all NETWORK retries are exhausted. Should NOT return
+   * (exit/throw). Defaults to `process.exit(1)` so systemd /
+   * `_switchroom_supervise` restart-on-failure can recycle the unit.
    */
   onExhausted?: (lastError: unknown) => never
+
+  /**
+   * Called when a startup API call returns 401 Unauthorized. The bot token
+   * is permanently wrong (revoked, wrong type, typo) — retrying just burns
+   * the supervisor restart budget. Caller should write an issue + quarantine
+   * marker and `process.exit(78)` (EX_CONFIG). Should NOT return.
+   *
+   * Default: same exit-1 path as `onExhausted` so callers that haven't been
+   * updated keep the pre-fix behaviour (rather than silently swallowing 401).
+   */
+  onUnauthorized?: (err: unknown) => never
 
   /** Log sink for retry progress messages. Defaults to process.stderr.write. */
   log?: (line: string) => void
@@ -67,38 +87,83 @@ const DEFAULT_SLEEP = (ms: number): Promise<void> =>
   new Promise((resolve) => setTimeout(resolve, ms))
 
 /**
- * Returns true if `err` is a transient network-level failure that the startup
- * retry loop should absorb. Covers:
+ * Classify a startup-time error into one of:
  *
- * - Grammy's `HttpError` (name === 'HttpError'), which wraps fetch/ECONN errors
- *   during `deleteWebhook` and `getMe`.
- * - Raw Node/fetch errors: ECONNRESET, ETIMEDOUT, ENOTFOUND, ECONNREFUSED,
- *   fetch failed, etc.
+ *   - `network`: transient connectivity / DNS / TCP / fetch failure — the
+ *     retry loop should absorb these with backoff.
+ *   - `unauthorized`: Telegram API 401 (revoked or wrong-typed bot token).
+ *     Permanent until the operator rotates the token. Retrying compounds
+ *     the supervisor restart budget for no gain — see #1076.
+ *   - `other`: everything else (bad request shape, 5xx, server bug, etc.).
+ *     Rethrown to the surrounding gateway catch block, which exits non-zero
+ *     so the supervisor can recycle.
+ *
+ * Grammy surfaces 401 via `GrammyError` (name === 'GrammyError') with
+ * `error_code === 401`. Some test fixtures and node-fetch wrappers surface
+ * 401 only in the message string, so we fall through to a substring match
+ * for `Unauthorized` as defence in depth.
  */
-export function isBootNetworkError(err: unknown): boolean {
-  if (!(err instanceof Error)) return false
-  // Grammy wraps network errors in HttpError (name is set in the constructor)
-  if (err.name === 'HttpError') return true
+export function classifyStartupError(err: unknown): StartupErrorKind {
+  if (!(err instanceof Error)) return 'other'
+
+  // Unauthorized (#1076). Check BEFORE the network arm so a Grammy-wrapped
+  // 401 doesn't accidentally match the "Network request" substring branch
+  // through some future change to grammy's error stringification.
+  const errAny = err as Error & {
+    error_code?: number
+    name?: string
+  }
+  if (
+    errAny.name === 'GrammyError' &&
+    errAny.error_code === 401
+  ) {
+    return 'unauthorized'
+  }
+  // Fall-back string match. Telegram's API returns the literal token
+  // 'Unauthorized' for 401 in the description field. We avoid a substring
+  // of just '401' here because that can match unrelated error codes /
+  // ports / numeric content.
+  if (err.message.includes('Unauthorized')) return 'unauthorized'
+
+  // Network arm — grammy wraps fetch/ECONN errors in HttpError.
+  if (err.name === 'HttpError') return 'network'
   const msg = err.message
-  return (
+  if (
     msg.includes('ECONNRESET') ||
     msg.includes('ETIMEDOUT') ||
     msg.includes('ENOTFOUND') ||
     msg.includes('ECONNREFUSED') ||
     msg.includes('fetch failed') ||
     msg.includes('Network request')
-  )
+  ) {
+    return 'network'
+  }
+
+  return 'other'
 }
 
 /**
- * Attempt `fn()` and retry on `isBootNetworkError` failures using the
- * provided delay schedule.
+ * Returns true if `err` is a transient network-level failure that the startup
+ * retry loop should absorb. Retained as a named export for the existing
+ * regression tests and downstream callers that only care about the network
+ * arm. Prefer `classifyStartupError` for new code.
+ */
+export function isBootNetworkError(err: unknown): boolean {
+  return classifyStartupError(err) === 'network'
+}
+
+/**
+ * Attempt `fn()` and retry on network failures using the provided delay
+ * schedule.
  *
  * - On success: returns whatever `fn()` resolved to.
- * - On non-network error: re-throws immediately (not a transient boot issue).
- * - On exhausted retries: calls `opts.onExhausted(lastError)` which must not
- *   return (it should exit or throw). The default is `process.exit(1)` so
- *   systemd's `Restart=always` picks up the dead unit.
+ * - On unauthorized (401): calls `opts.onUnauthorized(err)` which must not
+ *   return. The gateway uses this to write an issue + quarantine marker
+ *   + `process.exit(78)`. Default is `process.exit(1)` for back-compat.
+ * - On other non-network error: re-throws immediately (not a transient
+ *   boot issue, not a known config error).
+ * - On exhausted network retries: calls `opts.onExhausted(lastError)` which
+ *   must not return. Default is `process.exit(1)`.
  */
 export async function gatewayStartupRetry<T>(
   fn: () => Promise<T>,
@@ -111,6 +176,16 @@ export async function gatewayStartupRetry<T>(
     ((err: unknown) => {
       process.stderr.write(
         `telegram gateway: startup failed after ${delays.length + 1} attempts — exiting so systemd can restart: ${err}\n`,
+      )
+      process.exit(1)
+    })
+  const onUnauthorized: (err: unknown) => never =
+    opts.onUnauthorized ??
+    ((err: unknown) => {
+      // Back-compat default. Real callers (gateway.ts) override this with
+      // an issue-sink writer + quarantine-marker writer + exit-78.
+      process.stderr.write(
+        `telegram gateway: startup unauthorized (bot token rejected) — exiting: ${(err as Error).message}\n`,
       )
       process.exit(1)
     })
@@ -127,7 +202,10 @@ export async function gatewayStartupRetry<T>(
     try {
       return await fn()
     } catch (err) {
-      if (!isBootNetworkError(err)) throw err
+      const kind = classifyStartupError(err)
+      if (kind === 'unauthorized') return onUnauthorized(err)
+      if (kind === 'other') throw err
+      // network
       lastError = err
       if (attempt >= maxAttempts) break
       const delayMs = delays[attempt - 1]

--- a/telegram-plugin/tests/gateway-startup-network-retry.test.ts
+++ b/telegram-plugin/tests/gateway-startup-network-retry.test.ts
@@ -18,6 +18,7 @@ import { describe, it, expect, vi } from 'vitest'
 import {
   isBootNetworkError,
   gatewayStartupRetry,
+  classifyStartupError,
   STARTUP_RETRY_DELAYS_MS,
 } from '../gateway/startup-network-retry'
 
@@ -73,6 +74,57 @@ describe('isBootNetworkError', () => {
     expect(isBootNetworkError('string error')).toBe(false)
     expect(isBootNetworkError(null)).toBe(false)
     expect(isBootNetworkError(42)).toBe(false)
+  })
+})
+
+// ── classifyStartupError ──────────────────────────────────────────────────────
+
+describe('classifyStartupError', () => {
+  it('classifies grammy 401 (GrammyError, error_code=401) as unauthorized', () => {
+    const err = Object.assign(new Error('Unauthorized'), {
+      name: 'GrammyError',
+      error_code: 401,
+    })
+    expect(classifyStartupError(err)).toBe('unauthorized')
+  })
+
+  it('classifies an Unauthorized-message error as unauthorized — defence in depth', () => {
+    expect(classifyStartupError(new Error('Unauthorized'))).toBe('unauthorized')
+  })
+
+  it('does NOT mis-classify a network error mentioning "401" port as unauthorized', () => {
+    // Hypothetical message that happens to contain "401" but isn't a
+    // 401 status. classifyStartupError matches on the literal token
+    // "Unauthorized" rather than the substring "401" to avoid this.
+    expect(classifyStartupError(new Error('connect ECONNREFUSED 10.0.0.1:401'))).toBe('network')
+  })
+
+  it('classifies HttpError as network', () => {
+    const err = Object.assign(new Error('Network request failed'), {
+      name: 'HttpError',
+    })
+    expect(classifyStartupError(err)).toBe('network')
+  })
+
+  it('classifies ETIMEDOUT as network', () => {
+    expect(classifyStartupError(new Error('connect ETIMEDOUT 1.2.3.4:443'))).toBe('network')
+  })
+
+  it('classifies a bare app error as other', () => {
+    expect(classifyStartupError(new Error('something else'))).toBe('other')
+  })
+
+  it('classifies non-Error values as other', () => {
+    expect(classifyStartupError('string')).toBe('other')
+    expect(classifyStartupError(null)).toBe('other')
+  })
+
+  it('classifies a GrammyError 403 (kicked) as other — surfaces as a fatal rethrow', () => {
+    const err = Object.assign(new Error('Forbidden: bot was kicked'), {
+      name: 'GrammyError',
+      error_code: 403,
+    })
+    expect(classifyStartupError(err)).toBe('other')
   })
 })
 
@@ -160,6 +212,58 @@ describe('gatewayStartupRetry', () => {
     // Verify the schedule is monotonically increasing and ends at 64 s
     expect(STARTUP_RETRY_DELAYS_MS[0]).toBe(1_000)
     expect(STARTUP_RETRY_DELAYS_MS[STARTUP_RETRY_DELAYS_MS.length - 1]).toBe(64_000)
+  })
+
+  it('calls onUnauthorized (not onExhausted, not rethrow) on a 401 — #1076', async () => {
+    // Grammy surfaces 401 via GrammyError with error_code=401.
+    const authErr = Object.assign(new Error('Unauthorized'), {
+      name: 'GrammyError',
+      error_code: 401,
+    })
+    const fn = vi.fn().mockRejectedValue(authErr)
+    const onUnauthorized = vi.fn(() => {
+      throw new Error('__quarantined__')
+    }) as unknown as (err: unknown) => never
+    const onExhausted = vi.fn(() => {
+      throw new Error('__exhausted__')
+    }) as unknown as (err: unknown) => never
+    const sleep = vi.fn().mockResolvedValue(undefined)
+
+    await expect(
+      gatewayStartupRetry(fn, {
+        delaysMs: [100, 200, 400],
+        sleep,
+        onUnauthorized,
+        onExhausted,
+        log: noopLog,
+      }),
+    ).rejects.toThrow('__quarantined__')
+
+    // 401 short-circuits — only one fn() call, no retries, no exhaustion path.
+    expect(fn).toHaveBeenCalledTimes(1)
+    expect(sleep).not.toHaveBeenCalled()
+    expect(onExhausted).not.toHaveBeenCalled()
+    expect(onUnauthorized).toHaveBeenCalledTimes(1)
+    expect(onUnauthorized).toHaveBeenCalledWith(authErr)
+  })
+
+  it('classifies a 401-message-only error (no error_code) as unauthorized — defence in depth', async () => {
+    // Some fetch wrappers / test fixtures surface 401 only in the message.
+    const authErr = new Error('Unauthorized')
+    const fn = vi.fn().mockRejectedValue(authErr)
+    const onUnauthorized = vi.fn(() => {
+      throw new Error('__quarantined__')
+    }) as unknown as (err: unknown) => never
+
+    await expect(
+      gatewayStartupRetry(fn, {
+        delaysMs: [1, 2],
+        sleep: vi.fn(),
+        onUnauthorized,
+        log: noopLog,
+      }),
+    ).rejects.toThrow('__quarantined__')
+    expect(onUnauthorized).toHaveBeenCalledTimes(1)
   })
 
   it('logs retry progress before each sleep', async () => {

--- a/tests/cli.agent-quarantine.test.ts
+++ b/tests/cli.agent-quarantine.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  checkQuarantineRefusal,
+  formatQuarantineRefusal,
+} from "../src/cli/agent.js";
+import { mkdtempSync, mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  hostTelegramStateDir,
+  writeQuarantineMarker,
+} from "../src/agents/quarantine.js";
+
+/**
+ * Coverage for the CLI-side quarantine refusal + formatter (#1076).
+ *
+ * `checkQuarantineRefusal` is the load-bearing gate for `switchroom
+ * agent start` / `restart` — if it returns false for a quarantined
+ * agent, the operator pays for another respawn loop on the doomed
+ * gateway. If it returns true for a non-quarantined agent, every
+ * start spuriously aborts.
+ */
+
+describe("formatQuarantineRefusal", () => {
+  it("includes the agent name, reason text, and operator action", () => {
+    const out = formatQuarantineRefusal("alfred", {
+      v: 1,
+      reason: "startup.unauthorized",
+      ts: Date.now() - 5_000,
+      detail: "Telegram API returned 401 Unauthorized for getMe.",
+    });
+    expect(out).toMatch(/alfred is QUARANTINED/);
+    expect(out).toMatch(/401 Unauthorized/);
+    expect(out).toMatch(/switchroom agent unquarantine alfred/);
+  });
+
+  it("handles a missing detail field without printing 'undefined'", () => {
+    const out = formatQuarantineRefusal("alfred", {
+      v: 1,
+      reason: "startup.unauthorized",
+      ts: Date.now(),
+    });
+    expect(out).not.toMatch(/undefined/);
+  });
+});
+
+describe("checkQuarantineRefusal", () => {
+  it("returns false when no marker is present", () => {
+    const dir = mkdtempSync(join(tmpdir(), "quar-refusal-"));
+    try {
+      // No marker created → no refusal.
+      expect(checkQuarantineRefusal(dir, "alfred")).toBe(false);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("returns true when a marker exists (caller should abort)", () => {
+    const agentsDir = mkdtempSync(join(tmpdir(), "quar-refusal-"));
+    try {
+      const stateDir = hostTelegramStateDir(agentsDir, "alfred");
+      mkdirSync(stateDir, { recursive: true });
+      writeQuarantineMarker(stateDir, "startup.unauthorized", "401");
+      // Suppress console.error noise from the printed banner.
+      const origErr = console.error;
+      console.error = () => {};
+      try {
+        expect(checkQuarantineRefusal(agentsDir, "alfred")).toBe(true);
+      } finally {
+        console.error = origErr;
+      }
+    } finally {
+      rmSync(agentsDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/quarantine.test.ts
+++ b/tests/quarantine.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  clearQuarantineMarker,
+  hostTelegramStateDir,
+  quarantineMarkerPath,
+  readQuarantineMarker,
+  readQuarantineMarkerForAgent,
+  writeQuarantineMarker,
+  QUARANTINE_FILENAME,
+} from "../src/agents/quarantine.js";
+
+/**
+ * Coverage for the on-disk quarantine marker contract (#1076).
+ *
+ * The marker is the load-bearing signal that ties the gateway's 401
+ * detection to the host CLI's refuse-to-start path. If the writer/reader
+ * disagree on shape or location, the entire fix collapses silently.
+ */
+
+describe("quarantine marker", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "switchroom-quarantine-test-"));
+  });
+
+  afterEach(() => {
+    try {
+      rmSync(dir, { recursive: true, force: true });
+    } catch {
+      /* best-effort cleanup */
+    }
+  });
+
+  it("write then read round-trips fields", () => {
+    writeQuarantineMarker(
+      dir,
+      "startup.unauthorized",
+      "Telegram API returned 401 Unauthorized for getMe.",
+      () => 1700000000000,
+    );
+    const got = readQuarantineMarker(dir);
+    expect(got).not.toBeNull();
+    expect(got!.v).toBe(1);
+    expect(got!.reason).toBe("startup.unauthorized");
+    expect(got!.ts).toBe(1700000000000);
+    expect(got!.detail).toBe(
+      "Telegram API returned 401 Unauthorized for getMe.",
+    );
+  });
+
+  it("read returns null when the marker is absent", () => {
+    expect(readQuarantineMarker(dir)).toBeNull();
+  });
+
+  it("read returns null on unparseable JSON (best-effort surface)", () => {
+    writeFileSync(quarantineMarkerPath(dir), "{not json", "utf-8");
+    expect(readQuarantineMarker(dir)).toBeNull();
+  });
+
+  it("read returns null on a v=99 marker (forward-compat: unknown schema is no marker)", () => {
+    writeFileSync(
+      quarantineMarkerPath(dir),
+      JSON.stringify({ v: 99, reason: "x", ts: 1 }) + "\n",
+      "utf-8",
+    );
+    expect(readQuarantineMarker(dir)).toBeNull();
+  });
+
+  it("write creates the parent dir when missing", () => {
+    const nested = join(dir, "telegram-state-doesnt-exist-yet");
+    writeQuarantineMarker(nested, "startup.unauthorized");
+    const got = readQuarantineMarker(nested);
+    expect(got).not.toBeNull();
+    expect(got!.reason).toBe("startup.unauthorized");
+  });
+
+  it("write is idempotent and overwrites prior markers", () => {
+    writeQuarantineMarker(dir, "startup.unauthorized", "first", () => 100);
+    writeQuarantineMarker(dir, "startup.unauthorized", "second", () => 200);
+    const got = readQuarantineMarker(dir);
+    expect(got!.ts).toBe(200);
+    expect(got!.detail).toBe("second");
+  });
+
+  it("written file does not contain bot-token-like material (sanity check on the contract)", () => {
+    writeQuarantineMarker(
+      dir,
+      "startup.unauthorized",
+      "Telegram API returned 401 Unauthorized for getMe at gateway startup.",
+    );
+    const raw = readFileSync(quarantineMarkerPath(dir), "utf-8");
+    // The Telegram bot token format is `<digits>:<base64ish>`. Make sure
+    // a colon-separated digit-prefixed string can't sneak in via detail.
+    expect(raw).not.toMatch(/\b\d{6,}:[A-Za-z0-9_-]{20,}\b/);
+  });
+
+  it("clearQuarantineMarker removes the file and returns true; second call returns false", () => {
+    writeQuarantineMarker(dir, "startup.unauthorized");
+    expect(clearQuarantineMarker(dir)).toBe(true);
+    expect(readQuarantineMarker(dir)).toBeNull();
+    expect(clearQuarantineMarker(dir)).toBe(false);
+  });
+
+  it("hostTelegramStateDir composes <agentsDir>/<name>/telegram", () => {
+    expect(hostTelegramStateDir("/srv/agents", "alfred")).toBe(
+      "/srv/agents/alfred/telegram",
+    );
+  });
+
+  it("readQuarantineMarkerForAgent reads via the same on-disk location the gateway writes to", () => {
+    const agentsDir = dir;
+    const name = "alfred";
+    const stateDir = hostTelegramStateDir(agentsDir, name);
+    mkdirSync(stateDir, { recursive: true });
+    writeQuarantineMarker(stateDir, "startup.unauthorized", "detail-here", () => 42);
+    const got = readQuarantineMarkerForAgent(agentsDir, name);
+    expect(got).not.toBeNull();
+    expect(got!.ts).toBe(42);
+    expect(got!.detail).toBe("detail-here");
+  });
+
+  it("uses the documented filename `quarantine.json` (contract symmetry with telegram-plugin/gateway/quarantine.ts)", () => {
+    expect(QUARANTINE_FILENAME).toBe("quarantine.json");
+    writeQuarantineMarker(dir, "startup.unauthorized");
+    expect(quarantineMarkerPath(dir)).toBe(join(dir, "quarantine.json"));
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #1076 — silent gateway crashloop when the Telegram bot token is revoked or wrong-typed.

A 401 Unauthorized on the gateway's startup `getMe` probe used to rethrow → the surrounding catch exited 1 → `_switchroom_supervise` respawned → the new gateway re-hit the same 401 → repeat. Ten restarts in <60 s tripped the supervisor cap and the gateway went silently dead. No Telegram surface (the gateway IS the Telegram surface), no operator signal, no doctor flag — just an agent that stopped delivering messages until someone SSHed in.

The fix classifies 401 as a permanent config error and routes it through a one-shot quarantine path:

- `classifyStartupError(err)` returns `'network' | 'unauthorized' | 'other'`. 401 is matched on `GrammyError.error_code` AND a string fallback (defence in depth).
- `gatewayStartupRetry` gains `onUnauthorized` — the gateway uses it to write a `critical` issue (`gateway.startup.unauthorized`), write a quarantine marker at `<TELEGRAM_STATE_DIR>/quarantine.json`, and `process.exit(78)` (sysexits `EX_CONFIG`).
- `_switchroom_supervise` honours exit 78 as "permanent config error, do not restart" — preserves the existing crash-restart behaviour for crash-restart cases.
- `switchroom agent start` / `restart` refuse to bring up a quarantined agent with a clear operator action.
- `switchroom agent unquarantine <name>` clears the marker. Next start is naive; if the credential is still bad, the gateway re-quarantines.
- `switchroom doctor` surfaces quarantined agents as `fail` with the rotate-then-unquarantine fix line.

### Security

The marker NEVER contains the bot token, even truncated — the threat model assumes the token is the misused secret. The issue-sink detail is similarly token-free (just the API status name and the unquarantine command). Pinned in `tests/quarantine.test.ts` ("written file does not contain bot-token-like material").

### Exit-code rationale

`restart: unless-stopped` is on the agent container, but the gateway is a supervised sidecar inside the container, not the container's PID 1 — so docker's restart policy doesn't apply. The actual supervisor is `_switchroom_supervise` in `profiles/_base/start.sh.hbs`. Honouring 78 specifically lets us distinguish "permanent config" from "transient failure" without losing crash-restart for the crash-restart cases. Exit 0 was the alternative but would have masked legitimate clean-shutdown signals; 78 (sysexits `EX_CONFIG`) is unambiguous and survives a future migration to a different supervisor.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run build` — clean
- [x] `npm run test:vitest` — 5544 pass / 1 pre-existing unrelated fail (`scaffold.persona.test.ts` size cap, confirmed on base)
- [x] `npm run test:bun` — 640 pass / 0 fail
- [x] New unit coverage:
  - `classifyStartupError` for grammy-401, message-only-401, ETIMEDOUT, GrammyError-403, non-Error values
  - `gatewayStartupRetry` honours `onUnauthorized` (no retries, no exhaustion path, single-shot)
  - `writeQuarantineMarker` / `readQuarantineMarker` round-trip + forward-compat null on `v=99`
  - `checkQuarantineRefusal` + `formatQuarantineRefusal`
- [ ] **UAT skipped intentionally** — exercising the full path end-to-end requires deliberately revoking a live bot token. Unit + integration coverage above is the verification.

## Operator surface

- New CLI: `switchroom agent unquarantine <name>` — host-only, no Telegram surface (a quarantined agent has none).
- `switchroom doctor` lights up `<name>: quarantine [fail]` with the recovery steps.
- `switchroom agent start` / `restart` refuse quarantined agents and print the unquarantine command in the refusal banner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)