### PR TITLE
fix(gateway): vault-posture config error must exit EX_CONFIG, not crash-loop (#1115 follow-up)

### DIFF
--- a/scripts/check-bot-api-wrapping.sh
+++ b/scripts/check-bot-api-wrapping.sh
@@ -89,7 +89,7 @@ ALLOWLIST=(
   "telegram-plugin/gateway/gateway.ts:3160-3220:reply chunk-loop THREAD_NOT_FOUND fallback (intentional raw)"
 
   # credit-watch notification. No thread_id (DM).
-  "telegram-plugin/gateway/gateway.ts:8050-8120:credit-watch notify; no thread_id"
+  "telegram-plugin/gateway/gateway.ts:8100-8160:credit-watch notify; no thread_id"
 
   # gateway.ts:9260-9490 — ctx.api.editMessageText for vault grant wizard
   # cards. Every callsite has `.catch(() => {})` — a THREAD_NOT_FOUND

--- a/src/agents/quarantine.ts
+++ b/src/agents/quarantine.ts
@@ -53,7 +53,17 @@ export const QUARANTINE_FILENAME = "quarantine.json";
  * the operator remediation) when extending quarantine to new failure
  * modes — e.g. "vault permanently sealed", "agent UID mismatch".
  */
-export type QuarantineReason = "startup.unauthorized";
+export type QuarantineReason =
+  | "startup.unauthorized"
+  // Config-class refusal-to-boot. Added 2026-05-13 — the gateway
+  // can now exit EX_CONFIG (78) on a vault-posture config error
+  // (telegram-id posture declared but auto-unlock blob missing /
+  // unreadable / empty). The supervisor in start.sh quarantines on
+  // exit 78 (see _switchroom_supervise's exit-78 short-circuit).
+  // Operator remediation: run `switchroom vault broker
+  // enable-auto-unlock`, OR remove `vault.broker.approvalAuth:
+  // telegram-id` from switchroom.yaml.
+  | "startup.config_error";
 
 export interface QuarantineMarker {
   /** Schema version for forward-compat. Bump if shape changes. */

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -12390,7 +12390,33 @@ void (async () => {
   // blob and holds the plaintext passphrase in memory for silent
   // fallback when the operator taps Approve. Default-passphrase mode is
   // a no-op.
-  initVaultApprovalPosture()
+  try {
+    initVaultApprovalPosture()
+  } catch (err) {
+    // Config-class refusal-to-boot: the operator declared
+    // `vault.broker.approvalAuth: telegram-id` in switchroom.yaml but
+    // the machine-bound auto-unlock blob is missing / unreadable /
+    // empty. Pre-fix (#1115 follow-up, 2026-05-13) this throw bubbled
+    // up as an unhandled rejection — the supervisor treated it as a
+    // tight crash loop and posted an "agent-crashed" event on every
+    // restart until the 10-in-60s cap kicked in. The right outcome is
+    // EX_CONFIG (78) on the first failure so the supervisor
+    // quarantines (see _switchroom_supervise's exit-78 short-circuit
+    // in profiles/_base/start.sh.hbs) and the operator sees ONE
+    // clean error in the log + the quarantine marker.
+    const msg = err instanceof Error ? err.message : String(err)
+    process.stderr.write(
+      `telegram gateway: vault-posture-init-config-error — refusing to boot. ${msg}\n`,
+    )
+    try {
+      writeQuarantineMarker(STATE_DIR, 'startup.config_error', msg)
+    } catch (qerr) {
+      process.stderr.write(
+        `telegram gateway: failed to write quarantine marker: ${(qerr as Error).message}\n`,
+      )
+    }
+    process.exit(78)
+  }
 
   for (let attempt = 1; ; attempt++) {
     try {

--- a/telegram-plugin/gateway/quarantine.ts
+++ b/telegram-plugin/gateway/quarantine.ts
@@ -24,7 +24,17 @@ import { join } from 'node:path'
 
 export const QUARANTINE_FILENAME = 'quarantine.json'
 
-export type QuarantineReason = 'startup.unauthorized'
+export type QuarantineReason =
+  | 'startup.unauthorized'
+  // Config-class refusal-to-boot. Added 2026-05-13 after the
+  // vault-posture init started throwing as an unhandled rejection
+  // when the operator declared telegram-id posture but the auto-
+  // unlock blob couldn't be read. Pre-fix that path produced a tight
+  // restart loop ($n/60s -> hit supervisor cap -> stop) and posted
+  // an "agent-crashed" event per restart. The right outcome is a
+  // single EX_CONFIG exit at the first failure → supervisor
+  // quarantines → operator sees one clean error.
+  | 'startup.config_error'
 
 export interface QuarantineMarker {
   v: 1

--- a/telegram-plugin/tests/vault-posture-quarantine.test.ts
+++ b/telegram-plugin/tests/vault-posture-quarantine.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Regression for #1115 follow-up — vault-approval-posture config errors
+ * must NOT manifest as unhandled-rejection crash loops.
+ *
+ * Pre-fix (2026-05-13 overnight UAT discovery): when the operator
+ * declared `vault.broker.approvalAuth: telegram-id` in switchroom.yaml
+ * but the auto-unlock blob couldn't be read (e.g. agent UID can't
+ * access the operator's home dir), `resolveVaultApprovalPosture`
+ * threw, the startup IIFE in gateway.ts let the error propagate as an
+ * unhandled rejection, and `_switchroom_supervise` saw status=0 from
+ * the shutdown handler and respawned the gateway. 10 restarts in <60s
+ * before the supervisor's restart-cap kicked in. Each restart posted
+ * an "agent-crashed" operator-event card and the bridge was alive only
+ * in brief windows between restarts — inbound messages dropped.
+ *
+ * Post-fix: the startup catches the config-class error, writes a
+ * quarantine marker with reason `startup.config_error`, and calls
+ * `process.exit(78)` (sysexits EX_CONFIG). The supervisor short-
+ * circuits on exit 78 without restarting (`_switchroom_supervise` in
+ * `profiles/_base/start.sh.hbs`), so the operator sees ONE clean
+ * error and a quarantine file instead of a crash-loop log smear.
+ *
+ * These tests assert the contracts:
+ *   1. The reason code `startup.config_error` exists in both quarantine
+ *      modules (host-side and plugin-side stay in sync).
+ *   2. The quarantine marker writer accepts the new reason and writes
+ *      a parseable JSON file.
+ *   3. The reader at `src/agents/quarantine.ts` round-trips the new
+ *      reason.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { writeQuarantineMarker, QUARANTINE_FILENAME } from '../gateway/quarantine.js'
+import {
+  readQuarantineMarker,
+  type QuarantineReason,
+} from '../../src/agents/quarantine.js'
+
+let stateDir: string
+
+beforeEach(() => {
+  stateDir = mkdtempSync(join(tmpdir(), 'vault-posture-quarantine-'))
+})
+
+afterEach(() => {
+  rmSync(stateDir, { recursive: true, force: true })
+})
+
+describe('quarantine — startup.config_error reason', () => {
+  it('plugin-side writer accepts the new reason and writes a parseable marker', () => {
+    writeQuarantineMarker(
+      stateDir,
+      'startup.config_error',
+      'vault.broker.approvalAuth=telegram-id but blob unreadable',
+    )
+    const raw = readFileSync(join(stateDir, QUARANTINE_FILENAME), 'utf-8')
+    const parsed = JSON.parse(raw) as {
+      v: number
+      reason: string
+      ts: number
+      detail?: string
+    }
+    expect(parsed.v).toBe(1)
+    expect(parsed.reason).toBe('startup.config_error')
+    expect(typeof parsed.ts).toBe('number')
+    expect(parsed.detail).toContain('vault.broker.approvalAuth')
+  })
+
+  it('host-side reader round-trips the new reason', () => {
+    writeQuarantineMarker(stateDir, 'startup.config_error', 'detail goes here')
+    const m = readQuarantineMarker(stateDir)
+    expect(m).not.toBeNull()
+    expect(m!.reason).toBe('startup.config_error')
+    expect(m!.detail).toBe('detail goes here')
+  })
+
+  it('startup.unauthorized reason still round-trips (no regression)', () => {
+    writeQuarantineMarker(stateDir, 'startup.unauthorized', '401 Unauthorized')
+    const m = readQuarantineMarker(stateDir)
+    expect(m!.reason).toBe('startup.unauthorized')
+  })
+
+  it('type-level: both reasons accepted by QuarantineReason union', () => {
+    const accepted: QuarantineReason[] = ['startup.unauthorized', 'startup.config_error']
+    expect(accepted).toHaveLength(2)
+  })
+
+  it('marker survives in detail field — no truncation of operator-facing message', () => {
+    const longDetail =
+      'vault.broker.approvalAuth=telegram-id but reading auto-unlock blob at '
+      + '/state/agent/home/.switchroom/vault-auto-unlock failed: ENOENT no such '
+      + 'file or directory. Refusing to boot — silently falling back to '
+      + 'passphrase posture would invert the operator\'s declared security '
+      + 'posture. Either repair the auto-unlock blob (rerun `switchroom setup` '
+      + '/ `switchroom vault auto-unlock`) or remove vault.broker.approvalAuth '
+      + 'from switchroom.yaml.'
+    writeQuarantineMarker(stateDir, 'startup.config_error', longDetail)
+    const m = readQuarantineMarker(stateDir)
+    expect(m!.detail).toBe(longDetail)
+  })
+})

--- a/telegram-plugin/vault-approval-posture.ts
+++ b/telegram-plugin/vault-approval-posture.ts
@@ -29,7 +29,11 @@ export interface ResolvedPosture {
 export function resolveVaultApprovalPosture(
   broker: VaultBrokerPostureConfig | undefined,
   reader: (path: string) => string,
-  env: { HOME?: string } = process.env,
+  // Accept the wider `NodeJS.ProcessEnv` shape so callers can pass
+  // `process.env` directly. The narrow `{ HOME?: string }` shape this
+  // had before tripped tsc (TS2559 — no overlap with ProcessEnv) under
+  // the strict plugin-references lint check.
+  env: NodeJS.ProcessEnv | { HOME?: string } = process.env,
 ): ResolvedPosture {
   if (broker?.approvalAuth !== 'telegram-id') {
     return { mode: 'passphrase', passphrase: null }


### PR DESCRIPTION
## The bug (Bug 5 from overnight UAT report)

UAT traced a fleet-wide gateway crash-loop to the new `vault.broker.approvalAuth` posture init (PR #1115). When the operator declares `approvalAuth: telegram-id` in switchroom.yaml but the auto-unlock blob can't be read (e.g. agent UID can't access `/home/<operator>/.switchroom/vault-auto-unlock` from inside the container — which is the actual production state right now), `resolveVaultApprovalPosture()` correctly throws. But the startup IIFE let the error propagate as an **unhandled rejection**, which:

1. The shutdown handler treats as a crash (correct — it's not SIGTERM)
2. Skips the clean-shutdown marker write (correct)
3. Calls `process.exit(0)` eventually
4. The supervisor sees `status=0` and **respawns**
5. Next boot → same error → same crash → repeat
6. ~10 restarts in <60s before the supervisor's restart-cap quarantines
7. Every restart posts an "agent-crashed" operator-event card

Symptom: 35-45 boots in the supervisor log per agent, each one logging `shutdown.clean_marker_skipped signal=unhandledRejection`. Bridge alive only in brief windows between restarts — inbounds during restart windows silently dropped.

This was the root cause of the rapid-followup test failures that surfaced earlier in the overnight UAT — the second message in a rapid pair landed during a restart window and got dropped.

## Fix

Config errors should exit `EX_CONFIG` (78), which `_switchroom_supervise` short-circuits on (`profiles/_base/start.sh.hbs:58`). One exit, quarantine marker, supervisor stops. Operator sees a clean error and a `quarantine.json`.

Four changes:

1. **`telegram-plugin/gateway/gateway.ts`** — startup IIFE wraps `initVaultApprovalPosture()` in try/catch. On throw: log, write quarantine marker with new reason `startup.config_error`, `process.exit(78)`.
2. **`telegram-plugin/gateway/quarantine.ts`** — extend `QuarantineReason` union with `'startup.config_error'`.
3. **`src/agents/quarantine.ts`** — mirror the extension. The two modules' schemas have an explicit "must stay in sync" contract in their docstrings.
4. **`telegram-plugin/vault-approval-posture.ts`** — fix a pre-existing TS2559 lint error on the `env` parameter (no behavioural change; the narrow `{ HOME?: string }` shape had no overlap with `NodeJS.ProcessEnv`, tripping strict tsc). Widened to accept either.

## Tests

`telegram-plugin/tests/vault-posture-quarantine.test.ts` — 5 cases covering plugin-side writer, host-side reader round-trip, regression for the existing `startup.unauthorized` reason, type-level union, and long-detail preservation.

All 5501 vitest tests pass. Lint clean.

## Operator-facing implications

After deploy, agents with the config mismatch will quarantine on first boot rather than crash-loop:
- ONE `vault-posture-init-config-error` line in the gateway log
- A `quarantine.json` file at `TELEGRAM_STATE_DIR`
- Supervisor logs `[supervise] gateway exit 78 (EX_CONFIG) — quarantined, not restarting. Operator action required.`
- `switchroom doctor` / `switchroom agent restart` surface the quarantine

The remediation is unchanged from #1115's docstring: run `switchroom vault broker enable-auto-unlock` to repair the blob, OR remove `vault.broker.approvalAuth: telegram-id` from switchroom.yaml.

The underlying *blob location* issue (operator's home dir not readable from inside the agent container) is a separate concern from this PR — that's about WHERE the blob lives and HOW it gets propagated to agents. This PR just makes the error mode sane while that's sorted out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)