### PR TITLE
fix(reconcile): regenerate CLAUDE.md silently on template drift

### DIFF
--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -3440,26 +3440,14 @@ Don't wait for a slash command. Don't ask permission. Memory work is table stake
         composed = composed.trimEnd() + "\n\n" + agentConfig.claude_md_raw + "\n";
       }
 
-      // Migration detection: if on-disk differs and no sidecar exists, warn + abort
-      if (existsSync(claudeMdDest)) {
-        const onDisk = readFileSync(claudeMdDest, "utf-8");
-        if (onDisk !== composed && !existsSync(claudeCustomPath)) {
-          console.error(
-            chalk.red(
-              `CLAUDE.md has hand-edits that will be overwritten by reconcile.\n\n` +
-              `Options:\n` +
-              `  1. Move your custom content to ${claudeCustomPath} and re-run reconcile.\n` +
-              `     The sidecar is appended to the regenerated CLAUDE.md and never overwritten.\n` +
-              `  2. Pass --preserve-claude-md to keep your current CLAUDE.md as-is (no template updates).\n` +
-              `  3. Accept the regeneration and lose hand-edits.\n\n` +
-              `Aborting this reconcile. Re-run with one of the above options.`
-            )
-          );
-          process.exit(1);
-        }
-      }
-
-      // Write if changed
+      // CLAUDE.md is template-owned: every reconcile regenerates it from
+      // CLAUDE.md.hbs + workspace/CLAUDE.custom.md sidecar. Drift between
+      // on-disk and freshly-rendered bytes is almost always template
+      // churn upstream, not operator hand-edits (operators put custom
+      // content in the sidecar). The previous abort treated those cases
+      // identically and forced --preserve-claude-md on every release.
+      // Preserve mode still exists for operators who genuinely want to
+      // freeze a CLAUDE.md (`reconcile --preserve-claude-md`).
       const before = existsSync(claudeMdDest) ? readFileSync(claudeMdDest, "utf-8") : "";
       if (composed !== before) {
         writeFileSync(claudeMdDest, composed, "utf-8");

--- a/tests/reconcile.persona.test.ts
+++ b/tests/reconcile.persona.test.ts
@@ -152,7 +152,7 @@ describe("reconcileAgent — persona (Phase 3)", () => {
     expect(afterReconcile).toContain("User-added content");
   });
 
-  it("aborts reconcile with warning when CLAUDE.md has hand-edits and no sidecar exists", () => {
+  it("regenerates CLAUDE.md silently when on-disk drifts from template (no abort)", () => {
     const config = makeAgentConfig({
       soul: { name: "Agent", style: "default" },
     });
@@ -160,14 +160,19 @@ describe("reconcileAgent — persona (Phase 3)", () => {
     const result = scaffoldAgent("test-agent", config, tmpDir, telegramConfig);
     const claudeMdPath = join(result.agentDir, "CLAUDE.md");
 
-    // User edits CLAUDE.md (simulating hand-edits)
+    // Simulate template drift (or stray hand-edits) — bytes don't match
+    // what re-rendering the template would produce, no sidecar exists.
     const original = readFileSync(claudeMdPath, "utf-8");
     const edited = original + "\n\n## My Custom Section\n\nUser-added content.";
     writeFileSync(claudeMdPath, edited, "utf-8");
 
-    // Reconcile should abort with exit(1)
+    // Reconcile must NOT abort; it should regenerate from template.
     expect(() => {
       reconcileAgent("test-agent", config, tmpDir, telegramConfig, switchroomConfig);
-    }).toThrow(); // process.exit(1) will throw in test environment
+    }).not.toThrow();
+
+    // Drift is gone — file matches what scaffold would have written fresh.
+    const afterReconcile = readFileSync(claudeMdPath, "utf-8");
+    expect(afterReconcile).not.toContain("## My Custom Section");
   });
 });


### PR DESCRIPTION
## Summary

`reconcileAgent` aborted with a "CLAUDE.md has hand-edits that will be overwritten" error any time the on-disk bytes diverged from a freshly-rendered template. The check couldn't tell template churn upstream from operator hand-edits — both look identical at the byte level. In practice this meant every release that touched `CLAUDE.md.hbs`, the vault-protocol fragment, or the self-service fragment tripped the abort on every existing agent, forcing `--preserve-claude-md` on every run.

CLAUDE.md is template-owned (operators put custom content in `workspace/CLAUDE.custom.md`, which `composeWithSidecar` already appends). This change drops the abort, regenerates silently, keeps the sidecar composition unchanged, and keeps `--preserve-claude-md` as the explicit opt-out.

- Reviewed by an independent fresh-process reviewer: **APPROVE**, no blockers.
- 20/20 reconcile tests pass, lint clean.
- The persona test that pinned the abort is rewritten to assert silent regen; the `--preserve-claude-md` test (which actually exercises the operator-keeps-hand-edits use case) is unchanged.

## Test plan

- [x] `npx vitest run tests/reconcile` — 20/20 pass
- [x] `npm run lint` — clean
- [x] Verified `--preserve-claude-md` path still untouched
- [x] Verified `composeWithSidecar` still runs (operator sidecar still composed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)