### PR TITLE
fix(skills): scrub host-checkout paths from switchroom-cli + file-bug

### DIFF
--- a/skills/file-bug/SKILL.md
+++ b/skills/file-bug/SKILL.md
@@ -107,7 +107,7 @@ HH:MM:SS [journalctl]     <line>
 
 ## Environment
 - agent: <name>
-- branch: <branch> (run `cd ~/code/switchroom && git rev-parse --short HEAD`)
+- branch: <branch> (from inside your switchroom clone: `git rev-parse --short HEAD`)
 - runtime versions: <bun/node/claude-cli versions>
 - triggered: <human-readable timestamp>
 ```

--- a/skills/switchroom-cli/SKILL.md
+++ b/skills/switchroom-cli/SKILL.md
@@ -47,26 +47,20 @@ Include the last ~20 lines verbatim, then summarise what you see (crash, stall, 
 
 ## Update — "update", "pull latest", "get new code", "upgrade"
 
-Pull the latest switchroom source, then re-apply config and bring the fleet back up via docker compose.
+Use the `switchroom update` verb (since v0.7.8 / #918). It collapses pull + apply + recreate + doctor into one command.
 
 ```bash
-cd ~/code/switchroom
-git pull
-bun install
-bun run build
-switchroom apply
-docker compose -p switchroom -f ~/.switchroom/compose/docker-compose.yml pull
-docker compose -p switchroom -f ~/.switchroom/compose/docker-compose.yml up -d
+switchroom update                # pull images + apply + recreate + run doctor
+switchroom update --check        # dry-run: print the plan, exit 0
+switchroom update --status       # read-only: CLI version + image/container ages
+switchroom update --rebuild      # source-checkout users: also git pull + npm build
 ```
 
-`switchroom apply` reconciles every agent declared in `switchroom.yaml`
-(scaffolding any missing workspaces, refreshing bootstrap files), then
-writes `~/.switchroom/compose/docker-compose.yml`. The CLI deliberately
-does not run `docker` for you — the operator owns the bring-up.
+`switchroom update` is the operator path. The CLI self-elevates via sudo internally for the per-agent scaffold dirs that need root — no need for `sudo HOME=… PATH=…` incantations.
 
-The v0.6 `switchroom update` verb is removed in v0.7+; calling it now
-prints this upgrade hint and exits 1. The shim is slated for full removal
-in v0.8.
+If you only need the config-reconcile half without restarting agents, `switchroom apply` writes `~/.switchroom/compose/docker-compose.yml` and refreshes per-agent scaffolds without touching running containers. The operator runs the docker bring-up themselves.
+
+From inside an agent's Telegram DM, the same flow is available as `/upgradestatus` (read-only) and `/update apply` (admin-gated).
 
 ---
 

--- a/skills/switchroom-cli/SKILL.md
+++ b/skills/switchroom-cli/SKILL.md
@@ -8,8 +8,9 @@ allowed-tools: Bash(switchroom *) Bash(docker *) Bash(docker compose *)
 
 This skill is the reference for running `switchroom` CLI commands against existing agents. Each section below is triggered by a distinct user intent — jump to the relevant one rather than walking top-to-bottom.
 
-**Three commands to know:**
-- `switchroom apply` — reconcile every agent + (re)write `~/.switchroom/compose/docker-compose.yml`. Bring the fleet up afterwards with `docker compose -p switchroom -f ~/.switchroom/compose/docker-compose.yml up -d`. (Replaces the v0.6 `switchroom update` flow.)
+**Four commands to know:**
+- `switchroom update` — full operator path: pulls images + applies config + recreates containers + runs doctor (since v0.7.8 / #918). What you want 95% of the time.
+- `switchroom apply` — config-only reconcile: refresh per-agent scaffolds and (re)write `~/.switchroom/compose/docker-compose.yml` without touching running containers. Use when you want to inspect the generated compose before bringing the fleet up yourself.
 - `switchroom restart [agent]` — bounces a stuck or wedged agent
 - `switchroom version` — shows what's running (versions + health summary)
 


### PR DESCRIPTION
## Summary

Two bundled-default skills (`switchroom-cli`, `file-bug`) told agents to `cd ~/code/switchroom` — the operator's host checkout path that isn't visible from inside an agent container. Replaces with container-friendly instructions.

While in `switchroom-cli`, the Update section also described the v0.6 manual `git pull / bun install / bun run build / switchroom apply / docker compose up` sequence and incorrectly said `switchroom update` was removed. The `switchroom update` verb was **re-added** in v0.7.8 (#918) and is now the canonical operator path. Updated to recommend it.

## Diff highlights

- `skills/switchroom-cli/SKILL.md`: Update section rewritten around `switchroom update` (collapsed pull+apply+recreate+doctor). `switchroom apply` framed for config-only reconcile. Added pointers to `/upgradestatus` + `/update apply` Telegram surfaces.
- `skills/file-bug/SKILL.md`: removed `cd ~/code/switchroom` from the branch-SHA capture step in the bug-report template.

## Out of scope (filed separately)

#1193 covers the broader systemd-references sweep through `src/cli/agent.ts` user-visible help strings and `src/config/schema.ts` TZ description.

## Test plan

- [ ] Skills render correctly in `~/.switchroom/skills/_bundled/` after `switchroom apply`
- [ ] Agents reading `switchroom-cli` for an update get pointed at `switchroom update`, not the old manual sequence
- [ ] file-bug template doesn't reference a host path