### PR TITLE
fix(auth-cli): `auth use` + `auth rotate` now write auth.active to YAML

### DIFF
--- a/src/cli/auth-active-yaml.test.ts
+++ b/src/cli/auth-active-yaml.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+
+import { setAuthActive } from "./auth-active-yaml.js";
+
+const BASE = `# top-level comment
+switchroom:
+  version: 1
+telegram:
+  bot_token: "x"
+agents:
+  clerk:
+    extends: default
+`;
+
+describe("setAuthActive", () => {
+  it("creates auth: map when absent", () => {
+    const out = setAuthActive(BASE, "ken@example.com");
+    expect(out).toMatch(/^# top-level comment/m);
+    expect(out).toMatch(/^auth:\n  active: ken@example\.com$/m);
+    // Preserves surrounding content.
+    expect(out).toContain("switchroom:");
+    expect(out).toContain("clerk:");
+  });
+
+  it("updates auth.active when already present (different label)", () => {
+    const withAuth = `auth:\n  active: old@example.com\n  fallback_order:\n    - old@example.com\n    - new@example.com\n${BASE}`;
+    const out = setAuthActive(withAuth, "new@example.com");
+    expect(out).toMatch(/active: new@example\.com/);
+    expect(out).not.toMatch(/active: old@example\.com/);
+    // Preserves fallback_order.
+    expect(out).toMatch(/fallback_order:\n\s+- old@example\.com\n\s+- new@example\.com/);
+  });
+
+  it("is idempotent — returns input verbatim when already set to label", () => {
+    const withAuth = `auth:\n  active: same@example.com\n${BASE}`;
+    const out = setAuthActive(withAuth, "same@example.com");
+    expect(out).toBe(withAuth);
+  });
+
+  it("preserves comments around the auth: block", () => {
+    const withComments = `# header
+auth:
+  # active account
+  active: a@x.com
+  fallback_order: [a@x.com]
+# footer
+${BASE}`;
+    const out = setAuthActive(withComments, "b@x.com");
+    expect(out).toContain("# header");
+    expect(out).toContain("# active account");
+    expect(out).toContain("# footer");
+    expect(out).toMatch(/active: b@x\.com/);
+  });
+
+  it("throws on empty label", () => {
+    expect(() => setAuthActive(BASE, "")).toThrow(/non-empty string/);
+  });
+
+  it("throws on YAML root that isn't a map (defensive)", () => {
+    expect(() => setAuthActive("- list\n- root\n", "x@y.com")).toThrow(/not a map/);
+  });
+
+  it("ensures trailing newline on output", () => {
+    const noTrail = `switchroom:\n  version: 1\n`.trimEnd();
+    const out = setAuthActive(noTrail, "x@y.com");
+    expect(out.endsWith("\n")).toBe(true);
+  });
+});

--- a/src/cli/auth-active-yaml.test.ts
+++ b/src/cli/auth-active-yaml.test.ts
@@ -65,4 +65,32 @@ ${BASE}`;
     const out = setAuthActive(noTrail, "x@y.com");
     expect(out.endsWith("\n")).toBe(true);
   });
+
+  // Regression pins from PR #1282 reviewer: `setIn(["auth","active"], …)`
+  // crashes when `auth` exists but isn't a map. These are realistic
+  // operator states — `auth:` with no children is common after a partial
+  // setup or hand-edit — and the CLI callsites' yellow-warn fallback
+  // would otherwise silently leave the YAML out of sync with broker state.
+  it("handles auth: null (bare key) by replacing with a fresh map", () => {
+    const withNull = `auth:\n${BASE}`;
+    const out = setAuthActive(withNull, "x@y.com");
+    expect(out).toMatch(/^auth:\n  active: x@y\.com$/m);
+    expect(out).toContain("switchroom:");
+  });
+
+  it("handles auth: <scalar> by replacing with a fresh map", () => {
+    const withScalar = `auth: "legacy-string"\n${BASE}`;
+    const out = setAuthActive(withScalar, "x@y.com");
+    expect(out).toMatch(/^auth:\n  active: x@y\.com$/m);
+    expect(out).not.toContain("legacy-string");
+  });
+
+  it("round-trips cleanly across multiple calls (byte-equality short-circuit)", () => {
+    const first = setAuthActive(BASE, "a@x.com");
+    const second = setAuthActive(first, "a@x.com");
+    expect(second).toBe(first);
+    const third = setAuthActive(second, "b@x.com");
+    expect(third).not.toBe(second);
+    expect(third).toMatch(/active: b@x\.com/);
+  });
 });

--- a/src/cli/auth-active-yaml.ts
+++ b/src/cli/auth-active-yaml.ts
@@ -1,0 +1,46 @@
+/**
+ * YAML editor for the top-level `auth.active: <label>` field.
+ *
+ * Pure module — string-in / string-out — so the CLI can read the
+ * existing file, mutate, and atomic-write the result without losing
+ * comments or surrounding formatting. Mirrors the pattern in
+ * `google-accounts-yaml.ts`.
+ *
+ * Two callers today:
+ *   - `switchroom auth use <label>` — pin the fleet-wide active account
+ *     after broker setActive succeeds. Without this, doctor's
+ *     `auth-broker: fleet active account` check stays red because it
+ *     reads switchroom.yaml, not the broker's in-memory state.
+ *   - `switchroom setup` — seeds `auth.active: default` on first run
+ *     so a freshly-set-up host has a valid auth stanza before
+ *     `auth add default --from-oauth` mints credentials.
+ */
+
+import { parseDocument, isMap } from "yaml";
+
+/**
+ * Set `auth.active: <label>` in the YAML text. Creates the top-level
+ * `auth:` map if missing. Idempotent — returns the input verbatim
+ * (preserving byte-equality) when `auth.active` already equals
+ * `label`.
+ *
+ * Returns the new YAML text. Caller is responsible for the
+ * atomic-write to disk and any mode preservation.
+ */
+export function setAuthActive(yamlText: string, label: string): string {
+  if (typeof label !== "string" || label.length === 0) {
+    throw new Error("setAuthActive: label must be a non-empty string");
+  }
+  const doc = parseDocument(yamlText);
+  const root = doc.contents;
+  if (!isMap(root)) {
+    throw new Error("setAuthActive: YAML root is not a map");
+  }
+  const existing = root.get("auth", true);
+  if (isMap(existing) && existing.get("active") === label) {
+    return yamlText;
+  }
+  doc.setIn(["auth", "active"], label);
+  const out = String(doc);
+  return out.endsWith("\n") ? out : out + "\n";
+}

--- a/src/cli/auth-active-yaml.ts
+++ b/src/cli/auth-active-yaml.ts
@@ -37,10 +37,21 @@ export function setAuthActive(yamlText: string, label: string): string {
     throw new Error("setAuthActive: YAML root is not a map");
   }
   const existing = root.get("auth", true);
-  if (isMap(existing) && existing.get("active") === label) {
-    return yamlText;
+  if (isMap(existing)) {
+    if (existing.get("active") === label) {
+      return yamlText;
+    }
+    // Map exists with other siblings (fallback_order, admin_agents, etc.) —
+    // patch only the `active` key so siblings + comments survive.
+    doc.setIn(["auth", "active"], label);
+  } else {
+    // `auth:` either absent, null (e.g. operator wrote a bare `auth:`
+    // key with no children), or scalar. `setIn` crashes on null/scalar
+    // because the yaml lib expects a collection — replace the whole
+    // `auth` value with a fresh map. There are no siblings to preserve
+    // in any of these branches.
+    doc.set("auth", { active: label });
   }
-  doc.setIn(["auth", "active"], label);
   const out = String(doc);
   return out.endsWith("\n") ? out : out + "\n";
 }

--- a/src/cli/auth.ts
+++ b/src/cli/auth.ts
@@ -44,8 +44,11 @@ import {
   readAccountCredentials,
 } from "../auth/account-store.js";
 import { resolveAgentsDir } from "../config/loader.js";
-import { withConfigError, getConfig } from "./helpers.js";
+import { withConfigError, getConfig, getConfigPath } from "./helpers.js";
 import { registerAuthGoogleSubcommands } from "./auth-google.js";
+import { setAuthActive } from "./auth-active-yaml.js";
+import { atomicWriteFileSync } from "../util/atomic.js";
+import { statSync } from "node:fs";
 
 // ─── Diagnose (used by tests; CLI heal verb removed) ─────────────────────
 
@@ -509,6 +512,27 @@ export function registerAuthCommand(program: Command): void {
             chalk.gray(`  Re-mirrored to ${data.fanned.length} agent(s): ${data.fanned.join(", ")}`),
           );
         }
+        // Also patch switchroom.yaml so `auth.active` matches the broker's
+        // in-memory state. Without this, doctor's `auth-broker: fleet
+        // active account` check stays red until manual YAML edit (caught
+        // live on 2026-05-15 RFC H redeploy).
+        try {
+          const yamlPath = getConfigPath(program);
+          const before = readFileSync(yamlPath, "utf-8");
+          const after = setAuthActive(before, data.active);
+          if (after !== before) {
+            let mode = 0o644;
+            try { mode = statSync(yamlPath).mode & 0o777; } catch { /* default */ }
+            atomicWriteFileSync(yamlPath, after, mode);
+            console.log(chalk.gray(`  Pinned auth.active: ${data.active} in ${yamlPath}`));
+          }
+        } catch (err) {
+          console.error(
+            chalk.yellow(
+              `  ⚠ Could not write auth.active to YAML: ${(err as Error).message}`,
+            ),
+          );
+        }
       }),
     );
 
@@ -557,6 +581,24 @@ export function registerAuthCommand(program: Command): void {
         if (data.fanned.length > 0) {
           console.log(
             chalk.gray(`  Re-mirrored to ${data.fanned.length} agent(s)`),
+          );
+        }
+        // Pin the rotation target into YAML so doctor + restart-after-OOM
+        // pick up the new active (same rationale as `auth use` above).
+        try {
+          const yamlPath = getConfigPath(program);
+          const before = readFileSync(yamlPath, "utf-8");
+          const after = setAuthActive(before, data.active);
+          if (after !== before) {
+            let mode = 0o644;
+            try { mode = statSync(yamlPath).mode & 0o777; } catch { /* default */ }
+            atomicWriteFileSync(yamlPath, after, mode);
+          }
+        } catch (err) {
+          console.error(
+            chalk.yellow(
+              `  ⚠ Could not write auth.active to YAML: ${(err as Error).message}`,
+            ),
           );
         }
       }),

--- a/src/cli/auth.ts
+++ b/src/cli/auth.ts
@@ -499,6 +499,34 @@ export function registerAuthCommand(program: Command): void {
       }),
     );
 
+  // Shared YAML-pin helper for `auth use` and `auth rotate`. Without
+  // this, doctor's `auth-broker: fleet active account` check stays red
+  // until manual YAML edit (caught live on 2026-05-15 RFC H redeploy).
+  // Failure is intentionally soft (yellow warn, command stays exit-0)
+  // because the broker is the runtime source of truth — the YAML write
+  // is for next-boot persistence and the operator can retry.
+  function pinAuthActiveInYaml(label: string, quiet = false): void {
+    try {
+      const yamlPath = getConfigPath(program);
+      const before = readFileSync(yamlPath, "utf-8");
+      const after = setAuthActive(before, label);
+      if (after !== before) {
+        let mode = 0o644;
+        try { mode = statSync(yamlPath).mode & 0o777; } catch { /* default */ }
+        atomicWriteFileSync(yamlPath, after, mode);
+        if (!quiet) {
+          console.log(chalk.gray(`  Pinned auth.active: ${label} in ${yamlPath}`));
+        }
+      }
+    } catch (err) {
+      console.error(
+        chalk.yellow(
+          `  ⚠ Could not write auth.active to YAML: ${(err as Error).message}`,
+        ),
+      );
+    }
+  }
+
   // ── auth use <label> ──────────────────────────────────────────────────
   auth
     .command("use <label>")
@@ -512,27 +540,7 @@ export function registerAuthCommand(program: Command): void {
             chalk.gray(`  Re-mirrored to ${data.fanned.length} agent(s): ${data.fanned.join(", ")}`),
           );
         }
-        // Also patch switchroom.yaml so `auth.active` matches the broker's
-        // in-memory state. Without this, doctor's `auth-broker: fleet
-        // active account` check stays red until manual YAML edit (caught
-        // live on 2026-05-15 RFC H redeploy).
-        try {
-          const yamlPath = getConfigPath(program);
-          const before = readFileSync(yamlPath, "utf-8");
-          const after = setAuthActive(before, data.active);
-          if (after !== before) {
-            let mode = 0o644;
-            try { mode = statSync(yamlPath).mode & 0o777; } catch { /* default */ }
-            atomicWriteFileSync(yamlPath, after, mode);
-            console.log(chalk.gray(`  Pinned auth.active: ${data.active} in ${yamlPath}`));
-          }
-        } catch (err) {
-          console.error(
-            chalk.yellow(
-              `  ⚠ Could not write auth.active to YAML: ${(err as Error).message}`,
-            ),
-          );
-        }
+        pinAuthActiveInYaml(data.active);
       }),
     );
 
@@ -584,23 +592,9 @@ export function registerAuthCommand(program: Command): void {
           );
         }
         // Pin the rotation target into YAML so doctor + restart-after-OOM
-        // pick up the new active (same rationale as `auth use` above).
-        try {
-          const yamlPath = getConfigPath(program);
-          const before = readFileSync(yamlPath, "utf-8");
-          const after = setAuthActive(before, data.active);
-          if (after !== before) {
-            let mode = 0o644;
-            try { mode = statSync(yamlPath).mode & 0o777; } catch { /* default */ }
-            atomicWriteFileSync(yamlPath, after, mode);
-          }
-        } catch (err) {
-          console.error(
-            chalk.yellow(
-              `  ⚠ Could not write auth.active to YAML: ${(err as Error).message}`,
-            ),
-          );
-        }
+        // pick up the new active (quiet — the "Rotated to" line above is
+        // the operator-facing signal).
+        pinAuthActiveInYaml(data.active, true);
       }),
     );
 

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -883,26 +883,33 @@ async function stepScaffoldAgents(
 }
 
 /**
- * Set `auth.active: default` in switchroom.yaml when unset. Pure-YAML
- * edit (preserves comments via `yaml` library's Document model).
- * Atomic write via the shared util. Idempotent.
+ * Set `auth.active: default` in switchroom.yaml when unset. Atomic
+ * write via the shared util. Idempotent — does nothing when
+ * `auth.active` is already set.
+ *
+ * The YAML mutation itself lives in src/cli/auth-active-yaml.ts so
+ * `switchroom auth use|rotate` can share it (caught during the
+ * 2026-05-15 RFC H redeploy: `auth use` updated broker state but
+ * never wrote the YAML, leaving doctor red).
  */
 async function ensureAuthActiveDefault(configPath: string): Promise<void> {
   const fs = await import("node:fs");
   const { parseDocument, isMap } = await import("yaml");
   const { atomicWriteFileSync } = await import("../util/atomic.js");
+  const { setAuthActive } = await import("./auth-active-yaml.js");
   const raw = fs.readFileSync(configPath, "utf-8");
+  // Guard: only seed "default" when auth.active is unset (setAuthActive
+  // would otherwise overwrite an operator-pinned active).
   const doc = parseDocument(raw);
   const root = doc.contents;
   if (!isMap(root)) return;
   const existing = root.get("auth", true);
   if (isMap(existing) && existing.has("active")) return;
-  doc.setIn(["auth", "active"], "default");
-  const out = String(doc);
-  const tail = out.endsWith("\n") ? out : out + "\n";
+  const after = setAuthActive(raw, "default");
+  if (after === raw) return;
   let mode = 0o644;
   try { mode = fs.statSync(configPath).mode & 0o777; } catch { /* default */ }
-  atomicWriteFileSync(configPath, tail, mode);
+  atomicWriteFileSync(configPath, after, mode);
 }
 
 // ─── Step 8: Vault Auto-Unlock ──────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Caught live during the 2026-05-15 RFC H redeploy: `switchroom auth use ken.thompson@outlook.com.au` updated the broker's in-memory + on-disk state and re-mirrored to all 9 agents — but never wrote `auth.active: ken.thompson@outlook.com.au` into `switchroom.yaml`.

Doctor's `auth-broker: fleet active account` check reads the YAML, not broker state, so it kept reporting `❌ auth.active not set` until manual YAML edit. Same gap in `auth rotate` (also calls `setActive`).

## Fix

1. **New `src/cli/auth-active-yaml.ts`** — pure module exposing `setAuthActive(yamlText, label)` using the `yaml` library's Document model so comments + surrounding formatting survive. Idempotent (byte-equality return when already set).

2. **`auth use` + `auth rotate`** both call `setAuthActive` + atomic-write after the broker `setActive` succeeds. Failure is soft (yellow warn, command stays exit-0) — broker state is the runtime source of truth, the YAML is for next-boot persistence.

3. **`setup.ts`'s `ensureAuthActiveDefault`** refactored onto the shared helper so first-run seeding + operator-driven `auth use` go through one codepath.

## Test plan

- [x] `bun run test:vitest -- src/cli/auth-active-yaml` → 7/7 pass
- [x] `bun run test:vitest -- src/cli/auth src/cli/setup` → 19/19 pass
- [x] `npm run lint` clean (4 checks)
- [ ] After merge + redeploy: `switchroom auth use <label>` writes the YAML; doctor stays green without manual edit

7 new tests cover: create missing map, update existing label, idempotent on same label, preserve surrounding comments, empty-label rejection, non-map root rejection, trailing-newline invariant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)