### PR TITLE
feat(auth-broker): RFC G Phase 3b.4 — get-credentials provider:google + per-agent ACL gate

### DIFF
--- a/src/auth/broker/client.ts
+++ b/src/auth/broker/client.ts
@@ -264,12 +264,14 @@ export class AuthBrokerClient {
 
   // ─── Verb methods ────────────────────────────────────────────────────
 
-  async getCredentials(): Promise<GetCredentialsData> {
-    const data = await this.send({
+  async getCredentials(provider?: ProviderName): Promise<GetCredentialsData> {
+    const base = {
       v: PROTOCOL_VERSION,
       id: randomUUID(),
-      op: "get-credentials",
-    });
+      op: "get-credentials" as const,
+    };
+    const req = (provider !== undefined ? { ...base, provider } : base) as Request;
+    const data = await this.send(req);
     return data as GetCredentialsData;
   }
 

--- a/src/auth/broker/protocol.ts
+++ b/src/auth/broker/protocol.ts
@@ -73,6 +73,19 @@ export const GetCredentialsRequestSchema = z.object({
   v: z.literal(PROTOCOL_VERSION),
   op: z.literal("get-credentials"),
   id: z.string().min(1),
+  /**
+   * Provider for the credentials being requested. Optional; defaults to
+   * `"anthropic"` for back-compat with RFC H pre-Phase-3b.4 callers.
+   *
+   * For Anthropic: account is derived from path-as-identity per the
+   * existing callerAccount() logic (auth.active or per-agent override).
+   *
+   * For Google (RFC G Phase 3b.4): account is read from the agent's
+   * `google_workspace.account` config field. Broker validates the
+   * agent is in `google_accounts.<account>.enabled_for[]` before
+   * returning credentials.
+   */
+  provider: ProviderNameSchema.optional(),
 });
 
 export const ListStateRequestSchema = z.object({

--- a/src/auth/broker/server.test.ts
+++ b/src/auth/broker/server.test.ts
@@ -882,6 +882,154 @@ describe("AuthBroker — Google provider registration (Phase 3b.2b)", () => {
     broker.stop();
   });
 
+  it("Phase 3b.4 — get-credentials with provider:google returns the stored Google creds when agent is in enabled_for[]", async () => {
+    const h = makeHarness();
+    const config = makeConfig(h, {
+      active: "default",
+      admin_agents: ["clerk"],
+      agents: { klanker: {}, clerk: {} },
+      google_workspace: {
+        google_client_id: "id",
+        google_client_secret: "secret",
+      },
+    });
+    (config.agents.klanker as unknown as Record<string, unknown>).google_workspace = {
+      account: "alice@example.com",
+    };
+    (config as unknown as Record<string, unknown>).google_accounts = {
+      "alice@example.com": { enabled_for: ["klanker"] },
+    };
+    seedAccount(h, "default");
+    mkdirSync(join(h.agentsDir, "klanker"), { recursive: true });
+    mkdirSync(join(h.agentsDir, "clerk"), { recursive: true });
+    const broker = new AuthBroker(config, {
+      home: h.home,
+      stateDir: h.stateDir,
+      socketRoot: h.socketRoot,
+      disableRefreshLoop: true,
+    });
+    await broker.start();
+    const addedCreds = {
+      googleOauth: {
+        accessToken: "at-cur",
+        refreshToken: "rt-cur",
+        expiresAt: 88888,
+        scope: "drive",
+        clientId: "cid",
+        accountEmail: "alice@example.com",
+        tokenType: "Bearer" as const,
+      },
+    };
+    await rpc(join(h.socketRoot, "clerk", "sock"), {
+      v: 1, id: "1", op: "add-account", label: "alice@example.com",
+      provider: "google", credentials: addedCreds,
+    });
+    const resp = await rpc(join(h.socketRoot, "klanker", "sock"), {
+      v: 1, id: "2", op: "get-credentials", provider: "google",
+    }) as { ok: boolean; data?: { account: string; credentials: typeof addedCreds; expiresAt?: number } };
+    expect(resp.ok).toBe(true);
+    expect(resp.data?.account).toBe("alice@example.com");
+    expect(resp.data?.credentials).toEqual(addedCreds);
+    expect(resp.data?.expiresAt).toBe(88888);
+    broker.stop();
+  });
+
+  it("Phase 3b.4 — get-credentials google returns FORBIDDEN when agent NOT in enabled_for[]", async () => {
+    const h = makeHarness();
+    const config = makeConfig(h, {
+      active: "default",
+      admin_agents: ["clerk"],
+      agents: { klanker: {}, clerk: {} },
+      google_workspace: {
+        google_client_id: "id",
+        google_client_secret: "secret",
+      },
+    });
+    (config.agents.klanker as unknown as Record<string, unknown>).google_workspace = {
+      account: "alice@example.com",
+    };
+    (config as unknown as Record<string, unknown>).google_accounts = {
+      "alice@example.com": { enabled_for: ["gymbro"] },
+    };
+    seedAccount(h, "default");
+    mkdirSync(join(h.agentsDir, "klanker"), { recursive: true });
+    mkdirSync(join(h.agentsDir, "clerk"), { recursive: true });
+    const broker = new AuthBroker(config, {
+      home: h.home,
+      stateDir: h.stateDir,
+      socketRoot: h.socketRoot,
+      disableRefreshLoop: true,
+    });
+    await broker.start();
+    const resp = await rpc(join(h.socketRoot, "klanker", "sock"), {
+      v: 1, id: "1", op: "get-credentials", provider: "google",
+    }) as { ok: boolean; error?: { code: string; message: string } };
+    expect(resp.ok).toBe(false);
+    expect(resp.error?.code).toBe("FORBIDDEN");
+    expect(resp.error?.message).toContain("not in google_accounts");
+    expect(resp.error?.message).toContain("auth google enable");
+    broker.stop();
+  });
+
+  it("Phase 3b.4 — get-credentials google returns ACCOUNT_NOT_FOUND when agent has no google_workspace.account", async () => {
+    const h = makeHarness();
+    const config = makeConfig(h, {
+      active: "default",
+      admin_agents: ["clerk"],
+      agents: { klanker: {}, clerk: {} },
+      google_workspace: {
+        google_client_id: "id",
+        google_client_secret: "secret",
+      },
+    });
+    seedAccount(h, "default");
+    mkdirSync(join(h.agentsDir, "klanker"), { recursive: true });
+    mkdirSync(join(h.agentsDir, "clerk"), { recursive: true });
+    const broker = new AuthBroker(config, {
+      home: h.home,
+      stateDir: h.stateDir,
+      socketRoot: h.socketRoot,
+      disableRefreshLoop: true,
+    });
+    await broker.start();
+    const resp = await rpc(join(h.socketRoot, "klanker", "sock"), {
+      v: 1, id: "1", op: "get-credentials", provider: "google",
+    }) as { ok: boolean; error?: { code: string; message: string } };
+    expect(resp.ok).toBe(false);
+    expect(resp.error?.code).toBe("ACCOUNT_NOT_FOUND");
+    expect(resp.error?.message).toContain("google_workspace.account");
+    broker.stop();
+  });
+
+  it("Phase 3b.4 — get-credentials WITHOUT provider field still routes to Anthropic (back-compat)", async () => {
+    const h = makeHarness();
+    const config = makeConfig(h, {
+      active: "default",
+      admin_agents: ["clerk"],
+      agents: { klanker: {}, clerk: {} },
+      google_workspace: {
+        google_client_id: "id",
+        google_client_secret: "secret",
+      },
+    });
+    seedAccount(h, "default");
+    mkdirSync(join(h.agentsDir, "klanker"), { recursive: true });
+    mkdirSync(join(h.agentsDir, "clerk"), { recursive: true });
+    const broker = new AuthBroker(config, {
+      home: h.home,
+      stateDir: h.stateDir,
+      socketRoot: h.socketRoot,
+      disableRefreshLoop: true,
+    });
+    await broker.start();
+    const resp = await rpc(join(h.socketRoot, "klanker", "sock"), {
+      v: 1, id: "1", op: "get-credentials",
+    }) as { ok: boolean; data?: { account: string } };
+    expect(resp.ok).toBe(true);
+    expect(resp.data?.account).toBe("default");
+    broker.stop();
+  });
+
   it("Phase 3b.2c — rm-account succeeds after add when no agents are enabled", async () => {
     const h = makeHarness();
     const config = makeConfig(h, {

--- a/src/auth/broker/server.ts
+++ b/src/auth/broker/server.ts
@@ -527,9 +527,38 @@ export class AuthBroker {
 
     try {
       switch (req.op) {
-        case "get-credentials":
-          await this.opGetCredentials(socket, reqId, identity);
+        case "get-credentials": {
+          // Phase 3b.4 — provider field routes between Anthropic
+          // (existing path-as-identity flow) and Google (per-agent
+          // google_workspace.account + per-account ACL gate).
+          const provider: ProviderName = req.provider ?? "anthropic";
+          if (!this.providers.has(provider)) {
+            socket.write(
+              encodeError(
+                reqId,
+                "INVALID_ARGS",
+                `provider '${provider}' is not registered with this broker (only ${this.providers.names().join(", ")} available)`,
+              ),
+            );
+            break;
+          }
+          if (provider === "anthropic") {
+            await this.opGetCredentials(socket, reqId, identity);
+            break;
+          }
+          if (provider === "google") {
+            await this.opGoogleGetCredentials(socket, reqId, identity);
+            break;
+          }
+          socket.write(
+            encodeError(
+              reqId,
+              "INTERNAL",
+              `unhandled provider '${provider}' in get-credentials dispatch`,
+            ),
+          );
           break;
+        }
         case "list-state":
           await this.opListState(socket, reqId, identity);
           break;
@@ -981,6 +1010,85 @@ export class AuthBroker {
    *     it's needed — likely Phase 3b.2d alongside the refresh tick
    *     wiring).
    */
+  /**
+   * RFC G Phase 3b.4 — Google get-credentials.
+   *
+   * Identity comes from path-as-identity (the agent's bind socket).
+   * Account comes from the agent's `google_workspace.account` config
+   * field (NOT from the wire — agent can't ask for someone else's
+   * Google account). ACL is enforced via
+   * `google_accounts.<account>.enabled_for[]` containing the agent.
+   *
+   * Operator and consumer identities are not (yet) supported for Google
+   * get-credentials — the Google ACL model is per-agent, and operators
+   * + consumers have different identity models. Return INVALID_ARGS
+   * with a clear message until Phase 3b.4b extends the contract if
+   * needed.
+   */
+  private async opGoogleGetCredentials(
+    socket: net.Socket,
+    id: string,
+    identity: Identity,
+  ): Promise<void> {
+    if (identity.kind !== "agent") {
+      socket.write(
+        encodeError(
+          id,
+          "INVALID_ARGS",
+          `Google get-credentials is per-agent only (caller kind '${identity.kind}' not supported); use the agent's per-agent socket bind`,
+        ),
+      );
+      return;
+    }
+    const agentName = identity.name;
+    const agent = (this.config.agents ?? {})[agentName] as
+      | { google_workspace?: { account?: string } }
+      | undefined;
+    const account = agent?.google_workspace?.account;
+    if (!account) {
+      this.audit({ op: "get-credentials", identity, ok: false, error: "no-google-account-configured" });
+      socket.write(
+        encodeError(
+          id,
+          "ACCOUNT_NOT_FOUND",
+          `agent '${agentName}' has no google_workspace.account configured in switchroom.yaml`,
+        ),
+      );
+      return;
+    }
+    // ACL: agent must be in google_accounts.<account>.enabled_for[].
+    const ga = (this.config as { google_accounts?: Record<string, { enabled_for?: string[] }> })
+      .google_accounts;
+    const enabledFor = ga?.[account]?.enabled_for ?? [];
+    if (!enabledFor.includes(agentName)) {
+      this.audit({ op: "get-credentials", identity, account, ok: false, error: "acl-deny" });
+      socket.write(
+        encodeError(
+          id,
+          "FORBIDDEN",
+          `agent '${agentName}' not in google_accounts['${account}'].enabled_for[] — operator must run \`switchroom auth google enable ${account} ${agentName}\``,
+        ),
+      );
+      return;
+    }
+    // Storage read.
+    const creds = readGoogleAccountCredentials(this.stateDir, account);
+    if (!creds) {
+      this.audit({ op: "get-credentials", identity, account, ok: false, error: "missing-credentials" });
+      socket.write(
+        encodeError(
+          id,
+          "ACCOUNT_NOT_FOUND",
+          `no Google credentials for account '${account}' — operator must run \`switchroom auth google account add ${account}\``,
+        ),
+      );
+      return;
+    }
+    const expiresAt = creds.googleOauth?.expiresAt;
+    this.audit({ op: "get-credentials", identity, account, ok: true });
+    socket.write(encodeSuccess(id, { account, credentials: creds, expiresAt }));
+  }
+
   private async opGoogleAddAccount(
     socket: net.Socket,
     id: string,


### PR DESCRIPTION
## Summary

Wires the agent-side path: an agent's MCP wrapper can now call \`auth-broker.get-credentials({ provider: "google" })\` and receive the per-account stored Google credentials, gated by \`google_accounts.<account>.enabled_for[]\` ACL.

## Honest scope split

This PR ships the **broker-side enablement**. The actual **wrapper integration** — calling \`client.getCredentials("google")\` from \`src/drive/wrapper.ts\` and threading it through the gateway's MCP-spawn args — is **Phase 3b.4b**. After 3b.4b lands, agents can actually use Google Drive end-to-end.

## What ships

- \`protocol.ts\` — \`GetCredentialsRequestSchema\` gains optional \`provider:\` field (defaults "anthropic" for back-compat)
- \`server.ts\` — get-credentials dispatcher routes by provider; new \`opGoogleGetCredentials\`:
  - Identity must be \`kind: "agent"\` (operator/consumer not supported for Google)
  - Account read from agent's \`google_workspace.account\` (NEVER from wire — path-as-identity)
  - ACL: agent must be in \`google_accounts.<account>.enabled_for[]\`. FORBIDDEN with operator-actionable message naming \`auth google enable\`
  - Returns \`{ account, credentials, expiresAt }\`
- \`client.ts\` — \`getCredentials()\` gains optional \`provider?\` arg

## Tests — 138/138

- Google get-credentials succeeds when agent IS in enabled_for[]
- FORBIDDEN when agent NOT in enabled_for[]
- ACCOUNT_NOT_FOUND when agent has no \`google_workspace.account\`
- Back-compat: get-credentials WITHOUT provider field still routes to Anthropic

## Test plan

- [x] \`bun test src/auth/broker/\` — 138/138 pass (134 prior + 4 new)
- [x] \`tsc --noEmit\` clean
- [x] \`npm run lint\` clean
- [ ] Independent reviewer verdict (will dispatch after PR open)

🤖 Generated with [Claude Code](https://claude.com/claude-code)