### PR TITLE
feat(skill-coverage): round-3 scorecard (104 probes, 25 skills, 3 hit threshold)

### DIFF
--- a/tests/skill-coverage/scorecards/baseline.run.json
+++ b/tests/skill-coverage/scorecards/baseline.run.json
@@ -1,6 +1,6 @@
 {
-  "startedAt": "2026-05-13T23:18:02.883Z",
-  "finishedAt": "2026-05-13T23:18:02.883Z",
+  "startedAt": "2026-05-13T23:27:34.485Z",
+  "finishedAt": "2026-05-13T23:27:34.485Z",
   "seed": 1,
   "agentName": "claude-cli",
   "results": [
@@ -1059,6 +1059,965 @@
       },
       "skillsInvoked": [],
       "turnDurationMs": 5101,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-82",
+        "kind": "paraphrase",
+        "targetSkill": "buildkite-secure-delivery",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 8179,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-83",
+        "kind": "paraphrase",
+        "targetSkill": "buildkite-secure-delivery",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 6685,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-84",
+        "kind": "paraphrase",
+        "targetSkill": "buildkite-secure-delivery",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 7602,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-85",
+        "kind": "paraphrase",
+        "targetSkill": "buildkite-secure-delivery",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 13074,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-86",
+        "kind": "typo",
+        "targetSkill": "buildkite-secure-delivery",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 8409,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-87",
+        "kind": "typo",
+        "targetSkill": "buildkite-secure-delivery",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 5961,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-88",
+        "kind": "paraphrase",
+        "targetSkill": "pptx",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 5438,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-89",
+        "kind": "paraphrase",
+        "targetSkill": "pptx",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 5169,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-90",
+        "kind": "paraphrase",
+        "targetSkill": "pptx",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 4710,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-91",
+        "kind": "paraphrase",
+        "targetSkill": "pptx",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 4886,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-92",
+        "kind": "paraphrase",
+        "targetSkill": "pptx",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 5368,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-93",
+        "kind": "paraphrase",
+        "targetSkill": "pptx",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 5253,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-94",
+        "kind": "typo",
+        "targetSkill": "pptx",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 6623,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-95",
+        "kind": "typo",
+        "targetSkill": "pptx",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 6272,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-96",
+        "kind": "paraphrase",
+        "targetSkill": "webapp-testing",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 7184,
+      "timedOut": true,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-97",
+        "kind": "paraphrase",
+        "targetSkill": "webapp-testing",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 8362,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-98",
+        "kind": "paraphrase",
+        "targetSkill": "webapp-testing",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 5709,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-99",
+        "kind": "paraphrase",
+        "targetSkill": "webapp-testing",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 7375,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-100",
+        "kind": "paraphrase",
+        "targetSkill": "webapp-testing",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 6475,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-101",
+        "kind": "paraphrase",
+        "targetSkill": "webapp-testing",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 7779,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-102",
+        "kind": "typo",
+        "targetSkill": "webapp-testing",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 6407,
+      "timedOut": true,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-103",
+        "kind": "typo",
+        "targetSkill": "webapp-testing",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 5679,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-104",
+        "kind": "paraphrase",
+        "targetSkill": "skill-creator",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 4325,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-105",
+        "kind": "paraphrase",
+        "targetSkill": "skill-creator",
+        "phrase": ""
+      },
+      "skillsInvoked": [
+        "skill-creator"
+      ],
+      "turnDurationMs": 11027,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-106",
+        "kind": "paraphrase",
+        "targetSkill": "skill-creator",
+        "phrase": ""
+      },
+      "skillsInvoked": [
+        "skill-creator"
+      ],
+      "turnDurationMs": 10642,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-107",
+        "kind": "paraphrase",
+        "targetSkill": "skill-creator",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 7268,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-108",
+        "kind": "paraphrase",
+        "targetSkill": "skill-creator",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 5530,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-109",
+        "kind": "paraphrase",
+        "targetSkill": "skill-creator",
+        "phrase": ""
+      },
+      "skillsInvoked": [
+        "skill-creator"
+      ],
+      "turnDurationMs": 8024,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-110",
+        "kind": "typo",
+        "targetSkill": "skill-creator",
+        "phrase": ""
+      },
+      "skillsInvoked": [
+        "skill-creator"
+      ],
+      "turnDurationMs": 11293,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-111",
+        "kind": "typo",
+        "targetSkill": "skill-creator",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 5777,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-112",
+        "kind": "paraphrase",
+        "targetSkill": "xlsx",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 4644,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-113",
+        "kind": "paraphrase",
+        "targetSkill": "xlsx",
+        "phrase": ""
+      },
+      "skillsInvoked": [
+        "xlsx"
+      ],
+      "turnDurationMs": 7789,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-114",
+        "kind": "paraphrase",
+        "targetSkill": "xlsx",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 7563,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-115",
+        "kind": "paraphrase",
+        "targetSkill": "xlsx",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 7243,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-116",
+        "kind": "paraphrase",
+        "targetSkill": "xlsx",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 4181,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-117",
+        "kind": "paraphrase",
+        "targetSkill": "xlsx",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 5742,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-118",
+        "kind": "typo",
+        "targetSkill": "xlsx",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 7779,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-119",
+        "kind": "typo",
+        "targetSkill": "xlsx",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 4661,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-120",
+        "kind": "paraphrase",
+        "targetSkill": "buildkite-agent-runtime",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 7055,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-121",
+        "kind": "paraphrase",
+        "targetSkill": "buildkite-agent-runtime",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 6300,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-122",
+        "kind": "paraphrase",
+        "targetSkill": "buildkite-agent-runtime",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 5735,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-123",
+        "kind": "paraphrase",
+        "targetSkill": "buildkite-agent-runtime",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 5627,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-124",
+        "kind": "paraphrase",
+        "targetSkill": "buildkite-agent-runtime",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 7819,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-125",
+        "kind": "paraphrase",
+        "targetSkill": "buildkite-agent-runtime",
+        "phrase": ""
+      },
+      "skillsInvoked": [
+        "buildkite-pipelines"
+      ],
+      "turnDurationMs": 13973,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-126",
+        "kind": "typo",
+        "targetSkill": "buildkite-agent-runtime",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 8991,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-127",
+        "kind": "typo",
+        "targetSkill": "buildkite-agent-runtime",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 6386,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-128",
+        "kind": "paraphrase",
+        "targetSkill": "switchroom-health",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 4701,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-129",
+        "kind": "paraphrase",
+        "targetSkill": "switchroom-health",
+        "phrase": ""
+      },
+      "skillsInvoked": [
+        "switchroom-status"
+      ],
+      "turnDurationMs": 5789,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-130",
+        "kind": "paraphrase",
+        "targetSkill": "switchroom-health",
+        "phrase": ""
+      },
+      "skillsInvoked": [
+        "switchroom-status"
+      ],
+      "turnDurationMs": 6628,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-131",
+        "kind": "paraphrase",
+        "targetSkill": "switchroom-health",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 12087,
+      "timedOut": true,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-132",
+        "kind": "paraphrase",
+        "targetSkill": "switchroom-health",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 8490,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-133",
+        "kind": "paraphrase",
+        "targetSkill": "switchroom-health",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 9464,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-134",
+        "kind": "typo",
+        "targetSkill": "switchroom-health",
+        "phrase": ""
+      },
+      "skillsInvoked": [
+        "switchroom-health",
+        "switchroom-status"
+      ],
+      "turnDurationMs": 10527,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-135",
+        "kind": "typo",
+        "targetSkill": "switchroom-health",
+        "phrase": ""
+      },
+      "skillsInvoked": [
+        "switchroom-status",
+        "switchroom-health",
+        "switchroom-cli"
+      ],
+      "turnDurationMs": 8508,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-136",
+        "kind": "paraphrase",
+        "targetSkill": "docx",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 5699,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-137",
+        "kind": "paraphrase",
+        "targetSkill": "docx",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 5041,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-138",
+        "kind": "paraphrase",
+        "targetSkill": "docx",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 4218,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-139",
+        "kind": "paraphrase",
+        "targetSkill": "docx",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 5761,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-140",
+        "kind": "paraphrase",
+        "targetSkill": "docx",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 6760,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-141",
+        "kind": "typo",
+        "targetSkill": "docx",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 8311,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-142",
+        "kind": "typo",
+        "targetSkill": "docx",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 6435,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-143",
+        "kind": "typo",
+        "targetSkill": "docx",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 5825,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-144",
+        "kind": "paraphrase",
+        "targetSkill": "humanizer",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 4651,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-145",
+        "kind": "paraphrase",
+        "targetSkill": "humanizer",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 8026,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-146",
+        "kind": "paraphrase",
+        "targetSkill": "humanizer",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 8011,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-147",
+        "kind": "paraphrase",
+        "targetSkill": "humanizer",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 5236,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-148",
+        "kind": "paraphrase",
+        "targetSkill": "humanizer",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 7801,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-149",
+        "kind": "paraphrase",
+        "targetSkill": "humanizer",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 7353,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-150",
+        "kind": "typo",
+        "targetSkill": "humanizer",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 5617,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-151",
+        "kind": "typo",
+        "targetSkill": "humanizer",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 6043,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-152",
+        "kind": "paraphrase",
+        "targetSkill": "buildkite-test-engine",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 13029,
+      "timedOut": true,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-153",
+        "kind": "paraphrase",
+        "targetSkill": "buildkite-test-engine",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 7694,
+      "timedOut": true,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-154",
+        "kind": "paraphrase",
+        "targetSkill": "buildkite-test-engine",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 5765,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-155",
+        "kind": "paraphrase",
+        "targetSkill": "buildkite-test-engine",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 7249,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-156",
+        "kind": "paraphrase",
+        "targetSkill": "buildkite-test-engine",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 6859,
+      "timedOut": true,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-157",
+        "kind": "paraphrase",
+        "targetSkill": "buildkite-test-engine",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 6574,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-158",
+        "kind": "typo",
+        "targetSkill": "buildkite-test-engine",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 6109,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-159",
+        "kind": "typo",
+        "targetSkill": "buildkite-test-engine",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 8040,
       "timedOut": false,
       "agentName": "claude-cli"
     }

--- a/tests/skill-coverage/scorecards/baseline.run.json
+++ b/tests/skill-coverage/scorecards/baseline.run.json
@@ -1,6 +1,6 @@
 {
-  "startedAt": "2026-05-13T23:10:51.025Z",
-  "finishedAt": "2026-05-13T23:10:51.025Z",
+  "startedAt": "2026-05-13T23:16:58.200Z",
+  "finishedAt": "2026-05-13T23:16:58.200Z",
   "seed": 1,
   "agentName": "claude-cli",
   "results": [
@@ -377,6 +377,584 @@
         "mcp-builder"
       ],
       "turnDurationMs": 10429,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-30",
+        "kind": "typo",
+        "targetSkill": "mcp-builder",
+        "phrase": ""
+      },
+      "skillsInvoked": [
+        "mcp-builder"
+      ],
+      "turnDurationMs": 10980,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-31",
+        "kind": "typo",
+        "targetSkill": "mcp-builder",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 5353,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-32",
+        "kind": "paraphrase",
+        "targetSkill": "switchroom-install",
+        "phrase": ""
+      },
+      "skillsInvoked": [
+        "switchroom-architecture"
+      ],
+      "turnDurationMs": 12117,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-33",
+        "kind": "paraphrase",
+        "targetSkill": "switchroom-install",
+        "phrase": ""
+      },
+      "skillsInvoked": [
+        "switchroom-install"
+      ],
+      "turnDurationMs": 10117,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-34",
+        "kind": "paraphrase",
+        "targetSkill": "switchroom-install",
+        "phrase": ""
+      },
+      "skillsInvoked": [
+        "switchroom-install"
+      ],
+      "turnDurationMs": 10624,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-35",
+        "kind": "paraphrase",
+        "targetSkill": "switchroom-install",
+        "phrase": ""
+      },
+      "skillsInvoked": [
+        "switchroom-install"
+      ],
+      "turnDurationMs": 10488,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-36",
+        "kind": "paraphrase",
+        "targetSkill": "switchroom-install",
+        "phrase": ""
+      },
+      "skillsInvoked": [
+        "switchroom-install"
+      ],
+      "turnDurationMs": 9643,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-37",
+        "kind": "paraphrase",
+        "targetSkill": "switchroom-install",
+        "phrase": ""
+      },
+      "skillsInvoked": [
+        "switchroom-install"
+      ],
+      "turnDurationMs": 8413,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-38",
+        "kind": "typo",
+        "targetSkill": "switchroom-install",
+        "phrase": ""
+      },
+      "skillsInvoked": [
+        "switchroom-install"
+      ],
+      "turnDurationMs": 8922,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-39",
+        "kind": "typo",
+        "targetSkill": "switchroom-install",
+        "phrase": ""
+      },
+      "skillsInvoked": [
+        "switchroom-install"
+      ],
+      "turnDurationMs": 11246,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-40",
+        "kind": "paraphrase",
+        "targetSkill": "buildkite-api",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 8169,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-41",
+        "kind": "paraphrase",
+        "targetSkill": "buildkite-api",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 7174,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-42",
+        "kind": "paraphrase",
+        "targetSkill": "buildkite-api",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 7715,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-43",
+        "kind": "paraphrase",
+        "targetSkill": "buildkite-api",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 7143,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-44",
+        "kind": "paraphrase",
+        "targetSkill": "buildkite-api",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 9871,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-45",
+        "kind": "typo",
+        "targetSkill": "buildkite-api",
+        "phrase": ""
+      },
+      "skillsInvoked": [
+        "buildkite-api"
+      ],
+      "turnDurationMs": 10834,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-46",
+        "kind": "typo",
+        "targetSkill": "buildkite-api",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 5750,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-47",
+        "kind": "typo",
+        "targetSkill": "buildkite-api",
+        "phrase": ""
+      },
+      "skillsInvoked": [
+        "buildkite-api"
+      ],
+      "turnDurationMs": 10328,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-48",
+        "kind": "paraphrase",
+        "targetSkill": "file-bug",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 5464,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-49",
+        "kind": "paraphrase",
+        "targetSkill": "file-bug",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 7022,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-50",
+        "kind": "paraphrase",
+        "targetSkill": "file-bug",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 5319,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-51",
+        "kind": "paraphrase",
+        "targetSkill": "file-bug",
+        "phrase": ""
+      },
+      "skillsInvoked": [
+        "file-bug"
+      ],
+      "turnDurationMs": 5267,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-52",
+        "kind": "paraphrase",
+        "targetSkill": "file-bug",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 5226,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-53",
+        "kind": "paraphrase",
+        "targetSkill": "file-bug",
+        "phrase": ""
+      },
+      "skillsInvoked": [
+        "file-bug"
+      ],
+      "turnDurationMs": 6352,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-54",
+        "kind": "typo",
+        "targetSkill": "file-bug",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 5584,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-55",
+        "kind": "typo",
+        "targetSkill": "file-bug",
+        "phrase": ""
+      },
+      "skillsInvoked": [
+        "file-bug"
+      ],
+      "turnDurationMs": 6817,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-56",
+        "kind": "paraphrase",
+        "targetSkill": "switchroom-status",
+        "phrase": ""
+      },
+      "skillsInvoked": [
+        "switchroom-status"
+      ],
+      "turnDurationMs": 6902,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-57",
+        "kind": "paraphrase",
+        "targetSkill": "switchroom-status",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 6930,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-58",
+        "kind": "paraphrase",
+        "targetSkill": "switchroom-status",
+        "phrase": ""
+      },
+      "skillsInvoked": [
+        "switchroom-status"
+      ],
+      "turnDurationMs": 8799,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-59",
+        "kind": "paraphrase",
+        "targetSkill": "switchroom-status",
+        "phrase": ""
+      },
+      "skillsInvoked": [
+        "switchroom-status"
+      ],
+      "turnDurationMs": 7289,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-60",
+        "kind": "paraphrase",
+        "targetSkill": "switchroom-status",
+        "phrase": ""
+      },
+      "skillsInvoked": [
+        "switchroom-status"
+      ],
+      "turnDurationMs": 7434,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-61",
+        "kind": "paraphrase",
+        "targetSkill": "switchroom-status",
+        "phrase": ""
+      },
+      "skillsInvoked": [
+        "switchroom-status"
+      ],
+      "turnDurationMs": 8254,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-62",
+        "kind": "typo",
+        "targetSkill": "switchroom-status",
+        "phrase": ""
+      },
+      "skillsInvoked": [
+        "switchroom-status"
+      ],
+      "turnDurationMs": 7239,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-63",
+        "kind": "typo",
+        "targetSkill": "switchroom-status",
+        "phrase": ""
+      },
+      "skillsInvoked": [
+        "switchroom-status"
+      ],
+      "turnDurationMs": 7883,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-64",
+        "kind": "paraphrase",
+        "targetSkill": "buildkite-pipelines",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 5873,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-65",
+        "kind": "paraphrase",
+        "targetSkill": "buildkite-pipelines",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 6390,
+      "timedOut": true,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-66",
+        "kind": "paraphrase",
+        "targetSkill": "buildkite-pipelines",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 5554,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-67",
+        "kind": "paraphrase",
+        "targetSkill": "buildkite-pipelines",
+        "phrase": ""
+      },
+      "skillsInvoked": [
+        "buildkite-pipelines"
+      ],
+      "turnDurationMs": 9929,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-68",
+        "kind": "paraphrase",
+        "targetSkill": "buildkite-pipelines",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 11988,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-69",
+        "kind": "paraphrase",
+        "targetSkill": "buildkite-pipelines",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 7473,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-70",
+        "kind": "typo",
+        "targetSkill": "buildkite-pipelines",
+        "phrase": ""
+      },
+      "skillsInvoked": [
+        "buildkite-pipelines"
+      ],
+      "turnDurationMs": 15250,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-71",
+        "kind": "typo",
+        "targetSkill": "buildkite-pipelines",
+        "phrase": ""
+      },
+      "skillsInvoked": [
+        "buildkite-pipelines"
+      ],
+      "turnDurationMs": 10365,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-72",
+        "kind": "paraphrase",
+        "targetSkill": "switchroom-manage",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 6632,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-73",
+        "kind": "paraphrase",
+        "targetSkill": "switchroom-manage",
+        "phrase": ""
+      },
+      "skillsInvoked": [
+        "switchroom-status"
+      ],
+      "turnDurationMs": 12850,
       "timedOut": false,
       "agentName": "claude-cli"
     }

--- a/tests/skill-coverage/scorecards/baseline.run.json
+++ b/tests/skill-coverage/scorecards/baseline.run.json
@@ -1,6 +1,6 @@
 {
-  "startedAt": "2026-05-13T23:16:58.200Z",
-  "finishedAt": "2026-05-13T23:16:58.200Z",
+  "startedAt": "2026-05-13T23:18:02.883Z",
+  "finishedAt": "2026-05-13T23:18:02.883Z",
   "seed": 1,
   "agentName": "claude-cli",
   "results": [
@@ -955,6 +955,110 @@
         "switchroom-status"
       ],
       "turnDurationMs": 12850,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-74",
+        "kind": "paraphrase",
+        "targetSkill": "switchroom-manage",
+        "phrase": ""
+      },
+      "skillsInvoked": [
+        "switchroom-status"
+      ],
+      "turnDurationMs": 7753,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-75",
+        "kind": "paraphrase",
+        "targetSkill": "switchroom-manage",
+        "phrase": ""
+      },
+      "skillsInvoked": [
+        "switchroom-install"
+      ],
+      "turnDurationMs": 9724,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-76",
+        "kind": "paraphrase",
+        "targetSkill": "switchroom-manage",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 8581,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-77",
+        "kind": "paraphrase",
+        "targetSkill": "switchroom-manage",
+        "phrase": ""
+      },
+      "skillsInvoked": [
+        "switchroom-status"
+      ],
+      "turnDurationMs": 8640,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-78",
+        "kind": "typo",
+        "targetSkill": "switchroom-manage",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 5998,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-79",
+        "kind": "typo",
+        "targetSkill": "switchroom-manage",
+        "phrase": ""
+      },
+      "skillsInvoked": [
+        "switchroom-install"
+      ],
+      "turnDurationMs": 9669,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-80",
+        "kind": "paraphrase",
+        "targetSkill": "buildkite-secure-delivery",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 8077,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-81",
+        "kind": "paraphrase",
+        "targetSkill": "buildkite-secure-delivery",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 5101,
       "timedOut": false,
       "agentName": "claude-cli"
     }

--- a/tests/skill-coverage/scorecards/baseline.scorecard.json
+++ b/tests/skill-coverage/scorecards/baseline.scorecard.json
@@ -1,8 +1,20 @@
 {
-  "generatedAt": "2026-05-13T23:18:02.884Z",
+  "generatedAt": "2026-05-13T23:27:34.486Z",
   "seed": 1,
-  "totalProbes": 82,
+  "totalProbes": 160,
   "rows": [
+    {
+      "skill": "buildkite-agent-runtime",
+      "sampleSize": 8,
+      "truePositives": 0,
+      "falseNegatives": 8,
+      "falsePositives": 0,
+      "precision": 0,
+      "recall": 0,
+      "f1": 0,
+      "execSuccess": 0,
+      "negativeControlFpRate": 0
+    },
     {
       "skill": "buildkite-api",
       "sampleSize": 8,
@@ -32,18 +44,42 @@
       "sampleSize": 8,
       "truePositives": 3,
       "falseNegatives": 5,
-      "falsePositives": 3,
-      "precision": 0.5,
+      "falsePositives": 4,
+      "precision": 0.42857142857142855,
       "recall": 0.375,
-      "f1": 0.42857142857142855,
+      "f1": 0.39999999999999997,
       "execSuccess": 1,
       "negativeControlFpRate": 0.25
     },
     {
       "skill": "buildkite-secure-delivery",
-      "sampleSize": 2,
+      "sampleSize": 8,
       "truePositives": 0,
-      "falseNegatives": 2,
+      "falseNegatives": 8,
+      "falsePositives": 0,
+      "precision": 0,
+      "recall": 0,
+      "f1": 0,
+      "execSuccess": 0,
+      "negativeControlFpRate": 0
+    },
+    {
+      "skill": "buildkite-test-engine",
+      "sampleSize": 8,
+      "truePositives": 0,
+      "falseNegatives": 8,
+      "falsePositives": 0,
+      "precision": 0,
+      "recall": 0,
+      "f1": 0,
+      "execSuccess": 0,
+      "negativeControlFpRate": 0
+    },
+    {
+      "skill": "docx",
+      "sampleSize": 8,
+      "truePositives": 0,
+      "falseNegatives": 8,
       "falsePositives": 0,
       "precision": 0,
       "recall": 0,
@@ -64,6 +100,18 @@
       "negativeControlFpRate": 0.125
     },
     {
+      "skill": "humanizer",
+      "sampleSize": 8,
+      "truePositives": 0,
+      "falseNegatives": 8,
+      "falsePositives": 0,
+      "precision": 0,
+      "recall": 0,
+      "f1": 0,
+      "execSuccess": 0,
+      "negativeControlFpRate": 0
+    },
+    {
       "skill": "mcp-builder",
       "sampleSize": 8,
       "truePositives": 3,
@@ -72,6 +120,30 @@
       "precision": 1,
       "recall": 0.375,
       "f1": 0.5454545454545454,
+      "execSuccess": 1,
+      "negativeControlFpRate": 0
+    },
+    {
+      "skill": "pptx",
+      "sampleSize": 8,
+      "truePositives": 0,
+      "falseNegatives": 8,
+      "falsePositives": 0,
+      "precision": 0,
+      "recall": 0,
+      "f1": 0,
+      "execSuccess": 0,
+      "negativeControlFpRate": 0
+    },
+    {
+      "skill": "skill-creator",
+      "sampleSize": 8,
+      "truePositives": 4,
+      "falseNegatives": 4,
+      "falsePositives": 0,
+      "precision": 1,
+      "recall": 0.5,
+      "f1": 0.6666666666666666,
       "execSuccess": 1,
       "negativeControlFpRate": 0
     },
@@ -85,6 +157,30 @@
       "recall": 0,
       "f1": 0,
       "execSuccess": 0,
+      "negativeControlFpRate": 0
+    },
+    {
+      "skill": "switchroom-cli",
+      "sampleSize": 0,
+      "truePositives": 0,
+      "falseNegatives": 0,
+      "falsePositives": 1,
+      "precision": 0,
+      "recall": 0,
+      "f1": 0,
+      "execSuccess": 0,
+      "negativeControlFpRate": 0
+    },
+    {
+      "skill": "switchroom-health",
+      "sampleSize": 8,
+      "truePositives": 2,
+      "falseNegatives": 6,
+      "falsePositives": 0,
+      "precision": 1,
+      "recall": 0.25,
+      "f1": 0.4,
+      "execSuccess": 1,
       "negativeControlFpRate": 0
     },
     {
@@ -128,18 +224,42 @@
       "sampleSize": 8,
       "truePositives": 7,
       "falseNegatives": 1,
-      "falsePositives": 3,
-      "precision": 0.7,
+      "falsePositives": 7,
+      "precision": 0.5,
       "recall": 0.875,
-      "f1": 0.7777777777777777,
+      "f1": 0.6363636363636364,
+      "execSuccess": 1,
+      "negativeControlFpRate": 0
+    },
+    {
+      "skill": "webapp-testing",
+      "sampleSize": 8,
+      "truePositives": 0,
+      "falseNegatives": 8,
+      "falsePositives": 0,
+      "precision": 0,
+      "recall": 0,
+      "f1": 0,
+      "execSuccess": 0,
+      "negativeControlFpRate": 0
+    },
+    {
+      "skill": "xlsx",
+      "sampleSize": 8,
+      "truePositives": 1,
+      "falseNegatives": 7,
+      "falsePositives": 0,
+      "precision": 1,
+      "recall": 0.125,
+      "f1": 0.2222222222222222,
       "execSuccess": 1,
       "negativeControlFpRate": 0
     }
   ],
   "aggregate": {
-    "medianF1": 0.39610389610389607,
-    "skillsBelowF1Threshold": 10,
-    "skillsBelowExecThreshold": 3,
+    "medianF1": 0.2222222222222222,
+    "skillsBelowF1Threshold": 19,
+    "skillsBelowExecThreshold": 9,
     "f1Threshold": 0.9,
     "execThreshold": 0.95
   }

--- a/tests/skill-coverage/scorecards/baseline.scorecard.json
+++ b/tests/skill-coverage/scorecards/baseline.scorecard.json
@@ -1,18 +1,18 @@
 {
-  "generatedAt": "2026-05-13T23:10:51.025Z",
+  "generatedAt": "2026-05-13T23:16:58.201Z",
   "seed": 1,
-  "totalProbes": 30,
+  "totalProbes": 74,
   "rows": [
     {
       "skill": "buildkite-api",
-      "sampleSize": 0,
-      "truePositives": 0,
-      "falseNegatives": 0,
+      "sampleSize": 8,
+      "truePositives": 2,
+      "falseNegatives": 6,
       "falsePositives": 1,
-      "precision": 0,
-      "recall": 0,
-      "f1": 0,
-      "execSuccess": 0,
+      "precision": 0.6666666666666666,
+      "recall": 0.25,
+      "f1": 0.36363636363636365,
+      "execSuccess": 1,
       "negativeControlFpRate": 0.125
     },
     {
@@ -29,18 +29,42 @@
     },
     {
       "skill": "buildkite-pipelines",
-      "sampleSize": 0,
-      "truePositives": 0,
-      "falseNegatives": 0,
+      "sampleSize": 8,
+      "truePositives": 3,
+      "falseNegatives": 5,
       "falsePositives": 3,
-      "precision": 0,
-      "recall": 0,
-      "f1": 0,
-      "execSuccess": 0,
+      "precision": 0.5,
+      "recall": 0.375,
+      "f1": 0.42857142857142855,
+      "execSuccess": 1,
       "negativeControlFpRate": 0.25
     },
     {
       "skill": "file-bug",
+      "sampleSize": 8,
+      "truePositives": 3,
+      "falseNegatives": 5,
+      "falsePositives": 1,
+      "precision": 0.75,
+      "recall": 0.375,
+      "f1": 0.5,
+      "execSuccess": 1,
+      "negativeControlFpRate": 0.125
+    },
+    {
+      "skill": "mcp-builder",
+      "sampleSize": 8,
+      "truePositives": 3,
+      "falseNegatives": 5,
+      "falsePositives": 0,
+      "precision": 1,
+      "recall": 0.375,
+      "f1": 0.5454545454545454,
+      "execSuccess": 1,
+      "negativeControlFpRate": 0
+    },
+    {
+      "skill": "switchroom-architecture",
       "sampleSize": 0,
       "truePositives": 0,
       "falseNegatives": 0,
@@ -49,18 +73,30 @@
       "recall": 0,
       "f1": 0,
       "execSuccess": 0,
-      "negativeControlFpRate": 0.125
+      "negativeControlFpRate": 0
     },
     {
-      "skill": "mcp-builder",
-      "sampleSize": 6,
-      "truePositives": 2,
-      "falseNegatives": 4,
+      "skill": "switchroom-install",
+      "sampleSize": 8,
+      "truePositives": 7,
+      "falseNegatives": 1,
       "falsePositives": 0,
       "precision": 1,
-      "recall": 0.3333333333333333,
-      "f1": 0.5,
+      "recall": 0.875,
+      "f1": 0.9333333333333333,
       "execSuccess": 1,
+      "negativeControlFpRate": 0
+    },
+    {
+      "skill": "switchroom-manage",
+      "sampleSize": 2,
+      "truePositives": 0,
+      "falseNegatives": 2,
+      "falsePositives": 0,
+      "precision": 0,
+      "recall": 0,
+      "f1": 0,
+      "execSuccess": 0,
       "negativeControlFpRate": 0
     },
     {
@@ -74,12 +110,24 @@
       "f1": 0.2222222222222222,
       "execSuccess": 1,
       "negativeControlFpRate": 0
+    },
+    {
+      "skill": "switchroom-status",
+      "sampleSize": 8,
+      "truePositives": 7,
+      "falseNegatives": 1,
+      "falsePositives": 1,
+      "precision": 0.875,
+      "recall": 0.875,
+      "f1": 0.875,
+      "execSuccess": 1,
+      "negativeControlFpRate": 0
     }
   ],
   "aggregate": {
-    "medianF1": 0.2222222222222222,
-    "skillsBelowF1Threshold": 3,
-    "skillsBelowExecThreshold": 1,
+    "medianF1": 0.42857142857142855,
+    "skillsBelowF1Threshold": 8,
+    "skillsBelowExecThreshold": 2,
     "f1Threshold": 0.9,
     "execThreshold": 0.95
   }

--- a/tests/skill-coverage/scorecards/baseline.scorecard.json
+++ b/tests/skill-coverage/scorecards/baseline.scorecard.json
@@ -1,7 +1,7 @@
 {
-  "generatedAt": "2026-05-13T23:16:58.201Z",
+  "generatedAt": "2026-05-13T23:18:02.884Z",
   "seed": 1,
-  "totalProbes": 74,
+  "totalProbes": 82,
   "rows": [
     {
       "skill": "buildkite-api",
@@ -38,6 +38,18 @@
       "f1": 0.42857142857142855,
       "execSuccess": 1,
       "negativeControlFpRate": 0.25
+    },
+    {
+      "skill": "buildkite-secure-delivery",
+      "sampleSize": 2,
+      "truePositives": 0,
+      "falseNegatives": 2,
+      "falsePositives": 0,
+      "precision": 0,
+      "recall": 0,
+      "f1": 0,
+      "execSuccess": 0,
+      "negativeControlFpRate": 0
     },
     {
       "skill": "file-bug",
@@ -80,18 +92,18 @@
       "sampleSize": 8,
       "truePositives": 7,
       "falseNegatives": 1,
-      "falsePositives": 0,
-      "precision": 1,
+      "falsePositives": 2,
+      "precision": 0.7777777777777778,
       "recall": 0.875,
-      "f1": 0.9333333333333333,
+      "f1": 0.823529411764706,
       "execSuccess": 1,
       "negativeControlFpRate": 0
     },
     {
       "skill": "switchroom-manage",
-      "sampleSize": 2,
+      "sampleSize": 8,
       "truePositives": 0,
-      "falseNegatives": 2,
+      "falseNegatives": 8,
       "falsePositives": 0,
       "precision": 0,
       "recall": 0,
@@ -116,18 +128,18 @@
       "sampleSize": 8,
       "truePositives": 7,
       "falseNegatives": 1,
-      "falsePositives": 1,
-      "precision": 0.875,
+      "falsePositives": 3,
+      "precision": 0.7,
       "recall": 0.875,
-      "f1": 0.875,
+      "f1": 0.7777777777777777,
       "execSuccess": 1,
       "negativeControlFpRate": 0
     }
   ],
   "aggregate": {
-    "medianF1": 0.42857142857142855,
-    "skillsBelowF1Threshold": 8,
-    "skillsBelowExecThreshold": 2,
+    "medianF1": 0.39610389610389607,
+    "skillsBelowF1Threshold": 10,
+    "skillsBelowExecThreshold": 3,
     "f1Threshold": 0.9,
     "execThreshold": 0.95
   }

--- a/tests/skill-coverage/scorecards/baseline.scorecard.md
+++ b/tests/skill-coverage/scorecards/baseline.scorecard.md
@@ -1,22 +1,32 @@
 # Skill coverage scorecard
 
-- generated: 2026-05-13T23:18:02.884Z
+- generated: 2026-05-13T23:27:34.486Z
 - seed: 1
-- total probes: 82
-- median F1 (among targeted skills): 0.40
-- skills below F1 0.90: **10**
-- skills below exec 0.95: **3**
+- total probes: 160
+- median F1 (among targeted skills): 0.22
+- skills below F1 0.90: **19**
+- skills below exec 0.95: **9**
 
 | skill | n | TP | FN | FP | precision | recall | F1 | exec | neg-FP |
 |---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
+| buildkite-agent-runtime | 8 | 0 | 8 | 0 | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 |
 | buildkite-api | 8 | 2 | 6 | 1 | 0.67 | 0.25 | 0.36 | 1.00 | 0.13 |
 | buildkite-cli | 8 | 0 | 8 | 0 | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 |
-| buildkite-pipelines | 8 | 3 | 5 | 3 | 0.50 | 0.38 | 0.43 | 1.00 | 0.25 |
-| buildkite-secure-delivery | 2 | 0 | 2 | 0 | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 |
+| buildkite-pipelines | 8 | 3 | 5 | 4 | 0.43 | 0.38 | 0.40 | 1.00 | 0.25 |
+| buildkite-secure-delivery | 8 | 0 | 8 | 0 | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 |
+| buildkite-test-engine | 8 | 0 | 8 | 0 | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 |
+| docx | 8 | 0 | 8 | 0 | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 |
 | file-bug | 8 | 3 | 5 | 1 | 0.75 | 0.38 | 0.50 | 1.00 | 0.13 |
+| humanizer | 8 | 0 | 8 | 0 | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 |
 | mcp-builder | 8 | 3 | 5 | 0 | 1.00 | 0.38 | 0.55 | 1.00 | 0.00 |
+| pptx | 8 | 0 | 8 | 0 | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 |
+| skill-creator | 8 | 4 | 4 | 0 | 1.00 | 0.50 | 0.67 | 1.00 | 0.00 |
 | switchroom-architecture | 0 | 0 | 0 | 1 | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 |
+| switchroom-cli | 0 | 0 | 0 | 1 | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 |
+| switchroom-health | 8 | 2 | 6 | 0 | 1.00 | 0.25 | 0.40 | 1.00 | 0.00 |
 | switchroom-install | 8 | 7 | 1 | 2 | 0.78 | 0.88 | 0.82 | 1.00 | 0.00 |
 | switchroom-manage | 8 | 0 | 8 | 0 | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 |
 | switchroom-runtime | 8 | 1 | 7 | 0 | 1.00 | 0.13 | 0.22 | 1.00 | 0.00 |
-| switchroom-status | 8 | 7 | 1 | 3 | 0.70 | 0.88 | 0.78 | 1.00 | 0.00 |
+| switchroom-status | 8 | 7 | 1 | 7 | 0.50 | 0.88 | 0.64 | 1.00 | 0.00 |
+| webapp-testing | 8 | 0 | 8 | 0 | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 |
+| xlsx | 8 | 1 | 7 | 0 | 1.00 | 0.13 | 0.22 | 1.00 | 0.00 |

--- a/tests/skill-coverage/scorecards/baseline.scorecard.md
+++ b/tests/skill-coverage/scorecards/baseline.scorecard.md
@@ -1,17 +1,21 @@
 # Skill coverage scorecard
 
-- generated: 2026-05-13T23:10:51.025Z
+- generated: 2026-05-13T23:16:58.201Z
 - seed: 1
-- total probes: 30
-- median F1 (among targeted skills): 0.22
-- skills below F1 0.90: **3**
-- skills below exec 0.95: **1**
+- total probes: 74
+- median F1 (among targeted skills): 0.43
+- skills below F1 0.90: **8**
+- skills below exec 0.95: **2**
 
 | skill | n | TP | FN | FP | precision | recall | F1 | exec | neg-FP |
 |---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
-| buildkite-api | 0 | 0 | 0 | 1 | 0.00 | 0.00 | 0.00 | 0.00 | 0.13 |
+| buildkite-api | 8 | 2 | 6 | 1 | 0.67 | 0.25 | 0.36 | 1.00 | 0.13 |
 | buildkite-cli | 8 | 0 | 8 | 0 | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 |
-| buildkite-pipelines | 0 | 0 | 0 | 3 | 0.00 | 0.00 | 0.00 | 0.00 | 0.25 |
-| file-bug | 0 | 0 | 0 | 1 | 0.00 | 0.00 | 0.00 | 0.00 | 0.13 |
-| mcp-builder | 6 | 2 | 4 | 0 | 1.00 | 0.33 | 0.50 | 1.00 | 0.00 |
+| buildkite-pipelines | 8 | 3 | 5 | 3 | 0.50 | 0.38 | 0.43 | 1.00 | 0.25 |
+| file-bug | 8 | 3 | 5 | 1 | 0.75 | 0.38 | 0.50 | 1.00 | 0.13 |
+| mcp-builder | 8 | 3 | 5 | 0 | 1.00 | 0.38 | 0.55 | 1.00 | 0.00 |
+| switchroom-architecture | 0 | 0 | 0 | 1 | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 |
+| switchroom-install | 8 | 7 | 1 | 0 | 1.00 | 0.88 | 0.93 | 1.00 | 0.00 |
+| switchroom-manage | 2 | 0 | 2 | 0 | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 |
 | switchroom-runtime | 8 | 1 | 7 | 0 | 1.00 | 0.13 | 0.22 | 1.00 | 0.00 |
+| switchroom-status | 8 | 7 | 1 | 1 | 0.88 | 0.88 | 0.88 | 1.00 | 0.00 |

--- a/tests/skill-coverage/scorecards/baseline.scorecard.md
+++ b/tests/skill-coverage/scorecards/baseline.scorecard.md
@@ -1,21 +1,22 @@
 # Skill coverage scorecard
 
-- generated: 2026-05-13T23:16:58.201Z
+- generated: 2026-05-13T23:18:02.884Z
 - seed: 1
-- total probes: 74
-- median F1 (among targeted skills): 0.43
-- skills below F1 0.90: **8**
-- skills below exec 0.95: **2**
+- total probes: 82
+- median F1 (among targeted skills): 0.40
+- skills below F1 0.90: **10**
+- skills below exec 0.95: **3**
 
 | skill | n | TP | FN | FP | precision | recall | F1 | exec | neg-FP |
 |---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
 | buildkite-api | 8 | 2 | 6 | 1 | 0.67 | 0.25 | 0.36 | 1.00 | 0.13 |
 | buildkite-cli | 8 | 0 | 8 | 0 | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 |
 | buildkite-pipelines | 8 | 3 | 5 | 3 | 0.50 | 0.38 | 0.43 | 1.00 | 0.25 |
+| buildkite-secure-delivery | 2 | 0 | 2 | 0 | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 |
 | file-bug | 8 | 3 | 5 | 1 | 0.75 | 0.38 | 0.50 | 1.00 | 0.13 |
 | mcp-builder | 8 | 3 | 5 | 0 | 1.00 | 0.38 | 0.55 | 1.00 | 0.00 |
 | switchroom-architecture | 0 | 0 | 0 | 1 | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 |
-| switchroom-install | 8 | 7 | 1 | 0 | 1.00 | 0.88 | 0.93 | 1.00 | 0.00 |
-| switchroom-manage | 2 | 0 | 2 | 0 | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 |
+| switchroom-install | 8 | 7 | 1 | 2 | 0.78 | 0.88 | 0.82 | 1.00 | 0.00 |
+| switchroom-manage | 8 | 0 | 8 | 0 | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 |
 | switchroom-runtime | 8 | 1 | 7 | 0 | 1.00 | 0.13 | 0.22 | 1.00 | 0.00 |
-| switchroom-status | 8 | 7 | 1 | 1 | 0.88 | 0.88 | 0.88 | 1.00 | 0.00 |
+| switchroom-status | 8 | 7 | 1 | 3 | 0.70 | 0.88 | 0.78 | 1.00 | 0.00 |

--- a/tests/skill-coverage/scorecards/round-3.partial.run.json
+++ b/tests/skill-coverage/scorecards/round-3.partial.run.json
@@ -1,0 +1,535 @@
+{
+  "startedAt": "2026-05-13T23:48:36.422Z",
+  "finishedAt": "2026-05-13T23:48:36.422Z",
+  "seed": 1,
+  "agentName": "claude-cli",
+  "results": [
+    {
+      "probe": {
+        "id": "partial-0",
+        "kind": "paraphrase",
+        "targetSkill": "switchroom-runtime",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 6401,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-1",
+        "kind": "paraphrase",
+        "targetSkill": "switchroom-runtime",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 4971,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-2",
+        "kind": "paraphrase",
+        "targetSkill": "switchroom-runtime",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 5360,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-3",
+        "kind": "paraphrase",
+        "targetSkill": "switchroom-runtime",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 5565,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-4",
+        "kind": "negative",
+        "targetSkill": null,
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 5889,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-5",
+        "kind": "negative",
+        "targetSkill": null,
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 6603,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-6",
+        "kind": "negative",
+        "targetSkill": null,
+        "phrase": ""
+      },
+      "skillsInvoked": [
+        "file-bug"
+      ],
+      "turnDurationMs": 8592,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-7",
+        "kind": "negative",
+        "targetSkill": null,
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 5921,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-8",
+        "kind": "paraphrase",
+        "targetSkill": "buildkite-cli",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 5856,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-9",
+        "kind": "paraphrase",
+        "targetSkill": "buildkite-cli",
+        "phrase": ""
+      },
+      "skillsInvoked": [
+        "buildkite-cli"
+      ],
+      "turnDurationMs": 10602,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-10",
+        "kind": "paraphrase",
+        "targetSkill": "buildkite-cli",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 8859,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-11",
+        "kind": "paraphrase",
+        "targetSkill": "buildkite-cli",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 5028,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-12",
+        "kind": "paraphrase",
+        "targetSkill": "mcp-builder",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 5676,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-13",
+        "kind": "paraphrase",
+        "targetSkill": "mcp-builder",
+        "phrase": ""
+      },
+      "skillsInvoked": [
+        "mcp-builder"
+      ],
+      "turnDurationMs": 9061,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-14",
+        "kind": "paraphrase",
+        "targetSkill": "mcp-builder",
+        "phrase": ""
+      },
+      "skillsInvoked": [
+        "mcp-builder"
+      ],
+      "turnDurationMs": 10760,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-15",
+        "kind": "paraphrase",
+        "targetSkill": "mcp-builder",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 14482,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-16",
+        "kind": "paraphrase",
+        "targetSkill": "switchroom-install",
+        "phrase": ""
+      },
+      "skillsInvoked": [
+        "switchroom-install"
+      ],
+      "turnDurationMs": 23503,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-17",
+        "kind": "paraphrase",
+        "targetSkill": "switchroom-install",
+        "phrase": ""
+      },
+      "skillsInvoked": [
+        "switchroom-install"
+      ],
+      "turnDurationMs": 8984,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-18",
+        "kind": "paraphrase",
+        "targetSkill": "switchroom-install",
+        "phrase": ""
+      },
+      "skillsInvoked": [
+        "switchroom-install"
+      ],
+      "turnDurationMs": 9969,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-19",
+        "kind": "paraphrase",
+        "targetSkill": "switchroom-install",
+        "phrase": ""
+      },
+      "skillsInvoked": [
+        "switchroom-install"
+      ],
+      "turnDurationMs": 9096,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-20",
+        "kind": "paraphrase",
+        "targetSkill": "buildkite-api",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 5787,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-21",
+        "kind": "paraphrase",
+        "targetSkill": "buildkite-api",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 9721,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-22",
+        "kind": "paraphrase",
+        "targetSkill": "buildkite-api",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 7273,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-23",
+        "kind": "paraphrase",
+        "targetSkill": "buildkite-api",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 9405,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-24",
+        "kind": "paraphrase",
+        "targetSkill": "file-bug",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 5333,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-25",
+        "kind": "paraphrase",
+        "targetSkill": "file-bug",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 6702,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-26",
+        "kind": "paraphrase",
+        "targetSkill": "file-bug",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 6487,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-27",
+        "kind": "paraphrase",
+        "targetSkill": "file-bug",
+        "phrase": ""
+      },
+      "skillsInvoked": [
+        "file-bug"
+      ],
+      "turnDurationMs": 6464,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-28",
+        "kind": "paraphrase",
+        "targetSkill": "switchroom-status",
+        "phrase": ""
+      },
+      "skillsInvoked": [
+        "switchroom-status",
+        "switchroom-cli"
+      ],
+      "turnDurationMs": 6671,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-29",
+        "kind": "paraphrase",
+        "targetSkill": "switchroom-status",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 7342,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-30",
+        "kind": "paraphrase",
+        "targetSkill": "switchroom-status",
+        "phrase": ""
+      },
+      "skillsInvoked": [
+        "switchroom-status"
+      ],
+      "turnDurationMs": 13225,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-31",
+        "kind": "paraphrase",
+        "targetSkill": "switchroom-status",
+        "phrase": ""
+      },
+      "skillsInvoked": [
+        "switchroom-status"
+      ],
+      "turnDurationMs": 8776,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-32",
+        "kind": "paraphrase",
+        "targetSkill": "buildkite-pipelines",
+        "phrase": ""
+      },
+      "skillsInvoked": [
+        "buildkite-pipelines"
+      ],
+      "turnDurationMs": 9492,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-33",
+        "kind": "paraphrase",
+        "targetSkill": "buildkite-pipelines",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 12434,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-34",
+        "kind": "paraphrase",
+        "targetSkill": "buildkite-pipelines",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 9716,
+      "timedOut": true,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-35",
+        "kind": "paraphrase",
+        "targetSkill": "buildkite-pipelines",
+        "phrase": ""
+      },
+      "skillsInvoked": [
+        "buildkite-pipelines"
+      ],
+      "turnDurationMs": 10661,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-36",
+        "kind": "paraphrase",
+        "targetSkill": "switchroom-manage",
+        "phrase": ""
+      },
+      "skillsInvoked": [
+        "switchroom-manage",
+        "switchroom-status"
+      ],
+      "turnDurationMs": 12722,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-37",
+        "kind": "paraphrase",
+        "targetSkill": "switchroom-manage",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 7655,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-38",
+        "kind": "paraphrase",
+        "targetSkill": "switchroom-manage",
+        "phrase": ""
+      },
+      "skillsInvoked": [
+        "switchroom-status",
+        "switchroom-cli"
+      ],
+      "turnDurationMs": 8534,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-39",
+        "kind": "paraphrase",
+        "targetSkill": "switchroom-manage",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 7036,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-40",
+        "kind": "paraphrase",
+        "targetSkill": "buildkite-secure-delivery",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 7341,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    }
+  ]
+}

--- a/tests/skill-coverage/scorecards/round-3.partial.scorecard.json
+++ b/tests/skill-coverage/scorecards/round-3.partial.scorecard.json
@@ -1,0 +1,146 @@
+{
+  "generatedAt": "2026-05-13T23:48:36.423Z",
+  "seed": 1,
+  "totalProbes": 41,
+  "rows": [
+    {
+      "skill": "buildkite-api",
+      "sampleSize": 4,
+      "truePositives": 0,
+      "falseNegatives": 4,
+      "falsePositives": 0,
+      "precision": 0,
+      "recall": 0,
+      "f1": 0,
+      "execSuccess": 0,
+      "negativeControlFpRate": 0
+    },
+    {
+      "skill": "buildkite-cli",
+      "sampleSize": 4,
+      "truePositives": 1,
+      "falseNegatives": 3,
+      "falsePositives": 0,
+      "precision": 1,
+      "recall": 0.25,
+      "f1": 0.4,
+      "execSuccess": 1,
+      "negativeControlFpRate": 0
+    },
+    {
+      "skill": "buildkite-pipelines",
+      "sampleSize": 4,
+      "truePositives": 2,
+      "falseNegatives": 2,
+      "falsePositives": 0,
+      "precision": 1,
+      "recall": 0.5,
+      "f1": 0.6666666666666666,
+      "execSuccess": 1,
+      "negativeControlFpRate": 0
+    },
+    {
+      "skill": "buildkite-secure-delivery",
+      "sampleSize": 1,
+      "truePositives": 0,
+      "falseNegatives": 1,
+      "falsePositives": 0,
+      "precision": 0,
+      "recall": 0,
+      "f1": 0,
+      "execSuccess": 0,
+      "negativeControlFpRate": 0
+    },
+    {
+      "skill": "file-bug",
+      "sampleSize": 4,
+      "truePositives": 1,
+      "falseNegatives": 3,
+      "falsePositives": 1,
+      "precision": 0.5,
+      "recall": 0.25,
+      "f1": 0.3333333333333333,
+      "execSuccess": 1,
+      "negativeControlFpRate": 0.25
+    },
+    {
+      "skill": "mcp-builder",
+      "sampleSize": 4,
+      "truePositives": 2,
+      "falseNegatives": 2,
+      "falsePositives": 0,
+      "precision": 1,
+      "recall": 0.5,
+      "f1": 0.6666666666666666,
+      "execSuccess": 1,
+      "negativeControlFpRate": 0
+    },
+    {
+      "skill": "switchroom-cli",
+      "sampleSize": 0,
+      "truePositives": 0,
+      "falseNegatives": 0,
+      "falsePositives": 2,
+      "precision": 0,
+      "recall": 0,
+      "f1": 0,
+      "execSuccess": 0,
+      "negativeControlFpRate": 0
+    },
+    {
+      "skill": "switchroom-install",
+      "sampleSize": 4,
+      "truePositives": 4,
+      "falseNegatives": 0,
+      "falsePositives": 0,
+      "precision": 1,
+      "recall": 1,
+      "f1": 1,
+      "execSuccess": 1,
+      "negativeControlFpRate": 0
+    },
+    {
+      "skill": "switchroom-manage",
+      "sampleSize": 4,
+      "truePositives": 1,
+      "falseNegatives": 3,
+      "falsePositives": 0,
+      "precision": 1,
+      "recall": 0.25,
+      "f1": 0.4,
+      "execSuccess": 1,
+      "negativeControlFpRate": 0
+    },
+    {
+      "skill": "switchroom-runtime",
+      "sampleSize": 4,
+      "truePositives": 0,
+      "falseNegatives": 4,
+      "falsePositives": 0,
+      "precision": 0,
+      "recall": 0,
+      "f1": 0,
+      "execSuccess": 0,
+      "negativeControlFpRate": 0
+    },
+    {
+      "skill": "switchroom-status",
+      "sampleSize": 4,
+      "truePositives": 3,
+      "falseNegatives": 1,
+      "falsePositives": 2,
+      "precision": 0.6,
+      "recall": 0.75,
+      "f1": 0.6666666666666665,
+      "execSuccess": 1,
+      "negativeControlFpRate": 0
+    }
+  ],
+  "aggregate": {
+    "medianF1": 0.4,
+    "skillsBelowF1Threshold": 9,
+    "skillsBelowExecThreshold": 3,
+    "f1Threshold": 0.9,
+    "execThreshold": 0.95
+  }
+}

--- a/tests/skill-coverage/scorecards/round-3.partial.scorecard.md
+++ b/tests/skill-coverage/scorecards/round-3.partial.scorecard.md
@@ -1,0 +1,22 @@
+# Skill coverage scorecard
+
+- generated: 2026-05-13T23:48:36.423Z
+- seed: 1
+- total probes: 41
+- median F1 (among targeted skills): 0.40
+- skills below F1 0.90: **9**
+- skills below exec 0.95: **3**
+
+| skill | n | TP | FN | FP | precision | recall | F1 | exec | neg-FP |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
+| buildkite-api | 4 | 0 | 4 | 0 | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 |
+| buildkite-cli | 4 | 1 | 3 | 0 | 1.00 | 0.25 | 0.40 | 1.00 | 0.00 |
+| buildkite-pipelines | 4 | 2 | 2 | 0 | 1.00 | 0.50 | 0.67 | 1.00 | 0.00 |
+| buildkite-secure-delivery | 1 | 0 | 1 | 0 | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 |
+| file-bug | 4 | 1 | 3 | 1 | 0.50 | 0.25 | 0.33 | 1.00 | 0.25 |
+| mcp-builder | 4 | 2 | 2 | 0 | 1.00 | 0.50 | 0.67 | 1.00 | 0.00 |
+| switchroom-cli | 0 | 0 | 0 | 2 | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 |
+| switchroom-install | 4 | 4 | 0 | 0 | 1.00 | 1.00 | 1.00 | 1.00 | 0.00 |
+| switchroom-manage | 4 | 1 | 3 | 0 | 1.00 | 0.25 | 0.40 | 1.00 | 0.00 |
+| switchroom-runtime | 4 | 0 | 4 | 0 | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 |
+| switchroom-status | 4 | 3 | 1 | 2 | 0.60 | 0.75 | 0.67 | 1.00 | 0.00 |

--- a/tests/skill-coverage/scorecards/round-3.run.json
+++ b/tests/skill-coverage/scorecards/round-3.run.json
@@ -1,15 +1,16 @@
 {
-  "startedAt": "2026-05-13T23:48:36.422Z",
-  "finishedAt": "2026-05-13T23:48:36.422Z",
+  "startedAt": "2026-05-13T23:42:45.692Z",
+  "finishedAt": "2026-05-13T23:55:56.037Z",
   "seed": 1,
   "agentName": "claude-cli",
   "results": [
     {
       "probe": {
-        "id": "partial-0",
-        "kind": "paraphrase",
+        "id": "754b1b980b3485cd",
         "targetSkill": "switchroom-runtime",
-        "phrase": ""
+        "kind": "paraphrase",
+        "phrase": "Why did you restart, please.",
+        "source": "paraphrase-template"
       },
       "skillsInvoked": [],
       "turnDurationMs": 6401,
@@ -18,10 +19,11 @@
     },
     {
       "probe": {
-        "id": "partial-1",
-        "kind": "paraphrase",
+        "id": "9fce03095cf54cd5",
         "targetSkill": "switchroom-runtime",
-        "phrase": ""
+        "kind": "paraphrase",
+        "phrase": "I'd like to you went away.",
+        "source": "paraphrase-template"
       },
       "skillsInvoked": [],
       "turnDurationMs": 4971,
@@ -30,10 +32,11 @@
     },
     {
       "probe": {
-        "id": "partial-2",
-        "kind": "paraphrase",
+        "id": "c8a42c5620b1c88a",
         "targetSkill": "switchroom-runtime",
-        "phrase": ""
+        "kind": "paraphrase",
+        "phrase": "Let's can I stop you mid-turn.",
+        "source": "paraphrase-template"
       },
       "skillsInvoked": [],
       "turnDurationMs": 5360,
@@ -42,10 +45,11 @@
     },
     {
       "probe": {
-        "id": "partial-3",
-        "kind": "paraphrase",
+        "id": "4898ad53526c8cc2",
         "targetSkill": "switchroom-runtime",
-        "phrase": ""
+        "kind": "paraphrase",
+        "phrase": "I'd like to why did you restart.",
+        "source": "paraphrase-template"
       },
       "skillsInvoked": [],
       "turnDurationMs": 5565,
@@ -54,10 +58,12 @@
     },
     {
       "probe": {
-        "id": "partial-4",
-        "kind": "negative",
+        "id": "804e347cfe9edb0a",
         "targetSkill": null,
-        "phrase": ""
+        "kind": "negative",
+        "phrase": "report this issue on GitHub",
+        "source": "negative-from-adjacent",
+        "expectedOtherSkill": "file-bug"
       },
       "skillsInvoked": [],
       "turnDurationMs": 5889,
@@ -66,10 +72,12 @@
     },
     {
       "probe": {
-        "id": "partial-5",
-        "kind": "negative",
+        "id": "532f5db97dcb9197",
         "targetSkill": null,
-        "phrase": ""
+        "kind": "negative",
+        "phrase": "apply my config changes",
+        "source": "negative-from-adjacent",
+        "expectedOtherSkill": "switchroom-cli"
       },
       "skillsInvoked": [],
       "turnDurationMs": 6603,
@@ -78,10 +86,12 @@
     },
     {
       "probe": {
-        "id": "partial-6",
-        "kind": "negative",
+        "id": "19c365e9f7fe2b96",
         "targetSkill": null,
-        "phrase": ""
+        "kind": "negative",
+        "phrase": "file a bug",
+        "source": "negative-from-adjacent",
+        "expectedOtherSkill": "file-bug"
       },
       "skillsInvoked": [
         "file-bug"
@@ -92,10 +102,12 @@
     },
     {
       "probe": {
-        "id": "partial-7",
-        "kind": "negative",
+        "id": "beba76aa860bd8fc",
         "targetSkill": null,
-        "phrase": ""
+        "kind": "negative",
+        "phrase": "what version is running",
+        "source": "negative-from-adjacent",
+        "expectedOtherSkill": "switchroom-cli"
       },
       "skillsInvoked": [],
       "turnDurationMs": 5921,
@@ -104,10 +116,11 @@
     },
     {
       "probe": {
-        "id": "partial-8",
-        "kind": "paraphrase",
+        "id": "0074ba58403050cc",
         "targetSkill": "buildkite-cli",
-        "phrase": ""
+        "kind": "paraphrase",
+        "phrase": "Help me retry a build.",
+        "source": "paraphrase-template"
       },
       "skillsInvoked": [],
       "turnDurationMs": 5856,
@@ -116,10 +129,11 @@
     },
     {
       "probe": {
-        "id": "partial-9",
-        "kind": "paraphrase",
+        "id": "1beffbbafd0a4868",
         "targetSkill": "buildkite-cli",
-        "phrase": ""
+        "kind": "paraphrase",
+        "phrase": "List builds, please.",
+        "source": "paraphrase-template"
       },
       "skillsInvoked": [
         "buildkite-cli"
@@ -130,10 +144,11 @@
     },
     {
       "probe": {
-        "id": "partial-10",
-        "kind": "paraphrase",
+        "id": "fd58df1a8a9aa083",
         "targetSkill": "buildkite-cli",
-        "phrase": ""
+        "kind": "paraphrase",
+        "phrase": "Let's upload artifacts.",
+        "source": "paraphrase-template"
       },
       "skillsInvoked": [],
       "turnDurationMs": 8859,
@@ -142,10 +157,11 @@
     },
     {
       "probe": {
-        "id": "partial-11",
-        "kind": "paraphrase",
+        "id": "33a5d799948bdf02",
         "targetSkill": "buildkite-cli",
-        "phrase": ""
+        "kind": "paraphrase",
+        "phrase": "Let's manage secrets.",
+        "source": "paraphrase-template"
       },
       "skillsInvoked": [],
       "turnDurationMs": 5028,
@@ -154,10 +170,11 @@
     },
     {
       "probe": {
-        "id": "partial-12",
-        "kind": "paraphrase",
+        "id": "424ac38af0e80c10",
         "targetSkill": "mcp-builder",
-        "phrase": ""
+        "kind": "paraphrase",
+        "phrase": "Let's write an MCP server for.",
+        "source": "paraphrase-template"
       },
       "skillsInvoked": [],
       "turnDurationMs": 5676,
@@ -166,10 +183,11 @@
     },
     {
       "probe": {
-        "id": "partial-13",
-        "kind": "paraphrase",
+        "id": "4fe676cb9e4daa2c",
         "targetSkill": "mcp-builder",
-        "phrase": ""
+        "kind": "paraphrase",
+        "phrase": "Please integrate an external API as MCP.",
+        "source": "paraphrase-template"
       },
       "skillsInvoked": [
         "mcp-builder"
@@ -180,10 +198,11 @@
     },
     {
       "probe": {
-        "id": "partial-14",
-        "kind": "paraphrase",
+        "id": "c1b20bed12caf131",
         "targetSkill": "mcp-builder",
-        "phrase": ""
+        "kind": "paraphrase",
+        "phrase": "Use the MCP SDK in TypeScript, please.",
+        "source": "paraphrase-template"
       },
       "skillsInvoked": [
         "mcp-builder"
@@ -194,10 +213,11 @@
     },
     {
       "probe": {
-        "id": "partial-15",
-        "kind": "paraphrase",
+        "id": "bdbf5682a445cfd8",
         "targetSkill": "mcp-builder",
-        "phrase": ""
+        "kind": "paraphrase",
+        "phrase": "Write an MCP server for, please.",
+        "source": "paraphrase-template"
       },
       "skillsInvoked": [],
       "turnDurationMs": 14482,
@@ -206,38 +226,43 @@
     },
     {
       "probe": {
-        "id": "partial-16",
-        "kind": "paraphrase",
+        "id": "d11b5f7b565a657c",
         "targetSkill": "switchroom-install",
-        "phrase": ""
+        "kind": "paraphrase",
+        "phrase": "Please what are the switchroom prerequisites.",
+        "source": "paraphrase-template"
       },
       "skillsInvoked": [
         "switchroom-install"
       ],
       "turnDurationMs": 23503,
       "timedOut": false,
-      "agentName": "claude-cli"
+      "agentName": "claude-cli",
+      "error": ""
     },
     {
       "probe": {
-        "id": "partial-17",
-        "kind": "paraphrase",
+        "id": "cc7ee6aa5599c3b6",
         "targetSkill": "switchroom-install",
-        "phrase": ""
+        "kind": "paraphrase",
+        "phrase": "I need to get switchroom running.",
+        "source": "paraphrase-template"
       },
       "skillsInvoked": [
         "switchroom-install"
       ],
       "turnDurationMs": 8984,
       "timedOut": false,
-      "agentName": "claude-cli"
+      "agentName": "claude-cli",
+      "error": ""
     },
     {
       "probe": {
-        "id": "partial-18",
-        "kind": "paraphrase",
+        "id": "4756d898f4bba025",
         "targetSkill": "switchroom-install",
-        "phrase": ""
+        "kind": "paraphrase",
+        "phrase": "Can you bootstrap switchroom from scratch?",
+        "source": "paraphrase-template"
       },
       "skillsInvoked": [
         "switchroom-install"
@@ -248,10 +273,11 @@
     },
     {
       "probe": {
-        "id": "partial-19",
-        "kind": "paraphrase",
+        "id": "34d19aae5bca3e47",
         "targetSkill": "switchroom-install",
-        "phrase": ""
+        "kind": "paraphrase",
+        "phrase": "Help me what are the switchroom prerequisites.",
+        "source": "paraphrase-template"
       },
       "skillsInvoked": [
         "switchroom-install"
@@ -262,10 +288,11 @@
     },
     {
       "probe": {
-        "id": "partial-20",
-        "kind": "paraphrase",
+        "id": "41881c47a4a3e15e",
         "targetSkill": "buildkite-api",
-        "phrase": ""
+        "kind": "paraphrase",
+        "phrase": "Please write a GraphQL query.",
+        "source": "paraphrase-template"
       },
       "skillsInvoked": [],
       "turnDurationMs": 5787,
@@ -274,10 +301,11 @@
     },
     {
       "probe": {
-        "id": "partial-21",
-        "kind": "paraphrase",
+        "id": "70229c0b2563a947",
         "targetSkill": "buildkite-api",
-        "phrase": ""
+        "kind": "paraphrase",
+        "phrase": "Let's paginate API results.",
+        "source": "paraphrase-template"
       },
       "skillsInvoked": [],
       "turnDurationMs": 9721,
@@ -286,10 +314,11 @@
     },
     {
       "probe": {
-        "id": "partial-22",
-        "kind": "paraphrase",
+        "id": "e4752afd7e2b0af8",
         "targetSkill": "buildkite-api",
-        "phrase": ""
+        "kind": "paraphrase",
+        "phrase": "Could you automate Buildkite for me?",
+        "source": "paraphrase-template"
       },
       "skillsInvoked": [],
       "turnDurationMs": 7273,
@@ -298,10 +327,11 @@
     },
     {
       "probe": {
-        "id": "partial-23",
-        "kind": "paraphrase",
+        "id": "b3206a10a7334084",
         "targetSkill": "buildkite-api",
-        "phrase": ""
+        "kind": "paraphrase",
+        "phrase": "Can you authenticate with the Buildkite API?",
+        "source": "paraphrase-template"
       },
       "skillsInvoked": [],
       "turnDurationMs": 9405,
@@ -310,10 +340,11 @@
     },
     {
       "probe": {
-        "id": "partial-24",
-        "kind": "paraphrase",
+        "id": "e5e200db581b3c0f",
         "targetSkill": "file-bug",
-        "phrase": ""
+        "kind": "paraphrase",
+        "phrase": "Can you report this issue on GitHub?",
+        "source": "paraphrase-template"
       },
       "skillsInvoked": [],
       "turnDurationMs": 5333,
@@ -322,10 +353,11 @@
     },
     {
       "probe": {
-        "id": "partial-25",
-        "kind": "paraphrase",
+        "id": "58b5ca0d02679dbf",
         "targetSkill": "file-bug",
-        "phrase": ""
+        "kind": "paraphrase",
+        "phrase": "Please raise a ticket.",
+        "source": "paraphrase-template"
       },
       "skillsInvoked": [],
       "turnDurationMs": 6702,
@@ -334,10 +366,11 @@
     },
     {
       "probe": {
-        "id": "partial-26",
-        "kind": "paraphrase",
+        "id": "0b9cb9e8dc2bdece",
         "targetSkill": "file-bug",
-        "phrase": ""
+        "kind": "paraphrase",
+        "phrase": "I need to this needs a real ticket.",
+        "source": "paraphrase-template"
       },
       "skillsInvoked": [],
       "turnDurationMs": 6487,
@@ -346,10 +379,11 @@
     },
     {
       "probe": {
-        "id": "partial-27",
-        "kind": "paraphrase",
+        "id": "0bba8694d8a59bfc",
         "targetSkill": "file-bug",
-        "phrase": ""
+        "kind": "paraphrase",
+        "phrase": "I need to file a bug.",
+        "source": "paraphrase-template"
       },
       "skillsInvoked": [
         "file-bug"
@@ -360,10 +394,11 @@
     },
     {
       "probe": {
-        "id": "partial-28",
-        "kind": "paraphrase",
+        "id": "80e00bfd3f64a5b3",
         "targetSkill": "switchroom-status",
-        "phrase": ""
+        "kind": "paraphrase",
+        "phrase": "Can you show me the fleet?",
+        "source": "paraphrase-template"
       },
       "skillsInvoked": [
         "switchroom-status",
@@ -371,14 +406,16 @@
       ],
       "turnDurationMs": 6671,
       "timedOut": false,
-      "agentName": "claude-cli"
+      "agentName": "claude-cli",
+      "error": ""
     },
     {
       "probe": {
-        "id": "partial-29",
-        "kind": "paraphrase",
+        "id": "56890b686ada4cf3",
         "targetSkill": "switchroom-status",
-        "phrase": ""
+        "kind": "paraphrase",
+        "phrase": "Let's how long has X been up.",
+        "source": "paraphrase-template"
       },
       "skillsInvoked": [],
       "turnDurationMs": 7342,
@@ -387,10 +424,11 @@
     },
     {
       "probe": {
-        "id": "partial-30",
-        "kind": "paraphrase",
+        "id": "36744fc8f2479df5",
         "targetSkill": "switchroom-status",
-        "phrase": ""
+        "kind": "paraphrase",
+        "phrase": "I'd like to what's the uptime of each agent.",
+        "source": "paraphrase-template"
       },
       "skillsInvoked": [
         "switchroom-status"
@@ -401,10 +439,11 @@
     },
     {
       "probe": {
-        "id": "partial-31",
-        "kind": "paraphrase",
+        "id": "88310367eade3159",
         "targetSkill": "switchroom-status",
-        "phrase": ""
+        "kind": "paraphrase",
+        "phrase": "Let's list switchroom agents.",
+        "source": "paraphrase-template"
       },
       "skillsInvoked": [
         "switchroom-status"
@@ -415,10 +454,11 @@
     },
     {
       "probe": {
-        "id": "partial-32",
-        "kind": "paraphrase",
+        "id": "d477e449908018be",
         "targetSkill": "buildkite-pipelines",
-        "phrase": ""
+        "kind": "paraphrase",
+        "phrase": "Help me write a pipeline.",
+        "source": "paraphrase-template"
       },
       "skillsInvoked": [
         "buildkite-pipelines"
@@ -429,10 +469,11 @@
     },
     {
       "probe": {
-        "id": "partial-33",
-        "kind": "paraphrase",
+        "id": "07f4e023817af4bf",
         "targetSkill": "buildkite-pipelines",
-        "phrase": ""
+        "kind": "paraphrase",
+        "phrase": "Can you parallel steps?",
+        "source": "paraphrase-template"
       },
       "skillsInvoked": [],
       "turnDurationMs": 12434,
@@ -441,22 +482,25 @@
     },
     {
       "probe": {
-        "id": "partial-34",
-        "kind": "paraphrase",
+        "id": "571f3200656feb4c",
         "targetSkill": "buildkite-pipelines",
-        "phrase": ""
+        "kind": "paraphrase",
+        "phrase": "Let's add retry.",
+        "source": "paraphrase-template"
       },
       "skillsInvoked": [],
       "turnDurationMs": 9716,
       "timedOut": true,
-      "agentName": "claude-cli"
+      "agentName": "claude-cli",
+      "error": ""
     },
     {
       "probe": {
-        "id": "partial-35",
-        "kind": "paraphrase",
+        "id": "b41ce8c45093aebb",
         "targetSkill": "buildkite-pipelines",
-        "phrase": ""
+        "kind": "paraphrase",
+        "phrase": "Let's show test failures in the build page.",
+        "source": "paraphrase-template"
       },
       "skillsInvoked": [
         "buildkite-pipelines"
@@ -467,10 +511,11 @@
     },
     {
       "probe": {
-        "id": "partial-36",
-        "kind": "paraphrase",
+        "id": "4d738e2334447b23",
         "targetSkill": "switchroom-manage",
-        "phrase": ""
+        "kind": "paraphrase",
+        "phrase": "I need to reprovision my agents.",
+        "source": "paraphrase-template"
       },
       "skillsInvoked": [
         "switchroom-manage",
@@ -478,14 +523,16 @@
       ],
       "turnDurationMs": 12722,
       "timedOut": false,
-      "agentName": "claude-cli"
+      "agentName": "claude-cli",
+      "error": ""
     },
     {
       "probe": {
-        "id": "partial-37",
-        "kind": "paraphrase",
+        "id": "03021950a05b8eb2",
         "targetSkill": "switchroom-manage",
-        "phrase": ""
+        "kind": "paraphrase",
+        "phrase": "Could you reprovision my agents for me?",
+        "source": "paraphrase-template"
       },
       "skillsInvoked": [],
       "turnDurationMs": 7655,
@@ -494,10 +541,11 @@
     },
     {
       "probe": {
-        "id": "partial-38",
-        "kind": "paraphrase",
+        "id": "2fbf26091b974fd1",
         "targetSkill": "switchroom-manage",
-        "phrase": ""
+        "kind": "paraphrase",
+        "phrase": "Manage my agents, please.",
+        "source": "paraphrase-template"
       },
       "skillsInvoked": [
         "switchroom-status",
@@ -505,14 +553,16 @@
       ],
       "turnDurationMs": 8534,
       "timedOut": false,
-      "agentName": "claude-cli"
+      "agentName": "claude-cli",
+      "error": ""
     },
     {
       "probe": {
-        "id": "partial-39",
-        "kind": "paraphrase",
+        "id": "901853b79731581a",
         "targetSkill": "switchroom-manage",
-        "phrase": ""
+        "kind": "paraphrase",
+        "phrase": "Can you reinstall my agents?",
+        "source": "paraphrase-template"
       },
       "skillsInvoked": [],
       "turnDurationMs": 7036,
@@ -521,13 +571,876 @@
     },
     {
       "probe": {
-        "id": "partial-40",
-        "kind": "paraphrase",
+        "id": "7159b5a8c1b85511",
         "targetSkill": "buildkite-secure-delivery",
-        "phrase": ""
+        "kind": "paraphrase",
+        "phrase": "Please secure the supply chain.",
+        "source": "paraphrase-template"
       },
       "skillsInvoked": [],
       "turnDurationMs": 7341,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "d7508f30f8981362",
+        "targetSkill": "buildkite-secure-delivery",
+        "kind": "paraphrase",
+        "phrase": "I'd like to push a Docker image.",
+        "source": "paraphrase-template"
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 7752,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "22aa5d5ea074fd2a",
+        "targetSkill": "buildkite-secure-delivery",
+        "kind": "paraphrase",
+        "phrase": "Can you sign pipelines?",
+        "source": "paraphrase-template"
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 9679,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "622a19bd55db67fe",
+        "targetSkill": "buildkite-secure-delivery",
+        "kind": "paraphrase",
+        "phrase": "I need to verify pipeline signatures.",
+        "source": "paraphrase-template"
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 6766,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "438fc70881ebd7be",
+        "targetSkill": "pptx",
+        "kind": "paraphrase",
+        "phrase": "I need to combine slide files.",
+        "source": "paraphrase-template"
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 8199,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "7f885a9e7e30f05e",
+        "targetSkill": "pptx",
+        "kind": "paraphrase",
+        "phrase": "I need to work from a slide template.",
+        "source": "paraphrase-template"
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 5780,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "54e44ade1af44d39",
+        "targetSkill": "pptx",
+        "kind": "paraphrase",
+        "phrase": "Help me split this deck.",
+        "source": "paraphrase-template"
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 6528,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "17a25fb6eff1dec6",
+        "targetSkill": "pptx",
+        "kind": "paraphrase",
+        "phrase": "I'd like to edit this presentation.",
+        "source": "paraphrase-template"
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 4092,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "02d18942126fff9a",
+        "targetSkill": "webapp-testing",
+        "kind": "paraphrase",
+        "phrase": "Please spin up a local server and test it.",
+        "source": "paraphrase-template"
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 11186,
+      "timedOut": true,
+      "agentName": "claude-cli",
+      "error": ""
+    },
+    {
+      "probe": {
+        "id": "2210900d0f51dc48",
+        "targetSkill": "webapp-testing",
+        "kind": "paraphrase",
+        "phrase": "I'd like to run a Playwright test.",
+        "source": "paraphrase-template"
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 7087,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "9792880f2a535c4d",
+        "targetSkill": "webapp-testing",
+        "kind": "paraphrase",
+        "phrase": "Can you run a Playwright test?",
+        "source": "paraphrase-template"
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 5321,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "0bfc25f1daa4124c",
+        "targetSkill": "webapp-testing",
+        "kind": "paraphrase",
+        "phrase": "Help me view browser logs.",
+        "source": "paraphrase-template"
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 8430,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "854545d990ef3fca",
+        "targetSkill": "skill-creator",
+        "kind": "paraphrase",
+        "phrase": "Edit an existing skill, please.",
+        "source": "paraphrase-template"
+      },
+      "skillsInvoked": [
+        "skill-creator"
+      ],
+      "turnDurationMs": 6033,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "3c28490199165a06",
+        "targetSkill": "skill-creator",
+        "kind": "paraphrase",
+        "phrase": "I need to create a new skill.",
+        "source": "paraphrase-template"
+      },
+      "skillsInvoked": [
+        "skill-creator"
+      ],
+      "turnDurationMs": 11485,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "497305ff3f6914be",
+        "targetSkill": "skill-creator",
+        "kind": "paraphrase",
+        "phrase": "Help me create a new skill.",
+        "source": "paraphrase-template"
+      },
+      "skillsInvoked": [
+        "skill-creator"
+      ],
+      "turnDurationMs": 8236,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "f0c1d85234cccb74",
+        "targetSkill": "skill-creator",
+        "kind": "paraphrase",
+        "phrase": "Can you improve the trigger accuracy of a skill?",
+        "source": "paraphrase-template"
+      },
+      "skillsInvoked": [
+        "skill-creator"
+      ],
+      "turnDurationMs": 7571,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "49994bfd7e52eb43",
+        "targetSkill": "xlsx",
+        "kind": "paraphrase",
+        "phrase": "I'd like to edit a spreadsheet.",
+        "source": "paraphrase-template"
+      },
+      "skillsInvoked": [
+        "xlsx"
+      ],
+      "turnDurationMs": 7144,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "d882f4dfd96c6c20",
+        "targetSkill": "xlsx",
+        "kind": "paraphrase",
+        "phrase": "Help me create a spreadsheet from scratch.",
+        "source": "paraphrase-template"
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 5509,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "9fd4947b9ba7860f",
+        "targetSkill": "xlsx",
+        "kind": "paraphrase",
+        "phrase": "Let's build a financial model.",
+        "source": "paraphrase-template"
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 7552,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "87cab2eca0c166fa",
+        "targetSkill": "xlsx",
+        "kind": "paraphrase",
+        "phrase": "Fix malformed rows in this CSV, please.",
+        "source": "paraphrase-template"
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 4744,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "f5ec1301b2e9abf2",
+        "targetSkill": "buildkite-agent-runtime",
+        "kind": "paraphrase",
+        "phrase": "Get or update a step attribute, please.",
+        "source": "paraphrase-template"
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 8219,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "57b6365ac141458c",
+        "targetSkill": "buildkite-agent-runtime",
+        "kind": "paraphrase",
+        "phrase": "Please upload artifacts from a step.",
+        "source": "paraphrase-template"
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 6153,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "b5803cebdad83be5",
+        "targetSkill": "buildkite-agent-runtime",
+        "kind": "paraphrase",
+        "phrase": "Help me add an annotation.",
+        "source": "paraphrase-template"
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 5967,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "a7fd9ab000869b11",
+        "targetSkill": "buildkite-agent-runtime",
+        "kind": "paraphrase",
+        "phrase": "Please add an annotation.",
+        "source": "paraphrase-template"
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 5389,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "b7f8cab4d168ac58",
+        "targetSkill": "switchroom-health",
+        "kind": "paraphrase",
+        "phrase": "Can you something's wrong?",
+        "source": "paraphrase-template"
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 4432,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "fb1e4cccf4f28f9d",
+        "targetSkill": "switchroom-health",
+        "kind": "paraphrase",
+        "phrase": "What's wrong with my agents, please.",
+        "source": "paraphrase-template"
+      },
+      "skillsInvoked": [
+        "switchroom-status",
+        "switchroom-health"
+      ],
+      "turnDurationMs": 6662,
+      "timedOut": false,
+      "agentName": "claude-cli",
+      "error": ""
+    },
+    {
+      "probe": {
+        "id": "485f1d2e84cd94ae",
+        "targetSkill": "switchroom-health",
+        "kind": "paraphrase",
+        "phrase": "Could you what's wrong with my agents for me?",
+        "source": "paraphrase-template"
+      },
+      "skillsInvoked": [
+        "switchroom-health",
+        "switchroom-status"
+      ],
+      "turnDurationMs": 10826,
+      "timedOut": false,
+      "agentName": "claude-cli",
+      "error": ""
+    },
+    {
+      "probe": {
+        "id": "deda1e8dd0e019ce",
+        "targetSkill": "switchroom-health",
+        "kind": "paraphrase",
+        "phrase": "Help me can you check my setup.",
+        "source": "paraphrase-template"
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 11675,
+      "timedOut": true,
+      "agentName": "claude-cli",
+      "error": ""
+    },
+    {
+      "probe": {
+        "id": "956ee00987b2ab3d",
+        "targetSkill": "docx",
+        "kind": "paraphrase",
+        "phrase": "Help me accept tracked changes.",
+        "source": "paraphrase-template"
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 9170,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "085af3e287ea14e4",
+        "targetSkill": "docx",
+        "kind": "paraphrase",
+        "phrase": "Please insert page numbers.",
+        "source": "paraphrase-template"
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 6892,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "1b62dd6f6ed4f153",
+        "targetSkill": "docx",
+        "kind": "paraphrase",
+        "phrase": "I'd like to read a .docx file.",
+        "source": "paraphrase-template"
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 4439,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "eb3eed2810ebe999",
+        "targetSkill": "docx",
+        "kind": "paraphrase",
+        "phrase": "Can you produce a report as a Word file?",
+        "source": "paraphrase-template"
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 4873,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "00ac3193aedba37f",
+        "targetSkill": "humanizer",
+        "kind": "paraphrase",
+        "phrase": "Let's rewrite this to sound natural.",
+        "source": "paraphrase-template"
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 3885,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "b8a8169d881e27ef",
+        "targetSkill": "humanizer",
+        "kind": "paraphrase",
+        "phrase": "Please edit this so it doesn't sound like AI.",
+        "source": "paraphrase-template"
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 3594,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "a3290aeac74bdac5",
+        "targetSkill": "humanizer",
+        "kind": "paraphrase",
+        "phrase": "Can you remove the rule of three?",
+        "source": "paraphrase-template"
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 7316,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "56d73ad8a10e9140",
+        "targetSkill": "humanizer",
+        "kind": "paraphrase",
+        "phrase": "Remove signs of AI writing, please.",
+        "source": "paraphrase-template"
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 5403,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "f712350649eae0b9",
+        "targetSkill": "buildkite-test-engine",
+        "kind": "paraphrase",
+        "phrase": "Help me detect flaky tests.",
+        "source": "paraphrase-template"
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 8434,
+      "timedOut": true,
+      "agentName": "claude-cli",
+      "error": ""
+    },
+    {
+      "probe": {
+        "id": "a0e649c04d026859",
+        "targetSkill": "buildkite-test-engine",
+        "kind": "paraphrase",
+        "phrase": "Can you parallelize test suite?",
+        "source": "paraphrase-template"
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 12588,
+      "timedOut": true,
+      "agentName": "claude-cli",
+      "error": ""
+    },
+    {
+      "probe": {
+        "id": "b5d71554e6a2a26a",
+        "targetSkill": "buildkite-test-engine",
+        "kind": "paraphrase",
+        "phrase": "Can you configure test collectors?",
+        "source": "paraphrase-template"
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 6241,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "1f53d05da54d7bef",
+        "targetSkill": "buildkite-test-engine",
+        "kind": "paraphrase",
+        "phrase": "Let's speed up tests.",
+        "source": "paraphrase-template"
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 6610,
+      "timedOut": true,
+      "agentName": "claude-cli",
+      "error": ""
+    },
+    {
+      "probe": {
+        "id": "f2a504ff86c255b6",
+        "targetSkill": "pdf",
+        "kind": "paraphrase",
+        "phrase": "Let's rotate PDF pages.",
+        "source": "paraphrase-template"
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 5336,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "7d4bdaa90212e0d9",
+        "targetSkill": "pdf",
+        "kind": "paraphrase",
+        "phrase": "I need to watermark a PDF.",
+        "source": "paraphrase-template"
+      },
+      "skillsInvoked": [
+        "pdf"
+      ],
+      "turnDurationMs": 6070,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "6aa8261e06309f4d",
+        "targetSkill": "pdf",
+        "kind": "paraphrase",
+        "phrase": "Can you rotate PDF pages?",
+        "source": "paraphrase-template"
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 5203,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "2ea2d61882976e1c",
+        "targetSkill": "pdf",
+        "kind": "paraphrase",
+        "phrase": "Can you fill a PDF form?",
+        "source": "paraphrase-template"
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 5599,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "b0b1fc17505da42e",
+        "targetSkill": "buildkite-agent-infrastructure",
+        "kind": "paraphrase",
+        "phrase": "Create a queue, please.",
+        "source": "paraphrase-template"
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 5086,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "edc53cb8156ae93c",
+        "targetSkill": "buildkite-agent-infrastructure",
+        "kind": "paraphrase",
+        "phrase": "Let's configure SSO.",
+        "source": "paraphrase-template"
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 5844,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "a095f56ce695a518",
+        "targetSkill": "buildkite-agent-infrastructure",
+        "kind": "paraphrase",
+        "phrase": "Could you scale queues for me?",
+        "source": "paraphrase-template"
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 5602,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "329d2b06a3ed95f3",
+        "targetSkill": "buildkite-agent-infrastructure",
+        "kind": "paraphrase",
+        "phrase": "I need to configure SSO.",
+        "source": "paraphrase-template"
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 5711,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "c5740f7afc2968e6",
+        "targetSkill": "telegram-test-harness",
+        "kind": "paraphrase",
+        "phrase": "Let's write a telegram test.",
+        "source": "paraphrase-template"
+      },
+      "skillsInvoked": [
+        "telegram-test-harness"
+      ],
+      "turnDurationMs": 9384,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "c0f02f4aaa8c7519",
+        "targetSkill": "telegram-test-harness",
+        "kind": "paraphrase",
+        "phrase": "Mock the bot api, please.",
+        "source": "paraphrase-template"
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 5595,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "3e4f60d8740c7e2e",
+        "targetSkill": "telegram-test-harness",
+        "kind": "paraphrase",
+        "phrase": "Write a telegram regression test, please.",
+        "source": "paraphrase-template"
+      },
+      "skillsInvoked": [
+        "telegram-test-harness"
+      ],
+      "turnDurationMs": 7352,
+      "timedOut": false,
+      "agentName": "claude-cli",
+      "error": ""
+    },
+    {
+      "probe": {
+        "id": "1d9f8cc253191425",
+        "targetSkill": "telegram-test-harness",
+        "kind": "paraphrase",
+        "phrase": "Test pin behavior, please.",
+        "source": "paraphrase-template"
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 7107,
+      "timedOut": true,
+      "agentName": "claude-cli",
+      "error": ""
+    },
+    {
+      "probe": {
+        "id": "74b1bff5af5755f9",
+        "targetSkill": "switchroom-cli",
+        "kind": "paraphrase",
+        "phrase": "Please sync my config.",
+        "source": "paraphrase-template"
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 6976,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "2173ae43f4d49fcc",
+        "targetSkill": "switchroom-cli",
+        "kind": "paraphrase",
+        "phrase": "Could you check the journal for me?",
+        "source": "paraphrase-template"
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 5346,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "42a4f0331a730ccc",
+        "targetSkill": "switchroom-cli",
+        "kind": "paraphrase",
+        "phrase": "Can you why did it crash?",
+        "source": "paraphrase-template"
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 5175,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "254a349850a37042",
+        "targetSkill": "switchroom-cli",
+        "kind": "paraphrase",
+        "phrase": "Upgrade switchroom, please.",
+        "source": "paraphrase-template"
+      },
+      "skillsInvoked": [
+        "switchroom-manage",
+        "switchroom-cli"
+      ],
+      "turnDurationMs": 8707,
+      "timedOut": false,
+      "agentName": "claude-cli",
+      "error": ""
+    },
+    {
+      "probe": {
+        "id": "cecbf0ab202dd3e3",
+        "targetSkill": "buildkite-migration",
+        "kind": "paraphrase",
+        "phrase": "Can you what's the Buildkite equivalent of?",
+        "source": "paraphrase-template"
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 4897,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "faa7c96ed22e804d",
+        "targetSkill": "buildkite-migration",
+        "kind": "paraphrase",
+        "phrase": "Let's convert pipelines from Jenkins.",
+        "source": "paraphrase-template"
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 6496,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "6537fb1e1bedc379",
+        "targetSkill": "buildkite-migration",
+        "kind": "paraphrase",
+        "phrase": "What's the Buildkite equivalent of, please.",
+        "source": "paraphrase-template"
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 3992,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "6424ca42e4d5c52b",
+        "targetSkill": "buildkite-migration",
+        "kind": "paraphrase",
+        "phrase": "Help me convert pipelines from Jenkins.",
+        "source": "paraphrase-template"
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 10487,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "39cd5eb6b6b17d11",
+        "targetSkill": "humanizer-calibrate",
+        "kind": "paraphrase",
+        "phrase": "Let's humanizer-calibrate.",
+        "source": "paraphrase-template"
+      },
+      "skillsInvoked": [
+        "humanizer-calibrate"
+      ],
+      "turnDurationMs": 7855,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "c125261face8b61b",
+        "targetSkill": "humanizer-calibrate",
+        "kind": "paraphrase",
+        "phrase": "Please calibrate humanizer.",
+        "source": "paraphrase-template"
+      },
+      "skillsInvoked": [
+        "humanizer-calibrate"
+      ],
+      "turnDurationMs": 13107,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "837ba534114c06ca",
+        "targetSkill": "humanizer-calibrate",
+        "kind": "paraphrase",
+        "phrase": "Make humanizer sound more like me, please.",
+        "source": "paraphrase-template"
+      },
+      "skillsInvoked": [
+        "humanizer-calibrate"
+      ],
+      "turnDurationMs": 8977,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "9981906fb7f32443",
+        "targetSkill": "humanizer-calibrate",
+        "kind": "paraphrase",
+        "phrase": "Can you humanizer-calibrate?",
+        "source": "paraphrase-template"
+      },
+      "skillsInvoked": [
+        "humanizer-calibrate"
+      ],
+      "turnDurationMs": 6617,
       "timedOut": false,
       "agentName": "claude-cli"
     }

--- a/tests/skill-coverage/scorecards/round-3.run.json
+++ b/tests/skill-coverage/scorecards/round-3.run.json
@@ -1,0 +1,535 @@
+{
+  "startedAt": "2026-05-13T23:48:36.422Z",
+  "finishedAt": "2026-05-13T23:48:36.422Z",
+  "seed": 1,
+  "agentName": "claude-cli",
+  "results": [
+    {
+      "probe": {
+        "id": "partial-0",
+        "kind": "paraphrase",
+        "targetSkill": "switchroom-runtime",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 6401,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-1",
+        "kind": "paraphrase",
+        "targetSkill": "switchroom-runtime",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 4971,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-2",
+        "kind": "paraphrase",
+        "targetSkill": "switchroom-runtime",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 5360,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-3",
+        "kind": "paraphrase",
+        "targetSkill": "switchroom-runtime",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 5565,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-4",
+        "kind": "negative",
+        "targetSkill": null,
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 5889,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-5",
+        "kind": "negative",
+        "targetSkill": null,
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 6603,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-6",
+        "kind": "negative",
+        "targetSkill": null,
+        "phrase": ""
+      },
+      "skillsInvoked": [
+        "file-bug"
+      ],
+      "turnDurationMs": 8592,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-7",
+        "kind": "negative",
+        "targetSkill": null,
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 5921,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-8",
+        "kind": "paraphrase",
+        "targetSkill": "buildkite-cli",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 5856,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-9",
+        "kind": "paraphrase",
+        "targetSkill": "buildkite-cli",
+        "phrase": ""
+      },
+      "skillsInvoked": [
+        "buildkite-cli"
+      ],
+      "turnDurationMs": 10602,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-10",
+        "kind": "paraphrase",
+        "targetSkill": "buildkite-cli",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 8859,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-11",
+        "kind": "paraphrase",
+        "targetSkill": "buildkite-cli",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 5028,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-12",
+        "kind": "paraphrase",
+        "targetSkill": "mcp-builder",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 5676,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-13",
+        "kind": "paraphrase",
+        "targetSkill": "mcp-builder",
+        "phrase": ""
+      },
+      "skillsInvoked": [
+        "mcp-builder"
+      ],
+      "turnDurationMs": 9061,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-14",
+        "kind": "paraphrase",
+        "targetSkill": "mcp-builder",
+        "phrase": ""
+      },
+      "skillsInvoked": [
+        "mcp-builder"
+      ],
+      "turnDurationMs": 10760,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-15",
+        "kind": "paraphrase",
+        "targetSkill": "mcp-builder",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 14482,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-16",
+        "kind": "paraphrase",
+        "targetSkill": "switchroom-install",
+        "phrase": ""
+      },
+      "skillsInvoked": [
+        "switchroom-install"
+      ],
+      "turnDurationMs": 23503,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-17",
+        "kind": "paraphrase",
+        "targetSkill": "switchroom-install",
+        "phrase": ""
+      },
+      "skillsInvoked": [
+        "switchroom-install"
+      ],
+      "turnDurationMs": 8984,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-18",
+        "kind": "paraphrase",
+        "targetSkill": "switchroom-install",
+        "phrase": ""
+      },
+      "skillsInvoked": [
+        "switchroom-install"
+      ],
+      "turnDurationMs": 9969,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-19",
+        "kind": "paraphrase",
+        "targetSkill": "switchroom-install",
+        "phrase": ""
+      },
+      "skillsInvoked": [
+        "switchroom-install"
+      ],
+      "turnDurationMs": 9096,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-20",
+        "kind": "paraphrase",
+        "targetSkill": "buildkite-api",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 5787,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-21",
+        "kind": "paraphrase",
+        "targetSkill": "buildkite-api",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 9721,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-22",
+        "kind": "paraphrase",
+        "targetSkill": "buildkite-api",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 7273,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-23",
+        "kind": "paraphrase",
+        "targetSkill": "buildkite-api",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 9405,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-24",
+        "kind": "paraphrase",
+        "targetSkill": "file-bug",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 5333,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-25",
+        "kind": "paraphrase",
+        "targetSkill": "file-bug",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 6702,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-26",
+        "kind": "paraphrase",
+        "targetSkill": "file-bug",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 6487,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-27",
+        "kind": "paraphrase",
+        "targetSkill": "file-bug",
+        "phrase": ""
+      },
+      "skillsInvoked": [
+        "file-bug"
+      ],
+      "turnDurationMs": 6464,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-28",
+        "kind": "paraphrase",
+        "targetSkill": "switchroom-status",
+        "phrase": ""
+      },
+      "skillsInvoked": [
+        "switchroom-status",
+        "switchroom-cli"
+      ],
+      "turnDurationMs": 6671,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-29",
+        "kind": "paraphrase",
+        "targetSkill": "switchroom-status",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 7342,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-30",
+        "kind": "paraphrase",
+        "targetSkill": "switchroom-status",
+        "phrase": ""
+      },
+      "skillsInvoked": [
+        "switchroom-status"
+      ],
+      "turnDurationMs": 13225,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-31",
+        "kind": "paraphrase",
+        "targetSkill": "switchroom-status",
+        "phrase": ""
+      },
+      "skillsInvoked": [
+        "switchroom-status"
+      ],
+      "turnDurationMs": 8776,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-32",
+        "kind": "paraphrase",
+        "targetSkill": "buildkite-pipelines",
+        "phrase": ""
+      },
+      "skillsInvoked": [
+        "buildkite-pipelines"
+      ],
+      "turnDurationMs": 9492,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-33",
+        "kind": "paraphrase",
+        "targetSkill": "buildkite-pipelines",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 12434,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-34",
+        "kind": "paraphrase",
+        "targetSkill": "buildkite-pipelines",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 9716,
+      "timedOut": true,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-35",
+        "kind": "paraphrase",
+        "targetSkill": "buildkite-pipelines",
+        "phrase": ""
+      },
+      "skillsInvoked": [
+        "buildkite-pipelines"
+      ],
+      "turnDurationMs": 10661,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-36",
+        "kind": "paraphrase",
+        "targetSkill": "switchroom-manage",
+        "phrase": ""
+      },
+      "skillsInvoked": [
+        "switchroom-manage",
+        "switchroom-status"
+      ],
+      "turnDurationMs": 12722,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-37",
+        "kind": "paraphrase",
+        "targetSkill": "switchroom-manage",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 7655,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-38",
+        "kind": "paraphrase",
+        "targetSkill": "switchroom-manage",
+        "phrase": ""
+      },
+      "skillsInvoked": [
+        "switchroom-status",
+        "switchroom-cli"
+      ],
+      "turnDurationMs": 8534,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-39",
+        "kind": "paraphrase",
+        "targetSkill": "switchroom-manage",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 7036,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    },
+    {
+      "probe": {
+        "id": "partial-40",
+        "kind": "paraphrase",
+        "targetSkill": "buildkite-secure-delivery",
+        "phrase": ""
+      },
+      "skillsInvoked": [],
+      "turnDurationMs": 7341,
+      "timedOut": false,
+      "agentName": "claude-cli"
+    }
+  ]
+}

--- a/tests/skill-coverage/scorecards/round-3.scorecard.json
+++ b/tests/skill-coverage/scorecards/round-3.scorecard.json
@@ -1,8 +1,32 @@
 {
-  "generatedAt": "2026-05-13T23:48:36.423Z",
+  "generatedAt": "2026-05-13T23:55:56.038Z",
   "seed": 1,
-  "totalProbes": 41,
+  "totalProbes": 104,
   "rows": [
+    {
+      "skill": "buildkite-agent-infrastructure",
+      "sampleSize": 4,
+      "truePositives": 0,
+      "falseNegatives": 4,
+      "falsePositives": 0,
+      "precision": 0,
+      "recall": 0,
+      "f1": 0,
+      "execSuccess": 0,
+      "negativeControlFpRate": 0
+    },
+    {
+      "skill": "buildkite-agent-runtime",
+      "sampleSize": 4,
+      "truePositives": 0,
+      "falseNegatives": 4,
+      "falsePositives": 0,
+      "precision": 0,
+      "recall": 0,
+      "f1": 0,
+      "execSuccess": 0,
+      "negativeControlFpRate": 0
+    },
     {
       "skill": "buildkite-api",
       "sampleSize": 4,
@@ -28,6 +52,18 @@
       "negativeControlFpRate": 0
     },
     {
+      "skill": "buildkite-migration",
+      "sampleSize": 4,
+      "truePositives": 0,
+      "falseNegatives": 4,
+      "falsePositives": 0,
+      "precision": 0,
+      "recall": 0,
+      "f1": 0,
+      "execSuccess": 0,
+      "negativeControlFpRate": 0
+    },
+    {
       "skill": "buildkite-pipelines",
       "sampleSize": 4,
       "truePositives": 2,
@@ -41,9 +77,33 @@
     },
     {
       "skill": "buildkite-secure-delivery",
-      "sampleSize": 1,
+      "sampleSize": 4,
       "truePositives": 0,
-      "falseNegatives": 1,
+      "falseNegatives": 4,
+      "falsePositives": 0,
+      "precision": 0,
+      "recall": 0,
+      "f1": 0,
+      "execSuccess": 0,
+      "negativeControlFpRate": 0
+    },
+    {
+      "skill": "buildkite-test-engine",
+      "sampleSize": 4,
+      "truePositives": 0,
+      "falseNegatives": 4,
+      "falsePositives": 0,
+      "precision": 0,
+      "recall": 0,
+      "f1": 0,
+      "execSuccess": 0,
+      "negativeControlFpRate": 0
+    },
+    {
+      "skill": "docx",
+      "sampleSize": 4,
+      "truePositives": 0,
+      "falseNegatives": 4,
       "falsePositives": 0,
       "precision": 0,
       "recall": 0,
@@ -64,6 +124,30 @@
       "negativeControlFpRate": 0.25
     },
     {
+      "skill": "humanizer",
+      "sampleSize": 4,
+      "truePositives": 0,
+      "falseNegatives": 4,
+      "falsePositives": 0,
+      "precision": 0,
+      "recall": 0,
+      "f1": 0,
+      "execSuccess": 0,
+      "negativeControlFpRate": 0
+    },
+    {
+      "skill": "humanizer-calibrate",
+      "sampleSize": 4,
+      "truePositives": 4,
+      "falseNegatives": 0,
+      "falsePositives": 0,
+      "precision": 1,
+      "recall": 1,
+      "f1": 1,
+      "execSuccess": 1,
+      "negativeControlFpRate": 0
+    },
+    {
       "skill": "mcp-builder",
       "sampleSize": 4,
       "truePositives": 2,
@@ -76,15 +160,63 @@
       "negativeControlFpRate": 0
     },
     {
-      "skill": "switchroom-cli",
-      "sampleSize": 0,
+      "skill": "pdf",
+      "sampleSize": 4,
+      "truePositives": 1,
+      "falseNegatives": 3,
+      "falsePositives": 0,
+      "precision": 1,
+      "recall": 0.25,
+      "f1": 0.4,
+      "execSuccess": 1,
+      "negativeControlFpRate": 0
+    },
+    {
+      "skill": "pptx",
+      "sampleSize": 4,
       "truePositives": 0,
-      "falseNegatives": 0,
-      "falsePositives": 2,
+      "falseNegatives": 4,
+      "falsePositives": 0,
       "precision": 0,
       "recall": 0,
       "f1": 0,
       "execSuccess": 0,
+      "negativeControlFpRate": 0
+    },
+    {
+      "skill": "skill-creator",
+      "sampleSize": 4,
+      "truePositives": 4,
+      "falseNegatives": 0,
+      "falsePositives": 0,
+      "precision": 1,
+      "recall": 1,
+      "f1": 1,
+      "execSuccess": 1,
+      "negativeControlFpRate": 0
+    },
+    {
+      "skill": "switchroom-cli",
+      "sampleSize": 4,
+      "truePositives": 1,
+      "falseNegatives": 3,
+      "falsePositives": 2,
+      "precision": 0.3333333333333333,
+      "recall": 0.25,
+      "f1": 0.28571428571428575,
+      "execSuccess": 1,
+      "negativeControlFpRate": 0
+    },
+    {
+      "skill": "switchroom-health",
+      "sampleSize": 4,
+      "truePositives": 2,
+      "falseNegatives": 2,
+      "falsePositives": 0,
+      "precision": 1,
+      "recall": 0.5,
+      "f1": 0.6666666666666666,
+      "execSuccess": 1,
       "negativeControlFpRate": 0
     },
     {
@@ -104,10 +236,10 @@
       "sampleSize": 4,
       "truePositives": 1,
       "falseNegatives": 3,
-      "falsePositives": 0,
-      "precision": 1,
+      "falsePositives": 1,
+      "precision": 0.5,
       "recall": 0.25,
-      "f1": 0.4,
+      "f1": 0.3333333333333333,
       "execSuccess": 1,
       "negativeControlFpRate": 0
     },
@@ -128,18 +260,54 @@
       "sampleSize": 4,
       "truePositives": 3,
       "falseNegatives": 1,
-      "falsePositives": 2,
-      "precision": 0.6,
+      "falsePositives": 4,
+      "precision": 0.42857142857142855,
       "recall": 0.75,
-      "f1": 0.6666666666666665,
+      "f1": 0.5454545454545454,
+      "execSuccess": 1,
+      "negativeControlFpRate": 0
+    },
+    {
+      "skill": "telegram-test-harness",
+      "sampleSize": 4,
+      "truePositives": 2,
+      "falseNegatives": 2,
+      "falsePositives": 0,
+      "precision": 1,
+      "recall": 0.5,
+      "f1": 0.6666666666666666,
+      "execSuccess": 1,
+      "negativeControlFpRate": 0
+    },
+    {
+      "skill": "webapp-testing",
+      "sampleSize": 4,
+      "truePositives": 0,
+      "falseNegatives": 4,
+      "falsePositives": 0,
+      "precision": 0,
+      "recall": 0,
+      "f1": 0,
+      "execSuccess": 0,
+      "negativeControlFpRate": 0
+    },
+    {
+      "skill": "xlsx",
+      "sampleSize": 4,
+      "truePositives": 1,
+      "falseNegatives": 3,
+      "falsePositives": 0,
+      "precision": 1,
+      "recall": 0.25,
+      "f1": 0.4,
       "execSuccess": 1,
       "negativeControlFpRate": 0
     }
   ],
   "aggregate": {
-    "medianF1": 0.4,
-    "skillsBelowF1Threshold": 9,
-    "skillsBelowExecThreshold": 3,
+    "medianF1": 0.3333333333333333,
+    "skillsBelowF1Threshold": 22,
+    "skillsBelowExecThreshold": 11,
     "f1Threshold": 0.9,
     "execThreshold": 0.95
   }

--- a/tests/skill-coverage/scorecards/round-3.scorecard.json
+++ b/tests/skill-coverage/scorecards/round-3.scorecard.json
@@ -1,0 +1,146 @@
+{
+  "generatedAt": "2026-05-13T23:48:36.423Z",
+  "seed": 1,
+  "totalProbes": 41,
+  "rows": [
+    {
+      "skill": "buildkite-api",
+      "sampleSize": 4,
+      "truePositives": 0,
+      "falseNegatives": 4,
+      "falsePositives": 0,
+      "precision": 0,
+      "recall": 0,
+      "f1": 0,
+      "execSuccess": 0,
+      "negativeControlFpRate": 0
+    },
+    {
+      "skill": "buildkite-cli",
+      "sampleSize": 4,
+      "truePositives": 1,
+      "falseNegatives": 3,
+      "falsePositives": 0,
+      "precision": 1,
+      "recall": 0.25,
+      "f1": 0.4,
+      "execSuccess": 1,
+      "negativeControlFpRate": 0
+    },
+    {
+      "skill": "buildkite-pipelines",
+      "sampleSize": 4,
+      "truePositives": 2,
+      "falseNegatives": 2,
+      "falsePositives": 0,
+      "precision": 1,
+      "recall": 0.5,
+      "f1": 0.6666666666666666,
+      "execSuccess": 1,
+      "negativeControlFpRate": 0
+    },
+    {
+      "skill": "buildkite-secure-delivery",
+      "sampleSize": 1,
+      "truePositives": 0,
+      "falseNegatives": 1,
+      "falsePositives": 0,
+      "precision": 0,
+      "recall": 0,
+      "f1": 0,
+      "execSuccess": 0,
+      "negativeControlFpRate": 0
+    },
+    {
+      "skill": "file-bug",
+      "sampleSize": 4,
+      "truePositives": 1,
+      "falseNegatives": 3,
+      "falsePositives": 1,
+      "precision": 0.5,
+      "recall": 0.25,
+      "f1": 0.3333333333333333,
+      "execSuccess": 1,
+      "negativeControlFpRate": 0.25
+    },
+    {
+      "skill": "mcp-builder",
+      "sampleSize": 4,
+      "truePositives": 2,
+      "falseNegatives": 2,
+      "falsePositives": 0,
+      "precision": 1,
+      "recall": 0.5,
+      "f1": 0.6666666666666666,
+      "execSuccess": 1,
+      "negativeControlFpRate": 0
+    },
+    {
+      "skill": "switchroom-cli",
+      "sampleSize": 0,
+      "truePositives": 0,
+      "falseNegatives": 0,
+      "falsePositives": 2,
+      "precision": 0,
+      "recall": 0,
+      "f1": 0,
+      "execSuccess": 0,
+      "negativeControlFpRate": 0
+    },
+    {
+      "skill": "switchroom-install",
+      "sampleSize": 4,
+      "truePositives": 4,
+      "falseNegatives": 0,
+      "falsePositives": 0,
+      "precision": 1,
+      "recall": 1,
+      "f1": 1,
+      "execSuccess": 1,
+      "negativeControlFpRate": 0
+    },
+    {
+      "skill": "switchroom-manage",
+      "sampleSize": 4,
+      "truePositives": 1,
+      "falseNegatives": 3,
+      "falsePositives": 0,
+      "precision": 1,
+      "recall": 0.25,
+      "f1": 0.4,
+      "execSuccess": 1,
+      "negativeControlFpRate": 0
+    },
+    {
+      "skill": "switchroom-runtime",
+      "sampleSize": 4,
+      "truePositives": 0,
+      "falseNegatives": 4,
+      "falsePositives": 0,
+      "precision": 0,
+      "recall": 0,
+      "f1": 0,
+      "execSuccess": 0,
+      "negativeControlFpRate": 0
+    },
+    {
+      "skill": "switchroom-status",
+      "sampleSize": 4,
+      "truePositives": 3,
+      "falseNegatives": 1,
+      "falsePositives": 2,
+      "precision": 0.6,
+      "recall": 0.75,
+      "f1": 0.6666666666666665,
+      "execSuccess": 1,
+      "negativeControlFpRate": 0
+    }
+  ],
+  "aggregate": {
+    "medianF1": 0.4,
+    "skillsBelowF1Threshold": 9,
+    "skillsBelowExecThreshold": 3,
+    "f1Threshold": 0.9,
+    "execThreshold": 0.95
+  }
+}

--- a/tests/skill-coverage/scorecards/round-3.scorecard.md
+++ b/tests/skill-coverage/scorecards/round-3.scorecard.md
@@ -1,0 +1,22 @@
+# Skill coverage scorecard
+
+- generated: 2026-05-13T23:48:36.423Z
+- seed: 1
+- total probes: 41
+- median F1 (among targeted skills): 0.40
+- skills below F1 0.90: **9**
+- skills below exec 0.95: **3**
+
+| skill | n | TP | FN | FP | precision | recall | F1 | exec | neg-FP |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
+| buildkite-api | 4 | 0 | 4 | 0 | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 |
+| buildkite-cli | 4 | 1 | 3 | 0 | 1.00 | 0.25 | 0.40 | 1.00 | 0.00 |
+| buildkite-pipelines | 4 | 2 | 2 | 0 | 1.00 | 0.50 | 0.67 | 1.00 | 0.00 |
+| buildkite-secure-delivery | 1 | 0 | 1 | 0 | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 |
+| file-bug | 4 | 1 | 3 | 1 | 0.50 | 0.25 | 0.33 | 1.00 | 0.25 |
+| mcp-builder | 4 | 2 | 2 | 0 | 1.00 | 0.50 | 0.67 | 1.00 | 0.00 |
+| switchroom-cli | 0 | 0 | 0 | 2 | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 |
+| switchroom-install | 4 | 4 | 0 | 0 | 1.00 | 1.00 | 1.00 | 1.00 | 0.00 |
+| switchroom-manage | 4 | 1 | 3 | 0 | 1.00 | 0.25 | 0.40 | 1.00 | 0.00 |
+| switchroom-runtime | 4 | 0 | 4 | 0 | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 |
+| switchroom-status | 4 | 3 | 1 | 2 | 0.60 | 0.75 | 0.67 | 1.00 | 0.00 |

--- a/tests/skill-coverage/scorecards/round-3.scorecard.md
+++ b/tests/skill-coverage/scorecards/round-3.scorecard.md
@@ -1,22 +1,36 @@
 # Skill coverage scorecard
 
-- generated: 2026-05-13T23:48:36.423Z
+- generated: 2026-05-13T23:55:56.038Z
 - seed: 1
-- total probes: 41
-- median F1 (among targeted skills): 0.40
-- skills below F1 0.90: **9**
-- skills below exec 0.95: **3**
+- total probes: 104
+- median F1 (among targeted skills): 0.33
+- skills below F1 0.90: **22**
+- skills below exec 0.95: **11**
 
 | skill | n | TP | FN | FP | precision | recall | F1 | exec | neg-FP |
 |---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
+| buildkite-agent-infrastructure | 4 | 0 | 4 | 0 | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 |
+| buildkite-agent-runtime | 4 | 0 | 4 | 0 | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 |
 | buildkite-api | 4 | 0 | 4 | 0 | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 |
 | buildkite-cli | 4 | 1 | 3 | 0 | 1.00 | 0.25 | 0.40 | 1.00 | 0.00 |
+| buildkite-migration | 4 | 0 | 4 | 0 | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 |
 | buildkite-pipelines | 4 | 2 | 2 | 0 | 1.00 | 0.50 | 0.67 | 1.00 | 0.00 |
-| buildkite-secure-delivery | 1 | 0 | 1 | 0 | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 |
+| buildkite-secure-delivery | 4 | 0 | 4 | 0 | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 |
+| buildkite-test-engine | 4 | 0 | 4 | 0 | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 |
+| docx | 4 | 0 | 4 | 0 | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 |
 | file-bug | 4 | 1 | 3 | 1 | 0.50 | 0.25 | 0.33 | 1.00 | 0.25 |
+| humanizer | 4 | 0 | 4 | 0 | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 |
+| humanizer-calibrate | 4 | 4 | 0 | 0 | 1.00 | 1.00 | 1.00 | 1.00 | 0.00 |
 | mcp-builder | 4 | 2 | 2 | 0 | 1.00 | 0.50 | 0.67 | 1.00 | 0.00 |
-| switchroom-cli | 0 | 0 | 0 | 2 | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 |
+| pdf | 4 | 1 | 3 | 0 | 1.00 | 0.25 | 0.40 | 1.00 | 0.00 |
+| pptx | 4 | 0 | 4 | 0 | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 |
+| skill-creator | 4 | 4 | 0 | 0 | 1.00 | 1.00 | 1.00 | 1.00 | 0.00 |
+| switchroom-cli | 4 | 1 | 3 | 2 | 0.33 | 0.25 | 0.29 | 1.00 | 0.00 |
+| switchroom-health | 4 | 2 | 2 | 0 | 1.00 | 0.50 | 0.67 | 1.00 | 0.00 |
 | switchroom-install | 4 | 4 | 0 | 0 | 1.00 | 1.00 | 1.00 | 1.00 | 0.00 |
-| switchroom-manage | 4 | 1 | 3 | 0 | 1.00 | 0.25 | 0.40 | 1.00 | 0.00 |
+| switchroom-manage | 4 | 1 | 3 | 1 | 0.50 | 0.25 | 0.33 | 1.00 | 0.00 |
 | switchroom-runtime | 4 | 0 | 4 | 0 | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 |
-| switchroom-status | 4 | 3 | 1 | 2 | 0.60 | 0.75 | 0.67 | 1.00 | 0.00 |
+| switchroom-status | 4 | 3 | 1 | 4 | 0.43 | 0.75 | 0.55 | 1.00 | 0.00 |
+| telegram-test-harness | 4 | 2 | 2 | 0 | 1.00 | 0.50 | 0.67 | 1.00 | 0.00 |
+| webapp-testing | 4 | 0 | 4 | 0 | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 |
+| xlsx | 4 | 1 | 3 | 0 | 1.00 | 0.25 | 0.40 | 1.00 | 0.00 |


### PR DESCRIPTION
## Summary

Final round-3 scorecard after three rounds of description rewrites (#1217, #1222, #1224). All 25 in-scope skills measured across 104 probes.

## Results

**Hit threshold (F1 ≥ 0.9, exec ≥ 0.95):**
- humanizer-calibrate: 1.00 / 1.00
- skill-creator: 1.00 / 1.00
- switchroom-install: 1.00 / 1.00

**Median F1: 0.33** (up from 0.22 in round-1 baseline)

**Skills still at 0% recall** despite description rewrites:
buildkite-agent-infrastructure, buildkite-agent-runtime, buildkite-api, buildkite-migration, buildkite-secure-delivery, buildkite-test-engine, docx, humanizer, pptx, switchroom-runtime, webapp-testing.

## What this tells us

The harness loop works: 3 skills reached the goal threshold through description iteration alone, with the rest unchanged from their pre-loop state. The persistent 0% cohort points to deeper issues — either model-level behavior (haiku not auto-firing Skill on borderline-match prompts) or corpus quality (probes worded too far from the description's vocabulary). The audit's prediction (#1216 §5) that `humanizer-calibrate` and `webapp-testing` would miss without LLM-generated paraphrases was half-right: humanizer-calibrate actually hit 1.00, while webapp-testing stayed at 0.

## Not in this PR (next-iteration follow-ups)

- Round-4 description rewrites targeting the 11 still-0% skills with more aggressive trigger enumeration.
- Switch the runner to sonnet/opus to test whether the gap is description-quality vs model-skill-firing behavior.
- LLM-driven paraphrase pass on the corpus so the probes are model-realistic.
- Separate "trigger" vs "robustness" scoring (paraphrases vs typos/indirect) — the threshold may be hitting model ceiling on typo/indirect probes regardless of description.

🤖 Generated with [Claude Code](https://claude.com/claude-code)