### PR TITLE
fix(#1200): TS errors on main — overlay loader reads wrong config path + MockInstance type

### DIFF
--- a/src/cli/agent-config.test.ts
+++ b/src/cli/agent-config.test.ts
@@ -197,9 +197,17 @@ function buildProgram(): Command {
 describe("registered commands", () => {
   let stdout = "";
   let stderr = "";
-  let outSpy: ReturnType<typeof vi.spyOn>;
-  let errSpy: ReturnType<typeof vi.spyOn>;
-  let exitSpy: ReturnType<typeof vi.spyOn>;
+  // `vi.spyOn` returns a narrowly-typed MockInstance whose generic param
+  // matches the spied method's signature. The bare `ReturnType<typeof
+  // vi.spyOn>` defaults the generic to `(this: unknown, ...args:
+  // unknown[]) => unknown` which is incompatible with the specific
+  // `process.stdout.write` / `process.exit` overloads. Use `unknown` and
+  // narrow at use-site via the spy methods (`.mockImplementation`,
+  // `.mockRestore`) which are available on every MockInstance flavour.
+  // (#1200 fix — TS2322.)
+  let outSpy: unknown;
+  let errSpy: unknown;
+  let exitSpy: unknown;
   let prevAuditHome: string | undefined;
   let tmpHome: string;
 
@@ -234,9 +242,13 @@ describe("registered commands", () => {
   });
 
   afterEach(() => {
-    outSpy.mockRestore();
-    errSpy.mockRestore();
-    exitSpy.mockRestore();
+    // outSpy/errSpy/exitSpy are typed `unknown` to dodge the
+    // MockInstance generic-default incompatibility (see beforeEach
+    // declaration). `mockRestore` exists on every MockInstance —
+    // narrow via a minimal interface cast.
+    (outSpy as { mockRestore: () => void }).mockRestore();
+    (errSpy as { mockRestore: () => void }).mockRestore();
+    (exitSpy as { mockRestore: () => void }).mockRestore();
     if (prevAuditHome) process.env.HOME = prevAuditHome;
     delete process.env.SWITCHROOM_AGENT_NAME;
     try {

--- a/src/config/overlay-loader.test.ts
+++ b/src/config/overlay-loader.test.ts
@@ -32,10 +32,14 @@ import type { SwitchroomConfig } from "./schema.js";
 function makeConfig(
   agents: Record<string, { schedule?: unknown[] }>,
 ): SwitchroomConfig {
+  // `agents` lives at the TOP level of `SwitchroomConfig`, alongside
+  // `switchroom`, `telegram`, `defaults`, `profiles` — NOT inside the
+  // inner `switchroom:` block. Pre-#1200 the fixture put it under
+  // `switchroom.agents` (matching the bug in overlay-loader.ts:113
+  // which read `config.switchroom?.agents`), so the test silently
+  // passed against a no-op loader. Both halves fixed together.
   return {
-    switchroom: {
-      agents: agents as Record<string, never>,
-    },
+    agents: agents as Record<string, never>,
   } as unknown as SwitchroomConfig;
 }
 
@@ -72,7 +76,7 @@ describe("applyAgentOverlays", () => {
     });
     const { warnings } = applyAgentOverlays(cfg);
     expect(warnings).toEqual([]);
-    expect(cfg.switchroom.agents.foo.schedule).toHaveLength(1);
+    expect(cfg.agents.foo.schedule).toHaveLength(1);
   });
 
   it("is a no-op when the overlay directory exists but is empty", () => {
@@ -80,7 +84,7 @@ describe("applyAgentOverlays", () => {
     const cfg = makeConfig({ foo: { schedule: [] } });
     const { warnings } = applyAgentOverlays(cfg);
     expect(warnings).toEqual([]);
-    expect(cfg.switchroom.agents.foo.schedule).toEqual([]);
+    expect(cfg.agents.foo.schedule).toEqual([]);
   });
 
   it("appends overlay schedule entries AFTER main-config entries (precedence)", () => {
@@ -94,7 +98,7 @@ describe("applyAgentOverlays", () => {
     });
     const { warnings } = applyAgentOverlays(cfg);
     expect(warnings).toEqual([]);
-    const sched = cfg.switchroom.agents.foo.schedule as Array<{ prompt: string }>;
+    const sched = cfg.agents.foo.schedule as Array<{ prompt: string }>;
     expect(sched).toHaveLength(2);
     expect(sched[0].prompt).toBe("main-entry");
     expect(sched[1].prompt).toBe("overlay-entry");
@@ -107,7 +111,7 @@ describe("applyAgentOverlays", () => {
     writeFileSync(join(dir, "a-first.yaml"), "schedule:\n  - cron: '0 1 * * *'\n    prompt: first\n");
     const cfg = makeConfig({ foo: { schedule: [] } });
     applyAgentOverlays(cfg);
-    const sched = cfg.switchroom.agents.foo.schedule as Array<{ prompt: string }>;
+    const sched = cfg.agents.foo.schedule as Array<{ prompt: string }>;
     expect(sched.map((e) => e.prompt)).toEqual(["first", "second"]);
   });
 
@@ -119,7 +123,7 @@ describe("applyAgentOverlays", () => {
     const cfg = makeConfig({ foo: { schedule: [] } });
     const { warnings } = applyAgentOverlays(cfg);
     expect(warnings).toEqual([]);
-    expect(cfg.switchroom.agents.foo.schedule).toHaveLength(1);
+    expect(cfg.agents.foo.schedule).toHaveLength(1);
   });
 
   it("accepts both .yaml and .yml extensions", () => {
@@ -127,7 +131,7 @@ describe("applyAgentOverlays", () => {
     writeFileSync(join(dir, "a.yml"), "schedule:\n  - cron: '0 1 * * *'\n    prompt: from-yml\n");
     const cfg = makeConfig({ foo: { schedule: [] } });
     applyAgentOverlays(cfg);
-    expect(cfg.switchroom.agents.foo.schedule).toHaveLength(1);
+    expect(cfg.agents.foo.schedule).toHaveLength(1);
   });
 
   it("emits a warning and isolates the file when YAML is malformed", () => {
@@ -140,7 +144,7 @@ describe("applyAgentOverlays", () => {
     expect(warnings[0].file).toMatch(/broken\.yaml$/);
     expect(warnings[0].reason).toMatch(/parse error|schema/i);
     // Good file still loaded.
-    expect(cfg.switchroom.agents.foo.schedule).toHaveLength(1);
+    expect(cfg.agents.foo.schedule).toHaveLength(1);
     expect(warnSpy).toHaveBeenCalled();
   });
 
@@ -166,7 +170,7 @@ describe("applyAgentOverlays", () => {
     const { warnings } = applyAgentOverlays(cfg);
     expect(warnings).toHaveLength(1);
     expect(warnings[0].reason).toMatch(/schema rejection/);
-    expect(cfg.switchroom.agents.foo.schedule).toEqual([]);
+    expect(cfg.agents.foo.schedule).toEqual([]);
   });
 
   it("drops overlay entries that declare secrets, with a warning", () => {
@@ -185,7 +189,7 @@ describe("applyAgentOverlays", () => {
     const { warnings } = applyAgentOverlays(cfg);
     expect(warnings).toHaveLength(1);
     expect(warnings[0].reason).toMatch(/secrets/);
-    const sched = cfg.switchroom.agents.foo.schedule as Array<{ prompt: string }>;
+    const sched = cfg.agents.foo.schedule as Array<{ prompt: string }>;
     expect(sched).toHaveLength(1);
     expect(sched[0].prompt).toBe("clean-entry");
   });
@@ -201,7 +205,7 @@ describe("applyAgentOverlays", () => {
     });
     const { warnings } = applyAgentOverlays(cfg);
     expect(warnings.some((w) => w.agent === "agent-x")).toBe(true);
-    expect(cfg.switchroom.agents["agent-y"].schedule).toHaveLength(1);
+    expect(cfg.agents["agent-y"].schedule).toHaveLength(1);
   });
 
   it("handles agents with no schedule (treats undefined as empty)", () => {
@@ -209,7 +213,7 @@ describe("applyAgentOverlays", () => {
     writeFileSync(join(dir, "a.yaml"), "schedule:\n  - cron: '0 1 * * *'\n    prompt: only\n");
     const cfg = makeConfig({ foo: {} });
     applyAgentOverlays(cfg);
-    expect(cfg.switchroom.agents.foo.schedule).toHaveLength(1);
+    expect(cfg.agents.foo.schedule).toHaveLength(1);
   });
 
   it("stamps overlay-sourced entries with the OVERLAY_SOURCE symbol (non-enumerable)", () => {
@@ -219,7 +223,7 @@ describe("applyAgentOverlays", () => {
       foo: { schedule: [{ cron: "0 0 * * *", prompt: "main", secrets: [] }] },
     });
     applyAgentOverlays(cfg);
-    const sched = cfg.switchroom.agents.foo.schedule as Array<Record<symbol, unknown>>;
+    const sched = cfg.agents.foo.schedule as Array<Record<symbol, unknown>>;
     // Main entry not stamped.
     expect(sched[0][OVERLAY_SOURCE]).toBeUndefined();
     // Overlay entry stamped.
@@ -235,7 +239,7 @@ describe("applyAgentOverlays", () => {
     const cfg = makeConfig({ foo: { schedule: [] } });
     const { warnings } = applyAgentOverlays(cfg);
     expect(warnings).toEqual([]);
-    expect(cfg.switchroom.agents.foo.schedule).toEqual([]);
+    expect(cfg.agents.foo.schedule).toEqual([]);
   });
 
   it("returns the config object it was given (mutates in place)", () => {

--- a/src/config/overlay-loader.ts
+++ b/src/config/overlay-loader.ts
@@ -110,7 +110,13 @@ function stampOverlay(entry: ScheduleEntry): ScheduleEntry {
  */
 export function applyAgentOverlays(config: SwitchroomConfig): ApplyOverlaysResult {
   const warnings: OverlayWarning[] = [];
-  const agents = config.switchroom?.agents ?? {};
+  // `agents` lives at the top level of `SwitchroomConfig` alongside
+  // `switchroom`, `telegram`, `defaults`, `profiles` — NOT inside the
+  // inner `switchroom:` block. Pre-fix this read `config.switchroom?.
+  // agents` which always returned undefined, so the overlay loader
+  // silently became a no-op for every agent. Caught by #1200 (TS error
+  // TS2339 + 19 cascading failures, CI red since #1182/#1187 landed).
+  const agents = config.agents ?? {};
 
   for (const [agentName, agentCfg] of Object.entries(agents)) {
     try {


### PR DESCRIPTION
Closes #1200. 19 TS errors → 0.

## Bug A — wrong config path read (16 errors)
\`src/config/overlay-loader.ts:113\` read \`config.switchroom?.agents\` but \`agents\` lives at the TOP level of \`SwitchroomConfig\`. The test fixture (\`overlay-loader.test.ts\`) made the same mistake when building \`makeConfig()\`, so both halves passed (against a no-op loader). **Severity:** the overlay-merger has been silently non-functional on main since #1187 merged — every overlay file was globbed/parsed but the results were written into a never-read object.

## Bug B — MockInstance type (3 errors)
\`src/cli/agent-config.test.ts:200-202\` — \`ReturnType<typeof vi.spyOn>\` defaults its generic to a too-narrow signature. Type as \`unknown\` + narrow at use-site.

## Test plan
- [x] \`npm run lint\` — 0 errors
- [x] overlay-loader.test.ts 13/13 + agent-config.test.ts 26/26 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)