### PR TITLE
chore(auth-broker): audit-log SIGKILL-safety + AuthCommandContext rename

### DIFF
--- a/src/auth/broker/server.test.ts
+++ b/src/auth/broker/server.test.ts
@@ -18,6 +18,7 @@ import { join } from "node:path";
 import * as net from "node:net";
 
 import { AuthBroker } from "./server.js";
+import type { Identity } from "./peercred.js";
 import { decodeResponse, encodeRequest } from "./protocol.js";
 import type { SwitchroomConfig } from "../../config/schema.js";
 import { writeAccountCredentials } from "../account-store.js";
@@ -1372,6 +1373,116 @@ describe("AuthBroker — refresh tick + threshold-violation", () => {
     await broker._tick();
     expect(broker._state().thresholdViolations["default"]).toBeGreaterThanOrEqual(1);
     broker.stop();
+  });
+});
+
+describe("AuthBroker — audit-log torn-write hardening", () => {
+  // Real audit rows are <300 bytes and land in a single write(2) syscall
+  // to an O_APPEND fd, which Linux guarantees is atomic vs other writers
+  // AND vs signal delivery (the kernel doesn't yield mid-syscall to
+  // deliver SIGKILL — see write(2) man page). The size cap defends
+  // against a runaway field that would push past PIPE_BUF (4096).
+
+  it("writes a normal-sized audit row in a single syscall", async () => {
+    const h = makeHarness();
+    const config = makeConfig(h, {
+      active: "default",
+      admin_agents: ["clerk"],
+      agents: { clerk: {} },
+    });
+    seedAccount(h, "default");
+    mkdirSync(join(h.agentsDir, "clerk"), { recursive: true });
+    const broker = new AuthBroker(config, {
+      home: h.home,
+      stateDir: h.stateDir,
+      socketRoot: h.socketRoot,
+      disableRefreshLoop: true,
+    });
+    await broker.start();
+    // Trigger an audited op.
+    await rpc(join(h.socketRoot, "clerk", "sock"), {
+      v: 1,
+      id: "1",
+      op: "list-state",
+    });
+    broker.stop();
+    // Audit file exists and contains a parseable JSONL row.
+    const auditPath = join(h.stateDir, "audit.jsonl");
+    const lines = readFileSync(auditPath, "utf-8").trim().split("\n");
+    expect(lines.length).toBeGreaterThan(0);
+    const row = JSON.parse(lines[lines.length - 1]);
+    expect(row.op).toBe("list-state");
+    expect(row.ok).toBe(true);
+    expect(row.__truncated).toBeUndefined();
+    // Row well under the cap.
+    expect(Buffer.byteLength(lines[lines.length - 1] + "\n", "utf-8"))
+      .toBeLessThan(500);
+  });
+
+  it("structural pin: audit writer uses writeSync (single syscall), not writeFileSync (looping)", async () => {
+    // SIGKILL-safety pin. writeFileSync to a fd loops on short writes,
+    // could in principle issue multiple syscalls, breaks the O_APPEND
+    // atomicity guarantee. writeSync issues exactly one. A refactor
+    // that swaps back to writeFileSync(fd, ...) fails here first.
+    const fs = await import("node:fs");
+    const url = await import("node:url");
+    const path = await import("node:path");
+    const here = path.dirname(url.fileURLToPath(import.meta.url));
+    const serverSrc = fs.readFileSync(path.join(here, "server.ts"), "utf-8");
+    // The audit-write helper exists.
+    expect(serverSrc).toMatch(/_writeAuditLineAtomic\b/);
+    // And uses writeSync, not writeFileSync.
+    expect(serverSrc).toMatch(/_writeAuditLineAtomic[\s\S]{0,400}writeSync\(/);
+    expect(serverSrc).not.toMatch(/_writeAuditLineAtomic[\s\S]{0,400}writeFileSync\(/);
+    // O_APPEND flag is set.
+    expect(serverSrc).toMatch(/_writeAuditLineAtomic[\s\S]{0,400}O_APPEND/);
+  });
+
+  it("truncates an oversized audit row instead of risking a torn write", async () => {
+    const h = makeHarness();
+    const config = makeConfig(h, {
+      active: "default",
+      admin_agents: ["clerk"],
+      agents: { clerk: {} },
+    });
+    seedAccount(h, "default");
+    mkdirSync(join(h.agentsDir, "clerk"), { recursive: true });
+    const broker = new AuthBroker(config, {
+      home: h.home,
+      stateDir: h.stateDir,
+      socketRoot: h.socketRoot,
+      disableRefreshLoop: true,
+    });
+    await broker.start();
+    // Drive a refresh-account that we know will fail with a synthetic
+    // huge error string. We don't have a clean injection point on
+    // the broker's public surface; instead reach into the private
+    // audit() method directly via the broker instance.
+    const broker_ = broker as unknown as {
+      audit: (entry: {
+        op: string;
+        identity: Identity;
+        account?: string;
+        ok: boolean;
+        error?: string;
+      }) => void;
+    };
+    const hugeError = "X".repeat(8000);
+    broker_.audit({
+      op: "refresh-account",
+      identity: { kind: "operator" },
+      account: "default",
+      ok: false,
+      error: hugeError,
+    });
+    broker.stop();
+    // The row landed in audit.jsonl, truncated to fit under the cap.
+    const auditPath = join(h.stateDir, "audit.jsonl");
+    const text = readFileSync(auditPath, "utf-8");
+    const lastLine = text.trimEnd().split("\n").pop()!;
+    expect(Buffer.byteLength(lastLine + "\n", "utf-8")).toBeLessThanOrEqual(4000);
+    // Truncation marker present.
+    expect(lastLine).toContain('"__truncated":true');
   });
 });
 

--- a/src/auth/broker/server.ts
+++ b/src/auth/broker/server.ts
@@ -33,7 +33,7 @@ import {
   unlinkSync,
   writeFileSync,
 } from "node:fs";
-import { closeSync, openSync } from "node:fs";
+import { closeSync, openSync, writeSync } from "node:fs";
 import * as constants from "node:constants";
 import { createHash } from "node:crypto";
 import { dirname, join, resolve } from "node:path";
@@ -103,6 +103,13 @@ const MARK_EXHAUSTED_DEFAULT_MS = 5 * 60 * 60 * 1000;
 /** Audit-log size cap before rotation (10 MB, per RFC §4.4). */
 const AUDIT_ROTATE_BYTES = 10 * 1024 * 1024;
 const AUDIT_KEEP = 5;
+/**
+ * Maximum bytes per audit row. Sized below Linux's PIPE_BUF (4096) so a
+ * single `write(2)` to an O_APPEND fd is atomic — guarantees no torn
+ * row on SIGKILL mid-write. Real rows are <300 bytes; this is defence
+ * against runaway error strings.
+ */
+const AUDIT_LINE_MAX = 4000;
 
 /** Threshold-violation counter file. */
 interface ThresholdViolations {
@@ -1628,15 +1635,55 @@ export class AuthBroker {
     try {
       this.rotateAuditIfLarge(auditPath);
       const line = row + "\n";
-      const fd = openSync(auditPath, constants.O_WRONLY | constants.O_APPEND | constants.O_CREAT, 0o600);
-      try {
-        writeFileSync(fd, line);
-      } finally {
-        try { closeSync(fd); } catch { /* ignore */ }
+      let buf = Buffer.from(line, "utf-8");
+      // SIGKILL-safe torn-write guard. POSIX `write(2)` to an O_APPEND
+      // fd is atomic with respect to other writers AND with respect to
+      // signals — the kernel doesn't yield mid-syscall to deliver a
+      // signal — IFF the write is a single syscall AND the buffer
+      // length is ≤ PIPE_BUF (4096 bytes on Linux for regular files,
+      // per the `write(2)` man page). Two changes vs the prior code
+      // which used `writeFileSync(fd, line)`:
+      //   1. `writeFileSync` LOOPS internally on short writes, so it
+      //      could in principle issue multiple syscalls. Switched to
+      //      `writeSync` (one syscall) below.
+      //   2. Hard-cap the row at AUDIT_LINE_MAX. Real audit rows are
+      //      <300 bytes; the cap defends against a runaway field
+      //      (e.g. a huge `entry.error` string). Oversized rows are
+      //      truncated with a marker — a truncated audit entry is
+      //      strictly better than a torn one.
+      if (buf.length > AUDIT_LINE_MAX) {
+        const truncated =
+          row.slice(0, AUDIT_LINE_MAX - 32) + '","__truncated":true}\n';
+        buf = Buffer.from(truncated, "utf-8");
       }
+      this._writeAuditLineAtomic(auditPath, buf);
     } catch (err) {
       // Audit failure must not affect protocol responses.
       this.logErr(`audit write failed: ${(err as Error).message}`);
+    }
+  }
+
+  /**
+   * Single-syscall atomic append. Caller has enforced
+   * `buf.length <= AUDIT_LINE_MAX <= PIPE_BUF`.
+   */
+  private _writeAuditLineAtomic(path: string, buf: Buffer): void {
+    const fd = openSync(
+      path,
+      constants.O_WRONLY | constants.O_APPEND | constants.O_CREAT,
+      0o600,
+    );
+    try {
+      const written = writeSync(fd, buf, 0, buf.length, null);
+      if (written !== buf.length) {
+        // Short write on an O_APPEND fd to a regular file with a tiny
+        // buffer shouldn't happen on Linux — the size cap exists to
+        // prevent this. Log loud if it does. The line is partial but
+        // we got the prefix; retry-risk would duplicate bytes.
+        this.logErr(`audit short-write: wrote=${written} expected=${buf.length}`);
+      }
+    } finally {
+      try { closeSync(fd); } catch { /* ignore */ }
     }
   }
 

--- a/telegram-plugin/gateway/auth-command.ts
+++ b/telegram-plugin/gateway/auth-command.ts
@@ -220,8 +220,14 @@ export interface AuthBrokerClient {
 export interface AuthCommandContext {
   /** The agent the gateway is bound to (its socket-path identity). */
   agentName: string
-  /** Names of agents allowed to mutate fleet state. Empty / undefined → no admin. */
-  adminAgents: ReadonlyArray<string> | undefined
+  /**
+   * True when this agent is an admin (per `agents.<name>.admin: true`
+   * in switchroom.yaml — the same flag PR #1258 introduced for fleet
+   * ops, unified into the auth-broker gate by PR #1263). Computed by
+   * the gateway from its loaded config and passed through; the
+   * handler does not consult any list.
+   */
+  isAdmin: boolean
   client: AuthBrokerClient
   /**
    * Telegram chat id this command was issued in. Used to key the
@@ -563,17 +569,17 @@ export async function handleAuthCommand(
  * Admin gate. Exposed so the gateway-routed verbs (`/auth add`,
  * `/auth cancel`) reuse the same ACL check as the handler-routed
  * verbs (`/auth use`, `/auth rotate`).
+ *
+ * Post-RFC-H + PR #1263 unification, admin is a per-agent boolean
+ * (`agents.<name>.admin === true`) computed by the gateway from
+ * its loaded config. The gate is the boolean lookup itself.
  */
-export function isAuthAdmin(args: {
-  agentName: string
-  adminAgents: ReadonlyArray<string> | undefined
-}): boolean {
-  if (!args.adminAgents || args.adminAgents.length === 0) return false
-  return args.adminAgents.includes(args.agentName)
+export function isAuthAdmin(args: { isAdmin: boolean }): boolean {
+  return args.isAdmin === true
 }
 
 function isAdmin(ctx: AuthCommandContext): boolean {
-  return isAuthAdmin(ctx)
+  return ctx.isAdmin === true
 }
 
 /**

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -8525,16 +8525,15 @@ bot.command("auth", async ctx => {
   const currentAgent = getMyAgentName()
   // Post-unification admin gating: admin authority is sourced from each
   // agent's own `admin: true` flag (the same flag that gates /agents,
-  // /restart, /update etc. per PR #1258). The gateway-side check is
-  // for clean UX; the broker enforces server-side from the same source.
-  let adminAgents: string[] | undefined
+  // /restart, /update etc. per PR #1258). The gateway looks itself up
+  // and passes a boolean through — handler-side code does not consult
+  // any list. The broker enforces server-side from the same source.
+  let isAdmin = false
   try {
     const cfg = loadSwitchroomConfig()
-    const agentsMap = (cfg as unknown as { agents?: Record<string, { admin?: boolean }> })?.agents ?? {}
-    adminAgents = Object.entries(agentsMap)
-      .filter(([, a]) => a?.admin === true)
-      .map(([name]) => name)
-  } catch { /* best-effort */ }
+    const me = (cfg as unknown as { agents?: Record<string, { admin?: boolean }> })?.agents?.[currentAgent]
+    isAdmin = me?.admin === true
+  } catch { /* best-effort — non-admin is the safe default */ }
 
   // `/auth add` and `/auth cancel` are gateway-routed (drive a
   // scratch-dir-backed `claude setup-token` lifecycle the broker
@@ -8542,7 +8541,7 @@ bot.command("auth", async ctx => {
   // handleAuthCommand which only needs the narrow broker surface.
   const chatId = String(ctx.chat?.id ?? '')
   if (parsed.kind === 'add' || parsed.kind === 'cancel') {
-    if (!isAuthAdmin({ agentName: currentAgent, adminAgents })) {
+    if (!isAuthAdmin({ isAdmin })) {
       await switchroomReply(
         ctx,
         `<b>Not authorized.</b> <code>/auth ${parsed.kind}</code> is admin-only.\n` +
@@ -8608,7 +8607,7 @@ bot.command("auth", async ctx => {
   }
   const reply = await handleAuthCommand(parsed, {
     agentName: currentAgent,
-    adminAgents,
+    isAdmin,
     client,
     chatId,
   })

--- a/telegram-plugin/tests/auth-add-flow.test.ts
+++ b/telegram-plugin/tests/auth-add-flow.test.ts
@@ -214,21 +214,12 @@ describe('validateAuthAddLabel', () => {
 /* ── 2. Admin gating ──────────────────────────────────────────────────── */
 
 describe('isAuthAdmin', () => {
-  it('returns false when admin_agents is undefined', () => {
-    expect(isAuthAdmin({ agentName: 'foo', adminAgents: undefined })).toBe(false)
+  it('returns false when isAdmin is false', () => {
+    expect(isAuthAdmin({ isAdmin: false })).toBe(false)
   })
 
-  it('returns false when admin_agents is empty', () => {
-    expect(isAuthAdmin({ agentName: 'foo', adminAgents: [] })).toBe(false)
-  })
-
-  it('returns true when the current agent is in admin_agents', () => {
-    expect(isAuthAdmin({ agentName: 'clerk', adminAgents: ['clerk'] })).toBe(true)
-    expect(isAuthAdmin({ agentName: 'clerk', adminAgents: ['ken', 'clerk'] })).toBe(true)
-  })
-
-  it('returns false when the current agent is NOT in admin_agents', () => {
-    expect(isAuthAdmin({ agentName: 'other', adminAgents: ['clerk'] })).toBe(false)
+  it('returns true when isAdmin is true', () => {
+    expect(isAuthAdmin({ isAdmin: true })).toBe(true)
   })
 })
 
@@ -238,7 +229,7 @@ describe('handleAuthCommand — add/cancel are gateway-routed (defensive contrac
       { kind: 'add', label: 'foo' },
       {
         agentName: 'clerk',
-        adminAgents: ['clerk'],
+        isAdmin: true,
         client: { listState: async () => { throw new Error('unreachable') }, setActive: async () => { throw new Error('unreachable') } },
       },
     )
@@ -250,7 +241,7 @@ describe('handleAuthCommand — add/cancel are gateway-routed (defensive contrac
       { kind: 'add', label: 'foo' },
       {
         agentName: 'other',
-        adminAgents: ['clerk'],
+        isAdmin: false,
         client: { listState: async () => { throw new Error('unreachable') }, setActive: async () => { throw new Error('unreachable') } },
       },
     )
@@ -558,7 +549,7 @@ describe('help text discoverability', () => {
     expect(parsed?.kind).toBe('help')
     const reply = await handleAuthCommand(parsed!, {
       agentName: 'x',
-      adminAgents: ['x'],
+      isAdmin: true,
       client: { listState: async () => { throw new Error('n/a') }, setActive: async () => { throw new Error('n/a') } },
     })
     expect(reply.text).toMatch(/\/auth add/i)

--- a/telegram-plugin/tests/auth-command-vernacular.test.ts
+++ b/telegram-plugin/tests/auth-command-vernacular.test.ts
@@ -226,7 +226,7 @@ describe('handleAuthCommand — read verbs are open to any agent', () => {
     const client = mockClient()
     const reply = await handleAuthCommand(
       { kind: 'list' },
-      { agentName: 'random-agent', adminAgents: ['someone-else'], client },
+      { agentName: 'random-agent', isAdmin: false, client },
     )
     expect(reply.html).toBe(true)
     expect(reply.text).toMatch(/Auth — fleet snapshot/)
@@ -238,7 +238,7 @@ describe('handleAuthCommand — read verbs are open to any agent', () => {
     const client = mockClient()
     const reply = await handleAuthCommand(
       { kind: 'show', agent: 'researcher' },
-      { agentName: 'random', adminAgents: [], client },
+      { agentName: 'random', isAdmin: false, client },
     )
     expect(reply.text).toMatch(/researcher/)
     expect(reply.text).toMatch(/override/)
@@ -249,7 +249,7 @@ describe('handleAuthCommand — read verbs are open to any agent', () => {
     const client = mockClient()
     const reply = await handleAuthCommand(
       { kind: 'show', agent: 'ghost' },
-      { agentName: 'random', adminAgents: [], client },
+      { agentName: 'random', isAdmin: false, client },
     )
     expect(reply.text).toMatch(/no agent named/i)
     expect(reply.text).toMatch(/ghost/)
@@ -259,7 +259,7 @@ describe('handleAuthCommand — read verbs are open to any agent', () => {
 /* ── 3. Admin gating ──────────────────────────────────────────────────── */
 
 describe('handleAuthCommand — admin gating', () => {
-  const nonAdmin = { agentName: 'snooper', adminAgents: ['clerk'] as string[] }
+  const nonAdmin = { agentName: 'snooper', isAdmin: false }
 
   it('refuses /auth rm <label> for non-admin', async () => {
     const client = mockClient()
@@ -315,7 +315,7 @@ describe('handleAuthCommand — admin gating', () => {
 /* ── 4. rm two-step confirm flow ──────────────────────────────────────── */
 
 describe('handleAuthCommand — /auth rm two-step confirm', () => {
-  const admin = { agentName: 'clerk', adminAgents: ['clerk'] as string[] }
+  const admin = { agentName: 'clerk', isAdmin: true }
 
   it('prompt phase succeeds for a valid non-active label and stashes a pending entry', async () => {
     const client = mockClient()
@@ -418,7 +418,7 @@ describe('handleAuthCommand — /auth rm two-step confirm', () => {
 /* ── 5. refresh ───────────────────────────────────────────────────────── */
 
 describe('handleAuthCommand — /auth refresh', () => {
-  const admin = { agentName: 'clerk', adminAgents: ['clerk'] as string[] }
+  const admin = { agentName: 'clerk', isAdmin: true }
 
   it('without a label refreshes every account, once each', async () => {
     const client = mockClient()
@@ -473,7 +473,7 @@ describe('handleAuthCommand — /auth refresh', () => {
 /* ── 6. override set + clear ──────────────────────────────────────────── */
 
 describe('handleAuthCommand — /auth agent override', () => {
-  const admin = { agentName: 'clerk', adminAgents: ['clerk'] as string[] }
+  const admin = { agentName: 'clerk', isAdmin: true }
 
   it('set calls setOverride(agent, label)', async () => {
     const client = mockClient()
@@ -508,7 +508,7 @@ describe('handleAuthCommand — help text lists every verb', () => {
     const client = mockClient()
     const reply = await handleAuthCommand(
       { kind: 'help' },
-      { agentName: 'x', adminAgents: ['x'], client },
+      { agentName: 'x', isAdmin: true, client },
     )
     const text = reply.text
     // Verbs (all variants). The help is HTML; <code> wraps each verb.


### PR DESCRIPTION
## Summary

Two cleanups deferred from PR #1254. Both small, both surface-area reductions.

### 1. Audit-log torn-write hardening

`audit()` was using `writeFileSync(fd, line)` to append to an O_APPEND fd. `writeFileSync` loops on short writes — could in principle issue multiple syscalls and break the POSIX guarantee that a single `write(2)` to an O_APPEND fd is atomic with respect to other writers AND with respect to signal delivery (the kernel doesn't yield mid-syscall to deliver SIGKILL).

Switched to `writeSync(fd, buf, 0, len, null)` — exactly one syscall. Plus a hard cap at `AUDIT_LINE_MAX = 4000` bytes (sub-PIPE_BUF on Linux). Oversized rows truncate with a `"__truncated":true` marker; truncated > torn.

Three new tests pin:
- normal-sized rows write cleanly with no truncation marker
- structural pin: server.ts uses `writeSync` inside `_writeAuditLineAtomic` (refactor that swaps back fails CI here first)
- 8KB error string truncates to ≤4000 bytes with the marker

### 2. `AuthCommandContext.adminAgents` → `isAdmin: boolean`

After PR #1263 the admin source-of-truth is a per-agent boolean (`agents.<name>.admin`). The `adminAgents: ReadonlyArray<string>` field on the handler context was a vestige of the pre-unification surface — semantically it's just `agentName ∈ adminAgents`, computed once at the gateway. Renaming to `isAdmin: boolean` matches the actual semantic.

`isAuthAdmin`'s signature collapses from `{ agentName, adminAgents }` to `{ isAdmin }`. Gateway-side: `cfg.agents[currentAgent]?.admin === true` is now a single lookup instead of filter+map+`.includes`.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `npm run build` clean
- [x] vitest: 5800 pass, 0 fail (1 pre-existing file-level error in google-provider.test.ts is unrelated)
- [x] 124 targeted tests pass (broker server + auth-add-flow + auth-command-vernacular)
- [x] `check-bun-test-imports` lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)