### PR TITLE
fix(agents): resolve bundled skills from ~/.switchroom/skills/_bundled

### DIFF
--- a/src/agents/reconcile-default-skills.test.ts
+++ b/src/agents/reconcile-default-skills.test.ts
@@ -26,9 +26,11 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { homedir } from "node:os";
 import {
   reconcileAgentDefaultSkills,
   reconcileAllAgentDefaultSkills,
+  getBundledSkillsPoolDir,
 } from "./reconcile-default-skills.js";
 import type { BuiltinSkillEntry } from "../memory/scaffold-integration.js";
 
@@ -209,6 +211,61 @@ describe("reconcileAllAgentDefaultSkills", () => {
       poolDir,
     );
     expect(results).toEqual([]);
+  });
+});
+
+describe("getBundledSkillsPoolDir", () => {
+  it("resolves under ~/.switchroom/skills/_bundled (host-stable, RCA #1164)", () => {
+    const dir = getBundledSkillsPoolDir();
+    expect(dir).toBe(join(homedir(), ".switchroom/skills/_bundled"));
+  });
+});
+
+describe("reconcileAgentDefaultSkills — legacy-prefix migration (#1164)", () => {
+  let tmpRoot: string;
+  let poolDir: string;
+
+  beforeEach(() => {
+    tmpRoot = mkdtempSync(join(tmpdir(), "sr-skills-mig-"));
+    poolDir = makePool(tmpRoot, ["skill-a"]);
+  });
+
+  afterEach(() => {
+    rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  it("repoints a symlink whose target was a legacy /opt/skills/* path", () => {
+    const agentDir = makeAgentDir(tmpRoot, "ag1");
+    const skillsDir = join(agentDir, ".claude", "skills");
+    mkdirSync(skillsDir, { recursive: true });
+    // The legacy target path doesn't have to exist for readlink — we
+    // only need lstat to identify a symlink. Create a dangling link.
+    symlinkSync("/opt/skills/skill-a", join(skillsDir, "skill-a"));
+
+    const result = reconcileAgentDefaultSkills(
+      agentDir,
+      {},
+      [{ key: "skill-a", optOutKey: "skill-a", source: "anthropic" }],
+      poolDir,
+    );
+    expect(result.added).toContain("skill-a");
+    expect(readlinkSync(join(skillsDir, "skill-a"))).toBe(join(poolDir, "skill-a"));
+  });
+
+  it("repoints a symlink whose target was a legacy */switchroom/skills/* dev-checkout path", () => {
+    const agentDir = makeAgentDir(tmpRoot, "ag1");
+    const skillsDir = join(agentDir, ".claude", "skills");
+    mkdirSync(skillsDir, { recursive: true });
+    symlinkSync("/home/dev/code/switchroom/skills/skill-a", join(skillsDir, "skill-a"));
+
+    const result = reconcileAgentDefaultSkills(
+      agentDir,
+      {},
+      [{ key: "skill-a", optOutKey: "skill-a", source: "anthropic" }],
+      poolDir,
+    );
+    expect(result.added).toContain("skill-a");
+    expect(readlinkSync(join(skillsDir, "skill-a"))).toBe(join(poolDir, "skill-a"));
   });
 });
 

--- a/src/agents/reconcile-default-skills.ts
+++ b/src/agents/reconcile-default-skills.ts
@@ -23,8 +23,20 @@
  */
 
 import { existsSync, lstatSync, mkdirSync, readdirSync, readlinkSync, rmSync, symlinkSync } from "node:fs";
+import { homedir } from "node:os";
 import { join, resolve } from "node:path";
 import { getBuiltinDefaultSkillEntries, type BuiltinSkillEntry } from "../memory/scaffold-integration.js";
+
+/** Track which missing-pool-dir warnings we've already emitted so the
+ *  stderr line fires once per process rather than once per agent. */
+const warnedMissingPool = new Set<string>();
+function warnMissingPoolDir(poolDir: string): void {
+  if (warnedMissingPool.has(poolDir)) return;
+  warnedMissingPool.add(poolDir);
+  process.stderr.write(
+    `switchroom: bundled skills pool dir not found at ${poolDir} — run \`switchroom update\` to install it.\n`,
+  );
+}
 
 /**
  * Result for a single agent processed by reconcileAgentDefaultSkills.
@@ -45,16 +57,31 @@ export interface AgentSkillReconcileResult {
 }
 
 /**
- * Resolve the path to the bundled skills pool inside the installed
- * Switchroom package. The pool is shipped alongside the dist/ output —
- * see `package.json` "files" — so this resolves correctly whether
- * Switchroom is running from source (`bun run dev`) or from a
- * globally installed copy under `node_modules/switchroom/`.
+ * Resolve the path to the bundled skills pool. Switchroom now mirrors
+ * the shipped skill set into `~/.switchroom/skills/_bundled/` on each
+ * `switchroom update`, so the runtime resolution is host-stable and
+ * works identically across dev checkouts, packaged installs, and
+ * docker containers (where the in-image path `/opt/switchroom/skills/`
+ * is the wrong answer for an HOME-bind-mounted state dir).
  *
  * Exposed for tests so they can override the pool location with a tmpdir.
  */
 export function getBundledSkillsPoolDir(): string {
-  return resolve(import.meta.dirname, "../../skills");
+  return resolve(homedir(), ".switchroom/skills/_bundled");
+}
+
+/**
+ * Predicate: is `target` a stale symlink that switchroom installed
+ * under a previous resolver — and therefore safe to delete and
+ * recreate? Matches the current pool dir AND legacy prefixes (any
+ * path containing `/switchroom/skills/` — dev-checkout or packaged —
+ * plus the `/opt/skills/` baked-image path used by pre-fix containers).
+ */
+function isOwnedStaleLink(target: string, poolDir: string): boolean {
+  if (target.startsWith(poolDir)) return true;
+  if (target.includes("/switchroom/skills/")) return true;
+  if (target.startsWith("/opt/skills/")) return true;
+  return false;
 }
 
 /**
@@ -100,6 +127,11 @@ export function reconcileAgentDefaultSkills(
   const targetDir = join(claudeDir, "skills");
   mkdirSync(targetDir, { recursive: true });
 
+  if (!existsSync(poolDir)) {
+    warnMissingPoolDir(poolDir);
+    return result;
+  }
+
   for (const entry of defaults) {
     if (optOuts[entry.optOutKey] === false) {
       result.optedOut.push(entry.key);
@@ -130,10 +162,14 @@ export function reconcileAgentDefaultSkills(
           result.alreadyPresent.push(entry.key);
           continue;
         }
-        // Stale symlink — refresh only if it points inside the pool dir.
-        // A foreign symlink (e.g. operator pointed to a custom location)
+        // Stale symlink — refresh if it points inside the current pool
+        // OR matches a legacy switchroom-owned prefix (dev-checkout
+        // `*/switchroom/skills/*` or packaged `/opt/skills/*`). This
+        // is the migration path that heals broken symlinks on user
+        // machines after the pool-dir relocation (RCA: #1164). A
+        // foreign symlink (operator pointed to a custom location)
         // is left alone.
-        if (currentTarget && currentTarget.startsWith(poolDir)) {
+        if (currentTarget && isOwnedStaleLink(currentTarget, poolDir)) {
           try { rmSync(dest, { force: true }); } catch { /* best effort */ }
         } else {
           result.conflicts.push(entry.key);

--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -775,7 +775,10 @@ function syncGlobalSkills(
 
   // Clean up stale symlinks — ones that point into the skills pool but
   // aren't in the current declared set. Real files and symlinks that
-  // point elsewhere are left untouched.
+  // point elsewhere are left untouched. Bundled-default symlinks
+  // (targets under `~/.switchroom/skills/_bundled/`) are owned by the
+  // reconcile-default-skills path; skip them here so we don't prune
+  // them as orphans (RCA: #1164).
   const declaredSet = new Set(declared);
   for (const entry of readdirSync(agentSkillsDir)) {
     if (declaredSet.has(entry)) continue;
@@ -785,6 +788,9 @@ function syncGlobalSkills(
       linkTarget = readlinkSync(entryPath);
     } catch {
       continue; // not a symlink
+    }
+    if (linkTarget && linkTarget.includes("/.switchroom/skills/_bundled/")) {
+      continue; // owned by reconcile-default-skills
     }
     if (linkTarget && linkTarget.startsWith(skillsPool)) {
       rmSync(entryPath, { force: true });
@@ -818,8 +824,13 @@ export function installSwitchroomSkills(
   agentDir: string,
   opts: { role?: "assistant" | "foreman" } = {},
 ): void {
-  const builtinSkillsDir = resolve(import.meta.dirname, "../../skills");
-  if (!existsSync(builtinSkillsDir)) return;
+  const builtinSkillsDir = resolve(homedir(), ".switchroom/skills/_bundled");
+  if (!existsSync(builtinSkillsDir)) {
+    process.stderr.write(
+      `switchroom: bundled skills pool dir not found at ${builtinSkillsDir} — run \`switchroom update\` to install it.\n`,
+    );
+    return;
+  }
 
   const targetDir = join(agentDir, ".claude", "skills");
   mkdirSync(targetDir, { recursive: true });

--- a/src/cli/deps.ts
+++ b/src/cli/deps.ts
@@ -1,4 +1,5 @@
 import { existsSync } from "node:fs";
+import { homedir } from "node:os";
 import { join, resolve } from "node:path";
 import chalk from "chalk";
 import type { Command } from "commander";
@@ -6,7 +7,10 @@ import { ensurePythonEnv, PythonEnvError } from "../deps/python.js";
 import { ensureNodeEnv, NodeEnvError } from "../deps/node.js";
 
 function builtinSkillsRoot(): string {
-  return resolve(import.meta.dirname, "../../skills");
+  // Mirrors getBundledSkillsPoolDir() in reconcile-default-skills.ts —
+  // `switchroom update` syncs the shipped skills/ payload to this
+  // location so resolution is host-stable (RCA: #1164).
+  return resolve(homedir(), ".switchroom/skills/_bundled");
 }
 
 export function registerDepsCommand(program: Command): void {
@@ -20,7 +24,16 @@ export function registerDepsCommand(program: Command): void {
     .option("-p, --python", "Rebuild only the Python env")
     .option("-n, --node", "Rebuild only the Node env")
     .action(async (skill: string, opts: { python?: boolean; node?: boolean }) => {
-      const skillDir = join(builtinSkillsRoot(), skill);
+      const skillsRoot = builtinSkillsRoot();
+      if (!existsSync(skillsRoot)) {
+        console.error(
+          chalk.red(
+            `Bundled skills pool dir not found at ${skillsRoot} — run \`switchroom update\` to install it.`,
+          ),
+        );
+        process.exit(1);
+      }
+      const skillDir = join(skillsRoot, skill);
       if (!existsSync(skillDir)) {
         console.error(chalk.red(`Unknown skill: ${skill} (no dir at ${skillDir})`));
         process.exit(1);

--- a/src/cli/update.test.ts
+++ b/src/cli/update.test.ts
@@ -26,7 +26,7 @@ function fakeRunner() {
 }
 
 describe("planUpdate", () => {
-  it("produces 5 steps in default mode (no --rebuild)", () => {
+  it("produces 6 steps in default mode (no --rebuild)", () => {
     const tmp = mkdtempSync(join(tmpdir(), "update-plan-"));
     try {
       const composePath = join(tmp, "docker-compose.yml");
@@ -35,6 +35,7 @@ describe("planUpdate", () => {
       expect(steps.map((s) => s.name)).toEqual([
         "pull-images",
         "apply-config",
+        "sync-bundled-skills",
         "stamp-restart-marker",
         "recreate-containers",
         "doctor",
@@ -54,6 +55,7 @@ describe("planUpdate", () => {
         "pull-images",
         "rebuild-source",
         "apply-config",
+        "sync-bundled-skills",
         "stamp-restart-marker",
         "recreate-containers",
         "doctor",
@@ -379,6 +381,8 @@ describe("runUpdate", () => {
         // agent set deterministically here so the assertions don't read
         // the host's real switchroom.yaml.
         agentNamesFn: () => ["a", "b"],
+        // No-op the sync-bundled-skills filesystem effect under tests.
+        syncBundledSkillsFn: () => { /* intentional no-op */ },
       });
       expect(code).toBe(0);
       // 6 calls total:

--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -34,9 +34,9 @@
  */
 import type { Command } from "commander";
 import chalk from "chalk";
-import { existsSync, readFileSync, realpathSync, statSync } from "node:fs";
+import { cpSync, existsSync, mkdirSync, readFileSync, realpathSync, rmSync, statSync } from "node:fs";
 import { spawnSync } from "node:child_process";
-import { join, dirname } from "node:path";
+import { join, dirname, resolve } from "node:path";
 import { homedir } from "node:os";
 import { loadConfig } from "../config/loader.js";
 import { writeRestartReasonMarker } from "../agents/lifecycle.js";
@@ -65,6 +65,10 @@ interface UpdateOptions {
   /** Test seam — supply the agent name list for the stamp-restart-marker
    *  step instead of reading from switchroom.yaml. */
   agentNamesFn?: () => readonly string[];
+  /** Test seam — replace the bundled-skills sync (default: real cpSync to
+   *  `~/.switchroom/skills/_bundled/`). Tests override to a no-op so
+   *  the step doesn't write into the developer's HOME. */
+  syncBundledSkillsFn?: () => void;
   /** Test seam — replace the marker writer used by stamp-restart-marker. */
   writeMarkerFn?: (agent: string, reason: string) => void;
 }
@@ -202,6 +206,51 @@ export function planUpdate(opts: UpdateOptions): UpdateStep[] {
   // correctly attributes the planned redeploy to the operator. The
   // host-side fallback below DOES use preserveExisting: true so
   // systemd-runtime hosts retain the original /restart-race guard.
+  // Sync the shipped skills/ payload to the host-stable pool dir at
+  // `~/.switchroom/skills/_bundled/`. The runtime resolvers (reconcile-
+  // default-skills, scaffold.installSwitchroomSkills, cli/deps) all
+  // read from there, so this step is what makes default-skill symlinks
+  // resolve correctly across dev, packaged, and docker installs
+  // (RCA: #1164). Prune-and-replace: delete existing `_bundled/`, then
+  // recursive copy.
+  steps.push({
+    name: "sync-bundled-skills",
+    description:
+      "Sync shipped skills/ to ~/.switchroom/skills/_bundled/ (host-stable pool dir).",
+    run: () => {
+      if (opts.syncBundledSkillsFn) {
+        opts.syncBundledSkillsFn();
+        return;
+      }
+      // SOURCE: the skills/ directory shipped alongside the running
+      // CLI bundle. `import.meta.dirname` is dist/cli/ at runtime; the
+      // skills/ payload lives two levels up beside dist/ (see package
+      // .json "files" — skills/ is shipped). This is the only place
+      // the legacy `resolve(import.meta.dirname, "../../skills")`
+      // expression is still correct, because here it really IS the
+      // source for the copy.
+      const source = resolve(import.meta.dirname, "../../skills");
+      const dest = join(homedir(), ".switchroom", "skills", "_bundled");
+      if (!existsSync(source)) {
+        process.stderr.write(
+          `switchroom update: sync-bundled-skills — CLI bundle has no adjacent skills/ at ${source}; skipping.\n`,
+        );
+        return;
+      }
+      try {
+        if (existsSync(dest)) {
+          rmSync(dest, { recursive: true, force: true });
+        }
+        mkdirSync(dirname(dest), { recursive: true });
+        cpSync(source, dest, { recursive: true, dereference: false });
+      } catch (err) {
+        throw new Error(
+          `sync-bundled-skills failed: ${(err as Error).message}`,
+        );
+      }
+    },
+  });
+
   steps.push({
     name: "stamp-restart-marker",
     description:


### PR DESCRIPTION
## Summary

Fixes the dangling-default-skills bug: switchroom resolves bundled-skill paths via `resolve(import.meta.dirname, "../../skills")`, so when the CLI ran from a dev checkout the host-only path `~/code/switchroom/skills/...` got baked into every agent's `.claude/skills/<name>` symlink. Those targets don't exist inside agent containers (not bind-mounted), so 10/15 default skills dangle. The packaged install at `/opt/switchroom` also shipped no sibling `skills/`, so reconcile from the packaged CLI silently no-op'd.

Repoints the runtime resolver at `~/.switchroom/skills/_bundled/` (a path that's already bind-mounted into every container as part of `~/.switchroom/skills`), and adds a `sync-bundled-skills` step to `switchroom update` that copies the CLI-adjacent `skills/` payload into that location. Stale-link migration broadens reconcile's "is this a link we own" check to also match legacy prefixes, so the broken symlinks on existing user machines get rewritten on next reconcile without any manual `rm`.

Refs #1164.

## Changes

- **`src/agents/reconcile-default-skills.ts`** — `getBundledSkillsPoolDir()` → `~/.switchroom/skills/_bundled/`; existsSync guard with one-shot stderr warning; `isOwnedStaleLink()` matches current pool + legacy `*/switchroom/skills/*` and `/opt/skills/*` prefixes for migration.
- **`src/agents/scaffold.ts`** — `installSwitchroomSkills()` repointed; `syncGlobalSkills` orphan-cleanup skips `_bundled/` targets.
- **`src/cli/deps.ts`** — `builtinSkillsRoot()` repointed + existsSync guard.
- **`src/cli/update.ts`** — new `sync-bundled-skills` step (after `apply-config`, before `stamp-restart-marker`) doing prune-and-replace `cpSync` from CLI-adjacent `skills/` into `~/.switchroom/skills/_bundled/`.
- **Tests** — happy-path pool-dir resolution + two legacy-prefix migration cases; `update.test.ts` step-count/order updated.

## Packaging note

`package.json` `files:` already lists `skills` alongside `dist`, so the install tarball ships the payload — no packaging change required.

## Migration

Existing user machines: on next `switchroom update`, the new sync step populates `~/.switchroom/skills/_bundled/`. On next reconcile, the broadened stale-link detector overwrites the dangling host-path symlinks. No manual cleanup needed.

## Test plan

- [x] `bun test` — 43 relevant tests pass (reconcile-default-skills, scaffold, update)
- [x] `bun run build` — clean
- [x] Typecheck — clean
- [ ] Manual: run `switchroom update` on a host with an existing klanker agent, confirm all 15 default skills resolve inside the container (`ls -L ~/.switchroom/agents/klanker/.claude/skills/`)

Pre-existing `apply.test.ts` failures (9) unrelated — sandbox has no `docker compose` binary; confirmed unaffected by these changes via `git stash` baseline.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)