### PR TITLE
feat(update): fold `switchroom hostd install` into the update pipeline (#1175)

### DIFF
--- a/src/cli/update.test.ts
+++ b/src/cli/update.test.ts
@@ -26,15 +26,16 @@ function fakeRunner() {
 }
 
 describe("planUpdate", () => {
-  it("produces 6 steps in default mode (no --rebuild)", () => {
+  it("produces 7 steps in default mode (no --rebuild)", () => {
     const tmp = mkdtempSync(join(tmpdir(), "update-plan-"));
     try {
       const composePath = join(tmp, "docker-compose.yml");
       writeFileSync(composePath, "services: {}\n");
-      const steps = planUpdate({ composePath });
+      const steps = planUpdate({ composePath, hostControlEnabled: false });
       expect(steps.map((s) => s.name)).toEqual([
         "pull-images",
         "apply-config",
+        "refresh-hostd",
         "sync-bundled-skills",
         "stamp-restart-marker",
         "recreate-containers",
@@ -50,11 +51,12 @@ describe("planUpdate", () => {
     try {
       const composePath = join(tmp, "docker-compose.yml");
       writeFileSync(composePath, "services: {}\n");
-      const steps = planUpdate({ composePath, rebuild: true });
+      const steps = planUpdate({ composePath, rebuild: true, hostControlEnabled: false });
       expect(steps.map((s) => s.name)).toEqual([
         "pull-images",
         "rebuild-source",
         "apply-config",
+        "refresh-hostd",
         "sync-bundled-skills",
         "stamp-restart-marker",
         "recreate-containers",
@@ -63,6 +65,73 @@ describe("planUpdate", () => {
     } finally {
       rmSync(tmp, { recursive: true, force: true });
     }
+  });
+
+  // refresh-hostd: PR ε — closes the gap that hostd lives in a separate
+  // compose project and was previously not refreshed by `update`.
+  describe("refresh-hostd step", () => {
+    function planFor(opts: Parameters<typeof planUpdate>[0]) {
+      const tmp = mkdtempSync(join(tmpdir(), "update-hostd-"));
+      const composePath = join(tmp, "docker-compose.yml");
+      writeFileSync(composePath, "services: {}\n");
+      const steps = planUpdate({ composePath, ...opts });
+      const refresh = steps.find((s) => s.name === "refresh-hostd")!;
+      rmSync(tmp, { recursive: true, force: true });
+      return { steps, refresh };
+    }
+
+    it("is placed AFTER apply-config and BEFORE sync-bundled-skills", () => {
+      const { steps } = planFor({ hostControlEnabled: true });
+      const idxApply = steps.findIndex((s) => s.name === "apply-config");
+      const idxRefresh = steps.findIndex((s) => s.name === "refresh-hostd");
+      const idxSync = steps.findIndex((s) => s.name === "sync-bundled-skills");
+      const idxRecreate = steps.findIndex((s) => s.name === "recreate-containers");
+      expect(idxApply).toBeLessThan(idxRefresh);
+      expect(idxRefresh).toBeLessThan(idxSync);
+      expect(idxRefresh).toBeLessThan(idxRecreate);
+    });
+
+    it("runs (no skipReason) when host_control.enabled is true and --skip-images is not set", () => {
+      const { refresh } = planFor({ hostControlEnabled: true });
+      expect(refresh.skipReason).toBeUndefined();
+    });
+
+    it("skips with a clear reason when host_control is disabled", () => {
+      const { refresh } = planFor({ hostControlEnabled: false });
+      expect(refresh.skipReason).toMatch(/host_control\.enabled is not true/);
+    });
+
+    it("skips when --skip-images is set even with host_control enabled", () => {
+      const { refresh } = planFor({
+        hostControlEnabled: true,
+        skipImages: true,
+      });
+      expect(refresh.skipReason).toMatch(/--skip-images/);
+    });
+
+    it("invokes `switchroom hostd install` via re-exec when run()", () => {
+      const runner = fakeRunner();
+      const { refresh } = planFor({
+        hostControlEnabled: true,
+        runner: runner.fn,
+      });
+      refresh.run();
+      expect(runner.calls).toHaveLength(1);
+      const call = runner.calls[0]!;
+      // First positional arg after process.execPath is the CLI script
+      // path (process.argv[1]). The next two are the verb + subverb.
+      expect(call.args.slice(-2)).toEqual(["hostd", "install"]);
+    });
+
+    it("throws if hostd install exits non-zero", () => {
+      const runner = fakeRunner();
+      runner.setNextStatus(1);
+      const { refresh } = planFor({
+        hostControlEnabled: true,
+        runner: runner.fn,
+      });
+      expect(() => refresh.run()).toThrow(/switchroom hostd install failed/);
+    });
   });
 
   it("stamp-restart-marker runs before recreate-containers and writes a marker per agent", () => {
@@ -383,6 +452,12 @@ describe("runUpdate", () => {
         agentNamesFn: () => ["a", "b"],
         // No-op the sync-bundled-skills filesystem effect under tests.
         syncBundledSkillsFn: () => { /* intentional no-op */ },
+        // Pin host_control as disabled so refresh-hostd is skipped —
+        // separate test below covers the enabled case. Without this
+        // override, this test would pick up the host's real
+        // switchroom.yaml and the call count would depend on whether
+        // the developer running tests has hostd enabled.
+        hostControlEnabled: false,
       });
       expect(code).toBe(0);
       // 6 calls total:
@@ -414,6 +489,39 @@ describe("runUpdate", () => {
       // [5] <execPath> doctor
       expect(runner.calls[5]?.cmd).toBe(process.execPath);
       expect(runner.calls[5]?.args).toContain("doctor");
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("invokes `switchroom hostd install` between apply and stamp-marker when host_control is enabled (PR ε)", async () => {
+    const tmp = mkdtempSync(join(tmpdir(), "update-hostd-on-"));
+    try {
+      const composePath = join(tmp, "docker-compose.yml");
+      writeFileSync(composePath, "services: {}\n");
+      const out: string[] = [];
+      const runner = fakeRunner();
+      const code = await runUpdate({
+        composePath,
+        stdout: (s) => out.push(s),
+        stderr: (s) => out.push(s),
+        runner: runner.fn,
+        agentNamesFn: () => ["a"],
+        syncBundledSkillsFn: () => { /* intentional no-op */ },
+        hostControlEnabled: true,
+      });
+      expect(code).toBe(0);
+      // 6 calls total:
+      //   [0] docker compose pull
+      //   [1] <execPath> apply --non-interactive --no-doctor
+      //   [2] <execPath> hostd install                 ← NEW (PR ε)
+      //   [3] docker exec switchroom-a sh -c '…'  (stamp marker)
+      //   [4] docker compose up -d --remove-orphans
+      //   [5] <execPath> doctor
+      expect(runner.calls).toHaveLength(6);
+      // hostd install lands at position 2 (right after apply).
+      expect(runner.calls[2]?.cmd).toBe(process.execPath);
+      expect(runner.calls[2]?.args.slice(-2)).toEqual(["hostd", "install"]);
     } finally {
       rmSync(tmp, { recursive: true, force: true });
     }

--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -71,6 +71,9 @@ interface UpdateOptions {
   syncBundledSkillsFn?: () => void;
   /** Test seam — replace the marker writer used by stamp-restart-marker. */
   writeMarkerFn?: (agent: string, reason: string) => void;
+  /** Test seam — override `host_control.enabled` detection for the
+   *  `refresh-hostd` step instead of reading from switchroom.yaml. */
+  hostControlEnabled?: boolean;
 }
 
 interface UpdateStep {
@@ -181,6 +184,50 @@ export function planUpdate(opts: UpdateOptions): UpdateStep[] {
         "--no-doctor",
       ]);
       if (r.status !== 0) throw new Error("switchroom apply failed");
+    },
+  });
+
+  // refresh-hostd: pull the latest hostd image and recreate the daemon
+  // container. RFC C §5.1 keeps the daemon in its own compose project
+  // (`switchroom-hostd`, separate from the agent fleet's `switchroom`
+  // project) so the fleet's `up -d --remove-orphans` cycles can't
+  // accidentally recreate the daemon mid-RPC. The downside is that the
+  // daemon doesn't get pulled by the fleet's pull-images step — so
+  // before this step existed, operators who ran `switchroom update`
+  // after a hostd protocol bump would end up with a stale daemon
+  // serving an old verb set. Phase 2 (#1208) shipped new verbs but the
+  // daemon container kept refusing them with
+  // `invalid_union_discriminator` until the operator separately ran
+  // `switchroom hostd install`. This step folds that into the update.
+  //
+  // Skipped when host_control.enabled is false (no daemon to refresh)
+  // OR --skip-images is set (operator opted out of pulls in general).
+  // Mirrors how pull-images skips on --skip-images.
+  let hostControlEnabled: boolean;
+  if (typeof opts.hostControlEnabled === "boolean") {
+    hostControlEnabled = opts.hostControlEnabled;
+  } else {
+    try {
+      hostControlEnabled = loadConfig().host_control?.enabled === true;
+    } catch {
+      // Best-effort: if config can't be loaded, skip refresh-hostd
+      // rather than fail the whole update. Operators who care about
+      // hostd will hit the config error somewhere else in the pipeline.
+      hostControlEnabled = false;
+    }
+  }
+  steps.push({
+    name: "refresh-hostd",
+    description:
+      "switchroom hostd install — pull latest hostd image + recreate the daemon container (separate compose project, see RFC C §5.1)",
+    skipReason: !hostControlEnabled
+      ? "host_control.enabled is not true — daemon not in use"
+      : opts.skipImages
+        ? "--skip-images flag set"
+        : undefined,
+    run: () => {
+      const r = runner(process.execPath, [scriptPath, "hostd", "install"]);
+      if (r.status !== 0) throw new Error("switchroom hostd install failed");
     },
   });
 


### PR DESCRIPTION
## Summary

- **Closes a gap caught during PR δ rollout:** `switchroom update` previously did NOT refresh the hostd daemon container. Operators ended up with a stale daemon serving an old verb set every time the protocol bumped, and the only way to know was when MCP calls or gateway dispatches started failing with `invalid_union_discriminator`.
- **One new step inserted between `apply-config` and `sync-bundled-skills`**: `refresh-hostd` re-execs `switchroom hostd install`, which pulls latest + recreates the daemon container.
- **Skipped cleanly** when `host_control.enabled !== true` (no daemon to refresh) or `--skip-images` is set. Both surface a clear `skipReason` in `--check` output.

## Why this matters

Per RFC C §5.1, hostd lives in its own compose project (`switchroom-hostd`, separate from the agent fleet's `switchroom` project) so the fleet's `up -d --remove-orphans` cycles can't accidentally recreate the daemon mid-RPC. The trade-off: the fleet's `pull-images` step doesn't touch the daemon image either. After PR #1208 (Phase 2 verbs) shipped, klanker's MCP calls into hostd silently kept rejecting the new verbs until an operator separately ran `switchroom hostd install`. This PR folds that step in so the gap doesn't repeat.

## Placement
`pull-images → (rebuild) → apply-config → **refresh-hostd** → sync-bundled-skills → stamp-restart-marker → recreate-containers → doctor`

- AFTER `apply-config` so scaffold regen has settled the admin agent list (daemon binds one socket per admin)
- BEFORE `recreate-containers` so the new agent containers find a current daemon on their fresh boot

## Test plan
- [x] `npx vitest run src/cli/update.test.ts` — 26/26 pass.
- [x] `tsc --noEmit` clean.
- [x] `bun run build` + manual `switchroom update --check` — new step appears in the plan with the expected description.
- [ ] Operator verification: run `switchroom update` against the live fleet, confirm the daemon image hash updates as part of the cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)