### PR TITLE
feat(#1163): overlay loader — schedule.d/skills.d storage backend

### DIFF
--- a/src/agents/compose.ts
+++ b/src/agents/compose.ts
@@ -1236,6 +1236,15 @@ function emitAgentService(
   try {
     mkdirSync(`${hostHomeForChecks}/.switchroom/audit/${a.name}`, { recursive: true });
   } catch { /* best-effort */ }
+  // Phase B (switchroom #1163): pre-create the per-agent overlay
+  // directory so the agent-config write tools (Phase C) have a writable
+  // landing zone. The whole ~/.switchroom/agents/<name>/ tree is already
+  // bind-mounted rw at lines above (the dual-mount), so no separate
+  // volume entry is needed — just the host-side dir, owned by the
+  // operator umask before docker auto-creates it as root.
+  try {
+    mkdirSync(`${hostHomeForChecks}/.switchroom/agents/${a.name}/schedule.d`, { recursive: true });
+  } catch { /* best-effort */ }
   // Agent-config audit log (rw) — the read-only agent-config MCP broker
   // (src/mcp/agent-config/server.ts) appends one JSONL row per tool call
   // to ~/.switchroom/audit/<agent>/agent-config.jsonl. PER-AGENT mount:

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -5,6 +5,7 @@ import { parse as parseYaml } from "yaml";
 import { ZodError } from "zod";
 import { SwitchroomConfigSchema, type SwitchroomConfig } from "./schema.js";
 import { resolveDualPath } from "./paths.js";
+import { applyAgentOverlays } from "./overlay-loader.js";
 
 export class ConfigError extends Error {
   constructor(
@@ -101,14 +102,22 @@ export function loadConfig(configPath?: string): SwitchroomConfig {
     delete obj.clerk;
   }
 
+  let config: SwitchroomConfig;
   try {
-    return SwitchroomConfigSchema.parse(parsed);
+    config = SwitchroomConfigSchema.parse(parsed);
   } catch (err) {
     if (err instanceof ZodError) {
       throw new ConfigError("Invalid switchroom.yaml configuration", formatZodErrors(err));
     }
     throw err;
   }
+
+  // Phase B (switchroom #1163): merge per-agent overlay YAML from
+  // ~/.switchroom/agents/<name>/schedule.d/*.yaml. Overlay failures are
+  // per-file isolated and surfaced as warnings — they never fail the load.
+  applyAgentOverlays(config);
+
+  return config;
 }
 
 export function resolveAgentsDir(config: SwitchroomConfig): string {

--- a/src/config/overlay-loader.test.ts
+++ b/src/config/overlay-loader.test.ts
@@ -1,0 +1,252 @@
+/**
+ * Tests for applyAgentOverlays (switchroom #1163, Phase B).
+ *
+ * Covers:
+ *   - no overlay dir is a no-op (no warnings, schedule unchanged)
+ *   - overlay schedule entries are appended (precedence: main entries first,
+ *     overlay entries after)
+ *   - multiple overlay files load in sorted (deterministic) order
+ *   - non-yaml files in the dir are ignored
+ *   - malformed YAML produces a per-file warning and never throws
+ *   - schema rejection (unknown top-level key, bad entry) is per-file isolated
+ *   - secrets-bearing entries are dropped with a warning
+ *   - per-agent isolation: agent X's broken overlay does not prevent
+ *     agent Y from loading cleanly
+ *   - overlay-sourced entries are stamped with the OVERLAY_SOURCE symbol
+ *     (non-enumerable so JSON.stringify ignores them)
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { applyAgentOverlays, OVERLAY_SOURCE } from "./overlay-loader.js";
+import type { SwitchroomConfig } from "./schema.js";
+
+/**
+ * Build a minimal SwitchroomConfig with the given agents. We bypass the full
+ * SwitchroomConfigSchema here — the overlay loader only touches
+ * `switchroom.agents.<name>.schedule`, so we construct just enough shape to
+ * exercise it. Cast through `unknown` to keep TS quiet about the partial
+ * shape.
+ */
+function makeConfig(
+  agents: Record<string, { schedule?: unknown[] }>,
+): SwitchroomConfig {
+  return {
+    switchroom: {
+      agents: agents as Record<string, never>,
+    },
+  } as unknown as SwitchroomConfig;
+}
+
+describe("applyAgentOverlays", () => {
+  let tmpHome: string;
+  let prevHome: string | undefined;
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    tmpHome = mkdtempSync(join(tmpdir(), "overlay-loader-test-"));
+    prevHome = process.env.HOME;
+    process.env.HOME = tmpHome;
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    if (prevHome === undefined) delete process.env.HOME;
+    else process.env.HOME = prevHome;
+    warnSpy.mockRestore();
+    try {
+      rmSync(tmpHome, { recursive: true, force: true });
+    } catch { /* best-effort */ }
+  });
+
+  function overlayDir(agentName: string): string {
+    const dir = join(tmpHome, ".switchroom", "agents", agentName, "schedule.d");
+    mkdirSync(dir, { recursive: true });
+    return dir;
+  }
+
+  it("is a no-op when no overlay directory exists", () => {
+    const cfg = makeConfig({
+      foo: { schedule: [{ cron: "0 * * * *", prompt: "main", secrets: [] }] },
+    });
+    const { warnings } = applyAgentOverlays(cfg);
+    expect(warnings).toEqual([]);
+    expect(cfg.switchroom.agents.foo.schedule).toHaveLength(1);
+  });
+
+  it("is a no-op when the overlay directory exists but is empty", () => {
+    overlayDir("foo");
+    const cfg = makeConfig({ foo: { schedule: [] } });
+    const { warnings } = applyAgentOverlays(cfg);
+    expect(warnings).toEqual([]);
+    expect(cfg.switchroom.agents.foo.schedule).toEqual([]);
+  });
+
+  it("appends overlay schedule entries AFTER main-config entries (precedence)", () => {
+    const dir = overlayDir("foo");
+    writeFileSync(
+      join(dir, "a.yaml"),
+      "schedule:\n  - cron: '0 1 * * *'\n    prompt: overlay-entry\n",
+    );
+    const cfg = makeConfig({
+      foo: { schedule: [{ cron: "0 0 * * *", prompt: "main-entry", secrets: [] }] },
+    });
+    const { warnings } = applyAgentOverlays(cfg);
+    expect(warnings).toEqual([]);
+    const sched = cfg.switchroom.agents.foo.schedule as Array<{ prompt: string }>;
+    expect(sched).toHaveLength(2);
+    expect(sched[0].prompt).toBe("main-entry");
+    expect(sched[1].prompt).toBe("overlay-entry");
+  });
+
+  it("loads multiple overlay files in sorted order (deterministic)", () => {
+    const dir = overlayDir("foo");
+    // Write out-of-order; loader sorts by filename.
+    writeFileSync(join(dir, "z-second.yaml"), "schedule:\n  - cron: '0 2 * * *'\n    prompt: second\n");
+    writeFileSync(join(dir, "a-first.yaml"), "schedule:\n  - cron: '0 1 * * *'\n    prompt: first\n");
+    const cfg = makeConfig({ foo: { schedule: [] } });
+    applyAgentOverlays(cfg);
+    const sched = cfg.switchroom.agents.foo.schedule as Array<{ prompt: string }>;
+    expect(sched.map((e) => e.prompt)).toEqual(["first", "second"]);
+  });
+
+  it("ignores non-yaml files in the overlay dir", () => {
+    const dir = overlayDir("foo");
+    writeFileSync(join(dir, "notes.txt"), "not yaml");
+    writeFileSync(join(dir, "README.md"), "# nope");
+    writeFileSync(join(dir, "real.yaml"), "schedule:\n  - cron: '0 1 * * *'\n    prompt: ok\n");
+    const cfg = makeConfig({ foo: { schedule: [] } });
+    const { warnings } = applyAgentOverlays(cfg);
+    expect(warnings).toEqual([]);
+    expect(cfg.switchroom.agents.foo.schedule).toHaveLength(1);
+  });
+
+  it("accepts both .yaml and .yml extensions", () => {
+    const dir = overlayDir("foo");
+    writeFileSync(join(dir, "a.yml"), "schedule:\n  - cron: '0 1 * * *'\n    prompt: from-yml\n");
+    const cfg = makeConfig({ foo: { schedule: [] } });
+    applyAgentOverlays(cfg);
+    expect(cfg.switchroom.agents.foo.schedule).toHaveLength(1);
+  });
+
+  it("emits a warning and isolates the file when YAML is malformed", () => {
+    const dir = overlayDir("foo");
+    writeFileSync(join(dir, "broken.yaml"), "schedule: [unterminated\n");
+    writeFileSync(join(dir, "good.yaml"), "schedule:\n  - cron: '0 1 * * *'\n    prompt: good\n");
+    const cfg = makeConfig({ foo: { schedule: [] } });
+    const { warnings } = applyAgentOverlays(cfg);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0].file).toMatch(/broken\.yaml$/);
+    expect(warnings[0].reason).toMatch(/parse error|schema/i);
+    // Good file still loaded.
+    expect(cfg.switchroom.agents.foo.schedule).toHaveLength(1);
+    expect(warnSpy).toHaveBeenCalled();
+  });
+
+  it("emits a warning when an overlay declares an unknown top-level key", () => {
+    const dir = overlayDir("foo");
+    writeFileSync(
+      join(dir, "typo.yaml"),
+      "schedule: []\nagents:\n  evil: {}\n",
+    );
+    const cfg = makeConfig({ foo: { schedule: [] } });
+    const { warnings } = applyAgentOverlays(cfg);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0].reason).toMatch(/schema rejection/);
+  });
+
+  it("emits a warning when a schedule entry is missing required fields", () => {
+    const dir = overlayDir("foo");
+    writeFileSync(
+      join(dir, "bad-entry.yaml"),
+      "schedule:\n  - cron: '0 1 * * *'\n", // missing prompt
+    );
+    const cfg = makeConfig({ foo: { schedule: [] } });
+    const { warnings } = applyAgentOverlays(cfg);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0].reason).toMatch(/schema rejection/);
+    expect(cfg.switchroom.agents.foo.schedule).toEqual([]);
+  });
+
+  it("drops overlay entries that declare secrets, with a warning", () => {
+    const dir = overlayDir("foo");
+    writeFileSync(
+      join(dir, "with-secrets.yaml"),
+      "schedule:\n" +
+        "  - cron: '0 1 * * *'\n" +
+        "    prompt: needs-secret\n" +
+        "    secrets:\n" +
+        "      - api/key\n" +
+        "  - cron: '0 2 * * *'\n" +
+        "    prompt: clean-entry\n",
+    );
+    const cfg = makeConfig({ foo: { schedule: [] } });
+    const { warnings } = applyAgentOverlays(cfg);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0].reason).toMatch(/secrets/);
+    const sched = cfg.switchroom.agents.foo.schedule as Array<{ prompt: string }>;
+    expect(sched).toHaveLength(1);
+    expect(sched[0].prompt).toBe("clean-entry");
+  });
+
+  it("isolates failures per agent (broken X does not block clean Y)", () => {
+    const dirX = overlayDir("agent-x");
+    writeFileSync(join(dirX, "bad.yaml"), "schedule: [unterminated\n");
+    const dirY = overlayDir("agent-y");
+    writeFileSync(join(dirY, "ok.yaml"), "schedule:\n  - cron: '0 1 * * *'\n    prompt: y-ok\n");
+    const cfg = makeConfig({
+      "agent-x": { schedule: [] },
+      "agent-y": { schedule: [] },
+    });
+    const { warnings } = applyAgentOverlays(cfg);
+    expect(warnings.some((w) => w.agent === "agent-x")).toBe(true);
+    expect(cfg.switchroom.agents["agent-y"].schedule).toHaveLength(1);
+  });
+
+  it("handles agents with no schedule (treats undefined as empty)", () => {
+    const dir = overlayDir("foo");
+    writeFileSync(join(dir, "a.yaml"), "schedule:\n  - cron: '0 1 * * *'\n    prompt: only\n");
+    const cfg = makeConfig({ foo: {} });
+    applyAgentOverlays(cfg);
+    expect(cfg.switchroom.agents.foo.schedule).toHaveLength(1);
+  });
+
+  it("stamps overlay-sourced entries with the OVERLAY_SOURCE symbol (non-enumerable)", () => {
+    const dir = overlayDir("foo");
+    writeFileSync(join(dir, "a.yaml"), "schedule:\n  - cron: '0 1 * * *'\n    prompt: marked\n");
+    const cfg = makeConfig({
+      foo: { schedule: [{ cron: "0 0 * * *", prompt: "main", secrets: [] }] },
+    });
+    applyAgentOverlays(cfg);
+    const sched = cfg.switchroom.agents.foo.schedule as Array<Record<symbol, unknown>>;
+    // Main entry not stamped.
+    expect(sched[0][OVERLAY_SOURCE]).toBeUndefined();
+    // Overlay entry stamped.
+    expect(sched[1][OVERLAY_SOURCE]).toBe(true);
+    // Marker is non-enumerable: JSON.stringify must not surface it.
+    const json = JSON.stringify(sched[1]);
+    expect(json).not.toMatch(/overlay-source/i);
+  });
+
+  it("accepts an empty overlay document (no schedule key)", () => {
+    const dir = overlayDir("foo");
+    writeFileSync(join(dir, "empty.yaml"), "{}\n");
+    const cfg = makeConfig({ foo: { schedule: [] } });
+    const { warnings } = applyAgentOverlays(cfg);
+    expect(warnings).toEqual([]);
+    expect(cfg.switchroom.agents.foo.schedule).toEqual([]);
+  });
+
+  it("returns the config object it was given (mutates in place)", () => {
+    const cfg = makeConfig({ foo: { schedule: [] } });
+    const { config } = applyAgentOverlays(cfg);
+    expect(config).toBe(cfg);
+  });
+
+  it("handles a config with no agents at all", () => {
+    const cfg = makeConfig({});
+    const { warnings } = applyAgentOverlays(cfg);
+    expect(warnings).toEqual([]);
+  });
+});

--- a/src/config/overlay-loader.ts
+++ b/src/config/overlay-loader.ts
@@ -1,0 +1,182 @@
+/**
+ * Per-agent overlay loader (switchroom #1163, Phase B).
+ *
+ * After the main `switchroom.yaml` resolves, each agent may have a
+ * `~/.switchroom/agents/<name>/schedule.d/` directory containing one or more
+ * `*.yaml` overlay fragments. Each fragment is a standalone YAML document
+ * conforming to `OverlayDocSchema` (see `./overlay-schema.ts`).
+ *
+ * Merge semantics:
+ *   - Overlay `schedule` entries are *appended* to the agent's
+ *     `agents.<name>.schedule` array. They cannot override or replace main
+ *     config entries.
+ *   - Overlay entries with a non-empty `secrets:` list are dropped with a
+ *     warning. Granting vault access via overlay would let a write-tool
+ *     escalate its own broker grants without operator review.
+ *     TODO(switchroom#1163 Phase E): queue these for an operator approval
+ *     card instead of silently dropping.
+ *   - Per-file failure is isolated: malformed YAML, schema-rejected files,
+ *     and even one agent's bad overlay never block other files or agents.
+ *
+ * `skills.d/` is intentionally NOT loaded in this PR. The main-config
+ * `agents.<name>.skills` field is `string[]` (a list of skill names), not a
+ * structured-entry list, so an append-and-tag merge model needs a separate
+ * design pass. See `OverlayDocSchema.skills` for the reserved field — the
+ * schema accepts it shape-wise so a future PR can wire merging without a
+ * breaking change.
+ */
+import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
+import { resolve } from "node:path";
+import { parse as parseYaml } from "yaml";
+import { ZodError } from "zod";
+import type { ScheduleEntry, SwitchroomConfig } from "./schema.js";
+import { OverlayDocSchema } from "./overlay-schema.js";
+import { resolveDualPath } from "./paths.js";
+
+/**
+ * Marker stamped on every overlay-sourced schedule entry. Downstream code
+ * (e.g. the cron-unit namer) reads this to choose `cron-ovl-<hash>` style
+ * unit names instead of `cron-<index>`, which avoids index collisions if
+ * the main-config `schedule:` array grows.
+ *
+ * Exported as a Symbol so it's invisible to JSON-serialisation paths
+ * (scaffold writes, audit logs) and won't accidentally bleed into the
+ * agent-facing config view.
+ */
+export const OVERLAY_SOURCE = Symbol.for("switchroom.config.overlay-source");
+
+export interface OverlayWarning {
+  agent: string;
+  file: string;
+  reason: string;
+}
+
+export interface ApplyOverlaysResult {
+  config: SwitchroomConfig;
+  warnings: OverlayWarning[];
+}
+
+/**
+ * Locate the on-host root for an agent's overlay tree. Honours the
+ * dual-path resolver (`paths.ts`) so containerised callers and host
+ * callers both find the same directory.
+ */
+function overlayDirFor(agentName: string, subdir: string): string {
+  // ~/.switchroom/agents/<name>/<subdir>
+  const base = resolveDualPath(`~/.switchroom/agents/${agentName}/${subdir}`);
+  return resolve(base);
+}
+
+function listYamlFiles(dir: string): string[] {
+  if (!existsSync(dir)) return [];
+  let entries: string[];
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return [];
+  }
+  const out: string[] = [];
+  for (const name of entries) {
+    if (!/\.ya?ml$/i.test(name)) continue;
+    const full = resolve(dir, name);
+    try {
+      if (statSync(full).isFile()) out.push(full);
+    } catch {
+      /* unreadable entry — skip */
+    }
+  }
+  return out.sort(); // stable load order for deterministic merging
+}
+
+function stampOverlay(entry: ScheduleEntry): ScheduleEntry {
+  // Non-enumerable so JSON.stringify / structured logs ignore it. The
+  // marker is read by downstream consumers via `(entry as any)[OVERLAY_SOURCE]`.
+  Object.defineProperty(entry, OVERLAY_SOURCE, {
+    value: true,
+    enumerable: false,
+    configurable: false,
+    writable: false,
+  });
+  return entry;
+}
+
+/**
+ * Load + merge overlay files for every agent in the resolved config.
+ *
+ * Mutates `config` in place (appends to each agent's `schedule`) and also
+ * returns it for ergonomic chaining. Warnings are emitted via
+ * `console.warn` (matching the convention in `merge.ts`) and also returned
+ * for callers that want to surface them through a different channel.
+ */
+export function applyAgentOverlays(config: SwitchroomConfig): ApplyOverlaysResult {
+  const warnings: OverlayWarning[] = [];
+  const agents = config.switchroom?.agents ?? {};
+
+  for (const [agentName, agentCfg] of Object.entries(agents)) {
+    try {
+      const scheduleDir = overlayDirFor(agentName, "schedule.d");
+      const files = listYamlFiles(scheduleDir);
+      if (files.length === 0) continue;
+
+      // Snapshot the main-config entry shapes so we can detect "would
+      // override" attempts. Append-only means: if the overlay's
+      // (cron, prompt) tuple matches an existing main entry, we still
+      // append it (it'd be a duplicate cron, which is the operator's
+      // problem) — but we never *replace*. The current array-append
+      // merge naturally enforces this; no per-entry check needed.
+      const merged: ScheduleEntry[] = [...(agentCfg.schedule ?? [])];
+
+      for (const file of files) {
+        try {
+          const raw = readFileSync(file, "utf-8");
+          const parsed = parseYaml(raw);
+          const doc = OverlayDocSchema.parse(parsed);
+
+          for (const entry of doc.schedule ?? []) {
+            if (entry.secrets && entry.secrets.length > 0) {
+              const w: OverlayWarning = {
+                agent: agentName,
+                file,
+                reason:
+                  "Overlay schedule entry declares secrets — dropped pending Phase E operator approval",
+              };
+              warnings.push(w);
+              console.warn(
+                `[switchroom] overlay-loader: agent='${agentName}' file='${file}': ${w.reason}`,
+              );
+              continue;
+            }
+            merged.push(stampOverlay(entry));
+          }
+
+          // Phase B does NOT merge `doc.skills` — see file header.
+        } catch (err) {
+          const reason =
+            err instanceof ZodError
+              ? `schema rejection: ${err.errors.map((e) => `${e.path.join(".")}: ${e.message}`).join("; ")}`
+              : `parse error: ${(err as Error).message}`;
+          warnings.push({ agent: agentName, file, reason });
+          console.warn(
+            `[switchroom] overlay-loader: agent='${agentName}' file='${file}': ${reason}`,
+          );
+          // Continue to the next file — per-file failure isolation.
+        }
+      }
+
+      agentCfg.schedule = merged;
+    } catch (err) {
+      // Per-agent isolation — a directory-read failure (permissions etc.)
+      // for agent X must NOT block loading for agents Y/Z.
+      warnings.push({
+        agent: agentName,
+        file: "(agent overlay scan)",
+        reason: `unexpected error: ${(err as Error).message}`,
+      });
+      console.warn(
+        `[switchroom] overlay-loader: agent='${agentName}': unexpected error: ${(err as Error).message}`,
+      );
+    }
+  }
+
+  return { config, warnings };
+}

--- a/src/config/overlay-schema.test.ts
+++ b/src/config/overlay-schema.test.ts
@@ -1,0 +1,50 @@
+/**
+ * Tests for OverlayDocSchema (switchroom #1163, Phase B).
+ *
+ * Covers:
+ *   - valid overlay shape with `schedule` array
+ *   - rejection of unknown top-level keys
+ *   - reuse of ScheduleEntrySchema for entry validation
+ */
+import { describe, expect, it } from "vitest";
+import { OverlayDocSchema } from "./overlay-schema.js";
+
+describe("OverlayDocSchema", () => {
+  it("accepts a valid overlay with a schedule array", () => {
+    const parsed = OverlayDocSchema.parse({
+      schedule: [
+        { cron: "0 8 * * *", prompt: "morning brief" },
+      ],
+    });
+    expect(parsed.schedule).toHaveLength(1);
+    // ScheduleEntrySchema defaults secrets to [] — confirms we reused it.
+    expect(parsed.schedule?.[0].secrets).toEqual([]);
+  });
+
+  it("accepts an empty overlay (both keys omitted)", () => {
+    expect(() => OverlayDocSchema.parse({})).not.toThrow();
+  });
+
+  it("rejects unknown top-level keys", () => {
+    expect(() =>
+      OverlayDocSchema.parse({
+        schedule: [],
+        // Typo / injection of a real config field — must NOT silently merge.
+        agents: { evil: {} },
+      }),
+    ).toThrow();
+  });
+
+  it("rejects when schedule entry is missing required fields (reuses ScheduleEntrySchema)", () => {
+    expect(() =>
+      OverlayDocSchema.parse({
+        schedule: [{ cron: "0 8 * * *" /* missing prompt */ }],
+      }),
+    ).toThrow();
+  });
+
+  it("accepts skills:[] as a reserved-but-typed key", () => {
+    const parsed = OverlayDocSchema.parse({ skills: ["my-skill"] });
+    expect(parsed.skills).toEqual(["my-skill"]);
+  });
+});

--- a/src/config/overlay-schema.ts
+++ b/src/config/overlay-schema.ts
@@ -1,0 +1,34 @@
+/**
+ * Overlay-document schema for per-agent `schedule.d/*.yaml` files.
+ *
+ * Overlays are write-tool-managed YAML fragments that a future agent-config
+ * MCP write surface (Phase C of switchroom #1163) will create on the agent's
+ * behalf. Each file under `~/.switchroom/agents/<name>/schedule.d/` is a
+ * standalone YAML document that *appends* to the main `switchroom.yaml`
+ * config — it cannot override entries declared in the main file.
+ *
+ * The shape is intentionally narrow: only `schedule` (a list of
+ * `ScheduleEntrySchema` entries) is accepted right now. `skills` is reserved
+ * but not yet wired (the main-config `skills:` field is `string[]`, not a
+ * structured-entry list, so an overlay-append model needs a separate design
+ * pass — see the loader's `applyAgentOverlays` for the matching TODO).
+ *
+ * Anything else at the top level is a hard-reject — operators editing
+ * overlays by hand should get a clear error rather than silent acceptance
+ * of typos.
+ */
+import { z } from "zod";
+import { ScheduleEntrySchema } from "./schema.js";
+
+export const OverlayDocSchema = z
+  .object({
+    schedule: z.array(ScheduleEntrySchema).optional(),
+    // Reserved for Phase C+ — the loader currently ignores this key so
+    // that an early-adopter writing `skills:` in an overlay doesn't get a
+    // hard reject before the merge semantics ship. Schema-level we still
+    // require it to be the right *type* if present.
+    skills: z.array(z.string()).optional(),
+  })
+  .strict();
+
+export type OverlayDoc = z.infer<typeof OverlayDocSchema>;


### PR DESCRIPTION
## Summary
- Adds the writable per-agent overlay loader: globs `*.yaml` from `~/.switchroom/overlays/<agent>/{schedule.d,skills.d}/` and append-merges into the resolved config before Zod validation.
- Narrow `OverlayDocSchema` rejects unknown top-level keys early — overlays cannot override main `switchroom.yaml`.
- Compose emit pre-creates the per-agent overlay dir so the bind-mount target exists on first boot.
- This is the **storage backend** for the agent-config broker (Phase A merged as #1182). Per the reviewer-flipped sequencing in #1163, broker write tools (`schedule_add` / `_remove`) land on top of this — not exposed to agents as an independent surface in this PR.

## Test plan
- [x] `npm run build` clean
- [x] 21/21 new tests pass (5 schema + 16 loader): precedence, missing dirs, malformed YAML, schema rejection, merge semantics
- [x] Pre-existing failures verified against `origin/main` — same 19 environmental failures (vault-broker socket path, docker-compose v2 absence, etc.) — not introduced here
- [ ] Manual: drop a schedule.d/*.yaml into an agent's overlay dir; assert next reconcile picks it up via Zod validation

## Series context
Part of #1163. Sequence: A (#1182, merged) → **B (this PR)** → F (#1185, merged) → D / C / E (planned).