### PR TITLE
ci(docker): CACHE_BUST=run_attempt — `gh run rerun` actually bumps Claude

### DIFF
--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -100,6 +100,18 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           cache-from: type=gha,scope=base
           cache-to: type=gha,mode=max,scope=base
+          # CACHE_BUST is paired with the `ARG CACHE_BUST` in
+          # Dockerfile.base immediately before `npm install -g
+          # @anthropic-ai/claude-code@latest`. `github.run_attempt`
+          # increments only on `gh run rerun` (fresh pushes start at
+          # 1), so original commits hit the buildkit cache for fast
+          # builds, while a rerun forces a fresh npm resolve and
+          # picks up the current `@latest` from the registry. This
+          # is the canonical "give me the newest claude" lever:
+          # `gh run rerun <run-id>` → fresh image → `switchroom
+          # update` → fleet bumps.
+          build-args: |
+            CACHE_BUST=${{ github.run_attempt }}
 
   build-dependents:
     needs: build-base

--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -108,7 +108,19 @@ RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
 # want the image build to die here, not produce a base that ships
 # downstream and explodes at agent boot. Previously this had a
 # trailing `|| true` that swallowed any failure.
-RUN npm install -g @anthropic-ai/claude-code@latest \
+#
+# CACHE_BUST is wired through from the workflow as
+# `${{ github.run_attempt }}` — fresh pushes to main (attempt=1) hit
+# the cache for fast turnaround, but a `gh run rerun` (attempt=2+)
+# changes the layer hash and forces a fresh `npm install` that re-
+# resolves `@latest` from the registry. Without this, buildkit's
+# `cache-from: type=gha,scope=base` reuses the prior layer even on
+# rerun and the version stays stuck at whatever first cached it.
+# Default `default` so local `docker build` (no build-arg) still
+# works deterministically.
+ARG CACHE_BUST=default
+RUN echo "cache-bust=${CACHE_BUST}" > /dev/null \
+ && npm install -g @anthropic-ai/claude-code@latest \
  && claude --version >&2
 
 # Phase 1b: install bun. The broker server (src/vault/broker/server.ts)


### PR DESCRIPTION
## Summary
Wires \`github.run_attempt\` into a \`CACHE_BUST\` build-arg referenced by an \`ARG CACHE_BUST=default\` line in \`Dockerfile.base\` right before \`npm install -g @anthropic-ai/claude-code@latest\`. Original pushes (attempt=1) keep their cache; \`gh run rerun\` (attempt=2+) forces a fresh \`@latest\` resolve.

## Why
Tonight's plan to roll the fleet 2.1.138 → 2.1.140 was "just trigger a rebuild." Two reruns later the image was still 2.1.138 — buildkit's GHA cache reused the cached \`RUN npm install ... @latest\` layer (byte-identical RUN string → cache hit → no fresh npm resolve). Deleting the \`index-base-*\` GHA cache entries didn't help: buildkit re-imported from the remaining \`buildkit-blob-*\` entries.

Without this fix the operator runbook for a Claude bump is either:
1. Delete every \`buildkit-blob-*\` cache entry manually (~200 entries, repeat for every bump), or
2. Land a one-line PR that pins to an explicit version (deterministic but locks the bump cadence to PRs).

With this fix the runbook collapses to:
\`\`\`
gh run list --workflow docker-images --branch main --limit 1
gh run rerun <id>
switchroom update
\`\`\`

## Properties
- **Fast path preserved** — original pushes (attempt=1) still hit the cache.
- **Rerun bumps** — every \`gh run rerun\` increments \`github.run_attempt\` → new layer hash → fresh \`npm install\` → registry's \`@latest\` at that moment.
- **Local builds deterministic** — \`ARG CACHE_BUST=default\` makes \`docker build\` (no build-arg) reproducible.
- **Dependents cascade** — agent/broker/kernel jobs invalidate naturally because the base image SHA changes.

## Test plan
- [x] \`npm run lint\` — clean
- [ ] Merge, then \`gh run rerun\` the docker-images workflow on main, confirm new image has \`@latest = 2.1.140\` baked in
- [ ] \`switchroom update\` → \`docker exec switchroom-<agent> claude --version\` reports \`2.1.140\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)