### PR TITLE
fix(telegram-ux): restore deterministic silent-end + turn-active cleanup PR3 removed

### DIFF
--- a/scripts/check-bot-api-wrapping.sh
+++ b/scripts/check-bot-api-wrapping.sh
@@ -87,7 +87,7 @@ ALLOWLIST=(
   "telegram-plugin/gateway/gateway.ts:3125-3160:reply chunk-loop THREAD_NOT_FOUND fallback (intentional raw)"
 
   # credit-watch notification. No thread_id (DM).
-  "telegram-plugin/gateway/gateway.ts:8020-8055:credit-watch notify; no thread_id"
+  "telegram-plugin/gateway/gateway.ts:8020-8070:credit-watch notify; no thread_id"
 
   # gateway.ts:9260-9490 — ctx.api.editMessageText for vault grant wizard
   # cards. Every callsite has `.catch(() => {})` — a THREAD_NOT_FOUND

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -73,6 +73,7 @@ import {
 import { emitRuntimeMetric } from '../runtime-metrics.js'
 import { classifyInbound } from '../inbound-classifier.js'
 import * as silencePoke from '../silence-poke.js'
+import { writeSilentEndState, clearSilentEndState } from '../silent-end.js'
 import { createAnswerStream, type AnswerStreamHandle } from '../answer-stream.js'
 import { type SessionEvent } from '../session-tail.js'
 import {
@@ -3053,8 +3054,12 @@ async function executeReply(args: Record<string, unknown>): Promise<{ content: A
   // #1122 KPI: a `reply` always produces a fresh user-visible outbound
   // message — count it for the outbound-gap / TTFO KPI AND reset the
   // silence-poke clock so the next poke is measured from this send.
+  // Also clear any silent-end state file so the Stop hook doesn't fire
+  // a stale block when the session ends (deterministic restore of the
+  // detection PR3 inadvertently removed).
   signalTracker.noteOutbound(statusKey(chat_id, threadId), Date.now())
   silencePoke.noteOutbound(statusKey(chat_id, threadId), Date.now())
+  clearSilentEndState(statusKey(chat_id, threadId))
 
   if (previewMessageId != null && reply_to != null && replyMode !== 'off') {
     await deleteStalePreview(previewMessageId)
@@ -3343,6 +3348,7 @@ async function executeStreamReply(args: Record<string, unknown>): Promise<unknow
       const sKey = statusKey(streamChatId, streamThreadId)
       signalTracker.noteOutbound(sKey, Date.now())
       silencePoke.noteOutbound(sKey, Date.now())
+      clearSilentEndState(sKey)
     }
   }
 
@@ -4854,6 +4860,26 @@ function handleSessionEvent(ev: SessionEvent): void {
             longest_silent_gap_ms: outboundMetrics.longestOutboundGapMs,
             ended_via: 'silent',
           })
+          // #1122 PR4 fix: deterministic silent-end detection for the
+          // Stop hook. PR3 deleted the writer with the progress card;
+          // this restores it. If the user-message turn ended without
+          // any outbound, write the state file so silent-end-interrupt
+          // -stop.mjs blocks the stop and re-prompts the agent.
+          if (outboundMetrics.outboundCount === 0) {
+            writeSilentEndState({
+              chatId,
+              threadId: threadId ?? null,
+              turnKey: tKey,
+            })
+          }
+          // #1122 PR4 fix: PR3 removed the progressDriver.onTurnComplete
+          // callback that cleared the turn-active marker on silent-marker
+          // turns. The main turn-end path at ~line 5180 has its own
+          // cleanup (#550 defence-in-depth) but the silent-marker path
+          // relied solely on the driver callback. Without this the
+          // bridge-watchdog (#412) reads a stale marker and could
+          // false-positive wedge-detection across silent turns.
+          try { removeTurnActiveMarker(STATE_DIR) } catch { /* best-effort */ }
           signalTracker.clear(tKey)
           silencePoke.endTurn(tKey)
         }
@@ -5094,6 +5120,17 @@ function handleSessionEvent(ev: SessionEvent): void {
           longest_silent_gap_ms: outboundMetrics.longestOutboundGapMs,
           ended_via: outboundMetrics.outboundCount > 0 ? 'reply' : 'silent',
         })
+        // #1122 PR4 fix: deterministic silent-end detection (see the
+        // silent-marker path above for the rationale). The Stop hook
+        // reads the file we write here and blocks the session-end so
+        // the agent can be re-prompted to call reply.
+        if (outboundMetrics.outboundCount === 0) {
+          writeSilentEndState({
+            chatId,
+            threadId: threadId ?? null,
+            turnKey: tKey,
+          })
+        }
         signalTracker.clear(tKey)
         silencePoke.endTurn(tKey)
       }

--- a/telegram-plugin/silent-end.ts
+++ b/telegram-plugin/silent-end.ts
@@ -1,0 +1,151 @@
+/**
+ * silent-end.ts — gateway-side state-file writer for the Stop hook.
+ *
+ * The Stop hook (`telegram-plugin/hooks/silent-end-interrupt-stop.mjs`)
+ * reads `$TELEGRAM_STATE_DIR/silent-end-pending.json` to decide whether
+ * to block-and-re-prompt or allow the session to end. Pre-#1122 PR3 the
+ * file was written from inside the progress-card driver's `onSilentEnd`
+ * callback. PR3 deleted the driver and accidentally removed the writer.
+ * The hook still ran on every Stop, but the file never appeared, so the
+ * hook always allowed the stop → users could ask a question, see 👀
+ * fire, and then get nothing back if the model failed to call `reply`.
+ *
+ * This module is the deterministic replacement. The gateway calls
+ * `writeSilentEndState(...)` when a fresh user-message turn ends with
+ * zero outbound messages, and `clearSilentEndState(...)` the moment a
+ * reply lands. The Stop hook reads the same file and makes its
+ * decision — no prompt dependency, no model behaviour required.
+ *
+ * Retry semantics: on first silent-end the hook blocks the stop with
+ * a re-prompt; on the second silent-end (retryCount >= MAX_RETRIES in
+ * the hook) the hook lets the session end. We inherit retryCount from
+ * any prior state file IFF the prior file's `turnKey` matches — a new
+ * turn always starts at retryCount=0.
+ *
+ * The state file is per-agent (each agent has its own
+ * TELEGRAM_STATE_DIR), so two agents going silent at the same time
+ * don't collide.
+ */
+
+import { existsSync, readFileSync, writeFileSync, unlinkSync } from 'node:fs'
+import { join } from 'node:path'
+
+export interface SilentEndState {
+  /** The chat the silent turn was for — used by operator-facing diagnostics. */
+  chatId: string
+  /** Optional forum thread id, stringified or null. */
+  threadId: number | null
+  /** Stable identifier for the in-flight turn (statusKey shape). */
+  turnKey: string
+  /** Incremented each time the Stop hook blocks for this turn. */
+  retryCount: number
+  /** Wall-clock ms of last write. */
+  timestamp: number
+}
+
+export interface SilentEndDeps {
+  /** State dir root (defaults to `TELEGRAM_STATE_DIR` env). */
+  stateDir?: string
+  /** stderr writer (defaults to `process.stderr.write`). */
+  log?: (line: string) => void
+}
+
+function resolveStateDir(deps?: SilentEndDeps): string | null {
+  if (deps?.stateDir != null) return deps.stateDir
+  const env = process.env.TELEGRAM_STATE_DIR
+  return env != null && env !== '' ? env : null
+}
+
+function resolveStatePath(deps?: SilentEndDeps): string | null {
+  const dir = resolveStateDir(deps)
+  if (dir == null) return null
+  return join(dir, 'silent-end-pending.json')
+}
+
+function emitLog(deps: SilentEndDeps | undefined, line: string): void {
+  if (deps?.log != null) deps.log(line)
+  else process.stderr.write(line)
+}
+
+/**
+ * Write the silent-end state file for the given turn. Inherits
+ * retryCount from a prior write IFF the prior write's turnKey matches.
+ * Otherwise resets to 0.
+ *
+ * No-op when `TELEGRAM_STATE_DIR` is unset (host-side / out-of-container
+ * contexts).
+ */
+export function writeSilentEndState(
+  args: { chatId: string; threadId: number | null; turnKey: string },
+  deps?: SilentEndDeps,
+): void {
+  const statePath = resolveStatePath(deps)
+  if (statePath == null) return
+  let retryCount = 0
+  try {
+    if (existsSync(statePath)) {
+      const prev = JSON.parse(readFileSync(statePath, 'utf8')) as Partial<SilentEndState>
+      if (prev.turnKey === args.turnKey && typeof prev.retryCount === 'number') {
+        retryCount = prev.retryCount
+      }
+    }
+  } catch {
+    retryCount = 0
+  }
+  const state: SilentEndState = {
+    chatId: args.chatId,
+    threadId: args.threadId,
+    turnKey: args.turnKey,
+    retryCount,
+    timestamp: Date.now(),
+  }
+  try {
+    writeFileSync(statePath, JSON.stringify(state), 'utf8')
+    emitLog(
+      deps,
+      `silent-end: wrote state file turnKey=${args.turnKey} retryCount=${retryCount}\n`,
+    )
+  } catch (err) {
+    emitLog(
+      deps,
+      `silent-end: failed to write state file: ${(err as Error).message}\n`,
+    )
+  }
+}
+
+/**
+ * Clear the silent-end state file IFF it belongs to the given turnKey.
+ * Called the moment a reply / stream_reply first-emit lands so the
+ * Stop hook doesn't fire a stale block on the next stop.
+ *
+ * Fail-silent: missing file, mismatched turnKey, or read/unlink errors
+ * are all benign. The Stop hook itself defends against stale files via
+ * the retryCount mechanism.
+ */
+export function clearSilentEndState(turnKey: string, deps?: SilentEndDeps): void {
+  const statePath = resolveStatePath(deps)
+  if (statePath == null) return
+  if (!existsSync(statePath)) return
+  try {
+    const prev = JSON.parse(readFileSync(statePath, 'utf8')) as Partial<SilentEndState>
+    if (prev.turnKey !== turnKey) return
+    unlinkSync(statePath)
+    emitLog(deps, `silent-end: cleared state file turnKey=${turnKey}\n`)
+  } catch {
+    // best-effort
+  }
+}
+
+/**
+ * Read the state file (for tests + diagnostics). Returns null when
+ * absent or unparsable.
+ */
+export function readSilentEndState(deps?: SilentEndDeps): SilentEndState | null {
+  const statePath = resolveStatePath(deps)
+  if (statePath == null || !existsSync(statePath)) return null
+  try {
+    return JSON.parse(readFileSync(statePath, 'utf8')) as SilentEndState
+  } catch {
+    return null
+  }
+}

--- a/telegram-plugin/tests/silent-end.test.ts
+++ b/telegram-plugin/tests/silent-end.test.ts
@@ -1,0 +1,190 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, readFileSync, existsSync, rmSync, writeFileSync, mkdirSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { execFileSync } from 'node:child_process'
+import {
+  writeSilentEndState,
+  clearSilentEndState,
+  readSilentEndState,
+} from '../silent-end.js'
+
+let stateDir: string
+const ORIG_ENV = process.env.TELEGRAM_STATE_DIR
+
+beforeEach(() => {
+  stateDir = mkdtempSync(join(tmpdir(), 'silent-end-test-'))
+  process.env.TELEGRAM_STATE_DIR = stateDir
+})
+
+afterEach(() => {
+  rmSync(stateDir, { recursive: true, force: true })
+  if (ORIG_ENV != null) process.env.TELEGRAM_STATE_DIR = ORIG_ENV
+  else delete process.env.TELEGRAM_STATE_DIR
+})
+
+describe('silent-end.ts — gateway state writer', () => {
+  it('writeSilentEndState creates the file with retryCount=0 on first write', () => {
+    writeSilentEndState({ chatId: '123', threadId: null, turnKey: '123:_' })
+    const state = readSilentEndState()
+    expect(state).not.toBeNull()
+    expect(state!.chatId).toBe('123')
+    expect(state!.threadId).toBeNull()
+    expect(state!.turnKey).toBe('123:_')
+    expect(state!.retryCount).toBe(0)
+    expect(typeof state!.timestamp).toBe('number')
+  })
+
+  it('writeSilentEndState inherits retryCount IFF the prior file matches the same turnKey', () => {
+    // Prior file at retryCount=1 for the same turn (Stop hook had already
+    // blocked once and re-incremented).
+    const path = join(stateDir, 'silent-end-pending.json')
+    writeFileSync(path, JSON.stringify({
+      chatId: '123', threadId: null, turnKey: '123:_', retryCount: 1, timestamp: 0,
+    }))
+    writeSilentEndState({ chatId: '123', threadId: null, turnKey: '123:_' })
+    expect(readSilentEndState()!.retryCount).toBe(1)
+  })
+
+  it('writeSilentEndState resets retryCount to 0 when turnKey differs', () => {
+    const path = join(stateDir, 'silent-end-pending.json')
+    writeFileSync(path, JSON.stringify({
+      chatId: '123', threadId: null, turnKey: '123:_', retryCount: 1, timestamp: 0,
+    }))
+    // Different turn — new silent-end, fresh counter.
+    writeSilentEndState({ chatId: '999', threadId: 42, turnKey: '999:42' })
+    const state = readSilentEndState()
+    expect(state!.turnKey).toBe('999:42')
+    expect(state!.retryCount).toBe(0)
+  })
+
+  it('writeSilentEndState is a no-op when TELEGRAM_STATE_DIR is unset', () => {
+    delete process.env.TELEGRAM_STATE_DIR
+    writeSilentEndState({ chatId: '123', threadId: null, turnKey: '123:_' })
+    expect(existsSync(join(stateDir, 'silent-end-pending.json'))).toBe(false)
+  })
+
+  it('clearSilentEndState removes the file when turnKey matches', () => {
+    writeSilentEndState({ chatId: '123', threadId: null, turnKey: '123:_' })
+    expect(existsSync(join(stateDir, 'silent-end-pending.json'))).toBe(true)
+    clearSilentEndState('123:_')
+    expect(existsSync(join(stateDir, 'silent-end-pending.json'))).toBe(false)
+  })
+
+  it('clearSilentEndState leaves the file alone when turnKey does NOT match', () => {
+    writeSilentEndState({ chatId: '123', threadId: null, turnKey: '123:_' })
+    clearSilentEndState('different-turn')
+    expect(existsSync(join(stateDir, 'silent-end-pending.json'))).toBe(true)
+  })
+
+  it('clearSilentEndState is a no-op when no file exists', () => {
+    expect(() => clearSilentEndState('123:_')).not.toThrow()
+  })
+
+  it('clearSilentEndState is a no-op when TELEGRAM_STATE_DIR is unset', () => {
+    delete process.env.TELEGRAM_STATE_DIR
+    expect(() => clearSilentEndState('123:_')).not.toThrow()
+  })
+
+  it('writeSilentEndState handles corrupt prior file by resetting retryCount', () => {
+    const path = join(stateDir, 'silent-end-pending.json')
+    writeFileSync(path, 'not valid json {{{')
+    writeSilentEndState({ chatId: '123', threadId: null, turnKey: '123:_' })
+    expect(readSilentEndState()!.retryCount).toBe(0)
+  })
+
+  it('round-trip: write → read → clear', () => {
+    writeSilentEndState({ chatId: 'c', threadId: 7, turnKey: 'c:7' })
+    const state = readSilentEndState()
+    expect(state).toMatchObject({ chatId: 'c', threadId: 7, turnKey: 'c:7', retryCount: 0 })
+    clearSilentEndState('c:7')
+    expect(readSilentEndState()).toBeNull()
+  })
+})
+
+describe('silent-end-interrupt-stop hook — integration', () => {
+  const hookPath = join(__dirname, '..', 'hooks', 'silent-end-interrupt-stop.mjs')
+
+  function runHook(input: object): { exit: number; stdout: string; stderr: string } {
+    const { spawnSync } = require('node:child_process') as typeof import('node:child_process')
+    const r = spawnSync('node', [hookPath], {
+      input: JSON.stringify(input),
+      env: { ...process.env, TELEGRAM_STATE_DIR: stateDir },
+      encoding: 'utf8',
+      timeout: 5_000,
+    })
+    return { exit: r.status ?? 1, stdout: r.stdout ?? '', stderr: r.stderr ?? '' }
+  }
+
+  it('allows the stop when no state file exists (normal completion)', () => {
+    const r = runHook({
+      session_id: 's',
+      transcript_path: '/tmp/x.jsonl',
+      hook_event_name: 'Stop',
+    })
+    expect(r.exit).toBe(0)
+    expect(r.stdout.trim()).toBe('')
+  })
+
+  it('blocks the stop with decision:block when silent-end state exists at retryCount=0', () => {
+    writeSilentEndState({ chatId: 'c', threadId: null, turnKey: 'c:_' })
+    const r = runHook({
+      session_id: 's',
+      transcript_path: '/tmp/x.jsonl',
+      hook_event_name: 'Stop',
+    })
+    expect(r.exit).toBe(0)
+    const out = JSON.parse(r.stdout.trim())
+    expect(out.decision).toBe('block')
+    expect(out.reason).toContain('reply')
+    // retryCount must have been incremented to 1
+    expect(readSilentEndState()!.retryCount).toBe(1)
+  })
+
+  it('allows the stop when retryCount >= MAX_RETRIES (1)', () => {
+    const path = join(stateDir, 'silent-end-pending.json')
+    writeFileSync(path, JSON.stringify({
+      chatId: 'c', threadId: null, turnKey: 'c:_', retryCount: 1, timestamp: 0,
+    }))
+    const r = runHook({
+      session_id: 's',
+      transcript_path: '/tmp/x.jsonl',
+      hook_event_name: 'Stop',
+    })
+    expect(r.exit).toBe(0)
+    expect(r.stdout.trim()).toBe('')
+    expect(r.stderr).toContain('retry exhausted')
+  })
+
+  it('end-to-end: write silent-end → hook blocks → simulate reply → next stop allows', () => {
+    // 1. Turn ends silently — gateway writes state
+    writeSilentEndState({ chatId: 'c', threadId: null, turnKey: 'c:_' })
+
+    // 2. Stop hook fires, blocks, increments retryCount
+    const r1 = runHook({ session_id: 's', transcript_path: '/tmp/x.jsonl', hook_event_name: 'Stop' })
+    expect(JSON.parse(r1.stdout).decision).toBe('block')
+    expect(readSilentEndState()!.retryCount).toBe(1)
+
+    // 3. Re-prompted agent calls reply — gateway clears the file
+    clearSilentEndState('c:_')
+    expect(readSilentEndState()).toBeNull()
+
+    // 4. Next Stop allows cleanly (no state file)
+    const r2 = runHook({ session_id: 's', transcript_path: '/tmp/x.jsonl', hook_event_name: 'Stop' })
+    expect(r2.stdout.trim()).toBe('')
+  })
+
+  it('fails open on a corrupt state file', () => {
+    const path = join(stateDir, 'silent-end-pending.json')
+    mkdirSync(stateDir, { recursive: true })
+    writeFileSync(path, 'corrupt {{{', 'utf8')
+    const r = runHook({ session_id: 's', transcript_path: '/tmp/x.jsonl', hook_event_name: 'Stop' })
+    expect(r.exit).toBe(0)
+    expect(r.stdout.trim()).toBe('')
+  })
+
+  it('fails open on empty stdin', () => {
+    const r = runHook({}) // serialised as `{}` — but the hook also tolerates empty
+    expect(r.exit).toBe(0)
+  })
+})


### PR DESCRIPTION
## What broke

User asked an agent a question post-#1122 rollout, got no Telegram reply. Gateway logs confirmed: 👀 fired, agent worked for 35s + tool-used, then went silent. The model wrote a complete answer in its CLI session but never called \`reply\` / \`stream_reply\`.

The earlier hotfix (#1128) addressed the prompt — adding a hard "you MUST call reply" imperative. But the user pointed out the right question: **can this be deterministic via Claude Code hooks instead of prompt-dependent?** Yes — and there's already a Stop hook (\`telegram-plugin/hooks/silent-end-interrupt-stop.mjs\`) designed exactly for this. PR3 deleted the **writer** of the state file it reads. Hook ran on every Stop; state file was never written; hook always allowed the stop.

## What this restores

Audited PR3's deletion site (the \`createProgressDriver({…})\` block). Found two pieces of load-bearing logic that came out with the card and weren't card-specific:

### 1. \`onSilentEnd\` → \`silent-end-pending.json\` writer

The Stop hook reads this file to decide between block-and-re-prompt vs. allow-stop. Restoration: new \`telegram-plugin/silent-end.ts\` module with \`writeSilentEndState\` / \`clearSilentEndState\`. Called at:

- The two turn-end emission sites (silent-marker path + main turn-end path) when \`outboundCount === 0\` → writes the state file
- The two \`noteOutbound\` sites (reply + stream_reply first-emit) → clears the state file

Mirrors the deleted retryCount-inheritance semantics: a fresh write inherits retryCount from a prior file IFF \`turnKey\` matches (so the hook's increment-and-retry pattern keeps working).

### 2. \`removeTurnActiveMarker\` for the silent-marker path

#412's bridge-watchdog uses the turn-active marker to distinguish wedged-mid-turn from healthy-idle. The main turn-end path at \`gateway.ts:5180\` had its own \`removeTurnActiveMarker\` call (#550 defence-in-depth) — that survived. The silent-marker path relied **solely** on the deleted driver callback. Now it has its own cleanup too.

## Tests

16 new tests (\`telegram-plugin/tests/silent-end.test.ts\`):

- **Unit:** \`silent-end.ts\` retryCount inheritance, turnKey isolation, corrupt-file recovery, missing \`TELEGRAM_STATE_DIR\` no-op.
- **Hook integration:** spawn the actual \`silent-end-interrupt-stop.mjs\` child process, feed it the JSON the Stop hook event delivers, assert exit / stdout / stderr.
- **End-to-end:** silent-end → block → re-prompt → reply lands → next stop allows cleanly. **This is the test that would have caught PR3's gap.**

Build / lint / full vitest (5455 pass) / full bun (709 pass) clean.

## What I'm deferring (acknowledged)

- **\`writeLastTurnSummary\` → \`.last-turn-summary\` sidecar.** Was a fallback for the handoff-continuity line when the primary summarizer (\`switchroom handoff\`, run by start.sh) didn't fire. Soft degradation — not breaking anything. Restore in a follow-up.
- **\`✅ Done — {summary}\` per-turn forum-thread message.** Card-coupled per-turn confirmation. Intentionally retired in the new conversational-pacing model (the answer itself is the done signal).

## What's missing structurally (per user's other criticism)

You're right that the right defense against "behavioral regression slipping through" is a UAT harness — a test that spins up the real gateway against a fake bot and asserts a user-message turn produces a Telegram outbound. Switchroom has \`telegram-plugin/uat/login.ts\` + \`uat/driver-info.ts\` as starting scaffolding. A \`uat/conversational-pacing.ts\` scenario script that fires synthetic inbounds and asserts a \`reply\` lands within N seconds (with sub-cases for silent-poke, sub-agent dispatch, silent-end-then-recover) would have caught this in seconds before merge. Worth tracking as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)