### PR TITLE
test(compose): pin auth-broker operator command + volume gating

### DIFF
--- a/tests/docker/compose-generator.test.ts
+++ b/tests/docker/compose-generator.test.ts
@@ -764,6 +764,51 @@ describe("generateCompose", () => {
     expect(block).not.toContain("SWITCHROOM_AUTH_BROKER_OPERATOR_UID");
   });
 
+  // PR #1278: the auth-broker entry script reads `--operator-uid` as a
+  // CLI flag, not an env var. The env var above is a fallback the
+  // broker entry consumes (PR #1277) but the canonical wiring is a
+  // `command:` override that appends the flag. Without this, the
+  // bare CMD in docker/Dockerfile.auth-broker leaves operatorUid
+  // undefined inside the broker → bindOperatorListener never fires →
+  // operator socket never gets created. Caught live on 2026-05-15
+  // during the RFC H redeploy.
+  it("emits `command:` with --operator-uid flag when operatorUid is set", () => {
+    const out = generateCompose({
+      config: makeConfig({ a: {} }),
+      operatorUid: 1000,
+    });
+    const block = /switchroom-auth-broker:[\s\S]*?(?=\n  [a-z])/.exec(out)?.[0] ?? "";
+    expect(block).toMatch(
+      /command:\s*\["bun",\s*"\/opt\/switchroom\/dist\/auth-broker\/index\.js",\s*"--operator-uid",\s*"1000"\]/,
+    );
+  });
+
+  it("omits the `command:` override when operatorUid is not set (back-compat)", () => {
+    const out = generateCompose({ config: makeConfig({ a: {} }) });
+    const block = /switchroom-auth-broker:[\s\S]*?(?=\n  [a-z])/.exec(out)?.[0] ?? "";
+    expect(block).not.toMatch(/^\s+command:/m);
+  });
+
+  // The host-side operator bind mount must mirror the env / command
+  // gating — otherwise a no-operatorUid install ends up with an empty
+  // bind dir on disk that confuses operators reading the compose file.
+  it("emits the operator-socket bind mount when operatorUid is set", () => {
+    const out = generateCompose({
+      config: makeConfig({ a: {} }),
+      operatorUid: 1000,
+    });
+    const block = /switchroom-auth-broker:[\s\S]*?(?=\n  [a-z])/.exec(out)?.[0] ?? "";
+    expect(block).toMatch(
+      /\$\{HOME\}\/\.switchroom\/state\/auth-broker-operator:\/run\/switchroom\/auth-broker\/operator/,
+    );
+  });
+
+  it("omits the operator-socket bind mount when operatorUid is not set", () => {
+    const out = generateCompose({ config: makeConfig({ a: {} }) });
+    const block = /switchroom-auth-broker:[\s\S]*?(?=\n  [a-z])/.exec(out)?.[0] ?? "";
+    expect(block).not.toContain("auth-broker-operator:/run/switchroom/auth-broker/operator");
+  });
+
 });
 
 describe("agent service env (Phase 2c F2 — IPC wiring)", () => {


### PR DESCRIPTION
## Summary

Reviewer of PR #1278 (auth-broker `--operator-uid` wiring) flagged: `tests/docker/compose-generator.test.ts` had 3 tests pinning vault-broker's operator wiring but only 2 (env-var-only) for auth-broker. The `command:` override + volume-gate from #1278 had no coverage — exactly the contract that broke live on 2026-05-15 during the RFC H redeploy.

Adds 4 symmetric tests, mirrors of the vault-broker pair at `tests/docker/compose-generator.test.ts:714-731`:

| Test | Pins |
|---|---|
| `command:` includes `--operator-uid` + UID when set | The fix from #1278 |
| `command:` omitted when `operatorUid` undefined | Back-compat |
| Operator-socket bind mount emitted when set | New bind from #1278 |
| Operator-socket bind mount omitted when unset | Cleanup gate from #1278 |

## Test plan

- [x] `bun run test:vitest -- tests/docker/compose-generator.test.ts` → 121 pass / 0 fail (was 117 before)
- [x] `npm run lint` clean (4 checks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)