### PR TITLE
fix(gateway): #1150 — buffer synthetic inbounds on bridge disconnect + deny-side wake-up

### DIFF
--- a/scripts/check-bot-api-wrapping.sh
+++ b/scripts/check-bot-api-wrapping.sh
@@ -87,19 +87,19 @@ ALLOWLIST=(
   # The caller dropped the thread; this raw sendMessage retries on the
   # main chat. Wrapping would re-enter the THREAD_NOT_FOUND throw on a
   # phantom second deletion.
-  "telegram-plugin/gateway/gateway.ts:3160-3320:reply chunk-loop THREAD_NOT_FOUND fallback (intentional raw)"
+  "telegram-plugin/gateway/gateway.ts:3160-3340:reply chunk-loop THREAD_NOT_FOUND fallback (intentional raw)"
 
   # credit-watch notification. No thread_id (DM).
   # Range bumped 2026-05-13 for stuck-turn-recovery (#1136) v2 cleanup
   # (~100 lines) + gate-deny-log helper (~65 lines).
-  "telegram-plugin/gateway/gateway.ts:8100-8330:credit-watch notify; no thread_id"
+  "telegram-plugin/gateway/gateway.ts:8100-8400:credit-watch notify; no thread_id"
 
   # gateway.ts:9260-9490 — ctx.api.editMessageText for vault grant wizard
   # cards. Every callsite has `.catch(() => {})` — a THREAD_NOT_FOUND
   # is already swallowed there. Acceptable because the wizard messages
   # are tap-driven UI and a missed edit just leaves the previous state
   # visible (the user can re-tap).
-  "telegram-plugin/gateway/gateway.ts:9340-9790:vault grant wizard ctx.api.editMessageText already has .catch swallow"
+  "telegram-plugin/gateway/gateway.ts:9340-9890:vault grant wizard ctx.api.editMessageText already has .catch swallow"
 
   # boot-card.ts and issues-card.ts: these MODULES receive a bot adapter
   # via DI. The gateway wires those adapters through robustApiCall (see

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -150,6 +150,7 @@ import {
   parseAgentCallback,
   extractAgentButtonMeta,
   keyboardIsSingleUse,
+  finalizeCallback,
   type AgentButtonMeta,
 } from '../inline-keyboard-callbacks.js'
 import {
@@ -223,6 +224,7 @@ import type { AgentAudit } from '../welcome-text.js'
 import { shouldSweepChatAtBoot } from './boot-sweep-filter.js'
 
 import { createIpcServer, type IpcClient, type IpcServer } from './ipc-server.js'
+import { createPendingInboundBuffer } from './pending-inbound-buffer.js'
 import { createPollHealthCheck, type PollHealthCheckHandle } from './poll-health.js'
 import type {
   ToolCallMessage,
@@ -2620,12 +2622,42 @@ silencePoke.startTimer({
   },
 })
 
+// Per-agent buffer for synthetic inbounds the gateway couldn't deliver
+// because the bridge wasn't connected at send-time. Drained on
+// bridge-register so a fresh client picks up missed wake-ups before
+// any other work happens. See #1150 — pre-buffer, an Approve tap on a
+// vault_request_access card during the 100ms bridge-reconnect window
+// would mint the grant but silently drop the `vault_grant_approved`
+// inbound, leaving the agent stuck waiting for a manual poke.
+const pendingInboundBuffer = createPendingInboundBuffer()
+
 const ipcServer: IpcServer = createIpcServer({
   socketPath: SOCKET_PATH,
 
   onClientRegistered(client: IpcClient) {
     process.stderr.write(`telegram gateway: bridge registered — agent=${client.agentName}\n`)
     client.send({ type: 'status', status: 'agent_connected' })
+
+    // #1150: drain any synthetic inbounds queued for this agent while
+    // the bridge was offline. Done BEFORE the boot-card path below so
+    // the agent wakes up to its missed wake-ups first, even if the
+    // boot card edit happens to be slow. Skip drain when agentName is
+    // null (pre-handshake / anonymous client) — those clients are
+    // bridges that never registered an identity and can't have
+    // accumulated buffered inbounds keyed by name.
+    if (client.agentName != null) {
+      const pending = pendingInboundBuffer.drain(client.agentName)
+      for (const msg of pending) {
+        try {
+          client.send(msg)
+        } catch (err) {
+          process.stderr.write(
+            `telegram gateway: pending-inbound drain failed agent=${client.agentName} ` +
+            `source=${msg.meta?.source ?? '-'}: ${(err as Error).message}\n`,
+          )
+        }
+      }
+    }
 
     // If the agent reconnected after a /restart (or any restart), post a boot
     // card. The restart-marker carries the ack chat; if absent we fall back to
@@ -2929,6 +2961,12 @@ const ipcServer: IpcServer = createIpcServer({
     process.stderr.write(
       `telegram gateway: inject_inbound agent=${msg.agentName} source=${source} prompt_key=${promptKey} delivered=${delivered}\n`,
     )
+    // #1150: same buffer-on-failure pattern as vault_grant_approved.
+    // Cron fires use this path too — if a cron-driven wake-up lands
+    // mid bridge-reconnect, buffer it for the next register.
+    if (!delivered) {
+      pendingInboundBuffer.push(msg.agentName, msg.inbound)
+    }
   },
 
   log: (msg) => process.stderr.write(`telegram gateway: ipc — ${msg}\n`),
@@ -9134,6 +9172,16 @@ async function performVaultAccessApproval(
     `telegram gateway: vault_grant_approved injection agent=${pending.agent} ` +
     `key=${pending.key} stage=${stageId} delivered=${delivered}\n`,
   )
+  // #1150 root cause: if `delivered=false` the bridge wasn't connected
+  // at send-time (mid-reconnect, claude-session bouncing between
+  // turns, etc). Pre-fix this just logged + dropped — the agent stayed
+  // idle forever and the operator had to poke. Now we buffer the
+  // inbound so the next bridge-register call drains it. Bounded to
+  // 32 entries per agent (see pending-inbound-buffer.ts) — a never-
+  // reconnecting bridge can't fill memory.
+  if (!delivered) {
+    pendingInboundBuffer.push(pending.agent, synthetic)
+  }
 }
 
 async function handleVaultRequestAccessCallback(ctx: Context, data: string): Promise<void> {
@@ -9178,6 +9226,45 @@ async function handleVaultRequestAccessCallback(ctx: Context, data: string): Pro
           { parse_mode: 'HTML', reply_markup: { inline_keyboard: [] } },
         )
         .catch(() => {})
+    }
+    // #1150 sibling: invariant-3 was missing on the deny path too. The
+    // agent originally ended its turn after `vault_request_access` and
+    // waits for the gateway to wake it. On approve we already inject
+    // `vault_grant_approved` (#1052); now we mirror that for deny so
+    // the agent can pick the fallback path (apologise to the user,
+    // try a different approach, skip the feature) instead of staying
+    // wedged forever. Buffer-on-failure so a mid-reconnect bridge
+    // still receives this on its next register.
+    const denyTs = Date.now()
+    const denyInbound: InboundMessage = {
+      type: 'inbound',
+      chatId: pending.chat_id,
+      messageId: denyTs,
+      user: 'vault-broker',
+      userId: 0,
+      ts: denyTs,
+      text:
+        `🚫 Operator denied your vault access request for ` +
+        `\`${pending.key}\` (scope=${pending.scope}). ` +
+        `The credential is unavailable — pick a fallback for the original task ` +
+        `(apologise to the user, try a different approach, or skip the feature). ` +
+        `Do NOT re-request this key without first asking the user.`,
+      meta: {
+        source: 'vault_grant_denied',
+        agent: pending.agent,
+        key: pending.key,
+        scope: pending.scope,
+        stage_id: stageId,
+        operator_id: senderId,
+      },
+    }
+    const denyDelivered = ipcServer.sendToAgent(pending.agent, denyInbound)
+    process.stderr.write(
+      `telegram gateway: vault_grant_denied injection agent=${pending.agent} ` +
+      `key=${pending.key} stage=${stageId} delivered=${denyDelivered}\n`,
+    )
+    if (!denyDelivered) {
+      pendingInboundBuffer.push(pending.agent, denyInbound)
     }
     return
   }
@@ -12075,6 +12162,10 @@ function flushReactionBatch(batch: ReactionBatch): void {
     `telegram gateway: reactions.dispatch agent=${agentName} chat=${batch.chatId} ` +
     `count=${batch.reactions.length} batched=${batch.batched} delivered=${delivered}\n`,
   )
+  // #1150: buffer-on-failure for reaction-triggered wake-ups too.
+  if (!delivered) {
+    pendingInboundBuffer.push(agentName, inbound)
+  }
 }
 
 // ─── Inbound message_reaction handler ────────────────────────────────────

--- a/telegram-plugin/gateway/pending-inbound-buffer.ts
+++ b/telegram-plugin/gateway/pending-inbound-buffer.ts
@@ -1,0 +1,106 @@
+/**
+ * Per-agent buffer for synthetic inbounds the gateway couldn't deliver
+ * because no live IPC client was registered for the agent at send-time.
+ *
+ * Background: `ipcServer.sendToAgent(agent, msg)` returns `false` when
+ * the agent's bridge isn't connected. Before this buffer existed, the
+ * gateway logged the failure and dropped the message — root cause of
+ * issue #1150 (operator taps Approve on a vault_request_access card,
+ * grant lands, but the `vault_grant_approved` inbound that wakes the
+ * agent never arrives if the bridge happens to be reconnecting in
+ * that exact 100ms window).
+ *
+ * Contract:
+ *   - `push(agent, msg)` is best-effort and synchronous. Bounded:
+ *     a slow / dead bridge can't fill memory.
+ *   - `drain(agent)` returns ALL pending messages for `agent` in
+ *     insertion order and removes them from the buffer. Called from
+ *     `onClientRegistered` so a fresh bridge picks up the missed
+ *     wake-ups before doing anything else.
+ *   - In-memory only. Survives across IPC disconnect/reconnect within
+ *     a single gateway-process lifetime, but NOT a gateway restart.
+ *     A gateway crash mid-buffer means lost wake-ups; the silence-
+ *     poke ladder catches this downstream so the worst-case is a
+ *     5-minute delay, not a permanent stall.
+ *
+ * Per-agent cap prevents a never-reconnecting bridge from leaking
+ * unbounded memory. When the cap is hit, the OLDEST entry is dropped
+ * — the assumption is the freshest wake-up is the most relevant. A
+ * dropped entry is logged via the provided logger.
+ */
+
+import type { InboundMessage } from './ipc-protocol.js'
+
+/** Default cap per agent. Tuned for `should fit a reasonable backlog of
+ *  approval cards stacked while bridge is offline` but no more. */
+export const DEFAULT_PENDING_INBOUND_CAP = 32
+
+export interface PendingInboundBuffer {
+  /** Append `msg` to `agent`'s queue. Returns true if accepted, false if
+   *  the cap forced an eviction (the message is STILL accepted; `false`
+   *  signals "tail dropped to make room"). */
+  push: (agent: string, msg: InboundMessage) => boolean
+  /** Pop and return all pending messages for `agent`. Empty array when
+   *  none. Idempotent. */
+  drain: (agent: string) => InboundMessage[]
+  /** Test-only: current depth for `agent`. */
+  depth: (agent: string) => number
+  /** Test-only: total depth across all agents. */
+  totalDepth: () => number
+}
+
+export interface PendingInboundBufferOptions {
+  capPerAgent?: number
+  log?: (line: string) => void
+}
+
+export function createPendingInboundBuffer(
+  opts: PendingInboundBufferOptions = {},
+): PendingInboundBuffer {
+  const cap = opts.capPerAgent ?? DEFAULT_PENDING_INBOUND_CAP
+  const log = opts.log ?? ((line: string) => process.stderr.write(line))
+  const queues = new Map<string, InboundMessage[]>()
+
+  return {
+    push(agent, msg) {
+      let q = queues.get(agent)
+      if (q == null) {
+        q = []
+        queues.set(agent, q)
+      }
+      let evicted = false
+      if (q.length >= cap) {
+        const dropped = q.shift()
+        evicted = true
+        log(
+          `pending-inbound-buffer: agent=${agent} cap=${cap} reached — ` +
+          `dropped oldest entry source=${dropped?.meta?.source ?? '-'} ts=${dropped?.ts ?? '-'}\n`,
+        )
+      }
+      q.push(msg)
+      log(
+        `pending-inbound-buffer: agent=${agent} buffered source=${msg.meta?.source ?? '-'} ` +
+        `depth_after=${q.length} evicted=${evicted}\n`,
+      )
+      return !evicted
+    },
+    drain(agent) {
+      const q = queues.get(agent)
+      if (q == null || q.length === 0) return []
+      queues.delete(agent)
+      log(
+        `pending-inbound-buffer: drained agent=${agent} count=${q.length} ` +
+        `sources=[${q.map((m) => m.meta?.source ?? '-').join(',')}]\n`,
+      )
+      return q
+    },
+    depth(agent) {
+      return queues.get(agent)?.length ?? 0
+    },
+    totalDepth() {
+      let n = 0
+      for (const q of queues.values()) n += q.length
+      return n
+    },
+  }
+}

--- a/telegram-plugin/tests/pending-inbound-buffer.test.ts
+++ b/telegram-plugin/tests/pending-inbound-buffer.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Pin the per-agent inbound buffer that closes the #1150 root cause:
+ * if the gateway tries to deliver a synthetic inbound while the agent's
+ * bridge isn't connected (mid-reconnect, claude-session bouncing, etc),
+ * the inbound used to be silently dropped. Now it's buffered and
+ * drained on the next bridge-register.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { createPendingInboundBuffer, DEFAULT_PENDING_INBOUND_CAP } from '../gateway/pending-inbound-buffer.js'
+import type { InboundMessage } from '../gateway/ipc-protocol.js'
+
+function inbound(source: string, ts = Date.now()): InboundMessage {
+  return {
+    type: 'inbound',
+    chatId: 'c1',
+    messageId: ts,
+    user: 'vault-broker',
+    userId: 0,
+    ts,
+    text: `synthetic ${source}`,
+    meta: { source },
+  }
+}
+
+describe('pending-inbound-buffer', () => {
+  it('push + drain — FIFO order per agent', () => {
+    const buf = createPendingInboundBuffer({ log: () => {} })
+    buf.push('a', inbound('vault_grant_approved', 1))
+    buf.push('a', inbound('cron', 2))
+    buf.push('a', inbound('reaction', 3))
+    const drained = buf.drain('a')
+    expect(drained.map((m) => m.meta?.source)).toEqual([
+      'vault_grant_approved',
+      'cron',
+      'reaction',
+    ])
+  })
+
+  it('drain is idempotent — second call returns empty', () => {
+    const buf = createPendingInboundBuffer({ log: () => {} })
+    buf.push('a', inbound('x'))
+    expect(buf.drain('a')).toHaveLength(1)
+    expect(buf.drain('a')).toHaveLength(0)
+  })
+
+  it('drain only affects the named agent', () => {
+    const buf = createPendingInboundBuffer({ log: () => {} })
+    buf.push('a', inbound('x'))
+    buf.push('b', inbound('y'))
+    expect(buf.drain('a').map((m) => m.meta?.source)).toEqual(['x'])
+    expect(buf.depth('b')).toBe(1)
+    expect(buf.drain('b').map((m) => m.meta?.source)).toEqual(['y'])
+  })
+
+  it('respects per-agent cap — oldest evicted when full', () => {
+    const buf = createPendingInboundBuffer({ capPerAgent: 3, log: () => {} })
+    // Push 1 .. 5; cap is 3 so 1, 2 should be evicted.
+    buf.push('a', inbound('m1', 1))
+    buf.push('a', inbound('m2', 2))
+    buf.push('a', inbound('m3', 3))
+    buf.push('a', inbound('m4', 4))
+    buf.push('a', inbound('m5', 5))
+    expect(buf.depth('a')).toBe(3)
+    const drained = buf.drain('a')
+    expect(drained.map((m) => m.meta?.source)).toEqual(['m3', 'm4', 'm5'])
+  })
+
+  it('push returns false when eviction occurred', () => {
+    const buf = createPendingInboundBuffer({ capPerAgent: 2, log: () => {} })
+    expect(buf.push('a', inbound('m1'))).toBe(true)
+    expect(buf.push('a', inbound('m2'))).toBe(true)
+    expect(buf.push('a', inbound('m3'))).toBe(false) // evicted m1
+  })
+
+  it('default cap is 32', () => {
+    expect(DEFAULT_PENDING_INBOUND_CAP).toBe(32)
+    const buf = createPendingInboundBuffer({ log: () => {} })
+    for (let i = 0; i < 32; i++) buf.push('a', inbound(`m${i}`, i))
+    expect(buf.depth('a')).toBe(32)
+    buf.push('a', inbound('m33', 33))
+    expect(buf.depth('a')).toBe(32) // still at cap
+  })
+
+  it('logs on eviction', () => {
+    const logs: string[] = []
+    const buf = createPendingInboundBuffer({ capPerAgent: 1, log: (l) => logs.push(l) })
+    buf.push('a', inbound('m1', 1))
+    buf.push('a', inbound('m2', 2)) // evicts m1
+    expect(logs.some((l) => l.includes('cap=1') && l.includes('dropped oldest'))).toBe(true)
+    expect(logs.some((l) => l.includes('m1'))).toBe(true)
+  })
+
+  it('logs on push (depth tracking visibility)', () => {
+    const logs: string[] = []
+    const buf = createPendingInboundBuffer({ log: (l) => logs.push(l) })
+    buf.push('a', inbound('vault_grant_approved'))
+    expect(logs.some((l) => l.includes('agent=a buffered source=vault_grant_approved depth_after=1'))).toBe(true)
+  })
+
+  it('logs on drain with source listing', () => {
+    const logs: string[] = []
+    const buf = createPendingInboundBuffer({ log: (l) => logs.push(l) })
+    buf.push('a', inbound('vault_grant_approved'))
+    buf.push('a', inbound('cron'))
+    logs.length = 0
+    buf.drain('a')
+    expect(logs.some((l) => l.includes('drained agent=a count=2'))).toBe(true)
+    expect(logs.some((l) => l.includes('sources=[vault_grant_approved,cron]'))).toBe(true)
+  })
+
+  it('drain on empty agent does not log', () => {
+    const logs: string[] = []
+    const buf = createPendingInboundBuffer({ log: (l) => logs.push(l) })
+    expect(buf.drain('never-pushed')).toEqual([])
+    expect(logs).toEqual([])
+  })
+
+  it('depth and totalDepth track correctly across agents', () => {
+    const buf = createPendingInboundBuffer({ log: () => {} })
+    expect(buf.totalDepth()).toBe(0)
+    buf.push('a', inbound('x'))
+    buf.push('a', inbound('y'))
+    buf.push('b', inbound('z'))
+    expect(buf.depth('a')).toBe(2)
+    expect(buf.depth('b')).toBe(1)
+    expect(buf.depth('c')).toBe(0)
+    expect(buf.totalDepth()).toBe(3)
+    buf.drain('a')
+    expect(buf.totalDepth()).toBe(1)
+  })
+})


### PR DESCRIPTION
## Summary
Resolves #1150. Two related fixes:

1. **Silently-dropped wake-ups on bridge disconnect** — \`ipcServer.sendToAgent\` returned \`false\` when the bridge wasn't connected and the gateway just logged + dropped. Now buffered to a per-agent FIFO (capped at 32) and drained on \`onClientRegistered\`.
2. **\`vault_grant_denied\` was never wired** — Deny branch ack'd + edited the card and stopped. Agent stayed wedged on a denied request. Now synthesizes a deny-side wake-up steering the model toward a fallback.

## Why
Per the #1150 repro: Approve mints the grant correctly but no \`vault_grant_approved\` inbound arrives → agent idle until operator pokes. Root cause: \`sendToAgent\` ran during a 100ms bridge-reconnect window and the inbound was dropped without retry or buffer.

The buffer is wired into all three \`sendToAgent\` callsites (\`performVaultAccessApproval\`, \`onInjectInbound\` for cron, \`flushReactionBatch\` for reactions) so the same delivery-reliability win covers cron-triggered wake-ups and reaction-triggered turns too.

## Test plan
- [x] \`vitest run telegram-plugin/tests/pending-inbound-buffer.test.ts\` — 11/11
- [x] \`npm run lint\` — clean (allowlist range bumps mechanical)
- [ ] Manual: live-fleet repro of the #1150 scenario

## Out of scope
- Migrating the handler through the new \`finalizeCallback\` helper (#1152). Separate slice — this PR fixes the underlying delivery bug while preserving the existing UX.
- The other inline-keyboard surfaces in the audit (permission-request card re-tappable, recent-denial one-tap missing keyboard strip, etc). Follow-up PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)