### PR TITLE
feat(hooks): sandbox-hint-posttool — inject EROFS context after tool failures

### DIFF
--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -2691,6 +2691,27 @@ export function buildSettingsHooksBlock(p: HooksBlockParams): Record<string, unk
             },
           ],
         },
+        {
+          // Layer 2 of the sandbox UX work — fires on every PostToolUse,
+          // detects EROFS / read-only / sandbox-related errors in
+          // tool_response, and injects a one-line hint via
+          // additionalContext so the agent responds usefully on Telegram
+          // instead of silently retrying or echoing the raw kernel
+          // error. Pairs with the SANDBOX primer in
+          // --append-system-prompt. Hook is fail-silent: a broken hint
+          // never blocks the tool flow.
+          matcher: ".*",
+          hooks: [
+            {
+              type: "command",
+              command: wrap(
+                "hook:sandbox-hint-posttool",
+                `node "${join(DOCKER_HOOKS_PATH, "sandbox-hint-posttool.mjs")}"`,
+              ),
+              timeout: 3,
+            },
+          ],
+        },
       ]
     : [];
 

--- a/telegram-plugin/hooks/hooks.json
+++ b/telegram-plugin/hooks/hooks.json
@@ -40,6 +40,16 @@
             "timeout": 10
           }
         ]
+      },
+      {
+        "matcher": ".*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/sandbox-hint-posttool.mjs\"",
+            "timeout": 3
+          }
+        ]
       }
     ],
     "Stop": [

--- a/telegram-plugin/hooks/sandbox-hint-posttool.mjs
+++ b/telegram-plugin/hooks/sandbox-hint-posttool.mjs
@@ -1,0 +1,130 @@
+#!/usr/bin/env node
+/**
+ * PostToolUse hook — detects sandbox-related errors in tool_response and
+ * injects a one-line hint via Claude Code's `hookSpecificOutput.
+ * additionalContext` channel. The hint reminds the agent that the
+ * read-only file system / EROFS error is the switchroom sandbox working
+ * as intended, and that it should respond to the user with a concrete
+ * "Operator action: ..." line rather than retrying or echoing the raw
+ * kernel error.
+ *
+ * Pairs with the SANDBOX_GUIDANCE primer in --append-system-prompt
+ * (src/agents/scaffold.ts). The primer is the always-on context; this
+ * hook is the just-in-time nudge that fires only when the agent
+ * actually hits the boundary.
+ *
+ * Claude Code PostToolUse protocol:
+ *   stdin:  JSON { tool_name, tool_use_id, tool_input, tool_response, ... }
+ *   stdout: optional JSON
+ *             {"hookSpecificOutput":{"hookEventName":"PostToolUse",
+ *              "additionalContext":"<text>"}}
+ *           prepended to the model's next-turn context after the tool
+ *           result is shown.
+ *   exit:   0 always. Hook failures must never block the tool flow.
+ *
+ * Design notes:
+ *   - Detection is a substring/regex match against the stringified
+ *     tool_response (covers stdout, stderr, error fields).
+ *   - No DB writes, no IPC. Pure stdin → stdout, fail-silent.
+ *   - Idempotent: re-reading the same tool_response yields the same
+ *     hint. Claude Code dedupes additionalContext naturally because the
+ *     hook fires once per PostToolUse event.
+ */
+
+import { readFileSync } from 'node:fs'
+
+function readStdin() {
+  try {
+    return readFileSync(0, 'utf8')
+  } catch {
+    return ''
+  }
+}
+
+/**
+ * Patterns that indicate a sandbox-boundary hit, in order of specificity.
+ * Each entry: [regex, hint-key]. Hint text is composed below from the
+ * matched key — keeps the patterns easy to scan.
+ */
+const PATTERNS = [
+  // The canonical kernel error code + message. Covers most write/mkdir/
+  // rename/unlink failures against the read-only rootfs.
+  [/\bEROFS\b/, 'erofs'],
+  [/read[- ]only file ?system/i, 'erofs'],
+  // npm/pip install attempts that hit a read-only prefix. These usually
+  // surface as ENOENT or permission errors against /usr/lib/node_modules
+  // or /usr/local/lib — listing the explicit paths keeps us from
+  // false-matching on user code that legitimately mentions /usr.
+  [/EACCES.+\/(usr|opt|etc|bin|lib)\//, 'eacces-rootfs'],
+  // apt / dpkg refusing to write to /var/lib/dpkg etc.
+  [/dpkg.*permission denied|apt.*permission denied|Unable to acquire the dpkg/i, 'apt'],
+]
+
+function buildHint(key) {
+  const common =
+    'Sandbox boundary hit. The agent container has `read_only: true` rootfs ' +
+    '(see the SANDBOX primer in the system prompt). Do NOT retry the same ' +
+    'write. Tell the user what you tried, why the sandbox blocked it, and ' +
+    'name an operator action (e.g. "edit on host then `switchroom apply`", ' +
+    'or "add to docker/Dockerfile.agent and rebuild"). Writable paths: ' +
+    '$HOME (/state/agent/home), /tmp, /state/agent/**, /var/log/switchroom.'
+
+  if (key === 'apt') {
+    return (
+      common +
+      ' For package installs specifically: ask the operator to add the ' +
+      'package to docker/Dockerfile.agent and rebuild the agent image — ' +
+      'in-container apt is not the right path.'
+    )
+  }
+  return common
+}
+
+function emitContext(text) {
+  const payload = {
+    hookSpecificOutput: {
+      hookEventName: 'PostToolUse',
+      additionalContext: text,
+    },
+  }
+  process.stdout.write(JSON.stringify(payload) + '\n')
+}
+
+function main() {
+  const raw = readStdin()
+  if (!raw) return
+
+  let evt
+  try {
+    evt = JSON.parse(raw)
+  } catch {
+    return
+  }
+
+  // tool_response shape varies by tool — string for Bash, object with
+  // file/oldString/newString for Edit/Write, etc. Stringify the whole
+  // thing so we match against every nested error field at once. Cap the
+  // scan window to keep memory bounded if the model just dumped a 10MB
+  // log into the tool_response.
+  let body
+  try {
+    body = JSON.stringify(evt.tool_response ?? '')
+  } catch {
+    return
+  }
+  if (!body) return
+  if (body.length > 64 * 1024) body = body.slice(0, 64 * 1024)
+
+  for (const [pattern, key] of PATTERNS) {
+    if (pattern.test(body)) {
+      emitContext(buildHint(key))
+      return
+    }
+  }
+}
+
+try {
+  main()
+} catch {
+  // Fail-silent. The PostToolUse must never block the tool flow.
+}

--- a/telegram-plugin/tests/sandbox-hint-posttool.test.ts
+++ b/telegram-plugin/tests/sandbox-hint-posttool.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Tests for the sandbox-hint-posttool hook (Layer 2 of the sandbox UX work).
+ *
+ * Hook contract:
+ *   stdin:  PostToolUse JSON event { tool_name, tool_response, ... }
+ *   stdout: optional JSON
+ *             {"hookSpecificOutput":{"hookEventName":"PostToolUse",
+ *              "additionalContext":"..."}}
+ *   exit:   0 always.
+ *
+ * Tests spawn the hook as a subprocess (mirroring how Claude Code invokes
+ * it), feed a tool_response, and assert whether additionalContext was
+ * emitted and that it carries the load-bearing strings the agent needs.
+ */
+
+import { describe, it, expect } from 'bun:test'
+import { join } from 'path'
+import { spawnSync } from 'child_process'
+
+const HOOK_SCRIPT = join(import.meta.dir, '..', 'hooks', 'sandbox-hint-posttool.mjs')
+
+function runHook(event: object) {
+  const result = spawnSync(process.execPath, [HOOK_SCRIPT], {
+    input: JSON.stringify(event),
+    encoding: 'utf8',
+    env: process.env,
+    timeout: 5_000,
+  })
+  return result
+}
+
+function parseContext(stdout: string): string | null {
+  if (!stdout.trim()) return null
+  const parsed = JSON.parse(stdout)
+  return parsed?.hookSpecificOutput?.additionalContext ?? null
+}
+
+describe('sandbox-hint-posttool', () => {
+  it('emits sandbox hint when tool_response contains EROFS', () => {
+    const result = runHook({
+      tool_name: 'Write',
+      tool_use_id: 'toolu_001',
+      tool_response: {
+        error: "EROFS: read-only file system, open '/opt/switchroom/skills/foo.md'",
+      },
+    })
+
+    expect(result.status).toBe(0)
+    const ctx = parseContext(result.stdout)
+    expect(ctx).not.toBeNull()
+    expect(ctx).toContain('Sandbox boundary hit')
+    expect(ctx).toContain('operator action')
+    expect(ctx).toContain('Writable paths')
+  })
+
+  it('emits sandbox hint when tool_response contains "Read-only file system"', () => {
+    const result = runHook({
+      tool_name: 'Edit',
+      tool_use_id: 'toolu_002',
+      tool_response: 'mkdir: cannot create directory: Read-only file system',
+    })
+
+    expect(result.status).toBe(0)
+    const ctx = parseContext(result.stdout)
+    expect(ctx).toContain('Sandbox boundary hit')
+  })
+
+  it('emits an apt-specific hint when tool_response shows dpkg permission denied', () => {
+    const result = runHook({
+      tool_name: 'Bash',
+      tool_use_id: 'toolu_003',
+      tool_response: {
+        stderr:
+          'E: Unable to acquire the dpkg frontend lock (/var/lib/dpkg/lock-frontend), are you root?',
+      },
+    })
+
+    expect(result.status).toBe(0)
+    const ctx = parseContext(result.stdout)
+    expect(ctx).toContain('docker/Dockerfile.agent')
+    expect(ctx).toContain('rebuild')
+  })
+
+  it('emits a hint for EACCES on a rootfs path', () => {
+    const result = runHook({
+      tool_name: 'Bash',
+      tool_use_id: 'toolu_004',
+      tool_response: 'npm ERR! EACCES: permission denied, mkdir "/usr/lib/node_modules/foo"',
+    })
+
+    expect(result.status).toBe(0)
+    const ctx = parseContext(result.stdout)
+    expect(ctx).toContain('Sandbox boundary hit')
+  })
+
+  it('emits nothing when tool_response is a normal success', () => {
+    const result = runHook({
+      tool_name: 'Bash',
+      tool_use_id: 'toolu_005',
+      tool_response: { stdout: 'hello world\n', exit_code: 0 },
+    })
+
+    expect(result.status).toBe(0)
+    expect(result.stdout.trim()).toBe('')
+  })
+
+  it('emits nothing when tool_response merely mentions /usr but is not a sandbox error', () => {
+    // Guard against false positives — the agent may legitimately discuss
+    // paths under /usr in normal output (e.g. `which node` returning
+    // /usr/local/bin/node). Only EACCES / EROFS patterns should trigger.
+    const result = runHook({
+      tool_name: 'Bash',
+      tool_use_id: 'toolu_006',
+      tool_response: { stdout: '/usr/local/bin/node\n' },
+    })
+
+    expect(result.status).toBe(0)
+    expect(result.stdout.trim()).toBe('')
+  })
+
+  it('exits 0 on malformed stdin without crashing', () => {
+    const result = spawnSync(process.execPath, [HOOK_SCRIPT], {
+      input: 'not json at all',
+      encoding: 'utf8',
+      timeout: 5_000,
+    })
+    expect(result.status).toBe(0)
+    expect(result.stdout.trim()).toBe('')
+  })
+
+  it('exits 0 on empty stdin', () => {
+    const result = spawnSync(process.execPath, [HOOK_SCRIPT], {
+      input: '',
+      encoding: 'utf8',
+      timeout: 5_000,
+    })
+    expect(result.status).toBe(0)
+    expect(result.stdout.trim()).toBe('')
+  })
+
+  it('caps the scan window for huge tool_response payloads', () => {
+    // 100 KiB of harmless output followed by an EROFS — we cap at 64 KiB
+    // so this should NOT match. Keeps a runaway tool_response from
+    // pinning the hook on a regex scan.
+    const huge = 'x'.repeat(100 * 1024) + ' EROFS happened'
+    const result = runHook({
+      tool_name: 'Bash',
+      tool_use_id: 'toolu_007',
+      tool_response: { stdout: huge },
+    })
+
+    expect(result.status).toBe(0)
+    expect(result.stdout.trim()).toBe('')
+  })
+})

--- a/tests/telegram-plugin-manifest.test.ts
+++ b/tests/telegram-plugin-manifest.test.ts
@@ -84,6 +84,7 @@ describe("telegram-plugin manifest (#229)", () => {
     expect(all).toContain("secret-guard-pretool.mjs");
     expect(all).toContain("subagent-tracker-pretool.mjs");
     expect(all).toContain("subagent-tracker-posttool.mjs");
+    expect(all).toContain("sandbox-hint-posttool.mjs");
     expect(all).toContain("secret-scrub-stop.mjs");
     expect(all).toContain("silent-end-interrupt-stop.mjs");
   });


### PR DESCRIPTION
## Summary
- New `telegram-plugin/hooks/sandbox-hint-posttool.mjs`: fires on every PostToolUse, detects EROFS / "read-only file system" / EACCES-on-rootfs / dpkg-permission patterns in `tool_response`, and emits a one-line hint via `hookSpecificOutput.additionalContext`. The model sees the hint on the *same turn* it sees the tool failure, so it explains the failure to the user with a concrete "Operator action: …" line instead of silently retrying or echoing the raw kernel error.
- Wired into `scaffold.ts` under the existing `useSwitchroomPlugin` gate (mirrors the `subagent-tracker-posttool` entry, with a `.*` matcher and 3s timeout).
- Also added to the plugin manifest (`telegram-plugin/hooks/hooks.json`) per the #230 migration contract pinned by `tests/telegram-plugin-manifest.test.ts` — the manifest must own the same hook set scaffold writes by hand, otherwise the future plugin-direct path would silently drop the hint.

## Why
Layer 2 of the sandbox UX work; Layer 1 is #1098 (the SANDBOX primer in `--append-system-prompt`). The primer is always-on context giving the agent the vocabulary. This hook is the just-in-time nudge: it only fires when the agent actually hits the boundary, and the additionalContext lands *after* the tool result. Together they close the loop on the "agent silently retrying EROFS / echoing kernel errors to the user" failure mode observed this week.

Serves outcome #1 (visibility) — the sandbox boundary becomes something the operator can read and act on from Telegram in real time, instead of a stuck/noisy state.

## Test plan
- [x] `bun test telegram-plugin/tests/sandbox-hint-posttool.test.ts` — 9 cases (EROFS/EACCES/apt patterns + malformed stdin + 64 KiB scan-window cap), all green.
- [x] `bun test telegram-plugin/tests/subagent-tracker-hooks.test.ts` — 7 cases, still green (no regression in the sibling PostToolUse hook).
- [x] `vitest run tests/scaffold.test.ts tests/telegram-plugin-manifest.test.ts tests/reconcile-hooks-drift.test.ts` — 186 passed (incl. the manifest assertion update).
- [x] `tsc --noEmit` + `node scripts/check-plugin-references.mjs` — clean.
- [ ] Smoke: scaffold a fresh agent, run a `Write` against `/opt/foo`, confirm Telegram reply names the sandbox boundary + operator action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)