### PR TITLE
chore(uat): consolidate .env at repo root

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,11 +1,11 @@
-# telegram-plugin/uat/.env.example
+# Repo-root .env.example for UAT + future dev env knobs.
 #
-# Copy to telegram-plugin/uat/.env and populate from vault. The file is
+# Copy to `.env` (repo root) and populate from vault. The file is
 # gitignored repo-wide (`.env*` in /.gitignore). Never commit a populated
 # copy.
 #
-# Refresh workflow — see uat/SETUP.md §6. tl;dr from the test-harness
-# agent (which has these keys in its ACL):
+# Refresh workflow — see telegram-plugin/uat/SETUP.md §6. tl;dr from the
+# test-harness agent (which has these keys in its ACL):
 #
 #   read -sp "Vault passphrase: " SWITCHROOM_VAULT_PASSPHRASE; echo
 #   export SWITCHROOM_VAULT_PASSPHRASE
@@ -14,7 +14,7 @@
 #     echo "TELEGRAM_API_HASH=$(docker exec switchroom-test-harness switchroom vault get telegram-uat-api-hash)"
 #     echo "TELEGRAM_UAT_DRIVER_SESSION=$(docker exec switchroom-test-harness switchroom vault get telegram-uat-driver-session)"
 #     echo "TELEGRAM_TEST_BOT_USERNAME=meken_switchroom_test_bot"
-#   } > telegram-plugin/uat/.env )
+#   } > .env )
 #   unset SWITCHROOM_VAULT_PASSPHRASE
 #
 # (umask 077 ensures the file is never world-readable between creation and

--- a/telegram-plugin/uat/SETUP.md
+++ b/telegram-plugin/uat/SETUP.md
@@ -231,7 +231,7 @@ Once configured, unskip the card scenario by changing
 ## 6. Running scenarios — env setup
 
 The harness reads four env vars at `spinUp()` time. The recommended
-workflow is to materialise them once into `telegram-plugin/uat/.env`
+workflow is to materialise them once into `.env`
 — the harness loads that file automatically on import (see
 `load-env.ts`). The file is gitignored repo-wide (`.env*` in
 `/.gitignore`); never commit a populated copy.
@@ -252,7 +252,7 @@ export SWITCHROOM_VAULT_PASSPHRASE
   echo "TELEGRAM_API_HASH=$(docker exec switchroom-test-harness switchroom vault get telegram-uat-api-hash)"
   echo "TELEGRAM_UAT_DRIVER_SESSION=$(docker exec switchroom-test-harness switchroom vault get telegram-uat-driver-session)"
   echo "TELEGRAM_TEST_BOT_USERNAME=meken_switchroom_test_bot"
-} > telegram-plugin/uat/.env )
+} > .env )
 
 unset SWITCHROOM_VAULT_PASSPHRASE
 ```

--- a/telegram-plugin/uat/load-env.ts
+++ b/telegram-plugin/uat/load-env.ts
@@ -1,11 +1,14 @@
 /**
- * Load `telegram-plugin/uat/.env` into process.env at harness startup.
+ * Load the repo-root `.env` into process.env at harness startup.
  *
  * The UAT harness needs four env vars (TELEGRAM_API_ID, TELEGRAM_API_HASH,
  * TELEGRAM_UAT_DRIVER_SESSION, TELEGRAM_TEST_BOT_USERNAME) that originate
  * in the operator's vault. Re-exporting them every shell session is fiddly,
- * so we let the operator stash them in a gitignored `.env` next to this
- * file. See `SETUP.md` §6 for the refresh workflow.
+ * so we let the operator stash them in a gitignored repo-root `.env`.
+ * Consolidated at the repo root (previously lived at
+ * `telegram-plugin/uat/.env`) so a single file handles UAT secrets +
+ * any future repo-wide dev env knobs. See `SETUP.md` §6 for the
+ * refresh workflow.
  *
  * Existing process.env values win — a CI run that supplies vars via the
  * job environment doesn't get clobbered by a stale local `.env`.
@@ -16,7 +19,10 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 const HERE = path.dirname(fileURLToPath(import.meta.url));
-export const UAT_ENV_FILE = path.join(HERE, ".env");
+// HERE is `<repo>/telegram-plugin/uat` (or the dist-mirror); two
+// dirname() hops up gets us the repo root regardless of where the
+// bundled output lives.
+export const UAT_ENV_FILE = path.resolve(HERE, "..", "..", ".env");
 
 export function loadUatEnv(envPath: string = UAT_ENV_FILE): void {
   if (!existsSync(envPath)) return;


### PR DESCRIPTION
Move the UAT .env (and its .env.example) from `telegram-plugin/uat/` to the repo root. Single source of truth for dev env knobs; removes a footgun for anyone running scripts from the repo root.

`.gitignore:4-5` already covers both locations (`.env` + `.env.*`) — verified via `git check-ignore -v` — so no gitignore change needed.

## Test plan
- [x] `bun test telegram-plugin/uat/load-env.test.ts` — 7/7 pass.
- [x] `tsc --noEmit` — clean.
- [x] `UAT_ENV_FILE` resolves to `<repo>/.env` at runtime.
- [x] `git check-ignore -v .env` confirms ignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)