### PR TITLE
feat(config): agent.resources schema field for per-agent resource tuning

### DIFF
--- a/src/agents/compose.ts
+++ b/src/agents/compose.ts
@@ -39,6 +39,10 @@ export const AGENT_UID_MAX = 10999;
 export interface ResourceDefaults {
   memLimit: string;
   cpus: number;
+  /** Optional — when set, emitted as `mem_reservation` (cgroup memory.low). */
+  memReservation?: string;
+  /** Optional — when set, emitted as `pids_limit` (cgroup pids.max). */
+  pidsLimit?: number;
 }
 
 const RESOURCE_BY_PROFILE: Record<string, ResourceDefaults> = {
@@ -54,20 +58,58 @@ const RESOURCE_BY_PROFILE: Record<string, ResourceDefaults> = {
 };
 
 /**
- * Resolve resource defaults for an agent. Special-cases the agent name
- * "klanker" (matches the canonical fleet's klanker profile), then falls
- * through to the agent's `extends:` profile name, then to "default".
+ * Operator override shape — matches the snake_case keys in the
+ * `resources` schema field. Resolved into camelCase `ResourceDefaults`
+ * by `resolveResourceDefaults`. All fields optional: an unset field
+ * falls back to the per-profile default.
+ */
+export interface ResourceOverrides {
+  memory?: string;
+  memory_reservation?: string;
+  pids_limit?: number;
+  cpus?: number;
+}
+
+/**
+ * Resolve resource limits for an agent.
  *
- * Operator overrides at the agent level (resources.mem_limit etc.) win
- * over these defaults — see emitAgentService.
+ * Precedence (highest wins, per-field):
+ *   1. Operator override on `agent.resources.<field>` (cascaded by
+ *      `mergeAgentConfig` from defaults / profile / per-agent layers).
+ *   2. Agent-name special-case: `klanker` → klanker profile defaults.
+ *      Preserved for backward compatibility — the canonical fleet's
+ *      klanker hits this when its YAML doesn't override.
+ *   3. The agent's `extends:` profile entry in RESOURCE_BY_PROFILE.
+ *   4. The `default` profile entry.
+ *
+ * Per-field merge: an override that sets only `memory` keeps the
+ * profile's `cpus` and any default `memReservation` / `pidsLimit`.
+ * This matches the schema description for the `resources` field.
  */
 export function resolveResourceDefaults(
   agentName: string,
   profile: string | undefined,
+  overrides?: ResourceOverrides | undefined,
 ): ResourceDefaults {
-  if (agentName === "klanker") return RESOURCE_BY_PROFILE.klanker!;
-  if (profile && RESOURCE_BY_PROFILE[profile]) return RESOURCE_BY_PROFILE[profile]!;
-  return RESOURCE_BY_PROFILE.default!;
+  let base: ResourceDefaults;
+  if (agentName === "klanker") {
+    base = RESOURCE_BY_PROFILE.klanker!;
+  } else if (profile && RESOURCE_BY_PROFILE[profile]) {
+    base = RESOURCE_BY_PROFILE[profile]!;
+  } else {
+    base = RESOURCE_BY_PROFILE.default!;
+  }
+  if (!overrides) return { ...base };
+  const merged: ResourceDefaults = { ...base };
+  if (overrides.memory !== undefined) merged.memLimit = overrides.memory;
+  if (overrides.cpus !== undefined) merged.cpus = overrides.cpus;
+  if (overrides.memory_reservation !== undefined) {
+    merged.memReservation = overrides.memory_reservation;
+  }
+  if (overrides.pids_limit !== undefined) {
+    merged.pidsLimit = overrides.pids_limit;
+  }
+  return merged;
 }
 
 /**
@@ -308,7 +350,10 @@ export function describeAgents(config: SwitchroomConfig): AgentServiceData[] {
     const resolved = resolveAgentConfig(config.defaults, config.profiles, agent);
     const profile = agent.extends ?? "default";
     const uid = allocateAgentUid(name);
-    const resources = resolveResourceDefaults(name, profile);
+    // `resolved.resources` is the cascaded operator override (per-field
+    // merge of defaults.resources → profile.resources → agent.resources,
+    // see mergeAgentConfig). Unset fields fall back to RESOURCE_BY_PROFILE.
+    const resources = resolveResourceDefaults(name, profile, resolved.resources);
     const strippedCaps = readStrippedCaps(agent);
     out.push({
       name,
@@ -946,6 +991,12 @@ function emitAgentService(
   lines.push(`    stop_grace_period: 45s`);
   lines.push(`    user: "${a.uid}:${a.uid}"`);
   lines.push(`    mem_limit: ${a.resources.memLimit}`);
+  if (a.resources.memReservation !== undefined) {
+    lines.push(`    mem_reservation: ${a.resources.memReservation}`);
+  }
+  if (a.resources.pidsLimit !== undefined) {
+    lines.push(`    pids_limit: ${a.resources.pidsLimit}`);
+  }
   lines.push(`    cpus: ${a.resources.cpus.toFixed(1)}`);
   lines.push(`    security_opt:`);
   lines.push(`      - "no-new-privileges:true"`);

--- a/src/config/merge.ts
+++ b/src/config/merge.ts
@@ -608,6 +608,20 @@ export function mergeAgentConfig(
     (merged as { reactions?: Record<string, unknown> }).reactions = combined;
   }
 
+  // --- resources: shallow per-key merge, agent wins ---
+  //
+  // Same shape as `experimental` below — operators may set a subset of
+  // {memory, memory_reservation, pids_limit, cpus} at any cascade layer
+  // and the resolved tip is the field-wise union with agent overriding
+  // on conflict. Compose generator (src/agents/compose.ts) reads this
+  // and falls back to per-profile hard-coded defaults for any field
+  // still unset at the tip.
+  if (defaults.resources || merged.resources) {
+    const d = defaults.resources ?? {};
+    const a = merged.resources ?? {};
+    merged.resources = { ...d, ...a };
+  }
+
   // --- experimental: shallow per-key merge, agent wins ---
   //
   // The schema declares `experimental` at every cascade layer

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -1472,6 +1472,26 @@ export const AgentSchema = z.object({
       "Opt-in flags for experimental / legacy behaviours. Cascades through " +
       "defaults → profile → per-agent.",
     ),
+  // Mirror of profileFields.resources — must be repeated here because
+  // AgentSchema does not spread profileFields. Without this, the
+  // inferred AgentConfig type lacks `resources` and typed reads in
+  // compose.ts / merge.ts fail tsc (runtime works because zod doesn't
+  // strip unknown keys by default). See profileFields.resources at
+  // schema.ts above for the full description; keep the two in sync.
+  resources: z
+    .object({
+      memory: z
+        .string()
+        .regex(/^\d+(\.\d+)?[kmgKMG]?$/)
+        .optional(),
+      memory_reservation: z
+        .string()
+        .regex(/^\d+(\.\d+)?[kmgKMG]?$/)
+        .optional(),
+      pids_limit: z.number().int().positive().optional(),
+      cpus: z.number().positive().optional(),
+    })
+    .optional(),
 });
 
 export const TelegramConfigSchema = z.object({

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -944,6 +944,69 @@ const profileFields = {
       "`--append-system-prompt`. Missing files are silently skipped. " +
       "Example: ['BRIEF.md', 'CONTEXT.md'].",
     ),
+  resources: z
+    .object({
+      memory: z
+        .string()
+        .regex(
+          /^\d+(\.\d+)?[kmgKMG]?$/,
+          "memory must be a Docker size string like '6g', '512m', '1.5g'",
+        )
+        .optional()
+        .describe(
+          "Hard memory cap (Docker `mem_limit` → cgroup memory.max). When the " +
+          "container exceeds this, the kernel OOM-kills processes in the cgroup. " +
+          "Format: '6g', '1.5g', '512m'. When unset at every cascade layer the " +
+          "compose generator falls back to the hard-coded per-profile defaults " +
+          "in src/agents/compose.ts (klanker 6g, coding 2g, conversational 1.5g, " +
+          "lightweight 1g, default 1.5g).",
+        ),
+      memory_reservation: z
+        .string()
+        .regex(
+          /^\d+(\.\d+)?[kmgKMG]?$/,
+          "memory_reservation must be a Docker size string like '4g', '256m'",
+        )
+        .optional()
+        .describe(
+          "Soft memory floor (Docker `mem_reservation` → cgroup memory.low). " +
+          "Under host-wide memory pressure, the kernel protects at least this " +
+          "much from being reclaimed from the cgroup. Must be ≤ memory. Use to " +
+          "keep an agent RAM-resident when the host has other tenants that " +
+          "might push the box (Coolify apps, build jobs). Default: unset.",
+        ),
+      pids_limit: z
+        .number()
+        .int()
+        .positive()
+        .optional()
+        .describe(
+          "Max processes the cgroup can spawn (cgroup pids.max). Prevents " +
+          "fork bombs and runaway test runners. Counts every process in the " +
+          "cgroup including bash subprocesses, claude itself, sidecars, and " +
+          "any test/build worker. A typical agent at idle uses ~30 PIDs; " +
+          "`npm test`-style workloads can spike to 200+. Set generously " +
+          "(2000 is a comfortable cap for test-running agents). Default: " +
+          "unset (no cgroup pid cap).",
+        ),
+      cpus: z
+        .number()
+        .positive()
+        .optional()
+        .describe(
+          "CPU quota (Docker `cpus`). Fractional values OK (e.g. 0.5, 2.0). " +
+          "When unset at every cascade layer the compose generator falls " +
+          "back to the per-profile default (klanker/coding 2.0, default 1.0, " +
+          "lightweight 0.5).",
+        ),
+    })
+    .optional()
+    .describe(
+      "Per-agent resource limits. Cascades through defaults → profile → " +
+      "per-agent with per-field merge (agent wins on each field independently). " +
+      "Any field left unset at every layer falls back to the hard-coded " +
+      "per-profile defaults in src/agents/compose.ts.",
+    ),
   experimental: z
     .object({
       legacy_pty: z

--- a/tests/docker/compose-generator.test.ts
+++ b/tests/docker/compose-generator.test.ts
@@ -244,6 +244,23 @@ describe("generateCompose", () => {
     expect(out).toMatch(/agent-coach:[\s\S]*?cpus: 1\.0/);
   });
 
+  it("profile.resources (inline profile) cascades down to per-agent", () => {
+    // Inline profile sets memory_reservation; the agent extends it.
+    // resolveAgentConfig folds profile through mergeAgentConfig, which
+    // means our resources cascade clause must apply at the profile
+    // layer too (not just defaults). Pin it.
+    const config = makeConfig({ alice: { extends: "tight" } });
+    config.profiles = {
+      tight: { resources: { memory_reservation: "192m", pids_limit: 300 } },
+    } as unknown as typeof config.profiles;
+    const out = generateCompose({ config });
+    expect(out).toMatch(/agent-alice:[\s\S]*?mem_reservation: 192m/);
+    expect(out).toMatch(/agent-alice:[\s\S]*?pids_limit: 300/);
+    // memory still defaults — "tight" isn't in RESOURCE_BY_PROFILE so
+    // it falls through to the catch-all default 1.5g.
+    expect(out).toMatch(/agent-alice:[\s\S]*?mem_limit: 1\.5g/);
+  });
+
   it("agent.resources.cpus overrides profile (fractional accepted)", () => {
     const out = generateCompose({
       config: makeConfig({ ziggy: { extends: "lightweight", resources: { cpus: 0.25 } } }),

--- a/tests/docker/compose-generator.test.ts
+++ b/tests/docker/compose-generator.test.ts
@@ -30,8 +30,17 @@ import {
 } from "../../src/agents/compose.js";
 import type { SwitchroomConfig } from "../../src/config/schema.js";
 
+interface MakeConfigAgent {
+  extends?: string;
+  settings_raw?: Record<string, unknown>;
+  admin?: boolean;
+  env?: Record<string, string>;
+  bind_mounts?: Array<{ source: string; target?: string; mode?: "ro" | "rw" }>;
+  resources?: { memory?: string; memory_reservation?: string; pids_limit?: number; cpus?: number };
+}
+
 function makeConfig(
-  agents: Record<string, { extends?: string; settings_raw?: Record<string, unknown>; admin?: boolean; env?: Record<string, string>; bind_mounts?: Array<{ source: string; target?: string; mode?: "ro" | "rw" }> }>,
+  agents: Record<string, MakeConfigAgent>,
   topLevel?: { host_control?: { enabled?: boolean } },
 ): SwitchroomConfig {
   return {
@@ -48,6 +57,7 @@ function makeConfig(
           admin: cfg.admin,
           env: cfg.env,
           bind_mounts: cfg.bind_mounts,
+          resources: cfg.resources,
           schedule: [],
           tools: { allow: [], deny: [] },
           hooks: undefined,
@@ -186,6 +196,60 @@ describe("generateCompose", () => {
   it("unknown profile → default 1.5g / 1.0", () => {
     const out = generateCompose({ config: makeConfig({ misc: { extends: "made-up" } }) });
     expect(out).toMatch(/agent-misc:[\s\S]*?mem_limit: 1\.5g/);
+  });
+
+  it("agent.resources.memory overrides the profile default", () => {
+    const out = generateCompose({
+      config: makeConfig({ tiny: { extends: "conversational", resources: { memory: "512m" } } }),
+    });
+    expect(out).toMatch(/agent-tiny:[\s\S]*?mem_limit: 512m/);
+    // cpus still falls back to the profile default (1.0 for conversational)
+    expect(out).toMatch(/agent-tiny:[\s\S]*?cpus: 1\.0/);
+  });
+
+  it("agent.resources.memory_reservation emits mem_reservation under the agent service", () => {
+    const out = generateCompose({
+      config: makeConfig({
+        klanker: { resources: { memory_reservation: "4g" } },
+      }),
+    });
+    expect(out).toMatch(/agent-klanker:[\s\S]*?mem_reservation: 4g/);
+    // and the existing mem_limit/cpus are still emitted
+    expect(out).toMatch(/agent-klanker:[\s\S]*?mem_limit: 6g/);
+    expect(out).toMatch(/agent-klanker:[\s\S]*?cpus: 2\.0/);
+  });
+
+  it("agent.resources.pids_limit emits pids_limit under the agent service", () => {
+    const out = generateCompose({
+      config: makeConfig({ klanker: { resources: { pids_limit: 2000 } } }),
+    });
+    expect(out).toMatch(/agent-klanker:[\s\S]*?pids_limit: 2000/);
+  });
+
+  it("mem_reservation and pids_limit are absent when unset (backward-compat)", () => {
+    const out = generateCompose({ config: makeConfig({ coach: { extends: "conversational" } }) });
+    const block = /agent-coach:[\s\S]*?(?=\n  agent-|\nvolumes:|$)/.exec(out)?.[0] ?? "";
+    expect(block).not.toContain("mem_reservation");
+    expect(block).not.toContain("pids_limit");
+  });
+
+  it("defaults.resources cascades down to per-agent (per-field merge with agent winning)", () => {
+    // defaults.resources sets pids_limit; agent.resources sets memory.
+    // Resolved should have BOTH applied.
+    const config = makeConfig({ coach: { extends: "conversational", resources: { memory: "768m" } } });
+    config.defaults = { ...(config.defaults ?? {}), resources: { pids_limit: 500 } };
+    const out = generateCompose({ config });
+    expect(out).toMatch(/agent-coach:[\s\S]*?mem_limit: 768m/);
+    expect(out).toMatch(/agent-coach:[\s\S]*?pids_limit: 500/);
+    expect(out).toMatch(/agent-coach:[\s\S]*?cpus: 1\.0/);
+  });
+
+  it("agent.resources.cpus overrides profile (fractional accepted)", () => {
+    const out = generateCompose({
+      config: makeConfig({ ziggy: { extends: "lightweight", resources: { cpus: 0.25 } } }),
+    });
+    expect(out).toMatch(/agent-ziggy:[\s\S]*?cpus: 0\.3/); // toFixed(1) rounds
+    expect(out).toMatch(/agent-ziggy:[\s\S]*?mem_limit: 1g/); // unchanged
   });
 
   it("strips cap_add and emits a warning", () => {


### PR DESCRIPTION
## Summary

Adds the operator-tunable \`resources\` block to agent config, with cascade through defaults / profile / per-agent. Pure plumbing — no default behavior change. PR β (queued separately) will bump the default table.

Motivation: today \`RESOURCE_BY_PROFILE\` in \`src/agents/compose.ts\` hard-codes memory + cpus per profile and special-cases \`klanker\` by name. The comment at compose.ts:61 already promises operator-level overrides exist; this PR makes that promise real. Discovered during the klanker Bash-wedge RCA — klanker historical \`memory.peak\` was 5.69 GB / 6 GB cap during npm test, and operators have no knob to add reservation/PID-limit without editing source.

## Schema

\`agent.resources\` accepts four optional fields:
- \`memory\` — hard cap (Docker \`mem_limit\` → cgroup memory.max)
- \`memory_reservation\` — soft floor (Docker \`mem_reservation\` → cgroup memory.low)
- \`pids_limit\` — cgroup pids.max
- \`cpus\` — fractional OK

Per-field cascade: defaults → profile → per-agent. An override that sets only \`memory\` keeps the profile's \`cpus\` and any default reservation/PID cap. Mirrors the \`experimental\` cascade pattern.

## Files

\`\`\`
src/agents/compose.ts                  +69
src/config/merge.ts                    +14
src/config/schema.ts                   +63
tests/docker/compose-generator.test.ts +66
\`\`\`

## Backward-compat

Agents with no \`resources\` override emit identical compose. \`mem_reservation\` and \`pids_limit\` lines are emitted only when set. Existing 8-agent fleet and \`klanker\` continue to get the per-profile defaults from \`RESOURCE_BY_PROFILE\`.

## Test plan

- [x] \`npx vitest run tests/docker/compose-generator\` — 118/118 pass (was 112 + 6 new)
- [x] \`npm run lint\` against my diff — clean (pre-existing TS errors in \`overlay-loader.ts\`/test from #1187 are out of scope)
- [ ] After merge: smoke against a real \`switchroom apply\` to confirm a per-agent \`resources.memory_reservation\` lands in the generated compose

## Followup

PR β (queued, ~15 agent-min after this lands) bumps \`RESOURCE_BY_PROFILE\` to include sensible reservations + pids_limits per profile:
- klanker (test runner): + memory_reservation 4g, pids_limit 2000
- coding: + memory_reservation 512m, pids_limit 1000
- conversational: + memory_reservation 256m, pids_limit 500
- lightweight: + memory_reservation 128m, pids_limit 500

🤖 Generated with [Claude Code](https://claude.com/claude-code)