### PR TITLE
test(silence-poke): inline-snapshot framework-fallback wording (CC-4)

### DIFF
--- a/docs/status-ask-cause-classes.md
+++ b/docs/status-ask-cause-classes.md
@@ -159,7 +159,7 @@ Three cause classes pinned by executable UAT scenarios, one stale scenario delet
 
 **Left unaddressed (parked):**
 
-- **CC-4 framework-fallback wording.** Cheap to add as a snapshot unit test in a follow-up; deferred because the wording lives in `silence-poke.ts:formatPokeText` and the load-bearing piece (the wire path) is now covered.
+- **CC-4 framework-fallback wording.** ~~Cheap to add as a snapshot unit test in a follow-up; deferred because the wording lives in `silence-poke.ts:formatPokeText` and the load-bearing piece (the wire path) is now covered.~~ **Addressed:** `formatFrameworkFallbackText` extracted from the gateway's `onFrameworkFallback` callback into `silence-poke.ts` alongside `formatPokeText`. Both functions now have inline snapshot tests in `silence-poke.test.ts` § "wording snapshots (CC-4)" — 6 cases covering soft, firm, working-at-300s, thinking-at-300s, derived-minutes, and the 1-min floor.
 - **CC-5 subagent flag leak.** Requires a controlled gateway-abort path that's intrusive to mock at UAT level. Deferred until the silent-end-recovery code (#1131) gets a wider rework — the same path would need the `endTurn` call.
 - **CC-7 (full coverage extension).** This PR's fuzz block covers the existing regex set. Extending the classifier itself with new variants needs production hindsight access to avoid false positives. Out of scope without prod read access.
 - **CC-8 boot card silenced on real crash.** A scenario can be written but the marker semantics interact with #1142's freshness window — likely worth its own PR rather than bundling here.

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -2494,13 +2494,15 @@ silencePoke.startTimer({
     emitRuntimeMetric(event)
   },
   onFrameworkFallback: async (ctx) => {
-    // Derive the "N min" suffix from ctx.silenceMs so the wording stays
-    // honest if threshold is tuned. PR2 reviewer note #2.
-    const minutes = Math.max(1, Math.round(ctx.silenceMs / 60_000))
-    const suffix = `(no update from agent in ${minutes} min)`
-    const text = ctx.fallbackKind === 'thinking'
-      ? `still thinking… ${suffix}`
-      : `still working… ${suffix}`
+    // Wording is load-bearing — extracted to `formatFrameworkFallbackText`
+    // in `silence-poke.ts` so it can be snapshot-tested in isolation
+    // (CC-4 in `docs/status-ask-cause-classes.md`). Derives "N min" suffix
+    // from `ctx.silenceMs` so the wording stays honest if the 300s
+    // threshold is tuned.
+    const text = silencePoke.formatFrameworkFallbackText(
+      ctx.fallbackKind,
+      ctx.silenceMs,
+    )
     try {
       await robustApiCall(
         () => bot.api.sendMessage(ctx.chatId, text, {

--- a/telegram-plugin/silence-poke.ts
+++ b/telegram-plugin/silence-poke.ts
@@ -236,7 +236,7 @@ export function endTurn(key: string): void {
 }
 
 /** Verbatim poke text. Wording is load-bearing — see issue #1122 design. */
-function formatPokeText(level: PokeLevel): string {
+export function formatPokeText(level: PokeLevel): string {
   if (level === 'soft') {
     return (
       "[silence-poke] You've been silent to the user for 75s. If you're "
@@ -252,6 +252,33 @@ function formatPokeText(level: PokeLevel): string {
     + 'unusually long (slow tool, network, waiting on a sub-agent), say so '
     + 'explicitly.'
   )
+}
+
+/**
+ * Verbatim framework-fallback text — the user-visible "still working / still
+ * thinking" message the gateway sends at the 300s threshold when the model
+ * hasn't broken its own silence. Wording is load-bearing (see
+ * `reference/conversational-pacing.md` § Silence-poke ladder). Two principles:
+ *
+ *   1. The parenthetical `(no update from agent in N min)` is honest —
+ *      distinguishes from "the agent said something" so users learn to trust
+ *      real agent messages. `N` is derived from `silenceMs`, never hard-coded.
+ *   2. The verb is `working` by default, `thinking` only when the session
+ *      stream has emitted a `kind: 'thinking'` event in the last 30s. Picked
+ *      by the caller via `fallbackKind`; this helper just formats.
+ *
+ * Extracted from the gateway's `onFrameworkFallback` callback so the wording
+ * can be snapshot-tested in isolation. CC-4 in `docs/status-ask-cause-classes.md`.
+ */
+export function formatFrameworkFallbackText(
+  fallbackKind: 'working' | 'thinking',
+  silenceMs: number,
+): string {
+  const minutes = Math.max(1, Math.round(silenceMs / 60_000))
+  const suffix = `(no update from agent in ${minutes} min)`
+  return fallbackKind === 'thinking'
+    ? `still thinking… ${suffix}`
+    : `still working… ${suffix}`
 }
 
 /**

--- a/telegram-plugin/tests/silence-poke.test.ts
+++ b/telegram-plugin/tests/silence-poke.test.ts
@@ -7,6 +7,8 @@ import {
   consumeArmedPoke,
   endTurn,
   silencePokeEnabled,
+  formatPokeText,
+  formatFrameworkFallbackText,
   __tickForTests,
   __setDepsForTests,
   __getStateForTests,
@@ -328,6 +330,60 @@ describe('silence-poke — system reminder text', () => {
     const text = consumeArmedPoke()
     expect(text).toContain('3 minutes')
     expect(text).toContain('stuck')
+  })
+})
+
+// CC-4 from `docs/status-ask-cause-classes.md`: wording is load-bearing
+// (`reference/conversational-pacing.md` § Silence-poke ladder). Snapshot
+// the exact strings here so a refactor that drops a key phrase fails
+// loud at test time. If you genuinely need to change the wording,
+// update the snapshot AND the design doc together.
+describe('silence-poke — wording snapshots (CC-4)', () => {
+  it('soft poke text is unchanged', () => {
+    expect(formatPokeText('soft')).toMatchInlineSnapshot(
+      `"[silence-poke] You've been silent to the user for 75s. If you're still working on this, send one short conversational reply — e.g. "still going, working through X" — so they know you're alive. Keep it brief; don't restate the task. If you're about to finish within the next few seconds, skip the update."`,
+    )
+  })
+
+  it('firm poke text is unchanged', () => {
+    expect(formatPokeText('firm')).toMatchInlineSnapshot(
+      `"[silence-poke] 3 minutes silent. Please send an update now — what you're working on, or whether you're stuck. If something is taking unusually long (slow tool, network, waiting on a sub-agent), say so explicitly."`,
+    )
+  })
+
+  it('framework fallback — working at 300s', () => {
+    expect(formatFrameworkFallbackText('working', 300_000)).toMatchInlineSnapshot(
+      `"still working… (no update from agent in 5 min)"`,
+    )
+  })
+
+  it('framework fallback — thinking at 300s', () => {
+    expect(formatFrameworkFallbackText('thinking', 300_000)).toMatchInlineSnapshot(
+      `"still thinking… (no update from agent in 5 min)"`,
+    )
+  })
+
+  it('framework fallback — minutes derived from silenceMs, not hard-coded', () => {
+    // The "N min" suffix MUST track ctx.silenceMs so the wording stays
+    // honest if the 300s threshold is tuned. If a refactor accidentally
+    // hard-codes "5 min", these cases break.
+    expect(formatFrameworkFallbackText('working', 360_000)).toBe(
+      'still working… (no update from agent in 6 min)',
+    )
+    expect(formatFrameworkFallbackText('working', 600_000)).toBe(
+      'still working… (no update from agent in 10 min)',
+    )
+  })
+
+  it('framework fallback — minutes floor at 1 even when silenceMs is small', () => {
+    // Defensive: a future caller might invoke with sub-minute silenceMs.
+    // Rendering "0 min" reads as nonsense; floor at 1.
+    expect(formatFrameworkFallbackText('working', 30_000)).toBe(
+      'still working… (no update from agent in 1 min)',
+    )
+    expect(formatFrameworkFallbackText('working', 0)).toBe(
+      'still working… (no update from agent in 1 min)',
+    )
   })
 })
 


### PR DESCRIPTION
## Summary

Closes **CC-4** (framework-fallback wording snapshot) from `docs/status-ask-cause-classes.md`.

\`reference/conversational-pacing.md\` § Silence-poke ladder calls the wording load-bearing for two reasons:

1. The soft poke text saying "skip the update if you're about to finish within seconds" — without it, the model dutifully sends "still working" 5s before the answer lands.
2. The framework fallback parenthetical "(no update from agent in N min)" is honest — distinguishes from "the agent said something" so users learn to trust real agent messages.

Before this PR: the wording was untested, and `formatFrameworkFallbackText` was inlined inside the gateway's `onFrameworkFallback` callback at `gateway.ts:2497-2503` where it couldn't be unit-tested in isolation.

## Changes

- **`silence-poke.ts`** — promote `formatPokeText` from private to exported; extract new `formatFrameworkFallbackText(kind, silenceMs)` helper from the gateway.
- **`gateway.ts`** — call the new helper. Behavior identical (same string output for same inputs).
- **`silence-poke.test.ts`** — 6 inline-snapshot cases under \`describe('silence-poke — wording snapshots (CC-4)')\`:
  - soft poke text unchanged
  - firm poke text unchanged
  - working at 300s
  - thinking at 300s
  - minutes derived from \`silenceMs\` (6 min, 10 min) — guards against an accidental hard-code if a refactor flattens the formula
  - 1-min floor for sub-minute \`silenceMs\` (defensive — "0 min" reads as nonsense)

## Goal series context

Status-ask coverage now reads:

| Cause class | Coverage |
|---|---|
| CC-1, CC-2, CC-3, CC-6, CC-7 | UAT (dedicated + fuzz) from #1144 / #1146 / #1147 / #1148 / #1149 |
| **CC-4** | **This PR — inline-snapshot unit tests** |
| CC-5, CC-8 | Still parked (need harness extensions) |

## Test plan

- [ ] \`bunx tsc --noEmit\` clean ✅ (verified locally).
- [ ] \`bun test telegram-plugin/tests/silence-poke.test.ts\` — 32 pass, 4 snapshots ✅ (verified locally).
- [ ] Snapshot-update workflow: a future wording change needs \`bun test --update-snapshots\` (or vitest equivalent) AND a doc update — that pairing is the contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)