### PR TITLE
fix(auth-broker): mirror-time enrichment closes residual #1280 boot gap

### DIFF
--- a/src/auth/account-store.ts
+++ b/src/auth/account-store.ts
@@ -227,14 +227,27 @@ export function readAccountCredentials(
  * empty scopes list and missing subscriptionType don't pass the
  * post-RFC-H file-shape gate.
  *
- * Enrichment here closes the gap at the write side: any account
- * credentials we persist always carry the fields claude expects, even
- * if the OAuth handshake didn't return them.
+ * Enrichment closes the gap at the write side (#1280) AND at broker
+ * fanout time (`mirrorAccountToAgent` calls `enrichClaudeCreds` so a
+ * stale legacy source file on disk still produces a usable per-agent
+ * mirror without waiting for refresh-tick to rewrite the source).
  */
 const DEFAULT_SCOPES = ["user:inference"] as const;
 const DEFAULT_SUBSCRIPTION_TYPE = "max";
 
-function enrichClaudeCreds(value: AccountCredentials): AccountCredentials {
+/**
+ * Pure: fill `scopes` (when missing or empty) and `subscriptionType`
+ * (when missing) on an `AccountCredentials` value with the canonical
+ * defaults claude expects. Returns the input untouched when there's
+ * no `claudeAiOauth` block — we never synthesize one.
+ *
+ * Exported so the broker's `mirrorAccountToAgent` can reuse the same
+ * defaults at fanout time, closing the residual window between boot
+ * fanout and the first source-file rewrite.
+ */
+export function enrichClaudeCreds(
+  value: AccountCredentials,
+): AccountCredentials {
   const oauth = value.claudeAiOauth;
   if (!oauth) return value;
   const scopes =

--- a/src/auth/broker/mirror-enrich.test.ts
+++ b/src/auth/broker/mirror-enrich.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Unit tests for `enrichMirrorContent` — the broker's text-in /
+ * text-out wrapper around `enrichClaudeCreds` used by
+ * `mirrorAccountToAgent` to heal stale legacy source files at fanout
+ * time.
+ *
+ * Companion integration test (`server-mirror-enrich.test.ts`) drives
+ * the same path through `mirrorAccountToAgent` end-to-end.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { enrichMirrorContent } from "./server.js";
+
+describe("enrichMirrorContent", () => {
+  it("fills empty scopes with the canonical user:inference scope", () => {
+    const source = JSON.stringify({
+      claudeAiOauth: {
+        accessToken: "at-x",
+        expiresAt: 123,
+        scopes: [],
+        subscriptionType: "max",
+      },
+    });
+    const enriched = JSON.parse(enrichMirrorContent(source));
+    expect(enriched.claudeAiOauth.scopes).toEqual(["user:inference"]);
+  });
+
+  it("fills missing scopes with the canonical user:inference scope", () => {
+    const source = JSON.stringify({
+      claudeAiOauth: {
+        accessToken: "at-x",
+        expiresAt: 123,
+        subscriptionType: "max",
+      },
+    });
+    const enriched = JSON.parse(enrichMirrorContent(source));
+    expect(enriched.claudeAiOauth.scopes).toEqual(["user:inference"]);
+  });
+
+  it("fills missing subscriptionType with 'max'", () => {
+    const source = JSON.stringify({
+      claudeAiOauth: {
+        accessToken: "at-x",
+        expiresAt: 123,
+        scopes: ["user:inference"],
+      },
+    });
+    const enriched = JSON.parse(enrichMirrorContent(source));
+    expect(enriched.claudeAiOauth.subscriptionType).toBe("max");
+  });
+
+  it("preserves existing non-empty scopes verbatim", () => {
+    const customScopes = [
+      "user:inference",
+      "user:profile",
+      "user:sessions:claude_code",
+    ];
+    const source = JSON.stringify({
+      claudeAiOauth: {
+        accessToken: "at-x",
+        expiresAt: 123,
+        scopes: customScopes,
+        subscriptionType: "pro",
+      },
+    });
+    expect(enrichMirrorContent(source)).toBe(source);
+  });
+
+  it("returns source string verbatim (byte-identical) when already enriched", () => {
+    const source = JSON.stringify({
+      claudeAiOauth: {
+        accessToken: "at-x",
+        expiresAt: 123,
+        scopes: ["user:inference"],
+        subscriptionType: "max",
+      },
+    });
+    // Critical for diff-stability of per-agent mirrors — operator
+    // tooling that snapshots .credentials.json shouldn't see whitespace
+    // churn just because the mirror got rewritten.
+    expect(enrichMirrorContent(source)).toBe(source);
+  });
+
+  it("returns source string verbatim when JSON is malformed", () => {
+    const source = "{not valid json";
+    expect(enrichMirrorContent(source)).toBe(source);
+  });
+
+  it("returns source string verbatim when claudeAiOauth is missing", () => {
+    const source = JSON.stringify({ otherShape: { foo: "bar" } });
+    expect(enrichMirrorContent(source)).toBe(source);
+  });
+
+  it("preserves other claudeAiOauth fields when enriching (refreshToken, rateLimitTier)", () => {
+    const source = JSON.stringify({
+      claudeAiOauth: {
+        accessToken: "at-x",
+        refreshToken: "rt-x",
+        expiresAt: 123,
+        scopes: [],
+        rateLimitTier: "default_claude_max_20x",
+      },
+    });
+    const enriched = JSON.parse(enrichMirrorContent(source));
+    expect(enriched.claudeAiOauth.refreshToken).toBe("rt-x");
+    expect(enriched.claudeAiOauth.rateLimitTier).toBe("default_claude_max_20x");
+    expect(enriched.claudeAiOauth.accessToken).toBe("at-x");
+    expect(enriched.claudeAiOauth.expiresAt).toBe(123);
+  });
+});

--- a/src/auth/broker/mirror-enrich.test.ts
+++ b/src/auth/broker/mirror-enrich.test.ts
@@ -92,6 +92,27 @@ describe("enrichMirrorContent", () => {
     expect(enrichMirrorContent(source)).toBe(source);
   });
 
+  it("preserves a custom (non-canonical) scope set when only subscriptionType is missing", () => {
+    // Reviewer-flagged edge case: source has scopes the operator
+    // explicitly chose (e.g. broader claude scopes) AND missing
+    // subscriptionType. Enrichment must add subscriptionType WITHOUT
+    // clobbering the existing scope set.
+    const source = JSON.stringify({
+      claudeAiOauth: {
+        accessToken: "at-x",
+        expiresAt: 123,
+        scopes: ["org:create_api_key", "user:profile", "user:inference"],
+      },
+    });
+    const enriched = JSON.parse(enrichMirrorContent(source));
+    expect(enriched.claudeAiOauth.scopes).toEqual([
+      "org:create_api_key",
+      "user:profile",
+      "user:inference",
+    ]);
+    expect(enriched.claudeAiOauth.subscriptionType).toBe("max");
+  });
+
   it("preserves other claudeAiOauth fields when enriching (refreshToken, rateLimitTier)", () => {
     const source = JSON.stringify({
       claudeAiOauth: {

--- a/src/auth/broker/server-mirror-enrich.test.ts
+++ b/src/auth/broker/server-mirror-enrich.test.ts
@@ -1,0 +1,173 @@
+/**
+ * End-to-end test for the broker's mirror-time enrichment path.
+ *
+ * Drives `mirrorAccountToAgent` (via boot fanout) with a stale legacy
+ * source-of-truth credentials.json and asserts the per-agent mirror
+ * carries the post-#1280 shape claude accepts. This is the residual
+ * gap #1280 alone can't close: a stale source written before #1280
+ * landed (or via a path that bypasses `writeAccountCredentials`)
+ * doesn't get rewritten until refresh-tick fires — which can be
+ * hours away when expiresAt is far-future.
+ *
+ * Companion unit test (`mirror-enrich.test.ts`) covers the pure
+ * `enrichMirrorContent` helper.
+ */
+
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { AuthBroker } from "./server.js";
+import { accountCredentialsPath, accountDir } from "../account-store.js";
+import type { SwitchroomConfig } from "../../config/schema.js";
+
+interface Harness {
+  tmp: string;
+  home: string;
+  agentsDir: string;
+  stateDir: string;
+  socketRoot: string;
+}
+
+let harnesses: Harness[] = [];
+
+function makeHarness(): Harness {
+  const tmp = mkdtempSync(join(tmpdir(), "auth-broker-mirror-enrich-test-"));
+  const home = join(tmp, "home");
+  const agentsDir = join(home, ".switchroom", "agents");
+  const stateDir = join(home, ".switchroom", "state", "auth-broker");
+  const socketRoot = join(tmp, "run", "switchroom", "auth-broker");
+  mkdirSync(home, { recursive: true });
+  mkdirSync(agentsDir, { recursive: true });
+  const h: Harness = { tmp, home, agentsDir, stateDir, socketRoot };
+  harnesses.push(h);
+  return h;
+}
+
+afterEach(() => {
+  for (const h of harnesses) {
+    try {
+      rmSync(h.tmp, { recursive: true, force: true });
+    } catch {
+      /* ignore */
+    }
+  }
+  harnesses = [];
+});
+
+function makeConfig(h: Harness, agents: Record<string, object>): SwitchroomConfig {
+  return {
+    switchroom: { version: 1, agents_dir: h.agentsDir },
+    telegram: {},
+    agents,
+    auth: { active: "default" },
+  } as unknown as SwitchroomConfig;
+}
+
+/**
+ * Write a source-of-truth credentials.json by hand, bypassing
+ * `writeAccountCredentials` — that's the situation we're testing.
+ * Anything that ever wrote credentials before #1280 landed (legacy
+ * slot setup, manual sudo-tee unstick, third-party export) produced
+ * this shape.
+ */
+function writeStaleSourceCredentials(
+  h: Harness,
+  label: string,
+  body: object,
+): void {
+  mkdirSync(accountDir(label, h.home), { recursive: true });
+  writeFileSync(accountCredentialsPath(label, h.home), JSON.stringify(body));
+}
+
+describe("AuthBroker — mirror-time credential enrichment (residual #1280 gap)", () => {
+  it("enriches a stale legacy source file at boot fanout (empty scopes + missing subscriptionType)", async () => {
+    const h = makeHarness();
+    writeStaleSourceCredentials(h, "default", {
+      claudeAiOauth: {
+        accessToken: "at-default",
+        refreshToken: "rt-default",
+        expiresAt: Date.now() + 24 * 60 * 60 * 1000, // far future — refresh-tick won't fire
+        scopes: [],
+        // subscriptionType missing
+      },
+    });
+    mkdirSync(join(h.agentsDir, "ziggy"), { recursive: true });
+
+    const broker = new AuthBroker(makeConfig(h, { ziggy: {} }), {
+      home: h.home,
+      stateDir: h.stateDir,
+      socketRoot: h.socketRoot,
+      disableRefreshLoop: true,
+    });
+    await broker.start();
+
+    const mirror = JSON.parse(
+      readFileSync(
+        join(h.agentsDir, "ziggy", ".claude", ".credentials.json"),
+        "utf-8",
+      ),
+    );
+    // The per-agent mirror has the shape claude accepts.
+    expect(mirror.claudeAiOauth.scopes).toEqual(["user:inference"]);
+    expect(mirror.claudeAiOauth.subscriptionType).toBe("max");
+    // Original fields preserved.
+    expect(mirror.claudeAiOauth.accessToken).toBe("at-default");
+    expect(mirror.claudeAiOauth.refreshToken).toBe("rt-default");
+
+    // Source file is NOT mutated by mirror-time enrichment — that's
+    // #1280's job at write-time. Stale source stays stale until
+    // refresh-tick or another writer touches it.
+    const source = JSON.parse(
+      readFileSync(accountCredentialsPath("default", h.home), "utf-8"),
+    );
+    expect(source.claudeAiOauth.scopes).toEqual([]);
+    expect(source.claudeAiOauth.subscriptionType).toBeUndefined();
+
+    broker.stop();
+  });
+
+  it("passes through an already-enriched source file unchanged (byte-identical mirror)", async () => {
+    const h = makeHarness();
+    const enrichedBody = {
+      claudeAiOauth: {
+        accessToken: "at-default",
+        refreshToken: "rt-default",
+        expiresAt: Date.now() + 60_000,
+        scopes: ["user:inference"],
+        subscriptionType: "max",
+      },
+    };
+    writeStaleSourceCredentials(h, "default", enrichedBody);
+    mkdirSync(join(h.agentsDir, "ziggy"), { recursive: true });
+
+    const broker = new AuthBroker(makeConfig(h, { ziggy: {} }), {
+      home: h.home,
+      stateDir: h.stateDir,
+      socketRoot: h.socketRoot,
+      disableRefreshLoop: true,
+    });
+    await broker.start();
+
+    const sourceContent = readFileSync(
+      accountCredentialsPath("default", h.home),
+      "utf-8",
+    );
+    const mirrorContent = readFileSync(
+      join(h.agentsDir, "ziggy", ".claude", ".credentials.json"),
+      "utf-8",
+    );
+    // Byte-for-byte identical when no enrichment is needed — keeps
+    // operator tooling / audit snapshots stable.
+    expect(mirrorContent).toBe(sourceContent);
+
+    broker.stop();
+  });
+});

--- a/src/auth/broker/server.test.ts
+++ b/src/auth/broker/server.test.ts
@@ -1454,8 +1454,8 @@ describe("AuthBroker — historical-bug regressions (2026-05-14 fanout incident)
     // it root-owned. The exact pattern (a chownSync call against the
     // freshly-written .credentials.json path inside mirrorAccountToAgent)
     // is what closes Bug 1.
-    // Budget bumped from 1600 → 3000 when mirror-time enrichment landed
-    // (#1282: enrichMirrorContent call + load-bearing inline comments
+    // Budget bumped from 1600 → 3000 when mirror-time enrichment
+    // landed (enrichMirrorContent call + load-bearing inline comments
     // about the .credentials.json dotfile invariant). The pin is still
     // meaningful — it asserts the chown call is *inside* the function,
     // not extracted to a remote helper that could regress silently.

--- a/src/auth/broker/server.test.ts
+++ b/src/auth/broker/server.test.ts
@@ -1454,8 +1454,13 @@ describe("AuthBroker — historical-bug regressions (2026-05-14 fanout incident)
     // it root-owned. The exact pattern (a chownSync call against the
     // freshly-written .credentials.json path inside mirrorAccountToAgent)
     // is what closes Bug 1.
-    expect(serverSrc).toMatch(/mirrorAccountToAgent[\s\S]{0,1600}allocateAgentUid/);
-    expect(serverSrc).toMatch(/mirrorAccountToAgent[\s\S]{0,1600}chownSync\(targetPath/);
+    // Budget bumped from 1600 → 3000 when mirror-time enrichment landed
+    // (#1282: enrichMirrorContent call + load-bearing inline comments
+    // about the .credentials.json dotfile invariant). The pin is still
+    // meaningful — it asserts the chown call is *inside* the function,
+    // not extracted to a remote helper that could regress silently.
+    expect(serverSrc).toMatch(/mirrorAccountToAgent[\s\S]{0,3000}allocateAgentUid/);
+    expect(serverSrc).toMatch(/mirrorAccountToAgent[\s\S]{0,3000}chownSync\(targetPath/);
   });
 
   it("Bug 2: refresh tick writes ONLY the agent's effective account, not last-iterated label", async () => {

--- a/src/auth/broker/server.ts
+++ b/src/auth/broker/server.ts
@@ -64,6 +64,7 @@ import {
   accountDir,
   accountExists,
   accountsRoot,
+  enrichClaudeCreds,
   listAccounts,
   patchAccountMeta,
   readAccountCredentials,
@@ -164,6 +165,38 @@ function sha256Hex(content: string): string {
 
 function nowMs(): number {
   return Date.now();
+}
+
+/**
+ * Apply `enrichClaudeCreds` to a JSON string from the source-of-truth
+ * credentials.json, returning a JSON string for the per-agent
+ * `.credentials.json` mirror.
+ *
+ * Returns the source string verbatim (byte-identical) when:
+ *   - JSON is malformed (broker leaves the diagnostic to claude;
+ *     synthesizing a fake shape would mask the real corruption).
+ *   - There's nothing to enrich — `claudeAiOauth` is absent OR both
+ *     `scopes` (non-empty array) and `subscriptionType` are already
+ *     present. Avoids whitespace churn on the per-agent mirror when
+ *     the source is already in the post-#1280 shape.
+ *
+ * Exported for tests.
+ */
+export function enrichMirrorContent(sourceJson: string): string {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(sourceJson);
+  } catch {
+    return sourceJson;
+  }
+  const value = parsed as AccountCredentials;
+  const oauth = value?.claudeAiOauth;
+  if (!oauth) return sourceJson;
+  const hasScopes = Array.isArray(oauth.scopes) && oauth.scopes.length > 0;
+  const hasSubscription =
+    typeof oauth.subscriptionType === "string" && oauth.subscriptionType.length > 0;
+  if (hasScopes && hasSubscription) return sourceJson;
+  return JSON.stringify(enrichClaudeCreds(value), null, 2);
 }
 
 function configToShape(cfg: SwitchroomConfig): AuthConfigShape {
@@ -1519,7 +1552,9 @@ export class AuthBroker {
   private mirrorAccountToAgent(label: string, agentName: string): boolean {
     const credsPath = accountCredentialsPath(label, this.home);
     if (!existsSync(credsPath)) return false;
-    const content = readFileSync(credsPath, "utf-8");
+    // enrichMirrorContent: defense-in-depth on top of #1280's write-
+    // time enrichment for stale legacy source files. See its docstring.
+    const mirrorContent = enrichMirrorContent(readFileSync(credsPath, "utf-8"));
     const agentsDir = resolveAgentsDir(this.config);
     const agentDir = resolve(agentsDir, agentName);
     if (!existsSync(agentDir)) return false;
@@ -1535,7 +1570,7 @@ export class AuthBroker {
     // first restart. Pinned by tests in server.test.ts.
     const targetPath = join(claudeDir, ".credentials.json");
     try {
-      atomicWriteFileSync(targetPath, content, 0o600);
+      atomicWriteFileSync(targetPath, mirrorContent, 0o600);
       try {
         const uid = allocateAgentUid(agentName);
         chownSync(targetPath, uid, uid);


### PR DESCRIPTION
## Summary

PR #1280 enriched account credentials at **write-time** (`writeAccountCredentials`). That fixes new writes but leaves a residual window where stale legacy source files on disk get mirrored verbatim:

- For accounts within 60 min of expiry: window closes when refresh-tick fires (~1 min)
- **For accounts with far-future `expiresAt`: refresh-tick doesn't fire and the source is never rewritten** — per-agent `.credentials.json` mirrors keep shipping `{accessToken, expiresAt, scopes: []}` indefinitely, which claude rejects as "Not logged in"

This PR closes the window at the **mirror-time** layer.

## Design

- Lift #1280's `enrichClaudeCreds` out of its closure in `account-store.ts` and export it.
- New broker-side wrapper `enrichMirrorContent`: text-in / text-out around `enrichClaudeCreds`. Returns source verbatim (byte-identical) when no enrichment needed → no whitespace churn on already-enriched mirrors.
- `mirrorAccountToAgent` parses source through `enrichMirrorContent` before writing to per-agent path. **Source-of-truth file is never mutated** — that stays #1280's job at write-time. Defense in depth, not duplication.

Single enrichment function (`enrichClaudeCreds`) across both call sites means defaults stay in sync. If we ever change the defaults, one place to change.

## Test plan

- [x] `npm run lint` clean
- [x] 8 unit tests on `enrichMirrorContent` (the pure helper) — empty/missing scopes, missing subscriptionType, byte-identical pass-through when already enriched, malformed JSON pass-through, missing `claudeAiOauth` pass-through, field preservation
- [x] 2 end-to-end tests through `mirrorAccountToAgent` — stale source enriched at boot fanout (asserting source NOT mutated), already-enriched source mirrored byte-identically
- [x] All 249 tests in `src/auth/` + `tests/auth*.test.ts` pass
- [x] Bumped existing structural-pin regex (`server.test.ts:1457`) from 1600 → 3000 chars to accommodate the new helper call + load-bearing inline comments. Pin still asserts `chownSync(targetPath` + `allocateAgentUid` are inside `mirrorAccountToAgent` — just tolerates a larger function.
- [ ] Manual smoke (post-merge, on a host with a stale legacy source file): observe per-agent `.credentials.json` after `switchroom auth use <label>` (or restart) — should now contain `scopes: ["user:inference"]` + `subscriptionType: "max"` even though the source still carries the legacy shape.

## Why this is small but worth shipping

Without it, the manual unstick in `project_auth_broker_boot_fanout_gap.md` ("for pair in ...; sudo tee ...") is still needed for any operator with stale legacy source files until something triggers a rewrite. With it, **every fanout heals automatically**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)