### PR TITLE
fix(auth-heal): skip config load when --config-dir is provided

### DIFF
--- a/src/cli/auth.ts
+++ b/src/cli/auth.ts
@@ -406,22 +406,32 @@ export function registerAuthCommand(program: Command): void {
       "Override the .claude config dir to inspect (default: <agentsDir>/<agent>/.claude)",
     )
     .action(
-      withConfigError(
-        async (
-          agent: string,
-          opts: { json?: boolean; configDir?: string },
-        ) => {
+      async (
+        agent: string,
+        opts: { json?: boolean; configDir?: string },
+      ) => {
+        // boot-self-test.sh shells this from start.sh BEFORE the
+        // switchroom.yaml is reliably reachable (the script runs with
+        // a stripped env to mirror the hook sub-process context — see
+        // tests/boot-self-test.test.ts). When --config-dir is set, the
+        // caller already knows the exact path to inspect; loading
+        // global config here just makes `auth heal` ConfigError-out and
+        // the boot script swallow the error (its `2>/dev/null` masks it).
+        // Skip the config lookup unless we actually need to derive the
+        // default config-dir from `<agentsDir>/<agent>/.claude`.
+        let configDir = opts.configDir;
+        if (configDir === undefined) {
           const config = getConfig(program);
           const agentsDir = resolveAgentsDir(config);
-          const configDir = opts.configDir ?? join(agentsDir, agent, ".claude");
-          const diag = diagnoseAuthState(configDir);
-          if (opts.json) {
-            console.log(JSON.stringify(diag));
-          } else {
-            console.log(JSON.stringify(diag, null, 2));
-          }
-        },
-      ),
+          configDir = join(agentsDir, agent, ".claude");
+        }
+        const diag = diagnoseAuthState(configDir);
+        if (opts.json) {
+          console.log(JSON.stringify(diag));
+        } else {
+          console.log(JSON.stringify(diag, null, 2));
+        }
+      },
     );
 
   // ── auth add <label> ──────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- `bin/boot-self-test.sh` shells `switchroom auth heal --json --config-dir <dir>` under a stripped env from `start.sh`. Post-RFC-H (PR #1254), the handler unconditionally calls `getConfig(program)` → `ConfigError` whenever no `switchroom.yaml` is in the ancestor chain. The script's `2>/dev/null` swallows it and `DIAG_JSON` ends up empty.
- Symptom: 5 `boot-self-test.sh > records auth.*` tests in `tests/boot-self-test.test.ts` fail with "expected undefined to be defined" on every buildkite Core-tests run since the post-RFC-H merge (buildkite #1959 on commit `4fdac344` is the first failure on main).
- Fix: skip the config load when `--config-dir` is set — the caller already knows the exact path. The default-derivation branch (`<agentsDir>/<agent>/.claude`) still loads config.

Verified locally: `cd /tmp && switchroom auth heal testagent --json --config-dir /tmp/nonexistent` now emits the expected diagnoser JSON instead of erroring out.

## Test plan

- [x] `npm run lint` clean
- [x] Manual repro from a no-config dir produces diagnoser JSON
- [ ] buildkite Core tests green on the merged commit (will verify when CI runs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)