### PR TITLE
feat(compose): admin-gated bind_mounts: for per-agent host paths (#1164)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -395,6 +395,67 @@ For Claude Code settings switchroom doesn't wrap:
 - **`claude_md_raw:`** — appended verbatim to CLAUDE.md on initial scaffold
 - **`cli_args:`** — extra flags appended to `exec claude` in start.sh (POSIX-quoted)
 
+## Admin-Only: Extra Bind-Mounts (`bind_mounts:`)
+
+Agent containers ship with a fixed bind-mount set (state dir, .claude
+project dir, logs, read-only skills + credentials). That is the right
+default for the typical fleet — sandboxed agents stay isolated from
+the host's source trees and operator state.
+
+For the **dogfood / self-modification** case — an admin agent asked to
+fix a switchroom bug or edit a bundled skill — that isolation is the
+blocker. The agent can read `/opt/switchroom/switchroom.js` (the
+compiled bundle baked into the image) but not the TypeScript source
+on the host. `bind_mounts:` is the per-agent escape hatch.
+
+```yaml
+agents:
+  klanker:
+    admin: true                      # required — see "Admin gating" below
+    bind_mounts:
+      - source: /home/me/code/switchroom
+        mode: rw                     # read-write, for `bun build` + commits
+      - source: /home/me/code/some-other-repo
+        mode: ro                     # read-only is the default
+    add_dirs:
+      - /home/me/code/switchroom     # also extend claude's tool-reach allowlist
+      - /home/me/code/some-other-repo
+```
+
+Each entry takes:
+
+- **`source:`** (required) — absolute host path. Tilde-expansion is **not**
+  performed; pass the literal path. Refused if the path is under a
+  system-path denylist (`/`, `/etc`, `/proc`, `/sys`, `/dev`, `/run`,
+  `/var/run`, `/boot`, `/var/lib/docker`) or equals `/var/run/docker.sock`.
+- **`target:`** (optional) — container path the mount appears at.
+  Defaults to the same path as `source`, matching switchroom's existing
+  dual-mount convention so absolute paths in scaffolded scripts and tool
+  invocations Just Work.
+- **`mode:`** (optional, default `ro`) — `ro` or `rw`.
+
+### Admin gating
+
+`bind_mounts:` requires `admin: true` on the same agent. `switchroom apply`
+hard-fails if a non-admin agent declares it — silently dropping the
+entries would mask an intended privilege grant. The two are coupled
+deliberately: the same operator who already trusts an agent with vault
+grant-management (`/grant`) and fleet-admin slash commands (`/agents`,
+`/logs`, `/update`) is the right principal for source-tree access.
+
+If you want filesystem reach without admin powers, the right answer is
+to invoke a separate Claude session from outside switchroom (a host
+shell session) — not to relax the gate.
+
+### Pair with `add_dirs:`
+
+`bind_mounts:` makes the path **exist** inside the container.
+`add_dirs:` makes the claude CLI's tool-allowlist **include** it.
+You typically want both. Without `add_dirs:`, claude's Read/Edit tools
+will reject the path as outside the working set even though the file is
+there. Without `bind_mounts:`, the path doesn't exist in the sandbox and
+`add_dirs:` is a no-op.
+
 ## Minimal Example
 
 ```yaml

--- a/src/agents/compose.ts
+++ b/src/agents/compose.ts
@@ -26,7 +26,7 @@
 import { createHash } from "node:crypto";
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
-import type { SwitchroomConfig, AgentConfig } from "../config/schema.js";
+import type { SwitchroomConfig, AgentConfig, AgentBindMount } from "../config/schema.js";
 import { resolveAgentConfig } from "../config/merge.js";
 import { isReservedAgentName } from "../vault/broker/peercred.js";
 
@@ -254,6 +254,14 @@ interface AgentServiceData {
    */
   admin: boolean;
   /**
+   * Operator-declared extra bind-mounts (#1164). ADMIN-ONLY: validated
+   * + emitted by `emitAgentService` if and only if `admin === true`.
+   * Read directly from the per-agent config — deliberately not
+   * cascade-merged, so a profile can't silently grant filesystem reach
+   * to every agent that extends it.
+   */
+  bindMounts: AgentBindMount[];
+  /**
    * Operator-declared env vars from the cascade-resolved agent config
    * (`agent.env` block in switchroom.yaml). Propagated into the
    * compose `environment:` block so child processes forked
@@ -288,6 +296,9 @@ export function describeAgents(config: SwitchroomConfig): AgentServiceData[] {
       resources,
       strippedCaps,
       admin: agent.admin === true,
+      // Per-agent only (no cascade) — see AgentServiceData.bindMounts
+      // doc comment for the rationale.
+      bindMounts: agent.bind_mounts ? [...agent.bind_mounts] : [],
       // Read user env from the cascade-resolved config so defaults +
       // profile + agent layers all contribute. Empty object when the
       // operator hasn't declared any (the common case).
@@ -296,6 +307,86 @@ export function describeAgents(config: SwitchroomConfig): AgentServiceData[] {
     void resolved;
   }
   return out;
+}
+
+/**
+ * System paths refused as bind_mount sources, regardless of mode.
+ * Prefix-matched: an entry `/etc` rejects `/etc/foo` too.
+ *
+ * Mounting any of these inside an agent container is either pointless
+ * (the container has its own /proc, /sys, /dev) or a privilege-escalation
+ * vector (host `/etc` exposes shadow/passwd; `/var/lib/docker` and the
+ * docker socket give root-equivalent host control).
+ */
+const BIND_MOUNT_DENYLIST = [
+  "/",
+  "/etc",
+  "/proc",
+  "/sys",
+  "/dev",
+  "/run",
+  "/var/run",
+  "/boot",
+  "/var/lib/docker",
+];
+
+/** Exact source paths refused regardless of denylist prefix-matching. */
+const BIND_MOUNT_EXACT_DENY = new Set(["/var/run/docker.sock"]);
+
+/**
+ * Validate one entry from an agent's `bind_mounts:` list. Returns the
+ * resolved (source, target, mode) on success; throws a descriptive
+ * Error on rejection. Pure — no IO.
+ *
+ * Callers MUST also check the owning agent's `admin === true` before
+ * calling this; the admin gate is upstream (in emitAgentService).
+ */
+export function resolveBindMount(
+  agentName: string,
+  entry: AgentBindMount,
+): { source: string; target: string; mode: "ro" | "rw" } {
+  const source = entry.source;
+  if (typeof source !== "string" || source.length === 0) {
+    throw new Error(
+      `compose: agent "${agentName}" bind_mount has empty source`,
+    );
+  }
+  if (!source.startsWith("/")) {
+    throw new Error(
+      `compose: agent "${agentName}" bind_mount source "${source}" must be an absolute path ` +
+      `(tilde-expansion is not performed; pass the literal absolute path)`,
+    );
+  }
+  if (source.includes("/../") || source.endsWith("/..") || source === "/..") {
+    throw new Error(
+      `compose: agent "${agentName}" bind_mount source "${source}" contains '..' — refuse ambiguous paths`,
+    );
+  }
+  if (BIND_MOUNT_EXACT_DENY.has(source)) {
+    throw new Error(
+      `compose: agent "${agentName}" bind_mount source "${source}" is denylisted ` +
+      `(host docker socket — would grant root-equivalent control of the host)`,
+    );
+  }
+  for (const deny of BIND_MOUNT_DENYLIST) {
+    if (source === deny || source.startsWith(deny === "/" ? "/" : deny + "/")) {
+      // "/" matches everything, so handle it separately: only refuse the
+      // literal "/" as source. A path like "/home/x" passes — it merely
+      // *starts* with "/" but the denylist intent is "the root itself".
+      if (deny === "/" && source !== "/") continue;
+      throw new Error(
+        `compose: agent "${agentName}" bind_mount source "${source}" is under denylisted system path "${deny}"`,
+      );
+    }
+  }
+  const target = entry.target ?? source;
+  if (!target.startsWith("/")) {
+    throw new Error(
+      `compose: agent "${agentName}" bind_mount target "${target}" must be an absolute path`,
+    );
+  }
+  const mode = entry.mode ?? "ro";
+  return { source, target, mode };
 }
 
 /** Capability-add escape hatch — we strip these in Docker mode (RFC). */
@@ -894,6 +985,29 @@ function emitAgentService(
       lines.push(
         `      - ${homePrefix}/.switchroom/vault-audit.log:/state/agent/home/.switchroom/vault-audit.log:ro`,
       );
+    }
+  }
+  // Operator-declared extra bind-mounts (#1164). ADMIN-ONLY: emitting
+  // anything for a non-admin agent is a hard error — bind_mounts is the
+  // escape hatch that lets an agent dogfood / self-modify host source
+  // trees, so silently dropping the entries would mask a misconfigured
+  // privilege grant.
+  if (a.bindMounts.length > 0) {
+    if (!a.admin) {
+      throw new Error(
+        `compose: agent "${a.name}" declares bind_mounts but is not admin: true. ` +
+        `bind_mounts is an admin-only escalation (see issue #1164 and the bind_mounts ` +
+        `schema doc). Either set admin: true on this agent or remove bind_mounts.`,
+      );
+    }
+    for (const entry of a.bindMounts) {
+      const { source, target, mode } = resolveBindMount(a.name, entry);
+      // Match the existing :ro / no-suffix convention used by the
+      // skills/credentials mounts above. `:rw` is omitted because docker's
+      // default is read-write — being explicit would diverge from the
+      // surrounding lines and add noise.
+      const suffix = mode === "ro" ? ":ro" : "";
+      lines.push(`      - ${source}:${target}${suffix}`);
     }
   }
   // Dual mounts — the same host directory is bound BOTH at the canonical

--- a/src/build-info.ts
+++ b/src/build-info.ts
@@ -3,7 +3,7 @@
 // Values are refreshed every time `npm run build` runs.
 
 export const VERSION: string = "0.7.16";
-export const COMMIT_SHA: string | null = "8534cf75";
-export const COMMIT_DATE: string | null = "2026-05-12T12:11:45+10:00";
-export const LATEST_PR: number | null = 1075;
-export const COMMITS_AHEAD_OF_TAG: number | null = 78;
+export const COMMIT_SHA: string | null = "5c874b3d";
+export const COMMIT_DATE: string | null = "2026-05-13T10:02:26+10:00";
+export const LATEST_PR: number | null = 1162;
+export const COMMITS_AHEAD_OF_TAG: number | null = 124;

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -18,6 +18,49 @@ export const CodeRepoEntrySchema = z.object({
     .describe("Max simultaneous worktrees for this repo (default 5)"),
 });
 
+/**
+ * A single entry in an agent's bind_mounts list (#1164).
+ *
+ * Adds a host path to the agent container's bind-mount set, on top of the
+ * standard dual-mount baseline (agent state dir, .claude project dir, logs,
+ * read-only skills + credentials). Intended use case: dogfooding /
+ * self-modification — an admin agent that needs to read or edit the
+ * switchroom source tree at `~/code/switchroom`, or another repo not
+ * covered by the default mount policy.
+ *
+ * Admin-gated: the compose generator refuses to emit bind_mounts for an
+ * agent without `admin: true`. The denylist (`/`, `/etc`, `/proc`, `/sys`,
+ * `/dev`, `/run`, `/var/run`, `/boot`, `/var/lib/docker`, and the docker
+ * socket) is enforced in `src/agents/compose.ts`.
+ */
+export const AgentBindMountSchema = z.object({
+  source: z
+    .string()
+    .describe(
+      "Absolute host path to bind-mount into the container. Tilde-expansion " +
+      "is not performed — use the literal absolute path (e.g. " +
+      "'/home/me/code/switchroom'). The compose generator refuses sources " +
+      "under system paths (/, /etc, /proc, /sys, /dev, /run, /var/run, " +
+      "/boot, /var/lib/docker) and the docker socket.",
+    ),
+  target: z
+    .string()
+    .optional()
+    .describe(
+      "Container path the source mounts to. Must be absolute. Defaults to " +
+      "the same path as `source` (matches switchroom's existing dual-mount " +
+      "convention so absolute paths in scaffolded scripts Just Work).",
+    ),
+  mode: z
+    .enum(["ro", "rw"])
+    .optional()
+    .describe(
+      "Read-only (default) or read-write. Use `rw` only when the agent " +
+      "must mutate the host path (e.g. editing switchroom source). " +
+      "Default: 'ro'.",
+    ),
+});
+
 export const ScheduleEntrySchema = z.object({
   cron: z.string().describe("Cron expression (e.g., '0 8 * * *')"),
   prompt: z.string().describe("Prompt to send at the scheduled time"),
@@ -1251,7 +1294,24 @@ export const AgentSchema = z.object({
       "Additional filesystem paths the agent's tools can access. Passed " +
       "as repeated --add-dir <path> on the claude invocation. Use to grant " +
       "an agent reach into shared dirs (e.g. '/share/collab') without " +
-      "scaffold hacks. Per-agent only — paths are persona-specific. See #199."
+      "scaffold hacks. Per-agent only — paths are persona-specific. See #199. " +
+      "Note: this only adjusts the claude CLI's --add-dir tool-reach allowlist. " +
+      "If the path is not already inside the agent's container, also declare " +
+      "it in `bind_mounts:` (admin agents only) — otherwise the path doesn't " +
+      "exist inside the sandbox and --add-dir is a no-op."
+    ),
+  bind_mounts: z
+    .array(AgentBindMountSchema)
+    .optional()
+    .describe(
+      "Extra host paths bind-mounted into this agent's container, on top of " +
+      "the standard dual-mount baseline. ADMIN-ONLY: the compose generator " +
+      "refuses to emit bind_mounts unless `admin: true` is also set on the " +
+      "same agent. Use to dogfood / self-modify switchroom or another repo " +
+      "(see issue #1164). Pair with `add_dirs:` so claude's tool-reach " +
+      "allowlist also covers the mounted path. System paths (/, /etc, " +
+      "/proc, /sys, /dev, /run, /var/run, /boot, /var/lib/docker, " +
+      "/var/run/docker.sock) are denylisted regardless of mode."
     ),
   allowed_tools: z
     .array(z.string())
@@ -1597,4 +1657,5 @@ export type AgentDriveConfig = z.infer<typeof AgentDriveConfigSchema>;
 export type VaultBrokerConfig = z.infer<typeof VaultConfigSchema>["broker"];
 export type QuotaConfig = z.infer<typeof QuotaConfigSchema>;
 export type CodeRepoEntry = z.infer<typeof CodeRepoEntrySchema>;
+export type AgentBindMount = z.infer<typeof AgentBindMountSchema>;
 export type AgentRepoEntry = NonNullable<z.infer<typeof AgentSchema>["repos"]>[string];

--- a/tests/docker/compose-generator.test.ts
+++ b/tests/docker/compose-generator.test.ts
@@ -30,7 +30,7 @@ import {
 } from "../../src/agents/compose.js";
 import type { SwitchroomConfig } from "../../src/config/schema.js";
 
-function makeConfig(agents: Record<string, { extends?: string; settings_raw?: Record<string, unknown>; admin?: boolean; env?: Record<string, string> }>): SwitchroomConfig {
+function makeConfig(agents: Record<string, { extends?: string; settings_raw?: Record<string, unknown>; admin?: boolean; env?: Record<string, string>; bind_mounts?: Array<{ source: string; target?: string; mode?: "ro" | "rw" }> }>): SwitchroomConfig {
   return {
     switchroom: { version: 1, agents_dir: "~/.switchroom/agents", skills_dir: "~/.switchroom/skills" },
     telegram: { bot_token: "x" },
@@ -44,6 +44,7 @@ function makeConfig(agents: Record<string, { extends?: string; settings_raw?: Re
           settings_raw: cfg.settings_raw,
           admin: cfg.admin,
           env: cfg.env,
+          bind_mounts: cfg.bind_mounts,
           schedule: [],
           tools: { allow: [], deny: [] },
           hooks: undefined,
@@ -811,6 +812,197 @@ describe("agent service env (Phase 2c F2 — IPC wiring)", () => {
       expect(env).toMatch(/PIP_USER:\s*"1"/);
       expect(env).toMatch(/PIP_BREAK_SYSTEM_PACKAGES:\s*"1"/);
     }
+  });
+});
+
+describe("agent bind_mounts (#1164)", () => {
+  // Admin-gated escalation: admin agents can declare extra host paths
+  // to bind-mount into the container, on top of the standard dual-mount
+  // baseline. Use case: dogfooding switchroom from a switchroom agent.
+
+  it("emits a single :ro bind_mount under an admin agent's volumes", () => {
+    const out = generateCompose({
+      config: makeConfig({
+        klanker: {
+          admin: true,
+          bind_mounts: [{ source: "/home/me/code/switchroom" }],
+        },
+      }),
+    });
+    // Default mode is ro; default target is the same as source.
+    expect(out).toMatch(
+      /agent-klanker:[\s\S]*?- \/home\/me\/code\/switchroom:\/home\/me\/code\/switchroom:ro/,
+    );
+  });
+
+  it("emits :rw when mode is rw, and omits the suffix (docker default)", () => {
+    const out = generateCompose({
+      config: makeConfig({
+        klanker: {
+          admin: true,
+          bind_mounts: [{ source: "/home/me/code/switchroom", mode: "rw" }],
+        },
+      }),
+    });
+    expect(out).toMatch(
+      /- \/home\/me\/code\/switchroom:\/home\/me\/code\/switchroom\n/,
+    );
+    // The :ro suffix must not appear on the rw entry.
+    expect(out).not.toMatch(
+      /- \/home\/me\/code\/switchroom:\/home\/me\/code\/switchroom:ro/,
+    );
+  });
+
+  it("honours an explicit target distinct from source", () => {
+    const out = generateCompose({
+      config: makeConfig({
+        klanker: {
+          admin: true,
+          bind_mounts: [
+            { source: "/host/path", target: "/in/container", mode: "ro" },
+          ],
+        },
+      }),
+    });
+    expect(out).toMatch(/- \/host\/path:\/in\/container:ro/);
+  });
+
+  it("emits multiple bind_mounts in declared order", () => {
+    const out = generateCompose({
+      config: makeConfig({
+        klanker: {
+          admin: true,
+          bind_mounts: [
+            { source: "/a", mode: "ro" },
+            { source: "/b", mode: "rw" },
+          ],
+        },
+      }),
+    });
+    const idxA = out.indexOf("- /a:/a:ro");
+    const idxB = out.indexOf("- /b:/b\n");
+    expect(idxA).toBeGreaterThan(-1);
+    expect(idxB).toBeGreaterThan(-1);
+    expect(idxA).toBeLessThan(idxB);
+  });
+
+  it("throws when a non-admin agent declares bind_mounts", () => {
+    // fails when: the admin gate in emitAgentService is dropped. The
+    // operator could then silently grant filesystem reach to a
+    // non-admin agent just by adding bind_mounts to that agent's
+    // block — exactly the privilege escalation #1164's gating is
+    // meant to prevent.
+    expect(() =>
+      generateCompose({
+        config: makeConfig({
+          bob: {
+            bind_mounts: [{ source: "/home/me/code/switchroom" }],
+          },
+        }),
+      }),
+    ).toThrow(/agent "bob" declares bind_mounts but is not admin: true/);
+  });
+
+  it("non-admin agents emit no bind_mounts when none are declared (no regression)", () => {
+    const out = generateCompose({
+      config: makeConfig({ bob: {} }),
+    });
+    // No host path that doesn't already exist in the baseline.
+    expect(out).not.toMatch(/- \/home\/me\/code\/switchroom/);
+  });
+
+  it("rejects denylisted system-path sources", () => {
+    for (const bad of [
+      "/etc",
+      "/etc/passwd",
+      "/proc",
+      "/proc/1/environ",
+      "/sys/fs/cgroup",
+      "/dev",
+      "/run/foo",
+      "/var/run/whatever",
+      "/boot",
+      "/var/lib/docker/volumes",
+    ]) {
+      expect(() =>
+        generateCompose({
+          config: makeConfig({
+            klanker: {
+              admin: true,
+              bind_mounts: [{ source: bad }],
+            },
+          }),
+        }),
+      ).toThrow(/denylisted system path/);
+    }
+  });
+
+  it("rejects the docker socket explicitly (root-equivalent host control)", () => {
+    expect(() =>
+      generateCompose({
+        config: makeConfig({
+          klanker: {
+            admin: true,
+            bind_mounts: [{ source: "/var/run/docker.sock" }],
+          },
+        }),
+      }),
+    ).toThrow(/docker socket/);
+  });
+
+  it("rejects '/' itself as a source (would mount the entire host)", () => {
+    expect(() =>
+      generateCompose({
+        config: makeConfig({
+          klanker: {
+            admin: true,
+            bind_mounts: [{ source: "/" }],
+          },
+        }),
+      }),
+    ).toThrow(/denylisted system path/);
+  });
+
+  it("rejects relative or tilde-prefixed sources (no implicit expansion)", () => {
+    for (const bad of ["~/code/switchroom", "code/switchroom", "./foo"]) {
+      expect(() =>
+        generateCompose({
+          config: makeConfig({
+            klanker: {
+              admin: true,
+              bind_mounts: [{ source: bad }],
+            },
+          }),
+        }),
+      ).toThrow(/must be an absolute path/);
+    }
+  });
+
+  it("rejects sources containing '..'", () => {
+    expect(() =>
+      generateCompose({
+        config: makeConfig({
+          klanker: {
+            admin: true,
+            bind_mounts: [{ source: "/home/me/../etc/passwd" }],
+          },
+        }),
+      }),
+    ).toThrow(/contains '\.\.'/);
+  });
+
+  it("accepts sources whose path merely starts with '/' (not the literal root)", () => {
+    // Sanity that the BIND_MOUNT_DENYLIST '/' entry doesn't poison
+    // every legitimate absolute path.
+    const out = generateCompose({
+      config: makeConfig({
+        klanker: {
+          admin: true,
+          bind_mounts: [{ source: "/home/me/code/switchroom" }],
+        },
+      }),
+    });
+    expect(out).toContain("/home/me/code/switchroom:/home/me/code/switchroom:ro");
   });
 });
 


### PR DESCRIPTION
## Summary

Adds an admin-only `bind_mounts:` field to `switchroom.yaml` so an agent can be granted reach into host paths outside the standard dual-mount baseline. Closes the dogfooding gap RCA'd in #1164: a switchroom agent asked to fix a switchroom bug could read `/opt/switchroom/switchroom.js` (the compiled bundle baked into the image) but not the TypeScript source on the host.

- Schema (`AgentBindMountSchema`: `source`, `target?`, `mode? ro|rw`) + `bind_mounts` field on `AgentConfigSchema`. Per-agent only — deliberately not cascade-merged.
- Compose emission in `emitAgentService` after the audit-log mount block. **Hard-fails** if a non-admin agent declares `bind_mounts` — silently dropping entries would mask an intended privilege grant.
- Source-path denylist enforced in `resolveBindMount`: `/`, `/etc`, `/proc`, `/sys`, `/dev`, `/run`, `/var/run`, `/boot`, `/var/lib/docker`, plus an explicit refusal of `/var/run/docker.sock` (root-equivalent). Relative, tilde-prefixed, and `..`-containing sources are rejected.
- 12 new cases in `tests/docker/compose-generator.test.ts` cover emission, mode/target defaults, multi-entry ordering, the admin gate, the denylist, the docker-socket carve-out, relative-path rejection, and `..` rejection. Full vitest suite green (modulo one pre-existing `bun:test` glob-match in vitest that's unrelated).
- Docs section in `docs/configuration.md` covering the field, admin gating, denylist, and the pair-with-`add_dirs` guidance.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `tests/docker/compose-generator.test.ts` — 88/88 pass, including 12 new bind_mounts cases
- [x] full `vitest run` — 5578 pass, 1 pre-existing vitest-vs-bun:test glob-match unrelated to this change
- [x] `bun test` (telegram-plugin) — 727 pass, 0 fail
- [ ] Manual: declare `bind_mounts:` on klanker, `switchroom apply --check`, verify compose contains the line and `apply` self-elevates as expected. (Will exercise post-merge against a real fleet.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)