### PR TITLE
fix(gateway+bridge): session-scoped always-allow cache for sub-agents (#1138)

### DIFF
--- a/telegram-plugin/bridge/bridge.ts
+++ b/telegram-plugin/bridge/bridge.ts
@@ -28,6 +28,7 @@ import {
 } from '../pty-tail.js'
 import { createIpcClient, type IpcClientHandle } from './ipc-client.js'
 import type { InboundMessage, PermissionEvent, StatusEvent } from '../gateway/ipc-protocol.js'
+import { matchesAllowRule } from '../permission-rule.js'
 
 installPluginLogger()
 
@@ -488,6 +489,22 @@ mcp.setRequestHandler(CallToolRequestSchema, async (req) => {
 // approval. Forward them to the gateway which renders inline keyboard
 // buttons in the user's Telegram chat. The gateway sends the decision
 // back as a PermissionEvent which we relay to Claude Code (see onPermission).
+//
+// #1138: session-scoped always-allow cache. When the operator taps
+// "🔁 Always allow" the gateway calls `switchroom agent grant` which
+// updates settings.json on disk, but the running claude process won't
+// re-read that file — so a sub-agent (Task tool) dispatched later in
+// the same session still hits the popup. To close that gap the gateway
+// also broadcasts the resolved `rule` on the `permission` event and we
+// stash it here; subsequent `permission_request` notifications whose
+// (tool_name, input_preview) match a cached rule are auto-allowed
+// without a round-trip to Telegram. The cache lives for the bridge's
+// lifetime — which is the claude session's lifetime — so on the next
+// boot the now-persisted `tools.allow` entry takes over and this cache
+// is rebuilt as the operator approves things again. Parent claude and
+// every Task-tool sub-agent share the same bridge process, so a rule
+// added by either is honoured by all.
+const sessionAllowRules = new Set<string>()
 
 mcp.setNotificationHandler(
   z.object({
@@ -500,6 +517,28 @@ mcp.setNotificationHandler(
     }),
   }),
   async ({ params }) => {
+    // Cache hit? Auto-allow without bothering the gateway. We deliver
+    // the same `notifications/claude/channel/permission` shape claude
+    // would otherwise receive after a Telegram tap, so the call site
+    // is indistinguishable. We still notify the gateway out-of-band
+    // (via a permission_request that the gateway short-circuits on
+    // its side would be ideal, but for now skipping the forward is
+    // safe: pendingPermissions is a gateway-side bookkeeping map only,
+    // and nothing else depends on seeing this request_id).
+    for (const rule of sessionAllowRules) {
+      if (matchesAllowRule(rule, params.tool_name, params.input_preview)) {
+        process.stderr.write(
+          `telegram bridge: session-cached allow for ${params.tool_name} ` +
+          `(rule="${rule}", request_id=${params.request_id})\n`,
+        )
+        onPermission({
+          type: 'permission',
+          requestId: params.request_id,
+          behavior: 'allow',
+        })
+        return
+      }
+    }
     if (!ipc || !ipc.isConnected()) {
       process.stderr.write('telegram bridge: permission_request received but not connected to gateway\n')
       return
@@ -513,6 +552,7 @@ mcp.setNotificationHandler(
     })
   },
 )
+
 
 // ─── IPC client ──────────────────────────────────────────────────────────
 
@@ -532,6 +572,16 @@ function onInbound(msg: InboundMessage): void {
 }
 
 function onPermission(msg: PermissionEvent): void {
+  // #1138: stash the rule the gateway resolved on "Always allow" so we
+  // can short-circuit later matching permission_request notifications
+  // (from the parent claude or any Task-dispatched sub-agent in the
+  // same session). The gateway only sets `rule` when it has also
+  // persisted the rule to settings.json, so a process restart will
+  // pick up the same set of rules from disk — the cache is purely a
+  // mid-session bridge between the disk write and the next agent boot.
+  if (msg.rule) {
+    sessionAllowRules.add(msg.rule)
+  }
   mcp.notification({
     method: 'notifications/claude/channel/permission',
     params: {

--- a/telegram-plugin/bridge/ipc-client.ts
+++ b/telegram-plugin/bridge/ipc-client.ts
@@ -23,7 +23,10 @@ export function validateGatewayMessage(msg: unknown): msg is GatewayToClient {
       return typeof m.chatId === "string" && typeof m.text === "string";
     case "permission":
       return typeof m.requestId === "string"
-        && (m.behavior === "allow" || m.behavior === "deny");
+        && (m.behavior === "allow" || m.behavior === "deny")
+        // `rule` is optional (only sent on "🔁 Always allow"); when present
+        // it must be a non-empty string. #1138 wire extension.
+        && (m.rule === undefined || (typeof m.rule === "string" && m.rule.length > 0));
     case "status":
       return typeof m.status === "string";
     case "tool_call_result":

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -11591,8 +11591,20 @@ bot.on('callback_query:data', async ctx => {
       // if the yaml edit failed, the operator clearly meant "yes" so
       // we honour the immediate decision and surface the failure as
       // a hint in the chat.
+      //
+      // #1138: also carry the resolved `rule` so the bridge can cache
+      // it for the rest of the session and auto-allow matching tool
+      // calls from sub-agents (Task tool) and the parent without
+      // re-popping the prompt. Only set when the yaml edit succeeded —
+      // otherwise the rule may be unsafe to honour at scale and we
+      // fall back to single-use allow.
       synthInbound: () => {
-        ipcServer.broadcast({ type: 'permission', requestId: request_id, behavior: 'allow' })
+        ipcServer.broadcast({
+          type: 'permission',
+          requestId: request_id,
+          behavior: 'allow',
+          ...(grantOk ? { rule: rule.rule } : {}),
+        })
       },
     })
     return

--- a/telegram-plugin/gateway/ipc-protocol.ts
+++ b/telegram-plugin/gateway/ipc-protocol.ts
@@ -18,6 +18,24 @@ export interface PermissionEvent {
   type: "permission";
   requestId: string;
   behavior: "allow" | "deny";
+  /**
+   * Session-scoped always-allow rule. Only set when the operator taps
+   * "🔁 Always allow" — the gateway already persists the rule to
+   * switchroom.yaml + settings.json via `switchroom agent grant`, but
+   * those writes only kick in on the NEXT agent boot. This field carries
+   * the rule to the running bridge so it can short-circuit future
+   * `permission_request` notifications (from the parent claude AND any
+   * sub-agents dispatched via the Task tool, which share the same MCP
+   * server / bridge process) within the current session.
+   *
+   * Issue #1138: without this, a sub-agent dispatched after the operator
+   * tapped "Always allow" still hit the popup, because Claude Code reads
+   * `.claude/settings.json` once at boot.
+   *
+   * Format matches `resolveAlwaysAllowRule`'s output: bare tool name
+   * (`Edit`), `Skill(<name>)`, or `mcp__<server>__<tool>`.
+   */
+  rule?: string;
 }
 
 export interface StatusEvent {

--- a/telegram-plugin/permission-rule.ts
+++ b/telegram-plugin/permission-rule.ts
@@ -131,3 +131,54 @@ function skillBasenameFromPath(input: Record<string, unknown>): string | null {
   const trimmed = path.replace(/\/SKILL\.md$/i, "").replace(/\/$/, "");
   return basename(trimmed) || null;
 }
+
+/**
+ * Inverse of `resolveAlwaysAllowRule` — does a stored allow-rule cover a
+ * fresh `permission_request`? Used by the bridge's session-scoped
+ * always-allow cache (issue #1138) to short-circuit prompts when the
+ * operator has already tapped "🔁 Always allow" for an equivalent tool
+ * call earlier in the same session.
+ *
+ * Matching rules (mirrors what `resolveAlwaysAllowRule` produces):
+ *
+ *   - Bare tool name (`Edit`, `Bash`, `Write`, …) ⇒ matches any
+ *     invocation of that tool. This is consistent with how
+ *     `tools.allow: [Edit]` works in `.claude/settings.json` — there's
+ *     no arg matching at this layer.
+ *   - `Skill(<name>)` ⇒ matches only `Skill` invocations whose resolved
+ *     skill name (via the same field-fallback chain as the resolver)
+ *     equals `<name>`.
+ *   - `mcp__<server>__<tool>` ⇒ matches the exact namespaced MCP tool
+ *     name.
+ *
+ * Returns `false` for any malformed rule rather than throwing — the
+ * caller (bridge) is on the hot permission path and should fall through
+ * to the gateway prompt on bad input.
+ */
+export function matchesAllowRule(
+  rule: string,
+  toolName: string,
+  inputPreview: string | undefined,
+): boolean {
+  if (!rule || !toolName) return false;
+
+  // Skill(name) — extract the parenthesized argument and compare against
+  // the resolved skill identifier from the request.
+  const skillMatch = /^Skill\(([^)]+)\)$/.exec(rule);
+  if (skillMatch) {
+    if (toolName !== "Skill") return false;
+    const ruleSkill = skillMatch[1];
+    const input = parseInput(inputPreview);
+    if (!input) return false;
+    const reqSkill =
+      readString(input, "skill") ??
+      readString(input, "skill_name") ??
+      readString(input, "skillName") ??
+      readString(input, "name") ??
+      skillBasenameFromPath(input);
+    return reqSkill === ruleSkill;
+  }
+
+  // Bare tool name or namespaced MCP tool — exact string compare.
+  return rule === toolName;
+}

--- a/telegram-plugin/tests/gateway-message-validator.test.ts
+++ b/telegram-plugin/tests/gateway-message-validator.test.ts
@@ -88,6 +88,32 @@ describe('validateGatewayMessage', () => {
     it('rejects missing requestId', () => {
       expect(validateGatewayMessage({ type: 'permission', behavior: 'allow' })).toBe(false)
     })
+
+    // #1138: optional `rule` field on Always-allow broadcasts. Must be
+    // accepted when present + non-empty, accepted when absent, rejected
+    // when present-but-malformed (the bridge stashes the value verbatim
+    // into a Set<string> — empty strings or wrong types would poison
+    // the matcher).
+    it('accepts an optional rule when behavior is allow', () => {
+      expect(validateGatewayMessage({
+        type: 'permission', requestId: 'r', behavior: 'allow', rule: 'Edit',
+      })).toBe(true)
+      expect(validateGatewayMessage({
+        type: 'permission', requestId: 'r', behavior: 'allow', rule: 'Skill(mail)',
+      })).toBe(true)
+    })
+
+    it('rejects an empty-string rule', () => {
+      expect(validateGatewayMessage({
+        type: 'permission', requestId: 'r', behavior: 'allow', rule: '',
+      })).toBe(false)
+    })
+
+    it('rejects a non-string rule', () => {
+      expect(validateGatewayMessage({
+        type: 'permission', requestId: 'r', behavior: 'allow', rule: 42,
+      })).toBe(false)
+    })
   })
 
   describe('status', () => {

--- a/telegram-plugin/tests/permission-rule.test.ts
+++ b/telegram-plugin/tests/permission-rule.test.ts
@@ -12,7 +12,7 @@
  */
 
 import { describe, it, expect } from 'vitest'
-import { resolveAlwaysAllowRule } from '../permission-rule.js'
+import { resolveAlwaysAllowRule, matchesAllowRule } from '../permission-rule.js'
 
 describe('resolveAlwaysAllowRule — Skill', () => {
   it('returns Skill(name) for a typical skill input', () => {
@@ -117,5 +117,84 @@ describe('resolveAlwaysAllowRule — fallback', () => {
   it('returns null for unknown tools', () => {
     expect(resolveAlwaysAllowRule('UnknownTool', undefined)).toBeNull()
     expect(resolveAlwaysAllowRule('', undefined)).toBeNull()
+  })
+})
+
+describe('matchesAllowRule — bare tool names', () => {
+  // The whole point of #1138: a cached `Edit` rule covers every Edit
+  // call from the parent claude AND from sub-agents dispatched via the
+  // Task tool, no matter the file path.
+  it('matches any invocation of the same tool', () => {
+    expect(matchesAllowRule('Edit', 'Edit', undefined)).toBe(true)
+    expect(matchesAllowRule('Edit', 'Edit', JSON.stringify({ file_path: '/tmp/a' }))).toBe(true)
+    expect(matchesAllowRule('Edit', 'Edit', JSON.stringify({ file_path: '/etc/passwd' }))).toBe(true)
+  })
+
+  it('does not bleed into other tools', () => {
+    expect(matchesAllowRule('Edit', 'Write', undefined)).toBe(false)
+    expect(matchesAllowRule('Read', 'Edit', undefined)).toBe(false)
+    expect(matchesAllowRule('Bash', 'BashOutput', undefined)).toBe(false)
+  })
+
+  it.each(['Bash', 'Read', 'Write', 'MultiEdit', 'Glob', 'Grep', 'WebFetch', 'TodoWrite'])(
+    'roundtrips through resolve → match for %s',
+    (tool) => {
+      const resolved = resolveAlwaysAllowRule(tool, undefined)
+      expect(resolved).not.toBeNull()
+      expect(matchesAllowRule(resolved!.rule, tool, undefined)).toBe(true)
+    },
+  )
+})
+
+describe('matchesAllowRule — Skill(name)', () => {
+  it('matches only the specific skill', () => {
+    expect(matchesAllowRule('Skill(mail)', 'Skill', JSON.stringify({ skill: 'mail' }))).toBe(true)
+    expect(matchesAllowRule('Skill(mail)', 'Skill', JSON.stringify({ skill: 'calendar' }))).toBe(false)
+  })
+
+  it('uses the same field fallback chain as the resolver', () => {
+    expect(matchesAllowRule('Skill(mail)', 'Skill', JSON.stringify({ skill_name: 'mail' }))).toBe(true)
+    expect(matchesAllowRule('Skill(mail)', 'Skill', JSON.stringify({ skillName: 'mail' }))).toBe(true)
+    expect(matchesAllowRule('Skill(mail)', 'Skill', JSON.stringify({ name: 'mail' }))).toBe(true)
+    expect(matchesAllowRule(
+      'Skill(coolify)',
+      'Skill',
+      JSON.stringify({ path: 'skills/coolify/SKILL.md' }),
+    )).toBe(true)
+  })
+
+  it('does not match a different tool with the same arg', () => {
+    expect(matchesAllowRule('Skill(mail)', 'Bash', JSON.stringify({ skill: 'mail' }))).toBe(false)
+  })
+
+  it('returns false on malformed Skill input', () => {
+    expect(matchesAllowRule('Skill(mail)', 'Skill', undefined)).toBe(false)
+    expect(matchesAllowRule('Skill(mail)', 'Skill', 'not-json')).toBe(false)
+    expect(matchesAllowRule('Skill(mail)', 'Skill', JSON.stringify({ unrelated: 'x' }))).toBe(false)
+  })
+})
+
+describe('matchesAllowRule — MCP tools', () => {
+  it('matches the exact namespaced tool', () => {
+    expect(matchesAllowRule(
+      'mcp__switchroom-telegram__reply',
+      'mcp__switchroom-telegram__reply',
+      undefined,
+    )).toBe(true)
+  })
+
+  it('does not match a different MCP tool on the same server', () => {
+    expect(matchesAllowRule(
+      'mcp__switchroom-telegram__reply',
+      'mcp__switchroom-telegram__stream_reply',
+      undefined,
+    )).toBe(false)
+  })
+})
+
+describe('matchesAllowRule — defensive', () => {
+  it('returns false for empty inputs', () => {
+    expect(matchesAllowRule('', 'Edit', undefined)).toBe(false)
+    expect(matchesAllowRule('Edit', '', undefined)).toBe(false)
   })
 })


### PR DESCRIPTION
## Summary

Closes #1138.

When the operator taps "🔁 Always allow" on a Telegram permission card, the gateway writes the rule into `switchroom.yaml` + regenerates `.claude/settings.json` via `agent grant --no-restart`. But the running claude process never re-reads settings.json, so any tool call later in the same session — by the parent OR a sub-agent dispatched via the Task tool — still hits the popup. Issue #1138 documents the exact gymbro repro: parent agent's `Edit`/`Write` is always-allowed, a `@worker` sub-agent dispatched 7 minutes later is denied and forces the parent to do the edits inline.

## Fix

Piggyback the resolved rule onto the existing `PermissionEvent` broadcast (new optional `rule` field on the wire). The **bridge** — a single MCP server process shared by the parent claude AND every sub-agent in the session — stashes the rule in an in-memory `Set` on receipt, and short-circuits any subsequent `permission_request` notification that matches via the new `matchesAllowRule` helper (inverse of `resolveAlwaysAllowRule`).

The cache lives for the bridge's lifetime (== claude session lifetime); on the next agent boot the now-persisted `tools.allow` entry takes over and the cache rebuilds organically as the operator approves things again. No restart-mid-turn required — the parent agent keeps its in-flight context, and sub-agents dispatched after the tap auto-allow on the first call.

## Why the bridge

The bridge is the only chokepoint that sees every `permission_request` notification from the parent claude AND every Task-dispatched sub-agent (they share MCP servers). It already has the gateway IPC connection. Its process lifetime equals the session lifetime so the cache scope is natural.

## Wire change

`PermissionEvent` gains optional `rule?: string`. `validateGatewayMessage` accepts non-empty strings only — empty / non-string rejected so a typo can't poison the matcher. Gateway only emits `rule` when the YAML grant succeeded; failure falls back to single-use allow, preserving prior behaviour.

## Test plan

- [x] `tsc --noEmit` clean
- [x] New tests: `matchesAllowRule` round-trips through `resolveAlwaysAllowRule` for all built-in tools; `Skill(name)` matches the resolved skill via the same field-fallback chain; MCP tools match by exact namespaced name; bad inputs return `false`
- [x] New tests: `validateGatewayMessage` accepts the optional `rule` field, rejects empty / non-string values
- [x] `bun test`: 727 pass / 0 fail
- [x] Vitest on touched files: 75 pass / 0 fail
- [ ] Live repro: tap "Always allow" on parent's Edit, dispatch sub-agent → sub-agent's Edit auto-allows without a popup

🤖 Generated with [Claude Code](https://claude.com/claude-code)