### PR TITLE
fix(telegram-ux): restore mandatory-reply imperative (hotfix #1122)

### DIFF
--- a/profiles/_shared/telegram-style.md.hbs
+++ b/profiles/_shared/telegram-style.md.hbs
@@ -2,6 +2,8 @@
 
 Telegram is a chat — replies should feel like one, not a terminal dump or a tracking widget. A good chat partner acknowledges, goes quiet while working, surfaces meaningful updates, and delivers the answer when it's ready. Match that rhythm.
 
+**Every turn that responds to a user message MUST end with a `reply` (or `stream_reply` with `done=true`).** The user is on Telegram — they don't see your CLI output, tool-use trace, or inline thinking. The ONLY path for words to reach them is an MCP tool call. If you have a final answer, send it via `reply`. The text in your terminal is not the conversation.
+
 **Conversational pacing.**
 - **Soft commit if work will take >15s.** One short `reply`: *"let me check, back in a few"*, *"on it"*. Match persona tone. Skip for fast turns — the answer itself is the signal.
 - **Mid-turn updates at meaningful punctuation only.** Finished a hard step; hit a blocker; pivoting; dispatching a sub-agent; waiting on a slow tool; found something worth surfacing. **Not** on every tool call, **not** on a cadence, **not** to fill silence — the reaction on the user's inbound message already signals alive.


### PR DESCRIPTION
## Production regression

After PR2 (#1125) rewrote the conversational-pacing prompt, the model began producing answers in its CLI terminal but **never calling the `reply` MCP tool**. The user saw:
- 👀 reaction fires
- Agent works for 35s, tool-uses, reasons
- Then silence — no Telegram message ever sent

The model's answer was sitting in claude's own session output, never reaching Telegram.

## Root cause

The PR2 rewrite said:
> **`reply`** is the default. Use for soft-commits, mid-turn updates, sub-agent narration, final answers.

This is *descriptive*. The previous prompt said:
> Default to `stream_reply` for any response that requires tool calls before you can finalize the answer.

That was *imperative*. The model interpreted the descriptive framing as permissive — the answer in its own session was sufficient. It wasn't.

## Fix

Prepend a strong, unambiguous mandatory-reply imperative at the top of the section, before any pacing nuance. Frames the constraint in terms the model can't reinterpret:

> **Every turn that responds to a user message MUST end with a `reply` (or `stream_reply` with `done=true`).** The user is on Telegram — they don't see your CLI output, tool-use trace, or inline thinking. The ONLY path for words to reach them is an MCP tool call. If you have a final answer, send it via `reply`. The text in your terminal is not the conversation.

## Test plan

- [x] `npm run lint` — tsc + plugin-references + bot-api-wrapping clean.
- [x] `tests/scaffold.persona.test.ts` size cap — passes (CLAUDE.md stays under 32KB).
- No other tests affected (pure prompt change).

## Rollout

After merge: rebuild + `switchroom apply` + `switchroom agent restart all` to push the corrected prompt to every running agent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)