### PR TITLE
fix(auth-broker): wire --operator-uid into compose command

### DIFF
--- a/src/agents/compose.ts
+++ b/src/agents/compose.ts
@@ -1001,6 +1001,18 @@ export function generateCompose(opts: ComposeGeneratorOptions): string {
   lines.push(`      - "FOWNER"`);
   lines.push(`      - "DAC_READ_SEARCH"`);
   lines.push(`      - "DAC_OVERRIDE"`);
+  // Operator UID — when set, pass `--operator-uid <N>` so the broker
+  // entry binds the operator listener at
+  // /run/switchroom/auth-broker/operator/sock and chowns it to <N>.
+  // Without this the host operator's `switchroom auth use|add|show` CLI
+  // hits "auth-broker unreachable at .../auth-broker-operator/sock" —
+  // the bind mount below exists but the socket never gets created.
+  // Mirror of vault-broker's pattern (line ~813) but plumbed via flag
+  // rather than env var since the broker entry script reads
+  // --operator-uid as a flag, not an env (see src/auth/broker/index.ts).
+  if (opts.operatorUid !== undefined) {
+    lines.push(`    command: ["bun", "/opt/switchroom/dist/auth-broker/index.js", "--operator-uid", "${opts.operatorUid}"]`);
+  }
   lines.push(`    environment:`);
   if (switchroomConfigPath) {
     lines.push(`      SWITCHROOM_CONFIG: /state/config/switchroom.yaml`);
@@ -1025,10 +1037,15 @@ export function generateCompose(opts: ComposeGeneratorOptions): string {
   }
   // Operator socket — host-mounted bind so `switchroom auth …` from a
   // shell on the host can reach the broker. Path is the operator-
-  // socket bind documented in the RFC §4.2.
-  lines.push(
-    `      - ${homePrefix}/.switchroom/state/auth-broker-operator:/run/switchroom/auth-broker/operator`,
-  );
+  // socket bind documented in the RFC §4.2. Only emitted when an
+  // operator-uid is set (mirrors vault-broker line ~834) — without one
+  // the broker doesn't bind an operator listener so the bind mount
+  // would just be a confusingly-empty dir on disk.
+  if (opts.operatorUid !== undefined) {
+    lines.push(
+      `      - ${homePrefix}/.switchroom/state/auth-broker-operator:/run/switchroom/auth-broker/operator`,
+    );
+  }
   if (switchroomConfigPath) {
     lines.push(`      - ${switchroomConfigPath}:/state/config/switchroom.yaml:ro`);
   }


### PR DESCRIPTION
## Summary

`switchroom auth use|add|show|rotate` from the host shell hits `auth-broker unreachable at .../auth-broker-operator/sock`. The bind mount exists but the socket file never gets created because the auth-broker container's CMD is bare — no `--operator-uid <N>` flag, so the broker entry (`src/auth/broker/index.ts:32-50`) skips `bindOperatorListener` and the host operator has no way to talk to the broker.

Same env-var-emit-but-not-consume pattern as the `SWITCHROOM_AUTH_BROKER_STATE_DIR` follow-up (during PR #1254 stabilisation), but one layer deeper — here it was never even emitted as an env var because the broker entry reads `--operator-uid` as a CLI flag.

## Surfaced live

During the RFC H rollout (post-merge of PR #1254): `switchroom update` succeeded; doctor reported `auth-broker: fleet active account: \`auth.active\` not set` as the hard fail blocking agent boots; but `switchroom auth use ken.thompson@outlook.com.au` to fix that failed with the unreachable error. YAML-edit + apply is a workaround; this PR is the structural fix.

## What changed

Two related edits in `src/agents/compose.ts` (the auth-broker service block):

1. **Emit a `command:` override** when `opts.operatorUid !== undefined`:
   ```yaml
   command: ["bun", "/opt/switchroom/dist/auth-broker/index.js", "--operator-uid", "1000"]
   ```
   The Dockerfile's bare CMD stays as the default; compose just overrides it when an operator UID is known. Mirrors how vault-broker does it (line ~817) but via flag rather than env var, since `src/auth/broker/index.ts` only accepts the flag form.

2. **Gate the host-side operator bind** on `operatorUid !== undefined` (mirrors vault-broker line ~834). Without an operator UID the broker doesn't bind a listener, so a bound-but-unused empty dir on disk just confuses operators.

## Test plan

- [x] All 124 `tests/docker/compose-generator*.test.ts` pass
- [x] `npm run lint` clean (4 checks)
- [x] Manually verified: regenerated compose locally contains the new `command:` line with the host's UID (`1000`)
- [ ] Buildkite CI green
- [ ] After merge + redeploy on the live fleet: `switchroom auth use ken.thompson@outlook.com.au` succeeds; doctor's `auth-broker: fleet active account` check goes ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)