### PR TITLE
fix(update): stamp restart marker via docker exec (#1139 follow-up)

### DIFF
--- a/src/cli/update.test.ts
+++ b/src/cli/update.test.ts
@@ -90,6 +90,38 @@ describe("planUpdate", () => {
     }
   });
 
+  it("stamp-restart-marker uses docker exec by default (Docker-runtime fix: host-side write fails with EACCES on UID-owned dirs)", () => {
+    const tmp = mkdtempSync(join(tmpdir(), "update-stamp-exec-"));
+    try {
+      const composePath = join(tmp, "docker-compose.yml");
+      writeFileSync(composePath, "services: {}\n");
+      const runner = fakeRunner();
+      const steps = planUpdate({
+        composePath,
+        agentNamesFn: () => ["carrie", "klanker"],
+        runner: runner.fn,
+      });
+      const stamp = steps.find((s) => s.name === "stamp-restart-marker");
+      stamp?.run();
+      expect(runner.calls).toHaveLength(2);
+      // Both calls target docker exec into the named container.
+      expect(runner.calls[0]?.cmd).toBe("docker");
+      expect(runner.calls[0]?.args[0]).toBe("exec");
+      expect(runner.calls[0]?.args[1]).toBe("switchroom-carrie");
+      expect(runner.calls[0]?.args[2]).toBe("sh");
+      expect(runner.calls[0]?.args[3]).toBe("-c");
+      // The command writes a JSON marker with the canonical reason text
+      // to the in-container path (which is the same file the host sees
+      // via the compose bind-mount).
+      expect(runner.calls[0]?.args[4]).toMatch(/printf/);
+      expect(runner.calls[0]?.args[4]).toMatch(/"reason":"operator: switchroom update"/);
+      expect(runner.calls[0]?.args[4]).toMatch(/\/state\/agent\/telegram\/clean-shutdown\.json/);
+      expect(runner.calls[1]?.args[1]).toBe("switchroom-klanker");
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
   it("stamp-restart-marker tolerates per-agent write failures without aborting", () => {
     const tmp = mkdtempSync(join(tmpdir(), "update-stamp-err-"));
     try {
@@ -297,28 +329,41 @@ describe("runUpdate", () => {
         stdout: (s) => out.push(s),
         stderr: (s) => out.push(s),
         runner: runner.fn,
+        // Stamp-marker step fans out to `docker exec` per agent; pin the
+        // agent set deterministically here so the assertions don't read
+        // the host's real switchroom.yaml.
+        agentNamesFn: () => ["a", "b"],
       });
       expect(code).toBe(0);
-      // 4 calls: pull, apply, up, doctor. Identify each by its
-      // signature args (cmd + first non-script arg).
-      expect(runner.calls).toHaveLength(4);
-      // [0] docker compose ... pull
+      // 6 calls total:
+      //   [0] docker compose pull
+      //   [1] <execPath> apply --non-interactive --no-doctor
+      //   [2] docker exec switchroom-a sh -c '…'  ← stamp-restart-marker
+      //   [3] docker exec switchroom-b sh -c '…'  ← stamp-restart-marker
+      //   [4] docker compose up -d --remove-orphans
+      //   [5] <execPath> doctor
+      expect(runner.calls).toHaveLength(6);
       expect(runner.calls[0]?.cmd).toBe("docker");
       expect(runner.calls[0]?.args).toContain("pull");
-      // [1] <execPath> <scriptPath> apply --non-interactive --no-doctor
-      // (--no-doctor: update has its own doctor step at position 5;
-      // suppressing the apply-side sweep #929 avoids double-printing)
       expect(runner.calls[1]?.cmd).toBe(process.execPath);
       expect(runner.calls[1]?.args).toContain("apply");
       expect(runner.calls[1]?.args).toContain("--non-interactive");
       expect(runner.calls[1]?.args).toContain("--no-doctor");
-      // [2] docker compose ... up -d --remove-orphans
+      // Marker writes: one docker exec per agent, targeting the
+      // in-container clean-shutdown.json path.
       expect(runner.calls[2]?.cmd).toBe("docker");
-      expect(runner.calls[2]?.args).toContain("up");
-      expect(runner.calls[2]?.args).toContain("--remove-orphans");
-      // [3] <execPath> <scriptPath> doctor
-      expect(runner.calls[3]?.cmd).toBe(process.execPath);
-      expect(runner.calls[3]?.args).toContain("doctor");
+      expect(runner.calls[2]?.args.slice(0, 3)).toEqual(["exec", "switchroom-a", "sh"]);
+      expect(runner.calls[2]?.args.at(-1)).toMatch(/operator: switchroom update/);
+      expect(runner.calls[2]?.args.at(-1)).toMatch(/\/state\/agent\/telegram\/clean-shutdown\.json/);
+      expect(runner.calls[3]?.cmd).toBe("docker");
+      expect(runner.calls[3]?.args.slice(0, 3)).toEqual(["exec", "switchroom-b", "sh"]);
+      // [4] docker compose up -d --remove-orphans
+      expect(runner.calls[4]?.cmd).toBe("docker");
+      expect(runner.calls[4]?.args).toContain("up");
+      expect(runner.calls[4]?.args).toContain("--remove-orphans");
+      // [5] <execPath> doctor
+      expect(runner.calls[5]?.cmd).toBe(process.execPath);
+      expect(runner.calls[5]?.args).toContain("doctor");
     } finally {
       rmSync(tmp, { recursive: true, force: true });
     }

--- a/src/cli/update.test.ts
+++ b/src/cli/update.test.ts
@@ -5,7 +5,7 @@
  */
 
 import { describe, it, expect } from "vitest";
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, existsSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { planUpdate, runUpdate, isGitCheckout } from "./update.js";
@@ -118,6 +118,52 @@ describe("planUpdate", () => {
       expect(runner.calls[0]?.args[4]).toMatch(/\/state\/agent\/telegram\/clean-shutdown\.json/);
       expect(runner.calls[1]?.args[1]).toBe("switchroom-klanker");
     } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("stamp-restart-marker falls back to host-writer when docker exec fails (systemd-runtime / no-container path)", () => {
+    const tmp = mkdtempSync(join(tmpdir(), "update-stamp-fallback-"));
+    const prevAgentsDir = process.env.SWITCHROOM_AGENTS_DIR;
+    try {
+      const composePath = join(tmp, "docker-compose.yml");
+      writeFileSync(composePath, "services: {}\n");
+      // Point the host writer at our tmp dir so we can observe what
+      // would normally land in ~/.switchroom/agents/<name>/telegram/.
+      process.env.SWITCHROOM_AGENTS_DIR = tmp;
+      mkdirSync(join(tmp, "carrie", "telegram"), { recursive: true });
+      const runner = fakeRunner();
+      // Force every docker exec to fail (status 127 == "sh not found"
+      // / no such container in practice).
+      runner.setNextStatus(127);
+      const steps = planUpdate({
+        composePath,
+        agentNamesFn: () => ["carrie"],
+        runner: runner.fn,
+      });
+      const stamp = steps.find((s) => s.name === "stamp-restart-marker");
+      stamp?.run();
+      // Exactly one docker exec attempt, then fallback fires.
+      expect(runner.calls).toHaveLength(1);
+      expect(runner.calls[0]?.args[0]).toBe("exec");
+      // Host writer must have produced the marker file at the
+      // bind-mount location — that's the regression-catch: if the
+      // fallback ever gets accidentally removed (e.g. someone inverts
+      // the status check), this assertion fails.
+      const markerPath = join(tmp, "carrie", "telegram", "clean-shutdown.json");
+      expect(existsSync(markerPath)).toBe(true);
+      const parsed = JSON.parse(readFileSync(markerPath, "utf-8")) as {
+        reason?: string;
+        signal?: string;
+      };
+      expect(parsed.reason).toBe("operator: switchroom update");
+      expect(parsed.signal).toBe("SIGTERM");
+    } finally {
+      if (prevAgentsDir === undefined) {
+        delete process.env.SWITCHROOM_AGENTS_DIR;
+      } else {
+        process.env.SWITCHROOM_AGENTS_DIR = prevAgentsDir;
+      }
       rmSync(tmp, { recursive: true, force: true });
     }
   });

--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -200,8 +200,16 @@ export function planUpdate(opts: UpdateOptions): UpdateStep[] {
       'Write a clean-shutdown marker for every agent (reason="operator: switchroom update") so the post-recreate boot card renders as graceful rather than crash',
     run: () => {
       const reason = "operator: switchroom update";
+      // The default writer prefers `docker exec` for running containers
+      // (correct path under Docker runtime — the bind-mounted state dir
+      // is UID-owned by the agent, not the host operator, so a direct
+      // host-side write fails with EACCES and `writeRestartReasonMarker`'s
+      // best-effort catch silently swallows it). Falls back to the host-
+      // side writer when the container isn't running or the runtime is
+      // systemd (then the gateway runs under the host operator's UID
+      // and the host write succeeds). Tests override via writeMarkerFn.
       const writeMarker = opts.writeMarkerFn ?? ((agent, r) =>
-        writeRestartReasonMarker(agent, r, { preserveExisting: true }));
+        writeMarkerInPreferredLocation(agent, r, runner));
       let agents: readonly string[];
       try {
         agents = opts.agentNamesFn ? opts.agentNamesFn() : Object.keys(loadConfig().agents);
@@ -263,6 +271,67 @@ export function planUpdate(opts: UpdateOptions): UpdateStep[] {
 function defaultRunner(cmd: string, args: string[]): { status: number } {
   const r = spawnSync(cmd, args, { stdio: "inherit" });
   return { status: r.status ?? 1 };
+}
+
+/**
+ * Write the clean-shutdown marker for `agent` with `reason`. Tries
+ * `docker exec switchroom-<agent> ...` first, falling back to the
+ * host-side writer when the container isn't running OR docker isn't
+ * available (systemd-runtime hosts).
+ *
+ * Why two paths?
+ *
+ *   - Under the Docker runtime the per-agent state dir is bind-mounted
+ *     into the container and chowned to the agent's UID. The host
+ *     operator running `switchroom update` is a different UID with no
+ *     write permission, so a direct `writeFileSync` from the host fails
+ *     with EACCES. `writeRestartReasonMarker` already wraps that in a
+ *     best-effort catch — meaning the host CLI looked like it succeeded
+ *     while no marker was actually written, and every operator-initiated
+ *     update therefore booted as `reason=crash` even with the PR #1139
+ *     stamp-step in the plan. The docker-exec path runs *inside* the
+ *     container as the agent UID and writes through to the same
+ *     bind-mounted file, which the post-recreate gateway reads on boot.
+ *
+ *   - Under the systemd runtime the gateway runs under the host
+ *     operator's UID — there's no bind-mount, the host writer is the
+ *     correct path, and docker isn't necessarily installed at all. So
+ *     we fall back transparently.
+ *
+ * Returns silently on success. Throws on failure; the caller's
+ * try/catch logs and continues so a single agent's failure doesn't
+ * block the update for the rest of the fleet.
+ */
+function writeMarkerInPreferredLocation(
+  agent: string,
+  reason: string,
+  runner: (cmd: string, args: string[]) => { status: number },
+): void {
+  const ts = Date.now();
+  const markerJson = JSON.stringify({ ts, signal: "SIGTERM", reason });
+  // `sh -c` lets us redirect inside the container without needing tee or
+  // a here-doc. The path is `/state/agent/telegram/clean-shutdown.json`
+  // — that's the in-container view of the same file the host writer
+  // would target (`~/.switchroom/agents/<name>/telegram/...`), via the
+  // compose bind-mount. Quoting note: JSON.stringify produces a JSON
+  // string with embedded double quotes; we wrap the WHOLE shell argument
+  // in single quotes, which is safe because JSON.stringify won't emit
+  // single quotes (it always escapes characters using \\ + double quotes).
+  const cmd = `printf '%s' '${markerJson}' > /state/agent/telegram/clean-shutdown.json`;
+  const dockerExec = runner("docker", [
+    "exec",
+    `switchroom-${agent}`,
+    "sh",
+    "-c",
+    cmd,
+  ]);
+  if (dockerExec.status === 0) return;
+  // Docker exec failed — the container isn't running, the runtime is
+  // systemd, or docker is unavailable. Fall through to the host-side
+  // writer which works correctly under systemd (and harmlessly no-ops
+  // under Docker once the agent UID inherits the file via the in-
+  // container shutdown handler's own marker rewrite path).
+  writeRestartReasonMarker(agent, reason, { preserveExisting: true });
 }
 
 // ─── --status mode (#927) ────────────────────────────────────────────────

--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -191,9 +191,17 @@ export function planUpdate(opts: UpdateOptions): UpdateStep[] {
   // `/reset` verbs do via stampUserRestartReason. Reason text uses an
   // `operator:` prefix so the boot card can silence the notification
   // for this class of restart (boot-card.ts handles the disable_
-  // notification path). preserveExisting: true matches the restart.ts
-  // semantics — if a marker was written <30s ago by another flow we
-  // don't clobber it.
+  // notification path).
+  //
+  // Clobber semantics (#1141 review item C): the docker-exec path
+  // writes unconditionally — it does NOT honour the 30s preserve-
+  // existing window that `writeRestartReasonMarker` enforces from the
+  // host. Intentional: `switchroom update` is the more recent and more
+  // aggressive operator intent, and the recreate is going to subsume
+  // any in-flight `/restart` anyway. The boot-card silence then
+  // correctly attributes the planned redeploy to the operator. The
+  // host-side fallback below DOES use preserveExisting: true so
+  // systemd-runtime hosts retain the original /restart-race guard.
   steps.push({
     name: "stamp-restart-marker",
     description:
@@ -309,15 +317,24 @@ function writeMarkerInPreferredLocation(
 ): void {
   const ts = Date.now();
   const markerJson = JSON.stringify({ ts, signal: "SIGTERM", reason });
-  // `sh -c` lets us redirect inside the container without needing tee or
-  // a here-doc. The path is `/state/agent/telegram/clean-shutdown.json`
-  // — that's the in-container view of the same file the host writer
-  // would target (`~/.switchroom/agents/<name>/telegram/...`), via the
-  // compose bind-mount. Quoting note: JSON.stringify produces a JSON
-  // string with embedded double quotes; we wrap the WHOLE shell argument
-  // in single quotes, which is safe because JSON.stringify won't emit
-  // single quotes (it always escapes characters using \\ + double quotes).
-  const cmd = `printf '%s' '${markerJson}' > /state/agent/telegram/clean-shutdown.json`;
+  // `sh -c` lets us redirect inside the container without needing tee
+  // or a here-doc. The path is `/state/agent/telegram/clean-shutdown.
+  // json` — the in-container view of the same file the host writer
+  // would target (`~/.switchroom/agents/<name>/telegram/...`) via the
+  // compose bind-mount.
+  //
+  // Quoting: we wrap the JSON payload in single quotes for the shell.
+  // JSON's grammar escapes `"`, `\`, and control chars, but `'`
+  // (U+0027) passes through literally. Today's marker fields are all
+  // hardcoded primitives (numeric `ts`, the literal "SIGTERM" signal,
+  // the literal "operator: switchroom update" reason) so there's no
+  // apostrophe risk in this PR. Even so, we POSIX-escape the payload
+  // (`'` → `'\''`) defensively — if a future caller routes user-
+  // derived text through the reason field, the escape keeps the shell
+  // wrapping safe instead of silently breaking the redirect. (#1141
+  // review.)
+  const shellSafeJson = markerJson.replace(/'/g, "'\\''");
+  const cmd = `printf '%s' '${shellSafeJson}' > /state/agent/telegram/clean-shutdown.json`;
   const dockerExec = runner("docker", [
     "exec",
     `switchroom-${agent}`,
@@ -327,10 +344,18 @@ function writeMarkerInPreferredLocation(
   ]);
   if (dockerExec.status === 0) return;
   // Docker exec failed — the container isn't running, the runtime is
-  // systemd, or docker is unavailable. Fall through to the host-side
-  // writer which works correctly under systemd (and harmlessly no-ops
-  // under Docker once the agent UID inherits the file via the in-
-  // container shutdown handler's own marker rewrite path).
+  // systemd, docker is unavailable, OR the container is running but
+  // its rootfs lacks `sh` / `/state/agent/telegram/` doesn't exist yet
+  // (brand-new agent pre-first-boot). Logged so operators have a
+  // breadcrumb when the boot card still reads `crash` after an update.
+  // Fall through to the host-side writer which works correctly under
+  // systemd (and harmlessly no-ops under Docker via the EACCES catch
+  // in writeRestartReasonMarker — same behaviour as pre-#1139). (#1141
+  // review item B/E.)
+  process.stderr.write(
+    `switchroom update: stamp-restart-marker — ${agent}: docker exec failed ` +
+    `(status=${dockerExec.status}); falling back to host writer\n`,
+  );
   writeRestartReasonMarker(agent, reason, { preserveExisting: true });
 }
 


### PR DESCRIPTION
## Summary
PR #1139 added \`stamp-restart-marker\` to \`switchroom update\` but the marker writes silently no-op'd in the docker runtime. The host operator (uid 1000) doesn't have write permission to the agent's bind-mounted \`clean-shutdown.json\` (owned by the agent's UID, e.g. 10404), and \`writeRestartReasonMarker\`'s best-effort try/catch (\`lifecycle.ts:63\`) swallows the EACCES. Net effect: CLI looked successful, no marker was written, boot card still said \`reason=crash\`.

## Fix
The stamp step now prefers \`docker exec switchroom-<agent> sh -c 'printf … > /state/agent/telegram/clean-shutdown.json'\` — the exec runs inside the container as the agent UID with full write permission. Falls back to the host-side \`writeRestartReasonMarker\` when docker exec fails (container not running, systemd runtime, or docker unavailable).

Reproducer (pre-fix, verified tonight):
\`\`\`
\$ switchroom update     # exit 0, says ✓ update complete
\$ ls -la ~/.switchroom/agents/test-harness/telegram/clean-shutdown.json
-rw-r--r-- 1 10404 10404 71 May 12 08:39  # NOT freshened — yesterday's marker
\$ touch ~/.switchroom/agents/test-harness/telegram/clean-shutdown.json
touch: Permission denied
\`\`\`

Post-fix the docker-exec route writes inside the container as uid 10404 and the bind-mount surfaces the new marker to the host immediately.

## Test plan
- [x] \`npm run lint\` — clean
- [x] \`vitest run src/cli/update.test.ts\` — 18/18 pass (1 new dedicated test for the docker-exec shape; updated integration test to expect 6 runner calls)
- [ ] Manual: run \`switchroom update\` against the live fleet, confirm \`/var/log/switchroom/gateway-supervisor.log\` shows \`boot-card: posted ... reason=graceful reason_detail=operator: switchroom update silent=true\` for every agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)