### PR TITLE
test(vitest): clear switchroom container env at process root

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,5 +1,30 @@
 import { defineConfig } from "vitest/config";
 
+// Tests must produce identical results inside an agent container and on
+// the host. `src/agents/compose.ts` injects several env vars into every
+// agent container (SWITCHROOM_RUNTIME=docker, SWITCHROOM_CONTAINER=1,
+// SWITCHROOM_AGENT_NAME, broker/kernel socket paths) so `npm test`
+// invoked inside an agent inherits them. Runtime-aware code (e.g.
+// `defaultBrokerSocketPath` in src/vault/broker/client.ts, the
+// `isContainerContext()` probe in agent-config) then takes the
+// in-container branch and tests that expect default behavior fail —
+// resolve-socket-path.test.ts:77 wants the legacy fallback, but the
+// docker branch returns the operator path. Clear at the vitest process
+// root so both forked test workers and any spawnSync children they
+// launch see a clean baseline. Operators running `npm test` on a host
+// with these set legitimately for production tools won't notice — the
+// host's actual processes read the env independently from their own
+// systemd / shell context.
+for (const k of [
+  "SWITCHROOM_RUNTIME",
+  "SWITCHROOM_CONTAINER",
+  "SWITCHROOM_AGENT_NAME",
+  "SWITCHROOM_VAULT_BROKER_SOCK",
+  "SWITCHROOM_KERNEL_SOCKET",
+]) {
+  delete process.env[k];
+}
+
 // Buildkite Test Engine: only attach the collector reporter when the
 // analytics token is present. Locally (and in CI jobs without the token)
 // we fall back to vitest's default reporter so `npm test` stays quiet


### PR DESCRIPTION
## Background

Discovered while investigating the klanker Bash-wedge issue (host-agent RCA brief, symptom B). The brief reported \`resolve-socket-path.test.ts:77\` getting \`broker-operator/sock\` instead of \`vault-broker.sock\` when run inside an agent container, hypothesized as an operator-side env leak. Direct investigation showed it isn't a leak from outside — the agent container's own env is reaching the test child via standard \`process.env\` inheritance.

## Root cause

\`src/agents/compose.ts\` legitimately injects these into every agent container env:
- \`SWITCHROOM_RUNTIME=docker\`
- \`SWITCHROOM_CONTAINER=1\`
- \`SWITCHROOM_AGENT_NAME\`
- \`SWITCHROOM_VAULT_BROKER_SOCK=/run/switchroom/broker/sock\`
- \`SWITCHROOM_KERNEL_SOCKET=/run/switchroom/kernel/sock\`

\`npm test\` inside the agent inherits them. Runtime-aware code then takes the in-container branch:

- \`defaultBrokerSocketPath()\` (src/vault/broker/client.ts:77) returns the operator path under docker mode, legacy under systemd. \`resolve-socket-path.test.ts:77\` expects legacy → fails.
- \`tests/install/static-binary.test.ts:78\` spawns the compiled binary with \`apply --example switchroom\`; under docker mode the apply takes a different branch and skips writing the example file → \`existsSync(dest)\` returns false at line 93.

## Fix

Clear the five vars at the vitest entrypoint, before \`defineConfig\` builds the pool. Vitest forks inherit the cleared env, their \`spawnSync\` children too.

Host operators running \`npm test\` with these set legitimately for production tools aren't impacted — host processes read env from their own systemd / shell context, not from the vitest test runner.

## Verification

```bash
# Reproduce the in-container env, run the two affected tests:
SWITCHROOM_RUNTIME=docker SWITCHROOM_VAULT_BROKER_SOCK=/run/switchroom/broker/sock \\
  npx vitest run src/vault/broker/resolve-socket-path tests/install
```

Before this PR: 0/7 pass. After: 7/7 pass.

## Test plan

- [x] Both target tests pass with simulated in-container env
- [x] Both target tests still pass with no env set (host case)
- [ ] Full \`npm test\` smoke after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)