### PR TITLE
fix(gateway): vault_request_save rename action — strip keyboard atomically (#1150 audit follow-up)

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -9448,7 +9448,27 @@ async function handleVaultRequestSaveCallback(ctx: Context, data: string): Promi
       stageId,
       startedAt: Date.now(),
     } as PendingVaultOp)
-    await ctx.answerCallbackQuery({ text: 'Send the new key name as your next message.' }).catch(() => {})
+    // #1150 audit P0: pre-fix the [Save once][Discard][Rename] keyboard
+    // stayed live after the rename tap so the operator could re-tap
+    // Save with the old key name mid-rename — a Save tap fires the
+    // write immediately, racing the rename intercept. Strip the
+    // keyboard atomically with a status line that names the rename
+    // mode + the proposed new-key prompt. No synthInbound — the
+    // agent's `vault_request_save` tool already returned "waiting
+    // for operator," and the eventual save success/failure flows
+    // its own wake-up below.
+    const sourceMsg = ctx.callbackQuery?.message
+    const baseText = sourceMsg && 'text' in sourceMsg && sourceMsg.text
+      ? escapeHtmlForTg(sourceMsg.text)
+      : ''
+    const statusLine =
+      `\n\n✏️ <b>Rename mode</b> — send the new key name as your next message. ` +
+      `The current proposed key is <code>${escapeHtmlForTg(pending.key)}</code>.`
+    await finalizeCallback(ctx, {
+      ackText: 'Send the new key name as your next message.',
+      newText: baseText ? `${baseText}${statusLine}` : statusLine,
+      parseMode: 'HTML',
+    })
     return
   }
 


### PR DESCRIPTION
## Summary
Closes the last remaining P0 surface from the #1150 audit goal-prompt. Routes the \`rename\` action of \`handleVaultRequestSaveCallback\` through \`finalizeCallback\` so the [Save once] / [Discard] / [Rename] keyboard strips on tap + appends a status line.

## Bug pre-fix
Operator taps Rename → gateway sets intercept + ack toast → **card unchanged, all buttons tappable**. Race: re-tapping Save before sending the new name fires the write with the OLD key name, silently abandoning the rename.

## Fix
Atomic edit via \`finalizeCallback\`. Keyboard gone → operator can't re-tap Save → forced through the intercept (text-reply with the new name) — matches the intended UX.

## All 5 P0 surfaces now migrated
- vault request-access (#1156)
- permission request card (#1157)
- recent-denial one-tap (#1157)
- vault grant wizard final card (#1157)
- **vault request-save rename** (THIS PR)

## Test plan
- [x] \`npm run lint\` — clean
- [ ] Manual: agent calls \`vault_request_save\`, operator taps [Rename], confirm keyboard disappears + status line appears, operator can no longer tap Save with old name

🤖 Generated with [Claude Code](https://claude.com/claude-code)