### PR TITLE
docs(rfcs): RFC G v3 — align with RFC H (auth-broker / PR #1254)

### DIFF
--- a/docs/rfcs/google-workspace-generalization.md
+++ b/docs/rfcs/google-workspace-generalization.md
@@ -1,26 +1,59 @@
 # RFC G: Google Workspace as a first-class agent capability
 
-Status: Draft v2
+Status: Draft v3
 Author: Ken (with Claude pair-design)
 Date: 2026-05-14
 
-**v2 changes** (addressing PR #1240 review):
-- CLI moved from invented `switchroom workspace ...` (which collides with the existing top-level `workspace` verb) to `switchroom auth google ...`, mirroring the auth-slot-pool pattern (account creation as separate verb, plural-agents on `enable`/`disable`, `--from-agent` flag instead of arrow syntax). See §4.5.
-- Phase 2 migration changed from interactive per-token merge to **clean cutover** (apply-time legacy-slot detection + refusal pointing at the new flow). Mirrors `share-auth-across-the-fleet.md` decision #10. See §7 + §8.
-- §5 acknowledges multi-Google-account-per-agent as the expected #1 follow-up rather than an indefinite out-of-scope.
-- §9 adds scope-drift-on-re-consent risk + drops the migration risk that no longer applies.
-- §4.7 drops the unverified `examples/operator-rebar/` precedent claim — `examples/` ships only top-level YAMLs today.
+**v3 changes** (aligning with RFC H — `auth-broker.md` / PR #1254):
+
+RFC H (the canonical Anthropic-auth refactor) replaced the per-agent
+slot-pool model that v2 mirrored. Google Workspace now aligns with
+RFC H rather than the deleted `auth account ...` shape:
+
+- **CLI shape collapses to `enable | disable | list`** (Phase 3a's
+  shipped surface). Drop `share`, drop `connect <agent>` wizard alias
+  — RFC H deleted the equivalent Anthropic verbs (no `auth share`,
+  no `auth login`). Account *creation* moves to `auth google account
+  add <email>`, which becomes a thin client over the auth-broker
+  (Phase 3b). See §4.5.
+- **Drop the "dormant ACL" semantic** (`enabled_for: []` left in
+  YAML) per RFC H §10 decision: loud removal beats polite mirror.
+  `auth google disable` now prunes the entry; full teardown via
+  `auth google account remove`. See §4.5 + §4.4.
+- **OAuth refresh moves into the auth-broker** as a provider plugin
+  (Phase 3b). RFC H ships `auth.consumers[]` in v1 (decision #1)
+  precisely for non-agent peers needing OAuth credentials — Google
+  accounts are structurally consumers. Rebuilding a parallel
+  refresher in `src/drive/` would duplicate flock leases, sha-index
+  drift detection, and audit log machinery. The vault-broker stays
+  as the durable token-storage layer; auth-broker becomes the
+  single OAuth refresher for both Anthropic AND Google. See §4.4
+  + §7 Phase 3b.
+- **MCP wrapper credential-read pivots to `auth-broker.get-credentials
+  { provider: "google" }`** over UDS, mirroring the same path-as-
+  identity pattern Anthropic uses post-RFC-H. Replaces direct
+  vault-broker reads. See §7 Phase 3b.
+- **Apply-time legacy-slot detection becomes a hard refusal** with
+  a `migrate-google-slots.ts` one-shot rewrite, mirroring RFC H
+  §6's `migrate-schema.ts` pattern. See §7 Phase 3b.
+
+**Earlier change history**:
+
+v2 (addressing PR #1240 review): CLI moved from invented `workspace` verb (collided with existing top-level verb) to `auth google ...`; Phase 2 migration changed to clean cutover; §5 acknowledged multi-account-per-agent as #1 follow-up.
+
+v1: initial draft.
 
 Prerequisites:
 - **RFC B — Approval kernel** — landed v0.6.0 (#762).
 - **RFC D — Google Drive MCP integration** — landed v0.6.0 (#763, #766, #767, #768). This RFC generalizes RFC D from "Drive only" to "the whole upstream Workspace surface."
-- **RFC E — Drive collab loop** — drafted (PR #1227). Orthogonal: RFC E covers the *interaction* shape (folder picker, suggesting writes, anchors); this RFC covers *which surfaces* are available and *how operators enable them*. They can ship in either order.
+- **RFC E — Drive collab loop** — primitives merged (#1227, #1249, #1250, #1251, #1252). Orthogonal: RFC E covers the *interaction* shape (folder picker, suggesting writes, anchors); this RFC covers *which surfaces* are available and *how operators enable them*.
+- **RFC H — `switchroom-auth-broker`** — PR #1254. Phase 3b of this RFC plugs Google into the broker as a provider; Phase 1 / 2 / 3a / 4 / 5 are independent of RFC H and have already merged.
 
 This spec generalizes RFC D's Drive-only integration into the full
-Google Workspace surface, exposes the upstream MCP's tier knob, and —
-load-bearing — moves OAuth tokens from per-agent vault slots to
-**per-Google-account vault slots with per-agent ACL**, mirroring the
-auth slot pool pattern from `share-auth-across-the-fleet.md`.
+Google Workspace surface and routes OAuth tokens through the
+**auth-broker** (RFC H) with **per-Google-account vault slots
+gated by per-agent ACL**. The vault-broker remains the durable
+storage layer; auth-broker owns the refresh loop.
 
 ## 0. Goal
 
@@ -190,27 +223,32 @@ Exclude wins over include on conflict. Switchroom validates at
 `apply` time that included tools exist in the upstream MCP's
 manifest; unknown tool names fail fast with the suggestion list.
 
-### 4.4 Per-account vault slot + per-agent ACL (the load-bearing piece)
+### 4.4 Per-account vault slot + per-agent ACL via auth-broker (the load-bearing piece)
 
-**Vault slot key changes from per-agent to per-account:**
+**Two brokers, one OAuth refresh implementation, per RFC H §4.4 + §4.7:**
+
+- **vault-broker** (existing) — durable storage. Refresh tokens land
+  at `vault:google:<account>:refresh_token`. The vault file is the
+  single source of truth at rest.
+- **auth-broker** (RFC H) — sole OAuth refresher and credentials
+  writer. Owns the refresh loop for both Anthropic AND Google
+  accounts via the provider abstraction added in Phase 3b. Reads
+  refresh tokens from vault-broker, runs the refresh tick, exposes
+  short-lived access tokens to consumers via UDS.
+
+**Vault slot key shape** (Phase 2, already merged):
 
 ```
-# Before (RFC D §4.1):
-gdrive:<agent_unit>:refresh_token
-
-# After:
+# Per-Google-account, NOT per-agent:
 google:<account_email>:refresh_token
 google:<account_email>:refresh_token:status        # invalid-grant signaling
 google:<account_email>:scopes                      # cached scope set
 ```
 
-**Per-agent ACL enforced at the broker:**
-
-A new vault ACL primitive — `google_account_grant` — gates which
-agents can read which account's token:
+**Per-agent ACL** (Phase 2, already merged) — top-level config block
+gates which agents can read which account's token:
 
 ```yaml
-# Stored in the broker's ACL config, written by `workspace enable/disable`:
 google_accounts:
   pixsoul@gmail.com:
     enabled_for: [klanker, gymbro]
@@ -218,95 +256,124 @@ google_accounts:
     enabled_for: [executive]
 ```
 
-Broker enforcement: `getCredential("google:<acct>:refresh_token")` is
-allowed only when the requesting `agent_unit` is in
-`google_accounts.<acct>.enabled_for`. Matches the auth slot pool's
-existing pattern (per-account secret, per-agent ACL).
+The vault-broker's `checkAclByAgent()` routes `google:<acct>:*` keys
+through `google_accounts.<acct>.enabled_for[]` instead of the
+per-cron `schedule.secrets[]` allowlist. Fail-closed on unknown
+account, empty `enabled_for`, or agent-not-in-list. This is the
+load-bearing security boundary — without the ACL, any agent could
+read any Google account's token from vault.
 
-**Drift handling:** when an agent is removed from `enabled_for`,
-existing approval-kernel grants under that agent's identity for
-`doc:gdrive:*` etc. are *not* auto-revoked (the user might re-enable
-the agent shortly). They become **dormant** — the next access by
-that agent gets a `not_authorized` from the broker, which the
-approval kernel surfaces as: *"klanker no longer has access to
-pixsoul@gmail.com — re-enable with `switchroom auth google enable
-pixsoul@gmail.com klanker` or revoke remaining grants with
-`/approvals revoke <id>`."*
+**Drift handling — loud removal, not polite mirror** (v3 change per
+RFC H §10): when an agent is removed from `enabled_for`, the YAML
+entry's `enabled_for` shrinks; if it becomes empty, the entry is
+**pruned entirely** by `auth google disable`. There is no "dormant
+account" intermediate state. Operator wanting a fully-clean teardown
+runs `auth google account remove <account>`, which calls broker
+`remove-account` (deletes vault slot + revokes Google OAuth +
+removes refresh lease). Standing approval-kernel grants under the
+removed agent's identity get a `not_authorized` from the broker on
+next use, with the same operator-actionable message pointing at
+`auth google enable` to restore.
 
-**MCP wrapper change:** the per-agent subprocess (still running
-inside the agent container, per RFC D) now reads its OAuth token
-via the broker using the **account** named in its config, not its
-own agent_unit. The wrapper's startup sequence:
+**MCP wrapper credential read — via auth-broker, not vault-broker**
+(v3 change, Phase 3b): the per-agent MCP subprocess inside an
+agent container reads its OAuth credentials via the auth-broker's
+`get-credentials` UDS verb, mirroring how Anthropic creds are
+retrieved post-RFC-H. Wrapper startup:
 
 1. Read `google_workspace.account` from agent config.
-2. Call broker: `getCredential("google:<acct>:refresh_token")`.
-3. Broker validates `agent_unit ∈ google_accounts.<acct>.enabled_for`.
-4. Wrapper exchanges refresh → access token, runs the upstream MCP.
+2. Connect to per-agent auth-broker socket
+   (`/run/switchroom/auth-broker/<agent>/sock`).
+3. Call `getCredentials({ provider: "google" })`.
+4. Auth-broker validates path-as-identity (agent name from socket
+   path) against `google_accounts.<acct>.enabled_for[]` for the
+   account named in the agent's config.
+5. Returns short-lived access token + expiry. Wrapper hands
+   to the upstream MCP, no token persistence inside the wrapper.
 
-If broker denies (agent removed from ACL): wrapper exits cleanly,
-agent's MCP tools just don't appear, gateway surfaces a one-line
-notice in chat per the dormant-grant text above.
+Refresh ticks happen entirely inside auth-broker per RFC H §4.7's
+flock-protected lease primitive — wrapper never re-fetches refresh
+tokens from vault, never owns the refresh loop. Identical pattern
+to Anthropic; no Google-specific refresh code in `src/drive/`.
 
 ### 4.5 CLI surface — `switchroom auth google ...`
 
-**Naming:** the new verbs live under `auth` to mirror the existing
-`auth account ...` pattern for Anthropic accounts (which is the
-shape the JTBD `share-auth-across-the-fleet.md` settled on, and
-which we explicitly want to inherit one-for-one). Google is the
-second auth vendor; future vendors (Notion, Slack) follow the
-same `auth <vendor> ...` pattern. `switchroom workspace` already
-exists as a top-level verb (manages AGENTS.md/MEMORY.md scaffold
-files) — using it for Google would silently break operators.
+**Naming:** the new verbs live under `auth google ...`, sibling to
+`auth ...` (the post-RFC-H Anthropic surface). Google is the second
+auth vendor; future vendors (Notion, Slack) follow the same `auth
+<vendor> ...` pattern. `switchroom workspace` already exists as a
+top-level verb (manages AGENTS.md/MEMORY.md scaffold files) — using
+it for Google would silently break operators.
 
-`switchroom drive ...` (RFC D shipped surface) becomes a thin
-alias delegating to `auth google ...` for Drive-only operations,
-with a one-line deprecation note in `switchroom apply`.
+**Important divergence from Anthropic post-RFC-H** — Google and
+Anthropic have *different* problems, so the verb shapes are allowed
+to differ:
 
-**Verb shape — mirrors `switchroom auth account ...` exactly:**
+- Anthropic auth = **quota routing** ("which account is the
+  fleet-wide active one to spend against; per-agent overrides for
+  edge cases"). RFC H §4.6 surface: `auth use`, `auth agent
+  override`, `auth rotate`. Single primary, override exceptions.
+- Google auth = **per-account access ACL** ("which agents can read
+  this account's Drive token"). RFC G surface: `auth google
+  enable / disable`. Multi-account, multi-agent matrix.
+
+The JTBD `share-auth-across-the-fleet.md` originally specified the
+slot-pool / `enable`-style shape; RFC H changed Anthropic to fit
+its quota-routing problem better. Google keeps the enable/disable
+shape because the *problem* hasn't changed.
+
+**Verb shape — Phase 3a shipped surface:**
 
 ```
-# Account lifecycle (creation is its own verb — never a side effect of enable)
-switchroom auth google account add <account>           # OAuth flow, lands token in vault
-switchroom auth google account remove <account>        # OAuth revoke + delete vault slot (refused while any agent is enabled)
+# Agent-to-account ACL (Phase 3a — already merged)
+switchroom auth google enable <account> <agents...>    # plural agents
+switchroom auth google disable <account> <agents...>   # plural — prunes when last agent removed
+switchroom auth google list                            # accounts × agents matrix (--json for scripting)
+```
+
+**Verb shape — Phase 3b adds (post-#1254):**
+
+```
+# Account lifecycle (thin clients over auth-broker per Phase 3b)
+switchroom auth google account add <account>           # OAuth flow, lands token in vault, registers
+                                                        # refresh lease with auth-broker. No --enable-on
+                                                        # flag — operator runs `enable` next, same
+                                                        # account-creation-is-separate pattern as
+                                                        # RFC H `auth add`.
+switchroom auth google account remove <account>        # OAuth revoke + delete vault slot + remove
+                                                        # broker refresh lease + prune google_accounts
+                                                        # entry. Refused while any agent is enabled.
 switchroom auth google account list                    # bare accounts (no agent matrix)
-
-# Agent-to-account ACL
-switchroom auth google enable <account> <agents...>    # plural agents, multi-enable in one call
-switchroom auth google disable <account> <agents...>   # plural disable
-
-# Convenience
-switchroom auth google list                            # accounts × agents matrix
-switchroom auth google share <account> --from-agent <name> --to-agent <name>
-                                                        # copy enable-state from one agent to another
-                                                        # mirrors `auth share <label> --from-agent` exactly
-
-# Wizard convenience (NOT a primary verb — only used by `switchroom setup`)
-switchroom auth google connect <agent>                 # alias for: account add + enable in one shot,
-                                                        # for the first-run experience only
-                                                        # (mirrors `auth login <agent>` per JTBD decision #12)
 ```
+
+**Verbs explicitly NOT shipped (v3 cut):**
+
+- `auth google share` — RFC H deleted `auth share`; Google follows.
+  Use `enable <account> <agents...>` directly.
+- `auth google connect <agent>` — RFC H deleted `auth login <agent>`;
+  Google follows. Setup wizard (§4.6) uses the explicit `account
+  add` + `enable` two-step instead.
 
 **`account add` flow** uses RFC D's three-tier OAuth auto-select
 (device-code → OOB-paste → desktop-loopback). On a host with no
 `$DISPLAY`, the device-code flow is used by default; explicit
-`--headless` forces it. Token lands at
-`vault:google:<account>:refresh_token` regardless of which agent
-will use it.
+`--headless` forces it. The OAuth flow itself moves into
+`src/auth/broker/google-provider.ts` (Phase 3b — see §7) — the CLI
+verb is a thin client.
 
 **`account remove` refuses** while any agent is still enabled on
 that account, per the JTBD's "no orphaned tokens left behind"
-check (mirrors `auth account remove` exactly).
+check.
 
 **`enable` / `disable` are plural** — `enable pixsoul@gmail.com
 klanker gymbro coderev` is one call writing one ACL update + one
-audit row, not three. The JTBD calls this out as the right shape
-for "add a sixth agent to my Anthropic account" — same shape
-applies to Google.
+audit row, not three.
 
-**`share` uses `--from-agent` / `--to-agent` flags**, not arrow
-syntax. The CLI has no precedent for `→` and inventing one would
-be a consistency violation. (We considered `share <agent_a> →
-<agent_b>` in v1; the reviewer flagged it; we agreed.)
+**`disable` prunes when `enabled_for` empties** (v3 change per RFC
+H §10): no "dormant ACL" intermediate state. If the operator wants
+the account to stay configured but have no agents, they can leave
+`enabled_for: []` in YAML by hand — the CLI doesn't write that
+shape.
 
 ### 4.6 Setup wizard inline prompt
 
@@ -324,12 +391,25 @@ approval-gated requests in Telegram.
 Connect now? [Y/n] _
 ```
 
-Default Y. Inline runs `switchroom auth google connect klanker`
-(the wizard convenience verb that combines `account add` +
-`enable` per §4.5) → device-code flow if headless else loopback.
-If user declines, the wizard surfaces *"Connect later with:
-switchroom auth google connect klanker"* and continues. No
-mention of `docs/`.
+Default Y. Phase 4 (already merged) prints the next-step command
+and continues — does NOT run OAuth inline (would break the linear
+wizard, same reason RFC H §4.6 doesn't auto-add an account).
+
+**Phase 4 (today)** surfaces the legacy command for back-compat:
+`switchroom drive connect klanker` (the v0.6.0 verb, still works).
+
+**Phase 3b (post-RFC-H landing)** swaps the surfaced command to the
+two-step form:
+
+```
+switchroom auth google account add <your-email>
+switchroom auth google enable <your-email> klanker
+```
+
+Mirrors RFC H §4.6's `auth add default --from-oauth` + `auth use
+default` two-step. Account-creation and agent-enablement are
+deliberately separate verbs; the wizard surfaces both lines but
+runs neither inline.
 
 Survives the docs test (no docs reading needed) and the defaults
 test (no config-by-default for users who aren't using Workspace —
@@ -352,7 +432,7 @@ examples/
 with: *"This is for **operators** who want their **own** Claude Code
 on the host to have Workspace tools (alongside or instead of giving
 agents access). It does not affect switchroom agents — they get
-Workspace via `switchroom auth google connect <agent>` (RFC G §4.5)."*
+Workspace via `switchroom auth google account add` + `enable` (RFC G §4.5)."*
 
 Today `examples/` contains only top-level YAMLs (`minimal.yaml`,
 `switchroom.yaml`); RFC G establishes the `examples/<artifact>/`
@@ -424,13 +504,16 @@ Per `reference/principles.md`:
 ### 6.3 Consistency test — *"Does this feel like one product?"*
 
 - ✅ `switchroom auth google account add|remove|list` + `auth
-  google enable|disable|list|share` mirrors the existing
-  `switchroom auth account add|remove|list` + `auth enable|disable
-  |share` shape exactly. Account-creation is its own verb (per
-  JTBD decision #6), `enable`/`disable` are plural-agents, `share`
-  uses `--from-agent` flag (no invented arrow syntax).
+  google enable|disable|list` is a per-vendor namespace under
+  `auth`; sibling to RFC H's `auth add|use|rotate|rm` for
+  Anthropic. Different verb shapes are honest because the
+  problems differ (Anthropic = quota routing, Google = per-
+  account access ACL — see §4.5 divergence note).
 - ✅ `vault:google:<acct>:*` matches the `vault:<surface>:*` slot
   pattern.
+- ✅ Auth-broker is the single OAuth refresher per host (RFC H §4.7)
+  — Google plugs in via the provider abstraction (Phase 3b), not
+  a parallel refresher.
 - ✅ `apv:` callback shape unchanged; new tools added to existing
   approval kernel.
 - ✅ `/approvals list|revoke|add|stats` surface unchanged — adding
@@ -440,63 +523,139 @@ Per `reference/principles.md`:
   every other config field.
 - ✅ Setup wizard prompt is in the same style as the bot-token and
   first-agent prompts — opinionated default, easy decline.
+- ✅ "Loud removal beats polite mirror" applied to ACL pruning per
+  RFC H §10's decision against dormant intermediate states.
 
 ## 7. Migration / rollout
 
-Five phases, each independently shippable. Phase 2 is load-bearing;
-the others can land in any order around it.
+**Status:** Phases 1, 2, 3a, 4, 5 have **already merged** to main
+(PRs #1244, #1246, #1247, #1248, #1245). The implementation work
+remaining is **Phase 3b**, which depends on RFC H (PR #1254) being
+merged first.
 
-1. **Phase 1 — Config block + tier knob (no breaking changes).**
-   Generalize `drive:` → `google_workspace:` with the alias.
-   Plumb `tier` through to the MCP subprocess command-line. No
-   change to vault layout. Operators of existing Drive integrations
-   notice nothing. **~45 min.**
-2. **Phase 2 — Per-account vault slot + per-agent ACL (load-
-   bearing).** Add `google_account_grant` ACL primitive to the
-   broker. Wrapper updates to read by account. **Clean cutover, no
-   migration shipped** — `switchroom apply` detects legacy
-   `gdrive:<agent>:refresh_token` slots and **refuses to start the
-   new wrapper**, printing a one-screen explanation pointing the
-   operator at `switchroom auth google account add <account>` +
-   `enable`. Mirrors decision #10 of `share-auth-across-the-fleet.md`
-   ("no migration shipped... no compatibility shims") — RFC D shipped
-   only days ago in v0.6.0; the installed base is small enough that
-   asking those operators to re-add their accounts is the right
-   trade for keeping the design surface clean for everyone after.
-   **~60 min.**
-3. **Phase 3 — CLI verbs (`auth google account add|remove|list`,
-   `auth google enable|disable|list|share`, `auth google connect`
-   wizard alias).** `drive` verbs become thin aliases delegating to
-   `auth google` for Drive-only ops, with a one-line deprecation
-   note in `apply`. **~75 min.**
-4. **Phase 4 — Setup wizard prompt.** Inline Workspace connect
-   after first-agent creation. **~30 min.**
-5. **Phase 5 — `examples/personal-google-workspace-mcp/`.**
-   Compose.yaml + README + .env.example, lifted from the working
-   pair-design setup. **~30 min.**
+### Already shipped
 
-Total: **~3.7 hours agent time** for the full RFC (down from ~5h
-in v1 — Phase 2 dropped 90 min by removing the interactive
-migration tool per the clean-cutover decision).
+1. **Phase 1 — Config block + tier knob (no breaking changes)** —
+   merged #1244. `google_workspace:` block + `drive:` alias + tier
+   enum. Backwards-compatible.
+2. **Phase 2 — Per-account vault slot + per-agent ACL primitive** —
+   merged #1246. New helpers in `src/drive/vault-slots.ts`, ACL
+   routing in `src/vault/broker/acl.ts`, top-level `google_accounts:`
+   schema. **Currently inert** — no code consumes it yet (Phase 3b
+   wires the wrapper read).
+3. **Phase 3a — `auth google enable | disable | list` CLI verbs** —
+   merged #1247. Operators can populate `google_accounts.enabled_for[]`.
+4. **Phase 4 — Setup wizard Step 11** — merged #1248. Prompt only;
+   surfaces the connect command.
+5. **Phase 5 — `examples/personal-google-workspace-mcp/`** —
+   merged #1245. Operator-host docker-compose pattern, fully usable.
+
+### Phase 3b — auth-broker integration (post-RFC-H, post-#1254)
+
+Five sub-phases, each shippable as its own PR. Total ~3.5h agent
+time. **Prerequisite: RFC H (PR #1254) merged to main.**
+
+#### 3b.1 — Provider abstraction in auth-broker (~45 min)
+
+Add `provider:` field to broker's `add-account`, `remove-account`,
+`get-credentials`, `list-state`, `mark-exhausted` verbs. Defaults
+to `"anthropic"` (back-compat with Phase 1 of RFC H). Accepts
+`"google"`. Define provider interface (token endpoint, scope set,
+refresh-request shape, scope-to-grant mapping) in
+`src/auth/broker/provider.ts`.
+
+**Load-bearing for everything that follows.** Without this, the
+broker has no concept of multiple OAuth identities-per-account
+shape (Anthropic is one-set-of-scopes; Google has tier-driven
+scope expansion).
+
+#### 3b.2 — Google provider implementation (~60 min)
+
+Extract OAuth flow from `src/cli/drive.ts:runConnect` (lines
+259-620 in v0.6.0) into `src/auth/broker/google-provider.ts`.
+Implements the provider interface from 3b.1: device-code,
+OOB-paste, desktop-loopback tier-selection (preserves RFC D §3
+semantics); refresh-token exchange against Google OAuth endpoint;
+scope-set-validation against Workspace tier per RFC G Phase 1.
+
+The auth-broker loads provider plugins at startup (similar to how
+the vault-broker loads ACL config). New providers ship as new
+files under `src/auth/broker/<vendor>-provider.ts`.
+
+#### 3b.3 — `auth google account add | remove` CLI (~30 min)
+
+Thin clients in `src/cli/auth-google.ts` (extending the Phase 3a
+file). `add` calls `auth-broker.add-account { provider: "google",
+account: <email>, oauth-result: <tokens> }`; `remove` calls
+`auth-broker.remove-account { provider: "google", account: <email> }`
+which revokes Google OAuth, deletes the vault slot, removes the
+broker refresh lease, and prunes `google_accounts.<email>` from
+YAML.
+
+#### 3b.4 — MCP wrapper credential-read pivot (~30 min)
+
+`src/drive/wrapper.ts` calls `auth-broker.get-credentials {
+provider: "google" }` over the per-agent UDS instead of reading
+`vault:google:<email>:refresh_token` directly via vault-broker.
+Identity is path-as-identity (agent name from socket path); broker
+validates `agent ∈ google_accounts.<acct>.enabled_for[]`.
+
+After 3b.4 lands, the agent containers ARE actually using
+per-account shared tokens with per-agent ACL — the load-bearing
+RFC G goal.
+
+#### 3b.5 — Apply-time legacy-slot migration (~60 min)
+
+`switchroom apply` detects legacy `gdrive:<agent>:refresh_token`
+slots in vault and **hard-refuses** to proceed, printing the
+operator-actionable next step. New `src/auth/migrate-google-slots.ts`
+(mirroring RFC H §6's `src/auth/migrate-schema.ts`) provides a
+one-shot rewrite the operator runs explicitly: reads each legacy
+per-agent slot, prompts "which Google account does this token
+belong to?" (operators of v0.6.0 had per-agent tokens that may or
+may not represent the same Google account), writes the per-account
+slot + populates `google_accounts.<account>.enabled_for[]`, deletes
+the legacy slot.
+
+Mirrors RFC H §6 ("rewrite once, refuse second run") rather than
+the v2 "warn and continue" design — RFC H showed loud-fail is the
+honest default for installed-base migrations.
+
+### Phase 3b sequencing
+
+3b.1 → 3b.2 → 3b.3 → 3b.4 → 3b.5. Each PR independently reviewable;
+each builds on the prior. No interleave shortcuts because the broker
+provider abstraction (3b.1) is genuinely prerequisite to everything
+else.
 
 ## 8. Effort estimate
 
-Per CLAUDE.md, in **agent minutes**:
+Per CLAUDE.md, in **agent minutes**.
 
-| Phase | Item | Estimate |
+### Already shipped
+
+| Phase | Item | Actual | PR |
+|---|---|---|---|
+| 1 | Config block + tier knob + 75 tests | ~45 min | #1244 |
+| 2 | ACL primitive + per-account vault helpers + 41 tests | ~60 min | #1246 |
+| 3a | `auth google enable / disable / list` + 22 YAML mutator tests | ~60 min | #1247 |
+| 4 | Setup wizard Step 11 | ~30 min | #1248 |
+| 5 | Examples dir + README | ~30 min | #1245 |
+
+**~3.75h agent time spent.** Estimates held within ±15%.
+
+### Remaining (Phase 3b, post-RFC-H)
+
+| Sub-phase | Item | Estimate |
 |---|---|---|
-| 1 | Config block + tier knob + cascade tests | ~45 min |
-| 2 | ACL primitive + broker tests + apply-time legacy-slot detector | ~60 min |
-| 2 | MCP wrapper account-based credential read | ~30 min (subset of 60) |
-| 3 | `auth google` CLI verbs + `drive` deprecation alias | ~75 min |
-| 4 | Setup wizard prompt + decline path | ~30 min |
-| 5 | Examples dir + README | ~30 min |
+| 3b.1 | Provider abstraction in auth-broker (provider: field on add/remove/get/list verbs + provider interface) | ~45 min |
+| 3b.2 | Google provider implementation (extract OAuth from drive.ts:runConnect → google-provider.ts) | ~60 min |
+| 3b.3 | `auth google account add / remove` CLI (thin clients over broker) | ~30 min |
+| 3b.4 | MCP wrapper credential-read pivot (vault-broker → auth-broker UDS) | ~30 min |
+| 3b.5 | Apply-time legacy-slot migration tool + hard-refusal | ~60 min |
 | — | Doc updates (`docs/google-workspace.md` new file, RFC cross-refs) | ~30 min |
 
-**~3.7 hours agent time** total (Phase 2 dropped 90 min by
-removing the interactive migration tool per the clean-cutover
-decision in §7). Two-day spread if interspersed with other work;
-one focused day if pushed end-to-end.
+**~4.25h agent time** for Phase 3b. Total RFC G end-to-end: ~8h.
 
 ## 9. Risks and open questions
 
@@ -515,24 +674,23 @@ one focused day if pushed end-to-end.
   unwanted.
 
 - **Approval kernel drift on agent removal.** `disable <account>
-  <agents...>` orphans the agents' standing approvals. Per §4.4
-  they become dormant, not auto-revoked. Risk: if the operator
-  forgets about them, they sit indefinitely. Mitigation: weekly
-  staleness digest (RFC B §9.1) already surfaces dormant grants —
-  `auth google disable` adds a one-line notice listing the
-  about-to-go-dormant grants for the operator to confirm or
-  pre-revoke.
+  <agents...>` orphans the agents' standing approvals — they get
+  `not_authorized` from the broker on next use. Mitigation: the
+  approval-kernel surfaces a single chat nudge identifying the
+  removed-agent + grant + the `auth google enable` command to
+  restore. No "dormant grants pile up" risk because v3 prunes the
+  YAML entry rather than mirror the dormant state.
 
-- **Legacy-slot refusal (Phase 2 cutover) blocks operators
-  mid-flight.** A v0.6.0 operator running `switchroom apply` after
-  Phase 2 lands gets a hard refusal until they re-add their
-  account. If this lands during business hours and the operator
-  is mid-task, they're blocked. Mitigation: ship Phase 2 as a
-  CHANGELOG-headlined breaking change in a minor version bump
-  (v0.7.0 → v0.8.0), not a patch. The v0.7.x branch keeps
-  per-agent slots working for operators not ready to cut over.
-  Pattern is the same as the cron-fold-in cutover (PRs #890–#893)
-  documented in CLAUDE.md.
+- **Legacy-slot migration (Phase 3b.5) on the v0.6.0 → post-RFC-H
+  transition.** A v0.6.0 operator who hand-ran `switchroom drive
+  connect` for multiple agents on the same Google account ends up
+  with N copies of the same refresh token in N per-agent slots.
+  The migration tool needs to ask the operator "which Google
+  account does each per-agent slot belong to?" — there's no
+  programmatic way to know (the slot key is per-agent, not
+  per-account). Mitigation: migration tool prompts interactively;
+  operator with N agents on M accounts answers M times. Falls back
+  to "skip and re-OAuth" if operator can't remember.
 
 - **Tier change after connect.** Going from `core` to `extended`
   doesn't expand granted OAuth scopes — Google's consent already
@@ -563,21 +721,30 @@ one focused day if pushed end-to-end.
 
 ## 10. Tracking
 
-Open one tracking issue per phase, all blocked on this spec
-landing:
+### Shipped
 
-- [ ] Phase 1 — Config block + tier knob + `drive:` alias
-- [ ] Phase 2 — Per-account vault slot + per-agent ACL + apply-time
-  legacy-slot detector (clean cutover, no migration tool)
-- [ ] Phase 3 — `switchroom auth google ...` CLI verbs + `drive`
-  alias deprecation
-- [ ] Phase 4 — Setup wizard inline prompt
-- [ ] Phase 5 — `examples/personal-google-workspace-mcp/`
+- [x] Phase 1 — Config block + tier knob + `drive:` alias — #1244
+- [x] Phase 2 — Per-account vault slot + per-agent ACL primitive — #1246
+- [x] Phase 3a — `auth google enable / disable / list` CLI — #1247
+- [x] Phase 4 — Setup wizard Step 11 — #1248
+- [x] Phase 5 — `examples/personal-google-workspace-mcp/` — #1245
+
+### Pending Phase 3b (post-RFC-H / #1254 merge)
+
+- [ ] Phase 3b.1 — Provider abstraction in auth-broker
+- [ ] Phase 3b.2 — Google provider implementation
+- [ ] Phase 3b.3 — `auth google account add / remove` CLI
+- [ ] Phase 3b.4 — MCP wrapper credential-read pivot to auth-broker UDS
+- [ ] Phase 3b.5 — Apply-time legacy-slot migration tool + hard-refusal
 - [ ] Cross-cutting — `docs/google-workspace.md` user guide
 
-Pairs with:
-- **PR #1227 (RFC E)** — Drive collab loop — orthogonal, both can
-  ship.
-- **RFC F** (deferred, not yet open) — second doc surface (Notion).
-  RFC G's per-account ACL pattern becomes the template when RFC F
-  lands a Notion `notion:<workspace>:*` slot.
+### Pairs with
+
+- **RFC E (Drive collab loop)** — primitives merged: anchors (#1250),
+  diff-preview (#1252), deep-links (#1251), recovery detector (#1249).
+  Followups land the gateway/kernel wiring for those primitives.
+- **RFC H (`switchroom-auth-broker`)** — PR #1254. Phase 3b of
+  this RFC is a downstream consumer of RFC H's broker.
+- **RFC F** (deferred, not yet opened) — second doc surface
+  (Notion candidate). RFC G's per-account ACL pattern becomes
+  the template when Notion lands a `notion:<workspace>:*` slot.

--- a/docs/rfcs/google-workspace-generalization.md
+++ b/docs/rfcs/google-workspace-generalization.md
@@ -21,14 +21,19 @@ RFC H rather than the deleted `auth account ...` shape:
   `auth google disable` now prunes the entry; full teardown via
   `auth google account remove`. See §4.5 + §4.4.
 - **OAuth refresh moves into the auth-broker** as a provider plugin
-  (Phase 3b). RFC H ships `auth.consumers[]` in v1 (decision #1)
-  precisely for non-agent peers needing OAuth credentials — Google
-  accounts are structurally consumers. Rebuilding a parallel
-  refresher in `src/drive/` would duplicate flock leases, sha-index
-  drift detection, and audit log machinery. The vault-broker stays
-  as the durable token-storage layer; auth-broker becomes the
-  single OAuth refresher for both Anthropic AND Google. See §4.4
-  + §7 Phase 3b.
+  (Phase 3b). **Honest framing:** RFC H ships a single-provider
+  broker (Anthropic only). `auth.consumers[]` per RFC H §4.8 is
+  for *non-agent peers needing an Anthropic-account socket*
+  (hindsight is the in-tree consumer), NOT for non-Anthropic OAuth
+  providers. Phase 3b.1 introduces a provider abstraction RFC H
+  deliberately deferred — this is a real architectural addition,
+  not a config-flag wiring exercise. The motivation stands:
+  rebuilding a parallel refresher in `src/drive/` would duplicate
+  flock leases, sha-index drift detection, and audit log machinery
+  the broker already implements. The vault-broker stays as the
+  durable token-storage layer; auth-broker grows a provider
+  abstraction so it becomes the single OAuth refresher for both
+  Anthropic AND Google. See §4.4 + §7 Phase 3b.
 - **MCP wrapper credential-read pivots to `auth-broker.get-credentials
   { provider: "google" }`** over UDS, mirroring the same path-as-
   identity pattern Anthropic uses post-RFC-H. Replaces direct
@@ -231,10 +236,15 @@ manifest; unknown tool names fail fast with the suggestion list.
   at `vault:google:<account>:refresh_token`. The vault file is the
   single source of truth at rest.
 - **auth-broker** (RFC H) — sole OAuth refresher and credentials
-  writer. Owns the refresh loop for both Anthropic AND Google
-  accounts via the provider abstraction added in Phase 3b. Reads
-  refresh tokens from vault-broker, runs the refresh tick, exposes
-  short-lived access tokens to consumers via UDS.
+  writer. As shipped by RFC H, supports Anthropic only.
+  Phase 3b.1 of *this* RFC adds the provider abstraction the
+  broker needs to host Google as a second provider — RFC H
+  deliberately scoped the broker to Anthropic-only ("speaks OAuth
+  and only OAuth" per RFC H §3); the multi-provider extension
+  is RFC G's contribution, not RFC H's. Once 3b.1 lands the
+  broker reads refresh tokens from vault-broker for both providers,
+  runs per-provider refresh ticks, exposes short-lived access
+  tokens to consumers via UDS.
 
 **Vault slot key shape** (Phase 2, already merged):
 
@@ -555,32 +565,54 @@ merged first.
 Five sub-phases, each shippable as its own PR. Total ~3.5h agent
 time. **Prerequisite: RFC H (PR #1254) merged to main.**
 
-#### 3b.1 — Provider abstraction in auth-broker (~45 min)
+#### 3b.1 — Provider abstraction in auth-broker (~90-120 min)
 
-Add `provider:` field to broker's `add-account`, `remove-account`,
-`get-credentials`, `list-state`, `mark-exhausted` verbs. Defaults
-to `"anthropic"` (back-compat with Phase 1 of RFC H). Accepts
-`"google"`. Define provider interface (token endpoint, scope set,
-refresh-request shape, scope-to-grant mapping) in
-`src/auth/broker/provider.ts`.
+This is real architectural work, not a config-flag wiring exercise.
+Scope:
 
-**Load-bearing for everything that follows.** Without this, the
-broker has no concept of multiple OAuth identities-per-account
-shape (Anthropic is one-set-of-scopes; Google has tier-driven
-scope expansion).
+- New `src/auth/broker/provider.ts` defining the provider interface:
+  token endpoint, refresh-request shape, scope set, scope-to-grant
+  mapping, error mapping (provider-specific OAuth error codes →
+  broker's `invalid_grant` / `network` / `quota_exceeded`).
+- Provider plugin loading at broker startup (mirrors how the
+  vault-broker loads ACL config) — providers ship as files under
+  `src/auth/broker/<vendor>-provider.ts`.
+- Per-provider refresh tick — RFC H's existing flock-protected
+  lease primitive needs to key on `(provider, account)`, not just
+  `account`, since two accounts named the same string under
+  different providers must be independent.
+- Per-provider scope-set storage — Anthropic's scopes are
+  one-fixed-set; Google's are tier-driven and expand on re-OAuth.
+  Storage shape needs to handle both.
+- `provider:` field on every relevant verb (`add-account`,
+  `remove-account`, `get-credentials`, `list-state`,
+  `mark-exhausted`). Defaults to `"anthropic"` (back-compat with
+  RFC H Phase 1). Accepts `"google"`.
+- Test surface: every existing broker test that exercises the
+  verbs needs a Google variant; new tests for provider isolation
+  (account `"x@y.z"` in Anthropic provider does NOT collide with
+  account `"x@y.z"` in Google provider).
 
-#### 3b.2 — Google provider implementation (~60 min)
+**Load-bearing for everything that follows.** Without this, 3b.2
+through 3b.5 cannot be cleanly built.
+
+#### 3b.2 — Google provider implementation (~90 min)
 
 Extract OAuth flow from `src/cli/drive.ts:runConnect` (lines
-259-620 in v0.6.0) into `src/auth/broker/google-provider.ts`.
-Implements the provider interface from 3b.1: device-code,
-OOB-paste, desktop-loopback tier-selection (preserves RFC D §3
-semantics); refresh-token exchange against Google OAuth endpoint;
-scope-set-validation against Workspace tier per RFC G Phase 1.
+259-620 in v0.6.0, ~360 LOC) into
+`src/auth/broker/google-provider.ts`. Implements the provider
+interface from 3b.1:
 
-The auth-broker loads provider plugins at startup (similar to how
-the vault-broker loads ACL config). New providers ship as new
-files under `src/auth/broker/<vendor>-provider.ts`.
+- Device-code, OOB-paste, desktop-loopback tier-selection
+  (preserves RFC D §3 semantics).
+- Refresh-token exchange against Google OAuth endpoint.
+- Scope-set-validation against Workspace tier per RFC G Phase 1.
+- Google-specific error mapping (Google returns `invalid_grant`
+  for scope-revocation AND for password-change AND for
+  app-revocation; broker error contract needs to surface these
+  distinctly so 3b.4 can drive the right user message).
+- Test surface: replay-style tests against captured Google OAuth
+  responses for each error class.
 
 #### 3b.3 — `auth google account add | remove` CLI (~30 min)
 
@@ -621,12 +653,27 @@ Mirrors RFC H §6 ("rewrite once, refuse second run") rather than
 the v2 "warn and continue" design — RFC H showed loud-fail is the
 honest default for installed-base migrations.
 
+#### 3b.6 — Setup wizard pivot to two-step `account add` + `enable` (~10 min)
+
+The shipped Phase 4 (`src/cli/setup.ts:1112-1200`) explicitly
+anticipates `auth google connect <agent>` as a future surfaced
+command — but v3 §4.5 deletes that verb. Phase 3b.6 rewrites the
+`connectCmd` constant + the surrounding comment block in
+`stepGoogleWorkspace` to surface the two-step shape per §4.6:
+
+```
+switchroom auth google account add <your-email>
+switchroom auth google enable <your-email> <agent>
+```
+
+Small, isolated, can ship alongside 3b.3 if convenient.
+
 ### Phase 3b sequencing
 
-3b.1 → 3b.2 → 3b.3 → 3b.4 → 3b.5. Each PR independently reviewable;
-each builds on the prior. No interleave shortcuts because the broker
-provider abstraction (3b.1) is genuinely prerequisite to everything
-else.
+3b.1 → 3b.2 → 3b.3 → 3b.4 → 3b.5 (with 3b.6 piggybacking on 3b.3).
+Each PR independently reviewable; each builds on the prior. No
+interleave shortcuts because the broker provider abstraction
+(3b.1) is genuinely prerequisite to everything else.
 
 ## 8. Effort estimate
 
@@ -648,14 +695,18 @@ Per CLAUDE.md, in **agent minutes**.
 
 | Sub-phase | Item | Estimate |
 |---|---|---|
-| 3b.1 | Provider abstraction in auth-broker (provider: field on add/remove/get/list verbs + provider interface) | ~45 min |
-| 3b.2 | Google provider implementation (extract OAuth from drive.ts:runConnect → google-provider.ts) | ~60 min |
+| 3b.1 | Provider abstraction in auth-broker (interface + plugin loading + per-(provider,account) refresh leases + verb extension + isolation tests) | ~90-120 min |
+| 3b.2 | Google provider implementation (extract OAuth from drive.ts:runConnect, ~360 LOC + Google-specific error mapping + replay tests) | ~90 min |
 | 3b.3 | `auth google account add / remove` CLI (thin clients over broker) | ~30 min |
 | 3b.4 | MCP wrapper credential-read pivot (vault-broker → auth-broker UDS) | ~30 min |
-| 3b.5 | Apply-time legacy-slot migration tool + hard-refusal | ~60 min |
+| 3b.5 | Apply-time legacy-slot migration tool + hard-refusal (interactive prompts for account-attribution per legacy slot) | ~60 min |
+| 3b.6 | Setup wizard pivot to two-step `account add` + `enable` (rewrite connectCmd in setup.ts) | ~10 min |
 | — | Doc updates (`docs/google-workspace.md` new file, RFC cross-refs) | ~30 min |
 
-**~4.25h agent time** for Phase 3b. Total RFC G end-to-end: ~8h.
+**~5.75-6.5h agent time** for Phase 3b. Total RFC G end-to-end:
+~9.5-10.25h. (v3-initial estimate of ~4.25h was too aggressive
+per reviewer — provider abstraction is real architectural work,
+not a config-flag wiring exercise.)
 
 ## 9. Risks and open questions
 
@@ -688,9 +739,25 @@ Per CLAUDE.md, in **agent minutes**.
   The migration tool needs to ask the operator "which Google
   account does each per-agent slot belong to?" — there's no
   programmatic way to know (the slot key is per-agent, not
-  per-account). Mitigation: migration tool prompts interactively;
-  operator with N agents on M accounts answers M times. Falls back
-  to "skip and re-OAuth" if operator can't remember.
+  per-account). Mitigation: migration tool prompts interactively
+  AND surfaces the legacy slot's cached scope set + last-refresh
+  timestamp in the prompt — these are the only on-disk hints
+  for identifying which Google account is which. Falls back to
+  "skip and re-OAuth" if operator can't remember.
+
+- **Inheritance of RFC H known-blocker class.** PR #1254 (RFC H)
+  was reviewed with three blockers, including: *"`auth use` does
+  not persist `auth.active` to YAML — the broker mutates
+  in-memory only, so on any restart it re-reads YAML and the
+  swap reverts."* Phase 3b.3 (`auth google account add / remove`)
+  writes `google_accounts:` to YAML and expects the broker to
+  pick up the new account. If RFC H ships with the YAML-persist
+  bug unfixed, Phase 3b.3 inherits the same SIGHUP/reload
+  assumption. Mitigation: **Phase 3b.3 blocks on the
+  CLI-writes-YAML-first contract being enforced in #1254**.
+  Confirm before starting 3b.3 that `auth use` (and any
+  comparable verb) writes YAML before notifying the broker, then
+  mirror the same pattern in `auth google account add / remove`.
 
 - **Tier change after connect.** Going from `core` to `extended`
   doesn't expand granted OAuth scopes — Google's consent already
@@ -733,9 +800,11 @@ Per CLAUDE.md, in **agent minutes**.
 
 - [ ] Phase 3b.1 — Provider abstraction in auth-broker
 - [ ] Phase 3b.2 — Google provider implementation
-- [ ] Phase 3b.3 — `auth google account add / remove` CLI
+- [ ] Phase 3b.3 — `auth google account add / remove` CLI (blocks
+      on RFC H's CLI-writes-YAML-first contract — see §9)
 - [ ] Phase 3b.4 — MCP wrapper credential-read pivot to auth-broker UDS
 - [ ] Phase 3b.5 — Apply-time legacy-slot migration tool + hard-refusal
+- [ ] Phase 3b.6 — Setup wizard pivot in `setup.ts:stepGoogleWorkspace`
 - [ ] Cross-cutting — `docs/google-workspace.md` user guide
 
 ### Pairs with


### PR DESCRIPTION
## Summary

Spec-only PR. Aligns RFC G with RFC H (PR #1254 — \`switchroom-auth-broker\`), the canonical Anthropic-auth refactor that the user explicitly designated as authoritative.

RFC H replaced the per-agent slot-pool model that RFC G v2 mirrored. Rather than preserving a dead pattern, v3 reshapes RFC G to:

1. **Plug Google OAuth into the auth-broker** as a provider — single refresh implementation per host (RFC H §4.7's flock-protected lease primitive). Vault-broker stays as durable token storage; auth-broker becomes the sole OAuth refresher for both Anthropic AND Google.
2. **Drop deleted-by-RFC-H verbs** — \`auth google share\` and \`auth google connect <agent>\` are gone, mirroring the deleted Anthropic \`auth share\` and \`auth login\`. Surface collapses to \`enable | disable | list\` (Phase 3a, shipped) + \`account add | remove\` (Phase 3b, pending).
3. **Loud removal beats polite mirror** — \`auth google disable\` prunes the YAML entry when \`enabled_for\` empties; no "dormant ACL" intermediate state. Per RFC H §10's design philosophy.
4. **Setup wizard pivots** — Step 11 surfaces the two-step \`auth google account add\` + \`auth google enable\` pattern, mirroring RFC H §4.6's \`auth add\` + \`auth use\`.
5. **Phase 3b decomposed into 5 sub-phases** (3b.1 through 3b.5) each shippable as its own PR, gated on #1254 merging.

## Critical: where this diverges from RFC H

Anthropic and Google solve different problems:

- **Anthropic auth** = quota routing (which account is the fleet-wide active one)
- **Google auth** = per-account access ACL (which agents can read this account's Drive token)

RFC H's \`auth.active\` + \`auth.override\` shape fits quota routing. RFC G's \`google_accounts.<email>.enabled_for[]\` shape fits per-account ACL. The patterns are *allowed* to diverge — §6.3 makes this explicit so the next reviewer doesn't try to force them into one shape.

## What's already merged vs pending

**Already shipped:**
- Phase 1 (#1244), Phase 2 (#1246), Phase 3a (#1247), Phase 4 (#1248), Phase 5 (#1245)
- All RFC E primitives: anchors (#1250), diff-preview (#1252), deep-links (#1251), recovery detector (#1249)

**Pending Phase 3b** (requires #1254 merged first):
- 3b.1 — provider abstraction in auth-broker (~45min, load-bearing)
- 3b.2 — Google provider implementation (~60min)
- 3b.3 — \`auth google account add | remove\` CLI (~30min)
- 3b.4 — MCP wrapper credential-read pivot (~30min)
- 3b.5 — apply-time legacy-slot migration tool (~60min)

**~4.25h Phase 3b agent time remaining.** Total RFC G end-to-end: ~8h.

## Test plan

- [x] Spec is internally consistent — \`v3 changes\` block at top matches the actual §4.4/§4.5/§4.6/§7/§8/§9/§10 edits
- [x] Section cross-references resolve correctly
- [x] Effort table accurate against shipped PRs (held within ±15% of estimates)
- [ ] Independent reviewer verdict (will dispatch after PR open)

## Sequencing

This PR should land **before** Phase 3b implementation work begins, so the spec is the ground truth when the implementation PRs come up for review. Order: this → #1254 merges → 3b.1 → 3b.2 → 3b.3 → 3b.4 → 3b.5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)