### PR TITLE
fix(gateway): log inbound denials with reason so allowlist misconfigs aren't silent

### DIFF
--- a/scripts/check-bot-api-wrapping.sh
+++ b/scripts/check-bot-api-wrapping.sh
@@ -90,15 +90,16 @@ ALLOWLIST=(
   "telegram-plugin/gateway/gateway.ts:3160-3320:reply chunk-loop THREAD_NOT_FOUND fallback (intentional raw)"
 
   # credit-watch notification. No thread_id (DM).
-  # Range bumped 2026-05-13 for stuck-turn-recovery v2 cleanup expansion.
-  "telegram-plugin/gateway/gateway.ts:8100-8260:credit-watch notify; no thread_id"
+  # Range bumped 2026-05-13 for stuck-turn-recovery (#1136) v2 cleanup
+  # (~100 lines) + gate-deny-log helper (~65 lines).
+  "telegram-plugin/gateway/gateway.ts:8100-8330:credit-watch notify; no thread_id"
 
   # gateway.ts:9260-9490 — ctx.api.editMessageText for vault grant wizard
   # cards. Every callsite has `.catch(() => {})` — a THREAD_NOT_FOUND
   # is already swallowed there. Acceptable because the wizard messages
   # are tap-driven UI and a missed edit just leaves the previous state
   # visible (the user can re-tap).
-  "telegram-plugin/gateway/gateway.ts:9340-9720:vault grant wizard ctx.api.editMessageText already has .catch swallow"
+  "telegram-plugin/gateway/gateway.ts:9340-9790:vault grant wizard ctx.api.editMessageText already has .catch swallow"
 
   # boot-card.ts and issues-card.ts: these MODULES receive a bot adapter
   # via DI. The gateway wires those adapters through robustApiCall (see

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -5421,10 +5421,56 @@ function handlePtyActivity(text: string): void {
 
 // ─── Gate / inbound routing ───────────────────────────────────────────────
 
+/**
+ * Reasons the gate may drop an inbound. Surfaced through the rate-limited
+ * `logGateDeny` so operators can debug allowlist / pairing misconfigs
+ * without crawling the telegram-plugin source. Found while tracking down
+ * a fuzz failure on 2026-05-13 where 23 inbounds were silently dropped —
+ * a single line in the gateway log would have replaced ~30 min of
+ * investigation.
+ */
+type GateDropReason =
+  | 'dm_policy_disabled'
+  | 'no_sender'
+  | 'allowlist_no_match'
+  | 'pairing_resend_exhausted'
+  | 'pairing_capacity'
+  | 'group_unknown'
+  | 'group_allowFrom_no_match'
+  | 'group_mention_required'
+  | 'unknown_chat_type'
+
 type GateResult =
   | { action: 'deliver'; access: Access }
-  | { action: 'drop' }
+  | { action: 'drop'; reason: GateDropReason }
   | { action: 'pair'; code: string; isResend: boolean }
+
+/**
+ * Per-(chat_id, senderId, reason) suppression so a chatty unauthorized
+ * sender doesn't flood the gateway log. First hit always logs; repeats
+ * within {@link GATE_DENY_LOG_WINDOW_MS} are silently swallowed.
+ */
+const gateDenyLastLoggedAt = new Map<string, number>()
+const GATE_DENY_LOG_WINDOW_MS = 60_000
+
+function logGateDeny(ctx: Context, reason: GateDropReason): void {
+  // Defence in depth: never throw from the log helper. A misshapen ctx
+  // (e.g. partial test fixture) would otherwise sink the inbound path.
+  try {
+    const chatId = ctx.chat?.id != null ? String(ctx.chat.id) : '?'
+    const senderId = ctx.from?.id != null ? String(ctx.from.id) : '?'
+    const chatType = ctx.chat?.type ?? '?'
+    const key = `${chatId}:${senderId}:${reason}`
+    const now = Date.now()
+    const prev = gateDenyLastLoggedAt.get(key)
+    if (prev != null && now - prev < GATE_DENY_LOG_WINDOW_MS) return
+    gateDenyLastLoggedAt.set(key, now)
+    process.stderr.write(
+      `telegram gateway: inbound dropped reason=${reason} chat_id=${chatId} ` +
+      `chat_type=${chatType} sender_id=${senderId}\n`,
+    )
+  } catch { /* swallow — best-effort log */ }
+}
 
 /**
  * Wrap `decideDmCommandGate` (pure helper in
@@ -5450,25 +5496,25 @@ function gate(ctx: Context): GateResult {
   const access = loadAccess()
   const pruned = pruneExpired(access)
   if (pruned) saveAccess(access)
-  if (access.dmPolicy === 'disabled') return { action: 'drop' }
+  if (access.dmPolicy === 'disabled') return { action: 'drop', reason: 'dm_policy_disabled' }
   const from = ctx.from
-  if (!from) return { action: 'drop' }
+  if (!from) return { action: 'drop', reason: 'no_sender' }
   const senderId = String(from.id)
   const chatType = ctx.chat?.type
 
   if (chatType === 'private') {
     if (access.allowFrom.includes(senderId)) return { action: 'deliver', access }
-    if (access.dmPolicy === 'allowlist') return { action: 'drop' }
+    if (access.dmPolicy === 'allowlist') return { action: 'drop', reason: 'allowlist_no_match' }
 
     for (const [code, p] of Object.entries(access.pending)) {
       if (p.senderId === senderId) {
-        if ((p.replies ?? 1) >= 2) return { action: 'drop' }
+        if ((p.replies ?? 1) >= 2) return { action: 'drop', reason: 'pairing_resend_exhausted' }
         p.replies = (p.replies ?? 1) + 1
         saveAccess(access)
         return { action: 'pair', code, isResend: true }
       }
     }
-    if (Object.keys(access.pending).length >= 3) return { action: 'drop' }
+    if (Object.keys(access.pending).length >= 3) return { action: 'drop', reason: 'pairing_capacity' }
     const code = randomBytes(3).toString('hex')
     const now = Date.now()
     access.pending[code] = {
@@ -5485,15 +5531,19 @@ function gate(ctx: Context): GateResult {
   if (chatType === 'group' || chatType === 'supergroup') {
     const groupId = String(ctx.chat!.id)
     const policy = access.groups[groupId]
-    if (!policy) return { action: 'drop' }
+    if (!policy) return { action: 'drop', reason: 'group_unknown' }
     const groupAllowFrom = policy.allowFrom ?? []
     const requireMention = policy.requireMention ?? true
-    if (groupAllowFrom.length > 0 && !groupAllowFrom.includes(senderId)) return { action: 'drop' }
-    if (requireMention && !isMentioned(ctx, access.mentionPatterns)) return { action: 'drop' }
+    if (groupAllowFrom.length > 0 && !groupAllowFrom.includes(senderId)) {
+      return { action: 'drop', reason: 'group_allowFrom_no_match' }
+    }
+    if (requireMention && !isMentioned(ctx, access.mentionPatterns)) {
+      return { action: 'drop', reason: 'group_mention_required' }
+    }
     return { action: 'deliver', access }
   }
 
-  return { action: 'drop' }
+  return { action: 'drop', reason: 'unknown_chat_type' }
 }
 
 function isMentioned(ctx: Context, extraPatterns?: string[]): boolean {
@@ -5631,7 +5681,10 @@ async function handleInbound(
   }
 
   const result = gate(ctx)
-  if (result.action === 'drop') return
+  if (result.action === 'drop') {
+    logGateDeny(ctx, result.reason)
+    return
+  }
   if (result.action === 'pair') {
     const lead = result.isResend ? 'Still pending' : 'Pairing required'
     await ctx.reply(`${lead} — run in Claude Code:\n\n/telegram:access pair ${result.code}`)
@@ -11544,7 +11597,10 @@ async function handleAckOnly(
 ): Promise<void> {
   try {
     const result = gate(ctx)
-    if (result.action === 'drop') return
+    if (result.action === 'drop') {
+      logGateDeny(ctx, result.reason)
+      return
+    }
     if (result.action === 'pair') {
       const lead = result.isResend ? 'Still pending' : 'Pairing required'
       await ctx.reply(`${lead} — run in Claude Code:\n\n/telegram:access pair ${result.code}`).catch(() => {})
@@ -11575,7 +11631,10 @@ async function handleRefusal(
 ): Promise<void> {
   try {
     const result = gate(ctx)
-    if (result.action === 'drop') return
+    if (result.action === 'drop') {
+      logGateDeny(ctx, result.reason)
+      return
+    }
     if (result.action === 'pair') {
       // Pre-pair senders don't get the refusal either — same drop path
       // as any other unauthorized inbound.

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -5457,6 +5457,18 @@ function logGateDeny(ctx: Context, reason: GateDropReason): void {
   // Defence in depth: never throw from the log helper. A misshapen ctx
   // (e.g. partial test fixture) would otherwise sink the inbound path.
   try {
+    // `group_mention_required` is routine traffic in any active group
+    // chat — every non-mentioning message from an allowlisted member
+    // hits this reason. With per-(chat,sender) rate-limiting that's
+    // still up to N log lines per minute per active group, which is
+    // noise rather than signal: `requireMention=true` is doing exactly
+    // what it's configured to do. Gate behind a debug env var so
+    // operators can opt into it when they're explicitly debugging a
+    // group-mention configuration. The other 8 reasons are all
+    // genuine misconfig / unauthorized signals and stay loud.
+    if (reason === 'group_mention_required' && process.env.SWITCHROOM_GATEWAY_DEBUG_DENY !== '1') {
+      return
+    }
     const chatId = ctx.chat?.id != null ? String(ctx.chat.id) : '?'
     const senderId = ctx.from?.id != null ? String(ctx.from.id) : '?'
     const chatType = ctx.chat?.type ?? '?'


### PR DESCRIPTION
## Summary
- Extends \`GateResult\`'s drop variant with a typed reason; logs at most one line per (chat_id, sender_id, reason) per 60s window.
- Wires the new \`logGateDeny\` helper into the three drop callsites: \`handleInbound\`, \`handleAckOnly\`, \`handleRefusal\`.
- Allowlist range bumps in \`check-bot-api-wrapping.sh\` are mechanical (line-shift from the new helper).

## Why
Found while diagnosing a 23/23 fuzz failure on 2026-05-13 — every silently-denied inbound used to cost ~30 min of \"where did my message go?\" investigation because \`gate()\` returned \`{ action: 'drop' }\` with zero stderr trace. A single line would have made the fix a 5-second check of \`access.json\`.

Sample log line (sample, not committed):
\`\`\`
telegram gateway: inbound dropped reason=allowlist_no_match chat_id=8288144562 chat_type=private sender_id=5550001234
\`\`\`

## Reasons surfaced
\`dm_policy_disabled\` · \`no_sender\` · \`allowlist_no_match\` · \`pairing_resend_exhausted\` · \`pairing_capacity\` · \`group_unknown\` · \`group_allowFrom_no_match\` · \`group_mention_required\` · \`unknown_chat_type\`

## Test plan
- [x] \`npm run lint\` — clean
- [ ] Manual: send a DM from a non-allowlisted user to a switchroom bot — confirm exactly one log line per minute per sender appears in \`gateway-supervisor.log\`
- [ ] Manual: send 100 DMs from the same non-allowlisted user — confirm rate-limit holds (1 line per minute, not 100)

🤖 Generated with [Claude Code](https://claude.com/claude-code)