### PR TITLE
feat(examples): RFC G Phase 5 — personal-google-workspace-mcp/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,9 @@ dist/
 # Vault
 *.enc
 
+# RFC G Phase 5 — operator-host MCP credentials (refresh tokens land here)
+/examples/personal-google-workspace-mcp/credentials/
+
 # OpenClaw export bundle — contains real secrets, never commit
 /switchroom-export/
 /clerk-export/

--- a/examples/personal-google-workspace-mcp/.env.example
+++ b/examples/personal-google-workspace-mcp/.env.example
@@ -1,0 +1,34 @@
+# Personal Google Workspace MCP — environment configuration.
+#
+# Copy to `.env` and fill in:
+#   GOOGLE_OAUTH_CLIENT_ID    — from your Google Cloud Console OAuth client (Desktop app type)
+#   FASTMCP_SERVER_AUTH_GOOGLE_JWT_SIGNING_KEY — generate via: openssl rand -hex 32
+#
+# OAuth 2.1 PKCE flow — no client_secret needed (Desktop clients are
+# public clients per OAuth 2.0 spec; PKCE replaces the secret's role).
+
+# Required by upstream MCP for OAuth 2.1 mode.
+MCP_ENABLE_OAUTH21=true
+
+# Your OAuth client ID from Google Cloud Console.
+# Create: APIs & Services → Credentials → Create OAuth client ID → Desktop app.
+# Format: "12345678-abc...xyz.apps.googleusercontent.com"
+GOOGLE_OAUTH_CLIENT_ID=REPLACE_WITH_YOUR_CLIENT_ID
+
+# Port the MCP server listens on (must match compose.yaml's port mapping
+# AND the URL in your .mcp.json). 8217 is arbitrary; pick anything free.
+WORKSPACE_MCP_PORT=8217
+
+# OAuth callback URL — must match WORKSPACE_MCP_PORT exactly.
+# Loopback `localhost` is implicitly allowed for Desktop OAuth clients,
+# no GCP-side redirect URI registration needed.
+GOOGLE_OAUTH_REDIRECT_URI=http://localhost:8217/oauth2callback
+
+# Required for the loopback OAuth flow over plain HTTP. Safe in this
+# context — the OAuth handshake never leaves localhost.
+OAUTHLIB_INSECURE_TRANSPORT=1
+
+# JWT signing key for the MCP's session tokens. Generate ONCE per
+# install:  openssl rand -hex 32
+# DO NOT commit the real value to source control.
+FASTMCP_SERVER_AUTH_GOOGLE_JWT_SIGNING_KEY=REPLACE_WITH_HEX_FROM_OPENSSL_RAND

--- a/examples/personal-google-workspace-mcp/README.md
+++ b/examples/personal-google-workspace-mcp/README.md
@@ -69,7 +69,12 @@ cp .env.example .env
 # Edit .env:
 #   GOOGLE_OAUTH_CLIENT_ID   ← paste from step 5 above
 #   FASTMCP_SERVER_AUTH_GOOGLE_JWT_SIGNING_KEY ← generate via:
+
+# (GNU sed — Linux)
 sed -i "s|REPLACE_WITH_HEX_FROM_OPENSSL_RAND|$(openssl rand -hex 32)|" .env
+
+# (BSD sed — macOS — use this instead)
+# sed -i '' "s|REPLACE_WITH_HEX_FROM_OPENSSL_RAND|$(openssl rand -hex 32)|" .env
 
 chmod 600 .env
 ```
@@ -131,8 +136,13 @@ Pick whichever your nerve allows.
 `compose.yaml` defaults to `--tool-tier core` (~16 tools). Change to:
 
 - `extended` (~40 tools) — adds Slides, Forms, Tasks, Chat. Re-consent
-  needed (broader OAuth scopes). Re-run `docker compose up -d` after
-  editing.
+  needed (broader OAuth scopes). Procedure:
+  1. Edit `compose.yaml` to bump `--tool-tier core` → `--tool-tier extended`.
+  2. **Delete the existing token** so the upgraded scopes get requested
+     on the next OAuth flow: `rm -rf ./credentials/`.
+  3. `docker compose up -d --force-recreate`.
+  4. Trigger a tool call from Claude Code — the OAuth URL will appear
+     inline; tap to consent at the new scopes.
 - `complete` (~60+ tools) — adds Gmail. **Not recommended yet** — Gmail's
   per-thread approval shape is unsuitable for the broad OAuth scopes
   this tier requests. Wait for a dedicated Gmail spec.

--- a/examples/personal-google-workspace-mcp/README.md
+++ b/examples/personal-google-workspace-mcp/README.md
@@ -1,0 +1,184 @@
+# Personal Google Workspace MCP
+
+This example sets up [taylorwilsdon/google_workspace_mcp][upstream] as a
+docker-compose service exposing Google Drive + Docs + Sheets + Calendar
+tools to **your own Claude Code session on the host** (not to switchroom
+agents).
+
+It is intentionally **separate from the agent-side feature.** Agents get
+Workspace access via `switchroom auth google connect <agent>` (RFC G
+§4.5, available after Phase 3 lands). This example is for the
+operator's pair-design loop with their own host-side `claude`.
+
+> **Why two paths?** Agents run inside switchroom containers with
+> approval-kernel-mediated tool access; the per-agent OAuth posture is
+> load-bearing for the approval semantics (RFC D §2 + RFC G §4.4).
+> Your own host-side Claude Code is a single-identity surface — none of
+> that machinery applies. A shared HTTP MCP server is the right shape
+> for the operator case and the wrong shape for the fleet.
+
+[upstream]: https://github.com/taylorwilsdon/google_workspace_mcp
+
+## What you get
+
+- A long-running docker container (`google-workspace-mcp`) listening on
+  loopback port 8217.
+- 16 Workspace tools available to any Claude Code session that points
+  its `.mcp.json` at `http://127.0.0.1:8217/mcp`.
+- OAuth 2.1 PKCE flow — no client_secret to manage.
+- Refresh tokens persist in `./credentials/` so you re-auth only on
+  Google password change or 7-day Testing-mode expiry (see §5).
+
+## What you don't get
+
+- Tools in unrelated Claude Code sessions. The `.mcp.json` is
+  project-scoped — Drive surface only appears when you `cd` to a
+  directory that has it.
+- Any effect on switchroom agents.
+- HTTPS or LAN reachability. Loopback only by design.
+
+## 1. GCP Console setup (~5 minutes, you do this)
+
+1. Go to <https://console.cloud.google.com> and create (or pick) a
+   project — name it `claude-workspace-mcp`.
+2. **APIs & Services → Library** — enable each of these (one at a time;
+   wait for "API enabled" before moving on):
+   - Google Drive API
+   - Google Docs API
+   - Google Sheets API
+   - Google Calendar API
+3. **APIs & Services → OAuth consent screen** → User Type **External**.
+   - Fill App name (`claude-workspace-mcp`), your email, dev contact email.
+   - Save and continue past the Scopes page (the server requests scopes
+     at runtime — don't add any here).
+   - **Add yourself as a Test User** under "Audience" (your gmail
+     address).
+   - Decide whether to **Publish app** — see §5 for the trade-off.
+4. **APIs & Services → Credentials → Create Credentials → OAuth client
+   ID** → Application type **Desktop app** → name it `claude-code-local`.
+5. Copy the Client ID from the modal (looks like
+   `12345-abc...xyz.apps.googleusercontent.com`). You can ignore the
+   client secret — PKCE doesn't use it.
+
+## 2. Set up this directory
+
+```sh
+cd examples/personal-google-workspace-mcp/
+cp .env.example .env
+
+# Edit .env:
+#   GOOGLE_OAUTH_CLIENT_ID   ← paste from step 5 above
+#   FASTMCP_SERVER_AUTH_GOOGLE_JWT_SIGNING_KEY ← generate via:
+sed -i "s|REPLACE_WITH_HEX_FROM_OPENSSL_RAND|$(openssl rand -hex 32)|" .env
+
+chmod 600 .env
+```
+
+## 3. Bring it up
+
+```sh
+docker compose up -d
+docker compose ps          # should show "healthy" within ~30s
+docker compose logs -f     # ctrl-c when you see "Uvicorn running on http://0.0.0.0:8217"
+```
+
+## 4. Wire it into Claude Code
+
+Choose where the MCP server should be reachable:
+
+**Project-scoped (recommended)** — the Workspace tools only appear when
+you start Claude Code in this specific project directory:
+
+```sh
+cat > /path/to/your/project/.mcp.json <<'JSON'
+{
+  "mcpServers": {
+    "google-workspace": {
+      "type": "http",
+      "url": "http://127.0.0.1:8217/mcp"
+    }
+  }
+}
+JSON
+```
+
+Restart Claude Code in that directory. On first start it'll prompt to
+approve the new MCP server — say yes.
+
+**User-scoped** (every Claude Code session sees Workspace tools): use
+`claude mcp add` instead per upstream README — but think hard before you
+do this, because you're then carrying Workspace authorization into every
+unrelated codebase.
+
+## 5. OAuth consent — Testing vs Production trade-off
+
+When you set up the consent screen in §1.3, you chose between leaving
+the app in **Testing** or clicking **Publish app**.
+
+- **Testing** (default): refresh tokens expire **every 7 days** for
+  Google's "unverified app + sensitive scopes" policy. You re-auth
+  weekly via the inline OAuth prompt.
+- **Production**: no 7-day expiry. The "Publish app" button prompts
+  scary copy ("your app will be available to any user with a Google
+  Account") but for a personal Desktop OAuth client with you as the
+  only user, this is effectively a no-op — there's nothing to find or
+  use without your specific Client ID.
+
+Pick whichever your nerve allows.
+
+## 6. Tier choice
+
+`compose.yaml` defaults to `--tool-tier core` (~16 tools). Change to:
+
+- `extended` (~40 tools) — adds Slides, Forms, Tasks, Chat. Re-consent
+  needed (broader OAuth scopes). Re-run `docker compose up -d` after
+  editing.
+- `complete` (~60+ tools) — adds Gmail. **Not recommended yet** — Gmail's
+  per-thread approval shape is unsuitable for the broad OAuth scopes
+  this tier requests. Wait for a dedicated Gmail spec.
+
+## 7. Maintenance
+
+- **Logs**: `docker compose logs -f workspace-mcp`
+- **Restart**: `docker compose restart workspace-mcp`
+- **Re-auth** (Google password change or weekly Testing expiry): the
+  next failed tool call surfaces a fresh OAuth URL inline; tap to
+  consent, done.
+- **Upgrade**: bump the `workspace-mcp==X.Y.Z` pin in `compose.yaml`,
+  then `docker compose up -d --force-recreate`.
+- **Tear down**: `docker compose down` (keeps credentials);
+  `docker compose down -v` (deletes credentials, forces fresh OAuth).
+- **Inspect tokens**: `ls -la ./credentials/` — one JSON file per
+  authenticated Google account.
+
+## 8. Troubleshooting
+
+- **Container "unhealthy" forever**: check `docker compose logs` for
+  Python tracebacks. Most common cause: `GOOGLE_OAUTH_CLIENT_ID` or
+  `FASTMCP_SERVER_AUTH_GOOGLE_JWT_SIGNING_KEY` still has the
+  `REPLACE_WITH_*` placeholder.
+- **Port 8217 collision**: bump the port in `.env`
+  (`WORKSPACE_MCP_PORT` + `GOOGLE_OAUTH_REDIRECT_URI`), in
+  `compose.yaml` (the `ports:` mapping AND the healthcheck script),
+  and in your `.mcp.json` URL.
+- **OAuth flow fails with `redirect_uri_mismatch`**: make sure
+  `GOOGLE_OAUTH_REDIRECT_URI` in `.env` exactly matches
+  `WORKSPACE_MCP_PORT`. Loopback URIs don't need GCP-side registration
+  for Desktop clients, but they do need to match what the server
+  presents.
+- **Claude Code doesn't show the new MCP server after `cd` to project**:
+  exit and re-launch Claude Code (`/exit`, then `claude -c` to keep
+  the conversation). `.mcp.json` is loaded at startup, not hot-reloaded.
+
+## 9. Security notes
+
+- `.env` is mode 600 — don't commit, don't share, don't snapshot.
+- `./credentials/` directory holds refresh tokens — same restrictions.
+  Add to disk-encryption scope if your host has any.
+- The Workspace MCP sends data to Google APIs only, on your behalf,
+  using your OAuth client. No telemetry, no third-party endpoints
+  (verified per upstream's `pyproject.toml` dependency tree).
+- The OAuth client_secret in your `gcp-oauth.keys.json` (if Google
+  Cloud Console gave you one) is **not used** in PKCE flow. Treat it
+  as cosmetic; you can ignore it. If it's worried you, regenerate it
+  in GCP Console — won't break anything.

--- a/examples/personal-google-workspace-mcp/compose.yaml
+++ b/examples/personal-google-workspace-mcp/compose.yaml
@@ -1,0 +1,66 @@
+# Personal Google Workspace MCP — operator-host Claude Code surface.
+#
+# This is the docker-compose pattern for an operator who wants their own
+# Claude Code on the host to have Drive + Docs + Sheets + Calendar tools.
+# It does NOT affect switchroom agents — they get Workspace via
+# `switchroom auth google connect <agent>` (RFC G §4.5, post-Phase-3).
+#
+# Setup walkthrough: see README.md.
+#
+# Compose project name (`name:`) is deliberately distinct from the
+# `switchroom` project so `switchroom apply` / `switchroom update` /
+# `docker compose -p switchroom down -v` won't touch this container.
+# Same isolation pattern as the hostd compose project.
+
+name: google-workspace-mcp
+
+services:
+  workspace-mcp:
+    image: ghcr.io/astral-sh/uv:python3.12-bookworm-slim
+    container_name: google-workspace-mcp
+    restart: unless-stopped
+    env_file: .env
+    environment:
+      WORKSPACE_MCP_CREDENTIALS_DIR: /credentials
+    ports:
+      # Loopback only — never expose Workspace MCP to the LAN.
+      # Bump the host-side port if 8217 collides with something else
+      # (also update WORKSPACE_MCP_PORT + GOOGLE_OAUTH_REDIRECT_URI in .env
+      # and the URL in your .mcp.json).
+      - "127.0.0.1:8217:8217"
+    volumes:
+      # Refresh tokens persist here (chmod 700-equivalent inside the
+      # container). Survives container recreate; lost on `docker compose
+      # down -v`.
+      - ./credentials:/credentials
+    command:
+      - uvx
+      # Pinned: bumping is a deliberate operator decision, not a silent
+      # surprise. Bump in lockstep with retesting the OAuth flow.
+      - --from
+      - workspace-mcp==1.20.4
+      - workspace-mcp
+      # streamable-http (not stdio) is required for OAuth 2.1 PKCE per
+      # upstream README.
+      - --transport
+      - streamable-http
+      # Tier knob — see README §4 for tier choice. `core` = ~16 tools
+      # (Drive + Docs + Sheets + Calendar, the validated default).
+      - --tool-tier
+      - core
+      # Restrict to only the four core services; omits Gmail (which is
+      # in `complete` tier and warrants its own approval shape).
+      - --tools
+      - drive
+      - docs
+      - sheets
+      - calendar
+    healthcheck:
+      # TCP-connect probe — the server returns 401 on `/mcp` until OAuth
+      # completes, which would fail an HTTP healthcheck. TCP-connect just
+      # verifies the listener is bound.
+      test: ["CMD-SHELL", "python -c \"import socket; s=socket.socket(); s.settimeout(2); s.connect(('127.0.0.1',8217)); s.close()\""]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 20s


### PR DESCRIPTION
## Summary

RFC G Phase 5 (\`docs/rfcs/google-workspace-generalization.md\` §4.7) — ships the docker-compose pattern for operators who want their own host-side Claude Code session to have Google Workspace tools.

**Distinct from the agent-side feature** (Phases 2–4 of RFC G). Agents get Workspace via \`switchroom auth google connect <agent>\` (Phase 3 work). This is the operator's pair-design loop equivalent — a different threat model, deliberately a different architecture.

## What's shipped

- \`examples/personal-google-workspace-mcp/compose.yaml\` — workspace-mcp v1.20.4 pinned, OAuth 2.1 PKCE (no client_secret), loopback-only port 8217, TCP-connect healthcheck, \`--tool-tier core\`
- \`examples/personal-google-workspace-mcp/.env.example\` — placeholders for \`GOOGLE_OAUTH_CLIENT_ID\` and \`FASTMCP_SERVER_AUTH_GOOGLE_JWT_SIGNING_KEY\` (with \`openssl rand -hex 32\` hint inline)
- \`examples/personal-google-workspace-mcp/README.md\` — 9-section walkthrough: GCP Console setup (~5min), Testing-vs-Production OAuth posture trade-off, tier choice, maintenance, troubleshooting, security notes
- \`.gitignore\` — adds \`examples/personal-google-workspace-mcp/credentials/\` (refresh tokens land there at runtime; \`.env\` was already covered)

Establishes the \`examples/<artifact>/\` subdirectory pattern (today \`examples/\` ships only top-level YAMLs). Validated end-to-end against the working setup at \`~/.local/share/google-workspace-mcp/\`.

## Test plan

- [x] compose.yaml syntactically valid (\`docker compose config\` passes against the working setup it was lifted from)
- [x] \`.env\` and \`.env.*\` already gitignored at repo root; new credentials/ rule added
- [x] No code changes — purely additive content under \`examples/\`
- [ ] Independent reviewer verdict (will dispatch on push)

🤖 Generated with [Claude Code](https://claude.com/claude-code)