### PR TITLE
fix(subagent-watcher): stop foreign-slug ENOENT spam + duplicate Worker done (#1116)

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -13093,6 +13093,14 @@ void (async () => {
           if (watcherAgentDir != null) {
             subagentWatcher = startSubagentWatcher({
               agentDir: watcherAgentDir,
+              // Issue #1116 (Bug A): restrict project-dir enumeration to
+              // the slug Claude Code mints for this agent's cwd (which
+              // start.sh sets to agentDir before launching claude — see
+              // profiles/_base/start.sh.hbs `cd "{{agentDir}}"`). Foreign-
+              // slug shadow dirs left over from a prior CLAUDE_PROJECT_DIR
+              // accident no longer pollute the watcher with phantom
+              // registrations + ENOENT log spam + false stalls.
+              agentCwd: watcherAgentDir,
               // Bug 0 fix: previously omitted, leaving the watcher unable to
               // write liveness/stall/turn_end updates to the registry DB.
               // Liveness writes are now persisted across the gateway lifetime.

--- a/telegram-plugin/subagent-watcher.ts
+++ b/telegram-plugin/subagent-watcher.ts
@@ -40,7 +40,7 @@ import {
 } from 'fs'
 import { basename, join } from 'path'
 import { homedir } from 'os'
-import { projectSubagentLine } from './session-tail.js'
+import { projectSubagentLine, sanitizeCwdToProjectName } from './session-tail.js'
 import { sanitiseToolArg } from './fleet-state.js'
 import { escapeHtml, truncate } from './card-format.js'
 import { bumpSubagentActivity, recordSubagentStall, recordSubagentResume, recordSubagentEnd, reapStuckRunningRows } from './registry/subagents-schema.js'
@@ -127,6 +127,16 @@ export interface SubagentWatcherConfig {
    * Used to derive `.claude/projects/<cwd>/` dirs to watch.
    */
   agentDir: string
+  /**
+   * Agent's working directory — used to compute the project-dir slug the
+   * watcher should restrict its enumeration to (Claude Code keys project
+   * dirs off the cwd at first launch via `sanitizeCwdToProjectName`).
+   * When omitted, the watcher walks every subdir of
+   * `<agentDir>/.claude/projects/` (legacy behaviour; see issue #1116
+   * for why this is unsafe — a foreign agent's stale project dir under
+   * an agent's home pollutes the watcher with phantom registrations).
+   */
+  agentCwd?: string
   /**
    * Send a fresh (non-edit) Telegram message. For stall / completion
    * state-transition notifications.
@@ -608,6 +618,20 @@ function readSubTail(
 
 export function startSubagentWatcher(config: SubagentWatcherConfig): SubagentWatcherHandle {
   const agentDir = config.agentDir
+  // Issue #1116: when agentCwd is supplied, restrict project-dir
+  // enumeration to the slug Claude Code would mint for that cwd.
+  // Foreign-slug shadow dirs (a sibling agent's stale project tree
+  // left over from a wayward CLAUDE_PROJECT_DIR or a past boot) are
+  // skipped — pre-#1116 they caused ENOENT log spam and false stalls.
+  // When agentCwd is null/undefined, fall back to the legacy walk-
+  // every-subdir behaviour (preserves tests that don't care about
+  // multi-slug isolation).
+  const expectedProjectSlug = config.agentCwd != null
+    ? sanitizeCwdToProjectName(config.agentCwd)
+    : null
+  // One-shot logging: warn the first time a foreign slug is observed
+  // so silent regressions are visible without re-running with debug.
+  const warnedForeignSlugs = new Set<string>()
   // Threshold knobs resolve in this order: explicit config arg →
   // env-var override → compile-time default. Env-vars exist so the
   // UAT scenario (which times out at 120s) can compress the watcher's
@@ -683,6 +707,20 @@ export function startSubagentWatcher(config: SubagentWatcherConfig): SubagentWat
    * when they eventually report done — that transition is meaningful.
    */
   const historicalFiles = new Set<string>()
+  /**
+   * AgentIds that have transitioned to a terminal state and been swept
+   * out of `registry` by `cleanupTerminalAgent`. Issue #1116 (Bug B):
+   * the JSONL file outlives the registry entry — Claude Code leaves
+   * the file on disk after the sub-agent finishes. Without this guard,
+   * the next `rescanSubagentDirs` poll re-discovered the file, called
+   * `registerAgent`, the fresh entry read the terminal `turn_duration`
+   * line, and `maybySendStateTransition` fired a duplicate "Worker done"
+   * notification — looping forever every grace-window.
+   *
+   * `scanSubagentsDir` consults this set and treats re-discovered
+   * terminal JSONLs as a no-op.
+   */
+  const terminatedAgentIds = new Set<string>()
   /**
    * True while the initial boot scan is running. During this window every
    * newly discovered file is added to historicalFiles.
@@ -878,6 +916,10 @@ export function startSubagentWatcher(config: SubagentWatcherConfig): SubagentWat
       knownFiles.delete(entry.filePath)
     }
     registry.delete(agentId)
+    // Issue #1116 (Bug B): record that this agent has been fully
+    // processed so a rescan that rediscovers the still-present JSONL
+    // doesn't re-register and re-notify.
+    terminatedAgentIds.add(agentId)
     log?.(`subagent-watcher: cleaned up terminal agent ${agentId}`)
   }
 
@@ -1016,6 +1058,16 @@ export function startSubagentWatcher(config: SubagentWatcherConfig): SubagentWat
     } catch { return }
 
     for (const pDir of projectDirs) {
+      // Issue #1116: filter to the agent's own slug. Skip foreign
+      // project dirs so their stale subagent JSONLs (which Claude
+      // Code reaps mid-session) don't pollute the watcher's registry.
+      if (expectedProjectSlug != null && pDir !== expectedProjectSlug) {
+        if (!warnedForeignSlugs.has(pDir)) {
+          warnedForeignSlugs.add(pDir)
+          log?.(`subagent-watcher: skipping foreign project dir ${pDir} (expected ${expectedProjectSlug})`)
+        }
+        continue
+      }
       const projectPath = join(projectsRoot, pDir)
       let sessionDirs: string[]
       try {
@@ -1061,6 +1113,12 @@ export function startSubagentWatcher(config: SubagentWatcherConfig): SubagentWat
       if (!e.startsWith('agent-') || !e.endsWith('.jsonl')) continue
       const filePath = join(subagentsPath, e)
       if (knownFiles.has(filePath)) continue
+      const agentId = e.slice('agent-'.length, -'.jsonl'.length)
+      // Issue #1116 (Bug B): skip JSONLs whose agent already completed
+      // and was swept by cleanupTerminalAgent. Re-adding to knownFiles
+      // here would let a subsequent rescan re-register, fire a duplicate
+      // "Worker done", and loop forever every grace-window.
+      if (terminatedAgentIds.has(agentId)) continue
       knownFiles.add(filePath)
       // During the initial boot scan, mark every discovered file as
       // historical so stall-detection and completion notifications are
@@ -1069,7 +1127,6 @@ export function startSubagentWatcher(config: SubagentWatcherConfig): SubagentWat
       if (bootScanInProgress) {
         historicalFiles.add(filePath)
       }
-      const agentId = e.slice('agent-'.length, -'.jsonl'.length)
       registerAgent(filePath, agentId)
     }
   }
@@ -1154,6 +1211,7 @@ export function startSubagentWatcher(config: SubagentWatcherConfig): SubagentWat
       tails.clear()
       registry.clear()
       knownFiles.clear()
+      terminatedAgentIds.clear()
     },
 
     getRegistry(): ReadonlyMap<string, WorkerEntry> {

--- a/telegram-plugin/tests/subagent-watcher.test.ts
+++ b/telegram-plugin/tests/subagent-watcher.test.ts
@@ -879,4 +879,267 @@ describe('startSubagentWatcher', () => {
       h.watcher.stop()
     })
   })
+
+  // ─── Issue #1116 regressions ─────────────────────────────────────────────
+
+  describe('issue #1116 — project-dir slug filter (Bug A)', () => {
+    /**
+     * Claude Code keys its `.claude/projects/<slug>/` dirs off the cwd it
+     * was launched in. Over time an agent's home can accumulate stale
+     * project dirs from prior boots (or from a sibling agent that briefly
+     * shared the home via a wayward `CLAUDE_PROJECT_DIR`). Pre-#1116 the
+     * watcher enumerated every project dir under `<agentDir>/.claude/projects/`
+     * and registered any `agent-*.jsonl` it found, which produced phantom
+     * registry entries whose backing files vanish on the next session-cleanup
+     * tick (ENOENT spam + false stall notifications, per the issue's
+     * smoking-gun log).
+     *
+     * The fix: when `agentCwd` is supplied, the watcher restricts
+     * enumeration to the project dir whose slug matches
+     * `sanitizeCwdToProjectName(agentCwd)`. Foreign-slug shadow dirs are
+     * skipped entirely.
+     */
+
+    let tmpRoot = ''
+    const startedWatchers: Array<{ stop(): void }> = []
+
+    beforeEach(() => {
+      tmpRoot = mkdtempSync(join(tmpdir(), 'switchroom-watcher-1116-slug-'))
+    })
+
+    afterEach(() => {
+      while (startedWatchers.length) {
+        try { startedWatchers.pop()?.stop() } catch { /* ignore */ }
+      }
+      try { rmSync(tmpRoot, { recursive: true, force: true }) } catch { /* ignore */ }
+    })
+
+    function startWatcherSync(opts: { agentDir: string; agentCwd?: string }): {
+      notifications: string[]
+      logs: string[]
+      poll: () => void
+      watcher: ReturnType<typeof startSubagentWatcher>
+    } {
+      const notifications: string[] = []
+      const logs: string[] = []
+      const intervals: Array<{ fn: () => void; ref: number }> = []
+      const timeouts: Array<{ fn: () => void; ref: number }> = []
+      let nextRef = 1
+      const watcher = startSubagentWatcher({
+        agentDir: opts.agentDir,
+        ...(opts.agentCwd !== undefined ? { agentCwd: opts.agentCwd } : {}),
+        sendNotification: (text) => notifications.push(text),
+        stallThresholdMs: 60_000,
+        rescanMs: 500,
+        now: () => Date.now(),
+        setInterval: (fn) => {
+          const ref = nextRef++
+          intervals.push({ fn, ref })
+          return { ref }
+        },
+        clearInterval: (handle) => {
+          const { ref } = handle as { ref: number }
+          const idx = intervals.findIndex((i) => i.ref === ref)
+          if (idx !== -1) intervals.splice(idx, 1)
+        },
+        setTimeout: (fn) => {
+          const ref = nextRef++
+          timeouts.push({ fn, ref })
+          return { ref }
+        },
+        clearTimeout: (handle) => {
+          const { ref } = handle as { ref: number }
+          const idx = timeouts.findIndex((t) => t.ref === ref)
+          if (idx !== -1) timeouts.splice(idx, 1)
+        },
+        log: (msg) => logs.push(msg),
+      })
+      startedWatchers.push(watcher)
+      return {
+        notifications,
+        logs,
+        poll: () => intervals[0]?.fn(),
+        watcher,
+      }
+    }
+
+    it('skips foreign-slug project dirs when agentCwd is provided', () => {
+      // Layout: an agent whose real cwd is /home/test/agent-own. Its
+      // home contains BOTH its own project dir (-home-test-agent-own)
+      // AND a stale foreign one (-home-test-agent-foreign) left over
+      // from a prior boot. Each contains a sub-agent JSONL with a
+      // distinct agentId.
+      const agentDir = join(tmpRoot, 'agent')
+      const agentCwd = '/home/test/agent-own'
+      const ownSubagents = join(agentDir, '.claude', 'projects', '-home-test-agent-own', 'sess-A', 'subagents')
+      const foreignSubagents = join(agentDir, '.claude', 'projects', '-home-test-agent-foreign', 'sess-B', 'subagents')
+      mkdirSync(ownSubagents, { recursive: true })
+      mkdirSync(foreignSubagents, { recursive: true })
+      writeFileSync(
+        join(ownSubagents, 'agent-ownworker.jsonl'),
+        buildJSONL(subAgentUserMsg('legit work')),
+      )
+      writeFileSync(
+        join(foreignSubagents, 'agent-foreignworker.jsonl'),
+        buildJSONL(subAgentUserMsg('stale shadow')),
+      )
+
+      const h = startWatcherSync({ agentDir, agentCwd })
+      h.poll()
+
+      const reg = h.watcher.getRegistry()
+      expect(reg.has('ownworker')).toBe(true)
+      expect(reg.has('foreignworker')).toBe(false)
+    })
+
+    it('does NOT emit "read error" ENOENT for foreign-slug files that vanish mid-scan', () => {
+      // Simulates the smoking-gun log line from the issue. Foreign-slug
+      // JSONL is deleted from disk before the watcher's first readSubTail.
+      // With the slug filter in place the foreign agent is never even
+      // registered, so no ENOENT log line is emitted.
+      const agentDir = join(tmpRoot, 'agent')
+      const agentCwd = '/home/test/agent-own'
+      const ownSubagents = join(agentDir, '.claude', 'projects', '-home-test-agent-own', 'sess-A', 'subagents')
+      const foreignSubagents = join(agentDir, '.claude', 'projects', '-home-test-agent-foreign', 'sess-B', 'subagents')
+      mkdirSync(ownSubagents, { recursive: true })
+      mkdirSync(foreignSubagents, { recursive: true })
+      writeFileSync(
+        join(ownSubagents, 'agent-ownworker.jsonl'),
+        buildJSONL(subAgentUserMsg('legit work')),
+      )
+      const foreignJsonl = join(foreignSubagents, 'agent-foreignworker.jsonl')
+      writeFileSync(foreignJsonl, buildJSONL(subAgentUserMsg('about to vanish')))
+
+      const h = startWatcherSync({ agentDir, agentCwd })
+      // Reap the foreign file the way Claude Code's session cleanup
+      // would, *before* the first poll runs.
+      rmSync(foreignJsonl)
+      h.poll()
+
+      // Polls should not produce a "read error … ENOENT" log line.
+      const enoentLogs = h.logs.filter((l) => l.includes('read error') && l.includes('ENOENT'))
+      expect(enoentLogs).toHaveLength(0)
+      // And the foreign agent must not be registered.
+      expect(h.watcher.getRegistry().has('foreignworker')).toBe(false)
+    })
+  })
+
+  describe('issue #1116 — terminal cleanup must not re-fire completion (Bug B)', () => {
+    /**
+     * Pre-#1116: after `TERMINAL_CLEANUP_GRACE_MS` (30s) elapsed,
+     * `cleanupTerminalAgent` deleted the agentId from `registry` and
+     * the JSONL path from `knownFiles`. The JSONL itself stayed on disk
+     * (Claude Code keeps the file). The next `rescanSubagentDirs` poll
+     * found the JSONL absent from `knownFiles`, re-added it, called
+     * `registerAgent` with a fresh `completionNotified=false` entry,
+     * read the terminal `turn_duration` line again, and fired a SECOND
+     * `✓ Worker done` notification. This loops every grace-window
+     * (~30s); for the operator it manifests as the same handful of
+     * sub-agents announcing completion every ~6 min indefinitely.
+     */
+
+    let tmpRoot = ''
+    const startedWatchers: Array<{ stop(): void }> = []
+
+    beforeEach(() => {
+      tmpRoot = mkdtempSync(join(tmpdir(), 'switchroom-watcher-1116-rerun-'))
+    })
+
+    afterEach(() => {
+      while (startedWatchers.length) {
+        try { startedWatchers.pop()?.stop() } catch { /* ignore */ }
+      }
+      try { rmSync(tmpRoot, { recursive: true, force: true }) } catch { /* ignore */ }
+    })
+
+    it('does NOT re-fire "Worker done" after terminal cleanup grace expires and rescan rediscovers the JSONL', () => {
+      const agentDir = join(tmpRoot, 'agent')
+      const subagentsDir = join(agentDir, '.claude', 'projects', 'p1', 'sess-A', 'subagents')
+      mkdirSync(subagentsDir, { recursive: true })
+      const jsonlPath = join(subagentsDir, 'agent-loopme.jsonl')
+
+      // Boot with an empty subagents dir, then write a post-boot JSONL so
+      // the agent is registered non-historical (otherwise the historical
+      // shortcut suppresses the completion notification entirely).
+      const notifications: string[] = []
+      const intervals: Array<{ fn: () => void; ref: number }> = []
+      const timeouts: Array<{ fn: () => void; ref: number }> = []
+      let nextRef = 1
+      const watcher = startSubagentWatcher({
+        agentDir,
+        sendNotification: (text) => notifications.push(text),
+        stallThresholdMs: 60_000,
+        rescanMs: 500,
+        now: () => Date.now(),
+        setInterval: (fn) => {
+          const ref = nextRef++
+          intervals.push({ fn, ref })
+          return { ref }
+        },
+        clearInterval: (handle) => {
+          const { ref } = handle as { ref: number }
+          const idx = intervals.findIndex((i) => i.ref === ref)
+          if (idx !== -1) intervals.splice(idx, 1)
+        },
+        setTimeout: (fn) => {
+          const ref = nextRef++
+          timeouts.push({ fn, ref })
+          return { ref }
+        },
+        clearTimeout: (handle) => {
+          const { ref } = handle as { ref: number }
+          const idx = timeouts.findIndex((t) => t.ref === ref)
+          if (idx !== -1) timeouts.splice(idx, 1)
+        },
+        log: () => {},
+      })
+      startedWatchers.push(watcher)
+
+      const poll = () => intervals[0]?.fn()
+      const fireScheduledCleanups = () => {
+        let fired = 0
+        while (timeouts.length) {
+          const next = timeouts.shift()!
+          next.fn()
+          fired++
+        }
+        return fired
+      }
+
+      // Step 1: post-boot, write an in-flight JSONL → poll registers it.
+      writeFileSync(jsonlPath, buildJSONL(subAgentUserMsg('Do the task')))
+      poll()
+      expect(watcher.getRegistry().has('loopme')).toBe(true)
+      expect(watcher.getRegistry().get('loopme')?.historical).toBe(false)
+
+      // Step 2: append turn_duration → poll → state=done → "Worker done" fires.
+      appendFileSync(jsonlPath, buildJSONL(subAgentTurnDuration()))
+      poll()
+      const firstRoundNotifs = notifications.filter((n) => n.includes('Worker done'))
+      expect(firstRoundNotifs).toHaveLength(1)
+
+      // Step 3: fire the terminal-cleanup grace timer (drains the
+      // scheduled cleanup). Registry entry should be gone.
+      const fired = fireScheduledCleanups()
+      expect(fired).toBeGreaterThan(0)
+      expect(watcher.getRegistry().has('loopme')).toBe(false)
+
+      // Step 4: the JSONL is STILL on disk — Claude Code doesn't delete
+      // it after the sub-agent finishes. The next poll re-scans the dir
+      // and finds the file. Pre-fix: re-registers the agent and fires a
+      // SECOND "Worker done". Post-fix: re-discovery is a no-op for
+      // an agentId we've already announced as terminal.
+      poll()
+      const afterRescanNotifs = notifications.filter((n) => n.includes('Worker done'))
+      expect(
+        afterRescanNotifs.length,
+        `Expected exactly 1 "Worker done" notification, got ${afterRescanNotifs.length}: ${JSON.stringify(afterRescanNotifs)}`,
+      ).toBe(1)
+
+      // And another poll for good measure — still exactly one.
+      poll()
+      poll()
+      expect(notifications.filter((n) => n.includes('Worker done'))).toHaveLength(1)
+    })
+  })
 })

--- a/telegram-plugin/uat/scenarios/subagent-watcher-no-rerun-dm.test.ts
+++ b/telegram-plugin/uat/scenarios/subagent-watcher-no-rerun-dm.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Issue #1116 — subagent-watcher must not re-fire "✓ Worker done"
+ * after the terminal-cleanup grace window elapses.
+ *
+ * Pre-fix repro (validated by RCA on `clerk` DM, 2026-05-12): once a
+ * background sub-agent completed, `cleanupTerminalAgent` ran ~30s
+ * later, deleting the agent's filePath from `knownFiles` and its row
+ * from `registry`. The JSONL itself stayed on disk, so the next
+ * `rescanSubagentDirs` poll rediscovered it, re-registered the agent
+ * with `completionNotified=false`, read the terminal `turn_duration`
+ * line, and emitted a fresh `✓ Worker done: …` notification. The loop
+ * ran indefinitely — operator saw the same 4 sub-agents (30/2/15/105
+ * tools) re-announcing completion every ~6 minutes.
+ *
+ * Post-fix invariant: each completed sub-agent emits exactly ONE
+ * `✓ Worker done` notification for the lifetime of the gateway.
+ *
+ * As a side-benefit, this scenario also catches the original RFC's
+ * "raw HTML tags rendered in card text" symptom (Bug C in the RCA):
+ * any bot message containing a literal `<b>` / `<i>` / `<code>`
+ * substring during the window is flagged. The watcher's own
+ * notification path is HTML-correct on `main`, so this assertion is
+ * a regression detector — if a future change starts leaking raw
+ * tags via a fall-through send site, this scenario goes red.
+ *
+ * Requires the same env as the other DM scenarios (see SETUP.md §6)
+ * and the test-harness override `progress_card.delay_ms: 1000` so a
+ * short DM turn actually pins a card (SETUP.md §5).
+ *
+ * Time budget: the bg sub-agent does three ~20s sleeps (~60s total)
+ * + we listen for an extra 75s post-completion (>30s grace +
+ * generous rescan slack) to catch a rerun. Sum to ~240s plus settle.
+ */
+
+import { describe, expect, it } from "vitest";
+import { spinUp } from "../harness.js";
+
+// Same Option-1 explicit-dispatch prompt as bg-sub-agent-dispatch-dm.test.ts
+// — naming the tool + run_in_background flag keeps the model
+// deterministic. The inner sleeps are shorter here (3×10s = ~30s
+// background phase) so the outer budget stays sane: we only need
+// the sub-agent to *complete* once. The duplicate-detection window
+// is what makes the test meaningful, not the bg phase duration.
+const BG_DISPATCH_PROMPT =
+  `Use the Agent tool with subagent_type "general-purpose" and ` +
+  `run_in_background: true to dispatch a worker with this exact task: ` +
+  `"Run \`sleep 10\` via the Bash tool, then \`echo step1\`, then ` +
+  `\`sleep 10\` again, then \`echo step2\`, then \`echo done\`. ` +
+  `That's two separate Bash sleeps and three echoes." After ` +
+  `dispatching, send a brief reply saying you've kicked off the ` +
+  `background worker so I can watch the progress card.`;
+
+const WORKER_DONE_RE = /✓\s*Worker done/;
+const RAW_HTML_TAG_RE = /<\/?(b|i|code|pre|strong|em)>/i;
+
+describe("uat: issue #1116 — subagent-watcher does not re-fire Worker done", () => {
+  it(
+    "emits exactly one ✓ Worker done per bg sub-agent and no raw HTML leaks",
+    async () => {
+      const sc = await spinUp({ agent: "test-harness" });
+      try {
+        await sc.sendDM(BG_DISPATCH_PROMPT);
+
+        // Wait for the bg sub-agent to complete — the watcher's
+        // `✓ Worker done: …` notification is what we're locking
+        // behaviour around. Generous timeout: parent ack + bg sleeps
+        // + completion plumbing.
+        const firstDone = await sc.expectMessage(WORKER_DONE_RE, {
+          from: "bot",
+          timeout: 120_000,
+        });
+        expect(firstDone.text).toMatch(WORKER_DONE_RE);
+
+        // Snapshot bot-side messages observed after the first done.
+        // Pre-fix the same notification re-fired every ~30s
+        // (TERMINAL_CLEANUP_GRACE_MS + rescan). 75s gives us a
+        // comfortable >2 grace windows worth of observation.
+        const collected: Array<{ text: string; messageId: number }> = [];
+        const observer = sc.driver
+          .observeMessages(sc.botUserId)
+          [Symbol.asyncIterator]();
+        const deadline = Date.now() + 75_000;
+        try {
+          while (Date.now() < deadline) {
+            const remaining = deadline - Date.now();
+            if (remaining <= 0) break;
+            const winner = await Promise.race([
+              observer.next(),
+              new Promise<{ value?: undefined; done: true }>((resolve) =>
+                setTimeout(() => resolve({ done: true }), remaining),
+              ),
+            ]);
+            if (winner.done) break;
+            const msg = winner.value;
+            if (!msg) continue;
+            // Only count bot-sent messages (filter out anything the
+            // driver itself echoed in this window).
+            if (msg.fromUserId === sc.driverUserId) continue;
+            collected.push({ text: msg.text ?? "", messageId: msg.messageId });
+          }
+        } finally {
+          // Closing the iterator unregisters the mtcute listeners.
+          await observer.return?.();
+        }
+
+        // Invariant 1: no DUPLICATE Worker-done with the same shape
+        // as the first one. We compare text rather than message_id
+        // because the bug emits FRESH messages (not edits), so each
+        // re-fire has a new message_id but identical text.
+        const reruns = collected.filter((m) => WORKER_DONE_RE.test(m.text));
+        expect(
+          reruns,
+          `Expected zero re-fires of "Worker done" in the ${75}s post-completion window, got ${reruns.length}: ${JSON.stringify(reruns.slice(0, 4).map((r) => r.text.slice(0, 80)))}`,
+        ).toHaveLength(0);
+
+        // Invariant 2: no raw HTML tags in any bot text — including
+        // the original `firstDone` notification. Catches Bug C
+        // (RCA's third symptom) as a regression detector.
+        const allBotTexts = [firstDone.text, ...collected.map((m) => m.text)];
+        for (const text of allBotTexts) {
+          expect(
+            text,
+            `Raw HTML tag leaked into bot text: ${text.slice(0, 120)}`,
+          ).not.toMatch(RAW_HTML_TAG_RE);
+        }
+      } finally {
+        await sc.tearDown();
+      }
+    },
+    // Outer budget: 120s wait-for-done + 75s observation window +
+    // ~12s spinUp settle + slack. Round up.
+    240_000,
+  );
+});

--- a/telegram-plugin/uat/scenarios/subagent-watcher-no-rerun-dm.test.ts
+++ b/telegram-plugin/uat/scenarios/subagent-watcher-no-rerun-dm.test.ts
@@ -27,9 +27,10 @@
  * and the test-harness override `progress_card.delay_ms: 1000` so a
  * short DM turn actually pins a card (SETUP.md §5).
  *
- * Time budget: the bg sub-agent does three ~20s sleeps (~60s total)
+ * Time budget: the bg sub-agent does two ~10s sleeps (~20s total)
  * + we listen for an extra 75s post-completion (>30s grace +
- * generous rescan slack) to catch a rerun. Sum to ~240s plus settle.
+ * generous rescan slack) to catch a rerun. Plus parent-turn ack
+ * latency and Telegram-edit settle. Outer cap 240s.
  */
 
 import { describe, expect, it } from "vitest";


### PR DESCRIPTION
## Summary

Closes #1116. Two independent bugs in `subagent-watcher`:

- **Bug A** — `rescanSubagentDirs` enumerated every project dir under `<agentDir>/.claude/projects/`, registering agent IDs from foreign-slug shadow trees. Result: 234+ ENOENT log entries per polling window and false "stall detected" notifications. Fixed by adding `agentCwd` to the watcher config and restricting enumeration to `sanitizeCwdToProjectName(agentCwd)`.

- **Bug B** — `cleanupTerminalAgent` removed the JSONL path from `knownFiles` 30s after completion. The JSONL still exists on disk, so the next rescan re-registered with `completionNotified=false` and re-fired `✓ Worker done`. Looped every ~30s indefinitely. Fixed by adding a permanent `terminatedAgentIds: Set<string>` consulted in `scanSubagentsDir`.

Bug B is the actual driver of the operator-visible "same 4 sub-agents re-announcing completion every 6 min" pattern Ken saw on `clerk`. The original RCA attributed this to Bug A; that's incorrect — the wrong-slug path produces ENOENT and false stalls, not duplicate completions. RCA comment updated on the issue.

Bug C from the issue (raw `<b>`/`<i>` leaks in card text) wasn't pinned to an emit site. The watcher's own `sendNotification` path is HTML-correct on main; possibly downstream of Bug A's failure mode. The new UAT scenario adds a regression assertion.

## Test plan

- [x] 3 new unit tests in `telegram-plugin/tests/subagent-watcher.test.ts` — Bug A slug filter, no ENOENT for foreign-slug, Bug B no rerun. All red on main, green with the fix. Full 19-test file passes.
- [x] `npm run build` clean.
- [x] `tsc --noEmit` clean.
- [x] New UAT scenario `telegram-plugin/uat/scenarios/subagent-watcher-no-rerun-dm.test.ts` — dispatches one bg sub-agent, listens 75s post-completion, asserts exactly one Worker-done + no raw HTML leaks. **Requires the fix deployed to the test-harness container** (`switchroom apply --build-local` then restart). Will run after this PR merges.
- [ ] UAT run against test-harness (post-deploy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)