### PR TITLE
fix(provider-test): swap bun:test import to vitest

### DIFF
--- a/src/auth/broker/provider.test.ts
+++ b/src/auth/broker/provider.test.ts
@@ -10,7 +10,7 @@
  * pins the contract those implementations must honor.
  */
 
-import { describe, expect, it } from "bun:test";
+import { describe, expect, it } from "vitest";
 
 import {
   accountKeyString,


### PR DESCRIPTION
## Summary

- One-line import swap. `src/auth/broker/provider.test.ts` landed in #1259 (RFC G Phase 3b.1) importing `bun:test`, but the file uses no bun-specific APIs (no `mock()`, no `bun:sqlite`).
- vitest can't resolve `bun:test`, so the suite fails to load and `:vitest: Core tests` on buildkite goes red — currently the only failing step on `main` after the RFC H stabilisation loop.

## Test plan

- [x] `bun run test:vitest -- src/auth/broker/provider.test.ts` → 16 pass / 0 fail
- [x] `npm run lint` clean
- [ ] Buildkite Core tests green on the squash-merged commit

## Pattern

Fifth instance of this footgun in 24h (#1259 here; previously #1235's google-accounts-yaml; #1249/#1250/#1251's drive tests). Worth a structural fix — file a follow-up to add a lint rule rejecting `from "bun:test"` in files under `src/**/*.test.ts` that aren't in `vitest.config.ts`'s exclude list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)