### PR TITLE
feat(cli): RFC G Phase 3a — auth google enable/disable/list (CLI for the per-account ACL)

### DIFF
--- a/src/cli/auth-google.ts
+++ b/src/cli/auth-google.ts
@@ -1,0 +1,261 @@
+/**
+ * `switchroom auth google ...` — RFC G Phase 3a CLI verbs.
+ *
+ * Mirrors the `switchroom auth account ...` shape from `auth-accounts.ts`
+ * exactly (per RFC G §4.5), but indexes per-Google-account rather than
+ * per-Anthropic-account:
+ *
+ *   switchroom auth google enable <account> <agents...>
+ *   switchroom auth google disable <account> <agents...>
+ *   switchroom auth google list                              # accounts × agents matrix
+ *
+ * Phase 3a (this file) intentionally OMITS:
+ *   - account add / remove (need OAuth flow refactor — Phase 3b)
+ *   - share (one-shot enable + add) — Phase 3b
+ *   - connect (wizard alias for first-run UX) — Phase 3b
+ *   - drive connect/disconnect aliasing — Phase 3b
+ *   - apply-time legacy-slot detector wiring — Phase 3b
+ *
+ * The reason for the split: the OAuth flow is currently inlined in
+ * `src/cli/drive.ts:runConnect()` (lines 259–620, narrowly wired to the
+ * Drive-only approval flow). Extracting it cleanly is its own piece of
+ * work, and the load-bearing value of Phase 3 — letting operators
+ * declare which agents share which Google account in YAML — is reachable
+ * with just enable/disable/list. Operators can populate
+ * `google_accounts.<email>.enabled_for[]` by hand or via these verbs;
+ * Phase 3b adds the OAuth-driven `account add` that mints the vault
+ * slot for them.
+ */
+
+import type { Command } from "commander";
+import chalk from "chalk";
+import { readFileSync, writeFileSync } from "node:fs";
+
+import {
+  disableAgentsOnGoogleAccount,
+  enableAgentsOnGoogleAccount,
+  getEnabledAgentsForGoogleAccount,
+  listGoogleAccounts,
+} from "./google-accounts-yaml.js";
+import { withConfigError, getConfig, getConfigPath } from "./helpers.js";
+import type { SwitchroomConfig } from "../config/schema.js";
+
+export function registerAuthGoogleSubcommands(
+  program: Command,
+  authParent: Command,
+): void {
+  const google = authParent
+    .command("google")
+    .description(
+      "Manage Google Workspace accounts shared across agents (RFC G — see docs/rfcs/google-workspace-generalization.md)",
+    );
+
+  registerEnable(google, program);
+  registerDisable(google, program);
+  registerList(google, program);
+}
+
+function registerEnable(googleParent: Command, program: Command): void {
+  googleParent
+    .command("enable <account> <agents...>")
+    .description(
+      "Enable a Google account on one or more agents (appends to switchroom.yaml google_accounts.<account>.enabled_for[]). Mirrors `auth enable` exactly.",
+    )
+    .action(
+      withConfigError(async (account: string, agents: string[]) => {
+        const normalizedAccount = normalizeAccountEmail(account);
+        const config = getConfig(program);
+
+        // Verify all named agents exist in switchroom.yaml. Fail-fast
+        // before touching the YAML.
+        for (const name of agents) {
+          if (!config.agents[name]) {
+            throw new Error(
+              `agent '${name}' is not declared in switchroom.yaml under 'agents:'`,
+            );
+          }
+        }
+
+        const yamlPath = getConfigPath(program);
+        const before = readFileSync(yamlPath, "utf-8");
+        const after = enableAgentsOnGoogleAccount(before, normalizedAccount, agents);
+        const noop = after === before;
+        if (!noop) {
+          writeFileSync(yamlPath, after);
+        }
+
+        const enabledAfter = getEnabledAgentsForGoogleAccount(after, normalizedAccount) ?? [];
+        const newlyEnabled = agents.filter((a) => !getEnabledAgentsBefore(before, normalizedAccount).includes(a));
+
+        console.log();
+        if (noop) {
+          console.log(
+            `No change — ${chalk.bold(normalizedAccount)} already enabled on: ${agents.join(", ")}`,
+          );
+        } else {
+          console.log(
+            `${chalk.green("✓")} Enabled ${chalk.bold(normalizedAccount)} on: ${newlyEnabled.join(", ")}`,
+          );
+        }
+        console.log(
+          `  ${chalk.gray("now enabled on:")} ${enabledAfter.join(", ") || "(none)"}`,
+        );
+        console.log();
+        console.log(
+          `Next: ${chalk.bold(`switchroom agent restart ${newlyEnabled.join(" ") || "<agents>"}`)} so the wrapper picks up the new ACL.`,
+        );
+        console.log();
+      }),
+    );
+}
+
+function registerDisable(googleParent: Command, program: Command): void {
+  googleParent
+    .command("disable <account> <agents...>")
+    .description(
+      "Disable a Google account on one or more agents. Leaves the account in google_accounts: with an empty enabled_for[] (dormant) — does NOT remove the vault slot. Use `auth google account remove` (Phase 3b) for full teardown.",
+    )
+    .action(
+      withConfigError(async (account: string, agents: string[]) => {
+        const normalizedAccount = normalizeAccountEmail(account);
+        const yamlPath = getConfigPath(program);
+        const before = readFileSync(yamlPath, "utf-8");
+        const enabledBefore = getEnabledAgentsBefore(before, normalizedAccount);
+
+        if (enabledBefore.length === 0) {
+          console.log();
+          console.log(
+            chalk.yellow(`Account ${chalk.bold(normalizedAccount)} is not currently enabled on any agent — nothing to do.`),
+          );
+          console.log();
+          return;
+        }
+
+        const after = disableAgentsOnGoogleAccount(before, normalizedAccount, agents);
+        const noop = after === before;
+        if (!noop) {
+          writeFileSync(yamlPath, after);
+        }
+
+        const enabledAfter = getEnabledAgentsForGoogleAccount(after, normalizedAccount) ?? [];
+        const removed = enabledBefore.filter((a) => !enabledAfter.includes(a));
+
+        console.log();
+        if (removed.length === 0) {
+          console.log(
+            `No change — none of ${agents.join(", ")} were enabled on ${chalk.bold(normalizedAccount)}.`,
+          );
+        } else {
+          console.log(
+            `${chalk.green("✓")} Disabled ${chalk.bold(normalizedAccount)} from: ${removed.join(", ")}`,
+          );
+        }
+        if (enabledAfter.length === 0) {
+          console.log(
+            `  ${chalk.gray("account is now")} ${chalk.bold("dormant")} ${chalk.gray("(empty enabled_for[])")}`,
+          );
+          console.log(
+            `  Standing approval-kernel grants under removed agents become dormant (RFC G §4.4).`,
+          );
+        } else {
+          console.log(
+            `  ${chalk.gray("still enabled on:")} ${enabledAfter.join(", ")}`,
+          );
+        }
+        console.log();
+        if (removed.length > 0) {
+          console.log(
+            `Next: ${chalk.bold(`switchroom agent restart ${removed.join(" ")}`)} so the wrapper drops its access.`,
+          );
+          console.log();
+        }
+      }),
+    );
+}
+
+function registerList(googleParent: Command, program: Command): void {
+  googleParent
+    .command("list")
+    .description(
+      "List every Google account configured in switchroom.yaml with its enabled_for[] agents. Matrix view of accounts × agents.",
+    )
+    .option("--json", "Emit raw JSON instead of a table")
+    .action(
+      withConfigError(async (opts: { json?: boolean }) => {
+        const yamlPath = getConfigPath(program);
+        const yaml = readFileSync(yamlPath, "utf-8");
+        const accounts = listGoogleAccounts(yaml);
+
+        if (opts.json) {
+          console.log(JSON.stringify(accounts, null, 2));
+          return;
+        }
+
+        console.log();
+        if (accounts.length === 0) {
+          console.log(
+            chalk.gray("No Google accounts configured."),
+          );
+          console.log(
+            `Add one (Phase 3b): ${chalk.bold("switchroom auth google account add <email>")}`,
+          );
+          console.log(
+            `Or hand-edit: add a ${chalk.bold("google_accounts:")} block to switchroom.yaml.`,
+          );
+          console.log();
+          return;
+        }
+
+        const accountColWidth = Math.max(
+          ...accounts.map((a) => a.account.length),
+          "ACCOUNT".length,
+        );
+        console.log(
+          `${pad("ACCOUNT", accountColWidth)}  AGENTS`,
+        );
+        console.log(
+          `${pad("-".repeat(7), accountColWidth)}  ${"-".repeat(6)}`,
+        );
+        for (const { account, enabled_for } of accounts) {
+          const agentList = enabled_for.length === 0
+            ? chalk.gray("(dormant — empty enabled_for)")
+            : enabled_for.join(", ");
+          console.log(`${pad(account, accountColWidth)}  ${agentList}`);
+        }
+        console.log();
+      }),
+    );
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// helpers
+// ────────────────────────────────────────────────────────────────────────
+
+/**
+ * Normalize an account email to the form used everywhere else in the
+ * pipeline (lowercase + trim) — schema does this at parse time, vault
+ * slot helpers do it on write/read, broker does it on lookup. Doing it
+ * here too means the CLI accepts whatever case the operator types.
+ */
+function normalizeAccountEmail(account: string): string {
+  return account.trim().toLowerCase();
+}
+
+function getEnabledAgentsBefore(yamlText: string, account: string): string[] {
+  return getEnabledAgentsForGoogleAccount(yamlText, account) ?? [];
+}
+
+function pad(s: string, width: number): string {
+  return s.length >= width ? s : s + " ".repeat(width - s.length);
+}
+
+// Re-export for tests.
+export const _testing = {
+  normalizeAccountEmail,
+  getEnabledAgentsBefore,
+};
+
+// Quiet unused-import linting for SwitchroomConfig — used in the
+// withConfigError-wrapped callback's inferred config type but not
+// referenced by name in this file.
+export type _SwitchroomConfigUsed = SwitchroomConfig;

--- a/src/cli/auth-google.ts
+++ b/src/cli/auth-google.ts
@@ -59,12 +59,13 @@ function registerEnable(googleParent: Command, program: Command): void {
   googleParent
     .command("enable <account> <agents...>")
     .description(
-      "Enable a Google account on one or more agents (appends to switchroom.yaml google_accounts.<account>.enabled_for[]). Mirrors `auth enable` exactly.",
+      "Enable a Google account on one or more agents (appends to switchroom.yaml google_accounts.<account>.enabled_for[]). Use `all` to enable on every declared agent. Mirrors `auth enable` exactly.",
     )
     .action(
       withConfigError(async (account: string, agents: string[]) => {
-        const normalizedAccount = normalizeAccountEmail(account);
+        const normalizedAccount = validateAndNormalizeAccountEmail(account);
         const config = getConfig(program);
+        agents = expandAllAgents(agents, config);
 
         // Verify all named agents exist in switchroom.yaml. Fail-fast
         // before touching the YAML.
@@ -101,10 +102,15 @@ function registerEnable(googleParent: Command, program: Command): void {
           `  ${chalk.gray("now enabled on:")} ${enabledAfter.join(", ") || "(none)"}`,
         );
         console.log();
-        console.log(
-          `Next: ${chalk.bold(`switchroom agent restart ${newlyEnabled.join(" ") || "<agents>"}`)} so the wrapper picks up the new ACL.`,
-        );
-        console.log();
+        // Restart hint only when something actually changed — pure
+        // no-op enables don't require a restart, and printing a
+        // restart command with no agents to restart is misleading.
+        if (newlyEnabled.length > 0) {
+          console.log(
+            `Next: ${chalk.bold(`switchroom agent restart ${newlyEnabled.join(" ")}`)} so the wrapper picks up the new ACL.`,
+          );
+          console.log();
+        }
       }),
     );
 }
@@ -113,11 +119,13 @@ function registerDisable(googleParent: Command, program: Command): void {
   googleParent
     .command("disable <account> <agents...>")
     .description(
-      "Disable a Google account on one or more agents. Leaves the account in google_accounts: with an empty enabled_for[] (dormant) — does NOT remove the vault slot. Use `auth google account remove` (Phase 3b) for full teardown.",
+      "Disable a Google account on one or more agents. Use `all` to disable on every declared agent. Leaves the account in google_accounts: with an empty enabled_for[] (dormant) — does NOT remove the vault slot. Use `auth google account remove` (Phase 3b) for full teardown.",
     )
     .action(
       withConfigError(async (account: string, agents: string[]) => {
-        const normalizedAccount = normalizeAccountEmail(account);
+        const normalizedAccount = validateAndNormalizeAccountEmail(account);
+        const config = getConfig(program);
+        agents = expandAllAgents(agents, config);
         const yamlPath = getConfigPath(program);
         const before = readFileSync(yamlPath, "utf-8");
         const enabledBefore = getEnabledAgentsBefore(before, normalizedAccount);
@@ -236,13 +244,48 @@ function registerList(googleParent: Command, program: Command): void {
  * pipeline (lowercase + trim) — schema does this at parse time, vault
  * slot helpers do it on write/read, broker does it on lookup. Doing it
  * here too means the CLI accepts whatever case the operator types.
+ *
+ * Also enforces the same email-shape regex the schema uses, so
+ * malformed input fails at the CLI layer with an actionable error
+ * rather than getting written to YAML and rejected on the next
+ * config-load (would force operators to hand-edit the YAML to
+ * recover).
  */
-function normalizeAccountEmail(account: string): string {
-  return account.trim().toLowerCase();
+function validateAndNormalizeAccountEmail(account: string): string {
+  const normalized = account.trim().toLowerCase();
+  // Same regex as src/config/schema.ts:google_accounts key validator
+  // — must contain @ + dot, must NOT contain `:` (which would break
+  // the broker's slot-key parser).
+  if (!/^[^@\s:]+@[^@\s:]+\.[^@\s:]+$/.test(normalized)) {
+    throw new Error(
+      `'${account}' is not a valid Google account email. Expected format like 'alice@example.com' (colons not allowed).`,
+    );
+  }
+  return normalized;
 }
 
 function getEnabledAgentsBefore(yamlText: string, account: string): string[] {
   return getEnabledAgentsForGoogleAccount(yamlText, account) ?? [];
+}
+
+/**
+ * Expand the literal token `all` to every declared agent. Mirrors
+ * `auth-accounts.ts:expandAllAgents` exactly — operators reasonably
+ * try `auth google enable alice@example.com all`, and treating that as
+ * literal-agent-named-`all` would be a confusing failure.
+ *
+ * Pass-through if `all` isn't in the list. Multiple `all`s are
+ * harmless (deduplicated by the YAML mutator's idempotency).
+ */
+function expandAllAgents(agents: string[], config: SwitchroomConfig): string[] {
+  if (!agents.includes("all")) return agents;
+  const allNames = Object.keys(config.agents);
+  if (allNames.length === 0) {
+    throw new Error(
+      "switchroom.yaml has no agents declared — `all` matches nothing.",
+    );
+  }
+  return allNames;
 }
 
 function pad(s: string, width: number): string {
@@ -251,11 +294,8 @@ function pad(s: string, width: number): string {
 
 // Re-export for tests.
 export const _testing = {
-  normalizeAccountEmail,
+  validateAndNormalizeAccountEmail,
   getEnabledAgentsBefore,
+  expandAllAgents,
 };
 
-// Quiet unused-import linting for SwitchroomConfig — used in the
-// withConfigError-wrapped callback's inferred config type but not
-// referenced by name in this file.
-export type _SwitchroomConfigUsed = SwitchroomConfig;

--- a/src/cli/auth.ts
+++ b/src/cli/auth.ts
@@ -24,6 +24,7 @@ import {
 import { getAgentStatus, restartAgent } from "../agents/lifecycle.js";
 import { withConfigError, getConfig } from "./helpers.js";
 import { registerAuthAccountSubcommands } from "./auth-accounts.js";
+import { registerAuthGoogleSubcommands } from "./auth-google.js";
 
 function printAuthTable(
   headers: string[],
@@ -293,6 +294,13 @@ export function registerAuthCommand(program: Command): void {
   // `auth account ...` subcommand tree exists before the per-agent
   // legacy verbs hang off the same parent.
   registerAuthAccountSubcommands(program, auth);
+
+  // RFC G Phase 3a — `auth google enable|disable|list` for Google
+  // Workspace per-account ACL management. See
+  // docs/rfcs/google-workspace-generalization.md §4.5. Phase 3b adds
+  // `account add`, `account remove`, `share`, `connect` (wizard alias),
+  // and the apply-time legacy-slot detector.
+  registerAuthGoogleSubcommands(program, auth);
 
   // switchroom auth login <name>
   auth

--- a/src/cli/google-accounts-yaml.test.ts
+++ b/src/cli/google-accounts-yaml.test.ts
@@ -1,0 +1,199 @@
+/**
+ * Tests for google-accounts-yaml — pure string-in / string-out helpers
+ * for the top-level `google_accounts:` block (RFC G §4.4).
+ *
+ * Mirrors the test pattern in `tests/auth-accounts-yaml.test.ts`.
+ */
+
+import { describe, expect, it } from "bun:test";
+
+import {
+  disableAgentsOnGoogleAccount,
+  enableAgentsOnGoogleAccount,
+  getEnabledAgentsForGoogleAccount,
+  listGoogleAccounts,
+  removeGoogleAccountEntry,
+} from "./google-accounts-yaml.js";
+
+const baseYaml = `# top of file
+switchroom:
+  version: 1
+telegram:
+  bot_token: "x"
+  forum_chat_id: "1"
+agents:
+  klanker:
+    bot_token: "vault:k-bot"
+    forum_chat_id: 1
+    topic_name: klanker
+`;
+
+const yamlWithOneAccount = `${baseYaml}google_accounts:
+  alice@example.com:
+    enabled_for:
+      - klanker
+`;
+
+describe("enableAgentsOnGoogleAccount", () => {
+  it("creates the entry when google_accounts is missing entirely", () => {
+    const out = enableAgentsOnGoogleAccount(baseYaml, "alice@example.com", ["klanker"]);
+    expect(getEnabledAgentsForGoogleAccount(out, "alice@example.com")).toEqual(["klanker"]);
+  });
+
+  it("appends to existing enabled_for list", () => {
+    const out = enableAgentsOnGoogleAccount(yamlWithOneAccount, "alice@example.com", ["gymbro"]);
+    expect(getEnabledAgentsForGoogleAccount(out, "alice@example.com")).toEqual([
+      "klanker",
+      "gymbro",
+    ]);
+  });
+
+  it("idempotent — re-adding an existing agent is a no-op (returns input verbatim)", () => {
+    const out = enableAgentsOnGoogleAccount(yamlWithOneAccount, "alice@example.com", ["klanker"]);
+    expect(out).toBe(yamlWithOneAccount);
+  });
+
+  it("partial overlap — only adds the new agents, skips existing", () => {
+    const out = enableAgentsOnGoogleAccount(
+      yamlWithOneAccount,
+      "alice@example.com",
+      ["klanker", "gymbro", "coderev"],
+    );
+    expect(getEnabledAgentsForGoogleAccount(out, "alice@example.com")).toEqual([
+      "klanker",
+      "gymbro",
+      "coderev",
+    ]);
+  });
+
+  it("creates a second account alongside an existing one", () => {
+    const out = enableAgentsOnGoogleAccount(
+      yamlWithOneAccount,
+      "work@bigcorp.com",
+      ["coderev"],
+    );
+    expect(getEnabledAgentsForGoogleAccount(out, "alice@example.com")).toEqual(["klanker"]);
+    expect(getEnabledAgentsForGoogleAccount(out, "work@bigcorp.com")).toEqual(["coderev"]);
+  });
+
+  it("preserves a top-of-file comment", () => {
+    const out = enableAgentsOnGoogleAccount(baseYaml, "alice@example.com", ["klanker"]);
+    expect(out.startsWith("# top of file")).toBe(true);
+  });
+});
+
+describe("disableAgentsOnGoogleAccount", () => {
+  it("removes a single agent from enabled_for", () => {
+    const yaml = enableAgentsOnGoogleAccount(yamlWithOneAccount, "alice@example.com", [
+      "gymbro",
+    ]);
+    const out = disableAgentsOnGoogleAccount(yaml, "alice@example.com", ["klanker"]);
+    expect(getEnabledAgentsForGoogleAccount(out, "alice@example.com")).toEqual(["gymbro"]);
+  });
+
+  it("removes multiple agents in one call", () => {
+    let yaml = enableAgentsOnGoogleAccount(baseYaml, "alice@example.com", [
+      "klanker",
+      "gymbro",
+      "coderev",
+    ]);
+    yaml = disableAgentsOnGoogleAccount(yaml, "alice@example.com", ["klanker", "coderev"]);
+    expect(getEnabledAgentsForGoogleAccount(yaml, "alice@example.com")).toEqual(["gymbro"]);
+  });
+
+  it("leaves enabled_for as an empty array when last agent is removed (dormant state)", () => {
+    const out = disableAgentsOnGoogleAccount(yamlWithOneAccount, "alice@example.com", ["klanker"]);
+    expect(getEnabledAgentsForGoogleAccount(out, "alice@example.com")).toEqual([]);
+  });
+
+  it("no-op when account is not in google_accounts at all", () => {
+    expect(disableAgentsOnGoogleAccount(baseYaml, "alice@example.com", ["klanker"])).toBe(baseYaml);
+  });
+
+  it("no-op when none of the named agents are enabled", () => {
+    expect(disableAgentsOnGoogleAccount(yamlWithOneAccount, "alice@example.com", ["nope"])).toBe(
+      yamlWithOneAccount,
+    );
+  });
+});
+
+describe("getEnabledAgentsForGoogleAccount", () => {
+  it("returns null for an account not in YAML at all (vs empty array for dormant)", () => {
+    expect(getEnabledAgentsForGoogleAccount(baseYaml, "alice@example.com")).toBe(null);
+  });
+
+  it("returns [] for an account with empty enabled_for (dormant)", () => {
+    const yaml = disableAgentsOnGoogleAccount(yamlWithOneAccount, "alice@example.com", [
+      "klanker",
+    ]);
+    expect(getEnabledAgentsForGoogleAccount(yaml, "alice@example.com")).toEqual([]);
+  });
+
+  it("returns the agents in YAML-source order", () => {
+    const yaml = enableAgentsOnGoogleAccount(yamlWithOneAccount, "alice@example.com", [
+      "gymbro",
+      "coderev",
+    ]);
+    expect(getEnabledAgentsForGoogleAccount(yaml, "alice@example.com")).toEqual([
+      "klanker",
+      "gymbro",
+      "coderev",
+    ]);
+  });
+});
+
+describe("listGoogleAccounts", () => {
+  it("returns [] when google_accounts block is absent", () => {
+    expect(listGoogleAccounts(baseYaml)).toEqual([]);
+  });
+
+  it("returns one entry when one account is configured", () => {
+    expect(listGoogleAccounts(yamlWithOneAccount)).toEqual([
+      { account: "alice@example.com", enabled_for: ["klanker"] },
+    ]);
+  });
+
+  it("returns entries in YAML-source order", () => {
+    let yaml = enableAgentsOnGoogleAccount(yamlWithOneAccount, "work@bigcorp.com", ["coderev"]);
+    yaml = enableAgentsOnGoogleAccount(yaml, "personal@gmail.com", ["gymbro"]);
+    const list = listGoogleAccounts(yaml);
+    expect(list.map((e) => e.account)).toEqual([
+      "alice@example.com",
+      "work@bigcorp.com",
+      "personal@gmail.com",
+    ]);
+  });
+
+  it("includes dormant accounts (empty enabled_for)", () => {
+    const yaml = disableAgentsOnGoogleAccount(yamlWithOneAccount, "alice@example.com", [
+      "klanker",
+    ]);
+    expect(listGoogleAccounts(yaml)).toEqual([
+      { account: "alice@example.com", enabled_for: [] },
+    ]);
+  });
+});
+
+describe("removeGoogleAccountEntry", () => {
+  it("drops the entry entirely", () => {
+    const out = removeGoogleAccountEntry(yamlWithOneAccount, "alice@example.com");
+    expect(getEnabledAgentsForGoogleAccount(out, "alice@example.com")).toBe(null);
+  });
+
+  it("prunes the empty parent map when removing the last account", () => {
+    const out = removeGoogleAccountEntry(yamlWithOneAccount, "alice@example.com");
+    expect(out).not.toContain("google_accounts");
+  });
+
+  it("leaves the parent map intact when other accounts remain", () => {
+    const yaml = enableAgentsOnGoogleAccount(yamlWithOneAccount, "work@bigcorp.com", ["coderev"]);
+    const out = removeGoogleAccountEntry(yaml, "alice@example.com");
+    expect(listGoogleAccounts(out)).toEqual([
+      { account: "work@bigcorp.com", enabled_for: ["coderev"] },
+    ]);
+  });
+
+  it("no-op when account is not present (returns input verbatim)", () => {
+    expect(removeGoogleAccountEntry(baseYaml, "alice@example.com")).toBe(baseYaml);
+  });
+});

--- a/src/cli/google-accounts-yaml.ts
+++ b/src/cli/google-accounts-yaml.ts
@@ -1,0 +1,194 @@
+/**
+ * YAML editor for `switchroom auth google enable/disable`.
+ *
+ * Edits the **top-level** `google_accounts.<email>.enabled_for: [agents...]`
+ * map while preserving comments and formatting elsewhere in the file.
+ * Mirrors the pattern in `auth-accounts-yaml.ts` — pure module, string-in /
+ * string-out — but with a different shape: Anthropic auth lives under
+ * `agents.<name>.auth.accounts: []` (per-agent preference list) while
+ * Google Workspace lives under `google_accounts.<email>.enabled_for: []`
+ * (per-account allowlist of agents).
+ *
+ * The shape difference is load-bearing per RFC G §4.4: the per-account
+ * ACL is what lets two agents share one Google OAuth refresh token without
+ * granting cross-agent access to the slot. The auth-accounts-yaml helpers
+ * are not reusable here because the indexing flips (account → agents,
+ * not agent → accounts).
+ */
+
+import {
+  parseDocument,
+  type Document,
+  isMap,
+  isSeq,
+  type YAMLMap,
+  type YAMLSeq,
+} from "yaml";
+
+/**
+ * Append agents to `google_accounts.<account>.enabled_for`. Idempotent —
+ * agents already present are left in place; the relative order of existing
+ * entries is preserved. Creates the intermediate maps + sequence if absent.
+ *
+ * Pass-through if no agents would be added (returns the original YAML
+ * string verbatim, not a re-serialised version, so byte-equality checks
+ * for "no change" still work).
+ *
+ * Note: this helper does NOT validate that the agent slugs exist in the
+ * config. The CLI verb is responsible for that check (so it can give a
+ * better error than "YAML write failed").
+ */
+export function enableAgentsOnGoogleAccount(
+  yamlText: string,
+  account: string,
+  agentsToEnable: string[],
+): string {
+  const doc = parseDocument(yamlText);
+  ensureGoogleAccountEntry(doc, account);
+  const existing = doc.getIn(["google_accounts", account, "enabled_for"]);
+  const currentAgents = readEnabledFor(existing);
+  const additions = agentsToEnable.filter((a) => !currentAgents.includes(a));
+  if (additions.length === 0) return yamlText;
+  if (isSeq(existing)) {
+    const seq = existing as YAMLSeq;
+    for (const a of additions) seq.add(a);
+  } else {
+    doc.setIn(
+      ["google_accounts", account, "enabled_for"],
+      [...currentAgents, ...additions],
+    );
+  }
+  return String(doc);
+}
+
+/**
+ * Remove agents from `google_accounts.<account>.enabled_for`. No-op if
+ * none of the named agents are present. When `enabled_for` becomes empty,
+ * it stays as an empty array (NOT pruned) — empty-but-present is the
+ * RFC G §4.4 "dormant account" state, and dropping the key would be a
+ * silent migration to "account not configured at all" which has different
+ * semantics. Operators wanting to fully remove the account use
+ * `auth google account remove <account>`.
+ */
+export function disableAgentsOnGoogleAccount(
+  yamlText: string,
+  account: string,
+  agentsToDisable: string[],
+): string {
+  const doc = parseDocument(yamlText);
+  if (!hasGoogleAccountEntry(doc, account)) return yamlText;
+  const existing = doc.getIn(["google_accounts", account, "enabled_for"]);
+  if (!isSeq(existing)) return yamlText;
+  const seq = existing as YAMLSeq;
+  const beforeLen = seq.items.length;
+  for (let i = seq.items.length - 1; i >= 0; i--) {
+    const item = seq.items[i];
+    const v = (item as { value?: unknown })?.value ?? item;
+    if (typeof v === "string" && agentsToDisable.includes(v)) {
+      seq.delete(i);
+    }
+  }
+  if (seq.items.length === beforeLen) return yamlText;
+  return String(doc);
+}
+
+/**
+ * Read `google_accounts.<account>.enabled_for` without mutating. Returns
+ * `null` if the account isn't in the YAML at all (distinguished from `[]`
+ * which means dormant per RFC G §4.4). Used by the `list` verb and the
+ * remove-refusal logic.
+ */
+export function getEnabledAgentsForGoogleAccount(
+  yamlText: string,
+  account: string,
+): string[] | null {
+  const doc = parseDocument(yamlText);
+  if (!hasGoogleAccountEntry(doc, account)) return null;
+  const existing = doc.getIn(["google_accounts", account, "enabled_for"]);
+  return readEnabledFor(existing);
+}
+
+/**
+ * List every Google account configured in the YAML, with each account's
+ * `enabled_for` agents. Used by `auth google list` (matrix view) and by
+ * the apply preflight when warning operators about legacy slots.
+ *
+ * Returns entries in YAML-source order (not alphabetical) so the CLI
+ * output matches what the operator sees in the file.
+ */
+export function listGoogleAccounts(
+  yamlText: string,
+): Array<{ account: string; enabled_for: string[] }> {
+  const doc = parseDocument(yamlText);
+  const accounts = doc.get("google_accounts");
+  if (!isMap(accounts)) return [];
+  const out: Array<{ account: string; enabled_for: string[] }> = [];
+  for (const item of (accounts as YAMLMap).items) {
+    const account = String((item.key as { value?: unknown }).value ?? item.key);
+    const enabled = doc.getIn([
+      "google_accounts",
+      account,
+      "enabled_for",
+    ]);
+    out.push({ account, enabled_for: readEnabledFor(enabled) });
+  }
+  return out;
+}
+
+/**
+ * Remove the entire `google_accounts.<account>` entry from the YAML.
+ * Used by `auth google account remove`. The CLI verb is responsible for
+ * checking that `enabled_for` is empty first (so we don't strand any
+ * agents whose tools depended on the account).
+ *
+ * If the account isn't present, returns the original YAML string
+ * verbatim. If removing the last entry leaves `google_accounts: {}`,
+ * the empty parent map is also pruned.
+ */
+export function removeGoogleAccountEntry(
+  yamlText: string,
+  account: string,
+): string {
+  const doc = parseDocument(yamlText);
+  if (!hasGoogleAccountEntry(doc, account)) return yamlText;
+  doc.deleteIn(["google_accounts", account]);
+  pruneEmptyMap(doc, ["google_accounts"]);
+  return String(doc);
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// internals
+// ────────────────────────────────────────────────────────────────────────
+
+function readEnabledFor(node: unknown): string[] {
+  if (!isSeq(node)) return [];
+  const seq = node as YAMLSeq;
+  return seq.items
+    .map((item) => (item as { value?: unknown }).value ?? item)
+    .filter((v): v is string => typeof v === "string");
+}
+
+function ensureGoogleAccountEntry(doc: Document, account: string): void {
+  // Unlike auth-accounts-yaml's ensureAgent (which throws if the agent
+  // isn't declared), `auth google enable` may legitimately be the first
+  // thing that creates the google_accounts entry — operators run
+  // `auth google account add` first (writes vault slot), then `enable`
+  // (writes YAML). So this helper just ensures the entry exists,
+  // creating it if needed.
+  if (!hasGoogleAccountEntry(doc, account)) {
+    doc.setIn(["google_accounts", account, "enabled_for"], []);
+  }
+}
+
+function hasGoogleAccountEntry(doc: Document, account: string): boolean {
+  const accounts = doc.get("google_accounts");
+  if (!isMap(accounts)) return false;
+  return (accounts as YAMLMap).has(account);
+}
+
+function pruneEmptyMap(doc: Document, path: string[]): void {
+  const node = doc.getIn(path);
+  if (isMap(node) && (node as YAMLMap).items.length === 0) {
+    doc.deleteIn(path);
+  }
+}


### PR DESCRIPTION
## Summary

Phase 3a of RFC G — adds the load-bearing user-facing piece: operators can now declare which agents share which Google account in switchroom.yaml without hand-editing. Mirrors \`switchroom auth account ...\` shape exactly per RFC G §4.5 + share-auth-across-the-fleet.md decision #6.

**Scope split** (honest reduction from RFC's ~75min — actual work is more like 3-4h done faithfully):

**Phase 3a (this PR):**
- \`auth google enable <account> <agents...>\` (plural)
- \`auth google disable <account> <agents...>\` (plural)
- \`auth google list\` (matrix view + \`--json\`)
- Pure YAML mutator helpers (\`google-accounts-yaml.ts\`)

**Phase 3b (next PR):**
- \`auth google account add\` (needs OAuth flow refactored out of \`src/cli/drive.ts:runConnect\`)
- \`auth google account remove\` (needs OAuth revoke)
- \`auth google share\` (one-shot add+enable)
- \`auth google connect <agent>\` wizard alias
- \`drive connect/disconnect\` aliasing
- Apply-time legacy-slot detector wiring

The split keeps each PR reviewable. Phase 3a is enough for operators to populate \`google_accounts\` + manage ACLs against a slot they wrote by hand or via the existing \`switchroom drive connect\` flow (which keeps working unchanged).

## What's new

- \`src/cli/google-accounts-yaml.ts\` — pure helpers parallel to \`auth-accounts-yaml.ts\` but indexed per-account (account → agents) rather than per-agent (agent → accounts). The shape flip is load-bearing per RFC G §4.4 — the per-account ACL is exactly what lets two agents share one OAuth refresh token.
- \`src/cli/google-accounts-yaml.test.ts\` — 22 tests (enable/disable/list/remove + idempotency + dormant-state preservation + comment preservation)
- \`src/cli/auth-google.ts\` — the three CLI verbs
- Wired in \`src/cli/auth.ts\` alongside \`auth account\` subcommands

## Smoke test (run end-to-end against a real config)

```
$ switchroom auth google list
No Google accounts configured.

$ switchroom auth google enable alice@example.com klanker gymbro
✓ Enabled alice@example.com on: klanker, gymbro
  now enabled on: klanker, gymbro
Next: switchroom agent restart klanker gymbro so the wrapper picks up the new ACL.

$ switchroom auth google list
ACCOUNT            AGENTS
-------            ------
alice@example.com  klanker, gymbro

$ switchroom auth google disable alice@example.com klanker
✓ Disabled alice@example.com from: klanker
  still enabled on: gymbro
```

YAML output verified to be the canonical RFC G §4.4 shape:
\`\`\`yaml
google_accounts:
  alice@example.com:
    enabled_for:
      - gymbro
\`\`\`

## Test plan

- [x] \`bun test src/cli/google-accounts-yaml.test.ts\` — 22/22 pass
- [x] \`tsc --noEmit\` — clean
- [x] CLI smoke-tested end-to-end against a temp config: enable → list → disable → final YAML inspection — all correct
- [x] Pre-existing test failures unchanged (verified)
- [ ] Independent reviewer verdict (will dispatch after PR open)

🤖 Generated with [Claude Code](https://claude.com/claude-code)