### PR TITLE
fix(scaffold): re-render CLAUDE.md when profile template changes (#1122)

### DIFF
--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -16,6 +16,7 @@ import {
 import { homedir } from "node:os";
 import { execSync, execFileSync } from "node:child_process";
 import { basename, join, resolve } from "node:path";
+import { createHash } from "node:crypto";
 import chalk from "chalk";
 import type { AgentConfig, QuotaConfig, SwitchroomConfig, TelegramConfig } from "../config/schema.js";
 
@@ -1680,6 +1681,13 @@ export function scaffoldAgent(
   const agentDir = resolve(agentsDir, name);
   const created: string[] = [];
   const skipped: string[] = [];
+  /**
+   * Files we re-rendered AND backed up an operator-edited version
+   * of. Surfaced via stderr at the end of scaffoldAgent so operators
+   * notice; per-agent items are also included in `created` for the
+   * normal "N files created" count.
+   */
+  const rewrittenWithBackup: string[] = [];
 
   const profilePath = getProfilePath(agentConfig.extends ?? DEFAULT_PROFILE);
   const basePath = getBaseProfilePath();
@@ -1987,25 +1995,25 @@ export function scaffoldAgent(
   for (const { src, dest } of templateFiles) {
     const srcPath = join(profilePath, src);
     if (existsSync(srcPath)) {
-      writeIfMissing(
+      // CLAUDE.md uses a fingerprint-aware re-render so profile-template
+      // changes (e.g. `_shared/telegram-style.md.hbs`) propagate to
+      // existing agents on `switchroom apply`. Old behaviour
+      // (writeIfMissing) froze the file forever after first scaffold —
+      // the root cause of the #1122 conversational-pacing rollout
+      // silently bypassing every running agent's prompt. Operator
+      // hand-edits are preserved as a backup at
+      // `<filename>.before-rerender.<unix-ms>` so they can be
+      // re-merged manually.
+      rerenderWithFingerprint(
         join(agentDir, dest),
         () => {
           let rendered = renderTemplate(srcPath, context);
-          // Append the switchroom-managed vault protocol section. Every
-          // agent gets it regardless of profile — it's load-bearing
-          // safety guidance (how to handle VAULT-BROKER-DENIED, when to
-          // call vault_request_access, why --no-broker can't work from
-          // inside the sandbox). Reconcile re-applies it on every run.
           if (dest === "CLAUDE.md") {
             const vaultProtocol = renderVaultProtocolFragment(context);
             if (vaultProtocol) {
               rendered = rendered.trimEnd() + "\n\n" + vaultProtocol + "\n";
             }
           }
-          // Phase 5: append claude_md_raw escape hatch on initial
-          // scaffold. CLAUDE.md is user-protected afterwards so the
-          // hatch is one-shot — users who edit CLAUDE.md after scaffold
-          // keep their edits through subsequent reconciles.
           if (dest === "CLAUDE.md" && agentConfig.claude_md_raw) {
             rendered = rendered.trimEnd() + "\n\n" + agentConfig.claude_md_raw + "\n";
           }
@@ -2013,6 +2021,7 @@ export function scaffoldAgent(
         },
         created,
         skipped,
+        rewrittenWithBackup,
       );
     }
   }
@@ -2397,6 +2406,17 @@ export function scaffoldAgent(
     });
   }
 
+  // Loud warning when CLAUDE.md (or any future fingerprint-tracked
+  // file) was operator-edited and we backed it up. Surfaced via
+  // stderr so it lands in `switchroom apply` output; not added to
+  // ScaffoldResult to keep the public type stable.
+  for (const f of rewrittenWithBackup) {
+    process.stderr.write(
+      `scaffold: re-rendered ${f} from template change; backed up your `
+      + `edited version to ${f}.before-rerender.* — review and re-merge `
+      + `manually if needed.\n`,
+    );
+  }
   return { agentDir, created, skipped };
 }
 
@@ -3748,6 +3768,109 @@ function writeIfChanged(
     return;
   }
   writeFileSync(filePath, next, mode !== undefined ? { encoding: "utf-8", mode } : "utf-8");
+  created.push(filePath);
+}
+
+/**
+ * Smart-rerender for files we GENERATE from a template but that the
+ * operator MIGHT hand-edit between scaffolds. The previous
+ * `writeIfMissing` behaviour froze the file forever after first write
+ * — which meant a profile-template change (e.g. a new
+ * `_shared/telegram-style.md.hbs` prompt) never reached existing
+ * agents via `switchroom apply`. That was the root cause of the
+ * #1122 conversational-pacing rollout silently bypassing every
+ * agent's CLAUDE.md (discovered 2026-05-12 UAT overnight run).
+ *
+ * Contract:
+ *  - First write: fresh content, drop a fingerprint sidecar
+ *    (`<filename>.fingerprint`) holding the SHA-256 of what we wrote.
+ *  - Subsequent apply:
+ *     - Render fresh. If `hash(rendered) === hash(file_on_disk)`,
+ *       no-op — file already reflects current template.
+ *     - Else, read the fingerprint sidecar.
+ *        - If sidecar matches `hash(file_on_disk)`: the operator has
+ *          NOT touched the file since we last wrote it — template
+ *          drifted, safe to overwrite + update fingerprint.
+ *        - If sidecar doesn't match (or is missing): operator
+ *          hand-edited the file. Back up the existing file to
+ *          `<filename>.before-rerender.<unix-ms>` and overwrite
+ *          + update fingerprint. The backup is loud enough for the
+ *          operator to notice and re-merge their edits manually.
+ *
+ * Caveat: hashing is SHA-256 (`node:crypto`); cost is microseconds
+ * per call. Fingerprint sidecar gets ~64 bytes per file. Trivial.
+ */
+function rerenderWithFingerprint(
+  filePath: string,
+  contentFn: () => string,
+  created: string[],
+  skipped: string[],
+  rewrittenWithBackup: string[],
+  mode?: number,
+): void {
+  const next = contentFn();
+  const nextHash = createHash("sha256").update(next, "utf-8").digest("hex");
+  const fingerprintPath = filePath + ".fingerprint";
+  const writeMode = mode !== undefined ? { encoding: "utf-8" as const, mode } : "utf-8" as const;
+
+  if (!existsSync(filePath)) {
+    writeFileSync(filePath, next, writeMode);
+    writeFileSync(fingerprintPath, nextHash, "utf-8");
+    created.push(filePath);
+    return;
+  }
+
+  const prev = readFileSync(filePath, "utf-8");
+  if (prev === next) {
+    // File is already exactly what we'd render — refresh the fingerprint
+    // (cheap, covers the case where someone deleted the fingerprint or
+    // we're migrating an existing file into the fingerprint regime).
+    try {
+      writeFileSync(fingerprintPath, nextHash, "utf-8");
+    } catch {
+      // best-effort
+    }
+    skipped.push(filePath);
+    return;
+  }
+
+  // Source has drifted. Decide whether to clobber.
+  const prevHash = createHash("sha256").update(prev, "utf-8").digest("hex");
+  const recordedFingerprint = existsSync(fingerprintPath)
+    ? readFileSync(fingerprintPath, "utf-8").trim()
+    : null;
+
+  if (recordedFingerprint === prevHash) {
+    // Operator hasn't touched the file since we last wrote it —
+    // template drifted, clobber cleanly.
+    writeFileSync(filePath, next, writeMode);
+    writeFileSync(fingerprintPath, nextHash, "utf-8");
+    created.push(filePath);
+    return;
+  }
+
+  // Either no fingerprint (legacy state — file pre-dates this regime)
+  // or fingerprint mismatch (operator edited). Back up + overwrite.
+  const backupPath = `${filePath}.before-rerender.${Date.now()}`;
+  try {
+    writeFileSync(backupPath, prev, "utf-8");
+  } catch (err) {
+    // If we can't back up, BAIL — refuse to clobber unrecoverable
+    // operator edits. Push to `skipped` so apply's summary lists
+    // the file as untouched and the operator can investigate.
+    process.stderr.write(
+      `scaffold: refusing to overwrite ${filePath} — backup write failed ` +
+      `(${(err as Error).message}). Operator edits preserved.\n`,
+    );
+    skipped.push(filePath);
+    return;
+  }
+  writeFileSync(filePath, next, writeMode);
+  writeFileSync(fingerprintPath, nextHash, "utf-8");
+  rewrittenWithBackup.push(filePath);
+  // Also count this as "created" for apply's running total so the
+  // post-apply summary reflects that the file was rewritten rather
+  // than silently absent from both columns.
   created.push(filePath);
 }
 

--- a/tests/scaffold.rerender-claude-md.test.ts
+++ b/tests/scaffold.rerender-claude-md.test.ts
@@ -1,0 +1,200 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import {
+  mkdtempSync,
+  rmSync,
+  readFileSync,
+  writeFileSync,
+  existsSync,
+  readdirSync,
+} from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { scaffoldAgent } from "../src/agents/scaffold.js";
+import type { AgentConfig, SwitchroomConfig, TelegramConfig } from "../src/config/schema.js";
+
+/**
+ * Regression for #1122 UAT discovery: scaffoldAgent used to write
+ * CLAUDE.md via `writeIfMissing` — meaning the file was written ONCE
+ * on first scaffold and frozen forever, even if the profile template
+ * `_shared/telegram-style.md.hbs` (or anything else feeding the
+ * render) changed in a later release. The conversational-pacing
+ * rewrite + the mandatory-reply hotfix both silently bypassed every
+ * running agent because of this.
+ *
+ * Fix: re-render with a fingerprint sidecar. Preserve operator
+ * hand-edits via `.before-rerender.<ts>` backup files.
+ *
+ * These tests pin the new behaviour.
+ */
+
+const telegramConfig: TelegramConfig = {
+  bot_token: "123456:ABC-DEF",
+  forum_chat_id: "-1001234567890",
+};
+
+function makeAgentConfig(overrides: Partial<AgentConfig> = {}): AgentConfig {
+  return {
+    extends: "default",
+    topic_name: "Test Topic",
+    schedule: [],
+    ...overrides,
+  } as AgentConfig;
+}
+
+function makeSwitchroomConfig(name: string, agentConfig: AgentConfig): SwitchroomConfig {
+  return {
+    switchroom: {
+      version: 1,
+      agents_dir: "~/.switchroom/agents",
+      skills_dir: "~/.switchroom/skills",
+    },
+    telegram: telegramConfig,
+    agents: { [name]: agentConfig },
+  };
+}
+
+describe("scaffoldAgent — CLAUDE.md rerender-on-template-change (#1122)", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "scaffold-rerender-"));
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("first scaffold writes CLAUDE.md + fingerprint sidecar", () => {
+    const config = makeAgentConfig();
+    const result = scaffoldAgent("a", config, tmpDir, telegramConfig, makeSwitchroomConfig("a", config));
+    const claudeMd = join(result.agentDir, "CLAUDE.md");
+    expect(existsSync(claudeMd)).toBe(true);
+    expect(existsSync(claudeMd + ".fingerprint")).toBe(true);
+    // Fingerprint is a 64-char hex SHA-256.
+    const fp = readFileSync(claudeMd + ".fingerprint", "utf-8").trim();
+    expect(fp).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it("second scaffold with unchanged template is a no-op", () => {
+    const config = makeAgentConfig();
+    const r1 = scaffoldAgent("a", config, tmpDir, telegramConfig, makeSwitchroomConfig("a", config));
+    const claudeMd = join(r1.agentDir, "CLAUDE.md");
+    const fp1 = readFileSync(claudeMd + ".fingerprint", "utf-8");
+    const stat1 = readFileSync(claudeMd, "utf-8");
+
+    const r2 = scaffoldAgent("a", config, tmpDir, telegramConfig, makeSwitchroomConfig("a", config));
+    expect(r2.skipped).toContain(claudeMd);
+    expect(readFileSync(claudeMd, "utf-8")).toBe(stat1);
+    expect(readFileSync(claudeMd + ".fingerprint", "utf-8")).toBe(fp1);
+  });
+
+  it("template drift WITHOUT operator edits → file overwritten + fingerprint updated", () => {
+    const config = makeAgentConfig();
+    const r1 = scaffoldAgent("a", config, tmpDir, telegramConfig, makeSwitchroomConfig("a", config));
+    const claudeMd = join(r1.agentDir, "CLAUDE.md");
+    const original = readFileSync(claudeMd, "utf-8");
+    const fp1 = readFileSync(claudeMd + ".fingerprint", "utf-8").trim();
+
+    // Simulate a template drift by changing the agent's `claude_md_raw`
+    // (which feeds the render path). This produces a different rendered
+    // output without us touching the file directly.
+    const driftedConfig = makeAgentConfig({ claude_md_raw: "\n\n## Drift\nNew section.\n" });
+    const r2 = scaffoldAgent(
+      "a",
+      driftedConfig,
+      tmpDir,
+      telegramConfig,
+      makeSwitchroomConfig("a", driftedConfig),
+    );
+
+    expect(r2.created).toContain(claudeMd);
+    const rewritten = readFileSync(claudeMd, "utf-8");
+    expect(rewritten).not.toBe(original);
+    expect(rewritten).toContain("Drift");
+    const fp2 = readFileSync(claudeMd + ".fingerprint", "utf-8").trim();
+    expect(fp2).not.toBe(fp1);
+
+    // No backup should exist — operator didn't edit.
+    const backups = readdirSync(r1.agentDir).filter((f) =>
+      f.startsWith("CLAUDE.md.before-rerender."),
+    );
+    expect(backups).toHaveLength(0);
+  });
+
+  it("operator hand-edit → fingerprint mismatch → backup + overwrite", () => {
+    const config = makeAgentConfig();
+    const r1 = scaffoldAgent("a", config, tmpDir, telegramConfig, makeSwitchroomConfig("a", config));
+    const claudeMd = join(r1.agentDir, "CLAUDE.md");
+
+    // Operator hand-edits the file (this is what bypasses the fingerprint).
+    const handEdited = readFileSync(claudeMd, "utf-8") + "\n\n## Operator note\nKeep this.\n";
+    writeFileSync(claudeMd, handEdited, "utf-8");
+
+    // Template drift triggers a rerender attempt.
+    const driftedConfig = makeAgentConfig({ claude_md_raw: "\n\n## Drift\nNew section.\n" });
+    const r2 = scaffoldAgent(
+      "a",
+      driftedConfig,
+      tmpDir,
+      telegramConfig,
+      makeSwitchroomConfig("a", driftedConfig),
+    );
+
+    // File was rewritten...
+    expect(r2.created).toContain(claudeMd);
+    expect(readFileSync(claudeMd, "utf-8")).toContain("Drift");
+
+    // ...AND a backup was created with the operator's edit intact.
+    const backups = readdirSync(r1.agentDir).filter((f) =>
+      f.startsWith("CLAUDE.md.before-rerender."),
+    );
+    expect(backups).toHaveLength(1);
+    const backupContent = readFileSync(join(r1.agentDir, backups[0]!), "utf-8");
+    expect(backupContent).toContain("Operator note");
+  });
+
+  it("legacy state (CLAUDE.md exists, no fingerprint) → backup + overwrite", () => {
+    // Simulate pre-#1122 state: an agent scaffolded under the old
+    // writeIfMissing regime — CLAUDE.md exists but no fingerprint
+    // sidecar. The first apply post-upgrade should migrate cleanly:
+    // back up the existing file (we can't tell if operator edited),
+    // overwrite with the fresh render, install the fingerprint.
+    const config = makeAgentConfig();
+    const r1 = scaffoldAgent("a", config, tmpDir, telegramConfig, makeSwitchroomConfig("a", config));
+    const claudeMd = join(r1.agentDir, "CLAUDE.md");
+
+    // Delete the fingerprint to simulate legacy state.
+    rmSync(claudeMd + ".fingerprint");
+    // Also tweak the file so the rendered output will differ from
+    // what's on disk (otherwise we hit the same-content fast path).
+    writeFileSync(claudeMd, readFileSync(claudeMd, "utf-8") + "\n# legacy edit\n", "utf-8");
+
+    const driftedConfig = makeAgentConfig({ claude_md_raw: "\n\n## Drift\n" });
+    scaffoldAgent("a", driftedConfig, tmpDir, telegramConfig, makeSwitchroomConfig("a", driftedConfig));
+
+    // Legacy file backed up, new one written, fingerprint installed.
+    const backups = readdirSync(r1.agentDir).filter((f) =>
+      f.startsWith("CLAUDE.md.before-rerender."),
+    );
+    expect(backups).toHaveLength(1);
+    expect(existsSync(claudeMd + ".fingerprint")).toBe(true);
+  });
+
+  it("matching content (mid-upgrade refresh) → idempotent skip + fingerprint installed", () => {
+    const config = makeAgentConfig();
+    const r1 = scaffoldAgent("a", config, tmpDir, telegramConfig, makeSwitchroomConfig("a", config));
+    const claudeMd = join(r1.agentDir, "CLAUDE.md");
+
+    // Simulate: operator deleted only the fingerprint (e.g.
+    // accidentally rm'd, or migrated from an older version). The
+    // file content still exactly matches what we'd render now.
+    rmSync(claudeMd + ".fingerprint");
+
+    const r2 = scaffoldAgent("a", config, tmpDir, telegramConfig, makeSwitchroomConfig("a", config));
+
+    // Same content → skipped (not rewritten).
+    expect(r2.skipped).toContain(claudeMd);
+    // But fingerprint is restored for the next round-trip.
+    expect(existsSync(claudeMd + ".fingerprint")).toBe(true);
+  });
+});

--- a/tests/scaffold.test.ts
+++ b/tests/scaffold.test.ts
@@ -487,7 +487,16 @@ describe("scaffoldAgent", () => {
     expect(existsSync(join(result.agentDir, ".mcp.json"))).toBe(false);
   });
 
-  it("is idempotent — running twice does not overwrite existing files", () => {
+  it("is idempotent — running twice with unchanged config + template = no-op", () => {
+    // #1122: idempotency means "same inputs → same final state on
+    // subsequent runs," NOT "user hand-edits are frozen forever." The
+    // previous form of this test pinned the latter, which masked the
+    // bug where profile-template changes (e.g. the conversational-
+    // pacing prompt rewrite) silently bypassed every running agent
+    // because CLAUDE.md was written with writeIfMissing. The fingerprint
+    // -aware re-render replaces that contract; operator hand-edits are
+    // backed up to `.before-rerender.<ts>` instead of being preserved
+    // in-place (see scaffold.rerender-claude-md.test.ts).
     const config = makeAgentConfig({
       soul: { name: "Coach", style: "direct" },
     });
@@ -497,18 +506,17 @@ describe("scaffoldAgent", () => {
     expect(result1.created.length).toBeGreaterThan(0);
     expect(result1.skipped.length).toBe(0);
 
-    // Modify a file to verify it won't be overwritten
+    // Snapshot the rendered CLAUDE.md.
     const claudePath = join(result1.agentDir, "CLAUDE.md");
-    writeFileSync(claudePath, "# Custom content\n", "utf-8");
+    const renderedContent = readFileSync(claudePath, "utf-8");
 
-    // Second scaffold
+    // Second scaffold with the SAME config — should be a clean no-op.
     const result2 = scaffoldAgent("idem-agent", config, tmpDir, telegramConfig);
     expect(result2.created.length).toBe(0);
     expect(result2.skipped.length).toBeGreaterThan(0);
 
-    // Verify file was not overwritten
-    const content = readFileSync(claudePath, "utf-8");
-    expect(content).toBe("# Custom content\n");
+    // CLAUDE.md is unchanged.
+    expect(readFileSync(claudePath, "utf-8")).toBe(renderedContent);
   });
 
   it("includes --dangerously-skip-permissions when dangerous_mode is true", () => {


### PR DESCRIPTION
## The bug

The conversational-pacing prompt rewrite (PR2 #1125), the mandatory-reply hotfix (#1128), and PR4's prompt cleanups (#1127) ALL shipped to the canonical repo as merged PRs **but never reached any running agent**.

UAT overnight run (2026-05-12) traced it to `scaffold.ts:1990` — `writeIfMissing` writes CLAUDE.md once at first scaffold and refuses to rewrite afterwards, regardless of source-template drift. Every agent in production was running stale CLAUDE.md from the last `switchroom agent add` (weeks/months ago for most). The hotfix imperative for "you MUST call reply" never reached the model. The deterministic Stop hook (PR #1129) was the only thing keeping agents replying at all.

## Root cause

```ts
// Before
writeIfMissing(
  join(agentDir, "CLAUDE.md"),
  () => renderTemplate(/* ... */),
  ...
);
```

`writeIfMissing` no-ops when the destination exists. Intentional — the original contract was "CLAUDE.md is user-protected; hand-edits survive reconciles." But the cost was that ANY template change (a `_shared/telegram-style.md.hbs` rewrite, a `claude_md_raw` update, a new vault-protocol fragment) was silently dropped on every existing agent.

## Fix

New `rerenderWithFingerprint` helper that preserves operator hand-edits via a **backup mechanism** instead of freezing the file:

| State | Behaviour |
|---|---|
| First scaffold | Write file + fingerprint sidecar (`.fingerprint`) with SHA-256 of rendered output |
| File == rendered output | No-op (refresh fingerprint if missing — covers operators who deleted it) |
| File == fingerprint, but rendered differs | Operator hasn't touched the file; template drifted. Clobber + update fingerprint. **This is the path that propagates `_shared/telegram-style.md.hbs` changes to existing agents.** |
| File != fingerprint (operator hand-edit) | Back up to `<filename>.before-rerender.<unix-ms>`, overwrite, update fingerprint, loud stderr warning |
| File exists, no fingerprint (legacy) | Same as above — back up + overwrite + write fingerprint |

## Behavioural change

Operators who hand-edited CLAUDE.md will see their edits backed up rather than preserved in place. The backup file is loud (stderr warning, on-disk sibling), and `agents.<name>.claude_md_raw` in switchroom.yaml remains the sanctioned per-agent escape hatch.

## Test plan

- [x] `tests/scaffold.rerender-claude-md.test.ts` — 6 new cases covering first-scaffold, no-op, clean-overwrite-on-template-change, backup-and-overwrite-on-hand-edit, legacy-state migration, and idempotent skip with fingerprint restore.
- [x] `tests/scaffold.test.ts` — rewrote the "idempotent" assertion to test the new contract (same inputs → same final state) instead of the old user-protection one.
- [x] `npm run lint` — tsc + plugin-references + bot-api-wrapping clean.
- [x] `npm run test:vitest` — 5461 pass, 49 skipped.
- [x] `npm run test:bun` — 711 pass.

## Rollout

After merge: rebuild + `switchroom apply` will push every agent's CLAUDE.md to the current template state (with backups for any operator edits). Confirmed working on the operator's own fleet during UAT — all 9 agents got the new conversational-pacing prompt + mandatory-reply imperative on a single apply, the test-harness's silent-end-recovery scenario went from 132s (Stop-hook retry cycle) back to ~14s (model calls reply on the first try, prompt is doing its job).

🤖 Generated with [Claude Code](https://claude.com/claude-code)