### PR TITLE
docs(rfcs): renumber gdrive-mcp from RFC C → RFC D; mark Implemented

### DIFF
--- a/docs/rfcs/approval-kernel.md
+++ b/docs/rfcs/approval-kernel.md
@@ -276,13 +276,13 @@ The vault broker is request/response. Approvals can wait up to 5 minutes for a t
 
 **Phase 2 — secrets as first consumer.** Migrate the deferred-secret card path (`gateway.ts:5555`) to call the kernel. Lower-traffic, validates the abstraction. Preserve the inline-passphrase capture UX. ~0.5 day.
 
-**Phase 3 — first MCP consumer (Google Drive).** Covered separately in **RFC C — Google Drive MCP integration**.
+**Phase 3 — first MCP consumer (Google Drive).** Covered separately in **RFC D — Google Drive MCP integration** (originally drafted as "RFC C", renumbered after `host-control-daemon.md` took the C slot).
 
 ## 13. Estimated effort
 
 RFC B Phase 1 + Phase 2: **~2 days.**
 
-Combined with RFC A (~0.5d) and RFC C (~1d): **~3.5 days total** across the three RFCs.
+Combined with RFC A (~0.5d) and RFC D (~1d): **~3.5 days total** across the three RFCs.
 
 ## 14. Out of scope
 

--- a/docs/rfcs/gdrive-mcp.md
+++ b/docs/rfcs/gdrive-mcp.md
@@ -1,10 +1,18 @@
-# RFC C: Google Drive MCP integration
+# RFC D: Google Drive MCP integration
 
-Status: Draft v2
+Status: **Implemented in v0.6.0** (2026-05-06). Originally drafted as "RFC C" — renumbered to D after `host-control-daemon.md` claimed the C slot in v0.7.x. This document is retained as the design record; the implementation is the source of truth.
 Author: klanker (sub-agent draft)
 Date: 2026-05-06
 
-Prerequisite: **RFC B — Approval kernel** (`docs/rfcs/approval-kernel.md`) must be in place. The Drive MCP is the first real consumer.
+Prerequisite: **RFC B — Approval kernel** (`docs/rfcs/approval-kernel.md`) — landed in v0.6.0 (#762). The Drive MCP is the first real consumer.
+
+## Implementation pointers
+
+- Code: `src/drive/{oauth,vault-slots,onboarding,disconnect,reconciler,grants,wrapper}.ts` (+ co-located tests).
+- CLI: `src/cli/drive.ts` (`switchroom drive connect|disconnect`).
+- Config: `drive:` block (top-level + per-agent), schema in `src/config/schema.ts` (#768).
+- Landing PRs: #763 (full integration), #766 (CLI), #767 (desktop-loopback OAuth tier), #768 (`drive:` config block).
+- Still deferred (no tracking issue yet): folder picker UI (§6), Drive write operations (§12 out-of-scope; needs `doc:gdrive:write:*` scope namespace).
 
 ## 1. Summary
 


### PR DESCRIPTION
## Summary

- Resolves the "RFC C" name collision between `docs/rfcs/gdrive-mcp.md` (drafted 2026-05-06) and `docs/rfcs/host-control-daemon.md` (drafted 2026-05-13). CLAUDE.md and project memory both treat host-control-daemon as the canonical "RFC C", so gdrive moves to **RFC D**.
- Flips gdrive-mcp's Status from `Draft v2` → `Implemented in v0.6.0` — the integration shipped end-to-end via #762, #763, #766, #767, #768.
- Adds a brief "Implementation pointers" preamble linking the design doc to the live code: `src/drive/{oauth,vault-slots,onboarding,disconnect,reconciler,grants,wrapper}.ts`, `src/cli/drive.ts`, and the `drive:` block in `src/config/schema.ts`.
- Updates the cross-reference in `approval-kernel.md` §12 Phase 3 + §13 effort line to match.

No code changes. CHANGELOG history left untouched (it's a historical record of when "RFC C" was the gdrive name).

## Test plan

- [x] `grep -n "RFC C" docs/rfcs/gdrive-mcp.md docs/rfcs/approval-kernel.md` — only intentional historical-context references remain
- [x] All nine implementation-pointer paths exist on disk
- [x] No internal anchor links (`#rfc-c`) broken — none existed
- [x] Reviewed by an independent fresh-context reviewer (verdict: APPROVE)

🤖 Generated with [Claude Code](https://claude.com/claude-code)