### PR TITLE
feat(apply,setup): RFC G Phase 3b.5 + 3b.6 — legacy-slot detector + setup wizard pivot

### DIFF
--- a/src/cli/apply.ts
+++ b/src/cli/apply.ts
@@ -354,6 +354,76 @@ export function runApplyPreflight(config: SwitchroomConfig): void {
   if (composeErr) {
     throw new Error(composeErr);
   }
+  // RFC G Phase 3b.5 — best-effort legacy `gdrive:<agent>:refresh_token`
+  // detection. Reads vault slots only when SWITCHROOM_VAULT_PASSPHRASE
+  // is set in the env (interactive prompts in preflight would block CI).
+  // Without the passphrase the check is silently skipped — the agent
+  // wrapper (Phase 3b.4) and `auth google account add` (Phase 3b.3
+  // stub today) will catch the legacy slots when an operator actually
+  // touches Google.
+  detectAndReportLegacyGdriveSlots(vaultPath);
+}
+
+/**
+ * RFC G Phase 3b.5 — print operator-actionable advisory if any legacy
+ * RFC D `gdrive:<agent>:refresh_token` slots are present in the vault.
+ * Refuses apply only when the operator has the passphrase available
+ * AND legacy slots are detected — a mid-`apply` interactive prompt
+ * would block CI / scripted invocations.
+ *
+ * Today: detection-only, prints advisory to stderr. A future Phase
+ * 3b.5b will ship the actual interactive `switchroom auth google
+ * migrate` verb that reads each legacy slot, prompts the operator to
+ * attribute it to a Google account, writes to the new
+ * `vault:google:<account>:refresh_token` shape, and deletes the
+ * legacy slot. Until that lands, operators can manually use
+ * `switchroom drive disconnect` + `auth google account add` to
+ * migrate.
+ */
+function detectAndReportLegacyGdriveSlots(vaultPath: string): void {
+  if (!existsSync(vaultPath)) return; // no vault, no slots to migrate
+  const passphrase = process.env.SWITCHROOM_VAULT_PASSPHRASE;
+  if (!passphrase) return; // best-effort: skip without prompting
+  let slotKeys: string[];
+  try {
+    // Lazy-import to keep the apply hot path free of vault crypto when
+    // the passphrase isn't available.
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { listSecrets } = require("../vault/vault.js") as typeof import("../vault/vault.js");
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { detectLegacyGdriveSlots } = require("../drive/vault-slots.js") as typeof import("../drive/vault-slots.js");
+    slotKeys = listSecrets(passphrase, vaultPath);
+    const legacy = detectLegacyGdriveSlots(slotKeys);
+    if (legacy.length > 0) {
+      const lines = [
+        "",
+        chalk.yellow(`⚠  Legacy RFC D Drive slots detected in vault:`),
+        ...legacy.map((agent) => chalk.gray(`     gdrive:${agent}:refresh_token`)),
+        chalk.yellow(`   These were created by the v0.6.0 \`switchroom drive connect <agent>\` flow.`),
+        chalk.yellow(`   Per RFC G v3 §4.4 + Phase 3b.2c, Google credentials now live in the auth-broker`),
+        chalk.yellow(`   under per-account labels (\`google:<email>:...\`) rather than per-agent slots.`),
+        "",
+        `   To migrate manually for each affected agent:`,
+        chalk.cyan(`     1. Note the Google account each \`gdrive:<agent>\` slot was minted for`),
+        chalk.cyan(`     2. switchroom drive disconnect <agent>           # revokes Google + clears slot`),
+        chalk.cyan(`     3. switchroom auth google account add <email>    # mints new per-account slot`),
+        chalk.cyan(`     4. switchroom auth google enable <email> <agent> # writes ACL to switchroom.yaml`),
+        "",
+        chalk.gray(`   Phase 3b.5b will ship an interactive \`switchroom auth google migrate\` verb`),
+        chalk.gray(`   that automates this. \`apply\` is advisory-only for now — does not refuse.`),
+        "",
+      ];
+      for (const line of lines) process.stderr.write(line + "\n");
+    }
+  } catch (err) {
+    // Don't break apply over the legacy-slot check. If we can't open
+    // the vault for any reason (wrong passphrase, corrupt file, etc.)
+    // the operator's other vault-touching commands will surface a
+    // clearer error.
+    process.stderr.write(
+      chalk.gray(`  (skipping legacy-slot check: ${(err as Error).message})\n`),
+    );
+  }
 }
 
 /**

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -1205,34 +1205,47 @@ async function stepGoogleWorkspace(
     true,
   );
 
-  // The verb that completes the flow. Today (pre-Phase-3b) it's the
-  // shipped `drive connect`. Phase 3b will introduce
-  // `auth google connect <agent>` as the wizard alias and swap this
-  // string. Both end up at the same OAuth flow.
-  const connectCmd = `switchroom drive connect ${firstName}`;
+  // RFC G Phase 3b.6 — surfaces the post-3b two-step shape per RFC
+  // G v3 §4.6. Pre-3b.6 this was `switchroom drive connect <agent>`;
+  // post-3b.3 + 3b.2c the `auth google account add <email>` verb
+  // mints credentials in the broker, then `auth google enable
+  // <email> <agent>` writes the per-agent ACL.
+  //
+  // (The `account add` verb is a stub today per Phase 3b.3 — the
+  // OAuth flow extraction lives in Phase 3b.2d alongside refresh-
+  // tick wiring. Until that lands, the v0.6.0 `drive connect <agent>`
+  // verb still works as the OAuth onramp. Wizard surfaces both so
+  // operators can pick.)
+  const accountAddCmd = `switchroom auth google account add <your-google-account-email>`;
+  const enableCmd = `switchroom auth google enable <your-google-account-email> ${firstName}`;
+  const fallbackCmd = `switchroom drive connect ${firstName}`;
 
   if (wantConnect) {
-    console.log(
-      chalk.green(`  ${STEP_DONE} Ready to connect`),
-    );
+    console.log(chalk.green(`  ${STEP_DONE} Ready to connect`));
+    console.log();
+    console.log(chalk.gray("  After setup completes:"));
     console.log();
     console.log(
-      chalk.gray("  After setup completes, run:"),
+      chalk.gray(`    Step 1 — register the Google account with the auth-broker:`),
+    );
+    console.log(chalk.cyan(`      ${accountAddCmd}`));
+    console.log();
+    console.log(chalk.gray(`    Step 2 — enable the account on ${chalk.bold(firstName)}:`));
+    console.log(chalk.cyan(`      ${enableCmd}`));
+    console.log();
+    console.log(
+      chalk.gray(`    (\`account add\` is a stub today — Phase 3b.2d wires the OAuth flow.`),
     );
     console.log(
-      chalk.cyan(`    ${connectCmd}`),
+      chalk.gray(`     Until then, use the v0.6.0 fallback:`),
     );
-    console.log(
-      chalk.gray(
-        "  to start the OAuth flow (device-code on headless hosts, browser otherwise).",
-      ),
-    );
+    console.log(chalk.gray(`       ${fallbackCmd})`));
   } else {
+    console.log(chalk.gray(`  ${STEP_DONE} Skipped — connect later with:`));
+    console.log(chalk.cyan(`    ${accountAddCmd}`));
+    console.log(chalk.cyan(`    ${enableCmd}`));
     console.log(
-      chalk.gray(`  ${STEP_DONE} Skipped — connect later with:`),
-    );
-    console.log(
-      chalk.cyan(`    ${connectCmd}`),
+      chalk.gray(`  (or the v0.6.0 fallback: ${fallbackCmd})`),
     );
   }
 }


### PR DESCRIPTION
## Summary

Two related polish PRs combined:

**3b.5: apply-time legacy `gdrive:<agent>:refresh_token` detector.** Wires Phase 2's \`detectLegacyGdriveSlots\` helper into \`runApplyPreflight\`. Best-effort: reads vault slots only when \`SWITCHROOM_VAULT_PASSPHRASE\` is in env (interactive prompts in preflight would block CI). When set + legacy slots found, prints operator-actionable advisory to stderr listing each slot and the manual migration commands. **Advisory-only — does NOT refuse apply.** A future Phase 3b.5b will ship \`switchroom auth google migrate\` for full interactive migration.

**3b.6: setup wizard pivot.** Rewrites the surfaced commands in \`setup.ts:stepGoogleWorkspace\` to point at the post-RFC-G two-step shape per RFC G v3 §4.6. Pre-3b.6 the wizard printed \`switchroom drive connect <agent>\`; post-3b.6:
\`\`\`
Step 1 — switchroom auth google account add <your-email>
Step 2 — switchroom auth google enable <your-email> <agent>
\`\`\`
With honest fallback note that \`account add\` is a stub today (Phase 3b.2d wires OAuth) and the v0.6.0 \`drive connect\` still works.

## What's left in Phase 3b

- **3b.4** — MCP wrapper credential-read pivot (gateway calls \`auth-broker.get-credentials { provider: "google" }\` instead of vault-slot direct read). Needs \`provider\` field on get-credentials. ~60min.
- **3b.2d** — refresh-tick for Google + per-(provider, account) state-keying refactor + vault-broker mediation per RFC G v3 §4.4 + vault-ref resolution. ~2-3h.
- **3b.5b** — interactive \`switchroom auth google migrate\` verb. ~60min.

After 3b.4 + 3b.2d land, agents can actually use Google Drive end-to-end. The remaining sub-phases bridge "primitives all shipped" to "agent uses Google Drive in production."

## Test plan

- [x] \`tsc --noEmit\` clean
- [x] \`npm run lint\` clean (catches plugin-references + bun:test imports)
- [x] Smoke-tested 3b.5 against a vault with a fixture legacy slot — advisory renders correctly with expected migration commands
- [ ] Independent reviewer verdict (will dispatch after PR open)

🤖 Generated with [Claude Code](https://claude.com/claude-code)