### PR TITLE
feat(skill-coverage): round-1 baseline scorecard (160 probes, 21 skills)

### DIFF
--- a/tests/skill-coverage/scorecards/baseline.run.json
+++ b/tests/skill-coverage/scorecards/baseline.run.json
@@ -1,6 +1,6 @@
 {
-  "startedAt": "2026-05-13T23:18:02.883Z",
-  "finishedAt": "2026-05-13T23:18:02.883Z",
+  "startedAt": "2026-05-13T23:27:34.485Z",
+  "finishedAt": "2026-05-13T23:27:34.485Z",
   "seed": 1,
   "agentName": "claude-cli",
   "results": [
@@ -1059,6 +1059,965 @@
       },
       "skillsInvoked": [],
       "turnDurationMs": 5101,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-82",
+        "kind": "paraphrase",
+        "targetSkill": "buildkite-secure-delivery",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 8179,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-83",
+        "kind": "paraphrase",
+        "targetSkill": "buildkite-secure-delivery",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 6685,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-84",
+        "kind": "paraphrase",
+        "targetSkill": "buildkite-secure-delivery",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 7602,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-85",
+        "kind": "paraphrase",
+        "targetSkill": "buildkite-secure-delivery",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 13074,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-86",
+        "kind": "typo",
+        "targetSkill": "buildkite-secure-delivery",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 8409,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-87",
+        "kind": "typo",
+        "targetSkill": "buildkite-secure-delivery",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 5961,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-88",
+        "kind": "paraphrase",
+        "targetSkill": "pptx",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 5438,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-89",
+        "kind": "paraphrase",
+        "targetSkill": "pptx",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 5169,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-90",
+        "kind": "paraphrase",
+        "targetSkill": "pptx",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 4710,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-91",
+        "kind": "paraphrase",
+        "targetSkill": "pptx",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 4886,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-92",
+        "kind": "paraphrase",
+        "targetSkill": "pptx",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 5368,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-93",
+        "kind": "paraphrase",
+        "targetSkill": "pptx",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 5253,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-94",
+        "kind": "typo",
+        "targetSkill": "pptx",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 6623,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-95",
+        "kind": "typo",
+        "targetSkill": "pptx",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 6272,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-96",
+        "kind": "paraphrase",
+        "targetSkill": "webapp-testing",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 7184,
+      "timedOut": true,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-97",
+        "kind": "paraphrase",
+        "targetSkill": "webapp-testing",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 8362,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-98",
+        "kind": "paraphrase",
+        "targetSkill": "webapp-testing",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 5709,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-99",
+        "kind": "paraphrase",
+        "targetSkill": "webapp-testing",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 7375,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-100",
+        "kind": "paraphrase",
+        "targetSkill": "webapp-testing",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 6475,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-101",
+        "kind": "paraphrase",
+        "targetSkill": "webapp-testing",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 7779,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-102",
+        "kind": "typo",
+        "targetSkill": "webapp-testing",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 6407,
+      "timedOut": true,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-103",
+        "kind": "typo",
+        "targetSkill": "webapp-testing",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 5679,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-104",
+        "kind": "paraphrase",
+        "targetSkill": "skill-creator",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 4325,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-105",
+        "kind": "paraphrase",
+        "targetSkill": "skill-creator",
+        "phrase": ""
+      },
+      "skillsInvoked": [
+        "skill-creator"
+      ],
+      "turnDurationMs": 11027,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-106",
+        "kind": "paraphrase",
+        "targetSkill": "skill-creator",
+        "phrase": ""
+      },
+      "skillsInvoked": [
+        "skill-creator"
+      ],
+      "turnDurationMs": 10642,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-107",
+        "kind": "paraphrase",
+        "targetSkill": "skill-creator",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 7268,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-108",
+        "kind": "paraphrase",
+        "targetSkill": "skill-creator",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 5530,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-109",
+        "kind": "paraphrase",
+        "targetSkill": "skill-creator",
+        "phrase": ""
+      },
+      "skillsInvoked": [
+        "skill-creator"
+      ],
+      "turnDurationMs": 8024,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-110",
+        "kind": "typo",
+        "targetSkill": "skill-creator",
+        "phrase": ""
+      },
+      "skillsInvoked": [
+        "skill-creator"
+      ],
+      "turnDurationMs": 11293,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-111",
+        "kind": "typo",
+        "targetSkill": "skill-creator",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 5777,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-112",
+        "kind": "paraphrase",
+        "targetSkill": "xlsx",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 4644,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-113",
+        "kind": "paraphrase",
+        "targetSkill": "xlsx",
+        "phrase": ""
+      },
+      "skillsInvoked": [
+        "xlsx"
+      ],
+      "turnDurationMs": 7789,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-114",
+        "kind": "paraphrase",
+        "targetSkill": "xlsx",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 7563,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-115",
+        "kind": "paraphrase",
+        "targetSkill": "xlsx",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 7243,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-116",
+        "kind": "paraphrase",
+        "targetSkill": "xlsx",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 4181,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-117",
+        "kind": "paraphrase",
+        "targetSkill": "xlsx",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 5742,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-118",
+        "kind": "typo",
+        "targetSkill": "xlsx",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 7779,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-119",
+        "kind": "typo",
+        "targetSkill": "xlsx",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 4661,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-120",
+        "kind": "paraphrase",
+        "targetSkill": "buildkite-agent-runtime",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 7055,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-121",
+        "kind": "paraphrase",
+        "targetSkill": "buildkite-agent-runtime",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 6300,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-122",
+        "kind": "paraphrase",
+        "targetSkill": "buildkite-agent-runtime",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 5735,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-123",
+        "kind": "paraphrase",
+        "targetSkill": "buildkite-agent-runtime",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 5627,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-124",
+        "kind": "paraphrase",
+        "targetSkill": "buildkite-agent-runtime",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 7819,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-125",
+        "kind": "paraphrase",
+        "targetSkill": "buildkite-agent-runtime",
+        "phrase": ""
+      },
+      "skillsInvoked": [
+        "buildkite-pipelines"
+      ],
+      "turnDurationMs": 13973,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-126",
+        "kind": "typo",
+        "targetSkill": "buildkite-agent-runtime",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 8991,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-127",
+        "kind": "typo",
+        "targetSkill": "buildkite-agent-runtime",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 6386,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-128",
+        "kind": "paraphrase",
+        "targetSkill": "switchroom-health",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 4701,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-129",
+        "kind": "paraphrase",
+        "targetSkill": "switchroom-health",
+        "phrase": ""
+      },
+      "skillsInvoked": [
+        "switchroom-status"
+      ],
+      "turnDurationMs": 5789,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-130",
+        "kind": "paraphrase",
+        "targetSkill": "switchroom-health",
+        "phrase": ""
+      },
+      "skillsInvoked": [
+        "switchroom-status"
+      ],
+      "turnDurationMs": 6628,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-131",
+        "kind": "paraphrase",
+        "targetSkill": "switchroom-health",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 12087,
+      "timedOut": true,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-132",
+        "kind": "paraphrase",
+        "targetSkill": "switchroom-health",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 8490,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-133",
+        "kind": "paraphrase",
+        "targetSkill": "switchroom-health",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 9464,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-134",
+        "kind": "typo",
+        "targetSkill": "switchroom-health",
+        "phrase": ""
+      },
+      "skillsInvoked": [
+        "switchroom-health",
+        "switchroom-status"
+      ],
+      "turnDurationMs": 10527,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-135",
+        "kind": "typo",
+        "targetSkill": "switchroom-health",
+        "phrase": ""
+      },
+      "skillsInvoked": [
+        "switchroom-status",
+        "switchroom-health",
+        "switchroom-cli"
+      ],
+      "turnDurationMs": 8508,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-136",
+        "kind": "paraphrase",
+        "targetSkill": "docx",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 5699,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-137",
+        "kind": "paraphrase",
+        "targetSkill": "docx",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 5041,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-138",
+        "kind": "paraphrase",
+        "targetSkill": "docx",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 4218,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-139",
+        "kind": "paraphrase",
+        "targetSkill": "docx",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 5761,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-140",
+        "kind": "paraphrase",
+        "targetSkill": "docx",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 6760,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-141",
+        "kind": "typo",
+        "targetSkill": "docx",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 8311,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-142",
+        "kind": "typo",
+        "targetSkill": "docx",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 6435,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-143",
+        "kind": "typo",
+        "targetSkill": "docx",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 5825,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-144",
+        "kind": "paraphrase",
+        "targetSkill": "humanizer",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 4651,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-145",
+        "kind": "paraphrase",
+        "targetSkill": "humanizer",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 8026,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-146",
+        "kind": "paraphrase",
+        "targetSkill": "humanizer",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 8011,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-147",
+        "kind": "paraphrase",
+        "targetSkill": "humanizer",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 5236,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-148",
+        "kind": "paraphrase",
+        "targetSkill": "humanizer",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 7801,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-149",
+        "kind": "paraphrase",
+        "targetSkill": "humanizer",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 7353,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-150",
+        "kind": "typo",
+        "targetSkill": "humanizer",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 5617,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-151",
+        "kind": "typo",
+        "targetSkill": "humanizer",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 6043,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-152",
+        "kind": "paraphrase",
+        "targetSkill": "buildkite-test-engine",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 13029,
+      "timedOut": true,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-153",
+        "kind": "paraphrase",
+        "targetSkill": "buildkite-test-engine",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 7694,
+      "timedOut": true,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-154",
+        "kind": "paraphrase",
+        "targetSkill": "buildkite-test-engine",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 5765,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-155",
+        "kind": "paraphrase",
+        "targetSkill": "buildkite-test-engine",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 7249,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-156",
+        "kind": "paraphrase",
+        "targetSkill": "buildkite-test-engine",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 6859,
+      "timedOut": true,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-157",
+        "kind": "paraphrase",
+        "targetSkill": "buildkite-test-engine",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 6574,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-158",
+        "kind": "typo",
+        "targetSkill": "buildkite-test-engine",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 6109,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-159",
+        "kind": "typo",
+        "targetSkill": "buildkite-test-engine",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 8040,
       "timedOut": false,
       "agentName": "claude-cli"
     }

--- a/tests/skill-coverage/scorecards/baseline.run.json
+++ b/tests/skill-coverage/scorecards/baseline.run.json
@@ -1,6 +1,6 @@
 {
-  "startedAt": "2026-05-13T23:10:51.025Z",
-  "finishedAt": "2026-05-13T23:10:51.025Z",
+  "startedAt": "2026-05-13T23:16:58.200Z",
+  "finishedAt": "2026-05-13T23:16:58.200Z",
   "seed": 1,
   "agentName": "claude-cli",
   "results": [
@@ -377,6 +377,584 @@
         "mcp-builder"
       ],
       "turnDurationMs": 10429,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-30",
+        "kind": "typo",
+        "targetSkill": "mcp-builder",
+        "phrase": ""
+      },
+      "skillsInvoked": [
+        "mcp-builder"
+      ],
+      "turnDurationMs": 10980,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-31",
+        "kind": "typo",
+        "targetSkill": "mcp-builder",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 5353,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-32",
+        "kind": "paraphrase",
+        "targetSkill": "switchroom-install",
+        "phrase": ""
+      },
+      "skillsInvoked": [
+        "switchroom-architecture"
+      ],
+      "turnDurationMs": 12117,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-33",
+        "kind": "paraphrase",
+        "targetSkill": "switchroom-install",
+        "phrase": ""
+      },
+      "skillsInvoked": [
+        "switchroom-install"
+      ],
+      "turnDurationMs": 10117,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-34",
+        "kind": "paraphrase",
+        "targetSkill": "switchroom-install",
+        "phrase": ""
+      },
+      "skillsInvoked": [
+        "switchroom-install"
+      ],
+      "turnDurationMs": 10624,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-35",
+        "kind": "paraphrase",
+        "targetSkill": "switchroom-install",
+        "phrase": ""
+      },
+      "skillsInvoked": [
+        "switchroom-install"
+      ],
+      "turnDurationMs": 10488,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-36",
+        "kind": "paraphrase",
+        "targetSkill": "switchroom-install",
+        "phrase": ""
+      },
+      "skillsInvoked": [
+        "switchroom-install"
+      ],
+      "turnDurationMs": 9643,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-37",
+        "kind": "paraphrase",
+        "targetSkill": "switchroom-install",
+        "phrase": ""
+      },
+      "skillsInvoked": [
+        "switchroom-install"
+      ],
+      "turnDurationMs": 8413,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-38",
+        "kind": "typo",
+        "targetSkill": "switchroom-install",
+        "phrase": ""
+      },
+      "skillsInvoked": [
+        "switchroom-install"
+      ],
+      "turnDurationMs": 8922,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-39",
+        "kind": "typo",
+        "targetSkill": "switchroom-install",
+        "phrase": ""
+      },
+      "skillsInvoked": [
+        "switchroom-install"
+      ],
+      "turnDurationMs": 11246,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-40",
+        "kind": "paraphrase",
+        "targetSkill": "buildkite-api",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 8169,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-41",
+        "kind": "paraphrase",
+        "targetSkill": "buildkite-api",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 7174,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-42",
+        "kind": "paraphrase",
+        "targetSkill": "buildkite-api",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 7715,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-43",
+        "kind": "paraphrase",
+        "targetSkill": "buildkite-api",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 7143,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-44",
+        "kind": "paraphrase",
+        "targetSkill": "buildkite-api",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 9871,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-45",
+        "kind": "typo",
+        "targetSkill": "buildkite-api",
+        "phrase": ""
+      },
+      "skillsInvoked": [
+        "buildkite-api"
+      ],
+      "turnDurationMs": 10834,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-46",
+        "kind": "typo",
+        "targetSkill": "buildkite-api",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 5750,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-47",
+        "kind": "typo",
+        "targetSkill": "buildkite-api",
+        "phrase": ""
+      },
+      "skillsInvoked": [
+        "buildkite-api"
+      ],
+      "turnDurationMs": 10328,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-48",
+        "kind": "paraphrase",
+        "targetSkill": "file-bug",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 5464,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-49",
+        "kind": "paraphrase",
+        "targetSkill": "file-bug",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 7022,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-50",
+        "kind": "paraphrase",
+        "targetSkill": "file-bug",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 5319,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-51",
+        "kind": "paraphrase",
+        "targetSkill": "file-bug",
+        "phrase": ""
+      },
+      "skillsInvoked": [
+        "file-bug"
+      ],
+      "turnDurationMs": 5267,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-52",
+        "kind": "paraphrase",
+        "targetSkill": "file-bug",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 5226,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-53",
+        "kind": "paraphrase",
+        "targetSkill": "file-bug",
+        "phrase": ""
+      },
+      "skillsInvoked": [
+        "file-bug"
+      ],
+      "turnDurationMs": 6352,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-54",
+        "kind": "typo",
+        "targetSkill": "file-bug",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 5584,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-55",
+        "kind": "typo",
+        "targetSkill": "file-bug",
+        "phrase": ""
+      },
+      "skillsInvoked": [
+        "file-bug"
+      ],
+      "turnDurationMs": 6817,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-56",
+        "kind": "paraphrase",
+        "targetSkill": "switchroom-status",
+        "phrase": ""
+      },
+      "skillsInvoked": [
+        "switchroom-status"
+      ],
+      "turnDurationMs": 6902,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-57",
+        "kind": "paraphrase",
+        "targetSkill": "switchroom-status",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 6930,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-58",
+        "kind": "paraphrase",
+        "targetSkill": "switchroom-status",
+        "phrase": ""
+      },
+      "skillsInvoked": [
+        "switchroom-status"
+      ],
+      "turnDurationMs": 8799,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-59",
+        "kind": "paraphrase",
+        "targetSkill": "switchroom-status",
+        "phrase": ""
+      },
+      "skillsInvoked": [
+        "switchroom-status"
+      ],
+      "turnDurationMs": 7289,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-60",
+        "kind": "paraphrase",
+        "targetSkill": "switchroom-status",
+        "phrase": ""
+      },
+      "skillsInvoked": [
+        "switchroom-status"
+      ],
+      "turnDurationMs": 7434,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-61",
+        "kind": "paraphrase",
+        "targetSkill": "switchroom-status",
+        "phrase": ""
+      },
+      "skillsInvoked": [
+        "switchroom-status"
+      ],
+      "turnDurationMs": 8254,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-62",
+        "kind": "typo",
+        "targetSkill": "switchroom-status",
+        "phrase": ""
+      },
+      "skillsInvoked": [
+        "switchroom-status"
+      ],
+      "turnDurationMs": 7239,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-63",
+        "kind": "typo",
+        "targetSkill": "switchroom-status",
+        "phrase": ""
+      },
+      "skillsInvoked": [
+        "switchroom-status"
+      ],
+      "turnDurationMs": 7883,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-64",
+        "kind": "paraphrase",
+        "targetSkill": "buildkite-pipelines",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 5873,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-65",
+        "kind": "paraphrase",
+        "targetSkill": "buildkite-pipelines",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 6390,
+      "timedOut": true,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-66",
+        "kind": "paraphrase",
+        "targetSkill": "buildkite-pipelines",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 5554,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-67",
+        "kind": "paraphrase",
+        "targetSkill": "buildkite-pipelines",
+        "phrase": ""
+      },
+      "skillsInvoked": [
+        "buildkite-pipelines"
+      ],
+      "turnDurationMs": 9929,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-68",
+        "kind": "paraphrase",
+        "targetSkill": "buildkite-pipelines",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 11988,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-69",
+        "kind": "paraphrase",
+        "targetSkill": "buildkite-pipelines",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 7473,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-70",
+        "kind": "typo",
+        "targetSkill": "buildkite-pipelines",
+        "phrase": ""
+      },
+      "skillsInvoked": [
+        "buildkite-pipelines"
+      ],
+      "turnDurationMs": 15250,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-71",
+        "kind": "typo",
+        "targetSkill": "buildkite-pipelines",
+        "phrase": ""
+      },
+      "skillsInvoked": [
+        "buildkite-pipelines"
+      ],
+      "turnDurationMs": 10365,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-72",
+        "kind": "paraphrase",
+        "targetSkill": "switchroom-manage",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 6632,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-73",
+        "kind": "paraphrase",
+        "targetSkill": "switchroom-manage",
+        "phrase": ""
+      },
+      "skillsInvoked": [
+        "switchroom-status"
+      ],
+      "turnDurationMs": 12850,
       "timedOut": false,
       "agentName": "claude-cli"
     }

--- a/tests/skill-coverage/scorecards/baseline.run.json
+++ b/tests/skill-coverage/scorecards/baseline.run.json
@@ -1,6 +1,6 @@
 {
-  "startedAt": "2026-05-13T23:16:58.200Z",
-  "finishedAt": "2026-05-13T23:16:58.200Z",
+  "startedAt": "2026-05-13T23:18:02.883Z",
+  "finishedAt": "2026-05-13T23:18:02.883Z",
   "seed": 1,
   "agentName": "claude-cli",
   "results": [
@@ -955,6 +955,110 @@
         "switchroom-status"
       ],
       "turnDurationMs": 12850,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-74",
+        "kind": "paraphrase",
+        "targetSkill": "switchroom-manage",
+        "phrase": ""
+      },
+      "skillsInvoked": [
+        "switchroom-status"
+      ],
+      "turnDurationMs": 7753,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-75",
+        "kind": "paraphrase",
+        "targetSkill": "switchroom-manage",
+        "phrase": ""
+      },
+      "skillsInvoked": [
+        "switchroom-install"
+      ],
+      "turnDurationMs": 9724,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-76",
+        "kind": "paraphrase",
+        "targetSkill": "switchroom-manage",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 8581,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-77",
+        "kind": "paraphrase",
+        "targetSkill": "switchroom-manage",
+        "phrase": ""
+      },
+      "skillsInvoked": [
+        "switchroom-status"
+      ],
+      "turnDurationMs": 8640,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-78",
+        "kind": "typo",
+        "targetSkill": "switchroom-manage",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 5998,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-79",
+        "kind": "typo",
+        "targetSkill": "switchroom-manage",
+        "phrase": ""
+      },
+      "skillsInvoked": [
+        "switchroom-install"
+      ],
+      "turnDurationMs": 9669,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-80",
+        "kind": "paraphrase",
+        "targetSkill": "buildkite-secure-delivery",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 8077,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-81",
+        "kind": "paraphrase",
+        "targetSkill": "buildkite-secure-delivery",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 5101,
       "timedOut": false,
       "agentName": "claude-cli"
     }

--- a/tests/skill-coverage/scorecards/baseline.scorecard.json
+++ b/tests/skill-coverage/scorecards/baseline.scorecard.json
@@ -1,8 +1,20 @@
 {
-  "generatedAt": "2026-05-13T23:18:02.884Z",
+  "generatedAt": "2026-05-13T23:27:34.486Z",
   "seed": 1,
-  "totalProbes": 82,
+  "totalProbes": 160,
   "rows": [
+    {
+      "skill": "buildkite-agent-runtime",
+      "sampleSize": 8,
+      "truePositives": 0,
+      "falseNegatives": 8,
+      "falsePositives": 0,
+      "precision": 0,
+      "recall": 0,
+      "f1": 0,
+      "execSuccess": 0,
+      "negativeControlFpRate": 0
+    },
     {
       "skill": "buildkite-api",
       "sampleSize": 8,
@@ -32,18 +44,42 @@
       "sampleSize": 8,
       "truePositives": 3,
       "falseNegatives": 5,
-      "falsePositives": 3,
-      "precision": 0.5,
+      "falsePositives": 4,
+      "precision": 0.42857142857142855,
       "recall": 0.375,
-      "f1": 0.42857142857142855,
+      "f1": 0.39999999999999997,
       "execSuccess": 1,
       "negativeControlFpRate": 0.25
     },
     {
       "skill": "buildkite-secure-delivery",
-      "sampleSize": 2,
+      "sampleSize": 8,
       "truePositives": 0,
-      "falseNegatives": 2,
+      "falseNegatives": 8,
+      "falsePositives": 0,
+      "precision": 0,
+      "recall": 0,
+      "f1": 0,
+      "execSuccess": 0,
+      "negativeControlFpRate": 0
+    },
+    {
+      "skill": "buildkite-test-engine",
+      "sampleSize": 8,
+      "truePositives": 0,
+      "falseNegatives": 8,
+      "falsePositives": 0,
+      "precision": 0,
+      "recall": 0,
+      "f1": 0,
+      "execSuccess": 0,
+      "negativeControlFpRate": 0
+    },
+    {
+      "skill": "docx",
+      "sampleSize": 8,
+      "truePositives": 0,
+      "falseNegatives": 8,
       "falsePositives": 0,
       "precision": 0,
       "recall": 0,
@@ -64,6 +100,18 @@
       "negativeControlFpRate": 0.125
     },
     {
+      "skill": "humanizer",
+      "sampleSize": 8,
+      "truePositives": 0,
+      "falseNegatives": 8,
+      "falsePositives": 0,
+      "precision": 0,
+      "recall": 0,
+      "f1": 0,
+      "execSuccess": 0,
+      "negativeControlFpRate": 0
+    },
+    {
       "skill": "mcp-builder",
       "sampleSize": 8,
       "truePositives": 3,
@@ -72,6 +120,30 @@
       "precision": 1,
       "recall": 0.375,
       "f1": 0.5454545454545454,
+      "execSuccess": 1,
+      "negativeControlFpRate": 0
+    },
+    {
+      "skill": "pptx",
+      "sampleSize": 8,
+      "truePositives": 0,
+      "falseNegatives": 8,
+      "falsePositives": 0,
+      "precision": 0,
+      "recall": 0,
+      "f1": 0,
+      "execSuccess": 0,
+      "negativeControlFpRate": 0
+    },
+    {
+      "skill": "skill-creator",
+      "sampleSize": 8,
+      "truePositives": 4,
+      "falseNegatives": 4,
+      "falsePositives": 0,
+      "precision": 1,
+      "recall": 0.5,
+      "f1": 0.6666666666666666,
       "execSuccess": 1,
       "negativeControlFpRate": 0
     },
@@ -85,6 +157,30 @@
       "recall": 0,
       "f1": 0,
       "execSuccess": 0,
+      "negativeControlFpRate": 0
+    },
+    {
+      "skill": "switchroom-cli",
+      "sampleSize": 0,
+      "truePositives": 0,
+      "falseNegatives": 0,
+      "falsePositives": 1,
+      "precision": 0,
+      "recall": 0,
+      "f1": 0,
+      "execSuccess": 0,
+      "negativeControlFpRate": 0
+    },
+    {
+      "skill": "switchroom-health",
+      "sampleSize": 8,
+      "truePositives": 2,
+      "falseNegatives": 6,
+      "falsePositives": 0,
+      "precision": 1,
+      "recall": 0.25,
+      "f1": 0.4,
+      "execSuccess": 1,
       "negativeControlFpRate": 0
     },
     {
@@ -128,18 +224,42 @@
       "sampleSize": 8,
       "truePositives": 7,
       "falseNegatives": 1,
-      "falsePositives": 3,
-      "precision": 0.7,
+      "falsePositives": 7,
+      "precision": 0.5,
       "recall": 0.875,
-      "f1": 0.7777777777777777,
+      "f1": 0.6363636363636364,
+      "execSuccess": 1,
+      "negativeControlFpRate": 0
+    },
+    {
+      "skill": "webapp-testing",
+      "sampleSize": 8,
+      "truePositives": 0,
+      "falseNegatives": 8,
+      "falsePositives": 0,
+      "precision": 0,
+      "recall": 0,
+      "f1": 0,
+      "execSuccess": 0,
+      "negativeControlFpRate": 0
+    },
+    {
+      "skill": "xlsx",
+      "sampleSize": 8,
+      "truePositives": 1,
+      "falseNegatives": 7,
+      "falsePositives": 0,
+      "precision": 1,
+      "recall": 0.125,
+      "f1": 0.2222222222222222,
       "execSuccess": 1,
       "negativeControlFpRate": 0
     }
   ],
   "aggregate": {
-    "medianF1": 0.39610389610389607,
-    "skillsBelowF1Threshold": 10,
-    "skillsBelowExecThreshold": 3,
+    "medianF1": 0.2222222222222222,
+    "skillsBelowF1Threshold": 19,
+    "skillsBelowExecThreshold": 9,
     "f1Threshold": 0.9,
     "execThreshold": 0.95
   }

--- a/tests/skill-coverage/scorecards/baseline.scorecard.json
+++ b/tests/skill-coverage/scorecards/baseline.scorecard.json
@@ -1,18 +1,18 @@
 {
-  "generatedAt": "2026-05-13T23:10:51.025Z",
+  "generatedAt": "2026-05-13T23:16:58.201Z",
   "seed": 1,
-  "totalProbes": 30,
+  "totalProbes": 74,
   "rows": [
     {
       "skill": "buildkite-api",
-      "sampleSize": 0,
-      "truePositives": 0,
-      "falseNegatives": 0,
+      "sampleSize": 8,
+      "truePositives": 2,
+      "falseNegatives": 6,
       "falsePositives": 1,
-      "precision": 0,
-      "recall": 0,
-      "f1": 0,
-      "execSuccess": 0,
+      "precision": 0.6666666666666666,
+      "recall": 0.25,
+      "f1": 0.36363636363636365,
+      "execSuccess": 1,
       "negativeControlFpRate": 0.125
     },
     {
@@ -29,18 +29,42 @@
     },
     {
       "skill": "buildkite-pipelines",
-      "sampleSize": 0,
-      "truePositives": 0,
-      "falseNegatives": 0,
+      "sampleSize": 8,
+      "truePositives": 3,
+      "falseNegatives": 5,
       "falsePositives": 3,
-      "precision": 0,
-      "recall": 0,
-      "f1": 0,
-      "execSuccess": 0,
+      "precision": 0.5,
+      "recall": 0.375,
+      "f1": 0.42857142857142855,
+      "execSuccess": 1,
       "negativeControlFpRate": 0.25
     },
     {
       "skill": "file-bug",
+      "sampleSize": 8,
+      "truePositives": 3,
+      "falseNegatives": 5,
+      "falsePositives": 1,
+      "precision": 0.75,
+      "recall": 0.375,
+      "f1": 0.5,
+      "execSuccess": 1,
+      "negativeControlFpRate": 0.125
+    },
+    {
+      "skill": "mcp-builder",
+      "sampleSize": 8,
+      "truePositives": 3,
+      "falseNegatives": 5,
+      "falsePositives": 0,
+      "precision": 1,
+      "recall": 0.375,
+      "f1": 0.5454545454545454,
+      "execSuccess": 1,
+      "negativeControlFpRate": 0
+    },
+    {
+      "skill": "switchroom-architecture",
       "sampleSize": 0,
       "truePositives": 0,
       "falseNegatives": 0,
@@ -49,18 +73,30 @@
       "recall": 0,
       "f1": 0,
       "execSuccess": 0,
-      "negativeControlFpRate": 0.125
+      "negativeControlFpRate": 0
     },
     {
-      "skill": "mcp-builder",
-      "sampleSize": 6,
-      "truePositives": 2,
-      "falseNegatives": 4,
+      "skill": "switchroom-install",
+      "sampleSize": 8,
+      "truePositives": 7,
+      "falseNegatives": 1,
       "falsePositives": 0,
       "precision": 1,
-      "recall": 0.3333333333333333,
-      "f1": 0.5,
+      "recall": 0.875,
+      "f1": 0.9333333333333333,
       "execSuccess": 1,
+      "negativeControlFpRate": 0
+    },
+    {
+      "skill": "switchroom-manage",
+      "sampleSize": 2,
+      "truePositives": 0,
+      "falseNegatives": 2,
+      "falsePositives": 0,
+      "precision": 0,
+      "recall": 0,
+      "f1": 0,
+      "execSuccess": 0,
       "negativeControlFpRate": 0
     },
     {
@@ -74,12 +110,24 @@
       "f1": 0.2222222222222222,
       "execSuccess": 1,
       "negativeControlFpRate": 0
+    },
+    {
+      "skill": "switchroom-status",
+      "sampleSize": 8,
+      "truePositives": 7,
+      "falseNegatives": 1,
+      "falsePositives": 1,
+      "precision": 0.875,
+      "recall": 0.875,
+      "f1": 0.875,
+      "execSuccess": 1,
+      "negativeControlFpRate": 0
     }
   ],
   "aggregate": {
-    "medianF1": 0.2222222222222222,
-    "skillsBelowF1Threshold": 3,
-    "skillsBelowExecThreshold": 1,
+    "medianF1": 0.42857142857142855,
+    "skillsBelowF1Threshold": 8,
+    "skillsBelowExecThreshold": 2,
     "f1Threshold": 0.9,
     "execThreshold": 0.95
   }

--- a/tests/skill-coverage/scorecards/baseline.scorecard.json
+++ b/tests/skill-coverage/scorecards/baseline.scorecard.json
@@ -1,7 +1,7 @@
 {
-  "generatedAt": "2026-05-13T23:16:58.201Z",
+  "generatedAt": "2026-05-13T23:18:02.884Z",
   "seed": 1,
-  "totalProbes": 74,
+  "totalProbes": 82,
   "rows": [
     {
       "skill": "buildkite-api",
@@ -38,6 +38,18 @@
       "f1": 0.42857142857142855,
       "execSuccess": 1,
       "negativeControlFpRate": 0.25
+    },
+    {
+      "skill": "buildkite-secure-delivery",
+      "sampleSize": 2,
+      "truePositives": 0,
+      "falseNegatives": 2,
+      "falsePositives": 0,
+      "precision": 0,
+      "recall": 0,
+      "f1": 0,
+      "execSuccess": 0,
+      "negativeControlFpRate": 0
     },
     {
       "skill": "file-bug",
@@ -80,18 +92,18 @@
       "sampleSize": 8,
       "truePositives": 7,
       "falseNegatives": 1,
-      "falsePositives": 0,
-      "precision": 1,
+      "falsePositives": 2,
+      "precision": 0.7777777777777778,
       "recall": 0.875,
-      "f1": 0.9333333333333333,
+      "f1": 0.823529411764706,
       "execSuccess": 1,
       "negativeControlFpRate": 0
     },
     {
       "skill": "switchroom-manage",
-      "sampleSize": 2,
+      "sampleSize": 8,
       "truePositives": 0,
-      "falseNegatives": 2,
+      "falseNegatives": 8,
       "falsePositives": 0,
       "precision": 0,
       "recall": 0,
@@ -116,18 +128,18 @@
       "sampleSize": 8,
       "truePositives": 7,
       "falseNegatives": 1,
-      "falsePositives": 1,
-      "precision": 0.875,
+      "falsePositives": 3,
+      "precision": 0.7,
       "recall": 0.875,
-      "f1": 0.875,
+      "f1": 0.7777777777777777,
       "execSuccess": 1,
       "negativeControlFpRate": 0
     }
   ],
   "aggregate": {
-    "medianF1": 0.42857142857142855,
-    "skillsBelowF1Threshold": 8,
-    "skillsBelowExecThreshold": 2,
+    "medianF1": 0.39610389610389607,
+    "skillsBelowF1Threshold": 10,
+    "skillsBelowExecThreshold": 3,
     "f1Threshold": 0.9,
     "execThreshold": 0.95
   }

--- a/tests/skill-coverage/scorecards/baseline.scorecard.md
+++ b/tests/skill-coverage/scorecards/baseline.scorecard.md
@@ -1,22 +1,32 @@
 # Skill coverage scorecard
 
-- generated: 2026-05-13T23:18:02.884Z
+- generated: 2026-05-13T23:27:34.486Z
 - seed: 1
-- total probes: 82
-- median F1 (among targeted skills): 0.40
-- skills below F1 0.90: **10**
-- skills below exec 0.95: **3**
+- total probes: 160
+- median F1 (among targeted skills): 0.22
+- skills below F1 0.90: **19**
+- skills below exec 0.95: **9**
 
 | skill | n | TP | FN | FP | precision | recall | F1 | exec | neg-FP |
 |---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
+| buildkite-agent-runtime | 8 | 0 | 8 | 0 | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 |
 | buildkite-api | 8 | 2 | 6 | 1 | 0.67 | 0.25 | 0.36 | 1.00 | 0.13 |
 | buildkite-cli | 8 | 0 | 8 | 0 | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 |
-| buildkite-pipelines | 8 | 3 | 5 | 3 | 0.50 | 0.38 | 0.43 | 1.00 | 0.25 |
-| buildkite-secure-delivery | 2 | 0 | 2 | 0 | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 |
+| buildkite-pipelines | 8 | 3 | 5 | 4 | 0.43 | 0.38 | 0.40 | 1.00 | 0.25 |
+| buildkite-secure-delivery | 8 | 0 | 8 | 0 | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 |
+| buildkite-test-engine | 8 | 0 | 8 | 0 | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 |
+| docx | 8 | 0 | 8 | 0 | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 |
 | file-bug | 8 | 3 | 5 | 1 | 0.75 | 0.38 | 0.50 | 1.00 | 0.13 |
+| humanizer | 8 | 0 | 8 | 0 | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 |
 | mcp-builder | 8 | 3 | 5 | 0 | 1.00 | 0.38 | 0.55 | 1.00 | 0.00 |
+| pptx | 8 | 0 | 8 | 0 | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 |
+| skill-creator | 8 | 4 | 4 | 0 | 1.00 | 0.50 | 0.67 | 1.00 | 0.00 |
 | switchroom-architecture | 0 | 0 | 0 | 1 | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 |
+| switchroom-cli | 0 | 0 | 0 | 1 | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 |
+| switchroom-health | 8 | 2 | 6 | 0 | 1.00 | 0.25 | 0.40 | 1.00 | 0.00 |
 | switchroom-install | 8 | 7 | 1 | 2 | 0.78 | 0.88 | 0.82 | 1.00 | 0.00 |
 | switchroom-manage | 8 | 0 | 8 | 0 | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 |
 | switchroom-runtime | 8 | 1 | 7 | 0 | 1.00 | 0.13 | 0.22 | 1.00 | 0.00 |
-| switchroom-status | 8 | 7 | 1 | 3 | 0.70 | 0.88 | 0.78 | 1.00 | 0.00 |
+| switchroom-status | 8 | 7 | 1 | 7 | 0.50 | 0.88 | 0.64 | 1.00 | 0.00 |
+| webapp-testing | 8 | 0 | 8 | 0 | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 |
+| xlsx | 8 | 1 | 7 | 0 | 1.00 | 0.13 | 0.22 | 1.00 | 0.00 |

--- a/tests/skill-coverage/scorecards/baseline.scorecard.md
+++ b/tests/skill-coverage/scorecards/baseline.scorecard.md
@@ -1,17 +1,21 @@
 # Skill coverage scorecard
 
-- generated: 2026-05-13T23:10:51.025Z
+- generated: 2026-05-13T23:16:58.201Z
 - seed: 1
-- total probes: 30
-- median F1 (among targeted skills): 0.22
-- skills below F1 0.90: **3**
-- skills below exec 0.95: **1**
+- total probes: 74
+- median F1 (among targeted skills): 0.43
+- skills below F1 0.90: **8**
+- skills below exec 0.95: **2**
 
 | skill | n | TP | FN | FP | precision | recall | F1 | exec | neg-FP |
 |---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
-| buildkite-api | 0 | 0 | 0 | 1 | 0.00 | 0.00 | 0.00 | 0.00 | 0.13 |
+| buildkite-api | 8 | 2 | 6 | 1 | 0.67 | 0.25 | 0.36 | 1.00 | 0.13 |
 | buildkite-cli | 8 | 0 | 8 | 0 | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 |
-| buildkite-pipelines | 0 | 0 | 0 | 3 | 0.00 | 0.00 | 0.00 | 0.00 | 0.25 |
-| file-bug | 0 | 0 | 0 | 1 | 0.00 | 0.00 | 0.00 | 0.00 | 0.13 |
-| mcp-builder | 6 | 2 | 4 | 0 | 1.00 | 0.33 | 0.50 | 1.00 | 0.00 |
+| buildkite-pipelines | 8 | 3 | 5 | 3 | 0.50 | 0.38 | 0.43 | 1.00 | 0.25 |
+| file-bug | 8 | 3 | 5 | 1 | 0.75 | 0.38 | 0.50 | 1.00 | 0.13 |
+| mcp-builder | 8 | 3 | 5 | 0 | 1.00 | 0.38 | 0.55 | 1.00 | 0.00 |
+| switchroom-architecture | 0 | 0 | 0 | 1 | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 |
+| switchroom-install | 8 | 7 | 1 | 0 | 1.00 | 0.88 | 0.93 | 1.00 | 0.00 |
+| switchroom-manage | 2 | 0 | 2 | 0 | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 |
 | switchroom-runtime | 8 | 1 | 7 | 0 | 1.00 | 0.13 | 0.22 | 1.00 | 0.00 |
+| switchroom-status | 8 | 7 | 1 | 1 | 0.88 | 0.88 | 0.88 | 1.00 | 0.00 |

--- a/tests/skill-coverage/scorecards/baseline.scorecard.md
+++ b/tests/skill-coverage/scorecards/baseline.scorecard.md
@@ -1,21 +1,22 @@
 # Skill coverage scorecard
 
-- generated: 2026-05-13T23:16:58.201Z
+- generated: 2026-05-13T23:18:02.884Z
 - seed: 1
-- total probes: 74
-- median F1 (among targeted skills): 0.43
-- skills below F1 0.90: **8**
-- skills below exec 0.95: **2**
+- total probes: 82
+- median F1 (among targeted skills): 0.40
+- skills below F1 0.90: **10**
+- skills below exec 0.95: **3**
 
 | skill | n | TP | FN | FP | precision | recall | F1 | exec | neg-FP |
 |---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
 | buildkite-api | 8 | 2 | 6 | 1 | 0.67 | 0.25 | 0.36 | 1.00 | 0.13 |
 | buildkite-cli | 8 | 0 | 8 | 0 | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 |
 | buildkite-pipelines | 8 | 3 | 5 | 3 | 0.50 | 0.38 | 0.43 | 1.00 | 0.25 |
+| buildkite-secure-delivery | 2 | 0 | 2 | 0 | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 |
 | file-bug | 8 | 3 | 5 | 1 | 0.75 | 0.38 | 0.50 | 1.00 | 0.13 |
 | mcp-builder | 8 | 3 | 5 | 0 | 1.00 | 0.38 | 0.55 | 1.00 | 0.00 |
 | switchroom-architecture | 0 | 0 | 0 | 1 | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 |
-| switchroom-install | 8 | 7 | 1 | 0 | 1.00 | 0.88 | 0.93 | 1.00 | 0.00 |
-| switchroom-manage | 2 | 0 | 2 | 0 | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 |
+| switchroom-install | 8 | 7 | 1 | 2 | 0.78 | 0.88 | 0.82 | 1.00 | 0.00 |
+| switchroom-manage | 8 | 0 | 8 | 0 | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 |
 | switchroom-runtime | 8 | 1 | 7 | 0 | 1.00 | 0.13 | 0.22 | 1.00 | 0.00 |
-| switchroom-status | 8 | 7 | 1 | 1 | 0.88 | 0.88 | 0.88 | 1.00 | 0.00 |
+| switchroom-status | 8 | 7 | 1 | 3 | 0.70 | 0.88 | 0.78 | 1.00 | 0.00 |


### PR DESCRIPTION
## Summary

Round-1 baseline scorecard with 160 probes across 21 in-scope skills, frozen at user direction. Captures the descriptions as they stood after #1217 but BEFORE #1222 round-2 rewrites — sets the bar against which round-2 delta is measured.

## Results

- Total probes: 160 (early stop from a 208-probe slice)
- Skills sampled: 21
- Median F1: 0.22
- Below F1 ≥ 0.9: **19**
- Below exec ≥ 0.95: **9**

Major gaps (F1 = 0.00 on 8 probes each):
`buildkite-agent-runtime`, `buildkite-cli`, `buildkite-secure-delivery`, `buildkite-test-engine`, `docx`, `humanizer`, `pptx`, `switchroom-manage`, `webapp-testing`.

Near-threshold:
- `switchroom-install`: F1 = 0.82
- `switchroom-status`: F1 = 0.64 (precision drag from FPs)

## What's NOT in this PR

- A round-2 scorecard measuring the impact of #1222's description rewrites — that comes in the next PR (round-2 run is starting).
- A scorecard satisfying the "every skill at ≥0.9 F1" threshold — multiple rounds of description rewrites + corpus refinement are needed to get there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)