### PR TITLE
fix(compose): mount bundled-skills pool so default-skill symlinks resolve in-container

### DIFF
--- a/src/agents/compose.ts
+++ b/src/agents/compose.ts
@@ -29,6 +29,7 @@ import { join } from "node:path";
 import type { SwitchroomConfig, AgentConfig, AgentBindMount } from "../config/schema.js";
 import { resolveAgentConfig } from "../config/merge.js";
 import { isReservedAgentName } from "../vault/broker/peercred.js";
+import { getBundledSkillsPoolDir } from "./reconcile-default-skills.js";
 
 /** UID range reserved for agent containers. 999 slots — practical fleet limit. */
 export const AGENT_UID_MIN = 10001;
@@ -203,6 +204,26 @@ export interface ComposeGeneratorOptions {
    * pre-fix behavior. Setting it is what turns the host-shell path on.
    */
   operatorUid?: number;
+  /**
+   * Host path to the bundled-default skills pool directory. Mounted
+   * read-only at the same path inside each agent container so the
+   * symlinks created by `reconcileAgentDefaultSkills` (which point at
+   * this absolute host path — e.g. `<repo>/skills/skill-creator`) keep
+   * resolving inside the container.
+   *
+   * Without this mount, the 10 bundled-default skills (skill-creator,
+   * mcp-builder, pdf/docx/xlsx/pptx, webapp-testing, switchroom-cli/
+   * status/health) dangle inside the container because their symlink
+   * target — the source-repo or npm-package `skills/` dir — isn't
+   * mounted. probeSkills surfaces this as "N/M dangling" on the boot
+   * card.
+   *
+   * Defaults to `getBundledSkillsPoolDir()` — same resolver
+   * `reconcileAgentDefaultSkills` uses, so the symlink target and the
+   * mount source are guaranteed to agree. Tests override with a tmp
+   * path (or empty string to suppress emission).
+   */
+  bundledSkillsPoolDir?: string;
 }
 
 /** Resolve the image ref for one of the four service images. */
@@ -427,6 +448,9 @@ export function generateCompose(opts: ComposeGeneratorOptions): string {
   // home. Falls back to process.env.HOME when no homeDir is passed.
   const hostHomeForChecks = opts.homeDir ?? process.env.HOME ?? "";
   const switchroomConfigPath = opts.switchroomConfigPath;
+  // Bundled-skills pool dir. Default to the live resolver so production
+  // calls Just Work; tests pass an explicit path (or "") to override.
+  const bundledSkillsPoolDir = opts.bundledSkillsPoolDir ?? getBundledSkillsPoolDir();
 
   // Resolve the host's analytics distinct ID once per generator call. The
   // CLI persists this at ~/.switchroom/analytics-id (see
@@ -733,6 +757,7 @@ export function generateCompose(opts: ComposeGeneratorOptions): string {
         posthogKeyOverride,
         posthogHostOverride,
       },
+      bundledSkillsPoolDir,
     );
   }
 
@@ -772,6 +797,7 @@ function emitAgentService(
   switchroomConfigPath: string | undefined,
   containerNamePrefix: string,
   posthog: PosthogRuntimeEnv,
+  bundledSkillsPoolDir: string,
 ): void {
   lines.push(`  agent-${a.name}:`);
   emitImageOrBuild(lines, "agent", imageTag, buildMode, buildContext);
@@ -1042,6 +1068,21 @@ function emitAgentService(
   }
   if (existsSync(`${hostHomeForChecks}/.switchroom/credentials`)) {
     lines.push(`      - ${homePrefix}/.switchroom/credentials:${homePrefix}/.switchroom/credentials:ro`);
+  }
+  // Bundled-skills pool: mount at the same absolute host path so the
+  // symlinks created by reconcileAgentDefaultSkills (which target the
+  // source-repo or npm-package skills/ dir — e.g.
+  // `<repo>/skills/skill-creator`) resolve inside the container.
+  // Guard with existsSync because the resolved path may not exist in
+  // exotic test setups and docker compose `up` hard-fails on missing
+  // `:ro` sources. Skip when the pool path is already covered by the
+  // operator skills mount above (no duplicate volume entries).
+  if (
+    bundledSkillsPoolDir &&
+    existsSync(bundledSkillsPoolDir) &&
+    !bundledSkillsPoolDir.startsWith(`${hostHomeForChecks}/.switchroom/skills`)
+  ) {
+    lines.push(`      - ${bundledSkillsPoolDir}:${bundledSkillsPoolDir}:ro`);
   }
   // switchroom.yaml file mount (read-only) — the in-container gateway
   // daemon needs `--config $SWITCHROOM_CONFIG` to talk to the

--- a/tests/docker/compose-generator.test.ts
+++ b/tests/docker/compose-generator.test.ts
@@ -373,6 +373,75 @@ describe("generateCompose", () => {
     }
   });
 
+  it("emits a :ro mount for the bundled-skills pool dir (dangling-skill fix)", async () => {
+    // reconcileAgentDefaultSkills creates symlinks under
+    // <agent>/.claude/skills/<key> pointing at the absolute host path
+    // <poolDir>/<key>. Without mounting <poolDir> into the container,
+    // those targets dangle (boot card shows "N/M dangling: skill-creator,
+    // mcp-builder, ...").
+    const { mkdtempSync, mkdirSync, rmSync } = await import("node:fs");
+    const { tmpdir } = await import("node:os");
+    const { join } = await import("node:path");
+    const tmp = mkdtempSync(join(tmpdir(), "compose-pool-"));
+    const poolDir = join(tmp, "skills-pool");
+    mkdirSync(poolDir, { recursive: true });
+    try {
+      const out = generateCompose({
+        config: makeConfig({ a: {} }),
+        homeDir: tmp,
+        bundledSkillsPoolDir: poolDir,
+      });
+      expect(out).toContain(`${poolDir}:${poolDir}:ro`);
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("omits the bundled-skills pool mount when the dir doesn't exist", async () => {
+    // Skip emission gracefully — docker compose `up` hard-fails on
+    // missing `:ro` sources, and there are exotic test setups where the
+    // pool path simply doesn't resolve to a real dir.
+    const { mkdtempSync, rmSync } = await import("node:fs");
+    const { tmpdir } = await import("node:os");
+    const { join } = await import("node:path");
+    const tmp = mkdtempSync(join(tmpdir(), "compose-no-pool-"));
+    try {
+      const out = generateCompose({
+        config: makeConfig({ a: {} }),
+        homeDir: tmp,
+        bundledSkillsPoolDir: join(tmp, "does-not-exist"),
+      });
+      expect(out).not.toContain(`${tmp}/does-not-exist`);
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("skips the bundled-skills pool mount when it's already inside ~/.switchroom/skills", async () => {
+    // If an operator has placed their bundled pool under
+    // ~/.switchroom/skills (e.g. a custom packaging), the existing
+    // operator-skills mount already covers it — emitting a second
+    // identical-path entry would be a duplicate volume.
+    const { mkdtempSync, mkdirSync, rmSync } = await import("node:fs");
+    const { tmpdir } = await import("node:os");
+    const { join } = await import("node:path");
+    const tmp = mkdtempSync(join(tmpdir(), "compose-pool-overlap-"));
+    const opSkills = join(tmp, ".switchroom", "skills");
+    const nestedPool = join(opSkills, "_builtin");
+    mkdirSync(nestedPool, { recursive: true });
+    try {
+      const out = generateCompose({
+        config: makeConfig({ a: {} }),
+        homeDir: tmp,
+        bundledSkillsPoolDir: nestedPool,
+      });
+      expect(out).toContain(`${opSkills}:${opSkills}:ro`);
+      expect(out).not.toContain(`${nestedPool}:${nestedPool}:ro`);
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
   it("omits skills/credentials mounts when host dirs are absent (#907)", async () => {
     // docker compose `up` hard-fails if a `:ro` source path is missing.
     // Many operators keep all secrets in vault and never create


### PR DESCRIPTION
## Summary

- 10 of every agent's 14 default skills (skill-creator, mcp-builder, pdf/docx/xlsx/pptx, webapp-testing, switchroom-cli/status/health) dangle inside the agent container because their symlink target — the source-repo / npm-package `skills/` dir — was never mounted in.
- This PR mounts `getBundledSkillsPoolDir()` read-only at its same absolute host path inside each agent container, so the symlinks created by `reconcileAgentDefaultSkills` resolve.
- Source/mount agreement is guaranteed: both `reconcileAgentDefaultSkills` and the new mount call the same `getBundledSkillsPoolDir()` resolver.

## How it surfaces today

`probeSkills` (PR #1081) shows the persistent boot-card row:

```
⚠ Skills: 10/14 dangling: switchroom-status, switchroom-health, skill-creator +7 more
  → Run `switchroom agent reconcile <agent>` to rebuild symlinks…
```

The hint is misleading: the symlinks are correct on the host. They just point at a path that doesn't exist inside the container.

## Why this wasn't caught by #907 / #912

#907 fixed the operator skills mount (`~/.switchroom/skills`) and credentials mount. The bundled-skills *pool* (which feeds `reconcileAgentDefaultSkills` from PR #558) is a third path under either the source-repo or the npm-package install, and was never wired through.

## Guards

- `existsSync` — docker compose `up` hard-fails on missing `:ro` sources.
- Skip when the pool path is already covered by the operator skills mount above (no duplicate volume entries).
- Override via `ComposeGeneratorOptions.bundledSkillsPoolDir` for tests; empty string suppresses emission.

## Test plan

- [x] `npx vitest run tests/docker/compose-generator.test.ts` — 91 pass (3 new)
- [x] `npm run lint` — clean
- [ ] Reviewer agent (fresh process) verdict
- [ ] After merge: `switchroom update` regenerates compose; restart agents
- [ ] Verify boot card flips from "10/14 dangling" to "14 resolved" on every agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)