### PR TITLE
fix(lifecycle): restartAgent always writes a clean-shutdown marker (#1118)

### DIFF
--- a/src/agents/lifecycle.ts
+++ b/src/agents/lifecycle.ts
@@ -206,7 +206,22 @@ export function stopAgent(name: string): void {
 export function restartAgent(name: string, reason?: string): void {
   // Stamp WHY before killing so the next agent boot can render it in
   // the greeting card. Best-effort — if the dir is missing we swallow.
-  if (reason) writeRestartReasonMarker(name, reason);
+  //
+  // Issue #1118: ALWAYS write a marker (default reason "cli: restart")
+  // even when the caller didn't pass one. Pre-#1118 the seven in-tree
+  // callers that called `restartAgent(name)` bare (auth.ts after token
+  // rotation, agent.ts reconcile paths, web/api.ts, etc.) left the
+  // next boot to read whatever stale marker was on disk from an older
+  // /restart — almost always >5 min stale, so the boot-reason
+  // classifier fell through to 'crash' and posted a misleading
+  // "💥 agent-crashed" card on every legitimate operator action.
+  //
+  // preserveExisting:true keeps the cooperative-race contract intact:
+  // when the gateway /new handler writes "user: /new from chat" then
+  // spawns `switchroom agent restart`, the CLI's default "cli: restart"
+  // must NOT clobber the still-fresh user attribution (see
+  // writeRestartReasonMarker's 30s freshness window).
+  writeRestartReasonMarker(name, reason ?? "cli: restart", { preserveExisting: true });
   try {
     // `up -d --force-recreate --no-deps` not `restart` (#932). All
     // three flags are load-bearing — DO NOT strip any without

--- a/tests/lifecycle.docker.test.ts
+++ b/tests/lifecycle.docker.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 // Mock node:child_process so docker(...) calls are observable and don't
 // escape the test. tmux.js is mocked separately so we can control
@@ -128,6 +128,115 @@ describe("lifecycle (docker mode): start/stop/restart shellouts", () => {
       throw e;
     });
     expect(() => restartAgent("foo")).toThrowError(/Failed to restart agent "foo"/);
+  });
+});
+
+// Issue #1118: ALL callers of restartAgent must produce a fresh
+// clean-shutdown marker so the next boot's reason classifier sees
+// "graceful" instead of falling through to "crash" (operator-driven
+// restarts via auth.ts, reconcile, web/api, etc. previously omitted
+// the reason argument → no marker written → next boot misclassified
+// as crash → misleading "💥 agent-crashed" card on every legitimate
+// operator action).
+describe("lifecycle (docker mode): restartAgent ALWAYS writes a clean-shutdown marker (#1118)", () => {
+  let tmpRoot: string;
+  let prevAgentsDir: string | undefined;
+
+  beforeEach(async () => {
+    const { mkdtempSync } = await import("node:fs");
+    const { tmpdir } = await import("node:os");
+    const { join: joinPath } = await import("node:path");
+    tmpRoot = mkdtempSync(joinPath(tmpdir(), "sw-restartagent-1118-"));
+    prevAgentsDir = process.env.SWITCHROOM_AGENTS_DIR;
+    process.env.SWITCHROOM_AGENTS_DIR = tmpRoot;
+  });
+
+  afterEach(async () => {
+    const { rmSync } = await import("node:fs");
+    if (prevAgentsDir === undefined) delete process.env.SWITCHROOM_AGENTS_DIR;
+    else process.env.SWITCHROOM_AGENTS_DIR = prevAgentsDir;
+    rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  it("restartAgent(name) — no reason arg — writes a 'cli: restart' marker (regression #1118)", async () => {
+    recordingStub({ "compose up": () => "" });
+    restartAgent("foo");
+    const { readFileSync, existsSync } = await import("node:fs");
+    const { join: joinPath } = await import("node:path");
+    const markerPath = joinPath(tmpRoot, "foo", "telegram", "clean-shutdown.json");
+    expect(existsSync(markerPath)).toBe(true);
+    const m = JSON.parse(readFileSync(markerPath, "utf-8")) as {
+      ts: number;
+      signal: string;
+      reason: string;
+    };
+    expect(m.reason).toBe("cli: restart");
+    expect(m.signal).toBe("SIGTERM");
+    expect(typeof m.ts).toBe("number");
+    // Marker must be FRESH at write time — the boot reason classifier
+    // uses a 60s 'graceful' window, so a marker ts older than ~now is
+    // useless. Allow 5s slack for slow CI.
+    expect(Date.now() - m.ts).toBeLessThan(5_000);
+  });
+
+  it("restartAgent(name, customReason) — reason arg honored (regression: don't clobber explicit caller reason)", async () => {
+    recordingStub({ "compose up": () => "" });
+    restartAgent("foo", "auth: token rotated");
+    const { readFileSync } = await import("node:fs");
+    const { join: joinPath } = await import("node:path");
+    const markerPath = joinPath(tmpRoot, "foo", "telegram", "clean-shutdown.json");
+    const m = JSON.parse(readFileSync(markerPath, "utf-8")) as { reason: string };
+    expect(m.reason).toBe("auth: token rotated");
+  });
+
+  it("restartAgent preserves a fresh prior marker (cooperative race: gateway-written reason wins)", async () => {
+    // Production race: in-chat /new handler writes
+    // "user: /new from chat" into the marker, then spawns a detached
+    // `switchroom agent restart` CLI. The CLI's restartAgent() call
+    // would normally write "cli: restart" — but preserveExisting:true
+    // MUST leave the user attribution in place so the greeting card
+    // shows who really triggered it.
+    const { mkdirSync, writeFileSync, readFileSync } = await import("node:fs");
+    const { join: joinPath } = await import("node:path");
+    const dir = joinPath(tmpRoot, "foo", "telegram");
+    mkdirSync(dir, { recursive: true });
+    const markerPath = joinPath(dir, "clean-shutdown.json");
+    writeFileSync(
+      markerPath,
+      JSON.stringify({
+        ts: Date.now(),
+        signal: "SIGTERM",
+        reason: "user: /new from chat",
+      }),
+    );
+
+    recordingStub({ "compose up": () => "" });
+    restartAgent("foo");
+
+    const after = JSON.parse(readFileSync(markerPath, "utf-8")) as { reason: string };
+    expect(after.reason).toBe("user: /new from chat");
+  });
+
+  it("restartAgent overwrites a stale prior marker (>30s old)", async () => {
+    const { mkdirSync, writeFileSync, readFileSync } = await import("node:fs");
+    const { join: joinPath } = await import("node:path");
+    const dir = joinPath(tmpRoot, "foo", "telegram");
+    mkdirSync(dir, { recursive: true });
+    const markerPath = joinPath(dir, "clean-shutdown.json");
+    writeFileSync(
+      markerPath,
+      JSON.stringify({
+        ts: Date.now() - 60_000,
+        signal: "SIGTERM",
+        reason: "user: ancient marker",
+      }),
+    );
+
+    recordingStub({ "compose up": () => "" });
+    restartAgent("foo");
+
+    const after = JSON.parse(readFileSync(markerPath, "utf-8")) as { reason: string };
+    expect(after.reason).toBe("cli: restart");
   });
 });
 


### PR DESCRIPTION
## Summary

Closes #1118. The crash-loop framing in the original issue was wrong — investigation showed 28 boots across ~29 hours, all legitimate operator/UAT restarts. The **real** bug visible in the logs: operator-driven restarts via `restartAgent(name)` (called bare by 7 in-tree paths — auth.ts post-token-rotation, agent.ts reconcile + grant paths, web/api.ts) don't write a clean-shutdown marker. The next boot's reason classifier (`telegram-plugin/gateway/boot-reason.ts:26-51`) reads the stale `clean-shutdown.json` still on disk from an older /restart, sees the marker is older than the 60s freshness window, falls through to `'crash'`, and posts a misleading "💥 agent-crashed" boot card on every legitimate operator action.

(The `restart-pending.json` 5-min `'planned'` window is a separate path — written only by in-chat `/restart` — and isn't what classifies the operator-CLI case.)

## Fix

`src/agents/lifecycle.ts:206-228` — move the marker write outside the `if (reason)` guard with a default `"cli: restart"` reason + `preserveExisting: true`. The preserveExisting flag keeps the cooperative-race contract intact: when the gateway /new handler writes `"user: /new from chat"` and then spawns `switchroom agent restart`, the CLI's default doesn't clobber the still-fresh user attribution (the 30s freshness window in `writeRestartReasonMarker`).

## Test plan

- [x] 4 new unit tests in `tests/lifecycle.docker.test.ts` pin the new contract — bare `restartAgent(name)`, explicit `reason` arg honored, fresh prior marker preserved, stale prior marker overwritten. **2 of 4 fail on main; all 4 pass with the fix.**
- [x] Full lifecycle test files green (42/42).
- [x] `tsc --noEmit` clean.
- [x] Full vitest run: 9 file failures match the baseline on main (all pre-existing env-dependent — uat-driver, autoaccept-bundled, boot-self-test, etc. — unrelated to this change).

## Out of scope

Operator-direct `docker compose up -d` after `switchroom apply` still doesn't write a marker. That's a separate channel; this PR closes only the in-tree CLI gap. If misclassified boot-cards persist for that path post-merge, a `switchroom mark-restart` verb would be the right shape for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)