### PR TITLE
feat(skill-coverage): MTCute UAT runner using sidecar observability + Skill pre-approval

### DIFF
--- a/docs/skill-coverage/runbook.md
+++ b/docs/skill-coverage/runbook.md
@@ -32,14 +32,14 @@ Each probe is a real Claude Code turn against the user's Claude Pro/Max subscrip
 
 ## Live run
 
-**Preferred path — MTCute UAT runner** (`telegram-plugin/uat/runners/skill-coverage.ts`). Drives a real Telegram user account against the agent's bot via mtcute and extracts skill invocations from the progress-card label stream (`running skill <name>` per `tool-labels.ts:247`). No agent-uid perms dance, no JSONL tailing, no inject_inbound socket — Telegram is both the inbound channel and the observation surface.
+**Preferred path — MTCute UAT runner** (`telegram-plugin/uat/runners/skill-coverage.ts`). Drives a real Telegram user account against the agent's bot via mtcute, sends each probe, then reads which skills fired from the agent's host-readable `tool-labels-<session>.jsonl` sidecar (written by the PreToolUse hook at `telegram-plugin/hooks/tool-label-pretool.mjs`). Telegram is the inbound channel; the sidecar is the observation surface. No JSONL tailing of agent-uid-owned `session.jsonl`, no inject_inbound socket.
 
 Prereqs for this path are the standard UAT prereqs (see `telegram-plugin/uat/SETUP.md`):
 
 - `TELEGRAM_API_ID`, `TELEGRAM_API_HASH`, `TELEGRAM_UAT_DRIVER_SESSION` in the repo-root `.env`.
 - Test bot is wired to the target agent and reachable via the username you'll pass to `--agent`.
-- Target agent's `channels.telegram.progress_card.delay_ms` is set small (0 is fine) in `switchroom.yaml` so the progress card surfaces during short turns. Defaults to 45s which suppresses the card entirely on fast probes.
-- Target agent has been restarted since this branch landed so `Skill` lives in `permissions.allow` (see "Skill pre-approval" below).
+- Target agent has been restarted since this branch landed so (a) the PreToolUse hook emits Skill sidecar rows and (b) `Skill` lives in `permissions.allow` (see "Skill pre-approval" below).
+- Agent's `~/.switchroom/agents/<name>/telegram/` directory is host-readable (the sidecar files land here at mode 0644 — readable to any host user). No agent-uid sudo dance required.
 
 ```bash
 cd /path/to/switchroom

--- a/docs/skill-coverage/runbook.md
+++ b/docs/skill-coverage/runbook.md
@@ -32,21 +32,41 @@ Each probe is a real Claude Code turn against the user's Claude Pro/Max subscrip
 
 ## Live run
 
+**Preferred path — MTCute UAT runner** (`telegram-plugin/uat/runners/skill-coverage.ts`). Drives a real Telegram user account against the agent's bot via mtcute and extracts skill invocations from the progress-card label stream (`running skill <name>` per `tool-labels.ts:247`). No agent-uid perms dance, no JSONL tailing, no inject_inbound socket — Telegram is both the inbound channel and the observation surface.
+
+Prereqs for this path are the standard UAT prereqs (see `telegram-plugin/uat/SETUP.md`):
+
+- `TELEGRAM_API_ID`, `TELEGRAM_API_HASH`, `TELEGRAM_UAT_DRIVER_SESSION` in the repo-root `.env`.
+- Test bot is wired to the target agent and reachable via the username you'll pass to `--agent`.
+- Target agent's `channels.telegram.progress_card.delay_ms` is set small (0 is fine) in `switchroom.yaml` so the progress card surfaces during short turns. Defaults to 45s which suppresses the card entirely on fast probes.
+- Target agent has been restarted since this branch landed so `Skill` lives in `permissions.allow` (see "Skill pre-approval" below).
+
 ```bash
 cd /path/to/switchroom
 
-# Full run, every in-scope skill, deterministic seed:
+# Full run, deterministic corpus:
+bun telegram-plugin/uat/runners/skill-coverage.ts \
+  --agent test-harness:@your_test_bot
+
+# Slice for sanity-check first (recommended):
+bun telegram-plugin/uat/runners/skill-coverage.ts \
+  --agent test-harness:@your_test_bot \
+  --skills switchroom-cli,switchroom-status,docx \
+  --limit-per-skill 2
+```
+
+**Fallback path — inject_inbound runner** (`tests/skill-coverage/cli.ts`). Original design; works but requires agent-uid read on `~/.switchroom/agents/<name>/.claude/projects/`. Use one of the three modes (A/B/C above) to satisfy perms.
+
+```bash
 bun tests/skill-coverage/cli.ts <agent-name> \
   --agent-cwd=$HOME/.switchroom/agents/<agent-name> \
   --gateway-socket=$HOME/.switchroom/agents/<agent-name>/telegram/gateway.sock \
   --go
-
-# Slice to a few skills first to sanity-check:
-bun tests/skill-coverage/cli.ts <agent-name> \
-  --skills=switchroom-cli,switchroom-status,docx \
-  --limit-per-skill=4 \
-  --agent-cwd=... --gateway-socket=... --go
 ```
+
+### Skill pre-approval
+
+Probes will stall if the agent's `permissions.allow` doesn't include the bare `Skill` tool — every Skill invocation otherwise hits an approval prompt that the harness can't dismiss. The scaffold's `DEFAULT_READ_ONLY_PREAPPROVED_TOOLS` includes `Skill` since the same PR that introduced the MTCute runner; for older agents either `switchroom agent restart <name>` to refresh the scaffold or hand-edit `~/.switchroom/agents/<name>/.claude/settings.json` to add `"Skill"` to `permissions.allow`.
 
 The runner emits three artifacts at `tests/skill-coverage/out/skill-coverage.{run.json,scorecard.json,scorecard.md}` (override the base with `--out=<path>`):
 

--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -479,6 +479,13 @@ const DEFAULT_READ_ONLY_PREAPPROVED_TOOLS = [
   "Task",
   "TodoWrite",
   "ExitPlanMode",
+  // Skill itself just loads instruction context — the side-effecting
+  // tools the skill body invokes (Bash, Write, etc) retain their own
+  // approval gates. Pre-approving Skill lets routine "/loop", "/init",
+  // and the bundled-skill invocations land without a prompt, which
+  // matters for the skill-coverage UAT runner (every probe would
+  // otherwise stall on an approval).
+  "Skill",
 ];
 
 /**

--- a/telegram-plugin/hooks/tool-label-pretool.mjs
+++ b/telegram-plugin/hooks/tool-label-pretool.mjs
@@ -111,6 +111,17 @@ export function computeLabel(toolName, input) {
     case 'KillBash':
     case 'KillShell':
       return 'Stopping background process'
+    case 'Skill': {
+      // The Skill tool's input is `{ skill: "<slug>", args?: "..." }`.
+      // We emit `Running skill <slug>` so downstream observers
+      // (notably the skill-coverage UAT runner at
+      // telegram-plugin/uat/runners/skill-coverage.ts) can tail the
+      // sidecar JSONL and recover which skill fired per turn —
+      // the progress card path that used to surface this was retired
+      // when `progressDriver` was nulled out in #1122 PR3.
+      const slug = clip(String(i.skill ?? ''), 64)
+      return slug ? `Running skill ${slug}` : null
+    }
   }
 
   // MCP allowlist.

--- a/telegram-plugin/uat/runners/skill-coverage.test.ts
+++ b/telegram-plugin/uat/runners/skill-coverage.test.ts
@@ -1,0 +1,50 @@
+/**
+ * Unit tests for the skill-coverage UAT runner's pure pieces:
+ * label extractor, corpus loader, scoring math, markdown render.
+ *
+ * Network/driver paths are not exercised here — those are validated
+ * by a live operator-driven run against the test-harness agent
+ * (see docs/skill-coverage/runbook.md).
+ */
+
+import { describe, it, expect } from "vitest";
+import { extractSkillsFromText } from "./skill-coverage.js";
+
+describe("extractSkillsFromText", () => {
+  it("pulls a single skill name from a card-style label", () => {
+    expect(extractSkillsFromText("🛠 running skill switchroom-cli")).toEqual([
+      "switchroom-cli",
+    ]);
+  });
+
+  it("dedupes repeated mentions of the same skill", () => {
+    const t = "running skill docx\n…\nrunning skill docx";
+    expect(extractSkillsFromText(t)).toEqual(["docx"]);
+  });
+
+  it("collects multiple distinct skills across one progress card", () => {
+    const t = [
+      "🛠 running skill buildkite-cli",
+      "📖 reading file…",
+      "🛠 running skill switchroom-status",
+    ].join("\n");
+    const got = extractSkillsFromText(t).sort();
+    expect(got).toEqual(["buildkite-cli", "switchroom-status"]);
+  });
+
+  it("is case-insensitive on the label but lowercases the slug", () => {
+    expect(extractSkillsFromText("Running Skill BUILDKITE-API")).toEqual([
+      "buildkite-api",
+    ]);
+  });
+
+  it("ignores noise that doesn't match a kebab-case slug", () => {
+    expect(extractSkillsFromText("running skill (and reading)")).toEqual([]);
+  });
+
+  it("returns [] when no labels are present", () => {
+    expect(
+      extractSkillsFromText("Sure, let me check the agent status for you."),
+    ).toEqual([]);
+  });
+});

--- a/telegram-plugin/uat/runners/skill-coverage.test.ts
+++ b/telegram-plugin/uat/runners/skill-coverage.test.ts
@@ -1,50 +1,100 @@
 /**
  * Unit tests for the skill-coverage UAT runner's pure pieces:
- * label extractor, corpus loader, scoring math, markdown render.
- *
- * Network/driver paths are not exercised here — those are validated
- * by a live operator-driven run against the test-harness agent
- * (see docs/skill-coverage/runbook.md).
+ * label extractor + sidecar JSONL reader. Live driver/network paths
+ * are validated by operator-driven runs (see runbook).
  */
 
 import { describe, it, expect } from "vitest";
-import { extractSkillsFromText } from "./skill-coverage.js";
+import {
+  extractSkillFromLabel,
+  readSkillRowsSince,
+} from "./skill-coverage.js";
 
-describe("extractSkillsFromText", () => {
-  it("pulls a single skill name from a card-style label", () => {
-    expect(extractSkillsFromText("🛠 running skill switchroom-cli")).toEqual([
+describe("extractSkillFromLabel", () => {
+  it("pulls the slug from the hook's canonical label", () => {
+    expect(extractSkillFromLabel("Running skill switchroom-cli")).toBe(
       "switchroom-cli",
-    ]);
-  });
-
-  it("dedupes repeated mentions of the same skill", () => {
-    const t = "running skill docx\n…\nrunning skill docx";
-    expect(extractSkillsFromText(t)).toEqual(["docx"]);
-  });
-
-  it("collects multiple distinct skills across one progress card", () => {
-    const t = [
-      "🛠 running skill buildkite-cli",
-      "📖 reading file…",
-      "🛠 running skill switchroom-status",
-    ].join("\n");
-    const got = extractSkillsFromText(t).sort();
-    expect(got).toEqual(["buildkite-cli", "switchroom-status"]);
+    );
   });
 
   it("is case-insensitive on the label but lowercases the slug", () => {
-    expect(extractSkillsFromText("Running Skill BUILDKITE-API")).toEqual([
+    expect(extractSkillFromLabel("RUNNING SKILL BUILDKITE-API")).toBe(
       "buildkite-api",
+    );
+  });
+
+  it("returns null for non-Skill labels", () => {
+    expect(extractSkillFromLabel("Reading scaffold.ts")).toBeNull();
+    expect(extractSkillFromLabel("Replying")).toBeNull();
+  });
+
+  it("returns null when the slug is missing or malformed", () => {
+    expect(extractSkillFromLabel("running skill")).toBeNull();
+    expect(extractSkillFromLabel("running skill (and)")).toBeNull();
+  });
+});
+
+describe("readSkillRowsSince", () => {
+  const files: Record<string, string> = {
+    "tool-labels-A.jsonl": [
+      // before sinceMs: ignored
+      JSON.stringify({ ts: 100, tool_use_id: "u1", agent_id: "ag", label: "Running skill docx", tool_name: "Skill" }),
+      // after sinceMs, Skill: kept
+      JSON.stringify({ ts: 1500, tool_use_id: "u2", agent_id: "ag", label: "Running skill switchroom-cli", tool_name: "Skill" }),
+      // after sinceMs, non-Skill: ignored
+      JSON.stringify({ ts: 1600, tool_use_id: "u3", agent_id: "ag", label: "Reading foo.ts", tool_name: "Read" }),
+    ].join("\n") + "\n",
+    "tool-labels-B.jsonl": [
+      JSON.stringify({ ts: 2000, tool_use_id: "u4", agent_id: "ag", label: "Running skill buildkite-cli", tool_name: "Skill" }),
+      // malformed line: ignored
+      "{not-json",
+      "",
+    ].join("\n") + "\n",
+    "other.jsonl": JSON.stringify({ ts: 2500, tool_name: "Skill", label: "Running skill x" }),
+  };
+
+  const fakeReaddir = (_p: string): string[] => Object.keys(files);
+  const fakeReadFile = (p: string): string => {
+    const name = p.split("/").pop()!;
+    if (files[name] === undefined) throw new Error("ENOENT");
+    return files[name]!;
+  };
+
+  it("returns only Skill rows from tool-labels-*.jsonl with ts >= sinceMs", () => {
+    const got = readSkillRowsSince("/fake", 1000, fakeReaddir, fakeReadFile);
+    const labels = got.map((r) => r.label).sort();
+    expect(labels).toEqual([
+      "Running skill buildkite-cli",
+      "Running skill switchroom-cli",
     ]);
   });
 
-  it("ignores noise that doesn't match a kebab-case slug", () => {
-    expect(extractSkillsFromText("running skill (and reading)")).toEqual([]);
+  it("returns [] when the dir read throws", () => {
+    expect(
+      readSkillRowsSince("/fake", 0, () => { throw new Error("EACCES"); }, fakeReadFile),
+    ).toEqual([]);
   });
 
-  it("returns [] when no labels are present", () => {
-    expect(
-      extractSkillsFromText("Sure, let me check the agent status for you."),
-    ).toEqual([]);
+  it("skips files that fail to read but keeps siblings", () => {
+    const breakingRead = (p: string): string => {
+      if (p.endsWith("tool-labels-A.jsonl")) throw new Error("EACCES");
+      return fakeReadFile(p);
+    };
+    const got = readSkillRowsSince("/fake", 0, fakeReaddir, breakingRead);
+    expect(got.map((r) => r.label)).toEqual(["Running skill buildkite-cli"]);
+  });
+
+  it("ignores files that don't match the tool-labels-*.jsonl pattern", () => {
+    const files2: Record<string, string> = {
+      "other.jsonl": JSON.stringify({ ts: 100, tool_name: "Skill", label: "x" }),
+      "tool-labels-A.jsonl": "",
+    };
+    const got = readSkillRowsSince(
+      "/fake",
+      0,
+      () => Object.keys(files2),
+      (p) => files2[p.split("/").pop()!]!,
+    );
+    expect(got).toEqual([]);
   });
 });

--- a/telegram-plugin/uat/runners/skill-coverage.ts
+++ b/telegram-plugin/uat/runners/skill-coverage.ts
@@ -1,0 +1,549 @@
+#!/usr/bin/env bun
+/**
+ * Skill-coverage UAT runner — drives a real Telegram user account
+ * against a switchroom agent's bot to validate that the right Claude
+ * Code skill fires for fuzzy NL phrasings.
+ *
+ * Sister to `tests/skill-coverage/cli.ts` (the inject_inbound-based
+ * runner that hit an agent-uid perms blocker). This one observes
+ * everything through Telegram itself, so no host-side JSONL access
+ * is required.
+ *
+ * **Skill detection.** The gateway's progress card includes the
+ * literal substring `running skill <name>` for every Skill tool
+ * invocation (see `telegram-plugin/tool-labels.ts:247`). We
+ * subscribe to the bot DM chat's message stream BEFORE sending each
+ * probe, then collect every observed text fragment (initial replies,
+ * edits, pinned-card edits) and grep for the label. Any skill name
+ * extracted is "fired" for this probe.
+ *
+ * **Card-suppression caveat.** The gateway's `progress_card.delay_ms`
+ * (default 45s) hides the card entirely for short turns. For this
+ * runner to capture skill labels reliably, the target agent must run
+ * with a small `delay_ms` in its `channels.telegram` config — set 0
+ * for the test-harness agent before running. See
+ * `docs/skill-coverage/runbook.md` § "Live run".
+ *
+ * Usage:
+ *   bun telegram-plugin/uat/runners/skill-coverage.ts \
+ *     --agent test-harness:@your_test_bot \
+ *     --skills switchroom-cli,switchroom-status \
+ *     --limit-per-skill 2 \
+ *     --out tests/skill-coverage/out/skill-coverage
+ *
+ * Env equivalents (UAT-standard, fail loud):
+ *   TELEGRAM_API_ID, TELEGRAM_API_HASH, TELEGRAM_UAT_DRIVER_SESSION
+ *   SKILL_COVERAGE_AGENT="test-harness:@your_test_bot"
+ *   SKILL_COVERAGE_SKILLS="a,b,c"             (optional filter)
+ *   SKILL_COVERAGE_LIMIT_PER_SKILL=N          (optional)
+ *   SKILL_COVERAGE_OUT="..."                  (default tests/skill-coverage/out/skill-coverage)
+ */
+
+import { existsSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { Driver, type ObservedMessage } from "../driver.js";
+import { loadUatEnv } from "../load-env.js";
+
+loadUatEnv();
+
+// ─── Types — mirror tests/skill-coverage/{corpus,harness}/types.ts ────
+
+export interface Probe {
+  id: string;
+  targetSkill: string | null;
+  /** Adjacent-skill expectation for negative controls. */
+  expectedOtherSkill?: string;
+  kind: "paraphrase" | "typo" | "slang" | "indirect" | "negative";
+  phrase: string;
+}
+
+export interface ProbeResult {
+  probe: Probe;
+  skillsFired: string[];
+  replyText: string;
+  durationMs: number;
+  timedOut: boolean;
+  errorMessage?: string;
+}
+
+// ─── Skill-label extraction ──────────────────────────────────────────
+
+/**
+ * Matches the literal substring the gateway writes for a Skill tool
+ * invocation. Slug regex is restrictive on purpose — skill names are
+ * kebab-case ASCII per `skills/<name>/SKILL.md` frontmatter.
+ */
+const SKILL_LABEL_RE = /running skill\s+([a-z0-9][a-z0-9-]*)/gi;
+
+export function extractSkillsFromText(text: string): string[] {
+  const seen = new Set<string>();
+  let m: RegExpExecArray | null;
+  SKILL_LABEL_RE.lastIndex = 0;
+  while ((m = SKILL_LABEL_RE.exec(text)) !== null) {
+    seen.add(m[1]!.toLowerCase());
+  }
+  return [...seen];
+}
+
+// ─── CLI parsing ─────────────────────────────────────────────────────
+
+interface CliConfig {
+  agentName: string;
+  botUsername: string;
+  skillFilter: string[] | null;
+  limitPerSkill: number | null;
+  /** Per-probe reply timeout, ms. Default 90s. */
+  replyTimeoutMs: number;
+  /** Inter-probe settle, ms. Default 6s to keep us under Telegram's rate cap. */
+  settleMs: number;
+  /** Edit-window after first reply seen — collects card edits. Default 8s. */
+  editWindowMs: number;
+  outBase: string;
+}
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(HERE, "..", "..", "..");
+const DEFAULT_CORPUS_DIR = join(REPO_ROOT, "tests/skill-coverage/corpus");
+const DEFAULT_OUT_BASE = join(REPO_ROOT, "tests/skill-coverage/out/skill-coverage");
+
+function fail(msg: string): never {
+  process.stderr.write(`[skill-coverage-uat] ${msg}\n`);
+  process.exit(2);
+}
+
+function parseCli(argv: readonly string[]): CliConfig {
+  let agentSpec = process.env.SKILL_COVERAGE_AGENT ?? "";
+  let skillFilter = process.env.SKILL_COVERAGE_SKILLS
+    ? process.env.SKILL_COVERAGE_SKILLS.split(",").map((s) => s.trim()).filter(Boolean)
+    : null;
+  let limitPerSkill = process.env.SKILL_COVERAGE_LIMIT_PER_SKILL
+    ? Number.parseInt(process.env.SKILL_COVERAGE_LIMIT_PER_SKILL, 10)
+    : null;
+  let replyTimeoutMs = Number.parseInt(process.env.SKILL_COVERAGE_REPLY_TIMEOUT_MS ?? "90000", 10);
+  let settleMs = Number.parseInt(process.env.SKILL_COVERAGE_SETTLE_MS ?? "6000", 10);
+  let editWindowMs = Number.parseInt(process.env.SKILL_COVERAGE_EDIT_WINDOW_MS ?? "8000", 10);
+  let outBase = process.env.SKILL_COVERAGE_OUT ?? DEFAULT_OUT_BASE;
+
+  for (let i = 0; i < argv.length; i++) {
+    const tok = argv[i]!;
+    const next = (): string => {
+      const v = argv[++i];
+      if (!v) fail(`${tok}: missing value`);
+      return v;
+    };
+    switch (tok) {
+      case "--agent":
+        agentSpec = next();
+        break;
+      case "--skills":
+        skillFilter = next().split(",").map((s) => s.trim()).filter(Boolean);
+        break;
+      case "--limit-per-skill":
+        limitPerSkill = Number.parseInt(next(), 10);
+        break;
+      case "--reply-timeout-ms":
+        replyTimeoutMs = Number.parseInt(next(), 10);
+        break;
+      case "--settle-ms":
+        settleMs = Number.parseInt(next(), 10);
+        break;
+      case "--edit-window-ms":
+        editWindowMs = Number.parseInt(next(), 10);
+        break;
+      case "--out":
+        outBase = resolve(next());
+        break;
+      case "-h":
+      case "--help":
+        printHelp();
+        process.exit(0);
+        break;
+      default:
+        if (tok.startsWith("--")) fail(`unknown flag: ${tok}`);
+    }
+  }
+
+  if (!agentSpec) {
+    fail(
+      "no agent target. Pass --agent <name>:@<bot-username> or set SKILL_COVERAGE_AGENT.",
+    );
+  }
+  const [agentName, botUsername] = agentSpec.split(":").map((s) => s.trim());
+  if (!agentName || !botUsername || !botUsername.startsWith("@")) {
+    fail(`--agent expects "<name>:@<bot-username>"; got "${agentSpec}"`);
+  }
+
+  return {
+    agentName: agentName!,
+    botUsername: botUsername!,
+    skillFilter,
+    limitPerSkill,
+    replyTimeoutMs,
+    settleMs,
+    editWindowMs,
+    outBase,
+  };
+}
+
+function printHelp(): void {
+  process.stdout.write(`skill-coverage UAT runner
+
+Required env (fail loud if missing):
+  TELEGRAM_API_ID, TELEGRAM_API_HASH, TELEGRAM_UAT_DRIVER_SESSION
+
+Flags:
+  --agent NAME:@BOT         Agent + bot to target. Required.
+  --skills A,B,C            Filter to these skills only.
+  --limit-per-skill N       Cap probes per skill.
+  --reply-timeout-ms N      Per-probe budget. Default 90000.
+  --settle-ms N             Inter-probe settle. Default 6000.
+  --edit-window-ms N        Window after first reply for collecting card edits. Default 8000.
+  --out PATH                Output base path. Default tests/skill-coverage/out/skill-coverage.
+`);
+}
+
+// ─── Corpus loading ──────────────────────────────────────────────────
+
+function loadCorpus(dir: string, skillFilter: string[] | null): Probe[] {
+  if (!existsSync(dir)) {
+    fail(`corpus dir not found: ${dir} — run \`bun tests/skill-coverage/corpus/generate-corpus.ts --seed=1\` first.`);
+  }
+  const files = readdirSync(dir).filter((f) => f.endsWith(".jsonl"));
+  const out: Probe[] = [];
+  for (const f of files) {
+    const skill = f.replace(/\.jsonl$/, "");
+    if (skillFilter && !skillFilter.includes(skill)) continue;
+    const content = readFileSync(join(dir, f), "utf-8");
+    for (const line of content.split("\n")) {
+      if (!line.trim()) continue;
+      try {
+        out.push(JSON.parse(line) as Probe);
+      } catch {
+        // skip malformed lines
+      }
+    }
+  }
+  return out;
+}
+
+function trimPerSkill(probes: Probe[], limit: number | null): Probe[] {
+  if (limit == null) return probes;
+  const counts = new Map<string, number>();
+  const out: Probe[] = [];
+  for (const p of probes) {
+    const k = p.targetSkill ?? "<neg>";
+    const c = counts.get(k) ?? 0;
+    if (c >= limit) continue;
+    counts.set(k, c + 1);
+    out.push(p);
+  }
+  return out;
+}
+
+// ─── Send + observe a single probe ───────────────────────────────────
+
+async function pullOneWithTimeout(
+  it: AsyncIterator<ObservedMessage>,
+  ms: number,
+): Promise<ObservedMessage | "timeout"> {
+  return new Promise((resolveFn) => {
+    let settled = false;
+    const timer = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      resolveFn("timeout");
+    }, ms);
+    it.next().then((r) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      if (r.done === true) resolveFn("timeout");
+      else resolveFn(r.value);
+    }).catch(() => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolveFn("timeout");
+    });
+  });
+}
+
+async function runProbe(
+  driver: Driver,
+  botUserId: number,
+  driverUserId: number,
+  probe: Probe,
+  cfg: CliConfig,
+): Promise<ProbeResult> {
+  const startedAt = Date.now();
+  const stream = driver.observeMessages(botUserId)[Symbol.asyncIterator]();
+  const skills = new Set<string>();
+  const replyTexts = new Map<number, string>();
+  let sentMessageId: number;
+
+  try {
+    const sent = await driver.sendText(botUserId, probe.phrase);
+    sentMessageId = sent.messageId;
+  } catch (err) {
+    try {
+      await stream.return?.(undefined);
+    } catch {
+      /* ignore */
+    }
+    return {
+      probe,
+      skillsFired: [],
+      replyText: "",
+      durationMs: Date.now() - startedAt,
+      timedOut: false,
+      errorMessage: `send failed: ${(err as Error).message}`,
+    };
+  }
+
+  const deadline = startedAt + cfg.replyTimeoutMs;
+  let firstReplyAt = 0;
+  try {
+    while (Date.now() < deadline) {
+      const remaining = deadline - Date.now();
+      const winSize = firstReplyAt
+        ? Math.max(0, cfg.editWindowMs - (Date.now() - firstReplyAt))
+        : remaining;
+      if (firstReplyAt && winSize === 0) break;
+      const slice = await pullOneWithTimeout(
+        stream,
+        Math.min(remaining, Math.max(250, winSize)),
+      );
+      if (slice === "timeout") {
+        if (firstReplyAt) break;
+        continue;
+      }
+      if (slice.senderUserId === driverUserId) continue;
+      if (slice.messageId <= sentMessageId) continue;
+      const t = (slice.text ?? "").trim();
+      if (!t) continue;
+      for (const s of extractSkillsFromText(t)) skills.add(s);
+      replyTexts.set(slice.messageId, t);
+      if (!firstReplyAt) firstReplyAt = Date.now();
+    }
+  } finally {
+    try {
+      await stream.return?.(undefined);
+    } catch {
+      /* ignore */
+    }
+  }
+
+  const durationMs = Date.now() - startedAt;
+  if (!firstReplyAt) {
+    return {
+      probe,
+      skillsFired: [],
+      replyText: "",
+      durationMs,
+      timedOut: true,
+    };
+  }
+  // Collapse the per-message-id reply texts into a single newline-
+  // joined blob. Most turns will have just one or two entries (the
+  // streaming reply plus the pinned card); ordering is by messageId
+  // so the card (later in the stream) appears after the reply.
+  const replyText = [...replyTexts.entries()]
+    .sort((a, b) => a[0] - b[0])
+    .map(([, t]) => t)
+    .join("\n---\n");
+  return {
+    probe,
+    skillsFired: [...skills],
+    replyText,
+    durationMs,
+    timedOut: false,
+  };
+}
+
+// ─── Scoring ─────────────────────────────────────────────────────────
+
+interface SkillRow {
+  skill: string;
+  sampleSize: number;
+  truePositives: number;
+  falseNegatives: number;
+  falsePositives: number;
+  precision: number;
+  recall: number;
+  f1: number;
+  /** True when targetSkill fired at least once on positive probes. */
+  execSuccess: number;
+  negativeControlFpRate: number;
+}
+
+interface Scorecard {
+  generatedAt: string;
+  agentName: string;
+  totalProbes: number;
+  rows: SkillRow[];
+  aggregate: {
+    medianF1: number;
+    skillsBelowF1Threshold: number;
+    skillsBelowExecThreshold: number;
+    f1Threshold: number;
+    execThreshold: number;
+  };
+}
+
+function score(results: ProbeResult[], agentName: string): Scorecard {
+  const skills = new Set<string>();
+  for (const r of results) {
+    if (r.probe.targetSkill) skills.add(r.probe.targetSkill);
+    for (const s of r.skillsFired) skills.add(s);
+  }
+  const rows: SkillRow[] = [];
+  const F1_THRESHOLD = 0.9;
+  const EXEC_THRESHOLD = 0.95;
+  for (const s of [...skills].sort()) {
+    let tp = 0, fn = 0, fp = 0;
+    let sample = 0;
+    let execTotal = 0, execHits = 0;
+    let negTotal = 0, negFp = 0;
+    for (const r of results) {
+      const isTarget = r.probe.targetSkill === s;
+      const fired = r.skillsFired.includes(s);
+      if (isTarget) {
+        sample++;
+        if (fired) {
+          tp++;
+          execTotal++;
+          execHits++;
+        } else {
+          fn++;
+        }
+      } else if (fired) {
+        fp++;
+      }
+      if (r.probe.targetSkill === null) {
+        negTotal++;
+        if (fired) negFp++;
+      }
+    }
+    const precision = tp + fp === 0 ? 0 : tp / (tp + fp);
+    const recall = tp + fn === 0 ? 0 : tp / (tp + fn);
+    const f1 = precision + recall === 0 ? 0 : (2 * precision * recall) / (precision + recall);
+    rows.push({
+      skill: s,
+      sampleSize: sample,
+      truePositives: tp,
+      falseNegatives: fn,
+      falsePositives: fp,
+      precision: round3(precision),
+      recall: round3(recall),
+      f1: round3(f1),
+      execSuccess: execTotal === 0 ? 0 : round3(execHits / execTotal),
+      negativeControlFpRate: negTotal === 0 ? 0 : round3(negFp / negTotal),
+    });
+  }
+  const f1s = rows.map((r) => r.f1).sort((a, b) => a - b);
+  const medianF1 = f1s.length === 0 ? 0 : f1s[Math.floor(f1s.length / 2)]!;
+  return {
+    generatedAt: new Date().toISOString(),
+    agentName,
+    totalProbes: results.length,
+    rows,
+    aggregate: {
+      medianF1: round3(medianF1),
+      skillsBelowF1Threshold: rows.filter((r) => r.f1 < F1_THRESHOLD).length,
+      skillsBelowExecThreshold: rows.filter((r) => r.execSuccess < EXEC_THRESHOLD).length,
+      f1Threshold: F1_THRESHOLD,
+      execThreshold: EXEC_THRESHOLD,
+    },
+  };
+}
+
+function round3(n: number): number {
+  return Math.round(n * 1000) / 1000;
+}
+
+function renderMarkdown(card: Scorecard): string {
+  const lines: string[] = [];
+  lines.push(`# Skill-coverage scorecard`);
+  lines.push("");
+  lines.push(`- Generated: ${card.generatedAt}`);
+  lines.push(`- Agent: \`${card.agentName}\``);
+  lines.push(`- Probes: ${card.totalProbes}`);
+  lines.push(`- Median F1: ${card.aggregate.medianF1}`);
+  lines.push(`- Below F1 ≥ ${card.aggregate.f1Threshold}: ${card.aggregate.skillsBelowF1Threshold}`);
+  lines.push(`- Below execSuccess ≥ ${card.aggregate.execThreshold}: ${card.aggregate.skillsBelowExecThreshold}`);
+  lines.push("");
+  lines.push(`| Skill | n | TP | FN | FP | Precision | Recall | F1 | Exec | NegFP |`);
+  lines.push(`|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|`);
+  for (const r of card.rows) {
+    lines.push(
+      `| \`${r.skill}\` | ${r.sampleSize} | ${r.truePositives} | ${r.falseNegatives} | ${r.falsePositives} | ${r.precision} | ${r.recall} | ${r.f1} | ${r.execSuccess} | ${r.negativeControlFpRate} |`,
+    );
+  }
+  return lines.join("\n") + "\n";
+}
+
+// ─── Main ────────────────────────────────────────────────────────────
+
+async function main(): Promise<void> {
+  const cfg = parseCli(process.argv.slice(2));
+  for (const v of ["TELEGRAM_API_ID", "TELEGRAM_API_HASH", "TELEGRAM_UAT_DRIVER_SESSION"]) {
+    if (!process.env[v]) fail(`missing required env: ${v}`);
+  }
+
+  const corpusDir = DEFAULT_CORPUS_DIR;
+  const probesAll = loadCorpus(corpusDir, cfg.skillFilter);
+  const probes = trimPerSkill(probesAll, cfg.limitPerSkill);
+  process.stderr.write(
+    `[skill-coverage-uat] loaded ${probes.length} probes (from ${probesAll.length} in corpus)\n`,
+  );
+
+  const driver = new Driver({
+    apiId: Number.parseInt(process.env.TELEGRAM_API_ID!, 10),
+    apiHash: process.env.TELEGRAM_API_HASH!,
+    session: process.env.TELEGRAM_UAT_DRIVER_SESSION!,
+  });
+  await driver.connect();
+  process.stderr.write(`[skill-coverage-uat] connected as driver user\n`);
+
+  try {
+    const driverUserId = await driver.getMyUserId();
+    const botUserId = await driver.resolveBotUserId(cfg.botUsername);
+    process.stderr.write(
+      `[skill-coverage-uat] target ${cfg.agentName} via ${cfg.botUsername} (uid=${botUserId})\n`,
+    );
+
+    const results: ProbeResult[] = [];
+    let i = 0;
+    for (const p of probes) {
+      i++;
+      const r = await runProbe(driver, botUserId, driverUserId, p, cfg);
+      results.push(r);
+      const status = r.timedOut ? "TIMEOUT" : r.skillsFired.length ? r.skillsFired.join(",") : "<no-skill>";
+      process.stderr.write(
+        `[skill-coverage-uat] (${i}/${probes.length}) ${p.kind} target=${p.targetSkill ?? "<neg>"} → ${status} (${r.durationMs}ms)\n`,
+      );
+      if (i < probes.length) {
+        await new Promise((res) => setTimeout(res, cfg.settleMs));
+      }
+    }
+
+    const card = score(results, cfg.agentName);
+    mkdirSync(dirname(cfg.outBase), { recursive: true });
+    writeFileSync(`${cfg.outBase}.run.json`, JSON.stringify({ cfg: { ...cfg }, results }, null, 2));
+    writeFileSync(`${cfg.outBase}.scorecard.json`, JSON.stringify(card, null, 2));
+    writeFileSync(`${cfg.outBase}.scorecard.md`, renderMarkdown(card));
+    process.stderr.write(
+      `[skill-coverage-uat] wrote ${cfg.outBase}.{run.json,scorecard.json,scorecard.md}\n`,
+    );
+  } finally {
+    await driver.disconnect();
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((err) => {
+    process.stderr.write(`[skill-coverage-uat] FATAL: ${(err as Error).stack ?? err}\n`);
+    process.exit(1);
+  });
+}

--- a/telegram-plugin/uat/runners/skill-coverage.ts
+++ b/telegram-plugin/uat/runners/skill-coverage.ts
@@ -9,20 +9,18 @@
  * everything through Telegram itself, so no host-side JSONL access
  * is required.
  *
- * **Skill detection.** The gateway's progress card includes the
- * literal substring `running skill <name>` for every Skill tool
- * invocation (see `telegram-plugin/tool-labels.ts:247`). We
- * subscribe to the bot DM chat's message stream BEFORE sending each
- * probe, then collect every observed text fragment (initial replies,
- * edits, pinned-card edits) and grep for the label. Any skill name
- * extracted is "fired" for this probe.
+ * **Skill detection.** The PreToolUse hook
+ * `telegram-plugin/hooks/tool-label-pretool.mjs` writes one JSONL
+ * row per tool invocation to
+ * `~/.switchroom/agents/<agent>/telegram/tool-labels-<session_id>.jsonl`.
+ * Skill rows have `tool_name === "Skill"` and a label of the form
+ * `"Running skill <slug>"`. The runner tails every sidecar file
+ * that mtime-changes during a probe window and pulls the slugs out.
  *
- * **Card-suppression caveat.** The gateway's `progress_card.delay_ms`
- * (default 45s) hides the card entirely for short turns. For this
- * runner to capture skill labels reliably, the target agent must run
- * with a small `delay_ms` in its `channels.telegram` config — set 0
- * for the test-harness agent before running. See
- * `docs/skill-coverage/runbook.md` § "Live run".
+ * That sidecar dir is bind-mounted into the agent at
+ * `$TELEGRAM_STATE_DIR` AND lives at a host-readable path (owned by
+ * the agent UID but mode 0775; jsonl rows are 0644 from the hook).
+ * No gateway / progress-card dependency.
  *
  * Usage:
  *   bun telegram-plugin/uat/runners/skill-coverage.ts \
@@ -41,6 +39,7 @@
 
 import { existsSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
+import { homedir } from "node:os";
 import { fileURLToPath } from "node:url";
 import { Driver, type ObservedMessage } from "../driver.js";
 import { loadUatEnv } from "../load-env.js";
@@ -70,20 +69,67 @@ export interface ProbeResult {
 // ─── Skill-label extraction ──────────────────────────────────────────
 
 /**
- * Matches the literal substring the gateway writes for a Skill tool
+ * Matches the literal label substring written by the PreToolUse hook
+ * `telegram-plugin/hooks/tool-label-pretool.mjs` for a `Skill` tool
  * invocation. Slug regex is restrictive on purpose — skill names are
  * kebab-case ASCII per `skills/<name>/SKILL.md` frontmatter.
  */
-const SKILL_LABEL_RE = /running skill\s+([a-z0-9][a-z0-9-]*)/gi;
+const SKILL_LABEL_RE = /running skill\s+([a-z0-9][a-z0-9-]*)/i;
 
-export function extractSkillsFromText(text: string): string[] {
-  const seen = new Set<string>();
-  let m: RegExpExecArray | null;
-  SKILL_LABEL_RE.lastIndex = 0;
-  while ((m = SKILL_LABEL_RE.exec(text)) !== null) {
-    seen.add(m[1]!.toLowerCase());
+export function extractSkillFromLabel(label: string): string | null {
+  const m = SKILL_LABEL_RE.exec(label);
+  return m ? m[1]!.toLowerCase() : null;
+}
+
+export interface SidecarRow {
+  ts: number;
+  tool_use_id: string;
+  agent_id: string | null;
+  label: string;
+  tool_name: string;
+}
+
+/**
+ * Read every `tool-labels-*.jsonl` file in `dir` and return rows
+ * with `tool_name === "Skill"` and `ts >= sinceMs`. The sidecar is
+ * append-only so partial-line tails are unlikely; we still defensively
+ * skip malformed lines.
+ */
+export function readSkillRowsSince(
+  dir: string,
+  sinceMs: number,
+  readdir: (p: string) => string[],
+  readFile: (p: string) => string,
+): SidecarRow[] {
+  const out: SidecarRow[] = [];
+  let entries: string[] = [];
+  try {
+    entries = readdir(dir);
+  } catch {
+    return out;
   }
-  return [...seen];
+  for (const e of entries) {
+    if (!e.startsWith("tool-labels-") || !e.endsWith(".jsonl")) continue;
+    let content: string;
+    try {
+      content = readFile(`${dir}/${e}`);
+    } catch {
+      continue;
+    }
+    for (const line of content.split("\n")) {
+      if (!line.trim()) continue;
+      let row: SidecarRow;
+      try {
+        row = JSON.parse(line) as SidecarRow;
+      } catch {
+        continue;
+      }
+      if (typeof row.ts !== "number" || row.ts < sinceMs) continue;
+      if (row.tool_name !== "Skill") continue;
+      out.push(row);
+    }
+  }
+  return out;
 }
 
 // ─── CLI parsing ─────────────────────────────────────────────────────
@@ -97,8 +143,14 @@ interface CliConfig {
   replyTimeoutMs: number;
   /** Inter-probe settle, ms. Default 6s to keep us under Telegram's rate cap. */
   settleMs: number;
-  /** Edit-window after first reply seen — collects card edits. Default 8s. */
-  editWindowMs: number;
+  /** Sidecar-drain window after reply is seen, ms. The hook writes
+   *  asynchronously; a small post-reply hold avoids missing the last
+   *  Skill row of a turn. Default 3s. */
+  sidecarDrainMs: number;
+  /** Path to the agent's TELEGRAM_STATE_DIR on the host — where
+   *  `tool-labels-<session>.jsonl` files live. Defaults to
+   *  `~/.switchroom/agents/<name>/telegram/`. */
+  agentStateDir: string;
   outBase: string;
 }
 
@@ -122,7 +174,8 @@ function parseCli(argv: readonly string[]): CliConfig {
     : null;
   let replyTimeoutMs = Number.parseInt(process.env.SKILL_COVERAGE_REPLY_TIMEOUT_MS ?? "90000", 10);
   let settleMs = Number.parseInt(process.env.SKILL_COVERAGE_SETTLE_MS ?? "6000", 10);
-  let editWindowMs = Number.parseInt(process.env.SKILL_COVERAGE_EDIT_WINDOW_MS ?? "8000", 10);
+  let sidecarDrainMs = Number.parseInt(process.env.SKILL_COVERAGE_SIDECAR_DRAIN_MS ?? "3000", 10);
+  let agentStateDir = process.env.SKILL_COVERAGE_AGENT_STATE_DIR ?? "";
   let outBase = process.env.SKILL_COVERAGE_OUT ?? DEFAULT_OUT_BASE;
 
   for (let i = 0; i < argv.length; i++) {
@@ -148,8 +201,11 @@ function parseCli(argv: readonly string[]): CliConfig {
       case "--settle-ms":
         settleMs = Number.parseInt(next(), 10);
         break;
-      case "--edit-window-ms":
-        editWindowMs = Number.parseInt(next(), 10);
+      case "--sidecar-drain-ms":
+        sidecarDrainMs = Number.parseInt(next(), 10);
+        break;
+      case "--agent-state-dir":
+        agentStateDir = next();
         break;
       case "--out":
         outBase = resolve(next());
@@ -174,6 +230,10 @@ function parseCli(argv: readonly string[]): CliConfig {
     fail(`--agent expects "<name>:@<bot-username>"; got "${agentSpec}"`);
   }
 
+  const resolvedAgentStateDir = agentStateDir
+    ? resolve(agentStateDir)
+    : join(homedir(), ".switchroom", "agents", agentName!, "telegram");
+
   return {
     agentName: agentName!,
     botUsername: botUsername!,
@@ -181,7 +241,8 @@ function parseCli(argv: readonly string[]): CliConfig {
     limitPerSkill,
     replyTimeoutMs,
     settleMs,
-    editWindowMs,
+    sidecarDrainMs,
+    agentStateDir: resolvedAgentStateDir,
     outBase,
   };
 }
@@ -198,7 +259,8 @@ Flags:
   --limit-per-skill N       Cap probes per skill.
   --reply-timeout-ms N      Per-probe budget. Default 90000.
   --settle-ms N             Inter-probe settle. Default 6000.
-  --edit-window-ms N        Window after first reply for collecting card edits. Default 8000.
+  --sidecar-drain-ms N      Post-reply hold for the last hook write. Default 3000.
+  --agent-state-dir PATH    Override sidecar location. Default ~/.switchroom/agents/<name>/telegram.
   --out PATH                Output base path. Default tests/skill-coverage/out/skill-coverage.
 `);
 }
@@ -278,7 +340,6 @@ async function runProbe(
 ): Promise<ProbeResult> {
   const startedAt = Date.now();
   const stream = driver.observeMessages(botUserId)[Symbol.asyncIterator]();
-  const skills = new Set<string>();
   const replyTexts = new Map<number, string>();
   let sentMessageId: number;
 
@@ -301,19 +362,15 @@ async function runProbe(
     };
   }
 
+  // Bot reply is the turn-completion signal — we stop reading the
+  // stream once it lands. The sidecar-drain hold below absorbs any
+  // late hook writes after the visible reply.
   const deadline = startedAt + cfg.replyTimeoutMs;
   let firstReplyAt = 0;
   try {
     while (Date.now() < deadline) {
       const remaining = deadline - Date.now();
-      const winSize = firstReplyAt
-        ? Math.max(0, cfg.editWindowMs - (Date.now() - firstReplyAt))
-        : remaining;
-      if (firstReplyAt && winSize === 0) break;
-      const slice = await pullOneWithTimeout(
-        stream,
-        Math.min(remaining, Math.max(250, winSize)),
-      );
+      const slice = await pullOneWithTimeout(stream, Math.min(remaining, 2000));
       if (slice === "timeout") {
         if (firstReplyAt) break;
         continue;
@@ -322,9 +379,11 @@ async function runProbe(
       if (slice.messageId <= sentMessageId) continue;
       const t = (slice.text ?? "").trim();
       if (!t) continue;
-      for (const s of extractSkillsFromText(t)) skills.add(s);
       replyTexts.set(slice.messageId, t);
       if (!firstReplyAt) firstReplyAt = Date.now();
+      // First non-empty reply is enough — extra edits don't change
+      // which Skill labels landed in the sidecar.
+      break;
     }
   } finally {
     try {
@@ -334,20 +393,32 @@ async function runProbe(
     }
   }
 
-  const durationMs = Date.now() - startedAt;
   if (!firstReplyAt) {
     return {
       probe,
       skillsFired: [],
       replyText: "",
-      durationMs,
+      durationMs: Date.now() - startedAt,
       timedOut: true,
     };
   }
-  // Collapse the per-message-id reply texts into a single newline-
-  // joined blob. Most turns will have just one or two entries (the
-  // streaming reply plus the pinned card); ordering is by messageId
-  // so the card (later in the stream) appears after the reply.
+
+  // Drain window: hook writes are async to the assistant message
+  // landing. A small post-reply hold catches the last row.
+  await new Promise((res) => setTimeout(res, cfg.sidecarDrainMs));
+
+  const rows = readSkillRowsSince(
+    cfg.agentStateDir,
+    startedAt,
+    (p) => readdirSync(p),
+    (p) => readFileSync(p, "utf-8"),
+  );
+  const skills = new Set<string>();
+  for (const r of rows) {
+    const slug = extractSkillFromLabel(r.label);
+    if (slug) skills.add(slug);
+  }
+
   const replyText = [...replyTexts.entries()]
     .sort((a, b) => a[0] - b[0])
     .map(([, t]) => t)
@@ -356,7 +427,7 @@ async function runProbe(
     probe,
     skillsFired: [...skills],
     replyText,
-    durationMs,
+    durationMs: Date.now() - startedAt,
     timedOut: false,
   };
 }

--- a/tests/tool-label-pretool.test.ts
+++ b/tests/tool-label-pretool.test.ts
@@ -105,6 +105,36 @@ describe("tool-label-pretool.mjs", () => {
     expect(r.sidecarLines[0].tool_name).toBe("Read");
   });
 
+  it("Skill → 'Running skill <slug>' so the sidecar carries it for the UAT runner", () => {
+    const r = run(
+      {
+        session_id: "sess-test",
+        tool_use_id: "toolu_skill_1",
+        tool_name: "Skill",
+        tool_input: { skill: "switchroom-cli" },
+      },
+      stateDir,
+    );
+    expect(r.status).toBe(0);
+    expect(r.sidecarLines).toHaveLength(1);
+    expect(r.sidecarLines[0].label).toBe("Running skill switchroom-cli");
+    expect(r.sidecarLines[0].tool_name).toBe("Skill");
+  });
+
+  it("Skill with empty slug emits no sidecar line", () => {
+    const r = run(
+      {
+        session_id: "sess-test",
+        tool_use_id: "toolu_skill_empty",
+        tool_name: "Skill",
+        tool_input: { skill: "" },
+      },
+      stateDir,
+    );
+    expect(r.status).toBe(0);
+    expect(r.sidecarLines).toHaveLength(0);
+  });
+
   it("Edit / Write / NotebookEdit produce matching verbs", () => {
     const cases: Array<[string, Record<string, unknown>, string]> = [
       ["Edit", { file_path: "/x/foo.ts" }, "Editing foo.ts"],


### PR DESCRIPTION
## Summary

Resolves the agent-uid permissions blocker hit when trying to live-run the harness from #1216. Three coordinated changes:

1. **PreToolUse hook gains a `Skill` case** — `tool-label-pretool.mjs` now emits a `\"Running skill <slug>\"` sidecar row for every Skill invocation. The sidecar lives at `~/.switchroom/agents/<name>/telegram/tool-labels-<session>.jsonl` (mode 0644, host-readable). The progress-card path that used to surface this was retired in #1122 PR3 (`progressDriver = null`); this restores observability without resurrecting the dead pin path.
2. **MTCute UAT runner at `telegram-plugin/uat/runners/skill-coverage.ts`** — reuses the existing `telegram-plugin/uat/` driver scaffold. Per probe: send via DM → wait one bot reply (turn-end signal) → drain sidecar for 3s → scan `tool-labels-*.jsonl` for `tool_name === 'Skill'` rows with `ts >= startedAt` → extract slugs. Scores precision/recall/F1 per skill + negative-control FP rate. Emits `tests/skill-coverage/out/skill-coverage.{run.json,scorecard.json,scorecard.md}`.
3. **`Skill` added to `DEFAULT_READ_ONLY_PREAPPROVED_TOOLS`** — without this every probe would stall on an approval prompt. Skill itself just loads instruction context; side-effecting tools inside skill bodies retain their own approval gates (same model as `Task`).

## Reviewer history

Round 1 reviewer (fresh `claude -p`) returned **BLOCK** — caught that I was greping Telegram message text for skill labels that no longer reach Telegram. Round 2 reviewer reviews this commit; the deliverable is now observing the host-readable sidecar.

## Test plan

- [x] `npx vitest run tests/tool-label-pretool.test.ts` — 13/13 pass (2 new Skill cases).
- [x] `bun test telegram-plugin/uat/runners/skill-coverage.test.ts` — 8/8 pass (extractor + sidecar reader with fault injection).
- [x] `bunx tsc --noEmit` repo-wide — clean.
- [x] `npx vitest run tests/scaffold.test.ts` — 171/171 pass (Skill pre-approval doesn't break existing allowlist tests, all use `arrayContaining`).
- [ ] Live run against test-harness — requires operator to `switchroom agent restart test-harness` first (to pick up the new hook + pre-approval) then `bun telegram-plugin/uat/runners/skill-coverage.ts --agent test-harness:@<bot>`.

## Files

- `telegram-plugin/hooks/tool-label-pretool.mjs` — +14 lines
- `tests/tool-label-pretool.test.ts` — +30 lines
- `telegram-plugin/uat/runners/skill-coverage.ts` — new (~440 lines)
- `telegram-plugin/uat/runners/skill-coverage.test.ts` — new (~95 lines)
- `src/agents/scaffold.ts` — +7 lines (Skill in default allowlist)
- `docs/skill-coverage/runbook.md` — promotes MTCute path, documents sidecar mechanics

🤖 Generated with [Claude Code](https://claude.com/claude-code)