### PR TITLE
fix(docker-tests): label-filter prod-snapshot to fix recurring phase2c flake

### DIFF
--- a/tests/docker/_prod-snapshot.ts
+++ b/tests/docker/_prod-snapshot.ts
@@ -24,11 +24,11 @@ import { execSync } from "node:child_process";
 import { expect } from "vitest";
 
 /**
- * Filter regex for switchroom phase-test containers (any phase).
+ * Filter regex for switchroom phase-test container NAMES (any phase).
  *
  * Two shapes are matched:
  *   - `switchroom-phase<digit>...` — the per-container `docker run`
- *     pattern used by single-container tests (e.g. e2e.test.ts).
+ *     pattern used by single-container tests with explicit `--name`.
  *   - `phase<digit><letter>-<slug>-...` — the compose-project pattern
  *     used by fleet tests like broker-ipc-race.test.ts (project
  *     prefix `phase1c-race-${pid}`) and per-agent-isolation.test.ts
@@ -43,8 +43,36 @@ import { expect } from "vitest";
  * its afterAll teardown) would pollute the next docker test's
  * before/after snapshot comparison, cascading the failure into
  * unrelated tests (phase2b-kernel-ipc, phase2c-vault-integration).
+ *
+ * Belt to braces — the LABEL filter `switchroom.test=` below is the
+ * load-bearing rule (covers Moby-auto-named transient containers from
+ * `docker run --rm` callsites that omit `--name` — e.g. e2e.test.ts's
+ * spawnSync calls). The name regex is the fallback when a future test
+ * neglects to apply the canonical labelArgv().
  */
 const PHASE_TEST_NAME = /^switchroom-phase\d|^phase\d[a-z]-/;
+
+/**
+ * Substring match against the `{{.Labels}}` column from `docker ps`.
+ *
+ * The full docker test suite stamps every container (single-run and
+ * compose-emitted alike) with `switchroom.test=phase<digit><letter>`
+ * via `tests/docker/_label-helpers.ts:dockerRunLabelsArgv` and the
+ * `injectLabelsIntoCompose` post-processor. So a single substring
+ * check against the labels column reliably tags a row as test-owned
+ * regardless of what name docker assigned it.
+ *
+ * Pre-fix (this file at HEAD before #1079 fleet flake fix), the prod-
+ * snapshot only looked at NAMES. Concurrent vitest forks running
+ * `e2e.test.ts` issue `docker run --rm ...` (no `--name`), letting
+ * docker assign Moby names like `friendly_chatelet` that the name
+ * regex misses; the container was alive for less than a second but
+ * straddled `phase2c-vault-integration`'s afterAll snapshot, flaking
+ * every other docker-e2e run on main. Switching to a labels-first
+ * filter fixes that without weakening genuine drift detection
+ * (production containers do not carry `switchroom.test=` labels).
+ */
+const PHASE_TEST_LABEL_MARKER = "switchroom.test=";
 
 /**
  * A snapshot of the host's container list at one moment in time.
@@ -61,13 +89,17 @@ export interface ProdSnapshot {
  * `docker ps`, and returns an empty snapshot if neither works (e.g. CI
  * without docker).
  *
- * Uses `--no-trunc` so IDs are stable for diffing.
+ * Uses `--no-trunc` so IDs are stable for diffing. Includes
+ * `{{.Labels}}` so the labels-first filter in `filterPhaseTestContainers`
+ * can reliably classify rows as test-owned even when docker auto-
+ * assigned a Moby name (rather than the test passing `--name`).
  */
+const PS_FORMAT = "{{.Names}}|{{.ID}}|{{.Status}}|{{.Labels}}";
 export function captureProdSnapshot(): ProdSnapshot {
   try {
     return {
       raw: execSync(
-        "sudo docker ps --no-trunc --format '{{.Names}}|{{.ID}}|{{.Status}}'",
+        `sudo docker ps --no-trunc --format '${PS_FORMAT}'`,
         { stdio: ["ignore", "pipe", "pipe"] },
       ).toString(),
     };
@@ -75,7 +107,7 @@ export function captureProdSnapshot(): ProdSnapshot {
     try {
       return {
         raw: execSync(
-          "docker ps --no-trunc --format '{{.Names}}|{{.ID}}|{{.Status}}'",
+          `docker ps --no-trunc --format '${PS_FORMAT}'`,
           { stdio: ["ignore", "pipe", "pipe"] },
         ).toString(),
       };
@@ -109,10 +141,15 @@ export function expectNoProdDrift(
   );
 }
 
-function filterPhaseTestContainers(raw: string): string {
+export function filterPhaseTestContainers(raw: string): string {
   return raw
     .split("\n")
-    .filter((l) => l && !PHASE_TEST_NAME.test(l))
+    .filter((l) => {
+      if (!l) return false;
+      if (l.includes(PHASE_TEST_LABEL_MARKER)) return false;
+      if (PHASE_TEST_NAME.test(l)) return false;
+      return true;
+    })
     .sort()
     .join("\n");
 }

--- a/tests/docker/prod-snapshot.test.ts
+++ b/tests/docker/prod-snapshot.test.ts
@@ -33,6 +33,7 @@ import { execSync } from "node:child_process";
 import {
   productionFleetIsLive,
   assertNoProductionFleet,
+  filterPhaseTestContainers,
 } from "./_prod-snapshot.js";
 
 const mockExec = vi.mocked(execSync);
@@ -92,6 +93,47 @@ describe("productionFleetIsLive", () => {
     // still run the suite. The destructive op will fail loudly later
     // if docker is genuinely needed.
     expect(productionFleetIsLive()).toBe(false);
+  });
+});
+
+describe("filterPhaseTestContainers", () => {
+  // Format emitted by captureProdSnapshot:
+  //   {{.Names}}|{{.ID}}|{{.Status}}|{{.Labels}}
+  // Labels arrive as a comma-separated list like
+  //   foo=bar,switchroom.test=phase1b,switchroom.test.run=abc...
+  const PROD_ROW = "coolify-postgres|abcd1234|Up 3 hours|com.docker.compose.project=coolify";
+  const MOBY_TEST_ROW = "friendly_chatelet|3af1b7|Up Less than a second|switchroom.test=phase1b,switchroom.test.run=uuid-here";
+  const NAMED_PHASE_ROW = "switchroom-phase2c-broker-12345-deadbeef|9999|Up 2s|switchroom.test=phase2c";
+  const COMPOSE_PHASE_ROW = "phase1c-iso-9876-alice-1|1111|Up 5s|com.docker.compose.project=phase1c-iso-9876";
+
+  it("drops Moby-auto-named containers when they carry switchroom.test label (regression: #1079 flake follow-up)", () => {
+    // Pre-fix: e2e.test.ts's `docker run --rm ...` (no --name) produced
+    // names like `friendly_chatelet` that the name regex missed, causing
+    // phase2c-vault-integration's afterAll snapshot to flake on every
+    // docker-e2e run on main. The label-marker filter catches them.
+    const raw = `${PROD_ROW}\n${MOBY_TEST_ROW}\n`;
+    expect(filterPhaseTestContainers(raw)).toBe(PROD_ROW);
+  });
+
+  it("drops named phase test containers (the legacy name-regex case still works)", () => {
+    const raw = `${PROD_ROW}\n${NAMED_PHASE_ROW}\n`;
+    expect(filterPhaseTestContainers(raw)).toBe(PROD_ROW);
+  });
+
+  it("drops compose-project phase test containers", () => {
+    const raw = `${PROD_ROW}\n${COMPOSE_PHASE_ROW}\n`;
+    // Note: COMPOSE_PHASE_ROW has no switchroom.test label here (only
+    // compose.project) — must still match via the name regex fallback.
+    expect(filterPhaseTestContainers(raw)).toBe(PROD_ROW);
+  });
+
+  it("keeps a row that genuinely looks like production (no test label, no phase name)", () => {
+    expect(filterPhaseTestContainers(PROD_ROW)).toBe(PROD_ROW);
+  });
+
+  it("preserves empty input", () => {
+    expect(filterPhaseTestContainers("")).toBe("");
+    expect(filterPhaseTestContainers("\n\n")).toBe("");
   });
 });
 


### PR DESCRIPTION
## Summary
- `tests/docker/phase2c-vault-integration.test.ts`'s `afterAll` expectNoProdDrift has been flaking every few hours on main (4 failures observed since 2026-05-11) with the same shape:
  ```
  AssertionError: expected 'friendly_chatelet|...|Up Less than a second' to deeply equal ''
  ```
- Root cause: \`tests/docker/e2e.test.ts\` runs several \`docker run --rm <flags> <image>\` invocations **without \`--name\`** (lines 92-110, 207-229, 232-256, 268-283, 286-302, 304-…). Docker assigns Moby-style names (\`friendly_chatelet\`, \`nifty_beaver\`, \`sad_darwin\`, \`agitated_easley\` in recent failures) that don't match \`_prod-snapshot.ts\`'s name regex. Each container lives <1s, but vitest's parallel forks mean one is briefly alive while phase2c captures its \`after\` snapshot.
- The containers DO carry the canonical \`switchroom.test=phase1b\` label via \`LABELS_ARGV\` — \`_prod-snapshot.ts\` just wasn't reading labels.

## Fix
- \`captureProdSnapshot\` now includes \`{{.Labels}}\` in the \`docker ps\` format.
- \`filterPhaseTestContainers\` drops any row whose labels contain \`switchroom.test=\` (load-bearing).
- The legacy name regex stays as belt-and-braces.

## Failures fixed
GH Actions \`docker-e2e\` runs (each the same flake, different Moby name):
- run 25707282554 (commit f14ed40d, 2026-05-12 01:18Z) — friendly_chatelet
- run 25701528638 (commit becaa1c2, 2026-05-11 22:39Z) — nifty_beaver
- run 25699926396 (commit d63fade2, 2026-05-11 22:02Z) — sad_darwin
- run 25692084622 (commit a56ea594, 2026-05-11 19:22Z) — agitated_easley

## Test plan
- [x] \`npx vitest run tests/docker/prod-snapshot.test.ts\` — 13/13 pass (5 new regression tests, 8 existing).
- [x] \`npx tsc --noEmit\` — clean.
- [ ] Watch next 2-3 main runs for \`docker-e2e\` stability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)