### PR TITLE
fix(auth-broker): fanout at boot + wire SWITCHROOM_AUTH_BROKER_OPERATOR_UID

### DIFF
--- a/src/agents/compose.ts
+++ b/src/agents/compose.ts
@@ -1012,6 +1012,15 @@ export function generateCompose(opts: ComposeGeneratorOptions): string {
   lines.push(`      SWITCHROOM_AUTH_BROKER_STATE_DIR: /state/auth-broker`);
   lines.push(`      SWITCHROOM_ACCOUNTS_DIR: /state/accounts`);
   lines.push(`      SWITCHROOM_AGENTS_DIR: /state/agents`);
+  // Operator UID — when set, the broker binds an additional listener at
+  // /run/switchroom/auth-broker/operator/sock and chowns it to this UID
+  // so `switchroom auth …` from a shell on the host can reach the
+  // broker. Mirrors vault-broker's SWITCHROOM_BROKER_OPERATOR_UID
+  // env-driven enablement. Without this, the operator-dir bind mount
+  // below is unused dead weight.
+  if (opts.operatorUid !== undefined) {
+    lines.push(`      SWITCHROOM_AUTH_BROKER_OPERATOR_UID: "${opts.operatorUid}"`);
+  }
   lines.push(`    volumes:`);
   // Per-agent socket dir (named volume; agent side mounts the parent).
   for (const a of describeAgents(config)) {

--- a/src/auth/broker/index.ts
+++ b/src/auth/broker/index.ts
@@ -8,13 +8,22 @@
  *   SWITCHROOM_CONFIG          — Path to switchroom.yaml (default
  *                                /etc/switchroom/switchroom.yaml inside
  *                                the broker container).
+ *   SWITCHROOM_AUTH_BROKER_OPERATOR_UID — When set (and no explicit
+ *                                `--operator-uid` flag is passed), bind
+ *                                the operator socket and chown it to
+ *                                this UID. Mirrors the vault-broker
+ *                                `SWITCHROOM_BROKER_OPERATOR_UID` shape.
+ *                                Used by the compose generator so the
+ *                                host CLI's `switchroom auth …` verbs
+ *                                can reach the broker.
  *
  * Flags:
  *   --operator-uid <N>         — When set, bind the operator socket and
- *                                chown it to <N>. Without this, the
- *                                broker still binds per-agent / per-
- *                                consumer listeners (the operator surface
- *                                is purely additive).
+ *                                chown it to <N>. Wins over the env var
+ *                                when both are present. Without either,
+ *                                the broker still binds per-agent /
+ *                                per-consumer listeners (the operator
+ *                                surface is purely additive).
  *
  * Signals:
  *   SIGTERM / SIGINT — graceful stop (close sockets, drop refresh timer).
@@ -51,9 +60,23 @@ function parseFlags(argv: readonly string[]): { operatorUid?: number } {
   return out;
 }
 
+function operatorUidFromEnv(): number | undefined {
+  const raw = process.env.SWITCHROOM_AUTH_BROKER_OPERATOR_UID;
+  if (raw === undefined || raw.length === 0) return undefined;
+  const n = Number.parseInt(raw, 10);
+  if (!Number.isFinite(n) || n < 0) {
+    throw new Error(
+      `SWITCHROOM_AUTH_BROKER_OPERATOR_UID='${raw}' is not a non-negative integer`,
+    );
+  }
+  return n;
+}
+
 export async function main(): Promise<void> {
   const argv = process.argv.slice(2);
   const flags = parseFlags(argv);
+  // Flag wins; env-var is the compose-driven default.
+  const operatorUid = flags.operatorUid ?? operatorUidFromEnv();
 
   const configPath = process.env.SWITCHROOM_CONFIG;
   if (configPath !== undefined && !existsSync(configPath)) {
@@ -82,7 +105,7 @@ export async function main(): Promise<void> {
   // any `depends_on: service_healthy` chain stalls forever.
   const stateDirEnv = process.env.SWITCHROOM_AUTH_BROKER_STATE_DIR;
   const broker = new AuthBroker(config, {
-    operatorUid: flags.operatorUid,
+    operatorUid,
     stateDir: stateDirEnv && stateDirEnv.length > 0 ? stateDirEnv : undefined,
   });
 

--- a/src/auth/broker/server.test.ts
+++ b/src/auth/broker/server.test.ts
@@ -177,6 +177,55 @@ describe("AuthBroker — startup + listeners", () => {
     broker.stop();
   });
 
+  // Boot fanout — without this, `switchroom update` fleets come back
+  // logged-out: the new RFC-H runtime reads .credentials.json from disk,
+  // refreshTick() no-ops while expiresAt is far in the future, and
+  // there's no setActive() call after recreate. So the only opportunity
+  // to write the per-agent mirror is at boot. fanoutAll() honours the
+  // same effective-account rule (auth.override ?? auth.active) so it's
+  // safe regardless of how the operator pinned accounts.
+  it("writes per-agent .credentials.json mirrors at boot when auth.active is set", async () => {
+    const h = makeHarness();
+    const config = makeConfig(h, {
+      active: "default",
+      agents: { ziggy: {}, clerk: {} },
+    });
+    seedAccount(h, "default");
+    mkdirSync(join(h.agentsDir, "ziggy"), { recursive: true });
+    mkdirSync(join(h.agentsDir, "clerk"), { recursive: true });
+    const broker = new AuthBroker(config, {
+      home: h.home,
+      stateDir: h.stateDir,
+      socketRoot: h.socketRoot,
+      disableRefreshLoop: true,
+    });
+    await broker.start();
+    const ziggyMirror = join(h.agentsDir, "ziggy", ".claude", ".credentials.json");
+    const clerkMirror = join(h.agentsDir, "clerk", ".claude", ".credentials.json");
+    expect(existsSync(ziggyMirror)).toBe(true);
+    expect(existsSync(clerkMirror)).toBe(true);
+    expect(readFileSync(ziggyMirror, "utf-8")).toContain("at-default");
+    broker.stop();
+  });
+
+  it("boot fanout is a no-op when auth.active and per-agent overrides are both unset", async () => {
+    const h = makeHarness();
+    // No `active` set — exactly the misconfiguration this fanout guards.
+    const config = makeConfig(h, { agents: { ziggy: {} } });
+    seedAccount(h, "default");
+    mkdirSync(join(h.agentsDir, "ziggy"), { recursive: true });
+    const broker = new AuthBroker(config, {
+      home: h.home,
+      stateDir: h.stateDir,
+      socketRoot: h.socketRoot,
+      disableRefreshLoop: true,
+    });
+    await broker.start();
+    const ziggyMirror = join(h.agentsDir, "ziggy", ".claude", ".credentials.json");
+    expect(existsSync(ziggyMirror)).toBe(false);
+    broker.stop();
+  });
+
   it("refuses to start with a consumer named like an agent", () => {
     const h = makeHarness();
     const config = makeConfig(h, {

--- a/src/auth/broker/server.ts
+++ b/src/auth/broker/server.ts
@@ -313,6 +313,21 @@ export class AuthBroker {
       this.refreshTimer.unref();
     }
 
+    // Boot fanout — write per-agent .credentials.json mirrors for every
+    // agent whose effective account exists on disk. Without this, a fresh
+    // boot leaves agents without a mirror until the next setActive() RPC
+    // or threshold-driven refreshTick(): with a far-future expiresAt the
+    // refresh tick no-ops indefinitely, and `switchroom update` fleets
+    // come back logged-out because the new RFC-H runtime reads the file,
+    // not the env var the legacy path injected. fanoutAll is a no-op when
+    // auth.active and per-agent overrides are both unset (returns 0).
+    const fanned = this.fanoutAll();
+    if (fanned.length > 0) {
+      process.stdout.write(
+        `auth-broker: boot fanout wrote ${fanned.length} mirror(s) — ${fanned.join(", ")}\n`,
+      );
+    }
+
     // Healthy marker — docker healthcheck reads this.
     if (!this.opts.skipHealthyMarker) {
       try {

--- a/tests/docker/compose-generator.test.ts
+++ b/tests/docker/compose-generator.test.ts
@@ -744,6 +744,26 @@ describe("generateCompose", () => {
     expect(block).toContain("/home/op/.switchroom/broker-operator:/run/switchroom/broker/operator");
   });
 
+  // auth-broker mirrors the vault-broker operator-socket contract under
+  // its own env var name (SWITCHROOM_AUTH_BROKER_OPERATOR_UID) so the
+  // host CLI's `switchroom auth …` verbs can reach the broker. Without
+  // this the operator-dir bind mount the generator already emits is
+  // unused dead weight and the broker never binds an operator listener.
+  it("emits SWITCHROOM_AUTH_BROKER_OPERATOR_UID on the auth-broker when operatorUid is set", () => {
+    const out = generateCompose({
+      config: makeConfig({ a: {} }),
+      operatorUid: 1000,
+    });
+    const block = /switchroom-auth-broker:[\s\S]*?(?=\n  [a-z])/.exec(out)?.[0] ?? "";
+    expect(block).toMatch(/SWITCHROOM_AUTH_BROKER_OPERATOR_UID:\s*"1000"/);
+  });
+
+  it("omits SWITCHROOM_AUTH_BROKER_OPERATOR_UID when operatorUid is not set (back-compat)", () => {
+    const out = generateCompose({ config: makeConfig({ a: {} }) });
+    const block = /switchroom-auth-broker:[\s\S]*?(?=\n  [a-z])/.exec(out)?.[0] ?? "";
+    expect(block).not.toContain("SWITCHROOM_AUTH_BROKER_OPERATOR_UID");
+  });
+
 });
 
 describe("agent service env (Phase 2c F2 — IPC wiring)", () => {


### PR DESCRIPTION
## Summary

Closes two boot-time gaps in the RFC-H auth-broker rollout that left fleets logged-out after every \`switchroom update\` until manual intervention:

1. **\`broker.start()\` now writes per-agent \`.credentials.json\` mirrors at boot.** Previously the mirror writes only fired on \`setActive\` RPC or threshold-driven \`refreshTick()\` — both of which miss the post-recreate path. With a far-future \`expiresAt\`, refresh-tick no-ops indefinitely, and there's no setActive after the recreate. Result: claude inside each agent booted reading a stale (or non-existent) \`.credentials.json\` and rendered "Not logged in · Run /login". Now \`fanoutAll()\` runs after listeners bind; it's a no-op when \`auth.active\` and per-agent overrides are both unset, so the existing default-config path is untouched.

2. **The compose generator now emits \`SWITCHROOM_AUTH_BROKER_OPERATOR_UID\`** so the auth-broker actually binds an operator listener at the host-bound dir the compose file already mounts. Without this, \`switchroom auth use <label>\` from a host shell returned "broker unreachable: socket file not found" and operators had no clean path to set \`auth.active\`. Mirrors the vault-broker \`SWITCHROOM_BROKER_OPERATOR_UID\` pattern; CLI \`--operator-uid\` still wins when both are present.

This is what kept this morning's incident manual — without these, the only way to recover a fleet was to sudo-write \`.credentials.json\` per agent by hand.

- Reviewed by an independent fresh-process reviewer: **APPROVE**. Edge cases walked (no agents, dangling active label, missing agentDir, CAP_CHOWN missing in dev) — all short-circuit silently.
- 156/156 tests pass across the two targeted suites; lint clean.

## Test plan

- [x] \`npx vitest run src/auth/broker/server.test.ts tests/docker/compose-generator.test.ts\` — 156/156
- [x] \`npm run lint\` — clean
- [x] New server tests pin the boot-fanout behaviour (writes mirrors when active is set, no-op when it's not)
- [x] New compose-generator tests pin the env-var emission shape and the back-compat omission

🤖 Generated with [Claude Code](https://claude.com/claude-code)