### PR TITLE
feat(drive): RFC E Phase 1c (partial) — diff-preview builder for suggesting writes

### DIFF
--- a/src/drive/diff-preview.test.ts
+++ b/src/drive/diff-preview.test.ts
@@ -1,0 +1,226 @@
+/**
+ * Tests for the diff-preview builder — RFC E §4.2.
+ *
+ * Pinning the load-bearing security invariant: wrapper-attested
+ * fields appear on the card alongside (and visually distinct from)
+ * the agent-supplied summary, so the user can sanity-check intent.
+ */
+
+import { describe, expect, it } from "bun:test";
+
+import { buildDiffPreview, type DiffPreviewInput } from "./diff-preview.js";
+import { type ResolvedAnchor } from "./anchors.js";
+
+const sampleAnchor: ResolvedAnchor = {
+  op: { kind: "insert_after", paragraphIndex: 3 },
+  displayName: "after heading 'Goals' (level 2)",
+};
+
+function baseInput(overrides: Partial<DiffPreviewInput> = {}): DiffPreviewInput {
+  return {
+    agentName: "klanker",
+    docTitle: "Q3 Strategy Notes",
+    fileId: "1abcDEFxyz",
+    mimeType: "application/vnd.google-apps.document",
+    resolvedAnchor: sampleAnchor,
+    metrics: { linesAdded: 47, linesRemoved: 0 },
+    agentSummary: "Added Hiring section after 'Goals'",
+    mode: "suggest",
+    ...overrides,
+  };
+}
+
+describe("buildDiffPreview — title + body shape", () => {
+  it("renders the RFC §4.2 mockup shape for a suggesting edit", () => {
+    const p = buildDiffPreview(baseInput());
+    expect(p.title).toBe('✏️ klanker wants to add to "Q3 Strategy Notes"');
+    expect(p.lines).toHaveLength(3);
+    expect(p.lines[0].text).toBe("📍 after heading 'Goals' (level 2)");
+    expect(p.lines[1].text).toBe("+47 lines / -0 lines");
+    expect(p.lines[2].text).toBe(`💬 "Added Hiring section after 'Goals'"`);
+  });
+
+  it("uses ⚠ icon and 'wants to write to' verb in write mode", () => {
+    const p = buildDiffPreview(baseInput({ mode: "write" }));
+    expect(p.title).toBe('⚠ klanker wants to write to "Q3 Strategy Notes"');
+  });
+
+  it("omits the agent-summary line when no summary supplied", () => {
+    const p = buildDiffPreview(baseInput({ agentSummary: undefined }));
+    expect(p.lines).toHaveLength(2);
+    expect(p.lines.find((l) => l.text.startsWith("💬"))).toBeUndefined();
+  });
+
+  it("omits the agent-summary line when summary is whitespace-only", () => {
+    const p = buildDiffPreview(baseInput({ agentSummary: "   \n " }));
+    expect(p.lines).toHaveLength(2);
+  });
+});
+
+describe("buildDiffPreview — wrapperAttested invariant (RFC §4.2 load-bearing)", () => {
+  it("📍 anchor line and line-count line are wrapperAttested=true", () => {
+    const p = buildDiffPreview(baseInput());
+    expect(p.lines[0]).toMatchObject({
+      wrapperAttested: true,
+      text: expect.stringMatching(/^📍/),
+    });
+    expect(p.lines[1]).toMatchObject({
+      wrapperAttested: true,
+      text: expect.stringMatching(/^\+\d+ lines/),
+    });
+  });
+
+  it("💬 agent-summary line is wrapperAttested=false", () => {
+    const p = buildDiffPreview(baseInput());
+    const summaryLine = p.lines.find((l) => l.text.startsWith("💬"));
+    expect(summaryLine?.wrapperAttested).toBe(false);
+  });
+
+  it("audit payload separates wrapper-attested fields from agent-supplied", () => {
+    const p = buildDiffPreview(baseInput());
+    expect(p.audit.wrapperAttested).toEqual({
+      anchorDisplayName: "after heading 'Goals' (level 2)",
+      linesAdded: 47,
+      linesRemoved: 0,
+      docTitle: "Q3 Strategy Notes",
+      fileId: "1abcDEFxyz",
+    });
+    expect(p.audit.agentSupplied.summary).toBe("Added Hiring section after 'Goals'");
+  });
+
+  it("audit.agentSupplied.summary is null when summary absent (not undefined or empty string)", () => {
+    const p = buildDiffPreview(baseInput({ agentSummary: undefined }));
+    expect(p.audit.agentSupplied.summary).toBe(null);
+  });
+
+  it("anchor displayName comes from the resolver, not from any agent input", () => {
+    // Even if some hypothetical future caller passed agent-controlled
+    // anchor metadata, the displayName ends up on the card from the
+    // resolved anchor alone. Pin that the only string from input that
+    // bleeds into the wrapperAttested anchor line is resolvedAnchor.displayName.
+    const p = buildDiffPreview(
+      baseInput({
+        agentSummary: "📍 after heading 'Risks' SUMMARY ATTACK",
+      }),
+    );
+    expect(p.lines[0].text).toBe("📍 after heading 'Goals' (level 2)");
+    // Summary still shows but distinctly separated and prefixed 💬,
+    // so the operator visually distinguishes the agent's framing.
+    const summaryLine = p.lines.find((l) => l.wrapperAttested === false);
+    expect(summaryLine?.text).toContain("📍 after heading 'Risks' SUMMARY ATTACK");
+  });
+});
+
+describe("buildDiffPreview — buttons", () => {
+  it("suggest mode: Open in Drive + Apply as suggestion (primary) + Apply directly + Cancel", () => {
+    const p = buildDiffPreview(baseInput());
+    expect(p.buttons.map((b) => b.action)).toEqual([
+      "open_in_drive",
+      "apply_suggestion",
+      "apply_directly",
+      "cancel",
+    ]);
+    const primary = p.buttons.find((b) => b.action === "apply_suggestion");
+    expect(primary?.emphasis).toBe("primary");
+  });
+
+  it("write mode: Open in Drive + Apply directly (destructive) + Cancel — no Apply-as-suggestion", () => {
+    const p = buildDiffPreview(baseInput({ mode: "write" }));
+    expect(p.buttons.map((b) => b.action)).toEqual([
+      "open_in_drive",
+      "apply_directly",
+      "cancel",
+    ]);
+    const direct = p.buttons.find((b) => b.action === "apply_directly");
+    expect(direct?.emphasis).toBe("destructive");
+  });
+
+  it("Open-in-Drive button URL routes by mimeType", () => {
+    const docs = buildDiffPreview(baseInput({ mimeType: "application/vnd.google-apps.document" }));
+    expect(docs.buttons[0].url).toContain("docs.google.com/document/");
+
+    const sheet = buildDiffPreview(baseInput({ mimeType: "application/vnd.google-apps.spreadsheet" }));
+    expect(sheet.buttons[0].url).toContain("docs.google.com/spreadsheets/");
+
+    const generic = buildDiffPreview(baseInput({ mimeType: "application/pdf" }));
+    expect(generic.buttons[0].url).toContain("drive.google.com/file/");
+  });
+
+  it("Open-in-Drive carries discussionId when supplied (suggestion-write deep link)", () => {
+    const p = buildDiffPreview(
+      baseInput({ mode: "suggest", discussionId: "thread-xyz" }),
+    );
+    expect(p.buttons[0].url).toContain("?disco=thread-xyz");
+  });
+});
+
+describe("buildDiffPreview — agent-supplied summary sanitization", () => {
+  it("collapses newlines in the summary so the card stays one-line", () => {
+    const p = buildDiffPreview(
+      baseInput({ agentSummary: "Line 1\nLine 2\r\nLine 3" }),
+    );
+    const summaryLine = p.lines.find((l) => !l.wrapperAttested);
+    expect(summaryLine?.text).not.toContain("\n");
+    expect(summaryLine?.text).toContain("Line 1");
+    expect(summaryLine?.text).toContain("Line 3");
+  });
+
+  it("replaces embedded quotes so the card's quoting stays balanced", () => {
+    const p = buildDiffPreview(
+      baseInput({ agentSummary: 'He said "hello" then "goodbye"' }),
+    );
+    const summaryLine = p.lines.find((l) => !l.wrapperAttested);
+    // The outer quotes should remain; inner quotes get replaced.
+    expect(summaryLine?.text).toBe(`💬 "He said 'hello' then 'goodbye'"`);
+  });
+
+  it("truncates very long summaries with an ellipsis", () => {
+    const long = "x".repeat(500);
+    const p = buildDiffPreview(baseInput({ agentSummary: long }));
+    const summaryLine = p.lines.find((l) => !l.wrapperAttested);
+    expect(summaryLine?.text.length).toBeLessThan(220); // 200 cap + "…" + quoting
+    expect(summaryLine?.text).toContain("…");
+  });
+
+  it("audit summary preserves the full untruncated value (post-hoc review needs the raw)", () => {
+    const long = "x".repeat(500);
+    const p = buildDiffPreview(baseInput({ agentSummary: long }));
+    expect(p.audit.agentSupplied.summary).toBe(long);
+  });
+});
+
+describe("buildDiffPreview — line-count formatting", () => {
+  it("always shows both +added and -removed (zero is explicit, not omitted)", () => {
+    const noAdds = buildDiffPreview(
+      baseInput({ metrics: { linesAdded: 0, linesRemoved: 12 } }),
+    );
+    expect(noAdds.lines[1].text).toBe("+0 lines / -12 lines");
+
+    const noRemoves = buildDiffPreview(
+      baseInput({ metrics: { linesAdded: 5, linesRemoved: 0 } }),
+    );
+    expect(noRemoves.lines[1].text).toBe("+5 lines / -0 lines");
+  });
+});
+
+describe("buildDiffPreview — input validation", () => {
+  it("throws on empty agentName", () => {
+    expect(() => buildDiffPreview(baseInput({ agentName: "" }))).toThrow(/agentName/);
+  });
+
+  it("throws on empty docTitle", () => {
+    expect(() => buildDiffPreview(baseInput({ docTitle: "" }))).toThrow(/docTitle/);
+  });
+
+  it("throws on negative line counts (wrapper bug guard)", () => {
+    expect(() =>
+      buildDiffPreview(baseInput({ metrics: { linesAdded: -1, linesRemoved: 0 } })),
+    ).toThrow(/non-negative/);
+  });
+
+  it("throws on non-integer line counts", () => {
+    expect(() =>
+      buildDiffPreview(baseInput({ metrics: { linesAdded: 1.5, linesRemoved: 0 } })),
+    ).toThrow(/integer/);
+  });
+});

--- a/src/drive/diff-preview.ts
+++ b/src/drive/diff-preview.ts
@@ -1,0 +1,277 @@
+/**
+ * Suggesting-write diff-preview builder — RFC E §4.2.
+ *
+ * Pure assembler. Takes the wrapper-attested anchor (from
+ * `anchors.ts:resolveAnchor`), the wrapper-computed line-count delta,
+ * and the agent-supplied summary string, and produces the structured
+ * `DiffPreview` the approval card renders.
+ *
+ * The load-bearing security invariant per RFC E §4.2:
+ *
+ *     Anchor name + line counts come from the wrapper.
+ *     Summary string comes from the agent.
+ *     Both are surfaced separately on the card so the user has
+ *     wrapper-attested truth alongside the agent's framing.
+ *
+ * If the agent's summary says "Added Hiring section" but the wrapper-
+ * attested anchor reads `📍 after heading 'Goals'`, the user can see
+ * the discrepancy without needing to open the doc.
+ *
+ * Phase 1c ships the formatter + tests. Phase 1c-followup wires it
+ * into the actual approval-card builder + the MCP tool's call site
+ * (touches `src/vault/approvals/kernel.ts` and the gateway's
+ * card-rendering code; both substantial enough to warrant their own
+ * change).
+ */
+
+import { type ResolvedAnchor } from "./anchors.js";
+import { openInDriveButton } from "./deep-links.js";
+
+// ────────────────────────────────────────────────────────────────────────
+// Inputs
+// ────────────────────────────────────────────────────────────────────────
+
+export interface DiffMetrics {
+  /** Lines added by the proposed edit. NEVER agent-supplied — the wrapper computes it. */
+  linesAdded: number;
+  /** Lines removed by the proposed edit. NEVER agent-supplied. */
+  linesRemoved: number;
+}
+
+export interface DiffPreviewInput {
+  /** Agent slug — surfaced in the approval card title ("klanker wants to add to..."). */
+  agentName: string;
+  /** Drive doc title (from `files.get`). NOT agent-supplied. */
+  docTitle: string;
+  /** Drive file id — used to build the Open-in-Drive deep link. */
+  fileId: string;
+  /** mimeType from `files.get` — drives the deep-link kind. */
+  mimeType?: string;
+  /** Optional Drive discussion-thread id when the suggestion has been pre-allocated one. */
+  discussionId?: string;
+  /** The resolver's output (Phase 1b) — the anchor name surfaced on the card is from here. */
+  resolvedAnchor: ResolvedAnchor;
+  /** Wrapper-computed line counts. */
+  metrics: DiffMetrics;
+  /**
+   * Agent-supplied "what changed" string. Optional — when absent the
+   * card still renders without it (anchor + line counts are enough
+   * for the safety guarantee). When present, surfaced under a
+   * separate `💬` line so the user can see the agent's framing
+   * alongside the wrapper truth.
+   */
+  agentSummary?: string;
+  /**
+   * Direct write vs suggestion. RFC E §4.2 default = suggest;
+   * direct write is opt-in. Affects card title icon (✏️ vs ⚠).
+   */
+  mode: "suggest" | "write";
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// Output shape — what the approval card builder consumes
+// ────────────────────────────────────────────────────────────────────────
+
+export interface DiffPreviewLine {
+  /** Order on the card top-to-bottom. */
+  order: number;
+  /**
+   * Text content of the line. Already escaped for display — the
+   * caller renders verbatim (no further markdown processing should
+   * be applied).
+   */
+  text: string;
+  /** Whether this line came from the wrapper (true) or the agent (false). */
+  wrapperAttested: boolean;
+}
+
+export interface DiffPreviewButton {
+  /** Display text of the inline-keyboard button. */
+  text: string;
+  /** What kind of action this triggers (used to wire callback_data in the kernel). */
+  action: "apply_suggestion" | "apply_directly" | "open_in_drive" | "cancel";
+  /** For open-in-drive: the URL. For action buttons: undefined (kernel synthesizes callback_data). */
+  url?: string;
+  /** Cosmetic tier — primary buttons are emphasized in the row layout. */
+  emphasis: "primary" | "secondary" | "destructive";
+}
+
+export interface DiffPreview {
+  /** Title line: "✏️ klanker wants to add to "Q3 Strategy Notes"" */
+  title: string;
+  /** Body lines, in render order. The 📍 + line-count rows are wrapperAttested. */
+  lines: DiffPreviewLine[];
+  /** Inline-keyboard button rows. Render order is array order. */
+  buttons: DiffPreviewButton[];
+  /**
+   * Audit payload — what the kernel writes to `approval_audit` so a
+   * post-hoc review can compare wrapper truth against agent framing.
+   * RFC E §4.2 stores both for "post-hoc review of agent intent vs.
+   * wrapper resolution."
+   */
+  audit: {
+    wrapperAttested: {
+      anchorDisplayName: string;
+      linesAdded: number;
+      linesRemoved: number;
+      docTitle: string;
+      fileId: string;
+    };
+    agentSupplied: {
+      summary: string | null;
+    };
+  };
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// Builder
+// ────────────────────────────────────────────────────────────────────────
+
+export function buildDiffPreview(input: DiffPreviewInput): DiffPreview {
+  validateInput(input);
+
+  const titleIcon = input.mode === "write" ? "⚠" : "✏️";
+  const titleVerb = input.mode === "write" ? "wants to write to" : "wants to add to";
+  const title = `${titleIcon} ${input.agentName} ${titleVerb} "${input.docTitle}"`;
+
+  const lines: DiffPreviewLine[] = [];
+
+  // 📍 line — wrapper-attested anchor name. Always first body line.
+  // The 📍 prefix is the load-bearing visual cue per RFC E §4.2 mockup.
+  lines.push({
+    order: 0,
+    text: `📍 ${input.resolvedAnchor.displayName}`,
+    wrapperAttested: true,
+  });
+
+  // Line-count metrics — wrapper-computed. Format mirrors the RFC §4.2
+  // mockup ("+47 lines / -0 lines"). Agent CANNOT influence these.
+  lines.push({
+    order: 1,
+    text: formatMetrics(input.metrics),
+    wrapperAttested: true,
+  });
+
+  // Optional agent-supplied summary, prefixed `💬` so the user can
+  // visually distinguish "agent's framing" from "wrapper's truth"
+  // above. Only rendered when the agent supplied one — the card is
+  // already safety-complete without it.
+  if (input.agentSummary !== undefined && input.agentSummary.trim() !== "") {
+    lines.push({
+      order: 2,
+      text: `💬 "${sanitizeSummary(input.agentSummary)}"`,
+      wrapperAttested: false,
+    });
+  }
+
+  const buttons: DiffPreviewButton[] = [];
+
+  // Open-in-Drive — always present, always first button per RFC §4.2.
+  buttons.push({
+    text: "📖 Open in Drive",
+    action: "open_in_drive",
+    url: openInDriveButton({
+      fileId: input.fileId,
+      mimeType: input.mimeType,
+      discussionId: input.discussionId,
+    }).url,
+    emphasis: "secondary",
+  });
+
+  // Primary action: Apply as suggestion (default per RFC) or Apply
+  // directly (when mode=write, which is opt-in via expand only —
+  // the kernel routes the user there before this builder is called).
+  if (input.mode === "suggest") {
+    buttons.push({
+      text: "✅ Apply as suggestion",
+      action: "apply_suggestion",
+      emphasis: "primary",
+    });
+    buttons.push({
+      text: "⚠ Apply directly",
+      action: "apply_directly",
+      emphasis: "secondary",
+    });
+  } else {
+    buttons.push({
+      text: "⚠ Apply directly",
+      action: "apply_directly",
+      emphasis: "destructive",
+    });
+  }
+
+  buttons.push({
+    text: "🚫 Cancel",
+    action: "cancel",
+    emphasis: "secondary",
+  });
+
+  const audit: DiffPreview["audit"] = {
+    wrapperAttested: {
+      anchorDisplayName: input.resolvedAnchor.displayName,
+      linesAdded: input.metrics.linesAdded,
+      linesRemoved: input.metrics.linesRemoved,
+      docTitle: input.docTitle,
+      fileId: input.fileId,
+    },
+    agentSupplied: {
+      summary: input.agentSummary?.trim() || null,
+    },
+  };
+
+  return { title, lines, buttons, audit };
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// Internals
+// ────────────────────────────────────────────────────────────────────────
+
+/**
+ * Format the wrapper's diff metrics as the RFC §4.2 mockup line:
+ * "+47 lines / -0 lines". Always shows both halves so the absence
+ * of either is visually unambiguous.
+ */
+function formatMetrics(m: DiffMetrics): string {
+  return `+${m.linesAdded} lines / -${m.linesRemoved} lines`;
+}
+
+/**
+ * Strip control characters from agent-supplied summary text. The
+ * summary lands in a quoted string on the approval card; an embedded
+ * `"` or newline could break out of the quoting visually. We
+ * normalize to a single line, replace embedded quotes, and cap
+ * length to keep the card scannable.
+ *
+ * NOT a security boundary (the agent already controls the summary
+ * content; our defense is the wrapper-attested anchor surfaced
+ * separately). This is a "card stays well-formed" hygiene step.
+ */
+function sanitizeSummary(summary: string): string {
+  const oneLine = summary.replace(/[\r\n\t]+/g, " ").trim();
+  const noQuotes = oneLine.replace(/"/g, "'");
+  const max = 200;
+  if (noQuotes.length <= max) return noQuotes;
+  return noQuotes.slice(0, max - 1) + "…";
+}
+
+function validateInput(input: DiffPreviewInput): void {
+  if (input.agentName.length === 0) {
+    throw new Error("buildDiffPreview: agentName must not be empty");
+  }
+  if (input.docTitle.length === 0) {
+    throw new Error("buildDiffPreview: docTitle must not be empty");
+  }
+  if (input.metrics.linesAdded < 0 || input.metrics.linesRemoved < 0) {
+    throw new Error(
+      "buildDiffPreview: line counts must be non-negative (wrapper bug if you hit this)",
+    );
+  }
+  if (
+    !Number.isInteger(input.metrics.linesAdded) ||
+    !Number.isInteger(input.metrics.linesRemoved)
+  ) {
+    throw new Error(
+      "buildDiffPreview: line counts must be integers",
+    );
+  }
+}


### PR DESCRIPTION
## Summary

RFC E Phase 1c (partial — RFC E §4.2). Pure assembler that produces the structured \`DiffPreview\` the approval card renders. New module at \`src/drive/diff-preview.ts\`.

## Load-bearing security invariant per RFC E §4.2

  Anchor name + line counts come from the wrapper.
  Summary string comes from the agent.
  Both surfaced separately so the user has wrapper-attested
  truth alongside the agent's framing.

If the agent's summary says "Added Hiring section" but the wrapper-attested anchor reads \`📍 after heading 'Goals'\`, the user sees the discrepancy without opening the doc.

## Honest scope split

Same shipped-helper-then-wire pattern as Phases 1a (deep links), 1b (anchors), 1d (recovery detector), and RFC G Phase 2:

- ✅ **This PR**: pure formatter + tests
- ⏳ **Followup**: wire into the approval kernel (RFC B), the gateway approval-card builders, and the \`gdrive_suggest_edit\` / \`gdrive_apply_edit\` MCP tools that call Drive's Suggestions API. Each is substantial; this PR ships the kernel-agnostic reusable piece.

## What ships

- \`DiffPreviewInput\` (agent + wrapper inputs typed separately so callers can't accidentally pass agent data into a wrapperAttested field)
- \`buildDiffPreview()\` — pure builder
- \`DiffPreview\` output: title + lines (each tagged \`wrapperAttested\` true/false) + buttons (action + emphasis) + audit payload that splits wrapper-attested fields from agent-supplied for post-hoc review
- Suggest mode (default) + Write mode (opt-in) emit different buttons + title icons
- \`sanitizeSummary\`: newline collapse, embedded-quote replacement, 200-char truncation. Audit preserves the raw untruncated value.

## Tests

22 cases including a "summary attack" test that confirms an agent putting \`📍 after heading 'Risks'\` in its summary doesn't override the wrapper's 📍 line — load-bearing per RFC §4.2.

## Test plan

- [x] \`bun test src/drive/diff-preview.test.ts\` — 22/22 pass
- [x] \`tsc --noEmit\` — clean
- [ ] Independent reviewer verdict (will dispatch after PR open)

🤖 Generated with [Claude Code](https://claude.com/claude-code)