### PR TITLE
feat(telegram-ux): silence-poke + conversational pacing prompt + disable_notification (#1122 PR2)

### DIFF
--- a/profiles/_shared/telegram-style.md.hbs
+++ b/profiles/_shared/telegram-style.md.hbs
@@ -1,20 +1,20 @@
 ## Telegram interaction style
 
-You are talking to the user through Telegram. Telegram is a chat interface — your responses should feel like a chat, not a terminal dump.
+Telegram is a chat — replies should feel like one, not a terminal dump or a tracking widget. A good chat partner acknowledges, goes quiet while working, surfaces meaningful updates, and delivers the answer when it's ready. Match that rhythm.
 
-**When to use `stream_reply` vs `reply`:**
+**Conversational pacing.**
+- **Soft commit if work will take >15s.** One short `reply`: *"let me check, back in a few"*, *"on it"*. Match persona tone. Skip for fast turns — the answer itself is the signal.
+- **Mid-turn updates at meaningful punctuation only.** Finished a hard step; hit a blocker; pivoting; dispatching a sub-agent; waiting on a slow tool; found something worth surfacing. **Not** on every tool call, **not** on a cadence, **not** to fill silence — the reaction on the user's inbound message already signals alive.
+- **Mid-turn updates pass `disable_notification: true`.** The user only gets pinged on the final answer (or a genuine heads-up). Update freely without notification fatigue.
+- **Narrate sub-agent dispatches** — *"spinning up @reviewer to look at this"* — and summarise their reply when they report back. Sub-agent work belongs in the chat, not inferred from absence.
+- **Final answer is a fresh `reply`** (omit `disable_notification`, or pass false). Pings once.
+- **Silence-poke reminders.** A `<system-reminder>` containing `[silence-poke]` means the framework detected you've been quiet too long — send one short `reply` (*"still working through X"*, *"npm install is slow"*), brief, no task restatement. Skip if you're within ~5s of finishing. If the reminder mentions thinking, a one-liner on your current line of thought is fine.
 
-Default to `stream_reply` for any response that requires tool calls before you can finalize the answer. This includes: reading files, running commands, calling any MCP tool, searching memory, or any multi-step reasoning where the user would otherwise see silence followed by a final blob. Streaming shows progress; `reply` alone feels dead until the final message arrives.
+**`stream_reply` vs `reply`.**
+- **`reply`** is the default. Use for soft-commits, mid-turn updates, sub-agent narration, final answers. Pass `disable_notification: true` mid-turn.
+- **`stream_reply`** is for content whose final answer benefits from streaming character-by-character (long prose, code blocks). First call sends fresh; subsequent calls edit (no ping until `done=true`). Don't use it just to "show progress" — that's what `reply` is for.
 
-Pattern for `stream_reply`:
-
-1. **First call** (immediate, right after receiving the user's message): `stream_reply(chat_id, "Reading the file...", done=false)` — sends a fresh message. The user sees something within ~1 second of sending.
-2. **Interim calls** (after each tool result or meaningful step): `stream_reply(chat_id, "<full current text so far>", done=false)` — pass the FULL current text, not a delta. The plugin throttles edits to ~1/sec automatically.
-3. **Final call**: `stream_reply(chat_id, "<full final answer>", done=true)` — locks the message. This is the canonical reply for the turn.
-
-Use `reply` **only** for instant one-shot answers that require zero tool calls — e.g., answering a pure factual question you already know, acknowledging a simple instruction, or a one-line clarification. If you are unsure which to pick, use `stream_reply`.
-
-The status-reaction lifecycle (👀 → 🤔 → 🔥 → 👍) on the user's inbound message signals "working" automatically; you don't need to send a typing message.
+The status-reaction lifecycle (👀 → 🤔 → 🔥 → 👍) on the user's inbound message signals "working" automatically; you don't need a typing message or periodic "still working" replies just to keep that signal alive.
 
 **Reactions ON your replies.** Sometimes you'll receive a turn whose body is wrapped in `<channel source="reaction">`. That means the user reacted to one of your earlier messages and the gateway forwarded the reaction as a synthetic turn (the message preview is included so you know which reply they reacted to). 👎 / ❌ are stop signals — pause, reconsider the approach, ask what's off. 👍 / ✅ are acknowledgements — keep going if mid-task, no extra reply needed. A brief explicit acknowledgement is fine but not required; don't ceremonially reply to every reaction. The allowlist + per-hour cap are operator-tunable (default 10/hour); other emojis you might see don't trigger turns.
 

--- a/scripts/check-bot-api-wrapping.sh
+++ b/scripts/check-bot-api-wrapping.sh
@@ -77,23 +77,24 @@ ALLOWLIST=(
   "telegram-plugin/gateway/gateway.ts:2215-2245:operator-event broadcast; no thread_id in opts"
 
   # permission-request keyboard send. opts only has reply_markup. No thread_id.
-  "telegram-plugin/gateway/gateway.ts:2595-2625:permission-request keyboard; no thread_id"
+  # Range bumped 2026-05 for #1122 PR2 silence-poke insertions.
+  "telegram-plugin/gateway/gateway.ts:2660-2700:permission-request keyboard; no thread_id"
 
   # reply chunk-loop fallback after robustApiCall threw THREAD_NOT_FOUND.
   # The caller dropped the thread; this raw sendMessage retries on the
   # main chat. Wrapping would re-enter the THREAD_NOT_FOUND throw on a
   # phantom second deletion.
-  "telegram-plugin/gateway/gateway.ts:3050-3080:reply chunk-loop THREAD_NOT_FOUND fallback (intentional raw)"
+  "telegram-plugin/gateway/gateway.ts:3125-3160:reply chunk-loop THREAD_NOT_FOUND fallback (intentional raw)"
 
   # credit-watch notification. No thread_id (DM).
-  "telegram-plugin/gateway/gateway.ts:7990-8020:credit-watch notify; no thread_id"
+  "telegram-plugin/gateway/gateway.ts:8070-8110:credit-watch notify; no thread_id"
 
-  # gateway.ts:9260-9400 — ctx.api.editMessageText for vault grant wizard
+  # gateway.ts:9260-9490 — ctx.api.editMessageText for vault grant wizard
   # cards. Every callsite has `.catch(() => {})` — a THREAD_NOT_FOUND
   # is already swallowed there. Acceptable because the wizard messages
   # are tap-driven UI and a missed edit just leaves the previous state
   # visible (the user can re-tap).
-  "telegram-plugin/gateway/gateway.ts:9260-9400:vault grant wizard ctx.api.editMessageText already has .catch swallow"
+  "telegram-plugin/gateway/gateway.ts:9260-9490:vault grant wizard ctx.api.editMessageText already has .catch swallow"
 
   # boot-card.ts and issues-card.ts: these MODULES receive a bot adapter
   # via DI. The gateway wires those adapters through robustApiCall (see

--- a/telegram-plugin/bridge/bridge.ts
+++ b/telegram-plugin/bridge/bridge.ts
@@ -108,6 +108,7 @@ const TOOL_SCHEMAS = [
         disable_web_page_preview: { type: 'boolean', description: 'Disable link preview thumbnails. Default: true.' },
         protect_content: { type: 'boolean', description: 'When true, Telegram prevents the message from being forwarded or saved.' },
         quote_text: { type: 'string', description: 'Surgical quote: specific text to highlight from the reply_to message. Requires reply_to.' },
+        disable_notification: { type: 'boolean', description: 'When true, Telegram delivers the message silently — no device ping for this user. Default false (pings). Use true for mid-turn updates ("still working through X") so only the final answer pings. Always omit (or pass false) on the final answer of a turn.' },
         inline_keyboard: {
           type: 'array',
           description: 'Optional 2D array of tappable buttons rendered under the message. Outer array = rows; inner array = buttons in each row (max 8 per row, 8 rows). Each button needs a `text` (label, max 64 chars) plus EXACTLY ONE of: `url` (opens link in browser; must start with http(s):// or tg://) or `callback_data` (string, max 58 chars; tap is delivered to this agent as an inbound channel event with meta.button_callback_data=<the data> and the original button_text). Use buttons for single-tap approval/triage flows like [Approve] [Hold]; one tap on mobile beats asking the user to type YES/NO. By default a tap shows a brief "✓ received" toast and removes the entire keyboard so the user can\'t double-fire — override per-button via `ack_text` (custom toast text, max 200 chars) and `single_use: false` (preserve the keyboard so e.g. a [Refresh] button stays tappable).',
@@ -146,6 +147,7 @@ const TOOL_SCHEMAS = [
         quote: { type: 'boolean', description: 'Opt out of the default quote-reply behavior. Default: true. Ignored when reply_to is explicitly set.' },
         protect_content: { type: 'boolean', description: 'When true, Telegram prevents the message from being forwarded or saved.' },
         quote_text: { type: 'string', description: 'Surgical quote: specific text to highlight from the reply_to message. Requires reply_to.' },
+        disable_notification: { type: 'boolean', description: 'When true, the INITIAL message send is silent (no device ping). Has no effect on subsequent edits — Telegram never pings on editMessageText. Default false. Use for mid-turn stream starts you do not want to ping; omit on the final answer.' },
         inline_keyboard: {
           type: 'array',
           description: '2D array of tappable buttons under the final message. Same shape and constraints as `reply.inline_keyboard` — each button has `text` and EXACTLY ONE of `url` or `callback_data`, plus optional `ack_text` (custom tap-toast; default "✓ received") and `single_use` (default true; set false to keep the keyboard tappable after a tap). Tap on a callback_data button is delivered to this agent as an inbound channel event with meta.button_callback_data set.',

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -75,6 +75,7 @@ import {
 } from '../analytics-posthog.js'
 import { emitRuntimeMetric } from '../runtime-metrics.js'
 import { classifyInbound } from '../inbound-classifier.js'
+import * as silencePoke from '../silence-poke.js'
 import { createAnswerStream, type AnswerStreamHandle } from '../answer-stream.js'
 import { type SessionEvent } from '../session-tail.js'
 import {
@@ -2444,6 +2445,38 @@ function ensureIssuesCard(chatId: string, threadId: number | undefined): void {
   }
 }
 
+// #1122: framework safety-net for "model is silent to the user for >5min."
+// Starts a single setInterval poll that walks active turns and arms
+// soft/firm poke reminders piggybacked on the next tool result. At 300s
+// the framework itself sends a user-visible "still working… / still
+// thinking…" message. Honours SWITCHROOM_DISABLE_SILENCE_POKE=1 kill
+// switch (no-op if set).
+silencePoke.startTimer({
+  emitMetric: (event) => {
+    // Re-emit through the unified runtime-metrics fan-out (PostHog + JSONL).
+    emitRuntimeMetric(event)
+  },
+  onFrameworkFallback: async (ctx) => {
+    const text = ctx.fallbackKind === 'thinking'
+      ? 'still thinking… (no update from agent in 5 min)'
+      : 'still working… (no update from agent in 5 min)'
+    try {
+      await robustApiCall(
+        () => bot.api.sendMessage(ctx.chatId, text, {
+          ...(ctx.threadId != null ? { message_thread_id: ctx.threadId } : {}),
+          // Framework fallback pings — user genuinely needs to know.
+          disable_notification: false,
+        }),
+        { chat_id: ctx.chatId, ...(ctx.threadId != null ? { threadId: ctx.threadId } : {}) },
+      )
+    } catch (err) {
+      process.stderr.write(
+        `silence-poke fallback sendMessage failed chat=${ctx.chatId} thread=${ctx.threadId}: ${err}\n`,
+      )
+    }
+  },
+})
+
 const ipcServer: IpcServer = createIpcServer({
   socketPath: SOCKET_PATH,
 
@@ -2557,6 +2590,25 @@ const ipcServer: IpcServer = createIpcServer({
     process.stderr.write(`telegram gateway: ipc: tool_call tool=${msg.tool} agent=${client.agentName ?? '-'} clientId=${client.id ?? '-'} callId=${msg.id}\n`)
     try {
       const result = await executeToolCall(msg.tool, msg.args)
+      // #1122 silence-poke chokepoint: piggyback any armed poke onto the
+      // tool result's content text. The model sees the [silence-poke]
+      // system-reminder block as part of the next conversational turn.
+      // No-op when nothing is armed (the common case) — cost is one
+      // map iteration over <=N active turns (typically 1).
+      const reminder = silencePoke.consumeArmedPoke()
+      if (reminder != null && result != null && typeof result === 'object') {
+        const r = result as { content?: Array<{ type: string; text: string }> }
+        if (Array.isArray(r.content) && r.content.length > 0 && r.content[0]!.type === 'text') {
+          r.content[0]!.text = `${r.content[0]!.text}\n\n<system-reminder>\n${reminder}\n</system-reminder>`
+        } else {
+          // Tool result didn't carry a text block to wrap — re-shape so
+          // the reminder still reaches the model.
+          r.content = [
+            ...(Array.isArray(r.content) ? r.content : []),
+            { type: 'text', text: `<system-reminder>\n${reminder}\n</system-reminder>` },
+          ]
+        }
+      }
       return { type: 'tool_call_result', id: msg.id, success: true, result }
     } catch (err) {
       return {
@@ -2576,6 +2628,18 @@ const ipcServer: IpcServer = createIpcServer({
     const threadHint = msg.threadId != null ? String(msg.threadId) : undefined
     progressDriver?.ingest(ev, chatHint, threadHint)
     handleSessionEvent(ev)
+    // #1122 silence-poke: surface activity signals from the session
+    // stream so the fallback message wording is honest and so
+    // subagent-dispatch waits don't fire spurious soft pokes.
+    if (currentTurn != null) {
+      const key = statusKey(currentTurn.sessionChatId, currentTurn.sessionThreadId)
+      if (ev.kind === 'thinking') {
+        silencePoke.noteThinking(key, Date.now())
+      } else if (ev.kind === 'tool_use' && (ev.toolName === 'Task' || ev.toolName === 'Agent')) {
+        // Built-in claude sub-agent dispatch — extends soft threshold to 5min.
+        silencePoke.noteSubagentDispatch(key)
+      }
+    }
   },
 
   onPermissionRequest(_client: IpcClient, msg: PermissionRequestForward) {
@@ -2865,6 +2929,11 @@ async function executeReply(args: Record<string, unknown>): Promise<{ content: A
   const disableLinkPreview = args.disable_web_page_preview != null
     ? Boolean(args.disable_web_page_preview)
     : (access.disableLinkPreview ?? true)
+  // #1122 conversational pacing: mid-turn updates pass disable_notification:true
+  // so only the final answer pings the device. Default false (pings) so
+  // existing call-sites and the typical "final answer" reply keep their
+  // current behaviour without an explicit flag.
+  const disableNotification = args.disable_notification === true
 
   // Telegraph publish (#579). When the reply text is long enough AND
   // the agent has telegraph enabled in access.json, publish to
@@ -2994,8 +3063,10 @@ async function executeReply(args: Record<string, unknown>): Promise<{ content: A
     previewMessageId,
   })
   // #1122 KPI: a `reply` always produces a fresh user-visible outbound
-  // message — count it for the outbound-gap / TTFO KPI.
+  // message — count it for the outbound-gap / TTFO KPI AND reset the
+  // silence-poke clock so the next poke is measured from this send.
   signalTracker.noteOutbound(statusKey(chat_id, threadId), Date.now())
+  silencePoke.noteOutbound(statusKey(chat_id, threadId), Date.now())
 
   if (previewMessageId != null && reply_to != null && replyMode !== 'off') {
     await deleteStalePreview(previewMessageId)
@@ -3023,6 +3094,7 @@ async function executeReply(args: Record<string, unknown>): Promise<{ content: A
         ...(disableLinkPreview ? { link_preview_options: { is_disabled: true } } : {}),
         ...(replyMarkup != null && isLastChunk ? { reply_markup: replyMarkup } : {}),
         ...(protectContent ? { protect_content: true } : {}),
+        ...(disableNotification ? { disable_notification: true } : {}),
       }
 
       if (i === 0 && previewMessageId != null) {
@@ -3280,7 +3352,9 @@ async function executeStreamReply(args: Record<string, unknown>): Promise<unknow
     const streamThreadId = args.message_thread_id != null ? Number(args.message_thread_id) : undefined
     const sKeyBefore = streamKey(streamChatId, streamThreadId)
     if (!activeDraftStreams.has(sKeyBefore)) {
-      signalTracker.noteOutbound(statusKey(streamChatId, streamThreadId), Date.now())
+      const sKey = statusKey(streamChatId, streamThreadId)
+      signalTracker.noteOutbound(sKey, Date.now())
+      silencePoke.noteOutbound(sKey, Date.now())
     }
   }
 
@@ -3296,6 +3370,7 @@ async function executeStreamReply(args: Record<string, unknown>): Promise<unknow
       ...(args.protect_content === true ? { protect_content: true } : {}),
       ...(args.quote_text != null ? { quote_text: args.quote_text as string } : {}),
       ...(streamReplyMarkup != null ? { reply_markup: streamReplyMarkup } : {}),
+      ...(args.disable_notification === true ? { disable_notification: true } : {}),
     },
     { activeDraftStreams, activeDraftParseModes, suppressPtyPreview },
     {
@@ -4825,6 +4900,7 @@ function handleSessionEvent(ev: SessionEvent): void {
             ended_via: 'silent',
           })
           signalTracker.clear(tKey)
+          silencePoke.endTurn(tKey)
         }
         lastPtyPreviewByChat.delete(statusKey(chatId, threadId))
         pendingPtyPartial = null
@@ -5064,6 +5140,7 @@ function handleSessionEvent(ev: SessionEvent): void {
           ended_via: outboundMetrics.outboundCount > 0 ? 'reply' : 'silent',
         })
         signalTracker.clear(tKey)
+        silencePoke.endTurn(tKey)
       }
       lastPtyPreviewByChat.delete(statusKey(chatId, threadId))
       pendingPtyPartial = null
@@ -6088,6 +6165,10 @@ async function handleInbound(
         logStreamingEvent({ kind: 'inbound_ack', chatId: chat_id, messageId: msgId, ackDelayMs: Date.now() - inboundReceivedAt })
         // #203: signal tracker — start tracking silent gaps for this fresh turn.
         signalTracker.reset(statusKey(chat_id, messageThreadId), Date.now())
+        // #1122 silence-poke: start the silence clock for this turn so
+        // the framework can nudge the model if it goes quiet past the
+        // soft / firm thresholds.
+        silencePoke.startTurn(statusKey(chat_id, messageThreadId), Date.now())
         // #1122 KPI: emit turn_started so dashboards can compute funnel
         // start counts + correlate to turn_ended for duration / TTFO.
         emitRuntimeMetric({

--- a/telegram-plugin/runtime-metrics.ts
+++ b/telegram-plugin/runtime-metrics.ts
@@ -61,6 +61,43 @@ export type RuntimeMetricEvent =
       longest_silent_gap_ms: number
       ended_via: 'reply' | 'stream_reply_done' | 'silent' | 'forced'
     }
+  /**
+   * Framework safety-net: a silence-poke was armed at 75s (soft) or
+   * 180s (firm). The system-reminder appended to the next tool result
+   * nudges the model to send an update. Doubles as a design-health
+   * signal — if these fire frequently, the conversational-pacing
+   * prompt isn't doing its job.
+   */
+  | {
+      kind: 'silence_poke_fired'
+      key: string
+      level: 'soft' | 'firm'
+      silence_ms: number
+      subagent_wait: boolean
+    }
+  /**
+   * The model sent an outbound message within the success window
+   * (default 15s) after a poke fired. Pair with `silence_poke_fired`
+   * to compute success rate — the design target is >80%.
+   */
+  | {
+      kind: 'silence_poke_succeeded'
+      key: string
+      level: 'soft' | 'firm'
+      latency_ms: number
+    }
+  /**
+   * Last-resort: 5 minutes silent, the framework itself sent a
+   * user-visible "still working… / still thinking…" message. Should
+   * be rare (target <5 per 1000 turns); a high rate means the model
+   * is genuinely stuck or the soft/firm pokes aren't being honoured.
+   */
+  | {
+      kind: 'silence_fallback_sent'
+      key: string
+      fallback_kind: 'working' | 'thinking'
+      silence_ms: number
+    }
 
 /**
  * The JSONL sink lives under the runtime state dir so it's per-agent

--- a/telegram-plugin/silence-poke.ts
+++ b/telegram-plugin/silence-poke.ts
@@ -1,0 +1,386 @@
+/**
+ * silence-poke.ts — framework safety net for "model is silent to the user."
+ *
+ * Background (issue #1122): we're moving away from a pinned progress card
+ * to a conversational shape where the chat itself is the artifact. The
+ * progress card was implicitly doing one useful job — covering for a
+ * model that doesn't know how to say "still working." This module is the
+ * explicit replacement: when the model has been silent past a threshold,
+ * we nudge it (or, as a last resort, send a framework message ourselves).
+ *
+ * Two clocks (this module owns ONE of them; the other is the legacy
+ * idle stall in status-reactions.ts and is unrelated):
+ *
+ *   silence clock = now - lastOutboundAt   (or turnStartedAt if no outbound yet)
+ *
+ * Outbound = a fresh `reply` or `stream_reply` first-emit. Reactions,
+ * edits, and tool churn DO NOT reset the silence clock — that's the
+ * whole point. The model could be ripping through 20 tool calls and
+ * still be "silent" to the user.
+ *
+ * Escalation ladder per turn:
+ *
+ *   t=0       startTurn() — silence clock starts at turnStartedAt
+ *   t=75s     soft poke armed — appended to next tool result as a
+ *             <system-reminder> nudging the model to send an update
+ *   t=180s    firm poke armed (stronger wording) if no outbound landed
+ *   t=300s    framework fallback: gateway itself sends a user-visible
+ *             "still working… / still thinking…" message. Fires at most
+ *             once per turn. Pings the device (user needs to know).
+ *
+ * Subagent-dispatch override: when the model dispatches a sub-agent
+ * (`Task(...)`, `@worker` etc), the soft threshold extends to 300s for
+ * that turn — the model is legitimately waiting on a child, no point
+ * poking it to narrate the wait. Firm/fallback thresholds unchanged.
+ *
+ * Wired into the gateway at the central tool-result chokepoint
+ * (`gateway.ts:onToolCall`) so the poke text piggybacks the next tool
+ * result back to claude. MCP doesn't allow mid-generation injection;
+ * tool results are the only synchronous moment we own the wire.
+ *
+ * Kill switch: SWITCHROOM_DISABLE_SILENCE_POKE=1 disables the whole
+ * subsystem (no timers, no injection, no fallback). The conversational
+ * pacing prompt still applies; only the framework safety net is off.
+ */
+
+export type PokeLevel = 'soft' | 'firm'
+
+export interface SilencePokeState {
+  /** Wall-clock ms of turn start. Silence clock zero-point when no outbound yet. */
+  turnStartedAt: number
+  /** Wall-clock ms of last outbound message, or null. */
+  lastOutboundAt: number | null
+  /** 0 = none, 1 = soft fired, 2 = firm fired, 3 = fallback fired. */
+  pokesFired: 0 | 1 | 2 | 3
+  /** Armed pending drain on the next tool result, or null. */
+  pokeArmed: { level: PokeLevel } | null
+  /** When true, soft threshold extends to subagentSoft (default 300s). */
+  subagentDispatchActive: boolean
+  /** Wall-clock ms of last `thinking` session event, or null. */
+  lastThinkingAt: number | null
+  /** True once the 300s framework fallback has fired this turn. */
+  fallbackFired: boolean
+  /** Wall-clock ms of last poke fire — used for poke-success latency. */
+  lastPokeFiredAt: number | null
+}
+
+export interface ThresholdsMs {
+  soft: number
+  firm: number
+  fallback: number
+  /** Soft threshold when subagentDispatchActive=true. */
+  subagentSoft: number
+  /** How long after a poke we still count an outbound as a "success." */
+  pokeSuccessWindowMs: number
+}
+
+export const DEFAULT_THRESHOLDS: ThresholdsMs = {
+  soft: 75_000,
+  firm: 180_000,
+  fallback: 300_000,
+  subagentSoft: 300_000,
+  pokeSuccessWindowMs: 15_000,
+}
+
+export const DEFAULT_POLL_INTERVAL_MS = 5_000
+
+export interface FrameworkFallbackContext {
+  key: string
+  chatId: string
+  threadId: number | null
+  /** Picked from lastThinkingAt: 'thinking' if a thinking event landed in
+   *  the last 30s of silence, else 'working'. */
+  fallbackKind: 'working' | 'thinking'
+  silenceMs: number
+}
+
+export type SilencePokeMetric =
+  | { kind: 'silence_poke_fired'; key: string; level: PokeLevel; silence_ms: number; subagent_wait: boolean }
+  | { kind: 'silence_poke_succeeded'; key: string; level: PokeLevel; latency_ms: number }
+  | { kind: 'silence_fallback_sent'; key: string; fallback_kind: 'working' | 'thinking'; silence_ms: number }
+
+export interface SilencePokeDeps {
+  /** Called when the 300s fallback fires. Caller sends the user-visible
+   *  message + ensures it pings the device. Caller must NOT call back
+   *  into noteOutbound for this — it's a framework-sourced message,
+   *  not a model-sourced one, and we want pokes to continue (well, no,
+   *  fallbackFired ensures only one per turn anyway). */
+  onFrameworkFallback: (ctx: FrameworkFallbackContext) => Promise<void> | void
+  /** Telemetry sink for poke events. */
+  emitMetric: (event: SilencePokeMetric) => void
+  /** Threshold overrides (tests). */
+  thresholdsMs?: ThresholdsMs
+  /** Poll interval (tests). */
+  pollIntervalMs?: number
+}
+
+const state = new Map<string, SilencePokeState>()
+let timer: ReturnType<typeof setInterval> | null = null
+let activeDeps: SilencePokeDeps | null = null
+
+/**
+ * True iff the kill switch is OFF. Re-read every call so tests can
+ * toggle process.env without reloading the module.
+ */
+export function silencePokeEnabled(): boolean {
+  const v = process.env.SWITCHROOM_DISABLE_SILENCE_POKE
+  return !(v === '1' || v === 'true')
+}
+
+/**
+ * Initialise a fresh turn's silence state. No-op when kill switch is on.
+ */
+export function startTurn(key: string, now: number): void {
+  if (!silencePokeEnabled()) return
+  state.set(key, {
+    turnStartedAt: now,
+    lastOutboundAt: null,
+    pokesFired: 0,
+    pokeArmed: null,
+    subagentDispatchActive: false,
+    lastThinkingAt: null,
+    fallbackFired: false,
+    lastPokeFiredAt: null,
+  })
+}
+
+/**
+ * Record a fresh user-visible outbound message (reply or stream_reply
+ * first-emit). Resets the silence clock + the escalation counter. If a
+ * poke fired recently, emit a `silence_poke_succeeded` metric.
+ */
+export function noteOutbound(key: string, now: number): void {
+  const s = state.get(key)
+  if (s == null) return
+  // Success measurement: if a poke fired within the success window and
+  // an outbound just landed, count it as a successful poke.
+  const thresholds = activeDeps?.thresholdsMs ?? DEFAULT_THRESHOLDS
+  if (
+    s.lastPokeFiredAt != null
+    && (now - s.lastPokeFiredAt) <= thresholds.pokeSuccessWindowMs
+    && activeDeps != null
+    && s.pokesFired >= 1
+    && s.pokesFired <= 2
+  ) {
+    activeDeps.emitMetric({
+      kind: 'silence_poke_succeeded',
+      key,
+      level: s.pokesFired === 1 ? 'soft' : 'firm',
+      latency_ms: now - s.lastPokeFiredAt,
+    })
+  }
+  s.lastOutboundAt = now
+  s.pokesFired = 0
+  s.pokeArmed = null
+  s.subagentDispatchActive = false
+  s.lastPokeFiredAt = null
+  s.fallbackFired = false
+}
+
+/**
+ * Note that the model dispatched a sub-agent (Task tool, @worker, etc).
+ * Extends the soft threshold for THIS turn until the next outbound
+ * resets state.
+ */
+export function noteSubagentDispatch(key: string): void {
+  const s = state.get(key)
+  if (s == null) return
+  s.subagentDispatchActive = true
+}
+
+/**
+ * Record a `thinking` session event. Used to pick "still thinking…" vs
+ * "still working…" wording for the 300s framework fallback.
+ */
+export function noteThinking(key: string, now: number): void {
+  const s = state.get(key)
+  if (s == null) return
+  s.lastThinkingAt = now
+}
+
+/**
+ * Drain any armed poke for ANY active turn and return the system-reminder
+ * text to append. Returns null if nothing is armed.
+ *
+ * Called at the gateway's tool-result chokepoint; the appended reminder
+ * piggybacks the result back to claude. Drains the flag immediately so
+ * the next tool result doesn't double-inject.
+ *
+ * Iterates all keys because the tool result doesn't carry which turn it
+ * belongs to. In practice the gateway has ≤1 active turn at a time, but
+ * the code handles multi-turn correctly: each turn's poke text is
+ * appended once (and never appears in another turn's tool result, since
+ * we drain by mutating the matched state).
+ */
+export function consumeArmedPoke(): string | null {
+  for (const s of state.values()) {
+    if (s.pokeArmed != null) {
+      const level = s.pokeArmed.level
+      s.pokeArmed = null
+      return formatPokeText(level)
+    }
+  }
+  return null
+}
+
+/** End a turn — drop state. Idempotent. */
+export function endTurn(key: string): void {
+  state.delete(key)
+}
+
+/** Verbatim poke text. Wording is load-bearing — see issue #1122 design. */
+function formatPokeText(level: PokeLevel): string {
+  if (level === 'soft') {
+    return (
+      "[silence-poke] You've been silent to the user for 75s. If you're "
+      + "still working on this, send one short conversational reply — e.g. "
+      + "\"still going, working through X\" — so they know you're alive. "
+      + "Keep it brief; don't restate the task. If you're about to finish "
+      + 'within the next few seconds, skip the update.'
+    )
+  }
+  return (
+    "[silence-poke] 3 minutes silent. Please send an update now — what "
+    + "you're working on, or whether you're stuck. If something is taking "
+    + 'unusually long (slow tool, network, waiting on a sub-agent), say so '
+    + 'explicitly.'
+  )
+}
+
+/**
+ * Internal tick — iterates active states, arms pokes or fires fallback.
+ * Exported as __tickForTests so suite can step the clock deterministically.
+ */
+function tick(now: number): void {
+  if (activeDeps == null) return
+  const thresholds = activeDeps.thresholdsMs ?? DEFAULT_THRESHOLDS
+  for (const [key, s] of state.entries()) {
+    const zeroAt = s.lastOutboundAt ?? s.turnStartedAt
+    const silence = now - zeroAt
+    if (silence < 0) continue
+    const softThreshold = s.subagentDispatchActive
+      ? thresholds.subagentSoft
+      : thresholds.soft
+
+    if (s.pokesFired === 0 && silence >= softThreshold) {
+      s.pokeArmed = { level: 'soft' }
+      s.pokesFired = 1
+      s.lastPokeFiredAt = now
+      activeDeps.emitMetric({
+        kind: 'silence_poke_fired',
+        key,
+        level: 'soft',
+        silence_ms: silence,
+        subagent_wait: s.subagentDispatchActive,
+      })
+      continue
+    }
+
+    if (s.pokesFired === 1 && silence >= thresholds.firm) {
+      s.pokeArmed = { level: 'firm' }
+      s.pokesFired = 2
+      s.lastPokeFiredAt = now
+      activeDeps.emitMetric({
+        kind: 'silence_poke_fired',
+        key,
+        level: 'firm',
+        silence_ms: silence,
+        subagent_wait: s.subagentDispatchActive,
+      })
+      continue
+    }
+
+    if (s.pokesFired === 2 && !s.fallbackFired && silence >= thresholds.fallback) {
+      s.fallbackFired = true
+      s.pokesFired = 3
+      const { chatId, threadId } = parseKey(key)
+      const recentThinking = s.lastThinkingAt != null
+        && (now - s.lastThinkingAt) < 30_000
+      const fallbackKind: 'working' | 'thinking' = recentThinking ? 'thinking' : 'working'
+      activeDeps.emitMetric({
+        kind: 'silence_fallback_sent',
+        key,
+        fallback_kind: fallbackKind,
+        silence_ms: silence,
+      })
+      // Caller may throw or fail — guard so a busted fallback doesn't kill the timer.
+      try {
+        const r = activeDeps.onFrameworkFallback({
+          key,
+          chatId,
+          threadId,
+          fallbackKind,
+          silenceMs: silence,
+        })
+        if (r != null && typeof (r as Promise<void>).catch === 'function') {
+          ;(r as Promise<void>).catch((err) => {
+            process.stderr.write(
+              `silence-poke: framework fallback handler rejected: ${err}\n`,
+            )
+          })
+        }
+      } catch (err) {
+        process.stderr.write(
+          `silence-poke: framework fallback handler threw: ${err}\n`,
+        )
+      }
+    }
+  }
+}
+
+/**
+ * Parse `<chatId>:<threadIdOrEmpty>` back into structured fields. Matches
+ * the `statusKey` shape used throughout the gateway.
+ */
+function parseKey(key: string): { chatId: string; threadId: number | null } {
+  const idx = key.indexOf(':')
+  if (idx < 0) return { chatId: key, threadId: null }
+  const chatId = key.slice(0, idx)
+  const tail = key.slice(idx + 1)
+  if (tail === '' || tail === 'undefined') return { chatId, threadId: null }
+  const n = Number(tail)
+  return { chatId, threadId: Number.isFinite(n) ? n : null }
+}
+
+/**
+ * Start the timer. Idempotent — second call is a no-op. Stash deps so
+ * tick() can find them. Honours the kill switch.
+ */
+export function startTimer(deps: SilencePokeDeps): void {
+  if (!silencePokeEnabled()) return
+  if (timer != null) return
+  activeDeps = deps
+  const poll = deps.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS
+  timer = setInterval(() => tick(Date.now()), poll)
+  if (typeof timer.unref === 'function') timer.unref()
+}
+
+/** Stop the timer. Idempotent. */
+export function stopTimer(): void {
+  if (timer != null) {
+    clearInterval(timer)
+    timer = null
+  }
+  activeDeps = null
+}
+
+/** Test-only: drive a single tick at a deterministic clock value. */
+export function __tickForTests(now: number): void {
+  tick(now)
+}
+
+/** Test-only: install deps without starting the real timer. */
+export function __setDepsForTests(deps: SilencePokeDeps | null): void {
+  activeDeps = deps
+}
+
+/** Test-only: peek at state. */
+export function __getStateForTests(key: string): SilencePokeState | undefined {
+  return state.get(key)
+}
+
+/** Test-only: full reset. */
+export function __resetAllForTests(): void {
+  state.clear()
+  stopTimer()
+}

--- a/telegram-plugin/stream-controller.ts
+++ b/telegram-plugin/stream-controller.ts
@@ -81,6 +81,13 @@ export interface StreamSendOpts {
    * accept this parameter, so the controller omits it from edit opts.
    */
   protect_content?: boolean
+  /**
+   * When true, the initial `sendMessage` is silent (no device ping).
+   * Has no effect on `editMessageText` — Telegram never pings on edits.
+   * Used by mid-turn `stream_reply` calls under the #1122 conversational
+   * pacing redesign so only the final answer pings.
+   */
+  disable_notification?: boolean
 }
 
 export type RetryPolicy = <T>(
@@ -113,6 +120,11 @@ export interface StreamControllerConfig {
    * accept protect_content.
    */
   protectContent?: boolean
+  /**
+   * When true, the initial `sendMessage` is silent (no device ping).
+   * editMessageText never pings regardless. Default false. #1122.
+   */
+  disableNotification?: boolean
   /**
    * Inline keyboard markup attached to every send and edit. Without this,
    * editMessageText strips any previously attached keyboard. The progress-
@@ -228,6 +240,7 @@ export function createStreamController(cfg: StreamControllerConfig): DraftStream
         }
       : {}),
     ...(protectContent === true ? { protect_content: true } : {}),
+    ...(cfg.disableNotification === true ? { disable_notification: true } : {}),
   }
 
   // Strip parse_mode from a copy of opts — used for the parse-entities

--- a/telegram-plugin/stream-reply-handler.ts
+++ b/telegram-plugin/stream-reply-handler.ts
@@ -101,6 +101,12 @@ export interface StreamReplyArgs {
    */
   protect_content?: boolean
   /**
+   * When true, the INITIAL `sendMessage` is silent (no device ping).
+   * Edits never ping regardless. Used by mid-turn stream_reply calls
+   * under the #1122 conversational-pacing redesign. Default false.
+   */
+  disable_notification?: boolean
+  /**
    * Optional surgical quote text. When set along with `reply_to`, the initial
    * send includes `reply_parameters: { message_id, quote: { text, position: 0 } }`
    * so Telegram highlights the specific quoted sentence rather than the whole
@@ -508,6 +514,7 @@ export async function handleStreamReply(
       ...(replyToMessageId != null ? { replyToMessageId } : {}),
       ...(args.quote_text != null && replyToMessageId != null ? { quoteText: args.quote_text } : {}),
       ...(args.protect_content === true ? { protectContent: true } : {}),
+      ...(args.disable_notification === true ? { disableNotification: true } : {}),
       ...(args.reply_markup != null ? { replyMarkup: args.reply_markup } : {}),
       previewTransport: resolvedTransport,
       isPrivateChat: deps.isPrivateChat === true,

--- a/telegram-plugin/tests/silence-poke.test.ts
+++ b/telegram-plugin/tests/silence-poke.test.ts
@@ -1,0 +1,325 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import {
+  startTurn,
+  noteOutbound,
+  noteSubagentDispatch,
+  noteThinking,
+  consumeArmedPoke,
+  endTurn,
+  silencePokeEnabled,
+  __tickForTests,
+  __setDepsForTests,
+  __getStateForTests,
+  __resetAllForTests,
+  DEFAULT_THRESHOLDS,
+  type SilencePokeMetric,
+  type FrameworkFallbackContext,
+} from '../silence-poke.js'
+
+const ORIGINAL_KILL_SWITCH = process.env.SWITCHROOM_DISABLE_SILENCE_POKE
+
+interface TestFixtures {
+  emitted: SilencePokeMetric[]
+  fallbacks: FrameworkFallbackContext[]
+}
+
+function setupDeps(opts?: { thresholds?: Partial<typeof DEFAULT_THRESHOLDS> }): TestFixtures {
+  const fixtures: TestFixtures = { emitted: [], fallbacks: [] }
+  __setDepsForTests({
+    emitMetric: (e) => fixtures.emitted.push(e),
+    onFrameworkFallback: (ctx) => { fixtures.fallbacks.push(ctx) },
+    thresholdsMs: { ...DEFAULT_THRESHOLDS, ...(opts?.thresholds ?? {}) },
+  })
+  return fixtures
+}
+
+beforeEach(() => {
+  __resetAllForTests()
+  delete process.env.SWITCHROOM_DISABLE_SILENCE_POKE
+})
+
+afterEach(() => {
+  __resetAllForTests()
+  if (ORIGINAL_KILL_SWITCH != null) process.env.SWITCHROOM_DISABLE_SILENCE_POKE = ORIGINAL_KILL_SWITCH
+  else delete process.env.SWITCHROOM_DISABLE_SILENCE_POKE
+})
+
+describe('silence-poke — kill switch', () => {
+  it('startTurn is a no-op when SWITCHROOM_DISABLE_SILENCE_POKE=1', () => {
+    process.env.SWITCHROOM_DISABLE_SILENCE_POKE = '1'
+    expect(silencePokeEnabled()).toBe(false)
+    startTurn('k', 1000)
+    expect(__getStateForTests('k')).toBeUndefined()
+  })
+
+  it('startTurn is a no-op when SWITCHROOM_DISABLE_SILENCE_POKE=true', () => {
+    process.env.SWITCHROOM_DISABLE_SILENCE_POKE = 'true'
+    startTurn('k', 1000)
+    expect(__getStateForTests('k')).toBeUndefined()
+  })
+
+  it('is enabled when kill switch is unset', () => {
+    expect(silencePokeEnabled()).toBe(true)
+    startTurn('k', 1000)
+    expect(__getStateForTests('k')).toBeDefined()
+  })
+})
+
+describe('silence-poke — escalation ladder', () => {
+  it('soft poke fires at 75s', () => {
+    const fx = setupDeps()
+    startTurn('chat:0', 0)
+
+    __tickForTests(70_000) // before threshold
+    expect(consumeArmedPoke()).toBeNull()
+    expect(fx.emitted).toHaveLength(0)
+
+    __tickForTests(75_000) // at threshold
+    expect(fx.emitted).toEqual([
+      expect.objectContaining({ kind: 'silence_poke_fired', level: 'soft', subagent_wait: false }),
+    ])
+    const text = consumeArmedPoke()
+    expect(text).toContain('[silence-poke]')
+    expect(text).toContain('75s')
+  })
+
+  it('firm poke fires at 180s after soft', () => {
+    const fx = setupDeps()
+    startTurn('chat:0', 0)
+    __tickForTests(75_000)
+    consumeArmedPoke() // drain the soft
+    __tickForTests(180_000)
+    expect(fx.emitted.map((e) => e.kind)).toEqual([
+      'silence_poke_fired',
+      'silence_poke_fired',
+    ])
+    expect(fx.emitted[1]).toMatchObject({ level: 'firm' })
+    const firm = consumeArmedPoke()
+    expect(firm).toContain('3 minutes silent')
+  })
+
+  it('framework fallback fires at 300s with kind=working when no thinking signal', () => {
+    const fx = setupDeps()
+    startTurn('chatX:42', 0)
+    __tickForTests(75_000)
+    __tickForTests(180_000)
+    __tickForTests(300_000)
+    expect(fx.fallbacks).toEqual([
+      expect.objectContaining({ chatId: 'chatX', threadId: 42, fallbackKind: 'working' }),
+    ])
+    expect(fx.emitted.at(-1)).toMatchObject({ kind: 'silence_fallback_sent', fallback_kind: 'working' })
+  })
+
+  it('framework fallback fires with kind=thinking if a thinking event landed within 30s', () => {
+    const fx = setupDeps()
+    startTurn('c:0', 0)
+    noteThinking('c:0', 280_000)
+    __tickForTests(75_000)
+    __tickForTests(180_000)
+    __tickForTests(300_000)
+    expect(fx.fallbacks).toEqual([
+      expect.objectContaining({ fallbackKind: 'thinking' }),
+    ])
+  })
+
+  it('framework fallback fires at most once per turn', () => {
+    const fx = setupDeps()
+    startTurn('c:0', 0)
+    __tickForTests(75_000)
+    __tickForTests(180_000)
+    __tickForTests(300_000)
+    __tickForTests(450_000) // continued silence
+    __tickForTests(600_000)
+    expect(fx.fallbacks).toHaveLength(1)
+  })
+})
+
+describe('silence-poke — outbound resets clock + success measurement', () => {
+  it('noteOutbound resets the silence clock', () => {
+    setupDeps()
+    startTurn('k', 0)
+    noteOutbound('k', 50_000)
+    __tickForTests(120_000) // 70s after outbound — under 75s soft threshold
+    expect(consumeArmedPoke()).toBeNull()
+  })
+
+  it('emits silence_poke_succeeded when outbound lands within success window after a poke', () => {
+    const fx = setupDeps()
+    startTurn('k', 0)
+    __tickForTests(75_000) // soft poke armed
+    noteOutbound('k', 80_000) // 5s later — within 15s success window
+    expect(fx.emitted.map((e) => e.kind)).toContain('silence_poke_succeeded')
+    const success = fx.emitted.find((e) => e.kind === 'silence_poke_succeeded')!
+    expect(success).toMatchObject({ level: 'soft', latency_ms: 5_000 })
+  })
+
+  it('does NOT emit silence_poke_succeeded if outbound is later than the success window', () => {
+    const fx = setupDeps()
+    startTurn('k', 0)
+    __tickForTests(75_000)
+    noteOutbound('k', 95_000) // 20s later — outside 15s window
+    expect(fx.emitted.filter((e) => e.kind === 'silence_poke_succeeded')).toHaveLength(0)
+  })
+
+  it('outbound resets pokesFired so the next 75s silence can re-arm', () => {
+    const fx = setupDeps()
+    startTurn('k', 0)
+    __tickForTests(75_000) // soft fires
+    noteOutbound('k', 100_000) // reset
+    __tickForTests(180_000) // 80s since outbound — under threshold
+    __tickForTests(180_000 + 50_000) // would be 130s if not reset; still no fire because clock zero = 100_000, so silence = 130s
+    // Actually 230 - 100 = 130s past outbound, > 75s soft threshold:
+    expect(fx.emitted.filter((e) => e.kind === 'silence_poke_fired')).toHaveLength(2)
+    expect(fx.emitted.filter((e) => e.kind === 'silence_poke_fired').at(-1)).toMatchObject({ level: 'soft' })
+  })
+})
+
+describe('silence-poke — subagent dispatch extension', () => {
+  it('extends soft threshold to 300s when noteSubagentDispatch was called', () => {
+    const fx = setupDeps()
+    startTurn('k', 0)
+    noteSubagentDispatch('k')
+    __tickForTests(120_000) // past 75s but under 300s subagent threshold
+    expect(fx.emitted).toHaveLength(0)
+    __tickForTests(300_000)
+    expect(fx.emitted).toHaveLength(1)
+    expect(fx.emitted[0]).toMatchObject({ level: 'soft', subagent_wait: true })
+  })
+
+  it('subagent flag clears on outbound (after subagent reports back)', () => {
+    const fx = setupDeps()
+    startTurn('k', 0)
+    noteSubagentDispatch('k')
+    noteOutbound('k', 60_000) // simulate parent narrating "spinning up @reviewer"
+    // Now soft threshold should be 75s again
+    __tickForTests(60_000 + 80_000)
+    expect(fx.emitted.filter((e) => e.kind === 'silence_poke_fired')).toHaveLength(1)
+  })
+})
+
+describe('silence-poke — consumeArmedPoke draining', () => {
+  it('drains the armed flag so the next call returns null', () => {
+    setupDeps()
+    startTurn('k', 0)
+    __tickForTests(75_000)
+    expect(consumeArmedPoke()).not.toBeNull()
+    expect(consumeArmedPoke()).toBeNull()
+  })
+
+  it('returns null when nothing is armed', () => {
+    setupDeps()
+    startTurn('k', 0)
+    expect(consumeArmedPoke()).toBeNull()
+  })
+
+  it('returns the matching level text', () => {
+    setupDeps()
+    startTurn('k', 0)
+    __tickForTests(75_000)
+    expect(consumeArmedPoke()).toContain('75s')
+    __tickForTests(180_000)
+    expect(consumeArmedPoke()).toContain('3 minutes')
+  })
+})
+
+describe('silence-poke — endTurn cleanup', () => {
+  it('endTurn drops state', () => {
+    setupDeps()
+    startTurn('k', 0)
+    expect(__getStateForTests('k')).toBeDefined()
+    endTurn('k')
+    expect(__getStateForTests('k')).toBeUndefined()
+  })
+
+  it('endTurn on an unknown key is a no-op', () => {
+    setupDeps()
+    expect(() => endTurn('never-tracked')).not.toThrow()
+  })
+})
+
+describe('silence-poke — independence across turns', () => {
+  it('two turns in different chats fire independently', () => {
+    const fx = setupDeps()
+    startTurn('a:0', 0)
+    startTurn('b:0', 0)
+    noteOutbound('a:0', 50_000)
+    __tickForTests(75_000)
+    // a's clock was reset to 50_000, silence=25s — no fire.
+    // b's clock is still at 0, silence=75s — soft fires.
+    expect(fx.emitted).toHaveLength(1)
+    expect(fx.emitted[0]).toMatchObject({ key: 'b:0', level: 'soft' })
+  })
+})
+
+describe('silence-poke — fallback handler errors do not break timer', () => {
+  it('continues to function if onFrameworkFallback throws', () => {
+    const fx: TestFixtures = { emitted: [], fallbacks: [] }
+    __setDepsForTests({
+      emitMetric: (e) => fx.emitted.push(e),
+      onFrameworkFallback: () => { throw new Error('oh no') },
+      thresholdsMs: DEFAULT_THRESHOLDS,
+    })
+    startTurn('k', 0)
+    expect(() => {
+      __tickForTests(75_000)
+      __tickForTests(180_000)
+      __tickForTests(300_000)
+    }).not.toThrow()
+    // Telemetry still emitted
+    expect(fx.emitted.some((e) => e.kind === 'silence_fallback_sent')).toBe(true)
+  })
+
+  it('continues to function if onFrameworkFallback returns a rejected promise', async () => {
+    const fx: TestFixtures = { emitted: [], fallbacks: [] }
+    __setDepsForTests({
+      emitMetric: (e) => fx.emitted.push(e),
+      onFrameworkFallback: () => Promise.reject(new Error('async fail')),
+      thresholdsMs: DEFAULT_THRESHOLDS,
+    })
+    startTurn('k', 0)
+    __tickForTests(75_000)
+    __tickForTests(180_000)
+    __tickForTests(300_000)
+    // Allow microtasks for the rejection-catch to fire
+    await new Promise((r) => setTimeout(r, 0))
+    expect(fx.emitted.some((e) => e.kind === 'silence_fallback_sent')).toBe(true)
+  })
+})
+
+describe('silence-poke — system reminder text', () => {
+  it('soft poke text references the 75s threshold and contains the system-reminder marker', () => {
+    setupDeps()
+    startTurn('k', 0)
+    __tickForTests(75_000)
+    const text = consumeArmedPoke()
+    expect(text).toContain('[silence-poke]')
+    expect(text).toContain('75s')
+    expect(text).toContain('about to finish')
+  })
+
+  it('firm poke text references the 3-minute threshold', () => {
+    setupDeps()
+    startTurn('k', 0)
+    __tickForTests(75_000)
+    consumeArmedPoke()
+    __tickForTests(180_000)
+    const text = consumeArmedPoke()
+    expect(text).toContain('3 minutes')
+    expect(text).toContain('stuck')
+  })
+})
+
+describe('silence-poke — performance', () => {
+  it('tick over many active turns stays fast', () => {
+    setupDeps()
+    for (let i = 0; i < 1000; i++) {
+      startTurn(`chat${i}:0`, 0)
+    }
+    const start = performance.now()
+    __tickForTests(75_000)
+    const elapsed = performance.now() - start
+    // 1000 turns should tick in well under 50ms — guards against an
+    // accidentally-quadratic implementation.
+    expect(elapsed).toBeLessThan(50)
+  })
+})


### PR DESCRIPTION
## Summary

The behavioural half of the conversational-turn-UX redesign (#1122). Three additive changes; **progress card still runs alongside** (PR3 deletes it). Kill switch on the new subsystem.

### 1. Conversational pacing prompt

Rewrites `profiles/_shared/telegram-style.md.hbs`'s "When to use stream_reply vs reply" section into a concise rhythm spec:

- Soft commit (one short `reply`) if work will take >15s
- Mid-turn updates only at meaningful punctuation — finished a hard step, hit a blocker, dispatching a sub-agent, found something worth surfacing. **Not** on every tool call. **Not** on a cadence.
- Mid-turn updates pass `disable_notification: true` — only the final answer pings
- Sub-agent dispatches narrated in chat (*"spinning up @reviewer"*), summarised when they report back
- `[silence-poke]` system reminders mean send a brief update unless seconds from finishing
- `stream_reply` reserved for content that benefits from streaming (long prose, code blocks) — not for "show progress" theatre

Net delta: +706 bytes. Concise on purpose — verbose prompts hurt model performance.

### 2. `disable_notification` parameter

Added to both `reply` and `stream_reply` MCP schemas at `bridge.ts:98-180`. Auto-discovered via MCP ListTools, so claude sees the new param immediately without a separate schema rev. Default false (back-compat: existing call-sites still ping). Plumbed through `stream-controller.ts` so stream_reply's first send honours it; subsequent edits never ping regardless.

### 3. Silence-poke subsystem

New file `telegram-plugin/silence-poke.ts` (~340 lines). The framework safety net for "model is silent to user for too long" — replaces what the progress card was implicitly doing.

**Two clocks:**
- `silence = now - lastOutboundAt` (or turnStartedAt if no outbound yet) — this module owns it
- Idle clock = legacy stall tracker, untouched

**Escalation per turn:**
- **t=75s** — soft poke armed, piggybacked on the next tool result as a `<system-reminder>` containing `[silence-poke]`. Nudges the model to send a brief update.
- **t=180s** — firm poke (stronger wording).
- **t=300s** — **framework fallback**: gateway itself sends *"still working… (no update from agent in 5 min)"* or *"still thinking…"* (chosen by recent thinking-token activity). Pings the device. Fires at most once per turn.

**Subagent-dispatch extension:** when the session stream emits a `tool_use` for `Task` or `Agent`, the soft threshold extends to 300s for that turn (legitimate wait on a child).

**Kill switch:** `SWITCHROOM_DISABLE_SILENCE_POKE=1` disables timer + injection + fallback. Prompt stays in effect.

### Wire-up sites (gateway.ts)

| Site | Purpose |
|---|---|
| Boot (just before `createIpcServer`) | `silencePoke.startTimer(...)` with framework-fallback callback |
| `onToolCall` (the chokepoint at line 2589) | `consumeArmedPoke()` + append `<system-reminder>` to `result.content[0].text` |
| `onSessionEvent` | `noteThinking` on thinking events; `noteSubagentDispatch` on Task/Agent `tool_use` |
| Inbound fresh-turn handler | `startTurn` |
| `executeReply` + stream_reply first-emit | `noteOutbound` (in addition to existing `signalTracker.noteOutbound`) |
| Both turn_end paths (silent + reply) | `endTurn` |

### Telemetry (extends PR1 runtime-metrics.ts)

Three new events fanned out to PostHog + JSONL:

- `silence_poke_fired` { level: soft/firm, silence_ms, subagent_wait }
- `silence_poke_succeeded` { level, latency_ms } — outbound landed within 15s after a poke fired (poke worked)
- `silence_fallback_sent` { fallback_kind: working/thinking, silence_ms } — rare; >5 per 1000 turns is a design-health alarm

### Test plan

- [x] `bun test telegram-plugin/tests/silence-poke.test.ts` — 25 tests covering kill switch, escalation ladder, subagent extension, outbound reset + success measurement, drain semantics, multi-turn independence, error-handler isolation, performance (1000 turns/tick).
- [x] `npm run test:vitest` — 5837 pass, 50 skipped (full suite). Existing `scaffold.persona.test.ts` size-cap test still passes (prompt rewrite was trimmed to stay under 32KB).
- [x] `npm run test:bun` — 709 pass, 2 skip, 0 fail.
- [x] `npm run lint` — tsc + plugin-references + bot-api-wrapping all clean (allowlist line-ranges bumped for the 4 pre-existing raw `bot.api.*` sites whose line numbers shifted; no new raw calls introduced).
- [x] `bun run build` — bundles cleanly.

### What's next

- **PR3**: delete the progress card (`progress-card.ts`, `progress-card-driver.ts`, `two-zone-card.ts`, pin manager/watchdog, related tests, the `progress_card.delay_ms` config block). The conversational pacing + silence-poke replaces what the card was doing; running both is duplicative.
- **PR4**: `/lasttrace` command, `switchroom debug turn` extension to surface poke fires, reference doc rewrites (`know-what-my-agent-is-doing.md`, `principles.md`, archive `status-card-design.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)