### PR TITLE
refactor(gateway): extract synth-inbound builders + 13 shape-pin tests (#1150 audit follow-up)

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -225,6 +225,10 @@ import { shouldSweepChatAtBoot } from './boot-sweep-filter.js'
 
 import { createIpcServer, type IpcClient, type IpcServer } from './ipc-server.js'
 import { createPendingInboundBuffer } from './pending-inbound-buffer.js'
+import {
+  buildVaultGrantApprovedInbound,
+  buildVaultGrantDeniedInbound,
+} from './vault-grant-inbound-builders.js'
 import { createPollHealthCheck, type PollHealthCheckHandle } from './poll-health.js'
 import type {
   ToolCallMessage,
@@ -9179,31 +9183,18 @@ async function performVaultAccessApproval(
   // knows (a) which key was approved, (b) at what scope, (c) what to
   // do next. Meta carries the structured fields for forensics + for
   // future filters that want to suppress these in the chat tail.
-  const grantedSyntheticTs = Date.now()
-  const synthetic: InboundMessage = {
-    type: 'inbound',
-    chatId: pending.chat_id,
-    messageId: grantedSyntheticTs, // synthetic — no Telegram message id exists
-    user: 'vault-broker',
-    userId: 0,
-    ts: grantedSyntheticTs,
-    text:
-      `✅ Operator approved your vault access request for ` +
-      `\`${pending.key}\` (scope=${pending.scope}, ` +
-      `${Math.round(pending.ttl_seconds / 86400)}d, grant=${id}). ` +
-      `The token has been written. Please resume the task that was ` +
-      `waiting on this credential — fetch via the usual switchroom vault ` +
-      `get path.`,
-    meta: {
-      source: 'vault_grant_approved',
+  const synthetic = buildVaultGrantApprovedInbound({
+    ctx: {
       agent: pending.agent,
       key: pending.key,
       scope: pending.scope,
-      grant_id: id,
-      stage_id: stageId,
-      operator_id: senderId,
+      chat_id: pending.chat_id,
+      ttl_seconds: pending.ttl_seconds,
     },
-  }
+    grantId: id,
+    stageId,
+    operatorId: senderId,
+  })
   const delivered = ipcServer.sendToAgent(pending.agent, synthetic)
   process.stderr.write(
     `telegram gateway: vault_grant_approved injection agent=${pending.agent} ` +
@@ -9272,29 +9263,17 @@ async function handleVaultRequestAccessCallback(ctx: Context, data: string): Pro
     // try a different approach, skip the feature) instead of staying
     // wedged forever. Buffer-on-failure so a mid-reconnect bridge
     // still receives this on its next register.
-    const denyTs = Date.now()
-    const denyInbound: InboundMessage = {
-      type: 'inbound',
-      chatId: pending.chat_id,
-      messageId: denyTs,
-      user: 'vault-broker',
-      userId: 0,
-      ts: denyTs,
-      text:
-        `🚫 Operator denied your vault access request for ` +
-        `\`${pending.key}\` (scope=${pending.scope}). ` +
-        `The credential is unavailable — pick a fallback for the original task ` +
-        `(apologise to the user, try a different approach, or skip the feature). ` +
-        `Do NOT re-request this key without first asking the user.`,
-      meta: {
-        source: 'vault_grant_denied',
+    const denyInbound = buildVaultGrantDeniedInbound({
+      ctx: {
         agent: pending.agent,
         key: pending.key,
         scope: pending.scope,
-        stage_id: stageId,
-        operator_id: senderId,
+        chat_id: pending.chat_id,
+        ttl_seconds: pending.ttl_seconds,
       },
-    }
+      stageId,
+      operatorId: senderId,
+    })
     const denyDelivered = ipcServer.sendToAgent(pending.agent, denyInbound)
     process.stderr.write(
       `telegram gateway: vault_grant_denied injection agent=${pending.agent} ` +

--- a/telegram-plugin/gateway/vault-grant-inbound-builders.ts
+++ b/telegram-plugin/gateway/vault-grant-inbound-builders.ts
@@ -1,0 +1,125 @@
+/**
+ * Pure builders for the synthetic `vault_grant_approved` and
+ * `vault_grant_denied` inbounds the gateway injects after the
+ * operator taps Approve / Deny on a `vault_request_access` card
+ * (#1052 / #1150).
+ *
+ * Extracted from `gateway.ts` so the InboundMessage shape is pinned
+ * by tests separate from the broker/IPC plumbing. The shape is
+ * load-bearing — it carries the `meta.source` field the bridge keys
+ * on when rendering `<channel source="vault_grant_approved">` /
+ * `<channel source="vault_grant_denied">` blocks for the model, and
+ * the `meta.{agent,key,scope,stage_id,operator_id}` fields that
+ * downstream filters / dashboards may anchor on.
+ *
+ * A regression that drops a meta field or changes the source string
+ * would silently break the agent's wake-up flow — the bridge wouldn't
+ * recognize the source and route as a generic channel event, the
+ * model wouldn't know it was an approval response, and the
+ * conversation would drift. Pinning the builders against fixture
+ * tests is cheaper than catching that downstream.
+ */
+
+import type { InboundMessage } from './ipc-protocol.js'
+
+/** Subset of the pending-request state the builders need. Kept narrow
+ *  so callers don't have to pass the full PendingVaultRequestAccess. */
+export interface VaultGrantInboundContext {
+  agent: string
+  key: string
+  scope: 'read' | 'write'
+  /** Telegram chat id where the approval card lived. Used as the
+   *  inbound's chatId — keeps the synthesized turn associated with
+   *  the conversation that triggered the request. */
+  chat_id: string
+  /** Seconds. For approved grants; ignored for deny. */
+  ttl_seconds: number
+}
+
+/**
+ * Build the synthetic InboundMessage for a successful operator
+ * approval. Meta fields are pinned by tests.
+ *
+ * @param ctx              Per-request context (agent, key, scope, chat).
+ * @param grantId          Broker-returned grant id (e.g. "vg_a1b2c3").
+ * @param stageId          The card's stage id from the approval flow.
+ * @param operatorId       Telegram user id of the approving operator
+ *                         (string for portability — Telegram ids are
+ *                         numeric but routinely round-trip as strings).
+ * @param nowMs            Wall-clock ms. Used for both `ts` and
+ *                         `messageId` so the helper is deterministic
+ *                         under fake clock. Defaults to `Date.now()`.
+ */
+export function buildVaultGrantApprovedInbound(opts: {
+  ctx: VaultGrantInboundContext
+  grantId: string
+  stageId: string
+  operatorId: string
+  nowMs?: number
+}): InboundMessage {
+  const ts = opts.nowMs ?? Date.now()
+  const days = Math.round(opts.ctx.ttl_seconds / 86400)
+  return {
+    type: 'inbound',
+    chatId: opts.ctx.chat_id,
+    messageId: ts, // synthetic — no Telegram message id exists
+    user: 'vault-broker',
+    userId: 0,
+    ts,
+    text:
+      `✅ Operator approved your vault access request for ` +
+      `\`${opts.ctx.key}\` (scope=${opts.ctx.scope}, ` +
+      `${days}d, grant=${opts.grantId}). ` +
+      `The token has been written. Please resume the task that was ` +
+      `waiting on this credential — fetch via the usual switchroom vault ` +
+      `get path.`,
+    meta: {
+      source: 'vault_grant_approved',
+      agent: opts.ctx.agent,
+      key: opts.ctx.key,
+      scope: opts.ctx.scope,
+      grant_id: opts.grantId,
+      stage_id: opts.stageId,
+      operator_id: opts.operatorId,
+    },
+  }
+}
+
+/**
+ * Build the synthetic InboundMessage for an operator denial.
+ *
+ * The text steers the model toward a fallback path (apologise, try a
+ * different approach, skip the feature) — added in #1156 alongside
+ * the buffer-on-disconnect fix because the deny side had the same
+ * agent-stays-idle bug as the approve side.
+ */
+export function buildVaultGrantDeniedInbound(opts: {
+  ctx: VaultGrantInboundContext
+  stageId: string
+  operatorId: string
+  nowMs?: number
+}): InboundMessage {
+  const ts = opts.nowMs ?? Date.now()
+  return {
+    type: 'inbound',
+    chatId: opts.ctx.chat_id,
+    messageId: ts,
+    user: 'vault-broker',
+    userId: 0,
+    ts,
+    text:
+      `🚫 Operator denied your vault access request for ` +
+      `\`${opts.ctx.key}\` (scope=${opts.ctx.scope}). ` +
+      `The credential is unavailable — pick a fallback for the original task ` +
+      `(apologise to the user, try a different approach, or skip the feature). ` +
+      `Do NOT re-request this key without first asking the user.`,
+    meta: {
+      source: 'vault_grant_denied',
+      agent: opts.ctx.agent,
+      key: opts.ctx.key,
+      scope: opts.ctx.scope,
+      stage_id: opts.stageId,
+      operator_id: opts.operatorId,
+    },
+  }
+}

--- a/telegram-plugin/tests/vault-grant-inbound-builders.test.ts
+++ b/telegram-plugin/tests/vault-grant-inbound-builders.test.ts
@@ -1,0 +1,226 @@
+/**
+ * Pin the InboundMessage shapes the gateway synthesizes when the
+ * operator taps Approve / Deny on a `vault_request_access` card
+ * (#1052 / #1150). A regression that drops a `meta.source` field, or
+ * changes the source string, would silently break the agent's wake-
+ * up — the bridge wouldn't recognize the source, the message would
+ * render as a generic channel event, and the model wouldn't know it
+ * was an approval response.
+ *
+ * These tests are the cheap regression guard. The wire shape is
+ * load-bearing — downstream filters / dashboards / future replay
+ * tooling may anchor on individual meta fields.
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+  buildVaultGrantApprovedInbound,
+  buildVaultGrantDeniedInbound,
+  type VaultGrantInboundContext,
+} from '../gateway/vault-grant-inbound-builders.js'
+
+const FIXED_NOW = 1_700_000_000_000
+
+const CTX_READ: VaultGrantInboundContext = {
+  agent: 'gymbro',
+  key: 'fatsecret/credentials',
+  scope: 'read',
+  chat_id: '8248703757',
+  ttl_seconds: 30 * 86400,
+}
+
+const CTX_WRITE: VaultGrantInboundContext = {
+  ...CTX_READ,
+  key: 'analytics/api-token',
+  scope: 'write',
+  ttl_seconds: 7 * 86400,
+}
+
+describe('buildVaultGrantApprovedInbound', () => {
+  it('emits the canonical envelope (type, chat_id, user, userId, ts, messageId)', () => {
+    const msg = buildVaultGrantApprovedInbound({
+      ctx: CTX_READ,
+      grantId: 'vg_a1b2c3',
+      stageId: 'stage-001',
+      operatorId: '8248703757',
+      nowMs: FIXED_NOW,
+    })
+    expect(msg.type).toBe('inbound')
+    expect(msg.chatId).toBe('8248703757')
+    expect(msg.user).toBe('vault-broker')
+    expect(msg.userId).toBe(0)
+    expect(msg.ts).toBe(FIXED_NOW)
+    // messageId is synthetic — pin that it equals ts so the gateway
+    // can produce a stable id under fake-clock tests without colliding
+    // with real Telegram messageIds.
+    expect(msg.messageId).toBe(FIXED_NOW)
+  })
+
+  it('pins meta.source = "vault_grant_approved" — load-bearing for the bridge', () => {
+    const msg = buildVaultGrantApprovedInbound({
+      ctx: CTX_READ,
+      grantId: 'vg_x',
+      stageId: 's',
+      operatorId: '1',
+    })
+    expect(msg.meta?.source).toBe('vault_grant_approved')
+  })
+
+  it('carries all forensic fields in meta', () => {
+    const msg = buildVaultGrantApprovedInbound({
+      ctx: CTX_READ,
+      grantId: 'vg_a1b2c3',
+      stageId: 'stage-001',
+      operatorId: '8248703757',
+    })
+    expect(msg.meta).toEqual({
+      source: 'vault_grant_approved',
+      agent: 'gymbro',
+      key: 'fatsecret/credentials',
+      scope: 'read',
+      grant_id: 'vg_a1b2c3',
+      stage_id: 'stage-001',
+      operator_id: '8248703757',
+    })
+  })
+
+  it('text names the key, scope, ttl-in-days, and grant id', () => {
+    const msg = buildVaultGrantApprovedInbound({
+      ctx: CTX_READ,
+      grantId: 'vg_a1b2c3',
+      stageId: 's',
+      operatorId: '1',
+    })
+    expect(msg.text).toContain('approved')
+    expect(msg.text).toContain('`fatsecret/credentials`')
+    expect(msg.text).toContain('scope=read')
+    expect(msg.text).toContain('30d')
+    expect(msg.text).toContain('grant=vg_a1b2c3')
+    // Instructional: tells the agent how to recover the value.
+    expect(msg.text).toContain('switchroom vault get')
+  })
+
+  it('rounds ttl_seconds to days', () => {
+    const ctx7d: VaultGrantInboundContext = { ...CTX_READ, ttl_seconds: 7 * 86400 }
+    const msg = buildVaultGrantApprovedInbound({
+      ctx: ctx7d,
+      grantId: 'vg_x',
+      stageId: 's',
+      operatorId: '1',
+    })
+    expect(msg.text).toContain('7d')
+  })
+
+  it('honors write scope in text + meta', () => {
+    const msg = buildVaultGrantApprovedInbound({
+      ctx: CTX_WRITE,
+      grantId: 'vg_x',
+      stageId: 's',
+      operatorId: '1',
+    })
+    expect(msg.text).toContain('scope=write')
+    expect(msg.meta?.scope).toBe('write')
+  })
+
+  it('defaults nowMs to Date.now() when omitted', () => {
+    const before = Date.now()
+    const msg = buildVaultGrantApprovedInbound({
+      ctx: CTX_READ,
+      grantId: 'vg_x',
+      stageId: 's',
+      operatorId: '1',
+    })
+    const after = Date.now()
+    expect(msg.ts).toBeGreaterThanOrEqual(before)
+    expect(msg.ts).toBeLessThanOrEqual(after)
+    expect(msg.messageId).toBe(msg.ts)
+  })
+})
+
+describe('buildVaultGrantDeniedInbound', () => {
+  it('pins meta.source = "vault_grant_denied" — the deny-side wake-up was added in #1156', () => {
+    const msg = buildVaultGrantDeniedInbound({
+      ctx: CTX_READ,
+      stageId: 's',
+      operatorId: '1',
+    })
+    expect(msg.meta?.source).toBe('vault_grant_denied')
+  })
+
+  it('omits grant_id (denial never mints a grant)', () => {
+    const msg = buildVaultGrantDeniedInbound({
+      ctx: CTX_READ,
+      stageId: 'stage-001',
+      operatorId: '8248703757',
+    })
+    expect(msg.meta).toEqual({
+      source: 'vault_grant_denied',
+      agent: 'gymbro',
+      key: 'fatsecret/credentials',
+      scope: 'read',
+      stage_id: 'stage-001',
+      operator_id: '8248703757',
+    })
+    expect((msg.meta as { grant_id?: string }).grant_id).toBeUndefined()
+  })
+
+  it('text steers toward a fallback path', () => {
+    const msg = buildVaultGrantDeniedInbound({
+      ctx: CTX_READ,
+      stageId: 's',
+      operatorId: '1',
+    })
+    expect(msg.text).toContain('denied')
+    expect(msg.text).toContain('`fatsecret/credentials`')
+    expect(msg.text).toContain('fallback')
+    // The "DO NOT re-request" line is load-bearing UX — prevents the
+    // model from spam-tapping a fresh request immediately after a
+    // deny. Pin it.
+    expect(msg.text).toMatch(/Do NOT re-request/)
+  })
+
+  it('shares envelope shape with the approve builder (type, user, chat)', () => {
+    const denied = buildVaultGrantDeniedInbound({
+      ctx: CTX_READ,
+      stageId: 's',
+      operatorId: '1',
+      nowMs: FIXED_NOW,
+    })
+    expect(denied.type).toBe('inbound')
+    expect(denied.user).toBe('vault-broker')
+    expect(denied.userId).toBe(0)
+    expect(denied.chatId).toBe('8248703757')
+    expect(denied.ts).toBe(FIXED_NOW)
+    expect(denied.messageId).toBe(FIXED_NOW)
+  })
+})
+
+describe('approve vs deny shape invariants', () => {
+  it('both emit type=inbound, user=vault-broker — bridge anchors on these', () => {
+    const approve = buildVaultGrantApprovedInbound({
+      ctx: CTX_READ, grantId: 'g', stageId: 's', operatorId: '1',
+    })
+    const deny = buildVaultGrantDeniedInbound({
+      ctx: CTX_READ, stageId: 's', operatorId: '1',
+    })
+    for (const m of [approve, deny]) {
+      expect(m.type).toBe('inbound')
+      expect(m.user).toBe('vault-broker')
+      expect(m.userId).toBe(0)
+    }
+  })
+
+  it('source strings are disjoint — no shared substring that could route both to the same handler', () => {
+    const approve = buildVaultGrantApprovedInbound({
+      ctx: CTX_READ, grantId: 'g', stageId: 's', operatorId: '1',
+    })
+    const deny = buildVaultGrantDeniedInbound({
+      ctx: CTX_READ, stageId: 's', operatorId: '1',
+    })
+    expect(approve.meta?.source).not.toBe(deny.meta?.source)
+    // Defensive: a fuzzy match like `meta.source.includes('approve')`
+    // shouldn't accidentally fire on the deny side. Pin the prefixes.
+    expect(String(approve.meta?.source)).toMatch(/^vault_grant_approved$/)
+    expect(String(deny.meta?.source)).toMatch(/^vault_grant_denied$/)
+  })
+})


### PR DESCRIPTION
## Summary
Pulls the inline InboundMessage construction for \`vault_grant_approved\` (#1052) and \`vault_grant_denied\` (#1156) out of \`gateway.ts\` into a pure-helper module \`vault-grant-inbound-builders.ts\`. 13 shape-pin tests guard against silent regression.

## Why
The InboundMessage shape these builders produce is load-bearing — the bridge keys on \`meta.source\` to route as \`<channel source="vault_grant_approved">\` blocks for the model. A regression that drops a meta field or changes the source string surfaces as "the agent stopped waking up after approvals" — exactly the #1150 bug class.

Inline construction made silent regressions easy to introduce. Extraction makes them cheap to catch via the test fixtures.

## No semantic delta
Pure refactor. Call-sites still invoke \`ipcServer.sendToAgent\`, still buffer on delivery failure, same log lines. Just the InboundMessage literal is replaced with a helper call.

## Test plan
- [x] \`vitest run telegram-plugin/tests/vault-grant-inbound-builders.test.ts\` — 13/13
- [x] \`npm run lint\` — clean

## Closes
Follow-up B from the #1150 goal-prompt closure plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)