### PR TITLE
fix(auth-heal): polish + lock in --config-dir bypass + bun:test swap

### DIFF
--- a/src/auth/broker/google-provider.test.ts
+++ b/src/auth/broker/google-provider.test.ts
@@ -15,7 +15,7 @@
  * captured Google response body, no network round-trip.
  */
 
-import { describe, expect, it } from "bun:test";
+import { describe, expect, it } from "vitest";
 
 import { GoogleProvider } from "./google-provider.js";
 

--- a/src/cli/auth.ts
+++ b/src/cli/auth.ts
@@ -421,11 +421,19 @@ export function registerAuthCommand(program: Command): void {
         // default config-dir from `<agentsDir>/<agent>/.claude`.
         let configDir = opts.configDir;
         if (configDir === undefined) {
-          const config = getConfig(program);
-          const agentsDir = resolveAgentsDir(config);
-          configDir = join(agentsDir, agent, ".claude");
+          // Wrap just the config-derivation branch in withConfigError so a
+          // human typing `switchroom auth heal foo` without a yaml gets
+          // the friendly `chalk.red("Config error: ...")` line rather than
+          // an unformatted commander stack trace. boot-self-test always
+          // passes --config-dir and bypasses this branch entirely, so the
+          // wrapper has no effect on the programmatic path.
+          await withConfigError(async () => {
+            const config = getConfig(program);
+            const agentsDir = resolveAgentsDir(config);
+            configDir = join(agentsDir, agent, ".claude");
+          })();
         }
-        const diag = diagnoseAuthState(configDir);
+        const diag = diagnoseAuthState(configDir!);
         if (opts.json) {
           console.log(JSON.stringify(diag));
         } else {

--- a/tests/auth-heal-cli.test.ts
+++ b/tests/auth-heal-cli.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+/**
+ * Regression pin for PR #1260: `switchroom auth heal <agent> --json
+ * --config-dir <dir>` must NOT load the global switchroom.yaml.
+ *
+ * boot-self-test.sh shells this from start.sh under a stripped env;
+ * any host where the test temp dir has no switchroom.yaml in its
+ * ancestor chain (e.g. buildkite hosted agents cloning into
+ * /buildkite/builds/...) used to cause `getConfig` → ConfigError →
+ * `2>/dev/null` swallow → empty DIAG_JSON → 5 `boot-self-test.sh >
+ * records auth.*` tests fail with "expected undefined to be defined".
+ *
+ * The end-to-end coverage in tests/boot-self-test.test.ts is what
+ * surfaced the regression on buildkite, but only after main was red.
+ * This test exercises the CLI layer directly with HOME pointed at an
+ * empty temp dir so no `findConfigFile()` walk can succeed — catches
+ * the same class of breakage in `npm run lint`-time, not in CI.
+ */
+
+const CLI = resolve(__dirname, "..", "dist", "cli", "switchroom.js");
+const BUN = process.env.BUN_PATH ?? "bun";
+
+let scratch: string;
+let emptyHome: string;
+let configDir: string;
+
+beforeEach(() => {
+  scratch = mkdtempSync(join(tmpdir(), "auth-heal-cli-"));
+  emptyHome = mkdtempSync(join(tmpdir(), "auth-heal-home-"));
+  configDir = join(scratch, "claude-config");
+  mkdirSync(configDir, { recursive: true });
+});
+
+afterEach(() => {
+  rmSync(scratch, { recursive: true, force: true });
+  rmSync(emptyHome, { recursive: true, force: true });
+});
+
+function runHeal(args: string[], env: Record<string, string> = {}): {
+  stdout: string;
+  stderr: string;
+  status: number;
+} {
+  try {
+    const stdout = execFileSync(BUN, [CLI, "auth", "heal", "testagent", ...args], {
+      stdio: ["ignore", "pipe", "pipe"],
+      encoding: "utf-8",
+      // Stripped env so the binary can't walk up to a real ~/.switchroom/switchroom.yaml.
+      env: {
+        PATH: process.env.PATH ?? "/usr/bin:/bin",
+        HOME: emptyHome,
+        ...env,
+      },
+    });
+    return { stdout, stderr: "", status: 0 };
+  } catch (err) {
+    const e = err as { stdout?: Buffer | string; stderr?: Buffer | string; status?: number };
+    return {
+      stdout: typeof e.stdout === "string" ? e.stdout : (e.stdout ?? Buffer.alloc(0)).toString(),
+      stderr: typeof e.stderr === "string" ? e.stderr : (e.stderr ?? Buffer.alloc(0)).toString(),
+      status: e.status ?? 1,
+    };
+  }
+}
+
+describe("auth heal --json --config-dir (boot-self-test contract)", () => {
+  it("succeeds without a global switchroom.yaml in cwd when --config-dir is given", () => {
+    // Empty configDir → diagnoser reports credentials_missing.
+    const { stdout, status } = runHeal(["--json", "--config-dir", configDir]);
+    expect(status).toBe(0);
+    const diag = JSON.parse(stdout);
+    expect(diag.findings).toBeDefined();
+    expect(diag.findings.some((f: { code: string }) => f.code === "credentials_missing")).toBe(true);
+  });
+
+  it("diagnoses token_expired against a real .credentials.json", () => {
+    writeFileSync(
+      join(configDir, ".credentials.json"),
+      JSON.stringify({
+        claudeAiOauth: {
+          accessToken: "tok",
+          refreshToken: "rt",
+          expiresAt: Date.now() - 86_400_000,
+        },
+      }),
+    );
+    const { stdout, status } = runHeal(["--json", "--config-dir", configDir]);
+    expect(status).toBe(0);
+    const diag = JSON.parse(stdout);
+    expect(diag.findings.some((f: { code: string }) => f.code === "token_expired")).toBe(true);
+  });
+
+  it("WITHOUT --config-dir, falls back to global config (and errors cleanly if no yaml)", () => {
+    // No --config-dir means the handler walks to find switchroom.yaml.
+    // With HOME pointed at an empty temp dir, findConfigFile() should
+    // fail and the withConfigError wrapper should print a tidy red
+    // "Config error:" line and exit 1.
+    const { stderr, status } = runHeal(["--json"]);
+    expect(status).toBe(1);
+    expect(stderr).toMatch(/Config error:/);
+  });
+});


### PR DESCRIPTION
## Summary

Three small, related fixes — picking up the two reviewer-flagged follow-ups from PR #1260, plus a sixth `bun:test`-in-vitest-file caught by the new lint rule from PR #1265.

### 1. Restore `withConfigError` around inner `getConfig` (PR #1260 review nit)

PR #1260 dropped `withConfigError` from the `auth heal` handler so the `--config-dir` path wouldn't `ConfigError` on a missing global yaml. But that also stripped the chalk-red error formatting from the rare human-typed `switchroom auth heal foo` path (no `--config-dir`, no yaml). Wrap only the default-derivation branch so humans still get a tidy `Config error: …` line; programmatic (boot-self-test) path unchanged.

### 2. New unit test: `tests/auth-heal-cli.test.ts` (PR #1260 review nit)

The PR #1260 regression slipped past CI because `boot-self-test.test.ts` is end-to-end and the bug only surfaced on buildkite. New CLI-level test spawns `switchroom auth heal` with `HOME` pointed at an empty temp dir (so no `findConfigFile()` walk succeeds) and pins:

- `--json --config-dir <dir>` succeeds; emits `credentials_missing` on empty dir, `token_expired` on stale creds
- WITHOUT `--config-dir`, fails cleanly with `Config error:` + exit 1

The third pin also doubles as the regression test for the `withConfigError` polish.

### 3. Sixth `bun:test` → `vitest` swap caught by the new lint rule

`src/auth/broker/google-provider.test.ts` landed in #1263 (RFC G Phase 3b.2a) with `from "bun:test"`. The lint rule from PR #1265 (the one this PR just learned to depend on) caught it locally — confirms the rule works on a real wild file beyond my staged negative test.

## Test plan

- [x] `npm run lint` clean (all 4 checks)
- [x] `bun run test:vitest -- tests/auth-heal-cli.test.ts` → 3 pass
- [x] `bun run test:vitest -- src/cli/auth tests/auth tests/boot-self-test` → 264 pass / 2 skipped
- [ ] Buildkite Core tests green on the squash-merged commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)