### PR TITLE
feat(gateway): finalizeCallback helper — three-invariant button UX foundation (#1150 + audit)

### DIFF
--- a/telegram-plugin/inline-keyboard-callbacks.ts
+++ b/telegram-plugin/inline-keyboard-callbacks.ts
@@ -164,3 +164,139 @@ export function validateAndWrapAgentKeyboard(
   const wrapped = wrapAgentCallbacks(keyboard)
   return { ok: true, wrapped }
 }
+
+// ─── finalizeCallback (#1150 + audit follow-up) ──────────────────────────
+//
+// Centralized "the user tapped a terminal button" helper. Every callback
+// handler that resolves a decision (Approve / Deny / Pick option / Confirm
+// revoke / Always-allow / Dismiss / etc.) MUST route through this helper
+// so the three button-UX invariants are uniformly enforced:
+//
+//   1. Visible press feedback — `answerCallbackQuery` with `text:` so
+//      Telegram shows a toast. Operators who tap and see nothing within
+//      ~200ms double-tap; the toast IS the press-feedback affordance.
+//   2. Keyboard collapses with clarity — the message is edited in place
+//      to strip `reply_markup` AND append a status line that describes
+//      what the operator selected. One atomic edit, not two: the user
+//      must be able to scroll back later and see the resolved decision
+//      next to the original prompt.
+//   3. Side effect (typically: synthesize an inbound back to the model
+//      so the agent's turn continues) — runs AFTER the message edit
+//      lands so the model never sees "I'm being woken up" before the
+//      operator sees the visual confirmation.
+//
+// Multi-step wizards (vault grant wizard, etc.) should NOT use this
+// helper for intermediate-step transitions — those swap one keyboard
+// for the next via `editMessageText` + new `reply_markup`. Use this
+// helper for the WIZARD-FINAL step (Generate, Cancel) so the success
+// card collapses correctly and isn't re-tappable.
+
+/**
+ * Minimal callback-context shape the helper needs. Real grammy
+ * `Context` satisfies this; tests can implement a lightweight fake
+ * without dragging the grammy types in.
+ */
+export interface FinalizeCallbackContext {
+  answerCallbackQuery: (
+    opts?: { text?: string; show_alert?: boolean },
+  ) => Promise<unknown>
+  editMessageText: (text: string, opts?: Record<string, unknown>) => Promise<unknown>
+}
+
+export interface FinalizeCallbackOptions {
+  /**
+   * Toast text shown to the operator via `answerCallbackQuery`. Telegram
+   * caps this at 200 chars; pass a short verb-phrase ("Approved",
+   * "Saved", "Switching to slot 2"). Required — the toast IS invariant 1.
+   */
+  ackText: string
+  /**
+   * When true, the toast renders as a full modal alert instead of the
+   * bottom-bar toast. Default false. Use for destructive or one-way
+   * decisions (e.g. "Vault grant revoked") where the operator needs
+   * stronger acknowledgement.
+   */
+  alert?: boolean
+  /**
+   * The new body text for the message AFTER the keyboard is stripped.
+   * Build this yourself from `<original prompt>\n\n<status line>` so the
+   * scrollback preserves the question alongside the answer. The keyboard
+   * is stripped unconditionally regardless of `newText`.
+   */
+  newText: string
+  /**
+   * Parse mode for `newText`. Match the original message's parse mode —
+   * mixing modes mid-edit silently breaks formatting. Optional; omitted
+   * means plain text.
+   */
+  parseMode?: 'HTML' | 'Markdown' | 'MarkdownV2'
+  /**
+   * Side effect invoked AFTER `editMessageText` resolves. Use for
+   * synthesizing the `<channel source="...">` inbound that wakes the
+   * agent's session. Errors are caught + logged via the `log` seam;
+   * they do NOT propagate (a failed inbound synthesis must not regress
+   * to "operator's tap visually un-applied"). The model-visible flow
+   * is allowed to fail loudly via separate mechanisms (the supervisor
+   * watchdog, the silence-poke ladder); this helper's job is to keep
+   * invariants 1+2 strict and best-effort the rest.
+   *
+   * Skip for surfaces with no model in the loop (auth dashboard
+   * actions that shell to the host CLI, operator-event dismiss, etc).
+   */
+  synthInbound?: () => void | Promise<void>
+  /** Logger seam for tests. Defaults to stderr. */
+  log?: (line: string) => void
+}
+
+/**
+ * Apply the three-invariant finalize pattern. See module docstring
+ * above for design rationale.
+ *
+ * Order: ack → edit → synth. The ack is fired-and-forgotten (so a slow
+ * Telegram API doesn't delay the visible state change), but the edit
+ * is awaited so `synthInbound` doesn't race ahead of the operator's
+ * visual confirmation. Each step's error is logged + swallowed —
+ * partial success is preferred to "tap looked dead AND the model
+ * stayed stuck" full failure.
+ */
+export async function finalizeCallback(
+  ctx: FinalizeCallbackContext,
+  opts: FinalizeCallbackOptions,
+): Promise<void> {
+  const log = opts.log ?? ((line: string) => process.stderr.write(line))
+  // Invariant 1 — toast. Fire-and-forget; we don't want a slow
+  // answerCallbackQuery round-trip to delay the message edit.
+  void ctx.answerCallbackQuery({
+    text: opts.ackText,
+    ...(opts.alert ? { show_alert: true } : {}),
+  }).catch((err: unknown) => {
+    log(`finalizeCallback: answerCallbackQuery failed: ${(err as Error).message}\n`)
+  })
+  // Invariant 2 — strip keyboard + append status line, atomic edit.
+  try {
+    await ctx.editMessageText(opts.newText, {
+      reply_markup: { inline_keyboard: [] },
+      ...(opts.parseMode ? { parse_mode: opts.parseMode } : {}),
+      // Default link_preview_options off — most finalized cards don't
+      // benefit from preview cards, and a stale preview survives the
+      // edit otherwise.
+      link_preview_options: { is_disabled: true },
+    })
+  } catch (err) {
+    // MESSAGE_NOT_MODIFIED (text didn't change) and MESSAGE_TO_EDIT_NOT_FOUND
+    // (operator already deleted the card) are both benign. Other failures
+    // log + continue — we still want synthInbound to run.
+    log(`finalizeCallback: editMessageText failed: ${(err as Error).message}\n`)
+  }
+  // Invariant 3 — model wake-up (when applicable).
+  if (opts.synthInbound != null) {
+    try {
+      const r = opts.synthInbound()
+      if (r != null && typeof (r as Promise<unknown>).then === 'function') {
+        await (r as Promise<unknown>)
+      }
+    } catch (err) {
+      log(`finalizeCallback: synthInbound threw: ${(err as Error).message}\n`)
+    }
+  }
+}

--- a/telegram-plugin/tests/finalize-callback.test.ts
+++ b/telegram-plugin/tests/finalize-callback.test.ts
@@ -1,0 +1,190 @@
+/**
+ * Pin the three-invariant contract for `finalizeCallback`. Every other
+ * inline-keyboard callback handler in the gateway routes through this
+ * helper, so a regression here breaks the audit-wide button UX
+ * (#1150 + follow-ups).
+ *
+ *   1. Visible press feedback (answerCallbackQuery with text).
+ *   2. Keyboard collapses + status line appended (one atomic edit).
+ *   3. synthInbound fires AFTER the message edit lands, errors
+ *      swallowed but logged.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { finalizeCallback, type FinalizeCallbackContext } from '../inline-keyboard-callbacks.js'
+
+interface Capture {
+  acks: Array<{ text?: string; show_alert?: boolean }>
+  edits: Array<{ text: string; opts: Record<string, unknown> }>
+  ackThrows?: Error
+  editThrows?: Error
+}
+
+function mkCtx(cap: Capture): FinalizeCallbackContext {
+  return {
+    answerCallbackQuery: async (opts) => {
+      cap.acks.push(opts ?? {})
+      if (cap.ackThrows) throw cap.ackThrows
+      return true
+    },
+    editMessageText: async (text, opts) => {
+      cap.edits.push({ text, opts: opts ?? {} })
+      if (cap.editThrows) throw cap.editThrows
+      return { message_id: 1 }
+    },
+  }
+}
+
+describe('finalizeCallback — three-invariant contract', () => {
+  it('invariant 1: acks the callback with the supplied toast text', async () => {
+    const cap: Capture = { acks: [], edits: [] }
+    await finalizeCallback(mkCtx(cap), {
+      ackText: 'Approved',
+      newText: 'Original prompt\n\n✓ Approved by @op',
+    })
+    expect(cap.acks).toHaveLength(1)
+    expect(cap.acks[0]?.text).toBe('Approved')
+    expect(cap.acks[0]?.show_alert).toBeUndefined()
+  })
+
+  it('invariant 1: alert=true renders as full modal (show_alert: true)', async () => {
+    const cap: Capture = { acks: [], edits: [] }
+    await finalizeCallback(mkCtx(cap), {
+      ackText: 'Vault grant revoked',
+      alert: true,
+      newText: '...',
+    })
+    expect(cap.acks[0]?.show_alert).toBe(true)
+  })
+
+  it('invariant 2: strips reply_markup AND edits the body in one atomic call', async () => {
+    const cap: Capture = { acks: [], edits: [] }
+    await finalizeCallback(mkCtx(cap), {
+      ackText: 'Approved',
+      newText: '✓ Approved\n\nGrant minted at 22:38 UTC',
+      parseMode: 'HTML',
+    })
+    expect(cap.edits).toHaveLength(1)
+    expect(cap.edits[0]?.text).toBe('✓ Approved\n\nGrant minted at 22:38 UTC')
+    expect(cap.edits[0]?.opts.reply_markup).toEqual({ inline_keyboard: [] })
+    expect(cap.edits[0]?.opts.parse_mode).toBe('HTML')
+    // link_preview_options disabled by default — keeps the edited
+    // status line from rendering a stale preview card.
+    expect(cap.edits[0]?.opts.link_preview_options).toEqual({ is_disabled: true })
+  })
+
+  it('invariant 2: omits parse_mode when not specified (plain text)', async () => {
+    const cap: Capture = { acks: [], edits: [] }
+    await finalizeCallback(mkCtx(cap), { ackText: 'ok', newText: 'plain' })
+    expect(cap.edits[0]?.opts.parse_mode).toBeUndefined()
+  })
+
+  it('invariant 3: synthInbound fires AFTER editMessageText resolves', async () => {
+    const order: string[] = []
+    const ctx: FinalizeCallbackContext = {
+      answerCallbackQuery: async () => { order.push('ack'); return true },
+      editMessageText: async () => {
+        order.push('edit-start')
+        await new Promise((r) => setTimeout(r, 5))
+        order.push('edit-end')
+        return { message_id: 1 }
+      },
+    }
+    await finalizeCallback(ctx, {
+      ackText: 'ok',
+      newText: '...',
+      synthInbound: () => { order.push('synth') },
+    })
+    // ack is fire-and-forget so its position is "no later than edit-start"
+    // but we don't pin its exact position. Pin that synth comes AFTER
+    // edit-end — that's the guarantee callers need.
+    const editEndIdx = order.indexOf('edit-end')
+    const synthIdx = order.indexOf('synth')
+    expect(editEndIdx).toBeGreaterThanOrEqual(0)
+    expect(synthIdx).toBeGreaterThan(editEndIdx)
+  })
+
+  it('invariant 3: async synthInbound is awaited', async () => {
+    let synthResolved = false
+    const cap: Capture = { acks: [], edits: [] }
+    await finalizeCallback(mkCtx(cap), {
+      ackText: 'ok',
+      newText: '...',
+      synthInbound: async () => {
+        await new Promise((r) => setTimeout(r, 5))
+        synthResolved = true
+      },
+    })
+    expect(synthResolved).toBe(true)
+  })
+
+  it('invariant 3: synthInbound errors are caught + logged, never propagated', async () => {
+    const logs: string[] = []
+    const cap: Capture = { acks: [], edits: [] }
+    await expect(
+      finalizeCallback(mkCtx(cap), {
+        ackText: 'ok',
+        newText: '...',
+        synthInbound: () => { throw new Error('inject_inbound IPC closed') },
+        log: (l) => logs.push(l),
+      }),
+    ).resolves.toBeUndefined()
+    expect(logs.some((l) => l.includes('inject_inbound IPC closed'))).toBe(true)
+  })
+
+  it('robustness: editMessageText failure does NOT block synthInbound', async () => {
+    // Operator deleted the card between tap and our edit — Telegram
+    // returns MESSAGE_TO_EDIT_NOT_FOUND. The model still needs to wake
+    // up: a stale/missing card is preferred to a stuck conversation.
+    const logs: string[] = []
+    let synthFired = false
+    const cap: Capture = {
+      acks: [],
+      edits: [],
+      editThrows: new Error('Bad Request: message to edit not found'),
+    }
+    await finalizeCallback(mkCtx(cap), {
+      ackText: 'Approved',
+      newText: '...',
+      synthInbound: () => { synthFired = true },
+      log: (l) => logs.push(l),
+    })
+    expect(synthFired).toBe(true)
+    expect(logs.some((l) => l.includes('message to edit not found'))).toBe(true)
+  })
+
+  it('robustness: answerCallbackQuery failure does NOT block edit or synth', async () => {
+    // Telegram rejects the ack (e.g. the callback_query is already
+    // older than the 60s timeout). The edit + synth still must proceed.
+    const logs: string[] = []
+    let synthFired = false
+    const cap: Capture = {
+      acks: [],
+      edits: [],
+      ackThrows: new Error('query is too old'),
+    }
+    await finalizeCallback(mkCtx(cap), {
+      ackText: 'Approved',
+      newText: 'edited body',
+      synthInbound: () => { synthFired = true },
+      log: (l) => logs.push(l),
+    })
+    expect(cap.edits).toHaveLength(1)
+    expect(cap.edits[0]?.text).toBe('edited body')
+    expect(synthFired).toBe(true)
+    // ack fire-and-forget — its catch fires asynchronously; give it a tick
+    // so the log assertion is stable across runs.
+    await new Promise((r) => setTimeout(r, 0))
+    expect(logs.some((l) => l.includes('query is too old'))).toBe(true)
+  })
+
+  it('synthInbound is optional — surfaces with no model in the loop just ack + edit', async () => {
+    const cap: Capture = { acks: [], edits: [] }
+    await finalizeCallback(mkCtx(cap), {
+      ackText: 'Dismissed',
+      newText: '✗ Dismissed',
+    })
+    expect(cap.acks).toHaveLength(1)
+    expect(cap.edits).toHaveLength(1)
+  })
+})


### PR DESCRIPTION
## Summary
Foundation PR for the #1150 fix. Adds a centralized \`finalizeCallback\` helper that pins the three button-UX invariants every callback handler in the gateway must satisfy:

1. **Visible press feedback** — \`answerCallbackQuery\` with \`text:\` (toast).
2. **Keyboard collapses + status line** — one atomic \`editMessageText\` with \`reply_markup: { inline_keyboard: [] }\`.
3. **synthInbound runs AFTER the edit** — the side effect that wakes the agent's session.

No behavior change yet. Follow-up PRs migrate call-sites surface by surface (vault request-access first since that's the #1150 root cause).

## Why
Audit (see issue #1150 thread) found 5 P0 surfaces + 4 P1 surfaces where one or more invariants are silently broken. The permission request card leaves buttons tappable after Allow/Deny. The vault grant wizard success card stays re-tappable. \`vault_request_access\` Approve mints the grant but never synthesizes the wake-up inbound (the #1150 root cause). The existing pattern of "every handler hand-codes the three-step dance" is exactly why these regressions slipped — centralize once, pin with tests, migrate.

## Test plan
- [x] \`vitest run telegram-plugin/tests/finalize-callback.test.ts\` — 10/10 pass (toast + atomic edit + post-edit synth + 3 edge cases)
- [x] \`npm run lint\` — clean
- [ ] Follow-up PRs route every existing callback handler through this helper

🤖 Generated with [Claude Code](https://claude.com/claude-code)