### PR TITLE
feat(skill-coverage): inventory, audit, and probabilistic test harness

### DIFF
--- a/docs/skill-coverage/audit.md
+++ b/docs/skill-coverage/audit.md
@@ -1,0 +1,260 @@
+# Switchroom skill bundle audit
+
+Companion to `inventory.md`. Read that first — this file references skills by the exact names there.
+
+This audit feeds the probabilistic skill-coverage harness. Verdicts are biased toward "what will the fuzzer actually fire on?" rather than reading the SKILL.md charitably.
+
+## 1. Executive summary
+
+- **Pervasive missing negatives.** 21 of 27 skills carry `no-negatives` — most buildkite-* skills, `humanizer`, `humanizer-calibrate`, `mcp-builder`, `pdf`, `pptx`, `telegram-test-harness`, `webapp-testing`. Adjacent-but-wrong phrasings will rubber-stamp a fire. Highest-impact fixes are the `buildkite-cli` / `buildkite-pipelines` / `buildkite-api` triangle and the `pdf` / `pptx` / `webapp-testing` set.
+- **Switchroom-internal cluster is the cleanest negative-control discipline in the bundle** (`switchroom-cli`, `switchroom-status`, `switchroom-manage`, `switchroom-install`, `switchroom-architecture` all cite the rivals to defer to). The harness should expect ≥0.9 F1 there.
+- **`humanizer-calibrate`, `webapp-testing`, `mcp-builder` are likely under-triggers** — descriptions are abstract, no plain-language utterance enumeration. Will miss natural phrasings.
+- **`switchroom-runtime` cannot be fully NL-fuzzed.** Three of its five gates are side-channel signals (env var, sentinel file) — the harness must label those triggers as non-NL.
+- **Gaps:** no skill owns vault unlock flow, broker/socket recovery, `/restart` self-restart troubleshooting, agent-scheduler debugging, or progress-card editing. Operators will land in `switchroom-health` (too generic) or `file-bug` (too late). See §4.
+
+## 2. Per-skill audit
+
+### buildkite-agent-infrastructure
+- **Status:** NEEDS-FIX
+- **Trigger coverage assessment:** Strong concrete list. Will fire on the canonical operator phrasings ("create a cluster", "configure SSO", "manage agent tokens"). Ambiguity: "manage agent tokens" reads as runtime token use, not infra provisioning.
+- **Negative-control assessment:** Missing. Most plausible false-positive: *"I want to upload a build artifact using my agent token"* — runtime concern, will mis-fire here on the `agent tokens` substring.
+- **Execution coverage assessment:** Concrete — curl + GraphQL mutations, named reference files.
+- **Recommended fix:** Add "Do NOT use when..." pointing in-step token use → `buildkite-agent-runtime`; cluster CLI shortcuts → `buildkite-cli`.
+
+### buildkite-agent-runtime
+- **Status:** NEEDS-FIX
+- **Trigger coverage assessment:** Very strong — every subcommand named. Fires reliably on "annotate", "meta-data", "artifact upload".
+- **Negative-control assessment:** Missing. Most plausible false-positive: *"set up a cluster secret"* — secrets-related, but this is infra, not runtime `secret get`.
+- **Execution coverage assessment:** Concrete — flag tables, per-subcommand examples.
+- **Recommended fix:** Add a "Do NOT use when the user is provisioning/configuring rather than calling from inside a running step" clause naming `buildkite-agent-infrastructure` and `buildkite-secure-delivery` (for OIDC setup vs `oidc request-token`).
+
+### buildkite-api
+- **Status:** NEEDS-FIX
+- **Trigger coverage assessment:** Strong. "Call the Buildkite API", "GraphQL query" fire cleanly.
+- **Negative-control assessment:** Missing. Most plausible false-positive: *"trigger a build from the command line"* — operator wants `bk`, not curl.
+- **Execution coverage assessment:** Concrete — curl + jq, Python jwt examples, reference files.
+- **Recommended fix:** Add explicit "Do NOT use for interactive `bk` CLI usage — that's `buildkite-cli`" clause. Mention "one-shot terminal CI ops" as the disambiguator.
+
+### buildkite-cli
+- **Status:** NEEDS-FIX
+- **Trigger coverage assessment:** Strong, comprehensive verb list.
+- **Negative-control assessment:** Missing. Most plausible false-positive: *"write a pipeline YAML"* — fires on "create a pipeline" trigger but should route to `buildkite-pipelines`.
+- **Execution coverage assessment:** Concrete — full subcommand reference, MCP-tool equivalence callout.
+- **Recommended fix:** Add "Do NOT use when authoring `.buildkite/pipeline.yml` — that's `buildkite-pipelines`; or for scripted programmatic access — that's `buildkite-api`."
+
+### buildkite-migration
+- **Status:** OK
+- **Trigger coverage assessment:** Highly distinctive ("convert from Jenkins/GitHub Actions/CircleCI"). Will fire reliably.
+- **Negative-control assessment:** Implicit via specificity; explicit clause would be belt-and-braces but isn't load-bearing.
+- **Execution coverage assessment:** Concrete — `bk pipeline convert` invocation patterns.
+
+### buildkite-pipelines
+- **Status:** NEEDS-FIX
+- **Trigger coverage assessment:** Strong on YAML-authoring phrasings.
+- **Negative-control assessment:** Missing. Most plausible false-positive: *"add an annotation to the build page"* — should route to `buildkite-agent-runtime` (`buildkite-agent annotate`) when it's an in-step call, but this skill's `add annotations` trigger will grab it.
+- **Execution coverage assessment:** Concrete — YAML examples + `pipeline upload` invocation.
+- **Recommended fix:** Add a "Do NOT use when the user is invoking `buildkite-agent <subcommand>` inside a step — that's `buildkite-agent-runtime`" clause.
+
+### buildkite-secure-delivery
+- **Status:** NEEDS-FIX
+- **Trigger coverage assessment:** Strong on supply-chain phrasings.
+- **Negative-control assessment:** Missing. Most plausible false-positive: *"my step needs an OIDC token, how do I request one?"* — overlaps with `buildkite-agent-runtime`'s `oidc request-token`.
+- **Execution coverage assessment:** Concrete — OIDC plugin YAML, cosign, JWKS generation.
+- **Recommended fix:** Add "Do NOT use for in-step `buildkite-agent oidc request-token` — that's `buildkite-agent-runtime`. Use this for *setting up* OIDC trust, signing infrastructure, and SLSA provenance."
+
+### buildkite-test-engine
+- **Status:** OK
+- **Trigger coverage assessment:** Highly distinctive (`bktec`, "test splitting", "flaky tests"). Minimal overlap with other buildkite-* skills.
+- **Negative-control assessment:** Missing but low risk — no plausible competing skill.
+- **Execution coverage assessment:** Concrete — test-collector plugin, env wiring.
+
+### docx
+- **Status:** OK
+- **Trigger coverage assessment:** Extension-keyed + intent words ("Word doc", "report as docx"). Fires precisely.
+- **Negative-control assessment:** Explicit and correct. "Do NOT use for PDFs, spreadsheets, Google Docs..." is the exemplar pattern.
+- **Execution coverage assessment:** Concrete — pandoc + docx-js + python-docx workflows named.
+
+### file-bug
+- **Status:** OK
+- **Trigger coverage assessment:** Strong intent triggers ("file a bug", "open an issue"). Symptom-shaped phrasings handled too.
+- **Negative-control assessment:** Explicit anti-pattern section (no thin descriptions, no invented log lines, no mid-debug filing). Exemplar.
+- **Execution coverage assessment:** Concrete — six-phase forced workflow with named bash commands.
+
+### humanizer
+- **Status:** NEEDS-FIX
+- **Trigger coverage assessment:** Will fire on "make this sound human" but may miss "edit my text", "rewrite this draft" — abstract verb phrasings without "AI" in them.
+- **Negative-control assessment:** Missing. Most plausible false-positive: *"can you proofread this paragraph"* — generic editing, not de-AI-ification.
+- **Execution coverage assessment:** Body is an anti-pattern catalog + rewrite workflow; concrete enough but no single deliverable shape.
+- **Recommended fix:** Add "Do NOT use for proofreading, grammar fixes, or style edits where the input wasn't AI-generated. This skill specifically removes AI tells."
+
+### humanizer-calibrate
+- **Status:** NEEDS-FIX
+- **Trigger coverage assessment:** Description mentions a slash-command but won't fire on natural phrasings like "build a voice profile from my messages" or "tune the humanizer to my style". Flagged `no-triggers` in inventory.
+- **Negative-control assessment:** Missing. Most plausible false-positive: *"make this sound like me"* — could mis-fire onto `humanizer` instead.
+- **Execution coverage assessment:** Concrete — MCP tool calls + voice-template write path named.
+- **Recommended fix:** Enumerate NL phrasings: "build my voice template", "calibrate humanizer to my style", "fresh voice profile from my Telegram". Add "Do NOT use for one-shot rewrites — that's `humanizer`."
+
+### mcp-builder
+- **Status:** NEEDS-FIX
+- **Trigger coverage assessment:** "Build an MCP server" fires cleanly. Misses "add a tool to my MCP", "wrap this API as MCP" implicitly.
+- **Negative-control assessment:** Missing. Most plausible false-positive: *"create a new skill"* — sibling meta-skill `skill-creator` should win, but no explicit deferral.
+- **Execution coverage assessment:** Four-phase workflow but body-heavy and prose-shaped, not deliverable-shaped.
+- **Recommended fix:** Add "Do NOT use for skill authoring (that's `skill-creator`) or client-side MCP wiring."
+
+### pdf
+- **Status:** NEEDS-FIX
+- **Trigger coverage assessment:** Extension-keyed; fires on any `.pdf` mention.
+- **Negative-control assessment:** Missing. Most plausible false-positive: *"generate a report"* (no extension given) — could route to `docx`, `pptx`, or here ambiguously.
+- **Execution coverage assessment:** Concrete — pypdf/pdfplumber/reportlab/pdftotext.
+- **Recommended fix:** Add explicit "Do NOT use for Word, slides, or spreadsheet deliverables — `.pdf` must be the input or output." (Trivial fix, large precision win in fuzz.)
+
+### pptx
+- **Status:** NEEDS-FIX
+- **Trigger coverage assessment:** Fires on "deck", "slides", "presentation", ".pptx". Strong.
+- **Negative-control assessment:** Missing. Most plausible false-positive: *"draft a one-pager presentation as a Word doc"* — "presentation" trigger will grab it despite the deliverable being `.docx`.
+- **Execution coverage assessment:** Concrete — python-pptx + pptxgenjs + design QA loop.
+- **Recommended fix:** Add "Do NOT use when the deliverable is `.docx`, `.pdf`, or a non-slide format, even if the user says 'presentation'."
+
+### skill-creator
+- **Status:** OK
+- **Trigger coverage assessment:** Clear verb-set ("create a skill", "optimize a skill"). Fires only on meta-skill work.
+- **Negative-control assessment:** Implicit (verbs are skill-specific). Missing explicit but low risk.
+- **Execution coverage assessment:** Concrete — scaffolding + parallel eval runs.
+
+### switchroom-architecture
+- **Status:** OUT-OF-SCOPE-FOR-HARNESS
+- **Trigger coverage assessment:** `user-invocable: false` per inventory; explainer-only, no Bash. Triggers are conceptual single words ("architecture"). Don't NL-fuzz.
+- **Negative-control assessment:** Has explicit deferral to `switchroom-install` — good.
+- **Execution coverage assessment:** Read-only prose, by design.
+
+### switchroom-cli
+- **Status:** OK
+- **Trigger coverage assessment:** Exhaustive verb list with synonyms ("bounce", "kick", "it's stuck"). Will fire reliably.
+- **Negative-control assessment:** Explicit three-way deferral (manage / install / health). Highest disambiguation hygiene in the inventory.
+- **Execution coverage assessment:** Concrete Bash surface for every verb.
+
+### switchroom-health
+- **Status:** OK
+- **Trigger coverage assessment:** Strong on diagnostic phrasings ("my agents are broken", "diagnose", "what's wrong"). Cleanly distinguished from `switchroom-cli logs` ("specific crash" vs generic failure).
+- **Negative-control assessment:** Explicit prefer-this-over-logs clause; cites sibling.
+- **Execution coverage assessment:** Concrete — `switchroom doctor --json` + named fallback probes.
+
+### switchroom-install
+- **Status:** OK
+- **Trigger coverage assessment:** Onboarding phrasings well-covered ("first-time setup", "I'm new", "bootstrap from scratch").
+- **Negative-control assessment:** Explicit "not for managing existing agents → switchroom-manage".
+- **Execution coverage assessment:** Concrete — six-step bootstrap with named commands.
+
+### switchroom-manage
+- **Status:** OK
+- **Trigger coverage assessment:** Fleet-level verbs enumerated. "Reinstall my agents" disambiguated against `switchroom-install` explicitly — load-bearing.
+- **Negative-control assessment:** Explicit.
+- **Execution coverage assessment:** Concrete — Bash table mapping verbs to `switchroom agent <verb>`.
+
+### switchroom-runtime
+- **Status:** OK (with caveat)
+- **Trigger coverage assessment:** Five gated protocols. Triggers 1 and 2 are side-channel (env var / sentinel file) — **harness must label these non-NL**; triggers 3–5 are NL ("why did you restart?", "how do I cancel", "still there?") and concrete.
+- **Negative-control assessment:** Explicit — "Do NOT invoke for normal Telegram conversation, formatting, voice/sticker, MCP tool questions, persona". Strong.
+- **Execution coverage assessment:** Concrete — file reads + Bash + journal/container log probes per protocol.
+
+### switchroom-status
+- **Status:** OK
+- **Trigger coverage assessment:** "What agents are running" / "list agents" fires reliably.
+- **Negative-control assessment:** Explicit two-way deferral (version → `switchroom-cli`; broken → `switchroom-health`).
+- **Execution coverage assessment:** Concrete — mandates literal `switchroom agent list` invocation.
+
+### telegram-test-harness
+- **Status:** NEEDS-FIX
+- **Trigger coverage assessment:** Strong on testing intents ("test progress card", "mock the bot api"). Fires on the named harness fixtures.
+- **Negative-control assessment:** Missing. Most plausible false-positive: *"how do I render the progress card in production"* — fires on "progress card" but is a runtime concern (no skill owns this today — see §4).
+- **Execution coverage assessment:** Concrete — defers to HARNESS.md but names the fake-bot-api / update-factory entry points.
+- **Recommended fix:** Add "Do NOT use for live progress-card behavior or telegram-plugin runtime questions — this is strictly for writing Bun tests under `telegram-plugin/tests/`."
+
+### token-helpers
+- **Status:** OUT-OF-SCOPE-FOR-HARNESS
+- **Trigger coverage assessment:** Library skill with empty `trigger_phrases`. Explicitly "not directly by the user". Harness must label non-target.
+- **Negative-control assessment:** Has the library-skill clause.
+- **Execution coverage assessment:** Concrete — two named shell scripts.
+
+### webapp-testing
+- **Status:** NEEDS-FIX
+- **Trigger coverage assessment:** Short description (~250 chars), no enumerated NL phrasings. Will fire on "Playwright" or "test local web app" but miss "click through my UI", "automate this dashboard", "snapshot the frontend".
+- **Negative-control assessment:** Missing. Most plausible false-positive: *"test the telegram bot"* — both are "test" verbs; needs explicit cross-deferral to `telegram-test-harness`.
+- **Execution coverage assessment:** Concrete — `with_server.py` + Playwright scripts.
+- **Recommended fix:** Enumerate NL triggers; add "Do NOT use for Bot-API tests (`telegram-test-harness`), CLI tests (vitest under `tests/`), or non-web UI testing."
+
+### xlsx
+- **Status:** OK
+- **Trigger coverage assessment:** Extension + casual phrasings ("the xlsx in my downloads") covered. Strong.
+- **Negative-control assessment:** Explicit ban on Word / HTML / Python-script / DB-pipeline / Sheets-API deliverables. Exemplar.
+- **Execution coverage assessment:** Concrete — pandas + openpyxl + xlsxwriter standards.
+
+## 3. Overlap clusters
+
+### Cluster A: buildkite-cli vs buildkite-pipelines vs buildkite-api
+- **Conflict:** All three claim phrasings around "create / manage pipelines and builds". `buildkite-cli` says "create a pipeline" (CLI invocation), `buildkite-pipelines` claims "write a pipeline" (YAML authoring), `buildkite-api` claims "automate Buildkite" / "write a script that calls Buildkite".
+- **Competing skills:** `buildkite-cli`, `buildkite-pipelines`, `buildkite-api` (and `buildkite-migration` brushes on "convert my CI config").
+- **Disambiguation rule for the harness:**
+  - YAML file content / step types / `.buildkite/pipeline.yml` → `buildkite-pipelines`
+  - Interactive terminal verbs (`bk build view`, `bk pipeline list`) → `buildkite-cli`
+  - curl / GraphQL / programmatic / webhooks / "in a script" → `buildkite-api`
+  - "convert", "migrate", "switch from", "Jenkins/CircleCI/GHA equivalent" → `buildkite-migration` (wins over all three on these tokens)
+
+### Cluster B: buildkite-agent-runtime vs buildkite-agent-infrastructure vs buildkite-secure-delivery
+- **Conflict:** All three touch "OIDC", "tokens", "secrets", "annotations". Runtime is *in-step CLI invocation*, infrastructure is *cluster provisioning*, secure-delivery is *trust setup / signing*.
+- **Competing skills:** `buildkite-agent-runtime`, `buildkite-agent-infrastructure`, `buildkite-secure-delivery`, plus `buildkite-pipelines` ("add annotations" in YAML vs `buildkite-agent annotate`).
+- **Disambiguation rule for the harness:**
+  - Phrasing contains `buildkite-agent <subcommand>` literal → `buildkite-agent-runtime` (always wins)
+  - "Provision", "create", "configure", "scale", "set up cluster…" → `buildkite-agent-infrastructure`
+  - "Sign", "verify", "attestation", "SLSA", "JWKS", "cosign", *setup* of OIDC trust policies → `buildkite-secure-delivery`
+  - "Add annotation" inside a YAML step file → `buildkite-pipelines`; "add an annotation from my step" → `buildkite-agent-runtime`
+
+### Cluster C: switchroom-cli vs switchroom-health vs switchroom-status vs switchroom-manage vs switchroom-install
+- **Conflict:** Five-way fleet-of-skills cluster. The bundle already does the heavy lifting via cross-deferrals; harness just needs to score against the documented rules.
+- **Competing skills:** all five.
+- **Disambiguation rule for the harness:**
+  - "Bootstrap / first install / fresh machine / new to switchroom" → `switchroom-install`
+  - "Add agent / remove agent / reinstall agents / list my agents" → `switchroom-manage` (note: "reinstall *agents*" ≠ "reinstall *switchroom*")
+  - "Broken / diagnose / health check / something's wrong" generic → `switchroom-health`
+  - "What agents are running / uptime / how long has X been up" → `switchroom-status`
+  - All other runtime verbs against existing agents (logs, restart, update, version, apply, cron) → `switchroom-cli`
+
+### Cluster D: humanizer vs humanizer-calibrate
+- **Conflict:** Both touch voice / style of writing. Calibrate produces a template; humanizer applies edits.
+- **Competing skills:** `humanizer`, `humanizer-calibrate`.
+- **Disambiguation rule:** "Make this text sound human / remove AI tells / rewrite this draft" → `humanizer`. "Build / refresh my voice profile / sound like *me* (no specific text in hand)" → `humanizer-calibrate`. Slash-prefix `/humanizer-calibrate` always wins for calibrate.
+
+### Cluster E: switchroom-runtime vs file-bug
+- **Conflict:** Inventory flags `overlap:file-bug` on `switchroom-runtime`. The "status?" UX-failure handler offers to file an RCA via `/file-bug`.
+- **Disambiguation rule:** Runtime is the *handler* for the UX-failure signal; if the user explicitly says "file a bug" → `file-bug` wins. If the user sends bare "status?" / "still there?" → `switchroom-runtime` wins and may then chain to `file-bug` as a follow-up offer.
+
+## 4. Gaps — common agent needs without a skill
+
+1. **Vault unlock flow / auto-unlock recovery.** Operators routinely hit "broker is locked, what now?" — `switchroom vault broker unlock`, `enable-auto-unlock`, interactive unlock from a Telegram DM. `switchroom-health` will *detect* the lock but not own the unlock recipe. Currently falls between `switchroom-cli` and `switchroom-health`.
+2. **Self-restart / `/restart` troubleshooting.** The CLAUDE.md describes a load-bearing detached-spawn + restart-marker dance. When `/restart`, `/new`, `/reset`, or `/update apply` from Telegram doesn't return a boot card, the operator needs a recipe to read the restart marker, check the sweep, and confirm the detached spawn fired. No skill owns this.
+3. **Broker / kernel socket recovery.** Path-as-identity model: a missing `/run/switchroom/broker/<agent>/sock` after a recreate is a known failure mode. The canonical question "how do I reset the broker socket for agent X" has no skill — operators end up in `switchroom-health`'s doctor sweep, which reports but doesn't fix.
+4. **Agent-scheduler (in-container cron) debugging.** Phase-4 fold-in introduced `/state/agent/scheduler.jsonl`, the boot replay window, and the `SWITCHROOM_INLINE_SCHEDULER=0` kill-switch. "My cron didn't fire" is a JTBD; `switchroom-cli` lists schedules but doesn't debug them.
+5. **Progress-card editing / rendering.** Telegram-plugin's pinned progress card is the headline feature. `telegram-test-harness` only covers writing *tests* for it; no skill covers reading the current card state or editing the renderer/templates for a live agent.
+6. **Hostd / host-control daemon ops.** New separate compose project (per CLAUDE.md memory). `switchroom hostd install`, `switchroom update`'s hostd refresh path, and "why is hostd unhealthy" diagnostics — no skill owns the hostd surface yet, and the canonical CLAUDE.md flags it as load-bearing for `/update apply` on docker hosts.
+
+## 5. Threshold-prediction
+
+Predictions are for *as-is* skills (no fixes applied) against ≥0.9 F1 / ≥0.95 execution success.
+
+| Skill | Predicted F1 ≥0.9? | Predicted exec ≥0.95? | Rationale |
+|---|---|---|---|
+| buildkite-agent-infrastructure | No (≈0.75) | Yes | "manage agent tokens" will bleed in from runtime concerns. Execution surface is solid. |
+| buildkite-agent-runtime | Borderline (≈0.85) | Yes | Subcommand-keyed triggers are precise but no negative-control to suppress infra / secure-delivery overlap. |
+| buildkite-api | No (≈0.80) | Yes | Programmatic-vs-interactive ambiguity. Will lose phrasings to `buildkite-cli`. |
+| buildkite-cli | No (≈0.78) | Yes | "Create a pipeline" overlap with `buildkite-pipelines` is unresolved. |
+| buildkite-pipelines | No (≈0.80) | Yes | "Add annotations" overlap with runtime. |
+| buildkite-secure-delivery | Borderline (≈0.85) | Yes | OIDC overlap with runtime. |
+| humanizer | Borderline (≈0.85) | Yes | Generic-editing phrasings will false-positive. |
+| humanizer-calibrate | No (≈0.55) | Yes | `no-triggers` flag — natural utterances will route to `humanizer`. Almost certainly misses threshold. |
+| mcp-builder | Borderline (≈0.80) | Borderline | Body is prose-shaped; deliverable not crisp. Could miss exec threshold on first-shot scaffolding. |
+| pdf | Yes (≈0.92) | Yes | Extension-keyed precision saves it despite missing negatives. |
+| pptx | Borderline (≈0.85) | Yes | "Presentation" trigger leaks into docx territory. |
+| telegram-test-harness | Borderline (≈0.85) | Yes | "Test progress card" phrasing ambiguous with live-runtime questions. |
+| webapp-testing | No (≈0.65) | Yes | `short, no-triggers, no-negatives` triple-flag. Almost certainly misses threshold; will under-fire on natural NL utterances and over-fire on generic "test" phrasings.
+
+**Likely-to-miss-threshold-even-after-fixes if not also expanded:** `humanizer-calibrate` and `webapp-testing`. Both need real trigger enumeration, not just a negative clause, because the *positive* coverage is thin.

--- a/docs/skill-coverage/inventory.md
+++ b/docs/skill-coverage/inventory.md
@@ -1,0 +1,988 @@
+# Switchroom skill bundle inventory
+
+Source: `/home/kenthompson/code/switchroom-skill-coverage/skills/*/SKILL.md` at the worktree HEAD. Read-only inventory feeding the probabilistic skill-coverage harness.
+
+Skill count: **27**. Profile-overlay count: **7** (3 `_shared` fragments + 4 profile `CLAUDE.md.hbs`).
+
+## Summary table
+
+| Skill name | Category | Flag count | One-line description |
+|---|---|---|---|
+| buildkite-agent-infrastructure | buildkite | 1 | Provision and govern Buildkite clusters, queues, hosted agents, secrets, tokens, SSO, audit, cost. |
+| buildkite-agent-runtime | buildkite | 1 | `buildkite-agent` subcommands run inside a job step — annotate, artifact, meta-data, pipeline upload, OIDC, lock, env, secret, redactor, tool sign. |
+| buildkite-api | buildkite | 1 | REST + GraphQL + webhooks for programmatic Buildkite automation. |
+| buildkite-cli | buildkite | 1 | Terminal `bk` CLI — builds, jobs, pipelines, secrets, artifacts, clusters, packages. |
+| buildkite-migration | buildkite | 1 | Convert pipelines from GitHub Actions / Jenkins / CircleCI / Bitbucket / GitLab to Buildkite YAML via `bk pipeline convert`. |
+| buildkite-pipelines | buildkite | 1 | Author `.buildkite/pipeline.yml` — step types, caching, parallelism, retries, dynamic pipelines, matrix, plugins. |
+| buildkite-secure-delivery | buildkite | 1 | OIDC, SLSA provenance, Package Registry publishing, JWKS pipeline signing. |
+| buildkite-test-engine | buildkite | 1 | `bktec` test splitting, flaky-test detection, collectors, quarantine. |
+| docx | document-format | 1 | Create, read, edit `.docx` Word documents (pandoc + docx-js). |
+| file-bug | switchroom-internal | 1 | File a high-quality bug report against switchroom (or configured repo) via `gh issue create`. |
+| humanizer | generic-meta | 1 | Remove signs of AI-generated writing from text. |
+| humanizer-calibrate | humanizer/calibrate | 1 | Build a personal voice template for `humanizer` from the user's recent Telegram messages. |
+| mcp-builder | mcp-builder | 1 | Guide for creating high-quality MCP servers (FastMCP / TS SDK). |
+| pdf | document-format | 1 | Read, edit, merge, split, OCR, fill, encrypt `.pdf` files. |
+| pptx | document-format | 1 | Create / read / edit `.pptx` slide decks. |
+| skill-creator | generic-meta | 1 | Create, edit, optimize, and benchmark skills. |
+| switchroom-architecture | switchroom-internal | 2 | Internal architecture of switchroom — cascade, profiles, lifecycle, plugin system. |
+| switchroom-cli | switchroom-internal | 2 | `switchroom` CLI operations on existing agents — logs, update, restart, version, config inspection, scheduled tasks, plugin reference. |
+| switchroom-health | switchroom-internal | 1 | Health-check / diagnostic sweep ("my agents are broken"). |
+| switchroom-install | switchroom-internal | 1 | First-time bootstrap of switchroom + dependencies on a fresh machine. |
+| switchroom-manage | switchroom-internal | 1 | Add / remove / reinstall / list agents (fleet-level). |
+| switchroom-runtime | switchroom-internal | 2 | Conditional runtime protocols (interrupted-turn resume, wake audit, "why did you restart", `!` interrupt). |
+| switchroom-status | switchroom-internal | 1 | `switchroom agent list` — running agents, uptime, model, state. |
+| telegram-test-harness | telegram-test | 1 | Deterministic Bot-API mock harness for switchroom Telegram tests. |
+| token-helpers | switchroom-internal | 2 | Library skill — refresh Google Calendar / MS Graph OAuth tokens from the vault. |
+| webapp-testing | generic-meta | 1 | Playwright-based local webapp testing. |
+| xlsx | document-format | 1 | Create / read / edit `.xlsx`, `.csv`, `.tsv` spreadsheets. |
+
+Flag legend (`description_quality_flags`): `short` (<30 chars), `long` (>500 chars), `no-triggers` (no concrete trigger phrasings), `no-negatives` (no "do not use when" clause), `overlap:<other>` (overlapping trigger phrasings with another inventoried skill). The single-flag baseline below is "no-negatives" for skills that lack an explicit anti-trigger section — pervasive across the buildkite + Anthropic-bundled skills.
+
+---
+
+## buildkite-agent-infrastructure
+
+```yaml
+name: buildkite-agent-infrastructure
+description_raw: |
+  This skill should be used when the user asks to "create a cluster",
+  "create a queue", "set up hosted agents", "configure agents",
+  "right-size instance shapes", "scale queues", "manage cluster secrets",
+  "create a pipeline template", "set up audit logging", "configure SSO",
+  "set up SAML", "manage agent tokens", "optimize CI costs", or
+  "standardize pipelines across teams".
+  Also use when the user mentions buildkite-agent.cfg, agent tags, agent tokens,
+  cluster queues, hosted agent instance shapes, pipeline templates, audit events,
+  SSO/SAML providers, queue wait time, agent lifecycle hooks, or asks about
+  Buildkite CI infrastructure provisioning, platform governance, or
+  organization-level configuration.
+trigger_phrases:
+  - "create a cluster"
+  - "create a queue"
+  - "set up hosted agents"
+  - "configure agents"
+  - "right-size instance shapes"
+  - "scale queues"
+  - "manage cluster secrets"
+  - "create a pipeline template"
+  - "set up audit logging"
+  - "configure SSO"
+  - "set up SAML"
+  - "manage agent tokens"
+  - "optimize CI costs"
+  - "standardize pipelines across teams"
+  - mentions of buildkite-agent.cfg, agent tags, agent tokens, cluster queues,
+    instance shapes, pipeline templates, audit events, SSO/SAML providers,
+    queue wait time, agent lifecycle hooks
+negative_signals: []
+body_summary: |
+  Walks the agent through provisioning Buildkite clusters via REST + GraphQL,
+  creating queues with instance shapes, agent tokens, cluster secrets,
+  lifecycle hooks, plugin allowlists, pipeline templates (Enterprise), audit
+  logging, SSO/SAML, and queue cost optimization. Heavy cross-references to
+  sister buildkite-* skills.
+execution_surface:
+  - curl against api.buildkite.com/v2 and graphql.buildkite.com/v1
+  - clusterCreate / clusterQueueCreate / clusterQueuePauseDispatch GraphQL mutations
+  - cluster + agent-token REST endpoints
+  - references/{instance-shapes,graphql-mutations,self-hosted-agents,pipeline-templates,audit-logging,sso-saml}.md
+category: buildkite
+description_quality_flags: [no-negatives]
+```
+
+Concrete trigger list and "Also use when..." stem are unambiguous, but the skill has no "do NOT use when" clause — overlapping infra surface with `buildkite-cli` (cluster CLI commands) and `buildkite-pipelines` (pipeline templates) is only flagged via prose "see the X skill" footnotes. Harness should expect bleed between these four buildkite skills on phrasings like "manage agents" or "create a pipeline".
+
+## buildkite-agent-runtime
+
+```yaml
+name: buildkite-agent-runtime
+description_raw: |
+  This skill should be used when the user asks to "add an annotation",
+  "upload artifacts from a step", "share data between steps", "upload pipeline
+  dynamically", "request an OIDC token inside a step", "acquire a distributed lock",
+  "get or update a step attribute", "redact a secret from logs", "retrieve a cluster
+  secret at runtime", or "debug environment variables in hooks".
+  Also use when the user mentions buildkite-agent annotate, buildkite-agent artifact
+  upload/download, buildkite-agent meta-data set/get, buildkite-agent pipeline upload,
+  buildkite-agent oidc request-token, buildkite-agent step, buildkite-agent lock,
+  buildkite-agent env, buildkite-agent secret get, buildkite-agent redactor add,
+  buildkite-agent tool sign/verify, or any buildkite-agent subcommand used inside
+  a running job step.
+trigger_phrases:
+  - "add an annotation"
+  - "upload artifacts from a step"
+  - "share data between steps"
+  - "upload pipeline dynamically"
+  - "request an OIDC token inside a step"
+  - "acquire a distributed lock"
+  - "get or update a step attribute"
+  - "redact a secret from logs"
+  - "retrieve a cluster secret at runtime"
+  - "debug environment variables in hooks"
+  - mentions of buildkite-agent annotate/artifact/meta-data/pipeline upload/oidc/step/lock/env/secret/redactor/tool subcommands
+negative_signals: []
+body_summary: |
+  Reference for every `buildkite-agent` in-step subcommand: annotate, artifact,
+  meta-data, pipeline upload, oidc request-token, step, lock, env, secret,
+  redactor, tool sign/verify. Each section has flag tables, examples, and
+  "common mistakes". Points at `buildkite-cli` for terminal-side `bk` and at
+  `buildkite-agent-infrastructure` for cluster-side setup.
+execution_surface:
+  - in-step bash invocations of buildkite-agent <subcommand>
+  - references/{flag-reference,patterns-and-recipes}.md
+category: buildkite
+description_quality_flags: [no-negatives]
+```
+
+Clean and concrete. Potential phrasing overlap with `buildkite-agent-infrastructure` on the word "manage agent tokens" / "secrets" — runtime is for *inside a step*, infrastructure is for *cluster-level provisioning*. Harness should keep that split as a labeled axis.
+
+## buildkite-api
+
+```yaml
+name: buildkite-api
+description_raw: |
+  This skill should be used when the user asks to "call the Buildkite API",
+  "use the REST API", "write a GraphQL query", "set up webhooks",
+  "automate Buildkite", "integrate with Buildkite programmatically",
+  "write a script that calls Buildkite", "handle webhook events",
+  "paginate API results", or "authenticate with the Buildkite API".
+  Also use when the user mentions api.buildkite.com, graphql.buildkite.com,
+  Buildkite REST endpoints, GraphQL mutations, webhook payloads,
+  API tokens, or asks about programmatic access to Buildkite data.
+trigger_phrases:
+  - "call the Buildkite API"
+  - "use the REST API"
+  - "write a GraphQL query"
+  - "set up webhooks"
+  - "automate Buildkite"
+  - "integrate with Buildkite programmatically"
+  - "write a script that calls Buildkite"
+  - "handle webhook events"
+  - "paginate API results"
+  - "authenticate with the Buildkite API"
+  - mentions of api.buildkite.com / graphql.buildkite.com / webhook payloads / API tokens
+negative_signals: []
+body_summary: |
+  REST + GraphQL + webhooks reference: auth (Bearer + JWT), full endpoint
+  table, pagination, build CRUD, error codes, REST-vs-GraphQL decision guide,
+  webhook signatures. Cross-refs `buildkite-cli` (`bk api`), MCP-server tools,
+  and the secure-delivery skill for token claims.
+execution_surface:
+  - curl + jq pipelines, Python jwt encoding
+  - references/{graphql-reference,webhooks,patterns}.md
+category: buildkite
+description_quality_flags: [no-negatives]
+```
+
+Triggers overlap with `buildkite-cli` (`bk api`) and `buildkite-agent-infrastructure` (GraphQL mutations for clusters). The decision boundary is "writing a script vs. running a one-shot CLI" — make sure the harness corpus probes both phrasings.
+
+## buildkite-cli
+
+```yaml
+name: buildkite-cli
+description_raw: |
+  This skill should be used when the user asks to "trigger a build",
+  "check build status", "watch a build", "view build logs", "retry a build",
+  "cancel a build", "list builds", "download artifacts", "upload artifacts",
+  "manage secrets", "create a pipeline", "list pipelines", or
+  "interact with Buildkite from the command line".
+  Also use when the user mentions bk commands, bk build, bk job, bk pipeline,
+  bk secret, bk artifact, bk cluster, bk package, bk auth, bk configure,
+  bk use, bk init, bk api, or asks about Buildkite CLI installation,
+  terminal-based Buildkite workflows, or command-line CI/CD operations.
+trigger_phrases:
+  - "trigger a build"
+  - "check build status"
+  - "watch a build"
+  - "view build logs"
+  - "retry a build" / "cancel a build" / "list builds"
+  - "download artifacts" / "upload artifacts"
+  - "manage secrets"
+  - "create a pipeline" / "list pipelines"
+  - "interact with Buildkite from the command line"
+  - mentions of bk build/job/pipeline/secret/artifact/cluster/package/auth/configure/use/init/api
+negative_signals: []
+body_summary: |
+  Reference for the `bk` CLI: install, `bk configure`/`bk auth login`, build
+  create/view/list/watch/cancel/retry, job log/retry/cancel, pipeline
+  list/create/update/convert, secret CRUD, artifact upload/download, cluster
+  view, package push, `bk api`, and MCP-tool equivalents.
+execution_surface:
+  - bash bk subcommands, ~/.config/bk.yaml
+  - references/command-reference.md
+category: buildkite
+description_quality_flags: [no-negatives]
+```
+
+Phrasing overlap with `buildkite-pipelines` ("create a pipeline" — CLI vs. YAML authoring) and `buildkite-api` (programmatic vs. interactive). Body has a clear "When to use CLI vs MCP" callout that the harness can score against.
+
+## buildkite-migration
+
+```yaml
+name: buildkite-migration
+description_raw: |
+  This skill should be used when the user asks to "migrate to Buildkite",
+  "convert pipelines from Jenkins", "convert GitHub Actions workflows",
+  "convert CircleCI config", "convert Bitbucket Pipelines", "convert GitLab CI",
+  "migrate CI/CD to Buildkite", "switch from Jenkins to Buildkite",
+  "move from GitHub Actions", "plan a CI migration", "convert my CI config",
+  "bk pipeline convert", or "what's the Buildkite equivalent of".
+  Also use when the user mentions migration planning, CI conversion,
+  pipeline conversion, converting workflows, or asks about translating
+  CI/CD configuration from another provider to Buildkite.
+trigger_phrases:
+  - "migrate to Buildkite"
+  - "convert pipelines from Jenkins / GitHub Actions / CircleCI / Bitbucket / GitLab"
+  - "switch from Jenkins to Buildkite"
+  - "plan a CI migration"
+  - "convert my CI config"
+  - "bk pipeline convert"
+  - "what's the Buildkite equivalent of"
+negative_signals: []
+body_summary: |
+  `bk pipeline convert` reference + agent workflow for translating CI configs
+  from GitHub Actions / Jenkins / CircleCI / Bitbucket / GitLab / Harness /
+  Bitrise to Buildkite YAML. No login required.
+execution_surface:
+  - bk pipeline convert -F / --vendor / --output / stdin
+category: buildkite
+description_quality_flags: [no-negatives]
+```
+
+Triggers are highly distinctive — minimal overlap with the other buildkite-* skills (only `buildkite-cli` mentions `bk pipeline convert` in passing).
+
+## buildkite-pipelines
+
+```yaml
+name: buildkite-pipelines
+description_raw: |
+  This skill should be used when the user asks to "write a pipeline",
+  "add caching", "make this build faster", "show test failures in the build page",
+  "add annotations", "only run tests when code changes", "set up dynamic pipelines",
+  "add retry", "parallel steps", "matrix build", "add plugins", or
+  "work with artifacts in pipeline YAML".
+  Also use when the user mentions .buildkite/ directory, pipeline.yml,
+  buildkite-agent pipeline upload, step types (command, wait, block, trigger,
+  group, input), if_changed, notify, concurrency, or asks about Buildkite CI
+  configuration.
+trigger_phrases:
+  - "write a pipeline"
+  - "add caching" / "make this build faster"
+  - "show test failures in the build page" / "add annotations"
+  - "only run tests when code changes"
+  - "set up dynamic pipelines"
+  - "add retry" / "parallel steps" / "matrix build" / "add plugins"
+  - "work with artifacts in pipeline YAML"
+  - mentions of .buildkite/, pipeline.yml, step types, if_changed, notify, concurrency
+negative_signals: []
+body_summary: |
+  Pipeline-YAML reference: step types, caching, fast-fail, parallelism /
+  dependencies, annotations, retry, dynamic pipelines, conditionals
+  (`if_changed`), matrix builds, plugins, notifications, artifacts.
+execution_surface:
+  - .buildkite/pipeline.yml authoring
+  - `buildkite-agent pipeline upload` invocations
+category: buildkite
+description_quality_flags: [no-negatives]
+```
+
+Trigger phrase "add annotations" overlaps `buildkite-agent-runtime` ("add an annotation"). The body cleanly distinguishes "declarative YAML key" vs "in-step subcommand" via cross-refs — flag for harness scoring.
+
+## buildkite-secure-delivery
+
+```yaml
+name: buildkite-secure-delivery
+description_raw: |
+  This skill should be used when the user asks to "publish to package registry",
+  "push a Docker image", "set up OIDC authentication", "request an OIDC token",
+  "authenticate without static credentials", "set up SLSA provenance",
+  "generate attestation", "sign pipelines", "verify pipeline signatures",
+  or "secure the supply chain".
+  Also use when the user mentions OIDC, SLSA, provenance, attestation, cosign,
+  JWKS, pipeline signing, pipeline verification, packages.buildkite.com,
+  Package Registry, artifact signing, or asks about credential-free publishing,
+  supply chain security, or secure delivery in Buildkite.
+trigger_phrases:
+  - "publish to package registry" / "push a Docker image"
+  - "set up OIDC authentication" / "request an OIDC token"
+  - "authenticate without static credentials"
+  - "set up SLSA provenance" / "generate attestation"
+  - "sign pipelines" / "verify pipeline signatures"
+  - "secure the supply chain"
+  - mentions of OIDC / SLSA / provenance / attestation / cosign / JWKS / packages.buildkite.com
+negative_signals: []
+body_summary: |
+  OIDC auth (Package Registry + cloud providers), SLSA provenance attestations,
+  Package Registry ecosystems + Docker/OCI publishing, JWKS pipeline signing
+  setup + rollout, end-to-end secure publish flow.
+execution_surface:
+  - YAML steps with OIDC plugin
+  - cosign attest / verify
+  - JWKS keypair generation + verifying-keys config
+category: buildkite
+description_quality_flags: [no-negatives]
+```
+
+"request an OIDC token" overlaps `buildkite-agent-runtime`. Secure-delivery is the strategy/setup skill; runtime is the in-step CLI. Distinct enough for the harness.
+
+## buildkite-test-engine
+
+```yaml
+name: buildkite-test-engine
+description_raw: |
+  This skill should be used when the user asks to "split tests across machines",
+  "set up test splitting", "parallelize test suite", "detect flaky tests",
+  "quarantine flaky tests", "configure test collectors", "speed up tests",
+  "set up bktec", "configure test engine", or "reduce flaky test failures".
+  Also use when the user mentions bktec, Test Engine, test suites,
+  BUILDKITE_TEST_ENGINE_* environment variables, BUILDKITE_ANALYTICS_TOKEN,
+  test-collector plugin, test reliability scores, test timing data,
+  or asks about Buildkite test splitting and flaky test management.
+trigger_phrases:
+  - "split tests across machines" / "set up test splitting" / "parallelize test suite"
+  - "detect flaky tests" / "quarantine flaky tests" / "reduce flaky test failures"
+  - "configure test collectors" / "speed up tests"
+  - "set up bktec" / "configure test engine"
+  - mentions of bktec / Test Engine / BUILDKITE_TEST_ENGINE_* / BUILDKITE_ANALYTICS_TOKEN / test-collector
+negative_signals: []
+body_summary: |
+  Test Engine + bktec reference: suite creation, collectors, env vars,
+  timing-based test splitting, flaky-test detection / quarantine, MCP tools.
+execution_surface:
+  - test-collector plugin YAML
+  - bktec CLI invocations
+  - BUILDKITE_TEST_ENGINE_* / BUILDKITE_ANALYTICS_TOKEN env wiring
+category: buildkite
+description_quality_flags: [no-negatives]
+```
+
+Highly distinctive triggers; minimal overlap.
+
+## docx
+
+```yaml
+name: docx
+description_raw: |
+  Use this skill whenever the user wants to create, read, edit, or manipulate
+  Word documents (.docx files). Triggers include: any mention of 'Word doc',
+  'word document', '.docx', or requests to produce professional documents with
+  formatting like tables of contents, headings, page numbers, or letterheads.
+  Also use when extracting or reorganizing content from .docx files, inserting
+  or replacing images in documents, performing find-and-replace in Word files,
+  working with tracked changes or comments, or converting content into a
+  polished Word document. If the user asks for a 'report', 'memo', 'letter',
+  'template', or similar deliverable as a Word or .docx file, use this skill.
+  Do NOT use for PDFs, spreadsheets, Google Docs, or general coding tasks
+  unrelated to document generation.
+trigger_phrases:
+  - "Word doc" / "word document" / ".docx"
+  - "tables of contents" / "headings" / "page numbers" / "letterheads"
+  - "tracked changes" / "comments"
+  - "report" / "memo" / "letter" / "template" (as Word file)
+negative_signals:
+  - "Do NOT use for PDFs, spreadsheets, Google Docs, or general coding tasks unrelated to document generation"
+body_summary: |
+  Pandoc and docx-js workflows for reading, accepting tracked changes,
+  creating new .docx (styles, lists, tables, images, page breaks, footnotes),
+  converting to images. Heavy formatting + validation guidance.
+execution_surface:
+  - pandoc invocations
+  - docx-js (Node)
+  - python-docx for tracked changes / XML access
+  - LibreOffice / unoconv for image conversion
+category: document-format
+description_quality_flags: []
+```
+
+Has explicit `negative_signals` block, which is rare in this inventory. Overlaps the words "report" / "template" with `xlsx` and `pptx` — but the file extension claim is unambiguous.
+
+## file-bug
+
+```yaml
+name: file-bug
+description_raw: |
+  File a high-quality bug report against switchroom (or another configured
+  repo). Pulls the right log files automatically, forces a root-cause section
+  with citations, flags logging gaps when RCA can't be pinned, and files via
+  `gh issue create`. Use when a user asks "file a bug", "open an issue", or
+  describes a symptom that needs a real ticket.
+trigger_phrases:
+  - "file a bug"
+  - "open an issue"
+  - "raise a ticket" / "log this"
+  - any symptom that "needs a real ticket"
+negative_signals:
+  - "Do not auto-file from a thin description"
+  - "Do not invent log lines or paste paraphrased excerpts"
+  - "Do not file when the user is in the middle of debugging"
+body_summary: |
+  Six-phase forced workflow: lock the symptom, pull logs, build a timeline,
+  RCA, related issues, then `gh issue create`. Anti-stub philosophy — refuses
+  thin tickets.
+execution_surface:
+  - `gh issue create`, `gh search`
+  - journalctl / docker logs reads
+  - log-file Grep + Read
+category: switchroom-internal
+description_quality_flags: []
+```
+
+Has explicit "Non-goals" / "Anti-patterns" sections — exemplar for the harness scorecard.
+
+## humanizer-calibrate
+
+```yaml
+name: humanizer-calibrate
+description_raw: |
+  Build a personal voice template for the humanizer skill from the user's
+  recent Telegram messages. Reads the local message buffer, summarises
+  vocabulary / sentence shape / formatting habits, writes a markdown template
+  the humanizer will match against.
+trigger_phrases:
+  - "/humanizer-calibrate" (slash invocation)
+  - "make humanizer sound more like me"
+  - "fresh voice template"
+negative_signals: []
+body_summary: |
+  Pulls recent Telegram messages via MCP, distils sentence shape / register /
+  habits / signature phrases / counter-patterns into a markdown voice template
+  written to skills/humanizer/voice-template.md.
+execution_surface:
+  - mcp__switchroom-telegram__get_recent_messages
+  - mcp__hindsight__recall
+  - Read / Write / Edit
+category: humanizer/calibrate
+description_quality_flags: [no-triggers]
+```
+
+The description hints at the slash-command but doesn't enumerate plain-English phrasings — flag for harness scoring (likely under-triggers on natural utterances).
+
+## humanizer
+
+```yaml
+name: humanizer
+description_raw: |
+  Remove signs of AI-generated writing from text. Use when editing or
+  reviewing text to make it sound more natural and human-written. Based on
+  Wikipedia's comprehensive "Signs of AI writing" guide. Detects and fixes
+  patterns including: inflated symbolism, promotional language, superficial
+  -ing analyses, vague attributions, em dash overuse, rule of three, AI
+  vocabulary words, passive voice, negative parallelisms, and filler phrases.
+trigger_phrases:
+  - "remove signs of AI writing"
+  - "make this sound more human"
+  - "edit / review text"
+  - mentions of em-dash overuse / passive voice / AI vocabulary
+negative_signals: []
+body_summary: |
+  Long anti-pattern catalog from Wikipedia's "Signs of AI writing". Workflow:
+  identify patterns, rewrite, preserve meaning, match tone. Optional voice-
+  calibration step.
+execution_surface:
+  - Read / Edit / Write / Grep / Glob
+  - AskUserQuestion for voice sample
+category: generic-meta
+description_quality_flags: [no-negatives]
+```
+
+Triggers are intent-shaped ("make this sound human"), reliable. Calibration handoff is implicit.
+
+## mcp-builder
+
+```yaml
+name: mcp-builder
+description_raw: |
+  Guide for creating high-quality MCP (Model Context Protocol) servers that
+  enable LLMs to interact with external services through well-designed tools.
+  Use when building MCP servers to integrate external APIs or services,
+  whether in Python (FastMCP) or Node/TypeScript (MCP SDK).
+trigger_phrases:
+  - "build an MCP server"
+  - "integrate external API as MCP"
+  - "FastMCP" / "MCP SDK"
+negative_signals: []
+body_summary: |
+  Four-phase workflow (research → implementation → review → evaluations).
+  Heavy reliance on bundled reference docs loaded per phase.
+execution_surface:
+  - Python (FastMCP) or Node/TS (MCP SDK) scaffolding
+  - bundled SDK + evaluation reference files
+category: mcp-builder
+description_quality_flags: [no-negatives]
+```
+
+Description is concrete enough but body-heavy; would benefit from explicit "do NOT use for client-side MCP wiring or skill authoring (see skill-creator)".
+
+## pdf
+
+```yaml
+name: pdf
+description_raw: |
+  Use this skill whenever the user wants to do anything with PDF files. This
+  includes reading or extracting text/tables from PDFs, combining or merging
+  multiple PDFs into one, splitting PDFs apart, rotating pages, adding
+  watermarks, creating new PDFs, filling PDF forms, encrypting/decrypting
+  PDFs, extracting images, and OCR on scanned PDFs to make them searchable.
+  If the user mentions a .pdf file or asks to produce one, use this skill.
+trigger_phrases:
+  - any operation on .pdf
+  - "extract text from PDF" / "extract tables from PDF"
+  - "merge PDFs" / "split PDF" / "rotate pages"
+  - "watermark" / "fill PDF form" / "encrypt PDF" / "OCR a scanned PDF"
+negative_signals: []
+body_summary: |
+  Python (pypdf, pdfplumber, reportlab) and CLI (pdftotext) workflows for
+  reading, splitting, merging, generating PDFs, with form-fill instructions
+  in FORMS.md.
+execution_surface:
+  - python: pypdf / pdfplumber / reportlab
+  - poppler-utils (pdftotext)
+  - REFERENCE.md / FORMS.md
+category: document-format
+description_quality_flags: [no-negatives]
+```
+
+Extension-keyed and high-precision.
+
+## pptx
+
+```yaml
+name: pptx
+description_raw: |
+  Use this skill any time a .pptx file is involved in any way — as input,
+  output, or both. This includes: creating slide decks, pitch decks, or
+  presentations; reading, parsing, or extracting text from any .pptx file
+  (even if the extracted content will be used elsewhere, like in an email or
+  summary); editing, modifying, or updating existing presentations; combining
+  or splitting slide files; working with templates, layouts, speaker notes,
+  or comments. Trigger whenever the user mentions "deck," "slides,"
+  "presentation," or references a .pptx filename, regardless of what they
+  plan to do with the content afterward. If a .pptx file needs to be opened,
+  created, or touched, use this skill.
+trigger_phrases:
+  - "deck" / "slides" / "presentation" / ".pptx"
+  - "pitch deck"
+  - "speaker notes" / "comments" / "templates" / "layouts"
+  - "combine / split slide files"
+negative_signals: []
+body_summary: |
+  markitdown for reading, editing.md + pptxgenjs.md for editing/creating,
+  design guidance (palette, typography, spacing), required QA loop.
+execution_surface:
+  - python-pptx / markitdown
+  - pptxgenjs (Node)
+  - LibreOffice for image conversion
+category: document-format
+description_quality_flags: [no-negatives]
+```
+
+## skill-creator
+
+```yaml
+name: skill-creator
+description_raw: |
+  Create new skills, modify and improve existing skills, and measure skill
+  performance. Use when users want to create a skill from scratch, edit, or
+  optimize an existing skill, run evals to test a skill, benchmark skill
+  performance with variance analysis, or optimize a skill's description for
+  better triggering accuracy.
+trigger_phrases:
+  - "create a skill"
+  - "edit / optimize a skill"
+  - "run evals to test a skill"
+  - "benchmark skill performance"
+  - "optimize a skill's description"
+negative_signals: []
+body_summary: |
+  Capture intent → interview → write SKILL.md → test cases → spawn
+  with-skill + baseline runs → grade + aggregate. Skill-writing-guide
+  callouts.
+execution_surface:
+  - file scaffolding under skills/<name>/
+  - parallel claude-cli runs for eval
+  - viewer launch
+category: generic-meta
+description_quality_flags: [no-negatives]
+```
+
+Highly relevant to this very coverage-harness task — the harness scorer should treat skill-creator as the meta-tool, not a candidate to fire on user prompts.
+
+## switchroom-architecture
+
+```yaml
+name: switchroom-architecture
+description_raw: |
+  Explains how switchroom works internally — config cascade, profiles,
+  settings resolution, agent lifecycle, plugin system. Use when the user
+  asks 'how does switchroom work internally', 'how does the cascade decide',
+  'which settings apply', architecture, design, or internals. Do NOT use for
+  onboarding or getting-started questions ('how do I get started', 'I'm new
+  to switchroom', 'bootstrap from scratch', 'set up for the first time') —
+  those belong to switchroom-install.
+trigger_phrases:
+  - "how does switchroom work internally"
+  - "how does the cascade decide" / "which settings apply"
+  - "architecture" / "design" / "internals"
+negative_signals:
+  - Do NOT use for onboarding / getting-started — defer to switchroom-install
+body_summary: |
+  Conceptual overview: cascade, profile system, Docker-per-agent, Telegram
+  MCP plugin, Hindsight, skills, scaffolds. Heavy cross-link to deep dives.
+execution_surface:
+  - read-only / explainer (no Bash)
+category: switchroom-internal
+description_quality_flags: [no-triggers, overlap:switchroom-install]
+```
+
+`user-invocable: false` in frontmatter — not directly trigger-fireable. Marked with two flags because: (a) most trigger phrasings are conceptual single words ("architecture") rather than NL utterances, (b) explicit overlap-disambiguation against `switchroom-install`.
+
+## switchroom-cli
+
+```yaml
+name: switchroom-cli
+description_raw: |
+  Run switchroom CLI operations on existing agents: logs, update, restart,
+  version, config inspection, scheduled tasks, and Telegram plugin reference.
+  Use when the user wants to: show logs ("logs", "what happened", "check the
+  journal", "why did it crash"); update agents ("update", "pull latest",
+  "get new code", "upgrade"); restart agents ("restart", "reboot", "bounce",
+  "kick", "it's stuck"); check what's running ("version", "what sha", "are
+  agents up", "health summary"); apply config changes ("apply", "sync my
+  config", "I just edited switchroom.yaml"); inspect an agent's effective
+  config ("what model is X using", "how is <agent> configured", "show the
+  cascade"); list scheduled tasks ("cron", "timers", "what runs automatically",
+  "scheduled tasks"); or ask about Telegram-plugin features ("what MCP tools
+  does the bot have", "how does reply work"). Do NOT use for adding/removing
+  agents (switchroom-manage), bootstrapping switchroom from scratch
+  (switchroom-install), or "something is broken" diagnostics (switchroom-health).
+trigger_phrases:
+  - "logs" / "what happened" / "check the journal" / "why did it crash"
+  - "update" / "pull latest" / "get new code" / "upgrade"
+  - "restart" / "reboot" / "bounce" / "kick" / "it's stuck"
+  - "version" / "what sha" / "are agents up" / "health summary"
+  - "apply" / "sync my config" / "I just edited switchroom.yaml"
+  - "what model is X using" / "how is <agent> configured" / "show the cascade"
+  - "cron" / "timers" / "what runs automatically" / "scheduled tasks"
+  - "what MCP tools does the bot have" / "how does reply work"
+negative_signals:
+  - Do NOT use for add/remove agents → switchroom-manage
+  - Do NOT use for bootstrapping → switchroom-install
+  - Do NOT use for "something is broken" → switchroom-health
+body_summary: |
+  Reference for runtime CLI verbs against existing agents — `switchroom update`,
+  `apply`, `restart`, `version`, `agent config`, `agent schedule list`, plus
+  Telegram-plugin MCP-tool reference table.
+execution_surface:
+  - Bash(switchroom *) / Bash(docker *) / Bash(docker compose *)
+category: switchroom-internal
+description_quality_flags: [long, overlap:switchroom-health,switchroom-manage,switchroom-install]
+```
+
+Description is >500 chars — flagged `long`. But it earns its length with explicit negative-signal disambiguation against the three sibling skills. Highest disambiguation hygiene in the inventory.
+
+## switchroom-health
+
+```yaml
+name: switchroom-health
+description_raw: |
+  Runs a health check and diagnostics on the switchroom setup. Use when the
+  user says 'my agent keeps failing', 'my agents are broken', "what's wrong
+  with my agents", 'agent keeps crashing', 'health check', 'diagnose',
+  'troubleshoot', "something's wrong", 'can you check my setup', or wants
+  to verify everything is working correctly. Prefer this over logs when the
+  user is reporting a generic failure and wants to know *what* is wrong, not
+  *why* a specific crash happened.
+trigger_phrases:
+  - "my agent keeps failing" / "my agents are broken"
+  - "what's wrong with my agents" / "agent keeps crashing"
+  - "health check" / "diagnose" / "troubleshoot"
+  - "something's wrong" / "can you check my setup"
+negative_signals:
+  - "Prefer this over logs ... but defer to switchroom-cli (logs) when the user wants a specific crash"
+body_summary: |
+  Four-step diagnostic: `switchroom doctor --json`, fallback manual checks
+  (CLI version, auth, compose health, MCP config, bot tokens, Hindsight
+  reachability), interpret, suggest fixes.
+execution_surface:
+  - Bash: switchroom doctor / docker compose ps / Hindsight probe
+category: switchroom-internal
+description_quality_flags: [overlap:switchroom-cli]
+```
+
+## switchroom-install
+
+```yaml
+name: switchroom-install
+description_raw: |
+  Install switchroom and its dependencies (docker, claude CLI, switchroom
+  binary) on a fresh machine. Use for onboarding and first-time setup — when
+  the user says 'install switchroom on this machine', 'set up switchroom for
+  the first time', 'bootstrap switchroom from scratch', 'get switchroom
+  running', 'how do I get started with switchroom', "I'm new to switchroom,
+  where do I begin", or asks about switchroom dependencies or prerequisites.
+  This is the onboarding entry point, not for managing existing agents.
+trigger_phrases:
+  - "install switchroom on this machine"
+  - "set up switchroom for the first time"
+  - "bootstrap switchroom from scratch"
+  - "get switchroom running"
+  - "how do I get started with switchroom"
+  - "I'm new to switchroom, where do I begin"
+negative_signals:
+  - "not for managing existing agents" (defer to switchroom-manage)
+body_summary: |
+  Six-step bootstrap: detect existing install, verify prereqs, install host
+  deps (docker + claude CLI), install switchroom binary, run setup wizard,
+  apply + bring up fleet, verify.
+execution_surface:
+  - Bash: apt / brew, docker install, claude install, switchroom setup,
+    switchroom apply
+category: switchroom-internal
+description_quality_flags: [overlap:switchroom-manage]
+```
+
+## switchroom-manage
+
+```yaml
+name: switchroom-manage
+description_raw: |
+  Manage the fleet of switchroom agents from a Claude Code session — add,
+  create, remove, reinstall, reprovision, or lifecycle-control agents. Use
+  when the user says 'add a new agent', 'add an agent to my setup', 'create
+  a new agent', 'remove an agent', 'reinstall my agents', 'reprovision my
+  agents', 'list my agents', 'manage my agents', or invokes `/switchroom`.
+  This is the right skill for fleet-level changes (adding/removing agents)
+  even when the phrasing includes 'install' or 'reinstall' — use
+  switchroom-install only for bootstrapping switchroom itself on a fresh
+  machine.
+trigger_phrases:
+  - "add a new agent" / "create a new agent"
+  - "remove an agent"
+  - "reinstall my agents" / "reprovision my agents"
+  - "list my agents" / "manage my agents"
+  - "/switchroom" slash invocation
+negative_signals:
+  - "use switchroom-install only for bootstrapping switchroom itself"
+body_summary: |
+  Table of slash-style verbs mapped to `switchroom agent <verb>` Bash
+  invocations: list, create, remove, reinstall, plus Anthropic-account
+  helpers.
+execution_surface:
+  - Bash: switchroom agent list / create / remove / reinstall
+category: switchroom-internal
+description_quality_flags: [overlap:switchroom-install]
+```
+
+## switchroom-runtime
+
+```yaml
+name: switchroom-runtime
+description_raw: |
+  Runtime operational protocols for switchroom Telegram agents — the
+  conditional procedures that only fire on specific boot signals or user
+  phrases. Invoke when: (1) the env var SWITCHROOM_PENDING_TURN=true is set
+  on boot (interrupted-turn resume protocol); (2) the sentinel file
+  $TELEGRAM_STATE_DIR/.wake-audit-pending exists (wake audit: check for owed
+  replies, orphan sub-agents, stale todos before answering); (3) the user
+  asks why you restarted or what happened ("why did you restart?", "did you
+  crash?", "you went away") — surface the audit trail from
+  clean-shutdown.json + container/journal logs; (4) the user asks how to
+  stop you mid-turn ("how do I interrupt", "can I stop you", "how do I
+  cancel") and you need the implementation detail beyond the one-line
+  answer; (5) the user sends a short status check ("status?", "still
+  there?", "any update?") — treat as UX-failure signal, offer to file RCA
+  via /file-bug. Do NOT invoke for normal Telegram conversation, formatting
+  questions, voice/sticker/Telegraph behavior, MCP tool questions, or
+  persona / voice / Execution-Bias rules — those live in your always-loaded
+  CLAUDE.md.
+trigger_phrases:
+  - boot signal: SWITCHROOM_PENDING_TURN=true
+  - sentinel file: .wake-audit-pending exists
+  - "why did you restart?" / "did you crash?" / "you went away"
+  - "how do I interrupt" / "can I stop you" / "how do I cancel"
+  - "status?" / "still there?" / "any update?"
+negative_signals:
+  - Do NOT invoke for normal Telegram conversation, formatting, voice/sticker,
+    MCP tool questions, persona / Execution-Bias rules
+body_summary: |
+  Five gated protocols: interrupted-turn resume, wake audit, "why did you
+  restart" audit trail, `!` interrupt implementation, "status?" UX-failure
+  handler. Plus bash-shell-wedge escape hatch.
+execution_surface:
+  - Bash / Read / Grep
+  - reads of clean-shutdown.json, .wake-audit-pending, journal/container logs
+category: switchroom-internal
+description_quality_flags: [long, overlap:file-bug]
+```
+
+>500 chars (`long`). Cleanly gates by side-channel signals (env var, sentinel file) rather than just NL phrasings — distinctive for harness scoring (some triggers can't be evaluated from NL alone).
+
+## switchroom-status
+
+```yaml
+name: switchroom-status
+description_raw: |
+  List running switchroom agents with their uptime, model, and per-agent
+  state. Use when the user asks 'what agents are running', 'list switchroom
+  agents', 'how long has X been up', or wants a per-agent snapshot. Do NOT
+  use for switchroom-wide version/health summary (use switchroom-cli's
+  `switchroom version`) or "something is broken" diagnostics (use
+  switchroom-health).
+trigger_phrases:
+  - "what agents are running"
+  - "list switchroom agents"
+  - "how long has X been up"
+  - "per-agent snapshot"
+negative_signals:
+  - Do NOT use for version/health summary → switchroom-cli
+  - Do NOT use for "something is broken" → switchroom-health
+body_summary: |
+  Mandates literal `switchroom agent list` in the response and (when Bash
+  available) runs it; reports per-agent state + uptime + suspicious markers.
+execution_surface:
+  - Bash: switchroom agent list
+category: switchroom-internal
+description_quality_flags: [overlap:switchroom-cli,switchroom-manage]
+```
+
+## telegram-test-harness
+
+```yaml
+name: telegram-test-harness
+description_raw: |
+  This skill should be used when the user asks to "test telegram", "test bot
+  interactions", "mock the bot api", "write a telegram test", "test what
+  users see in chat", "test progress card", "test the slot banner", "test
+  soft-confirm", "test auto-fallback notification", "test pin behavior", or
+  any variation on validating switchroom's Telegram-side output
+  deterministically.
+  Also use when the user mentions fake-bot-api, update-factory,
+  bot-api.harness, GrammyError, e2e telegram, telegram regression test, or
+  asks how to add a test for code that calls bot.api.* or handles incoming
+  Telegram updates.
+trigger_phrases:
+  - "test telegram" / "test bot interactions" / "mock the bot api"
+  - "write a telegram test" / "test what users see in chat"
+  - "test progress card" / "test the slot banner" / "test soft-confirm"
+  - "test auto-fallback notification" / "test pin behavior"
+  - "telegram regression test"
+  - mentions of fake-bot-api / update-factory / bot-api.harness / GrammyError
+negative_signals: []
+body_summary: |
+  Quick-reference for `telegram-plugin/tests/` harness — fake-bot-api +
+  update-factory + error factories + time control. Defers to HARNESS.md for
+  full guide.
+execution_surface:
+  - Bun tests under telegram-plugin/tests/
+  - createFakeBotApi / update-factory / errors
+category: telegram-test
+description_quality_flags: [no-negatives]
+```
+
+## token-helpers
+
+```yaml
+name: token-helpers
+description_raw: |
+  Refresh OAuth access tokens for Google Calendar and Microsoft Graph from
+  refresh tokens stored in the switchroom vault. Library skill — invoked by
+  other skills that need a short-lived access token to call calendar or
+  Graph APIs, not directly by the user.
+trigger_phrases: []
+negative_signals:
+  - "not directly by the user" (library skill — invoked by other skills)
+body_summary: |
+  Two shell scripts (`scripts/google-cal-token.sh`,
+  `scripts/ms-graph-token.sh`) that exchange a vault-stored refresh token
+  for a short-lived access token and persist it back.
+execution_surface:
+  - Bash(switchroom vault *)
+  - Bash(./scripts/google-cal-token.sh / ms-graph-token.sh)
+category: switchroom-internal
+description_quality_flags: [no-triggers, library-skill]
+```
+
+Library skill — explicitly never user-fired. Harness must label this as a non-target so NL prompts don't get scored against it.
+
+## webapp-testing
+
+```yaml
+name: webapp-testing
+description_raw: |
+  Toolkit for interacting with and testing local web applications using
+  Playwright. Supports verifying frontend functionality, debugging UI
+  behavior, capturing browser screenshots, and viewing browser logs.
+trigger_phrases:
+  - "test local web app" / "test web app"
+  - "frontend testing" / "debug UI behavior"
+  - "capture browser screenshot" / "view browser logs"
+  - "Playwright"
+negative_signals: []
+body_summary: |
+  Decision-tree for static-vs-dynamic, with_server.py harness,
+  recon-then-action pattern, native Python Playwright scripts.
+execution_surface:
+  - scripts/with_server.py
+  - native Python Playwright
+category: generic-meta
+description_quality_flags: [short, no-triggers, no-negatives]
+```
+
+Description is only ~250 chars but trigger phrasings are loose; flagged for likely under-triggering.
+
+## xlsx
+
+```yaml
+name: xlsx
+description_raw: |
+  Use this skill any time a spreadsheet file is the primary input or output.
+  This means any task where the user wants to: open, read, edit, or fix an
+  existing .xlsx, .xlsm, .csv, or .tsv file (e.g., adding columns, computing
+  formulas, formatting, charting, cleaning messy data); create a new
+  spreadsheet from scratch or from other data sources; or convert between
+  tabular file formats. Trigger especially when the user references a
+  spreadsheet file by name or path — even casually (like "the xlsx in my
+  downloads") — and wants something done to it or produced from it. Also
+  trigger for cleaning or restructuring messy tabular data files (malformed
+  rows, misplaced headers, junk data) into proper spreadsheets. The
+  deliverable must be a spreadsheet file. Do NOT trigger when the primary
+  deliverable is a Word document, HTML report, standalone Python script,
+  database pipeline, or Google Sheets API integration, even if tabular data
+  is involved.
+trigger_phrases:
+  - any operation on .xlsx / .xlsm / .csv / .tsv
+  - "spreadsheet" / "the xlsx in my downloads"
+  - "add columns" / "compute formulas" / "formatting" / "charting"
+  - "clean messy data" / "malformed rows" / "misplaced headers"
+negative_signals:
+  - "Do NOT trigger when the primary deliverable is a Word document, HTML
+    report, standalone Python script, database pipeline, or Google Sheets
+    API integration"
+body_summary: |
+  Output requirements (zero formula errors, professional font, template
+  preservation), financial-model color/format/formula standards, pandas +
+  openpyxl workflows, formula-not-hardcoded discipline.
+execution_surface:
+  - pandas / openpyxl / xlsxwriter
+  - Excel + CSV / TSV I/O
+category: document-format
+description_quality_flags: []
+```
+
+Exemplar disambiguation — explicit ban on Word / HTML / Python-script deliverables. Bundled Anthropic skills (docx/xlsx) consistently have stronger negative signals than the buildkite or switchroom-internal sets.
+
+---
+
+## Profile context overlays
+
+Not skills — these are Handlebars system-prompt fragments rendered into every agent's `CLAUDE.md` at scaffold time. They define *always-loaded* behavior, so the harness should treat them as the agent's baseline persona / protocol context, not as fire-able skills.
+
+| File | Purpose |
+|---|---|
+| `/home/kenthompson/code/switchroom-skill-coverage/profiles/_shared/agent-self-service.md.hbs` | Tells the agent it has an `agent-config` MCP and should proactively use it for cron/config edits instead of asking the user to hand-edit `switchroom.yaml`. |
+| `/home/kenthompson/code/switchroom-skill-coverage/profiles/_shared/telegram-style.md.hbs` | Telegram interaction style — soft-commit pacing, `reply` / `stream_reply` discipline, "every turn must end with a reply" contract. |
+| `/home/kenthompson/code/switchroom-skill-coverage/profiles/_shared/vault-protocol.md.hbs` | Vault interaction protocol — managed section autoreconciled by `switchroom apply`; hand-edits warned-against. |
+| `/home/kenthompson/code/switchroom-skill-coverage/profiles/coding/CLAUDE.md.hbs` | Profile context for a coding-agent persona — header + channel/topic block + SOUL.md cross-reference. |
+| `/home/kenthompson/code/switchroom-skill-coverage/profiles/default/CLAUDE.md.hbs` | Profile context for the generic default persona — same shape as coding/EA/health-coach, just no role suffix. |
+| `/home/kenthompson/code/switchroom-skill-coverage/profiles/executive-assistant/CLAUDE.md.hbs` | Profile context for the executive-assistant persona — header + channel block + SOUL.md cross-reference. |
+| `/home/kenthompson/code/switchroom-skill-coverage/profiles/health-coach/CLAUDE.md.hbs` | Profile context for the health-and-fitness-coach persona — header + channel block + SOUL.md cross-reference. |

--- a/tests/skill-coverage/.gitignore
+++ b/tests/skill-coverage/.gitignore
@@ -1,0 +1,2 @@
+# Live-run artifacts — emitted by cli.ts --go.
+out/

--- a/tests/skill-coverage/README.md
+++ b/tests/skill-coverage/README.md
@@ -1,0 +1,68 @@
+# Skill-coverage harness
+
+Probabilistic test harness that fuzzes natural-language phrasings at a
+running switchroom agent and scores whether the right skill fires.
+
+## What it does
+
+1. **Generate a corpus** from `fixtures/skills.json` — six paraphrases,
+   three typos, three slang variants, three indirect "symptom"
+   phrasings, and four negative controls drawn from adjacent skills'
+   trigger space. Output: `corpus/<skill>.jsonl`.
+2. **Inject** each probe at the agent's gateway socket as a
+   synthesized `inject_inbound` envelope (same protocol the in-agent
+   scheduler uses for cron-fired turns).
+3. **Observe** the agent's session JSONL via `session-tail`, capture
+   every `tool_use` event, and pull the `input.skill` field for any
+   `Skill` invocations.
+4. **Score** precision / recall / F1 per skill plus a negative-control
+   FP rate. Output: `scorecard.json` + `scorecard.md`.
+
+## Run
+
+```bash
+# Generate the corpus (deterministic given the seed)
+bun run tests/skill-coverage/corpus/generate-corpus.ts --seed=1
+
+# Dry-run: build the corpus and exit (no agent contact)
+bun run tests/skill-coverage/cli.ts my-agent --regen-corpus
+
+# Live run against a real agent (requires gateway socket + agent cwd)
+bun run tests/skill-coverage/cli.ts my-agent \
+  --agent-cwd=/home/kenthompson/.switchroom/agents/my-agent \
+  --gateway-socket=/run/switchroom/agents/my-agent/gateway.sock \
+  --go
+```
+
+## Unit tests
+
+```bash
+npm test -- --run tests/skill-coverage
+```
+
+Tests cover:
+- corpus determinism (same seed → byte-identical output)
+- score module math (canned input → expected F1)
+
+No network — the runner is unit-tested with an in-memory inject + a
+fake observer.
+
+## Authoring curated seeds
+
+Drop a `corpus/seeds/<skill>.yaml` to add hand-written variants:
+
+```yaml
+paraphrases:
+  - "kill agent X and bring it back up"
+slang:
+  - "yo kick agent X"
+indirect:
+  - "agent X is wedged"
+negatives:
+  - phrase: "publish this to the package registry"
+    expectedOtherSkill: "buildkite-secure-delivery"
+```
+
+Curated seeds prepend to the rule-based output and dedupe by lowercase
+phrase. They count toward the per-category cap, so if you add 6 hand-
+written paraphrases the rule-based pass adds zero.

--- a/tests/skill-coverage/cli.ts
+++ b/tests/skill-coverage/cli.ts
@@ -1,0 +1,135 @@
+/**
+ * CLI entrypoint:
+ *   bun run tests/skill-coverage/cli.ts <agent-name> \
+ *     [--skills=a,b] [--limit-per-skill=N] [--seed=N] \
+ *     [--gateway-socket=/path/to/gateway.sock] \
+ *     [--agent-cwd=/path/to/agent/cwd] \
+ *     [--out=/path/to/scorecard-base]
+ *
+ * Writes:
+ *   <out>.run.json     — RunRecord
+ *   <out>.scorecard.json
+ *   <out>.scorecard.md
+ *
+ * DOES NOT execute against a real agent automatically — the actual
+ * end-to-end probe firing is gated behind --go to keep this script
+ * safe to import / dry-run.
+ */
+
+import { mkdirSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { generateCorpus, writeCorpusFiles } from "./corpus/generate-corpus.js";
+import { loadCorpus, runAll } from "./harness/runner.js";
+import { renderMarkdown, scoreRun } from "./harness/score.js";
+import type { ProbeRecord } from "./corpus/types.js";
+
+interface CliArgs {
+  agentName: string | null;
+  skills: string[] | null;
+  limitPerSkill: number | null;
+  seed: number;
+  gatewaySocket: string | null;
+  agentCwd: string | null;
+  outBase: string;
+  go: boolean;
+  regenCorpus: boolean;
+}
+
+function parse(argv: string[]): CliArgs {
+  const out: CliArgs = {
+    agentName: null,
+    skills: null,
+    limitPerSkill: null,
+    seed: 1,
+    gatewaySocket: null,
+    agentCwd: null,
+    outBase: resolve(process.cwd(), "tests/skill-coverage/out/skill-coverage"),
+    go: false,
+    regenCorpus: false,
+  };
+  for (const a of argv) {
+    if (!a.startsWith("--")) {
+      if (!out.agentName) out.agentName = a;
+      continue;
+    }
+    const m = a.match(/^--([^=]+)(?:=(.*))?$/);
+    if (!m) continue;
+    const [, k, v] = m;
+    switch (k) {
+      case "skills": out.skills = (v ?? "").split(",").map((s) => s.trim()).filter(Boolean); break;
+      case "limit-per-skill": out.limitPerSkill = v ? Number(v) : null; break;
+      case "seed": out.seed = v ? Number(v) : 1; break;
+      case "gateway-socket": out.gatewaySocket = v ?? null; break;
+      case "agent-cwd": out.agentCwd = v ?? null; break;
+      case "out": out.outBase = v ? resolve(v) : out.outBase; break;
+      case "go": out.go = true; break;
+      case "regen-corpus": out.regenCorpus = true; break;
+    }
+  }
+  return out;
+}
+
+function trimPerSkill(probes: ProbeRecord[], limit: number | null): ProbeRecord[] {
+  if (limit == null) return probes;
+  const counts = new Map<string, number>();
+  const out: ProbeRecord[] = [];
+  for (const p of probes) {
+    const k = p.targetSkill ?? "<neg>";
+    const c = counts.get(k) ?? 0;
+    if (c >= limit) continue;
+    counts.set(k, c + 1);
+    out.push(p);
+  }
+  return out;
+}
+
+async function main(): Promise<void> {
+  const args = parse(process.argv.slice(2));
+  // eslint-disable-next-line no-console
+  const log = (msg: string): void => console.error(`[skill-coverage] ${msg}`);
+
+  if (args.regenCorpus) {
+    const result = generateCorpus({ seed: args.seed, onlySkills: args.skills });
+    const written = writeCorpusFiles(result);
+    log(`regenerated corpus: ${written.length} files`);
+  }
+
+  if (!args.go) {
+    log("dry run (no --go) — corpus available; skipping inject/observe loop");
+    log("re-run with --go to execute against the live agent");
+    return;
+  }
+
+  if (!args.agentName) throw new Error("agent name is required as first positional arg");
+  if (!args.agentCwd) {
+    throw new Error("--agent-cwd is required (path the agent's claude process runs in)");
+  }
+
+  const corpusDir = resolve(process.cwd(), "tests/skill-coverage/corpus");
+  const probesAll = loadCorpus(corpusDir, args.skills ?? undefined);
+  const probes = trimPerSkill(probesAll, args.limitPerSkill);
+  log(`loaded ${probes.length} probes (from ${probesAll.length} in corpus)`);
+
+  const run = await runAll(probes, {
+    agentName: args.agentName,
+    gatewaySocket: args.gatewaySocket ?? undefined,
+    agentCwd: args.agentCwd,
+    log,
+  }, args.seed);
+
+  const card = scoreRun(run);
+
+  mkdirSync(dirname(args.outBase), { recursive: true });
+  writeFileSync(`${args.outBase}.run.json`, JSON.stringify(run, null, 2));
+  writeFileSync(`${args.outBase}.scorecard.json`, JSON.stringify(card, null, 2));
+  writeFileSync(`${args.outBase}.scorecard.md`, renderMarkdown(card));
+  log(`wrote ${args.outBase}.{run.json,scorecard.json,scorecard.md}`);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((err) => {
+    // eslint-disable-next-line no-console
+    console.error(err);
+    process.exit(1);
+  });
+}

--- a/tests/skill-coverage/corpus/buildkite-agent-infrastructure.jsonl
+++ b/tests/skill-coverage/corpus/buildkite-agent-infrastructure.jsonl
@@ -1,0 +1,19 @@
+{"id":"b0b1fc17505da42e","targetSkill":"buildkite-agent-infrastructure","kind":"paraphrase","phrase":"Create a queue, please.","source":"paraphrase-template"}
+{"id":"edc53cb8156ae93c","targetSkill":"buildkite-agent-infrastructure","kind":"paraphrase","phrase":"Let's configure SSO.","source":"paraphrase-template"}
+{"id":"a095f56ce695a518","targetSkill":"buildkite-agent-infrastructure","kind":"paraphrase","phrase":"Could you scale queues for me?","source":"paraphrase-template"}
+{"id":"329d2b06a3ed95f3","targetSkill":"buildkite-agent-infrastructure","kind":"paraphrase","phrase":"I need to configure SSO.","source":"paraphrase-template"}
+{"id":"cc09dbbc827b06c1","targetSkill":"buildkite-agent-infrastructure","kind":"paraphrase","phrase":"Could you create a queue for me?","source":"paraphrase-template"}
+{"id":"2d642661f2626711","targetSkill":"buildkite-agent-infrastructure","kind":"paraphrase","phrase":"Please optimize CI costs.","source":"paraphrase-template"}
+{"id":"ba0c592a9008ba42","targetSkill":"buildkite-agent-infrastructure","kind":"typo","phrase":"manage clusetr secrets","source":"typo-rule"}
+{"id":"5558e16ae1a59ac7","targetSkill":"buildkite-agent-infrastructure","kind":"typo","phrase":"configuree agents","source":"typo-rule"}
+{"id":"2f851cefb3d72de4","targetSkill":"buildkite-agent-infrastructure","kind":"typo","phrase":"set up hostted agents","source":"typo-rule"}
+{"id":"5a3c26e6fcf60189","targetSkill":"buildkite-agent-infrastructure","kind":"slang","phrase":"pls create a pipeline template","source":"slang-template"}
+{"id":"512b580407e488ad","targetSkill":"buildkite-agent-infrastructure","kind":"slang","phrase":"quick q — can i optimize CI costs","source":"slang-template"}
+{"id":"45baac09bfce11a6","targetSkill":"buildkite-agent-infrastructure","kind":"slang","phrase":"hey, set up audit logging?","source":"slang-template"}
+{"id":"d9f64f164903b5c2","targetSkill":"buildkite-agent-infrastructure","kind":"indirect","phrase":"something is going on with buildkite-agent-infrastructure","source":"indirect-template"}
+{"id":"0c4ab22cd0691d14","targetSkill":"buildkite-agent-infrastructure","kind":"indirect","phrase":"the buildkite-agent-infrastructure thing is weird","source":"indirect-template"}
+{"id":"1e72bcea669cafc1","targetSkill":"buildkite-agent-infrastructure","kind":"indirect","phrase":"can you take a look at the buildkite-agent-infrastructure situation","source":"indirect-template"}
+{"id":"b5991733c20e6ed1","targetSkill":null,"kind":"negative","phrase":"list builds","source":"negative-from-adjacent","expectedOtherSkill":"buildkite-cli"}
+{"id":"0093601c5cd0eb02","targetSkill":null,"kind":"negative","phrase":"set up dynamic pipelines","source":"negative-from-adjacent","expectedOtherSkill":"buildkite-pipelines"}
+{"id":"9cab4663cb1d0bb1","targetSkill":null,"kind":"negative","phrase":"authenticate with the Buildkite API","source":"negative-from-adjacent","expectedOtherSkill":"buildkite-api"}
+{"id":"c9cd0a82299e5e4a","targetSkill":null,"kind":"negative","phrase":"view build logs","source":"negative-from-adjacent","expectedOtherSkill":"buildkite-cli"}

--- a/tests/skill-coverage/corpus/buildkite-agent-runtime.jsonl
+++ b/tests/skill-coverage/corpus/buildkite-agent-runtime.jsonl
@@ -1,0 +1,18 @@
+{"id":"f5ec1301b2e9abf2","targetSkill":"buildkite-agent-runtime","kind":"paraphrase","phrase":"Get or update a step attribute, please.","source":"paraphrase-template"}
+{"id":"57b6365ac141458c","targetSkill":"buildkite-agent-runtime","kind":"paraphrase","phrase":"Please upload artifacts from a step.","source":"paraphrase-template"}
+{"id":"b5803cebdad83be5","targetSkill":"buildkite-agent-runtime","kind":"paraphrase","phrase":"Help me add an annotation.","source":"paraphrase-template"}
+{"id":"a7fd9ab000869b11","targetSkill":"buildkite-agent-runtime","kind":"paraphrase","phrase":"Please add an annotation.","source":"paraphrase-template"}
+{"id":"5bd5530a1d8756d2","targetSkill":"buildkite-agent-runtime","kind":"paraphrase","phrase":"Could you upload pipeline dynamically for me?","source":"paraphrase-template"}
+{"id":"541cb7ce87386bdb","targetSkill":"buildkite-agent-runtime","kind":"paraphrase","phrase":"Help me request an OIDC token inside a step.","source":"paraphrase-template"}
+{"id":"a94bc55318b41ecb","targetSkill":"buildkite-agent-runtime","kind":"typo","phrase":"request an IDC token inside a step","source":"typo-rule"}
+{"id":"8f265169a7294199","targetSkill":"buildkite-agent-runtime","kind":"typo","phrase":"retrieve a custer secret at runtime","source":"typo-rule"}
+{"id":"25e618dff8eec20c","targetSkill":"buildkite-agent-runtime","kind":"slang","phrase":"pls acquire a distributed lock","source":"slang-template"}
+{"id":"3685aaf5daf34ff9","targetSkill":"buildkite-agent-runtime","kind":"slang","phrase":"gonna need to add an annotation","source":"slang-template"}
+{"id":"aaddabac759f066f","targetSkill":"buildkite-agent-runtime","kind":"slang","phrase":"quick q — can i get or update a step attribute","source":"slang-template"}
+{"id":"b60a535fb87dc61b","targetSkill":"buildkite-agent-runtime","kind":"indirect","phrase":"something is going on with buildkite-agent-runtime","source":"indirect-template"}
+{"id":"9deefee0354b3021","targetSkill":"buildkite-agent-runtime","kind":"indirect","phrase":"the buildkite-agent-runtime thing is weird","source":"indirect-template"}
+{"id":"2bde229e4c07dcda","targetSkill":"buildkite-agent-runtime","kind":"indirect","phrase":"can you take a look at the buildkite-agent-runtime situation","source":"indirect-template"}
+{"id":"2a3061c9e9a4fc2c","targetSkill":null,"kind":"negative","phrase":"add plugins","source":"negative-from-adjacent","expectedOtherSkill":"buildkite-pipelines"}
+{"id":"164f970f3dea946a","targetSkill":null,"kind":"negative","phrase":"retry a build","source":"negative-from-adjacent","expectedOtherSkill":"buildkite-cli"}
+{"id":"5bfd5a2a54cb2879","targetSkill":null,"kind":"negative","phrase":"publish to package registry","source":"negative-from-adjacent","expectedOtherSkill":"buildkite-secure-delivery"}
+{"id":"90a11cd581409f08","targetSkill":null,"kind":"negative","phrase":"add annotations","source":"negative-from-adjacent","expectedOtherSkill":"buildkite-pipelines"}

--- a/tests/skill-coverage/corpus/buildkite-api.jsonl
+++ b/tests/skill-coverage/corpus/buildkite-api.jsonl
@@ -1,0 +1,18 @@
+{"id":"41881c47a4a3e15e","targetSkill":"buildkite-api","kind":"paraphrase","phrase":"Please write a GraphQL query.","source":"paraphrase-template"}
+{"id":"70229c0b2563a947","targetSkill":"buildkite-api","kind":"paraphrase","phrase":"Let's paginate API results.","source":"paraphrase-template"}
+{"id":"e4752afd7e2b0af8","targetSkill":"buildkite-api","kind":"paraphrase","phrase":"Could you automate Buildkite for me?","source":"paraphrase-template"}
+{"id":"b3206a10a7334084","targetSkill":"buildkite-api","kind":"paraphrase","phrase":"Can you authenticate with the Buildkite API?","source":"paraphrase-template"}
+{"id":"d99e93374b36bcfd","targetSkill":"buildkite-api","kind":"paraphrase","phrase":"Automate Buildkite, please.","source":"paraphrase-template"}
+{"id":"fafd3f3ce34187a1","targetSkill":"buildkite-api","kind":"typo","phrase":"authenticate with  the Buildkite API","source":"typo-rule"}
+{"id":"96b51a92d571749d","targetSkill":"buildkite-api","kind":"typo","phrase":"write a GraaphQL query","source":"typo-rule"}
+{"id":"c08e8dcb8902ab27","targetSkill":"buildkite-api","kind":"typo","phrase":"integrate with Buildikte programmatically","source":"typo-rule"}
+{"id":"1bd0d143289db8b7","targetSkill":"buildkite-api","kind":"slang","phrase":"hey, automate Buildkite?","source":"slang-template"}
+{"id":"819505fee6a55796","targetSkill":"buildkite-api","kind":"slang","phrase":"any way to write a GraphQL query?","source":"slang-template"}
+{"id":"987403ce96059c8d","targetSkill":"buildkite-api","kind":"slang","phrase":"any way to write a script that calls Buildkite?","source":"slang-template"}
+{"id":"f738e434920ff1d5","targetSkill":"buildkite-api","kind":"indirect","phrase":"the buildkite-api thing is weird","source":"indirect-template"}
+{"id":"baffd7d7ee91fc8d","targetSkill":"buildkite-api","kind":"indirect","phrase":"can you take a look at the buildkite-api situation","source":"indirect-template"}
+{"id":"01bfdcf82bfef5a7","targetSkill":"buildkite-api","kind":"indirect","phrase":"something is going on with buildkite-api","source":"indirect-template"}
+{"id":"69373c12dd02cb39","targetSkill":null,"kind":"negative","phrase":"upload artifacts","source":"negative-from-adjacent","expectedOtherSkill":"buildkite-cli"}
+{"id":"f8c2fccbbc969fe9","targetSkill":null,"kind":"negative","phrase":"manage cluster secrets","source":"negative-from-adjacent","expectedOtherSkill":"buildkite-agent-infrastructure"}
+{"id":"d51be7e23a3be0ef","targetSkill":null,"kind":"negative","phrase":"set up SAML","source":"negative-from-adjacent","expectedOtherSkill":"buildkite-agent-infrastructure"}
+{"id":"38f4356316901b5d","targetSkill":null,"kind":"negative","phrase":"download artifacts","source":"negative-from-adjacent","expectedOtherSkill":"buildkite-cli"}

--- a/tests/skill-coverage/corpus/buildkite-cli.jsonl
+++ b/tests/skill-coverage/corpus/buildkite-cli.jsonl
@@ -1,0 +1,19 @@
+{"id":"0074ba58403050cc","targetSkill":"buildkite-cli","kind":"paraphrase","phrase":"Help me retry a build.","source":"paraphrase-template"}
+{"id":"1beffbbafd0a4868","targetSkill":"buildkite-cli","kind":"paraphrase","phrase":"List builds, please.","source":"paraphrase-template"}
+{"id":"fd58df1a8a9aa083","targetSkill":"buildkite-cli","kind":"paraphrase","phrase":"Let's upload artifacts.","source":"paraphrase-template"}
+{"id":"33a5d799948bdf02","targetSkill":"buildkite-cli","kind":"paraphrase","phrase":"Let's manage secrets.","source":"paraphrase-template"}
+{"id":"3a46e5eea1cd4661","targetSkill":"buildkite-cli","kind":"paraphrase","phrase":"Help me upload artifacts.","source":"paraphrase-template"}
+{"id":"ee87f38f35534b8e","targetSkill":"buildkite-cli","kind":"paraphrase","phrase":"Could you create a pipeline for me?","source":"paraphrase-template"}
+{"id":"e01f2b982e9cbf4f","targetSkill":"buildkite-cli","kind":"typo","phrase":"list bbuilds","source":"typo-rule"}
+{"id":"3c37d215c70bd515","targetSkill":"buildkite-cli","kind":"typo","phrase":"list pieplines","source":"typo-rule"}
+{"id":"cb3de4c568f99d7c","targetSkill":"buildkite-cli","kind":"typo","phrase":"retry  abuild","source":"typo-rule"}
+{"id":"53a67912fd4434f5","targetSkill":"buildkite-cli","kind":"slang","phrase":"hey, cancel a build?","source":"slang-template"}
+{"id":"7d79299c80437a85","targetSkill":"buildkite-cli","kind":"slang","phrase":"pls list builds","source":"slang-template"}
+{"id":"219e46a9c1fdae1f","targetSkill":"buildkite-cli","kind":"slang","phrase":"quick q — can i manage secrets","source":"slang-template"}
+{"id":"50aeaab5e01a3aae","targetSkill":"buildkite-cli","kind":"indirect","phrase":"I want to do this from the terminal","source":"indirect-template"}
+{"id":"15400e55d923708b","targetSkill":"buildkite-cli","kind":"indirect","phrase":"scripting it locally would be easier","source":"indirect-template"}
+{"id":"12a56221e94e5498","targetSkill":"buildkite-cli","kind":"indirect","phrase":"I'd rather not click around the UI","source":"indirect-template"}
+{"id":"d96f5c7ba99f4a00","targetSkill":null,"kind":"negative","phrase":"show test failures in the build page","source":"negative-from-adjacent","expectedOtherSkill":"buildkite-pipelines"}
+{"id":"9cab4663cb1d0bb1","targetSkill":null,"kind":"negative","phrase":"authenticate with the Buildkite API","source":"negative-from-adjacent","expectedOtherSkill":"buildkite-api"}
+{"id":"6240b1b988432a88","targetSkill":null,"kind":"negative","phrase":"standardize pipelines across teams","source":"negative-from-adjacent","expectedOtherSkill":"buildkite-agent-infrastructure"}
+{"id":"2a3061c9e9a4fc2c","targetSkill":null,"kind":"negative","phrase":"add plugins","source":"negative-from-adjacent","expectedOtherSkill":"buildkite-pipelines"}

--- a/tests/skill-coverage/corpus/buildkite-migration.jsonl
+++ b/tests/skill-coverage/corpus/buildkite-migration.jsonl
@@ -1,0 +1,19 @@
+{"id":"cecbf0ab202dd3e3","targetSkill":"buildkite-migration","kind":"paraphrase","phrase":"Can you what's the Buildkite equivalent of?","source":"paraphrase-template"}
+{"id":"faa7c96ed22e804d","targetSkill":"buildkite-migration","kind":"paraphrase","phrase":"Let's convert pipelines from Jenkins.","source":"paraphrase-template"}
+{"id":"6537fb1e1bedc379","targetSkill":"buildkite-migration","kind":"paraphrase","phrase":"What's the Buildkite equivalent of, please.","source":"paraphrase-template"}
+{"id":"6424ca42e4d5c52b","targetSkill":"buildkite-migration","kind":"paraphrase","phrase":"Help me convert pipelines from Jenkins.","source":"paraphrase-template"}
+{"id":"7a9ec666e1884419","targetSkill":"buildkite-migration","kind":"paraphrase","phrase":"Please convert GitHub Actions workflows.","source":"paraphrase-template"}
+{"id":"0241503f38ea0b4e","targetSkill":"buildkite-migration","kind":"paraphrase","phrase":"I'd like to bk pipeline convert.","source":"paraphrase-template"}
+{"id":"d7383b1650b79cdb","targetSkill":"buildkite-migration","kind":"typo","phrase":"convert CirccleCI config","source":"typo-rule"}
+{"id":"beae089e94b079e3","targetSkill":"buildkite-migration","kind":"typo","phrase":"convert GitHub Atcions workflows","source":"typo-rule"}
+{"id":"195ad2c003febd1c","targetSkill":"buildkite-migration","kind":"typo","phrase":"convert CircleCI config","source":"typo-rule"}
+{"id":"fe143d30f11a4586","targetSkill":"buildkite-migration","kind":"slang","phrase":"quick q — can i what's the Buildkite equivalent of","source":"slang-template"}
+{"id":"b370c8497845a9d0","targetSkill":"buildkite-migration","kind":"slang","phrase":"hey, migrate to Buildkite?","source":"slang-template"}
+{"id":"b19ca54389eda3ec","targetSkill":"buildkite-migration","kind":"slang","phrase":"hey, convert GitHub Actions workflows?","source":"slang-template"}
+{"id":"e4b970c5174aee60","targetSkill":"buildkite-migration","kind":"indirect","phrase":"can you take a look at the buildkite-migration situation","source":"indirect-template"}
+{"id":"9e14531b4aa4d562","targetSkill":"buildkite-migration","kind":"indirect","phrase":"something is going on with buildkite-migration","source":"indirect-template"}
+{"id":"39eced995e77d1d9","targetSkill":"buildkite-migration","kind":"indirect","phrase":"the buildkite-migration thing is weird","source":"indirect-template"}
+{"id":"020507f9710d7ef8","targetSkill":null,"kind":"negative","phrase":"trigger a build","source":"negative-from-adjacent","expectedOtherSkill":"buildkite-cli"}
+{"id":"60999319a31298a0","targetSkill":null,"kind":"negative","phrase":"write a pipeline","source":"negative-from-adjacent","expectedOtherSkill":"buildkite-pipelines"}
+{"id":"82dc0047aa12ffb7","targetSkill":null,"kind":"negative","phrase":"add caching","source":"negative-from-adjacent","expectedOtherSkill":"buildkite-pipelines"}
+{"id":"164f970f3dea946a","targetSkill":null,"kind":"negative","phrase":"retry a build","source":"negative-from-adjacent","expectedOtherSkill":"buildkite-cli"}

--- a/tests/skill-coverage/corpus/buildkite-pipelines.jsonl
+++ b/tests/skill-coverage/corpus/buildkite-pipelines.jsonl
@@ -1,0 +1,19 @@
+{"id":"d477e449908018be","targetSkill":"buildkite-pipelines","kind":"paraphrase","phrase":"Help me write a pipeline.","source":"paraphrase-template"}
+{"id":"07f4e023817af4bf","targetSkill":"buildkite-pipelines","kind":"paraphrase","phrase":"Can you parallel steps?","source":"paraphrase-template"}
+{"id":"571f3200656feb4c","targetSkill":"buildkite-pipelines","kind":"paraphrase","phrase":"Let's add retry.","source":"paraphrase-template"}
+{"id":"b41ce8c45093aebb","targetSkill":"buildkite-pipelines","kind":"paraphrase","phrase":"Let's show test failures in the build page.","source":"paraphrase-template"}
+{"id":"de34f75fcd9ba061","targetSkill":"buildkite-pipelines","kind":"paraphrase","phrase":"I'd like to add caching.","source":"paraphrase-template"}
+{"id":"ac77f27c5585077f","targetSkill":"buildkite-pipelines","kind":"paraphrase","phrase":"Let's add annotations.","source":"paraphrase-template"}
+{"id":"27b5c8f3cdf16397","targetSkill":"buildkite-pipelines","kind":"typo","phrase":"set up dnamic pipelines","source":"typo-rule"}
+{"id":"bfbb3a6ede41a126","targetSkill":"buildkite-pipelines","kind":"typo","phrase":"add annotations","source":"typo-rule"}
+{"id":"2dadb78d1b64609e","targetSkill":"buildkite-pipelines","kind":"typo","phrase":"write a pipeline","source":"typo-rule"}
+{"id":"2a852bba898b410f","targetSkill":"buildkite-pipelines","kind":"slang","phrase":"yo, how do i matrix build","source":"slang-template"}
+{"id":"66a5aa865a20852b","targetSkill":"buildkite-pipelines","kind":"slang","phrase":"pls only run tests when code changes","source":"slang-template"}
+{"id":"f4a8616c464de167","targetSkill":"buildkite-pipelines","kind":"slang","phrase":"yo, how do i only run tests when code changes","source":"slang-template"}
+{"id":"b66ef600f9f671e7","targetSkill":"buildkite-pipelines","kind":"indirect","phrase":"my pipeline.yml is a mess","source":"indirect-template"}
+{"id":"bc8a6227ee6c4c63","targetSkill":"buildkite-pipelines","kind":"indirect","phrase":"the build is slow","source":"indirect-template"}
+{"id":"b9226daf57456f76","targetSkill":"buildkite-pipelines","kind":"indirect","phrase":"tests run in serial when they shouldn't","source":"indirect-template"}
+{"id":"11f5120e4d63c32e","targetSkill":null,"kind":"negative","phrase":"acquire a distributed lock","source":"negative-from-adjacent","expectedOtherSkill":"buildkite-agent-runtime"}
+{"id":"c9cd0a82299e5e4a","targetSkill":null,"kind":"negative","phrase":"view build logs","source":"negative-from-adjacent","expectedOtherSkill":"buildkite-cli"}
+{"id":"1132acfc5c544bf6","targetSkill":null,"kind":"negative","phrase":"quarantine flaky tests","source":"negative-from-adjacent","expectedOtherSkill":"buildkite-test-engine"}
+{"id":"6173445a0567d7d4","targetSkill":null,"kind":"negative","phrase":"debug environment variables in hooks","source":"negative-from-adjacent","expectedOtherSkill":"buildkite-agent-runtime"}

--- a/tests/skill-coverage/corpus/buildkite-secure-delivery.jsonl
+++ b/tests/skill-coverage/corpus/buildkite-secure-delivery.jsonl
@@ -1,0 +1,19 @@
+{"id":"7159b5a8c1b85511","targetSkill":"buildkite-secure-delivery","kind":"paraphrase","phrase":"Please secure the supply chain.","source":"paraphrase-template"}
+{"id":"d7508f30f8981362","targetSkill":"buildkite-secure-delivery","kind":"paraphrase","phrase":"I'd like to push a Docker image.","source":"paraphrase-template"}
+{"id":"22aa5d5ea074fd2a","targetSkill":"buildkite-secure-delivery","kind":"paraphrase","phrase":"Can you sign pipelines?","source":"paraphrase-template"}
+{"id":"622a19bd55db67fe","targetSkill":"buildkite-secure-delivery","kind":"paraphrase","phrase":"I need to verify pipeline signatures.","source":"paraphrase-template"}
+{"id":"6e40ae25b0f9e2c9","targetSkill":"buildkite-secure-delivery","kind":"paraphrase","phrase":"Could you sign pipelines for me?","source":"paraphrase-template"}
+{"id":"abb06ca591865855","targetSkill":"buildkite-secure-delivery","kind":"paraphrase","phrase":"Set up SLSA provenance, please.","source":"paraphrase-template"}
+{"id":"1b55e98386cb1f5b","targetSkill":"buildkite-secure-delivery","kind":"typo","phrase":"generate attestation","source":"typo-rule"}
+{"id":"bc3b78798b4d4b79","targetSkill":"buildkite-secure-delivery","kind":"typo","phrase":"set up LSA provenance","source":"typo-rule"}
+{"id":"d2b20a6ccfa030e0","targetSkill":"buildkite-secure-delivery","kind":"typo","phrase":"verify ppeline signatures","source":"typo-rule"}
+{"id":"3476eb096ee9cc34","targetSkill":"buildkite-secure-delivery","kind":"slang","phrase":"gonna need to verify pipeline signatures","source":"slang-template"}
+{"id":"22e1309b42936df1","targetSkill":"buildkite-secure-delivery","kind":"slang","phrase":"pls authenticate without static credentials","source":"slang-template"}
+{"id":"e931176cc2a11bef","targetSkill":"buildkite-secure-delivery","kind":"slang","phrase":"gonna need to sign pipelines","source":"slang-template"}
+{"id":"d3791d36b9efd441","targetSkill":"buildkite-secure-delivery","kind":"indirect","phrase":"something is going on with buildkite-secure-delivery","source":"indirect-template"}
+{"id":"7a84bba268c35a30","targetSkill":"buildkite-secure-delivery","kind":"indirect","phrase":"the buildkite-secure-delivery thing is weird","source":"indirect-template"}
+{"id":"611ccf4ac772b384","targetSkill":"buildkite-secure-delivery","kind":"indirect","phrase":"can you take a look at the buildkite-secure-delivery situation","source":"indirect-template"}
+{"id":"11f5120e4d63c32e","targetSkill":null,"kind":"negative","phrase":"acquire a distributed lock","source":"negative-from-adjacent","expectedOtherSkill":"buildkite-agent-runtime"}
+{"id":"60999319a31298a0","targetSkill":null,"kind":"negative","phrase":"write a pipeline","source":"negative-from-adjacent","expectedOtherSkill":"buildkite-pipelines"}
+{"id":"cb2c93354fa87337","targetSkill":null,"kind":"negative","phrase":"upload pipeline dynamically","source":"negative-from-adjacent","expectedOtherSkill":"buildkite-agent-runtime"}
+{"id":"82dc0047aa12ffb7","targetSkill":null,"kind":"negative","phrase":"add caching","source":"negative-from-adjacent","expectedOtherSkill":"buildkite-pipelines"}

--- a/tests/skill-coverage/corpus/buildkite-test-engine.jsonl
+++ b/tests/skill-coverage/corpus/buildkite-test-engine.jsonl
@@ -1,0 +1,19 @@
+{"id":"f712350649eae0b9","targetSkill":"buildkite-test-engine","kind":"paraphrase","phrase":"Help me detect flaky tests.","source":"paraphrase-template"}
+{"id":"a0e649c04d026859","targetSkill":"buildkite-test-engine","kind":"paraphrase","phrase":"Can you parallelize test suite?","source":"paraphrase-template"}
+{"id":"b5d71554e6a2a26a","targetSkill":"buildkite-test-engine","kind":"paraphrase","phrase":"Can you configure test collectors?","source":"paraphrase-template"}
+{"id":"1f53d05da54d7bef","targetSkill":"buildkite-test-engine","kind":"paraphrase","phrase":"Let's speed up tests.","source":"paraphrase-template"}
+{"id":"153e359bac1a1407","targetSkill":"buildkite-test-engine","kind":"paraphrase","phrase":"Can you speed up tests?","source":"paraphrase-template"}
+{"id":"c86d604f649f9d48","targetSkill":"buildkite-test-engine","kind":"paraphrase","phrase":"I need to configure test collectors.","source":"paraphrase-template"}
+{"id":"a9ed16234b615fb0","targetSkill":"buildkite-test-engine","kind":"typo","phrase":"parallelize  test suite","source":"typo-rule"}
+{"id":"0b63896d557b40ed","targetSkill":"buildkite-test-engine","kind":"typo","phrase":"set up test splitting","source":"typo-rule"}
+{"id":"a098a423cddce06b","targetSkill":"buildkite-test-engine","kind":"typo","phrase":"set up tes tsplitting","source":"typo-rule"}
+{"id":"9513ea2d612bdfa1","targetSkill":"buildkite-test-engine","kind":"slang","phrase":"gonna need to configure test collectors","source":"slang-template"}
+{"id":"3cfef95577b7b4a9","targetSkill":"buildkite-test-engine","kind":"slang","phrase":"yo, how do i speed up tests","source":"slang-template"}
+{"id":"e50984ba8485c812","targetSkill":"buildkite-test-engine","kind":"slang","phrase":"quick q — can i configure test collectors","source":"slang-template"}
+{"id":"cbd31409ad8b601e","targetSkill":"buildkite-test-engine","kind":"indirect","phrase":"can you take a look at the buildkite-test-engine situation","source":"indirect-template"}
+{"id":"ed497058ad30cc0d","targetSkill":"buildkite-test-engine","kind":"indirect","phrase":"something is going on with buildkite-test-engine","source":"indirect-template"}
+{"id":"eba316639e22dddd","targetSkill":"buildkite-test-engine","kind":"indirect","phrase":"the buildkite-test-engine thing is weird","source":"indirect-template"}
+{"id":"60999319a31298a0","targetSkill":null,"kind":"negative","phrase":"write a pipeline","source":"negative-from-adjacent","expectedOtherSkill":"buildkite-pipelines"}
+{"id":"b5a204ad1a189609","targetSkill":null,"kind":"negative","phrase":"work with artifacts in pipeline YAML","source":"negative-from-adjacent","expectedOtherSkill":"buildkite-pipelines"}
+{"id":"d96f5c7ba99f4a00","targetSkill":null,"kind":"negative","phrase":"show test failures in the build page","source":"negative-from-adjacent","expectedOtherSkill":"buildkite-pipelines"}
+{"id":"2a3061c9e9a4fc2c","targetSkill":null,"kind":"negative","phrase":"add plugins","source":"negative-from-adjacent","expectedOtherSkill":"buildkite-pipelines"}

--- a/tests/skill-coverage/corpus/docx.jsonl
+++ b/tests/skill-coverage/corpus/docx.jsonl
@@ -1,0 +1,18 @@
+{"id":"956ee00987b2ab3d","targetSkill":"docx","kind":"paraphrase","phrase":"Help me accept tracked changes.","source":"paraphrase-template"}
+{"id":"085af3e287ea14e4","targetSkill":"docx","kind":"paraphrase","phrase":"Please insert page numbers.","source":"paraphrase-template"}
+{"id":"1b62dd6f6ed4f153","targetSkill":"docx","kind":"paraphrase","phrase":"I'd like to read a .docx file.","source":"paraphrase-template"}
+{"id":"eb3eed2810ebe999","targetSkill":"docx","kind":"paraphrase","phrase":"Can you produce a report as a Word file?","source":"paraphrase-template"}
+{"id":"f653434324b0d980","targetSkill":"docx","kind":"paraphrase","phrase":"Let's add a table of contents.","source":"paraphrase-template"}
+{"id":"8698e9ce7d9adf2a","targetSkill":"docx","kind":"typo","phrase":"add a tableo f contents","source":"typo-rule"}
+{"id":"adb1203d5c15259b","targetSkill":"docx","kind":"typo","phrase":"insert page numbers","source":"typo-rule"}
+{"id":"c2a9be6640cfe2fd","targetSkill":"docx","kind":"typo","phrase":"write a lettera s a Word doc","source":"typo-rule"}
+{"id":"69189fbc5d27430a","targetSkill":"docx","kind":"slang","phrase":"hey, read a .docx file?","source":"slang-template"}
+{"id":"5d8d6355dfa2d157","targetSkill":"docx","kind":"slang","phrase":"gonna need to produce a report as a Word file","source":"slang-template"}
+{"id":"1f031341e9567f28","targetSkill":"docx","kind":"slang","phrase":"yo, how do i produce a report as a Word file","source":"slang-template"}
+{"id":"81fb39e9daecc1be","targetSkill":"docx","kind":"indirect","phrase":"this letter needs to look professional","source":"indirect-template"}
+{"id":"83a55c01ca185d18","targetSkill":"docx","kind":"indirect","phrase":"the formatting in this Word file is broken","source":"indirect-template"}
+{"id":"5b47136941795a59","targetSkill":"docx","kind":"indirect","phrase":"I need to send a polished doc","source":"indirect-template"}
+{"id":"1e5f75b8aaec5004","targetSkill":null,"kind":"negative","phrase":"create a PDF from scratch","source":"negative-from-adjacent","expectedOtherSkill":"pdf"}
+{"id":"167796822e148cf3","targetSkill":null,"kind":"negative","phrase":"create a spreadsheet from scratch","source":"negative-from-adjacent","expectedOtherSkill":"xlsx"}
+{"id":"bddea0aa678fe8cd","targetSkill":null,"kind":"negative","phrase":"split this deck","source":"negative-from-adjacent","expectedOtherSkill":"pptx"}
+{"id":"9a1b7b70cd444199","targetSkill":null,"kind":"negative","phrase":"extract text from a PDF","source":"negative-from-adjacent","expectedOtherSkill":"pdf"}

--- a/tests/skill-coverage/corpus/file-bug.jsonl
+++ b/tests/skill-coverage/corpus/file-bug.jsonl
@@ -1,0 +1,18 @@
+{"id":"e5e200db581b3c0f","targetSkill":"file-bug","kind":"paraphrase","phrase":"Can you report this issue on GitHub?","source":"paraphrase-template"}
+{"id":"58b5ca0d02679dbf","targetSkill":"file-bug","kind":"paraphrase","phrase":"Please raise a ticket.","source":"paraphrase-template"}
+{"id":"0b9cb9e8dc2bdece","targetSkill":"file-bug","kind":"paraphrase","phrase":"I need to this needs a real ticket.","source":"paraphrase-template"}
+{"id":"0bba8694d8a59bfc","targetSkill":"file-bug","kind":"paraphrase","phrase":"I need to file a bug.","source":"paraphrase-template"}
+{"id":"99affec2309baedb","targetSkill":"file-bug","kind":"paraphrase","phrase":"Report this issue on GitHub, please.","source":"paraphrase-template"}
+{"id":"330296938579d027","targetSkill":"file-bug","kind":"paraphrase","phrase":"Please file a bug.","source":"paraphrase-template"}
+{"id":"bf2051fe756e7573","targetSkill":"file-bug","kind":"typo","phrase":"raise a  ticket","source":"typo-rule"}
+{"id":"ea4d88853fa3250e","targetSkill":"file-bug","kind":"typo","phrase":"file aa bug","source":"typo-rule"}
+{"id":"1b5a4d976754c79e","targetSkill":"file-bug","kind":"typo","phrase":"log this  as a bug","source":"typo-rule"}
+{"id":"d36c711d41b5d180","targetSkill":"file-bug","kind":"slang","phrase":"gonna need to report this issue on GitHub","source":"slang-template"}
+{"id":"485d35615e0a28eb","targetSkill":"file-bug","kind":"slang","phrase":"quick q — can i open an issue","source":"slang-template"}
+{"id":"52eddde76b3ba9f0","targetSkill":"file-bug","kind":"indirect","phrase":"remember this for later","source":"indirect-template"}
+{"id":"665adcd7968daa05","targetSkill":"file-bug","kind":"indirect","phrase":"this needs to be tracked somewhere","source":"indirect-template"}
+{"id":"e3d9d6a51b270a28","targetSkill":"file-bug","kind":"indirect","phrase":"I want a paper trail for this","source":"indirect-template"}
+{"id":"3a94f9490a4268ab","targetSkill":null,"kind":"negative","phrase":"troubleshoot the fleet","source":"negative-from-adjacent","expectedOtherSkill":"switchroom-health"}
+{"id":"ed644e48dda4283b","targetSkill":null,"kind":"negative","phrase":"reboot this agent","source":"negative-from-adjacent","expectedOtherSkill":"switchroom-cli"}
+{"id":"85ad14d64092e3ec","targetSkill":null,"kind":"negative","phrase":"run a health check","source":"negative-from-adjacent","expectedOtherSkill":"switchroom-health"}
+{"id":"2c39ff7ac6919250","targetSkill":null,"kind":"negative","phrase":"update the agents","source":"negative-from-adjacent","expectedOtherSkill":"switchroom-cli"}

--- a/tests/skill-coverage/corpus/generate-corpus.ts
+++ b/tests/skill-coverage/corpus/generate-corpus.ts
@@ -1,0 +1,505 @@
+/**
+ * Rule-based corpus generator for the skill-coverage harness.
+ *
+ * Emits a JSONL of `ProbeRecord` per in-scope skill at
+ * `tests/skill-coverage/corpus/<skill>.jsonl`. Per-skill counts:
+ *   - 6 paraphrases  (template rewrites of trigger_phrases)
+ *   - 3 typos        (transposition / drop / autocorrect-style)
+ *   - 3 slang        ("how do I", "yo", "any way to" casual register)
+ *   - 3 indirect     (symptom phrasing — "X is acting weird")
+ *   - 4 negatives    (drawn from ADJACENT skills' trigger space)
+ *
+ * Deterministic: given the same skills.json + seed, output is byte-stable.
+ * No LLM at corpus-gen time — that's the v2 paraphrase pass. v1 also
+ * picks up curated `corpus/seeds/<skill>.yaml` entries when present.
+ */
+
+import { createHash } from "node:crypto";
+import { readFileSync, existsSync, writeFileSync, mkdirSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import type {
+  ProbeKind,
+  ProbeRecord,
+  SkillFixture,
+  SkillsFixtureFile,
+} from "./types.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const FIXTURES_PATH = resolve(__dirname, "..", "fixtures", "skills.json");
+const CORPUS_DIR = resolve(__dirname);
+const SEEDS_DIR = resolve(__dirname, "seeds");
+
+const PARAPHRASE_TEMPLATES: Array<(phrase: string) => string> = [
+  (p) => `Can you ${p}?`,
+  (p) => `I need to ${p}.`,
+  (p) => `Help me ${p}.`,
+  (p) => `Could you ${p} for me?`,
+  (p) => `Please ${p}.`,
+  (p) => `I'd like to ${p}.`,
+  (p) => `Let's ${p}.`,
+  (p) => `${p.charAt(0).toUpperCase()}${p.slice(1)}, please.`,
+];
+
+const SLANG_TEMPLATES: Array<(phrase: string) => string> = [
+  (p) => `yo, how do i ${p}`,
+  (p) => `any way to ${p}?`,
+  (p) => `quick q — can i ${p}`,
+  (p) => `hey, ${p}?`,
+  (p) => `pls ${p}`,
+  (p) => `gonna need to ${p}`,
+];
+
+const INDIRECT_TEMPLATES: Record<string, string[]> = {
+  // Symptom phrasings keyed by skill id. Falls back to a generic
+  // "something is going on with X" when no entry exists.
+  "switchroom-health": [
+    "my agents are acting weird",
+    "things feel off",
+    "the fleet is sluggish",
+  ],
+  "switchroom-cli": [
+    "the agent just disappeared on me",
+    "I don't know what version is live",
+    "I want to know what happened last night",
+  ],
+  "switchroom-status": [
+    "is anything running right now",
+    "how's the fleet doing",
+    "what's alive right now",
+  ],
+  "file-bug": [
+    "this needs to be tracked somewhere",
+    "I want a paper trail for this",
+    "remember this for later",
+  ],
+  pdf: [
+    "I have this pdf I can't deal with",
+    "can you help me with this scan",
+    "the form won't let me type into it",
+  ],
+  docx: [
+    "the formatting in this Word file is broken",
+    "I need to send a polished doc",
+    "this letter needs to look professional",
+  ],
+  xlsx: [
+    "this csv is a mess",
+    "the columns are all wrong in this sheet",
+    "I need to crunch some numbers in a sheet",
+  ],
+  pptx: [
+    "I need slides for tomorrow",
+    "this deck looks terrible",
+    "the presentation needs polishing",
+  ],
+  humanizer: [
+    "this paragraph screams ChatGPT",
+    "the prose sounds robotic",
+    "this reads like AI slop",
+  ],
+  "buildkite-pipelines": [
+    "my pipeline.yml is a mess",
+    "the build is slow",
+    "tests run in serial when they shouldn't",
+  ],
+  "buildkite-cli": [
+    "I want to do this from the terminal",
+    "scripting it locally would be easier",
+    "I'd rather not click around the UI",
+  ],
+};
+
+const TYPO_RULES: Array<(phrase: string) => string> = [
+  // Transpose two adjacent letters near the middle.
+  (p) => {
+    if (p.length < 6) return p;
+    const i = Math.floor(p.length / 2);
+    return p.slice(0, i) + p.charAt(i + 1) + p.charAt(i) + p.slice(i + 2);
+  },
+  // Drop a letter ~1/3 in.
+  (p) => {
+    if (p.length < 6) return p;
+    const i = Math.floor(p.length / 3);
+    return p.slice(0, i) + p.slice(i + 1);
+  },
+  // Autocorrect-style — replace a short common word.
+  (p) => p.replace(/\bthe\b/i, "teh").replace(/\band\b/i, "adn"),
+  // Double a letter.
+  (p) => {
+    if (p.length < 4) return p;
+    const i = Math.floor(p.length / 2);
+    return p.slice(0, i) + p.charAt(i) + p.slice(i);
+  },
+];
+
+export interface GenerateOptions {
+  seed: number;
+  /** Override; defaults to fixture file alongside this script. */
+  fixturesPath?: string;
+  /** Skill ids to include — null/empty = all in_default_pool. */
+  onlySkills?: string[] | null;
+}
+
+export interface GenerateResult {
+  /** All probes, grouped by target skill (null bucket holds free negatives). */
+  bySkill: Record<string, ProbeRecord[]>;
+  /** Skills considered out of scope (user_invocable=false or not in pool). */
+  skipped: string[];
+}
+
+/**
+ * Deterministic hash for probe ids. We mix seed in so that different
+ * seeds produce different ids for the same phrase — the runner uses
+ * ids as primary keys when persisting results.
+ */
+function probeId(skill: string | null, kind: ProbeKind, phrase: string, seed: number): string {
+  const h = createHash("sha256");
+  h.update(`${skill ?? "<null>"}|${kind}|${phrase}|${seed}`);
+  return h.digest("hex").slice(0, 16);
+}
+
+/**
+ * Tiny seedable RNG. Used to pick template indices deterministically.
+ * mulberry32 — small state, good enough for non-crypto sampling.
+ */
+function mulberry32(seed: number): () => number {
+  let t = seed >>> 0;
+  return () => {
+    t = (t + 0x6d2b79f5) >>> 0;
+    let r = t;
+    r = Math.imul(r ^ (r >>> 15), r | 1);
+    r ^= r + Math.imul(r ^ (r >>> 7), r | 61);
+    return ((r ^ (r >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+/**
+ * Per-skill seed: rng is reseeded from (globalSeed, skillId) so the
+ * order in which we walk skills doesn't perturb individual outputs.
+ */
+function skillRng(seed: number, skillId: string): () => number {
+  const h = createHash("sha256");
+  h.update(`${seed}|${skillId}`);
+  // Take the first 4 bytes as a u32 seed.
+  const buf = h.digest();
+  const localSeed = buf.readUInt32BE(0);
+  return mulberry32(localSeed);
+}
+
+/** Round-robin take of `n` items from `items`, using rng to rotate. */
+function pickN<T>(items: T[], n: number, rng: () => number): T[] {
+  if (items.length === 0) return [];
+  const offset = Math.floor(rng() * items.length);
+  const out: T[] = [];
+  for (let i = 0; i < n; i++) {
+    out.push(items[(offset + i) % items.length]);
+  }
+  return out;
+}
+
+interface SeedYaml {
+  paraphrases?: string[];
+  typos?: string[];
+  slang?: string[];
+  indirect?: string[];
+  negatives?: Array<{ phrase: string; expectedOtherSkill?: string }>;
+}
+
+/**
+ * Minimal YAML parser for the seeds files — enough to handle the
+ * shapes we document. We only need: top-level keys, list of scalars,
+ * and a `negatives:` list-of-objects with `phrase:` + optional
+ * `expectedOtherSkill:`. Bringing the `yaml` dep in would be fine,
+ * but keeping this dep-free makes the harness portable.
+ */
+function parseSeedYaml(src: string): SeedYaml {
+  const out: SeedYaml = {};
+  const lines = src.split(/\r?\n/);
+  let currentKey: keyof SeedYaml | null = null;
+  let pendingNeg: { phrase?: string; expectedOtherSkill?: string } | null = null;
+  for (const raw of lines) {
+    const line = raw.replace(/#.*$/, "").trimEnd();
+    if (!line.trim()) continue;
+    const topKey = line.match(/^([a-zA-Z_]+):\s*$/);
+    if (topKey) {
+      if (pendingNeg && pendingNeg.phrase != null) {
+        (out.negatives ??= []).push(pendingNeg as { phrase: string; expectedOtherSkill?: string });
+        pendingNeg = null;
+      }
+      const k = topKey[1] as keyof SeedYaml;
+      currentKey = k;
+      if (k === "negatives") out.negatives ??= [];
+      continue;
+    }
+    if (currentKey == null) continue;
+    if (currentKey === "negatives") {
+      const bullet = line.match(/^\s*-\s*phrase:\s*"(.+)"\s*$/);
+      if (bullet) {
+        if (pendingNeg && pendingNeg.phrase != null) {
+          out.negatives!.push(pendingNeg as { phrase: string; expectedOtherSkill?: string });
+        }
+        pendingNeg = { phrase: bullet[1] };
+        continue;
+      }
+      const ext = line.match(/^\s+expectedOtherSkill:\s*"?([^"\s]+)"?\s*$/);
+      if (ext && pendingNeg) {
+        pendingNeg.expectedOtherSkill = ext[1];
+        continue;
+      }
+      const bareBullet = line.match(/^\s*-\s*"(.+)"\s*$/);
+      if (bareBullet) {
+        if (pendingNeg && pendingNeg.phrase != null) {
+          out.negatives!.push(pendingNeg as { phrase: string; expectedOtherSkill?: string });
+        }
+        pendingNeg = { phrase: bareBullet[1] };
+        continue;
+      }
+    } else {
+      const m = line.match(/^\s*-\s*"?(.+?)"?\s*$/);
+      if (m) {
+        const arr = (out[currentKey] as string[] | undefined) ?? [];
+        arr.push(m[1]);
+        out[currentKey] = arr as never;
+      }
+    }
+  }
+  if (pendingNeg && pendingNeg.phrase != null) {
+    (out.negatives ??= []).push(pendingNeg as { phrase: string; expectedOtherSkill?: string });
+  }
+  return out;
+}
+
+function loadSeedYaml(skillId: string): SeedYaml | null {
+  const p = join(SEEDS_DIR, `${skillId}.yaml`);
+  if (!existsSync(p)) return null;
+  try {
+    return parseSeedYaml(readFileSync(p, "utf-8"));
+  } catch {
+    return null;
+  }
+}
+
+export function loadFixtures(path: string = FIXTURES_PATH): SkillsFixtureFile {
+  const raw = readFileSync(path, "utf-8");
+  return JSON.parse(raw) as SkillsFixtureFile;
+}
+
+/**
+ * Synthesise the per-skill probe set. Pure function — no I/O.
+ * Exposed for unit tests.
+ */
+export function generateForSkill(
+  skill: SkillFixture,
+  allSkills: SkillFixture[],
+  seed: number,
+): ProbeRecord[] {
+  const rng = skillRng(seed, skill.id);
+  const probes: ProbeRecord[] = [];
+  const seenPhrases = new Set<string>();
+
+  const push = (
+    rec: Omit<ProbeRecord, "id"> & { phrase: string },
+  ): void => {
+    const phrase = rec.phrase.trim();
+    if (!phrase) return;
+    if (seenPhrases.has(phrase.toLowerCase())) return;
+    seenPhrases.add(phrase.toLowerCase());
+    probes.push({
+      id: probeId(rec.targetSkill, rec.kind, phrase, seed),
+      ...rec,
+      phrase,
+    });
+  };
+
+  const triggers = skill.trigger_phrases.length > 0 ? skill.trigger_phrases : [skill.description];
+
+  // Curated seeds get prepended for each category; they take priority
+  // and are deduped against the rule-based variants below.
+  const yaml = loadSeedYaml(skill.id);
+  if (yaml?.paraphrases) {
+    for (const p of yaml.paraphrases) {
+      push({ targetSkill: skill.id, kind: "paraphrase", phrase: p, source: "seed-yaml" });
+    }
+  }
+  if (yaml?.typos) {
+    for (const p of yaml.typos) {
+      push({ targetSkill: skill.id, kind: "typo", phrase: p, source: "seed-yaml" });
+    }
+  }
+  if (yaml?.slang) {
+    for (const p of yaml.slang) {
+      push({ targetSkill: skill.id, kind: "slang", phrase: p, source: "seed-yaml" });
+    }
+  }
+  if (yaml?.indirect) {
+    for (const p of yaml.indirect) {
+      push({ targetSkill: skill.id, kind: "indirect", phrase: p, source: "seed-yaml" });
+    }
+  }
+  if (yaml?.negatives) {
+    for (const n of yaml.negatives) {
+      push({
+        targetSkill: null,
+        kind: "negative",
+        phrase: n.phrase,
+        source: "seed-yaml",
+        expectedOtherSkill: n.expectedOtherSkill,
+      });
+    }
+  }
+
+  // ── paraphrases: 6
+  for (let i = probes.filter((p) => p.kind === "paraphrase").length; i < 6; i++) {
+    const trigger = triggers[Math.floor(rng() * triggers.length)];
+    const tmpl = PARAPHRASE_TEMPLATES[Math.floor(rng() * PARAPHRASE_TEMPLATES.length)];
+    push({
+      targetSkill: skill.id,
+      kind: "paraphrase",
+      phrase: tmpl(trigger),
+      source: "paraphrase-template",
+    });
+  }
+
+  // ── typos: 3
+  for (let i = probes.filter((p) => p.kind === "typo").length; i < 3; i++) {
+    const trigger = triggers[Math.floor(rng() * triggers.length)];
+    const rule = TYPO_RULES[Math.floor(rng() * TYPO_RULES.length)];
+    push({
+      targetSkill: skill.id,
+      kind: "typo",
+      phrase: rule(trigger),
+      source: "typo-rule",
+    });
+  }
+
+  // ── slang: 3
+  for (let i = probes.filter((p) => p.kind === "slang").length; i < 3; i++) {
+    const trigger = triggers[Math.floor(rng() * triggers.length)];
+    const tmpl = SLANG_TEMPLATES[Math.floor(rng() * SLANG_TEMPLATES.length)];
+    push({
+      targetSkill: skill.id,
+      kind: "slang",
+      phrase: tmpl(trigger),
+      source: "slang-template",
+    });
+  }
+
+  // ── indirect: 3 (curated table preferred, fallback to generic)
+  const indirectPool =
+    INDIRECT_TEMPLATES[skill.id] ?? [
+      `something is going on with ${skill.id}`,
+      `the ${skill.id} thing is weird`,
+      `can you take a look at the ${skill.id} situation`,
+    ];
+  const indirects = pickN(indirectPool, 3, rng);
+  for (const phrase of indirects) {
+    push({
+      targetSkill: skill.id,
+      kind: "indirect",
+      phrase,
+      source: "indirect-template",
+    });
+  }
+
+  // ── negative controls: 4 drawn from adjacent skills
+  const adjacent = skill.adjacent_skills
+    .map((id) => allSkills.find((s) => s.id === id))
+    .filter((s): s is SkillFixture => !!s);
+  if (adjacent.length > 0) {
+    // Walk adjacents round-robin until we have 4.
+    let need = 4 - probes.filter((p) => p.kind === "negative").length;
+    let idx = 0;
+    let guard = 0;
+    while (need > 0 && guard < 32) {
+      const adj = adjacent[idx % adjacent.length];
+      const trigger = adj.trigger_phrases[Math.floor(rng() * Math.max(adj.trigger_phrases.length, 1))];
+      if (trigger) {
+        push({
+          targetSkill: null,
+          kind: "negative",
+          phrase: trigger,
+          source: "negative-from-adjacent",
+          expectedOtherSkill: adj.id,
+        });
+      }
+      idx++;
+      guard++;
+      need = 4 - probes.filter((p) => p.kind === "negative").length;
+    }
+  }
+
+  return probes;
+}
+
+export function generateCorpus(opts: GenerateOptions): GenerateResult {
+  const { seed, fixturesPath, onlySkills } = opts;
+  const fixtures = loadFixtures(fixturesPath);
+  const inScope = fixtures.skills.filter(
+    (s) =>
+      s.user_invocable &&
+      s.in_default_pool &&
+      (!onlySkills || onlySkills.length === 0 || onlySkills.includes(s.id)),
+  );
+  const skipped = fixtures.skills
+    .filter((s) => !s.user_invocable || !s.in_default_pool)
+    .map((s) => s.id);
+
+  const bySkill: Record<string, ProbeRecord[]> = {};
+  for (const skill of inScope) {
+    bySkill[skill.id] = generateForSkill(skill, fixtures.skills, seed);
+  }
+  return { bySkill, skipped };
+}
+
+/** Stable JSONL serialise: one record per line, keys in declared order. */
+export function probesToJsonl(probes: ProbeRecord[]): string {
+  return (
+    probes
+      .map((p) =>
+        JSON.stringify({
+          id: p.id,
+          targetSkill: p.targetSkill,
+          kind: p.kind,
+          phrase: p.phrase,
+          source: p.source,
+          ...(p.expectedOtherSkill ? { expectedOtherSkill: p.expectedOtherSkill } : {}),
+        }),
+      )
+      .join("\n") + "\n"
+  );
+}
+
+/** CLI entry — writes JSONL files under tests/skill-coverage/corpus/. */
+export function writeCorpusFiles(result: GenerateResult, outDir: string = CORPUS_DIR): string[] {
+  mkdirSync(outDir, { recursive: true });
+  const written: string[] = [];
+  for (const [skill, probes] of Object.entries(result.bySkill)) {
+    const p = join(outDir, `${skill}.jsonl`);
+    writeFileSync(p, probesToJsonl(probes));
+    written.push(p);
+  }
+  return written;
+}
+
+// ── CLI entrypoint ────────────────────────────────────────────────────────
+// Run as: `bun tests/skill-coverage/corpus/generate-corpus.ts [--seed=N] [--skills=a,b]`
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const argv = process.argv.slice(2);
+  let seed = 1;
+  let onlySkills: string[] | null = null;
+  for (const a of argv) {
+    const sm = a.match(/^--seed=(\d+)$/);
+    if (sm) seed = Number(sm[1]);
+    const km = a.match(/^--skills=(.+)$/);
+    if (km) onlySkills = km[1].split(",").map((s) => s.trim()).filter(Boolean);
+  }
+  const result = generateCorpus({ seed, onlySkills });
+  const written = writeCorpusFiles(result);
+  // eslint-disable-next-line no-console
+  console.log(`wrote ${written.length} jsonl files (seed=${seed})`);
+  if (result.skipped.length > 0) {
+    // eslint-disable-next-line no-console
+    console.log(`skipped (out of scope): ${result.skipped.join(", ")}`);
+  }
+}

--- a/tests/skill-coverage/corpus/humanizer-calibrate.jsonl
+++ b/tests/skill-coverage/corpus/humanizer-calibrate.jsonl
@@ -1,0 +1,18 @@
+{"id":"39cd5eb6b6b17d11","targetSkill":"humanizer-calibrate","kind":"paraphrase","phrase":"Let's humanizer-calibrate.","source":"paraphrase-template"}
+{"id":"c125261face8b61b","targetSkill":"humanizer-calibrate","kind":"paraphrase","phrase":"Please calibrate humanizer.","source":"paraphrase-template"}
+{"id":"837ba534114c06ca","targetSkill":"humanizer-calibrate","kind":"paraphrase","phrase":"Make humanizer sound more like me, please.","source":"paraphrase-template"}
+{"id":"9981906fb7f32443","targetSkill":"humanizer-calibrate","kind":"paraphrase","phrase":"Can you humanizer-calibrate?","source":"paraphrase-template"}
+{"id":"996640fc5d723131","targetSkill":"humanizer-calibrate","kind":"paraphrase","phrase":"Calibrate humanizer, please.","source":"paraphrase-template"}
+{"id":"f534a96f373073e9","targetSkill":"humanizer-calibrate","kind":"paraphrase","phrase":"Let's build a voice template.","source":"paraphrase-template"}
+{"id":"b67054fd6e5ee563","targetSkill":"humanizer-calibrate","kind":"typo","phrase":"calibrte humanizer","source":"typo-rule"}
+{"id":"e19200af1e1e23a8","targetSkill":"humanizer-calibrate","kind":"typo","phrase":"make humanier sound more like me","source":"typo-rule"}
+{"id":"3b4381336e8c217d","targetSkill":"humanizer-calibrate","kind":"slang","phrase":"quick q — can i make humanizer sound more like me","source":"slang-template"}
+{"id":"e86fbbfbb1da74a4","targetSkill":"humanizer-calibrate","kind":"slang","phrase":"gonna need to humanizer-calibrate","source":"slang-template"}
+{"id":"8da2758c14dfde10","targetSkill":"humanizer-calibrate","kind":"slang","phrase":"pls humanizer-calibrate","source":"slang-template"}
+{"id":"fde3246fc66879da","targetSkill":"humanizer-calibrate","kind":"indirect","phrase":"something is going on with humanizer-calibrate","source":"indirect-template"}
+{"id":"9e85e8802cfb0bf2","targetSkill":"humanizer-calibrate","kind":"indirect","phrase":"the humanizer-calibrate thing is weird","source":"indirect-template"}
+{"id":"96f94bbe1933e489","targetSkill":"humanizer-calibrate","kind":"indirect","phrase":"can you take a look at the humanizer-calibrate situation","source":"indirect-template"}
+{"id":"63533286e85cc636","targetSkill":null,"kind":"negative","phrase":"de-AI this paragraph","source":"negative-from-adjacent","expectedOtherSkill":"humanizer"}
+{"id":"531c9439523690c4","targetSkill":null,"kind":"negative","phrase":"review this text for AI tells","source":"negative-from-adjacent","expectedOtherSkill":"humanizer"}
+{"id":"f5fd008e868c9651","targetSkill":null,"kind":"negative","phrase":"remove the rule of three","source":"negative-from-adjacent","expectedOtherSkill":"humanizer"}
+{"id":"bbdecae9e762fc04","targetSkill":null,"kind":"negative","phrase":"rewrite this to sound natural","source":"negative-from-adjacent","expectedOtherSkill":"humanizer"}

--- a/tests/skill-coverage/corpus/humanizer.jsonl
+++ b/tests/skill-coverage/corpus/humanizer.jsonl
@@ -1,0 +1,18 @@
+{"id":"00ac3193aedba37f","targetSkill":"humanizer","kind":"paraphrase","phrase":"Let's rewrite this to sound natural.","source":"paraphrase-template"}
+{"id":"b8a8169d881e27ef","targetSkill":"humanizer","kind":"paraphrase","phrase":"Please edit this so it doesn't sound like AI.","source":"paraphrase-template"}
+{"id":"a3290aeac74bdac5","targetSkill":"humanizer","kind":"paraphrase","phrase":"Can you remove the rule of three?","source":"paraphrase-template"}
+{"id":"56d73ad8a10e9140","targetSkill":"humanizer","kind":"paraphrase","phrase":"Remove signs of AI writing, please.","source":"paraphrase-template"}
+{"id":"bb19cf611f4489e5","targetSkill":"humanizer","kind":"paraphrase","phrase":"Let's fix the em-dash overuse.","source":"paraphrase-template"}
+{"id":"d63b5bc3ae726c7c","targetSkill":"humanizer","kind":"paraphrase","phrase":"I need to make this sound more human.","source":"paraphrase-template"}
+{"id":"80bec780a669f77c","targetSkill":"humanizer","kind":"typo","phrase":"make this soudn more human","source":"typo-rule"}
+{"id":"5420bbaf61e30fb1","targetSkill":"humanizer","kind":"typo","phrase":"remove signs of AI writing","source":"typo-rule"}
+{"id":"598a299e44f64b44","targetSkill":"humanizer","kind":"typo","phrase":"fix theem-dash overuse","source":"typo-rule"}
+{"id":"55275d87b82264b9","targetSkill":"humanizer","kind":"slang","phrase":"yo, how do i remove signs of AI writing","source":"slang-template"}
+{"id":"4393cb8e127f0619","targetSkill":"humanizer","kind":"slang","phrase":"gonna need to remove signs of AI writing","source":"slang-template"}
+{"id":"e679468672b774bf","targetSkill":"humanizer","kind":"indirect","phrase":"this paragraph screams ChatGPT","source":"indirect-template"}
+{"id":"97a8e1155bfd5372","targetSkill":"humanizer","kind":"indirect","phrase":"the prose sounds robotic","source":"indirect-template"}
+{"id":"69742741d4c4468e","targetSkill":"humanizer","kind":"indirect","phrase":"this reads like AI slop","source":"indirect-template"}
+{"id":"9c6b7f7f9543041b","targetSkill":null,"kind":"negative","phrase":"humanizer-calibrate","source":"negative-from-adjacent","expectedOtherSkill":"humanizer-calibrate"}
+{"id":"caf6f3b37a17929c","targetSkill":null,"kind":"negative","phrase":"fresh voice template for humanizer","source":"negative-from-adjacent","expectedOtherSkill":"humanizer-calibrate"}
+{"id":"b13a5c7ce9b0a6d5","targetSkill":null,"kind":"negative","phrase":"build a voice template","source":"negative-from-adjacent","expectedOtherSkill":"humanizer-calibrate"}
+{"id":"91f194613377a010","targetSkill":null,"kind":"negative","phrase":"calibrate humanizer","source":"negative-from-adjacent","expectedOtherSkill":"humanizer-calibrate"}

--- a/tests/skill-coverage/corpus/mcp-builder.jsonl
+++ b/tests/skill-coverage/corpus/mcp-builder.jsonl
@@ -1,0 +1,19 @@
+{"id":"424ac38af0e80c10","targetSkill":"mcp-builder","kind":"paraphrase","phrase":"Let's write an MCP server for.","source":"paraphrase-template"}
+{"id":"4fe676cb9e4daa2c","targetSkill":"mcp-builder","kind":"paraphrase","phrase":"Please integrate an external API as MCP.","source":"paraphrase-template"}
+{"id":"c1b20bed12caf131","targetSkill":"mcp-builder","kind":"paraphrase","phrase":"Use the MCP SDK in TypeScript, please.","source":"paraphrase-template"}
+{"id":"bdbf5682a445cfd8","targetSkill":"mcp-builder","kind":"paraphrase","phrase":"Write an MCP server for, please.","source":"paraphrase-template"}
+{"id":"59f95422e1c03514","targetSkill":"mcp-builder","kind":"paraphrase","phrase":"I'd like to create a new MCP server.","source":"paraphrase-template"}
+{"id":"392117e06476d4e7","targetSkill":"mcp-builder","kind":"paraphrase","phrase":"I need to use the MCP SDK in TypeScript.","source":"paraphrase-template"}
+{"id":"9c1b7bc50f646c75","targetSkill":"mcp-builder","kind":"typo","phrase":"create  new MCP server","source":"typo-rule"}
+{"id":"c806eacd07331b6c","targetSkill":"mcp-builder","kind":"typo","phrase":"write an MCPP server for","source":"typo-rule"}
+{"id":"e05084602847e429","targetSkill":"mcp-builder","kind":"typo","phrase":"use the MCP SD Kin TypeScript","source":"typo-rule"}
+{"id":"2ac41070625d2c81","targetSkill":"mcp-builder","kind":"slang","phrase":"pls create a new MCP server","source":"slang-template"}
+{"id":"463b19f6d2f8261e","targetSkill":"mcp-builder","kind":"slang","phrase":"pls build an MCP server","source":"slang-template"}
+{"id":"cc37a2aa30d5144a","targetSkill":"mcp-builder","kind":"slang","phrase":"gonna need to build an MCP server","source":"slang-template"}
+{"id":"e55feaeeff81d209","targetSkill":"mcp-builder","kind":"indirect","phrase":"the mcp-builder thing is weird","source":"indirect-template"}
+{"id":"53117e4647d5e705","targetSkill":"mcp-builder","kind":"indirect","phrase":"can you take a look at the mcp-builder situation","source":"indirect-template"}
+{"id":"ae9cd86df2dfeb1d","targetSkill":"mcp-builder","kind":"indirect","phrase":"something is going on with mcp-builder","source":"indirect-template"}
+{"id":"042682ac45dbdcff","targetSkill":null,"kind":"negative","phrase":"edit an existing skill","source":"negative-from-adjacent","expectedOtherSkill":"skill-creator"}
+{"id":"e7b7662551300d17","targetSkill":null,"kind":"negative","phrase":"improve the trigger accuracy of a skill","source":"negative-from-adjacent","expectedOtherSkill":"skill-creator"}
+{"id":"5c62319dbca551cb","targetSkill":null,"kind":"negative","phrase":"create a new skill","source":"negative-from-adjacent","expectedOtherSkill":"skill-creator"}
+{"id":"9473fd6467d99336","targetSkill":null,"kind":"negative","phrase":"optimize a skill description","source":"negative-from-adjacent","expectedOtherSkill":"skill-creator"}

--- a/tests/skill-coverage/corpus/pdf.jsonl
+++ b/tests/skill-coverage/corpus/pdf.jsonl
@@ -1,0 +1,19 @@
+{"id":"f2a504ff86c255b6","targetSkill":"pdf","kind":"paraphrase","phrase":"Let's rotate PDF pages.","source":"paraphrase-template"}
+{"id":"7d4bdaa90212e0d9","targetSkill":"pdf","kind":"paraphrase","phrase":"I need to watermark a PDF.","source":"paraphrase-template"}
+{"id":"6aa8261e06309f4d","targetSkill":"pdf","kind":"paraphrase","phrase":"Can you rotate PDF pages?","source":"paraphrase-template"}
+{"id":"2ea2d61882976e1c","targetSkill":"pdf","kind":"paraphrase","phrase":"Can you fill a PDF form?","source":"paraphrase-template"}
+{"id":"163a184620d54b5b","targetSkill":"pdf","kind":"paraphrase","phrase":"Extract text from a PDF, please.","source":"paraphrase-template"}
+{"id":"1e145bedb4d1e800","targetSkill":"pdf","kind":"paraphrase","phrase":"Could you watermark a PDF for me?","source":"paraphrase-template"}
+{"id":"90748550720a0b2c","targetSkill":"pdf","kind":"typo","phrase":"merge PDFs","source":"typo-rule"}
+{"id":"12c271d1a4e22dcf","targetSkill":"pdf","kind":"typo","phrase":"fill a PDF form","source":"typo-rule"}
+{"id":"cc9aeee98e217cec","targetSkill":"pdf","kind":"typo","phrase":"fill  PDF form","source":"typo-rule"}
+{"id":"608419416d79a913","targetSkill":"pdf","kind":"slang","phrase":"pls rotate PDF pages","source":"slang-template"}
+{"id":"9478b23da6c1dac8","targetSkill":"pdf","kind":"slang","phrase":"any way to rotate PDF pages?","source":"slang-template"}
+{"id":"b25565c2a2f1b7e1","targetSkill":"pdf","kind":"slang","phrase":"gonna need to OCR a scanned PDF","source":"slang-template"}
+{"id":"3a62f436174afbd6","targetSkill":"pdf","kind":"indirect","phrase":"I have this pdf I can't deal with","source":"indirect-template"}
+{"id":"78ce872a8096f7ef","targetSkill":"pdf","kind":"indirect","phrase":"can you help me with this scan","source":"indirect-template"}
+{"id":"eacb16d142c41846","targetSkill":"pdf","kind":"indirect","phrase":"the form won't let me type into it","source":"indirect-template"}
+{"id":"a113419f817d8314","targetSkill":null,"kind":"negative","phrase":"produce a report as a Word file","source":"negative-from-adjacent","expectedOtherSkill":"docx"}
+{"id":"7a4da9ce9af61362","targetSkill":null,"kind":"negative","phrase":"compute formulas in Excel","source":"negative-from-adjacent","expectedOtherSkill":"xlsx"}
+{"id":"7754d6600d201cbd","targetSkill":null,"kind":"negative","phrase":"write a letter as a Word doc","source":"negative-from-adjacent","expectedOtherSkill":"docx"}
+{"id":"f74de1fc34a92037","targetSkill":null,"kind":"negative","phrase":"convert CSV to xlsx","source":"negative-from-adjacent","expectedOtherSkill":"xlsx"}

--- a/tests/skill-coverage/corpus/pptx.jsonl
+++ b/tests/skill-coverage/corpus/pptx.jsonl
@@ -1,0 +1,19 @@
+{"id":"438fc70881ebd7be","targetSkill":"pptx","kind":"paraphrase","phrase":"I need to combine slide files.","source":"paraphrase-template"}
+{"id":"7f885a9e7e30f05e","targetSkill":"pptx","kind":"paraphrase","phrase":"I need to work from a slide template.","source":"paraphrase-template"}
+{"id":"54e44ade1af44d39","targetSkill":"pptx","kind":"paraphrase","phrase":"Help me split this deck.","source":"paraphrase-template"}
+{"id":"17a25fb6eff1dec6","targetSkill":"pptx","kind":"paraphrase","phrase":"I'd like to edit this presentation.","source":"paraphrase-template"}
+{"id":"c7218e40112b6f99","targetSkill":"pptx","kind":"paraphrase","phrase":"I need to split this deck.","source":"paraphrase-template"}
+{"id":"fbab4ca23b480465","targetSkill":"pptx","kind":"paraphrase","phrase":"Let's edit this presentation.","source":"paraphrase-template"}
+{"id":"7a09c948ba4af4df","targetSkill":"pptx","kind":"typo","phrase":"build a pitch deck","source":"typo-rule"}
+{"id":"b234046d1c78d6d0","targetSkill":"pptx","kind":"typo","phrase":"update the sepaker notes","source":"typo-rule"}
+{"id":"325689ccbc01af4a","targetSkill":"pptx","kind":"typo","phrase":"combin slide files","source":"typo-rule"}
+{"id":"8d11f5eebfe6d42c","targetSkill":"pptx","kind":"slang","phrase":"gonna need to update the speaker notes","source":"slang-template"}
+{"id":"8771fe3d0195970d","targetSkill":"pptx","kind":"slang","phrase":"hey, work from a slide template?","source":"slang-template"}
+{"id":"3f10264f90ab9a99","targetSkill":"pptx","kind":"slang","phrase":"pls combine slide files","source":"slang-template"}
+{"id":"f52e22704aa223a0","targetSkill":"pptx","kind":"indirect","phrase":"I need slides for tomorrow","source":"indirect-template"}
+{"id":"ae212f436afa2f63","targetSkill":"pptx","kind":"indirect","phrase":"this deck looks terrible","source":"indirect-template"}
+{"id":"656859c1188ae57f","targetSkill":"pptx","kind":"indirect","phrase":"the presentation needs polishing","source":"indirect-template"}
+{"id":"521389eecca02b78","targetSkill":null,"kind":"negative","phrase":"add a table of contents","source":"negative-from-adjacent","expectedOtherSkill":"docx"}
+{"id":"fb08ccbac9d141d4","targetSkill":null,"kind":"negative","phrase":"fill a PDF form","source":"negative-from-adjacent","expectedOtherSkill":"pdf"}
+{"id":"08b4703c4a03072a","targetSkill":null,"kind":"negative","phrase":"leave comments on a Word doc","source":"negative-from-adjacent","expectedOtherSkill":"docx"}
+{"id":"f5009eb78b6837c1","targetSkill":null,"kind":"negative","phrase":"encrypt this PDF","source":"negative-from-adjacent","expectedOtherSkill":"pdf"}

--- a/tests/skill-coverage/corpus/skill-creator.jsonl
+++ b/tests/skill-coverage/corpus/skill-creator.jsonl
@@ -1,0 +1,19 @@
+{"id":"854545d990ef3fca","targetSkill":"skill-creator","kind":"paraphrase","phrase":"Edit an existing skill, please.","source":"paraphrase-template"}
+{"id":"3c28490199165a06","targetSkill":"skill-creator","kind":"paraphrase","phrase":"I need to create a new skill.","source":"paraphrase-template"}
+{"id":"497305ff3f6914be","targetSkill":"skill-creator","kind":"paraphrase","phrase":"Help me create a new skill.","source":"paraphrase-template"}
+{"id":"f0c1d85234cccb74","targetSkill":"skill-creator","kind":"paraphrase","phrase":"Can you improve the trigger accuracy of a skill?","source":"paraphrase-template"}
+{"id":"d21116a249988795","targetSkill":"skill-creator","kind":"paraphrase","phrase":"Can you optimize a skill description?","source":"paraphrase-template"}
+{"id":"e20d6724f58f262a","targetSkill":"skill-creator","kind":"paraphrase","phrase":"Could you edit an existing skill for me?","source":"paraphrase-template"}
+{"id":"e23976cf2b7670e4","targetSkill":"skill-creator","kind":"typo","phrase":"improve teh trigger accuracy of a skill","source":"typo-rule"}
+{"id":"71b5e2e9a5cea7c8","targetSkill":"skill-creator","kind":"typo","phrase":"optimize  skill description","source":"typo-rule"}
+{"id":"194a203e4a46d5f7","targetSkill":"skill-creator","kind":"typo","phrase":"create a new skill","source":"typo-rule"}
+{"id":"45e514cb8cb90c06","targetSkill":"skill-creator","kind":"slang","phrase":"any way to optimize a skill description?","source":"slang-template"}
+{"id":"273ff6b978681f90","targetSkill":"skill-creator","kind":"slang","phrase":"yo, how do i edit an existing skill","source":"slang-template"}
+{"id":"5b0aa7b9be225e76","targetSkill":"skill-creator","kind":"slang","phrase":"yo, how do i optimize a skill description","source":"slang-template"}
+{"id":"2271eeec053ca391","targetSkill":"skill-creator","kind":"indirect","phrase":"can you take a look at the skill-creator situation","source":"indirect-template"}
+{"id":"df02b2242ffb7522","targetSkill":"skill-creator","kind":"indirect","phrase":"something is going on with skill-creator","source":"indirect-template"}
+{"id":"afa375b8c81ab22c","targetSkill":"skill-creator","kind":"indirect","phrase":"the skill-creator thing is weird","source":"indirect-template"}
+{"id":"7b90a4aa72ad0936","targetSkill":null,"kind":"negative","phrase":"use the MCP SDK in TypeScript","source":"negative-from-adjacent","expectedOtherSkill":"mcp-builder"}
+{"id":"79ca852e340efd3f","targetSkill":null,"kind":"negative","phrase":"build an MCP server","source":"negative-from-adjacent","expectedOtherSkill":"mcp-builder"}
+{"id":"a7be2c271f408dc0","targetSkill":null,"kind":"negative","phrase":"write an MCP server for","source":"negative-from-adjacent","expectedOtherSkill":"mcp-builder"}
+{"id":"7b8f9a31b537e3b3","targetSkill":null,"kind":"negative","phrase":"wrap this API as MCP tools","source":"negative-from-adjacent","expectedOtherSkill":"mcp-builder"}

--- a/tests/skill-coverage/corpus/switchroom-cli.jsonl
+++ b/tests/skill-coverage/corpus/switchroom-cli.jsonl
@@ -1,0 +1,19 @@
+{"id":"74b1bff5af5755f9","targetSkill":"switchroom-cli","kind":"paraphrase","phrase":"Please sync my config.","source":"paraphrase-template"}
+{"id":"2173ae43f4d49fcc","targetSkill":"switchroom-cli","kind":"paraphrase","phrase":"Could you check the journal for me?","source":"paraphrase-template"}
+{"id":"42a4f0331a730ccc","targetSkill":"switchroom-cli","kind":"paraphrase","phrase":"Can you why did it crash?","source":"paraphrase-template"}
+{"id":"254a349850a37042","targetSkill":"switchroom-cli","kind":"paraphrase","phrase":"Upgrade switchroom, please.","source":"paraphrase-template"}
+{"id":"22d2977f278bdf1e","targetSkill":"switchroom-cli","kind":"paraphrase","phrase":"I'd like to why did it crash.","source":"paraphrase-template"}
+{"id":"cccedcbf5135b9fe","targetSkill":"switchroom-cli","kind":"paraphrase","phrase":"I'd like to apply my config changes.","source":"paraphrase-template"}
+{"id":"e1ffe2000531f894","targetSkill":"switchroom-cli","kind":"typo","phrase":"list schedlued tasks","source":"typo-rule"}
+{"id":"aef91121b27cbfe8","targetSkill":"switchroom-cli","kind":"typo","phrase":"apply my cofnig changes","source":"typo-rule"}
+{"id":"b7f169c37fe269d7","targetSkill":"switchroom-cli","kind":"typo","phrase":"kick teh agent, it's stuck","source":"typo-rule"}
+{"id":"c7f75a2c052e519f","targetSkill":"switchroom-cli","kind":"slang","phrase":"pls why did it crash","source":"slang-template"}
+{"id":"1da15e7801df8fd9","targetSkill":"switchroom-cli","kind":"slang","phrase":"yo, how do i check the journal","source":"slang-template"}
+{"id":"9bd0ee620f9f1d3d","targetSkill":"switchroom-cli","kind":"slang","phrase":"yo, how do i show the cascade for X","source":"slang-template"}
+{"id":"046b5f0a6ce8e8d6","targetSkill":"switchroom-cli","kind":"indirect","phrase":"the agent just disappeared on me","source":"indirect-template"}
+{"id":"1b5d81c7abd80443","targetSkill":"switchroom-cli","kind":"indirect","phrase":"I don't know what version is live","source":"indirect-template"}
+{"id":"ea56aa3d5335aaf8","targetSkill":"switchroom-cli","kind":"indirect","phrase":"I want to know what happened last night","source":"indirect-template"}
+{"id":"4ce3457a0df8a7dc","targetSkill":null,"kind":"negative","phrase":"my agents are broken","source":"negative-from-adjacent","expectedOtherSkill":"switchroom-health"}
+{"id":"fa99fc025157fece","targetSkill":null,"kind":"negative","phrase":"add a new agent","source":"negative-from-adjacent","expectedOtherSkill":"switchroom-manage"}
+{"id":"f69a2b5b8d64dc82","targetSkill":null,"kind":"negative","phrase":"bootstrap switchroom from scratch","source":"negative-from-adjacent","expectedOtherSkill":"switchroom-install"}
+{"id":"bc1b39b6bf8b8562","targetSkill":null,"kind":"negative","phrase":"per-agent snapshot","source":"negative-from-adjacent","expectedOtherSkill":"switchroom-status"}

--- a/tests/skill-coverage/corpus/switchroom-health.jsonl
+++ b/tests/skill-coverage/corpus/switchroom-health.jsonl
@@ -1,0 +1,19 @@
+{"id":"b7f8cab4d168ac58","targetSkill":"switchroom-health","kind":"paraphrase","phrase":"Can you something's wrong?","source":"paraphrase-template"}
+{"id":"fb1e4cccf4f28f9d","targetSkill":"switchroom-health","kind":"paraphrase","phrase":"What's wrong with my agents, please.","source":"paraphrase-template"}
+{"id":"485f1d2e84cd94ae","targetSkill":"switchroom-health","kind":"paraphrase","phrase":"Could you what's wrong with my agents for me?","source":"paraphrase-template"}
+{"id":"deda1e8dd0e019ce","targetSkill":"switchroom-health","kind":"paraphrase","phrase":"Help me can you check my setup.","source":"paraphrase-template"}
+{"id":"66b9aa06afbbd5c8","targetSkill":"switchroom-health","kind":"paraphrase","phrase":"Help me run a health check.","source":"paraphrase-template"}
+{"id":"19ae75ba03e39342","targetSkill":"switchroom-health","kind":"paraphrase","phrase":"I'd like to my agent keeps failing.","source":"paraphrase-template"}
+{"id":"d0bf37f7ec4d3c8e","targetSkill":"switchroom-health","kind":"typo","phrase":"diagnose my switchroom setup","source":"typo-rule"}
+{"id":"cebd942e715fa175","targetSkill":"switchroom-health","kind":"typo","phrase":"diagnose y switchroom setup","source":"typo-rule"}
+{"id":"e68562abdbcf0e1b","targetSkill":"switchroom-health","kind":"typo","phrase":"my agets are broken","source":"typo-rule"}
+{"id":"bb029a5a04dea3a0","targetSkill":"switchroom-health","kind":"slang","phrase":"hey, can you check my setup?","source":"slang-template"}
+{"id":"1d8c230d3f8df09e","targetSkill":"switchroom-health","kind":"slang","phrase":"hey, something's wrong?","source":"slang-template"}
+{"id":"1627e55885422bde","targetSkill":"switchroom-health","kind":"slang","phrase":"any way to run a health check?","source":"slang-template"}
+{"id":"e26f71def7db7a92","targetSkill":"switchroom-health","kind":"indirect","phrase":"things feel off","source":"indirect-template"}
+{"id":"fbe0aa9c6d9be867","targetSkill":"switchroom-health","kind":"indirect","phrase":"the fleet is sluggish","source":"indirect-template"}
+{"id":"646b3688f040a2dd","targetSkill":"switchroom-health","kind":"indirect","phrase":"my agents are acting weird","source":"indirect-template"}
+{"id":"e9e83bceac9354b0","targetSkill":null,"kind":"negative","phrase":"sync my config","source":"negative-from-adjacent","expectedOtherSkill":"switchroom-cli"}
+{"id":"804e347cfe9edb0a","targetSkill":null,"kind":"negative","phrase":"report this issue on GitHub","source":"negative-from-adjacent","expectedOtherSkill":"file-bug"}
+{"id":"842dae820114650a","targetSkill":null,"kind":"negative","phrase":"show me the logs","source":"negative-from-adjacent","expectedOtherSkill":"switchroom-cli"}
+{"id":"282e000b65a17b9a","targetSkill":null,"kind":"negative","phrase":"raise a ticket","source":"negative-from-adjacent","expectedOtherSkill":"file-bug"}

--- a/tests/skill-coverage/corpus/switchroom-install.jsonl
+++ b/tests/skill-coverage/corpus/switchroom-install.jsonl
@@ -1,0 +1,19 @@
+{"id":"d11b5f7b565a657c","targetSkill":"switchroom-install","kind":"paraphrase","phrase":"Please what are the switchroom prerequisites.","source":"paraphrase-template"}
+{"id":"cc7ee6aa5599c3b6","targetSkill":"switchroom-install","kind":"paraphrase","phrase":"I need to get switchroom running.","source":"paraphrase-template"}
+{"id":"4756d898f4bba025","targetSkill":"switchroom-install","kind":"paraphrase","phrase":"Can you bootstrap switchroom from scratch?","source":"paraphrase-template"}
+{"id":"34d19aae5bca3e47","targetSkill":"switchroom-install","kind":"paraphrase","phrase":"Help me what are the switchroom prerequisites.","source":"paraphrase-template"}
+{"id":"1f2f01f2bc3d26f6","targetSkill":"switchroom-install","kind":"paraphrase","phrase":"Can you how do I get started with switchroom?","source":"paraphrase-template"}
+{"id":"35ec2ad337fcf836","targetSkill":"switchroom-install","kind":"paraphrase","phrase":"Help me how do I get started with switchroom.","source":"paraphrase-template"}
+{"id":"f14c42038a1f5820","targetSkill":"switchroom-install","kind":"typo","phrase":"bootstrap switchrroom from scratch","source":"typo-rule"}
+{"id":"621579e9441b1c4a","targetSkill":"switchroom-install","kind":"typo","phrase":"I'm new to switchromo, where do I begin","source":"typo-rule"}
+{"id":"1b92ddebd87dcb0d","targetSkill":"switchroom-install","kind":"typo","phrase":"what are teh switchroom prerequisites","source":"typo-rule"}
+{"id":"74a19a1e59e8940f","targetSkill":"switchroom-install","kind":"slang","phrase":"gonna need to how do I get started with switchroom","source":"slang-template"}
+{"id":"2c441662d610ab7a","targetSkill":"switchroom-install","kind":"slang","phrase":"pls set up switchroom for the first time","source":"slang-template"}
+{"id":"ee0a9639cb084a68","targetSkill":"switchroom-install","kind":"slang","phrase":"quick q — can i set up switchroom for the first time","source":"slang-template"}
+{"id":"baa35d44f3fa4b9b","targetSkill":"switchroom-install","kind":"indirect","phrase":"the switchroom-install thing is weird","source":"indirect-template"}
+{"id":"da5bcbfa19534bee","targetSkill":"switchroom-install","kind":"indirect","phrase":"can you take a look at the switchroom-install situation","source":"indirect-template"}
+{"id":"1610d6ac0a23f680","targetSkill":"switchroom-install","kind":"indirect","phrase":"something is going on with switchroom-install","source":"indirect-template"}
+{"id":"5863d0584fbae4cd","targetSkill":null,"kind":"negative","phrase":"tear down this agent","source":"negative-from-adjacent","expectedOtherSkill":"switchroom-manage"}
+{"id":"e66f4ed7e3a7e8f0","targetSkill":null,"kind":"negative","phrase":"switchroom internals","source":"negative-from-adjacent","expectedOtherSkill":"switchroom-architecture"}
+{"id":"35b3358b56c3e968","targetSkill":null,"kind":"negative","phrase":"reinstall my agents","source":"negative-from-adjacent","expectedOtherSkill":"switchroom-manage"}
+{"id":"4e583f72f0342843","targetSkill":null,"kind":"negative","phrase":"switchroom design","source":"negative-from-adjacent","expectedOtherSkill":"switchroom-architecture"}

--- a/tests/skill-coverage/corpus/switchroom-manage.jsonl
+++ b/tests/skill-coverage/corpus/switchroom-manage.jsonl
@@ -1,0 +1,19 @@
+{"id":"4d738e2334447b23","targetSkill":"switchroom-manage","kind":"paraphrase","phrase":"I need to reprovision my agents.","source":"paraphrase-template"}
+{"id":"03021950a05b8eb2","targetSkill":"switchroom-manage","kind":"paraphrase","phrase":"Could you reprovision my agents for me?","source":"paraphrase-template"}
+{"id":"2fbf26091b974fd1","targetSkill":"switchroom-manage","kind":"paraphrase","phrase":"Manage my agents, please.","source":"paraphrase-template"}
+{"id":"901853b79731581a","targetSkill":"switchroom-manage","kind":"paraphrase","phrase":"Can you reinstall my agents?","source":"paraphrase-template"}
+{"id":"b08395074bcef3fe","targetSkill":"switchroom-manage","kind":"paraphrase","phrase":"I'd like to reinstall my agents.","source":"paraphrase-template"}
+{"id":"aa009cce97222e73","targetSkill":"switchroom-manage","kind":"paraphrase","phrase":"Help me list my agents.","source":"paraphrase-template"}
+{"id":"147aeda8ff8c7198","targetSkill":"switchroom-manage","kind":"typo","phrase":"create a enw agent","source":"typo-rule"}
+{"id":"ba2facfdf2b3e731","targetSkill":"switchroom-manage","kind":"typo","phrase":"reinstll my agents","source":"typo-rule"}
+{"id":"5d905da84feeda81","targetSkill":"switchroom-manage","kind":"typo","phrase":"list mya gents","source":"typo-rule"}
+{"id":"8fc8f3fac57b5331","targetSkill":"switchroom-manage","kind":"slang","phrase":"yo, how do i manage my agents","source":"slang-template"}
+{"id":"521f393dee14859b","targetSkill":"switchroom-manage","kind":"slang","phrase":"gonna need to add a new agent","source":"slang-template"}
+{"id":"55ed73ad5c5dfd1a","targetSkill":"switchroom-manage","kind":"slang","phrase":"quick q — can i add a new agent","source":"slang-template"}
+{"id":"4a6bc1cba595ad4d","targetSkill":"switchroom-manage","kind":"indirect","phrase":"the switchroom-manage thing is weird","source":"indirect-template"}
+{"id":"9d4dc98bf11d617e","targetSkill":"switchroom-manage","kind":"indirect","phrase":"can you take a look at the switchroom-manage situation","source":"indirect-template"}
+{"id":"bcc6a6e6512e2887","targetSkill":"switchroom-manage","kind":"indirect","phrase":"something is going on with switchroom-manage","source":"indirect-template"}
+{"id":"9ab6e31fce837dfc","targetSkill":null,"kind":"negative","phrase":"how do I get started with switchroom","source":"negative-from-adjacent","expectedOtherSkill":"switchroom-install"}
+{"id":"bc1b39b6bf8b8562","targetSkill":null,"kind":"negative","phrase":"per-agent snapshot","source":"negative-from-adjacent","expectedOtherSkill":"switchroom-status"}
+{"id":"894936e3d147ee65","targetSkill":null,"kind":"negative","phrase":"set up switchroom for the first time","source":"negative-from-adjacent","expectedOtherSkill":"switchroom-install"}
+{"id":"f69a2b5b8d64dc82","targetSkill":null,"kind":"negative","phrase":"bootstrap switchroom from scratch","source":"negative-from-adjacent","expectedOtherSkill":"switchroom-install"}

--- a/tests/skill-coverage/corpus/switchroom-runtime.jsonl
+++ b/tests/skill-coverage/corpus/switchroom-runtime.jsonl
@@ -1,0 +1,18 @@
+{"id":"754b1b980b3485cd","targetSkill":"switchroom-runtime","kind":"paraphrase","phrase":"Why did you restart, please.","source":"paraphrase-template"}
+{"id":"9fce03095cf54cd5","targetSkill":"switchroom-runtime","kind":"paraphrase","phrase":"I'd like to you went away.","source":"paraphrase-template"}
+{"id":"c8a42c5620b1c88a","targetSkill":"switchroom-runtime","kind":"paraphrase","phrase":"Let's can I stop you mid-turn.","source":"paraphrase-template"}
+{"id":"4898ad53526c8cc2","targetSkill":"switchroom-runtime","kind":"paraphrase","phrase":"I'd like to why did you restart.","source":"paraphrase-template"}
+{"id":"641e2b6b166d834b","targetSkill":"switchroom-runtime","kind":"paraphrase","phrase":"Can you still there??","source":"paraphrase-template"}
+{"id":"d4bafdaa3237f40a","targetSkill":"switchroom-runtime","kind":"typo","phrase":"anyupdate?","source":"typo-rule"}
+{"id":"07ff414eaad4078c","targetSkill":"switchroom-runtime","kind":"typo","phrase":"how do I interrupt you","source":"typo-rule"}
+{"id":"d40ba4fd4c1b680b","targetSkill":"switchroom-runtime","kind":"typo","phrase":"stil there?","source":"typo-rule"}
+{"id":"1491d8f17faeeba9","targetSkill":"switchroom-runtime","kind":"slang","phrase":"gonna need to still there?","source":"slang-template"}
+{"id":"03855c4e5407827a","targetSkill":"switchroom-runtime","kind":"slang","phrase":"gonna need to how do I interrupt you","source":"slang-template"}
+{"id":"12aa1d0f423ed707","targetSkill":"switchroom-runtime","kind":"slang","phrase":"gonna need to any update?","source":"slang-template"}
+{"id":"8c81765159abf8d6","targetSkill":"switchroom-runtime","kind":"indirect","phrase":"the switchroom-runtime thing is weird","source":"indirect-template"}
+{"id":"ea88817e19fa0b4b","targetSkill":"switchroom-runtime","kind":"indirect","phrase":"can you take a look at the switchroom-runtime situation","source":"indirect-template"}
+{"id":"cf5b0bcf9ee91a28","targetSkill":"switchroom-runtime","kind":"indirect","phrase":"something is going on with switchroom-runtime","source":"indirect-template"}
+{"id":"804e347cfe9edb0a","targetSkill":null,"kind":"negative","phrase":"report this issue on GitHub","source":"negative-from-adjacent","expectedOtherSkill":"file-bug"}
+{"id":"532f5db97dcb9197","targetSkill":null,"kind":"negative","phrase":"apply my config changes","source":"negative-from-adjacent","expectedOtherSkill":"switchroom-cli"}
+{"id":"19c365e9f7fe2b96","targetSkill":null,"kind":"negative","phrase":"file a bug","source":"negative-from-adjacent","expectedOtherSkill":"file-bug"}
+{"id":"beba76aa860bd8fc","targetSkill":null,"kind":"negative","phrase":"what version is running","source":"negative-from-adjacent","expectedOtherSkill":"switchroom-cli"}

--- a/tests/skill-coverage/corpus/switchroom-status.jsonl
+++ b/tests/skill-coverage/corpus/switchroom-status.jsonl
@@ -1,0 +1,19 @@
+{"id":"80e00bfd3f64a5b3","targetSkill":"switchroom-status","kind":"paraphrase","phrase":"Can you show me the fleet?","source":"paraphrase-template"}
+{"id":"56890b686ada4cf3","targetSkill":"switchroom-status","kind":"paraphrase","phrase":"Let's how long has X been up.","source":"paraphrase-template"}
+{"id":"36744fc8f2479df5","targetSkill":"switchroom-status","kind":"paraphrase","phrase":"I'd like to what's the uptime of each agent.","source":"paraphrase-template"}
+{"id":"88310367eade3159","targetSkill":"switchroom-status","kind":"paraphrase","phrase":"Let's list switchroom agents.","source":"paraphrase-template"}
+{"id":"2f84e103804b76ab","targetSkill":"switchroom-status","kind":"paraphrase","phrase":"Show me the fleet, please.","source":"paraphrase-template"}
+{"id":"ca6a45ae14c25de8","targetSkill":"switchroom-status","kind":"paraphrase","phrase":"I need to how long has X been up.","source":"paraphrase-template"}
+{"id":"2bfe0a62f9760e59","targetSkill":"switchroom-status","kind":"typo","phrase":"per-agent  snapshot","source":"typo-rule"}
+{"id":"8654f2412292ae3f","targetSkill":"switchroom-status","kind":"typo","phrase":"per-agents napshot","source":"typo-rule"}
+{"id":"f63c8b61ac6bc50c","targetSkill":"switchroom-status","kind":"typo","phrase":"list swtchroom agents","source":"typo-rule"}
+{"id":"9cece3a536e21e3b","targetSkill":"switchroom-status","kind":"slang","phrase":"any way to list switchroom agents?","source":"slang-template"}
+{"id":"6446c932cfca1ed2","targetSkill":"switchroom-status","kind":"slang","phrase":"quick q — can i show me the fleet","source":"slang-template"}
+{"id":"72a104e548746a07","targetSkill":"switchroom-status","kind":"slang","phrase":"pls per-agent snapshot","source":"slang-template"}
+{"id":"bbd1b5abad27f87d","targetSkill":"switchroom-status","kind":"indirect","phrase":"how's the fleet doing","source":"indirect-template"}
+{"id":"b2888542a177fc64","targetSkill":"switchroom-status","kind":"indirect","phrase":"what's alive right now","source":"indirect-template"}
+{"id":"e46ab87eb5ffb900","targetSkill":"switchroom-status","kind":"indirect","phrase":"is anything running right now","source":"indirect-template"}
+{"id":"842dae820114650a","targetSkill":null,"kind":"negative","phrase":"show me the logs","source":"negative-from-adjacent","expectedOtherSkill":"switchroom-cli"}
+{"id":"85ad14d64092e3ec","targetSkill":null,"kind":"negative","phrase":"run a health check","source":"negative-from-adjacent","expectedOtherSkill":"switchroom-health"}
+{"id":"beba76aa860bd8fc","targetSkill":null,"kind":"negative","phrase":"what version is running","source":"negative-from-adjacent","expectedOtherSkill":"switchroom-cli"}
+{"id":"c430593283d0aeb4","targetSkill":null,"kind":"negative","phrase":"what's wrong with my agents","source":"negative-from-adjacent","expectedOtherSkill":"switchroom-health"}

--- a/tests/skill-coverage/corpus/telegram-test-harness.jsonl
+++ b/tests/skill-coverage/corpus/telegram-test-harness.jsonl
@@ -1,0 +1,14 @@
+{"id":"c5740f7afc2968e6","targetSkill":"telegram-test-harness","kind":"paraphrase","phrase":"Let's write a telegram test.","source":"paraphrase-template"}
+{"id":"c0f02f4aaa8c7519","targetSkill":"telegram-test-harness","kind":"paraphrase","phrase":"Mock the bot api, please.","source":"paraphrase-template"}
+{"id":"3e4f60d8740c7e2e","targetSkill":"telegram-test-harness","kind":"paraphrase","phrase":"Write a telegram regression test, please.","source":"paraphrase-template"}
+{"id":"1d9f8cc253191425","targetSkill":"telegram-test-harness","kind":"paraphrase","phrase":"Test pin behavior, please.","source":"paraphrase-template"}
+{"id":"34cbc673fa0ef366","targetSkill":"telegram-test-harness","kind":"paraphrase","phrase":"Could you mock the bot api for me?","source":"paraphrase-template"}
+{"id":"27ff0718f996d2ca","targetSkill":"telegram-test-harness","kind":"typo","phrase":"mock he bot api","source":"typo-rule"}
+{"id":"10a32c79ff8c64e3","targetSkill":"telegram-test-harness","kind":"typo","phrase":"test what usesr see in chat","source":"typo-rule"}
+{"id":"d273c65897853c17","targetSkill":"telegram-test-harness","kind":"typo","phrase":"test the prgoress card","source":"typo-rule"}
+{"id":"ead15b23370073a7","targetSkill":"telegram-test-harness","kind":"slang","phrase":"hey, mock the bot api?","source":"slang-template"}
+{"id":"5557a5af836c73cc","targetSkill":"telegram-test-harness","kind":"slang","phrase":"hey, test bot interactions?","source":"slang-template"}
+{"id":"795957581edef57f","targetSkill":"telegram-test-harness","kind":"slang","phrase":"hey, test telegram?","source":"slang-template"}
+{"id":"7e214ee0a0d7004b","targetSkill":"telegram-test-harness","kind":"indirect","phrase":"something is going on with telegram-test-harness","source":"indirect-template"}
+{"id":"0922e0f1231c1bc1","targetSkill":"telegram-test-harness","kind":"indirect","phrase":"the telegram-test-harness thing is weird","source":"indirect-template"}
+{"id":"b76af9e075daafa9","targetSkill":"telegram-test-harness","kind":"indirect","phrase":"can you take a look at the telegram-test-harness situation","source":"indirect-template"}

--- a/tests/skill-coverage/corpus/types.ts
+++ b/tests/skill-coverage/corpus/types.ts
@@ -1,0 +1,56 @@
+/**
+ * Shared corpus types for the probabilistic skill-coverage harness.
+ *
+ * A `ProbeRecord` is a single natural-language utterance the harness
+ * will inject at a running agent. The `targetSkill` is the skill the
+ * authors expect to fire (or `null` for a negative control); the
+ * runner records which skills actually fired and the score module
+ * computes precision / recall / F1 per skill.
+ */
+
+export type ProbeKind =
+  | "paraphrase"
+  | "typo"
+  | "slang"
+  | "indirect"
+  | "negative";
+
+export interface ProbeRecord {
+  /** Stable hash(skill+kind+phrase+seed) — deterministic across runs. */
+  id: string;
+  /**
+   * Skill the corpus author expects to fire. `null` means this is a
+   * negative control: no skill should fire (or at least, the target
+   * should not).
+   */
+  targetSkill: string | null;
+  kind: ProbeKind;
+  phrase: string;
+  /**
+   * Optional: when this probe is a *negative for `targetSkill`* but
+   * the corpus author thinks a DIFFERENT skill might legitimately
+   * fire (cross-skill confusion test), record that skill here so the
+   * scorer can spot bleed.
+   */
+  expectedOtherSkill?: string;
+  /**
+   * For audit/debug only — which corpus rule synthesised the phrase.
+   */
+  source: "paraphrase-template" | "typo-rule" | "slang-template" | "indirect-template" | "negative-from-adjacent" | "seed-yaml";
+}
+
+export interface SkillFixture {
+  id: string;
+  category: string;
+  in_default_pool: boolean;
+  user_invocable: boolean;
+  description: string;
+  trigger_phrases: string[];
+  negatives: string[];
+  adjacent_skills: string[];
+}
+
+export interface SkillsFixtureFile {
+  $comment?: string;
+  skills: SkillFixture[];
+}

--- a/tests/skill-coverage/corpus/webapp-testing.jsonl
+++ b/tests/skill-coverage/corpus/webapp-testing.jsonl
@@ -1,0 +1,15 @@
+{"id":"02d18942126fff9a","targetSkill":"webapp-testing","kind":"paraphrase","phrase":"Please spin up a local server and test it.","source":"paraphrase-template"}
+{"id":"2210900d0f51dc48","targetSkill":"webapp-testing","kind":"paraphrase","phrase":"I'd like to run a Playwright test.","source":"paraphrase-template"}
+{"id":"9792880f2a535c4d","targetSkill":"webapp-testing","kind":"paraphrase","phrase":"Can you run a Playwright test?","source":"paraphrase-template"}
+{"id":"0bfc25f1daa4124c","targetSkill":"webapp-testing","kind":"paraphrase","phrase":"Help me view browser logs.","source":"paraphrase-template"}
+{"id":"141f05fca87c7977","targetSkill":"webapp-testing","kind":"paraphrase","phrase":"Help me spin up a local server and test it.","source":"paraphrase-template"}
+{"id":"1c65964ab71009d6","targetSkill":"webapp-testing","kind":"paraphrase","phrase":"Let's spin up a local server and test it.","source":"paraphrase-template"}
+{"id":"1fcb4fd56f8bf688","targetSkill":"webapp-testing","kind":"typo","phrase":"run a Playwwright test","source":"typo-rule"}
+{"id":"2a0b3d90c814cb6f","targetSkill":"webapp-testing","kind":"typo","phrase":"capture a browesr screenshot","source":"typo-rule"}
+{"id":"6a8af1a0582fb57e","targetSkill":"webapp-testing","kind":"typo","phrase":"test a local web app","source":"typo-rule"}
+{"id":"d2dbe893fc669ed9","targetSkill":"webapp-testing","kind":"slang","phrase":"pls capture a browser screenshot","source":"slang-template"}
+{"id":"c8667fc1113d1601","targetSkill":"webapp-testing","kind":"slang","phrase":"any way to test the frontend?","source":"slang-template"}
+{"id":"3a35357adf2842a5","targetSkill":"webapp-testing","kind":"slang","phrase":"gonna need to test a local web app","source":"slang-template"}
+{"id":"2bf9a9bba9a12336","targetSkill":"webapp-testing","kind":"indirect","phrase":"something is going on with webapp-testing","source":"indirect-template"}
+{"id":"49e43a933e5fe440","targetSkill":"webapp-testing","kind":"indirect","phrase":"the webapp-testing thing is weird","source":"indirect-template"}
+{"id":"76673fa042847e5f","targetSkill":"webapp-testing","kind":"indirect","phrase":"can you take a look at the webapp-testing situation","source":"indirect-template"}

--- a/tests/skill-coverage/corpus/xlsx.jsonl
+++ b/tests/skill-coverage/corpus/xlsx.jsonl
@@ -1,0 +1,19 @@
+{"id":"49994bfd7e52eb43","targetSkill":"xlsx","kind":"paraphrase","phrase":"I'd like to edit a spreadsheet.","source":"paraphrase-template"}
+{"id":"d882f4dfd96c6c20","targetSkill":"xlsx","kind":"paraphrase","phrase":"Help me create a spreadsheet from scratch.","source":"paraphrase-template"}
+{"id":"9fd4947b9ba7860f","targetSkill":"xlsx","kind":"paraphrase","phrase":"Let's build a financial model.","source":"paraphrase-template"}
+{"id":"87cab2eca0c166fa","targetSkill":"xlsx","kind":"paraphrase","phrase":"Fix malformed rows in this CSV, please.","source":"paraphrase-template"}
+{"id":"e3c386da78976895","targetSkill":"xlsx","kind":"paraphrase","phrase":"Open this xlsx, please.","source":"paraphrase-template"}
+{"id":"3e1753cbdf1e2f61","targetSkill":"xlsx","kind":"paraphrase","phrase":"Compute formulas in Excel, please.","source":"paraphrase-template"}
+{"id":"3d4e17fe8d0df1df","targetSkill":"xlsx","kind":"typo","phrase":"build a finnacial model","source":"typo-rule"}
+{"id":"a4e446d02afb040a","targetSkill":"xlsx","kind":"typo","phrase":"fix malfored rows in this CSV","source":"typo-rule"}
+{"id":"3778dfa96cd6c0cf","targetSkill":"xlsx","kind":"typo","phrase":"compute ormulas in Excel","source":"typo-rule"}
+{"id":"8afa57f9089aeff3","targetSkill":"xlsx","kind":"slang","phrase":"any way to fix malformed rows in this CSV?","source":"slang-template"}
+{"id":"b5276e28c63d1f84","targetSkill":"xlsx","kind":"slang","phrase":"pls convert CSV to xlsx","source":"slang-template"}
+{"id":"360ca4c4558b3be5","targetSkill":"xlsx","kind":"slang","phrase":"pls add columns to a CSV","source":"slang-template"}
+{"id":"ff7194311ef3118c","targetSkill":"xlsx","kind":"indirect","phrase":"this csv is a mess","source":"indirect-template"}
+{"id":"42771013c0b4680d","targetSkill":"xlsx","kind":"indirect","phrase":"the columns are all wrong in this sheet","source":"indirect-template"}
+{"id":"2f30a989da635cc1","targetSkill":"xlsx","kind":"indirect","phrase":"I need to crunch some numbers in a sheet","source":"indirect-template"}
+{"id":"a113419f817d8314","targetSkill":null,"kind":"negative","phrase":"produce a report as a Word file","source":"negative-from-adjacent","expectedOtherSkill":"docx"}
+{"id":"9aa3b919eee8c702","targetSkill":null,"kind":"negative","phrase":"extract tables from a PDF","source":"negative-from-adjacent","expectedOtherSkill":"pdf"}
+{"id":"9ead93293a462adb","targetSkill":null,"kind":"negative","phrase":"accept tracked changes","source":"negative-from-adjacent","expectedOtherSkill":"docx"}
+{"id":"21ecaa887914ad6a","targetSkill":null,"kind":"negative","phrase":"rotate PDF pages","source":"negative-from-adjacent","expectedOtherSkill":"pdf"}

--- a/tests/skill-coverage/fixtures/skills.json
+++ b/tests/skill-coverage/fixtures/skills.json
@@ -1,0 +1,583 @@
+{
+  "$comment": "Generated from docs/skill-coverage/inventory.md. user_invocable=false skills are kept in the file but flagged out via in_default_pool. trigger_phrases are NL utterances suitable for the corpus generator; negatives are explicit do-not-use clauses.",
+  "skills": [
+    {
+      "id": "buildkite-agent-infrastructure",
+      "category": "buildkite",
+      "in_default_pool": true,
+      "user_invocable": true,
+      "description": "Provision and govern Buildkite clusters, queues, hosted agents, secrets, tokens, SSO, audit, cost.",
+      "trigger_phrases": [
+        "create a cluster",
+        "create a queue",
+        "set up hosted agents",
+        "configure agents",
+        "right-size instance shapes",
+        "scale queues",
+        "manage cluster secrets",
+        "create a pipeline template",
+        "set up audit logging",
+        "configure SSO",
+        "set up SAML",
+        "manage agent tokens",
+        "optimize CI costs",
+        "standardize pipelines across teams"
+      ],
+      "negatives": [],
+      "adjacent_skills": ["buildkite-cli", "buildkite-pipelines", "buildkite-api"]
+    },
+    {
+      "id": "buildkite-agent-runtime",
+      "category": "buildkite",
+      "in_default_pool": true,
+      "user_invocable": true,
+      "description": "buildkite-agent subcommands run inside a job step.",
+      "trigger_phrases": [
+        "add an annotation",
+        "upload artifacts from a step",
+        "share data between steps",
+        "upload pipeline dynamically",
+        "request an OIDC token inside a step",
+        "acquire a distributed lock",
+        "get or update a step attribute",
+        "redact a secret from logs",
+        "retrieve a cluster secret at runtime",
+        "debug environment variables in hooks"
+      ],
+      "negatives": [],
+      "adjacent_skills": ["buildkite-pipelines", "buildkite-cli", "buildkite-secure-delivery"]
+    },
+    {
+      "id": "buildkite-api",
+      "category": "buildkite",
+      "in_default_pool": true,
+      "user_invocable": true,
+      "description": "REST + GraphQL + webhooks for programmatic Buildkite automation.",
+      "trigger_phrases": [
+        "call the Buildkite API",
+        "use the REST API",
+        "write a GraphQL query",
+        "set up webhooks",
+        "automate Buildkite",
+        "integrate with Buildkite programmatically",
+        "write a script that calls Buildkite",
+        "handle webhook events",
+        "paginate API results",
+        "authenticate with the Buildkite API"
+      ],
+      "negatives": [],
+      "adjacent_skills": ["buildkite-cli", "buildkite-agent-infrastructure"]
+    },
+    {
+      "id": "buildkite-cli",
+      "category": "buildkite",
+      "in_default_pool": true,
+      "user_invocable": true,
+      "description": "Terminal bk CLI — builds, jobs, pipelines, secrets, artifacts, clusters, packages.",
+      "trigger_phrases": [
+        "trigger a build",
+        "check build status",
+        "watch a build",
+        "view build logs",
+        "retry a build",
+        "cancel a build",
+        "list builds",
+        "download artifacts",
+        "upload artifacts",
+        "manage secrets",
+        "create a pipeline",
+        "list pipelines",
+        "interact with Buildkite from the command line"
+      ],
+      "negatives": [],
+      "adjacent_skills": ["buildkite-pipelines", "buildkite-api", "buildkite-agent-infrastructure"]
+    },
+    {
+      "id": "buildkite-migration",
+      "category": "buildkite",
+      "in_default_pool": true,
+      "user_invocable": true,
+      "description": "Convert pipelines from GitHub Actions / Jenkins / CircleCI / Bitbucket / GitLab to Buildkite YAML.",
+      "trigger_phrases": [
+        "migrate to Buildkite",
+        "convert pipelines from Jenkins",
+        "convert GitHub Actions workflows",
+        "convert CircleCI config",
+        "convert Bitbucket Pipelines",
+        "convert GitLab CI",
+        "switch from Jenkins to Buildkite",
+        "plan a CI migration",
+        "convert my CI config",
+        "bk pipeline convert",
+        "what's the Buildkite equivalent of"
+      ],
+      "negatives": [],
+      "adjacent_skills": ["buildkite-cli", "buildkite-pipelines"]
+    },
+    {
+      "id": "buildkite-pipelines",
+      "category": "buildkite",
+      "in_default_pool": true,
+      "user_invocable": true,
+      "description": "Author .buildkite/pipeline.yml — step types, caching, parallelism, retries, dynamic pipelines, matrix, plugins.",
+      "trigger_phrases": [
+        "write a pipeline",
+        "add caching",
+        "make this build faster",
+        "show test failures in the build page",
+        "add annotations",
+        "only run tests when code changes",
+        "set up dynamic pipelines",
+        "add retry",
+        "parallel steps",
+        "matrix build",
+        "add plugins",
+        "work with artifacts in pipeline YAML"
+      ],
+      "negatives": [],
+      "adjacent_skills": ["buildkite-agent-runtime", "buildkite-cli", "buildkite-test-engine"]
+    },
+    {
+      "id": "buildkite-secure-delivery",
+      "category": "buildkite",
+      "in_default_pool": true,
+      "user_invocable": true,
+      "description": "OIDC, SLSA provenance, Package Registry publishing, JWKS pipeline signing.",
+      "trigger_phrases": [
+        "publish to package registry",
+        "push a Docker image",
+        "set up OIDC authentication",
+        "request an OIDC token",
+        "authenticate without static credentials",
+        "set up SLSA provenance",
+        "generate attestation",
+        "sign pipelines",
+        "verify pipeline signatures",
+        "secure the supply chain"
+      ],
+      "negatives": [],
+      "adjacent_skills": ["buildkite-agent-runtime", "buildkite-pipelines"]
+    },
+    {
+      "id": "buildkite-test-engine",
+      "category": "buildkite",
+      "in_default_pool": true,
+      "user_invocable": true,
+      "description": "bktec test splitting, flaky-test detection, collectors, quarantine.",
+      "trigger_phrases": [
+        "split tests across machines",
+        "set up test splitting",
+        "parallelize test suite",
+        "detect flaky tests",
+        "quarantine flaky tests",
+        "configure test collectors",
+        "speed up tests",
+        "set up bktec",
+        "configure test engine",
+        "reduce flaky test failures"
+      ],
+      "negatives": [],
+      "adjacent_skills": ["buildkite-pipelines"]
+    },
+    {
+      "id": "docx",
+      "category": "document-format",
+      "in_default_pool": true,
+      "user_invocable": true,
+      "description": "Create, read, edit .docx Word documents.",
+      "trigger_phrases": [
+        "create a Word document",
+        "edit a Word doc",
+        "read a .docx file",
+        "produce a report as a Word file",
+        "draft a memo",
+        "write a letter as a Word doc",
+        "add a table of contents",
+        "insert page numbers",
+        "add a letterhead",
+        "accept tracked changes",
+        "leave comments on a Word doc"
+      ],
+      "negatives": [
+        "PDF files",
+        "spreadsheets",
+        "Google Docs",
+        "general coding tasks"
+      ],
+      "adjacent_skills": ["pdf", "xlsx", "pptx"]
+    },
+    {
+      "id": "file-bug",
+      "category": "switchroom-internal",
+      "in_default_pool": true,
+      "user_invocable": true,
+      "description": "File a high-quality bug report against switchroom via gh issue create.",
+      "trigger_phrases": [
+        "file a bug",
+        "open an issue",
+        "raise a ticket",
+        "log this as a bug",
+        "this needs a real ticket",
+        "report this issue on GitHub"
+      ],
+      "negatives": [
+        "thin descriptions",
+        "mid-debugging speculative tickets"
+      ],
+      "adjacent_skills": ["switchroom-health", "switchroom-cli"]
+    },
+    {
+      "id": "humanizer",
+      "category": "generic-meta",
+      "in_default_pool": true,
+      "user_invocable": true,
+      "description": "Remove signs of AI-generated writing from text.",
+      "trigger_phrases": [
+        "make this sound more human",
+        "remove signs of AI writing",
+        "edit this so it doesn't sound like AI",
+        "rewrite this to sound natural",
+        "de-AI this paragraph",
+        "review this text for AI tells",
+        "fix the em-dash overuse",
+        "remove the rule of three"
+      ],
+      "negatives": [],
+      "adjacent_skills": ["humanizer-calibrate"]
+    },
+    {
+      "id": "humanizer-calibrate",
+      "category": "humanizer/calibrate",
+      "in_default_pool": true,
+      "user_invocable": true,
+      "description": "Build a personal voice template for humanizer from recent Telegram messages.",
+      "trigger_phrases": [
+        "make humanizer sound more like me",
+        "calibrate humanizer",
+        "build a voice template",
+        "fresh voice template for humanizer",
+        "humanizer-calibrate"
+      ],
+      "negatives": [],
+      "adjacent_skills": ["humanizer"]
+    },
+    {
+      "id": "mcp-builder",
+      "category": "mcp-builder",
+      "in_default_pool": true,
+      "user_invocable": true,
+      "description": "Guide for creating MCP servers (FastMCP / TS SDK).",
+      "trigger_phrases": [
+        "build an MCP server",
+        "create a new MCP server",
+        "integrate an external API as MCP",
+        "wrap this API as MCP tools",
+        "scaffold a FastMCP project",
+        "use the MCP SDK in TypeScript",
+        "write an MCP server for"
+      ],
+      "negatives": [],
+      "adjacent_skills": ["skill-creator"]
+    },
+    {
+      "id": "pdf",
+      "category": "document-format",
+      "in_default_pool": true,
+      "user_invocable": true,
+      "description": "Read, edit, merge, split, OCR, fill, encrypt .pdf files.",
+      "trigger_phrases": [
+        "extract text from a PDF",
+        "extract tables from a PDF",
+        "merge PDFs",
+        "split a PDF",
+        "rotate PDF pages",
+        "watermark a PDF",
+        "fill a PDF form",
+        "encrypt this PDF",
+        "OCR a scanned PDF",
+        "create a PDF from scratch"
+      ],
+      "negatives": [],
+      "adjacent_skills": ["docx", "xlsx"]
+    },
+    {
+      "id": "pptx",
+      "category": "document-format",
+      "in_default_pool": true,
+      "user_invocable": true,
+      "description": "Create / read / edit .pptx slide decks.",
+      "trigger_phrases": [
+        "create a slide deck",
+        "build a pitch deck",
+        "edit this presentation",
+        "extract text from a pptx",
+        "update the speaker notes",
+        "combine slide files",
+        "split this deck",
+        "work from a slide template"
+      ],
+      "negatives": [],
+      "adjacent_skills": ["docx", "pdf"]
+    },
+    {
+      "id": "skill-creator",
+      "category": "generic-meta",
+      "in_default_pool": true,
+      "user_invocable": true,
+      "description": "Create, edit, optimize, and benchmark skills.",
+      "trigger_phrases": [
+        "create a new skill",
+        "edit an existing skill",
+        "optimize a skill description",
+        "benchmark this skill",
+        "run evals on a skill",
+        "improve the trigger accuracy of a skill"
+      ],
+      "negatives": [],
+      "adjacent_skills": ["mcp-builder"]
+    },
+    {
+      "id": "switchroom-architecture",
+      "category": "switchroom-internal",
+      "in_default_pool": false,
+      "user_invocable": false,
+      "description": "Internal architecture of switchroom — cascade, profiles, lifecycle, plugin system.",
+      "trigger_phrases": [
+        "how does switchroom work internally",
+        "how does the cascade decide",
+        "which settings apply",
+        "switchroom architecture",
+        "switchroom design",
+        "switchroom internals"
+      ],
+      "negatives": [
+        "onboarding",
+        "getting started",
+        "bootstrap from scratch"
+      ],
+      "adjacent_skills": ["switchroom-install", "switchroom-cli"]
+    },
+    {
+      "id": "switchroom-cli",
+      "category": "switchroom-internal",
+      "in_default_pool": true,
+      "user_invocable": true,
+      "description": "switchroom CLI operations on existing agents — logs, update, restart, version, config, scheduled tasks, plugin reference.",
+      "trigger_phrases": [
+        "show me the logs",
+        "what happened to this agent",
+        "check the journal",
+        "why did it crash",
+        "update the agents",
+        "pull latest",
+        "upgrade switchroom",
+        "restart the agent",
+        "reboot this agent",
+        "bounce the agent",
+        "kick the agent, it's stuck",
+        "what version is running",
+        "what sha am I on",
+        "apply my config changes",
+        "sync my config",
+        "I just edited switchroom.yaml",
+        "what model is X using",
+        "show the cascade for X",
+        "list scheduled tasks",
+        "what cron jobs do I have"
+      ],
+      "negatives": [
+        "add or remove agents",
+        "bootstrap switchroom on a fresh machine",
+        "something is broken diagnostics"
+      ],
+      "adjacent_skills": ["switchroom-health", "switchroom-manage", "switchroom-install", "switchroom-status"]
+    },
+    {
+      "id": "switchroom-health",
+      "category": "switchroom-internal",
+      "in_default_pool": true,
+      "user_invocable": true,
+      "description": "Health-check / diagnostic sweep.",
+      "trigger_phrases": [
+        "my agent keeps failing",
+        "my agents are broken",
+        "what's wrong with my agents",
+        "agent keeps crashing",
+        "run a health check",
+        "diagnose my switchroom setup",
+        "troubleshoot the fleet",
+        "something's wrong",
+        "can you check my setup"
+      ],
+      "negatives": [
+        "specific crash logs (use switchroom-cli)"
+      ],
+      "adjacent_skills": ["switchroom-cli", "file-bug"]
+    },
+    {
+      "id": "switchroom-install",
+      "category": "switchroom-internal",
+      "in_default_pool": true,
+      "user_invocable": true,
+      "description": "First-time bootstrap of switchroom + dependencies on a fresh machine.",
+      "trigger_phrases": [
+        "install switchroom on this machine",
+        "set up switchroom for the first time",
+        "bootstrap switchroom from scratch",
+        "get switchroom running",
+        "how do I get started with switchroom",
+        "I'm new to switchroom, where do I begin",
+        "what are the switchroom prerequisites"
+      ],
+      "negatives": [
+        "managing existing agents"
+      ],
+      "adjacent_skills": ["switchroom-manage", "switchroom-architecture"]
+    },
+    {
+      "id": "switchroom-manage",
+      "category": "switchroom-internal",
+      "in_default_pool": true,
+      "user_invocable": true,
+      "description": "Add / remove / reinstall / list agents (fleet-level).",
+      "trigger_phrases": [
+        "add a new agent",
+        "create a new agent",
+        "remove an agent",
+        "reinstall my agents",
+        "reprovision my agents",
+        "list my agents",
+        "manage my agents",
+        "tear down this agent"
+      ],
+      "negatives": [
+        "bootstrap switchroom itself (use switchroom-install)"
+      ],
+      "adjacent_skills": ["switchroom-install", "switchroom-status"]
+    },
+    {
+      "id": "switchroom-runtime",
+      "category": "switchroom-internal",
+      "in_default_pool": true,
+      "user_invocable": true,
+      "description": "Conditional runtime protocols (interrupted-turn resume, wake audit, why did you restart, ! interrupt).",
+      "trigger_phrases": [
+        "why did you restart",
+        "did you crash",
+        "you went away",
+        "how do I interrupt you",
+        "can I stop you mid-turn",
+        "how do I cancel",
+        "status?",
+        "still there?",
+        "any update?"
+      ],
+      "negatives": [
+        "normal Telegram conversation",
+        "formatting questions",
+        "voice/sticker behavior",
+        "MCP tool questions",
+        "persona / Execution-Bias rules"
+      ],
+      "adjacent_skills": ["file-bug", "switchroom-cli"]
+    },
+    {
+      "id": "switchroom-status",
+      "category": "switchroom-internal",
+      "in_default_pool": true,
+      "user_invocable": true,
+      "description": "switchroom agent list — running agents, uptime, model, state.",
+      "trigger_phrases": [
+        "what agents are running",
+        "list switchroom agents",
+        "how long has X been up",
+        "per-agent snapshot",
+        "show me the fleet",
+        "what's the uptime of each agent"
+      ],
+      "negatives": [
+        "version/health summary (use switchroom-cli)",
+        "something is broken (use switchroom-health)"
+      ],
+      "adjacent_skills": ["switchroom-cli", "switchroom-health"]
+    },
+    {
+      "id": "telegram-test-harness",
+      "category": "telegram-test",
+      "in_default_pool": true,
+      "user_invocable": true,
+      "description": "Deterministic Bot-API mock harness for switchroom Telegram tests.",
+      "trigger_phrases": [
+        "test telegram",
+        "test bot interactions",
+        "mock the bot api",
+        "write a telegram test",
+        "test what users see in chat",
+        "test the progress card",
+        "test the slot banner",
+        "test soft-confirm",
+        "test auto-fallback notification",
+        "test pin behavior",
+        "write a telegram regression test"
+      ],
+      "negatives": [],
+      "adjacent_skills": []
+    },
+    {
+      "id": "token-helpers",
+      "category": "switchroom-internal",
+      "in_default_pool": false,
+      "user_invocable": false,
+      "description": "Library skill — refresh Google Calendar / MS Graph OAuth tokens from the vault.",
+      "trigger_phrases": [],
+      "negatives": [
+        "not directly invoked by the user"
+      ],
+      "adjacent_skills": []
+    },
+    {
+      "id": "webapp-testing",
+      "category": "generic-meta",
+      "in_default_pool": true,
+      "user_invocable": true,
+      "description": "Playwright-based local webapp testing.",
+      "trigger_phrases": [
+        "test a local web app",
+        "test the frontend",
+        "debug UI behavior",
+        "capture a browser screenshot",
+        "view browser logs",
+        "run a Playwright test",
+        "spin up a local server and test it"
+      ],
+      "negatives": [],
+      "adjacent_skills": []
+    },
+    {
+      "id": "xlsx",
+      "category": "document-format",
+      "in_default_pool": true,
+      "user_invocable": true,
+      "description": "Create / read / edit .xlsx, .csv, .tsv spreadsheets.",
+      "trigger_phrases": [
+        "open this xlsx",
+        "edit a spreadsheet",
+        "add columns to a CSV",
+        "compute formulas in Excel",
+        "clean up messy tabular data",
+        "create a spreadsheet from scratch",
+        "fix malformed rows in this CSV",
+        "convert CSV to xlsx",
+        "build a financial model"
+      ],
+      "negatives": [
+        "Word documents",
+        "HTML reports",
+        "standalone Python scripts",
+        "database pipelines",
+        "Google Sheets API"
+      ],
+      "adjacent_skills": ["docx", "pdf"]
+    }
+  ]
+}

--- a/tests/skill-coverage/harness/inject.ts
+++ b/tests/skill-coverage/harness/inject.ts
@@ -1,0 +1,165 @@
+/**
+ * NDJSON `inject_inbound` writer for the harness runner.
+ *
+ * Mirrors `src/agent-scheduler/ipc-client.ts` — the same socket
+ * protocol the in-agent scheduler uses to inject synthesized turns
+ * into the gateway. We don't need reconnect/replay semantics here
+ * because the harness is short-lived; on the first connect failure
+ * we just bail and let the runner report the probe as `timedOut`.
+ */
+
+import { createConnection, type Socket } from "node:net";
+import type {
+  InboundMessage,
+  InjectInboundMessage,
+} from "../../../telegram-plugin/gateway/ipc-protocol.js";
+
+export interface InjectOptions {
+  socketPath: string;
+  agentName: string;
+  text: string;
+  /** Telegram chat id to claim — defaults to a deterministic harness id. */
+  chatId?: string;
+  /** Useful when the harness wants to thread its probes per skill. */
+  threadId?: number;
+  /** Defaults to 5000ms. */
+  connectTimeoutMs?: number;
+  /**
+   * Test seam — fakes pass an alternative connect to avoid touching
+   * the kernel socket layer in unit tests.
+   */
+  _connect?: (socketPath: string) => Socket;
+}
+
+export interface InjectOutcome {
+  injectedAt: string;
+  inboundId: string;
+  /** True if the bytes were accepted by the local socket. */
+  written: boolean;
+  /** Set only on failure paths. */
+  error?: string;
+}
+
+/**
+ * Connect to the gateway socket, write a single `inject_inbound`
+ * envelope, and end the connection. Returns once the OS has accepted
+ * the bytes — the runner's observe loop is what actually proves the
+ * turn ran.
+ */
+export function injectInbound(opts: InjectOptions): Promise<InjectOutcome> {
+  const {
+    socketPath,
+    agentName,
+    text,
+    chatId = "-1001000000000",
+    threadId,
+    connectTimeoutMs = 5_000,
+    _connect = (p) => createConnection(p),
+  } = opts;
+
+  const injectedAt = new Date().toISOString();
+  // Deterministic-ish ids: timestamp + agent + 6 random hex chars. The
+  // runner doesn't depend on uniqueness across runs; gateway just wants
+  // *some* message_id and ts. We use a randomised tail rather than a
+  // counter to keep this stateless.
+  const messageId = Math.floor(Date.now() & 0x7fffffff);
+  const ts = Date.now();
+  const inbound: InboundMessage = {
+    type: "inbound",
+    chatId,
+    threadId,
+    messageId,
+    user: "skill-coverage-harness",
+    userId: 0,
+    ts,
+    text,
+    meta: {
+      source: "skill-coverage-harness",
+      injectedAt,
+    },
+  };
+  const envelope: InjectInboundMessage = {
+    type: "inject_inbound",
+    agentName,
+    inbound,
+  };
+
+  return new Promise<InjectOutcome>((resolve) => {
+    let settled = false;
+    let socket: Socket;
+    try {
+      socket = _connect(socketPath);
+    } catch (err) {
+      resolve({
+        injectedAt,
+        inboundId: String(messageId),
+        written: false,
+        error: (err as Error).message,
+      });
+      return;
+    }
+
+    const timeout = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      try { socket.destroy(); } catch { /* ignore */ }
+      resolve({
+        injectedAt,
+        inboundId: String(messageId),
+        written: false,
+        error: `connect timeout after ${connectTimeoutMs}ms`,
+      });
+    }, connectTimeoutMs);
+
+    socket.on("connect", () => {
+      try {
+        const ok = socket.write(JSON.stringify(envelope) + "\n", (err) => {
+          if (settled) return;
+          settled = true;
+          clearTimeout(timeout);
+          try { socket.end(); } catch { /* ignore */ }
+          if (err) {
+            resolve({
+              injectedAt,
+              inboundId: String(messageId),
+              written: false,
+              error: err.message,
+            });
+          } else {
+            resolve({
+              injectedAt,
+              inboundId: String(messageId),
+              written: true,
+            });
+          }
+        });
+        if (!ok) {
+          // Backpressure — fall through, the write callback above will
+          // resolve us when drain completes.
+        }
+      } catch (err) {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timeout);
+        resolve({
+          injectedAt,
+          inboundId: String(messageId),
+          written: false,
+          error: (err as Error).message,
+        });
+      }
+    });
+
+    socket.on("error", (err) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      resolve({
+        injectedAt,
+        inboundId: String(messageId),
+        written: false,
+        error: err.message,
+      });
+    });
+  });
+}

--- a/tests/skill-coverage/harness/inject.ts
+++ b/tests/skill-coverage/harness/inject.ts
@@ -14,6 +14,12 @@ import type {
   InjectInboundMessage,
 } from "../../../telegram-plugin/gateway/ipc-protocol.js";
 
+let _injectCounter = 0;
+function injectCounter(): number {
+  _injectCounter = (_injectCounter + 1) & 0xffff;
+  return _injectCounter;
+}
+
 export interface InjectOptions {
   socketPath: string;
   agentName: string;
@@ -58,12 +64,11 @@ export function injectInbound(opts: InjectOptions): Promise<InjectOutcome> {
   } = opts;
 
   const injectedAt = new Date().toISOString();
-  // Deterministic-ish ids: timestamp + agent + 6 random hex chars. The
-  // runner doesn't depend on uniqueness across runs; gateway just wants
-  // *some* message_id and ts. We use a randomised tail rather than a
-  // counter to keep this stateless.
-  const messageId = Math.floor(Date.now() & 0x7fffffff);
+  // messageId: ms timestamp + 16-bit process-local counter, masked to a
+  // positive int32. Two probes inside the same ms get distinct ids
+  // (gateway treats duplicates as replays).
   const ts = Date.now();
+  const messageId = ((ts & 0x7fff) << 16) | (injectCounter() & 0xffff);
   const inbound: InboundMessage = {
     type: "inbound",
     chatId,

--- a/tests/skill-coverage/harness/observe.ts
+++ b/tests/skill-coverage/harness/observe.ts
@@ -1,0 +1,146 @@
+/**
+ * Tail an agent's active session JSONL and surface `SessionEvent`s as
+ * an async iterator scoped to a single turn.
+ *
+ * Reuses `startSessionTail` from telegram-plugin/session-tail.ts —
+ * that module already handles the cwd-sanitized projects-dir lookup,
+ * incremental file reads, and rotation across sub-agent JSONLs. The
+ * harness just needs:
+ *
+ *  1. start tailing,
+ *  2. inject a probe,
+ *  3. iterate events until `turn_end` (or timeout),
+ *  4. extract Skill tool-uses + their `input.skill` field.
+ */
+
+import {
+  startSessionTail,
+  type SessionEvent,
+} from "../../../telegram-plugin/session-tail.js";
+
+export interface ObserveTurnOptions {
+  /** Agent working directory (cwd) — feeds session-tail's project lookup. */
+  cwd: string;
+  /** Override CLAUDE_CONFIG_DIR; default: env or ~/.claude. */
+  claudeHome?: string;
+  /** Max wall-clock to wait for `turn_end`. Default 120_000 ms. */
+  timeoutMs?: number;
+  /** Optional logger. */
+  log?: (msg: string) => void;
+}
+
+export interface TurnObservation {
+  events: SessionEvent[];
+  timedOut: boolean;
+  durationMs: number;
+}
+
+/**
+ * Run a single turn observation. Returns once we've seen `turn_end`
+ * OR the timeout elapses. Caller is responsible for calling
+ * `inject` once `start()` returns.
+ *
+ * Usage:
+ *   const obs = createTurnObserver({ cwd, timeoutMs: 30_000 });
+ *   await obs.start();        // tail attached
+ *   await injectInbound(...);
+ *   const result = await obs.waitForTurnEnd();
+ *   obs.stop();
+ */
+export interface TurnObserver {
+  start(): Promise<void>;
+  waitForTurnEnd(): Promise<TurnObservation>;
+  stop(): void;
+}
+
+export function createTurnObserver(opts: ObserveTurnOptions): TurnObserver {
+  const { cwd, claudeHome, timeoutMs = 120_000, log } = opts;
+  const events: SessionEvent[] = [];
+  let tail: ReturnType<typeof startSessionTail> | null = null;
+  let resolveTurnEnd: ((obs: TurnObservation) => void) | null = null;
+  let timeoutTimer: ReturnType<typeof setTimeout> | null = null;
+  let startedAt = 0;
+  let sawTurnEnd = false;
+
+  return {
+    async start(): Promise<void> {
+      startedAt = Date.now();
+      tail = startSessionTail({
+        cwd,
+        claudeHome,
+        log,
+        onEvent: (ev) => {
+          events.push(ev);
+          if (ev.kind === "turn_end") {
+            sawTurnEnd = true;
+            if (resolveTurnEnd) {
+              const r = resolveTurnEnd;
+              resolveTurnEnd = null;
+              if (timeoutTimer) {
+                clearTimeout(timeoutTimer);
+                timeoutTimer = null;
+              }
+              r({
+                events: events.slice(),
+                timedOut: false,
+                durationMs: Date.now() - startedAt,
+              });
+            }
+          }
+        },
+      });
+    },
+    waitForTurnEnd(): Promise<TurnObservation> {
+      if (sawTurnEnd) {
+        return Promise.resolve({
+          events: events.slice(),
+          timedOut: false,
+          durationMs: Date.now() - startedAt,
+        });
+      }
+      return new Promise<TurnObservation>((resolve) => {
+        resolveTurnEnd = resolve;
+        timeoutTimer = setTimeout(() => {
+          resolveTurnEnd = null;
+          timeoutTimer = null;
+          resolve({
+            events: events.slice(),
+            timedOut: true,
+            durationMs: Date.now() - startedAt,
+          });
+        }, timeoutMs);
+      });
+    },
+    stop(): void {
+      if (timeoutTimer) {
+        clearTimeout(timeoutTimer);
+        timeoutTimer = null;
+      }
+      if (tail) {
+        try { tail.stop(); } catch { /* ignore */ }
+        tail = null;
+      }
+    },
+  };
+}
+
+/**
+ * Extract the list of skills invoked during a turn. The
+ * telegram-plugin tool-label code documents `input.skill` as the
+ * canonical field for Skill-tool invocations (see
+ * `telegram-plugin/tool-labels.ts:247`). We honour that contract
+ * here — falling through to the empty list if the field is absent.
+ */
+export function extractSkillsInvoked(events: SessionEvent[]): string[] {
+  const skills: string[] = [];
+  for (const ev of events) {
+    if (ev.kind !== "tool_use") continue;
+    if (ev.toolName !== "Skill") continue;
+    const input = ev.input as Record<string, unknown> | undefined;
+    const skill = input?.skill;
+    if (typeof skill === "string" && skill.length > 0) {
+      skills.push(skill);
+    }
+  }
+  return skills;
+}

--- a/tests/skill-coverage/harness/runner.ts
+++ b/tests/skill-coverage/harness/runner.ts
@@ -1,0 +1,154 @@
+/**
+ * Probe-runner main loop.
+ *
+ *   for each probe:
+ *     attach session-tail
+ *     inject_inbound the phrase
+ *     wait for turn_end (or timeout)
+ *     extract skills invoked
+ *     record result
+ *
+ * The loop is sequential by design — running probes in parallel
+ * against the same agent would tangle session-tail (the agent only
+ * has one active session JSONL at a time). Multi-agent fan-out is
+ * possible later: one runner per agent, each binding its own
+ * gateway socket.
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import type { ProbeRecord } from "../corpus/types.js";
+import { injectInbound, type InjectOptions } from "./inject.js";
+import {
+  createTurnObserver,
+  extractSkillsInvoked,
+  type ObserveTurnOptions,
+} from "./observe.js";
+import type { ProbeResult, RunRecord } from "./types.js";
+
+export interface RunnerOptions {
+  agentName: string;
+  /** Gateway socket path; default `${TELEGRAM_STATE_DIR}/gateway.sock` if set. */
+  gatewaySocket?: string;
+  /** Agent cwd — fed to session-tail. */
+  agentCwd: string;
+  /** Override CLAUDE_CONFIG_DIR. */
+  claudeHome?: string;
+  /** Per-probe timeout. Default 120s. */
+  turnTimeoutMs?: number;
+  /** Keep raw events in the ProbeResult for debug. Default false. */
+  debugRawEvents?: boolean;
+  /** Optional logger. */
+  log?: (msg: string) => void;
+  /** Test seam — replace inject. */
+  _inject?: typeof injectInbound;
+  /** Test seam — replace observer factory. */
+  _createObserver?: typeof createTurnObserver;
+}
+
+/** Load a probe JSONL file. */
+export function loadProbesJsonl(path: string): ProbeRecord[] {
+  if (!existsSync(path)) return [];
+  const raw = readFileSync(path, "utf-8");
+  return raw
+    .split("\n")
+    .map((l) => l.trim())
+    .filter(Boolean)
+    .map((l) => JSON.parse(l) as ProbeRecord);
+}
+
+/** Load every `<skill>.jsonl` file under `corpusDir`. */
+export function loadCorpus(corpusDir: string, onlySkills?: string[]): ProbeRecord[] {
+  if (!existsSync(corpusDir)) return [];
+  const { readdirSync } = require("node:fs") as typeof import("node:fs");
+  const entries = readdirSync(corpusDir);
+  const probes: ProbeRecord[] = [];
+  for (const e of entries) {
+    if (!e.endsWith(".jsonl")) continue;
+    const skill = e.slice(0, -".jsonl".length);
+    if (onlySkills && onlySkills.length > 0 && !onlySkills.includes(skill)) continue;
+    probes.push(...loadProbesJsonl(join(corpusDir, e)));
+  }
+  return probes;
+}
+
+export async function runProbe(
+  probe: ProbeRecord,
+  opts: RunnerOptions,
+): Promise<ProbeResult> {
+  const gatewaySocket =
+    opts.gatewaySocket ??
+    (process.env.SWITCHROOM_GATEWAY_SOCKET ||
+      (process.env.TELEGRAM_STATE_DIR
+        ? join(process.env.TELEGRAM_STATE_DIR, "gateway.sock")
+        : ""));
+  if (!gatewaySocket) {
+    throw new Error(
+      "runner: gateway socket not configured — set --gateway-socket or SWITCHROOM_GATEWAY_SOCKET",
+    );
+  }
+
+  const observerFactory = opts._createObserver ?? createTurnObserver;
+  const injectFn = opts._inject ?? injectInbound;
+
+  const observer = observerFactory({
+    cwd: opts.agentCwd,
+    claudeHome: opts.claudeHome,
+    timeoutMs: opts.turnTimeoutMs ?? 120_000,
+    log: opts.log,
+  } satisfies ObserveTurnOptions);
+
+  await observer.start();
+  // Small priming delay isn't required — startSessionTail seeks to
+  // current file end before returning, so any events from THIS point
+  // forward are captured. The inject happens immediately.
+  const injectOpts: InjectOptions = {
+    socketPath: gatewaySocket,
+    agentName: opts.agentName,
+    text: probe.phrase,
+  };
+  const injectOutcome = await injectFn(injectOpts);
+  if (!injectOutcome.written) {
+    observer.stop();
+    return {
+      probe,
+      skillsInvoked: [],
+      turnDurationMs: 0,
+      timedOut: true,
+      injectedAt: injectOutcome.injectedAt,
+      agentName: opts.agentName,
+    };
+  }
+  const turn = await observer.waitForTurnEnd();
+  observer.stop();
+  return {
+    probe,
+    skillsInvoked: extractSkillsInvoked(turn.events),
+    turnDurationMs: turn.durationMs,
+    timedOut: turn.timedOut,
+    rawEvents: opts.debugRawEvents ? turn.events : undefined,
+    injectedAt: injectOutcome.injectedAt,
+    agentName: opts.agentName,
+  };
+}
+
+export async function runAll(
+  probes: ProbeRecord[],
+  opts: RunnerOptions,
+  seed: number,
+): Promise<RunRecord> {
+  const startedAt = new Date().toISOString();
+  const results: ProbeResult[] = [];
+  for (const p of probes) {
+    opts.log?.(`runner: probe ${p.id} (${p.kind}, target=${p.targetSkill ?? "<neg>"})`);
+    const r = await runProbe(p, opts);
+    results.push(r);
+  }
+  return {
+    startedAt,
+    finishedAt: new Date().toISOString(),
+    seed,
+    agentName: opts.agentName,
+    results,
+  };
+}

--- a/tests/skill-coverage/harness/runner.ts
+++ b/tests/skill-coverage/harness/runner.ts
@@ -98,38 +98,47 @@ export async function runProbe(
     log: opts.log,
   } satisfies ObserveTurnOptions);
 
-  await observer.start();
-  // Small priming delay isn't required — startSessionTail seeks to
-  // current file end before returning, so any events from THIS point
-  // forward are captured. The inject happens immediately.
-  const injectOpts: InjectOptions = {
-    socketPath: gatewaySocket,
-    agentName: opts.agentName,
-    text: probe.phrase,
-  };
-  const injectOutcome = await injectFn(injectOpts);
-  if (!injectOutcome.written) {
+  try {
+    await observer.start();
+    const injectOpts: InjectOptions = {
+      socketPath: gatewaySocket,
+      agentName: opts.agentName,
+      text: probe.phrase,
+    };
+    const injectOutcome = await injectFn(injectOpts);
+    if (!injectOutcome.written) {
+      observer.stop();
+      return {
+        probe,
+        skillsInvoked: [],
+        turnDurationMs: 0,
+        timedOut: true,
+        injectedAt: injectOutcome.injectedAt,
+        agentName: opts.agentName,
+      };
+    }
+    const turn = await observer.waitForTurnEnd();
+    observer.stop();
+    return {
+      probe,
+      skillsInvoked: extractSkillsInvoked(turn.events),
+      turnDurationMs: turn.durationMs,
+      timedOut: turn.timedOut,
+      rawEvents: opts.debugRawEvents ? turn.events : undefined,
+      injectedAt: injectOutcome.injectedAt,
+      agentName: opts.agentName,
+    };
+  } catch (err) {
     observer.stop();
     return {
       probe,
       skillsInvoked: [],
       turnDurationMs: 0,
       timedOut: true,
-      injectedAt: injectOutcome.injectedAt,
+      error: err instanceof Error ? err.message : String(err),
       agentName: opts.agentName,
     };
   }
-  const turn = await observer.waitForTurnEnd();
-  observer.stop();
-  return {
-    probe,
-    skillsInvoked: extractSkillsInvoked(turn.events),
-    turnDurationMs: turn.durationMs,
-    timedOut: turn.timedOut,
-    rawEvents: opts.debugRawEvents ? turn.events : undefined,
-    injectedAt: injectOutcome.injectedAt,
-    agentName: opts.agentName,
-  };
 }
 
 export async function runAll(

--- a/tests/skill-coverage/harness/score.ts
+++ b/tests/skill-coverage/harness/score.ts
@@ -82,7 +82,12 @@ export function scoreRun(run: RunRecord, opts: ScoringOptions = {}): Scorecard {
         }
       } else if (fired) {
         // skillsInvoked contains this skill but it wasn't the target.
-        // That's a false positive *for this skill*. Count it.
+        // That's a false positive *for this skill*. Negative-control
+        // probes (targetSkill === null) hit this branch AND also
+        // increment negFpHits below — intentional double-accounting:
+        // the per-skill `falsePositives` measures "this skill mis-fires"
+        // while `negativeControlFpRate` measures "this skill fires on
+        // probes meant for no-one". Both are needed.
         fp++;
       }
       // Negative-control accounting — only for probes whose target

--- a/tests/skill-coverage/harness/score.ts
+++ b/tests/skill-coverage/harness/score.ts
@@ -1,0 +1,165 @@
+/**
+ * Score module — consumes a RunRecord, emits per-skill precision /
+ * recall / F1 + a markdown table.
+ *
+ * v1 definitions:
+ *   - TRUE POSITIVE   : probe.targetSkill === S and S ∈ skillsInvoked
+ *   - FALSE NEGATIVE  : probe.targetSkill === S and S ∉ skillsInvoked
+ *   - FALSE POSITIVE  : probe.targetSkill !== S and S ∈ skillsInvoked
+ *
+ * `execSuccess` is a stub interface — v1 returns 1 when the target
+ * skill fired at all. Wired through so a v2 implementation can plug
+ * in artifact / tool-shape verification without changing the schema.
+ *
+ * `negativeControlFpRate`: fraction of negative-control probes
+ * `(targetSkill=null)` where ANY skill fired. High values indicate
+ * the agent is over-eager to load skills.
+ */
+
+import type { ProbeResult, RunRecord, Scorecard, SkillScorecardRow } from "./types.js";
+
+export interface ScoringOptions {
+  /** F1 threshold for the aggregate `skillsBelowF1Threshold` count. */
+  f1Threshold?: number;
+  /** Exec threshold for the aggregate `skillsBelowExecThreshold` count. */
+  execThreshold?: number;
+  /**
+   * Plug point for v2 — given the events + target, decide whether the
+   * skill *actually did its job*. v1 default just returns true.
+   */
+  execSuccessJudge?: (r: ProbeResult) => boolean;
+}
+
+/** Median of a numeric array; 0 on empty. */
+export function median(xs: number[]): number {
+  if (xs.length === 0) return 0;
+  const s = xs.slice().sort((a, b) => a - b);
+  const m = Math.floor(s.length / 2);
+  return s.length % 2 === 0 ? (s[m - 1] + s[m]) / 2 : s[m];
+}
+
+function f1(precision: number, recall: number): number {
+  if (precision + recall === 0) return 0;
+  return (2 * precision * recall) / (precision + recall);
+}
+
+export function scoreRun(run: RunRecord, opts: ScoringOptions = {}): Scorecard {
+  const f1Threshold = opts.f1Threshold ?? 0.9;
+  const execThreshold = opts.execThreshold ?? 0.95;
+  const judge = opts.execSuccessJudge ?? (() => true);
+
+  // Discover every skill that appears as either a target or as
+  // invoked output — gives the row set a stable identity even when
+  // a skill never fires.
+  const allSkills = new Set<string>();
+  for (const r of run.results) {
+    if (r.probe.targetSkill) allSkills.add(r.probe.targetSkill);
+    for (const s of r.skillsInvoked) allSkills.add(s);
+    if (r.probe.expectedOtherSkill) allSkills.add(r.probe.expectedOtherSkill);
+  }
+
+  const rows: SkillScorecardRow[] = [];
+  for (const skill of allSkills) {
+    let tp = 0;
+    let fn = 0;
+    let fp = 0;
+    let sample = 0;
+    let execSuccessTimes = 0;
+    let execSuccessTotal = 0;
+    let negFpHits = 0;
+    let negTotal = 0;
+    for (const r of run.results) {
+      const fired = r.skillsInvoked.includes(skill);
+      const target = r.probe.targetSkill === skill;
+      if (target) {
+        sample++;
+        if (fired) {
+          tp++;
+          execSuccessTotal++;
+          if (judge(r)) execSuccessTimes++;
+        } else {
+          fn++;
+        }
+      } else if (fired) {
+        // skillsInvoked contains this skill but it wasn't the target.
+        // That's a false positive *for this skill*. Count it.
+        fp++;
+      }
+      // Negative-control accounting — only for probes whose target
+      // is null (true negatives), check if THIS skill fired.
+      if (r.probe.targetSkill === null) {
+        negTotal++;
+        if (fired) negFpHits++;
+      }
+    }
+    const precision = tp + fp === 0 ? 0 : tp / (tp + fp);
+    const recall = tp + fn === 0 ? 0 : tp / (tp + fn);
+    rows.push({
+      skill,
+      sampleSize: sample,
+      truePositives: tp,
+      falseNegatives: fn,
+      falsePositives: fp,
+      precision,
+      recall,
+      f1: f1(precision, recall),
+      execSuccess: execSuccessTotal === 0 ? 0 : execSuccessTimes / execSuccessTotal,
+      negativeControlFpRate: negTotal === 0 ? 0 : negFpHits / negTotal,
+    });
+  }
+
+  // Stable ordering: by skill id ascending.
+  rows.sort((a, b) => a.skill.localeCompare(b.skill));
+
+  const f1s = rows.filter((r) => r.sampleSize > 0).map((r) => r.f1);
+  const skillsBelowF1Threshold = rows.filter(
+    (r) => r.sampleSize > 0 && r.f1 < f1Threshold,
+  ).length;
+  const skillsBelowExecThreshold = rows.filter(
+    (r) => r.sampleSize > 0 && r.execSuccess < execThreshold,
+  ).length;
+
+  return {
+    generatedAt: new Date().toISOString(),
+    seed: run.seed,
+    totalProbes: run.results.length,
+    rows,
+    aggregate: {
+      medianF1: median(f1s),
+      skillsBelowF1Threshold,
+      skillsBelowExecThreshold,
+      f1Threshold,
+      execThreshold,
+    },
+  };
+}
+
+function fmt(n: number, digits = 2): string {
+  if (!Number.isFinite(n)) return "—";
+  return n.toFixed(digits);
+}
+
+export function renderMarkdown(card: Scorecard): string {
+  const out: string[] = [];
+  out.push(`# Skill coverage scorecard`);
+  out.push("");
+  out.push(`- generated: ${card.generatedAt}`);
+  out.push(`- seed: ${card.seed}`);
+  out.push(`- total probes: ${card.totalProbes}`);
+  out.push(`- median F1 (among targeted skills): ${fmt(card.aggregate.medianF1)}`);
+  out.push(
+    `- skills below F1 ${fmt(card.aggregate.f1Threshold)}: **${card.aggregate.skillsBelowF1Threshold}**`,
+  );
+  out.push(
+    `- skills below exec ${fmt(card.aggregate.execThreshold)}: **${card.aggregate.skillsBelowExecThreshold}**`,
+  );
+  out.push("");
+  out.push("| skill | n | TP | FN | FP | precision | recall | F1 | exec | neg-FP |");
+  out.push("|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|");
+  for (const r of card.rows) {
+    out.push(
+      `| ${r.skill} | ${r.sampleSize} | ${r.truePositives} | ${r.falseNegatives} | ${r.falsePositives} | ${fmt(r.precision)} | ${fmt(r.recall)} | ${fmt(r.f1)} | ${fmt(r.execSuccess)} | ${fmt(r.negativeControlFpRate)} |`,
+    );
+  }
+  return out.join("\n") + "\n";
+}

--- a/tests/skill-coverage/harness/types.ts
+++ b/tests/skill-coverage/harness/types.ts
@@ -1,0 +1,62 @@
+/**
+ * Runtime types for the harness — what runner.ts produces and what
+ * score.ts consumes.
+ */
+
+import type { SessionEvent } from "../../../telegram-plugin/session-tail.js";
+import type { ProbeRecord } from "../corpus/types.js";
+
+export interface ProbeResult {
+  probe: ProbeRecord;
+  /** Skill names extracted from `tool_use` events where toolName === "Skill". */
+  skillsInvoked: string[];
+  turnDurationMs: number;
+  timedOut: boolean;
+  /** Optional — kept only when debugMode is on; useful for forensic diffs. */
+  rawEvents?: SessionEvent[];
+  /** ISO timestamp at which the inject happened. */
+  injectedAt: string;
+  /** Population label — agent name so multi-agent runs can be split. */
+  agentName: string;
+}
+
+export interface RunRecord {
+  startedAt: string;
+  finishedAt: string;
+  seed: number;
+  agentName: string;
+  results: ProbeResult[];
+}
+
+export interface SkillScorecardRow {
+  skill: string;
+  sampleSize: number;
+  truePositives: number;
+  falseNegatives: number;
+  falsePositives: number;
+  precision: number;
+  recall: number;
+  f1: number;
+  /**
+   * v1 stub — counts as 1 when the target skill fired at least once.
+   * Wired so the v2 "did the skill actually finish its job" check can
+   * slot in without changing the schema.
+   */
+  execSuccess: number;
+  /** Negative-control probes where ANY skill fired (false positives on negatives). */
+  negativeControlFpRate: number;
+}
+
+export interface Scorecard {
+  generatedAt: string;
+  seed: number;
+  totalProbes: number;
+  rows: SkillScorecardRow[];
+  aggregate: {
+    medianF1: number;
+    skillsBelowF1Threshold: number;
+    skillsBelowExecThreshold: number;
+    f1Threshold: number;
+    execThreshold: number;
+  };
+}

--- a/tests/skill-coverage/harness/types.ts
+++ b/tests/skill-coverage/harness/types.ts
@@ -15,9 +15,11 @@ export interface ProbeResult {
   /** Optional — kept only when debugMode is on; useful for forensic diffs. */
   rawEvents?: SessionEvent[];
   /** ISO timestamp at which the inject happened. */
-  injectedAt: string;
+  injectedAt?: string;
   /** Population label — agent name so multi-agent runs can be split. */
   agentName: string;
+  /** Set when the probe failed before reaching turn_end (inject or observer error). */
+  error?: string;
 }
 
 export interface RunRecord {

--- a/tests/skill-coverage/tests/corpus.test.ts
+++ b/tests/skill-coverage/tests/corpus.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Determinism + shape tests for the corpus generator.
+ *
+ * Critical invariant: given the same fixture file + seed, the output
+ * must be byte-stable. Authors rely on stable probe ids to track
+ * which utterances have been graded by hand vs. machine.
+ */
+
+import { describe, expect, it } from "vitest";
+import { generateCorpus, generateForSkill, probesToJsonl } from "../corpus/generate-corpus.js";
+import type { SkillFixture } from "../corpus/types.js";
+
+describe("generate-corpus", () => {
+  it("is byte-stable across runs for the same seed", () => {
+    const a = generateCorpus({ seed: 42 });
+    const b = generateCorpus({ seed: 42 });
+    expect(Object.keys(a.bySkill).sort()).toEqual(Object.keys(b.bySkill).sort());
+    for (const skill of Object.keys(a.bySkill)) {
+      expect(probesToJsonl(a.bySkill[skill])).toEqual(probesToJsonl(b.bySkill[skill]));
+    }
+  });
+
+  it("produces different probes for different seeds", () => {
+    const a = generateCorpus({ seed: 1 });
+    const b = generateCorpus({ seed: 999 });
+    // The ID hash mixes the seed in — at least one skill should
+    // shift IDs. Spot-check the union of all ids.
+    const idsA = Object.values(a.bySkill).flat().map((p) => p.id).sort();
+    const idsB = Object.values(b.bySkill).flat().map((p) => p.id).sort();
+    expect(idsA).not.toEqual(idsB);
+  });
+
+  it("skips out-of-scope skills (in_default_pool=false or user_invocable=false)", () => {
+    const r = generateCorpus({ seed: 1 });
+    expect(r.skipped).toContain("token-helpers");
+    expect(r.skipped).toContain("switchroom-architecture");
+    expect(r.bySkill["token-helpers"]).toBeUndefined();
+    expect(r.bySkill["switchroom-architecture"]).toBeUndefined();
+  });
+
+  it("emits the expected per-skill probe distribution", () => {
+    const mockSkills: SkillFixture[] = [
+      {
+        id: "alpha",
+        category: "test",
+        in_default_pool: true,
+        user_invocable: true,
+        description: "Alpha skill",
+        trigger_phrases: ["do alpha", "perform alpha task"],
+        negatives: [],
+        adjacent_skills: ["beta"],
+      },
+      {
+        id: "beta",
+        category: "test",
+        in_default_pool: true,
+        user_invocable: true,
+        description: "Beta skill",
+        trigger_phrases: ["do beta", "perform beta task"],
+        negatives: [],
+        adjacent_skills: ["alpha"],
+      },
+    ];
+    const probes = generateForSkill(mockSkills[0], mockSkills, 7);
+    const byKind = {
+      paraphrase: probes.filter((p) => p.kind === "paraphrase").length,
+      typo: probes.filter((p) => p.kind === "typo").length,
+      slang: probes.filter((p) => p.kind === "slang").length,
+      indirect: probes.filter((p) => p.kind === "indirect").length,
+      negative: probes.filter((p) => p.kind === "negative").length,
+    };
+    // The dedupe step can drop variants when templates collide on
+    // short trigger sets. We assert lower bounds rather than exact
+    // counts — with a 2-phrase mock fixture and one adjacent skill,
+    // collision risk is high. The real corpus is keyed off skills
+    // with 8–14 triggers and 2–4 adjacents and hits the documented
+    // caps comfortably.
+    expect(byKind.paraphrase).toBeGreaterThanOrEqual(3);
+    expect(byKind.typo).toBeGreaterThanOrEqual(1);
+    expect(byKind.slang).toBeGreaterThanOrEqual(2);
+    expect(byKind.indirect).toBeGreaterThanOrEqual(2);
+    expect(byKind.negative).toBeGreaterThanOrEqual(2);
+  });
+
+  it("assigns negative controls to adjacent skill triggers with expectedOtherSkill set", () => {
+    const r = generateCorpus({ seed: 1, onlySkills: ["docx"] });
+    const docx = r.bySkill["docx"] ?? [];
+    const negatives = docx.filter((p) => p.kind === "negative");
+    expect(negatives.length).toBeGreaterThan(0);
+    for (const n of negatives) {
+      expect(n.targetSkill).toBeNull();
+      // negatives drawn from adjacent skills carry an expectedOtherSkill
+      expect(n.expectedOtherSkill).toBeDefined();
+      expect(["pdf", "xlsx", "pptx"]).toContain(n.expectedOtherSkill);
+    }
+  });
+
+  it("hits documented per-category caps on real fixture-set skills", () => {
+    // switchroom-cli has 20 triggers + 4 adjacents — comfortably
+    // above the cap-collision threshold, so it should hit the full
+    // 6/3/3/3/4 distribution.
+    const r = generateCorpus({ seed: 1, onlySkills: ["switchroom-cli"] });
+    const probes = r.bySkill["switchroom-cli"];
+    const byKind = {
+      paraphrase: probes.filter((p) => p.kind === "paraphrase").length,
+      typo: probes.filter((p) => p.kind === "typo").length,
+      slang: probes.filter((p) => p.kind === "slang").length,
+      indirect: probes.filter((p) => p.kind === "indirect").length,
+      negative: probes.filter((p) => p.kind === "negative").length,
+    };
+    expect(byKind.paraphrase).toBe(6);
+    expect(byKind.typo).toBe(3);
+    expect(byKind.slang).toBe(3);
+    expect(byKind.indirect).toBe(3);
+    expect(byKind.negative).toBe(4);
+  });
+
+  it("probe ids are 16-char hex and stable", () => {
+    const r = generateCorpus({ seed: 1, onlySkills: ["docx"] });
+    for (const p of r.bySkill["docx"]) {
+      expect(p.id).toMatch(/^[0-9a-f]{16}$/);
+    }
+  });
+});

--- a/tests/skill-coverage/tests/runner.test.ts
+++ b/tests/skill-coverage/tests/runner.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Runner unit test — uses fake inject + fake observer so no socket
+ * or filesystem session-tail is touched.
+ */
+
+import { describe, expect, it } from "vitest";
+import { runAll, runProbe } from "../harness/runner.js";
+import type { SessionEvent } from "../../../telegram-plugin/session-tail.js";
+import type { ProbeRecord } from "../corpus/types.js";
+
+function fakeInject() {
+  return async () => ({
+    injectedAt: "2025-01-01T00:00:00.000Z",
+    inboundId: "42",
+    written: true,
+  });
+}
+
+function fakeObserver(events: SessionEvent[]) {
+  return () => ({
+    start: async () => {},
+    waitForTurnEnd: async () => ({ events: events.slice(), timedOut: false, durationMs: 250 }),
+    stop: () => {},
+  });
+}
+
+const skillToolUse = (skill: string): SessionEvent => ({
+  kind: "tool_use",
+  toolName: "Skill",
+  toolUseId: `tu_${skill}`,
+  input: { skill },
+});
+
+const turnEnd: SessionEvent = { kind: "turn_end", durationMs: 250 };
+
+const baseProbe: ProbeRecord = {
+  id: "probe1__________",
+  targetSkill: "alpha",
+  kind: "paraphrase",
+  phrase: "do alpha",
+  source: "paraphrase-template",
+};
+
+describe("runner", () => {
+  it("extracts the invoked skill from tool_use events", async () => {
+    const r = await runProbe(baseProbe, {
+      agentName: "test-agent",
+      agentCwd: "/tmp/fake",
+      gatewaySocket: "/tmp/fake.sock",
+      _inject: fakeInject(),
+      _createObserver: fakeObserver([skillToolUse("alpha"), turnEnd]),
+    });
+    expect(r.skillsInvoked).toEqual(["alpha"]);
+    expect(r.timedOut).toBe(false);
+    expect(r.turnDurationMs).toBeGreaterThan(0);
+  });
+
+  it("returns empty skillsInvoked when nothing fires", async () => {
+    const r = await runProbe(baseProbe, {
+      agentName: "test-agent",
+      agentCwd: "/tmp/fake",
+      gatewaySocket: "/tmp/fake.sock",
+      _inject: fakeInject(),
+      _createObserver: fakeObserver([turnEnd]),
+    });
+    expect(r.skillsInvoked).toEqual([]);
+  });
+
+  it("treats inject failure as a timed-out probe", async () => {
+    const failInject = async () => ({
+      injectedAt: "2025-01-01T00:00:00.000Z",
+      inboundId: "42",
+      written: false,
+      error: "boom",
+    });
+    const r = await runProbe(baseProbe, {
+      agentName: "test-agent",
+      agentCwd: "/tmp/fake",
+      gatewaySocket: "/tmp/fake.sock",
+      _inject: failInject,
+      _createObserver: fakeObserver([turnEnd]),
+    });
+    expect(r.timedOut).toBe(true);
+    expect(r.skillsInvoked).toEqual([]);
+  });
+
+  it("runAll iterates probes sequentially and preserves order", async () => {
+    const probes: ProbeRecord[] = [
+      { ...baseProbe, id: "p1______________", targetSkill: "alpha", phrase: "do alpha" },
+      { ...baseProbe, id: "p2______________", targetSkill: "beta", phrase: "do beta" },
+    ];
+    const run = await runAll(probes, {
+      agentName: "test-agent",
+      agentCwd: "/tmp/fake",
+      gatewaySocket: "/tmp/fake.sock",
+      _inject: fakeInject(),
+      _createObserver: fakeObserver([skillToolUse("alpha"), turnEnd]),
+    }, 1);
+    expect(run.results.length).toBe(2);
+    expect(run.results.map((r) => r.probe.id)).toEqual([
+      "p1______________",
+      "p2______________",
+    ]);
+  });
+});

--- a/tests/skill-coverage/tests/score.test.ts
+++ b/tests/skill-coverage/tests/score.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Score-module math tests. Canned ProbeResult inputs → expected F1
+ * for hand-computed cases.
+ */
+
+import { describe, expect, it } from "vitest";
+import type { ProbeRecord } from "../corpus/types.js";
+import { median, renderMarkdown, scoreRun } from "../harness/score.js";
+import type { ProbeResult, RunRecord } from "../harness/types.js";
+
+function probe(target: string | null, phrase: string, kind: ProbeRecord["kind"] = "paraphrase"): ProbeRecord {
+  return {
+    id: phrase.slice(0, 16).padEnd(16, "_"),
+    targetSkill: target,
+    kind,
+    phrase,
+    source: "paraphrase-template",
+  };
+}
+
+function result(target: string | null, invoked: string[]): ProbeResult {
+  return {
+    probe: probe(target, `phrase-${target}-${invoked.join(",")}`),
+    skillsInvoked: invoked,
+    turnDurationMs: 100,
+    timedOut: false,
+    injectedAt: "2025-01-01T00:00:00Z",
+    agentName: "test-agent",
+  };
+}
+
+function run(results: ProbeResult[]): RunRecord {
+  return {
+    startedAt: "2025-01-01T00:00:00Z",
+    finishedAt: "2025-01-01T00:00:01Z",
+    seed: 1,
+    agentName: "test-agent",
+    results,
+  };
+}
+
+describe("score module", () => {
+  it("computes median correctly", () => {
+    expect(median([])).toBe(0);
+    expect(median([1])).toBe(1);
+    expect(median([1, 2, 3])).toBe(2);
+    expect(median([1, 2, 3, 4])).toBe(2.5);
+  });
+
+  it("perfect recall and precision yields F1 = 1.0", () => {
+    const r = run([
+      result("alpha", ["alpha"]),
+      result("alpha", ["alpha"]),
+      result("alpha", ["alpha"]),
+    ]);
+    const card = scoreRun(r);
+    const alpha = card.rows.find((x) => x.skill === "alpha");
+    expect(alpha).toBeDefined();
+    expect(alpha!.precision).toBe(1);
+    expect(alpha!.recall).toBe(1);
+    expect(alpha!.f1).toBe(1);
+  });
+
+  it("computes F1 for a mixed positive/negative case", () => {
+    // 4 alpha probes; 3 fire alpha (TP), 1 fires nothing (FN).
+    // 2 beta probes target beta but fire alpha → alpha gets 2 FP.
+    // P_alpha = TP / (TP + FP) = 3/5 = 0.6
+    // R_alpha = TP / (TP + FN) = 3/4 = 0.75
+    // F1     = 2 * 0.6 * 0.75 / 1.35 ≈ 0.6667
+    const r = run([
+      result("alpha", ["alpha"]),
+      result("alpha", ["alpha"]),
+      result("alpha", ["alpha"]),
+      result("alpha", []),
+      result("beta", ["alpha"]),
+      result("beta", ["alpha"]),
+    ]);
+    const card = scoreRun(r);
+    const alpha = card.rows.find((x) => x.skill === "alpha");
+    expect(alpha).toBeDefined();
+    expect(alpha!.truePositives).toBe(3);
+    expect(alpha!.falseNegatives).toBe(1);
+    expect(alpha!.falsePositives).toBe(2);
+    expect(alpha!.precision).toBeCloseTo(0.6, 5);
+    expect(alpha!.recall).toBeCloseTo(0.75, 5);
+    expect(alpha!.f1).toBeCloseTo(0.6667, 3);
+  });
+
+  it("computes negative-control FP rate per skill", () => {
+    // 3 negative probes, 1 fires alpha → alpha neg-FP = 1/3.
+    const r = run([
+      result(null, []),
+      result(null, ["alpha"]),
+      result(null, []),
+      result("beta", ["beta"]),
+    ]);
+    const card = scoreRun(r);
+    const alpha = card.rows.find((x) => x.skill === "alpha");
+    expect(alpha).toBeDefined();
+    expect(alpha!.negativeControlFpRate).toBeCloseTo(1 / 3, 5);
+    const beta = card.rows.find((x) => x.skill === "beta");
+    expect(beta!.negativeControlFpRate).toBe(0);
+  });
+
+  it("counts skills below F1 threshold in aggregate", () => {
+    const r = run([
+      // alpha: perfect F1
+      result("alpha", ["alpha"]),
+      result("alpha", ["alpha"]),
+      // beta: 0 recall (1 FN)
+      result("beta", []),
+    ]);
+    const card = scoreRun(r, { f1Threshold: 0.9 });
+    expect(card.aggregate.skillsBelowF1Threshold).toBe(1);
+    expect(card.aggregate.medianF1).toBeGreaterThan(0);
+  });
+
+  it("renderMarkdown produces a non-empty table", () => {
+    const r = run([result("alpha", ["alpha"]), result("beta", [])]);
+    const md = renderMarkdown(scoreRun(r));
+    expect(md).toContain("| skill |");
+    expect(md).toContain("alpha");
+    expect(md).toContain("beta");
+  });
+
+  it("execSuccess judge plug works", () => {
+    let calls = 0;
+    const judge = (): boolean => {
+      calls++;
+      return false; // every exec marked unsuccessful
+    };
+    const r = run([result("alpha", ["alpha"]), result("alpha", ["alpha"])]);
+    const card = scoreRun(r, { execSuccessJudge: judge });
+    const alpha = card.rows.find((x) => x.skill === "alpha");
+    expect(calls).toBe(2);
+    expect(alpha!.execSuccess).toBe(0);
+  });
+});

--- a/tests/skill-coverage/tsconfig.json
+++ b/tests/skill-coverage/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "../..",
+    "noEmit": true,
+    "declaration": false
+  },
+  "include": [
+    "./**/*.ts",
+    "../../telegram-plugin/session-tail.ts",
+    "../../telegram-plugin/gateway/ipc-protocol.ts"
+  ]
+}


### PR DESCRIPTION
## Summary

Foundation for measuring skill trigger precision/recall across the 27-skill bundle. Three deliverables:

- **`docs/skill-coverage/inventory.md`** — every SKILL.md catalogued with trigger phrasings, negatives, execution surface, quality flags. 27 skills total: 11 in the default-bundle pool, 16 install-on-demand. 7 profile context overlays listed separately.
- **`docs/skill-coverage/audit.md`** — per-skill verdicts (13 NEEDS-FIX, 2 OUT-OF-SCOPE for harness), 5 overlap-cluster disambiguation rules, 6 named domain gaps (vault unlock, broker socket recovery, `/restart` troubleshooting, agent-scheduler debugging, progress-card editing, hostd ops), and threshold predictions per skill.
- **`tests/skill-coverage/`** — corpus generator (rule-based fuzz + curated YAML seeds, deterministic by seed), inject/observe/runner/score modules wired to the existing `inject_inbound` IPC and `session-tail` observability, plus 18 unit tests covering corpus determinism, F1 math, fake-inject/observer wiring, and negative-control assignment.

## Architecture

Probe → `inject_inbound` UDS envelope (same protocol cron uses, since #890+) → agent runs a real turn → harness tails the agent's session JSONL → captures every `tool_use` event with `name === 'Skill'` → reads `input.skill` → scores per-skill precision/recall/F1 plus negative-control FP rate.

Five probe kinds per skill: 6 paraphrases, 3 typos, 3 slang, 3 indirect "symptom" phrasings, 4 negative controls drawn from adjacent skills' trigger space.

## Reviewer verdict

Fresh-process reviewer (separate `claude -p` invocation): **APPROVE**. Three non-blocking nits to address in a follow-up commit:
- `inject.ts:65` — `messageId` collisions theoretically possible at sub-ms cadence (sequential runner makes risk low).
- `runner.ts:101-122` — observer exception rejects whole `runAll` instead of marking the affected probe `timedOut`.
- `score.ts:83-87` — negative-control FP appears in both `falsePositives` and `negativeControlFpRate`; documented but worth an inline comment.

Audit verdicts spot-checked against `docx`, `humanizer`, `buildkite-cli`, `webapp-testing`, `switchroom-runtime` — all factually correct against the underlying SKILL.md content.

## Not in this PR (tracked as follow-ups)

- Live runs against a real agent (the harness is unit-tested end-to-end with an in-memory inject + fake observer; `--go` mode against a running gateway is untested).
- `execSuccess` scoring beyond "skill fired at all" — needs an artifact / tool-shape contract per skill (e.g. `file-bug` must have produced a `gh issue create` Bash call).
- Description-fix PRs against the 13 NEEDS-FIX skills.
- LLM-driven paraphrase pass for the trigger-poor cohort (`humanizer-calibrate`, `webapp-testing`, `mcp-builder`).
- Closing the 6 domain gaps named in `audit.md` §4.

## Test plan

- [x] `npx vitest run` in `tests/skill-coverage/` — 18/18 passing.
- [x] `npx tsc --noEmit -p tests/skill-coverage/tsconfig.json` — clean.
- [x] `bun tests/skill-coverage/corpus/generate-corpus.ts --seed=1` — emits 25 deterministic JSONL files (skips `switchroom-architecture`, `token-helpers`).
- [ ] Live `--go` run against a dev agent — deferred to follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)