### PR TITLE
feat(auth-broker): RFC G Phase 3b.1 — provider abstraction (interface + protocol field)

### DIFF
--- a/src/auth/broker/protocol.test.ts
+++ b/src/auth/broker/protocol.test.ts
@@ -80,3 +80,172 @@ describe("protocol encode/decode", () => {
     ).toThrow(/MAX_FRAME_BYTES/);
   });
 });
+
+// ────────────────────────────────────────────────────────────────────────
+// RFC G Phase 3b.1 — provider field on per-account verbs
+// ────────────────────────────────────────────────────────────────────────
+
+describe("provider: field (RFC G Phase 3b.1) — back-compat + new providers", () => {
+  it("set-active accepts requests WITHOUT provider field (back-compat with RFC H clients)", () => {
+    const line = encodeRequest({ v: 1, id: "x", op: "set-active", account: "default" });
+    const back = decodeRequest(line);
+    expect(back.op).toBe("set-active");
+    if (back.op === "set-active") {
+      expect(back.provider).toBeUndefined();
+    }
+  });
+
+  it("set-active accepts provider: 'anthropic' (explicit default)", () => {
+    const back = decodeRequest(encodeRequest({
+      v: 1, id: "x", op: "set-active", account: "default", provider: "anthropic",
+    }));
+    expect(back.op).toBe("set-active");
+    if (back.op === "set-active") {
+      expect(back.provider).toBe("anthropic");
+    }
+  });
+
+  it("set-active accepts provider: 'google' on the wire (server may reject)", () => {
+    const back = decodeRequest(encodeRequest({
+      v: 1, id: "x", op: "set-active", account: "alice@example.com", provider: "google",
+    }));
+    if (back.op === "set-active") {
+      expect(back.provider).toBe("google");
+    }
+  });
+
+  it("rejects unknown provider names", () => {
+    const bad = JSON.stringify({
+      v: 1, id: "x", op: "set-active", account: "x", provider: "openai",
+    });
+    expect(() => decodeRequest(bad)).toThrow();
+  });
+
+  it("refresh-account carries provider field with same back-compat semantics", () => {
+    const noProvider = decodeRequest(encodeRequest({
+      v: 1, id: "x", op: "refresh-account", account: "default",
+    }));
+    if (noProvider.op === "refresh-account") {
+      expect(noProvider.provider).toBeUndefined();
+    }
+    const google = decodeRequest(encodeRequest({
+      v: 1, id: "x", op: "refresh-account", account: "alice@example.com", provider: "google",
+    }));
+    if (google.op === "refresh-account") {
+      expect(google.provider).toBe("google");
+    }
+  });
+
+  it("rm-account carries provider field with same back-compat semantics", () => {
+    const noProvider = decodeRequest(encodeRequest({
+      v: 1, id: "x", op: "rm-account", label: "default",
+    }));
+    if (noProvider.op === "rm-account") {
+      expect(noProvider.provider).toBeUndefined();
+    }
+    const google = decodeRequest(encodeRequest({
+      v: 1, id: "x", op: "rm-account", label: "alice@example.com", provider: "google",
+    }));
+    if (google.op === "rm-account") {
+      expect(google.provider).toBe("google");
+    }
+  });
+});
+
+describe("add-account credentials union (RFC G Phase 3b.1)", () => {
+  const anthropicCreds = {
+    claudeAiOauth: {
+      accessToken: "at",
+      refreshToken: "rt",
+      expiresAt: 1234,
+    },
+  };
+
+  const googleCreds = {
+    googleOauth: {
+      accessToken: "at-google",
+      refreshToken: "rt-google",
+      expiresAt: 5678,
+      scope: "https://www.googleapis.com/auth/drive",
+      clientId: "client-id-x",
+      accountEmail: "alice@example.com",
+      tokenType: "Bearer" as const,
+    },
+  };
+
+  it("accepts Anthropic-shaped credentials with no provider field (back-compat)", () => {
+    const back = decodeRequest(encodeRequest({
+      v: 1, id: "x", op: "add-account", label: "default",
+      credentials: anthropicCreds,
+    }));
+    expect(back.op).toBe("add-account");
+    if (back.op === "add-account") {
+      expect(back.provider).toBeUndefined();
+      expect("claudeAiOauth" in back.credentials).toBe(true);
+    }
+  });
+
+  it("accepts Anthropic-shaped credentials with provider: 'anthropic'", () => {
+    const back = decodeRequest(encodeRequest({
+      v: 1, id: "x", op: "add-account", label: "default",
+      provider: "anthropic", credentials: anthropicCreds,
+    }));
+    if (back.op === "add-account") {
+      expect(back.provider).toBe("anthropic");
+    }
+  });
+
+  it("accepts Google-shaped credentials with provider: 'google'", () => {
+    const back = decodeRequest(encodeRequest({
+      v: 1, id: "x", op: "add-account", label: "alice@example.com",
+      provider: "google", credentials: googleCreds,
+    }));
+    if (back.op === "add-account") {
+      expect(back.provider).toBe("google");
+      expect("googleOauth" in back.credentials).toBe(true);
+    }
+  });
+
+  it("rejects malformed credentials (neither claudeAiOauth nor googleOauth)", () => {
+    const bad = JSON.stringify({
+      v: 1, id: "x", op: "add-account", label: "x",
+      credentials: { wrongShape: {} },
+    });
+    expect(() => decodeRequest(bad)).toThrow();
+  });
+
+  it("rejects Google credentials missing required fields", () => {
+    const bad = JSON.stringify({
+      v: 1, id: "x", op: "add-account", label: "x", provider: "google",
+      credentials: { googleOauth: { accessToken: "at" } }, // missing refreshToken, etc
+    });
+    expect(() => decodeRequest(bad)).toThrow();
+  });
+
+  it("the schema is a union — server is responsible for cross-checking provider matches credentials shape", () => {
+    // Protocol layer accepts (Anthropic creds + provider:google) since
+    // both are valid sub-shapes — the server enforces the cross-check
+    // and rejects with INVALID_ARGS. This pins that the schema layer
+    // doesn't pre-empt the server's check.
+    const back = decodeRequest(encodeRequest({
+      v: 1, id: "x", op: "add-account", label: "x", provider: "google",
+      credentials: anthropicCreds, // mismatch
+    }));
+    expect(back.op).toBe("add-account");
+    // Decoded successfully; server-side check fires on receive.
+  });
+});
+
+describe("DEFAULT_PROVIDER constant + ProviderNameSchema enum", () => {
+  it("DEFAULT_PROVIDER is 'anthropic' (RFC H back-compat)", async () => {
+    const { DEFAULT_PROVIDER } = await import("./protocol.js");
+    expect(DEFAULT_PROVIDER).toBe("anthropic");
+  });
+
+  it("ProviderNameSchema accepts the v1 provider enum", async () => {
+    const { ProviderNameSchema } = await import("./protocol.js");
+    expect(ProviderNameSchema.parse("anthropic")).toBe("anthropic");
+    expect(ProviderNameSchema.parse("google")).toBe("google");
+    expect(() => ProviderNameSchema.parse("unknown")).toThrow();
+  });
+});

--- a/src/auth/broker/protocol.ts
+++ b/src/auth/broker/protocol.ts
@@ -26,6 +26,19 @@
  * affects is derived from path-identity. This closes the
  * fleet-wide spurious-deauth abuse path the round-1 review
  * flagged.
+ *
+ * **Provider field (RFC G Phase 3b.1):** Per-account verbs accept an
+ * optional `provider:` field. When absent or `"anthropic"`, behavior
+ * is unchanged from RFC H. When `"google"` (added by Phase 3b.2),
+ * the broker dispatches through the Google provider. Per-account
+ * state is keyed on `(provider, account)` so an account named
+ * `"alice@example.com"` registered as Google does not collide with
+ * an Anthropic account label of the same string.
+ *
+ * `get-credentials` and `mark-exhausted` derive provider+account
+ * from path-identity (the broker knows which provider an agent or
+ * consumer is bound to from its socket-mount config), so they don't
+ * take a `provider:` field on the wire.
  */
 
 import { z } from "zod";
@@ -38,6 +51,21 @@ export const MAX_FRAME_BYTES = 64 * 1024;
 
 /** Wire-protocol major version. Bump on breaking change to envelope shape. */
 export const PROTOCOL_VERSION = 1;
+
+/**
+ * Provider names accepted on the wire (RFC G Phase 3b.1). New providers
+ * extend this enum; the broker server validates incoming `provider:`
+ * fields against it before dispatching.
+ */
+export const ProviderNameSchema = z.enum(["anthropic", "google"]);
+export type ProviderName = z.infer<typeof ProviderNameSchema>;
+
+/**
+ * Default provider — `"anthropic"`. Used when verbs omit the
+ * `provider:` field entirely (back-compat with RFC H pre-Phase-3b
+ * clients).
+ */
+export const DEFAULT_PROVIDER: ProviderName = "anthropic";
 
 // ─── Request schemas ───────────────────────────────────────────────────────
 
@@ -58,6 +86,17 @@ export const SetActiveRequestSchema = z.object({
   op: z.literal("set-active"),
   id: z.string().min(1),
   account: z.string().min(1),
+  /**
+   * Provider for the target account. Optional, defaults to
+   * `"anthropic"` (back-compat with RFC H pre-Phase-3b clients).
+   * `set-active` is fleet-wide active-account swap which is currently
+   * an Anthropic-only concept; Google's account-active model is
+   * per-agent-via-`google_accounts.enabled_for[]`. This field is
+   * carried for protocol uniformity even though `set-active` will
+   * reject `provider: "google"` until/unless a fleet-wide-active
+   * Google concept is added.
+   */
+  provider: ProviderNameSchema.optional(),
 });
 
 export const MarkExhaustedRequestSchema = z.object({
@@ -73,24 +112,81 @@ export const RefreshAccountRequestSchema = z.object({
   op: z.literal("refresh-account"),
   id: z.string().min(1),
   account: z.string().min(1),
+  /** Provider for the target account. Defaults to `"anthropic"` for back-compat. */
+  provider: ProviderNameSchema.optional(),
 });
+
+/**
+ * Anthropic-shaped credentials — the Phase-1 (RFC H) shape. Stored
+ * verbatim under `claudeAiOauth: { ... }`.
+ */
+export const AnthropicCredentialsSchema = z.object({
+  claudeAiOauth: z.object({
+    accessToken: z.string(),
+    refreshToken: z.string().optional(),
+    expiresAt: z.number().optional(),
+    scopes: z.array(z.string()).optional(),
+    subscriptionType: z.string().optional(),
+    rateLimitTier: z.string().optional(),
+  }),
+});
+export type AnthropicCredentialsShape = z.infer<typeof AnthropicCredentialsSchema>;
+
+/**
+ * Google-shaped credentials — added by Phase 3b.2. Stored verbatim
+ * under `googleOauth: { ... }`. Field set mirrors what
+ * `taylorwilsdon/google_workspace_mcp` and the Google OAuth 2.0
+ * token-exchange response provide.
+ */
+export const GoogleCredentialsSchema = z.object({
+  googleOauth: z.object({
+    accessToken: z.string(),
+    refreshToken: z.string(),
+    expiresAt: z.number(),
+    /** Granted scope set, space-separated as Google returns it. */
+    scope: z.string(),
+    /** OAuth client id used to obtain the credentials (broker validates on refresh). */
+    clientId: z.string(),
+    /** Account email — RFC G's per-account ACL key. */
+    accountEmail: z.string(),
+    tokenType: z.literal("Bearer"),
+  }),
+});
+export type GoogleCredentialsShape = z.infer<typeof GoogleCredentialsSchema>;
+
+/**
+ * Provider-discriminated credentials union. Each variant is the
+ * verbatim on-disk shape for that provider. Broker stores credentials
+ * pass-through; consumers (CLI, MCP wrapper) introspect.
+ */
+export const ProviderCredentialsSchema = z.union([
+  AnthropicCredentialsSchema,
+  GoogleCredentialsSchema,
+]);
+export type ProviderCredentialsShape = z.infer<typeof ProviderCredentialsSchema>;
 
 export const AddAccountRequestSchema = z.object({
   v: z.literal(PROTOCOL_VERSION),
   op: z.literal("add-account"),
   id: z.string().min(1),
   label: z.string().min(1),
-  /** Full credentials.json shape; broker stores verbatim. */
-  credentials: z.object({
-    claudeAiOauth: z.object({
-      accessToken: z.string(),
-      refreshToken: z.string().optional(),
-      expiresAt: z.number().optional(),
-      scopes: z.array(z.string()).optional(),
-      subscriptionType: z.string().optional(),
-      rateLimitTier: z.string().optional(),
-    }),
-  }),
+  /**
+   * Provider for the new account. Defaults to `"anthropic"` for
+   * back-compat — RFC H pre-Phase-3b clients omit this field and
+   * pass Anthropic credentials.
+   *
+   * The provider field MUST agree with the credentials shape:
+   * `provider: "anthropic"` requires `claudeAiOauth: { ... }`,
+   * `provider: "google"` requires `googleOauth: { ... }`. Server
+   * validates this agreement and rejects with INVALID_ARGS otherwise.
+   */
+  provider: ProviderNameSchema.optional(),
+  /**
+   * Full credentials.json shape for the provider; broker stores verbatim.
+   * Schema is a union over provider variants — the server validates the
+   * variant matches `provider:` (or `DEFAULT_PROVIDER`).
+   */
+  credentials: ProviderCredentialsSchema,
   /** Replace an existing account (used for drift recovery). */
   replace: z.boolean().optional(),
 });
@@ -100,6 +196,8 @@ export const RmAccountRequestSchema = z.object({
   op: z.literal("rm-account"),
   id: z.string().min(1),
   label: z.string().min(1),
+  /** Provider for the account. Defaults to `"anthropic"` for back-compat. */
+  provider: ProviderNameSchema.optional(),
 });
 
 export const SetOverrideRequestSchema = z.object({

--- a/src/auth/broker/provider.test.ts
+++ b/src/auth/broker/provider.test.ts
@@ -1,0 +1,215 @@
+/**
+ * Tests for the provider abstraction (RFC G Phase 3b.1).
+ *
+ * Covers the `Provider` interface contract via a fixture provider, the
+ * `AccountKey` composite-key utilities, and the `ProviderRegistry`
+ * register/lookup/has/names surface.
+ *
+ * The actual Anthropic + Google providers are implemented in Phase
+ * 3b.1b (server refactor) and Phase 3b.2 (Google provider). This file
+ * pins the contract those implementations must honor.
+ */
+
+import { describe, expect, it } from "bun:test";
+
+import {
+  accountKeyString,
+  ProviderRegistry,
+  type AccountKey,
+  type Provider,
+  type ProviderName,
+  type RefreshRequest,
+  type RefreshResult,
+} from "./provider.js";
+
+// ────────────────────────────────────────────────────────────────────────
+// Fixture provider — minimal implementation for testing the registry
+// + interface contract.
+// ────────────────────────────────────────────────────────────────────────
+
+function makeFixtureProvider(name: ProviderName, opts: {
+  refreshResult?: RefreshResult;
+  expiresAt?: number;
+  invalidShape?: boolean;
+} = {}): Provider {
+  return {
+    name,
+    async refresh(_req: RefreshRequest): Promise<RefreshResult> {
+      return opts.refreshResult ?? {
+        ok: true,
+        accessToken: "fixture-access",
+        expiresAt: opts.expiresAt ?? Date.now() + 3600_000,
+        rawCredentials: {},
+      };
+    },
+    extractExpiresAt(creds: unknown): number | undefined {
+      return (creds as { expiresAt?: number })?.expiresAt;
+    },
+    validateCredentialShape(creds: unknown): string | null {
+      if (opts.invalidShape) return "fixture provider rejects all shapes";
+      if (!creds || typeof creds !== "object") return "credentials must be an object";
+      return null;
+    },
+  };
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// AccountKey + accountKeyString
+// ────────────────────────────────────────────────────────────────────────
+
+describe("accountKeyString — composite (provider, account) encoding", () => {
+  it("encodes anthropic accounts as 'anthropic:<label>'", () => {
+    expect(accountKeyString({ provider: "anthropic", account: "default" })).toBe(
+      "anthropic:default",
+    );
+  });
+
+  it("encodes google accounts as 'google:<email>'", () => {
+    expect(
+      accountKeyString({ provider: "google", account: "alice@example.com" }),
+    ).toBe("google:alice@example.com");
+  });
+
+  it("the same account label under different providers produces different keys (collision avoidance)", () => {
+    // Load-bearing for the broker's per-(provider, account) state map.
+    // Without this, an Anthropic account labeled "alice@example.com"
+    // would collide with a Google account named "alice@example.com".
+    const a: AccountKey = { provider: "anthropic", account: "alice@example.com" };
+    const g: AccountKey = { provider: "google", account: "alice@example.com" };
+    expect(accountKeyString(a)).not.toBe(accountKeyString(g));
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────
+// ProviderRegistry
+// ────────────────────────────────────────────────────────────────────────
+
+describe("ProviderRegistry", () => {
+  it("registers and looks up a single provider", () => {
+    const reg = new ProviderRegistry();
+    const anthropic = makeFixtureProvider("anthropic");
+    reg.register(anthropic);
+    expect(reg.lookup("anthropic")).toBe(anthropic);
+  });
+
+  it("registers two providers and looks up each independently", () => {
+    const reg = new ProviderRegistry();
+    const anthropic = makeFixtureProvider("anthropic");
+    const google = makeFixtureProvider("google");
+    reg.register(anthropic);
+    reg.register(google);
+    expect(reg.lookup("anthropic")).toBe(anthropic);
+    expect(reg.lookup("google")).toBe(google);
+    expect(reg.lookup("anthropic")).not.toBe(google);
+  });
+
+  it("rejects double-registration of the same provider name (single-instance invariant)", () => {
+    const reg = new ProviderRegistry();
+    reg.register(makeFixtureProvider("anthropic"));
+    expect(() => reg.register(makeFixtureProvider("anthropic"))).toThrow(
+      /already registered/,
+    );
+  });
+
+  it("lookup throws on unknown provider with operator-actionable message", () => {
+    const reg = new ProviderRegistry();
+    reg.register(makeFixtureProvider("anthropic"));
+    expect(() => reg.lookup("google")).toThrow(/'google' is not registered/);
+  });
+
+  it("has() returns true for registered providers, false for unknown", () => {
+    const reg = new ProviderRegistry();
+    reg.register(makeFixtureProvider("google"));
+    expect(reg.has("google")).toBe(true);
+    expect(reg.has("anthropic")).toBe(false);
+  });
+
+  it("names() returns registered provider names", () => {
+    const reg = new ProviderRegistry();
+    expect(reg.names()).toEqual([]);
+    reg.register(makeFixtureProvider("anthropic"));
+    reg.register(makeFixtureProvider("google"));
+    expect(reg.names().sort()).toEqual(["anthropic", "google"]);
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────
+// Provider contract — what every implementation must honor
+// ────────────────────────────────────────────────────────────────────────
+
+describe("Provider interface contract (pinned via fixture)", () => {
+  it("refresh returns RefreshSuccess with accessToken + expiresAt + rawCredentials", async () => {
+    const p = makeFixtureProvider("anthropic", { expiresAt: 12345 });
+    const r = await p.refresh({ refreshToken: "rt" });
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.accessToken).toBe("fixture-access");
+      expect(r.expiresAt).toBe(12345);
+      expect(r.rawCredentials).toBeDefined();
+    }
+  });
+
+  it("refresh can return RefreshFailure with kind + detail (broker maps to REFRESH_FAILED)", async () => {
+    const p = makeFixtureProvider("anthropic", {
+      refreshResult: { ok: false, kind: "invalid_grant", detail: "rotated" },
+    });
+    const r = await p.refresh({ refreshToken: "rt" });
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.kind).toBe("invalid_grant");
+      expect(r.detail).toBe("rotated");
+    }
+  });
+
+  it("refresh accepts optional clientId + scopes (Google needs them, Anthropic doesn't)", async () => {
+    const p = makeFixtureProvider("google");
+    const r = await p.refresh({
+      refreshToken: "rt",
+      clientId: "client-id",
+      scopes: ["drive", "docs"],
+    });
+    expect(r.ok).toBe(true);
+  });
+
+  it("extractExpiresAt returns the expiry from credential shape", () => {
+    const p = makeFixtureProvider("anthropic");
+    expect(p.extractExpiresAt({ expiresAt: 9999 })).toBe(9999);
+    expect(p.extractExpiresAt({})).toBeUndefined();
+    expect(p.extractExpiresAt(null)).toBeUndefined();
+  });
+
+  it("validateCredentialShape returns null on valid shapes", () => {
+    const p = makeFixtureProvider("anthropic");
+    expect(p.validateCredentialShape({ accessToken: "x" })).toBeNull();
+  });
+
+  it("validateCredentialShape returns a string error on invalid shapes", () => {
+    const p = makeFixtureProvider("anthropic");
+    expect(p.validateCredentialShape("not-an-object")).toContain("must be");
+    const strict = makeFixtureProvider("anthropic", { invalidShape: true });
+    expect(strict.validateCredentialShape({})).toContain("rejects");
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────
+// Refresh failure kinds — pin the discriminant set so downstream UX
+// (CLI / MCP wrapper) can rely on the values being stable.
+// ────────────────────────────────────────────────────────────────────────
+
+describe("RefreshErrorKind discriminant set", () => {
+  it("supports the four documented kinds", () => {
+    const kinds: Array<RefreshResult> = [
+      { ok: false, kind: "invalid_grant", detail: "" },
+      { ok: false, kind: "network", detail: "" },
+      { ok: false, kind: "quota_exceeded", detail: "" },
+      { ok: false, kind: "provider_error", detail: "" },
+    ];
+    for (const r of kinds) {
+      expect(r.ok).toBe(false);
+      if (!r.ok) {
+        // TS narrows kind to the union; this just exercises every variant.
+        expect(typeof r.kind).toBe("string");
+      }
+    }
+  });
+});

--- a/src/auth/broker/provider.ts
+++ b/src/auth/broker/provider.ts
@@ -51,8 +51,13 @@
  * Adding a new provider is a deliberate enum extension — operators
  * can't accidentally type a wrong provider name. Future Notion / Slack
  * providers extend this.
+ *
+ * Re-exported from `protocol.ts` so the wire-validation enum and the
+ * TS-side type are guaranteed identical (single source of truth, no
+ * drift risk from defining the union in two places).
  */
-export type ProviderName = "anthropic" | "google";
+export type { ProviderName } from "./protocol.js";
+import type { ProviderName } from "./protocol.js";
 
 /**
  * Composite key for per-account state. Two accounts with the same label

--- a/src/auth/broker/provider.ts
+++ b/src/auth/broker/provider.ts
@@ -1,0 +1,246 @@
+/**
+ * Provider abstraction for the auth-broker (RFC G Phase 3b.1).
+ *
+ * The broker as shipped by RFC H (#1254) is Anthropic-only — `server.ts`
+ * has `claudeAiOauth.expiresAt` references baked throughout, the protocol
+ * has Anthropic's credentials shape on `add-account`, and account state
+ * is keyed on label alone.
+ *
+ * RFC G Phase 3b plugs Google in as a second provider, sharing the
+ * broker's flock-protected refresh leases, sha-index drift detection,
+ * and audit log machinery. To keep two providers from colliding (account
+ * `"x@y.z"` could be a Google account AND an Anthropic account label —
+ * unrelated identities), all per-account state is keyed on
+ * `(provider, account)`.
+ *
+ * **Phase 3b.1a (this file)** defines the contract Phase 3b.2 implements
+ * and Phase 3b.1b's server refactor dispatches through. The server is
+ * still Anthropic-only at this point; the wiring lands in 3b.1b.
+ *
+ * **Provider responsibilities:**
+ *   1. Refresh exchange — turn a refresh token into a fresh access token
+ *      + new refresh token + new expiry. Provider knows its OAuth
+ *      endpoint, request shape, and error codes.
+ *   2. Credential format — define the per-provider on-disk shape
+ *      (Anthropic = `claudeAiOauth: { ... }`, Google = `googleOauth: { ... }`).
+ *      The broker stores credentials verbatim per provider format.
+ *   3. Expiry extraction — given credentials, return the expiry timestamp
+ *      so the broker's threshold-based refresh tick works uniformly.
+ *   4. Error mapping — provider-specific OAuth error codes → broker's
+ *      generic `RefreshError` discriminant. Lets downstream UX (3b.4
+ *      MCP wrapper, 3b.3 CLI) drive the right user message regardless
+ *      of provider.
+ *
+ * **What providers DON'T own:**
+ *   - On-disk storage (broker writes / reads credentials.json mirrors)
+ *   - Refresh leases (broker holds the flock per (provider, account))
+ *   - Drift detection (broker compares sha-index per provider)
+ *   - ACL (broker enforces path-as-identity; for Google, also routes
+ *     through `google_accounts.<acct>.enabled_for[]` — but that's a
+ *     server-side ACL check, not a provider concern)
+ */
+
+// ────────────────────────────────────────────────────────────────────────
+// Provider identity
+// ────────────────────────────────────────────────────────────────────────
+
+/**
+ * The literal-union of provider names. `"anthropic"` is the default
+ * (RFC H's shipped behavior); `"google"` is added by Phase 3b.2.
+ *
+ * Adding a new provider is a deliberate enum extension — operators
+ * can't accidentally type a wrong provider name. Future Notion / Slack
+ * providers extend this.
+ */
+export type ProviderName = "anthropic" | "google";
+
+/**
+ * Composite key for per-account state. Two accounts with the same label
+ * under different providers are independent identities; the broker keys
+ * its in-memory state (`lastWrittenExpiresAt`, refresh leases, drift
+ * indices) on this composite, not on label alone.
+ */
+export interface AccountKey {
+  provider: ProviderName;
+  /** Account label / identifier within the provider's namespace. */
+  account: string;
+}
+
+/**
+ * Stable string form of an AccountKey for use as a Map key. Format:
+ * `<provider>:<account>`. Used everywhere the broker needs a Map keyed
+ * on (provider, account).
+ *
+ * Account labels are validated at the schema layer to not contain `:`
+ * (RFC G Phase 2 enforced this for Google emails specifically; Phase
+ * 3b.1b will extend the same constraint to Anthropic labels). So this
+ * encoding is unambiguous.
+ */
+export function accountKeyString(key: AccountKey): string {
+  return `${key.provider}:${key.account}`;
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// Refresh exchange
+// ────────────────────────────────────────────────────────────────────────
+
+/**
+ * Input to a refresh exchange. The broker passes the durable refresh
+ * token plus any provider-specific config (OAuth client id, scopes).
+ *
+ * `refreshToken` is the only field every provider needs. `clientId` /
+ * `scopes` are optional — Anthropic's refresh doesn't require them
+ * (the OAuth client identity is baked into the token); Google's
+ * does.
+ */
+export interface RefreshRequest {
+  refreshToken: string;
+  /** OAuth client id, when the provider needs it. */
+  clientId?: string;
+  /** Scope set to request, when the provider re-asserts scopes per refresh. */
+  scopes?: string[];
+}
+
+/**
+ * Output of a successful refresh exchange. Every provider returns at
+ * least an access token + expiry; some return a rotated refresh token.
+ *
+ * `rawCredentials` is the provider-shaped credentials object the broker
+ * writes verbatim to the per-agent mirror. Anthropic returns
+ * `{ claudeAiOauth: { ... } }`; Google returns `{ googleOauth: { ... } }`.
+ * Broker doesn't introspect this — it's pass-through to consumers.
+ */
+export interface RefreshSuccess {
+  ok: true;
+  accessToken: string;
+  /** Unix-ms when the access token expires. */
+  expiresAt: number;
+  /** Provider may rotate the refresh token; if absent, broker keeps the old one. */
+  newRefreshToken?: string;
+  /** Provider-shaped credentials object the broker stores verbatim. */
+  rawCredentials: unknown;
+}
+
+/**
+ * Discriminant for refresh failures. The broker maps these to its
+ * `REFRESH_FAILED` protocol error code; downstream UX (CLI, MCP wrapper)
+ * branches on `kind` to drive the right operator-actionable message.
+ *
+ *   - `invalid_grant` — refresh token revoked / rotated / expired.
+ *     Anthropic: rare. Google: happens on password change, app
+ *     revocation, or 7-day expiry under unverified-OAuth-client.
+ *     Operator action: re-OAuth.
+ *   - `network` — transient network failure. Operator action: wait.
+ *   - `quota_exceeded` — Anthropic 5h cap or Google quota. Operator
+ *     action: wait + maybe failover.
+ *   - `provider_error` — anything else. Operator action: read the
+ *     provider's error message in `detail`.
+ */
+export type RefreshErrorKind =
+  | "invalid_grant"
+  | "network"
+  | "quota_exceeded"
+  | "provider_error";
+
+export interface RefreshFailure {
+  ok: false;
+  kind: RefreshErrorKind;
+  /** Human-readable detail from the provider's error response. */
+  detail: string;
+}
+
+export type RefreshResult = RefreshSuccess | RefreshFailure;
+
+// ────────────────────────────────────────────────────────────────────────
+// Provider interface — what every provider must implement
+// ────────────────────────────────────────────────────────────────────────
+
+export interface Provider {
+  /**
+   * Provider name — must match the `name` used in protocol `provider:`
+   * fields and in operator-facing CLI verbs (`switchroom auth google ...`
+   * has provider name `"google"`).
+   */
+  readonly name: ProviderName;
+
+  /**
+   * Exchange a refresh token for new access credentials. Provider owns
+   * the HTTP request, error mapping, and result shape.
+   */
+  refresh(req: RefreshRequest): Promise<RefreshResult>;
+
+  /**
+   * Extract the expiry timestamp from a provider-shaped credentials
+   * object. Used by the broker's threshold-based refresh tick to decide
+   * "is this credential about to expire and need pre-emptive refresh?"
+   *
+   * Returns `undefined` when the credentials are missing the expiry
+   * field — broker treats undefined as "needs immediate refresh"
+   * (caller-of-broker probably has a stale shape).
+   */
+  extractExpiresAt(credentials: unknown): number | undefined;
+
+  /**
+   * Validate a credentials object has the expected shape for this
+   * provider. Called when an operator runs `auth <provider> account
+   * add` — broker rejects malformed credentials before storing.
+   * Returns null on success; a human-readable error on failure.
+   */
+  validateCredentialShape(credentials: unknown): string | null;
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// Provider registry — how the broker discovers loaded providers
+// ────────────────────────────────────────────────────────────────────────
+
+/**
+ * Registry of providers the broker knows about. Phase 3b.1b refactors
+ * `server.ts` to instantiate this at startup, register the Anthropic
+ * provider (extracted from current server logic), and dispatch
+ * provider-shaped operations through `lookup()`.
+ *
+ * Phase 3b.2 adds the Google provider via `register()`.
+ *
+ * This registry intentionally has no plugin-discovery mechanism —
+ * providers are compiled-in. Avoiding dynamic plugin loading keeps the
+ * broker's trust boundary tight (per RFC H §3): no third-party code
+ * runs in the broker process.
+ */
+export class ProviderRegistry {
+  private readonly providers = new Map<ProviderName, Provider>();
+
+  register(provider: Provider): void {
+    if (this.providers.has(provider.name)) {
+      throw new Error(
+        `provider '${provider.name}' is already registered — registry is single-instance per name`,
+      );
+    }
+    this.providers.set(provider.name, provider);
+  }
+
+  lookup(name: ProviderName): Provider {
+    const p = this.providers.get(name);
+    if (!p) {
+      throw new Error(
+        `provider '${name}' is not registered with the auth-broker`,
+      );
+    }
+    return p;
+  }
+
+  /**
+   * Whether the broker knows about this provider. Used by the protocol
+   * dispatcher to validate `provider:` field values before routing.
+   */
+  has(name: ProviderName): boolean {
+    return this.providers.has(name);
+  }
+
+  /**
+   * List of registered provider names. Used by `list-state` to surface
+   * the broker's known providers + by tests.
+   */
+  names(): ProviderName[] {
+    return [...this.providers.keys()];
+  }
+}

--- a/src/auth/broker/server.test.ts
+++ b/src/auth/broker/server.test.ts
@@ -390,6 +390,173 @@ describe("AuthBroker — add-account / rm-account", () => {
   });
 });
 
+// ────────────────────────────────────────────────────────────────────────
+// RFC G Phase 3b.1 — provider field gating
+// Server still Anthropic-only; non-default provider rejects with INVALID_ARGS.
+// ────────────────────────────────────────────────────────────────────────
+describe("AuthBroker — provider field gating (Phase 3b.1)", () => {
+  it("set-active rejects provider: 'google' with operator-actionable message", async () => {
+    const h = makeHarness();
+    const config = makeConfig(h, {
+      active: "default",
+      admin_agents: ["clerk"],
+      agents: { clerk: {} },
+    });
+    seedAccount(h, "default");
+    mkdirSync(join(h.agentsDir, "clerk"), { recursive: true });
+    const broker = new AuthBroker(config, {
+      home: h.home,
+      stateDir: h.stateDir,
+      socketRoot: h.socketRoot,
+      disableRefreshLoop: true,
+    });
+    await broker.start();
+    const resp = await rpc(join(h.socketRoot, "clerk", "sock"), {
+      v: 1,
+      id: "1",
+      op: "set-active",
+      account: "alice@example.com",
+      provider: "google",
+    }) as { ok: boolean; error?: { code: string; message: string } };
+    expect(resp.ok).toBe(false);
+    expect(resp.error?.code).toBe("INVALID_ARGS");
+    expect(resp.error?.message).toContain("Anthropic-only");
+    broker.stop();
+  });
+
+  it("refresh-account rejects provider: 'google' with Phase 3b.1b deferral message", async () => {
+    const h = makeHarness();
+    const config = makeConfig(h, {
+      active: "default",
+      admin_agents: ["clerk"],
+      agents: { clerk: {} },
+    });
+    seedAccount(h, "default");
+    mkdirSync(join(h.agentsDir, "clerk"), { recursive: true });
+    const broker = new AuthBroker(config, {
+      home: h.home,
+      stateDir: h.stateDir,
+      socketRoot: h.socketRoot,
+      disableRefreshLoop: true,
+    });
+    await broker.start();
+    const resp = await rpc(join(h.socketRoot, "clerk", "sock"), {
+      v: 1,
+      id: "1",
+      op: "refresh-account",
+      account: "alice@example.com",
+      provider: "google",
+    }) as { ok: boolean; error?: { code: string; message: string } };
+    expect(resp.ok).toBe(false);
+    expect(resp.error?.code).toBe("INVALID_ARGS");
+    expect(resp.error?.message).toContain("Phase 3b.1b");
+    broker.stop();
+  });
+
+  it("add-account rejects provider: 'google' with Phase 3b.1b deferral message", async () => {
+    const h = makeHarness();
+    const config = makeConfig(h, {
+      active: "default",
+      admin_agents: ["clerk"],
+      agents: { clerk: {} },
+    });
+    seedAccount(h, "default");
+    mkdirSync(join(h.agentsDir, "clerk"), { recursive: true });
+    const broker = new AuthBroker(config, {
+      home: h.home,
+      stateDir: h.stateDir,
+      socketRoot: h.socketRoot,
+      disableRefreshLoop: true,
+    });
+    await broker.start();
+    const resp = await rpc(join(h.socketRoot, "clerk", "sock"), {
+      v: 1,
+      id: "1",
+      op: "add-account",
+      label: "alice@example.com",
+      provider: "google",
+      credentials: {
+        googleOauth: {
+          accessToken: "at",
+          refreshToken: "rt",
+          expiresAt: 1234,
+          scope: "x",
+          clientId: "cid",
+          accountEmail: "alice@example.com",
+          tokenType: "Bearer",
+        },
+      },
+    }) as { ok: boolean; error?: { code: string; message: string } };
+    expect(resp.ok).toBe(false);
+    expect(resp.error?.code).toBe("INVALID_ARGS");
+    expect(resp.error?.message).toContain("Phase 3b.1b");
+    broker.stop();
+  });
+
+  it("add-account with NO provider field still works (back-compat with RFC H clients)", async () => {
+    const h = makeHarness();
+    const config = makeConfig(h, {
+      active: "default",
+      admin_agents: ["clerk"],
+      agents: { ziggy: {}, clerk: {} },
+    });
+    seedAccount(h, "default");
+    mkdirSync(join(h.agentsDir, "ziggy"), { recursive: true });
+    mkdirSync(join(h.agentsDir, "clerk"), { recursive: true });
+    const broker = new AuthBroker(config, {
+      home: h.home,
+      stateDir: h.stateDir,
+      socketRoot: h.socketRoot,
+      disableRefreshLoop: true,
+    });
+    await broker.start();
+    const resp = await rpc(join(h.socketRoot, "clerk", "sock"), {
+      v: 1,
+      id: "1",
+      op: "add-account",
+      label: "newone",
+      // no provider field — defaults to "anthropic"
+      credentials: {
+        claudeAiOauth: {
+          accessToken: "at-new",
+          refreshToken: "rt-new",
+          expiresAt: 5000,
+        },
+      },
+    }) as { ok: boolean };
+    expect(resp.ok).toBe(true);
+    broker.stop();
+  });
+
+  it("rm-account rejects provider: 'google' with Phase 3b.1b deferral message", async () => {
+    const h = makeHarness();
+    const config = makeConfig(h, {
+      active: "default",
+      admin_agents: ["clerk"],
+      agents: { clerk: {} },
+    });
+    seedAccount(h, "default");
+    mkdirSync(join(h.agentsDir, "clerk"), { recursive: true });
+    const broker = new AuthBroker(config, {
+      home: h.home,
+      stateDir: h.stateDir,
+      socketRoot: h.socketRoot,
+      disableRefreshLoop: true,
+    });
+    await broker.start();
+    const resp = await rpc(join(h.socketRoot, "clerk", "sock"), {
+      v: 1,
+      id: "1",
+      op: "rm-account",
+      label: "alice@example.com",
+      provider: "google",
+    }) as { ok: boolean; error?: { code: string; message: string } };
+    expect(resp.ok).toBe(false);
+    expect(resp.error?.code).toBe("INVALID_ARGS");
+    broker.stop();
+  });
+});
+
 describe("AuthBroker — list-state", () => {
   it("returns active, fallback_order, accounts, agents, consumers", async () => {
     const h = makeHarness();

--- a/src/auth/broker/server.ts
+++ b/src/auth/broker/server.ts
@@ -471,21 +471,90 @@ export class AuthBroker {
         case "list-state":
           await this.opListState(socket, reqId, identity);
           break;
-        case "set-active":
+        case "set-active": {
+          // Phase 3b.1: provider field is carried for protocol uniformity
+          // but `set-active` is fleet-wide active-account swap, an
+          // Anthropic-only concept. Reject non-default until/unless a
+          // fleet-wide-active Google concept exists.
+          const provider = req.provider ?? "anthropic";
+          if (provider !== "anthropic") {
+            socket.write(
+              encodeError(
+                reqId,
+                "INVALID_ARGS",
+                `set-active is Anthropic-only — Google's account-active model is per-agent via google_accounts.enabled_for[]`,
+              ),
+            );
+            break;
+          }
           await this.opSetActive(socket, reqId, identity, req.account);
           break;
+        }
         case "mark-exhausted":
           await this.opMarkExhausted(socket, reqId, identity, req.until);
           break;
-        case "refresh-account":
+        case "refresh-account": {
+          const provider = req.provider ?? "anthropic";
+          if (provider !== "anthropic") {
+            socket.write(
+              encodeError(
+                reqId,
+                "INVALID_ARGS",
+                `provider '${provider}' not yet implemented in broker server (Phase 3b.1b will add provider dispatch)`,
+              ),
+            );
+            break;
+          }
           await this.opRefreshAccount(socket, reqId, identity, req.account);
           break;
-        case "add-account":
-          await this.opAddAccount(socket, reqId, identity, req.label, req.credentials, req.replace ?? false);
+        }
+        case "add-account": {
+          // Phase 3b.1: protocol now accepts an optional `provider:` field
+          // and a discriminated `credentials:` union. Until 3b.1b refactors
+          // the server to dispatch through providers, the server is
+          // Anthropic-only and rejects non-default providers.
+          const provider = req.provider ?? "anthropic";
+          if (provider !== "anthropic") {
+            socket.write(
+              encodeError(
+                reqId,
+                "INVALID_ARGS",
+                `provider '${provider}' not yet implemented in broker server (Phase 3b.1b will add provider dispatch)`,
+              ),
+            );
+            break;
+          }
+          // Validate the credentials variant matches the provider.
+          if (!("claudeAiOauth" in req.credentials)) {
+            socket.write(
+              encodeError(
+                reqId,
+                "INVALID_ARGS",
+                `provider 'anthropic' requires credentials in claudeAiOauth shape`,
+              ),
+            );
+            break;
+          }
+          // Type narrows: variant is AnthropicCredentialsShape; assignable to AccountCredentials.
+          const anthropicCreds = req.credentials as { claudeAiOauth: AccountCredentials["claudeAiOauth"] };
+          await this.opAddAccount(socket, reqId, identity, req.label, anthropicCreds, req.replace ?? false);
           break;
-        case "rm-account":
+        }
+        case "rm-account": {
+          const provider = req.provider ?? "anthropic";
+          if (provider !== "anthropic") {
+            socket.write(
+              encodeError(
+                reqId,
+                "INVALID_ARGS",
+                `provider '${provider}' not yet implemented in broker server (Phase 3b.1b will add provider dispatch)`,
+              ),
+            );
+            break;
+          }
           await this.opRmAccount(socket, reqId, identity, req.label);
           break;
+        }
         case "set-override":
           await this.opSetOverride(socket, reqId, identity, req.agent, req.account);
           break;


### PR DESCRIPTION
## Summary

First Phase 3b PR. Lays the foundation for Phase 3b.2 (Google provider implementation) by adding the provider interface + protocol \`provider:\` field. Server still Anthropic-only — this PR adds the abstraction the next PR will actually dispatch through.

**Honest scope split** (per Phase 3b.1 reviewer feedback that estimated ~90-120min for the full server refactor):
- **3b.1a (this PR):** interface + protocol additions + back-compat gating + tests. Server delegates non-default providers to a clean rejection path.
- **3b.1b (next PR):** server refactor to actually dispatch through the registry, extract Anthropic provider, re-key state on \`(provider, account)\`.

Splitting keeps each PR ~600-1000 LOC reviewable.

## What ships (additive, no breaking changes)

**\`src/auth/broker/provider.ts\` (new, ~250 LOC):**
- \`ProviderName\` union (\`"anthropic" | "google"\`)
- \`AccountKey\` + \`accountKeyString()\` — composite (provider, account) encoding for per-account state. Account "alice@example.com" under Google is structurally distinct from an Anthropic label of the same string. **Load-bearing for 3b.1b's per-(provider, account) re-keying.**
- \`Provider\` interface — refresh exchange, expiry extraction, shape validation
- \`RefreshResult\` discriminated union with \`RefreshErrorKind\` so downstream UX (3b.4 MCP wrapper, 3b.3 CLI) branches on cause without provider-coupled code
- \`ProviderRegistry\` — single-instance per provider name, no dynamic plugin loading (RFC H §3 trust boundary)

**\`src/auth/broker/protocol.ts\`:**
- \`ProviderNameSchema\` zod enum + \`DEFAULT_PROVIDER\` constant
- Optional \`provider:\` field on \`set-active\`, \`refresh-account\`, \`add-account\`, \`rm-account\`. Absent or \`"anthropic"\` = current behavior.
- \`add-account.credentials\` becomes a discriminated union: \`AnthropicCredentialsSchema\` (existing) + new \`GoogleCredentialsSchema\` (Phase 3b.2 will produce). Schema accepts both; server validates the cross-check.

**\`src/auth/broker/server.ts\`:**
- Wraps each provider-aware verb to gate non-default providers with \`INVALID_ARGS\` and a clear deferral message
- \`set-active\` gets a different message because it's Anthropic-only by design ("Google's account-active model is per-agent via google_accounts.enabled_for[]")
- \`add-account\` validates credentials variant matches provider, returns INVALID_ARGS on mismatch

## Tests — 35 new, 78 total

- \`provider.test.ts\` (new, 18 tests) — accountKeyString collision avoidance, ProviderRegistry lifecycle, interface-contract pinning via fixture provider
- \`protocol.test.ts\` (extended, +12 tests) — provider field round-trip, back-compat decoding, credentials union variants, schema-vs-server cross-check separation
- \`server.test.ts\` (extended, +5 tests) — gating verbs reject provider:'google' with operator-actionable messages; back-compat add-account-without-provider still works

## Test plan

- [x] \`bun test src/auth/broker/\` — 78/78 pass (43 pre-existing + 35 new)
- [x] \`tsc --noEmit\` — clean
- [x] No regressions in pre-existing broker tests
- [ ] Independent reviewer verdict (will dispatch after PR open)

## RFC G v3 alignment

Implements §7 Phase 3b.1 per the v3 spec at \`docs/rfcs/google-workspace-generalization.md\`. Carries the "RFC H deliberately scoped broker to Anthropic; Phase 3b.1 introduces the provider abstraction" framing from the v3 spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)