### PR TITLE
feat(drive): RFC E Phase 1b — section-anchor editing primitive (resolver + tests)

### DIFF
--- a/src/drive/anchors.test.ts
+++ b/src/drive/anchors.test.ts
@@ -1,0 +1,295 @@
+/**
+ * Anchor resolver tests — RFC E §4.5.
+ *
+ * Covers all three anchor types (heading / snippet / position), the
+ * disambiguation paths (HEADING_AMBIGUOUS, SNIPPET_AMBIGUOUS,
+ * nth_match), the error shapes the wrapper surfaces back to the agent,
+ * and the displayName surfaces the diff-preview card will attest.
+ */
+
+import { describe, expect, it } from "bun:test";
+
+import {
+  resolveAnchor,
+  type DocumentSnapshot,
+  type HeadingParagraph,
+  type TextParagraph,
+} from "./anchors.js";
+
+// ────────────────────────────────────────────────────────────────────────
+// Fixtures
+// ────────────────────────────────────────────────────────────────────────
+
+function h(level: number, text: string, index: number): HeadingParagraph {
+  return { kind: "heading", level, text, index };
+}
+
+function p(text: string, index: number): TextParagraph {
+  return { kind: "text", text, index };
+}
+
+const headedDoc: DocumentSnapshot = {
+  paragraphs: [
+    h(1, "Q3 Strategy Notes", 1),
+    p("Intro paragraph.", 2),
+    h(2, "Goals", 3),
+    p("Ship hiring section.", 4),
+    p("Close two roles.", 5),
+    h(2, "Hiring", 6),
+    p("Open roles list.", 7),
+    h(2, "Risks", 8),
+    p("None identified.", 9),
+  ],
+};
+
+const unheadedDoc: DocumentSnapshot = {
+  paragraphs: [
+    p("We agreed to ship by Q3.", 1),
+    p("Action items:", 2),
+    p("- John to draft hiring plan.", 3),
+    p("- TBD: hiring section.", 4),
+    p("- Action items:", 5), // intentional duplicate of paragraph 2 to test ambiguity
+  ],
+};
+
+const emptyDoc: DocumentSnapshot = { paragraphs: [] };
+
+// ────────────────────────────────────────────────────────────────────────
+// Heading-based
+// ────────────────────────────────────────────────────────────────────────
+
+describe("resolveAnchor — heading-based", () => {
+  it("after_heading: 'Goals' resolves to insert_after at the heading's index", () => {
+    const r = resolveAnchor({ after_heading: "Goals" }, headedDoc);
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.resolved.op).toEqual({ kind: "insert_after", paragraphIndex: 3 });
+      expect(r.resolved.displayName).toBe("after heading 'Goals' (level 2)");
+    }
+  });
+
+  it("append_to_section: 'Goals' resolves to the LAST paragraph in the section", () => {
+    // Section runs from heading index 3 → next H2 at index 6, so last
+    // paragraph in section is index 5 ("Close two roles.")
+    const r = resolveAnchor({ append_to_section: "Goals" }, headedDoc);
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.resolved.op).toEqual({
+        kind: "append_to_section_end",
+        paragraphIndex: 5,
+      });
+      expect(r.resolved.displayName).toBe("end of section 'Goals' (level 2)");
+    }
+  });
+
+  it("append_to_section runs to end of doc when no following same-or-higher heading", () => {
+    // 'Risks' is the last H2 — section runs to end of doc, last paragraph
+    // is index 9 ("None identified.")
+    const r = resolveAnchor({ append_to_section: "Risks" }, headedDoc);
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.resolved.op).toEqual({
+        kind: "append_to_section_end",
+        paragraphIndex: 9,
+      });
+    }
+  });
+
+  it("HEADING_NOT_FOUND with operator-actionable message", () => {
+    const r = resolveAnchor({ after_heading: "Nonexistent" }, headedDoc);
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.error.code).toBe("HEADING_NOT_FOUND");
+      expect(r.error.message).toContain("Nonexistent");
+      expect(r.error.message).toContain("after_line_containing");
+    }
+  });
+
+  it("level filter — wrong level gives HEADING_NOT_FOUND", () => {
+    // 'Goals' is H2 in the fixture; asking for H1 → not found.
+    const r = resolveAnchor({ after_heading: "Goals", level: 1 }, headedDoc);
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.error.code).toBe("HEADING_NOT_FOUND");
+      expect(r.error.message).toContain("at level 1");
+    }
+  });
+
+  it("HEADING_AMBIGUOUS when multiple match and nth_match unset", () => {
+    // Add two same-level headings with the same title to a fresh doc.
+    const doc: DocumentSnapshot = {
+      paragraphs: [h(2, "Notes", 1), p("a", 2), h(2, "Notes", 3), p("b", 4)],
+    };
+    const r = resolveAnchor({ after_heading: "Notes" }, doc);
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.error.code).toBe("HEADING_AMBIGUOUS");
+      expect(r.error.candidates).toHaveLength(2);
+      expect(r.error.message).toContain("nth_match (1..2)");
+    }
+  });
+
+  it("HEADING_AMBIGUOUS resolved by nth_match", () => {
+    const doc: DocumentSnapshot = {
+      paragraphs: [h(2, "Notes", 1), p("a", 2), h(2, "Notes", 3), p("b", 4)],
+    };
+    const first = resolveAnchor({ after_heading: "Notes", nth_match: 1 }, doc);
+    const second = resolveAnchor({ after_heading: "Notes", nth_match: 2 }, doc);
+    expect(first.ok && first.resolved.op).toEqual({ kind: "insert_after", paragraphIndex: 1 });
+    expect(second.ok && second.resolved.op).toEqual({ kind: "insert_after", paragraphIndex: 3 });
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────
+// Text-snippet
+// ────────────────────────────────────────────────────────────────────────
+
+describe("resolveAnchor — text-snippet", () => {
+  it("after_line_containing matches case-insensitively", () => {
+    const r = resolveAnchor(
+      { after_line_containing: "we agreed to ship" },
+      unheadedDoc,
+    );
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.resolved.op).toEqual({ kind: "insert_after", paragraphIndex: 1 });
+      expect(r.resolved.displayName).toContain("after line:");
+      expect(r.resolved.displayName).toContain("agreed to ship");
+    }
+  });
+
+  it("before_line_containing places insert_before at the matched paragraph", () => {
+    const r = resolveAnchor(
+      { before_line_containing: "TBD: hiring section", nth_match: 1 },
+      unheadedDoc,
+    );
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.resolved.op).toEqual({ kind: "insert_before", paragraphIndex: 4 });
+    }
+  });
+
+  it("replace_line_matching uses the regex against the paragraph text", () => {
+    const r = resolveAnchor(
+      { replace_line_matching: /TBD:\s*hiring/ },
+      unheadedDoc,
+    );
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.resolved.op).toEqual({ kind: "replace_paragraph", paragraphIndex: 4 });
+      expect(r.resolved.displayName).toContain("replacing line:");
+    }
+  });
+
+  it("SNIPPET_NOT_FOUND with the search term in the error message", () => {
+    const r = resolveAnchor(
+      { after_line_containing: "this string is nowhere" },
+      unheadedDoc,
+    );
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.error.code).toBe("SNIPPET_NOT_FOUND");
+      expect(r.error.message).toContain("this string is nowhere");
+    }
+  });
+
+  it("SNIPPET_AMBIGUOUS with up-to-3 candidate excerpts when multiple match", () => {
+    // Both "Action items:" lines (paragraphs 2 and 5) match the snippet.
+    const r = resolveAnchor(
+      { after_line_containing: "Action items" },
+      unheadedDoc,
+    );
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.error.code).toBe("SNIPPET_AMBIGUOUS");
+      expect(r.error.candidates).toHaveLength(2);
+      expect(r.error.message).toContain("nth_match (1..2)");
+    }
+  });
+
+  it("SNIPPET_AMBIGUOUS resolved by nth_match", () => {
+    const r = resolveAnchor(
+      { after_line_containing: "Action items", nth_match: 2 },
+      unheadedDoc,
+    );
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.resolved.op).toEqual({ kind: "insert_after", paragraphIndex: 5 });
+    }
+  });
+
+  it("INVALID_ANCHOR when no snippet field is set under a snippet-shaped call", () => {
+    // Empty object falls through to INVALID_ANCHOR via the dispatcher.
+    const r = resolveAnchor({}, unheadedDoc);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error.code).toBe("INVALID_ANCHOR");
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────
+// Document-position
+// ────────────────────────────────────────────────────────────────────────
+
+describe("resolveAnchor — document-position", () => {
+  it("at_start places insert_before at the first paragraph", () => {
+    const r = resolveAnchor({ at_start: true }, headedDoc);
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.resolved.op).toEqual({ kind: "insert_before", paragraphIndex: 1 });
+      expect(r.resolved.displayName).toBe("at start of doc");
+    }
+  });
+
+  it("at_end places insert_after at the last paragraph", () => {
+    const r = resolveAnchor({ at_end: true }, headedDoc);
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.resolved.op).toEqual({ kind: "insert_after", paragraphIndex: 9 });
+      expect(r.resolved.displayName).toBe("at end of doc");
+    }
+  });
+
+  it("EMPTY_DOC_NEEDS_POSITION when at_start/at_end on an empty doc", () => {
+    const r = resolveAnchor({ at_start: true }, emptyDoc);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error.code).toBe("EMPTY_DOC_NEEDS_POSITION");
+  });
+
+  it("INVALID_ANCHOR when both at_start and at_end are set", () => {
+    const r = resolveAnchor({ at_start: true, at_end: true }, headedDoc);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error.code).toBe("INVALID_ANCHOR");
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────
+// displayName attestation invariants — load-bearing for RFC E §4.2
+// ────────────────────────────────────────────────────────────────────────
+
+describe("resolved displayName never contains agent-controlled text", () => {
+  it("heading anchor displayName comes from the doc, not the agent param", () => {
+    // Even though the agent passes the title, the displayName uses the
+    // *resolved heading's text* — which in practice would be identical
+    // to the agent input on a successful match. The invariant we're
+    // pinning is that it's the resolver that builds the string from
+    // doc state, not echoed agent input.
+    const r = resolveAnchor({ after_heading: "Goals" }, headedDoc);
+    expect(r.ok && r.resolved.displayName).toBe("after heading 'Goals' (level 2)");
+    // Same call, same result — pinning that no agent-supplied
+    // metadata bleeds through into the display string.
+    const r2 = resolveAnchor({ after_heading: "Goals" }, headedDoc);
+    expect(r2.ok && r2.resolved.displayName).toBe("after heading 'Goals' (level 2)");
+  });
+
+  it("snippet anchor displayName uses the doc's actual line text, not the search term", () => {
+    // The agent searches for "we agreed to ship" (truncated); the
+    // displayName surfaces the FULL matched paragraph text up to the
+    // ellipsis budget. Defends against an agent searching for a
+    // shortened snippet to mislead the operator.
+    const r = resolveAnchor(
+      { after_line_containing: "we agreed" },
+      unheadedDoc,
+    );
+    expect(r.ok && r.resolved.displayName).toContain("We agreed to ship by Q3.");
+  });
+});

--- a/src/drive/anchors.test.ts
+++ b/src/drive/anchors.test.ts
@@ -141,6 +141,77 @@ describe("resolveAnchor — heading-based", () => {
 });
 
 // ────────────────────────────────────────────────────────────────────────
+// append_to_section — empty-section semantics (post-review fix #1)
+// ────────────────────────────────────────────────────────────────────────
+
+describe("append_to_section — empty-section handling", () => {
+  it("heading immediately followed by another same-level heading → append_to_empty_section at heading index", () => {
+    const doc: DocumentSnapshot = {
+      paragraphs: [h(2, "Goals", 1), h(2, "Hiring", 2), p("Open roles.", 3)],
+    };
+    const r = resolveAnchor({ append_to_section: "Goals" }, doc);
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.resolved.op).toEqual({
+        kind: "append_to_empty_section",
+        paragraphIndex: 1,
+      });
+      expect(r.resolved.displayName).toContain("currently empty");
+    }
+  });
+
+  it("heading is the LAST paragraph in the doc → append_to_empty_section", () => {
+    const doc: DocumentSnapshot = {
+      paragraphs: [p("Body.", 1), h(2, "Risks", 2)],
+    };
+    const r = resolveAnchor({ append_to_section: "Risks" }, doc);
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.resolved.op).toEqual({
+        kind: "append_to_empty_section",
+        paragraphIndex: 2,
+      });
+    }
+  });
+
+  it("heading immediately followed by a higher-level heading (H2 → H1) → empty section", () => {
+    const doc: DocumentSnapshot = {
+      paragraphs: [h(2, "Notes", 1), h(1, "Other", 2), p("body", 3)],
+    };
+    const r = resolveAnchor({ append_to_section: "Notes" }, doc);
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.resolved.op).toEqual({
+        kind: "append_to_empty_section",
+        paragraphIndex: 1,
+      });
+    }
+  });
+
+  it("heading with body and nested subheading → section_end at last body paragraph (subheading bodies count)", () => {
+    // 'Goals' has body paragraph (idx 2), then subheading H3 (idx 3)
+    // with its own body (idx 4). Section runs to next H<=2 or EOF;
+    // here EOF, so last body is idx 4.
+    const doc: DocumentSnapshot = {
+      paragraphs: [
+        h(2, "Goals", 1),
+        p("Top-level intent.", 2),
+        h(3, "Subgoal", 3),
+        p("Sub body.", 4),
+      ],
+    };
+    const r = resolveAnchor({ append_to_section: "Goals" }, doc);
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.resolved.op).toEqual({
+        kind: "append_to_section_end",
+        paragraphIndex: 4,
+      });
+    }
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────
 // Text-snippet
 // ────────────────────────────────────────────────────────────────────────
 
@@ -223,6 +294,61 @@ describe("resolveAnchor — text-snippet", () => {
     const r = resolveAnchor({}, unheadedDoc);
     expect(r.ok).toBe(false);
     if (!r.ok) expect(r.error.code).toBe("INVALID_ANCHOR");
+  });
+
+  it("INVALID_ANCHOR when after_line_containing is empty string (would silently match every paragraph)", () => {
+    const r = resolveAnchor({ after_line_containing: "" }, unheadedDoc);
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.error.code).toBe("INVALID_ANCHOR");
+      expect(r.error.message).toContain("non-empty");
+    }
+  });
+
+  it("INVALID_ANCHOR when before_line_containing is whitespace-only", () => {
+    const r = resolveAnchor({ before_line_containing: "   " }, unheadedDoc);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error.code).toBe("INVALID_ANCHOR");
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────
+// nth_match out-of-range — distinct error code per review fix #2
+// ────────────────────────────────────────────────────────────────────────
+
+describe("nth_match out of range → NTH_MATCH_OUT_OF_RANGE (not _AMBIGUOUS)", () => {
+  it("heading: nth_match=5 when there are only 2 matches", () => {
+    const doc: DocumentSnapshot = {
+      paragraphs: [h(2, "Notes", 1), p("a", 2), h(2, "Notes", 3), p("b", 4)],
+    };
+    const r = resolveAnchor({ after_heading: "Notes", nth_match: 5 }, doc);
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.error.code).toBe("NTH_MATCH_OUT_OF_RANGE");
+      expect(r.error.message).toContain("nth_match=5");
+      expect(r.error.message).toContain("Valid range: 1..2");
+    }
+  });
+
+  it("snippet: nth_match=10 when there are only 2 matches", () => {
+    const r = resolveAnchor(
+      { after_line_containing: "Action items", nth_match: 10 },
+      unheadedDoc,
+    );
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.error.code).toBe("NTH_MATCH_OUT_OF_RANGE");
+      expect(r.error.message).toContain("nth_match=10");
+    }
+  });
+
+  it("nth_match=0 (boundary, 1-based indexing) → NTH_MATCH_OUT_OF_RANGE", () => {
+    const r = resolveAnchor(
+      { after_line_containing: "Action items", nth_match: 0 },
+      unheadedDoc,
+    );
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error.code).toBe("NTH_MATCH_OUT_OF_RANGE");
   });
 });
 

--- a/src/drive/anchors.ts
+++ b/src/drive/anchors.ts
@@ -1,0 +1,441 @@
+/**
+ * Section-anchor editing primitive — RFC E §4.5.
+ *
+ * Pure resolver. Takes an anchor (the agent's stated where-to-edit) plus
+ * a structural snapshot of the doc, returns either a `Resolved` position
+ * the wrapper can act on, or an error the wrapper surfaces back to the
+ * agent verbatim.
+ *
+ * Three anchor types, in priority order:
+ *
+ *   1. Heading-based (preferred for headed docs):
+ *      { after_heading: "Goals", level?: number, nth_match?: number }
+ *      { append_to_section: "Hiring", level?: number, nth_match?: number }
+ *
+ *   2. Text-snippet (covers unheaded docs — meeting notes, draft prose):
+ *      { after_line_containing: "we agreed to ship by Q3", nth_match?: number }
+ *      { before_line_containing: "Action items:", nth_match?: number }
+ *      { replace_line_matching: /TBD: hiring section/, nth_match?: number }
+ *
+ *   3. Document-position fallback (last resort, empty / very short docs):
+ *      { at_start: true } | { at_end: true }
+ *
+ * The "resolved anchor" returned on success is what the diff-preview
+ * card surfaces to the user (per RFC E §4.2). The agent cannot
+ * override the resolved-name string — that's the load-bearing detail
+ * that defends against the "summary lies about intent" attack.
+ *
+ * Phase 1b ships the resolver. Phase 1c wires it to the suggesting-edit
+ * tool + the diff-preview card.
+ */
+
+// ────────────────────────────────────────────────────────────────────────
+// Anchor types (input — what the agent passes to gdrive_suggest_edit)
+// ────────────────────────────────────────────────────────────────────────
+
+export type Anchor =
+  | HeadingAnchor
+  | SnippetAnchor
+  | PositionAnchor;
+
+export interface HeadingAnchor {
+  /** Insert immediately after the heading line itself. */
+  after_heading?: string;
+  /** Append to the end of the section under this heading (before the next same-or-higher level). */
+  append_to_section?: string;
+  /** Optional disambiguator: 1-based heading level (1=H1, 2=H2, etc). When unset, any level matches. */
+  level?: number;
+  /** Optional disambiguator when multiple headings match by title+level: 1-based index of which match to pick. Defaults to the only match (errors if ambiguous and unset). */
+  nth_match?: number;
+}
+
+export interface SnippetAnchor {
+  /** Insert after the FIRST line whose text contains this substring (case-insensitive). */
+  after_line_containing?: string;
+  /** Insert before the FIRST line whose text contains this substring (case-insensitive). */
+  before_line_containing?: string;
+  /** Replace the entire line whose text matches this regex. */
+  replace_line_matching?: RegExp;
+  /** Optional disambiguator when multiple lines match: 1-based index. Required if there are 2+ matches. */
+  nth_match?: number;
+}
+
+export interface PositionAnchor {
+  at_start?: boolean;
+  at_end?: boolean;
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// Document AST (input — supplied by the wrapper from documents.get)
+// ────────────────────────────────────────────────────────────────────────
+
+export type Paragraph = HeadingParagraph | TextParagraph;
+
+export interface HeadingParagraph {
+  kind: "heading";
+  /** 1-based: 1 = H1, 2 = H2, etc. */
+  level: number;
+  /** Plain-text rendering of the heading title (no formatting runs). */
+  text: string;
+  /** Stable per-doc index — what the wrapper uses to address insert/delete. */
+  index: number;
+}
+
+export interface TextParagraph {
+  kind: "text";
+  /** Plain-text rendering of the paragraph (no formatting runs). */
+  text: string;
+  /** Stable per-doc index — what the wrapper uses to address insert/delete. */
+  index: number;
+}
+
+export interface DocumentSnapshot {
+  paragraphs: Paragraph[];
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// Resolver result types (output — what the wrapper acts on)
+// ────────────────────────────────────────────────────────────────────────
+
+/** Where in the doc the wrapper should perform the edit. */
+export type ResolvedOp =
+  | { kind: "insert_after"; paragraphIndex: number }
+  | { kind: "insert_before"; paragraphIndex: number }
+  | { kind: "replace_paragraph"; paragraphIndex: number }
+  | { kind: "append_to_section_end"; paragraphIndex: number /* index of LAST paragraph in section */ };
+
+export interface ResolvedAnchor {
+  op: ResolvedOp;
+  /** Human-readable name surfaced on the diff-preview card per RFC E §4.2. AGENT CANNOT OVERRIDE THIS. */
+  displayName: string;
+}
+
+export type AnchorErrorCode =
+  | "HEADING_NOT_FOUND"
+  | "HEADING_AMBIGUOUS"
+  | "SNIPPET_NOT_FOUND"
+  | "SNIPPET_AMBIGUOUS"
+  | "EMPTY_DOC_NEEDS_POSITION"
+  | "INVALID_ANCHOR";
+
+export interface AnchorError {
+  code: AnchorErrorCode;
+  /** Operator-actionable message the wrapper surfaces to the agent verbatim. */
+  message: string;
+  /** When >0, includes per-match context excerpts so the agent can pick by nth_match. */
+  candidates?: Array<{ index: number; excerpt: string }>;
+}
+
+export type ResolveResult =
+  | { ok: true; resolved: ResolvedAnchor }
+  | { ok: false; error: AnchorError };
+
+// ────────────────────────────────────────────────────────────────────────
+// Resolver
+// ────────────────────────────────────────────────────────────────────────
+
+export function resolveAnchor(
+  anchor: Anchor,
+  doc: DocumentSnapshot,
+): ResolveResult {
+  // Dispatch in RFC E §4.5 priority order.
+  if (isHeadingAnchor(anchor)) return resolveHeading(anchor, doc);
+  if (isSnippetAnchor(anchor)) return resolveSnippet(anchor, doc);
+  if (isPositionAnchor(anchor)) return resolvePosition(anchor, doc);
+  return {
+    ok: false,
+    error: {
+      code: "INVALID_ANCHOR",
+      message:
+        "Anchor must specify one of: heading-based (after_heading / append_to_section), text-snippet (after_line_containing / before_line_containing / replace_line_matching), or document-position (at_start / at_end).",
+    },
+  };
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// Heading-based
+// ────────────────────────────────────────────────────────────────────────
+
+function resolveHeading(
+  anchor: HeadingAnchor,
+  doc: DocumentSnapshot,
+): ResolveResult {
+  const target = anchor.after_heading ?? anchor.append_to_section;
+  if (target === undefined) {
+    return invalidAnchor("Heading anchor must set after_heading or append_to_section");
+  }
+
+  const matches: HeadingParagraph[] = [];
+  for (const p of doc.paragraphs) {
+    if (p.kind !== "heading") continue;
+    if (p.text !== target) continue;
+    if (anchor.level !== undefined && p.level !== anchor.level) continue;
+    matches.push(p);
+  }
+
+  if (matches.length === 0) {
+    return notFound(
+      "HEADING_NOT_FOUND",
+      `Couldn't find heading '${target}'${anchor.level !== undefined ? ` at level ${anchor.level}` : ""} in current doc. Try after_line_containing: "..." or pick a different anchor.`,
+    );
+  }
+
+  const picked = pickByNthMatch(matches, anchor.nth_match);
+  if (picked === null) {
+    return ambiguous(
+      "HEADING_AMBIGUOUS",
+      `Found ${matches.length} headings titled '${target}'${anchor.level !== undefined ? ` at level ${anchor.level}` : ""}. Specify nth_match (1..${matches.length}) to disambiguate.`,
+      matches.map((m) => ({
+        index: m.index,
+        excerpt: `(${ordinalLevel(m.level)}) ${m.text}`,
+      })),
+    );
+  }
+
+  if (anchor.append_to_section !== undefined) {
+    // Find the last paragraph in this heading's section: the next paragraph
+    // index that is a heading at level <= picked.level (or end-of-doc).
+    const sectionEndIdx = findSectionEnd(picked, doc);
+    return {
+      ok: true,
+      resolved: {
+        op: { kind: "append_to_section_end", paragraphIndex: sectionEndIdx },
+        displayName: `end of section '${picked.text}' (${ordinalLevel(picked.level)})`,
+      },
+    };
+  }
+
+  return {
+    ok: true,
+    resolved: {
+      op: { kind: "insert_after", paragraphIndex: picked.index },
+      displayName: `after heading '${picked.text}' (${ordinalLevel(picked.level)})`,
+    },
+  };
+}
+
+function findSectionEnd(
+  heading: HeadingParagraph,
+  doc: DocumentSnapshot,
+): number {
+  // Find this heading's array position
+  const arrPos = doc.paragraphs.findIndex((p) => p === heading);
+  if (arrPos === -1) return heading.index; // shouldn't happen
+  for (let i = arrPos + 1; i < doc.paragraphs.length; i++) {
+    const p = doc.paragraphs[i];
+    if (p.kind === "heading" && p.level <= heading.level) {
+      // Section ends at the paragraph BEFORE this same-or-higher heading.
+      return doc.paragraphs[i - 1].index;
+    }
+  }
+  // Section runs to end of doc.
+  return doc.paragraphs[doc.paragraphs.length - 1].index;
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// Text-snippet
+// ────────────────────────────────────────────────────────────────────────
+
+function resolveSnippet(
+  anchor: SnippetAnchor,
+  doc: DocumentSnapshot,
+): ResolveResult {
+  const after = anchor.after_line_containing;
+  const before = anchor.before_line_containing;
+  const replace = anchor.replace_line_matching;
+  const setCount = [after, before, replace].filter((x) => x !== undefined).length;
+  if (setCount !== 1) {
+    return invalidAnchor(
+      "Snippet anchor must set exactly one of: after_line_containing, before_line_containing, replace_line_matching.",
+    );
+  }
+
+  type Match = { paragraph: Paragraph; matchedText: string };
+  const matches: Match[] = [];
+  for (const p of doc.paragraphs) {
+    const matchedText = matchSnippet(p, after, before, replace);
+    if (matchedText !== null) matches.push({ paragraph: p, matchedText });
+  }
+
+  if (matches.length === 0) {
+    const term = (after ?? before ?? String(replace ?? "")).slice(0, 50);
+    return notFound(
+      "SNIPPET_NOT_FOUND",
+      `Couldn't find any line containing/matching '${term}' in current doc. Re-read the doc and try a different snippet, or use a heading anchor if the doc has headings.`,
+    );
+  }
+
+  if (matches.length > 1 && anchor.nth_match === undefined) {
+    return ambiguous(
+      "SNIPPET_AMBIGUOUS",
+      `Found ${matches.length} lines matching the snippet. Specify nth_match (1..${matches.length}) to disambiguate.`,
+      matches.slice(0, 3).map((m, i) => ({
+        index: m.paragraph.index,
+        excerpt: `match ${i + 1}: "${ellipsize(m.matchedText, 80)}"`,
+      })),
+    );
+  }
+
+  const picked = pickByNthMatch(matches, anchor.nth_match);
+  if (picked === null) {
+    return ambiguous(
+      "SNIPPET_AMBIGUOUS",
+      `Found ${matches.length} lines matching the snippet. Specify nth_match (1..${matches.length}) to disambiguate.`,
+      matches.slice(0, 3).map((m, i) => ({
+        index: m.paragraph.index,
+        excerpt: `match ${i + 1}: "${ellipsize(m.matchedText, 80)}"`,
+      })),
+    );
+  }
+
+  if (after !== undefined) {
+    return {
+      ok: true,
+      resolved: {
+        op: { kind: "insert_after", paragraphIndex: picked.paragraph.index },
+        displayName: `after line: "${ellipsize(picked.matchedText, 60)}"`,
+      },
+    };
+  }
+  if (before !== undefined) {
+    return {
+      ok: true,
+      resolved: {
+        op: { kind: "insert_before", paragraphIndex: picked.paragraph.index },
+        displayName: `before line: "${ellipsize(picked.matchedText, 60)}"`,
+      },
+    };
+  }
+  // replace
+  return {
+    ok: true,
+    resolved: {
+      op: { kind: "replace_paragraph", paragraphIndex: picked.paragraph.index },
+      displayName: `replacing line: "${ellipsize(picked.matchedText, 60)}"`,
+    },
+  };
+}
+
+function matchSnippet(
+  p: Paragraph,
+  after?: string,
+  before?: string,
+  replace?: RegExp,
+): string | null {
+  const haystack = p.text;
+  const lc = haystack.toLowerCase();
+  if (after !== undefined) {
+    return lc.includes(after.toLowerCase()) ? haystack : null;
+  }
+  if (before !== undefined) {
+    return lc.includes(before.toLowerCase()) ? haystack : null;
+  }
+  if (replace !== undefined) {
+    return replace.test(haystack) ? haystack : null;
+  }
+  return null;
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// Document-position
+// ────────────────────────────────────────────────────────────────────────
+
+function resolvePosition(
+  anchor: PositionAnchor,
+  doc: DocumentSnapshot,
+): ResolveResult {
+  if (doc.paragraphs.length === 0) {
+    return {
+      ok: false,
+      error: {
+        code: "EMPTY_DOC_NEEDS_POSITION",
+        message:
+          "Doc is empty — nothing to anchor against. The wrapper will insert at position 1.",
+      },
+    };
+  }
+  if (anchor.at_start === true && anchor.at_end !== true) {
+    const first = doc.paragraphs[0];
+    return {
+      ok: true,
+      resolved: {
+        op: { kind: "insert_before", paragraphIndex: first.index },
+        displayName: "at start of doc",
+      },
+    };
+  }
+  if (anchor.at_end === true && anchor.at_start !== true) {
+    const last = doc.paragraphs[doc.paragraphs.length - 1];
+    return {
+      ok: true,
+      resolved: {
+        op: { kind: "insert_after", paragraphIndex: last.index },
+        displayName: "at end of doc",
+      },
+    };
+  }
+  return invalidAnchor(
+    "Position anchor must set exactly one of at_start: true or at_end: true.",
+  );
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// Type guards + helpers
+// ────────────────────────────────────────────────────────────────────────
+
+function isHeadingAnchor(a: Anchor): a is HeadingAnchor {
+  return (
+    (a as HeadingAnchor).after_heading !== undefined ||
+    (a as HeadingAnchor).append_to_section !== undefined
+  );
+}
+
+function isSnippetAnchor(a: Anchor): a is SnippetAnchor {
+  return (
+    (a as SnippetAnchor).after_line_containing !== undefined ||
+    (a as SnippetAnchor).before_line_containing !== undefined ||
+    (a as SnippetAnchor).replace_line_matching !== undefined
+  );
+}
+
+function isPositionAnchor(a: Anchor): a is PositionAnchor {
+  return (
+    (a as PositionAnchor).at_start === true ||
+    (a as PositionAnchor).at_end === true
+  );
+}
+
+function pickByNthMatch<T>(matches: T[], nthMatch: number | undefined): T | null {
+  if (matches.length === 1) return matches[0];
+  if (nthMatch === undefined) return null;
+  if (nthMatch < 1 || nthMatch > matches.length) return null;
+  return matches[nthMatch - 1];
+}
+
+function ordinalLevel(level: number): string {
+  return `level ${level}`;
+}
+
+function ellipsize(s: string, max: number): string {
+  if (s.length <= max) return s;
+  return s.slice(0, max - 1) + "…";
+}
+
+function notFound(
+  code: AnchorErrorCode,
+  message: string,
+): ResolveResult {
+  return { ok: false, error: { code, message } };
+}
+
+function ambiguous(
+  code: AnchorErrorCode,
+  message: string,
+  candidates: AnchorError["candidates"],
+): ResolveResult {
+  return { ok: false, error: { code, message, candidates } };
+}
+
+function invalidAnchor(message: string): ResolveResult {
+  return { ok: false, error: { code: "INVALID_ANCHOR", message } };
+}

--- a/src/drive/anchors.ts
+++ b/src/drive/anchors.ts
@@ -102,7 +102,16 @@ export type ResolvedOp =
   | { kind: "insert_after"; paragraphIndex: number }
   | { kind: "insert_before"; paragraphIndex: number }
   | { kind: "replace_paragraph"; paragraphIndex: number }
-  | { kind: "append_to_section_end"; paragraphIndex: number /* index of LAST paragraph in section */ };
+  | {
+      kind: "append_to_section_end";
+      /** Index of LAST body paragraph in the section. */
+      paragraphIndex: number;
+    }
+  | {
+      kind: "append_to_empty_section";
+      /** Index of the heading itself — the section has no body paragraphs to append after. Wrapper inserts a new body paragraph immediately after this heading. */
+      paragraphIndex: number;
+    };
 
 export interface ResolvedAnchor {
   op: ResolvedOp;
@@ -115,6 +124,7 @@ export type AnchorErrorCode =
   | "HEADING_AMBIGUOUS"
   | "SNIPPET_NOT_FOUND"
   | "SNIPPET_AMBIGUOUS"
+  | "NTH_MATCH_OUT_OF_RANGE"
   | "EMPTY_DOC_NEEDS_POSITION"
   | "INVALID_ANCHOR";
 
@@ -182,6 +192,17 @@ function resolveHeading(
 
   const picked = pickByNthMatch(matches, anchor.nth_match);
   if (picked === null) {
+    if (anchor.nth_match !== undefined) {
+      // Operator did disambiguate — they just picked an index that
+      // doesn't exist. Distinct error so the message is honest.
+      return outOfRange(
+        `nth_match=${anchor.nth_match} exceeds the ${matches.length} matching heading${matches.length === 1 ? "" : "s"} titled '${target}'${anchor.level !== undefined ? ` at level ${anchor.level}` : ""}. Valid range: 1..${matches.length}.`,
+        matches.map((m) => ({
+          index: m.index,
+          excerpt: `(${ordinalLevel(m.level)}) ${m.text}`,
+        })),
+      );
+    }
     return ambiguous(
       "HEADING_AMBIGUOUS",
       `Found ${matches.length} headings titled '${target}'${anchor.level !== undefined ? ` at level ${anchor.level}` : ""}. Specify nth_match (1..${matches.length}) to disambiguate.`,
@@ -193,13 +214,32 @@ function resolveHeading(
   }
 
   if (anchor.append_to_section !== undefined) {
-    // Find the last paragraph in this heading's section: the next paragraph
-    // index that is a heading at level <= picked.level (or end-of-doc).
-    const sectionEndIdx = findSectionEnd(picked, doc);
+    // Find the last BODY paragraph in this heading's section. If the
+    // section is empty (heading immediately followed by another
+    // same-or-higher heading, or heading is the last paragraph in the
+    // doc), we return a distinct op so the wrapper knows to insert
+    // a fresh paragraph after the heading rather than appending to
+    // the heading itself (which would corrupt heading text).
+    const sectionEnd = findSectionEnd(picked, doc);
+    if (sectionEnd.empty) {
+      return {
+        ok: true,
+        resolved: {
+          op: {
+            kind: "append_to_empty_section",
+            paragraphIndex: picked.index,
+          },
+          displayName: `end of section '${picked.text}' (${ordinalLevel(picked.level)}, currently empty)`,
+        },
+      };
+    }
     return {
       ok: true,
       resolved: {
-        op: { kind: "append_to_section_end", paragraphIndex: sectionEndIdx },
+        op: {
+          kind: "append_to_section_end",
+          paragraphIndex: sectionEnd.lastBodyIndex,
+        },
         displayName: `end of section '${picked.text}' (${ordinalLevel(picked.level)})`,
       },
     };
@@ -214,22 +254,43 @@ function resolveHeading(
   };
 }
 
+/**
+ * Result of locating the end of a heading's section.
+ * - `empty: true`      — the heading has no body paragraphs (next sibling
+ *                        is another same-or-higher heading, or the heading
+ *                        is the last paragraph in the doc).
+ * - `lastBodyIndex`    — paragraphIndex of the LAST body paragraph in the
+ *                        section. Only set when `empty: false`.
+ */
+type SectionEnd =
+  | { empty: true }
+  | { empty: false; lastBodyIndex: number };
+
 function findSectionEnd(
   heading: HeadingParagraph,
   doc: DocumentSnapshot,
-): number {
-  // Find this heading's array position
+): SectionEnd {
   const arrPos = doc.paragraphs.findIndex((p) => p === heading);
-  if (arrPos === -1) return heading.index; // shouldn't happen
+  if (arrPos === -1) return { empty: true }; // shouldn't happen — defensive
   for (let i = arrPos + 1; i < doc.paragraphs.length; i++) {
     const p = doc.paragraphs[i];
     if (p.kind === "heading" && p.level <= heading.level) {
       // Section ends at the paragraph BEFORE this same-or-higher heading.
-      return doc.paragraphs[i - 1].index;
+      // If that paragraph IS the heading we started from (i.e. arrPos +
+      // 1 == this heading), the section is empty.
+      if (i === arrPos + 1) return { empty: true };
+      return { empty: false, lastBodyIndex: doc.paragraphs[i - 1].index };
     }
   }
-  // Section runs to end of doc.
-  return doc.paragraphs[doc.paragraphs.length - 1].index;
+  // No following same-or-higher heading.
+  if (arrPos === doc.paragraphs.length - 1) {
+    // Heading is the last paragraph — section is empty.
+    return { empty: true };
+  }
+  return {
+    empty: false,
+    lastBodyIndex: doc.paragraphs[doc.paragraphs.length - 1].index,
+  };
 }
 
 // ────────────────────────────────────────────────────────────────────────
@@ -247,6 +308,20 @@ function resolveSnippet(
   if (setCount !== 1) {
     return invalidAnchor(
       "Snippet anchor must set exactly one of: after_line_containing, before_line_containing, replace_line_matching.",
+    );
+  }
+  // Reject empty/whitespace-only snippet strings up front. `''.includes('')`
+  // is true, so an empty string would silently match every paragraph and
+  // dump the operator into a SNIPPET_AMBIGUOUS error with no clue what
+  // went wrong.
+  if (after !== undefined && after.trim() === "") {
+    return invalidAnchor(
+      "after_line_containing must be a non-empty, non-whitespace search string.",
+    );
+  }
+  if (before !== undefined && before.trim() === "") {
+    return invalidAnchor(
+      "before_line_containing must be a non-empty, non-whitespace search string.",
     );
   }
 
@@ -278,6 +353,15 @@ function resolveSnippet(
 
   const picked = pickByNthMatch(matches, anchor.nth_match);
   if (picked === null) {
+    if (anchor.nth_match !== undefined) {
+      return outOfRange(
+        `nth_match=${anchor.nth_match} exceeds the ${matches.length} matching line${matches.length === 1 ? "" : "s"}. Valid range: 1..${matches.length}.`,
+        matches.slice(0, 3).map((m, i) => ({
+          index: m.paragraph.index,
+          excerpt: `match ${i + 1}: "${ellipsize(m.matchedText, 80)}"`,
+        })),
+      );
+    }
     return ambiguous(
       "SNIPPET_AMBIGUOUS",
       `Found ${matches.length} lines matching the snippet. Specify nth_match (1..${matches.length}) to disambiguate.`,
@@ -434,6 +518,13 @@ function ambiguous(
   candidates: AnchorError["candidates"],
 ): ResolveResult {
   return { ok: false, error: { code, message, candidates } };
+}
+
+function outOfRange(
+  message: string,
+  candidates: AnchorError["candidates"],
+): ResolveResult {
+  return { ok: false, error: { code: "NTH_MATCH_OUT_OF_RANGE", message, candidates } };
 }
 
 function invalidAnchor(message: string): ResolveResult {


### PR DESCRIPTION
## Summary

RFC E Phase 1b (\`docs/rfcs/doc-connection-completion.md\` §4.5) — pure resolver \`resolveAnchor(anchor, doc)\` for the three anchor types the suggesting-edit tool will accept. New module at \`src/drive/anchors.ts\`.

## Three anchor types, dispatched in priority order

1. **Heading-based** — \`{ after_heading, level?, nth_match? }\` or \`{ append_to_section }\`. Walks the doc structural tree.
2. **Text-snippet** — \`{ after_line_containing }\` / \`{ before_line_containing }\` / \`{ replace_line_matching }\`. Covers unheaded docs (meeting notes, draft prose). Multiple matches always require \`nth_match\` (no silent first-wins).
3. **Document-position fallback** — \`{ at_start: true }\` / \`{ at_end: true }\`.

## Load-bearing invariant per RFC E §4.2

The \`displayName\` on the ResolvedAnchor is built by the resolver from doc state, NOT echoed from agent input. This is the wrapper-attested string that lands on the diff-preview card — defends against the "summary lies about intent" attack.

## Error shapes

\`HEADING_NOT_FOUND\`, \`HEADING_AMBIGUOUS\`, \`SNIPPET_NOT_FOUND\`, \`SNIPPET_AMBIGUOUS\`, \`EMPTY_DOC_NEEDS_POSITION\`, \`INVALID_ANCHOR\`. All carry operator-actionable messages the wrapper surfaces back to the agent verbatim. Ambiguous variants include up-to-3 candidate excerpts so the agent can pick by \`nth_match\`.

## Scope split

Phase 1b ships **the resolver + tests against fixture docs**. Phase 1c (suggesting writes + diff preview) wires this into the actual MCP tool + approval card. Same pattern as RFC G Phase 2's \`detectLegacyGdriveSlots\` and RFC E Phase 1d's \`detectRecovery\` — pure helper landed first, consumer in a follow-up.

## Test coverage

20 unit tests across all three types:
- heading after_heading + append_to_section + level filter + last-heading-runs-to-EOF + ambiguity resolved by nth_match
- snippet contains / regex variants + ambiguous + resolved
- position at_start + at_end + empty-doc + invalid combinations
- displayName-attestation invariants (resolver builds the string from doc, not echo)

## Test plan

- [x] \`bun test src/drive/anchors.test.ts\` — 20/20 pass
- [x] \`tsc --noEmit\` — clean
- [ ] Independent reviewer verdict (will dispatch after PR open)

🤖 Generated with [Claude Code](https://claude.com/claude-code)