### PR TITLE
feat(drive): RFC E Phase 1d — reconciler missing→present recovery detector

### DIFF
--- a/src/drive/reconciler.test.ts
+++ b/src/drive/reconciler.test.ts
@@ -3,7 +3,13 @@
  */
 
 import { describe, expect, it } from "bun:test";
-import { reconcile, isNewer, hashMetadata } from "./reconciler.js";
+import {
+  detectRecovery,
+  hashMetadata,
+  isNewer,
+  reconcile,
+  type ReconcilerVerdict,
+} from "./reconciler.js";
 
 describe("reconcile — three-state detection", () => {
   it("404 → missing(not_found)", () => {
@@ -122,5 +128,109 @@ describe("hashMetadata", () => {
     const a = await hashMetadata({ mimeType: "x", modifiedTime: "t", size: 1 });
     const b = await hashMetadata({ mimeType: "x", modifiedTime: "t", size: 2 });
     expect(a).not.toBe(b);
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────
+// RFC E §4.4 — missing→present recovery detection
+// ────────────────────────────────────────────────────────────────────────
+
+const sampleMeta = {
+  id: "1abc",
+  name: "Q3 Strategy Notes",
+  modifiedTime: "2026-01-01T00:00:00Z",
+};
+
+describe("detectRecovery", () => {
+  it("returns false when there's no previous verdict (first observation)", () => {
+    const current: ReconcilerVerdict = { state: "present", meta: sampleMeta };
+    expect(detectRecovery(null, current)).toEqual({ recovered: false });
+  });
+
+  it("returns false on present → present (steady state)", () => {
+    const prev: ReconcilerVerdict = { state: "present", meta: sampleMeta };
+    const current: ReconcilerVerdict = { state: "present", meta: sampleMeta };
+    expect(detectRecovery(prev, current)).toEqual({ recovered: false });
+  });
+
+  it("returns false on present → missing (loss event, NOT recovery)", () => {
+    const prev: ReconcilerVerdict = { state: "present", meta: sampleMeta };
+    const current: ReconcilerVerdict = { state: "missing", reason: "trashed" };
+    expect(detectRecovery(prev, current)).toEqual({ recovered: false });
+  });
+
+  it("returns false on present → conflict (drift, covered by staleness digest)", () => {
+    const prev: ReconcilerVerdict = { state: "present", meta: sampleMeta };
+    const current: ReconcilerVerdict = {
+      state: "conflict",
+      meta: sampleMeta,
+      reasons: ["modified_time_newer"],
+    };
+    expect(detectRecovery(prev, current)).toEqual({ recovered: false });
+  });
+
+  it("returns false on conflict → present (drift resolved, not a recovery)", () => {
+    const prev: ReconcilerVerdict = {
+      state: "conflict",
+      meta: sampleMeta,
+      reasons: ["modified_time_newer"],
+    };
+    const current: ReconcilerVerdict = { state: "present", meta: sampleMeta };
+    expect(detectRecovery(prev, current)).toEqual({ recovered: false });
+  });
+
+  it("returns false on missing → missing (still gone)", () => {
+    const prev: ReconcilerVerdict = { state: "missing", reason: "trashed" };
+    const current: ReconcilerVerdict = { state: "missing", reason: "trashed" };
+    expect(detectRecovery(prev, current)).toEqual({ recovered: false });
+  });
+
+  it("fires recovery on missing(trashed) → present (operator un-trashed)", () => {
+    const prev: ReconcilerVerdict = { state: "missing", reason: "trashed" };
+    const current: ReconcilerVerdict = { state: "present", meta: sampleMeta };
+    const r = detectRecovery(prev, current);
+    expect(r.recovered).toBe(true);
+    if (r.recovered) {
+      expect(r.fromReason).toBe("trashed");
+      expect(r.toState).toBe("present");
+      expect(r.meta).toBe(sampleMeta);
+    }
+  });
+
+  it("fires recovery on missing(not_found) → present (re-uploaded with same id is unusual but possible)", () => {
+    const prev: ReconcilerVerdict = { state: "missing", reason: "not_found" };
+    const current: ReconcilerVerdict = { state: "present", meta: sampleMeta };
+    const r = detectRecovery(prev, current);
+    expect(r.recovered).toBe(true);
+    if (r.recovered) {
+      expect(r.fromReason).toBe("not_found");
+      expect(r.toState).toBe("present");
+    }
+  });
+
+  it("fires recovery on missing → conflict (restored but evolved while gone)", () => {
+    const prev: ReconcilerVerdict = { state: "missing", reason: "trashed" };
+    const current: ReconcilerVerdict = {
+      state: "conflict",
+      meta: sampleMeta,
+      reasons: ["modified_time_newer", "content_hash_changed"],
+    };
+    const r = detectRecovery(prev, current);
+    expect(r.recovered).toBe(true);
+    if (r.recovered) {
+      expect(r.fromReason).toBe("trashed");
+      expect(r.toState).toBe("conflict");
+      expect(r.meta).toBe(sampleMeta);
+    }
+  });
+
+  it("preserves the fromReason across the recovery (not_found vs trashed)", () => {
+    const prev1: ReconcilerVerdict = { state: "missing", reason: "trashed" };
+    const prev2: ReconcilerVerdict = { state: "missing", reason: "not_found" };
+    const current: ReconcilerVerdict = { state: "present", meta: sampleMeta };
+    const r1 = detectRecovery(prev1, current);
+    const r2 = detectRecovery(prev2, current);
+    expect(r1.recovered && r1.fromReason).toBe("trashed");
+    expect(r2.recovered && r2.fromReason).toBe("not_found");
   });
 });

--- a/src/drive/reconciler.ts
+++ b/src/drive/reconciler.ts
@@ -107,6 +107,57 @@ export function isNewer(a: string, b: string): boolean {
   return ta > tb;
 }
 
+// ────────────────────────────────────────────────────────────────────────
+// RFC E §4.4 — missing→present recovery detection
+// ────────────────────────────────────────────────────────────────────────
+
+/**
+ * The shape of "recovery" the user-facing JTBD cares about: a doc that
+ * was missing (deleted/trashed) on the previous reconciler check is
+ * back. Conflict↔present transitions are NOT recoveries — those are
+ * normal evolution, not the "I un-trashed it" signal that warrants a
+ * chat nudge.
+ *
+ * Recovery is asymmetric on purpose:
+ *   - missing → present  ✅ recovery (operator un-trashed / restored)
+ *   - missing → conflict ✅ recovery (restored but evolved while gone)
+ *   - present → present  ✗ no event
+ *   - present → missing  ✗ that's the loss event, separate signal
+ *   - conflict → *       ✗ the staleness digest covers conflict drift
+ *
+ * Pure: takes the previous + current verdicts, returns whether to fire
+ * a recovery event. Caller is responsible for the actual side-effects
+ * (writing the `recover` row to `approval_audit` per RFC B §5,
+ * surfacing the `[ ↻ Re-enabled ]` line in the staleness digest, and
+ * posting the chat nudge). Phase 1d ships the detector; wiring those
+ * three side-effects into the as-yet-unwritten reconciler-driver is
+ * follow-up work (matches the same shipped-helper-then-wire-up
+ * pattern as RFC G Phase 2's `detectLegacyGdriveSlots`).
+ */
+export interface RecoveryEvent {
+  recovered: true;
+  fromReason: "not_found" | "trashed";
+  toState: "present" | "conflict";
+  meta: DriveFileMetadata;
+}
+
+export type RecoveryResult = RecoveryEvent | { recovered: false };
+
+export function detectRecovery(
+  prev: ReconcilerVerdict | null,
+  current: ReconcilerVerdict,
+): RecoveryResult {
+  if (prev === null) return { recovered: false };
+  if (prev.state !== "missing") return { recovered: false };
+  if (current.state === "missing") return { recovered: false };
+  return {
+    recovered: true,
+    fromReason: prev.reason,
+    toState: current.state,
+    meta: current.meta,
+  };
+}
+
 /**
  * Stable content hash from the metadata fields Drive returns cheaply (we
  * don't want to download the body just to hash it — `files.get` is the only


### PR DESCRIPTION
## Summary

RFC E Phase 1d (\`docs/rfcs/doc-connection-completion.md\` §4.4) — pure helper that takes a previous + current reconciler verdict and classifies whether the transition warrants firing a recovery event (operator un-trashed a doc; the agent should know).

## Asymmetric by design

- \`missing → present\`  ✅ recovery
- \`missing → conflict\` ✅ recovery (restored but evolved while gone)
- everything else      ✗ no event

Conflict drift is covered by the existing staleness digest (RFC B §9.1). The other-direction missing transition is a loss event with its own signal. Recovery is specifically the un-trash / restore case the JTBD calls out.

## Scope split

Phase 1d ships **the detector**. Wiring the three side-effects RFC E §4.4 specifies (\`recover\` row in approval_audit, \`[ ↻ Re-enabled ]\` line in staleness digest, one-line chat nudge) needs a reconciler-driver that doesn't exist yet. The shipped reconciler.ts is a pure module with no live caller — same shape as RFC G Phase 2's \`detectLegacyGdriveSlots\`.

When the driver lands (downstream PR), it calls \`detectRecovery()\` on each per-grant check. If \`recovered=true\`, fire the side-effects.

## Tests

- 10 new cases covering every transition: steady-state, loss, drift in either direction, recovery from each missing reason to each non-missing state, fromReason preservation
- 22/22 reconciler tests pass (10 new + 12 original)
- \`tsc --noEmit\` clean

## Test plan

- [x] \`bun test src/drive/reconciler.test.ts\` — 22/22 pass
- [x] \`tsc --noEmit\` — clean
- [ ] Independent reviewer verdict (will dispatch after PR open)

🤖 Generated with [Claude Code](https://claude.com/claude-code)