### PR TITLE
chore: release v0.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## v0.8.1 — SOUL.md fingerprint re-render (v0.8.0 follow-up)
+
+Single fix. The v0.8.0 voice consolidation (PR #1177) moved the canonical AI-tells ban-list into `SOUL.md` "Never", but `seedWorkspaceBootstrapFiles` was seeding workspace bootstrap files via `writeIfMissing`. Once an agent had a `SOUL.md`, the template was frozen forever — same failure shape as #1122 was for `CLAUDE.md` before that fix.
+
+Result during the v0.8.0 rollout: the new "Never" rules didn't reach any existing agent. Operators had to `rm SOUL.md && switchroom apply` per agent to refresh.
+
+### Fix (#1181)
+
+`SOUL.md` now uses `rerenderWithFingerprint` — the same function `CLAUDE.md` has used since #1122. Other workspace files (`IDENTITY.md`, `TOOLS.md`, `MEMORY.md`, `HEARTBEAT.md`, `USER.md`) keep `writeIfMissing` because they're user-owned scratchpads the agent edits at runtime.
+
+`SOUL.custom.md` sidecar handling is preserved: operator additions are composed into the rendered output, and the sidecar file itself stays `writeIfMissing` so it survives re-renders untouched.
+
+Operator hand-edits to `SOUL.md` itself are backed up to `SOUL.md.before-rerender.<unix-ms>` then the file is rewritten from the new template. Legacy state (file exists, no fingerprint sidecar) migrates cleanly on the next apply — content unchanged, fingerprint installed.
+
+New regression test at `tests/scaffold.rerender-soul-md.test.ts` mirrors `scaffold.rerender-claude-md.test.ts`: first-scaffold-writes-fingerprint, no-op-on-unchanged-template, drift-without-edits, hand-edit-plus-drift, legacy-state-migration, sidecar-survives-rerender.
+
+### npm note
+
+v0.8.0 was briefly unpublished from npm during a force-republish attempt before the SOUL fix was ready. npm policy blocks same-version republish for 24h after unpublish, so v0.8.0 stays unpublished on npm. v0.8.1 carries the same content as v0.8.0 + the fix and is the version to install. GitHub `v0.8.0` tag + GHCR `:v0.8.0` images already point at the SOUL fix commit and remain available.
+
 ## v0.8.0 — voice/architecture cleanup + host-control daemon + vault posture toggle
 
 Big release. ~35 PRs since v0.7.16. Three headline themes:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "switchroom",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Run Claude Code 24/7 on your Claude Pro/Max subscription over Telegram. Open-source alternative to OpenClaw and NanoClaw — no API keys.",
   "type": "module",
   "bin": {

--- a/src/build-info.ts
+++ b/src/build-info.ts
@@ -2,8 +2,8 @@
 // Tracked in git so `tsc --noEmit` works on a fresh clone before `npm run build`.
 // Values are refreshed every time `npm run build` runs.
 
-export const VERSION: string = "0.8.0";
-export const COMMIT_SHA: string | null = "b325deb";
-export const COMMIT_DATE: string | null = "2026-05-13T04:28:33+00:00";
-export const LATEST_PR: number | null = null;
-export const COMMITS_AHEAD_OF_TAG: number | null = 12;
+export const VERSION: string = "0.8.1";
+export const COMMIT_SHA: string | null = "b1bd31aa";
+export const COMMIT_DATE: string | null = "2026-05-13T13:03:36+10:00";
+export const LATEST_PR: number | null = 1181;
+export const COMMITS_AHEAD_OF_TAG: number | null = 0;

--- a/src/build-info.ts
+++ b/src/build-info.ts
@@ -3,7 +3,7 @@
 // Values are refreshed every time `npm run build` runs.
 
 export const VERSION: string = "0.8.1";
-export const COMMIT_SHA: string | null = "b1bd31aa";
-export const COMMIT_DATE: string | null = "2026-05-13T13:03:36+10:00";
-export const LATEST_PR: number | null = 1181;
-export const COMMITS_AHEAD_OF_TAG: number | null = 0;
+export const COMMIT_SHA: string | null = "87f4a8fb";
+export const COMMIT_DATE: string | null = "2026-05-13T14:40:44+10:00";
+export const LATEST_PR: number | null = null;
+export const COMMITS_AHEAD_OF_TAG: number | null = 3;


### PR DESCRIPTION
## Summary

Single-fix follow-up to v0.8.0: SOUL.md uses fingerprint-aware re-render (#1181) so template changes propagate to existing agents. Without this fix, the v0.8.0 voice consolidation silently bypassed every running agent (same failure shape as #1122 was for CLAUDE.md before that fix).

## Why v0.8.1 and not a re-publish of v0.8.0

v0.8.0 was briefly unpublished from npm during a force-republish attempt before the SOUL fix was ready. npm's 24-hour rule blocks same-version re-publish after an unpublish. v0.8.1 carries the same content as v0.8.0 + the SOUL fingerprint fix and is the version to install from npm going forward. The GitHub `v0.8.0` tag and GHCR `:v0.8.0` images already point at the SOUL fix commit (`b1bd31aa`, #1181) and remain available for those who pin by tag.

## Test plan

- [x] `npx vitest run tests/scaffold tests/scaffold.rerender-soul-md src/agents/profiles.test.ts` — 233/233 pass on the merged base
- [x] `npm run lint` — clean
- [ ] Tag push fires `docker-images.yml` → `ghcr.io/switchroom/switchroom-{base,agent,broker,kernel}:v0.8.1` and `:latest` updated
- [ ] `npm publish` v0.8.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)