### PR TITLE
feat(auth-broker): RFC G Phase 3b.2d — Google refresh-tick (production hardening)

### DIFF
--- a/src/auth/broker/server-google-refresh.test.ts
+++ b/src/auth/broker/server-google-refresh.test.ts
@@ -1,0 +1,326 @@
+/**
+ * auth-broker — RFC G Phase 3b.2d Google refresh-tick.
+ *
+ * Tests the broker's pre-emptive Google refresh path: walk every
+ * stored Google account on each tick, refresh the ones near expiry
+ * via GoogleProvider (talking to Google's `/token` endpoint), and
+ * persist the new credentials back to disk.
+ *
+ * The Anthropic equivalent has been integration-tested in
+ * `server.test.ts` for many releases; these tests target Google's
+ * additional surface — separate provider, separate storage path,
+ * no per-agent fanout.
+ */
+
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { AuthBroker } from "./server.js";
+import {
+  googleAccountCredentialsPath,
+  writeGoogleAccountCredentials,
+} from "./google-storage.js";
+import type { SwitchroomConfig } from "../../config/schema.js";
+import type { GoogleCredentialsShape } from "./protocol.js";
+
+interface Harness {
+  tmp: string;
+  home: string;
+  agentsDir: string;
+  stateDir: string;
+  socketRoot: string;
+}
+
+let harnesses: Harness[] = [];
+
+function makeHarness(): Harness {
+  const tmp = mkdtempSync(join(tmpdir(), "auth-broker-google-refresh-test-"));
+  const home = join(tmp, "home");
+  const agentsDir = join(home, ".switchroom", "agents");
+  const stateDir = join(home, ".switchroom", "state", "auth-broker");
+  const socketRoot = join(tmp, "run", "switchroom", "auth-broker");
+  mkdirSync(home, { recursive: true });
+  mkdirSync(agentsDir, { recursive: true });
+  const h: Harness = { tmp, home, agentsDir, stateDir, socketRoot };
+  harnesses.push(h);
+  return h;
+}
+
+afterEach(() => {
+  for (const h of harnesses) {
+    try {
+      rmSync(h.tmp, { recursive: true, force: true });
+    } catch {
+      /* ignore */
+    }
+  }
+  harnesses = [];
+});
+
+function makeConfig(h: Harness): SwitchroomConfig {
+  return {
+    switchroom: { version: 1, agents_dir: h.agentsDir },
+    telegram: {},
+    agents: {},
+    auth: {},
+    google_workspace: {
+      google_client_id: "client-id-test.apps.googleusercontent.com",
+      google_client_secret: "test-secret",
+    },
+  } as unknown as SwitchroomConfig;
+}
+
+function seedGoogleAccount(
+  h: Harness,
+  account: string,
+  opts: { expiresAt: number; refreshToken?: string; accessToken?: string },
+): void {
+  const creds: GoogleCredentialsShape = {
+    googleOauth: {
+      accessToken: opts.accessToken ?? `at-${account}`,
+      refreshToken: opts.refreshToken ?? `rt-${account}`,
+      expiresAt: opts.expiresAt,
+      scope: "https://www.googleapis.com/auth/drive.readonly",
+      clientId: "client-id-test.apps.googleusercontent.com",
+      accountEmail: account,
+      tokenType: "Bearer",
+    },
+  };
+  writeGoogleAccountCredentials(h.stateDir, account, creds);
+}
+
+/**
+ * Stub fetch returning a successful Google token-exchange response.
+ * Records every URL hit so tests can assert exactly which accounts
+ * the tick refreshed.
+ */
+function makeOkFetcher(opts: {
+  newAccessToken?: string;
+  rotatedRefreshToken?: string;
+  expiresIn?: number;
+}): { fetcher: typeof fetch; calls: string[] } {
+  const calls: string[] = [];
+  const fetcher = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    calls.push(String(input));
+    const body: Record<string, unknown> = {
+      access_token: opts.newAccessToken ?? "at-new",
+      expires_in: opts.expiresIn ?? 3600,
+      token_type: "Bearer",
+      scope: "https://www.googleapis.com/auth/drive.readonly",
+    };
+    if (opts.rotatedRefreshToken) {
+      body.refresh_token = opts.rotatedRefreshToken;
+    }
+    return new Response(JSON.stringify(body), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    }) as unknown as Awaited<ReturnType<typeof fetch>>;
+    void init;
+  }) as unknown as typeof fetch;
+  return { fetcher, calls };
+}
+
+/** Stub fetch returning Google's `invalid_grant` error. */
+function makeInvalidGrantFetcher(): typeof fetch {
+  return (async () => {
+    return new Response(
+      JSON.stringify({
+        error: "invalid_grant",
+        error_description: "Token has been expired or revoked.",
+      }),
+      { status: 400, headers: { "content-type": "application/json" } },
+    ) as unknown as Awaited<ReturnType<typeof fetch>>;
+  }) as unknown as typeof fetch;
+}
+
+describe("AuthBroker — RFC G Phase 3b.2d Google refresh-tick", () => {
+  it("refreshes a Google account whose token is within REFRESH_THRESHOLD_MS of expiry", async () => {
+    const h = makeHarness();
+    const config = makeConfig(h);
+    // Expires in 30 minutes — well inside the 60-minute threshold.
+    const aboutToExpire = Date.now() + 30 * 60 * 1000;
+    seedGoogleAccount(h, "alice@example.com", {
+      expiresAt: aboutToExpire,
+      refreshToken: "rt-alice",
+    });
+
+    const { fetcher, calls } = makeOkFetcher({
+      newAccessToken: "at-alice-fresh",
+      expiresIn: 3600,
+    });
+    const broker = new AuthBroker(config, {
+      home: h.home,
+      stateDir: h.stateDir,
+      socketRoot: h.socketRoot,
+      disableRefreshLoop: true,
+      fetcher,
+    });
+    await broker.start();
+    await broker._tick();
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toContain("oauth2.googleapis.com/token");
+
+    const onDisk = JSON.parse(
+      readFileSync(googleAccountCredentialsPath(h.stateDir, "alice@example.com"), "utf-8"),
+    ) as GoogleCredentialsShape;
+    expect(onDisk.googleOauth.accessToken).toBe("at-alice-fresh");
+    // expiresAt should now be ~1h in the future, well past the original.
+    expect(onDisk.googleOauth.expiresAt).toBeGreaterThan(aboutToExpire);
+    // Refresh token preserved when Google didn't rotate it.
+    expect(onDisk.googleOauth.refreshToken).toBe("rt-alice");
+
+    broker.stop();
+  });
+
+  it("does NOT refresh when the token is comfortably within validity (>1h remaining)", async () => {
+    const h = makeHarness();
+    const config = makeConfig(h);
+    const farFuture = Date.now() + 24 * 60 * 60 * 1000;
+    seedGoogleAccount(h, "bob@example.com", { expiresAt: farFuture });
+
+    const { fetcher, calls } = makeOkFetcher({});
+    const broker = new AuthBroker(config, {
+      home: h.home,
+      stateDir: h.stateDir,
+      socketRoot: h.socketRoot,
+      disableRefreshLoop: true,
+      fetcher,
+    });
+    await broker.start();
+    await broker._tick();
+
+    expect(calls).toHaveLength(0);
+    const onDisk = JSON.parse(
+      readFileSync(googleAccountCredentialsPath(h.stateDir, "bob@example.com"), "utf-8"),
+    ) as GoogleCredentialsShape;
+    // Untouched.
+    expect(onDisk.googleOauth.accessToken).toBe("at-bob@example.com");
+    expect(onDisk.googleOauth.expiresAt).toBe(farFuture);
+
+    broker.stop();
+  });
+
+  it("preserves the old refresh token when Google rotates and includes it", async () => {
+    const h = makeHarness();
+    const config = makeConfig(h);
+    seedGoogleAccount(h, "carol@example.com", {
+      expiresAt: Date.now() + 5 * 60 * 1000, // 5 min — definitely refresh
+      refreshToken: "rt-carol-original",
+    });
+
+    const { fetcher } = makeOkFetcher({
+      rotatedRefreshToken: "rt-carol-rotated",
+    });
+    const broker = new AuthBroker(config, {
+      home: h.home,
+      stateDir: h.stateDir,
+      socketRoot: h.socketRoot,
+      disableRefreshLoop: true,
+      fetcher,
+    });
+    await broker.start();
+    await broker._tick();
+
+    const onDisk = JSON.parse(
+      readFileSync(googleAccountCredentialsPath(h.stateDir, "carol@example.com"), "utf-8"),
+    ) as GoogleCredentialsShape;
+    expect(onDisk.googleOauth.refreshToken).toBe("rt-carol-rotated");
+
+    broker.stop();
+  });
+
+  it("does NOT touch on-disk credentials when Google returns invalid_grant", async () => {
+    const h = makeHarness();
+    const config = makeConfig(h);
+    const originalExpiresAt = Date.now() + 5 * 60 * 1000;
+    seedGoogleAccount(h, "dave@example.com", {
+      expiresAt: originalExpiresAt,
+      accessToken: "at-dave-original",
+      refreshToken: "rt-dave-revoked",
+    });
+
+    const broker = new AuthBroker(config, {
+      home: h.home,
+      stateDir: h.stateDir,
+      socketRoot: h.socketRoot,
+      disableRefreshLoop: true,
+      fetcher: makeInvalidGrantFetcher(),
+    });
+    await broker.start();
+    // Should not throw — the failure is logged and the tick proceeds.
+    await broker._tick();
+
+    const onDisk = JSON.parse(
+      readFileSync(googleAccountCredentialsPath(h.stateDir, "dave@example.com"), "utf-8"),
+    ) as GoogleCredentialsShape;
+    // Untouched — the stale-but-still-valid creds give the operator
+    // time to re-OAuth.
+    expect(onDisk.googleOauth.accessToken).toBe("at-dave-original");
+    expect(onDisk.googleOauth.refreshToken).toBe("rt-dave-revoked");
+    expect(onDisk.googleOauth.expiresAt).toBe(originalExpiresAt);
+
+    broker.stop();
+  });
+
+  it("walks every stored Google account on each tick", async () => {
+    const h = makeHarness();
+    const config = makeConfig(h);
+    const near = Date.now() + 5 * 60 * 1000;
+    seedGoogleAccount(h, "alice@example.com", { expiresAt: near });
+    seedGoogleAccount(h, "bob@example.com", { expiresAt: near });
+    seedGoogleAccount(h, "carol@example.com", { expiresAt: near });
+
+    const { fetcher, calls } = makeOkFetcher({});
+    const broker = new AuthBroker(config, {
+      home: h.home,
+      stateDir: h.stateDir,
+      socketRoot: h.socketRoot,
+      disableRefreshLoop: true,
+      fetcher,
+    });
+    await broker.start();
+    await broker._tick();
+
+    expect(calls).toHaveLength(3);
+    broker.stop();
+  });
+
+  it("is a no-op when google_workspace config is absent (no provider registered)", async () => {
+    const h = makeHarness();
+    // Config WITHOUT google_workspace block.
+    const config = {
+      switchroom: { version: 1, agents_dir: h.agentsDir },
+      telegram: {},
+      agents: {},
+      auth: {},
+    } as unknown as SwitchroomConfig;
+
+    // Even seeding a Google account on disk shouldn't trigger anything.
+    seedGoogleAccount(h, "alice@example.com", {
+      expiresAt: Date.now() + 5 * 60 * 1000,
+    });
+
+    const { fetcher, calls } = makeOkFetcher({});
+    const broker = new AuthBroker(config, {
+      home: h.home,
+      stateDir: h.stateDir,
+      socketRoot: h.socketRoot,
+      disableRefreshLoop: true,
+      fetcher,
+    });
+    await broker.start();
+    await broker._tick();
+
+    // No refresh attempted — provider isn't registered.
+    expect(calls).toHaveLength(0);
+    broker.stop();
+  });
+});

--- a/src/auth/broker/server.ts
+++ b/src/auth/broker/server.ts
@@ -51,6 +51,7 @@ import { AnthropicProvider } from "./anthropic-provider.js";
 import { GoogleProvider } from "./google-provider.js";
 import {
   googleAccountExists,
+  listGoogleAccounts,
   readGoogleAccountCredentials,
   removeGoogleAccount,
   validateGoogleAccountLabel,
@@ -239,19 +240,19 @@ export class AuthBroker {
     // Google provider loaded; the broker still rejects
     // `provider: "google"` requests via registry.has() per Phase 3b.1.
     //
-    // **TODO (Phase 3b.2d):** the `google_client_id` / `_secret`
+    // **Known foot-gun (tracked):** the `google_client_id` / `_secret`
     // schema fields accept `vault:<key>` references (per
     // `src/config/schema.ts:759`); `src/cli/drive.ts:446-448`
-    // resolves them via `resolveMaybeVaultRef`. Today the broker
-    // passes the raw config string verbatim, so a vault-ref config
-    // would silently send a literal `"vault:..."` string to Google's
-    // token endpoint and fail. Phase 3b.2c shipped storage but
-    // refresh-tick is still deferred to 3b.2d (along with the
-    // per-(provider, account) state-keying refactor); 3b.2d MUST
-    // resolve vault refs here BEFORE the GoogleProvider's first
-    // refresh fires. Foot-gun until then — operators using
-    // `vault:` refs in google_workspace will hit it on the first
-    // refresh attempt.
+    // resolves them via `resolveMaybeVaultRef`. The broker passes the
+    // raw config string verbatim, so a vault-ref config would
+    // silently send a literal `"vault:..."` string to Google's token
+    // endpoint and fail. Resolution requires broker-side vault
+    // access (its own architectural piece — broker doesn't currently
+    // talk to vault-broker). Until then operators must use plain
+    // strings in `google_workspace.{google_client_id, google_client_secret}`
+    // — the OAuth client identity isn't a high-secrecy value (it's
+    // operator-owned, not account-owned). Refresh-tick (this file's
+    // `refreshOneGoogleAccount`) lands without vault-ref support.
     //
     // **Known limitation:** `reload()` does NOT re-run provider
     // registration. An operator who adds `google_workspace:` to a
@@ -1222,6 +1223,90 @@ export class AuthBroker {
       } catch (err) {
         this.logErr(`refresh-tick ${label}: ${(err as Error).message}`);
       }
+    }
+    // Phase 3b.2d — also walk Google accounts. The provider may not
+    // be registered (no google_workspace: config), in which case there
+    // are no Google accounts on disk anyway and the loop is a no-op.
+    if (this.providers.has("google")) {
+      for (const account of listGoogleAccounts(this.stateDir)) {
+        try {
+          await this.refreshOneGoogleAccount(account, /*force*/ false);
+        } catch (err) {
+          this.logErr(
+            `refresh-tick google:${account}: ${(err as Error).message}`,
+          );
+        }
+      }
+    }
+  }
+
+  /**
+   * Pre-emptively refresh one Google account's access token if it's
+   * within REFRESH_THRESHOLD_MS of expiry. Mirrors `refreshOneAccount`
+   * (the Anthropic path) in shape — same in-flight lease pattern, same
+   * threshold, same outcome discriminant — but talks to GoogleProvider
+   * and writes back via `writeGoogleAccountCredentials`.
+   *
+   * Unlike Anthropic refresh, there's no per-agent fanout: Google
+   * credentials are pulled on-demand by the wrapper-broker client
+   * (`src/drive/wrapper-broker.ts`) via `get-credentials({provider:
+   * "google"})`. The broker just needs the on-disk credentials kept
+   * fresh.
+   *
+   * Returns the same outcome shape as the Anthropic path so callers
+   * can branch uniformly.
+   */
+  private async refreshOneGoogleAccount(
+    account: string,
+    force: boolean,
+  ): Promise<
+    | { kind: "noop" }
+    | { kind: "refreshed"; newExpiresAt: number }
+    | { kind: "failed"; error: string }
+  > {
+    // Lease key is namespaced so Google `alice@example.com` doesn't
+    // collide with an Anthropic account literally named the same.
+    const leaseKey = `google:${account}`;
+    if (this.refreshInFlight.has(leaseKey)) return { kind: "noop" };
+
+    const credsBefore = readGoogleAccountCredentials(this.stateDir, account);
+    if (!credsBefore) {
+      // Account vanished between listGoogleAccounts() and now — treat
+      // as noop. Operator-driven `auth google account remove` is the
+      // typical path here.
+      return { kind: "noop" };
+    }
+    const provider = this.providers.lookup("google");
+    const onDiskExpires = provider.extractExpiresAt(credsBefore);
+    if (!force) {
+      const remaining = (onDiskExpires ?? 0) - this.now();
+      if (onDiskExpires !== undefined && remaining > REFRESH_THRESHOLD_MS) {
+        return { kind: "noop" };
+      }
+    }
+
+    this.refreshInFlight.add(leaseKey);
+    try {
+      const refreshToken = credsBefore.googleOauth.refreshToken;
+      const result = await provider.refresh({
+        refreshToken,
+        accountEmail: account,
+        clientId: credsBefore.googleOauth.clientId,
+      });
+      if (!result.ok) {
+        // Don't touch on-disk credentials on failure — the existing
+        // refreshToken may still work next tick (transient network),
+        // and on `invalid_grant` the operator needs to re-OAuth (the
+        // wrapper-broker get-credentials path will surface a clean
+        // error to the consumer when they next call).
+        return { kind: "failed", error: `${result.kind}: ${result.detail}` };
+      }
+      const newCreds = result.rawCredentials as GoogleCredentialsShape;
+      // Provider returned the rawCredentials shape verbatim; persist.
+      writeGoogleAccountCredentials(this.stateDir, account, newCreds);
+      return { kind: "refreshed", newExpiresAt: result.expiresAt };
+    } finally {
+      this.refreshInFlight.delete(leaseKey);
     }
   }
 


### PR DESCRIPTION
## Summary

Without this, Google access tokens expire after ~1h and the wrapper-broker `get-credentials({provider: "google"})` path starts returning expired-but-not-yet-refreshed tokens. This was the last load-bearing gap in the RFC G chain — `auth google account add` would work, agents would happily use Drive for an hour, then silently break.

The broker now walks every stored Google account on each refresh tick (one-minute interval, same as Anthropic) and refreshes any that are within `REFRESH_THRESHOLD_MS` (60 min) of expiry.

## Design

**Mirrors `refreshOneAccount` (the Anthropic path) in shape:**
- Same in-flight lease pattern (`refreshInFlight` Set; Google keys namespaced as `google:<account>` to avoid collision with an Anthropic account literally named the same).
- Same threshold (60 min) and tick interval (60 sec).
- Same outcome discriminant (`noop` | `refreshed` | `failed`).

**But differs where it should:**
- Talks to `GoogleProvider` (wraps `src/drive/oauth.ts:refreshAccessToken`) instead of `account-refresh.ts:refreshAccountIfNeeded`.
- Writes back via `writeGoogleAccountCredentials` (per-account `~/.switchroom/state/auth-broker/google/<email>/credentials.json`) instead of `writeAccountCredentials`.
- **No per-agent fanout** — Google credentials are pulled on-demand by the wrapper-broker client (`src/drive/wrapper-broker.ts`) via `get-credentials`. Broker just keeps on-disk credentials fresh.

**On failure (invalid_grant / network / quota):** broker leaves on-disk credentials untouched. Existing refreshToken may work next tick (transient); on hard failure operator's wrapper-broker call surfaces a clean error so they can re-OAuth.

## Test plan

- [x] `npm run lint` clean
- [x] 6 new tests in `server-google-refresh.test.ts`: threshold-hit refresh, no-op-when-fresh, refresh-token-rotation preservation, invalid_grant doesn't clobber on-disk creds, multi-account walk, no-op-when-provider-not-registered
- [x] All 144 tests in `src/auth/broker/` pass
- [ ] Manual smoke (post-merge, on host with running broker + a Google account that's about to expire): `journalctl -u switchroom-auth-broker | grep refresh-tick` shows the Google account refreshed before expiry; `cat ~/.switchroom/state/auth-broker/google/<email>/credentials.json | jq .googleOauth.expiresAt` shows the new far-future timestamp

## Out of scope (tracked follow-ups)

- **vault: ref resolution at startup** for `google_workspace.{google_client_id, google_client_secret}`. Broker doesn't talk to vault-broker yet (its own architectural piece). Until then operators must use plain strings — the OAuth client identity isn't a high-secrecy value (operator-owned, not account-owned). Existing `apply` preflight could surface a warning if vault refs are present here. Stale TODO comment at `server.ts:242` rewritten to reflect this clearly.
- **Threshold-violation tracking + sha-index drift detection** for Google credentials. Anthropic's path uses a config-mirrored sha index that doesn't translate 1:1 to per-account Google storage; defer to a separate hardening pass.
- **`list-google-accounts` broker op** — needed for `auth google account list` verb (currently errors with NOT_IMPLEMENTED per #1274).

🤖 Generated with [Claude Code](https://claude.com/claude-code)