### PR TITLE
fix(hostd): chmod dirs to 0o755 so the operator can traverse for existsSync

### DIFF
--- a/src/host-control/server.ts
+++ b/src/host-control/server.ts
@@ -103,7 +103,17 @@ export class HostdServer {
   async start(): Promise<void> {
     const hostdDir = join(this.opts.homeDir, ".switchroom", "hostd");
     await mkdir(hostdDir, { recursive: true });
-    await chmod(hostdDir, 0o700).catch(() => undefined);
+    // 0o755 (not 0o700) so the operator's compose generator can
+    // existsSync(<hostdDir>/<agentName>) at apply time — the dir
+    // listing is needed to emit the per-agent bind mount into the
+    // agent service. Confidentiality of incoming connections is
+    // enforced by the SOCKET mode (0o660) + chown-to-agent-uid below,
+    // not by the dir mode. The dir only ever contains other agent
+    // subdirs + sockets, all of which are themselves access-controlled.
+    // Pre-fix the daemon bound sockets but compose silently skipped
+    // every bind mount because the operator's uid couldn't traverse
+    // a root-owned 0700 dir, so no agent could ever reach the daemon.
+    await chmod(hostdDir, 0o755).catch(() => undefined);
 
     const agentNames = Object.keys(this.opts.agentUids).sort();
     if (agentNames.length === 0) {
@@ -125,7 +135,10 @@ export class HostdServer {
         const dir = join(hostdDir, name);
         const sockPath = join(dir, "sock");
         await mkdir(dir, { recursive: true });
-        await chmod(dir, 0o700).catch(() => undefined);
+        // Same rationale as the parent dir above: 0o755 so the
+        // operator's `existsSync(<dir>)` in compose.ts succeeds;
+        // socket-level mode + chown is the security boundary.
+        await chmod(dir, 0o755).catch(() => undefined);
         if (existsSync(sockPath)) await unlink(sockPath).catch(() => undefined);
 
         const server = createServer((socket) =>

--- a/tests/host-control/server.test.ts
+++ b/tests/host-control/server.test.ts
@@ -5,7 +5,7 @@
  */
 
 import { describe, it, expect, beforeAll, afterAll, beforeEach } from "vitest";
-import { mkdtempSync, writeFileSync, chmodSync, rmSync, mkdirSync } from "node:fs";
+import { mkdtempSync, writeFileSync, chmodSync, rmSync, mkdirSync, statSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { HostdServer } from "../../src/host-control/server.js";
@@ -56,6 +56,26 @@ describe("hostd server — startup & socket binding", () => {
     expect(bound).toHaveLength(2);
     expect(bound.some((p) => p.endsWith("/klanker/sock"))).toBe(true);
     expect(bound.some((p) => p.endsWith("/bob/sock"))).toBe(true);
+  });
+
+  it("parent hostd dir and per-agent dirs are 0755 so the operator can traverse", () => {
+    // Regression for the silent-bind-mount-skip bug: when the daemon
+    // ran the parent dir was created 0o700 (root-only). The compose
+    // generator runs as the operator's uid and calls
+    // existsSync(<hostdDir>/<agentName>) at apply time — with 0o700
+    // root-owned, the operator's uid can't traverse and the
+    // existsSync returns false, so compose silently omits the bind
+    // mount. Result: agent containers had no /run/switchroom/hostd/
+    // <name>/sock and could never reach the daemon. 0o755 fixes the
+    // traversal while the socket-level mode (0o660 + chown-to-agent)
+    // keeps the actual security boundary intact.
+    const parent = join(tmp, ".switchroom", "hostd");
+    const klankerDir = join(parent, "klanker");
+    const bobDir = join(parent, "bob");
+    // & 0o777 to drop the file-type bits and compare just the mode.
+    expect(statSync(parent).mode & 0o777).toBe(0o755);
+    expect(statSync(klankerDir).mode & 0o777).toBe(0o755);
+    expect(statSync(bobDir).mode & 0o777).toBe(0o755);
   });
 
   it("rebinds on a fresh start after stop (idempotent unlink)", async () => {


### PR DESCRIPTION
## Discovered during the klanker hostd standup

The daemon bound per-agent sockets fine but no agent could reach them. Root cause: `src/host-control/server.ts:106,128` chmod'd both the parent `~/.switchroom/hostd/` AND each per-agent `<name>/` dir to **0o700** (root-only).

The compose generator runs as the operator's uid, not root. It calls `existsSync(<hostdDir>/<agentName>)` at apply time before emitting the per-agent bind mount. With 0o700 root-owned dirs, the operator's uid couldn't traverse → existsSync returned false → compose silently omitted every hostd bind mount → agents had no `/run/switchroom/hostd/<name>/sock` in their containers.

## Fix

chmod 0o755 on both dirs. The socket file itself stays 0o660 + chowned to the agent's uid (server.ts:142-148), so only the owning agent can connect. 0o755 just lets `stat` and listings work cross-uid.

**What 0o755 newly exposes:** the list of admin-flagged agent names. Same info already visible from \`ls ~/.switchroom/agents/\` and from \`docker inspect\`. Net-new exposure: zero.

## Test

`tests/host-control/server.test.ts` adds one regression: assert both the parent and per-agent dirs are 0o755 after `start()`. Exercises the cross-uid traversal invariant compose.ts depends on, without needing a non-root uid in the test runner.

16/16 server tests pass.

## Test plan

- [x] `npx vitest run tests/host-control/server.test.ts` — 16/16 pass
- [x] `npm run lint` — clean against my diff
- [x] Manually verified end-to-end against running klanker on the canonical fleet — `agent_restart` now reaches docker correctly after the bind mount is wired

🤖 Generated with [Claude Code](https://claude.com/claude-code)