### PR TITLE
fix(auth): scrub stale auth login / auth status references post-RFC-H

### DIFF
--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -2253,8 +2253,10 @@ export function scaffoldAgent(
   // .credentials.json. Each agent must go through its own fresh OAuth flow
   // (Phase 2 policy: copyExistingCredentials removed from scaffold path).
   // Existing credential blobs can be stale and cause silent 401s.
-  // Operators are directed to `switchroom auth login <agent>` or
-  // `switchroom agent bootstrap <agent>` for a guided OAuth flow.
+  // Operators register a fleet-wide account via `switchroom auth add
+  // <label> --from-oauth` + `switchroom auth use <label>` (RFC H); the
+  // auth-broker mirrors `.credentials.json` per agent at boot, on
+  // setActive, and on refresh-tick.
   //
   // UPGRADE WARN: if ~/.claude-home/.credentials.json (or ~/.claude/.credentials.json)
   // exists at scaffold time, we deliberately skip copying it. Agents that were

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -1336,7 +1336,7 @@ export function checkAgents(config: SwitchroomConfig, configPath: string): Check
           detail: auth?.pendingAuth
             ? "pending (auth flow in progress)"
             : "not authenticated",
-          fix: `Run \`switchroom auth login ${name}\` and complete the OAuth flow`,
+          fix: `Run \`switchroom auth add <label> --from-oauth\` then \`switchroom auth use <label>\` (RFC H — see docs/auth.md)`,
         });
       }
     } else {
@@ -1356,7 +1356,7 @@ export function checkAgents(config: SwitchroomConfig, configPath: string): Check
         status: nearExpiry ? "warn" : "ok",
         detail: parts.join(" · "),
         fix: nearExpiry
-          ? `Token expires soon — run \`switchroom auth login ${name}\` to refresh`
+          ? `Token expires soon — broker refreshes automatically below 60 min remaining; force with \`switchroom auth refresh\``
           : undefined,
       });
     }
@@ -1396,9 +1396,9 @@ export function checkAgents(config: SwitchroomConfig, configPath: string): Check
           detail,
           fix:
             quotaOut > 0
-              ? `Quota-exhausted slot(s) will auto-recover. Add a fresh slot with \`switchroom auth add ${name} <slot>\``
+              ? `Quota-exhausted account(s) will auto-recover when the window resets; broker auto-rotates per \`auth.fallback_order\` (see \`switchroom auth show\`).`
               : expired > 0
-                ? `Expired slot(s) — run \`switchroom auth login ${name} --slot <name>\``
+                ? `Expired account(s) — add a fresh one via \`switchroom auth add <label> --from-oauth\` and \`switchroom auth use <label>\` (RFC H).`
                 : undefined,
         });
       }

--- a/src/cli/restart.ts
+++ b/src/cli/restart.ts
@@ -12,7 +12,7 @@ import { getAuthStatus } from "../auth/manager.js";
  * Poll auth status for `name` until it reads authenticated=true, up to
  * `timeoutMs` (default 30 s).  Returns true if auth converged within the
  * window, false if it timed out.  Fixes #176: restart now blocks until auth
- * status reflects reality so `switchroom restart && switchroom auth status`
+ * status reflects reality so `switchroom restart && switchroom auth list`
  * shows ✓ without a second manual run.
  */
 function waitForAuthConverge(

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -1306,7 +1306,7 @@ async function stepVerification(
       `    3. Send a message in the "${firstAgent.topic_name}" topic`,
     ),
   );
-  console.log(chalk.gray("    4. Check auth:      switchroom auth status"));
+  console.log(chalk.gray("    4. Check auth:      switchroom auth list"));
 
   if (!nonInteractive) {
     const startNow = await askYesNo(

--- a/telegram-plugin/gateway/boot-probes.ts
+++ b/telegram-plugin/gateway/boot-probes.ts
@@ -861,7 +861,7 @@ export async function probeQuota(
         status: 'degraded',
         label: 'Quota',
         detail: 'no OAuth token',
-        nextStep: 'No OAuth token on disk — run `switchroom auth login <agent>` to authenticate',
+        nextStep: 'No OAuth token on disk — register a fleet account: `switchroom auth add <label> --from-oauth` then `switchroom auth use <label>` (RFC H)',
       }
     }
 
@@ -880,8 +880,8 @@ export async function probeQuota(
         label: 'Quota',
         detail: probe.reason,
         nextStep: isAuth
-          ? 'Auth rejected by Anthropic — re-authenticate with `switchroom auth login <agent>`'
-          : 'Anthropic quota probe failed — re-check after a minute; if persistent, `switchroom auth login <agent>`',
+          ? 'Auth rejected by Anthropic — broker auto-refreshes; if persistent, replace the account: `switchroom auth add <label> --from-oauth --replace`'
+          : 'Anthropic quota probe failed — re-check after a minute; broker auto-rotates per `auth.fallback_order`',
       }
     }
 

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -7434,7 +7434,7 @@ function renderAuthCodeOutcome(outcome: AuthCodeOutcome | null | undefined): str
     case 'pane-not-ready':
       return `Auth pane not ready — tap <b>Retry</b>.`
     case 'timeout':
-      return `Still waiting after 2 min — tap <b>Retry</b> or check <code>switchroom auth status</code>.${tail}`
+      return `Still waiting after 2 min — tap <b>Retry</b> or check <code>switchroom auth list</code>.${tail}`
   }
 }
 
@@ -7621,6 +7621,10 @@ function buildAgentAudit(agentName: string): AgentAudit | undefined {
 
 // Build an AgentMetadata snapshot for the current agent by shelling out
 // to `switchroom agent list --json` and `switchroom auth status --json`.
+// TODO(rfc-h): the `auth status` verb was retired by RFC H. The shell
+// fails silently and `authSummary` lands as null — /status renders
+// without auth detail. Replace with an `auth show --json` adapter that
+// maps the new fleet-broker shape to the per-agent AuthSummary fields.
 // Best-effort — any missing piece renders as a placeholder in the text
 // templates rather than blocking the reply.
 async function buildAgentMetadata(agentName: string): Promise<AgentMetadata> {


### PR DESCRIPTION
## Summary

Install-validation findings #34 + #35. RFC H (#1254) retired the per-agent \`switchroom auth login <agent>\` and \`switchroom auth status\` verbs, but several runtime strings + module comments still send operators to the dead commands. This PR replaces them with the RFC H idioms.

## Touched

- **\`src/cli/setup.ts\`** step-12 verification: \`auth status\` → \`auth list\`
- **\`src/cli/doctor.ts\`** four agent-auth fix messages — \"not authenticated\", \"Token expires soon\", \"Expired slot(s)\", \"Quota-exhausted slot(s)\" — now point at \`auth add --from-oauth\` + \`auth use\`, the broker's auto-refresh, and \`auth.fallback_order\`
- **\`telegram-plugin/gateway/boot-probes.ts\`** three quota-probe nextSteps — \"No OAuth token on disk\", \"Auth rejected\", \"Quota probe failed\"
- **\`telegram-plugin/gateway/gateway.ts\`** /status timeout reply: \`auth status\` → \`auth list\`
- **\`src/agents/scaffold.ts\`** + **\`src/cli/restart.ts\`** comment refreshes

## Flagged for follow-up (NOT fixed here)

\`telegram-plugin/gateway/gateway.ts:7642\` still shells the dead \`switchroom auth status --json\` to populate /status auth detail. That call fails silently (authSummary lands as null, /status renders without auth info). Left in place with a TODO comment — fixing it needs an \`auth show --json\` response-shape adapter, which is more than a string change. Separate PR.

## Test plan

- [x] \`tsc --noEmit\` clean
- [x] All edits are user-facing strings or comments — no behaviour change

🤖 Generated with [Claude Code](https://claude.com/claude-code)