### PR TITLE
fix(compose): TINI_KILL_PROCESS_GROUP=1 so SIGTERM reaches the gateway sidecar

### DIFF
--- a/src/agents/compose.ts
+++ b/src/agents/compose.ts
@@ -1022,6 +1022,36 @@ function emitAgentService(
     SWITCHROOM_VAULT_BROKER_SOCK: `/run/switchroom/broker/sock`,
     SWITCHROOM_KERNEL_SOCKET: `/run/switchroom/kernel/sock`,
     SWITCHROOM_RUNTIME: "docker",
+    // tini's process-group signal mode. Default tini forwards signals
+    // ONLY to its single direct child — under our process tree that's
+    // tmux (or start.sh→tmux post-exec) at PID 7. The gateway sidecar
+    // and other backgrounded sidecars (autoaccept-poll, agent-scheduler)
+    // share PGID=7 with tmux but are NOT direct children of tini, so
+    // a SIGTERM from `docker stop` / `docker compose up -d --remove-
+    // orphans` reaches tmux only — the gateway gets SIGKILL'd after
+    // stop_grace_period without ever running its shutdown handler.
+    //
+    // The handler matters: it writes /state/agent/telegram/clean-
+    // shutdown.json with a fresh timestamp + reason (the SIGTERM
+    // fallback is "systemctl: external restart" — see clean-shutdown-
+    // marker.ts:139), and the next gateway boot reads that marker to
+    // resolve restartReason as 'graceful' instead of 'crash'. Without
+    // this env, every raw `docker compose up -d` recreate boots as
+    // crash + notifies the fleet (CC-equivalent to the bug PR #1141
+    // fixed for `switchroom update` specifically — that one uses
+    // `docker exec` to stamp the marker BEFORE the recreate, this one
+    // makes the in-gateway shutdown handler reliable so any graceful
+    // container stop self-attributes).
+    //
+    // TINI_KILL_PROCESS_GROUP=1 routes signals to the pgrp of tini's
+    // direct child via kill(-pgid, sig). Verified pgrp tree on
+    // 2026-05-13 (gymbro container): tmux client + supervisor bashes
+    // + bun gateway + bun scheduler + bun autoaccept all share PGID=7
+    // — they all get SIGTERM together. Claude (PGID=20, separate
+    // session via tmux server) is unaffected, which is correct: it
+    // doesn't write the marker and gets SIGKILL'd at grace-period
+    // expiry like before.
+    TINI_KILL_PROCESS_GROUP: "1",
   };
   // PostHog runtime telemetry — opt-out honoured, distinct-ID propagated
   // from the host CLI so CLI + runtime events merge under the same user.

--- a/tests/docker/compose-generator.test.ts
+++ b/tests/docker/compose-generator.test.ts
@@ -653,6 +653,22 @@ describe("agent service env (Phase 2c F2 — IPC wiring)", () => {
     }
   });
 
+  it("sets TINI_KILL_PROCESS_GROUP=1 so SIGTERM reaches the gateway sidecar", () => {
+    // Without this env, tini forwards SIGTERM only to its direct child
+    // (tmux at PID 7); the gateway/scheduler/autoaccept sidecars share
+    // PGID=7 but are NOT direct children of tini, so they get SIGKILL'd
+    // at stop_grace_period without running the shutdown handler. The
+    // handler writes clean-shutdown.json — without it, every graceful
+    // container stop boots as 'crash recovery' on the next start.
+    const out = generateCompose({
+      config: makeConfig({ alice: {}, bob: {} }),
+    });
+    for (const a of ["alice", "bob"]) {
+      const env = envBlockFor(out, a);
+      expect(env).toMatch(/TINI_KILL_PROCESS_GROUP:\s*"1"/);
+    }
+  });
+
   it("sets SWITCHROOM_KERNEL_SOCKET to the agent-perspective socket path", () => {
     // The agent mounts `kernel-<name>-sock` at `/run/switchroom/kernel`
     // (compose.ts line ~608 — directly at the parent dir, not at a


### PR DESCRIPTION
## Summary

- Default tini forwards signals only to its direct child (the tmux client at PID 7); the gateway/scheduler/autoaccept sidecars share PGID=7 but aren't direct children, so SIGTERM never reaches them on \`docker stop\` / \`docker compose up -d\`.
- The gateway's existing SIGTERM handler (the one that writes the \`EXTERNAL_RESTART_FALLBACK_REASON = \"systemctl: external restart\"\` marker) therefore never runs — every graceful container stop boots as 'crash recovery' and notifies the fleet.
- This PR sets \`TINI_KILL_PROCESS_GROUP=1\` on agent containers. Tini routes signals via \`kill(-pgid, sig)\`, every sidecar gets SIGTERM together, the existing fallback writer runs.

## Why this isn't already covered by #1141

PR #1141 covers \`switchroom update\` specifically (it docker-exec's the marker into each container *before* the recreate). It does NOT cover:
- raw \`docker compose up -d --remove-orphans\` (e.g. an agent rolling out a compose-only change)
- manual \`docker stop \$container\`
- Coolify-driven stops
- \`docker kill --signal=TERM\`

This PR closes the gap by making the in-gateway SIGTERM handler reliable so any graceful container stop self-attributes.

## Verification

Pgrp tree from the live \`switchroom-gymbro\` container (2026-05-13):

\`\`\`
  PID    PPID    PGID     SID COMMAND
    1       0       1       1 tini
    7       1       7       1 tmux: client
    8       7       7       1 start.sh   (supervisor for gateway)
    9       7       7       1 start.sh   (supervisor for autoaccept)
   10       8       7       1 bun        (gateway)
   11       7       7       1 start.sh   (supervisor for scheduler)
   13      11       7       1 bun        (scheduler)
   15       1      15      15 tmux: server
   20      15      20      20 claude     (separate session — not affected)
\`\`\`

All sidecars share PGID=7 → \`TINI_KILL_PROCESS_GROUP=1\` reaches every one.

## Test plan

- [x] \`npx vitest run tests/docker/compose-generator.test.ts\` — 99 pass (1 new)
- [x] \`npm run lint\` — clean
- [ ] Reviewer agent verdict
- [ ] After merge: \`switchroom update\` regenerates compose w/ new env, recreates containers
- [ ] Manual: \`docker stop switchroom-<one-agent>\` + \`docker start ...\`, verify boot card reads 'graceful' (\`systemctl: external restart\`), no notification

## Follow-up not in this PR

Belt-and-braces: cross-reference \`gateway-session.json\` mtime against \`/proc/1\` start time inside \`determineRestartReason\` to catch the SIGKILL/OOM/hung-shutdown cases where even \`TINI_KILL_PROCESS_GROUP=1\` doesn't help. Tracked separately — ship this surgical fix first and gather field data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)