### PR TITLE
feat(telemetry): instrument gateway runtime in PostHog + local JSONL (#1122 PR1)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -49,6 +49,7 @@
         "@secretlint/types": "^12.2.0",
         "@xterm/headless": "^6.0.0",
         "grammy": "^1.21.0",
+        "posthog-node": "^5.29.2",
       },
     },
   },

--- a/docs/posthog.md
+++ b/docs/posthog.md
@@ -44,7 +44,13 @@ to merge the anonymous ID into the real one. We don't do that today.
 
 ## Event catalogue
 
-Event names use `snake_case` verbs — `<noun>_<past_tense_verb>`.
+Event names use `snake_case` verbs — `<noun>_<past_tense_verb>`. Every event
+emitted from the in-container gateway auto-stamps `source: "gateway"` (CLI
+events are unmarked, equivalent to `source: "cli"`), so dashboards can slice
+by surface without each call-site repeating the property. Gateway events
+also auto-stamp `agent` (the agent name) and `switchroom_version`.
+
+### CLI events
 
 | Event                   | Source                          | Key properties                                     |
 |-------------------------|---------------------------------|----------------------------------------------------|
@@ -56,6 +62,41 @@ Event names use `snake_case` verbs — `<noun>_<past_tense_verb>`.
 | `agent_stopped`         | [src/web/api.ts](../src/web/api.ts)                      | `agent`, `source`                                  |
 | `agent_restarted`       | [src/web/api.ts](../src/web/api.ts)                      | `agent`, `source`                                  |
 | `integration_verified`  | [scripts/posthog-smoke-test.mjs](../scripts/posthog-smoke-test.mjs) | smoke-test only                        |
+
+### Gateway / runtime events (#1122)
+
+These power the **Switchroom Runtime** dashboard and the
+conversational-turn-UX KPIs (see `reference/know-what-my-agent-is-doing.md`).
+Emitted from inside each agent container by the telegram-plugin gateway.
+
+| Event                    | Source                                                                                  | Key properties                                                                                                              |
+|--------------------------|-----------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------|
+| `inbound_status_query`   | [telegram-plugin/inbound-classifier.ts](../telegram-plugin/inbound-classifier.ts)        | `chat_id`, `message_id`, `thread_id`, `text_length`, `prior_turn_in_flight`, `seconds_since_turn_start`                     |
+| `turn_started`           | [telegram-plugin/gateway/gateway.ts](../telegram-plugin/gateway/gateway.ts) (fresh-turn) | `chat_id`, `message_id`, `thread_id`, `inbound_classified_as_status_query`                                                  |
+| `turn_ended`             | [telegram-plugin/gateway/gateway.ts](../telegram-plugin/gateway/gateway.ts) (turn_end)   | `chat_id`, `thread_id`, `duration_ms`, `ttfo_ms`, `outbound_count`, `longest_silent_gap_ms`, `ended_via`                    |
+
+**Local JSONL mirror.** Every gateway event is ALSO appended to
+`/state/agent/runtime-metrics.jsonl` inside the agent container (one JSON
+line per event, with a `ts` epoch-ms stamp). This is the local-debug
+side-channel — operators can `tail -f` it or an agent can read its own
+past behaviour without round-tripping to PostHog. Disabled via
+`SWITCHROOM_RUNTIME_METRICS_JSONL_DISABLED=1` if disk pressure is a
+concern; PostHog continues to receive events.
+
+**Distinct ID flow.** `~/.switchroom/analytics-id` on the host is read by
+`src/agents/compose.ts` and baked into each agent container as
+`SWITCHROOM_ANALYTICS_ID`. The gateway uses that as the PostHog distinctId,
+so a user's CLI + every runtime turn merge under the same identity. The
+fallback (file missing) is a per-agent UUID at
+`/state/agent/analytics-id`.
+
+### KPIs powered by gateway events
+
+| KPI                              | Source events                          | Definition                                                                                       |
+|----------------------------------|----------------------------------------|--------------------------------------------------------------------------------------------------|
+| Status-query rate (lagging)      | `inbound_status_query`                 | Count of status-query inbound / count of all inbound. Target <0.5%.                              |
+| Outbound silence p95 (leading)   | `turn_ended.longest_silent_gap_ms`     | p95 of `longest_silent_gap_ms` across `turn_ended` events with `duration_ms > 30000`. Target <120s. |
+| TTFO p95                         | `turn_ended.ttfo_ms`                   | p95 of `ttfo_ms` across `turn_ended` events with `outbound_count > 0`. Target <30s.              |
 
 ### Adding a new event
 
@@ -85,6 +126,10 @@ Current boundaries:
 - `src/cli/setup.ts` — setup wizard catch-all (`action: "setup"`)
 - `src/cli/init.ts` — init catch-all (`action: "init"`)
 - `src/web/api.ts` — agent start/stop/restart handlers
+- `telegram-plugin/gateway/gateway.ts` — gateway top-level (`source: "gateway"`,
+  installed via `analytics-posthog.installGlobalErrorHandlers()`). Uncaught
+  exceptions and unhandled rejections inside the long-lived gateway land in
+  the same Switchroom Errors dashboard as CLI errors.
 
 ### Adding a new boundary
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "switchroom",
-  "version": "0.7.14",
+  "version": "0.7.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "switchroom",
-      "version": "0.7.14",
+      "version": "0.7.16",
       "license": "MIT",
       "workspaces": [
         "telegram-plugin"
@@ -5825,7 +5825,8 @@
         "@secretlint/secretlint-rule-preset-recommend": "^12.2.0",
         "@secretlint/types": "^12.2.0",
         "@xterm/headless": "^6.0.0",
-        "grammy": "^1.21.0"
+        "grammy": "^1.21.0",
+        "posthog-node": "^5.29.2"
       },
       "bin": {
         "switchroom-telegram-gateway": "dist/gateway/gateway.js",

--- a/scripts/check-bot-api-wrapping.sh
+++ b/scripts/check-bot-api-wrapping.sh
@@ -67,30 +67,33 @@ ALLOWLIST=(
   "telegram-plugin/auto-fallback-dispatcher.ts:1-9999:DM ownerChatId; no thread_id"
 
   # "Paired!" sendMessage to senderId (always a DM, bare). No thread_id.
-  "telegram-plugin/gateway/gateway.ts:975-990:Paired! sendMessage to DM senderId; no thread_id"
+  # Range bumped 2026-05 for #1122 PR1 telemetry insertions that shifted
+  # lines down. Use generous windows so further small shifts don't
+  # cascade through this allowlist.
+  "telegram-plugin/gateway/gateway.ts:990-1020:Paired! sendMessage to DM senderId; no thread_id"
 
   # operator-event broadcast. The loop's `opts` is built without
   # `message_thread_id` (parse_mode + reply_markup only).
-  "telegram-plugin/gateway/gateway.ts:2200-2215:operator-event broadcast; no thread_id in opts"
+  "telegram-plugin/gateway/gateway.ts:2215-2245:operator-event broadcast; no thread_id in opts"
 
   # permission-request keyboard send. opts only has reply_markup. No thread_id.
-  "telegram-plugin/gateway/gateway.ts:2580-2595:permission-request keyboard; no thread_id"
+  "telegram-plugin/gateway/gateway.ts:2595-2625:permission-request keyboard; no thread_id"
 
   # reply chunk-loop fallback after robustApiCall threw THREAD_NOT_FOUND.
   # The caller dropped the thread; this raw sendMessage retries on the
   # main chat. Wrapping would re-enter the THREAD_NOT_FOUND throw on a
   # phantom second deletion.
-  "telegram-plugin/gateway/gateway.ts:3035-3050:reply chunk-loop THREAD_NOT_FOUND fallback (intentional raw)"
+  "telegram-plugin/gateway/gateway.ts:3050-3080:reply chunk-loop THREAD_NOT_FOUND fallback (intentional raw)"
 
   # credit-watch notification. No thread_id (DM).
-  "telegram-plugin/gateway/gateway.ts:7900-7915:credit-watch notify; no thread_id"
+  "telegram-plugin/gateway/gateway.ts:7990-8020:credit-watch notify; no thread_id"
 
-  # gateway.ts:9000-9130 — ctx.api.editMessageText for vault grant wizard
+  # gateway.ts:9260-9400 — ctx.api.editMessageText for vault grant wizard
   # cards. Every callsite has `.catch(() => {})` — a THREAD_NOT_FOUND
   # is already swallowed there. Acceptable because the wizard messages
   # are tap-driven UI and a missed edit just leaves the previous state
   # visible (the user can re-tap).
-  "telegram-plugin/gateway/gateway.ts:9165-9300:vault grant wizard ctx.api.editMessageText already has .catch swallow"
+  "telegram-plugin/gateway/gateway.ts:9260-9400:vault grant wizard ctx.api.editMessageText already has .catch swallow"
 
   # boot-card.ts and issues-card.ts: these MODULES receive a bot adapter
   # via DI. The gateway wires those adapters through robustApiCall (see

--- a/src/agents/compose.ts
+++ b/src/agents/compose.ts
@@ -24,7 +24,8 @@
  */
 
 import { createHash } from "node:crypto";
-import { existsSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
 import type { SwitchroomConfig, AgentConfig } from "../config/schema.js";
 import { resolveAgentConfig } from "../config/merge.js";
 import { isReservedAgentName } from "../vault/broker/peercred.js";
@@ -335,6 +336,36 @@ export function generateCompose(opts: ComposeGeneratorOptions): string {
   // home. Falls back to process.env.HOME when no homeDir is passed.
   const hostHomeForChecks = opts.homeDir ?? process.env.HOME ?? "";
   const switchroomConfigPath = opts.switchroomConfigPath;
+
+  // Resolve the host's analytics distinct ID once per generator call. The
+  // CLI persists this at ~/.switchroom/analytics-id (see
+  // src/analytics/posthog.ts:getDistinctId). Threading it through to the
+  // agent container means runtime events merge with the same user's CLI
+  // events in PostHog (same distinctId, different `source` property).
+  //
+  // If the file doesn't exist (fresh install before any CLI invocation
+  // wrote it), we skip emitting the env var — the gateway's
+  // analytics-posthog.ts falls back to a per-agent UUID at
+  // /state/agent/analytics-id. Determinism: if the file is present, its
+  // contents are stable across runs by design.
+  let resolvedAnalyticsId: string | null = null;
+  if (hostHomeForChecks !== "") {
+    const idPath = join(hostHomeForChecks, ".switchroom", "analytics-id");
+    if (existsSync(idPath)) {
+      try {
+        const raw = readFileSync(idPath, "utf-8").trim();
+        if (raw !== "") resolvedAnalyticsId = raw;
+      } catch {
+        // Non-fatal — gateway will fall back.
+      }
+    }
+  }
+  // Operator opt-out — surfaced from the host env so a single
+  // SWITCHROOM_TELEMETRY_DISABLED=1 in the operator's shell propagates
+  // fleet-wide.
+  const telemetryDisabled = process.env.SWITCHROOM_TELEMETRY_DISABLED;
+  const posthogKeyOverride = process.env.SWITCHROOM_POSTHOG_KEY;
+  const posthogHostOverride = process.env.SWITCHROOM_POSTHOG_HOST;
   if (buildMode === "local" && !buildContext) {
     throw new Error(
       `compose: buildMode="local" requires buildContext (the absolute path to the switchroom checkout)`,
@@ -595,7 +626,23 @@ export function generateCompose(opts: ComposeGeneratorOptions): string {
     if (a.strippedCaps.length > 0) {
       warn(`compose: stripping cap_add ${JSON.stringify(a.strippedCaps)} from agent "${a.name}" (Docker mode forbids capability extras; see RFC §security)`);
     }
-    emitAgentService(lines, a, imageTag, buildMode, buildContext, homePrefix, hostHomeForChecks, switchroomConfigPath, containerNamePrefix);
+    emitAgentService(
+      lines,
+      a,
+      imageTag,
+      buildMode,
+      buildContext,
+      homePrefix,
+      hostHomeForChecks,
+      switchroomConfigPath,
+      containerNamePrefix,
+      {
+        analyticsId: resolvedAnalyticsId,
+        telemetryDisabled,
+        posthogKeyOverride,
+        posthogHostOverride,
+      },
+    );
   }
 
   // ── volumes ────────────────────────────────────────────────────────
@@ -609,6 +656,20 @@ export function generateCompose(opts: ComposeGeneratorOptions): string {
   return lines.join("\n");
 }
 
+interface PosthogRuntimeEnv {
+  /** Host-resolved distinct ID from ~/.switchroom/analytics-id, or null
+   *  if the file is missing/empty — gateway falls back to a per-agent UUID. */
+  analyticsId: string | null;
+  /** Verbatim value of process.env.SWITCHROOM_TELEMETRY_DISABLED on the
+   *  host. Normalised to "1" before emission so the gateway's truthy check
+   *  doesn't depend on operator casing. */
+  telemetryDisabled: string | undefined;
+  /** Optional PostHog key override (host env). */
+  posthogKeyOverride: string | undefined;
+  /** Optional PostHog host override (host env). */
+  posthogHostOverride: string | undefined;
+}
+
 function emitAgentService(
   lines: string[],
   a: AgentServiceData,
@@ -619,6 +680,7 @@ function emitAgentService(
   hostHomeForChecks: string,
   switchroomConfigPath: string | undefined,
   containerNamePrefix: string,
+  posthog: PosthogRuntimeEnv,
 ): void {
   lines.push(`  agent-${a.name}:`);
   emitImageOrBuild(lines, "agent", imageTag, buildMode, buildContext);
@@ -747,6 +809,24 @@ function emitAgentService(
     SWITCHROOM_KERNEL_SOCKET: `/run/switchroom/kernel/sock`,
     SWITCHROOM_RUNTIME: "docker",
   };
+  // PostHog runtime telemetry — opt-out honoured, distinct-ID propagated
+  // from the host CLI so CLI + runtime events merge under the same user.
+  // See docs/posthog.md (Switchroom Runtime dashboard section).
+  if (posthog.analyticsId != null) {
+    env.SWITCHROOM_ANALYTICS_ID = posthog.analyticsId;
+  }
+  if (
+    posthog.telemetryDisabled === "1"
+    || posthog.telemetryDisabled === "true"
+  ) {
+    env.SWITCHROOM_TELEMETRY_DISABLED = "1";
+  }
+  if (posthog.posthogKeyOverride && posthog.posthogKeyOverride !== "") {
+    env.SWITCHROOM_POSTHOG_KEY = posthog.posthogKeyOverride;
+  }
+  if (posthog.posthogHostOverride && posthog.posthogHostOverride !== "") {
+    env.SWITCHROOM_POSTHOG_HOST = posthog.posthogHostOverride;
+  }
   // SWITCHROOM_CONFIG: the in-container telegram-plugin gateway daemon
   // (forked as a sidecar by start.sh's docker preamble) shells out to
   // the switchroom CLI for handoff / vault / topic operations and

--- a/telegram-plugin/analytics-posthog.ts
+++ b/telegram-plugin/analytics-posthog.ts
@@ -1,0 +1,191 @@
+/**
+ * analytics-posthog.ts — gateway-side PostHog client.
+ *
+ * Mirrors `src/analytics/posthog.ts` (the CLI's client) but sized for a
+ * long-lived gateway process: default batching instead of immediate-flush.
+ * Honours the same env vars (SWITCHROOM_POSTHOG_KEY, SWITCHROOM_POSTHOG_HOST,
+ * SWITCHROOM_TELEMETRY_DISABLED) so an operator opt-out applies fleet-wide.
+ *
+ * Distinct ID lineage:
+ *   1. SWITCHROOM_ANALYTICS_ID env var — set by compose.ts from the host's
+ *      ~/.switchroom/analytics-id so per-agent runtime events merge with
+ *      the same user's CLI events in PostHog.
+ *   2. Per-agent fallback UUID at /state/agent/analytics-id when the env
+ *      var is missing (e.g. legacy compose). Persists across restarts.
+ *
+ * Every event auto-stamps `agent` and `switchroom_version` so dashboards
+ * can slice by agent without each call-site repeating the property.
+ */
+
+import { PostHog } from 'posthog-node'
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { randomUUID } from 'node:crypto'
+
+const DEFAULT_KEY = 'phc_qKY87cKWZm6ZyCtk7LcRd2cU8Sg42u7Ywhui5stYCegd'
+const DEFAULT_HOST = 'https://us.i.posthog.com'
+
+let client: PostHog | null = null
+let initialized = false
+let cachedDistinctId: string | null = null
+let globalHandlersInstalled = false
+
+function telemetryDisabled(): boolean {
+  const v = process.env.SWITCHROOM_TELEMETRY_DISABLED
+  return v === '1' || v === 'true'
+}
+
+function agentName(): string {
+  return process.env.SWITCHROOM_AGENT_NAME ?? 'unknown'
+}
+
+function switchroomVersion(): string {
+  return process.env.SWITCHROOM_VERSION ?? 'unknown'
+}
+
+export function getDistinctId(): string {
+  if (cachedDistinctId) return cachedDistinctId
+  const envId = process.env.SWITCHROOM_ANALYTICS_ID
+  if (envId && envId.trim() !== '') {
+    cachedDistinctId = envId.trim()
+    return cachedDistinctId
+  }
+  const fallbackPath = join(
+    process.env.SWITCHROOM_RUNTIME_STATE_DIR ?? '/state/agent',
+    'analytics-id',
+  )
+  try {
+    if (existsSync(fallbackPath)) {
+      const existing = readFileSync(fallbackPath, 'utf-8').trim()
+      if (existing) {
+        cachedDistinctId = existing
+        return existing
+      }
+    }
+  } catch {
+    // fall through to fresh uuid
+  }
+  const id = randomUUID()
+  cachedDistinctId = id
+  try {
+    mkdirSync(dirname(fallbackPath), { recursive: true })
+    writeFileSync(fallbackPath, id, 'utf-8')
+  } catch {
+    // non-fatal — fresh uuid next boot is acceptable
+  }
+  return id
+}
+
+export function getPostHog(): PostHog | null {
+  if (initialized) return client
+  initialized = true
+  if (telemetryDisabled()) return null
+  const apiKey = process.env.SWITCHROOM_POSTHOG_KEY ?? DEFAULT_KEY
+  const host = process.env.SWITCHROOM_POSTHOG_HOST ?? DEFAULT_HOST
+  if (!apiKey) return null
+  try {
+    client = new PostHog(apiKey, {
+      host,
+      // Long-lived gateway: rely on default batching instead of the
+      // immediate-flush the short-lived CLI uses.
+      enableExceptionAutocapture: false,
+      // IP is considered PII in our telemetry policy (see docs/posthog.md).
+      disableGeoip: true,
+    })
+  } catch {
+    client = null
+  }
+  return client
+}
+
+export async function captureEvent(
+  event: string,
+  properties: Record<string, unknown> = {},
+): Promise<void> {
+  const ph = getPostHog()
+  if (!ph) return
+  try {
+    ph.capture({
+      distinctId: getDistinctId(),
+      event,
+      properties: {
+        agent: agentName(),
+        switchroom_version: switchroomVersion(),
+        source: 'gateway',
+        ...properties,
+      },
+    })
+  } catch {
+    // Telemetry must never break the gateway.
+  }
+}
+
+export async function captureException(
+  error: unknown,
+  properties: Record<string, unknown> = {},
+): Promise<void> {
+  const ph = getPostHog()
+  if (!ph) return
+  try {
+    await ph.captureException(error, getDistinctId(), {
+      agent: agentName(),
+      switchroom_version: switchroomVersion(),
+      source: 'gateway',
+      ...properties,
+    })
+  } catch {
+    // Telemetry must never break the gateway.
+  }
+}
+
+export async function shutdownAnalytics(): Promise<void> {
+  if (!client) return
+  try {
+    await client.shutdown(2000)
+  } catch {
+    // ignore
+  }
+}
+
+/**
+ * Install process-level handlers for uncaught exceptions and unhandled
+ * rejections so they're reported to PostHog before the process dies.
+ *
+ * Mirrors the CLI's `installGlobalErrorHandlers()` so runtime errors land
+ * in the same Switchroom Errors dashboard as CLI errors, tagged
+ * `source: 'gateway'`.
+ *
+ * The gateway already exits non-zero on fatal errors (see the polling
+ * IIFE at the bottom of gateway.ts). We DO NOT re-exit here for
+ * unhandledRejection — Node's default is to keep running and we want
+ * the gateway to keep polling. For uncaughtException we DO exit, because
+ * Node's default-since-v15 is to exit anyway after listeners return.
+ */
+export function installGlobalErrorHandlers(): void {
+  if (globalHandlersInstalled) return
+  globalHandlersInstalled = true
+
+  const FLUSH_TIMEOUT_MS = 2000
+
+  const flushWithTimeout = async (
+    error: unknown,
+    kind: 'uncaughtException' | 'unhandledRejection',
+  ): Promise<void> => {
+    await Promise.race([
+      captureException(error, { kind }),
+      new Promise<void>((resolve) => setTimeout(resolve, FLUSH_TIMEOUT_MS)),
+    ])
+  }
+
+  process.on('uncaughtException', (err) => {
+    process.stderr.write(`telegram gateway: uncaughtException: ${err}\n`)
+    void flushWithTimeout(err, 'uncaughtException').finally(() => {
+      process.exit(1)
+    })
+  })
+
+  process.on('unhandledRejection', (reason) => {
+    process.stderr.write(`telegram gateway: unhandledRejection: ${reason}\n`)
+    void flushWithTimeout(reason, 'unhandledRejection')
+  })
+}

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -69,6 +69,12 @@ import { createPinManager } from '../progress-card-pin-manager.js'
 import { createPinWatchdog } from '../progress-card-pin-watchdog.js'
 import { logStreamingEvent } from '../streaming-metrics.js'
 import * as signalTracker from '../turn-signal-tracker.js'
+import {
+  installGlobalErrorHandlers as installPosthogErrorHandlers,
+  shutdownAnalytics,
+} from '../analytics-posthog.js'
+import { emitRuntimeMetric } from '../runtime-metrics.js'
+import { classifyInbound } from '../inbound-classifier.js'
 import { createAnswerStream, type AnswerStreamHandle } from '../answer-stream.js'
 import { type SessionEvent } from '../session-tail.js'
 import {
@@ -338,6 +344,20 @@ import { resolveCallingSubagent } from './resolve-calling-subagent.js'
 
 // ─── Stderr logging ───────────────────────────────────────────────────────
 installPluginLogger()
+
+// ─── Telemetry ────────────────────────────────────────────────────────────
+// Catch uncaught exceptions + unhandled rejections and forward them to
+// PostHog Error Tracking before the process dies. Mirrors the CLI's
+// install (src/cli/index.ts), so gateway + CLI errors land in the same
+// dashboard tagged `source: 'gateway'` vs `source: 'cli'`.
+installPosthogErrorHandlers()
+// Flush analytics on graceful shutdown so the last batch isn't lost.
+// The signal handlers themselves remain owned by other modules — we
+// piggyback by emitting a `beforeExit` listener which fires after
+// SIGTERM/SIGINT have run their handlers and the event loop is empty.
+process.on('beforeExit', () => {
+  void shutdownAnalytics()
+})
 
 // ─── Env + state dir ──────────────────────────────────────────────────────
 const STATE_DIR = process.env.TELEGRAM_STATE_DIR ?? join(homedir(), '.claude', 'channels', 'telegram')
@@ -2973,6 +2993,9 @@ async function executeReply(args: Record<string, unknown>): Promise<{ content: A
     replacedPreview: previewMessageId != null,
     previewMessageId,
   })
+  // #1122 KPI: a `reply` always produces a fresh user-visible outbound
+  // message — count it for the outbound-gap / TTFO KPI.
+  signalTracker.noteOutbound(statusKey(chat_id, threadId), Date.now())
 
   if (previewMessageId != null && reply_to != null && replyMode !== 'off') {
     await deleteStalePreview(previewMessageId)
@@ -3248,6 +3271,17 @@ async function executeStreamReply(args: Record<string, unknown>): Promise<unknow
     }
     streamButtonMeta = extractAgentButtonMeta(rawStreamKeyboard)
     streamReplyMarkup = { inline_keyboard: wrapAgentCallbacks(rawStreamKeyboard) }
+  }
+
+  // #1122 KPI: stream_reply's FIRST emit is a fresh user-visible outbound
+  // message (subsequent calls edit the same message — no device ping).
+  // Snapshot state BEFORE handleStreamReply to detect first-emit precisely.
+  {
+    const streamThreadId = args.message_thread_id != null ? Number(args.message_thread_id) : undefined
+    const sKeyBefore = streamKey(streamChatId, streamThreadId)
+    if (!activeDraftStreams.has(sKeyBefore)) {
+      signalTracker.noteOutbound(statusKey(streamChatId, streamThreadId), Date.now())
+    }
   }
 
   const result = await handleStreamReply(
@@ -4777,6 +4811,19 @@ function handleSessionEvent(ev: SessionEvent): void {
           const tKey = statusKey(chatId, threadId)
           signalTracker.noteSignal(tKey, Date.now())
           logStreamingEvent({ kind: 'turn_signal_gap', chatId, longestGapMs: signalTracker.getLongestGap(tKey), turnDurationMs })
+          // #1122 KPI: emit turn_ended (silent-marker path) with TTFO +
+          // outbound-gap metrics for the conversational-pacing dashboard.
+          const outboundMetrics = signalTracker.getOutboundMetrics(tKey)
+          emitRuntimeMetric({
+            kind: 'turn_ended',
+            chat_id: chatId,
+            thread_id: threadId ?? null,
+            duration_ms: turnDurationMs,
+            ttfo_ms: outboundMetrics.ttfoMs,
+            outbound_count: outboundMetrics.outboundCount,
+            longest_silent_gap_ms: outboundMetrics.longestOutboundGapMs,
+            ended_via: 'silent',
+          })
           signalTracker.clear(tKey)
         }
         lastPtyPreviewByChat.delete(statusKey(chatId, threadId))
@@ -5002,6 +5049,20 @@ function handleSessionEvent(ev: SessionEvent): void {
         const tKey = statusKey(chatId, threadId)
         signalTracker.noteSignal(tKey, Date.now())
         logStreamingEvent({ kind: 'turn_signal_gap', chatId, longestGapMs: signalTracker.getLongestGap(tKey), turnDurationMs })
+        // #1122 KPI: emit turn_ended with TTFO + outbound-gap metrics so
+        // the dashboard can compute outbound silence p95 and TTFO p95
+        // without per-event reconstruction.
+        const outboundMetrics = signalTracker.getOutboundMetrics(tKey)
+        emitRuntimeMetric({
+          kind: 'turn_ended',
+          chat_id: chatId,
+          thread_id: threadId ?? null,
+          duration_ms: turnDurationMs,
+          ttfo_ms: outboundMetrics.ttfoMs,
+          outbound_count: outboundMetrics.outboundCount,
+          longest_silent_gap_ms: outboundMetrics.longestOutboundGapMs,
+          ended_via: outboundMetrics.outboundCount > 0 ? 'reply' : 'silent',
+        })
         signalTracker.clear(tKey)
       }
       lastPtyPreviewByChat.delete(statusKey(chatId, threadId))
@@ -5379,6 +5440,33 @@ async function handleInbound(
   const msgId = ctx.message?.message_id
 
   if (messageThreadId != null) chatThreadMap.set(chat_id, messageThreadId)
+
+  // #1122 KPI: classify "are you still working / status?" pings as the
+  // primary lagging KPI of the conversational-turn-UX redesign. Every fire
+  // means the design failed to make the user feel heard. Read-only —
+  // never alters routing; the text still reaches the agent.
+  try {
+    const classification = classifyInbound(text)
+    if (classification.isStatusQuery) {
+      const priorKey = statusKey(chat_id, messageThreadId)
+      const priorTurnStartedAt = activeTurnStartedAt.get(priorKey)
+      const priorTurnInFlight = activeStatusReactions.get(priorKey) != null
+      emitRuntimeMetric({
+        kind: 'inbound_status_query',
+        chat_id,
+        message_id: msgId ?? null,
+        thread_id: messageThreadId ?? null,
+        text_length: text.length,
+        prior_turn_in_flight: priorTurnInFlight,
+        seconds_since_turn_start: priorTurnStartedAt != null
+          ? Math.round((inboundReceivedAt - priorTurnStartedAt) / 1000)
+          : null,
+      })
+    }
+  } catch (err) {
+    // Classifier is fire-and-forget — never break inbound on a metric error.
+    process.stderr.write(`telegram gateway: inbound classifier error: ${(err as Error).message}\n`)
+  }
 
   // `!`-prefix interrupt (#575). Closes
   // `reference/steer-or-queue-mid-flight.md`'s correction path.
@@ -6000,6 +6088,15 @@ async function handleInbound(
         logStreamingEvent({ kind: 'inbound_ack', chatId: chat_id, messageId: msgId, ackDelayMs: Date.now() - inboundReceivedAt })
         // #203: signal tracker — start tracking silent gaps for this fresh turn.
         signalTracker.reset(statusKey(chat_id, messageThreadId), Date.now())
+        // #1122 KPI: emit turn_started so dashboards can compute funnel
+        // start counts + correlate to turn_ended for duration / TTFO.
+        emitRuntimeMetric({
+          kind: 'turn_started',
+          chat_id,
+          message_id: msgId,
+          thread_id: messageThreadId ?? null,
+          inbound_classified_as_status_query: classifyInbound(text).isStatusQuery,
+        })
         const agentDir = resolveAgentDirFromEnv()
         if (agentDir != null) {
           addActiveReaction(agentDir, { chatId: chat_id, messageId: msgId, threadId: messageThreadId ?? null, reactedAt: Date.now() })

--- a/telegram-plugin/inbound-classifier.ts
+++ b/telegram-plugin/inbound-classifier.ts
@@ -1,0 +1,50 @@
+/**
+ * inbound-classifier.ts — cheap regex classifier for inbound user text.
+ *
+ * Today the only signal we emit is `status_query` — short user messages
+ * asking "are you still working / are you there / status?" — because that's
+ * the primary KPI for the conversational turn UX redesign (see issue #1122):
+ * if the user has to ask, the design has failed.
+ *
+ * Strictly read-only: the classifier never alters routing. Inbound text
+ * still reaches the agent unchanged.
+ */
+
+/**
+ * Patterns that mean "are you still working / do you remember me." Kept
+ * conservative on purpose — false positives are worse than misses, because
+ * a wrong-positive would noise up the very KPI we're trying to measure.
+ *
+ * All patterns match the entire trimmed message body (anchored), so longer
+ * messages that happen to contain "status" don't trip them.
+ */
+const STATUS_QUERY_PATTERNS: readonly RegExp[] = [
+  /^\?+$/,
+  /^status\s*\??$/i,
+  /^update\s*\??$/i,
+  /^any\s+update\s*\??$/i,
+  /^still\s+there\s*\??$/i,
+  /^still\s+working\s*\??$/i,
+  /^are\s+you\s+there\s*\??$/i,
+  /^you\s+there\s*\??$/i,
+  /^hello\s*\?+$/i,
+  /^hey\s*\?+$/i,
+]
+
+export interface InboundClassification {
+  isStatusQuery: boolean
+}
+
+export function classifyInbound(text: string | null | undefined): InboundClassification {
+  if (text == null) return { isStatusQuery: false }
+  const trimmed = text.trim()
+  if (trimmed === '') return { isStatusQuery: false }
+  // Cap length — a long message that starts with "status?" isn't a status
+  // query; the user's appending real content. Keep the classifier focused
+  // on standalone "ping" messages.
+  if (trimmed.length > 40) return { isStatusQuery: false }
+  for (const pat of STATUS_QUERY_PATTERNS) {
+    if (pat.test(trimmed)) return { isStatusQuery: true }
+  }
+  return { isStatusQuery: false }
+}

--- a/telegram-plugin/package.json
+++ b/telegram-plugin/package.json
@@ -32,7 +32,8 @@
     "@secretlint/secretlint-rule-preset-recommend": "^12.2.0",
     "@secretlint/types": "^12.2.0",
     "@xterm/headless": "^6.0.0",
-    "grammy": "^1.21.0"
+    "grammy": "^1.21.0",
+    "posthog-node": "^5.29.2"
   },
   "engines": {
     "node": ">=20.11.0"

--- a/telegram-plugin/runtime-metrics.ts
+++ b/telegram-plugin/runtime-metrics.ts
@@ -1,0 +1,140 @@
+/**
+ * runtime-metrics.ts — high-value gateway events fanned out to PostHog
+ * AND a local JSONL file.
+ *
+ * Why both sinks:
+ *  - PostHog gets the events for dashboards, funnels, error correlation,
+ *    fleet-wide KPI tracking. This is the source of truth for the
+ *    conversational-turn-UX redesign KPIs (see docs/posthog.md).
+ *  - JSONL is preserved as a per-agent debug breadcrumb so the agent's
+ *    own context (or an operator on the host) can read what happened
+ *    without round-tripping to PostHog. Same file the silence-poke
+ *    subsystem (next PR) will append to.
+ *
+ * Distinct from `streaming-metrics.ts` — that module is the noisy
+ * gated-by-env stderr stream used for one-off streaming-perf analysis.
+ * Runtime metrics are always-on, narrow, and KPI-shaped.
+ */
+
+import { existsSync, mkdirSync, appendFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { captureEvent } from './analytics-posthog.js'
+
+export type RuntimeMetricEvent =
+  /**
+   * A user-sent message that matches a status-query pattern
+   * ("status?", "still there?", etc). Primary lagging KPI for the
+   * conversational turn UX — every fire is a JTBD failure.
+   */
+  | {
+      kind: 'inbound_status_query'
+      chat_id: string
+      message_id: number | null
+      thread_id: number | null
+      text_length: number
+      prior_turn_in_flight: boolean
+      seconds_since_turn_start: number | null
+    }
+  /**
+   * A fresh turn began (user message arrived, ack reaction fired).
+   * Pairs with `turn_ended` for duration / TTFO computation.
+   */
+  | {
+      kind: 'turn_started'
+      chat_id: string
+      message_id: number | null
+      thread_id: number | null
+      inbound_classified_as_status_query: boolean
+    }
+  /**
+   * A turn completed (terminal reply or silent close). Carries the
+   * gap distribution + TTFO so the dashboard can compute outbound
+   * silence p95 without per-event reconstruction.
+   */
+  | {
+      kind: 'turn_ended'
+      chat_id: string
+      thread_id: number | null
+      duration_ms: number
+      ttfo_ms: number | null
+      outbound_count: number
+      longest_silent_gap_ms: number
+      ended_via: 'reply' | 'stream_reply_done' | 'silent' | 'forced'
+    }
+
+/**
+ * The JSONL sink lives under the runtime state dir so it's per-agent
+ * and survives container restarts (the dir is bind-mounted from the
+ * host). Path can be overridden for tests via SWITCHROOM_RUNTIME_METRICS_PATH.
+ */
+function resolveJsonlPath(): string {
+  const override = process.env.SWITCHROOM_RUNTIME_METRICS_PATH
+  if (override && override.trim() !== '') return override.trim()
+  const base = process.env.SWITCHROOM_RUNTIME_STATE_DIR ?? '/state/agent'
+  return join(base, 'runtime-metrics.jsonl')
+}
+
+function appendJsonl(line: string): void {
+  const path = resolveJsonlPath()
+  try {
+    mkdirSync(dirname(path), { recursive: true })
+    appendFileSync(path, line + '\n', 'utf-8')
+  } catch (err) {
+    // JSONL is a local debug aid; failing to write must not break
+    // the gateway. Surface to stderr so it's at least visible in
+    // the plugin log.
+    process.stderr.write(`runtime-metrics: jsonl write failed: ${(err as Error).message}\n`)
+  }
+}
+
+/**
+ * Whether to write JSONL at all. Defaults to ON (the user asked for it
+ * to stay as a local debugging side-channel). Operator can opt-out with
+ * SWITCHROOM_RUNTIME_METRICS_JSONL_DISABLED=1 if disk pressure is a
+ * concern.
+ */
+function jsonlEnabled(): boolean {
+  const v = process.env.SWITCHROOM_RUNTIME_METRICS_JSONL_DISABLED
+  return !(v === '1' || v === 'true')
+}
+
+/**
+ * Emit one runtime metric event. Fans out to:
+ *   1. JSONL file (unless disabled)
+ *   2. PostHog (unless SWITCHROOM_TELEMETRY_DISABLED=1)
+ *
+ * Never throws. Each sink fails independently — a broken sink does not
+ * block the other.
+ */
+export function emitRuntimeMetric(event: RuntimeMetricEvent): void {
+  const wrapped = { ts: Date.now(), ...event }
+  if (jsonlEnabled()) {
+    try {
+      appendJsonl(JSON.stringify(wrapped))
+    } catch {
+      // already guarded inside appendJsonl
+    }
+  }
+  // captureEvent is async + internally guarded; void-fire to avoid blocking
+  // the caller. PostHog batches, so this is cheap.
+  void captureEvent(event.kind, { ...event, ts: wrapped.ts })
+}
+
+/** Exposed for tests — pin the JSONL path to a temp file. */
+export function __setRuntimeMetricsPathForTests(path: string | null): void {
+  if (path == null) {
+    delete process.env.SWITCHROOM_RUNTIME_METRICS_PATH
+  } else {
+    process.env.SWITCHROOM_RUNTIME_METRICS_PATH = path
+  }
+}
+
+/** Exposed for tests — read back the current resolved path. */
+export function __getRuntimeMetricsPathForTests(): string {
+  return resolveJsonlPath()
+}
+
+/** Exposed for tests — JSONL gate helper. */
+export function __isJsonlEnabledForTests(): boolean {
+  return jsonlEnabled()
+}

--- a/telegram-plugin/tests/inbound-classifier.test.ts
+++ b/telegram-plugin/tests/inbound-classifier.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest'
+import { classifyInbound } from '../inbound-classifier.js'
+
+describe('inbound-classifier — status query', () => {
+  describe('positive matches (status_query=true)', () => {
+    const positives = [
+      '?',
+      '??',
+      '???',
+      'status',
+      'Status',
+      'STATUS',
+      'status?',
+      'status ?',
+      'update',
+      'update?',
+      'any update',
+      'any update?',
+      'still there',
+      'still there?',
+      'Still There?',
+      'still working',
+      'still working?',
+      'are you there',
+      'are you there?',
+      'you there',
+      'you there?',
+      'hello?',
+      'Hello??',
+      'hey?',
+      // surrounding whitespace
+      '  status?  ',
+      '\nstill there?\n',
+    ]
+    for (const text of positives) {
+      it(`matches: ${JSON.stringify(text)}`, () => {
+        expect(classifyInbound(text).isStatusQuery).toBe(true)
+      })
+    }
+  })
+
+  describe('negative matches (status_query=false)', () => {
+    const negatives = [
+      '',
+      '   ',
+      'hello',
+      'hi',
+      'what is the status of the deploy',
+      'status of the deploy?',
+      'are you there with the report',
+      'what update did you see',
+      'i need an update on the metrics',
+      // Plausible but rejected — message too long to be a standalone ping
+      'status? also can you check the deployment script for the lint errors please',
+      // Punctuation-shaped but not a query
+      '.',
+      '!',
+      '!?',
+    ]
+    for (const text of negatives) {
+      it(`does not match: ${JSON.stringify(text)}`, () => {
+        expect(classifyInbound(text).isStatusQuery).toBe(false)
+      })
+    }
+  })
+
+  it('handles null/undefined safely', () => {
+    expect(classifyInbound(null).isStatusQuery).toBe(false)
+    expect(classifyInbound(undefined).isStatusQuery).toBe(false)
+  })
+
+  it('does not match messages over 40 chars even if they start with a status word', () => {
+    const longPretendStatusQuery = 'status? but actually i wanted to ask about deploys'
+    expect(classifyInbound(longPretendStatusQuery).isStatusQuery).toBe(false)
+  })
+})

--- a/telegram-plugin/tests/runtime-metrics.test.ts
+++ b/telegram-plugin/tests/runtime-metrics.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, readFileSync, rmSync, existsSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  emitRuntimeMetric,
+  __setRuntimeMetricsPathForTests,
+  __getRuntimeMetricsPathForTests,
+  __isJsonlEnabledForTests,
+} from '../runtime-metrics.js'
+
+let tmpDir: string
+let metricsPath: string
+const ORIGINAL_TELEMETRY = process.env.SWITCHROOM_TELEMETRY_DISABLED
+const ORIGINAL_JSONL_DISABLED = process.env.SWITCHROOM_RUNTIME_METRICS_JSONL_DISABLED
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'runtime-metrics-test-'))
+  metricsPath = join(tmpDir, 'runtime-metrics.jsonl')
+  __setRuntimeMetricsPathForTests(metricsPath)
+  // Disable PostHog for unit tests — we only want to exercise the JSONL sink.
+  // Real PostHog wiring is covered indirectly by analytics-posthog itself.
+  process.env.SWITCHROOM_TELEMETRY_DISABLED = '1'
+  delete process.env.SWITCHROOM_RUNTIME_METRICS_JSONL_DISABLED
+})
+
+afterEach(() => {
+  __setRuntimeMetricsPathForTests(null)
+  rmSync(tmpDir, { recursive: true, force: true })
+  if (ORIGINAL_TELEMETRY != null) process.env.SWITCHROOM_TELEMETRY_DISABLED = ORIGINAL_TELEMETRY
+  else delete process.env.SWITCHROOM_TELEMETRY_DISABLED
+  if (ORIGINAL_JSONL_DISABLED != null) process.env.SWITCHROOM_RUNTIME_METRICS_JSONL_DISABLED = ORIGINAL_JSONL_DISABLED
+  else delete process.env.SWITCHROOM_RUNTIME_METRICS_JSONL_DISABLED
+})
+
+describe('runtime-metrics — JSONL sink', () => {
+  it('writes one JSON line per event', () => {
+    emitRuntimeMetric({
+      kind: 'inbound_status_query',
+      chat_id: '123',
+      message_id: 42,
+      thread_id: null,
+      text_length: 7,
+      prior_turn_in_flight: true,
+      seconds_since_turn_start: 12,
+    })
+    emitRuntimeMetric({
+      kind: 'turn_started',
+      chat_id: '123',
+      message_id: 43,
+      thread_id: null,
+      inbound_classified_as_status_query: false,
+    })
+    const raw = readFileSync(metricsPath, 'utf-8')
+    const lines = raw.trim().split('\n')
+    expect(lines).toHaveLength(2)
+    const first = JSON.parse(lines[0]!)
+    expect(first.kind).toBe('inbound_status_query')
+    expect(first.chat_id).toBe('123')
+    expect(first.message_id).toBe(42)
+    expect(first.text_length).toBe(7)
+    expect(typeof first.ts).toBe('number')
+  })
+
+  it('turn_ended carries TTFO + outbound gap fields', () => {
+    emitRuntimeMetric({
+      kind: 'turn_ended',
+      chat_id: 'c1',
+      thread_id: 7,
+      duration_ms: 8400,
+      ttfo_ms: 1200,
+      outbound_count: 3,
+      longest_silent_gap_ms: 5500,
+      ended_via: 'reply',
+    })
+    const raw = readFileSync(metricsPath, 'utf-8')
+    const parsed = JSON.parse(raw.trim())
+    expect(parsed.kind).toBe('turn_ended')
+    expect(parsed.ttfo_ms).toBe(1200)
+    expect(parsed.outbound_count).toBe(3)
+    expect(parsed.longest_silent_gap_ms).toBe(5500)
+    expect(parsed.ended_via).toBe('reply')
+  })
+
+  it('appends — does not overwrite — across calls', () => {
+    for (let i = 0; i < 5; i++) {
+      emitRuntimeMetric({
+        kind: 'turn_started',
+        chat_id: 'c1',
+        message_id: i,
+        thread_id: null,
+        inbound_classified_as_status_query: false,
+      })
+    }
+    const raw = readFileSync(metricsPath, 'utf-8')
+    const lines = raw.trim().split('\n')
+    expect(lines).toHaveLength(5)
+  })
+
+  it('creates the parent directory if missing', () => {
+    const nested = join(tmpDir, 'a', 'b', 'c', 'runtime-metrics.jsonl')
+    __setRuntimeMetricsPathForTests(nested)
+    emitRuntimeMetric({
+      kind: 'turn_started',
+      chat_id: 'c1',
+      message_id: 1,
+      thread_id: null,
+      inbound_classified_as_status_query: false,
+    })
+    expect(existsSync(nested)).toBe(true)
+  })
+
+  it('SWITCHROOM_RUNTIME_METRICS_JSONL_DISABLED=1 skips the JSONL write', () => {
+    process.env.SWITCHROOM_RUNTIME_METRICS_JSONL_DISABLED = '1'
+    expect(__isJsonlEnabledForTests()).toBe(false)
+    emitRuntimeMetric({
+      kind: 'turn_started',
+      chat_id: 'c1',
+      message_id: 1,
+      thread_id: null,
+      inbound_classified_as_status_query: false,
+    })
+    expect(existsSync(metricsPath)).toBe(false)
+  })
+
+  it('resolves SWITCHROOM_RUNTIME_METRICS_PATH override', () => {
+    const overridePath = join(tmpDir, 'override.jsonl')
+    __setRuntimeMetricsPathForTests(overridePath)
+    expect(__getRuntimeMetricsPathForTests()).toBe(overridePath)
+  })
+
+  it('emit never throws even if all sinks are disabled', () => {
+    process.env.SWITCHROOM_RUNTIME_METRICS_JSONL_DISABLED = '1'
+    process.env.SWITCHROOM_TELEMETRY_DISABLED = '1'
+    expect(() => {
+      emitRuntimeMetric({
+        kind: 'turn_started',
+        chat_id: 'c1',
+        message_id: 1,
+        thread_id: null,
+        inbound_classified_as_status_query: false,
+      })
+    }).not.toThrow()
+  })
+})

--- a/telegram-plugin/tests/turn-signal-tracker.test.ts
+++ b/telegram-plugin/tests/turn-signal-tracker.test.ts
@@ -2,8 +2,10 @@ import { describe, it, expect, beforeEach } from 'vitest'
 import {
   reset,
   noteSignal,
+  noteOutbound,
   getLongestGap,
   getLastSignalAt,
+  getOutboundMetrics,
   clear,
   __resetAllForTests,
 } from '../turn-signal-tracker.js'
@@ -103,5 +105,84 @@ describe('turn-signal-tracker', () => {
     // turn_end emits the metric, then clears
     clear(k)
     expect(getLongestGap(k)).toBe(0)
+  })
+})
+
+describe('turn-signal-tracker — outbound metrics (#1122)', () => {
+  it('a turn with zero outbound messages reports ttfoMs=null, count=0, gap=0', () => {
+    reset('k', 1000)
+    const m = getOutboundMetrics('k')
+    expect(m.ttfoMs).toBeNull()
+    expect(m.outboundCount).toBe(0)
+    expect(m.longestOutboundGapMs).toBe(0)
+  })
+
+  it('first noteOutbound() records TTFO = (now - turnStartedAt)', () => {
+    reset('k', 1000)
+    noteOutbound('k', 1750)
+    const m = getOutboundMetrics('k')
+    expect(m.ttfoMs).toBe(750)
+    expect(m.outboundCount).toBe(1)
+    expect(m.longestOutboundGapMs).toBe(0) // single message — no gap yet
+  })
+
+  it('multiple outbound messages compute the longest gap between them', () => {
+    reset('k', 0)
+    noteOutbound('k', 100)   // ttfo=100, no gap
+    noteOutbound('k', 200)   // gap=100
+    noteOutbound('k', 1700)  // gap=1500 (longest)
+    noteOutbound('k', 1800)  // gap=100
+    const m = getOutboundMetrics('k')
+    expect(m.ttfoMs).toBe(100)
+    expect(m.outboundCount).toBe(4)
+    expect(m.longestOutboundGapMs).toBe(1500)
+  })
+
+  it('noteOutbound() on an unknown key is a no-op', () => {
+    noteOutbound('untracked', 1000)
+    const m = getOutboundMetrics('untracked')
+    expect(m.ttfoMs).toBeNull()
+    expect(m.outboundCount).toBe(0)
+  })
+
+  it('reset() clears outbound state from prior turn', () => {
+    reset('k', 0)
+    noteOutbound('k', 100)
+    noteOutbound('k', 5000) // big gap
+    reset('k', 10000) // new turn
+    noteOutbound('k', 10100)
+    const m = getOutboundMetrics('k')
+    expect(m.ttfoMs).toBe(100)
+    expect(m.outboundCount).toBe(1)
+    expect(m.longestOutboundGapMs).toBe(0)
+  })
+
+  it('clear() wipes outbound state too', () => {
+    reset('k', 0)
+    noteOutbound('k', 100)
+    clear('k')
+    const m = getOutboundMetrics('k')
+    expect(m.ttfoMs).toBeNull()
+    expect(m.outboundCount).toBe(0)
+  })
+
+  it('outbound and signal counters track independently', () => {
+    reset('k', 0)
+    // Many signals (status reaction churn) but only one outbound
+    noteSignal('k', 100)
+    noteSignal('k', 500)
+    noteSignal('k', 2500)
+    noteOutbound('k', 3000) // first outbound, ttfo=3000
+    const m = getOutboundMetrics('k')
+    expect(m.ttfoMs).toBe(3000)
+    expect(m.outboundCount).toBe(1)
+    // Signal-gap reflects ALL signals (including reactions)
+    expect(getLongestGap('k')).toBeGreaterThanOrEqual(1000)
+  })
+
+  it('TTFO = 0 when first outbound fires at exact turn-start tick', () => {
+    reset('k', 5000)
+    noteOutbound('k', 5000)
+    expect(getOutboundMetrics('k').ttfoMs).toBe(0)
   })
 })

--- a/telegram-plugin/turn-signal-tracker.ts
+++ b/telegram-plugin/turn-signal-tracker.ts
@@ -1,46 +1,82 @@
 /**
- * Per-turn silent-gap tracker for streaming observability.
+ * Per-turn signal + outbound tracker for streaming observability.
  *
- * Tracks the longest contiguous interval within a turn where no user-visible
- * signal was sent. Signals include: progress-card edits, status-reaction
- * transitions, answer-lane updates, and fresh sendMessage calls.
+ * Tracks TWO things, keyed by chatId+threadId:
+ *
+ *   1. **Signal gap** — longest contiguous interval where no user-visible
+ *      signal of ANY kind was sent (progress-card edits, status-reaction
+ *      transitions, answer-lane updates, fresh sendMessage calls). The
+ *      original use case from #203.
+ *
+ *   2. **Outbound messages** (added 2026-05 for the conversational-turn-
+ *      UX redesign, issue #1122) — strictly user-visible MESSAGES that
+ *      the agent sent: `reply`, `stream_reply` first-emits, progress
+ *      card flushes that produce a fresh sendMessage. Status reactions
+ *      and message edits don't count here — they don't ping the device
+ *      and aren't what "outbound silence" means for the KPI.
  *
  * Keyed by chatId+threadId so concurrent turns in different chats don't
- * collide. Designed to be fully standalone (no grammy/bot dependency) so
- * it's testable with deterministic time injection via vi.useFakeTimers().
+ * collide. Fully standalone — no grammy/bot dependency, deterministic
+ * time injection via vi.useFakeTimers().
  *
  * Usage:
- *   signalTracker.reset(key, now)       // at turn start
- *   signalTracker.noteSignal(key, now)  // on every user-visible signal
- *   signalTracker.getLongestGap(key)    // at turn_end
- *   signalTracker.clear(key)            // after emitting (cleanup)
+ *   signalTracker.reset(key, now)                  // at turn start
+ *   signalTracker.noteSignal(key, now)             // any signal (legacy)
+ *   signalTracker.noteOutbound(key, now)           // outbound message only
+ *   signalTracker.getLongestGap(key)               // at turn_end (signal)
+ *   signalTracker.getOutboundMetrics(key)          // at turn_end (KPIs)
+ *   signalTracker.clear(key)                       // after emitting
  */
 
 export interface TurnSignalState {
-  /** The time the current gap started (i.e., the last signal time). */
+  /** The time the turn began. Used to compute TTFO. */
+  turnStartedAt: number
+  /** Time the current signal gap started (last signal time). */
   lastSignalAt: number
-  /** The longest gap observed so far (ms). */
+  /** Longest signal-gap (any signal) observed so far (ms). */
   longestGapMs: number
+  /** First outbound message timestamp this turn, or null if none yet. */
+  firstOutboundAt: number | null
+  /** Most recent outbound message timestamp, or null. */
+  lastOutboundAt: number | null
+  /** Total outbound messages sent this turn. */
+  outboundCount: number
+  /** Longest gap between consecutive outbound messages (ms). */
+  longestOutboundGapMs: number
 }
 
-/**
- * Module-scoped map: `"chatId:threadId"` → state. Using a module-level map
- * keeps the tracker lightweight and avoids passing state through every
- * call-site while remaining mockable in tests via the exported functions.
- */
+export interface OutboundMetrics {
+  /** ms between turn start and first outbound message; null if none sent. */
+  ttfoMs: number | null
+  /** Total outbound messages this turn. */
+  outboundCount: number
+  /** Longest gap between outbound messages — i.e. the "silent stretch"
+   *  metric for the conversational-pacing KPI. 0 if <2 messages. */
+  longestOutboundGapMs: number
+}
+
 const state = new Map<string, TurnSignalState>()
 
 /**
  * Begin tracking a new turn. Records `now` as the initial signal time and
- * resets the gap accumulator. Call at the start of each fresh turn.
+ * resets the gap accumulator + outbound state. Call at the start of each
+ * fresh turn.
  */
 export function reset(key: string, now: number): void {
-  state.set(key, { lastSignalAt: now, longestGapMs: 0 })
+  state.set(key, {
+    turnStartedAt: now,
+    lastSignalAt: now,
+    longestGapMs: 0,
+    firstOutboundAt: null,
+    lastOutboundAt: null,
+    outboundCount: 0,
+    longestOutboundGapMs: 0,
+  })
 }
 
 /**
- * Record a user-visible signal. Measures the gap since the last signal and
- * updates `longestGapMs` if this gap is larger.
+ * Record a user-visible signal (any kind: reaction, edit, send). Measures
+ * the gap since the last signal and updates `longestGapMs` if larger.
  */
 export function noteSignal(key: string, now: number): void {
   const entry = state.get(key)
@@ -51,8 +87,31 @@ export function noteSignal(key: string, now: number): void {
 }
 
 /**
- * Returns the longest gap observed during the current turn (ms).
- * Returns 0 if no tracking state exists for this key.
+ * Record a fresh outbound MESSAGE (reply, stream_reply first-emit, or
+ * card flush that produced a new sendMessage). Updates the
+ * outbound-specific metrics: TTFO on first call, outbound-gap on
+ * subsequent calls.
+ *
+ * Does not double-update the signal-gap stream — callers that note an
+ * outbound message should ALSO call `noteSignal()` to keep the legacy
+ * signal-gap accurate.
+ */
+export function noteOutbound(key: string, now: number): void {
+  const entry = state.get(key)
+  if (entry == null) return
+  if (entry.firstOutboundAt == null) {
+    entry.firstOutboundAt = now
+  } else if (entry.lastOutboundAt != null) {
+    const gap = now - entry.lastOutboundAt
+    if (gap > entry.longestOutboundGapMs) entry.longestOutboundGapMs = gap
+  }
+  entry.lastOutboundAt = now
+  entry.outboundCount += 1
+}
+
+/**
+ * Returns the longest gap observed during the current turn (ms) — legacy
+ * "any signal" metric. Returns 0 if no tracking state exists for this key.
  */
 export function getLongestGap(key: string): number {
   return state.get(key)?.longestGapMs ?? 0
@@ -67,8 +126,25 @@ export function getLastSignalAt(key: string): number | undefined {
 }
 
 /**
- * Remove state for this key. Call after emitting the turn_signal_gap metric.
+ * Returns the outbound-message KPI bundle for the conversational-pacing
+ * redesign. Zeroed-out if no tracking state exists.
  */
+export function getOutboundMetrics(key: string): OutboundMetrics {
+  const entry = state.get(key)
+  if (entry == null) {
+    return { ttfoMs: null, outboundCount: 0, longestOutboundGapMs: 0 }
+  }
+  const ttfoMs = entry.firstOutboundAt != null
+    ? entry.firstOutboundAt - entry.turnStartedAt
+    : null
+  return {
+    ttfoMs,
+    outboundCount: entry.outboundCount,
+    longestOutboundGapMs: entry.longestOutboundGapMs,
+  }
+}
+
+/** Remove state for this key. Call after emitting the turn-end metrics. */
 export function clear(key: string): void {
   state.delete(key)
 }

--- a/tests/docker/compose-generator-posthog.test.ts
+++ b/tests/docker/compose-generator-posthog.test.ts
@@ -1,0 +1,142 @@
+/**
+ * compose-generator-posthog.test.ts
+ *
+ * Verifies that the compose generator wires through PostHog runtime
+ * telemetry env vars per the new analytics-runtime PR (#1122 PR1):
+ *   - SWITCHROOM_ANALYTICS_ID emitted iff ~/.switchroom/analytics-id
+ *     exists on the host
+ *   - SWITCHROOM_TELEMETRY_DISABLED propagated from the operator's
+ *     shell (only when truthy)
+ *   - SWITCHROOM_POSTHOG_KEY / SWITCHROOM_POSTHOG_HOST overrides
+ *     propagated when present
+ *
+ * Pure compose-string assertions — no docker invocation.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { generateCompose } from "../../src/agents/compose.js";
+import type { SwitchroomConfig } from "../../src/config/schema.js";
+
+function makeConfig(): SwitchroomConfig {
+  return {
+    switchroom: {
+      version: 1,
+      agents_dir: "~/.switchroom/agents",
+      skills_dir: "~/.switchroom/skills",
+    },
+    telegram: { bot_token: "x" },
+    defaults: undefined,
+    profiles: undefined,
+    agents: {
+      coach: {
+        extends: undefined,
+        settings_raw: undefined,
+        admin: undefined,
+        env: undefined,
+        schedule: [],
+        tools: { allow: [], deny: [] },
+        hooks: undefined,
+        channels: undefined,
+      } as unknown as SwitchroomConfig["agents"][string],
+    },
+    drive: undefined as unknown as SwitchroomConfig["drive"],
+  } as unknown as SwitchroomConfig;
+}
+
+let tmpHome: string;
+const ENV_KEYS = [
+  "SWITCHROOM_TELEMETRY_DISABLED",
+  "SWITCHROOM_POSTHOG_KEY",
+  "SWITCHROOM_POSTHOG_HOST",
+] as const;
+const originalEnv: Record<string, string | undefined> = {};
+
+beforeEach(() => {
+  tmpHome = mkdtempSync(join(tmpdir(), "compose-posthog-test-"));
+  for (const k of ENV_KEYS) {
+    originalEnv[k] = process.env[k];
+    delete process.env[k];
+  }
+});
+
+afterEach(() => {
+  rmSync(tmpHome, { recursive: true, force: true });
+  for (const k of ENV_KEYS) {
+    if (originalEnv[k] != null) process.env[k] = originalEnv[k];
+    else delete process.env[k];
+  }
+});
+
+describe("compose-generator — PostHog runtime telemetry env vars", () => {
+  it("emits SWITCHROOM_ANALYTICS_ID when the host file exists", () => {
+    mkdirSync(join(tmpHome, ".switchroom"), { recursive: true });
+    writeFileSync(
+      join(tmpHome, ".switchroom", "analytics-id"),
+      "abc123-deterministic-uuid",
+      "utf-8",
+    );
+    const out = generateCompose({ config: makeConfig(), homeDir: tmpHome });
+    expect(out).toContain('SWITCHROOM_ANALYTICS_ID: "abc123-deterministic-uuid"');
+  });
+
+  it("omits SWITCHROOM_ANALYTICS_ID when the host file is missing", () => {
+    const out = generateCompose({ config: makeConfig(), homeDir: tmpHome });
+    expect(out).not.toContain("SWITCHROOM_ANALYTICS_ID:");
+  });
+
+  it("omits SWITCHROOM_ANALYTICS_ID when the host file is empty", () => {
+    mkdirSync(join(tmpHome, ".switchroom"), { recursive: true });
+    writeFileSync(join(tmpHome, ".switchroom", "analytics-id"), "   \n", "utf-8");
+    const out = generateCompose({ config: makeConfig(), homeDir: tmpHome });
+    expect(out).not.toContain("SWITCHROOM_ANALYTICS_ID:");
+  });
+
+  it("propagates SWITCHROOM_TELEMETRY_DISABLED=1 from host env", () => {
+    process.env.SWITCHROOM_TELEMETRY_DISABLED = "1";
+    const out = generateCompose({ config: makeConfig(), homeDir: tmpHome });
+    expect(out).toContain('SWITCHROOM_TELEMETRY_DISABLED: "1"');
+  });
+
+  it("propagates SWITCHROOM_TELEMETRY_DISABLED=true from host env", () => {
+    process.env.SWITCHROOM_TELEMETRY_DISABLED = "true";
+    const out = generateCompose({ config: makeConfig(), homeDir: tmpHome });
+    // Normalised to "1" on emission so the in-container reader's truthy
+    // check matches without operator-specific casing surprises.
+    expect(out).toContain('SWITCHROOM_TELEMETRY_DISABLED: "1"');
+  });
+
+  it("does NOT emit SWITCHROOM_TELEMETRY_DISABLED when unset (the common case)", () => {
+    const out = generateCompose({ config: makeConfig(), homeDir: tmpHome });
+    expect(out).not.toContain("SWITCHROOM_TELEMETRY_DISABLED:");
+  });
+
+  it("propagates SWITCHROOM_POSTHOG_KEY override from host env", () => {
+    process.env.SWITCHROOM_POSTHOG_KEY = "phc_override_key_xyz";
+    const out = generateCompose({ config: makeConfig(), homeDir: tmpHome });
+    expect(out).toContain('SWITCHROOM_POSTHOG_KEY: "phc_override_key_xyz"');
+  });
+
+  it("propagates SWITCHROOM_POSTHOG_HOST override from host env", () => {
+    process.env.SWITCHROOM_POSTHOG_HOST = "https://eu.i.posthog.com";
+    const out = generateCompose({ config: makeConfig(), homeDir: tmpHome });
+    expect(out).toContain(
+      'SWITCHROOM_POSTHOG_HOST: "https://eu.i.posthog.com"',
+    );
+  });
+
+  it("byte-determinism: two runs with same inputs produce identical output", () => {
+    mkdirSync(join(tmpHome, ".switchroom"), { recursive: true });
+    writeFileSync(
+      join(tmpHome, ".switchroom", "analytics-id"),
+      "stable-uuid",
+      "utf-8",
+    );
+    process.env.SWITCHROOM_TELEMETRY_DISABLED = "1";
+    const out1 = generateCompose({ config: makeConfig(), homeDir: tmpHome });
+    const out2 = generateCompose({ config: makeConfig(), homeDir: tmpHome });
+    expect(out1).toBe(out2);
+  });
+});


### PR DESCRIPTION
## Summary

Baseline instrumentation for the conversational-turn-UX redesign (#1122). PR 1 of 4 — measures today so we can compare tomorrow.

Adds three high-value events emitted from inside each agent container by the telegram-plugin gateway, fanned out to **both PostHog** (fleet dashboards) and a per-agent `runtime-metrics.jsonl` (local debugging — operator can `tail -f` it; an agent can read its own past behaviour without round-tripping to PostHog).

### Events

- `inbound_status_query` — fires when a user message matches a status-query pattern (`"status?"`, `"still there?"`, `"?"`, etc). Primary lagging KPI: every fire is a JTBD failure.
- `turn_started` — paired with `turn_ended` for funnel start-counts.
- `turn_ended` — carries `duration_ms`, `ttfo_ms`, `outbound_count`, `longest_silent_gap_ms`, `ended_via`. The dashboard computes outbound silence p95 + TTFO p95 directly from these without per-event reconstruction.

### Error tracking

Wires `installGlobalErrorHandlers()` into the gateway boot path so uncaught exceptions + unhandled rejections from the long-lived runtime land in the same Switchroom Errors dashboard as CLI errors, tagged `source: "gateway"`.

### Identity flow

Threads `~/.switchroom/analytics-id` (the host CLI's distinctId) through `compose.ts` as `SWITCHROOM_ANALYTICS_ID` env var. A user's CLI events + every runtime turn merge under a single PostHog identity. Operator opt-out via `SWITCHROOM_TELEMETRY_DISABLED=1` propagates fleet-wide; key/host overrides propagate the same way.

### Why both sinks

Per the design conversation: PostHog is the source of truth for dashboards / KPIs / error correlation. JSONL is the local debug breadcrumb the operator (or the agent itself) can read inline. Disable with `SWITCHROOM_RUNTIME_METRICS_JSONL_DISABLED=1` if disk pressure becomes a concern; PostHog continues to receive events independently.

## Files

- New modules: `telegram-plugin/analytics-posthog.ts` (gateway-side PostHog client, mirrors `src/analytics/posthog.ts` shape but tuned for long-lived process), `telegram-plugin/inbound-classifier.ts` (status-query regex), `telegram-plugin/runtime-metrics.ts` (typed event union + dual-sink emitter).
- Extended: `telegram-plugin/turn-signal-tracker.ts` (new outbound metrics — TTFO + outbound-only gap, alongside existing signal-gap tracking), `telegram-plugin/gateway/gateway.ts` (wire-up at 4 sites: boot, inbound handler, turn_start, two turn_end paths), `src/agents/compose.ts` (env-var plumbing).
- Allowlist range bump in `scripts/check-bot-api-wrapping.sh` — pre-existing raw `bot.api.*` callsites shifted line numbers due to telemetry insertions; ranges updated, no new raw calls added.

## Test plan

- [x] `npm run test:vitest` — 5812 pass, 50 skipped. New test files: `inbound-classifier.test.ts` (41 cases), `runtime-metrics.test.ts` (7 cases), `compose-generator-posthog.test.ts` (9 cases), `turn-signal-tracker.test.ts` (+8 new outbound-metric cases).
- [x] `npm run test:bun` — 709 pass, 2 skipped, 0 fail.
- [x] `npm run lint` — tsc + plugin-references + bot-api-wrapping all clean.
- [x] `bun run build` — bundles cleanly.

## KPI baseline

Once this lands, the **Switchroom Runtime** dashboard (to be created post-merge in PostHog) will start collecting:
- Status-query rate (target: <0.5% of inbound)
- Outbound silence p95 in long turns (target: <120s)
- TTFO p95 (target: <30s)

Let it bake for ~7 days before PR 2 (prompt overhaul + silence-poke subsystem) lands, so we have a real before/after comparison.

## Related

- Issue #1122 — Rethink turn UX: collapse to one artifact per turn
- PR sequence: **PR1 (this) → PR2 (prompt + silence-poke) → PR3 (delete progress card) → PR4 (/lasttrace + docs)**

🤖 Generated with [Claude Code](https://claude.com/claude-code)