### PR TITLE
fix(gateway): escape source-text in 2 pre-existing finalizeCallback-class callsites (#1160 review item F)

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -10088,8 +10088,14 @@ async function handleVaultGrantCallback(ctx: Context, data: string): Promise<voi
       pendingVaultOps.set(chatId, { ...state, awaitingCustomDuration: true })
       const msg = ctx.callbackQuery?.message
       if (msg && 'text' in msg && msg.text) {
+        // Escape source text before re-rendering with HTML parse mode.
+        // `msg.text` returns entities-stripped plain UTF-8; a raw
+        // `<`/`>`/`&` in the wizard's prior-step body (e.g. a future
+        // key or label) would crash the HTML re-parse and the bare
+        // `.catch(() => {})` would swallow the failure silently — same
+        // hazard PR #1158 caught on the operator-event card.
         await ctx.editMessageText(
-          msg.text + '\n\n<i>Send a duration like <code>30d</code> or <code>12h</code>:</i>',
+          escapeHtmlForTg(msg.text) + '\n\n<i>Send a duration like <code>30d</code> or <code>12h</code>:</i>',
           { parse_mode: 'HTML', reply_markup: buildGrantDurationKeyboard() },
         ).catch(() => {})
       }
@@ -11329,12 +11335,21 @@ bot.on('callback_query:data', async ctx => {
     // Edit the question in place to remove the buttons + show the
     // chosen option as a checkmarked line. Makes the chat surface
     // self-documenting — no orphaned-buttons graveyard.
+    //
+    // Escape `sourceMsg.text` before re-rendering with HTML parse
+    // mode. `msg.text` returns entities-stripped plain UTF-8; an
+    // agent-supplied `ask_user` question containing raw `<`/`>`/`&`
+    // (common in code-related questions like "Run `<command>`?")
+    // would crash the HTML re-parse, the try/catch would swallow,
+    // and the button keyboard would stay tappable — the exact bug
+    // PR #1158 caught on the operator-event card.
     const sourceMsg = ctx.callbackQuery?.message
     if (sourceMsg && 'text' in sourceMsg && sourceMsg.text != null) {
       try {
-        await ctx.editMessageText(`${sourceMsg.text}\n\n✅ <b>${escapeHtmlForTg(choice)}</b>`, {
-          parse_mode: 'HTML',
-        })
+        await ctx.editMessageText(
+          `${escapeHtmlForTg(sourceMsg.text)}\n\n✅ <b>${escapeHtmlForTg(choice)}</b>`,
+          { parse_mode: 'HTML' },
+        )
       } catch {
         /* edit-failed is fine — the answer-callback below still acks */
       }


### PR DESCRIPTION
## Summary
Closes the audit-grep gap from PR #1160's review. Two pre-existing callsites concat \`ctx.callbackQuery.message.text\` into HTML-parsed edits without escaping:

| Callsite | File:Line | Blast radius |
|---|---|---|
| \`vg:dur:custom\` (vault-grant wizard) | gateway.ts:10092 | Low — wizard's own text, no raw \`<>&\` today |
| \`ask-user\` answer-tap | gateway.ts:11335 | **High** — agent-supplied question, routinely carries \`<>&\` (e.g. \`Run \\\`<command>\\\`?\`) |

Same one-line \`escapeHtmlForTg\` fix as PR #1158 and #1160.

## Test plan
- [x] \`npm run lint\` — clean
- [x] finalize-callback tests pass
- [ ] Manual: agent calls \`ask_user\` with \`<\` in question, operator taps, confirm card edits cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)