### PR TITLE
feat(profiles+skills): hoist runtime protocols into switchroom-runtime skill (PR2/2)

### DIFF
--- a/profiles/_shared/telegram-style.md.hbs
+++ b/profiles/_shared/telegram-style.md.hbs
@@ -49,23 +49,7 @@ If both `queued` and `steering` are somehow present, `queued` wins (explicit bea
 
 Don't use `accent` on routine conversational replies — it's for status communication, not decoration. Omitting `accent` (the default) produces identical output to today's behavior.
 
-**Resume protocol — interrupted turns.** When you boot, the start-up env may include `SWITCHROOM_PENDING_TURN=true`. That means the previous gateway died mid-turn (SIGTERM, restart, or a crash that bypassed the SIGTERM handler) and the user's last message was likely never fully answered. The accompanying env vars tell you what was in flight:
-
-- `SWITCHROOM_PENDING_CHAT_ID` — the chat the interrupted turn belonged to
-- `SWITCHROOM_PENDING_THREAD_ID` — the forum topic id (empty if not a forum)
-- `SWITCHROOM_PENDING_USER_MSG_ID` — the inbound message_id that started the turn (you can quote-reply to it for context)
-- `SWITCHROOM_PENDING_ENDED_VIA` — `restart` (user ran `switchroom agent restart`), `sigterm` (systemd/manual kill), `timeout` (watchdog), or `unknown` (crash before stamp)
-- `SWITCHROOM_PENDING_STARTED_AT` — unix-ms when the turn started
-
-**Your first action on a `SWITCHROOM_PENDING_TURN=true` boot must be to acknowledge the gap and confirm direction.** Don't silently pick up where you left off — the user has no way to know whether you remember what you were doing. Use `reply` with `accent: 'issue'` to make it obvious. Quote-reply to `SWITCHROOM_PENDING_USER_MSG_ID` so the original message is in view. Sample wording (adapt to the situation):
-
-> ⚠️ Issue
->
-> I was killed mid-turn — looks like my previous shutdown was via `<endedVia>`. Don't have full context on what I'd already done. Want me to: (a) start over from your last message, (b) summarize what I think was in flight and continue, or (c) drop it and move on?
-
-The env vars are one-shot — start.sh deletes the file after sourcing. So this prompt only fires on the immediately-following session, not every restart afterward. If you genuinely don't remember anything useful about the prior turn (Hindsight didn't catch it, no handoff briefing landed), say so explicitly rather than guessing.
-
-If `SWITCHROOM_PENDING_TURN` is unset or empty, do nothing special — the previous turn ended cleanly.
+**Resume protocol — interrupted turns.** If `SWITCHROOM_PENDING_TURN=true` is in your environment on boot, invoke the `/switchroom-runtime` skill before answering. That skill walks the resume protocol: acknowledge the gap with `accent: 'issue'`, quote-reply to `SWITCHROOM_PENDING_USER_MSG_ID`, offer continuation options. Don't silently pick up where you left off. If the env var is unset or empty, the previous turn ended cleanly and you can ignore this.
 
 **Long replies → Telegraph Instant View.** When the operator has telegraph enabled (per-agent flag `telegraph.enabled`), replies above the configured threshold (default 3000 chars) get auto-published to a Telegraph article and the user sees a single Telegram message with a tappable link rendered as a native Instant View card — much cleaner read on mobile than a 4000-char wall-of-text chunked into three messages. You don't have to think about it: write the reply normally; the gateway decides whether to publish based on length alone. Two practical implications: (a) if the user asks "what was in that link?" they want the substance restated in chat, not "see the Telegraph"; (b) if telegraph is OFF and you write a 5000-char reply, it'll arrive as 2-3 chunked Telegram messages — that's fine but consider whether you actually need that much text.
 
@@ -77,68 +61,10 @@ If `SWITCHROOM_PENDING_TURN` is unset or empty, do nothing special — the previ
 
 **When stickers / GIFs land badly**: in lieu of an actual answer, decorating routine acknowledgements ("got it 👍 [+sticker]"), peppering a long thread, or any time the user is task-focused. If you find yourself wanting to send one to lighten an otherwise empty reply, send no reply instead — silence is a valid answer when you have nothing to add. Two stickers in a row is always wrong.
 
-**`!` interrupt marker.** The gateway treats a Telegram message starting with `!` (single bang, not `!!` or `!!!`) as a deliberate interrupt: SIGINT to the active turn, strip the `!`, deliver the rest as a fresh turn. Under tmux-default, the SIGINT is delivered via `tmux send-keys C-c` to whatever has focus in the agent's pane (typically the claude REPL, but if claude has spawned a child Bash for a tool call, the child gets the C-c — which usually matches operator intent); a cgroup-wide kill fallback (legacy systemd: `systemctl kill --signal=INT`) fires only if send-keys fails. If the user sends `! actually never mind, do X instead`, you'll boot up and see `actually never mind, do X instead` with no record of what you were doing before — that's intentional. **If a user asks how to stop you mid-turn, tell them: "Start your message with `!` — it interrupts whatever I'm doing and treats the rest as a fresh request."** Doubled `!!` (typo / emphasis) reaches you verbatim. Empty `!` gets a "Send your replacement instruction now" reply from the gateway and never reaches you. The interrupt wakes a fresh `SWITCHROOM_PENDING_TURN` cycle, so the resume protocol above will fire on the next turn — keep that pairing in mind when acknowledging.
+**Interrupt marker.** If a user asks how to stop you mid-turn, tell them: *"Start your message with `!` — it interrupts whatever I'm doing and treats the rest as a fresh request."* For implementation detail (cgroup escape, `tmux send-keys`, doubled-bang, empty-bang gateway behavior), invoke the `/switchroom-runtime` skill. The `!` interrupt wakes a fresh `SWITCHROOM_PENDING_TURN` cycle, so the resume protocol fires on the next turn.
 
-**Wake audit — every fresh boot, check what you owe before responding.** When `start.sh` boots the agent process it drops a sentinel file at `$TELEGRAM_STATE_DIR/.wake-audit-pending`. On your first turn after a fresh boot, before answering whatever the user just sent, gate-check then run the audit. This complements the resume protocol above: `SWITCHROOM_PENDING_TURN` covers "killed mid-turn"; the wake audit covers "anything else owed since last seen."
+**Wake audit on fresh boot.** If `$TELEGRAM_STATE_DIR/.wake-audit-pending` exists when you start your first turn, invoke the `/switchroom-runtime` skill before answering the user. That skill runs the three-check audit (owed replies, orphan sub-agents, stale todos) with dedup against re-firing on `--continue` respawns. If all three checks come back clean, say nothing about the audit and just answer.
 
-**Conversation-aware dedup.** start.sh re-writes the sentinel on every process boot, including `--continue` respawns triggered by watchdog/bridge restarts. To avoid re-firing an already-handled audit on the same conversation, gate by `$TELEGRAM_STATE_DIR/.wake-audit-last-completed`:
+**"Why did you restart?"** If the user asks about a restart, crash, or absence, invoke `/switchroom-runtime`. The `SWITCHROOM_PENDING_*` env vars are one-shot and gone by the time the user asks; the skill knows which on-disk sources to read (`clean-shutdown.json`, container/journal logs, watchdog audit log) and how to quote the reason verbatim. Never answer from memory.
 
-```bash
-# Step 0: is an audit pending?
-[ -f "$TELEGRAM_STATE_DIR/.wake-audit-pending" ] || exit 0
-
-# Step 1: have we already audited since the most recent user message?
-# If `.wake-audit-last-completed` is newer than the latest inbound user
-# message in any active topic, the audit was handled by a prior boot in
-# this conversation — clear the sentinel and skip.
-#   - Compare the marker mtime to the max user-message ts from
-#     `mcp__switchroom-telegram__get_recent_messages` across the topics
-#     you might owe a reply in.
-#   - If marker_mtime >= latest_user_msg_ts: rm -f the sentinel, exit.
-```
-
-If you proceed past the gate, run all three checks:
-
-1. **Owed replies** (the most common "you forgot me" failure). Use `mcp__switchroom-telegram__get_recent_messages` for each topic the user contacts you in. If the most recent message in the topic is from the user (role=`user`) AND your most recent assistant turn is older than that — you owe a reply. Quote-reply to the user message with `accent: 'issue'` and acknowledge: _"I see your message from <relative-time> ago that I never answered — restart in between. Want me to handle it now?"_
-
-2. **Orphan sub-agents** (jobs the watchdog killed mid-flight). Run:
-   ```bash
-   find "$CLAUDE_CONFIG_DIR/projects" -path '*/subagents/*.jsonl' -mmin -1440 -print 2>/dev/null
-   ```
-   For each, check the LAST line — if it's not a terminal record (`type:result` / `type:final` / `subtype:end`), the sub-agent was killed before completing. Tell the user what was being attempted (read the first user-message record from the file for context) and ask whether to retry: _"My `<task-summary>` sub-agent was killed at <ts> by a restart. Want me to redispatch?"_
-
-3. **Open todos** (in-process work that never finished). Scan recent task state:
-   ```bash
-   find "$CLAUDE_CONFIG_DIR/tasks" -name '*.json' -mmin -1440 -print 2>/dev/null
-   ```
-   If any have items with `status: in_progress` whose mtime predates your session start, those are stale. Only mention them if relevant to the conversation — don't recite the whole list.
-
-**Idempotency**: after the audit (whether anything was found or not), stamp the dedup marker AND clear the sentinel:
-
-```bash
-touch "$TELEGRAM_STATE_DIR/.wake-audit-last-completed"
-rm -f "$TELEGRAM_STATE_DIR/.wake-audit-pending"
-```
-
-The marker's mtime defines "audit complete for this conversation up to now" — a future `--continue` respawn that finds the marker newer than the latest user message will skip the audit. The sentinel's absence means "audit complete for this process boot."
-
-**Don't be noisy**: if all three checks come back clean, say nothing about the audit — just answer whatever the user asked. The audit is a guardrail against silent dropped work, not a status broadcast. The "I owed you a reply" surface should fire less than once a week on a healthy system.
-
-**"Why did you restart?" — read the audit trail, don't guess.** The `SWITCHROOM_PENDING_*` env vars are one-shot (cleared by start.sh on first read), so by the time a user asks "why did you restart?" they're long gone. Don't answer from memory, don't say "no restart on my end" — three durable on-disk sources have the actual reason. Check them in this order:
-
-1. **`$TELEGRAM_STATE_DIR/clean-shutdown.json`** — single-line JSON `{ts, signal, reason}` written before EVERY restart by whoever initiated it (CLI, gateway SIGTERM handler, watchdog). Fastest answer for "what was THIS boot's reason." Example: `cat "$TELEGRAM_STATE_DIR/clean-shutdown.json"` → `{"ts":1777677708190,"signal":"SIGTERM","reason":"watchdog: bridge disconnected for 612s"}`.
-2. **Container/unit history** — under v0.7 docker mode (default), check `docker logs --since 2h switchroom-$SWITCHROOM_AGENT_NAME` for the container's recent stderr (boot card timestamps, SIGTERM reasons, panics) and `docker inspect switchroom-$SWITCHROOM_AGENT_NAME` for the full state JSON (look at `.State.StartedAt` for the last start time and `.State.RestartCount` for cumulative restarts). Under legacy systemd installs, the equivalents are `journalctl --user -u switchroom-$SWITCHROOM_AGENT_NAME --since "2 hours ago"` and `systemctl --user show switchroom-$SWITCHROOM_AGENT_NAME -p NRestarts`.
-3. **Watchdog audit log** — under systemd, `journalctl --user -t switchroom-watchdog --since "2 hours ago"` (every watchdog action: `[restart] / [skip] / [detect] / [error]` with `agent=NAME reason=KIND threshold=Ns observed=Ns ...`). Under docker the watchdog is disabled (no NRestarts equivalent without the docker socket), so this source is silent — fall back to `clean-shutdown.json` plus the container logs above.
-
-Quote the reason field verbatim when answering — don't paraphrase. If `clean-shutdown.json` is older than the unit's current uptime, it's stale and the new boot wasn't a clean shutdown (likely OOM or panic) — say that explicitly. If all three sources are silent and uptime is fresh, the user might be looking at a "back up" card from a much older restart that's just scrolled into view; ask them to point at the specific card.
-
-**"status?" / "still there?" / "any update?" is a UX-failure signal, not a feature request.** The progress card and stream-reply pattern exist precisely so the user never has to ask. When you see one of those messages — short, low-content, asking whether you're alive — treat it as a defect signal: something about the in-flight turn made the user feel uncertain. The product expectation (per `reference/know-what-my-agent-is-doing.md`) is that this rate trends to zero.
-
-Your response in this case should:
-
-1. Answer the literal question — say what you're doing and where you are in it (one sentence).
-2. **Offer to file an RCA issue** — something like _"Want me to file this as an RCA so the progress surface gets fixed?"_ — and if the user says yes, invoke the bundled `/file-bug` skill which handles the log-pull + RCA structure + `gh issue create --label incident-rca`.
-
-Pre-emptively reach for `/file-bug` only when the user clearly indicates they want it filed. Don't auto-file from a single "status?" — that creates noise. The offer-then-confirm shape is the right friction.
-
-The companion telemetry already in place (`gateway.ts` logs every `status?` to stderr with chat_id + agent — see #109) lets the maintainer track the rate over time even when no RCA is filed. Your job is to make sure the user's *current* concern doesn't go unaddressed.
+**"status?" / "still there?" / "any update?" is a UX-failure signal**, not a feature request. The progress card and stream-reply pattern exist precisely so the user never has to ask. When you see one of those messages, answer the literal question in one sentence and invoke `/switchroom-runtime` for the offer-RCA flow (the skill walks the `/file-bug` integration).

--- a/profiles/default/workspace/SOUL.md.hbs
+++ b/profiles/default/workspace/SOUL.md.hbs
@@ -46,6 +46,7 @@ This is the canonical list of AI-tells to keep out of your replies. Apply to eve
 - Use em-dashes. Rewrite with commas, periods, or parentheses. (They are fine in source files like this one; not in replies.)
 - Use rule-of-three constructions ("X, Y, and Z" cadenced for rhythm rather than content) or "It's not just X, it's Y" negative parallelisms.
 - Add hedging filler: "it's important to note that", "as we can see", "based on available information", "in order to", "due to the fact that".
+- Bold every phrase for emphasis. Bold is for the one key fact in a reply, not for every interesting noun.
 - Pad with sycophantic preamble. Don't summarize what was just said back before answering.
 - Apologize for previous responses. Just give the better answer.
 

--- a/skills/switchroom-runtime/SKILL.md
+++ b/skills/switchroom-runtime/SKILL.md
@@ -1,0 +1,139 @@
+---
+name: switchroom-runtime
+description: |
+  Runtime operational protocols for switchroom Telegram agents — the conditional
+  procedures that only fire on specific boot signals or user phrases. Invoke when:
+  (1) the env var SWITCHROOM_PENDING_TURN=true is set on boot (interrupted-turn
+  resume protocol); (2) the sentinel file $TELEGRAM_STATE_DIR/.wake-audit-pending
+  exists (wake audit: check for owed replies, orphan sub-agents, stale todos
+  before answering); (3) the user asks why you restarted or what happened
+  ("why did you restart?", "did you crash?", "you went away") — surface the
+  audit trail from clean-shutdown.json + container/journal logs; (4) the user
+  asks how to stop you mid-turn ("how do I interrupt", "can I stop you",
+  "how do I cancel") and you need the implementation detail beyond the
+  one-line answer; (5) the user sends a short status check ("status?",
+  "still there?", "any update?") — treat as UX-failure signal, offer to file
+  RCA via /file-bug. Do NOT invoke for normal Telegram conversation,
+  formatting questions, voice/sticker/Telegraph behavior, MCP tool questions,
+  or persona / voice / Execution-Bias rules — those live in your always-loaded
+  CLAUDE.md.
+allowed-tools: Bash Read Grep
+---
+
+# Switchroom Runtime Protocols
+
+This skill holds the runtime protocols that fire on specific boot signals or user phrases. The always-loaded `CLAUDE.md` points at these sections; this is where the implementation detail lives. Each section is gated by a distinct trigger — jump to the one that fires.
+
+---
+
+## Resume protocol — interrupted turns
+
+**Trigger:** the env var `SWITCHROOM_PENDING_TURN=true` is set when your session boots. The previous gateway died mid-turn (SIGTERM, restart, or a crash that bypassed the SIGTERM handler) and the user's last message was likely never fully answered. The accompanying env vars tell you what was in flight:
+
+- `SWITCHROOM_PENDING_CHAT_ID` — the chat the interrupted turn belonged to
+- `SWITCHROOM_PENDING_THREAD_ID` — the forum topic id (empty if not a forum)
+- `SWITCHROOM_PENDING_USER_MSG_ID` — the inbound message_id that started the turn (you can quote-reply to it for context)
+- `SWITCHROOM_PENDING_ENDED_VIA` — `restart` (user ran `switchroom agent restart`), `sigterm` (systemd/manual kill), `timeout` (watchdog), or `unknown` (crash before stamp)
+- `SWITCHROOM_PENDING_STARTED_AT` — unix-ms when the turn started
+
+**Your first action on a `SWITCHROOM_PENDING_TURN=true` boot must be to acknowledge the gap and confirm direction.** Don't silently pick up where you left off. The user has no way to know whether you remember what you were doing. Use `reply` with `accent: 'issue'` to make it obvious. Quote-reply to `SWITCHROOM_PENDING_USER_MSG_ID` so the original message is in view. Sample wording (adapt to the situation):
+
+> ⚠️ Issue
+>
+> I was killed mid-turn. Looks like my previous shutdown was via `<endedVia>`. Don't have full context on what I'd already done. Want me to: (a) start over from your last message, (b) summarize what I think was in flight and continue, or (c) drop it and move on?
+
+The env vars are one-shot (start.sh deletes the file after sourcing), so this prompt only fires on the immediately-following session, not every restart afterward. If you genuinely don't remember anything useful about the prior turn (Hindsight didn't catch it, no handoff briefing landed), say so explicitly rather than guessing.
+
+If `SWITCHROOM_PENDING_TURN` is unset or empty, do nothing special: the previous turn ended cleanly.
+
+---
+
+## Wake audit — every fresh boot
+
+**Trigger:** the sentinel file `$TELEGRAM_STATE_DIR/.wake-audit-pending` exists. `start.sh` drops it on every process boot. On your first turn after a fresh boot, before answering whatever the user just sent, gate-check then run the audit. This complements the resume protocol above: `SWITCHROOM_PENDING_TURN` covers "killed mid-turn"; the wake audit covers "anything else owed since last seen."
+
+**Conversation-aware dedup.** start.sh re-writes the sentinel on every process boot, including `--continue` respawns triggered by watchdog/bridge restarts. To avoid re-firing an already-handled audit on the same conversation, gate by `$TELEGRAM_STATE_DIR/.wake-audit-last-completed`:
+
+```bash
+# Step 0: is an audit pending?
+[ -f "$TELEGRAM_STATE_DIR/.wake-audit-pending" ] || exit 0
+
+# Step 1: have we already audited since the most recent user message?
+# If `.wake-audit-last-completed` is newer than the latest inbound user
+# message in any active topic, the audit was handled by a prior boot in
+# this conversation. Clear the sentinel and skip.
+#   - Compare the marker mtime to the max user-message ts from
+#     `mcp__switchroom-telegram__get_recent_messages` across the topics
+#     you might owe a reply in.
+#   - If marker_mtime >= latest_user_msg_ts: rm -f the sentinel, exit.
+```
+
+If you proceed past the gate, run all three checks:
+
+1. **Owed replies** (the most common "you forgot me" failure). Use `mcp__switchroom-telegram__get_recent_messages` for each topic the user contacts you in. If the most recent message in the topic is from the user (role=`user`) AND your most recent assistant turn is older than that, you owe a reply. Quote-reply to the user message with `accent: 'issue'` and acknowledge: _"I see your message from <relative-time> ago that I never answered (restart in between). Want me to handle it now?"_
+
+2. **Orphan sub-agents** (jobs the watchdog killed mid-flight). Run:
+   ```bash
+   find "$CLAUDE_CONFIG_DIR/projects" -path '*/subagents/*.jsonl' -mmin -1440 -print 2>/dev/null
+   ```
+   For each, check the LAST line. If it's not a terminal record (`type:result` / `type:final` / `subtype:end`), the sub-agent was killed before completing. Tell the user what was being attempted (read the first user-message record from the file for context) and ask whether to retry: _"My `<task-summary>` sub-agent was killed at <ts> by a restart. Want me to redispatch?"_
+
+3. **Open todos** (in-process work that never finished). Scan recent task state:
+   ```bash
+   find "$CLAUDE_CONFIG_DIR/tasks" -name '*.json' -mmin -1440 -print 2>/dev/null
+   ```
+   If any have items with `status: in_progress` whose mtime predates your session start, those are stale. Only mention them if relevant to the conversation. Don't recite the whole list.
+
+**Idempotency**: after the audit (whether anything was found or not), stamp the dedup marker AND clear the sentinel:
+
+```bash
+touch "$TELEGRAM_STATE_DIR/.wake-audit-last-completed"
+rm -f "$TELEGRAM_STATE_DIR/.wake-audit-pending"
+```
+
+The marker's mtime defines "audit complete for this conversation up to now". A future `--continue` respawn that finds the marker newer than the latest user message will skip the audit. The sentinel's absence means "audit complete for this process boot."
+
+**Don't be noisy**: if all three checks come back clean, say nothing about the audit. Just answer whatever the user asked. The audit is a guardrail against silent dropped work, not a status broadcast. The "I owed you a reply" surface should fire less than once a week on a healthy system.
+
+---
+
+## "Why did you restart?" — read the audit trail
+
+**Trigger:** the user asks something like "why did you restart?", "did you crash?", "you went away", "what happened earlier". The `SWITCHROOM_PENDING_*` env vars are one-shot (cleared by start.sh on first read), so by the time a user asks this, they're long gone. Don't answer from memory, don't say "no restart on my end". Three durable on-disk sources have the actual reason. Check them in order:
+
+1. **`$TELEGRAM_STATE_DIR/clean-shutdown.json`** — single-line JSON `{ts, signal, reason}` written before EVERY restart by whoever initiated it (CLI, gateway SIGTERM handler, watchdog). Fastest answer for "what was THIS boot's reason." Example: `cat "$TELEGRAM_STATE_DIR/clean-shutdown.json"` → `{"ts":1777677708190,"signal":"SIGTERM","reason":"watchdog: bridge disconnected for 612s"}`.
+
+2. **Container/unit history.** Under v0.7 docker mode (default), check `docker logs --since 2h switchroom-$SWITCHROOM_AGENT_NAME` for the container's recent stderr (boot card timestamps, SIGTERM reasons, panics) and `docker inspect switchroom-$SWITCHROOM_AGENT_NAME` for the full state JSON (look at `.State.StartedAt` for the last start time and `.State.RestartCount` for cumulative restarts). Under legacy systemd installs, the equivalents are `journalctl --user -u switchroom-$SWITCHROOM_AGENT_NAME --since "2 hours ago"` and `systemctl --user show switchroom-$SWITCHROOM_AGENT_NAME -p NRestarts`.
+
+3. **Watchdog audit log.** Under systemd, `journalctl --user -t switchroom-watchdog --since "2 hours ago"` (every watchdog action: `[restart] / [skip] / [detect] / [error]` with `agent=NAME reason=KIND threshold=Ns observed=Ns ...`). Under docker the watchdog is disabled (no NRestarts equivalent without the docker socket), so this source is silent. Fall back to `clean-shutdown.json` plus the container logs above.
+
+Quote the `reason` field verbatim when answering. Don't paraphrase. If `clean-shutdown.json` is older than the unit's current uptime, it's stale and the new boot wasn't a clean shutdown (likely OOM or panic). Say that explicitly. If all three sources are silent and uptime is fresh, the user might be looking at a "back up" card from a much older restart that's just scrolled into view; ask them to point at the specific card.
+
+---
+
+## `!` interrupt marker — implementation detail
+
+**Trigger:** the user asks how to stop you mid-turn AND you want to give more than the one-liner answer (which lives in your always-loaded prompt). The one-liner answer is: *"Start your message with `!` — it interrupts whatever I'm doing and treats the rest as a fresh request."*
+
+Implementation detail:
+
+The gateway treats a Telegram message starting with `!` (single bang, not `!!` or `!!!`) as a deliberate interrupt: SIGINT to the active turn, strip the `!`, deliver the rest as a fresh turn. Under tmux-default, the SIGINT is delivered via `tmux send-keys C-c` to whatever has focus in the agent's pane (typically the claude REPL, but if claude has spawned a child Bash for a tool call, the child gets the C-c, which usually matches operator intent). A cgroup-wide kill fallback (legacy systemd: `systemctl kill --signal=INT`) fires only if send-keys fails.
+
+If the user sends `! actually never mind, do X instead`, you'll boot up and see `actually never mind, do X instead` with no record of what you were doing before. That's intentional.
+
+Doubled `!!` (typo / emphasis) reaches you verbatim. Empty `!` gets a "Send your replacement instruction now" reply from the gateway and never reaches you. The interrupt wakes a fresh `SWITCHROOM_PENDING_TURN` cycle, so the resume protocol above will fire on the next turn. Keep that pairing in mind when acknowledging.
+
+---
+
+## "status?" / "still there?" — UX-failure signal
+
+**Trigger:** the user sends a short, low-content message asking whether you're alive — "status?", "still there?", "any update?", "you working?". The progress card and stream-reply pattern exist precisely so the user never has to ask. When you see one of those messages, treat it as a defect signal: something about the in-flight turn made the user feel uncertain. The product expectation (per `reference/know-what-my-agent-is-doing.md`) is that this rate trends to zero.
+
+Your response should:
+
+1. Answer the literal question: say what you're doing and where you are in it (one sentence).
+2. **Offer to file an RCA issue.** Something like _"Want me to file this as an RCA so the progress surface gets fixed?"_ If the user says yes, invoke the bundled `/file-bug` skill which handles the log-pull + RCA structure + `gh issue create --label incident-rca`.
+
+Pre-emptively reach for `/file-bug` only when the user clearly indicates they want it filed. Don't auto-file from a single "status?". That creates noise. The offer-then-confirm shape is the right friction.
+
+The companion telemetry already in place (`gateway.ts` logs every `status?` to stderr with chat_id + agent, see #109) lets the maintainer track the rate over time even when no RCA is filed. Your job is to make sure the user's *current* concern doesn't go unaddressed.

--- a/src/agents/reconcile-default-skills.test.ts
+++ b/src/agents/reconcile-default-skills.test.ts
@@ -284,6 +284,7 @@ describe("getBuiltinDefaultSkillEntries", () => {
       "skill-creator",
       "switchroom-cli",
       "switchroom-health",
+      "switchroom-runtime",
       "switchroom-status",
       "webapp-testing",
       "xlsx",
@@ -297,6 +298,7 @@ describe("getBuiltinDefaultSkillEntries", () => {
     expect(switchroomEntries.sort()).toEqual([
       "switchroom-cli",
       "switchroom-health",
+      "switchroom-runtime",
       "switchroom-status",
     ]);
   });

--- a/src/memory/scaffold-integration.ts
+++ b/src/memory/scaffold-integration.ts
@@ -187,6 +187,7 @@ export function getBuiltinDefaultSkillEntries(): BuiltinSkillEntry[] {
     "switchroom-cli",
     "switchroom-status",
     "switchroom-health",
+    "switchroom-runtime",
   ] as const;
   return [
     ...anthropic.map((key) => ({ key, optOutKey: key, source: "anthropic" as const })),

--- a/tests/scaffold.persona.test.ts
+++ b/tests/scaffold.persona.test.ts
@@ -124,16 +124,17 @@ describe("scaffoldAgent — persona (Phase 2)", () => {
     // work from inside a sandbox — RCA: gymbro silently fell back to
     // estimates on VAULT-BROKER-DENIED instead of requesting a grant).
     // Raised again 32000 → 33000 for PR1 of the voice/architecture
-    // cleanup (#TBD): unified AI-tells ban-list into SOUL.md "Never"
-    // and added a procedural "Execution Bias" section to CLAUDE.md
-    // (verify mutable facts, final answer needs evidence, weak tool
-    // result is not a conclusion). Net add ~700 chars. PR2 of the
-    // same cleanup will hoist ~1.8KB of operational protocol (resume,
-    // wake-audit, ! interrupt, restart diagnostics) out of
-    // telegram-style.md.hbs into a runtime skill; the cap should
-    // drop back below 32000 after that lands.
+    // cleanup (#1177): unified AI-tells ban-list into SOUL.md "Never"
+    // and added a procedural "Execution Bias" section to CLAUDE.md.
+    // LOWERED 33000 → 28000 in PR2 of the same cleanup (#TBD):
+    // hoisted resume protocol, wake audit, "why did you restart" debug
+    // commands, `!` interrupt implementation detail, and "status?"
+    // UX-failure signal procedures out of telegram-style.md.hbs into
+    // a new bundled `switchroom-runtime` skill. Always-loaded prompt
+    // now points at the skill via short triggers; procedural detail
+    // loads on demand. ~5KB removed from every-turn context.
     // Each block is load-bearing. Future bumps should justify themselves
     // similarly.
-    expect(claudeMd.length).toBeLessThan(33000); // generous cap; target is lean but not 3KB
+    expect(claudeMd.length).toBeLessThan(28000); // tightened post-hoist; target is lean but not 3KB
   });
 });


### PR DESCRIPTION
## Summary

PR2 of the voice/architecture cleanup. PR1 (#1177) consolidated the voice rules into SOUL.md and added Execution Bias to CLAUDE.md, with a +700 char net cost. PR2 redeems that cost and more: hoists ~84 lines (~5KB) of runtime operational protocol out of the always-loaded `profiles/_shared/telegram-style.md.hbs` into a new bundled skill, `switchroom-runtime`. Net impact across both PRs: ~-4300 chars per turn vs pre-cleanup baseline, and the voice rules now live at the prompt position they deserve.

## The hoist

Five sections moved from the always-loaded prompt into the on-demand skill:

| Section | Old size | Trigger |
|---|---|---|
| Resume protocol (interrupted turns) | ~1,100 chars | `SWITCHROOM_PENDING_TURN=true` env on boot |
| Wake audit (owed replies / orphan sub-agents / stale todos) | ~2,400 chars | `$TELEGRAM_STATE_DIR/.wake-audit-pending` sentinel |
| "Why did you restart?" debug commands | ~1,400 chars | User asks about restart / crash / absence |
| `!` interrupt implementation detail | ~900 chars | User asks how to stop the agent (one-liner stays inline) |
| "status?" UX-failure signal procedure | ~900 chars | User sends short status check |

The always-loaded prompt now keeps a 1-3 sentence pointer for each, plus the trigger condition that should make the model invoke the skill.

## Why this layering works

- **Behavioral content stays inline** — pacing, formatting, Telegraph long-reply, voice transcripts, sticker/GIF rules, the "Sound human" pointer to SOUL. These apply on every turn.
- **Procedural recipes move to the skill** — bash snippets, env-var lists, sample wording, audit-trail commands. These fire conditionally and don't deserve every-turn prompt budget.
- **Triggers stay inline** — so the model knows *when* to invoke the skill without needing to read it first.

## Skill auto-loading

`switchroom-runtime` is added to `switchroomCore` in `src/memory/scaffold-integration.ts:186-190`, so the existing `reconcileAgentDefaultSkills` path auto-symlinks it into every agent's `.claude/skills/`. No per-agent config required. Operators can opt out via `bundled_skills: { switchroom-runtime: false }` if they want to (consistent with the other defaults).

## Files

```
profiles/_shared/telegram-style.md.hbs      | 84 ++---------------------------
profiles/default/workspace/SOUL.md.hbs      |  1 +
skills/switchroom-runtime/SKILL.md          | +139 (new)
src/agents/reconcile-default-skills.test.ts |  2 +
src/memory/scaffold-integration.ts          |  1 +
tests/scaffold.persona.test.ts              | 19 +++----
```

The SOUL.md +1 line addresses PR1 reviewer's nit: the old telegram-style paragraph banned "excessive bolding for emphasis" and the rule wasn't carried into the new SOUL "Never". Now is.

## Size-cap forcing function

`tests/scaffold.persona.test.ts` cap lowered 33000 → **28000** with an updated changelog comment. PR1 raised the cap, PR2 drops it well below the pre-PR1 baseline. The cap is the forcing function the PR1 reviewer asked for, and it pinned PR2 to actually land.

## Test plan

- [x] `npx vitest run src/agents/reconcile-default-skills tests/scaffold` — 217/217 pass
- [x] `npm run lint` — clean (`tsc --noEmit`)
- [ ] Smoke test in dev agent post-merge: trigger a fresh boot with `.wake-audit-pending`, verify the model invokes `/switchroom-runtime` rather than treating the absent inline procedure as "no audit needed"
- [ ] Smoke test: ask "why did you restart?" and verify the model invokes the skill rather than fabricating from memory

🤖 Generated with [Claude Code](https://claude.com/claude-code)