### PR TITLE
fix(install): round-4 — UID alignment for log dir + auth code

### DIFF
--- a/examples/switchroom.yaml
+++ b/examples/switchroom.yaml
@@ -45,12 +45,17 @@ defaults:
       format: html
   tools:
     allow: [all]
-  env:
-    SWITCHROOM_AUDIT_URL: "https://audit.example"
-  hooks:
-    PreToolUse:
-      - command: "/opt/switchroom-audit.sh"
-        timeout: 5
+  # Example: custom hooks. Uncomment + drop a script of your own at the
+  # referenced path to log every tool call before it runs. Left commented
+  # because the placeholder script doesn't ship — without one, Claude
+  # surfaces a non-blocking hook error on every tool call (noisy but
+  # harmless). Install-validation finding #29.
+  # env:
+  #   SWITCHROOM_AUDIT_URL: "https://audit.example"
+  # hooks:
+  #   PreToolUse:
+  #     - command: "/opt/switchroom-audit.sh"
+  #       timeout: 5
   # Bundled skills that ship with switchroom. `humanizer` removes AI-writing
   # patterns from agent replies before they reach Telegram (29 patterns from
   # Wikipedia's "Signs of AI writing" guide). `humanizer-calibrate` is its

--- a/src/cli/apply.ts
+++ b/src/cli/apply.ts
@@ -497,6 +497,41 @@ export async function runApply(
   // back to interactive unlock).
   await ensureHostMountSources(config);
 
+  // ── 2b. Re-align per-agent log dir ownership ─────────────────────
+  //
+  // `ensureHostMountSources` just created `~/.switchroom/logs/<agent>`
+  // as the host operator UID (because mkdir runs as the operator).
+  // The per-agent scaffold loop above already called `alignAgentUid`,
+  // but at that point the log dir didn't exist yet (existsSync gate
+  // in scaffold.ts:194), so it was silently skipped — leaving the
+  // dir operator-owned. start.sh inside the container runs as the
+  // per-agent UID and bind-mounts `~/.switchroom/logs/<agent>` to
+  // `/var/log/switchroom`; it then hits "Permission denied" trying
+  // to write supervisor logs and the autoaccept / gateway / scheduler
+  // sidecars never start. Re-run alignment now that the dir exists.
+  // Install-validation finding #21.
+  if (!skipScaffold) {
+    for (const name of Object.keys(config.agents)) {
+      try {
+        const uid = allocateAgentUid(name);
+        alignAgentUid(name, join(agentsDir, name), uid, {
+          confirm: !options.nonInteractive,
+          writeOut,
+        });
+      } catch (alignErr) {
+        const msg = (alignErr as Error).message;
+        if (!options.allowUnaligned) {
+          writeOut(
+            chalk.yellow(
+              `    ! post-mount-source UID re-align failed for ${name}: ${msg}\n` +
+                `      Agent may fail to write supervisor logs on first boot.\n`,
+            ),
+          );
+        }
+      }
+    }
+  }
+
   // ── 2c. Vault layout migration (v0.7.12) ─────────────────────────
   //
   // Move the legacy single-file vault layout (~/.switchroom/vault.enc)

--- a/src/cli/auth.ts
+++ b/src/cli/auth.ts
@@ -53,6 +53,35 @@ function realignAfterHostWrite(name: string, agentDir: string): void {
   }
 }
 
+/**
+ * Temporarily chown the agent dir to the HOST operator UID so a
+ * host-side process (like `switchroom auth code`) can write into it.
+ * Pair with `realignAfterHostWrite` at the end of the host-side
+ * operation. Without this, a reauth on an already-running agent
+ * fails with EACCES because the dir is owned by the per-agent UID.
+ * Install-validation finding #22 (round-4-followup).
+ */
+function chownToHostForWrite(agentDir: string): void {
+  const hostUid = process.getuid?.();
+  const hostGid = process.getgid?.();
+  if (hostUid === undefined || hostGid === undefined) return;
+  try {
+    execFileSync("chown", ["-R", `${hostUid}:${hostGid}`, agentDir], {
+      stdio: ["ignore", "ignore", "pipe"],
+    });
+  } catch {
+    // Fall back to sudo. If sudo isn't available we just let the
+    // subsequent write throw EACCES — operator can resolve manually.
+    try {
+      execFileSync("sudo", ["chown", "-R", `${hostUid}:${hostGid}`, agentDir], {
+        stdio: ["ignore", "ignore", "pipe"],
+      });
+    } catch {
+      // Don't crash; the subsequent write will surface the real error.
+    }
+  }
+}
+
 function printAuthTable(
   headers: string[],
   rows: string[][],
@@ -335,13 +364,21 @@ export function registerAuthCommand(program: Command): void {
         requireKnownAgent(config, name);
 
         const agentDir = resolve(agentsDir, name);
+
+        // Pre-write: ensure host operator can write into the agent
+        // dir for the session-metadata files (.setup-token.session.json).
+        // On a fresh install the dir is operator-owned already, but a
+        // re-login after `auth code` (or any flow that triggered
+        // realignAfterHostWrite) needs this re-prep.
+        chownToHostForWrite(agentDir);
+
         const result = loginAgent(name, agentDir);
 
-        // No UID realignment here — `auth login` writes session
-        // metadata only and the subsequent `auth code` invocation
-        // needs to read that metadata from the same host UID context.
-        // We realign once at the END of the auth flow (in `auth code`
-        // after submitAuthCode completes).
+        // No realign here — `auth login` writes session metadata
+        // and the subsequent `auth code` invocation needs to read
+        // that metadata from the same host UID context. We realign
+        // once at the END of the auth flow (in `auth code` after
+        // submitAuthCode completes).
 
         console.log();
         for (const line of result.instructions) {
@@ -365,6 +402,10 @@ export function registerAuthCommand(program: Command): void {
         requireKnownAgent(config, name);
 
         const agentDir = resolve(agentsDir, name);
+
+        // Pre-write: ensure host operator can write session metadata.
+        chownToHostForWrite(agentDir);
+
         const result = opts.slot
           ? startAuthSession(name, agentDir, { force: true, slot: opts.slot })
           : refreshAgent(name, agentDir);
@@ -591,10 +632,18 @@ export function registerAuthCommand(program: Command): void {
 
         requireKnownAgent(config, name);
         const agentDir = resolve(agentsDir, name);
+
+        // Pre-write: chown agent dir to host UID so submitAuthCode
+        // can write the token files. (Reauth on an already-running
+        // agent: the dir was previously realigned to the per-agent
+        // UID by a prior auth code, so the host operator can't write
+        // without this prep step.)
+        chownToHostForWrite(agentDir);
+
         const result = submitAuthCode(name, agentDir, code, opts.slot);
 
-        // Re-align UIDs after the host-side token write so the
-        // containerised agent (per-agent UID) can read its own tokens.
+        // Post-write: re-align UIDs so the containerised agent
+        // (per-agent UID) can read its own tokens.
         if (result.completed && result.tokenSaved) {
           realignAfterHostWrite(name, agentDir);
         }

--- a/src/cli/auth.ts
+++ b/src/cli/auth.ts
@@ -22,8 +22,36 @@ import {
   type RefreshOutcome,
 } from "../auth/token-refresh.js";
 import { getAgentStatus, restartAgent } from "../agents/lifecycle.js";
+import { alignAgentUid } from "../agents/scaffold.js";
+import { allocateAgentUid } from "../agents/compose.js";
 import { withConfigError, getConfig } from "./helpers.js";
 import { registerAuthAccountSubcommands } from "./auth-accounts.js";
+
+/**
+ * Re-chown the agent state dir to the per-agent UID after a host-side
+ * write (e.g. `switchroom auth code` writing OAuth token files). The
+ * scaffold/apply path already aligns this on first install, but any
+ * host-side write afterwards lands as the host operator UID — the
+ * containerised agent (running as the per-agent UID) then can't read
+ * its own .claude/.oauth-token and start.sh fails with EACCES.
+ * Install-validation finding #22.
+ */
+function realignAfterHostWrite(name: string, agentDir: string): void {
+  try {
+    const uid = allocateAgentUid(name);
+    alignAgentUid(name, agentDir, uid, { confirm: false });
+  } catch (err) {
+    // Don't fail the auth flow — surface as a warning so the operator
+    // knows to chown manually if needed.
+    process.stderr.write(
+      chalk.yellow(
+        `\n  ! could not re-align UID for ${name}: ${(err as Error).message}\n` +
+          `    The token was saved, but the agent (UID-isolated) may not be able to read it.\n` +
+          `    Fix: sudo chown -R ${allocateAgentUid(name)}:${allocateAgentUid(name)} ${agentDir}\n`,
+      ),
+    );
+  }
+}
 
 function printAuthTable(
   headers: string[],
@@ -309,6 +337,12 @@ export function registerAuthCommand(program: Command): void {
         const agentDir = resolve(agentsDir, name);
         const result = loginAgent(name, agentDir);
 
+        // No UID realignment here — `auth login` writes session
+        // metadata only and the subsequent `auth code` invocation
+        // needs to read that metadata from the same host UID context.
+        // We realign once at the END of the auth flow (in `auth code`
+        // after submitAuthCode completes).
+
         console.log();
         for (const line of result.instructions) {
           console.log(line);
@@ -558,6 +592,12 @@ export function registerAuthCommand(program: Command): void {
         requireKnownAgent(config, name);
         const agentDir = resolve(agentsDir, name);
         const result = submitAuthCode(name, agentDir, code, opts.slot);
+
+        // Re-align UIDs after the host-side token write so the
+        // containerised agent (per-agent UID) can read its own tokens.
+        if (result.completed && result.tokenSaved) {
+          realignAfterHostWrite(name, agentDir);
+        }
 
         if (opts.json) {
           console.log(JSON.stringify({


### PR DESCRIPTION
## Summary

Follow-up to merged PRs #1231 / #1234 / #1237. Phase 3 re-validation on a fresh VM surfaced two more UID-alignment holes that prevented an end-to-end install from producing a working agent.

## Findings fixed

**#21 — `alignAgentUid` skipped the log dir because it didn't exist yet.** The first-pass `alignAgentUid` call inside `apply`'s scaffold loop runs BEFORE `ensureHostMountSources` creates `~/.switchroom/logs/<agent>`, so the `existsSync` gate at `scaffold.ts:194` silently skipped the log dir. `ensureHostMountSources` then `mkdir`'d it as the host operator UID. `start.sh` inside the container runs as the per-agent UID, bind-mounts that dir to `/var/log/switchroom`, and hits "Permission denied" trying to write supervisor logs — the gateway/autoaccept/scheduler sidecars never start. Fixed by a second-pass `alignAgentUid` loop right after `ensureHostMountSources`. **Verified working on the VM** — `~/.switchroom/logs/<agent>` is now `10074:10074` after apply.

**#22 — `switchroom auth code` left OAuth tokens host-owned.** `auth code` runs as the host operator UID and writes tokens into `<agentDir>/.claude/`, undoing the alignAgentUid work apply did earlier. The containerised agent (per-agent UID) then can't read `.oauth-token` and `start.sh` hits EACCES. Fixed via a new `realignAfterHostWrite(name, agentDir)` helper in `auth.ts` that calls `alignAgentUid` after `submitAuthCode` completes. **Verified working on the VM** — `.oauth-token` is now `10074:10074` after auth code.

## What's still not working — beyond install-validation scope

Even with the UID alignment correct and `CLAUDE_CODE_OAUTH_TOKEN` set in the agent process's env, Claude Code 2.1.141 (the bundled version) shows the "Select login method" prompt at boot instead of consuming the env token. Verified via `cat /proc/<claude-pid>/environ` — the var is set with a valid `sk-ant-oat01-...` value. This is a Claude/switchroom integration question (likely involving `--dangerously-load-development-channels server:switchroom-telegram` mode's auth handling) that goes beyond the install-validation scope; tracking separately.

Related: autoaccept-poll's `PROMPTS` table doesn't include a rule for "Select login method" — even if Claude legitimately needs to be driven through it on first run, autoaccept would need to dispatch the keystroke. Easy follow-up if the integration path requires it.

Other follow-ups from this round:
- #17 — `setup --foreman` writes config but compose generator ignores it (foreman service never reaches docker). Separate larger PR.
- #24 — `install-deps.sh` should also install `expect` (doctor flags it as missing).
- #26 — bundled `examples/switchroom.yaml` puts 4 agents on one bot token, triggering Telegram 409 polling conflicts.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `vitest run tests/setup.test.ts src/agents/scaffold.test.ts` — 43 tests pass
- [x] On a fresh VM: apply → log dir is `10074:10074` (was host-uid-owned before this fix)
- [x] On a fresh VM: auth login → auth code → `.oauth-token` is `10074:10074` (was host-uid-owned before this fix)
- [ ] End-to-end "agent replies in Telegram" — blocked on the separate OAuth-handoff investigation noted above

🤖 Generated with [Claude Code](https://claude.com/claude-code)