### PR TITLE
fix(install): round-2 structural fixes from install-validation loop

### DIFF
--- a/src/agents/profiles.test.ts
+++ b/src/agents/profiles.test.ts
@@ -176,9 +176,9 @@ describe("renderProfileClaudeTemplate", () => {
     if (process.getuid && process.getuid() === 0) return;
 
     const tmp = mkdtempSync(join(tmpdir(), "switchroom-profile-render-readonly-"));
+    const profileName = "test-profile";
+    const profileDir = join(tmp, profileName);
     try {
-      const profileName = "test-profile";
-      const profileDir = join(tmp, profileName);
       mkdirSync(profileDir, { recursive: true });
       writeFileSync(join(profileDir, "CLAUDE.md.hbs"), "v1 {{profile}}");
       chmodSync(profileDir, 0o555); // read+execute, no write
@@ -189,7 +189,7 @@ describe("renderProfileClaudeTemplate", () => {
       expect(result.path).toBe(join(profileDir, "CLAUDE.md"));
     } finally {
       // Restore writable mode so rmSync can clean up.
-      try { chmodSync(resolve(tmp, "test-profile"), 0o755); } catch {}
+      try { chmodSync(profileDir, 0o755); } catch {}
       rmSync(tmp, { recursive: true, force: true });
     }
   });

--- a/src/agents/profiles.test.ts
+++ b/src/agents/profiles.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { sep as pathSep, resolve } from "node:path";
-import { mkdtempSync, mkdirSync, symlinkSync, writeFileSync, rmSync, readFileSync, existsSync } from "node:fs";
+import { mkdtempSync, mkdirSync, symlinkSync, writeFileSync, rmSync, readFileSync, existsSync, chmodSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -166,6 +166,30 @@ describe("renderProfileClaudeTemplate", () => {
       const content = readFileSync(result.path, "utf-8");
       expect(content).toBe("v1 test-profile");
     } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("gracefully skips with wrote=false when target dir is read-only (EACCES)", () => {
+    // Skip when running as root — chmod 0555 doesn't actually block root,
+    // so the EACCES path can't be exercised. CI usually runs as non-root.
+    if (process.getuid && process.getuid() === 0) return;
+
+    const tmp = mkdtempSync(join(tmpdir(), "switchroom-profile-render-readonly-"));
+    try {
+      const profileName = "test-profile";
+      const profileDir = join(tmp, profileName);
+      mkdirSync(profileDir, { recursive: true });
+      writeFileSync(join(profileDir, "CLAUDE.md.hbs"), "v1 {{profile}}");
+      chmodSync(profileDir, 0o555); // read+execute, no write
+
+      const result = renderProfileClaudeTemplate(profileName, tmp);
+
+      expect(result.wrote).toBe(false);
+      expect(result.path).toBe(join(profileDir, "CLAUDE.md"));
+    } finally {
+      // Restore writable mode so rmSync can clean up.
+      try { chmodSync(resolve(tmp, "test-profile"), 0o755); } catch {}
       rmSync(tmp, { recursive: true, force: true });
     }
   });

--- a/src/agents/profiles.ts
+++ b/src/agents/profiles.ts
@@ -234,7 +234,13 @@ export function renderAgentSelfServiceFragment(
  *
  * Returns `{ wrote: true, path }` when the template was found and the
  * output file was written, or `{ wrote: false, path }` when the .hbs
- * source doesn't exist (caller can skip gracefully).
+ * source doesn't exist (caller can skip gracefully) OR the target dir
+ * is read-only (e.g. switchroom installed under
+ * `/usr/local/lib/node_modules/switchroom/profiles/` and run as a
+ * non-root user). In the read-only case, the rendered output isn't
+ * consumed by anything downstream — the per-agent scaffold renders
+ * its own CLAUDE.md from the same .hbs source at `scaffold.ts:2123`
+ * — so a graceful skip with a warning is correct here.
  */
 export function renderProfileClaudeTemplate(
   profileName: string,
@@ -252,6 +258,23 @@ export function renderProfileClaudeTemplate(
   const source = readFileSync(hbsPath, "utf-8");
   const template = Handlebars.compile(source, { noEscape: true });
   const rendered = template({ profile: profileName });
-  writeFileSync(outPath, rendered, "utf-8");
-  return { wrote: true, path: outPath };
+  try {
+    writeFileSync(outPath, rendered, "utf-8");
+    return { wrote: true, path: outPath };
+  } catch (err) {
+    // EACCES / EROFS: switchroom is installed under a root-owned dir
+    // and we're running as a non-root operator. The per-agent scaffold
+    // path re-renders the same .hbs into the agent dir anyway, so this
+    // bookkeeping write is non-load-bearing — warn once and continue.
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === "EACCES" || code === "EROFS" || code === "EPERM") {
+      console.warn(
+        `Note: profile CLAUDE.md at ${outPath} is not writable (${code}); ` +
+          `skipping bookkeeping render. Agent scaffolds re-render the .hbs ` +
+          `into their own dir, so this is non-fatal.`,
+      );
+      return { wrote: false, path: outPath };
+    }
+    throw err;
+  }
 }

--- a/src/agents/profiles.ts
+++ b/src/agents/profiles.ts
@@ -239,7 +239,7 @@ export function renderAgentSelfServiceFragment(
  * `/usr/local/lib/node_modules/switchroom/profiles/` and run as a
  * non-root user). In the read-only case, the rendered output isn't
  * consumed by anything downstream — the per-agent scaffold renders
- * its own CLAUDE.md from the same .hbs source at `scaffold.ts:2123`
+ * its own CLAUDE.md from the same .hbs source at `scaffold.ts:2127`
  * — so a graceful skip with a warning is correct here.
  */
 export function renderProfileClaudeTemplate(

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -2081,6 +2081,55 @@ export function registerDoctorCommand(program: Command): void {
     .option("--skill <name>", "Run probes for a specific skill only (e.g. mff)")
     .action(
       withConfigError(async (opts: { json?: boolean; skill?: string }) => {
+        // Pre-config-load short-circuit: if no switchroom.yaml exists yet
+        // (e.g. fresh install before `switchroom setup`), running doctor
+        // should still be useful — that's exactly when an operator wants
+        // to verify their dependencies. Run the config-free sections
+        // (deps + skills prereqs) and exit, instead of erroring.
+        try {
+          getConfigPath(program);
+        } catch (_e) {
+          const depsOnlySections = [
+            { title: "Dependencies", results: checkDependencies() },
+            { title: "Skills Prerequisites", results: checkSkillsPrerequisites() },
+          ];
+          if (opts.json) {
+            console.log(
+              JSON.stringify(
+                {
+                  sections: depsOnlySections,
+                  configMissing: true,
+                  hint: "No switchroom.yaml found; ran deps-only preflight. Run `switchroom setup` to bootstrap config.",
+                },
+                null,
+                2,
+              ),
+            );
+          } else {
+            console.log(
+              chalk.yellow(
+                "No switchroom.yaml found — running deps-only preflight.",
+              ),
+            );
+            console.log(
+              chalk.gray(
+                "  Run `switchroom setup` to bootstrap config + Telegram wiring.",
+              ),
+            );
+            console.log();
+            let totalFails = 0;
+            for (const s of depsOnlySections) {
+              const { fails } = printSection(s.title, s.results);
+              totalFails += fails;
+            }
+            console.log();
+            if (totalFails > 0) {
+              process.exit(1);
+            }
+          }
+          return;
+        }
+
         const config = getConfig(program);
         const configPath = getConfigPath(program);
 

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -209,10 +209,14 @@ async function stepConfigFile(
     return { config, configPath: resolve(existingConfig) };
   }
 
-  if (nonInteractive) {
-    throw new ConfigError("No switchroom.yaml found and running in non-interactive mode");
-  }
-
+  // No config found. Bootstrap from the bundled example. In interactive
+  // mode this prompts for which example; in non-interactive it picks
+  // the default ("switchroom") deterministically. The previous
+  // behaviour — throwing ConfigError in non-interactive mode — made it
+  // impossible to drive `switchroom setup --non-interactive` from a
+  // fresh install, which was a P0 blocker for any scripted/CI install
+  // (the same code path that works interactively works fine
+  // non-interactively; nothing about the bootstrap requires a TTY).
   return await copyExampleConfig(cwd, nonInteractive);
 }
 
@@ -704,6 +708,7 @@ async function stepScaffoldAgents(
   const topicState = loadTopicState();
 
   let scaffolded = 0;
+  let scaffoldFailed = 0;
   for (const name of agentNames) {
     const agentConfig = config.agents[name];
     const botInfo = agentBots[name];
@@ -740,6 +745,7 @@ async function stepScaffoldAgents(
       console.error(
         chalk.red(`  x ${name}: ${(err as Error).message}`),
       );
+      scaffoldFailed++;
     }
   }
 
@@ -747,11 +753,20 @@ async function stepScaffoldAgents(
   // file is regenerated + brought up by `switchroom apply`. We don't
   // run that automatically from the setup wizard — the operator may
   // want to inspect switchroom.yaml first.
-  console.log(
-    chalk.green(
-      `  ${STEP_DONE} ${scaffolded} agent(s) scaffolded`,
-    ),
+  //
+  // #12: don't paint a green checkmark on a step that failed. If any
+  // agent scaffold threw, surface it as a hard failure so the final
+  // "Setup complete!" line never lies about reality.
+  const summary = `${scaffolded} agent(s) scaffolded` + (
+    scaffoldFailed > 0 ? `, ${scaffoldFailed} failed` : ""
   );
+  if (scaffoldFailed > 0) {
+    console.log(chalk.red(`  x ${summary}`));
+    throw new Error(
+      `${scaffoldFailed} agent scaffold(s) failed during setup — see errors above.`,
+    );
+  }
+  console.log(chalk.green(`  ${STEP_DONE} ${summary}`));
   console.log(
     chalk.gray(
       "  Next: switchroom apply  (regenerates docker-compose.yml + brings agents up)",


### PR DESCRIPTION
## Summary

Follow-up to #1231. Closes the 4 deferred blockers from the fresh-VM install-validation run. Combined with the round-1 PR (already merged), this covers all 12 friction findings captured during the Phase 1 cold install.

## What's in this PR

- **#4 — `switchroom doctor` works without a config file** (`src/cli/doctor.ts`). New users want to verify deps *before* running setup — that's the whole point of doctor. When `findConfigFile()` throws (no `switchroom.yaml` yet), doctor now runs a deps-only preflight (Dependencies + Skills Prerequisites) instead of erroring out. JSON mode surfaces a `configMissing: true` flag.
- **#7 — `setup --non-interactive` bootstraps from a blank slate** (`src/cli/setup.ts:stepConfigFile`). Removed the throw at the no-config branch; the same `copyExampleConfig` path that auto-copies interactively already handles non-interactive (deterministically picks the "switchroom" example). This was the only thing blocking scripted/CI installs from a blank slate.
- **#11 — Profile rendering no longer `EACCES`'s on global installs** (`src/agents/profiles.ts`). Catch `EACCES`/`EROFS`/`EPERM` on the bookkeeping write and skip with a one-line warning. Nothing downstream reads `profiles/<name>/CLAUDE.md` (the per-agent scaffold re-renders the same `.hbs` into the agent's own dir at `scaffold.ts:2123`), so the skip is non-fatal. Unblocks every non-root operator on an `npm install -g` host.
- **#12 — Setup reports accurate success/failure** (`src/cli/setup.ts:stepScaffoldAgents`). Track scaffold failures alongside successes and throw at the end if any agent failed. Prior behaviour printed `0 agent(s) scaffolded` mid-step then ended with a green `Setup complete!` — a false positive.

## Test plan

- [x] `vitest run src/agents/profiles.test.ts` — 35 tests pass (added `gracefully skips with wrote=false when target dir is read-only (EACCES)`)
- [x] `vitest run src/cli/setup-posture-rewrite.test.ts tests/setup.test.ts` — 39 tests pass
- [x] `vitest run tests/doctor.test.ts tests/doctor.repo-hygiene.test.ts` — 67 tests pass
- [x] `tsc --noEmit` clean
- [ ] Phase 3 of the install loop: rerun the full doc-driven install on a clean VM, time it, confirm all 12 findings are gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)