### PR TITLE
feat(auth-broker): RFC G Phase 3b.2a — GoogleProvider implementation (no broker integration yet)

### DIFF
--- a/src/auth/broker/google-provider.test.ts
+++ b/src/auth/broker/google-provider.test.ts
@@ -1,0 +1,351 @@
+/**
+ * Tests for GoogleProvider — RFC G Phase 3b.2a.
+ *
+ * Drives `refresh()` against a stub fetcher returning canned Google
+ * token-endpoint responses. Validates:
+ *   - Successful refresh round-trips into a RefreshSuccess shape
+ *   - Google's `invalid_grant` (rotation / revocation / 7-day expiry)
+ *     maps to RefreshErrorKind="invalid_grant"
+ *   - Network failures map to "network"
+ *   - 429 / quota responses map to "quota_exceeded"
+ *   - Other failures map to "provider_error" with the raw detail
+ *   - extractExpiresAt + validateCredentialShape correctness
+ *
+ * Replay-style: tests pass a fetcher that returns a Response from a
+ * captured Google response body, no network round-trip.
+ */
+
+import { describe, expect, it } from "bun:test";
+
+import { GoogleProvider } from "./google-provider.js";
+
+// ────────────────────────────────────────────────────────────────────────
+// Stub fetcher helpers — wraps a status + body into a Response that
+// matches the shape `refreshAccessToken` expects.
+// ────────────────────────────────────────────────────────────────────────
+
+function stubFetcher(status: number, body: unknown): typeof fetch {
+  return (async (_input: RequestInfo | URL, _init?: RequestInit) => {
+    return new Response(JSON.stringify(body), {
+      status,
+      headers: { "content-type": "application/json" },
+    });
+  }) as unknown as typeof fetch;
+}
+
+function failingFetcher(message: string): typeof fetch {
+  return (async () => {
+    throw new Error(message);
+  }) as unknown as typeof fetch;
+}
+
+function makeProvider(fetcher: typeof fetch): GoogleProvider {
+  return new GoogleProvider({
+    clientId: "test-client-id",
+    clientSecret: "test-secret",
+    fetcher,
+  });
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// refresh — success path
+// ────────────────────────────────────────────────────────────────────────
+
+describe("GoogleProvider.refresh — success", () => {
+  it("returns RefreshSuccess from a canned Google 200 response", async () => {
+    const provider = makeProvider(
+      stubFetcher(200, {
+        access_token: "new-access",
+        refresh_token: "new-refresh",
+        expires_in: 3600,
+        token_type: "Bearer",
+        scope: "https://www.googleapis.com/auth/drive",
+      }),
+    );
+    const r = await provider.refresh({
+      refreshToken: "old-refresh",
+      clientId: "alice@example.com",
+    });
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.accessToken).toBe("new-access");
+      expect(r.newRefreshToken).toBe("new-refresh");
+      // expiresAt is computed as Date.now() + expires_in*1000; just
+      // verify it's in the right range (within 5s of now+1h).
+      const expectedMin = Date.now() + 3590_000;
+      const expectedMax = Date.now() + 3610_000;
+      expect(r.expiresAt).toBeGreaterThan(expectedMin);
+      expect(r.expiresAt).toBeLessThan(expectedMax);
+    }
+  });
+
+  it("preserves the OLD refresh token when Google omits a new one (no rotation)", async () => {
+    const provider = makeProvider(
+      stubFetcher(200, {
+        access_token: "new-access",
+        // refresh_token field omitted — Google sometimes doesn't rotate
+        expires_in: 3600,
+        token_type: "Bearer",
+      }),
+    );
+    const r = await provider.refresh({
+      refreshToken: "kept-refresh",
+      clientId: "alice@example.com",
+    });
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      // newRefreshToken on the wire reflects what Google returned (undefined).
+      expect(r.newRefreshToken).toBeUndefined();
+      // rawCredentials.googleOauth.refreshToken is the OLD token (preserved).
+      const creds = r.rawCredentials as { googleOauth: { refreshToken: string } };
+      expect(creds.googleOauth.refreshToken).toBe("kept-refresh");
+    }
+  });
+
+  it("populates GoogleCredentialsShape rawCredentials with all required fields", async () => {
+    const provider = makeProvider(
+      stubFetcher(200, {
+        access_token: "at-1",
+        refresh_token: "rt-1",
+        expires_in: 3600,
+        token_type: "Bearer",
+        scope: "https://www.googleapis.com/auth/drive https://www.googleapis.com/auth/docs",
+      }),
+    );
+    const r = await provider.refresh({
+      refreshToken: "old-rt",
+      clientId: "alice@example.com",
+    });
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      const creds = r.rawCredentials as {
+        googleOauth: {
+          accessToken: string;
+          refreshToken: string;
+          expiresAt: number;
+          scope: string;
+          clientId: string;
+          accountEmail: string;
+          tokenType: "Bearer";
+        };
+      };
+      expect(creds.googleOauth.accessToken).toBe("at-1");
+      expect(creds.googleOauth.refreshToken).toBe("rt-1");
+      expect(creds.googleOauth.scope).toContain("drive");
+      expect(creds.googleOauth.scope).toContain("docs");
+      expect(creds.googleOauth.clientId).toBe("test-client-id");
+      expect(creds.googleOauth.accountEmail).toBe("alice@example.com");
+      expect(creds.googleOauth.tokenType).toBe("Bearer");
+    }
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────
+// refresh — error mapping
+// ────────────────────────────────────────────────────────────────────────
+
+describe("GoogleProvider.refresh — error classification", () => {
+  it("maps Google invalid_grant to RefreshErrorKind invalid_grant", async () => {
+    const provider = makeProvider(
+      stubFetcher(400, {
+        error: "invalid_grant",
+        error_description: "Token has been expired or revoked.",
+      }),
+    );
+    const r = await provider.refresh({
+      refreshToken: "rotated-rt",
+      clientId: "alice@example.com",
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.kind).toBe("invalid_grant");
+      expect(r.detail).toContain("expired or revoked");
+    }
+  });
+
+  it("maps 429 / rate-limit to quota_exceeded", async () => {
+    const provider = makeProvider(
+      stubFetcher(429, { error: "rateLimitExceeded" }),
+    );
+    const r = await provider.refresh({
+      refreshToken: "rt",
+      clientId: "alice@example.com",
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.kind).toBe("quota_exceeded");
+  });
+
+  it("maps network failures (ETIMEDOUT) to network", async () => {
+    const provider = makeProvider(failingFetcher("ETIMEDOUT connect 142.250.x.x:443"));
+    const r = await provider.refresh({
+      refreshToken: "rt",
+      clientId: "alice@example.com",
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.kind).toBe("network");
+  });
+
+  it("maps fetch failed to network", async () => {
+    const provider = makeProvider(failingFetcher("fetch failed"));
+    const r = await provider.refresh({
+      refreshToken: "rt",
+      clientId: "alice@example.com",
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.kind).toBe("network");
+  });
+
+  it("maps unknown error responses to provider_error with raw detail", async () => {
+    const provider = makeProvider(
+      stubFetcher(500, { error: "internal_server_error", error_description: "boom" }),
+    );
+    const r = await provider.refresh({
+      refreshToken: "rt",
+      clientId: "alice@example.com",
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.kind).toBe("provider_error");
+      expect(r.detail).toContain("internal_server_error");
+    }
+  });
+
+  it("rejects empty refreshToken before hitting the network", async () => {
+    let calls = 0;
+    const fetcher: typeof fetch = (async () => {
+      calls++;
+      return new Response("{}", { status: 200 });
+    }) as unknown as typeof fetch;
+    const provider = makeProvider(fetcher);
+    const r = await provider.refresh({
+      refreshToken: "",
+      clientId: "alice@example.com",
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.kind).toBe("provider_error");
+      expect(r.detail).toContain("refreshToken is required");
+    }
+    expect(calls).toBe(0);
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────
+// extractExpiresAt
+// ────────────────────────────────────────────────────────────────────────
+
+describe("GoogleProvider.extractExpiresAt", () => {
+  it("returns expiresAt from googleOauth", () => {
+    const provider = makeProvider(stubFetcher(200, {}));
+    expect(
+      provider.extractExpiresAt({ googleOauth: { expiresAt: 9999 } }),
+    ).toBe(9999);
+  });
+
+  it("returns undefined for missing googleOauth", () => {
+    const provider = makeProvider(stubFetcher(200, {}));
+    expect(provider.extractExpiresAt({})).toBeUndefined();
+    expect(provider.extractExpiresAt(null)).toBeUndefined();
+  });
+
+  it("does NOT return expiresAt from claudeAiOauth (provider isolation)", () => {
+    const provider = makeProvider(stubFetcher(200, {}));
+    // Anthropic-shaped credentials should yield undefined when read by
+    // Google provider. Pins that the providers correctly stay in their
+    // lanes per the AccountKey collision-avoidance contract.
+    expect(
+      provider.extractExpiresAt({ claudeAiOauth: { expiresAt: 9999 } }),
+    ).toBeUndefined();
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────
+// validateCredentialShape
+// ────────────────────────────────────────────────────────────────────────
+
+describe("GoogleProvider.validateCredentialShape", () => {
+  const validCreds = {
+    googleOauth: {
+      accessToken: "at",
+      refreshToken: "rt",
+      expiresAt: 1234,
+      scope: "drive",
+      clientId: "cid",
+      accountEmail: "alice@example.com",
+      tokenType: "Bearer",
+    },
+  };
+
+  function provider() {
+    return makeProvider(stubFetcher(200, {}));
+  }
+
+  it("accepts valid Google credentials", () => {
+    expect(provider().validateCredentialShape(validCreds)).toBeNull();
+  });
+
+  it("rejects non-object input", () => {
+    expect(provider().validateCredentialShape("not-an-object")).toContain("must be an object");
+    expect(provider().validateCredentialShape(null)).toContain("must be an object");
+  });
+
+  it("rejects missing googleOauth", () => {
+    expect(provider().validateCredentialShape({})).toContain("googleOauth object");
+  });
+
+  it("rejects missing required fields with field-name in error", () => {
+    const noAccessToken = {
+      googleOauth: { ...validCreds.googleOauth, accessToken: undefined },
+    };
+    expect(provider().validateCredentialShape(noAccessToken)).toContain("accessToken");
+  });
+
+  it("rejects empty accessToken", () => {
+    const empty = {
+      googleOauth: { ...validCreds.googleOauth, accessToken: "" },
+    };
+    expect(provider().validateCredentialShape(empty)).toContain("non-empty");
+  });
+
+  it("rejects non-positive expiresAt", () => {
+    const bad = {
+      googleOauth: { ...validCreds.googleOauth, expiresAt: -1 },
+    };
+    expect(provider().validateCredentialShape(bad)).toContain("positive");
+  });
+
+  it("rejects wrong tokenType", () => {
+    const bad = {
+      googleOauth: { ...validCreds.googleOauth, tokenType: "MAC" },
+    };
+    expect(provider().validateCredentialShape(bad)).toContain("Bearer");
+  });
+
+  it("rejects Anthropic-shaped credentials (provider isolation)", () => {
+    expect(
+      provider().validateCredentialShape({
+        claudeAiOauth: { accessToken: "at", refreshToken: "rt", expiresAt: 1 },
+      }),
+    ).toContain("googleOauth");
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────
+// Provider interface contract
+// ────────────────────────────────────────────────────────────────────────
+
+describe("GoogleProvider — Provider interface contract", () => {
+  it("has name === 'google'", () => {
+    const provider = makeProvider(stubFetcher(200, {}));
+    expect(provider.name).toBe("google");
+  });
+
+  it("is the same Provider type the registry accepts", async () => {
+    const { ProviderRegistry } = await import("./provider.js");
+    const reg = new ProviderRegistry();
+    const provider = makeProvider(stubFetcher(200, {}));
+    reg.register(provider);
+    expect(reg.lookup("google")).toBe(provider);
+    expect(reg.has("google")).toBe(true);
+  });
+});

--- a/src/auth/broker/google-provider.ts
+++ b/src/auth/broker/google-provider.ts
@@ -1,0 +1,232 @@
+/**
+ * GoogleProvider — Provider implementation for Google OAuth
+ * (RFC G Phase 3b.2a).
+ *
+ * Wraps `src/drive/oauth.ts:refreshAccessToken` (the existing RFC D
+ * refresh exchange) as a Provider. Unlike AnthropicProvider — which
+ * delegates back to the broker's storage layer — GoogleProvider
+ * actually calls Google's OAuth token endpoint, parses the response,
+ * and returns a structured `RefreshSuccess` for the broker to store.
+ *
+ * **What this provider owns:**
+ *   - HTTP refresh exchange against Google's `/token` endpoint
+ *   - Google-specific error mapping (`invalid_grant` for password change /
+ *     app revocation / 7-day Testing-mode expiry; rate-limit detection)
+ *   - Credential shape (`googleOauth: { ... }` per protocol.ts)
+ *   - Expiry extraction from `googleOauth.expiresAt`
+ *
+ * **What the broker owns** (per the per-account state model that
+ * Phase 3b.2b will refactor onto AccountKey):
+ *   - On-disk persistence of refresh + status sidecar
+ *   - Refresh leases (one in-flight refresh per account)
+ *   - Sha-index drift detection (across-restart consistency)
+ *   - Fanout to consumers (MCP wrapper subprocesses for Google;
+ *     per-agent .credentials.json mirrors for Anthropic)
+ *
+ * **Phase split:**
+ *   - 3b.2a (this file): provider class + tests against fixture HTTP.
+ *     Not registered with the broker yet — landing the unit standalone.
+ *   - 3b.2b: register GoogleProvider when `google_accounts:` config
+ *     non-empty; refactor `refreshOneAccount(label)` →
+ *     `refreshOneAccount(accountKey)`; swap remaining 8 hardcoded
+ *     `claudeAiOauth?.expiresAt` reads to
+ *     `lookup(provider).extractExpiresAt(...)`; wire Google-specific
+ *     storage path (vault slot, not per-agent .credentials.json).
+ */
+
+import {
+  refreshAccessToken,
+  InvalidGrantError,
+  type OAuthClientConfig,
+  type TokenResponse,
+} from "../../drive/oauth.js";
+import type { Provider, RefreshRequest, RefreshResult } from "./provider.js";
+import type { GoogleCredentialsShape } from "./protocol.js";
+
+/**
+ * Construction options. The OAuth client credentials (id + optional
+ * secret) are passed in by the broker — they're per-install config
+ * (one OAuth client per switchroom install per Google's terms),
+ * sourced from the `google_workspace.google_client_id` / `_secret`
+ * config block (RFC G Phase 1).
+ *
+ * Per Phase 5 (`examples/personal-google-workspace-mcp/`), Desktop
+ * OAuth clients are public and don't strictly need a client_secret —
+ * but `refreshAccessToken` (the existing implementation) sends one
+ * regardless. Phase 3b.3 may revisit this for the OAuth 2.1 PKCE
+ * flow; for 3b.2a we preserve the existing shape.
+ */
+export interface GoogleProviderOptions {
+  /** Google OAuth client id, e.g. "12345-abc.apps.googleusercontent.com". */
+  clientId: string;
+  /**
+   * Google OAuth client secret. Empty string for PKCE flow (Desktop
+   * client public mode). The existing `refreshAccessToken` always
+   * passes this in the body; Google accepts an empty string for
+   * Desktop clients.
+   */
+  clientSecret: string;
+  /**
+   * Injectable fetch — tests pass a stub that returns canned Google
+   * token-endpoint responses. Defaults to global fetch.
+   */
+  fetcher?: typeof fetch;
+}
+
+export class GoogleProvider implements Provider {
+  readonly name = "google" as const;
+
+  constructor(private readonly opts: GoogleProviderOptions) {}
+
+  async refresh(req: RefreshRequest): Promise<RefreshResult> {
+    if (!req.refreshToken) {
+      return {
+        ok: false,
+        kind: "provider_error",
+        detail: "GoogleProvider.refresh: refreshToken is required",
+      };
+    }
+    const cfg: OAuthClientConfig = {
+      client_id: this.opts.clientId,
+      client_secret: this.opts.clientSecret,
+      // Scopes are validated server-side at refresh time (Google echoes
+      // them in the response); we don't re-request scopes on refresh,
+      // so this field is unused by `refreshAccessToken` for the
+      // refresh path. Pass empty array for type-safety.
+      scopes: [],
+    };
+    let token: TokenResponse;
+    try {
+      token = await refreshAccessToken(
+        cfg,
+        req.refreshToken,
+        this.opts.fetcher ?? fetch,
+      );
+    } catch (err) {
+      if (err instanceof InvalidGrantError) {
+        return {
+          ok: false,
+          kind: "invalid_grant",
+          detail: err.message,
+        };
+      }
+      return classifyAsyncError(err);
+    }
+    // Google sometimes rotates the refresh token, sometimes doesn't.
+    // Pass through whichever shape we got.
+    const expiresAt = Date.now() + token.expires_in * 1000;
+    const rawCredentials: GoogleCredentialsShape = {
+      googleOauth: {
+        accessToken: token.access_token,
+        refreshToken: token.refresh_token ?? req.refreshToken,
+        expiresAt,
+        scope: token.scope ?? "",
+        clientId: this.opts.clientId,
+        // accountEmail is NOT in the refresh response — broker stores
+        // the account label (which IS the email per RFC G's per-account
+        // ACL) and the wrapper should look it up from there. Phase 3b.2b
+        // will pass the accountEmail through `req.clientId`-style
+        // smuggling or extend RefreshRequest properly.
+        accountEmail: req.clientId ?? "",
+        tokenType: "Bearer",
+      },
+    };
+    return {
+      ok: true,
+      accessToken: token.access_token,
+      expiresAt,
+      newRefreshToken: token.refresh_token,
+      rawCredentials,
+    };
+  }
+
+  /**
+   * Extract expiry from a Google credentials object. Returns undefined
+   * if the credentials are malformed or the field is absent — broker
+   * treats undefined as "needs immediate refresh."
+   */
+  extractExpiresAt(credentials: unknown): number | undefined {
+    const c = credentials as GoogleCredentialsShape | null | undefined;
+    return c?.googleOauth?.expiresAt;
+  }
+
+  /**
+   * Validate the on-disk shape Google credentials must conform to.
+   * Returns null on success; an actionable error string on failure.
+   *
+   * Mirrors the GoogleCredentialsSchema from protocol.ts but with
+   * actionable messages — at this layer we know we're validating an
+   * operator-or-OAuth-flow input, not a wire-protocol message.
+   */
+  validateCredentialShape(credentials: unknown): string | null {
+    if (!credentials || typeof credentials !== "object") {
+      return "Google credentials must be an object";
+    }
+    const c = credentials as { googleOauth?: unknown };
+    if (!c.googleOauth || typeof c.googleOauth !== "object") {
+      return "Google credentials must have a googleOauth object";
+    }
+    const oauth = c.googleOauth as Record<string, unknown>;
+    const required = [
+      "accessToken",
+      "refreshToken",
+      "expiresAt",
+      "scope",
+      "clientId",
+      "accountEmail",
+    ];
+    for (const field of required) {
+      if (oauth[field] === undefined || oauth[field] === null) {
+        return `Google googleOauth.${field} is required`;
+      }
+    }
+    if (typeof oauth.accessToken !== "string" || oauth.accessToken.length === 0) {
+      return "Google googleOauth.accessToken must be a non-empty string";
+    }
+    if (typeof oauth.refreshToken !== "string" || oauth.refreshToken.length === 0) {
+      return "Google googleOauth.refreshToken must be a non-empty string";
+    }
+    if (typeof oauth.expiresAt !== "number" || oauth.expiresAt <= 0) {
+      return "Google googleOauth.expiresAt must be a positive unix-ms timestamp";
+    }
+    if (oauth.tokenType !== "Bearer") {
+      return "Google googleOauth.tokenType must be 'Bearer'";
+    }
+    return null;
+  }
+}
+
+/**
+ * Map non-InvalidGrant errors from Google's OAuth endpoint to the
+ * broker's RefreshErrorKind discriminant. `refreshAccessToken` throws
+ * a generic Error wrapping the response body; we string-match the
+ * common patterns to give downstream UX (CLI, MCP wrapper) a useful
+ * branch.
+ *
+ * Patterns based on Google's documented OAuth error responses:
+ *   - 429 / "rate" / "quota" → quota_exceeded
+ *   - "ETIMEDOUT" / "ECONNRESET" / "fetch failed" → network
+ *   - everything else → provider_error (caller surfaces detail)
+ */
+function classifyAsyncError(err: unknown): RefreshResult {
+  const msg = err instanceof Error ? err.message : String(err);
+  const lower = msg.toLowerCase();
+  if (
+    lower.includes("etimedout") ||
+    lower.includes("econnreset") ||
+    lower.includes("network") ||
+    lower.includes("fetch failed") ||
+    lower.includes("getaddrinfo")
+  ) {
+    return { ok: false, kind: "network", detail: msg };
+  }
+  if (
+    lower.includes("429") ||
+    lower.includes("rate") ||
+    lower.includes("quota") ||
+    lower.includes("too many requests")
+  ) {
+    return { ok: false, kind: "quota_exceeded", detail: msg };
+  }
+  return { ok: false, kind: "provider_error", detail: msg };
+}


### PR DESCRIPTION
## Summary

Lands the Google provider as a standalone unit with thorough tests against fixture HTTP responses. **Not registered with the broker yet** — that wiring lands in Phase 3b.2b alongside the \`refreshOneAccount(label) → refreshOneAccount(accountKey)\` refactor the reviewer of 3b.1b flagged as the required follow-up.

Splitting Phase 3b.2 keeps each PR reviewable:
- **3b.2a (this PR):** provider class + 22 tests, no broker changes
- **3b.2b:** register when google_accounts non-empty + dispatcher refactor + AccountKey state-keying + Google storage path

## What ships

- \`src/auth/broker/google-provider.ts\` (~165 LOC) — implements Provider interface; \`refresh()\` wraps the existing \`src/drive/oauth.ts:refreshAccessToken\` (the v0.6.0 RFC D refresh exchange against Google's OAuth token endpoint)
- \`src/auth/broker/google-provider.test.ts\` (22 tests) — replay-style against canned Google token-endpoint responses

## Google-specific behavior

- Preserves the OLD refresh token when Google doesn't rotate (handles Google's inconsistent rotation behavior)
- \`invalid_grant\` (rotation / revocation / 7-day Testing-mode expiry) → RefreshErrorKind="invalid_grant" via existing InvalidGrantError class
- 429 / "rate" / "quota" → "quota_exceeded"
- ETIMEDOUT / ECONNRESET / "fetch failed" → "network"
- Unknown → "provider_error" with raw detail
- Empty refreshToken → fail-fast before HTTP

## Provider isolation pinned

- \`extractExpiresAt\` returns undefined for non-Google credential shapes (Anthropic-shaped credentials don't bleed through)
- \`validateCredentialShape\` rejects Anthropic-shaped credentials with actionable error pointing at \`googleOauth\`

## Tests — 101/101

- 22 new GoogleProvider tests (success path, error classification, expiry extraction, shape validation, registry-compatibility)
- 79 pre-existing broker tests still pass (no regressions)

## Test plan

- [x] \`bun test src/auth/broker/\` — 101/101 pass
- [x] \`tsc --noEmit\` — clean
- [ ] Independent reviewer verdict (will dispatch after PR open)

🤖 Generated with [Claude Code](https://claude.com/claude-code)