### PR TITLE
fix(apply): re-align per-agent log dir UID after host-mount creation

### DIFF
--- a/src/cli/apply.ts
+++ b/src/cli/apply.ts
@@ -503,15 +503,28 @@ export async function runApply(
   // as the host operator UID (because mkdir runs as the operator).
   // The per-agent scaffold loop above already called `alignAgentUid`,
   // but at that point the log dir didn't exist yet (existsSync gate
-  // in scaffold.ts:194), so it was silently skipped — leaving the
+  // in scaffold.ts:194 for the log dir), so it was silently skipped — leaving the
   // dir operator-owned. start.sh inside the container runs as the
   // per-agent UID and bind-mounts `~/.switchroom/logs/<agent>` to
   // `/var/log/switchroom`; it then hits "Permission denied" trying
   // to write supervisor logs and the autoaccept / gateway / scheduler
   // sidecars never start. Re-run alignment now that the dir exists.
   // Install-validation finding #21.
+  // Iterate `agentNames` (which respects `--only`), NOT
+  // `Object.keys(config.agents)` — otherwise `apply --only=<name>`
+  // would sudo-chown every agent's state tree on every run, defeating
+  // the migration playbook documented on `ApplyOptions.only`.
+  //
+  // Failure shape: this second pass is non-fatal regardless of
+  // `--allow-unaligned`. The first-pass alignAgentUid at line 443
+  // aborts on hard chown failure (UidAlignmentAbort), so by the time
+  // we reach the second pass the state-dir ownership is already
+  // correct — only the log dir is at risk of misalignment, and a
+  // log-dir EACCES surfaces visibly on the agent's first boot via
+  // start.sh's supervise restart-loop. We always warn so the operator
+  // has the actionable breadcrumb if first-boot fails.
   if (!skipScaffold) {
-    for (const name of Object.keys(config.agents)) {
+    for (const name of agentNames) {
       try {
         const uid = allocateAgentUid(name);
         alignAgentUid(name, join(agentsDir, name), uid, {
@@ -520,14 +533,12 @@ export async function runApply(
         });
       } catch (alignErr) {
         const msg = (alignErr as Error).message;
-        if (!options.allowUnaligned) {
-          writeOut(
-            chalk.yellow(
-              `    ! post-mount-source UID re-align failed for ${name}: ${msg}\n` +
-                `      Agent may fail to write supervisor logs on first boot.\n`,
-            ),
-          );
-        }
+        writeOut(
+          chalk.yellow(
+            `    ! post-mount-source UID re-align failed for ${name}: ${msg}\n` +
+              `      Agent may fail to write supervisor logs on first boot.\n`,
+          ),
+        );
       }
     }
   }

--- a/src/cli/apply.ts
+++ b/src/cli/apply.ts
@@ -497,6 +497,41 @@ export async function runApply(
   // back to interactive unlock).
   await ensureHostMountSources(config);
 
+  // ── 2b. Re-align per-agent log dir ownership ─────────────────────
+  //
+  // `ensureHostMountSources` just created `~/.switchroom/logs/<agent>`
+  // as the host operator UID (because mkdir runs as the operator).
+  // The per-agent scaffold loop above already called `alignAgentUid`,
+  // but at that point the log dir didn't exist yet (existsSync gate
+  // in scaffold.ts:194), so it was silently skipped — leaving the
+  // dir operator-owned. start.sh inside the container runs as the
+  // per-agent UID and bind-mounts `~/.switchroom/logs/<agent>` to
+  // `/var/log/switchroom`; it then hits "Permission denied" trying
+  // to write supervisor logs and the autoaccept / gateway / scheduler
+  // sidecars never start. Re-run alignment now that the dir exists.
+  // Install-validation finding #21.
+  if (!skipScaffold) {
+    for (const name of Object.keys(config.agents)) {
+      try {
+        const uid = allocateAgentUid(name);
+        alignAgentUid(name, join(agentsDir, name), uid, {
+          confirm: !options.nonInteractive,
+          writeOut,
+        });
+      } catch (alignErr) {
+        const msg = (alignErr as Error).message;
+        if (!options.allowUnaligned) {
+          writeOut(
+            chalk.yellow(
+              `    ! post-mount-source UID re-align failed for ${name}: ${msg}\n` +
+                `      Agent may fail to write supervisor logs on first boot.\n`,
+            ),
+          );
+        }
+      }
+    }
+  }
+
   // ── 2c. Vault layout migration (v0.7.12) ─────────────────────────
   //
   // Move the legacy single-file vault layout (~/.switchroom/vault.enc)


### PR DESCRIPTION
## Summary

Extracted from the now-closed #1241 (superseded by RFC H #1254). The log-dir alignment fix is independent of RFC H's auth-broker work — RFC H replaces per-agent token files but doesn't touch the supervisor log dir.

Install-validation finding #21. Without this, fresh installs hang on Claude Code's first-run TUI because:

1. `switchroom apply` calls `alignAgentUid` in the per-agent scaffold loop.
2. That loop runs BEFORE `ensureHostMountSources` creates `~/.switchroom/logs/<name>`.
3. `alignAgentUid`'s `existsSync` gate at `scaffold.ts:194` silently skips the log dir.
4. `ensureHostMountSources` then `mkdir`'s it as the host operator UID.
5. In the container, `start.sh` runs as the per-agent UID and bind-mounts `~/.switchroom/logs/<name>` → `/var/log/switchroom`.
6. Every supervisor-log write fails with `Permission denied`. The gateway / autoaccept / scheduler sidecars never start. autoaccept-poll specifically is gone, so the agent hangs on Claude Code's first-run theme picker forever.

Fix: second-pass `alignAgentUid` loop right after `ensureHostMountSources`. Operator-actionable warning if the chown fails (non-fatal — EACCES surfaces on first boot otherwise).

## Test plan

- [x] `tsc --noEmit` clean
- [x] `vitest run tests/setup.test.ts src/agents/scaffold.test.ts` — 43 tests pass
- [x] Validated end-to-end on fresh Ubuntu 26.04 VM as part of install-validation Phase 3

🤖 Generated with [Claude Code](https://claude.com/claude-code)