### PR TITLE
feat(auth-broker): RFC G Phase 3b.2c — Google credential storage in broker stateDir

### DIFF
--- a/src/auth/broker/google-storage.test.ts
+++ b/src/auth/broker/google-storage.test.ts
@@ -1,0 +1,174 @@
+/**
+ * Tests for google-storage — RFC G Phase 3b.2c.
+ *
+ * Covers normalize / read / write / remove / list with a tmpdir
+ * stateDir. No mocking — real filesystem.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { existsSync, mkdtempSync, readFileSync, rmSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  googleAccountCredentialsPath,
+  googleAccountDir,
+  googleAccountExists,
+  listGoogleAccounts,
+  normalizeGoogleAccountForStorage,
+  readGoogleAccountCredentials,
+  removeGoogleAccount,
+  writeGoogleAccountCredentials,
+} from "./google-storage.js";
+import type { GoogleCredentialsShape } from "./protocol.js";
+
+let stateDir: string;
+
+beforeEach(() => {
+  stateDir = mkdtempSync(join(tmpdir(), "google-storage-test-"));
+});
+
+afterEach(() => {
+  rmSync(stateDir, { recursive: true, force: true });
+});
+
+const sampleCreds: GoogleCredentialsShape = {
+  googleOauth: {
+    accessToken: "at-x",
+    refreshToken: "rt-x",
+    expiresAt: 99999,
+    scope: "https://www.googleapis.com/auth/drive",
+    clientId: "client-id-x",
+    accountEmail: "alice@example.com",
+    tokenType: "Bearer",
+  },
+};
+
+describe("normalizeGoogleAccountForStorage", () => {
+  it("lowercases + trims", () => {
+    expect(normalizeGoogleAccountForStorage("  Alice@Example.COM ")).toBe("alice@example.com");
+  });
+});
+
+describe("paths", () => {
+  it("googleAccountDir is <stateDir>/google/<normalized-account>/", () => {
+    expect(googleAccountDir(stateDir, "Alice@Example.COM")).toBe(
+      join(stateDir, "google", "alice@example.com"),
+    );
+  });
+
+  it("googleAccountCredentialsPath appends credentials.json", () => {
+    expect(googleAccountCredentialsPath(stateDir, "alice@example.com")).toBe(
+      join(stateDir, "google", "alice@example.com", "credentials.json"),
+    );
+  });
+});
+
+describe("write + read round-trip", () => {
+  it("write creates the dir + file, read returns the credentials verbatim", () => {
+    writeGoogleAccountCredentials(stateDir, "alice@example.com", sampleCreds);
+    const read = readGoogleAccountCredentials(stateDir, "alice@example.com");
+    expect(read).toEqual(sampleCreds);
+  });
+
+  it("writes credentials.json with mode 0600", () => {
+    writeGoogleAccountCredentials(stateDir, "alice@example.com", sampleCreds);
+    const path = googleAccountCredentialsPath(stateDir, "alice@example.com");
+    const stat = statSync(path);
+    // mask off the file-type bits, check perms
+    expect(stat.mode & 0o777).toBe(0o600);
+  });
+
+  it("normalization makes case-variant reads hit the same file", () => {
+    writeGoogleAccountCredentials(stateDir, "alice@example.com", sampleCreds);
+    const read = readGoogleAccountCredentials(stateDir, "ALICE@EXAMPLE.COM");
+    expect(read).toEqual(sampleCreds);
+  });
+
+  it("overwrites existing credentials atomically", () => {
+    writeGoogleAccountCredentials(stateDir, "alice@example.com", sampleCreds);
+    const updated = {
+      googleOauth: { ...sampleCreds.googleOauth, accessToken: "at-NEW" },
+    };
+    writeGoogleAccountCredentials(stateDir, "alice@example.com", updated);
+    expect(readGoogleAccountCredentials(stateDir, "alice@example.com")).toEqual(updated);
+  });
+});
+
+describe("read returns null for missing/malformed", () => {
+  it("returns null when credentials.json is absent", () => {
+    expect(readGoogleAccountCredentials(stateDir, "nobody@example.com")).toBe(null);
+  });
+
+  it("returns null when JSON is malformed", () => {
+    const path = googleAccountCredentialsPath(stateDir, "alice@example.com");
+    require("node:fs").mkdirSync(require("node:path").dirname(path), {
+      recursive: true,
+      mode: 0o700,
+    });
+    require("node:fs").writeFileSync(path, "{not json", { mode: 0o600 });
+    expect(readGoogleAccountCredentials(stateDir, "alice@example.com")).toBe(null);
+  });
+
+  it("returns null when shape lacks googleOauth.accessToken", () => {
+    const path = googleAccountCredentialsPath(stateDir, "alice@example.com");
+    require("node:fs").mkdirSync(require("node:path").dirname(path), {
+      recursive: true,
+      mode: 0o700,
+    });
+    require("node:fs").writeFileSync(path, JSON.stringify({ googleOauth: {} }), {
+      mode: 0o600,
+    });
+    expect(readGoogleAccountCredentials(stateDir, "alice@example.com")).toBe(null);
+  });
+});
+
+describe("googleAccountExists", () => {
+  it("false before write, true after, false after remove", () => {
+    expect(googleAccountExists(stateDir, "alice@example.com")).toBe(false);
+    writeGoogleAccountCredentials(stateDir, "alice@example.com", sampleCreds);
+    expect(googleAccountExists(stateDir, "alice@example.com")).toBe(true);
+    removeGoogleAccount(stateDir, "alice@example.com");
+    expect(googleAccountExists(stateDir, "alice@example.com")).toBe(false);
+  });
+});
+
+describe("removeGoogleAccount", () => {
+  it("removes the per-account directory", () => {
+    writeGoogleAccountCredentials(stateDir, "alice@example.com", sampleCreds);
+    expect(existsSync(googleAccountDir(stateDir, "alice@example.com"))).toBe(true);
+    removeGoogleAccount(stateDir, "alice@example.com");
+    expect(existsSync(googleAccountDir(stateDir, "alice@example.com"))).toBe(false);
+  });
+
+  it("idempotent — removing absent account is a no-op", () => {
+    expect(() => removeGoogleAccount(stateDir, "nobody@example.com")).not.toThrow();
+  });
+});
+
+describe("listGoogleAccounts", () => {
+  it("returns [] when state dir doesn't have a google subdir", () => {
+    expect(listGoogleAccounts(stateDir)).toEqual([]);
+  });
+
+  it("returns all accounts that have credentials.json", () => {
+    writeGoogleAccountCredentials(stateDir, "alice@example.com", sampleCreds);
+    writeGoogleAccountCredentials(stateDir, "work@bigcorp.com", {
+      googleOauth: { ...sampleCreds.googleOauth, accountEmail: "work@bigcorp.com" },
+    });
+    expect(listGoogleAccounts(stateDir).sort()).toEqual([
+      "alice@example.com",
+      "work@bigcorp.com",
+    ]);
+  });
+
+  it("excludes dirs without credentials.json (defensive against half-removed state)", () => {
+    writeGoogleAccountCredentials(stateDir, "alice@example.com", sampleCreds);
+    // Create an empty dir that doesn't have credentials.json
+    require("node:fs").mkdirSync(
+      join(stateDir, "google", "ghost@example.com"),
+      { recursive: true, mode: 0o700 },
+    );
+    expect(listGoogleAccounts(stateDir).sort()).toEqual(["alice@example.com"]);
+  });
+});

--- a/src/auth/broker/google-storage.test.ts
+++ b/src/auth/broker/google-storage.test.ts
@@ -5,10 +5,10 @@
  * stateDir. No mocking — real filesystem.
  */
 
-import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import { existsSync, mkdtempSync, readFileSync, rmSync, statSync } from "node:fs";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 
 import {
   googleAccountCredentialsPath,
@@ -18,6 +18,7 @@ import {
   normalizeGoogleAccountForStorage,
   readGoogleAccountCredentials,
   removeGoogleAccount,
+  validateGoogleAccountLabel,
   writeGoogleAccountCredentials,
 } from "./google-storage.js";
 import type { GoogleCredentialsShape } from "./protocol.js";
@@ -102,23 +103,15 @@ describe("read returns null for missing/malformed", () => {
 
   it("returns null when JSON is malformed", () => {
     const path = googleAccountCredentialsPath(stateDir, "alice@example.com");
-    require("node:fs").mkdirSync(require("node:path").dirname(path), {
-      recursive: true,
-      mode: 0o700,
-    });
-    require("node:fs").writeFileSync(path, "{not json", { mode: 0o600 });
+    mkdirSync(dirname(path), { recursive: true, mode: 0o700 });
+    writeFileSync(path, "{not json", { mode: 0o600 });
     expect(readGoogleAccountCredentials(stateDir, "alice@example.com")).toBe(null);
   });
 
   it("returns null when shape lacks googleOauth.accessToken", () => {
     const path = googleAccountCredentialsPath(stateDir, "alice@example.com");
-    require("node:fs").mkdirSync(require("node:path").dirname(path), {
-      recursive: true,
-      mode: 0o700,
-    });
-    require("node:fs").writeFileSync(path, JSON.stringify({ googleOauth: {} }), {
-      mode: 0o600,
-    });
+    mkdirSync(dirname(path), { recursive: true, mode: 0o700 });
+    writeFileSync(path, JSON.stringify({ googleOauth: {} }), { mode: 0o600 });
     expect(readGoogleAccountCredentials(stateDir, "alice@example.com")).toBe(null);
   });
 });
@@ -165,10 +158,57 @@ describe("listGoogleAccounts", () => {
   it("excludes dirs without credentials.json (defensive against half-removed state)", () => {
     writeGoogleAccountCredentials(stateDir, "alice@example.com", sampleCreds);
     // Create an empty dir that doesn't have credentials.json
-    require("node:fs").mkdirSync(
-      join(stateDir, "google", "ghost@example.com"),
-      { recursive: true, mode: 0o700 },
-    );
+    mkdirSync(join(stateDir, "google", "ghost@example.com"), {
+      recursive: true,
+      mode: 0o700,
+    });
     expect(listGoogleAccounts(stateDir).sort()).toEqual(["alice@example.com"]);
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────
+// validateGoogleAccountLabel — defense-in-depth path-traversal guard
+// per Phase 3b.2c reviewer feedback.
+// ────────────────────────────────────────────────────────────────────────
+
+describe("validateGoogleAccountLabel", () => {
+  it("accepts valid email-shaped labels", () => {
+    expect(() => validateGoogleAccountLabel("alice@example.com")).not.toThrow();
+    expect(() => validateGoogleAccountLabel("alice+work@example.co.uk")).not.toThrow();
+  });
+
+  it("rejects empty string", () => {
+    expect(() => validateGoogleAccountLabel("")).toThrow(/non-empty/);
+  });
+
+  it("rejects path-traversal sequences", () => {
+    expect(() => validateGoogleAccountLabel("..")).toThrow(/email shape/);
+    expect(() => validateGoogleAccountLabel("../../../etc/passwd")).toThrow();
+  });
+
+  it("rejects forward and back slashes", () => {
+    expect(() => validateGoogleAccountLabel("alice/bob@example.com")).toThrow();
+    expect(() => validateGoogleAccountLabel("alice\\bob@example.com")).toThrow();
+  });
+
+  it("rejects whitespace + leading/trailing whitespace", () => {
+    expect(() => validateGoogleAccountLabel("alice bob@example.com")).toThrow();
+    expect(() => validateGoogleAccountLabel("  alice@example.com  ")).toThrow();
+    expect(() => validateGoogleAccountLabel("alice@example.com\n")).toThrow();
+  });
+
+  it("rejects colons (broker slot-key separator)", () => {
+    expect(() => validateGoogleAccountLabel("alice:risky@example.com")).toThrow();
+  });
+
+  it("rejects null bytes", () => {
+    expect(() => validateGoogleAccountLabel("alice @example.com")).toThrow();
+  });
+
+  it("rejects non-string input via type-narrowing", () => {
+    expect(() => validateGoogleAccountLabel(undefined as unknown as string)).toThrow(
+      /non-empty/,
+    );
+    expect(() => validateGoogleAccountLabel(null as unknown as string)).toThrow();
   });
 });

--- a/src/auth/broker/google-storage.ts
+++ b/src/auth/broker/google-storage.ts
@@ -30,7 +30,7 @@
  * names but worth confirming.
  */
 
-import { existsSync, mkdirSync, readFileSync, rmSync } from "node:fs";
+import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync, statSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 
 import { atomicWriteFileSync } from "../../util/atomic.js";
@@ -44,6 +44,46 @@ import type { GoogleCredentialsShape } from "./protocol.js";
  */
 export function normalizeGoogleAccountForStorage(account: string): string {
   return account.trim().toLowerCase();
+}
+
+/**
+ * Validate that an account label is safe to use as a filesystem path
+ * component before any fs op touches it. Refuses path-traversal
+ * (`..`), separators (`/` `\`), null bytes, empty, and anything else
+ * that doesn't fit the email-shape contract Phase 2 already
+ * enforces at the schema layer.
+ *
+ * Throws on rejection with an operator-actionable message. Callers
+ * (broker dispatcher) wrap throws into `INVALID_ARGS` errors.
+ *
+ * Mirrors the schema-side regex from
+ * `src/config/schema.ts:google_accounts` key validator. Defense in
+ * depth — the broker can't assume the schema has already filtered
+ * (admin clients sending raw protocol frames bypass schema).
+ */
+export function validateGoogleAccountLabel(account: string): void {
+  if (typeof account !== "string" || account.length === 0) {
+    throw new Error(`Google account label must be a non-empty string`);
+  }
+  if (account !== account.trim()) {
+    throw new Error(`Google account label must not have leading/trailing whitespace`);
+  }
+  // Reject control characters explicitly. `\s` in JS regex matches
+  // ASCII/Unicode whitespace but NOT `\x00` (null) or other control
+  // chars, so a label like `"alice\0@example.com"` would slip through
+  // the email-shape regex below. POSIX filenames also reject null
+  // bytes — defending here keeps fs ops well-formed.
+  if (/[\x00-\x1f\x7f]/.test(account)) {
+    throw new Error(`Google account label '${account.replace(/[\x00-\x1f\x7f]/g, "?")}' contains control characters; email shape rejects them.`);
+  }
+  // Character allowlist matches the schema regex (`[^@\s:]+@[^@\s:]+\.[^@\s:]+`).
+  // No path separators, no `..`, no whitespace, no `:` (which the
+  // broker's slot-key parser uses).
+  if (!/^[^@\s:/\\]+@[^@\s:/\\]+\.[^@\s:/\\]+$/.test(account)) {
+    throw new Error(
+      `Google account label '${account}' is not a valid email shape. Expected like 'alice@example.com' (no slashes, colons, or whitespace).`,
+    );
+  }
 }
 
 /**
@@ -138,7 +178,6 @@ export function removeGoogleAccount(stateDir: string, account: string): void {
 export function listGoogleAccounts(stateDir: string): string[] {
   const root = join(stateDir, "google");
   if (!existsSync(root)) return [];
-  const { readdirSync, statSync } = require("node:fs") as typeof import("node:fs");
   return readdirSync(root)
     .filter((name) => {
       try {

--- a/src/auth/broker/google-storage.ts
+++ b/src/auth/broker/google-storage.ts
@@ -1,0 +1,153 @@
+/**
+ * Google credential storage for the auth-broker (RFC G Phase 3b.2c).
+ *
+ * **Pragmatic shortcut**: Google credentials live in the auth-broker's
+ * own state dir at `~/.switchroom/state/auth-broker/google/<account>/`,
+ * NOT (yet) in the vault-broker. RFC G v3 §4.4 specified vault-broker-
+ * mediated storage (so refresh tokens live in the encrypted vault),
+ * but that requires:
+ *   - A `set-secret-for-peer` verb on vault-broker (doesn't exist)
+ *   - auth-broker as a vault-broker peer with appropriate ACL
+ *   - Cross-broker IPC client library
+ *
+ * Building those is its own multi-PR architectural piece. **Phase
+ * 3b.2d** (future) will migrate from on-disk-here to vault-broker-
+ * mediated. Until then Google credentials live alongside Anthropic
+ * (which also stores plaintext on disk under `~/.switchroom/accounts/`)
+ * — same security posture as the existing pattern.
+ *
+ * Storage layout:
+ *
+ *   ~/.switchroom/state/auth-broker/google/
+ *     alice@example.com/
+ *       credentials.json   ← `{ googleOauth: { ... } }` verbatim, mode 0600
+ *     work@bigcorp.com/
+ *       credentials.json
+ *
+ * Account labels are normalized to lowercase + trimmed (Phase 2's
+ * `normalizeGoogleAccount` shape) before being used as directory
+ * names. Email-shape emails contain `@` which is safe in filesystem
+ * names but worth confirming.
+ */
+
+import { existsSync, mkdirSync, readFileSync, rmSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+
+import { atomicWriteFileSync } from "../../util/atomic.js";
+import type { GoogleCredentialsShape } from "./protocol.js";
+
+/**
+ * Normalize an account email to the on-disk-safe form. Mirrors
+ * `src/drive/vault-slots.ts:normalizeGoogleAccount` so the same
+ * label resolves identically regardless of which subsystem writes
+ * it.
+ */
+export function normalizeGoogleAccountForStorage(account: string): string {
+  return account.trim().toLowerCase();
+}
+
+/**
+ * Resolve the per-account directory under the broker's state dir.
+ * Caller passes the broker's own stateDir (typically
+ * `~/.switchroom/state/auth-broker/`).
+ */
+export function googleAccountDir(stateDir: string, account: string): string {
+  return resolve(
+    stateDir,
+    "google",
+    normalizeGoogleAccountForStorage(account),
+  );
+}
+
+export function googleAccountCredentialsPath(
+  stateDir: string,
+  account: string,
+): string {
+  return join(googleAccountDir(stateDir, account), "credentials.json");
+}
+
+/**
+ * Whether the per-account directory exists. Used by `add-account` to
+ * detect "account already exists" vs "first add."
+ */
+export function googleAccountExists(
+  stateDir: string,
+  account: string,
+): boolean {
+  return existsSync(googleAccountCredentialsPath(stateDir, account));
+}
+
+/**
+ * Read the per-account credentials.json. Returns null if absent or
+ * malformed (broker treats missing/malformed as "needs add-account").
+ */
+export function readGoogleAccountCredentials(
+  stateDir: string,
+  account: string,
+): GoogleCredentialsShape | null {
+  const path = googleAccountCredentialsPath(stateDir, account);
+  if (!existsSync(path)) return null;
+  try {
+    const raw = readFileSync(path, "utf-8");
+    const parsed = JSON.parse(raw) as Partial<GoogleCredentialsShape>;
+    if (!parsed?.googleOauth?.accessToken) return null;
+    return parsed as GoogleCredentialsShape;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Write per-account credentials.json. Creates the parent dir if
+ * absent (mode 0700). File written via atomicWriteFileSync — same
+ * semantics as Anthropic credential writes; survives concurrent
+ * readers.
+ *
+ * Returns the absolute path written so callers can audit.
+ */
+export function writeGoogleAccountCredentials(
+  stateDir: string,
+  account: string,
+  credentials: GoogleCredentialsShape,
+): string {
+  const path = googleAccountCredentialsPath(stateDir, account);
+  mkdirSync(dirname(path), { recursive: true, mode: 0o700 });
+  atomicWriteFileSync(path, JSON.stringify(credentials, null, 2), 0o600);
+  return path;
+}
+
+/**
+ * Delete the per-account directory + credentials. Idempotent — no
+ * error if the account doesn't exist.
+ */
+export function removeGoogleAccount(stateDir: string, account: string): void {
+  const dir = googleAccountDir(stateDir, account);
+  if (existsSync(dir)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+/**
+ * List all Google accounts the broker has stored. Used by `list-state`
+ * (Phase 3b.2c.2 future) and the doctor.
+ *
+ * Reads filesystem layout, not in-memory state — operators can drop
+ * a credentials.json by hand and the broker will pick it up on next
+ * read (same shape as Anthropic).
+ */
+export function listGoogleAccounts(stateDir: string): string[] {
+  const root = join(stateDir, "google");
+  if (!existsSync(root)) return [];
+  const { readdirSync, statSync } = require("node:fs") as typeof import("node:fs");
+  return readdirSync(root)
+    .filter((name) => {
+      try {
+        return statSync(join(root, name)).isDirectory();
+      } catch {
+        return false;
+      }
+    })
+    .filter((name) =>
+      existsSync(join(root, name, "credentials.json")),
+    );
+}

--- a/src/auth/broker/server.test.ts
+++ b/src/auth/broker/server.test.ts
@@ -813,6 +813,75 @@ describe("AuthBroker — Google provider registration (Phase 3b.2b)", () => {
     broker.stop();
   });
 
+  it("Phase 3b.2c — add-account rejects path-traversal labels (defense-in-depth)", async () => {
+    const h = makeHarness();
+    const config = makeConfig(h, {
+      active: "default",
+      admin_agents: ["clerk"],
+      agents: { clerk: {} },
+      google_workspace: {
+        google_client_id: "id",
+        google_client_secret: "secret",
+      },
+    });
+    seedAccount(h, "default");
+    mkdirSync(join(h.agentsDir, "clerk"), { recursive: true });
+    const broker = new AuthBroker(config, {
+      home: h.home,
+      stateDir: h.stateDir,
+      socketRoot: h.socketRoot,
+      disableRefreshLoop: true,
+    });
+    await broker.start();
+    // Attempt path-traversal via the label.
+    const resp = await rpc(join(h.socketRoot, "clerk", "sock"), {
+      v: 1, id: "1", op: "add-account", label: "../../../etc/passwd",
+      provider: "google",
+      credentials: {
+        googleOauth: {
+          accessToken: "at", refreshToken: "rt", expiresAt: 1, scope: "x",
+          clientId: "cid", accountEmail: "alice@example.com",
+          tokenType: "Bearer" as const,
+        },
+      },
+    }) as { ok: boolean; error?: { code: string; message: string } };
+    expect(resp.ok).toBe(false);
+    expect(resp.error?.code).toBe("INVALID_ARGS");
+    expect(resp.error?.message).toContain("email shape");
+    // Verify nothing was written outside stateDir.
+    expect(existsSync(join(h.stateDir, "..", "..", "..", "etc", "passwd"))).toBe(false);
+    broker.stop();
+  });
+
+  it("Phase 3b.2c — rm-account rejects path-traversal labels", async () => {
+    const h = makeHarness();
+    const config = makeConfig(h, {
+      active: "default",
+      admin_agents: ["clerk"],
+      agents: { clerk: {} },
+      google_workspace: {
+        google_client_id: "id",
+        google_client_secret: "secret",
+      },
+    });
+    seedAccount(h, "default");
+    mkdirSync(join(h.agentsDir, "clerk"), { recursive: true });
+    const broker = new AuthBroker(config, {
+      home: h.home,
+      stateDir: h.stateDir,
+      socketRoot: h.socketRoot,
+      disableRefreshLoop: true,
+    });
+    await broker.start();
+    const resp = await rpc(join(h.socketRoot, "clerk", "sock"), {
+      v: 1, id: "1", op: "rm-account", label: "../escape",
+      provider: "google",
+    }) as { ok: boolean; error?: { code: string } };
+    expect(resp.ok).toBe(false);
+    expect(resp.error?.code).toBe("INVALID_ARGS");
+    broker.stop();
+  });
+
   it("Phase 3b.2c — rm-account succeeds after add when no agents are enabled", async () => {
     const h = makeHarness();
     const config = makeConfig(h, {

--- a/src/auth/broker/server.test.ts
+++ b/src/auth/broker/server.test.ts
@@ -12,7 +12,7 @@
  */
 
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import * as net from "node:net";
@@ -645,8 +645,8 @@ describe("AuthBroker — Google provider registration (Phase 3b.2b)", () => {
       disableRefreshLoop: true,
     });
     await broker.start();
-    // Provider:google now PASSES the registry gate but hits the
-    // 3b.2c-deferral message for the storage path.
+    // Phase 3b.2c — rm-account on a non-existent Google account
+    // returns ACCOUNT_NOT_FOUND (the storage path is real now).
     const resp = await rpc(join(h.socketRoot, "clerk", "sock"), {
       v: 1,
       id: "1",
@@ -655,20 +655,13 @@ describe("AuthBroker — Google provider registration (Phase 3b.2b)", () => {
       provider: "google",
     }) as { ok: boolean; error?: { code: string; message: string } };
     expect(resp.ok).toBe(false);
-    expect(resp.error?.message).toContain("Phase 3b.2c");
+    expect(resp.error?.code).toBe("ACCOUNT_NOT_FOUND");
     // Importantly — NOT "not registered" anymore. Google IS registered.
     expect(resp.error?.message).not.toContain("not registered");
     broker.stop();
   });
 
-  it("with both providers registered, the validateCredentialShape route uses GoogleProvider for google: requests", async () => {
-    // Instead of fighting the schema enum to test "unknown provider"
-    // rejection, this test confirms BOTH providers are registered by
-    // routing a malformed Google credentials object through
-    // add-account → registry.lookup("google").validateCredentialShape.
-    // If GoogleProvider weren't registered, the request would fail at
-    // the registry.has() gate with "not registered" instead of the
-    // shape-validation message.
+  it("Phase 3b.2c — add-account with Google credentials writes to broker stateDir and succeeds", async () => {
     const h = makeHarness();
     const config = makeConfig(h, {
       active: "default",
@@ -688,14 +681,6 @@ describe("AuthBroker — Google provider registration (Phase 3b.2b)", () => {
       disableRefreshLoop: true,
     });
     await broker.start();
-    // Send WELL-FORMED Google credentials so the request passes
-    // schema validation and reaches the broker's dispatcher. The
-    // dispatcher routes through registry.lookup("google") (which
-    // requires GoogleProvider IS registered), runs
-    // validateCredentialShape, then hits the 3b.2c-deferral message
-    // for the storage path. If GoogleProvider weren't registered,
-    // it'd fail earlier at the registry.has() gate with a different
-    // message.
     const resp = await rpc(join(h.socketRoot, "clerk", "sock"), {
       v: 1,
       id: "1",
@@ -713,12 +698,162 @@ describe("AuthBroker — Google provider registration (Phase 3b.2b)", () => {
           tokenType: "Bearer",
         },
       },
+    }) as { ok: boolean; data?: { label: string; expiresAt?: number } };
+    expect(resp.ok).toBe(true);
+    expect(resp.data?.label).toBe("alice@example.com");
+    expect(resp.data?.expiresAt).toBe(99999);
+    // Verify the credentials.json is on disk under the broker stateDir.
+    const credPath = join(
+      h.stateDir,
+      "google",
+      "alice@example.com",
+      "credentials.json",
+    );
+    expect(existsSync(credPath)).toBe(true);
+    broker.stop();
+  });
+
+  it("Phase 3b.2c — add-account refuses duplicate without replace:true", async () => {
+    const h = makeHarness();
+    const config = makeConfig(h, {
+      active: "default",
+      admin_agents: ["clerk"],
+      agents: { clerk: {} },
+      google_workspace: {
+        google_client_id: "id",
+        google_client_secret: "secret",
+      },
+    });
+    seedAccount(h, "default");
+    mkdirSync(join(h.agentsDir, "clerk"), { recursive: true });
+    const broker = new AuthBroker(config, {
+      home: h.home,
+      stateDir: h.stateDir,
+      socketRoot: h.socketRoot,
+      disableRefreshLoop: true,
+    });
+    await broker.start();
+    const validCreds = {
+      accessToken: "at-1",
+      refreshToken: "rt-1",
+      expiresAt: 1234,
+      scope: "drive",
+      clientId: "cid",
+      accountEmail: "alice@example.com",
+      tokenType: "Bearer" as const,
+    };
+    // First add succeeds.
+    const r1 = await rpc(join(h.socketRoot, "clerk", "sock"), {
+      v: 1, id: "1", op: "add-account", label: "alice@example.com",
+      provider: "google", credentials: { googleOauth: validCreds },
+    }) as { ok: boolean };
+    expect(r1.ok).toBe(true);
+    // Second without replace fails with ACCOUNT_ALREADY_EXISTS.
+    const r2 = await rpc(join(h.socketRoot, "clerk", "sock"), {
+      v: 1, id: "2", op: "add-account", label: "alice@example.com",
+      provider: "google", credentials: { googleOauth: validCreds },
+    }) as { ok: boolean; error?: { code: string } };
+    expect(r2.ok).toBe(false);
+    expect(r2.error?.code).toBe("ACCOUNT_ALREADY_EXISTS");
+    // With replace:true succeeds.
+    const r3 = await rpc(join(h.socketRoot, "clerk", "sock"), {
+      v: 1, id: "3", op: "add-account", label: "alice@example.com",
+      provider: "google", credentials: { googleOauth: validCreds },
+      replace: true,
+    }) as { ok: boolean };
+    expect(r3.ok).toBe(true);
+    broker.stop();
+  });
+
+  it("Phase 3b.2c — rm-account refuses to remove while agent is in google_accounts.enabled_for[]", async () => {
+    const h = makeHarness();
+    const config = makeConfig(h, {
+      active: "default",
+      admin_agents: ["clerk"],
+      agents: { clerk: {} },
+      google_workspace: {
+        google_client_id: "id",
+        google_client_secret: "secret",
+      },
+    });
+    // Inject a google_accounts ACL entry with the agent enabled.
+    (config as unknown as Record<string, unknown>).google_accounts = {
+      "alice@example.com": { enabled_for: ["klanker"] },
+    };
+    seedAccount(h, "default");
+    mkdirSync(join(h.agentsDir, "clerk"), { recursive: true });
+    const broker = new AuthBroker(config, {
+      home: h.home,
+      stateDir: h.stateDir,
+      socketRoot: h.socketRoot,
+      disableRefreshLoop: true,
+    });
+    await broker.start();
+    // Add the account first.
+    await rpc(join(h.socketRoot, "clerk", "sock"), {
+      v: 1, id: "1", op: "add-account", label: "alice@example.com",
+      provider: "google",
+      credentials: {
+        googleOauth: {
+          accessToken: "at", refreshToken: "rt", expiresAt: 1, scope: "x",
+          clientId: "cid", accountEmail: "alice@example.com",
+          tokenType: "Bearer" as const,
+        },
+      },
+    });
+    // Try to remove with agent still enabled.
+    const resp = await rpc(join(h.socketRoot, "clerk", "sock"), {
+      v: 1, id: "2", op: "rm-account", label: "alice@example.com",
+      provider: "google",
     }) as { ok: boolean; error?: { code: string; message: string } };
-    // Reaches the storage-deferral path → confirms Google IS
-    // registered (otherwise we'd see "not registered" instead).
     expect(resp.ok).toBe(false);
-    expect(resp.error?.message).toContain("Phase 3b.2c");
-    expect(resp.error?.message).not.toContain("not registered");
+    expect(resp.error?.code).toBe("INVALID_ARGS");
+    expect(resp.error?.message).toContain("klanker");
+    expect(resp.error?.message).toContain("auth google disable");
+    broker.stop();
+  });
+
+  it("Phase 3b.2c — rm-account succeeds after add when no agents are enabled", async () => {
+    const h = makeHarness();
+    const config = makeConfig(h, {
+      active: "default",
+      admin_agents: ["clerk"],
+      agents: { clerk: {} },
+      google_workspace: {
+        google_client_id: "id",
+        google_client_secret: "secret",
+      },
+    });
+    seedAccount(h, "default");
+    mkdirSync(join(h.agentsDir, "clerk"), { recursive: true });
+    const broker = new AuthBroker(config, {
+      home: h.home,
+      stateDir: h.stateDir,
+      socketRoot: h.socketRoot,
+      disableRefreshLoop: true,
+    });
+    await broker.start();
+    await rpc(join(h.socketRoot, "clerk", "sock"), {
+      v: 1, id: "1", op: "add-account", label: "alice@example.com",
+      provider: "google",
+      credentials: {
+        googleOauth: {
+          accessToken: "at", refreshToken: "rt", expiresAt: 1, scope: "x",
+          clientId: "cid", accountEmail: "alice@example.com",
+          tokenType: "Bearer" as const,
+        },
+      },
+    });
+    const resp = await rpc(join(h.socketRoot, "clerk", "sock"), {
+      v: 1, id: "2", op: "rm-account", label: "alice@example.com",
+      provider: "google",
+    }) as { ok: boolean };
+    expect(resp.ok).toBe(true);
+    // Storage gone.
+    const credPath = join(
+      h.stateDir, "google", "alice@example.com", "credentials.json",
+    );
+    expect(existsSync(credPath)).toBe(false);
     broker.stop();
   });
 

--- a/src/auth/broker/server.ts
+++ b/src/auth/broker/server.ts
@@ -53,6 +53,7 @@ import {
   googleAccountExists,
   readGoogleAccountCredentials,
   removeGoogleAccount,
+  validateGoogleAccountLabel,
   writeGoogleAccountCredentials,
 } from "./google-storage.js";
 import { ProviderRegistry, type ProviderName } from "./provider.js";
@@ -234,16 +235,19 @@ export class AuthBroker {
     // Google provider loaded; the broker still rejects
     // `provider: "google"` requests via registry.has() per Phase 3b.1.
     //
-    // **TODO (Phase 3b.2c):** the `google_client_id` / `_secret`
+    // **TODO (Phase 3b.2d):** the `google_client_id` / `_secret`
     // schema fields accept `vault:<key>` references (per
     // `src/config/schema.ts:759`); `src/cli/drive.ts:446-448`
     // resolves them via `resolveMaybeVaultRef`. Today the broker
     // passes the raw config string verbatim, so a vault-ref config
     // would silently send a literal `"vault:..."` string to Google's
-    // token endpoint and fail. Phase 3b.2c must resolve vault refs
-    // here BEFORE constructing the GoogleProvider — otherwise the
-    // first refresh tick will surface a confusing error. Latent
-    // until 3b.2c wires storage; flagged here as a foot-gun.
+    // token endpoint and fail. Phase 3b.2c shipped storage but
+    // refresh-tick is still deferred to 3b.2d (along with the
+    // per-(provider, account) state-keying refactor); 3b.2d MUST
+    // resolve vault refs here BEFORE the GoogleProvider's first
+    // refresh fires. Foot-gun until then — operators using
+    // `vault:` refs in google_workspace will hit it on the first
+    // refresh attempt.
     //
     // **Known limitation:** `reload()` does NOT re-run provider
     // registration. An operator who adds `google_workspace:` to a
@@ -990,6 +994,16 @@ export class AuthBroker {
       this.respondForbidden(socket, id, "add-account requires admin");
       return;
     }
+    // Defense-in-depth path-traversal guard. Wire-protocol schema
+    // accepts `z.string().min(1)`; the email-shape validator runs
+    // here so a malformed label can't escape the stateDir via `..`,
+    // `/`, etc. before any fs op fires.
+    try {
+      validateGoogleAccountLabel(label);
+    } catch (err) {
+      socket.write(encodeError(id, "INVALID_ARGS", (err as Error).message));
+      return;
+    }
     if (googleAccountExists(this.stateDir, label) && !replace) {
       this.audit({ op: "add-account", identity, account: label, ok: false, error: "ACCOUNT_ALREADY_EXISTS" });
       socket.write(encodeError(id, "ACCOUNT_ALREADY_EXISTS", `google account '${label}' already exists; pass replace:true to overwrite`));
@@ -1021,6 +1035,12 @@ export class AuthBroker {
     if (!this.isAdmin(identity)) {
       this.audit({ op: "rm-account", identity, account: label, ok: false, error: "FORBIDDEN" });
       this.respondForbidden(socket, id, "rm-account requires admin");
+      return;
+    }
+    try {
+      validateGoogleAccountLabel(label);
+    } catch (err) {
+      socket.write(encodeError(id, "INVALID_ARGS", (err as Error).message));
       return;
     }
     if (!googleAccountExists(this.stateDir, label)) {

--- a/src/auth/broker/server.ts
+++ b/src/auth/broker/server.ts
@@ -49,7 +49,14 @@ import {
 } from "../account-refresh.js";
 import { AnthropicProvider } from "./anthropic-provider.js";
 import { GoogleProvider } from "./google-provider.js";
+import {
+  googleAccountExists,
+  readGoogleAccountCredentials,
+  removeGoogleAccount,
+  writeGoogleAccountCredentials,
+} from "./google-storage.js";
 import { ProviderRegistry, type ProviderName } from "./provider.js";
+import type { GoogleCredentialsShape } from "./protocol.js";
 import {
   accountCredentialsPath,
   accountDir,
@@ -606,7 +613,7 @@ export class AuthBroker {
             );
             break;
           }
-          // Anthropic-only storage path for now; Google path lands in 3b.2.
+          // Phase 3b.2c — providers dispatch by name.
           if (provider === "anthropic") {
             const anthropicCreds = req.credentials as {
               claudeAiOauth: AccountCredentials["claudeAiOauth"];
@@ -621,11 +628,29 @@ export class AuthBroker {
             );
             break;
           }
+          // Google: writes to broker's own state dir under
+          // `~/.switchroom/state/auth-broker/google/<account>/`.
+          // Phase 3b.2d will migrate to vault-broker-mediated storage
+          // per RFC G v3 §4.4.
+          if (provider === "google") {
+            const googleCreds = req.credentials as GoogleCredentialsShape;
+            await this.opGoogleAddAccount(
+              socket,
+              reqId,
+              identity,
+              req.label,
+              googleCreds,
+              req.replace ?? false,
+            );
+            break;
+          }
+          // Unreachable today (registry has() rejects unknown
+          // providers above), but defensive.
           socket.write(
             encodeError(
               reqId,
-              "INVALID_ARGS",
-              `add-account storage path for provider '${provider}' lands in Phase 3b.2c (vault-broker-mediated, not direct-to-disk like Anthropic)`,
+              "INTERNAL",
+              `unhandled provider '${provider}' in add-account dispatch`,
             ),
           );
           break;
@@ -646,11 +671,15 @@ export class AuthBroker {
             await this.opRmAccount(socket, reqId, identity, req.label);
             break;
           }
+          if (provider === "google") {
+            await this.opGoogleRmAccount(socket, reqId, identity, req.label);
+            break;
+          }
           socket.write(
             encodeError(
               reqId,
-              "INVALID_ARGS",
-              `rm-account storage path for provider '${provider}' lands in Phase 3b.2c (vault-broker-mediated, not direct-to-disk like Anthropic)`,
+              "INTERNAL",
+              `unhandled provider '${provider}' in rm-account dispatch`,
             ),
           );
           break;
@@ -923,6 +952,94 @@ export class AuthBroker {
     this.persistShaIndex();
     this.persistQuota();
     this.persistThresholdViolations();
+    this.audit({ op: "rm-account", identity, account: label, ok: true });
+    socket.write(encodeSuccess(id, { label }));
+  }
+
+  /**
+   * RFC G Phase 3b.2c — Google add-account.
+   *
+   * Storage layout: writes verbatim Google credentials to
+   * `<stateDir>/google/<account>/credentials.json` via
+   * `google-storage.ts`. Phase 3b.2d (future) will migrate to
+   * vault-broker-mediated storage per RFC G v3 §4.4.
+   *
+   * Differences from Anthropic's opAddAccount:
+   *   - Storage location is broker stateDir not `~/.switchroom/accounts/`
+   *   - Credentials are GoogleCredentialsShape (`googleOauth: {...}`)
+   *     not `claudeAiOauth`
+   *   - No fanout to per-agent .credentials.json mirrors — Google
+   *     consumers (MCP wrapper) will read via `get-credentials` UDS
+   *     when Phase 3b.4 wires the wrapper. Today the credentials sit
+   *     in storage waiting for that consumer.
+   *   - No sha-index or threshold-violation tracking yet (those are
+   *     Anthropic-state machinery; Google parallel state lands when
+   *     it's needed — likely Phase 3b.2d alongside the refresh tick
+   *     wiring).
+   */
+  private async opGoogleAddAccount(
+    socket: net.Socket,
+    id: string,
+    identity: Identity,
+    label: string,
+    credentials: GoogleCredentialsShape,
+    replace: boolean,
+  ): Promise<void> {
+    if (!this.isAdmin(identity)) {
+      this.audit({ op: "add-account", identity, account: label, ok: false, error: "FORBIDDEN" });
+      this.respondForbidden(socket, id, "add-account requires admin");
+      return;
+    }
+    if (googleAccountExists(this.stateDir, label) && !replace) {
+      this.audit({ op: "add-account", identity, account: label, ok: false, error: "ACCOUNT_ALREADY_EXISTS" });
+      socket.write(encodeError(id, "ACCOUNT_ALREADY_EXISTS", `google account '${label}' already exists; pass replace:true to overwrite`));
+      return;
+    }
+    try {
+      writeGoogleAccountCredentials(this.stateDir, label, credentials);
+    } catch (err) {
+      socket.write(encodeError(id, "INTERNAL", (err as Error).message));
+      return;
+    }
+    const expiresAt = credentials.googleOauth?.expiresAt;
+    this.audit({ op: "add-account", identity, account: label, ok: true, replace });
+    socket.write(encodeSuccess(id, { label, expiresAt }));
+  }
+
+  /**
+   * RFC G Phase 3b.2c — Google rm-account. Refuses to remove while
+   * the account is in `google_accounts.<label>.enabled_for[]` (any
+   * agent still depends on the credential). Operator must
+   * `auth google disable <label> all` first.
+   */
+  private async opGoogleRmAccount(
+    socket: net.Socket,
+    id: string,
+    identity: Identity,
+    label: string,
+  ): Promise<void> {
+    if (!this.isAdmin(identity)) {
+      this.audit({ op: "rm-account", identity, account: label, ok: false, error: "FORBIDDEN" });
+      this.respondForbidden(socket, id, "rm-account requires admin");
+      return;
+    }
+    if (!googleAccountExists(this.stateDir, label)) {
+      socket.write(encodeError(id, "ACCOUNT_NOT_FOUND", `google account '${label}' not found`));
+      return;
+    }
+    // Refuse if any agent is still enabled on this account.
+    const ga = (this.config as { google_accounts?: Record<string, { enabled_for?: string[] }> }).google_accounts;
+    const enabledFor = ga?.[label]?.enabled_for ?? [];
+    if (enabledFor.length > 0) {
+      socket.write(encodeError(id, "INVALID_ARGS", `google account '${label}' is still enabled for agents: ${enabledFor.join(", ")}. Run \`auth google disable ${label} all\` first.`));
+      return;
+    }
+    try {
+      removeGoogleAccount(this.stateDir, label);
+    } catch (err) {
+      socket.write(encodeError(id, "INTERNAL", (err as Error).message));
+      return;
+    }
     this.audit({ op: "rm-account", identity, account: label, ok: true });
     socket.write(encodeSuccess(id, { label }));
   }


### PR DESCRIPTION
## Summary

Wires the broker's \`provider: "google"\` dispatch branches to actually store + remove credentials. After this PR end-to-end:

1. \`auth google account add <email>\` (CLI from 3b.3) → \`client.addAccount(..., "google")\`
2. broker validates shape via \`GoogleProvider.validateCredentialShape\`
3. broker writes to \`~/.switchroom/state/auth-broker/google/<email>/credentials.json\` (mode 0600)
4. \`auth google enable <email> <agents>\` writes the ACL to \`switchroom.yaml\`
5. broker.rmAccount refuses while agents are enabled; succeeds after disable

## Pragmatic shortcut from RFC G v3 §4.4

RFC v3 spec'd vault-broker-mediated storage. **3b.2c writes to the auth-broker's own stateDir** (mirroring Anthropic's \`~/.switchroom/accounts/\` pattern) instead. The vault-broker route would require a \`set-secret-for-peer\` verb (doesn't exist), auth-broker as a vault-broker peer with appropriate ACL, and a cross-broker IPC client library — its own multi-PR architectural piece. **Phase 3b.2d** (future) migrates. Until then Google credentials live alongside Anthropic on disk (same security posture as the existing pattern).

## What's still deferred to Phase 3b.2d

- refresh-tick for Google (needs per-(provider, account) state refactor and refresh leases keyed on composite)
- vault-broker mediation (the original RFC G v3 §4.4 vision)
- list-state surfacing Google accounts (Phase 3b.2d alongside the state refactor)

## What ships

- \`src/auth/broker/google-storage.ts\` (new, ~140 LOC) — all storage helpers, mode 0600 credentials, mode 0700 dir, atomicWriteFileSync
- \`src/auth/broker/google-storage.test.ts\` (new, 16 tests)
- \`src/auth/broker/server.ts\` — adds \`opGoogleAddAccount\` + \`opGoogleRmAccount\`; dispatcher routes by provider; admin-gated; rm refused while \`google_accounts.enabled_for[]\` non-empty
- \`src/auth/broker/server.test.ts\` — 4 new tests + 2 updated 3b.2b "deferral" tests reflecting the new behavior

## Tests — 124/124

- 16 new google-storage tests (paths, round-trip, mode, normalize, list, idempotent remove)
- 4 new server tests (Google add succeeds + writes file; duplicate refused without replace; rm refused with enabled agents + helpful message; rm succeeds after disable)
- 2 existing 3b.2b "deferral" tests updated to verify the new real behavior
- 102 pre-existing broker tests still pass

## Test plan

- [x] \`bun test src/auth/broker/\` — 124/124 pass
- [x] \`tsc --noEmit\` clean
- [x] \`npm run lint\` clean (catches plugin-references)
- [ ] Independent reviewer verdict (will dispatch after PR open)

🤖 Generated with [Claude Code](https://claude.com/claude-code)