### PR TITLE
feat(hooks+skill): wedge-detect PostToolUse hook + self-recovery guidance

### DIFF
--- a/skills/switchroom-runtime/SKILL.md
+++ b/skills/switchroom-runtime/SKILL.md
@@ -137,3 +137,27 @@ Your response should:
 Pre-emptively reach for `/file-bug` only when the user clearly indicates they want it filed. Don't auto-file from a single "status?". That creates noise. The offer-then-confirm shape is the right friction.
 
 The companion telemetry already in place (`gateway.ts` logs every `status?` to stderr with chat_id + agent, see #109) lets the maintainer track the rate over time even when no RCA is filed. Your job is to make sure the user's *current* concern doesn't go unaddressed.
+
+---
+
+## Bash shell wedge — KillBash, then ask for restart
+
+**Trigger:** you receive a tool-result preamble from the framework that says `[wedge-detect] N consecutive empty-result Bash calls`, OR you notice trivial Bash calls (`echo ok`, `true`, `ls`) returning exit-1 with empty stdout/stderr two or three times in a row.
+
+This is **the persistent-shell wedge.** Claude Code keeps a single `bash` subprocess per session for state continuity (so `cd` carries across calls). When that shell's IO state desyncs (typically after a long-running or interrupted command like `npm test` that was `!`-interrupted) every subsequent Bash call comes back exit-1-empty. Even `true` fails. The wedge is sticky for the session.
+
+**Do not retry the same command.** The shell is dead to you; loops just burn the user's time. Two recovery steps in order:
+
+1. **Try `KillBash`.** Claude Code exposes a `KillBash` tool that drops the wedged shell session; the next Bash call gets a fresh shell. This works in some wedge modes but not all (sentinel-parsing wedges sometimes don't release until a full session restart). Worth trying first because it's cheap.
+
+2. **Ask the user for `switchroom agent restart <self>`.** If `KillBash` didn't recover (next Bash call is still exit-1-empty), the persistent shell needs the whole `claude` process to restart. Tell the user on Telegram with `accent: 'issue'`:
+
+   > ⚠️ Issue
+   >
+   > My Bash shell is wedged. Every command including `true` returns exit-1 with empty output. Tried `KillBash`, didn't recover. Run `switchroom agent restart <self>` on the host to bounce me. State that survives the restart: Hindsight memory, handoff briefing, Telegram history. State that doesn't: anything I was about to write that's not yet on disk.
+
+   Adapt the wording.
+
+**Triggering causes to avoid.** The wedge most often follows: (a) a long `npm test` / `bun test` run, (b) any command that was `!`-interrupted mid-flight, (c) heredoc-style commands the shell's stdin couldn't fully consume. Prevention: dispatch heavy test suites to a worker sub-agent (so the wedge dies with the worker) rather than running them in your own session, and use `run_in_background: true` for long jobs.
+
+A sentinel file at `$TELEGRAM_STATE_DIR/wedge-detected.json` records the most recent wedge detection. Operators can `cat` it for forensic timestamps; you don't normally need to read it yourself.

--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -2800,12 +2800,22 @@ export function buildSettingsHooksBlock(p: HooksBlockParams): Record<string, unk
           // long/interrupted command, every subsequent Bash call returns
           // exit-1 with empty stdout/stderr — even `true`. This hook
           // counts consecutive empty Bash results and writes a sentinel
-          // + logs to stderr after THRESHOLD (=3) in a row, plus injects
-          // a one-line nudge via additionalContext so the agent tries
+          // + logs to stderr after THRESHOLD in a row, plus injects a
+          // one-line nudge via additionalContext so the agent tries
           // KillBash or asks for `switchroom agent restart` rather than
           // retrying the wedged shell in a loop. Bash-only matcher
           // because the wedge is shell-specific; counter resets on any
           // other tool firing.
+          //
+          // Plugin-gated even though the wedge is a Claude-Code-runtime
+          // defect (not a telegram-plugin feature) because the hook
+          // depends on $TELEGRAM_STATE_DIR for counter / sentinel files
+          // and on the gateway surface to act on the sentinel. Operators
+          // running with `channels.telegram.plugin: official` won't get
+          // the hook, but they also don't have the gateway surface that
+          // would act on it. The hook's fail-silent / no-op-without-
+          // state-dir contract makes it safe to enable unconditionally
+          // in a future iteration if a non-plugin surface is added.
           matcher: "^Bash$",
           hooks: [
             {

--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -2793,6 +2793,31 @@ export function buildSettingsHooksBlock(p: HooksBlockParams): Record<string, unk
             },
           ],
         },
+        {
+          // Detect a wedged persistent-bash session. Claude Code's Bash
+          // tool uses a persistent shell for state continuity (so `cd`
+          // persists). When that shell's IO state desyncs after a
+          // long/interrupted command, every subsequent Bash call returns
+          // exit-1 with empty stdout/stderr — even `true`. This hook
+          // counts consecutive empty Bash results and writes a sentinel
+          // + logs to stderr after THRESHOLD (=3) in a row, plus injects
+          // a one-line nudge via additionalContext so the agent tries
+          // KillBash or asks for `switchroom agent restart` rather than
+          // retrying the wedged shell in a loop. Bash-only matcher
+          // because the wedge is shell-specific; counter resets on any
+          // other tool firing.
+          matcher: "^Bash$",
+          hooks: [
+            {
+              type: "command",
+              command: wrap(
+                "hook:wedge-detect-posttool",
+                `node "${join(DOCKER_HOOKS_PATH, "wedge-detect-posttool.mjs")}"`,
+              ),
+              timeout: 3,
+            },
+          ],
+        },
       ]
     : [];
 

--- a/telegram-plugin/hooks/wedge-detect-posttool.mjs
+++ b/telegram-plugin/hooks/wedge-detect-posttool.mjs
@@ -1,0 +1,232 @@
+#!/usr/bin/env node
+/**
+ * PostToolUse hook — detect a wedged persistent-bash session.
+ *
+ * Claude Code's Bash tool uses a persistent `bash` subprocess for state
+ * continuity (so `cd /foo` in one call survives to the next). When that
+ * subprocess's IO state desyncs — typically after a long-running or
+ * interrupted command leaves stdin in mid-heredoc, or after sentinel
+ * parsing breaks — every subsequent Bash call returns exit-1 with empty
+ * stdout and empty stderr. Even `true` returns exit 1. The wedge is
+ * sticky for the session; `switchroom agent restart <self>` is the only
+ * reliable recovery (it spawns a fresh `claude` → fresh persistent bash).
+ *
+ * This hook watches PostToolUse events for the wedge signature and,
+ * after N consecutive matches, writes a sentinel + logs to stderr so
+ * the operator (via `docker logs`) or the gateway (via a future card)
+ * can prompt for restart. The hook itself can NEVER fix the wedge —
+ * PostToolUse fires after the tool already ran. It's a detection +
+ * surfacing surface, not a recovery surface.
+ *
+ * Claude Code PostToolUse protocol:
+ *   stdin:  JSON { tool_name, tool_use_id, tool_input, tool_response, ... }
+ *   stdout: optional JSON (hookSpecificOutput.additionalContext for next
+ *           turn). We use this to nudge the model toward KillBash +
+ *           self-restart guidance once the wedge is detected.
+ *   exit:   0 always. Hook failures must never block the tool flow.
+ *
+ * State:
+ *   $TELEGRAM_STATE_DIR/wedge-counter.txt — integer, consecutive empty Bash
+ *     results. Reset to 0 on any non-Bash event or any non-empty Bash
+ *     result. Incremented on each empty Bash result.
+ *   $TELEGRAM_STATE_DIR/wedge-detected.json — JSON sentinel written when
+ *     counter reaches THRESHOLD. Contains { ts, session_id, agent,
+ *     consecutive }. Gateway can poll for this and surface a card; for
+ *     now its presence is informational only.
+ *
+ * Threshold: 3. Picked to balance false positives (some real commands
+ * legitimately produce no output and exit non-zero, e.g. `test -f
+ * /nonexistent`) against latency-to-detect. Three in a row is rare
+ * outside genuine wedge.
+ *
+ * Detection is shape-based not exit-code-based because the tool_response
+ * shape varies by Claude Code version. We match on:
+ *   - tool_name === "Bash"
+ *   - stringified response contains BOTH empty stdout marker AND empty
+ *     stderr marker. Marker patterns covered: <bash-stdout></bash-stdout>,
+ *     "stdout":"" + "stderr":"", and the bare "(no output)" string some
+ *     versions emit.
+ *
+ * If detection markers change in a future Claude Code release, this hook
+ * silently misses the wedge — that's the right failure mode (better than
+ * false-firing).
+ */
+
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'node:fs'
+import { join, dirname } from 'node:path'
+
+const THRESHOLD = 3
+
+function readStdin() {
+  try {
+    return readFileSync(0, 'utf8')
+  } catch {
+    return ''
+  }
+}
+
+function stateDir() {
+  return process.env.TELEGRAM_STATE_DIR || null
+}
+
+function counterPath() {
+  const dir = stateDir()
+  return dir ? join(dir, 'wedge-counter.txt') : null
+}
+
+function sentinelPath() {
+  const dir = stateDir()
+  return dir ? join(dir, 'wedge-detected.json') : null
+}
+
+function readCounter() {
+  const p = counterPath()
+  if (!p || !existsSync(p)) return 0
+  try {
+    const raw = readFileSync(p, 'utf8').trim()
+    const n = Number.parseInt(raw, 10)
+    return Number.isFinite(n) && n >= 0 ? n : 0
+  } catch {
+    return 0
+  }
+}
+
+function writeCounter(n) {
+  const p = counterPath()
+  if (!p) return
+  try {
+    mkdirSync(dirname(p), { recursive: true })
+    writeFileSync(p, String(n), 'utf8')
+  } catch {
+    // fail-silent; counter loss just delays detection by a couple of cycles
+  }
+}
+
+function writeSentinel(payload) {
+  const p = sentinelPath()
+  if (!p) return
+  try {
+    mkdirSync(dirname(p), { recursive: true })
+    writeFileSync(p, JSON.stringify(payload, null, 2), 'utf8')
+  } catch {
+    // fail-silent
+  }
+}
+
+/**
+ * Test whether a Bash tool_response matches the wedge signature
+ * (empty stdout AND empty stderr).
+ *
+ * Defensive: tool_response shape varies across Claude Code versions and
+ * across plain-string vs structured-object representations. We check a
+ * handful of likely markers and fail-no-match on anything else.
+ */
+function isEmptyBashResponse(toolResponse) {
+  if (toolResponse == null) return false
+  let body
+  try {
+    body = typeof toolResponse === 'string' ? toolResponse : JSON.stringify(toolResponse)
+  } catch {
+    return false
+  }
+  // Cap scan to keep us cheap on huge outputs (which are by definition
+  // not empty, so we can early-return).
+  if (body.length > 4096) return false
+
+  // Several response shapes Claude Code has used:
+  //   1. XML-style tags: <bash-stdout></bash-stdout><bash-stderr></bash-stderr>
+  //   2. JSON object stringified: {"stdout":"","stderr":"",...}
+  //   3. JSON object's literal stdout/stderr fields (when we passed the
+  //      object directly).
+  const hasEmptyStdoutTag = /<bash-stdout>\s*<\/bash-stdout>/i.test(body)
+  const hasEmptyStderrTag = /<bash-stderr>\s*<\/bash-stderr>/i.test(body)
+  if (hasEmptyStdoutTag && hasEmptyStderrTag) return true
+
+  const hasEmptyStdoutJson = /"stdout"\s*:\s*""/.test(body)
+  const hasEmptyStderrJson = /"stderr"\s*:\s*""/.test(body)
+  if (hasEmptyStdoutJson && hasEmptyStderrJson) return true
+
+  // Defensive: if the response is literally `{}` or `""`, that's also a
+  // zero-info Bash result. Treat the same as empty.
+  if (body === '{}' || body === '""' || body === '') return true
+
+  return false
+}
+
+function emitWedgeContext(consecutive) {
+  // PostToolUse can prepend additionalContext to the model's next turn.
+  // Use it to surface a single-line nudge once the wedge is suspected
+  // so the agent knows to try recovery rather than retrying the same
+  // command in a loop.
+  const text =
+    `[wedge-detect] ${consecutive} consecutive empty-result Bash calls — ` +
+    `your persistent shell is likely wedged. Try \`KillBash\` to drop ` +
+    `the wedged session, OR ask the user for \`switchroom agent restart ${process.env.SWITCHROOM_AGENT_NAME || '<self>'}\` ` +
+    `if KillBash doesn't recover. Don't retry the same command.`
+  const payload = {
+    hookSpecificOutput: {
+      hookEventName: 'PostToolUse',
+      additionalContext: text,
+    },
+  }
+  try {
+    process.stdout.write(JSON.stringify(payload) + '\n')
+  } catch {
+    // fail-silent
+  }
+}
+
+function main() {
+  const raw = readStdin()
+  if (!raw) return
+  let evt
+  try {
+    evt = JSON.parse(raw)
+  } catch {
+    return
+  }
+
+  // Non-Bash events reset the counter (the wedge is specific to the
+  // persistent shell; other tools succeeding doesn't tell us anything
+  // about Bash, but a different tool firing means we're at least not in
+  // a tight loop of Bash retries — safe to reset).
+  if (evt.tool_name !== 'Bash') {
+    writeCounter(0)
+    return
+  }
+
+  if (!isEmptyBashResponse(evt.tool_response)) {
+    // Bash call returned real output → not wedged → reset.
+    writeCounter(0)
+    return
+  }
+
+  // Empty Bash result. Increment.
+  const next = readCounter() + 1
+  writeCounter(next)
+
+  if (next >= THRESHOLD) {
+    const sentinel = {
+      ts: new Date().toISOString(),
+      session_id: evt.session_id || null,
+      agent: process.env.SWITCHROOM_AGENT_NAME || null,
+      consecutive: next,
+      // Capture the last tool_use_id so an operator-side investigator
+      // can pin which tool calls triggered the threshold.
+      last_tool_use_id: evt.tool_use_id || null,
+    }
+    writeSentinel(sentinel)
+    process.stderr.write(
+      `wedge-detect: ${next} consecutive empty-result Bash calls; ` +
+      `sentinel at ${sentinelPath()}; recommend KillBash or ` +
+      `switchroom agent restart\n`,
+    )
+    emitWedgeContext(next)
+  }
+}
+
+try {
+  main()
+} catch {
+  // PostToolUse must never block the tool flow.
+}

--- a/telegram-plugin/hooks/wedge-detect-posttool.mjs
+++ b/telegram-plugin/hooks/wedge-detect-posttool.mjs
@@ -52,10 +52,22 @@
  * false-firing).
  */
 
-import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'node:fs'
+import { readFileSync, writeFileSync, existsSync, mkdirSync, rmSync } from 'node:fs'
 import { join, dirname } from 'node:path'
 
-const THRESHOLD = 3
+// Higher than the original 3 to avoid false-firing on legitimate
+// empty-output command sequences (a sed, then two greps with no matches,
+// is a normal refactor pattern and shouldn't trigger). PR #1188 review
+// found 3 was guaranteed-FP. 5 + the noOutputExpected /
+// returnCodeInterpretation skip below should keep real wedges detectable
+// while staying quiet during normal grep/find/sed chains.
+const THRESHOLD = 5
+
+// node:fs operations on the counter / sentinel files are read-modify-write
+// without explicit locking. Safe because Claude Code serializes tool calls
+// per session — there is at most one PostToolUse fire in flight per agent
+// at any time. Documented so a future caller doesn't introduce parallelism
+// and silently lose counts.
 
 function readStdin() {
   try {
@@ -113,41 +125,100 @@ function writeSentinel(payload) {
   }
 }
 
+function clearSentinel() {
+  const p = sentinelPath()
+  if (!p) return
+  try {
+    rmSync(p, { force: true })
+  } catch {
+    // fail-silent
+  }
+}
+
+function resetCounter() {
+  // Counter reset means we're back in healthy territory — clear the
+  // sentinel too so a future operator-side surface that polls for
+  // `wedge-detected.json` doesn't see stale state from a long-cleared
+  // wedge. Per PR #1188 review B2.
+  writeCounter(0)
+  clearSentinel()
+}
+
 /**
- * Test whether a Bash tool_response matches the wedge signature
- * (empty stdout AND empty stderr).
+ * Test whether a Bash tool_response matches the wedge signature.
  *
- * Defensive: tool_response shape varies across Claude Code versions and
- * across plain-string vs structured-object representations. We check a
- * handful of likely markers and fail-no-match on anything else.
+ * The wedge produces: empty stdout AND empty stderr AND no
+ * Claude-Code-supplied "no output is expected here" annotation AND not
+ * interrupted by the user.
+ *
+ * The benign empty-output cases that PR #1188 review B1 called out
+ * (grep/find/sed/test with no matches or in-place mutation) are
+ * disambiguated by:
+ *   - `noOutputExpected: true` — Claude Code annotates Bash calls whose
+ *     command pattern legitimately produces no output.
+ *   - `returnCodeInterpretation: "..."` — present when Claude Code has
+ *     a human-readable explanation for the exit code (e.g. "No matches
+ *     found" for grep). Its presence means "this empty result is
+ *     understood, not a desync."
+ *   - `interrupted: true` — user pressed `!` mid-command. Not a wedge.
+ *
+ * Defensive: response shape varies across Claude Code versions and
+ * across plain-string vs structured-object representations. We check
+ * each known marker and fail-no-match on anything else.
  */
 function isEmptyBashResponse(toolResponse) {
   if (toolResponse == null) return false
+
+  // Structured-object path. Most reliable — read the fields directly
+  // and consult the annotations.
+  if (typeof toolResponse === 'object') {
+    const r = toolResponse
+    // Interruption is user-initiated, not a desync. Don't count.
+    if (r.interrupted === true) return false
+    // Claude Code already knows this command's empty output is expected.
+    if (r.noOutputExpected === true) return false
+    // Claude Code has a human-readable explanation — the empty result is
+    // accounted for, not a parse failure.
+    if (typeof r.returnCodeInterpretation === 'string' && r.returnCodeInterpretation.length > 0) {
+      return false
+    }
+    // Real empty-result check. Both streams empty (or missing).
+    const stdout = typeof r.stdout === 'string' ? r.stdout : ''
+    const stderr = typeof r.stderr === 'string' ? r.stderr : ''
+    if (stdout === '' && stderr === '') return true
+    return false
+  }
+
+  // String path — older Claude Code versions, or when the response was
+  // wrapped before reaching the hook. We can't read structured fields,
+  // so we rely on substring shape and accept slightly higher FP risk on
+  // this path (covered by THRESHOLD raise + skill-side recovery being
+  // cheap).
   let body
   try {
-    body = typeof toolResponse === 'string' ? toolResponse : JSON.stringify(toolResponse)
+    body = String(toolResponse)
   } catch {
     return false
   }
-  // Cap scan to keep us cheap on huge outputs (which are by definition
-  // not empty, so we can early-return).
   if (body.length > 4096) return false
 
-  // Several response shapes Claude Code has used:
-  //   1. XML-style tags: <bash-stdout></bash-stdout><bash-stderr></bash-stderr>
-  //   2. JSON object stringified: {"stdout":"","stderr":"",...}
-  //   3. JSON object's literal stdout/stderr fields (when we passed the
-  //      object directly).
+  // If the string form contains noOutputExpected:true or a
+  // returnCodeInterpretation, treat as accounted-for.
+  if (/"noOutputExpected"\s*:\s*true/.test(body)) return false
+  if (/"interrupted"\s*:\s*true/.test(body)) return false
+  if (/"returnCodeInterpretation"\s*:\s*"[^"]+"/.test(body)) return false
+
+  // XML-style tags: <bash-stdout></bash-stdout><bash-stderr></bash-stderr>
   const hasEmptyStdoutTag = /<bash-stdout>\s*<\/bash-stdout>/i.test(body)
   const hasEmptyStderrTag = /<bash-stderr>\s*<\/bash-stderr>/i.test(body)
   if (hasEmptyStdoutTag && hasEmptyStderrTag) return true
 
+  // JSON-stringified shape from older serializers.
   const hasEmptyStdoutJson = /"stdout"\s*:\s*""/.test(body)
   const hasEmptyStderrJson = /"stderr"\s*:\s*""/.test(body)
   if (hasEmptyStdoutJson && hasEmptyStderrJson) return true
 
-  // Defensive: if the response is literally `{}` or `""`, that's also a
-  // zero-info Bash result. Treat the same as empty.
+  // Literal zero-info bodies.
   if (body === '{}' || body === '""' || body === '') return true
 
   return false
@@ -191,13 +262,13 @@ function main() {
   // about Bash, but a different tool firing means we're at least not in
   // a tight loop of Bash retries — safe to reset).
   if (evt.tool_name !== 'Bash') {
-    writeCounter(0)
+    resetCounter()
     return
   }
 
   if (!isEmptyBashResponse(evt.tool_response)) {
     // Bash call returned real output → not wedged → reset.
-    writeCounter(0)
+    resetCounter()
     return
   }
 

--- a/tests/wedge-detect-posttool.test.ts
+++ b/tests/wedge-detect-posttool.test.ts
@@ -1,0 +1,204 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync, readFileSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+/**
+ * Unit tests for telegram-plugin/hooks/wedge-detect-posttool.mjs.
+ *
+ * Hook contract:
+ *   stdin:  PostToolUse JSON event { tool_name, tool_response, ... }
+ *   stdout: optional JSON
+ *             {"hookSpecificOutput":{"hookEventName":"PostToolUse",
+ *              "additionalContext":"..."}}
+ *           emitted only when the consecutive-empty-Bash counter
+ *           crosses THRESHOLD (=3).
+ *   exit:   0 always.
+ *
+ * State files in $TELEGRAM_STATE_DIR:
+ *   wedge-counter.txt   — integer, consecutive empty Bash results.
+ *   wedge-detected.json — sentinel written when counter >= THRESHOLD.
+ */
+
+const HOOK = resolve(
+  __dirname,
+  "..",
+  "telegram-plugin",
+  "hooks",
+  "wedge-detect-posttool.mjs",
+);
+
+interface RunResult {
+  status: number;
+  stdout: string;
+  stderr: string;
+  counter: number;
+  sentinel: Record<string, unknown> | null;
+}
+
+function run(
+  payload: Record<string, unknown> | string | null,
+  stateDir: string | null,
+  agentName = "test-agent",
+): RunResult {
+  const env: Record<string, string> = {};
+  for (const [k, v] of Object.entries(process.env)) {
+    if (v !== undefined) env[k] = v;
+  }
+  if (stateDir) env.TELEGRAM_STATE_DIR = stateDir;
+  else delete env.TELEGRAM_STATE_DIR;
+  env.SWITCHROOM_AGENT_NAME = agentName;
+
+  const stdin =
+    payload === null ? "" : typeof payload === "string" ? payload : JSON.stringify(payload);
+  const r = spawnSync(process.execPath, [HOOK], {
+    input: stdin,
+    env,
+    encoding: "utf8",
+  });
+
+  let counter = 0;
+  let sentinel: Record<string, unknown> | null = null;
+  if (stateDir) {
+    const cp = join(stateDir, "wedge-counter.txt");
+    if (existsSync(cp)) counter = Number.parseInt(readFileSync(cp, "utf8").trim(), 10) || 0;
+    const sp = join(stateDir, "wedge-detected.json");
+    if (existsSync(sp)) sentinel = JSON.parse(readFileSync(sp, "utf8")) as Record<string, unknown>;
+  }
+
+  return {
+    status: r.status ?? 0,
+    stdout: r.stdout ?? "",
+    stderr: r.stderr ?? "",
+    counter,
+    sentinel,
+  };
+}
+
+function bashEvent(toolResponse: unknown): Record<string, unknown> {
+  return {
+    session_id: "sess-test",
+    tool_use_id: `toolu_${Math.random().toString(36).slice(2, 8)}`,
+    tool_name: "Bash",
+    tool_input: { command: "true" },
+    tool_response: toolResponse,
+  };
+}
+
+describe("wedge-detect-posttool.mjs", () => {
+  let stateDir: string;
+
+  beforeEach(() => {
+    stateDir = mkdtempSync(join(tmpdir(), "wedge-detect-"));
+  });
+
+  afterEach(() => {
+    rmSync(stateDir, { recursive: true, force: true });
+  });
+
+  it("always exits 0 — even on bad input", () => {
+    for (const bad of [null, "", "not-json", "{}"]) {
+      const r = run(bad, stateDir);
+      expect(r.status).toBe(0);
+    }
+  });
+
+  it("non-Bash event resets the counter and is silent", () => {
+    // Pre-seed counter as if a wedge was in progress.
+    const r1 = run(bashEvent({ stdout: "", stderr: "" }), stateDir);
+    expect(r1.counter).toBe(1);
+
+    // Read event (not Bash) → counter reset to 0.
+    const r2 = run(
+      { session_id: "sess-test", tool_use_id: "t-r", tool_name: "Read", tool_response: "ok" },
+      stateDir,
+    );
+    expect(r2.counter).toBe(0);
+    expect(r2.stdout).toBe("");
+    expect(r2.sentinel).toBeNull();
+  });
+
+  it("non-empty Bash result resets the counter", () => {
+    const r1 = run(bashEvent({ stdout: "", stderr: "" }), stateDir);
+    expect(r1.counter).toBe(1);
+
+    const r2 = run(bashEvent({ stdout: "hello\n", stderr: "" }), stateDir);
+    expect(r2.counter).toBe(0);
+    expect(r2.sentinel).toBeNull();
+  });
+
+  it("counts consecutive empty Bash results with JSON-style response shape", () => {
+    const r1 = run(bashEvent({ stdout: "", stderr: "" }), stateDir);
+    expect(r1.counter).toBe(1);
+    expect(r1.sentinel).toBeNull();
+
+    const r2 = run(bashEvent({ stdout: "", stderr: "" }), stateDir);
+    expect(r2.counter).toBe(2);
+    expect(r2.sentinel).toBeNull();
+
+    const r3 = run(bashEvent({ stdout: "", stderr: "" }), stateDir);
+    expect(r3.counter).toBe(3);
+    expect(r3.sentinel).not.toBeNull();
+    expect(r3.sentinel?.consecutive).toBe(3);
+    expect(r3.sentinel?.agent).toBe("test-agent");
+    expect(r3.sentinel?.session_id).toBe("sess-test");
+  });
+
+  it("detects XML-tag style empty Bash response", () => {
+    const response = "<bash-stdout></bash-stdout><bash-stderr></bash-stderr>";
+    for (let i = 0; i < 3; i++) {
+      const r = run(bashEvent(response), stateDir);
+      expect(r.counter).toBe(i + 1);
+    }
+    expect(existsSync(join(stateDir, "wedge-detected.json"))).toBe(true);
+  });
+
+  it("at threshold, emits additionalContext nudge to stdout", () => {
+    run(bashEvent({ stdout: "", stderr: "" }), stateDir);
+    run(bashEvent({ stdout: "", stderr: "" }), stateDir);
+    const r3 = run(bashEvent({ stdout: "", stderr: "" }), stateDir);
+
+    expect(r3.stdout.length).toBeGreaterThan(0);
+    const parsed = JSON.parse(r3.stdout.trim()) as Record<string, unknown>;
+    const hsOutput = parsed.hookSpecificOutput as Record<string, unknown>;
+    expect(hsOutput.hookEventName).toBe("PostToolUse");
+    const ctx = hsOutput.additionalContext as string;
+    expect(ctx).toContain("wedge-detect");
+    expect(ctx).toContain("KillBash");
+    expect(ctx).toContain("switchroom agent restart");
+  });
+
+  it("at threshold, logs to stderr for docker logs visibility", () => {
+    run(bashEvent({ stdout: "", stderr: "" }), stateDir);
+    run(bashEvent({ stdout: "", stderr: "" }), stateDir);
+    const r3 = run(bashEvent({ stdout: "", stderr: "" }), stateDir);
+    expect(r3.stderr).toContain("wedge-detect");
+    expect(r3.stderr).toContain("consecutive empty-result Bash calls");
+  });
+
+  it("missing TELEGRAM_STATE_DIR — silent no-op (no crash)", () => {
+    const r = run(bashEvent({ stdout: "", stderr: "" }), null);
+    expect(r.status).toBe(0);
+  });
+
+  it("a long real Bash output (>4KB) is treated as non-empty, resets counter", () => {
+    run(bashEvent({ stdout: "", stderr: "" }), stateDir);
+    const bigResponse = { stdout: "x".repeat(5000), stderr: "" };
+    const r = run(bashEvent(bigResponse), stateDir);
+    expect(r.counter).toBe(0);
+  });
+
+  it("response is the literal string '{}' (zero-info) — counted as empty", () => {
+    const r = run(
+      {
+        session_id: "sess-test",
+        tool_use_id: "t1",
+        tool_name: "Bash",
+        tool_response: "{}",
+      },
+      stateDir,
+    );
+    expect(r.counter).toBe(1);
+  });
+});

--- a/tests/wedge-detect-posttool.test.ts
+++ b/tests/wedge-detect-posttool.test.ts
@@ -12,13 +12,20 @@ import { join, resolve } from "node:path";
  *   stdout: optional JSON
  *             {"hookSpecificOutput":{"hookEventName":"PostToolUse",
  *              "additionalContext":"..."}}
- *           emitted only when the consecutive-empty-Bash counter
- *           crosses THRESHOLD (=3).
+ *           emitted when consecutive empty Bash results reach THRESHOLD (=5)
+ *           and on every subsequent empty result while still wedged.
  *   exit:   0 always.
  *
  * State files in $TELEGRAM_STATE_DIR:
  *   wedge-counter.txt   — integer, consecutive empty Bash results.
  *   wedge-detected.json — sentinel written when counter >= THRESHOLD.
+ *                         CLEARED on any counter reset (PR #1188 review B2).
+ *
+ * Detection skips (PR #1188 review B1):
+ *   - tool_response.noOutputExpected === true  (grep/find/sed/etc.)
+ *   - tool_response.returnCodeInterpretation present (Claude already
+ *     explained the result)
+ *   - tool_response.interrupted === true  (user pressed `!`)
  */
 
 const HOOK = resolve(
@@ -28,6 +35,7 @@ const HOOK = resolve(
   "hooks",
   "wedge-detect-posttool.mjs",
 );
+const THRESHOLD = 5;
 
 interface RunResult {
   status: number;
@@ -86,6 +94,16 @@ function bashEvent(toolResponse: unknown): Record<string, unknown> {
   };
 }
 
+const EMPTY = { stdout: "", stderr: "", interrupted: false };
+
+function ramp(count: number, stateDir: string): RunResult {
+  let last: RunResult | null = null;
+  for (let i = 0; i < count; i++) {
+    last = run(bashEvent(EMPTY), stateDir);
+  }
+  return last!;
+}
+
 describe("wedge-detect-posttool.mjs", () => {
   let stateDir: string;
 
@@ -105,11 +123,9 @@ describe("wedge-detect-posttool.mjs", () => {
   });
 
   it("non-Bash event resets the counter and is silent", () => {
-    // Pre-seed counter as if a wedge was in progress.
-    const r1 = run(bashEvent({ stdout: "", stderr: "" }), stateDir);
+    const r1 = run(bashEvent(EMPTY), stateDir);
     expect(r1.counter).toBe(1);
 
-    // Read event (not Bash) → counter reset to 0.
     const r2 = run(
       { session_id: "sess-test", tool_use_id: "t-r", tool_name: "Read", tool_response: "ok" },
       stateDir,
@@ -120,7 +136,7 @@ describe("wedge-detect-posttool.mjs", () => {
   });
 
   it("non-empty Bash result resets the counter", () => {
-    const r1 = run(bashEvent({ stdout: "", stderr: "" }), stateDir);
+    const r1 = run(bashEvent(EMPTY), stateDir);
     expect(r1.counter).toBe(1);
 
     const r2 = run(bashEvent({ stdout: "hello\n", stderr: "" }), stateDir);
@@ -128,26 +144,23 @@ describe("wedge-detect-posttool.mjs", () => {
     expect(r2.sentinel).toBeNull();
   });
 
-  it("counts consecutive empty Bash results with JSON-style response shape", () => {
-    const r1 = run(bashEvent({ stdout: "", stderr: "" }), stateDir);
-    expect(r1.counter).toBe(1);
-    expect(r1.sentinel).toBeNull();
-
-    const r2 = run(bashEvent({ stdout: "", stderr: "" }), stateDir);
-    expect(r2.counter).toBe(2);
-    expect(r2.sentinel).toBeNull();
-
-    const r3 = run(bashEvent({ stdout: "", stderr: "" }), stateDir);
-    expect(r3.counter).toBe(3);
-    expect(r3.sentinel).not.toBeNull();
-    expect(r3.sentinel?.consecutive).toBe(3);
-    expect(r3.sentinel?.agent).toBe("test-agent");
-    expect(r3.sentinel?.session_id).toBe("sess-test");
+  it(`counts consecutive empty Bash results up to THRESHOLD=${THRESHOLD}`, () => {
+    for (let i = 1; i < THRESHOLD; i++) {
+      const r = run(bashEvent(EMPTY), stateDir);
+      expect(r.counter).toBe(i);
+      expect(r.sentinel).toBeNull();
+    }
+    const last = run(bashEvent(EMPTY), stateDir);
+    expect(last.counter).toBe(THRESHOLD);
+    expect(last.sentinel).not.toBeNull();
+    expect(last.sentinel?.consecutive).toBe(THRESHOLD);
+    expect(last.sentinel?.agent).toBe("test-agent");
+    expect(last.sentinel?.session_id).toBe("sess-test");
   });
 
   it("detects XML-tag style empty Bash response", () => {
     const response = "<bash-stdout></bash-stdout><bash-stderr></bash-stderr>";
-    for (let i = 0; i < 3; i++) {
+    for (let i = 0; i < THRESHOLD; i++) {
       const r = run(bashEvent(response), stateDir);
       expect(r.counter).toBe(i + 1);
     }
@@ -155,12 +168,9 @@ describe("wedge-detect-posttool.mjs", () => {
   });
 
   it("at threshold, emits additionalContext nudge to stdout", () => {
-    run(bashEvent({ stdout: "", stderr: "" }), stateDir);
-    run(bashEvent({ stdout: "", stderr: "" }), stateDir);
-    const r3 = run(bashEvent({ stdout: "", stderr: "" }), stateDir);
-
-    expect(r3.stdout.length).toBeGreaterThan(0);
-    const parsed = JSON.parse(r3.stdout.trim()) as Record<string, unknown>;
+    const last = ramp(THRESHOLD, stateDir);
+    expect(last.stdout.length).toBeGreaterThan(0);
+    const parsed = JSON.parse(last.stdout.trim()) as Record<string, unknown>;
     const hsOutput = parsed.hookSpecificOutput as Record<string, unknown>;
     expect(hsOutput.hookEventName).toBe("PostToolUse");
     const ctx = hsOutput.additionalContext as string;
@@ -170,20 +180,18 @@ describe("wedge-detect-posttool.mjs", () => {
   });
 
   it("at threshold, logs to stderr for docker logs visibility", () => {
-    run(bashEvent({ stdout: "", stderr: "" }), stateDir);
-    run(bashEvent({ stdout: "", stderr: "" }), stateDir);
-    const r3 = run(bashEvent({ stdout: "", stderr: "" }), stateDir);
-    expect(r3.stderr).toContain("wedge-detect");
-    expect(r3.stderr).toContain("consecutive empty-result Bash calls");
+    const last = ramp(THRESHOLD, stateDir);
+    expect(last.stderr).toContain("wedge-detect");
+    expect(last.stderr).toContain("consecutive empty-result Bash calls");
   });
 
   it("missing TELEGRAM_STATE_DIR — silent no-op (no crash)", () => {
-    const r = run(bashEvent({ stdout: "", stderr: "" }), null);
+    const r = run(bashEvent(EMPTY), null);
     expect(r.status).toBe(0);
   });
 
   it("a long real Bash output (>4KB) is treated as non-empty, resets counter", () => {
-    run(bashEvent({ stdout: "", stderr: "" }), stateDir);
+    run(bashEvent(EMPTY), stateDir);
     const bigResponse = { stdout: "x".repeat(5000), stderr: "" };
     const r = run(bashEvent(bigResponse), stateDir);
     expect(r.counter).toBe(0);
@@ -200,5 +208,114 @@ describe("wedge-detect-posttool.mjs", () => {
       stateDir,
     );
     expect(r.counter).toBe(1);
+  });
+
+  // PR #1188 review S1: still-wedged re-emit.
+  it("re-emits nudge and re-writes sentinel at N=THRESHOLD+1 and N+2", () => {
+    ramp(THRESHOLD, stateDir);
+    const r6 = run(bashEvent(EMPTY), stateDir);
+    expect(r6.counter).toBe(THRESHOLD + 1);
+    expect(r6.sentinel?.consecutive).toBe(THRESHOLD + 1);
+    expect(r6.stdout).toContain("KillBash");
+
+    const r7 = run(bashEvent(EMPTY), stateDir);
+    expect(r7.counter).toBe(THRESHOLD + 2);
+    expect(r7.sentinel?.consecutive).toBe(THRESHOLD + 2);
+  });
+
+  // PR #1188 review B2: sentinel cleared on counter reset.
+  it("counter reset (non-empty Bash result) clears the sentinel", () => {
+    ramp(THRESHOLD, stateDir);
+    expect(existsSync(join(stateDir, "wedge-detected.json"))).toBe(true);
+
+    // Healthy Bash result → reset → sentinel removed.
+    const r = run(bashEvent({ stdout: "hello\n", stderr: "" }), stateDir);
+    expect(r.counter).toBe(0);
+    expect(existsSync(join(stateDir, "wedge-detected.json"))).toBe(false);
+  });
+
+  it("counter reset (non-Bash event) also clears the sentinel", () => {
+    ramp(THRESHOLD, stateDir);
+    expect(existsSync(join(stateDir, "wedge-detected.json"))).toBe(true);
+
+    const r = run(
+      { session_id: "sess-test", tool_use_id: "tx", tool_name: "Read", tool_response: "ok" },
+      stateDir,
+    );
+    expect(r.counter).toBe(0);
+    expect(existsSync(join(stateDir, "wedge-detected.json"))).toBe(false);
+  });
+
+  // PR #1188 review B1: legitimate empty-output commands annotated by
+  // Claude Code must NOT count toward the wedge counter.
+  it("noOutputExpected:true does NOT increment the counter", () => {
+    for (let i = 0; i < THRESHOLD; i++) {
+      const r = run(
+        bashEvent({ stdout: "", stderr: "", interrupted: false, noOutputExpected: true }),
+        stateDir,
+      );
+      expect(r.counter).toBe(0);
+      expect(r.sentinel).toBeNull();
+    }
+  });
+
+  it("returnCodeInterpretation present does NOT increment the counter", () => {
+    for (let i = 0; i < THRESHOLD; i++) {
+      const r = run(
+        bashEvent({
+          stdout: "",
+          stderr: "",
+          interrupted: false,
+          returnCodeInterpretation: "No matches found",
+        }),
+        stateDir,
+      );
+      expect(r.counter).toBe(0);
+      expect(r.sentinel).toBeNull();
+    }
+  });
+
+  // PR #1188 review S3: user-initiated interrupt is not a wedge.
+  it("interrupted:true does NOT increment the counter", () => {
+    for (let i = 0; i < THRESHOLD; i++) {
+      const r = run(bashEvent({ stdout: "", stderr: "", interrupted: true }), stateDir);
+      expect(r.counter).toBe(0);
+      expect(r.sentinel).toBeNull();
+    }
+  });
+
+  it("mixed-shape sequence: grep (annotated) then real wedge — counter only counts the wedge", () => {
+    // Three annotated grep-style empties — should NOT count.
+    for (let i = 0; i < 3; i++) {
+      const r = run(
+        bashEvent({ stdout: "", stderr: "", interrupted: false, noOutputExpected: true }),
+        stateDir,
+      );
+      expect(r.counter).toBe(0);
+    }
+    // Now THRESHOLD raw empties — should reach threshold cleanly.
+    for (let i = 1; i <= THRESHOLD; i++) {
+      const r = run(bashEvent(EMPTY), stateDir);
+      expect(r.counter).toBe(i);
+    }
+    const sentinelPath = join(stateDir, "wedge-detected.json");
+    expect(existsSync(sentinelPath)).toBe(true);
+  });
+
+  it("string-form response with noOutputExpected:true does NOT count", () => {
+    const stringForm =
+      '{"stdout":"","stderr":"","interrupted":false,"noOutputExpected":true,"isImage":false}';
+    for (let i = 0; i < THRESHOLD; i++) {
+      const r = run(
+        {
+          session_id: "sess-test",
+          tool_use_id: `t-str-${i}`,
+          tool_name: "Bash",
+          tool_response: stringForm,
+        },
+        stateDir,
+      );
+      expect(r.counter).toBe(0);
+    }
   });
 });


### PR DESCRIPTION
## Background

Diagnosed during the klanker host-agent RCA — symptom A. Claude Code's Bash tool uses a persistent \`bash\` subprocess for state continuity; when its IO state desyncs (typically after a long or \`!\`-interrupted command), every subsequent Bash call returns exit-1 with empty stdout/stderr. Even \`true\` returns exit-1-empty. The wedge is sticky for the session.

PR #1186 fixed the related test-env-leak (symptom B). This PR addresses the wedge itself with **detection + surfacing + agent-side self-recovery guidance**.

## New PostToolUse hook

\`telegram-plugin/hooks/wedge-detect-posttool.mjs\` — matcher \`^Bash$\`. Tracks consecutive empty-Bash results; after THRESHOLD (=3) writes \`\$TELEGRAM_STATE_DIR/wedge-detected.json\` sentinel, logs to stderr, and emits \`hookSpecificOutput.additionalContext\` nudging the agent toward \`KillBash\` then self-restart. Exit 0 always — PostToolUse can't block.

Wired into \`buildSettingsHooksBlock\` alongside existing PostToolUse hooks. Timeout 3s.

## Skill update

Added "Bash shell wedge — KillBash, then ask for restart" to \`skills/switchroom-runtime/SKILL.md\`:
- Trigger: framework preamble OR observable wedge symptoms.
- Two-step recovery: \`KillBash\` first, then \`switchroom agent restart <self>\`. Sample Telegram-card wording included.
- Triggering-cause prevention: dispatch heavy tests to worker sub-agents, use \`run_in_background: true\`.

## Tests

\`tests/wedge-detect-posttool.test.ts\` — 10/10 pass. Covers: bad input, counter reset paths, threshold detection (both response shapes), sentinel write, stderr log, additionalContext emission, missing-state-dir no-op, large-output reset, bare \`{}\` literal.

## Files

\`\`\`
skills/switchroom-runtime/SKILL.md              +24
src/agents/scaffold.ts                          +25
telegram-plugin/hooks/wedge-detect-posttool.mjs +232 (new)
tests/wedge-detect-posttool.test.ts             +204 (new)
\`\`\`

## Test plan

- [x] \`npx vitest run tests/wedge-detect-posttool\` — 10/10 pass
- [x] \`npx vitest run tests/wedge-detect-posttool tests/scaffold src/agents/profiles.test.ts\` — 241/241 pass
- [x] \`npm run lint\` — clean
- [ ] Post-merge smoke: trigger a real wedge on a dev agent (long \`bun test\`), verify sentinel writes + stderr log + agent receives the additionalContext nudge on next turn

🤖 Generated with [Claude Code](https://claude.com/claude-code)