### PR TITLE
docs(rfcs): RFC E — make Google Drive a real collaboration surface

### DIFF
--- a/docs/rfcs/doc-connection-completion.md
+++ b/docs/rfcs/doc-connection-completion.md
@@ -1,6 +1,6 @@
-# RFC E: Complete the doc-connection surface
+# RFC E: Make Google Drive a real collaboration surface
 
-Status: Draft v1
+Status: Draft v2
 Author: Ken (with Claude pair-design)
 Date: 2026-05-14
 
@@ -8,201 +8,283 @@ Prerequisites — both shipped:
 - **RFC B — Approval kernel** (`approval-kernel.md`) — landed v0.6.0 (#762).
 - **RFC D — Google Drive MCP integration** (`gdrive-mcp.md`) — landed v0.6.0 (#763, #766, #767, #768).
 
-This spec finishes the work RFC D explicitly deferred and proves the
-approval-kernel + onboarding pattern is reusable across doc surfaces by
-landing a second one (Notion). It is the "Phase 4+" for doc-connection
-that RFC D pointed at without scoping.
+This spec finishes the Google Drive integration so it stops being a
+read-only data fetcher and becomes a proper place to **collaborate
+with the agent on docs**. Drive is the focused surface; Notion and
+the other doc sources are explicitly deferred to a follow-up spec
+once the Drive collab loop is real.
 
 ## 0. Goal
 
-The user can connect any agent to any document surface they live in
-(Drive, Notion, eventually Slack/Gmail) with the **same** one-tap
-onboarding card, the **same** approval shape, the **same** vault-stored
-OAuth they got with Drive in v0.6.0 — and the same ergonomics for the
-two pieces RFC D punted: browsing folders to grant access, and granting
-write access without conflating it with read.
+A user can give an agent a Google Doc, ask it to draft into the doc,
+review the agent's changes inline in Drive, and resume the
+conversation in Telegram — all without leaving the
+phone-or-laptop-they-already-have-open. The agent is a collaborator
+on the user's docs, not a one-shot reader-and-summarizer.
 
 ## 1. Outcome
 
-A user who tells klanker "go through my /Work/2026 folder and pull out
-anything that mentions hiring" can do the whole flow from Telegram on a
-phone in three taps:
+The user can do this end-to-end from a Telegram thread on a phone:
 
-1. Agent requests folder access → coalesced approval card with
-   `[ Browse this folder ]` + `[ Allow always ]`.
-2. (Optional) Tap browse → see the folder tree in a card, confirm.
-3. Tap Allow → done. Agent proceeds.
+```
+User:   "Klanker, take the meeting notes from /Work/2026/Q3 and
+         draft a hiring section into the Q3 Strategy doc."
 
-Today, step 1 forces the user to either pre-grant by typing
-`doc:gdrive:folder/<id>/**` (worse than per-doc), or accept the
-prompt-flood of per-doc on a fresh folder. The same user, asked to
-connect Notion next month, hits **the same card shape, the same vault
-slot pattern, the same CLI verb** — no new mental model.
+Agent:  [posts approval card]
+        🔐 klanker wants to read 4 docs in /Work/2026/Q3
+        "Q3 Strategy Notes", "Hiring plan", "+2 more"
+        [ ✅ Allow this folder ]  [ See all ]  [ 🚫 Deny ]
+
+User:   [taps Allow this folder]
+
+Agent:  "Read 4 docs. Drafting a Hiring section into Q3 Strategy
+         Notes — will post a preview in a sec."
+
+Agent:  [posts write-approval card]
+        ✏️  klanker wants to add to "Q3 Strategy Notes"
+        +47 lines · "Added Hiring section after 'Goals'"
+        [ 📖 Open in Drive ]  [ ✅ Apply as suggestion ]
+        [ ⚠ Apply directly ]  [ 🚫 Cancel ]
+
+User:   [taps Apply as suggestion]
+
+Agent:  "Done — open https://docs.google.com/document/d/.../edit
+         to review. I'll wait."
+
+User:   [opens link in Drive app, reviews, accepts the suggestion,
+         comes back to Telegram]
+        "Looks good, can you tighten the second paragraph?"
+
+Agent:  [posts write-approval card with new diff]
+        ...
+```
+
+Today this loop is impossible. The agent can read the doc but can't
+write back, can't propose changes the user can review in Drive's UI,
+can't link the user back to the doc from chat, and the folder-grant
+step requires the user to type a scope string. Every one of those
+gaps blocks the collaboration JTBD.
 
 ## 2. Vision alignment
 
 Maps to three of the four outcomes in `reference/vision.md`:
 
-- **Multi-agent fleet (#2)** — Specialists need access to the docs they
-  specialize in. A health coach without your habit-tracker notes is a
-  generalist; a research agent without your reading list is amnesia. Doc
-  connections are how a specialist becomes specific.
-- **Subscription-honest (#3)** — Every doc surface uses per-user OAuth,
-  refresh tokens in vault, no service accounts, no shadow API billing.
-  Same posture as RFC D §4.
-- **Always-on (#4)** — Refresh tokens survive reboots; missing-doc events
-  surface in chat without breaking the agent loop; reconciler recovery
-  (§4.3) lets scheduled tasks pick up after transient gaps.
+- **Multi-agent fleet (#2)** — Specialists become specific *because*
+  they have a real working relationship with the user's docs. A
+  research agent that can draft into your reading-notes is a
+  research agent; one that can only read is a search box.
+- **Subscription-honest (#3)** — Per-user OAuth, refresh tokens in
+  vault, no service accounts. Same posture as RFC D §4.
+- **Always-on (#4)** — Refresh tokens survive reboots; the
+  reconciler's missing→present recovery (§4.4) means a doc the user
+  un-trashes mid-week doesn't leave the agent stuck.
 
-**Visibility (#1)** is served by the approval card UX already shipped
-in RFC D — no new work here for that outcome.
+Visibility (#1) is served by the existing approval card UX from RFC
+D plus the new diff-preview surface in §4.2 — the user always sees
+what the agent is about to do *before* it touches their doc.
 
 ## 3. JTBD alignment
 
-- **`extend-without-forking.md`** — *"The user adds a new agent, skill,
-  or tool by configuring it, not by editing the product."* Adding
-  Notion access for klanker should be a config edit + an OAuth tap,
-  not a fork. The "second surface" goal in §4.4 is the JTBD test: if
-  Notion takes 200 lines of new code copy-pasted from `src/drive/*`,
-  that fails the JTBD and is a refactor signal.
-- **`share-auth-across-the-fleet.md`** — *"One auth per account, not
-  per agent."* Drive OAuth = once per Google account; Notion OAuth =
-  once per workspace. Refresh tokens live in vault slots scoped to the
-  agent_unit (per RFC D §4.1), but the OAuth flow itself is run once
-  and the resulting credentials cascade through the fleet via shared
-  vault references. Adding a second consumer to klanker doesn't trigger
-  a second OAuth dance.
-- **`talk-to-agents-from-anywhere.md`** — *"The user can drive their
-  fleet from a phone on the train as naturally as from a laptop."*
-  Folder picker, write approvals, reconnect-on-revocation — every flow
-  in this spec is reachable from Telegram, never requires SSH or a
-  desktop browser (the headless OAuth tier from RFC D §3.2 covers the
-  one place where a browser is needed).
+- **`extend-without-forking.md`** — Granting an agent access to a
+  new folder is a tap, not a code change. Per-folder write grants
+  are a config-surface affordance, not an MCP-server fork.
+- **`share-auth-across-the-fleet.md`** — Drive OAuth = once per
+  Google account. Adding a second agent that needs the same Drive
+  doesn't re-prompt; the cascade resolves the shared vault slot.
+- **`talk-to-agents-from-anywhere.md`** — Folder browsing, write
+  approvals with diff preview, deep-link to Drive, reconnect-on-
+  token-revocation — every step is reachable from a phone. The
+  headless OAuth tier from RFC D §3.2 covers initial connect;
+  nothing else needs a desktop browser.
+- **`know-what-my-agent-is-doing.md`** — The diff-preview-before-
+  write pattern is the JTBD's "see every step" applied to mutations.
+  The user never finds out the agent edited a doc by re-opening it
+  later.
 
-## 4. Scope — four pieces
+## 4. Scope — five pieces, all Drive
 
-### 4.1 Drive folder picker (deferred from RFC D §6) — P1
+### 4.1 Folder picker (deferred from RFC D §6) — Phase 1
 
 **Today:** per-doc grant works fine; folder grants require typing
-`doc:gdrive:folder/<id>/**` by hand. RFC D §6 acknowledges this is
+`doc:gdrive:folder/<id>/**` by hand. RFC D §6 acknowledged this is
 worse than either default and explicitly punted.
 
 **Design:**
 
-- New CLI verb: `switchroom drive folders <agent>` — does *not* render
-  in the terminal. Posts a card in the agent's Telegram topic.
-- Card surface: paginated folder list, top-level first, breadcrumb on
-  long names. One tap on a folder = expand into its children + back
-  arrow. One tap on `[ ✅ Allow this folder ]` = write `allow_always`
-  at `doc:gdrive:folder/<id>/**` and surface the standard granted-card
-  confirmation (with `· /approvals revoke <id>` inline per RFC B §9).
+- New CLI verb: `switchroom drive folders <agent>` — does *not*
+  render in the terminal. Posts a card in the agent's Telegram
+  topic.
+- Card surface: paginated folder list, top-level first, breadcrumb
+  on long names. One tap on a folder = expand into its children +
+  back arrow. One tap on `[ ✅ Allow this folder ]` = write
+  `allow_always` at `doc:gdrive:folder/<id>/**` and surface the
+  standard granted-card confirmation (with `· /approvals revoke
+  <id>` inline per RFC B §9).
 - The same picker is reachable from inside an in-flight per-doc
-  approval card via a new `[ 📁 Allow folder instead ]` button — the
-  primary mitigation for the prompt-flood path RFC D §5 warns about.
+  approval card via a new `[ 📁 Allow folder instead ]` button —
+  the primary mitigation for the prompt-flood path RFC D §5 warns
+  about.
 - Listing source: `files.list` with
-  `q="mimeType='application/vnd.google-apps.folder' and 'me' in owners
-  and trashed=false"`, paginated 50 per card. Cached for 5 min per
-  agent (folder structures don't change minute-by-minute).
-- Staleness digest from RFC B §9.1 also gets a `[ 📁 Browse ]` button
-  next to each folder grant so the user can audit before keeping.
+  `q="mimeType='application/vnd.google-apps.folder' and 'me' in
+  owners and trashed=false"`, paginated 50 per card. Cached for 5
+  min per agent.
+- Staleness digest from RFC B §9.1 also gets a `[ 📁 Browse ]`
+  button next to each folder grant so the user can audit before
+  keeping.
 
-**Pagination is not optional.** Drive accounts with deep folder trees
-(>100 top-level folders) are common. Ship the paginated path on day 1.
+**Pagination is not optional.** Drive accounts with deep folder
+trees (>100 top-level folders) are common. Ship paginated on day 1.
 
-### 4.2 Drive write operations (deferred from RFC D §12) — P2
+### 4.2 Write operations with Suggesting as the default (deferred from RFC D §12) — Phase 1
 
-**Today:** read-only by design. RFC D §12 stipulates writes need their
-own scope namespace so a read grant never silently authorizes a write.
+**Today:** read-only by design. RFC D §12 stipulates writes need
+their own scope namespace so a read grant never silently authorizes
+a write.
+
+**Why "Suggesting" is the default, not direct write:** Drive has a
+first-class Suggesting mode (the same one human collaborators use).
+Suggestions are non-destructive — the user reviews and accepts them
+in Drive's UI just like a peer's edit. **Defaulting to Suggesting
+mode is the difference between "agent writes to my doc" (scary) and
+"agent proposes edits I review" (collaboration).** Direct writes
+remain available behind a one-extra-tap affordance for cases where
+suggesting doesn't fit (creating a brand-new doc, scripted bulk
+edits, etc.).
 
 **Design:**
 
-- New scope namespace: `doc:gdrive:write:<id>` and
-  `doc:gdrive:write:folder/<id>/**`. Read scopes are unchanged.
-- MCP wrapper exposes write tools as separately approval-gated:
-  `gdrive_create_doc`, `gdrive_append_to_doc`,
-  `gdrive_replace_doc_content`. Read tools (`gdrive_read_doc`,
-  `gdrive_search`) keep using the existing read scopes.
-- `humanize()` for write scopes prefixes the title with **✏️** and
-  renders a one-line diff summary inline if available
-  (`+12 / −3 lines · "added Hiring section"`).
-- Approval defaults are stricter than reads:
-  - Primary `Allow` button = `allow_once` (matches RFC B §7).
-  - The "Always" affordance for writes is **opt-in via expand**, not
-    a top-level button. Surfacing it on the primary card row would
-    make a tap-through user accidentally grant standing write access.
-  - Audit row records `action: write` so `/approvals stats` separates
-    write traffic from read.
-- Onboarding card from RFC D §5 stays read-only by default. A new
-  expand option `[ ✏️ Also enable writes (per-action approval) ]`
-  flips the agent into write-aware mode without granting any standing
-  write access.
+- New scope namespaces (read scopes unchanged):
+  - `doc:gdrive:suggest:<id>` and `doc:gdrive:suggest:folder/<id>/**`
+    — non-destructive proposals.
+  - `doc:gdrive:write:<id>` and `doc:gdrive:write:folder/<id>/**`
+    — direct writes.
+- A `suggest` grant does NOT imply `write`. `write` implies
+  `suggest`.
+- MCP wrapper exposes:
+  - `gdrive_suggest_edit(doc_id, anchor, text)` — primary edit
+    tool.
+  - `gdrive_create_doc(title, content, parent_folder)` — new docs
+    only; uses `write` scope on the parent folder.
+  - `gdrive_apply_edit(doc_id, anchor, text)` — direct write; uses
+    `write` scope.
+  - `gdrive_append_to_doc(doc_id, text)` — append; uses `write` (no
+    Suggesting equivalent in the API for pure append).
+- Approval card for a suggestion edit:
+  ```
+  ✏️ klanker wants to add to "Q3 Strategy Notes"
+  +47 lines · "Added Hiring section after 'Goals'"
+  [ 📖 Open in Drive ]  [ ✅ Apply as suggestion ]
+  [ ⚠ Apply directly ]  [ 🚫 Cancel ]
+  ```
+  - Primary action is **Apply as suggestion** — single tap, lands
+    as a Drive Suggestion the user reviews in Drive's UI.
+  - **Apply directly** is a secondary, badged with `⚠`. Standing
+    direct-write grants are opt-in via expand only — never on the
+    primary card row.
+  - **Open in Drive** is always present. See §4.3.
+- Diff summary (`+47 lines · "..."`) is best-effort: render
+  line-counts always, render the agent-supplied "what changed"
+  string if present (the agent passes a `summary` param to the
+  suggest tool).
+- Audit row records `action: suggest` or `action: write` so
+  `/approvals stats` separates collaboration traffic from outright
+  writes.
+- The §5 onboarding card from RFC D gains a new expand option:
+  `[ ✏️ Also enable suggesting (per-action approval) ]`. This flips
+  the agent into write-aware mode without granting any standing
+  edit access. Direct writes remain a deeper, expand-only choice.
 
-### 4.3 Reconciler recovery event (deferred from RFC D §12) — P3
+### 4.3 Open-in-Drive deep links — Phase 1
 
-**Today:** when a doc the agent expected is in Missing state (deleted
-or trashed) and the user later un-trashes it, the agent re-discovers on
-next access. Fine for ad-hoc reads; means scheduled tasks ("scan my
-reading list weekly") that hit a transient missing window can stay
-broken for a week.
+**Today:** every reference to a doc in chat is a title; the user
+has to find the doc themselves to look at it. Breaks the collab
+loop — the user can't tap from "agent edited X" to "let me see X."
+
+**Design:**
+
+- Every approval card that names a doc renders the title as a
+  `[ 📖 Open in Drive ]` inline-keyboard button that opens
+  `https://docs.google.com/document/d/<id>/edit` (or the
+  spreadsheet/presentation equivalent based on `mimeType`).
+- Granted-card confirmations (RFC B §8.1) gain the same button so
+  the user can jump straight from "agent has access" to the doc
+  itself.
+- Suggestion-write approvals (§4.2) also include
+  `?disco=<thread_id>` on the URL when Drive's API exposes a
+  discussion thread for the proposed edit, so the link lands the
+  user directly on the suggestion they're reviewing.
+- No new permission needed — these are the same shareable URLs the
+  user would copy from Drive's "Share" dialog.
+
+### 4.4 Reconciler missing→present recovery (deferred from RFC D §12) — Phase 1
+
+**Today:** when a doc is in Missing state (deleted/trashed) and the
+user later un-trashes it, the agent re-discovers on next access.
+Fine for ad-hoc reads; means scheduled tasks ("scan my reading list
+weekly") that hit a transient missing window stay broken for a
+week even after the user fixes it.
+
+**Why it's promoted from "Phase 4 cleanup" to Phase 1:** in a
+collab loop the missing→present transition is *common*. The user
+trashes their draft, asks the agent to start over, un-trashes the
+original to compare — they expect both versions to be live for the
+agent.
 
 **Design:** trivial extension of `src/drive/reconciler.ts` —
 
-- When a missing-state grant transitions back to Present on its next
-  scheduled check, write a `recover` row to `approval_audit` and
-  surface a `[ ↻ Re-enabled ]` line in the next staleness digest.
+- When a missing-state grant transitions back to Present on its
+  next scheduled check, write a `recover` row to `approval_audit`
+  and surface a `[ ↻ Re-enabled ]` line in the next staleness
+  digest + a one-line nudge in the agent's chat:
+  *"↻ 'Q3 Strategy Notes' is back — let me know if you want me to
+  pick up where I left off."*
 - No retro-active state-management. No automatic re-trigger of the
   scheduled task. Just don't *hide* the recovery from the user.
 
-### 4.4 Second surface: Notion as the next consumer — P1, parallel with 4.1
+### 4.5 Section-anchor editing primitive — Phase 1
 
-The approval kernel (RFC B) and the onboarding pattern (RFC D §5) were
-both designed for N doc surfaces, not just Drive. **Building Notion
-second is the test that the framework actually generalizes.**
+The `gdrive_suggest_edit(doc_id, anchor, text)` tool from §4.2
+needs an anchor model that's robust enough for an agent to use.
+Naive "insert after byte offset N" breaks the moment the doc
+shifts.
 
 **Design:**
 
-- Server choice candidate: `makenotion/notion-mcp-server` (official,
-  MIT-licensed, OAuth supported). Pin a commit SHA per RFC D §2 (don't
-  track a floating tag).
-- Vault slot pattern mirrors Drive: `notion:<agent_unit>:refresh_token`
-  and `notion:<agent_unit>:refresh_token:status` for invalid-grant
-  signaling. Same revocation flow as RFC D §4.3.
-- Scope grammar:
-  - `doc:notion:page:<id>` — single page.
-  - `doc:notion:database:<id>/**` — database (analog to a folder).
-  - `doc:notion:workspace/<id>/**` — entire workspace.
-- Onboarding card: same shape as RFC D §5, swapped copy:
-  `[ ✅ Allow my Notion (read-only) — recommended ]` etc.
-- CLI: `switchroom notion connect|disconnect <agent>`, with the same
-  three-tier OAuth auto-select as Drive (device-code → OOB-paste →
-  desktop-loopback). RFC D §3 is the template; copy nothing, factor
-  the shared code.
-- The picker from §4.1 is generalized: `switchroom <surface> folders
-  <agent>` works for Drive folders and Notion databases identically.
+- Anchors are **heading-based**, not byte-offset-based. The agent
+  passes `anchor: { after_heading: "Goals", level: 2 }` or
+  `anchor: { append_to_section: "Hiring", level: 2 }`.
+- The wrapper resolves anchors against the current doc state at
+  edit-time (via `documents.get` → walk the structural tree).
+- If the anchor doesn't resolve (heading was renamed, deleted),
+  the edit is rejected at the wrapper layer with a clear error
+  the agent surfaces back: *"⚠ Couldn't find heading 'Goals' in
+  current doc. Want me to suggest a heading-by-heading rewrite,
+  or pick a different anchor?"*
+- For docs with no headings, the wrapper falls back to two anchor
+  modes: `at_start`, `at_end`. No silent guess at byte offsets.
 
-**Refactor signal:** if landing Notion requires copy-pasting more than
-~50 lines from `src/drive/*` into `src/notion/*`, stop and extract
-`src/doc-connection/` first (shared OAuth tier-selection, vault-slot
-pattern, onboarding card builder, picker primitive). The whole point
-of building a second surface is to find the seams.
+## 5. Out of scope (this spec)
 
-## 5. Out of scope
-
-- **Slack messages-as-docs** — same shape, separate spec when there's
-  user demand. Not blocking anything.
-- **Gmail surface** — `taylorwilsdon/google_workspace_mcp` (RFC D §2)
-  already supports it, but Gmail's approval shape is per-thread, not
-  per-doc; warrants its own spec.
-- **Local-filesystem doc indexing** (Obsidian, plain markdown trees) —
-  this spec is about *external* doc surfaces. Local trees are an
-  agent-workspace concern.
+- **Notion / Slack / Gmail** — deferred to RFC F. The Drive collab
+  loop has to land first as proof that the picker + write +
+  deep-link + reconciler-recovery model is real before we
+  generalize.
+- **Drive Sheets / Slides as first-class collaboration surfaces** —
+  reads work today via the same MCP; suggesting/writing into Sheets
+  cells and Slides components is its own UX problem (cell anchors,
+  slide layouts) and warrants its own spec.
+- **Track-changes / blame** — the user reviews suggestions in
+  Drive's own UI, which already has these; switchroom doesn't
+  reinvent them.
+- **Agent-initiated comments / @-mentions on Drive comments** —
+  separate from the edit loop; would need its own approval shape.
+- **Local-filesystem doc indexing** — agent-workspace concern, not
+  external-surface concern.
 - **Service-account auth** — same reason as RFC D §12: collapses
   approval semantics.
-- **Two-way doc sync** (treating Drive/Notion as a backing store for
-  agent-state) — out. The contract is read with optional write.
-- **A unified `switchroom docs ...` super-CLI** — premature
-  abstraction. `drive` and `notion` as siblings is fine until there
-  are 3+ surfaces.
+- **Two-way doc sync** (treating Drive as a backing store for
+  agent-state) — out. The contract is the user owns the doc; the
+  agent collaborates on it.
 
 ## 6. Principle checks
 
@@ -212,103 +294,115 @@ Per `reference/principles.md`, applied to this spec:
 
 - ✅ `switchroom drive folders klanker` posts a card with inline
   guidance. No prerequisite reading.
-- ✅ `switchroom notion connect klanker` mirrors `switchroom drive
-  connect` exactly — the user who did Drive once doesn't need to
-  learn anything new.
-- ✅ Onboarding card text explains the trade-off ("most users pick
-  Allow my workspace — one tap now") rather than naming the underlying
-  scope grammar.
-- ✅ Folder picker breadcrumbs make the active scope visible without a
-  glossary.
+- ✅ Approval card copy explains the suggestion vs direct-write
+  trade-off in one line — no glossary needed.
+- ✅ `[ 📖 Open in Drive ]` is self-explanatory. Tap → doc opens.
+- ✅ Anchor-resolution errors give the user a next step
+  (*"Want me to suggest a heading-by-heading rewrite?"*).
 
 ### 6.2 Defaults test — *"Does it work on a fresh `switchroom setup`?"*
 
-- ✅ Drive remains opt-in (must run `connect`); once enabled, the
-  folder picker is reachable with no further config.
-- ✅ Writes default to per-action approval. Standing write grants are
-  available but opt-in via expand. No one accidentally grants
-  klanker the ability to overwrite their `/Work` folder.
-- ✅ Notion's onboarding card defaults to "Allow my workspace
-  (read-only)" — the same pragmatic default as Drive.
+- ✅ Drive remains opt-in (must run `connect`); once connected,
+  the picker and Open-in-Drive surfaces are reachable with zero
+  further config.
+- ✅ Writes default to Suggesting mode. The single most dangerous
+  affordance (standing direct-write grants) is opt-in via expand,
+  not surfaced as a primary button.
+- ✅ Anchor model defaults to heading-based (the only model that
+  survives doc evolution). No setting to choose.
 
 ### 6.3 Consistency test — *"Does this feel like one product?"*
 
-- ✅ Same `apv:` callback shape across surfaces (RFC B §6.1).
-- ✅ Same `<surface>:<agent_unit>:refresh_token` vault slot pattern.
-- ✅ Same `switchroom <surface> connect|disconnect` CLI verb.
-- ✅ Same approval card states (pristine / expanded / granted / denied
-  / expired) — RFC B §8.1.
-- ✅ Same `/approvals list|revoke|add|stats` surface — adding Notion
-  scopes doesn't add new commands, just new rows.
-- ⚠️  Risk: if §4.4's refactor signal fires, doing it *before* shipping
-  Notion is a one-mind-built-this requirement, not a follow-up.
+- ✅ Same `apv:` callback shape across reads, suggests, writes
+  (RFC B §6.1).
+- ✅ Same `vault:gdrive:*` slot pattern (no new vault concepts).
+- ✅ Same approval card states (pristine / expanded / granted /
+  denied / expired) — RFC B §8.1.
+- ✅ Same `/approvals list|revoke|add|stats` surface — adding
+  `suggest` and `write` action types adds rows, not commands.
+- ✅ Same headed-doc model the user already lives in for any Drive
+  doc; agent anchors mean what they look like they mean.
 
 ## 7. Migration / rollout
 
-Phased so each phase is shippable on its own and the framework signal
-in 4.4 can shape the rest.
+All five pieces are scoped as **Phase 1 — Drive collab experience**.
+Substructure for sequencing within the phase:
 
-1. **Phase 1 (parallel)** — Drive folder picker (§4.1) + Notion
-   connect/disconnect skeleton with shared OAuth tier code (§4.4
-   minimum). Validates the picker primitive on Drive while Notion
-   surfaces the framework seams.
-2. **Phase 2** — Notion onboarding card + scope grammar wired through
-   the approval kernel. The "second consumer" milestone — if the
-   kernel needs changes to fit Notion, find them now.
-3. **Phase 3** — Drive writes (§4.2). Lower priority than Notion-reads
-   because writes carry more risk and existing read flows are
-   delivering value already.
-4. **Phase 4** — Reconciler recovery event (§4.3). Cleanup once write
-   flows have a few weeks of mileage.
+1. **1a — Folder picker (§4.1) + Open-in-Drive (§4.3).** The
+   lowest-risk pair; folder picker is contained UX, Open-in-Drive
+   is additive. Ships independently of writes.
+2. **1b — Anchor primitive (§4.5).** Foundation for §4.2; ship +
+   test in isolation against a fixture doc before wiring it to the
+   approval card.
+3. **1c — Suggesting writes + diff preview (§4.2).** The headline
+   feature. Lands on top of the anchor primitive and the
+   Open-in-Drive button.
+4. **1d — Reconciler recovery (§4.4).** Lowest-effort, ships last
+   — useful but not blocking the headline collab loop.
+
+Phase 2+ (Notion as second surface, framework extraction, broader
+doc surfaces) lives in a follow-up RFC and is explicitly out of
+scope here. Doing Drive collab first means RFC F (whenever it
+lands) has a real working model to copy from instead of a designed
+abstraction.
 
 ## 8. Effort estimate
 
 Per CLAUDE.md, in **agent minutes** (wall-clock for a current-gen
 agent, end-to-end including tests):
 
-| Phase | Item | Estimate |
+| Sub-phase | Item | Estimate |
 |---|---|---|
-| 1 | Folder picker (§4.1) — picker card + pagination + 5min cache + tests | ~45 min |
-| 1 | Notion skeleton (§4.4) — CLI verb + OAuth wiring + vault slots + tests | ~60 min |
-| 2 | Notion onboarding + scope grammar through kernel | ~45 min |
-| 2 | Framework extraction if §4.4 refactor signal fires | ~60 min (conditional) |
-| 3 | Drive writes (§4.2) — scope namespace + tools + approval defaults + tests | ~60 min |
-| 4 | Reconciler recovery event (§4.3) | ~15 min |
-| — | Doc updates across `docs/drive.md`, new `docs/notion.md`, RFC cross-refs | ~15 min |
+| 1a | Folder picker (§4.1) — picker card + pagination + 5min cache + tests | ~45 min |
+| 1a | Open-in-Drive deep links (§4.3) — wired into approval cards + grant confirmations + tests | ~20 min |
+| 1b | Anchor primitive (§4.5) — heading resolver + fallback modes + tests | ~45 min |
+| 1c | Suggesting writes + diff preview (§4.2) — scope namespaces + MCP tools + approval defaults + tests | ~75 min |
+| 1d | Reconciler recovery (§4.4) — recover event + digest line + chat nudge | ~25 min |
+| — | Doc updates (`docs/drive.md`, RFC cross-refs) | ~20 min |
 
-**Without framework extraction: ~4 hours agent time.** With extraction:
-~5 hours. Either way, this is one focused day, not an epic.
+**~3.75 hours agent time** for the full Phase 1. One focused day,
+shippable as four PRs (1a, 1b, 1c, 1d) for incremental review.
 
 ## 9. Risks and open questions
 
-- **Notion's OAuth scopes are coarser than Drive's.** Notion grants
-  per-workspace, not per-page. The "Allow my workspace" default is
-  honest about this; per-page scoping is an illusion the kernel can
-  enforce locally but Notion's API can't. Document this in the
-  onboarding copy so users aren't surprised.
-- **Write-approval fatigue.** Drive writes from a coding agent
-  ("update my README") could be high-volume. Per-folder write grants
-  are the safety valve; instrument via `/approvals stats` and observe
-  before opening up further.
-- **MCP server churn.** Notion's MCP ecosystem is younger than Drive's.
-  Pin the SHA per RFC D §2; revisit at each release.
-- **Picker discoverability.** A user who's been pre-granting per-doc
-  needs to discover the picker exists. The new
-  `[ 📁 Allow folder instead ]` button on per-doc approval cards is
-  the in-flow nudge; the staleness digest's `[ 📁 Browse ]` button is
-  the post-hoc one. If neither lands, surface a one-time tip after
-  the third per-doc grant.
-- **Surface-name confusion in copy.** Drive has "folders," Notion has
-  "databases" + "pages," Slack has "channels." The picker primitive
-  is generic; the copy must use surface-native nouns. No
-  `switchroom docs grant <generic-thing>` super-vocab.
+- **Drive's Suggestions API has gaps.** Some operations (creating
+  a doc, pure append) have no Suggesting equivalent — those stay
+  on the direct `write` scope. Document this clearly in the agent-
+  facing tool descriptions so the agent picks the right tool.
+- **Anchor robustness vs agent ergonomics.** Heading-based anchors
+  are robust against doc evolution but require docs to actually
+  have headings. For unheaded docs the fallback is `at_start` /
+  `at_end` only — agents working on unstructured notes will need
+  to add structure first or accept end-append as the only option.
+  Document this expectation in the prompt-pack for any agent that
+  uses Drive writes.
+- **Diff preview accuracy.** The "+47 lines · summary" preview is
+  agent-supplied. A misbehaving agent could under-state the diff
+  to pass approval. Mitigation: line-count comes from the wrapper
+  (not the agent), only the summary string is agent-supplied.
+  Audit row stores both for post-hoc review.
+- **Folder picker cache invalidation.** 5-min cache is right for
+  most users but wrong for someone reorganizing their Drive in the
+  same window. Add a `[ ↻ Refresh ]` affordance on the picker card
+  that bypasses cache. Cheap.
+- **Open-in-Drive auth assumption.** The deep-link assumes the
+  user is logged into Google in their browser/app on the device
+  they tap from. If they're not, Drive's own login flow handles it
+  — not our problem, but the link doesn't pre-validate.
+- **Discoverability of Suggesting vs Write.** A user who taps
+  `Apply directly` once might not realise Suggesting was the safer
+  default. After 3 direct-applies in a 24h window, surface a
+  one-time tip: *"You're approving direct writes a lot — want to
+  set 'always suggest' as the default for this doc?"*
 
 ## 10. Tracking
 
-Open one tracking issue per phase, all blocked on this spec landing:
+Open one tracking issue per sub-phase, all blocked on this spec
+landing:
 
-- [ ] Phase 1a — Drive folder picker
-- [ ] Phase 1b — Notion connect/disconnect skeleton
-- [ ] Phase 2 — Notion onboarding + kernel-scope grammar
-- [ ] Phase 3 — Drive writes + scope namespace
-- [ ] Phase 4 — Reconciler recovery event
+- [ ] Phase 1a — Folder picker + Open-in-Drive deep links
+- [ ] Phase 1b — Section-anchor editing primitive
+- [ ] Phase 1c — Suggesting writes + diff preview
+- [ ] Phase 1d — Reconciler missing→present recovery
+- [ ] **RFC F (separate)** — Second doc surface (Notion candidate)
+  + framework extraction once Drive collab is real.

--- a/docs/rfcs/doc-connection-completion.md
+++ b/docs/rfcs/doc-connection-completion.md
@@ -1,0 +1,314 @@
+# RFC E: Complete the doc-connection surface
+
+Status: Draft v1
+Author: Ken (with Claude pair-design)
+Date: 2026-05-14
+
+Prerequisites — both shipped:
+- **RFC B — Approval kernel** (`approval-kernel.md`) — landed v0.6.0 (#762).
+- **RFC D — Google Drive MCP integration** (`gdrive-mcp.md`) — landed v0.6.0 (#763, #766, #767, #768).
+
+This spec finishes the work RFC D explicitly deferred and proves the
+approval-kernel + onboarding pattern is reusable across doc surfaces by
+landing a second one (Notion). It is the "Phase 4+" for doc-connection
+that RFC D pointed at without scoping.
+
+## 0. Goal
+
+The user can connect any agent to any document surface they live in
+(Drive, Notion, eventually Slack/Gmail) with the **same** one-tap
+onboarding card, the **same** approval shape, the **same** vault-stored
+OAuth they got with Drive in v0.6.0 — and the same ergonomics for the
+two pieces RFC D punted: browsing folders to grant access, and granting
+write access without conflating it with read.
+
+## 1. Outcome
+
+A user who tells klanker "go through my /Work/2026 folder and pull out
+anything that mentions hiring" can do the whole flow from Telegram on a
+phone in three taps:
+
+1. Agent requests folder access → coalesced approval card with
+   `[ Browse this folder ]` + `[ Allow always ]`.
+2. (Optional) Tap browse → see the folder tree in a card, confirm.
+3. Tap Allow → done. Agent proceeds.
+
+Today, step 1 forces the user to either pre-grant by typing
+`doc:gdrive:folder/<id>/**` (worse than per-doc), or accept the
+prompt-flood of per-doc on a fresh folder. The same user, asked to
+connect Notion next month, hits **the same card shape, the same vault
+slot pattern, the same CLI verb** — no new mental model.
+
+## 2. Vision alignment
+
+Maps to three of the four outcomes in `reference/vision.md`:
+
+- **Multi-agent fleet (#2)** — Specialists need access to the docs they
+  specialize in. A health coach without your habit-tracker notes is a
+  generalist; a research agent without your reading list is amnesia. Doc
+  connections are how a specialist becomes specific.
+- **Subscription-honest (#3)** — Every doc surface uses per-user OAuth,
+  refresh tokens in vault, no service accounts, no shadow API billing.
+  Same posture as RFC D §4.
+- **Always-on (#4)** — Refresh tokens survive reboots; missing-doc events
+  surface in chat without breaking the agent loop; reconciler recovery
+  (§4.3) lets scheduled tasks pick up after transient gaps.
+
+**Visibility (#1)** is served by the approval card UX already shipped
+in RFC D — no new work here for that outcome.
+
+## 3. JTBD alignment
+
+- **`extend-without-forking.md`** — *"The user adds a new agent, skill,
+  or tool by configuring it, not by editing the product."* Adding
+  Notion access for klanker should be a config edit + an OAuth tap,
+  not a fork. The "second surface" goal in §4.4 is the JTBD test: if
+  Notion takes 200 lines of new code copy-pasted from `src/drive/*`,
+  that fails the JTBD and is a refactor signal.
+- **`share-auth-across-the-fleet.md`** — *"One auth per account, not
+  per agent."* Drive OAuth = once per Google account; Notion OAuth =
+  once per workspace. Refresh tokens live in vault slots scoped to the
+  agent_unit (per RFC D §4.1), but the OAuth flow itself is run once
+  and the resulting credentials cascade through the fleet via shared
+  vault references. Adding a second consumer to klanker doesn't trigger
+  a second OAuth dance.
+- **`talk-to-agents-from-anywhere.md`** — *"The user can drive their
+  fleet from a phone on the train as naturally as from a laptop."*
+  Folder picker, write approvals, reconnect-on-revocation — every flow
+  in this spec is reachable from Telegram, never requires SSH or a
+  desktop browser (the headless OAuth tier from RFC D §3.2 covers the
+  one place where a browser is needed).
+
+## 4. Scope — four pieces
+
+### 4.1 Drive folder picker (deferred from RFC D §6) — P1
+
+**Today:** per-doc grant works fine; folder grants require typing
+`doc:gdrive:folder/<id>/**` by hand. RFC D §6 acknowledges this is
+worse than either default and explicitly punted.
+
+**Design:**
+
+- New CLI verb: `switchroom drive folders <agent>` — does *not* render
+  in the terminal. Posts a card in the agent's Telegram topic.
+- Card surface: paginated folder list, top-level first, breadcrumb on
+  long names. One tap on a folder = expand into its children + back
+  arrow. One tap on `[ ✅ Allow this folder ]` = write `allow_always`
+  at `doc:gdrive:folder/<id>/**` and surface the standard granted-card
+  confirmation (with `· /approvals revoke <id>` inline per RFC B §9).
+- The same picker is reachable from inside an in-flight per-doc
+  approval card via a new `[ 📁 Allow folder instead ]` button — the
+  primary mitigation for the prompt-flood path RFC D §5 warns about.
+- Listing source: `files.list` with
+  `q="mimeType='application/vnd.google-apps.folder' and 'me' in owners
+  and trashed=false"`, paginated 50 per card. Cached for 5 min per
+  agent (folder structures don't change minute-by-minute).
+- Staleness digest from RFC B §9.1 also gets a `[ 📁 Browse ]` button
+  next to each folder grant so the user can audit before keeping.
+
+**Pagination is not optional.** Drive accounts with deep folder trees
+(>100 top-level folders) are common. Ship the paginated path on day 1.
+
+### 4.2 Drive write operations (deferred from RFC D §12) — P2
+
+**Today:** read-only by design. RFC D §12 stipulates writes need their
+own scope namespace so a read grant never silently authorizes a write.
+
+**Design:**
+
+- New scope namespace: `doc:gdrive:write:<id>` and
+  `doc:gdrive:write:folder/<id>/**`. Read scopes are unchanged.
+- MCP wrapper exposes write tools as separately approval-gated:
+  `gdrive_create_doc`, `gdrive_append_to_doc`,
+  `gdrive_replace_doc_content`. Read tools (`gdrive_read_doc`,
+  `gdrive_search`) keep using the existing read scopes.
+- `humanize()` for write scopes prefixes the title with **✏️** and
+  renders a one-line diff summary inline if available
+  (`+12 / −3 lines · "added Hiring section"`).
+- Approval defaults are stricter than reads:
+  - Primary `Allow` button = `allow_once` (matches RFC B §7).
+  - The "Always" affordance for writes is **opt-in via expand**, not
+    a top-level button. Surfacing it on the primary card row would
+    make a tap-through user accidentally grant standing write access.
+  - Audit row records `action: write` so `/approvals stats` separates
+    write traffic from read.
+- Onboarding card from RFC D §5 stays read-only by default. A new
+  expand option `[ ✏️ Also enable writes (per-action approval) ]`
+  flips the agent into write-aware mode without granting any standing
+  write access.
+
+### 4.3 Reconciler recovery event (deferred from RFC D §12) — P3
+
+**Today:** when a doc the agent expected is in Missing state (deleted
+or trashed) and the user later un-trashes it, the agent re-discovers on
+next access. Fine for ad-hoc reads; means scheduled tasks ("scan my
+reading list weekly") that hit a transient missing window can stay
+broken for a week.
+
+**Design:** trivial extension of `src/drive/reconciler.ts` —
+
+- When a missing-state grant transitions back to Present on its next
+  scheduled check, write a `recover` row to `approval_audit` and
+  surface a `[ ↻ Re-enabled ]` line in the next staleness digest.
+- No retro-active state-management. No automatic re-trigger of the
+  scheduled task. Just don't *hide* the recovery from the user.
+
+### 4.4 Second surface: Notion as the next consumer — P1, parallel with 4.1
+
+The approval kernel (RFC B) and the onboarding pattern (RFC D §5) were
+both designed for N doc surfaces, not just Drive. **Building Notion
+second is the test that the framework actually generalizes.**
+
+**Design:**
+
+- Server choice candidate: `makenotion/notion-mcp-server` (official,
+  MIT-licensed, OAuth supported). Pin a commit SHA per RFC D §2 (don't
+  track a floating tag).
+- Vault slot pattern mirrors Drive: `notion:<agent_unit>:refresh_token`
+  and `notion:<agent_unit>:refresh_token:status` for invalid-grant
+  signaling. Same revocation flow as RFC D §4.3.
+- Scope grammar:
+  - `doc:notion:page:<id>` — single page.
+  - `doc:notion:database:<id>/**` — database (analog to a folder).
+  - `doc:notion:workspace/<id>/**` — entire workspace.
+- Onboarding card: same shape as RFC D §5, swapped copy:
+  `[ ✅ Allow my Notion (read-only) — recommended ]` etc.
+- CLI: `switchroom notion connect|disconnect <agent>`, with the same
+  three-tier OAuth auto-select as Drive (device-code → OOB-paste →
+  desktop-loopback). RFC D §3 is the template; copy nothing, factor
+  the shared code.
+- The picker from §4.1 is generalized: `switchroom <surface> folders
+  <agent>` works for Drive folders and Notion databases identically.
+
+**Refactor signal:** if landing Notion requires copy-pasting more than
+~50 lines from `src/drive/*` into `src/notion/*`, stop and extract
+`src/doc-connection/` first (shared OAuth tier-selection, vault-slot
+pattern, onboarding card builder, picker primitive). The whole point
+of building a second surface is to find the seams.
+
+## 5. Out of scope
+
+- **Slack messages-as-docs** — same shape, separate spec when there's
+  user demand. Not blocking anything.
+- **Gmail surface** — `taylorwilsdon/google_workspace_mcp` (RFC D §2)
+  already supports it, but Gmail's approval shape is per-thread, not
+  per-doc; warrants its own spec.
+- **Local-filesystem doc indexing** (Obsidian, plain markdown trees) —
+  this spec is about *external* doc surfaces. Local trees are an
+  agent-workspace concern.
+- **Service-account auth** — same reason as RFC D §12: collapses
+  approval semantics.
+- **Two-way doc sync** (treating Drive/Notion as a backing store for
+  agent-state) — out. The contract is read with optional write.
+- **A unified `switchroom docs ...` super-CLI** — premature
+  abstraction. `drive` and `notion` as siblings is fine until there
+  are 3+ surfaces.
+
+## 6. Principle checks
+
+Per `reference/principles.md`, applied to this spec:
+
+### 6.1 Docs test — *"Can someone use this without opening `docs/`?"*
+
+- ✅ `switchroom drive folders klanker` posts a card with inline
+  guidance. No prerequisite reading.
+- ✅ `switchroom notion connect klanker` mirrors `switchroom drive
+  connect` exactly — the user who did Drive once doesn't need to
+  learn anything new.
+- ✅ Onboarding card text explains the trade-off ("most users pick
+  Allow my workspace — one tap now") rather than naming the underlying
+  scope grammar.
+- ✅ Folder picker breadcrumbs make the active scope visible without a
+  glossary.
+
+### 6.2 Defaults test — *"Does it work on a fresh `switchroom setup`?"*
+
+- ✅ Drive remains opt-in (must run `connect`); once enabled, the
+  folder picker is reachable with no further config.
+- ✅ Writes default to per-action approval. Standing write grants are
+  available but opt-in via expand. No one accidentally grants
+  klanker the ability to overwrite their `/Work` folder.
+- ✅ Notion's onboarding card defaults to "Allow my workspace
+  (read-only)" — the same pragmatic default as Drive.
+
+### 6.3 Consistency test — *"Does this feel like one product?"*
+
+- ✅ Same `apv:` callback shape across surfaces (RFC B §6.1).
+- ✅ Same `<surface>:<agent_unit>:refresh_token` vault slot pattern.
+- ✅ Same `switchroom <surface> connect|disconnect` CLI verb.
+- ✅ Same approval card states (pristine / expanded / granted / denied
+  / expired) — RFC B §8.1.
+- ✅ Same `/approvals list|revoke|add|stats` surface — adding Notion
+  scopes doesn't add new commands, just new rows.
+- ⚠️  Risk: if §4.4's refactor signal fires, doing it *before* shipping
+  Notion is a one-mind-built-this requirement, not a follow-up.
+
+## 7. Migration / rollout
+
+Phased so each phase is shippable on its own and the framework signal
+in 4.4 can shape the rest.
+
+1. **Phase 1 (parallel)** — Drive folder picker (§4.1) + Notion
+   connect/disconnect skeleton with shared OAuth tier code (§4.4
+   minimum). Validates the picker primitive on Drive while Notion
+   surfaces the framework seams.
+2. **Phase 2** — Notion onboarding card + scope grammar wired through
+   the approval kernel. The "second consumer" milestone — if the
+   kernel needs changes to fit Notion, find them now.
+3. **Phase 3** — Drive writes (§4.2). Lower priority than Notion-reads
+   because writes carry more risk and existing read flows are
+   delivering value already.
+4. **Phase 4** — Reconciler recovery event (§4.3). Cleanup once write
+   flows have a few weeks of mileage.
+
+## 8. Effort estimate
+
+Per CLAUDE.md, in **agent minutes** (wall-clock for a current-gen
+agent, end-to-end including tests):
+
+| Phase | Item | Estimate |
+|---|---|---|
+| 1 | Folder picker (§4.1) — picker card + pagination + 5min cache + tests | ~45 min |
+| 1 | Notion skeleton (§4.4) — CLI verb + OAuth wiring + vault slots + tests | ~60 min |
+| 2 | Notion onboarding + scope grammar through kernel | ~45 min |
+| 2 | Framework extraction if §4.4 refactor signal fires | ~60 min (conditional) |
+| 3 | Drive writes (§4.2) — scope namespace + tools + approval defaults + tests | ~60 min |
+| 4 | Reconciler recovery event (§4.3) | ~15 min |
+| — | Doc updates across `docs/drive.md`, new `docs/notion.md`, RFC cross-refs | ~15 min |
+
+**Without framework extraction: ~4 hours agent time.** With extraction:
+~5 hours. Either way, this is one focused day, not an epic.
+
+## 9. Risks and open questions
+
+- **Notion's OAuth scopes are coarser than Drive's.** Notion grants
+  per-workspace, not per-page. The "Allow my workspace" default is
+  honest about this; per-page scoping is an illusion the kernel can
+  enforce locally but Notion's API can't. Document this in the
+  onboarding copy so users aren't surprised.
+- **Write-approval fatigue.** Drive writes from a coding agent
+  ("update my README") could be high-volume. Per-folder write grants
+  are the safety valve; instrument via `/approvals stats` and observe
+  before opening up further.
+- **MCP server churn.** Notion's MCP ecosystem is younger than Drive's.
+  Pin the SHA per RFC D §2; revisit at each release.
+- **Picker discoverability.** A user who's been pre-granting per-doc
+  needs to discover the picker exists. The new
+  `[ 📁 Allow folder instead ]` button on per-doc approval cards is
+  the in-flow nudge; the staleness digest's `[ 📁 Browse ]` button is
+  the post-hoc one. If neither lands, surface a one-time tip after
+  the third per-doc grant.
+- **Surface-name confusion in copy.** Drive has "folders," Notion has
+  "databases" + "pages," Slack has "channels." The picker primitive
+  is generic; the copy must use surface-native nouns. No
+  `switchroom docs grant <generic-thing>` super-vocab.
+
+## 10. Tracking
+
+Open one tracking issue per phase, all blocked on this spec landing:
+
+- [ ] Phase 1a — Drive folder picker
+- [ ] Phase 1b — Notion connect/disconnect skeleton
+- [ ] Phase 2 — Notion onboarding + kernel-scope grammar
+- [ ] Phase 3 — Drive writes + scope namespace
+- [ ] Phase 4 — Reconciler recovery event

--- a/docs/rfcs/doc-connection-completion.md
+++ b/docs/rfcs/doc-connection-completion.md
@@ -1,8 +1,15 @@
 # RFC E: Make Google Drive a real collaboration surface
 
-Status: Draft v2
+Status: Draft v3
 Author: Ken (with Claude pair-design)
 Date: 2026-05-14
+
+**v3 changes** (addressing PR #1227 review):
+- §3 dropped `extend-without-forking` JTBD claim (overstated — that JTBD is about adding new agents/skills/tools, not config-surface affordances inside an existing integration).
+- §4.5 added a third anchor primitive: text-snippet anchor (`after_line_containing: "..."` resolved by wrapper). Covers the 80% of real-world meeting-notes / draft-prose docs that have no headings without forcing a "agent must add headings first" hard contract.
+- §4.2 hardened the diff-preview against intent-lies (not just size-lies): wrapper-attested anchor name appears on the primary card, agent-supplied summary appears below it. User has wrapper truth to sanity-check the agent's framing against.
+- §6.3 added explicit acknowledgment that approval cards are the existing exception to the "chat IS the artifact" sub-principle, per RFC B §8.1 — preempt the next reviewer re-litigating it.
+- §9 added two risks: anchor-fragmentation (covered in §4.5 expansion) + summary-lies-about-intent variant.
 
 Prerequisites — both shipped:
 - **RFC B — Approval kernel** (`approval-kernel.md`) — landed v0.6.0 (#762).
@@ -85,12 +92,11 @@ what the agent is about to do *before* it touches their doc.
 
 ## 3. JTBD alignment
 
-- **`extend-without-forking.md`** — Granting an agent access to a
-  new folder is a tap, not a code change. Per-folder write grants
-  are a config-surface affordance, not an MCP-server fork.
 - **`share-auth-across-the-fleet.md`** — Drive OAuth = once per
   Google account. Adding a second agent that needs the same Drive
   doesn't re-prompt; the cascade resolves the shared vault slot.
+  (Note: this JTBD is the load-bearing one for **RFC G** — RFC E
+  inherits its OAuth posture but doesn't drive that JTBD by itself.)
 - **`talk-to-agents-from-anywhere.md`** — Folder browsing, write
   approvals with diff preview, deep-link to Drive, reconnect-on-
   token-revocation — every step is reachable from a phone. The
@@ -99,7 +105,10 @@ what the agent is about to do *before* it touches their doc.
 - **`know-what-my-agent-is-doing.md`** — The diff-preview-before-
   write pattern is the JTBD's "see every step" applied to mutations.
   The user never finds out the agent edited a doc by re-opening it
-  later.
+  later. The wrapper-attested anchor name on the diff-preview card
+  (§4.2) is the load-bearing detail that makes this JTBD honest —
+  without it, "see every step" reduces to "see whatever the agent
+  chose to summarize."
 
 ## 4. Scope — five pieces, all Drive
 
@@ -169,23 +178,39 @@ edits, etc.).
     `write` scope.
   - `gdrive_append_to_doc(doc_id, text)` — append; uses `write` (no
     Suggesting equivalent in the API for pure append).
-- Approval card for a suggestion edit:
+- Approval card for a suggestion edit (anchor + line-count are
+  **wrapper-attested**; summary is agent-supplied):
   ```
   ✏️ klanker wants to add to "Q3 Strategy Notes"
-  +47 lines · "Added Hiring section after 'Goals'"
+  📍 after heading 'Goals' (level 2)         ← wrapper, not agent
+  +47 lines / -0 lines                       ← wrapper, not agent
+  💬 "Added Hiring section after 'Goals'"     ← agent-supplied summary
   [ 📖 Open in Drive ]  [ ✅ Apply as suggestion ]
   [ ⚠ Apply directly ]  [ 🚫 Cancel ]
   ```
+  - **Wrapper-attested anchor name** sits on its own line above the
+    diff metrics, prefixed `📍`. The wrapper has just resolved the
+    anchor (per §4.5) so it knows the actual heading / line-snippet
+    / position the edit will land at — and surfaces it independently
+    of whatever the agent says in its summary. This is the
+    load-bearing detail that makes the JTBD `know-what-my-agent-is-
+    doing` honest for mutations: even if the agent's summary says
+    *"Added Hiring section"*, if the resolved anchor reads `📍 after
+    heading 'Goals'` and the edit actually lands in Goals, the user
+    sees the truth.
+  - **Wrapper-attested diff metrics** (`+47 / -0 lines`) — the
+    wrapper computes these from the proposed edit relative to the
+    current doc state. Agent cannot lie about size.
+  - **Agent-supplied summary** (`💬 "..."`) is the agent's
+    explanation of *why*, not *what* — the wrapper-attested anchor
+    and metrics already cover *what*. Audit row stores both for
+    post-hoc review of agent intent vs. wrapper truth.
   - Primary action is **Apply as suggestion** — single tap, lands
     as a Drive Suggestion the user reviews in Drive's UI.
   - **Apply directly** is a secondary, badged with `⚠`. Standing
     direct-write grants are opt-in via expand only — never on the
     primary card row.
   - **Open in Drive** is always present. See §4.3.
-- Diff summary (`+47 lines · "..."`) is best-effort: render
-  line-counts always, render the agent-supplied "what changed"
-  string if present (the agent passes a `summary` param to the
-  suggest tool).
 - Audit row records `action: suggest` or `action: write` so
   `/approvals stats` separates collaboration traffic from outright
   writes.
@@ -248,20 +273,55 @@ needs an anchor model that's robust enough for an agent to use.
 Naive "insert after byte offset N" breaks the moment the doc
 shifts.
 
-**Design:**
+**Three anchor types, in priority order:**
 
-- Anchors are **heading-based**, not byte-offset-based. The agent
-  passes `anchor: { after_heading: "Goals", level: 2 }` or
-  `anchor: { append_to_section: "Hiring", level: 2 }`.
-- The wrapper resolves anchors against the current doc state at
-  edit-time (via `documents.get` → walk the structural tree).
-- If the anchor doesn't resolve (heading was renamed, deleted),
-  the edit is rejected at the wrapper layer with a clear error
-  the agent surfaces back: *"⚠ Couldn't find heading 'Goals' in
-  current doc. Want me to suggest a heading-by-heading rewrite,
-  or pick a different anchor?"*
-- For docs with no headings, the wrapper falls back to two anchor
-  modes: `at_start`, `at_end`. No silent guess at byte offsets.
+1. **Heading-based** (preferred for headed docs):
+   ```
+   anchor: { after_heading: "Goals", level: 2 }
+   anchor: { append_to_section: "Hiring", level: 2 }
+   ```
+   Wrapper resolves against `documents.get` → structural tree
+   walk. If multiple headings match (`level` not specified or
+   ambiguous), the first match wins; agent can disambiguate by
+   adding `level` or `nth_match`.
+
+2. **Text-snippet anchor** (covers unheaded docs — meeting notes,
+   draft prose, the long tail):
+   ```
+   anchor: { after_line_containing: "we agreed to ship by Q3" }
+   anchor: { before_line_containing: "Action items:" }
+   anchor: { replace_line_matching: /TBD: hiring section/ }
+   ```
+   Wrapper resolves by walking paragraph-level text content,
+   matching the snippet (case-insensitive substring by default;
+   regex if the value is a `RegExp`-shaped object). If multiple
+   matches, the agent gets `MULTIPLE_MATCHES` with the first 3
+   surrounding-context excerpts and must pick one — no "first
+   wins" silent guess for snippets, because the user can't
+   visually verify which match the agent meant.
+
+3. **Document-position fallback** (last resort, for empty / very
+   short docs only):
+   ```
+   anchor: { at_start: true }
+   anchor: { at_end: true }
+   ```
+
+**Resolution failure** at any tier:
+
+- Heading not found → `HEADING_NOT_FOUND` with suggestion to
+  switch to a snippet anchor: *"⚠ Couldn't find heading 'Goals'.
+  Try `after_line_containing: \"...\"` or pick a different
+  anchor."*
+- Snippet not found / matches multiple → `SNIPPET_NOT_FOUND` or
+  `SNIPPET_AMBIGUOUS` with the actual match excerpts. Agent must
+  re-decide; no silent fallback to `at_end`.
+- All three resolved successfully → wrapper computes the
+  **resolved anchor name** that gets surfaced on the diff-preview
+  card per §4.2 (e.g. `'Goals' (heading)` or `line 47: "we agreed
+  to ship by Q3"` or `at end of doc`). This is the
+  wrapper-attested anchor the user sees — the agent cannot
+  override it.
 
 ## 5. Out of scope (this spec)
 
@@ -323,6 +383,30 @@ Per `reference/principles.md`, applied to this spec:
 - ✅ Same headed-doc model the user already lives in for any Drive
   doc; agent anchors mean what they look like they mean.
 
+**Sub-principle: "the chat IS the artifact" — explicit
+acknowledgment.** `principles.md` §3 sub-principle warns against
+adding new pinned cards / status bars / live widgets when the
+model could communicate naturally instead. The diff-preview
+approval card in §4.2 looks like a violation of that rule. It
+isn't, and the spec says so explicitly so the next reviewer
+doesn't have to re-litigate:
+
+> Approval cards are the existing exception per RFC B §8.1. The
+> rule is "build the model to communicate; let the framework be
+> the safety net, not the headline." Approvals are the framework
+> safety net for **mutations under operator authorization** —
+> they're the one place where the chat alone can't carry the
+> semantic weight (a tap is structurally different from a
+> message). The diff-preview card in §4.2 is the same primitive
+> RFC B §8.1 already established, applied to write-shaped
+> approvals; it does not introduce a new pinned-card-shaped
+> object. Open-in-Drive is an inline-keyboard button on the
+> existing card, not a separate widget. If the user taps "Apply
+> directly" repeatedly the model can still narrate ("you've
+> approved 6 direct writes today, want me to suggest instead?")
+> in chat — the card never replaces the chat as the source of
+> truth.
+
 ## 7. Migration / rollout
 
 All five pieces are scoped as **Phase 1 — Drive collab experience**.
@@ -369,18 +453,36 @@ shippable as four PRs (1a, 1b, 1c, 1d) for incremental review.
   a doc, pure append) have no Suggesting equivalent — those stay
   on the direct `write` scope. Document this clearly in the agent-
   facing tool descriptions so the agent picks the right tool.
-- **Anchor robustness vs agent ergonomics.** Heading-based anchors
-  are robust against doc evolution but require docs to actually
-  have headings. For unheaded docs the fallback is `at_start` /
-  `at_end` only — agents working on unstructured notes will need
-  to add structure first or accept end-append as the only option.
-  Document this expectation in the prompt-pack for any agent that
-  uses Drive writes.
-- **Diff preview accuracy.** The "+47 lines · summary" preview is
-  agent-supplied. A misbehaving agent could under-state the diff
-  to pass approval. Mitigation: line-count comes from the wrapper
-  (not the agent), only the summary string is agent-supplied.
-  Audit row stores both for post-hoc review.
+- **Anchor type selection by the agent.** Three anchor types in
+  §4.5 (heading / snippet / position) means the agent has to pick
+  the right one. Wrong pick = `*_NOT_FOUND` error and a wasted
+  tool call, not user-visible damage — but it does add a class of
+  agent confusion. Mitigation: prompt-pack guidance + tool
+  descriptions explicitly call out the priority order (try
+  heading first, fall back to snippet, position only for
+  empty/very-short docs). After 3 wasted tool calls in a session
+  on the same doc, the wrapper returns the doc's structural tree
+  in the error response so the agent can re-plan from ground
+  truth instead of guessing again.
+- **Snippet anchor ambiguity in long docs.** A snippet that
+  appears multiple times forces the agent to pick a specific
+  match. In a long doc with repetitive structure (meeting notes
+  with a "Action items:" section in every entry), this becomes a
+  multi-round conversation. Mitigation: `MULTIPLE_MATCHES` error
+  returns the first 3 surrounding-context excerpts (per §4.5);
+  agent picks by `nth_match` index. Acceptable friction for the
+  collab loop; not a blocker.
+- **Diff preview — size lies and intent lies, separately
+  defended.** Two distinct attacks on the diff-preview card:
+  (a) *size lie* — agent claims `+5 lines` for a 47-line change;
+  (b) *intent lie* — agent's summary says "Added Hiring section"
+  but the edit lands in Goals. Mitigation: §4.2 surfaces both
+  the wrapper-attested anchor name (`📍 after heading 'Goals'`)
+  and the wrapper-attested line counts (`+47 / -0 lines`)
+  alongside the agent's summary, on the primary card row. User
+  has wrapper truth to sanity-check the agent's framing.
+  Audit row stores all three for post-hoc review of agent intent
+  vs. wrapper resolution.
 - **Folder picker cache invalidation.** 5-min cache is right for
   most users but wrong for someone reorganizing their Drive in the
   same window. Add a `[ ↻ Refresh ]` affordance on the picker card


### PR DESCRIPTION
## Summary (v2)

New design spec at \`docs/rfcs/doc-connection-completion.md\` (RFC E). **v2 refocus:** instead of trying to land Drive completion + Notion in parallel, this version focuses Phase 1 entirely on making Google Drive a real collaboration surface. Notion + the broader doc-connection framework move to follow-up **RFC F** (gets to copy from a working model instead of inheriting designed-up-front abstractions).

## Goal

A user can give an agent a Google Doc, ask it to draft into the doc, review the agent's changes inline in Drive, and resume the conversation in Telegram — all without leaving the phone-or-laptop they already have open. **The agent is a collaborator on the user's docs, not a one-shot reader-and-summarizer.**

## Scope (5 pieces, all Drive, all Phase 1)

1. **Folder picker** (RFC D §6 deferred) — Telegram-side picker so users don't hand-type \`doc:gdrive:folder/<id>/**\`
2. **Suggesting writes + diff preview** (RFC D §12 deferred) — \`doc:gdrive:suggest:*\` scope namespace, defaulting to Drive's native Suggesting mode (non-destructive). Direct writes (\`doc:gdrive:write:*\`) remain opt-in via expand.
3. **Open-in-Drive deep links** (new) — every approval card and grant confirmation gets \`[ 📖 Open in Drive ]\`. The chat→doc→chat handoff that makes the loop possible.
4. **Reconciler missing→present recovery** (RFC D §12 deferred) — promoted from "Phase 4 cleanup" because missing→present is common in collab.
5. **Section-anchor editing primitive** (new) — heading-based anchors so agent edits survive doc evolution.

## Vision / JTBD / principle alignment

- **Vision:** outcomes 2 (multi-agent fleet), 3 (subscription-honest), 4 (always-on). Visibility (#1) served by existing approval card + new diff-preview.
- **JTBDs:** \`extend-without-forking\`, \`share-auth-across-the-fleet\`, \`talk-to-agents-from-anywhere\`, \`know-what-my-agent-is-doing\` (diff-preview-before-write = "see every step" applied to mutations).
- **Principles:** Passes docs / defaults / consistency. Most-dangerous affordance (standing direct-write grants) is opt-in via expand, never on the primary card row.

## Sub-phase rollout

| Sub-phase | Pieces | Estimate |
|---|---|---|
| 1a | Folder picker + Open-in-Drive deep links | ~65m |
| 1b | Section-anchor primitive | ~45m |
| 1c | Suggesting writes + diff preview | ~75m |
| 1d | Reconciler recovery | ~25m |

**~3.75h agent time total.** One focused day, shippable as four PRs for incremental review.

## Status

**Draft v2 — substance review needed before implementation.** Tracking issues per sub-phase + RFC F to be opened after this lands.

## Test plan

- [ ] Read the spec end-to-end and sanity-check the JTBD/principle alignment
- [ ] Confirm Suggesting-as-default is the right framing for collab (vs always direct writes with confirmation)
- [ ] Confirm heading-based anchors are the right primitive (vs structural-position or document-position-based)
- [ ] Confirm sub-phase ordering (1a → 1b → 1c → 1d)

🤖 Generated with [Claude Code](https://claude.com/claude-code)