### PR TITLE
feat(auth-broker): RFC G Phase 3b.2b — register Google when config provides credentials

### DIFF
--- a/src/auth/broker/google-provider.ts
+++ b/src/auth/broker/google-provider.ts
@@ -122,12 +122,11 @@ export class GoogleProvider implements Provider {
         expiresAt,
         scope: token.scope ?? "",
         clientId: this.opts.clientId,
-        // accountEmail is NOT in the refresh response — broker stores
-        // the account label (which IS the email per RFC G's per-account
-        // ACL) and the wrapper should look it up from there. Phase 3b.2b
-        // will pass the accountEmail through `req.clientId`-style
-        // smuggling or extend RefreshRequest properly.
-        accountEmail: req.clientId ?? "",
+        // Phase 3b.2b — read accountEmail as a first-class
+        // RefreshRequest field (Phase 3b.2a smuggled it through
+        // `clientId`). Falls back to clientId for transitional
+        // callers; new callers should pass accountEmail explicitly.
+        accountEmail: req.accountEmail ?? req.clientId ?? "",
         tokenType: "Bearer",
       },
     };

--- a/src/auth/broker/provider.ts
+++ b/src/auth/broker/provider.ts
@@ -100,6 +100,15 @@ export function accountKeyString(key: AccountKey): string {
  */
 export interface RefreshRequest {
   refreshToken: string;
+  /**
+   * Account identity within the provider's namespace. For Google
+   * this is the account email (e.g. "alice@example.com"); the
+   * provider stores it back into rawCredentials so consumers can
+   * route per-account. Phase 3b.2a temporarily smuggled this through
+   * `clientId`; Phase 3b.2b promotes it to a first-class field.
+   * Anthropic ignores this (uses the broker-side label directly).
+   */
+  accountEmail?: string;
   /** OAuth client id, when the provider needs it. */
   clientId?: string;
   /** Scope set to request, when the provider re-asserts scopes per refresh. */

--- a/src/auth/broker/server.test.ts
+++ b/src/auth/broker/server.test.ts
@@ -661,7 +661,14 @@ describe("AuthBroker — Google provider registration (Phase 3b.2b)", () => {
     broker.stop();
   });
 
-  it("when Google IS registered, registry rejection error lists both providers", async () => {
+  it("with both providers registered, the validateCredentialShape route uses GoogleProvider for google: requests", async () => {
+    // Instead of fighting the schema enum to test "unknown provider"
+    // rejection, this test confirms BOTH providers are registered by
+    // routing a malformed Google credentials object through
+    // add-account → registry.lookup("google").validateCredentialShape.
+    // If GoogleProvider weren't registered, the request would fail at
+    // the registry.has() gate with "not registered" instead of the
+    // shape-validation message.
     const h = makeHarness();
     const config = makeConfig(h, {
       active: "default",
@@ -681,14 +688,27 @@ describe("AuthBroker — Google provider registration (Phase 3b.2b)", () => {
       disableRefreshLoop: true,
     });
     await broker.start();
-    // The schema enum doesn't accept arbitrary strings, so we can't
-    // directly send `provider: "openai"`. But we CAN test the
-    // list-state path that exercises `providers.names()`. List-state
-    // doesn't carry provider field, so this test demonstrates registration
-    // by checking what Google's add-account error path does — see prior
-    // test. This test confirms that both registrations happen and we
-    // can opt out of Anthropic-only assumption.
-    expect(true).toBe(true); // implicit: registration succeeded if start() didn't throw
+    const resp = await rpc(join(h.socketRoot, "clerk", "sock"), {
+      v: 1,
+      id: "1",
+      op: "add-account",
+      label: "alice@example.com",
+      provider: "google",
+      credentials: {
+        // Missing required fields → GoogleProvider's
+        // validateCredentialShape rejects with field-name-specific message.
+        googleOauth: {
+          accessToken: "at",
+          // no refreshToken, expiresAt, etc
+        },
+      },
+    }) as { ok: boolean; error?: { code: string; message: string } };
+    // Schema-level validation actually fails first (incomplete
+    // googleOauth shape doesn't match GoogleCredentialsSchema), but
+    // either way the rejection message confirms Google's path was
+    // hit (not the "not registered" path).
+    expect(resp.ok).toBe(false);
+    expect(resp.error?.message).not.toContain("not registered");
     broker.stop();
   });
 

--- a/src/auth/broker/server.test.ts
+++ b/src/auth/broker/server.test.ts
@@ -688,6 +688,14 @@ describe("AuthBroker — Google provider registration (Phase 3b.2b)", () => {
       disableRefreshLoop: true,
     });
     await broker.start();
+    // Send WELL-FORMED Google credentials so the request passes
+    // schema validation and reaches the broker's dispatcher. The
+    // dispatcher routes through registry.lookup("google") (which
+    // requires GoogleProvider IS registered), runs
+    // validateCredentialShape, then hits the 3b.2c-deferral message
+    // for the storage path. If GoogleProvider weren't registered,
+    // it'd fail earlier at the registry.has() gate with a different
+    // message.
     const resp = await rpc(join(h.socketRoot, "clerk", "sock"), {
       v: 1,
       id: "1",
@@ -695,19 +703,21 @@ describe("AuthBroker — Google provider registration (Phase 3b.2b)", () => {
       label: "alice@example.com",
       provider: "google",
       credentials: {
-        // Missing required fields → GoogleProvider's
-        // validateCredentialShape rejects with field-name-specific message.
         googleOauth: {
-          accessToken: "at",
-          // no refreshToken, expiresAt, etc
+          accessToken: "at-x",
+          refreshToken: "rt-x",
+          expiresAt: 99999,
+          scope: "https://www.googleapis.com/auth/drive",
+          clientId: "client-id-x",
+          accountEmail: "alice@example.com",
+          tokenType: "Bearer",
         },
       },
     }) as { ok: boolean; error?: { code: string; message: string } };
-    // Schema-level validation actually fails first (incomplete
-    // googleOauth shape doesn't match GoogleCredentialsSchema), but
-    // either way the rejection message confirms Google's path was
-    // hit (not the "not registered" path).
+    // Reaches the storage-deferral path → confirms Google IS
+    // registered (otherwise we'd see "not registered" instead).
     expect(resp.ok).toBe(false);
+    expect(resp.error?.message).toContain("Phase 3b.2c");
     expect(resp.error?.message).not.toContain("not registered");
     broker.stop();
   });

--- a/src/auth/broker/server.test.ts
+++ b/src/auth/broker/server.test.ts
@@ -62,6 +62,8 @@ function makeConfig(h: Harness, overrides: Partial<{
   admin_agents: string[];
   consumers: Array<{ name: string; account: string; uid?: number }>;
   agents: Record<string, { auth?: { override?: string } }>;
+  /** Phase 3b.2b — set to enable Google provider registration. */
+  google_workspace: { google_client_id: string; google_client_secret: string };
 }> = {}): SwitchroomConfig {
   return ({
     switchroom: { version: 1, agents_dir: h.agentsDir },
@@ -73,6 +75,7 @@ function makeConfig(h: Harness, overrides: Partial<{
       admin_agents: overrides.admin_agents,
       consumers: overrides.consumers,
     },
+    google_workspace: overrides.google_workspace,
   } as unknown) as SwitchroomConfig;
 }
 
@@ -584,6 +587,142 @@ describe("AuthBroker — provider field gating (Phase 3b.1)", () => {
     }) as { ok: boolean; error?: { code: string; message: string } };
     expect(resp.ok).toBe(false);
     expect(resp.error?.code).toBe("INVALID_ARGS");
+    broker.stop();
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────
+// RFC G Phase 3b.2b — conditional GoogleProvider registration
+// ────────────────────────────────────────────────────────────────────────
+describe("AuthBroker — Google provider registration (Phase 3b.2b)", () => {
+  it("does NOT register Google when google_workspace config is absent", async () => {
+    const h = makeHarness();
+    const config = makeConfig(h, {
+      active: "default",
+      admin_agents: ["clerk"],
+      agents: { clerk: {} },
+    });
+    seedAccount(h, "default");
+    mkdirSync(join(h.agentsDir, "clerk"), { recursive: true });
+    const broker = new AuthBroker(config, {
+      home: h.home,
+      stateDir: h.stateDir,
+      socketRoot: h.socketRoot,
+      disableRefreshLoop: true,
+    });
+    await broker.start();
+    // Provider:google should be rejected as unknown.
+    const resp = await rpc(join(h.socketRoot, "clerk", "sock"), {
+      v: 1,
+      id: "1",
+      op: "rm-account",
+      label: "x",
+      provider: "google",
+    }) as { ok: boolean; error?: { code: string; message: string } };
+    expect(resp.ok).toBe(false);
+    expect(resp.error?.message).toContain("not registered");
+    expect(resp.error?.message).toMatch(/only .*anthropic.* available/);
+    broker.stop();
+  });
+
+  it("registers Google when google_workspace config provides client id + secret", async () => {
+    const h = makeHarness();
+    const config = makeConfig(h, {
+      active: "default",
+      admin_agents: ["clerk"],
+      agents: { clerk: {} },
+      google_workspace: {
+        google_client_id: "test-client-id",
+        google_client_secret: "test-secret",
+      },
+    });
+    seedAccount(h, "default");
+    mkdirSync(join(h.agentsDir, "clerk"), { recursive: true });
+    const broker = new AuthBroker(config, {
+      home: h.home,
+      stateDir: h.stateDir,
+      socketRoot: h.socketRoot,
+      disableRefreshLoop: true,
+    });
+    await broker.start();
+    // Provider:google now PASSES the registry gate but hits the
+    // 3b.2c-deferral message for the storage path.
+    const resp = await rpc(join(h.socketRoot, "clerk", "sock"), {
+      v: 1,
+      id: "1",
+      op: "rm-account",
+      label: "alice@example.com",
+      provider: "google",
+    }) as { ok: boolean; error?: { code: string; message: string } };
+    expect(resp.ok).toBe(false);
+    expect(resp.error?.message).toContain("Phase 3b.2c");
+    // Importantly — NOT "not registered" anymore. Google IS registered.
+    expect(resp.error?.message).not.toContain("not registered");
+    broker.stop();
+  });
+
+  it("when Google IS registered, registry rejection error lists both providers", async () => {
+    const h = makeHarness();
+    const config = makeConfig(h, {
+      active: "default",
+      admin_agents: ["clerk"],
+      agents: { clerk: {} },
+      google_workspace: {
+        google_client_id: "id",
+        google_client_secret: "secret",
+      },
+    });
+    seedAccount(h, "default");
+    mkdirSync(join(h.agentsDir, "clerk"), { recursive: true });
+    const broker = new AuthBroker(config, {
+      home: h.home,
+      stateDir: h.stateDir,
+      socketRoot: h.socketRoot,
+      disableRefreshLoop: true,
+    });
+    await broker.start();
+    // The schema enum doesn't accept arbitrary strings, so we can't
+    // directly send `provider: "openai"`. But we CAN test the
+    // list-state path that exercises `providers.names()`. List-state
+    // doesn't carry provider field, so this test demonstrates registration
+    // by checking what Google's add-account error path does — see prior
+    // test. This test confirms that both registrations happen and we
+    // can opt out of Anthropic-only assumption.
+    expect(true).toBe(true); // implicit: registration succeeded if start() didn't throw
+    broker.stop();
+  });
+
+  it("Google registration fails fast when client secret missing", async () => {
+    // (Defensive — schema requires both, but test the broker's
+    // null-check path independently.)
+    const h = makeHarness();
+    const config = makeConfig(h, {
+      active: "default",
+      admin_agents: ["clerk"],
+      agents: { clerk: {} },
+    }) as unknown as Record<string, unknown>;
+    // Inject a partial google_workspace block (missing secret).
+    config.google_workspace = { google_client_id: "id" };
+    const broker = new AuthBroker(config as unknown as SwitchroomConfig, {
+      home: h.home,
+      stateDir: h.stateDir,
+      socketRoot: h.socketRoot,
+      disableRefreshLoop: true,
+    });
+    seedAccount(h, "default");
+    mkdirSync(join(h.agentsDir, "clerk"), { recursive: true });
+    await broker.start();
+    // Google should NOT be registered — partial config is treated as
+    // "not configured" rather than half-configured.
+    const resp = await rpc(join(h.socketRoot, "clerk", "sock"), {
+      v: 1,
+      id: "1",
+      op: "rm-account",
+      label: "x",
+      provider: "google",
+    }) as { ok: boolean; error?: { code: string; message: string } };
+    expect(resp.ok).toBe(false);
+    expect(resp.error?.message).toContain("not registered");
     broker.stop();
   });
 });

--- a/src/auth/broker/server.ts
+++ b/src/auth/broker/server.ts
@@ -48,6 +48,7 @@ import {
   type AccountRefreshOptions,
 } from "../account-refresh.js";
 import { AnthropicProvider } from "./anthropic-provider.js";
+import { GoogleProvider } from "./google-provider.js";
 import { ProviderRegistry, type ProviderName } from "./provider.js";
 import {
   accountCredentialsPath,
@@ -220,11 +221,24 @@ export class AuthBroker {
     this.socketRoot = opts.socketRoot ?? AUTH_BROKER_ROOT;
 
     // Phase 3b.1b — register the Anthropic provider unconditionally.
-    // Phase 3b.2 will conditionally register Google when the
-    // `google_accounts:` config block is non-empty (no point loading
-    // a Google OAuth provider in installs that don't use it).
+    // Phase 3b.2b — conditionally register Google when the
+    // `google_workspace:` config block is set (carries the OAuth
+    // client id/secret the provider needs). No client config = no
+    // Google provider loaded; the broker still rejects
+    // `provider: "google"` requests via registry.has() per Phase 3b.1.
     this.providers = new ProviderRegistry();
     this.providers.register(new AnthropicProvider());
+    const googleClientId = config.google_workspace?.google_client_id;
+    const googleClientSecret = config.google_workspace?.google_client_secret;
+    if (googleClientId !== undefined && googleClientSecret !== undefined) {
+      this.providers.register(
+        new GoogleProvider({
+          clientId: googleClientId,
+          clientSecret: googleClientSecret,
+          fetcher: opts.fetcher as typeof fetch | undefined,
+        }),
+      );
+    }
 
     this.assertConfigConsistent(config);
   }
@@ -542,7 +556,7 @@ export class AuthBroker {
             encodeError(
               reqId,
               "INVALID_ARGS",
-              `refresh-account dispatch through provider '${provider}' lands in Phase 3b.2`,
+              `refresh-account dispatch through provider '${provider}' storage path lands in Phase 3b.2c (vault-broker-mediated, not direct-to-disk like Anthropic)`,
             ),
           );
           break;
@@ -594,7 +608,7 @@ export class AuthBroker {
             encodeError(
               reqId,
               "INVALID_ARGS",
-              `add-account storage path for provider '${provider}' lands in Phase 3b.2`,
+              `add-account storage path for provider '${provider}' lands in Phase 3b.2c (vault-broker-mediated, not direct-to-disk like Anthropic)`,
             ),
           );
           break;
@@ -619,7 +633,7 @@ export class AuthBroker {
             encodeError(
               reqId,
               "INVALID_ARGS",
-              `rm-account storage path for provider '${provider}' lands in Phase 3b.2`,
+              `rm-account storage path for provider '${provider}' lands in Phase 3b.2c (vault-broker-mediated, not direct-to-disk like Anthropic)`,
             ),
           );
           break;

--- a/src/auth/broker/server.ts
+++ b/src/auth/broker/server.ts
@@ -226,6 +226,23 @@ export class AuthBroker {
     // client id/secret the provider needs). No client config = no
     // Google provider loaded; the broker still rejects
     // `provider: "google"` requests via registry.has() per Phase 3b.1.
+    //
+    // **TODO (Phase 3b.2c):** the `google_client_id` / `_secret`
+    // schema fields accept `vault:<key>` references (per
+    // `src/config/schema.ts:759`); `src/cli/drive.ts:446-448`
+    // resolves them via `resolveMaybeVaultRef`. Today the broker
+    // passes the raw config string verbatim, so a vault-ref config
+    // would silently send a literal `"vault:..."` string to Google's
+    // token endpoint and fail. Phase 3b.2c must resolve vault refs
+    // here BEFORE constructing the GoogleProvider — otherwise the
+    // first refresh tick will surface a confusing error. Latent
+    // until 3b.2c wires storage; flagged here as a foot-gun.
+    //
+    // **Known limitation:** `reload()` does NOT re-run provider
+    // registration. An operator who adds `google_workspace:` to a
+    // running broker and SIGHUPs will need to restart the broker
+    // for the provider to be picked up. Acceptable for v1; track
+    // as a future-hardening item.
     this.providers = new ProviderRegistry();
     this.providers.register(new AnthropicProvider());
     const googleClientId = config.google_workspace?.google_client_id;


### PR DESCRIPTION
## Summary

Builds on Phase 3b.2a (#1264) by conditionally registering GoogleProvider with the broker when \`google_workspace.google_client_id\` + \`_secret\` are set in switchroom.yaml. Also promotes accountEmail from the Phase 3b.2a clientId-smuggling shape to a first-class RefreshRequest field.

## After this PR

- \`provider: "google"\` requests pass the registry.has() gate when Google config is set
- The credentials-shape validation runs through the GoogleProvider's validateCredentialShape (already shipped in 3b.2a)
- Storage path returns "Phase 3b.2c" deferral message — Google needs vault-broker-mediated storage (vs Anthropic's direct-to-disk per-agent mirror) and that's the next PR

## Honest scope

**Phase 3b.2c (next):** wire the actual Google storage path. When dispatcher hits \`provider === "google"\` for add-account / rm-account / refresh, write to \`vault:google:<account>:refresh_token\` via the existing vault-broker helpers (Phase 2 \`src/drive/vault-slots.ts\`), with per-account ACL gating already enforced via Phase 2's \`checkAclByAgent\` google: routing.

## Tests — 105/105

- 4 new tests covering: Google NOT registered when config absent; Google IS registered when both client id+secret present; both providers loaded successfully; partial config (id without secret) treated as not-configured rather than half-configured
- 101 prior broker tests still pass

## Test plan

- [x] \`bun test src/auth/broker/\` — 105/105 pass
- [x] \`tsc --noEmit\` — clean
- [ ] Independent reviewer verdict (will dispatch after PR open)

🤖 Generated with [Claude Code](https://claude.com/claude-code)