### PR TITLE
chore: bump claude.cli pin to 2.1.140

### DIFF
--- a/dependencies.json
+++ b/dependencies.json
@@ -1,12 +1,12 @@
 {
   "switchroom_version": "0.7.3",
-  "tested_at": "2026-05-09T16:30:00+10:00",
+  "tested_at": "2026-05-13T22:30:00+10:00",
   "runtime": {
     "bun": "1.3.13",
     "node": "22.22.2"
   },
   "claude": {
-    "cli": "2.1.137"
+    "cli": "2.1.140"
   },
   "playwright_mcp": "0.0.71",
   "hindsight": {


### PR DESCRIPTION
## Summary

One-line bump in \`dependencies.json\`:
- \`claude.cli\`: 2.1.137 → 2.1.140
- \`tested_at\`: 2026-05-09 → 2026-05-13

\`switchroom doctor\` reported manifest drift on every host run because \`Dockerfile.base\` installs \`@anthropic-ai/claude-code@latest\`, which has moved to 2.1.140 across the fleet. The pin was just stale.

## Test plan

- [x] \`tests/manifest.test.ts\` — 15 tests passing
- [ ] Manual: \`switchroom doctor\` warning \"manifest drift: claude CLI\" should be gone after merge + sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)