### PR TITLE
fix(hostd): use bun (not node) in switchroom CLI shim

### DIFF
--- a/docker/Dockerfile.hostd
+++ b/docker/Dockerfile.hostd
@@ -77,8 +77,13 @@ COPY dist/cli/switchroom.js /opt/switchroom/dist/cli/switchroom.js
 COPY dist/host-control/main.js /opt/switchroom/dist/host-control/main.js
 
 # Tiny wrapper so `switchroom <verb>` invocations from hostd resolve
-# to the bundled CLI. Mirrors the host's ~/.bun/bin/switchroom shim.
-RUN printf '#!/bin/sh\nexec node /opt/switchroom/dist/cli/switchroom.js "$@"\n' \
+# to the bundled CLI. Uses `bun` (not `node`) because the CLI bundle
+# imports bun-specific modules (bun:sqlite, bun:test, etc. — produced
+# by scripts/build.mjs's bundling pass that marks bun: imports as
+# externals). Node throws ERR_UNSUPPORTED_ESM_URL_SCHEME on load.
+# Mirrors the host's ~/.bun/bin/switchroom shim and the broker image's
+# CMD which also runs under bun.
+RUN printf '#!/bin/sh\nexec bun /opt/switchroom/dist/cli/switchroom.js "$@"\n' \
     > /usr/local/bin/switchroom \
  && chmod 0755 /usr/local/bin/switchroom
 


### PR DESCRIPTION
## Bug found during canonical-host migration

The switchroom CLI bundle imports bun-specific modules (\`bun:sqlite\`, \`bun:test\`) — \`scripts/build.mjs\` marks the \`bun:\` namespace as external during bundling. Running under node:

\`\`\`
ERR_UNSUPPORTED_ESM_URL_SCHEME — Received protocol 'bun:'
\`\`\`

Hostd's spawned \`switchroom <verb>\` shellouts crashed on every call. Verified end-to-end: socket reached, request parsed, child spawned, child crashed on import. The renderer tests didn't catch this because they don't exercise the docker entrypoint.

## Fix

Update the shim at \`/usr/local/bin/switchroom\` in \`docker/Dockerfile.hostd\` to exec \`bun\` not \`node\`. Bun is already in \`switchroom/base\` (broker uses it). One-line change.

The hostd entrypoint itself (\`dist/host-control/main.js\`) is a node-target bundle and still runs via the Dockerfile's CMD. Only the shellout shim flips to bun.

🤖 Generated with [Claude Code](https://claude.com/claude-code)