### PR TITLE
fix(install): round-3 — six install-blocking fixes from Phase 3 re-validation

### DIFF
--- a/docker/Dockerfile.agent
+++ b/docker/Dockerfile.agent
@@ -15,8 +15,20 @@ RUN echo "switchroom/agent building for arch=${TARGETARCH}" >&2
 #   /state/.claude   — ~/.claude/projects/<name>
 #   /var/log/switchroom — ~/.switchroom/logs/<name>
 # Pre-create them so first-boot doesn't race the bind-mount semantics.
+#
+# /var/log/switchroom is the destination for `_switchroom_supervise`
+# log files (gateway-supervisor, autoaccept, agent-scheduler) written
+# by start.sh. The compose `user:` directive runs start.sh as the
+# per-agent UID (10001-10999, see Dockerfile.base) — but the dir is
+# created here as root with default umask. Without an explicit
+# 0777, start.sh hits "Permission denied" writing the supervisor
+# logs and the three sidecars (gateway / autoaccept / scheduler)
+# never start; the agent then hangs forever on the Claude Code
+# first-run theme picker because autoaccept-poll isn't there to
+# dispatch keystrokes. (Install-validation finding #19.)
 RUN mkdir -p /state/agent /state/.claude /var/log/switchroom \
- && mkdir -p /run/switchroom
+ && mkdir -p /run/switchroom \
+ && chmod 0777 /var/log/switchroom
 
 # Make sure tmux's runtime dir exists; the per-agent UID will own it via
 # the compose `user:` directive at runtime.

--- a/src/agents/compose.ts
+++ b/src/agents/compose.ts
@@ -928,12 +928,20 @@ export function generateCompose(opts: ComposeGeneratorOptions): string {
   // `cap_drop: ALL` and only CHOWN + FOWNER, root cannot read into
   // those dirs, so the probe always fails. Broker already has this
   // cap (for vault file reads); adding it here gives both singletons
-  // the same probe-reachability. Read-only DAC bypass — strictly less
-  // powerful than DAC_OVERRIDE which also bypasses write checks.
+  // the same probe-reachability.
+  //
+  // DAC_OVERRIDE is needed because /state/approvals is bind-mounted
+  // from `~/.switchroom/approvals` on the host — owned by the operator
+  // user, mode 0775 — and the kernel runs as root inside the container.
+  // Without DAC_OVERRIDE, root-in-container can't open the SQLite db
+  // file there for writes (it isn't the owner and "other" doesn't have
+  // write). DAC_READ_SEARCH alone is read-only. Install-validation
+  // finding #18 (PR adding this comment).
   lines.push(`    cap_add:`);
   lines.push(`      - "CHOWN"`);
   lines.push(`      - "FOWNER"`);
   lines.push(`      - "DAC_READ_SEARCH"`);
+  lines.push(`      - "DAC_OVERRIDE"`);
   if (switchroomConfigPath) {
     lines.push(`    environment:`);
     lines.push(`      SWITCHROOM_CONFIG: /state/config/switchroom.yaml`);

--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -2332,6 +2332,20 @@ export function scaffoldAgent(
     mkdirSync(agentsDir, { recursive: true });
     for (const [saName, saDef] of Object.entries(agentConfig.subagents)) {
       const mdPath = join(agentsDir, `${saName}.md`);
+      // Post-cascade invariant: description is what Claude Code uses
+      // to decide when to delegate to a subagent. The schema allows
+      // partial overrides (so profile-level overlays don't have to
+      // restate it — see SubagentSchema in src/config/schema.ts), but
+      // the FINAL merged subagent must have one. Fail loudly with
+      // actionable guidance instead of writing `description: undefined`
+      // to the markdown (which Claude Code rejects silently).
+      if (!saDef.description) {
+        throw new Error(
+          `subagent "${saName}" has no description after cascade — add one ` +
+            `to your defaults, the profile this agent extends, or the agent's ` +
+            `own subagents.${saName} block.`,
+        );
+      }
       const frontmatter: Record<string, unknown> = {
         name: saName,
         description: saDef.description,
@@ -3598,6 +3612,14 @@ Don't wait for a slash command. Don't ask permission. Memory work is table stake
       mkdirSync(saDir, { recursive: true });
       for (const [saName, saDef] of Object.entries(agentConfig.subagents)) {
         const mdPath = join(saDir, `${saName}.md`);
+        // Post-cascade invariant — see same check in scaffoldAgent above.
+        if (!saDef.description) {
+          throw new Error(
+            `subagent "${saName}" has no description after cascade — add one ` +
+              `to your defaults, the profile this agent extends, or the agent's ` +
+              `own subagents.${saName} block.`,
+          );
+        }
         const frontmatter: Record<string, unknown> = {
           name: saName,
           description: saDef.description,

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -338,8 +338,20 @@ async function stepBotToken(
     throw err;
   }
 
-  // Store in vault if interactive
-  if (!nonInteractive && config.telegram.bot_token.startsWith("vault:")) {
+  // Store in vault when the config references one. This works in both
+  // modes — interactive prompts for the vault passphrase if env-var
+  // isn't set, non-interactive requires SWITCHROOM_VAULT_PASSPHRASE.
+  // Previously this was gated behind `!nonInteractive`, which meant
+  // scripted/CI installs with `vault:`-prefixed config never created
+  // the vault — `switchroom apply` then refused to run with
+  // "vault.enc is missing" (install-validation finding #16).
+  if (config.telegram.bot_token.startsWith("vault:")) {
+    if (nonInteractive && !process.env.SWITCHROOM_VAULT_PASSPHRASE) {
+      throw new Error(
+        "Config references vault: refs but SWITCHROOM_VAULT_PASSPHRASE is unset. " +
+          "Set it in non-interactive mode so the vault can be created.",
+      );
+    }
     await storeTokenInVault(config, token);
   }
 
@@ -520,6 +532,20 @@ async function stepCreateTopics(
   nonInteractive: boolean,
 ): Promise<void> {
   stepHeader(5, "Create topics", STEP_ACTIVE);
+
+  // DM-only sentinel (v0.7+) — per-agent DM-pair is the default, the
+  // forum_chat_id field stays for schema compat with legacy installs.
+  // Don't actually call the Telegram API for a fake chat id; it'll
+  // return "Forum chat not found" and look like a real failure to a
+  // new user. (Install-validation finding #15.)
+  if (config.telegram.forum_chat_id === "0") {
+    console.log(
+      chalk.gray(
+        `  ${STEP_DONE} Skipped (DM-only mode — forum_chat_id is sentinel "0")`,
+      ),
+    );
+    return;
+  }
 
   const spin = spinner("Syncing forum topics...");
   try {

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -348,8 +348,7 @@ async function stepBotToken(
   if (config.telegram.bot_token.startsWith("vault:")) {
     if (nonInteractive && !process.env.SWITCHROOM_VAULT_PASSPHRASE) {
       throw new Error(
-        "Config references vault: refs but SWITCHROOM_VAULT_PASSPHRASE is unset. " +
-          "Set it in non-interactive mode so the vault can be created.",
+        "SWITCHROOM_VAULT_PASSPHRASE must be set before running setup in non-interactive mode when config uses vault: refs.",
       );
     }
     await storeTokenInVault(config, token);

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -228,8 +228,14 @@ export const AgentHooksSchema = z
  * YAML key in `subagents: { <name>: { ... } }`.
  */
 export const SubagentSchema = z.object({
+  // Optional so profile-level partial overrides (e.g. coding profile
+  // overlaying just `isolation: worktree` onto the defaults' worker)
+  // don't have to restate the description. The cascade merges by key
+  // with defaults; the merged subagent retains the description from
+  // defaults. (Install-validation finding #13.)
   description: z
     .string()
+    .optional()
     .describe("When the main agent should delegate to this sub-agent"),
   model: z
     .string()

--- a/src/telegram/topic-manager.ts
+++ b/src/telegram/topic-manager.ts
@@ -23,23 +23,34 @@ export class TopicSyncError extends Error {
 /**
  * Resolve the bot token from config, handling vault: prefix and env fallback.
  * Returns the token string or null if unresolvable.
+ *
+ * Note: the general vault resolver in src/vault/resolver.ts handles
+ * `vault:<key>` refs for secrets that flow through the broker. This
+ * path is invoked early (during `switchroom topics` / `syncTopics`)
+ * before the broker is necessarily up, so we keep an env-var fallback
+ * for bootstrap. (Install-validation finding #14.)
  */
 export function resolveBotToken(configToken: string): string | null {
-  if (configToken.startsWith("vault:")) {
-    console.warn(
-      `Warning: Vault references are not yet implemented (found "${configToken}").`
-    );
-    console.warn(
-      "  Set TELEGRAM_BOT_TOKEN environment variable as a fallback."
-    );
-    const envToken = process.env.TELEGRAM_BOT_TOKEN;
-    return envToken && envToken.length > 0 ? envToken : null;
-  }
-
-  // Check env override first, then fall back to config value
+  // Env var always wins — covers both the bootstrap case (vault not
+  // yet initialized) and operator overrides.
   const envToken = process.env.TELEGRAM_BOT_TOKEN;
   if (envToken && envToken.length > 0) {
     return envToken;
+  }
+
+  if (configToken.startsWith("vault:")) {
+    // We don't synchronously open the vault here — that requires a
+    // passphrase and the broker, neither of which is guaranteed at
+    // this callsite. Callers that need vault resolution should set
+    // TELEGRAM_BOT_TOKEN ahead of time (setup writes it; the per-
+    // agent telegram/.env writer covers runtime).
+    console.warn(
+      `Warning: bot_token "${configToken}" is a vault ref but TELEGRAM_BOT_TOKEN is not set in the environment.`,
+    );
+    console.warn(
+      "  Set TELEGRAM_BOT_TOKEN, or run from a context that has loaded the per-agent telegram/.env file.",
+    );
+    return null;
   }
 
   return configToken;

--- a/tests/docker/compose-generator.test.ts
+++ b/tests/docker/compose-generator.test.ts
@@ -689,6 +689,18 @@ describe("generateCompose", () => {
     expect(block).toContain("DAC_READ_SEARCH");
   });
 
+  it("kernel has DAC_OVERRIDE so it can write the SQLite db to the host-owned approvals dir", () => {
+    // /state/approvals is bind-mounted from ~/.switchroom/approvals on
+    // the host (owned by the operator user). Kernel runs as root inside
+    // the container; without DAC_OVERRIDE, root can't open the SQLite
+    // db for writes (not owner, "other" doesn't have write). The kernel
+    // then crash-loops with "SQLiteError: unable to open database file"
+    // on fresh installs. Install-validation finding #18.
+    const out = generateCompose({ config: makeConfig({ a: {} }) });
+    const block = /approval-kernel:[\s\S]*?(?=\n  [a-z])/.exec(out)?.[0] ?? "";
+    expect(block).toContain("DAC_OVERRIDE");
+  });
+
   // Operator socket — host-shell-reachable broker surface.
   // Pre-fix v0.7 docker mode bound the broker's data + unlock sockets
   // only inside the container; the host CLI defaulted to a v0.6 socket

--- a/tests/merge.test.ts
+++ b/tests/merge.test.ts
@@ -442,6 +442,29 @@ describe("mergeAgentConfig subagents", () => {
     expect(result.subagents?.worker?.maxTurns).toBe(100);
     expect(result.subagents?.worker?.isolation).toBe("worktree");
   });
+
+  it("preserves partial-override semantics when defaults has a description and override doesn't (install-validation #13)", () => {
+    // Reproduces the bundled examples/switchroom.yaml case: defaults
+    // declares worker.description; coding profile overrides ONLY
+    // isolation. With SubagentSchema.description optional (schema
+    // change in install-validation round-3), schema validation passes
+    // and the cascade fills in description from defaults — the
+    // downstream scaffold invariant in src/agents/scaffold.ts then
+    // sees a non-empty description.
+    const defaults: AgentDefaults = {
+      subagents: {
+        worker: { description: "implementation work", model: "sonnet" },
+      },
+    };
+    const agent = baseAgent({
+      subagents: {
+        worker: { isolation: "worktree" }, // no description
+      },
+    });
+    const result = mergeAgentConfig(defaults, agent);
+    expect(result.subagents?.worker?.description).toBe("implementation work");
+    expect(result.subagents?.worker?.isolation).toBe("worktree");
+  });
 });
 
 describe("coding profile resolution (#682)", () => {


### PR DESCRIPTION
## Summary

Round 3 of the install-validation loop. Phase 3 re-validation (re-running the full install on a clean Ubuntu 26.04 VM after merging #1231 + #1234) surfaced six more install blockers that were invisible without an end-to-end run.

## What's in this PR

| # | Finding | Fix |
|---|---|---|
| 13 | Bundled `examples/switchroom.yaml` fails schema validation | `SubagentSchema.description` optional |
| 14 | Misleading 'Vault refs not implemented' warning | Honest message + env-var-first |
| 15 | `forum_chat_id: "0"` sentinel still hits Telegram API | Skip topic sync on sentinel |
| 16 | Non-interactive setup never inits vault | Drop `!nonInteractive` gate; require env passphrase |
| 18 | approval-kernel SQLite crash loop | Add `DAC_OVERRIDE` cap |
| 19 | `/var/log/switchroom` perms block per-agent UIDs | `chmod 0777` in Dockerfile.agent |

#19's cascade was: log dir unwritable → start.sh's three sidecars (gateway/autoaccept/scheduler) all fail Permission denied → no autoaccept → agent stuck forever on Claude Code's first-run theme picker.

## Deferred to a separate PR

**#17 — foreman compose support.** `setup --foreman` writes config to `~/.switchroom/foreman/` but `src/agents/compose.ts` has zero foreman handling — the service never reaches docker. Larger fix (new container image / docker socket mount / switchroom CLI inside) deserves its own PR. For Phase 4 of the install-validation loop, the admin bot will be configured as a regular agent with `admin: true` (the existing schema-level flag at `schema.ts:1328` that intercepts admin slash commands at the gateway) instead of as a foreman.

## Test plan

- [x] `vitest run tests/setup.test.ts tests/doctor.test.ts src/cli/setup-posture-rewrite.test.ts` — 92 tests pass
- [x] `vitest run tests/docker/compose-generator.test.ts` — 115 tests pass (added DAC_OVERRIDE assertion)
- [x] `tsc --noEmit` clean
- [ ] Phase 3 end-to-end re-validation on a clean VM (deps script → setup --non-interactive → apply → docker compose up → 4 healthy containers → agent replies in Telegram)
- [ ] Phase 4 two-bot exercise (admin agent w/ `admin: true` + normal agent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)