### PR TITLE
Add vault.broker.approvalAuth posture toggle (passphrase | telegram-id)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### New features
 
-- **`vault.broker.approvalAuth` posture toggle (`passphrase` | `telegram-id`)** — opt-in single-factor approval for vault grant cards. Default (`passphrase`) is unchanged: the operator types the vault passphrase on every Approve tap (two-factor — Telegram ID + passphrase). Setting `approvalAuth: telegram-id` (requires `autoUnlock: true`) makes Approve mint immediately with no passphrase prompt, relying on Telegram account identity alone. Threat-model writeup in `docs/configuration.md`; `switchroom doctor` surfaces the active posture. Single-factor mode collapses security to the operator's Telegram account — opt-in only.
+- **`vault.broker.approvalAuth` posture toggle (`passphrase` | `telegram-id`)** — opt-in single-factor approval for vault grant cards. Default (`passphrase`) is unchanged: the operator types the vault passphrase on every Approve tap (two-factor — Telegram ID + passphrase). Setting `approvalAuth: telegram-id` (requires `autoUnlock: true`) makes Approve mint immediately with no passphrase prompt, relying on Telegram account identity alone. Threat-model writeup in `docs/configuration.md`; `switchroom doctor` surfaces the active posture. Single-factor mode collapses security to the operator's Telegram account — opt-in only. The gateway hard-fails on boot if `approvalAuth: telegram-id` is set but the auto-unlock blob is missing, unreadable, OR empty/whitespace-only — we never silently downgrade an operator's declared posture.
 
 ## v0.7.16 — vault UX epic close-out + host-shell broker socket
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### New features
+
+- **`vault.broker.approvalAuth` posture toggle (`passphrase` | `telegram-id`)** — opt-in single-factor approval for vault grant cards. Default (`passphrase`) is unchanged: the operator types the vault passphrase on every Approve tap (two-factor — Telegram ID + passphrase). Setting `approvalAuth: telegram-id` (requires `autoUnlock: true`) makes Approve mint immediately with no passphrase prompt, relying on Telegram account identity alone. Threat-model writeup in `docs/configuration.md`; `switchroom doctor` surfaces the active posture. Single-factor mode collapses security to the operator's Telegram account — opt-in only.
+
 ## v0.7.16 — vault UX epic close-out + host-shell broker socket
 
 Five PRs landed since v0.7.15: the remaining three phases of the #969

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -261,6 +261,30 @@ The broker runs as a `docker compose` singleton service alongside the agent cont
 
 For interactive use — `switchroom vault get key`, `switchroom vault set key`, etc. — the CLI does **not** go through the broker. It reads the vault file directly with your passphrase. The broker's ACL would deny an interactive caller anyway (the bind-time path-as-identity ACL only grants the per-agent UID), and the user already has the passphrase.
 
+#### Approval posture (`vault.broker.approvalAuth`)
+
+When an agent requests vault access via Telegram, the operator gets an inline card with **Approve** / **Deny** buttons. The factor an Approve tap relies on is configurable via `vault.broker.approvalAuth`:
+
+```yaml
+vault:
+  broker:
+    autoUnlock: true
+    approvalAuth: telegram-id   # default: passphrase
+```
+
+| `approvalAuth` | `autoUnlock` | Approve tap result |
+|---|---|---|
+| `passphrase` (default) | either | Prompts for the vault passphrase before minting the grant. **Two-factor**: Telegram identity + passphrase. |
+| `telegram-id` | `true` (required) | Mints immediately with no passphrase prompt. **Single-factor**: Telegram identity only. |
+| `telegram-id` | `false` | Config error at startup — the schema rejects this combination. |
+
+**Threat model.**
+
+- `passphrase` (default): an attacker who compromises the operator's Telegram account still needs the vault passphrase to mint grants. The passphrase never leaves the operator's device → broker → vault path.
+- `telegram-id`: the broker is auto-unlocked at boot and silently holds the passphrase in memory; the only check on an Approve tap is the sender's Telegram user ID matching the allowlist. **An attacker with Telegram account access can mint grants.** Acceptable when (a) the operator has Telegram 2FA enabled, (b) the host is not multi-tenant, and (c) the convenience of zero-friction approvals outweighs the lost factor.
+
+`telegram-id` is fully opt-in — the default behaviour is unchanged, and `switchroom doctor` surfaces the active posture so it's obvious which mode the host is running.
+
 ### Per-skill dependency caches
 
 Skills that need a Python venv or a Node `node_modules` tree get a lazy, hash-stamped cache per skill — no system-level installs, no per-agent duplication.

--- a/scripts/check-bot-api-wrapping.sh
+++ b/scripts/check-bot-api-wrapping.sh
@@ -74,27 +74,29 @@ ALLOWLIST=(
 
   # operator-event broadcast. The loop's `opts` is built without
   # `message_thread_id` (parse_mode + reply_markup only).
-  "telegram-plugin/gateway/gateway.ts:2215-2245:operator-event broadcast; no thread_id in opts"
+  # Range bumped 2026-05 for #1115 vault-approval-posture insertions
+  # (~100 lines added to gateway).
+  "telegram-plugin/gateway/gateway.ts:2300-2360:operator-event broadcast; no thread_id in opts"
 
   # permission-request keyboard send. opts only has reply_markup. No thread_id.
-  # Range bumped 2026-05 for #1122 PR2 silence-poke insertions.
-  "telegram-plugin/gateway/gateway.ts:2660-2700:permission-request keyboard; no thread_id"
+  # Range bumped 2026-05 for #1122 PR2 silence-poke + #1115 vault-posture insertions.
+  "telegram-plugin/gateway/gateway.ts:2740-2810:permission-request keyboard; no thread_id"
 
   # reply chunk-loop fallback after robustApiCall threw THREAD_NOT_FOUND.
   # The caller dropped the thread; this raw sendMessage retries on the
   # main chat. Wrapping would re-enter the THREAD_NOT_FOUND throw on a
   # phantom second deletion.
-  "telegram-plugin/gateway/gateway.ts:3125-3160:reply chunk-loop THREAD_NOT_FOUND fallback (intentional raw)"
+  "telegram-plugin/gateway/gateway.ts:3210-3270:reply chunk-loop THREAD_NOT_FOUND fallback (intentional raw)"
 
   # credit-watch notification. No thread_id (DM).
-  "telegram-plugin/gateway/gateway.ts:8020-8070:credit-watch notify; no thread_id"
+  "telegram-plugin/gateway/gateway.ts:8100-8170:credit-watch notify; no thread_id"
 
   # gateway.ts:9260-9490 — ctx.api.editMessageText for vault grant wizard
   # cards. Every callsite has `.catch(() => {})` — a THREAD_NOT_FOUND
   # is already swallowed there. Acceptable because the wizard messages
   # are tap-driven UI and a missed edit just leaves the previous state
   # visible (the user can re-tap).
-  "telegram-plugin/gateway/gateway.ts:9260-9490:vault grant wizard ctx.api.editMessageText already has .catch swallow"
+  "telegram-plugin/gateway/gateway.ts:9340-9590:vault grant wizard ctx.api.editMessageText already has .catch swallow"
 
   # boot-card.ts and issues-card.ts: these MODULES receive a bot adapter
   # via DI. The gateway wires those adapters through robustApiCall (see

--- a/scripts/check-bot-api-wrapping.sh
+++ b/scripts/check-bot-api-wrapping.sh
@@ -76,20 +76,20 @@ ALLOWLIST=(
   # `message_thread_id` (parse_mode + reply_markup only).
   # Range bumped 2026-05 for #1115 vault-approval-posture insertions
   # (~100 lines added to gateway).
-  "telegram-plugin/gateway/gateway.ts:2300-2360:operator-event broadcast; no thread_id in opts"
+  "telegram-plugin/gateway/gateway.ts:2250-2310:operator-event broadcast; no thread_id in opts"
 
   # permission-request keyboard send. opts only has reply_markup. No thread_id.
   # Range bumped 2026-05 for #1122 PR2 silence-poke + #1115 vault-posture insertions.
-  "telegram-plugin/gateway/gateway.ts:2740-2810:permission-request keyboard; no thread_id"
+  "telegram-plugin/gateway/gateway.ts:2695-2760:permission-request keyboard; no thread_id"
 
   # reply chunk-loop fallback after robustApiCall threw THREAD_NOT_FOUND.
   # The caller dropped the thread; this raw sendMessage retries on the
   # main chat. Wrapping would re-enter the THREAD_NOT_FOUND throw on a
   # phantom second deletion.
-  "telegram-plugin/gateway/gateway.ts:3210-3270:reply chunk-loop THREAD_NOT_FOUND fallback (intentional raw)"
+  "telegram-plugin/gateway/gateway.ts:3160-3220:reply chunk-loop THREAD_NOT_FOUND fallback (intentional raw)"
 
   # credit-watch notification. No thread_id (DM).
-  "telegram-plugin/gateway/gateway.ts:8100-8170:credit-watch notify; no thread_id"
+  "telegram-plugin/gateway/gateway.ts:8050-8120:credit-watch notify; no thread_id"
 
   # gateway.ts:9260-9490 — ctx.api.editMessageText for vault grant wizard
   # cards. Every callsite has `.catch(() => {})` — a THREAD_NOT_FOUND

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -446,8 +446,35 @@ function checkVault(config: SwitchroomConfig): CheckResult[] {
     ? config.vault.path.replace(/^~/, process.env.HOME ?? "")
     : resolveStatePath("vault.enc");
 
+  // Approval-auth posture surface. Surfaces independently of vault file
+  // existence so operators see the configured posture even when the
+  // vault hasn't been created yet.
+  const broker = config.vault?.broker;
+  const approvalAuth = broker?.approvalAuth ?? "passphrase";
+  const postureResult: CheckResult =
+    approvalAuth === "telegram-id"
+      ? broker?.autoUnlock === true
+        ? {
+            name: "vault approval-auth posture",
+            status: "ok",
+            detail: "Approval auth: telegram-id (single-factor, relies on Telegram account security)",
+          }
+        : {
+            name: "vault approval-auth posture",
+            status: "fail",
+            detail:
+              "approvalAuth: telegram-id configured but autoUnlock is not true — schema invariant violated",
+            fix: "Set vault.broker.autoUnlock: true (and run `switchroom vault broker enable-auto-unlock`) or revert approvalAuth to `passphrase`.",
+          }
+      : {
+          name: "vault approval-auth posture",
+          status: "ok",
+          detail: "Approval auth: passphrase (two-factor)",
+        };
+
   if (!existsSync(vaultPath)) {
     return [
+      postureResult,
       {
         name: "vault file present",
         status: "warn",
@@ -460,6 +487,7 @@ function checkVault(config: SwitchroomConfig): CheckResult[] {
   const passphrase = process.env.SWITCHROOM_VAULT_PASSPHRASE;
   if (!passphrase) {
     return [
+      postureResult,
       {
         name: "vault file present",
         status: "ok",
@@ -477,6 +505,7 @@ function checkVault(config: SwitchroomConfig): CheckResult[] {
   try {
     const keys = listSecrets(passphrase, vaultPath);
     return [
+      postureResult,
       {
         name: "vault unlock",
         status: "ok",
@@ -485,6 +514,7 @@ function checkVault(config: SwitchroomConfig): CheckResult[] {
     ];
   } catch (err) {
     return [
+      postureResult,
       {
         name: "vault unlock",
         status: "fail",

--- a/src/cli/setup-posture-rewrite.test.ts
+++ b/src/cli/setup-posture-rewrite.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Tests for the YAML-aware `vault.broker.approvalAuth` rewrite used by
+ * `switchroom setup`. Pre-fix the rewrite was a single regex
+ * (`^(\s+)broker:\s*\n`) that would match ANY `broker:` mapping in the
+ * file — landing the posture key under e.g. a top-level peer `broker:`
+ * sibling of `vault:`. These tests pin the scoping so the regression
+ * can't quietly recur.
+ */
+
+import { describe, expect, it } from "vitest";
+import { insertVaultBrokerApprovalAuth } from "./setup-posture-rewrite.js";
+import YAML from "yaml";
+
+describe("insertVaultBrokerApprovalAuth", () => {
+  it("inserts approvalAuth under vault.broker when only vault.broker exists", () => {
+    const src = [
+      "vault:",
+      "  broker:",
+      "    autoUnlock: true",
+      "    autoUnlockCredentialPath: ~/.switchroom/vault-auto-unlock",
+      "",
+    ].join("\n");
+    const result = insertVaultBrokerApprovalAuth(src, "telegram-id");
+    expect(result.kind).toBe("rewritten");
+    if (result.kind !== "rewritten") return;
+    const parsed = YAML.parse(result.content);
+    expect(parsed.vault.broker.approvalAuth).toBe("telegram-id");
+    expect(parsed.vault.broker.autoUnlock).toBe(true);
+  });
+
+  it("does NOT touch a sibling top-level broker: key", () => {
+    // This is the regression case the reviewer flagged: a top-level
+    // `broker:` peer of `vault:` should NOT receive the posture key.
+    const src = [
+      "broker:",
+      "  # totally unrelated top-level broker config",
+      "  endpoint: https://example.test",
+      "  port: 8080",
+      "vault:",
+      "  broker:",
+      "    autoUnlock: true",
+      "",
+    ].join("\n");
+    const result = insertVaultBrokerApprovalAuth(src, "telegram-id");
+    expect(result.kind).toBe("rewritten");
+    if (result.kind !== "rewritten") return;
+    const parsed = YAML.parse(result.content);
+    // The sibling top-level broker must be untouched.
+    expect(parsed.broker.endpoint).toBe("https://example.test");
+    expect(parsed.broker.port).toBe(8080);
+    expect(parsed.broker.approvalAuth).toBeUndefined();
+    // The vault.broker block gets the key.
+    expect(parsed.vault.broker.approvalAuth).toBe("telegram-id");
+    expect(parsed.vault.broker.autoUnlock).toBe(true);
+  });
+
+  it("returns already-set when approvalAuth is already declared", () => {
+    const src = [
+      "vault:",
+      "  broker:",
+      "    autoUnlock: true",
+      "    approvalAuth: passphrase",
+      "",
+    ].join("\n");
+    const result = insertVaultBrokerApprovalAuth(src, "telegram-id");
+    expect(result.kind).toBe("already-set");
+  });
+
+  it("returns not-found when vault.broker is missing", () => {
+    const src = [
+      "vault:",
+      "  path: ~/.switchroom/vault.enc",
+      "",
+    ].join("\n");
+    const result = insertVaultBrokerApprovalAuth(src, "telegram-id");
+    expect(result.kind).toBe("not-found");
+  });
+
+  it("returns not-found when vault is missing entirely", () => {
+    const src = [
+      "broker:",
+      "  endpoint: https://example.test",
+      "",
+    ].join("\n");
+    const result = insertVaultBrokerApprovalAuth(src, "telegram-id");
+    expect(result.kind).toBe("not-found");
+  });
+
+  it("preserves user comments and surrounding formatting", () => {
+    const src = [
+      "# top-level comment about the whole file",
+      "vault:",
+      "  # broker-related comment",
+      "  broker:",
+      "    autoUnlock: true   # inline comment",
+      "    # another comment",
+      "    autoUnlockCredentialPath: ~/.switchroom/vault-auto-unlock",
+      "",
+      "telegram:",
+      "  bot_token: xxx",
+      "",
+    ].join("\n");
+    const result = insertVaultBrokerApprovalAuth(src, "telegram-id");
+    expect(result.kind).toBe("rewritten");
+    if (result.kind !== "rewritten") return;
+    expect(result.content).toContain("# top-level comment about the whole file");
+    expect(result.content).toContain("# broker-related comment");
+    expect(result.content).toContain("# inline comment");
+    expect(result.content).toContain("# another comment");
+    // telegram block intact
+    expect(result.content).toContain("telegram:");
+    expect(result.content).toContain("bot_token: xxx");
+    const parsed = YAML.parse(result.content);
+    expect(parsed.vault.broker.approvalAuth).toBe("telegram-id");
+  });
+});

--- a/src/cli/setup-posture-rewrite.ts
+++ b/src/cli/setup-posture-rewrite.ts
@@ -1,0 +1,123 @@
+/**
+ * Helper for the `switchroom setup` posture-prompt step that writes
+ * `vault.broker.approvalAuth: telegram-id` into the operator's
+ * `switchroom.yaml`.
+ *
+ * Extracted from setup.ts so the rewrite can be exercised in unit
+ * tests without spawning the interactive setup flow. The reviewer
+ * called out the original regex (`^(\s+)broker:\s*\n`) as fragile:
+ * it would match ANY `broker:` key in the YAML, not just the one
+ * nested under `vault:` — landing the posture key under the wrong
+ * block if e.g. a sibling top-level `broker:` existed.
+ *
+ * Behaviour pinned by `setup-posture-rewrite.test.ts`:
+ *   - Insertion lands under `vault.broker:` only.
+ *   - A sibling top-level `broker:` is NOT touched.
+ *   - If `vault: > broker:` cannot be located, the rewrite is
+ *     refused (the helper returns a `not-found` result; the caller
+ *     surfaces a manual-edit hint instead of landing the key under
+ *     the wrong block).
+ *   - If `approvalAuth:` already exists anywhere under `vault.broker`,
+ *     the rewrite is a no-op.
+ *   - User comments and surrounding formatting are preserved — we
+ *     do not round-trip through a stringify-everything YAML emit.
+ */
+
+import YAML from 'yaml'
+
+export type PostureRewriteResult =
+  | { kind: 'rewritten'; content: string }
+  | { kind: 'already-set' }
+  | { kind: 'not-found' }
+
+/**
+ * Insert `approvalAuth: telegram-id` under the `vault.broker:` mapping.
+ *
+ * Strategy: parse the YAML to a Document with a CST so we can ask the
+ * parser to locate the `vault > broker` mapping unambiguously, then
+ * do a surgical text edit at that block's start so comments and
+ * formatting are preserved. We DON'T stringify the whole doc — that
+ * would reformat the operator's file.
+ */
+export function insertVaultBrokerApprovalAuth(
+  source: string,
+  value: 'telegram-id' | 'passphrase' = 'telegram-id',
+): PostureRewriteResult {
+  let doc: YAML.Document.Parsed
+  try {
+    doc = YAML.parseDocument(source)
+  } catch {
+    return { kind: 'not-found' }
+  }
+  const vault = doc.get('vault') as YAML.YAMLMap | undefined
+  if (!vault || !YAML.isMap(vault)) {
+    return { kind: 'not-found' }
+  }
+  const broker = vault.get('broker') as YAML.YAMLMap | undefined
+  if (!broker || !YAML.isMap(broker)) {
+    return { kind: 'not-found' }
+  }
+  // Already set?
+  if (broker.has('approvalAuth')) {
+    return { kind: 'already-set' }
+  }
+
+  // Locate the broker block's range in the source so we can insert a
+  // sibling key under it without touching anything else.
+  const brokerRange = broker.range
+  if (!brokerRange) {
+    return { kind: 'not-found' }
+  }
+  // Determine the broker block's child indent. We use the first key's
+  // column as the indent. If broker is empty (no children yet), fall
+  // back to the broker's own indent + 2 spaces.
+  let childIndent: string
+  if (broker.items.length > 0) {
+    const firstKey = broker.items[0]?.key as YAML.Scalar | undefined
+    const firstKeyRange = firstKey?.range
+    if (firstKeyRange) {
+      // Walk backwards from firstKey start to the prior newline to get
+      // the leading whitespace.
+      const start = firstKeyRange[0]
+      const lineStart = source.lastIndexOf('\n', start - 1) + 1
+      childIndent = source.slice(lineStart, start)
+    } else {
+      childIndent = '  '
+    }
+  } else {
+    // Find broker key's own column, add 2.
+    const brokerKeyItem = vault.items.find(it => {
+      const k = it.key as YAML.Scalar
+      return k && k.value === 'broker'
+    })
+    const brokerKey = brokerKeyItem?.key as YAML.Scalar | undefined
+    const brokerKeyRange = brokerKey?.range
+    if (brokerKeyRange) {
+      const start = brokerKeyRange[0]
+      const lineStart = source.lastIndexOf('\n', start - 1) + 1
+      const ownIndent = source.slice(lineStart, start)
+      childIndent = ownIndent + '  '
+    } else {
+      childIndent = '    '
+    }
+  }
+
+  // Insert at the END of the broker block — value-range [start, valueEnd, nodeEnd].
+  // range[1] is the end of the value (children), range[2] includes trailing
+  // whitespace. We want to insert just before the next sibling under vault
+  // (or end of file). Use the broker's value-end offset, then back up past
+  // any trailing whitespace so we land cleanly after the last child.
+  const valueEnd = brokerRange[1]
+  // Back up over trailing whitespace + newlines so we insert AFTER the
+  // last child's line, with our own newline.
+  let insertAt = valueEnd
+  while (insertAt > 0 && /\s/.test(source[insertAt - 1] ?? '')) {
+    insertAt--
+  }
+  // Now insertAt points just after the last non-whitespace char of the
+  // broker block. Insert "\n<indent>approvalAuth: telegram-id" and let
+  // any pre-existing trailing whitespace stay where it was.
+  const insertion = `\n${childIndent}approvalAuth: ${value}`
+  const rewritten = source.slice(0, insertAt) + insertion + source.slice(insertAt)
+  return { kind: 'rewritten', content: rewritten }
+}

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -42,6 +42,7 @@ import {
   isInteractive,
 } from "../setup/prompt.js";
 import { captureEvent, captureException } from "../analytics/posthog.js";
+import { insertVaultBrokerApprovalAuth } from "./setup-posture-rewrite.js";
 
 const STEP_PENDING = chalk.gray("○");
 const STEP_ACTIVE = chalk.blue("->");
@@ -880,31 +881,24 @@ async function stepAutoUnlock(
         ? resolve(process.cwd(), "switchroom.yaml")
         : resolve(process.cwd(), "switchroom.yml");
       if (existsSync(yamlPath)) {
-        let content = readFileSync(yamlPath, "utf-8");
-        // Best-effort insert into `vault: { broker: { ... } }` block.
-        // If the broker block already declares approvalAuth, leave it.
-        if (!/approvalAuth\s*:/.test(content)) {
-          // Look for `broker:` under `vault:` and append a key under it.
-          const brokerMatch = content.match(/^(\s+)broker:\s*\n/m);
-          if (brokerMatch) {
-            const indent = brokerMatch[1] + "  ";
-            content = content.replace(
-              /^(\s+broker:\s*\n)/m,
-              `$1${indent}approvalAuth: telegram-id\n`,
-            );
-            writeFileSync(yamlPath, content, "utf-8");
-            console.log(
-              chalk.green(`  ${STEP_DONE} Set vault.broker.approvalAuth: telegram-id in ${yamlPath}`),
-            );
-          } else {
-            console.log(
-              chalk.yellow(
-                "  Could not locate vault.broker block — add `approvalAuth: telegram-id` under `vault.broker:` manually.",
-              ),
-            );
-          }
-        } else {
+        const content = readFileSync(yamlPath, "utf-8");
+        // Use a YAML-aware rewrite scoped to vault.broker — the previous
+        // regex matched any top-level `broker:` and could land the
+        // posture key under the wrong block.
+        const result = insertVaultBrokerApprovalAuth(content, "telegram-id");
+        if (result.kind === "rewritten") {
+          writeFileSync(yamlPath, result.content, "utf-8");
+          console.log(
+            chalk.green(`  ${STEP_DONE} Set vault.broker.approvalAuth: telegram-id in ${yamlPath}`),
+          );
+        } else if (result.kind === "already-set") {
           console.log(chalk.gray("  approvalAuth already set — leaving it alone."));
+        } else {
+          console.log(
+            chalk.yellow(
+              "  Could not locate vault.broker block — add `approvalAuth: telegram-id` under `vault.broker:` manually.",
+            ),
+          );
         }
       }
     } catch (err) {

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -864,6 +864,59 @@ async function stepAutoUnlock(
     );
     console.log(chalk.gray("  Retry with: switchroom apply && docker compose -p switchroom -f ~/.switchroom/compose/docker-compose.yml restart vault-broker"));
   }
+
+  // Posture prompt: passphrase (two-factor, default) vs telegram-id
+  // (single-factor smoother UX). Only offered when auto-unlock is in
+  // place — telegram-id requires the broker to be unlocked already.
+  console.log("");
+  console.log(chalk.gray("  Approve vault grants with the passphrase each time (more secure)"));
+  console.log(chalk.gray("  or trust your Telegram account alone (smoother UX)?"));
+  const PASSPHRASE_CHOICE = "passphrase — prompt for vault passphrase on every Approve (two-factor)";
+  const TELEGRAM_ID_CHOICE = "telegram-id — Approve tap mints immediately, no passphrase prompt (single-factor)";
+  const choice = await askChoice("  Approval posture", [PASSPHRASE_CHOICE, TELEGRAM_ID_CHOICE]);
+  if (choice === TELEGRAM_ID_CHOICE) {
+    try {
+      const yamlPath = existsSync(resolve(process.cwd(), "switchroom.yaml"))
+        ? resolve(process.cwd(), "switchroom.yaml")
+        : resolve(process.cwd(), "switchroom.yml");
+      if (existsSync(yamlPath)) {
+        let content = readFileSync(yamlPath, "utf-8");
+        // Best-effort insert into `vault: { broker: { ... } }` block.
+        // If the broker block already declares approvalAuth, leave it.
+        if (!/approvalAuth\s*:/.test(content)) {
+          // Look for `broker:` under `vault:` and append a key under it.
+          const brokerMatch = content.match(/^(\s+)broker:\s*\n/m);
+          if (brokerMatch) {
+            const indent = brokerMatch[1] + "  ";
+            content = content.replace(
+              /^(\s+broker:\s*\n)/m,
+              `$1${indent}approvalAuth: telegram-id\n`,
+            );
+            writeFileSync(yamlPath, content, "utf-8");
+            console.log(
+              chalk.green(`  ${STEP_DONE} Set vault.broker.approvalAuth: telegram-id in ${yamlPath}`),
+            );
+          } else {
+            console.log(
+              chalk.yellow(
+                "  Could not locate vault.broker block — add `approvalAuth: telegram-id` under `vault.broker:` manually.",
+              ),
+            );
+          }
+        } else {
+          console.log(chalk.gray("  approvalAuth already set — leaving it alone."));
+        }
+      }
+    } catch (err) {
+      console.log(
+        chalk.yellow(
+          `  Could not write approvalAuth: ${err instanceof Error ? err.message : String(err)}`,
+        ),
+      );
+    }
+  } else {
+    console.log(chalk.green(`  ${STEP_DONE} Keeping default passphrase posture (two-factor)`));
+  }
 }
 
 // ─── Step 9: Dangerous Mode ─────────────────────────────────────────────────

--- a/src/config/schema.test.ts
+++ b/src/config/schema.test.ts
@@ -103,7 +103,45 @@ describe("VaultConfigSchema.broker", () => {
       enabled: true,
       autoUnlock: false,
       autoUnlockCredentialPath: "~/.switchroom/vault-auto-unlock",
+      approvalAuth: "passphrase",
     });
+  });
+
+  it("defaults approvalAuth to passphrase", () => {
+    const result = VaultConfigSchema.parse({});
+    expect(result.broker.approvalAuth).toBe("passphrase");
+  });
+
+  it("accepts approvalAuth: telegram-id when autoUnlock is true", () => {
+    const result = VaultConfigSchema.parse({
+      broker: { approvalAuth: "telegram-id", autoUnlock: true },
+    });
+    expect(result.broker.approvalAuth).toBe("telegram-id");
+    expect(result.broker.autoUnlock).toBe(true);
+  });
+
+  it("rejects approvalAuth: telegram-id without autoUnlock: true", () => {
+    expect(() =>
+      VaultConfigSchema.parse({
+        broker: { approvalAuth: "telegram-id" },
+      })
+    ).toThrow(/requires `autoUnlock: true`/);
+  });
+
+  it("rejects approvalAuth: telegram-id with autoUnlock: false", () => {
+    expect(() =>
+      VaultConfigSchema.parse({
+        broker: { approvalAuth: "telegram-id", autoUnlock: false },
+      })
+    ).toThrow(/requires `autoUnlock: true`/);
+  });
+
+  it("rejects an unknown approvalAuth value", () => {
+    expect(() =>
+      VaultConfigSchema.parse({
+        broker: { approvalAuth: "biometric" },
+      })
+    ).toThrow();
   });
 
   it("accepts an explicit broker socket override", () => {

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -1435,8 +1435,30 @@ export const VaultConfigSchema = z.object({
         "container by docker compose. Tilde-expansion happens " +
         "at read time."
       ),
+      approvalAuth: z
+        .enum(["passphrase", "telegram-id"])
+        .default("passphrase")
+        .describe(
+          "Posture for tap-to-Approve on vault grant cards. `passphrase` " +
+          "(default) prompts the operator to type the vault passphrase on " +
+          "every Approve — two-factor (Telegram ID + passphrase). " +
+          "`telegram-id` mints immediately on Approve with no passphrase " +
+          "prompt — single-factor (Telegram ID only); REQUIRES " +
+          "`autoUnlock: true` so the broker already holds the passphrase. " +
+          "Trades a factor of security for smoother UX; opt-in only."
+        ),
     })
     .default({})
+    .superRefine((broker, ctx) => {
+      if (broker.approvalAuth === "telegram-id" && broker.autoUnlock !== true) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message:
+            "`vault.broker.approvalAuth: telegram-id` requires `autoUnlock: true` — single-factor approval needs the broker already unlocked at startup.",
+          path: ["approvalAuth"],
+        });
+      }
+    })
     .describe(
       "Vault-broker daemon configuration. The broker holds the decrypted vault " +
       "in memory and serves secrets to cron scripts via a Unix socket, so the " +

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -318,6 +318,7 @@ import {
   approvalRecord,
 } from '../../src/vault/approvals/client.js'
 import { readAutoUnlockFile } from '../../src/vault/auto-unlock.js'
+import { resolveVaultApprovalPosture } from '../vault-approval-posture.js'
 import {
   openTurnsDb,
   markOrphanedAsRestarted,
@@ -1598,36 +1599,29 @@ const VAULT_PASSPHRASE_TTL_MS = 30 * 60 * 1000
 let VAULT_APPROVAL_AUTH_MODE: 'passphrase' | 'telegram-id' = 'passphrase'
 let AUTO_UNLOCK_PASSPHRASE: string | null = null
 
-function initVaultApprovalPosture(): void {
+export function initVaultApprovalPosture(): void {
+  let cfg: ReturnType<typeof loadSwitchroomConfig>
   try {
-    const cfg = loadSwitchroomConfig()
-    const broker = cfg.vault?.broker
-    if (broker?.approvalAuth === 'telegram-id') {
-      VAULT_APPROVAL_AUTH_MODE = 'telegram-id'
-      const credPathRaw = broker.autoUnlockCredentialPath ?? '~/.switchroom/vault-auto-unlock'
-      const credPath = credPathRaw.replace(/^~/, process.env.HOME ?? '')
-      try {
-        AUTO_UNLOCK_PASSPHRASE = readAutoUnlockFile(credPath)
-        process.stderr.write(
-          `telegram gateway: vault approval posture = telegram-id ` +
-            `(single-factor; auto-unlock blob loaded from ${credPath})\n`,
-        )
-      } catch (err) {
-        process.stderr.write(
-          `telegram gateway: vault.broker.approvalAuth=telegram-id but reading ` +
-            `auto-unlock blob failed: ${(err as Error).message}. ` +
-            `Falling back to passphrase posture for this session.\n`,
-        )
-        VAULT_APPROVAL_AUTH_MODE = 'passphrase'
-        AUTO_UNLOCK_PASSPHRASE = null
-      }
-    }
+    cfg = loadSwitchroomConfig()
   } catch (err) {
     // Best-effort — gateway may run in dirs where loadSwitchroomConfig
     // fails. Stay on the default passphrase posture.
     process.stderr.write(
       `telegram gateway: could not load switchroom config for vault approval ` +
         `posture (${(err as Error).message}); defaulting to passphrase.\n`,
+    )
+    return
+  }
+  // Posture-load failures (below) propagate — they are intentional
+  // hard-fails. The schema guarantees telegram-id implies autoUnlock:true,
+  // so a missing/corrupt blob at runtime is a refuse-to-boot condition.
+  const resolved = resolveVaultApprovalPosture(cfg.vault?.broker, readAutoUnlockFile)
+  VAULT_APPROVAL_AUTH_MODE = resolved.mode
+  AUTO_UNLOCK_PASSPHRASE = resolved.passphrase
+  if (resolved.mode === 'telegram-id') {
+    process.stderr.write(
+      `telegram gateway: vault approval posture = telegram-id ` +
+        `(single-factor; auto-unlock blob loaded from ${resolved.credPath})\n`,
     )
   }
 }

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -317,6 +317,7 @@ import {
   approvalConsume,
   approvalRecord,
 } from '../../src/vault/approvals/client.js'
+import { readAutoUnlockFile } from '../../src/vault/auto-unlock.js'
 import {
   openTurnsDb,
   markOrphanedAsRestarted,
@@ -1578,6 +1579,58 @@ function rememberAgentButtonMeta(
 // Vault
 const vaultPassphraseCache = new Map<string, { passphrase: string; expiresAt: number }>()
 const VAULT_PASSPHRASE_TTL_MS = 30 * 60 * 1000
+
+/**
+ * Approval posture for vault grant cards. Controlled by
+ * `vault.broker.approvalAuth` in switchroom.yaml.
+ *
+ *  - "passphrase" (default): Approve tap prompts the operator for the
+ *    vault passphrase before minting (today's behaviour, two-factor:
+ *    Telegram ID + passphrase).
+ *  - "telegram-id": Approve tap mints immediately using the
+ *    auto-unlock-derived passphrase silently held in memory below.
+ *    Single-factor (Telegram ID only); the schema rejects this without
+ *    `autoUnlock: true`.
+ *
+ * Loaded once at gateway boot from `loadSwitchroomConfig()` — see the
+ * startup IIFE near the bottom of this file.
+ */
+let VAULT_APPROVAL_AUTH_MODE: 'passphrase' | 'telegram-id' = 'passphrase'
+let AUTO_UNLOCK_PASSPHRASE: string | null = null
+
+function initVaultApprovalPosture(): void {
+  try {
+    const cfg = loadSwitchroomConfig()
+    const broker = cfg.vault?.broker
+    if (broker?.approvalAuth === 'telegram-id') {
+      VAULT_APPROVAL_AUTH_MODE = 'telegram-id'
+      const credPathRaw = broker.autoUnlockCredentialPath ?? '~/.switchroom/vault-auto-unlock'
+      const credPath = credPathRaw.replace(/^~/, process.env.HOME ?? '')
+      try {
+        AUTO_UNLOCK_PASSPHRASE = readAutoUnlockFile(credPath)
+        process.stderr.write(
+          `telegram gateway: vault approval posture = telegram-id ` +
+            `(single-factor; auto-unlock blob loaded from ${credPath})\n`,
+        )
+      } catch (err) {
+        process.stderr.write(
+          `telegram gateway: vault.broker.approvalAuth=telegram-id but reading ` +
+            `auto-unlock blob failed: ${(err as Error).message}. ` +
+            `Falling back to passphrase posture for this session.\n`,
+        )
+        VAULT_APPROVAL_AUTH_MODE = 'passphrase'
+        AUTO_UNLOCK_PASSPHRASE = null
+      }
+    }
+  } catch (err) {
+    // Best-effort — gateway may run in dirs where loadSwitchroomConfig
+    // fails. Stay on the default passphrase posture.
+    process.stderr.write(
+      `telegram gateway: could not load switchroom config for vault approval ` +
+        `posture (${(err as Error).message}); defaulting to passphrase.\n`,
+    )
+  }
+}
 /**
  * Gateway-side guard on vault-key shape — UX gate, not a security
  * boundary (the broker accepts any non-empty string per
@@ -8819,13 +8872,17 @@ async function performVaultAccessApproval(
   pendingVaultRequestAccesses.delete(stageId)
   if (pending.card_message_id != null) {
     const days = Math.round(pending.ttl_seconds / 86400)
+    const footer =
+      VAULT_APPROVAL_AUTH_MODE === 'telegram-id'
+        ? `\n<i>Approver verified by Telegram identity — broker auto-unlocked at startup.</i>`
+        : ''
     await ctx.api
       .editMessageText(
         pending.chat_id,
         pending.card_message_id,
         `✅ Granted <b>${escapeHtmlForTg(pending.agent)}</b> ${pending.scope} access to ` +
         `<code>${escapeHtmlForTg(pending.key)}</code> for ${days}d. ` +
-        `(grant <code>${escapeHtmlForTg(id)}</code>)`,
+        `(grant <code>${escapeHtmlForTg(id)}</code>)` + footer,
         { parse_mode: 'HTML', reply_markup: { inline_keyboard: [] } },
       )
       .catch(() => {})
@@ -8926,6 +8983,27 @@ async function handleVaultRequestAccessCallback(ctx: Context, data: string): Pro
   }
 
   if (action === 'approve') {
+    // Posture: telegram-id (opt-in single-factor). The broker is
+    // auto-unlocked and we silently hold the passphrase in memory; skip
+    // the passphrase-cache lookup + prompt entirely and mint directly.
+    // Allowlist check above already attested the operator's Telegram ID.
+    if (VAULT_APPROVAL_AUTH_MODE === 'telegram-id' && AUTO_UNLOCK_PASSPHRASE) {
+      const username = ctx.from?.username ?? ctx.from?.first_name ?? `id=${senderId}`
+      if (pending.card_message_id != null) {
+        await ctx.api
+          .editMessageText(
+            pending.chat_id,
+            pending.card_message_id,
+            `✅ Approved by @${escapeHtmlForTg(username)} — minting…`,
+            { parse_mode: 'HTML', reply_markup: { inline_keyboard: [] } },
+          )
+          .catch(() => {})
+      }
+      await ctx.answerCallbackQuery({ text: '⏳ Minting grant…' }).catch(() => {})
+      await performVaultAccessApproval(ctx, pending, stageId, senderId, AUTO_UNLOCK_PASSPHRASE)
+      return
+    }
+
     // Tap-to-unlock-and-approve: if the operator hasn't unlocked the
     // vault in this chat yet, capture the passphrase via a pending op
     // intercept and resume the approve flow automatically once it
@@ -9055,11 +9133,21 @@ async function handleVaultRequestSaveCallback(ctx: Context, data: string): Promi
     // stale "spinning" state on the button while we run the write.
     await ctx.answerCallbackQuery({ text: '⏳ Saving…' }).catch(() => {})
 
+    // Posture: telegram-id (opt-in single-factor). Broker auto-unlocked
+    // at startup; reuse the in-memory passphrase directly so the save
+    // mirrors the access-approve flow's silent fallback.
+    let effectivePassphrase: string | null = null
+    if (VAULT_APPROVAL_AUTH_MODE === 'telegram-id' && AUTO_UNLOCK_PASSPHRASE) {
+      effectivePassphrase = AUTO_UNLOCK_PASSPHRASE
+    }
+
     // Fetch the cached passphrase for this chat. If the gateway hasn't
     // seen the user unlock the vault yet, we can't attest the write —
     // surface the unlock card via the same path the deferred-secret
     // flow uses (issue #44).
-    const cached = vaultPassphraseCache.get(pending.chat_id)
+    const cached = effectivePassphrase
+      ? { passphrase: effectivePassphrase, expiresAt: Date.now() + VAULT_PASSPHRASE_TTL_MS }
+      : vaultPassphraseCache.get(pending.chat_id)
     if (!cached || cached.expiresAt <= Date.now()) {
       if (pending.card_message_id != null) {
         await ctx.api
@@ -9188,6 +9276,14 @@ async function handleVaultDeferCallback(ctx: Context, data: string): Promise<voi
       ctx.from?.id ?? 0,
       access.allowFrom,
     )
+    // Posture: telegram-id (single-factor). Auto-unlock passphrase is
+    // already in memory — skip the prompt and write immediately.
+    if (VAULT_APPROVAL_AUTH_MODE === 'telegram-id' && AUTO_UNLOCK_PASSPHRASE) {
+      await ctx.answerCallbackQuery({ text: 'Saving…' }).catch(() => {})
+      await executeDeferredSecretSave(ctx, deferKey, AUTO_UNLOCK_PASSPHRASE, cardMessageId)
+      return
+    }
+
     // If a passphrase is already cached we can skip straight to the write.
     // Covers the case where the user had unlocked separately between
     // detection and tap.
@@ -12278,6 +12374,13 @@ if (POLL_HEALTH_INTERVAL_MS > 0) {
 let didOneTimeSetup = false
 
 void (async () => {
+  // Load vault-grant approval posture once at startup. Side-effect: when
+  // posture is `telegram-id`, this reads the machine-bound auto-unlock
+  // blob and holds the plaintext passphrase in memory for silent
+  // fallback when the operator taps Approve. Default-passphrase mode is
+  // a no-op.
+  initVaultApprovalPosture()
+
   for (let attempt = 1; ; attempt++) {
     try {
       // ── Startup network-retry fence ───────────────────────────────────────

--- a/telegram-plugin/tests/vault-approval-posture.test.ts
+++ b/telegram-plugin/tests/vault-approval-posture.test.ts
@@ -98,6 +98,189 @@ describe('handleVaultRequestSaveCallback — silent fallback in telegram-id mode
   })
 })
 
+// ─────────────────────────────────────────────────────────────────────────
+// Adversarial / load-bearing invariants (#1115 follow-up).
+//
+// The threat the toggle introduces: in `telegram-id` posture the ONLY check
+// between a callback firing and a real vault grant being minted is the
+// allowlist. Anything that runs BEFORE the allowlist check, or any handler
+// that skips it, is a potential bypass.
+//
+// These tests pin the invariants identified by the threat-model review:
+//   - allowlist check is the FIRST gate in every handler (no posture
+//     branch, stage lookup, or side-effect runs before it).
+//   - `handleVaultDeferCallback` honours `telegram-id` posture too (same
+//     silent-mint contract as the access + save handlers).
+//   - `handleVaultGrantCallback` (the operator-initiated wizard) does
+//     NOT reference VAULT_APPROVAL_AUTH_MODE — flipping posture can never
+//     change wizard behaviour, since the wizard requires the operator
+//     to drive every step.
+// ─────────────────────────────────────────────────────────────────────────
+
+describe('allowlist is the first gate in every vault callback handler', () => {
+  // Slice the body of a handler from its declaration to the next
+  // `async function` boundary.
+  function handlerBody(name: string): string {
+    const after = gatewaySrc.split(`async function ${name}(`)[1] ?? ''
+    return after.split('\nasync function ')[0] ?? ''
+  }
+
+  // The first `if (...)` block inside the handler MUST be the allowlist
+  // check — i.e., it must mention `access.allowFrom.includes(senderId)`.
+  // Future refactors that move stage-lookup, posture branching, or
+  // `pending*` map reads above the allowlist would break this contract.
+  function firstGuardOf(body: string): string {
+    const idx = body.indexOf('if (')
+    if (idx < 0) return ''
+    // crude but sufficient: take the line containing the `if (` plus 1 line
+    return body.slice(idx, body.indexOf('\n', body.indexOf('\n', idx) + 1))
+  }
+
+  for (const handler of [
+    'handleVaultRequestAccessCallback',
+    'handleVaultRequestSaveCallback',
+    'handleVaultDeferCallback',
+    'handleVaultGrantCallback',
+  ]) {
+    it(`${handler}: allowlist check fires before any other branching`, () => {
+      const body = handlerBody(handler)
+      expect(body, `expected handler ${handler} to be present`).not.toBe('')
+      const firstGuard = firstGuardOf(body)
+      expect(firstGuard, `first guard in ${handler}`).toMatch(
+        /access\.allowFrom\.includes\(senderId\)/,
+      )
+    })
+
+    it(`${handler}: no callback side-effect (mint / passphrase prompt / pendingVault* mutation) appears before the allowlist check`, () => {
+      const body = handlerBody(handler)
+      const beforeAllowlist = body.split('access.allowFrom.includes(senderId)')[0] ?? body
+      // Things that MUST NOT appear before the allowlist gate:
+      //   - mintGrantViaBroker (the actual broker mint)
+      //   - performVaultAccessApproval (the wrapper that mints + edits card)
+      //   - pendingVaultOps.set (would let a non-operator queue an op)
+      //   - VAULT_APPROVAL_AUTH_MODE === 'telegram-id' branch
+      for (const sentinel of [
+        'mintGrantViaBroker',
+        'performVaultAccessApproval',
+        'pendingVaultOps.set',
+        "VAULT_APPROVAL_AUTH_MODE === 'telegram-id'",
+      ]) {
+        expect(
+          beforeAllowlist.includes(sentinel),
+          `${handler}: sentinel "${sentinel}" must NOT appear before the allowlist check`,
+        ).toBe(false)
+      }
+    })
+  }
+})
+
+describe('handleVaultDeferCallback — telegram-id posture also mints silently', () => {
+  it('uses AUTO_UNLOCK_PASSPHRASE and skips the prompt under telegram-id', () => {
+    const fnBlock =
+      gatewaySrc
+        .split('async function handleVaultDeferCallback')[1]
+        ?.split('\nasync function ')[0] ?? ''
+    // The unlock branch must short-circuit with AUTO_UNLOCK_PASSPHRASE
+    // BEFORE the vaultPassphraseCache lookup + pendingVaultOps prompt.
+    const unlockBranch = fnBlock.split("if (action === 'unlock')")[1] ?? ''
+    expect(unlockBranch).toMatch(/VAULT_APPROVAL_AUTH_MODE === ['"]telegram-id['"]/)
+    expect(unlockBranch).toMatch(/AUTO_UNLOCK_PASSPHRASE/)
+    // Ordering: telegram-id branch must precede the cache lookup.
+    const teleIdIdx = unlockBranch.indexOf("VAULT_APPROVAL_AUTH_MODE === 'telegram-id'")
+    const cacheIdx = unlockBranch.indexOf('vaultPassphraseCache.get(')
+    expect(teleIdIdx, 'telegram-id branch must appear').toBeGreaterThanOrEqual(0)
+    expect(cacheIdx, 'cache lookup must still appear (passphrase posture)').toBeGreaterThanOrEqual(0)
+    expect(teleIdIdx).toBeLessThan(cacheIdx)
+  })
+})
+
+describe('handleVaultGrantCallback (wizard) — posture cannot affect the wizard path', () => {
+  it('wizard handler never references VAULT_APPROVAL_AUTH_MODE — posture flips are inert here', () => {
+    const fnBlock =
+      gatewaySrc
+        .split('async function handleVaultGrantCallback')[1]
+        ?.split('\nasync function ')[0] ?? ''
+    expect(fnBlock).not.toMatch(/VAULT_APPROVAL_AUTH_MODE/)
+    // And the wizard MUST NOT silently use AUTO_UNLOCK_PASSPHRASE either.
+    expect(fnBlock).not.toMatch(/AUTO_UNLOCK_PASSPHRASE/)
+  })
+})
+
+describe('resolveVaultApprovalPosture — adversarial / property fuzz', () => {
+  // The contract under test: the resolver MUST NEVER return
+  // `{ mode: 'telegram-id', passphrase: null | '' }`. Either it returns
+  // a non-empty passphrase, or it throws.
+  it('never returns telegram-id mode with a null/empty passphrase, across 200 randomized config + reader pairs', () => {
+    const rand = mulberry32(0xdeadbeef)
+    const pick = <T>(xs: readonly T[]): T => xs[Math.floor(rand() * xs.length)]!
+    const approvalChoices = [undefined, 'passphrase', 'telegram-id', 'PASSPHRASE', 'telegram_id', '', 'nonsense', null]
+    const pathChoices: (string | undefined)[] = [
+      undefined,
+      '~/.switchroom/vault-auto-unlock',
+      '/tmp/x',
+      '/nonexistent/blob',
+      '~/empty',
+      '~',
+      '',
+    ]
+    const readerOutcomes = [
+      () => 'unlock-secret',
+      () => '',
+      () => '   ',
+      () => 'x'.repeat(2048),
+      () => { throw new Error('ENOENT: no such file or directory') },
+      () => { throw new Error('EACCES: permission denied') },
+      () => { throw new TypeError('weird non-error') },
+    ]
+    for (let i = 0; i < 200; i++) {
+      const broker = {
+        approvalAuth: pick(approvalChoices) as string | undefined,
+        autoUnlockCredentialPath: pick(pathChoices),
+      } as Record<string, unknown>
+      const reader = pick(readerOutcomes)
+      let returned: ResolvedPostureLike | null = null
+      let threw = false
+      try {
+        returned = resolveVaultApprovalPosture(
+          broker as never,
+          reader,
+          { HOME: '/home/test' },
+        ) as ResolvedPostureLike
+      } catch {
+        threw = true
+      }
+      if (threw) continue
+      // If a value came back, it MUST satisfy the safety contract.
+      expect(returned, `iter ${i}: must return a posture`).not.toBeNull()
+      if (returned!.mode === 'telegram-id') {
+        expect(returned!.passphrase, `iter ${i}: telegram-id mode must carry a non-empty passphrase`).toBeTruthy()
+        expect(typeof returned!.passphrase).toBe('string')
+        expect((returned!.passphrase as string).length).toBeGreaterThan(0)
+      } else {
+        // passphrase mode — passphrase field is null by construction.
+        expect(returned!.mode).toBe('passphrase')
+      }
+    }
+  })
+})
+
+interface ResolvedPostureLike {
+  mode: 'passphrase' | 'telegram-id'
+  passphrase: string | null
+}
+
+// Deterministic PRNG so the fuzz is reproducible across CI runs.
+function mulberry32(seed: number): () => number {
+  let a = seed >>> 0
+  return () => {
+    a = (a + 0x6D2B79F5) >>> 0
+    let t = a
+    t = Math.imul(t ^ (t >>> 15), t | 1)
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61)
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296
+  }
+}
+
 describe('resolveVaultApprovalPosture — runtime behaviour', () => {
   it('returns the passphrase default when approvalAuth is unset', () => {
     const result = resolveVaultApprovalPosture(undefined, () => {
@@ -137,6 +320,27 @@ describe('resolveVaultApprovalPosture — runtime behaviour', () => {
       { HOME: '/home/test' },
     )
     expect(seen).toBe('/home/test/.switchroom/vault-auto-unlock')
+  })
+
+  it('THROWS when telegram-id is configured and the auto-unlock blob is empty or whitespace — refuses to silently boot with no passphrase', () => {
+    // Found by the property fuzz above: a *readable but empty* blob is
+    // just as dangerous as a missing one — the gateway would silently
+    // hold "" as the auto-unlock passphrase, and any Approve tap would
+    // invoke the broker with an empty passphrase. Refuse to boot.
+    expect(() =>
+      resolveVaultApprovalPosture(
+        { approvalAuth: 'telegram-id' },
+        () => '',
+        { HOME: '/home/test' },
+      ),
+    ).toThrow(/empty.*whitespace-only|whitespace-only/i)
+    expect(() =>
+      resolveVaultApprovalPosture(
+        { approvalAuth: 'telegram-id' },
+        () => '   \n\t',
+        { HOME: '/home/test' },
+      ),
+    ).toThrow(/Refusing to boot/)
   })
 
   it('THROWS when telegram-id is configured but the auto-unlock blob is unreadable — refuses to silently downgrade', () => {

--- a/telegram-plugin/tests/vault-approval-posture.test.ts
+++ b/telegram-plugin/tests/vault-approval-posture.test.ts
@@ -9,19 +9,29 @@
  *     auto-unlock-derived passphrase silently held in memory. Single-
  *     factor; the schema rejects this without `autoUnlock: true`.
  *
- * These tests are source-text contracts (same shape as the unlock-resume
- * suite next door) — they don't spin up a bot, just guard the wiring
- * stays in the file.
+ * The source-text contracts (same shape as the unlock-resume suite next
+ * door) guard wiring stays in the gateway file. The negative-path
+ * resolver test covers the refuse-to-boot behaviour at runtime.
  */
 
 import { describe, expect, it } from 'vitest'
 import { readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
+import { resolveVaultApprovalPosture } from '../vault-approval-posture.js'
 
 const gatewaySrc = readFileSync(
   resolve(__dirname, '..', 'gateway', 'gateway.ts'),
   'utf-8',
 )
+
+// Anchor the approve-branch slice on `handleVaultRequestAccessCallback`
+// so it's robust against future occurrences of `action === 'approve'`
+// elsewhere in the file.
+function sliceAccessApproveBlock(): string {
+  const fn =
+    gatewaySrc.split('async function handleVaultRequestAccessCallback')[1]?.split('async function')[0] ?? ''
+  return fn.split("if (action === 'approve')")[1]?.split("await ctx.answerCallbackQuery({ text: 'Unknown action'")[0] ?? ''
+}
 
 describe('vault grant approval posture — module-level wiring', () => {
   it('declares the posture mode and auto-unlock passphrase holders', () => {
@@ -33,17 +43,14 @@ describe('vault grant approval posture — module-level wiring', () => {
     expect(gatewaySrc).toMatch(/function initVaultApprovalPosture/)
     // wired into the startup IIFE
     expect(gatewaySrc).toMatch(/initVaultApprovalPosture\(\)/)
-    // reads the machine-bound blob via the canonical helper
-    expect(gatewaySrc).toMatch(/readAutoUnlockFile\(/)
+    // delegates to the resolver helper (testable in isolation)
+    expect(gatewaySrc).toMatch(/resolveVaultApprovalPosture\(/)
   })
 })
 
 describe('handleVaultRequestAccessCallback — posture branch', () => {
   it('mints directly without prompting when posture is telegram-id', () => {
-    const approveBlock =
-      gatewaySrc
-        .split("if (action === 'approve')")[1]
-        ?.split("await ctx.answerCallbackQuery({ text: 'Unknown action'")[0] ?? ''
+    const approveBlock = sliceAccessApproveBlock()
     // telegram-id branch is present before the passphrase-cache lookup
     expect(approveBlock).toMatch(/VAULT_APPROVAL_AUTH_MODE === ['"]telegram-id['"]/)
     expect(approveBlock).toMatch(/performVaultAccessApproval\(ctx, pending, stageId, senderId, AUTO_UNLOCK_PASSPHRASE\)/)
@@ -59,10 +66,7 @@ describe('handleVaultRequestAccessCallback — posture branch', () => {
   })
 
   it('leaves the passphrase-prompt path intact for the default posture', () => {
-    const approveBlock =
-      gatewaySrc
-        .split("if (action === 'approve')")[1]
-        ?.split("await ctx.answerCallbackQuery({ text: 'Unknown action'")[0] ?? ''
+    const approveBlock = sliceAccessApproveBlock()
     // The "passphrase mode" code path (cache lookup + prompt) MUST still exist.
     // This is the regression check: passphrase posture is unchanged.
     expect(approveBlock).toMatch(/vaultPassphraseCache\.get\(pending\.chat_id\)/)
@@ -91,5 +95,72 @@ describe('handleVaultRequestSaveCallback — silent fallback in telegram-id mode
         ?.split('async function handleVaultDeferCallback')[0] ?? ''
     expect(fnBlock).toMatch(/VAULT_APPROVAL_AUTH_MODE === ['"]telegram-id['"]/)
     expect(fnBlock).toMatch(/AUTO_UNLOCK_PASSPHRASE/)
+  })
+})
+
+describe('resolveVaultApprovalPosture — runtime behaviour', () => {
+  it('returns the passphrase default when approvalAuth is unset', () => {
+    const result = resolveVaultApprovalPosture(undefined, () => {
+      throw new Error('reader must not be called for passphrase posture')
+    })
+    expect(result.mode).toBe('passphrase')
+    expect(result.passphrase).toBeNull()
+  })
+
+  it('returns the passphrase default when approvalAuth is explicitly passphrase', () => {
+    const result = resolveVaultApprovalPosture({ approvalAuth: 'passphrase' }, () => {
+      throw new Error('reader must not be called for passphrase posture')
+    })
+    expect(result.mode).toBe('passphrase')
+    expect(result.passphrase).toBeNull()
+  })
+
+  it('loads the blob and returns telegram-id posture on success', () => {
+    const result = resolveVaultApprovalPosture(
+      { approvalAuth: 'telegram-id', autoUnlockCredentialPath: '/tmp/fake-blob' },
+      (path) => {
+        expect(path).toBe('/tmp/fake-blob')
+        return 'unlock-secret'
+      },
+      { HOME: '/home/test' },
+    )
+    expect(result.mode).toBe('telegram-id')
+    expect(result.passphrase).toBe('unlock-secret')
+    expect(result.credPath).toBe('/tmp/fake-blob')
+  })
+
+  it('expands ~ in the credential path against env.HOME', () => {
+    let seen = ''
+    resolveVaultApprovalPosture(
+      { approvalAuth: 'telegram-id' },
+      (path) => { seen = path; return 'ok' },
+      { HOME: '/home/test' },
+    )
+    expect(seen).toBe('/home/test/.switchroom/vault-auto-unlock')
+  })
+
+  it('THROWS when telegram-id is configured but the auto-unlock blob is unreadable — refuses to silently downgrade', () => {
+    expect(() =>
+      resolveVaultApprovalPosture(
+        { approvalAuth: 'telegram-id', autoUnlockCredentialPath: '/nonexistent/blob' },
+        () => { throw new Error('ENOENT: no such file or directory') },
+      ),
+    ).toThrow(/Refusing to boot/)
+
+    // The thrown error must clearly identify the security-posture
+    // mismatch so the operator knows why boot is failing.
+    expect(() =>
+      resolveVaultApprovalPosture(
+        { approvalAuth: 'telegram-id' },
+        () => { throw new Error('EACCES: permission denied') },
+      ),
+    ).toThrow(/approvalAuth=telegram-id but reading/)
+
+    expect(() =>
+      resolveVaultApprovalPosture(
+        { approvalAuth: 'telegram-id' },
+        () => { throw new Error('boom') },
+      ),
+    ).toThrow(/silently falling back to passphrase posture/)
   })
 })

--- a/telegram-plugin/tests/vault-approval-posture.test.ts
+++ b/telegram-plugin/tests/vault-approval-posture.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Contract pins for the `vault.broker.approvalAuth` posture toggle.
+ *
+ * Behaviour:
+ *   - `passphrase` (default): Approve on a grant card prompts the
+ *     operator to type the vault passphrase before minting. Two-factor:
+ *     Telegram ID (allowlist) + passphrase.
+ *   - `telegram-id` (opt-in): Approve mints immediately using the
+ *     auto-unlock-derived passphrase silently held in memory. Single-
+ *     factor; the schema rejects this without `autoUnlock: true`.
+ *
+ * These tests are source-text contracts (same shape as the unlock-resume
+ * suite next door) — they don't spin up a bot, just guard the wiring
+ * stays in the file.
+ */
+
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+const gatewaySrc = readFileSync(
+  resolve(__dirname, '..', 'gateway', 'gateway.ts'),
+  'utf-8',
+)
+
+describe('vault grant approval posture — module-level wiring', () => {
+  it('declares the posture mode and auto-unlock passphrase holders', () => {
+    expect(gatewaySrc).toMatch(/let VAULT_APPROVAL_AUTH_MODE:\s*['"]passphrase['"]\s*\|\s*['"]telegram-id['"]/)
+    expect(gatewaySrc).toMatch(/let AUTO_UNLOCK_PASSPHRASE:\s*string\s*\|\s*null/)
+  })
+
+  it('initialises posture from switchroom config at startup', () => {
+    expect(gatewaySrc).toMatch(/function initVaultApprovalPosture/)
+    // wired into the startup IIFE
+    expect(gatewaySrc).toMatch(/initVaultApprovalPosture\(\)/)
+    // reads the machine-bound blob via the canonical helper
+    expect(gatewaySrc).toMatch(/readAutoUnlockFile\(/)
+  })
+})
+
+describe('handleVaultRequestAccessCallback — posture branch', () => {
+  it('mints directly without prompting when posture is telegram-id', () => {
+    const approveBlock =
+      gatewaySrc
+        .split("if (action === 'approve')")[1]
+        ?.split("await ctx.answerCallbackQuery({ text: 'Unknown action'")[0] ?? ''
+    // telegram-id branch is present before the passphrase-cache lookup
+    expect(approveBlock).toMatch(/VAULT_APPROVAL_AUTH_MODE === ['"]telegram-id['"]/)
+    expect(approveBlock).toMatch(/performVaultAccessApproval\(ctx, pending, stageId, senderId, AUTO_UNLOCK_PASSPHRASE\)/)
+    // body says "Approved by @..." rather than "Reply with your passphrase"
+    expect(approveBlock).toMatch(/Approved by @/)
+  })
+
+  it('preserves the allowlist guard regardless of posture', () => {
+    const handlerBlock =
+      gatewaySrc.split('async function handleVaultRequestAccessCallback')[1]?.split('async function')[0] ?? ''
+    expect(handlerBlock).toMatch(/if \(!access\.allowFrom\.includes\(senderId\)\)/)
+    expect(handlerBlock).toMatch(/Not authorized/)
+  })
+
+  it('leaves the passphrase-prompt path intact for the default posture', () => {
+    const approveBlock =
+      gatewaySrc
+        .split("if (action === 'approve')")[1]
+        ?.split("await ctx.answerCallbackQuery({ text: 'Unknown action'")[0] ?? ''
+    // The "passphrase mode" code path (cache lookup + prompt) MUST still exist.
+    // This is the regression check: passphrase posture is unchanged.
+    expect(approveBlock).toMatch(/vaultPassphraseCache\.get\(pending\.chat_id\)/)
+    expect(approveBlock).toMatch(/Reply with your passphrase/i)
+    expect(approveBlock).toMatch(/passphrase-for-access-approve/)
+  })
+})
+
+describe('performVaultAccessApproval — posture-aware card footer', () => {
+  it('annotates the success card with the telegram-id footer when applicable', () => {
+    const fnBlock =
+      gatewaySrc
+        .split('async function performVaultAccessApproval')[1]
+        ?.split('async function handleVaultRequestAccessCallback')[0] ?? ''
+    expect(fnBlock).toMatch(/VAULT_APPROVAL_AUTH_MODE === ['"]telegram-id['"]/)
+    expect(fnBlock).toMatch(/Approver verified by Telegram identity/)
+    expect(fnBlock).toMatch(/broker auto-unlocked at startup/)
+  })
+})
+
+describe('handleVaultRequestSaveCallback — silent fallback in telegram-id mode', () => {
+  it('uses AUTO_UNLOCK_PASSPHRASE without prompting when posture is telegram-id', () => {
+    const fnBlock =
+      gatewaySrc
+        .split('async function handleVaultRequestSaveCallback')[1]
+        ?.split('async function handleVaultDeferCallback')[0] ?? ''
+    expect(fnBlock).toMatch(/VAULT_APPROVAL_AUTH_MODE === ['"]telegram-id['"]/)
+    expect(fnBlock).toMatch(/AUTO_UNLOCK_PASSPHRASE/)
+  })
+})

--- a/telegram-plugin/uat/scenarios/vault-approval-posture-telegram-id-dm.test.ts
+++ b/telegram-plugin/uat/scenarios/vault-approval-posture-telegram-id-dm.test.ts
@@ -1,0 +1,191 @@
+/**
+ * UAT scenario for #1115 — `vault.broker.approvalAuth: telegram-id`
+ * single-factor approve path.
+ *
+ * **What this exercises that unit tests cannot.** The schema test, the
+ * resolver fuzz, and the source-text contracts all live inside the
+ * gateway process. They prove the wiring is shaped right. They do NOT
+ * prove that:
+ *   - the *live* Telegram callback for the Approve button is routed
+ *     to `handleVaultRequestAccessCallback`,
+ *   - the gateway-cached `AUTO_UNLOCK_PASSPHRASE` is what the broker
+ *     actually accepts,
+ *   - the broker mints a real grant token end-to-end with no
+ *     passphrase prompt visible in chat,
+ *   - the success card carries the single-factor footer
+ *     (`Approver verified by Telegram identity`).
+ *
+ * This scenario closes that gap by round-tripping a real Telegram tap
+ * against a real broker on a host configured with
+ * `vault.broker.approvalAuth: telegram-id`.
+ *
+ * Sibling: `vault-request-access-end-to-end-dm.test.ts` exercises the
+ * same agent-initiated path under the DEFAULT `passphrase` posture
+ * (two-factor). The two scenarios together pin both rungs of the
+ * posture matrix.
+ *
+ * **Skipped by default.** To unskip:
+ *
+ * 1. Standard UAT preflight (`uat/SETUP.md` §5-6) — test-harness agent
+ *    live, driver session auth'd, env vars set.
+ *
+ * 2. **Host posture flipped to single-factor.** Edit `switchroom.yaml`:
+ *
+ *      vault:
+ *        broker:
+ *          autoUnlock: true
+ *          approvalAuth: telegram-id
+ *
+ *    Then `switchroom update` (or `apply` + restart gateway). The
+ *    scenario refuses to run if `switchroom doctor` reports the
+ *    passphrase posture — running it under passphrase mode would
+ *    block on a passphrase prompt the scenario doesn't send.
+ *
+ * 3. **Sacrificial vault key.** Same convention as the sibling:
+ *
+ *      TMPF=$(mktemp) && printf '%s' 'sentinel-1115-value' > "$TMPF" && \
+ *        switchroom vault set uat/req-access-target-tid --file "$TMPF" \
+ *          --format string ; shred -u "$TMPF"
+ *
+ * 4. Remove `describe.skip` below.
+ *
+ * Why skipped: (a) mutates host vault state (mints a 30-day grant on
+ * test-harness), (b) requires the operator to flip the live posture
+ * — opt-in only. Cleanup is operator-side
+ * (`switchroom vault revoke <grant-id>` after the run, then revert
+ * the posture if desired).
+ */
+
+import { describe, expect, it } from "vitest";
+import { spinUp } from "../harness.js";
+
+const SENTINEL_VALUE = "sentinel-1115-value";
+const TARGET_KEY = "uat/req-access-target-tid";
+
+describe.skip("uat: vault_request_access — telegram-id (single-factor) posture (#1115)", () => {
+  it(
+    "agent calls tool → operator taps Approve → silent mint, no passphrase prompt, single-factor footer present",
+    async () => {
+      const sc = await spinUp({ agent: "test-harness" });
+      try {
+        // 1. Trigger the agent-side MCP tool call. The agent's reply
+        //    is what emits the approval card.
+        await sc.sendDM(
+          `Please call your vault_request_access MCP tool with ` +
+          `key="${TARGET_KEY}", scope="read", reason="UAT regression for #1115 ` +
+          `(telegram-id single-factor posture)". Then attempt to read the key ` +
+          `once the operator confirms.`,
+        );
+
+        // 2. Wait for the bot's approval card. Anchor on the headline
+        //    emoji + tool-specific copy — same as the passphrase
+        //    sibling scenario, since the card itself is identical
+        //    regardless of posture (it's the Approve-tap behaviour
+        //    that diverges).
+        const card = await sc.expectMessage(/🔐.*wants vault access/, {
+          from: "bot",
+          timeout: 60_000,
+        });
+
+        // 3. Confirm the inline keyboard has the Approve button and
+        //    locate its callback_data.
+        const kb = await sc.driver.getKeyboard(sc.botUserId, card.messageId);
+        expect(kb).not.toBeNull();
+        const approveButton = kb!
+          .flat()
+          .find((b) => b.callbackData !== undefined && /approve/i.test(b.text));
+        expect(approveButton, "card should have an [✅ Approve] button").toBeDefined();
+
+        // 4. Tap Approve. Under `telegram-id` posture this MUST take
+        //    us straight to the "Approved by @ … — minting…" state —
+        //    no passphrase prompt should appear at any point.
+        await sc.driver.pressButton(
+          sc.botUserId,
+          card.messageId,
+          approveButton!.callbackData!,
+        );
+
+        // 5. Expect the immediate "minting" edit (with operator
+        //    @username) — the load-bearing UX signal that the
+        //    passphrase prompt was skipped.
+        await sc.expectMessage(/Approved by @.*minting/i, {
+          from: "bot",
+          timeout: 15_000,
+        });
+
+        // 6. Expect the success card with the SINGLE-FACTOR footer —
+        //    `performVaultAccessApproval` annotates the card with
+        //    "Approver verified by Telegram identity (broker
+        //    auto-unlocked at startup)" only under telegram-id mode.
+        //    If posture flipped silently to passphrase between steps
+        //    1 and 5, the footer wouldn't say this and the regex
+        //    misses → the scenario fails with a posture-state
+        //    diagnosis.
+        const granted = await sc.expectMessage(
+          /Granted.*read access[\s\S]*Approver verified by Telegram identity/i,
+          { from: "bot", timeout: 30_000 },
+        );
+        expect(granted.text).toMatch(/broker auto-unlocked at startup/i);
+
+        // 7. **Negative invariant** — *implicit*. The scenario sends
+        //    no passphrase between steps 4 (tap) and 6 (Granted). If
+        //    the gateway had actually fallen back to the passphrase
+        //    branch (`Reply with your passphrase` prompt), the flow
+        //    would stall waiting for an operator reply and the
+        //    `expectMessage(/Granted .../)` in step 6 would time out.
+        //    The single-factor-footer regex in step 6 is the
+        //    explicit positive gate that we landed in the
+        //    telegram-id branch and not, say, an unlocked-cache
+        //    shortcut.
+
+        // 8. Load-bearing functional assertion: the freshly-minted
+        //    grant actually works. Mirrors the sibling scenario's
+        //    final assertion so a future regression that breaks
+        //    the token-write path is caught here too.
+        await sc.sendDM(
+          `Now run: switchroom vault get ${TARGET_KEY} — and tell me ` +
+          `exactly what the command printed (including any error markers).`,
+        );
+        const replyAfterGet = await sc.expectMessage(
+          new RegExp(SENTINEL_VALUE),
+          { from: "bot", timeout: 60_000 },
+        );
+        expect(replyAfterGet.text).toContain(SENTINEL_VALUE);
+        expect(replyAfterGet.text).not.toMatch(/VAULT-BROKER-DENIED/);
+      } finally {
+        await sc.tearDown();
+      }
+    },
+    300_000,
+  );
+
+  it(
+    "doctor reports the single-factor posture so operators can verify the host before merging",
+    async () => {
+      // This second-tier check exists to flush out the failure mode
+      // where the YAML lands `approvalAuth: telegram-id` but the
+      // gateway either didn't reload or the schema-validation gate
+      // silently rejected it. Without this check, scenario 1 still
+      // passes when the gateway has reverted to passphrase posture
+      // (the operator would just be looking at a separate gateway
+      // process state and we'd never know).
+      const sc = await spinUp({ agent: "test-harness" });
+      try {
+        await sc.sendDM(
+          `Run: switchroom doctor — and quote exactly the line containing ` +
+          `"Approval auth:".`,
+        );
+        const doctorReply = await sc.expectMessage(
+          /Approval auth:\s*telegram-id/i,
+          { from: "bot", timeout: 60_000 },
+        );
+        expect(doctorReply.text).toMatch(
+          /single-factor.*Telegram account security/i,
+        );
+      } finally {
+        await sc.tearDown();
+      }
+    },
+    120_000,
+  );
+});

--- a/telegram-plugin/vault-approval-posture.ts
+++ b/telegram-plugin/vault-approval-posture.ts
@@ -1,0 +1,54 @@
+/**
+ * Pure resolver for the vault grant-card approval posture.
+ *
+ * Extracted from gateway.ts so unit tests can exercise the negative
+ * path (telegram-id with unreadable auto-unlock blob) without dragging
+ * the gateway's top-level startup IIFE under the vitest runner.
+ *
+ * Behaviour pinned by `tests/vault-approval-posture.test.ts`:
+ *  - `approvalAuth` absent / `passphrase` → returns passphrase posture
+ *    with no passphrase loaded.
+ *  - `approvalAuth: telegram-id` + readable blob → returns telegram-id
+ *    posture with the blob contents.
+ *  - `approvalAuth: telegram-id` + unreadable blob → THROWS. The
+ *    gateway propagates this and refuses to boot. We never silently
+ *    downgrade the operator's declared posture.
+ */
+
+export interface VaultBrokerPostureConfig {
+  approvalAuth?: string
+  autoUnlockCredentialPath?: string
+}
+
+export interface ResolvedPosture {
+  mode: 'passphrase' | 'telegram-id'
+  passphrase: string | null
+  credPath?: string
+}
+
+export function resolveVaultApprovalPosture(
+  broker: VaultBrokerPostureConfig | undefined,
+  reader: (path: string) => string,
+  env: { HOME?: string } = process.env,
+): ResolvedPosture {
+  if (broker?.approvalAuth !== 'telegram-id') {
+    return { mode: 'passphrase', passphrase: null }
+  }
+  const credPathRaw = broker.autoUnlockCredentialPath ?? '~/.switchroom/vault-auto-unlock'
+  const credPath = credPathRaw.replace(/^~/, env.HOME ?? '')
+  let loaded: string
+  try {
+    loaded = reader(credPath)
+  } catch (err) {
+    throw new Error(
+      `telegram gateway: vault.broker.approvalAuth=telegram-id but reading ` +
+        `auto-unlock blob at ${credPath} failed: ${(err as Error).message}. ` +
+        `Refusing to boot — silently falling back to passphrase posture ` +
+        `would invert the operator's declared security posture. ` +
+        `Either repair the auto-unlock blob (rerun \`switchroom setup\` / ` +
+        `\`switchroom vault auto-unlock\`) or remove ` +
+        `vault.broker.approvalAuth from switchroom.yaml.`,
+    )
+  }
+  return { mode: 'telegram-id', passphrase: loaded, credPath }
+}

--- a/telegram-plugin/vault-approval-posture.ts
+++ b/telegram-plugin/vault-approval-posture.ts
@@ -50,5 +50,21 @@ export function resolveVaultApprovalPosture(
         `vault.broker.approvalAuth from switchroom.yaml.`,
     )
   }
+  // An empty / whitespace-only blob is just as dangerous as a missing one
+  // under telegram-id posture: the gateway would hold "" as the auto-
+  // unlock passphrase, and any Approve tap would invoke the broker with
+  // an empty passphrase. The broker rejects that, but the operator
+  // discovers it only by tapping Approve on a real grant card. Refuse
+  // to boot instead — same security stance as the read-error path.
+  if (loaded.trim().length === 0) {
+    throw new Error(
+      `telegram gateway: vault.broker.approvalAuth=telegram-id but the ` +
+        `auto-unlock blob at ${credPath} is empty / whitespace-only. ` +
+        `Refusing to boot — an empty passphrase would silently invert the ` +
+        `operator's declared security posture. Rerun \`switchroom vault ` +
+        `broker enable-auto-unlock\` to repair the blob, or remove ` +
+        `vault.broker.approvalAuth from switchroom.yaml.`,
+    )
+  }
   return { mode: 'telegram-id', passphrase: loaded, credPath }
 }


### PR DESCRIPTION
## Summary

Opt-in toggle for the vault grant-card Approve tap. Default behaviour is unchanged.

- `passphrase` (default, today): Approve prompts the operator for the vault passphrase before minting. Two-factor (Telegram ID + passphrase).
- `telegram-id` (opt-in): Approve mints immediately using the auto-unlock-derived passphrase silently held in memory. Single-factor (Telegram ID only). Requires `autoUnlock: true`; the schema rejects the combination otherwise.

## Behavior matrix

| `approvalAuth` | `autoUnlock` | Approve tap result |
|---|---|---|
| `passphrase` | either | Prompts for passphrase (today) |
| `telegram-id` | `true` | Mints immediately, no prompt |
| `telegram-id` | `false` | Config error at startup |

## What changed

- `src/config/schema.ts` — new `approvalAuth` enum + `.superRefine` rejecting the invalid combo.
- `telegram-plugin/gateway/gateway.ts` — module-level `VAULT_APPROVAL_AUTH_MODE` + `AUTO_UNLOCK_PASSPHRASE`, loaded once at gateway start via `readAutoUnlockFile`. Posture branches added to `handleVaultRequestAccessCallback`, `handleVaultRequestSaveCallback`, and `handleVaultDeferCallback`. `performVaultAccessApproval` annotates the success card footer. `handleVaultGrantCallback` (wizard) is untouched — it already does not prompt for a passphrase.
- `src/cli/setup.ts` — posture prompt offered after the auto-unlock step succeeds.
- `src/cli/doctor.ts` — surfaces `Approval auth: telegram-id (single-factor, relies on Telegram account security)` or `Approval auth: passphrase (two-factor)`.
- `docs/configuration.md` — full posture + threat-model writeup.
- `CHANGELOG.md` — entry under Unreleased -> New features.
- `scripts/check-bot-api-wrapping.sh` — allowlist line-range shifts (the gateway insert pushed pre-existing flagged-but-allowlisted lines by a fixed offset).
- Tests: schema validation suite + gateway source-text contracts pinning the wiring.

## Test plan

- [x] `npx tsc --noEmit` — clean.
- [x] `bash scripts/check-bot-api-wrapping.sh` — clean.
- [x] `npx vitest run src/config/schema.test.ts telegram-plugin/tests/vault-approval-posture.test.ts` — 50/50 pass.
- [x] Full `npx vitest run` — failures observed are all pre-existing infra (missing `docker compose` v2 binary in CI, missing build artifacts, `dist/cli/*` not generated). None touch the changed surface.
- [ ] Manual: enable `vault.broker.approvalAuth: telegram-id` on a host with `autoUnlock: true`, approve a `vault_request_access` card, confirm no passphrase prompt and the new footer.
- [ ] Manual: set `approvalAuth: telegram-id` with `autoUnlock: false`, confirm `switchroom apply` / config-load rejects with the schema error.
- [ ] Manual: default-posture regression — confirm `passphrase` mode still prompts and queues across sibling cards (#1051 batching path).

## Migration note

Default unchanged, fully backward compatible. Existing configs continue to behave exactly as before.

## Security callout

**Single-factor mode collapses approval security to Telegram account control.** Operator should have Telegram 2FA enabled and the host should not be multi-tenant before flipping this on. Opt-in only — `switchroom doctor` makes the active posture obvious.