### PR TITLE
feat(setup): RFC G Phase 4 — inline wizard prompt offering Google Workspace connect

### DIFF
--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -139,7 +139,10 @@ export function registerSetupCommand(program: Command): void {
         // ── Step 10: Agent onboarding guidance ───────────────────
         await stepOnboardingGuidance(config, nonInteractive);
 
-        // ── Step 11: Verification ────────────────────────────────
+        // ── Step 11: Optional Google Workspace connection (RFC G §4.6) ─
+        await stepGoogleWorkspace(config, nonInteractive);
+
+        // ── Step 12: Verification ────────────────────────────────
         await stepVerification(config, nonInteractive);
 
         await captureEvent("setup_completed", {
@@ -1077,13 +1080,103 @@ async function stepOnboardingGuidance(
   }
 }
 
-// ─── Step 11: Verification ───────────────────────────────────────────────────
+// ─── Step 11: Optional Google Workspace connection (RFC G §4.6) ────────────
+
+/**
+ * Inline opt-in for Google Workspace connect, offered after the first
+ * agent + bot are working. Default Y (advertised, not opt-out). Per
+ * RFC G §4.6 + the principles.md "defaults test" — opinionated default,
+ * easy decline.
+ *
+ * Phase 4 (this step) prompts and surfaces the connect command. Phase
+ * 3b will swap the surfaced command from `switchroom drive connect
+ * <agent>` to `switchroom auth google connect <agent>` (the wizard
+ * alias added in 3b that does account add + enable in one shot).
+ *
+ * This step never runs the connect flow inline — connect needs an
+ * OAuth tap that breaks the linear setup script. Instead it prints
+ * the next-step command and continues. Operators can run it
+ * immediately after setup completes if they tapped Y, or any time
+ * later if they tapped N.
+ */
+async function stepGoogleWorkspace(
+  config: SwitchroomConfig,
+  nonInteractive: boolean,
+): Promise<void> {
+  stepHeader(11, "Optional: Google Workspace", STEP_ACTIVE);
+
+  if (nonInteractive) {
+    console.log(chalk.gray("  Skipping in non-interactive mode."));
+    return;
+  }
+
+  const agentNames = Object.keys(config.agents);
+  if (agentNames.length === 0) {
+    console.log(chalk.gray("  Skipping (no agents to connect)."));
+    return;
+  }
+  const firstName = agentNames[0];
+
+  console.log(
+    chalk.gray(
+      `  Your agent (${chalk.cyan(firstName)}) can read and (with approval)`,
+    ),
+  );
+  console.log(
+    chalk.gray(
+      "  write to your Google Drive, Docs, Sheets, and Calendar.",
+    ),
+  );
+  console.log(
+    chalk.gray(
+      "  Tools appear as approval-gated requests in Telegram.",
+    ),
+  );
+
+  const wantConnect = await askYesNo(
+    `\n  ${chalk.bold("Connect Google Workspace now?")}`,
+    true,
+  );
+
+  // The verb that completes the flow. Today (pre-Phase-3b) it's the
+  // shipped `drive connect`. Phase 3b will introduce
+  // `auth google connect <agent>` as the wizard alias and swap this
+  // string. Both end up at the same OAuth flow.
+  const connectCmd = `switchroom drive connect ${firstName}`;
+
+  if (wantConnect) {
+    console.log(
+      chalk.green(`  ${STEP_DONE} Ready to connect`),
+    );
+    console.log();
+    console.log(
+      chalk.gray("  After setup completes, run:"),
+    );
+    console.log(
+      chalk.cyan(`    ${connectCmd}`),
+    );
+    console.log(
+      chalk.gray(
+        "  to start the OAuth flow (device-code on headless hosts, browser otherwise).",
+      ),
+    );
+  } else {
+    console.log(
+      chalk.gray(`  ${STEP_DONE} Skipped — connect later with:`),
+    );
+    console.log(
+      chalk.cyan(`    ${connectCmd}`),
+    );
+  }
+}
+
+// ─── Step 12: Verification ───────────────────────────────────────────────────
 
 async function stepVerification(
   config: SwitchroomConfig,
   nonInteractive: boolean,
 ): Promise<void> {
-  stepHeader(11, "Verification", STEP_ACTIVE);
+  stepHeader(12, "Verification", STEP_ACTIVE);
 
   const agentNames = Object.keys(config.agents);
   const firstName = agentNames[0];


### PR DESCRIPTION
## Summary

RFC G Phase 4 (\`docs/rfcs/google-workspace-generalization.md\` §4.6) — inserts an optional Step 11 \"Google Workspace\" in the \`switchroom setup\` wizard, between agent onboarding (Step 10) and verification (renumbered 11 → 12).

## What ships

- New \`stepGoogleWorkspace()\` function in \`src/cli/setup.ts\`
- Default Y per RFC G §4.6 (advertised, not opt-out)
- Skipped silently in \`--non-interactive\` mode
- Skipped if no agents declared
- Surfaces the connect command as cyan copy-paste, never runs OAuth inline (operator tap would break the linear wizard script — same pattern as the existing \`switchroom drive connect\` command's sibling status)
- Verification step renumbered 11 → 12 in both call site and \`stepHeader()\` arg

The surfaced command today is \`switchroom drive connect <agent>\` (shipped v0.6.0). Phase 3b will swap to \`switchroom auth google connect <agent>\` (the wizard alias added there).

## Pattern parity

Mirrors the existing optional-step pattern from Step 8 (vault auto-unlock) and Step 9 (dangerous mode) — same askYesNo + skip-on-non-interactive shape.

## Test plan

- [x] \`tsc --noEmit\` clean
- [x] Step numbers verified — 11 = new Workspace, 12 = Verification
- [x] No regressions in adjacent steps (didn't touch their bodies)
- [ ] Independent reviewer verdict (will dispatch after PR open)

No new unit tests — all 11 other wizard steps follow the same convention (focused unit tests on helpers, not on print-and-prompt steps). This micro-step is two prompt branches calling stepHeader + console.log + askYesNo; the behavior is fully captured by the visible step text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)