### PR TITLE
chore(uat): unskip bg-sub-agent-dispatch-dm — all 7 RFC bugs merged

### DIFF
--- a/telegram-plugin/uat/scenarios/bg-sub-agent-dispatch-dm.test.ts
+++ b/telegram-plugin/uat/scenarios/bg-sub-agent-dispatch-dm.test.ts
@@ -94,8 +94,12 @@ const BG_DISPATCH_PROMPT =
  * When Bug 1 + Bug 2 are fixed, change `describe.skip` to `describe`
  * below — the assertions are correct; only the production code is
  * wrong.
+ *
+ * Update post-#1105: all five RFC bugs (1–5 in earlier PRs, 6–7 in
+ * #1105) merged. Unskipped here for the next UAT re-run. If 6/6 ACs
+ * pass, close #709 / #776 / #782 / #788.
  */
-describe.skip("uat: background sub-agent visibility (#709/#776/#782/#788)", () => {
+describe("uat: background sub-agent visibility (#709/#776/#782/#788)", () => {
   it(
     "card stays pinned with 🌀 Background header + live fleet activity, then flips to ✅ Done",
     async () => {


### PR DESCRIPTION
## Summary
- Flips \`describe.skip\` → \`describe\` on \`telegram-plugin/uat/scenarios/bg-sub-agent-dispatch-dm.test.ts\` now that all 7 sub-agent visibility RFC bugs are merged (Bugs 1-5 via #1058 / #1060 / #1063 / #1066 / #1080; Bugs 6-7 via #1105).
- UAT scenarios are excluded from the default \`vitest run\` path (#863) — invoked via \`bun run test:uat\` from \`telegram-plugin/\`. Merging this PR doesn't trigger a UAT run; the operator (or a scheduled UAT job) runs the scenario next.
- If 6/6 ACs pass on the next UAT re-run, close #709 / #776 / #782 / #788 in a follow-up commit/comment that references this scenario as the regression-pin.

## Test plan
- [x] \`vitest run telegram-plugin/tests/\` — clean (UAT scenarios not in scope).
- [ ] \`bun run test:uat\` against the test-harness agent — confirms 6/6 ACs including AC-2-positive (card flips 🌀 → ✅ within ~5 min of bg worker completion).
- [ ] On green, close the four referenced issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)