### PR TITLE
fix(auth): enrich account credentials with scopes + subscriptionType on write

### DIFF
--- a/src/auth/account-store.ts
+++ b/src/auth/account-store.ts
@@ -214,6 +214,40 @@ export function readAccountCredentials(
   }
 }
 
+/**
+ * Default scopes and subscription for accounts written without them.
+ *
+ * Pre-RFC-H, claude-code's env-var path (`CLAUDE_CODE_OAUTH_TOKEN`)
+ * synthesised these fields at runtime — every Anthropic call from a
+ * subscription-tier OAuth token saw `scopes: ["user:inference"]` and
+ * `subscriptionType: "max"` regardless of what the on-disk creds said.
+ * RFC-H deletes the env-var path; claude now reads `.credentials.json`
+ * verbatim. Files written by the legacy slot setup ({accessToken,
+ * expiresAt, scopes: []}) are rejected as "not logged in" because the
+ * empty scopes list and missing subscriptionType don't pass the
+ * post-RFC-H file-shape gate.
+ *
+ * Enrichment here closes the gap at the write side: any account
+ * credentials we persist always carry the fields claude expects, even
+ * if the OAuth handshake didn't return them.
+ */
+const DEFAULT_SCOPES = ["user:inference"] as const;
+const DEFAULT_SUBSCRIPTION_TYPE = "max";
+
+function enrichClaudeCreds(value: AccountCredentials): AccountCredentials {
+  const oauth = value.claudeAiOauth;
+  if (!oauth) return value;
+  const scopes =
+    oauth.scopes !== undefined && oauth.scopes.length > 0
+      ? oauth.scopes
+      : [...DEFAULT_SCOPES];
+  const subscriptionType = oauth.subscriptionType ?? DEFAULT_SUBSCRIPTION_TYPE;
+  return {
+    ...value,
+    claudeAiOauth: { ...oauth, scopes, subscriptionType },
+  };
+}
+
 export function writeAccountCredentials(
   label: string,
   value: AccountCredentials,
@@ -221,7 +255,7 @@ export function writeAccountCredentials(
 ): void {
   validateAccountLabel(label);
   mkdirSync(accountDir(label, home), { recursive: true });
-  atomicWriteJson(accountCredentialsPath(label, home), value);
+  atomicWriteJson(accountCredentialsPath(label, home), enrichClaudeCreds(value));
 }
 
 /* ── Meta read/write ─────────────────────────────────────────────────── */

--- a/tests/auth-account-store.test.ts
+++ b/tests/auth-account-store.test.ts
@@ -148,6 +148,56 @@ describe("credentials roundtrip", () => {
     writeFileSync(accountCredentialsPath("broken", home), "{ not: json");
     expect(readAccountCredentials("broken", home)).toBeNull();
   });
+
+  // RFC-H file-shape gate. Claude post-RFC-H reads .credentials.json
+  // verbatim and rejects accounts whose `scopes` is empty or whose
+  // `subscriptionType` is missing as "not logged in" (the legacy
+  // env-var path used to synthesise these). Any caller writing creds
+  // without these fields would silently break the agent at next boot
+  // and force a manual unstick. Enrichment closes that loophole.
+  it("enriches missing scopes + subscriptionType on write (RFC-H shape gate)", () => {
+    writeAccountCredentials(
+      "legacy",
+      { claudeAiOauth: { accessToken: "at", expiresAt: 9_999_999_999_999 } },
+      home,
+    );
+    const out = readAccountCredentials("legacy", home);
+    expect(out?.claudeAiOauth?.scopes).toEqual(["user:inference"]);
+    expect(out?.claudeAiOauth?.subscriptionType).toBe("max");
+  });
+
+  it("treats empty scopes array as missing (replaces with defaults)", () => {
+    writeAccountCredentials(
+      "empty-scopes",
+      { claudeAiOauth: { accessToken: "at", scopes: [] } },
+      home,
+    );
+    const out = readAccountCredentials("empty-scopes", home);
+    expect(out?.claudeAiOauth?.scopes).toEqual(["user:inference"]);
+  });
+
+  it("preserves explicit scopes + subscriptionType when provided", () => {
+    writeAccountCredentials(
+      "explicit",
+      {
+        claudeAiOauth: {
+          accessToken: "at",
+          scopes: ["custom:scope"],
+          subscriptionType: "pro",
+        },
+      },
+      home,
+    );
+    const out = readAccountCredentials("explicit", home);
+    expect(out?.claudeAiOauth?.scopes).toEqual(["custom:scope"]);
+    expect(out?.claudeAiOauth?.subscriptionType).toBe("pro");
+  });
+
+  it("does not synthesise claudeAiOauth when the input has none", () => {
+    writeAccountCredentials("no-oauth", {}, home);
+    const out = readAccountCredentials("no-oauth", home);
+    expect(out?.claudeAiOauth).toBeUndefined();
+  });
 });
 
 describe("meta roundtrip + patch", () => {
@@ -326,7 +376,11 @@ describe("getAccountInfos", () => {
     const personal = infos.find((i) => i.label === "personal")!;
     // missing expiresAt → not expired path; healthy if accessToken present + no quota
     expect(personal.health).toBe("healthy");
-    expect(personal.subscriptionType).toBeUndefined();
+    // subscriptionType is now defaulted to "max" at write time to satisfy
+    // claude's post-RFC-H file-shape gate. See enrichClaudeCreds in
+    // account-store.ts. Callers that need a different default should
+    // pass it explicitly.
+    expect(personal.subscriptionType).toBe("max");
   });
 });
 


### PR DESCRIPTION
## Summary

Closes the third RFC-H gap that PRs #1277 and #1278 left open. Account \`credentials.json\` files written without \`scopes\` (or with \`scopes: []\`) and without \`subscriptionType\` are rejected by claude post-RFC-H as "not logged in" — the env-var path that used to synthesise those fields at runtime is gone, and claude now reads the file verbatim.

\`writeAccountCredentials\` now enriches the \`claudeAiOauth\` block at write time:
- \`scopes\` defaults to \`["user:inference"]\` when missing or empty
- \`subscriptionType\` defaults to \`"max"\` when missing
- explicit values are preserved
- no \`claudeAiOauth\` → no enrichment (we don't synthesise a block)

This closes the loophole at the source: every account file persisted carries the shape claude needs, regardless of which legacy slot setup or OAuth handshake variant produced the input. Existing on-disk accounts repair on the next write (refresh tick, add, rotate).

- Reviewed by an independent fresh-process reviewer: **APPROVE**. \`subscriptionType\` is only a display label downstream — defaulting to \`"max"\` is cosmetically wrong for Pro users until next refresh, but no quota/billing/routing logic keys off it.
- 86/86 tests pass across account-store + broker suites; lint clean.

## Test plan

- [x] \`npx vitest run tests/auth-account-store.test.ts src/auth/account-store-env-override.test.ts src/auth/broker/server.test.ts src/auth/broker/claude-compat.test.ts\` — 86/86
- [x] \`npm run lint\` — clean
- [x] New tests pin enrichment of missing/empty scopes, preservation of explicit values, and no-synthesis of \`claudeAiOauth\` when input has none
- [x] Existing \`getAccountInfos\` test updated to reflect the new invariant ("writes always carry a subscriptionType")

🤖 Generated with [Claude Code](https://claude.com/claude-code)