### PR TITLE
fix(gateway): interrupt-marker uses tmux send-keys directly in docker mode (#1122)

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -5617,9 +5617,26 @@ async function handleInbound(
     }
     if (agentName) {
       try {
-        const { interruptAgent } = await import('../../src/agents/lifecycle.js')
-        const { pid } = interruptAgent(agentName)
-        process.stderr.write(`telegram gateway: interrupt-marker SIGINT sent agent=${agentName} pid=${pid}\n`)
+        // The gateway runs INSIDE the agent container in docker mode,
+        // so calling `interruptAgent` (which probes `docker inspect`
+        // for the PID) always returns "no running PID" — the host's
+        // docker socket isn't visible to us. Skip the PID round-trip
+        // entirely and use tmux send-keys directly: the tmux socket
+        // is local to our container. Discovered during UAT overnight
+        // 2026-05-13 — pre-fix every `!` interrupt produced an
+        // "Agent has no running PID" stderr line and the user got
+        // ghosted because the SIGINT never fired.
+        const { sendAgentInterrupt } = await import('../../src/agents/tmux.js')
+        const r = sendAgentInterrupt({ agentName })
+        if ('ok' in r) {
+          process.stderr.write(
+            `telegram gateway: interrupt-marker SIGINT delivered via tmux send-keys agent=${agentName}\n`,
+          )
+        } else {
+          process.stderr.write(
+            `telegram gateway: interrupt-marker SIGINT via tmux failed agent=${agentName}: ${r.error}\n`,
+          )
+        }
       } catch (err) {
         process.stderr.write(`telegram gateway: interrupt-marker SIGINT failed: ${(err as Error).message}\n`)
       }


### PR DESCRIPTION
## The bug

UAT discovered tonight: the `!`-prefix interrupt marker has been broken in docker mode since switchroom went container-native. Every interrupt fires the ⚡ reaction (cosmetic feedback) but the SIGINT itself never lands.

Gateway log shows:
\`\`\`
telegram gateway: interrupt-marker received chat_id=... agent=test-harness ...
telegram gateway: interrupt-marker SIGINT failed: Agent "test-harness" has no running PID (status: inactive)
\`\`\`

User types `!`, sees the lightning bolt, agent keeps doing whatever it was doing.

## Root cause

The gateway runs **inside** the agent container. The old code path:
\`\`\`ts
const { interruptAgent } = await import('../../src/agents/lifecycle.js')
const { pid } = interruptAgent(agentName)
\`\`\`

`interruptAgent()` probes `docker inspect <container>` for the PID. From inside the container, the docker socket isn't visible — `dockerSync` throws, `getAgentStatus()` returns `{ active: 'inactive', pid: null }`, `interruptAgent()` refuses with "no running PID."

The PID was only used for logging. The actual SIGINT delivery is `tmux send-keys C-c` against the per-agent socket, which IS local to the agent container.

## Fix

Skip the PID round-trip; call `sendAgentInterrupt()` from `src/agents/tmux.ts` directly:

\`\`\`ts
const { sendAgentInterrupt } = await import('../../src/agents/tmux.js')
const r = sendAgentInterrupt({ agentName })
\`\`\`

This runs `tmux -L switchroom-<name> send-keys -t <name> C-c` against the local socket. No docker round-trip needed.

Verified manually: post-fix log line reads:
\`\`\`
telegram gateway: interrupt-marker SIGINT delivered via tmux send-keys agent=test-harness
\`\`\`

## Test

`jtbd-interrupt-marker-dm.test.ts` (PR1132) was failing because of this; expected to pass post-deploy.

Also: one-line allowlist bump in `check-bot-api-wrapping.sh` for the credit-watch raw `bot.api.sendMessage` site whose line number shifted by ~5 from this edit. No new raw calls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)