### PR TITLE
fix(compose): wire resolved timezone into agent container env (#1198)

### DIFF
--- a/bin/timezone-hook.sh
+++ b/bin/timezone-hook.sh
@@ -10,16 +10,18 @@
 # This hook fires on every UserPromptSubmit and prints a one-line hint that
 # Claude Code prepends to the prompt as additionalContext, so the LLM sees
 # fresh local time each turn. The resolved zone is passed in via
-# SWITCHROOM_TIMEZONE (baked into the agent's systemd unit at scaffold/
-# reconcile time). If unset we fall back to UTC — same default as the
-# resolver — so the hook never fails loudly.
+# SWITCHROOM_TIMEZONE (set in the agent container's `environment:` block by
+# the compose generator at `switchroom apply` time — see
+# src/agents/compose.ts). If unset we fall back to UTC — same default as
+# the resolver — so the hook never fails loudly.
 #
 # Stale-install detection: when SWITCHROOM_TIMEZONE is unset we also annotate
 # the hint with an in-band WARNING. This makes the failure visible to the
 # agent (and thus to the user), rather than silently emitting "UTC" while the
-# operator's real zone is Australia/Melbourne. Typical cause: an install
-# upgraded past the timezone-awareness PR without re-running
-# `switchroom systemd install` to refresh the unit files.
+# operator's real zone is Australia/Melbourne. Typical cause: the compose
+# env block is stale because `switchroom apply` hasn't run since the
+# operator added a `timezone:` cascade entry (or the agent container was
+# rebuilt from an image that predates the #1198 compose-TZ wiring fix).
 #
 # Failure modes are silent: hooks that error block the turn in Claude Code,
 # and a missing timezone hint is never worse than no hint at all.
@@ -46,7 +48,7 @@ ROUNDED=$(( NOW_UNIX - (NOW_UNIX % 900) ))
 NOW=$(TZ="$TZ_VAL" date -d "@$ROUNDED" '+%Y-%m-%d %H:%M %Z (UTC%:z)')
 
 if [ "$TZ_UNSET" = "1" ]; then
-  MSG="Current local time: $NOW ($TZ_VAL — WARNING: SWITCHROOM_TIMEZONE unset; systemd unit may be stale, run \`switchroom systemd install\` to refresh)"
+  MSG="Current local time: $NOW ($TZ_VAL — WARNING: SWITCHROOM_TIMEZONE unset; compose env may be stale, run \`switchroom apply && switchroom agent restart <agent>\` to refresh)"
 else
   MSG="Current local time: $NOW ($TZ_VAL)"
 fi

--- a/src/agents/compose.ts
+++ b/src/agents/compose.ts
@@ -28,6 +28,7 @@ import { existsSync, mkdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import type { SwitchroomConfig, AgentConfig, AgentBindMount } from "../config/schema.js";
 import { resolveAgentConfig } from "../config/merge.js";
+import { resolveTimezone } from "../config/timezone.js";
 import { isReservedAgentName } from "../vault/broker/peercred.js";
 import { getBundledSkillsPoolDir } from "./reconcile-default-skills.js";
 
@@ -381,6 +382,30 @@ interface AgentServiceData {
    * mirrors here.
    */
   userEnv: Record<string, string>;
+  /**
+   * Resolved IANA timezone for this agent (e.g. "Australia/Melbourne").
+   * Walks the four-step cascade in `resolveTimezone`:
+   * agent → profile (via merge) → switchroom.timezone → server detection
+   * → "UTC". Always a valid zone string; never undefined.
+   *
+   * Surfaces in the container `environment:` block as BOTH `TZ` (so
+   * `date(1)`, `Intl.DateTimeFormat`, and `node-cron`'s default schedule
+   * timezone read the operator-intended zone) AND `SWITCHROOM_TIMEZONE`
+   * (so `bin/timezone-hook.sh`'s UserPromptSubmit hint matches without
+   * a stale-unit warning).
+   *
+   * Why both: `TZ` is what every Unix tool already reads, including
+   * node-cron via libc. `SWITCHROOM_TIMEZONE` is the explicit name
+   * the hook checks so it can distinguish "operator declared zone is
+   * X" from "container default happens to be X" (the latter would
+   * leave SWITCHROOM_TIMEZONE unset and trigger the in-band warning).
+   *
+   * Wiring regressed during the v0.6→v0.7 systemd→Docker migration
+   * (#906 removed `generateUnit` which used to bake `TZ=` /
+   * `SWITCHROOM_TIMEZONE=` into the [Service] block). Restored here
+   * via the compose `environment:` block — see #1198.
+   */
+  timezone: string;
 }
 
 /** Per-agent metadata exposed to doctor checks (and tests). */
@@ -410,6 +435,12 @@ export function describeAgents(config: SwitchroomConfig): AgentServiceData[] {
       // profile + agent layers all contribute. Empty object when the
       // operator hasn't declared any (the common case).
       userEnv: { ...(resolved.env ?? {}) },
+      // Resolve once at describe-time so the same value lands in TZ
+      // and SWITCHROOM_TIMEZONE in `emitAgentService`. The resolver
+      // is pure modulo the server-detection probes, so two consecutive
+      // calls return the same string — but consolidating to one call
+      // keeps the surface obvious in tests.
+      timezone: resolveTimezone(config, resolved),
     });
     void resolved;
   }
@@ -1155,6 +1186,19 @@ function emitAgentService(
     // doesn't write the marker and gets SIGKILL'd at grace-period
     // expiry like before.
     TINI_KILL_PROCESS_GROUP: "1",
+    // Per-agent timezone (#1198). Both vars are emitted unconditionally
+    // because `resolveTimezone` always returns a valid IANA string
+    // (final fallback = "UTC"). `TZ` is the standard Unix env var
+    // every tool reads — `date(1)`, `Intl.DateTimeFormat`, `node-cron`'s
+    // schedule evaluator. Without it the agent container inherits the
+    // Debian base image's `Etc/UTC` and every cron expression fires
+    // 10–11 hours off the operator's local clock.
+    // `SWITCHROOM_TIMEZONE` is the explicit name `bin/timezone-hook.sh`
+    // reads so its UserPromptSubmit hint can distinguish "operator
+    // declared zone is X" from "container default happens to be X".
+    // Wiring regressed in #906 (systemd→Docker migration); see #1198.
+    SWITCHROOM_TIMEZONE: a.timezone,
+    TZ: a.timezone,
   };
   // PostHog runtime telemetry — opt-out honoured, distinct-ID propagated
   // from the host CLI so CLI + runtime events merge under the same user.

--- a/tests/docker/compose-generator.test.ts
+++ b/tests/docker/compose-generator.test.ts
@@ -37,14 +37,20 @@ interface MakeConfigAgent {
   env?: Record<string, string>;
   bind_mounts?: Array<{ source: string; target?: string; mode?: "ro" | "rw" }>;
   resources?: { memory?: string; memory_reservation?: string; pids_limit?: number; cpus?: number };
+  timezone?: string;
 }
 
 function makeConfig(
   agents: Record<string, MakeConfigAgent>,
-  topLevel?: { host_control?: { enabled?: boolean } },
+  topLevel?: { host_control?: { enabled?: boolean }; timezone?: string },
 ): SwitchroomConfig {
   return {
-    switchroom: { version: 1, agents_dir: "~/.switchroom/agents", skills_dir: "~/.switchroom/skills" },
+    switchroom: {
+      version: 1,
+      agents_dir: "~/.switchroom/agents",
+      skills_dir: "~/.switchroom/skills",
+      timezone: topLevel?.timezone,
+    },
     telegram: { bot_token: "x" },
     defaults: undefined,
     profiles: undefined,
@@ -58,6 +64,7 @@ function makeConfig(
           env: cfg.env,
           bind_mounts: cfg.bind_mounts,
           resources: cfg.resources,
+          timezone: cfg.timezone,
           schedule: [],
           tools: { allow: [], deny: [] },
           hooks: undefined,
@@ -997,6 +1004,84 @@ describe("agent service env (Phase 2c F2 — IPC wiring)", () => {
       expect(env).toMatch(/PIP_USER:\s*"1"/);
       expect(env).toMatch(/PIP_BREAK_SYSTEM_PACKAGES:\s*"1"/);
     }
+  });
+
+  // Per-agent timezone wiring (#1198).
+  //
+  // Pre-fix, compose.ts emitted no `TZ` or `SWITCHROOM_TIMEZONE` env var
+  // for agent services, so every container inherited the Debian base
+  // image's `Etc/UTC` default. node-cron inside the container read
+  // process.env.TZ (undefined) and evaluated every cron expression
+  // against UTC — `0 8 * * *` fired at 08:00 UTC instead of 08:00 in
+  // the operator's local zone, a 10-11 hour skew for Melbourne. The
+  // `resolveTimezone` cascade existed (agent → profile → switchroom →
+  // server detect → UTC) but its output never reached the container —
+  // it was only consumed by a scaffold-time CLI warning and the legacy
+  // (removed in #906) systemd unit's [Service] block. Restored here:
+  // emit both names so existing Unix tooling (`TZ`) and the
+  // UserPromptSubmit hook's stale-detection check (SWITCHROOM_TIMEZONE)
+  // both see the operator-intended zone.
+
+  it("emits TZ + SWITCHROOM_TIMEZONE from agent.timezone when set at the agent layer (#1198)", () => {
+    const out = generateCompose({
+      config: makeConfig({ clerk: { timezone: "Australia/Melbourne" } }),
+    });
+    const env = envBlockFor(out, "clerk");
+    expect(env).toMatch(/TZ:\s*"Australia\/Melbourne"/);
+    expect(env).toMatch(/SWITCHROOM_TIMEZONE:\s*"Australia\/Melbourne"/);
+  });
+
+  it("emits TZ + SWITCHROOM_TIMEZONE from switchroom.timezone (global default) when no agent layer set it", () => {
+    // The global cascade entry: `switchroom.timezone: "Region/City"` at
+    // the top of switchroom.yaml. Resolves through the cascade to every
+    // agent that doesn't declare its own zone.
+    const out = generateCompose({
+      config: makeConfig({ alice: {}, bob: {} }, { timezone: "America/New_York" }),
+    });
+    for (const a of ["alice", "bob"]) {
+      const env = envBlockFor(out, a);
+      expect(env).toMatch(/TZ:\s*"America\/New_York"/);
+      expect(env).toMatch(/SWITCHROOM_TIMEZONE:\s*"America\/New_York"/);
+    }
+  });
+
+  it("per-agent timezone wins over the global default", () => {
+    const out = generateCompose({
+      config: makeConfig(
+        {
+          clerk: { timezone: "Australia/Melbourne" },
+          alice: {},
+        },
+        { timezone: "America/New_York" },
+      ),
+    });
+    expect(envBlockFor(out, "clerk")).toMatch(/TZ:\s*"Australia\/Melbourne"/);
+    expect(envBlockFor(out, "alice")).toMatch(/TZ:\s*"America\/New_York"/);
+  });
+
+  it("emits a TZ env var unconditionally — never absent", () => {
+    // resolveTimezone always returns a string (final fallback "UTC" via
+    // server detection). The compose generator must therefore always
+    // emit TZ. A missing-TZ container would silently regress to UTC,
+    // re-introducing the #1198 bug without an obvious signal.
+    const out = generateCompose({
+      config: makeConfig({ alice: {}, bob: {} }), // no timezone anywhere
+    });
+    for (const a of ["alice", "bob"]) {
+      const env = envBlockFor(out, a);
+      expect(env).toMatch(/^\s*TZ:\s*"/m);
+      expect(env).toMatch(/^\s*SWITCHROOM_TIMEZONE:\s*"/m);
+    }
+  });
+
+  it("describeAgents() surfaces the resolved timezone on each agent's metadata", () => {
+    // The doctor checks + tests want to know the resolved zone without
+    // re-parsing YAML, so the resolution is exposed on AgentServiceData.
+    const agents = describeAgents(
+      makeConfig({ clerk: { timezone: "Australia/Melbourne" } }),
+    );
+    const clerk = agents.find((a) => a.name === "clerk");
+    expect(clerk?.timezone).toBe("Australia/Melbourne");
   });
 });
 

--- a/tests/timezone-hook.test.ts
+++ b/tests/timezone-hook.test.ts
@@ -54,7 +54,15 @@ describe("timezone-hook.sh", () => {
     expect(ctx).toMatch(/Current local time:/);
     expect(ctx).toMatch(/WARNING/);
     expect(ctx).toMatch(/SWITCHROOM_TIMEZONE unset/);
-    expect(ctx).toMatch(/switchroom systemd install/);
+    // The remediation hint pivoted in #1198: the legacy systemd unit
+    // path is gone (#906 removed `switchroom systemd install`), and the
+    // new wiring lives in the compose `environment:` block. Hint must
+    // point at the compose path now.
+    expect(ctx).toMatch(/compose env may be stale/);
+    expect(ctx).toMatch(/switchroom apply/);
+    expect(ctx).toMatch(/switchroom agent restart/);
+    // Regression pin: the legacy systemd verb is gone.
+    expect(ctx).not.toMatch(/switchroom systemd install/);
     // Still falls back to UTC so the base time string is meaningful.
     expect(ctx).toMatch(/UTC/);
   });


### PR DESCRIPTION
Closes #1198.

## Summary

Agent containers ran without `TZ` or `SWITCHROOM_TIMEZONE`, inheriting the Debian base image's `Etc/UTC` default. In-container `node-cron` therefore evaluated every cron expression against UTC — `0 8 * * *` fired at 08:00 UTC instead of 08:00 in the operator's local zone, a 10–11 hour skew for Australia/Melbourne. Confirmed in production: `clerk`'s morning brief fired at 6pm Melbourne on 2026-05-13.

`resolveTimezone` already existed and walked the cascade (agent → profile → switchroom → server detect → UTC), but its output never reached the container. Pre-v0.7 it was consumed by `generateUnit` to bake `TZ=` / `SWITCHROOM_TIMEZONE=` into the systemd `[Service]` block. PR #906 removed `generateUnit` along with the entire systemd path, but the equivalent compose wiring was never added. `resolveTimezone` silently became dead code for production — only the scaffold-time CLI warning and the USER.md.hbs template still consumed it.

## Changes

- `src/agents/compose.ts`
  - `AgentServiceData` carries a new `timezone: string` field, populated by `resolveTimezone(config, resolved)` in `describeAgents()`.
  - `emitAgentService` emits both `TZ` and `SWITCHROOM_TIMEZONE` unconditionally (resolver always returns a valid IANA string; UTC is its only fallback).
- `bin/timezone-hook.sh`
  - Warning text when `SWITCHROOM_TIMEZONE` is unset no longer references the removed `switchroom systemd install` verb. Points at `switchroom apply && switchroom agent restart <agent>` — the actual remediation path under the Docker runtime.
  - Docstring updated for the same reason (systemd → compose env).
- Tests: 5 new in `tests/docker/compose-generator.test.ts` (agent-layer, global-layer, per-agent override, always-emitted, `describeAgents` exposure). Existing `tests/timezone-hook.test.ts` updated to assert the new warning phrasing and pin that `switchroom systemd install` is gone.

## Test plan

- [x] `bunx vitest run tests/docker/compose-generator.test.ts` → 114 passed
- [x] `bunx vitest run tests/timezone-hook.test.ts` → 5 passed
- [x] Full vitest pass → 5785 passed, 1 skipped, 0 failed
- [ ] On-host verification post-merge: `switchroom apply && switchroom restart all`, then `docker exec switchroom-clerk env | grep -E "TZ=|SWITCHROOM_TIMEZONE"` should show the resolved zone; `docker exec switchroom-clerk date` should show local time
- [ ] `clerk`'s next `0 8 * * *` morning brief should fire at 08:00 local (22:00 UTC during AEDT, 21:00 UTC during AEST), not 08:00 UTC

## Out of scope

- The remaining systemd references in `src/cli/agent.ts` user-visible help text and `src/config/schema.ts` TZ description are tracked in #1193 (broader docs sweep).
- Per-cron-index ACL granularity loss is tracked in #1192.

## Severity

P1. Silent wrong-by-10-to-11-hours on every scheduled task and every time-aware reasoning prompt since the v0.6→v0.7 migration.