### PR TITLE
feat(agent-config): stage-on-reject MVP for schedule_add (#1163)

### DIFF
--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/home/kenthompson/code/switchroom/node_modules

--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/home/kenthompson/code/switchroom/node_modules

--- a/src/cli/agent-config-pending.test.ts
+++ b/src/cli/agent-config-pending.test.ts
@@ -4,7 +4,9 @@ import {
   existsSync,
   readFileSync,
   readdirSync,
+  statSync,
   writeFileSync,
+  mkdirSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -101,6 +103,24 @@ describe("listPendingScheduleEntries", () => {
   });
 });
 
+describe("staged file permissions", () => {
+  it("writes yaml + meta at 0600", () => {
+    const r = stagePendingScheduleEntry({
+      agent: "alice",
+      yamlText: "schedule:\n  - cron: '0 9 * * *'\n    prompt: x\n",
+      reason: "secrets_requires_approval",
+      summary: "s",
+      entry: { cron: "0 9 * * *", prompt: "x" },
+      root,
+      stageId: "cap_perm",
+    });
+    const yamlMode = statSync(r.yamlPath).mode & 0o777;
+    const metaMode = statSync(r.metaPath).mode & 0o777;
+    expect(yamlMode).toBe(0o600);
+    expect(metaMode).toBe(0o600);
+  });
+});
+
 describe("commitPendingScheduleEntry", () => {
   it("moves the yaml into schedule.d and removes meta", () => {
     const staged = stagePendingScheduleEntry({
@@ -126,6 +146,31 @@ describe("commitPendingScheduleEntry", () => {
     expect(r.committed).toBe(false);
     if (r.committed) return;
     expect(r.reason).toBe("not_found");
+  });
+
+  it("refuses to clobber a live schedule.d entry with the same slug", () => {
+    // Pre-seed a live entry under the chosen name
+    const live = join(root, "alice", "schedule.d");
+    mkdirSync(live, { recursive: true });
+    writeFileSync(join(live, "morning.yaml"), "schedule:\n  - cron: '0 8 * * *'\n    prompt: live\n");
+    stagePendingScheduleEntry({
+      agent: "alice",
+      yamlText: "schedule:\n  - cron: '0 9 * * *'\n    prompt: staged\n",
+      reason: "secrets_requires_approval",
+      summary: "s",
+      entry: { cron: "0 9 * * *", prompt: "staged", name: "morning" },
+      root,
+      stageId: "cap_collide",
+    });
+    const r = commitPendingScheduleEntry({ agent: "alice", stageId: "cap_collide", root });
+    expect(r.committed).toBe(false);
+    if (r.committed) return;
+    expect(r.reason).toBe("slug_collision");
+    // Live file untouched
+    const livePath = join(live, "morning.yaml");
+    expect(readFileSync(livePath, "utf-8")).toContain("prompt: live");
+    // Staged entry should still be there (operator can rename + retry)
+    expect(existsSync(join(live, ".pending", "cap_collide.yaml"))).toBe(true);
   });
 
   it("falls back to stage_id as slug when entry has no name", () => {
@@ -197,6 +242,20 @@ describe("scheduleAddOrStage", () => {
     expect(existsSync(r.yaml_path)).toBe(true);
     const meta = JSON.parse(readFileSync(r.yaml_path.replace(/\.yaml$/, ".meta.json"), "utf-8"));
     expect(meta.entry.secrets).toEqual(["v/k"]);
+  });
+
+  it("stages quota_exceeded entries instead of rejecting", () => {
+    // Hit the cap (20) with vanilla adds, then a 21st should stage.
+    for (let i = 0; i < 20; i++) {
+      const r = scheduleAddOrStage({ cronExpr: `${i % 60} 9 * * *`, prompt: `p${i}`, root });
+      expect(r.ok).toBe(true);
+    }
+    const r = scheduleAddOrStage({ cronExpr: "0 10 * * *", prompt: "overflow", root });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    if (!("staged" in r)) throw new Error("expected staged result");
+    expect(r.reason).toBe("quota_exceeded");
+    expect(r.stage_id).toMatch(/^cap_/);
   });
 
   it("stages too-frequent crons instead of rejecting", () => {

--- a/src/cli/agent-config-pending.test.ts
+++ b/src/cli/agent-config-pending.test.ts
@@ -1,0 +1,227 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import {
+  mkdtempSync,
+  existsSync,
+  readFileSync,
+  readdirSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  stagePendingScheduleEntry,
+  listPendingScheduleEntries,
+  commitPendingScheduleEntry,
+  denyPendingScheduleEntry,
+} from "./agent-config-pending.js";
+import { scheduleAddOrStage } from "./agent-config-write.js";
+
+let root: string;
+let savedEnv: string | undefined;
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), "scp-"));
+  savedEnv = process.env.SWITCHROOM_AGENT_NAME;
+  process.env.SWITCHROOM_AGENT_NAME = "alice";
+});
+afterEach(() => {
+  if (savedEnv === undefined) delete process.env.SWITCHROOM_AGENT_NAME;
+  else process.env.SWITCHROOM_AGENT_NAME = savedEnv;
+});
+
+describe("stagePendingScheduleEntry", () => {
+  it("writes yaml + meta.json under .pending/", () => {
+    const r = stagePendingScheduleEntry({
+      agent: "alice",
+      yamlText: "schedule:\n  - cron: '0 9 * * *'\n    prompt: hi\n",
+      reason: "secrets_requires_approval",
+      summary: "test entry",
+      entry: { cron: "0 9 * * *", prompt: "hi", secrets: ["v/k"] },
+      root,
+      stageId: "cap_deadbeef",
+      nowMs: 1700000000000,
+    });
+    expect(r.stageId).toBe("cap_deadbeef");
+    expect(existsSync(r.yamlPath)).toBe(true);
+    expect(existsSync(r.metaPath)).toBe(true);
+    const yaml = readFileSync(r.yamlPath, "utf-8");
+    expect(yaml).toContain("prompt: hi");
+    const meta = JSON.parse(readFileSync(r.metaPath, "utf-8"));
+    expect(meta.v).toBe(1);
+    expect(meta.stage_id).toBe("cap_deadbeef");
+    expect(meta.reason).toBe("secrets_requires_approval");
+    expect(meta.entry.secrets).toEqual(["v/k"]);
+    expect(meta.staged_at).toBe(1700000000000);
+  });
+
+  it("creates the .pending/ dir on first stage", () => {
+    const pending = join(root, "alice", "schedule.d", ".pending");
+    expect(existsSync(pending)).toBe(false);
+    stagePendingScheduleEntry({
+      agent: "alice",
+      yamlText: "",
+      reason: "quota_exceeded",
+      summary: "s",
+      entry: { cron: "0 9 * * *", prompt: "p" },
+      root,
+    });
+    expect(existsSync(pending)).toBe(true);
+  });
+});
+
+describe("listPendingScheduleEntries", () => {
+  it("returns [] when .pending/ does not exist", () => {
+    expect(listPendingScheduleEntries("alice", { root })).toEqual([]);
+  });
+
+  it("lists all staged entries with metadata", () => {
+    stagePendingScheduleEntry({ agent: "alice", yamlText: "a", reason: "secrets_requires_approval", summary: "one", entry: { cron: "0 9 * * *", prompt: "a" }, root, stageId: "cap_aaaa" });
+    stagePendingScheduleEntry({ agent: "alice", yamlText: "b", reason: "quota_exceeded", summary: "two", entry: { cron: "0 10 * * *", prompt: "b" }, root, stageId: "cap_bbbb" });
+    const list = listPendingScheduleEntries("alice", { root });
+    expect(list).toHaveLength(2);
+    expect(list.map((e) => e.stageId).sort()).toEqual(["cap_aaaa", "cap_bbbb"]);
+    expect(list.find((e) => e.stageId === "cap_aaaa")?.meta.summary).toBe("one");
+  });
+
+  it("skips orphan meta files (yaml missing)", () => {
+    const pdir = join(root, "alice", "schedule.d", ".pending");
+    stagePendingScheduleEntry({ agent: "alice", yamlText: "x", reason: "secrets_requires_approval", summary: "s", entry: { cron: "0 9 * * *", prompt: "x" }, root, stageId: "cap_zzz" });
+    writeFileSync(join(pdir, "cap_orphan.meta.json"), JSON.stringify({ v: 1, stage_id: "cap_orphan", staged_at: 0, agent: "alice", reason: "quota_exceeded", summary: "s", entry: { cron: "0 9 * * *", prompt: "x" } }));
+    const list = listPendingScheduleEntries("alice", { root });
+    expect(list.map((e) => e.stageId)).toEqual(["cap_zzz"]);
+  });
+
+  it("skips malformed meta.json", () => {
+    const pdir = join(root, "alice", "schedule.d", ".pending");
+    stagePendingScheduleEntry({ agent: "alice", yamlText: "y", reason: "quota_exceeded", summary: "s", entry: { cron: "0 9 * * *", prompt: "y" }, root, stageId: "cap_good" });
+    writeFileSync(join(pdir, "cap_bad.yaml"), "ignored");
+    writeFileSync(join(pdir, "cap_bad.meta.json"), "{ not valid json");
+    const list = listPendingScheduleEntries("alice", { root });
+    expect(list.map((e) => e.stageId)).toEqual(["cap_good"]);
+  });
+});
+
+describe("commitPendingScheduleEntry", () => {
+  it("moves the yaml into schedule.d and removes meta", () => {
+    const staged = stagePendingScheduleEntry({
+      agent: "alice",
+      yamlText: "schedule:\n  - cron: '0 9 * * *'\n    prompt: morning\n",
+      reason: "secrets_requires_approval",
+      summary: "s",
+      entry: { cron: "0 9 * * *", prompt: "morning", name: "morning" },
+      root,
+      stageId: "cap_xy",
+    });
+    const r = commitPendingScheduleEntry({ agent: "alice", stageId: "cap_xy", root });
+    expect(r.committed).toBe(true);
+    if (!r.committed) return;
+    expect(r.slug).toBe("morning");
+    expect(existsSync(r.path)).toBe(true);
+    expect(existsSync(staged.yamlPath)).toBe(false);
+    expect(existsSync(staged.metaPath)).toBe(false);
+  });
+
+  it("returns not_found for unknown stage_id", () => {
+    const r = commitPendingScheduleEntry({ agent: "alice", stageId: "cap_nope", root });
+    expect(r.committed).toBe(false);
+    if (r.committed) return;
+    expect(r.reason).toBe("not_found");
+  });
+
+  it("falls back to stage_id as slug when entry has no name", () => {
+    stagePendingScheduleEntry({
+      agent: "alice",
+      yamlText: "schedule:\n  - cron: '0 9 * * *'\n    prompt: x\n",
+      reason: "quota_exceeded",
+      summary: "s",
+      entry: { cron: "0 9 * * *", prompt: "x" },
+      root,
+      stageId: "cap_noname",
+    });
+    const r = commitPendingScheduleEntry({ agent: "alice", stageId: "cap_noname", root });
+    expect(r.committed).toBe(true);
+    if (!r.committed) return;
+    expect(r.slug).toBe("cap_noname");
+  });
+});
+
+describe("denyPendingScheduleEntry", () => {
+  it("removes both yaml and meta", () => {
+    const staged = stagePendingScheduleEntry({
+      agent: "alice",
+      yamlText: "y",
+      reason: "secrets_requires_approval",
+      summary: "s",
+      entry: { cron: "0 9 * * *", prompt: "p" },
+      root,
+      stageId: "cap_del",
+    });
+    const r = denyPendingScheduleEntry({ agent: "alice", stageId: "cap_del", root });
+    expect(r.denied).toBe(true);
+    expect(existsSync(staged.yamlPath)).toBe(false);
+    expect(existsSync(staged.metaPath)).toBe(false);
+  });
+
+  it("returns not_found for unknown stage_id", () => {
+    const r = denyPendingScheduleEntry({ agent: "alice", stageId: "cap_nope", root });
+    expect(r.denied).toBe(false);
+    if (r.denied) return;
+    expect(r.reason).toBe("not_found");
+  });
+});
+
+describe("scheduleAddOrStage", () => {
+  it("passes through happy-path adds (no staging)", () => {
+    const r = scheduleAddOrStage({ cronExpr: "0 9 * * *", prompt: "ok", root });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    if ("staged" in r) {
+      throw new Error("happy-path should not stage");
+    }
+    expect(r.slug).toMatch(/^cron-/);
+  });
+
+  it("stages secrets-bearing entries instead of rejecting", () => {
+    const r = scheduleAddOrStage({
+      cronExpr: "0 9 * * *",
+      prompt: "needs key",
+      secrets: ["v/k"],
+      root,
+    });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    if (!("staged" in r)) throw new Error("expected staged result");
+    expect(r.staged).toBe(true);
+    expect(r.reason).toBe("secrets_requires_approval");
+    expect(r.stage_id).toMatch(/^cap_/);
+    expect(existsSync(r.yaml_path)).toBe(true);
+    const meta = JSON.parse(readFileSync(r.yaml_path.replace(/\.yaml$/, ".meta.json"), "utf-8"));
+    expect(meta.entry.secrets).toEqual(["v/k"]);
+  });
+
+  it("stages too-frequent crons instead of rejecting", () => {
+    const r = scheduleAddOrStage({ cronExpr: "* * * * *", prompt: "spammy", root });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    if (!("staged" in r)) throw new Error("expected staged result");
+    expect(r.reason).toBe("cron_too_frequent");
+  });
+
+  it("commit round-trip: stage → commit produces a live schedule.d entry", () => {
+    const r = scheduleAddOrStage({
+      cronExpr: "0 9 * * *",
+      prompt: "needs key",
+      secrets: ["v/k"],
+      name: "morning-key",
+      root,
+    });
+    if (!r.ok || !("staged" in r)) throw new Error("expected staged");
+    const c = commitPendingScheduleEntry({ agent: "alice", stageId: r.stage_id, root });
+    expect(c.committed).toBe(true);
+    if (!c.committed) return;
+    expect(c.slug).toBe("morning-key");
+    const liveDir = join(root, "alice", "schedule.d");
+    const files = readdirSync(liveDir).filter((f) => f.endsWith(".yaml"));
+    expect(files).toContain("morning-key.yaml");
+  });
+});

--- a/src/cli/agent-config-pending.test.ts
+++ b/src/cli/agent-config-pending.test.ts
@@ -16,7 +16,7 @@ import {
   commitPendingScheduleEntry,
   denyPendingScheduleEntry,
 } from "./agent-config-pending.js";
-import { scheduleAddOrStage } from "./agent-config-write.js";
+import { scheduleAddOrStage, checkOperatorContext } from "./agent-config-write.js";
 
 let root: string;
 let savedEnv: string | undefined;
@@ -212,6 +212,45 @@ describe("denyPendingScheduleEntry", () => {
     expect(r.denied).toBe(false);
     if (r.denied) return;
     expect(r.reason).toBe("not_found");
+  });
+});
+
+describe("checkOperatorContext (operator-only guard for pending verbs)", () => {
+  it("refuses when SWITCHROOM_AGENT_NAME is set (agent-container signal)", () => {
+    const r = checkOperatorContext("commit", { SWITCHROOM_AGENT_NAME: "alice" });
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.message).toContain("operator-only");
+    expect(r.message).toContain("alice");
+    expect(r.message).toContain("SWITCHROOM_OPERATOR=1");
+  });
+
+  it("allows when neither env var is set (operator host default)", () => {
+    expect(checkOperatorContext("list", {}).ok).toBe(true);
+  });
+
+  it("allows SWITCHROOM_OPERATOR=1 override even when AGENT_NAME is set", () => {
+    expect(
+      checkOperatorContext("deny", {
+        SWITCHROOM_AGENT_NAME: "alice",
+        SWITCHROOM_OPERATOR: "1",
+      }).ok,
+    ).toBe(true);
+  });
+
+  it("treats empty SWITCHROOM_AGENT_NAME as unset (does not refuse)", () => {
+    expect(checkOperatorContext("commit", { SWITCHROOM_AGENT_NAME: "" }).ok).toBe(true);
+  });
+
+  it("does NOT honor SWITCHROOM_OPERATOR values other than literal '1'", () => {
+    // Hardening — if an attacker can set the env, they can also set
+    // `SWITCHROOM_OPERATOR=1`. But narrow the check so accidental
+    // `true` / `yes` / typo'd values don't bypass.
+    const r = checkOperatorContext("commit", {
+      SWITCHROOM_AGENT_NAME: "alice",
+      SWITCHROOM_OPERATOR: "true",
+    });
+    expect(r.ok).toBe(false);
   });
 });
 

--- a/src/cli/agent-config-pending.ts
+++ b/src/cli/agent-config-pending.ts
@@ -1,0 +1,237 @@
+/**
+ * Pending-approval storage for agent-config writes that require
+ * operator authorization (#1163 Phase 2 — approval-card MVP).
+ *
+ * Today's broker hard-rejects writes when the agent declares anything
+ * that would let it self-grant capabilities — `secrets:` on a schedule
+ * entry, more than the per-agent quota, intervals tighter than the
+ * 5-min floor, etc. The reject is correct (silent-strip would let the
+ * agent escalate quietly), but the resulting UX is "agent paste-blocks
+ * a yaml the operator has to apply by hand".
+ *
+ * This module is the storage layer for a proper approval flow:
+ *
+ *   1. Agent calls `schedule_add` with `secrets: ["vault/gmail-token"]`.
+ *   2. Broker stages the write under
+ *      `~/.switchroom/agents/<name>/schedule.d/.pending/<stage_id>.yaml`
+ *      with sibling `<stage_id>.meta.json` capturing the operator-
+ *      readable reason (which gate tripped, what the entry will do,
+ *      who authored it).
+ *   3. The MCP tool returns `{ ok: true, staged: true, stage_id, reason }`
+ *      instead of the hard-reject. Agent reports the stage_id to the
+ *      user.
+ *   4. Operator approves either:
+ *      a. From the host CLI: `switchroom schedule pending commit <id>`
+ *      b. (Phase 2 follow-up) Via Telegram approval card synthesized
+ *         from the staged metadata.
+ *   5. Commit moves the file out of `.pending/` into `schedule.d/` and
+ *      triggers the existing hot-apply reconcile path.
+ *
+ * Path layout:
+ *   ~/.switchroom/agents/<name>/schedule.d/
+ *     .pending/
+ *       <stage_id>.yaml      ← the staged overlay entry
+ *       <stage_id>.meta.json ← human/audit metadata
+ *     .staging/              ← (existing — atomic-write tmpdir)
+ *     <slug>.yaml            ← committed entries
+ *
+ * Stage IDs are 12-hex `cap_<random>` slugs, distinct from the
+ * `cron-<hash>` slug shape so a glance can tell pending from committed.
+ *
+ * Skills are NOT wired in this v1 — `skill_install` already restricts
+ * to bundled sources which are operator-pre-approved by virtue of
+ * being in the operator's skill pool. Phase 2 follow-up will add
+ * git-pinned-SHA skills which DO need approval.
+ */
+
+import {
+  closeSync,
+  existsSync,
+  fsyncSync,
+  mkdirSync,
+  openSync,
+  readdirSync,
+  readFileSync,
+  renameSync,
+  unlinkSync,
+  writeFileSync,
+  writeSync,
+} from "node:fs";
+import { join } from "node:path";
+import { randomBytes } from "node:crypto";
+import { overlayPathsFor } from "../config/overlay-writer.js";
+
+/** Identifier prefix that distinguishes pending stages from committed
+ *  slugs at a glance (`cron-<12hex>` vs `cap_<8hex>`). */
+const STAGE_ID_PREFIX = "cap_";
+
+export type PendingReasonCode =
+  | "secrets_requires_approval"
+  | "quota_exceeded"
+  | "cron_too_frequent";
+
+export interface PendingEntryMetadata {
+  v: 1;
+  /** Random 8-hex slug; the on-disk filename is `<stage_id>.yaml`. */
+  stage_id: string;
+  /** Wall-clock ms when staged. */
+  staged_at: number;
+  /** Agent that authored the request. */
+  agent: string;
+  /** Which gate tripped — operator-facing label for the approval card. */
+  reason: PendingReasonCode;
+  /** One-line operator-readable description of the entry being staged. */
+  summary: string;
+  /** Original raw schedule-entry fields (cron, prompt, secrets, name)
+   *  for the approval card to render. */
+  entry: {
+    cron: string;
+    prompt: string;
+    secrets?: string[];
+    name?: string;
+  };
+}
+
+export interface ListedPendingEntry {
+  stageId: string;
+  agent: string;
+  yamlPath: string;
+  metaPath: string;
+  meta: PendingEntryMetadata;
+}
+
+function pendingDir(agent: string, opts: { root?: string } = {}): string {
+  const paths = overlayPathsFor(agent, opts);
+  return join(paths.scheduleDir, ".pending");
+}
+
+function ensurePendingDir(agent: string, opts: { root?: string } = {}): string {
+  const dir = pendingDir(agent, opts);
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+function newStageId(): string {
+  return `${STAGE_ID_PREFIX}${randomBytes(4).toString("hex")}`;
+}
+
+/**
+ * Stage an entry pending operator approval. Returns the stage_id +
+ * absolute paths. Atomic: writes both files via temp + rename so a
+ * crash mid-stage leaves no half-staged state.
+ */
+export function stagePendingScheduleEntry(opts: {
+  agent: string;
+  yamlText: string;
+  reason: PendingReasonCode;
+  summary: string;
+  entry: PendingEntryMetadata["entry"];
+  /** Test seam — override overlay root. */
+  root?: string;
+  /** Test seam — supply a deterministic stage id. */
+  stageId?: string;
+  /** Test seam — supply a deterministic wall-clock. */
+  nowMs?: number;
+}): { stageId: string; yamlPath: string; metaPath: string } {
+  const dir = ensurePendingDir(opts.agent, { root: opts.root });
+  const stageId = opts.stageId ?? newStageId();
+  const yamlPath = join(dir, `${stageId}.yaml`);
+  const metaPath = join(dir, `${stageId}.meta.json`);
+  const meta: PendingEntryMetadata = {
+    v: 1,
+    stage_id: stageId,
+    staged_at: opts.nowMs ?? Date.now(),
+    agent: opts.agent,
+    reason: opts.reason,
+    summary: opts.summary,
+    entry: opts.entry,
+  };
+  // Write YAML first (the load-bearing content); meta last (the
+  // operator-facing record). A crash between them leaves an
+  // orphaned YAML with no metadata — listPending will skip it (meta
+  // is the discriminator) and the operator can clean up manually.
+  const yamlTmp = `${yamlPath}.tmp-${process.pid}`;
+  {
+    const fd = openSync(yamlTmp, "w", 0o600);
+    try {
+      writeSync(fd, opts.yamlText);
+      fsyncSync(fd);
+    } finally {
+      closeSync(fd);
+    }
+    renameSync(yamlTmp, yamlPath);
+  }
+  writeFileSync(metaPath, JSON.stringify(meta, null, 2) + "\n", { mode: 0o600 });
+  return { stageId, yamlPath, metaPath };
+}
+
+/**
+ * Enumerate pending entries for an agent. Reads metadata eagerly so
+ * callers can match by stageId / agent / reason without a second
+ * file read.
+ */
+export function listPendingScheduleEntries(
+  agent: string,
+  opts: { root?: string } = {},
+): ListedPendingEntry[] {
+  const dir = pendingDir(agent, opts);
+  if (!existsSync(dir)) return [];
+  const out: ListedPendingEntry[] = [];
+  for (const name of readdirSync(dir).sort()) {
+    if (!name.endsWith(".meta.json")) continue;
+    const stageId = name.slice(0, -".meta.json".length);
+    const metaPath = join(dir, name);
+    const yamlPath = join(dir, `${stageId}.yaml`);
+    if (!existsSync(yamlPath)) continue; // crash-recovery: skip orphan meta
+    try {
+      const meta = JSON.parse(readFileSync(metaPath, "utf-8")) as PendingEntryMetadata;
+      if (meta?.v !== 1 || typeof meta.stage_id !== "string") continue;
+      out.push({ stageId: meta.stage_id, agent: meta.agent, yamlPath, metaPath, meta });
+    } catch {
+      /* unreadable / malformed — skip */
+    }
+  }
+  return out;
+}
+
+/**
+ * Move a staged entry from `.pending/` to the live `schedule.d/`
+ * directory. Returns the committed file path. Does NOT trigger
+ * reconcile — caller is responsible for invoking the reconcile
+ * bridge after commit (matches the `agent-config-write.ts:scheduleAdd`
+ * pattern).
+ */
+export function commitPendingScheduleEntry(opts: {
+  agent: string;
+  stageId: string;
+  root?: string;
+}): { committed: true; path: string; slug: string } | { committed: false; reason: "not_found" } {
+  const entries = listPendingScheduleEntries(opts.agent, { root: opts.root });
+  const match = entries.find((e) => e.stageId === opts.stageId);
+  if (!match) return { committed: false, reason: "not_found" };
+  // Derive the committed slug from the entry's `name:` if set; else
+  // fall back to a cron-hash equivalent. For v1 we re-use the stage
+  // id as the slug to keep the round-trip identifiable.
+  const slug = match.meta.entry.name ?? match.stageId;
+  const paths = overlayPathsFor(opts.agent, { root: opts.root });
+  const finalPath = join(paths.scheduleDir, `${slug}.yaml`);
+  renameSync(match.yamlPath, finalPath);
+  unlinkSync(match.metaPath);
+  return { committed: true, path: finalPath, slug };
+}
+
+/**
+ * Discard a staged entry without committing.
+ */
+export function denyPendingScheduleEntry(opts: {
+  agent: string;
+  stageId: string;
+  root?: string;
+}): { denied: true } | { denied: false; reason: "not_found" } {
+  const entries = listPendingScheduleEntries(opts.agent, { root: opts.root });
+  const match = entries.find((e) => e.stageId === opts.stageId);
+  if (!match) return { denied: false, reason: "not_found" };
+  try { unlinkSync(match.yamlPath); } catch { /* best-effort */ }
+  try { unlinkSync(match.metaPath); } catch { /* best-effort */ }
+  return { denied: true };
+}

--- a/src/cli/agent-config-pending.ts
+++ b/src/cli/agent-config-pending.ts
@@ -205,7 +205,7 @@ export function commitPendingScheduleEntry(opts: {
   agent: string;
   stageId: string;
   root?: string;
-}): { committed: true; path: string; slug: string } | { committed: false; reason: "not_found" } {
+}): { committed: true; path: string; slug: string } | { committed: false; reason: "not_found" | "slug_collision" } {
   const entries = listPendingScheduleEntries(opts.agent, { root: opts.root });
   const match = entries.find((e) => e.stageId === opts.stageId);
   if (!match) return { committed: false, reason: "not_found" };
@@ -215,6 +215,12 @@ export function commitPendingScheduleEntry(opts: {
   const slug = match.meta.entry.name ?? match.stageId;
   const paths = overlayPathsFor(opts.agent, { root: opts.root });
   const finalPath = join(paths.scheduleDir, `${slug}.yaml`);
+  // Reject collisions instead of silently clobbering — the agent
+  // controls `entry.name`, so a rename-over-existing would be a
+  // write-anywhere primitive once the operator approves.
+  if (existsSync(finalPath)) {
+    return { committed: false, reason: "slug_collision" };
+  }
   renameSync(match.yamlPath, finalPath);
   unlinkSync(match.metaPath);
   return { committed: true, path: finalPath, slug };

--- a/src/cli/agent-config-write.ts
+++ b/src/cli/agent-config-write.ts
@@ -62,6 +62,42 @@ import { existsSync, readFileSync } from "node:fs";
 
 const MAX_ENTRIES_PER_AGENT = 20;
 
+/**
+ * Defense-in-depth check that the caller is the operator host CLI,
+ * not an agent shell-out. Returns `{ ok: true }` when the caller may
+ * proceed; otherwise an exit-7 reason payload the CLI wrapper emits
+ * and process.exit's on.
+ *
+ * **This is not a capability boundary** — it inspects env, which an
+ * agent that can spawn child processes can scrub (`env -u
+ * SWITCHROOM_AGENT_NAME …`). True capability hardening (uid/gid
+ * check, host-only socket, mode-0400 token file outside the container
+ * mount) is a tracked follow-up. The env check still raises the bar
+ * meaningfully: it blocks the naive shell-out path and forces an
+ * attacker to be deliberate about env scrubbing, which leaves a
+ * trace in audit logs.
+ *
+ * Override: `SWITCHROOM_OPERATOR=1` bypasses the check for trusted
+ * host shells (CI, recovery, manual operator sessions) where the env
+ * pin happens to be set for unrelated reasons.
+ *
+ * @param env  Inject for tests; defaults to `process.env`.
+ */
+export function checkOperatorContext(
+  verb: string,
+  env: NodeJS.ProcessEnv = process.env,
+): { ok: true } | { ok: false; message: string } {
+  if (env.SWITCHROOM_OPERATOR === "1") return { ok: true };
+  const agentEnv = env.SWITCHROOM_AGENT_NAME;
+  if (agentEnv && agentEnv.length > 0) {
+    return {
+      ok: false,
+      message: `schedule pending ${verb} is operator-only; refusing because $SWITCHROOM_AGENT_NAME=${agentEnv} (set SWITCHROOM_OPERATOR=1 to override on a trusted host)`,
+    };
+  }
+  return { ok: true };
+}
+
 type ErrorCode =
   | "E_OVERLAY_SECRETS_REQUIRES_APPROVAL"
   | "E_CRON_TOO_FREQUENT"
@@ -560,23 +596,11 @@ export function registerAgentConfigWriteCommands(program: Command): void {
     .command("pending")
     .description("Manage agent-requested schedule entries awaiting operator approval");
 
-  /**
-   * Privilege boundary: the `pending` verbs are operator-only. The
-   * canonical signal that a process is INSIDE an agent container is
-   * `$SWITCHROOM_AGENT_NAME` being set (compose pins it). If it's
-   * present, refuse the verb — otherwise an agent could self-approve
-   * its own staged entry by shelling out to the CLI. Operator host
-   * never has this env set; `SWITCHROOM_OPERATOR=1` is an explicit
-   * override for unusual host configs (CI, recovery shells).
-   */
+  /** Defense-in-depth: see {@link checkOperatorContext} for limits. */
   function requireOperatorContext(verb: string): void {
-    if (process.env.SWITCHROOM_OPERATOR === "1") return;
-    const agentEnv = process.env.SWITCHROOM_AGENT_NAME;
-    if (agentEnv && agentEnv.length > 0) {
-      emitError(
-        "E_NOT_FOUND",
-        `schedule pending ${verb} is operator-only; refusing because $SWITCHROOM_AGENT_NAME=${agentEnv} (set SWITCHROOM_OPERATOR=1 to override on a trusted host)`,
-      );
+    const r = checkOperatorContext(verb);
+    if (!r.ok) {
+      emitError("E_NOT_FOUND", r.message);
       process.exit(7);
     }
   }

--- a/src/cli/agent-config-write.ts
+++ b/src/cli/agent-config-write.ts
@@ -108,6 +108,7 @@ type ErrorCode =
   | "E_NOT_FOUND"
   | "E_RECONCILE_FAILED"
   | "E_SLUG_COLLISION"
+  | "E_OPERATOR_ONLY"
   | "E_INTERNAL";
 
 /**
@@ -135,6 +136,8 @@ function exitCodeFor(code: ErrorCode): number {
     case "E_NOT_FOUND":
     case "E_INTERNAL":
       return 1;
+    case "E_OPERATOR_ONLY":
+      return 7;
     case "E_RECONCILE_FAILED":
       return 10;
   }
@@ -600,7 +603,7 @@ export function registerAgentConfigWriteCommands(program: Command): void {
   function requireOperatorContext(verb: string): void {
     const r = checkOperatorContext(verb);
     if (!r.ok) {
-      emitError("E_NOT_FOUND", r.message);
+      emitError("E_OPERATOR_ONLY", r.message);
       process.exit(7);
     }
   }

--- a/src/cli/agent-config-write.ts
+++ b/src/cli/agent-config-write.ts
@@ -71,6 +71,7 @@ type ErrorCode =
   | "E_INVALID_PROMPT"
   | "E_NOT_FOUND"
   | "E_RECONCILE_FAILED"
+  | "E_SLUG_COLLISION"
   | "E_INTERNAL";
 
 /**
@@ -91,6 +92,7 @@ function exitCodeFor(code: ErrorCode): number {
     case "E_CRON_TOO_FREQUENT":
     case "E_QUOTA_EXCEEDED":
     case "E_WRITE_REQUIRES_RECREATE":
+    case "E_SLUG_COLLISION":
       return 9;
     case "E_INVALID_CRON":
     case "E_INVALID_PROMPT":
@@ -558,12 +560,38 @@ export function registerAgentConfigWriteCommands(program: Command): void {
     .command("pending")
     .description("Manage agent-requested schedule entries awaiting operator approval");
 
+  /**
+   * Privilege boundary: the `pending` verbs are operator-only. The
+   * canonical signal that a process is INSIDE an agent container is
+   * `$SWITCHROOM_AGENT_NAME` being set (compose pins it). If it's
+   * present, refuse the verb — otherwise an agent could self-approve
+   * its own staged entry by shelling out to the CLI. Operator host
+   * never has this env set; `SWITCHROOM_OPERATOR=1` is an explicit
+   * override for unusual host configs (CI, recovery shells).
+   */
+  function requireOperatorContext(verb: string): void {
+    if (process.env.SWITCHROOM_OPERATOR === "1") return;
+    const agentEnv = process.env.SWITCHROOM_AGENT_NAME;
+    if (agentEnv && agentEnv.length > 0) {
+      emitError(
+        "E_NOT_FOUND",
+        `schedule pending ${verb} is operator-only; refusing because $SWITCHROOM_AGENT_NAME=${agentEnv} (set SWITCHROOM_OPERATOR=1 to override on a trusted host)`,
+      );
+      process.exit(7);
+    }
+  }
+
   pending
     .command("list")
     .description("List entries staged by the agent and awaiting approval")
-    .option("--agent <name>", "Target agent (defaults to $SWITCHROOM_AGENT_NAME)")
-    .action(async (opts: { agent?: string }) => {
-      const agent = resolveTargetAgent(opts.agent);
+    .requiredOption("--agent <name>", "Target agent")
+    .action(async (opts: { agent: string }) => {
+      requireOperatorContext("list");
+      // Bypass resolveTargetAgent — that helper enforces the
+      // env-pin equality check used by agent-authored writes. The
+      // pending verbs are operator-only (see requireOperatorContext)
+      // and explicitly take any agent name on the host.
+      const agent = opts.agent;
       const entries = listPendingScheduleEntries(agent);
       process.stdout.write(
         JSON.stringify({
@@ -585,11 +613,20 @@ export function registerAgentConfigWriteCommands(program: Command): void {
   pending
     .command("commit <stageId>")
     .description("Approve a staged entry — moves it into the live schedule.d/ and reconciles")
-    .option("--agent <name>", "Target agent (defaults to $SWITCHROOM_AGENT_NAME)")
-    .action(async (stageId: string, opts: { agent?: string }) => {
-      const agent = resolveTargetAgent(opts.agent);
+    .requiredOption("--agent <name>", "Target agent")
+    .action(async (stageId: string, opts: { agent: string }) => {
+      requireOperatorContext("commit");
+      const agent = opts.agent;
       const r = commitPendingScheduleEntry({ agent, stageId });
       if (!r.committed) {
+        if (r.reason === "slug_collision") {
+          emitError(
+            "E_SLUG_COLLISION",
+            `pending entry ${stageId} cannot be committed — a live schedule.d entry with the same slug already exists`,
+          );
+          appendAudit(agent, "schedule.pending.commit", { stage_id: stageId, ok: false, reason: r.reason }, 9);
+          process.exit(9);
+        }
         emitError("E_NOT_FOUND", `pending entry ${stageId} not found for agent ${agent}`);
         appendAudit(agent, "schedule.pending.commit", { stage_id: stageId, ok: false }, 1);
         process.exit(1);
@@ -607,9 +644,10 @@ export function registerAgentConfigWriteCommands(program: Command): void {
   pending
     .command("deny <stageId>")
     .description("Discard a staged entry without committing")
-    .option("--agent <name>", "Target agent (defaults to $SWITCHROOM_AGENT_NAME)")
-    .action(async (stageId: string, opts: { agent?: string }) => {
-      const agent = resolveTargetAgent(opts.agent);
+    .requiredOption("--agent <name>", "Target agent")
+    .action(async (stageId: string, opts: { agent: string }) => {
+      requireOperatorContext("deny");
+      const agent = opts.agent;
       const r = denyPendingScheduleEntry({ agent, stageId });
       if (!r.denied) {
         emitError("E_NOT_FOUND", `pending entry ${stageId} not found for agent ${agent}`);

--- a/src/cli/agent-config-write.ts
+++ b/src/cli/agent-config-write.ts
@@ -51,6 +51,13 @@ import {
   type ReconcileBridgeResult,
   type ReconcileBridgeError,
 } from "./reconcile-bridge.js";
+import {
+  stagePendingScheduleEntry,
+  listPendingScheduleEntries,
+  commitPendingScheduleEntry,
+  denyPendingScheduleEntry,
+  type PendingReasonCode,
+} from "./agent-config-pending.js";
 import { existsSync, readFileSync } from "node:fs";
 
 const MAX_ENTRIES_PER_AGENT = 20;
@@ -134,6 +141,22 @@ export interface ScheduleErrorResult {
   code: ErrorCode;
   message: string;
   exit: number;
+}
+
+/**
+ * Returned by {@link scheduleAddOrStage} when a security gate trips
+ * and the entry has been staged for operator approval (instead of
+ * hard-rejected). Exit code is 0 — the agent's call SUCCEEDED, the
+ * commit is just pending.
+ */
+export interface ScheduleStagedResult {
+  ok: true;
+  staged: true;
+  stage_id: string;
+  reason: PendingReasonCode;
+  summary: string;
+  /** Operator-facing path on disk. */
+  yaml_path: string;
 }
 
 /**
@@ -283,6 +306,73 @@ export function scheduleAdd(opts: AddOpts): ScheduleAddResult | ScheduleErrorRes
   };
 }
 
+/**
+ * Stage-or-add wrapper used by the CLI / MCP path. Calls
+ * {@link scheduleAdd}; if it rejects with one of the three
+ * approval-gated codes, stages the entry under `.pending/` and
+ * returns a {@link ScheduleStagedResult} (exit 0 — the request was
+ * recorded, not denied). All other failures pass through unchanged.
+ *
+ * Why this lives next to `scheduleAdd` rather than inside it: the
+ * direct write path is used by tests + the legacy operator CLI where
+ * a reject should remain a reject. The MCP path explicitly wants
+ * the approval flow.
+ */
+export function scheduleAddOrStage(
+  opts: AddOpts,
+): ScheduleAddResult | ScheduleStagedResult | ScheduleErrorResult {
+  const r = scheduleAdd(opts);
+  if (r.ok) return r;
+  let stageReason: PendingReasonCode | null = null;
+  if (r.code === "E_OVERLAY_SECRETS_REQUIRES_APPROVAL") stageReason = "secrets_requires_approval";
+  else if (r.code === "E_CRON_TOO_FREQUENT") stageReason = "cron_too_frequent";
+  else if (r.code === "E_QUOTA_EXCEEDED") stageReason = "quota_exceeded";
+  if (stageReason === null) return r;
+
+  const agent = resolveTargetAgent(opts.agent);
+  const entry: { cron: string; prompt: string; secrets?: string[]; name?: string } = {
+    cron: opts.cronExpr,
+    prompt: opts.prompt,
+  };
+  if (opts.secrets && opts.secrets.length > 0) entry.secrets = opts.secrets;
+  if (opts.name) entry.name = opts.name;
+
+  // Reconstruct the YAML body we WOULD have written. Mirrors the
+  // scheduleAdd doc-build (filter `name` out of the schedule entry;
+  // stash agent-facing name in a leading comment for round-trip).
+  const doc: Record<string, unknown> = {
+    schedule: [
+      Object.fromEntries(Object.entries(entry).filter(([k]) => k !== "name")),
+    ],
+  };
+  const yamlText =
+    (opts.name ? `# name: ${opts.name}\n` : "") + yamlStringify(doc);
+
+  const summary = (() => {
+    const parts: string[] = [`cron=${opts.cronExpr}`];
+    if (opts.secrets?.length) parts.push(`secrets=[${opts.secrets.join(",")}]`);
+    parts.push(`prompt=${opts.prompt.slice(0, 60)}${opts.prompt.length > 60 ? "…" : ""}`);
+    return parts.join(" ");
+  })();
+
+  const staged = stagePendingScheduleEntry({
+    agent,
+    yamlText,
+    reason: stageReason,
+    summary,
+    entry,
+    root: opts.root,
+  });
+  return {
+    ok: true,
+    staged: true,
+    stage_id: staged.stageId,
+    reason: stageReason,
+    summary,
+    yaml_path: staged.yamlPath,
+  };
+}
+
 export interface ScheduleRemoveResult {
   ok: true;
   slug: string;
@@ -381,12 +471,17 @@ export function registerAgentConfigWriteCommands(program: Command): void {
     .option("--agent <name>", "Target agent (defaults to $SWITCHROOM_AGENT_NAME)")
     .option("--secrets <list>", "Comma-separated vault keys (REJECTED for agent-authored overlays)")
     .option("--name <slug>", "Optional human-readable name (a-z 0-9 -)")
+    .option(
+      "--stage-on-reject",
+      "When a security gate trips (secrets/quota/min-interval), stage the entry under .pending/ for operator approval instead of rejecting with exit 9. Used by the MCP path; operator CLI defaults to off.",
+    )
     .action(async (opts: {
       agent?: string;
       cron: string;
       prompt: string;
       secrets?: string;
       name?: string;
+      stageOnReject?: boolean;
     }) => {
       const secrets = opts.secrets
         ? opts.secrets.split(",").map((s) => s.trim()).filter(Boolean)
@@ -398,10 +493,11 @@ export function registerAgentConfigWriteCommands(program: Command): void {
         } catch { /* ignore */ }
         process.exit(1);
       }
-      let r: ScheduleAddResult | ScheduleErrorResult;
+      let r: ScheduleAddResult | ScheduleStagedResult | ScheduleErrorResult;
       let resolvedAgent = opts.agent ?? "<unknown>";
       try {
-        r = scheduleAdd({
+        const addFn = opts.stageOnReject ? scheduleAddOrStage : scheduleAdd;
+        r = addFn({
           agent: opts.agent,
           cronExpr: opts.cron,
           prompt: opts.prompt,
@@ -426,6 +522,23 @@ export function registerAgentConfigWriteCommands(program: Command): void {
         );
         process.exit(r.exit);
       }
+      if ("staged" in r) {
+        process.stdout.write(JSON.stringify({
+          ok: true,
+          staged: true,
+          stage_id: r.stage_id,
+          reason: r.reason,
+          summary: r.summary,
+          yaml_path: r.yaml_path,
+        }) + "\n");
+        appendAudit(
+          resolvedAgent,
+          "schedule.add",
+          { cron: opts.cron, prompt: opts.prompt, name: opts.name, staged: true, stage_id: r.stage_id, reason: r.reason },
+          0,
+        );
+        return;
+      }
       process.stdout.write(JSON.stringify({
         ok: true,
         slug: r.slug,
@@ -439,6 +552,72 @@ export function registerAgentConfigWriteCommands(program: Command): void {
         { cron: opts.cron, prompt: opts.prompt, name: opts.name, cron_hash: r.cron_hash, would_recreate: false },
         0,
       );
+    });
+
+  const pending = schedule
+    .command("pending")
+    .description("Manage agent-requested schedule entries awaiting operator approval");
+
+  pending
+    .command("list")
+    .description("List entries staged by the agent and awaiting approval")
+    .option("--agent <name>", "Target agent (defaults to $SWITCHROOM_AGENT_NAME)")
+    .action(async (opts: { agent?: string }) => {
+      const agent = resolveTargetAgent(opts.agent);
+      const entries = listPendingScheduleEntries(agent);
+      process.stdout.write(
+        JSON.stringify({
+          ok: true,
+          agent,
+          count: entries.length,
+          entries: entries.map((e) => ({
+            stage_id: e.stageId,
+            staged_at: e.meta.staged_at,
+            reason: e.meta.reason,
+            summary: e.meta.summary,
+            entry: e.meta.entry,
+            yaml_path: e.yamlPath,
+          })),
+        }) + "\n",
+      );
+    });
+
+  pending
+    .command("commit <stageId>")
+    .description("Approve a staged entry — moves it into the live schedule.d/ and reconciles")
+    .option("--agent <name>", "Target agent (defaults to $SWITCHROOM_AGENT_NAME)")
+    .action(async (stageId: string, opts: { agent?: string }) => {
+      const agent = resolveTargetAgent(opts.agent);
+      const r = commitPendingScheduleEntry({ agent, stageId });
+      if (!r.committed) {
+        emitError("E_NOT_FOUND", `pending entry ${stageId} not found for agent ${agent}`);
+        appendAudit(agent, "schedule.pending.commit", { stage_id: stageId, ok: false }, 1);
+        process.exit(1);
+      }
+      const rr = reconcileAgentCronOnly(agent);
+      if (!rr.ok) {
+        emitError("E_RECONCILE_FAILED", `committed but reconcile failed: ${rr.error}`);
+        appendAudit(agent, "schedule.pending.commit", { stage_id: stageId, slug: r.slug, ok: false, reconcile: rr.error }, 10);
+        process.exit(10);
+      }
+      process.stdout.write(JSON.stringify({ ok: true, stage_id: stageId, slug: r.slug, path: r.path }) + "\n");
+      appendAudit(agent, "schedule.pending.commit", { stage_id: stageId, slug: r.slug }, 0);
+    });
+
+  pending
+    .command("deny <stageId>")
+    .description("Discard a staged entry without committing")
+    .option("--agent <name>", "Target agent (defaults to $SWITCHROOM_AGENT_NAME)")
+    .action(async (stageId: string, opts: { agent?: string }) => {
+      const agent = resolveTargetAgent(opts.agent);
+      const r = denyPendingScheduleEntry({ agent, stageId });
+      if (!r.denied) {
+        emitError("E_NOT_FOUND", `pending entry ${stageId} not found for agent ${agent}`);
+        appendAudit(agent, "schedule.pending.deny", { stage_id: stageId, ok: false }, 1);
+        process.exit(1);
+      }
+      process.stdout.write(JSON.stringify({ ok: true, stage_id: stageId, denied: true }) + "\n");
+      appendAudit(agent, "schedule.pending.deny", { stage_id: stageId }, 0);
     });
 
   schedule

--- a/src/mcp/agent-config/server.ts
+++ b/src/mcp/agent-config/server.ts
@@ -247,7 +247,19 @@ export function dispatchTool(
       if (!a.cron_expr || !a.prompt) {
         return errorText("schedule_add: cron_expr and prompt are required");
       }
-      const base = ["schedule", "add", "--cron", a.cron_expr, "--prompt", a.prompt];
+      // MCP path: stage instead of hard-reject when a security gate
+      // trips. The operator approves from the host CLI (`switchroom
+      // schedule pending commit <stage_id>`) or — once #1163 Phase 2
+      // lands the card — from Telegram.
+      const base = [
+        "schedule",
+        "add",
+        "--cron",
+        a.cron_expr,
+        "--prompt",
+        a.prompt,
+        "--stage-on-reject",
+      ];
       if (a.agent) base.push("--agent", a.agent);
       if (a.name) base.push("--name", a.name);
       if (a.secrets && a.secrets.length > 0) base.push("--secrets", a.secrets.join(","));


### PR DESCRIPTION
## Summary

Closes the last gap in the agent self-service flow: agent-authored
overlay writes that trip a security gate (`secrets:`, >20 entries,
<5min cron) now stage under `.pending/` for operator approval instead
of hard-rejecting with exit 9.

- **Storage** — `src/cli/agent-config-pending.ts` writes
  `<stage_id>.yaml` + `<stage_id>.meta.json` (mode 0600) under
  `~/.switchroom/agents/<name>/schedule.d/.pending/`. Atomic
  (tmp+rename for the yaml), crash-recovery-safe (orphan-yaml is
  skipped on list).
- **Wrapper** — `scheduleAddOrStage` calls `scheduleAdd`; on the three
  approval-gated codes it stages and returns
  `{ok:true, staged:true, stage_id, reason, summary, yaml_path}`.
  Happy path + non-gate errors unchanged.
- **CLI** — `switchroom schedule add --stage-on-reject` is the opt-in
  flag; operator CLI default stays reject-with-exit-9. New verbs:
  `switchroom schedule pending list|commit <id>|deny <id>` (all
  `--agent <name>` required, operator-only).
- **MCP** — `schedule_add` always passes `--stage-on-reject` so agents
  get the approval flow.

## Privilege boundary (read this before approving)

The `pending` verbs are gated by `checkOperatorContext`: refused
when `$SWITCHROOM_AGENT_NAME` is set, allowed otherwise; explicit
override via `SWITCHROOM_OPERATOR=1`.

**This is defense-in-depth, not a capability boundary.** An agent
that can spawn child processes can scrub env (`env -u
SWITCHROOM_AGENT_NAME …`). The env check still raises the bar
meaningfully — it blocks the naive shell-out and forces a deliberate
scrub which leaves an audit trail. True capability hardening
(uid/gid check, host-only socket, mode-0400 token outside the
container mount) is tracked as a follow-up and called out inline in
the guard's doc-comment.

Slug collisions on commit are rejected with `E_SLUG_COLLISION`
(exit 9) — the agent controls `entry.name`, so silent rename-over
would have been a write-anywhere primitive once the operator approves.

Telegram approval card (synth `<channel source=\"config_request_apply\">`
+ finalizeCallback tap handlers) is a tracked follow-up. This slice
lets operators approve from the host CLI immediately and is enough
for end-to-end \"agent asks → operator approves → entry is live\".

## Test plan

- [x] `npm test` — 23 tests in agent-config-pending.test.ts incl.
      five for the operator-context guard, plus the existing
      agent-config-write suite untouched.
- [x] Lint clean.
- [ ] Manual: agent calls `schedule_add` with `secrets:[\"v/k\"]` →
      returns staged stage_id; operator runs `switchroom schedule
      pending commit cap_… --agent <name>` → entry shows up in
      `schedule list`; reconcile fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)