### PR TITLE
fix(compose): propagate agent.env into compose environment block

### DIFF
--- a/src/agents/compose.ts
+++ b/src/agents/compose.ts
@@ -252,6 +252,22 @@ interface AgentServiceData {
    * `/logs`, `/grant`, `/update` etc). Default false.
    */
   admin: boolean;
+  /**
+   * Operator-declared env vars from the cascade-resolved agent config
+   * (`agent.env` block in switchroom.yaml). Propagated into the
+   * compose `environment:` block so child processes forked
+   * BEFORE start.sh's `export` lines (e.g. the gateway sidecar at
+   * `profiles/_base/start.sh.hbs:88`) can see them. Without this
+   * route, env vars set in switchroom.yaml are silently lossy for
+   * the gateway — they only reach Claude itself via the start.sh
+   * exports much later in the boot sequence.
+   *
+   * Repo/humanizer/channel-derived env stays in `userEnvQuoted` for
+   * scaffold.ts only — those are agent-shell-scoped, not container-
+   * wide. The schema's user-facing `env:` field is the one that
+   * mirrors here.
+   */
+  userEnv: Record<string, string>;
 }
 
 /** Per-agent metadata exposed to doctor checks (and tests). */
@@ -271,6 +287,10 @@ export function describeAgents(config: SwitchroomConfig): AgentServiceData[] {
       resources,
       strippedCaps,
       admin: agent.admin === true,
+      // Read user env from the cascade-resolved config so defaults +
+      // profile + agent layers all contribute. Empty object when the
+      // operator hasn't declared any (the common case).
+      userEnv: { ...(resolved.env ?? {}) },
     });
     void resolved;
   }
@@ -753,6 +773,14 @@ function emitAgentService(
     // agent UID from connecting (#1021). #1021 Design B moves the
     // gate into the broker; the agent-side env/mount are no longer
     // needed.
+  }
+  // Merge operator-declared env vars from the agent's `env:` block.
+  // System-managed keys (HOME, NPM_*, SWITCHROOM_*) win on collision —
+  // an operator can't override the runtime contract from yaml. A
+  // collision warning would help, but skipped for now (rare in
+  // practice; doctor check could add this later).
+  for (const [k, v] of Object.entries(a.userEnv)) {
+    if (env[k] === undefined) env[k] = v;
   }
   for (const k of Object.keys(env).sort()) {
     lines.push(`      ${k}: ${JSON.stringify(env[k])}`);

--- a/tests/docker/compose-generator.test.ts
+++ b/tests/docker/compose-generator.test.ts
@@ -30,7 +30,7 @@ import {
 } from "../../src/agents/compose.js";
 import type { SwitchroomConfig } from "../../src/config/schema.js";
 
-function makeConfig(agents: Record<string, { extends?: string; settings_raw?: Record<string, unknown>; admin?: boolean }>): SwitchroomConfig {
+function makeConfig(agents: Record<string, { extends?: string; settings_raw?: Record<string, unknown>; admin?: boolean; env?: Record<string, string> }>): SwitchroomConfig {
   return {
     switchroom: { version: 1, agents_dir: "~/.switchroom/agents", skills_dir: "~/.switchroom/skills" },
     telegram: { bot_token: "x" },
@@ -43,6 +43,7 @@ function makeConfig(agents: Record<string, { extends?: string; settings_raw?: Re
           extends: cfg.extends,
           settings_raw: cfg.settings_raw,
           admin: cfg.admin,
+          env: cfg.env,
           schedule: [],
           tools: { allow: [], deny: [] },
           hooks: undefined,
@@ -1015,6 +1016,67 @@ describe("generateCompose — buildMode (pull vs local)", () => {
     });
     expect(out).toContain("image: ghcr.io/switchroom/switchroom-broker:v0.7.3");
     expect(out).toContain("image: ghcr.io/switchroom/switchroom-agent:v0.7.3");
+  });
+});
+
+describe("agent service env — user-declared env propagation", () => {
+  // Operator-declared env vars (the `env:` block in switchroom.yaml)
+  // must land in the compose `environment:` block, not just in
+  // start.sh's later `export` lines. The gateway sidecar is forked
+  // BEFORE start.sh exports user env (start.sh.hbs:88) — without
+  // compose-level propagation the gateway never sees these vars,
+  // silently breaking knobs like SWITCHROOM_SUBAGENT_STALL_TERMINAL_MS
+  // (the UAT enablement knobs from #1110). Surfaced 2026-05-12 when
+  // a live-edit was the only way to feed env vars into the gateway.
+  function envBlockFor(yml: string, agent: string): string {
+    const re = new RegExp(
+      `  agent-${agent}:[\\s\\S]*?    environment:([\\s\\S]*?)\\n    volumes:`,
+    );
+    return re.exec(yml)?.[1] ?? "";
+  }
+
+  it("emits operator-declared env vars in the compose environment block", () => {
+    const out = generateCompose({
+      config: makeConfig({
+        alice: {
+          env: {
+            SWITCHROOM_SUBAGENT_STALL_TERMINAL_MS: "10000",
+            CUSTOM_KNOB: "hello",
+          },
+        },
+      }),
+    });
+    const env = envBlockFor(out, "alice");
+    expect(env).toMatch(/SWITCHROOM_SUBAGENT_STALL_TERMINAL_MS:\s*"10000"/);
+    expect(env).toMatch(/CUSTOM_KNOB:\s*"hello"/);
+  });
+
+  it("system-managed keys (HOME, SWITCHROOM_RUNTIME) win on collision with user env", () => {
+    // An operator can't override the runtime contract from yaml —
+    // the compose-level defaults stay authoritative. Without this
+    // guard a yaml typo could silently re-target HOME away from
+    // /state/agent/home and break the agent's writable mounts.
+    const out = generateCompose({
+      config: makeConfig({
+        bob: {
+          env: {
+            HOME: "/tmp/operator-takeover",
+            SWITCHROOM_RUNTIME: "host",
+          },
+        },
+      }),
+    });
+    const env = envBlockFor(out, "bob");
+    expect(env).toMatch(/HOME:\s*"\/state\/agent\/home"/);
+    expect(env).toMatch(/SWITCHROOM_RUNTIME:\s*"docker"/);
+    expect(env).not.toMatch(/HOME:\s*"\/tmp\/operator-takeover"/);
+  });
+
+  it("agents without env: declared still emit the standard system env", () => {
+    const out = generateCompose({ config: makeConfig({ charlie: {} }) });
+    const env = envBlockFor(out, "charlie");
+    expect(env).toMatch(/SWITCHROOM_RUNTIME:\s*"docker"/);
+    expect(env).toMatch(/HOME:\s*"\/state\/agent\/home"/);
   });
 });
 


### PR DESCRIPTION
## Summary

Operator-declared env vars (the `env:` block under each agent in `switchroom.yaml`) used to land ONLY in start.sh's `export` lines, which fire AFTER the gateway sidecar is forked (`profiles/_base/start.sh.hbs:88`). The gateway therefore silently never saw any env knob the operator set — e.g. the new `SWITCHROOM_SUBAGENT_STALL_TERMINAL_MS` from #1110.

Fix: merge `agent.env` (cascade-resolved) into the compose `environment:` block. System-managed keys (HOME, NPM_*, SWITCHROOM_*) still win on collision — an operator can't override the runtime contract from yaml.

## Why

Surfaced 2026-05-12 while validating #1105 via the UAT scenario `bg-sub-agent-dispatch-dm.test.ts`. Setting the env knobs from #1110 in switchroom.yaml looked correct but the gateway ran on production defaults. Live-editing docker-compose.yml unblocked the UAT, but the next `switchroom apply` would have reverted that — this commit makes yaml the durable source of truth.

## Test plan
- [x] `vitest run tests/docker/compose-generator.test.ts` — 76 pass (3 new).
- [x] `tsc --noEmit` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)