### PR TITLE
feat(auth-broker): list-google-accounts op + wire `auth google account list` verb

### DIFF
--- a/src/auth/broker/client.ts
+++ b/src/auth/broker/client.ts
@@ -180,6 +180,18 @@ export interface SetOverrideData {
   account: string | null;
 }
 
+/** Per-account inventory entry returned by `listGoogleAccounts()`. */
+export interface GoogleAccountState {
+  account: string;
+  expiresAt: number;
+  scope: string;
+  clientId: string;
+}
+
+export interface ListGoogleAccountsData {
+  accounts: GoogleAccountState[];
+}
+
 /** Anthropic-shaped credentials payload for `addAccount`. */
 export interface AnthropicAddAccountCredentials {
   claudeAiOauth: {
@@ -282,6 +294,15 @@ export class AuthBrokerClient {
       op: "list-state",
     });
     return data as ListStateData;
+  }
+
+  async listGoogleAccounts(): Promise<ListGoogleAccountsData> {
+    const data = await this.send({
+      v: PROTOCOL_VERSION,
+      id: randomUUID(),
+      op: "list-google-accounts",
+    });
+    return data as ListGoogleAccountsData;
   }
 
   async setActive(account: string): Promise<SetActiveData> {

--- a/src/auth/broker/google-storage.ts
+++ b/src/auth/broker/google-storage.ts
@@ -168,8 +168,10 @@ export function removeGoogleAccount(stateDir: string, account: string): void {
 }
 
 /**
- * List all Google accounts the broker has stored. Used by `list-state`
- * (Phase 3b.2c.2 future) and the doctor.
+ * List all Google accounts the broker has stored. Used by the
+ * `list-google-accounts` op (powering `switchroom auth google account
+ * list`), the refresh-tick loop (`refreshOneGoogleAccount`), and the
+ * doctor.
  *
  * Reads filesystem layout, not in-memory state — operators can drop
  * a credentials.json by hand and the broker will pick it up on next

--- a/src/auth/broker/protocol.ts
+++ b/src/auth/broker/protocol.ts
@@ -222,6 +222,26 @@ export const SetOverrideRequestSchema = z.object({
   account: z.string().min(1).nullable(),
 });
 
+/**
+ * Phase 3b.2d follow-up — enumerate Google accounts the broker has
+ * stored. Distinct from `list-state` (which is Anthropic-shaped:
+ * fleet active, fallback order, per-agent + consumer overrides). The
+ * Google equivalent is the per-account ACL via `google_accounts.<email>.
+ * enabled_for[]` in switchroom.yaml — that's the operator-facing matrix
+ * (see `switchroom auth google list`); this op is the broker-side
+ * inventory of what credentials are stored, used by `auth google
+ * account list` to confirm the YAML matches what the broker holds.
+ *
+ * Refresh token + access token are NOT returned — those stay on disk.
+ * Only credential metadata an operator needs to reason about (which
+ * accounts exist, when each token expires, what scopes were granted).
+ */
+export const ListGoogleAccountsRequestSchema = z.object({
+  v: z.literal(PROTOCOL_VERSION),
+  op: z.literal("list-google-accounts"),
+  id: z.string().min(1),
+});
+
 export const RequestSchema = z.discriminatedUnion("op", [
   GetCredentialsRequestSchema,
   ListStateRequestSchema,
@@ -231,6 +251,7 @@ export const RequestSchema = z.discriminatedUnion("op", [
   AddAccountRequestSchema,
   RmAccountRequestSchema,
   SetOverrideRequestSchema,
+  ListGoogleAccountsRequestSchema,
 ]);
 
 export type Request = z.infer<typeof RequestSchema>;
@@ -299,6 +320,23 @@ export const RmAccountDataSchema = z.object({
 export const SetOverrideDataSchema = z.object({
   agent: z.string(),
   account: z.string().nullable(),
+});
+
+/**
+ * Per-Google-account inventory entry returned by `list-google-accounts`.
+ * Excludes the refresh + access tokens — operators querying the
+ * inventory don't need those, and never returning them keeps the wire
+ * surface narrow.
+ */
+export const GoogleAccountStateSchema = z.object({
+  account: z.string(),
+  expiresAt: z.number(),
+  scope: z.string(),
+  clientId: z.string(),
+});
+
+export const ListGoogleAccountsDataSchema = z.object({
+  accounts: z.array(GoogleAccountStateSchema),
 });
 
 // ─── Response envelope ─────────────────────────────────────────────────────

--- a/src/auth/broker/server-list-google-accounts.test.ts
+++ b/src/auth/broker/server-list-google-accounts.test.ts
@@ -1,0 +1,237 @@
+/**
+ * auth-broker — `list-google-accounts` op (RFC G follow-up).
+ *
+ * Tests the broker-side inventory of stored Google accounts. Returns
+ * metadata only (account, expiresAt, scope, clientId) — refresh + access
+ * tokens stay on disk.
+ */
+
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import * as net from "node:net";
+
+import { AuthBroker } from "./server.js";
+import { decodeResponse, encodeRequest } from "./protocol.js";
+import { writeGoogleAccountCredentials } from "./google-storage.js";
+import type { SwitchroomConfig } from "../../config/schema.js";
+import type { GoogleCredentialsShape } from "./protocol.js";
+
+interface Harness {
+  tmp: string;
+  home: string;
+  agentsDir: string;
+  stateDir: string;
+  socketRoot: string;
+}
+
+let harnesses: Harness[] = [];
+
+function makeHarness(): Harness {
+  const tmp = mkdtempSync(
+    join(tmpdir(), "auth-broker-list-google-test-"),
+  );
+  const home = join(tmp, "home");
+  const agentsDir = join(home, ".switchroom", "agents");
+  const stateDir = join(home, ".switchroom", "state", "auth-broker");
+  const socketRoot = join(tmp, "run", "switchroom", "auth-broker");
+  mkdirSync(home, { recursive: true });
+  mkdirSync(agentsDir, { recursive: true });
+  const h: Harness = { tmp, home, agentsDir, stateDir, socketRoot };
+  harnesses.push(h);
+  return h;
+}
+
+afterEach(() => {
+  for (const h of harnesses) {
+    try {
+      rmSync(h.tmp, { recursive: true, force: true });
+    } catch {
+      /* ignore */
+    }
+  }
+  harnesses = [];
+});
+
+function makeConfig(h: Harness, agents: Record<string, object> = {}): SwitchroomConfig {
+  return {
+    switchroom: { version: 1, agents_dir: h.agentsDir },
+    telegram: {},
+    agents,
+    auth: {},
+    google_workspace: {
+      google_client_id: "client-id-test.apps.googleusercontent.com",
+      google_client_secret: "test-secret",
+    },
+  } as unknown as SwitchroomConfig;
+}
+
+function seedGoogleAccount(
+  h: Harness,
+  account: string,
+  opts: { expiresAt: number; scope?: string; clientId?: string } = { expiresAt: Date.now() + 3600_000 },
+): void {
+  const creds: GoogleCredentialsShape = {
+    googleOauth: {
+      accessToken: `at-${account}`,
+      refreshToken: `rt-${account}`,
+      expiresAt: opts.expiresAt,
+      scope: opts.scope ?? "https://www.googleapis.com/auth/drive.readonly",
+      clientId: opts.clientId ?? "client-id-test.apps.googleusercontent.com",
+      accountEmail: account,
+      tokenType: "Bearer",
+    },
+  };
+  writeGoogleAccountCredentials(h.stateDir, account, creds);
+}
+
+/** Open UDS, send one request, read one response, close. */
+async function rpc(socketPath: string, req: object): Promise<unknown> {
+  return await new Promise<unknown>((resolveP, rejectP) => {
+    const c = net.createConnection(socketPath);
+    let buf = "";
+    let settled = false;
+    const settle = (v: unknown, err?: Error): void => {
+      if (settled) return;
+      settled = true;
+      try {
+        c.destroy();
+      } catch {
+        /* ignore */
+      }
+      if (err) rejectP(err);
+      else resolveP(v);
+    };
+    c.on("connect", () => {
+      c.write(encodeRequest(req as Parameters<typeof encodeRequest>[0]));
+    });
+    c.on("data", (chunk) => {
+      buf += chunk.toString("utf-8");
+      const nl = buf.indexOf("\n");
+      if (nl !== -1) {
+        const line = buf.slice(0, nl);
+        try {
+          settle(decodeResponse(line));
+        } catch (err) {
+          settle(null, err as Error);
+        }
+      }
+    });
+    c.on("error", (err) => settle(null, err));
+    setTimeout(() => settle(null, new Error("rpc timeout")), 3000);
+  });
+}
+
+describe("AuthBroker — list-google-accounts op", () => {
+  it("returns every stored Google account, sorted by email, without tokens", async () => {
+    const h = makeHarness();
+    const config = makeConfig(h, { ziggy: {} });
+    seedGoogleAccount(h, "carol@example.com", {
+      expiresAt: 3000,
+      scope: "https://www.googleapis.com/auth/drive.readonly",
+    });
+    seedGoogleAccount(h, "alice@example.com", {
+      expiresAt: 1000,
+      scope: "https://www.googleapis.com/auth/calendar",
+    });
+    seedGoogleAccount(h, "bob@example.com", { expiresAt: 2000 });
+
+    const broker = new AuthBroker(config, {
+      home: h.home,
+      stateDir: h.stateDir,
+      socketRoot: h.socketRoot,
+      disableRefreshLoop: true,
+    });
+    await broker.start();
+
+    const resp = (await rpc(join(h.socketRoot, "ziggy", "sock"), {
+      v: 1,
+      id: "test-1",
+      op: "list-google-accounts",
+    })) as { ok: true; data: { accounts: Array<Record<string, unknown>> } };
+
+    expect(resp.ok).toBe(true);
+    const emails = resp.data.accounts.map((a) => a.account);
+    expect(emails).toEqual([
+      "alice@example.com",
+      "bob@example.com",
+      "carol@example.com",
+    ]);
+    expect(resp.data.accounts[0].expiresAt).toBe(1000);
+    expect(resp.data.accounts[0].scope).toBe(
+      "https://www.googleapis.com/auth/calendar",
+    );
+    expect(resp.data.accounts[0].clientId).toBe(
+      "client-id-test.apps.googleusercontent.com",
+    );
+    // Refresh + access tokens are explicitly NOT in the response.
+    for (const a of resp.data.accounts) {
+      expect(a).not.toHaveProperty("refreshToken");
+      expect(a).not.toHaveProperty("accessToken");
+    }
+
+    broker.stop();
+  });
+
+  it("returns an empty list when no Google accounts are stored", async () => {
+    const h = makeHarness();
+    const config = makeConfig(h, { ziggy: {} });
+
+    const broker = new AuthBroker(config, {
+      home: h.home,
+      stateDir: h.stateDir,
+      socketRoot: h.socketRoot,
+      disableRefreshLoop: true,
+    });
+    await broker.start();
+
+    const resp = (await rpc(join(h.socketRoot, "ziggy", "sock"), {
+      v: 1,
+      id: "test-2",
+      op: "list-google-accounts",
+    })) as { ok: true; data: { accounts: unknown[] } };
+
+    expect(resp.ok).toBe(true);
+    expect(resp.data.accounts).toEqual([]);
+
+    broker.stop();
+  });
+
+  it("returns an empty list when google_workspace config is absent", async () => {
+    const h = makeHarness();
+    // Config without google_workspace block.
+    const config = {
+      switchroom: { version: 1, agents_dir: h.agentsDir },
+      telegram: {},
+      agents: { ziggy: {} },
+      auth: {},
+    } as unknown as SwitchroomConfig;
+
+    const broker = new AuthBroker(config, {
+      home: h.home,
+      stateDir: h.stateDir,
+      socketRoot: h.socketRoot,
+      disableRefreshLoop: true,
+    });
+    await broker.start();
+
+    const resp = (await rpc(join(h.socketRoot, "ziggy", "sock"), {
+      v: 1,
+      id: "test-3",
+      op: "list-google-accounts",
+    })) as { ok: true; data: { accounts: unknown[] } };
+
+    // Even without the provider registered, this op just reads disk.
+    // If the dir doesn't exist, it returns []. No INVALID_ARGS — the
+    // op's contract is "what's stored on disk."
+    expect(resp.ok).toBe(true);
+    expect(resp.data.accounts).toEqual([]);
+
+    broker.stop();
+  });
+});

--- a/src/auth/broker/server.ts
+++ b/src/auth/broker/server.ts
@@ -744,6 +744,9 @@ export class AuthBroker {
         case "set-override":
           await this.opSetOverride(socket, reqId, identity, req.agent, req.account);
           break;
+        case "list-google-accounts":
+          await this.opListGoogleAccounts(socket, reqId, identity);
+          break;
       }
     } catch (err) {
       socket.write(
@@ -844,6 +847,43 @@ export class AuthBroker {
         consumers,
       }),
     );
+  }
+
+  /**
+   * Inventory of Google accounts the broker has stored on disk.
+   * Reads `~/.switchroom/state/auth-broker/google/<account>/credentials.json`
+   * for each account and returns metadata only — refresh + access
+   * tokens stay on disk. Sorted by account email for stable output.
+   *
+   * Distinct from `list-state` (Anthropic-shaped fleet snapshot). The
+   * Google equivalent for the operator-facing matrix lives in YAML
+   * (`google_accounts.<email>.enabled_for[]`); this op exists so the
+   * `auth google account list` verb can confirm the broker actually
+   * holds the credentials the YAML claims.
+   *
+   * No ACL — same posture as `list-state`. Identity is recorded in the
+   * audit log but every caller that reaches the broker can call this.
+   */
+  private async opListGoogleAccounts(
+    socket: net.Socket,
+    id: string,
+    identity: Identity,
+  ): Promise<void> {
+    const accounts = listGoogleAccounts(this.stateDir)
+      .map((account) => {
+        const creds = readGoogleAccountCredentials(this.stateDir, account);
+        if (!creds) return null;
+        return {
+          account,
+          expiresAt: creds.googleOauth.expiresAt,
+          scope: creds.googleOauth.scope,
+          clientId: creds.googleOauth.clientId,
+        };
+      })
+      .filter((entry): entry is NonNullable<typeof entry> => entry !== null)
+      .sort((a, b) => a.account.localeCompare(b.account));
+    this.audit({ op: "list-google-accounts", identity, ok: true });
+    socket.write(encodeSuccess(id, { accounts }));
   }
 
   private async opSetActive(

--- a/src/cli/auth-google.ts
+++ b/src/cli/auth-google.ts
@@ -562,35 +562,72 @@ function registerAccountList(accountParent: Command): void {
     )
     .option("--json", "Emit raw JSON instead of a table")
     .action(
-      withConfigError(async (_opts: { json?: boolean }) => {
-        // The broker stores Google credentials per-account today
-        // (#1272 / opGoogleAddAccount → google-storage.ts) but doesn't
-        // yet expose a `list-google-accounts` op. Rather than return
-        // a misleading empty list (which scripts would silently treat
-        // as "no accounts"), refuse with NOT_IMPLEMENTED + a pointer
-        // at the on-disk source of truth and the sibling YAML matrix
-        // verb. A `list-google-accounts` broker op + this verb's
-        // wiring is tracked as a follow-up.
-        console.error();
-        console.error(
-          chalk.yellow(
-            `  ⚠  \`auth google account list\` is not yet implemented — the broker has no list-google-accounts op.`,
-          ),
+      withConfigError(async (opts: { json?: boolean }) => {
+        const { brokerCall } = await import("./broker-call.js");
+        const data = await brokerCall(async (client) =>
+          client.listGoogleAccounts(),
         );
-        console.error();
-        console.error(`  To inspect Google accounts the broker holds:`);
-        console.error(
-          chalk.gray(`    ls ~/.switchroom/state/auth-broker/google/`),
+
+        if (opts.json) {
+          console.log(JSON.stringify(data, null, 2));
+          return;
+        }
+
+        console.log();
+        if (data.accounts.length === 0) {
+          console.log(chalk.gray("  No Google accounts stored in broker."));
+          console.log(
+            `  Add one: ${chalk.bold("switchroom auth google account add <email>")}`,
+          );
+          console.log();
+          return;
+        }
+
+        const accountColWidth = Math.max(
+          ...data.accounts.map((a) => a.account.length),
+          "ACCOUNT".length,
         );
-        console.error();
-        console.error(`  For the YAML google_accounts × agents matrix:`);
-        console.error(
-          chalk.cyan(`    switchroom auth google list`),
+        const expiresColWidth = "EXPIRES".length + 2;
+        console.log(
+          `${pad("ACCOUNT", accountColWidth)}  ${pad("EXPIRES", expiresColWidth)}  SCOPE`,
         );
-        console.error();
-        process.exit(1);
+        console.log(
+          `${pad("-".repeat(7), accountColWidth)}  ${pad("-".repeat(7), expiresColWidth)}  ${"-".repeat(5)}`,
+        );
+        const now = Date.now();
+        for (const a of data.accounts) {
+          const remainingMs = a.expiresAt - now;
+          const expiresLabel = formatExpiry(remainingMs);
+          // Compress scope display — operators don't need the full URL
+          // prefix on every list. Keep enough to distinguish read-only
+          // from writable scopes.
+          const scopes = a.scope
+            .split(" ")
+            .map((s) => s.replace(/^https:\/\/www\.googleapis\.com\/auth\//, ""))
+            .filter(Boolean)
+            .join(", ");
+          console.log(
+            `${pad(a.account, accountColWidth)}  ${pad(expiresLabel, expiresColWidth)}  ${scopes}`,
+          );
+        }
+        console.log();
       }),
     );
+}
+
+/**
+ * Format a millisecond duration as a short relative time. Negative
+ * durations render as "expired" — the broker's refresh-tick keeps
+ * stored creds within the 60-min threshold so this should be rare.
+ */
+function formatExpiry(remainingMs: number): string {
+  if (remainingMs <= 0) return chalk.red("expired");
+  const minutes = Math.round(remainingMs / 60_000);
+  if (minutes < 60) return `${minutes}m`;
+  const hours = Math.round(minutes / 60);
+  if (hours < 48) return `${hours}h`;
+  const days = Math.round(hours / 24);
+  return `${days}d`;
 }
 
 // ────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Closes the last operator-facing gap in the RFC G chain. Before this, `switchroom auth google account list` exited with NOT_IMPLEMENTED (see #1274) and the broker had no way to report which Google accounts it had stored.

## What changed

**Protocol** — new `list-google-accounts` request + `GoogleAccountStateSchema` returning `{account, expiresAt, scope, clientId}` per account. Refresh + access tokens explicitly excluded — operators querying inventory don't need them and never returning them keeps the wire surface narrow.

**Server** — `opListGoogleAccounts` reads `~/.switchroom/state/auth-broker/google/<account>/credentials.json` for each entry from `listGoogleAccounts(stateDir)`, sorts by email for stable output. No ACL (same posture as `list-state`).

**Client** — `listGoogleAccounts(): Promise<ListGoogleAccountsData>`.

**CLI verb** — `auth google account list` now does what its description claims. Human mode renders a 3-col table (ACCOUNT, EXPIRES relative, SCOPE compressed). `--json` mode emits the broker response verbatim. Empty list points operators at `auth google account add`.

## Test plan

- [x] `npm run lint` clean
- [x] 3 new integration tests against a real broker socket: sorted multi-account, empty list, absent-google-config (still returns empty)
- [x] All 155 tests across `src/auth/broker/` + `src/cli/auth-google.test.ts` pass
- [ ] Manual smoke (post-merge, against running broker with at least one Google account):
  ```
  switchroom auth google account list
  switchroom auth google account list --json
  ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)