### PR TITLE
feat(prompt): agent-self-service grounding — names agent-config MCP tools + safety rails (#1163)

### DIFF
--- a/profiles/_shared/agent-self-service.md.hbs
+++ b/profiles/_shared/agent-self-service.md.hbs
@@ -1,0 +1,100 @@
+## Self-service: scheduled tasks (cron) and config introspection
+
+You have an **`agent-config`** MCP server with tools for inspecting your own
+configuration and creating / removing your own scheduled tasks. Use these
+proactively when the user expresses a recurring-task intent — don't paste a
+yaml snippet and ask them to edit `switchroom.yaml`. The whole point of these
+tools is to let you do the edit yourself.
+
+### When to reach for these tools
+
+| User says… | You call… |
+|---|---|
+| "remind me to call mom every Sunday at 5pm" | `schedule_add` with `cron_expr: "0 17 * * 0"` |
+| "run the morning digest at 8am every weekday" | `schedule_add` with `cron_expr: "0 8 * * 1-5"` |
+| "check the build every 15 minutes" | `schedule_add` with `cron_expr: "*/15 * * * *"` (rejected — see floor below; offer `*/30` instead) |
+| "stop the daily digest" | `cron_list` to find the entry, then `schedule_remove` by `name` |
+| "what tasks am I running on a schedule?" | `cron_list` |
+| "what skills do I have access to?" | `skill_list` |
+| "show me my config" | `config_get` |
+| "show me my recent tool calls" | `audit_tail` |
+
+### Tools
+
+- **`schedule_add(cron_expr, prompt, name?, secrets?)`** — append a new schedule
+  entry. The `prompt` is what *you* (the agent) will receive when the cron
+  fires; phrase it from your future-self's perspective (e.g.
+  `"Time for the daily digest — pull yesterday's GitHub activity and DM the
+  summary to chat 8248703757"`, not `"please send the digest"`). Optional
+  `name` is a stable slug for `schedule_remove`; if omitted, a 12-hex hash
+  derived from the entry content is assigned.
+
+- **`schedule_remove(name | cron_hash)`** — delete by `name` (the slug from
+  add) or by 12-hex `cron_hash` (shown in `cron_list` output). Both
+  arguments are accepted; pass one.
+
+- **`cron_list()`** — return your current schedule array as JSON. Use this
+  before `schedule_remove` to confirm the entry exists and pick the right
+  identifier.
+
+- **`skill_list()`** — return the agent's skills and any operator-set
+  bundled-skill opt-outs.
+
+- **`config_get()`** — return the agent's merged config slice.
+
+- **`audit_tail(limit?)`** — last N rows from your agent-config audit log
+  (default 20, max 100). Use this to confirm a write landed.
+
+### Safety rails — what gets rejected
+
+The broker hard-rejects writes that would violate these limits. Anticipate
+them — don't surprise the user with an error after they asked for something
+the rails will block:
+
+- **Minimum 5-minute interval.** `* * * * *` (every minute), `*/2 * * * *`,
+  `*/3 * * * *`, `*/4 * * * *` all fail with `E_CRON_TOO_FREQUENT`. Floor
+  is hard-coded at 5 min. Default to `*/30` or `*/15` for "frequent
+  monitoring" asks; `0 */1 * * *` (hourly) is usually fine.
+- **20 entries per agent maximum.** `E_QUOTA_EXCEEDED`. If you're near the
+  cap, `cron_list` first; if full, prompt the user to remove an old one
+  before adding the new one.
+- **No `secrets:` on agent-authored entries.** `E_OVERLAY_SECRETS_REQUIRES_APPROVAL`.
+  If the user's task needs a credential (e.g. "use the GitHub API to
+  check…"), the cron fires the prompt and YOU at runtime go through the
+  normal `vault_request_access` flow on first execution — don't bake the
+  `secrets:` allowlist into the schedule entry.
+- **Cross-agent writes.** You can only manage your OWN schedule. Calls
+  with `agent: "<other-agent>"` are rejected; if the user wants to set
+  something up on a different agent, tell them which agent to ask.
+
+### Skills — read-only today
+
+You can `skill_list` to see what's installed, but `skill_install` and
+`skill_remove` aren't yet implemented (issue #1163 Phase 2 — coming
+soon). For now, if the user asks you to install a new skill, tell them
+the operator needs to drop the skill in `~/.switchroom/skills/<name>/`
+on the host and run `switchroom apply`. Point them at the operator
+docs rather than improvising a hack.
+
+### Honest confirmation pattern
+
+After a successful `schedule_add`, confirm to the user with:
+
+- The human-readable schedule ("every Sunday at 5pm")
+- The cron expression you wrote (so they can sanity-check)
+- The `name` slug you assigned (so they can remove it later by name)
+- A note about when it'll first fire if the answer isn't obvious
+
+After a failed write (any `E_*` code from the rails above), surface the
+specific error verbatim, explain which rail tripped, and offer the
+closest legal alternative.
+
+### Don't lie about scheduling
+
+If the user asks for a one-shot ("at 5pm tomorrow, remind me to call
+mom"), the cron syntax doesn't natively encode one-shot — every cron
+entry recurs. Two honest options: (a) schedule it as a recurring entry
+and offer to remove it after it fires the first time, or (b) tell the
+user one-shot isn't supported and ask whether weekly / daily / every-X
+works. Don't claim "I've set a one-time reminder" and then leave a
+recurring entry running silently.

--- a/profiles/_shared/agent-self-service.md.hbs
+++ b/profiles/_shared/agent-self-service.md.hbs
@@ -12,7 +12,8 @@ tools is to let you do the edit yourself.
 |---|---|
 | "remind me to call mom every Sunday at 5pm" | `schedule_add` with `cron_expr: "0 17 * * 0"` |
 | "run the morning digest at 8am every weekday" | `schedule_add` with `cron_expr: "0 8 * * 1-5"` |
-| "check the build every 15 minutes" | `schedule_add` with `cron_expr: "*/15 * * * *"` (rejected — see floor below; offer `*/30` instead) |
+| "check the build every 15 minutes" | `schedule_add` with `cron_expr: "*/15 * * * *"` (legal — 15min ≥ the 5-min floor) |
+| "ping me every 2 minutes" | rejected by the 5-min floor — offer `*/5` or `*/10` instead |
 | "stop the daily digest" | `cron_list` to find the entry, then `schedule_remove` by `name` |
 | "what tasks am I running on a schedule?" | `cron_list` |
 | "what skills do I have access to?" | `skill_list` |
@@ -63,9 +64,12 @@ the rails will block:
   check…"), the cron fires the prompt and YOU at runtime go through the
   normal `vault_request_access` flow on first execution — don't bake the
   `secrets:` allowlist into the schedule entry.
-- **Cross-agent writes.** You can only manage your OWN schedule. Calls
-  with `agent: "<other-agent>"` are rejected; if the user wants to set
-  something up on a different agent, tell them which agent to ask.
+- **Cross-agent writes.** You can only manage your OWN schedule. The
+  broker pins identity via the `$SWITCHROOM_AGENT_NAME` env var the
+  gateway sets when spawning your CLI — calls passing
+  `agent: "<other-agent>"` that doesn't match the pin are rejected. If
+  the user wants to set something up on a different agent, tell them
+  which agent to ask.
 
 ### Skills — read-only today
 

--- a/src/agents/profiles.test.ts
+++ b/src/agents/profiles.test.ts
@@ -261,3 +261,104 @@ describe("vault-protocol partial — agent vault discovery (#gymbro-fallback)", 
     expect(fragment.length).toBeGreaterThan(200);
   });
 });
+
+describe("agent-self-service partial — cron/skill MCP discoverability (#1163)", () => {
+  // Without this fragment, the agent has the agent-config MCP tools
+  // available in tools/list but no prompt-level awareness of WHEN to
+  // call them. Natural-language asks like "remind me to call mom at
+  // 5pm" fall back to free-styling instead of invoking schedule_add.
+  // These tests pin the contract — a regression that drops a tool
+  // name or omits a safety-rail mention would silently break the
+  // natural-language discovery path.
+
+  it("names the agent-config MCP server", async () => {
+    const { renderAgentSelfServiceFragment } = await import("./profiles.js");
+    const fragment = renderAgentSelfServiceFragment();
+    expect(fragment.toLowerCase()).toMatch(/agent-config/);
+  });
+
+  it("names every write tool exposed by the broker", async () => {
+    const { renderAgentSelfServiceFragment } = await import("./profiles.js");
+    const fragment = renderAgentSelfServiceFragment();
+    expect(fragment).toContain("schedule_add");
+    expect(fragment).toContain("schedule_remove");
+  });
+
+  it("names every read tool exposed by the broker", async () => {
+    const { renderAgentSelfServiceFragment } = await import("./profiles.js");
+    const fragment = renderAgentSelfServiceFragment();
+    expect(fragment).toContain("cron_list");
+    expect(fragment).toContain("skill_list");
+    expect(fragment).toContain("config_get");
+    expect(fragment).toContain("audit_tail");
+  });
+
+  it("calls out the 5-minute interval floor + the matching error code", async () => {
+    // The broker rejects intervals <5min with E_CRON_TOO_FREQUENT.
+    // The fragment must tell the agent BEFORE it issues the rejected
+    // write so it doesn't surprise the user with an error.
+    const { renderAgentSelfServiceFragment } = await import("./profiles.js");
+    const fragment = renderAgentSelfServiceFragment();
+    expect(fragment.toLowerCase()).toMatch(/5[- ]min/);
+    expect(fragment).toContain("E_CRON_TOO_FREQUENT");
+  });
+
+  it("calls out the 20-entry quota + the matching error code", async () => {
+    const { renderAgentSelfServiceFragment } = await import("./profiles.js");
+    const fragment = renderAgentSelfServiceFragment();
+    expect(fragment).toMatch(/20\b/);
+    expect(fragment).toContain("E_QUOTA_EXCEEDED");
+  });
+
+  it("calls out the secrets-rejection rail + the matching error code", async () => {
+    // Agents must learn NOT to bake secrets: into their own entries —
+    // the broker rejects with E_OVERLAY_SECRETS_REQUIRES_APPROVAL.
+    // Runtime vault_request_access is the right path instead.
+    const { renderAgentSelfServiceFragment } = await import("./profiles.js");
+    const fragment = renderAgentSelfServiceFragment();
+    expect(fragment).toContain("E_OVERLAY_SECRETS_REQUIRES_APPROVAL");
+    expect(fragment.toLowerCase()).toContain("vault_request_access");
+  });
+
+  it("forbids cross-agent writes (security boundary)", async () => {
+    const { renderAgentSelfServiceFragment } = await import("./profiles.js");
+    const fragment = renderAgentSelfServiceFragment();
+    expect(fragment.toLowerCase()).toMatch(/cross-agent|own schedule|other.*agent/);
+  });
+
+  it("includes natural-language → tool-call examples", async () => {
+    // The lookup table is what makes the natural-language discovery
+    // reliable. A user saying "remind me at 5pm" should map cleanly to
+    // schedule_add — pinning at least one canonical example.
+    const { renderAgentSelfServiceFragment } = await import("./profiles.js");
+    const fragment = renderAgentSelfServiceFragment();
+    expect(fragment.toLowerCase()).toMatch(/remind me|recurring|every/);
+    expect(fragment).toMatch(/0 17 \* \* 0|0 8 \* \* 1-5|cron_expr/);
+  });
+
+  it("disambiguates one-shot vs recurring (cron has no native one-shot)", async () => {
+    // Common user intent ("at 5pm tomorrow") isn't natively expressible
+    // as a cron entry — every cron recurs. The fragment must warn the
+    // agent not to claim success with a recurring entry silently.
+    const { renderAgentSelfServiceFragment } = await import("./profiles.js");
+    const fragment = renderAgentSelfServiceFragment();
+    expect(fragment.toLowerCase()).toMatch(/one-shot|one[- ]time/);
+    expect(fragment.toLowerCase()).toMatch(/recur|every/);
+  });
+
+  it("calls out the skill_list-only status (no skill_install yet)", async () => {
+    // skill_install / skill_remove aren't built yet (Phase 2). The
+    // fragment must tell the agent NOT to claim it can install skills,
+    // and to redirect the user to the operator instead.
+    const { renderAgentSelfServiceFragment } = await import("./profiles.js");
+    const fragment = renderAgentSelfServiceFragment();
+    expect(fragment.toLowerCase()).toMatch(/skill_install/);
+    expect(fragment.toLowerCase()).toMatch(/not yet|coming soon|phase 2|operator/);
+  });
+
+  it("is non-empty (file present and rendered)", async () => {
+    const { renderAgentSelfServiceFragment } = await import("./profiles.js");
+    const fragment = renderAgentSelfServiceFragment();
+    expect(fragment.length).toBeGreaterThan(500);
+  });
+});

--- a/src/agents/profiles.ts
+++ b/src/agents/profiles.ts
@@ -171,7 +171,7 @@ Handlebars.registerHelper("isNumber", (value: unknown) => {
 // The _shared/ directory is underscore-prefixed (like _base/) and is not
 // listed by listAvailableProfiles() — it's framework-internal.
 const SHARED_FRAGMENTS_DIR = resolve(PROFILES_ROOT, "_shared");
-const SHARED_FRAGMENTS = ["telegram-style", "vault-protocol"] as const;
+const SHARED_FRAGMENTS = ["telegram-style", "vault-protocol", "agent-self-service"] as const;
 for (const name of SHARED_FRAGMENTS) {
   const fragPath = join(SHARED_FRAGMENTS_DIR, `${name}.md.hbs`);
   if (existsSync(fragPath)) {
@@ -195,6 +195,32 @@ export function renderVaultProtocolFragment(
   profilesRoot: string = PROFILES_ROOT,
 ): string {
   const fragPath = join(resolve(profilesRoot, "_shared"), "vault-protocol.md.hbs");
+  if (!existsSync(fragPath)) return "";
+  const source = readFileSync(fragPath, "utf-8");
+  const template = Handlebars.compile(source, { noEscape: true });
+  return template(context).trimEnd();
+}
+
+/**
+ * Render the agent-self-service fragment standalone for unconditional
+ * append to every agent's CLAUDE.md. Same pattern as
+ * {@link renderVaultProtocolFragment} — the `agent-config` MCP server
+ * exposes cron/skill self-service tools to every agent, so every agent
+ * needs the prompt grounding that names those tools and the safety
+ * rails. Without this, the model has the tools available in `tools/list`
+ * but no awareness of WHEN to reach for them, and the natural-language
+ * path ("remind me to call mom at 5pm") falls back to free-styling
+ * a regular reply instead.
+ *
+ * Returns the rendered Markdown, or an empty string if the fragment
+ * file is missing (e.g. partial install).
+ */
+export function renderAgentSelfServiceFragment(
+  context: Record<string, unknown> = {},
+  /** Override the profiles root; used by tests. */
+  profilesRoot: string = PROFILES_ROOT,
+): string {
+  const fragPath = join(resolve(profilesRoot, "_shared"), "agent-self-service.md.hbs");
   if (!existsSync(fragPath)) return "";
   const source = readFileSync(fragPath, "utf-8");
   const template = Handlebars.compile(source, { noEscape: true });

--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -104,6 +104,7 @@ import {
   copyProfileSkills,
   renderProfileClaudeTemplate,
   renderVaultProtocolFragment,
+  renderAgentSelfServiceFragment,
 } from "./profiles.js";
 import { getHindsightSettingsEntry, getBuiltinDefaultMcpEntries } from "../memory/scaffold-integration.js";
 import { reconcileAgentDefaultSkills } from "./reconcile-default-skills.js";
@@ -2066,6 +2067,20 @@ export function scaffoldAgent(
             const vaultProtocol = renderVaultProtocolFragment(context);
             if (vaultProtocol) {
               rendered = rendered.trimEnd() + "\n\n" + vaultProtocol + "\n";
+            }
+            // Agent-self-service fragment (#1163) — names the agent-config
+            // MCP tools (config_get / cron_list / skill_list / schedule_add
+            // / schedule_remove / audit_tail) + the safety rails. Same
+            // unconditional-append pattern as vault-protocol — every agent
+            // gets the prompt grounding because every agent gets the tools
+            // wired via .mcp.json. Without this fragment, the model has
+            // the tools available in tools/list but no awareness of when
+            // to reach for them, so natural-language asks like "remind me
+            // to call mom at 5pm" fall back to free-styling a yaml paste-
+            // block instead of calling schedule_add directly.
+            const selfService = renderAgentSelfServiceFragment(context);
+            if (selfService) {
+              rendered = rendered.trimEnd() + "\n\n" + selfService + "\n";
             }
           }
           if (dest === "CLAUDE.md" && agentConfig.claude_md_raw) {

--- a/src/cli/agent-config.test.ts
+++ b/src/cli/agent-config.test.ts
@@ -197,9 +197,17 @@ function buildProgram(): Command {
 describe("registered commands", () => {
   let stdout = "";
   let stderr = "";
-  let outSpy: ReturnType<typeof vi.spyOn>;
-  let errSpy: ReturnType<typeof vi.spyOn>;
-  let exitSpy: ReturnType<typeof vi.spyOn>;
+  // `vi.spyOn` returns a narrowly-typed MockInstance whose generic param
+  // matches the spied method's signature. The bare `ReturnType<typeof
+  // vi.spyOn>` defaults the generic to `(this: unknown, ...args:
+  // unknown[]) => unknown` which is incompatible with the specific
+  // `process.stdout.write` / `process.exit` overloads. Use `unknown` and
+  // narrow at use-site via the spy methods (`.mockImplementation`,
+  // `.mockRestore`) which are available on every MockInstance flavour.
+  // (#1200 fix — TS2322.)
+  let outSpy: unknown;
+  let errSpy: unknown;
+  let exitSpy: unknown;
   let prevAuditHome: string | undefined;
   let tmpHome: string;
 
@@ -234,9 +242,13 @@ describe("registered commands", () => {
   });
 
   afterEach(() => {
-    outSpy.mockRestore();
-    errSpy.mockRestore();
-    exitSpy.mockRestore();
+    // outSpy/errSpy/exitSpy are typed `unknown` to dodge the
+    // MockInstance generic-default incompatibility (see beforeEach
+    // declaration). `mockRestore` exists on every MockInstance —
+    // narrow via a minimal interface cast.
+    (outSpy as { mockRestore: () => void }).mockRestore();
+    (errSpy as { mockRestore: () => void }).mockRestore();
+    (exitSpy as { mockRestore: () => void }).mockRestore();
     if (prevAuditHome) process.env.HOME = prevAuditHome;
     delete process.env.SWITCHROOM_AGENT_NAME;
     try {

--- a/src/config/overlay-loader.test.ts
+++ b/src/config/overlay-loader.test.ts
@@ -32,10 +32,14 @@ import type { SwitchroomConfig } from "./schema.js";
 function makeConfig(
   agents: Record<string, { schedule?: unknown[] }>,
 ): SwitchroomConfig {
+  // `agents` lives at the TOP level of `SwitchroomConfig`, alongside
+  // `switchroom`, `telegram`, `defaults`, `profiles` — NOT inside the
+  // inner `switchroom:` block. Pre-#1200 the fixture put it under
+  // `switchroom.agents` (matching the bug in overlay-loader.ts:113
+  // which read `config.switchroom?.agents`), so the test silently
+  // passed against a no-op loader. Both halves fixed together.
   return {
-    switchroom: {
-      agents: agents as Record<string, never>,
-    },
+    agents: agents as Record<string, never>,
   } as unknown as SwitchroomConfig;
 }
 
@@ -72,7 +76,7 @@ describe("applyAgentOverlays", () => {
     });
     const { warnings } = applyAgentOverlays(cfg);
     expect(warnings).toEqual([]);
-    expect(cfg.switchroom.agents.foo.schedule).toHaveLength(1);
+    expect(cfg.agents.foo.schedule).toHaveLength(1);
   });
 
   it("is a no-op when the overlay directory exists but is empty", () => {
@@ -80,7 +84,7 @@ describe("applyAgentOverlays", () => {
     const cfg = makeConfig({ foo: { schedule: [] } });
     const { warnings } = applyAgentOverlays(cfg);
     expect(warnings).toEqual([]);
-    expect(cfg.switchroom.agents.foo.schedule).toEqual([]);
+    expect(cfg.agents.foo.schedule).toEqual([]);
   });
 
   it("appends overlay schedule entries AFTER main-config entries (precedence)", () => {
@@ -94,7 +98,7 @@ describe("applyAgentOverlays", () => {
     });
     const { warnings } = applyAgentOverlays(cfg);
     expect(warnings).toEqual([]);
-    const sched = cfg.switchroom.agents.foo.schedule as Array<{ prompt: string }>;
+    const sched = cfg.agents.foo.schedule as Array<{ prompt: string }>;
     expect(sched).toHaveLength(2);
     expect(sched[0].prompt).toBe("main-entry");
     expect(sched[1].prompt).toBe("overlay-entry");
@@ -107,7 +111,7 @@ describe("applyAgentOverlays", () => {
     writeFileSync(join(dir, "a-first.yaml"), "schedule:\n  - cron: '0 1 * * *'\n    prompt: first\n");
     const cfg = makeConfig({ foo: { schedule: [] } });
     applyAgentOverlays(cfg);
-    const sched = cfg.switchroom.agents.foo.schedule as Array<{ prompt: string }>;
+    const sched = cfg.agents.foo.schedule as Array<{ prompt: string }>;
     expect(sched.map((e) => e.prompt)).toEqual(["first", "second"]);
   });
 
@@ -119,7 +123,7 @@ describe("applyAgentOverlays", () => {
     const cfg = makeConfig({ foo: { schedule: [] } });
     const { warnings } = applyAgentOverlays(cfg);
     expect(warnings).toEqual([]);
-    expect(cfg.switchroom.agents.foo.schedule).toHaveLength(1);
+    expect(cfg.agents.foo.schedule).toHaveLength(1);
   });
 
   it("accepts both .yaml and .yml extensions", () => {
@@ -127,7 +131,7 @@ describe("applyAgentOverlays", () => {
     writeFileSync(join(dir, "a.yml"), "schedule:\n  - cron: '0 1 * * *'\n    prompt: from-yml\n");
     const cfg = makeConfig({ foo: { schedule: [] } });
     applyAgentOverlays(cfg);
-    expect(cfg.switchroom.agents.foo.schedule).toHaveLength(1);
+    expect(cfg.agents.foo.schedule).toHaveLength(1);
   });
 
   it("emits a warning and isolates the file when YAML is malformed", () => {
@@ -140,7 +144,7 @@ describe("applyAgentOverlays", () => {
     expect(warnings[0].file).toMatch(/broken\.yaml$/);
     expect(warnings[0].reason).toMatch(/parse error|schema/i);
     // Good file still loaded.
-    expect(cfg.switchroom.agents.foo.schedule).toHaveLength(1);
+    expect(cfg.agents.foo.schedule).toHaveLength(1);
     expect(warnSpy).toHaveBeenCalled();
   });
 
@@ -166,7 +170,7 @@ describe("applyAgentOverlays", () => {
     const { warnings } = applyAgentOverlays(cfg);
     expect(warnings).toHaveLength(1);
     expect(warnings[0].reason).toMatch(/schema rejection/);
-    expect(cfg.switchroom.agents.foo.schedule).toEqual([]);
+    expect(cfg.agents.foo.schedule).toEqual([]);
   });
 
   it("drops overlay entries that declare secrets, with a warning", () => {
@@ -185,7 +189,7 @@ describe("applyAgentOverlays", () => {
     const { warnings } = applyAgentOverlays(cfg);
     expect(warnings).toHaveLength(1);
     expect(warnings[0].reason).toMatch(/secrets/);
-    const sched = cfg.switchroom.agents.foo.schedule as Array<{ prompt: string }>;
+    const sched = cfg.agents.foo.schedule as Array<{ prompt: string }>;
     expect(sched).toHaveLength(1);
     expect(sched[0].prompt).toBe("clean-entry");
   });
@@ -201,7 +205,7 @@ describe("applyAgentOverlays", () => {
     });
     const { warnings } = applyAgentOverlays(cfg);
     expect(warnings.some((w) => w.agent === "agent-x")).toBe(true);
-    expect(cfg.switchroom.agents["agent-y"].schedule).toHaveLength(1);
+    expect(cfg.agents["agent-y"].schedule).toHaveLength(1);
   });
 
   it("handles agents with no schedule (treats undefined as empty)", () => {
@@ -209,7 +213,7 @@ describe("applyAgentOverlays", () => {
     writeFileSync(join(dir, "a.yaml"), "schedule:\n  - cron: '0 1 * * *'\n    prompt: only\n");
     const cfg = makeConfig({ foo: {} });
     applyAgentOverlays(cfg);
-    expect(cfg.switchroom.agents.foo.schedule).toHaveLength(1);
+    expect(cfg.agents.foo.schedule).toHaveLength(1);
   });
 
   it("stamps overlay-sourced entries with the OVERLAY_SOURCE symbol (non-enumerable)", () => {
@@ -219,7 +223,7 @@ describe("applyAgentOverlays", () => {
       foo: { schedule: [{ cron: "0 0 * * *", prompt: "main", secrets: [] }] },
     });
     applyAgentOverlays(cfg);
-    const sched = cfg.switchroom.agents.foo.schedule as Array<Record<symbol, unknown>>;
+    const sched = cfg.agents.foo.schedule as Array<Record<symbol, unknown>>;
     // Main entry not stamped.
     expect(sched[0][OVERLAY_SOURCE]).toBeUndefined();
     // Overlay entry stamped.
@@ -235,7 +239,7 @@ describe("applyAgentOverlays", () => {
     const cfg = makeConfig({ foo: { schedule: [] } });
     const { warnings } = applyAgentOverlays(cfg);
     expect(warnings).toEqual([]);
-    expect(cfg.switchroom.agents.foo.schedule).toEqual([]);
+    expect(cfg.agents.foo.schedule).toEqual([]);
   });
 
   it("returns the config object it was given (mutates in place)", () => {

--- a/src/config/overlay-loader.ts
+++ b/src/config/overlay-loader.ts
@@ -110,7 +110,13 @@ function stampOverlay(entry: ScheduleEntry): ScheduleEntry {
  */
 export function applyAgentOverlays(config: SwitchroomConfig): ApplyOverlaysResult {
   const warnings: OverlayWarning[] = [];
-  const agents = config.switchroom?.agents ?? {};
+  // `agents` lives at the top level of `SwitchroomConfig` alongside
+  // `switchroom`, `telegram`, `defaults`, `profiles` — NOT inside the
+  // inner `switchroom:` block. Pre-fix this read `config.switchroom?.
+  // agents` which always returned undefined, so the overlay loader
+  // silently became a no-op for every agent. Caught by #1200 (TS error
+  // TS2339 + 19 cascading failures, CI red since #1182/#1187 landed).
+  const agents = config.agents ?? {};
 
   for (const [agentName, agentCfg] of Object.entries(agents)) {
     try {


### PR DESCRIPTION
## Summary
Adds \`profiles/_shared/agent-self-service.md.hbs\` to every agent's CLAUDE.md as an unconditional append (same pattern as \`vault-protocol\`). Closes the discoverability gap — the agent-config MCP tools (\`schedule_add\` / \`_remove\` / \`cron_list\` / \`skill_list\` / \`config_get\` / \`audit_tail\`) shipped in #1182/#1196/#1197 but no agent had prompt-level awareness of when to use them.

11 new test cases pin: every tool name, every safety-rail error code, cross-agent boundary, natural-language examples, one-shot disambiguation, skill_install caveats.

## Blocked on
- #1205 (fix #1200 TS errors) — currently red on this PR due to inherited overlay-loader bugs from main. Will rebase clean after #1205 merges.

## Closes part of
#1163 — broker server already ships; this is the prompt half that makes "remind me at 5pm" reliably hit \`schedule_add\` instead of free-styling a yaml paste-block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)