### PR TITLE
fix(compose): bind_mounts follow-up — path normalization, target denylist, docs reframe (#1166)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -402,59 +402,99 @@ project dir, logs, read-only skills + credentials). That is the right
 default for the typical fleet — sandboxed agents stay isolated from
 the host's source trees and operator state.
 
-For the **dogfood / self-modification** case — an admin agent asked to
-fix a switchroom bug or edit a bundled skill — that isolation is the
-blocker. The agent can read `/opt/switchroom/switchroom.js` (the
-compiled bundle baked into the image) but not the TypeScript source
-on the host. `bind_mounts:` is the per-agent escape hatch.
+### Which primitive solves which problem
+
+`bind_mounts:` is the catch-all *extra host paths* escape hatch.
+Before reaching for it, check whether one of the more focused
+primitives is the right tool:
+
+- **"Agent should edit a git repo (incl. switchroom itself)."** Use
+  `repos:` (see `src/config/schema.ts` `AgentRepoEntry`). Switchroom
+  provisions a dedicated worktree at `<agentDir>/work/<slug>/` from
+  a shared bare clone — the agent edits *inside its own sandbox*,
+  not on a mounted host checkout. `bind_mounts:` is not needed and
+  doesn't help: the worktree pattern lets the agent commit + push +
+  open a PR using its own git identity without touching host state.
+- **"Admin agent should deploy a merged change (`switchroom apply`,
+  `agent restart`, `update apply`)."** That's the host-control
+  daemon's job — see `docs/rfcs/host-control-daemon.md`. `bind_mounts:`
+  does not give an agent host-side control; even with the source
+  tree mounted, the agent can't run docker commands or `sudo` on
+  the host. The daemon is the right surface.
+- **"Operator + agent need to share a host directory that isn't a
+  git repo and isn't operator config."** *That's* what `bind_mounts:`
+  is for. Examples: a shared `~/shared/notes` dir two agents
+  collaborate in; a read-only NAS path; a small operator file the
+  agent maintains.
+
+If none of the above fit and you still want filesystem reach for a
+non-admin agent, the right answer is to run a separate Claude
+session from outside switchroom (a host shell), not to relax the
+admin gate.
+
+### Shape
 
 ```yaml
 agents:
-  klanker:
+  collab-bot:
     admin: true                      # required — see "Admin gating" below
     bind_mounts:
-      - source: /home/me/code/switchroom
-        mode: rw                     # read-write, for `bun build` + commits
-      - source: /home/me/code/some-other-repo
-        mode: ro                     # read-only is the default
+      - source: /home/me/shared/notes
+        target: /home/agent/notes    # optional; defaults to `source`
+        mode: rw                     # default is `ro`
     add_dirs:
-      - /home/me/code/switchroom     # also extend claude's tool-reach allowlist
-      - /home/me/code/some-other-repo
+      - /home/me/shared/notes        # also extend claude's tool-reach
 ```
 
 Each entry takes:
 
-- **`source:`** (required) — absolute host path. Tilde-expansion is **not**
-  performed; pass the literal path. Refused if the path is under a
-  system-path denylist (`/`, `/etc`, `/proc`, `/sys`, `/dev`, `/run`,
-  `/var/run`, `/boot`, `/var/lib/docker`) or equals `/var/run/docker.sock`.
+- **`source:`** (required) — absolute host path. Tilde-expansion is
+  **not** performed; pass the literal path. Refused if the path is
+  under a system-path denylist (`/`, `/etc`, `/proc`, `/sys`, `/dev`,
+  `/run`, `/var/run`, `/boot`, `/var/lib/docker`) or equals
+  `/var/run/docker.sock`. Repeated `/`, `.` segments, and trailing
+  `/` are normalized before the denylist check, so `//etc`,
+  `/etc/.`, and `/etc/` are all refused as expected.
 - **`target:`** (optional) — container path the mount appears at.
-  Defaults to the same path as `source`, matching switchroom's existing
-  dual-mount convention so absolute paths in scaffolded scripts and tool
-  invocations Just Work.
+  Defaults to the same path as `source`, matching switchroom's
+  existing dual-mount convention so absolute paths in scaffolded
+  scripts and tool invocations Just Work. Refused if it shadows a
+  switchroom-owned container path (`/state`, `/run/switchroom`,
+  `/opt/switchroom`, `/var/log/switchroom`) or an OS path inside
+  the container (`/etc`, `/bin`, `/sbin`, `/usr/{bin,sbin,lib}`,
+  `/lib`, `/lib64`, `/proc`, `/sys`, `/dev`, `/boot`).
 - **`mode:`** (optional, default `ro`) — `ro` or `rw`.
+
+> **Note (symlinks):** the source-path denylist is *textual*. If
+> `source` points at a host path that is itself a symlink to a
+> denylisted directory (e.g. `/home/me/proj` → `/etc`), Docker
+> resolves the symlink at mount time and the agent ends up with
+> `/etc` regardless. Admin-trusted: the operator who set `admin:
+> true` is the same principal who controls host filesystem layout,
+> so the textual check is the right tradeoff against doing
+> `fs.realpathSync` in the compose generator (which would couple
+> compose generation to filesystem state). If you want defense
+> here, declare absolute paths only and avoid symlinking your
+> mount sources.
 
 ### Admin gating
 
-`bind_mounts:` requires `admin: true` on the same agent. `switchroom apply`
-hard-fails if a non-admin agent declares it — silently dropping the
-entries would mask an intended privilege grant. The two are coupled
-deliberately: the same operator who already trusts an agent with vault
-grant-management (`/grant`) and fleet-admin slash commands (`/agents`,
-`/logs`, `/update`) is the right principal for source-tree access.
-
-If you want filesystem reach without admin powers, the right answer is
-to invoke a separate Claude session from outside switchroom (a host
-shell session) — not to relax the gate.
+`bind_mounts:` requires `admin: true` on the same agent. `switchroom
+apply` hard-fails if a non-admin agent declares it — silently
+dropping the entries would mask an intended privilege grant. The two
+are coupled deliberately: the same operator who already trusts an
+agent with vault grant-management (`/grant`) and fleet-admin slash
+commands (`/agents`, `/logs`, `/update`) is the right principal for
+extra-bind-mount access.
 
 ### Pair with `add_dirs:`
 
 `bind_mounts:` makes the path **exist** inside the container.
 `add_dirs:` makes the claude CLI's tool-allowlist **include** it.
-You typically want both. Without `add_dirs:`, claude's Read/Edit tools
-will reject the path as outside the working set even though the file is
-there. Without `bind_mounts:`, the path doesn't exist in the sandbox and
-`add_dirs:` is a no-op.
+You typically want both. Without `add_dirs:`, claude's Read/Edit
+tools will reject the path as outside the working set even though
+the file is there. Without `bind_mounts:`, the path doesn't exist in
+the sandbox and `add_dirs:` is a no-op.
 
 ## Minimal Example
 

--- a/src/agents/compose.ts
+++ b/src/agents/compose.ts
@@ -311,14 +311,15 @@ export function describeAgents(config: SwitchroomConfig): AgentServiceData[] {
 
 /**
  * System paths refused as bind_mount sources, regardless of mode.
- * Prefix-matched: an entry `/etc` rejects `/etc/foo` too.
+ * Prefix-matched against the *normalized* source path: an entry `/etc`
+ * rejects `/etc/foo`, `//etc`, `/etc/.`, etc.
  *
  * Mounting any of these inside an agent container is either pointless
  * (the container has its own /proc, /sys, /dev) or a privilege-escalation
  * vector (host `/etc` exposes shadow/passwd; `/var/lib/docker` and the
  * docker socket give root-equivalent host control).
  */
-const BIND_MOUNT_DENYLIST = [
+const BIND_MOUNT_SOURCE_DENYLIST = [
   "/",
   "/etc",
   "/proc",
@@ -330,8 +331,66 @@ const BIND_MOUNT_DENYLIST = [
   "/var/lib/docker",
 ];
 
-/** Exact source paths refused regardless of denylist prefix-matching. */
-const BIND_MOUNT_EXACT_DENY = new Set(["/var/run/docker.sock"]);
+/**
+ * Container paths refused as bind_mount targets.
+ *
+ * Two classes:
+ *   (1) switchroom-owned container locations — overlaying these breaks
+ *       the agent runtime (`/state/*` is the agent's state mount, `/opt/switchroom`
+ *       is the bundled CLI, `/run/switchroom/*` is the broker/kernel/hostd
+ *       socket mounts, `/var/log/switchroom` is the log mount).
+ *   (2) OS-shadow vectors — shadowing `/etc`, `/bin`, etc. inside the
+ *       container would let an admin agent surprise itself or future
+ *       agents that extend the same profile. Admin-only blast radius,
+ *       but cheap to refuse.
+ */
+const BIND_MOUNT_TARGET_DENYLIST = [
+  // switchroom-owned (must not be overridable from yaml)
+  "/state",
+  "/run/switchroom",
+  "/var/log/switchroom",
+  "/opt/switchroom",
+  // OS-shadow vectors
+  "/",
+  "/etc",
+  "/proc",
+  "/sys",
+  "/dev",
+  "/boot",
+  "/bin",
+  "/sbin",
+  "/usr/bin",
+  "/usr/sbin",
+  "/lib",
+  "/lib64",
+  "/usr/lib",
+];
+
+/** Exact source paths refused regardless of prefix-matching. */
+const BIND_MOUNT_EXACT_SOURCE_DENY = new Set(["/var/run/docker.sock"]);
+
+/**
+ * Normalize an absolute POSIX-style path for denylist comparison.
+ *   - Collapses runs of `/` to a single `/` (so `//etc` → `/etc`).
+ *   - Collapses `.` segments (so `/etc/.` → `/etc`, `/./etc` → `/etc`).
+ *   - Strips a trailing `/` (so `/etc/` → `/etc`), unless the input is
+ *     the literal `/`.
+ *
+ * Caller must reject `..` segments BEFORE calling this; we intentionally
+ * do not resolve `..` (resolving would mask the original intent — an
+ * input that pre-resolution contains `/..` should error, not silently
+ * normalize). Pure — no IO. Does NOT follow symlinks; that's a
+ * documented limitation (see docs/configuration.md § bind_mounts).
+ */
+export function normalizeBindMountPath(p: string): string {
+  // Collapse repeated slashes.
+  let out = p.replace(/\/+/g, "/");
+  // Strip "/." segments. Iteration handles `/./.` cases.
+  out = out.replace(/(\/)\.(?=\/|$)/g, "$1").replace(/\/+/g, "/");
+  // Strip trailing slash unless the whole path is the root.
+  if (out.length > 1 && out.endsWith("/")) out = out.slice(0, -1);
+  return out;
+}
 
 /**
  * Validate one entry from an agent's `bind_mounts:` list. Returns the
@@ -340,52 +399,90 @@ const BIND_MOUNT_EXACT_DENY = new Set(["/var/run/docker.sock"]);
  *
  * Callers MUST also check the owning agent's `admin === true` before
  * calling this; the admin gate is upstream (in emitAgentService).
+ *
+ * Note on symlinks: this validator is textual. If `source` points at
+ * a host path that is itself a symlink to a denylisted directory
+ * (e.g. `/home/me/proj → /etc`), the textual denylist will pass but
+ * Docker will resolve the symlink at mount time and the agent ends up
+ * with /etc anyway. Admin-trusted: the operator who set `admin: true`
+ * is the same principal who controls host filesystem layout. See the
+ * docs caveat at `docs/configuration.md` § bind_mounts.
  */
 export function resolveBindMount(
   agentName: string,
   entry: AgentBindMount,
 ): { source: string; target: string; mode: "ro" | "rw" } {
-  const source = entry.source;
-  if (typeof source !== "string" || source.length === 0) {
+  const rawSource = entry.source;
+  if (typeof rawSource !== "string" || rawSource.length === 0) {
     throw new Error(
       `compose: agent "${agentName}" bind_mount has empty source`,
     );
   }
-  if (!source.startsWith("/")) {
+  if (!rawSource.startsWith("/")) {
     throw new Error(
-      `compose: agent "${agentName}" bind_mount source "${source}" must be an absolute path ` +
+      `compose: agent "${agentName}" bind_mount source "${rawSource}" must be an absolute path ` +
       `(tilde-expansion is not performed; pass the literal absolute path)`,
     );
   }
-  if (source.includes("/../") || source.endsWith("/..") || source === "/..") {
+  // `..` rejected before normalization — see normalizeBindMountPath
+  // docstring for the rationale (we don't want to silently resolve
+  // `/etc/../foo` to `/foo`; the caller's intent was ambiguous).
+  if (
+    rawSource.includes("/../") ||
+    rawSource.endsWith("/..") ||
+    rawSource === "/.."
+  ) {
     throw new Error(
-      `compose: agent "${agentName}" bind_mount source "${source}" contains '..' — refuse ambiguous paths`,
+      `compose: agent "${agentName}" bind_mount source "${rawSource}" contains '..' — refuse ambiguous paths`,
     );
   }
-  if (BIND_MOUNT_EXACT_DENY.has(source)) {
+  const source = normalizeBindMountPath(rawSource);
+  if (BIND_MOUNT_EXACT_SOURCE_DENY.has(source)) {
     throw new Error(
-      `compose: agent "${agentName}" bind_mount source "${source}" is denylisted ` +
+      `compose: agent "${agentName}" bind_mount source "${rawSource}" is denylisted ` +
       `(host docker socket — would grant root-equivalent control of the host)`,
     );
   }
-  for (const deny of BIND_MOUNT_DENYLIST) {
+  for (const deny of BIND_MOUNT_SOURCE_DENYLIST) {
     if (source === deny || source.startsWith(deny === "/" ? "/" : deny + "/")) {
-      // "/" matches everything, so handle it separately: only refuse the
-      // literal "/" as source. A path like "/home/x" passes — it merely
-      // *starts* with "/" but the denylist intent is "the root itself".
+      // The "/" entry would otherwise match every absolute path; only
+      // refuse the literal "/" as source. A path like "/home/x" passes —
+      // it merely *starts* with "/" but the denylist intent is "the
+      // root itself".
       if (deny === "/" && source !== "/") continue;
       throw new Error(
-        `compose: agent "${agentName}" bind_mount source "${source}" is under denylisted system path "${deny}"`,
+        `compose: agent "${agentName}" bind_mount source "${rawSource}" is under denylisted system path "${deny}"`,
       );
     }
   }
-  const target = entry.target ?? source;
-  if (!target.startsWith("/")) {
+  const rawTarget = entry.target ?? rawSource;
+  if (!rawTarget.startsWith("/")) {
     throw new Error(
-      `compose: agent "${agentName}" bind_mount target "${target}" must be an absolute path`,
+      `compose: agent "${agentName}" bind_mount target "${rawTarget}" must be an absolute path`,
     );
   }
+  if (
+    rawTarget.includes("/../") ||
+    rawTarget.endsWith("/..") ||
+    rawTarget === "/.."
+  ) {
+    throw new Error(
+      `compose: agent "${agentName}" bind_mount target "${rawTarget}" contains '..' — refuse ambiguous paths`,
+    );
+  }
+  const target = normalizeBindMountPath(rawTarget);
+  for (const deny of BIND_MOUNT_TARGET_DENYLIST) {
+    if (target === deny || target.startsWith(deny === "/" ? "/" : deny + "/")) {
+      if (deny === "/" && target !== "/") continue;
+      throw new Error(
+        `compose: agent "${agentName}" bind_mount target "${rawTarget}" is under denylisted container path "${deny}" ` +
+        `(switchroom-owned mount or OS-shadow vector — pick a different target)`,
+      );
+    }
+  }
   const mode = entry.mode ?? "ro";
+  // Emit the *normalized* paths so the generated compose is byte-stable
+  // across textually-equivalent inputs (e.g. `//foo` and `/foo`).
   return { source, target, mode };
 }
 

--- a/tests/docker/compose-generator.test.ts
+++ b/tests/docker/compose-generator.test.ts
@@ -992,7 +992,7 @@ describe("agent bind_mounts (#1164)", () => {
   });
 
   it("accepts sources whose path merely starts with '/' (not the literal root)", () => {
-    // Sanity that the BIND_MOUNT_DENYLIST '/' entry doesn't poison
+    // Sanity that the BIND_MOUNT_SOURCE_DENYLIST '/' entry doesn't poison
     // every legitimate absolute path.
     const out = generateCompose({
       config: makeConfig({
@@ -1003,6 +1003,169 @@ describe("agent bind_mounts (#1164)", () => {
       }),
     });
     expect(out).toContain("/home/me/code/switchroom:/home/me/code/switchroom:ro");
+  });
+
+  // ── follow-up hardening (post-#1166 reviewer nits) ────────────────
+
+  it("normalizes collapsed-slash sources before applying the denylist (//etc → /etc)", () => {
+    // fails when: the textual denylist check is applied to the raw
+    // source instead of the normalized form. Without normalization
+    // `//etc` (which Linux/Docker collapse to `/etc` at mount time)
+    // would pass the textual check despite being a clear attempt to
+    // mount /etc. Admin-only blast radius, but the fix is one regex.
+    for (const bad of [
+      "//etc",
+      "//etc/passwd",
+      "//proc",
+      "/etc//passwd",
+    ]) {
+      expect(() =>
+        generateCompose({
+          config: makeConfig({
+            klanker: {
+              admin: true,
+              bind_mounts: [{ source: bad }],
+            },
+          }),
+        }),
+        `should refuse normalized source "${bad}"`,
+      ).toThrow(/denylisted system path/);
+    }
+  });
+
+  it("normalizes '.' segments before applying the denylist (/etc/. → /etc)", () => {
+    // fails when: `.` segments aren't stripped before the denylist
+    // prefix-match. An input like `/etc/.` resolves to `/etc` at mount
+    // time but bypasses the textual check.
+    for (const bad of ["/etc/.", "/./etc", "/etc/./passwd"]) {
+      expect(() =>
+        generateCompose({
+          config: makeConfig({
+            klanker: {
+              admin: true,
+              bind_mounts: [{ source: bad }],
+            },
+          }),
+        }),
+        `should refuse normalized source "${bad}"`,
+      ).toThrow(/denylisted system path/);
+    }
+  });
+
+  it("emits normalized paths in the generated compose (byte-stability)", () => {
+    // Two textually-different inputs that normalize to the same canonical
+    // form should produce byte-identical compose lines. Catches the
+    // would-be regression of emitting the raw source verbatim.
+    const a = generateCompose({
+      config: makeConfig({
+        klanker: { admin: true, bind_mounts: [{ source: "/home/me/proj" }] },
+      }),
+    });
+    const b = generateCompose({
+      config: makeConfig({
+        klanker: { admin: true, bind_mounts: [{ source: "//home/me/proj/" }] },
+      }),
+    });
+    // The bind-mount line itself should be identical, even if other
+    // bytes differ (e.g. analytics IDs not present in tests).
+    expect(a).toContain("- /home/me/proj:/home/me/proj:ro");
+    expect(b).toContain("- /home/me/proj:/home/me/proj:ro");
+    expect(b).not.toContain("//home/me/proj");
+  });
+
+  it("rejects targets that shadow switchroom-owned container paths", () => {
+    // fails when: an admin agent can declare a target under /state,
+    // /run/switchroom, /opt/switchroom, or /var/log/switchroom and
+    // shadow the runtime mounts. Self-harm only (admin-trusted), but
+    // the surprise mode (agent boots and silently misbehaves) is
+    // worse than a clear error at compose-generation time.
+    for (const bad of [
+      "/state",
+      "/state/agent",
+      "/state/.claude",
+      "/run/switchroom",
+      "/run/switchroom/broker",
+      "/opt/switchroom",
+      "/opt/switchroom/switchroom.js",
+      "/var/log/switchroom",
+    ]) {
+      expect(() =>
+        generateCompose({
+          config: makeConfig({
+            klanker: {
+              admin: true,
+              bind_mounts: [{ source: "/home/me/dummy", target: bad }],
+            },
+          }),
+        }),
+        `should refuse switchroom-owned target "${bad}"`,
+      ).toThrow(/denylisted container path/);
+    }
+  });
+
+  it("rejects targets that shadow OS paths inside the container", () => {
+    // Admin-only blast radius, but mounting host-anything at /etc
+    // inside the container is almost certainly a misconfig — refuse
+    // up front rather than letting the agent boot with surprising state.
+    for (const bad of [
+      "/etc",
+      "/etc/passwd",
+      "/bin",
+      "/sbin",
+      "/usr/bin",
+      "/usr/sbin",
+      "/lib",
+      "/lib64",
+      "/usr/lib",
+      "/proc",
+      "/sys",
+      "/dev",
+      "/boot",
+    ]) {
+      expect(() =>
+        generateCompose({
+          config: makeConfig({
+            klanker: {
+              admin: true,
+              bind_mounts: [{ source: "/home/me/dummy", target: bad }],
+            },
+          }),
+        }),
+        `should refuse OS-shadow target "${bad}"`,
+      ).toThrow(/denylisted container path/);
+    }
+  });
+
+  it("rejects targets containing '..'", () => {
+    expect(() =>
+      generateCompose({
+        config: makeConfig({
+          klanker: {
+            admin: true,
+            bind_mounts: [
+              { source: "/home/me/x", target: "/state/../etc/passwd" },
+            ],
+          },
+        }),
+      }),
+    ).toThrow(/target.*contains '\.\.'/);
+  });
+
+  it("accepts well-formed targets outside the denylist", () => {
+    // Sanity check — common operator targets must still work.
+    const out = generateCompose({
+      config: makeConfig({
+        klanker: {
+          admin: true,
+          bind_mounts: [
+            { source: "/home/me/shared", target: "/home/agent/shared", mode: "ro" },
+            { source: "/home/me/notes", mode: "rw" },
+          ],
+        },
+      }),
+    });
+    expect(out).toContain("- /home/me/shared:/home/agent/shared:ro");
+    expect(out).toContain("- /home/me/notes:/home/me/notes\n");
   });
 });
 


### PR DESCRIPTION
## Summary

Three follow-ups to #1166, bundled. All admin-only blast radius (admin-trusted operators only); cheap to harden.

**Code**
- **Path normalization.** Source denylist now runs after collapsing repeated `/` and `.` segments. `//etc`, `/etc/.`, `/./etc`, `/etc/./passwd`, `/etc/` all refused as `/etc` instead of slipping past the raw-prefix-match. `..` still rejected pre-normalization (don't silently resolve ambiguous intent). Compose emits the normalized form for byte-stability.
- **Target denylist.** New `BIND_MOUNT_TARGET_DENYLIST` refuses targets that shadow switchroom-owned container paths (`/state`, `/run/switchroom`, `/opt/switchroom`, `/var/log/switchroom`) or OS paths inside the container (`/etc`, `/bin`, …). `..` in targets rejected symmetrically.

**Tests**
- 7 new cases; suite 88 → 95, all green.

**Docs**
- `docs/configuration.md § "Admin-Only: Extra Bind-Mounts"` rewritten. The old framing oversold bind_mounts as the dogfood primitive. The host-control daemon RFC (#1171) surfaced the real picture: `repos:` for source edits, the daemon for deploy, `bind_mounts:` for the residual catch-all. New "Which primitive solves which problem" subsection points readers at the right tool.
- Adds an explicit symlink caveat note.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `tests/docker/compose-generator.test.ts` — 95/95 pass (88 prior + 7 new)
- [x] First reviewer's three nits all addressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)